### PR TITLE
fix(diff): diff against the PR's real base, not session.baseBranch

### DIFF
--- a/src/diff-base.ts
+++ b/src/diff-base.ts
@@ -1,0 +1,52 @@
+import type { Session } from "./types";
+import type { PrCache } from "./pr-poller";
+import type { GitForge } from "./forge/types";
+
+export interface ResolvedBase {
+  /** The base branch to diff against. */
+  base: string;
+  /** True when `base` is authoritative — a PR's `baseRefName`, or a definitive "no PR
+   *  exists" — and false when we fell back to `session.baseBranch` because the PR base
+   *  was momentarily unknowable (on-demand `gh` failed / forge unreachable). The diff
+   *  endpoints use `base` regardless; only the recap dedup consults `resolved` (so a
+   *  transient fallback can't flip the dedup key and re-fire a billed recap spawn). */
+  resolved: boolean;
+}
+
+/**
+ * Resolve the base branch a session's diff should compare against: prefer the PR's
+ * actual target (`baseRefName`) so the diff matches the PR's "Files changed" even when
+ * it targets a non-default branch, falling back to the session's stored `baseBranch`.
+ *
+ * Order: warm prCache → definitive cached "no PR" → on-demand `prStatus` (cold/evicted
+ * cache) → `session.baseBranch`. Only a PR base or a definitive no-PR is `resolved:true`;
+ * a transient miss (gh failure / unreachable forge) yields the `baseBranch` fallback with
+ * `resolved:false`.
+ */
+export async function resolveDiffBase(
+  session: Pick<Session, "id" | "baseBranch" | "branch" | "repoPath">,
+  prCache?: Pick<PrCache, "get">,
+  resolveForge?: (repoDir: string) => GitForge | null,
+): Promise<ResolvedBase> {
+  const cached = prCache?.get(session.id);
+  if (cached?.baseRefName) return { base: cached.baseRefName, resolved: true };
+  if (cached && cached.state === "none") return { base: session.baseBranch, resolved: true };
+
+  if (session.branch && resolveForge) {
+    try {
+      // resolveForge can shell out to git (cold cache) and prStatus shells out to gh; both can
+      // throw. Keep the whole thing in try so this never throws out of a caller (e.g. the recap
+      // archive hook) — a failure is simply non-authoritative.
+      const forge = resolveForge(session.repoPath);
+      if (forge) {
+        const st = await forge.prStatus(session.branch);
+        if (st.baseRefName) return { base: st.baseRefName, resolved: true };
+        if (st.state === "none") return { base: session.baseBranch, resolved: true };
+      }
+    } catch {
+      // transient gh/forge failure — not authoritative; fall through to the stored base.
+    }
+  }
+
+  return { base: session.baseBranch, resolved: false };
+}

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -129,6 +129,7 @@ interface GhPr {
   isDraft?: boolean;
   statusCheckRollup?: RollupEntry[];
   headRefOid?: string;
+  baseRefName?: string;
   reviews?: GhReview[];
   reviewRequests?: { login?: string }[];
   headRepositoryOwner?: { login?: string };
@@ -523,7 +524,7 @@ export class GithubForge implements GitForge {
       "--state",
       "all",
       "--json",
-      "number,url,title,state,createdAt,mergeable,mergeStateStatus,isDraft,statusCheckRollup,headRefOid,reviews,reviewRequests,headRepositoryOwner",
+      "number,url,title,state,createdAt,mergeable,mergeStateStatus,isDraft,statusCheckRollup,headRefOid,baseRefName,reviews,reviewRequests,headRepositoryOwner",
       "--limit",
       this.forkOwner ? "30" : "1",
     ]);
@@ -545,6 +546,7 @@ export class GithubForge implements GitForge {
       isDraft: pr.isDraft ?? false,
       checks: rollupChecks(pr.statusCheckRollup ?? []),
       headSha: pr.headRefOid,
+      baseRefName: pr.baseRefName,
       latestReview: latestHumanReview(pr.reviews),
       requestedReviewers: (pr.reviewRequests ?? [])
         .map((r) => r.login)

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -154,6 +154,11 @@ export interface PrStatus {
   isDraft?: boolean;
   /** GitHub's merge-eligibility signal; undefined on forges that don't supply it (Gitea). */
   mergeStateStatus?: MergeStateStatus;
+  /** The PR's actual base (target) branch ref name, e.g. "main". Drives the diff/recap
+   *  base so they match the PR's "Files changed" even when it targets a non-default branch.
+   *  Undefined when there is no PR, or on forges/payloads that don't supply it. Unlike
+   *  {@link PullRequest.nonDefaultBase} this IS the raw base ref — safe to diff against. */
+  baseRefName?: string;
   /** A deploy workflow is configured for this host. */
   deployConfigured: boolean;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { EventHub } from "./events";
 import { SessionService } from "./service";
 import { StatusPoller } from "./poller";
 import { PrPoller } from "./pr-poller";
+import { resolveDiffBase } from "./diff-base";
 import { BranchPruner } from "./branch-pruner";
 import { reconcile } from "./reconcile";
 import { reapOrphanTabs, reapStaleReviewWorktrees } from "./tab-reaper";
@@ -262,10 +263,16 @@ const egressWatcher = new EgressWatcher({
 // so the operator can skim what happened without reading the transcript. Mirrors planGate's
 // deps/onChange wiring; model defaults to "sonnet" inside the service. Constructed BEFORE
 // SessionService so its pre-teardown hook (beforeArchive) can be wired into the service.
-const recapService = new RecapService({
+// Explicit type annotation breaks the type-inference cycle the resolveBase closure introduces
+// (recapService → prPoller/resolveForge → service → recapService via beforeArchive). The closure
+// only runs at recap time (well after init), so the forward references are safe at runtime.
+const recapService: RecapService = new RecapService({
   store,
   herdr,
   onChange: (id, recap) => events.emit("session:recap", { id, recap }),
+  // Resolve the PR's real base so the recap diff matches the PR. prPoller + resolveForge are
+  // declared below; this closure only runs at recap time (well after init), like refreshPr above.
+  resolveBase: (s) => resolveDiffBase(s, prPoller, resolveForge),
 });
 
 // Lazy holder for the restricted agent-ingress listener's ephemeral port. The listener is started

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -81,6 +81,7 @@ function gitStateChanged(prev: GitState | undefined, git: GitState): boolean {
     prev.mergeStateStatus !== git.mergeStateStatus ||
     prev.isDraft !== git.isDraft ||
     prev.headSha !== git.headSha ||
+    prev.baseRefName !== git.baseRefName ||
     prev.latestReview?.submittedAt !== git.latestReview?.submittedAt ||
     prev.handoff !== git.handoff ||
     prev.handoffWho !== git.handoffWho

--- a/src/recap-core.ts
+++ b/src/recap-core.ts
@@ -188,9 +188,27 @@ export function isSettledIdle(status: string, idleMs: number, thresholdMs: numbe
   return (status === "idle" || status === "done") && idleMs >= thresholdMs;
 }
 
-/** Head-keyed dedupe: regenerate only when there's no recap yet, or the existing recap
- *  summarized a different HEAD. Any existing row at the same head — generating/ready/failed/
- *  empty — means do NOT auto-fire; fail-closed: no auto-retry of a failed recap. */
-export function needsRecap(existing: Recap | null, currentHeadSha: string): boolean {
-  return !existing || existing.headSha !== currentHeadSha;
+/** `(headSha, base)`-keyed dedupe: regenerate when there's no recap yet, the existing recap
+ *  summarized a different HEAD, or — when the current base was authoritatively resolved — the
+ *  existing recap diffed against a different base (e.g. it baked the stored baseBranch before
+ *  the PR's real base became known). Otherwise an existing row at the same head — generating/
+ *  ready/failed/empty — means do NOT auto-fire; fail-closed: no auto-retry of a failed recap.
+ *
+ *  Two guards on the base dimension:
+ *   - `existing.base !== ""` — legacy rows (predating the base column) are never force-regenerated
+ *     on base alone, so a deploy doesn't mass-regenerate every prior recap.
+ *   - `resolved` — only an authoritatively-resolved base re-fires; a transient fallback to
+ *     `baseBranch` (cold/evicted cache, on-demand gh failed) must NOT flip the key and bill a
+ *     recap spawn each tick. */
+export function needsRecap(
+  existing: Recap | null,
+  currentHeadSha: string,
+  currentBase: string,
+  resolved: boolean,
+): boolean {
+  return (
+    !existing ||
+    existing.headSha !== currentHeadSha ||
+    (resolved && existing.base !== "" && existing.base !== currentBase)
+  );
 }

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -349,9 +349,11 @@ export class RecapService {
    * so every session gets a durable recap row for the Done lens (the live-sweep's
    * skip of `auto` sessions would otherwise starve drained sessions of a recap).
    *
-   * Head-keyed dedup: if a recap already exists for the current HEAD we return "skip"
-   * (the common case — the live sweep usually already generated one), so we never
-   * double-spawn. Otherwise we generate synchronously.
+   * `(head, base)`-keyed dedup (see {@link needsRecap}): if a recap already exists for the
+   * current HEAD *and* the same base we return "skip" (the common case — the live sweep usually
+   * already generated one), so we never double-spawn. A recap baked against a stale base before
+   * the PR's real base was resolvable regenerates here once that base becomes known. Otherwise we
+   * generate synchronously.
    *
    * Does NOT throw: a git/worktree-unavailable rev-parse failure self-heals to "error"
    * rather than throwing out of the archive hook.

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -180,6 +180,9 @@ export interface RecapServiceDeps {
   timeoutMs?: number;
   idleThresholdMs?: number;
   // injectables:
+  /** Resolve the base branch to diff against (the PR's real base when resolvable) plus whether
+   *  that resolution was authoritative. Default: the session's stored baseBranch (non-authoritative). */
+  resolveBase?: (session: Session) => Promise<{ base: string; resolved: boolean }>;
   computeDiff?: (worktreePath: string, base: string, branch: string | null) => Promise<DiffResult>;
   headSha?: (worktreePath: string) => Promise<string>;
   readTranscript?: (worktreePath: string, claudeSessionId: string) => ActivityEntry[];
@@ -205,6 +208,7 @@ export class RecapService {
   private idleThresholdMs: number;
   private model: string | null;
 
+  private _resolveBase: (session: Session) => Promise<{ base: string; resolved: boolean }>;
   private _computeDiff: (
     worktreePath: string,
     base: string,
@@ -232,6 +236,8 @@ export class RecapService {
     this.timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.idleThresholdMs = deps.idleThresholdMs ?? DEFAULT_IDLE_THRESHOLD_MS;
     this.model = deps.model ?? "sonnet";
+    this._resolveBase =
+      deps.resolveBase ?? ((s) => Promise.resolve({ base: s.baseBranch, resolved: false }));
     this._computeDiff = deps.computeDiff ?? computeDiff;
     this._headSha = deps.headSha ?? defaultHeadSha;
     this._readTranscript = deps.readTranscript ?? defaultReadTranscript;
@@ -308,9 +314,10 @@ export class RecapService {
     // rev-parse succeeded → mark fired so we don't re-rev-parse until re-activity.
     entry.fired = true;
 
-    if (!needsRecap(this.deps.store.getRecap(s.id), head)) return;
+    const { base, resolved } = await this._resolveBase(s);
+    if (!needsRecap(this.deps.store.getRecap(s.id), head, base, resolved)) return;
 
-    await this.generate(s, head);
+    await this.generate(s, head, base);
   }
 
   /**
@@ -357,9 +364,10 @@ export class RecapService {
       return "error"; // git/worktree unavailable — don't throw out of the hook
     }
 
-    if (!needsRecap(this.deps.store.getRecap(session.id), head)) return "skip";
+    const { base, resolved } = await this._resolveBase(session);
+    if (!needsRecap(this.deps.store.getRecap(session.id), head, base, resolved)) return "skip";
 
-    return await this.generate(session, head);
+    return await this.generate(session, head, base);
   }
 
   // ── onArchived ─────────────────────────────────────────────────────────────────
@@ -392,7 +400,11 @@ export class RecapService {
    * (incl. the bare-`void` sweep loop) need not guard it.
    * A synchronous in-flight guard prevents double-spawn if regenerate races sweep.
    */
-  async generate(session: Session, knownHead?: string): Promise<"started" | "empty" | "error"> {
+  async generate(
+    session: Session,
+    knownHead?: string,
+    knownBase?: string,
+  ): Promise<"started" | "empty" | "error"> {
     // Fail closed: api-key mode without a configured key must NOT bill the subscription.
     if (isApiKeyMode() && !isApiKeyConfigured()) {
       console.warn(
@@ -400,7 +412,7 @@ export class RecapService {
       );
       return "error";
     }
-    const { id, worktreePath, baseBranch, branch, claudeSessionId } = session;
+    const { id, worktreePath, branch, claudeSessionId } = session;
 
     // Synchronous guard: if already mid-flight for this session, bail immediately.
     if (this.inFlight.has(id)) return "started";
@@ -410,13 +422,17 @@ export class RecapService {
       // Reap any in-flight row for this session first (prevents stale generating rows).
       this.reapGenerating(id);
 
-      // Resolve HEAD + diff up front; a git/diff rejection self-heals to "error"
+      // Resolve HEAD + base + diff up front; a git/diff rejection self-heals to "error"
       // (no row left) rather than throwing out of this bare-`void`-called method.
+      // Resolving the base HERE (not just in the dedup callers) covers regenerate(),
+      // which bypasses dedup — so a forced regenerate never re-bakes the stored base.
       let head: string;
+      let base: string;
       let diff: DiffResult;
       try {
         head = knownHead ?? (await this._headSha(worktreePath));
-        diff = await this._computeDiff(worktreePath, baseBranch, branch);
+        base = knownBase ?? (await this._resolveBase(session)).base;
+        diff = await this._computeDiff(worktreePath, base, branch);
       } catch {
         return "error";
       }
@@ -427,6 +443,7 @@ export class RecapService {
           sessionId: id,
           state: "empty",
           headSha: head,
+          base,
           verdict: null,
           headline: "",
           body: "",
@@ -498,6 +515,7 @@ export class RecapService {
         sessionId: id,
         state: "generating",
         headSha: head,
+        base,
         verdict: null,
         headline: "",
         body: "",

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,6 +57,7 @@ import { loadSteers, saveSteers } from "./steers";
 import { loadIcons, setIcon } from "./project-icons";
 import { listBranches } from "./branches";
 import { computeDiff } from "./diff";
+import { resolveDiffBase } from "./diff-base";
 import { sessionTokens, jsonlPathFor, type SessionUsageRollup } from "./usage";
 import { buildUsageBreakdown } from "./usage-breakdown";
 import { isApiKeyMode } from "./spawn-auth";
@@ -1542,7 +1543,10 @@ async function sessionDiffRead(id: string, deps: AppDeps): Promise<Response> {
   const s = deps.store.get(id);
   if (!s) return json({ error: "not found" }, 404);
   try {
-    return json(await computeDiff(s.worktreePath, s.baseBranch, s.branch));
+    // Diff against the PR's actual base (so it matches the PR's "Files changed" even when
+    // the PR targets a non-default branch), falling back to the session's stored baseBranch.
+    const { base } = await resolveDiffBase(s, deps.prCache, deps.resolveForge);
+    return json(await computeDiff(s.worktreePath, base, s.branch));
   } catch (e) {
     return json({ error: e instanceof Error ? e.message : "diff failed" }, 500);
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -302,6 +302,7 @@ type RecapRow = {
   sessionId: string;
   state: string;
   headSha: string | null;
+  base: string | null;
   verdict: string | null;
   headline: string | null;
   body: string | null;
@@ -734,6 +735,7 @@ export class SessionStore implements CapStore, CreditStore {
       sessionId TEXT PRIMARY KEY,
       state TEXT NOT NULL,
       headSha TEXT NOT NULL DEFAULT '',
+      base TEXT NOT NULL DEFAULT '',
       verdict TEXT,
       headline TEXT NOT NULL DEFAULT '',
       body TEXT NOT NULL DEFAULT '',
@@ -757,6 +759,11 @@ export class SessionStore implements CapStore, CreditStore {
     }
     if (!recapCols.some((c) => c.name === "pendingDiff")) {
       this.db.run(`ALTER TABLE recaps ADD COLUMN pendingDiff TEXT NOT NULL DEFAULT '[]'`);
+    }
+    // migrate recaps that predate the base column (legacy rows default to '' — the dedup's
+    // legacy guard then never force-regenerates them on base alone).
+    if (!recapCols.some((c) => c.name === "base")) {
+      this.db.run(`ALTER TABLE recaps ADD COLUMN base TEXT NOT NULL DEFAULT ''`);
     }
     // Manual operator steps — durable post-merge materialization (#1061, epic #1056 P3). One row
     // per merged session carrying its outstanding manual steps so they outlive the session. This
@@ -2168,6 +2175,7 @@ export class SessionStore implements CapStore, CreditStore {
       sessionId: r.sessionId,
       state: r.state,
       headSha: r.headSha ?? "",
+      base: r.base ?? "",
       verdict: r.verdict ?? null,
       headline: r.headline ?? "",
       body: r.body ?? "",
@@ -2195,7 +2203,7 @@ export class SessionStore implements CapStore, CreditStore {
   getRecap(sessionId: string): Recap | null {
     const r = this.db
       .query(
-        `SELECT sessionId, state, headSha, verdict, headline, body, openItems, changedFiles, blocks,
+        `SELECT sessionId, state, headSha, base, verdict, headline, body, openItems, changedFiles, blocks,
                 spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt
               FROM recaps WHERE sessionId = ?`,
       )
@@ -2205,10 +2213,11 @@ export class SessionStore implements CapStore, CreditStore {
 
   putRecap(recap: Recap): void {
     this.db.run(
-      `INSERT INTO recaps (sessionId, state, headSha, verdict, headline, body, openItems, changedFiles,
+      `INSERT INTO recaps (sessionId, state, headSha, base, verdict, headline, body, openItems, changedFiles,
          blocks, spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
        ON CONFLICT(sessionId) DO UPDATE SET state=excluded.state, headSha=excluded.headSha,
+         base=excluded.base,
          verdict=excluded.verdict, headline=excluded.headline, body=excluded.body,
          openItems=excluded.openItems, changedFiles=excluded.changedFiles,
          blocks=excluded.blocks,
@@ -2219,6 +2228,7 @@ export class SessionStore implements CapStore, CreditStore {
         recap.sessionId,
         recap.state,
         recap.headSha ?? "",
+        recap.base ?? "",
         recap.verdict ?? null,
         recap.headline ?? "",
         recap.body ?? "",
@@ -2239,7 +2249,7 @@ export class SessionStore implements CapStore, CreditStore {
   snapshotRecaps(): Record<string, Recap> {
     const rows = this.db
       .query(
-        `SELECT sessionId, state, headSha, verdict, headline, body, openItems, changedFiles, blocks,
+        `SELECT sessionId, state, headSha, base, verdict, headline, body, openItems, changedFiles, blocks,
                 spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt
               FROM recaps WHERE state != 'empty'`,
       )
@@ -2253,7 +2263,7 @@ export class SessionStore implements CapStore, CreditStore {
   generatingRecaps(): Recap[] {
     const rows = this.db
       .query(
-        `SELECT sessionId, state, headSha, verdict, headline, body, openItems, changedFiles, blocks,
+        `SELECT sessionId, state, headSha, base, verdict, headline, body, openItems, changedFiles, blocks,
                 pendingDiff, spawnSessionId, cwd, model, spawnedAt, generatedAt, updatedAt
               FROM recaps WHERE state = 'generating'`,
       )

--- a/src/types.ts
+++ b/src/types.ts
@@ -346,6 +346,7 @@ export interface Recap {
   sessionId: string;
   state: RecapState;
   headSha: string; // the git HEAD this recap summarizes; "" for empty/in-flight w/o head
+  base: string; // base branch this recap diffed against (the PR's real base when resolvable); "" for legacy rows. Half of the (headSha, base) dedup key.
   verdict: RecapVerdict | null;
   headline: string; // <=100 chars; "" until ready
   body: string; // markdown; "" until ready

--- a/test/diff-base.test.ts
+++ b/test/diff-base.test.ts
@@ -1,0 +1,68 @@
+import { test, expect } from "bun:test";
+import { resolveDiffBase } from "../src/diff-base";
+import type { GitForge, GitState, PrStatus } from "../src/forge/types";
+
+type Sess = Parameters<typeof resolveDiffBase>[0];
+const SESSION: Sess = { id: "s1", baseBranch: "dev", branch: "hotfix/x", repoPath: "/repo" };
+
+function cache(git: Partial<GitState> | undefined): { get: (id: string) => GitState | undefined } {
+  return {
+    get: () => (git ? ({ kind: "github", checks: "none", ...git } as GitState) : undefined),
+  };
+}
+
+function forgeWith(prStatus: () => Promise<PrStatus>): (dir: string) => GitForge {
+  return () => ({ prStatus }) as unknown as GitForge;
+}
+
+test("warm cache with baseRefName → authoritative PR base, no forge call", async () => {
+  let forgeCalled = false;
+  const forge = () => {
+    forgeCalled = true;
+    return null;
+  };
+  const r = await resolveDiffBase(SESSION, cache({ state: "open", baseRefName: "main" }), forge);
+  expect(r).toEqual({ base: "main", resolved: true });
+  expect(forgeCalled).toBe(false);
+});
+
+test("cached state=none → baseBranch, authoritative, no forge call", async () => {
+  let forgeCalled = false;
+  const forge = () => {
+    forgeCalled = true;
+    return null;
+  };
+  const r = await resolveDiffBase(SESSION, cache({ state: "none" }), forge);
+  expect(r).toEqual({ base: "dev", resolved: true });
+  expect(forgeCalled).toBe(false);
+});
+
+test("cold cache → on-demand prStatus baseRefName (authoritative)", async () => {
+  const forge = forgeWith(async () => ({
+    state: "open",
+    checks: "none",
+    baseRefName: "main",
+    deployConfigured: false,
+  }));
+  const r = await resolveDiffBase(SESSION, cache(undefined), forge);
+  expect(r).toEqual({ base: "main", resolved: true });
+});
+
+test("cold cache + on-demand reports no PR → baseBranch, authoritative", async () => {
+  const forge = forgeWith(async () => ({ state: "none", checks: "none", deployConfigured: false }));
+  const r = await resolveDiffBase(SESSION, cache(undefined), forge);
+  expect(r).toEqual({ base: "dev", resolved: true });
+});
+
+test("cold cache + on-demand throws → baseBranch fallback, NOT authoritative (no thrash)", async () => {
+  const forge = forgeWith(async () => {
+    throw new Error("gh exploded");
+  });
+  const r = await resolveDiffBase(SESSION, cache(undefined), forge);
+  expect(r).toEqual({ base: "dev", resolved: false });
+});
+
+test("no branch / no forge → baseBranch fallback, not authoritative", async () => {
+  const r = await resolveDiffBase({ ...SESSION, branch: null }, undefined, undefined);
+  expect(r).toEqual({ base: "dev", resolved: false });
+});

--- a/test/forge/github.test.ts
+++ b/test/forge/github.test.ts
@@ -235,6 +235,7 @@ test("GithubForge.prStatus: open PR with rollup → mapped PrStatus", async () =
       title: "feat",
       state: "OPEN",
       mergeable: "MERGEABLE",
+      baseRefName: "main",
       statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS" }],
     },
   ]);
@@ -251,6 +252,19 @@ test("GithubForge.prStatus: open PR with rollup → mapped PrStatus", async () =
   expect(calls[0]).toContain("--head");
   expect(calls[0]).toContain("feature");
   expect(calls[0]).toContain("o/r");
+});
+
+test("GithubForge.prStatus: surfaces baseRefName (the PR's real target branch)", async () => {
+  // A hotfix PR targeting a non-default branch — the case the diff/recap base resolution needs.
+  const prJson = JSON.stringify([
+    { number: 9, url: "u", title: "hotfix", state: "OPEN", baseRefName: "main" },
+  ]);
+  const { run, calls } = fakeRunner({ "pr list": prJson });
+  const forge = new GithubForge("o/r", {}, run);
+  const st = await forge.prStatus("hotfix/backport");
+  expect(st.baseRefName).toBe("main");
+  // baseRefName must be among the requested --json fields
+  expect(calls[0]?.join(" ")).toContain("baseRefName");
 });
 
 test("GithubForge.prStatus: maps isDraft from the json", async () => {

--- a/test/recap-core.test.ts
+++ b/test/recap-core.test.ts
@@ -257,6 +257,7 @@ const baseRecap = (over: Partial<Recap> = {}): Recap => ({
   sessionId: "s1",
   state: "ready",
   headSha: "sha-abc",
+  base: "main",
   verdict: "ready",
   headline: "done",
   body: "",
@@ -272,27 +273,59 @@ const baseRecap = (over: Partial<Recap> = {}): Recap => ({
 });
 
 test("needsRecap: null existing → true (no recap yet)", () => {
-  expect(needsRecap(null, "sha-abc")).toBe(true);
+  expect(needsRecap(null, "sha-abc", "main", true)).toBe(true);
 });
 
 test("needsRecap: same head (state=ready) → false", () => {
-  expect(needsRecap(baseRecap({ state: "ready", headSha: "sha-abc" }), "sha-abc")).toBe(false);
+  expect(
+    needsRecap(baseRecap({ state: "ready", headSha: "sha-abc" }), "sha-abc", "main", true),
+  ).toBe(false);
 });
 
 test("needsRecap: same head (state=generating) → false", () => {
-  expect(needsRecap(baseRecap({ state: "generating", headSha: "sha-abc" }), "sha-abc")).toBe(false);
+  expect(
+    needsRecap(baseRecap({ state: "generating", headSha: "sha-abc" }), "sha-abc", "main", true),
+  ).toBe(false);
 });
 
 test("needsRecap: same head (state=failed) → false (no auto-retry)", () => {
-  expect(needsRecap(baseRecap({ state: "failed", headSha: "sha-abc" }), "sha-abc")).toBe(false);
+  expect(
+    needsRecap(baseRecap({ state: "failed", headSha: "sha-abc" }), "sha-abc", "main", true),
+  ).toBe(false);
 });
 
 test("needsRecap: same head (state=empty) → false", () => {
-  expect(needsRecap(baseRecap({ state: "empty", headSha: "sha-abc" }), "sha-abc")).toBe(false);
+  expect(
+    needsRecap(baseRecap({ state: "empty", headSha: "sha-abc" }), "sha-abc", "main", true),
+  ).toBe(false);
 });
 
 test("needsRecap: different head → true", () => {
-  expect(needsRecap(baseRecap({ headSha: "sha-old" }), "sha-new")).toBe(true);
+  expect(needsRecap(baseRecap({ headSha: "sha-old" }), "sha-new", "main", true)).toBe(true);
+});
+
+test("needsRecap: same head, base changed + resolved → true (PR base became known)", () => {
+  expect(needsRecap(baseRecap({ headSha: "sha-abc", base: "dev" }), "sha-abc", "main", true)).toBe(
+    true,
+  );
+});
+
+test("needsRecap: same head, base changed but NOT resolved → false (no thrash on transient fallback)", () => {
+  expect(needsRecap(baseRecap({ headSha: "sha-abc", base: "main" }), "sha-abc", "dev", false)).toBe(
+    false,
+  );
+});
+
+test("needsRecap: same head, legacy base='' → false (no mass regeneration on deploy)", () => {
+  expect(needsRecap(baseRecap({ headSha: "sha-abc", base: "" }), "sha-abc", "main", true)).toBe(
+    false,
+  );
+});
+
+test("needsRecap: same head, same resolved base → false", () => {
+  expect(needsRecap(baseRecap({ headSha: "sha-abc", base: "main" }), "sha-abc", "main", true)).toBe(
+    false,
+  );
 });
 
 // ── buildTranscriptDigest ─────────────────────────────────────────────────────

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -89,6 +89,7 @@ function makeRecap(over: Partial<Recap> = {}): Recap {
     sessionId: "s1",
     state: "generating",
     headSha: "sha-a",
+    base: "",
     verdict: null,
     headline: "",
     body: "",
@@ -246,6 +247,8 @@ function buildSvc(opts: {
   cleanup?: (d: string) => void;
   makeTmpDir?: () => string;
   readUsage?: () => Promise<any>;
+  resolveBase?: (s: Session) => Promise<{ base: string; resolved: boolean }>;
+  computeDiff?: (worktreePath: string, base: string, branch: string | null) => Promise<any>;
 }): RecapService {
   let tmpIdx = 0;
   return new RecapService({
@@ -257,7 +260,8 @@ function buildSvc(opts: {
     idleThresholdMs: opts.idleThresholdMs ?? 120_000,
     timeoutMs: opts.timeoutMs ?? 300_000,
     headSha: async () => opts.headSha ?? "sha-head",
-    computeDiff: async () => (opts.diff ?? NON_EMPTY_DIFF) as any,
+    resolveBase: opts.resolveBase,
+    computeDiff: opts.computeDiff ?? (async () => (opts.diff ?? NON_EMPTY_DIFF) as any),
     readTranscript: (): ActivityEntry[] => [],
     readPlan: () => "",
     readVerdict: (): VerdictRead<unknown> =>
@@ -1426,4 +1430,104 @@ test("finalize: empty carrier fail-closed — diff dropped, file-tree filtered, 
   }
   // callout passes through
   expect(blocks.some((b) => b.type === "callout")).toBe(true);
+});
+
+// ── base resolution (PR base, not stored baseBranch) ───────────────────────────────
+
+test("generate: diffs against the resolved PR base and persists it (not session.baseBranch)", async () => {
+  const s = makeSession({ status: "done", baseBranch: "dev" }); // stored default, but PR targets main
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+  let diffedBase: string | undefined;
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    headSha: "sha-head",
+    makeTmpDir: () => "/tmp/recap-base-gen",
+    resolveBase: async () => ({ base: "main", resolved: true }),
+    computeDiff: async (_wt, base) => {
+      diffedBase = base;
+      return NON_EMPTY_DIFF;
+    },
+  });
+
+  const result = await svc.generate(s);
+  expect(result).toBe("started");
+  expect(diffedBase).toBe("main"); // diffed against the PR base, not "dev"
+  expect(store.getRecap("s1")?.base).toBe("main"); // persisted on the generating row
+});
+
+test("regenerate: resolves the PR base inside generate() despite bypassing dedup", async () => {
+  // regenerate() bypasses needsRecap and calls generate(session) with no knownBase — so generate
+  // MUST resolve the base itself, else a forced regenerate re-bakes the stale base.
+  const s = makeSession({ status: "done", baseBranch: "dev" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+  let diffedBase: string | undefined;
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    makeTmpDir: () => "/tmp/recap-base-regen",
+    resolveBase: async () => ({ base: "main", resolved: true }),
+    computeDiff: async (_wt, base) => {
+      diffedBase = base;
+      return NON_EMPTY_DIFF;
+    },
+  });
+
+  const result = await svc.regenerate(s);
+  expect(result).toBe("started");
+  expect(diffedBase).toBe("main");
+  expect(store.getRecap("s1")?.base).toBe("main");
+});
+
+test("considerForArchive: same head but PR base now resolvable → regenerates (not 'skip')", async () => {
+  // A recap baked against the old base "dev" at this HEAD; the PR's real base "main" is now known.
+  const s = makeSession({ status: "done", baseBranch: "dev" });
+  const stale = makeRecap({ state: "ready", headSha: "sha-head", base: "dev", verdict: "ready" });
+  const store = makeStore([s], [stale]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    headSha: "sha-head",
+    makeTmpDir: () => "/tmp/recap-base-rearchive",
+    resolveBase: async () => ({ base: "main", resolved: true }),
+  });
+
+  const result = await svc.considerForArchive(s);
+  expect(result).toBe("started"); // base changed + resolved → regenerate despite same HEAD
+  expect(store.getRecap("s1")?.base).toBe("main");
+});
+
+test("considerForArchive: same head, base change only via transient fallback → 'skip' (no thrash)", async () => {
+  const s = makeSession({ status: "done", baseBranch: "dev" });
+  const existing = makeRecap({
+    state: "ready",
+    headSha: "sha-head",
+    base: "main",
+    verdict: "ready",
+  });
+  const store = makeStore([s], [existing]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    headSha: "sha-head",
+    // on-demand resolution failed → non-authoritative fallback to baseBranch "dev"
+    resolveBase: async () => ({ base: "dev", resolved: false }),
+  });
+
+  const result = await svc.considerForArchive(s);
+  expect(result).toBe("skip"); // resolved:false must NOT flip the dedup key
+  expect(herdr.started.length).toBe(0);
+  expect(store.getRecap("s1")?.base).toBe("main"); // untouched
 });

--- a/test/server-diff.test.ts
+++ b/test/server-diff.test.ts
@@ -53,7 +53,7 @@ const SESSION: Session = {
   manualStepsAckedAt: null,
 };
 
-function makeDeps(session: Session | null): AppDeps {
+function makeDeps(session: Session | null, prCache?: AppDeps["prCache"]): AppDeps {
   const store: Partial<SessionStore> = {
     get: (id) => (session && id === session.id ? session : null),
   };
@@ -62,6 +62,7 @@ function makeDeps(session: Session | null): AppDeps {
     service: {} as SessionService,
     events: { emit: () => {} } as unknown as EventHub,
     usageLimits: { limits: () => ({}) } as never,
+    prCache,
   };
 }
 
@@ -73,6 +74,24 @@ test("GET /api/sessions/:id/diff → empty result for a non-isolated session", a
   expect(body.head).toBeNull();
   expect(body.files).toEqual([]);
   expect(body.base).toBe("main");
+});
+
+test("GET /api/sessions/:id/diff → prefers the PR's cached base over session.baseBranch", async () => {
+  // Session stored baseBranch="main" but its PR actually targets "release-1.2" (the TASK-852 shape:
+  // base diverges from the stored default). The diff must reflect the PR's base. Using a null-branch
+  // session keeps computeDiff side-effect-free while still threading the resolved base into the result.
+  const prCache = {
+    snapshot: () => ({}),
+    get: () =>
+      ({ kind: "github", state: "open", checks: "none", baseRefName: "release-1.2" }) as never,
+    set: () => {},
+    drop: () => {},
+  };
+  const app = makeApp(makeDeps(SESSION, prCache));
+  const res = await app.fetch(new Request("http://localhost/api/sessions/s1/diff"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.base).toBe("release-1.2"); // PR base, NOT the stored "main"
 });
 
 test("GET /api/sessions/:id/diff → 404 when session unknown", async () => {

--- a/test/server-recap.test.ts
+++ b/test/server-recap.test.ts
@@ -39,6 +39,7 @@ test("GET /api/recaps returns snapshot when recapCache is present", async () => 
     sessionId: "sess-1",
     state: "ready",
     headSha: "abc123",
+    base: "main",
     verdict: "ready",
     headline: "Did the thing",
     body: "",

--- a/test/store-recaps.test.ts
+++ b/test/store-recaps.test.ts
@@ -7,6 +7,7 @@ const r = (over: Partial<Recap> = {}): Recap => ({
   sessionId: "s1",
   state: "generating",
   headSha: "sha-abc",
+  base: "",
   verdict: null,
   headline: "",
   body: "",
@@ -24,12 +25,13 @@ const r = (over: Partial<Recap> = {}): Recap => ({
 test("recaps: put→get round-trip (incl. openItems JSON)", () => {
   const s = new SessionStore(":memory:");
   expect(s.getRecap("s1")).toBeNull();
-  s.putRecap(r({ openItems: ["fix tests", "update docs"] }));
+  s.putRecap(r({ openItems: ["fix tests", "update docs"], base: "main" }));
   const got = s.getRecap("s1");
   expect(got).not.toBeNull();
   expect(got?.sessionId).toBe("s1");
   expect(got?.state).toBe("generating");
   expect(got?.headSha).toBe("sha-abc");
+  expect(got?.base).toBe("main");
   expect(got?.openItems).toEqual(["fix tests", "update docs"]);
   expect(got?.verdict).toBeNull();
   expect(got?.model).toBe("claude-sonnet-4-5");

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -466,6 +466,7 @@ const recap = (sessionId: string, over: Partial<Recap> = {}): Recap => ({
   sessionId,
   state: "ready",
   headSha: "sha",
+  base: "",
   verdict: "ready",
   headline: "done",
   body: "",


### PR DESCRIPTION
## Problem

TASK-852 (in the `flowagent` repo) was explicitly based off a non-default branch — a hotfix targeting `main` while the repo default is `dev`. Shepherd's **diff tab listed far more files than the PR touched**, because the diff was computed against the session's stored `baseBranch` (`dev`), folding the entire `dev`↔`main` divergence on top of the task's own changes.

Root cause: both the diff endpoint (`sessionDiffRead`) and the recap diff (`recap.ts`) compared against `session.baseBranch`, which is set once at session creation and never reconciled to the PR's actual base. GitHub's "Files changed" uses three-dot/merge-base semantics against the PR's real base, so diffing against `dev` could never match.

## Fix (diff surfaces only)

Resolve the PR's **actual** base (`baseRefName`) and diff against that, with `session.baseBranch` as an always-safe fallback.

- **`baseRefName` on `PrStatus`/`GitState`** — populated by the GitHub forge as one extra `gh pr list --json` field (no extra call; confirmed returned for merged/closed PRs too). Added to `gitStateChanged` so a PR retarget refreshes the cache.
- **Shared `resolveDiffBase` helper** (`src/diff-base.ts`) returning `{ base, resolved }`: warm `prCache` → on-demand `prStatus` (cold/evicted cache) → `baseBranch`. The gh runner is async, so on-demand never blocks the event loop. `resolved` marks an authoritative resolution (a PR base or a definitive "no PR").
- **Live diff tab** (`sessionDiffRead`) now diffs against the resolved base.
- **Recap diff**: base is resolved **inside `generate()`** (covers operator-forced `regenerate()`, which bypasses dedup) and persisted on the recap row (empty + generating). Recap dedup becomes **`(headSha, base)`-keyed** so a recap baked before the PR base was known regenerates — guarded against legacy mass-regeneration (`base=""`) and transient-fallback thrash (only an authoritatively-resolved base re-fires).

## Scope notes (deliberate)

- **Diff-only**, per operator decision: `session.baseBranch` is **not** reconciled, and `hasCommittedChanges` / drain / merge / epic-base consumers are unchanged. The diff-only option explicitly accepted that `hasCommittedChanges` stays on `baseBranch` (behaviorally inert for a real hotfix).
- **TASK-852 itself is already archived** (worktree removed), so its recap is permanent and cannot be retroactively corrected; the fix prevents recurrence for future/active sessions and is proven by the deterministic tests.

## Tests

- Forge: `prStatus` surfaces `baseRefName`.
- `resolveDiffBase` unit: warm cache / definitive-no-PR / on-demand / transient-failure (`resolved:false`) / no-forge.
- Diff endpoint: prefers the cached PR base over the stored `baseBranch`.
- Recap: `generate()`/`regenerate()` diff + persist the resolved base; `considerForArchive` regenerates when the base becomes resolvable at the same HEAD, and **skips** on a transient (`resolved:false`) fallback (no thrash); legacy `base=""` never mass-regenerates.
- Store: `base` column round-trips + additive migration.

Full root suite green (4843 pass), `tsc` + `lint` clean. Server-only change — no UI strings/catalog/glossary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)