### PR TITLE
feat(viewport): pinned ⤓ jump-to-latest key on mobile control bar

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1892,5 +1892,7 @@
   "feat_tui_fullscreen_body": "Agent-Sitzungen können jetzt in den Vollbild-Renderer von Claude Code gewechselt werden — erreichbar unter Einstellungen → Sitzung. Ermöglicht einen flacheren Speicherverbrauch bei langen autonomen Läufen. Forschungsvorschau (standardmäßig deaktiviert), gilt für neu gestartete oder fortgesetzte Sitzungen.",
   "gitrail_decommission_action": "Stilllegen",
   "feat_decommission_on_merge_title": "Stilllegen nach dem Merge",
-  "feat_decommission_on_merge_body": "Nachdem du den PR einer Session gemerged hast, bietet die Bestätigungsmeldung jetzt ein Ein-Klick-Stilllegen, um die abgeschlossene Session zu entfernen – kein Suchen nach dem Button mehr."
+  "feat_decommission_on_merge_body": "Nachdem du den PR einer Session gemerged hast, bietet die Bestätigungsmeldung jetzt ein Ein-Klick-Stilllegen, um die abgeschlossene Session zu entfernen – kein Suchen nach dem Button mehr.",
+  "feat_scroll_to_end_key_title": "Taste „Zum Ende springen“",
+  "feat_scroll_to_end_key_body": "Die mobile Terminal-Steuerleiste erhält neben „Anhängen“ eine fest verankerte ⤓-Taste, die zur neuesten Ausgabe springt – analog zu Strg+Ende in Claude Code, immer erreichbar, auch wenn du nicht hochgescrollt bist."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1894,5 +1894,5 @@
   "feat_decommission_on_merge_title": "Stilllegen nach dem Merge",
   "feat_decommission_on_merge_body": "Nachdem du den PR einer Session gemerged hast, bietet die Bestätigungsmeldung jetzt ein Ein-Klick-Stilllegen, um die abgeschlossene Session zu entfernen – kein Suchen nach dem Button mehr.",
   "feat_scroll_to_end_key_title": "Taste „Zum Ende springen“",
-  "feat_scroll_to_end_key_body": "Die mobile Terminal-Steuerleiste erhält neben „Anhängen“ eine fest verankerte ⤓-Taste, die zur neuesten Ausgabe springt – analog zu Strg+Ende in Claude Code, immer erreichbar, auch wenn du nicht hochgescrollt bist."
+  "feat_scroll_to_end_key_body": "Die mobile Terminal-Steuerleiste erhält eine fest verankerte ⤓-Taste, die zur neuesten Ausgabe springt – analog zu Strg+Ende in Claude Code, immer erreichbar, auch wenn du nicht hochgescrollt bist."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1892,5 +1892,7 @@
   "feat_tui_fullscreen_body": "You can now opt agent sessions into Claude Code's fullscreen renderer from Settings → Session, for flatter memory on long autonomous runs. It's a research preview (off by default) and applies to newly started or resumed sessions.",
   "gitrail_decommission_action": "Decommission",
   "feat_decommission_on_merge_title": "Decommission after merge",
-  "feat_decommission_on_merge_body": "After you merge a session's PR, the confirmation toast now offers a one-click Decommission to tear the finished session down — no hunting for the button."
+  "feat_decommission_on_merge_body": "After you merge a session's PR, the confirmation toast now offers a one-click Decommission to tear the finished session down — no hunting for the button.",
+  "feat_scroll_to_end_key_title": "Jump-to-latest key",
+  "feat_scroll_to_end_key_body": "The mobile terminal control bar gains a pinned ⤓ key next to attach that jumps to the latest output, mirroring Claude Code's Ctrl+End — always reachable, even when you're not scrolled up."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1894,5 +1894,5 @@
   "feat_decommission_on_merge_title": "Decommission after merge",
   "feat_decommission_on_merge_body": "After you merge a session's PR, the confirmation toast now offers a one-click Decommission to tear the finished session down — no hunting for the button.",
   "feat_scroll_to_end_key_title": "Jump-to-latest key",
-  "feat_scroll_to_end_key_body": "The mobile terminal control bar gains a pinned ⤓ key next to attach that jumps to the latest output, mirroring Claude Code's Ctrl+End — always reachable, even when you're not scrolled up."
+  "feat_scroll_to_end_key_body": "The mobile terminal control bar gains a pinned ⤓ key that jumps to the latest output, mirroring Claude Code's Ctrl+End — always reachable, even when you're not scrolled up."
 }

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2177,6 +2177,7 @@
     {touch}
     {tab}
     send={(seq) => conn?.send(seq)}
+    {scrollToBottom}
     {notesKey}
     {enter}
     {uploading}

--- a/ui/src/lib/components/viewport/ViewportTermControls.svelte
+++ b/ui/src/lib/components/viewport/ViewportTermControls.svelte
@@ -11,6 +11,7 @@
     touch,
     tab,
     send,
+    scrollToBottom,
     notesKey,
     enter,
     uploading,
@@ -22,6 +23,7 @@
     touch: boolean;
     tab: string;
     send: (seq: string) => void;
+    scrollToBottom: () => void;
     notesKey: string | null;
     enter: ControlKey;
     uploading: boolean;
@@ -112,6 +114,19 @@
          compose sheet. -->
     <ControlBar onkey={(seq) => send(seq)} include={["cancel"]} scroll={false} />
     <ControlBar onkey={(seq) => send(seq)} include={["edit", "nav", "signal"]} />
+    <!-- jump-to-latest, pinned so it never scrolls off the palette. Reuses the
+         smart scrollToBottom() (sends Ctrl+End when the agent owns the scroll, else
+         xterm's native scroll) — mirrors the floating ↓ banner, but always reachable. -->
+    <button
+      type="button"
+      class="scroll-end"
+      title={m.viewport_scroll_to_bottom()}
+      aria-label={m.viewport_scroll_to_bottom()}
+      onpointerup={(e) => {
+        e.preventDefault();
+        scrollToBottom();
+      }}>⤓</button
+    >
     <!-- only while Claude's prompt offers it: a pulsing "add notes" key. There's
          no keyboard on a phone to press the letter, so this is the sole way into
          the dialog's notes branch; it pulses to catch the eye and vanishes once
@@ -231,6 +246,7 @@
     background: var(--color-head);
     border-top: 1px solid var(--color-line);
   }
+  .ctrl-row .scroll-end,
   .ctrl-row .dictate,
   .ctrl-row .attach,
   .ctrl-row .enter {
@@ -249,6 +265,7 @@
       background 0.08s,
       border-color 0.08s;
   }
+  .ctrl-row .scroll-end:active,
   .ctrl-row .dictate:active,
   .ctrl-row .attach:active,
   .ctrl-row .enter:active {

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1537,4 +1537,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_decommission_on_merge_title",
     bodyKey: "feat_decommission_on_merge_body",
   },
+  {
+    // The mobile terminal control bar gains a pinned ⤓ "jump to latest" key next to attach,
+    // mirroring Claude Code's Ctrl+End scroll-to-bottom — always reachable, unlike the floating
+    // ↓ that only appears when scrolled up. No targetId — the control bar mounts on mobile/touch
+    // only; surface via the What's-New drawer only. v1.36.0 is the latest released tag → ships in 1.37.0.
+    id: "mobile-scroll-to-end-key",
+    sinceVersion: "1.37.0",
+    titleKey: "feat_scroll_to_end_key_title",
+    bodyKey: "feat_scroll_to_end_key_body",
+  },
 ];

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1538,10 +1538,10 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_decommission_on_merge_body",
   },
   {
-    // The mobile terminal control bar gains a pinned ⤓ "jump to latest" key next to attach,
-    // mirroring Claude Code's Ctrl+End scroll-to-bottom — always reachable, unlike the floating
-    // ↓ that only appears when scrolled up. No targetId — the control bar mounts on mobile/touch
-    // only; surface via the What's-New drawer only. v1.36.0 is the latest released tag → ships in 1.37.0.
+    // The mobile terminal control bar gains a pinned ⤓ "jump to latest" key in the right-hand
+    // action cluster, mirroring Claude Code's Ctrl+End scroll-to-bottom — always reachable, unlike
+    // the floating ↓ that only appears when scrolled up. No targetId — the control bar mounts on
+    // mobile/touch only; surface via the What's-New drawer only. v1.36.0 is the latest released tag → ships in 1.37.0.
     id: "mobile-scroll-to-end-key",
     sinceVersion: "1.37.0",
     titleKey: "feat_scroll_to_end_key_title",


### PR DESCRIPTION
## What

Adds a pinned **⤓ "jump to latest"** button to the mobile terminal control bar (the key bar), mirroring Claude Code's recent `Ctrl+End` (`scroll:bottom`) shortcut.

![placement] `[Esc] | ←→↑↓ ^A^E^U^C^D (scrolls) | [⤓][📎][⏎]` — `⤓` is pinned in the right-hand action cluster, so it never scrolls off the palette.

## Why this shape

- **Reuses the existing smart `scrollToBottom()`** (`Viewport.svelte`) — the same logic the floating `↓` banner uses. It sends `\x1b[1;5F` (Ctrl+End) when the agent owns the scroll (`agentOwnsScroll`) and falls back to xterm's native `term.scrollToBottom()` otherwise, so it's correct under **both** the classic and the opt-in fullscreen renderer (#1055). No raw-byte injection that would no-op in a plain shell.
- **Pinned, not a scrolling palette key.** A `nav`-group palette key can scroll out of reach on a narrow phone, and would have needed a `ControlAction`/`onaction`/`ControlBar.tap()` refactor + `controlKeys` test churn. The pinned button touches only `ViewportTermControls.svelte` + `Viewport.svelte`, reuses the shared `.ctrl-row` button recipe (no new tokens/literals), and reuses the existing `viewport_scroll_to_bottom` i18n string for its label.
- **Always present (intended).** The floating `↓` overlay only appears when scrolled up; this is a persistent, discoverable key-bar affordance. No-op at the bottom is harmless (re-enables auto-follow).

Mobile/touch-only by design — desktop users press `Ctrl+End` directly.

## Changes

- `ViewportTermControls.svelte` — `scrollToBottom` prop + pinned `⤓` button (shared pinned-button style).
- `Viewport.svelte` — pass `scrollToBottom` through.
- `feature-announcements.ts` + `en.json`/`de.json` — one catalog entry (`mobile-scroll-to-end-key`, `sinceVersion 1.37.0`) with EN+DE title/body.

## Verification

- `cd ui && bun run check` → 0 errors
- `bun run check:i18n` → locales in parity
- `bun run test` → 2030 passed
- pre-push gates (branch-hygiene, i18n, feature-catalog, fallow) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)