### PR TITLE
fix(build-queue): resolve short/prefix step ids; loud 4xx on mismatch (#1011)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2172,9 +2172,28 @@ async function postBuildStepStatus(
   if (ctErr) return ctErr;
   const status = validateBuildStepStatus(await req.json().catch(() => null));
   if (status === null) return json({ error: "invalid status" }, 400);
-  if (!deps.store.setBuildStepStatus(id, stepId, status)) {
-    return json({ error: "step not found" }, 404);
+  // Resolve the posted id (full UUID or unambiguous ≥8-char prefix) before updating, so a
+  // short/abbreviated or stale id returns a clear 4xx instead of silently no-op'ing.
+  const resolved = deps.store.resolveStepId(id, stepId);
+  if (!resolved.ok) {
+    if (resolved.reason === "ambiguous") {
+      return json(
+        {
+          error: `ambiguous step id prefix "${stepId}" matches ${resolved.matches.length} steps — use a longer prefix or the full id`,
+          matches: resolved.matches,
+        },
+        409,
+      );
+    }
+    return json(
+      {
+        error: `step "${stepId}" not found — use a full or unambiguous (≥8-char) prefix step id from the PUT/GET response`,
+      },
+      404,
+    );
   }
+  // resolved.ok ⇒ the row exists, so setBuildStepStatus returns true; ignore its boolean.
+  deps.store.setBuildStepStatus(id, resolved.id, status);
   const q = deps.store.getBuildQueue(id);
   deps.events?.emit("queue:update", q);
   return json(q);

--- a/src/service.ts
+++ b/src/service.ts
@@ -569,6 +569,12 @@ export function buildQueueDirective(args: {
     "update keeps the whole queue accurate. The operator's view of your progress depends entirely " +
     "on these. If your reported statuses ever fall behind your actual progress you may receive a " +
     "reminder to reconcile them — do so promptly.\n\n" +
+    "   The POST response echoes the full queue — confirm your step's new status in it. A 4xx body " +
+    "means the update did NOT take. IMPORTANT: any cached step id — full UUID or short prefix — is " +
+    "invalidated by a later PUT (a PUT whose steps omit `id` regenerates every UUID). After any " +
+    "PUT, take fresh ids from the PUT response (or re-GET) before posting status; never reuse ids " +
+    "from before a PUT. You may post a short id as long as it is an unambiguous prefix of ≥8 chars " +
+    "of the full id; a 409 means the prefix matched several steps (use a longer prefix or the full id).\n\n" +
     "3. Inspect the current queue at any time:\n" +
     `   curl -s${authHeader} ${queueUrl}\n\n` +
     "Self-revision: if you discover a better approach mid-run, PUT an updated steps array. " +

--- a/src/store.ts
+++ b/src/store.ts
@@ -500,6 +500,40 @@ function localPrFromRow(r: LocalPrRow): LocalPr {
   };
 }
 
+/** Minimum length for a non-exact step-id prefix to be resolvable. 8 = the conventional
+ *  short-UUID form (the first UUID segment, e.g. `1444d473`) shown in logs/progress summaries.
+ *  Below this we refuse to resolve: a shorter unique prefix could silently bind to the WRONG
+ *  step after a re-PUT regenerates ids, so we return not-found with guidance rather than guess. */
+export const STEP_ID_PREFIX_MIN = 8;
+
+/** Outcome of resolving a posted step id against a session's actual step ids. */
+export type StepIdResolution =
+  | { ok: true; id: string }
+  | { ok: false; reason: "not-found" }
+  | { ok: false; reason: "ambiguous"; matches: string[] };
+
+/**
+ * Pure resolver: map a posted `idOrPrefix` onto one of `ids` (a session's step ids).
+ *
+ * Exact match is checked FIRST and wins unconditionally, so an id that also happens to be a
+ * prefix of another id resolves to itself. With production UUIDs this exact-first ordering is
+ * purely defensive — all ids are fixed-length 36-char UUIDs, so a 36-char exact-match query can
+ * never also be a strict prefix of a *distinct* 36-char id (equal length ⇒ prefix ⇒ identical).
+ * It is unit-tested with synthetic ids precisely because real UUIDs can't construct the collision.
+ *
+ * Failing an exact match, an unambiguous prefix of ≥ STEP_ID_PREFIX_MIN chars resolves to the
+ * single id it prefixes; >1 match is `ambiguous`; 0 matches (or a too-short non-exact id) is
+ * `not-found`.
+ */
+export function resolveStepId(ids: string[], idOrPrefix: string): StepIdResolution {
+  if (ids.includes(idOrPrefix)) return { ok: true, id: idOrPrefix };
+  if (idOrPrefix.length < STEP_ID_PREFIX_MIN) return { ok: false, reason: "not-found" };
+  const matches = ids.filter((id) => id.startsWith(idOrPrefix));
+  if (matches.length === 1) return { ok: true, id: matches[0]! };
+  if (matches.length > 1) return { ok: false, reason: "ambiguous", matches };
+  return { ok: false, reason: "not-found" };
+}
+
 export class SessionStore implements CapStore, CreditStore {
   private db: Database;
   constructor(path: string) {
@@ -3317,6 +3351,22 @@ export class SessionStore implements CapStore, CreditStore {
       }
     })();
     return this.getBuildQueue(sessionId);
+  }
+
+  /**
+   * Resolve a posted step `idOrPrefix` against this session's actual step ids (exact match first,
+   * else an unambiguous ≥8-char prefix — see the pure `resolveStepId` helper). The POST handler
+   * uses this to turn a short/abbreviated id into the full id (or a clear 404/409) so a status
+   * update can't silently no-op on an unmatched id.
+   */
+  resolveStepId(sessionId: string, idOrPrefix: string): StepIdResolution {
+    const rows = this.db
+      .query(`SELECT id FROM build_queue_steps WHERE sessionId = ?`)
+      .all(sessionId) as { id: string }[];
+    return resolveStepId(
+      rows.map((r) => r.id),
+      idOrPrefix,
+    );
   }
 
   /**

--- a/test/build-queue-api.test.ts
+++ b/test/build-queue-api.test.ts
@@ -228,7 +228,7 @@ test("POST queue/steps/:stepId emits queue:update", async () => {
   expect(ev).toBeDefined();
 });
 
-test("POST queue/steps with unknown stepId → 404", async () => {
+test("POST queue/steps with unknown stepId → 404 with actionable message", async () => {
   const { app, store } = harness();
   const session = makeSession(store, repoDir);
 
@@ -240,6 +240,74 @@ test("POST queue/steps with unknown stepId → 404", async () => {
     }),
   );
   expect(res.status).toBe(404);
+  const body = await res.json();
+  expect(body.error).toContain("not found");
+});
+
+test("POST queue/steps with an unambiguous ≥8-char prefix resolves and updates the step", async () => {
+  const { app, store } = harness();
+  const session = makeSession(store, repoDir);
+
+  const putRes = await app.fetch(
+    new Request(`http://x/api/sessions/${session.id}/queue`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ steps: [{ title: "Step A" }] }),
+    }),
+  );
+  const queue = await putRes.json();
+  const fullId = queue.steps[0].id;
+  const prefix = fullId.slice(0, 8);
+
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${session.id}/queue/steps/${prefix}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ status: "done" }),
+    }),
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.steps[0].id).toBe(fullId);
+  expect(body.steps[0].status).toBe("done");
+});
+
+test("POST queue/steps with an ambiguous prefix → 409 with matches, no change", async () => {
+  const { app, store } = harness();
+  const session = makeSession(store, repoDir);
+
+  // Seed two steps whose ids share an 8-char prefix so the posted prefix is ambiguous.
+  // This is a SYNTHETIC scenario: real step ids are fixed-length random UUIDs that can't
+  // collide on an 8-char prefix, and replaceBuildQueue discards explicit ids on a fresh
+  // session (store.ts), so we insert the rows directly to construct the collision.
+  const db = (store as unknown as { db: import("bun:sqlite").Database }).db;
+  const now = Date.now();
+  for (const [pos, id, title] of [
+    [0, "abcd1234-aaaa-4e41-88b0-c4f255337d81", "A"],
+    [1, "abcd1234-bbbb-4e41-88b0-c4f255337d81", "B"],
+  ] as const) {
+    db.run(
+      `INSERT INTO build_queue_steps (id, sessionId, position, title, detail, status, createdAt, updatedAt)
+       VALUES (?,?,?,?,?,?,?,?)`,
+      [id, session.id, pos, title, "", "pending", now, now],
+    );
+  }
+
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${session.id}/queue/steps/abcd1234`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ status: "done" }),
+    }),
+  );
+  expect(res.status).toBe(409);
+  const body = await res.json();
+  expect(body.matches).toHaveLength(2);
+  // nothing changed — both steps still pending
+  expect(store.getBuildQueue(session.id).steps.map((x: { status: string }) => x.status)).toEqual([
+    "pending",
+    "pending",
+  ]);
 });
 
 test("POST queue/steps with invalid status → 400", async () => {

--- a/test/build-queue-store.test.ts
+++ b/test/build-queue-store.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { SessionStore } from "../src/store";
+import { SessionStore, resolveStepId, STEP_ID_PREFIX_MIN } from "../src/store";
 
 function mk() {
   return new SessionStore(":memory:");
@@ -204,6 +204,93 @@ test("forward-fill: a missing target id does not cascade", () => {
   s.replaceBuildQueue(sess.id, [{ title: "Step A" }, { title: "Step B" }]);
   expect(s.setBuildStepStatus(sess.id, "no-such-id", "done")).toBe(false);
   expect(s.getBuildQueue(sess.id).steps.map((x) => x.status)).toEqual(["pending", "pending"]);
+});
+
+// ── resolveStepId (pure helper) ──────────────────────────────────────────────
+
+test("resolveStepId: exact match resolves to itself", () => {
+  expect(resolveStepId(["abcd1234ef", "99887766aa"], "abcd1234ef")).toEqual({
+    ok: true,
+    id: "abcd1234ef",
+  });
+});
+
+test("resolveStepId: exact match WINS over being a prefix of another id (defensive ordering)", () => {
+  // Synthetic ids: "abcd1234" is both an exact id AND a prefix of "abcd1234ef". Exact wins.
+  // Real fixed-length 36-char UUIDs can't construct this collision, so this guards implementation
+  // robustness, not a production-reachable case.
+  expect(resolveStepId(["abcd1234", "abcd1234ef"], "abcd1234")).toEqual({
+    ok: true,
+    id: "abcd1234",
+  });
+});
+
+test("resolveStepId: unambiguous ≥8-char prefix resolves to the full id", () => {
+  const ids = ["1444d473-ffc4-4e41-88b0-c4f255337d81", "9c14f3da-0000-4e41-88b0-c4f255337d81"];
+  expect(resolveStepId(ids, "1444d473")).toEqual({ ok: true, id: ids[0]! });
+});
+
+test("resolveStepId: ambiguous prefix returns all matches", () => {
+  const ids = ["abcd1234aaaa", "abcd1234bbbb", "ffffffff0000"];
+  const r = resolveStepId(ids, "abcd1234");
+  expect(r).toEqual({ ok: false, reason: "ambiguous", matches: ["abcd1234aaaa", "abcd1234bbbb"] });
+});
+
+test("resolveStepId: a too-short (<8) non-exact prefix is refused as not-found, never resolved", () => {
+  // "abcd123" uniquely prefixes the lone id, but is below the floor — refuse rather than guess.
+  expect("abcd123".length).toBeLessThan(STEP_ID_PREFIX_MIN);
+  expect(resolveStepId(["abcd1234ef"], "abcd123")).toEqual({ ok: false, reason: "not-found" });
+});
+
+test("resolveStepId: unknown id is not-found", () => {
+  expect(resolveStepId(["abcd1234ef"], "no-such-step-id")).toEqual({
+    ok: false,
+    reason: "not-found",
+  });
+});
+
+// ── store.resolveStepId + setBuildStepStatus interaction ─────────────────────
+
+test("store.resolveStepId maps an unambiguous 8-char prefix to the full step id, scoped to session", () => {
+  const s = mk();
+  const sess = s.create(base);
+  const q = s.replaceBuildQueue(sess.id, [{ title: "Step A" }, { title: "Step B" }]);
+  const fullId = q.steps[1]!.id;
+  const prefix = fullId.slice(0, 8);
+  expect(s.resolveStepId(sess.id, prefix)).toEqual({ ok: true, id: fullId });
+  // a prefix that matches nothing in THIS session is not-found
+  expect(s.resolveStepId(sess.id, "00000000")).toEqual({ ok: false, reason: "not-found" });
+});
+
+test("forward-fill fires when a later step is marked done via a RESOLVED ≥8-char prefix", () => {
+  const s = mk();
+  const sess = s.create(base);
+  const q = s.replaceBuildQueue(sess.id, [
+    { title: "Step A" },
+    { title: "Step B" },
+    { title: "Step C" },
+  ]);
+  const cFull = q.steps[2]!.id;
+  const cPrefix = cFull.slice(0, 8);
+
+  // Resolve the short prefix, then drive setBuildStepStatus with the full id (the handler's path).
+  const resolved = s.resolveStepId(sess.id, cPrefix);
+  expect(resolved.ok).toBe(true);
+  if (!resolved.ok) throw new Error("expected prefix to resolve");
+  expect(s.setBuildStepStatus(sess.id, resolved.id, "done")).toBe(true);
+
+  // earlier pending steps back-filled to done exactly as with a full UUID
+  expect(s.getBuildQueue(sess.id).steps.map((x) => x.status)).toEqual(["done", "done", "done"]);
+});
+
+test("mode-2 regression: a lone pending step goes pending → done directly (no active first)", () => {
+  const s = mk();
+  const sess = s.create(base);
+  const q = s.replaceBuildQueue(sess.id, [{ title: "Only step" }]);
+  const id = q.steps[0]!.id;
+  expect(q.steps[0]!.status).toBe("pending");
+  expect(s.setBuildStepStatus(sess.id, id, "done")).toBe(true);
+  expect(s.getBuildQueue(sess.id).steps[0]!.status).toBe("done");
 });
 
 test("replaceBuildQueue leaves approval untouched (self-revision must not re-gate)", () => {


### PR DESCRIPTION
Fixes #1011.

## Problem

`POST /api/sessions/<id>/queue/steps/<stepId>` silently no-op'd: `store.setBuildStepStatus` matched ids **exactly** (`WHERE id = ?`), so a short prefix (`1444d473`) — or a **stale** UUID cached from a `PUT` that a later `PUT` regenerated (`store.ts` regenerates ids for steps posted without `id`) — changed 0 rows and returned a 404 the agent typically discards. Net effect: queues stuck all-`pending` while work was done.

## Fix

- **`resolveStepId(ids, idOrPrefix)`** (pure, exported) — exact match checked **first** (wins unconditionally), else an unambiguous prefix of **≥8 chars** (the conventional short-UUID form). `>1` match → `ambiguous`; 0 / sub-8 non-exact → `not-found`. Plus a thin `store.resolveStepId(sessionId, …)` wrapper that queries the session's ids and delegates.
- **`postBuildStepStatus`** resolves before updating: `404` (actionable message) on not-found, `409` (with `matches`) on ambiguous, else update + `200` with the full queue.
- **`buildQueueDirective`** prompt note: the response echoes the queue (confirm your step's status); **any** cached id (full UUID *or* prefix) is invalidated by a later `PUT` — re-`GET` for fresh ids; `409` means use a longer prefix.

`setBuildStepStatus` is unchanged (exact-match boolean primitive); resolution lives at the handler boundary. Error bodies are agent-facing curl JSON — not i18n'd, matching the existing `{ error: "invalid status" }` convention.

## On "mode 2" (`pending → done` reportedly dropped)

**This is not a code bug.** A direct single-step `pending → done` already applies correctly (locked by a new lone-step regression test). The reporter's repro #3 is best explained as a **stale post-re-`PUT` UUID** — the same invisible-mismatch family as the short-id bug — which this PR's loud `4xx` + re-`GET` guidance addresses.

⚠️ **Hedge:** the regression test proves the *current code* is correct; it does **not** prove repro #3 was specifically a stale id. That cause is the only one consistent with the code, but it is *inferred, not observed*. If mode 2 had some other cause (e.g. a client/transport quirk not captured here), this PR would leave it unaddressed — a reviewer with the original session context should refute this if they know otherwise.

## Residual case (NOT closed by this PR)

A stale **full** UUID posted with output piped to `/dev/null` still 404s **invisibly to the agent** — the server can't force the agent to read its response. Narrowed by the directive guidance + the existing `BuildQueueReminderService` settled-idle nudge. Closing it server-side would need **stable step ids across re-`PUT`** (risky: titles mutate), proposed as a follow-up (#1014) rather than built here.

## Tests

- Pure helper: exact match, **exact-wins-over-prefix** (synthetic ids — real fixed-length UUIDs can't construct the collision), unambiguous ≥8 prefix, ambiguous, sub-8 refused, unknown.
- Store: `resolveStepId` session-scoping; **forward-fill cascade via a resolved short prefix**; lone-step `pending → done` regression.
- API: short-prefix → 200, ambiguous → 409 (+ no change), unknown → 404 with message.
- Root `bun test ./test` (4527 pass), `bun run lint`, `bunx tsc --noEmit`, `fallow audit` all green.

[no-feature-entry] — server-only plumbing + agent-facing prompt/API text; no user-facing UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)