### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs/sandbox-security.md
+++ b/docs/sandbox-security.md
@@ -52,7 +52,7 @@ secrets out of the membrane entirely.
 
 Egress confinement is keyed to the autonomous **profile**, not to whether a human
 is watching (`willEgressConfine`, `src/sandbox.ts:543-549`; applied at
-`src/service.ts:1229`): the wrap applies iff the autonomous profile resolves
+`src/service.ts:1246`): the wrap applies iff the autonomous profile resolves
 **and** the fs + egress backends are present, independent of `ctx.auto`.
 Consequences:
 
@@ -76,19 +76,19 @@ Write --permission-mode dontAsk` (`src/reviewer-argv.ts:14-117`,
   `readonlyReviewerArgv`).
 - **Research is the deliberately egress-UNCONFINED surface.** A research session
   that would resolve to `autonomous` is **downgraded to `standard`**
-  (`src/service.ts` `researchSafeProfileOverride`, ~L1456-1474, warns once),
+  (`src/service.ts` `researchSafeProfileOverride`, ~L1478-1496, warns once),
   because research needs **open** web egress (search/fetch + sub-agents) that the
   autonomous firewall would block. It is operator-_created_ (cannot be
   auto-drained — `standard` refuses auto-spawn) but **autopilot-steerable, so it
   runs unattended in practice** (`RESEARCH_PROCEED_STEER`,
-  `src/autopilot.ts:22-27`, dispatched at L262). It ingests **untrusted web**
+  `src/autopilot.ts:23-28`, dispatched at L295). It ingests **untrusted web**
   content on `trusted`/`standard` with the **network open**, and can
   `gh pr create` / open issues via the bound gh token — so a hijacked research
   agent has **both** readable tokens **and** open egress.
 
   **Compensating factors:** the downgrade is explicit and warns once; research
   delivers a **report PR or GitHub issue only, never a code PR**
-  (`src/autopilot.ts:264-269`). The residual is **accepted**.
+  (`src/autopilot.ts:299-301`). The residual is **accepted**.
 
 ## See also
 


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc update summary

## Changes

- **`docs/sandbox-security.md`** — Refreshed four source line-number citations that had
  drifted after recent autopilot/service changes (the symbol names were all still correct;
  only the line anchors were stale). The maintainers keep these citations precise — the
  `src/sandbox.ts` anchors (`302-304`, `309-311`, `392`, `417`, `egressApplies` L532,
  `willEgressConfine` 543-549, `autoHoldReason` L480-481) were all re-verified and remain
  exact, so only the drifted ones were touched:
  - `willEgressConfine` applied at `src/service.ts:1229` → `:1246` (current call site,
    `const egressOn = willEgressConfine(...)`).
  - `researchSafeProfileOverride`, `~L1456-1474` → `~L1478-1496` (current function span).
  - `RESEARCH_PROCEED_STEER`, `src/autopilot.ts:22-27` → `:23-28` (current `export const`
    span), dispatched at `L262` → `L295` (current `dispatch()` `case "gate"`).
  - research "never a code PR" enforcement `src/autopilot.ts:264-269` → `:299-301` (current
    `finished`-case `if (s.research) … markComplete` that skips opening a code PR).

  Source: current `src/service.ts`, `src/autopilot.ts`, `src/sandbox.ts`; the line drift was
  introduced by recent autopilot work (e.g. #1064 `feat(autopilot): rebase idle review-passed
  non-mergeable PR`, #1071 drain auto-rebase) and surrounding service edits.

## No change needed (verified current)

- **`docs-site/.../reference/configuration.md`** — Already documents the newest env vars,
  including `SHEPHERD_TUI_FULLSCREEN` / `SHEPHERD_TUI_DISABLE_MOUSE` added in #1055
  (`src/config.ts:438-444`). All documented defaults (port 7330, host 127.0.0.1, usage-hold
  80%, preview port base 8001/count 16/sweep 4000, etc.) match `src/config.ts`. The doc-agent
  observe→act flags and cadence match the source.
- **`docs-site/.../reference/glossary.md`** — In sync with the tooltip registry
  `ui/src/lib/glossary.ts` (epic, pr, ci, critic, merge-train, rework, inferred, trial,
  weighted-units, satellite-pass). Trial / Weighted units / Satellite pass were added by the
  last sync (#1065); no registry term is missing from the doc.
- **`docs/token-usage-analysis.md`** — The pricing weights it quotes (Opus 5/25, Sonnet 3/15,
  Haiku 1/5, Fable 10/50, cache 0.1×/1.25×/2×) still match `src/pricing.ts`. The report is a
  point-in-time analysis grounded in #500/#502 history, not source-tracking prose.
- **`docs/external-task-api.md`** — Endpoints (`POST /api/sessions`, `/reply`, `/broadcast`,
  `GET/POST/DELETE /api/held`), the request schema, `force` bypass, and the usage-hold gate
  semantics all match `src/server.ts` / `src/validate.ts` / `src/usage-hold.ts`.
- **`docs-site/.../index.md`, `getting-started.md`, `operating.md`** — No drift versus current
  installer/operating behavior.

## Uncertain / needs human judgment

- **`SHEPHERD_SANDBOX_EXTRA_HOSTS`** (`src/config.ts:313`, used in `src/egress.ts`) is
  referenced obliquely in `configuration.md`'s sandbox section ("operator extras") but has no
  dedicated row in the env-var tables, unlike most other vars. It is **not** a recent
  addition, and the config reference is deliberately curated (it also omits the
  `SHEPHERD_LEARNINGS_*` family, VAPID keys, `SHEPHERD_REDUCED_PUSH_MODE`, autopilot caps,
  etc.), so this may be an intentional omission rather than staleness. Left as-is — a human
  should decide whether to promote it to a full row.
- Recent operator-facing orchestration features (manual operator steps gated on a PR — epic
  #1056/#1070; drain/autopilot auto-rebase — #1071/#1064; decommission-after-manual-merge —
  #1062) are UI/workflow behaviors with no corresponding prose section in the in-scope pages
  and no matching glossary registry term. Not added, since creating new sections/pages is out
  of scope and none map cleanly onto an existing stale passage.