### PR TITLE
feat(spawn): pull issue comments into a task spawned from an issue

### DIFF
--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -8,6 +8,7 @@ import type {
   ForgeConfig,
   GitForge,
   Issue,
+  IssueComment,
   MergeInput,
   MergeMethod,
   MergeStateStatus,
@@ -266,6 +267,35 @@ export class GithubForge implements GitForge {
     } catch {
       return null;
     }
+  }
+
+  async listIssueComments(issueNumber: number): Promise<IssueComment[]> {
+    // `gh issue view <n> --json comments` returns the thread oldest-first. authorAssociation
+    // rides in the same payload (no extra call) so the spawn filter can scope to repo-standing
+    // authors. Parse mirrors listPrComments.
+    const out = await this.run([
+      "issue",
+      "view",
+      String(issueNumber),
+      "--repo",
+      this.slug,
+      "--json",
+      "comments",
+    ]);
+    const parsed = JSON.parse(out || "{}") as {
+      comments?: {
+        author?: { login?: string } | null;
+        authorAssociation?: string | null;
+        body?: string | null;
+        createdAt?: string | null;
+      }[];
+    };
+    return (parsed.comments ?? []).map((c) => ({
+      author: c.author?.login ?? "",
+      authorAssociation: c.authorAssociation ?? "NONE",
+      body: c.body ?? "",
+      createdAt: c.createdAt ? Date.parse(c.createdAt) : 0,
+    }));
   }
 
   async listPullRequests(): Promise<PullRequest[]> {

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -42,6 +42,13 @@ export const AUTHOR_RESPONSE_MARKER = "<!-- shepherd-author-note -->";
  *  rebase it onto the base branch. Posted by the dependabot-rebase endpoint. */
 export const DEPENDABOT_REBASE_COMMAND = "@dependabot rebase";
 
+/** Invisible marker appended to every issue-log comment Shepherd authors (the
+ *  ⏸️ waiting / ✅ merged workflow notes). Lets a task spawned from that issue
+ *  filter Shepherd's own machine chatter back out of the comment thread it feeds
+ *  to the agent — they're posted under the operator's gh identity (so not `[bot]`)
+ *  and would otherwise read as discussion. HTML comments don't render in GitHub's UI. */
+export const SHEPHERD_ISSUE_LOG_MARKER = "<!-- shepherd-issue-log -->";
+
 /** One issue comment on a PR (author responses to review rounds). */
 export interface PrComment {
   /** Host-stable comment id, used to inject each author note into the critic exactly
@@ -49,6 +56,19 @@ export interface PrComment {
    *  comment on every re-review. Empty when the host can't supply one. */
   id: string;
   author: string;
+  body: string;
+  createdAt: number; // epoch ms
+}
+
+/** One comment on an issue (the human discussion that refines the original request),
+ *  fed into a task spawned from that issue alongside the body. `authorAssociation` is
+ *  GitHub's per-comment relationship enum (OWNER | MEMBER | COLLABORATOR | CONTRIBUTOR |
+ *  FIRST_TIME_CONTRIBUTOR | FIRST_TIMER | MANNEQUIN | NONE), used to scope the included
+ *  comments to repo-standing authors — bounding the prompt-injection surface, which would
+ *  otherwise widen from the single issue author to any GitHub commenter. */
+export interface IssueComment {
+  author: string;
+  authorAssociation: string;
   body: string;
   createdAt: number; // epoch ms
 }
@@ -375,6 +395,12 @@ export interface GitForge {
    *  null when the issue is gone/unreadable. Best-effort and optional — hosts without it
    *  (or a transient failure → null) fall back to the cached candidate set + local dedup. */
   getIssue?(issueNumber: number): Promise<Issue | null>;
+  /** Issue comments (oldest first), fed into a task spawned from the issue so the
+   *  agent sees the discussion that refined the request, not just the body. Optional:
+   *  only hosts with a comments API (GitHub) implement it; others omit it and the spawn
+   *  prompt stays body-only. Best-effort — the caller wraps the call so a failure never
+   *  blocks or fails a spawn. */
+  listIssueComments?(issueNumber: number): Promise<IssueComment[]>;
   /** Open a new issue (capture-extension delivery path). Returns the created
    *  issue's number + URL. Optional: hosts without an issue-create API omit it
    *  and POST /api/issues 400s. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -261,10 +261,17 @@ const recapService = new RecapService({
 // forward-reference `let`.
 const agentIngressState: { port: number | undefined } = { port: undefined };
 
+// Mode-aware forge resolution: lightweight repos get a LocalForge; forge repos
+// get the memoized detectForge result (git shell-out). repoMode is read per call
+// (cheap PK lookup) so a runtime toggle takes effect without a restart. Defined before
+// the service so create() can pull an attached issue's comments at spawn (composePromptArg).
+const resolveForge = makeProductionForgeResolver(store, config.forges);
+
 const service = new SessionService({
   store,
   worktree,
   herdr,
+  resolveForge,
   agentIngressPort: () => agentIngressState.port,
   detectEgressHostLoopback,
   namer: generateName,
@@ -375,11 +382,6 @@ const sweepOrphanTabs = () => {
 setTimeout(sweepOrphanTabs, 5_000);
 setTimeout(sweepOrphanTabs, 45_000);
 setInterval(sweepOrphanTabs, 60 * 60 * 1000);
-
-// Mode-aware forge resolution: lightweight repos get a LocalForge; forge repos
-// get the memoized detectForge result (git shell-out). repoMode is read per call
-// (cheap PK lookup) so a runtime toggle takes effect without a restart.
-const resolveForge = makeProductionForgeResolver(store, config.forges);
 
 const tailscaleServe = new TailscaleServeService({
   base: config.previewPortBase,

--- a/src/issue-log.ts
+++ b/src/issue-log.ts
@@ -1,3 +1,4 @@
+import { SHEPHERD_ISSUE_LOG_MARKER } from "./forge/types";
 import type { GitForge, GitState } from "./forge/types";
 import type { Session } from "./types";
 
@@ -44,13 +45,21 @@ export function issueLogEntries(
   // opt-in to explicitly-configured roles (see module doc).
   if (git.state === "open" && git.checks === "success" && git.handoff && !git.handoffInferred) {
     const key = `waiting:${git.number}`;
-    if (!alreadyLogged(key)) out.push({ key, body: waitingBody(git, git.number) });
+    if (!alreadyLogged(key)) out.push({ key, body: stamp(waitingBody(git, git.number)) });
   }
   if (git.state === "merged") {
     const key = `merged:${git.number}`;
-    if (!alreadyLogged(key)) out.push({ key, body: `✅ PR #${git.number} merged.` });
+    if (!alreadyLogged(key)) out.push({ key, body: stamp(`✅ PR #${git.number} merged.`) });
   }
   return out;
+}
+
+/** Append the invisible issue-log marker so a task later spawned from this issue can
+ *  filter Shepherd's own workflow notes out of the comment thread it feeds the agent.
+ *  Appended (not prepended) so the leading wording stays intact for the spawn filter's
+ *  pre-marker wording fallback (and for human readers of the issue timeline). */
+function stamp(body: string): string {
+  return `${body}\n\n${SHEPHERD_ISSUE_LOG_MARKER}`;
 }
 
 /** The "waiting" comment wording. Only reached for a non-inferred (explicitly

--- a/src/service.ts
+++ b/src/service.ts
@@ -65,7 +65,8 @@ import {
   type EgressBackend,
 } from "./egress";
 import type { EgressWatcher } from "./egress-watch";
-import type { GitState } from "./forge/types";
+import { SHEPHERD_ISSUE_LOG_MARKER } from "./forge/types";
+import type { GitForge, GitState, IssueComment } from "./forge/types";
 
 /** Post-archive late-credit await window: after a merge-train session archives,
  *  its completion-tracker entry waits this long for a poller-gated late merge to
@@ -141,6 +142,10 @@ export interface ServiceDeps {
   /** Hard cap on the beforeArchive hook (ms) so a stuck git can never permanently stall
    *  teardown / the merge train. Defaults to 15_000; tests inject a tiny value. */
   beforeArchiveTimeoutMs?: number;
+  /** Resolve the forge for a repo, used at spawn to pull an attached issue's comment
+   *  thread into the prompt (see composePromptArg). Absent (tests) or a host without
+   *  listIssueComments → the spawn prompt stays body-only. */
+  resolveForge?: (repoPath: string) => GitForge | null;
 }
 
 /**
@@ -872,6 +877,81 @@ type SpawnSuccess = {
 };
 type SpawnOutcome = SpawnSuccess | { ok: false; holdReason: string };
 
+/** Total char budget for the issue-comment block appended to a spawn prompt. Generous —
+ *  comments ride out-of-band like the body, so they don't count against the 8000-char
+ *  human-prompt guard; this only bounds a runaway thread from bloating the agent's context. */
+export const ISSUE_COMMENTS_CHAR_BUDGET = 50_000;
+
+/** Author associations trusted to appear in a spawned task's prompt — accounts with standing
+ *  on the repo. Comments from anyone else (CONTRIBUTOR / NONE / first-timers) are dropped:
+ *  the issue body has a single (operator-vetted) author, but comments can come from any GitHub
+ *  user, so this scopes the included set and bounds the prompt-injection surface. */
+const TRUSTED_COMMENT_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+
+/** True when a comment is one of Shepherd's own issue-log workflow notes: marker-tagged
+ *  (current) or matching the pre-marker wording (historical notes posted under the operator's
+ *  gh identity — not [bot] and lacking the marker). The wording test is intentionally narrow
+ *  (emoji-prefixed, Shepherd-specific) so it won't swallow genuine human comments. */
+function isShepherdIssueLogNote(body: string): boolean {
+  if (body.includes(SHEPHERD_ISSUE_LOG_MARKER)) return true;
+  const t = body.trimStart();
+  return t.startsWith("⏸️ Waiting on") || /^✅ PR #\d+ merged/.test(t);
+}
+
+/** Render one comment with an author + date header and EVERY body line blockquoted, so a
+ *  multi-line comment stays visually fenced from the next. */
+function renderIssueComment(c: IssueComment): string {
+  const who = c.author ? `@${c.author}` : "unknown";
+  const when = c.createdAt ? new Date(c.createdAt).toISOString().slice(0, 10) : "";
+  const header = when ? `Comment by ${who} (${when}):` : `Comment by ${who}:`;
+  const quoted = c.body
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((l) => `> ${l}`)
+    .join("\n");
+  return `${header}\n${quoted}`;
+}
+
+/**
+ * Build the out-of-band issue-comment block appended to a task spawned from an issue.
+ * Filters Shepherd's own workflow notes, [bot] authors, and untrusted-authorship comments;
+ * keeps the NEWEST comments within ISSUE_COMMENTS_CHAR_BUDGET (issue threads put the refined
+ * decision at the end), rendered chronologically with each body line blockquoted. When the
+ * budget drops older comments, a leading note names how many (and which end) were omitted.
+ * Returns "" when nothing survives the filter. Pure + exported for tests.
+ */
+export function composeIssueCommentsBlock(issueNumber: number, comments: IssueComment[]): string {
+  const kept = comments.filter(
+    (c) =>
+      c.body.trim().length > 0 &&
+      !c.author.endsWith("[bot]") &&
+      TRUSTED_COMMENT_ASSOCIATIONS.has(c.authorAssociation) &&
+      !isShepherdIssueLogNote(c.body),
+  );
+  if (kept.length === 0) return "";
+  const chrono = [...kept].sort((a, b) => a.createdAt - b.createdAt);
+  const rendered = chrono.map(renderIssueComment);
+  // Walk newest→oldest, accumulating until the next comment would overflow the budget; the
+  // newest is always kept (even if it alone exceeds the budget). firstKeptIdx then doubles as
+  // the dropped (oldest) count.
+  let used = 0;
+  let firstKeptIdx = rendered.length;
+  for (let i = rendered.length - 1; i >= 0; i--) {
+    const cost = (rendered[i]?.length ?? 0) + 2; // +2 ≈ the "\n\n" join between blocks
+    if (used + cost > ISSUE_COMMENTS_CHAR_BUDGET && firstKeptIdx < rendered.length) break;
+    used += cost;
+    firstKeptIdx = i;
+  }
+  const dropped = firstKeptIdx;
+  const lines: string[] = [`GitHub Issue #${issueNumber} comments:`];
+  if (dropped > 0)
+    lines.push(
+      `[${dropped} of ${chrono.length} comments omitted — oldest comments dropped to fit size budget]`,
+    );
+  lines.push(...rendered.slice(firstKeptIdx));
+  return lines.join("\n\n");
+}
+
 export class SessionService {
   constructor(private deps: ServiceDeps) {}
 
@@ -921,11 +1001,13 @@ export class SessionService {
   >();
 
   /**
-   * Build the human-turn prompt: the user's text plus any attached images and the
-   * issue body, both appended out-of-band so they never count against the
-   * 8000-char human-prompt guard (the same approach for each).
+   * Build the human-turn prompt: the user's text plus any attached images, the issue
+   * body, and the issue's comment thread — all appended out-of-band so they never count
+   * against the 8000-char human-prompt guard (the same approach for each). The comment
+   * thread is the human discussion that refined the original request; fetching it is
+   * best-effort (see fetchIssueCommentsBlock) so a spawn never fails on comments.
    */
-  private composePromptArg(input: CreateSessionInput, worktreePath: string): string {
+  private async composePromptArg(input: CreateSessionInput, worktreePath: string): Promise<string> {
     let promptArg = input.prompt;
     if (input.images.length > 0) {
       const move = this.deps.moveUploads ?? moveStagedIntoWorktree;
@@ -935,8 +1017,27 @@ export class SessionService {
     if (input.issueRef) {
       const r = input.issueRef;
       promptArg = `${promptArg}\n\nGitHub Issue #${r.number}: ${r.title}\n${r.url}\n\n${r.body}`;
+      const comments = await this.fetchIssueCommentsBlock(input.repoPath, r.number);
+      if (comments) promptArg = `${promptArg}\n\n${comments}`;
     }
     return promptArg;
+  }
+
+  /** Best-effort fetch + compose of an attached issue's comment thread. Any missing forge,
+   *  a host without listIssueComments, or a fetch/parse error → "" so the spawn proceeds
+   *  body-only; a comment fetch must never block or fail a spawn. */
+  private async fetchIssueCommentsBlock(repoPath: string, issueNumber: number): Promise<string> {
+    try {
+      const forge = this.deps.resolveForge?.(repoPath);
+      if (!forge?.listIssueComments) return "";
+      const comments = await forge.listIssueComments(issueNumber);
+      return composeIssueCommentsBlock(issueNumber, comments);
+    } catch (err) {
+      console.warn(
+        `[service] listIssueComments failed for issue #${issueNumber} in ${repoPath}: ${(err as Error)?.message ?? String(err)}`,
+      );
+      return "";
+    }
   }
 
   /** trimDecision via the injected plugin-id seam (tests) or the real memoized read —
@@ -1414,7 +1515,7 @@ export class SessionService {
       // before the store row exists — the store.create() call below receives this id explicitly.
       const sessionId = randomUUID();
 
-      const promptArg = this.composePromptArg(input, wt.worktreePath);
+      const promptArg = await this.composePromptArg(input, wt.worktreePath);
       const repoConfig = this.deps.store.getRepoConfig(input.repoPath);
       // Plan gate (#348): when on, spawn into a PLANNING phase with a grill directive that
       // suppresses autopilot — interactive grills a present human, auto (drain) just writes the

--- a/test/issue-comments.test.ts
+++ b/test/issue-comments.test.ts
@@ -1,0 +1,135 @@
+import { test, expect } from "bun:test";
+import { composeIssueCommentsBlock, ISSUE_COMMENTS_CHAR_BUDGET } from "../src/service";
+import { GithubForge } from "../src/forge/github";
+import { SHEPHERD_ISSUE_LOG_MARKER } from "../src/forge/types";
+import type { IssueComment } from "../src/forge/types";
+
+function c(over: Partial<IssueComment> = {}): IssueComment {
+  return {
+    author: "alice",
+    authorAssociation: "MEMBER",
+    body: "looks good",
+    createdAt: Date.parse("2026-06-20T00:00:00Z"),
+    ...over,
+  };
+}
+
+// ── composeIssueCommentsBlock (pure) ──────────────────────────────────────────
+
+test("empty / all-filtered → empty string", () => {
+  expect(composeIssueCommentsBlock(7, [])).toBe("");
+  // only bots + untrusted + Shepherd notes → nothing survives
+  expect(
+    composeIssueCommentsBlock(7, [
+      c({ author: "dependabot[bot]" }),
+      c({ authorAssociation: "NONE" }),
+      c({ body: `⏸️ Waiting on @x to merge PR #7.` }),
+    ]),
+  ).toBe("");
+});
+
+test("renders trusted human comments chronologically with a header", () => {
+  const block = composeIssueCommentsBlock(42, [
+    c({ author: "bob", body: "second", createdAt: Date.parse("2026-06-21T00:00:00Z") }),
+    c({ author: "alice", body: "first", createdAt: Date.parse("2026-06-20T00:00:00Z") }),
+  ]);
+  expect(block).toBe(
+    [
+      "GitHub Issue #42 comments:",
+      "Comment by @alice (2026-06-20):\n> first",
+      "Comment by @bob (2026-06-21):\n> second",
+    ].join("\n\n"),
+  );
+});
+
+test("blockquotes EVERY line of a multi-line body, not just the first", () => {
+  const block = composeIssueCommentsBlock(1, [c({ body: "line one\nline two\nline three" })]);
+  expect(block).toContain("> line one\n> line two\n> line three");
+});
+
+test("drops [bot] authors", () => {
+  const block = composeIssueCommentsBlock(1, [
+    c({ author: "dependabot[bot]", body: "bump dep" }),
+    c({ author: "alice", body: "real" }),
+  ]);
+  expect(block).toContain("real");
+  expect(block).not.toContain("bump dep");
+});
+
+test("scopes to repo-standing authorAssociation (drops NONE / CONTRIBUTOR)", () => {
+  const block = composeIssueCommentsBlock(1, [
+    c({ author: "owner", authorAssociation: "OWNER", body: "owner-says" }),
+    c({ author: "collab", authorAssociation: "COLLABORATOR", body: "collab-says" }),
+    c({ author: "rando", authorAssociation: "NONE", body: "rando-says" }),
+    c({ author: "drive", authorAssociation: "CONTRIBUTOR", body: "drive-says" }),
+  ]);
+  expect(block).toContain("owner-says");
+  expect(block).toContain("collab-says");
+  expect(block).not.toContain("rando-says");
+  expect(block).not.toContain("drive-says");
+});
+
+test("filters Shepherd's own notes via the marker (current) and wording (pre-marker)", () => {
+  const block = composeIssueCommentsBlock(1, [
+    c({ body: `✅ PR #7 merged.\n\n${SHEPHERD_ISSUE_LOG_MARKER}` }), // marker-tagged
+    c({ body: "⏸️ Waiting on @scoop to merge PR #7." }), // pre-marker wording
+    c({ body: "genuine human note" }),
+  ]);
+  expect(block).toContain("genuine human note");
+  expect(block).not.toContain("merged");
+  expect(block).not.toContain("Waiting on");
+});
+
+test("oversized thread keeps the NEWEST and names the dropped (oldest) end", () => {
+  const big = "x".repeat(ISSUE_COMMENTS_CHAR_BUDGET); // each comment alone ~ the whole budget
+  const comments = [
+    c({ author: "a", body: `OLDEST ${big}`, createdAt: Date.parse("2026-06-20T00:00:00Z") }),
+    c({ author: "b", body: `MIDDLE ${big}`, createdAt: Date.parse("2026-06-21T00:00:00Z") }),
+    c({ author: "c", body: `NEWEST ${big}`, createdAt: Date.parse("2026-06-22T00:00:00Z") }),
+  ];
+  const block = composeIssueCommentsBlock(9, comments);
+  expect(block).toContain("NEWEST");
+  expect(block).not.toContain("OLDEST");
+  expect(block).toContain("2 of 3 comments omitted — oldest comments dropped to fit size budget");
+});
+
+test("handles a missing author / createdAt without throwing", () => {
+  const block = composeIssueCommentsBlock(1, [c({ author: "", createdAt: 0, body: "anon note" })]);
+  expect(block).toContain("Comment by unknown:");
+  expect(block).toContain("> anon note");
+});
+
+// ── GithubForge.listIssueComments (parse) ─────────────────────────────────────
+
+test("listIssueComments parses gh JSON incl. authorAssociation", async () => {
+  const runner = async (args: string[]) => {
+    expect(args).toEqual(["issue", "view", "5", "--repo", "o/r", "--json", "comments"]);
+    return JSON.stringify({
+      comments: [
+        {
+          author: { login: "alice" },
+          authorAssociation: "MEMBER",
+          body: "hi",
+          createdAt: "2026-06-20T10:00:00Z",
+        },
+        { author: null, body: "anon" }, // missing fields default safely
+      ],
+    });
+  };
+  const forge = new GithubForge("o/r", {}, runner);
+  const comments = await forge.listIssueComments(5);
+  expect(comments).toEqual([
+    {
+      author: "alice",
+      authorAssociation: "MEMBER",
+      body: "hi",
+      createdAt: Date.parse("2026-06-20T10:00:00Z"),
+    },
+    { author: "", authorAssociation: "NONE", body: "anon", createdAt: 0 },
+  ]);
+});
+
+test("listIssueComments tolerates empty output", async () => {
+  const forge = new GithubForge("o/r", {}, async () => "");
+  expect(await forge.listIssueComments(1)).toEqual([]);
+});

--- a/test/issue-log.test.ts
+++ b/test/issue-log.test.ts
@@ -1,9 +1,14 @@
 import { test, expect, mock } from "bun:test";
 import { issueLogEntries, createIssueLogger } from "../src/issue-log";
 import { SessionStore } from "../src/store";
+import { SHEPHERD_ISSUE_LOG_MARKER } from "../src/forge/types";
 import type { GitState } from "../src/forge/types";
 
 const never = () => false;
+
+// Every issue-log body carries the invisible marker so a task spawned from the issue can
+// filter Shepherd's own workflow notes back out of the comment thread it feeds the agent.
+const stamped = (body: string) => `${body}\n\n${SHEPHERD_ISSUE_LOG_MARKER}`;
 
 function open(over: Partial<GitState> = {}): GitState {
   return {
@@ -20,22 +25,33 @@ function open(over: Partial<GitState> = {}): GitState {
 
 test("open+green+reviewer handoff → one waiting entry naming the reviewer", () => {
   const e = issueLogEntries(open({ handoff: "reviewer", handoffWho: "scoop" }), never);
-  expect(e).toEqual([{ key: "waiting:7", body: "⏸️ Waiting on review of PR #7 by @scoop." }]);
+  expect(e).toEqual([
+    { key: "waiting:7", body: stamped("⏸️ Waiting on review of PR #7 by @scoop.") },
+  ]);
 });
 
 test("open+green+merger handoff → one waiting entry naming the merger", () => {
   const e = issueLogEntries(open({ handoff: "merger", handoffWho: "scoop" }), never);
-  expect(e).toEqual([{ key: "waiting:7", body: "⏸️ Waiting on @scoop to merge PR #7." }]);
+  expect(e).toEqual([{ key: "waiting:7", body: stamped("⏸️ Waiting on @scoop to merge PR #7.") }]);
 });
 
 test("handoff without a login → generic waiting wording", () => {
   const e = issueLogEntries(open({ handoff: "merger" }), never);
-  expect(e).toEqual([{ key: "waiting:7", body: "⏸️ Waiting on PR #7 to merge." }]);
+  expect(e).toEqual([{ key: "waiting:7", body: stamped("⏸️ Waiting on PR #7 to merge.") }]);
 });
 
 test("merged → one merged entry, phrased issue-state-agnostic", () => {
   const e = issueLogEntries(open({ state: "merged" }), never);
-  expect(e).toEqual([{ key: "merged:7", body: "✅ PR #7 merged." }]);
+  expect(e).toEqual([{ key: "merged:7", body: stamped("✅ PR #7 merged.") }]);
+});
+
+test("every authored body carries the invisible issue-log marker", () => {
+  const waiting = issueLogEntries(open({ handoff: "merger", handoffWho: "scoop" }), never);
+  const merged = issueLogEntries(open({ state: "merged" }), never);
+  expect(waiting[0]?.body).toContain(SHEPHERD_ISSUE_LOG_MARKER);
+  expect(merged[0]?.body).toContain(SHEPHERD_ISSUE_LOG_MARKER);
+  // marker is appended, not prepended — leading wording stays intact for the spawn filter
+  expect(waiting[0]?.body.startsWith("⏸️ Waiting on")).toBe(true);
 });
 
 test("auto-inferred handoff (no roles.json) → NO waiting entry (gated to configured roles)", () => {
@@ -44,7 +60,7 @@ test("auto-inferred handoff (no roles.json) → NO waiting entry (gated to confi
   // the SAME state without the inferred flag (configured) → comments as before
   const configured = open({ handoff: "merger", handoffWho: "scoop" });
   expect(issueLogEntries(configured, never)).toEqual([
-    { key: "waiting:7", body: "⏸️ Waiting on @scoop to merge PR #7." },
+    { key: "waiting:7", body: stamped("⏸️ Waiting on @scoop to merge PR #7.") },
   ]);
 });
 
@@ -86,7 +102,7 @@ test("posts the owed comment once, stamps it, and never re-posts", async () => {
   const git = open({ handoff: "merger", handoffWho: "scoop" });
   await log(session, git);
   await log(session, git); // flap / restart replay
-  expect(comment.mock.calls).toEqual([[42, "⏸️ Waiting on @scoop to merge PR #7."]]);
+  expect(comment.mock.calls).toEqual([[42, stamped("⏸️ Waiting on @scoop to merge PR #7.")]]);
   expect(store.hasIssueLog("s1", "waiting:7")).toBe(true);
 });
 

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -953,6 +953,106 @@ test("createSession: appends the issueRef body out-of-band, keeps the stored pro
   expect(store.get(s.id)?.prompt).toBe("fix it");
 });
 
+test("createSession: appends the issue's comment thread after the body when the forge has it", async () => {
+  const store = new SessionStore(":memory:");
+  const calls: any = {};
+  const service = new SessionService({
+    store,
+    namer: async () => "repo-x",
+    worktree: {
+      ensureBaseRef: async () => {},
+      branchExists: () => false,
+      create: () => ({ worktreePath: "/wt/x", branch: "shepherd/x", isolated: true }),
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: (_n: string, _c: string, argv: string[]) => {
+        calls.argv = argv;
+        return { terminalId: "t", cwd: "/wt/x", agentStatus: "working" };
+      },
+      list: () => [],
+    } as any,
+    resolveForge: () =>
+      ({
+        listIssueComments: async () => [
+          {
+            author: "alice",
+            authorAssociation: "MEMBER",
+            body: "cap the retry at 3",
+            createdAt: Date.parse("2026-06-20T00:00:00Z"),
+          },
+        ],
+      }) as any,
+  });
+
+  await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "fix it",
+    model: null,
+    images: [],
+    issueRef: {
+      number: 42,
+      url: "https://github.com/o/r/issues/42",
+      title: "Soft-delete users",
+      body: "the long issue body",
+    },
+  });
+
+  expect(calls.argv[calls.argv.length - 1]).toBe(
+    "fix it\n\nGitHub Issue #42: Soft-delete users\nhttps://github.com/o/r/issues/42\n\nthe long issue body" +
+      "\n\nGitHub Issue #42 comments:\n\nComment by @alice (2026-06-20):\n> cap the retry at 3",
+  );
+});
+
+test("createSession: a throwing listIssueComments degrades to a body-only prompt (never fails the spawn)", async () => {
+  const store = new SessionStore(":memory:");
+  const calls: any = {};
+  const service = new SessionService({
+    store,
+    namer: async () => "repo-x",
+    worktree: {
+      ensureBaseRef: async () => {},
+      branchExists: () => false,
+      create: () => ({ worktreePath: "/wt/x", branch: "shepherd/x", isolated: true }),
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: (_n: string, _c: string, argv: string[]) => {
+        calls.argv = argv;
+        return { terminalId: "t", cwd: "/wt/x", agentStatus: "working" };
+      },
+      list: () => [],
+    } as any,
+    resolveForge: () =>
+      ({
+        listIssueComments: async () => {
+          throw new Error("gh boom");
+        },
+      }) as any,
+  });
+
+  const s = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "fix it",
+    model: null,
+    images: [],
+    issueRef: {
+      number: 42,
+      url: "https://github.com/o/r/issues/42",
+      title: "Soft-delete users",
+      body: "the long issue body",
+    },
+  });
+
+  // spawn succeeded, prompt is exactly the body-only assembly
+  expect(s.id).toBeTruthy();
+  expect(calls.argv[calls.argv.length - 1]).toBe(
+    "fix it\n\nGitHub Issue #42: Soft-delete users\nhttps://github.com/o/r/issues/42\n\nthe long issue body",
+  );
+});
+
 test("createSession: persists auto=true and issueNumber from issueRef.number", async () => {
   const store = new SessionStore(":memory:");
   const service = new SessionService({


### PR DESCRIPTION
## What

Spawning a task from a GitHub issue now pulls in the issue's **comment thread** — the human discussion that refines the original request — not just the issue body.

## Why

Issues evolve in their comments: scope gets narrowed, decisions get made, edge cases get raised. Feeding the agent only the body discards all of that, so it works from a stale picture of the task.

## How

- **Single source.** Comments are fetched server-side in `SessionService.create()` → `composePromptArg()`, the one path that auto-drain, manual *New Task from issue*, and relaunch all funnel through. Appended **out-of-band** after the body (like images/body today), so they never count against the 8000-char human-prompt guard.
- **Forge layer.** New `GitForge.listIssueComments` (`gh issue view <n> --json comments`) + `IssueComment` type. Optional — hosts without it (Gitea/local) stay body-only.
- **Human discussion only.** The filter drops:
  - **Shepherd's own issue-log notes** — via a new invisible `SHEPHERD_ISSUE_LOG_MARKER` appended to authored `⏸️/✅` notes going forward, **plus** an `⏸️ Waiting`/`✅ PR # merged` wording fallback for pre-marker historical notes (posted under the operator's gh identity, so not `[bot]`).
  - **`[bot]` authors** (dependabot, etc.).
  - **Untrusted authorship** — keeps only `authorAssociation ∈ {OWNER, MEMBER, COLLABORATOR}`. The body has one operator-vetted author; comments can come from any commenter, so this scopes the included set and bounds the prompt-injection surface.
- **Newest-kept cap.** Issue threads put the refined decision at the END, so when the thread exceeds a 50k-char budget the **most recent** comments are kept; a leading note names how many (and which end) were dropped. Every body line is blockquoted.
- **Best-effort.** A missing forge/method or a fetch error degrades to the existing body-only prompt — a comment fetch can never block or fail a spawn.

## Tests

- `composeIssueCommentsBlock`: bot/association/marker/wording filtering, chronological order, multi-line per-line `>` quoting, newest-kept truncation + omitted-count note, empty → "".
- `GithubForge.listIssueComments` parse (incl. `authorAssociation`, empty output).
- `issue-log`: marker present on authored bodies (existing exact-body assertions updated).
- `create()`: appends the thread when the forge has it; degrades to body-only when `listIssueComments` throws.
- Full root suite green (4610 pass); lint + tsc clean; fallow delta audit clean.

## Notes

- Server-only plumbing, no UI surface → feature-catalog exempt (`[no-feature-entry]`).
- The comment block is agent-prompt content (English, like PR bodies) → not i18n'd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)