### PR TITLE
fix(held): re-sync held count on tab-return so badge isn't stale after deploy

### DIFF
--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -467,9 +467,10 @@
   // can't gate on store.connected.
   //
   // The held-tasks badge counts off `store.heldCount`, seeded once in onMount and
-  // otherwise kept live by delta-only `held:changed` events. A restart/deploy that
-  // auto-releases held tasks (usage reset) emits those events while the socket is
-  // down, so the badge sits stale until reload — unless resync() re-pulls the count.
+  // otherwise kept live by `held:changed` events (each carries an absolute count).
+  // Those events are push-on-change only — there's no snapshot on reconnect — so a
+  // restart/deploy that auto-releases held tasks (usage reset) emits them while the
+  // socket is down, leaving the badge stale until reload unless resync() re-pulls it.
   function refreshHeldCount() {
     listHeld()
       .then((arr) => (store.heldCount = arr.length))

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -465,7 +465,19 @@
   // comes back so launching from a notification or unlocking shows current state
   // without one. Always fires — a half-open socket can read as connected, so we
   // can't gate on store.connected.
+  //
+  // The held-tasks badge counts off `store.heldCount`, seeded once in onMount and
+  // otherwise kept live by delta-only `held:changed` events. A restart/deploy that
+  // auto-releases held tasks (usage reset) emits those events while the socket is
+  // down, so the badge sits stale until reload — unless resync() re-pulls the count.
+  function refreshHeldCount() {
+    listHeld()
+      .then((arr) => (store.heldCount = arr.length))
+      .catch(() => {});
+  }
+
   function resync() {
+    refreshHeldCount();
     listSessions()
       .then((list) => store.setAll(list))
       .catch(() => {});
@@ -1125,9 +1137,7 @@
     recaps.load();
     herdDigest.load();
     learnings.load().then(() => (learningsLoaded = true));
-    listHeld()
-      .then((arr) => (store.heldCount = arr.length))
-      .catch(() => {});
+    refreshHeldCount();
     loadSettings();
     // Feature-discovery gate — synchronous, independent of loadSettings().
     // hydrate() reads localStorage; version + featureAnnouncements are compile-time constants.


### PR DESCRIPTION
## Problem

After held tasks **auto-release** (usage reset during a server restart/deploy), the amber **"N held"** badge in the top bar stays stale until a hard page reload.

Confirmed repro (operator flow):
1. Shepherd open with N held tasks (usage high).
2. Switch to terminal → merge PR → `bun run update` (deploy). Usage has reset; on restart the sweeper auto-releases the held tasks and emits `held:changed` **while the client socket is down**.
3. Switch back to the Shepherd tab → the badge still shows the stale N.
4. Only a hard reload corrects it.

## Root cause

The `/events` WS stream is delta-only. `store.heldCount` is seeded **once** in `onMount` via `listHeld()` and otherwise kept live by `held:changed` events. On tab-return the page runs `resync()` (`visibilitychange`/`pageshow`) to re-pull REST state — sessions, usage, git, activity, holds, backlog, build-queues, reviews, plan-gates, recaps — but it **omitted `listHeld()`**. So a `held:changed` emitted while the socket was down is never reconciled, and the badge sits stale until a reload re-runs the `onMount` seed.

That `resync()` already refreshes the *rest* of the UI on tab-return confirms it fires — the defect was purely the missing held-count re-pull.

> Investigated and ruled out: `EventHub.emit` lacking a per-listener guard. Bun's `ws.send` returns `-1/0/bytes` and does **not** throw on a dead/backpressured socket, so a stale socket can't starve other listeners. The server/UI held-count contract is otherwise complete.

## Fix

Extract a small `refreshHeldCount()` helper (`listHeld()` → `store.heldCount`) and call it from **both** the `onMount` bootstrap and `resync()`. Re-syncs the badge in both directions (released → decrement/hide; held during downtime → increment/appear) on every tab-return. One file, no server change.

Follow-up to #1018.

## Scope note

Deliberately **not** also triggering `resync()` on WS *reconnect* for a desktop tab that stays visible through a deploy (and never fires `visibilitychange`). That's a broader gap across all delta-only state; the confirmed repro returns focus to the tab, so the existing `visibilitychange`-driven `resync()` covers it. Possible follow-up.

## Verification

- `cd ui && bun run check` (svelte-check + tsc): **0 errors, 0 warnings**
- `bun run check:i18n`: parity OK (no new strings — it's a `fix`, no feature-catalog entry)
- `prettier --check`: clean; pre-push gate suite green
- A full badge-change repro requires an active usage-hold condition (held tasks present); not reproduced against live prod. The change mirrors the proven `onMount` seed on the same `resync()` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)