### PR TITLE
fix(top-bar): explain why tasks are held and enlarge the held popover

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1615,6 +1615,8 @@
   "topbar_held_spawn_now": "Jetzt starten",
   "topbar_held_discard": "Verwerfen",
   "topbar_held_empty": "Keine zurückgehaltenen Aufgaben",
+  "topbar_held_why": "Zurückgehalten, weil die Nutzung hoch ist – sie starten automatisch beim nächsten Reset.",
+  "topbar_held_why_at": "Nächster Reset {time}.",
   "retry_title": "Halted wiederholen",
   "retry_confirm": "{count} Sitzungen wiederholen",
   "retry_arm": "Wiederholen bestätigen ({count})?",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1615,6 +1615,8 @@
   "topbar_held_spawn_now": "Spawn now",
   "topbar_held_discard": "Discard",
   "topbar_held_empty": "No held tasks",
+  "topbar_held_why": "Held because usage is high — they start automatically when usage resets.",
+  "topbar_held_why_at": "Next reset {time}.",
   "retry_title": "Retry halted",
   "retry_confirm": "Retry {count} sessions",
   "retry_arm": "Confirm retry {count}?",

--- a/ui/src/lib/components/top-bar/TopBarHeldBadge.svelte
+++ b/ui/src/lib/components/top-bar/TopBarHeldBadge.svelte
@@ -70,6 +70,10 @@
         tabindex="-1"
       >
         <div class="held-pop-head">{m.topbar_held_title()}</div>
+        <p class="held-pop-why">
+          {m.topbar_held_why()}{#if hotter?.w.resetAt}
+            {m.topbar_held_why_at({ time: formatResetIn(hotter.w.resetAt, nowMs) })}{/if}
+        </p>
         {#if heldLoading}
           <div class="held-pop-empty">{m.common_loading()}</div>
         {:else if heldItems.length === 0}
@@ -140,7 +144,7 @@
     right: 0;
     z-index: 20;
     margin-top: 4px;
-    width: 300px;
+    width: 340px;
     max-width: 90vw;
     background: var(--color-inset);
     border: 1px solid var(--color-line);
@@ -170,23 +174,30 @@
     }
   }
   .held-pop-head {
-    font-size: var(--fs-micro);
+    font-size: var(--fs-meta);
     letter-spacing: 0.14em;
     text-transform: uppercase;
     color: var(--color-muted);
-    padding: 10px 12px 6px;
+    padding: 12px 14px 4px;
+  }
+  .held-pop-why {
+    margin: 0;
+    font-size: var(--fs-meta);
+    line-height: 1.45;
+    color: var(--color-faint);
+    padding: 0 14px 10px;
   }
   .held-pop-empty {
-    font-size: var(--fs-meta);
+    font-size: var(--fs-base);
     color: var(--color-faint);
-    padding: 6px 12px 10px;
+    padding: 8px 14px 12px;
   }
   .held-row {
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
     gap: 10px;
-    padding: 6px 12px;
+    padding: 8px 14px;
     border-top: 1px solid var(--color-line);
   }
   .held-row-info {
@@ -197,15 +208,15 @@
     flex: 1;
   }
   .held-row-prompt {
-    font-size: var(--fs-meta);
+    font-size: var(--fs-base);
     color: var(--color-ink-bright);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: 22ch;
+    max-width: 26ch;
   }
   .held-row-repo {
-    font-size: var(--fs-micro);
+    font-size: var(--fs-meta);
     color: var(--color-muted);
     letter-spacing: 0.04em;
     overflow: hidden;
@@ -223,9 +234,9 @@
     border: 1px solid var(--color-line-bright);
     border-radius: 2px;
     font: inherit;
-    font-size: var(--fs-micro);
+    font-size: var(--fs-meta);
     letter-spacing: 0.06em;
-    padding: 2px 8px;
+    padding: 3px 10px;
     cursor: pointer;
     white-space: nowrap;
     color: var(--color-ink);


### PR DESCRIPTION
## Was

Im *Zurückgehaltene Aufgaben*-Popover (amber **Zurückgehalten**-Badge in der TopBar) fehlte die Erklärung, **warum** eine Aufgabe zurückgehalten wurde — es stand nur die Liste der Tasks da. Außerdem war der Dialog auf dem Desktop recht klein und schlecht lesbar.

## Änderungen

- **Erklärung „warum zurückgehalten"** — neue Zeile unter dem Titel: *„Zurückgehalten, weil die Nutzung hoch ist – sie starten automatisch beim nächsten Reset."* Wenn die Reset-Zeit bekannt ist (`hotter.w.resetAt`), wird sie als *„Nächster Reset {time}."* angehängt.
- **Größer / lesbarer auf Desktop** — Popover-Breite `300px → 340px`; Prompt-Text `--fs-meta → --fs-base`, Repo-Zeile / Buttons / Header je eine Token-Stufe größer; etwas mehr Padding. Alles über die Design-System-Tokens, keine Roh-Literale.

## i18n

Neue Keys `topbar_held_why` + `topbar_held_why_at` in `en.json` **und** `de.json` (Parität geprüft).

## Checks

- `bun run check:i18n` ✓ (2 locales, 1790 keys each)
- `bun run check` (svelte-check) ✓ 0 errors / 0 warnings

Kein neues user-facing *Feature* (Verbesserung einer bestehenden Oberfläche) → `fix`, kein Feature-Catalog-Eintrag nötig.