### PR TITLE
feat(automation): confirm automation settings on first task for a new repo (#1025)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -751,7 +751,7 @@ async function parseRepoConfigPatch(req: Request): Promise<
     return json(
       {
         error:
-          "body must set at least one of: criticEnabled, autoAddressEnabled, learningsEnabled, autopilotEnabled, autoDrainEnabled, autoMergeEnabled, buildQueueEnabled, draftMode, autoOptimizeFlagged, signoffAuthority, sandboxProfile, defaultModel, egressExtraHosts, maxAuto, autoLabel, usageCeilingPct, repoMode",
+          "body must set at least one of: criticEnabled, autoAddressEnabled, learningsEnabled, autopilotEnabled, autoDrainEnabled, autoMergeEnabled, buildQueueEnabled, draftMode, autoOptimizeFlagged, signoffAuthority, sandboxProfile, defaultModel, egressExtraHosts, maxAuto, autoLabel, usageCeilingPct, repoMode, automationConfirmed",
       },
       400,
     );

--- a/src/server.ts
+++ b/src/server.ts
@@ -785,7 +785,10 @@ async function parseRepoConfigPatch(req: Request): Promise<
  *  field overrides and absent fields keep the current value. */
 function mergeRepoConfig(
   cur: RepoConfig,
-  patch: Exclude<Awaited<ReturnType<typeof parseRepoConfigPatch>>, Response>,
+  patch: Omit<
+    Exclude<Awaited<ReturnType<typeof parseRepoConfigPatch>>, Response>,
+    "automationConfirmed"
+  >,
 ): RepoConfig {
   const out: RepoConfig = { ...cur };
   const writable = out as unknown as Record<string, unknown>;
@@ -812,6 +815,7 @@ async function handleRepoConfig({ req, parts, url, deps }: Ctx): Promise<Respons
 
   const patch = await parseRepoConfigPatch(req);
   if (patch instanceof Response) return patch;
+  // Load-bearing destructure: keeps the metadata flag off the RepoConfig written by mergeRepoConfig.
   const { automationConfirmed, ...cfgPatch } = patch;
   const merged = mergeRepoConfig(deps.store.getRepoConfig(dir), cfgPatch);
   if (merged.draftMode && merged.autoMergeEnabled) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -631,6 +631,7 @@ type RepoCfgBody = {
   autoLabel?: unknown;
   usageCeilingPct?: unknown;
   repoMode?: unknown;
+  automationConfirmed?: unknown;
 };
 
 // true when any present boolean field is not actually a boolean
@@ -707,6 +708,7 @@ async function parseRepoConfigPatch(req: Request): Promise<
       autoLabel?: string;
       usageCeilingPct?: number;
       repoMode?: "forge" | "lightweight";
+      automationConfirmed?: boolean;
     }
   | Response
 > {
@@ -720,6 +722,8 @@ async function parseRepoConfigPatch(req: Request): Promise<
       400,
     );
   }
+  if (body.automationConfirmed !== undefined && typeof body.automationConfirmed !== "boolean")
+    return json({ error: "automationConfirmed must be a boolean" }, 400);
   const scalars = parseRepoCfgScalars(body);
   if (scalars instanceof Response) return scalars;
   const {
@@ -741,7 +745,8 @@ async function parseRepoConfigPatch(req: Request): Promise<
     sandboxProfile !== undefined ||
     defaultModel !== undefined ||
     egressExtraHosts !== undefined ||
-    repoMode !== undefined;
+    repoMode !== undefined ||
+    body.automationConfirmed !== undefined;
   if (!present) {
     return json(
       {
@@ -771,6 +776,7 @@ async function parseRepoConfigPatch(req: Request): Promise<
     autoLabel,
     usageCeilingPct,
     repoMode,
+    automationConfirmed: body.automationConfirmed as boolean | undefined,
   };
 }
 
@@ -789,16 +795,25 @@ function mergeRepoConfig(
   return out;
 }
 
+function repoConfigResponse(deps: Ctx["deps"], dir: string): Response {
+  return json({
+    ...deps.store.getRepoConfig(dir),
+    automationConfirmed: deps.store.isAutomationConfirmed(dir),
+    automationRowExists: deps.store.automationRowExists(dir),
+  });
+}
+
 async function handleRepoConfig({ req, parts, url, deps }: Ctx): Promise<Response | null> {
   if (!(parts[0] === "api" && parts[1] === "repo-config" && !parts[2])) return null;
   const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
   if (!dir) return json({ error: "invalid repo" }, 400);
-  if (req.method === "GET") return json(deps.store.getRepoConfig(dir));
+  if (req.method === "GET") return repoConfigResponse(deps, dir);
   if (req.method !== "PUT") return null;
 
   const patch = await parseRepoConfigPatch(req);
   if (patch instanceof Response) return patch;
-  const merged = mergeRepoConfig(deps.store.getRepoConfig(dir), patch);
+  const { automationConfirmed, ...cfgPatch } = patch;
+  const merged = mergeRepoConfig(deps.store.getRepoConfig(dir), cfgPatch);
   if (merged.draftMode && merged.autoMergeEnabled) {
     return json({ error: "draftMode and autoMergeEnabled are mutually exclusive" }, 400);
   }
@@ -814,7 +829,8 @@ async function handleRepoConfig({ req, parts, url, deps }: Ctx): Promise<Respons
     );
   }
   deps.store.setRepoConfig(dir, merged);
-  return json(deps.store.getRepoConfig(dir));
+  if (automationConfirmed === true) deps.store.markAutomationConfirmed(dir);
+  return repoConfigResponse(deps, dir);
 }
 
 // /api/repo-roles?repo=<path> — read (GET) / set (PUT) the committed reviewer +

--- a/src/store.ts
+++ b/src/store.ts
@@ -967,6 +967,37 @@ export class SessionStore implements CapStore, CreditStore {
     );
   }
 
+  // ── automation-confirmation (issue #1025) ────────────────────────────────
+
+  /** True when the repo has been explicitly confirmed OR has any prior session (legacy repos). */
+  isAutomationConfirmed(repoPath: string): boolean {
+    const row = this.db
+      .query(`SELECT automationConfirmedAt FROM repo_config WHERE repoPath = ?`)
+      .get(repoPath) as { automationConfirmedAt: number | null } | null;
+    if (row?.automationConfirmedAt != null) return true;
+    return this.hasSessionForRepo(repoPath);
+  }
+
+  /** True when at least one session exists for the given repoPath. */
+  hasSessionForRepo(repoPath: string): boolean {
+    const row = this.db.query(`SELECT 1 FROM sessions WHERE repoPath = ? LIMIT 1`).get(repoPath);
+    return row != null;
+  }
+
+  /** True when a repo_config row exists for the given repoPath. */
+  automationRowExists(repoPath: string): boolean {
+    const row = this.db.query(`SELECT 1 FROM repo_config WHERE repoPath = ? LIMIT 1`).get(repoPath);
+    return row != null;
+  }
+
+  /** Stamp automationConfirmedAt = now. A row must already exist (PUT runs setRepoConfig first). */
+  markAutomationConfirmed(repoPath: string): void {
+    this.db.run(`UPDATE repo_config SET automationConfirmedAt = ? WHERE repoPath = ?`, [
+      Date.now(),
+      repoPath,
+    ]);
+  }
+
   // ── local_prs (lightweight-mode pseudo-PRs) ──────────────────────────────
 
   ensureLocalPr(repoPath: string, branch: string, base: string): LocalPr {
@@ -2478,6 +2509,17 @@ export class SessionStore implements CapStore, CreditStore {
     add("repoMode", `repoMode TEXT NOT NULL DEFAULT 'forge'`);
     // auto-optimize flagged rules: default OFF (explicit opt-in).
     add("autoOptimizeFlagged", `autoOptimizeFlagged INTEGER NOT NULL DEFAULT 0`);
+    // Issue #1025: first-task automation-confirmation. Nullable — new repos start unconfirmed.
+    if (!cols.some((c) => c.name === "automationConfirmedAt")) {
+      this.db.run(`ALTER TABLE repo_config ADD COLUMN automationConfirmedAt INTEGER`);
+      // Issue #1025: pre-feature rows = already-engaged repos ⇒ treat as already-confirmed so the
+      // first-task confirm step only fires for genuinely new repos. Backfill from updatedAt (NOT NULL
+      // on every row, store.ts:607). Gated inside this column-missing branch so it runs EXACTLY ONCE —
+      // a server bounce must never auto-confirm a freshly-seeded-but-unconfirmed row.
+      this.db.run(
+        `UPDATE repo_config SET automationConfirmedAt = updatedAt WHERE automationConfirmedAt IS NULL`,
+      );
+    }
   }
 
   private migrateEpicIntegratedColumns(): void {

--- a/test/automation-confirm.test.ts
+++ b/test/automation-confirm.test.ts
@@ -73,10 +73,7 @@ test("migrateRepoConfigColumns backfill: pre-existing rows get automationConfirm
   }
 });
 
-test("migrateRepoConfigColumns backfill is one-time: re-opening does not re-confirm a NULL row", () => {
-  // We can't test the column-missing branch directly on :memory: (it's always fresh),
-  // but we can verify that markAutomationConfirmed → NULL reset is respected on re-open:
-  // i.e., the migrate code checks column-missing, not value-null, so a NULL row stays NULL.
+test("isAutomationConfirmed returns false when automationConfirmedAt is NULL and no session exists", () => {
   const s = new SessionStore(":memory:");
   s.setRepoConfig("/repo/b", s.getRepoConfig("/repo/b"));
   // Manually clear automationConfirmedAt via the internal DB (simulates a freshly-seeded
@@ -84,11 +81,8 @@ test("migrateRepoConfigColumns backfill is one-time: re-opening does not re-conf
   (s as any).db.run(
     `UPDATE repo_config SET automationConfirmedAt = NULL WHERE repoPath = '/repo/b'`,
   );
-  // isAutomationConfirmed uses the session fallback — no sessions → should be false.
+  // No sessions for this repo → both fallbacks miss → false.
   expect(s.isAutomationConfirmed("/repo/b")).toBe(false);
-  // A new store instance opening the same :memory: DB is not possible, but we can verify
-  // the store doesn't re-backfill by re-calling migrate via a second store (isolated DB).
-  // The gist: the branch is column-missing, and since the column exists now, it won't re-run.
 });
 
 test("isAutomationConfirmed: true when automationConfirmedAt is set", () => {

--- a/test/automation-confirm.test.ts
+++ b/test/automation-confirm.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Tests for issue #1025: first-task automation-confirmation persistence + API.
+ * RED phase — all tests fail until implementation lands.
+ */
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Database } from "bun:sqlite";
+import { SessionStore } from "../src/store";
+import { makeApp, type AppDeps } from "../src/server";
+import { SessionService } from "../src/service";
+import { EventHub } from "../src/events";
+import { config } from "../src/config";
+
+// ── Store unit tests ──────────────────────────────────────────────────────────
+
+const base = {
+  name: "repo-flatten",
+  prompt: "flatten repo",
+  repoPath: "/r",
+  baseBranch: "main",
+  branch: "shepherd/repo-flatten",
+  worktreePath: "/r-wt",
+  isolated: true,
+  herdrSession: "default",
+  herdrAgentId: "term_1",
+};
+
+test("migrateRepoConfigColumns adds automationConfirmedAt column", () => {
+  const s = new SessionStore(":memory:");
+  // Column exists after init — PRAGMA returns it.
+  const cols = (s as any).db.query(`PRAGMA table_info(repo_config)`).all() as { name: string }[];
+  expect(cols.some((c: { name: string }) => c.name === "automationConfirmedAt")).toBe(true);
+});
+
+test("migrateRepoConfigColumns backfill: pre-existing rows get automationConfirmedAt set, re-open with NULL stays NULL", () => {
+  // Uses a file-backed DB to survive across SessionStore instances.
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-test-"));
+  const dbPath = join(dir, "test.db");
+  try {
+    // Step 1: create a raw DB with repo_config but WITHOUT automationConfirmedAt, insert a row.
+    const raw = new Database(dbPath);
+    raw.run(`CREATE TABLE IF NOT EXISTS repo_config (
+      repoPath TEXT PRIMARY KEY, criticEnabled INTEGER NOT NULL DEFAULT 1,
+      criticAllPrs INTEGER NOT NULL DEFAULT 0,
+      learningsEnabled INTEGER NOT NULL DEFAULT 1,
+      autoDrainEnabled INTEGER NOT NULL DEFAULT 0,
+      autoMergeEnabled INTEGER NOT NULL DEFAULT 0,
+      maxAuto INTEGER NOT NULL DEFAULT 1,
+      autoLabel TEXT NOT NULL DEFAULT 'shepherd:auto',
+      usageCeilingPct INTEGER NOT NULL DEFAULT 80,
+      repoMode TEXT NOT NULL DEFAULT 'forge',
+      updatedAt INTEGER NOT NULL)`);
+    raw.run(`INSERT INTO repo_config (repoPath, updatedAt) VALUES ('/repo/legacy', 9999)`);
+    raw.close();
+
+    // Step 2: open a real SessionStore — migration runs, adds column + backfills from updatedAt.
+    const s1 = new SessionStore(dbPath);
+    // Backfill should have set automationConfirmedAt = updatedAt (9999) → confirmed.
+    expect(s1.isAutomationConfirmed("/repo/legacy")).toBe(true);
+
+    // Step 3: simulate a freshly-seeded-but-unconfirmed row (NULL set explicitly after migration).
+    (s1 as any).db.run(
+      `UPDATE repo_config SET automationConfirmedAt = NULL WHERE repoPath = '/repo/legacy'`,
+    );
+
+    // Step 4: re-open — column already exists, backfill branch is skipped → row stays NULL.
+    const s2 = new SessionStore(dbPath);
+    expect(s2.isAutomationConfirmed("/repo/legacy")).toBe(false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("migrateRepoConfigColumns backfill is one-time: re-opening does not re-confirm a NULL row", () => {
+  // We can't test the column-missing branch directly on :memory: (it's always fresh),
+  // but we can verify that markAutomationConfirmed → NULL reset is respected on re-open:
+  // i.e., the migrate code checks column-missing, not value-null, so a NULL row stays NULL.
+  const s = new SessionStore(":memory:");
+  s.setRepoConfig("/repo/b", s.getRepoConfig("/repo/b"));
+  // Manually clear automationConfirmedAt via the internal DB (simulates a freshly-seeded
+  // unconfirmed row on a DB that already has the column).
+  (s as any).db.run(
+    `UPDATE repo_config SET automationConfirmedAt = NULL WHERE repoPath = '/repo/b'`,
+  );
+  // isAutomationConfirmed uses the session fallback — no sessions → should be false.
+  expect(s.isAutomationConfirmed("/repo/b")).toBe(false);
+  // A new store instance opening the same :memory: DB is not possible, but we can verify
+  // the store doesn't re-backfill by re-calling migrate via a second store (isolated DB).
+  // The gist: the branch is column-missing, and since the column exists now, it won't re-run.
+});
+
+test("isAutomationConfirmed: true when automationConfirmedAt is set", () => {
+  const s = new SessionStore(":memory:");
+  s.setRepoConfig("/repo/c", s.getRepoConfig("/repo/c"));
+  // Clear to ensure clean state
+  (s as any).db.run(
+    `UPDATE repo_config SET automationConfirmedAt = NULL WHERE repoPath = '/repo/c'`,
+  );
+  expect(s.isAutomationConfirmed("/repo/c")).toBe(false);
+  s.markAutomationConfirmed("/repo/c");
+  expect(s.isAutomationConfirmed("/repo/c")).toBe(true);
+});
+
+test("isAutomationConfirmed: true when a session exists for the repo (no confirmedAt)", () => {
+  const s = new SessionStore(":memory:");
+  // No repo_config row at all, but a session exists
+  s.create({ ...base, repoPath: "/repo/with-session" });
+  expect(s.isAutomationConfirmed("/repo/with-session")).toBe(true);
+});
+
+test("isAutomationConfirmed: false when neither confirmedAt nor session exists", () => {
+  const s = new SessionStore(":memory:");
+  // setRepoConfig writes a row; clear automationConfirmedAt so it's null
+  s.setRepoConfig("/repo/fresh", s.getRepoConfig("/repo/fresh"));
+  (s as any).db.run(
+    `UPDATE repo_config SET automationConfirmedAt = NULL WHERE repoPath = '/repo/fresh'`,
+  );
+  expect(s.isAutomationConfirmed("/repo/fresh")).toBe(false);
+});
+
+test("isAutomationConfirmed: false when no repo_config row exists", () => {
+  const s = new SessionStore(":memory:");
+  expect(s.isAutomationConfirmed("/repo/nonexistent")).toBe(false);
+});
+
+test("hasSessionForRepo: true when at least one session exists", () => {
+  const s = new SessionStore(":memory:");
+  s.create({ ...base, repoPath: "/repo/has-session" });
+  expect(s.hasSessionForRepo("/repo/has-session")).toBe(true);
+});
+
+test("hasSessionForRepo: false when no session exists", () => {
+  const s = new SessionStore(":memory:");
+  expect(s.hasSessionForRepo("/repo/no-session")).toBe(false);
+});
+
+test("automationRowExists: false when no repo_config row", () => {
+  const s = new SessionStore(":memory:");
+  expect(s.automationRowExists("/repo/new")).toBe(false);
+});
+
+test("automationRowExists: true after setRepoConfig is called", () => {
+  const s = new SessionStore(":memory:");
+  s.setRepoConfig("/repo/exists", s.getRepoConfig("/repo/exists"));
+  expect(s.automationRowExists("/repo/exists")).toBe(true);
+});
+
+test("markAutomationConfirmed sets automationConfirmedAt to non-null", () => {
+  const s = new SessionStore(":memory:");
+  s.setRepoConfig("/repo/mark", s.getRepoConfig("/repo/mark"));
+  (s as any).db.run(
+    `UPDATE repo_config SET automationConfirmedAt = NULL WHERE repoPath = '/repo/mark'`,
+  );
+  expect(s.isAutomationConfirmed("/repo/mark")).toBe(false);
+  const before = Date.now();
+  s.markAutomationConfirmed("/repo/mark");
+  const after = Date.now();
+  const row = (s as any).db
+    .query(`SELECT automationConfirmedAt FROM repo_config WHERE repoPath = '/repo/mark'`)
+    .get() as { automationConfirmedAt: number } | null;
+  expect(row?.automationConfirmedAt).toBeGreaterThanOrEqual(before);
+  expect(row?.automationConfirmedAt).toBeLessThanOrEqual(after);
+});
+
+// ── API tests ─────────────────────────────────────────────────────────────────
+
+let tmpRoot: string;
+let validRepo: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(config.repoRoot, "shepherd-srv-test-"));
+  validRepo = join(tmpRoot, "repo");
+  mkdirSync(validRepo);
+});
+
+afterEach(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+function makeDeps(): AppDeps {
+  const store = new SessionStore(":memory:");
+  const events = new EventHub();
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: {
+      create: () => ({ worktreePath: "/wt", branch: "shepherd/x", isolated: true }),
+      ensureBaseRef: async () => {},
+      branchExists: () => false,
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: () => ({
+        terminalId: "term_x",
+        cwd: "/wt",
+        agent: "claude",
+        agentStatus: "working",
+        paneId: "p",
+        tabId: "t",
+        workspaceId: "w",
+      }),
+      list: () => [],
+      stop: () => {},
+      send: () => {},
+    } as any,
+    events,
+  });
+  const usageLimits = {
+    limits: () => ({
+      session5h: null,
+      week: null,
+      credits: null,
+      stale: true,
+      calibratedAt: null,
+      subscriptionOnly: false,
+    }),
+    projections: () => [],
+  };
+  const distiller = { distillNow: () => {} };
+  return { store, service, events, usageLimits, distiller };
+}
+
+function getRepoConfig(app: ReturnType<typeof makeApp>, repo: string) {
+  return app.fetch(
+    new Request(`http://x/api/repo-config?repo=${encodeURIComponent(repo)}`, {
+      headers: { Origin: "http://localhost:7330" },
+    }),
+  );
+}
+
+function putRepoConfig(app: ReturnType<typeof makeApp>, repo: string, body: unknown) {
+  return app.fetch(
+    new Request(`http://x/api/repo-config?repo=${encodeURIComponent(repo)}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json", Origin: "http://localhost:7330" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+test("GET /api/repo-config returns automationConfirmed and automationRowExists", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  const res = await getRepoConfig(app, validRepo);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toHaveProperty("automationConfirmed");
+  expect(body).toHaveProperty("automationRowExists");
+});
+
+test("GET /api/repo-config on fresh repo returns automationConfirmed: false, automationRowExists: false", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  const res = await getRepoConfig(app, validRepo);
+  const body = await res.json();
+  expect(body.automationConfirmed).toBe(false);
+  expect(body.automationRowExists).toBe(false);
+});
+
+test("PUT /api/repo-config with only { automationConfirmed: true } returns 200", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  const res = await putRepoConfig(app, validRepo, { automationConfirmed: true });
+  expect(res.status).toBe(200);
+});
+
+test("PUT /api/repo-config with automationConfirmed: true marks the repo as confirmed", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  await putRepoConfig(app, validRepo, { automationConfirmed: true });
+  expect(deps.store.isAutomationConfirmed(validRepo)).toBe(true);
+});
+
+test("PUT /api/repo-config with automationConfirmed: true does not mutate other fields", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  // First establish a config with criticEnabled: false
+  await putRepoConfig(app, validRepo, { criticEnabled: false });
+  // Then confirm automation (should not touch criticEnabled)
+  await putRepoConfig(app, validRepo, { automationConfirmed: true });
+  expect(deps.store.getRepoConfig(validRepo).criticEnabled).toBe(false);
+});
+
+test("PUT /api/repo-config returns automationConfirmed and automationRowExists in response", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  const res = await putRepoConfig(app, validRepo, { automationConfirmed: true });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.automationConfirmed).toBe(true);
+  expect(body.automationRowExists).toBe(true);
+});
+
+test("GET and PUT return the same shape (both include automationConfirmed + automationRowExists)", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  // PUT a toggle
+  const putRes = await putRepoConfig(app, validRepo, { criticEnabled: true });
+  const putBody = await putRes.json();
+  // GET
+  const getRes = await getRepoConfig(app, validRepo);
+  const getBody = await getRes.json();
+  expect(Object.keys(putBody).sort()).toEqual(Object.keys(getBody).sort());
+  expect(putBody.automationConfirmed).toBeDefined();
+  expect(putBody.automationRowExists).toBeDefined();
+  expect(getBody.automationConfirmed).toBeDefined();
+  expect(getBody.automationRowExists).toBeDefined();
+});
+
+test("routine toggle PUT on already-confirmed repo still reports automationConfirmed: true", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  // Confirm first
+  await putRepoConfig(app, validRepo, { automationConfirmed: true });
+  // Now toggle some other field
+  const res = await putRepoConfig(app, validRepo, { criticEnabled: false });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.automationConfirmed).toBe(true);
+});
+
+test("PUT /api/repo-config rejects automationConfirmed: non-boolean", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  const res = await putRepoConfig(app, validRepo, { automationConfirmed: "yes" });
+  expect(res.status).toBe(400);
+});
+
+test("PUT /api/repo-config automationConfirmed: false alongside a valid toggle is accepted", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  // automationConfirmed: false just means "don't call markAutomationConfirmed" — still valid
+  const res = await putRepoConfig(app, validRepo, {
+    criticEnabled: true,
+    automationConfirmed: false,
+  });
+  expect(res.status).toBe(200);
+  expect(deps.store.isAutomationConfirmed(validRepo)).toBe(false);
+});

--- a/test/server-reviews.test.ts
+++ b/test/server-reviews.test.ts
@@ -109,6 +109,8 @@ test("GET /api/repo-config defaults to critic on + auto-address off", async () =
     defaultModel: "inherit",
     egressExtraHosts: [],
     repoMode: "forge",
+    automationConfirmed: false,
+    automationRowExists: false,
   });
 });
 
@@ -160,6 +162,8 @@ test("PUT /api/repo-config sets criticEnabled=false, GET reflects it", async () 
     defaultModel: "inherit",
     egressExtraHosts: [],
     repoMode: "forge",
+    automationConfirmed: false,
+    automationRowExists: true,
   });
 
   const get = await app.fetch(new Request(url));
@@ -184,6 +188,8 @@ test("PUT /api/repo-config sets criticEnabled=false, GET reflects it", async () 
     defaultModel: "inherit",
     egressExtraHosts: [],
     repoMode: "forge",
+    automationConfirmed: false,
+    automationRowExists: true,
   });
 });
 
@@ -218,6 +224,8 @@ test("PUT /api/repo-config toggles autoAddressEnabled independently of criticEna
     defaultModel: "inherit",
     egressExtraHosts: [],
     repoMode: "forge",
+    automationConfirmed: false,
+    automationRowExists: true,
   });
 });
 
@@ -252,6 +260,8 @@ test("PUT /api/repo-config sets learningsEnabled independently of criticEnabled"
     defaultModel: "inherit",
     egressExtraHosts: [],
     repoMode: "forge",
+    automationConfirmed: false,
+    automationRowExists: true,
   });
 });
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1850,5 +1850,10 @@
   "feat_why_parked_title": "Warum wartet diese Sitzung?",
   "feat_why_parked_body": "Gehaltene, blockierte und von einem Gate aufgehaltene Sitzungen zeigen jetzt einen einzeiligen Grund auf der Karte und in der Triage-Schublade — damit du auf einen Blick siehst, warum eine Sitzung deine Aufmerksamkeit braucht.",
   "feat_usage_task_names_title": "Aufgabennamen in der Nutzung",
-  "feat_usage_task_names_body": "Die Zeilen pro Aufgabe in den Ansichten Nutzung → Verbrauch und Overhead zeigen jetzt den Kurznamen jeder Aufgabe neben ihrer Kennung — damit du Aufgaben auf einen Blick auseinanderhältst, statt IDs lesen zu müssen."
+  "feat_usage_task_names_body": "Die Zeilen pro Aufgabe in den Ansichten Nutzung → Verbrauch und Overhead zeigen jetzt den Kurznamen jeder Aufgabe neben ihrer Kennung — damit du Aufgaben auf einen Blick auseinanderhältst, statt IDs lesen zu müssen.",
+  "firsttask_confirm_title": "Automatisierung bestätigen",
+  "firsttask_confirm_intro": "Shepherd hat {repo} noch nie gesteuert. Überprüfe die Automatisierungseinstellungen unten — sie gelten für jede Aufgabe in diesem Repository — und bestätige, um diese Aufgabe zu starten.",
+  "firsttask_confirm_cta": "Bestätigen & Aufgabe starten",
+  "feat_first_task_confirm_title": "Einstellungen vor der ersten Aufgabe prüfen",
+  "feat_first_task_confirm_body": "Das Starten einer Aufgabe in einem neuen Repository zeigt nun einen kurzen Überprüfungsschritt, damit du die Automatisierungseinstellungen vor dem ersten Durchlauf prüfen kannst. Nach einmaliger Bestätigung starten weitere Aufgaben im selben Repository ohne Unterbrechung."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1850,5 +1850,10 @@
   "feat_why_parked_title": "Why is this parked?",
   "feat_why_parked_body": "Held, blocked and gate-stuck sessions now show a one-line reason on the card and in the triage drawer — so you can see why a session needs you at a glance.",
   "feat_usage_task_names_title": "Task names in Usage",
-  "feat_usage_task_names_body": "The per-task rows in the Usage → Spend and Overhead lenses now show each task's short name alongside its designation — so you can tell tasks apart at a glance instead of reading IDs."
+  "feat_usage_task_names_body": "The per-task rows in the Usage → Spend and Overhead lenses now show each task's short name alongside its designation — so you can tell tasks apart at a glance instead of reading IDs.",
+  "firsttask_confirm_title": "Confirm automation settings",
+  "firsttask_confirm_intro": "Shepherd hasn't driven {repo} before. Review the automation settings below — they apply to every task on this repo — then confirm to start this one.",
+  "firsttask_confirm_cta": "Confirm & start task",
+  "feat_first_task_confirm_title": "Review settings before the first task",
+  "feat_first_task_confirm_body": "Starting a task on a new repo now shows a quick review step so you can check automation settings before the first run. After confirming once, future tasks on the same repo start without interruption."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -57,7 +57,6 @@ import type {
   DistillerHealth,
   RawAnswer,
   DocAgentRun,
-  UsageHistoryResponse,
   HoldReason,
 } from "./types";
 import { m } from "$lib/paraglide/messages";
@@ -490,12 +489,6 @@ export async function getDiff(id: string): Promise<DiffResult> {
 export async function getUsageLimits(): Promise<UsageLimitsResponse> {
   const r = await fetch("/api/usage/limits");
   if (!r.ok) throw await failed(r, "limits");
-  return r.json();
-}
-
-export async function getUsageHistory(): Promise<UsageHistoryResponse> {
-  const r = await fetch("/api/usage/history");
-  if (!r.ok) throw await failed(r, "history");
   return r.json();
 }
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1118,7 +1118,12 @@ export async function adoptGitignore(repoPath: string): Promise<{
   return r.json();
 }
 
-export async function getRepoConfig(repoPath: string): Promise<RepoConfig> {
+export type RepoConfigResponse = RepoConfig & {
+  automationConfirmed?: boolean;
+  automationRowExists?: boolean;
+};
+
+export async function getRepoConfig(repoPath: string): Promise<RepoConfigResponse> {
   return getJson(`/api/repo-config?repo=${encodeURIComponent(repoPath)}`, "repo-config");
 }
 
@@ -1144,8 +1149,8 @@ export async function putRepoConfig(
       | "repoMode"
       | "autoOptimizeFlagged"
     >
-  >,
-): Promise<RepoConfig> {
+  > & { automationConfirmed?: boolean },
+): Promise<RepoConfigResponse> {
   const r = await fetch(`/api/repo-config?repo=${encodeURIComponent(repoPath)}`, {
     method: "PUT",
     headers: JSON_HEADERS,

--- a/ui/src/lib/components/FirstTaskAutomationConfirm.svelte
+++ b/ui/src/lib/components/FirstTaskAutomationConfirm.svelte
@@ -7,11 +7,13 @@
     onconfirm,
     oncancel,
     submitting = false,
+    error = null,
   }: {
     repoPath: string;
     onconfirm: () => void;
     oncancel: () => void;
     submitting?: boolean;
+    error?: string | null;
   } = $props();
 
   /** Last path segment of the repo path — the repo's base name shown in the intro. */
@@ -25,6 +27,12 @@
   <div class="ftac-settings">
     <AutomationSettings {repoPath} showHeader={false} />
   </div>
+
+  {#if error}
+    <div class="err" role="alert">
+      <span>{error}</span>
+    </div>
+  {/if}
 
   <div class="ftac-actions">
     <button type="button" class="gbtn" onclick={oncancel}>
@@ -63,6 +71,15 @@
     border-radius: 2px;
     background: var(--color-inset);
     overflow: hidden;
+  }
+
+  .err {
+    color: var(--color-red);
+    font-size: var(--fs-meta);
+    margin-top: 6px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
   }
 
   .ftac-actions {

--- a/ui/src/lib/components/FirstTaskAutomationConfirm.svelte
+++ b/ui/src/lib/components/FirstTaskAutomationConfirm.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import AutomationSettings from "./AutomationSettings.svelte";
+
+  let {
+    repoPath,
+    onconfirm,
+    oncancel,
+    submitting = false,
+  }: {
+    repoPath: string;
+    onconfirm: () => void;
+    oncancel: () => void;
+    submitting?: boolean;
+  } = $props();
+
+  /** Last path segment of the repo path — the repo's base name shown in the intro. */
+  const repoBaseName = $derived(repoPath.split("/").filter(Boolean).at(-1) ?? repoPath);
+</script>
+
+<div class="ftac">
+  <p class="ftac-title micro">{m.firsttask_confirm_title()}</p>
+  <p class="ftac-intro">{m.firsttask_confirm_intro({ repo: repoBaseName })}</p>
+
+  <div class="ftac-settings">
+    <AutomationSettings {repoPath} showHeader={false} />
+  </div>
+
+  <div class="ftac-actions">
+    <button type="button" class="gbtn" onclick={oncancel}>
+      {m.common_cancel()}
+    </button>
+    <button type="button" class="gbtn primary" disabled={submitting} onclick={onconfirm}>
+      {m.firsttask_confirm_cta()}
+    </button>
+  </div>
+</div>
+
+<style>
+  .ftac {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .ftac-title {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin: 0;
+  }
+
+  .ftac-intro {
+    font-size: var(--fs-base);
+    color: var(--color-ink);
+    margin: 0;
+    line-height: 1.45;
+  }
+
+  .ftac-settings {
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    background: var(--color-inset);
+    overflow: hidden;
+  }
+
+  .ftac-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 4px;
+  }
+
+  /* Canonical .gbtn recipe — see /design-system */
+  .gbtn {
+    background: none;
+    border: 1px solid var(--color-line-bright);
+    border-radius: 6px;
+    color: var(--color-muted);
+    font: inherit;
+    font-size: var(--fs-base);
+    padding: 7px 16px;
+    cursor: pointer;
+  }
+
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+
+  .gbtn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+
+  .gbtn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .gbtn.primary {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+</style>

--- a/ui/src/lib/components/FirstTaskAutomationConfirm.svelte
+++ b/ui/src/lib/components/FirstTaskAutomationConfirm.svelte
@@ -3,12 +3,14 @@
   import AutomationSettings from "./AutomationSettings.svelte";
 
   let {
+    active = false,
     repoPath,
     onconfirm,
     oncancel,
     submitting = false,
     error = null,
   }: {
+    active?: boolean;
     repoPath: string;
     onconfirm: () => void;
     oncancel: () => void;
@@ -20,29 +22,31 @@
   const repoBaseName = $derived(repoPath.split("/").filter(Boolean).at(-1) ?? repoPath);
 </script>
 
-<div class="ftac">
-  <p class="ftac-title micro">{m.firsttask_confirm_title()}</p>
-  <p class="ftac-intro">{m.firsttask_confirm_intro({ repo: repoBaseName })}</p>
+{#if active}
+  <div class="ftac">
+    <p class="ftac-title micro">{m.firsttask_confirm_title()}</p>
+    <p class="ftac-intro">{m.firsttask_confirm_intro({ repo: repoBaseName })}</p>
 
-  <div class="ftac-settings">
-    <AutomationSettings {repoPath} showHeader={false} />
-  </div>
-
-  {#if error}
-    <div class="err" role="alert">
-      <span>{error}</span>
+    <div class="ftac-settings">
+      <AutomationSettings {repoPath} showHeader={false} />
     </div>
-  {/if}
 
-  <div class="ftac-actions">
-    <button type="button" class="gbtn" onclick={oncancel}>
-      {m.common_cancel()}
-    </button>
-    <button type="button" class="gbtn primary" disabled={submitting} onclick={onconfirm}>
-      {m.firsttask_confirm_cta()}
-    </button>
+    {#if error}
+      <div class="err" role="alert">
+        <span>{error}</span>
+      </div>
+    {/if}
+
+    <div class="ftac-actions">
+      <button type="button" class="gbtn" onclick={oncancel}>
+        {m.common_cancel()}
+      </button>
+      <button type="button" class="gbtn primary" disabled={submitting} onclick={onconfirm}>
+        {m.firsttask_confirm_cta()}
+      </button>
+    </div>
   </div>
-</div>
+{/if}
 
 <style>
   .ftac {

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -331,17 +331,16 @@ describe("NewTask plan-gate inheritance", () => {
     await expect.poll(() => planGateBox().disabled).toBe(false);
     expect(planGateBox().checked).toBe(false);
 
-    // After a failed fetch, automationConfirmed is unknown (false default) → the
-    // first-task confirm step appears to let the user review settings before spawning.
-    // Mock putRepoConfig so seedNewRepoDefaults and confirmAutomation can resolve.
+    // A FAILED fetch leaves confirmed/rowExists unset. The submit gate must NOT treat that
+    // as a new repo: it must spawn DIRECTLY (no confirm step) and must NOT seed (no PUT that
+    // would clobber a deliberate planGate=off on an existing-but-unloaded repo).
     mockPutRepoConfig.mockResolvedValue({ ...repoConfig(false), automationConfirmed: true });
     await fillAndSubmit();
-    // confirm step appears (not an immediate spawn)
-    await expect.poll(() => document.querySelector(".ftac")).toBeTruthy();
-    // clicking Confirm proceeds to spawn with planGateEnabled:null (box untouched)
-    await page.getByRole("button", { name: m.firsttask_confirm_cta() }).click();
     await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
     expect(onsubmit.mock.calls[0]![0]).toMatchObject({ planGateEnabled: null });
+    // no confirm step, and crucially no seed PUT
+    expect(document.querySelector(".ftac")).toBeNull();
+    expect(mockPutRepoConfig).not.toHaveBeenCalled();
   });
 
   it("first-task confirm replays force from 'Submit anyway' (no silent downgrade to hold)", async () => {

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -1023,6 +1023,35 @@ describe("NewTask first-task confirm step", () => {
     expect(onsubmit).not.toHaveBeenCalled();
   });
 
+  it("confirm PUT fails: onsubmit NOT called, confirm step still shown, error visible", async () => {
+    const repoPath = "/repo/ftac-confirm-reject";
+    mockGetRepoConfig.mockResolvedValue(unconfirmedNewRepoConfig());
+    // seedNewRepoDefaults call (first put)
+    mockPutRepoConfig.mockResolvedValueOnce(unconfirmedNewRepoConfig());
+    // confirmAutomation call (second put) rejects
+    mockPutRepoConfig.mockRejectedValueOnce(new Error("network error"));
+    const onsubmit = vi.fn();
+    render(NewTask, { props: { onsubmit, initialRepoPath: repoPath } });
+
+    await expect.poll(() => document.querySelector(".plan-gate input")).toBeTruthy();
+    await fillPromptAndClickRun();
+
+    // Confirm step appears
+    await expect.poll(() => document.querySelector(".ftac")).toBeTruthy();
+
+    // Click Confirm — the PUT will reject
+    const confirmBtn = page.getByRole("button", { name: m.firsttask_confirm_cta() });
+    await confirmBtn.click();
+
+    // onsubmit must NOT have been called
+    expect(onsubmit).not.toHaveBeenCalled();
+    // Confirm step must still be shown
+    await expect.poll(() => document.querySelector(".ftac")).toBeTruthy();
+    // Error must be visible inside the confirm step
+    await expect.poll(() => document.querySelector(".ftac .err")).toBeTruthy();
+    expect(document.querySelector(".ftac .err")?.textContent).toBeTruthy();
+  });
+
   it("settle race: ensure resolving to confirmed repo spawns directly with no spurious step", async () => {
     const repoPath = "/repo/ftac-settle-race";
 

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -343,6 +343,38 @@ describe("NewTask plan-gate inheritance", () => {
     await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
     expect(onsubmit.mock.calls[0]![0]).toMatchObject({ planGateEnabled: null });
   });
+
+  it("first-task confirm replays force from 'Submit anyway' (no silent downgrade to hold)", async () => {
+    // Brand-new repo (unconfirmed, no row) that ALSO hits a likely usage hold. Clicking
+    // "Submit anyway" (force=true) must keep force=true through the confirm step — not get
+    // downgraded to force=false (which would silently become "Hold for reset").
+    const repoPath = "/repo/force-through-confirm";
+    mockGetRepoConfig.mockResolvedValue({
+      ...repoConfig(false),
+      automationConfirmed: false,
+      automationRowExists: false,
+    });
+    mockPutRepoConfig.mockResolvedValue({ ...repoConfig(false), automationConfirmed: true });
+    const onsubmit = vi.fn();
+    render(NewTask, { props: { onsubmit, initialRepoPath: repoPath, holdLikely: true } });
+
+    const promptField = document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;
+    promptField.value = "do the thing";
+    promptField.dispatchEvent(new Event("input", { bubbles: true }));
+
+    const anyway = () => document.querySelector<HTMLButtonElement>("button.run-anyway")!;
+    await expect.poll(() => anyway().disabled).toBe(false);
+    anyway().click(); // submit(e, true)
+
+    // first task on this repo → confirm step intercepts before spawning
+    await expect.poll(() => document.querySelector(".ftac")).toBeTruthy();
+    expect(onsubmit).not.toHaveBeenCalled();
+
+    await page.getByRole("button", { name: m.firsttask_confirm_cta() }).click();
+    await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
+    // force must survive the confirm step
+    expect(onsubmit.mock.calls[0]![0]).toMatchObject({ force: true });
+  });
 });
 
 describe("NewTask autopilot override", () => {

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -10,8 +10,10 @@ import {
   getTodo,
   listBranches,
   getRepoConfig,
+  putRepoConfig,
   listRepos,
   branchStatus,
+  getCommands,
 } from "$lib/api";
 
 // Mock the API so the issue picker renders deterministically with no network.
@@ -24,24 +26,32 @@ vi.mock("$lib/api", async (importOriginal) => {
     getTodo: vi.fn(),
     listBranches: vi.fn(),
     getRepoConfig: vi.fn(),
+    putRepoConfig: vi.fn(),
     listRepos: vi.fn(),
     branchStatus: vi.fn(),
+    getCommands: vi.fn(),
   };
 });
 
 const { default: NewTask } = await import("./NewTask.svelte");
+const { default: FirstTaskAutomationConfirm } = await import("./FirstTaskAutomationConfirm.svelte");
 
 const mockListIssues = vi.mocked(listIssues);
 const mockGetEpics = vi.mocked(getEpics);
 const mockGetTodo = vi.mocked(getTodo);
 const mockListBranches = vi.mocked(listBranches);
 const mockGetRepoConfig = vi.mocked(getRepoConfig);
+const mockPutRepoConfig = vi.mocked(putRepoConfig);
 const mockListRepos = vi.mocked(listRepos);
 const mockBranchStatus = vi.mocked(branchStatus);
+const mockGetCommands = vi.mocked(getCommands);
 
 // A full RepoConfig with the plan gate flag overridable; the composer only reads
-// planGateEnabled but the store ingests the whole shape.
-function repoConfig(planGateEnabled: boolean): RepoConfig {
+// planGateEnabled but the store ingests the whole shape. automationConfirmed defaults
+// to true so existing tests (which don't test the confirm step) bypass the gate.
+function repoConfig(
+  planGateEnabled: boolean,
+): RepoConfig & { automationConfirmed: boolean; automationRowExists: boolean } {
   return {
     criticEnabled: true,
     criticAllPrs: false,
@@ -61,6 +71,8 @@ function repoConfig(planGateEnabled: boolean): RepoConfig {
     defaultModel: "inherit",
     repoMode: "forge",
     autoOptimizeFlagged: false,
+    automationConfirmed: true,
+    automationRowExists: true,
   };
 }
 
@@ -70,8 +82,10 @@ beforeEach(() => {
   mockGetTodo.mockReset();
   mockListBranches.mockReset();
   mockGetRepoConfig.mockReset();
+  mockPutRepoConfig.mockReset();
   mockListRepos.mockReset();
   mockBranchStatus.mockReset();
+  mockGetCommands.mockReset();
   // Safe defaults so any test that mounts the picker (PromptSources) gets resolved
   // promises, never `undefined`; individual tests override as needed.
   mockGetTodo.mockResolvedValue({ exists: false, content: "" });
@@ -79,7 +93,9 @@ beforeEach(() => {
   mockGetEpics.mockResolvedValue({ epics: [], subIssues: [] });
   mockListBranches.mockResolvedValue({ current: "main", branches: ["main"], default: null });
   mockGetRepoConfig.mockResolvedValue(repoConfig(false));
+  mockPutRepoConfig.mockResolvedValue(repoConfig(false));
   mockListRepos.mockResolvedValue({ repos: [], recentWindowDays: 30 });
+  mockGetCommands.mockResolvedValue({ commands: [] });
   // Default: up to date — no hint rendered
   mockBranchStatus.mockResolvedValue({
     behind: 0,
@@ -315,7 +331,15 @@ describe("NewTask plan-gate inheritance", () => {
     await expect.poll(() => planGateBox().disabled).toBe(false);
     expect(planGateBox().checked).toBe(false);
 
+    // After a failed fetch, automationConfirmed is unknown (false default) → the
+    // first-task confirm step appears to let the user review settings before spawning.
+    // Mock putRepoConfig so seedNewRepoDefaults and confirmAutomation can resolve.
+    mockPutRepoConfig.mockResolvedValue({ ...repoConfig(false), automationConfirmed: true });
     await fillAndSubmit();
+    // confirm step appears (not an immediate spawn)
+    await expect.poll(() => document.querySelector(".ftac")).toBeTruthy();
+    // clicking Confirm proceeds to spawn with planGateEnabled:null (box untouched)
+    await page.getByRole("button", { name: m.firsttask_confirm_cta() }).click();
     await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
     expect(onsubmit.mock.calls[0]![0]).toMatchObject({ planGateEnabled: null });
   });
@@ -832,5 +856,262 @@ describe("NewTask fableAvailable prop", () => {
 
     // No <p class="micro"> inside .model-field should render when fable is available
     expect(document.querySelector(".model-field p.micro")).toBeNull();
+  });
+});
+
+// ── Helpers shared by the confirm-step test suites ──────────────────────────
+
+/** A RepoConfigResponse for unconfirmed brand-new repos (no row yet). */
+function unconfirmedNewRepoConfig(): RepoConfig & {
+  automationConfirmed: boolean;
+  automationRowExists: boolean;
+} {
+  return {
+    criticEnabled: true,
+    criticAllPrs: false,
+    autoAddressEnabled: false,
+    learningsEnabled: true,
+    autopilotEnabled: false,
+    autoDrainEnabled: false,
+    autoMergeEnabled: false,
+    buildQueueEnabled: false,
+    planGateEnabled: false,
+    draftMode: false,
+    signoffAuthority: "human",
+    sandboxProfile: "trusted",
+    maxAuto: 1,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+    defaultModel: "inherit",
+    repoMode: "forge",
+    autoOptimizeFlagged: false,
+    automationConfirmed: false,
+    automationRowExists: false,
+  };
+}
+
+/** A RepoConfigResponse for repos that have a row but haven't confirmed yet. */
+function unconfirmedExistingRepoConfig(): RepoConfig & {
+  automationConfirmed: boolean;
+  automationRowExists: boolean;
+} {
+  return { ...unconfirmedNewRepoConfig(), automationRowExists: true };
+}
+
+/** A RepoConfigResponse for confirmed repos. */
+function confirmedRepoConfig(): RepoConfig & {
+  automationConfirmed: boolean;
+  automationRowExists: boolean;
+} {
+  return { ...unconfirmedNewRepoConfig(), automationConfirmed: true, automationRowExists: true };
+}
+
+async function fillPromptAndClickRun() {
+  const promptField = document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;
+  promptField.value = "do the thing";
+  promptField.dispatchEvent(new Event("input", { bubbles: true }));
+  // Wait for the run button to be enabled (prompt filled)
+  const runBtn = () => document.querySelector<HTMLButtonElement>("button.run");
+  await expect.poll(() => runBtn()?.disabled).toBe(false);
+  runBtn()!.click();
+}
+
+describe("NewTask first-task confirm step", () => {
+  it("confirmed repo: Run calls onsubmit directly, no confirm step shown", async () => {
+    const repoPath = "/repo/ftac-confirmed";
+    mockGetRepoConfig.mockResolvedValue(confirmedRepoConfig());
+    const onsubmit = vi.fn().mockResolvedValue(undefined);
+    render(NewTask, { props: { onsubmit, initialRepoPath: repoPath } });
+
+    // Wait for config to settle (plan-gate box becomes enabled)
+    await expect.poll(() => document.querySelector(".plan-gate input")).toBeTruthy();
+
+    await fillPromptAndClickRun();
+
+    // Confirm step must NOT appear
+    expect(document.querySelector(".ftac")).toBeNull();
+    // onsubmit must have been called
+    await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
+  });
+
+  it("unconfirmed brand-new repo: Run shows confirm step, does NOT call onsubmit, calls seedNewRepoDefaults", async () => {
+    const repoPath = "/repo/ftac-new-unconfirmed";
+    mockGetRepoConfig.mockResolvedValue(unconfirmedNewRepoConfig());
+    // putRepoConfig is called by seedNewRepoDefaults
+    mockPutRepoConfig.mockResolvedValue(unconfirmedNewRepoConfig());
+    const onsubmit = vi.fn().mockResolvedValue(undefined);
+    render(NewTask, { props: { onsubmit, initialRepoPath: repoPath } });
+
+    await expect.poll(() => document.querySelector(".plan-gate input")).toBeTruthy();
+    await fillPromptAndClickRun();
+
+    // Confirm step appears
+    await expect.poll(() => document.querySelector(".ftac")).toBeTruthy();
+    // onsubmit must NOT have been called
+    expect(onsubmit).not.toHaveBeenCalled();
+    // putRepoConfig was called for seedNewRepoDefaults (planGateEnabled: true)
+    await expect.poll(() => mockPutRepoConfig.mock.calls.length).toBeGreaterThanOrEqual(1);
+    const seedCall = mockPutRepoConfig.mock.calls.find((c) => c[1]?.planGateEnabled === true);
+    expect(seedCall).toBeTruthy();
+  });
+
+  it("unconfirmed but row exists: confirm step appears, seedNewRepoDefaults NOT called", async () => {
+    const repoPath = "/repo/ftac-existing-unconfirmed";
+    mockGetRepoConfig.mockResolvedValue(unconfirmedExistingRepoConfig());
+    const onsubmit = vi.fn().mockResolvedValue(undefined);
+    render(NewTask, { props: { onsubmit, initialRepoPath: repoPath } });
+
+    await expect.poll(() => document.querySelector(".plan-gate input")).toBeTruthy();
+    await fillPromptAndClickRun();
+
+    // Confirm step appears
+    await expect.poll(() => document.querySelector(".ftac")).toBeTruthy();
+    // putRepoConfig must NOT have been called (no seed)
+    expect(mockPutRepoConfig).not.toHaveBeenCalled();
+    expect(onsubmit).not.toHaveBeenCalled();
+  });
+
+  it("Confirm: calls confirmAutomation (putRepoConfig with automationConfirmed:true) then onsubmit", async () => {
+    const repoPath = "/repo/ftac-confirm-action";
+    mockGetRepoConfig.mockResolvedValue(unconfirmedNewRepoConfig());
+    // seed call
+    mockPutRepoConfig.mockResolvedValueOnce(unconfirmedNewRepoConfig());
+    // confirm call
+    mockPutRepoConfig.mockResolvedValueOnce(confirmedRepoConfig());
+    const onsubmit = vi.fn().mockResolvedValue(undefined);
+    render(NewTask, { props: { onsubmit, initialRepoPath: repoPath } });
+
+    await expect.poll(() => document.querySelector(".plan-gate input")).toBeTruthy();
+    await fillPromptAndClickRun();
+
+    // Wait for confirm step
+    await expect.poll(() => document.querySelector(".ftac")).toBeTruthy();
+
+    // Click Confirm
+    const confirmBtn = page.getByRole("button", { name: m.firsttask_confirm_cta() });
+    await confirmBtn.click();
+
+    // onsubmit must have been called
+    await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
+    // putRepoConfig was called with automationConfirmed: true
+    const confirmCall = mockPutRepoConfig.mock.calls.find(
+      (c) => c[1]?.automationConfirmed === true,
+    );
+    expect(confirmCall).toBeTruthy();
+  });
+
+  it("Cancel: hides confirm step and does NOT call onsubmit", async () => {
+    const repoPath = "/repo/ftac-cancel";
+    mockGetRepoConfig.mockResolvedValue(unconfirmedNewRepoConfig());
+    mockPutRepoConfig.mockResolvedValue(unconfirmedNewRepoConfig());
+    const onsubmit = vi.fn();
+    render(NewTask, { props: { onsubmit, initialRepoPath: repoPath } });
+
+    await expect.poll(() => document.querySelector(".plan-gate input")).toBeTruthy();
+    await fillPromptAndClickRun();
+
+    // Wait for confirm step
+    await expect.poll(() => document.querySelector(".ftac")).toBeTruthy();
+
+    // Click Cancel
+    const cancelBtn = page.getByRole("button", { name: m.common_cancel() });
+    await cancelBtn.click();
+
+    // Confirm step is gone; back to form
+    await expect.poll(() => document.querySelector(".ftac")).toBeFalsy();
+    await expect.poll(() => document.querySelector("#nt-prompt")).toBeTruthy();
+    expect(onsubmit).not.toHaveBeenCalled();
+  });
+
+  it("settle race: ensure resolving to confirmed repo spawns directly with no spurious step", async () => {
+    const repoPath = "/repo/ftac-settle-race";
+
+    let resolveConfig!: (v: RepoConfig) => void;
+    const configPromise = new Promise<RepoConfig>((res) => {
+      resolveConfig = res;
+    });
+    mockGetRepoConfig.mockReturnValue(configPromise);
+
+    const onsubmit = vi.fn().mockResolvedValue(undefined);
+    render(NewTask, { props: { onsubmit, initialRepoPath: repoPath } });
+
+    // Fill prompt while config is still in flight
+    const promptField = document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;
+    promptField.value = "do the thing";
+    promptField.dispatchEvent(new Event("input", { bubbles: true }));
+
+    // Click Run while config is still loading (submitting guard: not yet enabled, but
+    // the submit() gate only checks prompt+repoPath+submitting, so we wait for the
+    // store to settle via ensure() before it reads confirmed state — we resolve AFTER click)
+    // We need to wait for the run button to NOT be disabled (prompt is filled).
+    const runBtn = () => document.querySelector<HTMLButtonElement>("button.run");
+    await expect.poll(() => runBtn()?.disabled).toBe(false);
+    runBtn()!.click();
+
+    // Before config settles — neither step is active yet (submit is awaiting ensure())
+    // Now resolve with a confirmed config
+    resolveConfig(confirmedRepoConfig());
+
+    // Because ensure() awaited, reads happen AFTER it resolves → confirmed → spawn directly
+    await expect.poll(() => onsubmit.mock.calls.length, { timeout: 3000 }).toBe(1);
+    // Confirm step must NOT have appeared
+    expect(document.querySelector(".ftac")).toBeNull();
+  });
+});
+
+// ── FirstTaskAutomationConfirm component tests ──────────────────────────────
+
+describe("FirstTaskAutomationConfirm", () => {
+  it("renders title, intro with repo basename, and both buttons", async () => {
+    const onconfirm = vi.fn();
+    const oncancel = vi.fn();
+    render(FirstTaskAutomationConfirm, {
+      props: { repoPath: "/home/user/my-project", onconfirm, oncancel },
+    });
+
+    await expect.element(page.getByText(m.firsttask_confirm_title())).toBeInTheDocument();
+    // intro interpolates the basename ("my-project")
+    const intro = document.querySelector(".ftac-intro");
+    expect(intro?.textContent).toContain("my-project");
+    await expect
+      .element(page.getByRole("button", { name: m.firsttask_confirm_cta() }))
+      .toBeInTheDocument();
+    await expect.element(page.getByRole("button", { name: m.common_cancel() })).toBeInTheDocument();
+  });
+
+  it("Confirm button calls onconfirm", async () => {
+    const onconfirm = vi.fn();
+    const oncancel = vi.fn();
+    render(FirstTaskAutomationConfirm, {
+      props: { repoPath: "/repo/test", onconfirm, oncancel },
+    });
+
+    await page.getByRole("button", { name: m.firsttask_confirm_cta() }).click();
+    expect(onconfirm).toHaveBeenCalledOnce();
+    expect(oncancel).not.toHaveBeenCalled();
+  });
+
+  it("Cancel button calls oncancel", async () => {
+    const onconfirm = vi.fn();
+    const oncancel = vi.fn();
+    render(FirstTaskAutomationConfirm, {
+      props: { repoPath: "/repo/test", onconfirm, oncancel },
+    });
+
+    await page.getByRole("button", { name: m.common_cancel() }).click();
+    expect(oncancel).toHaveBeenCalledOnce();
+    expect(onconfirm).not.toHaveBeenCalled();
+  });
+
+  it("Confirm button is disabled when submitting=true", async () => {
+    const onconfirm = vi.fn();
+    const oncancel = vi.fn();
+    render(FirstTaskAutomationConfirm, {
+      props: { repoPath: "/repo/test", onconfirm, oncancel, submitting: true },
+    });
+
+    const confirmBtn = document.querySelector<HTMLButtonElement>(`button[disabled]`);
+    expect(confirmBtn).toBeTruthy();
+    expect(confirmBtn?.textContent?.trim()).toContain(m.firsttask_confirm_cta());
   });
 });

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -1052,6 +1052,48 @@ describe("NewTask first-task confirm step", () => {
     expect(document.querySelector(".ftac .err")?.textContent).toBeTruthy();
   });
 
+  it("double-click Confirm spawns exactly once (re-entry guard)", async () => {
+    const repoPath = "/repo/ftac-double-click";
+    mockGetRepoConfig.mockResolvedValue(unconfirmedNewRepoConfig());
+    // seedNewRepoDefaults
+    mockPutRepoConfig.mockResolvedValueOnce(unconfirmedNewRepoConfig());
+
+    // confirmAutomation: use a deferred promise so both clicks arrive before it resolves
+    let resolveConfirm!: (
+      v: RepoConfig & { automationConfirmed: boolean; automationRowExists: boolean },
+    ) => void;
+    const confirmPromise = new Promise<
+      RepoConfig & { automationConfirmed: boolean; automationRowExists: boolean }
+    >((res) => {
+      resolveConfirm = res;
+    });
+    mockPutRepoConfig.mockReturnValueOnce(confirmPromise);
+
+    const onsubmit = vi.fn().mockResolvedValue(undefined);
+    render(NewTask, { props: { onsubmit, initialRepoPath: repoPath } });
+
+    await expect.poll(() => document.querySelector(".plan-gate input")).toBeTruthy();
+    await fillPromptAndClickRun();
+
+    // Confirm step must appear
+    await expect.poll(() => document.querySelector(".ftac")).toBeTruthy();
+
+    // Find the Confirm button by its text content (it has no aria-label — text node only)
+    const confirmBtn = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(".ftac button"),
+    ).find((b) => b.textContent?.trim() === m.firsttask_confirm_cta())!;
+    // Click Confirm twice in rapid succession before the promise resolves
+    confirmBtn.click();
+    confirmBtn.click();
+
+    // Now resolve the confirm promise
+    resolveConfirm(confirmedRepoConfig());
+
+    // onsubmit must be called at most once (not twice)
+    await expect.poll(() => onsubmit.mock.calls.length, { timeout: 3000 }).toBe(1);
+    expect(onsubmit.mock.calls.length).toBe(1);
+  });
+
   it("settle race: ensure resolving to confirmed repo spawns directly with no spurious step", async () => {
     const repoPath = "/repo/ftac-settle-race";
 

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -1137,7 +1137,7 @@ describe("FirstTaskAutomationConfirm", () => {
     const onconfirm = vi.fn();
     const oncancel = vi.fn();
     render(FirstTaskAutomationConfirm, {
-      props: { repoPath: "/home/user/my-project", onconfirm, oncancel },
+      props: { active: true, repoPath: "/home/user/my-project", onconfirm, oncancel },
     });
 
     await expect.element(page.getByText(m.firsttask_confirm_title())).toBeInTheDocument();
@@ -1154,7 +1154,7 @@ describe("FirstTaskAutomationConfirm", () => {
     const onconfirm = vi.fn();
     const oncancel = vi.fn();
     render(FirstTaskAutomationConfirm, {
-      props: { repoPath: "/repo/test", onconfirm, oncancel },
+      props: { active: true, repoPath: "/repo/test", onconfirm, oncancel },
     });
 
     await page.getByRole("button", { name: m.firsttask_confirm_cta() }).click();
@@ -1166,7 +1166,7 @@ describe("FirstTaskAutomationConfirm", () => {
     const onconfirm = vi.fn();
     const oncancel = vi.fn();
     render(FirstTaskAutomationConfirm, {
-      props: { repoPath: "/repo/test", onconfirm, oncancel },
+      props: { active: true, repoPath: "/repo/test", onconfirm, oncancel },
     });
 
     await page.getByRole("button", { name: m.common_cancel() }).click();
@@ -1178,7 +1178,7 @@ describe("FirstTaskAutomationConfirm", () => {
     const onconfirm = vi.fn();
     const oncancel = vi.fn();
     render(FirstTaskAutomationConfirm, {
-      props: { repoPath: "/repo/test", onconfirm, oncancel, submitting: true },
+      props: { active: true, repoPath: "/repo/test", onconfirm, oncancel, submitting: true },
     });
 
     const confirmBtn = document.querySelector<HTMLButtonElement>(`button[disabled]`);

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -618,6 +618,7 @@
 
   async function confirmAndSpawn() {
     const repo = repoPath.trim();
+    error = null;
     try {
       await repoConfig.confirmAutomation(repo);
     } catch (err) {
@@ -633,7 +634,10 @@
   class="overlay"
   role="presentation"
   onclick={(e) => {
-    if (e.target === e.currentTarget) onclose?.();
+    if (e.target === e.currentTarget) {
+      confirmStep = false;
+      onclose?.();
+    }
   }}
 >
   <!-- The modal card is a <form> so the prompt submits natively; role="dialog"
@@ -647,7 +651,12 @@
     role="dialog"
     aria-modal="true"
     aria-label={heading}
-    use:dialog={{ onclose: () => onclose?.() }}
+    use:dialog={{
+      onclose: () => {
+        confirmStep = false;
+        onclose?.();
+      },
+    }}
     onsubmit={submit}
     onkeydown={onRepoShortcut}
     ondragover={(e) => {
@@ -665,8 +674,14 @@
            44px line with the ✕ instead of leaving an empty band above it. Hidden
            on desktop, where the stacked label in .repo-field shows instead. -->
       <label class="micro chead-repo" for="nt-repo">{m.newtask_repo_label()}</label>
-      <button type="button" class="x" onclick={() => onclose?.()} aria-label={m.common_close()}
-        >✕</button
+      <button
+        type="button"
+        class="x"
+        onclick={() => {
+          confirmStep = false;
+          onclose?.();
+        }}
+        aria-label={m.common_close()}>✕</button
       >
     </div>
 
@@ -674,8 +689,12 @@
       <FirstTaskAutomationConfirm
         repoPath={repoPath.trim()}
         {submitting}
+        {error}
         onconfirm={confirmAndSpawn}
-        oncancel={() => (confirmStep = false)}
+        oncancel={() => {
+          confirmStep = false;
+          error = null;
+        }}
       />
     {:else}
       <div class="repo-field" use:coachTarget={"nt-repo"}>

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -145,6 +145,9 @@
   let retry = $state<(() => void) | null>(null);
   // True while the first-task confirm step is shown (unconfirmed repo intercept)
   let confirmStep = $state(false);
+  // Carries the `force` flag (e.g. "Submit anyway" past a usage hold) across the confirm
+  // step so confirming a first-task repo replays the original intent, not a downgraded force=false.
+  let pendingForce = $state(false);
 
   function reason(e: unknown, fallback: string): string {
     const msg = e instanceof Error ? e.message.trim() : "";
@@ -610,6 +613,7 @@
       // Brand-new repo (no row) → seed the raised default posture (plan-gate ON) so the embedded
       // settings show it. Guarded by !automationRowExists so we never clobber an existing repo's toggles.
       if (!repoConfig.automationRowExists(repo)) await repoConfig.seedNewRepoDefaults(repo);
+      pendingForce = force; // replay the original force intent after confirmation
       confirmStep = true;
       return;
     }
@@ -632,7 +636,7 @@
     // doSpawn sets submitting=true at entry and resets it in its finally; since we
     // already set it true above, doSpawn must NOT bail on the guard — it sets it
     // unconditionally at entry so there is no double-true problem.
-    await doSpawn(false);
+    await doSpawn(pendingForce); // replay the force captured when the step opened
   }
 </script>
 

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -27,6 +27,7 @@
   import PromptSources from "./PromptSources.svelte";
   import SlashCommandMenu from "./SlashCommandMenu.svelte";
   import NewTaskRunSettings from "./new-task/NewTaskRunSettings.svelte";
+  import FirstTaskAutomationConfirm from "./FirstTaskAutomationConfirm.svelte";
   import { dialog } from "$lib/a11yDialog";
   import { repoConfig } from "$lib/reviews.svelte";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
@@ -142,6 +143,8 @@
   let error = $state<string | null>(null);
   // re-invokes whichever action last failed (upload or create) from an inline Retry
   let retry = $state<(() => void) | null>(null);
+  // True while the first-task confirm step is shown (unconfirmed repo intercept)
+  let confirmStep = $state(false);
 
   function reason(e: unknown, fallback: string): string {
     const msg = e instanceof Error ? e.message.trim() : "";
@@ -549,9 +552,7 @@
     e.stopPropagation();
   }
 
-  async function submit(e: Event, force = false) {
-    e.preventDefault();
-    if (!prompt.trim() || !repoPath.trim() || submitting) return;
+  async function doSpawn(force = false) {
     submitting = true;
     error = null;
     retry = null;
@@ -583,10 +584,10 @@
         // The page maps relaunch ApiError codes to localized messages before
         // throwing; render that verbatim, falling back to a generic relaunch error.
         error = reason(err, m.relaunch_failed());
-        retry = () => submit(e);
+        retry = () => doSpawn(force);
       } else {
         error = m.newtask_create_failed({ reason: reason(err, m.newtask_submit()) });
-        retry = () => submit(e);
+        retry = () => doSpawn(force);
       }
     } finally {
       // Clear submitting on every path. This only matters for the error path, where the
@@ -594,6 +595,37 @@
       // the success and held paths both close the dialog page-side, so it's harmless there.
       submitting = false;
     }
+  }
+
+  async function submit(e: Event, force = false) {
+    e.preventDefault();
+    if (!prompt.trim() || !repoPath.trim() || submitting) return;
+    const repo = repoPath.trim();
+    // Settle the repo config BEFORE reading confirm/rowExists — an in-flight fetch reads both falsy,
+    // which would spuriously show the step for a confirmed repo AND fail the !rowExists seed guard,
+    // clobbering an existing repo's plan-gate. ensure() is idempotent + populates the maps before it
+    // resolves. (Same settledness concern the inline plan-gate box handles via isConfigSettled.)
+    await repoConfig.ensure(repo);
+    if (!repoConfig.isAutomationConfirmed(repo)) {
+      // Brand-new repo (no row) → seed the raised default posture (plan-gate ON) so the embedded
+      // settings show it. Guarded by !automationRowExists so we never clobber an existing repo's toggles.
+      if (!repoConfig.automationRowExists(repo)) await repoConfig.seedNewRepoDefaults(repo);
+      confirmStep = true;
+      return;
+    }
+    await doSpawn(force);
+  }
+
+  async function confirmAndSpawn() {
+    const repo = repoPath.trim();
+    try {
+      await repoConfig.confirmAutomation(repo);
+    } catch (err) {
+      error = m.newtask_create_failed({ reason: reason(err, m.newtask_submit()) });
+      return; // stay on the step; do NOT spawn if the confirm PUT failed
+    }
+    confirmStep = false;
+    await doSpawn(false);
   }
 </script>
 
@@ -638,220 +670,237 @@
       >
     </div>
 
-    <div class="repo-field" use:coachTarget={"nt-repo"}>
-      <label class="micro" for="nt-repo">{m.newtask_repo_label()}</label>
-      <RepoSelect
-        bind:this={repoSelect}
-        {repos}
-        windowDays={recentRepoWindowDays}
-        value={repoPath}
-        onchange={(p) => (repoPath = p)}
-        {onclone}
-        {onfork}
-        {onnewproject}
-        onsync={handleSync}
-        onescape={() => promptInput?.focus()}
+    {#if confirmStep}
+      <FirstTaskAutomationConfirm
+        repoPath={repoPath.trim()}
+        {submitting}
+        onconfirm={confirmAndSpawn}
+        oncancel={() => (confirmStep = false)}
       />
-    </div>
+    {:else}
+      <div class="repo-field" use:coachTarget={"nt-repo"}>
+        <label class="micro" for="nt-repo">{m.newtask_repo_label()}</label>
+        <RepoSelect
+          bind:this={repoSelect}
+          {repos}
+          windowDays={recentRepoWindowDays}
+          value={repoPath}
+          onchange={(p) => (repoPath = p)}
+          {onclone}
+          {onfork}
+          {onnewproject}
+          onsync={handleSync}
+          onescape={() => promptInput?.focus()}
+        />
+      </div>
 
-    {#if !coarse.current}
-      <span class="hint repo-shortcuts-hint">
-        {m.newtask_repo_shortcuts_hint({ mod: isMac ? "⌥" : "Alt+" })}
-      </span>
-    {/if}
+      {#if !coarse.current}
+        <span class="hint repo-shortcuts-hint">
+          {m.newtask_repo_shortcuts_hint({ mod: isMac ? "⌥" : "Alt+" })}
+        </span>
+      {/if}
 
-    {#if relaunch}
-      <div class="relaunch-note">
-        <span>{m.newtask_relaunch_note()}</span>
-        {#if relaunchIssueNumber != null && repoPath !== initialRepoPath}
-          <span>{m.newtask_relaunch_issue_drop_note({ number: relaunchIssueNumber })}</span>
+      {#if relaunch}
+        <div class="relaunch-note">
+          <span>{m.newtask_relaunch_note()}</span>
+          {#if relaunchIssueNumber != null && repoPath !== initialRepoPath}
+            <span>{m.newtask_relaunch_issue_drop_note({ number: relaunchIssueNumber })}</span>
+          {/if}
+        </div>
+      {/if}
+
+      <label class="micro" for="nt-prompt">{m.newtask_prompt_label()}</label>
+      <div class="prompt-wrap">
+        <textarea
+          id="nt-prompt"
+          bind:this={promptInput}
+          bind:value={prompt}
+          data-1p-ignore
+          rows="3"
+          placeholder={m.newtask_prompt_placeholder()}
+          oninput={onPromptInput}
+          onkeydown={onPromptKeydown}
+          onblur={() => (slashOpen = false)}
+          required></textarea>
+        {#if slashOpen}
+          <SlashCommandMenu
+            commands={slashMatches}
+            activeIndex={slashIndex}
+            onpick={pickCommand}
+            onhover={(i) => (slashIndex = i)}
+          />
         {/if}
       </div>
-    {/if}
+      <div class="attach-row">
+        <button
+          type="button"
+          class="attach"
+          onclick={() => fileInput?.click()}
+          disabled={uploading}
+        >
+          {uploading ? m.newtask_uploading() : m.newtask_attach_image()}
+        </button>
+        <span class="hint">{m.newtask_drop_hint()}</span>
+      </div>
+      {#if relaunch}
+        <span class="hint attach-relaunch-note">{m.newtask_relaunch_image_note()}</span>
+      {/if}
+      <input
+        bind:this={fileInput}
+        type="file"
+        accept="image/*"
+        multiple
+        hidden
+        onchange={(e) => {
+          const t = e.currentTarget;
+          if (t.files) addFiles(t.files);
+          t.value = "";
+        }}
+      />
+      {#if images.length > 0}
+        <div class="chips">
+          {#each images as img (img.path)}
+            <span class="chip">
+              <span class="chip-name">{img.name}</span>
+              <button
+                type="button"
+                class="chip-x"
+                onclick={() => removeImage(img.path)}
+                aria-label={m.newtask_remove_image_aria()}>✕</button
+              >
+            </span>
+          {/each}
+        </div>
+      {/if}
 
-    <label class="micro" for="nt-prompt">{m.newtask_prompt_label()}</label>
-    <div class="prompt-wrap">
-      <textarea
-        id="nt-prompt"
-        bind:this={promptInput}
-        bind:value={prompt}
-        data-1p-ignore
-        rows="3"
-        placeholder={m.newtask_prompt_placeholder()}
-        oninput={onPromptInput}
-        onkeydown={onPromptKeydown}
-        onblur={() => (slashOpen = false)}
-        required></textarea>
-      {#if slashOpen}
-        <SlashCommandMenu
-          commands={slashMatches}
-          activeIndex={slashIndex}
-          onpick={pickCommand}
-          onhover={(i) => (slashIndex = i)}
+      {#if issueRef && !relaunch}
+        <div class="issue-ref">
+          <span class="issue-ref-label">{m.newtask_issue_attached_label()}</span>
+          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external GitHub URL -->
+          <a class="issue-ref-link" href={issueRef.url} target="_blank" rel="noopener"
+            >#{issueRef.number} {issueRef.title}</a
+          >
+          <button
+            type="button"
+            class="issue-ref-x"
+            onclick={() => (issueRef = null)}
+            aria-label={m.newtask_issue_remove_aria()}>✕</button
+          >
+        </div>
+      {/if}
+
+      {#if repoPath}
+        <PromptSources
+          {repoPath}
+          {epicParents}
+          {nativeSubIssues}
+          {epicsLoaded}
+          allowIssues={!relaunch}
+          onpick={(p) => {
+            prompt = p;
+            // resize, then land focus + caret at the end so a seeded command like
+            // "/merge-train " is immediately editable for args
+            queueMicrotask(() => {
+              autogrow();
+              promptInput?.focus();
+              promptInput?.setSelectionRange(prompt.length, prompt.length);
+            });
+          }}
+          onpickissue={pickIssue}
         />
       {/if}
-    </div>
-    <div class="attach-row">
-      <button type="button" class="attach" onclick={() => fileInput?.click()} disabled={uploading}>
-        {uploading ? m.newtask_uploading() : m.newtask_attach_image()}
-      </button>
-      <span class="hint">{m.newtask_drop_hint()}</span>
-    </div>
-    {#if relaunch}
-      <span class="hint attach-relaunch-note">{m.newtask_relaunch_image_note()}</span>
-    {/if}
-    <input
-      bind:this={fileInput}
-      type="file"
-      accept="image/*"
-      multiple
-      hidden
-      onchange={(e) => {
-        const t = e.currentTarget;
-        if (t.files) addFiles(t.files);
-        t.value = "";
-      }}
-    />
-    {#if images.length > 0}
-      <div class="chips">
-        {#each images as img (img.path)}
-          <span class="chip">
-            <span class="chip-name">{img.name}</span>
-            <button
-              type="button"
-              class="chip-x"
-              onclick={() => removeImage(img.path)}
-              aria-label={m.newtask_remove_image_aria()}>✕</button
-            >
-          </span>
-        {/each}
-      </div>
-    {/if}
 
-    {#if issueRef && !relaunch}
-      <div class="issue-ref">
-        <span class="issue-ref-label">{m.newtask_issue_attached_label()}</span>
-        <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external GitHub URL -->
-        <a class="issue-ref-link" href={issueRef.url} target="_blank" rel="noopener"
-          >#{issueRef.number} {issueRef.title}</a
+      <label class="micro" for="nt-base">{m.newtask_branch_label()}</label>
+      {#if branches.length > 0}
+        <select id="nt-base" bind:value={baseBranch}>
+          {#each baseOptions as b (b)}
+            <option value={b}>{b}</option>
+          {/each}
+        </select>
+      {:else}
+        <input id="nt-base" bind:value={baseBranch} placeholder={m.newtask_branch_placeholder()} />
+      {/if}
+      {#if upstreamLoading}
+        <span class="nt-upstream micro">{m.newtask_upstream_checking()}</span>
+      {:else if upstream?.diverged}
+        <span class="nt-upstream micro nt-upstream-warn">
+          {m.newtask_upstream_diverged({
+            behind: upstream.behind,
+            ahead: upstream.ahead,
+            base: baseBranch,
+          })}
+        </span>
+      {:else if upstream && upstream.behind > 0}
+        <span class="nt-upstream micro"
+          >{m.newtask_upstream_behind({ count: upstream.behind })}</span
         >
-        <button
-          type="button"
-          class="issue-ref-x"
-          onclick={() => (issueRef = null)}
-          aria-label={m.newtask_issue_remove_aria()}>✕</button
-        >
-      </div>
-    {/if}
+      {/if}
 
-    {#if repoPath}
-      <PromptSources
+      <NewTaskRunSettings
+        bind:planGate
+        bind:research
+        bind:autopilot
+        bind:model
+        bind:sandboxProfile
+        onPlanGateTouched={() => (planGateTouched = true)}
+        onAutopilotTouched={() => (autopilotTouched = true)}
+        onModelTouched={() => (modelTouched = true)}
+        {planGateLoading}
+        {autopilotLoading}
+        {autopilotDefault}
         {repoPath}
-        {epicParents}
-        {nativeSubIssues}
-        {epicsLoaded}
-        allowIssues={!relaunch}
-        onpick={(p) => {
-          prompt = p;
-          // resize, then land focus + caret at the end so a seeded command like
-          // "/merge-train " is immediately editable for args
-          queueMicrotask(() => {
-            autogrow();
-            promptInput?.focus();
-            promptInput?.setSelectionRange(prompt.length, prompt.length);
-          });
-        }}
-        onpickissue={pickIssue}
+        {relaunch}
+        {fableAvailable}
       />
-    {/if}
 
-    <label class="micro" for="nt-base">{m.newtask_branch_label()}</label>
-    {#if branches.length > 0}
-      <select id="nt-base" bind:value={baseBranch}>
-        {#each baseOptions as b (b)}
-          <option value={b}>{b}</option>
-        {/each}
-      </select>
-    {:else}
-      <input id="nt-base" bind:value={baseBranch} placeholder={m.newtask_branch_placeholder()} />
-    {/if}
-    {#if upstreamLoading}
-      <span class="nt-upstream micro">{m.newtask_upstream_checking()}</span>
-    {:else if upstream?.diverged}
-      <span class="nt-upstream micro nt-upstream-warn">
-        {m.newtask_upstream_diverged({
-          behind: upstream.behind,
-          ahead: upstream.ahead,
-          base: baseBranch,
-        })}
-      </span>
-    {:else if upstream && upstream.behind > 0}
-      <span class="nt-upstream micro">{m.newtask_upstream_behind({ count: upstream.behind })}</span>
-    {/if}
+      {#if error}
+        <div class="err" role="alert">
+          <span>{error}</span>
+          {#if retry}
+            <button type="button" class="retry" onclick={() => retry?.()}>{m.common_retry()}</button
+            >
+          {/if}
+        </div>
+      {/if}
 
-    <NewTaskRunSettings
-      bind:planGate
-      bind:research
-      bind:autopilot
-      bind:model
-      bind:sandboxProfile
-      onPlanGateTouched={() => (planGateTouched = true)}
-      onAutopilotTouched={() => (autopilotTouched = true)}
-      onModelTouched={() => (modelTouched = true)}
-      {planGateLoading}
-      {autopilotLoading}
-      {autopilotDefault}
-      {repoPath}
-      {relaunch}
-      {fableAvailable}
-    />
-
-    {#if error}
-      <div class="err" role="alert">
-        <span>{error}</span>
-        {#if retry}
-          <button type="button" class="retry" onclick={() => retry?.()}>{m.common_retry()}</button>
-        {/if}
-      </div>
-    {/if}
-
-    {#if holdLikely}
-      <div class="run-dual">
+      {#if holdLikely}
+        <div class="run-dual">
+          <button
+            class="run run-hold"
+            type="button"
+            disabled={submitting}
+            onclick={(e) => submit(e, false)}
+          >
+            <span>{submitting ? m.newtask_spawning() : m.newtask_hold_for_reset()}</span>
+          </button>
+          <button
+            class="run run-anyway"
+            type="button"
+            disabled={submitting}
+            onclick={(e) => submit(e, true)}
+          >
+            <span>{m.newtask_submit_anyway()}</span>
+          </button>
+        </div>
+      {:else}
         <button
-          class="run run-hold"
-          type="button"
+          class="run"
+          type="submit"
           disabled={submitting}
-          onclick={(e) => submit(e, false)}
+          title={coarse.current ? undefined : isMac ? "⌘ + Enter" : "Ctrl + Enter"}
         >
-          <span>{submitting ? m.newtask_spawning() : m.newtask_hold_for_reset()}</span>
+          <span
+            >{submitting
+              ? m.newtask_spawning()
+              : selectedRepoName
+                ? m.newtask_submit_in_repo({ repo: selectedRepoName })
+                : m.newtask_submit()}</span
+          >
+          {#if !submitting && !coarse.current}
+            <kbd class="kbd">{isMac ? "⌘↵" : "Ctrl+↵"}</kbd>
+          {/if}
         </button>
-        <button
-          class="run run-anyway"
-          type="button"
-          disabled={submitting}
-          onclick={(e) => submit(e, true)}
-        >
-          <span>{m.newtask_submit_anyway()}</span>
-        </button>
-      </div>
-    {:else}
-      <button
-        class="run"
-        type="submit"
-        disabled={submitting}
-        title={coarse.current ? undefined : isMac ? "⌘ + Enter" : "Ctrl + Enter"}
-      >
-        <span
-          >{submitting
-            ? m.newtask_spawning()
-            : selectedRepoName
-              ? m.newtask_submit_in_repo({ repo: selectedRepoName })
-              : m.newtask_submit()}</span
-        >
-        {#if !submitting && !coarse.current}
-          <kbd class="kbd">{isMac ? "⌘↵" : "Ctrl+↵"}</kbd>
-        {/if}
-      </button>
+      {/if}
     {/if}
   </form>
 </div>

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -608,8 +608,13 @@
     // which would spuriously show the step for a confirmed repo AND fail the !rowExists seed guard,
     // clobbering an existing repo's plan-gate. ensure() is idempotent + populates the maps before it
     // resolves. (Same settledness concern the inline plan-gate box handles via isConfigSettled.)
-    await repoConfig.ensure(repo);
-    if (!repoConfig.isAutomationConfirmed(repo)) {
+    // Only act on confirmed/rowExists when the fetch SUCCEEDED. On a transient GET failure
+    // ensure() leaves those maps unset (both read falsy), which would misdetect an existing
+    // confirmed repo as new — showing a spurious confirm step AND seeding planGateEnabled:true
+    // over a deliberate planGate=off. On failure we can't know the repo's state, so degrade to
+    // the prior behavior (spawn directly); the gate re-fires next task once the fetch lands.
+    const configLoaded = await repoConfig.ensure(repo);
+    if (configLoaded && !repoConfig.isAutomationConfirmed(repo)) {
       // Brand-new repo (no row) → seed the raised default posture (plan-gate ON) so the embedded
       // settings show it. Guarded by !automationRowExists so we never clobber an existing repo's toggles.
       if (!repoConfig.automationRowExists(repo)) await repoConfig.seedNewRepoDefaults(repo);

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -691,18 +691,18 @@
       >
     </div>
 
-    {#if confirmStep}
-      <FirstTaskAutomationConfirm
-        repoPath={repoPath.trim()}
-        {submitting}
-        {error}
-        onconfirm={confirmAndSpawn}
-        oncancel={() => {
-          confirmStep = false;
-          error = null;
-        }}
-      />
-    {:else}
+    <FirstTaskAutomationConfirm
+      active={confirmStep}
+      repoPath={repoPath.trim()}
+      {submitting}
+      {error}
+      onconfirm={confirmAndSpawn}
+      oncancel={() => {
+        confirmStep = false;
+        error = null;
+      }}
+    />
+    <div class="composer" class:hidden={confirmStep}>
       <div class="repo-field" use:coachTarget={"nt-repo"}>
         <label class="micro" for="nt-repo">{m.newtask_repo_label()}</label>
         <RepoSelect
@@ -926,11 +926,19 @@
           {/if}
         </button>
       {/if}
-    {/if}
+    </div>
   </form>
 </div>
 
 <style>
+  /* Boxless wrapper for the compose body — display:contents passes flex layout
+     straight through to children so the card's column gap is undisturbed. */
+  .composer {
+    display: contents;
+  }
+  .composer.hidden {
+    display: none;
+  }
   .overlay {
     position: fixed;
     inset: 0;

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -617,15 +617,21 @@
   }
 
   async function confirmAndSpawn() {
-    const repo = repoPath.trim();
+    if (submitting) return;
+    submitting = true;
     error = null;
+    const repo = repoPath.trim();
     try {
       await repoConfig.confirmAutomation(repo);
     } catch (err) {
       error = m.newtask_create_failed({ reason: reason(err, m.newtask_submit()) });
+      submitting = false; // re-enable so the user can retry
       return; // stay on the step; do NOT spawn if the confirm PUT failed
     }
     confirmStep = false;
+    // doSpawn sets submitting=true at entry and resets it in its finally; since we
+    // already set it true above, doSpawn must NOT bail on the guard — it sets it
+    // unconditionally at entry so there is no double-true problem.
     await doSpawn(false);
   }
 </script>

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1464,4 +1464,15 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_review_inflight_body",
     targetId: "review-inflight",
   },
+  {
+    // First task for a new repo now shows an inline confirm step in the New Task dialog
+    // so users can review and adjust automation settings before the first spawn. The repo
+    // is seeded with plan-gate ON. Subsequent tasks on the same repo spawn silently.
+    // No targetId — the confirm step is transient (shown only once per repo); no
+    // persistently-mounted anchor for a coachmark. v1.36.0 → ships in 1.37.0.
+    id: "first-task-confirm",
+    sinceVersion: "1.37.0",
+    titleKey: "feat_first_task_confirm_title",
+    bodyKey: "feat_first_task_confirm_body",
+  },
 ];

--- a/ui/src/lib/reviews.svelte.test.ts
+++ b/ui/src/lib/reviews.svelte.test.ts
@@ -68,6 +68,8 @@ beforeEach(() => {
   repoConfig.maxAuto = {};
   repoConfig.autoLabel = {};
   repoConfig.usageCeiling = {};
+  repoConfig.confirmed = {};
+  repoConfig.rowExists = {};
   vi.clearAllMocks();
 });
 
@@ -521,4 +523,63 @@ test("repoConfig.toggleAutoOptimize reverts on error", async () => {
   repoConfig.autoOptimize = { "/repo": true };
   await repoConfig.toggleAutoOptimize("/repo");
   expect(repoConfig.autoOptimizeOn("/repo")).toBe(true); // reverted to prev
+});
+
+// ── automationConfirmed / automationRowExists (issue #1025) ────────────────
+
+test("repoConfig.isAutomationConfirmed defaults to false for unknown repo", () => {
+  expect(repoConfig.isAutomationConfirmed("/unknown")).toBe(false);
+});
+
+test("repoConfig.automationRowExists defaults to false for unknown repo", () => {
+  expect(repoConfig.automationRowExists("/unknown")).toBe(false);
+});
+
+test("ensure ingests automationConfirmed and automationRowExists from response", async () => {
+  vi.mocked(getRepoConfig).mockResolvedValue({
+    ...rc(),
+    automationConfirmed: true,
+    automationRowExists: true,
+  });
+  await repoConfig.ensure("/repo");
+  expect(repoConfig.isAutomationConfirmed("/repo")).toBe(true);
+  expect(repoConfig.automationRowExists("/repo")).toBe(true);
+});
+
+test("ensure: response WITHOUT the new fields does NOT clobber already-set confirmed/rowExists", async () => {
+  // Pre-seed the maps as if a previous fetch had set them
+  repoConfig.confirmed = { "/repo": true };
+  repoConfig.rowExists = { "/repo": true };
+  // Force a re-fetch by clearing `enabled` (ensure bails early if enabled is set)
+  repoConfig.enabled = {};
+  vi.mocked(getRepoConfig).mockResolvedValue(rc()); // no automationConfirmed / automationRowExists
+  await repoConfig.ensure("/repo");
+  // maps must NOT be clobbered to false/undefined
+  expect(repoConfig.isAutomationConfirmed("/repo")).toBe(true);
+  expect(repoConfig.automationRowExists("/repo")).toBe(true);
+});
+
+test("seedNewRepoDefaults calls putRepoConfig with planGateEnabled:true and sets planGate true", async () => {
+  vi.mocked(putRepoConfig).mockResolvedValue(rc({ planGateEnabled: true }));
+  await repoConfig.seedNewRepoDefaults("/repo");
+  expect(putRepoConfig).toHaveBeenCalledWith("/repo", { planGateEnabled: true });
+  expect(repoConfig.isPlanGateEnabled("/repo")).toBe(true);
+});
+
+test("confirmAutomation calls putRepoConfig with automationConfirmed:true and sets confirmed true", async () => {
+  vi.mocked(putRepoConfig).mockResolvedValue({
+    ...rc(),
+    automationConfirmed: true,
+    automationRowExists: true,
+  });
+  await repoConfig.confirmAutomation("/repo");
+  expect(putRepoConfig).toHaveBeenCalledWith("/repo", { automationConfirmed: true });
+  expect(repoConfig.isAutomationConfirmed("/repo")).toBe(true);
+});
+
+test("confirmAutomation reverts confirmed and rethrows on PUT failure", async () => {
+  repoConfig.confirmed = { "/repo": false };
+  vi.mocked(putRepoConfig).mockRejectedValueOnce(new Error("network error"));
+  await expect(repoConfig.confirmAutomation("/repo")).rejects.toThrow("network error");
+  expect(repoConfig.isAutomationConfirmed("/repo")).toBe(false); // reverted
 });

--- a/ui/src/lib/reviews.svelte.ts
+++ b/ui/src/lib/reviews.svelte.ts
@@ -212,15 +212,21 @@ class RepoConfigStore {
     this.settled = { ...this.settled, [repoPath]: true };
   }
 
-  async ensure(repoPath: string) {
+  /** Returns whether the config is actually available (loaded now or already cached).
+   *  False means the fetch FAILED and the per-repo maps are unset — callers that act on
+   *  confirmed/rowExists (e.g. the first-task seed/confirm gate) must NOT treat that as a
+   *  genuine "new repo", or a transient GET failure would mis-seed an existing repo. */
+  async ensure(repoPath: string): Promise<boolean> {
     if (repoPath in this.enabled) {
       this.markSettled(repoPath); // already-loaded ⇒ settled
-      return;
+      return true;
     }
     try {
       this.ingest(repoPath, await getRepoConfig(repoPath));
+      return true;
     } catch {
       /* leave unset; UI shows defaults optimistically */
+      return false;
     } finally {
       // mark settled on every exit (success AND failure) so a failed fetch never
       // wedges the UI in a loading state — it falls back to defaults instead.

--- a/ui/src/lib/reviews.svelte.ts
+++ b/ui/src/lib/reviews.svelte.ts
@@ -1,5 +1,6 @@
 import type { ReviewVerdict, PlanGate, RepoConfig, SandboxProfile } from "./types";
 import type { AutomationFlags } from "./components/git-rail-automation";
+import type { RepoConfigResponse } from "./api";
 import {
   getReviews,
   getReviewingIds,
@@ -171,13 +172,15 @@ class RepoConfigStore {
   maxAuto = $state<Record<string, number>>({}); // max concurrent auto sessions (default 1)
   autoLabel = $state<Record<string, string>>({}); // label used to pick drain issues (default "shepherd:auto")
   usageCeiling = $state<Record<string, number>>({}); // usage % ceiling before pausing drain (default 80)
+  confirmed = $state<Record<string, boolean>>({}); // automation reviewed+confirmed for this repo (issue #1025)
+  rowExists = $state<Record<string, boolean>>({}); // a repo_config row exists server-side
   // repoPaths whose ensure() fetch has resolved (success OR failure). Distinct from
   // "has a value": a failed fetch leaves the per-field maps unset yet must count as
   // settled so the UI stops showing a loading state and falls back to defaults.
   settled = $state<Record<string, boolean>>({});
 
-  /** Spread a fetched RepoConfig into every per-field $state map for `repoPath`. */
-  private ingest(repoPath: string, c: RepoConfig) {
+  /** Spread a fetched RepoConfigResponse into every per-field $state map for `repoPath`. */
+  private ingest(repoPath: string, c: RepoConfigResponse) {
     this.enabled = { ...this.enabled, [repoPath]: c.criticEnabled };
     this.allPrs = { ...this.allPrs, [repoPath]: c.criticAllPrs };
     this.autoAddress = { ...this.autoAddress, [repoPath]: c.autoAddressEnabled };
@@ -196,6 +199,10 @@ class RepoConfigStore {
     this.maxAuto = { ...this.maxAuto, [repoPath]: c.maxAuto };
     this.autoLabel = { ...this.autoLabel, [repoPath]: c.autoLabel };
     this.usageCeiling = { ...this.usageCeiling, [repoPath]: c.usageCeilingPct };
+    if (c.automationConfirmed !== undefined)
+      this.confirmed = { ...this.confirmed, [repoPath]: c.automationConfirmed };
+    if (c.automationRowExists !== undefined)
+      this.rowExists = { ...this.rowExists, [repoPath]: c.automationRowExists };
   }
 
   /** Idempotently mark a repo's config as settled; no-op (no reactive write) if it
@@ -522,6 +529,38 @@ class RepoConfigStore {
 
   usageCeilingFor(repoPath: string): number {
     return this.usageCeiling[repoPath] ?? 80;
+  }
+
+  isAutomationConfirmed(repoPath: string): boolean {
+    return this.confirmed[repoPath] ?? false;
+  }
+
+  automationRowExists(repoPath: string): boolean {
+    return this.rowExists[repoPath] ?? false;
+  }
+
+  /** Seed a brand-new repo with the raised default posture (plan-gate ON). Only call when no
+   *  repo_config row exists yet — guarded by automationRowExists() at the call site (Task 3) — so it
+   *  never clobbers an existing repo's planGate choice. */
+  async seedNewRepoDefaults(repoPath: string) {
+    const prev = this.planGate[repoPath];
+    this.planGate = { ...this.planGate, [repoPath]: true }; // optimistic
+    await this.apply(repoPath, { planGateEnabled: true }, () => {
+      this.planGate = { ...this.planGate, [repoPath]: prev };
+    });
+  }
+
+  /** Mark this repo's automation as reviewed+confirmed (issue #1025). PUT returns the wrapped
+   *  response; ingest() updates the confirmed/rowExists maps from it. */
+  async confirmAutomation(repoPath: string) {
+    const prev = this.confirmed[repoPath];
+    this.confirmed = { ...this.confirmed, [repoPath]: true }; // optimistic
+    try {
+      this.ingest(repoPath, await putRepoConfig(repoPath, { automationConfirmed: true }));
+    } catch (e) {
+      this.confirmed = { ...this.confirmed, [repoPath]: prev };
+      throw e; // surface to the caller so the spawn doesn't proceed on a failed confirm
+    }
   }
 }
 export const repoConfig = new RepoConfigStore();


### PR DESCRIPTION
Closes #1025.

## Problem

The **first task on a repo Shepherd has never driven** silently accepts the conservative default automation config — and the defaults are conservative (critic ON, learnings ON, everything else OFF, **including plan-gate**). Nothing nudges a first-time-on-this-repo operator to look at what's on/off, so you can start an autonomous run without the discipline you assumed was active.

## What this does

On the **first interactive task spawn for a repo**, the New Task flow now shows a **blocking review-and-confirm step** before the task spawns. The operator consciously reviews (and can adjust) the full automation config once per repo; after that one confirmation, subsequent tasks spawn silently using the saved per-repo settings (no repeated nagging).

Brand-new repos also get a **safer default posture**: **plan-gate is seeded ON** (on top of the existing critic ON + learnings ON), so the safe path is the default. The operator can still turn it off in the same step.

### How it works
- **Detection** — a nullable `automationConfirmedAt` column on `repo_config`. A repo is "already confirmed" when that column is set **OR** a prior session exists for the repo path. A one-time, restart-safe migration backfills all existing rows as confirmed, so established repos never see the step.
- **Server** — `GET`/`PUT /api/repo-config` now return an identical wrapped shape `{…RepoConfig, automationConfirmed, automationRowExists}`; `PUT` accepts `{automationConfirmed: true}` (destructured out before the config merge, applied via a dedicated `markAutomationConfirmed` setter — never written onto `RepoConfig`).
- **UI** — a new `FirstTaskAutomationConfirm` step renders **inline inside New Task's existing `aria-modal` dialog** (no second scrim/focus-trap — design-system rule), embedding the existing `AutomationSettings` groups. The submit handler awaits `repoConfig.ensure()` (settle-race guard) before deciding, seeds plan-gate ON only for genuinely new repos (`!automationRowExists`, so an existing repo's toggles are never clobbered), then gates Run on confirmation. Confirm marks the repo confirmed then spawns; Cancel/close returns to the form.
- **Discovery** — adds the feature-catalog entry (`first-task-confirm`, `sinceVersion 1.37.0`) + EN/DE keys for the What's-New drawer.

## Deliberate deviations (flagged per house rules)

- **Detection vs the issue's literal "no automation row" wording.** Detection keys on *session-OR-confirmedAt*, not strictly "no `repo_config` row". So a post-feature repo that has a row but no session and was never confirmed (e.g. someone toggled a setting in the backlog panel but never spawned) still gets the step once on its first spawn. This is intentional and benign — that operator hasn't *confirmed* anything yet — and the seed is guarded by `!automationRowExists`, so their existing toggles are never re-seeded.
- **Scope boundary: interactive New Task only.** The confirm step gates the interactive spawn, where a human is present to confirm. It does **not** intercept auto-drain / programmatic spawns (those can't block on a human confirm). Enabling auto-drain is itself done from the AutomationPanel with all settings visible, so it's a conscious act — this is a documented boundary, not a claim that auto-drain can't precede the step.
- **Incidental dead-code removal.** Removed `getUsageHistory` from `ui/src/lib/api.ts` (+ its now-unused import). It has had zero callers since #991 removed the `/usage` route; the fallow audit gate surfaced it once this branch touched `api.ts`. The `UsageHistoryResponse` type in `types.ts` is untouched (still used by the Usage components/tests).

## Verification

- Root: `bun run lint`, `bunx tsc --noEmit`, `bun test ./test` (4598 pass / 0 fail).
- UI: `bun run check` (0/0), `check:i18n` (EN/DE parity), `bun run test` (1996 pass), `bun run build`.
- PR-hygiene gates: branch-hygiene, feature-catalog, glossary, and the fallow delta audit (0 dead-code / 0 complexity findings) all green.
- New tests cover: the migration (one-time, restart-safe backfill), `isAutomationConfirmed` truth table, flag-only PUT acceptance, GET≡PUT shape (toggle doesn't un-confirm), the non-clobber ingest guard, `confirmAutomation` reject/revert, the settle-race guard, confirm-failure error surfacing, and the double-spawn guard.

Built subagent-driven (implementer + spec/quality review per task, broad whole-branch review at the end). The whole-branch review caught and fixed a double-spawn race on the Confirm button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
