### PR TITLE
feat(usage): live burn-rate projections for the Limits lens (#966)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -154,7 +154,7 @@ export interface AppDeps {
   store: SessionStore;
   service: SessionService;
   events: EventHub;
-  usageLimits: Pick<UsageLimitsService, "limits">;
+  usageLimits: Pick<UsageLimitsService, "limits" | "projections">;
   /** Force a `/usage` re-scrape (calibration) and return fresh limits; absent in tests that
    *  don't wire the live calibrator (the route then falls back to the current snapshot). */
   refreshUsage?: () => Promise<UsageLimits>;
@@ -2453,7 +2453,11 @@ async function handleUsageLimits({ req, parts, deps }: Ctx): Promise<Response | 
     return json(limits);
   }
   if (req.method === "GET" && parts[0] === "api" && parts[1] === "usage" && parts[2] === "limits") {
-    return json(deps.usageLimits.limits(Date.now()));
+    const now = Date.now();
+    return json({
+      limits: deps.usageLimits.limits(now),
+      projections: deps.usageLimits.projections(now),
+    });
   }
   return null;
 }

--- a/src/usage-limits.ts
+++ b/src/usage-limits.ts
@@ -8,6 +8,12 @@ const PERIOD_MS: Record<WindowKey, number> = {
   week: 7 * 24 * 60 * 60 * 1000,
 };
 
+const LOOKBACK_MS: Record<WindowKey, number> = {
+  session5h: 60 * 60 * 1000, // 1h trailing window for the 5H projection
+  week: 24 * 60 * 60 * 1000, // 24h trailing window for the WK projection
+};
+const WINDOW_LABEL: Record<WindowKey, "5H" | "WK"> = { session5h: "5H", week: "WK" };
+
 /** Below this scraped %, inverting to a cap is too noisy — keep the prior cap instead. */
 const MIN_CALIBRATION_PCT = 5;
 
@@ -234,6 +240,13 @@ export interface UsageLimits {
   subscriptionOnly: boolean;
 }
 
+export interface UsageProjection {
+  window: "5H" | "WK";
+  projectedPct: number; // projected % at reset if burn holds (NOT clamped; may exceed 100)
+  resetAt: number; // ms epoch of window reset
+  burnRatePerHour: number; // recent weighted units/hour
+}
+
 // Credits is scrape-fresh-only (no local signal to recompute from), so it goes stale fast —
 // 1h, unlike the 2-week cap stale that tolerates JSONL-recomputed windows drifting.
 const CREDIT_STALE_MS = 60 * 60 * 1000;
@@ -387,5 +400,31 @@ export class UsageLimitsService {
       };
     }
     return { session5h, week, credits, stale, calibratedAt, subscriptionOnly: isApiKeyMode() };
+  }
+
+  /** Burn-rate projections: projected % at window reset, based on a trailing lookback window. */
+  projections(now: number): UsageProjection[] {
+    const rows = new Map(this.caps.getCaps().map((r) => [r.window, r]));
+    const out: UsageProjection[] = [];
+    for (const key of ["session5h", "week"] as WindowKey[]) {
+      const row = rows.get(key);
+      if (!row || row.cap <= 0) continue; // mirrors limits() returning null
+      const period = PERIOD_MS[key];
+      const resetAt = rollForward(row.resetAt, period, now);
+      const windowStart = resetAt - period;
+      const curUnits = this.index.windowSum(windowStart, now);
+      const lookback = LOOKBACK_MS[key];
+      // numerator start clamped to windowStart so the trailing window never bleeds
+      // pre-reset burn into a fresh window; denominator stays the NOMINAL lookback hours
+      // (so the first hour of a fresh window yields a low, non-explosive rate that ramps).
+      const recentUnits = this.index.windowSum(Math.max(windowStart, now - lookback), now);
+      const burnRatePerHour = Math.round(recentUnits / (lookback / 3_600_000));
+      const hoursToReset = Math.max(0, (resetAt - now) / 3_600_000);
+      const projectedPct = Math.round(
+        ((curUnits + burnRatePerHour * hoursToReset) / row.cap) * 100,
+      );
+      out.push({ window: WINDOW_LABEL[key], projectedPct, resetAt, burnRatePerHour });
+    }
+    return out;
   }
 }

--- a/test/agent-ingress.test.ts
+++ b/test/agent-ingress.test.ts
@@ -81,6 +81,7 @@ function makeDeps(): AppDeps {
       calibratedAt: null,
       subscriptionOnly: false,
     }),
+    projections: () => [],
   };
   return { store, service, events, usageLimits, distiller: { distillNow: () => {} } };
 }

--- a/test/server-fork.test.ts
+++ b/test/server-fork.test.ts
@@ -49,6 +49,7 @@ function makeDeps(ghRunner?: GhRunner): AppDeps {
       calibratedAt: null,
       subscriptionOnly: false,
     }),
+    projections: () => [],
   };
   const distiller = { distillNow: () => {} };
   return { store, service, events, usageLimits, distiller, newProjectGhRunner: ghRunner };

--- a/test/server-ping.test.ts
+++ b/test/server-ping.test.ts
@@ -28,6 +28,7 @@ function makeDeps(): AppDeps {
       calibratedAt: null,
       subscriptionOnly: false,
     }),
+    projections: () => [],
   };
   return { store, service, events, usageLimits, distiller: { distillNow: () => {} } };
 }

--- a/test/server-projects.test.ts
+++ b/test/server-projects.test.ts
@@ -57,6 +57,7 @@ function makeDeps(): AppDeps {
       calibratedAt: null,
       subscriptionOnly: false,
     }),
+    projections: () => [],
   };
   const distiller = { distillNow: () => {} };
   return { store, service, events, usageLimits, distiller };

--- a/test/server-sync-fork.test.ts
+++ b/test/server-sync-fork.test.ts
@@ -69,6 +69,7 @@ function makeDeps(resolveForge?: (dir: string) => GitForge | null): AppDeps {
       calibratedAt: null,
       subscriptionOnly: false,
     }),
+    projections: () => [],
   };
   const distiller = { distillNow: () => {} };
   return { store, service, events, usageLimits, distiller, resolveForge } as AppDeps;

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -61,6 +61,7 @@ function makeDeps(liveTerminals: string[] = []): AppDeps {
       calibratedAt: null,
       subscriptionOnly: false,
     }),
+    projections: () => [],
   };
   const distiller = { distillNow: () => {} };
   return { store, service, events, usageLimits, distiller };
@@ -71,17 +72,20 @@ function harness() {
   return makeApp(deps);
 }
 
-test("GET /api/usage/limits returns the limits snapshot", async () => {
+test("GET /api/usage/limits returns limits + projections", async () => {
   const res = await harness().fetch(new Request("http://x/api/usage/limits"));
   expect(res.status).toBe(200);
   const body = await res.json();
   expect(body).toEqual({
-    session5h: null,
-    week: null,
-    credits: null,
-    stale: true,
-    calibratedAt: null,
-    subscriptionOnly: false,
+    limits: {
+      session5h: null,
+      week: null,
+      credits: null,
+      stale: true,
+      calibratedAt: null,
+      subscriptionOnly: false,
+    },
+    projections: [],
   });
 });
 
@@ -256,6 +260,7 @@ function harnessWithReaper(reaper: { detect: any; reap: any; stopListenersOnPort
       calibratedAt: null,
       subscriptionOnly: false,
     }),
+    projections: () => [],
   };
   const app = makeApp({ store, service, events, usageLimits, distiller: { distillNow: () => {} } });
   return { app, store };
@@ -1315,6 +1320,7 @@ function clearMergedHarness() {
       calibratedAt: null,
       subscriptionOnly: false,
     }),
+    projections: () => [],
   };
   const app = makeApp({ store, service, events, usageLimits, prCache } as any);
   const mk = (name: string, state: string) => {
@@ -1892,6 +1898,7 @@ function harnessWithPreviewStop({
       calibratedAt: null,
       subscriptionOnly: false,
     }),
+    projections: () => [],
   };
   const app = makeApp({ store, service, events, usageLimits, distiller: { distillNow: () => {} } });
   return { app, store };

--- a/test/usage-limits.test.ts
+++ b/test/usage-limits.test.ts
@@ -578,15 +578,14 @@ test("projections: just-after-reset boundary excludes pre-reset records", () => 
   );
   const proj = svc.projections(now);
   const p = proj[0]!;
-  // (a) pre-reset records excluded → projectedPct well under 100
-  expect(p.projectedPct).toBeLessThanOrEqual(100);
+  // (a) pre-reset records excluded → curUnits=10, projectedPct = round((10 + 10*4.5)/1000*100) = 6
+  expect(p.projectedPct).toBe(6);
   // recentUnits clamped to windowStart → only the 0.25h record = 10; burnRatePerHour = 10
   expect(p.burnRatePerHour).toBe(10);
   // (b) non-vacuous: unclamped windowSum(now-1h, now) WOULD include the pre-reset record
   const idx = seededIndex(records);
   const unclampedRecent = idx.windowSum(now - H, now);
   expect(unclampedRecent).toBe(510); // 500 + 10 — proves the clamp matters
-  expect(p.burnRatePerHour).toBe(10); // clamped recent = only 10
 });
 
 test("projections: no-cap window skipped / empty caps returns []", () => {

--- a/test/usage-limits.test.ts
+++ b/test/usage-limits.test.ts
@@ -10,6 +10,7 @@ import {
   CREDIT_WATCH_INTERVAL_MS,
   CALIBRATE_INTERVAL_MS,
   type UsageLimits,
+  type UsageProjection,
   UsageLimitsService,
   type CapRow,
   type CapStore,
@@ -492,4 +493,117 @@ test("limits() subscriptionOnly is true in api-key mode, false in subscription m
   } finally {
     config.authMode = prior;
   }
+});
+
+// ── projections() ────────────────────────────────────────────────────────────
+
+/** Range-aware index stub: sums records whose ts falls within [s, e] inclusive. */
+function seededIndex(records: { ts: number; units: number }[]): AccountUsageIndex {
+  return {
+    windowSum: (s: number, e: number) =>
+      records.filter((r) => r.ts >= s && r.ts <= e).reduce((a, r) => a + r.units, 0),
+  } as unknown as AccountUsageIndex;
+}
+
+test("projections: math from seeded records", () => {
+  // session5h: period=5h, cap=1000, resetAt=now+3h (windowStart=now-2h)
+  // records at now-1.5h (within window, outside 1h lookback) and now-0.5h (within both)
+  const H = 3_600_000;
+  const now = NOW;
+  const resetAt = now + 3 * H;
+  const caps = new MemCaps();
+  caps.putCap({ window: "session5h", cap: 1000, resetAt, pct: 10, scrapedAt: now });
+  const records = [
+    { ts: now - 1.5 * H, units: 60 }, // in window (windowStart=now-2h), outside 1h lookback
+    { ts: now - 0.5 * H, units: 40 }, // in both window and 1h lookback
+  ];
+  // recentUnits (last 1h) = 40; burnRatePerHour = round(40/1) = 40
+  // curUnits (full window) = 100; hoursToReset = 3
+  // projectedPct = round((100 + 40*3)/1000 * 100) = round(22) = 22
+  const svc = new UsageLimitsService(
+    seededIndex(records),
+    caps,
+    new StubProbe(null),
+    new MemCredits(),
+  );
+  const proj = svc.projections(now);
+  expect(proj).toHaveLength(1);
+  const p = proj[0] as UsageProjection;
+  expect(p.window).toBe("5H");
+  expect(p.burnRatePerHour).toBe(40);
+  expect(p.resetAt).toBe(resetAt);
+  expect(p.projectedPct).toBe(22);
+});
+
+test("projections: will-exceed (projectedPct > 100) is NOT clamped", () => {
+  const H = 3_600_000;
+  const now = NOW;
+  const resetAt = now + 2 * H;
+  const caps = new MemCaps();
+  // cap=100, windowStart=now-3h
+  caps.putCap({ window: "session5h", cap: 100, resetAt, pct: 50, scrapedAt: now });
+  // 200 units in last 0.5h → burnRatePerHour=200, curUnits=200, hoursToReset=2
+  // projectedPct = round((200 + 200*2)/100 * 100) = 600
+  const records = [{ ts: now - 0.5 * H, units: 200 }];
+  const svc = new UsageLimitsService(
+    seededIndex(records),
+    caps,
+    new StubProbe(null),
+    new MemCredits(),
+  );
+  const proj = svc.projections(now);
+  expect(proj[0]!.projectedPct).toBeGreaterThan(100); // NOT clamped
+  expect(proj[0]!.projectedPct).toBe(600);
+});
+
+test("projections: just-after-reset boundary excludes pre-reset records", () => {
+  const H = 3_600_000;
+  const now = NOW;
+  // resetAt=now+4.5h → windowStart=now-0.5h (fresh window, only 0.5h old)
+  // lookback=1h → now-lookback=now-1h < windowStart (now-0.5h) → Math.max clamps to windowStart
+  const resetAt = now + 4.5 * H;
+  const caps = new MemCaps();
+  caps.putCap({ window: "session5h", cap: 1000, resetAt, pct: 5, scrapedAt: now });
+  const records = [
+    // pre-reset: 0.75h ago — BEFORE windowStart (0.5h ago) but WITHIN unclamped lookback (1h)
+    { ts: now - 0.75 * H, units: 500 },
+    // post-reset: 0.25h ago — inside both window and lookback
+    { ts: now - 0.25 * H, units: 10 },
+  ];
+  const svc = new UsageLimitsService(
+    seededIndex(records),
+    caps,
+    new StubProbe(null),
+    new MemCredits(),
+  );
+  const proj = svc.projections(now);
+  const p = proj[0]!;
+  // (a) pre-reset records excluded → projectedPct well under 100
+  expect(p.projectedPct).toBeLessThanOrEqual(100);
+  // recentUnits clamped to windowStart → only the 0.25h record = 10; burnRatePerHour = 10
+  expect(p.burnRatePerHour).toBe(10);
+  // (b) non-vacuous: unclamped windowSum(now-1h, now) WOULD include the pre-reset record
+  const idx = seededIndex(records);
+  const unclampedRecent = idx.windowSum(now - H, now);
+  expect(unclampedRecent).toBe(510); // 500 + 10 — proves the clamp matters
+  expect(p.burnRatePerHour).toBe(10); // clamped recent = only 10
+});
+
+test("projections: no-cap window skipped / empty caps returns []", () => {
+  const caps = new MemCaps();
+  // only week cap present → projections returns just the WK entry
+  caps.putCap({ window: "week", cap: 500, resetAt: NOW + 3_600_000, pct: 20, scrapedAt: NOW });
+  const svc = new UsageLimitsService(fakeIndex(50), caps, new StubProbe(null), new MemCredits());
+  const proj = svc.projections(NOW);
+  expect(proj).toHaveLength(1);
+  expect(proj[0]!.window).toBe("WK");
+
+  // empty caps → []
+  const empty = new UsageLimitsService(
+    fakeIndex(0),
+    new MemCaps(),
+    new StubProbe(null),
+    new MemCredits(),
+  );
+  expect(empty.projections(NOW)).toEqual([]);
 });

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -9,6 +9,7 @@ import type {
   ActivityEntry,
   SessionUsage,
   UsageLimits,
+  UsageLimitsResponse,
   UsageBreakdown,
   UsageRange,
   GitState,
@@ -484,7 +485,7 @@ export async function getDiff(id: string): Promise<DiffResult> {
   return r.json();
 }
 
-export async function getUsageLimits(): Promise<UsageLimits> {
+export async function getUsageLimits(): Promise<UsageLimitsResponse> {
   const r = await fetch("/api/usage/limits");
   if (!r.ok) throw await failed(r, "limits");
   return r.json();

--- a/ui/src/lib/components/usage/LimitsLens.browser.test.ts
+++ b/ui/src/lib/components/usage/LimitsLens.browser.test.ts
@@ -2,7 +2,28 @@ import { describe, it, expect, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../../app.css";
-import { mockLimits, mockProjections } from "$lib/usage-mock";
+import type { UsageLimits, UsageProjection } from "$lib/types";
+
+const BASE = Date.now();
+const H = 3_600_000;
+
+function limitsFixture(): UsageLimits {
+  return {
+    session5h: { pct: 38, resetAt: BASE + 2.5 * H },
+    week: { pct: 22, resetAt: BASE + 58 * H },
+    credits: null,
+    stale: false,
+    calibratedAt: BASE - 5 * 60_000,
+    subscriptionOnly: false,
+  };
+}
+
+function projectionsFixture(): UsageProjection[] {
+  return [
+    { window: "5H", projectedPct: 64, resetAt: BASE + 2.5 * H, burnRatePerHour: 48_000 },
+    { window: "WK", projectedPct: 41, resetAt: BASE + 58 * H, burnRatePerHour: 31_000 },
+  ];
+}
 
 const { default: LimitsLens } = await import("./LimitsLens.svelte");
 
@@ -12,8 +33,8 @@ afterEach(() => {
 
 describe("LimitsLens", () => {
   it("renders a meter block for each window", async () => {
-    const limits = mockLimits();
-    const projections = mockProjections();
+    const limits = limitsFixture();
+    const projections = projectionsFixture();
     render(LimitsLens, { limits, projections });
 
     // Two window blocks — one per gauge (5H and WK)
@@ -22,8 +43,8 @@ describe("LimitsLens", () => {
   });
 
   it("shows the current pct for each window", async () => {
-    const limits = mockLimits(); // session5h.pct=38, week.pct=22
-    const projections = mockProjections();
+    const limits = limitsFixture(); // session5h.pct=38, week.pct=22
+    const projections = projectionsFixture();
     render(LimitsLens, { limits, projections });
 
     await expect.element(page.getByText("38%")).toBeInTheDocument();
@@ -31,8 +52,8 @@ describe("LimitsLens", () => {
   });
 
   it("renders reset-time captions for each window", async () => {
-    const limits = mockLimits();
-    const projections = mockProjections();
+    const limits = limitsFixture();
+    const projections = projectionsFixture();
     render(LimitsLens, { limits, projections });
 
     // Both windows should show "resets in …"
@@ -45,8 +66,8 @@ describe("LimitsLens", () => {
   });
 
   it("renders projection info for matched windows", async () => {
-    const limits = mockLimits();
-    const projections = mockProjections(); // 5H: projectedPct=64, burnRate=48_000; WK: projectedPct=41, burnRate=31_000
+    const limits = limitsFixture();
+    const projections = projectionsFixture(); // 5H: projectedPct=64, burnRate=48_000; WK: projectedPct=41, burnRate=31_000 (see projectionsFixture)
     render(LimitsLens, { limits, projections });
 
     // Projection info rows should be present for both windows
@@ -60,8 +81,8 @@ describe("LimitsLens", () => {
   });
 
   it("renders burn rate captions", async () => {
-    const limits = mockLimits();
-    const projections = mockProjections();
+    const limits = limitsFixture();
+    const projections = projectionsFixture();
     render(LimitsLens, { limits, projections });
 
     // Both windows have projections → two burn rate captions
@@ -75,8 +96,8 @@ describe("LimitsLens", () => {
   });
 
   it("shows projection tick on the meter", async () => {
-    const limits = mockLimits();
-    const projections = mockProjections();
+    const limits = limitsFixture();
+    const projections = projectionsFixture();
     render(LimitsLens, { limits, projections });
 
     const ticks = document.querySelectorAll(".proj-tick");

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -791,6 +791,12 @@ export interface UsageProjection {
   burnRatePerHour: number; // recent weighted units/hour
 }
 
+/** Combined payload of GET /api/usage/limits: the limit windows + their live burn-rate projections. */
+export interface UsageLimitsResponse {
+  limits: UsageLimits;
+  projections: UsageProjection[];
+}
+
 export interface UpdateCommit {
   sha: string;
   subject: string;

--- a/ui/src/lib/usage-mock.ts
+++ b/ui/src/lib/usage-mock.ts
@@ -2,23 +2,10 @@
  * Mock fixtures for the /usage token-spend dashboard (Phase 0 prototype).
  * No backend — all data is hand-written for visual prototyping.
  */
-import type {
-  UsageBreakdown,
-  UsageLimits,
-  UsageProjection,
-  UsageRange,
-  UsageTaskBreakdown,
-} from "./types";
+import type { UsageBreakdown, UsageRange, UsageTaskBreakdown } from "./types";
 
 /** Single stable base to keep all timestamps deterministic across calls. */
 const BASE = Date.now();
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** ms offsets used for reset timestamps */
-const H = 3_600_000;
 
 // ---------------------------------------------------------------------------
 // Shepherd repo tasks (≥7 so "… N more" tail is exercised in the Spend lens)
@@ -554,34 +541,4 @@ export function mockBreakdown(range: UsageRange): UsageBreakdown {
       };
     }
   }
-}
-
-/** Burn-down projections for the Limits lens (one 5H, one WK). */
-export function mockProjections(): UsageProjection[] {
-  return [
-    {
-      window: "5H",
-      projectedPct: 64,
-      resetAt: BASE + 2.5 * H,
-      burnRatePerHour: 48_000,
-    },
-    {
-      window: "WK",
-      projectedPct: 41,
-      resetAt: BASE + 58 * H,
-      burnRatePerHour: 31_000,
-    },
-  ];
-}
-
-/** A fixture shaped like the real UsageLimits. */
-export function mockLimits(): UsageLimits {
-  return {
-    session5h: { pct: 38, resetAt: BASE + 2.5 * H },
-    week: { pct: 22, resetAt: BASE + 58 * H },
-    credits: null,
-    stale: false,
-    calibratedAt: BASE - 5 * 60_000,
-    subscriptionOnly: false,
-  };
 }

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -468,7 +468,7 @@
       .then((list) => store.setAll(list))
       .catch(() => {});
     getUsageLimits()
-      .then((l) => store.setUsageLimits(l))
+      .then((r) => store.setUsageLimits(r.limits))
       .catch(() => {});
     gitStates()
       .then((m) => store.setGit(m))
@@ -1067,7 +1067,7 @@
       })
       .catch(() => {});
     getUsageLimits()
-      .then((l) => store.setUsageLimits(l))
+      .then((r) => store.setUsageLimits(r.limits))
       .catch(() => {});
     getUpdate()
       .then((u) => store.setUpdate(u))

--- a/ui/src/routes/usage/+page.svelte
+++ b/ui/src/routes/usage/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { UsageBreakdown, UsageLimits, UsageRange } from "$lib/types";
+  import type { UsageBreakdown, UsageLimits, UsageProjection, UsageRange } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { getUsageBreakdown, getUsageLimits } from "$lib/api";
   import SpendLens from "$lib/components/usage/SpendLens.svelte";
@@ -13,6 +13,7 @@
 
   let breakdown = $state<UsageBreakdown | null>(null);
   let limits = $state<UsageLimits | null>(null);
+  let projections = $state<UsageProjection[]>([]);
   let loading = $state(true);
   let error = $state(false);
   // Limits has its own error track (the Limits tab doesn't use `breakdown`), so a
@@ -24,7 +25,9 @@
   async function loadLimits() {
     limitsError = false;
     try {
-      limits = await getUsageLimits();
+      const res = await getUsageLimits();
+      limits = res.limits;
+      projections = res.projections;
     } catch {
       limitsError = true;
     }
@@ -158,7 +161,7 @@
         <p class="usage-status-line">{m.common_loading()}</p>
       {/if}
     {:else if limits}
-      <LimitsLens {limits} projections={[]} />
+      <LimitsLens {limits} {projections} />
     {:else if limitsError}
       <p class="usage-status-line usage-error">{m.usage_load_error()}</p>
       <button type="button" class="gbtn gbtn-secondary" onclick={retry}>{m.common_retry()}</button>

--- a/ui/src/routes/usage/page.browser.test.ts
+++ b/ui/src/routes/usage/page.browser.test.ts
@@ -2,16 +2,33 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
-import type { UsageRange } from "$lib/types";
+import type { UsageLimits, UsageProjection, UsageRange } from "$lib/types";
+
+const BASE = Date.now();
+const H = 3_600_000;
+
+const inlineLimits: UsageLimits = {
+  session5h: { pct: 38, resetAt: BASE + 2.5 * H },
+  week: { pct: 22, resetAt: BASE + 58 * H },
+  credits: null,
+  stale: false,
+  calibratedAt: BASE - 5 * 60_000,
+  subscriptionOnly: false,
+};
+
+const inlineProjections: UsageProjection[] = [
+  { window: "5H", projectedPct: 64, resetAt: BASE + 2.5 * H, burnRatePerHour: 48_000 },
+  { window: "WK", projectedPct: 41, resetAt: BASE + 58 * H, burnRatePerHour: 31_000 },
+];
 
 // The page fetches live data from $lib/api; mock those two calls with the retained
 // fixtures so this suite is deterministic and backend-independent (CI has no server,
 // and a real backend would otherwise serve environment-specific data).
 vi.mock("$lib/api", async () => {
-  const { mockBreakdown, mockLimits } = await import("$lib/usage-mock");
+  const { mockBreakdown } = await import("$lib/usage-mock");
   return {
     getUsageBreakdown: (range: UsageRange) => Promise.resolve(mockBreakdown(range)),
-    getUsageLimits: () => Promise.resolve(mockLimits()),
+    getUsageLimits: () => Promise.resolve({ limits: inlineLimits, projections: inlineProjections }),
   };
 });
 


### PR DESCRIPTION
Closes #966. Follow-up to #952 (Phase 1) / part of the #943 arc.

The Limits lens already had the projection UI (tick, projected %, will-exceed, burn-rate caption) but was fed an empty array (`projections={[]}`); `mockProjections`/`mockLimits` lingered unused. This wires real data through.

## What
- **Server — `UsageLimitsService.projections(now)`** (`src/usage-limits.ts`): one `UsageProjection` per `5H`/`WK` window, derived from the same `caps.getCaps()` + `AccountUsageIndex.windowSum` + `rollForward` machinery `limits()` uses.
  - **Burn rate** = trailing live window: `windowSum(max(windowStart, now−lookback), now) / lookbackHours`, lookback **1h (5H)** / **24h (WK)**. The numerator start is clamped to `windowStart` so a trailing window never bleeds pre-reset burn into a fresh window; the denominator stays the nominal lookback hours, so the first hour of a fresh window yields a low, ramping rate (no early-window blow-up, no false will-exceed).
  - `projectedPct = round((curUnits + burnRate·hoursToReset)/cap·100)`, **unclamped** (the lens uses the raw value for its will-exceed flag).
  - Windows with no/zero cap are skipped (api-key / subscription-only ⇒ empty array).
- **Combined endpoint** (`src/server.ts`): `GET /api/usage/limits` now returns `{ limits, projections }` from a **single** `now` + `getCaps()` snapshot, so gauge and projection can't desync and the page needs one fetch / one error path. `POST /api/usage/refresh` and the `usage:limits` SSE event stay bare `UsageLimits`.
- **UI**: `UsageLimitsResponse` type; `getUsageLimits()` returns the combined payload; the `/usage` page feeds real projections to `LimitsLens` (state initialized to `[]`, never null); the dashboard resync sites extract `.limits`. Dead `mockProjections`/`mockLimits` deleted; the two browser tests use inline fixtures.

## Verification
Root: `lint` ✓, `tsc --noEmit` ✓, `bun test ./test` (4431 pass / 0 fail, incl. new `projections()` cases — math, will-exceed >100, just-after-reset clamp proven non-vacuous, no-cap skip). UI: `check` (0 errors) ✓, `check:i18n` (parity) ✓, prettier ✓, `bun test` (1910 pass) ✓, `build` ✓. Gates: branch-hygiene ✓, glossary ✓.

[no-feature-entry] No new What's-New card: the existing `usage-dashboard` 1.36.0 entry already advertises "live limit burn-down" — these projections are the data behind that claim, shipping in the same unreleased 1.36.0 line. A separate card would double-announce. No new i18n keys (the lens strings shipped in Phase 2 #953).

🤖 Generated with [Claude Code](https://claude.com/claude-code)