### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs-site/src/content/docs/reference/glossary.md
+++ b/docs-site/src/content/docs/reference/glossary.md
@@ -42,6 +42,25 @@ A repo Shepherd drives with local git only — no Forge, no GitHub, no PRs, no
 remote. When a task finishes, the agent's branch is squash-merged into the base
 branch locally; the operator pushes to a remote when they choose.
 
+### Trial
+
+A proposed house rule auto-promoted to active on strong, multi-source evidence,
+injected at lowest priority while it proves itself. It is auto-removed if it
+underperforms (Wilson auto-retire) or stays inert, and can be reverted to the
+queue by hand.
+
+### Weighted units
+
+A model-weighted measure of token spend that counts what actually draws down your
+subscription limits — output tokens cost far more than cached reads, so weighted
+units, not raw token counts, reflect true usage.
+
+### Satellite pass
+
+An automated LLM pass Shepherd spawns alongside the main task agent — critic /
+PR-review, plan-gate, recap, rundown, or doc-agent. Its token spend is real
+overhead attributed back to the task, on top of the agent's own authoring.
+
 ## Industry terms
 
 ### PR


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc-update summary

## Changes

- **`docs-site/src/content/docs/reference/glossary.md`** — added three "Shepherd
  concepts" entries (**Trial**, **Weighted units**, **Satellite pass**) that exist
  in the glossary registry (`ui/src/lib/glossary.ts`) but were never carried into
  the doc. The doc opens by stating its definitions mirror that registry, and the
  three terms were added to the registry *after* the doc was created (#908):
  `trial` in #946 (`f97cee03`), `weighted-units` and `satellite-pass` in #954
  (`1e2792cc`). Definitions are copied verbatim from the message catalog
  (`ui/messages/en.json`: `gloss_trial_def`, `gloss_weighted_units_def`,
  `gloss_satellite_pass_def`), matching how the doc's existing entries already
  mirror that catalog word-for-word. Inserted after "Lightweight repo" (registry
  order) and before the "Industry terms" section, since all three are `internal`
  terms.

## Uncertain / needs human judgment

- **`docs-site/src/content/docs/reference/configuration.md`** — the page's
  frontmatter description claims it documents "Every environment variable," but
  `src/config.ts` reads many env vars the page omits (e.g. `SHEPHERD_AUTH_MODE`,
  `SHEPHERD_API_KEY_HELPER_PATH`, `SHEPHERD_DEFAULT_MODEL`,
  `SHEPHERD_FABLE_AVAILABLE`, `SHEPHERD_REVIEW_CYCLES_CAP`,
  `SHEPHERD_PLAN_REVIEW_CYCLES_CAP`, `SHEPHERD_AUTOPILOT_STEP_CAP`,
  `SHEPHERD_EXTRA_CREDITS_DRAIN_CEILING`, `SHEPHERD_AUTOMERGE_REBASE_CAP`,
  `SHEPHERD_PUSH_COOLDOWN_MS`, `SHEPHERD_REDUCED_PUSH_MODE`,
  `SHEPHERD_REMOTE_CONTROL_AT_STARTUP`, `SHEPHERD_HOOKS_INGEST`/`_SIGNALS`,
  `SHEPHERD_LLM_NAMING`, `SHEPHERD_NAMER_MODEL`, `SHEPHERD_SESSION_HOUSEKEEPING`,
  `SHEPHERD_HOUSE_RULES_BUDGET_CHARS`, `SHEPHERD_STANDARD_COMMAND`,
  `SHEPHERD_VAPID_*`, `SHEPHERD_NODE_BIN`, `CLAUDE_CONFIG_DIR`,
  `CLAUDE_PROJECTS_DIR`, `SHEPHERD_HERDR_UPDATE_LOG`, `SHEPHERD_SANDBOX_EXTRA_HOSTS`).
  This gap is **not** the result of a recent change — the page has documented a
  curated subset since it was created — so I did not treat it as "stale vs. a
  recent source change" and left it untouched. Whether to expand the page to a
  truly exhaustive table (or soften the "Every environment variable" framing) is
  an editorial call for a human.

- Pages reviewed and found **current**: `docs/external-task-api.md` (request
  schema/models match `src/types.ts` `MODELS` and `src/validate.ts`; usage-hold
  behavior matches `src/usage-hold.ts`), `docs/sandbox-security.md` (synced today
  in `9c0525b1`; no `src/sandbox.ts`/`egress.ts`/`service.ts`/`autopilot.ts`/
  `reviewer-argv.ts` changes since), `docs/token-usage-analysis.md` (pricing
  weights still match `src/pricing.ts`), `configuration.md` core/TUI/usage-hold
  rows (match `src/config.ts` at HEAD), `index.md`, `getting-started.md`,
  `operating.md`. No edits made to these.