### PR TITLE
fix(herdr): pin classic renderer for spawned claude agents

### DIFF
--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -360,7 +360,26 @@ export class HerdrDriver {
             .sort(([a], [b]) => a.localeCompare(b))
             .map(([k, v]) => `${k}=${v}`)
         : [];
-      const wrapped = ["env", `NODE_COMPILE_CACHE=${compileCacheDir()}`, ...envTokens, ...argv];
+      // Pin the CLASSIC renderer for every spawned claude. Claude Code's opt-in fullscreen
+      // renderer (v2.1.89+) draws on the terminal's ALTERNATE screen buffer and captures the
+      // mouse — Shepherd's whole integration assumes the classic renderer: the poller/blocked
+      // classifier scrape the rendered viewport (`agent read --source visible`) with a layout
+      // tuned to the classic prompt, and the web terminal forwards xterm keystrokes (mouse
+      // capture would inject click/scroll escape sequences into claude's input). Fullscreen
+      // turns on via a persisted `tui` setting or ambient CLAUDE_CODE_NO_FLICKER, either of
+      // which a spawned agent would inherit from the operator's global config/env — and the
+      // docs warn the default may flip. CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1 forces the
+      // classic renderer regardless of the saved setting or NO_FLICKER, immunizing us against
+      // both. (Shepherd attaches via `herdr agent attach`, not `claude attach`, so the docs'
+      // "background sessions always use fullscreen" carve-out — which ignores this var — does
+      // not apply to our foreground spawns.)
+      const wrapped = [
+        "env",
+        `NODE_COMPILE_CACHE=${compileCacheDir()}`,
+        "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1",
+        ...envTokens,
+        ...argv,
+      ];
       // Collision-breaker: if herdr rejects with `agent_name_taken` (a stale same-named
       // agent is still registered — e.g. shepherd restarted while an interactive `claude`
       // was running), resolve the squatter(s) by name from `list()`, close their tabs

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -105,6 +105,7 @@ test("start gives each agent its own full-width tab, not a shared split pane", (
     "--",
     "env",
     "NODE_COMPILE_CACHE=/disk/ncc",
+    "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1",
     "claude",
     "--dangerously-skip-permissions",
     "go",
@@ -123,8 +124,29 @@ test("start wraps the agent argv in an `env NODE_COMPILE_CACHE=…` shim (off tm
   d.start("flatten", "/wt/a", ["claude", "--dangerously-skip-permissions", "go"]);
   const startCall = calls.find((c) => c[0] === "agent" && c[1] === "start")!;
   const post = startCall.slice(startCall.indexOf("--") + 1);
-  // env shim is the first three post-`--` tokens, and claude is still argv[0] after it
-  expect(post.slice(0, 3)).toEqual(["env", "NODE_COMPILE_CACHE=/disk/ncc", "claude"]);
+  // env shim is the first four post-`--` tokens (env + two pinned vars), and claude is
+  // still argv[0] after it
+  expect(post.slice(0, 4)).toEqual([
+    "env",
+    "NODE_COMPILE_CACHE=/disk/ncc",
+    "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1",
+    "claude",
+  ]);
+});
+
+test("start pins the classic renderer (CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1) for every spawn", () => {
+  // Claude Code's fullscreen renderer draws on the alternate screen buffer and captures the
+  // mouse; Shepherd's poller/blocked scraping + xterm web terminal assume the classic
+  // renderer. The pin forces classic regardless of the operator's persisted `tui` setting or
+  // ambient CLAUDE_CODE_NO_FLICKER, so it must be present on EVERY spawned claude.
+  const calls: string[][] = [];
+  const d = new HerdrDriver((args) => {
+    calls.push(args);
+    return reply(args, WORKSPACE_LIST);
+  });
+  d.start("flatten", "/wt/a", ["claude", "go"], { CLAUDE_CONFIG_DIR: "/x" });
+  const post = extractPost(calls);
+  expect(post).toContain("CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1");
 });
 
 test("start bootstraps a 'shepherd' workspace when herdr has none (fresh/restarted daemon)", () => {
@@ -412,7 +434,13 @@ test("start with no env arg: wrapped portion is exactly [env, NODE_COMPILE_CACHE
   });
   d.start("flatten", "/wt/a", ["claude", "go"]);
   const post = extractPost(calls);
-  expect(post).toEqual(["env", "NODE_COMPILE_CACHE=/disk/ncc", "claude", "go"]);
+  expect(post).toEqual([
+    "env",
+    "NODE_COMPILE_CACHE=/disk/ncc",
+    "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1",
+    "claude",
+    "go",
+  ]);
 });
 
 test("start with env arg: extra vars appear after NODE_COMPILE_CACHE, sorted by key, before argv", () => {
@@ -423,10 +451,11 @@ test("start with env arg: extra vars appear after NODE_COMPILE_CACHE, sorted by 
   });
   d.start("flatten", "/wt/a", ["claude", "go"], { CLAUDE_CONFIG_DIR: "/x", FOO: "bar" });
   const post = extractPost(calls);
-  // Keys sorted: CLAUDE_CONFIG_DIR < FOO
+  // Keys sorted: CLAUDE_CONFIG_DIR < FOO; both pinned vars precede caller-supplied env
   expect(post).toEqual([
     "env",
     "NODE_COMPILE_CACHE=/disk/ncc",
+    "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1",
     "CLAUDE_CONFIG_DIR=/x",
     "FOO=bar",
     "claude",
@@ -442,7 +471,13 @@ test("start with empty env {}: wrapped is identical to no-env case", () => {
   });
   d.start("flatten", "/wt/a", ["claude", "go"], {});
   const post = extractPost(calls);
-  expect(post).toEqual(["env", "NODE_COMPILE_CACHE=/disk/ncc", "claude", "go"]);
+  expect(post).toEqual([
+    "env",
+    "NODE_COMPILE_CACHE=/disk/ncc",
+    "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1",
+    "claude",
+    "go",
+  ]);
 });
 
 // -- panes() tests --


### PR DESCRIPTION
## What

Inject `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1` into the `env` shim at the universal `herdr.start` spawn chokepoint (alongside `NODE_COMPILE_CACHE`), forcing the **classic renderer** for every spawned `claude` agent.

## Why — does the new fullscreen renderer break Shepherd?

Claude Code shipped a **fullscreen renderer** ([docs](https://code.claude.com/docs/en/fullscreen), v2.1.89+). It draws on the terminal's **alternate screen buffer** (like `vim`/`htop`) and **captures the mouse**.

**Today: not broken out of the box** — fullscreen is an opt-in research preview; the default is still the classic renderer.

**But Shepherd is exposed**, because its whole integration assumes the classic renderer:
- **Status / blocked detection** (`poller.ts`, `blocked.ts`) scrapes the rendered visible viewport (`herdr agent read --source visible`) with regexes tuned to the classic prompt layout. Fullscreen pins the input box at the bottom and only renders visible messages — a relocated/reshaped prompt risks misclassification.
- **Web terminal** (`Viewport.svelte` / xterm.js) forwards keystrokes back into the PTY. Fullscreen's mouse capture (modes 1000/1002/1003) would make operator clicks/scrolls in the browser emit mouse-event escape sequences **into claude's input**.
- Browser scrollback no longer accumulates the conversation (it lives in the alt buffer).

Fullscreen turns on via a **persisted `tui` setting** (`/tui fullscreen` → `~/.claude/settings.json`) or **ambient `CLAUDE_CODE_NO_FLICKER`** — either of which a Shepherd-spawned agent inherits from the operator's global config/env. And the docs warn the **default may flip** based on feedback, which would break every install at once with no operator action.

`CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1` "forces the classic renderer regardless of the saved `tui` setting" (and overrides `NO_FLICKER`), immunizing Shepherd against both the operator-settings path and a future default flip, at zero cost.

## Scope / safety notes
- Single chokepoint: every TUI claude spawn (interactive session, recap, review, distiller, plan-gate, optimizer, autopilot-llm, doc-agent, namer, herd-digest/rundown, merge-suggest) routes through `herdr.start`.
- Shepherd attaches via `herdr agent attach`, **not** `claude attach`, so the docs' "background sessions always use fullscreen" carve-out (which ignores this var) does **not** apply to our foreground spawns. Flagged in the code comment + here per house rules.
- Shepherd never reads `--source recent` scrollback, so the "scrollback goes empty" failure mode wasn't a direct hit — but pinning classic keeps that guarantee robust too.

## Verification
- `bun test ./test/herdr.test.ts` → 50 pass (updated 5 argv assertions + added a focused regression test for the pin)
- `bun run lint`, `bunx tsc --noEmit` clean
- `bunx fallow@2.97.0 audit --base origin/main --fail-on-issues` clean
- pre-push gate green

Server-only plumbing, no UI surface → exempt from feature catalog / i18n / glossary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)