### PR TITLE
fix(ui): make relaunch's two-step confirm visibly armed

### DIFF
--- a/ui/src/lib/components/CardMenu.browser.test.ts
+++ b/ui/src/lib/components/CardMenu.browser.test.ts
@@ -49,12 +49,13 @@ describe("CardMenu relaunch action", () => {
 
     // armed: label switched to the confirm text, callback NOT yet fired
     expect(onrelaunch).not.toHaveBeenCalled();
-    await expect
-      .element(page.getByRole("menuitem", { name: m.cardmenu_relaunch_confirm() }))
-      .toBeInTheDocument();
+    const confirm = page.getByRole("menuitem", { name: m.cardmenu_relaunch_confirm() });
+    await expect.element(confirm).toBeInTheDocument();
+    // the armed item gains the danger-wash class so the second click is obviously hot
+    await expect.element(confirm).toHaveClass(/\barmed\b/);
 
     // second click within the window fires it exactly once
-    await page.getByRole("menuitem", { name: m.cardmenu_relaunch_confirm() }).click();
+    await confirm.click();
     expect(onrelaunch).toHaveBeenCalledTimes(1);
   });
 
@@ -70,11 +71,12 @@ describe("CardMenu relaunch action", () => {
         .element(page.getByRole("menuitem", { name: m.cardmenu_relaunch_confirm() }))
         .toBeInTheDocument();
 
-      // past the ~3s arm window → disarms back to the idle label, no fire
+      // past the ~3s arm window → disarms back to the idle label (and drops the
+      // armed danger-wash), no fire
       vi.advanceTimersByTime(3500);
-      await expect
-        .element(page.getByRole("menuitem", { name: m.cardmenu_relaunch() }))
-        .toBeInTheDocument();
+      const idle = page.getByRole("menuitem", { name: m.cardmenu_relaunch() });
+      await expect.element(idle).toBeInTheDocument();
+      await expect.element(idle).not.toHaveClass(/\barmed\b/);
       expect(onrelaunch).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();

--- a/ui/src/lib/components/CardMenu.svelte
+++ b/ui/src/lib/components/CardMenu.svelte
@@ -142,8 +142,15 @@
     </button>
   {/if}
   {#if onrelaunch}
-    <button class="cm-item" type="button" role="menuitem" tabindex="-1" onclick={onRelaunchClick}>
-      <span class="cm-icon" aria-hidden="true">♻</span>{relaunchArmed
+    <button
+      class="cm-item"
+      class:armed={relaunchArmed}
+      type="button"
+      role="menuitem"
+      tabindex="-1"
+      onclick={onRelaunchClick}
+    >
+      <span class="cm-icon" aria-hidden="true">{relaunchArmed ? "⚠" : "♻"}</span>{relaunchArmed
         ? m.cardmenu_relaunch_confirm()
         : m.cardmenu_relaunch()}
     </button>
@@ -220,6 +227,18 @@
   .cm-item.danger:hover,
   .cm-item.danger:focus-visible {
     background: color-mix(in srgb, var(--color-red) 14%, var(--color-panel));
+  }
+  /* Armed relaunch: the first click only arms the two-step confirm (label swaps to
+     the confirm text + the ⚠ glyph). Without a colour shift the change was too quiet
+     to read as "click again to confirm" — operators saw the label toggle and thought
+     relaunch did nothing. The danger wash marks it hot so the second click is obvious. */
+  .cm-item.armed {
+    color: var(--color-red);
+    background: color-mix(in srgb, var(--color-red) 14%, var(--color-panel));
+  }
+  .cm-item.armed:hover,
+  .cm-item.armed:focus-visible {
+    background: color-mix(in srgb, var(--color-red) 22%, var(--color-panel));
   }
   .cm-icon {
     font-size: var(--fs-meta);


### PR DESCRIPTION
## Problem

Operators reported *"Neustart funktioniert nicht — es passiert einfach nichts"*: the **Neu starten / Relaunch** action in a session card's right-click/long-press menu seemed to do nothing.

It actually works — relaunch is irreversible (it discards the original's worktree and archives it), so it uses a **two-step arm → confirm**: the first click arms (label swaps `Neu starten` → `Verwerfen & neu starten?`) and a second click within ~3s fires it.

The problem was **discoverability**: arming changed only the label text, with no colour or icon shift. The confirm label even ends in `?`, so it read as a passive question rather than a button to click again. Operators saw the label toggle, waited for a dialog that never came, the arm auto-disarmed after 3s — and concluded relaunch was broken. (The two attached states in the bug report are exactly the armed/idle label toggle.)

## Fix

Make the armed state unmistakable, matching the app's existing danger convention (the same `color-mix(var(--color-red) …)` wash used by the menu's Decommission item and the swipe-to-decommission arm):

- Armed relaunch item gets a **red danger wash** (`.cm-item.armed`) so it reads as hot.
- Its glyph swaps `♻` → `⚠` while armed.

No behaviour change to the arm/confirm flow itself — purely the missing visual cue that a second click confirms.

## Tests

- `CardMenu.browser.test.ts`: extended the existing arm→confirm test to assert the armed item carries the `armed` class, and the disarm test to assert it's dropped on auto-disarm.
- `cd ui && bun run check` ✅ · `bun run test -- --run CardMenu` ✅ (3/3)

`fix(ui)` to an existing affordance — no new user-facing capability, so no feature-catalog entry.