### PR TITLE
fix(usage): read the real credits panel past the /usage-credits menu text

### DIFF
--- a/src/usage-limits.ts
+++ b/src/usage-limits.ts
@@ -158,30 +158,40 @@ function parseSegment(seg: string, now: number): ScrapedWindow | null {
  *   Usagecredits▎0%used€0.29/€50.00spent·ResetsJun1(Europe/Berlin)
  * The gauge pct rounds down (can read `0%used` while real money is spent), so `spent` is the truth
  * signal and is parsed independently of pct.
+ *
+ * Scan EVERY "Usagecredits" occurrence, not just the first. The probe runs claude in the classic
+ * renderer (CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN), which accumulates the `/usage` slash-command menu
+ * into the buffer — and the `/usage-credits` command (renamed from `/extra-usage` in Claude Code
+ * v2.1.144) carries the description "Configure usage credits to keep working when you hit a limit",
+ * which collapses to a `Usagecredits…` run that precedes the real panel. The first match is thus
+ * that menu text (no spend figure); the actual panel — the only occurrence carrying a `…/…spent`
+ * amount — comes later. So match on the spend line as the truth signal and skip any occurrence
+ * (menu text, or a still-"Refreshing…" partial frame) that lacks it.
  */
 export function parseCredits(collapsed: string, now: number): ScrapedCredit | null {
-  const start = collapsed.search(/Usagecredits/i);
-  if (start < 0) return null;
-  let seg = collapsed.slice(start);
-  const end = seg.search(/Esctocancel/i);
-  if (end >= 0) seg = seg.slice(0, end);
-  // pct rounds down and can be absent; treat missing as 0 — spend below is the real signal
-  const pct = +(seg.match(/(\d+)%used/i)?.[1] ?? 0);
-  // symbol-only currency group: a `(\D*)([\d.]+)` form would wrongly grab the `%used` of `0%used€`.
-  // Amounts are assumed dot-decimal (as the Europe/Berlin TUI renders, e.g. `€0.29`); a comma render
-  // (`€0,29`) wouldn't match `[\d.]+` and would drop the whole credits section (returns null).
-  // `seg` is already whitespace-collapsed, so there is no inter-group whitespace to skip.
-  const spend = seg.match(/([^\d.\s/])([\d.]+)\/[^\d.\s/]?([\d.]+)spent/i);
-  if (!spend) return null;
-  const label = seg.match(/Resets(.*?)\(/i)?.[1] ?? null;
-  return {
-    pct,
-    spent: +spend[2]!,
-    cap: +spend[3]!,
-    currency: spend[1]!,
-    resetLabel: label,
-    resetAt: label ? parseMonthlyReset(label, now) : null,
-  };
+  for (const m of collapsed.matchAll(/Usagecredits/gi)) {
+    let seg = collapsed.slice(m.index);
+    const end = seg.search(/Esctocancel/i);
+    if (end >= 0) seg = seg.slice(0, end);
+    // symbol-only currency group: a `(\D*)([\d.]+)` form would wrongly grab the `%used` of `0%used€`.
+    // Amounts are assumed dot-decimal (as the Europe/Berlin TUI renders, e.g. `€0.29`); a comma render
+    // (`€0,29`) wouldn't match `[\d.]+` and would drop the whole credits section (returns null).
+    // `seg` is already whitespace-collapsed, so there is no inter-group whitespace to skip.
+    const spend = seg.match(/([^\d.\s/])([\d.]+)\/[^\d.\s/]?([\d.]+)spent/i);
+    if (!spend) continue; // menu text or a still-"Refreshing…" partial — try the next occurrence
+    // pct rounds down and can be absent; treat missing as 0 — spend above is the real signal
+    const pct = +(seg.match(/(\d+)%used/i)?.[1] ?? 0);
+    const label = seg.match(/Resets(.*?)\(/i)?.[1] ?? null;
+    return {
+      pct,
+      spent: +spend[2]!,
+      cap: +spend[3]!,
+      currency: spend[1]!,
+      resetLabel: label,
+      resetAt: label ? parseMonthlyReset(label, now) : null,
+    };
+  }
+  return null;
 }
 
 /** Extract the two limit windows from a (possibly multi-frame, ANSI-laden) `/usage` capture. */

--- a/test/usage-limits.test.ts
+++ b/test/usage-limits.test.ts
@@ -152,6 +152,29 @@ test("parseCredits stops at the Esc-to-cancel chrome and ignores absent section"
   expect(parseUsageFrame("Current session\n3% used\nResets 9:30pm (x)", NOW).credits).toBeNull();
 });
 
+test("parseCredits skips the /usage-credits command-menu text and reads the real panel", () => {
+  // The probe runs claude in the classic renderer, which accumulates the `/usage` slash-command menu
+  // into the buffer. The `/usage-credits` command (renamed from `/extra-usage` in Claude Code
+  // v2.1.144) describes itself as "Configure usage credits to keep working when you hit a limit",
+  // collapsing to a `Usagecredits…` run with NO spend figure that precedes the actual panel. Reading
+  // the first match yielded null and the gauge silently vanished; the parser must skip it.
+  const collapsed =
+    "/usageShowsessioncost,planusage,andactivitystats" +
+    "/usage-creditsConfigureusagecreditstokeepworkingwhenyouhitalimit" +
+    "Esctocancel" +
+    "Currentweek(allmodels)100%usedResetsJun25,11pm(x)" +
+    "Usagecredits65%used€12.34/€80.00spent·ResetsJul1(x)Esctocancel";
+  const c = parseCredits(collapsed, NOW)!;
+  expect(c).not.toBeNull();
+  expect(c.currency).toBe("€");
+  expect(c.spent).toBe(12.34);
+  expect(c.cap).toBe(80);
+  expect(c.pct).toBe(65);
+  expect(c.resetLabel).toBe("Jul1");
+  // end-to-end: the same menu-poisoned buffer must still surface credits through parseUsageFrame
+  expect(parseUsageFrame(collapsed, NOW).credits?.spent).toBe(12.34);
+});
+
 test("parseMonthlyReset rolls a past day forward ONE MONTH, not one year", () => {
   // Jun1 is past relative to mid-June → next month, same year (Jul 1), NOT Jun 2027
   const jul1 = new Date(parseMonthlyReset("Jun1", JUN13)!);


### PR DESCRIPTION
## Symptom

The extra-usage **CR gauge** silently vanished from the usage popover — only the **5h** and **Weekly** bars rendered — even with the weekly window at **100%** and paid extra usage actively spending (€68/€100). Reported live:

> hier fehlen die extra-usage credits die man zubuchen kann

## Diagnosis (empirical)

- `usage_caps` (5h + week) populated; the `usage_credit` snapshot table **never written** → a credits-only capture miss, not a display bug. The UI correctly hides the gauge when `credits === null`.
- Captured a live `/usage` scrape through the **real probe path** (herdr + `pty-attach`, classic renderer at 120×40). The buffer **does** contain the panel (`Usagecredits … €68.67/€100.00 spent`), yet `parseUsageFrame(...).credits` returned **null**.

## Root cause

The probe runs claude in the **classic renderer** (`CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN`), which accumulates the `/usage` **slash-command menu** into the scrape buffer. The `/usage-credits` command — renamed from `/extra-usage` in Claude Code **v2.1.144** — describes itself as *"Configure usage credits to keep working when you hit a limit"*, which collapses (whitespace-stripped) to a `Usagecredits…` run **with no `…/…spent` figure**, sitting **before** the actual panel.

`parseCredits` anchored on the **first** `Usagecredits` match (the menu text), sliced to the next `Esc to cancel`, found no spend line, and returned `null` — never reaching the real panel below. Session/week parse fine because their anchors (`Currentsession|Currentweek`) never appear in the menu.

This is a regression triggered by the upstream `/extra-usage` → `/usage-credits` rename: before it, typing `/usage` surfaced no menu entry containing the words "usage credits", so the buffer wasn't poisoned.

## Fix

`parseCredits` now scans **every** `Usagecredits` occurrence and returns the first one carrying a real `…/…spent` amount, skipping menu text and still-`Refreshing…` partial frames. Minimal, localized; the single-occurrence (alt-screen) path is unchanged.

## Verification

- Ran the **fixed** parser against the live classic-renderer probe capture → now extracts `{ spent: 68.67, cap: 100, currency: "€", pct: 68, resetLabel: "Jul1" }` where it previously returned `null`.
- New regression test feeds a menu-poisoned collapsed buffer through `parseCredits` **and** `parseUsageFrame` end to end.
- `bun test test/usage-limits.test.ts` → 46 pass · `test/usage-probe.test.ts` → 6 pass · `bun run lint` clean · pre-push gates green.

No UI/i18n/feature-catalog changes (server-side parser fix; the CR gauge feature already ships).