### PR TITLE
feat(plan-gate): log plan-blocks capture for #804 activation tracking

### DIFF
--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -321,6 +321,12 @@ export class PlanGateService {
       return "error";
     }
     const blocks = this.readPlanBlocks(session.worktreePath);
+    // Observe-only telemetry for #804: how often the live planning agent actually emits a usable
+    // (grounded, ≥1-block) plan-blocks sidecar. The `plan_gates` row is a lossy upsert snapshot, so
+    // this durable per-capture log is the reliable activation-rate surface for the strengthen/close call.
+    console.log(
+      `[plan-gate] plan-blocks captured session=${session.id} planHash=${planHash.slice(0, 8)} blocks=${blocks.length}`,
+    );
     this.inflight.set(session.id, {
       sessionId: session.id,
       repoPath: session.repoPath,


### PR DESCRIPTION
## What

Adds one observe-only log line at `PlanGateService.begin()` recording the grounded plan-block count per capture:

```
[plan-gate] plan-blocks captured session=<id> planHash=<8> blocks=<n>
```

## Why

Follow-up to #804 (observe plan-block sidecar activation before deciding whether to strengthen the emit path). Re-checking #804 today surfaced that the **only** measurement surface is the `plan_gates.blocks` column — but that row is keyed by `sessionId` and upserted, so re-plans overwrite and archived sessions leave no row (lossy), and there is **zero** plan-block logging in `shepherd.log`. So the activation rate can't be measured reliably.

This durable per-capture log is the reliable activation-rate surface: count `blocks=0` vs `blocks≥1` over a window to make the strengthen-vs-close call on #804. Strictly additive, observe-only — no behavior change.

`blocks` is already grounded here (`readPlanBlocks` → `groundPlanBlocks`), so `blocks=<n>` is exactly "how often `groundPlanBlocks` keeps ≥1 block" — the metric #804 asks for.

## Test

- `bun run lint` clean, `bunx tsc --noEmit` clean.
- `bun test ./test/plan-gate-service.test.ts` → 54 pass / 0 fail (log line observed firing with both `blocks=0` and `blocks=1`).

Refs #804. `[no-feature-entry]` (server-side observability, no user-facing UX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)