### PR TITLE
feat(rundown): surface integrated-but-unlanded epics as Tier-1 items (#1045)

### DIFF
--- a/src/completed-epic.ts
+++ b/src/completed-epic.ts
@@ -83,6 +83,51 @@ export function computeLandingStranded(opts: {
   );
 }
 
+/** Accessors enrichLandingEpics needs, injected so this module stays forge-light (a structural
+ *  forge shape, not the full GitForge type). `resolveForge` returns null when the repo has no forge. */
+export interface EnrichLandingDeps {
+  getEpicIntegrationBranch: (repoPath: string, parentIssueNumber: number) => string | null;
+  resolveForge: (
+    repoPath: string,
+  ) => { prStatus: (headBranch: string) => Promise<PrStatus> } | null | undefined;
+  now: number;
+}
+
+/** Enrich each OPEN-landing completed epic in `rows` with live landing-PR gate signals
+ *  (`landingChecks`/`landingMergeable`/`landingReady`/`landingStranded`), mutating in place.
+ *  Best-effort + fail-safe per row: a missing branch/forge or a forge error simply leaves that
+ *  row's live fields undefined — never throws. Shared by GET /api/epics/completed and the rundown's
+ *  landing-ready accessor so both compute readiness identically. */
+export async function enrichLandingEpics(
+  rows: CompletedEpic[],
+  deps: EnrichLandingDeps,
+): Promise<void> {
+  await Promise.all(
+    rows.map(async (row) => {
+      if (row.landingState !== "open") return;
+      const branch = deps.getEpicIntegrationBranch(row.repoPath, row.parentIssueNumber);
+      if (branch === null) return;
+      const forge = deps.resolveForge(row.repoPath);
+      if (!forge) return;
+      try {
+        const pr = await forge.prStatus(branch);
+        row.landingChecks = pr.checks;
+        row.landingMergeable = pr.mergeable ?? null;
+        const landingReady = computeLandingReady(pr);
+        row.landingReady = landingReady;
+        row.landingStranded = computeLandingStranded({
+          landingState: "open",
+          landingReady,
+          completedAt: row.completedAt,
+          now: deps.now,
+        });
+      } catch {
+        // leave live fields undefined — callers always serve/return the base DB rows
+      }
+    }),
+  );
+}
+
 export function buildRollup(
   children: Pick<EpicChild, "number" | "title" | "url">[],
   details: {

--- a/src/herd-digest.ts
+++ b/src/herd-digest.ts
@@ -447,25 +447,29 @@ export class HerdDigestService {
   // ── reconcileEpics ─────────────────────────────────────────────────────────────
 
   /**
-   * Keep today's READY digest's `epicsToLand` live as landing readiness flips intraday (#1045).
+   * Keep today's settled digest's `epicsToLand` live as landing readiness flips intraday (#1045).
    *
    * `epicsToLand` is frozen on the row at spawn time. Without this, an epic whose CI goes green
-   * AFTER the digest was generated would never surface (sweep early-returns on the existing ready
+   * AFTER the digest was generated would never surface (sweep early-returns on the existing settled
    * row, and epics are deliberately out of the attentionFingerprint, so staleCount never moves —
    * staleCount is also bootstrap-only). Because `epicsToLand` is server ground truth (never parsed
    * from the LLM verdict), we recompute it and update the row IN PLACE — no re-spawn, no LLM call —
    * then push it over `herd:digest` so the panel's epic section updates live. Self-heals both ways
    * (readiness gained, or lost/landed).
    *
+   * Targets BOTH `ready` and `failed` digests: RundownPanel renders the epic section in either state
+   * (it is ground truth, not LLM output), so a `failed` digest must be kept live too — otherwise it
+   * would freeze a stale/landed "land this epic" entry until a manual regenerate.
+   *
    * Cheap by construction: when no epic is open the (memoized) accessor short-circuits to [] with no
-   * forge call; the set-equality check makes the in-place write + WS push fire only on a real change.
+   * forge call; the deep-equality check makes the in-place write + WS push fire only on a real change.
    */
   private reconcilingEpics = false;
   async reconcileEpics(): Promise<void> {
     if (this.reconcilingEpics) return; // overlapping ticks: one at a time
     if (!this.deps.landingReadyEpics) return; // nothing to reconcile against
     const latest = this.deps.store.getLatestHerdDigest();
-    if (!latest || latest.state !== "ready") return;
+    if (!latest || (latest.state !== "ready" && latest.state !== "failed")) return;
     if (latest.dayKey !== dayKeyFor(this.now())) return; // only today's settled digest
     // A regenerate for today is mid-flight — don't fight it.
     if (this.inFlight.has(latest.dayKey) || this.finalizing.has(latest.dayKey)) return;
@@ -475,13 +479,11 @@ export class HerdDigestService {
       // Cap to the same bound assembleHerdState applies at spawn time (RundownPanel renders
       // epicsToLand uncapped, so the intraday list must honor the same ceiling for consistency).
       const current = ((await this.deps.landingReadyEpics()) ?? []).slice(0, RUNDOWN_EPICS_CAP);
-      const key = (e: RundownEpicItem) => `${e.repo}#${e.parent}`;
-      const sortKeys = (xs: RundownEpicItem[]) => xs.map(key).sort();
-      const before = JSON.stringify(sortKeys(latest.epicsToLand));
-      const after = JSON.stringify(sortKeys(current));
-      // Also re-write when the SAME epics changed shape (e.g. stranded flipped, landing PR appeared).
-      const shapeChanged = JSON.stringify(latest.epicsToLand) !== JSON.stringify(current);
-      if (before === after && !shapeChanged) return; // no change → no-op
+      // Deep (ordered) equality is the only check needed — write whenever the rendered list differs
+      // in membership OR shape (e.g. stranded flipped, landing PR appeared). A bare reorder of the
+      // same epics would also write, but listEpicCompleted's stable completedAt-DESC ordering makes
+      // that vanishingly rare.
+      if (JSON.stringify(latest.epicsToLand) === JSON.stringify(current)) return; // no change → no-op
 
       const t = this.now();
       const updated: HerdDigest = { ...latest, epicsToLand: current, updatedAt: t };

--- a/src/herd-digest.ts
+++ b/src/herd-digest.ts
@@ -38,6 +38,7 @@ import {
   classifyAttention,
   RUNDOWN_VERDICT_FILE,
   RUNDOWN_DEFAULT_TOPN,
+  RUNDOWN_EPICS_CAP,
 } from "./rundown-core";
 
 const DEFAULT_TIMEOUT_MS = 5 * 60_000;
@@ -471,7 +472,9 @@ export class HerdDigestService {
 
     this.reconcilingEpics = true;
     try {
-      const current = (await this.deps.landingReadyEpics()) ?? [];
+      // Cap to the same bound assembleHerdState applies at spawn time (RundownPanel renders
+      // epicsToLand uncapped, so the intraday list must honor the same ceiling for consistency).
+      const current = ((await this.deps.landingReadyEpics()) ?? []).slice(0, RUNDOWN_EPICS_CAP);
       const key = (e: RundownEpicItem) => `${e.repo}#${e.parent}`;
       const sortKeys = (xs: RundownEpicItem[]) => xs.map(key).sort();
       const before = JSON.stringify(sortKeys(latest.epicsToLand));

--- a/src/herd-digest.ts
+++ b/src/herd-digest.ts
@@ -20,7 +20,7 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
-import type { HerdDigest, ReviewVerdict, PlanGate, Recap } from "./types";
+import type { HerdDigest, ReviewVerdict, PlanGate, Recap, RundownEpicItem } from "./types";
 import type { GitState } from "./forge/types";
 import type { SessionUsage } from "./usage";
 import { readSessionUsage } from "./usage";
@@ -153,6 +153,14 @@ export interface HerdDigestServiceDeps {
   /** Backlog-priority rank per repoPath (lower = higher priority) from the warm /api/backlog
    *  cache; weights focusNext within a tier. Optional — absent → no backlog weighting. */
   backlogPriority?: () => Record<string, number>;
+  /** Landing-ready completed epics to surface as Tier-1 "land this epic" items (#1045). Async —
+   *  the index.ts wiring does forge probes (TTL-memoized) to compute readiness. Resolved inside
+   *  generate() (≤once/day) and reconcileEpics(). Optional — absent → no epic surfacing. */
+  landingReadyEpics?: () => Promise<RundownEpicItem[]>;
+  /** Cheap sync signal: any completed epic currently in landingState 'open' (DB-only). Used ONLY
+   *  as the sweep() pre-filter so an idle herd with a pending epic still triggers generate(); the
+   *  authoritative not-ready→no-spawn decision lives in generate(). Optional — absent → false. */
+  hasOpenLandingEpics?: () => boolean;
   model?: string | null;
   now?: () => number;
   timeoutMs?: number;
@@ -243,7 +251,14 @@ export class HerdDigestService {
     if (this.inFlight.has(dayKey)) return;
 
     if (!this.deps.isActive()) return;
-    if (this.deps.store.list({ activeOnly: true }).length === 0) return;
+    // Pre-filter (cheap): skip only when the herd is empty AND no completed epic is awaiting landing.
+    // The epic DB check runs only when there are no active sessions, so the 15s tick stays cheap.
+    // generate() is the authority on whether an actually-ready epic warrants a spawn (#1045).
+    if (
+      this.deps.store.list({ activeOnly: true }).length === 0 &&
+      !(this.deps.hasOpenLandingEpics?.() ?? false)
+    )
+      return;
 
     await this.generate();
   }
@@ -294,7 +309,12 @@ export class HerdDigestService {
       this.reapGenerating(dayKey);
 
       const sessions = this.deps.store.list({ activeOnly: true });
-      if (sessions.length === 0) return "empty";
+
+      // Resolve the landing-ready epic set (forge-backed, TTL-memoized in the wiring) BEFORE the
+      // empty-guard: an idle/empty herd should still spawn when an epic is genuinely ready to land,
+      // but an open-but-NOT-ready epic (e.g. CI red) must NOT trigger an all-clear spawn for nothing.
+      const epicsToLand = (await this.deps.landingReadyEpics?.()) ?? [];
+      if (sessions.length === 0 && epicsToLand.length === 0) return "empty";
 
       const snap = this.deps.snapshots();
       const stalled = this.deps.stalledSessionIds?.() ?? new Set<string>();
@@ -314,6 +334,7 @@ export class HerdDigestService {
         stalled,
         trains: train?.bySession,
         backlogRank: this.deps.backlogPriority?.(),
+        epics: epicsToLand,
         overnightDelta,
         generatedFor: dayKey,
         now,
@@ -370,6 +391,9 @@ export class HerdDigestService {
         ciRework: [],
         train: "",
         focusNext: [],
+        // Deterministic ground truth (NOT from the LLM verdict): captured at spawn time so the epic
+        // section survives finalize/failed and is kept live intraday by reconcileEpics() (#1045).
+        epicsToLand: assembled.epics,
         attentionFingerprint: fingerprint,
         spawnSessionId,
         cwd,
@@ -414,6 +438,54 @@ export class HerdDigestService {
       } finally {
         this.finalizing.delete(d.dayKey);
       }
+    }
+
+    await this.reconcileEpics();
+  }
+
+  // ── reconcileEpics ─────────────────────────────────────────────────────────────
+
+  /**
+   * Keep today's READY digest's `epicsToLand` live as landing readiness flips intraday (#1045).
+   *
+   * `epicsToLand` is frozen on the row at spawn time. Without this, an epic whose CI goes green
+   * AFTER the digest was generated would never surface (sweep early-returns on the existing ready
+   * row, and epics are deliberately out of the attentionFingerprint, so staleCount never moves —
+   * staleCount is also bootstrap-only). Because `epicsToLand` is server ground truth (never parsed
+   * from the LLM verdict), we recompute it and update the row IN PLACE — no re-spawn, no LLM call —
+   * then push it over `herd:digest` so the panel's epic section updates live. Self-heals both ways
+   * (readiness gained, or lost/landed).
+   *
+   * Cheap by construction: when no epic is open the (memoized) accessor short-circuits to [] with no
+   * forge call; the set-equality check makes the in-place write + WS push fire only on a real change.
+   */
+  private reconcilingEpics = false;
+  async reconcileEpics(): Promise<void> {
+    if (this.reconcilingEpics) return; // overlapping ticks: one at a time
+    if (!this.deps.landingReadyEpics) return; // nothing to reconcile against
+    const latest = this.deps.store.getLatestHerdDigest();
+    if (!latest || latest.state !== "ready") return;
+    if (latest.dayKey !== dayKeyFor(this.now())) return; // only today's settled digest
+    // A regenerate for today is mid-flight — don't fight it.
+    if (this.inFlight.has(latest.dayKey) || this.finalizing.has(latest.dayKey)) return;
+
+    this.reconcilingEpics = true;
+    try {
+      const current = (await this.deps.landingReadyEpics()) ?? [];
+      const key = (e: RundownEpicItem) => `${e.repo}#${e.parent}`;
+      const sortKeys = (xs: RundownEpicItem[]) => xs.map(key).sort();
+      const before = JSON.stringify(sortKeys(latest.epicsToLand));
+      const after = JSON.stringify(sortKeys(current));
+      // Also re-write when the SAME epics changed shape (e.g. stranded flipped, landing PR appeared).
+      const shapeChanged = JSON.stringify(latest.epicsToLand) !== JSON.stringify(current);
+      if (before === after && !shapeChanged) return; // no change → no-op
+
+      const t = this.now();
+      const updated: HerdDigest = { ...latest, epicsToLand: current, updatedAt: t };
+      this.deps.store.putHerdDigest(updated);
+      this.deps.onChange(updated);
+    } finally {
+      this.reconcilingEpics = false;
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1140,16 +1140,28 @@ setInterval(() => {
 //                        (mergeErrorSessions, fed by the automerge:status stream above)
 // Landing-ready completed epics for the rundown (#1045). TTL-memoized: sweep()'s 15s tick keeps
 // calling generate()/reconcileEpics() while an epic sits open, and each call would otherwise probe
-// the forge. The cheap part (which epics are 'open') is a sync DB filter; the forge probe runs only
-// when an epic IS open and is bounded to ≈once/TTL by the memo (mirrors backlogPriority reading a
-// kept-warm cache rather than a live round-trip). readiness still refreshes within one TTL.
+// the forge. The cheap part (which epics are 'open') is a sync DB filter, computed EVERY call so a
+// just-landed epic drops immediately; only the forge probe is memoized (≈once/TTL) and the cache is
+// keyed on the open-epic set so any land/open busts it (TTL only bounds same-set CI-readiness flips).
+// Mirrors backlogPriority reading a kept-warm cache rather than a live round-trip.
 const EPIC_READY_TTL_MS = 5 * 60_000;
-let epicReadyCache: { ts: number; val: RundownEpicItem[] } | null = null;
+let epicReadyCache: { key: string; ts: number; val: RundownEpicItem[] } | null = null;
 const landingReadyEpics = async (): Promise<RundownEpicItem[]> => {
   const now = Date.now();
-  if (epicReadyCache && now - epicReadyCache.ts < EPIC_READY_TTL_MS) return epicReadyCache.val;
   const openRows = store.listEpicCompleted().filter((r) => r.landingState === "open");
-  if (openRows.length === 0) return []; // cheap path: nothing open → no forge, no caching
+  if (openRows.length === 0) {
+    epicReadyCache = null; // nothing open → drop any stale cache so a just-landed epic clears at once
+    return [];
+  }
+  // Cache key = the set of open epics. A change (one landed, or a new one opened) busts the cache so
+  // the panel never shows an already-landed "land this epic"; the TTL only throttles re-probing the
+  // forge when the SAME set's CI-readiness might have flipped.
+  const key = openRows
+    .map((r) => `${r.repoPath}#${r.parentIssueNumber}`)
+    .sort()
+    .join(",");
+  if (epicReadyCache && epicReadyCache.key === key && now - epicReadyCache.ts < EPIC_READY_TTL_MS)
+    return epicReadyCache.val;
   const epics: CompletedEpic[] = openRows.map(({ childrenJson, landingAttempts, ...rest }) => {
     void landingAttempts;
     return { ...rest, children: JSON.parse(childrenJson) as CompletedEpic["children"] };
@@ -1169,7 +1181,7 @@ const landingReadyEpics = async (): Promise<RundownEpicItem[]> => {
       landingPr: e.landingPrNumber,
       stranded: e.landingStranded === true,
     }));
-  epicReadyCache = { ts: now, val };
+  epicReadyCache = { key, ts: now, val };
   return val;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,12 @@ import {
   validatePreviewPortRange,
 } from "./config";
 import { SessionStore } from "./store";
-import type { Session, SessionPreviewEvent, SessionPreviewServeEvent } from "./types";
+import type {
+  Session,
+  SessionPreviewEvent,
+  SessionPreviewServeEvent,
+  RundownEpicItem,
+} from "./types";
 import { WorktreeMgr } from "./worktree";
 import { HerdrDriver, matchAgent } from "./herdr";
 import { generateName } from "./namer";
@@ -71,6 +76,7 @@ import { sweepClaudeTmp, compileCacheDir, reapFallowCaches, pruneRepoWorktrees }
 import { runSessionUsageBackfill } from "./usage-backfill";
 import { PreviewService } from "./preview";
 import { listRepos, listReposPathForReal } from "./repos";
+import { enrichLandingEpics, type CompletedEpic } from "./completed-epic";
 import { DistillerService, defaultScratch } from "./distiller";
 import { OptimizerService, defaultOptimizerScratch } from "./optimizer";
 import { MergeSuggestionService, defaultMergeScratch } from "./merge-suggest";
@@ -1132,10 +1138,47 @@ setInterval(() => {
 //                        running session, mirroring the poller's stall candidate)
 //   mergeTrainState    → live queued PRs (service.liveTrainPrs) + per-session train errors
 //                        (mergeErrorSessions, fed by the automerge:status stream above)
+// Landing-ready completed epics for the rundown (#1045). TTL-memoized: sweep()'s 15s tick keeps
+// calling generate()/reconcileEpics() while an epic sits open, and each call would otherwise probe
+// the forge. The cheap part (which epics are 'open') is a sync DB filter; the forge probe runs only
+// when an epic IS open and is bounded to ≈once/TTL by the memo (mirrors backlogPriority reading a
+// kept-warm cache rather than a live round-trip). readiness still refreshes within one TTL.
+const EPIC_READY_TTL_MS = 5 * 60_000;
+let epicReadyCache: { ts: number; val: RundownEpicItem[] } | null = null;
+const landingReadyEpics = async (): Promise<RundownEpicItem[]> => {
+  const now = Date.now();
+  if (epicReadyCache && now - epicReadyCache.ts < EPIC_READY_TTL_MS) return epicReadyCache.val;
+  const openRows = store.listEpicCompleted().filter((r) => r.landingState === "open");
+  if (openRows.length === 0) return []; // cheap path: nothing open → no forge, no caching
+  const epics: CompletedEpic[] = openRows.map(({ childrenJson, landingAttempts, ...rest }) => {
+    void landingAttempts;
+    return { ...rest, children: JSON.parse(childrenJson) as CompletedEpic["children"] };
+  });
+  await enrichLandingEpics(epics, {
+    getEpicIntegrationBranch: (repoPath, parent) =>
+      store.getEpicIntegrationBranch(repoPath, parent),
+    resolveForge: (repoPath) => resolveForge(repoPath),
+    now,
+  });
+  const val: RundownEpicItem[] = epics
+    .filter((e) => e.landingState === "open" && e.landingReady === true)
+    .map((e) => ({
+      repo: e.repoPath,
+      parent: e.parentIssueNumber,
+      title: e.parentTitle,
+      landingPr: e.landingPrNumber,
+      stranded: e.landingStranded === true,
+    }));
+  epicReadyCache = { ts: now, val };
+  return val;
+};
+
 const herdDigestService = new HerdDigestService({
   store,
   herdr,
   isActive: () => presence.isActive(),
+  landingReadyEpics,
+  hasOpenLandingEpics: () => store.listEpicCompleted().some((r) => r.landingState === "open"),
   onChange: (digest) => events.emit("herd:digest", { digest }),
   snapshots: () => ({
     git: prPoller.snapshot(),

--- a/src/rundown-core.ts
+++ b/src/rundown-core.ts
@@ -11,6 +11,7 @@ import type {
   PlanGate,
   Recap,
   RundownItem,
+  RundownEpicItem,
   RundownVerdict,
   HoldReason,
 } from "./types";
@@ -28,6 +29,9 @@ export const RUNDOWN_DECISIONS_CAP = 6;
 const RUNDOWN_CIREWORK_CAP = 6;
 export const RUNDOWN_FOCUSNEXT_CAP = 3;
 export const RUNDOWN_DEFAULT_TOPN = 40;
+// Bound on the deterministic "land this epic" Tier-1 items (#1045). Completed epics are few per
+// repo; this is a safety ceiling, not an expected limit.
+export const RUNDOWN_EPICS_CAP = 12;
 
 // DRIFT: keep in sync with ui/src/lib/components/merge-train.ts (MERGE_MARK_BACKSTOP_MS).
 // Re-implemented server-side so the rundown can classify merging sessions without
@@ -304,6 +308,9 @@ export interface AssembledHerdState {
   generatedFor: string;
   overnightDelta: { mergedPrs: number[]; archivedSessions: { id: string; desig: string }[] };
   sessions: AssembledSession[];
+  /** Deterministic Tier-1 "land this epic" items (#1045) — landing-ready completed epics with no
+   *  live session. NOT classified/ranked like sessions; injected by the server, never dropped. */
+  epics: RundownEpicItem[];
   /** Count of Tier-2 sessions elided by the topN budget (0 when none dropped). Tier-1 is
    *  never dropped, so a positive count here means a HIGH-attention session is hidden. */
   truncatedTier2: number;
@@ -322,6 +329,9 @@ export interface AssembleInput {
   trains?: Record<string, { error?: boolean }>;
   overnightDelta: { mergedPrs: number[]; archivedSessions: { id: string; desig: string }[] };
   generatedFor: string;
+  /** Landing-ready completed epics to surface as Tier-1 "land this epic" items (#1045). Optional —
+   *  absent ⇒ none. Sliced to RUNDOWN_EPICS_CAP. */
+  epics?: RundownEpicItem[];
   now?: number;
   topN?: number;
   /** Backlog-priority rank per repoPath (lower = higher priority; 0 = top-priority repo). A
@@ -428,6 +438,7 @@ export function assembleHerdState(input: AssembleInput): AssembledHerdState {
     generatedFor: input.generatedFor,
     overnightDelta: input.overnightDelta,
     sessions: kept,
+    epics: (input.epics ?? []).slice(0, RUNDOWN_EPICS_CAP),
     truncatedTier2,
     truncatedTier3,
   };
@@ -469,6 +480,30 @@ export function buildRundownPrompt(assembled: AssembledHerdState): string {
     );
   }
 
+  if (assembled.epics.length > 0) {
+    lines.push(
+      "",
+      "EPICS AWAITING LANDING — these integrated epics have a landing PR that is ready to merge",
+      "but has NOT been landed. They are ALREADY surfaced separately to the operator as Tier-1",
+      '"land the epic" items (a dedicated section with a Land CTA), so you MUST NOT repeat them in',
+      'decisions/focusNext. You MUST NOT claim "all clear" or that the herd is idle while any',
+      "exist; you MAY mention them in `overnight` for context. For reference only (do NOT echo into",
+      "the verdict):",
+      ...assembled.epics.map(
+        (e) =>
+          `  - ${e.repo} #${e.parent} "${e.title}"` +
+          (e.landingPr != null ? ` (landing PR #${e.landingPr})` : "") +
+          (e.stranded ? " [STRANDED — unlanded well past threshold]" : ""),
+      ),
+    );
+  }
+
+  // Strip `epics` from the herd-state dump below — they are rendered once in the dedicated block
+  // above; leaving them in the dump would double-inject and tempt the agent to echo them into the
+  // verdict (#1045).
+  const { epics: _epics, ...assembledForDump } = assembled;
+  void _epics;
+
   lines.push(
     'Each session may carry a "why" line — the system\'s reason it is held/blocked; use it to phrase the operator-facing items.',
     "",
@@ -491,7 +526,7 @@ export function buildRundownPrompt(assembled: AssembledHerdState): string {
     "Herd state (already significance-ranked):",
     JSON.stringify(
       {
-        ...assembled,
+        ...assembledForDump,
         sessions: assembled.sessions.map((s) => {
           const { hold, ...rest } = s;
           if (hold) return { ...rest, why: renderHold(hold, "en") };

--- a/src/server.ts
+++ b/src/server.ts
@@ -104,7 +104,7 @@ import { importEpicLinks, type ImportResult } from "./epic-import";
 import {
   buildRollup,
   computeLandingReady,
-  computeLandingStranded,
+  enrichLandingEpics,
   type CompletedEpic,
 } from "./completed-epic";
 import { parseEpicBody } from "./epic-parse";
@@ -4528,32 +4528,14 @@ async function handleEpicsCompletedList({ req, parts, url, deps }: Ctx): Promise
   });
 
   // Enrich open-landing rows with live gate signals (best-effort, fail-safe — forge/network
-  // errors must NOT 500 this route; just omit the live fields for that row).
-  const now = Date.now();
-  await Promise.all(
-    baseRows.map(async (row) => {
-      if (row.landingState !== "open") return;
-      const branch = deps.store.getEpicIntegrationBranch(row.repoPath, row.parentIssueNumber);
-      if (branch === null) return;
-      const forge = deps.resolveForge?.(row.repoPath);
-      if (!forge) return;
-      try {
-        const pr = await forge.prStatus(branch);
-        row.landingChecks = pr.checks;
-        row.landingMergeable = pr.mergeable ?? null;
-        const landingReady = computeLandingReady(pr);
-        row.landingReady = landingReady;
-        row.landingStranded = computeLandingStranded({
-          landingState: "open",
-          landingReady,
-          completedAt: row.completedAt,
-          now,
-        });
-      } catch {
-        // leave live fields undefined — always serve DB rows
-      }
-    }),
-  );
+  // errors must NOT 500 this route; just omit the live fields for that row). Shared helper so the
+  // rundown's landing-ready accessor (#1045) computes readiness identically.
+  await enrichLandingEpics(baseRows, {
+    getEpicIntegrationBranch: (repoPath, parent) =>
+      deps.store.getEpicIntegrationBranch(repoPath, parent),
+    resolveForge: (repoPath) => deps.resolveForge?.(repoPath),
+    now: Date.now(),
+  });
 
   return json(baseRows);
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -22,6 +22,7 @@ import type {
   PrReview,
   HerdDigest,
   RundownItem,
+  RundownEpicItem,
   HeldTask,
   CreateSessionInput,
   SessionUsageRow,
@@ -316,6 +317,7 @@ type HerdDigestRow = {
   train: string | null;
   focusNext: string;
   attentionFingerprint: string;
+  epicsToLand: string;
   spawnSessionId: string | null;
   cwd: string | null;
   model: string | null;
@@ -685,12 +687,17 @@ export class SessionStore implements CapStore, CreditStore {
       train TEXT NOT NULL DEFAULT '',
       focusNext TEXT NOT NULL DEFAULT '[]',
       attentionFingerprint TEXT NOT NULL DEFAULT '{}',
+      epicsToLand TEXT NOT NULL DEFAULT '[]',
       spawnSessionId TEXT NOT NULL DEFAULT '',
       cwd TEXT NOT NULL DEFAULT '',
       model TEXT,
       spawnedAt INTEGER NOT NULL,
       generatedAt INTEGER,
       updatedAt INTEGER NOT NULL)`);
+    // migrate herd_digests rows that predate the epicsToLand column (#1045) (legacy rows default []).
+    const herdCols = this.db.query(`PRAGMA table_info(herd_digests)`).all() as { name: string }[];
+    if (!herdCols.some((c) => c.name === "epicsToLand"))
+      this.db.run(`ALTER TABLE herd_digests ADD COLUMN epicsToLand TEXT NOT NULL DEFAULT '[]'`);
     // Exact reviewer-cost attribution. Keyed by the *reviewer's* forced --session-id (which
     // locates its transcript), NOT the task — and deliberately carries NO foreign key to
     // `sessions`. `reviews`/`plan_gates` are keyed by the task sessionId and get deleted on
@@ -2140,6 +2147,30 @@ export class SessionStore implements CapStore, CreditStore {
     return out;
   }
 
+  private hydrateEpics(raw: unknown): RundownEpicItem[] {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(typeof raw === "string" ? raw : "[]");
+    } catch {
+      return [];
+    }
+    if (!Array.isArray(parsed)) return [];
+    const out: RundownEpicItem[] = [];
+    for (const x of parsed) {
+      if (!x || typeof x !== "object") continue;
+      const o = x as Record<string, unknown>;
+      if (typeof o.repo !== "string" || typeof o.parent !== "number") continue;
+      out.push({
+        repo: o.repo,
+        parent: o.parent,
+        title: typeof o.title === "string" ? o.title : "",
+        landingPr: typeof o.landingPr === "number" ? o.landingPr : null,
+        stranded: o.stranded === true,
+      });
+    }
+    return out;
+  }
+
   private hydrateHerdDigest(r: HerdDigestRow): HerdDigest {
     let fingerprint: Record<string, string[]> = {};
     try {
@@ -2161,6 +2192,7 @@ export class SessionStore implements CapStore, CreditStore {
       ciRework: this.hydrateItems(r.ciRework),
       train: r.train ?? "",
       focusNext: this.hydrateItems(r.focusNext),
+      epicsToLand: this.hydrateEpics(r.epicsToLand),
       attentionFingerprint: fingerprint,
       spawnSessionId: r.spawnSessionId ?? "",
       cwd: r.cwd ?? "",
@@ -2172,7 +2204,7 @@ export class SessionStore implements CapStore, CreditStore {
   }
 
   private readonly HERD_COLS = `dayKey, state, overnight, decisions, ciRework, train, focusNext,
-    attentionFingerprint, spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt`;
+    attentionFingerprint, epicsToLand, spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt`;
 
   getHerdDigest(dayKey: string): HerdDigest | null {
     const r = this.db
@@ -2191,13 +2223,14 @@ export class SessionStore implements CapStore, CreditStore {
   putHerdDigest(d: HerdDigest): void {
     this.db.run(
       `INSERT INTO herd_digests (dayKey, state, overnight, decisions, ciRework, train, focusNext,
-         attentionFingerprint, spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+         attentionFingerprint, epicsToLand, spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
        ON CONFLICT(dayKey) DO UPDATE SET state=excluded.state, overnight=excluded.overnight,
          decisions=excluded.decisions, ciRework=excluded.ciRework, train=excluded.train,
          focusNext=excluded.focusNext, attentionFingerprint=excluded.attentionFingerprint,
-         spawnSessionId=excluded.spawnSessionId, cwd=excluded.cwd, model=excluded.model,
-         spawnedAt=excluded.spawnedAt, generatedAt=excluded.generatedAt, updatedAt=excluded.updatedAt`,
+         epicsToLand=excluded.epicsToLand, spawnSessionId=excluded.spawnSessionId, cwd=excluded.cwd,
+         model=excluded.model, spawnedAt=excluded.spawnedAt, generatedAt=excluded.generatedAt,
+         updatedAt=excluded.updatedAt`,
       [
         d.dayKey,
         d.state,
@@ -2207,6 +2240,7 @@ export class SessionStore implements CapStore, CreditStore {
         d.train ?? "",
         JSON.stringify(d.focusNext ?? []),
         JSON.stringify(d.attentionFingerprint ?? {}),
+        JSON.stringify(d.epicsToLand ?? []),
         d.spawnSessionId ?? "",
         d.cwd ?? "",
         d.model ?? null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -331,6 +331,20 @@ export interface RundownItem {
   pr?: number;
 }
 
+/** A Tier-1 "land this epic" item in the rundown (#1045). Unlike RundownItem these are NOT
+ *  LLM-authored — the server injects them deterministically from the landing-ready completed-epic
+ *  set (open landing PR that is CLEAN + CI-green + mergeable per #1039's computeLandingReady), so
+ *  they can never be dropped or hallucinated. `repo`/`parent` deep-link to the IntegratedEpicsBand
+ *  row + its Land CTA. `stranded` flags an open+ready landing that has sat unlanded past the Rec D
+ *  threshold (urgency emphasis only — it does not gate inclusion). */
+export interface RundownEpicItem {
+  repo: string;
+  parent: number;
+  title: string;
+  landingPr: number | null;
+  stranded: boolean;
+}
+
 /** The LLM-authored verdict the rundown spawn writes to `.shepherd-rundown.json`. */
 export interface RundownVerdict {
   overnight: string;
@@ -353,6 +367,9 @@ export interface HerdDigest {
   ciRework: RundownItem[];
   train: string;
   focusNext: RundownItem[];
+  /** Tier-1 "land this epic" items (#1045). Server ground truth, NOT from the LLM verdict — set
+   *  at spawn time and kept live intraday by reconcileEpics() (see HerdDigestService). */
+  epicsToLand: RundownEpicItem[];
   attentionFingerprint: Record<string, string[]>; // sessionId → sorted signal codes
   spawnSessionId: string; // claude --session-id of the rundown spawn (usage + pane resolve)
   cwd: string; // tmpdir cwd of the spawn (verdict file read + pane reap)

--- a/test/completed-epic.test.ts
+++ b/test/completed-epic.test.ts
@@ -3,8 +3,11 @@ import {
   buildRollup,
   computeLandingReady,
   computeLandingStranded,
+  enrichLandingEpics,
   EPIC_LANDING_STRANDED_MS,
 } from "../src/completed-epic";
+import type { CompletedEpic } from "../src/completed-epic";
+import type { PrStatus } from "../src/forge/types";
 
 describe("buildRollup", () => {
   it("child WITH detail row → integrated true, PR facts from row", () => {
@@ -280,5 +283,94 @@ describe("computeLandingStranded", () => {
         now: completedAt + EPIC_LANDING_STRANDED_MS + 1,
       }),
     ).toBe(false);
+  });
+});
+
+// ── enrichLandingEpics ────────────────────────────────────────────────────────
+describe("enrichLandingEpics", () => {
+  const baseEpic = (over: Partial<CompletedEpic> = {}): CompletedEpic => ({
+    repoPath: "/repo/a",
+    parentIssueNumber: 7,
+    parentTitle: "Epic A",
+    completedAt: 1_000,
+    children: [],
+    landingPrNumber: 42,
+    landingPrUrl: "http://x/42",
+    landingState: "open",
+    migrationPaths: [],
+    migrationsAckedAt: null,
+    ...over,
+  });
+
+  const prStatus = (over: Partial<PrStatus> = {}): PrStatus =>
+    ({ state: "open", checks: "success", mergeable: true, ...over }) as PrStatus;
+
+  it("open + ready PR → fills landingReady/Checks/Mergeable/Stranded", async () => {
+    const rows = [baseEpic({ completedAt: 0 })];
+    await enrichLandingEpics(rows, {
+      getEpicIntegrationBranch: () => "epic/7",
+      resolveForge: () => ({ prStatus: async () => prStatus() }),
+      now: EPIC_LANDING_STRANDED_MS + 1, // completed long ago → stranded
+    });
+    expect(rows[0]?.landingReady).toBe(true);
+    expect(rows[0]?.landingChecks).toBe("success");
+    expect(rows[0]?.landingMergeable).toBe(true);
+    expect(rows[0]?.landingStranded).toBe(true);
+  });
+
+  it("open but CI red → landingReady false, not stranded", async () => {
+    const rows = [baseEpic({ completedAt: 0 })];
+    await enrichLandingEpics(rows, {
+      getEpicIntegrationBranch: () => "epic/7",
+      resolveForge: () => ({ prStatus: async () => prStatus({ checks: "failure" }) }),
+      now: EPIC_LANDING_STRANDED_MS + 1,
+    });
+    expect(rows[0]?.landingReady).toBe(false);
+    expect(rows[0]?.landingStranded).toBe(false);
+  });
+
+  it("landingState != 'open' → skipped, no live fields", async () => {
+    const rows = [baseEpic({ landingState: "merged" })];
+    await enrichLandingEpics(rows, {
+      getEpicIntegrationBranch: () => "epic/7",
+      resolveForge: () => ({ prStatus: async () => prStatus() }),
+      now: 0,
+    });
+    expect(rows[0]?.landingReady).toBeUndefined();
+  });
+
+  it("no integration branch → skipped", async () => {
+    const rows = [baseEpic()];
+    await enrichLandingEpics(rows, {
+      getEpicIntegrationBranch: () => null,
+      resolveForge: () => ({ prStatus: async () => prStatus() }),
+      now: 0,
+    });
+    expect(rows[0]?.landingReady).toBeUndefined();
+  });
+
+  it("no forge for repo → skipped", async () => {
+    const rows = [baseEpic()];
+    await enrichLandingEpics(rows, {
+      getEpicIntegrationBranch: () => "epic/7",
+      resolveForge: () => null,
+      now: 0,
+    });
+    expect(rows[0]?.landingReady).toBeUndefined();
+  });
+
+  it("forge prStatus throws → fail-safe, live fields left undefined", async () => {
+    const rows = [baseEpic()];
+    await enrichLandingEpics(rows, {
+      getEpicIntegrationBranch: () => "epic/7",
+      resolveForge: () => ({
+        prStatus: async () => {
+          throw new Error("network");
+        },
+      }),
+      now: 0,
+    });
+    expect(rows[0]?.landingReady).toBeUndefined();
+    expect(rows[0]?.landingChecks).toBeUndefined();
   });
 });

--- a/test/herd-digest.test.ts
+++ b/test/herd-digest.test.ts
@@ -2,6 +2,7 @@ import { expect, test, beforeEach, afterEach } from "bun:test";
 import { HerdDigestService, dayKeyFor } from "../src/herd-digest";
 import type { HerdSnapshots, MergeTrainState } from "../src/herd-digest";
 import type { HerdDigest, RundownEpicItem, Session } from "../src/types";
+import { RUNDOWN_EPICS_CAP } from "../src/rundown-core";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
 
 beforeEach(() => {
@@ -842,4 +843,36 @@ test("reconcileEpics: only today's ready digest (stale day ignored)", async () =
   });
   await svc.reconcileEpics();
   expect(store.getHerdDigest(staleDay)?.epicsToLand).toEqual([]); // untouched
+});
+
+test("reconcileEpics: caps the intraday list to RUNDOWN_EPICS_CAP", async () => {
+  const dayKey = dayKeyFor(DAY1);
+  const ready: HerdDigest = {
+    dayKey,
+    state: "ready",
+    overnight: "",
+    decisions: [],
+    ciRework: [],
+    train: "",
+    focusNext: [],
+    epicsToLand: [],
+    attentionFingerprint: {},
+    spawnSessionId: "spawn-1",
+    cwd: "/tmp/x",
+    model: "sonnet",
+    spawnedAt: DAY1 - 1000,
+    generatedAt: DAY1 - 1000,
+    updatedAt: DAY1 - 1000,
+  };
+  const store = makeStore([], [ready]);
+  const herdr = makeHerdr();
+  const many = Array.from({ length: RUNDOWN_EPICS_CAP + 8 }, (_, i) => sampleEpic({ parent: i }));
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => DAY1,
+    landingReadyEpics: async () => many,
+  });
+  await svc.reconcileEpics();
+  expect(store.getHerdDigest(dayKey)?.epicsToLand.length).toBe(RUNDOWN_EPICS_CAP);
 });

--- a/test/herd-digest.test.ts
+++ b/test/herd-digest.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, beforeEach, afterEach } from "bun:test";
 import { HerdDigestService, dayKeyFor } from "../src/herd-digest";
 import type { HerdSnapshots, MergeTrainState } from "../src/herd-digest";
-import type { HerdDigest, Session } from "../src/types";
+import type { HerdDigest, RundownEpicItem, Session } from "../src/types";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
 
 beforeEach(() => {
@@ -160,6 +160,8 @@ function buildSvc(opts: {
   stalledSessionIds?: () => Set<string>;
   mergeTrainState?: () => MergeTrainState;
   backlogPriority?: () => Record<string, number>;
+  landingReadyEpics?: () => Promise<RundownEpicItem[]>;
+  hasOpenLandingEpics?: () => boolean;
   verdict?: string | null;
   timeoutMs?: number;
   readUsage?: () => Promise<any>;
@@ -176,6 +178,8 @@ function buildSvc(opts: {
     stalledSessionIds: opts.stalledSessionIds,
     mergeTrainState: opts.mergeTrainState,
     backlogPriority: opts.backlogPriority,
+    landingReadyEpics: opts.landingReadyEpics,
+    hasOpenLandingEpics: opts.hasOpenLandingEpics,
     model: "sonnet",
     now: opts.nowFn,
     timeoutMs: opts.timeoutMs ?? 300_000,
@@ -263,6 +267,7 @@ test("tick: generating row + valid verdict → 'ready' with parsed fields + onCh
     ciRework: [],
     train: "",
     focusNext: [],
+    epicsToLand: [],
     attentionFingerprint: { s1: ["in-flight"] },
     spawnSessionId: "sp1",
     cwd: "/tmp/rundown-x",
@@ -328,6 +333,7 @@ test("tick: generating row, no verdict, past timeout → 'failed' (not ready, no
     ciRework: [],
     train: "",
     focusNext: [],
+    epicsToLand: [],
     attentionFingerprint: {},
     spawnSessionId: "sp2",
     cwd: "/tmp/rundown-timeout",
@@ -367,6 +373,7 @@ test("tick: generating row, unparseable verdict → 'failed'", async () => {
     ciRework: [],
     train: "",
     focusNext: [],
+    epicsToLand: [],
     attentionFingerprint: {},
     spawnSessionId: "sp3",
     cwd: "/tmp/rundown-garbage",
@@ -401,6 +408,7 @@ test("regenerate: forces a new generation even when today's digest is ready", as
     ciRework: [],
     train: "",
     focusNext: [],
+    epicsToLand: [],
     attentionFingerprint: {},
     spawnSessionId: "old-sp",
     cwd: "/tmp/old",
@@ -431,6 +439,7 @@ test("regenerate: forced over an in-flight (generating) row → reaps OLD pane+t
     ciRework: [],
     train: "",
     focusNext: [],
+    epicsToLand: [],
     attentionFingerprint: {},
     spawnSessionId: "old-sp",
     cwd: "/tmp/rundown-old-inflight",
@@ -585,4 +594,252 @@ test("generate: backlogPriority is threaded into the assembled prompt as backlog
   const prompt = herdr.started[0]!.argv.at(-1)!;
   // The emitted session for /r must carry its rank-0 priority in the herd-state JSON.
   expect(prompt).toContain('"backlogRank": 0');
+});
+
+// ── #1045: epics-to-land surfacing + intraday reconcile ──────────────────────────
+
+const sampleEpic = (over: Partial<RundownEpicItem> = {}): RundownEpicItem => ({
+  repo: "/repo/a",
+  parent: 7,
+  title: "Epic A",
+  landingPr: 99,
+  stranded: false,
+  ...over,
+});
+
+test("generate: empty herd BUT a landing-ready epic → spawns, row carries epicsToLand", async () => {
+  const store = makeStore([]); // no live sessions
+  const herdr = makeHerdr();
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => DAY1,
+    hasOpenLandingEpics: () => true,
+    landingReadyEpics: async () => [sampleEpic()],
+  });
+
+  expect(await svc.generate()).toBe("started");
+  expect(herdr.started.length).toBe(1);
+  const row = store.getHerdDigest(dayKeyFor(DAY1));
+  expect(row?.epicsToLand).toEqual([sampleEpic()]);
+});
+
+test("generate: empty herd + open-but-NOT-ready epic → 'empty', no spawn, no row", async () => {
+  const store = makeStore([]);
+  const herdr = makeHerdr();
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => DAY1,
+    hasOpenLandingEpics: () => true, // sweep pre-filter would pass...
+    landingReadyEpics: async () => [], // ...but nothing is actually ready
+  });
+
+  expect(await svc.generate()).toBe("empty");
+  expect(herdr.started.length).toBe(0);
+  expect(store.getHerdDigest(dayKeyFor(DAY1))).toBeNull();
+});
+
+test("sweep: empty herd + hasOpenLandingEpics → calls generate (spawns for ready epic)", async () => {
+  const store = makeStore([]);
+  const herdr = makeHerdr();
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => DAY1,
+    hasOpenLandingEpics: () => true,
+    landingReadyEpics: async () => [sampleEpic()],
+  });
+  await svc.sweep();
+  expect(herdr.started.length).toBe(1);
+});
+
+test("sweep: empty herd + NO open epics → pre-filter skips, no spawn (no forge probe)", async () => {
+  const store = makeStore([]);
+  const herdr = makeHerdr();
+  let probed = false;
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => DAY1,
+    hasOpenLandingEpics: () => false,
+    landingReadyEpics: async () => {
+      probed = true;
+      return [];
+    },
+  });
+  await svc.sweep();
+  expect(herdr.started.length).toBe(0);
+  expect(probed).toBe(false); // generate() never called → no forge probe
+});
+
+test("regenerate: truly empty (no sessions, no ready epics) → 'empty', writes no row", async () => {
+  const store = makeStore([]);
+  const herdr = makeHerdr();
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => DAY1,
+    hasOpenLandingEpics: () => false,
+    landingReadyEpics: async () => [],
+  });
+  expect(await svc.regenerate()).toBe("empty");
+  expect(store.getHerdDigest(dayKeyFor(DAY1))).toBeNull();
+  expect(herdr.started.length).toBe(0);
+});
+
+test("finalize: epicsToLand on generating row carries through to ready", async () => {
+  const store = makeStore([]);
+  const herdr = makeHerdr();
+  const verdict = JSON.stringify({
+    overnight: "",
+    decisions: [],
+    ciRework: [],
+    train: "",
+    focusNext: [],
+  });
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => DAY1,
+    hasOpenLandingEpics: () => true,
+    landingReadyEpics: async () => [sampleEpic()],
+    verdict,
+  });
+  await svc.generate();
+  await svc.tick(); // finalize the generating row
+  const row = store.getHerdDigest(dayKeyFor(DAY1));
+  expect(row?.state).toBe("ready");
+  expect(row?.epicsToLand).toEqual([sampleEpic()]); // survived finalize
+});
+
+test("reconcileEpics: red→green flip updates today's ready row + emits", async () => {
+  const dayKey = dayKeyFor(DAY1);
+  const ready: HerdDigest = {
+    dayKey,
+    state: "ready",
+    overnight: "",
+    decisions: [],
+    ciRework: [],
+    train: "",
+    focusNext: [],
+    epicsToLand: [], // epic was NOT ready when generated
+    attentionFingerprint: {},
+    spawnSessionId: "spawn-1",
+    cwd: "/tmp/x",
+    model: "sonnet",
+    spawnedAt: DAY1 - 1000,
+    generatedAt: DAY1 - 1000,
+    updatedAt: DAY1 - 1000,
+  };
+  const store = makeStore([], [ready]);
+  const herdr = makeHerdr();
+  const changes: HerdDigest[] = [];
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => DAY1,
+    onChange: (d) => changes.push(d),
+    landingReadyEpics: async () => [sampleEpic()], // now ready
+  });
+
+  await svc.reconcileEpics();
+  const row = store.getHerdDigest(dayKey);
+  expect(row?.epicsToLand).toEqual([sampleEpic()]);
+  expect(changes.at(-1)?.epicsToLand).toEqual([sampleEpic()]);
+});
+
+test("reconcileEpics: unchanged set → no-op (no emit)", async () => {
+  const dayKey = dayKeyFor(DAY1);
+  const ready: HerdDigest = {
+    dayKey,
+    state: "ready",
+    overnight: "",
+    decisions: [],
+    ciRework: [],
+    train: "",
+    focusNext: [],
+    epicsToLand: [sampleEpic()],
+    attentionFingerprint: {},
+    spawnSessionId: "spawn-1",
+    cwd: "/tmp/x",
+    model: "sonnet",
+    spawnedAt: DAY1 - 1000,
+    generatedAt: DAY1 - 1000,
+    updatedAt: DAY1 - 1000,
+  };
+  const store = makeStore([], [ready]);
+  const herdr = makeHerdr();
+  const changes: HerdDigest[] = [];
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => DAY1,
+    onChange: (d) => changes.push(d),
+    landingReadyEpics: async () => [sampleEpic()], // identical
+  });
+  await svc.reconcileEpics();
+  expect(changes.length).toBe(0);
+});
+
+test("reconcileEpics: landed/lost readiness shrinks the set", async () => {
+  const dayKey = dayKeyFor(DAY1);
+  const ready: HerdDigest = {
+    dayKey,
+    state: "ready",
+    overnight: "",
+    decisions: [],
+    ciRework: [],
+    train: "",
+    focusNext: [],
+    epicsToLand: [sampleEpic()],
+    attentionFingerprint: {},
+    spawnSessionId: "spawn-1",
+    cwd: "/tmp/x",
+    model: "sonnet",
+    spawnedAt: DAY1 - 1000,
+    generatedAt: DAY1 - 1000,
+    updatedAt: DAY1 - 1000,
+  };
+  const store = makeStore([], [ready]);
+  const herdr = makeHerdr();
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => DAY1,
+    landingReadyEpics: async () => [], // epic landed → no longer ready
+  });
+  await svc.reconcileEpics();
+  expect(store.getHerdDigest(dayKey)?.epicsToLand).toEqual([]);
+});
+
+test("reconcileEpics: only today's ready digest (stale day ignored)", async () => {
+  const staleDay = dayKeyFor(DAY1);
+  const stale: HerdDigest = {
+    dayKey: staleDay,
+    state: "ready",
+    overnight: "",
+    decisions: [],
+    ciRework: [],
+    train: "",
+    focusNext: [],
+    epicsToLand: [],
+    attentionFingerprint: {},
+    spawnSessionId: "spawn-1",
+    cwd: "/tmp/x",
+    model: "sonnet",
+    spawnedAt: DAY1 - 1000,
+    generatedAt: DAY1 - 1000,
+    updatedAt: DAY1 - 1000,
+  };
+  const store = makeStore([], [stale]);
+  const herdr = makeHerdr();
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => DAY2, // "today" is DAY2; the ready row is from DAY1
+    landingReadyEpics: async () => [sampleEpic()],
+  });
+  await svc.reconcileEpics();
+  expect(store.getHerdDigest(staleDay)?.epicsToLand).toEqual([]); // untouched
 });

--- a/test/herd-digest.test.ts
+++ b/test/herd-digest.test.ts
@@ -750,6 +750,42 @@ test("reconcileEpics: red→green flip updates today's ready row + emits", async
   expect(changes.at(-1)?.epicsToLand).toEqual([sampleEpic()]);
 });
 
+test("reconcileEpics: a FAILED digest is kept live too (epic landed → drops)", async () => {
+  const dayKey = dayKeyFor(DAY1);
+  const failed: HerdDigest = {
+    dayKey,
+    state: "failed",
+    overnight: "",
+    decisions: [],
+    ciRework: [],
+    train: "",
+    focusNext: [],
+    epicsToLand: [sampleEpic()], // epic was ready when the (failed) digest spawned
+    attentionFingerprint: {},
+    spawnSessionId: "spawn-1",
+    cwd: "/tmp/x",
+    model: "sonnet",
+    spawnedAt: DAY1 - 1000,
+    generatedAt: DAY1 - 1000,
+    updatedAt: DAY1 - 1000,
+  };
+  const store = makeStore([], [failed]);
+  const herdr = makeHerdr();
+  const changes: HerdDigest[] = [];
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => DAY1,
+    onChange: (d) => changes.push(d),
+    landingReadyEpics: async () => [], // epic has since landed → no longer ready
+  });
+
+  await svc.reconcileEpics();
+  expect(store.getHerdDigest(dayKey)?.epicsToLand).toEqual([]);
+  expect(store.getHerdDigest(dayKey)?.state).toBe("failed"); // state preserved
+  expect(changes.at(-1)?.epicsToLand).toEqual([]);
+});
+
 test("reconcileEpics: unchanged set → no-op (no emit)", async () => {
   const dayKey = dayKeyFor(DAY1);
   const ready: HerdDigest = {

--- a/test/rundown-core.test.ts
+++ b/test/rundown-core.test.ts
@@ -12,6 +12,7 @@ import {
   RUNDOWN_LABEL_MAX,
   RUNDOWN_DECISIONS_CAP,
   RUNDOWN_FOCUSNEXT_CAP,
+  RUNDOWN_EPICS_CAP,
   explainHold,
   type ClassifyCaches,
 } from "../src/rundown-core";
@@ -664,4 +665,75 @@ test("buildRundownPrompt: prompt instructs model about the 'why' field and rende
   expect(prompt).toContain("Plan review");
   // The "hold" object must NOT appear in prompt JSON — it's replaced by the "why" string
   expect(prompt).not.toContain('"hold"');
+});
+
+// ── epics-to-land (#1045) ─────────────────────────────────────────────────────
+const epic = (over: Partial<import("../src/types").RundownEpicItem> = {}) => ({
+  repo: "/repo/a",
+  parent: 7,
+  title: "Epic A",
+  landingPr: 99,
+  stranded: false,
+  ...over,
+});
+
+test("assembleHerdState: epics passed through (default [] when absent)", () => {
+  const none = assembleHerdState({
+    sessions: [],
+    overnightDelta: { mergedPrs: [], archivedSessions: [] },
+    generatedFor: "2026-06-15",
+    now: NOW,
+  });
+  expect(none.epics).toEqual([]);
+
+  const out = assembleHerdState({
+    sessions: [],
+    epics: [epic(), epic({ parent: 8, title: "Epic B" })],
+    overnightDelta: { mergedPrs: [], archivedSessions: [] },
+    generatedFor: "2026-06-15",
+    now: NOW,
+  });
+  expect(out.epics.map((e) => e.parent)).toEqual([7, 8]);
+});
+
+test("assembleHerdState: epics sliced to RUNDOWN_EPICS_CAP", () => {
+  const many = Array.from({ length: 30 }, (_, i) => epic({ parent: i }));
+  const out = assembleHerdState({
+    sessions: [],
+    epics: many,
+    overnightDelta: { mergedPrs: [], archivedSessions: [] },
+    generatedFor: "2026-06-15",
+    now: NOW,
+  });
+  expect(out.epics.length).toBe(RUNDOWN_EPICS_CAP);
+});
+
+test("buildRundownPrompt: epics surfaced in dedicated block, NOT echoed in the JSON dump", () => {
+  const out = assembleHerdState({
+    sessions: [],
+    epics: [epic({ repo: "/repo/x", parent: 7, title: "Land me", landingPr: 99, stranded: true })],
+    overnightDelta: { mergedPrs: [], archivedSessions: [] },
+    generatedFor: "2026-06-15",
+    now: NOW,
+  });
+  const prompt = buildRundownPrompt(out);
+  // dedicated block present
+  expect(prompt).toContain("EPICS AWAITING LANDING");
+  expect(prompt).toContain("/repo/x #7");
+  expect(prompt).toContain("landing PR #99");
+  expect(prompt).toContain("STRANDED");
+  expect(prompt).toContain("MUST NOT repeat them in");
+  // the JSON herd-state dump must NOT carry an `epics` key (stripped to avoid double-injection)
+  const dump = prompt.slice(prompt.indexOf("Herd state (already significance-ranked):"));
+  expect(dump).not.toContain('"epics"');
+});
+
+test("buildRundownPrompt: no epic block when none", () => {
+  const out = assembleHerdState({
+    sessions: [],
+    overnightDelta: { mergedPrs: [], archivedSessions: [] },
+    generatedFor: "2026-06-15",
+    now: NOW,
+  });
+  expect(buildRundownPrompt(out)).not.toContain("EPICS AWAITING LANDING");
 });

--- a/test/server-herd-digest.test.ts
+++ b/test/server-herd-digest.test.ts
@@ -24,6 +24,7 @@ function mkDigest(over: Partial<HerdDigest> = {}): HerdDigest {
     ciRework: [],
     train: "queue idle",
     focusNext: [],
+    epicsToLand: [],
     attentionFingerprint: { s1: ["blocked-decision"], s2: ["in-flight"] },
     spawnSessionId: "spawn-1",
     cwd: "/tmp/rundown-xyz",
@@ -77,6 +78,7 @@ test("GET /api/herd/digest → returns the digest with staleCount 0 when the her
 
 test("GET /api/herd/digest → staleCount reflects drift (a session went CI-red, another cleared)", async () => {
   const digest = mkDigest({
+    epicsToLand: [],
     attentionFingerprint: { s1: ["blocked-decision"], s2: ["in-flight"] },
   });
   const app = harness({

--- a/test/store-herd-digests.test.ts
+++ b/test/store-herd-digests.test.ts
@@ -10,6 +10,7 @@ const d = (over: Partial<HerdDigest> = {}): HerdDigest => ({
   ciRework: [],
   train: "",
   focusNext: [],
+  epicsToLand: [],
   attentionFingerprint: {},
   spawnSessionId: "spawn-1",
   cwd: "/tmp/rundown-1",
@@ -32,6 +33,7 @@ test("herd_digests: put→get round-trip (incl. JSON columns)", () => {
       train: "1 ready",
       focusNext: [{ label: "review migration" }],
       attentionFingerprint: { s1: ["ci-red", "in-flight"] },
+      epicsToLand: [{ repo: "/repo/a", parent: 7, title: "Epic A", landingPr: 99, stranded: true }],
       generatedAt: 2000,
     }),
   );
@@ -42,6 +44,9 @@ test("herd_digests: put→get round-trip (incl. JSON columns)", () => {
   expect(got?.decisions).toEqual([{ label: "answer auth", sessionId: "s1" }]);
   expect(got?.ciRework).toEqual([{ label: "ci red", pr: 42 }]);
   expect(got?.focusNext).toEqual([{ label: "review migration" }]);
+  expect(got?.epicsToLand).toEqual([
+    { repo: "/repo/a", parent: 7, title: "Epic A", landingPr: 99, stranded: true },
+  ]);
   expect(got?.attentionFingerprint).toEqual({ s1: ["ci-red", "in-flight"] });
   expect(got?.model).toBe("claude-opus-4-8");
   expect(got?.generatedAt).toBe(2000);

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1875,5 +1875,11 @@
   "feat_land_epic_body": "Wenn der Landing-PR eines Epics offen ist und alle Checks bestanden haben, ermöglicht ein neuer 'Epic landen'-Button im Band der integrierten Epics das Mergen mit einem Klick — kein Wechsel zu GitHub nötig.",
   "feat_epic_auto_land_title": "Integrierte Epics automatisch landen",
   "feat_epic_auto_land_body": "Wenn Auto-Merge für ein Repo aktiviert ist, wird der Landing-PR eines integrierten Epics jetzt automatisch gemergt, sobald er sauber ist und alle Checks bestanden haben — dieselbe Opt-in-Einstellung, die auch deine Voll-Auto-Sessions landet. Epics mit Migrationen werden für die manuelle Prüfung zurückgehalten, und der 'Epic landen'-Button funktioniert weiterhin jederzeit.",
-  "landed_epic_toast": "Epic #{number} gelandet — in den Standardbranch gemergt"
+  "landed_epic_toast": "Epic #{number} gelandet — in den Standardbranch gemergt",
+  "rundown_epics_to_land": "Diese [[epic|Epics]] landen",
+  "rundown_epic_label": "{repo} · {title} #{number}",
+  "rundown_epic_stranded": "festgefahren",
+  "rundown_epic_open_aria": "Zu Epic #{number} springen, um es zu landen",
+  "feat_rundown_epics_to_land_title": "Rundown zeigt zu landende Epics",
+  "feat_rundown_epics_to_land_body": "Der tägliche Herd-Rundown hebt jetzt integrierte Epics, deren Landing-PR merge-bereit ist, als Top-Priorität hervor — auch wenn keine Sitzung aktiv ist — damit eine vergessene letzte Landung nicht mehr durchrutscht. Per Klick direkt zum Landen-Button des Epics springen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1875,5 +1875,11 @@
   "feat_land_epic_body": "When an epic's landing PR is open and all checks pass, a new 'Land epic' button in the Integrated-epics band lets you merge it with one click — no need to switch to GitHub.",
   "feat_epic_auto_land_title": "Auto-land integrated epics",
   "feat_epic_auto_land_body": "With auto-merge enabled for a repo, an integrated epic's landing PR now merges automatically once it's clean and all checks pass — the same opt-in that lands your full-auto sessions. Epics that touch migrations are held for manual review, and the 'Land epic' button still works any time.",
-  "landed_epic_toast": "Epic #{number} landed — merged to the default branch"
+  "landed_epic_toast": "Epic #{number} landed — merged to the default branch",
+  "rundown_epics_to_land": "Land these [[epic|epics]]",
+  "rundown_epic_label": "{repo} · {title} #{number}",
+  "rundown_epic_stranded": "stranded",
+  "rundown_epic_open_aria": "Go to epic #{number} to land it",
+  "feat_rundown_epics_to_land_title": "Rundown surfaces epics to land",
+  "feat_rundown_epics_to_land_body": "The daily Herd Rundown now escalates integrated epics whose landing PR is ready to merge as a top-priority item — even when no session is live — so a forgotten last-mile landing no longer slips. Click it to jump straight to the epic's Land button."
 }

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -66,6 +66,8 @@
     doneSelectedId = null,
     ondoneselect = undefined,
     onrundownitem = undefined,
+    onrundownepic = undefined,
+    focusEpic = null,
     onackmigrationsepic = undefined,
   }: {
     sessions: Session[];
@@ -159,6 +161,11 @@
     // a Rundown digest item with a sessionId was clicked → page leaves the Rundown lens
     // and selects that live session (deep-link). Same mechanism a rail click uses.
     onrundownitem?: (id: string) => void;
+    // a Rundown epics-to-land item was clicked (#1045) → page leaves the Rundown lens and focuses
+    // that epic's row in the IntegratedEpicsBand (deep-link to its Land CTA), NOT a direct land.
+    onrundownepic?: (repo: string, parent: number) => void;
+    // when set, the IntegratedEpicsBand auto-expands + scrolls/opens this epic's row (#1045).
+    focusEpic?: { repo: string; parent: number } | null;
     // acknowledge a completed epic's landing-PR migrations (#645); also clears the row
     onackmigrationsepic?: (repoPath: string, parent: number) => void;
   } = $props();
@@ -428,7 +435,7 @@
   <div class="units" class:flow>
     {#if filter === "rundown"}
       <!-- Rundown lens: the daily Herd Rundown digest panel, no session list. -->
-      <RundownPanel onitemselect={onrundownitem} />
+      <RundownPanel onitemselect={onrundownitem} onepicland={onrundownepic} />
     {:else if filter === "done"}
       <!-- Done lens: archived sessions from the page's lazy doneSessions store (NOT the
          live `sessions` list). Read-only rows; clicking opens the DoneRecapPanel. -->
@@ -478,6 +485,7 @@
         ondismiss={ondismissepic ?? (() => {})}
         onackmigrations={onackmigrationsepic ?? (() => {})}
         onland={onlandepic ?? (() => {})}
+        {focusEpic}
         {nowMs}
       />
     {/if}

--- a/ui/src/lib/components/IntegratedEpicRow.svelte
+++ b/ui/src/lib/components/IntegratedEpicRow.svelte
@@ -9,16 +9,32 @@
     ondismiss,
     onackmigrations,
     onland,
+    focused = false,
     nowMs = Date.now(),
   }: {
     epic: CompletedEpic;
     ondismiss: (repoPath: string, parent: number) => void;
     onackmigrations: (repoPath: string, parent: number) => void;
     onland: (repoPath: string, parent: number) => void;
+    // a Rundown epics-to-land deep-link (#1045) targeted this row → auto-open, scroll into view,
+    // and briefly highlight so the operator's eye lands on the Land CTA.
+    focused?: boolean;
     nowMs?: number;
   } = $props();
 
   let open = $state(false);
+
+  let rowEl = $state<HTMLDivElement | null>(null);
+  let highlight = $state(false);
+  // When this row becomes the deep-link focus, open it, scroll it into view, and flash a highlight.
+  $effect(() => {
+    if (!focused || !rowEl) return;
+    open = true;
+    rowEl.scrollIntoView({ behavior: "smooth", block: "center" });
+    highlight = true;
+    const t = setTimeout(() => (highlight = false), 1600);
+    return () => clearTimeout(t);
+  });
 
   // repo basename — last path segment (e.g. "community-map")
   const repoName = $derived(epic.repoPath.split("/").filter(Boolean).at(-1) ?? epic.repoPath);
@@ -31,7 +47,13 @@
   const isOpen = $derived(epic.landingState === "open");
 </script>
 
-<div class="row" role="region" aria-label={epic.parentTitle}>
+<div
+  class="row"
+  class:row-focused={highlight}
+  bind:this={rowEl}
+  role="region"
+  aria-label={epic.parentTitle}
+>
   <button
     type="button"
     class="row-head"
@@ -104,6 +126,13 @@
     gap: 4px;
     font-family: var(--font-mono);
     font-size: var(--fs-meta);
+    border-radius: 3px;
+    transition: box-shadow 0.4s ease;
+  }
+  /* Deep-link highlight (#1045): a brief amber ring when a Rundown epics-to-land item targets this
+     row, drawing the eye to the Land CTA. Fades out after ~1.6s. */
+  .row-focused {
+    box-shadow: 0 0 0 2px var(--color-amber);
   }
 
   /* Collapsed header — quiet/slate, matching the done-state recipe. */

--- a/ui/src/lib/components/IntegratedEpicsBand.browser.test.ts
+++ b/ui/src/lib/components/IntegratedEpicsBand.browser.test.ts
@@ -45,6 +45,28 @@ describe("IntegratedEpicsBand", () => {
     expect(document.querySelector(".band-head")).toBeNull();
   });
 
+  it("focusEpic auto-expands the band and opens the targeted row (#1045)", async () => {
+    render(IntegratedEpicsBand, {
+      epics: [epic(1), epic(2)],
+      ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
+      onland: vi.fn(),
+      focusEpic: { repo: "/home/me/work/repo2", parent: 302 },
+    });
+    // band auto-expands (not collapsed) → both rows render…
+    const rows = await vi.waitFor(() => {
+      const r = document.querySelectorAll(".rows .row");
+      if (r.length !== 2) throw new Error("rows not yet rendered");
+      return r;
+    });
+    expect(rows.length).toBe(2);
+    // …and the targeted row is highlighted (focus ring).
+    await vi.waitFor(() => {
+      if (!document.querySelector(".rows .row.row-focused")) throw new Error("not focused yet");
+    });
+    expect(document.querySelectorAll(".rows .row.row-focused").length).toBe(1);
+  });
+
   it("header shows the count and expanding reveals one row per epic", async () => {
     render(IntegratedEpicsBand, {
       epics: [epic(1), epic(2)],

--- a/ui/src/lib/components/IntegratedEpicsBand.svelte
+++ b/ui/src/lib/components/IntegratedEpicsBand.svelte
@@ -8,18 +8,29 @@
     ondismiss,
     onackmigrations,
     onland,
+    focusEpic = null,
     nowMs = Date.now(),
   }: {
     epics: CompletedEpic[];
     ondismiss: (repoPath: string, parent: number) => void;
     onackmigrations: (repoPath: string, parent: number) => void;
     onland: (repoPath: string, parent: number) => void;
+    // when set (a Rundown epics-to-land deep-link, #1045), expand the band + focus this row.
+    focusEpic?: { repo: string; parent: number } | null;
     nowMs?: number;
   } = $props();
 
   let collapsed = $state(true);
 
   const count = $derived(epics.length);
+
+  // A focus request (from the Rundown deep-link) must expand the band so the target row is visible;
+  // the row itself self-scrolls + opens when its `focused` flag turns on.
+  $effect(() => {
+    if (focusEpic) collapsed = false;
+  });
+  const isFocused = (e: CompletedEpic) =>
+    focusEpic != null && e.repoPath === focusEpic.repo && e.parentIssueNumber === focusEpic.parent;
 </script>
 
 {#if epics.length > 0}
@@ -38,7 +49,14 @@
     {#if !collapsed}
       <div class="rows">
         {#each epics as epic (`${epic.repoPath}#${epic.parentIssueNumber}`)}
-          <IntegratedEpicRow {epic} {ondismiss} {onackmigrations} {onland} {nowMs} />
+          <IntegratedEpicRow
+            {epic}
+            {ondismiss}
+            {onackmigrations}
+            {onland}
+            focused={isFocused(epic)}
+            {nowMs}
+          />
         {/each}
       </div>
     {/if}

--- a/ui/src/lib/components/RundownPanel.browser.test.ts
+++ b/ui/src/lib/components/RundownPanel.browser.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import type { HerdDigest, RundownEpicItem } from "$lib/types";
+import { herdDigest } from "$lib/herd-digest.svelte";
+
+const { default: RundownPanel } = await import("./RundownPanel.svelte");
+
+const epicItem = (over: Partial<RundownEpicItem> = {}): RundownEpicItem => ({
+  repo: "/home/me/work/community-map",
+  parent: 875,
+  title: "Docs site",
+  landingPr: 908,
+  stranded: false,
+  ...over,
+});
+
+const digest = (over: Partial<HerdDigest> = {}): HerdDigest => ({
+  dayKey: "2026-06-24",
+  state: "ready",
+  overnight: "",
+  decisions: [],
+  ciRework: [],
+  train: "",
+  focusNext: [],
+  epicsToLand: [],
+  attentionFingerprint: {},
+  spawnSessionId: "spawn-1",
+  cwd: "/tmp/x",
+  model: null,
+  spawnedAt: 0,
+  generatedAt: 1000,
+  updatedAt: 1000,
+  ...over,
+});
+
+afterEach(() => {
+  herdDigest.digest = null;
+  document.body.innerHTML = "";
+});
+
+describe("RundownPanel epics-to-land (#1045)", () => {
+  it("renders a Tier-1 epics-to-land deep-link with PR ref + stranded chip", async () => {
+    herdDigest.digest = digest({
+      epicsToLand: [epicItem({ stranded: true })],
+    });
+    render(RundownPanel, {});
+    await expect.element(page.getByText("Docs site", { exact: false })).toBeInTheDocument();
+    expect(document.querySelector(".rd-item-epic")).not.toBeNull();
+    expect(document.body.textContent).toContain("PR #908");
+    expect(document.querySelector(".rd-epic-stranded")).not.toBeNull();
+  });
+
+  it("clicking an epic item fires onepicland(repo, parent)", async () => {
+    herdDigest.digest = digest({ epicsToLand: [epicItem()] });
+    const onepicland = vi.fn();
+    render(RundownPanel, { onepicland });
+    (document.querySelector(".rd-item-epic") as HTMLButtonElement).click();
+    expect(onepicland).toHaveBeenCalledWith("/home/me/work/community-map", 875);
+  });
+
+  it("epics section renders while state is 'generating' (ground truth, not LLM output)", async () => {
+    herdDigest.digest = digest({ state: "generating", epicsToLand: [epicItem()] });
+    render(RundownPanel, {});
+    expect(document.querySelector(".rd-item-epic")).not.toBeNull();
+  });
+
+  it("all-quiet line is suppressed when an epic is pending (ready, otherwise empty)", async () => {
+    herdDigest.digest = digest({ epicsToLand: [epicItem()] });
+    render(RundownPanel, {});
+    // populated epics section present, but no all-quiet copy above it
+    expect(document.querySelector(".rd-item-epic")).not.toBeNull();
+    expect(document.body.textContent).not.toContain("All quiet");
+  });
+
+  it("all-quiet line shows when truly empty (no sessions, no epics)", async () => {
+    herdDigest.digest = digest({ epicsToLand: [] });
+    render(RundownPanel, {});
+    await expect.element(page.getByText("All quiet", { exact: false })).toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/components/RundownPanel.svelte
+++ b/ui/src/lib/components/RundownPanel.svelte
@@ -9,11 +9,24 @@
 
   // A rundown item with a sessionId deep-links to that session; the page swaps the
   // lens away from Rundown and selects it. PR-only items render as a static ref.
-  let { onitemselect }: { onitemselect?: (id: string) => void } = $props();
+  // onepicland deep-links a landing-ready epic to the IntegratedEpicsBand's Land CTA (#1045).
+  let {
+    onitemselect,
+    onepicland,
+  }: {
+    onitemselect?: (id: string) => void;
+    onepicland?: (repo: string, parent: number) => void;
+  } = $props();
 
   const digest = $derived(herdDigest.digest);
   const digestState = $derived(digest?.state ?? null);
   const generating = $derived(digestState === "generating");
+
+  // Epics-to-land (#1045): server ground truth on the digest row, NOT from the LLM verdict — so it
+  // renders in generating/ready/failed alike (it must not vanish mid-regenerate or on LLM failure).
+  const epicsToLand = $derived(digest?.epicsToLand ?? []);
+  // repo basename for a compact deep-link label (mirrors IntegratedEpicRow).
+  const repoBase = (p: string) => p.split("/").filter(Boolean).at(-1) ?? p;
 
   // "generated X ago" off the digest's generatedAt; ticks with the shared 30s clock
   // (same helper DoneRecapPanel uses for "finished X ago"). Null until a first digest.
@@ -27,13 +40,16 @@
 
   // Ready, yet every section empty: a legitimate all-clear, not a failure. Without an
   // explicit affordance the body renders blank and reads as broken.
+  // epicsToLand must gate all-quiet too (#1045): a landing-ready epic is a Tier-1 attention item,
+  // so the "all quiet" copy must never render above a populated epics section.
   const allQuiet = $derived(
     digestState === "ready" &&
       !digest?.overnight &&
       !digest?.train &&
       (digest?.decisions.length ?? 0) === 0 &&
       (digest?.ciRework.length ?? 0) === 0 &&
-      (digest?.focusNext.length ?? 0) === 0,
+      (digest?.focusNext.length ?? 0) === 0 &&
+      epicsToLand.length === 0,
   );
 
   // Fail-closed refresh: a rejected regenerate sets an error flag so it never reads
@@ -58,6 +74,31 @@
   }
 </script>
 
+<!-- Shared item renderers — extracted as snippets so the three near-identical section blocks
+     (focusNext/decisions/ciRework) don't repeat the sessionId/pr/static three-way (keeps the
+     template's complexity + duplication down). -->
+{#snippet linkItem(it: RundownItem, btnClass: string)}
+  {#if it.sessionId}
+    <button type="button" class={btnClass} onclick={() => clickItem(it)}>{it.label}</button>
+  {:else if it.pr != null}
+    <span class="rd-item-pr">{it.label} · {m.prbadge_open({ number: it.pr })}</span>
+  {:else}
+    <span class="rd-item-static">{it.label}</span>
+  {/if}
+{/snippet}
+
+{#snippet reworkItem(it: RundownItem)}
+  {#if it.sessionId}
+    <button type="button" class="rd-item rd-item-red" onclick={() => clickItem(it)}
+      >{it.label}{#if it.pr != null}&nbsp;· {m.prbadge_open({ number: it.pr })}{/if}</button
+    >
+  {:else if it.pr != null}
+    <span class="rd-item-pr">{it.label} · {m.prbadge_open({ number: it.pr })}</span>
+  {:else}
+    <span class="rd-item-static">{it.label}</span>
+  {/if}
+{/snippet}
+
 <section class="rundown" aria-label={m.rundown_title()}>
   <header class="rd-head">
     <span class="rd-title">{m.rundown_title()}</span>
@@ -81,6 +122,32 @@
   </header>
 
   <div class="rd-body">
+    {#if epicsToLand.length > 0}
+      <!-- Tier-1 epics-to-land (#1045): rendered regardless of digest state (generating/ready/failed)
+           because it is server ground truth, not LLM output, and must stay visible mid-regenerate. -->
+      <div class="rd-section rd-epics">
+        <p class="rd-section-head rd-section-head-epics">
+          <GlossaryText text={m.rundown_epics_to_land()} />
+        </p>
+        <ul class="rd-list">
+          {#each epicsToLand as e (`${e.repo}#${e.parent}`)}
+            <li>
+              <button
+                type="button"
+                class="rd-item rd-item-epic"
+                aria-label={m.rundown_epic_open_aria({ number: e.parent })}
+                onclick={() => onepicland?.(e.repo, e.parent)}
+              >
+                {m.rundown_epic_label({ repo: repoBase(e.repo), title: e.title, number: e.parent })}
+                {#if e.landingPr != null}&nbsp;· {m.prbadge_open({ number: e.landingPr })}{/if}
+                {#if e.stranded}<span class="rd-epic-stranded">{m.rundown_epic_stranded()}</span
+                  >{/if}
+              </button>
+            </li>
+          {/each}
+        </ul>
+      </div>
+    {/if}
     {#if generating}
       <p class="rd-muted">{m.rundown_generating()}</p>
     {:else if digestState === "failed"}
@@ -111,17 +178,7 @@
           <p class="rd-section-head">{m.rundown_focus_next()}</p>
           <ul class="rd-list">
             {#each digest.focusNext as it, i (i)}
-              <li>
-                {#if it.sessionId}
-                  <button type="button" class="rd-item rd-item-focus" onclick={() => clickItem(it)}
-                    >{it.label}</button
-                  >
-                {:else if it.pr != null}
-                  <span class="rd-item-pr">{it.label} · {m.prbadge_open({ number: it.pr })}</span>
-                {:else}
-                  <span class="rd-item-static">{it.label}</span>
-                {/if}
-              </li>
+              <li>{@render linkItem(it, "rd-item rd-item-focus")}</li>
             {/each}
           </ul>
         </div>
@@ -132,17 +189,7 @@
           <p class="rd-section-head">{m.rundown_decisions()}</p>
           <ul class="rd-list">
             {#each digest.decisions as it, i (i)}
-              <li>
-                {#if it.sessionId}
-                  <button type="button" class="rd-item" onclick={() => clickItem(it)}
-                    >{it.label}</button
-                  >
-                {:else if it.pr != null}
-                  <span class="rd-item-pr">{it.label} · {m.prbadge_open({ number: it.pr })}</span>
-                {:else}
-                  <span class="rd-item-static">{it.label}</span>
-                {/if}
-              </li>
+              <li>{@render linkItem(it, "rd-item")}</li>
             {/each}
           </ul>
         </div>
@@ -155,19 +202,7 @@
           </p>
           <ul class="rd-list">
             {#each digest.ciRework as it, i (i)}
-              <li>
-                {#if it.sessionId}
-                  <button type="button" class="rd-item rd-item-red" onclick={() => clickItem(it)}
-                    >{it.label}{#if it.pr != null}&nbsp;· {m.prbadge_open({
-                        number: it.pr,
-                      })}{/if}</button
-                  >
-                {:else if it.pr != null}
-                  <span class="rd-item-pr">{it.label} · {m.prbadge_open({ number: it.pr })}</span>
-                {:else}
-                  <span class="rd-item-static">{it.label}</span>
-                {/if}
-              </li>
+              <li>{@render reworkItem(it)}</li>
             {/each}
           </ul>
         </div>
@@ -283,6 +318,28 @@
     color: var(--color-muted);
   }
   .rd-section-head-red {
+    color: var(--color-red);
+  }
+  /* Epics-to-land is a Tier-1 actionable escalation (a ready landing awaiting a human), so its
+     heading carries the amber attention hue — the same "needs you, action available" signal. */
+  .rd-section-head-epics {
+    color: var(--color-amber);
+  }
+
+  /* Deep-link to the band's Land CTA; reads as actionable amber like the heading. */
+  .rd-item-epic {
+    color: var(--color-amber);
+  }
+  .rd-item-epic:hover {
+    color: var(--color-amber);
+    text-decoration: underline;
+  }
+  /* Stranded (overdue) landing — escalate to red. */
+  .rd-epic-stranded {
+    margin-left: 6px;
+    font-size: var(--fs-micro);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
     color: var(--color-red);
   }
 

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1507,4 +1507,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_epic_auto_land_title",
     bodyKey: "feat_epic_auto_land_body",
   },
+  {
+    // The daily Herd Rundown now injects landing-ready integrated epics as a Tier-1 "land these
+    // epics" section — surfacing a forgotten last-mile landing even when no session is live. No
+    // targetId — the section mounts only when a landing-ready epic exists; surface via the What's-New
+    // drawer only. v1.36.0 → ships in 1.37.0.
+    id: "rundown-epics-to-land",
+    sinceVersion: "1.37.0",
+    titleKey: "feat_rundown_epics_to_land_title",
+    bodyKey: "feat_rundown_epics_to_land_body",
+  },
 ];

--- a/ui/src/lib/herd-digest.svelte.test.ts
+++ b/ui/src/lib/herd-digest.svelte.test.ts
@@ -16,6 +16,7 @@ const digest = (dayKey: string): HerdDigest => ({
   ciRework: [],
   train: "no train",
   focusNext: [],
+  epicsToLand: [],
   attentionFingerprint: {},
   spawnSessionId: "spawn-1",
   cwd: "/repo",

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -431,6 +431,14 @@ export interface RundownItem {
   sessionId?: string;
   pr?: number;
 }
+// Tier-1 "land this epic" item (#1045) — server ground truth; repo/parent deep-link to the band.
+export interface RundownEpicItem {
+  repo: string;
+  parent: number;
+  title: string;
+  landingPr: number | null;
+  stranded: boolean;
+}
 export interface HerdDigest {
   dayKey: string;
   state: HerdDigestState;
@@ -439,6 +447,7 @@ export interface HerdDigest {
   ciRework: RundownItem[];
   train: string;
   focusNext: RundownItem[];
+  epicsToLand: RundownEpicItem[];
   attentionFingerprint: Record<string, string[]>;
   spawnSessionId: string;
   cwd: string;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -838,6 +838,17 @@
     selectUnit(id);
   }
 
+  // Deep-link a Rundown epics-to-land item (#1045) to its row in the IntegratedEpicsBand: leave the
+  // panel-only Rundown lens (the band is hidden there) and hand the band a focus target so it
+  // expands + scrolls/opens that epic's row with its Land CTA. Cleared first so re-clicking the same
+  // epic re-triggers the scroll/highlight (the focus effect keys on the value changing).
+  let focusEpic = $state<{ repo: string; parent: number } | null>(null);
+  function selectRundownEpic(repo: string, parent: number) {
+    herdFilter = "all";
+    focusEpic = null;
+    queueMicrotask(() => (focusEpic = { repo, parent }));
+  }
+
   // true when focus sits in something that consumes typing — a form field or the
   // PTY terminal (xterm holds focus in a hidden <textarea>, so the TEXTAREA check
   // covers it). Single-key shortcuts must stay silent there so they never eat a
@@ -1796,6 +1807,8 @@
               mobileScreen = "detail";
             }}
             onrundownitem={selectRundownItem}
+            onrundownepic={selectRundownEpic}
+            {focusEpic}
             onackmigrationsepic={onAckEpicMigrations}
           />
           {#if store.sessions.length === 0 && herdFilter !== "done" && herdFilter !== "rundown"}
@@ -1953,6 +1966,8 @@
             {doneSelectedId}
             ondoneselect={(id) => (doneSelectedId = id)}
             onrundownitem={selectRundownItem}
+            onrundownepic={selectRundownEpic}
+            {focusEpic}
             onackmigrationsepic={onAckEpicMigrations}
           />
         {/if}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -843,10 +843,17 @@
   // expands + scrolls/opens that epic's row with its Land CTA. Cleared first so re-clicking the same
   // epic re-triggers the scroll/highlight (the focus effect keys on the value changing).
   let focusEpic = $state<{ repo: string; parent: number } | null>(null);
+  let focusEpicToken = 0;
   function selectRundownEpic(repo: string, parent: number) {
     herdFilter = "all";
     focusEpic = null;
+    const token = ++focusEpicToken;
     queueMicrotask(() => (focusEpic = { repo, parent }));
+    // Clear once the row's highlight (~1.6s) has settled so a later band remount doesn't re-expand
+    // and re-flash a stale target. Token-guarded so a rapid re-click to another epic isn't cleared.
+    setTimeout(() => {
+      if (focusEpicToken === token) focusEpic = null;
+    }, 2000);
   }
 
   // true when focus sits in something that consumes typing — a form field or the


### PR DESCRIPTION
Closes #1045. Builds on #1039 (PR #1049, merged).

## What

The daily **Herd Rundown** now escalates a forgotten last-mile epic landing. Landing-ready completed epics — `landingState === "open"` **and** `landingReady` (CLEAN + CI-green + mergeable, per #1039's `computeLandingReady`) — are injected as a **Tier-1 "land these epics"** section, with a deep-link to the `IntegratedEpicsBand`'s Land CTA. Because an integrated epic's children are archived, it usually has **no live session**, so the digest now also spawns when the herd is otherwise idle but an epic is ready to land.

## How

- **types** — `RundownEpicItem` + `HerdDigest.epicsToLand` (server ground truth, **not** LLM-authored).
- **completed-epic** — extract shared `enrichLandingEpics` helper; `GET /api/epics/completed` reuses it (no behavior change).
- **rundown-core** — `epics` flow through `assembleHerdState`; dedicated prompt block; `RUNDOWN_EPICS_CAP`. Epics are **stripped from the herd-state JSON dump** so they're emitted once and never echoed into `decisions`/`focusNext`.
- **herd-digest / index** — `landingReadyEpics` (TTL-memoized ~5 min forge probe, mirrors `backlogPriority`'s warm-cache pattern) + cheap sync `hasOpenLandingEpics` (sweep pre-filter). `generate()` spawns for a ready epic even with an empty herd, but returns `"empty"` for an open-but-**not**-ready one (no all-clear spawn for nothing). `reconcileEpics()` keeps today's `ready` row live as readiness flips intraday — in place, no re-spawn, no LLM.
- **store** — persist `epicsToLand` (column + additive migration + hydrate).
- **ui** — `RundownPanel` epics-to-land section (renders in `generating`/`ready`/`failed`; `allQuiet` gated on `epicsToLand`); `IntegratedEpicsBand`/`Row` auto-expand + scroll/open + highlight the targeted row on deep-link. Item renderers extracted into Svelte snippets (keeps template complexity + duplication down).

## Deliberate deviation (flagged per house rules)

The issue suggested **extending the parse/clamp path** so the LLM carries the epics. Instead, epics are **deterministically server-injected** and `parseRundownVerdict` is untouched — a Tier-1 landing escalation must not depend on LLM fidelity (it could drop or hallucinate the item). Noted in a code comment on `epicsToLand` and here.

## Behavior change

An idle/empty herd with a landing-ready epic now triggers one daily digest spawn (the intent). Bounded to ≤1/day by the existing once-per-dayKey ready-row guard; forge probes bounded by the TTL memo. A truly empty herd (no sessions, no ready epics) still returns `"empty"` — no "nothing to triage" regression.

## Tests / gates

- Root: `bun run lint`, `bun test` (4673 pass) — unit tests for `enrichLandingEpics`, rundown-core epic flow + dump-strip + cap, store round-trip + migration, and herd-digest (epic-only spawn, open-not-ready → empty, regenerate-empty, finalize carry-through, `reconcileEpics` flip/no-op/shrink/stale-day).
- UI: `bun run check` (0 errors), `bun test` (2020 pass) — `RundownPanel` browser tests (section render across states, deep-link callback, allQuiet gating) + band focus/scroll.
- `check:i18n` (EN+DE parity), `check-feature-catalog` (entry added), `check-glossary`, branch-hygiene, `fallow audit` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)