### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs/sandbox-security.md
+++ b/docs/sandbox-security.md
@@ -12,7 +12,7 @@ The egress firewall (slirp4netns + nftables + dnsmasq, shipped in **PR #601**,
 closed **#551** — `src/egress.ts`) confines outbound traffic to
 `api.anthropic.com` + `statsig.anthropic.com` + the GitHub hosts, and watches
 for DNS drops. Egress is keyed to the **autonomous profile**, not to
-attendedness (`src/sandbox.ts` `egressApplies`, ~L450).
+attendedness (`src/sandbox.ts` `egressApplies`, ~L532).
 
 This note records two residuals the operator has **accepted** after the audit.
 
@@ -21,12 +21,12 @@ This note records two residuals the operator has **accepted** after the audit.
 The membrane keeps two token surfaces readable to any in-membrane tool call:
 
 - `~/.claude/.credentials.json` — bound **RW** so OAuth refresh writes back
-  (`src/sandbox.ts:296-299`, `--bind-try`); the whole `~/.claude` dir is
-  `--ro-bind`ed at `src/sandbox.ts:280-282`.
+  (`src/sandbox.ts:309-311`, `--bind-try`); the whole `~/.claude` dir is
+  `--ro-bind`ed at `src/sandbox.ts:302-304`.
 - `~/.config/gh` — bound **RO** (the gh token, needed to `git push` /
-  `gh pr create`) at `src/sandbox.ts:318`.
+  `gh pr create`) at `src/sandbox.ts:392`.
 
-`--clearenv` (`src/sandbox.ts:335`) strips **all** inherited env
+`--clearenv` (`src/sandbox.ts:417`) strips **all** inherited env
 (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `GH_TOKEN`, `SHEPHERD_TOKEN`,
 …), re-setting only HOME/PATH/TERM + non-secret locale vars — so these two
 **bound files** are the only token surfaces left inside the membrane.
@@ -51,9 +51,10 @@ secrets out of the membrane entirely.
 ## Attended-mode egress coverage
 
 Egress confinement is keyed to the autonomous **profile**, not to whether a human
-is watching (`src/service.ts` ~L757-768, L792-828): the wrap applies iff the
-autonomous profile resolves **and** the fs + egress backends are present,
-independent of `ctx.auto`. Consequences:
+is watching (`willEgressConfine`, `src/sandbox.ts:543-549`; applied at
+`src/service.ts:1229`): the wrap applies iff the autonomous profile resolves
+**and** the fs + egress backends are present, independent of `ctx.auto`.
+Consequences:
 
 - An **attended** session on the autonomous profile **is** egress-confined (with
   an egress-degraded banner if the backend is missing).
@@ -67,27 +68,27 @@ in the repo's Settings panel, or globally via `SHEPHERD_SANDBOX_DEFAULT_PROFILE`
 
 - **Autonomous task agents** run `--dangerously-skip-permissions`, but behind
   **both** the filesystem and the egress membrane. `standard` auto-spawns are
-  refused outright (`src/sandbox.ts` `autoHoldReason`, ~L398-399).
+  refused outright (`src/sandbox.ts` `autoHoldReason`, ~L480-481).
 - **Unattended reviewers** (PR critic + plan-gate) run **read-only**, not
   skip-permissions: `--safe-mode --disable-slash-commands --allowedTools Read
 Grep Glob Bash(git diff *) Bash(git log *) Bash(git show *) Bash(git status)
-Write --permission-mode dontAsk` (`src/reviewer-argv.ts:13-109`,
+Write --permission-mode dontAsk` (`src/reviewer-argv.ts:14-117`,
   `readonlyReviewerArgv`).
 - **Research is the deliberately egress-UNCONFINED surface.** A research session
   that would resolve to `autonomous` is **downgraded to `standard`**
-  (`src/service.ts` `researchSafeProfileOverride`, ~L923-941, warns once),
+  (`src/service.ts` `researchSafeProfileOverride`, ~L1456-1474, warns once),
   because research needs **open** web egress (search/fetch + sub-agents) that the
   autonomous firewall would block. It is operator-_created_ (cannot be
   auto-drained — `standard` refuses auto-spawn) but **autopilot-steerable, so it
   runs unattended in practice** (`RESEARCH_PROCEED_STEER`,
-  `src/autopilot.ts:22-27`, dispatched at L200). It ingests **untrusted web**
+  `src/autopilot.ts:22-27`, dispatched at L262). It ingests **untrusted web**
   content on `trusted`/`standard` with the **network open**, and can
   `gh pr create` / open issues via the bound gh token — so a hijacked research
   agent has **both** readable tokens **and** open egress.
 
   **Compensating factors:** the downgrade is explicit and warns once; research
   delivers a **report PR or GitHub issue only, never a code PR**
-  (`src/autopilot.ts:204-206`). The residual is **accepted**.
+  (`src/autopilot.ts:264-269`). The residual is **accepted**.
 
 ## See also
 


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc-update summary

Scope swept: the eight in-scope prose pages against current `src/` (notably
`src/config.ts`, `src/sandbox.ts`, `src/service.ts`, `src/autopilot.ts`,
`src/reviewer-argv.ts`, `src/usage-hold.ts`, `src/egress.ts`, `src/pricing.ts`).

The operator-facing prose is current — the recent doc syncs (#959, #994) plus the
usage-hold behavior change (#1038 / `b598a133`) are already reflected. The only
demonstrable staleness was a set of source line-number citations in
`docs/sandbox-security.md` that had drifted as the cited files grew.

## Changes

- **`docs/sandbox-security.md`** — refreshed nine stale source line/anchor
  citations to their verified current locations (the cited *behavior* was
  accurate; only the line numbers had drifted):
  - `egressApplies` `~L450` → `~L532` (`src/sandbox.ts:532`).
  - `.credentials.json` RW `--bind-try` `:296-299` → `:309-311`;
    whole-`~/.claude` `--ro-bind` `:280-282` → `:302-304` (`src/sandbox.ts`).
  - `~/.config/gh` RO bind `:318` → `:392` (`src/sandbox.ts:392`).
  - `--clearenv` `:335` → `:417` (`src/sandbox.ts:417`).
  - `standard` auto-spawn refusal `autoHoldReason` `~L398-399` → `~L480-481`
    (`src/sandbox.ts:474` def, refusal at 480-481).
  - attended-egress wrap citation `src/service.ts ~L757-768, L792-828` →
    `willEgressConfine` (`src/sandbox.ts:543-549`) applied at `src/service.ts:1229`
    (the predicate moved into a shared helper).
  - `researchSafeProfileOverride` `~L923-941` → `~L1456-1474` (`src/service.ts:1456`).
  - `RESEARCH_PROCEED_STEER` dispatch `L200` → `L262` (`src/autopilot.ts:262`);
    the steer constant itself is still at `:22-27` (unchanged).
  - "report PR / issue, never a code PR" `src/autopilot.ts:204-206` → `:264-269`
    (the `if (s.research)` finished branch that marks complete instead of opening a PR).
  - `readonlyReviewerArgv` `src/reviewer-argv.ts:13-109` → `:14-117` (current
    function span). The quoted reviewer flag/allowlist string still matches
    `src/reviewer-argv.ts` exactly, so it was left as-is.

No other in-scope page was edited — `docs/external-task-api.md`,
`docs/token-usage-analysis.md`, and all five `docs-site` pages were verified
current and left unchanged.

## Uncertain / needs human judgment

- **`docs-site/.../reference/configuration.md` is not exhaustive.** Its front
  matter / the index page say "every environment variable," but it documents a
  curated subset. `src/config.ts` reads many vars it omits (e.g.
  `SHEPHERD_AUTH_MODE`, `SHEPHERD_DEFAULT_MODEL`, `SHEPHERD_FABLE_AVAILABLE`,
  `SHEPHERD_REVIEW_CYCLES_CAP`, `SHEPHERD_PLAN_REVIEW_CYCLES_CAP`,
  `SHEPHERD_AUTOPILOT_STEP_CAP`, `SHEPHERD_EXTRA_CREDITS_DRAIN_CEILING`,
  `SHEPHERD_AUTOMERGE_REBASE_CAP`, `SHEPHERD_REMOTE_CONTROL_AT_STARTUP`,
  `SHEPHERD_REDUCED_PUSH_MODE`, `SHEPHERD_PUSH_COOLDOWN_MS`,
  `SHEPHERD_SESSION_HOUSEKEEPING`, `SHEPHERD_LLM_NAMING`, `SHEPHERD_NAMER_MODEL`,
  `SHEPHERD_HOUSE_RULES_BUDGET_CHARS`, `SHEPHERD_STANDARD_COMMAND`,
  `SHEPHERD_VAPID_*`, the `SHEPHERD_HOOKS_INGEST/SIGNALS` soak flags, etc.). This
  looks like a deliberately selective table rather than recent staleness, so I did
  not add rows — but a human should decide whether to (a) document the missing
  operator-facing knobs or (b) soften the "every environment variable" claim.
- **`SHEPHERD_SANDBOX_EXTRA_HOSTS` is named in source but not in the docs.** The
  autonomous-egress allowlist in `configuration.md` and `sandbox-security.md`
  refers to "operator extras," and `src/egress.ts` / `src/config.ts` implement
  that via `SHEPHERD_SANDBOX_EXTRA_HOSTS` (plus the per-repo `egressExtraHosts`
  setting). A reader can't act on "operator extras" without the var name. I left
  it because it's unclear whether the omission is intentional; consider adding a
  row to the sandbox section.
- **`docs/token-usage-analysis.md` is a point-in-time report.** Its tables are a
  captured analysis of five specific tasks, not living behavior docs. The
  methodology claims I could verify are current (the pricing weights
  Opus 5/25, Sonnet 3/15, Haiku 1/5, Fable 10/50 with 0.1×/1.25×/2× cache ratios
  match `src/pricing.ts`), so nothing was changed. The numbers should not be
  edited by an automated sweep.