### PR TITLE
feat(usage): Phase 2 — wire /usage to real data + mode-aware $ + top-bar entry (#953)

### DIFF
--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -1,5 +1,5 @@
 // The TABLE values are real Anthropic $/Mtok list prices and MUST stay absolute — they must NOT
-// be rescaled (e.g. normalised so a tier = 1), because /usage renders them as real currency via
+// be rescaled (e.g. normalized so a tier = 1), because /usage renders them as real currency via
 // dollars() (and as USD-denominated "units" in the spend breakdown). A rescale would silently
 // corrupt displayed money. The limit-% math (weightedUnits feeding the daily calibration) is
 // ratio-only, so it is unaffected by keeping the absolute anchor. Keep the rows in price order

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -83,7 +83,16 @@ export function weightedUnits(
 }
 
 /** Absolute USD cost of a token bundle at list price — the money view of the same weighted
- *  units; displayed in /usage's api-key `$` column. */
+ *  units; displayed in /usage's api-key `$` column.
+ *
+ *  Intentional separation from `buildUsageBreakdown`: the breakdown's repo/total `$` is NOT
+ *  computed by calling this on aggregate tokens. The accumulated `authoringUnits`/
+ *  `satelliteUnits` ARE already list-price USD (`weightedUnits`, computed per-record from the
+ *  full per-model + 5m/1h cache split), so the breakdown sums those directly — re-deriving from
+ *  a task's flattened `cacheWrite` + dominant model would diverge from the units shown in the
+ *  same row. This helper is the canonical per-bundle money API for callers that hold a single
+ *  raw bundle (e.g. the per-task `$` follow-up, #980); `pricing-dollars.test.ts` pins
+ *  `dollars(c) === weightedUnits(c)`, so the two formulas cannot silently drift. */
 export function dollars(
   c: {
     input: number;

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -1,9 +1,9 @@
-// Relative per-million-token weights used ONLY for the limit-% math — never displayed.
-// Absolute scale is irrelevant: the daily /usage calibration backs out the cap against these,
-// so only the ratios between models/kinds matter. Values track current public API list prices
-// ($/Mtok): Fable 5 10/50, Opus 4.8 5/25, Sonnet 4.6 3/15, Haiku 4.5 1/5 (input/output), with
-// cache kinds derived at the fixed 0.1× / 1.25× / 2× ratios. Keep the rows in price order so
-// Fable stays the heaviest tier — its weight must exceed Opus's, matching the cost copy.
+// The TABLE values are real Anthropic $/Mtok list prices and MUST stay absolute — they must NOT
+// be rescaled (e.g. normalised so a tier = 1), because /usage renders them as real currency via
+// dollars() (and as USD-denominated "units" in the spend breakdown). A rescale would silently
+// corrupt displayed money. The limit-% math (weightedUnits feeding the daily calibration) is
+// ratio-only, so it is unaffected by keeping the absolute anchor. Keep the rows in price order
+// so Fable stays the heaviest tier — its weight must exceed Opus's, matching the cost copy.
 
 interface ModelWeights {
   input: number;
@@ -62,6 +62,29 @@ export function cacheWriteUnits(
 
 /** Weighted "limit units" for one usage record, in arbitrary (per-Mtok) units. */
 export function weightedUnits(
+  c: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite5m: number;
+    cacheWrite1h: number;
+  },
+  model: string,
+): number {
+  const w = weightsFor(model);
+  return (
+    (c.input * w.input +
+      c.output * w.output +
+      c.cacheRead * w.cacheRead +
+      c.cacheWrite5m * w.cacheWrite5m +
+      c.cacheWrite1h * w.cacheWrite1h) /
+    1_000_000
+  );
+}
+
+/** Absolute USD cost of a token bundle at list price — the money view of the same weighted
+ *  units; displayed in /usage's api-key `$` column. */
+export function dollars(
   c: {
     input: number;
     output: number;

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,6 +58,7 @@ import { listBranches } from "./branches";
 import { computeDiff } from "./diff";
 import { sessionTokens, jsonlPathFor } from "./usage";
 import { buildUsageBreakdown } from "./usage-breakdown";
+import { isApiKeyMode } from "./spawn-auth";
 import { detectDevCommand } from "./preview";
 import { sessionActivity } from "./activity";
 import { handleUpload } from "./uploads";
@@ -2470,7 +2471,12 @@ async function handleUsageBreakdown({ req, parts, url, deps }: Ctx): Promise<Res
   const raw = url.searchParams.get("range") ?? "7d";
   if (raw !== "24h" && raw !== "7d" && raw !== "30d" && raw !== "all")
     return json({ error: "invalid range" }, 400);
-  const breakdown = await buildUsageBreakdown({ store: deps.store, range: raw, now: Date.now() });
+  const breakdown = await buildUsageBreakdown({
+    store: deps.store,
+    range: raw,
+    now: Date.now(),
+    apiKey: isApiKeyMode(),
+  });
   return json(breakdown);
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -666,6 +666,7 @@ export interface UsageRepoBreakdown {
   repoName: string;
   authoringUnits: number;
   satelliteUnits: number;
+  dollars: number | null; // absolute USD spend; null unless api-key auth mode (subscription mode shows no dollars)
   tasks: UsageTaskBreakdown[];
 }
 
@@ -677,6 +678,7 @@ export interface UsageBreakdown {
   satelliteUnits: number;
   cacheReadUnits: number;
   generationUnits: number;
+  dollars: number | null; // absolute USD spend; null unless api-key auth mode (subscription mode shows no dollars)
   repos: UsageRepoBreakdown[];
 }
 
@@ -699,6 +701,7 @@ export const USAGE_REPO_KEYS = [
   "repoName",
   "authoringUnits",
   "satelliteUnits",
+  "dollars",
   "tasks",
 ] as const;
 // Mirrors UsageBreakdown:
@@ -710,5 +713,6 @@ export const USAGE_BREAKDOWN_KEYS = [
   "satelliteUnits",
   "cacheReadUnits",
   "generationUnits",
+  "dollars",
   "repos",
 ] as const;

--- a/src/usage-breakdown.ts
+++ b/src/usage-breakdown.ts
@@ -166,6 +166,8 @@ function buildRepoBreakdowns(
       repoName,
       authoringUnits: repoAuthoring,
       satelliteUnits: repoSatellite,
+      // `$` = the accumulated list-price units themselves (NOT pricing.dollars() on aggregate
+      // tokens — that would diverge from the units shown). See dollars()'s doc in pricing.ts.
       dollars: apiKey ? repoAuthoring + repoSatellite : null,
       tasks: publicTasks,
     });

--- a/src/usage-breakdown.ts
+++ b/src/usage-breakdown.ts
@@ -127,7 +127,10 @@ function attributeSatellites(
 }
 
 /** Group task accumulators by repo, sort within each repo, and produce public repo breakdowns. */
-function buildRepoBreakdowns(taskMap: Map<string, TaskAccum>): UsageRepoBreakdown[] {
+function buildRepoBreakdowns(
+  taskMap: Map<string, TaskAccum>,
+  apiKey: boolean,
+): UsageRepoBreakdown[] {
   const repoMap = new Map<string, TaskAccum[]>();
   for (const task of taskMap.values()) {
     let bucket = repoMap.get(task.repoPath);
@@ -163,6 +166,7 @@ function buildRepoBreakdowns(taskMap: Map<string, TaskAccum>): UsageRepoBreakdow
       repoName,
       authoringUnits: repoAuthoring,
       satelliteUnits: repoSatellite,
+      dollars: apiKey ? repoAuthoring + repoSatellite : null,
       tasks: publicTasks,
     });
   }
@@ -199,8 +203,9 @@ export async function buildUsageBreakdown(opts: {
   store: SessionStore;
   range: UsageRange;
   now: number;
+  apiKey: boolean;
 }): Promise<UsageBreakdown> {
-  const { store, range, now } = opts;
+  const { store, range, now, apiKey } = opts;
 
   const cutoff = rangeCutoff(range, now);
 
@@ -228,7 +233,7 @@ export async function buildUsageBreakdown(opts: {
   attributeSatellites(taskMap, store.listReviewerSpawns());
 
   // Group by repo, sort, produce public breakdowns
-  const repos = buildRepoBreakdowns(taskMap);
+  const repos = buildRepoBreakdowns(taskMap, apiKey);
 
   // Top-level aggregates
   const totals = aggregateTotals(taskMap, repos);
@@ -237,6 +242,7 @@ export async function buildUsageBreakdown(opts: {
     range,
     generatedAt: now,
     ...totals,
+    dollars: apiKey ? totals.totalUnits : null,
     repos,
   };
 }

--- a/test/pricing-dollars.test.ts
+++ b/test/pricing-dollars.test.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "bun:test";
+import { dollars, weightedUnits } from "../src/pricing";
+
+// Hand-computed expected USD values from Anthropic list prices:
+// Opus: $5/Mtok input, $25/Mtok output
+// Sonnet: $3/Mtok input, $15/Mtok output
+
+test("pure-input Opus 1M tokens → $5.00", () => {
+  const c = { input: 1_000_000, output: 0, cacheRead: 0, cacheWrite5m: 0, cacheWrite1h: 0 };
+  expect(dollars(c, "claude-opus-4-8")).toBe(5);
+  expect(dollars(c, "claude-opus-4-8")).toBe(weightedUnits(c, "claude-opus-4-8"));
+});
+
+test("mixed Opus 1M input + 1M output → $30.00", () => {
+  const c = { input: 1_000_000, output: 1_000_000, cacheRead: 0, cacheWrite5m: 0, cacheWrite1h: 0 };
+  expect(dollars(c, "claude-opus-4-8")).toBe(5 + 25); // 30
+  expect(dollars(c, "claude-opus-4-8")).toBe(weightedUnits(c, "claude-opus-4-8"));
+});
+
+test("Sonnet 2M output tokens → $30.00", () => {
+  const c = { input: 0, output: 2_000_000, cacheRead: 0, cacheWrite5m: 0, cacheWrite1h: 0 };
+  expect(dollars(c, "claude-sonnet-4-6")).toBe(2 * 15); // 30
+  expect(dollars(c, "claude-sonnet-4-6")).toBe(weightedUnits(c, "claude-sonnet-4-6"));
+});

--- a/test/server-usage-breakdown.test.ts
+++ b/test/server-usage-breakdown.test.ts
@@ -64,9 +64,12 @@ test("GET /api/usage/breakdown?range=7d → 200 with correct shape", async () =>
   const body = await res.json();
   exactKeys(body, USAGE_BREAKDOWN_KEYS);
   expect(body.range).toBe("7d");
+  // api-key gate: subscription harness defaults to non-api-key mode → dollars must be null
+  expect(body.dollars).toBeNull();
 
   for (const repo of body.repos) {
     exactKeys(repo, USAGE_REPO_KEYS);
+    expect(repo.dollars).toBeNull();
     for (const task of repo.tasks) {
       exactKeys(task, USAGE_TASK_KEYS);
       exactKeys(task.tokens, USAGE_TOKENS_KEYS);

--- a/test/usage-breakdown.test.ts
+++ b/test/usage-breakdown.test.ts
@@ -163,7 +163,7 @@ test("repo→task grouping, sorting, field mapping", async () => {
     }),
   );
 
-  const bd = await buildUsageBreakdown({ store, range: "all", now: NOW });
+  const bd = await buildUsageBreakdown({ store, range: "all", now: NOW, apiKey: false });
 
   // Repos sorted by total desc: alpha (snapA1Wu+snapA2Wu) > beta (snapBWu)
   expect(bd.repos).toHaveLength(2);
@@ -229,17 +229,17 @@ test("persisted range filter: stale snapshot absent at 24h, present at all/30d",
     }),
   );
 
-  const bd24h = await buildUsageBreakdown({ store, range: "24h", now: NOW });
+  const bd24h = await buildUsageBreakdown({ store, range: "24h", now: NOW, apiKey: false });
   const taskIds24h = bd24h.repos.flatMap((r) => r.tasks.map((t) => t.sessionId));
   expect(taskIds24h).toContain("recent");
   expect(taskIds24h).not.toContain("stale");
 
-  const bdAll = await buildUsageBreakdown({ store, range: "all", now: NOW });
+  const bdAll = await buildUsageBreakdown({ store, range: "all", now: NOW, apiKey: false });
   const taskIdsAll = bdAll.repos.flatMap((r) => r.tasks.map((t) => t.sessionId));
   expect(taskIdsAll).toContain("recent");
   expect(taskIdsAll).toContain("stale");
 
-  const bd30d = await buildUsageBreakdown({ store, range: "30d", now: NOW });
+  const bd30d = await buildUsageBreakdown({ store, range: "30d", now: NOW, apiKey: false });
   const taskIds30d = bd30d.repos.flatMap((r) => r.tasks.map((t) => t.sessionId));
   expect(taskIds30d).toContain("recent");
   expect(taskIds30d).toContain("stale");
@@ -321,7 +321,7 @@ test("satellite: targeted task accumulates spawn cost; out-of-scope spawn ignore
     NOW - 1500,
   );
 
-  const bd = await buildUsageBreakdown({ store, range: "all", now: NOW });
+  const bd = await buildUsageBreakdown({ store, range: "all", now: NOW, apiKey: false });
 
   const task = bd.repos.flatMap((r) => r.tasks).find((t) => t.sessionId === "task-a");
   expect(task).toBeDefined();
@@ -403,14 +403,14 @@ test("live per-record windowing: 24h reflects only recent record; all reflects b
   writeJsonl(worktreePath, claudeSessionId, [oldRecord, recentRecord]);
 
   // 24h: only recent record
-  const bd24h = await buildUsageBreakdown({ store, range: "24h", now: NOW });
+  const bd24h = await buildUsageBreakdown({ store, range: "24h", now: NOW, apiKey: false });
   const task24h = bd24h.repos.flatMap((r) => r.tasks).find((t) => t.sessionId === liveSessionId);
   expect(task24h).toBeDefined();
   expect(task24h!.tokens.input).toBe(300);
   expect(task24h!.tokens.output).toBe(100);
 
   // all: both records
-  const bdAll = await buildUsageBreakdown({ store, range: "all", now: NOW });
+  const bdAll = await buildUsageBreakdown({ store, range: "all", now: NOW, apiKey: false });
   const taskAll = bdAll.repos.flatMap((r) => r.tasks).find((t) => t.sessionId === liveSessionId);
   expect(taskAll).toBeDefined();
   expect(taskAll!.tokens.input).toBe(800);
@@ -470,7 +470,7 @@ test("dedupe: live session also having a snapshot appears once (persisted wins)"
     }),
   );
 
-  const bd = await buildUsageBreakdown({ store, range: "all", now: NOW });
+  const bd = await buildUsageBreakdown({ store, range: "all", now: NOW, apiKey: false });
   const tasks = bd.repos.flatMap((r) => r.tasks).filter((t) => t.sessionId === liveSession.id);
 
   // Only appears once (persisted wins — tokens from snapshot, not live)
@@ -513,7 +513,7 @@ test("operational-archetype live session excluded", async () => {
     asst({ requestId: "r1", ts: NOW, model: "claude-opus-4-8", input: 1000, output: 500 }),
   ]);
 
-  const bd = await buildUsageBreakdown({ store, range: "all", now: NOW });
+  const bd = await buildUsageBreakdown({ store, range: "all", now: NOW, apiKey: false });
   const tasks = bd.repos.flatMap((r) => r.tasks);
   const found = tasks.find((t) => t.sessionId === mtSession.id);
   expect(found).toBeUndefined();
@@ -575,7 +575,7 @@ test("top-level invariants: cacheReadUnits + generationUnits === totalUnits, tot
     NOW - 500,
   );
 
-  const bd = await buildUsageBreakdown({ store, range: "all", now: NOW });
+  const bd = await buildUsageBreakdown({ store, range: "all", now: NOW, apiKey: false });
 
   expect(bd.totalUnits).toBeCloseTo(bd.authoringUnits + bd.satelliteUnits, 10);
   expect(bd.totalUnits).toBeCloseTo(bd.cacheReadUnits + bd.generationUnits, 10);
@@ -584,7 +584,7 @@ test("top-level invariants: cacheReadUnits + generationUnits === totalUnits, tot
 
 test("empty store returns zero-valued breakdown", async () => {
   const store = new SessionStore(":memory:");
-  const bd = await buildUsageBreakdown({ store, range: "24h", now: NOW });
+  const bd = await buildUsageBreakdown({ store, range: "24h", now: NOW, apiKey: false });
 
   expect(bd.range).toBe("24h");
   expect(bd.generatedAt).toBe(NOW);
@@ -594,4 +594,91 @@ test("empty store returns zero-valued breakdown", async () => {
   expect(bd.cacheReadUnits).toBe(0);
   expect(bd.generationUnits).toBe(0);
   expect(bd.repos).toHaveLength(0);
+});
+
+test("apiKey gate: dollars non-null and equals total units when true, null when false", async () => {
+  const store = new SessionStore(":memory:");
+  const model = "claude-opus-4-8";
+
+  // Two repos, each with one task + satellite spend
+  const snapAWu = weightedUnits(
+    { input: 1000, output: 400, cacheRead: 0, cacheWrite5m: 0, cacheWrite1h: 0 },
+    model,
+  );
+  store.upsertSessionUsage(
+    makeSnap({
+      sessionId: "ak-s1",
+      desig: "TASK-01",
+      repoPath: "/repos/ak-alpha",
+      input: 1000,
+      output: 400,
+      weightedUnits: snapAWu,
+      cacheReadUnits: 0,
+      snapshotAt: NOW,
+    }),
+  );
+
+  const snapBWu = weightedUnits(
+    { input: 600, output: 200, cacheRead: 0, cacheWrite5m: 0, cacheWrite1h: 0 },
+    model,
+  );
+  store.upsertSessionUsage(
+    makeSnap({
+      sessionId: "ak-s2",
+      desig: "TASK-02",
+      repoPath: "/repos/ak-beta",
+      input: 600,
+      output: 200,
+      weightedUnits: snapBWu,
+      cacheReadUnits: 0,
+      snapshotAt: NOW,
+    }),
+  );
+
+  // Add a satellite spawn on ak-s1 to ensure satelliteUnits are included
+  const spawnInput = 200;
+  const spawnOutput = 80;
+  store.recordReviewerSpawn({
+    reviewerSessionId: "ak-rev-1",
+    taskSessionId: "ak-s1",
+    kind: "review",
+    worktreePath: "/wt",
+    model,
+    spawnedAt: NOW - 1000,
+  });
+  store.completeReviewerSpawn(
+    "ak-rev-1",
+    {
+      input: spawnInput,
+      output: spawnOutput,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: spawnInput + spawnOutput,
+      messageCount: 1,
+      lastActivity: NOW - 500,
+      byModel: { [model]: spawnInput + spawnOutput },
+      fullRecaches: 0,
+      sidechainCount: 0,
+    },
+    NOW - 500,
+  );
+
+  // apiKey: true — dollars must be non-null and equal authoringUnits + satelliteUnits
+  const bdOn = await buildUsageBreakdown({ store, range: "all", now: NOW, apiKey: true });
+
+  expect(bdOn.dollars).not.toBeNull();
+  expect(bdOn.dollars).toBeCloseTo(bdOn.authoringUnits + bdOn.satelliteUnits, 10);
+
+  for (const repo of bdOn.repos) {
+    expect(repo.dollars).not.toBeNull();
+    expect(repo.dollars).toBeCloseTo(repo.authoringUnits + repo.satelliteUnits, 10);
+  }
+
+  // apiKey: false — dollars must be null at every level
+  const bdOff = await buildUsageBreakdown({ store, range: "all", now: NOW, apiKey: false });
+
+  expect(bdOff.dollars).toBeNull();
+  for (const repo of bdOff.repos) {
+    expect(repo.dollars).toBeNull();
+  }
 });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1762,7 +1762,6 @@
   "usage_limits_will_exceed": "voraussichtlich Limit überschritten",
   "usage_limits_no_data": "Keine Nutzungsfenster-Daten",
   "usage_page_title": "Nutzung",
-  "usage_prototype_note": "Beispieldaten · visueller Prototyp",
   "usage_spend_tab": "Verbrauch",
   "usage_overhead_tab": "Overhead",
   "usage_limits_tab": "Limits",
@@ -1787,5 +1786,6 @@
   "settings_feedback_title": "Feedback",
   "settings_feedback_blurb": "Fehler gefunden oder eine Idee? Sagen Sie uns Bescheid.",
   "feat_feedback_title": "Fehler melden & Feedback senden",
-  "feat_feedback_body": "Fehler gefunden oder eine Idee? Über das Zahnrad-Menü oder Einstellungen → Gerät können Sie einen Fehler melden, eine Funktion vorschlagen oder Feedback senden – es öffnet ein vorausgefülltes GitHub-Issue."
+  "feat_feedback_body": "Fehler gefunden oder eine Idee? Über das Zahnrad-Menü oder Einstellungen → Gerät können Sie einen Fehler melden, eine Funktion vorschlagen oder Feedback senden – es öffnet ein vorausgefülltes GitHub-Issue.",
+  "usage_load_error": "Nutzungsdaten konnten nicht geladen werden."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1787,5 +1787,6 @@
   "settings_feedback_blurb": "Fehler gefunden oder eine Idee? Sagen Sie uns Bescheid.",
   "feat_feedback_title": "Fehler melden & Feedback senden",
   "feat_feedback_body": "Fehler gefunden oder eine Idee? Über das Zahnrad-Menü oder Einstellungen → Gerät können Sie einen Fehler melden, eine Funktion vorschlagen oder Feedback senden – es öffnet ein vorausgefülltes GitHub-Issue.",
-  "usage_load_error": "Nutzungsdaten konnten nicht geladen werden."
+  "usage_load_error": "Nutzungsdaten konnten nicht geladen werden.",
+  "usage_spend_cost_label": "Kosten"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1788,5 +1788,7 @@
   "feat_feedback_title": "Fehler melden & Feedback senden",
   "feat_feedback_body": "Fehler gefunden oder eine Idee? Über das Zahnrad-Menü oder Einstellungen → Gerät können Sie einen Fehler melden, eine Funktion vorschlagen oder Feedback senden – es öffnet ein vorausgefülltes GitHub-Issue.",
   "usage_load_error": "Nutzungsdaten konnten nicht geladen werden.",
-  "usage_spend_cost_label": "Kosten"
+  "usage_spend_cost_label": "Kosten",
+  "topbar_usage_link": "Token-Nutzung",
+  "topbar_usage_link_aria": "Token-Nutzungs-Dashboard öffnen"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1790,5 +1790,7 @@
   "usage_load_error": "Nutzungsdaten konnten nicht geladen werden.",
   "usage_spend_cost_label": "Kosten",
   "topbar_usage_link": "Token-Nutzung",
-  "topbar_usage_link_aria": "Token-Nutzungs-Dashboard öffnen"
+  "topbar_usage_link_aria": "Token-Nutzungs-Dashboard öffnen",
+  "feat_usage_dashboard_title": "Token-Nutzungs-Dashboard",
+  "feat_usage_dashboard_body": "Sehen Sie, wofür Ihre Tokens verbraucht werden — Verbrauch pro Repository und Task, der Cache-vs-Generierung-Overhead und die Live-Auslastung der Limits. Öffnen über das Zahnradmenü."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1787,5 +1787,6 @@
   "settings_feedback_blurb": "Found a bug or have an idea? Let us know.",
   "feat_feedback_title": "Report bugs & send feedback",
   "feat_feedback_body": "Found a bug or have an idea? Use the gear menu or Settings → Device to report a bug, request a feature, or send feedback — it opens a prefilled GitHub issue.",
-  "usage_load_error": "Couldn't load usage data."
+  "usage_load_error": "Couldn't load usage data.",
+  "usage_spend_cost_label": "Cost"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1788,5 +1788,7 @@
   "feat_feedback_title": "Report bugs & send feedback",
   "feat_feedback_body": "Found a bug or have an idea? Use the gear menu or Settings → Device to report a bug, request a feature, or send feedback — it opens a prefilled GitHub issue.",
   "usage_load_error": "Couldn't load usage data.",
-  "usage_spend_cost_label": "Cost"
+  "usage_spend_cost_label": "Cost",
+  "topbar_usage_link": "Token usage",
+  "topbar_usage_link_aria": "Open the token-usage dashboard"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1790,5 +1790,7 @@
   "usage_load_error": "Couldn't load usage data.",
   "usage_spend_cost_label": "Cost",
   "topbar_usage_link": "Token usage",
-  "topbar_usage_link_aria": "Open the token-usage dashboard"
+  "topbar_usage_link_aria": "Open the token-usage dashboard",
+  "feat_usage_dashboard_title": "Token usage dashboard",
+  "feat_usage_dashboard_body": "See where your tokens go — spend by repo and task, the cache-vs-generation overhead split, and live limit burn-down. Open it from the gear menu."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1762,7 +1762,6 @@
   "usage_limits_will_exceed": "projected to exceed limit",
   "usage_limits_no_data": "No usage-window data",
   "usage_page_title": "Usage",
-  "usage_prototype_note": "Sample data · visual prototype",
   "usage_spend_tab": "Spend",
   "usage_overhead_tab": "Overhead",
   "usage_limits_tab": "Limits",
@@ -1787,5 +1786,6 @@
   "settings_feedback_title": "Feedback",
   "settings_feedback_blurb": "Found a bug or have an idea? Let us know.",
   "feat_feedback_title": "Report bugs & send feedback",
-  "feat_feedback_body": "Found a bug or have an idea? Use the gear menu or Settings → Device to report a bug, request a feature, or send feedback — it opens a prefilled GitHub issue."
+  "feat_feedback_body": "Found a bug or have an idea? Use the gear menu or Settings → Device to report a bug, request a feature, or send feedback — it opens a prefilled GitHub issue.",
+  "usage_load_error": "Couldn't load usage data."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -9,6 +9,8 @@ import type {
   ActivityEntry,
   SessionUsage,
   UsageLimits,
+  UsageBreakdown,
+  UsageRange,
   GitState,
   PrStatus,
   MergeMethod,
@@ -485,6 +487,12 @@ export async function getDiff(id: string): Promise<DiffResult> {
 export async function getUsageLimits(): Promise<UsageLimits> {
   const r = await fetch("/api/usage/limits");
   if (!r.ok) throw await failed(r, "limits");
+  return r.json();
+}
+
+export async function getUsageBreakdown(range: UsageRange): Promise<UsageBreakdown> {
+  const r = await fetch(`/api/usage/breakdown?range=${range}`);
+  if (!r.ok) throw await failed(r, "breakdown");
   return r.json();
 }
 

--- a/ui/src/lib/components/top-bar/TopBarGear.svelte
+++ b/ui/src/lib/components/top-bar/TopBarGear.svelte
@@ -2,6 +2,7 @@
   import { m } from "$lib/paraglide/messages";
   import { DOCS_URL } from "$lib/build-info";
   import type { FeedbackKind } from "$lib/feedback-link";
+  import { coachTarget } from "$lib/actions/coachTarget.svelte";
 
   type GearPipTier = "red" | "orange" | "yellow" | "blue" | null;
 
@@ -98,6 +99,18 @@
         <span class="menu-label">{m.settings_title()}</span>
       </button>
       <div class="menu-sep" role="separator"></div>
+      <!-- eslint-disable svelte/no-navigation-without-resolve -- internal SvelteKit route -->
+      <a
+        class="menu-item"
+        role="menuitem"
+        href="/usage"
+        use:coachTarget={"usage-link"}
+        onclick={() => (menuOpen = false)}
+      >
+        <span class="menu-glyph" aria-hidden="true">▦</span>
+        <span class="menu-label">{m.topbar_usage_link()}</span>
+      </a>
+      <!-- eslint-enable svelte/no-navigation-without-resolve -->
       <!-- External docs site — opens in a new tab; ↗ marks it external, matching the
            mobile sheet + Settings → About link convention. Closes the menu on click. -->
       <a

--- a/ui/src/lib/components/top-bar/TopBarGear.svelte
+++ b/ui/src/lib/components/top-bar/TopBarGear.svelte
@@ -3,6 +3,7 @@
   import { DOCS_URL } from "$lib/build-info";
   import type { FeedbackKind } from "$lib/feedback-link";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
+  import { resolve } from "$app/paths";
 
   type GearPipTier = "red" | "orange" | "yellow" | "blue" | null;
 
@@ -99,18 +100,16 @@
         <span class="menu-label">{m.settings_title()}</span>
       </button>
       <div class="menu-sep" role="separator"></div>
-      <!-- eslint-disable svelte/no-navigation-without-resolve -- internal SvelteKit route -->
       <a
         class="menu-item"
         role="menuitem"
-        href="/usage"
+        href={resolve("/usage")}
         use:coachTarget={"usage-link"}
         onclick={() => (menuOpen = false)}
       >
         <span class="menu-glyph" aria-hidden="true">▦</span>
         <span class="menu-label">{m.topbar_usage_link()}</span>
       </a>
-      <!-- eslint-enable svelte/no-navigation-without-resolve -->
       <!-- External docs site — opens in a new tab; ↗ marks it external, matching the
            mobile sheet + Settings → About link convention. Closes the menu on click. -->
       <a

--- a/ui/src/lib/components/top-bar/TopBarMobileSheet.svelte
+++ b/ui/src/lib/components/top-bar/TopBarMobileSheet.svelte
@@ -12,6 +12,7 @@
   import { fly } from "svelte/transition";
   import { dialog } from "$lib/a11yDialog";
   import { portal } from "$lib/portal";
+  import { resolve } from "$app/paths";
 
   // Quick theme controls surfaced directly in the gear menu on mobile — the desktop
   // ActionBar carries these, but on phone it hides them, leaving Settings → Device the
@@ -200,8 +201,7 @@
           />
         </div>
       {/if}
-      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal SvelteKit route -->
-      <a class="sheet-item" href="/usage" onclick={() => closeMenu()}>
+      <a class="sheet-item" href={resolve("/usage")} onclick={() => closeMenu()}>
         <span class="sheet-glyph" aria-hidden="true">▦</span>
         <span class="sheet-label">{m.topbar_usage_link()}</span>
       </a>

--- a/ui/src/lib/components/top-bar/TopBarMobileSheet.svelte
+++ b/ui/src/lib/components/top-bar/TopBarMobileSheet.svelte
@@ -200,6 +200,11 @@
           />
         </div>
       {/if}
+      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal SvelteKit route -->
+      <a class="sheet-item" href="/usage" onclick={() => closeMenu()}>
+        <span class="sheet-glyph" aria-hidden="true">▦</span>
+        <span class="sheet-label">{m.topbar_usage_link()}</span>
+      </a>
       <div class="sheet-sep"></div>
     {/if}
 

--- a/ui/src/lib/components/top-bar/TopBarUsage.svelte
+++ b/ui/src/lib/components/top-bar/TopBarUsage.svelte
@@ -6,6 +6,7 @@
   import { formatResetIn, formatReset } from "$lib/format";
   import CreditGauge from "./CreditGauge.svelte";
   import CreditDetail from "./CreditDetail.svelte";
+  import { resolve } from "$app/paths";
 
   let {
     subscriptionOnly,
@@ -143,8 +144,7 @@
             {refreshError}
             {onRefresh}
           />
-          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal SvelteKit route -->
-          <a class="gauge-pop-link" href="/usage" onclick={() => (popoverOpen = false)}>
+          <a class="gauge-pop-link" href={resolve("/usage")} onclick={() => (popoverOpen = false)}>
             {m.topbar_usage_link()}
           </a>
         </div>
@@ -158,8 +158,7 @@
     onmouseenter={() => (detailOpen = true)}
     onmouseleave={() => (detailOpen = false)}
   >
-    <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal SvelteKit route -->
-    <a class="gauges-link" href="/usage" aria-label={m.topbar_usage_link_aria()}>
+    <a class="gauges-link" href={resolve("/usage")} aria-label={m.topbar_usage_link_aria()}>
       <div class="gauges" class:stale>
         {#each gauges as g (g.label)}
           <div class="gauge" aria-label={gaugeTip(g.label, g.w.pct, g.w.resetAt)}>

--- a/ui/src/lib/components/top-bar/TopBarUsage.svelte
+++ b/ui/src/lib/components/top-bar/TopBarUsage.svelte
@@ -143,6 +143,10 @@
             {refreshError}
             {onRefresh}
           />
+          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal SvelteKit route -->
+          <a class="gauge-pop-link" href="/usage" onclick={() => (popoverOpen = false)}>
+            {m.topbar_usage_link()}
+          </a>
         </div>
       {/if}
     </div>
@@ -154,22 +158,25 @@
     onmouseenter={() => (detailOpen = true)}
     onmouseleave={() => (detailOpen = false)}
   >
-    <div class="gauges" class:stale>
-      {#each gauges as g (g.label)}
-        <div class="gauge" aria-label={gaugeTip(g.label, g.w.pct, g.w.resetAt)}>
-          <span class="g-label micro">{g.label}</span>
-          <span class="g-bar"
-            ><span
-              class="g-fill"
-              style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) /
-                100});background:{gaugeColor(g.w.pct)}"
-            ></span></span
-          >
-          <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
-        </div>
-      {/each}
-      <CreditGauge {credits} {overspend} {creditFill} {creditColor} {creditAmount} />
-    </div>
+    <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal SvelteKit route -->
+    <a class="gauges-link" href="/usage" aria-label={m.topbar_usage_link_aria()}>
+      <div class="gauges" class:stale>
+        {#each gauges as g (g.label)}
+          <div class="gauge" aria-label={gaugeTip(g.label, g.w.pct, g.w.resetAt)}>
+            <span class="g-label micro">{g.label}</span>
+            <span class="g-bar"
+              ><span
+                class="g-fill"
+                style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) /
+                  100});background:{gaugeColor(g.w.pct)}"
+              ></span></span
+            >
+            <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
+          </div>
+        {/each}
+        <CreditGauge {credits} {overspend} {creditFill} {creditColor} {creditAmount} />
+      </div>
+    </a>
     {#if detailOpen}
       <div class="gauge-pop gauge-pop-desk" role="tooltip" class:stale>
         <div class="gauge-pop-title micro">
@@ -221,6 +228,25 @@
   .usage-sub-only {
     color: var(--color-muted);
     max-width: 22rem;
+  }
+  /* Desktop: clicking the gauges cluster navigates to /usage. */
+  .gauges-link {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+  }
+  /* Touch popover: quiet /usage nav link at the bottom of the breakdown popover. */
+  .gauge-pop-link {
+    display: block;
+    margin-top: 8px;
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    text-decoration: none;
+    text-align: right;
+  }
+  .gauge-pop-link:hover,
+  .gauge-pop-link:focus-visible {
+    color: var(--color-ink);
   }
   .gauges-wrap {
     position: relative;

--- a/ui/src/lib/components/usage/SpendLens.browser.test.ts
+++ b/ui/src/lib/components/usage/SpendLens.browser.test.ts
@@ -53,6 +53,37 @@ describe("SpendLens", () => {
     expect(moreText).toMatch(/6/);
   });
 
+  it("api-key mode shows $ cost cells and total", async () => {
+    const breakdown = mockBreakdown("7d");
+    render(SpendLens, { breakdown });
+
+    // Each repo row should have a cost cell
+    const costCells = document.querySelectorAll(".repo-cost");
+    expect(costCells.length, "repo-cost cells rendered").toBeGreaterThanOrEqual(
+      breakdown.repos.length,
+    );
+
+    // Grand-total cost element should exist with $ prefix
+    const totalEl = document.querySelector(".spend-total-cost");
+    expect(totalEl, "spend-total-cost element exists").not.toBeNull();
+    expect(totalEl?.textContent?.trim().startsWith("$"), "total starts with $").toBe(true);
+  });
+
+  it("subscription mode hides $ cost cells and total", async () => {
+    const sub = {
+      ...mockBreakdown("7d"),
+      dollars: null,
+      repos: mockBreakdown("7d").repos.map((r) => ({ ...r, dollars: null })),
+    };
+    render(SpendLens, { breakdown: sub });
+
+    const costCells = document.querySelectorAll(".repo-cost");
+    expect(costCells.length, "no repo-cost cells in subscription mode").toBe(0);
+
+    const totalEl = document.querySelector(".spend-total-cost");
+    expect(totalEl, "no spend-total-cost in subscription mode").toBeNull();
+  });
+
   it("toggling a collapsed repo expands it and shows task rows", async () => {
     const breakdown = mockBreakdown("7d");
     render(SpendLens, { breakdown });

--- a/ui/src/lib/components/usage/SpendLens.svelte
+++ b/ui/src/lib/components/usage/SpendLens.svelte
@@ -4,7 +4,7 @@
   import { m } from "$lib/paraglide/messages";
   import GlossaryText from "$lib/components/GlossaryText.svelte";
   import UsageBar from "./UsageBar.svelte";
-  import { formatUnits, formatPct } from "./format";
+  import { formatUnits, formatPct, formatDollars } from "./format";
 
   const { breakdown }: { breakdown: UsageBreakdown } = $props();
 
@@ -71,6 +71,11 @@
     <span class="units-label">
       <GlossaryText text={m.usage_units_label()} />
     </span>
+    {#if breakdown.dollars != null}
+      <span class="spend-total-cost" aria-label={m.usage_spend_cost_label()}>
+        {formatDollars(breakdown.dollars)}
+      </span>
+    {/if}
   </div>
 
   <div class="repo-list">
@@ -84,6 +89,7 @@
       <div class="repo-row-wrap">
         <button
           class="repo-row"
+          class:has-cost={breakdown.dollars != null}
           aria-expanded={expanded}
           onclick={() => toggleRepo(repo.repoPath)}
           type="button"
@@ -95,6 +101,9 @@
           </span>
           <span class="repo-pct">{formatPct(total / breakdown.totalUnits)}</span>
           <span class="repo-units">{formatUnits(total)}</span>
+          {#if breakdown.dollars != null}
+            <span class="repo-cost">{formatDollars(repo.dollars ?? 0)}</span>
+          {/if}
         </button>
 
         {#if expanded}
@@ -176,6 +185,10 @@
     width: 100%;
   }
 
+  .repo-row.has-cost {
+    grid-template-columns: 1rem 8rem 1fr 3rem 5rem 4rem;
+  }
+
   .repo-row:hover {
     background: var(--color-hover);
   }
@@ -207,6 +220,20 @@
 
   .repo-units {
     font-size: var(--fs-base);
+    color: var(--color-ink);
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .repo-cost {
+    font-size: var(--fs-base);
+    color: var(--color-ink);
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .spend-total-cost {
+    font-size: var(--fs-meta);
     color: var(--color-ink);
     text-align: right;
     font-variant-numeric: tabular-nums;

--- a/ui/src/lib/components/usage/format.test.ts
+++ b/ui/src/lib/components/usage/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatUnits, formatPct } from "./format";
+import { formatUnits, formatPct, formatDollars } from "./format";
 
 describe("formatUnits", () => {
   it("renders raw counts below 1K verbatim", () => {
@@ -32,5 +32,20 @@ describe("formatPct", () => {
     expect(formatPct(0)).toBe("0%");
     expect(formatPct(0.357)).toBe("36%");
     expect(formatPct(1)).toBe("100%");
+  });
+});
+
+describe("formatDollars", () => {
+  it("renders small amounts with two decimal places", () => {
+    expect(formatDollars(5.42)).toBe("$5.42");
+    expect(formatDollars(0.28)).toBe("$0.28");
+  });
+
+  it("renders thousands with one decimal place and K suffix", () => {
+    expect(formatDollars(1500)).toBe("$1.5K");
+  });
+
+  it("renders millions with two decimal places and M suffix", () => {
+    expect(formatDollars(2_500_000)).toBe("$2.50M");
   });
 });

--- a/ui/src/lib/components/usage/format.ts
+++ b/ui/src/lib/components/usage/format.ts
@@ -21,3 +21,13 @@ export function formatUnits(n: number): string {
 export function formatPct(fraction: number): string {
   return Math.round(fraction * 100) + "%";
 }
+
+/**
+ * Format a dollar amount as a human-readable USD string.
+ * ≥1M → 2 decimal places + "M"; ≥1K → 1 decimal place + "K"; else 2 decimal places.
+ */
+export function formatDollars(n: number): string {
+  if (n >= 1_000_000) return "$" + (n / 1_000_000).toFixed(2) + "M";
+  if (n >= 1_000) return "$" + (n / 1_000).toFixed(1) + "K";
+  return "$" + n.toFixed(2);
+}

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1399,4 +1399,11 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_feedback_title",
     bodyKey: "feat_feedback_body",
   },
+  {
+    id: "usage-dashboard",
+    sinceVersion: "1.36.0",
+    titleKey: "feat_usage_dashboard_title",
+    bodyKey: "feat_usage_dashboard_body",
+    targetId: "usage-link",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -766,6 +766,7 @@ export interface UsageRepoBreakdown {
   repoName: string;
   authoringUnits: number;
   satelliteUnits: number;
+  dollars: number | null; // absolute USD spend; null unless api-key auth mode
   tasks: UsageTaskBreakdown[];
 }
 
@@ -778,6 +779,7 @@ export interface UsageBreakdown {
   satelliteUnits: number;
   cacheReadUnits: number; // cheap-cache share (Overhead b)
   generationUnits: number; // non-cacheRead share (Overhead b)
+  dollars: number | null; // absolute USD spend; null unless api-key auth mode
   repos: UsageRepoBreakdown[];
 }
 

--- a/ui/src/lib/usage-mock.ts
+++ b/ui/src/lib/usage-mock.ts
@@ -382,12 +382,14 @@ export function mockBreakdown(range: UsageRange): UsageBreakdown {
         satelliteUnits: totalS,
         cacheReadUnits: Math.round(total * 0.75),
         generationUnits: Math.round(total * 0.25),
+        dollars: total,
         repos: [
           {
             repoPath: "/home/user/shepherd",
             repoName: "shepherd",
             authoringUnits: shepherdAuth24h,
             satelliteUnits: shepherdSat24h,
+            dollars: shepherdAuth24h + shepherdSat24h,
             tasks: shepherdTasks24h,
           },
           {
@@ -395,6 +397,7 @@ export function mockBreakdown(range: UsageRange): UsageBreakdown {
             repoName: "web-app",
             authoringUnits: webappAuth24h,
             satelliteUnits: webappSat24h,
+            dollars: webappAuth24h + webappSat24h,
             tasks: webappTasks24h,
           },
           {
@@ -402,6 +405,7 @@ export function mockBreakdown(range: UsageRange): UsageBreakdown {
             repoName: "infra",
             authoringUnits: infraAuth24h,
             satelliteUnits: infraSat24h,
+            dollars: infraAuth24h + infraSat24h,
             tasks: infraTasks24h,
           },
         ],
@@ -420,12 +424,14 @@ export function mockBreakdown(range: UsageRange): UsageBreakdown {
         satelliteUnits: totalS,
         cacheReadUnits: Math.round(total * 0.76),
         generationUnits: Math.round(total * 0.24),
+        dollars: total,
         repos: [
           {
             repoPath: "/home/user/shepherd",
             repoName: "shepherd",
             authoringUnits: shepherdAuth7d,
             satelliteUnits: shepherdSat7d,
+            dollars: shepherdAuth7d + shepherdSat7d,
             tasks: shepherdTasks7d,
           },
           {
@@ -433,6 +439,7 @@ export function mockBreakdown(range: UsageRange): UsageBreakdown {
             repoName: "web-app",
             authoringUnits: webappAuth7d,
             satelliteUnits: webappSat7d,
+            dollars: webappAuth7d + webappSat7d,
             tasks: webappTasks7d,
           },
           {
@@ -440,6 +447,7 @@ export function mockBreakdown(range: UsageRange): UsageBreakdown {
             repoName: "infra",
             authoringUnits: infraAuth7d,
             satelliteUnits: infraSat7d,
+            dollars: infraAuth7d + infraSat7d,
             tasks: infraTasks7d,
           },
         ],
@@ -458,12 +466,14 @@ export function mockBreakdown(range: UsageRange): UsageBreakdown {
         satelliteUnits: totalS,
         cacheReadUnits: Math.round(total * 0.77),
         generationUnits: Math.round(total * 0.23),
+        dollars: total,
         repos: [
           {
             repoPath: "/home/user/shepherd",
             repoName: "shepherd",
             authoringUnits: shepherdAuth30d,
             satelliteUnits: shepherdSat30d,
+            dollars: shepherdAuth30d + shepherdSat30d,
             tasks: shepherdTasks30d,
           },
           {
@@ -471,6 +481,7 @@ export function mockBreakdown(range: UsageRange): UsageBreakdown {
             repoName: "web-app",
             authoringUnits: webappAuth30d,
             satelliteUnits: webappSat30d,
+            dollars: webappAuth30d + webappSat30d,
             tasks: webappTasks30d,
           },
           {
@@ -478,6 +489,7 @@ export function mockBreakdown(range: UsageRange): UsageBreakdown {
             repoName: "infra",
             authoringUnits: infraAuth30d,
             satelliteUnits: infraSat30d,
+            dollars: infraAuth30d + infraSat30d,
             tasks: infraTasks30d,
           },
           {
@@ -485,6 +497,7 @@ export function mockBreakdown(range: UsageRange): UsageBreakdown {
             repoName: "docs",
             authoringUnits: docsAuth30d,
             satelliteUnits: docsSat30d,
+            dollars: docsAuth30d + docsSat30d,
             tasks: docsTasks30d,
           },
         ],
@@ -503,12 +516,14 @@ export function mockBreakdown(range: UsageRange): UsageBreakdown {
         satelliteUnits: totalS,
         cacheReadUnits: Math.round(total * 0.78),
         generationUnits: Math.round(total * 0.22),
+        dollars: total,
         repos: [
           {
             repoPath: "/home/user/shepherd",
             repoName: "shepherd",
             authoringUnits: shepherdAuthAll,
             satelliteUnits: shepherdSatAll,
+            dollars: shepherdAuthAll + shepherdSatAll,
             tasks: shepherdTasksAll,
           },
           {
@@ -516,6 +531,7 @@ export function mockBreakdown(range: UsageRange): UsageBreakdown {
             repoName: "web-app",
             authoringUnits: webappAuthAll,
             satelliteUnits: webappSatAll,
+            dollars: webappAuthAll + webappSatAll,
             tasks: webappTasksAll,
           },
           {
@@ -523,6 +539,7 @@ export function mockBreakdown(range: UsageRange): UsageBreakdown {
             repoName: "infra",
             authoringUnits: infraAuthAll,
             satelliteUnits: infraSatAll,
+            dollars: infraAuthAll + infraSatAll,
             tasks: infraTasksAll,
           },
           {
@@ -530,6 +547,7 @@ export function mockBreakdown(range: UsageRange): UsageBreakdown {
             repoName: "docs",
             authoringUnits: docsAuthAll,
             satelliteUnits: docsSatAll,
+            dollars: docsAuthAll + docsSatAll,
             tasks: docsTasksAll,
           },
         ],

--- a/ui/src/routes/usage/+page.svelte
+++ b/ui/src/routes/usage/+page.svelte
@@ -27,45 +27,32 @@
       });
   });
 
-  // Fetch breakdown on mount and whenever range changes.
-  // Guard against out-of-order responses with a request token.
-  $effect(() => {
-    const requestedRange = range;
+  // Monotonic token: latest request always wins; stale requests discard their results.
+  let reqToken = 0;
+
+  async function loadBreakdown(r: UsageRange) {
+    const my = ++reqToken;
     loading = true;
     error = false;
-    getUsageBreakdown(requestedRange)
-      .then((b) => {
-        // Ignore stale responses: only accept if range hasn't changed since we fired
-        if (range === requestedRange) {
-          breakdown = b;
-          loading = false;
-        }
-      })
-      .catch(() => {
-        if (range === requestedRange) {
-          error = true;
-          loading = false;
-        }
-      });
+    try {
+      const b = await getUsageBreakdown(r);
+      if (my !== reqToken) return;
+      breakdown = b;
+    } catch {
+      if (my !== reqToken) return;
+      error = true;
+    } finally {
+      if (my === reqToken) loading = false;
+    }
+  }
+
+  // Fetch breakdown on mount and whenever range changes.
+  $effect(() => {
+    loadBreakdown(range);
   });
 
   function retry() {
-    const requestedRange = range;
-    loading = true;
-    error = false;
-    getUsageBreakdown(requestedRange)
-      .then((b) => {
-        if (range === requestedRange) {
-          breakdown = b;
-          loading = false;
-        }
-      })
-      .catch(() => {
-        if (range === requestedRange) {
-          error = true;
-          loading = false;
-        }
-      });
+    loadBreakdown(range);
   }
 </script>
 

--- a/ui/src/routes/usage/+page.svelte
+++ b/ui/src/routes/usage/+page.svelte
@@ -15,16 +15,22 @@
   let limits = $state<UsageLimits | null>(null);
   let loading = $state(true);
   let error = $state(false);
+  // Limits has its own error track (the Limits tab doesn't use `breakdown`), so a
+  // limits-endpoint failure surfaces an error + Retry instead of loading forever.
+  let limitsError = $state(false);
 
-  // Fetch limits once on mount (range-independent).
+  // Fetch limits once on mount (range-independent). `limits === null && !limitsError`
+  // ⇒ still loading.
+  async function loadLimits() {
+    limitsError = false;
+    try {
+      limits = await getUsageLimits();
+    } catch {
+      limitsError = true;
+    }
+  }
   $effect(() => {
-    getUsageLimits()
-      .then((l) => {
-        limits = l;
-      })
-      .catch(() => {
-        // limits failure is non-fatal; error state is driven by breakdown
-      });
+    loadLimits();
   });
 
   // Monotonic token: latest request always wins; stale requests discard their results.
@@ -51,8 +57,10 @@
     loadBreakdown(range);
   });
 
+  // Retry re-fetches BOTH tracks so either failure surface recovers.
   function retry() {
     loadBreakdown(range);
+    loadLimits();
   }
 </script>
 
@@ -126,21 +134,34 @@
 
   <!-- Lens body -->
   <div class="lens-body">
-    {#if loading && !breakdown}
-      <p class="usage-status-line">{m.common_loading()}</p>
-    {:else if error && !breakdown}
-      <p class="usage-status-line usage-error">{m.usage_load_error()}</p>
-      <button type="button" class="gbtn gbtn-secondary" onclick={retry}>{m.common_retry()}</button>
-    {:else if tab === "spend"}
+    <!-- Breakdown-error banner for the Spend/Overhead tabs. Shown even when a stale
+         `breakdown` is still present (a failed range-change refetch) so the user isn't
+         silently left on old-range data with no indication the new range failed. -->
+    {#if error && tab !== "limits"}
+      <div class="usage-error-banner" role="alert">
+        <span class="usage-status-line usage-error">{m.usage_load_error()}</span>
+        <button type="button" class="gbtn gbtn-secondary" onclick={retry}>{m.common_retry()}</button
+        >
+      </div>
+    {/if}
+
+    {#if tab === "spend"}
       {#if breakdown}
         <SpendLens {breakdown} />
+      {:else if loading}
+        <p class="usage-status-line">{m.common_loading()}</p>
       {/if}
     {:else if tab === "overhead"}
       {#if breakdown}
         <OverheadLens {breakdown} />
+      {:else if loading}
+        <p class="usage-status-line">{m.common_loading()}</p>
       {/if}
     {:else if limits}
       <LimitsLens {limits} projections={[]} />
+    {:else if limitsError}
+      <p class="usage-status-line usage-error">{m.usage_load_error()}</p>
+      <button type="button" class="gbtn gbtn-secondary" onclick={retry}>{m.common_retry()}</button>
     {:else}
       <p class="usage-status-line">{m.common_loading()}</p>
     {/if}
@@ -236,5 +257,19 @@
 
   .usage-error {
     color: var(--color-red);
+  }
+
+  /* Non-blocking refetch-error banner: sits above stale lens content so a failed
+     range change is visible without discarding the previous range's data. */
+  .usage-error-banner {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-top: 16px;
+  }
+
+  .usage-error-banner .usage-status-line {
+    margin: 0;
   }
 </style>

--- a/ui/src/routes/usage/+page.svelte
+++ b/ui/src/routes/usage/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import type { UsageRange } from "$lib/types";
+  import type { UsageBreakdown, UsageLimits, UsageRange } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
-  import { mockBreakdown, mockLimits, mockProjections } from "$lib/usage-mock";
+  import { getUsageBreakdown, getUsageLimits } from "$lib/api";
   import SpendLens from "$lib/components/usage/SpendLens.svelte";
   import OverheadLens from "$lib/components/usage/OverheadLens.svelte";
   import LimitsLens from "$lib/components/usage/LimitsLens.svelte";
@@ -11,7 +11,62 @@
   let tab = $state<Tab>("spend");
   let range = $state<UsageRange>("7d");
 
-  const breakdown = $derived(mockBreakdown(range));
+  let breakdown = $state<UsageBreakdown | null>(null);
+  let limits = $state<UsageLimits | null>(null);
+  let loading = $state(true);
+  let error = $state(false);
+
+  // Fetch limits once on mount (range-independent).
+  $effect(() => {
+    getUsageLimits()
+      .then((l) => {
+        limits = l;
+      })
+      .catch(() => {
+        // limits failure is non-fatal; error state is driven by breakdown
+      });
+  });
+
+  // Fetch breakdown on mount and whenever range changes.
+  // Guard against out-of-order responses with a request token.
+  $effect(() => {
+    const requestedRange = range;
+    loading = true;
+    error = false;
+    getUsageBreakdown(requestedRange)
+      .then((b) => {
+        // Ignore stale responses: only accept if range hasn't changed since we fired
+        if (range === requestedRange) {
+          breakdown = b;
+          loading = false;
+        }
+      })
+      .catch(() => {
+        if (range === requestedRange) {
+          error = true;
+          loading = false;
+        }
+      });
+  });
+
+  function retry() {
+    const requestedRange = range;
+    loading = true;
+    error = false;
+    getUsageBreakdown(requestedRange)
+      .then((b) => {
+        if (range === requestedRange) {
+          breakdown = b;
+          loading = false;
+        }
+      })
+      .catch(() => {
+        if (range === requestedRange) {
+          error = true;
+          loading = false;
+        }
+      });
+  }
 </script>
 
 <svelte:head>
@@ -21,7 +76,6 @@
 <main class="usage-page">
   <header class="usage-header">
     <h1 class="usage-title">{m.usage_page_title()}</h1>
-    <p class="usage-prototype-note">{m.usage_prototype_note()}</p>
   </header>
 
   <!-- Tab switcher -->
@@ -85,12 +139,23 @@
 
   <!-- Lens body -->
   <div class="lens-body">
-    {#if tab === "spend"}
-      <SpendLens {breakdown} />
+    {#if loading && !breakdown}
+      <p class="usage-status-line">{m.common_loading()}</p>
+    {:else if error && !breakdown}
+      <p class="usage-status-line usage-error">{m.usage_load_error()}</p>
+      <button type="button" class="gbtn gbtn-secondary" onclick={retry}>{m.common_retry()}</button>
+    {:else if tab === "spend"}
+      {#if breakdown}
+        <SpendLens {breakdown} />
+      {/if}
     {:else if tab === "overhead"}
-      <OverheadLens {breakdown} />
+      {#if breakdown}
+        <OverheadLens {breakdown} />
+      {/if}
+    {:else if limits}
+      <LimitsLens {limits} projections={[]} />
     {:else}
-      <LimitsLens limits={mockLimits()} projections={mockProjections()} />
+      <p class="usage-status-line">{m.common_loading()}</p>
     {/if}
   </div>
 </main>
@@ -114,12 +179,6 @@
     font-size: var(--fs-xl);
     font-weight: 600;
     color: var(--color-ink);
-  }
-
-  .usage-prototype-note {
-    margin: 0;
-    font-size: var(--fs-meta);
-    color: var(--color-muted);
   }
 
   /* Segmented controls */
@@ -180,5 +239,15 @@
 
   .lens-body {
     margin-top: 0;
+  }
+
+  .usage-status-line {
+    margin: 24px 0 8px;
+    font-size: var(--fs-base);
+    color: var(--color-muted);
+  }
+
+  .usage-error {
+    color: var(--color-red);
   }
 </style>

--- a/ui/src/routes/usage/page.browser.test.ts
+++ b/ui/src/routes/usage/page.browser.test.ts
@@ -1,7 +1,19 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
+import type { UsageRange } from "$lib/types";
+
+// The page fetches live data from $lib/api; mock those two calls with the retained
+// fixtures so this suite is deterministic and backend-independent (CI has no server,
+// and a real backend would otherwise serve environment-specific data).
+vi.mock("$lib/api", async () => {
+  const { mockBreakdown, mockLimits } = await import("$lib/usage-mock");
+  return {
+    getUsageBreakdown: (range: UsageRange) => Promise.resolve(mockBreakdown(range)),
+    getUsageLimits: () => Promise.resolve(mockLimits()),
+  };
+});
 
 const { default: UsagePage } = await import("./+page.svelte");
 


### PR DESCRIPTION
Closes #953. Phase 2 of the `/usage` token-visualization arc (#943) — makes the dashboard live.

## What changed

**Server**
- `src/pricing.ts`: new `dollars(c, model)` (absolute USD at list price) + the file-top docstring rewritten — `TABLE` is now contractually a real $/Mtok list-price table that must NOT be rescaled (the limit-% math stays ratio-only, so it's unaffected). Locked by `test/pricing-dollars.test.ts` (`dollars()` ≡ `weightedUnits()` + hard-coded USD).
- `src/usage-breakdown.ts` + `src/server.ts`: per-repo + total `dollars` on `GET /api/usage/breakdown`, **gated to api-key mode** via `isApiKeyMode()`. Subscription mode carries `dollars: null` — no dollar data leaves the server, ever.
- `$` is derived from the accumulated `authoringUnits + satelliteUnits` (already absolute USD), so it never diverges from the units in the same row.

**Types**
- `dollars: number | null` mirrored in `src/types.ts` + `ui/src/lib/types.ts`, added to the runtime drift sentinels (`USAGE_REPO_KEYS`/`USAGE_BREAKDOWN_KEYS`); `exactKeys()` holds in both modes (always-present field).

**UI**
- `/usage` now fetches `GET /api/usage/breakdown?range=` + `/api/usage/limits` live — loading/error/retry, range-driven refetch with a monotonic request-token race guard. Prototype caption removed; mock fixtures retained as a **test-only** asset.
- Spend lens gains a mode-aware **`$` column** (per-repo + grand total, only when `dollars != null`); subscription mode renders byte-identically to before.
- Entry points: gear-menu item + mobile-sheet row (both auth modes) + gauge click-through (subscription mode), all internal links via `resolve("/usage")`.
- Limits lens shows live 5H/WK gauges + reset countdowns; projections dropped (no real burn-rate source yet — see follow-up).

**Gates**
- Feature-catalog entry (`usage-dashboard`, `sinceVersion 1.36.0`, `targetId usage-link`); EN+DE i18n parity; glossary clean.

## Verification
Root `tsc`/`eslint`/`bun test` (4427 pass), UI `check`/`test` (1889 pass)/`check:i18n`, branch-hygiene, feature-catalog, glossary — all green.

## Follow-ups (operator-requested, out of scope here)
- #979 — real Limits projection / burn-rate source (re-enable the projection tick + burn rate).
- #980 — per-task `$` in the Spend lens (top consuming tasks).
- Minor/known: if the breakdown loads but `/api/usage/limits` fails, the Limits tab shows a perpetual loading line (no independent error/retry for limits) — non-blocking, candidate for a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)