### PR TITLE
ci(release-please): degrade to GITHUB_TOKEN if the App token mint fails

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,6 +52,12 @@ jobs:
       - name: Mint a scoped, short-lived GitHub App token (when the App is configured)
         id: app-token
         if: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID != '' }}
+        # Don't let a token-mint failure (rotated key, App uninstalled, GitHub
+        # API blip) block releases: on failure the step is non-fatal, its `token`
+        # output is empty, and release-please falls back to GITHUB_TOKEN below —
+        # i.e. it degrades to the (approval-gated but working) default path
+        # instead of hard-failing every release.
+        continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID }}


### PR DESCRIPTION
Follow-up to #1002 (scoped GitHub App token for release PRs).

## Problem

The App-token step is gated on `vars.RELEASE_PLEASE_APP_CLIENT_ID`, but if that var is set while the mint *fails* — rotated key, App uninstalled from the repo, GitHub API blip — the step fails, the whole `release-please` job fails, and release-please is **skipped**. That silently blocks **every** release until someone notices. (We hit the failure mode for real when the App wasn't yet installed: `GET /repos/.../installation` → 404 → job failed.)

The `|| secrets.GITHUB_TOKEN` fallback only covers the App being *absent*, not the mint *failing*.

## Fix

Mark the mint step `continue-on-error: true`. On failure it's non-fatal, `steps.app-token.outputs.token` is empty, and release-please falls back to `GITHUB_TOKEN` — i.e. it **degrades to the (approval-gated but working) default path** instead of hard-failing the release.

```yaml
- id: app-token
  if: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID != '' }}
  continue-on-error: true   # <-- mint failure degrades to GITHUB_TOKEN, never blocks releases
  uses: actions/create-github-app-token@v3
  ...
```

Trade-off worth naming: a mint failure now degrades **quietly** (back to manual approve-and-run) rather than failing loudly. That's the right default for a release pipeline — resilience over a hard stop — but it means a broken App won't announce itself; you'd notice via the approval gate reappearing.

[no-feature-entry] — CI/release plumbing, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)