### PR TITLE
feat(manual-steps): gate auto-merge on un-acked manual operator steps (#1060)

### DIFF
--- a/src/automerge-core.ts
+++ b/src/automerge-core.ts
@@ -1,13 +1,14 @@
 import type { ChecksState, PrStatus } from "./forge/types";
 import type { ReviewDecision } from "./types";
+import type { ManualStep } from "./manual-steps";
 import { signedOff, type SignoffAuthority } from "./signoff";
 
 /** Why the merge train is holding — surfaced on automerge:status. */
 export interface MergeHoldReason {
-  code: "disabled" | "rebase_cap" | "idle";
-  /** A desig (rebase_cap) for the operator banner. */
+  code: "disabled" | "rebase_cap" | "idle" | "manual_steps";
+  /** A desig (rebase_cap / manual_steps) for the operator banner. */
   detail?: string;
-  /** The affected session's id, so the push deep-link selects it (rebase_cap). */
+  /** The affected session's id, so the push deep-link selects it (rebase_cap / manual_steps). */
   sessionId?: string;
 }
 
@@ -44,6 +45,11 @@ export interface MergeSessionView {
   /** True when this PR's merge is backed off (CAP rapid failures on the current head,
    *  inside the backoff window) → the core skips it so siblings can still merge. */
   mergeBlocked: boolean;
+  /** Manual operator steps detected in the PR body (#1059); [] when none. A non-`POST-MERGE`
+   *  step that is still un-acked (`manualStepsAckedAt == null`) holds auto-merge (#1060). */
+  manualSteps: ManualStep[];
+  /** Epoch ms the operator acknowledged the manual steps; null until acked. */
+  manualStepsAckedAt: number | null;
 }
 
 export interface MergeRepoState {
@@ -70,14 +76,25 @@ function signoffView(s: MergeSessionView) {
   };
 }
 
-/** True when this PR is clean enough to land RIGHT NOW: open, green, host-mergeable,
- *  up-to-date with main, and (critic on) a clean verdict for the current head.
+/** True when an un-acked, non-`POST-MERGE` manual operator step holds this PR (#1060). A
+ *  `POST-MERGE`-only PR never qualifies (those never gate — they only inform + carry forward).
+ *  Used as the `readyToMerge` disqualifier AND the rundown signal predicate — NOT as the
+ *  hold/push trigger (that additionally needs readyExceptManualSteps; see computeMerge). */
+function hasBlockingManualSteps(s: MergeSessionView): boolean {
+  return s.manualStepsAckedAt == null && s.manualSteps.some((st) => !st.postMerge);
+}
+
+/** True when this PR is clean enough to land RIGHT NOW *ignoring* the manual-steps gate: open,
+ *  green, host-mergeable, up-to-date with main, and (critic on) a clean verdict for the current
+ *  head. Split out from readyToMerge so computeMerge can tell "otherwise-ready, held only on
+ *  un-acked steps" (→ a manual_steps hold) apart from a PR that is red/draft/stale on its own
+ *  merits (which must NOT surface as a manual-steps hold or fire its push).
  *
  *  In draftMode it ALSO requires the configured `authority`'s sign-off. draftMode repos force
  *  auto-merge OFF (Task 1), so the merge train normally has NO sessions for them — this gate is
  *  defense-in-depth for config drift (a stray full-auto session in a draft repo), NOT dead code:
  *  it's exercised by tests. */
-function readyToMerge(
+function readyExceptManualSteps(
   s: MergeSessionView,
   criticEnabled: boolean,
   draftMode: boolean,
@@ -94,6 +111,19 @@ function readyToMerge(
     if (s.reviewHeadSha !== s.headSha) return false;
   }
   return true;
+}
+
+/** True when this PR is clean enough to land RIGHT NOW: readyExceptManualSteps AND not held by an
+ *  un-acked non-`POST-MERGE` manual step (#1060). */
+function readyToMerge(
+  s: MergeSessionView,
+  criticEnabled: boolean,
+  draftMode: boolean,
+  authority: SignoffAuthority,
+): boolean {
+  return (
+    readyExceptManualSteps(s, criticEnabled, draftMode, authority) && !hasBlockingManualSteps(s)
+  );
 }
 
 /** True when the PR is otherwise mergeable-intent but stale or conflicting: open, green,
@@ -146,6 +176,22 @@ export function computeMerge(state: MergeRepoState): MergeDecision {
       };
     }
     return { kind: "rebase", sessionId: stale.id, headSha: stale.headSha };
+  }
+
+  // A PR that is otherwise ready to land but held ONLY on un-acked non-POST-MERGE manual steps
+  // (#1060). Reported as a distinct hold (not idle) so the operator learns which PR is held and
+  // why; gated on readyExceptManualSteps so a red/draft/stale PR that merely declares steps never
+  // surfaces here (and never fires the manual_steps push, which rides this hold's status event).
+  const heldManual = state.sessions.find(
+    (s) =>
+      readyExceptManualSteps(s, state.criticEnabled, state.draftMode, state.signoffAuthority) &&
+      hasBlockingManualSteps(s),
+  );
+  if (heldManual) {
+    return {
+      kind: "hold",
+      reason: { code: "manual_steps", detail: heldManual.desig, sessionId: heldManual.id },
+    };
   }
 
   return { kind: "hold", reason: { code: "idle" } };

--- a/src/automerge.ts
+++ b/src/automerge.ts
@@ -167,6 +167,8 @@ export class AutoMergeService {
       rebaseCount: s.autoMergeRebaseCount,
       rebaseSteeredHead: s.autoMergeRebaseHead,
       mergeBlocked: this.computeMergeBlocked(s.id, pr.headSha),
+      manualSteps: s.manualSteps,
+      manualStepsAckedAt: s.manualStepsAckedAt,
     };
   }
 

--- a/src/hold-service.ts
+++ b/src/hold-service.ts
@@ -90,7 +90,8 @@ export class HoldReasonService {
       case "session:halt":
       case "session:autopilot":
       case "session:merging":
-      case "session:ready": {
+      case "session:ready":
+      case "session:manual-steps": {
         const id = d.id as string;
         this.recompute(id);
         break;
@@ -105,15 +106,7 @@ export class HoldReasonService {
       }
 
       case "automerge:status": {
-        const sessionId = d.sessionId as string | null;
-        if (!sessionId) return;
-        const state = d.state as string | null;
-        if (state === "merge_error" || state === "rebase_cap") {
-          this.mergeErrorSessions.add(sessionId);
-        } else {
-          this.mergeErrorSessions.delete(sessionId);
-        }
-        this.recompute(sessionId);
+        this.handleAutoMergeStatus(d);
         break;
       }
 
@@ -140,6 +133,21 @@ export class HoldReasonService {
         break;
       }
     }
+  }
+
+  /** Track merge-train error/cap state per session, then recompute. Extracted from handleEvent so
+   *  that switch stays under the complexity gate. A non-error state (incl. the manual_steps hold)
+   *  clears the error flag — manual-steps holds come from the session's own fields, not train state. */
+  private handleAutoMergeStatus(d: Record<string, unknown>): void {
+    const sessionId = d.sessionId as string | null;
+    if (!sessionId) return;
+    const state = d.state as string | null;
+    if (state === "merge_error" || state === "rebase_cap") {
+      this.mergeErrorSessions.add(sessionId);
+    } else {
+      this.mergeErrorSessions.delete(sessionId);
+    }
+    this.recompute(sessionId);
   }
 
   private recompute(id: string): void {

--- a/src/hold.ts
+++ b/src/hold.ts
@@ -79,6 +79,8 @@ const EN: CopyMap = {
   "merge-rebasing": (p) => `Rebasing in the merge train (attempt ${p.rebaseCount ?? "?"}).`,
   "ready-merge": (p) =>
     `Ready to merge${p.pr !== undefined ? ` (PR #${p.pr})` : ""} — waiting on you.`,
+  "manual-steps": (p) =>
+    `${p.steps ?? 1} manual step${(p.steps ?? 1) === 1 ? "" : "s"} to do before merge — ack to proceed.`,
 };
 
 const DE: CopyMap = {
@@ -118,6 +120,8 @@ const DE: CopyMap = {
   "merge-rebasing": (p) => `Rebase im Merge-Train (Versuch ${p.rebaseCount ?? "?"}).`,
   "ready-merge": (p) =>
     `Bereit zum Mergen${p.pr !== undefined ? ` (PR #${p.pr})` : ""} — wartet auf dich.`,
+  "manual-steps": (p) =>
+    `${p.steps ?? 1} manuelle${(p.steps ?? 1) === 1 ? "r" : ""} Schritt${(p.steps ?? 1) === 1 ? "" : "e"} vor dem Mergen — bestätigen zum Fortfahren.`,
 };
 
 /** Server-side localized copy for a hold reason. Locale "de" → German, else English. */

--- a/src/push.ts
+++ b/src/push.ts
@@ -23,6 +23,7 @@ export interface PushPayload {
     | "extra_credits"
     | "learnings_retired"
     | "learnings_trialed"
+    | "manual_steps"
     | "ready";
   tag: string;
 }
@@ -44,6 +45,7 @@ const KIND_CATEGORY: Record<PushPayload["kind"], PushCategory> = {
   extra_credits: "agent",
   learnings_retired: "agent",
   learnings_trialed: "agent",
+  manual_steps: "ci",
   ready: "agent",
 };
 
@@ -62,6 +64,7 @@ export interface NotifyInput {
     | "extra_credits"
     | "learnings_retired"
     | "learnings_trialed"
+    | "manual_steps"
     | "ready";
   sessionId: string;
   tag: string;
@@ -149,6 +152,8 @@ const NOTIFY_TEXT = {
       `${n} ${n === 1 ? "proposal" : "proposals"} auto-promoted to trial — tap to review.`,
     readyTitle: (name: string) => `${name} — your turn`,
     readyBody: "Waiting on you for 5s — your turn.",
+    manualStepsTitle: (name: string) => `${name} — manual steps`,
+    manualStepsBody: "Ready to merge, but held until you ack the manual steps it needs.",
   },
   de: {
     doneTitle: (name: string) => `${name} — wartet`,
@@ -188,6 +193,9 @@ const NOTIFY_TEXT = {
       `${n} ${n === 1 ? "Vorschlag" : "Vorschläge"} automatisch in den Test übernommen — zum Prüfen tippen.`,
     readyTitle: (name: string) => `${name} — du bist dran`,
     readyBody: "Wartet seit 5s auf dich — du bist dran.",
+    manualStepsTitle: (name: string) => `${name} — manuelle Schritte`,
+    manualStepsBody:
+      "Bereit zum Mergen, aber zurückgehalten, bis du die manuellen Schritte bestätigst.",
   },
 } as const;
 
@@ -303,6 +311,8 @@ export function buildPayload(input: NotifyInput, locale: string): PushPayload {
       };
     case "ready":
       return { ...base, title: t.readyTitle(input.name), body: t.readyBody };
+    case "manual_steps":
+      return { ...base, title: t.manualStepsTitle(input.name), body: t.manualStepsBody };
     default:
       return {
         ...base,
@@ -481,6 +491,25 @@ export function attachMergePush(events: EventHub, push: PushService): void {
       detail: string | null;
       sessionId: string | null;
     };
+    // A green, up-to-date, otherwise-ready PR held ONLY on un-acked manual operator steps (#1060):
+    // the "don't let auto-merge eat this" nudge. computeMerge emits this state only for a PR that
+    // is ready except for the gate, so it never fires for a red/draft PR. Per-session tag +
+    // cooldown key; the cooldown stamp is set inside notify() only on a successful send (house rule
+    // — optimistic stamping drops the signal).
+    if (state === "manual_steps") {
+      const desig = detail ?? repoPath;
+      const target = sessionId ?? repoPath;
+      void push
+        .notify({
+          kind: "manual_steps",
+          sessionId: target,
+          tag: `manual_steps:${target}`,
+          name: desig,
+          cooldownKey: `manual_steps:${target}`,
+        })
+        .catch((err) => console.warn("[push] manual_steps notify failed:", err));
+      return;
+    }
     if (state !== "merge_error" && state !== "rebase_cap") return;
     const desig = detail ?? repoPath;
     // Deep-link to the affected session when known; fall back to repoPath.

--- a/src/rundown-core.ts
+++ b/src/rundown-core.ts
@@ -54,6 +54,7 @@ export type SignalCode =
   | "plan-rework"
   | "critic-rework"
   | "ci-red"
+  | "manual-steps"
   | "awaiting-merge"
   | "stalled"
   | "recap-attention"
@@ -71,6 +72,7 @@ const SIGNAL_TIER: Record<SignalCode, AttentionTier> = {
   "plan-rework": 1,
   "critic-rework": 1,
   "ci-red": 1,
+  "manual-steps": 1,
   "halted-usage": 2,
   "awaiting-merge": 2,
   stalled: 2,
@@ -123,6 +125,18 @@ const ATTENTION_RULES: Array<{
   },
   { signal: "critic-rework", when: (_s, c) => c.review?.decision === "changes_requested" },
   { signal: "ci-red", when: (_s, c) => c.git?.checks === "failure" },
+  // manual-steps: a PR declares un-acked, non-POST-MERGE manual operator steps that gate its
+  // auto-merge (#1060). Last in the Tier-1 block so a genuinely-more-urgent co-signal stays the
+  // PRIMARY hold line while the session still classifies Tier-1. Requires an OPEN PR so it can't
+  // fire pre-PR (no steps yet) or post-merge (a PR a human merged manually before archive), where
+  // the gate is moot. POST-MERGE-only steps never qualify (they only inform + carry forward).
+  {
+    signal: "manual-steps",
+    when: (s, c) =>
+      s.manualStepsAckedAt == null &&
+      c.git?.state === "open" &&
+      s.manualSteps.some((st) => !st.postMerge),
+  },
   // Tier 2: HIGH — needs a look soon, not yet a hard stop.
   { signal: "halted-usage", when: (s) => s.haltReason === "usage_limit" },
   // awaiting-merge: operator's turn — the server has handed the PR off to a merger.
@@ -211,6 +225,10 @@ const SIGNAL_TO_HOLD: Record<
   "ready-merge": (_session, caches) => {
     const pr = caches.git?.number;
     return pr !== undefined ? { code: "ready-merge", params: { pr } } : { code: "ready-merge" };
+  },
+  "manual-steps": (session) => {
+    const steps = session.manualSteps.filter((st) => !st.postMerge).length;
+    return { code: "manual-steps", params: { steps } };
   },
   stalled: () => ({ code: "stalled" }),
   "recap-attention": () => ({ code: "recap-attention" }),

--- a/src/server.ts
+++ b/src/server.ts
@@ -4615,6 +4615,30 @@ async function handleEpicsCompletedAckMigrations({
   return json({ ok: true });
 }
 
+// POST /api/sessions/:id/ack-manual-steps — acknowledge a session's manual operator steps (#1060):
+// stamps manualStepsAckedAt, clearing the auto-merge gate. Ack = "operator owns these"
+// (acknowledged-will-do, mirrors handleEpicsCompletedAckMigrations) — NOT an assertion the steps
+// are done. Idempotent (store.ackManualSteps COALESCEs the first ack time). Emits
+// session:manual-steps (with the fresh ackedAt) so the live hold + chip + CTA recompute on every
+// client.
+async function handleSessionsAckManualSteps({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (!(parts[0] === "api" && parts[1] === "sessions" && parts[3] === "ack-manual-steps"))
+    return null;
+  const id = parts[2];
+  if (!id || parts[4]) return null;
+  if (req.method !== "POST") return null;
+  const session = deps.store.get(id);
+  if (!session) return json({ error: "session not found" }, 404);
+  deps.store.ackManualSteps(id);
+  const updated = deps.store.get(id);
+  deps.events?.emit("session:manual-steps", {
+    id,
+    manualSteps: updated?.manualSteps ?? session.manualSteps,
+    manualStepsAckedAt: updated?.manualStepsAckedAt ?? null,
+  });
+  return json({ ok: true });
+}
+
 // Validate + resolve everything needed to perform a land merge. Returns { error: Response } on any
 // failure (wrong body, missing row, wrong state, no forge, no branch, prStatus throw, not ready),
 // or the resolved targets on success. Extracted to keep handleEpicsCompletedLand below the
@@ -4744,6 +4768,7 @@ const ROUTE_HANDLERS = [
   handleEpicsList,
   handleEpicsCompletedDismiss,
   handleEpicsCompletedAckMigrations,
+  handleSessionsAckManualSteps,
   handleEpicsCompletedLand,
   handleEpicsCompletedList,
   handleEpicApproveNext,

--- a/src/store.ts
+++ b/src/store.ts
@@ -2337,6 +2337,18 @@ export class SessionStore implements CapStore, CreditStore {
     ]);
   }
 
+  /** Acknowledge a session's manual operator steps (#1060): stamp `manualStepsAckedAt`, clearing
+   *  the auto-merge gate. Ack = "operator owns these" (acknowledged-will-do, mirrors
+   *  {@link ackEpicMigrations}) — NOT an assertion the steps are done. Idempotent: `COALESCE`
+   *  keeps the FIRST ack time, so a re-ack is a durable no-op. */
+  ackManualSteps(id: string): void {
+    const now = Date.now();
+    this.db.run(
+      `UPDATE sessions SET manualStepsAckedAt = COALESCE(manualStepsAckedAt, ?), updatedAt = ? WHERE id = ?`,
+      [now, now, id],
+    );
+  }
+
   // ── reviewer spawn cost attribution ──────────────────────────────────────────
   /** Record a freshly-spawned reviewer session. Token/completed columns stay NULL until
    *  finalize (`completeReviewerSpawn`). A plain INSERT is correct — every spawn forces a

--- a/src/types.ts
+++ b/src/types.ts
@@ -814,7 +814,8 @@ export type HoldCode =
   | "recap-attention"
   | "merging"
   | "merge-rebasing"
-  | "ready-merge";
+  | "ready-merge"
+  | "manual-steps";
 
 /** Display params interpolated into the localized hold line. All optional; each code
  *  uses the subset it needs. `question` is verbatim agent text (not translated). */
@@ -826,6 +827,7 @@ export interface HoldParams {
   pr?: number; // ci-red/awaiting-merge/train-error/merging/ready-merge
   rebaseCount?: number; // merge-rebasing: auto-rebase attempts
   question?: string; // autopilot-paused: the agent's hand-back question (verbatim)
+  steps?: number; // manual-steps: count of un-acked non-POST-MERGE manual operator steps
 }
 
 export interface HoldReason {

--- a/test/automerge-core.test.ts
+++ b/test/automerge-core.test.ts
@@ -19,6 +19,8 @@ function sess(o: Partial<MergeSessionView> = {}): MergeSessionView {
     rebaseCount: 0,
     rebaseSteeredHead: null,
     mergeBlocked: false,
+    manualSteps: [],
+    manualStepsAckedAt: null,
     ...o,
   };
 }
@@ -187,4 +189,52 @@ test("draftMode + signed + behind → rebase (signed drafts still rebase to stay
     }),
   );
   expect(d).toEqual({ kind: "rebase", sessionId: "s1", headSha: "h1" });
+});
+
+// ── manual operator steps gate (#1060) ──────────────────────────────────────────
+
+const step = (text: string, postMerge = false) => ({ id: "ms1", text, postMerge });
+
+test("gate ON: otherwise-ready PR with an un-acked non-POST-MERGE step → manual_steps hold (not merge)", () => {
+  const d = computeMerge(state([sess({ manualSteps: [step("flip the flag")] })]));
+  expect(d).toEqual({
+    kind: "hold",
+    reason: { code: "manual_steps", detail: "TASK-01", sessionId: "s1" },
+  });
+});
+
+test("gate CLEARED by ack: manualStepsAckedAt set → merge proceeds", () => {
+  const d = computeMerge(
+    state([sess({ manualSteps: [step("flip the flag")], manualStepsAckedAt: 123 })]),
+  );
+  expect(d).toEqual({ kind: "merge", sessionId: "s1", prNumber: 7, headSha: "h1" });
+});
+
+test("POST-MERGE-only steps never block → merge proceeds", () => {
+  const d = computeMerge(
+    state([sess({ manualSteps: [step("run the backfill", true)], manualStepsAckedAt: null })]),
+  );
+  expect(d).toEqual({ kind: "merge", sessionId: "s1", prNumber: 7, headSha: "h1" });
+});
+
+test("manual_steps hold requires otherwise-ready: a NOT-green PR with steps → idle hold, not manual_steps", () => {
+  const d = computeMerge(
+    state([sess({ checks: "pending", manualSteps: [step("flip the flag")] })]),
+  );
+  expect(d).toEqual({ kind: "hold", reason: { code: "idle" } });
+});
+
+test("manual_steps hold requires otherwise-ready: a BEHIND PR with steps → rebase, not manual_steps", () => {
+  const d = computeMerge(state([sess({ behind: true, manualSteps: [step("flip the flag")] })]));
+  expect(d).toEqual({ kind: "rebase", sessionId: "s1", headSha: "h1" });
+});
+
+test("held-on-steps PR is skipped while a ready sibling merges first", () => {
+  const d = computeMerge(
+    state([
+      sess({ id: "a", manualSteps: [step("flip the flag")] }),
+      sess({ id: "b", headSha: "hB" }),
+    ]),
+  );
+  expect(d).toEqual({ kind: "merge", sessionId: "b", prNumber: 7, headSha: "hB" });
 });

--- a/test/automerge.test.ts
+++ b/test/automerge.test.ts
@@ -16,6 +16,8 @@ function baseSession(over: any = {}) {
     autoMergeEnabled: true,
     autoMergeRebaseCount: 0,
     autoMergeRebaseHead: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
     ...over,
   };
 }
@@ -284,6 +286,37 @@ test("rebase_cap: behind session at cap → no reply steer, emitStatus rebase_ca
   const calls: any[] = (emitStatus as any).mock.calls;
   const capCall = calls.find((c) => c[0]?.state === "rebase_cap");
   expect(capCall).toBeDefined();
+});
+
+test("manual_steps gate: otherwise-ready PR with an un-acked step → emitStatus manual_steps, no merge (#1060)", async () => {
+  const emitStatus = mock(() => {});
+  const merge = mock(async () => {});
+  const session = baseSession({
+    manualSteps: [{ id: "ms1", text: "flip the flag", postMerge: false }],
+    manualStepsAckedAt: null,
+  });
+  const d = deps({
+    store: {
+      get: () => session as any,
+      list: () => [session as any],
+      getRepoConfig: () =>
+        ({ autoMergeEnabled: true, criticEnabled: false, autopilotEnabled: true }) as any,
+      getReview: () => null,
+      setAutoMergeState: mock(() => {}),
+      setAutopilotState: mock(() => {}),
+      isEpicIntegratedChild: () => false,
+    } as any,
+    resolveForge: () =>
+      ({ kind: "github", mergeMethod: "squash", merge, closeIssue: mock(async () => {}) }) as any,
+    emitStatus,
+  });
+  const svc = new AutoMergeService(d);
+  await svc.pump("/r");
+  expect(merge.mock.calls.length).toBe(0); // held — not merged
+  const calls: any[] = (emitStatus as any).mock.calls;
+  const held = calls.find((c) => c[0]?.state === "manual_steps");
+  expect(held?.[0]?.sessionId).toBe("s1");
+  expect(held?.[0]?.detail).toBe("TASK-01");
 });
 
 // ── rebase counter reset on progress ──────────────────────────────────────────

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -1015,6 +1015,46 @@ test("attachMergePush notifies on merge_error and rebase_cap, ignores other stat
   });
 });
 
+test("attachMergePush notifies manual_steps with a per-session dedupe key (#1060)", async () => {
+  const calls: any[] = [];
+  const { push } = svc(async () => ({}));
+  (push as any).notify = async (p: any) => calls.push(p);
+  const events = new EventHub();
+  attachMergePush(events, push);
+
+  events.emit("automerge:status", {
+    repoPath: "/repo/a",
+    enabled: true,
+    state: "manual_steps",
+    detail: "TASK-42",
+    sessionId: "sess-x",
+  });
+  await Promise.resolve();
+
+  expect(calls.length).toBe(1);
+  expect(calls[0]).toMatchObject({
+    kind: "manual_steps",
+    sessionId: "sess-x",
+    name: "TASK-42",
+    tag: "manual_steps:sess-x",
+    cooldownKey: "manual_steps:sess-x",
+  });
+});
+
+test("buildPayload manual_steps localizes title + body by locale (#1060)", () => {
+  const input = {
+    kind: "manual_steps" as const,
+    sessionId: "sess-x",
+    tag: "manual_steps:sess-x",
+    name: "TASK-42",
+  };
+  expect(buildPayload(input, "en")).toMatchObject({
+    kind: "manual_steps",
+    title: "TASK-42 — manual steps",
+  });
+  expect(buildPayload(input, "de").title).toBe("TASK-42 — manuelle Schritte");
+});
+
 // ── reducedPushMode tests ─────────────────────────────────────────────────────
 
 let _savedReducedPushMode: boolean;

--- a/test/rundown-core.test.ts
+++ b/test/rundown-core.test.ts
@@ -194,6 +194,59 @@ test("classifyAttention: merger handoff → awaiting-merge (tier 2), not ready-m
   expect(r.signals).not.toContain("ready-merge");
 });
 
+// ── manual operator steps signal (#1060) ─────────────────────────────────────
+
+const mstep = (text: string, postMerge = false) => ({ id: "ms1", text, postMerge });
+
+test("classifyAttention: un-acked non-POST-MERGE step on an open PR → manual-steps (tier 1)", () => {
+  const r = classifyAttention(
+    session({ status: "idle", manualSteps: [mstep("flip the flag")], manualStepsAckedAt: null }),
+    { git: git() },
+    NOW,
+  );
+  expect(r.tier).toBe(1);
+  expect(r.signals).toContain("manual-steps");
+});
+
+test("classifyAttention: acked steps → no manual-steps signal", () => {
+  const r = classifyAttention(
+    session({ status: "idle", manualSteps: [mstep("flip the flag")], manualStepsAckedAt: 123 }),
+    { git: git() },
+    NOW,
+  );
+  expect(r.signals).not.toContain("manual-steps");
+});
+
+test("classifyAttention: POST-MERGE-only steps → no manual-steps signal", () => {
+  const r = classifyAttention(
+    session({ status: "idle", manualSteps: [mstep("run the backfill", true)] }),
+    { git: git() },
+    NOW,
+  );
+  expect(r.signals).not.toContain("manual-steps");
+});
+
+test("classifyAttention: steps but no open PR → no manual-steps signal (gate is moot)", () => {
+  const r = classifyAttention(
+    session({ status: "idle", manualSteps: [mstep("flip the flag")] }),
+    { git: git({ state: "merged" }) },
+    NOW,
+  );
+  expect(r.signals).not.toContain("manual-steps");
+});
+
+test("explainHold: manual-steps → hold reason with the non-POST-MERGE step count", () => {
+  const hold = explainHold(
+    session({
+      status: "idle",
+      manualSteps: [mstep("flip the flag"), mstep("run the backfill", true), mstep("seed a row")],
+    }),
+    { git: git() },
+    NOW,
+  );
+  expect(hold).toEqual({ code: "manual-steps", params: { steps: 2 } });
+});
+
 // ── assembleHerdState — Tier-1 never dropped by top-N ─────────────────────────
 
 test("assembleHerdState: Tier-1 always kept, only Tier-3 dropped, truncatedTier3 set", () => {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1223,3 +1223,17 @@ test("parseMergeTrainPrsJson: non-number elements treated as corrupt → null", 
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("ackManualSteps stamps manualStepsAckedAt and is idempotent (first ack wins) — #1060", () => {
+  const s = mk();
+  const a = s.create(base);
+  expect(s.get(a.id)!.manualStepsAckedAt).toBeNull();
+
+  s.ackManualSteps(a.id);
+  const first = s.get(a.id)!.manualStepsAckedAt;
+  expect(first).not.toBeNull();
+
+  // Re-ack is a durable no-op: COALESCE keeps the original ack time.
+  s.ackManualSteps(a.id);
+  expect(s.get(a.id)!.manualStepsAckedAt).toBe(first);
+});

--- a/test/task5-completion-barrier.test.ts
+++ b/test/task5-completion-barrier.test.ts
@@ -264,6 +264,8 @@ test("computeMerge → merge for a LocalForge-shaped ready view (proves auto-mer
     rebaseCount: 0,
     rebaseSteeredHead: null,
     mergeBlocked: false,
+    manualSteps: [],
+    manualStepsAckedAt: null,
   };
   const state: MergeRepoState = {
     enabled: true,

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -489,6 +489,8 @@
   "unitrow_preview_badge": "Vorschau",
   "unitrow_preview_badge_degraded": "Vorschau; Tailscale-Registrierung fehlgeschlagen, nur über Loopback erreichbar",
   "unitrow_manual_steps": "{count} manuelle(r) Schritt(e)",
+  "unitrow_ack_manual_steps": "Schritte best.",
+  "unitrow_ack_manual_steps_failed": "Manuelle Schritte konnten nicht bestätigt werden — bitte erneut versuchen.",
   "viewport_preview_serve_failed": "Tailscale-Registrierung für diesen Vorschau-Port fehlgeschlagen; nur über Loopback erreichbar. Nutze 'In neuem Tab öffnen', wenn der Frame leer bleibt.",
   "viewport_git_actions": "PR",
   "viewport_git_actions_title": "PR, Merge, Kritiker & Merge-Freigabe",
@@ -1847,6 +1849,7 @@
   "hold_merging": "Im Merge-Train.",
   "hold_merge_rebasing": "Rebase im Merge-Train (Versuch {rebaseCount}).",
   "hold_ready_merge": "Bereit zum Mergen — wartet auf Sie.",
+  "hold_manual_steps": "{steps} manuelle(r) Schritt(e) vor dem Mergen — bestätigen zum Fortfahren.",
   "feat_why_parked_title": "Warum wartet diese Sitzung?",
   "feat_why_parked_body": "Gehaltene, blockierte und von einem Gate aufgehaltene Sitzungen zeigen jetzt einen einzeiligen Grund auf der Karte und in der Triage-Schublade — damit du auf einen Blick siehst, warum eine Sitzung deine Aufmerksamkeit braucht.",
   "feat_usage_task_names_title": "Aufgabennamen in der Nutzung",
@@ -1895,5 +1898,7 @@
   "feat_decommission_on_merge_title": "Stilllegen nach dem Merge",
   "feat_decommission_on_merge_body": "Nachdem du den PR einer Session gemerged hast, bietet die Bestätigungsmeldung jetzt ein Ein-Klick-Stilllegen, um die abgeschlossene Session zu entfernen – kein Suchen nach dem Button mehr.",
   "feat_manual_operator_steps_title": "Manuelle Operator-Schritte",
-  "feat_manual_operator_steps_body": "Deklariere manuelle Schritte im shepherd:manual-steps-Block eines PR (Flag umlegen, Umgebungsvariable setzen, Backfill ausführen), und Shepherd zeigt sie als bernsteinfarbenen Chip in der Session-Zeile sowie als Checkliste im Done-Recap an – damit sie beim Mergen des PR nicht verloren gehen."
+  "feat_manual_operator_steps_body": "Deklariere manuelle Schritte im shepherd:manual-steps-Block eines PR (Flag umlegen, Umgebungsvariable setzen, Backfill ausführen), und Shepherd zeigt sie als bernsteinfarbenen Chip in der Session-Zeile sowie als Checkliste im Done-Recap an – damit sie beim Mergen des PR nicht verloren gehen.",
+  "feat_manual_operator_steps_gate_title": "Manuelle Schritte blockieren Auto-Merge",
+  "feat_manual_operator_steps_gate_body": "Ein PR mit einem unbestätigten manuellen Schritt (alles, was nicht als POST-MERGE markiert ist) wird jetzt vom Auto-Merge zurückgehalten, bis du handelst. Klicke in der Session-Zeile auf \"Schritte best.\", um die Sperre aufzuheben; du wirst per Push und im täglichen Rundown erinnert. Reine POST-MERGE-Schritte blockieren nie."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -489,6 +489,8 @@
   "unitrow_preview_badge": "Preview",
   "unitrow_preview_badge_degraded": "Preview; Tailscale registration failed, reachable on loopback only",
   "unitrow_manual_steps": "{count} manual step(s)",
+  "unitrow_ack_manual_steps": "Ack steps",
+  "unitrow_ack_manual_steps_failed": "Couldn't acknowledge the manual steps — try again.",
   "viewport_preview_serve_failed": "Tailscale registration failed for this preview port; it's reachable on loopback only. Use Open in new tab if the frame is blank.",
   "viewport_git_actions": "PR",
   "viewport_git_actions_title": "PR, merge, critic & ready-to-merge actions",
@@ -1847,6 +1849,7 @@
   "hold_merging": "In the merge train.",
   "hold_merge_rebasing": "Rebasing in the merge train (attempt {rebaseCount}).",
   "hold_ready_merge": "Ready to merge — waiting on you.",
+  "hold_manual_steps": "{steps} manual step(s) to do before merge — ack to proceed.",
   "feat_why_parked_title": "Why is this parked?",
   "feat_why_parked_body": "Held, blocked and gate-stuck sessions now show a one-line reason on the card and in the triage drawer — so you can see why a session needs you at a glance.",
   "feat_usage_task_names_title": "Task names in Usage",
@@ -1895,5 +1898,7 @@
   "feat_decommission_on_merge_title": "Decommission after merge",
   "feat_decommission_on_merge_body": "After you merge a session's PR, the confirmation toast now offers a one-click Decommission to tear the finished session down — no hunting for the button.",
   "feat_manual_operator_steps_title": "Manual operator steps",
-  "feat_manual_operator_steps_body": "Declare manual steps in a PR's shepherd:manual-steps block (flip a flag, set an env var, run a backfill) and Shepherd surfaces them as an amber chip on the session row and a checklist in the Done recap — so they aren't lost when the PR lands."
+  "feat_manual_operator_steps_body": "Declare manual steps in a PR's shepherd:manual-steps block (flip a flag, set an env var, run a backfill) and Shepherd surfaces them as an amber chip on the session row and a checklist in the Done recap — so they aren't lost when the PR lands.",
+  "feat_manual_operator_steps_gate_title": "Manual steps gate auto-merge",
+  "feat_manual_operator_steps_gate_body": "A PR with an un-acknowledged manual step (anything not marked POST-MERGE) is now held out of auto-merge until you act. Click \"Ack steps\" on the session row to clear the gate; you're nudged via push and the daily rundown. POST-MERGE-only steps never block."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1562,6 +1562,15 @@ export async function ackEpicMigrations(
   );
 }
 
+/** Acknowledge a session's manual operator steps (#1060), clearing the auto-merge gate. */
+export async function ackManualSteps(sessionId: string): Promise<{ ok: boolean }> {
+  return postJson(
+    `/api/sessions/${encodeURIComponent(sessionId)}/ack-manual-steps`,
+    {},
+    "acknowledge manual steps",
+  );
+}
+
 /** Merge the landing PR for a completed epic (#1039). Fails non-2xx on not-ready / not-open / no row
  *  (409), merge failure (502), or invalid input (400). On success the server emits an `epic:completed`
  *  WS event with the updated row (`landingState:"merged"`) so the band updates live. */

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -69,6 +69,7 @@
     onrundownepic = undefined,
     focusEpic = null,
     onackmigrationsepic = undefined,
+    onackmanualsteps = undefined,
   }: {
     sessions: Session[];
     selectedId: string | null;
@@ -168,6 +169,8 @@
     focusEpic?: { repo: string; parent: number } | null;
     // acknowledge a completed epic's landing-PR migrations (#645); also clears the row
     onackmigrationsepic?: (repoPath: string, parent: number) => void;
+    // acknowledge a session's manual operator steps (#1060); clears its auto-merge gate
+    onackmanualsteps?: (id: string) => void;
   } = $props();
 
   // a critic post-PR review or a pre-execution plan-gate review currently in flight —
@@ -289,6 +292,7 @@
     workingBlocked,
     quotaKindFor,
     holdFor,
+    onackmanualsteps,
   });
 
   // Lifecycle groups in display order — each entry maps to a <HerdGroup> render.

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -67,6 +67,7 @@
     workingBlocked = {},
     quotaKind = null,
     hold = undefined,
+    onackmanualsteps,
   }: {
     session: Session;
     selected: boolean;
@@ -102,6 +103,8 @@
     quotaKind?: "rework" | "review" | "error" | "plan" | null;
     // hold reason for this session; when present renders a muted "why parked" subline
     hold?: HoldReason;
+    // when provided, the manual-steps chip gains an "Ack" CTA that clears the auto-merge gate (#1060)
+    onackmanualsteps?: (id: string) => void;
   } = $props();
 
   // Every status-driven DISPLAY branch below reads this, not session.status: a
@@ -111,6 +114,13 @@
 
   // repo the unit works in — the last path segment of its repoPath (e.g. "community-map")
   const repoName = $derived(session.repoPath.split("/").filter(Boolean).at(-1) ?? session.repoPath);
+
+  // True when an un-acked, non-POST-MERGE manual step holds this session's auto-merge (#1060).
+  // POST-MERGE-only steps never gate, so they show the chip but no Ack CTA. Mirrors the server
+  // hasBlockingManualSteps predicate (src/automerge-core.ts).
+  const hasBlockingManualSteps = $derived(
+    session.manualStepsAckedAt == null && session.manualSteps.some((s) => !s.postMerge),
+  );
   const repoIcon = $derived(projectIcons.iconFor(session.repoPath));
   const repoFiltered = $derived(repoFilter === session.repoPath);
   function toggleRepoFilter() {
@@ -443,6 +453,19 @@
         >
           {m.unitrow_manual_steps({ count: session.manualSteps.length })}
         </span>
+        {#if hasBlockingManualSteps && onackmanualsteps}
+          <button
+            type="button"
+            class="manual-steps-ack"
+            title={m.unitrow_ack_manual_steps()}
+            onclick={(e) => {
+              e.stopPropagation();
+              onackmanualsteps?.(session.id);
+            }}
+          >
+            {m.unitrow_ack_manual_steps()}
+          </button>
+        {/if}
       {/if}
       {#if showStepper && !session.readyToMerge}
         <span class="meta-stepper">
@@ -851,6 +874,33 @@
     border-radius: 2px;
     color: var(--status-warn);
     background: color-mix(in oklab, var(--status-warn) 12%, transparent);
+  }
+  /* "Ack" CTA beside the manual-steps chip — warn-toned, micro, clears the auto-merge gate (#1060) */
+  .manual-steps-ack {
+    flex: none;
+    font-family: var(--font-mono);
+    font-size: var(--fs-micro);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 1px 6px;
+    border: 1px solid var(--status-warn);
+    border-radius: 2px;
+    color: var(--status-warn);
+    background: transparent;
+    cursor: pointer;
+    transition:
+      border-color 0.12s,
+      color 0.12s,
+      background 0.12s;
+  }
+  .manual-steps-ack:hover {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+    background: color-mix(in oklab, var(--status-warn) 12%, transparent);
+  }
+  .manual-steps-ack:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
   }
   /* thin stage stepper on the quietest row — pushed to the right edge */
   .meta-stepper {

--- a/ui/src/lib/components/herd/HerdGroup.svelte
+++ b/ui/src/lib/components/herd/HerdGroup.svelte
@@ -20,6 +20,8 @@
     quotaKindFor: (id: string) => "rework" | "review" | "error" | "plan" | null;
     // returns the hold reason for a session, or undefined if none
     holdFor: (id: string) => HoldReason | undefined;
+    // acknowledge a session's manual operator steps, clearing its auto-merge gate (#1060)
+    onackmanualsteps?: (id: string) => void;
   };
 
   type ActionDef = {
@@ -83,6 +85,7 @@
     workingBlocked={ctx.workingBlocked}
     quotaKind={ctx.quotaKindFor(session.id)}
     hold={ctx.holdFor(session.id)}
+    onackmanualsteps={ctx.onackmanualsteps}
   />
 {/each}
 

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1548,4 +1548,15 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_manual_operator_steps_title",
     bodyKey: "feat_manual_operator_steps_body",
   },
+  {
+    // P2 of the manual-operator-steps epic (#1060): those declared steps now GATE auto-merge. A PR
+    // with an un-acked, non-POST-MERGE step is held out of the merge train with a clear reason; an
+    // "Ack steps" button on the session row clears the gate, and you're nudged via push + the daily
+    // rundown. POST-MERGE-only steps never block. No targetId — the chip/CTA mount only when steps
+    // are detected; surface via the What's-New drawer only. Ships in 1.37.0 alongside P1.
+    id: "manual-operator-steps-gate",
+    sinceVersion: "1.37.0",
+    titleKey: "feat_manual_operator_steps_gate_title",
+    bodyKey: "feat_manual_operator_steps_gate_body",
+  },
 ];

--- a/ui/src/lib/hold.ts
+++ b/ui/src/lib/hold.ts
@@ -38,6 +38,7 @@ const HOLD_LINE: Record<HoldCode, (hold: HoldReason) => string> = {
   "merge-rebasing": ({ params: p = {} }) =>
     m.hold_merge_rebasing({ rebaseCount: p.rebaseCount ?? 0 }),
   "ready-merge": () => m.hold_ready_merge(),
+  "manual-steps": ({ params: p = {} }) => m.hold_manual_steps({ steps: p.steps ?? 1 }),
 };
 
 /** Return a localized one-line description for a hold reason. Used by Task-7 components. */

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -374,7 +374,14 @@ export class HerdStore {
         });
         return true;
       case "session:manual-steps":
-        this.patchSession(ev.data.id, { manualSteps: ev.data.manualSteps });
+        this.patchSession(ev.data.id, {
+          manualSteps: ev.data.manualSteps,
+          // ackedAt rides along on the ack broadcast (#1060) so the CTA clears on every client;
+          // the P1 detection emit omits it (steps changed, ack unchanged) → leave it untouched.
+          ...(ev.data.manualStepsAckedAt !== undefined
+            ? { manualStepsAckedAt: ev.data.manualStepsAckedAt }
+            : {}),
+        });
         return true;
       default:
         return false;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -161,7 +161,8 @@ export type HoldCode =
   | "recap-attention"
   | "merging"
   | "merge-rebasing"
-  | "ready-merge";
+  | "ready-merge"
+  | "manual-steps";
 
 /** Display params interpolated into the localized hold line. All optional; each code
  *  uses the subset it needs. `question` is verbatim agent text (not translated). */
@@ -173,6 +174,7 @@ export interface HoldParams {
   pr?: number; // ci-red/awaiting-merge/train-error/merging/ready-merge
   rebaseCount?: number; // merge-rebasing: auto-rebase attempts
   question?: string; // autopilot-paused: the agent's hand-back question (verbatim)
+  steps?: number; // manual-steps: count of un-acked non-POST-MERGE manual operator steps
 }
 
 export interface HoldReason {
@@ -1063,7 +1065,10 @@ export type WsEvent =
       data: { id: string; haltReason: Session["haltReason"]; haltedAt: number | null };
     }
   | { event: "session:git"; data: { id: string; git: GitState } }
-  | { event: "session:manual-steps"; data: { id: string; manualSteps: ManualStep[] } }
+  | {
+      event: "session:manual-steps";
+      data: { id: string; manualSteps: ManualStep[]; manualStepsAckedAt?: number | null };
+    }
   | { event: "session:activity"; data: { id: string; activity: SessionActivity } }
   | { event: "session:subagents"; data: { id: string; subagents: SubagentEntry[] } }
   | { event: "session:claude-alive"; data: { id: string; claudeAlive: boolean } }

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -32,6 +32,7 @@
     getCompletedEpics,
     dismissCompletedEpic,
     ackEpicMigrations,
+    ackManualSteps,
     landEpic,
     getEpic,
     getDiagnostics,
@@ -1611,6 +1612,22 @@
     }
   }
 
+  // Acknowledge a session's manual operator steps (#1060), clearing its auto-merge gate. The
+  // server emits session:manual-steps with the fresh ackedAt on success, so the chip/CTA clear
+  // live via the WS handler — no optimistic mutation needed. On failure, a persistent, tone-
+  // namespaced keyed toast (shared store, not transient info) so a flapping failure can't stack.
+  async function onAckManualSteps(id: string) {
+    try {
+      await ackManualSteps(id);
+    } catch {
+      toasts.info(m.unitrow_ack_manual_steps_failed(), {
+        alert: true,
+        duration: null,
+        key: `ack-manual-steps-fail:${id}`,
+      });
+    }
+  }
+
   // Merge the landing PR for a completed epic (#1039). Server emits epic:completed on success
   // (landingState:"merged") so the band updates live — no optimistic mutation needed here.
   async function onLandEpic(repoPath: string, parent: number) {
@@ -1817,6 +1834,7 @@
             onrundownepic={selectRundownEpic}
             {focusEpic}
             onackmigrationsepic={onAckEpicMigrations}
+            onackmanualsteps={onAckManualSteps}
           />
           {#if store.sessions.length === 0 && herdFilter !== "done" && herdFilter !== "rundown"}
             <BacklogView
@@ -1976,6 +1994,7 @@
             onrundownepic={selectRundownEpic}
             {focusEpic}
             onackmigrationsepic={onAckEpicMigrations}
+            onackmanualsteps={onAckManualSteps}
           />
         {/if}
         {#if herdFilter === "rundown"}


### PR DESCRIPTION
## Manual operator steps — P2 (epic #1056)

Closes #1060. Builds on P1 (#1059): those declared manual steps now **gate auto-merge**. Targets the epic integration branch `epic/1056-surface-gate-manual-operator-steps-attac` (not the default branch).

A PR with an un-acked, **non-`POST-MERGE`** manual operator step is held out of the merge train with a clear reason; a one-click **Ack steps** CTA clears the gate; the operator is nudged via push + the daily rundown. Generalizes the epic migration-ACK pattern (#645) to all session PRs.

### Plan-gate decisions (re-confirmed the two flagged Open Questions)
- **Gate scope = all session PRs, no opt-in setting** (issue default). The gate only ever fires when a PR author *explicitly declared* steps in the body, so it self-scopes — a PR with no declared steps is untouched. A per-repo setting was judged unwarranted config surface.
- **Ack = acknowledged-will-do** (stamps `manualStepsAckedAt`), mirroring `ackEpicMigrations` — it does not assert the steps are done. Idempotent.

### What changed
- **Gate** (`automerge-core.ts`): `MergeSessionView` gains `manualSteps` + `manualStepsAckedAt`. `readyToMerge` is refactored into `readyExceptManualSteps` + a steps clause; `computeMerge` emits a distinct `manual_steps` hold (desig + sessionId) **only for an otherwise-ready PR held solely on un-acked steps** — a red/draft/stale PR that merely declares steps can't produce a spurious hold or premature push. `toView` projects the two fields.
- **Ack** (`store.ts`, `server.ts`): `store.ackManualSteps` (`COALESCE` — idempotent, first ack wins); `POST /api/sessions/:id/ack-manual-steps` mirrors the ack-migrations endpoint; emits `session:manual-steps` (with `ackedAt`) so chip/hold/CTA clear live on every client.
- **Hold** (`hold.ts`, `types.ts` server+UI, `hold-service.ts`): `manual-steps` `HoldCode` + `steps` param, EN/DE copy, UI `holdLine`; `HoldReasonService` recomputes on `session:manual-steps` → the live `.u-hold` line updates. (`automerge:status` handling extracted to a helper to keep `handleEvent` under the complexity gate.)
- **Push** (`push.ts`): `manual_steps` notification kind + EN/DE payload; `attachMergePush` fires on the `manual_steps` status state with a per-session, tone-namespaced cooldown key; the stamp is set only on a successful send (rides `notify()`'s success-gated path).
- **Rundown** (`rundown-core.ts`): Tier-1 `manual-steps` `SignalCode` + tier + `ATTENTION_RULES` rule (last in the Tier-1 block, requires an **open PR** so it can't fire pre-PR/post-merge) + `SIGNAL_TO_HOLD`.
- **UI**: `api.ackManualSteps` + an **Ack steps** CTA beside the existing amber chip on `UnitRow` (threaded through `HerdGroup`/`Herd`); the handler relies on the authoritative WS broadcast to clear, with a keyed persistent failure toast through the shared store.
- **Gates**: feature-announcement entry (`manual-operator-steps-gate`, 1.37.0), EN+DE i18n parity, glossary N/A.

### Push semantics (intentional, documented)
Like `rebase_cap`, the push rides the per-pump merge decision: `computeMerge` surfaces **one** held session at a time and the send is cooldown-debounced — so it's not strictly "once per held PR". A second held PR won't push until the first is acked; the rundown + per-row chip/CTA cover the not-yet-pushed held PRs.

### CTA surface
Row-only (justified): `holdLine` renders only on `UnitRow` (beside the chip) and in the rundown digest (which deep-links to the row). `Viewport` has no hold pane and P1 placed the chip on the row only, so the row CTA covers every surface where the chip/hold renders.

### Tests
gate-on, gate-cleared-by-ack, POST-MERGE-only-not-blocked, the otherwise-ready guard (red/behind PR with steps → no `manual_steps` hold), ack idempotency, push payload + `attachMergePush` dispatch, and rundown classify/`explainHold`. Root `bun test` (4743) + UI vitest (2032) green; `tsc`, lint, i18n parity, feature-catalog, glossary, branch-hygiene, and fallow audit all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)