### PR TITLE
fix(forge): re-probe negative forge resolution after TTL (#1023)

### DIFF
--- a/src/backlog-poller.ts
+++ b/src/backlog-poller.ts
@@ -38,8 +38,11 @@ export class BacklogPoller {
   private isForgeBacked(path: string): boolean {
     // Not forge-backed: no forge, or a local forge (no remote issues/PRs to count).
     // Computed per tick with no local cache so a repoMode flip propagates without a
-    // restart; the underlying `git remote get-url` shell-out is memoized upstream in
-    // the production `resolveForge` (makeForgeResolver), so this stays cheap.
+    // restart. The underlying `git remote get-url` shell-out is memoized upstream in
+    // the production `resolveForge` (makeForgeResolver): a detected forge is cached for
+    // the process lifetime, and a negative (no-origin) result is re-probed only after a
+    // TTL (< this poll cadence) — so an `origin` added later is picked up on the next
+    // tick (#1023) while the per-tick cost stays at most a handful of cheap shell-outs.
     const forge = this.resolveForge(path);
     return forge != null && forge.kind !== "local";
   }

--- a/src/backlog.ts
+++ b/src/backlog.ts
@@ -3,8 +3,9 @@ import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { parseRemote } from "./forge/remote";
 import { detectForge } from "./forge";
+import { makeForgeMemo } from "./forge/resolve";
 import { classifyPr } from "./forge/pr-kind";
-import type { ForgeMap } from "./forge/types";
+import type { ForgeMap, GitForge } from "./forge/types";
 
 /** Default-branch CI rollup state, or null when unknown / no CI / non-GitHub. */
 export type CiStatus = "success" | "failure" | "pending" | null;
@@ -125,8 +126,10 @@ function mapRollupState(state: string | undefined | null): CiStatus {
 }
 
 export class CountsService {
-  /** Resolved forge per repoPath, null = not a supported forge. Immutable once set. */
-  private readonly forgeCache = new Map<string, ReturnType<typeof detectForge>>();
+  /** Forge resolver: positives cached for the process lifetime, negatives (e.g. a repo
+   *  whose `origin` is added later) re-probed after a TTL so they self-heal without a
+   *  restart (#1023). Built in the ctor so `now`/TTL can be injected for tests. */
+  private readonly resolveForgeCached: (repoPath: string) => GitForge | null;
   /** TTL read-through cache: repoPath → {at, value}. */
   private readonly cache = new Map<string, CacheEntry>();
   /** Single-flight: repoPath → in-flight Promise. */
@@ -142,8 +145,11 @@ export class CountsService {
     /** Optional: when provided, lightweight repos are treated as not-forge-backed.
      *  Read per call so a runtime repoMode toggle propagates without a restart. */
     private readonly getRepoConfig?: (repoPath: string) => { repoMode: string },
+    /** Optional clock-seam injection for the negative-forge re-probe TTL (tests only). */
+    forgeMemoOpts?: { negativeTtlMs?: number; now?: () => number },
   ) {
     this.gate = new Semaphore(maxConcurrency);
+    this.resolveForgeCached = makeForgeMemo((dir) => detectForge(dir, this.forges), forgeMemoOpts);
   }
 
   /**
@@ -202,11 +208,8 @@ export class CountsService {
     return promise;
   }
 
-  private resolveForge(repoPath: string): ReturnType<typeof detectForge> {
-    if (!this.forgeCache.has(repoPath)) {
-      this.forgeCache.set(repoPath, detectForge(repoPath, this.forges));
-    }
-    return this.forgeCache.get(repoPath)!;
+  private resolveForge(repoPath: string): GitForge | null {
+    return this.resolveForgeCached(repoPath);
   }
 
   private async fetch(repoPath: string): Promise<RepoCounts> {

--- a/src/backlog.ts
+++ b/src/backlog.ts
@@ -208,16 +208,12 @@ export class CountsService {
     return promise;
   }
 
-  private resolveForge(repoPath: string): GitForge | null {
-    return this.resolveForgeCached(repoPath);
-  }
-
   private async fetch(repoPath: string): Promise<RepoCounts> {
     // Lightweight repos have no remote forge — skip counts regardless of origin URL.
     // Read repoMode per call so a runtime toggle propagates without a restart.
     if (this.getRepoConfig?.(repoPath)?.repoMode === "lightweight") return NULL_COUNTS;
 
-    const forge = this.resolveForge(repoPath);
+    const forge = this.resolveForgeCached(repoPath);
     if (!forge) return NULL_COUNTS;
 
     if (forge.kind === "github") {

--- a/src/forge/resolve.ts
+++ b/src/forge/resolve.ts
@@ -16,6 +16,56 @@ export interface ForgeResolverDeps {
   makeLocalForge: (dir: string) => LocalForge;
 }
 
+/** Default window before a negative (null) forge result is re-probed. */
+const DEFAULT_NEGATIVE_TTL_MS = 30_000;
+
+/**
+ * Memoize `detect(dir)` with **asymmetric** caching:
+ *  - **Positive** results (a real forge) are cached for the process lifetime — a
+ *    detected forge identity never changes for a given dir, and the `git` shell-out
+ *    is expensive, so once per path is enough.
+ *  - **Negative** results (null — e.g. a repo seen before its `origin` remote was
+ *    added) are cached only for `negativeTtlMs`, then re-probed. This is the #1023
+ *    fix: a permanent negative cache left a later `git remote add origin` invisible
+ *    until a process restart. We do NOT re-probe on literally every miss (that would
+ *    add a recurring synchronous git shell-out to poll paths like
+ *    `backlog-poller.isForgeBacked`, which runs the resolver for every repo each
+ *    tick); the TTL bounds re-probes to at most once per window per dir while still
+ *    self-healing on the next poll after a remote appears.
+ *
+ * `now` is injectable purely so tests can drive the TTL deterministically.
+ *
+ * Note: positive caching is intentionally permanent — a dir that *later* gains a
+ * differing-slug `upstream` remote (the fork topology `detectForge` re-targets to)
+ * will not re-target without a restart. Pre-existing behavior, out of scope for #1023.
+ */
+export function makeForgeMemo(
+  detect: (dir: string) => GitForge | null,
+  opts: { negativeTtlMs?: number; now?: () => number } = {},
+): (dir: string) => GitForge | null {
+  const positive = new Map<string, GitForge>();
+  const negativeAt = new Map<string, number>();
+  const ttl = opts.negativeTtlMs ?? DEFAULT_NEGATIVE_TTL_MS;
+  const now = opts.now ?? Date.now;
+
+  return (dir: string): GitForge | null => {
+    const hit = positive.get(dir);
+    if (hit) return hit;
+
+    const at = negativeAt.get(dir);
+    if (at !== undefined && now() - at < ttl) return null;
+
+    const f = detect(dir);
+    if (f) {
+      positive.set(dir, f);
+      negativeAt.delete(dir);
+      return f;
+    }
+    negativeAt.set(dir, now());
+    return null;
+  };
+}
+
 /**
  * Build the mode-aware `resolveForge` closure used in src/index.ts.
  *
@@ -28,12 +78,12 @@ export interface ForgeResolverDeps {
  *  - `localForgeCache`: reuse the LocalForge instance across calls while the
  *    repo stays in lightweight mode. If the mode flips to "forge", the local
  *    entry is simply skipped; if it flips back, the same instance is reused.
- *  - `forgeCache`: the existing detectForge memoization (git shell-out is
- *    expensive — once per path is enough for forge repos).
+ *  - `forgeMemo`: detectForge memoization — positives cached for the process
+ *    lifetime, negatives re-probed after a TTL (see `makeForgeMemo`).
  */
 export function makeForgeResolver(deps: ForgeResolverDeps): (dir: string) => GitForge | null {
   const localForgeCache = new Map<string, LocalForge>();
-  const forgeCache = new Map<string, GitForge | null>();
+  const forgeMemo = makeForgeMemo(deps.detectForge);
 
   return (dir: string): GitForge | null => {
     const { repoMode } = deps.getRepoConfig(dir);
@@ -47,11 +97,8 @@ export function makeForgeResolver(deps: ForgeResolverDeps): (dir: string) => Git
       return local;
     }
 
-    // forge mode — memoized detectForge
-    if (!forgeCache.has(dir)) {
-      forgeCache.set(dir, deps.detectForge(dir));
-    }
-    return forgeCache.get(dir) ?? null;
+    // forge mode — memoized detectForge (positives permanent, negatives TTL-bounded)
+    return forgeMemo(dir);
   };
 }
 

--- a/test/backlog.test.ts
+++ b/test/backlog.test.ts
@@ -553,3 +553,40 @@ test("CountsService: repoMode toggle propagates — flip lightweight→forge tri
   expect(r2.openIssues).toBe(7);
   expect(runnerCalled).toBe(1);
 });
+
+// 11. #1023: a forge dir seen before its `origin` was added re-resolves without a
+// restart — the negative forge result is re-probed once the injected TTL elapses.
+test("CountsService: null forge re-resolves after origin is added past the TTL (#1023)", async () => {
+  const repoDir = join(tmpBase, "late-origin");
+  mkdirSync(repoDir, { recursive: true });
+  spawnSync("git", ["init", "-q"], { cwd: repoDir }); // no `origin` yet
+  const forges: ForgeMap = {};
+
+  let forgeClock = 1_000;
+  const graphqlResponse = JSON.stringify({
+    data: { repository: { issues: { totalCount: 12 }, pullRequests: { totalCount: 2 } } },
+  });
+  const { run, calls } = fakeRunner(graphqlResponse);
+  const svc = new CountsService(forges, run, fetch, undefined, undefined, {
+    negativeTtlMs: 30_000,
+    now: () => forgeClock,
+  });
+
+  // 1) No origin → no forge → null counts.
+  const before = await svc.refresh(repoDir);
+  expect(before.openIssues).toBeNull();
+
+  // 2) Add origin, but stay inside the negative-TTL window → still treated as no forge.
+  spawnSync("git", ["remote", "add", "origin", "https://github.com/o/late"], { cwd: repoDir });
+  forgeClock = 1_000 + 29_999;
+  const within = await svc.refresh(repoDir);
+  expect(within.openIssues).toBeNull();
+  expect(calls.filter((c) => c.includes("graphql")).length).toBe(0); // not re-probed yet
+
+  // 3) TTL elapses → forge re-probed → GitHub detected → real counts, no restart.
+  forgeClock = 1_000 + 30_000;
+  const after = await svc.refresh(repoDir);
+  expect(after.openIssues).toBe(12);
+  expect(after.openPRs).toBe(2);
+  expect(calls.filter((c) => c.includes("graphql")).length).toBe(1);
+});

--- a/test/forge-resolve.test.ts
+++ b/test/forge-resolve.test.ts
@@ -4,7 +4,7 @@
  * All deps are stubs — no git I/O, no real store.
  */
 import { test, expect } from "bun:test";
-import { makeForgeResolver } from "../src/forge/resolve";
+import { makeForgeResolver, makeForgeMemo } from "../src/forge/resolve";
 import type { LocalForge } from "../src/forge/local";
 import type { GitForge } from "../src/forge/types";
 
@@ -122,6 +122,60 @@ test("toggle: flipping repoMode forge→lightweight propagates immediately", () 
   // flip to lightweight → now returns LocalForge
   mode = "lightweight";
   expect(resolver("/repo/f")?.kind).toBe("local");
+});
+
+// ── makeForgeMemo: negative-TTL re-probe (#1023) ────────────────────────────────
+
+test("makeForgeMemo: positive result is cached for the process lifetime (one detect)", () => {
+  let detectCount = 0;
+  const gh = stubGithubForge();
+  const memo = makeForgeMemo(() => {
+    detectCount++;
+    return gh;
+  });
+
+  expect(memo("/repo/a")).toBe(gh);
+  expect(memo("/repo/a")).toBe(gh);
+  expect(memo("/repo/a")).toBe(gh);
+  expect(detectCount).toBe(1);
+});
+
+test("makeForgeMemo: a negative result is NOT re-probed within the TTL window", () => {
+  let detectCount = 0;
+  let clock = 1_000;
+  const memo = makeForgeMemo(
+    () => {
+      detectCount++;
+      return null;
+    },
+    { negativeTtlMs: 30_000, now: () => clock },
+  );
+
+  expect(memo("/repo/x")).toBeNull(); // first miss → one detect, caches negative @1000
+  clock = 1_000 + 29_999; // still inside the window
+  expect(memo("/repo/x")).toBeNull();
+  expect(detectCount).toBe(1); // not re-probed
+});
+
+test("makeForgeMemo: a negative result is re-probed (and heals) once the TTL elapses", () => {
+  let detectCount = 0;
+  let clock = 1_000;
+  const gh = stubGithubForge();
+  // Simulate `git remote add origin` after the second probe: detect flips null → forge.
+  const memo = makeForgeMemo(
+    () => {
+      detectCount++;
+      return detectCount >= 2 ? gh : null;
+    },
+    { negativeTtlMs: 30_000, now: () => clock },
+  );
+
+  expect(memo("/repo/y")).toBeNull(); // probe #1 → null, caches negative @1000
+  clock = 1_000 + 30_000; // TTL elapsed
+  expect(memo("/repo/y")).toBe(gh); // probe #2 → forge, now cached positive
+  clock = 1_000 + 100_000; // far in the future
+  expect(memo("/repo/y")).toBe(gh); // served from positive cache, no further detect
+  expect(detectCount).toBe(2);
 });
 
 test("two dirs are independent", () => {


### PR DESCRIPTION
## Problem

Closes #1023. A repo Shepherd sees **before it has an `origin` remote** (dir tracked while still non-git, or before `git remote add origin`) was permanently treated as having **no GitHub upstream** until the core process was restarted — adding the remote and pushing afterward didn't fix it.

`detectForge` returns `null` when `origin` is absent, and two independent memos cached that negative `null` for the life of the process with no TTL or invalidation:

- `makeForgeResolver.forgeCache` (`src/forge/resolve.ts`) — built once at boot, injected everywhere.
- `CountsService.forgeCache` (`src/backlog.ts`) — same shape, also never invalidated.

Positive results are always correct and never need busting — only the negative-cache case bites.

## Fix

One **shared `makeForgeMemo` helper** (so the two caches can't drift) with **asymmetric** caching:

- **Positive** results (a real forge) → cached for the process lifetime (a detected identity doesn't change; the git shell-out is expensive).
- **Negative** results (`null`) → cached only for a **TTL, then re-probed**, so a later `git remote add origin` self-heals **without a restart**.

Both `makeForgeResolver` (forge-mode path) and `CountsService.resolveForge` now route through it.

## Why a TTL, not re-probe-on-every-miss (deviation from the issue's literal proposal)

The issue proposed re-probing on *every* cached miss. But `backlog-poller.isForgeBacked` runs the resolver for **every repo on every 45s tick**, and `detectForge` is a **synchronous** `execFileSync` git shell-out — a documented house rule forbids adding recurring sync git I/O to poll paths (the single Bun event loop freezes the web terminal).

In practice the negative path fires only for **forge-mode dirs lacking `origin`** (lightweight dirs → cached `LocalForge`; forge dirs with origin → cached positive), i.e. typically **0–2 dirs**, so even pure re-probe is small. The TTL is bounded insurance: it collapses any within-window burst of callers into one shell-out without abandoning near-tick heal.

**TTL = 30s (below the 45s poll cadence)** so a newly-added remote is picked up on the poller's **next tick** — worst-case heal ≈ one poll cadence (~45s), not the ~90s a 60s TTL would force by making the 45s poller skip alternate ticks. `now`/`negativeTtlMs` are injectable purely for deterministic tests.

The stale `backlog-poller.ts` comment that relied on permanent negative memoization is updated in the same change.

## Known limitation (pre-existing, out of scope)

Positive caching stays permanent, so a dir that *later* gains a differing-slug `upstream` remote (the fork topology `detectForge` re-targets to) won't re-target without a restart. This predates this PR and is out of scope for #1023, which is strictly the was-null → remote-added-later case.

## Tests

- `test/forge-resolve.test.ts`: positive cached permanently (one detect); negative **not** re-probed within the TTL window; negative re-probed and healed once the TTL elapses (with injected clock).
- `test/backlog.test.ts`: `CountsService` with a no-`origin` repo returns null counts, stays null within the TTL window after `origin` is added, then re-resolves to real GitHub counts once the TTL elapses — no restart.

Root `bun run lint`, `bunx tsc --noEmit`, and full `bun test ./test` (4566 pass / 0 fail) all green.

[no-feature-entry] — server-side bug fix, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
