### PR TITLE
fix(glossary): hide closed floating tooltip so it stops obscuring content

### DIFF
--- a/ui/src/lib/components/GlossaryTerm.browser.test.ts
+++ b/ui/src/lib/components/GlossaryTerm.browser.test.ts
@@ -103,4 +103,39 @@ describe("GlossaryTerm — activation-only inline disclosure", () => {
     const href = await link.element().getAttribute("href");
     expect(href).toContain("/wiki/Distributed_version_control#Pull_requests");
   });
+
+  // Regression: the floating popover is always mounted, so its closed state must be
+  // display:none. A base display:flex used to override the UA closed-popover rule,
+  // leaving the definition visibly pinned over content with no interaction (it
+  // "auto-opened" and "wouldn't close"). The :popover-open assertions above pass even
+  // with that bug, so these test rendered VISIBILITY rather than popover-open state.
+  it("closed floating tooltip is display:none — no auto-open / stuck overlay", () => {
+    render(GlossaryTerm, { id: "epic", label: "epic" });
+
+    const tip = document.querySelector<HTMLElement>(".gloss-tooltip");
+    expect(tip).not.toBeNull();
+    expect(getComputedStyle(tip!).display).toBe("none");
+  });
+
+  it("floating tooltip display tracks :popover-open (open shows, closed hides)", async () => {
+    render(GlossaryTerm, { id: "epic", label: "epic" });
+
+    const btn = page.getByRole("button", { name: "epic" });
+    const tip = document.querySelector<HTMLElement>(".gloss-tooltip");
+    expect(tip).not.toBeNull();
+
+    // hover opens it → :popover-open → visible
+    btn
+      .element()
+      .dispatchEvent(new PointerEvent("pointerenter", { pointerType: "mouse", bubbles: true }));
+    await expect.poll(() => tip!.matches(":popover-open")).toBe(true);
+    expect(getComputedStyle(tip!).display).not.toBe("none");
+
+    // Once no longer open it must hide again — the "won't close" half. Drive the
+    // popover-open state directly so the assertion tests the CSS contract itself,
+    // not the event/timer-driven close path (that path is covered live + by the
+    // mouse-leave/Escape dismiss handlers; synthetic-event timing is racy here).
+    tip!.hidePopover();
+    expect(getComputedStyle(tip!).display).toBe("none");
+  });
 });

--- a/ui/src/lib/components/GlossaryTerm.svelte
+++ b/ui/src/lib/components/GlossaryTerm.svelte
@@ -283,6 +283,15 @@
     font: inherit;
   }
 
+  /* A closed manual popover must not render. The base rule's display:flex would
+     otherwise override the UA closed-popover display:none, leaving the definition
+     visibly pinned at its last anchored (or in-flow) position — the "auto-opens /
+     won't-close" tooltip obscuring content. Sibling InfoTip avoids this by setting
+     no base display at all; this guard restores the same closed-state behavior. */
+  [popover].gloss-tooltip:not(:popover-open) {
+    display: none;
+  }
+
   .gt-body {
     display: block;
     margin: 0;


### PR DESCRIPTION
## Problem

The glossary definition popover (e.g. for `trial`) appeared **without any interaction** and **never went away**, sitting on top of the What's New drawer and hiding the text behind it.

## Root cause (reproduced + confirmed in the live browser)

`GlossaryText` renders one `GlossaryTerm` per marked term, and each `GlossaryTerm` **always mounts** its floating `<div class="gloss-tooltip" popover="manual">` — visibility is meant to be governed purely by `showPopover()`/`hidePopover()`. But the component's CSS set `display:flex` on the base `[popover].gloss-tooltip` rule, which **overrides the UA "closed popover ⇒ `display:none`"**, so every tooltip rendered regardless of `:popover-open`. DOM inspection showed all 7 drawer tooltips at `display:flex; visibility:visible` with `:popover-open === false`.

Two symptoms, one cause:

- **"Auto-opens":** `trial` is the *topmost* glossary term, so its closed popover laid out at its in-flow static position — top of the drawer, in-viewport — and showed immediately. (Other terms' static positions sit far down the scrolled list, off-screen.)
- **"Won't close":** hovering runs Floating UI, which writes inline `left/top`; on close `hidePopover()` fires but `display:flex` keeps the element rendered, pinned at its last position.

The working sibling `InfoTip.svelte` proves the correct pattern: it sets **no** base `display`, so closed popovers fall back to the UA `display:none`.

## Fix

Add a higher-specificity guard so a closed popover is genuinely hidden:

```css
[popover].gloss-tooltip:not(:popover-open) { display: none; }
```

Closed tooltips are now hidden; hover still opens exactly one, dismiss hides it again. CSS-only change to the component — no script/markup change.

## Tests

Added two browser regression tests asserting rendered **visibility** (`display`), not just `:popover-open` count — the bug slipped past the existing count-based assertions. Both fail on the old CSS and pass with the fix:
- closed floating tooltip is `display:none` (no auto-open / stuck overlay);
- display tracks `:popover-open` (open shows, closed hides).

## Verification

- Live repro before/after: fresh drawer open shows no stuck tooltip; hover opens, mouse-leave closes.
- `cd ui && bun run check` clean; `bun run test` — 1944 passed.

No new feature/glossary term/string ⇒ no feature-catalog / glossary / i18n catalog changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)