### PR TITLE
feat(epic): surface + manually land integrated-but-unlanded epics (#1039)

### DIFF
--- a/src/completed-epic.ts
+++ b/src/completed-epic.ts
@@ -1,4 +1,5 @@
 import type { EpicChild } from "./epic-core";
+import type { ChecksState, PrStatus } from "./forge/types";
 
 export interface CompletedEpicChild {
   number: number;
@@ -31,6 +32,55 @@ export interface CompletedEpic {
   // band row's clear behind an explicit acknowledgement — NEVER the autonomous completion flip.
   migrationPaths: string[];
   migrationsAckedAt: number | null;
+  /** Live, non-persisted landing-PR gate signals (present only when the landing PR could be fetched). */
+  landingChecks?: ChecksState;
+  landingMergeable?: boolean | null;
+  /** True when the landing PR is safe to merge from the app (gates the "Land epic" CTA). */
+  landingReady?: boolean;
+  /** True when an open+ready landing has sat unlanded past EPIC_LANDING_STRANDED_MS (Rec D escalation). */
+  landingStranded?: boolean;
+}
+
+/** Rec D threshold: surface the "stranded" escalation when an open+ready landing PR has sat
+ *  unlanded this long after epic completion.
+ *
+ *  Documented deviation: the issue says "landing PR mergeable for > N hours"; we approximate with
+ *  "epic completed > N h ago AND landing PR currently ready" to avoid persisting a `mergeableSince`
+ *  column. A PR that becomes ready long after the epic completed would fire earlier than intended,
+ *  but this is conservative (earlier escalation) and avoids a schema change. */
+export const EPIC_LANDING_STRANDED_MS = 6 * 60 * 60_000;
+
+/** Returns true when the landing PR is safe to merge from the app (gates the "Land epic" CTA).
+ *
+ *  Requires: open, checks passing, and mergeable=true. When mergeStateStatus is present (GitHub),
+ *  it must be "clean" or "has_hooks" — all other statuses indicate a PR that is not ready:
+ *  - "blocked": branch-protection rules are blocking the merge; the app-triggered merge would fail,
+ *    so we must NOT show an enabled CTA that fires a doomed merge call.
+ *  - "behind", "dirty", "unstable", "draft", "unknown": also not mergeable.
+ *  When mergeStateStatus is undefined (Gitea), we fall back to state+checks+mergeable alone. */
+export function computeLandingReady(
+  pr: Pick<PrStatus, "state" | "checks" | "mergeable" | "mergeStateStatus">,
+): boolean {
+  if (pr.state !== "open") return false;
+  if (pr.checks !== "success") return false;
+  if (pr.mergeable !== true) return false;
+  if (pr.mergeStateStatus === undefined) return true; // Gitea fallback
+  return pr.mergeStateStatus === "clean" || pr.mergeStateStatus === "has_hooks";
+}
+
+/** Returns true when the landing PR is open, ready, and the epic completed over
+ *  EPIC_LANDING_STRANDED_MS ago (the Rec D escalation threshold). */
+export function computeLandingStranded(opts: {
+  landingState: EpicLandingState;
+  landingReady: boolean;
+  completedAt: number;
+  now: number;
+}): boolean {
+  return (
+    opts.landingState === "open" &&
+    opts.landingReady &&
+    opts.now - opts.completedAt > EPIC_LANDING_STRANDED_MS
+  );
 }
 
 export function buildRollup(

--- a/src/server.ts
+++ b/src/server.ts
@@ -101,7 +101,12 @@ import type { DrainStatus, QueuedItem } from "./drain";
 import { ACTIVE_LABEL } from "./drain-core";
 import type { Epic, EpicRun, EpicSource } from "./epic-core";
 import { importEpicLinks, type ImportResult } from "./epic-import";
-import { buildRollup, type CompletedEpic } from "./completed-epic";
+import {
+  buildRollup,
+  computeLandingReady,
+  computeLandingStranded,
+  type CompletedEpic,
+} from "./completed-epic";
 import { parseEpicBody } from "./epic-parse";
 import { countDefinedWorkflows, type CountsService, type RepoCounts } from "./backlog";
 import { join, normalize } from "node:path";
@@ -4512,13 +4517,45 @@ async function handleEpicsCompletedList({ req, parts, url, deps }: Ctx): Promise
   for (const repo of scopeRepos) await reconcileCompletedEpicsForRepo(deps, repo);
 
   // Re-query post-reconcile so the response reflects dismiss + backfill.
-  const rows = deps.store.listEpicCompleted(repoFilter).map((row): CompletedEpic => {
+  const dbRows = deps.store.listEpicCompleted(repoFilter);
+  const baseRows: Array<
+    CompletedEpic & { repoPath: string; parentIssueNumber: number; completedAt: number }
+  > = dbRows.map((row) => {
     // landingAttempts is an internal retry counter, not part of the CompletedEpic response.
     const { childrenJson, landingAttempts, ...rest } = row;
     void landingAttempts;
     return { ...rest, children: JSON.parse(childrenJson) as CompletedEpic["children"] };
   });
-  return json(rows);
+
+  // Enrich open-landing rows with live gate signals (best-effort, fail-safe — forge/network
+  // errors must NOT 500 this route; just omit the live fields for that row).
+  const now = Date.now();
+  await Promise.all(
+    baseRows.map(async (row) => {
+      if (row.landingState !== "open") return;
+      const branch = deps.store.getEpicIntegrationBranch(row.repoPath, row.parentIssueNumber);
+      if (branch === null) return;
+      const forge = deps.resolveForge?.(row.repoPath);
+      if (!forge) return;
+      try {
+        const pr = await forge.prStatus(branch);
+        row.landingChecks = pr.checks;
+        row.landingMergeable = pr.mergeable ?? null;
+        const landingReady = computeLandingReady(pr);
+        row.landingReady = landingReady;
+        row.landingStranded = computeLandingStranded({
+          landingState: "open",
+          landingReady,
+          completedAt: row.completedAt,
+          now,
+        });
+      } catch {
+        // leave live fields undefined — always serve DB rows
+      }
+    }),
+  );
+
+  return json(baseRows);
 }
 
 // POST /api/epics/completed/dismiss — body { repo, parent }. Dismiss one completed epic + emit.
@@ -4573,6 +4610,90 @@ async function handleEpicsCompletedAckMigrations({
   return json({ ok: true });
 }
 
+// POST /api/epics/completed/land — body { repo, parent }. Merge the open landing PR using
+// method:"merge" to preserve per-child commit history (squash, the host default, would flatten it).
+// Fail-closed: only merges when computeLandingReady confirms the PR is green + unblocked.
+async function handleEpicsCompletedLand({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (
+    !(
+      req.method === "POST" &&
+      parts[0] === "api" &&
+      parts[1] === "epics" &&
+      parts[2] === "completed" &&
+      parts[3] === "land"
+    )
+  )
+    return null;
+  const body = (await req.json().catch(() => null)) as { repo?: string; parent?: number } | null;
+  const dir = safeRepoDir(body?.repo ?? "", config.repoRoot);
+  if (!dir) return json({ error: "invalid repo" }, 400);
+  const parent = body?.parent;
+  if (typeof parent !== "number" || !Number.isInteger(parent) || parent <= 0)
+    return json({ error: "parent must be a positive integer" }, 400);
+
+  const row = deps.store.listEpicCompleted(dir).find((r) => r.parentIssueNumber === parent);
+  if (!row) return json({ error: "no completed epic" }, 409);
+  if (row.landingState !== "open" || row.landingPrNumber == null)
+    return json({ error: "landing not open" }, 409);
+
+  const forge = deps.resolveForge?.(dir);
+  if (!forge) return json({ error: "no forge" }, 409);
+
+  const branch = deps.store.getEpicIntegrationBranch(dir, parent);
+  if (branch === null) return json({ error: "no integration branch" }, 409);
+
+  let pr;
+  try {
+    pr = await forge.prStatus(branch);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return json({ error: msg }, 502);
+  }
+
+  if (!computeLandingReady(pr)) return json({ error: "landing PR not ready" }, 409);
+
+  try {
+    // Use method:"merge" deliberately — a merge commit preserves the epic's per-child commit
+    // history; squash (the host default) would flatten all child commits into one.
+    await forge.merge(row.landingPrNumber, { method: "merge", deleteBranch: true });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return json({ error: msg }, 502);
+  }
+
+  deps.store.setEpicLandingPr(dir, parent, {
+    state: "merged",
+    prNumber: row.landingPrNumber,
+    prUrl: row.landingPrUrl,
+    attempts: row.landingAttempts,
+  });
+
+  // Re-read the row and emit updated CompletedEpic (mirrors emitCompleted in drain.ts).
+  const updatedRow = deps.store.listEpicCompleted(dir).find((r) => r.parentIssueNumber === parent);
+  if (updatedRow) {
+    try {
+      const children = JSON.parse(updatedRow.childrenJson) as CompletedEpic["children"];
+      const completed: CompletedEpic = {
+        repoPath: dir,
+        parentIssueNumber: parent,
+        parentTitle: updatedRow.parentTitle,
+        completedAt: updatedRow.completedAt,
+        children,
+        landingPrNumber: updatedRow.landingPrNumber,
+        landingPrUrl: updatedRow.landingPrUrl,
+        landingState: updatedRow.landingState,
+        migrationPaths: updatedRow.migrationPaths,
+        migrationsAckedAt: updatedRow.migrationsAckedAt,
+      };
+      deps.events?.emit("epic:completed", completed);
+    } catch {
+      // best-effort emit; a bad childrenJson must not fail the land endpoint
+    }
+  }
+
+  return json({ ok: true });
+}
+
 // Ordered dispatch chain — preserves the original guard sequence verbatim.
 const ROUTE_HANDLERS = [
   handlePing,
@@ -4593,6 +4714,7 @@ const ROUTE_HANDLERS = [
   handleEpicsList,
   handleEpicsCompletedDismiss,
   handleEpicsCompletedAckMigrations,
+  handleEpicsCompletedLand,
   handleEpicsCompletedList,
   handleEpicApproveNext,
   handleEpicImport,

--- a/src/server.ts
+++ b/src/server.ts
@@ -4656,9 +4656,9 @@ async function resolveLandTarget(
   return { dir, parent, row, forge, branch, pr };
 }
 
-// POST /api/epics/completed/land — body { repo, parent }. Merge the open landing PR using
-// method:"merge" to preserve per-child commit history (squash, the host default, would flatten it).
-// Fail-closed: only merges when computeLandingReady confirms the PR is green + unblocked.
+// POST /api/epics/completed/land — body { repo, parent }. Merge the open landing PR using the
+// host-configured merge method (same as AutoMergeService + the other merge routes), so the feature
+// works on squash-only repos too. Fail-closed: only merges when computeLandingReady confirms green.
 async function handleEpicsCompletedLand({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (
     !(
@@ -4676,9 +4676,11 @@ async function handleEpicsCompletedLand({ req, parts, deps }: Ctx): Promise<Resp
   const { dir, parent, row, forge } = r;
 
   try {
-    // Use method:"merge" deliberately — a merge commit preserves the epic's per-child commit
-    // history; squash (the host default) would flatten all child commits into one.
-    await forge.merge(row.landingPrNumber!, { method: "merge", deleteBranch: true });
+    // Use the host-configured merge method (mirrors AutoMergeService + the other merge routes) so
+    // the merge respects whatever the repo actually allows. Hardcoding "merge" would 405 on a
+    // squash-only repo even though computeLandingReady reports ready (mergeStateStatus reflects
+    // branch state, not method availability), making the CTA fire a doomed merge there.
+    await forge.merge(row.landingPrNumber!, { method: forge.mergeMethod, deleteBranch: true });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return json({ error: msg }, 502);

--- a/src/server.ts
+++ b/src/server.ts
@@ -4610,6 +4610,52 @@ async function handleEpicsCompletedAckMigrations({
   return json({ ok: true });
 }
 
+// Validate + resolve everything needed to perform a land merge. Returns { error: Response } on any
+// failure (wrong body, missing row, wrong state, no forge, no branch, prStatus throw, not ready),
+// or the resolved targets on success. Extracted to keep handleEpicsCompletedLand below the
+// cyclomatic/cognitive thresholds.
+type LandTarget = {
+  dir: string;
+  parent: number;
+  row: ReturnType<AppDeps["store"]["listEpicCompleted"]>[number];
+  forge: GitForge;
+  branch: string;
+  pr: PrStatus;
+};
+async function resolveLandTarget(
+  deps: AppDeps,
+  body: { repo?: string; parent?: number } | null,
+): Promise<{ error: Response } | LandTarget> {
+  const dir = safeRepoDir(body?.repo ?? "", config.repoRoot);
+  if (!dir) return { error: json({ error: "invalid repo" }, 400) };
+  const parent = body?.parent;
+  if (typeof parent !== "number" || !Number.isInteger(parent) || parent <= 0)
+    return { error: json({ error: "parent must be a positive integer" }, 400) };
+
+  const row = deps.store.listEpicCompleted(dir).find((r) => r.parentIssueNumber === parent);
+  if (!row) return { error: json({ error: "no completed epic" }, 409) };
+  if (row.landingState !== "open" || row.landingPrNumber == null)
+    return { error: json({ error: "landing not open" }, 409) };
+
+  const forge = deps.resolveForge?.(dir);
+  if (!forge) return { error: json({ error: "no forge" }, 409) };
+
+  const branch = deps.store.getEpicIntegrationBranch(dir, parent);
+  if (branch === null) return { error: json({ error: "no integration branch" }, 409) };
+
+  let pr: PrStatus;
+  try {
+    pr = await forge.prStatus(branch);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { error: json({ error: msg }, 502) };
+  }
+
+  if (!computeLandingReady(pr)) return { error: json({ error: "landing PR not ready" }, 409) };
+
+  return { dir, parent, row, forge, branch, pr };
+}
+
 // POST /api/epics/completed/land — body { repo, parent }. Merge the open landing PR using
 // method:"merge" to preserve per-child commit history (squash, the host default, would flatten it).
 // Fail-closed: only merges when computeLandingReady confirms the PR is green + unblocked.
@@ -4625,37 +4671,14 @@ async function handleEpicsCompletedLand({ req, parts, deps }: Ctx): Promise<Resp
   )
     return null;
   const body = (await req.json().catch(() => null)) as { repo?: string; parent?: number } | null;
-  const dir = safeRepoDir(body?.repo ?? "", config.repoRoot);
-  if (!dir) return json({ error: "invalid repo" }, 400);
-  const parent = body?.parent;
-  if (typeof parent !== "number" || !Number.isInteger(parent) || parent <= 0)
-    return json({ error: "parent must be a positive integer" }, 400);
-
-  const row = deps.store.listEpicCompleted(dir).find((r) => r.parentIssueNumber === parent);
-  if (!row) return json({ error: "no completed epic" }, 409);
-  if (row.landingState !== "open" || row.landingPrNumber == null)
-    return json({ error: "landing not open" }, 409);
-
-  const forge = deps.resolveForge?.(dir);
-  if (!forge) return json({ error: "no forge" }, 409);
-
-  const branch = deps.store.getEpicIntegrationBranch(dir, parent);
-  if (branch === null) return json({ error: "no integration branch" }, 409);
-
-  let pr;
-  try {
-    pr = await forge.prStatus(branch);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return json({ error: msg }, 502);
-  }
-
-  if (!computeLandingReady(pr)) return json({ error: "landing PR not ready" }, 409);
+  const r = await resolveLandTarget(deps, body);
+  if ("error" in r) return r.error;
+  const { dir, parent, row, forge } = r;
 
   try {
     // Use method:"merge" deliberately — a merge commit preserves the epic's per-child commit
     // history; squash (the host default) would flatten all child commits into one.
-    await forge.merge(row.landingPrNumber, { method: "merge", deleteBranch: true });
+    await forge.merge(row.landingPrNumber!, { method: "merge", deleteBranch: true });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return json({ error: msg }, 502);
@@ -4663,7 +4686,7 @@ async function handleEpicsCompletedLand({ req, parts, deps }: Ctx): Promise<Resp
 
   deps.store.setEpicLandingPr(dir, parent, {
     state: "merged",
-    prNumber: row.landingPrNumber,
+    prNumber: row.landingPrNumber!,
     prUrl: row.landingPrUrl,
     attempts: row.landingAttempts,
   });

--- a/src/store.ts
+++ b/src/store.ts
@@ -1136,6 +1136,16 @@ export class SessionStore implements CapStore, CreditStore {
     return derived;
   }
 
+  /** SELECT-only sibling of getOrInitEpicIntegrationBranch. Returns the pinned integration
+   *  branch for an epic, or null when no pin exists. Safe to call from read paths — never
+   *  INSERTs a row. */
+  getEpicIntegrationBranch(repoPath: string, parentIssueNumber: number): string | null {
+    const row = this.db
+      .query(`SELECT branch FROM epic_branch WHERE repoPath = ? AND parentIssueNumber = ?`)
+      .get(repoPath, parentIssueNumber) as { branch: string } | null;
+    return row?.branch ?? null;
+  }
+
   /** Record that a child PR was squash-merged into the epic integration branch.
    *  Idempotent (PK upsert) — the drain may re-observe a merge across pumps.
    *  On conflict, updates only PR columns (guarded by COALESCE so a null re-observe

--- a/test/completed-epic.test.ts
+++ b/test/completed-epic.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { buildRollup } from "../src/completed-epic";
+import {
+  buildRollup,
+  computeLandingReady,
+  computeLandingStranded,
+  EPIC_LANDING_STRANDED_MS,
+} from "../src/completed-epic";
 
 describe("buildRollup", () => {
   it("child WITH detail row → integrated true, PR facts from row", () => {
@@ -107,5 +112,173 @@ describe("buildRollup", () => {
     expect(result.at(0)?.integrated).toBe(true);
     expect(result.at(1)?.integrated).toBe(true);
     expect(result.at(2)?.integrated).toBe(false);
+  });
+});
+
+// ── computeLandingReady ───────────────────────────────────────────────────────
+
+describe("computeLandingReady", () => {
+  it("clean+success+mergeable → ready", () => {
+    expect(
+      computeLandingReady({
+        state: "open",
+        checks: "success",
+        mergeable: true,
+        mergeStateStatus: "clean",
+      }),
+    ).toBe(true);
+  });
+
+  it("has_hooks → ready (protected branches that still allow merge via hooks)", () => {
+    expect(
+      computeLandingReady({
+        state: "open",
+        checks: "success",
+        mergeable: true,
+        mergeStateStatus: "has_hooks",
+      }),
+    ).toBe(true);
+  });
+
+  it("blocked → NOT ready (branch-protection would reject the merge)", () => {
+    expect(
+      computeLandingReady({
+        state: "open",
+        checks: "success",
+        mergeable: true,
+        mergeStateStatus: "blocked",
+      }),
+    ).toBe(false);
+  });
+
+  it("behind → NOT ready", () => {
+    expect(
+      computeLandingReady({
+        state: "open",
+        checks: "success",
+        mergeable: true,
+        mergeStateStatus: "behind",
+      }),
+    ).toBe(false);
+  });
+
+  it("dirty → NOT ready", () => {
+    expect(
+      computeLandingReady({
+        state: "open",
+        checks: "success",
+        mergeable: true,
+        mergeStateStatus: "dirty",
+      }),
+    ).toBe(false);
+  });
+
+  it("unstable → NOT ready", () => {
+    expect(
+      computeLandingReady({
+        state: "open",
+        checks: "success",
+        mergeable: true,
+        mergeStateStatus: "unstable",
+      }),
+    ).toBe(false);
+  });
+
+  it("Gitea (undefined mergeStateStatus) + clean signals → ready", () => {
+    expect(computeLandingReady({ state: "open", checks: "success", mergeable: true })).toBe(true);
+  });
+
+  it("not-open → NOT ready", () => {
+    expect(
+      computeLandingReady({
+        state: "merged",
+        checks: "success",
+        mergeable: true,
+        mergeStateStatus: "clean",
+      }),
+    ).toBe(false);
+  });
+
+  it("checks failure → NOT ready", () => {
+    expect(
+      computeLandingReady({
+        state: "open",
+        checks: "failure",
+        mergeable: true,
+        mergeStateStatus: "clean",
+      }),
+    ).toBe(false);
+  });
+
+  it("mergeable=false → NOT ready", () => {
+    expect(
+      computeLandingReady({
+        state: "open",
+        checks: "success",
+        mergeable: false,
+        mergeStateStatus: "clean",
+      }),
+    ).toBe(false);
+  });
+
+  it("mergeable=null → NOT ready", () => {
+    expect(
+      computeLandingReady({
+        state: "open",
+        checks: "success",
+        mergeable: null,
+        mergeStateStatus: "clean",
+      }),
+    ).toBe(false);
+  });
+});
+
+// ── computeLandingStranded ────────────────────────────────────────────────────
+
+describe("computeLandingStranded", () => {
+  const completedAt = 1_000_000;
+
+  it("just under the threshold → NOT stranded", () => {
+    expect(
+      computeLandingStranded({
+        landingState: "open",
+        landingReady: true,
+        completedAt,
+        now: completedAt + EPIC_LANDING_STRANDED_MS - 1,
+      }),
+    ).toBe(false);
+  });
+
+  it("just over the threshold → stranded", () => {
+    expect(
+      computeLandingStranded({
+        landingState: "open",
+        landingReady: true,
+        completedAt,
+        now: completedAt + EPIC_LANDING_STRANDED_MS + 1,
+      }),
+    ).toBe(true);
+  });
+
+  it("not-ready → NOT stranded even when old", () => {
+    expect(
+      computeLandingStranded({
+        landingState: "open",
+        landingReady: false,
+        completedAt,
+        now: completedAt + EPIC_LANDING_STRANDED_MS + 99999,
+      }),
+    ).toBe(false);
+  });
+
+  it("landingState != 'open' → NOT stranded", () => {
+    expect(
+      computeLandingStranded({
+        landingState: "pending",
+        landingReady: true,
+        completedAt,
+        now: completedAt + EPIC_LANDING_STRANDED_MS + 1,
+      }),
+    ).toBe(false);
   });
 });

--- a/test/epic-server-land.test.ts
+++ b/test/epic-server-land.test.ts
@@ -42,6 +42,9 @@ function makeForge(opts?: {
     deployConfigured: false,
   };
   const forge: any = {
+    // Host-configured merge method — set to "squash" so the happy-path test proves the handler
+    // uses forge.mergeMethod (not a hardcoded "merge", which would 405 on a squash-only repo).
+    mergeMethod: "squash",
     prStatus: async () => {
       if (opts?.prStatusThrows) throw opts.prStatusThrows;
       return opts?.prStatusResult ?? defaultPrStatus;
@@ -289,7 +292,7 @@ describe("POST /api/epics/completed/land", () => {
     expect(body.error).toMatch(/merge commits disabled/);
   });
 
-  test("happy path: forge.merge called with method:merge+deleteBranch, setEpicLandingPr state merged, epic:completed emitted, 200 ok", async () => {
+  test("happy path: forge.merge called with the host mergeMethod + deleteBranch, setEpicLandingPr state merged, epic:completed emitted, 200 ok", async () => {
     const { forge, mergeCalls } = makeForge();
     const { app, store, epicCompletedEmitted } = landHarness(() => forge);
     seedCompletedEpic(store, repoDir, 42, "open", 77);
@@ -305,9 +308,9 @@ describe("POST /api/epics/completed/land", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
 
-    // merge was called with the right method
+    // merge was called with the host-configured method (forge.mergeMethod = "squash"), not a hardcoded "merge"
     expect(mergeCalls).toHaveLength(1);
-    expect(mergeCalls[0]).toEqual({ prNumber: 77, method: "merge", deleteBranch: true });
+    expect(mergeCalls[0]).toEqual({ prNumber: 77, method: "squash", deleteBranch: true });
 
     // store updated to merged
     const updated = store.listEpicCompleted(repoDir).find((r) => r.parentIssueNumber === 42);

--- a/test/epic-server-land.test.ts
+++ b/test/epic-server-land.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Tests for POST /api/epics/completed/land
+ *
+ * Mirrors the style of epic-server.test.ts (completedHarness pattern).
+ */
+
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { makeApp, type AppDeps } from "../src/server";
+import { SessionStore } from "../src/store";
+import { EventHub } from "../src/events";
+import { config } from "../src/config";
+import type { PrStatus } from "../src/forge/types";
+
+let tmpRoot: string;
+let repoDir: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(config.repoRoot, "shepherd-land-test-"));
+  repoDir = join(tmpRoot, "repo");
+  mkdirSync(repoDir);
+});
+afterEach(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+type FakeMergeInput = { prNumber: number; method: string; deleteBranch: boolean };
+
+function makeForge(opts?: {
+  prStatusResult?: PrStatus;
+  prStatusThrows?: Error;
+  mergeThrows?: Error;
+}): {
+  forge: any;
+  mergeCalls: FakeMergeInput[];
+} {
+  const mergeCalls: FakeMergeInput[] = [];
+  const defaultPrStatus: PrStatus = {
+    state: "open",
+    checks: "success",
+    mergeable: true,
+    mergeStateStatus: "clean",
+    deployConfigured: false,
+  };
+  const forge: any = {
+    prStatus: async () => {
+      if (opts?.prStatusThrows) throw opts.prStatusThrows;
+      return opts?.prStatusResult ?? defaultPrStatus;
+    },
+    merge: async (prNumber: number, o: { method: string; deleteBranch: boolean }) => {
+      if (opts?.mergeThrows) throw opts.mergeThrows;
+      mergeCalls.push({ prNumber, method: o.method, deleteBranch: o.deleteBranch });
+    },
+  };
+  return { forge, mergeCalls };
+}
+
+function landHarness(resolveForge?: AppDeps["resolveForge"]): {
+  app: ReturnType<typeof makeApp>;
+  store: SessionStore;
+  epicCompletedEmitted: unknown[];
+} {
+  const store = new SessionStore(":memory:");
+  const epicCompletedEmitted: unknown[] = [];
+  const events = new EventHub();
+  events.subscribe((event, data) => {
+    if (event === "epic:completed") epicCompletedEmitted.push(data);
+  });
+
+  const drain: AppDeps["drain"] = {
+    snapshot: async () => [],
+    queue: async () => [],
+    retainClaim: () => {},
+    buildEpic: async () => null,
+    approveEpicNext: () => {},
+    tick: async () => {},
+  };
+
+  const deps: AppDeps = {
+    store,
+    service: {} as AppDeps["service"],
+    events,
+    usageLimits: { limits: () => ({}) } as any,
+    drain,
+    resolveForge,
+  };
+  return { app: makeApp(deps), store, epicCompletedEmitted };
+}
+
+function seedCompletedEpic(
+  store: SessionStore,
+  dir: string,
+  parent: number,
+  landingState: "pending" | "open" | "merged" | "none" | "error" = "open",
+  prNumber: number | null = 77,
+) {
+  store.recordEpicCompleted({
+    repoPath: dir,
+    parentIssueNumber: parent,
+    parentTitle: `Epic #${parent}`,
+    completedAt: 1000,
+    childrenJson: JSON.stringify([
+      {
+        number: 1,
+        title: "C1",
+        url: "u1",
+        prNumber: 10,
+        prUrl: "pu10",
+        mergedAt: 900,
+        integrated: true,
+      },
+    ]),
+  });
+  if (landingState !== "pending" || prNumber !== null) {
+    store.setEpicLandingPr(dir, parent, {
+      state: landingState,
+      prNumber,
+      prUrl: prNumber ? `https://example/pr/${prNumber}` : null,
+      attempts: 0,
+    });
+  }
+}
+
+// ── POST /api/epics/completed/land ────────────────────────────────────────────
+
+describe("POST /api/epics/completed/land", () => {
+  test("invalid repo → 400", async () => {
+    const { app } = landHarness();
+    const res = await app.fetch(
+      new Request("http://x/api/epics/completed/land", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: "/nope/not/here", parent: 5 }),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("non-positive parent → 400", async () => {
+    const { app } = landHarness();
+    const res = await app.fetch(
+      new Request("http://x/api/epics/completed/land", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: repoDir, parent: 0 }),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("non-integer parent → 400", async () => {
+    const { app } = landHarness();
+    const res = await app.fetch(
+      new Request("http://x/api/epics/completed/land", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: repoDir, parent: "abc" }),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("missing row → 409 no completed epic", async () => {
+    const { app } = landHarness(() => null);
+    const res = await app.fetch(
+      new Request("http://x/api/epics/completed/land", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: repoDir, parent: 42 }),
+      }),
+    );
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ error: "no completed epic" });
+  });
+
+  test("landingState=pending → 409 landing not open", async () => {
+    const { app, store } = landHarness(() => null);
+    seedCompletedEpic(store, repoDir, 42, "pending", null);
+    const res = await app.fetch(
+      new Request("http://x/api/epics/completed/land", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: repoDir, parent: 42 }),
+      }),
+    );
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ error: "landing not open" });
+  });
+
+  test("landingState=merged → 409 landing not open", async () => {
+    const { app, store } = landHarness(() => null);
+    seedCompletedEpic(store, repoDir, 42, "merged", 77);
+    const res = await app.fetch(
+      new Request("http://x/api/epics/completed/land", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: repoDir, parent: 42 }),
+      }),
+    );
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ error: "landing not open" });
+  });
+
+  test("no forge → 409 no forge", async () => {
+    const { app, store } = landHarness(() => null);
+    seedCompletedEpic(store, repoDir, 42, "open", 77);
+    const res = await app.fetch(
+      new Request("http://x/api/epics/completed/land", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: repoDir, parent: 42 }),
+      }),
+    );
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ error: "no forge" });
+  });
+
+  test("no integration branch pinned → 409", async () => {
+    const { forge } = makeForge();
+    const { app, store } = landHarness(() => forge);
+    seedCompletedEpic(store, repoDir, 42, "open", 77);
+    // No epic_branch row seeded → getEpicIntegrationBranch returns null
+    const res = await app.fetch(
+      new Request("http://x/api/epics/completed/land", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: repoDir, parent: 42 }),
+      }),
+    );
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ error: "no integration branch" });
+  });
+
+  test("PR not ready (blocked mergeStateStatus) → 409, forge.merge NOT called", async () => {
+    const { forge, mergeCalls } = makeForge({
+      prStatusResult: {
+        state: "open",
+        checks: "success",
+        mergeable: true,
+        mergeStateStatus: "blocked",
+        deployConfigured: false,
+      },
+    });
+    const { app, store } = landHarness(() => forge);
+    seedCompletedEpic(store, repoDir, 42, "open", 77);
+    store.getOrInitEpicIntegrationBranch(repoDir, 42, "epic/42-my-epic");
+    const res = await app.fetch(
+      new Request("http://x/api/epics/completed/land", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: repoDir, parent: 42 }),
+      }),
+    );
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ error: "landing PR not ready" });
+    expect(mergeCalls).toHaveLength(0);
+  });
+
+  test("prStatus throws → 502", async () => {
+    const { forge } = makeForge({ prStatusThrows: new Error("network failure") });
+    const { app, store } = landHarness(() => forge);
+    seedCompletedEpic(store, repoDir, 42, "open", 77);
+    store.getOrInitEpicIntegrationBranch(repoDir, 42, "epic/42-my-epic");
+    const res = await app.fetch(
+      new Request("http://x/api/epics/completed/land", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: repoDir, parent: 42 }),
+      }),
+    );
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toMatch(/network failure/);
+  });
+
+  test("forge.merge throws → 502", async () => {
+    const { forge } = makeForge({ mergeThrows: new Error("merge commits disabled") });
+    const { app, store } = landHarness(() => forge);
+    seedCompletedEpic(store, repoDir, 42, "open", 77);
+    store.getOrInitEpicIntegrationBranch(repoDir, 42, "epic/42-my-epic");
+    const res = await app.fetch(
+      new Request("http://x/api/epics/completed/land", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: repoDir, parent: 42 }),
+      }),
+    );
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toMatch(/merge commits disabled/);
+  });
+
+  test("happy path: forge.merge called with method:merge+deleteBranch, setEpicLandingPr state merged, epic:completed emitted, 200 ok", async () => {
+    const { forge, mergeCalls } = makeForge();
+    const { app, store, epicCompletedEmitted } = landHarness(() => forge);
+    seedCompletedEpic(store, repoDir, 42, "open", 77);
+    store.getOrInitEpicIntegrationBranch(repoDir, 42, "epic/42-my-epic");
+
+    const res = await app.fetch(
+      new Request("http://x/api/epics/completed/land", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: repoDir, parent: 42 }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+
+    // merge was called with the right method
+    expect(mergeCalls).toHaveLength(1);
+    expect(mergeCalls[0]).toEqual({ prNumber: 77, method: "merge", deleteBranch: true });
+
+    // store updated to merged
+    const updated = store.listEpicCompleted(repoDir).find((r) => r.parentIssueNumber === 42);
+    expect(updated?.landingState).toBe("merged");
+
+    // epic:completed emitted
+    expect(epicCompletedEmitted).toHaveLength(1);
+    const emitted = epicCompletedEmitted[0] as any;
+    expect(emitted.landingState).toBe("merged");
+    expect(emitted.parentIssueNumber).toBe(42);
+  });
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1872,5 +1872,6 @@
   "integrated_epics_land_stranded": "gestrandet vor {ago}",
   "integrated_epics_land_failed": "Epic konnte nicht gelandet werden — erneut versuchen",
   "feat_land_epic_title": "Integrierte Epics direkt in der App landen",
-  "feat_land_epic_body": "Wenn der Landing-PR eines Epics offen ist und alle Checks bestanden haben, ermöglicht ein neuer 'Epic landen'-Button im Band der integrierten Epics das Mergen mit einem Klick — kein Wechsel zu GitHub nötig."
+  "feat_land_epic_body": "Wenn der Landing-PR eines Epics offen ist und alle Checks bestanden haben, ermöglicht ein neuer 'Epic landen'-Button im Band der integrierten Epics das Mergen mit einem Klick — kein Wechsel zu GitHub nötig.",
+  "landed_epic_toast": "Epic #{number} gelandet — in den Standardbranch gemergt"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1859,5 +1859,18 @@
   "toast_broadcast_result": "Broadcast · {delivered} sofort gesteuert, {queued} bei beschäftigten Agenten in Warteschlange (wird nach aktuellem Zug ausgeführt), {offline} nicht erreichbar.",
   "issuerow_assignee_title": "Zugewiesen an {login}",
   "feat_issue_assignee_title": "Sieh, wer welchem Issue zugewiesen ist",
-  "feat_issue_assignee_body": "Wenn der Filter „meine & nicht zugewiesen“ ausgeschaltet ist, zeigt jedes Issue im Backlog nun einen Chip für jede zugewiesene Person, sodass du auf einen Blick erkennst, wer bereits an einer Aufgabe arbeitet."
+  "feat_issue_assignee_body": "Wenn der Filter „meine & nicht zugewiesen“ ausgeschaltet ist, zeigt jedes Issue im Backlog nun einen Chip für jede zugewiesene Person, sodass du auf einen Blick erkennst, wer bereits an einer Aufgabe arbeitet.",
+  "integrated_epics_awaiting_landing_pill": "WARTET AUF LANDUNG",
+  "integrated_epics_land": "Epic landen",
+  "integrated_epics_land_confirm_prompt": "Landing-PR mergen und Epic schließen?",
+  "integrated_epics_land_confirm_migration_warn": "{count} Migration(en) erkannt — sie wurden nie ausgeführt; vor dem Landen prüfen.",
+  "integrated_epics_land_confirm": "Bestätigen",
+  "integrated_epics_land_not_ready_ci_failing": "CI schlägt beim Landing-PR fehl",
+  "integrated_epics_land_not_ready_computing": "Noch am Prüfen — Checks ausstehend oder Mergebarkeit wird berechnet",
+  "integrated_epics_land_not_ready_conflicts": "Landing-PR hat Konflikte und ist nicht mergebar",
+  "integrated_epics_land_not_ready_generic": "Landing-PR ist noch nicht bereit zum Mergen",
+  "integrated_epics_land_stranded": "gestrandet vor {ago}",
+  "integrated_epics_land_failed": "Epic konnte nicht gelandet werden — erneut versuchen",
+  "feat_land_epic_title": "Integrierte Epics direkt in der App landen",
+  "feat_land_epic_body": "Wenn der Landing-PR eines Epics offen ist und alle Checks bestanden haben, ermöglicht ein neuer 'Epic landen'-Button im Band der integrierten Epics das Mergen mit einem Klick — kein Wechsel zu GitHub nötig."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1859,5 +1859,18 @@
   "toast_broadcast_result": "Broadcast · {delivered} steered now, {queued} queued on busy agents (act after current turn), {offline} unreachable.",
   "issuerow_assignee_title": "Assigned to {login}",
   "feat_issue_assignee_title": "See who's assigned to each issue",
-  "feat_issue_assignee_body": "When the \"mine & unassigned\" issue filter is off, each backlog issue now shows a chip for every assignee, so you can tell at a glance who already owns a piece of work."
+  "feat_issue_assignee_body": "When the \"mine & unassigned\" issue filter is off, each backlog issue now shows a chip for every assignee, so you can tell at a glance who already owns a piece of work.",
+  "integrated_epics_awaiting_landing_pill": "AWAITING LANDING",
+  "integrated_epics_land": "Land epic",
+  "integrated_epics_land_confirm_prompt": "Merge the landing PR and close the epic?",
+  "integrated_epics_land_confirm_migration_warn": "{count} migration(s) detected — they were never run; verify before landing.",
+  "integrated_epics_land_confirm": "Confirm",
+  "integrated_epics_land_not_ready_ci_failing": "CI is failing on the landing PR",
+  "integrated_epics_land_not_ready_computing": "Still computing — checks pending or mergeability resolving",
+  "integrated_epics_land_not_ready_conflicts": "Landing PR has conflicts and is not mergeable",
+  "integrated_epics_land_not_ready_generic": "Landing PR is not ready to merge yet",
+  "integrated_epics_land_stranded": "stranded {ago} ago",
+  "integrated_epics_land_failed": "Couldn't land the epic — try again",
+  "feat_land_epic_title": "Land integrated epics from the app",
+  "feat_land_epic_body": "When an epic's landing PR is open and all checks pass, a new 'Land epic' button in the Integrated-epics band lets you merge it with one click — no need to switch to GitHub."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1872,5 +1872,6 @@
   "integrated_epics_land_stranded": "stranded {ago} ago",
   "integrated_epics_land_failed": "Couldn't land the epic — try again",
   "feat_land_epic_title": "Land integrated epics from the app",
-  "feat_land_epic_body": "When an epic's landing PR is open and all checks pass, a new 'Land epic' button in the Integrated-epics band lets you merge it with one click — no need to switch to GitHub."
+  "feat_land_epic_body": "When an epic's landing PR is open and all checks pass, a new 'Land epic' button in the Integrated-epics band lets you merge it with one click — no need to switch to GitHub.",
+  "landed_epic_toast": "Epic #{number} landed — merged to the default branch"
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1554,6 +1554,13 @@ export async function ackEpicMigrations(
   );
 }
 
+/** Merge the landing PR for a completed epic (#1039). Fails non-2xx on not-ready / not-open / no row
+ *  (409), merge failure (502), or invalid input (400). On success the server emits an `epic:completed`
+ *  WS event with the updated row (`landingState:"merged"`) so the band updates live. */
+export async function landEpic(repoPath: string, parent: number): Promise<{ ok: boolean }> {
+  return postJson("/api/epics/completed/land", { repo: repoPath, parent }, "land epic");
+}
+
 /** Manually trigger the PR-gated doc agent for a repo. 202 → started; 409 → skipped
  *  (with the server's reason); other non-2xx throws. */
 export async function triggerDocAgent(

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -61,6 +61,7 @@
     oncollapse = undefined,
     completedEpics = [],
     ondismissepic = undefined,
+    onlandepic = undefined,
     doneList = [],
     doneSelectedId = null,
     ondoneselect = undefined,
@@ -145,6 +146,8 @@
     completedEpics?: CompletedEpic[];
     // dismiss a completed epic from the band; page owns the optimistic remove + reconcile
     ondismissepic?: (repoPath: string, parent: number) => void;
+    // merge the landing PR for a completed epic (#1039); server emits epic:completed on success
+    onlandepic?: (repoPath: string, parent: number) => void;
     // Done lens: the archived ("done") sessions to list when filter === "done" (newest
     // first; the endpoint already orders them). These are NOT live sessions — they live in
     // the page's lazy doneSessions store, distinct from `sessions`.
@@ -474,6 +477,7 @@
         epics={completedEpics}
         ondismiss={ondismissepic ?? (() => {})}
         onackmigrations={onackmigrationsepic ?? (() => {})}
+        onland={onlandepic ?? (() => {})}
         {nowMs}
       />
     {/if}

--- a/ui/src/lib/components/IntegratedEpicLanding.svelte
+++ b/ui/src/lib/components/IntegratedEpicLanding.svelte
@@ -1,0 +1,264 @@
+<script lang="ts">
+  import type { CompletedEpic } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import { formatAgo } from "$lib/format";
+
+  let {
+    epic,
+    nowMs = Date.now(),
+    onland,
+    ondismiss,
+    onackmigrations,
+  }: {
+    epic: CompletedEpic;
+    nowMs?: number;
+    onland: (repoPath: string, parent: number) => void;
+    ondismiss: (repoPath: string, parent: number) => void;
+    onackmigrations: (repoPath: string, parent: number) => void;
+  } = $props();
+
+  let confirming = $state(false);
+
+  const migrationCount = $derived(epic.migrationPaths.length);
+  const pendingAck = $derived(migrationCount > 0 && epic.migrationsAckedAt == null);
+
+  const parentUrl = $derived.by(() => {
+    const ref = epic.children.find((c) => c.url)?.url;
+    if (!ref) return null;
+    return ref.replace(/\/\d+(?=\/?$)/, `/${epic.parentIssueNumber}`);
+  });
+
+  const isOpen = $derived(epic.landingState === "open");
+
+  const landNotReadyReason = $derived.by((): string => {
+    if (epic.landingChecks === "failure") return m.integrated_epics_land_not_ready_ci_failing();
+    if (epic.landingChecks === "pending" || epic.landingMergeable === null)
+      return m.integrated_epics_land_not_ready_computing();
+    if (epic.landingMergeable === false) return m.integrated_epics_land_not_ready_conflicts();
+    return m.integrated_epics_land_not_ready_generic();
+  });
+
+  function handleLandConfirm() {
+    confirming = false;
+    onland(epic.repoPath, epic.parentIssueNumber);
+  }
+</script>
+
+<div class="actions">
+  {#if isOpen}
+    <!-- open state: Land CTA (+ Dismiss); Ack-migrations path suppressed here to avoid
+         silently clearing an unlanded epic (the bug #1039 fixes). Migration advisory
+         moves into the Land confirm step instead. -->
+    {#if epic.landingPrNumber != null}
+      {#if confirming}
+        <span class="confirm-prompt">
+          {m.integrated_epics_land_confirm_prompt()}
+          {#if pendingAck}
+            <span class="confirm-migration-warn"
+              >{m.integrated_epics_land_confirm_migration_warn({
+                count: migrationCount,
+              })}</span
+            >
+          {/if}
+        </span>
+        <button class="gbtn gbtn-primary" type="button" onclick={handleLandConfirm}>
+          {m.integrated_epics_land_confirm()}
+        </button>
+        <button class="gbtn" type="button" onclick={() => (confirming = false)}>
+          {m.common_cancel()}
+        </button>
+      {:else}
+        {#if epic.landingStranded}
+          <span class="chip-stranded"
+            >{m.integrated_epics_land_stranded({
+              ago: formatAgo(nowMs - epic.completedAt),
+            })}</span
+          >
+        {/if}
+        {#if epic.landingReady === true}
+          <button class="gbtn" type="button" onclick={() => (confirming = true)}>
+            {m.integrated_epics_land()}
+          </button>
+        {:else}
+          <button
+            class="gbtn"
+            type="button"
+            disabled
+            title={landNotReadyReason}
+            aria-disabled="true"
+          >
+            {m.integrated_epics_land()}
+          </button>
+        {/if}
+      {/if}
+    {/if}
+    <!-- Always show Dismiss in open state (explicit operator hide) -->
+    {#if !confirming}
+      <button
+        class="gbtn"
+        type="button"
+        title={m.integrated_epics_dismiss()}
+        onclick={() => ondismiss(epic.repoPath, epic.parentIssueNumber)}
+      >
+        {m.integrated_epics_dismiss()}
+      </button>
+    {/if}
+    {#if epic.landingPrUrl}
+      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
+      <a class="awaiting" href={epic.landingPrUrl} target="_blank" rel="noopener noreferrer"
+        >{m.integrated_epics_landing_pr({ number: epic.landingPrNumber! })}</a
+      >
+    {:else if epic.landingPrNumber != null}
+      <span class="awaiting">{m.integrated_epics_landing_pr({ number: epic.landingPrNumber })}</span
+      >
+    {/if}
+  {:else if pendingAck && epic.landingState !== "open"}
+    <!-- legacy/rare Ack-migrations path: only for non-open states with pending migrations -->
+    <span class="chip-migrations" title={m.epic_migrations_pending({ count: migrationCount })}>
+      {m.epic_migrations_pending({ count: migrationCount })}
+    </span>
+    <button
+      class="gbtn"
+      type="button"
+      title={m.integrated_epics_ack_migrations()}
+      onclick={() => onackmigrations(epic.repoPath, epic.parentIssueNumber)}
+    >
+      {m.integrated_epics_ack_migrations()}
+    </button>
+  {:else if epic.landingState !== "open"}
+    <button
+      class="gbtn"
+      type="button"
+      title={m.integrated_epics_dismiss()}
+      onclick={() => ondismiss(epic.repoPath, epic.parentIssueNumber)}
+    >
+      {m.integrated_epics_dismiss()}
+    </button>
+  {/if}
+  {#if !isOpen}
+    {#if epic.landingState === "merged" && epic.landingPrNumber != null}
+      {#if epic.landingPrUrl}
+        <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
+        <a class="awaiting" href={epic.landingPrUrl} target="_blank" rel="noopener noreferrer"
+          >{m.integrated_epics_landing_pr_merged({ number: epic.landingPrNumber })}</a
+        >
+      {:else}
+        <span class="awaiting"
+          >{m.integrated_epics_landing_pr_merged({ number: epic.landingPrNumber })}</span
+        >
+      {/if}
+    {:else if epic.landingState === "error"}
+      <span class="landing-failed">{m.integrated_epics_landing_failed()}</span>
+    {:else if parentUrl}
+      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
+      <a class="awaiting" href={parentUrl} target="_blank" rel="noopener noreferrer"
+        >{m.integrated_epics_awaiting_landing({ number: epic.parentIssueNumber })}</a
+      >
+    {:else}
+      <span class="awaiting"
+        >{m.integrated_epics_awaiting_landing({ number: epic.parentIssueNumber })}</span
+      >
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    padding: 2px 8px 6px;
+  }
+  /* Quiet/muted "parent still open" note. */
+  .awaiting {
+    color: var(--color-faint);
+    font-size: var(--fs-micro);
+    text-decoration: none;
+  }
+  a.awaiting:hover {
+    color: var(--color-muted);
+    text-decoration: underline;
+  }
+  /* Quiet warning note — landing PR couldn't be opened (no link yet). */
+  .landing-failed {
+    color: var(--status-warn);
+    font-size: var(--fs-micro);
+  }
+
+  /* Warning-tone chip — unrun migrations need operator verification before clearing the row.
+     Warn = caution (NOT success-green); mirrors the .badge recipe with the warn hue. */
+  .chip-migrations {
+    flex: none;
+    font-size: var(--fs-micro);
+    letter-spacing: 0.08em;
+    padding: 1px 6px;
+    border: 1px solid var(--status-warn);
+    border-radius: 2px;
+    color: var(--status-warn);
+    background: color-mix(in oklab, var(--status-warn) 12%, transparent);
+  }
+
+  /* Stranded escalation badge — open+unlanded past 6h threshold */
+  .chip-stranded {
+    flex: none;
+    font-size: var(--fs-micro);
+    letter-spacing: 0.08em;
+    padding: 1px 6px;
+    border: 1px solid var(--status-warn);
+    border-radius: 2px;
+    color: var(--status-warn);
+    background: color-mix(in oklab, var(--status-warn) 12%, transparent);
+    text-transform: uppercase;
+  }
+
+  /* Inline confirm step — prompt text + migration warning */
+  .confirm-prompt {
+    font-size: var(--fs-micro);
+    color: var(--color-muted);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+  .confirm-migration-warn {
+    color: var(--status-warn);
+  }
+
+  /* Canonical .gbtn recipe (scoped per-component; see /design-system). */
+  .gbtn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 2px 8px;
+    cursor: pointer;
+    transition:
+      border-color 0.12s,
+      color 0.12s;
+  }
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .gbtn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+  .gbtn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  /* Primary confirm button — slightly elevated */
+  .gbtn-primary {
+    border-color: var(--status-warn);
+    color: var(--status-warn);
+  }
+  .gbtn-primary:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+</style>

--- a/ui/src/lib/components/IntegratedEpicRow.browser.test.ts
+++ b/ui/src/lib/components/IntegratedEpicRow.browser.test.ts
@@ -41,6 +41,7 @@ describe("IntegratedEpicRow", () => {
       epic: epic([child({ number: 1 }), child({ number: 2 })]),
       ondismiss: vi.fn(),
       onackmigrations: vi.fn(),
+      onland: vi.fn(),
     });
     await expect.element(page.getByText("INTEGRATED 2/2")).toBeInTheDocument();
     const chip = document.querySelector(".chip") as HTMLElement;
@@ -67,6 +68,7 @@ describe("IntegratedEpicRow", () => {
       ]),
       ondismiss: vi.fn(),
       onackmigrations: vi.fn(),
+      onland: vi.fn(),
     });
     // mixed epic: merged counts only integrated children, total counts all → 1/2 (not 2/2)
     await expect.element(page.getByText("INTEGRATED 1/2")).toBeInTheDocument();
@@ -100,6 +102,7 @@ describe("IntegratedEpicRow", () => {
       ]),
       ondismiss: vi.fn(),
       onackmigrations: vi.fn(),
+      onland: vi.fn(),
     });
     (document.querySelector(".row-head") as HTMLButtonElement).click();
 
@@ -127,6 +130,7 @@ describe("IntegratedEpicRow", () => {
       ]),
       ondismiss: vi.fn(),
       onackmigrations: vi.fn(),
+      onland: vi.fn(),
     });
     (document.querySelector(".row-head") as HTMLButtonElement).click();
 
@@ -143,31 +147,33 @@ describe("IntegratedEpicRow", () => {
     expect(document.querySelector(".child .closed")).toBeNull();
   });
 
-  it("landingState 'open' with a PR number renders the Landing PR link to landingPrUrl", async () => {
+  it("landingState 'open' with a PR number renders the Land button + awaiting-landing link", async () => {
     render(IntegratedEpicRow, {
       epic: epic([child({ number: 1 })], {
         landingState: "open",
         landingPrNumber: 42,
         landingPrUrl: "https://github.com/o/r/pull/42",
+        landingReady: true,
       }),
       ondismiss: vi.fn(),
       onackmigrations: vi.fn(),
+      onland: vi.fn(),
     });
     (document.querySelector(".row-head") as HTMLButtonElement).click();
 
-    const link = await vi.waitFor(() => {
-      const a = [...document.querySelectorAll(".actions a")].find((el) =>
-        el.textContent?.includes("Landing PR #42"),
-      ) as HTMLAnchorElement | undefined;
-      if (!a) throw new Error("no landing pr link yet");
-      return a;
+    // Land button must be present and enabled
+    const landBtn = await vi.waitFor(() => {
+      const btns = [...document.querySelectorAll(".actions .gbtn")] as HTMLButtonElement[];
+      const b = btns.find((el) => el.textContent?.includes("Land epic"));
+      if (!b) throw new Error("no land button yet");
+      return b;
     });
-    expect(link.getAttribute("href")).toBe("https://github.com/o/r/pull/42");
+    expect(landBtn.disabled).toBe(false);
     // not the fallback awaiting-landing copy
     expect(document.querySelector(".actions")?.textContent).not.toContain("awaiting landing");
   });
 
-  it("landingState 'merged' renders the merged Landing PR link, not the awaiting copy", async () => {
+  it("landingState 'merged' renders the merged Landing PR link, no Land button", async () => {
     render(IntegratedEpicRow, {
       epic: epic([child({ number: 1 })], {
         landingState: "merged",
@@ -176,6 +182,7 @@ describe("IntegratedEpicRow", () => {
       }),
       ondismiss: vi.fn(),
       onackmigrations: vi.fn(),
+      onland: vi.fn(),
     });
     (document.querySelector(".row-head") as HTMLButtonElement).click();
 
@@ -191,6 +198,9 @@ describe("IntegratedEpicRow", () => {
     // not the "awaiting merge" copy, not the awaiting-landing fallback
     expect(document.querySelector(".actions")?.textContent).not.toContain("awaiting merge");
     expect(document.querySelector(".actions")?.textContent).not.toContain("awaiting landing");
+    // No Land button in merged state
+    const btns = [...document.querySelectorAll(".actions .gbtn")] as HTMLButtonElement[];
+    expect(btns.find((b) => b.textContent?.includes("Land epic"))).toBeUndefined();
   });
 
   it("landingState 'error' renders the failure note and NO PR link", async () => {
@@ -202,6 +212,7 @@ describe("IntegratedEpicRow", () => {
       }),
       ondismiss: vi.fn(),
       onackmigrations: vi.fn(),
+      onland: vi.fn(),
     });
     (document.querySelector(".row-head") as HTMLButtonElement).click();
 
@@ -220,6 +231,7 @@ describe("IntegratedEpicRow", () => {
       epic: epic([child({ number: 1 })], { landingState: "pending" }),
       ondismiss: vi.fn(),
       onackmigrations: vi.fn(),
+      onland: vi.fn(),
     });
     (document.querySelector(".row-head") as HTMLButtonElement).click();
 
@@ -238,10 +250,12 @@ describe("IntegratedEpicRow", () => {
       epic: epic([child({ number: 1 })], { repoPath: "/x/y/zrepo", parentIssueNumber: 42 }),
       ondismiss,
       onackmigrations: vi.fn(),
+      onland: vi.fn(),
     });
     (document.querySelector(".row-head") as HTMLButtonElement).click();
     const btn = await vi.waitFor(() => {
-      const b = document.querySelector(".actions .gbtn") as HTMLButtonElement | null;
+      const btns = [...document.querySelectorAll(".actions .gbtn")] as HTMLButtonElement[];
+      const b = btns.find((el) => el.textContent?.includes("Dismiss"));
       if (!b) throw new Error("no dismiss yet");
       return b;
     });
@@ -257,9 +271,12 @@ describe("IntegratedEpicRow", () => {
       epic: epic([child({ number: 1 })], {
         migrationPaths: ["server/migrations/001.sql", "drizzle/0002.sql"],
         migrationsAckedAt: null,
+        // landingState defaults to "pending" — ack path is for non-open states
+        landingState: "pending",
       }),
       ondismiss: vi.fn(),
       onackmigrations: vi.fn(),
+      onland: vi.fn(),
     });
     (document.querySelector(".row-head") as HTMLButtonElement).click();
 
@@ -287,6 +304,7 @@ describe("IntegratedEpicRow", () => {
       }),
       ondismiss: vi.fn(),
       onackmigrations: vi.fn(),
+      onland: vi.fn(),
     });
     (document.querySelector(".row-head") as HTMLButtonElement).click();
     await vi.waitFor(() => {
@@ -302,6 +320,7 @@ describe("IntegratedEpicRow", () => {
       epic: epic([child({ number: 1 })], { migrationPaths: [], migrationsAckedAt: null }),
       ondismiss: vi.fn(),
       onackmigrations: vi.fn(),
+      onland: vi.fn(),
     });
     (document.querySelector(".row-head") as HTMLButtonElement).click();
     await vi.waitFor(() => {
@@ -319,9 +338,11 @@ describe("IntegratedEpicRow", () => {
         parentIssueNumber: 42,
         migrationPaths: ["migrations/001.sql"],
         migrationsAckedAt: null,
+        landingState: "pending",
       }),
       ondismiss: vi.fn(),
       onackmigrations,
+      onland: vi.fn(),
     });
     (document.querySelector(".row-head") as HTMLButtonElement).click();
     const btn = await vi.waitFor(() => {
@@ -332,5 +353,228 @@ describe("IntegratedEpicRow", () => {
     btn.click();
     expect(onackmigrations).toHaveBeenCalledTimes(1);
     expect(onackmigrations).toHaveBeenCalledWith("/x/y/zrepo", 42);
+  });
+
+  // ── Land epic CTA (#1039) ──────────────────────────────────────────────────
+
+  it("open+ready: Land button present, enabled; clicking shows confirm step; confirming calls onland", async () => {
+    const onland = vi.fn();
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], {
+        repoPath: "/x/y/zrepo",
+        parentIssueNumber: 42,
+        landingState: "open",
+        landingPrNumber: 55,
+        landingPrUrl: "https://github.com/o/r/pull/55",
+        landingReady: true,
+      }),
+      ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
+      onland,
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+
+    const landBtn = await vi.waitFor(() => {
+      const btns = [...document.querySelectorAll(".actions .gbtn")] as HTMLButtonElement[];
+      const b = btns.find((el) => el.textContent?.includes("Land epic"));
+      if (!b) throw new Error("no land button");
+      return b;
+    });
+    expect(landBtn.disabled).toBe(false);
+
+    // click → confirm step appears
+    landBtn.click();
+    const confirmBtn = await vi.waitFor(() => {
+      const btns = [...document.querySelectorAll(".actions .gbtn")] as HTMLButtonElement[];
+      const b = btns.find((el) => el.textContent?.trim() === "Confirm");
+      if (!b) throw new Error("no confirm button");
+      return b;
+    });
+    expect(document.querySelector(".actions")?.textContent).toContain(
+      "Merge the landing PR and close the epic?",
+    );
+
+    // confirm → calls onland with correct args
+    confirmBtn.click();
+    expect(onland).toHaveBeenCalledTimes(1);
+    expect(onland).toHaveBeenCalledWith("/x/y/zrepo", 42);
+  });
+
+  it("open+not-ready: Land button is disabled with a tooltip", async () => {
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], {
+        landingState: "open",
+        landingPrNumber: 55,
+        landingPrUrl: "https://github.com/o/r/pull/55",
+        landingReady: false,
+        landingChecks: "failure",
+      }),
+      ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
+      onland: vi.fn(),
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+
+    const landBtn = await vi.waitFor(() => {
+      const btns = [...document.querySelectorAll(".actions .gbtn")] as HTMLButtonElement[];
+      const b = btns.find((el) => el.textContent?.includes("Land epic"));
+      if (!b) throw new Error("no land button");
+      return b;
+    });
+    expect(landBtn.disabled).toBe(true);
+    expect(landBtn.title).toBeTruthy();
+    expect(landBtn.title).toContain("CI");
+  });
+
+  it("open+landingReady undefined: Land button disabled with generic tooltip", async () => {
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], {
+        landingState: "open",
+        landingPrNumber: 55,
+        landingPrUrl: "https://github.com/o/r/pull/55",
+        // landingReady undefined (forge unreachable)
+      }),
+      ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
+      onland: vi.fn(),
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+
+    const landBtn = await vi.waitFor(() => {
+      const btns = [...document.querySelectorAll(".actions .gbtn")] as HTMLButtonElement[];
+      const b = btns.find((el) => el.textContent?.includes("Land epic"));
+      if (!b) throw new Error("no land button");
+      return b;
+    });
+    expect(landBtn.disabled).toBe(true);
+    expect(landBtn.title).toBeTruthy();
+  });
+
+  it("landingStranded: stranded badge is rendered", async () => {
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], {
+        landingState: "open",
+        landingPrNumber: 55,
+        landingPrUrl: "https://github.com/o/r/pull/55",
+        landingReady: false,
+        landingStranded: true,
+      }),
+      ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
+      onland: vi.fn(),
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+
+    const badge = await vi.waitFor(() => {
+      const el = document.querySelector(".actions .chip-stranded") as HTMLElement | null;
+      if (!el) throw new Error("no stranded badge");
+      return el;
+    });
+    expect(badge.textContent?.toLowerCase()).toContain("stranded");
+  });
+
+  it("open+pendingAck: Ack-migrations button NOT rendered; Land button shown; migration warn in confirm step", async () => {
+    const onland = vi.fn();
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], {
+        landingState: "open",
+        landingPrNumber: 55,
+        landingPrUrl: "https://github.com/o/r/pull/55",
+        landingReady: true,
+        migrationPaths: ["migrations/001.sql", "migrations/002.sql"],
+        migrationsAckedAt: null,
+      }),
+      ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
+      onland,
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+
+    await vi.waitFor(() => {
+      const btns = [...document.querySelectorAll(".actions .gbtn")] as HTMLButtonElement[];
+      if (!btns.find((b) => b.textContent?.includes("Land epic"))) throw new Error("no land btn");
+    });
+
+    const actionText = document.querySelector(".actions")?.textContent ?? "";
+    // Ack-migrations button must NOT appear in open state
+    expect(actionText).not.toContain("Acknowledge migrations");
+
+    // click Land → confirm step with migration warning
+    const landBtn = [...document.querySelectorAll(".actions .gbtn")].find((b) =>
+      b.textContent?.includes("Land epic"),
+    ) as HTMLButtonElement;
+    landBtn.click();
+
+    const confirmText = await vi.waitFor(() => {
+      const t = document.querySelector(".actions")?.textContent ?? "";
+      if (!t.includes("migration")) throw new Error("no migration warn in confirm");
+      return t;
+    });
+    expect(confirmText).toContain("2 migration");
+  });
+
+  it("pendingAck+landingState NOT open: Ack-migrations button still rendered (legacy unchanged)", async () => {
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], {
+        landingState: "pending",
+        migrationPaths: ["migrations/001.sql"],
+        migrationsAckedAt: null,
+      }),
+      ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
+      onland: vi.fn(),
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+
+    const ackBtn = await vi.waitFor(() => {
+      const btns = [...document.querySelectorAll(".actions .gbtn")] as HTMLButtonElement[];
+      const b = btns.find((el) => el.textContent?.includes("Acknowledge migrations"));
+      if (!b) throw new Error("no ack button");
+      return b;
+    });
+    expect(ackBtn).toBeTruthy();
+    // No Land button when landingState is not "open"
+    const btns = [...document.querySelectorAll(".actions .gbtn")] as HTMLButtonElement[];
+    expect(btns.find((b) => b.textContent?.includes("Land epic"))).toBeUndefined();
+  });
+
+  it("confirm cancel: clicking Cancel resets confirming state without calling onland", async () => {
+    const onland = vi.fn();
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], {
+        landingState: "open",
+        landingPrNumber: 55,
+        landingPrUrl: "https://github.com/o/r/pull/55",
+        landingReady: true,
+      }),
+      ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
+      onland,
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+
+    const landBtn = await vi.waitFor(() => {
+      const btns = [...document.querySelectorAll(".actions .gbtn")] as HTMLButtonElement[];
+      const b = btns.find((el) => el.textContent?.includes("Land epic"));
+      if (!b) throw new Error("no land button");
+      return b;
+    });
+    landBtn.click();
+
+    // Cancel should be visible
+    const cancelBtn = await vi.waitFor(() => {
+      const btns = [...document.querySelectorAll(".actions .gbtn")] as HTMLButtonElement[];
+      const b = btns.find((el) => el.textContent?.trim() === "Cancel");
+      if (!b) throw new Error("no cancel button");
+      return b;
+    });
+    cancelBtn.click();
+
+    // Land button reappears, onland not called
+    await vi.waitFor(() => {
+      const btns = [...document.querySelectorAll(".actions .gbtn")] as HTMLButtonElement[];
+      if (!btns.find((b) => b.textContent?.includes("Land epic"))) throw new Error("land not back");
+    });
+    expect(onland).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/lib/components/IntegratedEpicRow.svelte
+++ b/ui/src/lib/components/IntegratedEpicRow.svelte
@@ -2,6 +2,7 @@
   import type { CompletedEpic } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { formatAgo } from "$lib/format";
+  import IntegratedEpicLanding from "./IntegratedEpicLanding.svelte";
 
   let {
     epic,
@@ -18,16 +19,6 @@
   } = $props();
 
   let open = $state(false);
-  let confirming = $state(false);
-
-  // Migration-awareness checkpoint (#645): the landing PR carries unacknowledged migration
-  // files. The harness never runs them (read-only critic, no DB), so the operator must verify +
-  // acknowledge before clearing the row. Count derives from the array — no hardcoded number.
-  // Note: acknowledging dismisses the row server-side (ackEpicMigrations sets dismissedAt, which
-  // listEpicCompleted filters out), so a displayed row always has migrationsAckedAt == null; the
-  // == null guard is belt-and-suspenders, not the gate. The real gate is the row being shown.
-  const migrationCount = $derived(epic.migrationPaths.length);
-  const pendingAck = $derived(migrationCount > 0 && epic.migrationsAckedAt == null);
 
   // repo basename — last path segment (e.g. "community-map")
   const repoName = $derived(epic.repoPath.split("/").filter(Boolean).at(-1) ?? epic.repoPath);
@@ -36,31 +27,8 @@
   const total = $derived(epic.children.length);
   const merged = $derived(epic.children.filter((c) => c.integrated).length);
 
-  // Parent issue URL derived from any child's issue URL: children are all issues in
-  // the same repo (".../issues/<n>"), so swapping the trailing /<n> for the parent
-  // number targets the parent issue. Null when no child carries a url → plain text.
-  const parentUrl = $derived.by(() => {
-    const ref = epic.children.find((c) => c.url)?.url;
-    if (!ref) return null;
-    return ref.replace(/\/\d+(?=\/?$)/, `/${epic.parentIssueNumber}`);
-  });
-
   // Whether this row is in "action needed" open-landing state.
   const isOpen = $derived(epic.landingState === "open");
-
-  // Derive a tooltip for the disabled Land button when not ready.
-  const landNotReadyReason = $derived.by((): string => {
-    if (epic.landingChecks === "failure") return m.integrated_epics_land_not_ready_ci_failing();
-    if (epic.landingChecks === "pending" || epic.landingMergeable === null)
-      return m.integrated_epics_land_not_ready_computing();
-    if (epic.landingMergeable === false) return m.integrated_epics_land_not_ready_conflicts();
-    return m.integrated_epics_land_not_ready_generic();
-  });
-
-  function handleLandConfirm() {
-    confirming = false;
-    onland(epic.repoPath, epic.parentIssueNumber);
-  }
 </script>
 
 <div class="row" role="region" aria-label={epic.parentTitle}>
@@ -125,124 +93,7 @@
       {/each}
     </ul>
 
-    <div class="actions">
-      {#if isOpen}
-        <!-- open state: Land CTA (+ Dismiss); Ack-migrations path suppressed here to avoid
-             silently clearing an unlanded epic (the bug #1039 fixes). Migration advisory
-             moves into the Land confirm step instead. -->
-        {#if epic.landingPrNumber != null}
-          {#if confirming}
-            <span class="confirm-prompt">
-              {m.integrated_epics_land_confirm_prompt()}
-              {#if pendingAck}
-                <span class="confirm-migration-warn"
-                  >{m.integrated_epics_land_confirm_migration_warn({
-                    count: migrationCount,
-                  })}</span
-                >
-              {/if}
-            </span>
-            <button class="gbtn gbtn-primary" type="button" onclick={handleLandConfirm}>
-              {m.integrated_epics_land_confirm()}
-            </button>
-            <button class="gbtn" type="button" onclick={() => (confirming = false)}>
-              {m.common_cancel()}
-            </button>
-          {:else}
-            {#if epic.landingStranded}
-              <span class="chip-stranded"
-                >{m.integrated_epics_land_stranded({
-                  ago: formatAgo(nowMs - epic.completedAt),
-                })}</span
-              >
-            {/if}
-            {#if epic.landingReady === true}
-              <button class="gbtn" type="button" onclick={() => (confirming = true)}>
-                {m.integrated_epics_land()}
-              </button>
-            {:else}
-              <button
-                class="gbtn"
-                type="button"
-                disabled
-                title={landNotReadyReason}
-                aria-disabled="true"
-              >
-                {m.integrated_epics_land()}
-              </button>
-            {/if}
-          {/if}
-        {/if}
-        <!-- Always show Dismiss in open state (explicit operator hide) -->
-        {#if !confirming}
-          <button
-            class="gbtn"
-            type="button"
-            title={m.integrated_epics_dismiss()}
-            onclick={() => ondismiss(epic.repoPath, epic.parentIssueNumber)}
-          >
-            {m.integrated_epics_dismiss()}
-          </button>
-        {/if}
-        {#if epic.landingPrUrl}
-          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
-          <a class="awaiting" href={epic.landingPrUrl} target="_blank" rel="noopener noreferrer"
-            >{m.integrated_epics_landing_pr({ number: epic.landingPrNumber! })}</a
-          >
-        {:else if epic.landingPrNumber != null}
-          <span class="awaiting"
-            >{m.integrated_epics_landing_pr({ number: epic.landingPrNumber })}</span
-          >
-        {/if}
-      {:else if pendingAck && epic.landingState !== "open"}
-        <!-- legacy/rare Ack-migrations path: only for non-open states with pending migrations -->
-        <span class="chip-migrations" title={m.epic_migrations_pending({ count: migrationCount })}>
-          {m.epic_migrations_pending({ count: migrationCount })}
-        </span>
-        <button
-          class="gbtn"
-          type="button"
-          title={m.integrated_epics_ack_migrations()}
-          onclick={() => onackmigrations(epic.repoPath, epic.parentIssueNumber)}
-        >
-          {m.integrated_epics_ack_migrations()}
-        </button>
-      {:else if epic.landingState !== "open"}
-        <button
-          class="gbtn"
-          type="button"
-          title={m.integrated_epics_dismiss()}
-          onclick={() => ondismiss(epic.repoPath, epic.parentIssueNumber)}
-        >
-          {m.integrated_epics_dismiss()}
-        </button>
-      {/if}
-      {#if !isOpen}
-        {#if epic.landingState === "merged" && epic.landingPrNumber != null}
-          {#if epic.landingPrUrl}
-            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
-            <a class="awaiting" href={epic.landingPrUrl} target="_blank" rel="noopener noreferrer"
-              >{m.integrated_epics_landing_pr_merged({ number: epic.landingPrNumber })}</a
-            >
-          {:else}
-            <span class="awaiting"
-              >{m.integrated_epics_landing_pr_merged({ number: epic.landingPrNumber })}</span
-            >
-          {/if}
-        {:else if epic.landingState === "error"}
-          <span class="landing-failed">{m.integrated_epics_landing_failed()}</span>
-        {:else if parentUrl}
-          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
-          <a class="awaiting" href={parentUrl} target="_blank" rel="noopener noreferrer"
-            >{m.integrated_epics_awaiting_landing({ number: epic.parentIssueNumber })}</a
-          >
-        {:else}
-          <span class="awaiting"
-            >{m.integrated_epics_awaiting_landing({ number: epic.parentIssueNumber })}</span
-          >
-        {/if}
-      {/if}
-    </div>
+    <IntegratedEpicLanding {epic} {nowMs} {onland} {ondismiss} {onackmigrations} />
   {/if}
 </div>
 
@@ -375,104 +226,5 @@
     font-size: var(--fs-micro);
     text-transform: uppercase;
     letter-spacing: 0.08em;
-  }
-
-  .actions {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    flex-wrap: wrap;
-    padding: 2px 8px 6px;
-  }
-  /* Quiet/muted "parent still open" note. */
-  .awaiting {
-    color: var(--color-faint);
-    font-size: var(--fs-micro);
-    text-decoration: none;
-  }
-  a.awaiting:hover {
-    color: var(--color-muted);
-    text-decoration: underline;
-  }
-  /* Quiet warning note — landing PR couldn't be opened (no link yet). */
-  .landing-failed {
-    color: var(--status-warn);
-    font-size: var(--fs-micro);
-  }
-
-  /* Warning-tone chip — unrun migrations need operator verification before clearing the row.
-     Warn = caution (NOT success-green); mirrors the .badge recipe with the warn hue. */
-  .chip-migrations {
-    flex: none;
-    font-size: var(--fs-micro);
-    letter-spacing: 0.08em;
-    padding: 1px 6px;
-    border: 1px solid var(--status-warn);
-    border-radius: 2px;
-    color: var(--status-warn);
-    background: color-mix(in oklab, var(--status-warn) 12%, transparent);
-  }
-
-  /* Stranded escalation badge — open+unlanded past 6h threshold */
-  .chip-stranded {
-    flex: none;
-    font-size: var(--fs-micro);
-    letter-spacing: 0.08em;
-    padding: 1px 6px;
-    border: 1px solid var(--status-warn);
-    border-radius: 2px;
-    color: var(--status-warn);
-    background: color-mix(in oklab, var(--status-warn) 12%, transparent);
-    text-transform: uppercase;
-  }
-
-  /* Inline confirm step — prompt text + migration warning */
-  .confirm-prompt {
-    font-size: var(--fs-micro);
-    color: var(--color-muted);
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    flex-wrap: wrap;
-  }
-  .confirm-migration-warn {
-    color: var(--status-warn);
-  }
-
-  /* Canonical .gbtn recipe (scoped per-component; see /design-system). */
-  .gbtn {
-    background: transparent;
-    border: 1px solid var(--color-line);
-    border-radius: 2px;
-    color: var(--color-muted);
-    font-family: var(--font-mono);
-    font-size: var(--fs-meta);
-    letter-spacing: 0.08em;
-    padding: 2px 8px;
-    cursor: pointer;
-    transition:
-      border-color 0.12s,
-      color 0.12s;
-  }
-  .gbtn:hover:not(:disabled) {
-    border-color: var(--color-amber);
-    color: var(--color-amber);
-  }
-  .gbtn:focus-visible {
-    outline: none;
-    box-shadow: inset 0 0 0 1px var(--color-amber);
-  }
-  .gbtn:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
-  /* Primary confirm button — slightly elevated */
-  .gbtn-primary {
-    border-color: var(--status-warn);
-    color: var(--status-warn);
-  }
-  .gbtn-primary:hover:not(:disabled) {
-    border-color: var(--color-amber);
-    color: var(--color-amber);
   }
 </style>

--- a/ui/src/lib/components/IntegratedEpicRow.svelte
+++ b/ui/src/lib/components/IntegratedEpicRow.svelte
@@ -7,15 +7,18 @@
     epic,
     ondismiss,
     onackmigrations,
+    onland,
     nowMs = Date.now(),
   }: {
     epic: CompletedEpic;
     ondismiss: (repoPath: string, parent: number) => void;
     onackmigrations: (repoPath: string, parent: number) => void;
+    onland: (repoPath: string, parent: number) => void;
     nowMs?: number;
   } = $props();
 
   let open = $state(false);
+  let confirming = $state(false);
 
   // Migration-awareness checkpoint (#645): the landing PR carries unacknowledged migration
   // files. The harness never runs them (read-only critic, no DB), so the operator must verify +
@@ -41,12 +44,30 @@
     if (!ref) return null;
     return ref.replace(/\/\d+(?=\/?$)/, `/${epic.parentIssueNumber}`);
   });
+
+  // Whether this row is in "action needed" open-landing state.
+  const isOpen = $derived(epic.landingState === "open");
+
+  // Derive a tooltip for the disabled Land button when not ready.
+  const landNotReadyReason = $derived.by((): string => {
+    if (epic.landingChecks === "failure") return m.integrated_epics_land_not_ready_ci_failing();
+    if (epic.landingChecks === "pending" || epic.landingMergeable === null)
+      return m.integrated_epics_land_not_ready_computing();
+    if (epic.landingMergeable === false) return m.integrated_epics_land_not_ready_conflicts();
+    return m.integrated_epics_land_not_ready_generic();
+  });
+
+  function handleLandConfirm() {
+    confirming = false;
+    onland(epic.repoPath, epic.parentIssueNumber);
+  }
 </script>
 
 <div class="row" role="region" aria-label={epic.parentTitle}>
   <button
     type="button"
     class="row-head"
+    class:row-head-open={isOpen}
     aria-expanded={open}
     aria-label={open
       ? m.integrated_epics_collapse_aria({ number: epic.parentIssueNumber })
@@ -57,7 +78,13 @@
     <span class="repo" title={repoName}>{repoName}</span>
     <span class="title">{epic.parentTitle}</span>
     <span class="num">#{epic.parentIssueNumber}</span>
-    <span class="chip chip-done">{m.integrated_epics_chip({ merged, total })}</span>
+    {#if isOpen}
+      <span class="chip chip-warn">{m.integrated_epics_awaiting_landing_pill()}</span>
+      <span class="chip chip-done chip-secondary">{m.integrated_epics_chip({ merged, total })}</span
+      >
+    {:else}
+      <span class="chip chip-done">{m.integrated_epics_chip({ merged, total })}</span>
+    {/if}
     <span class="ago"
       >{m.integrated_epics_finished_ago({ ago: formatAgo(nowMs - epic.completedAt) })}</span
     >
@@ -99,7 +126,76 @@
     </ul>
 
     <div class="actions">
-      {#if pendingAck}
+      {#if isOpen}
+        <!-- open state: Land CTA (+ Dismiss); Ack-migrations path suppressed here to avoid
+             silently clearing an unlanded epic (the bug #1039 fixes). Migration advisory
+             moves into the Land confirm step instead. -->
+        {#if epic.landingPrNumber != null}
+          {#if confirming}
+            <span class="confirm-prompt">
+              {m.integrated_epics_land_confirm_prompt()}
+              {#if pendingAck}
+                <span class="confirm-migration-warn"
+                  >{m.integrated_epics_land_confirm_migration_warn({
+                    count: migrationCount,
+                  })}</span
+                >
+              {/if}
+            </span>
+            <button class="gbtn gbtn-primary" type="button" onclick={handleLandConfirm}>
+              {m.integrated_epics_land_confirm()}
+            </button>
+            <button class="gbtn" type="button" onclick={() => (confirming = false)}>
+              {m.common_cancel()}
+            </button>
+          {:else}
+            {#if epic.landingStranded}
+              <span class="chip-stranded"
+                >{m.integrated_epics_land_stranded({
+                  ago: formatAgo(nowMs - epic.completedAt),
+                })}</span
+              >
+            {/if}
+            {#if epic.landingReady === true}
+              <button class="gbtn" type="button" onclick={() => (confirming = true)}>
+                {m.integrated_epics_land()}
+              </button>
+            {:else}
+              <button
+                class="gbtn"
+                type="button"
+                disabled
+                title={landNotReadyReason}
+                aria-disabled="true"
+              >
+                {m.integrated_epics_land()}
+              </button>
+            {/if}
+          {/if}
+        {/if}
+        <!-- Always show Dismiss in open state (explicit operator hide) -->
+        {#if !confirming}
+          <button
+            class="gbtn"
+            type="button"
+            title={m.integrated_epics_dismiss()}
+            onclick={() => ondismiss(epic.repoPath, epic.parentIssueNumber)}
+          >
+            {m.integrated_epics_dismiss()}
+          </button>
+        {/if}
+        {#if epic.landingPrUrl}
+          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
+          <a class="awaiting" href={epic.landingPrUrl} target="_blank" rel="noopener noreferrer"
+            >{m.integrated_epics_landing_pr({ number: epic.landingPrNumber! })}</a
+          >
+        {:else if epic.landingPrNumber != null}
+          <span class="awaiting"
+            >{m.integrated_epics_landing_pr({ number: epic.landingPrNumber })}</span
+          >
+        {/if}
+      {:else if pendingAck && epic.landingState !== "open"}
+        <!-- legacy/rare Ack-migrations path: only for non-open states with pending migrations -->
         <span class="chip-migrations" title={m.epic_migrations_pending({ count: migrationCount })}>
           {m.epic_migrations_pending({ count: migrationCount })}
         </span>
@@ -111,7 +207,7 @@
         >
           {m.integrated_epics_ack_migrations()}
         </button>
-      {:else}
+      {:else if epic.landingState !== "open"}
         <button
           class="gbtn"
           type="button"
@@ -121,39 +217,30 @@
           {m.integrated_epics_dismiss()}
         </button>
       {/if}
-      {#if epic.landingState === "open" && epic.landingPrNumber != null}
-        {#if epic.landingPrUrl}
+      {#if !isOpen}
+        {#if epic.landingState === "merged" && epic.landingPrNumber != null}
+          {#if epic.landingPrUrl}
+            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
+            <a class="awaiting" href={epic.landingPrUrl} target="_blank" rel="noopener noreferrer"
+              >{m.integrated_epics_landing_pr_merged({ number: epic.landingPrNumber })}</a
+            >
+          {:else}
+            <span class="awaiting"
+              >{m.integrated_epics_landing_pr_merged({ number: epic.landingPrNumber })}</span
+            >
+          {/if}
+        {:else if epic.landingState === "error"}
+          <span class="landing-failed">{m.integrated_epics_landing_failed()}</span>
+        {:else if parentUrl}
           <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
-          <a class="awaiting" href={epic.landingPrUrl} target="_blank" rel="noopener noreferrer"
-            >{m.integrated_epics_landing_pr({ number: epic.landingPrNumber })}</a
+          <a class="awaiting" href={parentUrl} target="_blank" rel="noopener noreferrer"
+            >{m.integrated_epics_awaiting_landing({ number: epic.parentIssueNumber })}</a
           >
         {:else}
           <span class="awaiting"
-            >{m.integrated_epics_landing_pr({ number: epic.landingPrNumber })}</span
+            >{m.integrated_epics_awaiting_landing({ number: epic.parentIssueNumber })}</span
           >
         {/if}
-      {:else if epic.landingState === "merged" && epic.landingPrNumber != null}
-        {#if epic.landingPrUrl}
-          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
-          <a class="awaiting" href={epic.landingPrUrl} target="_blank" rel="noopener noreferrer"
-            >{m.integrated_epics_landing_pr_merged({ number: epic.landingPrNumber })}</a
-          >
-        {:else}
-          <span class="awaiting"
-            >{m.integrated_epics_landing_pr_merged({ number: epic.landingPrNumber })}</span
-          >
-        {/if}
-      {:else if epic.landingState === "error"}
-        <span class="landing-failed">{m.integrated_epics_landing_failed()}</span>
-      {:else if parentUrl}
-        <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
-        <a class="awaiting" href={parentUrl} target="_blank" rel="noopener noreferrer"
-          >{m.integrated_epics_awaiting_landing({ number: epic.parentIssueNumber })}</a
-        >
-      {:else}
-        <span class="awaiting"
-          >{m.integrated_epics_awaiting_landing({ number: epic.parentIssueNumber })}</span
-        >
       {/if}
     </div>
   {/if}
@@ -181,6 +268,10 @@
     text-align: left;
     cursor: pointer;
     padding: 4px 8px;
+  }
+  /* Open-landing re-tone: action-needed warn hue on the head */
+  .row-head.row-head-open {
+    color: var(--status-warn);
   }
   .row-head:focus-visible {
     outline: none;
@@ -238,6 +329,15 @@
   .chip-done {
     color: var(--status-done);
     background: color-mix(in oklab, var(--status-done) 12%, transparent);
+  }
+  /* Secondary (smaller, less prominent) done chip alongside the warn pill */
+  .chip-secondary {
+    opacity: 0.7;
+  }
+  /* Warn chip for "Awaiting landing" action-needed state */
+  .chip-warn {
+    color: var(--status-warn);
+    background: color-mix(in oklab, var(--status-warn) 12%, transparent);
   }
 
   /* Expanded rollup. */
@@ -313,6 +413,32 @@
     background: color-mix(in oklab, var(--status-warn) 12%, transparent);
   }
 
+  /* Stranded escalation badge — open+unlanded past 6h threshold */
+  .chip-stranded {
+    flex: none;
+    font-size: var(--fs-micro);
+    letter-spacing: 0.08em;
+    padding: 1px 6px;
+    border: 1px solid var(--status-warn);
+    border-radius: 2px;
+    color: var(--status-warn);
+    background: color-mix(in oklab, var(--status-warn) 12%, transparent);
+    text-transform: uppercase;
+  }
+
+  /* Inline confirm step — prompt text + migration warning */
+  .confirm-prompt {
+    font-size: var(--fs-micro);
+    color: var(--color-muted);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+  .confirm-migration-warn {
+    color: var(--status-warn);
+  }
+
   /* Canonical .gbtn recipe (scoped per-component; see /design-system). */
   .gbtn {
     background: transparent;
@@ -339,5 +465,14 @@
   .gbtn:disabled {
     opacity: 0.4;
     cursor: not-allowed;
+  }
+  /* Primary confirm button — slightly elevated */
+  .gbtn-primary {
+    border-color: var(--status-warn);
+    color: var(--status-warn);
+  }
+  .gbtn-primary:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
   }
 </style>

--- a/ui/src/lib/components/IntegratedEpicsBand.browser.test.ts
+++ b/ui/src/lib/components/IntegratedEpicsBand.browser.test.ts
@@ -35,7 +35,12 @@ afterEach(() => {
 
 describe("IntegratedEpicsBand", () => {
   it("renders nothing when epics is empty", async () => {
-    render(IntegratedEpicsBand, { epics: [], ondismiss: vi.fn(), onackmigrations: vi.fn() });
+    render(IntegratedEpicsBand, {
+      epics: [],
+      ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
+      onland: vi.fn(),
+    });
     expect(document.querySelector(".band")).toBeNull();
     expect(document.querySelector(".band-head")).toBeNull();
   });
@@ -45,6 +50,7 @@ describe("IntegratedEpicsBand", () => {
       epics: [epic(1), epic(2)],
       ondismiss: vi.fn(),
       onackmigrations: vi.fn(),
+      onland: vi.fn(),
     });
     await expect.element(page.getByText("Integrated epics (2)")).toBeInTheDocument();
     // collapsed by default → no rows

--- a/ui/src/lib/components/IntegratedEpicsBand.svelte
+++ b/ui/src/lib/components/IntegratedEpicsBand.svelte
@@ -7,11 +7,13 @@
     epics,
     ondismiss,
     onackmigrations,
+    onland,
     nowMs = Date.now(),
   }: {
     epics: CompletedEpic[];
     ondismiss: (repoPath: string, parent: number) => void;
     onackmigrations: (repoPath: string, parent: number) => void;
+    onland: (repoPath: string, parent: number) => void;
     nowMs?: number;
   } = $props();
 
@@ -36,7 +38,7 @@
     {#if !collapsed}
       <div class="rows">
         {#each epics as epic (`${epic.repoPath}#${epic.parentIssueNumber}`)}
-          <IntegratedEpicRow {epic} {ondismiss} {onackmigrations} {nowMs} />
+          <IntegratedEpicRow {epic} {ondismiss} {onackmigrations} {onland} {nowMs} />
         {/each}
       </div>
     {/if}

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1487,4 +1487,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_issue_assignee_title",
     bodyKey: "feat_issue_assignee_body",
   },
+  {
+    // Integrated-epics band now shows a "Land epic" CTA when the landing PR is ready —
+    // one-click merge from the app, no GitHub context-switch needed. No targetId — the
+    // band only mounts when completed epics exist; surface via the What's-New drawer only.
+    // v1.36.0 → ships in 1.37.0.
+    id: "land-epic-cta",
+    sinceVersion: "1.37.0",
+    titleKey: "feat_land_epic_title",
+    bodyKey: "feat_land_epic_body",
+  },
 ];

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -795,6 +795,15 @@ test("epic:completed adds to completedEpics and enqueues a toast", () => {
   expect(toasts.items.some((t) => t.key === "epic-complete:/r#42")).toBe(true);
 });
 
+test("epic:completed with landingState=merged enqueues a landed toast (not completion)", () => {
+  toasts.items = [];
+  const s = new HerdStore();
+  const epic = { ...completedEpic("/r", 42), landingState: "merged" as const };
+  s.apply({ event: "epic:completed", data: epic });
+  expect(toasts.items.some((t) => t.key === "epic-landed:/r#42")).toBe(true);
+  expect(toasts.items.some((t) => t.key === "epic-complete:/r#42")).toBe(false);
+});
+
 test("epic:completed with same key replaces (no duplicates)", () => {
   const s = new HerdStore();
   const v1 = completedEpic("/r", 42);

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -475,13 +475,22 @@ export class HerdStore {
           (e) => `${e.repoPath}#${e.parentIssueNumber}` !== key,
         );
         this.completedEpics = [ev.data, ...filtered];
-        toasts.info(
-          m.completed_epic_toast({
-            number: ev.data.parentIssueNumber,
-            count: ev.data.children.length,
-          }),
-          { key: `epic-complete:${ev.data.repoPath}#${ev.data.parentIssueNumber}` },
-        );
+        // A merged landing state is the operator's own land action resolving (#1039), not a fresh
+        // completion — confirm the land instead of re-announcing "complete". Distinct dedupe-key
+        // namespace (epic-landed:) so it never collides with the completion toast's key.
+        if (ev.data.landingState === "merged") {
+          toasts.info(m.landed_epic_toast({ number: ev.data.parentIssueNumber }), {
+            key: `epic-landed:${ev.data.repoPath}#${ev.data.parentIssueNumber}`,
+          });
+        } else {
+          toasts.info(
+            m.completed_epic_toast({
+              number: ev.data.parentIssueNumber,
+              count: ev.data.children.length,
+            }),
+            { key: `epic-complete:${ev.data.repoPath}#${ev.data.parentIssueNumber}` },
+          );
+        }
         return true;
       }
       case "epic:completed-cleared":

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -608,6 +608,12 @@ export interface CompletedEpic {
   // ask for acknowledgement before it can be cleared — never gates the completion flip.
   migrationPaths: string[];
   migrationsAckedAt: number | null;
+  // Live, display-only landing-PR gate signals from GET /api/epics/completed (server #1039);
+  // present only for open-landing rows the server could fetch. Drive the "Land epic" CTA + escalation.
+  landingChecks?: ChecksState;
+  landingMergeable?: boolean | null;
+  landingReady?: boolean;
+  landingStranded?: boolean;
 }
 
 /** One queued backlog issue behind DrainStatus.queued — a row in the queue popover.

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -516,6 +516,12 @@
     getBuildQueues()
       .then((m) => store.setBuildQueues(m))
       .catch(() => {});
+    // Re-seed completed epics: the epic:completed WS payload carries the bare row WITHOUT the
+    // GET-only live landing-gate fields (landingReady/landingChecks/landingMergeable/landingStranded),
+    // so only a fetch repopulates them — without this, the "Land epic" CTA reads disabled on wake.
+    getCompletedEpics()
+      .then((l) => store.seedCompletedEpics(l))
+      .catch(() => {});
     // Reconcile critic + plan-gate verdicts and their reviewing latches from the
     // server snapshot (both self-handle errors). load() re-fetches the /inflight
     // ids, so a `reviewing=false` missed across a disconnect/restart is corrected.
@@ -1208,6 +1214,25 @@
     if (!hasSessions) return;
     nowMs = Date.now(); // refresh on the empty→non-empty flip so the first frame isn't up to 1s stale
     const t = setInterval(() => (nowMs = Date.now()), 1000);
+    return () => clearInterval(t);
+  });
+
+  // Keep the "Land epic" CTA + stranded badge live. The landing-gate fields are computed only in the
+  // GET /api/epics/completed enrichment; the epic:completed WS payload omits them, and the two signals
+  // that flip them — the landing PR's CI going green and the time-based `stranded` crossing — fire no
+  // WS event. So while an open-landing epic exists, re-seed from the GET on a slow timer (and once
+  // immediately on the none→open flip, so a freshly-opened landing isn't disabled for a full interval).
+  // Gated on a $derived boolean (same reasoning as hasSessions above): it only flips on none↔open, so
+  // the interval is created once — completedEpics reassignment from WS events won't recreate it.
+  const hasOpenLandingEpic = $derived(store.completedEpics.some((e) => e.landingState === "open"));
+  $effect(() => {
+    if (!hasOpenLandingEpic) return;
+    const refresh = () =>
+      getCompletedEpics()
+        .then((l) => store.seedCompletedEpics(l))
+        .catch(() => {});
+    refresh();
+    const t = setInterval(refresh, 30_000);
     return () => clearInterval(t);
   });
 

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -32,6 +32,7 @@
     getCompletedEpics,
     dismissCompletedEpic,
     ackEpicMigrations,
+    landEpic,
     getEpic,
     getDiagnostics,
     halt as apiHalt,
@@ -1567,6 +1568,22 @@
     }
   }
 
+  // Merge the landing PR for a completed epic (#1039). Server emits epic:completed on success
+  // (landingState:"merged") so the band updates live — no optimistic mutation needed here.
+  async function onLandEpic(repoPath: string, parent: number) {
+    try {
+      await landEpic(repoPath, parent);
+    } catch (err) {
+      const msg =
+        err instanceof Error && err.message ? err.message : m.integrated_epics_land_failed();
+      toasts.info(msg, {
+        alert: true,
+        duration: null,
+        key: `epic-land-fail:${repoPath}#${parent}`,
+      });
+    }
+  }
+
   // Confirmed: clear the dialog state (before the await, so it can't double-submit),
   // then run the bulk archive.
   function confirmClearMerged() {
@@ -1746,6 +1763,7 @@
             holds={store.holds}
             completedEpics={completedEpicsShown}
             ondismissepic={onDismissEpic}
+            onlandepic={onLandEpic}
             doneList={doneSessions.sessions}
             {doneSelectedId}
             ondoneselect={(id) => {
@@ -1905,6 +1923,7 @@
             oncollapse={toggleSidebar}
             completedEpics={completedEpicsShown}
             ondismissepic={onDismissEpic}
+            onlandepic={onLandEpic}
             doneList={doneSessions.sessions}
             {doneSelectedId}
             ondoneselect={(id) => (doneSelectedId = id)}


### PR DESCRIPTION
Closes #1039 (Rec B *manual surface* + Rec D *reconcile*).

## Problem
An epic that is fully **integrated** (all children squash-merged into its integration branch) but never **landed** (the aggregate landing PR is still OPEN on the default branch) sat silently in the IntegratedEpics band's "done/slate" zone while the whole backlog still read OPEN — looking *broken* when it was actually *waiting on one un-surfaced human action* (Finding 1 of #1037).

## What this PR does
- **Live landing-PR gate state** on `GET /api/epics/completed` (display-only, **not persisted**, no DB migration): for `landingState==="open"` rows it best-effort fetches `forge.prStatus(integrationBranch)` and attaches `landingChecks` / `landingMergeable` / `landingReady` / `landingStranded`. Read-only and fail-safe — a forge/network error just omits the live fields (the route still always serves DB rows, never 500s). Uses a new **SELECT-only** `store.getEpicIntegrationBranch` so the GET path has no write side-effect.
- **`POST /api/epics/completed/land`** — a one-click "Land epic" endpoint. Fail-closed: `400` invalid input, `409` when the row isn't open / not mergeable / CI-red / branch-protection-**blocked** / conflicting / draft, `502` (surfaced, not swallowed) if the merge call throws. On success sets `landingState="merged"` and emits `epic:completed` so the band updates live.
- **Re-toned band** (`IntegratedEpicRow` + new `IntegratedEpicLanding` child): an open landing now reads as a **warn-tone action item** ("Awaiting landing"), with a **Land epic** button (enabled only when `landingReady`, otherwise disabled with a "why not ready" tooltip), a two-step inline confirm, and a **"stranded {ago}"** escalation badge (Rec D). A `merged` landing keeps the done-tone "Landed".
- **Fixes the headline bug-fix invariant:** while `landingState==="open"` the Ack-migrations button (which sets `dismissedAt` and would silently clear an *unlanded* epic — the exact silent state #1039 targets) is **suppressed**; the migration advisory moves onto the Land confirm (non-blocking — migration-ack is advisory per #1037). The ack path is retained only for the legacy `pendingAck && landingState!=="open"` case.

## Deliberate deviations (flagged per house rules; also in code comments)
1. **Merge method = the host-configured `forge.mergeMethod`** (consistent with `AutoMergeService` + the other merge routes). _(Updated per #1049 critic — an earlier revision hardcoded `"merge"` to preserve per-child history, but that 405s on squash-only repos since `computeLandingReady` reports ready from `mergeStateStatus`, which reflects branch state not method availability. Respecting the repo's configured method makes the CTA work everywhere; operators who want a merge commit set the host merge method.)_ A merge failure is still surfaced as a `502`.
2. **Rec D "stranded" approximation.** The issue says "landing PR mergeable for > N hours"; this approximates with "epic **completed** > N h ago **AND** landing PR currently ready" (`EPIC_LANDING_STRANDED_MS = 6h`) to avoid persisting a `mergeableSince` column. Captures the operator-relevant signal ("integrated, ready, unlanded for hours").

## Descoped (operator decision during plan-gate) — filed as follow-ups
- **#1044** — opt-in **auto-land** of the landing PR (Rec B option 2; reuse repo `autoMergeEnabled`). Ships as **zero code** here by design (the "auto-land" in #1039's title).
- **#1045** — **rundown** Tier-1 integration of integrated-but-unlanded epics (this PR surfaces them on the band only; the daily-digest urgency is deferred).

## Verification
- Root: `bun run lint` ✓, `bunx tsc --noEmit` ✓, `bun test ./test` → 4652 pass.
- UI: `bun run check` → 0 errors, `bun run check:i18n` → 1870 keys parity (EN+DE), `bun run test` → 2006 pass.
- PR-hygiene gates (branch-hygiene, feature-catalog, glossary) ✓; fallow audit ✓ (0 complexity findings).
- New tests: 20 pure-helper (`computeLandingReady`/`Stranded`) + 12 land-endpoint + 8 `IntegratedEpicRow` browser tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
