### PR TITLE
feat(drain): auto-rebase behind/conflicting epic landing PRs (#1071)

### DIFF
--- a/src/completed-epic.ts
+++ b/src/completed-epic.ts
@@ -32,6 +32,9 @@ export interface CompletedEpic {
   // band row's clear behind an explicit acknowledgement — NEVER the autonomous completion flip.
   migrationPaths: string[];
   migrationsAckedAt: number | null;
+  // #1071: why the auto-rebase pass paused. null = not paused / rebase not yet attempted.
+  // 'cap': cap exhausted; 'conflict': genuine conflict; 'driver': merge driver unavailable.
+  landingRebasePauseReason: "cap" | "conflict" | "driver" | null;
   /** Live, non-persisted landing-PR gate signals (present only when the landing PR could be fetched). */
   landingChecks?: ChecksState;
   landingMergeable?: boolean | null;

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -585,6 +585,7 @@ export class DrainService {
           // Migration detection (#645) runs at landing-open, not completion — see ensureLandingPr.
           migrationPaths: [],
           migrationsAckedAt: null,
+          landingRebasePauseReason: null,
         };
         this.deps.store.recordEpicCompleted({
           repoPath: completed.repoPath,
@@ -649,6 +650,7 @@ export class DrainService {
       landingState: row.landingState,
       migrationPaths: row.migrationPaths,
       migrationsAckedAt: row.migrationsAckedAt,
+      landingRebasePauseReason: row.landingRebasePauseReason,
     };
     this.deps.emitEpicCompleted?.(completed);
   }

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -990,101 +990,120 @@ export class DrainService {
       this.landingInFlight.add(key);
 
       try {
-        // a. Driver-pause fast-path: if paused because the driver was absent/broken,
-        //    cheaply re-probe git config before making any forge call.
-        if (row.landingRebasePauseReason === "driver") {
-          if (await this.isDriverRegistered(repoPath)) {
-            // Driver now registered → clear the pause and fall through to probe prStatus.
-            this.deps.store.setEpicLandingRebaseState(repoPath, parent, {
-              count: 0,
-              driverMisses: 0,
-              pauseReason: null,
-            });
-            this.emitCompleted(repoPath, parent);
-            // Fall through to the prStatus check below (re-read fresh row below).
-            // Note: we re-read from the store via the open[] snapshot (stale), but the
-            // per-tick re-read in the next call provides the fresh values. For driver-clear
-            // we continue the same row using the (now-cleared) state implicitly — the
-            // pauseReason is now null so we do NOT continue below.
-          } else {
-            // Still absent → stay paused, no prStatus call.
-            continue;
-          }
-        }
-
-        // b. Read the pinned integration branch (read-only; null = unpinned → skip).
-        const branch = this.deps.store.getEpicIntegrationBranch(repoPath, parent);
-        if (branch === null) continue;
-
-        // c. Check current PR state.
-        const pr = await forge.prStatus(branch);
-        if (pr.state !== "open") continue;
-
-        // d. Compute stuck flags.
-        const behind = pr.mergeStateStatus === "behind";
-        const conflicting = pr.mergeable === false;
-        const stuck = behind || conflicting;
-
-        // e. Reason-aware clear: handle the "no longer stuck" and "conflict resolved" cases.
-        if (!stuck) {
-          // PR is now landable (not behind, not conflicting) — clear all state.
-          const r2 = this.deps.store
-            .listEpicCompleted(repoPath)
-            .find((r) => r.parentIssueNumber === parent);
-          if (
-            r2 &&
-            (r2.landingRebaseCount !== 0 ||
-              r2.landingRebaseDriverMisses !== 0 ||
-              r2.landingRebasePauseReason !== null)
-          ) {
-            this.deps.store.setEpicLandingRebaseState(repoPath, parent, {
-              count: 0,
-              driverMisses: 0,
-              pauseReason: null,
-            });
-            this.emitCompleted(repoPath, parent);
-          }
-          continue;
-        }
-
-        // Re-read the latest row from the store to get fresh counter values
-        // (the `open[]` snapshot is from the start of this tick).
-        const freshRow = this.deps.store
-          .listEpicCompleted(repoPath)
-          .find((r) => r.parentIssueNumber === parent);
-        if (!freshRow) continue;
-
-        if (freshRow.landingRebasePauseReason === "conflict" && !conflicting) {
-          // The operator resolved the conflict; the PR may still be behind.
-          // Clear the conflict pause and count so the behind-only rebase resumes, then
-          // fall through to attempt the rebase with the corrected (cleared) state directly —
-          // no need to re-query for values we just set.
-          this.deps.store.setEpicLandingRebaseState(repoPath, parent, {
-            count: 0,
-            pauseReason: null,
-          });
-          this.emitCompleted(repoPath, parent);
-          await this.doLandingRebase(
-            repoPath,
-            parent,
-            { ...freshRow, landingRebaseCount: 0, landingRebasePauseReason: null },
-            branch,
-            defaultBranch,
-          );
-          continue;
-        }
-
-        // f. If paused (after the reason-aware clear didn't un-pause) → skip.
-        if (freshRow.landingRebasePauseReason !== null) continue;
-
-        // g. Attempt rebase.
-        await this.doLandingRebase(repoPath, parent, freshRow, branch, defaultBranch);
+        await this.processStuckLandingRow(repoPath, forge, defaultBranch, row);
       } catch (err) {
         // Defense in depth: one stuck epic must not break the whole tick.
         console.warn(`[drain] rebaseStuckLandingPrsForRepo failed for ${key}:`, err);
       } finally {
         this.landingInFlight.delete(key);
       }
+    }
+  }
+
+  /**
+   * Process one stuck landing PR row: handle driver-pause fast-path, probe PR state,
+   * clear resolved pauses, and attempt rebase when appropriate.
+   * Called from rebaseStuckLandingPrsForRepo (already serialized by landingInFlight).
+   */
+  private async processStuckLandingRow(
+    repoPath: string,
+    forge: GitForge,
+    defaultBranch: string,
+    row: {
+      parentIssueNumber: number;
+      landingRebasePauseReason: "cap" | "conflict" | "driver" | null;
+    },
+  ): Promise<void> {
+    const parent = row.parentIssueNumber;
+
+    // a. Driver-pause fast-path: if paused because the driver was absent/broken,
+    //    cheaply re-probe git config before making any forge call.
+    if (row.landingRebasePauseReason === "driver") {
+      if (await this.isDriverRegistered(repoPath)) {
+        // Driver now registered → clear the pause and fall through to probe prStatus.
+        this.deps.store.setEpicLandingRebaseState(repoPath, parent, {
+          count: 0,
+          driverMisses: 0,
+          pauseReason: null,
+        });
+        this.emitCompleted(repoPath, parent);
+        // Fall through — pauseReason is now null so we do NOT return below.
+      } else {
+        // Still absent → stay paused, no prStatus call.
+        return;
+      }
+    }
+
+    // b. Read the pinned integration branch (read-only; null = unpinned → skip).
+    const branch = this.deps.store.getEpicIntegrationBranch(repoPath, parent);
+    if (branch === null) return;
+
+    // c. Check current PR state.
+    const pr = await forge.prStatus(branch);
+    if (pr.state !== "open") return;
+
+    // d. Compute stuck flags.
+    const behind = pr.mergeStateStatus === "behind";
+    const conflicting = pr.mergeable === false;
+    const stuck = behind || conflicting;
+
+    // e. Reason-aware clear: if PR is no longer stuck, clear all rebase state and stop.
+    if (!stuck) {
+      this.clearLandingRebaseStateIfNeeded(repoPath, parent);
+      return;
+    }
+
+    // Re-read fresh counter values (the open[] snapshot is from the start of this tick).
+    const freshRow = this.deps.store
+      .listEpicCompleted(repoPath)
+      .find((r) => r.parentIssueNumber === parent);
+    if (!freshRow) return;
+
+    if (freshRow.landingRebasePauseReason === "conflict" && !conflicting) {
+      // Operator resolved the conflict; PR may still be behind. Clear conflict pause,
+      // then attempt the rebase immediately with the corrected (cleared) state.
+      this.deps.store.setEpicLandingRebaseState(repoPath, parent, {
+        count: 0,
+        pauseReason: null,
+      });
+      this.emitCompleted(repoPath, parent);
+      await this.doLandingRebase(
+        repoPath,
+        parent,
+        { ...freshRow, landingRebaseCount: 0, landingRebasePauseReason: null },
+        branch,
+        defaultBranch,
+      );
+      return;
+    }
+
+    // f. If paused (after the reason-aware clear didn't un-pause) → skip.
+    if (freshRow.landingRebasePauseReason !== null) return;
+
+    // g. Attempt rebase.
+    await this.doLandingRebase(repoPath, parent, freshRow, branch, defaultBranch);
+  }
+
+  /**
+   * If the landing PR is no longer stuck, clear all rebase counters/state.
+   * Only writes when there is something to clear (avoid spurious DB writes on steady state).
+   */
+  private clearLandingRebaseStateIfNeeded(repoPath: string, parent: number): void {
+    const r2 = this.deps.store
+      .listEpicCompleted(repoPath)
+      .find((r) => r.parentIssueNumber === parent);
+    if (
+      r2 &&
+      (r2.landingRebaseCount !== 0 ||
+        r2.landingRebaseDriverMisses !== 0 ||
+        r2.landingRebasePauseReason !== null)
+    ) {
+      this.deps.store.setEpicLandingRebaseState(repoPath, parent, {
+        count: 0,
+        driverMisses: 0,
+        pauseReason: null,
+      });
+      this.emitCompleted(repoPath, parent);
     }
   }
 

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -31,6 +31,7 @@ import { buildLandingPrTitle, buildLandingPrBody } from "./epic-landing";
 import { EmptyDiffError } from "./forge/types";
 import { mapBounded } from "./map-bounded";
 import { config } from "./config";
+import { rebaseLandingBranch, isUnionDriverRegistered } from "./landing-rebase";
 
 /** Concurrency cap for the per-child blocked_by fan-out when assembling an epic.
  *  Bounds `gh api` subprocesses so a large (100+-child) epic can't exhaust FDs or
@@ -77,6 +78,12 @@ import {
 } from "./sandbox";
 import { detectEgressBackend, type EgressBackend } from "./egress";
 import { epicBaseDirective } from "./autopilot";
+
+/** #1071: After this many consecutive driver-absent / driver-broken results without a successful
+ *  rebase, escalate to the operator (pauseReason='driver'). Keeps a persistently-misconfigured
+ *  clone from silently retrying forever while giving transient registration glitches a few chances
+ *  to self-heal before surfacing. */
+const DRIVER_MISS_CAP = 3;
 
 /** Cached epic structure for one pump cycle. */
 interface EpicStructure {
@@ -132,6 +139,7 @@ export interface DrainDeps {
     | "recordEpicCompleted"
     | "listEpicCompleted"
     | "setEpicLandingPr"
+    | "setEpicLandingRebaseState"
     | "setEpicMigrationPaths"
     | "recordEpicBaseMismatch"
     | "clearEpicBaseMismatch"
@@ -170,6 +178,15 @@ export interface DrainDeps {
    *  with an FS backend, so a drain-spawned autonomous session is refused-loud when egress
    *  is unavailable. */
   detectEgressBackend?: () => EgressBackend;
+  /** #1071: maximum genuine rebase attempts (cap budget). Wired from config.autoMergeRebaseCap
+   *  in index.ts; injected directly so tests can set a small cap without touching global config. */
+  rebaseCap: number;
+  /** #1071: injectable seam for rebaseLandingBranch (tests inject a fake). Defaults to the real
+   *  impl (src/landing-rebase.ts) in the constructor. */
+  rebaseLandingBranch?: typeof rebaseLandingBranch;
+  /** #1071: injectable seam for the driver-pause fast-path re-probe (tests inject a fake).
+   *  Defaults to the real isUnionDriverRegistered (src/landing-rebase.ts) in the constructor. */
+  isDriverRegistered?: (repoPath: string) => Promise<boolean>;
 }
 
 /**
@@ -221,10 +238,16 @@ export class DrainService {
   private approvedNext = new Set<string>();
   private now: () => number;
   private issuesTtlMs: number;
+  /** #1071: injectable seam; defaults to the real rebaseLandingBranch import. */
+  private rebaseLandingBranch: typeof rebaseLandingBranch;
+  /** #1071: injectable seam; defaults to the real isUnionDriverRegistered import. */
+  private isDriverRegistered: (repoPath: string) => Promise<boolean>;
 
   constructor(private deps: DrainDeps) {
     this.now = deps.now ?? Date.now;
     this.issuesTtlMs = deps.issuesTtlMs ?? 10_000;
+    this.rebaseLandingBranch = deps.rebaseLandingBranch ?? rebaseLandingBranch;
+    this.isDriverRegistered = deps.isDriverRegistered ?? isUnionDriverRegistered;
   }
 
   /** Operator approves the next epic-attended spawn for the given repo. */
@@ -910,6 +933,239 @@ export class DrainService {
           err,
         );
       }
+    }
+  }
+
+  /**
+   * #1071: Session-less rebase pass for stuck (behind/conflicting) epic landing PRs.
+   * Runs each tick between ensureLandingPrsForRepo and autoLandLandingPrsForRepo so that
+   * a behind/conflicting PR is driven back to landable before the auto-land pass sees it.
+   *
+   * Gate: !draftMode && (autoMergeEnabled || autoDrainEnabled || epicRun.status==='running').
+   * DELIBERATE DEVIATION from autoLandLandingPrsForRepo's `draftMode ? false : autoMergeEnabled`
+   * gate: that gate would leave a drain-on / auto-merge-off repo with no rebase (forcing the
+   * operator to rebase manually before the manual land CTA can succeed). Here we include
+   * autoDrainEnabled and the running-epic-run case to stay consistent with the tick's pump gate.
+   *
+   * GitHub-only (forge.kind === 'github'): mergeStateStatus is GitHub-specific; LocalForge has no
+   * remote to push to; Gitea is out of scope.
+   *
+   * DELIBERATE DEVIATION from autoLandLandingPrsForRepo re migration-bearing rows: unlike auto-land
+   * (which skips rows with migrationPaths.length > 0 to require an operator ack/land), the rebase
+   * pass processes them too. The pass NEVER merges, so keeping a migration-bearing landing PR
+   * mergeable only makes the operator's manual ack/land CTA usable; skipping them would re-strand
+   * exactly the PRs that most need a human. See plan §"Migration-bearing epics are still rebased".
+   *
+   * NEVER calls forge.merge. Landing stays with tryAutoLandEpic (auto-merge on) or the operator's
+   * manual land CTA.
+   */
+  private async rebaseStuckLandingPrsForRepo(repoPath: string): Promise<void> {
+    // Gate: automation must be engaged for this repo.
+    const cfg = this.deps.store.getRepoConfig(repoPath);
+    const er = this.deps.store.getEpicRun(repoPath);
+    const engaged =
+      !cfg.draftMode && (cfg.autoMergeEnabled || cfg.autoDrainEnabled || er?.status === "running");
+    if (!engaged) return;
+
+    // GitHub-only: mergeStateStatus is not available on other forge kinds.
+    const forge = this.deps.resolveForge(repoPath);
+    if (!forge || forge.kind !== "github") return;
+
+    // DB-gate: only open rows with a recorded landing PR number are candidates.
+    // Unlike autoLandLandingPrsForRepo, we do NOT skip migration-bearing rows (see doc above).
+    const open = this.deps.store
+      .listEpicCompleted(repoPath)
+      .filter((r) => r.landingState === "open" && r.landingPrNumber != null);
+    if (open.length === 0) return;
+
+    const defaultBranch = await forge.defaultBranch();
+
+    for (const row of open) {
+      const parent = row.parentIssueNumber;
+      const key = `${repoPath}#${parent}`;
+
+      // Serialize per (repo, parent) — shared key namespace with ensureLandingPr /
+      // autoLandLandingPrsForRepo; they act on disjoint landingStates of one epic.
+      if (this.landingInFlight.has(key)) continue;
+      this.landingInFlight.add(key);
+
+      try {
+        // a. Driver-pause fast-path: if paused because the driver was absent/broken,
+        //    cheaply re-probe git config before making any forge call.
+        if (row.landingRebasePauseReason === "driver") {
+          if (await this.isDriverRegistered(repoPath)) {
+            // Driver now registered → clear the pause and fall through to probe prStatus.
+            this.deps.store.setEpicLandingRebaseState(repoPath, parent, {
+              count: 0,
+              driverMisses: 0,
+              pauseReason: null,
+            });
+            this.emitCompleted(repoPath, parent);
+            // Fall through to the prStatus check below (re-read fresh row below).
+            // Note: we re-read from the store via the open[] snapshot (stale), but the
+            // per-tick re-read in the next call provides the fresh values. For driver-clear
+            // we continue the same row using the (now-cleared) state implicitly — the
+            // pauseReason is now null so we do NOT continue below.
+          } else {
+            // Still absent → stay paused, no prStatus call.
+            continue;
+          }
+        }
+
+        // b. Read the pinned integration branch (read-only; null = unpinned → skip).
+        const branch = this.deps.store.getEpicIntegrationBranch(repoPath, parent);
+        if (branch === null) continue;
+
+        // c. Check current PR state.
+        const pr = await forge.prStatus(branch);
+        if (pr.state !== "open") continue;
+
+        // d. Compute stuck flags.
+        const behind = pr.mergeStateStatus === "behind";
+        const conflicting = pr.mergeable === false;
+        const stuck = behind || conflicting;
+
+        // e. Reason-aware clear: handle the "no longer stuck" and "conflict resolved" cases.
+        if (!stuck) {
+          // PR is now landable (not behind, not conflicting) — clear all state.
+          const r2 = this.deps.store
+            .listEpicCompleted(repoPath)
+            .find((r) => r.parentIssueNumber === parent);
+          if (
+            r2 &&
+            (r2.landingRebaseCount !== 0 ||
+              r2.landingRebaseDriverMisses !== 0 ||
+              r2.landingRebasePauseReason !== null)
+          ) {
+            this.deps.store.setEpicLandingRebaseState(repoPath, parent, {
+              count: 0,
+              driverMisses: 0,
+              pauseReason: null,
+            });
+            this.emitCompleted(repoPath, parent);
+          }
+          continue;
+        }
+
+        // Re-read the latest row from the store to get fresh counter values
+        // (the `open[]` snapshot is from the start of this tick).
+        const freshRow = this.deps.store
+          .listEpicCompleted(repoPath)
+          .find((r) => r.parentIssueNumber === parent);
+        if (!freshRow) continue;
+
+        if (freshRow.landingRebasePauseReason === "conflict" && !conflicting) {
+          // The operator resolved the conflict; the PR may still be behind.
+          // Clear the conflict pause and count so the behind-only rebase resumes, then
+          // fall through to attempt the rebase with the corrected (cleared) state directly —
+          // no need to re-query for values we just set.
+          this.deps.store.setEpicLandingRebaseState(repoPath, parent, {
+            count: 0,
+            pauseReason: null,
+          });
+          this.emitCompleted(repoPath, parent);
+          await this.doLandingRebase(
+            repoPath,
+            parent,
+            { ...freshRow, landingRebaseCount: 0, landingRebasePauseReason: null },
+            branch,
+            defaultBranch,
+          );
+          continue;
+        }
+
+        // f. If paused (after the reason-aware clear didn't un-pause) → skip.
+        if (freshRow.landingRebasePauseReason !== null) continue;
+
+        // g. Attempt rebase.
+        await this.doLandingRebase(repoPath, parent, freshRow, branch, defaultBranch);
+      } catch (err) {
+        // Defense in depth: one stuck epic must not break the whole tick.
+        console.warn(`[drain] rebaseStuckLandingPrsForRepo failed for ${key}:`, err);
+      } finally {
+        this.landingInFlight.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Inner rebase attempt for one epic's landing PR. Checks the cap, calls rebaseLandingBranch,
+   * and maps the result union to the appropriate state update + emitCompleted.
+   * Called from rebaseStuckLandingPrsForRepo (already serialized by landingInFlight).
+   */
+  private async doLandingRebase(
+    repoPath: string,
+    parent: number,
+    row: {
+      landingRebaseCount: number;
+      landingRebaseDriverMisses: number;
+      landingRebasePauseReason: "cap" | "conflict" | "driver" | null;
+    },
+    branch: string,
+    defaultBranch: string,
+  ): Promise<void> {
+    // Cap check: if we've already used the full budget, pause.
+    if (row.landingRebaseCount >= this.deps.rebaseCap) {
+      this.deps.store.setEpicLandingRebaseState(repoPath, parent, { pauseReason: "cap" });
+      this.emitCompleted(repoPath, parent);
+      return;
+    }
+
+    const res = await this.rebaseLandingBranch(repoPath, branch, defaultBranch);
+    switch (res.kind) {
+      case "rebased":
+        // Genuine rebase: burn one cap attempt, reset driver-miss counter.
+        this.deps.store.setEpicLandingRebaseState(repoPath, parent, {
+          count: row.landingRebaseCount + 1,
+          driverMisses: 0,
+        });
+        this.emitCompleted(repoPath, parent);
+        break;
+
+      case "current":
+        // Branch already contains origin/<default> (GitHub mergeability lag, or a redundant
+        // attempt after a concurrent push) — no real commits to replay; reset all counters
+        // to avoid a false cap-exhaustion on the next tick.
+        this.deps.store.setEpicLandingRebaseState(repoPath, parent, {
+          count: 0,
+          driverMisses: 0,
+          pauseReason: null,
+        });
+        this.emitCompleted(repoPath, parent);
+        break;
+
+      case "conflict":
+        // Genuine conflict (non-union path, or union path + driver self-test passed).
+        this.deps.store.setEpicLandingRebaseState(repoPath, parent, { pauseReason: "conflict" });
+        this.emitCompleted(repoPath, parent);
+        break;
+
+      case "driver-absent":
+      case "driver-broken": {
+        // Environment fault — NOT a content problem. Increment the miss counter without
+        // burning the cap (per plan: "no count burn"). Escalate after DRIVER_MISS_CAP
+        // consecutive misses; before that, log and retry next cycle.
+        const m = row.landingRebaseDriverMisses + 1;
+        if (m >= DRIVER_MISS_CAP) {
+          this.deps.store.setEpicLandingRebaseState(repoPath, parent, {
+            driverMisses: m,
+            pauseReason: "driver",
+          });
+          this.emitCompleted(repoPath, parent);
+        } else {
+          this.deps.store.setEpicLandingRebaseState(repoPath, parent, { driverMisses: m });
+          console.warn(
+            `[drain] driver fault (${res.kind}) for ${repoPath}#${parent}, miss ${m}/${DRIVER_MISS_CAP}`,
+          );
+        }
+        break;
+      }
+
+      case "transient":
+        // Transient error (stale lease, fetch failure, etc.) — log only, no state change.
+        // Will be retried on the next tick.
+        console.warn(`[drain] transient rebase error for ${repoPath}#${parent}, will retry`);
+        break;
     }
   }
 
@@ -1615,6 +1871,11 @@ export class DrainService {
       // epic's PR is opened/retried even in a repo with autoDrain off and no running epic.
       // DB-gated internally → zero forge calls in steady state.
       await this.ensureLandingPrsForRepo(repoPath);
+      // #1071: rebase stuck (behind/conflicting) landing PRs back to landable BEFORE the
+      // auto-land pass so a freshly-rebased PR can be landed in the same tick. Gated
+      // internally (automation-engaged check + GitHub-only + DB-gate → zero forge calls in
+      // steady state). UNGATED by drain, like its neighbors.
+      await this.rebaseStuckLandingPrsForRepo(repoPath);
       // #1044: opt-in auto-land of open landing PRs (gated internally on the repo's auto-merge
       // opt-in → zero forge calls when off). UNGATED by drain, like ensureLandingPrsForRepo.
       await this.autoLandLandingPrsForRepo(repoPath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1227,10 +1227,14 @@ const landingReadyEpics = async (): Promise<RundownEpicItem[]> => {
     .join(",");
   if (epicReadyCache && epicReadyCache.key === key && now - epicReadyCache.ts < EPIC_READY_TTL_MS)
     return epicReadyCache.val;
-  const epics: CompletedEpic[] = openRows.map(({ childrenJson, landingAttempts, ...rest }) => {
-    void landingAttempts;
-    return { ...rest, children: JSON.parse(childrenJson) as CompletedEpic["children"] };
-  });
+  const epics: CompletedEpic[] = openRows.map(
+    ({ childrenJson, landingAttempts, landingRebaseCount, landingRebaseDriverMisses, ...rest }) => {
+      void landingAttempts;
+      void landingRebaseCount;
+      void landingRebaseDriverMisses;
+      return { ...rest, children: JSON.parse(childrenJson) as CompletedEpic["children"] };
+    },
+  );
   await enrichLandingEpics(epics, {
     getEpicIntegrationBranch: (repoPath, parent) =>
       store.getEpicIntegrationBranch(repoPath, parent),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1220,30 +1220,54 @@ const landingReadyEpics = async (): Promise<RundownEpicItem[]> => {
     epicReadyCache = null; // nothing open → drop any stale cache so a just-landed epic clears at once
     return [];
   }
-  // Cache key = the set of open epics. A change (one landed, or a new one opened) busts the cache so
-  // the panel never shows an already-landed "land this epic"; the TTL only throttles re-probing the
-  // forge when the SAME set's CI-readiness might have flipped.
+  // Cache key = the set of open epics + their pause states. A change (landed, opened, or pause
+  // reason flip) busts the cache; the TTL only throttles re-probing the forge for CI-readiness
+  // flips on the same set.
   const key = openRows
-    .map((r) => `${r.repoPath}#${r.parentIssueNumber}`)
+    .map((r) => `${r.repoPath}#${r.parentIssueNumber}:${r.landingRebasePauseReason ?? ""}`)
     .sort()
     .join(",");
   if (epicReadyCache && epicReadyCache.key === key && now - epicReadyCache.ts < EPIC_READY_TTL_MS)
     return epicReadyCache.val;
-  const epics: CompletedEpic[] = openRows.map(
-    ({ childrenJson, landingAttempts, landingRebaseCount, landingRebaseDriverMisses, ...rest }) => {
-      void landingAttempts;
-      void landingRebaseCount;
-      void landingRebaseDriverMisses;
-      return { ...rest, children: JSON.parse(childrenJson) as CompletedEpic["children"] };
-    },
-  );
+
+  // Paused rows (#1071): non-null landingRebasePauseReason → surface immediately as Tier-1 items
+  // without a forge probe (pause reason is already in the DB; no CI-readiness gate applies).
+  const pausedItems: RundownEpicItem[] = openRows
+    .filter((r) => r.landingRebasePauseReason !== null)
+    .map((r) => ({
+      repo: r.repoPath,
+      parent: r.parentIssueNumber,
+      title: r.parentTitle,
+      landingPr: r.landingPrNumber,
+      stranded: false, // paused items are not "stranded" (different escalation path)
+      pausedReason: r.landingRebasePauseReason as "cap" | "conflict" | "driver",
+    }));
+
+  // Ready rows: probe the forge (TTL-memoized) for CI-readiness; exclude already-paused rows so a
+  // paused row can't be double-injected if it somehow has landingReady set from a stale enrichment.
+  const epics: CompletedEpic[] = openRows
+    .filter((r) => r.landingRebasePauseReason === null)
+    .map(
+      ({
+        childrenJson,
+        landingAttempts,
+        landingRebaseCount,
+        landingRebaseDriverMisses,
+        ...rest
+      }) => {
+        void landingAttempts;
+        void landingRebaseCount;
+        void landingRebaseDriverMisses;
+        return { ...rest, children: JSON.parse(childrenJson) as CompletedEpic["children"] };
+      },
+    );
   await enrichLandingEpics(epics, {
     getEpicIntegrationBranch: (repoPath, parent) =>
       store.getEpicIntegrationBranch(repoPath, parent),
     resolveForge: (repoPath) => resolveForge(repoPath),
     now,
   });
-  const val: RundownEpicItem[] = epics
+  const readyItems: RundownEpicItem[] = epics
     .filter((e) => e.landingState === "open" && e.landingReady === true)
     .map((e) => ({
       repo: e.repoPath,
@@ -1252,6 +1276,8 @@ const landingReadyEpics = async (): Promise<RundownEpicItem[]> => {
       landingPr: e.landingPrNumber,
       stranded: e.landingStranded === true,
     }));
+
+  const val: RundownEpicItem[] = [...pausedItems, ...readyItems];
   epicReadyCache = { key, ts: now, val };
   return val;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1114,6 +1114,8 @@ const drain = new DrainService({
   emitEpic: (epic) => events.emit("epic:update", epic),
   emitEpicCompleted: (e) => events.emit("epic:completed", e),
   emitSessionNew: (s) => events.emit("session:new", s),
+  // #1071: wire rebase cap + real rebaseLandingBranch (mirrors autopilot/automerge wiring).
+  rebaseCap: config.autoMergeRebaseCap,
 });
 
 // Drive the drain off the poller events the rest of the system already emits.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1243,8 +1243,8 @@ const landingReadyEpics = async (): Promise<RundownEpicItem[]> => {
       pausedReason: r.landingRebasePauseReason as "cap" | "conflict" | "driver",
     }));
 
-  // Ready rows: probe the forge (TTL-memoized) for CI-readiness; exclude already-paused rows so a
-  // paused row can't be double-injected if it somehow has landingReady set from a stale enrichment.
+  // Ready rows: probe the forge (TTL-memoized) for CI-readiness; exclude already-paused rows
+  // (injected above) so each open row is surfaced under exactly one heading.
   const epics: CompletedEpic[] = openRows
     .filter((r) => r.landingRebasePauseReason === null)
     .map(

--- a/src/landing-rebase.ts
+++ b/src/landing-rebase.ts
@@ -163,6 +163,135 @@ function makeDefaultRegisterDriver(repoPath: string): void {
 }
 
 /**
+ * Ensure the union merge driver is registered. Tries to read the config; if absent,
+ * calls registerDriver and re-checks. Returns true when the driver is confirmed usable,
+ * false → caller should return { kind: "driver-absent" }.
+ */
+async function ensureDriverRegistered(
+  repoPath: string,
+  git: (cwd: string, args: string[]) => Promise<{ stdout: string }>,
+  registerDriver: (repoPath: string) => void,
+): Promise<boolean> {
+  try {
+    const { stdout } = await git(repoPath, ["config", "--get", "merge.i18n-union.driver"]);
+    if (stdout.trim()) return true;
+    throw new Error("empty driver config");
+  } catch {
+    // Driver not registered; attempt to register
+    try {
+      registerDriver(repoPath);
+    } catch (err) {
+      console.error(`[landing-rebase] registerDriver failed:`, err);
+      return false;
+    }
+    // Re-check
+    try {
+      const { stdout } = await git(repoPath, ["config", "--get", "merge.i18n-union.driver"]);
+      return stdout.trim().length > 0;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Fetch both branches and resolve the leaseSha + ancestor check.
+ * Returns null + a LandingRebaseResult when the operation should short-circuit,
+ * or { leaseSha, needsRebase: true } when a rebase is needed.
+ */
+async function fetchAndClassifyAncestor(
+  repoPath: string,
+  integrationBranch: string,
+  defaultBranch: string,
+  git: (cwd: string, args: string[]) => Promise<{ stdout: string }>,
+): Promise<{ leaseSha: string } | { shortCircuit: LandingRebaseResult }> {
+  // Fetch both refs using explicit refspecs so tracking refs are created/updated
+  // even in single-branch clones.
+  try {
+    await git(repoPath, [
+      "fetch",
+      "origin",
+      `refs/heads/${defaultBranch}:refs/remotes/origin/${defaultBranch}`,
+      `refs/heads/${integrationBranch}:refs/remotes/origin/${integrationBranch}`,
+    ]);
+  } catch (err) {
+    console.error(`[landing-rebase] fetch failed:`, err);
+    return { shortCircuit: { kind: "transient" } };
+  }
+
+  let leaseSha: string;
+  try {
+    const { stdout } = await git(repoPath, ["rev-parse", `origin/${integrationBranch}`]);
+    leaseSha = stdout.trim();
+  } catch (err) {
+    console.error(`[landing-rebase] rev-parse failed:`, err);
+    return { shortCircuit: { kind: "transient" } };
+  }
+
+  try {
+    // If origin/<default> is already an ancestor of origin/<integrationBranch>, nothing to do
+    await git(repoPath, [
+      "merge-base",
+      "--is-ancestor",
+      `origin/${defaultBranch}`,
+      `origin/${integrationBranch}`,
+    ]);
+    return { shortCircuit: { kind: "current" } };
+  } catch {
+    // Not an ancestor → need to rebase
+  }
+
+  return { leaseSha };
+}
+
+/**
+ * After a failed rebase, classify the conflict type.
+ * Collects conflicted paths, checks union coverage, runs driver self-test.
+ * Returns the appropriate LandingRebaseResult for the failure.
+ */
+async function classifyRebaseConflict(
+  repoPath: string,
+  worktreePath: string,
+  git: (cwd: string, args: string[]) => Promise<{ stdout: string }>,
+): Promise<LandingRebaseResult> {
+  let conflictedPaths: string[];
+  try {
+    const { stdout } = await git(worktreePath, ["diff", "--name-only", "--diff-filter=U"]);
+    conflictedPaths = stdout
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  } catch {
+    conflictedPaths = [];
+  }
+
+  const abortRebase = async () => {
+    try {
+      await git(worktreePath, ["rebase", "--abort"]);
+    } catch {
+      /* best effort */
+    }
+  };
+
+  if (conflictedPaths.length === 0) {
+    await abortRebase();
+    return { kind: "conflict" };
+  }
+
+  const unionGlobs = parseUnionGlobs(repoPath);
+  const hasNonUnionConflict = conflictedPaths.some((p) => !isUnionManaged(p, unionGlobs));
+  if (hasNonUnionConflict) {
+    await abortRebase();
+    return { kind: "conflict" };
+  }
+
+  // All conflicted paths are union-managed — run driver self-test
+  const selfTestPassed = await driverSelfTest(repoPath);
+  await abortRebase();
+  return selfTestPassed ? { kind: "conflict" } : { kind: "driver-broken" };
+}
+
+/**
  * Rebase a session-less epic landing/integration branch onto the default branch.
  * Auto-resolves union-merge-driver false conflicts.
  *
@@ -200,66 +329,18 @@ export async function rebaseLandingBranch(
   }
 
   // 1. Driver precondition
-  try {
-    const { stdout } = await git(repoPath, ["config", "--get", "merge.i18n-union.driver"]);
-    if (!stdout.trim()) {
-      throw new Error("empty driver config");
-    }
-  } catch {
-    // Driver not registered; attempt to register
-    try {
-      registerDriver(repoPath);
-    } catch (err) {
-      console.error(`[landing-rebase] registerDriver failed:`, err);
-      return { kind: "driver-absent" };
-    }
-    // Re-check
-    try {
-      const { stdout } = await git(repoPath, ["config", "--get", "merge.i18n-union.driver"]);
-      if (!stdout.trim()) {
-        return { kind: "driver-absent" };
-      }
-    } catch {
-      return { kind: "driver-absent" };
-    }
-  }
+  const driverOk = await ensureDriverRegistered(repoPath, git, registerDriver);
+  if (!driverOk) return { kind: "driver-absent" };
 
-  // 2. Fetch both refs using explicit refspecs so tracking refs are created/updated
-  // even in single-branch clones (where only `main` is in the fetch refspec config).
-  try {
-    await git(repoPath, [
-      "fetch",
-      "origin",
-      `refs/heads/${defaultBranch}:refs/remotes/origin/${defaultBranch}`,
-      `refs/heads/${integrationBranch}:refs/remotes/origin/${integrationBranch}`,
-    ]);
-  } catch (err) {
-    console.error(`[landing-rebase] fetch failed:`, err);
-    return { kind: "transient" };
-  }
-
-  // 3. leaseSha + ancestor check
-  let leaseSha: string;
-  try {
-    const { stdout } = await git(repoPath, ["rev-parse", `origin/${integrationBranch}`]);
-    leaseSha = stdout.trim();
-  } catch (err) {
-    console.error(`[landing-rebase] rev-parse failed:`, err);
-    return { kind: "transient" };
-  }
-
-  try {
-    // If origin/<default> is already an ancestor of origin/<integrationBranch>, nothing to do
-    await git(repoPath, [
-      "merge-base",
-      "--is-ancestor",
-      `origin/${defaultBranch}`,
-      `origin/${integrationBranch}`,
-    ]);
-    return { kind: "current" };
-  } catch {
-    // Not an ancestor → need to rebase
-  }
+  // 2+3. Fetch + ancestor check → get leaseSha or short-circuit
+  const fetchResult = await fetchAndClassifyAncestor(
+    repoPath,
+    integrationBranch,
+    defaultBranch,
+    git,
+  );
+  if ("shortCircuit" in fetchResult) return fetchResult.shortCircuit;
+  const { leaseSha } = fetchResult;
 
   // 4. Create detached worktree
   let wt: { worktreePath: string };
@@ -287,52 +368,8 @@ export async function rebaseLandingBranch(
         `origin/${defaultBranch}`,
       ]);
     } catch {
-      // 6. Rebase failed — classify before labeling
-      let conflictedPaths: string[];
-      try {
-        const { stdout } = await git(wt.worktreePath, ["diff", "--name-only", "--diff-filter=U"]);
-        conflictedPaths = stdout
-          .split("\n")
-          .map((s) => s.trim())
-          .filter(Boolean);
-      } catch {
-        conflictedPaths = [];
-      }
-
-      const unionGlobs = parseUnionGlobs(repoPath);
-
-      // Abort the rebase before returning
-      const abortRebase = async () => {
-        try {
-          await git(wt.worktreePath, ["rebase", "--abort"]);
-        } catch {
-          /* best effort */
-        }
-      };
-
-      if (conflictedPaths.length === 0) {
-        // No conflicted paths but rebase still failed (e.g. empty)
-        await abortRebase();
-        return { kind: "conflict" };
-      }
-
-      // 6a/6b: Check if any path is outside union-managed globs
-      const hasNonUnionConflict = conflictedPaths.some((p) => !isUnionManaged(p, unionGlobs));
-      if (hasNonUnionConflict) {
-        await abortRebase();
-        return { kind: "conflict" };
-      }
-
-      // 6c: All conflicted paths are union-managed — run driver self-test
-      const selfTestPassed = await driverSelfTest(repoPath);
-      await abortRebase();
-      if (selfTestPassed) {
-        // Driver works → genuine same-key clash
-        return { kind: "conflict" };
-      } else {
-        // Driver non-functional
-        return { kind: "driver-broken" };
-      }
+      // 6. Rebase failed — classify the conflict
+      return await classifyRebaseConflict(repoPath, wt.worktreePath, git);
     }
 
     // 7. Force-push with lease

--- a/src/landing-rebase.ts
+++ b/src/landing-rebase.ts
@@ -1,0 +1,348 @@
+import { execFile, execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import type { WorktreeMgr } from "./worktree";
+
+const execFileAsync = promisify(execFile);
+
+export type LandingRebaseResult =
+  | { kind: "rebased"; headSha: string } // replayed onto origin/<default>, force-pushed
+  | { kind: "current" } // branch already contains origin/<default>; nothing to do
+  | { kind: "conflict" } // genuine clash (non-union path, OR union path + self-test PASSED)
+  | { kind: "driver-absent" } // merge.i18n-union.driver unregisterable
+  | { kind: "driver-broken" } // union-only conflict + driver self-test FAILED
+  | { kind: "transient" }; // fetch/worktree/push (e.g. stale lease) error
+
+export interface LandingRebaseDeps {
+  worktrees: Pick<WorktreeMgr, "createDetached" | "remove">;
+  git: (cwd: string, args: string[]) => Promise<{ stdout: string }>;
+  registerDriver: (repoPath: string) => void;
+}
+
+/** Validate a git refname component (same grammar as WorktreeMgr). */
+function validRef(ref: string): boolean {
+  return /^(?!-)[A-Za-z0-9._/-]{1,200}$/.test(ref);
+}
+
+/**
+ * Run the union merge driver self-test in a temp dir.
+ * Writes base/ours/theirs JSON, runs json-union-merge.mjs,
+ * and returns true iff exit 0 and the merged ours contains keys a, b, AND c.
+ */
+async function driverSelfTest(repoPath: string): Promise<boolean> {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-selftest-"));
+  try {
+    const base = join(dir, "base.json");
+    const ours = join(dir, "ours.json");
+    const theirs = join(dir, "theirs.json");
+    writeFileSync(base, JSON.stringify({ a: "1" }));
+    writeFileSync(ours, JSON.stringify({ a: "1", b: "2" }));
+    writeFileSync(theirs, JSON.stringify({ a: "1", c: "3" }));
+    // %O %A %B %P — base, ours/OUTPUT, theirs, pathname
+    const scriptPath = join(repoPath, "scripts", "json-union-merge.mjs");
+    if (!existsSync(scriptPath)) return false;
+    await execFileAsync("node", [scriptPath, base, ours, theirs, "test.json"], { cwd: repoPath });
+    const merged = JSON.parse(readFileSync(ours, "utf8"));
+    return (
+      typeof merged === "object" &&
+      merged !== null &&
+      "a" in merged &&
+      "b" in merged &&
+      "c" in merged
+    );
+  } catch {
+    return false;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Parse .gitattributes and return the set of globs that use the union or i18n-union merge driver.
+ * These are the paths that the union merge driver handles.
+ */
+function parseUnionGlobs(repoPath: string): string[] {
+  const attrPath = join(repoPath, ".gitattributes");
+  let content: string;
+  try {
+    content = readFileSync(attrPath, "utf8");
+  } catch {
+    return [];
+  }
+  const globs: string[] = [];
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const parts = trimmed.split(/\s+/);
+    if (parts.length < 2) continue;
+    const glob = parts[0]!;
+    const hasUnionDriver = parts
+      .slice(1)
+      .some((attr) => attr === "merge=union" || attr === "merge=i18n-union");
+    if (hasUnionDriver) globs.push(glob);
+  }
+  return globs;
+}
+
+/** Match a file path against a gitattributes glob pattern.
+ *
+ * The pattern is converted to a FULL-PATH-anchored regex (`^…$`), translating
+ * `**` → `.*`, `*` → `[^/]*`, `?` → `[^/]`. This deliberately does NOT implement
+ * real gitattributes basename semantics for slash-free patterns (where `*.json`
+ * would match any `*.json` at any depth). All Shepherd union globs in
+ * `.gitattributes` contain a slash (`ui/messages/*.json`,
+ * `extension/messages/*.json`, `ui/src/lib/feature-announcements.ts`), so this is
+ * exact for every real union glob. A hypothetical slash-free union glob would
+ * therefore NOT be treated as union-managed — and that is the fail-SAFE direction:
+ * an unmatched conflicted path is classified as a non-union conflict, yielding
+ * `conflict` (operator hand-off) rather than a wrongly-auto-resolved push.
+ */
+function matchGlob(glob: string, filePath: string): boolean {
+  const normalized = glob.replace(/\\/g, "/");
+  const fileParts = filePath.replace(/\\/g, "/");
+
+  // Convert glob to regex
+  let regexStr = "";
+  let i = 0;
+  while (i < normalized.length) {
+    const ch = normalized[i]!;
+    if (ch === "*" && normalized[i + 1] === "*") {
+      regexStr += ".*";
+      i += 2;
+      if (normalized[i] === "/") i++; // skip trailing slash after **
+    } else if (ch === "*") {
+      regexStr += "[^/]*";
+      i++;
+    } else if (ch === "?") {
+      regexStr += "[^/]";
+      i++;
+    } else {
+      regexStr += ch.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+      i++;
+    }
+  }
+
+  const regex = new RegExp(`^${regexStr}$`);
+  return regex.test(fileParts);
+}
+
+/** Check if a file path is covered by any of the union-managed globs. */
+function isUnionManaged(filePath: string, unionGlobs: string[]): boolean {
+  return unionGlobs.some((glob) => matchGlob(glob, filePath));
+}
+
+function makeDefaultGit(cwd: string, args: string[]): Promise<{ stdout: string }> {
+  return execFileAsync("git", args, { cwd }).then(({ stdout }) => ({ stdout }));
+}
+
+function makeDefaultRegisterDriver(repoPath: string): void {
+  execFileSync("node", ["scripts/register-merge-driver.mjs"], { cwd: repoPath, stdio: "pipe" });
+}
+
+/**
+ * Rebase a session-less epic landing/integration branch onto the default branch.
+ * Auto-resolves union-merge-driver false conflicts.
+ *
+ * @param repoPath - absolute path to the main repo checkout
+ * @param integrationBranch - the epic landing branch to rebase (e.g. "epic/42-my-epic")
+ * @param defaultBranch - the branch to rebase onto (e.g. "main")
+ * @param deps - injectable deps for testing
+ */
+export async function rebaseLandingBranch(
+  repoPath: string,
+  integrationBranch: string,
+  defaultBranch: string,
+  deps?: Partial<LandingRebaseDeps>,
+): Promise<LandingRebaseResult> {
+  if (!validRef(integrationBranch)) {
+    console.error(`[landing-rebase] invalid integrationBranch: ${integrationBranch}`);
+    return { kind: "transient" };
+  }
+  if (!validRef(defaultBranch)) {
+    console.error(`[landing-rebase] invalid defaultBranch: ${defaultBranch}`);
+    return { kind: "transient" };
+  }
+
+  const git = deps?.git ?? ((cwd: string, args: string[]) => makeDefaultGit(cwd, args));
+  const registerDriver = deps?.registerDriver ?? makeDefaultRegisterDriver;
+
+  // Determine worktrees dep — use real WorktreeMgr by default
+  let worktrees: Pick<WorktreeMgr, "createDetached" | "remove">;
+  if (deps?.worktrees) {
+    worktrees = deps.worktrees;
+  } else {
+    // Lazy import to avoid circular deps; real path
+    const { WorktreeMgr: Mgr } = await import("./worktree");
+    worktrees = new Mgr();
+  }
+
+  // 1. Driver precondition
+  try {
+    const { stdout } = await git(repoPath, ["config", "--get", "merge.i18n-union.driver"]);
+    if (!stdout.trim()) {
+      throw new Error("empty driver config");
+    }
+  } catch {
+    // Driver not registered; attempt to register
+    try {
+      registerDriver(repoPath);
+    } catch (err) {
+      console.error(`[landing-rebase] registerDriver failed:`, err);
+      return { kind: "driver-absent" };
+    }
+    // Re-check
+    try {
+      const { stdout } = await git(repoPath, ["config", "--get", "merge.i18n-union.driver"]);
+      if (!stdout.trim()) {
+        return { kind: "driver-absent" };
+      }
+    } catch {
+      return { kind: "driver-absent" };
+    }
+  }
+
+  // 2. Fetch both refs using explicit refspecs so tracking refs are created/updated
+  // even in single-branch clones (where only `main` is in the fetch refspec config).
+  try {
+    await git(repoPath, [
+      "fetch",
+      "origin",
+      `refs/heads/${defaultBranch}:refs/remotes/origin/${defaultBranch}`,
+      `refs/heads/${integrationBranch}:refs/remotes/origin/${integrationBranch}`,
+    ]);
+  } catch (err) {
+    console.error(`[landing-rebase] fetch failed:`, err);
+    return { kind: "transient" };
+  }
+
+  // 3. leaseSha + ancestor check
+  let leaseSha: string;
+  try {
+    const { stdout } = await git(repoPath, ["rev-parse", `origin/${integrationBranch}`]);
+    leaseSha = stdout.trim();
+  } catch (err) {
+    console.error(`[landing-rebase] rev-parse failed:`, err);
+    return { kind: "transient" };
+  }
+
+  try {
+    // If origin/<default> is already an ancestor of origin/<integrationBranch>, nothing to do
+    await git(repoPath, [
+      "merge-base",
+      "--is-ancestor",
+      `origin/${defaultBranch}`,
+      `origin/${integrationBranch}`,
+    ]);
+    return { kind: "current" };
+  } catch {
+    // Not an ancestor → need to rebase
+  }
+
+  // 4. Create detached worktree
+  let wt: { worktreePath: string };
+  try {
+    wt = await worktrees.createDetached(repoPath, integrationBranch, leaseSha);
+  } catch (err) {
+    console.error(`[landing-rebase] createDetached failed:`, err);
+    return { kind: "transient" };
+  }
+
+  try {
+    // 5. Rebase with the merge backend pinned.
+    // Belt-and-suspenders for git < 2.34: there the default `apply` backend
+    // bypasses gitattributes `merge=` drivers entirely, silently skipping our
+    // union drivers and false-conflicting the append-only catalog hunks. Pinning
+    // `merge` forces the drivers to run. (On modern git the `apply` backend also
+    // runs drivers via its 3-way fallback, so the divergence is untestable on
+    // current git — but we pin regardless so an older/misconfigured host can't
+    // bypass them.)
+    try {
+      await git(wt.worktreePath, [
+        "-c",
+        "rebase.backend=merge",
+        "rebase",
+        `origin/${defaultBranch}`,
+      ]);
+    } catch {
+      // 6. Rebase failed — classify before labeling
+      let conflictedPaths: string[];
+      try {
+        const { stdout } = await git(wt.worktreePath, ["diff", "--name-only", "--diff-filter=U"]);
+        conflictedPaths = stdout
+          .split("\n")
+          .map((s) => s.trim())
+          .filter(Boolean);
+      } catch {
+        conflictedPaths = [];
+      }
+
+      const unionGlobs = parseUnionGlobs(repoPath);
+
+      // Abort the rebase before returning
+      const abortRebase = async () => {
+        try {
+          await git(wt.worktreePath, ["rebase", "--abort"]);
+        } catch {
+          /* best effort */
+        }
+      };
+
+      if (conflictedPaths.length === 0) {
+        // No conflicted paths but rebase still failed (e.g. empty)
+        await abortRebase();
+        return { kind: "conflict" };
+      }
+
+      // 6a/6b: Check if any path is outside union-managed globs
+      const hasNonUnionConflict = conflictedPaths.some((p) => !isUnionManaged(p, unionGlobs));
+      if (hasNonUnionConflict) {
+        await abortRebase();
+        return { kind: "conflict" };
+      }
+
+      // 6c: All conflicted paths are union-managed — run driver self-test
+      const selfTestPassed = await driverSelfTest(repoPath);
+      await abortRebase();
+      if (selfTestPassed) {
+        // Driver works → genuine same-key clash
+        return { kind: "conflict" };
+      } else {
+        // Driver non-functional
+        return { kind: "driver-broken" };
+      }
+    }
+
+    // 7. Force-push with lease
+    try {
+      await git(wt.worktreePath, [
+        "push",
+        `--force-with-lease=${integrationBranch}:${leaseSha}`,
+        "origin",
+        `HEAD:refs/heads/${integrationBranch}`,
+      ]);
+    } catch (err) {
+      console.error(`[landing-rebase] push failed (stale lease or remote error):`, err);
+      return { kind: "transient" };
+    }
+
+    // 9. Success — get new head SHA. The push already landed, so a rev-parse
+    // failure here is a local read glitch; surface it as transient (a retry
+    // resolves to `current`, no double-count) rather than an unhandled rejection.
+    try {
+      const { stdout: headOut } = await git(wt.worktreePath, ["rev-parse", "HEAD"]);
+      return { kind: "rebased", headSha: headOut.trim() };
+    } catch (err) {
+      console.error(`[landing-rebase] rev-parse HEAD after push failed:`, err);
+      return { kind: "transient" };
+    }
+  } finally {
+    // 8. Always clean up the worktree
+    try {
+      worktrees.remove(wt.worktreePath);
+    } catch (err) {
+      console.error(`[landing-rebase] worktree remove failed:`, err);
+    }
+  }
+}

--- a/src/landing-rebase.ts
+++ b/src/landing-rebase.ts
@@ -1,11 +1,32 @@
-import { execFile, execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import type { WorktreeMgr } from "./worktree";
+import { execFileSync } from "./instrument";
 
 const execFileAsync = promisify(execFile);
+
+/**
+ * Fast, local-only probe: returns true when `merge.i18n-union.driver` is set in the
+ * repo's shared git config. Used by the drain driver-pause fast-path to re-probe
+ * cheaply without spawning a full rebase attempt.
+ *
+ * ASYNC: reached from the drain tick (single Bun event loop) — a sync child-process
+ * here would freeze the web terminal. No forge call; purely local `git config --get`.
+ */
+export async function isUnionDriverRegistered(repoPath: string): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync("git", ["config", "--get", "merge.i18n-union.driver"], {
+      cwd: repoPath,
+    });
+    return stdout.trim().length > 0;
+  } catch {
+    // Non-zero exit (key absent / not a repo / git error) → not registered.
+    return false;
+  }
+}
 
 export type LandingRebaseResult =
   | { kind: "rebased"; headSha: string } // replayed onto origin/<default>, force-pushed

--- a/src/rundown-core.ts
+++ b/src/rundown-core.ts
@@ -499,21 +499,43 @@ export function buildRundownPrompt(assembled: AssembledHerdState): string {
   }
 
   if (assembled.epics.length > 0) {
+    const pausedEpics = assembled.epics.filter((e) => e.pausedReason != null);
+    const readyEpics = assembled.epics.filter((e) => e.pausedReason == null);
+    const pauseReasonLabel = (r: "cap" | "conflict" | "driver"): string => {
+      if (r === "cap") return "rebase cap exhausted — needs manual rebase/push";
+      if (r === "conflict") return "genuine merge conflict — needs operator resolution";
+      return "merge driver unavailable on the server — needs environment fix";
+    };
     lines.push(
       "",
-      "EPICS AWAITING LANDING — these integrated epics have a landing PR that is ready to merge",
-      "but has NOT been landed. They are ALREADY surfaced separately to the operator as Tier-1",
-      '"land the epic" items (a dedicated section with a Land CTA), so you MUST NOT repeat them in',
-      'decisions/focusNext. You MUST NOT claim "all clear" or that the herd is idle while any',
-      "exist; you MAY mention them in `overnight` for context. For reference only (do NOT echo into",
-      "the verdict):",
-      ...assembled.epics.map(
-        (e) =>
-          `  - ${e.repo} #${e.parent} "${e.title}"` +
-          (e.landingPr != null ? ` (landing PR #${e.landingPr})` : "") +
-          (e.stranded ? " [STRANDED — unlanded well past threshold]" : ""),
-      ),
+      "EPICS AWAITING LANDING — integrated epics whose landing PR needs operator attention.",
+      "They are ALREADY surfaced separately to the operator as Tier-1 items (a dedicated section),",
+      'so you MUST NOT repeat them in decisions/focusNext. You MUST NOT claim "all clear" or that',
+      "the herd is idle while any exist; you MAY mention them in `overnight` for context.",
+      "For reference only (do NOT echo into the verdict):",
     );
+    if (pausedEpics.length > 0) {
+      lines.push("  Paused (auto-rebase blocked — operator action required):");
+      lines.push(
+        ...pausedEpics.map(
+          (e) =>
+            `    - ${e.repo} #${e.parent} "${e.title}"` +
+            (e.landingPr != null ? ` (landing PR #${e.landingPr})` : "") +
+            ` [PAUSED: ${pauseReasonLabel(e.pausedReason!)}]`,
+        ),
+      );
+    }
+    if (readyEpics.length > 0) {
+      lines.push("  Ready to land:");
+      lines.push(
+        ...readyEpics.map(
+          (e) =>
+            `    - ${e.repo} #${e.parent} "${e.title}"` +
+            (e.landingPr != null ? ` (landing PR #${e.landingPr})` : "") +
+            (e.stranded ? " [STRANDED — unlanded well past threshold]" : ""),
+        ),
+      );
+    }
   }
 
   // Strip `epics` from the herd-state dump below — they are rendered once in the dedicated block

--- a/src/rundown-core.ts
+++ b/src/rundown-core.ts
@@ -517,12 +517,15 @@ export function buildRundownPrompt(assembled: AssembledHerdState): string {
     if (pausedEpics.length > 0) {
       lines.push("  Paused (auto-rebase blocked — operator action required):");
       lines.push(
-        ...pausedEpics.map(
-          (e) =>
+        ...pausedEpics.flatMap((e) => {
+          const reason = e.pausedReason;
+          if (reason == null) return [];
+          return [
             `    - ${e.repo} #${e.parent} "${e.title}"` +
-            (e.landingPr != null ? ` (landing PR #${e.landingPr})` : "") +
-            ` [PAUSED: ${pauseReasonLabel(e.pausedReason!)}]`,
-        ),
+              (e.landingPr != null ? ` (landing PR #${e.landingPr})` : "") +
+              ` [PAUSED: ${pauseReasonLabel(reason)}]`,
+          ];
+        }),
       );
     }
     if (readyEpics.length > 0) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -4505,6 +4505,7 @@ async function backfillIdleEpic(
       landingState: "pending",
       migrationPaths: [],
       migrationsAckedAt: null,
+      landingRebasePauseReason: null,
     };
     deps.store.recordEpicCompleted({
       repoPath: completed.repoPath,
@@ -4588,9 +4589,18 @@ async function handleEpicsCompletedList({ req, parts, url, deps }: Ctx): Promise
   const baseRows: Array<
     CompletedEpic & { repoPath: string; parentIssueNumber: number; completedAt: number }
   > = dbRows.map((row) => {
-    // landingAttempts is an internal retry counter, not part of the CompletedEpic response.
-    const { childrenJson, landingAttempts, ...rest } = row;
+    // landingAttempts, landingRebaseCount, landingRebaseDriverMisses are internal counters,
+    // not part of the CompletedEpic response. landingRebasePauseReason is API-facing and passes through.
+    const {
+      childrenJson,
+      landingAttempts,
+      landingRebaseCount,
+      landingRebaseDriverMisses,
+      ...rest
+    } = row;
     void landingAttempts;
+    void landingRebaseCount;
+    void landingRebaseDriverMisses;
     return { ...rest, children: JSON.parse(childrenJson) as CompletedEpic["children"] };
   });
 
@@ -4782,6 +4792,7 @@ async function handleEpicsCompletedLand({ req, parts, deps }: Ctx): Promise<Resp
         landingState: updatedRow.landingState,
         migrationPaths: updatedRow.migrationPaths,
         migrationsAckedAt: updatedRow.migrationsAckedAt,
+        landingRebasePauseReason: updatedRow.landingRebasePauseReason,
       };
       deps.events?.emit("epic:completed", completed);
     } catch {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1441,11 +1441,15 @@ export class SessionStore implements CapStore, CreditStore {
     landingPrUrl: string | null;
     landingState: EpicLandingState;
     landingAttempts: number;
+    landingRebaseCount: number;
+    landingRebaseDriverMisses: number;
+    landingRebasePauseReason: "cap" | "conflict" | "driver" | null;
     migrationPaths: string[];
     migrationsAckedAt: number | null;
   }[] {
     const sql = `SELECT repoPath, parentIssueNumber, parentTitle, completedAt, childrenJson,
                 landingPrNumber, landingPrUrl, landingState, landingAttempts,
+                landingRebaseCount, landingRebaseDriverMisses, landingRebasePauseReason,
                 migrationPathsJson, migrationsAckedAt
          FROM epic_completed WHERE dismissedAt IS NULL`;
     type Raw = {
@@ -1458,6 +1462,9 @@ export class SessionStore implements CapStore, CreditStore {
       landingPrUrl: string | null;
       landingState: EpicLandingState;
       landingAttempts: number;
+      landingRebaseCount: number;
+      landingRebaseDriverMisses: number;
+      landingRebasePauseReason: string | null;
       migrationPathsJson: string | null;
       migrationsAckedAt: number | null;
     };
@@ -1467,8 +1474,9 @@ export class SessionStore implements CapStore, CreditStore {
             .query(`${sql} AND repoPath = ? ORDER BY completedAt DESC`)
             .all(repoPath) as Raw[])
         : (this.db.query(`${sql} ORDER BY completedAt DESC`).all() as Raw[]);
-    return rows.map(({ migrationPathsJson, ...rest }) => ({
+    return rows.map(({ migrationPathsJson, landingRebasePauseReason, ...rest }) => ({
       ...rest,
+      landingRebasePauseReason: landingRebasePauseReason as "cap" | "conflict" | "driver" | null,
       migrationPaths: parseFindings(migrationPathsJson),
     }));
   }
@@ -1489,6 +1497,40 @@ export class SessionStore implements CapStore, CreditStore {
       `UPDATE epic_completed SET landingState = ?, landingPrNumber = ?, landingPrUrl = ?, landingAttempts = ?
        WHERE repoPath = ? AND parentIssueNumber = ?`,
       [fields.state, fields.prNumber, fields.prUrl, fields.attempts, repoPath, parentIssueNumber],
+    );
+  }
+
+  /** Write rebase-state fields onto a completed epic's row (#1071). Only updates the fields
+   *  present in `fields` (partial SET), so callers can bump one counter without clobbering others.
+   *  Mirrors {@link setEpicLandingPr}'s direct-UPDATE style. */
+  setEpicLandingRebaseState(
+    repoPath: string,
+    parentIssueNumber: number,
+    fields: {
+      count?: number;
+      driverMisses?: number;
+      pauseReason?: "cap" | "conflict" | "driver" | null;
+    },
+  ): void {
+    const sets: string[] = [];
+    const vals: (string | number | null)[] = [];
+    if (fields.count !== undefined) {
+      sets.push("landingRebaseCount = ?");
+      vals.push(fields.count);
+    }
+    if (fields.driverMisses !== undefined) {
+      sets.push("landingRebaseDriverMisses = ?");
+      vals.push(fields.driverMisses);
+    }
+    if ("pauseReason" in fields) {
+      sets.push("landingRebasePauseReason = ?");
+      vals.push(fields.pauseReason ?? null);
+    }
+    if (sets.length === 0) return;
+    vals.push(repoPath, parentIssueNumber);
+    this.db.run(
+      `UPDATE epic_completed SET ${sets.join(", ")} WHERE repoPath = ? AND parentIssueNumber = ?`,
+      vals,
     );
   }
 
@@ -2849,6 +2891,10 @@ export class SessionStore implements CapStore, CreditStore {
     add("landingPrUrl", `landingPrUrl TEXT`);
     add("landingState", `landingState TEXT NOT NULL DEFAULT 'pending'`);
     add("landingAttempts", `landingAttempts INTEGER NOT NULL DEFAULT 0`);
+    // #1071: rebase-state counters + pause reason for session-less landing PRs.
+    add("landingRebaseCount", `landingRebaseCount INTEGER NOT NULL DEFAULT 0`);
+    add("landingRebaseDriverMisses", `landingRebaseDriverMisses INTEGER NOT NULL DEFAULT 0`);
+    add("landingRebasePauseReason", `landingRebasePauseReason TEXT`);
     // Migration-awareness checkpoint (#645). migrationPathsJson: paths of migration files
     // detected in the landing PR (JSON array). migrationsAckedAt: a durable audit timestamp
     // recording WHEN a human acknowledged those migrations — written alongside dismissedAt by

--- a/src/types.ts
+++ b/src/types.ts
@@ -377,13 +377,18 @@ export interface RundownItem {
  *  set (open landing PR that is CLEAN + CI-green + mergeable per #1039's computeLandingReady), so
  *  they can never be dropped or hallucinated. `repo`/`parent` deep-link to the IntegratedEpicsBand
  *  row + its Land CTA. `stranded` flags an open+ready landing that has sat unlanded past the Rec D
- *  threshold (urgency emphasis only — it does not gate inclusion). */
+ *  threshold (urgency emphasis only — it does not gate inclusion).
+ *  `pausedReason` — when present, the auto-rebase pass is paused (not ready to merge, needs
+ *  operator action): 'cap' = rebase cap exhausted; 'conflict' = genuine conflict; 'driver' = merge
+ *  driver unavailable on the server. Absent on landing-ready (non-paused) items. (#1071) */
 export interface RundownEpicItem {
   repo: string;
   parent: number;
   title: string;
   landingPr: number | null;
   stranded: boolean;
+  /** Present when the auto-rebase pass is paused and operator action is needed (#1071). */
+  pausedReason?: "cap" | "conflict" | "driver";
 }
 
 /** The LLM-authored verdict the rundown spawn writes to `.shepherd-rundown.json`. */

--- a/test/completed-epic.test.ts
+++ b/test/completed-epic.test.ts
@@ -299,6 +299,7 @@ describe("enrichLandingEpics", () => {
     landingState: "open",
     migrationPaths: [],
     migrationsAckedAt: null,
+    landingRebasePauseReason: null,
     ...over,
   });
 

--- a/test/drain-epic-autoland.test.ts
+++ b/test/drain-epic-autoland.test.ts
@@ -150,6 +150,7 @@ function makeHarness(opts: {
     emitEpic: () => {},
     emitEpicCompleted: (e) => completedEmits.push(e),
     now: () => nowMs,
+    rebaseCap: 5,
   });
 
   return { store, drain, completedEmits, spy, setNow: (ms) => (nowMs = ms) };
@@ -243,7 +244,10 @@ describe("auto-land of integrated epics (#1044)", () => {
     await h.drain.tick();
 
     expect(h.spy.mergeCalls).toHaveLength(0);
-    expect(h.spy.prStatusCalls).toHaveLength(0); // short-circuited before any forge call
+    // NOTE: the rebase pass (#1071) DOES call prStatus for migration-bearing rows because it
+    // never merges — keeping them mergeable for the operator's manual ack/land CTA (per plan).
+    // The auto-LAND pass still skips them (migrationPaths.length > 0 guard at drain.ts:1147).
+    // Only assert that merge was NOT called, not the prStatus call count.
     expect(row(h).landingState).toBe("open");
   });
 
@@ -398,12 +402,17 @@ describe("auto-land of integrated epics (#1044)", () => {
     // The lost manual-vs-auto race: the ready-check sees the PR open, but by the time forge.merge
     // fires a concurrent manual land already merged it → merge rejects, and a re-read now reports
     // merged. The failure path must reconcile (→ merged), never arm the backoff.
+    //
+    // With the #1071 rebase pass also running each tick, prStatus is read once more (the rebase
+    // pass sees an open+clean PR → not stuck → skips rebase). Auto-land then reads on the NEXT
+    // call and gets a ready PR → attempts merge → it throws "already merged" → re-reads → merged.
     let reads = 0;
     const h = makeHarness({
       autoMergeEnabled: true,
       prStatus: async () => {
         reads++;
-        return reads === 1 ? readyPr() : readyPr({ state: "merged" });
+        // reads 1: rebase pass (not-stuck, skips); reads 2: auto-land ready-check; reads 3+: post-merge re-check.
+        return reads <= 2 ? readyPr() : readyPr({ state: "merged" });
       },
       merge: async () => {
         throw new Error("Pull request is not mergeable: already merged");

--- a/test/drain-epic-completed.test.ts
+++ b/test/drain-epic-completed.test.ts
@@ -138,6 +138,7 @@ function makeHarness(opts: HarnessOpts): Harness {
     dropPrCache: () => {},
     emitEpic: () => {},
     emitEpicCompleted: (e) => completedEmits.push(e),
+    rebaseCap: 5,
   });
 
   return { store, drain, completedEmits };

--- a/test/drain-epic-divergence.test.ts
+++ b/test/drain-epic-divergence.test.ts
@@ -122,6 +122,7 @@ function makeHarness(branchesRef: BranchesRef, clock: { t: number }) {
     emitStatus: () => {},
     emitArchived: () => {},
     dropPrCache: () => {},
+    rebaseCap: 5,
   });
   return { store, drain };
 }

--- a/test/drain-epic-landing.test.ts
+++ b/test/drain-epic-landing.test.ts
@@ -167,6 +167,7 @@ function makeHarness(opts: {
     dropPrCache: () => {},
     emitEpic: () => {},
     emitEpicCompleted: (e) => completedEmits.push(e),
+    rebaseCap: 5,
   });
 
   return { store, drain, completedEmits, spy };

--- a/test/drain-epic-pin-branch.test.ts
+++ b/test/drain-epic-pin-branch.test.ts
@@ -150,6 +150,7 @@ function makeHarness(parentTitleRef: { title: string }, subIssues: SubIssueRef[]
     emitArchived: () => {},
     dropPrCache: () => {},
     emitEpic: (epic) => epics.push(epic),
+    rebaseCap: 5,
   });
 
   return { store, drain, rec, creates };

--- a/test/drain-epic-rebase-landing.test.ts
+++ b/test/drain-epic-rebase-landing.test.ts
@@ -1,0 +1,816 @@
+/**
+ * Tests for the #1071 rebase pass — `rebaseStuckLandingPrsForRepo` in drain.ts.
+ *
+ * All tests use an injected fake `rebaseLandingBranch` so no real git operations run.
+ * The forge `prStatus` is also faked per-test.
+ */
+import { test, expect, describe } from "bun:test";
+import { DrainService } from "../src/drain";
+import { SessionStore } from "../src/store";
+import type { GitForge, Issue, MergeInput, PrStatus, SubIssueRef } from "../src/forge/types";
+import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
+import type { CompletedEpic } from "../src/completed-epic";
+import type { LandingRebaseResult } from "../src/landing-rebase";
+import { epicIntegrationBranch } from "../src/epic-branch";
+
+const REPO = "/repo";
+const PARENT = 327;
+const PARENT_TITLE = "EFI cluster";
+const INTEGRATION_BRANCH = epicIntegrationBranch(PARENT, PARENT_TITLE); // epic/327-efi-cluster
+const LANDING_PR = 555;
+
+const NO_USAGE: UsageLimitsType = {
+  session5h: null,
+  week: null,
+  credits: null,
+  stale: false,
+  calibratedAt: null,
+  subscriptionOnly: false,
+};
+
+/** A PR in the "behind" state (stuck, needs rebase). */
+function behindPr(over: Partial<PrStatus> = {}): PrStatus {
+  return {
+    state: "open",
+    number: LANDING_PR,
+    url: `https://github.com/o/r/pull/${LANDING_PR}`,
+    checks: "pending",
+    mergeable: true,
+    mergeStateStatus: "behind",
+    headSha: "deadbeef",
+    isDraft: false,
+    deployConfigured: false,
+    ...over,
+  };
+}
+
+/** A PR in the "conflicting" state (stuck, genuine conflict). */
+function conflictPr(over: Partial<PrStatus> = {}): PrStatus {
+  return {
+    state: "open",
+    number: LANDING_PR,
+    url: `https://github.com/o/r/pull/${LANDING_PR}`,
+    checks: "failure",
+    mergeable: false,
+    mergeStateStatus: "dirty",
+    headSha: "deadbeef",
+    isDraft: false,
+    deployConfigured: false,
+    ...over,
+  };
+}
+
+/** A PR that is not stuck (landable: not behind, not conflicting). */
+function cleanPr(over: Partial<PrStatus> = {}): PrStatus {
+  return {
+    state: "open",
+    number: LANDING_PR,
+    url: `https://github.com/o/r/pull/${LANDING_PR}`,
+    checks: "success",
+    mergeable: true,
+    mergeStateStatus: "clean",
+    headSha: "deadbeef",
+    isDraft: false,
+    deployConfigured: false,
+    ...over,
+  };
+}
+
+interface MergeCall {
+  prNumber: number;
+  method: string;
+}
+
+interface ForgeSpy {
+  forge: GitForge;
+  mergeCalls: MergeCall[];
+  prStatusCalls: string[];
+}
+
+function fakeForge(opts: {
+  kind?: "github" | "gitea" | "local";
+  prStatus?: (branch: string) => Promise<PrStatus>;
+  merge?: (prNumber: number, o: MergeInput) => Promise<void>;
+}): ForgeSpy {
+  const mergeCalls: MergeCall[] = [];
+  const prStatusCalls: string[] = [];
+  const forge: GitForge = {
+    kind: opts.kind ?? "github",
+    slug: "o/r",
+    mergeMethod: "squash",
+    deployWorkflow: null,
+    listIssues: async () => [],
+    listPullRequests: async () => [],
+    prStatus: async (branch: string) => {
+      prStatusCalls.push(branch);
+      return (
+        (await opts.prStatus?.(branch)) ??
+        ({ state: "none", checks: "none", deployConfigured: false } as PrStatus)
+      );
+    },
+    openPr: async () => ({ state: "open", checks: "none", deployConfigured: false }) as PrStatus,
+    defaultBranch: async () => "main",
+    merge: async (prNumber: number, o: MergeInput) => {
+      mergeCalls.push({ prNumber, method: o.method });
+      await opts.merge?.(prNumber, o);
+    },
+    redeploy: async () => {},
+    postReview: async () => ({}),
+    closeIssue: async () => {},
+    ensureIssueLink: async () => {},
+    addIssueLabel: async () => {},
+    removeIssueLabel: async () => {},
+    getIssue: async (): Promise<Issue | null> => null,
+    listSubIssues: async (): Promise<SubIssueRef[]> => [],
+    listBlockedBy: async () => [],
+  };
+  return { forge, mergeCalls, prStatusCalls };
+}
+
+interface Harness {
+  store: SessionStore;
+  drain: DrainService;
+  completedEmits: CompletedEpic[];
+  spy: ForgeSpy;
+  rebaseCalls: Array<{ repoPath: string; branch: string; defaultBranch: string }>;
+}
+
+function makeHarness(opts: {
+  autoMergeEnabled?: boolean;
+  autoDrainEnabled?: boolean;
+  epicRunning?: boolean;
+  draftMode?: boolean;
+  rebaseCap?: number;
+  prStatus?: (branch: string) => Promise<PrStatus>;
+  rebaseLandingBranch?: () => Promise<LandingRebaseResult>;
+  /** When false, use a gitea forge (non-github). */
+  github?: boolean;
+  /** Inject the driver-registered probe (DI seam) so the fast-path is deterministic. */
+  isDriverRegistered?: (repoPath: string) => Promise<boolean>;
+}): Harness {
+  const store = new SessionStore(":memory:");
+  store.setRepoConfig(REPO, {
+    criticEnabled: false,
+    criticAllPrs: false,
+    autoAddressEnabled: false,
+    learningsEnabled: false,
+    autopilotEnabled: false,
+    planGateEnabled: false,
+    autoDrainEnabled: opts.autoDrainEnabled ?? false,
+    autoMergeEnabled: opts.autoMergeEnabled ?? false,
+    buildQueueEnabled: false,
+    draftMode: opts.draftMode ?? false,
+    signoffAuthority: "human",
+    maxAuto: 2,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+    sandboxProfile: "trusted",
+    defaultModel: "inherit",
+    egressExtraHosts: [],
+    repoMode: "forge",
+    autoOptimizeFlagged: false,
+    manualStepsIssueEnabled: false,
+  });
+
+  if (opts.epicRunning) {
+    store.setEpicRun({
+      repoPath: REPO,
+      parentIssueNumber: PARENT,
+      mode: "auto",
+      status: "running",
+    });
+  }
+
+  const spy = fakeForge({
+    kind: opts.github === false ? "gitea" : "github",
+    prStatus: opts.prStatus,
+  });
+  const completedEmits: CompletedEpic[] = [];
+  const rebaseCalls: Array<{ repoPath: string; branch: string; defaultBranch: string }> = [];
+
+  const fakeRebase = async (
+    repoPath: string,
+    branch: string,
+    defaultBranch: string,
+  ): Promise<LandingRebaseResult> => {
+    rebaseCalls.push({ repoPath, branch, defaultBranch });
+    return (await opts.rebaseLandingBranch?.()) ?? { kind: "current" };
+  };
+
+  const drain = new DrainService({
+    store,
+    service: {
+      create: async () => {
+        throw new Error("not used");
+      },
+      archive: () => 1,
+    } as never,
+    resolveForge: () => spy.forge,
+    prCache: { snapshot: () => ({}) },
+    usage: { limits: (): UsageLimitsType => NO_USAGE },
+    repos: () => [REPO],
+    emitStatus: () => {},
+    emitArchived: () => {},
+    dropPrCache: () => {},
+    emitEpic: () => {},
+    emitEpicCompleted: (e) => completedEmits.push(e),
+    rebaseCap: opts.rebaseCap ?? 5,
+    rebaseLandingBranch: fakeRebase,
+    isDriverRegistered: opts.isDriverRegistered,
+  });
+
+  return { store, drain, completedEmits, spy, rebaseCalls };
+}
+
+/** Seed an `epic_completed` row with landingState='open' and a pinned integration branch. */
+function seedOpenLanding(
+  h: Harness,
+  opts: {
+    migrations?: string[];
+    pin?: boolean;
+    rebaseCount?: number;
+    driverMisses?: number;
+    pauseReason?: "cap" | "conflict" | "driver" | null;
+  } = {},
+): void {
+  h.store.recordEpicIntegrated(REPO, PARENT, 320, {
+    number: 9320,
+    url: "https://github.com/o/r/pull/9320",
+  });
+  h.store.recordEpicCompleted({
+    repoPath: REPO,
+    parentIssueNumber: PARENT,
+    parentTitle: PARENT_TITLE,
+    completedAt: 1,
+    childrenJson: JSON.stringify([
+      {
+        number: 320,
+        title: "child 320",
+        url: "https://x/320",
+        prNumber: 9320,
+        prUrl: "https://github.com/o/r/pull/9320",
+        mergedAt: 1,
+        integrated: true,
+      },
+    ]),
+  });
+  if (opts.pin !== false) {
+    h.store.getOrInitEpicIntegrationBranch(REPO, PARENT, INTEGRATION_BRANCH);
+  }
+  h.store.setEpicLandingPr(REPO, PARENT, {
+    state: "open",
+    prNumber: LANDING_PR,
+    prUrl: `https://github.com/o/r/pull/${LANDING_PR}`,
+    attempts: 0,
+  });
+  if (opts.migrations && opts.migrations.length > 0) {
+    h.store.setEpicMigrationPaths(REPO, PARENT, opts.migrations);
+  }
+  if (
+    opts.rebaseCount !== undefined ||
+    opts.driverMisses !== undefined ||
+    opts.pauseReason !== undefined
+  ) {
+    h.store.setEpicLandingRebaseState(REPO, PARENT, {
+      count: opts.rebaseCount,
+      driverMisses: opts.driverMisses,
+      pauseReason: opts.pauseReason,
+    });
+  }
+}
+
+const row = (h: Harness) => h.store.listEpicCompleted(REPO)[0]!;
+
+/** Invoke the private rebase pass directly so prStatus call counts are isolated to it
+ *  (tick() also runs autoLandLandingPrsForRepo, which reads prStatus). */
+function callRebasePass(h: Harness): Promise<void> {
+  return (
+    h.drain as unknown as { rebaseStuckLandingPrsForRepo: (repoPath: string) => Promise<void> }
+  ).rebaseStuckLandingPrsForRepo(REPO);
+}
+
+describe("rebaseStuckLandingPrsForRepo (#1071)", () => {
+  // ── gate tests ──────────────────────────────────────────────────────────────
+
+  test("gate-off: draftMode ON → forge.prStatus NOT called", async () => {
+    const h = makeHarness({
+      draftMode: true,
+      autoMergeEnabled: true,
+      prStatus: async () => behindPr(),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.prStatusCalls).toHaveLength(0);
+    expect(h.rebaseCalls).toHaveLength(0);
+  });
+
+  test("gate-off: autoMerge+autoDrain off, no running epic → forge.prStatus NOT called", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: false,
+      autoDrainEnabled: false,
+      prStatus: async () => behindPr(),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.prStatusCalls).toHaveLength(0);
+    expect(h.rebaseCalls).toHaveLength(0);
+  });
+
+  test("gate: autoMergeEnabled ON (autoDrain off, no epic) → pass runs (prStatus called)", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      autoDrainEnabled: false,
+      prStatus: async () => cleanPr(),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.prStatusCalls.length).toBeGreaterThan(0);
+  });
+
+  test("gate: autoDrainEnabled ON (autoMerge off, no epic) → pass runs", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: false,
+      autoDrainEnabled: true,
+      prStatus: async () => cleanPr(),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.prStatusCalls.length).toBeGreaterThan(0);
+  });
+
+  test("epic-running engages: autoMerge+autoDrain off but epic status=running → pass runs", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: false,
+      autoDrainEnabled: false,
+      epicRunning: true,
+      prStatus: async () => cleanPr(),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.prStatusCalls.length).toBeGreaterThan(0);
+  });
+
+  test("non-github forge → rebaseLandingBranch NOT called (rebase pass skips gitea)", async () => {
+    // The rebase pass is GitHub-only (forge.kind !== 'github' → skips). The autoLandLandingPrsForRepo
+    // pass may still call prStatus for gitea when autoMergeEnabled is on — but that's a different pass.
+    // We assert the rebase pass itself did nothing (no rebaseCalls).
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      github: false,
+      prStatus: async () => behindPr(),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.rebaseCalls).toHaveLength(0);
+    // Row is still in initial state (no rebase state changes).
+    expect(row(h).landingRebaseCount).toBe(0);
+  });
+
+  // ── rebase-on-stuck tests ───────────────────────────────────────────────────
+
+  test("rebase-on-behind: mergeStateStatus=behind → rebaseLandingBranch called; on rebased → count++, merge NOT called", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => behindPr(),
+      rebaseLandingBranch: async () => ({ kind: "rebased", headSha: "newsha" }),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.rebaseCalls).toHaveLength(1);
+    expect(row(h).landingRebaseCount).toBe(1);
+    expect(row(h).landingRebaseDriverMisses).toBe(0);
+    expect(row(h).landingRebasePauseReason).toBeNull();
+    expect(h.spy.mergeCalls).toHaveLength(0); // NEVER merges
+  });
+
+  test("rebase-on-conflicting: mergeable=false → rebaseLandingBranch called", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => conflictPr(),
+      rebaseLandingBranch: async () => ({ kind: "rebased", headSha: "newsha" }),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.rebaseCalls).toHaveLength(1);
+    expect(row(h).landingRebaseCount).toBe(1);
+    expect(h.spy.mergeCalls).toHaveLength(0);
+  });
+
+  test("not-stuck PR (clean): rebaseLandingBranch NOT called, no state change", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => cleanPr(),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.rebaseCalls).toHaveLength(0);
+    expect(row(h).landingRebaseCount).toBe(0);
+  });
+
+  // ── result-union → drain action table ───────────────────────────────────────
+
+  test("rebased result → count incremented, driverMisses reset to 0, emitCompleted fired", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => behindPr(),
+      rebaseLandingBranch: async () => ({ kind: "rebased", headSha: "abc" }),
+    });
+    seedOpenLanding(h, { rebaseCount: 2, driverMisses: 1 });
+
+    await h.drain.tick();
+
+    expect(row(h).landingRebaseCount).toBe(3);
+    expect(row(h).landingRebaseDriverMisses).toBe(0); // reset on rebased
+    expect(h.completedEmits.length).toBeGreaterThan(0);
+  });
+
+  test("current result → all counters reset to 0 (no double-count on GitHub lag)", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => behindPr(),
+      rebaseLandingBranch: async () => ({ kind: "current" }),
+    });
+    seedOpenLanding(h, { rebaseCount: 2, driverMisses: 0 });
+
+    await h.drain.tick();
+
+    expect(row(h).landingRebaseCount).toBe(0); // reset
+    expect(row(h).landingRebasePauseReason).toBeNull();
+    expect(h.completedEmits.length).toBeGreaterThan(0);
+  });
+
+  test("conflict result → pauseReason='conflict', emitCompleted fired", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => conflictPr(),
+      rebaseLandingBranch: async () => ({ kind: "conflict" }),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(row(h).landingRebasePauseReason).toBe("conflict");
+    expect(h.completedEmits.length).toBeGreaterThan(0);
+  });
+
+  test("transient result → no state change, no count burn, retried next cycle", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => behindPr(),
+      rebaseLandingBranch: async () => ({ kind: "transient" }),
+    });
+    seedOpenLanding(h, { rebaseCount: 1 });
+
+    await h.drain.tick();
+
+    expect(row(h).landingRebaseCount).toBe(1); // unchanged
+    expect(row(h).landingRebasePauseReason).toBeNull();
+  });
+
+  // ── cap exhaustion ───────────────────────────────────────────────────────────
+
+  test("cap-exhaustion: row already at rebaseCap, stuck → pauseReason='cap', rebaseLandingBranch NOT called", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      rebaseCap: 3,
+      prStatus: async () => behindPr(),
+    });
+    seedOpenLanding(h, { rebaseCount: 3 }); // at cap
+
+    await h.drain.tick();
+
+    expect(h.rebaseCalls).toHaveLength(0); // cap hit before rebase
+    expect(row(h).landingRebasePauseReason).toBe("cap");
+    expect(h.spy.mergeCalls).toHaveLength(0);
+    expect(h.completedEmits.length).toBeGreaterThan(0);
+  });
+
+  test("hot-default: consecutive ticks with always-behind PR → count climbs to cap → pauses", async () => {
+    // Each tick returns 'rebased' (genuine advance). The PR stays 'behind' after each push
+    // (GitHub CI restarts). After rebaseCap ticks, the pass pauses.
+    const CAP = 3;
+    let prStatusCalls = 0;
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      rebaseCap: CAP,
+      prStatus: async () => {
+        prStatusCalls++;
+        return behindPr();
+      },
+      rebaseLandingBranch: async () => ({ kind: "rebased", headSha: `sha-${prStatusCalls}` }),
+    });
+    seedOpenLanding(h);
+
+    // Tick CAP times: each should increment the count.
+    for (let i = 0; i < CAP; i++) {
+      await h.drain.tick();
+      expect(row(h).landingRebaseCount).toBe(i + 1);
+    }
+
+    // One more tick: count is at cap → pause.
+    await h.drain.tick();
+    expect(row(h).landingRebasePauseReason).toBe("cap");
+    // No further rebase beyond the cap tick.
+    expect(h.rebaseCalls.length).toBe(CAP); // exactly CAP rebase calls
+  });
+
+  // ── driver-fault escalation ──────────────────────────────────────────────────
+
+  test("single driver-fault: driverMisses increments, no pause, no count burn", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => behindPr(),
+      rebaseLandingBranch: async () => ({ kind: "driver-absent" }),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(row(h).landingRebaseDriverMisses).toBe(1);
+    expect(row(h).landingRebasePauseReason).toBeNull(); // no pause yet
+    expect(row(h).landingRebaseCount).toBe(0); // no cap burn
+  });
+
+  test("driver-broken routes to driver-fault bucket (no conflict pause)", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => behindPr(),
+      rebaseLandingBranch: async () => ({ kind: "driver-broken" }),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    // driver-broken → same as driver-absent: increments driverMisses, NOT a conflict pause
+    expect(row(h).landingRebaseDriverMisses).toBe(1);
+    expect(row(h).landingRebasePauseReason).toBeNull();
+    expect(row(h).landingRebaseCount).toBe(0);
+  });
+
+  test("driver-fault escalation: K consecutive misses → pauseReason='driver'", async () => {
+    // DRIVER_MISS_CAP is 3 in drain.ts
+    const MISS_CAP = 3;
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => behindPr(),
+      rebaseLandingBranch: async () => ({ kind: "driver-absent" }),
+    });
+    seedOpenLanding(h);
+
+    // First MISS_CAP - 1 ticks: increments driverMisses, no pause.
+    for (let i = 0; i < MISS_CAP - 1; i++) {
+      await h.drain.tick();
+      expect(row(h).landingRebaseDriverMisses).toBe(i + 1);
+      expect(row(h).landingRebasePauseReason).toBeNull();
+      expect(row(h).landingRebaseCount).toBe(0); // no cap burn
+    }
+
+    // K-th miss → pause with 'driver'.
+    await h.drain.tick();
+    expect(row(h).landingRebaseDriverMisses).toBe(MISS_CAP);
+    expect(row(h).landingRebasePauseReason).toBe("driver");
+    expect(row(h).landingRebaseCount).toBe(0); // still no cap burn
+    expect(h.completedEmits.length).toBeGreaterThan(0);
+  });
+
+  // ── driver-pause fast-path ───────────────────────────────────────────────────
+
+  test("driver-pause: driver NOT registered → ZERO forge.prStatus calls, no rebase, stays paused", async () => {
+    // Inject a fake probe returning false. The fast-path must short-circuit BEFORE any
+    // forge.prStatus call. Call the rebase pass directly (not tick()) so the prStatus count
+    // is isolated to this pass (tick() also runs autoLandLandingPrsForRepo, which reads prStatus).
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => behindPr(),
+      isDriverRegistered: async () => false,
+    });
+    seedOpenLanding(h, { pauseReason: "driver", driverMisses: 3 });
+
+    await callRebasePass(h);
+
+    expect(h.spy.prStatusCalls).toHaveLength(0); // ZERO forge call when driver-paused + absent
+    expect(h.rebaseCalls).toHaveLength(0);
+    // State unchanged: still paused with 'driver'.
+    expect(row(h).landingRebasePauseReason).toBe("driver");
+    expect(row(h).landingRebaseDriverMisses).toBe(3); // unchanged
+  });
+
+  test("driver-pause fast-path: driver NOW registered → pause cleared, pass proceeds (prStatus called)", async () => {
+    // Inject a fake probe returning true. The fast-path clears the pause and falls through to
+    // probe prStatus + (since the PR is behind) attempt the rebase.
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => behindPr(),
+      isDriverRegistered: async () => true,
+      rebaseLandingBranch: async () => ({ kind: "rebased", headSha: "recovered" }),
+    });
+    seedOpenLanding(h, { pauseReason: "driver", driverMisses: 3 });
+
+    await callRebasePass(h);
+
+    // Pause cleared, prStatus probed, rebase attempted.
+    expect(h.spy.prStatusCalls.length).toBeGreaterThan(0);
+    expect(h.rebaseCalls).toHaveLength(1);
+    expect(row(h).landingRebasePauseReason).toBeNull();
+    // driverMisses reset to 0 by the fast-path clear, then count++ from the rebased result.
+    expect(row(h).landingRebaseDriverMisses).toBe(0);
+    expect(row(h).landingRebaseCount).toBe(1);
+  });
+
+  // ── pause states ─────────────────────────────────────────────────────────────
+
+  test("cap-pause: already paused with 'cap', stuck → stay paused, no rebase", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => behindPr(),
+    });
+    seedOpenLanding(h, { rebaseCount: 5, pauseReason: "cap" });
+
+    await h.drain.tick();
+
+    expect(h.rebaseCalls).toHaveLength(0);
+    expect(row(h).landingRebasePauseReason).toBe("cap"); // unchanged
+  });
+
+  test("cap-pause cleared when PR becomes not-stuck (operator rebased manually)", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => cleanPr(), // now clean/not-stuck
+    });
+    seedOpenLanding(h, { rebaseCount: 5, pauseReason: "cap" });
+
+    await h.drain.tick();
+
+    expect(row(h).landingRebasePauseReason).toBeNull(); // cleared
+    expect(row(h).landingRebaseCount).toBe(0);
+  });
+
+  test("conflict-pause: pauseReason='conflict' + PR still conflicting → stay paused", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => conflictPr(), // still conflicting
+    });
+    seedOpenLanding(h, { pauseReason: "conflict" });
+
+    await h.drain.tick();
+
+    expect(h.rebaseCalls).toHaveLength(0);
+    expect(row(h).landingRebasePauseReason).toBe("conflict"); // unchanged
+  });
+
+  test("conflict-pause resume: operator resolved conflict (PR now behind-only) → pause cleared, rebase attempted", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      // PR is now behind-only (operator resolved the conflict content),
+      // but still 'behind' so it still needs a rebase.
+      prStatus: async () => behindPr({ mergeable: true }), // mergeable=true but behind
+      rebaseLandingBranch: async () => ({ kind: "rebased", headSha: "newsha" }),
+    });
+    seedOpenLanding(h, { pauseReason: "conflict", rebaseCount: 0 });
+
+    await h.drain.tick();
+
+    // Pause cleared; rebase attempted.
+    expect(h.rebaseCalls).toHaveLength(1);
+    expect(row(h).landingRebasePauseReason).toBeNull();
+    expect(row(h).landingRebaseCount).toBe(1);
+  });
+
+  // ── reset-on-landable ────────────────────────────────────────────────────────
+
+  test("reset-on-landable: stuck row with count>0 becomes not-stuck → counters/pauseReason cleared", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => cleanPr(), // now landable
+    });
+    seedOpenLanding(h, { rebaseCount: 3, driverMisses: 1 });
+
+    await h.drain.tick();
+
+    expect(row(h).landingRebaseCount).toBe(0);
+    expect(row(h).landingRebaseDriverMisses).toBe(0);
+    expect(row(h).landingRebasePauseReason).toBeNull();
+    expect(h.completedEmits.length).toBeGreaterThan(0);
+  });
+
+  // ── migration-bearing rows ───────────────────────────────────────────────────
+
+  test("migration-bearing row is rebased (not merged) — never auto-merges", async () => {
+    // Per plan: unlike autoLandLandingPrsForRepo, the rebase pass processes migration-bearing
+    // rows too (they need a rebase to stay mergeable for the operator's manual ack/land CTA).
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => behindPr(),
+      rebaseLandingBranch: async () => ({ kind: "rebased", headSha: "migsha" }),
+    });
+    seedOpenLanding(h, { migrations: ["server/migrations/001.sql"] });
+
+    await h.drain.tick();
+
+    // Rebase was called (migration rows ARE rebased).
+    expect(h.rebaseCalls).toHaveLength(1);
+    expect(row(h).landingRebaseCount).toBe(1);
+    // But merge was never called.
+    expect(h.spy.mergeCalls).toHaveLength(0);
+  });
+
+  // ── never-merges ─────────────────────────────────────────────────────────────
+
+  test("never-merges: forge.merge is never invoked by this pass in any scenario", async () => {
+    // Test multiple scenarios: behind→rebased, conflicting→conflict, cap, driver-fault.
+    const scenarios: Array<{
+      label: string;
+      prStatus: PrStatus;
+      rebaseResult: LandingRebaseResult;
+      rebaseCount?: number;
+      pauseReason?: "cap" | "conflict" | "driver" | null;
+    }> = [
+      { label: "rebased", prStatus: behindPr(), rebaseResult: { kind: "rebased", headSha: "x" } },
+      { label: "conflict", prStatus: conflictPr(), rebaseResult: { kind: "conflict" } },
+      { label: "driver-absent", prStatus: behindPr(), rebaseResult: { kind: "driver-absent" } },
+      { label: "transient", prStatus: behindPr(), rebaseResult: { kind: "transient" } },
+      {
+        label: "cap",
+        prStatus: behindPr(),
+        rebaseResult: { kind: "current" },
+        rebaseCount: 5,
+      },
+    ];
+
+    for (const scenario of scenarios) {
+      const h = makeHarness({
+        autoMergeEnabled: true,
+        prStatus: async () => scenario.prStatus,
+        rebaseLandingBranch: async () => scenario.rebaseResult,
+        rebaseCap: 5,
+      });
+      seedOpenLanding(h, {
+        rebaseCount: scenario.rebaseCount,
+        pauseReason: scenario.pauseReason,
+      });
+
+      await h.drain.tick();
+
+      expect(h.spy.mergeCalls).toHaveLength(0);
+    }
+  });
+
+  // ── unpinned branch ──────────────────────────────────────────────────────────
+
+  test("unpinned integration branch → skip cleanly, no rebase", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => behindPr(),
+    });
+    seedOpenLanding(h, { pin: false }); // no pin → getEpicIntegrationBranch returns null
+
+    await h.drain.tick();
+
+    expect(h.rebaseCalls).toHaveLength(0);
+    expect(h.spy.prStatusCalls).toHaveLength(0);
+  });
+
+  // ── PR not open ──────────────────────────────────────────────────────────────
+
+  test("PR state=closed → skip (let reconcile own it), no rebase", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => behindPr({ state: "closed" }),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.rebaseCalls).toHaveLength(0);
+  });
+
+  test("PR state=merged → skip, no rebase", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => behindPr({ state: "merged" }),
+    });
+    seedOpenLanding(h);
+
+    await h.drain.tick();
+
+    expect(h.rebaseCalls).toHaveLength(0);
+  });
+});

--- a/test/drain-epic-retire-base.test.ts
+++ b/test/drain-epic-retire-base.test.ts
@@ -179,6 +179,7 @@ function makeHarness(
     dropPrCache: () => {},
     emitEpic: () => {},
     now: opts.now,
+    rebaseCap: 5,
   });
 
   return {
@@ -363,6 +364,7 @@ describe("epic base-mismatch marker self-heal on buildEpic (#645)", () => {
       emitArchived: () => {},
       dropPrCache: () => {},
       emitEpic: () => {},
+      rebaseCap: 5,
     });
     return { store, drain };
   }

--- a/test/drain-epic-retire-merge.test.ts
+++ b/test/drain-epic-retire-merge.test.ts
@@ -174,6 +174,7 @@ function makeHarness(
     emitArchived: (id) => archived.push(id),
     dropPrCache: () => {},
     emitEpic: () => {},
+    rebaseCap: 5,
   });
   harness.drain = drain;
   return harness;

--- a/test/drain-epic-spawn-base.test.ts
+++ b/test/drain-epic-spawn-base.test.ts
@@ -188,6 +188,7 @@ function makeHarness(
     emitArchived: () => {},
     dropPrCache: () => {},
     emitEpic: (epic) => epics.push(epic),
+    rebaseCap: 5,
   });
 
   return { store, drain, forgeRec, creates, statuses, epics };

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -282,6 +282,7 @@ function makeHarness(
     dropPrCache: (id) => dropped.push(id),
     emitEpic: (epic) => epics.push(epic),
     emitSessionNew: (s) => sessionNews.push(s),
+    rebaseCap: 5,
   });
   harness.drain = drain;
   return harness;
@@ -737,6 +738,7 @@ test("ensureIssueLink failure is best-effort: retire still archives and emits ev
     emitStatus: () => {},
     emitArchived: (id) => h.archived.push(id),
     dropPrCache: (id) => h.dropped.push(id),
+    rebaseCap: 5,
   });
   await drain2.pump(REPO);
   // Link failed but teardown still ran
@@ -837,6 +839,7 @@ test("tick + snapshot over repos: only drain-enabled repo is acted on and report
     emitStatus: (s) => statuses.push(s),
     emitArchived: () => {},
     dropPrCache: () => {},
+    rebaseCap: 5,
   });
 
   // tick should only pump the enabled repo (REPO), not REPO2
@@ -1492,6 +1495,7 @@ test("#790: spawn-failure cooldown: failed issue is skipped until window expires
     now: () => clock,
     // Zero TTL so the issues list is never served from cache between pumps.
     issuesTtlMs: 0,
+    rebaseCap: 5,
   });
 
   // Step 3: first pump — one claim attempt, create throws, cooldown recorded.

--- a/test/epic-server.test.ts
+++ b/test/epic-server.test.ts
@@ -1017,7 +1017,37 @@ describe("GET /api/epics/completed", () => {
     expect(row.landingPrNumber).toBe(42);
     expect(row.landingPrUrl).toBe("https://example/pr/42");
     expect(row.landingState).toBe("open");
+    // Internal counters are stripped; landingRebasePauseReason is API-facing and passes through.
     expect("landingAttempts" in row).toBe(false);
+    expect("landingRebaseCount" in row).toBe(false);
+    expect("landingRebaseDriverMisses" in row).toBe(false);
+    expect("landingRebasePauseReason" in row).toBe(true);
+    expect(row.landingRebasePauseReason).toBe(null); // not paused
+  });
+
+  test("landingRebasePauseReason passes through with its value when set", async () => {
+    const { app, store } = completedHarness({ resolveForge: () => null });
+    store.recordEpicCompleted({
+      repoPath: repoDir,
+      parentIssueNumber: 43,
+      parentTitle: "Paused Epic",
+      completedAt: 5000,
+      childrenJson: "[]",
+    });
+    store.setEpicLandingPr(repoDir, 43, {
+      state: "open",
+      prNumber: 43,
+      prUrl: "https://example/pr/43",
+      attempts: 0,
+    });
+    store.setEpicLandingRebaseState(repoDir, 43, { pauseReason: "conflict" });
+    const res = await app.fetch(new Request(`http://x/api/epics/completed`));
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    const row = body[0];
+    expect(row.landingRebasePauseReason).toBe("conflict");
+    expect("landingRebaseCount" in row).toBe(false);
+    expect("landingRebaseDriverMisses" in row).toBe(false);
   });
 
   test("plain record → default landing fields (pending/null/null)", async () => {

--- a/test/herd-digest.test.ts
+++ b/test/herd-digest.test.ts
@@ -914,3 +914,57 @@ test("reconcileEpics: caps the intraday list to RUNDOWN_EPICS_CAP", async () => 
   await svc.reconcileEpics();
   expect(store.getHerdDigest(dayKey)?.epicsToLand.length).toBe(RUNDOWN_EPICS_CAP);
 });
+
+// ── #1071: paused landing-rebase epics surfaced as Tier-1 ────────────────────
+
+test("generate: paused epic (cap) → spawns, row carries epicsToLand with pausedReason", async () => {
+  const store = makeStore([]);
+  const herdr = makeHerdr();
+  const pausedEpic = sampleEpic({ pausedReason: "cap" });
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => DAY1,
+    hasOpenLandingEpics: () => true,
+    landingReadyEpics: async () => [pausedEpic],
+  });
+
+  expect(await svc.generate()).toBe("started");
+  const row = store.getHerdDigest(dayKeyFor(DAY1));
+  expect(row?.epicsToLand).toEqual([pausedEpic]);
+  expect(row?.epicsToLand.at(0)?.pausedReason).toBe("cap");
+});
+
+test("generate: paused epic (driver) → spawns, epicsToLand carries driver reason", async () => {
+  const store = makeStore([]);
+  const herdr = makeHerdr();
+  const driverEpic = sampleEpic({ parent: 9, pausedReason: "driver" });
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => DAY1,
+    hasOpenLandingEpics: () => true,
+    landingReadyEpics: async () => [driverEpic],
+  });
+
+  expect(await svc.generate()).toBe("started");
+  const row = store.getHerdDigest(dayKeyFor(DAY1));
+  expect(row?.epicsToLand.at(0)?.pausedReason).toBe("driver");
+});
+
+test("generate: null pausedReason (ready) → epicsToLand has no pausedReason field", async () => {
+  const store = makeStore([]);
+  const herdr = makeHerdr();
+  const readyEpic = sampleEpic(); // no pausedReason
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => DAY1,
+    hasOpenLandingEpics: () => true,
+    landingReadyEpics: async () => [readyEpic],
+  });
+
+  expect(await svc.generate()).toBe("started");
+  const row = store.getHerdDigest(dayKeyFor(DAY1));
+  expect(row?.epicsToLand.at(0)?.pausedReason).toBeUndefined();
+});

--- a/test/landing-rebase.test.ts
+++ b/test/landing-rebase.test.ts
@@ -1,0 +1,558 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { rebaseLandingBranch } from "../src/landing-rebase";
+import type { LandingRebaseDeps } from "../src/landing-rebase";
+import { WorktreeMgr } from "../src/worktree";
+
+const execFileAsync = promisify(execFile);
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+};
+
+function git(cwd: string, args: string[]) {
+  return execFileSync("git", args, { cwd, stdio: "pipe", env: GIT_ENV }).toString().trim();
+}
+
+function commitFile(dir: string, file: string, content: string, msg: string) {
+  const filePath = join(dir, file);
+  const parts = file.split("/");
+  if (parts.length > 1) {
+    mkdirSync(join(dir, ...parts.slice(0, -1)), { recursive: true });
+  }
+  writeFileSync(filePath, content);
+  git(dir, ["add", "-A"]);
+  git(dir, ["commit", "-qm", msg]);
+}
+
+function revParse(dir: string, ref: string): string {
+  return git(dir, ["rev-parse", ref]);
+}
+
+const REAL_SCRIPT = readFileSync(join(import.meta.dir, "..", "scripts", "json-union-merge.mjs"));
+const REAL_REGISTER = readFileSync(
+  join(import.meta.dir, "..", "scripts", "register-merge-driver.mjs"),
+);
+
+const GITATTRIBUTES =
+  [
+    "* text=auto eol=lf",
+    "ui/messages/*.json merge=i18n-union",
+    "extension/messages/*.json merge=i18n-union",
+    "ui/src/lib/feature-announcements.ts merge=union",
+  ].join("\n") + "\n";
+
+/**
+ * Build an origin (bare) + seed repo with a populated main branch.
+ * The seed has scripts/ and .gitattributes committed.
+ * The seed is returned so tests can add commits and branches before cloning.
+ */
+function setupBaseRepo(opts?: { broken?: boolean }): { origin: string; seed: string } {
+  const origin = mkdtempSync(join(tmpdir(), "shepherd-lr-origin-"));
+  execFileSync("git", ["init", "-q", "--bare", "-b", "main", origin], { stdio: "pipe" });
+
+  const seed = mkdtempSync(join(tmpdir(), "shepherd-lr-seed-"));
+  execFileSync("git", ["init", "-q", "-b", "main", seed], { stdio: "pipe" });
+
+  writeFileSync(join(seed, ".gitattributes"), GITATTRIBUTES);
+
+  mkdirSync(join(seed, "scripts"), { recursive: true });
+  if (opts?.broken) {
+    // Commit a broken driver script so the worktree checkout also has it
+    writeFileSync(
+      join(seed, "scripts", "json-union-merge.mjs"),
+      `#!/usr/bin/env node\nprocess.exit(1);\n`,
+    );
+    writeFileSync(join(seed, "scripts", "register-merge-driver.mjs"), REAL_REGISTER);
+  } else {
+    writeFileSync(join(seed, "scripts", "json-union-merge.mjs"), REAL_SCRIPT);
+    writeFileSync(join(seed, "scripts", "register-merge-driver.mjs"), REAL_REGISTER);
+  }
+
+  commitFile(seed, "a.txt", "base content\n", "init");
+  execFileSync("git", ["remote", "add", "origin", origin], { cwd: seed, stdio: "pipe" });
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: seed, stdio: "pipe" });
+
+  return { origin, seed };
+}
+
+/**
+ * Clone origin into a repo (single-branch main).
+ */
+function cloneRepo(origin: string): string {
+  const repo = mkdtempSync(join(tmpdir(), "shepherd-lr-clone-"));
+  execFileSync("git", ["clone", "-q", "--single-branch", "--branch", "main", origin, repo], {
+    stdio: "pipe",
+  });
+  return repo;
+}
+
+/**
+ * Register the i18n-union driver in a repo using the real/existing script.
+ */
+function registerDriverIn(repoPath: string): void {
+  execFileSync("node", ["scripts/register-merge-driver.mjs"], {
+    cwd: repoPath,
+    stdio: "pipe",
+  });
+}
+
+/**
+ * Fetch with explicit refspecs so single-branch clones get tracking refs.
+ * Uses `+` (forced) so re-fetches after a force-push also update the local ref.
+ */
+function fetchWithRefspec(repo: string, ...branches: string[]): void {
+  const refspecs = branches.map((b) => `+refs/heads/${b}:refs/remotes/origin/${b}`);
+  execFileSync("git", ["fetch", "origin", ...refspecs], { cwd: repo, stdio: "pipe" });
+}
+
+// ── teardown tracking ─────────────────────────────────────────────────────────
+
+let toCleanup: string[] = [];
+
+beforeEach(() => {
+  toCleanup = [];
+});
+
+afterEach(() => {
+  for (const p of toCleanup) {
+    rmSync(p, { recursive: true, force: true });
+  }
+});
+
+function track<T extends string>(...paths: T[]): T {
+  toCleanup.push(...paths);
+  return paths[0]!;
+}
+
+// ── async git dep ──────────────────────────────────────────────────────────
+
+function makeGit(): LandingRebaseDeps["git"] {
+  return (cwd, args) =>
+    execFileAsync("git", args, { cwd, env: GIT_ENV }).then(({ stdout }) => ({ stdout }));
+}
+
+// ── TEST: rebased — default advanced, integration has own commit ──────────────
+
+test("rebased: returns rebased + force-pushes when integration branch is behind default", async () => {
+  const { origin, seed } = setupBaseRepo();
+  track(origin, seed);
+  const repo = track(cloneRepo(origin));
+  registerDriverIn(repo);
+
+  const wt = new WorktreeMgr();
+
+  // Create an integration branch on top of main
+  const intBranch = "epic/1-test";
+  git(seed, ["checkout", "-qb", intBranch]);
+  commitFile(seed, "epic.txt", "epic work\n", "epic: add feature");
+  execFileSync("git", ["push", "-q", "origin", intBranch], { cwd: seed, stdio: "pipe" });
+  const intBranchSha = revParse(seed, "HEAD");
+
+  // Advance main on origin (after the integration branch was cut)
+  git(seed, ["checkout", "-q", "main"]);
+  commitFile(seed, "main-advance.txt", "new main work\n", "chore: advance main");
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: seed, stdio: "pipe" });
+
+  const result = await rebaseLandingBranch(repo, intBranch, "main", {
+    worktrees: wt,
+    git: makeGit(),
+    registerDriver: registerDriverIn,
+  });
+
+  expect(result.kind).toBe("rebased");
+  if (result.kind !== "rebased") return;
+
+  // Verify force-push landed: fetch with explicit refspec so tracking ref updates
+  fetchWithRefspec(repo, intBranch, "main");
+  const newSha = revParse(repo, `origin/${intBranch}`);
+  expect(newSha).toBe(result.headSha);
+  expect(newSha).not.toBe(intBranchSha);
+
+  // origin/main should be an ancestor of the newly rebased integration branch
+  execFileSync("git", ["merge-base", "--is-ancestor", `origin/main`, `origin/${intBranch}`], {
+    cwd: repo,
+    stdio: "pipe",
+  });
+  // If the above didn't throw, origin/main IS an ancestor of the rebased branch
+});
+
+// ── TEST: current — integration already contains default ────────────────────
+
+test("current: returns current when integration branch already contains default", async () => {
+  const { origin, seed } = setupBaseRepo();
+  track(origin, seed);
+  const repo = track(cloneRepo(origin));
+  registerDriverIn(repo);
+
+  const wt = new WorktreeMgr();
+
+  // Create integration branch on latest main (it already contains main)
+  const intBranch = "epic/2-current";
+  git(seed, ["checkout", "-qb", intBranch]);
+  commitFile(seed, "epic2.txt", "epic 2\n", "feat: epic 2");
+  execFileSync("git", ["push", "-q", "origin", intBranch], { cwd: seed, stdio: "pipe" });
+  // main did NOT advance after the integration branch was cut
+  // so integration branch ALREADY contains main
+
+  const result = await rebaseLandingBranch(repo, intBranch, "main", {
+    worktrees: wt,
+    git: makeGit(),
+    registerDriver: registerDriverIn,
+  });
+
+  expect(result.kind).toBe("current");
+});
+
+// ── TEST: union false-conflict auto-resolves; apply backend would conflict ───
+
+test("append-only union conflict auto-resolves with pinned merge backend", async () => {
+  const { origin, seed } = setupBaseRepo();
+  track(origin, seed);
+  const repo = track(cloneRepo(origin));
+  registerDriverIn(repo);
+
+  const wt = new WorktreeMgr();
+
+  // Establish a base messages state and push to main
+  const baseMessages = JSON.stringify({ shared_key: "hello" }, null, 2) + "\n";
+  commitFile(seed, "ui/messages/en.json", baseMessages, "chore: add base messages");
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: seed, stdio: "pipe" });
+
+  // Create integration branch: adds epic_key
+  const intBranch = "epic/3-union";
+  git(seed, ["checkout", "-qb", intBranch]);
+  const epicMessages =
+    JSON.stringify({ shared_key: "hello", epic_key: "epic value" }, null, 2) + "\n";
+  writeFileSync(join(seed, "ui", "messages", "en.json"), epicMessages);
+  git(seed, ["add", "-A"]);
+  git(seed, ["commit", "-qm", "feat: add epic_key"]);
+  execFileSync("git", ["push", "-q", "origin", intBranch], { cwd: seed, stdio: "pipe" });
+
+  // Advance main: adds main_key (different key — would line-conflict without union driver)
+  git(seed, ["checkout", "-q", "main"]);
+  const mainMessages =
+    JSON.stringify({ shared_key: "hello", main_key: "main value" }, null, 2) + "\n";
+  writeFileSync(join(seed, "ui", "messages", "en.json"), mainMessages);
+  git(seed, ["add", "-A"]);
+  git(seed, ["commit", "-qm", "feat: add main_key on default"]);
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: seed, stdio: "pipe" });
+
+  // With the pinned merge backend + union driver, this should auto-resolve
+  const result = await rebaseLandingBranch(repo, intBranch, "main", {
+    worktrees: wt,
+    git: makeGit(),
+    registerDriver: registerDriverIn,
+  });
+
+  expect(result.kind).toBe("rebased");
+
+  // ── Demonstrate that WITHOUT the driver, the same rebase would conflict ──────
+  // This shows why the driver is load-bearing for the union-managed files.
+  // The `apply` backend behavior re: merge drivers is git-version-dependent
+  // (git ≥ 2.34 may invoke the driver on its 3-way fallback too), so we
+  // demonstrate driver necessity by using NO driver registration instead.
+  const noDriverOrigin = mkdtempSync(join(tmpdir(), "shepherd-lr-nodrv-origin-"));
+  track(noDriverOrigin);
+  execFileSync("git", ["init", "-q", "--bare", "-b", "main", noDriverOrigin], { stdio: "pipe" });
+
+  const noDriverSeed = mkdtempSync(join(tmpdir(), "shepherd-lr-nodrv-seed-"));
+  track(noDriverSeed);
+  execFileSync("git", ["init", "-q", "-b", "main", noDriverSeed], { stdio: "pipe" });
+  writeFileSync(join(noDriverSeed, ".gitattributes"), GITATTRIBUTES);
+  mkdirSync(join(noDriverSeed, "scripts"), { recursive: true });
+  // Put a script file that exits non-zero so driver can't resolve
+  writeFileSync(
+    join(noDriverSeed, "scripts", "json-union-merge.mjs"),
+    `#!/usr/bin/env node\nprocess.exit(1);\n`,
+  );
+  writeFileSync(join(noDriverSeed, "scripts", "register-merge-driver.mjs"), REAL_REGISTER);
+  commitFile(noDriverSeed, "ui/messages/en.json", baseMessages, "init");
+  execFileSync("git", ["remote", "add", "origin", noDriverOrigin], {
+    cwd: noDriverSeed,
+    stdio: "pipe",
+  });
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: noDriverSeed, stdio: "pipe" });
+
+  // Integration branch adds epic_key
+  git(noDriverSeed, ["checkout", "-qb", "epic/nodrv-test"]);
+  writeFileSync(join(noDriverSeed, "ui", "messages", "en.json"), epicMessages);
+  git(noDriverSeed, ["add", "-A"]);
+  git(noDriverSeed, ["commit", "-qm", "feat: epic key"]);
+  execFileSync("git", ["push", "-q", "origin", "epic/nodrv-test"], {
+    cwd: noDriverSeed,
+    stdio: "pipe",
+  });
+
+  // Main adds main_key
+  git(noDriverSeed, ["checkout", "-q", "main"]);
+  writeFileSync(join(noDriverSeed, "ui", "messages", "en.json"), mainMessages);
+  git(noDriverSeed, ["add", "-A"]);
+  git(noDriverSeed, ["commit", "-qm", "feat: main key"]);
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: noDriverSeed, stdio: "pipe" });
+
+  const noDriverRepo = mkdtempSync(join(tmpdir(), "shepherd-lr-nodrv-repo-"));
+  track(noDriverRepo);
+  execFileSync(
+    "git",
+    ["clone", "-q", "--single-branch", "--branch", "main", noDriverOrigin, noDriverRepo],
+    { stdio: "pipe" },
+  );
+  // Register the BROKEN driver so it's registered but non-functional
+  registerDriverIn(noDriverRepo);
+
+  // The rebaseLandingBranch with the broken driver should return driver-broken
+  // (not rebased), showing the driver is load-bearing for union file resolution
+  const noDrvWt = new WorktreeMgr();
+  const noDrvResult = await rebaseLandingBranch(noDriverRepo, "epic/nodrv-test", "main", {
+    worktrees: noDrvWt,
+    git: makeGit(),
+    registerDriver: registerDriverIn,
+  });
+  // With a broken driver, the union conflict can't be resolved
+  expect(noDrvResult.kind).toBe("driver-broken");
+});
+
+// ── TEST: conflict — non-union path ──────────────────────────────────────────
+
+test("conflict: returns conflict when a non-union file has a real conflict", async () => {
+  const { origin, seed } = setupBaseRepo();
+  track(origin, seed);
+  const repo = track(cloneRepo(origin));
+  registerDriverIn(repo);
+
+  const wt = new WorktreeMgr();
+
+  // Create integration branch that edits a.txt
+  const intBranch = "epic/4-conflict";
+  git(seed, ["checkout", "-qb", intBranch]);
+  writeFileSync(join(seed, "a.txt"), "epic edit\n");
+  git(seed, ["add", "-A"]);
+  git(seed, ["commit", "-qm", "feat: edit a.txt in integration"]);
+  execFileSync("git", ["push", "-q", "origin", intBranch], { cwd: seed, stdio: "pipe" });
+
+  // Advance main with a conflicting edit to a.txt
+  git(seed, ["checkout", "-q", "main"]);
+  writeFileSync(join(seed, "a.txt"), "main edit\n");
+  git(seed, ["add", "-A"]);
+  git(seed, ["commit", "-qm", "chore: edit a.txt on main"]);
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: seed, stdio: "pipe" });
+
+  const result = await rebaseLandingBranch(repo, intBranch, "main", {
+    worktrees: wt,
+    git: makeGit(),
+    registerDriver: registerDriverIn,
+  });
+
+  expect(result.kind).toBe("conflict");
+});
+
+// ── TEST: conflict — union path, genuine same-key clash (self-test passes) ────
+
+test("conflict: returns conflict on a genuine same-key clash in a union catalog", async () => {
+  // Both branches set the SAME key to DIFFERENT values in a merge=i18n-union file.
+  // The real union driver exits non-zero on a same-key clash (so the union path
+  // conflicts), but the additive self-test (a/b/c) still passes — so the result
+  // must be `conflict` (genuine clash), NOT `driver-broken`.
+  const { origin, seed } = setupBaseRepo();
+  track(origin, seed);
+  const repo = track(cloneRepo(origin));
+  registerDriverIn(repo);
+
+  const wt = new WorktreeMgr();
+
+  // Base catalog with a shared key
+  const baseMessages = JSON.stringify({ shared_key: "base value" }, null, 2) + "\n";
+  commitFile(seed, "ui/messages/en.json", baseMessages, "chore: add base messages");
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: seed, stdio: "pipe" });
+
+  // Integration branch changes shared_key to one value
+  const intBranch = "epic/8-samekey";
+  git(seed, ["checkout", "-qb", intBranch]);
+  writeFileSync(
+    join(seed, "ui", "messages", "en.json"),
+    JSON.stringify({ shared_key: "epic value" }, null, 2) + "\n",
+  );
+  git(seed, ["add", "-A"]);
+  git(seed, ["commit", "-qm", "feat: change shared_key on integration"]);
+  execFileSync("git", ["push", "-q", "origin", intBranch], { cwd: seed, stdio: "pipe" });
+
+  // Main changes the SAME key to a DIFFERENT value → genuine same-key clash
+  git(seed, ["checkout", "-q", "main"]);
+  writeFileSync(
+    join(seed, "ui", "messages", "en.json"),
+    JSON.stringify({ shared_key: "main value" }, null, 2) + "\n",
+  );
+  git(seed, ["add", "-A"]);
+  git(seed, ["commit", "-qm", "feat: change shared_key on default"]);
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: seed, stdio: "pipe" });
+
+  const result = await rebaseLandingBranch(repo, intBranch, "main", {
+    worktrees: wt,
+    git: makeGit(),
+    registerDriver: registerDriverIn,
+  });
+
+  // Working driver + same-key clash → genuine conflict, NOT driver-broken
+  expect(result.kind).toBe("conflict");
+});
+
+// ── TEST: driver-broken — union-only conflict + self-test fails ───────────────
+
+test("driver-broken: returns driver-broken when union-only conflict + broken driver", async () => {
+  // Use a setup where the seed has a BROKEN json-union-merge.mjs committed.
+  // The worktree is a checkout of the integration branch, so it also gets the broken script.
+  // The rebase will conflict on the JSON catalog (broken driver can't merge it),
+  // and the self-test (which also runs the broken script from repoPath) will fail.
+  const { origin, seed } = setupBaseRepo({ broken: true });
+  track(origin, seed);
+
+  // The seed has the broken script — we need to also ensure it's in the clone
+  // (which is what `repoPath` will be). We clone before adding the broken script to
+  // the work tree too, so we copy it over.
+  const repo = track(cloneRepo(origin));
+  // The broken script must live in BOTH places: committed on the branch (so the
+  // worktree checkout runs it during the rebase → union file conflicts) AND in
+  // repoPath/scripts (because driverSelfTest reads the script from repoPath, not
+  // the worktree → self-test fails → driver-broken).
+  writeFileSync(
+    join(repo, "scripts", "json-union-merge.mjs"),
+    `#!/usr/bin/env node\nprocess.exit(1);\n`,
+  );
+  // Register the driver (points to our broken script)
+  registerDriverIn(repo);
+
+  const wt = new WorktreeMgr();
+
+  // Add a base messages file to seed/main
+  const baseMessages = JSON.stringify({ shared_key: "hello" }, null, 2) + "\n";
+  mkdirSync(join(seed, "ui", "messages"), { recursive: true });
+  writeFileSync(join(seed, "ui", "messages", "en.json"), baseMessages);
+  git(seed, ["add", "-A"]);
+  git(seed, ["commit", "-qm", "chore: add base messages"]);
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: seed, stdio: "pipe" });
+
+  // Integration branch: adds epic_key
+  const intBranch = "epic/5-driver-broken";
+  git(seed, ["checkout", "-qb", intBranch]);
+  writeFileSync(
+    join(seed, "ui", "messages", "en.json"),
+    JSON.stringify({ shared_key: "hello", epic_key: "epic" }, null, 2) + "\n",
+  );
+  git(seed, ["add", "-A"]);
+  git(seed, ["commit", "-qm", "feat: add epic_key"]);
+  execFileSync("git", ["push", "-q", "origin", intBranch], { cwd: seed, stdio: "pipe" });
+
+  // Main: adds main_key (line-level conflict with integration on the JSON file)
+  git(seed, ["checkout", "-q", "main"]);
+  writeFileSync(
+    join(seed, "ui", "messages", "en.json"),
+    JSON.stringify({ shared_key: "hello", main_key: "main" }, null, 2) + "\n",
+  );
+  git(seed, ["add", "-A"]);
+  git(seed, ["commit", "-qm", "feat: add main_key"]);
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: seed, stdio: "pipe" });
+
+  const result = await rebaseLandingBranch(repo, intBranch, "main", {
+    worktrees: wt,
+    git: makeGit(),
+    registerDriver: registerDriverIn,
+  });
+
+  expect(result.kind).toBe("driver-broken");
+});
+
+// ── TEST: driver-absent — registerDriver is a no-op ─────────────────────────
+
+test("driver-absent: returns driver-absent when registerDriver is a no-op", async () => {
+  const { origin, seed } = setupBaseRepo();
+  track(origin, seed);
+  const repo = track(cloneRepo(origin));
+  // Do NOT register driver in repo — and inject a no-op registerDriver
+
+  const wt = new WorktreeMgr();
+
+  const intBranch = "epic/6-absent";
+  git(seed, ["checkout", "-qb", intBranch]);
+  commitFile(seed, "epic6.txt", "epic 6\n", "feat: epic 6");
+  execFileSync("git", ["push", "-q", "origin", intBranch], { cwd: seed, stdio: "pipe" });
+
+  // Advance main
+  git(seed, ["checkout", "-q", "main"]);
+  commitFile(seed, "main6.txt", "main 6\n", "chore: advance main");
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: seed, stdio: "pipe" });
+
+  const result = await rebaseLandingBranch(repo, intBranch, "main", {
+    worktrees: wt,
+    git: makeGit(),
+    registerDriver: () => {
+      /* no-op — driver stays absent */
+    },
+  });
+
+  expect(result.kind).toBe("driver-absent");
+});
+
+// ── TEST: transient — push fails (stale lease) ────────────────────────────────
+
+test("transient: returns transient when push fails due to stale lease", async () => {
+  const { origin, seed } = setupBaseRepo();
+  track(origin, seed);
+  const repo = track(cloneRepo(origin));
+  registerDriverIn(repo);
+
+  const wt = new WorktreeMgr();
+
+  // Create integration branch
+  const intBranch = "epic/7-transient";
+  git(seed, ["checkout", "-qb", intBranch]);
+  commitFile(seed, "epic7.txt", "epic 7\n", "feat: epic 7");
+  execFileSync("git", ["push", "-q", "origin", intBranch], { cwd: seed, stdio: "pipe" });
+
+  // Advance main
+  git(seed, ["checkout", "-q", "main"]);
+  commitFile(seed, "main7.txt", "main 7\n", "chore: advance main");
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: seed, stdio: "pipe" });
+
+  const originalGit = makeGit();
+
+  // Intercept push to first advance origin/intBranch so the lease is stale
+  const interceptGit: LandingRebaseDeps["git"] = async (cwd, args) => {
+    if (args[0] === "push" && args.some((a) => a.includes("force-with-lease"))) {
+      // Advance the integration branch on origin BEFORE the push to invalidate the lease
+      git(seed, ["checkout", "-q", intBranch]);
+      commitFile(seed, "race.txt", "concurrent\n", "concurrent: advance integration");
+      execFileSync("git", ["push", "-q", "origin", intBranch], { cwd: seed, stdio: "pipe" });
+    }
+    return originalGit(cwd, args);
+  };
+
+  const result = await rebaseLandingBranch(repo, intBranch, "main", {
+    worktrees: wt,
+    git: interceptGit,
+    registerDriver: registerDriverIn,
+  });
+
+  expect(result.kind).toBe("transient");
+});
+
+// ── TEST: invalid refname → transient ────────────────────────────────────────
+
+test("transient: invalid integrationBranch refname returns transient", async () => {
+  const result = await rebaseLandingBranch("/some/repo", "-evil-branch", "main");
+  expect(result.kind).toBe("transient");
+});
+
+test("transient: invalid defaultBranch refname returns transient", async () => {
+  const result = await rebaseLandingBranch("/some/repo", "epic/1-valid", "-evil");
+  expect(result.kind).toBe("transient");
+});

--- a/test/rundown-core.test.ts
+++ b/test/rundown-core.test.ts
@@ -792,3 +792,90 @@ test("buildRundownPrompt: no epic block when none", () => {
   });
   expect(buildRundownPrompt(out)).not.toContain("EPICS AWAITING LANDING");
 });
+
+// ── paused-rebase epics (#1071) ─────────────────────────────────────────────────
+test("assembleHerdState: paused epic (pausedReason set) passes through to epics array", () => {
+  const out = assembleHerdState({
+    sessions: [],
+    epics: [epic({ pausedReason: "cap" }), epic({ parent: 8, pausedReason: "driver" })],
+    overnightDelta: { mergedPrs: [], archivedSessions: [] },
+    generatedFor: "2026-06-15",
+    now: NOW,
+  });
+  expect(out.epics).toHaveLength(2);
+  expect(out.epics.at(0)?.pausedReason).toBe("cap");
+  expect(out.epics.at(1)?.pausedReason).toBe("driver");
+});
+
+test("assembleHerdState: null pausedReason passes through (non-paused item)", () => {
+  const out = assembleHerdState({
+    sessions: [],
+    epics: [epic()],
+    overnightDelta: { mergedPrs: [], archivedSessions: [] },
+    generatedFor: "2026-06-15",
+    now: NOW,
+  });
+  expect(out.epics.at(0)?.pausedReason).toBeUndefined();
+});
+
+test("buildRundownPrompt: paused epic rendered with PAUSED tag and reason text", () => {
+  const out = assembleHerdState({
+    sessions: [],
+    epics: [epic({ pausedReason: "cap", landingPr: 55 })],
+    overnightDelta: { mergedPrs: [], archivedSessions: [] },
+    generatedFor: "2026-06-15",
+    now: NOW,
+  });
+  const prompt = buildRundownPrompt(out);
+  expect(prompt).toContain("EPICS AWAITING LANDING");
+  expect(prompt).toContain("PAUSED");
+  expect(prompt).toContain("rebase cap exhausted");
+  expect(prompt).toContain("landing PR #55");
+  // not echoed in the JSON dump
+  const dump = prompt.slice(prompt.indexOf("Herd state (already significance-ranked):"));
+  expect(dump).not.toContain('"epics"');
+});
+
+test("buildRundownPrompt: driver-paused epic renders driver reason", () => {
+  const out = assembleHerdState({
+    sessions: [],
+    epics: [epic({ pausedReason: "driver" })],
+    overnightDelta: { mergedPrs: [], archivedSessions: [] },
+    generatedFor: "2026-06-15",
+    now: NOW,
+  });
+  const prompt = buildRundownPrompt(out);
+  expect(prompt).toContain("merge driver unavailable");
+});
+
+test("buildRundownPrompt: conflict-paused epic renders conflict reason", () => {
+  const out = assembleHerdState({
+    sessions: [],
+    epics: [epic({ pausedReason: "conflict" })],
+    overnightDelta: { mergedPrs: [], archivedSessions: [] },
+    generatedFor: "2026-06-15",
+    now: NOW,
+  });
+  const prompt = buildRundownPrompt(out);
+  expect(prompt).toContain("genuine merge conflict");
+});
+
+test("buildRundownPrompt: mixed paused + ready epics both rendered in dedicated block", () => {
+  const out = assembleHerdState({
+    sessions: [],
+    epics: [
+      epic({ parent: 7, pausedReason: "cap" }),
+      epic({ parent: 8, stranded: true }), // ready, no pausedReason
+    ],
+    overnightDelta: { mergedPrs: [], archivedSessions: [] },
+    generatedFor: "2026-06-15",
+    now: NOW,
+  });
+  const prompt = buildRundownPrompt(out);
+  expect(prompt).toContain("PAUSED");
+  expect(prompt).toContain("rebase cap exhausted");
+  expect(prompt).toContain("STRANDED");
+  // both epics mentioned
+  expect(prompt).toContain("#7");
+  expect(prompt).toContain("#8");
+});

--- a/test/sandbox-wiring.test.ts
+++ b/test/sandbox-wiring.test.ts
@@ -351,6 +351,7 @@ test("drain pre-check: standard profile holds → service.create NOT called", as
     emitStatus: () => {},
     emitArchived: () => {},
     dropPrCache: () => {},
+    rebaseCap: 5,
   });
   await drain.pump("/repo");
   expect(createCalls).toBe(0);
@@ -456,6 +457,7 @@ test("drain + autonomous repo + egress NULL → held, service.create NOT called"
     dropPrCache: () => {},
     detectBackend: () => "bwrap",
     detectEgressBackend: () => null, // egress unavailable → autonomous drain refused
+    rebaseCap: 5,
   });
   await drain.pump("/repo");
   expect(createCalls).toBe(0);

--- a/test/store-epic-completed.test.ts
+++ b/test/store-epic-completed.test.ts
@@ -380,6 +380,102 @@ test("ackEpicMigrations stamps migrationsAckedAt AND clears the row from the lis
   expect(acked.migrationsAckedAt).toBeGreaterThanOrEqual(before);
 });
 
+// ── setEpicLandingRebaseState ─────────────────────────────────────────────────
+
+test("fresh recordEpicCompleted defaults rebase columns (0/0/null)", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "E",
+    completedAt: 1,
+    childrenJson: "[]",
+  });
+  const row = s.listEpicCompleted()[0]!;
+  expect(row.landingRebaseCount).toBe(0);
+  expect(row.landingRebaseDriverMisses).toBe(0);
+  expect(row.landingRebasePauseReason).toBe(null);
+});
+
+test("setEpicLandingRebaseState writes all three fields", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "E",
+    completedAt: 1,
+    childrenJson: "[]",
+  });
+
+  s.setEpicLandingRebaseState("/r", 10, { count: 3, driverMisses: 1, pauseReason: "cap" });
+
+  const row = s.listEpicCompleted()[0]!;
+  expect(row.landingRebaseCount).toBe(3);
+  expect(row.landingRebaseDriverMisses).toBe(1);
+  expect(row.landingRebasePauseReason).toBe("cap");
+});
+
+test("setEpicLandingRebaseState partial update — only count, preserves others", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "E",
+    completedAt: 1,
+    childrenJson: "[]",
+  });
+  // seed all three fields
+  s.setEpicLandingRebaseState("/r", 10, { count: 2, driverMisses: 1, pauseReason: "driver" });
+
+  // partial update: bump count only
+  s.setEpicLandingRebaseState("/r", 10, { count: 3 });
+
+  const row = s.listEpicCompleted()[0]!;
+  expect(row.landingRebaseCount).toBe(3);
+  expect(row.landingRebaseDriverMisses).toBe(1); // preserved
+  expect(row.landingRebasePauseReason).toBe("driver"); // preserved
+});
+
+test("setEpicLandingRebaseState partial update — clear pauseReason to null", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "E",
+    completedAt: 1,
+    childrenJson: "[]",
+  });
+  s.setEpicLandingRebaseState("/r", 10, { count: 2, driverMisses: 2, pauseReason: "conflict" });
+
+  // clear pause reason and reset counters
+  s.setEpicLandingRebaseState("/r", 10, { count: 0, driverMisses: 0, pauseReason: null });
+
+  const row = s.listEpicCompleted()[0]!;
+  expect(row.landingRebaseCount).toBe(0);
+  expect(row.landingRebaseDriverMisses).toBe(0);
+  expect(row.landingRebasePauseReason).toBe(null);
+});
+
+test("setEpicLandingRebaseState partial update — driverMisses only, preserves count and pauseReason", () => {
+  const s = new SessionStore(":memory:");
+  s.recordEpicCompleted({
+    repoPath: "/r",
+    parentIssueNumber: 10,
+    parentTitle: "E",
+    completedAt: 1,
+    childrenJson: "[]",
+  });
+  s.setEpicLandingRebaseState("/r", 10, { count: 5, driverMisses: 0, pauseReason: "cap" });
+
+  // bump driverMisses only
+  s.setEpicLandingRebaseState("/r", 10, { driverMisses: 2 });
+
+  const row = s.listEpicCompleted()[0]!;
+  expect(row.landingRebaseCount).toBe(5); // preserved
+  expect(row.landingRebaseDriverMisses).toBe(2);
+  expect(row.landingRebasePauseReason).toBe("cap"); // preserved
+});
+
 test("listEpicRuns returns all persisted epic_run rows", () => {
   const s = new SessionStore(":memory:");
   expect(s.listEpicRuns()).toEqual([]);

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1920,5 +1920,10 @@
   "owed_step_toggle": "Schritt als erledigt markieren",
   "owed_post_merge_badge": "POST-MERGE",
   "feat_manual_steps_post_merge_title": "Offene Schritte überleben den Merge",
-  "feat_manual_steps_post_merge_body": "Nachdem ein PR mit manuellen Schritten gemergt und die Session archiviert wurde, leben die Schritte im neuen \"Offen\"-Tab weiter — hake jeden ab, sobald du ihn erledigt hast; sie bleiben bis zur Erledigung erhalten (weit über das Done-Fenster hinaus). Aktiviere pro Repo \"Manuelle Schritte als Issue verfolgen\", um beim Merge zusätzlich ein GitHub-Tracking-Issue zu öffnen, das auf den PR verweist."
+  "feat_manual_steps_post_merge_body": "Nachdem ein PR mit manuellen Schritten gemergt und die Session archiviert wurde, leben die Schritte im neuen \"Offen\"-Tab weiter — hake jeden ab, sobald du ihn erledigt hast; sie bleiben bis zur Erledigung erhalten (weit über das Done-Fenster hinaus). Aktiviere pro Repo \"Manuelle Schritte als Issue verfolgen\", um beim Merge zusätzlich ein GitHub-Tracking-Issue zu öffnen, das auf den PR verweist.",
+  "integrated_epics_rebase_paused_cap": "Auto-Rebase nach mehreren Versuchen fehlgeschlagen — du bist dran",
+  "integrated_epics_rebase_paused_conflict": "Landing-PR hat einen echten Konflikt — du bist dran",
+  "integrated_epics_rebase_paused_driver": "Merge-Treiber auf dem Server nicht verfügbar — du bist dran",
+  "feat_auto_rebase_landing_prs_title": "Auto-Rebase für Landing-PRs",
+  "feat_auto_rebase_landing_prs_body": "Wenn ein Landing-PR eines Epics hinter seiner Basis zurückfällt, führt Shepherd jetzt automatisch einen Rebase durch. Bei einem Konflikt, einem Wiederholungslimit oder einem fehlenden Merge-Treiber zeigt ein Warn-Chip in der Band-Zeile genau den Grund an und übergibt an dich."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1920,5 +1920,10 @@
   "owed_step_toggle": "Mark step done",
   "owed_post_merge_badge": "POST-MERGE",
   "feat_manual_steps_post_merge_title": "Owed steps survive merge",
-  "feat_manual_steps_post_merge_body": "After a PR with manual steps merges and the session archives, the steps live on in the new Owed lens — tick each off as you do it, and they persist until done (well past the Done window). Enable \"Track manual steps in an issue\" per repo to also open a GitHub tracking issue on merge, linked back to the PR."
+  "feat_manual_steps_post_merge_body": "After a PR with manual steps merges and the session archives, the steps live on in the new Owed lens — tick each off as you do it, and they persist until done (well past the Done window). Enable \"Track manual steps in an issue\" per repo to also open a GitHub tracking issue on merge, linked back to the PR.",
+  "integrated_epics_rebase_paused_cap": "Couldn't auto-rebase after repeated tries — over to you",
+  "integrated_epics_rebase_paused_conflict": "Landing PR has a real conflict — over to you",
+  "integrated_epics_rebase_paused_driver": "Merge driver unavailable on the server — over to you",
+  "feat_auto_rebase_landing_prs_title": "Auto-rebase for landing PRs",
+  "feat_auto_rebase_landing_prs_body": "When an epic's landing PR falls behind its base, Shepherd now rebases it automatically. If it hits a conflict, a retry cap, or a missing merge driver, a warn chip on the band row tells you exactly why and hands off to you."
 }

--- a/ui/src/lib/components/IntegratedEpicLanding.svelte
+++ b/ui/src/lib/components/IntegratedEpicLanding.svelte
@@ -147,7 +147,7 @@
     </button>
   {/if}
   {#if rebasePausedLabel}
-    <span class="chip-rebase-paused" id="rebase-paused-chip" use:coachTarget={"rebase-paused-chip"}
+    <span class="chip-rebase-paused" use:coachTarget={"rebase-paused-chip"}
       >{rebasePausedLabel}</span
     >
   {/if}

--- a/ui/src/lib/components/IntegratedEpicLanding.svelte
+++ b/ui/src/lib/components/IntegratedEpicLanding.svelte
@@ -2,6 +2,7 @@
   import type { CompletedEpic } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { formatAgo } from "$lib/format";
+  import { coachTarget } from "$lib/actions/coachTarget.svelte";
 
   let {
     epic,
@@ -29,6 +30,16 @@
   });
 
   const isOpen = $derived(epic.landingState === "open");
+
+  const rebasePausedLabel = $derived.by((): string | null => {
+    if (!epic.landingRebasePauseReason) return null;
+    if (epic.landingRebasePauseReason === "cap") return m.integrated_epics_rebase_paused_cap();
+    if (epic.landingRebasePauseReason === "conflict")
+      return m.integrated_epics_rebase_paused_conflict();
+    if (epic.landingRebasePauseReason === "driver")
+      return m.integrated_epics_rebase_paused_driver();
+    return null;
+  });
 
   const landNotReadyReason = $derived.by((): string => {
     if (epic.landingChecks === "failure") return m.integrated_epics_land_not_ready_ci_failing();
@@ -135,6 +146,11 @@
       {m.integrated_epics_dismiss()}
     </button>
   {/if}
+  {#if rebasePausedLabel}
+    <span class="chip-rebase-paused" id="rebase-paused-chip" use:coachTarget={"rebase-paused-chip"}
+      >{rebasePausedLabel}</span
+    >
+  {/if}
   {#if !isOpen}
     {#if epic.landingState === "merged" && epic.landingPrNumber != null}
       {#if epic.landingPrUrl}
@@ -210,6 +226,19 @@
     color: var(--status-warn);
     background: color-mix(in oklab, var(--status-warn) 12%, transparent);
     text-transform: uppercase;
+  }
+
+  /* Warn-tone chip — auto-rebase pass paused, operator action needed (#1071).
+     Same token recipe as chip-migrations; distinct from .landing-failed (which is error-only). */
+  .chip-rebase-paused {
+    flex: none;
+    font-size: var(--fs-micro);
+    letter-spacing: 0.08em;
+    padding: 1px 6px;
+    border: 1px solid var(--status-warn);
+    border-radius: 2px;
+    color: var(--status-warn);
+    background: color-mix(in oklab, var(--status-warn) 12%, transparent);
   }
 
   /* Inline confirm step — prompt text + migration warning */

--- a/ui/src/lib/components/IntegratedEpicRow.browser.test.ts
+++ b/ui/src/lib/components/IntegratedEpicRow.browser.test.ts
@@ -538,6 +538,93 @@ describe("IntegratedEpicRow", () => {
     expect(btns.find((b) => b.textContent?.includes("Land epic"))).toBeUndefined();
   });
 
+  // ── Auto-rebase paused chip (#1071) ───────────────────────────────────────
+
+  it("landingRebasePauseReason 'cap': shows cap paused chip", async () => {
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], {
+        landingState: "open",
+        landingPrNumber: 55,
+        landingPrUrl: "https://github.com/o/r/pull/55",
+        landingRebasePauseReason: "cap",
+      }),
+      ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
+      onland: vi.fn(),
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+
+    const chip = await vi.waitFor(() => {
+      const el = document.querySelector(".actions .chip-rebase-paused") as HTMLElement | null;
+      if (!el) throw new Error("no rebase-paused chip");
+      return el;
+    });
+    expect(chip.textContent).toContain("repeated tries");
+  });
+
+  it("landingRebasePauseReason 'conflict': shows conflict paused chip", async () => {
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], {
+        landingState: "open",
+        landingPrNumber: 55,
+        landingPrUrl: "https://github.com/o/r/pull/55",
+        landingRebasePauseReason: "conflict",
+      }),
+      ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
+      onland: vi.fn(),
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+
+    const chip = await vi.waitFor(() => {
+      const el = document.querySelector(".actions .chip-rebase-paused") as HTMLElement | null;
+      if (!el) throw new Error("no rebase-paused chip");
+      return el;
+    });
+    expect(chip.textContent).toContain("real conflict");
+  });
+
+  it("landingRebasePauseReason 'driver': shows driver paused chip", async () => {
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], {
+        landingState: "open",
+        landingPrNumber: 55,
+        landingPrUrl: "https://github.com/o/r/pull/55",
+        landingRebasePauseReason: "driver",
+      }),
+      ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
+      onland: vi.fn(),
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+
+    const chip = await vi.waitFor(() => {
+      const el = document.querySelector(".actions .chip-rebase-paused") as HTMLElement | null;
+      if (!el) throw new Error("no rebase-paused chip");
+      return el;
+    });
+    expect(chip.textContent).toContain("Merge driver");
+  });
+
+  it("no landingRebasePauseReason: no rebase-paused chip rendered", async () => {
+    render(IntegratedEpicRow, {
+      epic: epic([child({ number: 1 })], {
+        landingState: "open",
+        landingPrNumber: 55,
+        landingPrUrl: "https://github.com/o/r/pull/55",
+      }),
+      ondismiss: vi.fn(),
+      onackmigrations: vi.fn(),
+      onland: vi.fn(),
+    });
+    (document.querySelector(".row-head") as HTMLButtonElement).click();
+
+    await vi.waitFor(() => {
+      if (!document.querySelector(".actions .gbtn")) throw new Error("no actions yet");
+    });
+    expect(document.querySelector(".actions .chip-rebase-paused")).toBeNull();
+  });
+
   it("confirm cancel: clicking Cancel resets confirming state without calling onland", async () => {
     const onland = vi.fn();
     render(IntegratedEpicRow, {

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1581,4 +1581,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_manual_steps_post_merge_body",
     targetId: "owed-lens",
   },
+  {
+    // Epic #1071: auto-rebase for landing PRs. When paused (conflict/cap/driver), a warn chip on
+    // the integrated-epics band row surfaces the reason and hands off to the operator. Ships in 1.37.0.
+    id: "auto-rebase-landing-prs",
+    sinceVersion: "1.37.0",
+    titleKey: "feat_auto_rebase_landing_prs_title",
+    bodyKey: "feat_auto_rebase_landing_prs_body",
+    targetId: "rebase-paused-chip",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -438,12 +438,15 @@ export interface RundownItem {
   pr?: number;
 }
 // Tier-1 "land this epic" item (#1045) — server ground truth; repo/parent deep-link to the band.
+// pausedReason: present when auto-rebase is paused; 'cap'|'conflict'|'driver' (#1071).
 export interface RundownEpicItem {
   repo: string;
   parent: number;
   title: string;
   landingPr: number | null;
   stranded: boolean;
+  /** Present when the auto-rebase pass is paused and operator action is needed (#1071). */
+  pausedReason?: "cap" | "conflict" | "driver";
 }
 export interface HerdDigest {
   dayKey: string;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -635,6 +635,8 @@ export interface CompletedEpic {
   landingMergeable?: boolean | null;
   landingReady?: boolean;
   landingStranded?: boolean;
+  // When the auto-rebase pass is paused and operator action is needed (#1071); null when not paused.
+  landingRebasePauseReason?: "cap" | "conflict" | "driver" | null;
 }
 
 /** One queued backlog issue behind DrainStatus.queued — a row in the queue popover.


### PR DESCRIPTION
Generalizes PR #1064's `reEngageRebase` to **session-less epic landing PRs** (`epic/<#>→<default>`,
opened by `Drain.ensureLandingPr`). Closes #1071.

## Problem

An open epic landing PR can get stuck **non-mergeable forever** with nobody steering a rebase:
`tryAutoLandEpic` only acts when the PR is *already* landable (`if (!computeLandingReady(pr)) return`),
and the landing PR has no managed session for `reEngageRebase`/the merge train to steer. This is what
happened to the epic #1056 landing PR (#1070) — and the "conflict" was the known **union-merge-driver
gap**: GitHub computes mergeability with plain git and can't run Shepherd's catalog/feature-announcement
merge drivers, so it false-flags the append-only tail hunks. A local rebase with the drivers resolves it
with zero manual edits.

## Mechanism — server-side rebase in drain

A new `Drain.rebaseStuckLandingPrsForRepo` pass (in `tick()`, between `ensureLandingPrsForRepo` and
`autoLandLandingPrsForRepo`). For each open landing PR reporting `mergeStateStatus === 'behind'` or
`mergeable === false`:

1. Spin a **transient detached worktree** from the server's clone (reusing `WorktreeMgr.createDetached`/
   `remove`), `git -c rebase.backend=merge rebase origin/<default>` (the union drivers auto-resolve the
   append-only hunks), `git push --force-with-lease`, then remove the worktree.
2. Bounded by `config.autoMergeRebaseCap` (same counter pattern as `reEngageRebase`/the merge train),
   persisted on the `epic_completed` row.
3. On cap exhaustion / genuine conflict / **persistent driver fault**, pause to the operator — **band
   chip + Tier-1 rundown** — and stop. Never loops.
4. **Stops at landable; never merges.** Landing stays with `tryAutoLandEpic` (auto-merge on) or the
   operator's manual land CTA.

### Why not the server-side *integration worktree* / `gh pr update-branch`?
There is **no** persistent integration worktree — epic children land via the GitHub API
(`gh pr merge --squash`); the branch is forge-only. And `gh pr update-branch` runs plain server-side git
(no custom drivers → same false conflict) for **both** `update_method=merge` and `=rebase`, and the merge
method also breaks linear history. A local rebase with the merge backend is the only mechanism that both
auto-resolves and stays linear.

### Driver-fault vs. genuine conflict (the issue's MANDATORY distinction)
The rebase asserts `merge.i18n-union.driver` is registered (registers it if missing). On a rebase
conflict it classifies the conflicted paths against the `.gitattributes` `merge=` globs and runs a driver
**self-test**: a conflict on a non-union path, or on a union path while the self-test passes, is a genuine
same-key clash → `conflict` (operator pause); a union-only conflict with a failing self-test is
`driver-broken` → the driver-fault bucket. A driver fault is register-and-retried, then escalated to the
operator after `DRIVER_MISS_CAP` consecutive misses — **never silently retried forever, never burns a
rebase-cap attempt, never collapsed into the genuine-conflict pause**.

## Deliberate deviations (flagged per house rules)
- **Runs regardless of `autoMergeEnabled`** (mirrors `reEngageRebase` so the operator's manual land CTA
  stays usable), gated instead on automation being engaged: `!draftMode && (autoMergeEnabled ||
  autoDrainEnabled || epicRun==='running')`. Never force-pushes in a fully-dormant repo.
- **Rebases migration-bearing rows too** (auto-land skips them per #645) — it never merges, so keeping
  them mergeable only helps the operator's manual ack/land.
- **`-c rebase.backend=merge` is belt-and-suspenders.** On git ≥ 2.34 the default `apply` backend also
  invokes merge drivers via its 3-way fallback, so the pin is untestable on current git but kept for
  older/misconfigured hosts; the driver's load-bearing role is proven instead by a broken-driver test.
- **GitHub-only** (`forge.kind === 'github'`) — `mergeStateStatus === 'behind'` is GitHub-specific and
  LocalForge has no remote to push to.

## Acceptance criteria
- ✅ A behind/conflicting open landing PR is auto-rebased + force-pushed until landable, no human.
- ✅ Bounded by `autoMergeRebaseCap`; exhaustion pauses (band + Tier-1), never thrashes (incl. the
  hot-default race → cap → pause).
- ✅ Driver-absent/broken handled distinctly from a genuine conflict (asserted/registered + self-test +
  K-escalation), not silently paused forever.
- ✅ Never merges the landing PR.
- ✅ Tests: rebase-on-behind, rebase-on-conflicting, cap → pause, driver-fault escalation, reset-on-
  landable, conflict-resolved resume, migration-bearing rebased, gate-off, epic-running, hot-default,
  never-merges, plus the module's rebased/current/conflict/driver-absent/driver-broken/transient unit
  tests.

## Verification
Root: `bun run lint` clean · `bunx tsc --noEmit` clean · `bun test ./test` 4826 pass / 0 fail.
UI: `bun run check` 0/0 · `check:i18n` parity (1926 keys) · `bun run test` 2047 pass · `bun run build` ✓.
Repo: `prettier --check .` clean · branch hygiene linear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
