### PR TITLE
fix(review): zero-context patch-id so a clean rebase skips critic re-review

### DIFF
--- a/docs/superpowers/specs/2026-06-03-skip-critic-rebase-design.md
+++ b/docs/superpowers/specs/2026-06-03-skip-critic-rebase-design.md
@@ -28,15 +28,36 @@ across a pure rebase and changes only when the branch's actual changes change.
 
 ## Fingerprint: `git patch-id`
 
-Compute `git patch-id --stable` over `git diff <base>...HEAD`, take the first
-token (the patch id). Rationale:
+Compute `git patch-id --stable` over `git diff -U0 <base>...HEAD` (**zero
+context**), take the first token (the patch id). Rationale:
 
 - patch-id deliberately **ignores line numbers**, so a rebase that only shifts
   the branch's hunks (because new `main` edited code elsewhere in the same
   files) still produces the same id.
-- It **does** hash the changed lines and their immediate context, so it differs
-  when there are new commits, or when conflict resolution during the rebase
-  altered the branch's content. Both genuinely warrant a fresh review.
+- The `-U0` diff hashes **only the branch's own added/removed lines**, not the
+  surrounding (base-owned) context. So the id changes when there are new commits,
+  or when conflict resolution during the rebase altered the branch's content —
+  both edit the branch's own +/- lines, so both still warrant (and get) a fresh
+  review. The id does **not** change on pure *base-only context drift*: a clean
+  rebase where the branch's own lines are byte-identical and only a nearby
+  base-owned line moved. That is the intended behavior — review keys off the
+  branch's change, not the base's.
+
+  > **Why not default 3-line context (the original design).** This section
+  > originally hashed "the changed lines **and their immediate context**" to
+  > catch conflict resolution. That was over-broad: hashing context also made a
+  > line moved by the base *within a hunk's context window* flip the id on an
+  > otherwise clean rebase, re-triggering a needless review (operator-observed).
+  > `-U0` still catches conflict resolution (it edits the branch's own +/- lines),
+  > so the original concern is preserved; only the incidental context-drift
+  > re-trigger is removed.
+  >
+  > **Tradeoff.** Dropping context marginally widens the collision surface: two
+  > distinct revisions whose +/- line text is identical but which sit in
+  > different surrounding code can now share an id (a rare false-skip). The
+  > per-file diff headers keep cross-file changes distinct; the residual risk is
+  > same-file, identical +/- text in a relocated position — judged acceptable for
+  > a skip-vs-review decision that already errs toward reviewing on any failure.
 
 **Base currency (critical).** The three-dot `base...HEAD` diff is taken from the
 merge-base of `base` and `HEAD`. `createDetached` fetches only the *head* branch,
@@ -133,7 +154,7 @@ Add an injectable dep to `ReviewServiceDeps`, mirroring the existing
 computePatchId?: (worktreePath: string, base: string) => string | null;
 ```
 
-Default implementation runs the real `git diff base...HEAD | git patch-id
+Default implementation runs the real `git diff -U0 base...HEAD | git patch-id
 --stable` in the worktree. Unit tests inject a stub.
 
 ### Test cases

--- a/src/critic-core.ts
+++ b/src/critic-core.ts
@@ -176,7 +176,16 @@ export interface RawVerdict {
 /** Fingerprint the branch diff with `git patch-id` so a rebase (same diff, new SHA) is a
  *  no-op, AND return the concrete base it diffed against + the changed-file set. patch-id
  *  ignores line numbers, so it stays stable when the rebased-onto base shifts hunks elsewhere;
- *  it changes only when the branch's own changed lines or their context change. `patchId` is
+ *  the diff is taken at ZERO context (`-U0`) so the fingerprint keys ONLY off the branch's own
+ *  added/removed lines and changes only when THOSE change. (Default 3-line context folded the
+ *  base-owned context lines into the hash: a clean rebase that moved a line within a hunk's
+ *  context window then flipped the id and re-triggered a needless review — the operator-observed
+ *  bug. Conflict resolution still flips the id because it edits the branch's own +/- lines, so
+ *  the "re-review when the rebase changed branch content" intent is preserved; only pure
+ *  base-only context drift no longer re-triggers.) Tradeoff: -U0 marginally widens the collision
+ *  surface — two distinct revisions with identical +/- line text in different surroundings can
+ *  now share an id (rare false-skip); the per-file diff headers keep cross-file changes distinct.
+ *  `patchId` is
  *  null on no diff or any git failure → caller never skips (reviews) — UNCHANGED skip semantics.
  *  `baseSha` is the SHA the prompt + the buildVerdict backstop both key off (one source of
  *  truth); null on a total git failure → prompt falls back to the local base, backstop is
@@ -229,8 +238,11 @@ export async function defaultComputePatchId(
     // to null (review) rather than throwing.
     // Local but can read up to 64 MiB, so run it async too (mirrors computeDiff) to keep
     // the critic poll off the Bun event loop. (patch-id below stays sync — see its note.)
+    // `-U0` (zero context): fingerprint only the branch's own +/- lines, NOT the base-owned
+    // context around them — see the docstring. The critic's actual review diff is computed
+    // separately with full context; this `-U0` diff feeds patch-id only.
     const { stdout: diff } = await timedAsync("git diff", () =>
-      execFileAsync("git", ["diff", `${diffRef}...HEAD`], {
+      execFileAsync("git", ["diff", "-U0", `${diffRef}...HEAD`], {
         cwd: worktreePath,
         maxBuffer: 64 * 1024 * 1024,
         encoding: "utf8",

--- a/test/review-patchid.test.ts
+++ b/test/review-patchid.test.ts
@@ -219,3 +219,76 @@ test("real origin: FETCH_HEAD path keeps the id stable when origin/main advances
   expect(stale).toBeTruthy();
   expect(stale).not.toBe(after);
 });
+
+test("real origin: FETCH_HEAD path keeps the id stable across pure CONTEXT drift (base edits a line within the branch hunk's context window)", async () => {
+  // The operator-observed incident path: a clean rebase onto an advanced origin/main where
+  // the branch's OWN +/- lines are byte-identical, but main moved a line that falls INSIDE the
+  // 3-line context window of the branch's hunk. A context-bearing fingerprint flips here and the
+  // critic needlessly re-reviews; the zero-context (-U0) fingerprint stays stable. This is the
+  // production fetch path, not the offline local-base fallback, so it exercises the real bug.
+  const bare = mkTmp("shepherd-patchid-ctxorigin-");
+  git(["init", "-q", "--bare", "-b", "main"], bare);
+
+  // Seed a multi-line file on main — the branch must MODIFY a pre-existing file so there is
+  // surrounding base context that can drift (a brand-new file has none).
+  writeAdd(repo, "shared.txt", "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\n");
+  commit(repo, "seed shared file");
+  git(["remote", "add", "origin", bare], repo);
+  git(["push", "-q", "origin", "main"], repo);
+
+  // Branch edits line 6 only.
+  git(["checkout", "-q", "-b", "feature"], repo);
+  writeAdd(repo, "shared.txt", "l1\nl2\nl3\nl4\nl5\nl6_FEATURE\nl7\nl8\nl9\nl10\n");
+  commit(repo, "feature edits line 6");
+  git(["push", "-q", "origin", "feature"], repo);
+
+  const { patchId: before } = await defaultComputePatchId(repo, "main");
+  expect(before).toBeTruthy();
+
+  // Advance origin/main from a throwaway clone: edit line 4 — inside line 6's 3-line context
+  // window but non-adjacent, so the rebase stays clean. Local `main` stays stale (as in flight).
+  const pusherParent = mkTmp("shepherd-patchid-ctxpusher-");
+  const pusher = join(pusherParent, "clone");
+  git(["clone", "-q", bare, pusher], pusherParent);
+  writeAdd(pusher, "shared.txt", "l1\nl2\nl3\nl4_BASE\nl5\nl6\nl7\nl8\nl9\nl10\n");
+  commit(pusher, "main edits line 4 near the branch hunk");
+  git(["push", "-q", "origin", "main"], pusher);
+
+  git(["fetch", "-q", "origin"], repo);
+  git(["rebase", "-q", "origin/main"], repo);
+
+  // Branch's own change (line 6) is unchanged; only base-owned context (line 4) moved →
+  // zero-context fingerprint is invariant.
+  const { patchId: after } = await defaultComputePatchId(repo, "main");
+  expect(after).toBe(before);
+});
+
+test("patch-id is stable across a clean rebase with multiple hunks when the base edits between them", async () => {
+  // Guards that `git patch-id --stable` is invariant to how the -U0 fingerprint groups/splits
+  // hunks: a branch with two separate hunks in one file, the base editing a line between them
+  // (inside the first hunk's context window), clean rebase. Offline local-base path (no remote).
+  const seed = Array.from({ length: 30 }, (_, i) => `line${i + 1}`);
+  writeAdd(repo, "multi.txt", seed.join("\n") + "\n");
+  commit(repo, "seed multi-line file");
+
+  git(["checkout", "-q", "-b", "feature"], repo);
+  const edited = [...seed];
+  edited[4] = "line5_F"; // hunk A
+  edited[24] = "line25_F"; // hunk B
+  writeAdd(repo, "multi.txt", edited.join("\n") + "\n");
+  commit(repo, "two separate hunks");
+  const { patchId: before } = await defaultComputePatchId(repo, "main");
+  expect(before).toBeTruthy();
+
+  // Base edits line 7 — between the two hunks (and inside hunk A's context). Clean rebase.
+  git(["checkout", "-q", "main"], repo);
+  const baseEdited = [...seed];
+  baseEdited[6] = "line7_BASE";
+  writeAdd(repo, "multi.txt", baseEdited.join("\n") + "\n");
+  commit(repo, "base edits between the hunks");
+  git(["checkout", "-q", "feature"], repo);
+  git(["rebase", "-q", "main"], repo);
+
+  const { patchId: after } = await defaultComputePatchId(repo, "main");
+  expect(after).toBe(before);
+});


### PR DESCRIPTION
## Problem

The autopilot now rebases an idle, review-passed, non-mergeable PR (#1064), but after the rebase the critic re-reviews even though the branch's own changes didn't change — the operator-observed symptom behind this task.

**Root cause (empirically confirmed):** the rebase-skip fingerprint in `defaultComputePatchId` hashed `git diff <base>...HEAD` at git's **default 3-line context**, and `git patch-id` hashes context lines too. A clean rebase that pulls in a base change *within a hunk's context window* flips the patch-id even though the branch's own added/removed lines are byte-identical → `shouldSkipForPatchId` misses → needless re-review. Existing tests only advanced the base in *unrelated* files, so they never exercised context drift.

Spike (single-hunk): default-context id `be3b82…`→`a0fe1a…` (flips, bug) vs `-U0` `1571f9…`→`1571f9…` (stable); a real edit → `e19327…` (still distinguished).

## Fix

Fingerprint at **`-U0` (zero context)** so the id keys only off the branch's own +/- lines. One change to the *shared* fingerprint covers **every** rebase path — autopilot `reEngageRebase`, the full-auto merge train, manual force-pushes, and the repo-level critic — matching the agreed "any agent rebase/force-push" scope. No path-specific code.

The critic's own review diff (full context), the changed-file set, and the fresh-fetch + three-dot merge-base logic are untouched — `-U0` affects only the skip fingerprint, not what the critic reads.

## Rebuts the original design rationale

The design spec (`docs/superpowers/specs/2026-06-03-skip-critic-rebase-design.md`) intentionally hashed context to catch conflict-resolution edits. `-U0` **still** catches those: a conflict resolution edits the branch's *own* +/- lines, so the id flips and the critic re-reviews. The only behavior removed is re-triggering on *pure base-only context drift* on a clean rebase — never the documented intent, just an incidental side effect of hashing context. Spec revised accordingly.

## Deliberate tradeoffs (noted in code + spec)

- **Wider skip window (intended):** base-only changes no longer re-trigger review even within 3 lines of a hunk — matches the merge-train philosophy that a clean rebase onto main is trusted.
- **Marginally wider collision surface:** dropping context means identical +/- line text relocated within a file can share an id → a rare false-skip. Per-file diff headers keep cross-file changes distinct; acceptable for a skip-vs-review decision that already errs toward reviewing on any failure.
- **One-time post-deploy re-review (self-healing):** in-flight sessions hold an old default-context id, so the first head after deploy re-reviews once, then the `-U0` id is stored and subsequent rebases match.

## Confidence

The spikes prove the *mechanism* (default-context patch-id flips on a clean rebase via context drift; `-U0` is stable, single- and multi-hunk). They do not replay the *specific* observed branch's history, but context drift is the only known way a clean rebase changes the current fingerprint — the strong leading explanation, stated honestly.

## Tests

- **Real-origin FETCH_HEAD context-drift invariance** (the production fetch path): red before the fix, green after.
- **Multi-hunk stability**: two hunks, base change between them, clean rebase — guards `patch-id --stable` invariance to `-U0` hunk grouping.
- Existing merge-train + real-edit + offline-fallback patch-id tests still pass.

## Verification

`bun run lint` ✓ · `bunx tsc --noEmit` ✓ · `bun test ./test` (4741 pass, 0 fail) ✓ · `fallow@2.100.0 audit` no issues in changed files ✓

[no-feature-entry] server-internal bugfix, no UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)