### PR TITLE
feat(usage): backfill pre-existing archived sessions into session_usage (#965)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ import { CountsService } from "./backlog";
 import { BacklogPoller } from "./backlog-poller";
 import { ProcessReaper } from "./process-reaper";
 import { sweepClaudeTmp, compileCacheDir, reapFallowCaches, pruneRepoWorktrees } from "./tmp-sweep";
+import { runSessionUsageBackfill } from "./usage-backfill";
 import { PreviewService } from "./preview";
 import { listRepos, listReposPathForReal } from "./repos";
 import { DistillerService, defaultScratch } from "./distiller";
@@ -1531,6 +1532,10 @@ const appDeps: AppDeps = {
 };
 const server = serve(appDeps, config.port);
 console.log(`shepherd core on http://localhost:${server.port}`);
+
+// One-time gap-fill of pre-existing archived sessions into session_usage (#965).
+// Fire-and-forget: async JSONL reads yield the event loop; never awaited at boot.
+void runSessionUsageBackfill(store);
 
 // Restricted agent-ingress listener: the autonomous netns's ONLY reachable control-plane surface.
 // Bound to loopback on an ephemeral port; slirp maps the netns's 10.0.2.2 → host 127.0.0.1. Started

--- a/src/store.ts
+++ b/src/store.ts
@@ -1405,6 +1405,18 @@ export class SessionStore implements CapStore, CreditStore {
     ).map((r) => this.hydrate(r));
   }
 
+  /** All archived sessions, newest-first by real archive time. Includes legacy rows whose
+   *  archivedAt column is NULL (a `archivedAt >= 0` filter would drop them). */
+  listArchivedSessions(): Session[] {
+    return (
+      this.db
+        .query(
+          `SELECT ${COLS} FROM sessions WHERE status = 'archived' ORDER BY COALESCE(archivedAt, updatedAt, createdAt) DESC`,
+        )
+        .all() as SessionRow[]
+    ).map((r) => this.hydrate(r));
+  }
+
   update(
     id: string,
     patch: Partial<

--- a/src/usage-backfill.ts
+++ b/src/usage-backfill.ts
@@ -1,0 +1,37 @@
+import type { SessionStore } from "./store";
+import { snapshotSessionUsage } from "./usage-snapshot";
+
+const GUARD_KEY = "backfill:session_usage_v1";
+
+/** One-time gap-fill: snapshot authoring spend for already-archived sessions that have no
+ *  session_usage row yet, stamping each row with the session's REAL archive time
+ *  (COALESCE(archivedAt, updatedAt, createdAt)) so it buckets into the correct time window.
+ *  Guarded so it runs once; the guard is set only after the loop completes, so a crash
+ *  mid-backfill resumes on the next boot (gap-fill skips rows already written). Never throws. */
+export async function runSessionUsageBackfill(store: SessionStore): Promise<void> {
+  try {
+    if (store.getSetting(GUARD_KEY) === "done") return;
+    const existing = new Set(store.listSessionUsage().map((u) => u.sessionId));
+    const archived = store.listArchivedSessions();
+    let snapshotted = 0;
+    let skipped = 0;
+    let errored = 0;
+    for (const s of archived) {
+      if (existing.has(s.id)) {
+        skipped++;
+        continue;
+      }
+      const asOf = s.archivedAt ?? s.updatedAt ?? s.createdAt;
+      const r = await snapshotSessionUsage(s, store, { asOf });
+      if (r === "snapshotted") snapshotted++;
+      else if (r === "error") errored++;
+      else skipped++;
+    }
+    store.setSetting(GUARD_KEY, "done");
+    console.log(
+      `[usage-backfill] archived=${archived.length} snapshotted=${snapshotted} skipped=${skipped} errored=${errored}`,
+    );
+  } catch (err) {
+    console.warn("[usage-backfill] backfill failed:", err);
+  }
+}

--- a/src/usage-backfill.ts
+++ b/src/usage-backfill.ts
@@ -6,8 +6,15 @@ const GUARD_KEY = "backfill:session_usage_v1";
 /** One-time gap-fill: snapshot authoring spend for already-archived sessions that have no
  *  session_usage row yet, stamping each row with the session's REAL archive time
  *  (COALESCE(archivedAt, updatedAt, createdAt)) so it buckets into the correct time window.
- *  Guarded so it runs once; the guard is set only after the loop completes, so a crash
- *  mid-backfill resumes on the next boot (gap-fill skips rows already written). Never throws. */
+ *  Guarded so it runs once; the guard is set only after the loop completes, so a real process
+ *  crash mid-backfill resumes on the next boot (gap-fill skips rows already written).
+ *
+ *  Per-session `"error"` returns (an unreadable/unparseable transcript) are intentionally
+ *  one-shot: the guard is still set even when `errored > 0`. Such failures are deterministic
+ *  (a corrupt transcript fails identically every boot), so NOT setting the guard would re-scan
+ *  every archived session on every boot forever without ever converging. This is best-effort
+ *  historical backfill — we log a loud warning instead so the operator can investigate, rather
+ *  than trap the migration in a permanent retry loop. Never throws. */
 export async function runSessionUsageBackfill(store: SessionStore): Promise<void> {
   try {
     if (store.getSetting(GUARD_KEY) === "done") return;
@@ -31,6 +38,11 @@ export async function runSessionUsageBackfill(store: SessionStore): Promise<void
     console.log(
       `[usage-backfill] archived=${archived.length} snapshotted=${snapshotted} skipped=${skipped} errored=${errored}`,
     );
+    if (errored > 0) {
+      console.warn(
+        `[usage-backfill] ${errored} session(s) failed to snapshot (unreadable/unparseable transcript) and will NOT be retried (one-shot migration); spend for these stays absent from the usage tree`,
+      );
+    }
   } catch (err) {
     console.warn("[usage-backfill] backfill failed:", err);
   }

--- a/src/usage-snapshot.ts
+++ b/src/usage-snapshot.ts
@@ -4,29 +4,34 @@ import { isOperationalArchetype } from "./usage-archetype";
 import { jsonlPathFor, sessionCost, dominantModel } from "./usage";
 
 /** Persist a session's authoring spend into the session_usage table.
- *  Never throws — the whole body is wrapped so archive teardown is never blocked. */
-export async function snapshotSessionUsage(s: Session, store: SessionStore): Promise<void> {
+ *  Never throws — the whole body is wrapped so archive teardown is never blocked.
+ *  Pass `opts.asOf` to stamp both archivedAt and snapshotAt with a historical time (backfill). */
+export async function snapshotSessionUsage(
+  s: Session,
+  store: SessionStore,
+  opts?: { asOf?: number },
+): Promise<"snapshotted" | "skipped" | "error"> {
   try {
     // 1. Skip operational archetypes and sessions without a pinned session id.
-    if (isOperationalArchetype(s) || !s.claudeSessionId) return;
+    if (isOperationalArchetype(s) || !s.claudeSessionId) return "skipped";
 
     // 2. Resolve and read the JSONL file; skip if absent.
     const path = jsonlPathFor(s.worktreePath, s.claudeSessionId);
     const file = Bun.file(path);
-    if (!(await file.exists())) return;
+    if (!(await file.exists())) return "skipped";
     const text = await file.text();
 
     // 3. Compute cost from the full transcript.
     const sc = sessionCost(text.split("\n"));
 
     // 4. Skip empty transcripts.
-    if (sc.usage.messageCount === 0) return;
+    if (sc.usage.messageCount === 0) return "skipped";
 
     // 5. Resolve dominant model.
     const model = dominantModel(sc.usage) ?? s.model ?? "unknown";
 
-    // 6. Timestamp.
-    const now = Date.now();
+    // 6. Timestamp — use opts.asOf when provided (backfill), otherwise now.
+    const asOf = opts?.asOf ?? Date.now();
 
     // 7. Upsert the snapshot row.
     store.upsertSessionUsage({
@@ -44,10 +49,12 @@ export async function snapshotSessionUsage(s: Session, store: SessionStore): Pro
       messageCount: sc.usage.messageCount,
       byModel: sc.weightedByModel,
       createdAt: s.createdAt,
-      archivedAt: now,
-      snapshotAt: now,
+      archivedAt: asOf,
+      snapshotAt: asOf,
     });
+    return "snapshotted";
   } catch (err) {
     console.warn("[usage-snapshot] error snapshotting session", s.id, err);
+    return "error";
   }
 }

--- a/test/usage-backfill.test.ts
+++ b/test/usage-backfill.test.ts
@@ -265,3 +265,27 @@ test("idempotent / guarded: second run after guard is set does NOT re-create del
   await runSessionUsageBackfill(store);
   expect(store.listSessionUsage()).toHaveLength(0);
 });
+
+test("errored session is one-shot: guard is set even when a snapshot fails (no permanent retry loop)", async () => {
+  const store = new SessionStore(":memory:");
+  makeArchivedSession(store, {
+    claudeSessionId: "csid-err",
+    archivedAt: 1_700_000_000_000,
+  });
+  writeJsonl(tmpDir, "csid-err", [
+    asst({ requestId: "r1", model: "claude-opus-4-8", input: 100, output: 50 }),
+  ]);
+
+  // Force snapshotSessionUsage into its catch (→ "error") by making the upsert throw — this
+  // models a deterministic failure (e.g. an unparseable transcript) that would recur every boot.
+  store.upsertSessionUsage = (() => {
+    throw new Error("boom");
+  }) as typeof store.upsertSessionUsage;
+
+  await runSessionUsageBackfill(store);
+
+  // Guard is set despite errored > 0: a deterministic failure must not trap the migration in a
+  // permanent every-boot re-scan. No row was written (the upsert threw).
+  expect(store.getSetting("backfill:session_usage_v1")).toBe("done");
+  expect(store.listSessionUsage()).toHaveLength(0);
+});

--- a/test/usage-backfill.test.ts
+++ b/test/usage-backfill.test.ts
@@ -1,0 +1,267 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { SessionStore } from "../src/store";
+import { config } from "../src/config";
+import { runSessionUsageBackfill } from "../src/usage-backfill";
+import { buildUsageBreakdown } from "../src/usage-breakdown";
+import { jsonlPathFor } from "../src/usage";
+
+// ── JSONL helpers (same shape as usage-snapshot.test.ts) ──────────────────
+
+function asst(opts: {
+  model?: string;
+  requestId?: string;
+  input?: number;
+  output?: number;
+}): string {
+  return JSON.stringify({
+    type: "assistant",
+    timestamp: "2026-05-30T09:31:01.924Z",
+    requestId: opts.requestId ?? "r1",
+    message: {
+      model: opts.model ?? "claude-opus-4-8",
+      usage: {
+        input_tokens: opts.input ?? 100,
+        output_tokens: opts.output ?? 50,
+        cache_read_input_tokens: 0,
+        cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 0 },
+      },
+    },
+  });
+}
+
+function writeJsonl(worktreePath: string, claudeSessionId: string, lines: string[]): void {
+  const p = jsonlPathFor(worktreePath, claudeSessionId);
+  mkdirSync(join(p, ".."), { recursive: true });
+  Bun.write(p, lines.join("\n"));
+}
+
+// ── Test infra ──────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+let origProjectsDir: string;
+
+beforeEach(() => {
+  tmpDir = join(
+    tmpdir(),
+    `usage-backfill-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(tmpDir, { recursive: true });
+  origProjectsDir = config.claudeProjectsDir;
+  config.claudeProjectsDir = tmpDir;
+});
+
+afterEach(() => {
+  config.claudeProjectsDir = origProjectsDir;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// Helper: create a session via store.create() then archive it with a known archivedAt.
+function makeArchivedSession(
+  store: SessionStore,
+  opts: {
+    claudeSessionId: string;
+    worktreePath?: string;
+    archivedAt?: number;
+    updatedAt?: number;
+  },
+): ReturnType<SessionStore["get"]> {
+  const input = {
+    name: "feat-x",
+    prompt: "add a button",
+    repoPath: tmpDir,
+    baseBranch: "main",
+    branch: "feat-x",
+    worktreePath: opts.worktreePath ?? tmpDir,
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_a",
+    model: "claude-opus-4-8",
+    auto: false,
+  } as const;
+  const s = store.create(input);
+  // Manually set claudeSessionId + archived status + archivedAt directly in DB.
+  const csid = opts.claudeSessionId;
+  const archivedAt = opts.archivedAt ?? Date.now();
+  const updatedAt = opts.updatedAt ?? archivedAt;
+  store["db"].run(
+    `UPDATE sessions SET claudeSessionId=?, status='archived', archivedAt=?, updatedAt=? WHERE id=?`,
+    [csid, archivedAt, updatedAt, s.id],
+  );
+  return store.get(s.id);
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+test("gap-fill: archived session with transcript and no existing row → row written with correct archivedAt", async () => {
+  const store = new SessionStore(":memory:");
+  const ARCHIVED_AT = 1_700_000_000_000; // a known past timestamp
+  const s = makeArchivedSession(store, {
+    claudeSessionId: "csid-gap-1",
+    archivedAt: ARCHIVED_AT,
+  });
+
+  writeJsonl(tmpDir, "csid-gap-1", [
+    asst({ requestId: "r1", model: "claude-opus-4-8", input: 100, output: 50 }),
+  ]);
+
+  await runSessionUsageBackfill(store);
+
+  const rows = store.listSessionUsage();
+  expect(rows).toHaveLength(1);
+  const r = rows[0]!;
+  expect(r.sessionId).toBe(s!.id);
+  expect(r.snapshotAt).toBe(ARCHIVED_AT);
+  expect(r.archivedAt).toBe(ARCHIVED_AT);
+  // sanity: NOT stamped with "now" (which would be ~1.75 trillion, not 1.7 trillion)
+  expect(r.snapshotAt).toBeLessThan(Date.now() - 1_000_000);
+});
+
+test("skip existing: archived session with pre-existing usage row is NOT overwritten", async () => {
+  const store = new SessionStore(":memory:");
+  const s = makeArchivedSession(store, {
+    claudeSessionId: "csid-existing",
+    archivedAt: 1_700_000_000_000,
+  });
+
+  writeJsonl(tmpDir, "csid-existing", [
+    asst({ requestId: "r1", model: "claude-opus-4-8", input: 100, output: 50 }),
+  ]);
+
+  // Pre-seed a sentinel usage row with a known sentinel value.
+  store.upsertSessionUsage({
+    sessionId: s!.id,
+    desig: "TASK-SENTINEL",
+    repoPath: tmpDir,
+    model: "sentinel-model",
+    input: 9999,
+    output: 9999,
+    cacheRead: 0,
+    cacheWrite: 0,
+    total: 9999,
+    weightedUnits: 42.0,
+    cacheReadUnits: 0,
+    messageCount: 99,
+    byModel: { "sentinel-model": 42.0 },
+    createdAt: 1,
+    archivedAt: 1,
+    snapshotAt: 1,
+  });
+
+  await runSessionUsageBackfill(store);
+
+  // Row must NOT have been overwritten — sentinel values must remain.
+  const rows = store.listSessionUsage();
+  expect(rows).toHaveLength(1);
+  expect(rows[0]!.model).toBe("sentinel-model");
+  expect(rows[0]!.weightedUnits).toBe(42.0);
+});
+
+test("skip non-archived: live session with transcript → no row written", async () => {
+  const store = new SessionStore(":memory:");
+  const input = {
+    name: "live-feat",
+    prompt: "live feature",
+    repoPath: tmpDir,
+    baseBranch: "main",
+    branch: "live-feat",
+    worktreePath: tmpDir,
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_a",
+    model: "claude-opus-4-8",
+    auto: false,
+  } as const;
+  const s = store.create(input);
+  // Set claudeSessionId but keep status = 'running'
+  store["db"].run(`UPDATE sessions SET claudeSessionId=? WHERE id=?`, ["csid-live", s.id]);
+
+  writeJsonl(tmpDir, "csid-live", [
+    asst({ requestId: "r1", model: "claude-opus-4-8", input: 100, output: 50 }),
+  ]);
+
+  await runSessionUsageBackfill(store);
+
+  expect(store.listSessionUsage()).toHaveLength(0);
+});
+
+test("COALESCE fallback: archived session with NULL archivedAt → snapshotAt === updatedAt", async () => {
+  const store = new SessionStore(":memory:");
+  const UPDATED_AT = 1_690_000_000_000;
+  const s = makeArchivedSession(store, {
+    claudeSessionId: "csid-coalesce",
+    archivedAt: undefined, // will be set to now in makeArchivedSession, we override below
+    updatedAt: UPDATED_AT,
+  });
+
+  // Override: set archivedAt to NULL but keep updatedAt = UPDATED_AT.
+  store["db"].run(`UPDATE sessions SET archivedAt=NULL, updatedAt=? WHERE id=?`, [
+    UPDATED_AT,
+    s!.id,
+  ]);
+
+  writeJsonl(tmpDir, "csid-coalesce", [
+    asst({ requestId: "r1", model: "claude-opus-4-8", input: 100, output: 50 }),
+  ]);
+
+  await runSessionUsageBackfill(store);
+
+  const rows = store.listSessionUsage();
+  expect(rows).toHaveLength(1);
+  // snapshotAt should equal updatedAt (the COALESCE fallback), not now
+  expect(rows[0]!.snapshotAt).toBe(UPDATED_AT);
+  expect(rows[0]!.archivedAt).toBe(UPDATED_AT);
+});
+
+test("end-to-end bucketing: months-old session excluded from 24h but included in all", async () => {
+  const store = new SessionStore(":memory:");
+  const now = Date.now();
+  const OLD_AT = now - 120 * 24 * 60 * 60 * 1000; // ~120 days ago
+
+  makeArchivedSession(store, {
+    claudeSessionId: "csid-old",
+    archivedAt: OLD_AT,
+  });
+
+  writeJsonl(tmpDir, "csid-old", [
+    asst({ requestId: "r1", model: "claude-opus-4-8", input: 100, output: 50 }),
+  ]);
+
+  await runSessionUsageBackfill(store);
+
+  const breakdown24h = await buildUsageBreakdown({ store, range: "24h", now, apiKey: false });
+  const breakdownAll = await buildUsageBreakdown({ store, range: "all", now, apiKey: false });
+
+  // 120-day-old session should NOT appear in 24h view
+  expect(breakdown24h.repos).toHaveLength(0);
+
+  // But should appear in "all" view
+  expect(breakdownAll.repos.length).toBeGreaterThan(0);
+});
+
+test("idempotent / guarded: second run after guard is set does NOT re-create deleted row", async () => {
+  const store = new SessionStore(":memory:");
+  const s = makeArchivedSession(store, {
+    claudeSessionId: "csid-guard",
+    archivedAt: 1_700_000_000_000,
+  });
+
+  writeJsonl(tmpDir, "csid-guard", [
+    asst({ requestId: "r1", model: "claude-opus-4-8", input: 100, output: 50 }),
+  ]);
+
+  // First run — should snapshot and set guard.
+  await runSessionUsageBackfill(store);
+  expect(store.listSessionUsage()).toHaveLength(1);
+  expect(store.getSetting("backfill:session_usage_v1")).toBe("done");
+
+  // Delete the row to verify guard short-circuits a second run.
+  store["db"].run(`DELETE FROM session_usage WHERE sessionId = ?`, [s!.id]);
+  expect(store.listSessionUsage()).toHaveLength(0);
+
+  // Second run — guard is "done", should NOT re-create the row.
+  await runSessionUsageBackfill(store);
+  expect(store.listSessionUsage()).toHaveLength(0);
+});

--- a/test/usage-snapshot.test.ts
+++ b/test/usage-snapshot.test.ts
@@ -153,7 +153,7 @@ test("/impeccable prompt session → no row (archetype skip)", async () => {
 test("absent JSONL → resolves without throwing and writes no row", async () => {
   const session = makeSession({ claudeSessionId: "no-file-here" });
   const store = new SessionStore(":memory:");
-  await expect(snapshotSessionUsage(session, store)).resolves.toBeUndefined();
+  await expect(snapshotSessionUsage(session, store)).resolves.toBe("skipped");
   expect(store.listSessionUsage()).toHaveLength(0);
 });
 
@@ -172,4 +172,28 @@ test("empty transcript (0 assistant records) → no row", async () => {
   const store = new SessionStore(":memory:");
   await snapshotSessionUsage(session, store);
   expect(store.listSessionUsage()).toHaveLength(0);
+});
+
+test("asOf override → row stamped with historical timestamp", async () => {
+  const T = 1_700_000_000_000;
+  const session = makeSession({
+    id: "sess-backfill",
+    desig: "TASK-99",
+    repoPath: "/repos/foo",
+    worktreePath: "/repos/foo",
+    claudeSessionId: "backfill-123",
+    createdAt: 1_000_000,
+    model: "claude-opus-4-8",
+  });
+  writeJsonl("/repos/foo", "backfill-123", [
+    asst({ requestId: "r1", model: "claude-opus-4-8", input: 100, output: 50 }),
+  ]);
+  const store = new SessionStore(":memory:");
+  const result = await snapshotSessionUsage(session, store, { asOf: T });
+  expect(result).toBe("snapshotted");
+  const rows = store.listSessionUsage();
+  expect(rows).toHaveLength(1);
+  const r = rows[0]!;
+  expect(r.archivedAt).toBe(T);
+  expect(r.snapshotAt).toBe(T);
 });


### PR DESCRIPTION
Closes #965. Follow-up to #952 (Phase 1) / part of the #943 arc.

## Problem
Phase 1 snapshots authoring spend at the `beforeArchive` hook, so `session_usage` history **starts empty and fills forward**. Sessions archived before the feature shipped have no row and never appear in the Spend/Overhead tree.

## What this does
A guarded, **one-time, gap-fill boot migration** that walks already-archived sessions and writes a `session_usage` snapshot for each missing one, reusing `snapshotSessionUsage`/`sessionCost` against their JSONL (when still present under `~/.claude/projects`).

- **Trigger:** deferred, fire-and-forget after `serve()` — never awaited, so async JSONL reads yield Shepherd's single event loop and can't block boot or freeze the terminal.
- **Coverage:** gap-fill only — sessions with no existing `session_usage` row; Phase-1 rows untouched.
- **Timestamps:** stamps **both `snapshotAt` and `archivedAt`** with the session's real archive time = `COALESCE(archivedAt, updatedAt, createdAt)`. `buildUsageBreakdown` range-filters on `snapshotAt` (`usage-breakdown.ts:220`), so backdating it is what lands each historical session in its correct time window (and out of short ranges) — **no breakdown change**. Legacy NULL-`archivedAt` rows bucket by true age, not today.
- **Idempotent / crash-resumable:** upsert by `sessionId`; the guard flag (`backfill:session_usage_v1`) is set **only after the loop completes**, so a crash mid-backfill resumes on the next boot. Tolerates missing/GC'd transcripts (skipped, never errors).

## Changes
- `src/usage-snapshot.ts` — `snapshotSessionUsage` gains an `asOf` override (stamps both timestamps) and returns `"snapshotted"|"skipped"|"error"`. Live path unchanged (both = now).
- `src/store.ts` — `listArchivedSessions()` (all archived, incl. legacy NULL-`archivedAt`).
- `src/usage-backfill.ts` (new) — `runSessionUsageBackfill(store)`.
- `src/index.ts` — fire-and-forget kick-off after `serve()`.
- `test/usage-backfill.test.ts` (new) + `test/usage-snapshot.test.ts` — gap-fill, skip-existing, skip-non-archived, COALESCE fallback, idempotency, and an end-to-end `buildUsageBreakdown` bucketing assertion (months-old session excluded from 24h, included in all).

## Verification
- Root `bunx tsc --noEmit` clean, `bun run lint` clean, `bun test ./test` → **4434 pass / 0 fail**.
- Reviewed task-by-task plus a final adversarial whole-branch review (boot-blocking, concurrency/double-count vs Phase-1 hook, snapshotAt readers, test rigor) → READY TO MERGE.

Server-only plumbing; the data surfaces through the existing #953 Spend tree (already announced) — no new user-facing strings, so no i18n keys and no new feature-catalog entry. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)