### PR TITLE
fix(epic): never close integrated epic child out-of-band on merged-PR teardown (#1037)

### DIFF
--- a/src/automerge.ts
+++ b/src/automerge.ts
@@ -43,7 +43,13 @@ const MERGE_ERROR_BACKOFF_MS = 300_000;
 export interface AutoMergeDeps {
   store: Pick<
     SessionStore,
-    "get" | "list" | "getRepoConfig" | "getReview" | "setAutoMergeState" | "setAutopilotState"
+    | "get"
+    | "list"
+    | "getRepoConfig"
+    | "getReview"
+    | "setAutoMergeState"
+    | "setAutopilotState"
+    | "isEpicIntegratedChild"
   >;
   service: {
     archive(id: string): Promise<number>;
@@ -303,6 +309,10 @@ export class AutoMergeService {
       dropPrCache: this.deps.dropPrCache,
       emitArchived: this.deps.emitArchived,
       retainClaim: this.deps.retainClaim,
+      // #1037: defense-in-depth — never close an integrated epic child out of band here either.
+      isIntegratedEpicChild: (sess) =>
+        sess.issueNumber != null &&
+        this.deps.store.isEpicIntegratedChild(sess.repoPath, sess.issueNumber),
     });
     return true;
   }

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -116,6 +116,7 @@ export interface DrainDeps {
     | "setEpicRun"
     | "getOrInitEpicIntegrationBranch"
     | "listEpicIntegrated"
+    | "isEpicIntegratedChild"
     | "recordEpicIntegrated"
     | "listEpicIntegratedDetails"
     | "recordEpicCompleted"
@@ -1084,10 +1085,12 @@ export class DrainService {
       // recoverable, not a permanent strand: we deliberately do NOT dropPrCache/emit below, so the
       // session stays live AND polled (pr-poller skips only archived rows). The poller re-observes
       // the merged PR and settles it via reapMerged → settleMergedSession (archive + teardown) —
-      // the same path any out-of-band merge takes. That recovery closes the child issue instead of
-      // keeping it open, but the integration is already recorded above, so dependents unblock
-      // either way. The session can NOT be re-selected by the retire gate (readyToRetire requires
-      // state==="open"; the PR is merged), hence the poller is the recovery, not a retry.
+      // the same path any out-of-band merge takes. #1037: because the integration is already
+      // recorded above, settleMergedSession's isIntegratedEpicChild guard sees this child as
+      // integrated and ARCHIVES-ONLY (never closes the issue) — so this recovery keeps the child
+      // open until the landing PR merges, just like the happy path. The session can NOT be
+      // re-selected by the retire gate (readyToRetire requires state==="open"; the PR is merged),
+      // hence the poller is the recovery, not a retry.
       console.warn(
         `[drain] archive (epic child) failed for ${decision.sessionId}; pr-poller will reap the merged PR:`,
         err,
@@ -1333,6 +1336,10 @@ export class DrainService {
       dropPrCache: this.deps.dropPrCache,
       emitArchived: this.deps.emitArchived,
       retainClaim: (sid) => this.retainClaimOnArchive.add(sid),
+      // #1037: an integrated epic child observed merged mid-archive must archive-only, never close.
+      isIntegratedEpicChild: (sess) =>
+        sess.issueNumber != null &&
+        this.deps.store.isEpicIntegratedChild(sess.repoPath, sess.issueNumber),
     });
   }
 

--- a/src/merge-teardown.ts
+++ b/src/merge-teardown.ts
@@ -11,6 +11,11 @@ export interface MergeTeardownDeps {
   emitArchived: (id: string) => void;
   /** Mark the session so onArchived KEEPS its claim label (issue still open). */
   retainClaim: (id: string) => void;
+  /** #1037: true when this session's issue is an integrated epic child (its PR already
+   *  squash-merged into the epic's integration branch). Such a child must NEVER be closed
+   *  out of band here — its issue closes only when the landing PR merges into the default
+   *  branch. When true we archive + retain the claim and skip `closeIssue` entirely. */
+  isIntegratedEpicChild: (s: Session) => boolean;
 }
 
 /**
@@ -22,6 +27,18 @@ export interface MergeTeardownDeps {
  */
 export async function settleMergedSession(s: Session, deps: MergeTeardownDeps): Promise<void> {
   let closed = false;
+  // #1037: an integrated epic child is closed ONLY by the landing-PR merge (Closes #N into the
+  // default branch). The merge here landed it into the integration branch, so closing now —
+  // whether on a poller-observed merge mid-archive (the race) or on the archive-failure recovery
+  // path — would close the child out of band, violating that invariant. Archive + retain the
+  // claim (the still-open issue's label is what stops a re-spawn) and skip closeIssue entirely.
+  if (s.auto && s.issueNumber != null && deps.isIntegratedEpicChild(s)) {
+    deps.retainClaim(s.id);
+    await deps.archive(s.id);
+    deps.dropPrCache(s.id);
+    deps.emitArchived(s.id);
+    return;
+  }
   if (s.auto && s.issueNumber != null) {
     const forge = deps.resolveForge(s.repoPath);
     // Gate on the method existing: a forge without closeIssue leaves the issue

--- a/src/server.ts
+++ b/src/server.ts
@@ -2391,6 +2391,10 @@ async function forgeMerge(
       dropPrCache: (id) => deps.prCache?.drop(id),
       emitArchived: (id) => deps.events.emit("session:archived", { id }),
       retainClaim: (id) => deps.drain?.retainClaim(id),
+      // #1037: never close an integrated epic child out of band on the local-merge path either.
+      isIntegratedEpicChild: (sess) =>
+        sess.issueNumber != null &&
+        deps.store.isEpicIntegratedChild(sess.repoPath, sess.issueNumber),
     });
     return json({ ...cur, state: "merged" as const });
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1174,6 +1174,19 @@ export class SessionStore implements CapStore, CreditStore {
     return new Set(rows.map((r) => r.childNumber));
   }
 
+  /** True when this issue was already squash-merged into an epic's integration branch (#1037).
+   *  Single source of truth for "this is an integrated epic child" — the merged-PR teardown path
+   *  consults it to ARCHIVE-ONLY (never `closeIssue`) such a child, keeping the invariant that an
+   *  epic child closes only when the landing PR merges into the default branch. Keyed by
+   *  (repoPath, childNumber): a child belongs to exactly one epic per repo. */
+  isEpicIntegratedChild(repoPath: string, childNumber: number): boolean {
+    return (
+      this.db
+        .query(`SELECT 1 FROM epic_integrated WHERE repoPath = ? AND childNumber = ? LIMIT 1`)
+        .get(repoPath, childNumber) != null
+    );
+  }
+
   /** All integrated child rows for one epic, with PR details and mergedAt timestamp. */
   listEpicIntegratedDetails(
     repoPath: string,

--- a/test/automerge.test.ts
+++ b/test/automerge.test.ts
@@ -31,6 +31,7 @@ function deps(over: Partial<AutoMergeDeps> = {}): AutoMergeDeps {
       getReview: () => null,
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
+      isEpicIntegratedChild: () => false,
     } as any,
     service: {
       archive: mock(() => 1),
@@ -195,6 +196,7 @@ test("multi-session: merges ready A then steers rebase for behind B", async () =
       getReview: () => null,
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
+      isEpicIntegratedChild: () => false,
     } as any,
     service: { archive, reply, resume: mock(() => true), resolveMerging: mock(() => {}) } as any,
     resolveForge: () =>
@@ -264,6 +266,7 @@ test("rebase_cap: behind session at cap → no reply steer, emitStatus rebase_ca
       getReview: () => null,
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
+      isEpicIntegratedChild: () => false,
     } as any,
     worktree: { behindBase: async () => true } as any,
     service: {
@@ -300,6 +303,7 @@ test("reset-on-progress: behind=false + mergeable=true → rebaseCount reset to 
       getReview: () => null,
       setAutoMergeState: setState,
       setAutopilotState: mock(() => {}),
+      isEpicIntegratedChild: () => false,
     } as any,
     worktree: { behindBase: async () => false } as any,
     resolveForge: () =>
@@ -334,6 +338,7 @@ test("reset-on-progress NEGATIVE: behind=false + mergeable=false → counter NOT
       getReview: () => null,
       setAutoMergeState: setState,
       setAutopilotState: mock(() => {}),
+      isEpicIntegratedChild: () => false,
     } as any,
     worktree: { behindBase: async () => false } as any,
     // PR is open+green but mergeable=false (conflict)
@@ -407,6 +412,7 @@ test("tick: skips repo with no full-auto session (no merge/steer)", async () => 
       getReview: () => null,
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
+      isEpicIntegratedChild: () => false,
     } as any,
     resolveForge: () =>
       ({
@@ -446,6 +452,7 @@ test("per-session override true + repo default false → merges (repoHasFullAuto
       getReview: () => null,
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
+      isEpicIntegratedChild: () => false,
     } as any,
     resolveForge: () =>
       ({ kind: "github", mergeMethod: "squash", merge, closeIssue: mock(async () => {}) }) as any,
@@ -482,6 +489,7 @@ test("rebase outstanding: same head not re-steered / not re-bumped on a second p
       getReview: () => null,
       setAutoMergeState: setState as any,
       setAutopilotState: mock(() => {}),
+      isEpicIntegratedChild: () => false,
     } as any,
     worktree: { behindBase: async () => true } as any,
     service: {
@@ -531,6 +539,7 @@ test("merge-error backoff: after CAP failures the stuck PR is skipped, a ready s
       getReview: () => null,
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
+      isEpicIntegratedChild: () => false,
     } as any,
     resolveForge: () => forge as any,
     service: {
@@ -583,6 +592,7 @@ test("status payload carries sessionId on rebase_cap hold", async () => {
       getReview: () => null,
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
+      isEpicIntegratedChild: () => false,
     } as any,
     worktree: { behindBase: async () => true } as any,
     emitStatus,
@@ -609,6 +619,7 @@ test("rebase steer references origin/<baseBranch> from the session", async () =>
       getReview: () => null,
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
+      isEpicIntegratedChild: () => false,
     } as any,
     worktree: { behindBase: async () => true } as any,
     service: {

--- a/test/merge-teardown.test.ts
+++ b/test/merge-teardown.test.ts
@@ -8,6 +8,7 @@ function deps(over: Partial<MergeTeardownDeps> = {}): MergeTeardownDeps {
     dropPrCache: mock(() => {}),
     emitArchived: mock(() => {}),
     retainClaim: mock(() => {}),
+    isIntegratedEpicChild: () => false,
     ...over,
   };
 }
@@ -30,6 +31,18 @@ test("closeIssue throws → retain claim (issue still open)", async () => {
   });
   await settleMergedSession({ id: "s1", auto: true, issueNumber: 9, repoPath: "/r" } as any, d);
   expect((d.retainClaim as any).mock.calls).toEqual([["s1"]]);
+  expect((d.archive as any).mock.calls.length).toBe(1);
+});
+
+test("integrated epic child: archives + retains claim, NEVER closes the issue (#1037)", async () => {
+  const close = mock(async () => {});
+  const d = deps({
+    resolveForge: () => ({ closeIssue: close }) as any,
+    isIntegratedEpicChild: () => true,
+  });
+  await settleMergedSession({ id: "s1", auto: true, issueNumber: 12, repoPath: "/r" } as any, d);
+  expect(close.mock.calls.length).toBe(0); // close reserved for the landing PR merge
+  expect((d.retainClaim as any).mock.calls).toEqual([["s1"]]); // still-open issue must not re-spawn
   expect((d.archive as any).mock.calls.length).toBe(1);
 });
 

--- a/test/server-prs.test.ts
+++ b/test/server-prs.test.ts
@@ -53,7 +53,7 @@ function fakeForge(over: Partial<GitForge> = {}): GitForge {
 
 function makeDeps(resolveForge: AppDeps["resolveForge"]): AppDeps {
   return {
-    store: {} as SessionStore,
+    store: { isEpicIntegratedChild: () => false } as unknown as SessionStore,
     service: {} as SessionService,
     events: { emit: () => {} } as unknown as EventHub,
     usageLimits: { limits: () => ({}) } as never,

--- a/test/store-epic-integrated.test.ts
+++ b/test/store-epic-integrated.test.ts
@@ -12,6 +12,15 @@ test("records and lists integration-merged children per epic parent", () => {
   expect([...s.listEpicIntegrated("/other", 327)]).toEqual([]); // scoped by repo
 });
 
+test("isEpicIntegratedChild: true once recorded, scoped by repo + child (#1037)", () => {
+  const s = new SessionStore(":memory:");
+  expect(s.isEpicIntegratedChild("/r", 12)).toBe(false); // not recorded
+  s.recordEpicIntegrated("/r", 1, 12); // child #12 of epic #1
+  expect(s.isEpicIntegratedChild("/r", 12)).toBe(true);
+  expect(s.isEpicIntegratedChild("/r", 99)).toBe(false); // different child
+  expect(s.isEpicIntegratedChild("/other", 12)).toBe(false); // different repo
+});
+
 test("recordEpicIntegrated persists prNumber/prUrl; listEpicIntegratedDetails returns them", () => {
   const s = new SessionStore(":memory:");
   s.recordEpicIntegrated("/r", 100, 10, { number: 42, url: "https://github.com/r/pull/42" });


### PR DESCRIPTION
## What

Fixes the **genuine bug** in #1037 (Finding 2): an integrated epic child issue
(`#12` / A7) was closed out-of-band by the PR-poller, violating the invariant
**"an epic child closes only when the landing PR merges into the default branch."**

## Root cause

`retireEpicChild` does `forge.merge` → `recordEpicIntegrated` (deliberately keeps
the issue open) → *slow* `archive()` (worktree removal + LLM recap). During that
multi-second window the session is still `activeOnly`, so the 15s `fastTick`
re-polls the cached-open PR, sees `merged`, and runs
`onGit → reapMerged → settleMergedSession → forge.closeIssue(child)`. Siblings
A1–A6 finished archiving before a poll tick caught them; A7 lost the race. The
same path also fires on the documented archive-*failure* recovery
(`src/drain.ts`), which today likewise closes the child.

## Fix

- New canonical store predicate `isEpicIntegratedChild(repoPath, childNumber)` —
  single source of truth for "this issue was already integrated into an epic".
- `settleMergedSession` is now epic-aware: an integrated child **archives +
  retains its claim but is NEVER closed here**. Closing stays reserved for the
  landing-PR merge (`Closes #N` into the default branch).
- Wired the predicate at all three callers — `drain.reapMerged` (the bug path),
  `automerge.doMerge`, and the server local-merge route. The dep is **required**,
  so the typed `MergeTeardownDeps` fake regresses at compile time; the two
  `as`-cast test stores (`automerge.test.ts`, `server-prs.test.ts`) were updated
  by hand since TypeScript can't see through the casts.
- The fix is **not timing-dependent** (a guard, not a poll-ordering tweak), and it
  also corrects the archive-failure recovery edge — that path now keeps the child
  open too. Stale comment at `retireEpicChild` updated to match.

### Deliberate decision (per house rules)

**Landing-state-independent:** an integrated child is never auto-closed here
*regardless of whether the epic has landed*. If the epic already landed, the
landing-PR merge already closed the child (`Closes #N`), so a close here is a
redundant no-op; if it hasn't, closing is exactly the bug. "Integrated ⇒ never
auto-close" is the simplest strictly-safe invariant. The rejected cheaper
alternative (`dropPrCache` before `archive`) was avoided because it would disable
the intentional archive-failure recovery.

The concurrent double-`archive()` in the race window is **pre-existing** (it's why
#12 closed today) and out of scope here; verified benign (`store.archive` is an
idempotent UPDATE, `worktree.remove` is `existsSync`-guarded, `beforeArchive` is
best-effort/15s-capped).

## Scope

Rec A only (operator decision). **Finding 1** (integrated-but-unlanded epics sit
silently — the headline UX symptom) is intentionally **not** fixed here and is
tracked in **#1039** (Rec B surfacing + "Land epic" CTA + opt-in auto-land; Rec D
stale-epic reconcile). Rec C (migration-ack surfacing) is already shipped.

Server-only change; no UI, no DB migration (reuses `epic_integrated`).
`[no-feature-entry]` — no user-facing feature.

## Test

- `isEpicIntegratedChild`: true once recorded, scoped by repo + child.
- `settleMergedSession`: integrated child archives + retains claim, never closes;
  non-epic + close-failure + manual paths unchanged.
- Full suite green (4623 pass), `tsc` clean, `lint` clean, `fallow audit` clean.

Closes #1037
