### PR TITLE
feat(tui): make Shepherd compatible with Claude Code fullscreen renderer (opt-in)

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -46,6 +46,21 @@ lines), read by the systemd unit if present.
 
 See [Operating Shepherd](/operating/) for the host-level `/etc/fstab` belt.
 
+## Main agent terminal renderer (research preview)
+
+Every spawned `claude` runs on Claude Code's **classic** renderer by default —
+Shepherd's poller/blocked classifier scrape the rendered viewport and the web
+terminal forwards xterm keystrokes, both of which assume the classic prompt.
+The operator can opt the **main agent session** (satellites always stay classic)
+into Claude Code's opt-in fullscreen renderer. The choice applies to newly
+spawned/resumed sessions only and is also configurable from the Settings panel
+(persisted in the SQLite `settings` table); the env vars below seed a fresh DB.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SHEPHERD_TUI_FULLSCREEN` | `0` (off) | Set `1` to opt the main agent session into Claude Code's fullscreen renderer (research preview). Implies `SHEPHERD_TUI_DISABLE_MOUSE`. |
+| `SHEPHERD_TUI_DISABLE_MOUSE` | `0` (off) | Set `1` to disable Claude Code mouse capture for the main agent session, so fullscreen mouse-capture escape sequences don't leak into the web terminal's keystroke stream. |
+
 ## Documentation automation (PR-gated doc agent)
 
 Opt-in, default-off. When enabled, a manual trigger (`POST /api/doc-agent?repo=<path>`)

--- a/src/blocked.ts
+++ b/src/blocked.ts
@@ -19,8 +19,12 @@ export interface BlockReason {
 }
 
 const TAIL_LINES = 15;
-// Matches "1. Yes", "❯ 2. No", "│  3) Foo" — captures the digit and the label.
-const OPTION_RE = /^[\s│|]*[❯>*]?\s*(\d+)[.)]\s+(.*\S)\s*$/;
+// Matches "1. Yes", "❯ 2. No", "│  3) Foo", AND the fullscreen renderer's zero-space packing
+// of the long option ("2.Yes, allow all edits…"). Group 2 captures the delimiter spacing
+// (undefined when packed with no space); group 3 is the label. The zero-space form is gated
+// in classifyBlocked (see below) so a decimal ("2.5 GB") or a bare-token run ("1.tsx"/"2.x")
+// can't forge a menu.
+const OPTION_RE = /^[\s│|]*[❯>*]?\s*(\d+)[.)](\s+)?(\S.*?)\s*$/;
 const YES_NO_RE = /\(\s*y\s*\/\s*n\s*\)|\[\s*y\s*\/\s*n\s*\]/i;
 // eslint-disable-next-line no-control-regex
 const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]/g;
@@ -75,9 +79,15 @@ export function classifyBlocked(text: string): BlockReason {
   for (const line of tail) {
     const m = OPTION_RE.exec(line);
     if (!m) continue;
-    const n = Number(m[1]);
-    if (n === run.length + 1) run.push({ label: m[2]!, send: m[1]! });
-    else if (n === 1) run = [{ label: m[2]!, send: m[1]! }];
+    const [, num, spaced, label] = m;
+    // Fullscreen drops the delimiter space ONLY on the long, wrapping option
+    // ("2.Yes, allow all edits…"); short options keep theirs. Accept a zero-space option
+    // ONLY when its label is a non-digit-leading multi-token phrase, so a decimal
+    // ("2.5 GB" → "5 GB") or a bare-token run ("1.tsx"/"2.x"/"1.txt") can't forge a menu.
+    if (!spaced && (/^\d/.test(label!) || !/\s/.test(label!))) continue;
+    const n = Number(num);
+    if (n === run.length + 1) run.push({ label: label!, send: num! });
+    else if (n === 1) run = [{ label: label!, send: num! }];
   }
   if (run.length >= 2) return { shape: "menu", options: run, tail };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -433,6 +433,12 @@ export const config = {
   // stored session model (so cost accounting + fable intent survive for later replay).
   // Persisted + UI-configurable; SHEPHERD_FABLE_AVAILABLE=0/false seeds it off.
   fableAvailable: normalizeFableAvailable(process.env.SHEPHERD_FABLE_AVAILABLE) ?? true,
+  // Opt the main agent session into Claude Code's fullscreen renderer (research preview;
+  // applies to newly spawned/resumed sessions only). Persisted + UI-configurable; default off.
+  tuiFullscreen: process.env.SHEPHERD_TUI_FULLSCREEN === "1",
+  // Disable Claude Code mouse capture for the main agent session. Persisted + UI-configurable;
+  // default off. (tuiFullscreen also implies this — coupling lives in the spawn wiring, not here.)
+  tuiDisableMouse: process.env.SHEPHERD_TUI_DISABLE_MOUSE === "1",
   // Operator auth footing for spawned agents. 'subscription' (default) = subscription OAuth;
   // 'api-key' = bill against an Anthropic API key. Persisted + UI-configurable; env seeds a fresh DB.
   authMode: normalizeAuthModeSetting(process.env.SHEPHERD_AUTH_MODE) ?? "subscription",

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -360,23 +360,24 @@ export class HerdrDriver {
             .sort(([a], [b]) => a.localeCompare(b))
             .map(([k, v]) => `${k}=${v}`)
         : [];
-      // Pin the CLASSIC renderer for every spawned claude. Claude Code's opt-in fullscreen
-      // renderer (v2.1.89+) draws on the terminal's ALTERNATE screen buffer and captures the
-      // mouse — Shepherd's whole integration assumes the classic renderer: the poller/blocked
-      // classifier scrape the rendered viewport (`agent read --source visible`) with a layout
-      // tuned to the classic prompt, and the web terminal forwards xterm keystrokes (mouse
-      // capture would inject click/scroll escape sequences into claude's input). Fullscreen
-      // turns on via a persisted `tui` setting or ambient CLAUDE_CODE_NO_FLICKER, either of
-      // which a spawned agent would inherit from the operator's global config/env — and the
-      // docs warn the default may flip. CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1 forces the
-      // classic renderer regardless of the saved setting or NO_FLICKER, immunizing us against
-      // both. (Shepherd attaches via `herdr agent attach`, not `claude attach`, so the docs'
-      // "background sessions always use fullscreen" carve-out — which ignores this var — does
-      // not apply to our foreground spawns.)
+      // Pin the CLASSIC renderer for every spawned claude UNLESS the caller already specified a
+      // renderer choice in `env`. The main-session spawn (prepareSpawn) computes its own renderer
+      // env — classic pin by default, or CLAUDE_CODE_NO_FLICKER when the operator opted into the
+      // fullscreen research preview (tuiFullscreen) — and routes it through BOTH the membrane
+      // --setenv and this shim, so re-adding the pin here would duplicate it (and `env`'s last-wins
+      // would let the pin override an intended NO_FLICKER). Satellites pass no renderer var and keep
+      // the classic pin exactly as before.
+      // Claude Code's opt-in fullscreen renderer (v2.1.89+) draws on the terminal's ALTERNATE
+      // screen buffer and captures the mouse — Shepherd's integration assumes the classic renderer
+      // (poller/blocked classifier scrape `agent read --source visible`; the web terminal forwards
+      // xterm keystrokes). (Shepherd attaches via `herdr agent attach`, not `claude attach`, so the
+      // docs' "background sessions always use fullscreen" carve-out does not apply.)
+      const callerSetRenderer =
+        !!env && ("CLAUDE_CODE_NO_FLICKER" in env || "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN" in env);
       const wrapped = [
         "env",
         `NODE_COMPILE_CACHE=${compileCacheDir()}`,
-        "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1",
+        ...(callerSetRenderer ? [] : ["CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1"]),
         ...envTokens,
         ...argv,
       ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,6 +173,12 @@ if (savedFa !== null) {
   const v = normalizeFableAvailable(savedFa);
   if (v !== null) config.fableAvailable = v;
 }
+// a UI-chosen fullscreen-renderer opt-in (persisted) overrides the env default; absent → keep
+// the config default (off). Stored as "1"/"0".
+const savedTuiFs = store.getSetting("tuiFullscreen");
+if (savedTuiFs !== null) config.tuiFullscreen = savedTuiFs === "1";
+const savedTuiMouse = store.getSetting("tuiDisableMouse");
+if (savedTuiMouse !== null) config.tuiDisableMouse = savedTuiMouse === "1";
 // a UI-chosen auth mode (persisted) overrides the env seed; absent or unrecognised → keep default.
 const savedAm = store.getSetting("authMode");
 if (savedAm !== null) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -2943,6 +2943,9 @@ async function handleSettings({ req, parts, deps }: Ctx): Promise<Response | nul
       usageHoldPct: config.usageHoldPct,
       // global fable availability flag; false = fable spawns reroute to opus[1m].
       fableAvailable: config.fableAvailable,
+      // TUI renderer opt-in (research preview) + mouse-capture disable; apply to new/resumed sessions.
+      tuiFullscreen: config.tuiFullscreen,
+      tuiDisableMouse: config.tuiDisableMouse,
       // doc-agent soak flags (read-only; env-driven; no PUT patch).
       docAgentEnabled: config.docAgentEnabled,
       docAgentAct: config.docAgentAct,
@@ -2977,6 +2980,8 @@ const SETTING_PATCHES: [string, (value: unknown, deps: Ctx["deps"]) => Response]
   ["usageHoldEnabled", putUsageHoldEnabled],
   ["usageHoldPct", putUsageHoldPct],
   ["fableAvailable", putFableAvailable],
+  ["tuiFullscreen", putTuiFullscreen],
+  ["tuiDisableMouse", putTuiDisableMouse],
 ];
 
 function putRemoteControl(value: unknown, deps: Ctx["deps"]): Response {
@@ -3106,6 +3111,24 @@ function putFableAvailable(value: unknown, deps: Ctx["deps"]): Response {
   config.fableAvailable = v; // live: next spawn picks it up
   deps.store.setSetting("fableAvailable", String(v)); // persist across restarts
   return json({ fableAvailable: config.fableAvailable });
+}
+
+function putTuiFullscreen(value: unknown, deps: Ctx["deps"]): Response {
+  if (typeof value !== "boolean") {
+    return json({ error: "tuiFullscreen must be a boolean" }, 400);
+  }
+  config.tuiFullscreen = value; // live: next spawn/resume picks it up (renderer is fixed at process start)
+  deps.store.setSetting("tuiFullscreen", value ? "1" : "0"); // persist
+  return json({ tuiFullscreen: config.tuiFullscreen });
+}
+
+function putTuiDisableMouse(value: unknown, deps: Ctx["deps"]): Response {
+  if (typeof value !== "boolean") {
+    return json({ error: "tuiDisableMouse must be a boolean" }, 400);
+  }
+  config.tuiDisableMouse = value; // live: next spawn/resume picks it up
+  deps.store.setSetting("tuiDisableMouse", value ? "1" : "0"); // persist
+  return json({ tuiDisableMouse: config.tuiDisableMouse });
 }
 
 function putRepoRoot(value: unknown, deps: Ctx["deps"]): Response {

--- a/src/service.ts
+++ b/src/service.ts
@@ -845,12 +845,6 @@ function pickOverride<T>(override: T | undefined, original: T): T {
   return override !== undefined ? override : original;
 }
 
-/**
- * A freshly-created session is pre-approved into the build queue only when the repo runs the
- * build queue AND the session is effectively on autopilot (so no human approval gate will ever
- * come) AND it isn't a research task. Keyed on the session's EFFECTIVE autopilot (not the raw
- * repo default), so an autopilot-off session — e.g. a merge-train driver — is never auto-approved.
- */
 /** Renderer env for the MAIN session spawn. Default: pin the classic renderer. The
  *  tuiFullscreen opt-in (research preview) switches to NO_FLICKER. tuiFullscreen also implies
  *  DISABLE_MOUSE (every main session is reachable in the web terminal, where fullscreen
@@ -868,6 +862,12 @@ function mainSessionRendererEnv(
   return env;
 }
 
+/**
+ * A freshly-created session is pre-approved into the build queue only when the repo runs the
+ * build queue AND the session is effectively on autopilot (so no human approval gate will ever
+ * come) AND it isn't a research task. Keyed on the session's EFFECTIVE autopilot (not the raw
+ * repo default), so an autopilot-off session — e.g. a merge-train driver — is never auto-approved.
+ */
 function shouldPreApproveBuildQueue(
   repoConfig: RepoConfig,
   session: Pick<Session, "autopilotEnabled">,

--- a/src/service.ts
+++ b/src/service.ts
@@ -1231,6 +1231,19 @@ export class SessionService {
     // FS-only (network open) — warrants the egress-degraded banner.
     const egressDegraded = isEgressDegraded(profile, backend, egressBackend ?? null);
 
+    // Renderer env for the MAIN session ONLY (satellites call herdr.start directly and keep the
+    // classic pin). Default: pin classic. The tuiFullscreen opt-in (research preview) switches to
+    // NO_FLICKER. tuiFullscreen ALSO implies DISABLE_MOUSE — every main session is reachable in the
+    // web terminal, where fullscreen mouse-capture escapes (modes 1000/1002/1003) would be injected
+    // into the keystroke stream; tuiDisableMouse can also set it independently (e.g. in classic mode).
+    // Applied via BOTH the membrane --setenv (sandboxed; the outer env shim is wiped by
+    // bwrap --clearenv) AND spawnEnv (trusted). The renderer is fixed at claude process start, so a
+    // settings change only affects subsequently spawned/resumed sessions.
+    const rendererEnv: Record<string, string> = config.tuiFullscreen
+      ? { CLAUDE_CODE_NO_FLICKER: "1" }
+      : { CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN: "1" };
+    if (config.tuiFullscreen || config.tuiDisableMouse) rendererEnv.CLAUDE_CODE_DISABLE_MOUSE = "1";
+
     // Build the membrane only when it'll actually wrap (a sandboxed profile WITH a backend).
     // wrapArgv ignores the membrane for trusted / no-backend (passthrough), so skipping the
     // git/realpath resolution avoids needless host work — and the placeholder is never read.
@@ -1246,7 +1259,7 @@ export class SessionService {
           home: homedir(),
           nodeBinReal,
           term: process.env.TERM,
-          extraEnv: collectPassthroughEnv(),
+          extraEnv: { ...collectPassthroughEnv(), ...rendererEnv },
           // api-key mode: bind the helper RO + mask the OAuth credential in place
           // (the operator's ~/.claude customizations stay bound). Subscription: null/false.
           ...apiKeyAuth.membraneFields,
@@ -1268,7 +1281,7 @@ export class SessionService {
     // credential-less mirror dir. The membrane case masks creds in place (keeping
     // the operator's real ~/.claude customizations), so it needs no env override.
     // The egress branch is always willWrap, so this is undefined there.
-    const spawnEnv = apiKeyAuth.passthroughEnv(willWrap);
+    const spawnEnv = { ...(apiKeyAuth.passthroughEnv(willWrap) ?? {}), ...rendererEnv };
     const agent = this.deps.herdr.start(ctx.name, ctx.worktreePath, wrapped, spawnEnv);
     // Start the egress drop-watcher AFTER herdr.start (the agent is now running).
     if (egressOn && egressAllowlist && egressDnsLog) {

--- a/src/service.ts
+++ b/src/service.ts
@@ -851,6 +851,23 @@ function pickOverride<T>(override: T | undefined, original: T): T {
  * come) AND it isn't a research task. Keyed on the session's EFFECTIVE autopilot (not the raw
  * repo default), so an autopilot-off session — e.g. a merge-train driver — is never auto-approved.
  */
+/** Renderer env for the MAIN session spawn. Default: pin the classic renderer. The
+ *  tuiFullscreen opt-in (research preview) switches to NO_FLICKER. tuiFullscreen also implies
+ *  DISABLE_MOUSE (every main session is reachable in the web terminal, where fullscreen
+ *  mouse-capture escapes (modes 1000/1002/1003) would be injected into the keystroke stream);
+ *  tuiDisableMouse sets it independently (e.g. in classic mode). Applied via both the membrane
+ *  --setenv (sandboxed) and the herdr.start env shim (trusted). */
+function mainSessionRendererEnv(
+  tuiFullscreen: boolean,
+  tuiDisableMouse: boolean,
+): Record<string, string> {
+  const env: Record<string, string> = tuiFullscreen
+    ? { CLAUDE_CODE_NO_FLICKER: "1" }
+    : { CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN: "1" };
+  if (tuiFullscreen || tuiDisableMouse) env.CLAUDE_CODE_DISABLE_MOUSE = "1";
+  return env;
+}
+
 function shouldPreApproveBuildQueue(
   repoConfig: RepoConfig,
   session: Pick<Session, "autopilotEnabled">,
@@ -1232,17 +1249,9 @@ export class SessionService {
     const egressDegraded = isEgressDegraded(profile, backend, egressBackend ?? null);
 
     // Renderer env for the MAIN session ONLY (satellites call herdr.start directly and keep the
-    // classic pin). Default: pin classic. The tuiFullscreen opt-in (research preview) switches to
-    // NO_FLICKER. tuiFullscreen ALSO implies DISABLE_MOUSE — every main session is reachable in the
-    // web terminal, where fullscreen mouse-capture escapes (modes 1000/1002/1003) would be injected
-    // into the keystroke stream; tuiDisableMouse can also set it independently (e.g. in classic mode).
-    // Applied via BOTH the membrane --setenv (sandboxed; the outer env shim is wiped by
-    // bwrap --clearenv) AND spawnEnv (trusted). The renderer is fixed at claude process start, so a
-    // settings change only affects subsequently spawned/resumed sessions.
-    const rendererEnv: Record<string, string> = config.tuiFullscreen
-      ? { CLAUDE_CODE_NO_FLICKER: "1" }
-      : { CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN: "1" };
-    if (config.tuiFullscreen || config.tuiDisableMouse) rendererEnv.CLAUDE_CODE_DISABLE_MOUSE = "1";
+    // classic pin). Applied via BOTH the membrane --setenv (sandboxed; the outer env shim is wiped
+    // by bwrap --clearenv) AND spawnEnv (trusted). See mainSessionRendererEnv for details.
+    const rendererEnv = mainSessionRendererEnv(config.tuiFullscreen, config.tuiDisableMouse);
 
     // Build the membrane only when it'll actually wrap (a sandboxed profile WITH a backend).
     // wrapArgv ignores the membrane for trusted / no-backend (passthrough), so skipping the

--- a/test/blocked.test.ts
+++ b/test/blocked.test.ts
@@ -1,4 +1,6 @@
 import { test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { classifyBlocked, hasActiveSpinner, quotaBlockReason } from "../src/blocked";
 import type { Session, PlanGate } from "../src/types";
 
@@ -187,4 +189,45 @@ test("quotaBlockReason: planning session with at-cap gate still raises plan bloc
   const result = quotaBlockReason(session, null, atCapGate, 2000);
   expect(result).not.toBeNull();
   expect(result?.quotaKind).toBe("plan");
+});
+
+// ── Fullscreen renderer fixtures ──────────────────────────────────────────────
+
+const fixturesDir = join(import.meta.dir, "fixtures", "fullscreen");
+
+test("fullscreen menu fixture classifies as menu with 3 options", () => {
+  const text = readFileSync(join(fixturesDir, "fullscreen-menu.txt"), "utf8");
+  const r = classifyBlocked(text);
+  expect(r.shape).toBe("menu");
+  expect(r.options).toHaveLength(3);
+  expect(r.options.map((o) => o.send)).toEqual(["1", "2", "3"]);
+  // The long packed option must be present
+  expect(r.options.some((o) => o.label.includes("allow all edits"))).toBe(true);
+});
+
+test("classic menu fixture still classifies as menu with 3 options (no regression)", () => {
+  const text = readFileSync(join(fixturesDir, "classic-menu.txt"), "utf8");
+  const r = classifyBlocked(text);
+  expect(r.shape).toBe("menu");
+  expect(r.options).toHaveLength(3);
+  expect(r.options.map((o) => o.send)).toEqual(["1", "2", "3"]);
+});
+
+test("decimal false-positive guard: '1.5 GB' / '2.5 GB' does not classify as menu", () => {
+  const tail = ["Available space: 1.5 GB", "Used space: 2.5 GB"].join("\n");
+  const r = classifyBlocked(tail);
+  expect(r.shape).toBe("awaiting-input");
+});
+
+test("bare-token-run false-positive guard: '1.tsx'/'2.tsx' does not classify as menu", () => {
+  const tail1 = ["1.tsx", "2.tsx"].join("\n");
+  expect(classifyBlocked(tail1).shape).toBe("awaiting-input");
+
+  const tail2 = ["1.x", "2.x"].join("\n");
+  expect(classifyBlocked(tail2).shape).toBe("awaiting-input");
+});
+
+test("fullscreen-spinner.txt hasActiveSpinner returns true", () => {
+  const text = readFileSync(join(fixturesDir, "fullscreen-spinner.txt"), "utf8");
+  expect(hasActiveSpinner(text)).toBe(true);
 });

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -480,6 +480,29 @@ test("start with empty env {}: wrapped is identical to no-env case", () => {
   ]);
 });
 
+test("start with CLAUDE_CODE_NO_FLICKER env: pin omitted, NO_FLICKER present in wrapped", () => {
+  const calls: string[][] = [];
+  const d = new HerdrDriver((args) => {
+    calls.push(args);
+    return reply(args, WORKSPACE_LIST);
+  });
+  d.start("flatten", "/wt/a", ["claude", "go"], { CLAUDE_CODE_NO_FLICKER: "1" });
+  const post = extractPost(calls);
+  expect(post).not.toContain("CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1");
+  expect(post).toContain("CLAUDE_CODE_NO_FLICKER=1");
+});
+
+test("start with CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN env: pin appears exactly once (no duplicate)", () => {
+  const calls: string[][] = [];
+  const d = new HerdrDriver((args) => {
+    calls.push(args);
+    return reply(args, WORKSPACE_LIST);
+  });
+  d.start("flatten", "/wt/a", ["claude", "go"], { CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN: "1" });
+  const post = extractPost(calls);
+  expect(post.filter((t) => t === "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1").length).toBe(1);
+});
+
 // -- panes() tests --
 
 const PANE_LIST = JSON.stringify({

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -1,9 +1,11 @@
 import { test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { SessionStore } from "../src/store";
 import { StatusPoller } from "../src/poller";
 import { makeApp } from "../src/server";
 import type { HerdrAgent } from "../src/herdr";
-import { classifyBlocked } from "../src/blocked";
+import { classifyBlocked, hasActiveSpinner } from "../src/blocked";
 import { DEFAULT_STALL } from "../src/stall";
 import { maintenance } from "../src/maintenance";
 import { config } from "../src/config";
@@ -2764,4 +2766,59 @@ test("quota: idle session with exhausted plan gate (no review) emits quotaKind '
   expect(blocks).toHaveLength(1);
   expect((blocks[0]!.block as any).shape).toBe("quota");
   expect((blocks[0]!.block as any).quotaKind).toBe("plan");
+});
+
+// ── Fullscreen renderer stall-detection regression coverage ───────────────────
+
+const fullscreenFixturesDir = join(import.meta.dir, "fixtures", "fullscreen");
+const fullscreenSpinner = readFileSync(
+  join(fullscreenFixturesDir, "fullscreen-spinner.txt"),
+  "utf8",
+);
+const fullscreenIdle = readFileSync(join(fullscreenFixturesDir, "fullscreen-idle.txt"), "utf8");
+
+test("fullscreen idle frame is not mistaken for a live turn (hasActiveSpinner = false)", () => {
+  expect(hasActiveSpinner(fullscreenIdle)).toBe(false);
+});
+
+test("fullscreen: a wedged (frozen) spinner frame is detected as frozen — chrome does not fake advancement", () => {
+  // The fullscreen buffer contains incidental status-bar chrome (path, progress bar).
+  // Holding it CONSTANT across cadences must read as FROZEN and re-arm the block,
+  // exactly like the classic "frozen spinner re-arms" test.
+  const h = spinnerHarness(fullscreenSpinner);
+  // first tick: spinner detected → one-cadence grace, suppressed
+  h.poller.tick();
+  expect(h.blocks).toHaveLength(0);
+  expect(h.working).toEqual([{ id: h.id, working: true }]);
+
+  // buffer did NOT advance → wedged; re-arm must fire working:false then block
+  h.advance(3001);
+  h.poller.tick();
+  expect(h.events).toEqual(["working:true", "working:false", "block:awaiting-input"]);
+  expect(h.poller.workingBlockedSnapshot()).toEqual({});
+
+  // further identical-buffer cadence: sig-dedupe → no new emissions
+  h.advance(3001);
+  h.poller.tick();
+  expect(h.events).toEqual(["working:true", "working:false", "block:awaiting-input"]);
+});
+
+test("fullscreen: an advancing spinner frame stays suppressed (live turn, not a stall)", () => {
+  // Simulate the elapsed-time counter ticking by appending a distinct suffix each
+  // cadence. The spinner line remains valid across all iterations; the buffer
+  // advances → suppression holds throughout.
+  const h = spinnerHarness(fullscreenSpinner);
+  h.poller.tick(); // first tick: spinner detected → grace, suppressed
+  expect(h.blocks).toHaveLength(0);
+  expect(h.working).toEqual([{ id: h.id, working: true }]);
+
+  for (let secs = 13; secs <= 16; secs++) {
+    // buffer changes each cadence (different suffix) while the spinner line persists
+    h.setText(fullscreenSpinner + `\n<!-- tick:${secs} -->`);
+    h.advance(3001);
+    h.poller.tick();
+  }
+  expect(h.blocks).toHaveLength(0);
+  expect(h.working).toEqual([{ id: h.id, working: true }]); // only the initial flag-on
+  expect(h.poller.workingBlockedSnapshot()).toEqual({ [h.id]: true });
 });

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -668,6 +668,33 @@ describe("buildMembraneFlags", () => {
   });
 });
 
+describe("buildMembraneFlags renderer env", () => {
+  test("CLAUDE_CODE_NO_FLICKER in extraEnv => --setenv triple present, after --clearenv", () => {
+    const f = buildMembraneFlags(
+      fakeMembrane({ extraEnv: { CLAUDE_CODE_NO_FLICKER: "1" } }),
+      detDeps,
+    );
+    expect(hasTriple(f, "--setenv", "CLAUDE_CODE_NO_FLICKER", "1")).toBe(true);
+    const clearIdx = f.indexOf("--clearenv");
+    let tripleIdx = -1;
+    for (let i = 0; i + 2 < f.length; i++) {
+      if (f[i] === "--setenv" && f[i + 1] === "CLAUDE_CODE_NO_FLICKER" && f[i + 2] === "1") {
+        tripleIdx = i;
+        break;
+      }
+    }
+    expect(tripleIdx).toBeGreaterThan(clearIdx);
+  });
+
+  test("CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN in extraEnv => --setenv triple present", () => {
+    const f = buildMembraneFlags(
+      fakeMembrane({ extraEnv: { CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN: "1" } }),
+      detDeps,
+    );
+    expect(hasTriple(f, "--setenv", "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN", "1")).toBe(true);
+  });
+});
+
 describe("collectPassthroughEnv", () => {
   test("excludes secrets, includes allowlisted locale/display vars", () => {
     const out = collectPassthroughEnv({

--- a/test/server-settings.test.ts
+++ b/test/server-settings.test.ts
@@ -21,6 +21,8 @@ let savedExtraCredits: number;
 let savedAuthMode: AuthMode;
 let savedAuthApiKeyHelperPath: string | null;
 let savedHome: string | undefined;
+let savedTuiFullscreen: boolean;
+let savedTuiDisableMouse: boolean;
 
 beforeEach(() => {
   // realpath so comparisons hold where tmpdir() is a symlink (macOS)
@@ -37,6 +39,8 @@ beforeEach(() => {
   savedExtraCredits = config.extraCreditsDrainCeiling;
   savedAuthMode = config.authMode;
   savedAuthApiKeyHelperPath = config.authApiKeyHelperPath;
+  savedTuiFullscreen = config.tuiFullscreen;
+  savedTuiDisableMouse = config.tuiDisableMouse;
   savedHome = process.env.HOME;
   // the ceiling is the immutable boundary; point it at our temp dir for the test so
   // dirs inside tmp validate and the dir browser is confined to tmp.
@@ -57,6 +61,8 @@ afterEach(() => {
   config.extraCreditsDrainCeiling = savedExtraCredits;
   config.authMode = savedAuthMode;
   config.authApiKeyHelperPath = savedAuthApiKeyHelperPath;
+  config.tuiFullscreen = savedTuiFullscreen;
+  config.tuiDisableMouse = savedTuiDisableMouse;
   if (savedHome !== undefined) process.env.HOME = savedHome;
   else delete process.env.HOME;
   rmSync(tmp, { recursive: true, force: true });
@@ -617,4 +623,72 @@ test("GET /api/settings is unaffected by the verify-key route", async () => {
   const res = await app.fetch(new Request("http://x/api/settings"));
   expect(res.status).toBe(200);
   expect((await res.json()).repoRoot).toBe(tmp);
+});
+
+// ── tuiFullscreen ─────────────────────────────────────────────────────────────
+
+test("GET /api/settings includes tuiFullscreen (default false)", async () => {
+  config.tuiFullscreen = false;
+  const { app } = harness();
+  const res = await app.fetch(new Request("http://x/api/settings"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.tuiFullscreen).toBe(false);
+});
+
+test('PUT /api/settings toggles tuiFullscreen, persists ("1"/"0"), leaves repoRoot intact', async () => {
+  config.repoRoot = tmp;
+  config.tuiFullscreen = false;
+  const { app, store } = harness();
+  const res = await put(app, { tuiFullscreen: true });
+  expect(res.status).toBe(200);
+  expect((await res.json()).tuiFullscreen).toBe(true);
+  expect(config.tuiFullscreen).toBe(true); // live
+  expect(store.getSetting("tuiFullscreen")).toBe("1"); // persisted as "1"/"0"
+  expect(config.repoRoot).toBe(tmp); // a tuiFullscreen patch must not touch the repo root
+  // reflected by GET, and toggling back persists "0"
+  const got = await (await app.fetch(new Request("http://x/api/settings"))).json();
+  expect(got.tuiFullscreen).toBe(true);
+  await put(app, { tuiFullscreen: false });
+  expect(store.getSetting("tuiFullscreen")).toBe("0");
+});
+
+test("PUT /api/settings rejects a non-boolean tuiFullscreen", async () => {
+  const { app } = harness();
+  const res = await put(app, { tuiFullscreen: "yes" });
+  expect(res.status).toBe(400);
+});
+
+// ── tuiDisableMouse ───────────────────────────────────────────────────────────
+
+test("GET /api/settings includes tuiDisableMouse (default false)", async () => {
+  config.tuiDisableMouse = false;
+  const { app } = harness();
+  const res = await app.fetch(new Request("http://x/api/settings"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.tuiDisableMouse).toBe(false);
+});
+
+test('PUT /api/settings toggles tuiDisableMouse, persists ("1"/"0"), leaves repoRoot intact', async () => {
+  config.repoRoot = tmp;
+  config.tuiDisableMouse = false;
+  const { app, store } = harness();
+  const res = await put(app, { tuiDisableMouse: true });
+  expect(res.status).toBe(200);
+  expect((await res.json()).tuiDisableMouse).toBe(true);
+  expect(config.tuiDisableMouse).toBe(true); // live
+  expect(store.getSetting("tuiDisableMouse")).toBe("1"); // persisted as "1"/"0"
+  expect(config.repoRoot).toBe(tmp); // a tuiDisableMouse patch must not touch the repo root
+  // reflected by GET, and toggling back persists "0"
+  const got = await (await app.fetch(new Request("http://x/api/settings"))).json();
+  expect(got.tuiDisableMouse).toBe(true);
+  await put(app, { tuiDisableMouse: false });
+  expect(store.getSetting("tuiDisableMouse")).toBe("0");
+});
+
+test("PUT /api/settings rejects a non-boolean tuiDisableMouse", async () => {
+  const { app } = harness();
+  const res = await put(app, { tuiDisableMouse: "yes" });
+  expect(res.status).toBe(400);
 });

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -4499,6 +4499,110 @@ test("create NON-research under autonomous: stays autonomous (no downgrade)", as
   expect(s.sandboxApplied).toBe("autonomous");
 });
 
+// ── renderer env wired through membrane --setenv (sandboxed profile) ────────────────────────────
+// prepareSpawn computes rendererEnv from config.tuiFullscreen/tuiDisableMouse and passes it into
+// membrane.extraEnv, which buildMembraneFlags emits as --setenv pairs. bwrap --clearenv wipes the
+// outer env shim, so ONLY these --setenv entries survive into the claude process.
+
+function findSetenvTriple(argv: string[], key: string): { found: boolean; idx: number } {
+  for (let i = 0; i + 2 < argv.length; i++) {
+    if (argv[i] === "--setenv" && argv[i + 1] === key) {
+      return { found: true, idx: i };
+    }
+  }
+  return { found: false, idx: -1 };
+}
+
+function hasSetenvPair(argv: string[], key: string, value: string): boolean {
+  for (let i = 0; i + 2 < argv.length; i++) {
+    if (argv[i] === "--setenv" && argv[i + 1] === key && argv[i + 2] === value) return true;
+  }
+  return false;
+}
+
+test("renderer env: tuiFullscreen=true => --setenv CLAUDE_CODE_NO_FLICKER 1 + DISABLE_MOUSE, no DISABLE_ALTERNATE_SCREEN", async () => {
+  const prevFullscreen = config.tuiFullscreen;
+  const prevMouse = config.tuiDisableMouse;
+  try {
+    config.tuiFullscreen = true;
+    config.tuiDisableMouse = false;
+    const store = new SessionStore(":memory:");
+    store.setRepoConfig("/repo", { ...store.getRepoConfig("/repo"), sandboxProfile: "standard" });
+    const captured: { argv?: string[] } = {};
+    const svc = new SessionService(sandboxResearchDeps(store, captured) as any);
+    await svc.create({
+      repoPath: "/repo",
+      baseBranch: "main",
+      prompt: "go",
+      model: null,
+      images: [],
+    });
+    const argv = captured.argv!;
+    expect(argv[0]).toBe("bwrap");
+    expect(hasSetenvPair(argv, "CLAUDE_CODE_NO_FLICKER", "1")).toBe(true);
+    expect(hasSetenvPair(argv, "CLAUDE_CODE_DISABLE_MOUSE", "1")).toBe(true);
+    expect(findSetenvTriple(argv, "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN").found).toBe(false);
+  } finally {
+    config.tuiFullscreen = prevFullscreen;
+    config.tuiDisableMouse = prevMouse;
+  }
+});
+
+test("renderer env: both false (default) => --setenv CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN 1, no NO_FLICKER/DISABLE_MOUSE", async () => {
+  const prevFullscreen = config.tuiFullscreen;
+  const prevMouse = config.tuiDisableMouse;
+  try {
+    config.tuiFullscreen = false;
+    config.tuiDisableMouse = false;
+    const store = new SessionStore(":memory:");
+    store.setRepoConfig("/repo", { ...store.getRepoConfig("/repo"), sandboxProfile: "standard" });
+    const captured: { argv?: string[] } = {};
+    const svc = new SessionService(sandboxResearchDeps(store, captured) as any);
+    await svc.create({
+      repoPath: "/repo",
+      baseBranch: "main",
+      prompt: "go",
+      model: null,
+      images: [],
+    });
+    const argv = captured.argv!;
+    expect(argv[0]).toBe("bwrap");
+    expect(hasSetenvPair(argv, "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN", "1")).toBe(true);
+    expect(findSetenvTriple(argv, "CLAUDE_CODE_NO_FLICKER").found).toBe(false);
+    expect(findSetenvTriple(argv, "CLAUDE_CODE_DISABLE_MOUSE").found).toBe(false);
+  } finally {
+    config.tuiFullscreen = prevFullscreen;
+    config.tuiDisableMouse = prevMouse;
+  }
+});
+
+test("renderer env: tuiDisableMouse=true (fullscreen false) => DISABLE_ALTERNATE_SCREEN + DISABLE_MOUSE", async () => {
+  const prevFullscreen = config.tuiFullscreen;
+  const prevMouse = config.tuiDisableMouse;
+  try {
+    config.tuiFullscreen = false;
+    config.tuiDisableMouse = true;
+    const store = new SessionStore(":memory:");
+    store.setRepoConfig("/repo", { ...store.getRepoConfig("/repo"), sandboxProfile: "standard" });
+    const captured: { argv?: string[] } = {};
+    const svc = new SessionService(sandboxResearchDeps(store, captured) as any);
+    await svc.create({
+      repoPath: "/repo",
+      baseBranch: "main",
+      prompt: "go",
+      model: null,
+      images: [],
+    });
+    const argv = captured.argv!;
+    expect(argv[0]).toBe("bwrap");
+    expect(hasSetenvPair(argv, "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN", "1")).toBe(true);
+    expect(hasSetenvPair(argv, "CLAUDE_CODE_DISABLE_MOUSE", "1")).toBe(true);
+  } finally {
+    config.tuiFullscreen = prevFullscreen;
+    config.tuiDisableMouse = prevMouse;
+  }
+});
+
 test("relaunch keeps research:true; explicit override flips it to false", async () => {
   const store = new SessionStore(":memory:");
   const { service } = relaunchHarness(store);

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1881,5 +1881,13 @@
   "rundown_epic_stranded": "festgefahren",
   "rundown_epic_open_aria": "Zu Epic #{number} springen, um es zu landen",
   "feat_rundown_epics_to_land_title": "Rundown zeigt zu landende Epics",
-  "feat_rundown_epics_to_land_body": "Der tägliche Herd-Rundown hebt jetzt integrierte Epics, deren Landing-PR merge-bereit ist, als Top-Priorität hervor — auch wenn keine Sitzung aktiv ist — damit eine vergessene letzte Landung nicht mehr durchrutscht. Per Klick direkt zum Landen-Button des Epics springen."
+  "feat_rundown_epics_to_land_body": "Der tägliche Herd-Rundown hebt jetzt integrierte Epics, deren Landing-PR merge-bereit ist, als Top-Priorität hervor — auch wenn keine Sitzung aktiv ist — damit eine vergessene letzte Landung nicht mehr durchrutscht. Per Klick direkt zum Landen-Button des Epics springen.",
+  "settings_tui_fullscreen_label": "Vollbild-Renderer (experimentell)",
+  "settings_tui_fullscreen_hint": "Aktiviert den Vollbild-Renderer von Claude Code für die Hauptagenten-Sitzung, um bei langen autonomen Läufen einen flacheren Speicherverbrauch zu erreichen. Forschungsvorschau — Verhalten kann sich ändern. Gilt für neu gestartete oder fortgesetzte Sitzungen, nicht für bereits laufende. Deaktiviert außerdem die Mauserfassung, damit das Web-Terminal bedienbar bleibt.",
+  "settings_tui_fullscreen_save_failed": "Einstellung für den Vollbild-Renderer konnte nicht geändert werden.",
+  "settings_tui_disable_mouse_label": "Mauserfassung deaktivieren",
+  "settings_tui_disable_mouse_hint": "Verhindert, dass Claude Code die Maus im Agenten-Terminal erfasst. Gilt für neu gestartete oder fortgesetzte Sitzungen.",
+  "settings_tui_disable_mouse_save_failed": "Einstellung für die Mauserfassung konnte nicht geändert werden.",
+  "feat_tui_fullscreen_title": "Vollbild-Renderer (experimentell)",
+  "feat_tui_fullscreen_body": "Agent-Sitzungen können jetzt in den Vollbild-Renderer von Claude Code gewechselt werden — erreichbar unter Einstellungen → Sitzung. Ermöglicht einen flacheren Speicherverbrauch bei langen autonomen Läufen. Forschungsvorschau (standardmäßig deaktiviert), gilt für neu gestartete oder fortgesetzte Sitzungen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1881,5 +1881,13 @@
   "rundown_epic_stranded": "stranded",
   "rundown_epic_open_aria": "Go to epic #{number} to land it",
   "feat_rundown_epics_to_land_title": "Rundown surfaces epics to land",
-  "feat_rundown_epics_to_land_body": "The daily Herd Rundown now escalates integrated epics whose landing PR is ready to merge as a top-priority item — even when no session is live — so a forgotten last-mile landing no longer slips. Click it to jump straight to the epic's Land button."
+  "feat_rundown_epics_to_land_body": "The daily Herd Rundown now escalates integrated epics whose landing PR is ready to merge as a top-priority item — even when no session is live — so a forgotten last-mile landing no longer slips. Click it to jump straight to the epic's Land button.",
+  "settings_tui_fullscreen_label": "Fullscreen renderer (experimental)",
+  "settings_tui_fullscreen_hint": "Opt the main agent session into Claude Code's fullscreen renderer for flatter memory on long autonomous runs. Research preview — behavior may change. Applies to newly started or resumed sessions, not ones already running. Also disables mouse capture so the web terminal stays usable.",
+  "settings_tui_fullscreen_save_failed": "Couldn't change the fullscreen renderer setting.",
+  "settings_tui_disable_mouse_label": "Disable mouse capture",
+  "settings_tui_disable_mouse_hint": "Stop Claude Code from capturing the mouse in the agent terminal. Applies to newly started or resumed sessions.",
+  "settings_tui_disable_mouse_save_failed": "Couldn't change the mouse-capture setting.",
+  "feat_tui_fullscreen_title": "Fullscreen renderer (experimental)",
+  "feat_tui_fullscreen_body": "You can now opt agent sessions into Claude Code's fullscreen renderer from Settings → Session, for flatter memory on long autonomous runs. It's a research preview (off by default) and applies to newly started or resumed sessions."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -175,6 +175,14 @@ export const putFableAvailable = (value: boolean): Promise<{ fableAvailable: boo
 export const putReducedPushMode = (enabled: boolean): Promise<{ reducedPushMode: boolean }> =>
   patchSettings({ reducedPushMode: enabled });
 
+// Opt the main session into Claude Code's fullscreen renderer (applies to new/resumed sessions).
+export const putTuiFullscreen = (value: boolean): Promise<{ tuiFullscreen: boolean }> =>
+  patchSettings<{ tuiFullscreen: boolean }>({ tuiFullscreen: value });
+
+// Disable Claude Code mouse capture for the main session.
+export const putTuiDisableMouse = (value: boolean): Promise<{ tuiDisableMouse: boolean }> =>
+  patchSettings<{ tuiDisableMouse: boolean }>({ tuiDisableMouse: value });
+
 /** Upload one image; returns its absolute server path. Pass sessionId to store it
  *  inside that session's worktree (live terminal); omit for New Task staging. */
 export async function uploadImage(file: File, sessionId?: string): Promise<string> {

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -69,6 +69,8 @@ function settings(over: Partial<SettingsPayload> = {}): SettingsPayload {
     usageHoldEnabled: true,
     usageHoldPct: 90,
     fableAvailable: true,
+    tuiFullscreen: false,
+    tuiDisableMouse: false,
     reducedPushMode: false,
     docAgentEnabled: false,
     docAgentAct: true,

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -15,6 +15,8 @@
     putUsageHoldPct,
     putFableAvailable,
     putReducedPushMode,
+    putTuiFullscreen,
+    putTuiDisableMouse,
   } from "$lib/api";
   import { verifyFailureMessage } from "$lib/verify-key";
   import { modelLabel } from "$lib/model-label";
@@ -137,6 +139,14 @@
   // Fable availability — operator kill-switch while Fable is globally unavailable.
   let fableAvailable = $state(true);
   let fableAvailableBusy = $state(false);
+
+  // TUI fullscreen renderer — opt-in research preview for flatter memory on long runs.
+  let tuiFullscreen = $state(false);
+  let tuiFullscreenBusy = $state(false);
+
+  // TUI disable-mouse — stop Claude Code from capturing the mouse in the agent terminal.
+  let tuiDisableMouse = $state(false);
+  let tuiDisableMouseBusy = $state(false);
 
   // Reduced-notifications mode — mutes all pushes except ready-after-5s + cost alerts.
   let reducedPushMode = $state(false);
@@ -382,6 +392,40 @@
     }
   }
 
+  async function toggleTuiFullscreen() {
+    if (tuiFullscreenBusy) return;
+    tuiFullscreenBusy = true;
+    try {
+      const r = await putTuiFullscreen(!tuiFullscreen);
+      tuiFullscreen = r.tuiFullscreen;
+    } catch {
+      toasts.info(m.settings_tui_fullscreen_save_failed(), {
+        key: "tui-fullscreen",
+        duration: null,
+        alert: true,
+      });
+    } finally {
+      tuiFullscreenBusy = false;
+    }
+  }
+
+  async function toggleTuiDisableMouse() {
+    if (tuiDisableMouseBusy) return;
+    tuiDisableMouseBusy = true;
+    try {
+      const r = await putTuiDisableMouse(!tuiDisableMouse);
+      tuiDisableMouse = r.tuiDisableMouse;
+    } catch {
+      toasts.info(m.settings_tui_disable_mouse_save_failed(), {
+        key: "tui-disable-mouse",
+        duration: null,
+        alert: true,
+      });
+    } finally {
+      tuiDisableMouseBusy = false;
+    }
+  }
+
   async function toggleReducedPush() {
     if (reducedPushBusy) return;
     reducedPushBusy = true;
@@ -475,6 +519,8 @@
       usageHoldPct = s.usageHoldPct;
       usageHoldPctSaved = s.usageHoldPct;
       fableAvailable = s.fableAvailable;
+      tuiFullscreen = s.tuiFullscreen;
+      tuiDisableMouse = s.tuiDisableMouse;
       reducedPushMode = s.reducedPushMode;
       repoRoot = s.repoRoot;
       repoRootDisplay = s.repoRootDisplay;
@@ -809,6 +855,40 @@
           <span class="track" class:on={fableAvailable}><span class="knob"></span></span>
           <span class="state"
             >{fableAvailable ? m.settings_usage_hold_on() : m.settings_usage_hold_off()}</span
+          >
+        </button>
+      </div>
+      <div class="rc">
+        <span class="micro">{m.settings_tui_fullscreen_label()}</span>
+        <p class="hint">{m.settings_tui_fullscreen_hint()}</p>
+        <button
+          type="button"
+          class="toggle"
+          role="switch"
+          aria-checked={tuiFullscreen}
+          disabled={tuiFullscreenBusy}
+          onclick={toggleTuiFullscreen}
+        >
+          <span class="track" class:on={tuiFullscreen}><span class="knob"></span></span>
+          <span class="state"
+            >{tuiFullscreen ? m.settings_usage_hold_on() : m.settings_usage_hold_off()}</span
+          >
+        </button>
+      </div>
+      <div class="rc">
+        <span class="micro">{m.settings_tui_disable_mouse_label()}</span>
+        <p class="hint">{m.settings_tui_disable_mouse_hint()}</p>
+        <button
+          type="button"
+          class="toggle"
+          role="switch"
+          aria-checked={tuiDisableMouse}
+          disabled={tuiDisableMouseBusy}
+          onclick={toggleTuiDisableMouse}
+        >
+          <span class="track" class:on={tuiDisableMouse}><span class="knob"></span></span>
+          <span class="state"
+            >{tuiDisableMouse ? m.settings_usage_hold_on() : m.settings_usage_hold_off()}</span
           >
         </button>
       </div>

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1517,4 +1517,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_rundown_epics_to_land_title",
     bodyKey: "feat_rundown_epics_to_land_body",
   },
+  {
+    // Operators can opt agent sessions into Claude Code's fullscreen renderer (Settings → Session),
+    // a research preview for flatter memory on long autonomous runs; off by default. No targetId —
+    // surfaced via the What's-New drawer only. v1.36.0 is the latest released tag → ships in 1.37.0.
+    id: "tui-fullscreen",
+    sinceVersion: "1.37.0",
+    titleKey: "feat_tui_fullscreen_title",
+    bodyKey: "feat_tui_fullscreen_body",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -72,6 +72,10 @@ export interface Settings {
   usageHoldPct: number;
   /** Whether Fable is globally available; when false, Fable selections run on Opus (1M context). */
   fableAvailable: boolean;
+  /** Opt the main session into Claude Code's fullscreen renderer (research preview). */
+  tuiFullscreen: boolean;
+  /** Disable Claude Code mouse capture for the main session. */
+  tuiDisableMouse: boolean;
   /** Global reduced-notifications mode: when on, only the ready-after-5s push (+ usage/credit alerts) is sent. */
   reducedPushMode: boolean;
   /** Whether the PR-gated doc agent feature is enabled. */


### PR DESCRIPTION
Closes #1047. Follow-up to the **GO** outcome of spike #1043.

Lets an operator opt the **main agent session** (interactive + autonomous drain) into Claude Code's fullscreen renderer for its flat-memory upside on long drains — **without changing the default** (classic stays pinned) and without breaking blocked/stall classification or the web terminal.

## What changed

- **`OPTION_RE` re-tune** (`src/blocked.ts`) — tolerate the fullscreen renderer's zero-space option packing (`2.Yes, allow all edits…`), which the classic `\s+`-after-delimiter pattern missed (collapsing the whole menu to `awaiting-input`). The relaxation is guarded so two new false-positive classes can't forge a menu: decimals (`2.5 GB`) and bare-token runs (`1.tsx`/`2.x`/`1.txt`). Accept rule for a zero-space option: label is non-digit-leading **and** contains internal whitespace; the contiguous 1,2,3-run check remains the backstop.
- **Two global settings** `tuiFullscreen` + `tuiDisableMouse` (both default **false**), following the existing `fableAvailable` pattern across `config.ts` → `index.ts` (persist) → `server.ts` (GET + PUT) → `api.ts` → `types.ts` → `Settings.svelte` (SESSION panel) → EN+DE i18n → feature catalog (`sinceVersion: 1.37.0`).
- **Per-spawn renderer env** — `prepareSpawn` computes the main session's renderer env (`mainSessionRendererEnv`) and applies it on **both** spawn paths:
  - **trusted** (incl. all satellites): the `herdr.start` `env` shim.
  - **sandboxed** (standard/autonomous — the long-drain target): the membrane's existing `extraEnv` → `--setenv`, which survives `bwrap --clearenv` (the outer shim does not).
  - Default pins classic (`CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1`); `tuiFullscreen` sets `CLAUDE_CODE_NO_FLICKER=1`.
- **`herdr.start` classic pin made conditional** — skipped when the caller already supplies a renderer var, so the main session can never end up with both `NO_FLICKER` and the classic pin (the pin would otherwise win under `env` last-wins and silently defeat the opt-in), while **satellites keep the classic pin unchanged**.
- **Stall detection** — no code change needed; added poller regression coverage that a frozen fullscreen frame reads as frozen (alt-screen chrome doesn't fake buffer advancement) while an advancing spinner stays suppressed, and that the idle fullscreen frame isn't mistaken for a live turn.

## Deliberate deviations (per house rules)

- **#1042's classic pin is now conditional, not unconditional.** Building on the merged #1042, the renderer pin is routed through the spawn-env decision and skipped when a renderer var is already supplied. Side effect: the classic pin now genuinely reaches the **sandboxed** main session for the first time (the outer `env` shim was previously wiped by `bwrap --clearenv`) — a strict improvement, tested.
- **`tuiFullscreen` auto-implies `DISABLE_MOUSE`.** Every main session is reachable in the web terminal, where fullscreen mouse-capture escapes would be injected into the operator's keystroke stream, and there's no spawn-time "headless" signal. So fullscreen always disables mouse capture; the separate `tuiDisableMouse` toggle remains meaningful in classic mode. Documented in the setting copy.
- **Multi-width menu validation deferred → #1054.** herdr exposes no terminal-column control in-session, so the `OPTION_RE` guard is tuned to and tested against the spike's 54-col fixture. Narrow-width packing robustness is tracked in #1054 rather than faked here.

## Verification (Phase-0 empirical go/no-go)

Spawned a real fullscreen `claude` (`CLAUDE_CODE_NO_FLICKER=1`) bound to a config dir with `tui: default` (classic) persisted; `/tui` reported **`Current renderer: fullscreen`** — confirming `NO_FLICKER` overrides a persisted classic setting, so the env-only opt-in is sound (no `--settings` overlay escalation needed).

## Gates

- root `bun run lint` + `bunx tsc --noEmit` + `bun test ./test` → **4674 pass / 0 fail**
- `cd ui && bun run check` (0 errors) + `check:i18n` (1882 keys, EN/DE parity) + `bun run test` → **2014 pass**
- branch-hygiene ✓ · feature-catalog ✓ · glossary ✓ · `fallow@2.97.0 audit --fail-on-issues` ✓ · pre-push ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)