### PR TITLE
fix(build-queue): stable step ids across re-PUT (#1014)

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -550,9 +550,12 @@ export function buildQueueDirective(args: {
     "1. Author / replace the whole plan (do this first, before starting any work):\n" +
     `   curl -s -X PUT${authHeader} \\\n` +
     `     -H "Content-Type: application/json" \\\n` +
-    `     -d '{"steps":[{"title":"Step title","detail":"Optional detail"}]}' \\\n` +
+    `     -d '{"steps":[{"id":"s1","title":"Step title","detail":"Optional detail"}]}' \\\n` +
     `     ${queueUrl}\n` +
-    "   The response returns each step with a generated `id` and the queue's `approved` flag.\n\n" +
+    "   Assign each step your own short, stable `id` (`s1`, `s2`, …) and ALWAYS resend a step with " +
+    "the SAME `id` on every PUT: an id you own is stored verbatim and never regenerated, so your " +
+    "cached ids stay valid across re-PUTs. The response echoes each step's `id` and the queue's " +
+    "`approved` flag.\n\n" +
     "2. Mark a step's progress (use the `id` values from the PUT/GET response):\n" +
     `   curl -s -X POST${authHeader} \\\n` +
     `     -H "Content-Type: application/json" \\\n` +
@@ -570,16 +573,20 @@ export function buildQueueDirective(args: {
     "on these. If your reported statuses ever fall behind your actual progress you may receive a " +
     "reminder to reconcile them — do so promptly.\n\n" +
     "   The POST response echoes the full queue — confirm your step's new status in it. A 4xx body " +
-    "means the update did NOT take. IMPORTANT: any cached step id — full UUID or short prefix — is " +
-    "invalidated by a later PUT (a PUT whose steps omit `id` regenerates every UUID). After any " +
-    "PUT, take fresh ids from the PUT response (or re-GET) before posting status; never reuse ids " +
-    "from before a PUT. You may post a short id as long as it is an unambiguous prefix of ≥8 chars " +
-    "of the full id; a 409 means the prefix matched several steps (use a longer prefix or the full id).\n\n" +
+    "means the update did NOT take. IMPORTANT: ids you assign yourself (`s1`, `s2`, …) are kept " +
+    "verbatim across every PUT, so always reuse them — that is what keeps your cached ids valid. " +
+    "Only a step PUT WITHOUT an `id` gets a server-generated one, and an omitted id survives a " +
+    "re-PUT only when that step keeps the same position AND title; otherwise it is regenerated. " +
+    "So the rule is: assign and resend your own ids. Fallback only if you didn't — re-GET (or read " +
+    "the PUT response) to pick up the current ids before posting status. A short id resolves by " +
+    "exact match; a server UUID may also be posted as an unambiguous prefix of ≥8 chars (a 409 " +
+    "means the prefix matched several steps — use a longer prefix or the full id).\n\n" +
     "3. Inspect the current queue at any time:\n" +
     `   curl -s${authHeader} ${queueUrl}\n\n` +
     "Self-revision: if you discover a better approach mid-run, PUT an updated steps array. " +
-    "Only add, change, or remove steps that are still PENDING. To preserve a completed step, " +
-    "include it with its existing `id` (its status is kept server-side).\n\n" +
+    "Only add, change, or remove steps that are still PENDING. ALWAYS include each carried step " +
+    "with its existing `id` (its status is kept server-side) — that is how completed and " +
+    "in-progress steps keep their identity across the revision.\n\n" +
     "Runaway guard: keep the plan small and focused (a handful of steps). " +
     "Do not let self-revision loop indefinitely — each PUT should reflect a genuine course correction, " +
     "not iterative micro-adjustment.\n\n" +

--- a/src/store.ts
+++ b/src/store.ts
@@ -516,10 +516,12 @@ export type StepIdResolution =
  * Pure resolver: map a posted `idOrPrefix` onto one of `ids` (a session's step ids).
  *
  * Exact match is checked FIRST and wins unconditionally, so an id that also happens to be a
- * prefix of another id resolves to itself. With production UUIDs this exact-first ordering is
- * purely defensive — all ids are fixed-length 36-char UUIDs, so a 36-char exact-match query can
- * never also be a strict prefix of a *distinct* 36-char id (equal length ⇒ prefix ⇒ identical).
- * It is unit-tested with synthetic ids precisely because real UUIDs can't construct the collision.
+ * prefix of another id resolves to itself. This exact-first ordering is LOAD-BEARING: step ids
+ * are no longer all fixed-length UUIDs — an agent may own a short stable id (e.g. "s1") via a
+ * verbatim `id` on PUT (see `replaceBuildQueue`). A short id is below `STEP_ID_PREFIX_MIN`, so it
+ * never prefix-resolves; it resolves only by this exact match. (Server-generated ids remain
+ * 36-char UUIDs, for which equal-length ⇒ prefix ⇒ identical, so exact-first is also defensive
+ * there.) It is unit-tested with both a synthetic UUID-prefix collision and a short exact id.
  *
  * Failing an exact match, an unambiguous prefix of ≥ STEP_ID_PREFIX_MIN chars resolves to the
  * single id it prefixes; >1 match is `ambiguous`; 0 matches (or a too-short non-exact id) is
@@ -745,11 +747,16 @@ export class SessionStore implements CapStore, CreditStore {
     );
     this.migrateLearningsColumns();
     this.backfillLearningDiversity();
+    // PK is composite (sessionId, id): step ids are scoped to a session so an agent may own a
+    // short stable id (e.g. "s1") that survives a re-PUT, without colliding with the same id in
+    // another session. Every build_queue_steps query is already session-scoped.
     this.db.run(`CREATE TABLE IF NOT EXISTS build_queue_steps (
-      id TEXT PRIMARY KEY, sessionId TEXT NOT NULL, position INTEGER NOT NULL,
+      id TEXT NOT NULL, sessionId TEXT NOT NULL, position INTEGER NOT NULL,
       title TEXT NOT NULL, detail TEXT NOT NULL DEFAULT '',
       status TEXT NOT NULL DEFAULT 'pending',
-      createdAt INTEGER NOT NULL, updatedAt INTEGER NOT NULL)`);
+      createdAt INTEGER NOT NULL, updatedAt INTEGER NOT NULL,
+      PRIMARY KEY (sessionId, id))`);
+    this.migrateBuildQueueStepsPk();
     this.db.run(
       `CREATE INDEX IF NOT EXISTS build_queue_steps_session ON build_queue_steps (sessionId, position)`,
     );
@@ -2407,6 +2414,34 @@ export class SessionStore implements CapStore, CreditStore {
     add("haltedAt", `haltedAt INTEGER`);
   }
 
+  // Migrate build_queue_steps from the legacy global `PRIMARY KEY (id)` to the composite
+  // `PRIMARY KEY (sessionId, id)`. SQLite can't ALTER a primary key, so this rebuilds the table
+  // once. Detect the legacy shape via PRAGMA (the `id` column carries pk=1 while `sessionId`
+  // carries pk=0); a table already on the composite PK reports sessionId with pk>0 and is skipped.
+  // Idempotent + transactional; existing ids are globally-unique UUIDs, so they migrate trivially.
+  private migrateBuildQueueStepsPk(): void {
+    const cols = this.db.query(`PRAGMA table_info(build_queue_steps)`).all() as {
+      name: string;
+      pk: number;
+    }[];
+    const sessionIdInPk = cols.some((c) => c.name === "sessionId" && c.pk > 0);
+    if (sessionIdInPk) return; // already composite (or freshly created above)
+    this.db.transaction(() => {
+      this.db.run(`CREATE TABLE build_queue_steps_new (
+        id TEXT NOT NULL, sessionId TEXT NOT NULL, position INTEGER NOT NULL,
+        title TEXT NOT NULL, detail TEXT NOT NULL DEFAULT '',
+        status TEXT NOT NULL DEFAULT 'pending',
+        createdAt INTEGER NOT NULL, updatedAt INTEGER NOT NULL,
+        PRIMARY KEY (sessionId, id))`);
+      this.db.run(
+        `INSERT INTO build_queue_steps_new (id, sessionId, position, title, detail, status, createdAt, updatedAt)
+         SELECT id, sessionId, position, title, detail, status, createdAt, updatedAt FROM build_queue_steps`,
+      );
+      this.db.run(`DROP TABLE build_queue_steps`);
+      this.db.run(`ALTER TABLE build_queue_steps_new RENAME TO build_queue_steps`);
+    })();
+  }
+
   // migrate repo_config that predates these opt-in columns. auto-address defaults
   // OFF (the spendier loop — existing repos opt in explicitly); learnings defaults ON.
   private migrateRepoConfigColumns(): void {
@@ -3324,23 +3359,76 @@ export class SessionStore implements CapStore, CreditStore {
     return { sessionId, steps, approved: state ? !!state.approved : false };
   }
 
+  /**
+   * Replace a session's whole queue, preserving step identity across the re-PUT two ways:
+   *
+   *  1. **Verbatim client ids.** A step posted WITH an `id` keeps that id as-is (matched or new),
+   *     so an agent that owns stable ids (e.g. "s1") survives reorder/insert/delete with no
+   *     regeneration. A matched id also preserves its prior `status` + `createdAt` (unless an
+   *     explicit `status` is given — that still wins).
+   *  2. **Conservative carry-over for an OMITTED id.** Reuse the existing step's id only when the
+   *     step at the SAME position has the SAME title (position AND title must agree). This never
+   *     mis-binds; any insert/delete/rename/reorder falls back to a fresh UUID. It is the safe
+   *     synthesis of the two single-key heuristics (positional / title-keyed) that are each unsafe
+   *     alone, and it keeps cached ids valid for the common "revise the tail, keep finished steps"
+   *     re-PUT even when the agent omits ids.
+   *
+   * Duplicate explicit ids are rejected upstream (`validateBuildSteps`); the `reserved`/`used`
+   * guards below additionally ensure no two rows resolve to the same id (which would throw on the
+   * composite PK): an omitted-id step never carries over an id another step claims explicitly, nor
+   * one already assigned earlier in this PUT.
+   */
   replaceBuildQueue(sessionId: string, steps: BuildStepInput[]): BuildQueue {
     const now = Date.now();
     this.db.transaction(() => {
-      // read existing rows (inside the txn) to preserve status + createdAt for id-matching entries
-      const existing = new Map<string, { status: BuildStepStatus; createdAt: number }>();
+      // read existing rows (inside the txn) to preserve status + createdAt across the replace
+      const byId = new Map<string, { status: BuildStepStatus; createdAt: number }>();
+      const byPosition = new Map<
+        number,
+        { id: string; title: string; status: BuildStepStatus; createdAt: number }
+      >();
       const existingRows = this.db
-        .query(`SELECT id, status, createdAt FROM build_queue_steps WHERE sessionId = ?`)
-        .all(sessionId) as { id: string; status: string; createdAt: number }[];
+        .query(
+          `SELECT id, position, title, status, createdAt FROM build_queue_steps WHERE sessionId = ?`,
+        )
+        .all(sessionId) as {
+        id: string;
+        position: number;
+        title: string;
+        status: string;
+        createdAt: number;
+      }[];
       for (const r of existingRows) {
-        existing.set(r.id, { status: r.status as BuildStepStatus, createdAt: r.createdAt });
+        byId.set(r.id, { status: r.status as BuildStepStatus, createdAt: r.createdAt });
+        byPosition.set(r.position, {
+          id: r.id,
+          title: r.title,
+          status: r.status as BuildStepStatus,
+          createdAt: r.createdAt,
+        });
       }
+      // ids the agent claims explicitly this PUT — an omitted-id carry-over must not steal one.
+      const reserved = new Set(steps.filter((s) => s.id).map((s) => s.id!));
+      const used = new Set<string>();
+
       this.db.run(`DELETE FROM build_queue_steps WHERE sessionId = ?`, [sessionId]);
       for (let i = 0; i < steps.length; i++) {
         const input = steps[i]!;
-        const matchId = input.id && existing.has(input.id) ? input.id : null;
-        const prior = matchId ? existing.get(matchId)! : null;
-        const id = matchId ?? randomUUID();
+        let id: string;
+        let prior: { status: BuildStepStatus; createdAt: number } | null = null;
+        if (input.id) {
+          id = input.id; // verbatim
+          prior = byId.get(id) ?? null;
+        } else {
+          const cand = byPosition.get(i);
+          if (cand && cand.title === input.title && !reserved.has(cand.id) && !used.has(cand.id)) {
+            id = cand.id; // position+title carry-over
+            prior = { status: cand.status, createdAt: cand.createdAt };
+          } else {
+            id = randomUUID();
+          }
+        }
+        used.add(id);
         const status = input.status ?? prior?.status ?? "pending";
         const createdAt = prior?.createdAt ?? now;
         this.db.run(

--- a/src/types.ts
+++ b/src/types.ts
@@ -427,9 +427,12 @@ export interface BuildQueue {
   approved: boolean;
 }
 
-/** Input shape for replacing a queue. `id` present + matching an existing step
- *  preserves that step's status (unless `status` is given). New entries get a
- *  fresh id and default to "pending". */
+/** Input shape for replacing a queue. A present `id` is kept VERBATIM as the step's id
+ *  (scoped per session), so an agent can own a stable id that survives a re-PUT; a present
+ *  `id` matching an existing step also preserves that step's status (unless `status` is given).
+ *  When `id` is OMITTED, the server reuses the existing step's id only when the step at the same
+ *  position has the same title (position+title carry-over); otherwise it mints a fresh UUID.
+ *  Either way a brand-new step defaults to "pending". */
 export interface BuildStepInput {
   id?: string;
   title: string;

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -823,9 +823,16 @@ export function validateBuildSteps(body: unknown): BuildStepInput[] | null {
   const o = body as Record<string, unknown>;
   if (!Array.isArray(o.steps) || o.steps.length > STEPS_MAX) return null;
   const out: BuildStepInput[] = [];
+  const seenIds = new Set<string>();
   for (const it of o.steps) {
     const step = validateBuildStepItem(it);
     if (step === null) return null;
+    // Explicit ids are stored verbatim and must be unique within a queue (the composite PK
+    // (sessionId, id) would otherwise throw on insert) — reject duplicates as an invalid body.
+    if (step.id !== undefined) {
+      if (seenIds.has(step.id)) return null;
+      seenIds.add(step.id);
+    }
     out.push(step);
   }
   return out;

--- a/test/build-queue-api.test.ts
+++ b/test/build-queue-api.test.ts
@@ -132,6 +132,48 @@ test("PUT queue with bad body → 400", async () => {
   expect(res.status).toBe(400);
 });
 
+test("PUT queue with duplicate explicit step ids → 400, queue unchanged", async () => {
+  const { app, store } = harness();
+  const session = makeSession(store, repoDir);
+  // seed a valid queue first
+  store.replaceBuildQueue(session.id, [{ id: "s1", title: "A" }]);
+
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${session.id}/queue`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        steps: [
+          { id: "dup", title: "A" },
+          { id: "dup", title: "B" },
+        ],
+      }),
+    }),
+  );
+  expect(res.status).toBe(400);
+  // the rejected PUT did not replace the existing queue
+  expect(store.getBuildQueue(session.id).steps.map((x) => x.id)).toEqual(["s1"]);
+});
+
+test("POST queue/steps resolves a short verbatim agent id by exact match", async () => {
+  const { app, store } = harness();
+  const session = makeSession(store, repoDir);
+  store.replaceBuildQueue(session.id, [
+    { id: "s1", title: "A" },
+    { id: "s2", title: "B" },
+  ]);
+
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${session.id}/queue/steps/s1`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ status: "active" }),
+    }),
+  );
+  expect(res.status).toBe(200);
+  expect(store.getBuildQueue(session.id).steps[0]!.status).toBe("active");
+});
+
 test("PUT queue with missing steps → 400", async () => {
   const { app, store } = harness();
   const session = makeSession(store, repoDir);
@@ -277,21 +319,13 @@ test("POST queue/steps with an ambiguous prefix → 409 with matches, no change"
   const session = makeSession(store, repoDir);
 
   // Seed two steps whose ids share an 8-char prefix so the posted prefix is ambiguous.
-  // This is a SYNTHETIC scenario: real step ids are fixed-length random UUIDs that can't
-  // collide on an 8-char prefix, and replaceBuildQueue discards explicit ids on a fresh
-  // session (store.ts), so we insert the rows directly to construct the collision.
-  const db = (store as unknown as { db: import("bun:sqlite").Database }).db;
-  const now = Date.now();
-  for (const [pos, id, title] of [
-    [0, "abcd1234-aaaa-4e41-88b0-c4f255337d81", "A"],
-    [1, "abcd1234-bbbb-4e41-88b0-c4f255337d81", "B"],
-  ] as const) {
-    db.run(
-      `INSERT INTO build_queue_steps (id, sessionId, position, title, detail, status, createdAt, updatedAt)
-       VALUES (?,?,?,?,?,?,?,?)`,
-      [id, session.id, pos, title, "", "pending", now, now],
-    );
-  }
+  // This is a SYNTHETIC scenario: server-generated ids are fixed-length random UUIDs that can't
+  // collide on an 8-char prefix. replaceBuildQueue now stores explicit ids VERBATIM (store.ts),
+  // so we just PUT the colliding ids directly rather than poking the DB.
+  store.replaceBuildQueue(session.id, [
+    { id: "abcd1234-aaaa-4e41-88b0-c4f255337d81", title: "A" },
+    { id: "abcd1234-bbbb-4e41-88b0-c4f255337d81", title: "B" },
+  ]);
 
   const res = await app.fetch(
     new Request(`http://x/api/sessions/${session.id}/queue/steps/abcd1234`, {

--- a/test/build-queue-store.test.ts
+++ b/test/build-queue-store.test.ts
@@ -1,4 +1,8 @@
 import { test, expect } from "bun:test";
+import { Database } from "bun:sqlite";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { SessionStore, resolveStepId, STEP_ID_PREFIX_MIN } from "../src/store";
 
 function mk() {
@@ -72,6 +76,120 @@ test("replaceBuildQueue: explicit input.status overrides the preserved status", 
   // re-replace with the same id but an explicit status — the explicit value wins
   const q2 = s.replaceBuildQueue(sess.id, [{ id: idA, title: "Step A", status: "active" }]);
   expect(q2.steps[0]!.status).toBe("active");
+});
+
+// ── identity model: verbatim client ids + position+title carry-over (#1014) ───
+
+test("replaceBuildQueue: an explicit client id is stored verbatim on a fresh session", () => {
+  const s = mk();
+  const sess = s.create(base);
+  const q = s.replaceBuildQueue(sess.id, [
+    { id: "s1", title: "Step A" },
+    { id: "s2", title: "Step B" },
+  ]);
+  expect(q.steps.map((x) => x.id)).toEqual(["s1", "s2"]);
+});
+
+test("replaceBuildQueue: client ids survive a re-PUT (verbatim), preserving status", () => {
+  const s = mk();
+  const sess = s.create(base);
+  s.replaceBuildQueue(sess.id, [
+    { id: "s1", title: "Step A" },
+    { id: "s2", title: "Step B" },
+  ]);
+  s.setBuildStepStatus(sess.id, "s1", "done");
+  // re-PUT reordered + an insert, all carrying their own ids
+  const q = s.replaceBuildQueue(sess.id, [
+    { id: "s2", title: "Step B" },
+    { id: "s3", title: "Step C (new)" },
+    { id: "s1", title: "Step A renamed" },
+  ]);
+  expect(q.steps.map((x) => x.id)).toEqual(["s2", "s3", "s1"]);
+  const s1 = q.steps.find((x) => x.id === "s1")!;
+  expect(s1.status).toBe("done"); // preserved across reorder + rename
+  expect(s1.title).toBe("Step A renamed");
+});
+
+test("carry-over: omitted id keeps the existing id when position AND title match", () => {
+  const s = mk();
+  const sess = s.create(base);
+  const q = s.replaceBuildQueue(sess.id, [{ title: "Step A" }, { title: "Step B" }]);
+  const idA = q.steps[0]!.id;
+  const idB = q.steps[1]!.id;
+  s.setBuildStepStatus(sess.id, idB, "done"); // B done (forward-fills A → done too)
+  // re-PUT WITHOUT ids, same order + titles, revising only the pending tail
+  const q2 = s.replaceBuildQueue(sess.id, [
+    { title: "Step A" },
+    { title: "Step B" },
+    { title: "Step C (new)" },
+  ]);
+  expect(q2.steps[0]!.id).toBe(idA); // carried over
+  expect(q2.steps[1]!.id).toBe(idB); // carried over
+  expect(q2.steps[0]!.status).toBe("done"); // status preserved with the id
+  expect(q2.steps[1]!.status).toBe("done");
+  expect(q2.steps[2]!.id).not.toBe(idA);
+  expect(q2.steps[2]!.id).not.toBe(idB);
+  expect(q2.steps[2]!.status).toBe("pending");
+});
+
+test("carry-over: a renamed step at the same position gets a fresh id (no mis-bind)", () => {
+  const s = mk();
+  const sess = s.create(base);
+  const q = s.replaceBuildQueue(sess.id, [{ title: "Step A" }]);
+  const idA = q.steps[0]!.id;
+  const q2 = s.replaceBuildQueue(sess.id, [{ title: "Step A — reworded" }]);
+  expect(q2.steps[0]!.id).not.toBe(idA); // title differs → no carry-over
+});
+
+test("carry-over: an insert shifting positions gives the shifted step a fresh id", () => {
+  const s = mk();
+  const sess = s.create(base);
+  const q = s.replaceBuildQueue(sess.id, [{ title: "Step A" }, { title: "Step B" }]);
+  const idA = q.steps[0]!.id;
+  const idB = q.steps[1]!.id;
+  // insert a new step at the front, omitting ids → positions shift
+  const q2 = s.replaceBuildQueue(sess.id, [
+    { title: "Step 0 (new)" },
+    { title: "Step A" },
+    { title: "Step B" },
+  ]);
+  // position 0 now has title "Step 0 (new)" — old idA was at pos 0 with title "Step A" → no match
+  expect(q2.steps[0]!.id).not.toBe(idA);
+  expect(q2.steps[1]!.id).not.toBe(idA); // pos 1 had title "Step B", now "Step A" → no match
+  expect(q2.steps[2]!.id).not.toBe(idB); // pos 2 had no existing step → fresh
+});
+
+test("carry-over: an omitted-id step never steals an id an explicit step claims this PUT", () => {
+  const s = mk();
+  const sess = s.create(base);
+  const q = s.replaceBuildQueue(sess.id, [{ title: "Step A" }, { title: "Step B" }]);
+  const idA = q.steps[0]!.id;
+  // Step B (omitted) sits at position 0 with the SAME title as old position-0 "Step A"? No —
+  // construct the clash: explicit step reclaims idA at position 1, while an omitted step at
+  // position 0 has title "Step A" (would otherwise carry over idA). reserved must win.
+  const q2 = s.replaceBuildQueue(sess.id, [
+    { title: "Step A" }, // omitted id, pos 0, title matches old pos-0 "Step A" → candidate idA
+    { id: idA, title: "Step A" }, // explicit reclaim of idA at pos 1
+  ]);
+  // idA is reserved by the explicit step → the omitted step must NOT carry it over.
+  expect(q2.steps[1]!.id).toBe(idA);
+  expect(q2.steps[0]!.id).not.toBe(idA);
+  // all ids unique
+  expect(new Set(q2.steps.map((x) => x.id)).size).toBe(2);
+});
+
+test("replaceBuildQueue: the same client id may exist in two different sessions (composite PK)", () => {
+  const s = mk();
+  const sess1 = s.create(base);
+  const sess2 = s.create({ ...base, herdrAgentId: "term_2" });
+  const q1 = s.replaceBuildQueue(sess1.id, [{ id: "s1", title: "A1" }]);
+  const q2 = s.replaceBuildQueue(sess2.id, [{ id: "s1", title: "A2" }]);
+  expect(q1.steps[0]!.id).toBe("s1");
+  expect(q2.steps[0]!.id).toBe("s1");
+  // independent rows: status on one does not leak to the other
+  s.setBuildStepStatus(sess1.id, "s1", "done");
+  expect(s.getBuildQueue(sess1.id).steps[0]!.status).toBe("done");
+  expect(s.getBuildQueue(sess2.id).steps[0]!.status).toBe("pending");
 });
 
 test("setBuildStepStatus: true on hit, false for unknown id, false for wrong sessionId", () => {
@@ -215,6 +333,15 @@ test("resolveStepId: exact match resolves to itself", () => {
   });
 });
 
+test("resolveStepId: a short agent id (< prefix-min) resolves by exact match", () => {
+  // verbatim agent ids like "s1" are below STEP_ID_PREFIX_MIN, so they never prefix-resolve —
+  // exact-first matching is load-bearing for them.
+  expect("s1".length).toBeLessThan(STEP_ID_PREFIX_MIN);
+  expect(resolveStepId(["s1", "s2"], "s1")).toEqual({ ok: true, id: "s1" });
+  // a short id that is NOT an exact member stays not-found (never prefix-resolves)
+  expect(resolveStepId(["s1", "s2"], "s")).toEqual({ ok: false, reason: "not-found" });
+});
+
 test("resolveStepId: exact match WINS over being a prefix of another id (defensive ordering)", () => {
   // Synthetic ids: "abcd1234" is both an exact id AND a prefix of "abcd1234ef". Exact wins.
   // Real fixed-length 36-char UUIDs can't construct this collision, so this guards implementation
@@ -356,4 +483,42 @@ test("pruneArchivedSessions removes build_queue_steps and build_queue_state for 
 
   // survivor's queue intact
   expect(s.getBuildQueue(keep.id).steps).toHaveLength(1);
+});
+
+test("migration: legacy global-PK build_queue_steps rebuilds to composite PK, preserving rows", () => {
+  const path = join(tmpdir(), `shepherd-bq-migrate-${process.pid}-${Date.now()}.db`);
+  rmSync(path, { force: true });
+  try {
+    // Seed the OLD schema: global `PRIMARY KEY (id)`, with one row.
+    const raw = new Database(path);
+    raw.run(`CREATE TABLE build_queue_steps (
+      id TEXT PRIMARY KEY, sessionId TEXT NOT NULL, position INTEGER NOT NULL,
+      title TEXT NOT NULL, detail TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL DEFAULT 'pending',
+      createdAt INTEGER NOT NULL, updatedAt INTEGER NOT NULL)`);
+    raw.run(
+      `INSERT INTO build_queue_steps (id, sessionId, position, title, detail, status, createdAt, updatedAt)
+       VALUES (?,?,?,?,?,?,?,?)`,
+      ["uuid-legacy-1", "sessLegacy", 0, "Legacy Step", "", "done", 1, 1],
+    );
+    raw.close();
+
+    // Opening a SessionStore runs migrateBuildQueueStepsPk() in the constructor.
+    const s = new SessionStore(path);
+    const db = (s as unknown as { db: Database }).db;
+    const cols = db.query(`PRAGMA table_info(build_queue_steps)`).all() as {
+      name: string;
+      pk: number;
+    }[];
+    // sessionId now participates in the (composite) primary key.
+    expect(cols.find((c) => c.name === "sessionId")!.pk).toBeGreaterThan(0);
+    // the legacy row survived the rebuild.
+    const q = s.getBuildQueue("sessLegacy");
+    expect(q.steps).toHaveLength(1);
+    expect(q.steps[0]!.id).toBe("uuid-legacy-1");
+    expect(q.steps[0]!.status).toBe("done");
+    db.close();
+  } finally {
+    rmSync(path, { force: true });
+  }
 });

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -2962,6 +2962,23 @@ test("buildQueueDirective states the ordered contract that forward-fill relies o
   expect(d).toMatch(/reminder to reconcile/);
 });
 
+test("buildQueueDirective makes assign-and-resend-your-own-ids the primary id rule", () => {
+  const d = buildQueueDirective({
+    sessionId: "sess-1",
+    baseUrl: "http://127.0.0.1:7330",
+    token: null,
+    autopilot: true,
+  });
+  // Primary instruction: agent owns short stable ids and resends them.
+  expect(d).toMatch(/short, stable `id`/);
+  expect(d).toMatch(/ALWAYS resend a step with the SAME `id`/);
+  expect(d).toContain('"id":"s1"');
+  // Verbatim-stored, never regenerated.
+  expect(d).toMatch(/stored verbatim and never regenerated/);
+  // re-GET is demoted to a fallback, not an equal option.
+  expect(d).toMatch(/Fallback only if you didn't/);
+});
+
 test("composeSystemPrompt places <build-queue> after <autopilot-directive>", () => {
   const sp = composeSystemPrompt(null, true, { buildQueue: "bq-text" });
   const autopilotPos = sp.indexOf("<autopilot-directive>");


### PR DESCRIPTION
Closes #1014. Follow-up to #1011 / PR #1013.

## Problem

#1013 made the status-POST resolve prefixes and return a loud 4xx, but one path stayed silent: a status POST carrying a **stale full UUID** (cached from a `PUT` that a later `PUT` regenerated) returns a `404` the agent discards (`curl -s … >/dev/null`), so the update no-ops invisibly agent-side.

**Root cause** (`store.ts`): `replaceBuildQueue` preserved an id only when `input.id` was present **and already matched** a stored id; otherwise it minted a fresh UUID — so agent-chosen ids were dropped on the first PUT and any omitted id on re-PUT regenerated.

## Approach — "Both" (operator-chosen identity model)

1. **Honor client-supplied ids verbatim.** A step posted with an `id` keeps it as-is (scoped per session), so an agent can own a stable id (`s1`, `s2`…) that survives reorder/insert/delete with no regeneration. A matched id still preserves its prior status/createdAt (explicit `status` still wins).
2. **Conservative position+title carry-over for an omitted id.** Reuse the existing step's id only when the step at the **same position has the same title** (both must agree). Never mis-binds; degrades to a fresh UUID on any insert/delete/rename/reorder.

### Blocking prerequisite — composite primary key
`build_queue_steps.id` was a **global** `TEXT PRIMARY KEY`, so directing every agent to `s1/s2` would cause cross-session PK collisions (500). Migrated the PK to composite `(sessionId, id)` via the updated `CREATE TABLE` plus a guarded one-time `migrateBuildQueueStepsPk()` rebuild (PRAGMA pk-detection, transactional; existing UUID ids migrate trivially). Every step query was already session-scoped, so it's a near-drop-in.

## Other changes
- **Dedup:** duplicate explicit ids rejected in `validateBuildSteps` → `400`.
- **Directive** (`buildQueueDirective`): "assign + resend your own stable ids" is now the **primary** rule; re-GET demoted to a last-resort fallback (the re-GET branch is what kept the cache-and-omit no-op alive).
- **`resolveStepId` docstring** corrected: exact-first matching is now **load-bearing** (a short agent id is below `STEP_ID_PREFIX_MIN` and resolves only by exact match). `BuildStepInput` doc updated.

## Known residual (documented, not closed)
An omitted-id step that is **renamed/inserted/reordered** still gets a fresh UUID, re-creating the stale-id 404 if the agent then posts a cached id. Full closure of that path depends on prong-1 (verbatim ids) + agent compliance (resend ids) — by design.

## Tests
- store: verbatim ids on a fresh session, verbatim survival across reorder+rename, position+title carry-over, no carry-over on rename / position-shift, reserved-id not stolen, same id in two sessions (composite PK), legacy-PK → composite migration preserving rows.
- api: duplicate-id `400` (queue unchanged), short verbatim id resolves by exact match, ambiguous-prefix test reworked to PUT verbatim ids.
- service: directive asserts resend-ids-primary guidance.

`bun run lint`, `bunx tsc --noEmit`, `bun test ./test` (4560 pass), and the fallow pre-push gate (dead code 0, complexity 0) all green.

[no-feature-entry] server-internal + agent-facing directive only; no user-facing UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)