### PR TITLE
refactor(repo-switcher): remove dedicated per-repo learnings bar

### DIFF
--- a/ui/src/lib/components/RepoSwitcher.browser.test.ts
+++ b/ui/src/lib/components/RepoSwitcher.browser.test.ts
@@ -148,25 +148,24 @@ describe("RepoSwitcher — filter rail", () => {
       .toBeVisible();
   });
 
-  it("active chip with insights shows the ✦ count ONCE — telemetry line only, no chip mark (no dup)", async () => {
+  it("the active chip keeps its ✦ mark and renders no learnings bar", async () => {
     const learnChip = chip({ repoPath: "/repo/alpha", insights: 31 });
     const { container } = render(RepoSwitcher, {
       chips: [learnChip, chip({ repoPath: "/repo/beta" })],
       repoFilter: "/repo/alpha",
       onrepofilter: () => {},
     });
-    // the active chip drops its decorative mark...
-    expect(
-      container.querySelector(".rs-learn-mark"),
-      "no decorative ✦ mark on the active chip",
-    ).toBeNull();
-    // ...the actionable ✦ count lives once, in the telemetry detail line below
-    const insightsBtns = container.querySelectorAll(".rs-insights");
-    expect(insightsBtns.length, "exactly one actionable ✦ count").toBe(1);
-    expect(insightsBtns[0].querySelector(".rs-insights-n")?.textContent).toBe("31");
+    // the active chip keeps its decorative ✦ mark (no dedicated bar to dup with anymore)
+    const mark = container.querySelector<HTMLElement>(".rs-learn-mark");
+    expect(mark, "✦ mark on the active chip").not.toBeNull();
+    expect(mark!.querySelector(".rs-learn-n")?.textContent).toBe("31");
+    // the dedicated learnings bar is gone (learnings live on the gear menu)
+    expect(container.querySelector(".rs-insights"), "no learnings bar").toBeNull();
+    // insights-only repo (no drain) → no telemetry detail line at all
+    expect(container.querySelector(".rs-tele"), "no detail line for insights-only repo").toBeNull();
   });
 
-  it("a NON-active chip with insights keeps its ✦ mark even while another repo is filtered", async () => {
+  it("every chip with insights keeps its ✦ mark, including the active one", async () => {
     const { container } = render(RepoSwitcher, {
       chips: [
         chip({ repoPath: "/repo/alpha", insights: 5 }),
@@ -175,10 +174,11 @@ describe("RepoSwitcher — filter rail", () => {
       repoFilter: "/repo/beta",
       onrepofilter: () => {},
     });
-    // beta is active → its chip mark is gone; alpha (inactive) keeps its mark
+    // both alpha (inactive) AND beta (active) now carry marks — no active-chip suppression
     const marks = container.querySelectorAll(".rs-learn-mark");
-    expect(marks.length, "one mark — on the inactive chip only").toBe(1);
+    expect(marks.length, "a mark on each chip with insights").toBe(2);
     expect(marks[0].querySelector(".rs-learn-n")?.textContent).toBe("5");
+    expect(marks[1].querySelector(".rs-learn-n")?.textContent).toBe("9");
   });
 
   it("the active filter chip carries no underline text-decoration", async () => {
@@ -254,30 +254,25 @@ describe("RepoSwitcher — filter rail", () => {
     expect(live!.textContent?.trim()).toBe("");
   });
 
-  it("lone-repo with insights > 0 shows 'LEARNINGS' label and insights count in the telemetry button", async () => {
-    const { container } = render(RepoSwitcher, {
+  it("a lone-repo with only learnings (insights/curate, no drain) renders no bar and no detail line", async () => {
+    // insights-only
+    const insightsRender = render(RepoSwitcher, {
       chips: [chip({ repoPath: "/repo/solo", insights: 5 })],
       repoFilter: null,
       onrepofilter: () => {},
     });
-    const btn = container.querySelector<HTMLElement>(".rs-insights");
-    expect(btn, "insights button present").not.toBeNull();
-    expect(btn!.querySelector(".rs-insights-label")?.textContent?.trim()).toBe(m.learnings_title());
-    expect(btn!.querySelector(".rs-insights-n")?.textContent?.trim()).toBe("5");
-  });
+    expect(insightsRender.container.querySelector(".rs-insights"), "no learnings bar").toBeNull();
+    expect(insightsRender.container.querySelector(".rs-tele"), "no detail line").toBeNull();
+    insightsRender.unmount();
 
-  it("lone-repo with insights: 0, curate > 0 shows 'TRIM' label and curate count in the telemetry button", async () => {
-    const { container } = render(RepoSwitcher, {
+    // curate-only
+    const curateRender = render(RepoSwitcher, {
       chips: [chip({ repoPath: "/repo/solo", insights: 0, curate: 3 })],
       repoFilter: null,
       onrepofilter: () => {},
     });
-    const btn = container.querySelector<HTMLElement>(".rs-insights");
-    expect(btn, "insights button present").not.toBeNull();
-    expect(btn!.querySelector(".rs-insights-label")?.textContent?.trim()).toBe(
-      m.learnings_trim_title(),
-    );
-    expect(btn!.querySelector(".rs-insights-n")?.textContent?.trim()).toBe("3");
+    expect(curateRender.container.querySelector(".rs-insights"), "no learnings bar").toBeNull();
+    expect(curateRender.container.querySelector(".rs-tele"), "no detail line").toBeNull();
   });
 
   it("clicking the queued button expands the inline queue (fetches via getDrainQueue)", async () => {

--- a/ui/src/lib/components/RepoSwitcher.svelte
+++ b/ui/src/lib/components/RepoSwitcher.svelte
@@ -10,7 +10,6 @@
     chips,
     repoFilter,
     onrepofilter,
-    onlearnings,
     mobile = false,
   }: {
     chips: RepoChip[];
@@ -18,8 +17,6 @@
     repoFilter: string | null;
     // toggle the herd filter for a repo; null clears it
     onrepofilter: (repoPath: string | null) => void;
-    // open the learnings drawer for a repo
-    onlearnings?: (repoPath: string) => void;
     // true when rendered on a phone-sized viewport — suppresses the lone-repo
     // telemetry band (collapses into the selected-state subline instead)
     mobile?: boolean;
@@ -143,9 +140,9 @@
             {#if chip.drain?.paused}
               <span class="rs-paused-dot" aria-hidden="true">●</span>
             {/if}
-            {#if !active && (chip.insights > 0 || chip.curate > 0)}
-              <!-- decorative ✦ mark — suppressed on the active chip, whose actionable
-                   ✦ count already shows in the telemetry detail line below (no dup) -->
+            {#if chip.insights > 0 || chip.curate > 0}
+              <!-- decorative ✦ mark: this repo has pending learnings/curate. Shown on every
+                   chip including the active one — open the learnings drawer via the gear menu. -->
               <span class="rs-learn-mark" title={m.learnings_badge_tip()} aria-hidden="true"
                 >✦{#if chip.insights > 0}<span class="rs-learn-n">{chip.insights}</span>{/if}</span
               >
@@ -157,13 +154,13 @@
 
     {#if activeChip}
       {#key activeChip.repoPath}
-        <RepoChipTelemetry chip={activeChip} {onlearnings} />
+        <RepoChipTelemetry chip={activeChip} />
       {/key}
     {/if}
   </div>
 {:else if loneChip && !mobile}
   <div class="rs">
-    <RepoChipTelemetry chip={loneChip} {onlearnings} />
+    <RepoChipTelemetry chip={loneChip} />
   </div>
 {/if}
 

--- a/ui/src/lib/components/RepoSwitcher.svelte
+++ b/ui/src/lib/components/RepoSwitcher.svelte
@@ -24,7 +24,7 @@
 
   // ── render branch selection ────────────────────────────────────────────────
   const railVisible = $derived(chipRailVisible(chips, repoFilter));
-  // Lone-repo telemetry: one repo with no active filter, carrying drain/learnings.
+  // Lone-repo telemetry: one repo with no active filter, carrying drain telemetry.
   // (When that lone repo IS the active filter, the rail shows instead — see railVisible.)
   const loneChip = $derived(chips.length === 1 && chipHasTelemetry(chips[0]) ? chips[0] : null);
   // The active chip whose detail line shows below the rail — only when it has telemetry.

--- a/ui/src/lib/components/queue-strip.test.ts
+++ b/ui/src/lib/components/queue-strip.test.ts
@@ -421,7 +421,7 @@ describe("chipHasTelemetry", () => {
     return { repoPath: "/repos/a", count: 1, drain: null, insights: 0, curate: 0, ...over };
   }
 
-  it("false when no drain, no insights, no curate", () => {
+  it("false when no drain", () => {
     expect(chipHasTelemetry(chip({}))).toBe(false);
   });
 
@@ -429,12 +429,14 @@ describe("chipHasTelemetry", () => {
     expect(chipHasTelemetry(chip({ drain: drain({}) }))).toBe(true);
   });
 
-  it("true when insights > 0", () => {
-    expect(chipHasTelemetry(chip({ insights: 1 }))).toBe(true);
+  // learnings no longer surface on the detail line (they live on the chip ✦ mark + the
+  // gear menu), so insights/curate alone do not warrant a telemetry band.
+  it("false when only insights > 0 (no drain)", () => {
+    expect(chipHasTelemetry(chip({ insights: 1 }))).toBe(false);
   });
 
-  it("true when curate > 0", () => {
-    expect(chipHasTelemetry(chip({ curate: 2 }))).toBe(true);
+  it("false when only curate > 0 (no drain)", () => {
+    expect(chipHasTelemetry(chip({ curate: 2 }))).toBe(false);
   });
 });
 

--- a/ui/src/lib/components/queue-strip.ts
+++ b/ui/src/lib/components/queue-strip.ts
@@ -85,9 +85,11 @@ export function chipRailVisible(chips: RepoChip[], repoFilter: string | null): b
   return chips.length >= 2 || (repoFilter !== null && chips.some((c) => c.repoPath === repoFilter));
 }
 
-/** Whether a chip carries any drain/learnings telemetry worth showing on its own. */
+/** Whether a chip carries drain telemetry worth showing on its own detail line.
+ *  Learnings are no longer surfaced here (they live on the chip's ✦ mark + the gear
+ *  menu), so an insights-only repo would otherwise render an empty detail band. */
 export function chipHasTelemetry(chip: RepoChip): boolean {
-  return chip.drain !== null || chip.insights > 0 || chip.curate > 0;
+  return chip.drain !== null;
 }
 
 /** Whether an active repo filter should be cleared because its repo no longer has any live

--- a/ui/src/lib/components/repo-switcher/RepoChipTelemetry.svelte
+++ b/ui/src/lib/components/repo-switcher/RepoChipTelemetry.svelte
@@ -8,18 +8,11 @@
 
   let {
     chip,
-    onlearnings,
   }: {
     chip: RepoChip;
-    // open the learnings drawer for a repo
-    onlearnings?: (repoPath: string) => void;
   } = $props();
 
   const d = $derived(chip.drain);
-  const insightsLabel = $derived(
-    chip.insights > 0 ? m.learnings_title() : m.learnings_trim_title(),
-  );
-  const insightsCount = $derived(chip.insights > 0 ? chip.insights : chip.curate);
 
   // ── inline queue expansion (mirrors QueueStrip toggle/loading/failed) ───────
   // At most one repo's queue is expanded at a time, fetched fresh on open.
@@ -79,22 +72,6 @@
     {:else}
       <span class="rs-queued">{m.drain_queued({ count: d.queued })}</span>
     {/if}
-  {/if}
-
-  {#if chip.insights > 0 || chip.curate > 0}
-    <button
-      type="button"
-      class="rs-insights"
-      title={m.learnings_badge_tip()}
-      aria-label={chip.insights > 0
-        ? m.learnings_open_aria({ count: chip.insights })
-        : m.learnings_open_curate_aria({ count: chip.curate })}
-      onclick={() => onlearnings?.(chip.repoPath)}
-    >
-      <span class="rs-insights-icon" aria-hidden="true">✦</span><span class="rs-insights-label"
-        >{insightsLabel}</span
-      ><span class="rs-insights-n">{insightsCount}</span>
-    </button>
   {/if}
 
   {#if d?.paused}
@@ -170,26 +147,6 @@
   .rs-queued-btn:hover,
   .rs-queued-btn:focus-visible {
     color: var(--color-ink-bright);
-  }
-  .rs-insights {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    font: inherit;
-    letter-spacing: inherit;
-    background: none;
-    border: none;
-    padding: 0;
-    margin: 0;
-    cursor: pointer;
-    color: var(--color-faint);
-  }
-  .rs-insights:hover,
-  .rs-insights:focus-visible {
-    color: var(--color-ink-bright);
-  }
-  .rs-insights-n {
-    font-variant-numeric: tabular-nums;
   }
   /* a paused drain is the loud thing in the detail line: red, reason inline */
   .rs-pause {
@@ -269,8 +226,7 @@
   /* Coarse pointers: ≥44px tap targets on the inline action buttons
      (mirrors the QueueStrip / TopBar coarse-pointer pattern). */
   @media (pointer: coarse) {
-    .rs-queued-btn,
-    .rs-insights {
+    .rs-queued-btn {
       min-height: 44px;
       display: inline-flex;
       align-items: center;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -185,9 +185,9 @@
   // deep-link (issue #852: ?learnings=1 / "open-learnings") that opens the drawer before
   // the async load populates items/injectable isn't reversed by the still-empty lists.
   let learningsLoaded = $state(false);
-  // When the learnings drawer is opened from a repo's chip (its ✦ in the RepoSwitcher
-  // rail), this carries that repoPath so the drawer scrolls to the matching section;
-  // null = opened globally.
+  // When the learnings drawer is opened from the gear menu and there's nothing to
+  // approve, this carries the first over-budget ("curate") repoPath so the drawer scrolls
+  // to the matching section; null = opened globally with proposals to review.
   let learningsRepo = $state<string | null>(null);
   // Herd repo filter (full repo path), toggled from a RepoSwitcher chip or from a
   // card's inline repo emoji; null = all repos. Only narrows the herd list views —
@@ -1678,10 +1678,6 @@
         {repoFilter}
         mobile={mobile.current}
         onrepofilter={(repoPath) => (repoFilter = repoPath)}
-        onlearnings={(repoPath) => {
-          learningsRepo = repoPath;
-          showLearnings = true;
-        }}
       />
       <QueueStrip autoMerge={store.autoMerge} />
     </header>


### PR DESCRIPTION
## What

Removes the dedicated **"✦ Learnings N" bar** that rendered below the active/lone repo chip in the repo switcher (the `.rs-insights` button in `RepoChipTelemetry`). Learnings stay reachable through the existing **global learnings link in the gear menu** (TopBar / mobile sheet) — unchanged.

Per the agreed scope, only the bar is removed; the small decorative **`✦N` marks on the chips** stay.

## Behavior change (intentional, not pure removal)

The `✦N` mark now also shows on the **active/filtered** chip. That mark was previously suppressed on the active chip *solely* to avoid duplicating the bar's count; with the bar gone, suppressing it would hide the filtered repo's learnings count entirely. So the suppression (`!active` guard) is removed and every chip with learnings shows its mark.

## Notable internals

- `chipHasTelemetry()` is narrowed to **drain-only**. The telemetry detail line now carries only drain info (in-flight / queued / paused + inline queue), so an insights-only repo (no drain) would otherwise render an empty band.
- `onlearnings` prop threading (`+page.svelte` → `RepoSwitcher` → `RepoChipTelemetry`) is dropped. `RepoChip.insights`/`curate` plumbing is kept — the chip marks still use it. Global learnings counts derive from the learnings store, not `RepoChip`, so the gear-menu badge is untouched.

## Tests

- `RepoSwitcher.browser.test.ts`: reworked the obsolete bar tests — active chip keeps its mark + renders no bar; every chip with insights keeps its mark (active included → `marks.length === 2`); lone-repo with only learnings renders no bar/detail line.
- `queue-strip.test.ts`: `chipHasTelemetry` insights/curate cases now assert drain-only (false without a drain).
- `cd ui && bun run check` → 0 errors; `cd ui && bun run test` → 1927 passed.

No i18n catalog change (no orphaned keys), no feature-catalog entry (removal, not a `feat`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)