### PR TITLE
feat(backup): automated hourly SQLite backups + restore + staleness alert (#1080)

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -234,6 +234,13 @@ main() {
   resolve_source
 
   cd "$SHEPHERD_DIR" || die "cannot cd into $SHEPHERD_DIR"
+  # Mirror the systemd units' EnvironmentFile=-%h/.shepherd/env so any SHEPHERD_DB /
+  # SHEPHERD_BACKUP_DIR override reaches provision via process.env — otherwise provision would
+  # write the .backup-configured marker to the DEFAULT dir while the server (which DOES read the
+  # env file) looks in the override dir, silently disabling staleness alerting (#1080).
+  set -a
+  [ -f "$HOME/.shepherd/env" ] && . "$HOME/.shepherd/env"
+  set +a
   note "handing off to deploy/provision.ts (from $SHEPHERD_DIR)"
   exec bun run deploy/provision.ts
 }

--- a/deploy/provision.ts
+++ b/deploy/provision.ts
@@ -285,6 +285,10 @@ export function installService(
   run("mkdir", ["-p", resolveBackupDir(env)]);
   fileIO.write(backupConfiguredMarker(env), "shepherd-backup.timer enabled\n");
   run("systemctl", ["--user", "enable", "--now", "shepherd-backup.timer"]);
+  // Kick one backup immediately — the timer's first scheduled run is at the next hour boundary, so
+  // without this a fresh box has no `.last-success` until then. (The staleness probe also has a
+  // marker-age grace, so this is belt-and-suspenders against a spurious first alert. #1080)
+  run("systemctl", ["--user", "start", "shepherd-backup.service"]);
   // update.sh does deps → UI build → restart (starts the now-enabled unit) → health.
   log("building + starting via deploy/update.sh");
   run("bash", [join(repo, "deploy", "update.sh")], { env: buildEnv });

--- a/deploy/provision.ts
+++ b/deploy/provision.ts
@@ -285,10 +285,10 @@ export function installService(
   run("mkdir", ["-p", resolveBackupDir(env)]);
   fileIO.write(backupConfiguredMarker(env), "shepherd-backup.timer enabled\n");
   run("systemctl", ["--user", "enable", "--now", "shepherd-backup.timer"]);
-  // Kick one backup immediately — the timer's first scheduled run is at the next hour boundary, so
-  // without this a fresh box has no `.last-success` until then. (The staleness probe also has a
-  // marker-age grace, so this is belt-and-suspenders against a spurious first alert. #1080)
-  run("systemctl", ["--user", "start", "shepherd-backup.service"]);
+  // No immediate `start shepherd-backup.service` here: on a fresh install the DB does not exist yet
+  // (the server is started below by update.sh), so a read-only snapshot would fail the oneshot and
+  // abort provision. update.sh runs its own GUARDED kick once deps are built, and the staleness
+  // probe's marker-age grace already covers the spurious-first-alert race. #1080
   // update.sh does deps → UI build → restart (starts the now-enabled unit) → health.
   log("building + starting via deploy/update.sh");
   run("bash", [join(repo, "deploy", "update.sh")], { env: buildEnv });

--- a/deploy/provision.ts
+++ b/deploy/provision.ts
@@ -21,6 +21,7 @@ import { join } from "node:path";
 import { BUN_MIN_VERSION, NODE_MIN_VERSION, HERDR_MIN_VERSION } from "../src/config";
 import { compareSemver } from "../src/herdr-update";
 import { autoFixCommandFor } from "../src/remediations";
+import { resolveBackupDir, backupConfiguredMarker } from "../src/backup-paths";
 
 // ── pure types + data ─────────────────────────────────────────────────────────
 
@@ -267,11 +268,23 @@ export function installService(
   // hardcoded %h/Work/shepherd. Default repo (~/Work/shepherd) ⇒ identical output.
   const unitSrc = fileIO.read(join(repo, "deploy", "shepherd.service"));
   fileIO.write(join(unitDir, "shepherd.service"), templateUnit(unitSrc, repo));
+  // Hourly backup units (#1080), installed alongside the main service. The .service carries a
+  // WorkingDirectory to template; the .timer has none, so it copies verbatim.
+  const backupSvc = fileIO.read(join(repo, "deploy", "shepherd-backup.service"));
+  fileIO.write(join(unitDir, "shepherd-backup.service"), templateUnit(backupSvc, repo));
+  const backupTimer = fileIO.read(join(repo, "deploy", "shepherd-backup.timer"));
+  fileIO.write(join(unitDir, "shepherd-backup.timer"), backupTimer);
   run("systemctl", ["--user", "daemon-reload"]);
   const user = env.USER;
   if (!user) throw new Error("cannot enable-linger: $USER is not set");
   run("loginctl", ["enable-linger", user]);
   run("systemctl", ["--user", "enable", "shepherd"]);
+  // Mark this host as backup-EXPECTED before enabling the timer: the server's staleness check
+  // treats marker-present + no recent success as a failure, so a box whose backup is broken from
+  // the very first run is flagged (a no-marker host, e.g. macOS/core-only, stays silent).
+  run("mkdir", ["-p", resolveBackupDir(env)]);
+  fileIO.write(backupConfiguredMarker(env), "shepherd-backup.timer enabled\n");
+  run("systemctl", ["--user", "enable", "--now", "shepherd-backup.timer"]);
   // update.sh does deps → UI build → restart (starts the now-enabled unit) → health.
   log("building + starting via deploy/update.sh");
   run("bash", [join(repo, "deploy", "update.sh")], { env: buildEnv });

--- a/deploy/shepherd-backup.service
+++ b/deploy/shepherd-backup.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Shepherd — hourly SQLite backup (VACUUM INTO → integrity_check → gzip → GFS rotation)
+Documentation=https://github.com/erwins-enkel/shepherd
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/Work/shepherd
+ExecStart=%h/.bun/bin/bun run scripts/backup.ts
+
+# bun lives in ~/.bun/bin; keep the same resolvable PATH as shepherd.service
+Environment=PATH=%h/.bun/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+# optional overrides (SHEPHERD_DB, SHEPHERD_BACKUP_DIR) — shared with the main unit; file may be absent
+EnvironmentFile=-%h/.shepherd/env
+
+# Output goes to journald: `journalctl --user -u shepherd-backup`

--- a/deploy/shepherd-backup.timer
+++ b/deploy/shepherd-backup.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Shepherd — hourly SQLite backup timer
+Documentation=https://github.com/erwins-enkel/shepherd
+
+[Timer]
+OnCalendar=hourly
+# Run on boot if the host was off when a window was due (a missed hour is still worth catching up).
+Persistent=true
+# A oneshot service + a single timer means runs can never overlap; an hourly VACUUM INTO of a small
+# DB finishes far under an hour.
+
+[Install]
+WantedBy=timers.target

--- a/deploy/shepherd-restore.sh
+++ b/deploy/shepherd-restore.sh
@@ -21,6 +21,13 @@ die() {
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO"
 
+# Mirror the systemd units' EnvironmentFile=-%h/.shepherd/env so a SHEPHERD_DB / SHEPHERD_BACKUP_DIR
+# override resolves to the SAME paths the server + backup script use — else we'd restore to the
+# wrong DB / list the wrong backup dir (#1080).
+set -a
+[ -f "$HOME/.shepherd/env" ] && . "$HOME/.shepherd/env"
+set +a
+
 # Resolve DB + backup dir through the shared resolver so this never drifts from the backup script.
 DB="$(bun -e 'import {resolveDbPath} from "./src/backup-paths"; process.stdout.write(resolveDbPath())')"
 BACKUP_DIR="$(bun -e 'import {resolveBackupDir} from "./src/backup-paths"; process.stdout.write(resolveBackupDir())')"

--- a/deploy/shepherd-restore.sh
+++ b/deploy/shepherd-restore.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Restore Shepherd's SQLite DB from a backup snapshot (#1080).
+#
+#   deploy/shepherd-restore.sh              # list snapshots, then pick one
+#   deploy/shepherd-restore.sh <snapshot>   # restore a specific shepherd-*.db.gz
+#
+# A backup you've never restored isn't a backup. This stops the service (and the backup timer, so a
+# mid-restore firing can't open the DB), copies the current DB aside as a safety net, removes any
+# hot rollback-journal/WAL sidecars (a crash-left journal would otherwise be REPLAYED into the
+# freshly-restored file → re-corruption), gunzips the snapshot into place, verifies its integrity,
+# and restarts.
+set -euo pipefail
+
+note() { printf '\033[36m▸ %s\033[0m\n' "$*"; }
+warn() { printf '\033[33m! %s\033[0m\n' "$*"; }
+die() {
+  printf '\033[31m✗ %s\033[0m\n' "$*" >&2
+  exit 1
+}
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+# Resolve DB + backup dir through the shared resolver so this never drifts from the backup script.
+DB="$(bun -e 'import {resolveDbPath} from "./src/backup-paths"; process.stdout.write(resolveDbPath())')"
+BACKUP_DIR="$(bun -e 'import {resolveBackupDir} from "./src/backup-paths"; process.stdout.write(resolveBackupDir())')"
+
+SNAP="${1:-}"
+if [[ -z "$SNAP" ]]; then
+  note "available snapshots in $BACKUP_DIR (newest first):"
+  mapfile -t SNAPS < <(ls -1 "$BACKUP_DIR"/shepherd-*.db.gz 2>/dev/null | sort -r)
+  [[ ${#SNAPS[@]} -gt 0 ]] || die "no snapshots found in $BACKUP_DIR"
+  for i in "${!SNAPS[@]}"; do printf '  [%d] %s\n' "$i" "$(basename "${SNAPS[$i]}")"; done
+  read -r -p "restore which index? " IDX
+  [[ "$IDX" =~ ^[0-9]+$ && -n "${SNAPS[$IDX]:-}" ]] || die "invalid selection"
+  SNAP="${SNAPS[$IDX]}"
+fi
+[[ -f "$SNAP" ]] || die "snapshot not found: $SNAP"
+
+warn "About to OVERWRITE $DB with $(basename "$SNAP")."
+read -r -p "Type 'restore' to proceed: " CONFIRM
+[[ "$CONFIRM" == "restore" ]] || die "aborted"
+
+# Stop the server AND the backup timer so nothing holds/opens the DB mid-restore.
+note "stopping shepherd + backup timer"
+systemctl --user stop shepherd shepherd-backup.timer || warn "stop returned non-zero (already stopped?)"
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+if [[ -f "$DB" ]]; then
+  note "copying current DB aside → $DB.pre-restore-$TS"
+  cp "$DB" "$DB.pre-restore-$TS"
+fi
+
+# A hot journal/WAL left by a crash would be rolled back INTO the restored file on next open.
+note "removing stale rollback-journal / WAL sidecars"
+rm -f "$DB-journal" "$DB-wal" "$DB-shm"
+
+note "restoring snapshot"
+gunzip -c "$SNAP" >"$DB"
+
+note "verifying restored DB integrity"
+INTEGRITY="$(bun -e "import {Database} from 'bun:sqlite'; const d=new Database(process.argv[1],{readonly:true}); const r=d.query('PRAGMA integrity_check').all(); process.stdout.write(JSON.stringify(r)); d.close();" "$DB")"
+[[ "$INTEGRITY" == '[{"integrity_check":"ok"}]' ]] || die "integrity_check FAILED on restored DB: $INTEGRITY (your previous DB is at $DB.pre-restore-$TS)"
+
+note "starting shepherd + backup timer"
+systemctl --user start shepherd
+systemctl --user enable --now shepherd-backup.timer
+
+printf '\033[32m✓ restored %s → %s (integrity ok)\033[0m\n' "$(basename "$SNAP")" "$DB"
+printf '  previous DB preserved at %s\n' "$DB.pre-restore-$TS"

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -42,6 +42,29 @@ bun install
 note "building UI"
 (cd ui && bun run build)
 
+# ── sync backup units (#1080) ─────────────────────────────────────────────────
+# update.sh historically only restarts; provision.ts installs units only on a fresh box. So an
+# existing live host would never pick up the hourly-backup timer. Re-sync it here, idempotently, so
+# every `bun run update` self-heals: template the .service (WorkingDirectory → this checkout), copy
+# the .timer verbatim, reload, enable --now, and (re)write the backup-expected marker. Soft-skip
+# where there's no systemd user manager (macOS / core-only) — those hosts get no backups by design.
+if command -v systemctl >/dev/null 2>&1 && systemctl --user show-environment >/dev/null 2>&1; then
+  note "syncing backup timer units"
+  UNIT_DIR="$HOME/.config/systemd/user"
+  mkdir -p "$UNIT_DIR"
+  sed "s|^WorkingDirectory=.*|WorkingDirectory=${REPO}|" \
+    "$REPO/deploy/shepherd-backup.service" >"$UNIT_DIR/shepherd-backup.service"
+  cp "$REPO/deploy/shepherd-backup.timer" "$UNIT_DIR/shepherd-backup.timer"
+  # Resolve the backup dir via the shared resolver so the marker can't drift from the script.
+  BACKUP_DIR="$(bun -e 'import {resolveBackupDir} from "./src/backup-paths"; process.stdout.write(resolveBackupDir())')"
+  mkdir -p "$BACKUP_DIR"
+  [[ -f "$BACKUP_DIR/.backup-configured" ]] || printf 'shepherd-backup.timer enabled\n' >"$BACKUP_DIR/.backup-configured"
+  systemctl --user daemon-reload
+  systemctl --user enable --now shepherd-backup.timer
+else
+  warn "no systemd user manager — skipping backup timer sync (no automated backups on this host)"
+fi
+
 # ── restart ───────────────────────────────────────────────────────────────────
 note "restarting $UNIT"
 systemctl --user restart "$UNIT"

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -56,11 +56,18 @@ if command -v systemctl >/dev/null 2>&1 && systemctl --user show-environment >/d
     "$REPO/deploy/shepherd-backup.service" >"$UNIT_DIR/shepherd-backup.service"
   cp "$REPO/deploy/shepherd-backup.timer" "$UNIT_DIR/shepherd-backup.timer"
   # Resolve the backup dir via the shared resolver so the marker can't drift from the script.
-  BACKUP_DIR="$(bun -e 'import {resolveBackupDir} from "./src/backup-paths"; process.stdout.write(resolveBackupDir())')"
+  # Source ~/.shepherd/env (the units' EnvironmentFile) in a SUBSHELL first, so a SHEPHERD_DB /
+  # SHEPHERD_BACKUP_DIR override resolves to the SAME dir the server reads — else the marker lands
+  # where the server never looks and staleness alerting is silently off (#1080). Subshell-scoped so
+  # the override can't leak into the rest of this deploy script.
+  BACKUP_DIR="$(set -a; [ -f "$HOME/.shepherd/env" ] && . "$HOME/.shepherd/env"; set +a; bun -e 'import {resolveBackupDir} from "./src/backup-paths"; process.stdout.write(resolveBackupDir())')"
   mkdir -p "$BACKUP_DIR"
   [[ -f "$BACKUP_DIR/.backup-configured" ]] || printf 'shepherd-backup.timer enabled\n' >"$BACKUP_DIR/.backup-configured"
   systemctl --user daemon-reload
   systemctl --user enable --now shepherd-backup.timer
+  # Kick one backup now (the timer's first scheduled run is at the next hour boundary), so a freshly
+  # adopted host has a .last-success well before the daily-sweep staleness probe runs (#1080).
+  systemctl --user start shepherd-backup.service || warn "initial backup run did not start"
 else
   warn "no systemd user manager — skipping backup timer sync (no automated backups on this host)"
 fi

--- a/docs-site/src/content/docs/getting-started.md
+++ b/docs-site/src/content/docs/getting-started.md
@@ -38,8 +38,8 @@ before running it. Read it first:
 
 | OS | Mode | Notes |
 | --- | --- | --- |
-| **Linux** (systemd + unprivileged userns) | Full | The only fully supported target — sandbox membrane, egress allowlist, auto-drain, Tailscale-serve previews, and the systemd user unit. |
-| **macOS** | Core-only / degraded | Installs prereqs, clones, builds the UI, prints a loud degraded banner. **No** sandbox, egress allowlist, auto-drain, previews, or systemd unit — run `bun run start` manually. |
+| **Linux** (systemd + unprivileged userns) | Full | The only fully supported target — sandbox membrane, egress allowlist, auto-drain, Tailscale-serve previews, the systemd user unit, and the hourly DB backup timer. |
+| **macOS** | Core-only / degraded | Installs prereqs, clones, builds the UI, prints a loud degraded banner. **No** sandbox, egress allowlist, auto-drain, previews, systemd unit, or automated backups — run `bun run start` manually. |
 | **Windows** | Not supported | The installer refuses and routes you to **WSL2**. |
 
 ### Installer environment knobs

--- a/docs-site/src/content/docs/operating.md
+++ b/docs-site/src/content/docs/operating.md
@@ -54,6 +54,28 @@ It is idempotent and safe to re-run — sessions survive the restart (herdr owns
 PTYs). UI-only changes don't strictly need it: a fresh `cd ui && bun run build` is
 served on the next request, since the core reads `ui/build` from disk per request.
 
+## Backups & restore
+
+On Linux the installer/provision step also enables a **second** systemd user
+timer — `shepherd-backup.timer` (`OnCalendar=hourly`) — that snapshots the SQLite
+state DB out-of-process from the server (read-only `VACUUM INTO` → integrity check
+→ gzip → atomic rename → GFS rotation). Snapshots land in `~/.shepherd/backups/`
+by default (override `SHEPHERD_BACKUP_DIR`).
+
+```bash
+systemctl --user status shepherd-backup.timer   # check the timer
+journalctl --user -u shepherd-backup             # per-run logs
+deploy/shepherd-restore.sh                       # list snapshots, then restore one
+deploy/shepherd-restore.sh <file>                # restore a specific shepherd-*.db.gz
+```
+
+The server's daily sweep also runs a read-only **staleness probe**: on a host
+that's expected to back up, if the newest snapshot is missing or older than 3h it
+logs a warning, records a durable `backup_stale` signal, and sends a best-effort
+web-push alert. macOS / core-only hosts have no backup timer and stay silent. Full
+details are in the
+[backups runbook](https://github.com/erwins-enkel/shepherd/blob/main/docs/backups.md).
+
 ## Host tuning — tmpfs inodes
 
 Shepherd keeps spawned agents' Node compile cache **off** the `/tmp` tmpfs and runs

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -14,6 +14,7 @@ lines), read by the systemd unit if present.
 | `SHEPHERD_PORT` | `7330` | HTTP/WS listen port |
 | `SHEPHERD_HOST` | `127.0.0.1` | Bind address; loopback-only by default (set `0.0.0.0` to expose all NICs) |
 | `SHEPHERD_DB` | `~/.shepherd/shepherd.db` | SQLite session store path |
+| `SHEPHERD_BACKUP_DIR` | `~/.shepherd/backups` (next to the DB) | Destination dir for the automated hourly SQLite backups (Linux backup timer); see [Operating Shepherd](/operating/) |
 | `SHEPHERD_REPO_ROOT` | `~` (home) | Repos must live under this root (spawn is confined to it) |
 | `SHEPHERD_ALLOWED_HOSTS` | `localhost,127.0.0.1,::1,[::1]` | Comma-separated origin hostnames allowed for writes + WS (CSRF/CSWSH guard) |
 | `SHEPHERD_PASSWORD` | _(auto-generated)_ | Single-operator login password. When set it's authoritative — argon2id-hashed and re-seeded into the persisted hash every boot. Unset → the persisted hash is reused, or (first boot) a strong password is generated, hashed, persisted, and printed to the log **once**. The browser exchanges it for an HMAC-signed session cookie that gates every HTTP route plus the `/events` + `/pty` WebSocket channels |

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -61,9 +61,12 @@ Counts are tunable constants (`GFS` in `scripts/backup.ts`).
 ## Staleness alerting
 
 The server's once-daily sweep does a **read-only** check: if `.backup-configured` exists (so the
-host is _expected_ to back up) and `.last-success` is absent or older than 3h, it emits a guaranteed
-log line, a durable `backup_stale` signal, and a best-effort web push. This catches a hard run
-failure, a box broken from its first run, and a silently-dead timer alike.
+host is _expected_ to back up), the marker is **itself older than 3h** (a grace window so a
+just-configured host isn't flagged before its first backup runs), and `.last-success` is absent or
+older than 3h, it emits a guaranteed log line, a durable `backup_stale` signal, and a best-effort
+web push. This catches a hard run failure, a box broken from its first run, and a silently-dead
+timer alike. (Provision/update also kick one backup immediately on enable, so a healthy host has a
+`.last-success` within seconds.)
 
 > **Detection latency.** The probe only runs once per daily sweep, so worst-case detection is ~24h —
 > the 3h threshold defines _stale_, not how fast it's noticed. A host with **no** marker (macOS /

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -1,0 +1,92 @@
+# Backups & restore
+
+Shepherd's entire state lives in one SQLite file (`~/.shepherd/shepherd.db`). This doc covers the
+automated hourly backups and how to restore from one. (Issue #1080.)
+
+## What runs
+
+A systemd **user** timer (`shepherd-backup.timer`, `OnCalendar=hourly`, `Persistent=true`) triggers
+a oneshot service that runs `scripts/backup.ts` — out-of-process from the server, so snapshot I/O
+never touches the single Bun event loop.
+
+Each run:
+
+1. Opens the live DB **read-only** and `VACUUM INTO`s a temp snapshot — atomic and transactionally
+   consistent on a running DB, compacted, and emitting no `-wal`/`-shm` sidecars.
+2. Runs `PRAGMA integrity_check` on the raw snapshot. A failing snapshot is **discarded** (the run
+   exits non-zero) — a corrupt snapshot is never kept.
+3. gzips it (`Bun.gzipSync`) to a temp sibling, then **atomically renames** it to
+   `shepherd-<YYYYMMDDTHHmmssZ>.db.gz` — a crashed run never leaves a half-file.
+4. Applies **GFS rotation**.
+5. Writes `.last-success` (ISO timestamp) and appends a line to `backup.log`.
+
+### Locking
+
+Both the server connection (`src/store.ts`) and the backup connection set `PRAGMA busy_timeout =
+5000`. `VACUUM INTO` holds a shared read lock for its (sub-second) duration; the timeout makes a
+concurrent server write **wait** for it rather than throwing `SQLITE_BUSY`. The wait is bounded by
+the snapshot duration on a small DB.
+
+## Layout & configuration
+
+|                           |                                                         |
+| ------------------------- | ------------------------------------------------------- |
+| DB                        | `~/.shepherd/shepherd.db` — override `SHEPHERD_DB`      |
+| Backups                   | `~/.shepherd/backups/` — override `SHEPHERD_BACKUP_DIR` |
+| Per-run log               | `~/.shepherd/backups/backup.log`                        |
+| Last success              | `~/.shepherd/backups/.last-success`                     |
+| "Backups expected" marker | `~/.shepherd/backups/.backup-configured`                |
+| Unit logs                 | `journalctl --user -u shepherd-backup`                  |
+
+Overrides go in `~/.shepherd/env` (read by both `shepherd.service` and `shepherd-backup.service`).
+
+> **Same-disk caveat.** Backups land on the same disk as the DB by default — this protects against
+> corruption and accidental deletion, **not** disk/host failure (out of scope for v1). Point
+> `SHEPHERD_BACKUP_DIR` at a different mount for that.
+
+### GFS retention
+
+A union keep-set, newest-per-bucket — everything else is pruned each run:
+
+| Tier    | Keep | Bucket                                      |
+| ------- | ---- | ------------------------------------------- |
+| Hourly  | 48   | newest 48 overall                           |
+| Daily   | 14   | newest per UTC day, 14 most-recent days     |
+| Weekly  | 8    | newest per ISO week, 8 most-recent weeks    |
+| Monthly | 12   | newest per UTC month, 12 most-recent months |
+
+~82 small compacted files; monthlies reach ~1 year, outlasting the 30/60/90-day retention prunes.
+Counts are tunable constants (`GFS` in `scripts/backup.ts`).
+
+## Staleness alerting
+
+The server's once-daily sweep does a **read-only** check: if `.backup-configured` exists (so the
+host is _expected_ to back up) and `.last-success` is absent or older than 3h, it emits a guaranteed
+log line, a durable `backup_stale` signal, and a best-effort web push. This catches a hard run
+failure, a box broken from its first run, and a silently-dead timer alike.
+
+> **Detection latency.** The probe only runs once per daily sweep, so worst-case detection is ~24h —
+> the 3h threshold defines _stale_, not how fast it's noticed. A host with **no** marker (macOS /
+> core-only, which has no systemd timer) stays silent. If no push device is subscribed, the alert is
+> still recorded in `shepherd.log` and the signal row.
+
+## Restore
+
+> A backup you've never restored isn't a backup.
+
+```sh
+deploy/shepherd-restore.sh            # list snapshots, then pick one
+deploy/shepherd-restore.sh <file>     # restore a specific shepherd-*.db.gz
+```
+
+It stops `shepherd` **and** `shepherd-backup.timer` (so nothing reopens the DB mid-restore), copies
+the current DB aside to `shepherd.db.pre-restore-<ts>`, removes any stale `*-journal`/`*-wal`/`*-shm`
+sidecars (a crash-left rollback journal would otherwise be replayed into the restored file →
+re-corruption), gunzips the snapshot into place, verifies `integrity_check = ok`, and restarts. If
+the integrity check fails it aborts and leaves your previous DB at the `.pre-restore-<ts>` copy.
+
+## macOS / core-only
+
+No systemd ⇒ no backup timer ⇒ no `.backup-configured` marker ⇒ no automated backups and no
+staleness alerts. Linux is the primary deployment target; on macOS, snapshot manually with
+`SHEPHERD_DB=… bun run scripts/backup.ts` if needed.

--- a/scripts/backup.ts
+++ b/scripts/backup.ts
@@ -38,6 +38,11 @@ export const BUSY_TIMEOUT_MS = 5000;
 export const GFS = { hourly: 48, daily: 14, weekly: 8, monthly: 12 } as const;
 
 const FILE_RE = /^shepherd-(\d{8}T\d{6}Z)\.db\.gz$/;
+// In-progress artifacts a crashed run can orphan: the uncompressed snapshot (`.shepherd-<ts>.db.tmp`)
+// and the pre-rename gzip (`shepherd-<ts>.db.gz.tmp`). Neither matches FILE_RE, so rotation would
+// never reap them — reap them explicitly. Safe because Type=oneshot + a single timer means runs
+// never overlap, so any leftover .tmp is from a dead earlier run, not a live one.
+const TMP_RE = /^(?:\.shepherd-\d{8}T\d{6}Z\.db\.tmp|shepherd-\d{8}T\d{6}Z\.db\.gz\.tmp)$/;
 
 /** UTC timestamp → `YYYYMMDDTHHmmssZ` (lexically sortable, parseable). */
 export function formatTs(d: Date): string {
@@ -152,10 +157,13 @@ function compress(snapPath: string, outGz: string): void {
   renameSync(tmpGz, outGz);
 }
 
-/** Delete every snapshot the GFS classifier drops. */
+/** Delete every snapshot the GFS classifier drops, plus any orphaned in-progress temp files. */
 export function rotate(dir: string): void {
-  const files = readdirSync(dir).filter((f) => FILE_RE.test(f));
+  const entries = readdirSync(dir);
+  const files = entries.filter((f) => FILE_RE.test(f));
   for (const f of classifyRetention(files).delete) unlinkSync(join(dir, f));
+  // Reap temp artifacts orphaned by a crashed prior run (FILE_RE never matches them).
+  for (const f of entries.filter((f) => TMP_RE.test(f))) unlinkSync(join(dir, f));
 }
 
 async function main(): Promise<void> {

--- a/scripts/backup.ts
+++ b/scripts/backup.ts
@@ -1,0 +1,191 @@
+#!/usr/bin/env bun
+/**
+ * Hourly SQLite backup for Shepherd's single source of truth (#1080).
+ *
+ * Runs OUT-OF-PROCESS (systemd-user `shepherd-backup.timer` → this script), never on the server's
+ * single Bun event loop. Flow:
+ *   1. `VACUUM INTO` a temp snapshot — atomic + transactionally consistent on the LIVE db (read
+ *      lock only), compacted, and crucially emits no `-wal/-shm` artifacts. Opened read-only with
+ *      a `busy_timeout` so a concurrent server write commit waits rather than throwing SQLITE_BUSY
+ *      (the server connection carries the same pragma — see src/store.ts). Phase-0 spike confirmed
+ *      bun:sqlite accepts `VACUUM INTO ?` on a read-only connection.
+ *   2. `PRAGMA integrity_check` on the raw snapshot BEFORE compression — a failing snapshot is
+ *      discarded and never kept.
+ *   3. gzip (Bun built-in) → write to a temp sibling → atomic rename into place.
+ *   4. GFS rotation (48 hourly / 14 daily / 8 weekly / 12 monthly).
+ *   5. Record `.last-success` + append to `backup.log`. Any failure exits non-zero (journald logs).
+ *
+ * The pure `classifyRetention` is the unit-tested core (test/backup.test.ts).
+ */
+import { Database } from "bun:sqlite";
+import { gzipSync } from "bun";
+import {
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { resolveBackupDir, resolveDbPath, lastSuccessMarker } from "../src/backup-paths";
+
+/** Busy-timeout (ms) for both backup + server connections (kept equal to src/store.ts). */
+export const BUSY_TIMEOUT_MS = 5000;
+
+/** GFS retention tiers: keep the newest snapshot per bucket for the N most-recent buckets. */
+export const GFS = { hourly: 48, daily: 14, weekly: 8, monthly: 12 } as const;
+
+const FILE_RE = /^shepherd-(\d{8}T\d{6}Z)\.db\.gz$/;
+
+/** UTC timestamp → `YYYYMMDDTHHmmssZ` (lexically sortable, parseable). */
+export function formatTs(d: Date): string {
+  const p = (n: number, w = 2) => String(n).padStart(w, "0");
+  return (
+    `${d.getUTCFullYear()}${p(d.getUTCMonth() + 1)}${p(d.getUTCDate())}` +
+    `T${p(d.getUTCHours())}${p(d.getUTCMinutes())}${p(d.getUTCSeconds())}Z`
+  );
+}
+
+/** Parse a snapshot filename back to a Date, or null if it isn't one of ours. */
+export function parseTs(filename: string): Date | null {
+  const m = FILE_RE.exec(filename);
+  if (!m || !m[1]) return null;
+  const s = m[1];
+  const d = new Date(
+    Date.UTC(
+      Number(s.slice(0, 4)),
+      Number(s.slice(4, 6)) - 1,
+      Number(s.slice(6, 8)),
+      Number(s.slice(9, 11)),
+      Number(s.slice(11, 13)),
+      Number(s.slice(13, 15)),
+    ),
+  );
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+const dayKey = (d: Date) => formatTs(d).slice(0, 8); // YYYYMMDD
+const monthKey = (d: Date) => formatTs(d).slice(0, 6); // YYYYMM
+/** ISO-8601 week key `YYYY-Www` (UTC). */
+export function weekKey(d: Date): string {
+  const t = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  // ISO: Thursday determines the week-year; week 1 contains Jan 4th.
+  const day = (t.getUTCDay() + 6) % 7; // Mon=0..Sun=6
+  t.setUTCDate(t.getUTCDate() - day + 3); // nearest Thursday
+  const firstThu = new Date(Date.UTC(t.getUTCFullYear(), 0, 4));
+  const firstDay = (firstThu.getUTCDay() + 6) % 7;
+  firstThu.setUTCDate(firstThu.getUTCDate() - firstDay + 3);
+  const week = 1 + Math.round((t.getTime() - firstThu.getTime()) / (7 * 86400000));
+  return `${t.getUTCFullYear()}-W${String(week).padStart(2, "0")}`;
+}
+
+/**
+ * Pure GFS classifier. Given snapshot filenames, return which to keep and which to delete.
+ * Keep = (newest 48 overall) ∪ (newest per day for 14 most-recent days) ∪ (newest per ISO week for
+ * 8 most-recent weeks) ∪ (newest per month for 12 most-recent months). Unparseable names are kept
+ * defensively (never delete what we can't identify).
+ */
+export function classifyRetention(filenames: string[]): { keep: string[]; delete: string[] } {
+  const parsed = filenames
+    .map((f) => ({ f, d: parseTs(f) }))
+    .filter((x): x is { f: string; d: Date } => x.d !== null)
+    .sort((a, b) => b.d.getTime() - a.d.getTime()); // newest first
+
+  const keep = new Set<string>();
+  // unparseable → keep, never delete
+  for (const f of filenames) if (parseTs(f) === null) keep.add(f);
+
+  // hourly: newest N overall
+  for (const { f } of parsed.slice(0, GFS.hourly)) keep.add(f);
+
+  // per-tier: walk newest-first, keep the first (newest) file of each new bucket up to `count`
+  const tier = (keyFn: (d: Date) => string, count: number) => {
+    const seen = new Set<string>();
+    for (const { f, d } of parsed) {
+      const k = keyFn(d);
+      if (seen.has(k)) continue;
+      if (seen.size >= count) continue; // already retained the `count` most-recent buckets
+      seen.add(k);
+      keep.add(f);
+    }
+  };
+  tier(dayKey, GFS.daily);
+  tier(weekKey, GFS.weekly);
+  tier(monthKey, GFS.monthly);
+
+  return {
+    keep: filenames.filter((f) => keep.has(f)),
+    delete: filenames.filter((f) => !keep.has(f)),
+  };
+}
+
+/** Open the live DB read-only and `VACUUM INTO` a temp snapshot (consistent on a live db). */
+export function snapshot(dbPath: string, tmpPath: string): void {
+  const src = new Database(dbPath, { readonly: true });
+  try {
+    src.run(`PRAGMA busy_timeout = ${BUSY_TIMEOUT_MS}`);
+    src.run("VACUUM INTO ?", [tmpPath]);
+  } finally {
+    src.close();
+  }
+}
+
+/** Throw unless the snapshot passes `PRAGMA integrity_check` (=> caller discards it). */
+export function verifyIntegrity(snapPath: string): void {
+  const db = new Database(snapPath, { readonly: true });
+  try {
+    const rows = db.query("PRAGMA integrity_check").all() as { integrity_check: string }[];
+    if (rows.length !== 1 || rows[0]?.integrity_check !== "ok") {
+      throw new Error(`integrity_check failed: ${JSON.stringify(rows)}`);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+/** gzip the snapshot and atomically rename into place. */
+function compress(snapPath: string, outGz: string): void {
+  const tmpGz = `${outGz}.tmp`;
+  writeFileSync(tmpGz, gzipSync(readFileSync(snapPath)));
+  renameSync(tmpGz, outGz);
+}
+
+/** Delete every snapshot the GFS classifier drops. */
+export function rotate(dir: string): void {
+  const files = readdirSync(dir).filter((f) => FILE_RE.test(f));
+  for (const f of classifyRetention(files).delete) unlinkSync(join(dir, f));
+}
+
+async function main(): Promise<void> {
+  const dbPath = resolveDbPath();
+  const dir = resolveBackupDir();
+  mkdirSync(dir, { recursive: true });
+
+  const ts = formatTs(new Date());
+  const snapTmp = join(dir, `.shepherd-${ts}.db.tmp`);
+  const outGz = join(dir, `shepherd-${ts}.db.gz`);
+
+  try {
+    snapshot(dbPath, snapTmp);
+    verifyIntegrity(snapTmp);
+    compress(snapTmp, outGz);
+  } finally {
+    rmSync(snapTmp, { force: true });
+  }
+
+  rotate(dir);
+
+  const nowIso = new Date().toISOString();
+  writeFileSync(lastSuccessMarker(), `${nowIso}\n`);
+  writeFileSync(join(dir, "backup.log"), `${nowIso} ok ${outGz}\n`, { flag: "a" });
+}
+
+// Only run when invoked directly (not when imported by tests).
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(`[backup] FAILED: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}

--- a/src/backup-paths.ts
+++ b/src/backup-paths.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure, side-effect-free path resolution for the SQLite backup feature (#1080).
+ *
+ * Deliberately self-contained: the backup *script* (`scripts/backup.ts`) must NOT import
+ * `src/config.ts`, which eagerly runs `loadForgeMap`/`resolveNodeBin` and other side effects at
+ * module load. Both the script and the server's staleness check import THIS module so the backup
+ * directory default can never drift between writer and reader.
+ */
+import { dirname, join } from "node:path";
+
+/** Absolute path to the SQLite DB. Mirrors `src/config.ts`'s `SHEPHERD_DB` resolution exactly. */
+export function resolveDbPath(env: NodeJS.ProcessEnv = process.env): string {
+  return env.SHEPHERD_DB ?? `${env.HOME}/.shepherd/shepherd.db`;
+}
+
+/** Backup destination dir. `SHEPHERD_BACKUP_DIR` override, else `<dir-of-db>/backups` (mirrors
+ *  how forges.json sits next to the db). */
+export function resolveBackupDir(env: NodeJS.ProcessEnv = process.env): string {
+  return env.SHEPHERD_BACKUP_DIR ?? join(dirname(resolveDbPath(env)), "backups");
+}
+
+/** Marker written when the backup timer is enabled (provision/update). Its presence is what tells
+ *  the server a host is *expected* to have backups — so a box with zero successful runs is still
+ *  flagged stale, while a macOS/core-only host (no timer, no marker) stays silent. */
+export function backupConfiguredMarker(env: NodeJS.ProcessEnv = process.env): string {
+  return join(resolveBackupDir(env), ".backup-configured");
+}
+
+/** Timestamp of the most recent successful backup (ISO string inside). */
+export function lastSuccessMarker(env: NodeJS.ProcessEnv = process.env): string {
+  return join(resolveBackupDir(env), ".last-success");
+}

--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -17,9 +17,13 @@ import {
 const PROPOSALS_FILE = ".shepherd-learnings.json";
 
 /** Signal kinds the learnings distiller does NOT mine for code-review patterns.
- *  `egress_drop` is a security/operational alert (a blocked-host name) — feeding it to
- *  the rule-proposal LLM would pollute the corpus and count toward the distill threshold. */
-const NON_LEARNING_SIGNAL_KINDS: ReadonlySet<SignalKind> = new Set<SignalKind>(["egress_drop"]);
+ *  `egress_drop` (a blocked-host name) and `backup_stale` (#1080, a host-global backup-health
+ *  alert) are operational, not code-review signals — feeding them to the rule-proposal LLM would
+ *  pollute the corpus and count toward the distill threshold. */
+const NON_LEARNING_SIGNAL_KINDS: ReadonlySet<SignalKind> = new Set<SignalKind>([
+  "egress_drop",
+  "backup_stale",
+]);
 
 /**
  * Prefix for ephemeral distiller agent names. Each run appends the first 8 chars of its

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, existsSync, readdirSync, statSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import {
   config,
@@ -46,6 +47,7 @@ import { HerdrUsageProbe } from "./usage-probe";
 import { sweepStaging, STAGING_TTL_MS } from "./uploads";
 import { validateRoot } from "./dirs";
 import { bootstrapAuth } from "./operator-auth";
+import { backupConfiguredMarker, lastSuccessMarker } from "./backup-paths";
 import { UpdateService } from "./update";
 import { HerdrUpdateService } from "./herdr-update";
 import { DiagnosticsService } from "./diagnostics";
@@ -1435,6 +1437,59 @@ setInterval(() => {
 const gitignoreAdopter = new GitignoreAdopter({ worktree, resolveForge });
 // Daily: prune archived sessions, prune old signals, then consider a distill per repo
 // with enough recent signal.
+// Backups (#1080) are considered stale once the newest successful snapshot is older than this.
+// Tunable default — NOT load-bearing. Note: this is only SAMPLED once per daily sweep, so the
+// worst-case detection latency is ~24h regardless of the threshold.
+const BACKUP_STALENESS_MS = 3 * 60 * 60 * 1000;
+const HOST_SIGNAL_REPO = "__host__"; // sentinel repoPath for host-global (non-repo) signals
+
+/**
+ * Read-only staleness probe for the external backup timer. Runs inside the daily sweep so no
+ * snapshot I/O ever touches the event loop. A host is only checked if it's *expected* to back up:
+ * provision/update writes a `.backup-configured` marker when it enables the timer, so a macOS /
+ * core-only box (no marker) stays silent, while a Linux box whose backup is broken from its very
+ * first run (marker present, no `.last-success`) IS flagged. Alerts via three channels: a
+ * guaranteed log line (visible even with no push subscription), a durable `backup_stale` signal
+ * row, and a best-effort web push.
+ */
+const checkBackupStaleness = async (): Promise<void> => {
+  try {
+    await readFile(backupConfiguredMarker(), "utf8");
+  } catch {
+    return; // no marker → backups never configured on this host → stay silent
+  }
+  let ageMs: number | null = null;
+  try {
+    const iso = (await readFile(lastSuccessMarker(), "utf8")).trim();
+    const ts = Date.parse(iso);
+    if (!Number.isNaN(ts)) ageMs = Date.now() - ts;
+  } catch {
+    ageMs = null; // marker present but never a successful run
+  }
+  const stale = ageMs === null || ageMs > BACKUP_STALENESS_MS;
+  if (!stale) return;
+  const staleHours = ageMs === null ? null : Math.floor(ageMs / (60 * 60 * 1000));
+  console.warn(
+    `[backup] STALE: ${ageMs === null ? "no successful backup yet" : `newest snapshot ~${staleHours}h old`} — the backup timer may be failing.`,
+  );
+  store.addSignal({
+    repoPath: HOST_SIGNAL_REPO,
+    sessionId: null,
+    kind: "backup_stale",
+    payload: JSON.stringify({ ageMs, thresholdMs: BACKUP_STALENESS_MS }),
+  });
+  void push
+    .notify({
+      kind: "backup_stale",
+      sessionId: "",
+      tag: "backup-stale",
+      name: "backup",
+      staleHours: staleHours ?? undefined,
+      cooldownKey: "backup_stale",
+    })
+    .catch((err) => console.warn("[push] backup_stale notify failed:", err));
+};
+
 const runDailySweep = () => {
   if (maintenance.active) return;
   if (config.sessionHousekeepingEnabled)
@@ -1504,6 +1559,8 @@ const runDailySweep = () => {
   // (force-removed/crashed) — archive() consumes the rest.
   store.pruneOrphanInjectedLearnings();
   fireTmpSweep("daily");
+  // Read-only backup-staleness probe (#1080); fire-and-forget so it never blocks the sweep.
+  void checkBackupStaleness();
 };
 setTimeout(runDailySweep, 10_000); // once shortly after boot
 setInterval(runDailySweep, 24 * 60 * 60 * 1000);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, existsSync, readdirSync, statSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import {
   config,
@@ -1453,11 +1453,18 @@ const HOST_SIGNAL_REPO = "__host__"; // sentinel repoPath for host-global (non-r
  * row, and a best-effort web push.
  */
 const checkBackupStaleness = async (): Promise<void> => {
+  let markerAgeMs: number;
   try {
-    await readFile(backupConfiguredMarker(), "utf8");
+    const st = await stat(backupConfiguredMarker());
+    markerAgeMs = Date.now() - st.mtimeMs;
   } catch {
     return; // no marker → backups never configured on this host → stay silent
   }
+  // Grace window: a freshly-configured host (marker younger than the staleness threshold) hasn't had
+  // a chance to run its first backup — the timer's first fire is at the next hour boundary while the
+  // boot+10s sweep would otherwise see no `.last-success` and cry stale. Suppress until the window
+  // passes (provision/update also kick one backup immediately, so this is the race-free backstop).
+  if (markerAgeMs < BACKUP_STALENESS_MS) return;
   let ageMs: number | null = null;
   try {
     const iso = (await readFile(lastSuccessMarker(), "utf8")).trim();

--- a/src/push.ts
+++ b/src/push.ts
@@ -24,7 +24,8 @@ export interface PushPayload {
     | "learnings_retired"
     | "learnings_trialed"
     | "manual_steps"
-    | "ready";
+    | "ready"
+    | "backup_stale";
   tag: string;
 }
 
@@ -47,6 +48,8 @@ const KIND_CATEGORY: Record<PushPayload["kind"], PushCategory> = {
   learnings_trialed: "agent",
   manual_steps: "ci",
   ready: "agent",
+  // Host-global operational alert; ride the "agent" toggle like usage_limit/extra_credits.
+  backup_stale: "agent",
 };
 
 /** A notification described by intent, not text — localized per device at send time. */
@@ -65,7 +68,8 @@ export interface NotifyInput {
     | "learnings_retired"
     | "learnings_trialed"
     | "manual_steps"
-    | "ready";
+    | "ready"
+    | "backup_stale";
   sessionId: string;
   tag: string;
   name: string;
@@ -96,6 +100,8 @@ export interface NotifyInput {
   retiredCount?: number;
   /** For kind "learnings_trialed": how many proposals the auto-trial sweep promoted. */
   trialedCount?: number;
+  /** For kind "backup_stale": whole hours since the newest snapshot (for the body copy). */
+  staleHours?: number;
   /** Overrides the cooldown key (default `${kind}:${sessionId}`). */
   cooldownKey?: string;
 }
@@ -105,7 +111,12 @@ export type SendFn = (sub: PushSubInput, payload: string) => Promise<SendResult>
 type GenKeys = () => { publicKey: string; privateKey: string };
 
 /** Kinds that are allowed through even when reducedPushMode is on. */
-const REDUCED_ALLOWED = new Set<NotifyInput["kind"]>(["ready", "usage_limit", "extra_credits"]);
+const REDUCED_ALLOWED = new Set<NotifyInput["kind"]>([
+  "ready",
+  "usage_limit",
+  "extra_credits",
+  "backup_stale",
+]);
 
 const defaultSend: SendFn = (sub, payload) =>
   webpush.sendNotification(sub as webpush.PushSubscription, payload) as Promise<SendResult>;
@@ -154,6 +165,11 @@ const NOTIFY_TEXT = {
     readyBody: "Waiting on you for 5s — your turn.",
     manualStepsTitle: (name: string) => `${name} — manual steps`,
     manualStepsBody: "Ready to merge, but held until you ack the manual steps it needs.",
+    backupStaleTitle: "Backups stale",
+    backupStaleBody: (h: number | null) =>
+      h !== null
+        ? `No successful DB backup in ~${h}h — the backup timer may be failing.`
+        : "No successful DB backup yet — the backup timer may be failing.",
   },
   de: {
     doneTitle: (name: string) => `${name} — wartet`,
@@ -196,6 +212,11 @@ const NOTIFY_TEXT = {
     manualStepsTitle: (name: string) => `${name} — manuelle Schritte`,
     manualStepsBody:
       "Bereit zum Mergen, aber zurückgehalten, bis du die manuellen Schritte bestätigst.",
+    backupStaleTitle: "Backups veraltet",
+    backupStaleBody: (h: number | null) =>
+      h !== null
+        ? `Seit ~${h}h kein erfolgreiches DB-Backup — der Backup-Timer könnte fehlschlagen.`
+        : "Noch kein erfolgreiches DB-Backup — der Backup-Timer könnte fehlschlagen.",
   },
 } as const;
 
@@ -227,6 +248,13 @@ export function blockSummary(reason: BlockReason, locale: string = "en"): string
 /** Autopilot body: the agent's summary when present, else the locale fallback line. */
 function autopilotBody(summary: string | undefined, fallback: string): string {
   return summary && summary.trim() ? summary : fallback;
+}
+
+/** Learnings summary title/body (auto-retire vs auto-trial) — both background sweep pushes. */
+function learningsParts(t: NotifyText, input: NotifyInput): { title: string; body: string } {
+  return input.kind === "learnings_trialed"
+    ? { title: t.learningsTrialedTitle, body: t.learningsTrialedBody(input.trialedCount ?? 0) }
+    : { title: t.learningsRetiredTitle, body: t.learningsRetiredBody(input.retiredCount ?? 0) };
 }
 
 /** Merge-attention title/body: rebase-cap copy when capped, else the generic merge-error copy. */
@@ -298,21 +326,18 @@ export function buildPayload(input: NotifyInput, locale: string): PushPayload {
     case "extra_credits":
       return { ...base, title: t.extraCreditsTitle, body: extraCreditsBody(t, input) };
     case "learnings_retired":
-      return {
-        ...base,
-        title: t.learningsRetiredTitle,
-        body: t.learningsRetiredBody(input.retiredCount ?? 0),
-      };
     case "learnings_trialed":
-      return {
-        ...base,
-        title: t.learningsTrialedTitle,
-        body: t.learningsTrialedBody(input.trialedCount ?? 0),
-      };
+      return { ...base, ...learningsParts(t, input) };
     case "ready":
       return { ...base, title: t.readyTitle(input.name), body: t.readyBody };
     case "manual_steps":
       return { ...base, title: t.manualStepsTitle(input.name), body: t.manualStepsBody };
+    case "backup_stale":
+      return {
+        ...base,
+        title: t.backupStaleTitle,
+        body: t.backupStaleBody(input.staleHours ?? null),
+      };
     default:
       return {
         ...base,

--- a/src/store.ts
+++ b/src/store.ts
@@ -628,6 +628,12 @@ export class SessionStore implements CapStore, CreditStore {
     // Enforce FK constraints (enforces session_usage_bucket → session_usage cascade).
     // Must be set immediately after open, BEFORE any DDL — it is a no-op inside a transaction.
     this.db.run("PRAGMA foreign_keys = ON");
+    // Wait (don't throw) on a held lock. The external hourly backup (#1080) holds a SHARED read
+    // lock for the duration of its `VACUUM INTO`; without a busy_timeout a concurrent write commit
+    // here would get SQLITE_BUSY immediately and throw on the event loop. Snapshotting a small DB
+    // is sub-second, so the worst-case wait is a brief, bounded stall — not a crash. Keep equal to
+    // BUSY_TIMEOUT_MS in scripts/backup.ts.
+    this.db.run("PRAGMA busy_timeout = 5000");
     this.db.run(`CREATE TABLE IF NOT EXISTS sessions (
       id TEXT PRIMARY KEY, desig TEXT NOT NULL, name TEXT NOT NULL, prompt TEXT NOT NULL,
       repoPath TEXT NOT NULL, baseBranch TEXT NOT NULL, branch TEXT,

--- a/src/types.ts
+++ b/src/types.ts
@@ -539,7 +539,7 @@ export interface SessionPreviewServeEvent {
 }
 
 // ── learnings flywheel ────────────────────────────────────────────────────────
-export type SignalKind = "reply" | "critic" | "block" | "stall" | "egress_drop";
+export type SignalKind = "reply" | "critic" | "block" | "stall" | "egress_drop" | "backup_stale";
 
 export interface Signal {
   id: string;

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync, writeFileSync, readdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  classifyRetention,
+  formatTs,
+  parseTs,
+  weekKey,
+  snapshot,
+  verifyIntegrity,
+  rotate,
+  GFS,
+} from "../scripts/backup";
+
+const name = (d: Date) => `shepherd-${formatTs(d)}.db.gz`;
+const hoursAgo = (base: Date, h: number) => new Date(base.getTime() - h * 3600_000);
+
+describe("formatTs / parseTs round-trip", () => {
+  it("formats UTC and parses back", () => {
+    const d = new Date(Date.UTC(2026, 5, 25, 14, 30, 5));
+    expect(formatTs(d)).toBe("20260625T143005Z");
+    expect(parseTs(name(d))?.getTime()).toBe(d.getTime());
+  });
+  it("rejects foreign filenames", () => {
+    expect(parseTs("shepherd.db.gz")).toBeNull();
+    expect(parseTs("backup.log")).toBeNull();
+    expect(parseTs("shepherd-20260625T143005Z.db.gz.tmp")).toBeNull();
+  });
+});
+
+describe("weekKey (ISO-8601)", () => {
+  it("matches known ISO weeks", () => {
+    // 2026-01-01 is a Thursday → ISO week 2026-W01
+    expect(weekKey(new Date(Date.UTC(2026, 0, 1)))).toBe("2026-W01");
+    // 2025-12-29 (Mon) belongs to ISO week 2026-W01
+    expect(weekKey(new Date(Date.UTC(2025, 11, 29)))).toBe("2026-W01");
+  });
+});
+
+describe("classifyRetention (GFS)", () => {
+  const base = new Date(Date.UTC(2026, 5, 25, 0, 0, 0));
+  // 6-hourly snapshots across 400 days → exercises every tier + heavy deletion.
+  const files = Array.from({ length: 400 * 4 }, (_, i) => name(hoursAgo(base, i * 6)));
+
+  it("partitions input disjointly and completely", () => {
+    const { keep, delete: del } = classifyRetention(files);
+    expect(keep.length + del.length).toBe(files.length);
+    expect(new Set([...keep, ...del]).size).toBe(files.length);
+  });
+
+  it("never keeps more than the tier ceiling", () => {
+    const { keep } = classifyRetention(files);
+    expect(keep.length).toBeLessThanOrEqual(GFS.hourly + GFS.daily + GFS.weekly + GFS.monthly);
+  });
+
+  it("deletes the bulk of a long sparse history", () => {
+    const { keep, delete: del } = classifyRetention(files);
+    expect(del.length).toBeGreaterThan(keep.length); // 1600 in, ≤82 kept
+  });
+
+  it("keeps the newest snapshot and drops the oldest", () => {
+    const { keep, delete: del } = classifyRetention(files);
+    expect(keep).toContain(name(base)); // newest
+    expect(del).toContain(name(hoursAgo(base, 399 * 24))); // oldest
+  });
+
+  it("keeps every one of the newest 48 (hourly window)", () => {
+    const { keep } = classifyRetention(files);
+    for (let i = 0; i < GFS.hourly; i++) expect(keep).toContain(name(hoursAgo(base, i * 6)));
+  });
+
+  it("retains at least the 12 most-recent monthly buckets", () => {
+    const { keep } = classifyRetention(files);
+    const keptMonths = new Set(keep.map((f) => formatTs(parseTs(f)!).slice(0, 6)));
+    expect(keptMonths.size).toBeGreaterThanOrEqual(GFS.monthly);
+  });
+
+  it("keeps unparseable names defensively", () => {
+    const { keep, delete: del } = classifyRetention([
+      ...files.slice(0, 5),
+      "shepherd.db",
+      "weird.gz",
+    ]);
+    expect(keep).toContain("shepherd.db");
+    expect(keep).toContain("weird.gz");
+    expect(del).not.toContain("shepherd.db");
+  });
+
+  it("is deterministic", () => {
+    expect(classifyRetention(files)).toEqual(classifyRetention(files));
+  });
+});
+
+describe("snapshot + integrity + rotate (live db)", () => {
+  let dir: string;
+  let dbPath: string;
+  let live: Database;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "shep-backup-"));
+    dbPath = join(dir, "shepherd.db");
+    live = new Database(dbPath); // a connection stays OPEN to mimic the running server
+    live.run("PRAGMA foreign_keys = ON");
+    live.run("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)");
+    for (let i = 0; i < 500; i++) live.run("INSERT INTO t (v) VALUES (?)", ["row" + i]);
+  });
+  afterEach(() => {
+    live.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("snapshots a live db read-only and the snapshot passes integrity_check", () => {
+    const snap = join(dir, "snap.db");
+    snapshot(dbPath, snap);
+    expect(existsSync(snap)).toBe(true);
+    expect(() => verifyIntegrity(snap)).not.toThrow();
+    // the live writer can still commit afterwards
+    expect(() => live.run("INSERT INTO t (v) VALUES ('after')")).not.toThrow();
+  });
+
+  it("verifyIntegrity throws on a corrupt snapshot (=> caller discards it)", () => {
+    const bad = join(dir, "bad.db");
+    writeFileSync(bad, "this is not a sqlite file at all");
+    expect(() => verifyIntegrity(bad)).toThrow();
+  });
+
+  it("rotate deletes only the GFS losers, keeping shepherd-*.db.gz survivors", () => {
+    // plant 200 six-hourly snapshots + a foreign file
+    const base = new Date(Date.UTC(2026, 5, 25, 0, 0, 0));
+    for (let i = 0; i < 200; i++) writeFileSync(join(dir, name(hoursAgo(base, i * 6))), "x");
+    writeFileSync(join(dir, "backup.log"), "log");
+    rotate(dir);
+    const left = readdirSync(dir).filter((f) => f.startsWith("shepherd-") && f.endsWith(".db.gz"));
+    expect(left.length).toBeLessThanOrEqual(GFS.hourly + GFS.daily + GFS.weekly + GFS.monthly);
+    expect(left.length).toBeLessThan(200);
+    expect(existsSync(join(dir, "backup.log"))).toBe(true); // foreign file untouched
+  });
+});

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -137,4 +137,17 @@ describe("snapshot + integrity + rotate (live db)", () => {
     expect(left.length).toBeLessThan(200);
     expect(existsSync(join(dir, "backup.log"))).toBe(true); // foreign file untouched
   });
+
+  it("rotate reaps orphaned in-progress temp files a crashed run left behind", () => {
+    const ts = formatTs(new Date(Date.UTC(2026, 5, 25, 0, 0, 0)));
+    const snapTmp = `.shepherd-${ts}.db.tmp`; // uncompressed snapshot temp
+    const gzTmp = `shepherd-${ts}.db.gz.tmp`; // pre-rename gzip temp
+    writeFileSync(join(dir, snapTmp), "x");
+    writeFileSync(join(dir, gzTmp), "x");
+    writeFileSync(join(dir, name(new Date(Date.UTC(2026, 5, 25)))), "x"); // a real survivor
+    rotate(dir);
+    expect(existsSync(join(dir, snapTmp))).toBe(false);
+    expect(existsSync(join(dir, gzTmp))).toBe(false);
+    expect(existsSync(join(dir, name(new Date(Date.UTC(2026, 5, 25)))))).toBe(true);
+  });
 });

--- a/test/provision.test.ts
+++ b/test/provision.test.ts
@@ -323,8 +323,9 @@ describe("extracted helpers (direct)", () => {
     );
     expect([...writes.keys()].some((p) => p.endsWith(".backup-configured"))).toBe(true);
     expect(flat.some((c) => c.includes("enable --now shepherd-backup.timer"))).toBe(true);
-    // kicks one immediate backup so a fresh box has a .last-success before the staleness probe
-    expect(flat.some((c) => c.includes("start shepherd-backup.service"))).toBe(true);
+    // NO immediate `start shepherd-backup.service` here: the DB doesn't exist yet on a fresh
+    // install, so it would fail the oneshot and abort provision (update.sh does the guarded kick).
+    expect(flat.some((c) => c.includes("start shepherd-backup.service"))).toBe(false);
     // ~/.shepherd is created before the unit starts (systemd opens StandardOutput=append:
     // there before ExecStart and won't make parent dirs — else first start fails, #725).
     const shepherdDir = join("/home/op", ".shepherd");

--- a/test/provision.test.ts
+++ b/test/provision.test.ts
@@ -311,6 +311,18 @@ describe("extracted helpers (direct)", () => {
     expect(flat.some((c) => c.includes("daemon-reload"))).toBe(true);
     expect(flat.some((c) => c.includes("enable-linger"))).toBe(true);
     expect(flat.some((c) => c.includes("deploy/update.sh"))).toBe(true);
+    // Backup units (#1080): both written, the .service templated to the checkout, the timer
+    // enabled --now, and the backup-expected marker written.
+    const backupSvcWrite = [...writes.entries()].find(([p]) =>
+      p.endsWith("systemd/user/shepherd-backup.service"),
+    );
+    expect(backupSvcWrite).toBeDefined();
+    expect(backupSvcWrite![1]).toContain("WorkingDirectory=/repo");
+    expect([...writes.keys()].some((p) => p.endsWith("systemd/user/shepherd-backup.timer"))).toBe(
+      true,
+    );
+    expect([...writes.keys()].some((p) => p.endsWith(".backup-configured"))).toBe(true);
+    expect(flat.some((c) => c.includes("enable --now shepherd-backup.timer"))).toBe(true);
     // ~/.shepherd is created before the unit starts (systemd opens StandardOutput=append:
     // there before ExecStart and won't make parent dirs — else first start fails, #725).
     const shepherdDir = join("/home/op", ".shepherd");

--- a/test/provision.test.ts
+++ b/test/provision.test.ts
@@ -323,6 +323,8 @@ describe("extracted helpers (direct)", () => {
     );
     expect([...writes.keys()].some((p) => p.endsWith(".backup-configured"))).toBe(true);
     expect(flat.some((c) => c.includes("enable --now shepherd-backup.timer"))).toBe(true);
+    // kicks one immediate backup so a fresh box has a .last-success before the staleness probe
+    expect(flat.some((c) => c.includes("start shepherd-backup.service"))).toBe(true);
     // ~/.shepherd is created before the unit starts (systemd opens StandardOutput=append:
     // there before ExecStart and won't make parent dirs — else first start fails, #725).
     const shepherdDir = join("/home/op", ".shepherd");


### PR DESCRIPTION
Closes #1080.

## What

Shepherd's entire state lives in one un-backed-up SQLite file. This adds an **external, hourly, OS-level backup** with GFS retention, a tested restore path, and in-app detection of silent backup failure. Threat model: DB corruption + accidental data loss (retention prune / buggy delete). Disk/host failure is out of scope (v1, local backups OK).

## How

- **`scripts/backup.ts`** runs out-of-process from the single Bun event loop (systemd-user `shepherd-backup.timer`, hourly): opens the DB **read-only**, `VACUUM INTO` a temp snapshot (atomic + consistent on a live DB, compacted, no `-wal/-shm`), `PRAGMA integrity_check` (a failing snapshot is **discarded**), `Bun.gzipSync`, **atomic rename**, then **GFS rotation** (48h / 14d / 8w / 12mo). Writes `.last-success` + `backup.log`. Pure `classifyRetention` is unit-tested.
- **`src/backup-paths.ts`** — pure, side-effect-free `resolveDbPath`/`resolveBackupDir` shared by the script **and** the server, so the backup dir can't drift and the script avoids `config.ts`'s eager `loadForgeMap`/`resolveNodeBin`.
- **`src/store.ts`** — `PRAGMA busy_timeout = 5000` so a concurrent server write **waits** for the backup's shared read lock instead of throwing `SQLITE_BUSY` on the event loop (verified: no busy_timeout/WAL existed anywhere before).
- **Install wiring** — `provision.ts` installs + enables the units and writes a `.backup-configured` marker; **`update.sh` idempotently re-syncs** the units every deploy, so the existing live box self-heals.
- **`deploy/shepherd-restore.sh`** — stops `shepherd` **and** the backup timer, copies the current DB aside, **removes stale `*-journal`/`*-wal`/`*-shm`** (else a crash-left journal replays into the restored file → re-corruption), gunzips, verifies `integrity_check = ok`, restarts.
- **Staleness alert** — `runDailySweep` does a read-only, marker-gated probe → guaranteed log line + durable `backup_stale` signal (new `SignalKind`, excluded from the learnings distiller) + web push (new push kind). A box broken from its first run is flagged; macOS/core-only (no marker) stays silent.
- **`docs/backups.md`** runbook.

## Phase-0 spike result

Confirmed `bun:sqlite` (1.3.14) accepts `VACUUM INTO ?` on a **read-only** connection against a live, server-held DB; snapshot `integrity_check = ok`; the live writer commits fine after. So the read-write fallback in the plan was **not** needed.

## Deviations (flagged per house rules)

- `backup_stale` has **no in-app toast/drawer** — `egress_drop`'s toast is a transient, session-scoped `toasts.info()` with no global-broadcast path for a host-level daily-sweep alert. v1 channels = guaranteed log line + durable signal + push; an in-app banner is a deliberate follow-up.
- **Detection latency ≈ 24h** (daily-sweep sampling), not the 3h staleness threshold — documented, not implied.

## Tests / verification

- `test/backup.test.ts` (new): GFS classifier bucketing + integrity-fail-discard + live-DB snapshot/rotate. `test/provision.test.ts`: backup units + marker written, timer enabled.
- Root `bun test ./test` (4857 pass), `bunx tsc --noEmit`, `bun run lint`, `cd ui && bun run check` (0 errors), fallow delta audit (✓ no new issues) — all green. End-to-end: ran the real script against a live DB, restored the `.gz`, integrity ok, 2000 rows intact.

`[no-feature-entry]` — server/deploy/docs only, no user-facing UI component or route; the sole user-facing text (push payload) is hand-synced EN+DE in `src/push.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)