### PR TITLE
fix(epic): kick drain on Start so first sub-issue session surfaces live

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -4224,6 +4224,22 @@ async function handleEpicGet({ req, parts, url, deps }: Ctx): Promise<Response |
   return json(epic);
 }
 
+// Kick the drain immediately on epic Start so the first sub-issue session spawns
+// at once and surfaces live in the (push-only) Herd via doSpawn's session:new
+// emit — without this it only appears on the next ~30s sweep. Fire-and-forget,
+// DELIBERATELY unlike approve-next which `await`s tick(): the EpicPanel discards
+// the PUT response and gets session:new + epic:update over the WS, so awaiting
+// tick() (which pumps ALL repos with forge I/O) would only add Start latency with
+// no payoff. The .catch keeps a throwing/slow tick from turning Start into a
+// 500 — the periodic sweep remains the safety net.
+function kickDrainOnEpicStart(
+  drain: NonNullable<AppDeps["drain"]>,
+  status: EpicRun["status"],
+): void {
+  if (status !== "running") return;
+  void drain.tick().catch((err) => console.warn("[epic] start tick:", err));
+}
+
 // PUT /api/epic?repo=&parent= — patch the EpicRun settings, re-assemble, emit.
 async function handleEpicPut({ req, parts, url, deps }: Ctx): Promise<Response | null> {
   if (!(req.method === "PUT" && parts[0] === "api" && parts[1] === "epic" && !parts[2]))
@@ -4250,6 +4266,7 @@ async function handleEpicPut({ req, parts, url, deps }: Ctx): Promise<Response |
     ...(patch.status !== undefined ? { status: patch.status } : {}),
   };
   deps.store.setEpicRun(merged);
+  kickDrainOnEpicStart(deps.drain, merged.status);
   const epic = await deps.drain.buildEpic(dir, merged);
   if (epic) deps.events?.emit("epic:update", epic);
   return json(epic ?? { ok: true });

--- a/test/epic-server.test.ts
+++ b/test/epic-server.test.ts
@@ -217,6 +217,71 @@ describe("PUT /api/epic", () => {
     expect(emitted.length).toBe(1);
     expect((emitted[0] as Epic).run.status).toBe("running");
   });
+
+  test("{status:'running'} kicks drain.tick() (first sub-issue spawns at once)", async () => {
+    let tickCalled = false;
+    const { app } = harness({
+      drainOverrides: {
+        tick: async () => {
+          tickCalled = true;
+        },
+      },
+    });
+    const res = await app.fetch(
+      new Request(`http://x/api/epic?repo=${encRepo(repoDir)}&parent=327`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ status: "running" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(tickCalled).toBe(true);
+  });
+
+  test("non-running status does not kick drain.tick()", async () => {
+    // seed a running run so the patch transitions OUT of running
+    let tickCalled = false;
+    const { app, store } = harness({
+      drainOverrides: {
+        tick: async () => {
+          tickCalled = true;
+        },
+      },
+    });
+    store.setEpicRun({
+      repoPath: repoDir,
+      parentIssueNumber: 327,
+      mode: "auto",
+      status: "running",
+    });
+    const res = await app.fetch(
+      new Request(`http://x/api/epic?repo=${encRepo(repoDir)}&parent=327`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ status: "idle" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(tickCalled).toBe(false);
+  });
+
+  test("{status:'running'} with a throwing drain.tick() still returns 200 (kick is best-effort)", async () => {
+    const { app } = harness({
+      drainOverrides: {
+        tick: async () => {
+          throw new Error("tick boom");
+        },
+      },
+    });
+    const res = await app.fetch(
+      new Request(`http://x/api/epic?repo=${encRepo(repoDir)}&parent=327`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ status: "running" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
 });
 
 // ── GET /api/epic ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Starting an epic from the backlog (EpicPanel **Start** → `PUT /api/epic` with `status:"running"`) kicks off a session for the first sub-issue, but the Herd session list doesn't refresh — the session stays invisible until a manual page reload.

This is the same class of bug as the recent held-task fix (#1018): the Herd is **push-only**, populated solely from the `session:new` WS event (`ui/src/lib/store.svelte.ts`). The drain's spawn path (`doSpawn`, `src/drain.ts:1305`) already emits `session:new` correctly, so the gap here is **timing**, not a missing emit:

- `POST /api/epic/approve-next` calls `deps.drain.tick()` after approving, so the spawn fires at once.
- `PUT /api/epic` (Start) persisted the run but **never ticked** the drain, so the first sub-issue session only spawned on the next periodic ~30s sweep (`src/index.ts:1063`) — reading as "nothing happened, refresh needed."

## Fix

`handleEpicPut` now kicks `drain.tick()` on the transition into `running`, so the first session spawns immediately and surfaces live via the existing emit.

**Deliberately fire-and-forget, NOT awaited** — unlike `approve-next`, which `await`s an uncaught `tick()`. Flagged here and in the code comment per house rules:

- **No payoff in awaiting.** EpicPanel discards the PUT response (`EpicPanel.svelte:77`) and receives `session:new` + `epic:update` over the WS. `tick()` pumps **all** repos with forge I/O, so awaiting it would only add Start latency with no benefit to the returned payload.
- **Robustness.** The kick is `void drain.tick().catch(...)`, so a throwing/slow tick can never turn Start into a 500; the periodic sweep stays the safety net.

Extracted into a small `kickDrainOnEpicStart` helper to keep `handleEpicPut` under the fallow cognitive-complexity gate.

### Attended mode
Start sets `status:"running"` regardless of mode, so the kick fires for attended epics too — but the drain's approval gate holds the first spawn until `approve-next`. The tick pumps without spawning (no-op spawn-wise); the "harmless" claim rests on that gate.

## Tests
`test/epic-server.test.ts`:
- `{status:"running"}` kicks `drain.tick()`.
- A non-running status (`idle`) does **not** kick `tick()`.
- `{status:"running"}` with a throwing `tick()` still returns **200** (best-effort kick).

The unit tests cover only the kick wiring (`FakeDrain.tick` is a no-op); end-to-end live-surfacing relies on the `tick→pump→doSpawn→emitSessionNew` chain already exercised by the drain/approve-next + held-task suites, plus a manual check.

Server-only plumbing — no UI/i18n/feature-catalog/glossary changes. `[no-feature-entry]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)