### PR TITLE
ci(release-please): auto-run release PR CI via a scoped GitHub App token (kill the manual approval gate)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,19 +21,49 @@ jobs:
     # the local self-hosted runner is down. See ci/self-hosted-runner/README.md.
     runs-on: ubuntu-latest
     steps:
-      # Maintains a release PR that accrues a CHANGELOG from conventional
-      # commits; merging it tags the version and cuts a GitHub release.
-      # Uses the default GITHUB_TOKEN. The release PR it opens DOES trigger the
-      # CI + PR-hygiene workflows (observed: event=pull_request, actor=
-      # github-actions[bot]); both short-circuit on `release-please--*` head
-      # branches via their job `if:` guards, so verify/hygiene don't burn minutes
-      # on a generated release PR. Separately, GitHub may park those bot-authored
-      # runs behind the repo's "require approval for workflows" Actions setting
-      # ("awaiting maintainer approval") — that gate is a repo/org setting, not
-      # controllable here. Swap in a PAT via `token: secrets.RELEASE_PLEASE_TOKEN`
-      # (a maintainer's token isn't approval-gated) if you want those runs to
-      # execute without manual approval.
+      # release-please maintains a release PR that accrues a CHANGELOG from
+      # conventional commits; merging it tags the version and cuts a GitHub
+      # release. The release PR it opens DOES trigger the CI + PR-hygiene
+      # workflows; both short-circuit on `release-please--*` head branches via
+      # their job `if:` guards, so verify/hygiene don't burn minutes on a
+      # generated release PR — and a skipped required job still reports
+      # "skipped", which satisfies the branch ruleset's required
+      # `verify`/`docs-site` checks.
+      #
+      # The catch: a PR authored by the default GITHUB_TOKEN creates its CI runs
+      # in an "approval-required" state (GitHub Docs, GITHUB_TOKEN: bot-authored
+      # runs are parked behind the repo's "require approval for workflows" gate),
+      # so those required checks never report and the release PR can't merge
+      # until a maintainer clicks "Approve and run" on every release. GitHub's
+      # documented remedy is to author the PR with a GitHub App installation
+      # token or a PAT — runs from a non-github-actions[bot] identity are NOT
+      # approval-gated.
+      #
+      # We use a GitHub App token: it's the least-privilege option — repo-scoped,
+      # ~1h auto-expiring, no human identity, and down-scoped here to exactly the
+      # permissions release-please needs (contents: push the release branch +
+      # cut tags/releases; pull-requests: open/update the PR; issues: the
+      # autorelease:* labels). To enable: create a GitHub App, install it on this
+      # repo granting those three write perms, then set repo VARIABLE
+      # RELEASE_PLEASE_APP_CLIENT_ID and repo SECRET RELEASE_PLEASE_APP_PRIVATE_KEY.
+      # Until both exist, the app-token step is skipped and we fall back to the
+      # default GITHUB_TOKEN — current approval-gated behavior, safe, just still
+      # needs the manual approval.
+      - name: Mint a scoped, short-lived GitHub App token (when the App is configured)
+        id: app-token
+        if: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID != '' }}
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          # Defaults to this repository only. Down-scope the token to just what
+          # release-please needs — not the App installation's full grant.
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+
       - uses: googleapis/release-please-action@v5
         with:
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Problem

release-please opens its release PR as `github-actions[bot]` using the default `GITHUB_TOKEN`. Per GitHub Docs, a PR created/updated with `GITHUB_TOKEN` has its `pull_request` workflow runs created in an **approval-required** state ("require approval for workflows"). The `main` ruleset requires the `verify` + `docs-site` checks; those jobs skip on `release-please--*` and a skipped job reports `skipped` (which satisfies a required check) — **but only once the run executes**. While parked in `action_required`, the checks never report, so the release PR is `BLOCKED` and can't merge (even `--admin` is refused — `bypass_actors` is empty) until a maintainer clicks **"Approve and run"** on every release. This bit #921 (release 1.36.0).

Required checks key off the **target** branch (`main`), so the ruleset can't "exclude" a source branch. GitHub's [documented remedy](https://docs.github.com/en/actions/concepts/security/github_token) is to author the PR with a **GitHub App installation token or a PAT** — runs from a non-`github-actions[bot]` identity aren't approval-gated.

## Fix — scoped GitHub App token (least-privilege)

Mint a short-lived App token with `actions/create-github-app-token@v3` and feed it to release-please:

```yaml
- id: app-token
  if: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID != '' }}
  uses: actions/create-github-app-token@v3
  with:
    client-id:   ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID }}
    private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
    permission-contents: write
    permission-pull-requests: write
    permission-issues: write
- uses: googleapis/release-please-action@v5
  with:
    token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
```

Chosen over a PAT because it's strictly tighter: **repo-scoped, ~1h auto-expiring, no human identity**, and down-scoped to exactly the three permissions release-please needs — `contents` (push the release branch + cut tags/releases), `pull-requests` (open/update the PR), `issues` (the `autorelease:*` labels). A leak is bounded in both scope and time; nothing else is weakened (no ruleset/fork-PR/governance change).

The `if:` gate + `|| secrets.GITHUB_TOKEN` fallback make this **safe to merge immediately**: until the App is configured the step is skipped and behavior is unchanged (still approval-gated).

## One-time setup (maintainer)

1. Create a GitHub App (org/personal), **install it on this repo**, granting **Contents: RW, Pull requests: RW, Issues: RW**.
2. Repo **variable** `RELEASE_PLEASE_APP_CLIENT_ID` = the App's Client ID (not secret).
3. Repo **secret** `RELEASE_PLEASE_APP_PRIVATE_KEY` = the App's generated private key (`.pem` contents).

```
gh variable set RELEASE_PLEASE_APP_CLIENT_ID --repo erwins-enkel/shepherd --body '<client-id>'
gh secret  set RELEASE_PLEASE_APP_PRIVATE_KEY --repo erwins-enkel/shepherd < app-private-key.pem
```

Verified against current docs: `client-id` is the current input (`app-id` deprecated); `actions/create-github-app-token` is at `v3`; the GITHUB_TOKEN approval-required behavior + the App/PAT remedy are stated on the GITHUB_TOKEN docs page. No spike needed.

[no-feature-entry] — CI/release plumbing, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)