### PR TITLE
feat(usage): show task short name in breakdown, not just its ID

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -825,6 +825,7 @@ export class SessionStore implements CapStore, CreditStore {
     this.db.run(`CREATE TABLE IF NOT EXISTS session_usage (
       sessionId      TEXT PRIMARY KEY,
       desig          TEXT NOT NULL,
+      name           TEXT NOT NULL DEFAULT '',
       repoPath       TEXT NOT NULL,
       model          TEXT NOT NULL,
       input          INTEGER NOT NULL,
@@ -855,6 +856,12 @@ export class SessionStore implements CapStore, CreditStore {
     this.db.run(
       `CREATE INDEX IF NOT EXISTS session_usage_bucket_start ON session_usage_bucket (bucketStart)`,
     );
+    // migrate session_usage rows that predate the human-readable name column (legacy rows
+    // default to '' — the usage UI falls back to showing the desig alone for those)
+    const usageCols = this.db.query(`PRAGMA table_info(session_usage)`).all() as { name: string }[];
+    if (!usageCols.some((c) => c.name === "name")) {
+      this.db.run(`ALTER TABLE session_usage ADD COLUMN name TEXT NOT NULL DEFAULT ''`);
+    }
   }
 
   // ── settings (key/value) ─────────────────────────────────────────────────
@@ -3674,11 +3681,12 @@ export class SessionStore implements CapStore, CreditStore {
   upsertSessionUsage(snap: SessionUsageSnapshot): void {
     this.db.run(
       `INSERT INTO session_usage
-         (sessionId, desig, repoPath, model, input, output, cacheRead, cacheWrite, total,
+         (sessionId, desig, name, repoPath, model, input, output, cacheRead, cacheWrite, total,
           weightedUnits, cacheReadUnits, messageCount, byModel, createdAt, archivedAt, snapshotAt)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
        ON CONFLICT(sessionId) DO UPDATE SET
          desig = excluded.desig,
+         name = excluded.name,
          repoPath = excluded.repoPath,
          model = excluded.model,
          input = excluded.input,
@@ -3696,6 +3704,7 @@ export class SessionStore implements CapStore, CreditStore {
       [
         snap.sessionId,
         snap.desig,
+        snap.name,
         snap.repoPath,
         snap.model,
         snap.input,

--- a/src/types.ts
+++ b/src/types.ts
@@ -611,6 +611,7 @@ export interface HeldTask {
 export interface SessionUsageRow {
   sessionId: string;
   desig: string;
+  name: string;
   repoPath: string;
   model: string;
   input: number;
@@ -631,6 +632,7 @@ export interface SessionUsageRow {
 export interface SessionUsageSnapshot {
   sessionId: string;
   desig: string;
+  name: string;
   repoPath: string;
   model: string;
   input: number;
@@ -684,6 +686,7 @@ export interface UsageTokens {
 export interface UsageTaskBreakdown {
   sessionId: string;
   desig: string;
+  name: string;
   model: string;
   authoringUnits: number;
   satelliteUnits: number;
@@ -730,6 +733,7 @@ export const USAGE_TOKENS_KEYS = ["input", "output", "cacheRead", "cacheWrite"] 
 export const USAGE_TASK_KEYS = [
   "sessionId",
   "desig",
+  "name",
   "model",
   "authoringUnits",
   "satelliteUnits",

--- a/src/usage-breakdown.ts
+++ b/src/usage-breakdown.ts
@@ -17,6 +17,7 @@ import { weightedUnits } from "./pricing";
 interface TaskAccum {
   sessionId: string;
   desig: string;
+  name: string;
   model: string;
   repoPath: string;
   authoringUnits: number;
@@ -40,6 +41,7 @@ function snapshotToAccum(snap: ReturnType<SessionStore["listSessionUsage"]>[numb
   return {
     sessionId: snap.sessionId,
     desig: snap.desig,
+    name: snap.name,
     model: snap.model,
     repoPath: snap.repoPath,
     authoringUnits: snap.weightedUnits,
@@ -64,6 +66,7 @@ function windowedSnapshotToAccum(
   return {
     sessionId: snap.sessionId,
     desig: snap.desig,
+    name: snap.name,
     model: snap.model,
     repoPath: snap.repoPath,
     authoringUnits: w.weightedUnits,
@@ -85,6 +88,7 @@ function zeroAuthoringAccum(snap: ReturnType<SessionStore["listSessionUsage"]>[n
   return {
     sessionId: snap.sessionId,
     desig: snap.desig,
+    name: snap.name,
     model: snap.model,
     repoPath: snap.repoPath,
     authoringUnits: 0,
@@ -115,6 +119,7 @@ async function liveSessionToAccum(
   return {
     sessionId: s.id,
     desig: s.desig,
+    name: s.name,
     model: dominantModel(sc.usage) ?? s.model ?? "unknown",
     repoPath: s.repoPath,
     authoringUnits: sc.weightedUnits,
@@ -241,6 +246,7 @@ function buildRepoBreakdowns(
     const publicTasks: UsageTaskBreakdown[] = tasks.map((t) => ({
       sessionId: t.sessionId,
       desig: t.desig,
+      name: t.name,
       model: t.model,
       authoringUnits: t.authoringUnits,
       satelliteUnits: t.satelliteUnits,
@@ -349,6 +355,7 @@ async function addLiveRollupTasks(
     taskMap.set(s.id, {
       sessionId: s.id,
       desig: s.desig,
+      name: s.name,
       model: w.dominantModel ?? s.model ?? "unknown",
       repoPath: s.repoPath,
       authoringUnits: w.weightedUnits,

--- a/src/usage-snapshot.ts
+++ b/src/usage-snapshot.ts
@@ -74,6 +74,7 @@ export async function snapshotSessionUsage(
     store.upsertSessionUsage({
       sessionId: s.id,
       desig: s.desig,
+      name: s.name,
       repoPath: s.repoPath,
       model,
       input: agg.input,

--- a/test/server-usage-breakdown.test.ts
+++ b/test/server-usage-breakdown.test.ts
@@ -38,6 +38,7 @@ function seedSnapshot(store: SessionStore, overrides: Partial<SessionUsageSnapsh
   const snap: SessionUsageSnapshot = {
     sessionId: "sess-usage-1",
     desig: "TASK-01",
+    name: "my-feature",
     repoPath: "/home/user/repos/my-project",
     model: "claude-sonnet-4",
     input: 1000,

--- a/test/store-session-usage.test.ts
+++ b/test/store-session-usage.test.ts
@@ -5,6 +5,7 @@ import type { SessionUsageBucket, SessionUsageSnapshot } from "../src/types";
 const snap = (over: Partial<SessionUsageSnapshot> = {}): SessionUsageSnapshot => ({
   sessionId: "sess-1",
   desig: "TASK-01",
+  name: "round-trip-fields",
   repoPath: "/repos/foo",
   model: "claude-sonnet-4-5",
   input: 1000,
@@ -30,6 +31,7 @@ test("session_usage: upsert then list round-trips all fields", () => {
   const r = rows[0]!;
   expect(r.sessionId).toBe("sess-1");
   expect(r.desig).toBe("TASK-01");
+  expect(r.name).toBe("round-trip-fields");
   expect(r.repoPath).toBe("/repos/foo");
   expect(r.model).toBe("claude-sonnet-4-5");
   expect(r.input).toBe(1000);

--- a/test/usage-backfill.test.ts
+++ b/test/usage-backfill.test.ts
@@ -134,6 +134,7 @@ test("skip existing: archived session with pre-existing usage row is NOT overwri
   store.upsertSessionUsage({
     sessionId: s!.id,
     desig: "TASK-SENTINEL",
+    name: "sentinel-name",
     repoPath: tmpDir,
     model: "sentinel-model",
     input: 9999,

--- a/test/usage-breakdown.test.ts
+++ b/test/usage-breakdown.test.ts
@@ -71,6 +71,7 @@ afterEach(() => {
 function makeSnap(over: {
   sessionId: string;
   desig: string;
+  name?: string;
   repoPath: string;
   model?: string;
   input: number;
@@ -90,6 +91,7 @@ function makeSnap(over: {
   return {
     sessionId: over.sessionId,
     desig: over.desig,
+    name: over.name ?? `name-${over.desig}`,
     repoPath: over.repoPath,
     model,
     input,
@@ -184,6 +186,7 @@ test("repo→task grouping, sorting, field mapping", async () => {
   // Task field mapping
   const t1 = alphaTasks[1]!; // TASK-01
   expect(t1.sessionId).toBe("s1");
+  expect(t1.name).toBe("name-TASK-01"); // short name threads snapshot → breakdown
   expect(t1.authoringUnits).toBeCloseTo(snapA1Wu, 10);
   expect(t1.satelliteUnits).toBe(0);
   expect(t1.tokens.input).toBe(1000);

--- a/test/usage-snapshot.test.ts
+++ b/test/usage-snapshot.test.ts
@@ -89,6 +89,7 @@ test("normal session → one row with correct fields", async () => {
   const session = makeSession({
     id: "sess-1",
     desig: "TASK-01",
+    name: "add-button",
     repoPath: "/repos/foo",
     worktreePath: "/repos/foo",
     claudeSessionId: "abc-123",
@@ -117,6 +118,7 @@ test("normal session → one row with correct fields", async () => {
   const r = rows[0]!;
   expect(r.sessionId).toBe("sess-1");
   expect(r.desig).toBe("TASK-01");
+  expect(r.name).toBe("add-button");
   expect(r.repoPath).toBe("/repos/foo");
   expect(r.model).toBe("claude-opus-4-8");
   expect(r.messageCount).toBe(2);

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1839,5 +1839,7 @@
   "hold_merge_rebasing": "Rebase im Merge-Train (Versuch {rebaseCount}).",
   "hold_ready_merge": "Bereit zum Mergen — wartet auf Sie.",
   "feat_why_parked_title": "Warum wartet diese Sitzung?",
-  "feat_why_parked_body": "Gehaltene, blockierte und von einem Gate aufgehaltene Sitzungen zeigen jetzt einen einzeiligen Grund auf der Karte und in der Triage-Schublade — damit du auf einen Blick siehst, warum eine Sitzung deine Aufmerksamkeit braucht."
+  "feat_why_parked_body": "Gehaltene, blockierte und von einem Gate aufgehaltene Sitzungen zeigen jetzt einen einzeiligen Grund auf der Karte und in der Triage-Schublade — damit du auf einen Blick siehst, warum eine Sitzung deine Aufmerksamkeit braucht.",
+  "feat_usage_task_names_title": "Aufgabennamen in der Nutzung",
+  "feat_usage_task_names_body": "Die Zeilen pro Aufgabe in den Ansichten Nutzung → Verbrauch und Overhead zeigen jetzt den Kurznamen jeder Aufgabe neben ihrer Kennung — damit du Aufgaben auf einen Blick auseinanderhältst, statt IDs lesen zu müssen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1839,5 +1839,7 @@
   "hold_merge_rebasing": "Rebasing in the merge train (attempt {rebaseCount}).",
   "hold_ready_merge": "Ready to merge — waiting on you.",
   "feat_why_parked_title": "Why is this parked?",
-  "feat_why_parked_body": "Held, blocked and gate-stuck sessions now show a one-line reason on the card and in the triage drawer — so you can see why a session needs you at a glance."
+  "feat_why_parked_body": "Held, blocked and gate-stuck sessions now show a one-line reason on the card and in the triage drawer — so you can see why a session needs you at a glance.",
+  "feat_usage_task_names_title": "Task names in Usage",
+  "feat_usage_task_names_body": "The per-task rows in the Usage → Spend and Overhead lenses now show each task's short name alongside its designation — so you can tell tasks apart at a glance instead of reading IDs."
 }

--- a/ui/src/lib/components/usage/OverheadLens.svelte
+++ b/ui/src/lib/components/usage/OverheadLens.svelte
@@ -101,7 +101,12 @@
         {#each topTaxTasks as task (task.sessionId)}
           {@const tax = taskTax(task)}
           <div class="tax-task-row">
-            <span class="tax-desig">{task.desig}</span>
+            <span class="tax-label">
+              <span class="tax-desig">{task.desig}</span>
+              {#if task.name}
+                <span class="tax-name" title={task.name}>{task.name}</span>
+              {/if}
+            </span>
             <span class="tax-bar">
               <UsageBar value={tax} max={maxTax} tone="var(--color-amber)" />
             </span>
@@ -223,16 +228,30 @@
 
   .tax-task-row {
     display: grid;
-    grid-template-columns: 6rem 1fr 4rem;
+    grid-template-columns: 11rem 1fr 4rem;
     align-items: center;
     gap: 0.5rem;
     padding: 0.25rem 0.5rem;
     font-size: var(--fs-meta);
   }
 
+  .tax-label {
+    display: flex;
+    align-items: baseline;
+    gap: 0.375rem;
+    min-width: 0;
+  }
+
   .tax-desig {
+    flex: none;
     color: var(--color-muted);
+    font-size: var(--fs-micro);
     font-variant-numeric: tabular-nums;
+  }
+
+  .tax-name {
+    min-width: 0;
+    color: var(--color-ink);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -301,7 +320,7 @@
       grid-template-areas: "desig pct" "bar bar";
       row-gap: 0.25rem;
     }
-    .tax-desig {
+    .tax-label {
       grid-area: desig;
     }
     .tax-pct {

--- a/ui/src/lib/components/usage/SpendLens.svelte
+++ b/ui/src/lib/components/usage/SpendLens.svelte
@@ -115,7 +115,12 @@
             {#each tasks as task (task.sessionId)}
               {@const tTotal = taskTotal(task)}
               <div class="task-row" class:has-cost={breakdown.dollars != null}>
-                <span class="task-desig">{task.desig}</span>
+                <span class="task-label">
+                  <span class="task-desig">{task.desig}</span>
+                  {#if task.name}
+                    <span class="task-name" title={task.name}>{task.name}</span>
+                  {/if}
+                </span>
                 <span class="task-bar">
                   <UsageBar value={tTotal} max={maxTask} tone="var(--color-slate)" />
                 </span>
@@ -258,7 +263,7 @@
 
   .task-row {
     display: grid;
-    grid-template-columns: 6rem 1fr 5rem;
+    grid-template-columns: 11rem 1fr 5rem;
     align-items: center;
     gap: 0.5rem;
     padding: 0.25rem 0.5rem;
@@ -266,12 +271,26 @@
   }
 
   .task-row.has-cost {
-    grid-template-columns: 6rem 1fr 5rem 4rem;
+    grid-template-columns: 11rem 1fr 5rem 4rem;
+  }
+
+  .task-label {
+    display: flex;
+    align-items: baseline;
+    gap: 0.375rem;
+    min-width: 0;
   }
 
   .task-desig {
+    flex: none;
     color: var(--color-muted);
+    font-size: var(--fs-micro);
     font-variant-numeric: tabular-nums;
+  }
+
+  .task-name {
+    min-width: 0;
+    color: var(--color-ink);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -344,7 +363,7 @@
       grid-template-columns: minmax(0, 1fr) auto auto;
       grid-template-areas: "desig units cost" "bar bar bar";
     }
-    .task-desig {
+    .task-label {
       grid-area: desig;
     }
     .task-units {

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1444,4 +1444,15 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_why_parked_title",
     bodyKey: "feat_why_parked_body",
   },
+  {
+    // Per-task rows in the Usage → Spend + Overhead lenses now show each task's
+    // human-readable short name (e.g. "add-auth-flow") with its designation as a muted
+    // tag, instead of the designation alone. No targetId — the task rows mount only when a
+    // repo group is expanded, so there is no persistently-mounted anchor for a coachmark;
+    // surface via the What's-New drawer only. v1.36.0 is the latest released tag → ships in 1.37.0.
+    id: "usage-task-names",
+    sinceVersion: "1.37.0",
+    titleKey: "feat_usage_task_names_title",
+    bodyKey: "feat_usage_task_names_body",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -794,6 +794,7 @@ export interface UsageTokens {
 export interface UsageTaskBreakdown {
   sessionId: string;
   desig: string; // e.g. "TASK-07" — data, never translated
+  name: string; // human-readable short name, e.g. "add-auth-flow"; "" for legacy rows — data, never translated
   model: string; // dominant model id, e.g. "claude-opus-4-8"
   authoringUnits: number; // weighted units, main agent
   satelliteUnits: number; // weighted units, reviewer/critic/etc spawns

--- a/ui/src/lib/usage-mock.ts
+++ b/ui/src/lib/usage-mock.ts
@@ -36,6 +36,7 @@ const shepherdTasks24h: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-001",
     desig: "TASK-07",
+    name: "add-auth-flow",
     model: "claude-opus-4-8",
     authoringUnits: 84_000,
     satelliteUnits: 18_000,
@@ -45,6 +46,7 @@ const shepherdTasks24h: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-002",
     desig: "TASK-12",
+    name: "fix-toast-dedupe",
     model: "claude-opus-4-8",
     authoringUnits: 72_000,
     satelliteUnits: 14_500,
@@ -54,6 +56,7 @@ const shepherdTasks24h: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-003",
     desig: "TASK-15",
+    name: "usage-task-names",
     model: "claude-opus-4-8",
     authoringUnits: 61_000,
     satelliteUnits: 12_000,
@@ -63,6 +66,7 @@ const shepherdTasks24h: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-004",
     desig: "TASK-18",
+    name: "refactor-store",
     model: "claude-sonnet-4-5",
     authoringUnits: 28_000,
     satelliteUnits: 6_000,
@@ -72,6 +76,7 @@ const shepherdTasks24h: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-005",
     desig: "TASK-21",
+    name: "plan-gate-restart",
     model: "claude-opus-4-8",
     authoringUnits: 22_000,
     satelliteUnits: 4_500,
@@ -81,6 +86,7 @@ const shepherdTasks24h: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-006",
     desig: "TASK-24",
+    name: "merge-train-marker",
     model: "claude-opus-4-8",
     authoringUnits: 17_000,
     satelliteUnits: 3_500,
@@ -90,6 +96,7 @@ const shepherdTasks24h: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-007",
     desig: "TASK-27",
+    name: "egress-allowlist",
     model: "claude-sonnet-4-5",
     authoringUnits: 11_000,
     satelliteUnits: 2_200,
@@ -106,6 +113,7 @@ const webappTasks24h: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-008",
     desig: "TASK-03",
+    name: "glossary-popover",
     model: "claude-opus-4-8",
     authoringUnits: 76_000,
     satelliteUnits: 15_000,
@@ -115,6 +123,7 @@ const webappTasks24h: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-009",
     desig: "TASK-04",
+    name: "doc-agent-pr",
     model: "claude-sonnet-4-5",
     authoringUnits: 60_000,
     satelliteUnits: 12_200,
@@ -130,6 +139,7 @@ const infraTasks24h: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-010",
     desig: "TASK-01",
+    name: "readiness-tab",
     model: "claude-sonnet-4-5",
     authoringUnits: 38_000,
     satelliteUnits: 8_000,
@@ -149,6 +159,7 @@ const shepherdTasks7d: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-101",
     desig: "TASK-30",
+    name: "epic-integration",
     model: "claude-opus-4-8",
     authoringUnits: 95_000,
     satelliteUnits: 19_000,
@@ -158,6 +169,7 @@ const shepherdTasks7d: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-102",
     desig: "TASK-33",
+    name: "critic-effort",
     model: "claude-opus-4-8",
     authoringUnits: 78_000,
     satelliteUnits: 16_000,
@@ -174,6 +186,7 @@ const webappTasks7d: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-110",
     desig: "TASK-05",
+    name: "preview-serve",
     model: "claude-opus-4-8",
     authoringUnits: 88_000,
     satelliteUnits: 17_500,
@@ -189,6 +202,7 @@ const infraTasks7d: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-120",
     desig: "TASK-02",
+    name: "tmpfs-guard",
     model: "claude-sonnet-4-5",
     authoringUnits: 42_000,
     satelliteUnits: 8_500,
@@ -208,6 +222,7 @@ const shepherdTasks30d: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-201",
     desig: "TASK-36",
+    name: "feature-catalog-gate",
     model: "claude-opus-4-8",
     authoringUnits: 110_000,
     satelliteUnits: 22_000,
@@ -217,6 +232,7 @@ const shepherdTasks30d: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-202",
     desig: "TASK-39",
+    name: "learnings-decay",
     model: "claude-opus-4-8",
     authoringUnits: 92_000,
     satelliteUnits: 18_500,
@@ -226,6 +242,7 @@ const shepherdTasks30d: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-203",
     desig: "TASK-42",
+    name: "rundown-digest",
     model: "claude-sonnet-4-5",
     authoringUnits: 45_000,
     satelliteUnits: 9_000,
@@ -241,6 +258,7 @@ const webappTasks30d: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-210",
     desig: "TASK-06",
+    name: "api-key-auth",
     model: "claude-opus-4-8",
     authoringUnits: 98_000,
     satelliteUnits: 19_600,
@@ -250,6 +268,7 @@ const webappTasks30d: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-211",
     desig: "TASK-07",
+    name: "backlog-badges",
     model: "claude-opus-4-8",
     authoringUnits: 75_000,
     satelliteUnits: 15_000,
@@ -265,6 +284,7 @@ const infraTasks30d: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-220",
     desig: "TASK-03",
+    name: "union-merge-driver",
     model: "claude-haiku-4-5",
     authoringUnits: 18_000,
     satelliteUnits: 3_600,
@@ -279,6 +299,7 @@ const docsTasks30d: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-230",
     desig: "TASK-01",
+    name: "recap-done-lens",
     model: "claude-sonnet-4-5",
     authoringUnits: 32_000,
     satelliteUnits: 6_400,
@@ -298,6 +319,7 @@ const shepherdTasksAll: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-301",
     desig: "TASK-45",
+    name: "onboarding-harness",
     model: "claude-opus-4-8",
     authoringUnits: 130_000,
     satelliteUnits: 26_000,
@@ -307,6 +329,7 @@ const shepherdTasksAll: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-302",
     desig: "TASK-48",
+    name: "installer-fix",
     model: "claude-opus-4-8",
     authoringUnits: 115_000,
     satelliteUnits: 23_000,
@@ -316,6 +339,7 @@ const shepherdTasksAll: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-303",
     desig: "TASK-51",
+    name: "i18n-parity",
     model: "claude-sonnet-4-5",
     authoringUnits: 58_000,
     satelliteUnits: 11_600,
@@ -331,6 +355,7 @@ const webappTasksAll: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-310",
     desig: "TASK-08",
+    name: "fable-guard",
     model: "claude-opus-4-8",
     authoringUnits: 108_000,
     satelliteUnits: 21_600,
@@ -346,6 +371,7 @@ const infraTasksAll: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-320",
     desig: "TASK-04",
+    name: "spend-lens",
     model: "claude-sonnet-4-5",
     authoringUnits: 55_000,
     satelliteUnits: 11_000,
@@ -361,6 +387,7 @@ const docsTasksAll: UsageTaskBreakdown[] = [
   task({
     sessionId: "s-330",
     desig: "TASK-02",
+    name: "overhead-lens",
     model: "claude-haiku-4-5",
     authoringUnits: 14_000,
     satelliteUnits: 2_800,


### PR DESCRIPTION
## What

Per-task rows in the **Usage → Spend** and **Overhead** lenses now show each task's human-readable short name (`session.name`, e.g. `add-auth-flow`) as the primary label, with the designation (`TASK-NN`) kept as a small muted tag. Previously these rows showed only the designation.

Display treatment chosen with the operator: **name primary, ID tag**.

## How

The short name was being dropped at snapshot time — the `session_usage` table only ever stored `desig`, so `name` never reached the breakdown. This threads `name` end-to-end along the exact path `desig` already travels:

`Session.name` → `session_usage.name` (new column + additive migration) → `TaskAccum` → `UsageTaskBreakdown` → the Spend/Overhead lenses.

`name` is persisted in the snapshot (not looked up live) because the snapshot row outlives the `sessions` row once the prune sweep deletes it — the snapshot is the only durable carrier past prune.

## Notes

- **Legacy archived sessions stay ID-only (by design).** The one-shot backfill (`backfill:session_usage_v1`) is already `done` on existing installs, so previously-archived rows keep `name=''` and fall back to ID-only in the UI. Only sessions archived *after* this change get a stored name. Re-running the backfill would re-scan every historical transcript and is out of scope.
- `desig`/`name` are data passed verbatim — exempt from i18n. The only new strings are the What's-New catalog entry's title/body (added EN+DE).
- Added What's-New entry `usage-task-names` (`sinceVersion: 1.37.0`, matching the current unreleased catalog entries).
- Added `"name"` to the `USAGE_TASK_KEYS` runtime drift sentinel so the `exactKeys` shape assertion stays in sync.

## Verification

- Root: `bun run lint` ✓, `bunx tsc --noEmit` ✓, `bun test ./test` → 4548 pass / 0 fail
- UI: `bun run check` → 0 errors, `bun run check:i18n` → 2 locales in parity, `bun run test` → 1949 pass
- Gates: branch-hygiene ✓, feature-catalog ✓, glossary ✓, fallow audit ✓ (no new issues)
- Added a flow-through assertion (snapshot → breakdown carries `name`) and a round-trip assertion (`session_usage` persists `name`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)