### PR TITLE
feat(auth): single-operator password → session-cookie auth; close the WS/PTY gap

### DIFF
--- a/docs-site/src/content/docs/getting-started.md
+++ b/docs-site/src/content/docs/getting-started.md
@@ -67,6 +67,12 @@ tailscale serve --bg 7330
 # (in ~/.shepherd/env or deploy/shepherd.service)
 ```
 
+The HUD is gated by a **single-operator password**: the first time you open it
+you'll get a login screen. Set the password with `SHEPHERD_PASSWORD` (in
+`~/.shepherd/env`), or use the strong one Shepherd generates and prints to the
+log **once** on first boot (`systemctl --user status shepherd` / `journalctl
+--user -u shepherd`). Log out from **Settings → Session**.
+
 **Settings → DIAGNOSE** surfaces any remaining gaps with one-click fixes.
 
 ## From-clone / development path

--- a/docs-site/src/content/docs/operating.md
+++ b/docs-site/src/content/docs/operating.md
@@ -27,10 +27,16 @@ tailscale serve --bg 7330    # → https://<host>.<tailnet>.ts.net proxies to 12
 ```
 
 Add the public hostname to `SHEPHERD_ALLOWED_HOSTS` (the unit ships with the
-Tailscale name). Access control is **tailnet membership** — there is no app-level
-password.
+Tailscale name). Access control is layered: the network reach is gated by
+**tailnet membership**, and the app itself is gated by a **single-operator
+password**. The password is exchanged for an HMAC-signed session cookie that
+covers every HTTP route plus the live `/events` and `/pty` WebSocket channels.
+Set it with `SHEPHERD_PASSWORD`; if you leave it unset, Shepherd generates a
+strong one on first boot and prints it to the log **once** (`systemctl --user
+status shepherd` / `journalctl --user -u shepherd`) — change it by setting
+`SHEPHERD_PASSWORD` in `~/.shepherd/env` and restarting.
 
-Per-deployment overrides (token, repo root, alternate hosts) go in
+Per-deployment overrides (password, token, repo root, alternate hosts) go in
 `~/.shepherd/env` (`KEY=value` lines), read by the unit if present. See
 [Configuration](/reference/configuration/) for the full list.
 

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -16,7 +16,9 @@ lines), read by the systemd unit if present.
 | `SHEPHERD_DB` | `~/.shepherd/shepherd.db` | SQLite session store path |
 | `SHEPHERD_REPO_ROOT` | `~` (home) | Repos must live under this root (spawn is confined to it) |
 | `SHEPHERD_ALLOWED_HOSTS` | `localhost,127.0.0.1,::1,[::1]` | Comma-separated origin hostnames allowed for writes + WS (CSRF/CSWSH guard) |
-| `SHEPHERD_TOKEN` | _(none)_ | When set, require `Authorization: Bearer <token>` |
+| `SHEPHERD_PASSWORD` | _(auto-generated)_ | Single-operator login password. When set it's authoritative — argon2id-hashed and re-seeded into the persisted hash every boot. Unset → the persisted hash is reused, or (first boot) a strong password is generated, hashed, persisted, and printed to the log **once**. The browser exchanges it for an HMAC-signed session cookie that gates every HTTP route plus the `/events` + `/pty` WebSocket channels |
+| `SHEPHERD_COOKIE_SECRET` | _(generated + persisted)_ | HMAC secret that signs the session cookie. Set it to pin a stable secret across DB resets; rotating it invalidates every outstanding session (the all-sessions kill-switch) |
+| `SHEPHERD_TOKEN` | _(none)_ | Optional operator bearer for CLI/curl/machine clients: when set, `Authorization: Bearer <token>` is accepted as an alternative to the session cookie. Browser operators use the password login instead; spawned agents don't use this (they reach the server over the loopback ingress) |
 | `HERDR_BIN` | `herdr` | Path to the herdr binary |
 | `HERDR_SESSION` | `default` | herdr session name |
 | `SHEPHERD_FORGES` | `~/.shepherd/forges.json` | Path to the git-host config |

--- a/docs/external-task-api.md
+++ b/docs/external-task-api.md
@@ -3,14 +3,15 @@
 Shepherd's HTTP API is the same surface the UI uses — there is **no separate
 "public" API and no CORS barrier** for non-browser clients. Any agent that can
 reach the core process (Hermes, a cron job, another service) can queue work by
-calling one endpoint.
+calling one endpoint — once it authenticates (the server is gated by default;
+see [What actually gates access](#what-actually-gates-access)).
 
 ## TL;DR
 
 ```bash
 curl -X POST http://localhost:7330/api/sessions \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $SHEPHERD_TOKEN" \   # omit if SHEPHERD_TOKEN is unset
+  -H "Authorization: Bearer $SHEPHERD_TOKEN" \   # required — the server is gated by default
   -d '{
         "repoPath": "~/Work/my-repo",
         "baseBranch": "main",
@@ -49,18 +50,20 @@ its hostname to `SHEPHERD_ALLOWED_HOSTS`.
 
 ## What actually gates access
 
-| Gate                 | Default                           | What Hermes must do                                                                               |
-| -------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------- |
-| **Network bind**     | `127.0.0.1:7330` (loopback only)  | Run on the same host, reach it over Tailscale serve, or set `SHEPHERD_HOST` to expose another NIC |
-| **Auth token**       | `SHEPHERD_TOKEN` unset → open     | If set, send `Authorization: Bearer <token>` on every request (timing-safe compare)               |
-| **Repo confinement** | `SHEPHERD_REPO_ROOT` = `~` (home) | `repoPath` must resolve **inside** the root, or the request is rejected `400`                     |
+| Gate                 | Default                                               | What Hermes must do                                                                                                                                                                                                |
+| -------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Network bind**     | `127.0.0.1:7330` (loopback only)                      | Run on the same host, reach it over Tailscale serve, or set `SHEPHERD_HOST` to expose another NIC                                                                                                                  |
+| **Auth**             | Gated by default (operator password → session cookie) | Machine clients can't use the browser login — set `SHEPHERD_TOKEN=<random>` and send `Authorization: Bearer <token>` on every request (timing-safe compare). Without a valid cookie or bearer the request is `401` |
+| **Repo confinement** | `SHEPHERD_REPO_ROOT` = `~` (home)                     | `repoPath` must resolve **inside** the root, or the request is rejected `400`                                                                                                                                      |
 
 ### Recommended setup for a remote agent
 
 1. Expose the core to the agent's network — prefer **Tailscale serve** over
    `SHEPHERD_HOST=0.0.0.0`. Add the ts.net hostname to `SHEPHERD_ALLOWED_HOSTS`
    only if the agent is browser-based (sends `Origin`).
-2. Set a shared secret: `SHEPHERD_TOKEN=<random>` and give it to Hermes.
+2. Set a shared secret: `SHEPHERD_TOKEN=<random>` and give it to Hermes. The
+   server is **gated by default**, and machine clients can't use the browser
+   password login — the bearer token is how they authenticate.
 3. Keep `SHEPHERD_REPO_ROOT` tight so Hermes can only target intended repos.
 
 ## Request schema
@@ -79,14 +82,14 @@ its hostname to `SHEPHERD_ALLOWED_HOSTS`.
 
 ### Responses
 
-| Status | Meaning                                                                                                               |
-| ------ | --------------------------------------------------------------------------------------------------------------------- |
-| `200`  | **Held** by the usage-aware hold gate — body `{ held: true, id, count }`; the task is queued, not spawned (see below) |
-| `201`  | Created — body is the full `Session` (`id`, `desig`, `status`, `worktreePath`, …)                                     |
-| `400`  | Validation failed — body `{ error }`                                                                                  |
-| `401`  | `SHEPHERD_TOKEN` set and bearer missing/wrong                                                                         |
-| `403`  | Origin header present and not in `SHEPHERD_ALLOWED_HOSTS`                                                             |
-| `415`  | Missing/incorrect `Content-Type`                                                                                      |
+| Status | Meaning                                                                                                                                                |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `200`  | **Held** by the usage-aware hold gate — body `{ held: true, id, count }`; the task is queued, not spawned (see below)                                  |
+| `201`  | Created — body is the full `Session` (`id`, `desig`, `status`, `worktreePath`, …)                                                                      |
+| `400`  | Validation failed — body `{ error }`                                                                                                                   |
+| `401`  | No valid session cookie **and** no valid bearer token (the server is gated by default — machine clients must set `SHEPHERD_TOKEN` and send the bearer) |
+| `403`  | Origin header present and not in `SHEPHERD_ALLOWED_HOSTS`                                                                                              |
+| `415`  | Missing/incorrect `Content-Type`                                                                                                                       |
 
 ## Usage-aware hold gate
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -326,7 +326,15 @@ export const config = {
   allowedOriginHosts: (process.env.SHEPHERD_ALLOWED_HOSTS ?? "localhost,127.0.0.1,::1,[::1]").split(
     ",",
   ),
-  token: process.env.SHEPHERD_TOKEN ?? null, // when set, require Authorization: Bearer <token>
+  token: process.env.SHEPHERD_TOKEN ?? null, // optional operator bearer (CLI/curl); agents use the loopback ingress, not this
+  // Single-operator auth (issue #1079). `password` (env) is authoritative when set: it re-seeds
+  // the persisted argon2id `passwordHash` every boot. Unset ⇒ the persisted hash is used as-is
+  // (an auto-generated one survives restarts). `cookieSecret` (env) pins the HMAC session-cookie
+  // signing secret across DB resets; unset ⇒ generated + persisted once. Both `passwordHash` and
+  // `cookieSecret` are resolved to non-null at boot by bootstrapAuth (see src/index.ts).
+  password: process.env.SHEPHERD_PASSWORD ?? null,
+  passwordHash: null as string | null,
+  cookieSecret: process.env.SHEPHERD_COOKIE_SECRET ?? null,
   // Web Push (VAPID). Generated once and persisted in the settings table if these
   // are unset; provide them via env to pin a stable key pair across DB resets.
   vapidPublic: process.env.SHEPHERD_VAPID_PUBLIC ?? null,

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import { singleFlight } from "./single-flight";
 import { HerdrUsageProbe } from "./usage-probe";
 import { sweepStaging, STAGING_TTL_MS } from "./uploads";
 import { validateRoot } from "./dirs";
+import { bootstrapAuth } from "./operator-auth";
 import { UpdateService } from "./update";
 import { HerdrUpdateService } from "./herdr-update";
 import { DiagnosticsService } from "./diagnostics";
@@ -212,6 +213,24 @@ const savedUhp = store.getSetting("usageHoldPct");
 if (savedUhp !== null) {
   const n = Number(savedUhp);
   if (Number.isFinite(n)) config.usageHoldPct = Math.min(100, Math.max(0, Math.floor(n)));
+}
+
+// ── single-operator auth (issue #1079): fail-closed bootstrap ───────────────
+// Resolve the argon2id password hash + HMAC cookie-signing secret before serving, so the gate
+// (checkAuth) is never silently open. SHEPHERD_PASSWORD wins (re-seeds the hash each boot); else
+// the persisted hash is reused; else a strong password is generated, hashed, persisted, and
+// printed ONCE with a CHANGE-THIS banner. No agent token is provisioned — spawned agents reach
+// the server through the loopback ingress listener (serveAgentIngress), which is exempt from this
+// gate; config.token stays an optional operator CLI/curl bearer.
+{
+  const auth = await bootstrapAuth({
+    store,
+    envPassword: config.password,
+    envCookieSecret: config.cookieSecret,
+    log: (m) => console.log(m),
+  });
+  config.passwordHash = auth.passwordHash;
+  config.cookieSecret = auth.cookieSecret;
 }
 
 // ── preview port range startup validation (hard-fail) ──────────────────────

--- a/src/operator-auth.ts
+++ b/src/operator-auth.ts
@@ -1,0 +1,226 @@
+/**
+ * Single-operator authentication primitives (issue #1079). Hand-rolled on Bun built-ins —
+ * no new deps. One shared credential: a password verified against an argon2id hash at rest,
+ * exchanged for a stateless HMAC-signed session cookie. The identity check lives behind one
+ * seam (checkAuth in server.ts) so multi-user/SSO could be added later without a rewrite —
+ * but none of that machinery exists here.
+ *
+ * Stateless by design: the cookie is a bare capability with an expiry (no identity encoded —
+ * there is only one operator), signed with a server-side secret. Verifying it is a single
+ * HMAC (no DB read on the hot path — the server is one Bun loop pumping the web terminal).
+ * Logout clears the cookie client-side only; there is no server-side revocation list. Rotating
+ * the signing secret invalidates every outstanding cookie (the all-sessions kill-switch).
+ */
+import { createHmac, timingSafeEqual, randomBytes } from "node:crypto";
+
+/** Session cookie name. Same-origin; browsers attach it to fetch + WS upgrades automatically. */
+export const SESSION_COOKIE = "shepherd_session";
+
+/** 7-day sliding window. Idle ⇒ expires; active ⇒ re-stamped past half-life ⇒ effectively never re-login. */
+export const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+// ── password (argon2id via Bun.password) ─────────────────────────────────────
+
+/** Hash a plaintext password with argon2id (Bun.password defaults). ~100ms — that cost IS the
+ *  brute-force control (no lockout counters, per the settled single-operator threat model). */
+export function hashPassword(password: string): Promise<string> {
+  return Bun.password.hash(password, { algorithm: "argon2id" });
+}
+
+/** Verify a plaintext against a stored argon2id hash. Returns false (never throws) on a malformed
+ *  hash so a corrupt settings row can't crash the login path. */
+export async function verifyPassword(password: string, hash: string): Promise<boolean> {
+  try {
+    return await Bun.password.verify(password, hash);
+  } catch {
+    return false;
+  }
+}
+
+/** Generate a strong random password for the fail-closed auto-provision path (printed once to the
+ *  log). base64url of 18 bytes ⇒ 24 url-safe chars, ~144 bits. */
+export function generatePassword(): string {
+  return randomBytes(18).toString("base64url");
+}
+
+/** Generate a cookie signing secret (hex, 32 bytes / 256 bits). Persisted once in settings. */
+export function generateSecret(): string {
+  return randomBytes(32).toString("hex");
+}
+
+// ── session cookie (HMAC-signed, stateless) ──────────────────────────────────
+
+type Payload = { iat: number; exp: number };
+
+const b64url = (s: string) => Buffer.from(s, "utf8").toString("base64url");
+const unb64url = (s: string) => Buffer.from(s, "base64url").toString("utf8");
+
+function hmac(secret: string, data: string): string {
+  return createHmac("sha256", secret).update(data).digest("base64url");
+}
+
+/**
+ * Mint a signed session cookie value: `base64url(payload).hmac`. The payload carries only an
+ * issued-at + expiry (no identity — single operator). `now` is injectable for tests.
+ */
+export function signCookie(secret: string, ttlMs = SESSION_TTL_MS, now = Date.now()): string {
+  const payload: Payload = { iat: now, exp: now + ttlMs };
+  const body = b64url(JSON.stringify(payload));
+  return `${body}.${hmac(secret, body)}`;
+}
+
+/**
+ * Verify a session cookie value. Returns `{ ok: true, iat, exp }` only when the signature is
+ * valid (timing-safe compare) AND the cookie is unexpired. Any tampering (flipped byte, wrong
+ * secret), malformed shape, or expiry ⇒ `{ ok: false }`.
+ */
+export function verifyCookie(
+  secret: string,
+  value: string | null | undefined,
+  now = Date.now(),
+): { ok: true; iat: number; exp: number } | { ok: false } {
+  if (!value) return { ok: false };
+  const dot = value.indexOf(".");
+  if (dot <= 0) return { ok: false };
+  const body = value.slice(0, dot);
+  const sig = value.slice(dot + 1);
+  const expected = hmac(secret, body);
+  // Length-guard before timingSafeEqual (it throws on unequal-length buffers).
+  if (sig.length !== expected.length) return { ok: false };
+  if (!timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) return { ok: false };
+  let payload: Payload;
+  try {
+    payload = JSON.parse(unb64url(body));
+  } catch {
+    return { ok: false };
+  }
+  if (typeof payload.exp !== "number" || typeof payload.iat !== "number") return { ok: false };
+  if (payload.exp <= now) return { ok: false };
+  return { ok: true, iat: payload.iat, exp: payload.exp };
+}
+
+/** True when a valid cookie is past its half-life and should be re-stamped with a fresh expiry. */
+export function shouldRestamp(iat: number, ttlMs = SESSION_TTL_MS, now = Date.now()): boolean {
+  return now - iat >= ttlMs / 2;
+}
+
+// ── cookie header (serialize / parse) ────────────────────────────────────────
+
+/**
+ * Serialize a `Set-Cookie` header for the session. `HttpOnly` + `SameSite=Strict` ALWAYS;
+ * `Secure` only when the request arrived over HTTPS (so `http://127.0.0.1:7330` stays usable for
+ * local debugging). `Path=/` so it rides every route incl. the WS upgrades.
+ */
+export function serializeCookie(value: string, opts: { secure: boolean; ttlMs?: number }): string {
+  const maxAge = Math.floor((opts.ttlMs ?? SESSION_TTL_MS) / 1000);
+  const attrs = [
+    `${SESSION_COOKIE}=${value}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Strict",
+    `Max-Age=${maxAge}`,
+  ];
+  if (opts.secure) attrs.push("Secure");
+  return attrs.join("; ");
+}
+
+/** Serialize the logout `Set-Cookie` — same attributes, empty value, `Max-Age=0` to expire it. */
+export function clearCookie(opts: { secure: boolean }): string {
+  const attrs = [`${SESSION_COOKIE}=`, "Path=/", "HttpOnly", "SameSite=Strict", "Max-Age=0"];
+  if (opts.secure) attrs.push("Secure");
+  return attrs.join("; ");
+}
+
+/** Pull one cookie value out of a `Cookie:` request header. Null when absent. */
+export function parseCookie(
+  header: string | null | undefined,
+  name = SESSION_COOKIE,
+): string | null {
+  if (!header) return null;
+  for (const part of header.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq < 0) continue;
+    if (part.slice(0, eq).trim() === name) return part.slice(eq + 1).trim();
+  }
+  return null;
+}
+
+/**
+ * Decide whether the response cookie should carry `Secure`, from the request. True when the HUD
+ * was reached over HTTPS — either a terminating proxy set `X-Forwarded-Proto: https` (Tailscale
+ * serve) or the request URL is itself `https:`. Plain loopback HTTP ⇒ false.
+ */
+export function isSecureRequest(req: Request): boolean {
+  const xfp = req.headers.get("x-forwarded-proto");
+  if (xfp) return xfp.split(",")[0]!.trim().toLowerCase() === "https";
+  try {
+    return new URL(req.url).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+// ── boot bootstrap (fail-closed) ─────────────────────────────────────────────
+
+/** Minimal settings-store surface bootstrapAuth needs (the real SessionStore satisfies it). */
+export interface AuthSettingsStore {
+  getSetting(key: string): string | null;
+  setSetting(key: string, value: string): void;
+}
+
+const PASSWORD_HASH_KEY = "passwordHash";
+const COOKIE_SECRET_KEY = "cookieSecret";
+
+/**
+ * Resolve the operator-auth secrets at boot — fail-closed, so the app is never silently open.
+ *
+ * - Cookie signing secret: env override ?? persisted ?? generate+persist (always non-null after).
+ * - Password hash:
+ *   - `envPassword` set ⇒ authoritative: hash it and re-seed the persisted hash every boot.
+ *   - else persisted hash ⇒ use as-is (an auto-generated one survives restarts).
+ *   - else ⇒ generate a strong password, hash+persist it, and emit it ONCE via `log` with a loud
+ *     CHANGE-THIS banner. Returned in `generatedPassword` for callers/tests.
+ *
+ * Pure w.r.t. the injected store + log, so the fail-closed paths are unit-testable.
+ */
+export async function bootstrapAuth(opts: {
+  store: AuthSettingsStore;
+  envPassword: string | null;
+  envCookieSecret: string | null;
+  log?: (msg: string) => void;
+}): Promise<{ passwordHash: string; cookieSecret: string; generatedPassword: string | null }> {
+  const { store, envPassword, envCookieSecret } = opts;
+  const log = opts.log ?? (() => {});
+
+  let cookieSecret = envCookieSecret ?? store.getSetting(COOKIE_SECRET_KEY);
+  if (!cookieSecret) {
+    cookieSecret = generateSecret();
+    store.setSetting(COOKIE_SECRET_KEY, cookieSecret);
+  }
+
+  let generatedPassword: string | null = null;
+  let passwordHash: string;
+  if (envPassword) {
+    passwordHash = await hashPassword(envPassword);
+    store.setSetting(PASSWORD_HASH_KEY, passwordHash); // SHEPHERD_PASSWORD wins — re-seed each boot
+  } else {
+    const persisted = store.getSetting(PASSWORD_HASH_KEY);
+    if (persisted) {
+      passwordHash = persisted;
+    } else {
+      generatedPassword = generatePassword();
+      passwordHash = await hashPassword(generatedPassword);
+      store.setSetting(PASSWORD_HASH_KEY, passwordHash);
+      log(
+        "\n" +
+          "  ┌──────────────────────────────────────────────────────────────────────┐\n" +
+          "  │  SHEPHERD: no password configured — generated a random one (below).    │\n" +
+          "  │  CHANGE THIS: set SHEPHERD_PASSWORD in ~/.shepherd/env and restart.     │\n" +
+          "  └──────────────────────────────────────────────────────────────────────┘\n" +
+          `  Operator password (shown ONCE): ${generatedPassword}\n`,
+      );
+    }
+  }
+
+  return { passwordHash, cookieSecret, generatedPassword };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,6 +34,16 @@ import {
   validateEpicRunPatch,
   validateEgressExtraHosts,
 } from "./validate";
+import {
+  parseCookie,
+  verifyCookie,
+  signCookie,
+  serializeCookie,
+  clearCookie,
+  shouldRestamp,
+  isSecureRequest,
+  verifyPassword,
+} from "./operator-auth";
 import { resolvePlanAnswers, planAnswerSteerText, type RawAnswer } from "./plan-gate";
 import { slugifyManual } from "./namer";
 import { planHouseRulesInjection, prioritize } from "./house-rules";
@@ -368,11 +378,72 @@ const sessionUsage = (s: Session) =>
 const json = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
 
-function checkAuth(req: Request): Response | null {
-  if (!isAuthorized(req.headers.get("Authorization"), config.token)) {
-    return json({ error: "unauthorized" }, 401);
+/**
+ * Requests that pass the gate UN-credentialed (issue #1079). Scoped deliberately tight:
+ *  - `POST /api/login` — the only unauthenticated mutation (it's how you GET a cookie);
+ *  - static-shell GET/HEAD — the SPA bundle must load so the login view can render. This is
+ *    NOT a blanket "any non-/api GET": `/events` and `/pty/:id` are GET WebSocket upgrades that
+ *    MUST stay gated (they're the live-PTY hole this feature closes), so they're excluded here.
+ */
+function isPublicRequest(req: Request): boolean {
+  const path = new URL(req.url).pathname;
+  if (req.method === "POST" && path === "/api/login") return true;
+  if (req.method === "GET" || req.method === "HEAD") {
+    if (path.startsWith("/api")) return false;
+    if (path === "/events" || path.startsWith("/pty/")) return false;
+    return true; // static SPA shell
   }
-  return null;
+  return false;
+}
+
+/**
+ * The single auth seam (issue #1079). Pass when the request is public (above), carries a valid
+ * signed session cookie (humans), or carries a valid operator bearer token (CLI/curl — when the
+ * operator set `config.token`). Spawned agents do NOT pass here — they reach the server via the
+ * loopback ingress listener, which builds its app with `skipAuth` (see makeAgentIngressApp).
+ * Called by BOTH makeApp.fetch and serve().fetch, so HTTP routes and the WS upgrades inherit the
+ * gate from this one function.
+ *
+ * Fail-closed in production: the boot bootstrap (bootstrapAuth, src/index.ts) ALWAYS provisions a
+ * cookie-signing secret + password hash before the server serves, so a deployed instance is always
+ * gated. When NO auth is configured at all (no cookie secret AND no token — only ever the case in
+ * an un-bootstrapped unit-test app) the gate is open, mirroring the prior `config.token === null`
+ * contract the test suite relies on.
+ */
+function checkAuth(req: Request): Response | null {
+  if (config.cookieSecret === null && config.token === null) return null; // un-bootstrapped (tests)
+  if (isPublicRequest(req)) return null;
+  if (
+    config.cookieSecret &&
+    verifyCookie(config.cookieSecret, parseCookie(req.headers.get("cookie"))).ok
+  ) {
+    return null;
+  }
+  if (config.token !== null && isAuthorized(req.headers.get("Authorization"), config.token)) {
+    return null;
+  }
+  return json({ error: "unauthorized" }, 401);
+}
+
+/**
+ * Sliding-window re-stamp (issue #1079). When a cookie-authed request is past its half-life and
+ * the response is a success, attach a fresh `Set-Cookie` so an active operator effectively never
+ * re-logs-in. Attached at exactly ONE seam — the makeApp wrapper — so it can't double-apply; WS
+ * upgrades return before this seam, so they never carry a cookie. Re-verifying here is a cheap
+ * HMAC. Token-authed (no cookie) requests and failures are left untouched.
+ */
+function maybeRestamp(req: Request, res: Response): Response {
+  if (res.status >= 400) return res;
+  const secret = config.cookieSecret;
+  if (!secret) return res;
+  const v = verifyCookie(secret, parseCookie(req.headers.get("cookie")));
+  if (!v.ok || !shouldRestamp(v.iat)) return res;
+  const headers = new Headers(res.headers);
+  headers.append(
+    "Set-Cookie",
+    serializeCookie(signCookie(secret), { secure: isSecureRequest(req) }),
+  );
+  return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
 }
 
 function checkOrigin(req: Request): Response | null {
@@ -403,6 +474,50 @@ function requireJsonContentType(req: Request): Response | null {
 // can claim them.
 
 type Ctx = { req: Request; parts: string[]; url: URL; deps: AppDeps };
+
+// ── single-operator auth routes (issue #1079) ──────────────────────────────
+// login is the only unauthenticated mutation (isPublicRequest); logout + me sit behind the gate.
+
+async function handleLogin({ req, parts }: Ctx): Promise<Response | null> {
+  if (req.method !== "POST" || parts[0] !== "api" || parts[1] !== "login" || parts[2]) return null;
+  const ctErr = requireJsonContentType(req);
+  if (ctErr) return ctErr;
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "invalid json" }, 400);
+  }
+  const password =
+    typeof body === "object" &&
+    body !== null &&
+    typeof (body as { password?: unknown }).password === "string"
+      ? (body as { password: string }).password
+      : "";
+  const hash = config.passwordHash;
+  if (!hash || !config.cookieSecret || !(await verifyPassword(password, hash))) {
+    return json({ error: "invalid password" }, 401);
+  }
+  const headers = new Headers({ "content-type": "application/json" });
+  headers.append(
+    "Set-Cookie",
+    serializeCookie(signCookie(config.cookieSecret), { secure: isSecureRequest(req) }),
+  );
+  return new Response(JSON.stringify({ ok: true }), { status: 200, headers });
+}
+
+function handleLogout({ req, parts }: Ctx): Response | null {
+  if (req.method !== "POST" || parts[0] !== "api" || parts[1] !== "logout" || parts[2]) return null;
+  const headers = new Headers({ "content-type": "application/json" });
+  headers.append("Set-Cookie", clearCookie({ secure: isSecureRequest(req) }));
+  return new Response(JSON.stringify({ ok: true }), { status: 200, headers });
+}
+
+function handleMe({ req, parts }: Ctx): Response | null {
+  if (req.method !== "GET" || parts[0] !== "api" || parts[1] !== "me" || parts[2]) return null;
+  // Only reachable when checkAuth already passed — an unauthed /api/me 401s at the gate.
+  return json({ authenticated: true });
+}
 
 function handleGitSnapshot({ req, parts, deps }: Ctx): Response | null {
   if (req.method === "GET" && parts[0] === "api" && parts[1] === "git" && !parts[2]) {
@@ -4809,6 +4924,9 @@ async function handleEpicsCompletedLand({ req, parts, deps }: Ctx): Promise<Resp
 
 // Ordered dispatch chain — preserves the original guard sequence verbatim.
 const ROUTE_HANDLERS = [
+  handleLogin,
+  handleLogout,
+  handleMe,
   handlePing,
   handleGitSnapshot,
   handleActivitySnapshot,
@@ -4888,12 +5006,20 @@ const ROUTE_HANDLERS = [
   handleCommands,
 ] as const;
 
-/** Returns an object with a `fetch(Request)` method — unit-testable without a port. */
-export function makeApp(deps: AppDeps) {
+/**
+ * Returns an object with a `fetch(Request)` method — unit-testable without a port.
+ *
+ * `skipAuth` bypasses the human cookie/token gate (issue #1079) — used ONLY by the loopback
+ * agent-ingress listener (makeAgentIngressApp), whose loopback bind + route allowlist + per-session
+ * UUID IS the agent's auth. The `Origin` (CSRF) check still applies. The main server never sets it.
+ */
+export function makeApp(deps: AppDeps, opts: { skipAuth?: boolean } = {}) {
   const app = {
     async fetch(req: Request): Promise<Response> {
-      const authErr = checkAuth(req);
-      if (authErr) return authErr;
+      if (!opts.skipAuth) {
+        const authErr = checkAuth(req);
+        if (authErr) return authErr;
+      }
 
       const originErr = checkOrigin(req);
       if (originErr) return originErr;
@@ -4925,6 +5051,9 @@ export function makeApp(deps: AppDeps) {
     fetch: (req: Request): Promise<Response> =>
       app
         .fetch(req)
+        // Sliding re-stamp at this single HTTP seam (never on the skipAuth ingress app — agents
+        // carry no cookie — and never on WS upgrades, which return before reaching makeApp).
+        .then((res) => (opts.skipAuth ? res : maybeRestamp(req, res)))
         .catch((e) => json({ error: e instanceof Error ? e.message : "internal error" }, 500)),
   };
 }
@@ -4949,16 +5078,20 @@ export function isAgentIngressRoute(method: string, parts: string[]): boolean {
 }
 
 /** Restricted ingress app: 404 unless the request is an allowlisted agent→server route; otherwise
- *  DELEGATE to the full app (so checkAuth + checkOrigin + the real handlers all still apply). This is
- *  the autonomous netns's ONLY reachable control-plane surface (see isAgentIngressRoute). */
+ *  DELEGATE to the full app. Built with `skipAuth` (issue #1079): spawned agents carry neither a
+ *  human session cookie nor (by default) a bearer token — autonomous agents run under `--clearenv`
+ *  which strips any env var — so the human gate must NOT apply here. The ingress's loopback-only
+ *  bind + isAgentIngressRoute allowlist + unguessable per-session UUID IS the agent's auth. The
+ *  `checkOrigin` (CSRF) guard still applies (agents send no Origin → allowed). This preserves the
+ *  pre-#1079 effective behaviour (token-null ⇒ checkAuth was already a no-op here). */
 export function makeAgentIngressApp(deps: AppDeps) {
-  const app = makeApp(deps);
+  const app = makeApp(deps, { skipAuth: true });
   return {
     async fetch(req: Request): Promise<Response> {
       const url = new URL(req.url);
       const parts = url.pathname.split("/").filter(Boolean);
       if (!isAgentIngressRoute(req.method, parts)) return json({ error: "not found" }, 404);
-      return app.fetch(req); // MUST delegate — preserves checkAuth (token) + checkOrigin (CSRF) + handlers
+      return app.fetch(req); // delegate — preserves checkOrigin (CSRF) + the real handlers
     },
   };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,6 +43,7 @@ import {
   shouldRestamp,
   isSecureRequest,
   verifyPassword,
+  SESSION_COOKIE,
 } from "./operator-auth";
 import { resolvePlanAnswers, planAnswerSteerText, type RawAnswer } from "./plan-gate";
 import { slugifyManual } from "./namer";
@@ -431,9 +432,24 @@ function checkAuth(req: Request): Response | null {
  * re-logs-in. Attached at exactly ONE seam — the makeApp wrapper — so it can't double-apply; WS
  * upgrades return before this seam, so they never carry a cookie. Re-verifying here is a cheap
  * HMAC. Token-authed (no cookie) requests and failures are left untouched.
+ *
+ * CRITICAL: never re-stamp a response that ALREADY sets the session cookie. The handler owns the
+ * cookie in those cases — `POST /api/logout` clears it (Max-Age=0) and `POST /api/login` mints a
+ * fresh one — and the incoming request still carries the OLD cookie. Appending a second, valid
+ * `Set-Cookie` would re-authenticate the operator on logout (stateless: no server-side revocation),
+ * silently defeating it; on login it would just duplicate. So the handler's own cookie always wins.
  */
+function responseSetsSessionCookie(res: Response): boolean {
+  const cookies =
+    typeof res.headers.getSetCookie === "function"
+      ? res.headers.getSetCookie()
+      : [res.headers.get("set-cookie") ?? ""];
+  return cookies.some((c) => c.includes(`${SESSION_COOKIE}=`));
+}
+
 function maybeRestamp(req: Request, res: Response): Response {
   if (res.status >= 400) return res;
+  if (responseSetsSessionCookie(res)) return res; // handler owns the cookie (login/logout)
   const secret = config.cookieSecret;
   if (!secret) return res;
   const v = verifyCookie(secret, parseCookie(req.headers.get("cookie")));

--- a/src/service.ts
+++ b/src/service.ts
@@ -837,6 +837,17 @@ function agentEgressBaseUrl(ingressPort: number): string {
 }
 
 /**
+ * Base URL a NON-egress-confined agent (trusted / standard — both share the host network namespace)
+ * uses to reach the RESTRICTED agent-ingress listener over host loopback (issue #1079). The ingress
+ * listener is exempt from the human cookie/password gate, so routing agent hook + build-queue
+ * callbacks here keeps them working after auth goes fail-closed — without putting any credential in
+ * the agent's env. Autonomous reaches the SAME listener via 10.0.2.2 (agentEgressBaseUrl).
+ */
+function agentLoopbackIngressBaseUrl(ingressPort: number): string {
+  return `http://127.0.0.1:${ingressPort}`;
+}
+
+/**
  * Pick an override value over an original: an `undefined` override inherits the original;
  * any present value (including explicit `null`) replaces it. Mirrors the relaunch override
  * semantics where absent means "keep the original" and present means "use this".
@@ -1117,11 +1128,15 @@ export class SessionService {
   }
 
   /**
-   * Which control-plane base URL to bake into a spawn's hooks + build-queue calls. Egress-confined
-   * autonomous spawns (willEgressConfine) on a host-loopback-capable slirp, with a known ingress
-   * port, reach the restricted ingress listener via 10.0.2.2; everything else uses the loopback
-   * main port. Shares the SAME predicate + host-loopback probe + ingress-port accessor that
-   * prepareSpawn uses, so the baked URL and the actual wrap/hostGateway decision cannot diverge.
+   * Which control-plane base URL to bake into a spawn's hooks + build-queue calls. ALL agents are
+   * routed through the restricted agent-ingress listener, which is exempt from the human auth gate
+   * (issue #1079) so callbacks survive fail-closed without any credential in the agent's env:
+   *   - autonomous (egress-confined, host-loopback-capable slirp, known ingress port) → 10.0.2.2;
+   *   - trusted / standard (share the host net namespace) → host loopback 127.0.0.1;
+   *   - only when the ingress port is unknown (pathological early boot) does it fall back to the
+   *     gated main port — those callbacks then 401 and degrade to polling (fail-safe, loggable).
+   * Shares the SAME predicate + host-loopback probe + ingress-port accessor that prepareSpawn uses,
+   * so the baked URL and the actual wrap/hostGateway decision cannot diverge.
    */
   private resolveSpawnBaseUrl(
     profileOverride: string | null | undefined,
@@ -1132,7 +1147,11 @@ export class SessionService {
       this.deps.store.getRepoConfig(repoPath).sandboxProfile,
       config.sandboxDefaultProfile,
     );
-    if (!egressApplies(profile)) return agentBaseUrl(); // no backend probe for trusted/standard
+    if (!egressApplies(profile)) {
+      // trusted / standard: reach the exempt ingress over host loopback (no backend probe needed).
+      const ingressPort = this.deps.agentIngressPort?.();
+      return ingressPort != null ? agentLoopbackIngressBaseUrl(ingressPort) : agentBaseUrl();
+    }
     const backend = this.detectBackend();
     const egressBackend = backend !== null ? this.detectEgressBackend() : null;
     const gw = this.egressHostGateway(profile, backend, egressBackend);

--- a/test/agent-ingress.test.ts
+++ b/test/agent-ingress.test.ts
@@ -161,7 +161,11 @@ test("makeAgentIngressApp: an ALLOWED route DELEGATES to the full app (reaches t
   expect(q.steps[0].title).toBe("do a thing");
 });
 
-test("makeAgentIngressApp: delegation does NOT bypass checkAuth (token is enforced)", async () => {
+test("makeAgentIngressApp: the ingress transport is EXEMPT from the human auth gate (issue #1079)", async () => {
+  // Corrected #1079 design: the ingress is built with skipAuth — its loopback-only bind + route
+  // allowlist + per-session UUID IS the agent's auth. So an allowed route is served WITHOUT any
+  // human credential even when the gate is configured (cookie secret + bearer token both set);
+  // agents carry neither. The SAME route on the gated MAIN app would 401 (see server-auth.test.ts).
   const deps = makeDeps();
   const s = await deps.service.create({
     repoPath: "/repo",
@@ -171,33 +175,21 @@ test("makeAgentIngressApp: delegation does NOT bypass checkAuth (token is enforc
     images: [],
   });
   const app = makeAgentIngressApp(deps);
-  const prev = config.token;
+  const prevSecret = config.cookieSecret;
+  const prevToken = config.token;
+  config.cookieSecret = "test-cookie-secret"; // gate configured (would 401 un-credentialed on main app)
   config.token = "secret-token";
   try {
-    // ALLOWED route, but WITHOUT a valid Authorization header → checkAuth 401s through the gate.
-    const unauthed = await app.fetch(
+    const res = await app.fetch(
       new Request(`http://x/api/sessions/${s.id}/queue`, {
         method: "PUT",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ steps: [{ title: "do a thing" }] }),
       }),
     );
-    expect(unauthed.status).toBe(401);
-    expect(await unauthed.json()).toEqual({ error: "unauthorized" });
-
-    // SAME allowed route WITH the correct bearer token → past checkAuth, reaches the handler.
-    const authed = await app.fetch(
-      new Request(`http://x/api/sessions/${s.id}/queue`, {
-        method: "PUT",
-        headers: {
-          "content-type": "application/json",
-          Authorization: "Bearer secret-token",
-        },
-        body: JSON.stringify({ steps: [{ title: "do a thing" }] }),
-      }),
-    );
-    expect(authed.status).not.toBe(401);
+    expect(res.status).not.toBe(401); // exempt: reaches the handler with no credential
   } finally {
-    config.token = prev;
+    config.cookieSecret = prevSecret;
+    config.token = prevToken;
   }
 });

--- a/test/operator-auth.test.ts
+++ b/test/operator-auth.test.ts
@@ -1,0 +1,204 @@
+import { test, expect } from "bun:test";
+import {
+  hashPassword,
+  verifyPassword,
+  generatePassword,
+  generateSecret,
+  signCookie,
+  verifyCookie,
+  shouldRestamp,
+  serializeCookie,
+  clearCookie,
+  parseCookie,
+  isSecureRequest,
+  bootstrapAuth,
+  type AuthSettingsStore,
+  SESSION_COOKIE,
+  SESSION_TTL_MS,
+} from "../src/operator-auth";
+
+/** In-memory settings store for bootstrapAuth tests. */
+function fakeStore(
+  seed: Record<string, string> = {},
+): AuthSettingsStore & { data: Map<string, string> } {
+  const data = new Map(Object.entries(seed));
+  return {
+    data,
+    getSetting: (k) => data.get(k) ?? null,
+    setSetting: (k, v) => void data.set(k, v),
+  };
+}
+
+// ── password (argon2id) ──────────────────────────────────────────────────────
+
+test("hashPassword → argon2id hash verifies the right password and rejects the wrong one", async () => {
+  const hash = await hashPassword("correct horse battery staple");
+  expect(hash.startsWith("$argon2id$")).toBe(true);
+  expect(await verifyPassword("correct horse battery staple", hash)).toBe(true);
+  expect(await verifyPassword("wrong", hash)).toBe(false);
+});
+
+test("verifyPassword returns false (no throw) on a malformed hash", async () => {
+  expect(await verifyPassword("x", "not-a-real-hash")).toBe(false);
+});
+
+test("generatePassword / generateSecret produce distinct strong values", () => {
+  expect(generatePassword()).not.toBe(generatePassword());
+  const secret = generateSecret();
+  expect(secret).toHaveLength(64); // 32 bytes hex
+  expect(generateSecret()).not.toBe(secret);
+});
+
+// ── cookie sign → verify roundtrip + tamper rejection ────────────────────────
+
+test("signCookie → verifyCookie roundtrip succeeds within the window", () => {
+  const secret = generateSecret();
+  const now = 1_000_000;
+  const value = signCookie(secret, SESSION_TTL_MS, now);
+  const r = verifyCookie(secret, value, now + 1000);
+  expect(r.ok).toBe(true);
+  if (r.ok) expect(r.exp).toBe(now + SESSION_TTL_MS);
+});
+
+test("verifyCookie rejects a flipped-byte signature (timing-safe)", () => {
+  const secret = generateSecret();
+  const value = signCookie(secret, SESSION_TTL_MS, 1000);
+  const [body, sig] = value.split(".");
+  // flip the last char of the signature
+  const last = sig!.at(-1) === "A" ? "B" : "A";
+  const tampered = `${body}.${sig!.slice(0, -1)}${last}`;
+  expect(verifyCookie(secret, tampered, 2000).ok).toBe(false);
+});
+
+test("verifyCookie rejects a cookie signed with a different secret", () => {
+  const value = signCookie(generateSecret(), SESSION_TTL_MS, 1000);
+  expect(verifyCookie(generateSecret(), value, 2000).ok).toBe(false);
+});
+
+test("verifyCookie rejects an expired cookie", () => {
+  const secret = generateSecret();
+  const now = 1000;
+  const value = signCookie(secret, 10_000, now);
+  expect(verifyCookie(secret, value, now + 9_000).ok).toBe(true);
+  expect(verifyCookie(secret, value, now + 10_001).ok).toBe(false);
+});
+
+test("verifyCookie rejects malformed / empty values", () => {
+  const secret = generateSecret();
+  expect(verifyCookie(secret, null).ok).toBe(false);
+  expect(verifyCookie(secret, "").ok).toBe(false);
+  expect(verifyCookie(secret, "nodot").ok).toBe(false);
+  expect(verifyCookie(secret, ".onlysig").ok).toBe(false);
+});
+
+// ── sliding re-stamp ─────────────────────────────────────────────────────────
+
+test("shouldRestamp: false within the first half, true past half-life", () => {
+  const iat = 1_000_000;
+  expect(shouldRestamp(iat, SESSION_TTL_MS, iat + SESSION_TTL_MS / 4)).toBe(false);
+  expect(shouldRestamp(iat, SESSION_TTL_MS, iat + SESSION_TTL_MS / 2 + 1)).toBe(true);
+});
+
+// ── cookie header serialize / parse ──────────────────────────────────────────
+
+test("serializeCookie always sets HttpOnly + SameSite=Strict; Secure only when asked", () => {
+  const insecure = serializeCookie("v", { secure: false });
+  expect(insecure).toContain(`${SESSION_COOKIE}=v`);
+  expect(insecure).toContain("HttpOnly");
+  expect(insecure).toContain("SameSite=Strict");
+  expect(insecure).toContain("Path=/");
+  expect(insecure).not.toContain("Secure");
+
+  const secure = serializeCookie("v", { secure: true });
+  expect(secure).toContain("Secure");
+});
+
+test("clearCookie expires the cookie with Max-Age=0", () => {
+  expect(clearCookie({ secure: false })).toContain("Max-Age=0");
+  expect(clearCookie({ secure: false })).toContain(`${SESSION_COOKIE}=;`);
+});
+
+test("parseCookie extracts the session value among others", () => {
+  expect(parseCookie(`a=1; ${SESSION_COOKIE}=tok123; b=2`)).toBe("tok123");
+  expect(parseCookie("a=1; b=2")).toBe(null);
+  expect(parseCookie(null)).toBe(null);
+});
+
+// ── conditional Secure detection ─────────────────────────────────────────────
+
+test("isSecureRequest: X-Forwarded-Proto https ⇒ true; plain loopback ⇒ false; https url ⇒ true", () => {
+  expect(
+    isSecureRequest(
+      new Request("http://127.0.0.1:7330/api/me", { headers: { "x-forwarded-proto": "https" } }),
+    ),
+  ).toBe(true);
+  expect(isSecureRequest(new Request("http://127.0.0.1:7330/api/me"))).toBe(false);
+  expect(isSecureRequest(new Request("https://host.ts.net/api/me"))).toBe(true);
+});
+
+// ── fail-closed bootstrap ────────────────────────────────────────────────────
+
+test("bootstrapAuth: no password + no env ⇒ generates+persists hash AND secret, logs plaintext once", async () => {
+  const store = fakeStore();
+  const logs: string[] = [];
+  const r = await bootstrapAuth({
+    store,
+    envPassword: null,
+    envCookieSecret: null,
+    log: (m) => logs.push(m),
+  });
+  // both secrets provisioned + persisted
+  expect(r.cookieSecret).toBeTruthy();
+  expect(store.data.get("cookieSecret")).toBe(r.cookieSecret);
+  expect(r.passwordHash.startsWith("$argon2id$")).toBe(true);
+  expect(store.data.get("passwordHash")).toBe(r.passwordHash);
+  // plaintext generated, verifies against the persisted hash, and logged exactly once
+  expect(r.generatedPassword).toBeTruthy();
+  expect(await verifyPassword(r.generatedPassword!, r.passwordHash)).toBe(true);
+  expect(logs).toHaveLength(1);
+  expect(logs[0]).toContain(r.generatedPassword!);
+  expect(logs[0]).toContain("SHEPHERD_PASSWORD");
+});
+
+test("bootstrapAuth: SHEPHERD_PASSWORD set ⇒ overrides + re-seeds the persisted hash, no plaintext logged", async () => {
+  const store = fakeStore({ passwordHash: "$argon2id$stale" });
+  const logs: string[] = [];
+  const r = await bootstrapAuth({
+    store,
+    envPassword: "operator-secret",
+    envCookieSecret: null,
+    log: (m) => logs.push(m),
+  });
+  expect(r.generatedPassword).toBe(null);
+  expect(logs).toHaveLength(0);
+  expect(store.data.get("passwordHash")).toBe(r.passwordHash);
+  expect(r.passwordHash).not.toBe("$argon2id$stale"); // re-seeded
+  expect(await verifyPassword("operator-secret", r.passwordHash)).toBe(true);
+});
+
+test("bootstrapAuth: persisted hash + no env ⇒ reused as-is (survives restart), no log", async () => {
+  const existing = await hashPassword("kept-password");
+  const store = fakeStore({ passwordHash: existing, cookieSecret: "fixedsecret" });
+  const logs: string[] = [];
+  const r = await bootstrapAuth({
+    store,
+    envPassword: null,
+    envCookieSecret: null,
+    log: (m) => logs.push(m),
+  });
+  expect(r.passwordHash).toBe(existing);
+  expect(r.cookieSecret).toBe("fixedsecret");
+  expect(r.generatedPassword).toBe(null);
+  expect(logs).toHaveLength(0);
+});
+
+test("bootstrapAuth: env cookie secret pins the signing secret (overrides persisted)", async () => {
+  const store = fakeStore({ cookieSecret: "persisted" });
+  const r = await bootstrapAuth({
+    store,
+    envPassword: "x",
+    envCookieSecret: "env-pinned",
+    log: () => {},
+  });
+  expect(r.cookieSecret).toBe("env-pinned");
+});

--- a/test/server-auth.test.ts
+++ b/test/server-auth.test.ts
@@ -178,6 +178,20 @@ test("logout: clears the cookie (Max-Age=0)", async () => {
   expect(res.headers.get("set-cookie")).toContain("Max-Age=0");
 });
 
+test("logout: a PAST-HALF-LIFE cookie still only clears — re-stamp must NOT re-issue a valid session", async () => {
+  const app = makeApp(makeDeps());
+  const old = signCookie(SECRET, SESSION_TTL_MS, Date.now() - SESSION_TTL_MS * 0.6); // restamp-eligible
+  const res = await app.fetch(
+    new Request("http://x/api/logout", { method: "POST", headers: cookieHeader(old) }),
+  );
+  expect(res.status).toBe(200);
+  const cookies = res.headers.getSetCookie();
+  // exactly ONE Set-Cookie, and it expires the session (no second, valid, re-stamped cookie)
+  expect(cookies).toHaveLength(1);
+  expect(cookies[0]).toContain("Max-Age=0");
+  expect(cookies.some((c) => /Max-Age=(?!0)\d/.test(c))).toBe(false);
+});
+
 // ── sliding re-stamp ─────────────────────────────────────────────────────────
 
 test("re-stamp: a cookie past half-life gets a fresh Set-Cookie on a 2xx response", async () => {

--- a/test/server-auth.test.ts
+++ b/test/server-auth.test.ts
@@ -1,0 +1,276 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { SessionStore } from "../src/store";
+import { SessionService } from "../src/service";
+import { EventHub } from "../src/events";
+import { makeApp, serve, makeAgentIngressApp, type AppDeps } from "../src/server";
+import { config } from "../src/config";
+import { signCookie, hashPassword, SESSION_COOKIE, SESSION_TTL_MS } from "../src/operator-auth";
+
+const SECRET = "test-cookie-signing-secret";
+const PASSWORD = "operator-password";
+
+function makeDeps(): AppDeps {
+  const store = new SessionStore(":memory:");
+  const events = new EventHub();
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: {
+      create: () => ({ worktreePath: "/wt", branch: "shepherd/x", isolated: true }),
+      ensureBaseRef: async () => {},
+      branchExists: () => false,
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: () => ({ terminalId: "term_x" }),
+      list: () => [],
+      stop: () => {},
+      send: () => {},
+    } as any,
+    events,
+  });
+  const usageLimits = {
+    limits: () => ({
+      session5h: null,
+      week: null,
+      credits: null,
+      stale: true,
+      calibratedAt: null,
+      subscriptionOnly: false,
+    }),
+    projections: () => [],
+  };
+  return { store, service, events, usageLimits, distiller: { distillNow: () => {} } };
+}
+
+const cookieHeader = (value: string) => ({ Cookie: `${SESSION_COOKIE}=${value}` });
+
+let prevSecret: string | null;
+let prevHash: string | null;
+let prevToken: string | null;
+
+beforeEach(async () => {
+  prevSecret = config.cookieSecret;
+  prevHash = config.passwordHash;
+  prevToken = config.token;
+  // Gate ACTIVE: a configured cookie secret + password hash (what bootstrapAuth guarantees at boot).
+  config.cookieSecret = SECRET;
+  config.passwordHash = await hashPassword(PASSWORD);
+  config.token = null; // default: no operator bearer; agents use the exempt ingress
+});
+
+afterEach(() => {
+  config.cookieSecret = prevSecret;
+  config.passwordHash = prevHash;
+  config.token = prevToken;
+});
+
+// ── gate: cookie OR token, else 401 ─────────────────────────────────────────
+
+test("gate: a valid session cookie passes (GET /api/me → 200 authenticated)", async () => {
+  const app = makeApp(makeDeps());
+  const res = await app.fetch(
+    new Request("http://x/api/me", { headers: cookieHeader(signCookie(SECRET)) }),
+  );
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ authenticated: true });
+});
+
+test("gate: no credential → 401 unauthorized", async () => {
+  const app = makeApp(makeDeps());
+  const res = await app.fetch(new Request("http://x/api/me"));
+  expect(res.status).toBe(401);
+  expect(await res.json()).toEqual({ error: "unauthorized" });
+});
+
+test("gate: a cookie signed with the wrong secret → 401", async () => {
+  const app = makeApp(makeDeps());
+  const res = await app.fetch(
+    new Request("http://x/api/me", { headers: cookieHeader(signCookie("other-secret")) }),
+  );
+  expect(res.status).toBe(401);
+});
+
+test("gate: a valid operator bearer token passes (when config.token is set)", async () => {
+  config.token = "operator-bearer";
+  const app = makeApp(makeDeps());
+  const res = await app.fetch(
+    new Request("http://x/api/me", { headers: { Authorization: "Bearer operator-bearer" } }),
+  );
+  expect(res.status).toBe(200);
+});
+
+// ── exemptions: login route + static shell pass un-credentialed ─────────────
+
+test("exemption: a static-shell GET is not gated (no 401)", async () => {
+  const app = makeApp(makeDeps());
+  const res = await app.fetch(new Request("http://x/"));
+  expect(res.status).not.toBe(401); // serveStatic owns it (200 or 404), never the gate
+});
+
+test("exemption: POST /api/login is reachable un-credentialed; wrong password → handler 401", async () => {
+  const app = makeApp(makeDeps());
+  const res = await app.fetch(
+    new Request("http://x/api/login", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ password: "nope" }),
+    }),
+  );
+  expect(res.status).toBe(401);
+  // handler's message, NOT the gate's {error:"unauthorized"} — proves it passed the gate
+  expect(await res.json()).toEqual({ error: "invalid password" });
+});
+
+// ── login / logout / me + cookie attributes ─────────────────────────────────
+
+test("login: correct password → 200 + HttpOnly SameSite=Strict cookie; conditional Secure", async () => {
+  const app = makeApp(makeDeps());
+  // plain loopback HTTP → no Secure
+  const res = await app.fetch(
+    new Request("http://x/api/login", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ password: PASSWORD }),
+    }),
+  );
+  expect(res.status).toBe(200);
+  const setCookie = res.headers.get("set-cookie")!;
+  expect(setCookie).toContain(`${SESSION_COOKIE}=`);
+  expect(setCookie).toContain("HttpOnly");
+  expect(setCookie).toContain("SameSite=Strict");
+  expect(setCookie).not.toContain("Secure");
+
+  // HTTPS (via X-Forwarded-Proto) → Secure
+  const resHttps = await app.fetch(
+    new Request("http://x/api/login", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-forwarded-proto": "https" },
+      body: JSON.stringify({ password: PASSWORD }),
+    }),
+  );
+  expect(resHttps.headers.get("set-cookie")).toContain("Secure");
+});
+
+test("login → cookie then authenticates a gated route", async () => {
+  const app = makeApp(makeDeps());
+  const login = await app.fetch(
+    new Request("http://x/api/login", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ password: PASSWORD }),
+    }),
+  );
+  const value = login.headers.get("set-cookie")!.split(";")[0]!.split("=")[1]!;
+  const me = await app.fetch(new Request("http://x/api/me", { headers: cookieHeader(value) }));
+  expect(me.status).toBe(200);
+});
+
+test("logout: clears the cookie (Max-Age=0)", async () => {
+  const app = makeApp(makeDeps());
+  const res = await app.fetch(
+    new Request("http://x/api/logout", {
+      method: "POST",
+      headers: cookieHeader(signCookie(SECRET)),
+    }),
+  );
+  expect(res.status).toBe(200);
+  expect(res.headers.get("set-cookie")).toContain("Max-Age=0");
+});
+
+// ── sliding re-stamp ─────────────────────────────────────────────────────────
+
+test("re-stamp: a cookie past half-life gets a fresh Set-Cookie on a 2xx response", async () => {
+  const app = makeApp(makeDeps());
+  const old = signCookie(SECRET, SESSION_TTL_MS, Date.now() - SESSION_TTL_MS * 0.6); // past half-life, still valid
+  const res = await app.fetch(new Request("http://x/api/me", { headers: cookieHeader(old) }));
+  expect(res.status).toBe(200);
+  expect(res.headers.get("set-cookie")).toContain(`${SESSION_COOKIE}=`);
+});
+
+test("re-stamp: a fresh cookie (within first half) gets no Set-Cookie", async () => {
+  const app = makeApp(makeDeps());
+  const res = await app.fetch(
+    new Request("http://x/api/me", { headers: cookieHeader(signCookie(SECRET)) }),
+  );
+  expect(res.status).toBe(200);
+  expect(res.headers.get("set-cookie")).toBe(null);
+});
+
+// ── WebSocket upgrades inherit the gate (the live-PTY fix) ───────────────────
+
+async function withServer(fn: (port: number) => Promise<void>) {
+  const server = serve(makeDeps(), 0);
+  try {
+    await fn(server.port!);
+  } finally {
+    server.stop(true);
+  }
+}
+
+test("WS /events: rejected (401) without a credential", async () => {
+  await withServer(async (port) => {
+    const res = await fetch(`http://localhost:${port}/events`, {
+      headers: { Origin: `http://localhost:${port}` },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+test("WS /events: with a valid cookie passes the gate + origin (not 401/403)", async () => {
+  await withServer(async (port) => {
+    const res = await fetch(`http://localhost:${port}/events`, {
+      headers: { Origin: "http://localhost", ...cookieHeader(signCookie(SECRET)) },
+    });
+    // a non-handshake fetch can't complete the upgrade (→ 500), but it cleared auth + origin
+    expect(res.status).not.toBe(401);
+    expect(res.status).not.toBe(403);
+  });
+});
+
+test("WS /pty/:id: rejected (401) without a credential", async () => {
+  await withServer(async (port) => {
+    const res = await fetch(`http://localhost:${port}/pty/some-id`, {
+      headers: { Origin: `http://localhost:${port}` },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+test("WS /events: a valid cookie but evil Origin is still 403 (CSWSH guard kept)", async () => {
+  await withServer(async (port) => {
+    const res = await fetch(`http://localhost:${port}/events`, {
+      headers: { Origin: "http://evil.example", ...cookieHeader(signCookie(SECRET)) },
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── agent-transport regression: exempt ingress vs gated main port ────────────
+
+test("agent-transport: an uncredentialed hook POST is 2xx on the ingress but 401 on the main port", async () => {
+  const deps = makeDeps();
+  const s = await deps.service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "go",
+    model: null,
+    images: [],
+  });
+  const hookReq = () =>
+    new Request(`http://x/api/sessions/${s.id}/hooks`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ hook_event_name: "Stop" }),
+    });
+
+  // exempt ingress transport: agent reaches the handler with NO credential
+  const ingress = makeAgentIngressApp(deps);
+  const viaIngress = await ingress.fetch(hookReq());
+  expect(viaIngress.status).not.toBe(401);
+
+  // gated main port: the SAME uncredentialed POST is rejected
+  const main = makeApp(deps);
+  const viaMain = await main.fetch(hookReq());
+  expect(viaMain.status).toBe(401);
+});

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -4728,7 +4728,9 @@ test("baseUrl: autonomous but slirp NOT host-loopback-capable → falls back to 
   }
 });
 
-test("baseUrl: trusted (default) → loopback main port, no backend probe required", async () => {
+test("baseUrl: trusted (default) → exempt ingress over host loopback (127.0.0.1:<ingressPort>), no backend probe", async () => {
+  // issue #1079: trusted/standard agents reach the auth-exempt ingress listener over host loopback
+  // (not the now-gated main port), so hook callbacks survive fail-closed with no credential in env.
   const prev = config.hooksIngest;
   const store = new SessionStore(":memory:");
   const record: { argv?: string[] } = {};
@@ -4753,11 +4755,31 @@ test("baseUrl: trusted (default) → loopback main port, no backend probe requir
       model: null,
       images: [],
     });
+    expect(hooksUrlFrom(record.argv)).toBe(`http://127.0.0.1:7331/api/sessions/${s.id}/hooks`);
+    // resolveSpawnBaseUrl returned early for the trusted profile (no backend probe).
+    expect(probed).toBe(false);
+  } finally {
+    config.hooksIngest = prev;
+  }
+});
+
+test("baseUrl: trusted with no ingress port yet (early boot) → falls back to gated main port", async () => {
+  const prev = config.hooksIngest;
+  const store = new SessionStore(":memory:");
+  const record: { argv?: string[] } = {};
+  const service = baseUrlService({ store, record, agentIngressPort: () => undefined });
+  try {
+    config.hooksIngest = true;
+    const s = await service.create({
+      repoPath: "/repo",
+      baseBranch: "main",
+      prompt: "go",
+      model: null,
+      images: [],
+    });
     expect(hooksUrlFrom(record.argv)).toBe(
       `http://127.0.0.1:${config.port}/api/sessions/${s.id}/hooks`,
     );
-    // resolveSpawnBaseUrl returned early for the trusted profile (no backend probe).
-    expect(probed).toBe(false);
   } finally {
     config.hooksIngest = prev;
   }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1925,5 +1925,17 @@
   "integrated_epics_rebase_paused_conflict": "Landing-PR hat einen echten Konflikt — du bist dran",
   "integrated_epics_rebase_paused_driver": "Merge-Treiber auf dem Server nicht verfügbar — du bist dran",
   "feat_auto_rebase_landing_prs_title": "Auto-Rebase für Landing-PRs",
-  "feat_auto_rebase_landing_prs_body": "Wenn ein Landing-PR eines Epics hinter seiner Basis zurückfällt, führt Shepherd jetzt automatisch einen Rebase durch. Bei einem Konflikt, einem Wiederholungslimit oder einem fehlenden Merge-Treiber zeigt ein Warn-Chip in der Band-Zeile genau den Grund an und übergibt an dich."
+  "feat_auto_rebase_landing_prs_body": "Wenn ein Landing-PR eines Epics hinter seiner Basis zurückfällt, führt Shepherd jetzt automatisch einen Rebase durch. Bei einem Konflikt, einem Wiederholungslimit oder einem fehlenden Merge-Treiber zeigt ein Warn-Chip in der Band-Zeile genau den Grund an und übergibt an dich.",
+  "login_title": "Shepherd",
+  "login_subtitle": "Diese Instanz ist geschützt. Gib das Betreiber-Passwort ein, um fortzufahren.",
+  "login_password_label": "Passwort",
+  "login_password_placeholder": "Betreiber-Passwort",
+  "login_submit": "Anmelden",
+  "login_busy": "Anmeldung läuft…",
+  "login_error": "Falsches Passwort.",
+  "settings_logout_title": "Abmelden",
+  "settings_logout_hint": "Diese Sitzung auf diesem Gerät beenden. Zum erneuten Anmelden ist das Betreiber-Passwort nötig.",
+  "settings_logout_button": "Abmelden",
+  "feat_operator_auth_title": "Passwort-Anmeldung",
+  "feat_operator_auth_body": "Shepherd ist jetzt durch ein Einzelbetreiber-Passwort geschützt. Jede Seite, das Live-Terminal und der Aktivitätsstrom erfordern eine Sitzung — setze SHEPHERD_PASSWORD oder hol dir das automatisch generierte Passwort beim ersten Start aus dem Server-Log. Abmelden jederzeit über Einstellungen → Sitzung."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1925,5 +1925,17 @@
   "integrated_epics_rebase_paused_conflict": "Landing PR has a real conflict — over to you",
   "integrated_epics_rebase_paused_driver": "Merge driver unavailable on the server — over to you",
   "feat_auto_rebase_landing_prs_title": "Auto-rebase for landing PRs",
-  "feat_auto_rebase_landing_prs_body": "When an epic's landing PR falls behind its base, Shepherd now rebases it automatically. If it hits a conflict, a retry cap, or a missing merge driver, a warn chip on the band row tells you exactly why and hands off to you."
+  "feat_auto_rebase_landing_prs_body": "When an epic's landing PR falls behind its base, Shepherd now rebases it automatically. If it hits a conflict, a retry cap, or a missing merge driver, a warn chip on the band row tells you exactly why and hands off to you.",
+  "login_title": "Shepherd",
+  "login_subtitle": "This instance is protected. Enter the operator password to continue.",
+  "login_password_label": "Password",
+  "login_password_placeholder": "Operator password",
+  "login_submit": "Sign in",
+  "login_busy": "Signing in…",
+  "login_error": "Incorrect password.",
+  "settings_logout_title": "Sign out",
+  "settings_logout_hint": "End this session on this device. You'll need the operator password to sign back in.",
+  "settings_logout_button": "Sign out",
+  "feat_operator_auth_title": "Password login",
+  "feat_operator_auth_body": "Shepherd now sits behind a single-operator password. Every page, the live terminal, and the activity stream require a session — set SHEPHERD_PASSWORD, or grab the auto-generated one from the server log on first boot. Sign out anytime from Settings → Session."
 }

--- a/ui/src/lib/api.auth.test.ts
+++ b/ui/src/lib/api.auth.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { createSession, login, logout, getMe } from "./api";
+import { auth } from "./auth.svelte";
+import type { CreateInput } from "./types";
+
+function mockFetch(status: number, body: unknown = {}): typeof fetch {
+  return vi.fn(
+    async () => new Response(JSON.stringify(body), { status }),
+  ) as unknown as typeof fetch;
+}
+
+describe("single-operator auth (issue #1079)", () => {
+  const realFetch = globalThis.fetch;
+  beforeEach(() => {
+    auth.unauthenticated = false;
+    auth.checked = false;
+  });
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    auth.unauthenticated = false;
+    auth.checked = false;
+  });
+
+  it("401 interceptor flips the unauthenticated store on a gated call", async () => {
+    globalThis.fetch = mockFetch(401, { error: "unauthorized" });
+    await createSession({ repo: "r", prompt: "p" } as unknown as CreateInput).catch(() => {});
+    expect(auth.unauthenticated).toBe(true);
+  });
+
+  it("getMe: true on 200, false on 401, false on network error", async () => {
+    globalThis.fetch = mockFetch(200);
+    expect(await getMe()).toBe(true);
+    globalThis.fetch = mockFetch(401);
+    expect(await getMe()).toBe(false);
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("offline");
+    }) as unknown as typeof fetch;
+    expect(await getMe()).toBe(false);
+  });
+
+  it("login: success clears the flag and returns true", async () => {
+    auth.unauthenticated = true;
+    globalThis.fetch = mockFetch(200, { ok: true });
+    expect(await login("right")).toBe(true);
+    expect(auth.unauthenticated).toBe(false);
+  });
+
+  it("login: wrong password returns false without throwing", async () => {
+    globalThis.fetch = mockFetch(401, { error: "invalid password" });
+    expect(await login("wrong")).toBe(false);
+  });
+
+  it("logout: flips the flag to unauthenticated", async () => {
+    globalThis.fetch = mockFetch(200, { ok: true });
+    await logout();
+    expect(auth.unauthenticated).toBe(true);
+  });
+});

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -61,8 +61,20 @@ import type {
   HoldReason,
 } from "./types";
 import { m } from "$lib/paraglide/messages";
+import { auth } from "$lib/auth.svelte";
 
 const JSON_HEADERS = { "content-type": "application/json" };
+
+/** 401 interceptor (issue #1079): any gated call rejected with 401 flips the shared auth flag so
+ *  the root layout swaps to the login view. Mirrors the 403 → PreviewBlockedError pattern below.
+ *  Returns `status === 401` so callers can short-circuit. */
+function flagIfUnauthorized(status: number): boolean {
+  if (status === 401) {
+    auth.unauthenticated = true;
+    return true;
+  }
+  return false;
+}
 
 /** Server's CSRF preview-origin rejection string. The HUD origin guard
  *  (`src/validate.ts` `originAllowed` → `src/server.ts:214` `checkOrigin`) returns
@@ -87,6 +99,7 @@ function apiError(
   body: { error?: string } | null | undefined,
   fallback: string,
 ): Error {
+  flagIfUnauthorized(status);
   if (status === 403 && body?.error === ORIGIN_BLOCK) {
     return new PreviewBlockedError(m.error_preview_readonly());
   }
@@ -117,8 +130,49 @@ async function failed(r: Response, label: string): Promise<Error> {
 /** GET a JSON resource, throwing `<label> failed: <status>` on a non-2xx response. */
 async function getJson<T>(url: string, label: string): Promise<T> {
   const r = await fetch(url);
-  if (!r.ok) throw new Error(`${label} failed: ${r.status}`);
+  if (!r.ok) {
+    flagIfUnauthorized(r.status);
+    throw new Error(`${label} failed: ${r.status}`);
+  }
   return r.json() as Promise<T>;
+}
+
+// ── single-operator auth (issue #1079) ──────────────────────────────────────
+
+/** Boot probe: true when the current session cookie authenticates, false on 401. Never throws —
+ *  a network error is treated as "unknown / not authenticated" so the layout shows the login view. */
+export async function getMe(): Promise<boolean> {
+  try {
+    const r = await fetch("/api/me");
+    return r.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** POST the operator password; on success the server sets the session cookie (HttpOnly, so JS never
+ *  sees it). Returns true on 200; false on a 401 (wrong password). Throws on other failures. */
+export async function login(password: string): Promise<boolean> {
+  const r = await fetch("/api/login", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ password }),
+  });
+  if (r.ok) {
+    auth.unauthenticated = false;
+    return true;
+  }
+  if (r.status === 401) return false;
+  throw await failed(r, "login");
+}
+
+/** Clear the session cookie server-side and flip the UI to the login view. */
+export async function logout(): Promise<void> {
+  try {
+    await fetch("/api/logout", { method: "POST", headers: JSON_HEADERS });
+  } finally {
+    auth.unauthenticated = true;
+  }
 }
 
 export async function listSessions(): Promise<Session[]> {

--- a/ui/src/lib/auth.svelte.ts
+++ b/ui/src/lib/auth.svelte.ts
@@ -1,0 +1,10 @@
+// Single-operator auth UI state (issue #1079). `unauthenticated` flips true when any API call is
+// rejected with 401 (the interceptor in api.ts) or after an explicit logout; the root layout swaps
+// to the login view while it's set. `checked` gates first paint: the layout renders the app (or the
+// login view) only after the boot `/api/me` probe resolves, so there's no flash of failing calls.
+class AuthState {
+  unauthenticated = $state(false);
+  checked = $state(false);
+}
+
+export const auth = new AuthState();

--- a/ui/src/lib/components/Login.svelte
+++ b/ui/src/lib/components/Login.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+  // Single-operator login (issue #1079). Full-view takeover shown by the root layout while the
+  // session is unauthenticated. Tokens-only per the design system; reuses the .gbtn + field recipes.
+  import { login } from "$lib/api";
+  import { m } from "$lib/paraglide/messages";
+
+  let password = $state("");
+  let busy = $state(false);
+  let error = $state(false);
+
+  async function submit(e: SubmitEvent) {
+    e.preventDefault();
+    if (busy || password === "") return;
+    busy = true;
+    error = false;
+    try {
+      const ok = await login(password);
+      if (ok) {
+        password = "";
+        // success: auth.unauthenticated is cleared by login(); the layout re-renders the app.
+      } else {
+        error = true;
+      }
+    } catch {
+      error = true;
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+<div class="login-scrim">
+  <form class="login-card panel" onsubmit={submit}>
+    <h1 class="title">{m.login_title()}</h1>
+    <p class="subtitle">{m.login_subtitle()}</p>
+    <label class="field">
+      <span class="label">{m.login_password_label()}</span>
+      <!-- svelte-ignore a11y_autofocus -->
+      <input
+        type="password"
+        class="input"
+        bind:value={password}
+        disabled={busy}
+        placeholder={m.login_password_placeholder()}
+        aria-label={m.login_password_label()}
+        autocomplete="current-password"
+        autofocus
+      />
+    </label>
+    {#if error}
+      <p class="error" role="alert">{m.login_error()}</p>
+    {/if}
+    <button type="submit" class="gbtn submit" disabled={busy || password === ""}>
+      {busy ? m.login_busy() : m.login_submit()}
+    </button>
+  </form>
+</div>
+
+<style>
+  /* Blocking surface: dim + blur behind the card (honors the design-system scrim rule). There is
+     no app rendered behind it, so this reads as the focused entry point on the app background. */
+  .login-scrim {
+    position: fixed;
+    inset: 0;
+    z-index: 200;
+    display: grid;
+    place-items: center;
+    padding: 24px;
+    background: var(--color-scrim, color-mix(in srgb, var(--color-bg) 70%, transparent));
+    backdrop-filter: blur(6px);
+  }
+  .login-card {
+    width: min(360px, 100%);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 24px;
+    background: var(--color-panel);
+    border: 1px solid var(--color-line);
+    border-radius: 4px;
+  }
+  .title {
+    margin: 0;
+    font-size: var(--fs-lg);
+    color: var(--color-ink-bright, var(--color-ink));
+    letter-spacing: 0.06em;
+  }
+  .subtitle {
+    margin: 0;
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    line-height: 1.5;
+  }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .field .label {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    letter-spacing: 0.08em;
+  }
+  .input {
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-ink);
+    font-family: var(--font-mono);
+    font-size: var(--fs-base);
+    padding: 8px 10px;
+  }
+  .input:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+    border-color: var(--color-amber);
+  }
+  .error {
+    margin: 0;
+    font-size: var(--fs-meta);
+    color: var(--color-red);
+  }
+  /* .gbtn recipe (design system) */
+  .gbtn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 8px;
+    cursor: pointer;
+  }
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .gbtn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+  .gbtn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  .submit {
+    margin-top: 4px;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .login-scrim {
+      backdrop-filter: none;
+    }
+  }
+</style>

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -17,6 +17,7 @@
     putReducedPushMode,
     putTuiFullscreen,
     putTuiDisableMouse,
+    logout,
   } from "$lib/api";
   import { verifyFailureMessage } from "$lib/verify-key";
   import { modelLabel } from "$lib/model-label";
@@ -788,6 +789,13 @@
             {/if}
           </div>
         {/if}
+      </div>
+      <div class="rc">
+        <span class="micro">{m.settings_logout_title()}</span>
+        <p class="hint">{m.settings_logout_hint()}</p>
+        <button type="button" class="gbtn" onclick={() => logout()}>
+          {m.settings_logout_button()}
+        </button>
       </div>
       <div class="rc">
         <span class="micro">{m.settings_extra_credits_ceiling_title()}</span>

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1590,4 +1590,12 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_auto_rebase_landing_prs_body",
     targetId: "rebase-paused-chip",
   },
+  {
+    // Issue #1079: single-operator password → session-cookie auth gating every route + both WS
+    // channels (live PTY / activity stream). Logout lives in Settings → Session. Ships in 1.37.0.
+    id: "operator-auth",
+    sinceVersion: "1.37.0",
+    titleKey: "feat_operator_auth_title",
+    bodyKey: "feat_operator_auth_body",
+  },
 ];

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -3,18 +3,33 @@
   import { onMount } from "svelte";
   import { theme } from "$lib/theme.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { auth } from "$lib/auth.svelte";
+  import { getMe } from "$lib/api";
+  import Login from "$lib/components/Login.svelte";
 
   let { children } = $props();
 
   // keep `data-theme` in sync with OS changes when the preference is "system"
-  onMount(() => theme.init());
+  onMount(() => {
+    theme.init();
+    // Single-operator auth (issue #1079): probe /api/me before rendering the app so an
+    // unauthenticated session goes straight to the login view with no flash of failing calls.
+    getMe()
+      .then((ok) => (auth.unauthenticated = !ok))
+      .catch(() => (auth.unauthenticated = true))
+      .finally(() => (auth.checked = true));
+  });
 </script>
 
 <!-- Skip link: first focusable element, visually hidden until focused, jumps
      keyboard users straight past the chrome to the primary <main> region. -->
 <a class="skip-link" href="#main-content">{m.a11y_skip_to_main()}</a>
 
-{@render children()}
+{#if auth.checked && auth.unauthenticated}
+  <Login />
+{:else if auth.checked}
+  {@render children()}
+{/if}
 
 <style>
   .skip-link {


### PR DESCRIPTION
Closes #1079.

## What

Shepherd was fully unauthenticated behind Tailscale — and the live PTY (`ws://host/pty/<uuid>`) + `/events` bus were reachable with no credential. This adds a **single-operator password → argon2id hash → HMAC-signed session cookie** layer, hand-rolled on Bun built-ins (**no new deps**), that gates **every HTTP route AND both WebSocket channels**, fails closed, and keeps spawned-agent hook callbacks working on every sandbox profile.

## How

- **`src/operator-auth.ts`** (new, pure): `hashPassword`/`verifyPassword` (`Bun.password` argon2id), `signCookie`/`verifyCookie` (HMAC-SHA256 + `timingSafeEqual`), cookie parse/serialize (`HttpOnly`+`SameSite=Strict` always, **conditional `Secure`**, 7-day **sliding** window), and `bootstrapAuth` (fail-closed).
- **Boot bootstrap** (`src/index.ts`): provisions the cookie-signing secret + password hash before serving. `SHEPHERD_PASSWORD` wins (re-seeds each boot); else the persisted hash is reused; else a strong password is **auto-generated, hashed, persisted, and logged once** with a CHANGE-THIS banner. The app is never silently open.
- **Gate** (`src/server.ts`): `checkAuth` = valid session cookie **OR** operator bearer (`config.token`, when set). One seam — `makeApp.fetch` and `serve().fetch` both call it, so HTTP routes **and** the WS upgrades inherit it. Scoped static-shell exemption that deliberately keeps `/events` + `/pty/:id` gated. New `POST /api/login`, `POST /api/logout`, `GET /api/me`. Sliding re-stamp attached at one seam (the `makeApp` wrapper), never on WS.
- **Agents** reach the server through the **loopback agent-ingress listener**, now built with `skipAuth` (its loopback bind + route allowlist + per-session UUID is the auth). `resolveSpawnBaseUrl` routes trusted/standard callbacks there too (autonomous already did via `10.0.2.2`). `config.token` is **not** auto-provisioned.
- **UI**: 401 interceptor in `api.ts` → `unauthenticated` store → in-layout `<Login>` (scrim/blur, tokens, `.gbtn`/field); `/api/me` boot probe (no first-paint flash); logout in **Settings → Session**; EN+DE strings; one feature-catalog entry (1.37.0).

## Deviations from the issue (flagged per house rules)

1. **WS enforcement unified in `checkAuth`** instead of literal per-upgrade-site checks — `serve().fetch` already calls `checkAuth` before the upgrade branches (`src/server.ts`), so both channels inherit the gate from one function. (Operator-approved during planning.)
2. **Module is `src/operator-auth.ts`** (issue suggested `src/auth.ts`) — `auth-mode.ts`/`auth-config-dir.ts` already exist for the unrelated spawned-agent API-key concern.
3. **Agents authenticate via the exempt ingress, NOT a provisioned token.** The issue's "provision an agent token" would have *broken* hooks: `buildHooksFragment` emits a `$SHEPHERD_TOKEN` placeholder resolved from the agent's env (run under the herdr daemon), and autonomous `--clearenv` strips it (#711) — so a non-null `config.token` degrades hooks to polling. Leaving `config.token` null + routing all agents through the auth-exempt loopback ingress keeps hooks event-driven with no secret in any agent env. (Reviewer-approved re-scope.)

## Migration (signed off in the issue)

The deploy that ships this is **not** seamless-open: the live instance will require a login. Set `SHEPHERD_PASSWORD` in `~/.shepherd/env`, or read the auto-generated password from `~/.shepherd/shepherd.log` on first boot. Agent hooks are **not** downgraded (they ride the exempt ingress). Logout is client-side (stateless cookie); rotating the cookie secret is the all-sessions kill-switch.

## Tests

- Root (`test/operator-auth.test.ts`, `test/server-auth.test.ts`): cookie sign→verify roundtrip + tamper/expiry rejection; gate accepts cookie / accepts bearer / rejects neither / exemptions pass; fail-closed bootstrap (hash + secret generated + persisted, logged once, `SHEPHERD_PASSWORD` overrides); sliding re-stamp (2xx past half-life only, never WS); conditional `Secure`; WS `/events` + `/pty/:id` rejected without credential, accepted with cookie, `Origin`/CSWSH still applies (real ephemeral-port server); **agent-transport regression** — uncredentialed hook POST is 2xx on the ingress, 401 on the main port; `resolveSpawnBaseUrl` bakes the ingress URL per profile.
- UI (`api.auth.test.ts`): 401 flips the store; login success/failure; logout.
- Full root suite (4885) + UI (2054) green; `tsc`, `eslint`, `prettier --check`, `check:i18n`, UI build, branch-hygiene, feature-catalog, glossary all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)