### PR TITLE
fix(plan-panel): full-bleed plan view on phones + drop recap-only inferred badge

### DIFF
--- a/ui/src/lib/components/PlanPanel.svelte
+++ b/ui/src/lib/components/PlanPanel.svelte
@@ -11,7 +11,16 @@
   let { session, onclose }: { session: Session; onclose: () => void } = $props();
 
   const gate = $derived(planGates.map[session.id]);
-  const planBlocks = $derived(gate?.blocks ?? []);
+  // Plan blocks are the planning agent's own proposed structures. The "inferred" badge
+  // (and its glossary tooltip) is recap-specific: it warns that a recap card was
+  // model-extracted and "not verified against the real diff." In the plan-before-execution
+  // view there is no diff and no recap model, so that caveat is false and confusing here —
+  // strip the flag so the badge doesn't render in this context (it still shows in recaps).
+  const planBlocks = $derived(
+    (gate?.blocks ?? []).map((b) =>
+      "inferred" in b && b.inferred ? { ...b, inferred: false } : b,
+    ),
+  );
   const reviewing = $derived(planGates.isReviewing(session.id));
   const releasable = $derived(canRelease(session, gate));
   // Manual re-review only makes sense while still planning (not once executing).
@@ -463,6 +472,22 @@
     .bracket::before,
     .bracket::after {
       display: none;
+    }
+    /* edge-to-edge plan content: trim the body's side gutter and let the plan /
+       verdict bands span the full screen width (no side border, no rounding) so
+       long code, tables and data-model cards use every available pixel. The bands
+       keep their inner text inset; actions/notes keep the slim body gutter so
+       buttons don't collide with the screen edge. */
+    .body {
+      padding: 12px 10px;
+    }
+    .plan,
+    .verdict {
+      margin-left: -10px;
+      margin-right: -10px;
+      border-left: 0;
+      border-right: 0;
+      border-radius: 0;
     }
   }
 </style>


### PR DESCRIPTION
## Was & warum

Zwei Anpassungen am **„PLAN VOR DER AUSFÜHRUNG"**-Panel (`PlanPanel.svelte`), gemeldet vom iPhone 14:

### 1. Ränder links/rechts weg (Mobile)
Das Sheet war auf Phones schon randlos, aber `.body` behielt einen 16px-Seitengutter und die `.plan`/`.verdict`-Bänder saßen eingerückt — viel verschenkte Breite auf schmalen Displays. Auf Mobile (`≤768px`) wird der Seitengutter getrimmt und die Bänder laufen jetzt **edge-to-edge** (kein Seitenrahmen/Rundung), sodass Code, Tabellen und Datenmodell-Karten die volle Breite nutzen. Die inneren Textabstände der Bänder bleiben; Buttons/Notizen behalten den schmalen Gutter, damit sie nicht am Bildschirmrand kleben.

### 2. Schwebender Dialog entfernt (Zweck war irreführend)
Der „über allem schwebende" Kasten war das Glossar-Tooltip des **„abgeleitet"**-Badges. Sein Text: *„Vom Recap-Modell aus dem Code abgeleitet — nicht gegen das echte Diff verifiziert."* Dieser Hinweis ist **recap-spezifisch** und in der Plan-vor-Ausführung-Ansicht schlicht falsch — es gibt hier noch kein Diff und kein Recap-Modell. Genau deshalb wirkte er sinnlos und ließ sich schwer wegtippen.

Fix: Das `inferred`-Flag wird für Plan-Blöcke gestrippt, sodass das recap-only Badge in diesem Kontext nicht mehr rendert. In Session-Recaps (wo „nicht gegen das echte Diff verifiziert" zutrifft) bleibt es unverändert erhalten.

## Test
- `bun run check` → 0 Fehler
- `bun run test src/lib/components/blocks/` → 72 passed
- Visuell auf Mobile-Breite verifiziert (Plan-Chip → PlanPanel)

[no-feature-entry] — reiner Fix, keine neue user-facing Capability.