### PR TITLE
fix(pre-push): terminate linter argv with `--` to block flag smuggling (#1035)

### DIFF
--- a/scripts/pre-push.ts
+++ b/scripts/pre-push.ts
@@ -404,8 +404,8 @@ function buildLanes(
           {
             label: "prettier --check (delta)",
             cmd: "bunx",
-            // `--` terminator: `opts.changed` is raw git diff output, so a
-            // dash-leading filename here is the one LIVE flag-smuggling exposure.
+            // `--` terminator: dash-leading paths are already dropped upstream by
+            // `isSafePath` in `changedFiles`; this is the second layer guarding the spread.
             args: withFileArgs(["prettier", "--check", "--ignore-unknown"], opts.changed),
             cwd: repoRoot,
           },

--- a/scripts/pre-push.ts
+++ b/scripts/pre-push.ts
@@ -72,6 +72,26 @@ export function routeEslintFiles(changed: string[]): { root: string[]; ext: stri
 }
 
 /**
+ * Guard against argv flag smuggling: a file whose name begins with `-` (e.g.
+ * `--config`, `-rf`) would be parsed as an OPTION rather than a path if spread
+ * into a linter's argv. We never lint such a path, so drop it at the source.
+ */
+export function isSafePath(f: string): boolean {
+  return !f.startsWith("-");
+}
+
+/**
+ * Assemble a tool argv with a `--` option terminator before a spread file list,
+ * so a dash-leading filename can't smuggle a flag into prettier/eslint. Verified
+ * empirically that bunx forwards the first `--` and both binaries honor a bare
+ * `--` (prettier v3, eslint v10). See `changedFiles`/`isSafePath` for the
+ * upstream defense-in-depth layer.
+ */
+export function withFileArgs(flags: string[], files: string[]): string[] {
+  return [...flags, "--", ...files];
+}
+
+/**
  * Bound the AGGREGATE worker count, not just the lane count. Several lanes each
  * spawn multi-worker tools (vitest ×2, chromium, `bun test`); running them all
  * unbounded oversubscribes a modest box. Cap lane fan-out scaled to cores, then
@@ -314,7 +334,7 @@ function changedFiles(repoRoot: string): string[] {
     .split("\n")
     .map((f) => f.trim())
     .filter(Boolean)
-    .filter((f) => existsSync(join(repoRoot, f)));
+    .filter((f) => isSafePath(f) && existsSync(join(repoRoot, f)));
 }
 
 // ── Lane assembly + main ──────────────────────────────────────────────────────
@@ -384,7 +404,9 @@ function buildLanes(
           {
             label: "prettier --check (delta)",
             cmd: "bunx",
-            args: ["prettier", "--check", "--ignore-unknown", ...opts.changed],
+            // `--` terminator: `opts.changed` is raw git diff output, so a
+            // dash-leading filename here is the one LIVE flag-smuggling exposure.
+            args: withFileArgs(["prettier", "--check", "--ignore-unknown"], opts.changed),
             cwd: repoRoot,
           },
         ],
@@ -413,14 +435,17 @@ function buildLanes(
       steps.push({
         label: "eslint root (delta)",
         cmd: "bunx",
-        args: ["eslint", "--no-error-on-unmatched-pattern", ...routed.root],
+        // `--` terminator: defense-in-depth — `routeEslintFiles` only admits
+        // `src/`/`test/`/`ui/src/`-prefixed paths, so these can't be dash-leading.
+        args: withFileArgs(["eslint", "--no-error-on-unmatched-pattern"], routed.root),
         cwd: repoRoot,
       });
     if (routed.ext.length)
       steps.push({
         label: "eslint extension (delta)",
         cmd: "bunx",
-        args: ["eslint", "--no-error-on-unmatched-pattern", ...routed.ext],
+        // `--` terminator: defense-in-depth — routed paths are `extension/src/`-prefixed.
+        args: withFileArgs(["eslint", "--no-error-on-unmatched-pattern"], routed.ext),
         cwd: ext,
       });
     if (steps.length) lanes.push({ name: "eslint", timeoutMs: t(120_000), steps });

--- a/test/pre-push.test.ts
+++ b/test/pre-push.test.ts
@@ -2,9 +2,11 @@ import { test, expect } from "bun:test";
 import {
   computeConcurrency,
   isEslintFile,
+  isSafePath,
   plannedLaneCount,
   routeEslintFiles,
   runLanes,
+  withFileArgs,
   type LaneHandle,
   type LaneSpec,
   type StepResult,
@@ -35,6 +37,31 @@ test("routeEslintFiles: ui/src→root, extension/src→ext(relative), paraglide+
   expect(root).toEqual(["src/server.ts", "test/foo.test.ts", "ui/src/lib/components/Foo.svelte"]);
   // extension files are returned relative to extension/ (eslint runs with cwd=extension)
   expect(ext).toEqual(["src/recorder.ts"]);
+});
+
+test("isSafePath: rejects dash-leading paths (argv flag-smuggling guard)", () => {
+  expect(isSafePath("src/server.ts")).toBe(true);
+  expect(isSafePath("ui/src/lib/-weird.ts")).toBe(true); // dash mid-path is fine
+  expect(isSafePath("-rf")).toBe(false);
+  expect(isSafePath("--config")).toBe(false);
+  expect(isSafePath("--check-foo.js")).toBe(false);
+});
+
+test("withFileArgs: inserts a `--` terminator before the spread file list", () => {
+  expect(withFileArgs(["prettier", "--check", "--ignore-unknown"], ["-rf", "src/a.ts"])).toEqual([
+    "prettier",
+    "--check",
+    "--ignore-unknown",
+    "--",
+    "-rf",
+    "src/a.ts",
+  ]);
+  // empty file list still terminates options (harmless; no dash-file can slip through)
+  expect(withFileArgs(["eslint", "--no-error-on-unmatched-pattern"], [])).toEqual([
+    "eslint",
+    "--no-error-on-unmatched-pattern",
+    "--",
+  ]);
 });
 
 test("computeConcurrency: laneCap scales with cores and laneCap×maxWorkers ≤ cores", () => {


### PR DESCRIPTION
Closes #1035.

## Problem

`scripts/pre-push.ts` spread git-derived file paths directly into `prettier`/`eslint` argv with **no `--` option terminator**. A repo file whose name begins with `-` (e.g. `--config`, `-rf`) would be parsed as a flag rather than a path, smuggling an arbitrary option into the linter invocation. Flagged MEDIUM by automated security review; pre-existing on `main`.

## Fix

Two layers, both routed through small **pure exported helpers** (so they ship tested, with no side effects):

- **`withFileArgs(flags, files)` → `[...flags, "--", ...files]`** — the real fix. Used at the three delta argv sites:
  - **prettier** (`...opts.changed`) — the only *live* exposure: raw `git diff` output, so a real dash-leading filename can reach it.
  - **eslint root / ext** (`...routed.root` / `...routed.ext`) — *defense-in-depth*: `routeEslintFiles` only admits `src/`/`test/`/`ui/src/`/`extension/src/`-prefixed paths, which can never be dash-leading. `--` added for uniformity (noted in code comments).
- **`isSafePath(f)` → `!f.startsWith("-")`** — added to the `changedFiles()` filter, dropping dash-leading paths at the source (belt-and-suspenders).

`buildLanes` is deliberately **not** exported/tested — it calls `mkdtempSync` unconditionally and would leak a temp dir per test invocation; the pure helpers carry the regression guards instead.

## Verification

`bunx` `--` forwarding **and** bare-`--` terminator support verified **independently** for each binary (different parsers):

- **prettier v3:** `bunx prettier --check --ignore-unknown -- '--check-foo.js'` → treated as a path (`[warn] --check-foo.js`).
- **eslint v10.5.0:** `bunx eslint --no-error-on-unmatched-pattern -- scripts/pre-push.ts` → exit 0 (bare `--` honored, lane does not break); `-- '--rf.ts'` → exit 0; control without `--` → `Invalid option '--rf'`.

Pure unit tests for `withFileArgs` (`--` placement) and `isSafePath` (dash rejection) added to `test/pre-push.test.ts`. `bun run lint`, `bunx tsc --noEmit`, and the full root suite (4621 pass) all green; pre-push hook passed on push.

No behavior change for legitimate paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)