### PR TITLE
fix(top-bar): center count in compact held-tasks badge

### DIFF
--- a/ui/src/lib/components/top-bar/TopBarHeldBadge.svelte
+++ b/ui/src/lib/components/top-bar/TopBarHeldBadge.svelte
@@ -129,6 +129,15 @@
   .held-badge:hover {
     background: color-mix(in srgb, var(--color-amber) 10%, transparent);
   }
+  /* Compact (mobile / measured-overflow) variant: a single-digit count in a
+     square box. Mirror .needsyou.compact (TopBar.svelte) so the digit centers —
+     base .held-badge only centers vertically, and its letter-spacing trails the
+     lone glyph leftward. */
+  .held-badge.compact {
+    justify-content: center;
+    min-width: 44px;
+    letter-spacing: 0;
+  }
   .held-badge .held-n {
     font-weight: 600;
     font-variant-numeric: tabular-nums;


### PR DESCRIPTION
## Problem
In the top bar, the held-tasks badge in compact/touch mode renders the held count as a single digit inside a 44×44px box. The digit was vertically centered but pinned to the **left** of the box — not horizontally centered.

## Cause
`.held-badge` had **no `.compact` rule**. In compact mode it inherited only the base style (`display:inline-flex; align-items:center` → vertical centering only) plus the coarse-pointer `min-width:44px`. With no `justify-content:center`, the lone digit sat at flex-start; the base `letter-spacing:0.06em` trailed it further left.

## Fix
Add a scoped `.held-badge.compact` rule mirroring the established sibling recipe `.needsyou.compact` (`TopBar.svelte`):

```css
.held-badge.compact {
  justify-content: center;
  min-width: 44px;
  letter-spacing: 0;
}
```

CSS-only, scoped to the compact variant — the full label badge is untouched.

## Verification
- `cd ui && bun run check` → 0 errors, 0 warnings.
- Fix is a direct copy of the proven, in-use `.needsyou.compact` centering recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)