### PR TITLE
feat(backlog): show per-issue assignees when mine & unassigned filter is off

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1856,5 +1856,8 @@
   "feat_first_task_confirm_title": "Einstellungen vor der ersten Aufgabe prüfen",
   "feat_first_task_confirm_body": "Das Starten einer Aufgabe in einem neuen Repository zeigt nun einen kurzen Überprüfungsschritt, damit du die Automatisierungseinstellungen vor dem ersten Durchlauf prüfen kannst. Nach einmaliger Bestätigung starten weitere Aufgaben im selben Repository ohne Unterbrechung.",
   "toast_broadcast_delivered": "Broadcast hat {delivered} Agenten sofort gesteuert.",
-  "toast_broadcast_result": "Broadcast · {delivered} sofort gesteuert, {queued} bei beschäftigten Agenten in Warteschlange (wird nach aktuellem Zug ausgeführt), {offline} nicht erreichbar."
+  "toast_broadcast_result": "Broadcast · {delivered} sofort gesteuert, {queued} bei beschäftigten Agenten in Warteschlange (wird nach aktuellem Zug ausgeführt), {offline} nicht erreichbar.",
+  "issuerow_assignee_title": "Zugewiesen an {login}",
+  "feat_issue_assignee_title": "Sieh, wer welchem Issue zugewiesen ist",
+  "feat_issue_assignee_body": "Wenn der Filter „meine & nicht zugewiesen“ ausgeschaltet ist, zeigt jedes Issue im Backlog nun einen Chip für jede zugewiesene Person, sodass du auf einen Blick erkennst, wer bereits an einer Aufgabe arbeitet."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1856,5 +1856,8 @@
   "feat_first_task_confirm_title": "Review settings before the first task",
   "feat_first_task_confirm_body": "Starting a task on a new repo now shows a quick review step so you can check automation settings before the first run. After confirming once, future tasks on the same repo start without interruption.",
   "toast_broadcast_delivered": "Broadcast steered {delivered} agents now.",
-  "toast_broadcast_result": "Broadcast · {delivered} steered now, {queued} queued on busy agents (act after current turn), {offline} unreachable."
+  "toast_broadcast_result": "Broadcast · {delivered} steered now, {queued} queued on busy agents (act after current turn), {offline} unreachable.",
+  "issuerow_assignee_title": "Assigned to {login}",
+  "feat_issue_assignee_title": "See who's assigned to each issue",
+  "feat_issue_assignee_body": "When the \"mine & unassigned\" issue filter is off, each backlog issue now shows a chip for every assignee, so you can tell at a glance who already owns a piece of work."
 }

--- a/ui/src/lib/components/IssuesPanel.browser.test.ts
+++ b/ui/src/lib/components/IssuesPanel.browser.test.ts
@@ -416,6 +416,49 @@ describe("IssuesPanel mine & unassigned filter (#824)", () => {
     expect(checkboxByLabel(m.issues_filter_active_label())).toBeTruthy();
   });
 
+  // Assignee chips (#824 follow-up): exposed per issue row only when the mine &
+  // unassigned filter isn't hiding others' issues.
+  const assigneeChips = () => document.querySelectorAll(".label-chip.assignee");
+  const assigneeText = () => [...assigneeChips()].map((el) => el.textContent ?? "");
+
+  it("shows no assignee chips while the mine & unassigned filter is active", async () => {
+    seedMixed("octocat");
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
+
+    await expect.poll(() => document.querySelectorAll(".issue-title").length).toBe(2);
+    // Filter on + viewer known → every visible issue is mine-or-unassigned, so chips
+    // would be redundant and are suppressed.
+    expect(assigneeChips().length).toBe(0);
+  });
+
+  it("reveals assignee chips when the mine & unassigned filter is toggled off", async () => {
+    seedMixed("octocat");
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
+
+    await expect.poll(() => document.querySelectorAll(".issue-title").length).toBe(2);
+
+    openPopover();
+    await expect.poll(() => checkboxByLabel(m.issues_filter_mine_label())).toBeTruthy();
+    checkboxByLabel(m.issues_filter_mine_label())!.click();
+
+    await expect.poll(() => document.querySelectorAll(".issue-title").length).toBe(3);
+    // One chip per assignee login; the unassigned issue contributes none.
+    await expect.poll(() => assigneeChips().length).toBe(2);
+    expect(assigneeText().some((t) => t.includes("octocat"))).toBe(true);
+    expect(assigneeText().some((t) => t.includes("someone-else"))).toBe(true);
+  });
+
+  it("shows assignee chips when the viewer is unknown even with the filter on (fail open)", async () => {
+    seedMixed(null);
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
+
+    // Fail open: all 3 issues show AND the chips render without toggling the filter —
+    // guards the `|| viewer == null` clause in IssuesPanel's showAssignees.
+    await expect.poll(() => document.querySelectorAll(".issue-title").length).toBe(3);
+    await expect.poll(() => assigneeChips().length).toBe(2);
+    expect(assigneeText().some((t) => t.includes("someone-else"))).toBe(true);
+  });
+
   it("hide-in-progress checkbox drops shepherd:active issues and restores them when toggled off", async () => {
     mockListIssues.mockResolvedValue({
       slug: "owner/repo",

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -56,6 +56,11 @@
   // The mine chip only shows when `viewer` is known, so hideOthers is a no-op
   // identity otherwise (fail open); hideActive is viewer-agnostic.
   let assigneeFiltered = $derived(hideOthers(issues, viewer, issuesFilter.hideOthers));
+  // Expose per-issue assignees on the rows whenever the mine & unassigned filter (#824)
+  // isn't hiding others' issues — i.e. when it's toggled off, or fails open because the
+  // viewer is unknown. With the filter active, every visible issue is mine-or-unassigned,
+  // so an assignee chip would be redundant.
+  let showAssignees = $derived(!issuesFilter.hideOthers || viewer == null);
   let activeFiltered = $derived(hideActive(assigneeFiltered, issuesFilter.hideActive));
   let epicParentNums = $derived(new Set(epicByNumber.keys()));
   let subFiltered = $derived(
@@ -222,6 +227,7 @@
           {repoPath}
           {bodyPreview}
           {age}
+          {showAssignees}
           {issueActions}
           {onnewtask}
           {onquick}

--- a/ui/src/lib/components/issues-panel/IssueRow.svelte
+++ b/ui/src/lib/components/issues-panel/IssueRow.svelte
@@ -18,6 +18,7 @@
     repoPath,
     bodyPreview = false,
     age = false,
+    showAssignees = false,
     issueActions,
     onnewtask,
     onquick = undefined,
@@ -33,6 +34,9 @@
     repoPath: string;
     bodyPreview?: boolean;
     age?: boolean;
+    /** Show a chip per assignee login — set only when the "mine & unassigned" filter
+     *  isn't hiding others' issues (#824), so the assignee isn't redundant noise. */
+    showAssignees?: boolean;
     issueActions: Steer[];
     onnewtask: (issue: Issue) => void;
     onquick?: (issue: Issue, action: Steer) => void;
@@ -86,8 +90,15 @@
   {#if bodyPreview && issue.body}
     <div class="body-preview">{issue.body}</div>
   {/if}
-  {#if issue.labels.length > 0 || age}
+  {#if issue.labels.length > 0 || age || (showAssignees && issue.assignees.length > 0)}
     <div class="label-row">
+      {#if showAssignees}
+        {#each issue.assignees as login (login)}
+          <span class="label-chip assignee" title={m.issuerow_assignee_title({ login })}
+            ><span class="assignee-glyph" aria-hidden="true">👤</span>{login}</span
+          >
+        {/each}
+      {/if}
       {#each issue.labels as label (label)}
         <span
           class="label-chip"
@@ -200,6 +211,21 @@
     border: 1px solid var(--color-line);
     border-radius: 2px;
     padding: 1px 5px;
+  }
+
+  /* Assignee chip — reuses the label-chip recipe but keeps the login verbatim (logins are
+     mixed-case, so no uppercasing/letter-spacing) and leads the row with a person glyph.
+     Shown only when the "mine & unassigned" filter isn't hiding others' issues (#824). */
+  .label-chip.assignee {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    text-transform: none;
+    letter-spacing: normal;
+  }
+
+  .assignee-glyph {
+    font-size: var(--fs-micro);
   }
 
   /* shepherd:active — claimed work. Uses the semantic running/in-progress token so a

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1475,4 +1475,16 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_first_task_confirm_title",
     bodyKey: "feat_first_task_confirm_body",
   },
+  {
+    // Backlog issue rows now show a chip per assignee login, but only when the
+    // "mine & unassigned" filter (#824) isn't hiding others' issues — so you can see who
+    // already owns a piece of work. No targetId — the chips mount conditionally (filter
+    // off + at least one assignee), so there's no persistently-mounted anchor for a
+    // coachmark; surface via the What's-New drawer only. v1.36.0 is the latest released
+    // tag → ships in 1.37.0.
+    id: "issue-assignee-chip",
+    sinceVersion: "1.37.0",
+    titleKey: "feat_issue_assignee_title",
+    bodyKey: "feat_issue_assignee_body",
+  },
 ];


### PR DESCRIPTION
## What

Expose a chip per **assignee login** on each backlog issue row — but only when the **"mine & unassigned" filter** (#824) isn't hiding others' issues. The filter is "in use" exactly when `hideOthers && viewer != null`, so chips show when it's toggled **off** or **fails open** because the viewer is unknown. With the filter active, every visible issue is already mine-or-unassigned, so an assignee chip would be redundant noise.

## Why

When you turn the filter off to see the whole backlog (including issues assigned to others), "who already owns this" is the missing context. Surfacing the assignee inline answers it at a glance.

## Details

- **Data already flows end-to-end** — `Issue.assignees: string[]` (logins only, no avatar URLs) is fetched by the forge and already drives the #824 filter. **No server change**; pure UI render.
- `IssueRow` gains an opt-in `showAssignees` prop; `IssuesPanel` passes `!issuesFilter.hideOthers || viewer == null`.
- Chips **lead** the label row (who-owns-this is the primary signal), reuse the `.label-chip` recipe with a person glyph (`👤`) + **verbatim, non-uppercased** login (logins are mixed-case). Loop keyed `(login)` per existing convention.
- **Unassigned issues show no chip** (absence implies unassigned).
- i18n: `issuerow_assignee_title` + feature-catalog keys added to **both** EN + DE (parity gate green).
- Feature catalog: `issue-assignee-chip` entry (`sinceVersion 1.37.0`, no targetId — chips mount conditionally; surfaced via the What's-New drawer).

## Tests

Three new cases in `IssuesPanel.browser.test.ts` cover all axes:
- filter **on** + viewer known → no chips
- filter **off** + viewer known → chips for assigned rows, none for unassigned
- **fail-open** (`viewer == null`, filter default on) → chips render — guards the `|| viewer == null` clause

## Verification

- `cd ui && bun run check` ✓ (0 errors)
- `cd ui && bun run check:i18n` ✓ (1860 keys, parity)
- `cd ui && bun run test` ✓ (2002 passed)
- root `bun run lint` ✓
- pre-push gate ✓ (branch hygiene + i18n + feature catalog + glossary + fallow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)