### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -22,6 +22,8 @@ lines), read by the systemd unit if present.
 | `SHEPHERD_FORGES` | `~/.shepherd/forges.json` | Path to the git-host config |
 | `SHEPHERD_SANDBOX_DEFAULT_PROFILE` | `trusted` | Default sandbox profile for every spawned agent (`trusted` / `standard` / `autonomous`) — see below |
 | `SHEPHERD_TRIM_AUTO_CONTEXT` | `true` | Trim the per-turn context of auto-spawned (drain) agents (skill catalog + optional plugins disabled per-spawn). Interactive sessions untouched. Set `false`/`0`/`off` if drain quality regresses |
+| `SHEPHERD_USAGE_HOLD_ENABLED` | `true` | Queue newly submitted tasks instead of spawning them while account usage is high (auto-released as usage falls). Set `0`/`false` to always spawn immediately |
+| `SHEPHERD_USAGE_HOLD_PCT` | `80` | Hold threshold: when the higher of the 5-hour / weekly usage window reaches this percent (and ≥1 session is running), new tasks are held. Range `0`–`100` |
 
 ## Live preview
 

--- a/docs/external-task-api.md
+++ b/docs/external-task-api.md
@@ -20,7 +20,10 @@ curl -X POST http://localhost:7330/api/sessions \
 ```
 
 A `201` returns the full session, including its designation (`TASK-07`) and
-`id` — the agent spawns immediately on an isolated git worktree.
+`id` — the agent spawns immediately on an isolated git worktree. When the
+default usage-aware hold gate is active and account usage is high, the
+submission is instead **queued** and answered `200 { "held": true, … }`
+rather than spawned — see [Usage-aware hold gate](#usage-aware-hold-gate) below.
 
 ## Why no new endpoint is needed
 
@@ -46,11 +49,11 @@ its hostname to `SHEPHERD_ALLOWED_HOSTS`.
 
 ## What actually gates access
 
-| Gate                 | Default                          | What Hermes must do                                                                               |
-| -------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------- |
-| **Network bind**     | `127.0.0.1:7330` (loopback only) | Run on the same host, reach it over Tailscale serve, or set `SHEPHERD_HOST` to expose another NIC |
-| **Auth token**       | `SHEPHERD_TOKEN` unset → open    | If set, send `Authorization: Bearer <token>` on every request (timing-safe compare)               |
-| **Repo confinement** | `SHEPHERD_REPO_ROOT` = `~/Work`  | `repoPath` must resolve **inside** the root, or the request is rejected `400`                     |
+| Gate                 | Default                           | What Hermes must do                                                                               |
+| -------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------- |
+| **Network bind**     | `127.0.0.1:7330` (loopback only)  | Run on the same host, reach it over Tailscale serve, or set `SHEPHERD_HOST` to expose another NIC |
+| **Auth token**       | `SHEPHERD_TOKEN` unset → open     | If set, send `Authorization: Bearer <token>` on every request (timing-safe compare)               |
+| **Repo confinement** | `SHEPHERD_REPO_ROOT` = `~` (home) | `repoPath` must resolve **inside** the root, or the request is rejected `400`                     |
 
 ### Recommended setup for a remote agent
 
@@ -65,23 +68,48 @@ its hostname to `SHEPHERD_ALLOWED_HOSTS`.
 `POST /api/sessions`, `Content-Type: application/json`. Validated by
 `validateCreate` (`src/validate.ts`); unknown keys are rejected.
 
-| Field        | Type                                                                             | Required | Notes                                                                        |
-| ------------ | -------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------- |
-| `repoPath`   | string                                                                           | ✅       | Absolute or `~`-expanded; must resolve inside `SHEPHERD_REPO_ROOT`           |
-| `baseBranch` | string                                                                           | ✅       | Git branch; `^(?!-)[A-Za-z0-9._/-]{1,200}$`                                  |
-| `prompt`     | string                                                                           | ✅       | The task instructions; 1–8000 chars                                          |
-| `model`      | `"fable" \| "opus" \| "opus[1m]" \| "sonnet" \| "sonnet[1m]" \| "haiku" \| null` | —        | Omit/`null` = Claude's default; `[1m]` selects the 1M-context variant        |
-| `images`     | `string[]`                                                                       | —        | ≤10 paths, each confined to the upload staging dir (see `POST /api/uploads`) |
+| Field        | Type                                                                             | Required | Notes                                                                                                                       |
+| ------------ | -------------------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `repoPath`   | string                                                                           | ✅       | Absolute or `~`-expanded; must resolve inside `SHEPHERD_REPO_ROOT`                                                          |
+| `baseBranch` | string                                                                           | ✅       | Git branch; `^(?!-)[A-Za-z0-9._/-]{1,200}$`                                                                                 |
+| `prompt`     | string                                                                           | ✅       | The task instructions; 1–8000 chars                                                                                         |
+| `model`      | `"fable" \| "opus" \| "opus[1m]" \| "sonnet" \| "sonnet[1m]" \| "haiku" \| null` | —        | Omit/`null` = Claude's default; `[1m]` selects the 1M-context variant                                                       |
+| `images`     | `string[]`                                                                       | —        | ≤10 paths, each confined to the upload staging dir (see `POST /api/uploads`)                                                |
+| `force`      | boolean                                                                          | —        | `true` bypasses the usage-aware hold gate so the task spawns even at high usage (transport-only; not stored on the session) |
 
 ### Responses
 
-| Status | Meaning                                                                           |
-| ------ | --------------------------------------------------------------------------------- |
-| `201`  | Created — body is the full `Session` (`id`, `desig`, `status`, `worktreePath`, …) |
-| `400`  | Validation failed — body `{ error }`                                              |
-| `401`  | `SHEPHERD_TOKEN` set and bearer missing/wrong                                     |
-| `403`  | Origin header present and not in `SHEPHERD_ALLOWED_HOSTS`                         |
-| `415`  | Missing/incorrect `Content-Type`                                                  |
+| Status | Meaning                                                                                                               |
+| ------ | --------------------------------------------------------------------------------------------------------------------- |
+| `200`  | **Held** by the usage-aware hold gate — body `{ held: true, id, count }`; the task is queued, not spawned (see below) |
+| `201`  | Created — body is the full `Session` (`id`, `desig`, `status`, `worktreePath`, …)                                     |
+| `400`  | Validation failed — body `{ error }`                                                                                  |
+| `401`  | `SHEPHERD_TOKEN` set and bearer missing/wrong                                                                         |
+| `403`  | Origin header present and not in `SHEPHERD_ALLOWED_HOSTS`                                                             |
+| `415`  | Missing/incorrect `Content-Type`                                                                                      |
+
+## Usage-aware hold gate
+
+Shepherd can **queue** newly submitted tasks instead of spawning them when account
+usage is already high, so an automated submitter doesn't push you over a cap. The
+gate is **on by default** and governed by two env vars (`SHEPHERD_USAGE_HOLD_ENABLED`,
+default on; `SHEPHERD_USAGE_HOLD_PCT`, default `80`).
+
+A submission is held only when **all** of these hold (`src/usage-hold.ts`):
+
+- the gate is enabled, and the request did not set `force: true`;
+- at least one session is already **running**; and
+- the higher of the 5-hour and weekly usage windows is at or above
+  `SHEPHERD_USAGE_HOLD_PCT`.
+
+When usage can't be measured (api-key auth, or caps not yet calibrated) the windows
+read `0`, so a task is **never** held — Shepherd won't freeze work it can't measure.
+
+A held submission returns **`200 { "held": true, "id", "count" }`** (not `201`) and no
+agent spawns yet. Held tasks are released **FIFO automatically** by a ~30 s sweeper once
+usage drops back below the threshold; an operator can also list, release, or drop them via
+`GET /api/held`, `POST /api/held/:id/spawn`, and `DELETE /api/held/:id`. To bypass the gate
+for a single submission, send `"force": true` in the create body.
 
 ## Steering and ending a task
 


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc update summary

## Changes

- **`docs/external-task-api.md`** — Documented the **usage-aware hold gate**
  (added in #825/#830, `src/usage-hold.ts` + `src/server.ts` `tryHoldNewTask`,
  `src/validate.ts` allowed-key `force`). The page previously claimed a submission
  "spawns immediately"; with the gate **on by default** a submission made at high
  usage is instead queued and answered `200 { held:true, id, count }`. Specifically:
  - Added a caveat to the TL;DR `201` paragraph.
  - Added a `200` (held) row to the Responses table.
  - Added the `force` field to the request-schema table.
  - Added a new **Usage-aware hold gate** section describing the hold conditions
    (`shouldHold`: enabled + not `force` + ≥1 running session + max(5h, week) ≥
    `SHEPHERD_USAGE_HOLD_PCT`), the never-hold-when-unmeasurable behavior, the ~30 s
    FIFO auto-release sweeper (`releaseHeldTasks`, `src/index.ts`), the `/api/held`
    endpoints (`src/server.ts` `handleHeld`), and `force: true` as the bypass.
  - Corrected the `SHEPHERD_REPO_ROOT` "Default" in the access-gate table from
    `~/Work` to `~` (home), matching `src/config.ts` (`process.env.HOME`) and the
    Configuration page (the two in-scope docs previously disagreed).

- **`docs-site/src/content/docs/reference/configuration.md`** — Added the two
  usage-hold env vars to the Core table: `SHEPHERD_USAGE_HOLD_ENABLED` (default
  `true`) and `SHEPHERD_USAGE_HOLD_PCT` (default `80`), grounded in `src/config.ts`
  (lines ~482–489). These govern the behavior newly documented in the External Task
  API page and were absent from the env reference.

## Uncertain / needs human judgment

- **`configuration.md` is a curated subset, not exhaustive**, despite its
  description ("Every environment variable…"). Many real env vars in `src/config.ts`
  remain undocumented (e.g. `SHEPHERD_VAPID_*`, `SHEPHERD_PUSH_COOLDOWN_MS`,
  `SHEPHERD_HOOKS_INGEST`/`_SIGNALS`, `SHEPHERD_AUTH_MODE`,
  `SHEPHERD_API_KEY_HELPER_PATH`, `SHEPHERD_EXTRA_CREDITS_DRAIN_CEILING`,
  `SHEPHERD_REVIEW_CYCLES_CAP`, `SHEPHERD_PLAN_REVIEW_CYCLES_CAP`,
  `SHEPHERD_DEFAULT_MODEL`, `SHEPHERD_FABLE_AVAILABLE`,
  `SHEPHERD_SANDBOX_EXTRA_HOSTS`, `SHEPHERD_LLM_NAMING`, `SHEPHERD_NAMER_MODEL`,
  `SHEPHERD_HOUSE_RULES_BUDGET_CHARS`, `SHEPHERD_AUTOPILOT_*`,
  `SHEPHERD_AUTOMERGE_REBASE_CAP`, `SHEPHERD_SESSION_HOUSEKEEPING`, …). This looks
  like a deliberate curation choice rather than staleness, so I did not bulk-add
  them. A human may want to decide whether the page should aim for completeness.

- **The `/usage` token-spend dashboard** (a large recent feature — Phases 0–2 plus
  the cap-scrape Limits trend, #943/#953/#968/#989, with a top-bar entry and live
  burn-rate/limits/overhead/spend lenses) is a significant new operator-facing UI
  surface that no in-scope page mentions. The current docs generally don't enumerate
  UI features, so I treated this as out of scope rather than staleness — but if the
  docs should cover it, that's a human call (and would likely need a new page, which
  is explicitly out of scope here).

- **`docs/token-usage-analysis.md`** — Verified the methodology's weight description
  ("Opus 5/25, Sonnet 3/15, Haiku 1/5, Fable 10/50", cache at 0.1×/1.25×/2×) still
  matches `src/pricing.ts`. The report is an explicitly frozen historical
  reconstruction ("table figures … are unchanged"), so I left its numbers untouched.
  No change made.

- **`docs/sandbox-security.md`** — Spot-checked the egress allowlist claim
  (`api.anthropic.com` + `statsig.anthropic.com` + GitHub hosts) against
  `src/egress.ts`; still accurate. No change made.