### PR TITLE
feat(manual-steps): detect + surface manual operator steps from PRs (#1059)

### DIFF
--- a/src/hold-service.test.ts
+++ b/src/hold-service.test.ts
@@ -51,6 +51,8 @@ function makeSession(overrides: Partial<Session> = {}): Session {
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
     completionRepromptCount: 0,
     ...overrides,
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import { scanClaudeAliveByWorktree } from "./process-reaper";
 import { serve, serveAgentIngress, buildBacklogPayload, type AppDeps } from "./server";
 import { makeProductionForgeResolver } from "./forge/resolve";
 import { EmptyDiffError, type GitState } from "./forge/types";
+import { parseManualSteps } from "./manual-steps";
 import { annotateHandoff } from "./repo-roles";
 import { AccountUsageIndex, SessionUsageRollup } from "./usage";
 import { UsageLimitsService, calibrateDelay, type UsageLimits } from "./usage-limits";
@@ -529,6 +530,39 @@ events.subscribe((event, data) => {
   if (event !== "session:status") return;
   const { id, status } = data as { id: string; status: string };
   if (status !== "running") prPoller.pollSession(id);
+});
+
+// Manual operator steps (#1059): when a session's PR body is (re)fetched, parse any
+// shepherd:manual-steps carrier + `Manual-Step:` trailers and persist them on the session, so the
+// backlog chip + Done recap surface them. Throttled on head SHA so we don't re-`gh pr view` on
+// every CI/review transition (`session:git` fires on each one) — mirrors drain.ts's
+// ≤1/child/~60s prReviewMeta throttle. In-memory marker → at most one re-fetch per session after
+// a restart. Persist + push only when the parsed steps differ from what's stored.
+const manualStepsHeadSeen = new Map<string, string>();
+const detectAndPersistManualSteps = async (id: string, prNumber: number): Promise<void> => {
+  const s = store.get(id);
+  if (!s) return;
+  const forge = resolveForge(s.repoPath);
+  if (!forge?.prReviewMeta) return; // no forge / host without a PR-body API (e.g. Gitea) — skip
+  try {
+    const meta = await forge.prReviewMeta(prNumber);
+    if (!meta) return;
+    const steps = parseManualSteps(meta.body);
+    if (JSON.stringify(steps) === JSON.stringify(s.manualSteps)) return;
+    store.setSessionManualSteps(id, steps);
+    events.emit("session:manual-steps", { id, manualSteps: steps });
+  } catch (err) {
+    console.warn(`[manual-steps] detection for ${id} pr#${prNumber} failed:`, err);
+  }
+};
+events.subscribe((event, data) => {
+  if (event !== "session:git") return;
+  const { id, git } = data as { id: string; git: GitState };
+  if (git.number == null || (git.state !== "open" && git.state !== "merged")) return;
+  const headSha = git.headSha ?? "";
+  if (manualStepsHeadSeen.get(id) === headSha) return; // unchanged head — skip the fetch
+  manualStepsHeadSeen.set(id, headSha);
+  void detectAndPersistManualSteps(id, git.number);
 });
 
 // Drive tailscale serve mappings: register when a preview port binds, unregister

--- a/src/manual-steps.ts
+++ b/src/manual-steps.ts
@@ -1,0 +1,132 @@
+/**
+ * Manual-operator-step carrier parsing (#1059, epic #1056 P1).
+ *
+ * Manual operator steps = work a human must do around merge/deploy that the diff itself can't
+ * perform (flip a feature flag, set an env var, run a one-off backfill, restart a worker, DNS
+ * cutover, seed a record). Today they live only in PR prose and are silently lost when auto-merge
+ * or an inattentive operator lands the PR and archives the session. This module is the PURE
+ * detection half: given a PR body, it returns the structured steps so the band can surface them
+ * on the backlog row + carry them into the Done recap. NO I/O — the forge supplies the body.
+ *
+ * Two carriers, both read from the single already-fetched PR body (no extra I/O, no new forge
+ * method):
+ *  1. PRIMARY — a fenced ```shepherd:manual-steps block: each `- [ ]` / `- [x]` line is a step.
+ *  2. ADDITIVE — `Manual-Step:` trailer-form lines anchored at column 0 (outside the fence), so a
+ *     `Manual-Step:` substring quoted inside prose or a blockquote can't match.
+ * A leading `POST-MERGE:` (case-insensitive) on either form marks the step post-merge.
+ *
+ * Commit-message git trailers (which would need a new forge.prCommits() + squash-survival
+ * analysis) are intentionally out of scope here — a follow-up.
+ */
+
+/** Stable parsed shape persisted on the session + carried into the recap checklist. */
+export interface ManualStep {
+  /** Deterministic id by final output order (`ms1`, `ms2`, …) — pure, test-stable. */
+  id: string;
+  /** Display text, with checkbox + `POST-MERGE:` prefix stripped. */
+  text: string;
+  /** True when the step must happen after the PR merges (leading `POST-MERGE:`). */
+  postMerge: boolean;
+}
+
+/** The fence that opens/closes the primary carrier block. */
+const FENCE_OPEN = /^```shepherd:manual-steps[ \t]*$/i;
+const FENCE_CLOSE = /^```[ \t]*$/;
+/** A markdown task-list line inside the fence: `- [ ] text` / `- [x] text` / `* [X] text`. */
+const TASK_LINE = /^[ \t]*[-*][ \t]+\[[ xX]\][ \t]*(.*)$/;
+/** A `Manual-Step:` trailer line, anchored at column 0 (no leading whitespace / blockquote). */
+const TRAILER_LINE = /^Manual-Step:[ \t]*(.+)$/i;
+/** A leading `POST-MERGE:` marker on a step's text (case-insensitive). */
+const POST_MERGE_PREFIX = /^POST-MERGE:[ \t]*/i;
+
+/** A raw step before dedupe: its text (POST-MERGE stripped) and post-merge flag. */
+interface RawStep {
+  text: string;
+  postMerge: boolean;
+}
+
+/** Split a step's raw text into its post-merge flag + cleaned text. */
+function splitPostMerge(raw: string): RawStep {
+  const postMerge = POST_MERGE_PREFIX.test(raw);
+  const text = raw.replace(POST_MERGE_PREFIX, "").trim();
+  return { text, postMerge };
+}
+
+/** Normalize for dedupe: collapse whitespace + lowercase. Run BOTH new and stored text through
+ *  this same normalizer before keying the Set (house rule: dedupe in normalized space). */
+function normalize(text: string): string {
+  return text.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+/**
+ * Pull every `- [ ]` / `- [x]` line out of all ```shepherd:manual-steps fences. Order-preserving;
+ * tolerant of an unclosed final fence (reads to end of body). Non-list lines inside the fence are
+ * ignored. Returns the raw lines AND the body with those fences removed (so trailer parsing can't
+ * re-match lines that lived inside a fence).
+ */
+function extractBlockSteps(body: string): { steps: RawStep[]; bodyWithoutFences: string } {
+  const lines = body.split(/\r?\n/);
+  const steps: RawStep[] = [];
+  const kept: string[] = [];
+  let inFence = false;
+  for (const line of lines) {
+    if (!inFence) {
+      if (FENCE_OPEN.test(line)) {
+        inFence = true;
+        continue; // drop the opening fence from the trailer-scan body
+      }
+      kept.push(line);
+      continue;
+    }
+    // inside a fence
+    if (FENCE_CLOSE.test(line)) {
+      inFence = false;
+      continue; // drop the closing fence too
+    }
+    const m = TASK_LINE.exec(line);
+    if (m) steps.push(splitPostMerge(m[1]!.trim()));
+    // non-list lines inside the fence are dropped (not kept for trailer scan)
+  }
+  return { steps, bodyWithoutFences: kept.join("\n") };
+}
+
+/** Pull `Manual-Step:` trailer lines from the fence-stripped body (column-0 anchored). */
+function extractTrailerSteps(bodyWithoutFences: string): RawStep[] {
+  const steps: RawStep[] = [];
+  for (const line of bodyWithoutFences.split(/\r?\n/)) {
+    const m = TRAILER_LINE.exec(line);
+    if (m) steps.push(splitPostMerge(m[1]!.trim()));
+  }
+  return steps;
+}
+
+/**
+ * Parse manual operator steps from a PR body. Block steps first (primary), then trailer steps
+ * (additive). Merge + dedupe in normalized space: first occurrence wins for display text;
+ * `postMerge` is true if ANY source marks it. Pure; no I/O. Empty / malformed body → [].
+ */
+export function parseManualSteps(prBody: string): ManualStep[] {
+  if (!prBody) return [];
+  const { steps: blockSteps, bodyWithoutFences } = extractBlockSteps(prBody);
+  const trailerSteps = extractTrailerSteps(bodyWithoutFences);
+
+  const byKey = new Map<string, RawStep>();
+  for (const s of [...blockSteps, ...trailerSteps]) {
+    if (!s.text) continue; // skip empty steps (e.g. `- [ ]` with no text)
+    const key = normalize(s.text);
+    if (!key) continue;
+    const existing = byKey.get(key);
+    if (existing) {
+      // keep first text, OR the post-merge flag across duplicates
+      if (s.postMerge) existing.postMerge = true;
+    } else {
+      byKey.set(key, { text: s.text, postMerge: s.postMerge });
+    }
+  }
+
+  return [...byKey.values()].map((s, i) => ({
+    id: `ms${i + 1}`,
+    text: s.text,
+    postMerge: s.postMerge,
+  }));
+}

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -39,7 +39,7 @@ import {
   isSettledIdle,
   needsRecap,
 } from "./recap-core";
-import { groundBlocks } from "./visual-blocks";
+import { groundBlocks, type VisualBlock } from "./visual-blocks";
 import { tolerantParseJson, isSpawnWorking, decideVerdictAction } from "./json-tolerant";
 import type { VerdictRead } from "./json-tolerant";
 
@@ -161,6 +161,7 @@ function recapArgv(model: string | null, prompt: string): { argv: string[]; sess
 export interface RecapServiceDeps {
   store: Pick<
     SessionStore,
+    | "get"
     | "getRecap"
     | "putRecap"
     | "snapshotRecaps"
@@ -454,6 +455,14 @@ export class RecapService {
       if (review?.summary) contextParts.push(`Critic verdict: ${review.summary}`);
       if (session.readyToMerge) contextParts.push("Operator marked ready to merge.");
       if (session.planPhase) contextParts.push(`Plan phase: ${session.planPhase}`);
+      // #1059: hint the prose about detected manual operator steps (the authoritative copy is the
+      // deterministic checklist block injected at finalize; this just lets the body reference them).
+      if (session.manualSteps.length > 0)
+        contextParts.push(
+          `Manual operator steps required (surfaced as a checklist): ${session.manualSteps
+            .map((s) => (s.postMerge ? `POST-MERGE: ${s.text}` : s.text))
+            .join("; ")}`,
+        );
       const context = contextParts.join("\n");
 
       const prompt = buildRecapPrompt({
@@ -551,10 +560,32 @@ export class RecapService {
     }
   }
 
+  /** Build a deterministic checklist block from a session's persisted manual operator steps
+   *  (#1059), or null when there are none. Read at finalize (latest possible point) so a
+   *  detection write racing in around merge time is most likely to have landed. */
+  private buildManualStepsBlock(sessionId: string): VisualBlock | null {
+    const steps = this.deps.store.get(sessionId)?.manualSteps ?? [];
+    if (steps.length === 0) return null;
+    return {
+      type: "checklist",
+      id: "manual-steps",
+      items: steps.map((s) => ({
+        id: s.id,
+        label: s.text,
+        ...(s.postMerge ? { note: "POST-MERGE" } : {}),
+      })),
+    };
+  }
+
   private async finalize(r: Recap, raw: unknown | null): Promise<void> {
     const t = this.now();
     // Strip the server-only carrier so it never reaches putRecap or onChange.
     const { pendingDiff = [], ...rBase } = r;
+    // Manual operator steps (#1059): deterministically carry the session's persisted manual steps
+    // into the recap as a checklist block, so the durability win never depends on the LLM choosing
+    // to emit it. Prepended in BOTH branches below — the failure branch must keep it too, since a
+    // recap failure is exactly the case where these otherwise-lost steps matter most.
+    const manualBlock = this.buildManualStepsBlock(r.sessionId);
     let newRow: Recap;
     try {
       const parsed = raw ? parseRecapVerdict(raw) : null;
@@ -567,7 +598,7 @@ export class RecapService {
           headline: parsed.headline,
           body: parsed.body,
           openItems: parsed.openItems,
-          blocks: grounded,
+          blocks: manualBlock ? [manualBlock, ...grounded] : grounded,
           generatedAt: t,
           updatedAt: t,
         };
@@ -581,7 +612,13 @@ export class RecapService {
             `[recap] ${r.sessionId}: verdict parsed as JSON but failed recap-shape validation (verdict=${JSON.stringify(v)}) — failing. snippet: ${recapSnippet(JSON.stringify(raw))}`,
           );
         }
-        newRow = { ...rBase, state: "failed", blocks: [], generatedAt: t, updatedAt: t };
+        newRow = {
+          ...rBase,
+          state: "failed",
+          blocks: manualBlock ? [manualBlock] : [],
+          generatedAt: t,
+          updatedAt: t,
+        };
       }
       this.deps.store.putRecap(newRow);
       this.deps.onChange(r.sessionId, newRow);

--- a/src/store.ts
+++ b/src/store.ts
@@ -31,6 +31,7 @@ import type {
   WindowedBucketSum,
 } from "./types";
 import type { VisualBlock } from "./visual-blocks";
+import type { ManualStep } from "./manual-steps";
 import type { CapRow, CapStore, CreditSnapshot, CreditStore, WindowKey } from "./usage-limits";
 import { dominantModel, type SessionUsage } from "./usage";
 import { type SandboxProfile, isSandboxProfile } from "./sandbox";
@@ -174,6 +175,8 @@ type NewSession = Omit<
   | "research"
   | "haltReason"
   | "haltedAt"
+  | "manualSteps"
+  | "manualStepsAckedAt"
 > & {
   id?: string;
   model?: string | null;
@@ -199,7 +202,7 @@ const COLS = `id, desig, name, prompt, repoPath, baseBranch, branch, worktreePat
   auto, issueNumber, sandboxApplied, sandboxDegraded, egressApplied, egressDegraded,
   research,
   createdAt, updatedAt, archivedAt, mergingSince, mergingTrainId, mergeTrainPrs, mergingPrNumber,
-  haltReason, haltedAt`;
+  haltReason, haltedAt, manualStepsJson, manualStepsAckedAt`;
 
 // ── SQLite row shapes ──────────────────────────────────────────────────────────
 
@@ -248,6 +251,8 @@ type SessionRow = {
   mergingPrNumber: number | null;
   haltReason: string | null;
   haltedAt: number | null;
+  manualStepsJson: string | null;
+  manualStepsAckedAt: number | null;
 };
 
 /** SQLite row shape for the reviews table. */
@@ -413,6 +418,25 @@ function parseMergeTrainPrsJson(raw: string | null | undefined): number[] | null
     return parsed as number[];
   } catch {
     return null;
+  }
+}
+
+/** Tolerantly parse the persisted manualSteps JSON back to ManualStep[] (never throws). #1059. */
+function parseManualStepsJson(raw: string | null | undefined): ManualStep[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (s): s is ManualStep =>
+        !!s &&
+        typeof s === "object" &&
+        typeof s.id === "string" &&
+        typeof s.text === "string" &&
+        typeof s.postMerge === "boolean",
+    );
+  } catch {
+    return [];
   }
 }
 
@@ -1465,6 +1489,8 @@ export class SessionStore implements CapStore, CreditStore {
       mergingPrNumber: null,
       haltReason: null,
       haltedAt: null,
+      manualSteps: [],
+      manualStepsAckedAt: null,
     };
   }
 
@@ -1474,7 +1500,7 @@ export class SessionStore implements CapStore, CreditStore {
       const seq = this.nextDesignationSeq();
       const s = this.buildSessionRow(input, seq, now);
       this.db.run(
-        `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+        `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
         [
           s.id,
           s.desig,
@@ -1519,6 +1545,8 @@ export class SessionStore implements CapStore, CreditStore {
           null, // mergingPrNumber — always null at create
           null, // haltReason — always null at create
           null, // haltedAt — always null at create
+          null, // manualStepsJson — always null at create (detected later from the PR body)
+          null, // manualStepsAckedAt — always null at create (P2)
         ],
       );
       return s;
@@ -2298,6 +2326,17 @@ export class SessionStore implements CapStore, CreditStore {
     ]);
   }
 
+  /** Persist the manual operator steps detected in a session's PR body (#1059). Stored as a JSON
+   *  array; an empty array clears any prior detection. Dedicated setter (the generic update()
+   *  whitelist would silently drop it), mirroring {@link setHaltReason}'s direct-UPDATE style. */
+  setSessionManualSteps(id: string, steps: ManualStep[]): void {
+    this.db.run(`UPDATE sessions SET manualStepsJson = ?, updatedAt = ? WHERE id = ?`, [
+      JSON.stringify(steps),
+      Date.now(),
+      id,
+    ]);
+  }
+
   // ── reviewer spawn cost attribution ──────────────────────────────────────────
   /** Record a freshly-spawned reviewer session. Token/completed columns stay NULL until
    *  finalize (`completeReviewerSpawn`). A plain INSERT is correct — every spawn forces a
@@ -2507,6 +2546,11 @@ export class SessionStore implements CapStore, CreditStore {
     // halt detection: reason + timestamp; nullable, no default (null = not halted).
     add("haltReason", `haltReason TEXT`);
     add("haltedAt", `haltedAt INTEGER`);
+    // manual operator steps (#1059): detected carrier steps (JSON ManualStep[]) + the epoch the
+    // operator acknowledged them. manualStepsAckedAt is written by P2; the column lands here so P2
+    // is purely additive. Both nullable: absence = no detection ran / not yet acknowledged.
+    add("manualStepsJson", `manualStepsJson TEXT`);
+    add("manualStepsAckedAt", `manualStepsAckedAt INTEGER`);
   }
 
   // Migrate build_queue_steps from the legacy global `PRIMARY KEY (id)` to the composite
@@ -3730,6 +3774,8 @@ export class SessionStore implements CapStore, CreditStore {
       mergingPrNumber: r.mergingPrNumber ?? null,
       haltReason: r.haltReason ?? null,
       haltedAt: r.haltedAt ?? null,
+      manualSteps: parseManualStepsJson(r.manualStepsJson),
+      manualStepsAckedAt: r.manualStepsAckedAt ?? null,
     } as Session;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { SandboxProfile } from "./sandbox";
 import type { VisualBlock } from "./visual-blocks";
+import type { ManualStep } from "./manual-steps";
 
 export type HerdrState = "idle" | "working" | "blocked" | "done" | "unknown";
 export type SessionStatus = "running" | "idle" | "blocked" | "done" | "archived";
@@ -81,6 +82,10 @@ export interface Session {
   haltReason: "usage_limit" | "completed" | "operator" | "error" | null;
   /** Epoch ms when haltReason was set; null when not halted. */
   haltedAt: number | null;
+  /** Manual operator steps detected in this session's PR body (#1059); [] when none/undetected. */
+  manualSteps: ManualStep[];
+  /** Epoch ms the operator acknowledged the manual steps; null until acknowledged. Written by P2. */
+  manualStepsAckedAt: number | null;
 }
 
 /**

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -63,6 +63,8 @@ function sess(over: Partial<Session> = {}): Session {
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
     ...over,
   };
 }

--- a/test/blocked.test.ts
+++ b/test/blocked.test.ts
@@ -159,6 +159,8 @@ function makeSession(planPhase: Session["planPhase"]): Session {
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
   };
 }
 

--- a/test/herd-digest.test.ts
+++ b/test/herd-digest.test.ts
@@ -60,6 +60,8 @@ function makeSession(over: Partial<Session> = {}): Session {
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
     ...over,
   };
 }

--- a/test/manual-steps.test.ts
+++ b/test/manual-steps.test.ts
@@ -1,0 +1,84 @@
+import { test, expect, describe } from "bun:test";
+import { parseManualSteps } from "../src/manual-steps";
+
+const block = (lines: string) => "Some PR prose.\n\n```shepherd:manual-steps\n" + lines + "\n```\n";
+
+describe("parseManualSteps — manual-operator-step carrier parsing (#1059)", () => {
+  test("empty / falsy body → []", () => {
+    expect(parseManualSteps("")).toEqual([]);
+    expect(parseManualSteps("just prose, no carrier")).toEqual([]);
+  });
+
+  test("fenced block: each task line → a step, order preserved", () => {
+    const body = block(
+      "- [ ] Set FLOWAGENT_WORKER_CONCURRENCY=4 in prod env\n- [x] Run `bun run backfill` once after deploy",
+    );
+    expect(parseManualSteps(body)).toEqual([
+      { id: "ms1", text: "Set FLOWAGENT_WORKER_CONCURRENCY=4 in prod env", postMerge: false },
+      { id: "ms2", text: "Run `bun run backfill` once after deploy", postMerge: false },
+    ]);
+  });
+
+  test("POST-MERGE prefix (case-insensitive) sets postMerge + is stripped", () => {
+    const body = block(
+      "- [ ] POST-MERGE: rotate the webhook secret\n- [ ] post-merge: restart worker",
+    );
+    expect(parseManualSteps(body)).toEqual([
+      { id: "ms1", text: "rotate the webhook secret", postMerge: true },
+      { id: "ms2", text: "restart worker", postMerge: true },
+    ]);
+  });
+
+  test("non-list lines inside the fence are ignored", () => {
+    const body = block("Here are the steps:\n- [ ] do the thing\nthanks!");
+    expect(parseManualSteps(body)).toEqual([{ id: "ms1", text: "do the thing", postMerge: false }]);
+  });
+
+  test("empty task line (no text) is skipped", () => {
+    const body = block("- [ ] \n- [ ] real step");
+    expect(parseManualSteps(body)).toEqual([{ id: "ms1", text: "real step", postMerge: false }]);
+  });
+
+  test("Manual-Step: trailer lines (column-0 anchored) are parsed", () => {
+    const body =
+      "PR body\n\nManual-Step: set the env var\nManual-Step: POST-MERGE: flip the flag\n";
+    expect(parseManualSteps(body)).toEqual([
+      { id: "ms1", text: "set the env var", postMerge: false },
+      { id: "ms2", text: "flip the flag", postMerge: true },
+    ]);
+  });
+
+  test("quoted / indented / blockquoted Manual-Step: lines must NOT match", () => {
+    const body = [
+      "Note: a reviewer wrote `Manual-Step: do X` inline.",
+      "> Manual-Step: this is quoted in a blockquote",
+      "   Manual-Step: this is indented",
+      "see Manual-Step: in the middle of a sentence",
+    ].join("\n");
+    expect(parseManualSteps(body)).toEqual([]);
+  });
+
+  test("merge + dedupe across both sources in normalized space; postMerge OR-ed", () => {
+    const body =
+      block("- [ ] Restart the   worker") + "\nManual-Step: POST-MERGE: restart the worker\n"; // same step, whitespace + post-merge differ
+    expect(parseManualSteps(body)).toEqual([
+      { id: "ms1", text: "Restart the   worker", postMerge: true },
+    ]);
+  });
+
+  test("malformed: unclosed fence still reads task lines to end of body", () => {
+    const body = "intro\n\n```shepherd:manual-steps\n- [ ] orphaned step\n- [ ] second";
+    expect(parseManualSteps(body)).toEqual([
+      { id: "ms1", text: "orphaned step", postMerge: false },
+      { id: "ms2", text: "second", postMerge: false },
+    ]);
+  });
+
+  test("block + distinct trailer steps both appear, in order", () => {
+    const body = block("- [ ] block step") + "\nManual-Step: trailer step\n";
+    expect(parseManualSteps(body)).toEqual([
+      { id: "ms1", text: "block step", postMerge: false },
+      { id: "ms2", text: "trailer step", postMerge: false },
+    ]);
+  });
+});

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -78,6 +78,8 @@ function makeSession(over: Partial<Session> = {}): Session {
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
     ...over,
   };
 }
@@ -126,6 +128,7 @@ type FakeStore = {
   completeReviewerSpawn: (id: string, u: any, at: number) => void;
   list: (opts?: { activeOnly?: boolean }) => Session[];
   setRecapPendingDiff: (sessionId: string, files: any[]) => void;
+  get: (id: string) => Session | undefined;
 };
 
 function makeStore(sessions: Session[] = [], recaps: Recap[] = []): FakeStore {
@@ -162,6 +165,7 @@ function makeStore(sessions: Session[] = [], recaps: Recap[] = []): FakeStore {
     setRecapPendingDiff: (sessionId, files) => {
       store.pendingDiffs[sessionId] = files;
     },
+    get: (id) => store.sessions.find((s) => s.id === id),
   };
   return store;
 }
@@ -1323,6 +1327,66 @@ test("finalize: carrier cleared on failed path", async () => {
   await svc.tick();
   expect(store.getRecap("s1")?.state).toBe("failed");
   expect(store.pendingDiffs["s1"]).toEqual([]);
+});
+
+test("finalize: manual steps injected as a checklist block on the ready path (#1059)", async () => {
+  const rec = makeRecap({ state: "generating", cwd: "/tmp/recap-ms-ready", spawnedAt: 100_000 });
+  const session = makeSession({
+    manualSteps: [
+      { id: "ms1", text: "Set FLAG=1 in prod", postMerge: false },
+      { id: "ms2", text: "rotate webhook secret", postMerge: true },
+    ],
+  });
+  const store = makeStore([session], [rec]);
+  const herdr = makeHerdr([{ cwd: "/tmp/recap-ms-ready", terminalId: "tm1" }]);
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    verdictJson: { verdict: "ready", headline: "ok", body: "done", openItems: [] },
+    cleanup: () => {},
+  });
+
+  await svc.tick();
+  const saved = store.getRecap("s1");
+  expect(saved?.state).toBe("ready");
+  expect(saved?.blocks?.[0]).toEqual({
+    type: "checklist",
+    id: "manual-steps",
+    items: [
+      { id: "ms1", label: "Set FLAG=1 in prod" },
+      { id: "ms2", label: "rotate webhook secret", note: "POST-MERGE" },
+    ],
+  });
+});
+
+test("finalize: manual steps survive the FAILED path too (#1059)", async () => {
+  const rec = makeRecap({ state: "generating", cwd: "/tmp/recap-ms-fail", spawnedAt: 100_000 });
+  const session = makeSession({
+    manualSteps: [{ id: "ms1", text: "run the backfill once", postMerge: false }],
+  });
+  const store = makeStore([session], [rec]);
+  const herdr = makeHerdr([{ cwd: "/tmp/recap-ms-fail", terminalId: "tm2" }]);
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    verdictJson: { verdict: "not-valid", headline: 42 }, // unparseable → failed
+    cleanup: () => {},
+  });
+
+  await svc.tick();
+  const saved = store.getRecap("s1");
+  expect(saved?.state).toBe("failed");
+  expect(saved?.blocks).toEqual([
+    {
+      type: "checklist",
+      id: "manual-steps",
+      items: [{ id: "ms1", label: "run the backfill once" }],
+    },
+  ]);
 });
 
 test("finalize: empty carrier fail-closed — diff dropped, file-tree filtered, callout kept", async () => {

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -86,6 +86,8 @@ function session(over: Partial<Session> = {}): Session {
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
     ...over,
   };
 }

--- a/test/rundown-core.test.ts
+++ b/test/rundown-core.test.ts
@@ -67,6 +67,8 @@ function session(over: Partial<Session> = {}): Session {
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
     ...over,
   };
 }

--- a/test/server-diff.test.ts
+++ b/test/server-diff.test.ts
@@ -49,6 +49,8 @@ const SESSION: Session = {
   archivedAt: null,
   haltReason: null,
   haltedAt: null,
+  manualSteps: [],
+  manualStepsAckedAt: null,
 };
 
 function makeDeps(session: Session | null): AppDeps {

--- a/test/server-git.test.ts
+++ b/test/server-git.test.ts
@@ -53,6 +53,8 @@ const SESSION: Session = {
   archivedAt: null,
   haltReason: null,
   haltedAt: null,
+  manualSteps: [],
+  manualStepsAckedAt: null,
 };
 
 function fakeForge(

--- a/test/server-quota-endpoints.test.ts
+++ b/test/server-quota-endpoints.test.ts
@@ -54,6 +54,8 @@ const SESSION: Session = {
   archivedAt: null,
   haltReason: null,
   haltedAt: null,
+  manualSteps: [],
+  manualStepsAckedAt: null,
 };
 
 /** A ReviewVerdict that triggers the "rework" quota kind (addressRound >= addressCap, no pending). */

--- a/test/server-review-pr.test.ts
+++ b/test/server-review-pr.test.ts
@@ -54,6 +54,8 @@ const SESSION: Session = {
   archivedAt: null,
   haltReason: null,
   haltedAt: null,
+  manualSteps: [],
+  manualStepsAckedAt: null,
 };
 
 function fakeForge(over: Partial<GitForge> = {}): GitForge & { log: string[] } {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -488,6 +488,7 @@
   "viewport_preview_stop_failed": "Devserver konnte nicht gestoppt werden; er ignoriert möglicherweise das Stoppsignal.",
   "unitrow_preview_badge": "Vorschau",
   "unitrow_preview_badge_degraded": "Vorschau; Tailscale-Registrierung fehlgeschlagen, nur über Loopback erreichbar",
+  "unitrow_manual_steps": "{count} manuelle(r) Schritt(e)",
   "viewport_preview_serve_failed": "Tailscale-Registrierung für diesen Vorschau-Port fehlgeschlagen; nur über Loopback erreichbar. Nutze 'In neuem Tab öffnen', wenn der Frame leer bleibt.",
   "viewport_git_actions": "PR",
   "viewport_git_actions_title": "PR, Merge, Kritiker & Merge-Freigabe",
@@ -1892,5 +1893,7 @@
   "feat_tui_fullscreen_body": "Agent-Sitzungen können jetzt in den Vollbild-Renderer von Claude Code gewechselt werden — erreichbar unter Einstellungen → Sitzung. Ermöglicht einen flacheren Speicherverbrauch bei langen autonomen Läufen. Forschungsvorschau (standardmäßig deaktiviert), gilt für neu gestartete oder fortgesetzte Sitzungen.",
   "gitrail_decommission_action": "Stilllegen",
   "feat_decommission_on_merge_title": "Stilllegen nach dem Merge",
-  "feat_decommission_on_merge_body": "Nachdem du den PR einer Session gemerged hast, bietet die Bestätigungsmeldung jetzt ein Ein-Klick-Stilllegen, um die abgeschlossene Session zu entfernen – kein Suchen nach dem Button mehr."
+  "feat_decommission_on_merge_body": "Nachdem du den PR einer Session gemerged hast, bietet die Bestätigungsmeldung jetzt ein Ein-Klick-Stilllegen, um die abgeschlossene Session zu entfernen – kein Suchen nach dem Button mehr.",
+  "feat_manual_operator_steps_title": "Manuelle Operator-Schritte",
+  "feat_manual_operator_steps_body": "Deklariere manuelle Schritte im shepherd:manual-steps-Block eines PR (Flag umlegen, Umgebungsvariable setzen, Backfill ausführen), und Shepherd zeigt sie als bernsteinfarbenen Chip in der Session-Zeile sowie als Checkliste im Done-Recap an – damit sie beim Mergen des PR nicht verloren gehen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -488,6 +488,7 @@
   "viewport_preview_stop_failed": "Couldn't stop the dev server; it may be ignoring the stop signal.",
   "unitrow_preview_badge": "Preview",
   "unitrow_preview_badge_degraded": "Preview; Tailscale registration failed, reachable on loopback only",
+  "unitrow_manual_steps": "{count} manual step(s)",
   "viewport_preview_serve_failed": "Tailscale registration failed for this preview port; it's reachable on loopback only. Use Open in new tab if the frame is blank.",
   "viewport_git_actions": "PR",
   "viewport_git_actions_title": "PR, merge, critic & ready-to-merge actions",
@@ -1892,5 +1893,7 @@
   "feat_tui_fullscreen_body": "You can now opt agent sessions into Claude Code's fullscreen renderer from Settings → Session, for flatter memory on long autonomous runs. It's a research preview (off by default) and applies to newly started or resumed sessions.",
   "gitrail_decommission_action": "Decommission",
   "feat_decommission_on_merge_title": "Decommission after merge",
-  "feat_decommission_on_merge_body": "After you merge a session's PR, the confirmation toast now offers a one-click Decommission to tear the finished session down — no hunting for the button."
+  "feat_decommission_on_merge_body": "After you merge a session's PR, the confirmation toast now offers a one-click Decommission to tear the finished session down — no hunting for the button.",
+  "feat_manual_operator_steps_title": "Manual operator steps",
+  "feat_manual_operator_steps_body": "Declare manual steps in a PR's shepherd:manual-steps block (flip a flag, set an env var, run a backfill) and Shepherd surfaces them as an amber chip on the session row and a checklist in the Done recap — so they aren't lost when the PR lands."
 }

--- a/ui/src/lib/components/DoneRecapPanel.browser.test.ts
+++ b/ui/src/lib/components/DoneRecapPanel.browser.test.ts
@@ -47,6 +47,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     archivedAt: Date.now() - 60_000,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
     ...partial,
   };
 }

--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -47,6 +47,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
     ...partial,
   };
 }

--- a/ui/src/lib/components/PlanPanel.browser.test.ts
+++ b/ui/src/lib/components/PlanPanel.browser.test.ts
@@ -58,6 +58,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
     ...partial,
   };
 }

--- a/ui/src/lib/components/ResearchBadge.browser.test.ts
+++ b/ui/src/lib/components/ResearchBadge.browser.test.ts
@@ -47,6 +47,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
     ...partial,
   };
 }

--- a/ui/src/lib/components/SessionRecap.browser.test.ts
+++ b/ui/src/lib/components/SessionRecap.browser.test.ts
@@ -47,6 +47,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
     ...partial,
   };
 }

--- a/ui/src/lib/components/TriageDrawer.browser.test.ts
+++ b/ui/src/lib/components/TriageDrawer.browser.test.ts
@@ -49,6 +49,8 @@ function session(id: string): Session {
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
   };
 }
 

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -57,6 +57,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
     ...partial,
   };
 }

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -436,6 +436,14 @@
           ? modelLabel(session.model)
           : m.newtask_model_default()}</span
       >
+      {#if session.manualSteps.length > 0}
+        <span
+          class="chip-manual-steps"
+          title={m.unitrow_manual_steps({ count: session.manualSteps.length })}
+        >
+          {m.unitrow_manual_steps({ count: session.manualSteps.length })}
+        </span>
+      {/if}
       {#if showStepper && !session.readyToMerge}
         <span class="meta-stepper">
           <Stepper
@@ -831,6 +839,18 @@
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+  }
+  /* amber "N manual steps" chip (#1059) — modeled on the epic .chip-migrations recipe; amber
+     (--status-warn) reads as caution-pending, never the actionable-complete green. */
+  .chip-manual-steps {
+    flex: none;
+    font-size: var(--fs-micro);
+    letter-spacing: 0.08em;
+    padding: 1px 6px;
+    border: 1px solid var(--status-warn);
+    border-radius: 2px;
+    color: var(--status-warn);
+    background: color-mix(in oklab, var(--status-warn) 12%, transparent);
   }
   /* thin stage stepper on the quietest row — pushed to the right edge */
   .meta-stepper {

--- a/ui/src/lib/components/UnitTile.browser.test.ts
+++ b/ui/src/lib/components/UnitTile.browser.test.ts
@@ -55,6 +55,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
     ...partial,
   };
 }

--- a/ui/src/lib/components/Viewport.browser.test.ts
+++ b/ui/src/lib/components/Viewport.browser.test.ts
@@ -68,6 +68,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
     ...partial,
   };
 }

--- a/ui/src/lib/components/epic-grouping.test.ts
+++ b/ui/src/lib/components/epic-grouping.test.ts
@@ -50,6 +50,8 @@ function session(
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
   };
 }
 

--- a/ui/src/lib/components/herd-keynav.test.ts
+++ b/ui/src/lib/components/herd-keynav.test.ts
@@ -57,6 +57,8 @@ function session(
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
   };
 }
 

--- a/ui/src/lib/components/herd-partition.test.ts
+++ b/ui/src/lib/components/herd-partition.test.ts
@@ -44,6 +44,8 @@ function session(id: string, readyToMerge = false, status: SessionStatus = "runn
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
   };
 }
 

--- a/ui/src/lib/components/merge-train.test.ts
+++ b/ui/src/lib/components/merge-train.test.ts
@@ -50,6 +50,8 @@ function session(partial: Partial<Session> & { id: string }): Session {
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
     ...partial,
   };
 }

--- a/ui/src/lib/components/queue-strip.test.ts
+++ b/ui/src/lib/components/queue-strip.test.ts
@@ -257,6 +257,8 @@ function session(over: Partial<Session>): Session {
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
     ...over,
   };
 }

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1537,4 +1537,15 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_decommission_on_merge_title",
     bodyKey: "feat_decommission_on_merge_body",
   },
+  {
+    // Shepherd now detects manual operator steps declared in a PR's `shepherd:manual-steps` block
+    // (flip a flag, set an env var, run a backfill) and surfaces them as an amber chip on the
+    // session row + a checklist in the Done recap — so they aren't lost when the PR lands. No
+    // targetId — the chip mounts only when steps are detected; surface via the What's-New drawer
+    // only. v1.36.0 is the latest released tag → ships in 1.37.0.
+    id: "manual-operator-steps",
+    sinceVersion: "1.37.0",
+    titleKey: "feat_manual_operator_steps_title",
+    bodyKey: "feat_manual_operator_steps_body",
+  },
 ];

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -66,6 +66,8 @@ function session(id: string): Session {
     archivedAt: null,
     haltReason: null,
     haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
   };
 }
 

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -373,6 +373,9 @@ export class HerdStore {
           haltedAt: ev.data.haltedAt,
         });
         return true;
+      case "session:manual-steps":
+        this.patchSession(ev.data.id, { manualSteps: ev.data.manualSteps });
+        return true;
       default:
         return false;
     }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -731,6 +731,18 @@ export interface Session {
   haltReason: "usage_limit" | "completed" | "operator" | "error" | null;
   /** Epoch ms when haltReason was set; null when not halted. */
   haltedAt: number | null;
+  /** Manual operator steps detected in this session's PR body (#1059); [] when none/undetected. */
+  manualSteps: ManualStep[];
+  /** Epoch ms the operator acknowledged the manual steps; null until acknowledged (P2). */
+  manualStepsAckedAt: number | null;
+}
+
+/** A manual operator step parsed from a PR's shepherd:manual-steps carrier (#1059). Mirrors the
+ *  server `ManualStep` shape in src/manual-steps.ts. */
+export interface ManualStep {
+  id: string;
+  text: string;
+  postMerge: boolean;
 }
 
 export interface SessionUsage {
@@ -1051,6 +1063,7 @@ export type WsEvent =
       data: { id: string; haltReason: Session["haltReason"]; haltedAt: number | null };
     }
   | { event: "session:git"; data: { id: string; git: GitState } }
+  | { event: "session:manual-steps"; data: { id: string; manualSteps: ManualStep[] } }
   | { event: "session:activity"; data: { id: string; activity: SessionActivity } }
   | { event: "session:subagents"; data: { id: string; subagents: SubagentEntry[] } }
   | { event: "session:claude-alive"; data: { id: string; claudeAlive: boolean } }

--- a/ui/test/store.test.ts
+++ b/ui/test/store.test.ts
@@ -43,6 +43,8 @@ const s = (id: string, status: any = "running"): Session => ({
   archivedAt: null,
   haltReason: null,
   haltedAt: null,
+  manualSteps: [],
+  manualStepsAckedAt: null,
 });
 
 test("applies snapshot, new, status, archived", () => {


### PR DESCRIPTION
Closes #1059. Part of epic #1056 (DAG root) — targets the epic integration branch `epic/1056-surface-gate-manual-operator-steps-attac`, **not** the default branch.

## What

Parse manual-operator-step carriers from a session's PR body, persist them on the session, and surface them on the backlog row + Done recap. **No merge gate** — that's the P2 sub-issue.

Manual operator steps = work a human must do around merge/deploy that the diff can't perform (flip a flag, set an env var, run a backfill, restart a worker, DNS cutover). Today they live only in PR prose and are silently lost when auto-merge or an inattentive operator lands the PR and archives the session.

## Carrier (re-confirmed at plan gate)

- **Fenced block (primary):** ` ```shepherd:manual-steps ` — each `- [ ]` / `- [x]` line is a step; a leading `POST-MERGE:` (case-insensitive) marks it post-merge.
- **`Manual-Step:` trailer (additive):** column-0-anchored body lines (parsed from the *same* already-fetched PR body — zero extra I/O, no new forge method). Quoted/indented/blockquoted `Manual-Step:` lines do **not** match.
- Merge + dedupe in normalized space across both sources; `postMerge` OR-ed.

> **Deliberate deviation (flagged per house rule):** the issue's "trailer" example implies git trailers in *commit messages*. Reading those needs a new `forge.prCommits()` + squash-merge survival analysis — there's no clean I/O-free path today, so I implement **body-line** trailers (the only clean path) and **defer commit-message trailers to a follow-up**, which the issue explicitly permits.

## Changes

- **`src/manual-steps.ts`** — pure parser (`ManualStep[]`), fully unit-tested (block, trailer, dedupe, POST-MERGE, empty/malformed, quoted-line negative).
- **Persistence** — `manualStepsJson` + `manualStepsAckedAt` cols on `sessions` (ALTER migration), `parseManualStepsJson` hydration, dedicated `setSessionManualSteps` setter (generic `update()` whitelist would drop it). `manualStepsAckedAt` is written by P2; the column lands here so P2 is purely additive.
- **Detection** — subscribes to the existing `session:git` event (head-SHA throttled, mirroring drain's `prReviewMeta` throttle) → fetch body via `prReviewMeta` → parse → persist-on-change → emit a new **`session:manual-steps`** WS event so the chip updates live (no reload).
- **Surface — backlog chip** — amber `.chip-manual-steps` on `UnitRow.svelte` (design-system tokens only; `--status-warn`, never green).
- **Surface — Done recap** — deterministic `checklist` block injected into **both** branches of `recap.finalize()` (ready **and** failed) so steps survive a recap failure — the case where they matter most. Read at `finalize()` (post-LLM) for freshness.

## Out of scope (P2/P3)

No auto-merge gate, no ack endpoint, no push notification, no rundown signal, no GitHub tracking issue, no commit-message-trailer reading.

## Known limitations (documented)

- A body-only PR edit with no head-SHA change won't re-trigger detection (agents emit the carrier at PR creation/push).
- Detection-write ↔ recap-read race at merge time is documented + accepted: the read at `finalize()` (post-LLM round-trip) reliably lands the sub-second write; a hard `await` guarantee is a deferred follow-up.

## Gates

- ✅ feature-announcement entry (`manual-operator-steps`, sinceVersion 1.37.0)
- ✅ EN+DE i18n keys (`unitrow_manual_steps`, `feat_manual_operator_steps_*`)
- ✅ root `bun run lint` + `bun test` (4728 pass), `bunx tsc --noEmit`
- ✅ ui `bun run check` + `check:i18n` + `bun run test` (2030 pass)
- ✅ PR-hygiene: branch-hygiene, feature-catalog, glossary; fallow audit (dead 0 / complexity 0)
- No glossary entry: no `[[id|…]]` marker is introduced (chip is a plain count; tooltip is a `title` attr).

🤖 Generated with [Claude Code](https://claude.com/claude-code)