### PR TITLE
fix(held): refresh session list when a held task is spawned

### DIFF
--- a/src/held-release.ts
+++ b/src/held-release.ts
@@ -7,12 +7,12 @@
  * the operator no longer wants the gate — release everything).
  */
 import type { SessionStore } from "./store";
-import type { CreateSessionInput } from "./types";
+import type { CreateSessionInput, Session } from "./types";
 import type { UsageLimits } from "./usage-limits";
 
 export interface HeldReleaseDeps {
   store: Pick<SessionStore, "listHeldTasks" | "removeHeldTask" | "countHeldTasks">;
-  service: { create(input: CreateSessionInput): Promise<unknown> };
+  service: { create(input: CreateSessionInput): Promise<Session> };
   usageLimits: { limits(now: number): UsageLimits };
   events: { emit(event: string, data: unknown): void };
 }
@@ -41,7 +41,10 @@ export async function releaseHeldTasks(
   for (const task of tasks) {
     if (released >= maxPerTick) break;
     try {
-      await deps.service.create(task.input);
+      const s = await deps.service.create(task.input);
+      // service.create does not emit session:new — emit it so the released session
+      // appears in the Herd live; the held:changed badge update follows below.
+      deps.events.emit("session:new", s);
       deps.store.removeHeldTask(task.id);
       released++;
     } catch (err) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -3158,6 +3158,9 @@ async function heldSpawn(id: string, deps: AppDeps): Promise<Response> {
     return createErrorResponse(e);
   }
   deps.store.removeHeldTask(h.id);
+  // service.create does not emit session:new (see finalizeRelaunch) — emit it here so the
+  // new session appears in the Herd live, then decrement the held badge.
+  deps.events.emit("session:new", s);
   deps.events.emit("held:changed", { count: deps.store.countHeldTasks() });
   return json(s, 201);
 }

--- a/test/held-release.test.ts
+++ b/test/held-release.test.ts
@@ -1,7 +1,11 @@
 import { test, expect } from "bun:test";
 import { releaseHeldTasks, type HeldReleaseDeps } from "../src/held-release";
-import type { CreateSessionInput } from "../src/types";
+import type { CreateSessionInput, Session } from "../src/types";
 import type { UsageLimits } from "../src/usage-limits";
+
+// Minimal Session stub — these tests only ever read `.id` off the created session
+// (it's the session:new payload), so a full literal would be noise.
+const fakeSession = (id: string) => ({ id }) as unknown as Session;
 
 function makeInput(prompt: string): CreateSessionInput {
   return {
@@ -16,7 +20,7 @@ function makeInput(prompt: string): CreateSessionInput {
 function makeDeps(
   tasks: { id: string; input: CreateSessionInput }[],
   limits: Partial<UsageLimits> = {},
-  createFn?: (input: CreateSessionInput) => Promise<unknown>,
+  createFn?: (input: CreateSessionInput) => Promise<Session>,
 ): HeldReleaseDeps & {
   emitted: { event: string; data: unknown }[];
   creates: CreateSessionInput[];
@@ -45,10 +49,10 @@ function makeDeps(
       countHeldTasks: () => rows.length,
     },
     service: {
-      async create(input: CreateSessionInput): Promise<unknown> {
+      async create(input: CreateSessionInput): Promise<Session> {
         if (createFn) return createFn(input);
         creates.push(input);
-        return { id: "fake-session" };
+        return fakeSession("fake-session");
       },
     },
     usageLimits: { limits: () => defaultLimits },
@@ -85,7 +89,7 @@ test("usage low + 3 held → releases all 3 FIFO", async () => {
     { session5h: { pct: 30, resetAt: 0 }, week: null },
     async (input) => {
       creates.push(input);
-      return { id: "fake" };
+      return fakeSession("fake");
     },
   );
 
@@ -97,6 +101,8 @@ test("usage low + 3 held → releases all 3 FIFO", async () => {
   expect(creates[2]!.prompt).toBe("task 3");
   expect(deps.store.countHeldTasks()).toBe(0);
   expect(deps.emitted.some((e) => e.event === "held:changed")).toBe(true);
+  // each released task surfaces in the Herd via session:new (one per release)
+  expect(deps.emitted.filter((e) => e.event === "session:new")).toHaveLength(3);
 });
 
 test("5 held, maxPerTick=2 → only 2 released, 3 remain", async () => {
@@ -128,7 +134,7 @@ test("service.create throws on 2nd → 1 released, loop stops, rows intact", asy
   const deps = makeDeps(tasks, { session5h: { pct: 20, resetAt: 0 }, week: null }, async () => {
     callCount++;
     if (callCount === 2) throw new Error("spawn failed");
-    return { id: "fake" };
+    return fakeSession("fake");
   });
 
   const result = await releaseHeldTasks(deps, { enabled: true, holdPct: 80 }, Date.now(), 10);

--- a/test/hold-gate.test.ts
+++ b/test/hold-gate.test.ts
@@ -273,6 +273,10 @@ test("POST /api/held/:id/spawn → calls service.create, removes row, returns 20
   expect((creates[0] as typeof input).prompt).toBe("task to spawn");
   expect(store.countHeldTasks()).toBe(0);
   expect(emitted.some((e) => e.event === "held:changed")).toBe(true);
+  // the spawned session must surface in the Herd live via session:new (the bug: it didn't)
+  const spawned = emitted.find((e) => e.event === "session:new");
+  expect(spawned).toBeDefined();
+  expect((spawned!.data as { id: string }).id).toBe((await res.json()).id);
 });
 
 test("POST /api/held/:id/spawn with unknown id → 404", async () => {


### PR DESCRIPTION
## Problem

Spawning a held task didn't refresh the session list — the new session stayed invisible in the Herd until a manual page reload / WS reconnect.

## Root cause

The UI never adds a session locally on spawn; it populates the Herd **solely** from the server's `session:new` WebSocket event (`store.svelte.ts`, dedup-guarded by `byId`). `service.create()` deliberately does **not** emit `session:new` — the calling route handler must (documented at `server.ts:2058`; done correctly in `handleSessionCreate` and `finalizeRelaunch`).

Both held-task spawn paths created the session but emitted only `held:changed`, never `session:new`:

| Path | Trigger |
|------|---------|
| `heldSpawn` (`src/server.ts`) | manual "Spawn now" in the held-tasks popover |
| `releaseHeldTasks` (`src/held-release.ts`) | the 30s auto-release sweeper once usage drops |

Both produce the identical symptom, so both are fixed.

## Fix (server-only)

Emit `session:new` with the created session in both paths, matching the existing convention. The UI needs no change. Also tightened `HeldReleaseDeps.service.create` from `Promise<unknown>` to `Promise<Session>` so the per-release emit is typed (test fake updated in the same change).

## Tests

- `test/hold-gate.test.ts` — `POST /api/held/:id/spawn` now asserts a `session:new` carrying the created session's id.
- `test/held-release.test.ts` — asserts one `session:new` per released task.
- Full root suite: 4560 pass / 0 fail; lint + `tsc --noEmit` clean.

## Out of scope (flagged)

`handleSessionCreate`/`finalizeRelaunch` also re-stamp the drain claim (`claimLinkedIssue`) when the input has an `issueRef`; the held paths don't. That's a separate issue-claim-labeling concern, not session-list refresh — left for a follow-up. `[no-feature-entry]` (bug fix, no new user-facing capability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)