### PR TITLE
feat(viewport): offer to decommission a session after a manual PR merge

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1890,5 +1890,7 @@
   "settings_tui_disable_mouse_save_failed": "Einstellung für die Mauserfassung konnte nicht geändert werden.",
   "feat_tui_fullscreen_title": "Vollbild-Renderer (experimentell)",
   "feat_tui_fullscreen_body": "Agent-Sitzungen können jetzt in den Vollbild-Renderer von Claude Code gewechselt werden — erreichbar unter Einstellungen → Sitzung. Ermöglicht einen flacheren Speicherverbrauch bei langen autonomen Läufen. Forschungsvorschau (standardmäßig deaktiviert), gilt für neu gestartete oder fortgesetzte Sitzungen.",
-  "gitrail_decommission_action": "Stilllegen"
+  "gitrail_decommission_action": "Stilllegen",
+  "feat_decommission_on_merge_title": "Stilllegen nach dem Merge",
+  "feat_decommission_on_merge_body": "Nachdem du den PR einer Session gemerged hast, bietet die Bestätigungsmeldung jetzt ein Ein-Klick-Stilllegen, um die abgeschlossene Session zu entfernen – kein Suchen nach dem Button mehr."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1889,5 +1889,6 @@
   "settings_tui_disable_mouse_hint": "Verhindert, dass Claude Code die Maus im Agenten-Terminal erfasst. Gilt für neu gestartete oder fortgesetzte Sitzungen.",
   "settings_tui_disable_mouse_save_failed": "Einstellung für die Mauserfassung konnte nicht geändert werden.",
   "feat_tui_fullscreen_title": "Vollbild-Renderer (experimentell)",
-  "feat_tui_fullscreen_body": "Agent-Sitzungen können jetzt in den Vollbild-Renderer von Claude Code gewechselt werden — erreichbar unter Einstellungen → Sitzung. Ermöglicht einen flacheren Speicherverbrauch bei langen autonomen Läufen. Forschungsvorschau (standardmäßig deaktiviert), gilt für neu gestartete oder fortgesetzte Sitzungen."
+  "feat_tui_fullscreen_body": "Agent-Sitzungen können jetzt in den Vollbild-Renderer von Claude Code gewechselt werden — erreichbar unter Einstellungen → Sitzung. Ermöglicht einen flacheren Speicherverbrauch bei langen autonomen Läufen. Forschungsvorschau (standardmäßig deaktiviert), gilt für neu gestartete oder fortgesetzte Sitzungen.",
+  "gitrail_decommission_action": "Stilllegen"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1889,5 +1889,6 @@
   "settings_tui_disable_mouse_hint": "Stop Claude Code from capturing the mouse in the agent terminal. Applies to newly started or resumed sessions.",
   "settings_tui_disable_mouse_save_failed": "Couldn't change the mouse-capture setting.",
   "feat_tui_fullscreen_title": "Fullscreen renderer (experimental)",
-  "feat_tui_fullscreen_body": "You can now opt agent sessions into Claude Code's fullscreen renderer from Settings → Session, for flatter memory on long autonomous runs. It's a research preview (off by default) and applies to newly started or resumed sessions."
+  "feat_tui_fullscreen_body": "You can now opt agent sessions into Claude Code's fullscreen renderer from Settings → Session, for flatter memory on long autonomous runs. It's a research preview (off by default) and applies to newly started or resumed sessions.",
+  "gitrail_decommission_action": "Decommission"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1890,5 +1890,7 @@
   "settings_tui_disable_mouse_save_failed": "Couldn't change the mouse-capture setting.",
   "feat_tui_fullscreen_title": "Fullscreen renderer (experimental)",
   "feat_tui_fullscreen_body": "You can now opt agent sessions into Claude Code's fullscreen renderer from Settings → Session, for flatter memory on long autonomous runs. It's a research preview (off by default) and applies to newly started or resumed sessions.",
-  "gitrail_decommission_action": "Decommission"
+  "gitrail_decommission_action": "Decommission",
+  "feat_decommission_on_merge_title": "Decommission after merge",
+  "feat_decommission_on_merge_body": "After you merge a session's PR, the confirmation toast now offers a one-click Decommission to tear the finished session down — no hunting for the button."
 }

--- a/ui/src/lib/components/GitRail.browser.test.ts
+++ b/ui/src/lib/components/GitRail.browser.test.ts
@@ -1307,3 +1307,97 @@ describe("GitRail — Open PR hidden under autopilot", () => {
     );
   });
 });
+
+describe("GitRail — post-merge decommission offer", () => {
+  const mergePrFn = vi.fn();
+
+  beforeEach(() => {
+    toastsInfo.mockClear();
+    mergePrFn.mockClear();
+  });
+
+  // Helper: arm and confirm the merge button (two-click pattern used across the suite)
+  async function armAndConfirmMerge(h: HTMLElement) {
+    const mergeBtn = await vi.waitFor(() => {
+      const btn = h.querySelector<HTMLButtonElement>("button.gbtn:not(.auto-pill)");
+      expect(btn, "merge button present").not.toBeNull();
+      return btn!;
+    });
+    mergeBtn.click();
+    await vi.waitFor(() => {
+      const btn = h.querySelector<HTMLButtonElement>("button.gbtn:not(.auto-pill)");
+      expect(btn?.textContent?.toLowerCase()).toMatch(/confirm/);
+    });
+    h.querySelector<HTMLButtonElement>("button.gbtn:not(.auto-pill)")!.click();
+  }
+
+  it("remote-forge merge shows decommission offer with the merged session id", async () => {
+    // mergePr returns a github-kind merged status
+    const { mergePr: mergePrMock } = await import("$lib/api");
+    (mergePrMock as ReturnType<typeof vi.fn>).mockResolvedValue({
+      kind: "github",
+      state: "merged",
+      checks: "none",
+      deployConfigured: false,
+    });
+    gitStateFn.mockResolvedValue(openPrState);
+
+    const ondecommission = vi.fn();
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, {
+      target: h,
+      props: { ...baseProps, sessionId: "sess-A", mobile: false, ondecommission },
+    });
+    await expect.element(screen.getByTitle("PR #12345")).toBeVisible();
+
+    await armAndConfirmMerge(h);
+
+    // Wait for toasts.info to be called
+    await vi.waitFor(() => expect(toastsInfo).toHaveBeenCalledTimes(1));
+
+    // The toast must have an action with the decommission label
+    const [, opts] = toastsInfo.mock.calls[0] as [
+      string,
+      { action?: { label: string; run: () => void }; duration?: number; key?: string },
+    ];
+    expect(opts?.action, "toast has action").toBeDefined();
+    expect(opts?.duration, "toast has 15s duration").toBe(15_000);
+    expect(opts?.key, "toast has decommission key").toBe("decommission-offer:sess-A");
+
+    // Invoking the action must call ondecommission with the CAPTURED id ("sess-A"),
+    // not whatever session might be focused at click time.
+    opts!.action!.run();
+    expect(ondecommission, "ondecommission called with captured id").toHaveBeenCalledWith("sess-A");
+  });
+
+  it("local-forge merge → no decommission offer action", async () => {
+    const { mergePr: mergePrMock } = await import("$lib/api");
+    (mergePrMock as ReturnType<typeof vi.fn>).mockResolvedValue({
+      kind: "local",
+      state: "merged",
+      checks: "none",
+      deployConfigured: false,
+    });
+    gitStateFn.mockResolvedValue(openPrState);
+
+    const ondecommission = vi.fn();
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, {
+      target: h,
+      props: { ...baseProps, sessionId: "sess-B", mobile: false, ondecommission },
+    });
+    await expect.element(screen.getByTitle("PR #12345")).toBeVisible();
+
+    await armAndConfirmMerge(h);
+
+    await vi.waitFor(() => expect(toastsInfo).toHaveBeenCalledTimes(1));
+
+    const call = toastsInfo.mock.calls[0] as [string, ({ action?: unknown } | undefined)?];
+    // local-forge toast: plain call with no action opts, OR opts without action
+    const opts = call[1];
+    expect(opts?.action ?? undefined, "no action on local-forge toast").toBeUndefined();
+    expect(ondecommission, "ondecommission never invoked").not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -38,6 +38,7 @@
     drain = null,
     autopilotOn = false,
     issueNumber = null,
+    ondecommission = undefined,
   }: {
     sessionId: string;
     repoPath?: string;
@@ -58,6 +59,8 @@
     /** Backlog issue this session was spawned for; drives the leftmost open-issue link.
         null = no linked issue. */
     issueNumber?: number | null;
+    /** Offer to tear down THIS session after its PR is merged; called with the merged session's id. */
+    ondecommission?: (id: string) => void;
   } = $props();
 
   let git = $state<GitState | null>(null);
@@ -268,8 +271,17 @@
     err = null;
     retry = null;
     try {
+      const mergedId = sessionId;
       git = { kind: git?.kind ?? "github", ...(await mergePr(sessionId)) };
-      toasts.info(m.toast_merged({ name: name || sessionId }));
+      if (git.kind === "local") {
+        toasts.info(m.toast_merged({ name: name || mergedId }));
+      } else {
+        toasts.info(m.toast_merged({ name: name || mergedId }), {
+          action: { label: m.gitrail_decommission_action(), run: () => ondecommission?.(mergedId) },
+          duration: 15_000,
+          key: `decommission-offer:${mergedId}`,
+        });
+      }
       // A non-isolated session has its feature branch checked out in the canonical
       // clone, so there's no separate default-branch checkout to fast-forward — the
       // offer would always report wrong_branch. Only offer for isolated sessions.

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -584,6 +584,7 @@
   // leftover subprocesses still running from this session — populated on the
   // confirming click; a non-empty list pops the dialog instead of closing outright.
   let leftovers = $state<Leftover[]>([]);
+  let decomTarget = $state<string | null>(null);
   $effect(() => {
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- touch reactive dep
     unitId; // on unit switch: disarm decommission + default back to terminal tab
@@ -615,6 +616,18 @@
     if (!hasPreview && tab === "preview") tab = "term";
   });
   $effect(() => () => clearTimeout(armTimer));
+  async function confirmDecommission(id: string) {
+    // only interrupt the close with the dialog when something is actually still
+    // running; a probe failure must never block decommission, so fall through to close.
+    const found = await getLeftovers(id).catch(() => [] as Leftover[]);
+    if (found.length === 0) {
+      onarchive?.(id);
+      return;
+    }
+    decomTarget = id;
+    leftovers = found;
+  }
+
   async function decommission() {
     if (!armed) {
       armed = true;
@@ -624,14 +637,7 @@
     }
     clearTimeout(armTimer);
     armed = false;
-    // only interrupt the close with the dialog when something is actually still
-    // running; a probe failure must never block decommission, so fall through to close.
-    const found = await getLeftovers(session.id).catch(() => [] as Leftover[]);
-    if (found.length === 0) {
-      onarchive?.(session.id);
-      return;
-    }
-    leftovers = found;
+    confirmDecommission(session.id);
   }
 
   // ── rename: ✎ click or title double-tap opens an inline editor; Enter/blur commits, Esc cancels ──
@@ -1978,6 +1984,7 @@
         {drain}
         autopilotOn={autopilotEffective}
         issueNumber={session.issueNumber}
+        ondecommission={confirmDecommission}
         mobile
       />
       <span class="strip-controls">
@@ -2213,11 +2220,11 @@
     {leftovers}
     onclose={() => {
       leftovers = [];
-      onarchive?.(session.id);
+      onarchive?.(decomTarget ?? session.id);
     }}
     onconfirm={(keys) => {
       leftovers = [];
-      onarchive?.(session.id, keys);
+      onarchive?.(decomTarget ?? session.id, keys);
     }}
   />
 {/if}

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -590,6 +590,7 @@
     unitId; // on unit switch: disarm decommission + default back to terminal tab
     armed = false;
     leftovers = [];
+    decomTarget = null; // drop any captured decommission target from the prior unit
     tab = "term";
     ended = false;
     resumeFailed = false;

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2220,12 +2220,16 @@
   <LeftoverDialog
     {leftovers}
     onclose={() => {
+      const target = decomTarget ?? session.id;
       leftovers = [];
-      onarchive?.(decomTarget ?? session.id);
+      decomTarget = null;
+      onarchive?.(target);
     }}
     onconfirm={(keys) => {
+      const target = decomTarget ?? session.id;
       leftovers = [];
-      onarchive?.(decomTarget ?? session.id, keys);
+      decomTarget = null;
+      onarchive?.(target, keys);
     }}
   />
 {/if}

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1526,4 +1526,15 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_tui_fullscreen_title",
     bodyKey: "feat_tui_fullscreen_body",
   },
+  {
+    // After you manually merge a session's PR, the "Merged" toast now offers a one-click
+    // Decommission action to tear down that finished session (stop the agent, remove the
+    // worktree) without hunting for the decommission button. No targetId — the offer is a
+    // transient toast with no persistent anchor; surface via the What's-New drawer only.
+    // v1.36.0 is the latest released tag → ships in 1.37.0.
+    id: "decommission-on-merge",
+    sinceVersion: "1.37.0",
+    titleKey: "feat_decommission_on_merge_title",
+    bodyKey: "feat_decommission_on_merge_body",
+  },
 ];


### PR DESCRIPTION
## What

After an operator manually merges a session's PR via the GitRail **Merge** button on a **remote forge** (GitHub/Gitea), the "Merged {name}" toast now carries a one-click **Decommission** action (15s) that tears the finished session down through the existing leftover-probe + undo-window flow.

## Why

Verified gap: for an **attended (non-auto) session on a remote forge**, `drain.onGit()` early-returns (`if (!s.auto) return`) and no other poller archives on merge — the session lingered as `running` until the operator hunted down the decommission button. (Local-forge merges already archive synchronously via `settleMergedSession`; auto/full-auto sessions are reaped by drain/automerge.)

## How

Mirrors the existing `offerUpdateMain` pattern: a `toasts.info` with an `action`, 15s duration, per-session dedupe key.

- **GitRail** gains an `ondecommission?: (id: string) => void` prop. On a successful **remote-forge** merge, `doMerge()` captures `const mergedId = sessionId` and the toast action closes over `mergedId`. Local-forge (`git.kind === "local"`) keeps the plain toast — no offer (session already gone).
- **Viewport** extracts `confirmDecommission(id)` (id-explicit leftover probe + `onarchive`), adds a `decomTarget` state var, re-points the LeftoverDialog handlers at the captured target, and wires `ondecommission={confirmDecommission}` into GitRail.
- New i18n key `gitrail_decommission_action` (EN/DE) + What's-New feature-catalog entry (`sinceVersion 1.37.0`).

### Crux: no stale-focus teardown

The offer outlives focus changes, so the merged session id is **captured at toast-creation** and threaded explicitly end-to-end (`ondecommission(id)` → `confirmDecommission(id)` → `getLeftovers(id)`/`onarchive(id)` → LeftoverDialog via `decomTarget`). No code on this path reads the reactive `session.id`. A browser test asserts the **id argument** passed to `ondecommission` (not merely that it was called), locking this in.

## Tests / gates

- `GitRail.browser.test.ts`: remote-forge merge surfaces the action and invokes `ondecommission("sess-A")`; local-forge merge surfaces no action.
- `bun run check`, `check:i18n` (1885 keys, parity), branch-hygiene, feature-catalog, pre-push fallow audit — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)