### PR TITLE
feat(epic): opt-in auto-land of integrated epics (#1044)

### DIFF
--- a/src/drain.ts
+++ b/src/drain.ts
@@ -1,5 +1,5 @@
 import type { SessionStore } from "./store";
-import type { GitForge, GitState, Issue, SubIssueRef } from "./forge/types";
+import type { GitForge, GitState, Issue, PrStatus, SubIssueRef } from "./forge/types";
 import type { CreateSessionInput, Session } from "./types";
 import type { UsageLimits } from "./usage-limits";
 import { settleMergedSession } from "./merge-teardown";
@@ -22,6 +22,7 @@ import { selectEpicCandidates, type Epic, type EpicRun } from "./epic-core";
 import { detectMigrationPaths } from "./epic-migrations";
 import {
   buildRollup,
+  computeLandingReady,
   type CompletedEpic,
   type CompletedEpicChild,
   type EpicLandingState,
@@ -58,6 +59,14 @@ const EPIC_BASE_RECHECK_TTL_MS = 60_000;
  *  still surfaced on the band, but excluded from the retry set so it makes no further
  *  forge calls. Bounds the cost of a permanently-broken landing (no perpetual retry). */
 const MAX_LANDING_ATTEMPTS = 5;
+
+/** Auto-land merge-error guardrails (#1044) — mirror AutoMergeService's per-head cap + backoff.
+ *  After this many consecutive merge failures on the SAME landing-PR head, back the epic off so it
+ *  stops re-firing forge.merge each tick; one retry per backoff window thereafter. In-memory only
+ *  (a merge failure is NOT persisted on the row — `landingAttempts`/`error` track the OPEN action,
+ *  not the merge — so the manual CTA and the next eligible tick can still retry). */
+const LAND_MERGE_ERROR_CAP = 3;
+const LAND_MERGE_BACKOFF_MS = 300_000;
 import { drainSpawnModel, resolveDefaultModelSetting } from "./default-model";
 import {
   resolveProfile,
@@ -115,6 +124,7 @@ export interface DrainDeps {
     | "getEpicRun"
     | "setEpicRun"
     | "getOrInitEpicIntegrationBranch"
+    | "getEpicIntegrationBranch"
     | "listEpicIntegrated"
     | "isEpicIntegratedChild"
     | "recordEpicIntegrated"
@@ -187,6 +197,10 @@ export class DrainService {
   // same landingAttempts → lose an increment. This set makes the second invocation a
   // no-op; it'll be retried next tick anyway.
   private landingInFlight = new Set<string>();
+  // Auto-land (#1044) per-epic merge-error backoff, keyed `${repoPath}#${parentIssueNumber}`:
+  // consecutive merge failures on the current landing-PR head + when the epic is blocked until.
+  // A new head or a success clears the entry. In-memory (ephemeral); mirrors AutoMergeService.
+  private landMergeFail = new Map<string, { head: string; count: number; blockedUntil: number }>();
   // sessionIds whose claim label onArchived must NOT release. Populated in doRetire
   // (a ready PR stays open → keep the claim so no instance re-spawns it; the human
   // merge auto-closes the issue, retiring the claim) and in onGit ONLY for a merge
@@ -898,6 +912,184 @@ export class DrainService {
   }
 
   /**
+   * AUTO-LAND (#1044): opt-in autonomous merge of a completed epic's aggregate landing PR. Runs in
+   * {@link tick} alongside {@link ensureLandingPrsForRepo} — the session-less landing PR has no
+   * managed session, so it can't ride the session-owned `AutoMergeService`; the drain (which
+   * already OPENS these PRs) is its home. Mirrors the manual land endpoint's action
+   * (`forge.merge` + landingState→'merged') and AutoMergeService's guardrails, scoped to landing PRs.
+   *
+   * Opt-in gate: `draftMode ? false : autoMergeEnabled` — the SAME effective merge predicate the
+   * session train uses (isFullAuto's merge half), so draftMode suppresses auto-land too.
+   *
+   * DELIBERATE BROADENING vs isFullAuto (#1044): the gate intentionally does NOT also require
+   * autopilot. A landing PR is session-less, so autopilot (a session-stepping flag) is orthogonal;
+   * `autoMergeEnabled` is the operator's "automate my merges" opt-in and the correct signal. A repo
+   * with autoMerge ON + autopilot OFF — which sees ZERO session auto-merges today (isFullAuto is
+   * false there) — WILL now begin auto-landing epic landing PRs. Intended; flagged in the PR body.
+   *
+   * DB-gated to zero forge calls in steady state: candidates are only `open` rows carrying a
+   * recorded landing PR, and only when the opt-in is on.
+   */
+  private async autoLandLandingPrsForRepo(repoPath: string): Promise<void> {
+    const cfg = this.deps.store.getRepoConfig(repoPath);
+    const mergeOn = cfg.draftMode ? false : cfg.autoMergeEnabled;
+    if (!mergeOn) return;
+    const forge = this.deps.resolveForge(repoPath);
+    if (!forge) return;
+    const open = this.deps.store
+      .listEpicCompleted(repoPath)
+      .filter((r) => r.landingState === "open" && r.landingPrNumber != null);
+    for (const r of open) {
+      // Migration-bearing epics are NEVER auto-landed — they require the operator's manual
+      // ack/land (#645 checkpoint). The predicate is just `migrationPaths.length > 0`:
+      // ackEpicMigrations also stamps dismissedAt, and listEpicCompleted filters dismissedAt IS
+      // NULL, so an acked row is already gone from this list — a `migrationsAckedAt == null`
+      // conjunct would be dead. Consequence: ack dismisses WITHOUT merging; such epics land only
+      // via the manual CTA.
+      if (r.migrationPaths.length > 0) continue;
+      // Serialize per (repo, parent) against an overlapping tick / ensureLandingPr edge (shared
+      // key namespace with ensureLandingPr — they act on disjoint landingStates of one epic).
+      const key = `${repoPath}#${r.parentIssueNumber}`;
+      if (this.landingInFlight.has(key)) continue;
+      this.landingInFlight.add(key);
+      try {
+        await this.tryAutoLandEpic(forge, repoPath, r.parentIssueNumber, r.landingPrNumber!);
+      } catch (err) {
+        // tryAutoLandEpic is fail-closed internally; defense-in-depth so one epic can't break tick.
+        console.warn(`[drain] auto-land failed for ${key}:`, err);
+      } finally {
+        this.landingInFlight.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Resolve + (maybe) merge ONE open landing PR. Fail-closed everywhere; never throws past the
+   * caller's guard:
+   *   - unpinned branch / prStatus throw → skip (never merge on an unreadable PR).
+   *   - PR merged out-of-band → reconcile row to 'merged' (covers a manual land / external merge,
+   *     and closes the manual-vs-auto DB-staleness window).
+   *   - PR closed/none → reconcile to terminal 'none' (human-closed/vanished) so we stop re-polling.
+   *   - draft / not-ready / backed-off → skip.
+   *   - ready → forge.merge; success → reconcile 'merged' + clear backoff; failure → see
+   *     {@link handleAutoLandMergeError} (lost race reconciles; genuine failure arms the backoff).
+   */
+  private async tryAutoLandEpic(
+    forge: GitForge,
+    repoPath: string,
+    parentIssueNumber: number,
+    prNumber: number,
+  ): Promise<void> {
+    // Read-only branch read (NOT getOrInitEpicIntegrationBranch — never INSERT a title-drifted pin
+    // from this path). Matches the manual land endpoint + band enrichment. Null ⇒ unpinned ⇒ skip.
+    const branch = this.deps.store.getEpicIntegrationBranch(repoPath, parentIssueNumber);
+    if (branch === null) return;
+    let pr: PrStatus;
+    try {
+      pr = await forge.prStatus(branch);
+    } catch (err) {
+      console.warn(`[drain] auto-land prStatus failed for ${repoPath}#${parentIssueNumber}:`, err);
+      return; // fail-closed
+    }
+    if (pr.state === "merged") {
+      this.reconcileAutoLand(repoPath, parentIssueNumber, "merged", pr);
+      return;
+    }
+    if (pr.state === "closed" || pr.state === "none") {
+      this.reconcileAutoLand(repoPath, parentIssueNumber, "none", pr);
+      return;
+    }
+    if (pr.isDraft) return; // never merge a draft (computeLandingReady's Gitea fallback can't tell)
+    if (!computeLandingReady(pr)) return; // not green / mergeable yet
+    const key = `${repoPath}#${parentIssueNumber}`;
+    if (this.landMergeBlocked(key, pr.headSha ?? "")) return; // backed off on this head
+    try {
+      await forge.merge(prNumber, { method: forge.mergeMethod, deleteBranch: true });
+    } catch (err) {
+      await this.handleAutoLandMergeError(forge, repoPath, parentIssueNumber, branch, key, pr, err);
+      return;
+    }
+    this.landMergeFail.delete(key); // success clears any backoff
+    this.reconcileAutoLand(repoPath, parentIssueNumber, "merged", pr);
+  }
+
+  /**
+   * A failed auto-land merge. Re-read live state ONCE (forge-agnostic — doesn't parse host-specific
+   * error strings): a PR that is now merged/closed means a concurrent manual land (the server's
+   * handleEpicsCompletedLand takes no shared lock with this loop) won the race — reconcile WITHOUT
+   * arming the backoff (a lost race must not poison the cap). A still-open/unreadable PR is a
+   * genuine failure → leave landingState 'open' (manual CTA + next tick can retry) and arm the
+   * per-head backoff.
+   */
+  private async handleAutoLandMergeError(
+    forge: GitForge,
+    repoPath: string,
+    parentIssueNumber: number,
+    branch: string,
+    key: string,
+    pr: PrStatus,
+    err: unknown,
+  ): Promise<void> {
+    let live: PrStatus | null;
+    try {
+      live = await forge.prStatus(branch);
+    } catch {
+      live = null;
+    }
+    if (live && live.state === "merged") {
+      this.landMergeFail.delete(key);
+      this.reconcileAutoLand(repoPath, parentIssueNumber, "merged", live);
+      return;
+    }
+    if (live && (live.state === "closed" || live.state === "none")) {
+      this.landMergeFail.delete(key);
+      this.reconcileAutoLand(repoPath, parentIssueNumber, "none", live);
+      return;
+    }
+    console.warn(`[drain] auto-land merge failed for ${key}:`, err);
+    this.recordLandMergeFailure(key, pr.headSha ?? "");
+  }
+
+  /** Persist a reconciled landing state + re-emit the band's CompletedEpic (reuses resolveLanding).
+   *  'merged' keeps the live/recorded PR number+url; terminal 'none' nulls them (mirrors
+   *  classifyLanding's human-closed branch). */
+  private reconcileAutoLand(
+    repoPath: string,
+    parentIssueNumber: number,
+    state: EpicLandingState,
+    pr: PrStatus,
+  ): void {
+    const row = this.deps.store
+      .listEpicCompleted(repoPath)
+      .find((r) => r.parentIssueNumber === parentIssueNumber);
+    this.resolveLanding(repoPath, parentIssueNumber, {
+      state,
+      prNumber: state === "merged" ? (pr.number ?? row?.landingPrNumber ?? null) : null,
+      prUrl: state === "merged" ? (pr.url ?? row?.landingPrUrl ?? null) : null,
+      attempts: row?.landingAttempts ?? 0,
+    });
+  }
+
+  /** True while this epic's auto-land is backed off: CAP failures on the current head, inside the
+   *  window. A new head or a success clears the entry. Mirrors AutoMergeService.computeMergeBlocked. */
+  private landMergeBlocked(key: string, head: string): boolean {
+    const f = this.landMergeFail.get(key);
+    return !!f && f.head === head && f.count >= LAND_MERGE_ERROR_CAP && this.now() < f.blockedUntil;
+  }
+
+  /** Record a merge failure against the current head; arm the backoff window at the cap. Mirrors
+   *  AutoMergeService.recordMergeFailure. */
+  private recordLandMergeFailure(key: string, head: string): void {
+    const cur = this.landMergeFail.get(key);
+    const count = cur && cur.head === head ? cur.count + 1 : 1;
+    this.landMergeFail.set(key, {
+      head,
+      count,
+      blockedUntil: count >= LAND_MERGE_ERROR_CAP ? this.now() + LAND_MERGE_BACKOFF_MS : 0,
+    });
+  }
+
+  /**
    * Execute one step of the drain loop: build state, run epic side-effects,
    * compute the next decision, emit status, then apply the decision.
    * Returns false when the loop should break (hold or error), true to continue.
@@ -1421,6 +1613,9 @@ export class DrainService {
       // epic's PR is opened/retried even in a repo with autoDrain off and no running epic.
       // DB-gated internally → zero forge calls in steady state.
       await this.ensureLandingPrsForRepo(repoPath);
+      // #1044: opt-in auto-land of open landing PRs (gated internally on the repo's auto-merge
+      // opt-in → zero forge calls when off). UNGATED by drain, like ensureLandingPrsForRepo.
+      await this.autoLandLandingPrsForRepo(repoPath);
       const cfg = this.deps.store.getRepoConfig(repoPath);
       const er = this.deps.store.getEpicRun(repoPath);
       if (cfg.autoDrainEnabled || er?.status === "running") await this.pump(repoPath);

--- a/test/drain-epic-autoland.test.ts
+++ b/test/drain-epic-autoland.test.ts
@@ -1,0 +1,419 @@
+import { test, expect, describe } from "bun:test";
+import { DrainService } from "../src/drain";
+import { SessionStore } from "../src/store";
+import type { GitForge, Issue, MergeInput, PrStatus, SubIssueRef } from "../src/forge/types";
+import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
+import type { CompletedEpic } from "../src/completed-epic";
+import { epicIntegrationBranch } from "../src/epic-branch";
+
+const REPO = "/repo";
+const PARENT = 327;
+const PARENT_TITLE = "EFI cluster";
+const INTEGRATION_BRANCH = epicIntegrationBranch(PARENT, PARENT_TITLE); // epic/327-efi-cluster
+const LANDING_PR = 555;
+
+const NO_USAGE: UsageLimitsType = {
+  session5h: null,
+  week: null,
+  credits: null,
+  stale: false,
+  calibratedAt: null,
+  subscriptionOnly: false,
+};
+
+/** A ready-to-merge landing PR (clean GitHub mergeStateStatus). Override fields per test. */
+function readyPr(over: Partial<PrStatus> = {}): PrStatus {
+  return {
+    state: "open",
+    number: LANDING_PR,
+    url: `https://github.com/o/r/pull/${LANDING_PR}`,
+    checks: "success",
+    mergeable: true,
+    mergeStateStatus: "clean",
+    headSha: "deadbeef",
+    isDraft: false,
+    deployConfigured: false,
+    ...over,
+  };
+}
+
+interface MergeCall {
+  prNumber: number;
+  method: string;
+  deleteBranch: boolean | undefined;
+}
+
+interface ForgeSpy {
+  forge: GitForge;
+  mergeCalls: MergeCall[];
+  prStatusCalls: string[];
+}
+
+function fakeForge(opts: {
+  prStatus?: (head: string) => Promise<PrStatus>;
+  merge?: (prNumber: number, o: MergeInput) => Promise<void>;
+}): ForgeSpy {
+  const mergeCalls: MergeCall[] = [];
+  const prStatusCalls: string[] = [];
+  const forge: GitForge = {
+    kind: "github",
+    slug: "o/r",
+    mergeMethod: "squash",
+    deployWorkflow: null,
+    listIssues: async () => [],
+    listPullRequests: async () => [],
+    prStatus: async (head: string) => {
+      prStatusCalls.push(head);
+      return (
+        (await opts.prStatus?.(head)) ??
+        ({ state: "none", checks: "none", deployConfigured: false } as PrStatus)
+      );
+    },
+    openPr: async () => ({ state: "open", checks: "none", deployConfigured: false }) as PrStatus,
+    defaultBranch: async () => "main",
+    merge: async (prNumber: number, o: MergeInput) => {
+      mergeCalls.push({ prNumber, method: o.method, deleteBranch: o.deleteBranch });
+      await opts.merge?.(prNumber, o);
+    },
+    redeploy: async () => {},
+    postReview: async () => ({}),
+    closeIssue: async () => {},
+    ensureIssueLink: async () => {},
+    addIssueLabel: async () => {},
+    removeIssueLabel: async () => {},
+    getIssue: async (): Promise<Issue | null> => null,
+    listSubIssues: async (): Promise<SubIssueRef[]> => [],
+    listBlockedBy: async () => [],
+  };
+  return { forge, mergeCalls, prStatusCalls };
+}
+
+interface Harness {
+  store: SessionStore;
+  drain: DrainService;
+  completedEmits: CompletedEpic[];
+  spy: ForgeSpy;
+  setNow: (ms: number) => void;
+}
+
+function makeHarness(opts: {
+  autoMergeEnabled?: boolean;
+  draftMode?: boolean;
+  prStatus?: (head: string) => Promise<PrStatus>;
+  merge?: (prNumber: number, o: MergeInput) => Promise<void>;
+  /** Skip pinning the integration branch (models an unpinned row). */
+  noPin?: boolean;
+}): Harness {
+  const store = new SessionStore(":memory:");
+  store.setRepoConfig(REPO, {
+    criticEnabled: true,
+    criticAllPrs: false,
+    autoAddressEnabled: false,
+    learningsEnabled: true,
+    autopilotEnabled: false,
+    planGateEnabled: false,
+    autoDrainEnabled: false, // keep pump() gated off → tick() exercises only landing logic
+    autoMergeEnabled: opts.autoMergeEnabled ?? false,
+    buildQueueEnabled: false,
+    draftMode: opts.draftMode ?? false,
+    signoffAuthority: "human",
+    maxAuto: 2,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+    sandboxProfile: "trusted",
+    defaultModel: "inherit",
+    egressExtraHosts: [],
+    repoMode: "forge",
+    autoOptimizeFlagged: false,
+  });
+
+  const spy = fakeForge(opts);
+  const completedEmits: CompletedEpic[] = [];
+  let nowMs = 1_000;
+
+  const drain = new DrainService({
+    store,
+    service: {
+      create: async () => {
+        throw new Error("not used");
+      },
+      archive: () => 1,
+    } as never,
+    resolveForge: () => spy.forge,
+    prCache: { snapshot: () => ({}) },
+    usage: { limits: (): UsageLimitsType => NO_USAGE },
+    repos: () => [REPO],
+    emitStatus: () => {},
+    emitArchived: () => {},
+    dropPrCache: () => {},
+    emitEpic: () => {},
+    emitEpicCompleted: (e) => completedEmits.push(e),
+    now: () => nowMs,
+  });
+
+  return { store, drain, completedEmits, spy, setNow: (ms) => (nowMs = ms) };
+}
+
+/** Seed an epic_completed row already in landingState='open' with a pinned integration branch. */
+function seedOpenLanding(h: Harness, opts: { migrations?: string[]; pin?: boolean } = {}): void {
+  h.store.recordEpicIntegrated(REPO, PARENT, 320, {
+    number: 9320,
+    url: "https://github.com/o/r/pull/9320",
+  });
+  h.store.recordEpicCompleted({
+    repoPath: REPO,
+    parentIssueNumber: PARENT,
+    parentTitle: PARENT_TITLE,
+    completedAt: 1,
+    childrenJson: JSON.stringify([
+      {
+        number: 320,
+        title: "child 320",
+        url: "https://x/320",
+        prNumber: 9320,
+        prUrl: "https://github.com/o/r/pull/9320",
+        mergedAt: 1,
+        integrated: true,
+      },
+    ]),
+  });
+  if (opts.pin !== false) {
+    // Pin the integration branch (getEpicIntegrationBranch returns null until pinned).
+    h.store.getOrInitEpicIntegrationBranch(REPO, PARENT, INTEGRATION_BRANCH);
+  }
+  h.store.setEpicLandingPr(REPO, PARENT, {
+    state: "open",
+    prNumber: LANDING_PR,
+    prUrl: `https://github.com/o/r/pull/${LANDING_PR}`,
+    attempts: 0,
+  });
+  if (opts.migrations && opts.migrations.length > 0) {
+    h.store.setEpicMigrationPaths(REPO, PARENT, opts.migrations);
+  }
+}
+
+const row = (h: Harness) => h.store.listEpicCompleted(REPO)[0]!;
+
+describe("auto-land of integrated epics (#1044)", () => {
+  test("autoMergeEnabled OFF → ready landing PR is NOT merged", async () => {
+    const h = makeHarness({ autoMergeEnabled: false, prStatus: async () => readyPr() });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.mergeCalls).toHaveLength(0);
+    expect(row(h).landingState).toBe("open");
+  });
+
+  test("autoMergeEnabled ON + draftMode ON → suppressed (no merge)", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      draftMode: true,
+      prStatus: async () => readyPr(),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.mergeCalls).toHaveLength(0);
+    expect(row(h).landingState).toBe("open");
+  });
+
+  test("autoMerge ON, ready, no migrations → merge via host method + row merged + emit", async () => {
+    const h = makeHarness({ autoMergeEnabled: true, prStatus: async () => readyPr() });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.mergeCalls).toHaveLength(1);
+    expect(h.spy.mergeCalls[0]).toEqual({
+      prNumber: LANDING_PR,
+      method: "squash",
+      deleteBranch: true,
+    });
+    expect(row(h).landingState).toBe("merged");
+    expect(h.completedEmits.at(-1)!.landingState).toBe("merged");
+  });
+
+  test("migrationPaths non-empty → epic is NEVER auto-landed (manual CTA only)", async () => {
+    const h = makeHarness({ autoMergeEnabled: true, prStatus: async () => readyPr() });
+    seedOpenLanding(h, { migrations: ["server/migrations/001.sql"] });
+
+    await h.drain.tick();
+
+    expect(h.spy.mergeCalls).toHaveLength(0);
+    expect(h.spy.prStatusCalls).toHaveLength(0); // short-circuited before any forge call
+    expect(row(h).landingState).toBe("open");
+  });
+
+  test("not ready (checks pending) → no merge, row stays open", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => readyPr({ checks: "pending" }),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.mergeCalls).toHaveLength(0);
+    expect(row(h).landingState).toBe("open");
+  });
+
+  test("blocked mergeStateStatus → no merge (computeLandingReady false)", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => readyPr({ mergeStateStatus: "blocked" }),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.mergeCalls).toHaveLength(0);
+    expect(row(h).landingState).toBe("open");
+  });
+
+  test("draft landing PR → no merge (explicit guard)", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      // Gitea-style: undefined mergeStateStatus would pass computeLandingReady; the isDraft
+      // guard must still block it.
+      prStatus: async () => readyPr({ isDraft: true, mergeStateStatus: undefined }),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.mergeCalls).toHaveLength(0);
+    expect(row(h).landingState).toBe("open");
+  });
+
+  test("prStatus throws → fail-closed (no merge), row stays open", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => {
+        throw new Error("forge down");
+      },
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.mergeCalls).toHaveLength(0);
+    expect(row(h).landingState).toBe("open");
+  });
+
+  test("unpinned integration branch → skip cleanly, no forge call", async () => {
+    const h = makeHarness({ autoMergeEnabled: true, prStatus: async () => readyPr() });
+    seedOpenLanding(h, { pin: false });
+
+    await h.drain.tick();
+
+    expect(h.spy.prStatusCalls).toHaveLength(0);
+    expect(h.spy.mergeCalls).toHaveLength(0);
+    expect(row(h).landingState).toBe("open");
+  });
+
+  test("prStatus reports merged on an open row → reconcile to merged, no merge call", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => readyPr({ state: "merged" }),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.mergeCalls).toHaveLength(0);
+    expect(row(h).landingState).toBe("merged");
+    expect(h.completedEmits.at(-1)!.landingState).toBe("merged");
+  });
+
+  test("prStatus reports closed on an open row → reconcile to none, not re-polled next tick", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => readyPr({ state: "closed" }),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+    expect(h.spy.mergeCalls).toHaveLength(0);
+    expect(row(h).landingState).toBe("none");
+    const pollsAfterFirst = h.spy.prStatusCalls.length;
+
+    // Second tick: row is terminal 'none' → never a candidate → no further prStatus.
+    await h.drain.tick();
+    expect(h.spy.prStatusCalls.length).toBe(pollsAfterFirst);
+  });
+
+  test("merge throws (real failure) → row stays open; per-head cap backs off; new head clears", async () => {
+    // console.warn expected on each merge failure.
+    let head = "head-A";
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => readyPr({ headSha: head }),
+      merge: async () => {
+        throw new Error("merge 500");
+      },
+    });
+    seedOpenLanding(h);
+
+    // 3 failing ticks → at the cap, backed off.
+    for (let i = 0; i < 3; i++) await h.drain.tick();
+    expect(h.spy.mergeCalls.length).toBe(3);
+    expect(row(h).landingState).toBe("open");
+
+    // 4th tick within the backoff window on the SAME head → no new merge attempt.
+    await h.drain.tick();
+    expect(h.spy.mergeCalls.length).toBe(3);
+
+    // A NEW head clears the backoff → merge is attempted again.
+    head = "head-B";
+    await h.drain.tick();
+    expect(h.spy.mergeCalls.length).toBe(4);
+  });
+
+  test("backoff window expiry → retry allowed after the window elapses", async () => {
+    // console.warn expected on each merge failure.
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => readyPr(),
+      merge: async () => {
+        throw new Error("merge 500");
+      },
+    });
+    seedOpenLanding(h);
+
+    for (let i = 0; i < 3; i++) await h.drain.tick();
+    expect(h.spy.mergeCalls.length).toBe(3);
+
+    await h.drain.tick(); // still inside window → suppressed
+    expect(h.spy.mergeCalls.length).toBe(3);
+
+    h.setNow(1_000 + 600_000); // advance past the 300s backoff window
+    await h.drain.tick();
+    expect(h.spy.mergeCalls.length).toBe(4);
+  });
+
+  test("already-merged merge error → reconciled to merged, NOT counted as a failure", async () => {
+    // The lost manual-vs-auto race: the ready-check sees the PR open, but by the time forge.merge
+    // fires a concurrent manual land already merged it → merge rejects, and a re-read now reports
+    // merged. The failure path must reconcile (→ merged), never arm the backoff.
+    let reads = 0;
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => {
+        reads++;
+        return reads === 1 ? readyPr() : readyPr({ state: "merged" });
+      },
+      merge: async () => {
+        throw new Error("Pull request is not mergeable: already merged");
+      },
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.mergeCalls).toHaveLength(1); // we did attempt the merge
+    expect(row(h).landingState).toBe("merged"); // …but reconciled to merged, not error/open
+    expect(h.completedEmits.at(-1)!.landingState).toBe("merged");
+  });
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1873,5 +1873,7 @@
   "integrated_epics_land_failed": "Epic konnte nicht gelandet werden — erneut versuchen",
   "feat_land_epic_title": "Integrierte Epics direkt in der App landen",
   "feat_land_epic_body": "Wenn der Landing-PR eines Epics offen ist und alle Checks bestanden haben, ermöglicht ein neuer 'Epic landen'-Button im Band der integrierten Epics das Mergen mit einem Klick — kein Wechsel zu GitHub nötig.",
+  "feat_epic_auto_land_title": "Integrierte Epics automatisch landen",
+  "feat_epic_auto_land_body": "Wenn Auto-Merge für ein Repo aktiviert ist, wird der Landing-PR eines integrierten Epics jetzt automatisch gemergt, sobald er sauber ist und alle Checks bestanden haben — dieselbe Opt-in-Einstellung, die auch deine Voll-Auto-Sessions landet. Epics mit Migrationen werden für die manuelle Prüfung zurückgehalten, und der 'Epic landen'-Button funktioniert weiterhin jederzeit.",
   "landed_epic_toast": "Epic #{number} gelandet — in den Standardbranch gemergt"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1873,5 +1873,7 @@
   "integrated_epics_land_failed": "Couldn't land the epic — try again",
   "feat_land_epic_title": "Land integrated epics from the app",
   "feat_land_epic_body": "When an epic's landing PR is open and all checks pass, a new 'Land epic' button in the Integrated-epics band lets you merge it with one click — no need to switch to GitHub.",
+  "feat_epic_auto_land_title": "Auto-land integrated epics",
+  "feat_epic_auto_land_body": "With auto-merge enabled for a repo, an integrated epic's landing PR now merges automatically once it's clean and all checks pass — the same opt-in that lands your full-auto sessions. Epics that touch migrations are held for manual review, and the 'Land epic' button still works any time.",
   "landed_epic_toast": "Epic #{number} landed — merged to the default branch"
 }

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1497,4 +1497,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_land_epic_title",
     bodyKey: "feat_land_epic_body",
   },
+  {
+    // With auto-merge enabled, an integrated epic's landing PR now lands automatically once it's
+    // CLEAN + CI-green (the manual "Land epic" CTA still works). Migration-bearing epics are held
+    // for manual review. No targetId — server-driven behavior with no persistent anchor; surface
+    // via the What's-New drawer only. v1.36.0 → ships in 1.37.0.
+    id: "epic-auto-land",
+    sinceVersion: "1.37.0",
+    titleKey: "feat_epic_auto_land_title",
+    bodyKey: "feat_epic_auto_land_body",
+  },
 ];


### PR DESCRIPTION
Closes #1044. The **auto-land** half of #1039's Rec B (which shipped manual surfacing + Rec D reconcile).

## What
When a repo has **auto-merge enabled**, the drain now automatically merges an epic's aggregate **landing PR** once it is CLEAN + CI-green + mergeable — mirroring the full-auto-merge guardrails, scoped to session-less landing PRs. Default off (autonomous merge is opt-in per house rules).

A landing PR has no managed session (epic children are archived), so it can't ride the session-owned `AutoMergeService`. It lives in `DrainService`, which already *opens* these PRs ungated in `tick()` (`ensureLandingPrsForRepo`) — the natural home for the rest of their lifecycle. Reuses the #1039 `computeLandingReady` predicate and the manual land endpoint's action (`forge.merge` + `landingState→'merged'`).

## Decisions (resolved in planning + adversarial plan review)
- **Gate on the existing `autoMergeEnabled`** — no new flag. Effective predicate `draftMode ? false : autoMergeEnabled` (isFullAuto's merge half), so **draftMode suppresses** auto-land.
- **⚠️ Deliberate broadening vs `isFullAuto`:** the gate intentionally does **not** also require autopilot. A landing PR is session-less, so autopilot (a session-stepping flag) is orthogonal; `autoMergeEnabled` is the operator's "automate my merges" opt-in and the correct signal. **Consequence:** a repo with `autoMergeEnabled=true` + `autopilotEnabled=false` — which sees *zero* session auto-merges today (`isFullAuto` is false there) — **will** now begin auto-landing epic landing PRs. This is intended; the one-line conservative alternative is to also require `cfg.autopilotEnabled`.
- **Migration-bearing epics are NEVER auto-landed** — held for the operator's manual ack/land (#645 checkpoint). Skip predicate is just `migrationPaths.length > 0`: `ackEpicMigrations` also stamps `dismissedAt` and `listEpicCompleted` filters `dismissedAt IS NULL`, so an acked row is already gone (a `migrationsAckedAt == null` conjunct would be dead). **Ack dismisses without merging.**

## Guardrails (mirror AutoMergeService)
- **Fail-closed:** skip on unpinned integration branch, `prStatus` throw, draft PR, or not-ready.
- **Reconcile a stale `open` row:** PR merged out-of-band → `merged` (covers manual land / external merge); closed/none → terminal `none` (stop re-polling a dead PR).
- **Per-head merge-error cap (3) + 300s backoff** (in-memory; the persisted `landingAttempts` tracks the *open* action, not merge). A failed merge re-reads live state once (forge-agnostic) — a lost manual-vs-auto-land race (PR now merged/closed) **reconciles without arming the backoff**, so it can't poison the cap.
- Read-only `getEpicIntegrationBranch` (never INSERTs a title-drifted pin from this path).

## Scope / notes
- **No DB schema change.**
- One `DrainDeps` store-`Pick<>` addition (`getEpicIntegrationBranch`).
- The manual "Land epic" CTA (#1039) still works for everything, including migration-bearing epics.

## Tests
`test/drain-epic-autoland.test.ts` (14 cases, TDD): opt-in off; draftMode suppression; ready→merge; migrations held; not-ready/blocked/draft skip; prStatus fail-closed; unpinned skip; merged/closed reconcile (+ no re-poll); per-head cap + backoff + window expiry + new-head clear; already-merged race → reconcile-not-failure.

Verification: root `tsc` clean, `lint` clean, full root suite `4667 pass / 0 fail`, `fallow audit` clean on changed files, i18n parity (1876 keys each), UI `check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)