### PR TITLE
feat(autopilot): pre-completion verification gate for drain sessions (#1009)

### DIFF
--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -57,6 +57,21 @@ export const CI_FIX_STEER = [
   "can't resolve, and then say exactly what you need.",
 ].join("\n");
 
+/** Agent-facing steer when a drain session reports complete but produced NO diff and NO PR. NOT UI
+ *  chrome — typed into the agent PTY, never i18n'd (Shepherd owns this text). */
+export const EMPTY_COMPLETION_STEER = [
+  "You're in autopilot and you reported the task complete, but there's no committed diff against the",
+  "base branch and no pull request — nothing was actually produced. Either do the work and commit it",
+  "(then open a PR if the task calls for one), or if the task genuinely required no code change, say",
+  "precisely why so a human can confirm.",
+].join("\n");
+
+/** Hand-back text when the empty-completion gate gives up after its one re-prompt and routes the
+ *  session to a human. Plain English, mirrors CAP_MESSAGE/COMPLETE_MESSAGE (stored as the
+ *  autopilotQuestion hand-back summary). */
+export const EMPTY_COMPLETION_MESSAGE =
+  "Autopilot reported the task complete but produced no changes and no PR — over to you.";
+
 /** Steers autopilot will only consider for these block shapes. menu/stall always surface. */
 const STEERABLE_SHAPES = new Set(["awaiting-input", "yes-no"]);
 
@@ -79,6 +94,10 @@ export interface AutopilotDeps {
   /** Whether the session already has a PR in any state (open/merged/closed). True → autopilot
    *  stands down (open = critic territory; merged/closed = pre-PR mission over). */
   hasPr: (id: string) => boolean;
+  /** Deterministic completion verifier: true when the session's branch has a committed diff vs its
+   *  base (no LLM, no fetch). Paired with hasPr to answer "did anything happen" before autopilot
+   *  accepts a `complete` verdict for a drain session. */
+  hasDiff: (id: string) => Promise<boolean>;
   /** Register a lightweight (local) session's pseudo-PR server-side. Replaces the forge-mode
    *  open-a-PR steer for a `lightweight` repo: the agent has no `gh`, so the deliberate
    *  completion barrier runs here instead of being typed into the PTY. Best-effort — the
@@ -182,6 +201,18 @@ export class AutopilotService {
     this.deps.store.setAutopilotState(s.id, { stepCount: s.autopilotStepCount + 1 });
   }
 
+  /** Empty-completion handler (#1009): the session reported complete with no diff and no PR. Re-prompt
+   *  the agent exactly once (bounded by the persisted completionRepromptCount), then hand it to a
+   *  human rather than silently filing it as done. */
+  private async handleEmptyCompletion(s: Session): Promise<void> {
+    if (s.completionRepromptCount >= 1) {
+      this.pause(s, EMPTY_COMPLETION_MESSAGE); // re-prompt already spent → needs-human
+      return;
+    }
+    this.deps.store.setAutopilotState(s.id, { completionReprompt: s.completionRepromptCount + 1 });
+    await this.driveSteer(s, EMPTY_COMPLETION_STEER);
+  }
+
   /** Send `text` into the session, resuming an exited pane first. Returns whether the steer
    *  landed; does NOT bump the step (the caller decides whether the attempt counts). */
   private async sendSteer(s: Session, text: string): Promise<boolean> {
@@ -222,9 +253,27 @@ export class AutopilotService {
           openPrSteer(this.deps.store.getRepoConfig(s.repoPath).draftMode, s.baseBranch),
         );
         return;
-      case "complete":
+      case "complete": {
+        // Pre-completion verification gate (#1009): for a DRAIN/auto session, don't accept "done"
+        // unless something actually happened — a committed diff or an associated PR. The check is
+        // deterministic (no LLM). Attended sessions are exempt: a non-code `complete` (issue
+        // creation / one-off answer) is legitimate there and must not be false-flagged.
+        if (s.auto && !this.deps.hasPr(s.id)) {
+          const empty = !(await this.deps.hasDiff(s.id));
+          // hasDiff is async — re-read the session and PR state after the await (it may have been
+          // archived / toggled off, or a PR may have appeared during the await).
+          const cur = this.deps.store.get(s.id);
+          if (!cur || cur.status === "archived") return;
+          if (empty && !this.deps.hasPr(cur.id)) {
+            await this.handleEmptyCompletion(cur);
+            return;
+          }
+          this.markComplete(cur, v.summary || COMPLETE_MESSAGE);
+          return;
+        }
         this.markComplete(s, v.summary || COMPLETE_MESSAGE);
         return;
+      }
       default: // "question" | "unknown" → bias to surface
         this.pause(s, v.summary || SURFACE_MESSAGE);
     }
@@ -298,6 +347,7 @@ export class AutopilotService {
       complete: false,
       question: null,
       stepCount: 0,
+      completionReprompt: 0,
     });
     this.deps.store.setAutoMergeState(id, { rebaseCount: 0, rebaseHead: null });
     this.deps.onState?.(id);
@@ -313,6 +363,7 @@ export class AutopilotService {
       complete: false,
       question: null,
       stepCount: 0,
+      completionReprompt: 0,
     });
     this.deps.onState?.(id);
   }

--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -204,6 +204,32 @@ export class AutopilotService {
   /** Empty-completion handler (#1009): the session reported complete with no diff and no PR. Re-prompt
    *  the agent exactly once (bounded by the persisted completionRepromptCount), then hand it to a
    *  human rather than silently filing it as done. */
+  /** Accept (or gate) a `complete` verdict. Pre-completion verification gate (#1009): for a
+   *  DRAIN/auto session with no PR, verify deterministically (no LLM) that something happened — a
+   *  committed diff — before marking done; on empty, re-prompt once then route to needs-human.
+   *  Attended sessions are exempt: a non-code `complete` (issue creation / one-off answer) is
+   *  legitimate there and must not be false-flagged, so they complete unconditionally. */
+  private async verifyAndComplete(s: Session, summary: string): Promise<void> {
+    if (s.auto && !this.deps.hasPr(s.id)) {
+      const empty = !(await this.deps.hasDiff(s.id));
+      // hasDiff is async — re-read the session and PR state after the await (it may have been
+      // archived / toggled off, or a PR may have appeared during the await).
+      const cur = this.deps.store.get(s.id);
+      if (!cur || cur.status === "archived") return;
+      // Re-derive empty/PR on the fresh row rather than reusing eligible(): a full-auto session
+      // stays eligible past PR-open, so eligible() would not stand it down here — we want a PR that
+      // appeared during the await to fall through to markComplete. Don't "simplify" this to
+      // eligible() without accounting for that fullAuto interaction (it would change behavior).
+      if (empty && !this.deps.hasPr(cur.id)) {
+        await this.handleEmptyCompletion(cur);
+        return;
+      }
+      this.markComplete(cur, summary);
+      return;
+    }
+    this.markComplete(s, summary);
+  }
+
   private async handleEmptyCompletion(s: Session): Promise<void> {
     if (s.completionRepromptCount >= 1) {
       this.pause(s, EMPTY_COMPLETION_MESSAGE); // re-prompt already spent → needs-human
@@ -253,27 +279,9 @@ export class AutopilotService {
           openPrSteer(this.deps.store.getRepoConfig(s.repoPath).draftMode, s.baseBranch),
         );
         return;
-      case "complete": {
-        // Pre-completion verification gate (#1009): for a DRAIN/auto session, don't accept "done"
-        // unless something actually happened — a committed diff or an associated PR. The check is
-        // deterministic (no LLM). Attended sessions are exempt: a non-code `complete` (issue
-        // creation / one-off answer) is legitimate there and must not be false-flagged.
-        if (s.auto && !this.deps.hasPr(s.id)) {
-          const empty = !(await this.deps.hasDiff(s.id));
-          // hasDiff is async — re-read the session and PR state after the await (it may have been
-          // archived / toggled off, or a PR may have appeared during the await).
-          const cur = this.deps.store.get(s.id);
-          if (!cur || cur.status === "archived") return;
-          if (empty && !this.deps.hasPr(cur.id)) {
-            await this.handleEmptyCompletion(cur);
-            return;
-          }
-          this.markComplete(cur, v.summary || COMPLETE_MESSAGE);
-          return;
-        }
-        this.markComplete(s, v.summary || COMPLETE_MESSAGE);
+      case "complete":
+        await this.verifyAndComplete(s, v.summary || COMPLETE_MESSAGE);
         return;
-      }
       default: // "question" | "unknown" → bias to surface
         this.pause(s, v.summary || SURFACE_MESSAGE);
     }

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -236,6 +236,46 @@ async function resolveBaseRef(
 }
 
 /**
+ * Cheap, no-network check: does this branch have any committed changes vs base?
+ *
+ * Ref resolution: prefers `origin/<base>` when the local remote-tracking ref
+ * exists (avoids a fetch — three-dot merge-base diff means a stale local base
+ * can never produce a *false* diff, so no fetch is needed for correctness).
+ * Falls back to `<base>` when no remote-tracking ref is present.
+ *
+ * Exit-code semantics: `git diff --quiet` exits 0 (no diff → false) or 1 (diff
+ * exists → true). Any other non-zero exit is a real error and is rethrown so the
+ * caller can log it and fail open — never swallow unexpected git errors.
+ *
+ * Non-isolated sessions (branch == null) have no branch and return false
+ * immediately without invoking git.
+ */
+export async function hasCommittedChanges(
+  worktreePath: string,
+  base: string,
+  branch: string | null,
+): Promise<boolean> {
+  if (branch === null) return false;
+
+  const remoteRef = `${REMOTE}/${base}`;
+  const ref = (await refExists(worktreePath, remoteRef)) ? remoteRef : base;
+
+  try {
+    await timedAsync("git diff --quiet", () =>
+      execFileAsync("git", ["diff", "--quiet", `${ref}...HEAD`], {
+        cwd: worktreePath,
+        encoding: "utf8",
+      }),
+    );
+    return false; // exit 0 → no diff
+  } catch (err) {
+    const code = (err as { code?: unknown }).code;
+    if (code === 1) return true; // exit 1 → diff exists
+    throw err; // unexpected error (e.g. not a repo, git missing)
+  }
+}
+
+/**
  * Structured diff of a session's branch against its (freshly fetched) base.
  * Uses three-dot `<baseRef>...HEAD` = merge-base→HEAD = "what would merge".
  * Non-isolated sessions (no branch) return an empty result for the empty state.

--- a/src/index.ts
+++ b/src/index.ts
@@ -943,6 +943,8 @@ const autopilot = new AutopilotService({
       console.warn("[autopilot] openLocalPr:", err);
     }
   },
+  // TODO(task-4): wire hasCommittedChanges from src/diff.ts for real completion verification
+  hasDiff: async () => true,
   prGit: (id) => prPoller.snapshot()[id] ?? null,
   fullAuto: (id) => {
     const s = store.get(id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,7 @@ import { jsonlPathFor } from "./usage";
 import { verifyApiKey } from "./verify-key";
 import { releaseHeldTasks } from "./held-release";
 import { snapshotSessionUsage } from "./usage-snapshot";
+import { hasCommittedChanges } from "./diff";
 
 const execFileAsync = promisify(execFile);
 
@@ -943,8 +944,19 @@ const autopilot = new AutopilotService({
       console.warn("[autopilot] openLocalPr:", err);
     }
   },
-  // TODO(task-4): wire hasCommittedChanges from src/diff.ts for real completion verification
-  hasDiff: async () => true,
+  // Deterministic completion verifier (#1009): true when the session's branch has a committed diff
+  // vs base. Fails OPEN (returns true) on any git error so a systemic failure can't false-route a
+  // genuinely-complete session to needs-human — but logs, so the bypass is observable, not silent.
+  hasDiff: async (id) => {
+    const s = store.get(id);
+    if (!s) return true;
+    try {
+      return await hasCommittedChanges(s.worktreePath, s.baseBranch, s.branch);
+    } catch (err) {
+      console.warn("[autopilot] hasDiff:", err);
+      return true;
+    }
+  },
   prGit: (id) => prPoller.snapshot()[id] ?? null,
   fullAuto: (id) => {
     const s = store.get(id);

--- a/src/store.ts
+++ b/src/store.ts
@@ -158,6 +158,7 @@ type NewSession = Omit<
   | "autopilotPaused"
   | "autopilotComplete"
   | "autopilotQuestion"
+  | "completionRepromptCount"
   | "planGateEnabled"
   | "planPhase"
   | "autoMergeEnabled"
@@ -191,7 +192,7 @@ type NewSession = Omit<
 
 const COLS = `id, desig, name, prompt, repoPath, baseBranch, branch, worktreePath,
   isolated, herdrSession, herdrAgentId, claudeSessionId, model, readyToMerge, status, lastState,
-  autopilotEnabled, autopilotStepCount, autopilotPaused, autopilotComplete, autopilotQuestion,
+  autopilotEnabled, autopilotStepCount, autopilotPaused, autopilotComplete, autopilotQuestion, completionRepromptCount,
   planGateEnabled, planPhase,
   autoMergeEnabled, autoMergeRebaseCount, autoMergeRebaseHead,
   auto, issueNumber, sandboxApplied, sandboxDegraded, egressApplied, egressDegraded,
@@ -224,6 +225,7 @@ type SessionRow = {
   autopilotPaused: number;
   autopilotComplete: number;
   autopilotQuestion: string | null;
+  completionRepromptCount: number | null;
   planGateEnabled: number | null;
   planPhase: string | null;
   autoMergeEnabled: number | null;
@@ -1330,6 +1332,7 @@ export class SessionStore implements CapStore, CreditStore {
       autopilotPaused: false,
       autopilotComplete: false,
       autopilotQuestion: null,
+      completionRepromptCount: 0,
       planGateEnabled: input.planGateEnabled ?? null,
       planPhase: input.planPhase ?? null,
       autoMergeEnabled: null,
@@ -1362,7 +1365,7 @@ export class SessionStore implements CapStore, CreditStore {
       const seq = this.nextDesignationSeq();
       const s = this.buildSessionRow(input, seq, now);
       this.db.run(
-        `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+        `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
         [
           s.id,
           s.desig,
@@ -1385,6 +1388,7 @@ export class SessionStore implements CapStore, CreditStore {
           0, // autopilotPaused
           0, // autopilotComplete
           null, // autopilotQuestion
+          0, // completionRepromptCount
           s.planGateEnabled === null ? null : s.planGateEnabled ? 1 : 0, // planGateEnabled — inherit repo default
           s.planPhase, // planPhase — null = gate off
           null, // autoMergeEnabled — inherit repo default
@@ -1524,6 +1528,7 @@ export class SessionStore implements CapStore, CreditStore {
       paused?: boolean;
       complete?: boolean;
       question?: string | null;
+      completionReprompt?: number;
     },
   ): void {
     const cur = this.get(id);
@@ -1533,14 +1538,16 @@ export class SessionStore implements CapStore, CreditStore {
     const paused = patch.paused ?? cur.autopilotPaused;
     const complete = patch.complete ?? cur.autopilotComplete;
     const question = patch.question === undefined ? cur.autopilotQuestion : patch.question;
+    const completionReprompt = patch.completionReprompt ?? cur.completionRepromptCount;
     this.db.run(
-      `UPDATE sessions SET autopilotEnabled=?, autopilotStepCount=?, autopilotPaused=?, autopilotComplete=?, autopilotQuestion=?, updatedAt=? WHERE id=?`,
+      `UPDATE sessions SET autopilotEnabled=?, autopilotStepCount=?, autopilotPaused=?, autopilotComplete=?, autopilotQuestion=?, completionRepromptCount=?, updatedAt=? WHERE id=?`,
       [
         enabled === null ? null : enabled ? 1 : 0,
         stepCount,
         paused ? 1 : 0,
         complete ? 1 : 0,
         question,
+        completionReprompt,
         Date.now(),
         id,
       ],
@@ -2340,6 +2347,7 @@ export class SessionStore implements CapStore, CreditStore {
     add("autopilotPaused", `autopilotPaused INTEGER NOT NULL DEFAULT 0`);
     add("autopilotComplete", `autopilotComplete INTEGER NOT NULL DEFAULT 0`);
     add("autopilotQuestion", `autopilotQuestion TEXT`);
+    add("completionRepromptCount", `completionRepromptCount INTEGER NOT NULL DEFAULT 0`);
     // nullable: NULL = inherit / gate off, 0/1 = explicit per-session override
     add("planGateEnabled", `planGateEnabled INTEGER`);
     add("planPhase", `planPhase TEXT`);
@@ -3459,6 +3467,7 @@ export class SessionStore implements CapStore, CreditStore {
       autopilotPaused: !!r.autopilotPaused,
       autopilotComplete: !!r.autopilotComplete,
       autopilotQuestion: r.autopilotQuestion ?? null,
+      completionRepromptCount: r.completionRepromptCount ?? 0,
       planGateEnabled: nullableBool(r.planGateEnabled),
       planPhase: r.planPhase ?? null,
       autoMergeEnabled: nullableBool(r.autoMergeEnabled),

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,9 @@ export interface Session {
   /** The classifier's 1–2 sentence hand-back summary — what the agent is waiting for (paused)
    *  or what it delivered (complete); null in neither state. */
   autopilotQuestion: string | null;
+  /** Count of empty-completion re-prompts autopilot has spent on this session (gate runaway guard;
+   *  reset on PR-open / operator reply, alongside autopilotStepCount). */
+  completionRepromptCount: number;
   /** Plan-gate opt-in: true/false override, or null to inherit the repo default. */
   planGateEnabled: boolean | null;
   /** Plan-gate phase: "planning" (grill+review) → "executing" (gate passed); null = gate off. */

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -7,6 +7,8 @@ import {
   epicBaseDirective,
   CI_FIX_STEER,
   CI_CAP_MESSAGE,
+  EMPTY_COMPLETION_STEER,
+  EMPTY_COMPLETION_MESSAGE,
 } from "../src/autopilot";
 import { DRAFT_PR_NOTE } from "../src/service";
 
@@ -82,6 +84,8 @@ function harness(opts: {
   fullAuto?: boolean;
   /** Cached PR snapshot returned by the prGit dep (the tick / reEngageCi source). */
   prGit?: GitState | null;
+  /** Whether the session's branch has a committed diff vs base (default true = work exists). */
+  hasDiff?: boolean;
 }) {
   let cur = opts.session;
   const events: any[] = [];
@@ -108,6 +112,7 @@ function harness(opts: {
           paused?: boolean;
           complete?: boolean;
           question?: string | null;
+          completionReprompt?: number;
         },
       ) => {
         cur = {
@@ -117,6 +122,7 @@ function harness(opts: {
           autopilotPaused: patch.paused ?? cur.autopilotPaused,
           autopilotComplete: patch.complete ?? cur.autopilotComplete,
           autopilotQuestion: patch.question === undefined ? cur.autopilotQuestion : patch.question,
+          completionRepromptCount: patch.completionReprompt ?? cur.completionRepromptCount,
         };
       },
       setAutoMergeState: (
@@ -147,6 +153,7 @@ function harness(opts: {
     paneAlive: () => opts.paneAlive ?? true,
     readTail: () => ["finished, nothing else"],
     hasPr: () => opts.openPr ?? false,
+    hasDiff: async () => opts.hasDiff ?? true,
     openLocalPr: async (id) => {
       events.push({ openLocalPr: id });
     },
@@ -551,6 +558,7 @@ test("re-entrant onBlock during an in-flight classify spawns + steers only once"
     paneAlive: () => true,
     readTail: () => [],
     hasPr: () => false,
+    hasDiff: async () => true,
     openLocalPr: async () => {},
     prGit: () => null,
     fullAuto: () => false,
@@ -1031,4 +1039,114 @@ test("merge-train: gate/classify path is NOT suppressed by the mark (CI-fix-only
   await h.svc.onBlock("s1", block());
   expect(h.events).toContainEqual({ steer: PROCEED_STEER });
   expect(h.state().autopilotStepCount).toBe(1);
+});
+
+// ───────────────────── completion-verification gate (#1009) ─────────────────────
+// For drain (auto:true) sessions, a `complete` verdict is only accepted when something
+// actually happened — a committed diff vs base OR an associated PR. On empty: re-prompt
+// the agent once, then route to needs-human. Attended sessions are exempt.
+
+test("completion gate: diff exists → markComplete (no gate trip)", async () => {
+  // auto:true + hasDiff:true + no PR → gate passes, markComplete fires
+  const h = harness({
+    session: sess({ auto: true, status: "done" }),
+    verdict: { kind: "complete", summary: "All done." },
+    repoEnabled: true,
+    openPr: false,
+    hasDiff: true,
+  });
+  await h.svc.onDone("s1");
+  expect(h.events).toContainEqual({ complete: "s1", summary: "All done." });
+  expect(h.state().autopilotComplete).toBe(true);
+  expect(h.state().autopilotPaused).toBe(false);
+  expect(h.state().completionRepromptCount).toBe(0);
+});
+
+test("completion gate: PR exists → markComplete (hasPr short-circuits before hasDiff)", async () => {
+  // auto:true + openPr:true + hasDiff:false + fullAuto:true (keeps eligible past PR) →
+  // hasPr short-circuit inside dispatch, markComplete fires, hasDiff never called
+  const h = harness({
+    session: sess({ auto: true, status: "done" }),
+    verdict: { kind: "complete", summary: "PR already open." },
+    repoEnabled: true,
+    openPr: true,
+    hasDiff: false,
+    fullAuto: true,
+  });
+  let hasDiffCalled = false;
+  (h.svc as any).deps.hasDiff = async () => {
+    hasDiffCalled = true;
+    return false;
+  };
+  await h.svc.onDone("s1");
+  expect(h.events).toContainEqual({ complete: "s1", summary: "PR already open." });
+  expect(h.state().autopilotComplete).toBe(true);
+  expect(h.state().autopilotPaused).toBe(false);
+  expect(h.state().completionRepromptCount).toBe(0);
+  expect(hasDiffCalled).toBe(false); // hasPr short-circuits before hasDiff is called
+});
+
+test("completion gate: empty first time → steer EMPTY_COMPLETION_STEER, reprompt count 1", async () => {
+  // auto:true + openPr:false + hasDiff:false + count:0 → re-prompt, NOT complete, NOT paused
+  const h = harness({
+    session: sess({ auto: true, status: "done", completionRepromptCount: 0 }),
+    verdict: { kind: "complete", summary: "Nothing to do." },
+    repoEnabled: true,
+    openPr: false,
+    hasDiff: false,
+  });
+  await h.svc.onDone("s1");
+  expect(h.events).toContainEqual({ steer: EMPTY_COMPLETION_STEER });
+  expect(h.state().completionRepromptCount).toBe(1);
+  expect(h.state().autopilotComplete).toBe(false);
+  expect(h.state().autopilotPaused).toBe(false);
+});
+
+test("completion gate: empty second time → pause with EMPTY_COMPLETION_MESSAGE, no steer", async () => {
+  // auto:true + openPr:false + hasDiff:false + count:1 → pause, no steer
+  const h = harness({
+    session: sess({ auto: true, status: "done", completionRepromptCount: 1 }),
+    verdict: { kind: "complete", summary: "Nothing to do." },
+    repoEnabled: true,
+    openPr: false,
+    hasDiff: false,
+  });
+  await h.svc.onDone("s1");
+  expect(h.events).toContainEqual({ pause: "s1", q: EMPTY_COMPLETION_MESSAGE });
+  expect(h.state().autopilotPaused).toBe(true);
+  expect(h.events.some((e) => "steer" in e)).toBe(false);
+  expect(h.state().autopilotComplete).toBe(false);
+});
+
+test("completion gate: attended session exempt (auto:false, hasDiff:false → still markComplete)", async () => {
+  // Non-drain (auto:false): gate is skipped regardless of diff/PR state
+  const h = harness({
+    session: sess({ auto: false, status: "done" }),
+    verdict: { kind: "complete", summary: "Created issue #99." },
+    repoEnabled: true,
+    openPr: false,
+    hasDiff: false,
+  });
+  await h.svc.onDone("s1");
+  expect(h.events).toContainEqual({ complete: "s1", summary: "Created issue #99." });
+  expect(h.state().autopilotComplete).toBe(true);
+  expect(h.state().completionRepromptCount).toBe(0);
+});
+
+test("completion gate: counter resets on onStatus running", () => {
+  // Operator re-engages a paused session → completionRepromptCount reset to 0
+  const h = harness({
+    session: sess({ autopilotPaused: true, completionRepromptCount: 1 }),
+  });
+  h.svc.onStatus("s1", "running");
+  expect(h.state().completionRepromptCount).toBe(0);
+});
+
+test("completion gate: counter resets on onPrOpen", () => {
+  // Critic handoff → completionRepromptCount reset to 0
+  const h = harness({
+    session: sess({ completionRepromptCount: 1 }),
+  });
+  h.svc.onPrOpen("s1");
+  expect(h.state().completionRepromptCount).toBe(0);
 });

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -41,6 +41,7 @@ function sess(over: Partial<Session> = {}): Session {
     autopilotPaused: false,
     autopilotComplete: false,
     autopilotQuestion: null,
+    completionRepromptCount: 0,
     planGateEnabled: null,
     planPhase: null,
     autoMergeEnabled: null,

--- a/test/blocked.test.ts
+++ b/test/blocked.test.ts
@@ -137,6 +137,7 @@ function makeSession(planPhase: Session["planPhase"]): Session {
     autopilotPaused: false,
     autopilotComplete: false,
     autopilotQuestion: null,
+    completionRepromptCount: 0,
     planGateEnabled: null,
     planPhase,
     research: false,

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -219,3 +219,104 @@ test("computeDiff: non-isolated session (no branch) → empty result", async () 
   expect(r.head).toBeNull();
   expect(r.fetchFailed).toBe(false);
 });
+
+import { hasCommittedChanges } from "../src/diff";
+
+test("hasCommittedChanges: null branch → false without invoking git", async () => {
+  // /nonexistent is not a git repo; if git were called it would throw
+  expect(await hasCommittedChanges("/nonexistent", "main", null)).toBe(false);
+});
+
+test("hasCommittedChanges: branch at same tree as base → false", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "shepherd-hcc-nochange-"));
+  try {
+    git(repo, "init", "-q", "-b", "main");
+    writeFileSync(join(repo, "a.txt"), "hello\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "base");
+    git(repo, "checkout", "-q", "-b", "feature");
+    // no additional commits on feature — same tree as main
+
+    expect(await hasCommittedChanges(repo, "main", "feature")).toBe(false);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("hasCommittedChanges: branch has a committed change vs base → true", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "shepherd-hcc-change-"));
+  try {
+    git(repo, "init", "-q", "-b", "main");
+    writeFileSync(join(repo, "a.txt"), "hello\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "base");
+    git(repo, "checkout", "-q", "-b", "feature");
+    writeFileSync(join(repo, "a.txt"), "hello\nworld\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "feature change");
+
+    expect(await hasCommittedChanges(repo, "main", "feature")).toBe(true);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("hasCommittedChanges: uncommitted-only changes are not counted → false", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "shepherd-hcc-dirty-"));
+  try {
+    git(repo, "init", "-q", "-b", "main");
+    writeFileSync(join(repo, "a.txt"), "hello\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "base");
+    git(repo, "checkout", "-q", "-b", "feature");
+    // dirty working tree — not staged/committed
+    writeFileSync(join(repo, "a.txt"), "hello\nworld\n");
+
+    expect(await hasCommittedChanges(repo, "main", "feature")).toBe(false);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("hasCommittedChanges: prefers origin/<base> when present, falls back to local base", async () => {
+  // Test the local fallback path: no remote → falls back to local base ref
+  const repo = mkdtempSync(join(tmpdir(), "shepherd-hcc-fallback-"));
+  try {
+    git(repo, "init", "-q", "-b", "main");
+    writeFileSync(join(repo, "a.txt"), "hello\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "base");
+    git(repo, "checkout", "-q", "-b", "feature");
+    writeFileSync(join(repo, "a.txt"), "hello\nworld\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "feature change");
+    // No remote → no origin/main → should fall back to local "main"
+
+    expect(await hasCommittedChanges(repo, "main", "feature")).toBe(true);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+
+  // Also test origin/<base> preference when a local remote-tracking ref exists
+  const remote = mkdtempSync(join(tmpdir(), "shepherd-hcc-remote-"));
+  const repo2 = mkdtempSync(join(tmpdir(), "shepherd-hcc-origin-"));
+  try {
+    git(remote, "init", "-q", "--bare", "-b", "main");
+    git(repo2, "init", "-q", "-b", "main");
+    writeFileSync(join(repo2, "a.txt"), "hello\n");
+    git(repo2, "add", "-A");
+    git(repo2, "commit", "-q", "-m", "base");
+    git(repo2, "remote", "add", "origin", remote);
+    git(repo2, "push", "-q", "origin", "main");
+    git(repo2, "checkout", "-q", "-b", "feature");
+    writeFileSync(join(repo2, "a.txt"), "hello\nworld\n");
+    git(repo2, "add", "-A");
+    git(repo2, "commit", "-q", "-m", "feature change");
+    // origin/main exists (pushed above, no fetch needed since push populated it)
+
+    expect(await hasCommittedChanges(repo2, "main", "feature")).toBe(true);
+  } finally {
+    rmSync(remote, { recursive: true, force: true });
+    rmSync(repo2, { recursive: true, force: true });
+  }
+});

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -107,6 +107,7 @@ function mkSession(o: Partial<Session> & { id: string }): Session {
     autopilotPaused: false,
     autopilotComplete: false,
     autopilotQuestion: null,
+    completionRepromptCount: 0,
     planGateEnabled: null,
     planPhase: null,
     research: false,

--- a/test/herd-digest.test.ts
+++ b/test/herd-digest.test.ts
@@ -39,6 +39,7 @@ function makeSession(over: Partial<Session> = {}): Session {
     autopilotPaused: false,
     autopilotComplete: false,
     autopilotQuestion: null,
+    completionRepromptCount: 0,
     planGateEnabled: null,
     planPhase: null,
     research: false,

--- a/test/quota-block-reason.test.ts
+++ b/test/quota-block-reason.test.ts
@@ -28,6 +28,7 @@ function makeSession(status: Session["status"] = "idle"): Session {
     autopilotPaused: false,
     autopilotComplete: false,
     autopilotQuestion: null,
+    completionRepromptCount: 0,
     planGateEnabled: null,
     planPhase: null,
     research: false,

--- a/test/ready-stage.test.ts
+++ b/test/ready-stage.test.ts
@@ -30,6 +30,7 @@ function makeSession(overrides: Partial<Session> = {}): Session {
     autopilotPaused: false,
     autopilotComplete: false,
     autopilotQuestion: null,
+    completionRepromptCount: 0,
     planGateEnabled: null,
     planPhase: null,
     research: false,

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -58,6 +58,7 @@ function makeSession(over: Partial<Session> = {}): Session {
     autopilotPaused: false,
     autopilotComplete: false,
     autopilotQuestion: null,
+    completionRepromptCount: 0,
     planGateEnabled: null,
     planPhase: null,
     research: false,

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -66,6 +66,7 @@ function session(over: Partial<Session> = {}): Session {
     autopilotPaused: false,
     autopilotComplete: false,
     autopilotQuestion: null,
+    completionRepromptCount: 0,
     planGateEnabled: null,
     planPhase: null,
     autoMergeEnabled: null,

--- a/test/rundown-core.test.ts
+++ b/test/rundown-core.test.ts
@@ -44,6 +44,7 @@ function session(over: Partial<Session> = {}): Session {
     autopilotPaused: false,
     autopilotComplete: false,
     autopilotQuestion: null,
+    completionRepromptCount: 0,
     planGateEnabled: null,
     planPhase: null,
     research: false,

--- a/test/server-diff.test.ts
+++ b/test/server-diff.test.ts
@@ -29,6 +29,7 @@ const SESSION: Session = {
   autopilotPaused: false,
   autopilotComplete: false,
   autopilotQuestion: null,
+  completionRepromptCount: 0,
   planGateEnabled: null,
   planPhase: null,
   autoMergeEnabled: null,

--- a/test/server-git.test.ts
+++ b/test/server-git.test.ts
@@ -33,6 +33,7 @@ const SESSION: Session = {
   autopilotPaused: false,
   autopilotComplete: false,
   autopilotQuestion: null,
+  completionRepromptCount: 0,
   planGateEnabled: null,
   planPhase: null,
   autoMergeEnabled: null,

--- a/test/server-quota-endpoints.test.ts
+++ b/test/server-quota-endpoints.test.ts
@@ -34,6 +34,7 @@ const SESSION: Session = {
   autopilotPaused: false,
   autopilotComplete: false,
   autopilotQuestion: null,
+  completionRepromptCount: 0,
   planGateEnabled: null,
   planPhase: null,
   autoMergeEnabled: null,

--- a/test/server-review-pr.test.ts
+++ b/test/server-review-pr.test.ts
@@ -34,6 +34,7 @@ const SESSION: Session = {
   autopilotPaused: false,
   autopilotComplete: false,
   autopilotQuestion: null,
+  completionRepromptCount: 0,
   planGateEnabled: null,
   planPhase: null,
   autoMergeEnabled: null,

--- a/test/store-autopilot.test.ts
+++ b/test/store-autopilot.test.ts
@@ -88,6 +88,38 @@ test("hydrates a pre-autopilot row with defaults", () => {
   expect(s.autopilotQuestion).toBeNull();
 });
 
+test("new sessions default completionRepromptCount to 0", () => {
+  const store = freshStore();
+  const s = store.get(seed(store).id)!;
+  expect(s.completionRepromptCount).toBe(0);
+});
+
+test("setAutopilotState completionReprompt increments and resets", () => {
+  const store = freshStore();
+  const id = seed(store).id;
+  store.setAutopilotState(id, { completionReprompt: 1 });
+  expect(store.get(id)!.completionRepromptCount).toBe(1);
+  store.setAutopilotState(id, { completionReprompt: 2 });
+  expect(store.get(id)!.completionRepromptCount).toBe(2);
+  store.setAutopilotState(id, { completionReprompt: 0 });
+  expect(store.get(id)!.completionRepromptCount).toBe(0);
+});
+
+test("partial-patch: stepCount does not clobber completionRepromptCount and vice-versa", () => {
+  const store = freshStore();
+  const id = seed(store).id;
+  store.setAutopilotState(id, { completionReprompt: 3 });
+  store.setAutopilotState(id, { stepCount: 5 });
+  const s = store.get(id)!;
+  expect(s.autopilotStepCount).toBe(5);
+  expect(s.completionRepromptCount).toBe(3); // not clobbered by stepCount patch
+
+  store.setAutopilotState(id, { completionReprompt: 7 });
+  const s2 = store.get(id)!;
+  expect(s2.autopilotStepCount).toBe(5); // not clobbered by completionReprompt patch
+  expect(s2.completionRepromptCount).toBe(7);
+});
+
 test("repo config autopilotEnabled defaults off and round-trips", () => {
   const store = freshStore();
   expect(store.getRepoConfig("/repo").autopilotEnabled).toBe(false);


### PR DESCRIPTION
Closes #1009.

## Problem

A drain session can be accepted as **done** on the agent's word alone, with nothing to show. Downstream gates (retire requires a green PR; merge requires a merged PR) catch most no-ops — but autopilot's `complete` verdict (`dispatch()` → `markComplete()`) is a **silent terminal "done" with no diff/PR check**, the mechanism behind the "agent declared done with nothing to show" failure class.

## Premise correction

The issue described the gate firing on `haltReason:'completed'` before `archive()`. In the actual code that path doesn't exist: `haltReason:'completed'` is declared but **never set**, and autopilot **never archives** — `archive()` only runs at retire/merge, where a PR exists by construction. So the gate lives at the real hole: autopilot's `complete` verdict. (Full reasoning in `.shepherd-plan.md`, reviewed pre-execution.)

## What this does

A **deterministic, no-LLM** completion verifier. When autopilot is about to accept a `complete` verdict for a **drain/auto** session, it first checks "did anything happen" — a committed diff vs base **or** an associated PR:

- Something exists → `markComplete` as before.
- Nothing → re-prompt the agent **once** (bounded by a persisted `completionRepromptCount`), then route to **needs-human** (reuse the existing `pause()` hand-back) instead of silently filing it done.

It is a *completion verifier, not a quality judge* (that's the critic's job) — it only answers "did anything happen", via `git diff --quiet base...HEAD` (local base ref, no fetch) + the existing PR snapshot.

### Scope / guardrails
- **Drain/auto sessions only.** Attended sessions are exempt — a non-code `complete` (issue creation, one-off answer) is legitimate there and must not be false-flagged. Research is attended-only, so it's outside the gate by construction.
- **Respects the lightweight-repo barrier** — the `finished`/`openLocalPr`/`EmptyDiffError` path is untouched.
- **Exactly-once** re-prompt: the persisted counter resets alongside the step budget (`onStatus` re-engage, `onPrOpen`), so a re-engaged session that later genuinely completes isn't immediately re-paused.
- **Fail-open + logged:** a systemic git error returns "has work" (no false needs-human) but `console.warn`s, so the bypass is observable.

## Acceptance
- [x] On `complete`, verify a diff/PR exists before accepting done.
- [x] On empty: bounded re-prompt (once), then needs-human rather than done.
- [x] Deterministic (no LLM); covered by tests.

## Tests
- `src/diff.ts` `hasCommittedChanges`: no-diff / committed-diff / null-branch / uncommitted-excluded / base-ref resolution (`test/diff.test.ts`).
- Gate matrix (`test/autopilot.test.ts`): diff→complete, PR→complete (asserts `hasDiff` short-circuited), empty-first→steer+counter, empty-second→pause, attended-exempt, counter resets.
- Counter persistence + partial-patch preserve (`test/store-autopilot.test.ts`).
- Full suite green (4516 pass), `tsc`/`lint`/`fallow` clean.

Server-only autopilot plumbing — no user-facing UI surface (no feature-catalog entry needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
