### PR TITLE
feat(usage): persist a cap-scrape timeline for a true Limits trend (#973)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -512,5 +512,5 @@ export const REVIEWER_SPAWN_RETENTION_MS = REVIEWER_SPAWN_RETENTION_DAYS * 24 * 
 // usage_caps_history / usage_credit_history: append-only per-scrape timeline for the Limits
 // trend (issue #973). 90 days matches reviewer_spawns — long enough for meaningful monthly credit
 // cycles and weekly cap patterns, bounded enough to stay cheap.
-export const USAGE_HISTORY_RETENTION_DAYS = 90;
+const USAGE_HISTORY_RETENTION_DAYS = 90; // module-local; only the _MS form is consumed
 export const USAGE_HISTORY_RETENTION_MS = USAGE_HISTORY_RETENTION_DAYS * 24 * 60 * 60 * 1000;

--- a/src/config.ts
+++ b/src/config.ts
@@ -508,3 +508,9 @@ export const DONE_LENS_WINDOW_MS = 48 * 60 * 60 * 1000; // 48h
 // burn for a recently-archived task whose session row is already gone.
 const REVIEWER_SPAWN_RETENTION_DAYS = 90; // module-local; only the _MS form is consumed
 export const REVIEWER_SPAWN_RETENTION_MS = REVIEWER_SPAWN_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+
+// usage_caps_history / usage_credit_history: append-only per-scrape timeline for the Limits
+// trend (issue #973). 90 days matches reviewer_spawns — long enough for meaningful monthly credit
+// cycles and weekly cap patterns, bounded enough to stay cheap.
+export const USAGE_HISTORY_RETENTION_DAYS = 90;
+export const USAGE_HISTORY_RETENTION_MS = USAGE_HISTORY_RETENTION_DAYS * 24 * 60 * 60 * 1000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   SESSION_RETENTION_MS,
   SESSION_RETENTION_KEEP,
   REVIEWER_SPAWN_RETENTION_MS,
+  USAGE_HISTORY_RETENTION_MS,
   clampCap,
   PR_REVIEW_CYCLES_MIN,
   PR_REVIEW_CYCLES_MAX,
@@ -1238,6 +1239,8 @@ const runDailySweep = () => {
   // Cost-attribution records (issue #502); pruned on their own 90-day window, independent of
   // session housekeeping, so they survive an archived task's removal for later usage reports.
   store.pruneReviewerSpawns(Date.now() - REVIEWER_SPAWN_RETENTION_MS);
+  // Scrape timeline history; pruned on a 90-day window matching the caps/credit tables.
+  store.pruneUsageHistory(Date.now() - USAGE_HISTORY_RETENTION_MS);
   for (const repo of listRepos(config.repoRoot)) distiller.consider(repo.path);
   // Phase 4 merge suggestions: per-repo near-duplicate clustering (intra) + a single global
   // cross-repo recurrence pass. Both no-op unless the active set is large enough AND changed

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import {
   PR_REVIEW_CYCLES_MAX,
   PLAN_REVIEW_CYCLES_MIN,
   PLAN_REVIEW_CYCLES_MAX,
+  USAGE_HISTORY_RETENTION_MS,
 } from "./config";
 import {
   validateCreate,
@@ -2458,6 +2459,20 @@ async function handleUsageLimits({ req, parts, deps }: Ctx): Promise<Response | 
       limits: deps.usageLimits.limits(now),
       projections: deps.usageLimits.projections(now),
     });
+  }
+  if (
+    req.method === "GET" &&
+    parts[0] === "api" &&
+    parts[1] === "usage" &&
+    parts[2] === "history"
+  ) {
+    const now = Date.now();
+    const since = now - USAGE_HISTORY_RETENTION_MS;
+    const caps = deps.store.getCapsHistory(since);
+    const credit = deps.store.getCreditHistory(since);
+    const session5h = caps.filter((c) => c.window === "session5h");
+    const week = caps.filter((c) => c.window === "week");
+    return json({ caps: { session5h, week }, credit, since });
   }
   return null;
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -528,6 +528,20 @@ export class SessionStore implements CapStore, CreditStore {
       id INTEGER PRIMARY KEY CHECK (id = 1),
       spent REAL NOT NULL, cap REAL NOT NULL, currency TEXT NOT NULL,
       pct INTEGER NOT NULL, resetAt INTEGER, scrapedAt INTEGER NOT NULL)`);
+    this.db.run(`CREATE TABLE IF NOT EXISTS usage_caps_history (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      window TEXT NOT NULL, cap REAL NOT NULL, resetAt INTEGER NOT NULL,
+      pct INTEGER NOT NULL, scrapedAt INTEGER NOT NULL)`);
+    this.db.run(
+      `CREATE INDEX IF NOT EXISTS usage_caps_history_window_ts ON usage_caps_history (window, scrapedAt)`,
+    );
+    this.db.run(`CREATE TABLE IF NOT EXISTS usage_credit_history (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      spent REAL NOT NULL, cap REAL NOT NULL, currency TEXT NOT NULL,
+      pct INTEGER NOT NULL, resetAt INTEGER, scrapedAt INTEGER NOT NULL)`);
+    this.db.run(
+      `CREATE INDEX IF NOT EXISTS usage_credit_history_ts ON usage_credit_history (scrapedAt)`,
+    );
     this.db.run(`CREATE TABLE IF NOT EXISTS held_tasks (
       id TEXT PRIMARY KEY,
       repoPath TEXT NOT NULL,
@@ -1571,12 +1585,18 @@ export class SessionStore implements CapStore, CreditStore {
   }
 
   putCap(row: CapRow): void {
-    this.db.run(
-      `INSERT INTO usage_caps (window, cap, resetAt, pct, scrapedAt) VALUES (?,?,?,?,?)
-       ON CONFLICT(window) DO UPDATE SET cap=excluded.cap, resetAt=excluded.resetAt,
-         pct=excluded.pct, scrapedAt=excluded.scrapedAt`,
-      [row.window as WindowKey, row.cap, row.resetAt, row.pct, row.scrapedAt],
-    );
+    this.db.transaction(() => {
+      this.db.run(
+        `INSERT INTO usage_caps (window, cap, resetAt, pct, scrapedAt) VALUES (?,?,?,?,?)
+         ON CONFLICT(window) DO UPDATE SET cap=excluded.cap, resetAt=excluded.resetAt,
+           pct=excluded.pct, scrapedAt=excluded.scrapedAt`,
+        [row.window as WindowKey, row.cap, row.resetAt, row.pct, row.scrapedAt],
+      );
+      this.db.run(
+        `INSERT INTO usage_caps_history (window, cap, resetAt, pct, scrapedAt) VALUES (?,?,?,?,?)`,
+        [row.window as WindowKey, row.cap, row.resetAt, row.pct, row.scrapedAt],
+      );
+    })();
   }
 
   getCreditSnapshot(): CreditSnapshot | null {
@@ -1590,12 +1610,53 @@ export class SessionStore implements CapStore, CreditStore {
   }
 
   putCreditSnapshot(row: CreditSnapshot): void {
-    this.db.run(
-      `INSERT INTO usage_credit (id, spent, cap, currency, pct, resetAt, scrapedAt) VALUES (1, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(id) DO UPDATE SET spent=excluded.spent, cap=excluded.cap, currency=excluded.currency,
-         pct=excluded.pct, resetAt=excluded.resetAt, scrapedAt=excluded.scrapedAt`,
-      [row.spent, row.cap, row.currency, row.pct, row.resetAt, row.scrapedAt],
-    );
+    this.db.transaction(() => {
+      this.db.run(
+        `INSERT INTO usage_credit (id, spent, cap, currency, pct, resetAt, scrapedAt) VALUES (1, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET spent=excluded.spent, cap=excluded.cap, currency=excluded.currency,
+           pct=excluded.pct, resetAt=excluded.resetAt, scrapedAt=excluded.scrapedAt`,
+        [row.spent, row.cap, row.currency, row.pct, row.resetAt, row.scrapedAt],
+      );
+      this.db.run(
+        `INSERT INTO usage_credit_history (spent, cap, currency, pct, resetAt, scrapedAt) VALUES (?,?,?,?,?,?)`,
+        [row.spent, row.cap, row.currency, row.pct, row.resetAt, row.scrapedAt],
+      );
+    })();
+  }
+
+  getCapsHistory(sinceTs: number): CapRow[] {
+    return this.db
+      .query(
+        `SELECT window, cap, resetAt, pct, scrapedAt FROM usage_caps_history
+         WHERE scrapedAt >= ? ORDER BY scrapedAt ASC`,
+      )
+      .all(sinceTs) as CapRow[];
+  }
+
+  getCreditHistory(sinceTs: number): CreditSnapshot[] {
+    return this.db
+      .query(
+        `SELECT spent, cap, currency, pct, resetAt, scrapedAt FROM usage_credit_history
+         WHERE scrapedAt >= ? ORDER BY scrapedAt ASC`,
+      )
+      .all(sinceTs) as CreditSnapshot[];
+  }
+
+  /** Delete history rows older than `beforeTs` from both tables; returns total rows removed. */
+  pruneUsageHistory(beforeTs: number): number {
+    const caps = (
+      this.db
+        .query(`SELECT COUNT(*) AS c FROM usage_caps_history WHERE scrapedAt < ?`)
+        .get(beforeTs) as { c: number }
+    ).c;
+    const credits = (
+      this.db
+        .query(`SELECT COUNT(*) AS c FROM usage_credit_history WHERE scrapedAt < ?`)
+        .get(beforeTs) as { c: number }
+    ).c;
+    this.db.run(`DELETE FROM usage_caps_history WHERE scrapedAt < ?`, [beforeTs]);
+    this.db.run(`DELETE FROM usage_credit_history WHERE scrapedAt < ?`, [beforeTs]);
+    return caps + credits;
   }
 
   // ── critic reviews ─────────────────────────────────────────────────────────

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -7,7 +7,7 @@ import { SessionService } from "../src/service";
 import { EventHub } from "../src/events";
 import { makeApp, serve, PTY_GONE_CODE, claimLinkedIssue, type AppDeps } from "../src/server";
 import type { GitForge } from "../src/forge/types";
-import { config } from "../src/config";
+import { config, USAGE_HISTORY_RETENTION_MS } from "../src/config";
 import { ACTIVE_LABEL } from "../src/drain-core";
 
 // Create a real tmp dir inside config.repoRoot so validation passes
@@ -2007,4 +2007,119 @@ test("GET /api/sessions/:id/preview/stop (wrong method) → falls through router
   });
   const res = await app.fetch(new Request(`http://x/api/sessions/${s.id}/preview/stop`));
   expect(res.status).not.toBe(200);
+});
+
+// ── GET /api/usage/history ─────────────────────────────────────────────────
+
+test("GET /api/usage/history returns empty arrays when no history rows exist", async () => {
+  const res = await harness().fetch(new Request("http://x/api/usage/history"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.caps.session5h).toEqual([]);
+  expect(body.caps.week).toEqual([]);
+  expect(body.credit).toEqual([]);
+  expect(typeof body.since).toBe("number");
+});
+
+test("GET /api/usage/history returns cap rows split by window in ASC scrapedAt order", async () => {
+  const now = Date.now();
+  const deps = makeDeps();
+
+  // Insert two session5h rows at different times
+  deps.store.putCap({
+    window: "session5h",
+    cap: 100,
+    resetAt: now - 1000,
+    pct: 10,
+    scrapedAt: now - 200,
+  });
+  deps.store.putCap({
+    window: "session5h",
+    cap: 100,
+    resetAt: now - 1000,
+    pct: 20,
+    scrapedAt: now - 100,
+  });
+  // Insert one week row
+  deps.store.putCap({
+    window: "week",
+    cap: 1000,
+    resetAt: now - 5000,
+    pct: 30,
+    scrapedAt: now - 150,
+  });
+
+  const res = await makeApp(deps).fetch(new Request("http://x/api/usage/history"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+
+  expect(body.caps.session5h).toHaveLength(2);
+  expect(body.caps.session5h[0].pct).toBe(10);
+  expect(body.caps.session5h[1].pct).toBe(20);
+  expect(body.caps.session5h[0].window).toBe("session5h");
+
+  expect(body.caps.week).toHaveLength(1);
+  expect(body.caps.week[0].pct).toBe(30);
+  expect(body.caps.week[0].window).toBe("week");
+
+  expect(body.credit).toEqual([]);
+});
+
+test("GET /api/usage/history returns credit snapshots and since equals now - USAGE_HISTORY_RETENTION_MS", async () => {
+  const now = Date.now();
+  const deps = makeDeps();
+
+  deps.store.putCreditSnapshot({
+    spent: 5,
+    cap: 50,
+    currency: "€",
+    pct: 10,
+    resetAt: now - 3000,
+    scrapedAt: now - 100,
+  });
+
+  const res = await makeApp(deps).fetch(new Request("http://x/api/usage/history"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+
+  expect(body.credit).toHaveLength(1);
+  expect(body.credit[0]).toEqual({
+    spent: 5,
+    cap: 50,
+    currency: "€",
+    pct: 10,
+    resetAt: now - 3000,
+    scrapedAt: now - 100,
+  });
+
+  // since must be approximately now - USAGE_HISTORY_RETENTION_MS (within 1s)
+  expect(Math.abs(body.since - (Date.now() - USAGE_HISTORY_RETENTION_MS))).toBeLessThan(1000);
+});
+
+test("GET /api/usage/history does not return rows older than retention window", async () => {
+  const now = Date.now();
+  const deps = makeDeps();
+
+  const oldTs = now - USAGE_HISTORY_RETENTION_MS - 10000; // older than retention
+  // Directly insert an old row via the store's internal db to bypass putCap which writes current time
+  (deps.store as any).db.run(
+    `INSERT INTO usage_caps_history (window, cap, resetAt, pct, scrapedAt) VALUES (?,?,?,?,?)`,
+    ["session5h", 100, now - 5000, 99, oldTs],
+  );
+  // Also insert a recent row
+  deps.store.putCap({
+    window: "session5h",
+    cap: 100,
+    resetAt: now - 1000,
+    pct: 50,
+    scrapedAt: now - 50,
+  });
+
+  const res = await makeApp(deps).fetch(new Request("http://x/api/usage/history"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+
+  // Only the recent row should appear
+  expect(body.caps.session5h).toHaveLength(1);
+  expect(body.caps.session5h[0].pct).toBe(50);
 });

--- a/test/store-usage-history.test.ts
+++ b/test/store-usage-history.test.ts
@@ -1,0 +1,153 @@
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+import type { CapRow, CreditSnapshot } from "../src/usage-limits";
+
+function mk() {
+  return new SessionStore(":memory:");
+}
+
+const capRow = (over: Partial<CapRow> = {}): CapRow => ({
+  window: "session5h",
+  cap: 1000,
+  resetAt: 2_000_000,
+  pct: 40,
+  scrapedAt: 1_000_000,
+  ...over,
+});
+
+const creditRow = (over: Partial<CreditSnapshot> = {}): CreditSnapshot => ({
+  spent: 5.0,
+  cap: 50.0,
+  currency: "€",
+  pct: 10,
+  resetAt: 3_000_000,
+  scrapedAt: 1_000_000,
+  ...over,
+});
+
+// ── putCap / history append ──────────────────────────────────────────────────
+
+test("putCap: appends a history row; usage_caps holds one row after one call", () => {
+  const s = mk();
+  s.putCap(capRow({ scrapedAt: 1_000_000 }));
+  const caps = s.getCaps();
+  expect(caps).toHaveLength(1);
+  const hist = s.getCapsHistory(0);
+  expect(hist).toHaveLength(1);
+  expect(hist[0]!.window).toBe("session5h");
+  expect(hist[0]!.scrapedAt).toBe(1_000_000);
+});
+
+test("putCap: second call for same window upserts usage_caps (still 1 row) but appends a second history row", () => {
+  const s = mk();
+  s.putCap(capRow({ scrapedAt: 1_000_000 }));
+  s.putCap(capRow({ scrapedAt: 2_000_000, pct: 50 }));
+  const caps = s.getCaps();
+  expect(caps).toHaveLength(1);
+  expect(caps[0]!.pct).toBe(50); // upsert took effect
+  const hist = s.getCapsHistory(0);
+  expect(hist).toHaveLength(2);
+  expect(hist[0]!.scrapedAt).toBe(1_000_000);
+  expect(hist[1]!.scrapedAt).toBe(2_000_000);
+});
+
+// ── putCreditSnapshot / history append ──────────────────────────────────────
+
+test("putCreditSnapshot: appends a history row; usage_credit holds id=1 after one call", () => {
+  const s = mk();
+  s.putCreditSnapshot(creditRow({ scrapedAt: 1_000_000 }));
+  const snap = s.getCreditSnapshot();
+  expect(snap).not.toBeNull();
+  const hist = s.getCreditHistory(0);
+  expect(hist).toHaveLength(1);
+  expect(hist[0]!.spent).toBe(5.0);
+  expect(hist[0]!.scrapedAt).toBe(1_000_000);
+});
+
+test("putCreditSnapshot: second call upserts usage_credit (id=1 only) but appends another history row", () => {
+  const s = mk();
+  s.putCreditSnapshot(creditRow({ scrapedAt: 1_000_000, spent: 5.0 }));
+  s.putCreditSnapshot(creditRow({ scrapedAt: 2_000_000, spent: 10.0 }));
+  // usage_credit still has only id=1
+  const snap = s.getCreditSnapshot()!;
+  expect(snap.spent).toBe(10.0); // upsert took effect
+  const hist = s.getCreditHistory(0);
+  expect(hist).toHaveLength(2);
+  expect(hist[0]!.scrapedAt).toBe(1_000_000);
+  expect(hist[1]!.scrapedAt).toBe(2_000_000);
+});
+
+// ── getCapsHistory: since filter + ASC order ─────────────────────────────────
+
+test("getCapsHistory: respects since filter and returns ASC by scrapedAt", () => {
+  const s = mk();
+  s.putCap(capRow({ scrapedAt: 1_000 }));
+  s.putCap(capRow({ scrapedAt: 2_000 }));
+  s.putCap(capRow({ scrapedAt: 3_000 }));
+
+  const all = s.getCapsHistory(0);
+  expect(all).toHaveLength(3);
+  expect(all.map((r) => r.scrapedAt)).toEqual([1_000, 2_000, 3_000]);
+
+  const filtered = s.getCapsHistory(2_000);
+  expect(filtered).toHaveLength(2);
+  expect(filtered[0]!.scrapedAt).toBe(2_000);
+  expect(filtered[1]!.scrapedAt).toBe(3_000);
+});
+
+// ── getCreditHistory: since filter + ASC order ───────────────────────────────
+
+test("getCreditHistory: respects since filter and returns ASC by scrapedAt", () => {
+  const s = mk();
+  s.putCreditSnapshot(creditRow({ scrapedAt: 1_000 }));
+  s.putCreditSnapshot(creditRow({ scrapedAt: 2_000 }));
+  s.putCreditSnapshot(creditRow({ scrapedAt: 3_000 }));
+
+  const all = s.getCreditHistory(0);
+  expect(all).toHaveLength(3);
+  expect(all.map((r) => r.scrapedAt)).toEqual([1_000, 2_000, 3_000]);
+
+  const filtered = s.getCreditHistory(2_000);
+  expect(filtered).toHaveLength(2);
+  expect(filtered[0]!.scrapedAt).toBe(2_000);
+  expect(filtered[1]!.scrapedAt).toBe(3_000);
+});
+
+// ── pruneUsageHistory ────────────────────────────────────────────────────────
+
+test("pruneUsageHistory: deletes rows with scrapedAt < before from both tables and returns total count", () => {
+  const s = mk();
+  // 3 cap rows: ts 1000, 2000, 3000
+  s.putCap(capRow({ scrapedAt: 1_000 }));
+  s.putCap(capRow({ scrapedAt: 2_000 }));
+  s.putCap(capRow({ scrapedAt: 3_000 }));
+  // 2 credit rows: ts 1000, 4000
+  s.putCreditSnapshot(creditRow({ scrapedAt: 1_000 }));
+  s.putCreditSnapshot(creditRow({ scrapedAt: 4_000 }));
+
+  // prune before ts=2000 → removes cap@1000 + credit@1000 = 2
+  const removed = s.pruneUsageHistory(2_000);
+  expect(removed).toBe(2);
+
+  const capsLeft = s.getCapsHistory(0);
+  expect(capsLeft.map((r) => r.scrapedAt)).toEqual([2_000, 3_000]);
+
+  const creditsLeft = s.getCreditHistory(0);
+  expect(creditsLeft.map((r) => r.scrapedAt)).toEqual([4_000]);
+});
+
+test("pruneUsageHistory: rows at/after before survive", () => {
+  const s = mk();
+  s.putCap(capRow({ scrapedAt: 5_000 }));
+  s.putCreditSnapshot(creditRow({ scrapedAt: 5_000 }));
+
+  const removed = s.pruneUsageHistory(5_000); // strict <, so 5000 survives
+  expect(removed).toBe(0);
+  expect(s.getCapsHistory(0)).toHaveLength(1);
+  expect(s.getCreditHistory(0)).toHaveLength(1);
+});
+
+test("pruneUsageHistory: returns 0 when nothing to prune", () => {
+  const s = mk();
+  expect(s.pruneUsageHistory(Date.now())).toBe(0);
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1802,5 +1802,7 @@
   "usage_history_latest": "jetzt {pct}%",
   "usage_history_peak": "Spitze {pct}%",
   "usage_history_span": "{from} – {to}",
-  "usage_history_empty": "Noch kein aufgezeichneter Verlauf"
+  "usage_history_empty": "Noch kein aufgezeichneter Verlauf",
+  "feat_usage_limits_trend_title": "Aufgezeichnete Limit-Verläufe",
+  "feat_usage_limits_trend_body": "Die Limits-Ansicht zeigt jetzt einen echten aufgezeichneten Verlauf statt nur einer Prognose — eine Sparkline des laufenden Zyklus unter jeder Anzeige sowie ein aufklappbares Verlaufspanel, das darstellt, wie sich Ihr 5-Stunden-, Wochen- und Guthabenverbrauch über vergangene Zurücksetzungszyklen entwickelt hat."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1794,5 +1794,13 @@
   "topbar_usage_link": "Token-Nutzung",
   "topbar_usage_link_aria": "Token-Nutzungs-Dashboard öffnen",
   "feat_usage_dashboard_title": "Token-Nutzungs-Dashboard",
-  "feat_usage_dashboard_body": "Sehen Sie, wofür Ihre Tokens verbraucht werden — Verbrauch pro Repository und Task, der Cache-vs-Generierung-Overhead und die Live-Auslastung der Limits. Öffnen über das Zahnradmenü."
+  "feat_usage_dashboard_body": "Sehen Sie, wofür Ihre Tokens verbraucht werden — Verbrauch pro Repository und Task, der Cache-vs-Generierung-Overhead und die Live-Auslastung der Limits. Öffnen über das Zahnradmenü.",
+  "usage_history_inline_label": "{window} – aufgezeichneter Verlauf in diesem Zyklus",
+  "usage_history_view": "Verlauf anzeigen",
+  "usage_history_hide": "Verlauf ausblenden",
+  "usage_history_credit_label": "Zusatzguthaben",
+  "usage_history_latest": "jetzt {pct}%",
+  "usage_history_peak": "Spitze {pct}%",
+  "usage_history_span": "{from} – {to}",
+  "usage_history_empty": "Noch kein aufgezeichneter Verlauf"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1802,5 +1802,7 @@
   "usage_history_latest": "now {pct}%",
   "usage_history_peak": "peak {pct}%",
   "usage_history_span": "{from} – {to}",
-  "usage_history_empty": "No recorded history yet"
+  "usage_history_empty": "No recorded history yet",
+  "feat_usage_limits_trend_title": "Recorded limit trends",
+  "feat_usage_limits_trend_body": "The Limits lens now shows a real recorded trend, not just a projection — a current-cycle sparkline under each gauge plus an expandable history panel that charts how your 5h, weekly, and credit usage moved over past reset cycles."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1794,5 +1794,13 @@
   "topbar_usage_link": "Token usage",
   "topbar_usage_link_aria": "Open the token-usage dashboard",
   "feat_usage_dashboard_title": "Token usage dashboard",
-  "feat_usage_dashboard_body": "See where your tokens go — spend by repo and task, the cache-vs-generation overhead split, and live limit burn-down. Open it from the gear menu."
+  "feat_usage_dashboard_body": "See where your tokens go — spend by repo and task, the cache-vs-generation overhead split, and live limit burn-down. Open it from the gear menu.",
+  "usage_history_inline_label": "{window} recorded trend this cycle",
+  "usage_history_view": "View history",
+  "usage_history_hide": "Hide history",
+  "usage_history_credit_label": "Extra credit",
+  "usage_history_latest": "now {pct}%",
+  "usage_history_peak": "peak {pct}%",
+  "usage_history_span": "{from} – {to}",
+  "usage_history_empty": "No recorded history yet"
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -57,6 +57,7 @@ import type {
   DistillerHealth,
   RawAnswer,
   DocAgentRun,
+  UsageHistoryResponse,
 } from "./types";
 import { m } from "$lib/paraglide/messages";
 
@@ -488,6 +489,12 @@ export async function getDiff(id: string): Promise<DiffResult> {
 export async function getUsageLimits(): Promise<UsageLimitsResponse> {
   const r = await fetch("/api/usage/limits");
   if (!r.ok) throw await failed(r, "limits");
+  return r.json();
+}
+
+export async function getUsageHistory(): Promise<UsageHistoryResponse> {
+  const r = await fetch("/api/usage/history");
+  if (!r.ok) throw await failed(r, "history");
   return r.json();
 }
 

--- a/ui/src/lib/components/usage/LimitsLens.browser.test.ts
+++ b/ui/src/lib/components/usage/LimitsLens.browser.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../../app.css";
-import type { UsageLimits, UsageProjection } from "$lib/types";
+import type { UsageLimits, UsageProjection, UsageHistoryResponse } from "$lib/types";
 
 const BASE = Date.now();
 const H = 3_600_000;
@@ -23,6 +23,42 @@ function projectionsFixture(): UsageProjection[] {
     { window: "5H", projectedPct: 64, resetAt: BASE + 2.5 * H, burnRatePerHour: 48_000 },
     { window: "WK", projectedPct: 41, resetAt: BASE + 58 * H, burnRatePerHour: 31_000 },
   ];
+}
+
+function historyFixture(): UsageHistoryResponse {
+  const reset5h = BASE + 2.5 * H;
+  const resetWk = BASE + 58 * H;
+  return {
+    caps: {
+      session5h: [
+        { window: "session5h", cap: 100, resetAt: reset5h, pct: 12, scrapedAt: BASE - 1 * H },
+        { window: "session5h", cap: 100, resetAt: reset5h, pct: 30, scrapedAt: BASE - 0.5 * H },
+      ],
+      week: [
+        { window: "week", cap: 100, resetAt: resetWk, pct: 8, scrapedAt: BASE - 40 * H },
+        { window: "week", cap: 100, resetAt: resetWk, pct: 18, scrapedAt: BASE - 10 * H },
+      ],
+    },
+    credit: [
+      {
+        spent: 0.1,
+        cap: 50,
+        currency: "€",
+        pct: 0,
+        resetAt: BASE + 200 * H,
+        scrapedAt: BASE - 20 * H,
+      },
+      {
+        spent: 0.3,
+        cap: 50,
+        currency: "€",
+        pct: 1,
+        resetAt: BASE + 200 * H,
+        scrapedAt: BASE - 2 * H,
+      },
+    ],
+    since: BASE - 90 * 24 * H,
+  };
 }
 
 const { default: LimitsLens } = await import("./LimitsLens.svelte");
@@ -102,6 +138,40 @@ describe("LimitsLens", () => {
 
     const ticks = document.querySelectorAll(".proj-tick");
     expect(ticks.length, "one tick per matched projection").toBe(2);
+  });
+
+  it("renders inline sparklines and a working history toggle when history is present", async () => {
+    const limits = limitsFixture();
+    const projections = projectionsFixture();
+    const history = historyFixture();
+    render(LimitsLens, { limits, projections, history });
+
+    // One inline sparkline per gauge (5H + WK)
+    expect(document.querySelectorAll(".spark-row svg").length, "inline spark per window").toBe(2);
+
+    // Toggle present, collapsed by default
+    const toggle = document.querySelector<HTMLButtonElement>("button[aria-expanded]");
+    expect(toggle, "history toggle present").not.toBeNull();
+    expect(toggle!.getAttribute("aria-expanded")).toBe("false");
+    expect(document.querySelector(".history-panel"), "panel hidden initially").toBeNull();
+
+    // Expands the panel
+    toggle!.click();
+    await expect.poll(() => document.querySelector(".history-panel")).not.toBeNull();
+    expect(toggle!.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("still renders gauges + projection and hides the toggle when history is null", async () => {
+    const limits = limitsFixture();
+    const projections = projectionsFixture();
+    render(LimitsLens, { limits, projections, history: null });
+
+    expect(document.querySelectorAll(".meter-track").length).toBe(2);
+    expect(document.querySelectorAll(".proj-tick").length).toBe(2);
+    // No recorded history ⇒ no toggle
+    expect(document.querySelector("button[aria-expanded]"), "no toggle without history").toBeNull();
+    // Inline sparkline still renders (single live "now" point)
+    expect(document.querySelectorAll(".spark-row svg").length).toBe(2);
   });
 
   it("renders 'no data' message when limits are empty", async () => {

--- a/ui/src/lib/components/usage/LimitsLens.svelte
+++ b/ui/src/lib/components/usage/LimitsLens.svelte
@@ -101,6 +101,7 @@
             points={inlinePoints(gauge.label, gauge.w.pct, gauge.w.resetAt)}
             {color}
             liveLast={true}
+            domain={{ min: 0, max: 100 }}
             ariaLabel={m.usage_history_inline_label({ window: windowLabel(gauge.label) })}
           />
         </div>

--- a/ui/src/lib/components/usage/LimitsLens.svelte
+++ b/ui/src/lib/components/usage/LimitsLens.svelte
@@ -1,21 +1,61 @@
 <script lang="ts">
-  import type { UsageLimits, UsageProjection } from "$lib/types";
+  import type { UsageLimits, UsageProjection, UsageHistoryResponse } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { gaugeList, gaugeColor } from "$lib/components/usage-gauges";
   import { formatResetIn } from "$lib/format";
   import { formatUnits } from "./format";
+  import Sparkline from "./Sparkline.svelte";
+  import UsageHistoryPanel from "./UsageHistoryPanel.svelte";
 
-  const { limits, projections }: { limits: UsageLimits; projections: UsageProjection[] } = $props();
+  const {
+    limits,
+    projections,
+    history = null,
+  }: {
+    limits: UsageLimits;
+    projections: UsageProjection[];
+    history?: UsageHistoryResponse | null;
+  } = $props();
+
+  // Window period lengths (ms) — used to scope an inline sparkline to the current cycle.
+  const PERIOD_MS = { session5h: 5 * 3_600_000, week: 7 * 24 * 3_600_000 } as const;
 
   const nowMs = $derived(Date.now());
   const gauges = $derived(gaugeList(limits));
+
+  let showHistory = $state(false);
+
+  // Toggle is offered only when there's actually recorded history to show.
+  const hasHistory = $derived(
+    !!history &&
+      (history.caps.session5h.length > 0 ||
+        history.caps.week.length > 0 ||
+        history.credit.length > 0),
+  );
 
   function windowLabel(label: "5H" | "WK"): string {
     return label === "5H" ? m.usage_limits_window_5h() : m.usage_limits_window_week();
   }
 
+  function windowKey(label: "5H" | "WK"): "session5h" | "week" {
+    return label === "5H" ? "session5h" : "week";
+  }
+
   function findProjection(label: "5H" | "WK"): UsageProjection | undefined {
     return projections.find((p) => p.window === label);
+  }
+
+  /** Current-cycle inline series: in-cycle scrape samples + a synthetic live "now"
+   *  endpoint at the gauge's live pct, so the curve terminates at the number above it. */
+  function inlinePoints(label: "5H" | "WK", livePct: number, resetAt: number) {
+    const key = windowKey(label);
+    const cutoff = resetAt - PERIOD_MS[key];
+    const samples = history
+      ? history.caps[key]
+          .filter((p) => p.scrapedAt >= cutoff)
+          .map((p) => ({ t: p.scrapedAt, v: p.pct }))
+      : [];
+    return [...samples, { t: nowMs, v: livePct }];
   }
 </script>
 
@@ -55,6 +95,16 @@
           </div>
         </div>
 
+        <!-- Recorded current-cycle trend: scrape samples + a live "now" endpoint. -->
+        <div class="spark-row">
+          <Sparkline
+            points={inlinePoints(gauge.label, gauge.w.pct, gauge.w.resetAt)}
+            {color}
+            liveLast={true}
+            ariaLabel={m.usage_history_inline_label({ window: windowLabel(gauge.label) })}
+          />
+        </div>
+
         <div class="window-meta">
           <span class="reset-time"
             >{m.usage_limits_resets_in({ time: formatResetIn(gauge.w.resetAt, nowMs) })}</span
@@ -73,6 +123,22 @@
         </div>
       </div>
     {/each}
+
+    {#if hasHistory}
+      <div class="history-toggle-row">
+        <button
+          type="button"
+          class="gbtn"
+          aria-expanded={showHistory}
+          onclick={() => (showHistory = !showHistory)}
+        >
+          {showHistory ? m.usage_history_hide() : m.usage_history_view()}
+        </button>
+      </div>
+      {#if showHistory && history}
+        <UsageHistoryPanel {history} />
+      {/if}
+    {/if}
   {/if}
 </div>
 
@@ -186,5 +252,40 @@
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
+  }
+
+  .spark-row {
+    display: flex;
+    align-items: center;
+  }
+
+  .history-toggle-row {
+    display: flex;
+  }
+
+  /* Canonical .gbtn recipe (design-system) */
+  .gbtn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 2px 8px;
+    cursor: pointer;
+    transition:
+      border-color 0.12s,
+      color 0.12s;
+  }
+
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+
+  .gbtn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
   }
 </style>

--- a/ui/src/lib/components/usage/Sparkline.browser.test.ts
+++ b/ui/src/lib/components/usage/Sparkline.browser.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import "../../../app.css";
+
+const { default: Sparkline } = await import("./Sparkline.svelte");
+
+const NOW = Date.now();
+const MIN = 60_000;
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("Sparkline", () => {
+  it("renders a polyline for ≥2 points", async () => {
+    const points = [
+      { t: NOW - 60 * MIN, v: 10 },
+      { t: NOW - 30 * MIN, v: 30 },
+      { t: NOW, v: 50 },
+    ];
+    render(Sparkline, { points, color: "var(--color-green)", ariaLabel: "test sparkline" });
+
+    const polyline = document.querySelector("polyline");
+    expect(polyline, "polyline should be rendered for ≥2 points").toBeTruthy();
+  });
+
+  it("does NOT render a polyline for 1 point — only a single circle marker", async () => {
+    const points = [{ t: NOW, v: 42 }];
+    render(Sparkline, { points, color: "var(--color-green)", ariaLabel: "single point" });
+
+    const polyline = document.querySelector("polyline");
+    expect(polyline, "no polyline for 1 point").toBeNull();
+
+    const circle = document.querySelector("circle");
+    expect(circle, "a dot marker should be rendered for 1 point").toBeTruthy();
+  });
+
+  it("renders nothing (empty stable svg) for 0 points without throwing", async () => {
+    const points: { t: number; v: number }[] = [];
+    // Should not throw
+    expect(() =>
+      render(Sparkline, { points, color: "var(--color-green)", ariaLabel: "empty sparkline" }),
+    ).not.toThrow();
+
+    const svg = document.querySelector("svg");
+    expect(svg, "svg placeholder should exist for layout stability").toBeTruthy();
+
+    const polyline = document.querySelector("polyline");
+    expect(polyline, "no polyline for 0 points").toBeNull();
+
+    const circle = document.querySelector("circle");
+    expect(circle, "no markers for 0 points").toBeNull();
+  });
+
+  it("sets aria-label on the svg", async () => {
+    const label = "5H usage trend";
+    const points = [
+      { t: NOW - 30 * MIN, v: 20 },
+      { t: NOW, v: 40 },
+    ];
+    render(Sparkline, { points, color: "var(--color-blue)", ariaLabel: label });
+
+    const svg = document.querySelector("svg");
+    expect(svg, "svg element exists").toBeTruthy();
+    expect(svg!.getAttribute("aria-label")).toBe(label);
+    expect(svg!.getAttribute("role")).toBe("img");
+  });
+
+  it("renders a distinct live-last marker when liveLast is true", async () => {
+    const points = [
+      { t: NOW - 30 * MIN, v: 20 },
+      { t: NOW, v: 55 },
+    ];
+    render(Sparkline, {
+      points,
+      color: "var(--color-blue)",
+      ariaLabel: "live last test",
+      liveLast: true,
+    });
+
+    const circles = document.querySelectorAll("circle");
+    // One scrape marker + one live-last marker
+    expect(circles.length).toBe(2);
+  });
+});

--- a/ui/src/lib/components/usage/Sparkline.svelte
+++ b/ui/src/lib/components/usage/Sparkline.svelte
@@ -11,6 +11,7 @@
     height = 28,
     ariaLabel,
     liveLast = false,
+    domain,
   }: {
     points: Point[];
     color: string;
@@ -18,6 +19,10 @@
     height?: number;
     ariaLabel: string;
     liveLast?: boolean;
+    // Fixed y-axis range. Pass {min:0,max:100} for percentage series so cross-cycle
+    // magnitude is comparable (and the inline curve shares the gauge meter's scale).
+    // Omitted → auto-scale to the series' own min/max.
+    domain?: { min: number; max: number };
   } = $props();
 
   // Padding so markers at extremes don't get clipped
@@ -30,19 +35,22 @@
 
     const tMin = pts[0].t;
     const tMax = pts[pts.length - 1].t;
-    const vMin = Math.min(...pts.map((p) => p.v));
-    const vMax = Math.max(...pts.map((p) => p.v));
+    const vMin = domain ? domain.min : Math.min(...pts.map((p) => p.v));
+    const vMax = domain ? domain.max : Math.max(...pts.map((p) => p.v));
 
     const tRange = tMax - tMin || 1;
     const vRange = vMax - vMin || 1;
 
     const innerW = width - PAD * 2;
     const innerH = height - PAD * 2;
+    // Clamp the normalized value into [0,1] so an out-of-domain point (e.g. credit
+    // spend over budget vs a fixed 0–100) renders at the edge, never outside the svg.
+    const norm = (v: number) => Math.max(0, Math.min(1, (v - vMin) / vRange));
 
     return pts.map((p) => ({
       x: PAD + ((p.t - tMin) / tRange) * innerW,
       // SVG y axis is inverted: low v → high y
-      y: PAD + (1 - (p.v - vMin) / vRange) * innerH,
+      y: PAD + (1 - norm(p.v)) * innerH,
     }));
   }
 

--- a/ui/src/lib/components/usage/Sparkline.svelte
+++ b/ui/src/lib/components/usage/Sparkline.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+  interface Point {
+    t: number; // ms epoch, time-sorted ASC
+    v: number; // plotted value (e.g. pct 0–100)
+  }
+
+  let {
+    points,
+    color,
+    width = 120,
+    height = 28,
+    ariaLabel,
+    liveLast = false,
+  }: {
+    points: Point[];
+    color: string;
+    width?: number;
+    height?: number;
+    ariaLabel: string;
+    liveLast?: boolean;
+  } = $props();
+
+  // Padding so markers at extremes don't get clipped
+  const PAD = 4;
+
+  type Coord = { x: number; y: number };
+
+  function mapCoords(pts: Point[]): Coord[] {
+    if (pts.length === 0) return [];
+
+    const tMin = pts[0].t;
+    const tMax = pts[pts.length - 1].t;
+    const vMin = Math.min(...pts.map((p) => p.v));
+    const vMax = Math.max(...pts.map((p) => p.v));
+
+    const tRange = tMax - tMin || 1;
+    const vRange = vMax - vMin || 1;
+
+    const innerW = width - PAD * 2;
+    const innerH = height - PAD * 2;
+
+    return pts.map((p) => ({
+      x: PAD + ((p.t - tMin) / tRange) * innerW,
+      // SVG y axis is inverted: low v → high y
+      y: PAD + (1 - (p.v - vMin) / vRange) * innerH,
+    }));
+  }
+
+  const coords = $derived(mapCoords(points));
+
+  const polylinePoints = $derived(
+    coords.length >= 2 ? coords.map((c) => `${c.x},${c.y}`).join(" ") : "",
+  );
+
+  // Marker radius: regular scrape markers vs the distinct live-last marker
+  const R_SCRAPE = 2;
+  const R_LIVE = 3.5;
+</script>
+
+{#if points.length === 0}
+  <!-- Empty: render a fixed-size placeholder so layout stays stable -->
+  <svg
+    role="img"
+    aria-label={ariaLabel}
+    {width}
+    {height}
+    viewBox="0 0 {width} {height}"
+    style="display:block;overflow:visible"
+  ></svg>
+{:else if points.length === 1}
+  <!-- Single point: just a dot, no polyline -->
+  <svg
+    role="img"
+    aria-label={ariaLabel}
+    {width}
+    {height}
+    viewBox="0 0 {width} {height}"
+    style="display:block;overflow:visible"
+  >
+    <circle cx={width / 2} cy={height / 2} r={R_LIVE} fill={color} stroke="none" />
+  </svg>
+{:else}
+  <svg
+    role="img"
+    aria-label={ariaLabel}
+    {width}
+    {height}
+    viewBox="0 0 {width} {height}"
+    style="display:block;overflow:visible"
+  >
+    <!-- Series line -->
+    <polyline
+      points={polylinePoints}
+      fill="none"
+      stroke={color}
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+
+    <!-- Scrape-point markers (all except the last when liveLast is set) -->
+    {#each coords as c, i (i)}
+      {@const isLast = i === coords.length - 1}
+      {#if !isLast}
+        <circle cx={c.x} cy={c.y} r={R_SCRAPE} fill={color} opacity="0.65" />
+      {:else if liveLast}
+        <!-- Distinct terminal "now" point: filled, larger, full opacity -->
+        <circle
+          cx={c.x}
+          cy={c.y}
+          r={R_LIVE}
+          fill={color}
+          stroke="var(--color-bg, #fff)"
+          stroke-width="1"
+        />
+      {:else}
+        <!-- Last point without liveLast: same as scrape marker -->
+        <circle cx={c.x} cy={c.y} r={R_SCRAPE} fill={color} opacity="0.65" />
+      {/if}
+    {/each}
+  </svg>
+{/if}

--- a/ui/src/lib/components/usage/Sparkline.svelte
+++ b/ui/src/lib/components/usage/Sparkline.svelte
@@ -110,7 +110,7 @@
           cy={c.y}
           r={R_LIVE}
           fill={color}
-          stroke="var(--color-bg, #fff)"
+          stroke="var(--color-panel)"
           stroke-width="1"
         />
       {:else}

--- a/ui/src/lib/components/usage/UsageHistoryPanel.browser.test.ts
+++ b/ui/src/lib/components/usage/UsageHistoryPanel.browser.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../../app.css";
+import type { UsageHistoryResponse } from "$lib/types";
+
+const BASE = Date.now();
+const H = 3_600_000;
+
+const { default: UsageHistoryPanel } = await import("./UsageHistoryPanel.svelte");
+
+function fullHistory(): UsageHistoryResponse {
+  const reset5h = BASE + 2.5 * H;
+  const resetWk = BASE + 58 * H;
+  return {
+    caps: {
+      session5h: [
+        { window: "session5h", cap: 100, resetAt: reset5h, pct: 12, scrapedAt: BASE - 1 * H },
+        { window: "session5h", cap: 100, resetAt: reset5h, pct: 30, scrapedAt: BASE - 0.5 * H },
+      ],
+      week: [
+        // two distinct reset cycles → must segment, not connect across the reset
+        { window: "week", cap: 100, resetAt: BASE - 50 * H, pct: 60, scrapedAt: BASE - 80 * H },
+        { window: "week", cap: 100, resetAt: resetWk, pct: 8, scrapedAt: BASE - 40 * H },
+        { window: "week", cap: 100, resetAt: resetWk, pct: 18, scrapedAt: BASE - 10 * H },
+      ],
+    },
+    credit: [
+      {
+        spent: 0.1,
+        cap: 50,
+        currency: "€",
+        pct: 0,
+        resetAt: BASE + 200 * H,
+        scrapedAt: BASE - 20 * H,
+      },
+      {
+        spent: 0.3,
+        cap: 50,
+        currency: "€",
+        pct: 1,
+        resetAt: BASE + 200 * H,
+        scrapedAt: BASE - 2 * H,
+      },
+    ],
+    since: BASE - 90 * 24 * H,
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("UsageHistoryPanel", () => {
+  it("renders all three series from a fixture", async () => {
+    render(UsageHistoryPanel, { history: fullHistory() });
+
+    const sections = document.querySelectorAll(".series");
+    expect(sections.length, "one section per non-empty series (5H, WK, credit)").toBe(3);
+
+    // WK has two reset cycles → two segmented sparklines in its .cycles row
+    const cycleRows = document.querySelectorAll(".cycles");
+    expect(cycleRows.length).toBe(3);
+    // Total sparkline SVGs: 5H(1) + WK(2) + credit(1) = 4
+    expect(document.querySelectorAll(".cycles svg").length).toBe(4);
+  });
+
+  it("skips empty series and shows empty state when all are empty", async () => {
+    const empty: UsageHistoryResponse = {
+      caps: { session5h: [], week: [] },
+      credit: [],
+      since: BASE - 90 * 24 * H,
+    };
+    render(UsageHistoryPanel, { history: empty });
+
+    expect(document.querySelectorAll(".series").length).toBe(0);
+    await expect.element(page.getByText(/no recorded history/i)).toBeInTheDocument();
+  });
+
+  it("renders only the non-empty series", async () => {
+    const partial: UsageHistoryResponse = {
+      caps: {
+        session5h: [
+          { window: "session5h", cap: 100, resetAt: BASE + H, pct: 25, scrapedAt: BASE - 0.5 * H },
+        ],
+        week: [],
+      },
+      credit: [],
+      since: BASE - 90 * 24 * H,
+    };
+    render(UsageHistoryPanel, { history: partial });
+
+    expect(document.querySelectorAll(".series").length, "only 5H series renders").toBe(1);
+  });
+});

--- a/ui/src/lib/components/usage/UsageHistoryPanel.svelte
+++ b/ui/src/lib/components/usage/UsageHistoryPanel.svelte
@@ -107,6 +107,7 @@
             <Sparkline
               points={cycle.points}
               color={isCurrent ? gaugeColor(s.latest) : "var(--color-faint)"}
+              domain={{ min: 0, max: 100 }}
               ariaLabel={s.label}
               liveLast={isCurrent}
             />

--- a/ui/src/lib/components/usage/UsageHistoryPanel.svelte
+++ b/ui/src/lib/components/usage/UsageHistoryPanel.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+  import type { UsageHistoryResponse, CapHistoryPoint, CreditHistoryPoint } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import { gaugeColor } from "$lib/components/usage-gauges";
+  import { formatReset } from "$lib/format";
+  import Sparkline from "./Sparkline.svelte";
+
+  const { history }: { history: UsageHistoryResponse } = $props();
+
+  const nowMs = $derived(Date.now());
+
+  interface Cycle {
+    /** Reset-boundary key grouping the points; null = the open/last cycle. */
+    resetAt: number | null;
+    points: { t: number; v: number }[];
+  }
+
+  /** A renderable series: its chart cycles + headline stats, or null if empty. */
+  interface Series {
+    label: string;
+    cycles: Cycle[];
+    latest: number;
+    peak: number;
+    spanFrom: number;
+    spanTo: number;
+  }
+
+  /** Group time-ASC points into per-reset-cycle segments so a polyline never
+   *  connects across a reset boundary. Points sharing a resetAt are one cycle;
+   *  a null resetAt collapses into a single trailing cycle. */
+  function segment(points: { t: number; v: number; resetAt: number | null }[]): Cycle[] {
+    const cycles: Cycle[] = [];
+    for (const p of points) {
+      const last = cycles[cycles.length - 1];
+      if (last && last.resetAt === p.resetAt) {
+        last.points.push({ t: p.t, v: p.v });
+      } else {
+        cycles.push({ resetAt: p.resetAt, points: [{ t: p.t, v: p.v }] });
+      }
+    }
+    return cycles;
+  }
+
+  function capSeries(label: string, rows: CapHistoryPoint[]): Series | null {
+    if (rows.length === 0) return null;
+    const mapped = rows.map((r) => ({ t: r.scrapedAt, v: r.pct, resetAt: r.resetAt }));
+    return buildSeries(label, mapped);
+  }
+
+  function creditSeries(rows: CreditHistoryPoint[]): Series | null {
+    if (rows.length === 0) return null;
+    // Gauge pct rounds down to 0 while money is spent — plot the spend ratio instead.
+    const mapped = rows.map((r) => ({
+      t: r.scrapedAt,
+      v: r.cap > 0 ? (r.spent / r.cap) * 100 : 0,
+      resetAt: r.resetAt,
+    }));
+    return buildSeries(m.usage_history_credit_label(), mapped);
+  }
+
+  function buildSeries(
+    label: string,
+    mapped: { t: number; v: number; resetAt: number | null }[],
+  ): Series {
+    const cycles = segment(mapped);
+    const current = cycles[cycles.length - 1];
+    const latest = current.points[current.points.length - 1].v;
+    const peak = Math.max(...current.points.map((p) => p.v));
+    return {
+      label,
+      cycles,
+      latest,
+      peak,
+      spanFrom: mapped[0].t,
+      spanTo: mapped[mapped.length - 1].t,
+    };
+  }
+
+  const series = $derived(
+    [
+      capSeries(m.usage_limits_window_5h(), history.caps.session5h),
+      capSeries(m.usage_limits_window_week(), history.caps.week),
+      creditSeries(history.credit),
+    ].filter((s): s is Series => s !== null),
+  );
+
+  const allEmpty = $derived(series.length === 0);
+</script>
+
+<div class="history-panel panel">
+  {#if allEmpty}
+    <p class="empty">{m.usage_history_empty()}</p>
+  {:else}
+    {#each series as s (s.label)}
+      <section class="series">
+        <div class="series-head">
+          <span class="series-label">{s.label}</span>
+          <span class="series-stat"
+            >{m.usage_history_latest({ pct: Math.round(s.latest) })} ·
+            {m.usage_history_peak({ pct: Math.round(s.peak) })}</span
+          >
+        </div>
+
+        <div class="cycles" aria-hidden="true">
+          {#each s.cycles as cycle, i (cycle.resetAt ?? `open-${i}`)}
+            {@const isCurrent = i === s.cycles.length - 1}
+            <Sparkline
+              points={cycle.points}
+              color={isCurrent ? gaugeColor(s.latest) : "var(--color-faint)"}
+              ariaLabel={s.label}
+              liveLast={isCurrent}
+            />
+          {/each}
+        </div>
+
+        <span class="span"
+          >{m.usage_history_span({
+            from: formatReset(s.spanFrom, nowMs),
+            to: formatReset(s.spanTo, nowMs),
+          })}</span
+        >
+      </section>
+    {/each}
+  {/if}
+</div>
+
+<style>
+  .panel {
+    background: var(--color-panel);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    padding: 14px 16px;
+  }
+
+  .history-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
+  .empty {
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+    margin: 0;
+  }
+
+  .series {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .series-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+
+  .series-label {
+    font-size: var(--fs-base);
+    font-weight: 600;
+    color: var(--color-ink-bright);
+  }
+
+  .series-stat {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .cycles {
+    display: flex;
+    align-items: flex-end;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .span {
+    font-size: var(--fs-meta);
+    color: var(--color-faint);
+  }
+</style>

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1406,4 +1406,10 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_usage_dashboard_body",
     targetId: "usage-link",
   },
+  {
+    id: "usage-limits-trend",
+    sinceVersion: "1.36.0",
+    titleKey: "feat_usage_limits_trend_title",
+    bodyKey: "feat_usage_limits_trend_body",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -797,6 +797,35 @@ export interface UsageLimitsResponse {
   projections: UsageProjection[];
 }
 
+/** One persisted cap-scrape sample (mirrors server CapRow). */
+export interface CapHistoryPoint {
+  window: "session5h" | "week";
+  cap: number;
+  resetAt: number;
+  pct: number;
+  scrapedAt: number;
+}
+
+/** One persisted credit-scrape sample (mirrors server CreditSnapshot). */
+export interface CreditHistoryPoint {
+  spent: number;
+  cap: number;
+  currency: string;
+  pct: number;
+  resetAt: number | null;
+  scrapedAt: number;
+}
+
+/** GET /api/usage/history response: all three recorded series, ASC by scrapedAt. */
+export interface UsageHistoryResponse {
+  caps: {
+    session5h: CapHistoryPoint[];
+    week: CapHistoryPoint[];
+  };
+  credit: CreditHistoryPoint[];
+  since: number;
+}
+
 export interface UpdateCommit {
   sha: string;
   subject: string;

--- a/ui/src/routes/usage/+page.svelte
+++ b/ui/src/routes/usage/+page.svelte
@@ -106,11 +106,14 @@
     loadBreakdown(range);
   });
 
-  // Retry re-fetches BOTH tracks so either failure surface recovers.
-  function retry() {
+  // Retry re-fetches BOTH tracks so either failure surface recovers. Rebaseline the
+  // scrape signal after the limits/history loads so the next poll tick doesn't see a
+  // stale signal and trigger a redundant /api/usage/history refetch.
+  async function retry() {
     loadBreakdown(range);
-    loadLimits();
-    loadHistory();
+    await loadLimits();
+    await loadHistory();
+    lastScrapeSig = scrapeSig();
   }
 </script>
 

--- a/ui/src/routes/usage/+page.svelte
+++ b/ui/src/routes/usage/+page.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
-  import type { UsageBreakdown, UsageLimits, UsageProjection, UsageRange } from "$lib/types";
+  import type {
+    UsageBreakdown,
+    UsageLimits,
+    UsageProjection,
+    UsageRange,
+    UsageHistoryResponse,
+  } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
-  import { getUsageBreakdown, getUsageLimits } from "$lib/api";
+  import { getUsageBreakdown, getUsageLimits, getUsageHistory } from "$lib/api";
+  import { pollWhileVisible } from "$lib/visibility";
   import { resolve } from "$app/paths";
   import SpendLens from "$lib/components/usage/SpendLens.svelte";
   import OverheadLens from "$lib/components/usage/OverheadLens.svelte";
@@ -15,11 +22,19 @@
   let breakdown = $state<UsageBreakdown | null>(null);
   let limits = $state<UsageLimits | null>(null);
   let projections = $state<UsageProjection[]>([]);
+  let history = $state<UsageHistoryResponse | null>(null);
   let loading = $state(true);
   let error = $state(false);
   // Limits has its own error track (the Limits tab doesn't use `breakdown`), so a
   // limits-endpoint failure surfaces an error + Retry instead of loading forever.
   let limitsError = $state(false);
+
+  // Last-seen scrape signal — history only moves on a scrape, so the 30s poll
+  // re-fetches /api/usage/history ONLY when this advances (never every tick).
+  let lastScrapeSig = "";
+  function scrapeSig(): string {
+    return `${limits?.calibratedAt}:${limits?.credits?.scrapedAt}`;
+  }
 
   // Fetch limits once on mount (range-independent). `limits === null && !limitsError`
   // ⇒ still loading.
@@ -33,9 +48,39 @@
       limitsError = true;
     }
   }
+
+  // History augments the lens — a failed load must NOT blank it. Quiet on error.
+  async function loadHistory() {
+    try {
+      history = await getUsageHistory();
+    } catch {
+      /* augmentation only — leave prior history untouched */
+    }
+  }
   $effect(() => {
-    loadLimits();
+    // Async IIFE so the `scrapeSig()` baseline read happens AFTER the awaits — reading
+    // `limits` synchronously here would make this effect depend on `limits`, and since
+    // loadLimits() assigns a fresh object each call it would re-invalidate → refetch loop.
+    void (async () => {
+      await loadLimits();
+      // Initial unconditional history load; baseline the signal so the first poll
+      // tick doesn't redundantly refetch.
+      await loadHistory();
+      lastScrapeSig = scrapeSig();
+    })();
   });
+
+  // Live refresh while visible: gauges + projection every tick (cheap recompute);
+  // history only when the scrape signal advanced.
+  async function refresh() {
+    await loadLimits();
+    const sig = scrapeSig();
+    if (sig !== lastScrapeSig) {
+      lastScrapeSig = sig;
+      loadHistory();
+    }
+  }
+  $effect(() => pollWhileVisible(refresh, 30_000));
 
   // Monotonic token: latest request always wins; stale requests discard their results.
   let reqToken = 0;
@@ -65,6 +110,7 @@
   function retry() {
     loadBreakdown(range);
     loadLimits();
+    loadHistory();
   }
 </script>
 
@@ -163,7 +209,7 @@
         <p class="usage-status-line">{m.common_loading()}</p>
       {/if}
     {:else if limits}
-      <LimitsLens {limits} {projections} />
+      <LimitsLens {limits} {projections} {history} />
     {:else if limitsError}
       <p class="usage-status-line usage-error">{m.usage_load_error()}</p>
       <button type="button" class="gbtn gbtn-secondary" onclick={retry}>{m.common_retry()}</button>

--- a/ui/src/routes/usage/page.browser.test.ts
+++ b/ui/src/routes/usage/page.browser.test.ts
@@ -29,6 +29,8 @@ vi.mock("$lib/api", async () => {
   return {
     getUsageBreakdown: (range: UsageRange) => Promise.resolve(mockBreakdown(range)),
     getUsageLimits: () => Promise.resolve({ limits: inlineLimits, projections: inlineProjections }),
+    getUsageHistory: () =>
+      Promise.resolve({ caps: { session5h: [], week: [] }, credit: [], since: BASE }),
   };
 });
 


### PR DESCRIPTION
Closes #973. Follow-up to #952 (Phase 1) / part of the #943 arc — its explicit open follow-up *"Persist a cap-scrape timeline for a true Limits trend."*

## Problem
`usage_caps` (keyed by `window`) and `usage_credit` (`id=1`) overwrite on every `/usage` scrape, so they hold only the latest snapshot. The Limits lens could therefore show only the #966 **projection** (a forward estimate from recent burn), never an actual recorded trend.

## What this does
- **Append-only history** — new `usage_caps_history` + `usage_credit_history` tables, written transactionally alongside the existing `putCap`/`putCreditSnapshot` upserts (latest-snapshot tables stay the fast read path).
- **Bounded retention** — `pruneUsageHistory` in the daily sweep, 90 days (mirrors `reviewer_spawns`).
- **Endpoint** — `GET /api/usage/history` → `{ caps: { session5h, week }, credit, since }`.
- **Recorded trend in the lens** (augments, does not replace, the #966 projection):
  - Inline **current-cycle** sparkline under each 5H/WK gauge (`scrapedAt >= resetAt − period`), terminating at a synthetic live "now" point so the curve ends at the gauge value shown above it.
  - An expandable **history panel** charting all three series (5H, WK, credit), **segmented by reset cycle** so no polyline connects across a reset. Credit plots `spent/cap*100` (gauge pct rounds down to 0 while money is spent).
  - The page refreshes via `pollWhileVisible`; `/api/usage/history` is re-fetched only when the scrape signal (`calibratedAt`/credit `scrapedAt`) advances — never on the bare 30s recompute tick.

## Notes on cadence
Scrapes are daily (15-min only when weekly ≥90%, plus manual refresh), so credit (~30 pts/cycle) and weekly curves are dense, while 5h is sparse — sparklines degrade gracefully to a dot.

## Tests / gates
Root: lint clean, `bun test ./test` 4444 pass. UI: `bun run check` 0 errors, 1920 tests pass, i18n parity (EN+DE), feature-catalog gate green (`usage-limits-trend`, sinceVersion 1.36.0). Branch hygiene linear; `fallow audit` clean (duplication warn-only). Whole-branch adversarial review: APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
