### PR TITLE
fix(recap): make expanded recap scrollable instead of clipping

### DIFF
--- a/ui/src/lib/components/SessionRecap.svelte
+++ b/ui/src/lib/components/SessionRecap.svelte
@@ -159,6 +159,23 @@
     border-bottom: 1px solid var(--color-line);
   }
 
+  /* Full (non-inline) recap sits at the bottom of the Viewport flex column
+     (.viewport is overflow:hidden). Without min-height:0 the flex item can't
+     shrink below its expanded content, so a long recap overflows and gets
+     clipped with no scroll. min-height:0 lets it shrink within the column;
+     overflow-y:auto makes it the scroll container. Explicit --color-inset
+     background because the `panel` class has no global rule — the card is
+     otherwise transparent over .viewport's --color-inset. */
+  .recap-card:not(.inline) {
+    min-height: 0;
+    overflow-y: auto;
+    background: var(--color-inset);
+    /* Top padding moves onto the sticky header below — a scroll container's
+       content scrolls *into* the top padding, so any padding-top here would let
+       body content peek above the pinned header. The header carries it instead. */
+    padding-top: 0;
+  }
+
   .recap-card.inline {
     border: none;
     padding: 0;
@@ -209,6 +226,24 @@
 
   .recap-header:hover .recap-headline {
     text-decoration: underline;
+  }
+
+  /* Keep the collapse toggle reachable while the body scrolls. Scoped to the
+     non-inline path — the inline static header reuses `.recap-header`
+     (recap-header-static) and must stay non-sticky/transparent. Opaque
+     --color-inset (matching the card) hides scrolled body content beneath it
+     and makes the card's top-padding strip seamless with the header. */
+  .recap-card:not(.inline) .recap-header {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--color-inset);
+    /* carries the card's former top padding so the opaque header reaches the
+       card's top edge (no gap for scrolled content to peek through); the
+       bottom padding is an opaque buffer between the pinned header and the
+       body content scrolling beneath it. */
+    padding-top: 6px;
+    padding-bottom: 6px;
   }
 
   .recap-verdict-chip {

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2768,6 +2768,11 @@
     position: relative;
     flex: 1;
     overflow: hidden;
+    /* Floor so an expanded, scrollable SessionRecap (a sibling flex item that
+       can shrink to its content) can't squeeze the body to 0px — a sliver of
+       terminal/diff/todo/preview always remains. Only bites under the
+       expanded-recap takeover; normal body content is far taller. */
+    min-height: 4rem;
   }
 
   /* faint amber scan line: full-height layer with a 70px amber band at its top,


### PR DESCRIPTION
## Problem

The expanded session recap (the `SessionRecap` strip at the bottom of the Viewport) clipped its content with no way to scroll — the tail (open items, **Regenerate**) was unreachable (see report screenshot, `DECISION`-style section cut off).

**Root cause:** the full (non-inline) `.recap-card` had no `min-height` and no `overflow`. As a flex item in `.viewport` (`overflow: hidden`), its default `min-height: auto` prevented it shrinking below its expanded content, so the body overflowed the column and was clipped — there was no scroll container.

## Fix (CSS only, 2 files)

- **`SessionRecap.svelte`** — `.recap-card:not(.inline)` becomes its own scroll container (`min-height: 0` + `overflow-y: auto`) with an explicit `--color-inset` background (the `panel` class has no global rule). The header (`.recap-card:not(.inline) .recap-header`) is `position: sticky; top: 0` with a matching opaque background so the collapse toggle stays pinned while the body scrolls. The card's top padding is moved onto the (opaque) header so scrolled content can't peek above the pinned header.
- **`Viewport.svelte`** — a `min-height` floor on `.vp-body` so an expanded recap can't squeeze the terminal/diff/todo/preview body to `0px`; a sliver always remains and the recap takes the rest.

Scoped via `:not(.inline)` so the Activity-tab inline recap and the Herd done/parked inline recaps (which already scroll in their own contexts) are untouched.

## Verification

- `cd ui && bun run check` — 0 errors. `SessionRecap` + `Viewport` tests pass (19/19); full UI suite green (1949).
- Browser-verified against live (vite proxy) on a real long recap (TASK-438, 8 blocks / `scrollHeight 2708`):
  - **Term tab:** recap scrolls internally, header pinned, tail reachable, no content peek above the header, terminal sliver preserved.
  - **Diff tab** (no SteerBar): recap takes over the available space and scrolls; diff body floored to a sliver (not `0px`).

`fix`, not `feat` → no feature-catalog / i18n / glossary changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)