### PR TITLE
fix(usage): extra-credits bar renders full-width to match 5h/weekly gauges

### DIFF
--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -1097,6 +1097,43 @@ describe("TopBar — CR extra-credit gauge", () => {
       true,
     );
   });
+
+  it("mobile sheet: extra-credits bar is full-width (matches sibling 5H/Weekly bars)", async () => {
+    // Regression guard for the "46px stub" bug: CreditDetail rendered its bar at 46px
+    // in any context that did not pass the `wide` prop (touch popover, mobile sheet).
+    // The fix collapses the .g-bar rule to always be 100% wide. In the mobile sheet,
+    // sibling gauge rows are `width:100%` so credit-bar and gauge-bar widths must be
+    // equal within sub-pixel rounding.
+    //
+    // Mutation check (verified): with CreditDetail's .g-bar left at `width: 46px` (no
+    // full-width rule reachable from mobile-sheet context), this test FAILS — the credit
+    // bar measures ~46px while the sibling .g-bar-wide measures the full sheet width, so
+    // the equality assertion fails. Restoring .g-bar { width: 100% } makes it pass.
+    await page.viewport(390, 800);
+    document.body.style.width = "390px";
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.mobile,
+      ...sessionsProp(0),
+      limits: limitsWithCredit({}),
+    });
+    // Open the gear sheet.
+    await page.getByRole("button", { name: m.topbar_menu_aria() }).click();
+    // The sheet renders a usage section with gauge rows + credit detail.
+    const creditBar = document.querySelector<HTMLElement>(".credit-detail .g-bar");
+    expect(creditBar, "credit bar rendered in mobile sheet").not.toBeNull();
+    const siblingBar = document.querySelector<HTMLElement>(".sheet-gauge-row .g-bar-wide");
+    expect(siblingBar, "sibling gauge bar rendered in mobile sheet").not.toBeNull();
+    const creditWidth = creditBar!.getBoundingClientRect().width;
+    const siblingWidth = siblingBar!.getBoundingClientRect().width;
+    expect(creditWidth, "credit bar must be wider than the 46px stub").toBeGreaterThan(100);
+    // Sub-pixel rounding tolerance of 1px — both are width:100% of the same parent.
+    expect(
+      Math.abs(creditWidth - siblingWidth),
+      `credit bar (${creditWidth.toFixed(1)}px) must match sibling gauge bar (${siblingWidth.toFixed(1)}px)`,
+    ).toBeLessThanOrEqual(1);
+  });
 });
 
 describe("TopBar — mobile gear sheet stays open on in-sheet clicks (dismissOnOutside bug)", () => {

--- a/ui/src/lib/components/top-bar/CreditDetail.svelte
+++ b/ui/src/lib/components/top-bar/CreditDetail.svelte
@@ -12,7 +12,6 @@
     refreshing,
     refreshError,
     onRefresh,
-    wide = false,
   }: {
     credits: CreditWindow | null;
     creditFill: number;
@@ -22,7 +21,6 @@
     refreshing: boolean;
     refreshError: boolean;
     onRefresh: () => void;
-    wide?: boolean;
   } = $props();
 
   // relativeAge returns the "now" sentinel for <60s; branch it to a natural phrase
@@ -36,7 +34,7 @@
       <span class="gp-period">{m.topbar_credits_period()}</span>
       <span class="g-pct credit-amount" style="color:{creditColor}">{creditAmount}</span>
     </div>
-    <span class="g-bar g-bar-wide {wide ? 'wide' : ''}"
+    <span class="g-bar"
       ><span class="g-fill" style="transform:scaleX({creditFill});background:{creditColor}"
       ></span></span
     >
@@ -74,8 +72,8 @@
 
 <style>
   .g-bar {
-    width: 46px;
-    height: 5px;
+    width: 100%;
+    height: 6px;
     background: var(--color-line);
     border: 1px solid var(--color-line-bright);
     overflow: hidden;
@@ -91,10 +89,6 @@
     font-size: var(--fs-meta);
     min-width: 30px;
     text-align: right;
-  }
-  .g-bar.wide {
-    width: 100%;
-    height: 6px;
   }
   .credit-amount {
     min-width: max-content;

--- a/ui/src/lib/components/top-bar/TopBarUsage.svelte
+++ b/ui/src/lib/components/top-bar/TopBarUsage.svelte
@@ -231,7 +231,6 @@
               {refreshing}
               {refreshError}
               {onRefresh}
-              wide
             />
           </div>
         {/if}


### PR DESCRIPTION
## Problem

In the USAGE panel (mobile Controls gear sheet and the touch popover), the **Extra Credits** progress bar rendered as a ~46px stub while the **5-Hour** and **Weekly** bars span the full panel width.

![reported: narrow Extra Credits bar]

## Root cause

`CreditDetail.svelte` marked its bar `g-bar g-bar-wide`, but its **own scoped `<style>`** only defined width for `.g-bar` (46px) and `.g-bar.wide` (100%) — there was **no `.g-bar-wide` rule in its scope**. Svelte scopes styles per component, so the parent rules targeting `.g-bar-wide` (in `TopBarUsage.svelte` / `TopBarMobileSheet.svelte`) cannot reach the child element. The bar was full-width only when the `wide` prop was passed:

- Desktop hover popover passed `wide` → correct.
- Touch popover and mobile gear sheet omitted `wide` → 46px stub (the bug).

`CreditDetail` is only ever rendered in a detail/popover/sheet next to full-width gauge bars (the inline credit gauge is the separate `CreditGauge`), so the bar should always be full-width — the `wide` prop was the design smell.

## Fix

- `CreditDetail.svelte`: bar is now unconditionally full-width (`.g-bar { width: 100% }`); removed the redundant `wide` prop + `.g-bar.wide` rule + the no-op `g-bar-wide` class on the span.
- `TopBarUsage.svelte`: dropped the now-unused `wide` attribute at the one call site.

## What "match 5h/week" means per surface

- **Mobile sheet** + **desktop popover**: pixel-exact (siblings are `width:100%`).
- **Touch popover**: the stub is gone; the credit bar is a full-width column bar, structurally distinct from the narrower `flex:1` gauge rows there (not expected to equal them).

## Tests

Added a regression test pinned to the mobile gear sheet (a non-`wide` context): it measures the real rendered widths and asserts the credit `.g-bar` equals the sibling `.sheet-gauge-row .g-bar-wide` within 1px, plus a `>100px` stub guard. Includes a verified mutation-check note (the test fails against the 46px-stub markup).

`cd ui && bun run check` clean; `bun run test` 1929/1929 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)