### PR TITLE
perf(usage): per-record windowing of persisted history + continuous rollup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import { serve, serveAgentIngress, buildBacklogPayload, type AppDeps } from "./s
 import { makeProductionForgeResolver } from "./forge/resolve";
 import { EmptyDiffError, type GitState } from "./forge/types";
 import { annotateHandoff } from "./repo-roles";
-import { AccountUsageIndex } from "./usage";
+import { AccountUsageIndex, SessionUsageRollup } from "./usage";
 import { UsageLimitsService, calibrateDelay, type UsageLimits } from "./usage-limits";
 import { HerdrUsageProbe } from "./usage-probe";
 import { sweepStaging, STAGING_TTL_MS } from "./uploads";
@@ -295,6 +295,7 @@ const buildQueueReminder = new BuildQueueReminderService({
 });
 
 const accountIndex = new AccountUsageIndex();
+const usageRollup = new SessionUsageRollup();
 const usageLimits = new UsageLimitsService(accountIndex, store, new HerdrUsageProbe(herdr), store);
 
 reconcile(store, herdr);
@@ -1449,6 +1450,7 @@ const appDeps: AppDeps = {
   service,
   events,
   usageLimits,
+  usageRollup,
   refreshUsage,
   updates,
   herdrUpdates,

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,7 +56,7 @@ import { loadSteers, saveSteers } from "./steers";
 import { loadIcons, setIcon } from "./project-icons";
 import { listBranches } from "./branches";
 import { computeDiff } from "./diff";
-import { sessionTokens, jsonlPathFor } from "./usage";
+import { sessionTokens, jsonlPathFor, type SessionUsageRollup } from "./usage";
 import { buildUsageBreakdown } from "./usage-breakdown";
 import { isApiKeyMode } from "./spawn-auth";
 import { detectDevCommand } from "./preview";
@@ -158,6 +158,8 @@ export interface AppDeps {
   /** Force a `/usage` re-scrape (calibration) and return fresh limits; absent in tests that
    *  don't wire the live calibrator (the route then falls back to the current snapshot). */
   refreshUsage?: () => Promise<UsageLimits>;
+  /** Incremental per-session rollup; absent in tests → breakdown falls back to re-parsing JSONL. */
+  usageRollup?: SessionUsageRollup;
   /** Resolve the git forge for a repo dir; null when none is configured. */
   resolveForge?: (repoDir: string) => GitForge | null;
   /** Self-update tracker; absent in environments where it isn't wired. */
@@ -2480,6 +2482,7 @@ async function handleUsageBreakdown({ req, parts, url, deps }: Ctx): Promise<Res
     range: raw,
     now: Date.now(),
     apiKey: isApiKeyMode(),
+    usageRollup: deps.usageRollup,
   });
   return json(breakdown);
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -3529,7 +3529,9 @@ export class SessionStore implements CapStore, CreditStore {
              (sessionId, bucketStart, input, output, cacheRead, cacheWrite, weightedUnits, cacheReadUnits, byModel)
            VALUES (?,?,?,?,?,?,?,?,?)`,
           [
-            b.sessionId,
+            // bind the method's sessionId (which scoped the DELETE), not b.sessionId, so a
+            // bucket row can never land under a different parent than the one being replaced.
+            sessionId,
             b.bucketStart,
             b.input,
             b.output,

--- a/src/store.ts
+++ b/src/store.ts
@@ -26,6 +26,8 @@ import type {
   CreateSessionInput,
   SessionUsageRow,
   SessionUsageSnapshot,
+  SessionUsageBucket,
+  WindowedBucketSum,
 } from "./types";
 import type { VisualBlock } from "./visual-blocks";
 import type { CapRow, CapStore, CreditSnapshot, CreditStore, WindowKey } from "./usage-limits";
@@ -500,6 +502,9 @@ export class SessionStore implements CapStore, CreditStore {
   private db: Database;
   constructor(path: string) {
     this.db = new Database(path);
+    // Enforce FK constraints (enforces session_usage_bucket → session_usage cascade).
+    // Must be set immediately after open, BEFORE any DDL — it is a no-op inside a transaction.
+    this.db.run("PRAGMA foreign_keys = ON");
     this.db.run(`CREATE TABLE IF NOT EXISTS sessions (
       id TEXT PRIMARY KEY, desig TEXT NOT NULL, name TEXT NOT NULL, prompt TEXT NOT NULL,
       repoPath TEXT NOT NULL, baseBranch TEXT NOT NULL, branch TEXT,
@@ -777,6 +782,22 @@ export class SessionStore implements CapStore, CreditStore {
       createdAt      INTEGER NOT NULL,
       archivedAt     INTEGER NOT NULL,
       snapshotAt     INTEGER NOT NULL)`);
+    this.db.run(`CREATE TABLE IF NOT EXISTS session_usage_bucket (
+      sessionId      TEXT NOT NULL,
+      bucketStart    INTEGER NOT NULL,
+      input          INTEGER NOT NULL,
+      output         INTEGER NOT NULL,
+      cacheRead      INTEGER NOT NULL,
+      cacheWrite     INTEGER NOT NULL,
+      weightedUnits  REAL NOT NULL,
+      cacheReadUnits REAL NOT NULL,
+      byModel        TEXT NOT NULL DEFAULT '{}',
+      PRIMARY KEY (sessionId, bucketStart),
+      FOREIGN KEY (sessionId) REFERENCES session_usage(sessionId) ON DELETE CASCADE
+    )`);
+    this.db.run(
+      `CREATE INDEX IF NOT EXISTS session_usage_bucket_start ON session_usage_bucket (bucketStart)`,
+    );
   }
 
   // ── settings (key/value) ─────────────────────────────────────────────────
@@ -3492,5 +3513,96 @@ export class SessionStore implements CapStore, CreditStore {
       ...row,
       byModel: JSON.parse(row.byModel) as Record<string, number>,
     }));
+  }
+
+  // ── per-session usage buckets ────────────────────────────────────────────────
+
+  /** Replace all bucket rows for sessionId atomically.
+   *  DELETE existing + INSERT all new in one transaction — idempotent on re-archive.
+   *  Requires the parent session_usage row to already exist (FK). */
+  replaceSessionUsageBuckets(sessionId: string, buckets: SessionUsageBucket[]): void {
+    this.db.transaction(() => {
+      this.db.run(`DELETE FROM session_usage_bucket WHERE sessionId = ?`, [sessionId]);
+      for (const b of buckets) {
+        this.db.run(
+          `INSERT INTO session_usage_bucket
+             (sessionId, bucketStart, input, output, cacheRead, cacheWrite, weightedUnits, cacheReadUnits, byModel)
+           VALUES (?,?,?,?,?,?,?,?,?)`,
+          [
+            b.sessionId,
+            b.bucketStart,
+            b.input,
+            b.output,
+            b.cacheRead,
+            b.cacheWrite,
+            b.weightedUnits,
+            b.cacheReadUnits,
+            JSON.stringify(b.byModel),
+          ],
+        );
+      }
+    })();
+  }
+
+  /** Sum bucket rows per session for the given cutoff window.
+   *  Selects rows WHERE bucketStart = 0 OR bucketStart >= floorHour(cutoff).
+   *  Folds in JS (no SQL SUM) so float math matches archive-time folding. */
+  sumSessionUsageBucketsSince(cutoff: number): Map<string, WindowedBucketSum> {
+    const floorHour = cutoff - (cutoff % 3_600_000);
+    type BucketRow = {
+      sessionId: string;
+      bucketStart: number;
+      input: number;
+      output: number;
+      cacheRead: number;
+      cacheWrite: number;
+      weightedUnits: number;
+      cacheReadUnits: number;
+      byModel: string;
+    };
+    const rows = this.db
+      .query(
+        `SELECT sessionId, bucketStart, input, output, cacheRead, cacheWrite,
+                weightedUnits, cacheReadUnits, byModel
+         FROM session_usage_bucket
+         WHERE bucketStart = 0 OR bucketStart >= ?`,
+      )
+      .all(floorHour) as BucketRow[];
+
+    const result = new Map<string, WindowedBucketSum>();
+    for (const row of rows) {
+      const existing = result.get(row.sessionId);
+      const rowByModel = JSON.parse(row.byModel) as Record<string, number>;
+      if (!existing) {
+        result.set(row.sessionId, {
+          input: row.input,
+          output: row.output,
+          cacheRead: row.cacheRead,
+          cacheWrite: row.cacheWrite,
+          weightedUnits: row.weightedUnits,
+          cacheReadUnits: row.cacheReadUnits,
+          byModel: { ...rowByModel },
+        });
+      } else {
+        existing.input += row.input;
+        existing.output += row.output;
+        existing.cacheRead += row.cacheRead;
+        existing.cacheWrite += row.cacheWrite;
+        existing.weightedUnits += row.weightedUnits;
+        existing.cacheReadUnits += row.cacheReadUnits;
+        for (const [model, units] of Object.entries(rowByModel)) {
+          existing.byModel[model] = (existing.byModel[model] ?? 0) + units;
+        }
+      }
+    }
+    return result;
+  }
+
+  /** Distinct sessionIds that have at least one bucket row. */
+  bucketedSessionIds(): Set<string> {
+    const rows = this.db.query(`SELECT DISTINCT sessionId FROM session_usage_bucket`).all() as {
+      sessionId: string;
+    }[];
+    return new Set(rows.map((r) => r.sessionId));
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -641,6 +641,30 @@ export interface SessionUsageSnapshot {
   snapshotAt: number;
 }
 
+/** One UTC-hour bucket of a session's spend, persisted in session_usage_bucket. */
+export interface SessionUsageBucket {
+  sessionId: string;
+  bucketStart: number; // ms epoch, floorHour(ts); 0 = timeless bucket
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  weightedUnits: number;
+  cacheReadUnits: number;
+  byModel: Record<string, number>; // weighted units per model
+}
+
+/** Per-session windowed sum returned by sumSessionUsageBucketsSince. */
+export interface WindowedBucketSum {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  weightedUnits: number;
+  cacheReadUnits: number;
+  byModel: Record<string, number>;
+}
+
 // Mirror of the UsageBreakdown contract in ui/src/lib/types.ts — keep in sync.
 export type UsageRange = "24h" | "7d" | "30d" | "all";
 

--- a/src/usage-breakdown.ts
+++ b/src/usage-breakdown.ts
@@ -242,6 +242,80 @@ function aggregateTotals(
   return { totalUnits, authoringUnits, satelliteUnits, cacheReadUnits, generationUnits };
 }
 
+/** Populate taskMap with windowed persisted tasks (cutoff > 0 path). */
+function addWindowedPersistedTasks(
+  taskMap: Map<string, TaskAccum>,
+  store: SessionStore,
+  snapshots: ReturnType<SessionStore["listSessionUsage"]>,
+  cutoff: number,
+): void {
+  const bucketed = store.bucketedSessionIds();
+  const sums = store.sumSessionUsageBucketsSince(cutoff);
+  const spawnParents = new Set(
+    store
+      .listReviewerSpawns()
+      .filter((sp) => sp.totalTokens != null)
+      .map((sp) => sp.taskSessionId),
+  );
+
+  for (const snap of snapshots) {
+    if (!bucketed.has(snap.sessionId)) {
+      // Legacy row (no bucket rows) — include whole iff snapshotAt >= cutoff
+      if (snap.snapshotAt >= cutoff) taskMap.set(snap.sessionId, snapshotToAccum(snap));
+      continue;
+    }
+    const w = sums.get(snap.sessionId);
+    if (w) {
+      // Has in-window bucket activity — use windowed sums
+      taskMap.set(snap.sessionId, windowedSnapshotToAccum(snap, w));
+    } else if (spawnParents.has(snap.sessionId)) {
+      // No in-window authoring but has a completed spawn — retain so satellite attaches
+      taskMap.set(snap.sessionId, zeroAuthoringAccum(snap));
+    }
+    // else: drop (no in-window activity, no spawn)
+  }
+}
+
+/** Populate taskMap with live rollup tasks (usageRollup path). */
+async function addLiveRollupTasks(
+  taskMap: Map<string, TaskAccum>,
+  rollup: SessionUsageRollup,
+  eligible: ReturnType<SessionStore["list"]>,
+  cutoff: number,
+  now: number,
+): Promise<void> {
+  await rollup.refresh(
+    eligible.map((s) => ({
+      id: s.id,
+      worktreePath: s.worktreePath,
+      claudeSessionId: s.claudeSessionId,
+    })),
+    now,
+  );
+  for (const s of eligible) {
+    if (taskMap.has(s.id)) continue; // persisted wins
+    const w = rollup.windowedAccum(s.id, cutoff);
+    if (!w) continue;
+    taskMap.set(s.id, {
+      sessionId: s.id,
+      desig: s.desig,
+      model: w.dominantModel ?? s.model ?? "unknown",
+      repoPath: s.repoPath,
+      authoringUnits: w.weightedUnits,
+      satelliteUnits: 0,
+      tokens: {
+        input: w.input,
+        output: w.output,
+        cacheRead: w.cacheRead,
+        cacheWrite: w.cacheWrite,
+      },
+      byModel: w.byModel,
+      authoringCacheReadUnits: w.cacheReadUnits,
+      satelliteCacheReadUnits: 0,
+    });
+  }
+}
+
 export async function buildUsageBreakdown(opts: {
   store: SessionStore;
   range: UsageRange;
@@ -265,32 +339,7 @@ export async function buildUsageBreakdown(opts: {
       taskMap.set(snap.sessionId, snapshotToAccum(snap));
     }
   } else {
-    // cutoff > 0: windowed via buckets; fall back to snapshotAt for legacy rows
-    const bucketed = store.bucketedSessionIds();
-    const sums = store.sumSessionUsageBucketsSince(cutoff);
-    const spawnParents = new Set(
-      store
-        .listReviewerSpawns()
-        .filter((sp) => sp.totalTokens != null)
-        .map((sp) => sp.taskSessionId),
-    );
-
-    for (const snap of snapshots) {
-      if (!bucketed.has(snap.sessionId)) {
-        // Legacy row (no bucket rows) — include whole iff snapshotAt >= cutoff
-        if (snap.snapshotAt >= cutoff) taskMap.set(snap.sessionId, snapshotToAccum(snap));
-        continue;
-      }
-      const w = sums.get(snap.sessionId);
-      if (w) {
-        // Has in-window bucket activity — use windowed sums
-        taskMap.set(snap.sessionId, windowedSnapshotToAccum(snap, w));
-      } else if (spawnParents.has(snap.sessionId)) {
-        // No in-window authoring but has a completed spawn — retain so satellite attaches
-        taskMap.set(snap.sessionId, zeroAuthoringAccum(snap));
-      }
-      // else: drop (no in-window activity, no spawn)
-    }
+    addWindowedPersistedTasks(taskMap, store, snapshots, cutoff);
   }
 
   // Live tasks — rollup path if provided, else re-parse fallback
@@ -298,36 +347,7 @@ export async function buildUsageBreakdown(opts: {
   const eligible = activeSessions.filter((s) => s.claudeSessionId && !isOperationalArchetype(s));
 
   if (opts.usageRollup) {
-    await opts.usageRollup.refresh(
-      eligible.map((s) => ({
-        id: s.id,
-        worktreePath: s.worktreePath,
-        claudeSessionId: s.claudeSessionId,
-      })),
-      now,
-    );
-    for (const s of eligible) {
-      if (taskMap.has(s.id)) continue; // persisted wins
-      const w = opts.usageRollup.windowedAccum(s.id, cutoff);
-      if (!w) continue;
-      taskMap.set(s.id, {
-        sessionId: s.id,
-        desig: s.desig,
-        model: w.dominantModel ?? s.model ?? "unknown",
-        repoPath: s.repoPath,
-        authoringUnits: w.weightedUnits,
-        satelliteUnits: 0,
-        tokens: {
-          input: w.input,
-          output: w.output,
-          cacheRead: w.cacheRead,
-          cacheWrite: w.cacheWrite,
-        },
-        byModel: w.byModel,
-        authoringCacheReadUnits: w.cacheReadUnits,
-        satelliteCacheReadUnits: 0,
-      });
-    }
+    await addLiveRollupTasks(taskMap, opts.usageRollup, eligible, cutoff, now);
   } else {
     // Back-compat: re-parse JSONL for each active session
     await Promise.all(

--- a/src/usage-breakdown.ts
+++ b/src/usage-breakdown.ts
@@ -6,9 +6,10 @@ import type {
   UsageRepoBreakdown,
   UsageTaskBreakdown,
   UsageTokens,
+  WindowedBucketSum,
 } from "./types";
 import { isOperationalArchetype } from "./usage-archetype";
-import { jsonlPathFor, sessionCost, dominantModel } from "./usage";
+import { jsonlPathFor, sessionCost, dominantModel, SessionUsageRollup } from "./usage";
 import { weightedUnits } from "./pricing";
 
 /** Internal accumulator — public fields + private cacheRead accumulators. */
@@ -50,6 +51,46 @@ function snapshotToAccum(snap: ReturnType<SessionStore["listSessionUsage"]>[numb
     },
     byModel: snap.byModel,
     authoringCacheReadUnits: snap.cacheReadUnits,
+    satelliteCacheReadUnits: 0,
+  };
+}
+
+/** Build a TaskAccum from a persisted snapshot + windowed bucket sums. */
+function windowedSnapshotToAccum(
+  snap: ReturnType<SessionStore["listSessionUsage"]>[number],
+  w: WindowedBucketSum,
+): TaskAccum {
+  return {
+    sessionId: snap.sessionId,
+    desig: snap.desig,
+    model: snap.model,
+    repoPath: snap.repoPath,
+    authoringUnits: w.weightedUnits,
+    satelliteUnits: 0,
+    tokens: {
+      input: w.input,
+      output: w.output,
+      cacheRead: w.cacheRead,
+      cacheWrite: w.cacheWrite,
+    },
+    byModel: w.byModel,
+    authoringCacheReadUnits: w.cacheReadUnits,
+    satelliteCacheReadUnits: 0,
+  };
+}
+
+/** Build a zero-authoring TaskAccum for a spawn-parent session with no in-window activity. */
+function zeroAuthoringAccum(snap: ReturnType<SessionStore["listSessionUsage"]>[number]): TaskAccum {
+  return {
+    sessionId: snap.sessionId,
+    desig: snap.desig,
+    model: snap.model,
+    repoPath: snap.repoPath,
+    authoringUnits: 0,
+    satelliteUnits: 0,
+    tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    byModel: {},
+    authoringCacheReadUnits: 0,
     satelliteCacheReadUnits: 0,
   };
 }
@@ -206,6 +247,7 @@ export async function buildUsageBreakdown(opts: {
   range: UsageRange;
   now: number;
   apiKey: boolean;
+  usageRollup?: SessionUsageRollup;
 }): Promise<UsageBreakdown> {
   const { store, range, now, apiKey } = opts;
 
@@ -216,22 +258,88 @@ export async function buildUsageBreakdown(opts: {
 
   // Persisted tasks
   const snapshots = store.listSessionUsage();
-  for (const snap of snapshots) {
-    if (snap.snapshotAt < cutoff) continue;
-    taskMap.set(snap.sessionId, snapshotToAccum(snap));
+
+  if (cutoff === 0) {
+    // "all" range: unchanged — aggregate rows are exact all-time totals
+    for (const snap of snapshots) {
+      taskMap.set(snap.sessionId, snapshotToAccum(snap));
+    }
+  } else {
+    // cutoff > 0: windowed via buckets; fall back to snapshotAt for legacy rows
+    const bucketed = store.bucketedSessionIds();
+    const sums = store.sumSessionUsageBucketsSince(cutoff);
+    const spawnParents = new Set(
+      store
+        .listReviewerSpawns()
+        .filter((sp) => sp.totalTokens != null)
+        .map((sp) => sp.taskSessionId),
+    );
+
+    for (const snap of snapshots) {
+      if (!bucketed.has(snap.sessionId)) {
+        // Legacy row (no bucket rows) — include whole iff snapshotAt >= cutoff
+        if (snap.snapshotAt >= cutoff) taskMap.set(snap.sessionId, snapshotToAccum(snap));
+        continue;
+      }
+      const w = sums.get(snap.sessionId);
+      if (w) {
+        // Has in-window bucket activity — use windowed sums
+        taskMap.set(snap.sessionId, windowedSnapshotToAccum(snap, w));
+      } else if (spawnParents.has(snap.sessionId)) {
+        // No in-window authoring but has a completed spawn — retain so satellite attaches
+        taskMap.set(snap.sessionId, zeroAuthoringAccum(snap));
+      }
+      // else: drop (no in-window activity, no spawn)
+    }
   }
 
-  // Live tasks — read concurrently; persisted wins on collision
+  // Live tasks — rollup path if provided, else re-parse fallback
   const activeSessions = store.list({ activeOnly: true });
-  await Promise.all(
-    activeSessions.map(async (s) => {
-      if (taskMap.has(s.id)) return; // persisted wins
-      const accum = await liveSessionToAccum(s, cutoff);
-      if (accum) taskMap.set(s.id, accum);
-    }),
-  );
+  const eligible = activeSessions.filter((s) => s.claudeSessionId && !isOperationalArchetype(s));
 
-  // Satellite spawns
+  if (opts.usageRollup) {
+    await opts.usageRollup.refresh(
+      eligible.map((s) => ({
+        id: s.id,
+        worktreePath: s.worktreePath,
+        claudeSessionId: s.claudeSessionId,
+      })),
+      now,
+    );
+    for (const s of eligible) {
+      if (taskMap.has(s.id)) continue; // persisted wins
+      const w = opts.usageRollup.windowedAccum(s.id, cutoff);
+      if (!w) continue;
+      taskMap.set(s.id, {
+        sessionId: s.id,
+        desig: s.desig,
+        model: w.dominantModel ?? s.model ?? "unknown",
+        repoPath: s.repoPath,
+        authoringUnits: w.weightedUnits,
+        satelliteUnits: 0,
+        tokens: {
+          input: w.input,
+          output: w.output,
+          cacheRead: w.cacheRead,
+          cacheWrite: w.cacheWrite,
+        },
+        byModel: w.byModel,
+        authoringCacheReadUnits: w.cacheReadUnits,
+        satelliteCacheReadUnits: 0,
+      });
+    }
+  } else {
+    // Back-compat: re-parse JSONL for each active session
+    await Promise.all(
+      activeSessions.map(async (s) => {
+        if (taskMap.has(s.id)) return; // persisted wins
+        const accum = await liveSessionToAccum(s, cutoff);
+        if (accum) taskMap.set(s.id, accum);
+      }),
+    );
+  }
+
+  // Satellite spawns — runs AFTER both persisted and live loops
   attributeSatellites(taskMap, store.listReviewerSpawns());
 
   // Group by repo, sort, produce public breakdowns

--- a/src/usage-snapshot.ts
+++ b/src/usage-snapshot.ts
@@ -1,7 +1,40 @@
 import type { Session } from "./types";
 import type { SessionStore } from "./store";
+import type { SessionUsageBucket } from "./types";
 import { isOperationalArchetype } from "./usage-archetype";
-import { jsonlPathFor, sessionCost, dominantModel } from "./usage";
+import { jsonlPathFor, foldSessionBuckets, dominantModelOf } from "./usage";
+import type { SessionBucket } from "./usage";
+
+/** Sum all buckets (incl. bucket 0) into a flat aggregate. */
+function sumBuckets(buckets: Map<number, SessionBucket>): {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  weightedUnits: number;
+  cacheReadUnits: number;
+  byModel: Record<string, number>;
+} {
+  let input = 0,
+    output = 0,
+    cacheRead = 0,
+    cacheWrite = 0,
+    weightedUnits = 0,
+    cacheReadUnits = 0;
+  const byModel: Record<string, number> = {};
+  for (const b of buckets.values()) {
+    input += b.input;
+    output += b.output;
+    cacheRead += b.cacheRead;
+    cacheWrite += b.cacheWrite;
+    weightedUnits += b.weightedUnits;
+    cacheReadUnits += b.cacheReadUnits;
+    for (const [model, units] of Object.entries(b.byModel)) {
+      byModel[model] = (byModel[model] ?? 0) + units;
+    }
+  }
+  return { input, output, cacheRead, cacheWrite, weightedUnits, cacheReadUnits, byModel };
+}
 
 /** Persist a session's authoring spend into the session_usage table.
  *  Never throws — the whole body is wrapped so archive teardown is never blocked.
@@ -21,37 +54,56 @@ export async function snapshotSessionUsage(
     if (!(await file.exists())) return "skipped";
     const text = await file.text();
 
-    // 3. Compute cost from the full transcript.
-    const sc = sessionCost(text.split("\n"));
+    // 3. Single-pass fold into per-hour buckets.
+    const fold = foldSessionBuckets(text.split("\n"));
 
     // 4. Skip empty transcripts.
-    if (sc.usage.messageCount === 0) return "skipped";
+    if (fold.messageCount === 0) return "skipped";
 
-    // 5. Resolve dominant model.
-    const model = dominantModel(sc.usage) ?? s.model ?? "unknown";
+    // 5. Aggregate from buckets (Σ incl. bucket 0).
+    const agg = sumBuckets(fold.buckets);
+    const total = agg.input + agg.output + agg.cacheRead + agg.cacheWrite;
 
-    // 6. Timestamp — use opts.asOf when provided (backfill), otherwise now.
+    // 6. Resolve dominant model.
+    const model = dominantModelOf(fold.rawByModel) ?? s.model ?? "unknown";
+
+    // 7. Timestamp — use opts.asOf when provided (backfill), otherwise now.
     const asOf = opts?.asOf ?? Date.now();
 
-    // 7. Upsert the snapshot row.
+    // 8. Upsert the parent session_usage row FIRST (FK parent must exist before buckets).
     store.upsertSessionUsage({
       sessionId: s.id,
       desig: s.desig,
       repoPath: s.repoPath,
       model,
-      input: sc.usage.input,
-      output: sc.usage.output,
-      cacheRead: sc.usage.cacheRead,
-      cacheWrite: sc.usage.cacheWrite,
-      total: sc.usage.total,
-      weightedUnits: sc.weightedUnits,
-      cacheReadUnits: sc.cacheReadUnits,
-      messageCount: sc.usage.messageCount,
-      byModel: sc.weightedByModel,
+      input: agg.input,
+      output: agg.output,
+      cacheRead: agg.cacheRead,
+      cacheWrite: agg.cacheWrite,
+      total,
+      weightedUnits: agg.weightedUnits,
+      cacheReadUnits: agg.cacheReadUnits,
+      messageCount: fold.messageCount,
+      byModel: agg.byModel,
       createdAt: s.createdAt,
       archivedAt: asOf,
       snapshotAt: asOf,
     });
+
+    // 9. Persist per-hour buckets (FK child — parent row must already exist).
+    const buckets: SessionUsageBucket[] = Array.from(fold.buckets.values()).map((b) => ({
+      sessionId: s.id,
+      bucketStart: b.bucketStart,
+      input: b.input,
+      output: b.output,
+      cacheRead: b.cacheRead,
+      cacheWrite: b.cacheWrite,
+      weightedUnits: b.weightedUnits,
+      cacheReadUnits: b.cacheReadUnits,
+      byModel: b.byModel,
+    }));
+    store.replaceSessionUsageBuckets(s.id, buckets);
+
     return "snapshotted";
   } catch (err) {
     console.warn("[usage-snapshot] error snapshotting session", s.id, err);

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -646,6 +646,10 @@ export class SessionUsageRollup {
     const byModel: Record<string, number> = {};
     const rawByModel: Record<string, number> = {};
 
+    // ts=0 ("timeless") records are always in-window; others are kept when ts >= cutoff.
+    // This dedups at ingest and filters here, whereas sessionCost filters before its dedup.
+    // The two only diverge for a duplicate requestId whose copies carry different ts — which
+    // cannot happen for a real transcript (one requestId = one API response = one ts).
     for (const rec of st.records) {
       if (rec.ts !== 0 && rec.ts < cutoff) continue;
       input += rec.input;

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -542,20 +542,19 @@ export class SessionUsageRollup {
         await this.appendChunk(st, path, size);
       }
 
-      // Prune records older than cutoff (ts=0 records are never pruned)
-      const before = st.records.length;
-      if (before > 0 && st.records[0]!.ts > 0 && st.records[0]!.ts < cutoff) {
-        const kept: PerRecord[] = [];
-        for (const rec of st.records) {
-          if (rec.ts === 0 || rec.ts >= cutoff) {
-            kept.push(rec);
-          } else {
-            // Remove requestId from seen so it can be re-ingested if needed
-            if (rec.requestId) st.seen.delete(rec.requestId);
-          }
+      // Prune records older than cutoff (ts=0 records are never pruned).
+      // Walk every record — a ts=0 entry in slot 0 must not short-circuit the walk.
+      let pruned = false;
+      const kept: PerRecord[] = [];
+      for (const rec of st.records) {
+        if (rec.ts === 0 || rec.ts >= cutoff) {
+          kept.push(rec);
+        } else {
+          if (rec.requestId) st.seen.delete(rec.requestId);
+          pruned = true;
         }
-        st.records = kept;
       }
+      if (pruned) st.records = kept;
     }
   }
 

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -216,15 +216,12 @@ export function sessionCost(lines: Iterable<string>, sinceMs?: number): SessionC
   };
 }
 
-/** The real model that produced the most tokens in this usage, or null when none was named.
- *  A reviewer session is effectively one model, so this resolves its TRUE model from the
- *  transcript — used to backfill the spawn row whose configured model was "auto" (null).
- *  Skips parseLine's "unknown" sentinel (an assistant record with no `model` field) so the
- *  sentinel can never overwrite a recorded model; "unknown"-only / empty usage → null. */
-export function dominantModel(u: SessionUsage): string | null {
+/** Pick the key with the maximum value from a byModel map, skipping the "unknown" sentinel.
+ *  Returns null if the map is empty or contains only "unknown". */
+export function dominantModelOf(byModel: Record<string, number>): string | null {
   let best: string | null = null;
   let bestTokens = -1;
-  for (const [model, tokens] of Object.entries(u.byModel)) {
+  for (const [model, tokens] of Object.entries(byModel)) {
     if (model === "unknown") continue;
     if (tokens > bestTokens) {
       bestTokens = tokens;
@@ -232,6 +229,15 @@ export function dominantModel(u: SessionUsage): string | null {
     }
   }
   return best;
+}
+
+/** The real model that produced the most tokens in this usage, or null when none was named.
+ *  A reviewer session is effectively one model, so this resolves its TRUE model from the
+ *  transcript — used to backfill the spawn row whose configured model was "auto" (null).
+ *  Skips parseLine's "unknown" sentinel (an assistant record with no `model` field) so the
+ *  sentinel can never overwrite a recorded model; "unknown"-only / empty usage → null. */
+export function dominantModel(u: SessionUsage): string | null {
+  return dominantModelOf(u.byModel);
 }
 
 /** Read a session's JSONL transcript and accumulate its token totals. Returns null if the
@@ -331,5 +337,341 @@ export class AccountUsageIndex {
       for (const r of st.records) if (r.ts >= startMs && r.ts <= endMs) sum += r.units;
     }
     return sum;
+  }
+}
+
+// ── Session bucket fold ───────────────────────────────────────────────────────
+
+/** floor-hour: truncate ms-epoch to the start of its UTC hour. ts=0 → 0. */
+function floorHour(ts: number): number {
+  return ts - (ts % 3_600_000);
+}
+
+export interface SessionBucket {
+  bucketStart: number; // ms epoch, floorHour(ts); 0 = timeless
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number; // cacheWrite5m + cacheWrite1h
+  weightedUnits: number;
+  cacheReadUnits: number;
+  byModel: Record<string, number>; // weighted units per model
+}
+
+export interface SessionFold {
+  buckets: Map<number, SessionBucket>; // keyed by bucketStart
+  rawByModel: Record<string, number>; // raw tokens per model, session-wide
+  messageCount: number; // accepted (post-dedupe) record count
+}
+
+/** Single-pass fold of JSONL lines into per-hour buckets, deduping by requestId. */
+export function foldSessionBuckets(lines: Iterable<string>): SessionFold {
+  const buckets = new Map<number, SessionBucket>();
+  const rawByModel: Record<string, number> = {};
+  let messageCount = 0;
+  const seen = new Set<string>();
+
+  for (const line of lines) {
+    const r = parseLine(line);
+    if (!r) continue;
+    if (r.requestId) {
+      if (seen.has(r.requestId)) continue;
+      seen.add(r.requestId);
+    }
+    messageCount += 1;
+
+    const bucketStart = floorHour(r.ts);
+    let b = buckets.get(bucketStart);
+    if (!b) {
+      b = {
+        bucketStart,
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        weightedUnits: 0,
+        cacheReadUnits: 0,
+        byModel: {},
+      };
+      buckets.set(bucketStart, b);
+    }
+
+    b.input += r.input;
+    b.output += r.output;
+    b.cacheRead += r.cacheRead;
+    b.cacheWrite += r.cacheWrite5m + r.cacheWrite1h;
+
+    const wu = weightedUnits(r, r.model);
+    b.weightedUnits += wu;
+    b.byModel[r.model] = (b.byModel[r.model] ?? 0) + wu;
+
+    const cru = weightedUnits(
+      { input: 0, output: 0, cacheRead: r.cacheRead, cacheWrite5m: 0, cacheWrite1h: 0 },
+      r.model,
+    );
+    b.cacheReadUnits += cru;
+
+    const rawTokens = r.input + r.output + r.cacheRead + r.cacheWrite5m + r.cacheWrite1h;
+    rawByModel[r.model] = (rawByModel[r.model] ?? 0) + rawTokens;
+  }
+
+  return { buckets, rawByModel, messageCount };
+}
+
+// ── SessionUsageRollup ────────────────────────────────────────────────────────
+
+export interface RollupWindow {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  weightedUnits: number;
+  cacheReadUnits: number;
+  byModel: Record<string, number>; // weighted units per model (in-window)
+  dominantModel: string | null; // from in-window raw tokens (cutoff>0) or session-wide (cutoff===0)
+  messageCount: number;
+}
+
+export interface RollupSession {
+  id: string;
+  worktreePath: string;
+  claudeSessionId: string | null;
+}
+
+interface PerRecord {
+  ts: number;
+  requestId: string | null;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number; // 5m + 1h combined
+  weighted: number; // weighted units
+  cacheReadUnits: number;
+  model: string;
+  rawTokens: number; // for byModel raw tracking
+}
+
+interface AggTotals {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  weightedUnits: number;
+  cacheReadUnits: number;
+  messageCount: number;
+  weightedByModel: Record<string, number>; // weighted units per model
+  rawByModel: Record<string, number>; // raw tokens per model
+}
+
+interface SessionFileState {
+  size: number;
+  offset: number;
+  leftover: string;
+  seen: Set<string>;
+  records: PerRecord[];
+  agg: AggTotals;
+}
+
+function emptyAgg(): AggTotals {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    weightedUnits: 0,
+    cacheReadUnits: 0,
+    messageCount: 0,
+    weightedByModel: {},
+    rawByModel: {},
+  };
+}
+
+const THIRTY_DAYS_MS = 30 * 86_400_000;
+const PRUNE_SLACK_MS = 60_000;
+
+/**
+ * Per-session incremental rollup. Tracks session JSONL files, ingesting only appended bytes.
+ * Maintains a per-record array (pruned to ~30d) plus an unpruned running aggregate.
+ */
+export class SessionUsageRollup {
+  private sessions = new Map<string, SessionFileState>();
+  private inflight: Promise<void> | null = null;
+
+  /** Resolve the JSONL path for a session. Overridable for tests. */
+  protected pathFor(worktreePath: string, claudeSessionId: string): string {
+    return jsonlPathFor(worktreePath, claudeSessionId);
+  }
+
+  /** Rescan sessions, ingesting newly-appended lines. Concurrent calls share one in-flight promise. */
+  refresh(sessions: RollupSession[], now: number): Promise<void> {
+    if (this.inflight) return this.inflight;
+    this.inflight = this.doRefresh(sessions, now).finally(() => {
+      this.inflight = null;
+    });
+    return this.inflight;
+  }
+
+  private async doRefresh(sessions: RollupSession[], now: number): Promise<void> {
+    // Drop sessions not in the new list
+    const liveIds = new Set(sessions.map((s) => s.id));
+    for (const key of this.sessions.keys()) {
+      if (!liveIds.has(key)) this.sessions.delete(key);
+    }
+
+    const cutoff = now - THIRTY_DAYS_MS - PRUNE_SLACK_MS;
+
+    for (const sess of sessions) {
+      if (!sess.claudeSessionId) continue;
+      const path = this.pathFor(sess.worktreePath, sess.claudeSessionId);
+
+      let size: number;
+      try {
+        size = statSync(path).size;
+      } catch {
+        continue;
+      }
+
+      let st = this.sessions.get(sess.id);
+      if (!st || size < st.offset) {
+        // File truncated/rotated — reset state
+        st = { size, offset: 0, leftover: "", seen: new Set(), records: [], agg: emptyAgg() };
+        this.sessions.set(sess.id, st);
+      }
+
+      if (size > st.offset) {
+        await this.appendChunk(st, path, size);
+      }
+
+      // Prune records older than cutoff (ts=0 records are never pruned)
+      const before = st.records.length;
+      if (before > 0 && st.records[0]!.ts > 0 && st.records[0]!.ts < cutoff) {
+        const kept: PerRecord[] = [];
+        for (const rec of st.records) {
+          if (rec.ts === 0 || rec.ts >= cutoff) {
+            kept.push(rec);
+          } else {
+            // Remove requestId from seen so it can be re-ingested if needed
+            if (rec.requestId) st.seen.delete(rec.requestId);
+          }
+        }
+        st.records = kept;
+      }
+    }
+  }
+
+  private async appendChunk(st: SessionFileState, path: string, size: number): Promise<void> {
+    const chunk = await Bun.file(path).slice(st.offset, size).text();
+    st.offset = size;
+    st.size = size;
+    const parts = (st.leftover + chunk).split("\n");
+    st.leftover = parts.pop() ?? "";
+    for (const line of parts) {
+      const r = parseLine(line);
+      if (!r) continue;
+      // Dedupe by requestId
+      if (r.requestId) {
+        if (st.seen.has(r.requestId)) continue;
+        st.seen.add(r.requestId);
+      }
+
+      const wu = weightedUnits(r, r.model);
+      const cru = weightedUnits(
+        { input: 0, output: 0, cacheRead: r.cacheRead, cacheWrite5m: 0, cacheWrite1h: 0 },
+        r.model,
+      );
+      const cw = r.cacheWrite5m + r.cacheWrite1h;
+      const rawTokens = r.input + r.output + r.cacheRead + r.cacheWrite5m + r.cacheWrite1h;
+
+      const rec: PerRecord = {
+        ts: r.ts,
+        requestId: r.requestId,
+        input: r.input,
+        output: r.output,
+        cacheRead: r.cacheRead,
+        cacheWrite: cw,
+        weighted: wu,
+        cacheReadUnits: cru,
+        model: r.model,
+        rawTokens,
+      };
+      st.records.push(rec);
+
+      // Update running aggregate (never pruned)
+      const agg = st.agg;
+      agg.input += r.input;
+      agg.output += r.output;
+      agg.cacheRead += r.cacheRead;
+      agg.cacheWrite += cw;
+      agg.weightedUnits += wu;
+      agg.cacheReadUnits += cru;
+      agg.messageCount += 1;
+      agg.weightedByModel[r.model] = (agg.weightedByModel[r.model] ?? 0) + wu;
+      agg.rawByModel[r.model] = (agg.rawByModel[r.model] ?? 0) + rawTokens;
+    }
+  }
+
+  /**
+   * Compute the RollupWindow for a session.
+   * cutoff===0: return the unpruned running aggregate.
+   * cutoff>0: sum per-record entries where ts===0 || ts>=cutoff.
+   * Returns null if the session is unknown or the windowed messageCount===0.
+   */
+  windowedAccum(sessionId: string, cutoff: number): RollupWindow | null {
+    const st = this.sessions.get(sessionId);
+    if (!st) return null;
+
+    if (cutoff === 0) {
+      const agg = st.agg;
+      if (agg.messageCount === 0) return null;
+      return {
+        input: agg.input,
+        output: agg.output,
+        cacheRead: agg.cacheRead,
+        cacheWrite: agg.cacheWrite,
+        weightedUnits: agg.weightedUnits,
+        cacheReadUnits: agg.cacheReadUnits,
+        byModel: { ...agg.weightedByModel },
+        dominantModel: dominantModelOf(agg.rawByModel),
+        messageCount: agg.messageCount,
+      };
+    }
+
+    // cutoff > 0: sum in-window records
+    let input = 0,
+      output = 0,
+      cacheRead = 0,
+      cacheWrite = 0,
+      wu = 0,
+      cru = 0,
+      messageCount = 0;
+    const byModel: Record<string, number> = {};
+    const rawByModel: Record<string, number> = {};
+
+    for (const rec of st.records) {
+      if (rec.ts !== 0 && rec.ts < cutoff) continue;
+      input += rec.input;
+      output += rec.output;
+      cacheRead += rec.cacheRead;
+      cacheWrite += rec.cacheWrite;
+      wu += rec.weighted;
+      cru += rec.cacheReadUnits;
+      messageCount += 1;
+      byModel[rec.model] = (byModel[rec.model] ?? 0) + rec.weighted;
+      rawByModel[rec.model] = (rawByModel[rec.model] ?? 0) + rec.rawTokens;
+    }
+
+    if (messageCount === 0) return null;
+
+    return {
+      input,
+      output,
+      cacheRead,
+      cacheWrite,
+      weightedUnits: wu,
+      cacheReadUnits: cru,
+      byModel,
+      dominantModel: dominantModelOf(rawByModel),
+      messageCount,
+    };
   }
 }

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -511,6 +511,48 @@ export class SessionUsageRollup {
     return this.inflight;
   }
 
+  /** Prune records older than cutoff from st. ts=0 records are never pruned. */
+  private pruneSession(st: SessionFileState, cutoff: number): void {
+    // Walk every record — a ts=0 entry in slot 0 must not short-circuit the walk.
+    let pruned = false;
+    const kept: PerRecord[] = [];
+    for (const rec of st.records) {
+      if (rec.ts === 0 || rec.ts >= cutoff) {
+        kept.push(rec);
+      } else {
+        if (rec.requestId) st.seen.delete(rec.requestId);
+        pruned = true;
+      }
+    }
+    if (pruned) st.records = kept;
+  }
+
+  /** Ingest one session file: stat, reset if truncated, appendChunk if grown, then prune. */
+  private async ingestSession(sess: RollupSession, cutoff: number): Promise<void> {
+    if (!sess.claudeSessionId) return;
+    const path = this.pathFor(sess.worktreePath, sess.claudeSessionId);
+
+    let size: number;
+    try {
+      size = statSync(path).size;
+    } catch {
+      return;
+    }
+
+    let st = this.sessions.get(sess.id);
+    if (!st || size < st.offset) {
+      // File truncated/rotated — reset state
+      st = { size, offset: 0, leftover: "", seen: new Set(), records: [], agg: emptyAgg() };
+      this.sessions.set(sess.id, st);
+    }
+
+    if (size > st.offset) {
+      await this.appendChunk(st, path, size);
+    }
+
+    this.pruneSession(st, cutoff);
+  }
+
   private async doRefresh(sessions: RollupSession[], now: number): Promise<void> {
     // Drop sessions not in the new list
     const liveIds = new Set(sessions.map((s) => s.id));
@@ -521,40 +563,7 @@ export class SessionUsageRollup {
     const cutoff = now - THIRTY_DAYS_MS - PRUNE_SLACK_MS;
 
     for (const sess of sessions) {
-      if (!sess.claudeSessionId) continue;
-      const path = this.pathFor(sess.worktreePath, sess.claudeSessionId);
-
-      let size: number;
-      try {
-        size = statSync(path).size;
-      } catch {
-        continue;
-      }
-
-      let st = this.sessions.get(sess.id);
-      if (!st || size < st.offset) {
-        // File truncated/rotated — reset state
-        st = { size, offset: 0, leftover: "", seen: new Set(), records: [], agg: emptyAgg() };
-        this.sessions.set(sess.id, st);
-      }
-
-      if (size > st.offset) {
-        await this.appendChunk(st, path, size);
-      }
-
-      // Prune records older than cutoff (ts=0 records are never pruned).
-      // Walk every record — a ts=0 entry in slot 0 must not short-circuit the walk.
-      let pruned = false;
-      const kept: PerRecord[] = [];
-      for (const rec of st.records) {
-        if (rec.ts === 0 || rec.ts >= cutoff) {
-          kept.push(rec);
-        } else {
-          if (rec.requestId) st.seen.delete(rec.requestId);
-          pruned = true;
-        }
-      }
-      if (pruned) st.records = kept;
+      await this.ingestSession(sess, cutoff);
     }
   }
 

--- a/test/server-usage-breakdown.test.ts
+++ b/test/server-usage-breakdown.test.ts
@@ -165,7 +165,7 @@ test("GET /api/usage/breakdown with usageRollup: active session's units appear i
         },
       },
     });
-    Bun.write(join(rollupDir, `${claudeSessionId}.jsonl`), line1 + "\n");
+    await Bun.write(join(rollupDir, `${claudeSessionId}.jsonl`), line1 + "\n");
 
     const rollup = new TestRollup(rollupDir);
     const deps: AppDeps = {

--- a/test/server-usage-breakdown.test.ts
+++ b/test/server-usage-breakdown.test.ts
@@ -1,4 +1,7 @@
 import { test, expect } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { makeApp, type AppDeps } from "../src/server";
 import { SessionStore } from "../src/store";
 import { EventHub } from "../src/events";
@@ -9,6 +12,7 @@ import {
   USAGE_TOKENS_KEYS,
 } from "../src/types";
 import type { SessionUsageSnapshot } from "../src/types";
+import { SessionUsageRollup } from "../src/usage";
 
 function harness(): { app: ReturnType<typeof makeApp>; store: SessionStore } {
   const store = new SessionStore(":memory:");
@@ -95,4 +99,97 @@ test("GET /api/usage/breakdown?range=bogus → 400", async () => {
   expect(res.status).toBe(400);
   const body = await res.json();
   expect(body.error).toBe("invalid range");
+});
+
+// ── deps.usageRollup forwarded into buildUsageBreakdown ───────────────────────
+
+// TestRollup overrides pathFor so the fixture lives in a temp dir keyed by claudeSessionId.
+class TestRollup extends SessionUsageRollup {
+  constructor(private dir: string) {
+    super();
+  }
+  protected override pathFor(_worktreePath: string, claudeSessionId: string): string {
+    return join(this.dir, `${claudeSessionId}.jsonl`);
+  }
+}
+
+test("GET /api/usage/breakdown with usageRollup: active session's units appear in response", async () => {
+  const rollupDir = join(
+    tmpdir(),
+    `srv-breakdown-rollup-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(rollupDir, { recursive: true });
+
+  try {
+    const store = new SessionStore(":memory:");
+    const claudeSessionId = "srv-rollup-csid";
+    const worktreePath = "/wt/srv-rollup-test";
+
+    // Create an active (non-archived) session in the store.
+    const sess = store.create({
+      name: "TASK-99",
+      prompt: "test",
+      repoPath: "/repos/srv-rollup",
+      baseBranch: "main",
+      branch: "shepherd/task-99",
+      worktreePath,
+      isolated: true,
+      herdrSession: "default",
+      herdrAgentId: "a1",
+      sandboxApplied: null,
+      sandboxDegraded: false,
+      egressApplied: false,
+      egressDegraded: false,
+      research: false,
+    });
+    // Patch claudeSessionId directly so the rollup can locate the JSONL.
+    // @ts-expect-error accessing internal db for test setup
+    store.db.run(`UPDATE sessions SET claudeSessionId = ? WHERE id = ?`, [
+      claudeSessionId,
+      sess.id,
+    ]);
+
+    // Write a JSONL fixture with two usage records inside the 24h window.
+    const tsNow = Date.now();
+    const line1 = JSON.stringify({
+      type: "assistant",
+      timestamp: new Date(tsNow - 3_600_000).toISOString(),
+      requestId: "srv-r1",
+      message: {
+        model: "claude-opus-4-8",
+        usage: {
+          input_tokens: 200,
+          output_tokens: 80,
+          cache_read_input_tokens: 0,
+          cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 0 },
+        },
+      },
+    });
+    Bun.write(join(rollupDir, `${claudeSessionId}.jsonl`), line1 + "\n");
+
+    const rollup = new TestRollup(rollupDir);
+    const deps: AppDeps = {
+      store,
+      service: {} as any,
+      events: new EventHub(),
+      usageLimits: { limits: () => ({}) } as any,
+      usageRollup: rollup,
+    };
+    const app = makeApp(deps);
+
+    const res = await app.fetch(new Request("http://x/api/usage/breakdown?range=24h"));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    const tasks: any[] = body.repos.flatMap((r: any) => r.tasks);
+    const task = tasks.find((t: any) => t.sessionId === sess.id);
+
+    expect(task).toBeDefined();
+    // Rollup ingested the fixture: active session must carry non-zero authoring units.
+    expect(task!.authoringUnits).toBeGreaterThan(0);
+    expect(task!.tokens.input).toBe(200);
+    expect(task!.tokens.output).toBe(80);
+  } finally {
+    rmSync(rollupDir, { recursive: true, force: true });
+  }
 });

--- a/test/store-session-usage.test.ts
+++ b/test/store-session-usage.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { SessionStore } from "../src/store";
-import type { SessionUsageSnapshot } from "../src/types";
+import type { SessionUsageBucket, SessionUsageSnapshot } from "../src/types";
 
 const snap = (over: Partial<SessionUsageSnapshot> = {}): SessionUsageSnapshot => ({
   sessionId: "sess-1",
@@ -62,4 +62,169 @@ test("session_usage: upserting same sessionId twice yields one row with second v
 test("session_usage: listSessionUsage on empty table returns []", () => {
   const s = new SessionStore(":memory:");
   expect(s.listSessionUsage()).toEqual([]);
+});
+
+// ── session_usage_bucket tests ────────────────────────────────────────────────
+
+/** Helper: minimal bucket fixture. */
+const bucket = (over: Partial<SessionUsageBucket> = {}): SessionUsageBucket => ({
+  sessionId: "sess-1",
+  bucketStart: 3_600_000,
+  input: 100,
+  output: 50,
+  cacheRead: 20,
+  cacheWrite: 5,
+  weightedUnits: 1.5,
+  cacheReadUnits: 0.1,
+  byModel: { "claude-sonnet-4-5": 1.5 },
+  ...over,
+});
+
+test("session_usage_bucket: replaceSessionUsageBuckets inserts and round-trips rows", () => {
+  const s = new SessionStore(":memory:");
+  // Parent row required for FK
+  s.upsertSessionUsage(snap());
+  s.replaceSessionUsageBuckets("sess-1", [
+    bucket({ bucketStart: 0 }),
+    bucket({ bucketStart: 3_600_000, input: 200 }),
+  ]);
+  const ids = s.bucketedSessionIds();
+  expect(ids.has("sess-1")).toBe(true);
+  expect(ids.size).toBe(1);
+});
+
+test("session_usage_bucket: replaceSessionUsageBuckets is idempotent — no PK error, old rows replaced", () => {
+  const s = new SessionStore(":memory:");
+  s.upsertSessionUsage(snap());
+  s.replaceSessionUsageBuckets("sess-1", [bucket({ input: 100 })]);
+  // Re-call with updated data for the same bucketStart — must not throw PK error
+  s.replaceSessionUsageBuckets("sess-1", [bucket({ input: 999 })]);
+  // Only the new data should survive
+  const sums = s.sumSessionUsageBucketsSince(0);
+  expect(sums.get("sess-1")!.input).toBe(999);
+});
+
+test("session_usage_bucket: empty buckets array clears session rows", () => {
+  const s = new SessionStore(":memory:");
+  s.upsertSessionUsage(snap());
+  s.replaceSessionUsageBuckets("sess-1", [bucket()]);
+  expect(s.bucketedSessionIds().has("sess-1")).toBe(true);
+  s.replaceSessionUsageBuckets("sess-1", []);
+  expect(s.bucketedSessionIds().has("sess-1")).toBe(false);
+});
+
+test("session_usage_bucket: FK CASCADE — deleting session_usage parent removes buckets", () => {
+  const s = new SessionStore(":memory:");
+  // Must create parent before inserting buckets
+  s.upsertSessionUsage(snap());
+  s.replaceSessionUsageBuckets("sess-1", [bucket(), bucket({ bucketStart: 7_200_000 })]);
+  expect(s.bucketedSessionIds().has("sess-1")).toBe(true);
+  // Delete parent — CASCADE should wipe child rows
+  (s as unknown as { db: import("bun:sqlite").Database }).db.run(
+    `DELETE FROM session_usage WHERE sessionId = ?`,
+    ["sess-1"],
+  );
+  expect(s.bucketedSessionIds().has("sess-1")).toBe(false);
+});
+
+test("session_usage_bucket: sumSessionUsageBucketsSince includes bucket 0 and buckets >= floorHour(cutoff)", () => {
+  const s = new SessionStore(":memory:");
+  s.upsertSessionUsage(snap());
+
+  const H = 3_600_000; // one hour in ms
+  // hour 1 = 1H, hour 2 = 2H, hour 3 = 3H; plus timeless bucket 0
+  s.replaceSessionUsageBuckets("sess-1", [
+    bucket({ bucketStart: 0, input: 10, weightedUnits: 0.1 }),
+    bucket({ bucketStart: 1 * H, input: 20, weightedUnits: 0.2 }),
+    bucket({ bucketStart: 2 * H, input: 30, weightedUnits: 0.3 }),
+    bucket({ bucketStart: 3 * H, input: 40, weightedUnits: 0.4 }),
+  ]);
+
+  // cutoff at 2H + 1ms → floorHour = 2H → includes bucket 0 + bucket 2H + bucket 3H
+  const cutoff = 2 * H + 1;
+  const sums = s.sumSessionUsageBucketsSince(cutoff);
+  const w = sums.get("sess-1")!;
+  // bucket 0 (10) + bucket 2H (30) + bucket 3H (40) = 80; bucket 1H excluded
+  expect(w.input).toBe(80);
+  expect(w.weightedUnits).toBeCloseTo(0.8, 10);
+});
+
+test("session_usage_bucket: sumSessionUsageBucketsSince merges byModel across rows", () => {
+  const s = new SessionStore(":memory:");
+  s.upsertSessionUsage(snap());
+
+  const H = 3_600_000;
+  s.replaceSessionUsageBuckets("sess-1", [
+    bucket({ bucketStart: 0, byModel: { sonnet: 1.0, opus: 0.5 } }),
+    bucket({ bucketStart: 2 * H, byModel: { sonnet: 2.0 } }),
+    bucket({ bucketStart: 3 * H, byModel: { haiku: 0.3 } }),
+  ]);
+
+  const sums = s.sumSessionUsageBucketsSince(2 * H);
+  const bm = sums.get("sess-1")!.byModel;
+  expect(bm["sonnet"]).toBeCloseTo(3.0, 10); // 1.0 + 2.0
+  expect(bm["opus"]).toBeCloseTo(0.5, 10); // only in bucket 0
+  expect(bm["haiku"]).toBeCloseTo(0.3, 10); // bucket 3H
+});
+
+test("session_usage_bucket: sumSessionUsageBucketsSince sums multiple sessions independently", () => {
+  const s = new SessionStore(":memory:");
+  s.upsertSessionUsage(snap({ sessionId: "sess-1" }));
+  s.upsertSessionUsage(snap({ sessionId: "sess-2" }));
+
+  s.replaceSessionUsageBuckets("sess-1", [bucket({ sessionId: "sess-1", input: 100 })]);
+  s.replaceSessionUsageBuckets("sess-2", [bucket({ sessionId: "sess-2", input: 200 })]);
+
+  const sums = s.sumSessionUsageBucketsSince(0);
+  expect(sums.get("sess-1")!.input).toBe(100);
+  expect(sums.get("sess-2")!.input).toBe(200);
+  expect(sums.size).toBe(2);
+});
+
+test("session_usage_bucket: sumSessionUsageBucketsSince excludes buckets before floorHour(cutoff)", () => {
+  const s = new SessionStore(":memory:");
+  s.upsertSessionUsage(snap());
+
+  const H = 3_600_000;
+  s.replaceSessionUsageBuckets("sess-1", [
+    bucket({ bucketStart: 1 * H, input: 10 }),
+    bucket({ bucketStart: 2 * H, input: 20 }),
+  ]);
+
+  // cutoff = 2H → only bucket 2H included; bucket 1H is excluded
+  const sums = s.sumSessionUsageBucketsSince(2 * H);
+  expect(sums.get("sess-1")!.input).toBe(20);
+});
+
+test("session_usage_bucket: sumSessionUsageBucketsSince cutoff=0 => floorHour=0 => only bucket 0 matches bucketStart=0", () => {
+  const s = new SessionStore(":memory:");
+  s.upsertSessionUsage(snap());
+
+  const H = 3_600_000;
+  s.replaceSessionUsageBuckets("sess-1", [
+    bucket({ bucketStart: 0, input: 5 }),
+    bucket({ bucketStart: 1 * H, input: 50 }),
+  ]);
+
+  // cutoff=0 → floorHour=0 → WHERE bucketStart=0 OR bucketStart>=0 → ALL rows
+  const sums = s.sumSessionUsageBucketsSince(0);
+  expect(sums.get("sess-1")!.input).toBe(55);
+});
+
+test("session_usage_bucket: bucketedSessionIds returns distinct set", () => {
+  const s = new SessionStore(":memory:");
+  s.upsertSessionUsage(snap({ sessionId: "sess-1" }));
+  s.upsertSessionUsage(snap({ sessionId: "sess-2" }));
+
+  s.replaceSessionUsageBuckets("sess-1", [
+    bucket({ sessionId: "sess-1", bucketStart: 0 }),
+    bucket({ sessionId: "sess-1", bucketStart: 3_600_000 }),
+  ]);
+  s.replaceSessionUsageBuckets("sess-2", [bucket({ sessionId: "sess-2" })]);
+
+  const ids = s.bucketedSessionIds();
+  expect(ids.size).toBe(2);
+  expect(ids.has("sess-1")).toBe(true);
+  expect(ids.has("sess-2")).toBe(true);
+  expect(ids.has("sess-3")).toBe(false);
 });

--- a/test/usage-breakdown.test.ts
+++ b/test/usage-breakdown.test.ts
@@ -5,8 +5,9 @@ import { tmpdir } from "node:os";
 import { SessionStore } from "../src/store";
 import { config } from "../src/config";
 import { buildUsageBreakdown } from "../src/usage-breakdown";
-import { jsonlPathFor } from "../src/usage";
+import { jsonlPathFor, SessionUsageRollup } from "../src/usage";
 import { weightedUnits } from "../src/pricing";
+import type { SessionUsageBucket } from "../src/types";
 
 const NOW = 1_750_000_000_000; // fixed epoch ms for tests
 const H24 = 86_400_000;
@@ -681,4 +682,456 @@ test("apiKey gate: dollars non-null and equals total units when true, null when 
   for (const repo of bdOff.repos) {
     expect(repo.dollars).toBeNull();
   }
+});
+
+// ── Task 4: windowed bucket + rollup tests ────────────────────────────────────
+
+// TestRollup subclass that uses worktreePath as directory directly (mirrors usage.test.ts pattern).
+class TestRollup extends SessionUsageRollup {
+  constructor(private dir: string) {
+    super();
+  }
+  protected override pathFor(worktreePath: string, claudeSessionId: string): string {
+    return join(this.dir, `${claudeSessionId}.jsonl`);
+  }
+}
+
+/** Write a JSONL file to a TestRollup-compatible location. */
+function writeRollupJsonl(dir: string, claudeSessionId: string, lines: string[]): void {
+  mkdirSync(dir, { recursive: true });
+  Bun.write(join(dir, `${claudeSessionId}.jsonl`), lines.join("\n") + "\n");
+}
+
+/** Helper to create and wire a session in the store, patching claudeSessionId via DB. */
+function createLiveSession(
+  store: SessionStore,
+  opts: {
+    sessionId?: string; // optional: use a fixed id to make test deterministic
+    worktreePath: string;
+    claudeSessionId: string;
+    repoPath: string;
+    desig?: string;
+  },
+): string {
+  const s = store.create({
+    name: opts.desig ?? "test-session",
+    prompt: "test",
+    repoPath: opts.repoPath,
+    baseBranch: "main",
+    branch: "shepherd/test",
+    worktreePath: opts.worktreePath,
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "t1",
+    sandboxApplied: null,
+    sandboxDegraded: false,
+    egressApplied: false,
+    egressDegraded: false,
+    research: false,
+  });
+  // @ts-expect-error accessing internal db for test setup
+  store.db.run(`UPDATE sessions SET claudeSessionId = ? WHERE id = ?`, [
+    opts.claudeSessionId,
+    s.id,
+  ]);
+  return s.id;
+}
+
+/** Insert a session_usage row + its bucket rows. */
+function insertSnapshotWithBuckets(
+  store: SessionStore,
+  snap: Parameters<typeof makeSnap>[0],
+  buckets: Omit<SessionUsageBucket, "sessionId">[],
+): void {
+  const snapRow = makeSnap(snap);
+  store.upsertSessionUsage(snapRow);
+  store.replaceSessionUsageBuckets(
+    snap.sessionId,
+    buckets.map((b) => ({ ...b, sessionId: snap.sessionId })),
+  );
+}
+
+// ── Test 1: persisted windowed sub-session ────────────────────────────────────
+
+test("persisted windowed sub-session: 24h returns only recent hour; 30d/all returns full total", async () => {
+  const store = new SessionStore(":memory:");
+  const model = "claude-opus-4-8";
+
+  // Two hours of activity
+  const oldHour = NOW - 48 * 60 * 60 * 1000; // 48h ago (outside 24h, inside 30d)
+  const oldHourFloor = oldHour - (oldHour % 3_600_000);
+  const recentHour = NOW - 1 * 60 * 60 * 1000; // 1h ago (inside 24h)
+  const recentHourFloor = recentHour - (recentHour % 3_600_000);
+
+  const oldWu = weightedUnits(
+    { input: 500, output: 200, cacheRead: 0, cacheWrite5m: 0, cacheWrite1h: 0 },
+    model,
+  );
+  const recentWu = weightedUnits(
+    { input: 300, output: 100, cacheRead: 0, cacheWrite5m: 0, cacheWrite1h: 0 },
+    model,
+  );
+  const totalWu = weightedUnits(
+    { input: 800, output: 300, cacheRead: 0, cacheWrite5m: 0, cacheWrite1h: 0 },
+    model,
+  );
+
+  insertSnapshotWithBuckets(
+    store,
+    {
+      sessionId: "bucketed-s1",
+      desig: "TASK-01",
+      repoPath: "/repos/foo",
+      model,
+      input: 800,
+      output: 300,
+      weightedUnits: totalWu,
+      cacheReadUnits: 0,
+      snapshotAt: NOW - 500, // archived recently
+    },
+    [
+      {
+        bucketStart: oldHourFloor,
+        input: 500,
+        output: 200,
+        cacheRead: 0,
+        cacheWrite: 0,
+        weightedUnits: oldWu,
+        cacheReadUnits: 0,
+        byModel: { [model]: oldWu },
+      },
+      {
+        bucketStart: recentHourFloor,
+        input: 300,
+        output: 100,
+        cacheRead: 0,
+        cacheWrite: 0,
+        weightedUnits: recentWu,
+        cacheReadUnits: 0,
+        byModel: { [model]: recentWu },
+      },
+    ],
+  );
+
+  // 24h: only recent bucket (straddling the cutoff — recentHour is inside 24h window)
+  const bd24h = await buildUsageBreakdown({ store, range: "24h", now: NOW, apiKey: false });
+  const task24h = bd24h.repos.flatMap((r) => r.tasks).find((t) => t.sessionId === "bucketed-s1");
+  expect(task24h).toBeDefined();
+  expect(task24h!.tokens.input).toBe(300);
+  expect(task24h!.tokens.output).toBe(100);
+  expect(task24h!.authoringUnits).toBeCloseTo(recentWu, 10);
+
+  // 30d: both buckets (old hour is 48h ago, within 30d)
+  const bd30d = await buildUsageBreakdown({ store, range: "30d", now: NOW, apiKey: false });
+  const task30d = bd30d.repos.flatMap((r) => r.tasks).find((t) => t.sessionId === "bucketed-s1");
+  expect(task30d).toBeDefined();
+  expect(task30d!.tokens.input).toBe(800);
+  expect(task30d!.tokens.output).toBe(300);
+  expect(task30d!.authoringUnits).toBeCloseTo(totalWu, 10);
+
+  // all: uses aggregate row → same total
+  const bdAll = await buildUsageBreakdown({ store, range: "all", now: NOW, apiKey: false });
+  const taskAll = bdAll.repos.flatMap((r) => r.tasks).find((t) => t.sessionId === "bucketed-s1");
+  expect(taskAll).toBeDefined();
+  expect(taskAll!.tokens.input).toBe(800);
+  expect(taskAll!.tokens.output).toBe(300);
+  expect(taskAll!.authoringUnits).toBeCloseTo(totalWu, 10);
+});
+
+// ── Test 2: legacy fallback (no buckets) ─────────────────────────────────────
+
+test("legacy fallback: no bucket rows → included whole iff snapshotAt >= cutoff", async () => {
+  const store = new SessionStore(":memory:");
+  const model = "claude-opus-4-8";
+
+  const recentAt = NOW - H24 / 2; // within 24h
+  const staleAt = NOW - 2 * H24; // outside 24h
+
+  const recentWu = weightedUnits(
+    { input: 100, output: 50, cacheRead: 0, cacheWrite5m: 0, cacheWrite1h: 0 },
+    model,
+  );
+  const staleWu = weightedUnits(
+    { input: 200, output: 80, cacheRead: 0, cacheWrite5m: 0, cacheWrite1h: 0 },
+    model,
+  );
+
+  // No bucket rows inserted — legacy fallback
+  store.upsertSessionUsage(
+    makeSnap({
+      sessionId: "legacy-recent",
+      desig: "TASK-01",
+      repoPath: "/repos/foo",
+      model,
+      input: 100,
+      output: 50,
+      weightedUnits: recentWu,
+      cacheReadUnits: 0,
+      snapshotAt: recentAt,
+    }),
+  );
+  store.upsertSessionUsage(
+    makeSnap({
+      sessionId: "legacy-stale",
+      desig: "TASK-02",
+      repoPath: "/repos/foo",
+      model,
+      input: 200,
+      output: 80,
+      weightedUnits: staleWu,
+      cacheReadUnits: 0,
+      snapshotAt: staleAt,
+    }),
+  );
+
+  const bd24h = await buildUsageBreakdown({ store, range: "24h", now: NOW, apiKey: false });
+  const ids24h = bd24h.repos.flatMap((r) => r.tasks.map((t) => t.sessionId));
+  expect(ids24h).toContain("legacy-recent");
+  expect(ids24h).not.toContain("legacy-stale");
+
+  // Both appear in 30d (stale is 2d, within 30d)
+  const bd30d = await buildUsageBreakdown({ store, range: "30d", now: NOW, apiKey: false });
+  const ids30d = bd30d.repos.flatMap((r) => r.tasks.map((t) => t.sessionId));
+  expect(ids30d).toContain("legacy-recent");
+  expect(ids30d).toContain("legacy-stale");
+});
+
+// ── Test 3: bucketed-zero dropped vs spawn-parent retained ────────────────────
+
+test("bucketed zero-window: dropped when no spawn; retained as zero-authoring when spawn exists", async () => {
+  const store = new SessionStore(":memory:");
+  const model = "claude-opus-4-8";
+
+  // Two sessions: only old bucket (outside 24h). No bucket 0.
+  // Session A: no spawn → should be DROPPED from 24h
+  // Session B: has a completed spawn → should be RETAINED with authoringUnits 0
+
+  const oldHour = NOW - 48 * 60 * 60 * 1000;
+  const oldHourFloor = oldHour - (oldHour % 3_600_000);
+  const oldWu = weightedUnits(
+    { input: 400, output: 150, cacheRead: 0, cacheWrite5m: 0, cacheWrite1h: 0 },
+    model,
+  );
+  const totalWu = oldWu; // only the old bucket
+
+  for (const sessId of ["dropped-s", "retained-s"]) {
+    store.upsertSessionUsage(
+      makeSnap({
+        sessionId: sessId,
+        desig: sessId === "dropped-s" ? "TASK-10" : "TASK-11",
+        repoPath: "/repos/bar",
+        model,
+        input: 400,
+        output: 150,
+        weightedUnits: totalWu,
+        cacheReadUnits: 0,
+        snapshotAt: NOW - 500,
+      }),
+    );
+    store.replaceSessionUsageBuckets(sessId, [
+      {
+        sessionId: sessId,
+        bucketStart: oldHourFloor,
+        input: 400,
+        output: 150,
+        cacheRead: 0,
+        cacheWrite: 0,
+        weightedUnits: oldWu,
+        cacheReadUnits: 0,
+        byModel: { [model]: oldWu },
+      },
+    ]);
+  }
+
+  // Add a completed spawn for retained-s
+  const spawnWu = weightedUnits(
+    { input: 200, output: 80, cacheRead: 0, cacheWrite5m: 0, cacheWrite1h: 0 },
+    model,
+  );
+  store.recordReviewerSpawn({
+    reviewerSessionId: "rev-retained",
+    taskSessionId: "retained-s",
+    kind: "review",
+    worktreePath: "/wt",
+    model,
+    spawnedAt: NOW - 2000,
+  });
+  store.completeReviewerSpawn(
+    "rev-retained",
+    {
+      input: 200,
+      output: 80,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 280,
+      messageCount: 1,
+      lastActivity: NOW - 1500,
+      byModel: { [model]: 280 },
+      fullRecaches: 0,
+      sidechainCount: 0,
+    },
+    NOW - 1500,
+  );
+
+  const bd24h = await buildUsageBreakdown({ store, range: "24h", now: NOW, apiKey: false });
+  const ids24h = bd24h.repos.flatMap((r) => r.tasks.map((t) => t.sessionId));
+
+  // Session with no spawn is dropped
+  expect(ids24h).not.toContain("dropped-s");
+
+  // Session with completed spawn is retained
+  expect(ids24h).toContain("retained-s");
+  const retainedTask = bd24h.repos
+    .flatMap((r) => r.tasks)
+    .find((t) => t.sessionId === "retained-s");
+  expect(retainedTask).toBeDefined();
+  expect(retainedTask!.authoringUnits).toBe(0);
+  // Satellite cost is attributed
+  expect(retainedTask!.satelliteUnits).toBeCloseTo(spawnWu, 10);
+});
+
+// ── Test 4: live via rollup == re-parse fallback ──────────────────────────────
+
+test("live via rollup == re-parse fallback: identical authoringUnits/tokens/byModel/model", async () => {
+  const rollupDir = join(
+    tmpdir(),
+    `rollup-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(rollupDir, { recursive: true });
+
+  const store = new SessionStore(":memory:");
+  const claudeSessionId = "live-rollup-csid";
+  const worktreePath = "/wt/rollup-live";
+
+  // Write JSONL fixture to tmpDir (for TestRollup) AND to the real config.claudeProjectsDir path
+  // (for the liveSessionToAccum re-parse fallback).
+  const model = "claude-opus-4-8";
+  const lines = [
+    asst({ requestId: "rr1", ts: NOW - H24 / 4, model, input: 300, output: 120, cacheRead: 50 }),
+    asst({ requestId: "rr2", ts: NOW - H24 / 8, model, input: 150, output: 60 }),
+  ];
+
+  // Write for re-parse fallback (uses config.claudeProjectsDir + dashified worktreePath)
+  writeJsonl(worktreePath, claudeSessionId, lines);
+
+  // Write for TestRollup (uses rollupDir + claudeSessionId.jsonl)
+  writeRollupJsonl(rollupDir, claudeSessionId, lines);
+
+  // Create live session in store
+  const sessId = createLiveSession(store, {
+    worktreePath,
+    claudeSessionId,
+    repoPath: "/repos/rollup-test",
+  });
+
+  const rollup = new TestRollup(rollupDir);
+
+  // Build WITH rollup
+  const bdWithRollup = await buildUsageBreakdown({
+    store,
+    range: "24h",
+    now: NOW,
+    apiKey: false,
+    usageRollup: rollup,
+  });
+  const taskWithRollup = bdWithRollup.repos
+    .flatMap((r) => r.tasks)
+    .find((t) => t.sessionId === sessId);
+
+  // Build WITHOUT rollup (re-parse fallback)
+  const bdFallback = await buildUsageBreakdown({
+    store,
+    range: "24h",
+    now: NOW,
+    apiKey: false,
+  });
+  const taskFallback = bdFallback.repos.flatMap((r) => r.tasks).find((t) => t.sessionId === sessId);
+
+  expect(taskWithRollup).toBeDefined();
+  expect(taskFallback).toBeDefined();
+
+  // Both paths must agree on all fields
+  expect(taskWithRollup!.tokens.input).toBe(taskFallback!.tokens.input);
+  expect(taskWithRollup!.tokens.output).toBe(taskFallback!.tokens.output);
+  expect(taskWithRollup!.tokens.cacheRead).toBe(taskFallback!.tokens.cacheRead);
+  expect(taskWithRollup!.tokens.cacheWrite).toBe(taskFallback!.tokens.cacheWrite);
+  expect(taskWithRollup!.authoringUnits).toBeCloseTo(taskFallback!.authoringUnits, 10);
+  expect(taskWithRollup!.model).toBe(taskFallback!.model);
+  expect(taskWithRollup!.byModel).toEqual(taskFallback!.byModel);
+
+  // Sanity: actual values match the 24h window (both records are within 24h)
+  expect(taskWithRollup!.tokens.input).toBe(450);
+  expect(taskWithRollup!.tokens.output).toBe(180);
+
+  rmSync(rollupDir, { recursive: true, force: true });
+});
+
+// ── Test 5: cutoff===0 persisted uses aggregate rows ─────────────────────────
+
+test("cutoff===0 persisted uses aggregate rows (bucketed session all-time = aggregate row)", async () => {
+  const store = new SessionStore(":memory:");
+  const model = "claude-opus-4-8";
+
+  const oldHour = NOW - 48 * 60 * 60 * 1000;
+  const oldHourFloor = oldHour - (oldHour % 3_600_000);
+  const recentHour = NOW - 1 * 60 * 60 * 1000;
+  const recentHourFloor = recentHour - (recentHour % 3_600_000);
+
+  const oldWu = weightedUnits(
+    { input: 500, output: 200, cacheRead: 0, cacheWrite5m: 0, cacheWrite1h: 0 },
+    model,
+  );
+  const recentWu = weightedUnits(
+    { input: 300, output: 100, cacheRead: 0, cacheWrite5m: 0, cacheWrite1h: 0 },
+    model,
+  );
+  const totalWu = weightedUnits(
+    { input: 800, output: 300, cacheRead: 0, cacheWrite5m: 0, cacheWrite1h: 0 },
+    model,
+  );
+
+  insertSnapshotWithBuckets(
+    store,
+    {
+      sessionId: "all-time-s",
+      desig: "TASK-01",
+      repoPath: "/repos/alltime",
+      model,
+      input: 800,
+      output: 300,
+      weightedUnits: totalWu,
+      cacheReadUnits: 0,
+      snapshotAt: NOW - 500,
+    },
+    [
+      {
+        bucketStart: oldHourFloor,
+        input: 500,
+        output: 200,
+        cacheRead: 0,
+        cacheWrite: 0,
+        weightedUnits: oldWu,
+        cacheReadUnits: 0,
+        byModel: { [model]: oldWu },
+      },
+      {
+        bucketStart: recentHourFloor,
+        input: 300,
+        output: 100,
+        cacheRead: 0,
+        cacheWrite: 0,
+        weightedUnits: recentWu,
+        cacheReadUnits: 0,
+        byModel: { [model]: recentWu },
+      },
+    ],
+  );
+
+  const bdAll = await buildUsageBreakdown({ store, range: "all", now: NOW, apiKey: false });
+  const taskAll = bdAll.repos.flatMap((r) => r.tasks).find((t) => t.sessionId === "all-time-s");
+  expect(taskAll).toBeDefined();
+  // Must use aggregate row (input=800, output=300), not just recent bucket
+  expect(taskAll!.tokens.input).toBe(800);
+  expect(taskAll!.tokens.output).toBe(300);
+  expect(taskAll!.authoringUnits).toBeCloseTo(totalWu, 10);
 });

--- a/test/usage-snapshot.test.ts
+++ b/test/usage-snapshot.test.ts
@@ -197,3 +197,86 @@ test("asOf override → row stamped with historical timestamp", async () => {
   expect(r.archivedAt).toBe(T);
   expect(r.snapshotAt).toBe(T);
 });
+
+// ── New bucket tests (Task 3) ────────────────────────────────────────────────
+
+/** Build an assistant JSONL line with an explicit ISO timestamp. */
+function asstAt(ts: string, opts: Parameters<typeof asst>[0]): string {
+  const line = JSON.parse(asst(opts)) as Record<string, unknown>;
+  line.timestamp = ts;
+  return JSON.stringify(line);
+}
+
+test("buckets persisted: ≥2 hours → ≥2 bucket rows, Σ buckets == aggregate", async () => {
+  // Two records in different UTC hours
+  const session = makeSession({ id: "sess-b1", claudeSessionId: "bkt-multi" });
+  writeJsonl("/repos/foo", "bkt-multi", [
+    asstAt("2026-05-30T09:00:00.000Z", { requestId: "r1", input: 100, output: 50, cacheRead: 10 }),
+    asstAt("2026-05-30T10:00:00.000Z", { requestId: "r2", input: 200, output: 80, w5m: 5 }),
+  ]);
+  const store = new SessionStore(":memory:");
+  await snapshotSessionUsage(session, store);
+
+  // At least 2 bucket rows
+  expect(store.bucketedSessionIds().has("sess-b1")).toBe(true);
+  const sums = store.sumSessionUsageBucketsSince(0);
+  expect(sums.has("sess-b1")).toBe(true);
+
+  const bucketed = sums.get("sess-b1")!;
+  const rows = store.listSessionUsage();
+  const r = rows.find((x) => x.sessionId === "sess-b1")!;
+  expect(r).toBeDefined();
+
+  // Σ buckets == aggregate row (float-tolerant for REAL fields)
+  expect(bucketed.input).toBe(r.input);
+  expect(bucketed.output).toBe(r.output);
+  expect(bucketed.cacheRead).toBe(r.cacheRead);
+  expect(bucketed.cacheWrite).toBe(r.cacheWrite);
+  expect(bucketed.weightedUnits).toBeCloseTo(r.weightedUnits, 6);
+  expect(bucketed.cacheReadUnits).toBeCloseTo(r.cacheReadUnits, 6);
+});
+
+test("ts=0 record lands in bucket 0 and is included in aggregate", async () => {
+  const session = makeSession({ id: "sess-b2", claudeSessionId: "bkt-ts0" });
+  // One record with unparseable timestamp (ts=0), one normal
+  const line0 = JSON.stringify({
+    type: "assistant",
+    timestamp: "not-a-date",
+    requestId: "r0",
+    message: {
+      model: "claude-opus-4-8",
+      usage: { input_tokens: 50, output_tokens: 20, cache_read_input_tokens: 0 },
+    },
+  });
+  const line1 = asstAt("2026-05-30T09:00:00.000Z", { requestId: "r1", input: 100, output: 50 });
+  writeJsonl("/repos/foo", "bkt-ts0", [line0, line1]);
+
+  const store = new SessionStore(":memory:");
+  await snapshotSessionUsage(session, store);
+
+  const rows = store.listSessionUsage();
+  const r = rows.find((x) => x.sessionId === "sess-b2")!;
+  expect(r).toBeDefined();
+  expect(r.messageCount).toBe(2);
+  // Bucket 0 must exist
+  expect(store.bucketedSessionIds().has("sess-b2")).toBe(true);
+  // Σ input includes both records
+  expect(r.input).toBe(150);
+});
+
+test("idempotent re-archive: second call replaces buckets, no dup, no FK error", async () => {
+  const session = makeSession({ id: "sess-b3", claudeSessionId: "bkt-idem" });
+  writeJsonl("/repos/foo", "bkt-idem", [
+    asstAt("2026-05-30T09:00:00.000Z", { requestId: "r1", input: 100, output: 50 }),
+  ]);
+  const store = new SessionStore(":memory:");
+  await snapshotSessionUsage(session, store);
+  await snapshotSessionUsage(session, store);
+
+  // Still only one aggregate row
+  expect(store.listSessionUsage().filter((r) => r.sessionId === "sess-b3")).toHaveLength(1);
+  // Bucket sums unchanged (no double-counting)
+  const sums = store.sumSessionUsageBucketsSince(0);
+  const r = store.listSessionUsage().find((x) => x.sessionId === "sess-b3")!;
+  expect(sums.get("sess-b3")!.input).toBe(r.input);
+});

--- a/test/usage-snapshot.test.ts
+++ b/test/usage-snapshot.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { SessionStore } from "../src/store";
 import { config } from "../src/config";
 import { snapshotSessionUsage } from "../src/usage-snapshot";
-import { jsonlPathFor } from "../src/usage";
+import { jsonlPathFor, sessionCost } from "../src/usage";
 import type { Session } from "../src/types";
 
 // Build a minimal assistant JSONL line matching the shape parseLine expects.
@@ -279,4 +279,106 @@ test("idempotent re-archive: second call replaces buckets, no dup, no FK error",
   const sums = store.sumSessionUsageBucketsSince(0);
   const r = store.listSessionUsage().find((x) => x.sessionId === "sess-b3")!;
   expect(sums.get("sess-b3")!.input).toBe(r.input);
+});
+
+// ── Task-3 gap tests ─────────────────────────────────────────────────────────
+
+/** Multi-record JSONL spanning 2 models and 2 UTC hours (with realistic cache fields). */
+const MULTI_LINES = [
+  // hour 09, model opus-4-8: input+output+cacheRead+cacheWrite5m
+  asstAt("2026-05-30T09:15:00.000Z", {
+    requestId: "mx1",
+    model: "claude-opus-4-8",
+    input: 1_200,
+    output: 400,
+    cacheRead: 800,
+    w5m: 150,
+  }),
+  // hour 09, model sonnet-4-5: input+output+cacheWrite1h
+  asstAt("2026-05-30T09:45:00.000Z", {
+    requestId: "mx2",
+    model: "claude-sonnet-4-5",
+    input: 2_000,
+    output: 300,
+    cacheRead: 0,
+    w1h: 500,
+  }),
+  // hour 10, model opus-4-8: input+output+cacheRead
+  asstAt("2026-05-30T10:10:00.000Z", {
+    requestId: "mx3",
+    model: "claude-opus-4-8",
+    input: 900,
+    output: 250,
+    cacheRead: 600,
+    w5m: 0,
+  }),
+  // hour 10, model sonnet-4-5: pure input+output
+  asstAt("2026-05-30T10:55:00.000Z", {
+    requestId: "mx4",
+    model: "claude-sonnet-4-5",
+    input: 500,
+    output: 100,
+    cacheRead: 0,
+    w5m: 0,
+  }),
+];
+
+test("snapshot aggregate parity: snapshotSessionUsage matches sessionCost for same transcript", async () => {
+  const session = makeSession({ id: "sess-parity", claudeSessionId: "parity-sess" });
+  writeJsonl("/repos/foo", "parity-sess", MULTI_LINES);
+
+  // Legacy path
+  const legacy = sessionCost(MULTI_LINES);
+
+  // New path
+  const store = new SessionStore(":memory:");
+  await snapshotSessionUsage(session, store);
+  const rows = store.listSessionUsage();
+  const r = rows.find((x) => x.sessionId === "sess-parity");
+  expect(r).toBeDefined();
+  const row = r!;
+
+  // Scalar token counts must be exact
+  expect(row.input).toBe(legacy.usage.input);
+  expect(row.output).toBe(legacy.usage.output);
+  expect(row.cacheRead).toBe(legacy.usage.cacheRead);
+  expect(row.cacheWrite).toBe(legacy.usage.cacheWrite);
+  expect(row.total).toBe(legacy.usage.total);
+  expect(row.messageCount).toBe(legacy.usage.messageCount);
+
+  // Floating-point fields: match to 6 decimal places
+  expect(row.weightedUnits).toBeCloseTo(legacy.weightedUnits, 6);
+  expect(row.cacheReadUnits).toBeCloseTo(legacy.cacheReadUnits, 6);
+
+  // byModel weighted units must match per-model (float-tolerant)
+  const legacyModels = Object.keys(legacy.weightedByModel);
+  expect(Object.keys(row.byModel).sort()).toEqual(legacyModels.sort());
+  for (const model of legacyModels) {
+    expect(row.byModel[model]).toBeCloseTo(legacy.weightedByModel[model]!, 6);
+  }
+});
+
+test("bucket row count: ≥2 UTC hours produce ≥2 distinct bucket rows (cutoff-split proof)", async () => {
+  const session = makeSession({ id: "sess-bktcount", claudeSessionId: "bktcount-sess" });
+  writeJsonl("/repos/foo", "bktcount-sess", MULTI_LINES);
+
+  const store = new SessionStore(":memory:");
+  await snapshotSessionUsage(session, store);
+
+  // Sum with cutoff=0 includes ALL buckets
+  const allSums = store.sumSessionUsageBucketsSince(0);
+  const allTotal = allSums.get("sess-bktcount");
+  expect(allTotal).toBeDefined();
+
+  // Sum with cutoff between hour 09 and hour 10 (i.e. at the exact start of hour 10)
+  // — the 09:xx bucket rows are excluded by the query (bucketStart < floorHour(cutoff))
+  const cutoffMs = Date.parse("2026-05-30T10:00:00.000Z");
+  const partialSums = store.sumSessionUsageBucketsSince(cutoffMs);
+  const partialTotal = partialSums.get("sess-bktcount");
+
+  // If only one bucket row existed both queries would return the same sum.
+  // A strictly smaller partial sum proves the earlier-hour row is a separate DB row.
+  expect(partialTotal).toBeDefined();
+  expect(partialTotal!.input).toBeGreaterThan(0); // hour-10 data present
+  expect(partialTotal!.input).toBeLessThan(allTotal!.input); // hour-09 data excluded → proves ≥2 rows
 });

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -1,5 +1,18 @@
 import { test, expect } from "bun:test";
-import { accumulate, parseLine, dashify, jsonlPathFor } from "../src/usage";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  accumulate,
+  parseLine,
+  dashify,
+  jsonlPathFor,
+  dominantModelOf,
+  foldSessionBuckets,
+  SessionUsageRollup,
+  type RollupSession,
+} from "../src/usage";
+import { sessionCost } from "../src/usage";
 
 function asst(opts: {
   model?: string;
@@ -165,4 +178,417 @@ test("sidechainCount tallies isSidechain accepted records", () => {
     asst({ requestId: "r3" }), // main — not counted
   ]);
   expect(u.sidechainCount).toBe(2);
+});
+
+// ── dominantModelOf ───────────────────────────────────────────────────────────
+
+test("dominantModelOf picks the model with max weighted units", () => {
+  expect(dominantModelOf({ "claude-opus-4-8": 100, "claude-sonnet-4-6": 200 })).toBe(
+    "claude-sonnet-4-6",
+  );
+});
+
+test("dominantModelOf skips the 'unknown' sentinel", () => {
+  expect(dominantModelOf({ unknown: 9999, "claude-opus-4-8": 10 })).toBe("claude-opus-4-8");
+});
+
+test("dominantModelOf returns null on empty record", () => {
+  expect(dominantModelOf({})).toBeNull();
+});
+
+test("dominantModelOf returns null when only 'unknown' is present", () => {
+  expect(dominantModelOf({ unknown: 500 })).toBeNull();
+});
+
+// ── foldSessionBuckets ────────────────────────────────────────────────────────
+
+// Fixture: two different hours + one ts=0 record, with distinct models and multiple token kinds.
+// Hour A: 2026-05-30T09:00:00.000Z
+// Hour B: 2026-05-30T10:00:00.000Z
+const TS_A = "2026-05-30T09:31:01.000Z"; // in hour A
+const TS_B = "2026-05-30T10:15:00.000Z"; // in hour B
+
+// Make a ts=0 record by using an invalid timestamp
+function asstNoTs(opts: Parameters<typeof asst>[0]): string {
+  const o = JSON.parse(asst(opts));
+  o.timestamp = "invalid"; // Date.parse("invalid") === NaN → 0
+  return JSON.stringify(o);
+}
+
+const multiHourLinesFixed = [
+  asst({
+    requestId: "r1",
+    model: "claude-opus-4-8",
+    input: 100,
+    output: 50,
+    cacheRead: 10,
+    w5m: 5,
+    w1h: 3,
+    ts: TS_A,
+  }),
+  asst({
+    requestId: "r2",
+    model: "claude-sonnet-4-6",
+    input: 200,
+    output: 80,
+    cacheRead: 20,
+    w5m: 8,
+    ts: TS_B,
+  }),
+  asst({ requestId: "r3", model: "claude-opus-4-8", input: 50, output: 30, ts: TS_B }),
+  asstNoTs({ requestId: "r4", model: "claude-haiku-4-5", input: 40, output: 20 }),
+];
+
+test("foldSessionBuckets: summing all buckets matches sessionCost totals (no window)", () => {
+  const fold = foldSessionBuckets(multiHourLinesFixed);
+  const ref = sessionCost(multiHourLinesFixed);
+
+  let input = 0,
+    output = 0,
+    cacheRead = 0,
+    cacheWrite = 0,
+    weightedUnits = 0,
+    cacheReadUnits = 0;
+  for (const b of fold.buckets.values()) {
+    input += b.input;
+    output += b.output;
+    cacheRead += b.cacheRead;
+    cacheWrite += b.cacheWrite;
+    weightedUnits += b.weightedUnits;
+    cacheReadUnits += b.cacheReadUnits;
+  }
+
+  expect(input).toBe(ref.usage.input);
+  expect(output).toBe(ref.usage.output);
+  expect(cacheRead).toBe(ref.usage.cacheRead);
+  expect(cacheWrite).toBe(ref.usage.cacheWrite);
+  expect(weightedUnits).toBeCloseTo(ref.weightedUnits, 10);
+  expect(cacheReadUnits).toBeCloseTo(ref.cacheReadUnits, 10);
+});
+
+test("foldSessionBuckets: messageCount equals sessionCost messageCount", () => {
+  const fold = foldSessionBuckets(multiHourLinesFixed);
+  const ref = sessionCost(multiHourLinesFixed);
+  expect(fold.messageCount).toBe(ref.usage.messageCount);
+});
+
+test("foldSessionBuckets: dedupes by requestId across buckets", () => {
+  const dup = [
+    asst({ requestId: "dup1", input: 100, ts: TS_A }),
+    asst({ requestId: "dup1", input: 100, ts: TS_B }), // same requestId, different hour → skipped
+  ];
+  const fold = foldSessionBuckets(dup);
+  expect(fold.messageCount).toBe(1);
+  let total = 0;
+  for (const b of fold.buckets.values()) total += b.input;
+  expect(total).toBe(100);
+});
+
+test("foldSessionBuckets: ts=0 record folds into bucket 0", () => {
+  const lines = [asstNoTs({ requestId: "r0", input: 77 })];
+  const fold = foldSessionBuckets(lines);
+  expect(fold.buckets.has(0)).toBe(true);
+  expect(fold.buckets.get(0)!.input).toBe(77);
+});
+
+// ── SessionUsageRollup ────────────────────────────────────────────────────────
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "rollup-test-"));
+}
+
+function makeSession(dir: string, id: string): RollupSession {
+  return { id, worktreePath: dir, claudeSessionId: id };
+}
+
+// Override jsonlPathFor for tests by using worktreePath as the directory directly.
+// We monkey-patch via a wrapper that creates a TestRollup subclass.
+class TestRollup extends SessionUsageRollup {
+  constructor(private dir: string) {
+    super();
+  }
+  // Override to use dir+sessionId.jsonl as path
+  protected override pathFor(worktreePath: string, sessionId: string): string {
+    return join(this.dir, `${sessionId}.jsonl`);
+  }
+}
+
+test("SessionUsageRollup: incremental append — second refresh sees appended bytes", async () => {
+  const dir = makeTmpDir();
+  const sessionId = "sess-inc";
+  const path = join(dir, `${sessionId}.jsonl`);
+  const lines1 = [asst({ requestId: "a1", input: 100, output: 50, ts: TS_A })];
+  writeFileSync(path, lines1.join("\n") + "\n");
+
+  const r = new TestRollup(dir);
+  const sessions = [makeSession(dir, sessionId)];
+  const now = Date.now();
+  await r.refresh(sessions, now);
+
+  const w1 = r.windowedAccum(sessionId, 0);
+  expect(w1).not.toBeNull();
+  expect(w1!.input).toBe(100);
+
+  // Append more bytes
+  const lines2 = [asst({ requestId: "a2", input: 200, output: 80, ts: TS_B })];
+  writeFileSync(path, [...lines1, ...lines2].join("\n") + "\n");
+  await r.refresh(sessions, now);
+
+  const ref = sessionCost([...lines1, ...lines2]);
+  const w2 = r.windowedAccum(sessionId, 0);
+  expect(w2!.input).toBe(ref.usage.input);
+  expect(w2!.output).toBe(ref.usage.output);
+  expect(w2!.weightedUnits).toBeCloseTo(ref.weightedUnits, 10);
+});
+
+test("SessionUsageRollup: single-flight — concurrent refresh() calls don't double-count", async () => {
+  const dir = makeTmpDir();
+  const sessionId = "sess-sf";
+  const path = join(dir, `${sessionId}.jsonl`);
+  // Use records WITHOUT requestId so they WOULD double-count if read twice
+  const lines = [
+    asst({ input: 100, output: 50 }), // no requestId
+    asst({ input: 200, output: 80 }), // no requestId
+  ];
+  writeFileSync(path, lines.join("\n") + "\n");
+
+  const r = new TestRollup(dir);
+  const sessions = [makeSession(dir, sessionId)];
+  const now = Date.now();
+  // Fire two concurrent refreshes
+  await Promise.all([r.refresh(sessions, now), r.refresh(sessions, now)]);
+
+  const w = r.windowedAccum(sessionId, 0);
+  expect(w).not.toBeNull();
+  // Should only count each record once
+  expect(w!.input).toBe(300);
+  expect(w!.output).toBe(130);
+  expect(w!.messageCount).toBe(2);
+});
+
+test("SessionUsageRollup: dedupe before accumulate — duplicate requestId across chunks counted once", async () => {
+  const dir = makeTmpDir();
+  const sessionId = "sess-dup";
+  const path = join(dir, `${sessionId}.jsonl`);
+  const line = asst({ requestId: "dup-x", input: 100, output: 50, ts: TS_A });
+
+  // First refresh with one record
+  writeFileSync(path, line + "\n");
+  const r = new TestRollup(dir);
+  const sessions = [makeSession(dir, sessionId)];
+  const now = Date.now();
+  await r.refresh(sessions, now);
+
+  // Append the same requestId again (simulating duplicate)
+  const dup = asst({ requestId: "dup-x", input: 100, output: 50, ts: TS_B });
+  writeFileSync(path, line + "\n" + dup + "\n");
+  await r.refresh(sessions, now);
+
+  const w = r.windowedAccum(sessionId, 0);
+  expect(w!.messageCount).toBe(1);
+  expect(w!.input).toBe(100);
+});
+
+test("SessionUsageRollup: exact-cutoff windowing (cutoff>0) equals sessionCost(lines, cutoff)", async () => {
+  const dir = makeTmpDir();
+  const sessionId = "sess-cutoff";
+  const path = join(dir, `${sessionId}.jsonl`);
+  const lines = [
+    asst({ requestId: "c1", input: 100, output: 50, cacheRead: 10, ts: TS_A }),
+    asst({ requestId: "c2", input: 200, output: 80, ts: TS_B }),
+    asstNoTs({ requestId: "c3", input: 40, output: 20 }), // ts=0 always included
+  ];
+  writeFileSync(path, lines.join("\n") + "\n");
+
+  const r = new TestRollup(dir);
+  const sessions = [makeSession(dir, sessionId)];
+  const now = Date.now();
+  await r.refresh(sessions, now);
+
+  // cutoff = floor of hour B = exclude TS_A records
+  const hourBFloor = Math.floor(Date.parse(TS_B) / 3_600_000) * 3_600_000;
+  const ref = sessionCost(lines, hourBFloor);
+  const w = r.windowedAccum(sessionId, hourBFloor);
+  expect(w).not.toBeNull();
+  expect(w!.input).toBe(ref.usage.input);
+  expect(w!.output).toBe(ref.usage.output);
+  expect(w!.weightedUnits).toBeCloseTo(ref.weightedUnits, 10);
+  expect(w!.cacheReadUnits).toBeCloseTo(ref.cacheReadUnits, 10);
+});
+
+test("SessionUsageRollup: cutoff===0 uses unpruned running agg — old record pruned from array but still in agg", async () => {
+  const dir = makeTmpDir();
+  const sessionId = "sess-agg";
+  const path = join(dir, `${sessionId}.jsonl`);
+  // Use ts=1 (epoch+1ms) for an old record
+  const oldLine = JSON.stringify({
+    type: "assistant",
+    timestamp: new Date(1).toISOString(),
+    requestId: "old1",
+    message: {
+      model: "claude-opus-4-8",
+      usage: {
+        input_tokens: 500,
+        output_tokens: 100,
+        cache_read_input_tokens: 0,
+        cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 0 },
+      },
+    },
+  });
+  const recentLine = asst({ requestId: "new1", input: 10, ts: TS_B });
+  writeFileSync(path, [oldLine, recentLine].join("\n") + "\n");
+
+  const r = new TestRollup(dir);
+  const sessions = [makeSession(dir, sessionId)];
+  // now = 30d + 60s + 2ms after ts=1, so the old record is prunable
+  const THIRTY_DAYS = 30 * 86_400_000;
+  const now = 1 + THIRTY_DAYS + 60_000 + 2;
+  await r.refresh(sessions, now);
+
+  const w = r.windowedAccum(sessionId, 0);
+  expect(w).not.toBeNull();
+  // cutoff===0 uses unpruned agg — both records counted
+  expect(w!.messageCount).toBe(2);
+  expect(w!.input).toBe(510);
+});
+
+test("SessionUsageRollup: 30d prune — array shrank, agg did not; requestId removed from seen", async () => {
+  const dir = makeTmpDir();
+  const sessionId = "sess-prune";
+  const path = join(dir, `${sessionId}.jsonl`);
+  const oldLine = JSON.stringify({
+    type: "assistant",
+    timestamp: new Date(1).toISOString(),
+    requestId: "prune1",
+    message: {
+      model: "claude-opus-4-8",
+      usage: {
+        input_tokens: 300,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 0 },
+      },
+    },
+  });
+  writeFileSync(path, oldLine + "\n");
+
+  const r = new TestRollup(dir);
+  const sessions = [makeSession(dir, sessionId)];
+  const THIRTY_DAYS = 30 * 86_400_000;
+  const now = 1 + THIRTY_DAYS + 60_000 + 2;
+  await r.refresh(sessions, now);
+
+  // The windowed (cutoff>0) view returns null because the only record was pruned from records[]
+  const cutoff = now - THIRTY_DAYS;
+  const w = r.windowedAccum(sessionId, cutoff);
+  // Record ts=1 < cutoff, so not in window; ts=0 records are always included but there are none
+  expect(w).toBeNull(); // messageCount===0 → null
+
+  // But cutoff===0 still shows the agg
+  const wAgg = r.windowedAccum(sessionId, 0);
+  expect(wAgg).not.toBeNull();
+  expect(wAgg!.messageCount).toBe(1);
+});
+
+test("SessionUsageRollup: truncation reset — size < offset resets state", async () => {
+  const dir = makeTmpDir();
+  const sessionId = "sess-trunc";
+  const path = join(dir, `${sessionId}.jsonl`);
+  const lines = [asst({ requestId: "t1", input: 100, ts: TS_A })];
+  writeFileSync(path, lines.join("\n") + "\n");
+
+  const r = new TestRollup(dir);
+  const sessions = [makeSession(dir, sessionId)];
+  const now = Date.now();
+  await r.refresh(sessions, now);
+
+  const w1 = r.windowedAccum(sessionId, 0);
+  expect(w1!.input).toBe(100);
+
+  // Truncate: write fewer bytes (smaller file)
+  const newLines = [asst({ requestId: "t2", input: 50, ts: TS_A })];
+  writeFileSync(path, newLines.join("\n") + "\n");
+  await r.refresh(sessions, now);
+
+  // After reset, only the new content should be counted
+  const w2 = r.windowedAccum(sessionId, 0);
+  expect(w2!.input).toBe(50);
+  expect(w2!.messageCount).toBe(1);
+});
+
+test("SessionUsageRollup: drop inactive sessions not in sessions arg", async () => {
+  const dir = makeTmpDir();
+  const sessA = "sess-drop-a";
+  const sessB = "sess-drop-b";
+  writeFileSync(
+    join(dir, `${sessA}.jsonl`),
+    asst({ requestId: "da1", input: 100, ts: TS_A }) + "\n",
+  );
+  writeFileSync(
+    join(dir, `${sessB}.jsonl`),
+    asst({ requestId: "db1", input: 200, ts: TS_A }) + "\n",
+  );
+
+  const r = new TestRollup(dir);
+  const now = Date.now();
+  await r.refresh([makeSession(dir, sessA), makeSession(dir, sessB)], now);
+
+  expect(r.windowedAccum(sessA, 0)).not.toBeNull();
+  expect(r.windowedAccum(sessB, 0)).not.toBeNull();
+
+  // Drop sessB from sessions list
+  await r.refresh([makeSession(dir, sessA)], now);
+
+  expect(r.windowedAccum(sessA, 0)).not.toBeNull();
+  expect(r.windowedAccum(sessB, 0)).toBeNull();
+});
+
+test("SessionUsageRollup: windowedAccum returns null for unknown sessionId", async () => {
+  const r = new SessionUsageRollup();
+  expect(r.windowedAccum("no-such-session", 0)).toBeNull();
+});
+
+test("SessionUsageRollup: windowedAccum returns null for empty in-window set (messageCount===0)", async () => {
+  const dir = makeTmpDir();
+  const sessionId = "sess-empty-win";
+  const path = join(dir, `${sessionId}.jsonl`);
+  // Record is in hour A; cutoff is hour B → no in-window records
+  writeFileSync(path, asst({ requestId: "ew1", input: 100, ts: TS_A }) + "\n");
+
+  const r = new TestRollup(dir);
+  const sessions = [makeSession(dir, sessionId)];
+  const now = Date.now();
+  await r.refresh(sessions, now);
+
+  const hourBFloor = Math.floor(Date.parse(TS_B) / 3_600_000) * 3_600_000;
+  // TS_A is in hour 09:xx, hourBFloor is 10:00; TS_A < hourBFloor → excluded
+  const w = r.windowedAccum(sessionId, hourBFloor);
+  expect(w).toBeNull();
+});
+
+test("SessionUsageRollup: dominantModel for cutoff>0 from in-window raw tokens; cutoff===0 from session-wide agg", async () => {
+  const dir = makeTmpDir();
+  const sessionId = "sess-dom";
+  const path = join(dir, `${sessionId}.jsonl`);
+  // Hour A: opus with lots of tokens
+  // Hour B: sonnet with fewer tokens
+  const lines = [
+    asst({ requestId: "dm1", model: "claude-opus-4-8", input: 1000, output: 500, ts: TS_A }),
+    asst({ requestId: "dm2", model: "claude-sonnet-4-6", input: 50, output: 20, ts: TS_B }),
+  ];
+  writeFileSync(path, lines.join("\n") + "\n");
+
+  const r = new TestRollup(dir);
+  const sessions = [makeSession(dir, sessionId)];
+  const now = Date.now();
+  await r.refresh(sessions, now);
+
+  // cutoff===0 → session-wide: opus dominates
+  const wAll = r.windowedAccum(sessionId, 0);
+  expect(wAll!.dominantModel).toBe("claude-opus-4-8");
+
+  // cutoff = hour B floor → only hour B in window → sonnet dominates
+  const hourBFloor = Math.floor(Date.parse(TS_B) / 3_600_000) * 3_600_000;
+  const wB = r.windowedAccum(sessionId, hourBFloor);
+  expect(wB!.dominantModel).toBe("claude-sonnet-4-6");
 });

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { appendFileSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -596,7 +596,10 @@ test("SessionUsageRollup: dominantModel for cutoff>0 from in-window raw tokens; 
 test("SessionUsageRollup: prune walks all records even when first record is ts=0", async () => {
   // Regression: the old guard `st.records[0].ts > 0 && st.records[0].ts < cutoff` would
   // skip the prune loop entirely when the first record has ts=0, leaving stale real-ts
-  // records and their requestIds in `seen` unbounded.
+  // records and their requestIds in `seen` unbounded. The observable effect of that bug:
+  // "old-real" stays in `seen`, so a later re-append of that requestId is deduped away.
+  // With the fix, "old-real" is removed from `seen` during prune, so the re-appended line
+  // IS counted. This test observes that via the in-window input total.
   const dir = makeTmpDir();
   const sessionId = "sess-prune-ts0-first";
   const path = join(dir, `${sessionId}.jsonl`);
@@ -633,19 +636,36 @@ test("SessionUsageRollup: prune walks all records even when first record is ts=0
   const now = 1 + THIRTY_DAYS + 60_000 + 2;
   await r.refresh(sessions, now);
 
-  // After prune: ts=0 kept, old real-ts pruned, recent kept.
-  // windowedAccum with cutoff>0 only sees ts=0 and ts>=cutoff records.
+  // Sanity: ts=0 record is still counted in-window (never pruned)
   const cutoff = now - THIRTY_DAYS - 60_000;
-  const w = r.windowedAccum(sessionId, cutoff);
-  // ts=0 (input=11) and recentLine (input=99) are in-window; oldLine (input=777) was pruned
-  expect(w).not.toBeNull();
-  expect(w!.input).toBe(11 + 99); // 110 — NOT 11 + 777 + 99
-  expect(w!.messageCount).toBe(2);
+  const wAfterFirst = r.windowedAccum(sessionId, cutoff);
+  expect(wAfterFirst).not.toBeNull();
+  expect(wAfterFirst!.input >= 11).toBe(true); // ts0Line still present
 
-  // Verify old requestId was removed from seen by attempting a re-ingest in a second refresh.
-  // Append oldLine again: if pruned correctly, it will be re-ingested (seen no longer has "old-real").
-  // We don't need to verify re-ingest here — the input assertion above already proves prune happened.
-  // Extra: ensure ts=0 record is still present in the window (not pruned).
-  const ts0InWindow = w!.input >= 11;
-  expect(ts0InWindow).toBe(true);
+  // KEY assertion: re-append a NEW line reusing requestId "old-real" with a recent timestamp
+  // and a distinctive input (500). If the prune correctly removed "old-real" from `seen`,
+  // the rollup will accept this line and count it. If the bug is present ("old-real" still in
+  // `seen`), the line is deduped away and the total stays at 11+99=110.
+  const reAppendedLine = JSON.stringify({
+    type: "assistant",
+    timestamp: new Date(now - 1).toISOString(), // recent: well within window (>= cutoff=3)
+    requestId: "old-real",
+    message: {
+      model: "claude-opus-4-8",
+      usage: {
+        input_tokens: 500,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 0 },
+      },
+    },
+  });
+  appendFileSync(path, reAppendedLine + "\n");
+  await r.refresh(sessions, now);
+
+  // With the fix: "old-real" was pruned from `seen` → re-appended line accepted → 11+99+500=610
+  // With the bug: "old-real" still in `seen` → re-appended line deduped → 11+99=110 (assertion fails)
+  const wAfterReappend = r.windowedAccum(sessionId, cutoff);
+  expect(wAfterReappend).not.toBeNull();
+  expect(wAfterReappend!.input).toBe(11 + 99 + 500); // 610
 });

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -592,3 +592,60 @@ test("SessionUsageRollup: dominantModel for cutoff>0 from in-window raw tokens; 
   const wB = r.windowedAccum(sessionId, hourBFloor);
   expect(wB!.dominantModel).toBe("claude-sonnet-4-6");
 });
+
+test("SessionUsageRollup: prune walks all records even when first record is ts=0", async () => {
+  // Regression: the old guard `st.records[0].ts > 0 && st.records[0].ts < cutoff` would
+  // skip the prune loop entirely when the first record has ts=0, leaving stale real-ts
+  // records and their requestIds in `seen` unbounded.
+  const dir = makeTmpDir();
+  const sessionId = "sess-prune-ts0-first";
+  const path = join(dir, `${sessionId}.jsonl`);
+  const THIRTY_DAYS = 30 * 86_400_000;
+
+  // ts=0 record (invalid timestamp → Date.parse → NaN → 0)
+  const ts0Line = asstNoTs({ requestId: "ts0-rec", input: 11 });
+
+  // Old real-ts record: ts=1 (epoch+1ms), will be prunable
+  const oldLine = JSON.stringify({
+    type: "assistant",
+    timestamp: new Date(1).toISOString(),
+    requestId: "old-real",
+    message: {
+      model: "claude-opus-4-8",
+      usage: {
+        input_tokens: 777,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 0 },
+      },
+    },
+  });
+
+  // Recent record
+  const recentLine = asst({ requestId: "recent-rec", input: 99, ts: TS_B });
+
+  // Order: ts=0 FIRST, then old real-ts, then recent — the bug skipped the prune when [0].ts===0
+  writeFileSync(path, [ts0Line, oldLine, recentLine].join("\n") + "\n");
+
+  const r = new TestRollup(dir);
+  const sessions = [makeSession(dir, sessionId)];
+  // now far enough past ts=1 to make oldLine prunable
+  const now = 1 + THIRTY_DAYS + 60_000 + 2;
+  await r.refresh(sessions, now);
+
+  // After prune: ts=0 kept, old real-ts pruned, recent kept.
+  // windowedAccum with cutoff>0 only sees ts=0 and ts>=cutoff records.
+  const cutoff = now - THIRTY_DAYS - 60_000;
+  const w = r.windowedAccum(sessionId, cutoff);
+  // ts=0 (input=11) and recentLine (input=99) are in-window; oldLine (input=777) was pruned
+  expect(w).not.toBeNull();
+  expect(w!.input).toBe(11 + 99); // 110 — NOT 11 + 777 + 99
+  expect(w!.messageCount).toBe(2);
+
+  // Verify old requestId was removed from seen by attempting a re-ingest in a second refresh.
+  // Append oldLine again: if pruned correctly, it will be re-ingested (seen no longer has "old-real").
+  // We don't need to verify re-ingest here — the input assertion above already proves prune happened.
+  // Extra: ensure ts=0 record is still present in the window (not pruned).
+  const ts0InWindow = w!.input >= 11;
+  expect(ts0InWindow).toBe(true);
+});


### PR DESCRIPTION
Closes #967. Follow-up to #952 (Phase 1) / part of the #943 `/usage` arc. Rebased on #965 (backfill).

## What & why
Phase 1 left an asymmetric range filter: **live** active sessions were per-record windowed, but **persisted** snapshots went whole-snapshot in/out by `snapshotAt`, and active sessions re-parsed their full JSONL on every breakdown request. This PR closes both:

- **(A) Per-record windowing of persisted history.** Archive now writes per-UTC-hour weighted-unit buckets (`session_usage_bucket`), so archived sessions are windowed *sub-session* (24h/7d/30d) instead of whole-snapshot. Boundary error is bounded to ≤1h (the cost of bucketing).
- **(B) Continuous active-session rollup.** A new `SessionUsageRollup` (sibling of `AccountUsageIndex`) reads only appended JSONL bytes and serves the breakdown from memory, replacing the full re-parse. The re-parse path is kept as a fallback when no rollup is wired (tests).

## Design highlights
- **ts=0 ("timeless") rule, one rule on all three paths:** records with an unparseable timestamp are always counted in every window — sentinel `bucketStart=0` for persisted; `ts===0 || ts>=cutoff` for the rollup; unchanged `sessionCost` for the fallback.
- **Live stays per-record exact** (rollup windows by the *exact* cutoff, `floorHour` is persisted-only); only persisted is hour-bucketed.
- **Σ(all buckets) == the aggregate `session_usage` row by construction** — one `foldSessionBuckets` pass produces both at archive. `"all"` range reads the exact aggregate row.
- **cutoff===0** served from an unpruned O(1) running aggregate so a >30d-spanning active session isn't undercounted; the rollup prunes its per-record array (+ `seen`) to 30d, never pruning ts=0.
- **Single-flight `refresh()`** so concurrent breakdown requests can't double-count appended bytes.
- **Legacy rows** (no buckets) keep whole-snapshot-by-`snapshotAt` windowing (no backfill of pre-bucket aggregates is possible); a bucketed session with 0 in-window authoring is dropped *unless* it parents a reviewer spawn (so satellite stays attributed).
- **FK lifecycle:** `session_usage_bucket` has `ON DELETE CASCADE` to `session_usage`; `PRAGMA foreign_keys=ON` set in the store constructor (safe — no other table declares a FK).

## Out of scope (documented)
- Satellite/reviewer-spawn windowing (deferred; a straddling row mixes windowed authoring with full satellite).
- Retention/prune of `session_usage(_bucket)` (pre-existing growth).

## Tests
New + extended coverage in `usage`, `store-session-usage`, `usage-snapshot`, `usage-breakdown`, `server-usage-breakdown` (incl. ts=0 three-path parity, rollup byte-identical to re-parse, single-flight no-double-count, Σbuckets==aggregate, sub-session windowing, spawn-parent retention, FK CASCADE). Full root suite: **4480 pass / 0 fail**; tsc + eslint + fallow gate clean.

No UI/i18n/feature-catalog changes — response contract (`UsageBreakdown`) is unchanged; this is a `perf`-only change. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
