### PR TITLE
fix(ci): onboarding-release-gate reads via release-please App token

### DIFF
--- a/.github/workflows/onboarding-release-gate.yml
+++ b/.github/workflows/onboarding-release-gate.yml
@@ -37,9 +37,12 @@ jobs:
       # `issues: read` granted — every call 403s "Resource not accessible by
       # integration" (an org-level constraint on the built-in token). So mint a
       # scoped, read-only token from the release-please GitHub App (same App as
-      # release-please.yml; installed with issues + commit-statuses read). If the
-      # App isn't configured we fall back to GITHUB_TOKEN, which fails closed —
-      # the safe direction for a release gate.
+      # release-please.yml). REQUIRED App installation grants: issues read (§1),
+      # contents read + commit-statuses read (§2). The App was extended with
+      # Commit statuses: read for this gate — if that grant is ever revoked the
+      # token mint below errors and the step fails, which fails the gate CLOSED
+      # (release blocked), never a false green. If the App is unconfigured we
+      # fall back to GITHUB_TOKEN, which also fails closed — both safe for a gate.
       - name: Mint a scoped, read-only GitHub App token (when the App is configured)
         id: app-token
         if: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID != '' }}

--- a/.github/workflows/onboarding-release-gate.yml
+++ b/.github/workflows/onboarding-release-gate.yml
@@ -13,20 +13,48 @@ name: Onboarding release gate
 on:
   pull_request:
     branches: [main]
+  # Manually runnable so the gate can be exercised on demand. It otherwise fires
+  # only on release-please PRs, whose bot-authored CI runs are approval-parked —
+  # which made this gate effectively untestable until now.
+  workflow_dispatch:
 
+# Governs the GITHUB_TOKEN fallback only; the gate normally runs under the App
+# token minted below (which carries its own grant). statuses:read covers the
+# section-2 commit-status read.
 permissions:
   issues: read
   contents: read
+  statuses: read
 
 jobs:
   onboarding-release-gate:
-    # Only the release-please release PR is gated; every other PR is unaffected.
-    if: ${{ startsWith(github.head_ref, 'release-please--') }}
+    # Gate the release-please PR; also allow manual dispatch for on-demand testing.
+    # Every other PR is unaffected.
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     steps:
+      # The Actions GITHUB_TOKEN cannot read this repo's issues even with
+      # `issues: read` granted — every call 403s "Resource not accessible by
+      # integration" (an org-level constraint on the built-in token). So mint a
+      # scoped, read-only token from the release-please GitHub App (same App as
+      # release-please.yml; installed with issues + commit-statuses read). If the
+      # App isn't configured we fall back to GITHUB_TOKEN, which fails closed —
+      # the safe direction for a release gate.
+      - name: Mint a scoped, read-only GitHub App token (when the App is configured)
+        id: app-token
+        if: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID != '' }}
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          # Down-scope to exactly what the gate reads — not the App's full grant.
+          permission-issues: read
+          permission-contents: read
+          permission-statuses: read
+
       - name: Require the onboarding harness to be fresh-green
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           REPO: ${{ github.repository }}
           # Max age of the latest nightly verdict before it's "stale" (nightly is
           # daily, so this allows one missed run of slack).
@@ -48,11 +76,11 @@ jobs:
           # the human-facing active-regression signal.
 
           # (1) Active regression?
-          # Use the REST issues endpoint via `gh api` (not `gh issue list`): under the
-          # Actions GITHUB_TOKEN, gh's GraphQL-backed `issue list` 403s "Resource not
-          # accessible by integration" even with `issues: read` granted, whereas the REST
-          # endpoint honors it cleanly. `select(.pull_request|not)` drops any PR that shares
-          # the label (the REST issues endpoint returns PRs too).
+          # Read the rolling `onboarding-regression` issue via the REST issues
+          # endpoint (`gh api`). This runs under the App token (see above); the
+          # built-in GITHUB_TOKEN 403s on issues regardless of REST vs gh's
+          # GraphQL `issue list`. `select(.pull_request|not)` drops any PR that
+          # shares the label (the REST issues endpoint returns PRs too).
           open=$(gh api "repos/$REPO/issues?labels=onboarding-regression&state=open&per_page=100" \
             --jq '[.[] | select(.pull_request|not)]')
           if [ "$(printf '%s' "$open" | jq 'length')" -gt 0 ]; then


### PR DESCRIPTION
## Background

The Onboarding release gate has been crashing on every release-please PR that runs it (e.g. [run 27930377999](https://github.com/erwins-enkel/shepherd/actions/runs/27930377999)). Root cause, established by a **live dispatch**: the built-in Actions `GITHUB_TOKEN` 403s `Resource not accessible by integration` on this repo's **issues** API *even though the token is minted with `issues: read`* — an org-level constraint on the built-in token, not a REST-vs-GraphQL issue.

PR #996 swapped `gh issue list` → REST `gh api`; a live run on the fixed workflow proved that **did not** fix it (the REST call 403s identically). This PR supersedes that with the actual fix.

## Fix

Mint a **scoped, read-only token from the release-please GitHub App** (the one wired up in #1002) and run the gate's reads under it:

- Reuses `vars.RELEASE_PLEASE_APP_CLIENT_ID` + `secrets.RELEASE_PLEASE_APP_PRIVATE_KEY` — no new credential.
- Down-scoped to exactly `issues: read`, `contents: read`, `statuses: read` (not the App's full write grant). The App was extended with **Commit statuses: Read** (+ org re-auth) so section 2's commit-status read works.
- `GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}` — falls back to `GITHUB_TOKEN` if the App is ever unconfigured, which **fails closed** (the safe direction for a release gate).

Also adds **`workflow_dispatch`** (with an event-aware job guard) so the gate is runnable on demand. It previously fired only on release-please PRs, whose bot-authored CI runs are approval-parked — which is *why this was undetectable until now* and why it couldn't be tested pre-merge.

## Verification plan

`workflow_dispatch` requires the workflow to be on the default branch, so the empirical proof is **post-merge**: dispatch the gate and confirm it clears the issue check **and** reaches/passes the status-freshness logic. The gate is currently broken (403), so this can't regress it. CI-only change. `[no-feature-entry]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)