### PR TITLE
fix(glossary): activation-only inline disclosure so tooltip never obscures content

### DIFF
--- a/ui/src/lib/components/GlossaryTerm.browser.test.ts
+++ b/ui/src/lib/components/GlossaryTerm.browser.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page, userEvent } from "vitest/browser";
+import "../../app.css";
+import GlossaryTerm from "./GlossaryTerm.svelte";
+import { m } from "$lib/paraglide/messages";
+
+describe("GlossaryTerm — activation-only inline disclosure", () => {
+  it("click → inline panel opens, no floating tooltip", async () => {
+    render(GlossaryTerm, { id: "epic", label: "epic" });
+
+    const btn = page.getByRole("button", { name: "epic" });
+    await btn.click();
+
+    // inline panel present with correct role and body text
+    await expect.element(page.getByRole("note")).toBeVisible();
+    await expect.element(page.getByRole("note")).toHaveTextContent(m.gloss_epic_def());
+
+    // no floating tooltip open
+    const tooltips = document.querySelectorAll(".gloss-tooltip:popover-open");
+    expect(tooltips).toHaveLength(0);
+  });
+
+  it("bare Tab-focus is inert — nothing opens", async () => {
+    render(GlossaryTerm, { id: "epic", label: "epic" });
+
+    const btn = page.getByRole("button", { name: "epic" });
+    await btn.element().focus();
+
+    // no inline panel
+    const inlines = document.querySelectorAll(".gloss-inline");
+    expect(inlines).toHaveLength(0);
+
+    // no floating tooltip open
+    const tooltips = document.querySelectorAll(".gloss-tooltip:popover-open");
+    expect(tooltips).toHaveLength(0);
+  });
+
+  it("keyboard Enter → inline panel opens", async () => {
+    render(GlossaryTerm, { id: "epic", label: "epic" });
+
+    const btn = page.getByRole("button", { name: "epic" });
+    await btn.element().focus();
+
+    // confirm nothing open after focus
+    expect(document.querySelectorAll(".gloss-inline")).toHaveLength(0);
+
+    // pressing Enter on a focused button fires a native click
+    await userEvent.keyboard("{Enter}");
+
+    await expect.element(page.getByRole("note")).toBeVisible();
+  });
+
+  it("hover → floating tooltip opens, no inline panel", async () => {
+    render(GlossaryTerm, { id: "epic", label: "epic" });
+
+    const btn = page.getByRole("button", { name: "epic" });
+    btn
+      .element()
+      .dispatchEvent(new PointerEvent("pointerenter", { pointerType: "mouse", bubbles: true }));
+
+    // floating tooltip should become open
+    await expect
+      .poll(() => {
+        return document.querySelectorAll(".gloss-tooltip:popover-open").length;
+      })
+      .toBe(1);
+
+    // no inline panel
+    expect(document.querySelectorAll(".gloss-inline")).toHaveLength(0);
+  });
+
+  it("pinned inline survives mouse-leave", async () => {
+    render(GlossaryTerm, { id: "epic", label: "epic" });
+
+    const btn = page.getByRole("button", { name: "epic" });
+    await btn.click();
+
+    // verify inline open
+    await expect.element(page.getByRole("note")).toBeVisible();
+
+    // dispatch mouse pointerleave
+    btn
+      .element()
+      .dispatchEvent(new PointerEvent("pointerleave", { pointerType: "mouse", bubbles: true }));
+
+    // inline still present
+    await expect.element(page.getByRole("note")).toBeVisible();
+  });
+
+  it("external term → inline panel has role=dialog and Wikipedia link", async () => {
+    render(GlossaryTerm, { id: "pr", label: "PR" });
+
+    const btn = page.getByRole("button", { name: "PR" });
+    await btn.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect.element(dialog).toBeVisible();
+
+    // Wikipedia link href contains expected slug
+    const link = dialog.getByRole("link");
+    await expect.element(link).toBeVisible();
+    const href = await link.element().getAttribute("href");
+    expect(href).toContain("/wiki/Distributed_version_control#Pull_requests");
+  });
+});

--- a/ui/src/lib/components/GlossaryTerm.svelte
+++ b/ui/src/lib/components/GlossaryTerm.svelte
@@ -19,20 +19,14 @@
   );
 
   let open = $state(false);
-  // Presentation is chosen per interaction at open time: hover/focus → "floating"
-  // (anchored popover), touch-tap → "inline" (in-flow disclosure that pushes content
-  // down). Per-interaction (not per-device) so hybrid touch+mouse devices keep both.
+  // Presentation is chosen per interaction at open time: mouse-hover → "floating"
+  // (transient anchored popover), activation (click / tap / Enter / Space) → "inline"
+  // (in-flow disclosure that pushes content down, never obscures). Bare focus opens
+  // nothing. Per-interaction (not per-device) so detection can't misfire.
   let presentation = $state<"floating" | "inline">("floating");
   let btnEl = $state<HTMLButtonElement | null>(null);
   let popEl = $state<HTMLElement | null>(null);
   let inlineEl = $state<HTMLElement | null>(null);
-
-  // Detect touch (coarse pointer) — determines open strategy.
-  // We check at pointer event time too (pointerType === "touch") for accuracy,
-  // but a module-level media query covers the button enter/leave handlers.
-  function isCoarse(): boolean {
-    return typeof window !== "undefined" && window.matchMedia("(pointer: coarse)").matches;
-  }
 
   // Floating UI: position popover relative to button whenever open + both elements exist.
   $effect(() => {
@@ -131,14 +125,16 @@
     open = false;
   }
 
-  // Desktop (fine pointer): hover open, grace-delayed close.
+  // Hover (non-touch): open floating tooltip. Don't override a pinned inline.
   function onPointerenter(e: PointerEvent) {
-    if (e.pointerType === "touch") return; // coarse — handled by click
+    if (e.pointerType === "touch") return;
+    if (open && presentation === "inline") return;
     presentation = "floating";
     openTooltip();
   }
   function onPointerleave(e: PointerEvent) {
     if (e.pointerType === "touch") return;
+    if (presentation !== "floating") return;
     scheduleClose();
   }
 
@@ -152,32 +148,11 @@
     scheduleClose();
   }
 
-  // Desktop: focus open/close.
-  function onFocus() {
-    if (isCoarse()) return;
-    presentation = "floating";
-    openTooltip();
-  }
-  function onBlur(e: FocusEvent) {
-    if (isCoarse()) return;
-    // Don't close if focus moved into the tooltip (e.g. keyboard Tab to the Wikipedia link).
-    if (popEl?.contains(e.relatedTarget as Node)) return;
-    close();
-  }
-
-  // Wikipedia link blur — close only when focus leaves both the popover and the trigger button.
-  function onWikiBlur(e: FocusEvent) {
-    const target = e.relatedTarget as Node | null;
-    if (popEl?.contains(target) || btnEl?.contains(target)) return;
-    close();
-  }
-
-  // Touch (coarse pointer): tap-toggle.
+  // Click / keyboard Enter / Space / touch tap → inline push-down.
+  // A native <button> fires click for Enter (keydown) and Space (keyup) automatically.
   function onClick(e: MouseEvent & { currentTarget: HTMLButtonElement }) {
-    // Only toggle on coarse — fine pointer already handled by hover/focus.
-    if (!isCoarse()) return;
     e.stopPropagation();
-    if (open) {
+    if (open && presentation === "inline") {
       close();
     } else {
       presentation = "inline";
@@ -206,8 +181,6 @@
     aria-controls={presentation === "inline" && open ? tooltipId : undefined}
     onpointerenter={onPointerenter}
     onpointerleave={onPointerleave}
-    onfocus={onFocus}
-    onblur={(e) => onBlur(e)}
     onclick={onClick}>{label}</button
   >
 
@@ -218,12 +191,7 @@
     <span class="gt-body">{bodyText}</span>
     {#if term?.kind === "external" && wikiHref}
       <!-- eslint-disable svelte/no-navigation-without-resolve -- external Wikipedia URL -->
-      <a
-        class="gt-wiki"
-        href={wikiHref}
-        target="_blank"
-        rel="noopener noreferrer"
-        onblur={onWikiBlur}
+      <a class="gt-wiki" href={wikiHref} target="_blank" rel="noopener noreferrer"
         >{(m as unknown as Record<string, () => string>)["gloss_wikipedia_link"]()}</a
       >
       <!-- eslint-enable svelte/no-navigation-without-resolve -->


### PR DESCRIPTION
## Problem

Opening a glossary definition would float a **persistent overlay down over the
paragraph it explains**, obscuring it. Reported in the What's-New drawer; equally
reproducible by clicking or keyboard-focusing any glossary term anywhere.

**Root cause** (in `GlossaryTerm.svelte`): the floating-vs-inline presentation
was chosen from `matchMedia("(pointer: coarse)")` — unreliable (reports `false`
under device emulation, some webviews, and any click/keyboard path) — and
`onFocus` opened the *floating* overlay and left it open. So persistent opens
fell through to the floating overlay that covers content. The non-obscuring
in-flow disclosure already existed; it just wasn't reached.

## Fix

Decide presentation from the **actual interaction**, not a media query or a
focus-open:

| Interaction | Result |
| --- | --- |
| Mouse hover | transient **floating** tooltip (unchanged) |
| Mouse click / touch tap | **inline** push-down (pinned) |
| Keyboard Enter / Space | **inline** push-down |
| Bare Tab-focus | focus ring only — nothing opens |

A native `<button>` fires `click` for Enter/Space, so one `onClick` covers
keyboard activation (no extra keydown handler). `onPointerleave` only closes the
floating mode, so a pinned inline survives mouse-leave; re-hovering an open inline
won't yank it into the overlay. Removed: `isCoarse()`, `onFocus`, `onBlur`,
`onWikiBlur` and their bindings.

The keyboard model is **activation-only** (definition opens on activation, never
on bare Tab-focus) — chosen deliberately so tabbing through prose with several
glossary terms never jumps the layout (auto-open-on-focus would re-create the
same "content moves under the user" problem).

## Tests / verification

- New `GlossaryTerm.browser.test.ts` (6 cases, real-DOM `vitest-browser-svelte`):
  click→inline, Enter→inline, bare-focus inert, hover→floating, pinned-survives-
  mouse-leave, external `pr` term→`role=dialog` + Wikipedia link.
- `cd ui && bun run check` → 0 errors; `bun run test` → 1934 pass.
- Live re-check on `/design-system`: click now renders the definition in-flow
  (content pushes down, nothing obscured); hover still shows the floating tooltip.

No CSS, i18n, glossary-registry, or feature-announcement changes — behavior-only
fix.

## Follow-up (not in this PR)

`InfoTip.svelte` carries the same `isCoarse()` detection pattern (a separate
text-only "i" affordance with no inline mode). Out of scope here; can file a
follow-up to apply the same interaction model if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
