### PR TITLE
fix(usage): re-capture extra-credit panel on /usage scrape

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -4898,6 +4898,11 @@ function livePtyTerminalId(
   }
 }
 
+/** The /usage refresh handler drives a multi-second ephemeral `claude` scrape and needs a longer
+ *  idle window than Bun's 10s default (see the fetch handler). */
+const isSlowScrapeRequest = (req: Request, url: URL): boolean =>
+  req.method === "POST" && url.pathname === "/api/usage/refresh";
+
 export function serve(deps: AppDeps, port: number) {
   const app = makeApp(deps);
   // current owning socket per terminal — a single owner avoids the takeover war
@@ -4957,6 +4962,10 @@ export function serve(deps: AppDeps, port: number) {
           ? undefined
           : new Response("upgrade failed", { status: 500 });
       }
+      // /usage refresh drives an ephemeral claude scrape (~24s worst case: boot + week wait +
+      // credits grace); lift Bun's 10s idle timeout for just this request so a slow scrape can't
+      // reset the connection into a false "Retry" on the gauge. Insurance — other endpoints unchanged.
+      if (isSlowScrapeRequest(req, url)) server.timeout(req, 60);
       return app.fetch(req);
     },
     websocket: {

--- a/src/usage-probe.ts
+++ b/src/usage-probe.ts
@@ -29,6 +29,14 @@ export const PROBE_NAME = "__usage_probe__";
  *     never advances and the gauge reads perpetually stale. Give credits a bounded grace (up to
  *     `creditTries`), returning the instant it parses. A true no-credit account simply waits the
  *     bounded grace and falls through to the same buffer — nothing is fabricated.
+ *
+ * The grace is intentionally a fixed bound rather than gated on a "has-credits" signal or an
+ * early-bail when the buffer stops growing: those save ~`creditTries`s only on no-credit accounts,
+ * whose grace is paid **solely by the background calibrate** (the manual REFRESH control lives in
+ * CreditDetail, rendered only when `credits != null`, so no user ever waits on it). An early-bail
+ * would also risk missing credits if the TUI pauses streaming between the week gauge and the panel
+ * below it — trading away the very reliability this wait exists to provide. Background-only latency
+ * isn't worth that.
  */
 export async function awaitUsageFrame(
   read: () => string,

--- a/src/usage-probe.ts
+++ b/src/usage-probe.ts
@@ -4,7 +4,7 @@ import { config } from "./config";
 import { compileCacheDir } from "./tmp-sweep";
 import { isApiKeyMode } from "./spawn-auth";
 
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 const decoder = new TextDecoder();
 
 /**
@@ -15,6 +15,34 @@ const decoder = new TextDecoder();
  * probe")` slugs to exactly that, so a user prompt could take the name and get killed mid-turn.
  */
 export const PROBE_NAME = "__usage_probe__";
+
+/**
+ * Wait for a usable `/usage` capture, then return the raw buffer (or null if the week window never
+ * rendered). Pure + injectable (`read` yields the live buffer, `sleep` the delay) so the gating
+ * logic is unit-testable without a real PTY.
+ *
+ * Two phases:
+ *  1. Wait (up to `weekTries`) for the weekly window's "Resets …" label — a pct-only partial render
+ *     would calibrate against a guessed anchor, so prefer the labelled frame.
+ *  2. The "Usage credits" panel renders BELOW the week gauge, so it streams into the buffer a cycle
+ *     or two AFTER week's label. Gating on week alone returns before credits lands → its snapshot
+ *     never advances and the gauge reads perpetually stale. Give credits a bounded grace (up to
+ *     `creditTries`), returning the instant it parses. A true no-credit account simply waits the
+ *     bounded grace and falls through to the same buffer — nothing is fabricated.
+ */
+export async function awaitUsageFrame(
+  read: () => string,
+  sleep: (ms: number) => Promise<void>,
+  weekTries = 12,
+  creditTries = 6,
+): Promise<string | null> {
+  const frame = () => parseUsageFrame(read(), 0);
+  for (let i = 0; i < weekTries && !frame().week?.resetLabel; i++) await sleep(1000);
+  // Skip the grace entirely when week never rendered (frame().week falsy) — there's nothing to wait
+  // for and the scrape has already failed.
+  for (let i = 0; i < creditTries && frame().week && !frame().credits; i++) await sleep(1000);
+  return frame().week ? read() : null;
+}
 
 /**
  * Drives an ephemeral interactive `claude`, sends `/usage`, and captures the rendered panel.
@@ -97,12 +125,8 @@ export class HerdrUsageProbe implements UsageProbe {
       for await (const _ of proc.stderr as ReadableStream<Uint8Array>) void _;
     })();
 
-    // Gate on whether the panel actually parses (parseUsageFrame strips ANSI before matching —
-    // a whitespace-only check fails since color codes sit between "Current" and "week"). Wait
-    // for the week's "Resets …" line too — a pct-only partial render calibrates against a
-    // guessed anchor — but fall back to pct-only if the label never shows up.
-    const week = () => parseUsageFrame(buf, 0).week;
-
+    // Drive the panel open, then hand off to awaitUsageFrame for the parse-gated wait (week label
+    // first, then a bounded grace for the trailing credits panel — see its docstring).
     try {
       // type the slash command, let the command menu register, THEN submit with Enter separately —
       // a combined "/usage\r" runs before the menu is ready and the panel never opens.
@@ -112,8 +136,7 @@ export class HerdrUsageProbe implements UsageProbe {
       await sleep(900);
       proc.stdin.write("\r");
       proc.stdin.flush();
-      for (let i = 0; i < 12 && !week()?.resetLabel; i++) await sleep(1000);
-      return week() ? buf : null;
+      return await awaitUsageFrame(() => buf, sleep);
     } catch {
       return null;
     } finally {

--- a/test/usage-probe.test.ts
+++ b/test/usage-probe.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "bun:test";
-import { HerdrUsageProbe, PROBE_NAME } from "../src/usage-probe";
+import { HerdrUsageProbe, PROBE_NAME, awaitUsageFrame } from "../src/usage-probe";
+import { parseUsageFrame } from "../src/usage-limits";
 import type { HerdrAgent } from "../src/herdr";
 import { config } from "../src/config";
 
@@ -73,4 +74,67 @@ test("scrape reaps leftover probe tabs and never touches real sessions", async (
   // …real sessions are left alone — the plain one and the "usage-probe"-slugged user session.
   expect(stopped).not.toContain("keep");
   expect(stopped).not.toContain("user");
+});
+
+// ── awaitUsageFrame: the credits-grace gate ──────────────────────────────────
+// Regression for the "extra-credit gauge stuck stale, refresh never clears it" bug. The wait used
+// to gate ONLY on the weekly window and return the instant week's "Resets …" line appeared — but
+// the "Usage credits" panel renders BELOW week and streams in a cycle later, so it was missed and
+// its snapshot never advanced. awaitUsageFrame now waits a bounded grace for credits after week.
+// The fake `read` evolves with the fake `sleep`'s step counter so the grace loop is genuinely
+// exercised (a static both-present buffer would pass without ever looping).
+
+const WEEK_ONLY = "Current week (all models)\n 50% used\nResets Jun 7 (Europe/Berlin)\n";
+const WEEK_PLUS_CREDITS =
+  WEEK_ONLY + "Esc to cancel\nUsage credits\n 64% used\n€79.16/€100.00 spent · Resets Jul 1 (x)\n";
+
+const hasCredits = (buf: string | null) => !!(buf && parseUsageFrame(buf, 0).credits);
+
+test("awaitUsageFrame waits the grace for credits that render a few cycles after week", async () => {
+  let step = 0;
+  const sleep = async () => {
+    step++;
+  };
+  // week+label is present immediately; credits only appears from the 3rd grace cycle on
+  const read = () => (step < 3 ? WEEK_ONLY : WEEK_PLUS_CREDITS);
+
+  const out = await awaitUsageFrame(read, sleep, 12, 6);
+
+  expect(hasCredits(out)).toBe(true); // captured credits — would have been null without the grace
+  expect(step).toBe(3); // grace actually looped until credits landed
+});
+
+test("awaitUsageFrame returns immediately when credits already rendered (no added latency)", async () => {
+  let sleeps = 0;
+  const sleep = async () => {
+    sleeps++;
+  };
+  const out = await awaitUsageFrame(() => WEEK_PLUS_CREDITS, sleep, 12, 6);
+
+  expect(hasCredits(out)).toBe(true);
+  expect(sleeps).toBe(0); // week + credits both present on the first read → no waiting at all
+});
+
+test("awaitUsageFrame falls through after a bounded grace on a true no-credit account", async () => {
+  let sleeps = 0;
+  const sleep = async () => {
+    sleeps++;
+  };
+  const out = await awaitUsageFrame(() => WEEK_ONLY, sleep, 12, 6);
+
+  expect(out).toBe(WEEK_ONLY); // week captured…
+  expect(hasCredits(out)).toBe(false); // …no credits fabricated
+  expect(sleeps).toBe(6); // grace is bounded (creditTries) — never hangs
+});
+
+test("awaitUsageFrame returns null and skips the grace when the week never renders", async () => {
+  let sleeps = 0;
+  const sleep = async () => {
+    sleeps++;
+  };
+  const out = await awaitUsageFrame(() => "", sleep, 12, 6);
+
+  expect(out).toBeNull(); // scrape failed — week absent
+  expect(sleeps).toBe(12); // waited out the week budget…
+  // …but no credits grace ran (week falsy) — 12, not 12+6
 });


### PR DESCRIPTION
## Problem

The **Usage credits** (extra-credit) gauge in the top bar stayed perpetually **stale** and clicking **REFRESH** never cleared it — while the session/week meters refreshed fine and **no error** was shown. Confirmed with the user: only credits stuck, no red "Retry".

## Root cause

The `/usage` scrape wait loop (`src/usage-probe.ts`) gated **only on the weekly window** and returned the buffer the instant week's "Resets …" line appeared. But the **"Usage credits" panel renders *below* the week gauge** in the TUI, so it streams into the buffer a render-cycle *later* and was missed:

`parseCredits → null → persistCredit no-op → credit snapshot's scrapedAt never advances → stale`

Because week *was* captured (`scraped === true`), the server returned HTTP 200 with no error — it just kept reading stale.

## Phase-0 spike (go/no-go, run before coding)

Two rival hypotheses produce the identical symptom; live evidence picked the winner:

- **H2 (parse/locale) ruled out** — the live snapshot has `spent: €79.16` (dot-decimal), which `parseCredits` handled fine. Not a comma-decimal format bug.
- **"Needs keypress" ruled out** — a snapshot was captured non-interactively before → credits renders on the default `/usage` screen.
- **H1 (render-timing) confirmed** — a live `POST /api/usage/refresh` returned **200 in 11s** with caps (`calibratedAt`) advancing, yet the credit snapshot stayed frozen **~2.8 days** old. Week captured, credits missed on a successful scrape — exactly the timing race.
- **Idle timeout ruled out as the cause** — the 11s refresh returned 200 (no reset), so Bun's 10s idle timeout is not firing here today.

> The standalone instrumented probe could not cleanly reproduce the timing locally (the spawned `claude` hit a folder-trust prompt that swallowed the `/usage` send — a known spawn gotcha; the long-running daemon is pre-trusted). The go decision rests on the live-daemon evidence above, which reflects real repeated behavior rather than one synthetic scrape.

## Fix

- **`src/usage-probe.ts`** — extract the wait into a pure, unit-testable `awaitUsageFrame(read, sleep, weekTries, creditTries)`. After the week reset-label wait, add an **unconditional bounded grace** that waits for the credits panel, returning the instant it parses. A true no-credit account simply waits the bounded grace and falls through to the same buffer (nothing fabricated); a failed scrape (no week) skips the grace and returns null. Unconditional (rather than gated on a "has-credits" signal) keeps it to one file, **fixes cold-start**, and is equivalent for no-credit accounts.
- **`src/server.ts`** — lift Bun's 10s idle timeout to 60s for just the refresh request (`server.timeout(req, 60)` via an extracted `isSlowScrapeRequest` predicate). **Insurance only** for the now-longer worst-case scrape — *not* the diagnosed cause (the predicate is extracted so the `fetch` handler stays under the fallow cognitive-complexity threshold).

## Tests

`test/usage-probe.test.ts` — 4 new cases for `awaitUsageFrame`, using a fake `read()` that **evolves with the fake `sleep`'s step counter** so the grace loop is genuinely exercised: credits-appears-late (captured, grace ran), already-present (no added latency), no-credit (bounded grace, no hang), nothing-renders (null, grace skipped).

## Verification

- `bun run lint` ✓ · `bunx tsc --noEmit` ✓ · `bun test ./test` ✓ (4657 pass, 0 fail) · `bunx fallow audit --base origin/main` ✓ (no issues in changed files)
- Branch cut from latest `origin/main`, linear.

No UI/i18n/feature-catalog/glossary/design-system impact (`fix`, server-side only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)