### PR TITLE
fix(ci): onboarding-release-gate uses REST issues API, not gh issue list

### DIFF
--- a/.github/workflows/onboarding-release-gate.yml
+++ b/.github/workflows/onboarding-release-gate.yml
@@ -48,8 +48,15 @@ jobs:
           # the human-facing active-regression signal.
 
           # (1) Active regression?
-          if [ "$(gh issue list --repo "$REPO" --label onboarding-regression --state open --json url --jq 'length')" -gt 0 ]; then
-            url=$(gh issue list --repo "$REPO" --label onboarding-regression --state open --json url --jq '.[0].url')
+          # Use the REST issues endpoint via `gh api` (not `gh issue list`): under the
+          # Actions GITHUB_TOKEN, gh's GraphQL-backed `issue list` 403s "Resource not
+          # accessible by integration" even with `issues: read` granted, whereas the REST
+          # endpoint honors it cleanly. `select(.pull_request|not)` drops any PR that shares
+          # the label (the REST issues endpoint returns PRs too).
+          open=$(gh api "repos/$REPO/issues?labels=onboarding-regression&state=open&per_page=100" \
+            --jq '[.[] | select(.pull_request|not)]')
+          if [ "$(printf '%s' "$open" | jq 'length')" -gt 0 ]; then
+            url=$(printf '%s' "$open" | jq -r '.[0].html_url')
             echo "::error::Onboarding harness is RED (open regression issue) — resolve before releasing: $url"
             exit 1
           fi


### PR DESCRIPTION
## Problem

The **Onboarding release gate** crashes on every release-please PR that actually runs it, blocking releases for a plumbing reason rather than a real onboarding regression.

Failing run: [release 1.36.0 → run 27930377999](https://github.com/erwins-enkel/shepherd/actions/runs/27930377999/job/82641193236)

```
gh issue list --repo "$REPO" --label onboarding-regression --state open --json url --jq 'length'
→ gh: Resource not accessible by integration (HTTP 403)
→ ##[error]Process completed with exit code 1
```

The run's token **has** the scope — "Set up job" logs `Issues: read`, `Contents: read`, `Metadata: read`, and the workflow declares `permissions: issues: read`. The problem is *which* call fails: `gh issue list` is **GraphQL-backed**, and under the Actions `GITHUB_TOKEN` (a GitHub App installation token) it 403s "Resource not accessible by integration" even with `issues: read` granted. The workflow's other calls (`gh api .../commits`, `.../statuses`) are REST and work in the same job.

Latent since the gate was introduced (`850449fb`, never modified) — prior release-please runs all show `action_required` (gated, never executed), so this is the first run to actually execute the step.

## Fix

Replace the two GraphQL `gh issue list` calls with the REST `issues` endpoint via `gh api` — consistent with the file's other (working) calls and proven to honor `issues: read`. A `select(.pull_request|not)` guard drops any PR that shares the label (the REST issues endpoint returns PRs too). Gate semantics (fail-closed on an open regression) are unchanged.

## Verification

- YAML parses; the exact shell pipeline runs clean under `set -euo pipefail` (length-0 → gate proceeds, jq paths valid).
- **This PR's CI does NOT exercise the gate**: it is `pull_request`-only and guarded by `startsWith(github.head_ref, 'release-please--')`, and this branch (`shepherd/what-going-here-https`) does not match — so the gate is *skipped* here.
- The "other REST calls work" evidence covers `contents:read` (commits/statuses), **not** the `issues` endpoint specifically. Direct empirical proof requires running the gate under the real Actions token via a `release-please--*` branch (see PR thread).

CI-only change; no app/UI/i18n/feature-catalog impact. `[no-feature-entry]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)