### PR TITLE
fix(seed-picker): stop issue labels crushing the title

### DIFF
--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -284,16 +284,16 @@
 </div>
 
 {#snippet labelChips(ordered: string[])}
-  {#each ordered.slice(0, 3) as lbl (lbl)}
+  {#each ordered.slice(0, 1) as lbl (lbl)}
     <span
       class="chip"
       class:active={lbl === ACTIVE_LABEL}
       title={lbl === ACTIVE_LABEL ? m.issuespanel_active_label_title() : undefined}>{lbl}</span
     >
   {/each}
-  {#if ordered.length > 3}
-    <span class="chip chip-more" title={ordered.slice(3).join(", ")}>
-      {m.promptsources_more_labels({ count: ordered.length - 3 })}
+  {#if ordered.length > 1}
+    <span class="chip chip-more" title={ordered.slice(1).join(", ")}>
+      {m.promptsources_more_labels({ count: ordered.length - 1 })}
     </span>
   {/if}
 {/snippet}
@@ -483,10 +483,14 @@
     white-space: nowrap;
   }
 
+  /* Single label chip + a "+N" count (labelChips caps inline chips at 1). The group
+     is bounded so the title keeps the row instead of being crushed to a character:
+     it may shrink (min-width:0), the label chip ellipsates, and the count never clips. */
   .chips {
     display: flex;
     gap: 3px;
-    flex-shrink: 0;
+    min-width: 0;
+    flex-shrink: 1;
   }
 
   .chip {
@@ -497,6 +501,12 @@
     border: 1px solid var(--color-faint);
     border-radius: 2px;
     padding: 0 4px;
+    /* Cap a pathologically long single label (e.g. COMPONENT/VALUEMAP…) so it
+       truncates instead of pushing the "+N" count off the row. */
+    max-width: 14ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   /* shepherd:active — claimed work. Same semantic running/in-progress token as
@@ -513,5 +523,9 @@
     color: var(--color-muted);
     border-color: transparent;
     cursor: default;
+    /* Always visible — the count is the signal that more labels exist, so it must
+       never be the thing that gets clipped when the row is tight. */
+    flex-shrink: 0;
+    max-width: none;
   }
 </style>

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -478,6 +478,10 @@
 
   .row-text {
     flex: 1;
+    /* Explicit floor: flex-basis is 0%, so on a very narrow row (where #num + chips
+       already fill the width) the title would otherwise grow by 0 and sit near 0px.
+       This reserves a readable minimum; the bounded, shrinkable chips yield first. */
+    min-width: 6rem;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -485,7 +489,8 @@
 
   /* Single label chip + a "+N" count (labelChips caps inline chips at 1). The group
      is bounded so the title keeps the row instead of being crushed to a character:
-     it may shrink (min-width:0), the label chip ellipsates, and the count never clips. */
+     it may shrink (min-width:0), the label chip ellipsates, and the count never clips.
+     Combined with .row-text's min-width floor, the title can't collapse to nothing. */
   .chips {
     display: flex;
     gap: 3px;


### PR DESCRIPTION
## Problem

In the **Seed From** issue picker (`PromptSources.svelte`), label chips are `flex-shrink:0` and up to **3 full-length** labels render per row, so the title (`flex:1`) absorbs all the squeeze and collapses to a single character — `#428 → "in"`, `#425 → "delete"`, `#428 → "o…"` (see the report screenshot).

## Fix

Title-first, single line — bound the chip group instead of the title:

- **One priority label + a `+N` count.** `labelChips` now shows the highest-priority label (active-first ordering already in place, so `shepherd:active` wins), then a single `+N` chip for the rest. The `+N` keeps its `title` listing the hidden labels — nothing is lost, one hover away.
- **Chip group can't crowd out the title or the count.** The label chip is ellipsis-capped (`max-width:14ch`) so one pathologically long label truncates instead of pushing things off-row; `.chip-more` (`+N`) is pinned `flex-shrink:0` so the count is never the thing that clips; `.chips` gets `min-width:0` so it yields before the title.

Net: the chip region is now ~one short pill + a tiny count, so the title organically keeps the row.

**Scope:** only the Seed-From picker. The backlog Issues panel (`IssueRow.svelte`) already puts the title on its own line and wraps labels below — left untouched.

## Before / after

| Row | Now | After |
|---|---|---|
| #428 | `in` | `in beta: rollup fails on persisted… · TYPE/BUG · +6` |
| #425 | `delete` | `delete stale worktrees on abandon · TYPE/BUG · +5` |
| #369 | `sync…` | `syncing GoalDetailPane state acro… · EPIC · +5` |

Direction (Option C, one chip + count) was picked from a live mockup comparison.

## Gates

- No new message keys (reuses `promptsources_more_labels` + `promptsources_epic_tag`) → `check:i18n` unaffected.
- A `fix`, not a user-facing `feat` → no feature-catalog entry needed. [no-feature-entry]
- No new glossary terms.

## Verification

- `cd ui && bun run check` → 0 errors
- `cd ui && bun run test` → 1910 passed (incl. `PromptSources.browser.test.ts`, `NewTask.browser.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)