### PR TITLE
fix(held): re-stamp drain claim when a held task with a linked issue spawns

### DIFF
--- a/src/held-release.ts
+++ b/src/held-release.ts
@@ -6,6 +6,8 @@
  * regardless of current usage (they were held while enabled; disabled means
  * the operator no longer wants the gate — release everything).
  */
+import type { GitForge } from "./forge/types";
+import { claimLinkedIssue } from "./server";
 import type { SessionStore } from "./store";
 import type { CreateSessionInput, Session } from "./types";
 import type { UsageLimits } from "./usage-limits";
@@ -15,6 +17,8 @@ export interface HeldReleaseDeps {
   service: { create(input: CreateSessionInput): Promise<Session> };
   usageLimits: { limits(now: number): UsageLimits };
   events: { emit(event: string, data: unknown): void };
+  /** Resolve the forge for a repo so a released task's linked issue can be re-claimed. */
+  resolveForge?: (repoDir: string) => GitForge | null;
 }
 
 /**
@@ -47,6 +51,18 @@ export async function releaseHeldTasks(
       deps.events.emit("session:new", s);
       deps.store.removeHeldTask(task.id);
       released++;
+      // A human linked an issue before the task was held: stamp the drain claim now that it's
+      // spawning, matching handleSessionCreate/heldSpawn — so the board reflects it's being
+      // worked and the drain won't double-spawn it. Deferred (macrotask) + best-effort:
+      // addIssueLabel shells out synchronously, so setTimeout(0) keeps it off this sweep tick.
+      const issueRef = task.input.issueRef;
+      if (issueRef) {
+        const { repoPath } = task.input;
+        setTimeout(
+          () => void claimLinkedIssue(deps.resolveForge?.(repoPath) ?? null, issueRef.number),
+          0,
+        );
+      }
     } catch (err) {
       console.warn("[held] spawn failed for task", task.id, err);
       // Head-of-line blocking: a task whose service.create throws (e.g. repo deleted

--- a/src/index.ts
+++ b/src/index.ts
@@ -1342,7 +1342,7 @@ setInterval(async () => {
   releasingHeld = true;
   try {
     await releaseHeldTasks(
-      { store, service, usageLimits, events },
+      { store, service, usageLimits, events, resolveForge },
       { enabled: config.usageHoldEnabled, holdPct: config.usageHoldPct },
       Date.now(),
     );

--- a/src/server.ts
+++ b/src/server.ts
@@ -3162,6 +3162,17 @@ async function heldSpawn(id: string, deps: AppDeps): Promise<Response> {
   // new session appears in the Herd live, then decrement the held badge.
   deps.events.emit("session:new", s);
   deps.events.emit("held:changed", { count: deps.store.countHeldTasks() });
+  // A human linked an issue before the task was held: stamp the drain claim now that it's
+  // spawning, matching handleSessionCreate — so the board reflects it's being worked and the
+  // drain won't double-spawn it. Deferred (macrotask) + best-effort: addIssueLabel shells out
+  // synchronously, so setTimeout(0) lets json(s, 201) flush first.
+  if (h.input.issueRef) {
+    const { repoPath, issueRef } = h.input;
+    setTimeout(
+      () => void claimLinkedIssue(deps.resolveForge?.(repoPath) ?? null, issueRef.number),
+      0,
+    );
+  }
   return json(s, 201);
 }
 

--- a/test/held-release.test.ts
+++ b/test/held-release.test.ts
@@ -7,13 +7,16 @@ import type { UsageLimits } from "../src/usage-limits";
 // (it's the session:new payload), so a full literal would be noise.
 const fakeSession = (id: string) => ({ id }) as unknown as Session;
 
-function makeInput(prompt: string): CreateSessionInput {
+function makeInput(prompt: string, issueNumber?: number): CreateSessionInput {
   return {
     repoPath: "/tmp/repo",
     baseBranch: "main",
     prompt,
     model: null,
     images: [],
+    ...(issueNumber
+      ? { issueRef: { number: issueNumber, url: "http://x/i", title: "t", body: "" } }
+      : {}),
   };
 }
 
@@ -24,10 +27,12 @@ function makeDeps(
 ): HeldReleaseDeps & {
   emitted: { event: string; data: unknown }[];
   creates: CreateSessionInput[];
+  labeled: number[];
 } {
   const rows = tasks.map((t, i) => ({ ...t, repoPath: "/tmp/repo", createdAt: i + 1 }));
   const emitted: { event: string; data: unknown }[] = [];
   const creates: CreateSessionInput[] = [];
+  const labeled: number[] = [];
 
   const defaultLimits: UsageLimits = {
     session5h: null,
@@ -57,10 +62,20 @@ function makeDeps(
     },
     usageLimits: { limits: () => defaultLimits },
     events: { emit: (event: string, data: unknown) => emitted.push({ event, data }) },
+    resolveForge: () =>
+      ({
+        async addIssueLabel(n: number) {
+          labeled.push(n);
+        },
+      }) as unknown as import("../src/forge/types").GitForge,
     emitted,
     creates,
+    labeled,
   };
 }
+
+// Flush the setTimeout(0) macrotask the claim-stamp is deferred onto.
+const flush = () => new Promise((r) => setTimeout(r, 0));
 
 // ── held-release tests ────────────────────────────────────────────────────────
 
@@ -159,4 +174,20 @@ test("disabled + tasks present → releases them (below-threshold behavior)", as
   const result = await releaseHeldTasks(deps, { enabled: false, holdPct: 80 }, Date.now(), 10);
   expect(result.released).toBe(2);
   expect(deps.store.countHeldTasks()).toBe(0);
+});
+
+test("released task with linked issue → re-stamps the drain claim", async () => {
+  const deps = makeDeps(
+    [
+      { id: "t1", input: makeInput("linked", 42) },
+      { id: "t2", input: makeInput("unlinked") },
+    ],
+    { session5h: { pct: 20, resetAt: 0 }, week: null },
+  );
+
+  const result = await releaseHeldTasks(deps, { enabled: true, holdPct: 80 }, Date.now(), 10);
+  await flush();
+  expect(result.released).toBe(2);
+  // only the issue-linked task stamps ACTIVE_LABEL (one claim, for #42)
+  expect(deps.labeled).toEqual([42]);
 });

--- a/test/hold-gate.test.ts
+++ b/test/hold-gate.test.ts
@@ -38,10 +38,12 @@ function harness(limitsOverride?: Partial<UsageLimits>): {
   store: SessionStore;
   emitted: { event: string; data: unknown }[];
   creates: unknown[];
+  labeled: number[];
 } {
   const store = new SessionStore(":memory:");
   const emitted: { event: string; data: unknown }[] = [];
   const creates: unknown[] = [];
+  const labeled: number[] = [];
 
   const hub = new EventHub();
   hub.subscribe((event, data) => emitted.push({ event, data }));
@@ -73,8 +75,14 @@ function harness(limitsOverride?: Partial<UsageLimits>): {
     service: fakeService as any,
     events: hub,
     usageLimits: { limits: () => defaultLimits } as any,
+    resolveForge: () =>
+      ({
+        async addIssueLabel(n: number) {
+          labeled.push(n);
+        },
+      }) as any,
   };
-  return { app: makeApp(deps), store, emitted, creates };
+  return { app: makeApp(deps), store, emitted, creates, labeled };
 }
 
 function postSession(app: ReturnType<typeof makeApp>, extra?: Record<string, unknown>) {
@@ -277,6 +285,30 @@ test("POST /api/held/:id/spawn → calls service.create, removes row, returns 20
   const spawned = emitted.find((e) => e.event === "session:new");
   expect(spawned).toBeDefined();
   expect((spawned!.data as { id: string }).id).toBe((await res.json()).id);
+});
+
+test("POST /api/held/:id/spawn with linked issue → re-stamps the drain claim", async () => {
+  const { app, store, labeled } = harness();
+
+  store.addHeldTask({
+    id: "held-1",
+    repoPath: repoDir,
+    input: {
+      repoPath: repoDir,
+      baseBranch: "main",
+      prompt: "linked task",
+      model: null,
+      images: [],
+      issueRef: { number: 99, url: "http://x/i/99", title: "t", body: "" },
+    },
+    createdAt: 1000,
+  });
+
+  const res = await app.fetch(new Request("http://x/api/held/held-1/spawn", { method: "POST" }));
+  expect(res.status).toBe(201);
+  // claim stamp is deferred onto setTimeout(0) — flush the macrotask before asserting
+  await new Promise((r) => setTimeout(r, 0));
+  expect(labeled).toEqual([99]);
 });
 
 test("POST /api/held/:id/spawn with unknown id → 404", async () => {


### PR DESCRIPTION
## Problem

Follow-up to #1018 (flagged there as out of scope).

`handleSessionCreate` and `finalizeRelaunch` stamp the drain claim (`ACTIVE_LABEL` on the linked issue, via `claimLinkedIssue`) when a human-linked session is created — so the board reflects the issue is being worked and the drain won't double-spawn it. The two held-task spawn paths created the session but **never** re-stamped the claim:

| Path | Trigger |
|------|---------|
| `heldSpawn` (`src/server.ts`) | manual "Spawn now" in the held-tasks popover |
| `releaseHeldTasks` (`src/held-release.ts`) | the 30s auto-release sweeper once usage drops |

So a task carrying a `issueRef` that got held (because usage was high) and later spawned left its linked issue unclaimed — the board didn't show it as in-progress, and the drain could double-spawn it.

## Fix (server-only)

Both paths now call `claimLinkedIssue` when the held input has an `issueRef`, deferred via `setTimeout(0)` and best-effort — matching the create/relaunch convention exactly (`addIssueLabel` shells out synchronously, so the defer keeps it off the response tick / sweep tick).

- `heldSpawn`: stamp after the `session:new` + `held:changed` emits, reusing the `deps.resolveForge` it already has.
- `releaseHeldTasks`: gains an optional `resolveForge` dep on `HeldReleaseDeps`, wired from `src/index.ts`; stamps per released task inside the loop. Reuses the canonical `claimLinkedIssue` helper rather than reimplementing it.

UI needs no change.

## Tests

- `test/hold-gate.test.ts` — `POST /api/held/:id/spawn` with a linked issue stamps `ACTIVE_LABEL` for that issue number.
- `test/held-release.test.ts` — a released task with a linked issue stamps exactly one claim (for the linked number); an unlinked sibling stamps nothing.
- Full root suite: 4562 pass / 0 fail; lint + `tsc --noEmit` clean; fallow pre-push gate clean.

`[no-feature-entry]` — bug fix, no new user-facing capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)