### PR TITLE
fix(critic): don't persist a post-merge error verdict as REVIEW ERR

### DIFF
--- a/src/review.ts
+++ b/src/review.ts
@@ -640,36 +640,13 @@ export class ReviewService {
     // (a forge/store/steer failure must not strand them).
     try {
       const verdict = this.buildVerdict(f, raw);
+      // A verdict for a PR that's no longer open is moot. The real branch handles that inside
+      // publishVerdict(); the error branch needs its own gate (finalizeErrorVerdict) since it
+      // never reaches publishVerdict. When persist is false we skip persisting the verdict as
+      // session review state — see below.
+      let persist = true;
       if (verdict.decision === "error") {
-        // A transient critic failure (timeout / unparseable verdict) posts nothing and
-        // has no findings to steer. Don't let it pose as "clean": count it on a separate
-        // no-progress streak so a flapping critic still escalates instead of looping
-        // forever, and preserve the findings round (those findings are still outstanding,
-        // just un-reverified this push).
-        verdict.errorRound = f.priorErrorRound + 1;
-        verdict.addressRound = f.priorRound;
-        // Error verdicts deliberately do NOT increment streakReviews: error-spawn token cost
-        // is bounded by the separate errorRound counter + its own cap escalation, not by the
-        // spawn ceiling. Preserve the streak's review count + reviewed-patch-id set so the
-        // ceiling math and churn dedup stay correct across a transient failure (and the errored
-        // patch-id is NOT added — mirrors patchId:"" so the same diff re-reviews).
-        verdict.streakReviews = f.priorStreakReviews;
-        verdict.reviewedPatchIds = f.priorReviewedPatchIds;
-        // The critic never produced a verdict, so it didn't actually consider this run's
-        // freshly-fetched notes — roll the seen set back so they re-inject next round
-        // instead of being silently swallowed by an error pass.
-        verdict.seenNoteIds = f.priorSeenNoteIds;
-        // Escalate once, when the streak first reaches the cap. `>=` with a crossing guard
-        // (not `=== cap`) so a cap lowered between runs still fires rather than being
-        // stepped over, while errors past the cap don't re-signal every tick.
-        if (verdict.errorRound >= this.cap && f.priorErrorRound < this.cap) {
-          this.deps.store.addSignal({
-            repoPath: f.repoPath,
-            sessionId: f.sessionId,
-            kind: "stall",
-            payload: `critic produced ${verdict.errorRound} consecutive error verdicts for this PR — auto-address can't make progress`,
-          });
-        }
+        persist = await this.finalizeErrorVerdict(f, verdict);
       } else {
         // Per-streak review accounting — independent of publish/steer outcome and of
         // autoAddressEnabled (review token spend happens whether or not findings are steered).
@@ -698,8 +675,13 @@ export class ReviewService {
         }
         await this.publishVerdict(f, verdict);
       }
-      this.deps.store.putReview(verdict);
-      this.deps.onChange(f.sessionId, verdict);
+      // Skipped only for a moot post-merge error verdict (persist=false above): it must not
+      // become the session's review state. captureUsage + the finally-reap below still run, so
+      // the critic spawn's token cost is attributed and its terminal/worktree are reaped.
+      if (persist) {
+        this.deps.store.putReview(verdict);
+        this.deps.onChange(f.sessionId, verdict);
+      }
       // Persist the critic's token total for exact cost attribution (issue #502). Best-effort:
       // a missing/half-written transcript leaves the spawn row's totals null rather than
       // stranding finalize. The reviewer transcript lives under ~/.claude/projects (keyed by
@@ -716,6 +698,79 @@ export class ReviewService {
     } finally {
       this.deps.onReviewing?.(f.sessionId, false);
       reapRun(this.deps.herdr, this.deps.worktree, f.terminalId, f.worktreePath);
+    }
+  }
+
+  /**
+   * Bookkeeping for a transient critic *error* verdict (timeout / unparseable). Returns whether
+   * the verdict should be persisted as session review state.
+   *
+   * Critic spawn and PR merge both fire on CI-green, so they race: the critic can finish AFTER
+   * the merge is observable. An error on a PR that already merged/closed is moot — persisting it
+   * would flip a not-yet-decommissioned session to a stale REVIEW ERR badge until archive, and
+   * escalating it is noise (no merge left to gate). So suppress (return false) on a CONFIRMED
+   * terminal state only; fail OPEN on an unconfirmable state (no forge / fetch threw) so a genuine
+   * error on a still-open PR is never hidden by a failed recheck — at the cost of a residual
+   * transient REVIEW ERR if the PR did merge but the recheck couldn't see it (logged so the field
+   * cause is distinguishable; self-clears at archive).
+   */
+  private async finalizeErrorVerdict(f: InFlight, verdict: ReviewVerdict): Promise<boolean> {
+    const live = await this.livePrState(f);
+    if (live === "merged" || live === "closed") {
+      console.warn(
+        `[review] error verdict suppressed for ${f.sessionId}: PR ${live} before finalize (moot)`,
+      );
+      return false;
+    }
+    if (live === undefined)
+      console.warn(
+        `[review] error verdict kept for ${f.sessionId}: live PR state unconfirmable (fail-open) — may surface a transient REVIEW ERR if the PR already merged`,
+      );
+    // A transient critic failure posts nothing and has no findings to steer. Don't let it pose as
+    // "clean": count it on a separate no-progress streak so a flapping critic still escalates
+    // instead of looping forever, and preserve the findings round (those findings are still
+    // outstanding, just un-reverified this push).
+    verdict.errorRound = f.priorErrorRound + 1;
+    verdict.addressRound = f.priorRound;
+    // Error verdicts deliberately do NOT increment streakReviews: error-spawn token cost is
+    // bounded by the separate errorRound counter + its own cap escalation, not by the spawn
+    // ceiling. Preserve the streak's review count + reviewed-patch-id set so the ceiling math and
+    // churn dedup stay correct across a transient failure (and the errored patch-id is NOT added —
+    // mirrors patchId:"" so the same diff re-reviews).
+    verdict.streakReviews = f.priorStreakReviews;
+    verdict.reviewedPatchIds = f.priorReviewedPatchIds;
+    // The critic never produced a verdict, so it didn't actually consider this run's freshly-
+    // fetched notes — roll the seen set back so they re-inject next round instead of being
+    // silently swallowed by an error pass.
+    verdict.seenNoteIds = f.priorSeenNoteIds;
+    // Escalate once, when the streak first reaches the cap. `>=` with a crossing guard (not
+    // `=== cap`) so a cap lowered between runs still fires rather than being stepped over, while
+    // errors past the cap don't re-signal every tick.
+    if (verdict.errorRound >= this.cap && f.priorErrorRound < this.cap) {
+      this.deps.store.addSignal({
+        repoPath: f.repoPath,
+        sessionId: f.sessionId,
+        kind: "stall",
+        payload: `critic produced ${verdict.errorRound} consecutive error verdicts for this PR — auto-address can't make progress`,
+      });
+    }
+    return true;
+  }
+
+  /**
+   * Live PR state for the at-finalize recheck. `undefined` when it can't be confirmed (no forge,
+   * or the forge throws) — callers treat that as "unconfirmable" and decide their own fail mode.
+   * Mirrors the fetch publishVerdict() does for real verdicts; the error branch uses it too so a
+   * transient critic error finishing AFTER the merge isn't persisted as a stale REVIEW ERR.
+   */
+  private async livePrState(f: InFlight): Promise<PrStatus["state"] | undefined> {
+    const forge = this.deps.resolveForge(f.repoPath);
+    if (!forge) return undefined;
+    try {
+      return (await forge.prStatus(f.branch))?.state;
+    } catch (err) {
+      console.warn(`[review] PR-state recheck failed for ${f.sessionId}:`, err);
+      return undefined;
     }
   }
 

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -1282,6 +1282,47 @@ test("PR closed (not merged) before finalize: also fully inert", async () => {
   expect(postedComments).toHaveLength(0); // closed-unmerged → moot, no post-merge comment either
 });
 
+test("PR merged before finalize (error verdict): not persisted, no escalation", async () => {
+  // Critic spawn and PR merge both fire on CI-green → they race. A transient critic error that
+  // finalizes after the merge is observable must NOT flip the (not-yet-archived) session to
+  // REVIEW ERR. Seed the error streak at the cap boundary (errorRound 2, cap 3) so the no-stall
+  // assertion is discriminating: on the pre-fix code the error path bumps 2→3, crossing the cap
+  // and emitting a stall signal. With the fix the verdict is suppressed, so neither happens.
+  const {
+    deps: d,
+    reviews,
+    signals,
+  } = makeDeps(
+    { readVerdict: () => ({ decision: "junk", summary: "boom", body: "" }) }, // unparseable → error
+    { prStatus: async () => ({ ...OPEN_GREEN, state: "merged" }) },
+  );
+  reviews["s1"] = priorReview({ errorRound: 2, addressRound: 1 });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN); // spawn while open (no prStatus call yet)
+  await svc.tick(); // finalize: live recheck sees "merged" → moot error, suppressed
+  expect(reviews["s1"]?.decision).not.toBe("error"); // not overwritten with the moot error verdict
+  expect(reviews["s1"]?.errorRound).toBe(2); // NOT bumped to 3 (verdict wasn't persisted)
+  expect(signals.some((s) => s.kind === "stall")).toBe(false); // and no cap-crossing escalation
+});
+
+test("PR closed before finalize (error verdict): also suppressed, no escalation", async () => {
+  // Same suppression for closed-unmerged: the guard is state !== "open", not just merged.
+  const {
+    deps: d,
+    reviews,
+    signals,
+  } = makeDeps(
+    { readVerdict: () => ({ decision: "junk", summary: "boom", body: "" }) },
+    { prStatus: async () => ({ ...OPEN_GREEN, state: "closed" }) },
+  );
+  reviews["s1"] = priorReview({ errorRound: 2 });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.tick();
+  expect(reviews["s1"]?.errorRound).toBe(2); // suppressed → counter untouched
+  expect(signals.some((s) => s.kind === "stall")).toBe(false);
+});
+
 test("advancing into the cap marks the final round pending (not yet stalled)", async () => {
   const { deps: d, reviews } = makeDeps(
     {


### PR DESCRIPTION
## Problem

After a PR merges, a session **occasionally flips to REVIEW ERR** even though it hasn't been decommissioned yet.

**Cause — a race:** the critic spawn and the PR merge both fire on CI-green, so they race by construction. The critic can finish *after* the PR is already merged. When it finishes with a transient **error** verdict (timeout / unparseable), `finalize()` handled it differently from a real verdict:

- The **real-verdict** path routes through `publishVerdict()`, which rechecks the *live* PR state (`forge.prStatus`) and bails when the PR is `merged`/`closed`.
- The **error** path had **no such recheck** — it recorded escalation and then `finalize()` unconditionally `putReview()` + `onChange()`'d the verdict, flipping the not-yet-archived session to REVIEW ERR until `forget()`/`dropReview()` finally ran at archive.

## Fix

Give the error path the same live-state recheck (extracted as `finalizeErrorVerdict()` to keep `finalize` under the complexity gate):

- **Confirmed `merged`/`closed`** → the error is moot: don't persist it as session review state and don't escalate. `captureUsage` + the worktree/terminal reap still run.
- **Unconfirmable** (no forge / `prStatus` threw → `undefined`) → **fail open**: keep the existing persist + escalate, so a genuine critic error on a still-open PR is never hidden by a failed recheck.

Real-verdict persistence is unchanged (it's deliberate, locked by `review.test.ts` "verdict still persisted"). Suppression is post-merge only, where the `error`-decision consumers (auto-merge / autopilot gates) are already moot; archive/decommission (`merge-teardown.ts`) never reads the verdict, so nothing downstream regresses.

### Scope & tradeoffs (deliberate)
- **Fixes "must not flip once the merge is observable"** — the recheck is best-effort, matching the same residual race `publishVerdict()` already accepts: an error finalizing microseconds before the merge becomes observable still persists.
- **Fail-open accepts a residual occurrence** of the exact symptom (REVIEW ERR if the PR merged but `prStatus` couldn't confirm it). Chosen over fail-closed, which would silently drop real critic errors + stall escalation on still-open PRs whenever a forge fetch hiccups. The residual self-clears at archive.
- **Observability:** both branches `console.warn` (suppressed-post-merge vs kept-fail-open) so the field cause of any reported flip is distinguishable.
- Out of scope: clearing a *pre-merge* error verdict at merge time (a legit error that then merges stays visible until archive).

## Tests

Two regression tests in `test/review.test.ts`, seeded at the cap boundary (`errorRound: 2`, cap 3) so the no-stall assertion is **discriminating** — they fail on `main` (2→3 crosses the cap and emits a stall signal) and pass with the fix (verified by stashing the source):
- PR merged before finalize (error verdict) → not persisted, no escalation.
- PR closed before finalize (error verdict) → also suppressed.

## Verification
- `bun test ./test` — 4669 pass, 0 fail
- `bun run lint`, `bunx tsc --noEmit` — clean
- `fallow audit --base origin/main --fail-on-issues` — exit 0
- pre-push gate — passed

Server-only; no UI change. `[no-feature-entry]` — internal critic-lifecycle fix, ships no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)