### PR TITLE
fix(usage): mobile UX pass — %-only cache, info-icon glossary, stacked rows, close button

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1743,7 +1743,7 @@
   "feat_doc_agent_ui_title": "Doc-Agent im Backlog",
   "feat_doc_agent_ui_body": "Starte den PR-gesicherten Doc-Agent für ein Repo direkt aus der Backlog-Aktionsleiste. Ein Status-Badge verfolgt den Lauf und verlinkt die geöffnete Doku-Update-PR; ein Popover zeigt die letzten Läufe. Aktivierung über SHEPHERD_DOC_AGENT.",
   "usage_spend_heading": "Verbrauch",
-  "usage_units_label": "[[weighted-units|gewichtete Einheiten]]",
+  "usage_units_label": "gewichtete Einheiten",
   "usage_more_count": "… {count} weitere",
   "gloss_weighted_units_term": "gewichtete Einheiten",
   "gloss_weighted_units_def": "Ein modellgewichtetes Maß für den Token-Verbrauch, das angibt, was tatsächlich dein Abonnement-Limit belastet — Ausgabe-Tokens kosten deutlich mehr als Cache-Lesevorgänge, daher spiegeln gewichtete Einheiten den echten Verbrauch besser wider als rohe Token-Zahlen.",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1749,7 +1749,7 @@
   "gloss_weighted_units_def": "Ein modellgewichtetes Maß für den Token-Verbrauch, das angibt, was tatsächlich dein Abonnement-Limit belastet — Ausgabe-Tokens kosten deutlich mehr als Cache-Lesevorgänge, daher spiegeln gewichtete Einheiten den echten Verbrauch besser wider als rohe Token-Zahlen.",
   "usage_overhead_tax_heading": "Prüfer-Overhead",
   "usage_overhead_authoring_label": "Authoring",
-  "usage_overhead_satellite_label": "[[satellite-pass|Satelliten-Durchläufe]]",
+  "usage_overhead_satellite_label": "Satelliten-Durchläufe",
   "usage_overhead_tax_caption": "{pct} durch Satelliten-Durchläufe hinzugekommen",
   "usage_overhead_cache_heading": "Cache-Effizienz",
   "usage_overhead_cacheread_label": "Cache-Lesevorgänge",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1749,7 +1749,7 @@
   "gloss_weighted_units_def": "A model-weighted measure of token spend that counts what actually draws down your subscription limits — output tokens cost far more than cached reads, so weighted units, not raw token counts, reflect true usage.",
   "usage_overhead_tax_heading": "Reviewer tax",
   "usage_overhead_authoring_label": "authoring",
-  "usage_overhead_satellite_label": "[[satellite-pass|satellite passes]]",
+  "usage_overhead_satellite_label": "satellite passes",
   "usage_overhead_tax_caption": "{pct} added by satellite passes",
   "usage_overhead_cache_heading": "Cache efficiency",
   "usage_overhead_cacheread_label": "cached reads",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1743,7 +1743,7 @@
   "feat_doc_agent_ui_title": "Doc agent in the Backlog",
   "feat_doc_agent_ui_body": "Trigger the PR-gated doc agent for a repo from the Backlog Actions bar. A status badge tracks the run and links the doc-update PR it opens; a popover shows recent runs. Opt-in via SHEPHERD_DOC_AGENT.",
   "usage_spend_heading": "Spend",
-  "usage_units_label": "[[weighted-units|weighted units]]",
+  "usage_units_label": "weighted units",
   "usage_more_count": "… {count} more",
   "gloss_weighted_units_term": "weighted units",
   "gloss_weighted_units_def": "A model-weighted measure of token spend that counts what actually draws down your subscription limits — output tokens cost far more than cached reads, so weighted units, not raw token counts, reflect true usage.",

--- a/ui/src/lib/components/usage/OverheadLens.svelte
+++ b/ui/src/lib/components/usage/OverheadLens.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import type { UsageBreakdown, UsageTaskBreakdown } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
-  import GlossaryText from "$lib/components/GlossaryText.svelte";
+  import InfoTip from "$lib/components/InfoTip.svelte";
   import UsageBar from "./UsageBar.svelte";
   import SplitBar from "./SplitBar.svelte";
-  import { formatUnits, formatPct } from "./format";
+  import { formatPct } from "./format";
 
   const { breakdown }: { breakdown: UsageBreakdown } = $props();
 
@@ -47,7 +47,11 @@
       <div class="split-labels">
         <span class="split-label authoring-label">{m.usage_overhead_authoring_label()}</span>
         <span class="split-label satellite-label">
-          <GlossaryText text={m.usage_overhead_satellite_label()} />
+          <span>{m.usage_overhead_satellite_label()}</span>
+          <InfoTip
+            text={m.gloss_satellite_pass_def()}
+            label={m.newtask_info_aria({ topic: m.gloss_satellite_pass_term() })}
+          />
         </span>
       </div>
       <SplitBar
@@ -88,12 +92,10 @@
       <div class="split-labels">
         <span class="split-label cacheread-label">
           <span>{m.usage_overhead_cacheread_label()}</span>
-          <span class="split-units">{formatUnits(breakdown.cacheReadUnits)}</span>
           <span class="split-share">{formatPct(cacheReadPct)}</span>
         </span>
         <span class="split-label generation-label">
           <span>{m.usage_overhead_generation_label()}</span>
-          <span class="split-units">{formatUnits(breakdown.generationUnits)}</span>
           <span class="split-share">{formatPct(generationPct)}</span>
         </span>
       </div>
@@ -151,11 +153,6 @@
     gap: 0.3rem;
   }
 
-  .split-units {
-    font-variant-numeric: tabular-nums;
-    color: var(--color-ink);
-  }
-
   .split-share {
     color: var(--color-ink-bright);
     font-weight: 500;
@@ -201,5 +198,22 @@
     color: var(--color-ink);
     text-align: right;
     font-variant-numeric: tabular-nums;
+  }
+
+  @media (max-width: 480px) {
+    .tax-task-row {
+      grid-template-columns: 1fr auto;
+      grid-template-areas: "desig pct" "bar bar";
+      row-gap: 0.25rem;
+    }
+    .tax-desig {
+      grid-area: desig;
+    }
+    .tax-pct {
+      grid-area: pct;
+    }
+    .tax-bar {
+      grid-area: bar;
+    }
   }
 </style>

--- a/ui/src/lib/components/usage/SpendLens.svelte
+++ b/ui/src/lib/components/usage/SpendLens.svelte
@@ -2,7 +2,7 @@
   import { SvelteSet } from "svelte/reactivity";
   import type { UsageBreakdown, UsageRepoBreakdown, UsageTaskBreakdown } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
-  import GlossaryText from "$lib/components/GlossaryText.svelte";
+  import InfoTip from "$lib/components/InfoTip.svelte";
   import UsageBar from "./UsageBar.svelte";
   import { formatUnits, formatPct, formatDollars } from "./format";
 
@@ -69,7 +69,11 @@
   <div class="spend-header">
     <h2 class="spend-heading">{m.usage_spend_heading()}</h2>
     <span class="units-label">
-      <GlossaryText text={m.usage_units_label()} />
+      <span>{m.usage_units_label()}</span>
+      <InfoTip
+        text={m.gloss_weighted_units_def()}
+        label={m.newtask_info_aria({ topic: m.gloss_weighted_units_term() })}
+      />
     </span>
     {#if breakdown.dollars != null}
       <span class="spend-total-cost" aria-label={m.usage_spend_cost_label()}>
@@ -155,6 +159,9 @@
     font-size: var(--fs-meta);
     color: var(--color-muted);
     text-align: right;
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
   }
 
   .repo-list {
@@ -279,5 +286,55 @@
     color: var(--color-faint);
     padding: 0.2rem 0.5rem;
     font-style: italic;
+  }
+
+  @media (max-width: 480px) {
+    .spend-header {
+      flex-wrap: wrap;
+    }
+
+    .repo-row {
+      grid-template-columns: auto minmax(0, 1fr) auto auto;
+      grid-template-areas: "caret name pct units" "bar bar bar bar";
+      column-gap: 0.4rem;
+      row-gap: 0.3rem;
+    }
+    .repo-row.has-cost {
+      grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+      grid-template-areas: "caret name pct units cost" "bar bar bar bar bar";
+    }
+    .caret {
+      grid-area: caret;
+    }
+    .repo-name {
+      grid-area: name;
+    }
+    .repo-pct {
+      grid-area: pct;
+    }
+    .repo-units {
+      grid-area: units;
+    }
+    .repo-cost {
+      grid-area: cost;
+    }
+    .repo-bar {
+      grid-area: bar;
+    }
+
+    .task-row {
+      grid-template-columns: minmax(0, 1fr) auto;
+      grid-template-areas: "desig units" "bar bar";
+      row-gap: 0.2rem;
+    }
+    .task-desig {
+      grid-area: desig;
+    }
+    .task-units {
+      grid-area: units;
+    }
+    .task-bar {
+      grid-area: bar;
+    }
   }
 </style>

--- a/ui/src/lib/components/usage/format.test.ts
+++ b/ui/src/lib/components/usage/format.test.ts
@@ -8,6 +8,21 @@ describe("formatUnits", () => {
     expect(formatUnits(999)).toBe("999");
   });
 
+  it("rounds fractional weighted units", () => {
+    // [0.1, 1) — one decimal
+    expect(formatUnits(0.5)).toBe("0.5");
+    expect(formatUnits(0.74)).toBe("0.7");
+    // <0.1 — clamp label
+    expect(formatUnits(0.04)).toBe("<0.1");
+    // [1, 10) decimal
+    expect(formatUnits(8.05)).toBe("8.1");
+    // ≥10 integer rounding
+    expect(formatUnits(53.9247)).toBe("54");
+    expect(formatUnits(9.96)).toBe("10");
+    // boundary: rounds to 1000 → "1K"
+    expect(formatUnits(999.6)).toBe("1K");
+  });
+
   it("renders thousands with a rounded K suffix", () => {
     expect(formatUnits(1_000)).toBe("1K");
     expect(formatUnits(12_400)).toBe("12K");

--- a/ui/src/lib/components/usage/format.ts
+++ b/ui/src/lib/components/usage/format.ts
@@ -12,7 +12,11 @@ export function formatUnits(n: number): string {
     const k = Math.round(n / 1_000);
     return k >= 1_000 ? (n / 1_000_000).toFixed(2) + "M" : k + "K";
   }
-  return String(n);
+  if (n === 0) return "0";
+  if (n < 0.1) return "<0.1";
+  if (n < 10) return n.toFixed(1).replace(/\.0$/, "");
+  const rounded = Math.round(n);
+  return rounded >= 1000 ? "1K" : String(rounded);
 }
 
 /**

--- a/ui/src/routes/usage/+page.svelte
+++ b/ui/src/routes/usage/+page.svelte
@@ -2,6 +2,7 @@
   import type { UsageBreakdown, UsageLimits, UsageRange } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { getUsageBreakdown, getUsageLimits } from "$lib/api";
+  import { resolve } from "$app/paths";
   import SpendLens from "$lib/components/usage/SpendLens.svelte";
   import OverheadLens from "$lib/components/usage/OverheadLens.svelte";
   import LimitsLens from "$lib/components/usage/LimitsLens.svelte";
@@ -71,6 +72,7 @@
 <main class="usage-page">
   <header class="usage-header">
     <h1 class="usage-title">{m.usage_page_title()}</h1>
+    <a class="usage-close" href={resolve("/")} aria-label={m.common_close()}>✕</a>
   </header>
 
   <!-- Tab switcher -->
@@ -179,7 +181,32 @@
   }
 
   .usage-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
     margin-bottom: 20px;
+  }
+
+  .usage-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 44px;
+    min-height: 44px;
+    font-size: var(--fs-lg);
+    color: var(--color-muted);
+    text-decoration: none;
+    flex-shrink: 0;
+  }
+
+  .usage-close:hover {
+    color: var(--color-ink);
+  }
+
+  .usage-close:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
   }
 
   .usage-title {


### PR DESCRIPTION
## Why

The `/usage` page had several mobile UX defects (reported with screenshots):
- **Cache efficiency showed a duplicated, unformatted percentage** — e.g. `53.92467529999999` sitting next to `53%`. Root cause: real weighted units are dollar-scale floats (`pricing.ts` divides by 1,000,000) and `formatUnits()` printed sub-1000 values verbatim.
- **Glossary tooltips obscured the UI** — the inline dashed-term disclosure overflowed off the right edge inside narrow header cells.
- **Rows overflowed** — fixed-width grids clipped the %/units/$ columns off the right edge.
- **No way back** — `/usage` is a bare route with no top-bar chrome, so mobile users had no close/back affordance.

## What

- **`formatUnits` rounds fractional values** (`53.9247 → "54"`, `0.5 → "0.5"`, `<0.1 → "<0.1"`, boundary `999.6 → "1K"`). The ≥1000 K/M path is untouched; integers stay verbatim.
- **Cache efficiency → % only** per side (the bar already conveys proportion); the raw weighted-units number is dropped.
- **Glossary markers → `InfoTip` (i) icon** for *weighted units* and *satellite passes*. The popover floats with flip/shift so it never runs off-screen. Registry entries + `gloss_*` keys are retained (InfoTip sources its text from them).
- **Responsive stacked rows** — Spend repo/task rows + Overhead tax rows restack on `@media (max-width: 480px)`: name + numbers on top, bar full-width below. Desktop grid rules are byte-for-byte unchanged (add-only media queries).
- **Close button** (`✕` → links home) added to the usage header; reuses `common_close`, 44px tap target, accent focus ring.

## Verification

- `bun run check` 0 errors, `check:i18n` parity, glossary gate clean, full UI suite **1911 tests pass** (incl. new `formatUnits` fractional cases — the sole regression guard since `usage-mock.ts` rounds to integers).
- **Live mobile sweep** (iPhone viewport, all three lenses + controls): Spend/Overhead/Limits all fit with no horizontal overflow, info tooltips open fully on-screen, cache efficiency reads `cached reads 50% / generation 50%`, close button navigates home. Per-task review + final whole-branch review: **APPROVED**, no Critical/Important findings.

## Notes

- `fix(usage):` only — no feature-catalog entry needed.
- Minor follow-up candidate (out of scope, pre-existing & app-wide): the shared `InfoTip` icon's hit area is ~15px; widening it would touch every InfoTip call site (e.g. NewTask), so left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)