### PR TITLE
fix(buildqueue): truthful queue header — auto/operator approval + run-state

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2411,7 +2411,7 @@ async function postBuildStepStatus(
 
 // POST /api/sessions/:id/queue/approve — human gate: approve + steer the agent.
 function approveBuildQueue(deps: AppDeps, id: string): Response {
-  deps.store.setBuildQueueApproved(id, true);
+  deps.store.setBuildQueueApproved(id, true, "operator");
   const q = deps.store.getBuildQueue(id);
   deps.events?.emit("queue:update", q);
   deps.service.reply(id, APPROVE_STEER); // best-effort; ignore boolean return

--- a/src/service.ts
+++ b/src/service.ts
@@ -1618,7 +1618,7 @@ export class SessionService {
       // Autopilot sessions are pre-approved so the agent can begin executing immediately
       // after authoring the queue without waiting for a human gate that will never come.
       if (shouldPreApproveBuildQueue(repoConfig, session, input.research))
-        this.deps.store.setBuildQueueApproved(sessionId, true);
+        this.deps.store.setBuildQueueApproved(sessionId, true, "auto");
       this.scheduleRefine(session, herdSlug);
       this.#maybeRegisterTrain(session, input);
       return session;

--- a/src/store.ts
+++ b/src/store.ts
@@ -879,7 +879,13 @@ export class SessionStore implements CapStore, CreditStore {
       `CREATE INDEX IF NOT EXISTS build_queue_steps_session ON build_queue_steps (sessionId, position)`,
     );
     this.db.run(`CREATE TABLE IF NOT EXISTS build_queue_state (
-      sessionId TEXT PRIMARY KEY, approved INTEGER NOT NULL DEFAULT 0, updatedAt INTEGER NOT NULL)`);
+      sessionId TEXT PRIMARY KEY, approved INTEGER NOT NULL DEFAULT 0, approvalKind TEXT, updatedAt INTEGER NOT NULL)`);
+    // migrate build_queue_state rows that predate the approvalKind column (legacy rows NULL = unknown kind)
+    const bqStateCols = this.db.query(`PRAGMA table_info(build_queue_state)`).all() as {
+      name: string;
+    }[];
+    if (!bqStateCols.some((c) => c.name === "approvalKind"))
+      this.db.run(`ALTER TABLE build_queue_state ADD COLUMN approvalKind TEXT`);
     // One stamp per workflow-protocol comment posted on a session's backlog issue
     // (issue-log: `waiting:<pr>` / `merged:<pr>`), so each transition comments exactly
     // once per PR across restarts and CI flaps.
@@ -3754,8 +3760,8 @@ export class SessionStore implements CapStore, CreditStore {
       status: string;
     }[];
     const state = this.db
-      .query(`SELECT approved FROM build_queue_state WHERE sessionId = ?`)
-      .get(sessionId) as { approved: number } | null;
+      .query(`SELECT approved, approvalKind FROM build_queue_state WHERE sessionId = ?`)
+      .get(sessionId) as { approved: number; approvalKind: string | null } | null;
     const steps: BuildStep[] = rows.map((r) => ({
       id: r.id,
       title: r.title,
@@ -3763,7 +3769,13 @@ export class SessionStore implements CapStore, CreditStore {
       status: r.status as BuildStepStatus,
       position: r.position,
     }));
-    return { sessionId, steps, approved: state ? !!state.approved : false };
+    const kind = state?.approvalKind as "auto" | "operator" | null | undefined;
+    return {
+      sessionId,
+      steps,
+      approved: state ? !!state.approved : false,
+      ...(kind ? { approvalKind: kind } : {}),
+    };
   }
 
   /**
@@ -3909,11 +3921,12 @@ export class SessionStore implements CapStore, CreditStore {
   }
 
   /** Flip the human-curation gate for a session's queue. */
-  setBuildQueueApproved(sessionId: string, approved: boolean): void {
+  setBuildQueueApproved(sessionId: string, approved: boolean, kind?: "auto" | "operator"): void {
+    const approvalKind = approved ? (kind ?? null) : null;
     this.db.run(
-      `INSERT INTO build_queue_state (sessionId, approved, updatedAt) VALUES (?,?,?)
-       ON CONFLICT(sessionId) DO UPDATE SET approved = excluded.approved, updatedAt = excluded.updatedAt`,
-      [sessionId, approved ? 1 : 0, Date.now()],
+      `INSERT INTO build_queue_state (sessionId, approved, approvalKind, updatedAt) VALUES (?,?,?,?)
+       ON CONFLICT(sessionId) DO UPDATE SET approved = excluded.approved, approvalKind = excluded.approvalKind, updatedAt = excluded.updatedAt`,
+      [sessionId, approved ? 1 : 0, approvalKind, Date.now()],
     );
   }
 
@@ -3922,7 +3935,7 @@ export class SessionStore implements CapStore, CreditStore {
   listBuildQueues(): BuildQueue[] {
     const rows = this.db
       .query(
-        `SELECT s.id AS stepId, s.sessionId, s.position, s.title, s.detail, s.status, st.approved
+        `SELECT s.id AS stepId, s.sessionId, s.position, s.title, s.detail, s.status, st.approved, st.approvalKind
          FROM build_queue_steps s
          LEFT JOIN build_queue_state st ON st.sessionId = s.sessionId
          ORDER BY s.sessionId, s.position`,
@@ -3935,12 +3948,19 @@ export class SessionStore implements CapStore, CreditStore {
       detail: string;
       status: string;
       approved: number | null;
+      approvalKind: string | null;
     }[];
     const map = new Map<string, BuildQueue>();
     for (const r of rows) {
       let q = map.get(r.sessionId);
       if (!q) {
-        q = { sessionId: r.sessionId, steps: [], approved: !!r.approved };
+        const kind = r.approvalKind as "auto" | "operator" | null;
+        q = {
+          sessionId: r.sessionId,
+          steps: [],
+          approved: !!r.approved,
+          ...(kind ? { approvalKind: kind } : {}),
+        };
         map.set(r.sessionId, q);
       }
       q.steps.push({

--- a/src/types.ts
+++ b/src/types.ts
@@ -489,6 +489,10 @@ export interface BuildQueue {
   sessionId: string;
   steps: BuildStep[];
   approved: boolean;
+  /** How `approved` was set: "auto" = autopilot pre-approval at spawn, "operator" = a human
+   *  clicked Approve & run. Absent for an unapproved queue or a legacy row written before this
+   *  field existed (renders as plain "approved"). */
+  approvalKind?: "auto" | "operator";
 }
 
 /** Input shape for replacing a queue. A present `id` is kept VERBATIM as the step's id

--- a/test/build-queue-api.test.ts
+++ b/test/build-queue-api.test.ts
@@ -429,6 +429,51 @@ test("POST queue/approve for unknown session → 404", async () => {
   expect(res.status).toBe(404);
 });
 
+// ── approvalKind round-trips ──────────────────────────────────────────────────
+
+test("POST queue/approve sets approvalKind=operator in response and store", async () => {
+  const { app, store } = harness();
+  const session = makeSession(store, repoDir);
+
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${session.id}/queue/approve`, {
+      method: "POST",
+    }),
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.approvalKind).toBe("operator");
+  expect(store.getBuildQueue(session.id).approvalKind).toBe("operator");
+});
+
+test("POST queue/approve emits queue:update with approvalKind=operator", async () => {
+  const { app, store, emitted } = harness();
+  const session = makeSession(store, repoDir);
+
+  await app.fetch(
+    new Request(`http://x/api/sessions/${session.id}/queue/approve`, {
+      method: "POST",
+    }),
+  );
+
+  const ev = emitted.find((e) => e.event === "queue:update");
+  expect(ev).toBeDefined();
+  const data = ev!.data as { sessionId: string; approved: boolean; approvalKind?: string };
+  expect(data.approvalKind).toBe("operator");
+});
+
+test("store: auto-approved queue has approvalKind=auto, unapproved has no approvalKind", () => {
+  const { store } = harness();
+  const session = makeSession(store, repoDir);
+
+  // unapproved: approvalKind must be absent (undefined)
+  expect(store.getBuildQueue(session.id).approvalKind).toBeUndefined();
+
+  // auto-approve
+  store.setBuildQueueApproved(session.id, true, "auto");
+  expect(store.getBuildQueue(session.id).approvalKind).toBe("auto");
+});
+
 // ── GET /api/queues — bulk snapshot ──────────────────────────────────────────
 
 test("GET /api/queues returns keyed map of sessions with steps, approved flag", async () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -889,7 +889,6 @@
   "buildqueue_move_down_aria": "Schritt nach unten",
   "buildqueue_approve": "Freigeben & ausführen",
   "buildqueue_new_step": "Neuer Schritt",
-  "buildqueue_approved_header": "freigegeben · läuft",
   "buildqueue_step_title_aria": "Schritttitel",
   "buildqueue_step_detail_aria": "Schrittdetail",
   "buildqueue_step_detail_placeholder": "Detail (optional)",
@@ -1937,5 +1936,10 @@
   "settings_logout_hint": "Diese Sitzung auf diesem Gerät beenden. Zum erneuten Anmelden ist das Betreiber-Passwort nötig.",
   "settings_logout_button": "Abmelden",
   "feat_operator_auth_title": "Passwort-Anmeldung",
-  "feat_operator_auth_body": "Shepherd ist jetzt durch ein Einzelbetreiber-Passwort geschützt. Jede Seite, das Live-Terminal und der Aktivitätsstrom erfordern eine Sitzung — setze SHEPHERD_PASSWORD oder hol dir das automatisch generierte Passwort beim ersten Start aus dem Server-Log. Abmelden jederzeit über Einstellungen → Sitzung."
+  "feat_operator_auth_body": "Shepherd ist jetzt durch ein Einzelbetreiber-Passwort geschützt. Jede Seite, das Live-Terminal und der Aktivitätsstrom erfordern eine Sitzung — setze SHEPHERD_PASSWORD oder hol dir das automatisch generierte Passwort beim ersten Start aus dem Server-Log. Abmelden jederzeit über Einstellungen → Sitzung.",
+  "buildqueue_approval_auto": "auto-freigegeben",
+  "buildqueue_approval_operator": "freigegeben",
+  "buildqueue_run_queued": "wartet",
+  "buildqueue_run_running": "läuft",
+  "buildqueue_run_done": "erledigt"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -889,7 +889,6 @@
   "buildqueue_move_down_aria": "Move step down",
   "buildqueue_approve": "Approve & run",
   "buildqueue_new_step": "New step",
-  "buildqueue_approved_header": "approved · running",
   "buildqueue_step_title_aria": "Step title",
   "buildqueue_step_detail_aria": "Step detail",
   "buildqueue_step_detail_placeholder": "Detail (optional)",
@@ -1937,5 +1936,10 @@
   "settings_logout_hint": "End this session on this device. You'll need the operator password to sign back in.",
   "settings_logout_button": "Sign out",
   "feat_operator_auth_title": "Password login",
-  "feat_operator_auth_body": "Shepherd now sits behind a single-operator password. Every page, the live terminal, and the activity stream require a session — set SHEPHERD_PASSWORD, or grab the auto-generated one from the server log on first boot. Sign out anytime from Settings → Session."
+  "feat_operator_auth_body": "Shepherd now sits behind a single-operator password. Every page, the live terminal, and the activity stream require a session — set SHEPHERD_PASSWORD, or grab the auto-generated one from the server log on first boot. Sign out anytime from Settings → Session.",
+  "buildqueue_approval_auto": "auto-approved",
+  "buildqueue_approval_operator": "approved",
+  "buildqueue_run_queued": "queued",
+  "buildqueue_run_running": "running",
+  "buildqueue_run_done": "done"
 }

--- a/ui/src/lib/components/BuildQueuePanel.browser.test.ts
+++ b/ui/src/lib/components/BuildQueuePanel.browser.test.ts
@@ -42,6 +42,8 @@ beforeEach(() => {
     --color-amber: #f5a623;
     --color-green: #4caf50;
     --color-red: #f44336;
+    --color-slate: #708090;
+    --status-done: var(--color-slate);
     --fs-meta: 12px;
     --fs-micro: 10px;
   }
@@ -229,7 +231,114 @@ describe("BuildQueuePanel — approved/running state", () => {
       queue: approvedQueue,
       onbootstrap: noop,
     });
-    await expect.element(page.getByText(m.buildqueue_approved_header())).toBeInTheDocument();
+    // approvedQueue has steps [done, active] and no approvalKind → operator + running
+    await expect
+      .element(
+        page.getByText(`${m.buildqueue_approval_operator()} · ${m.buildqueue_run_running()}`),
+      )
+      .toBeInTheDocument();
+  });
+
+  it("shows auto-approved · queued for auto-approved queue with all pending steps", async () => {
+    const autoQueuedQueue: BuildQueue = {
+      sessionId: "s1",
+      approved: true,
+      approvalKind: "auto",
+      steps: [
+        { id: "a", title: "Step 1", status: "pending", position: 0 },
+        { id: "b", title: "Step 2", status: "pending", position: 1 },
+      ],
+    };
+    render(BuildQueuePanel, {
+      sessionId: "s1",
+      enabled: true,
+      queue: autoQueuedQueue,
+      onbootstrap: noop,
+    });
+    await expect
+      .element(page.getByText(`${m.buildqueue_approval_auto()} · ${m.buildqueue_run_queued()}`))
+      .toBeInTheDocument();
+  });
+
+  it("shows auto-approved · running for auto-approved queue with an active step", async () => {
+    const autoRunningQueue: BuildQueue = {
+      sessionId: "s1",
+      approved: true,
+      approvalKind: "auto",
+      steps: [
+        { id: "a", title: "Step 1", status: "done", position: 0 },
+        { id: "b", title: "Step 2", status: "active", position: 1 },
+      ],
+    };
+    render(BuildQueuePanel, {
+      sessionId: "s1",
+      enabled: true,
+      queue: autoRunningQueue,
+      onbootstrap: noop,
+    });
+    await expect
+      .element(page.getByText(`${m.buildqueue_approval_auto()} · ${m.buildqueue_run_running()}`))
+      .toBeInTheDocument();
+  });
+
+  it("shows approved · done for operator-approved queue with all steps done/skipped", async () => {
+    const operatorDoneQueue: BuildQueue = {
+      sessionId: "s1",
+      approved: true,
+      approvalKind: "operator",
+      steps: [
+        { id: "a", title: "Step 1", status: "done", position: 0 },
+        { id: "b", title: "Step 2", status: "skipped", position: 1 },
+      ],
+    };
+    render(BuildQueuePanel, {
+      sessionId: "s1",
+      enabled: true,
+      queue: operatorDoneQueue,
+      onbootstrap: noop,
+    });
+    await expect
+      .element(page.getByText(`${m.buildqueue_approval_operator()} · ${m.buildqueue_run_done()}`))
+      .toBeInTheDocument();
+  });
+
+  it("renders operator label for undefined approvalKind and auto label only for explicit auto", async () => {
+    const undefinedKindQueue: BuildQueue = {
+      sessionId: "s1",
+      approved: true,
+      steps: [{ id: "a", title: "Step 1", status: "pending", position: 0 }],
+    };
+    const { unmount } = render(BuildQueuePanel, {
+      sessionId: "s1",
+      enabled: true,
+      queue: undefinedKindQueue,
+      onbootstrap: noop,
+    });
+    // undefined kind → renders operator label
+    await expect
+      .element(page.getByText(`${m.buildqueue_approval_operator()} · ${m.buildqueue_run_queued()}`))
+      .toBeInTheDocument();
+    // auto label must NOT appear
+    const autoLabel = document.querySelector(".bqp-approved");
+    expect(autoLabel?.textContent).not.toContain(m.buildqueue_approval_auto());
+    unmount();
+
+    // Now render an explicit auto queue — the auto label DOES appear
+    const autoKindQueue: BuildQueue = {
+      sessionId: "s1",
+      approved: true,
+      approvalKind: "auto",
+      steps: [{ id: "a", title: "Step 1", status: "pending", position: 0 }],
+    };
+    render(BuildQueuePanel, {
+      sessionId: "s1",
+      enabled: true,
+      queue: autoKindQueue,
+      onbootstrap: noop,
+    });
+    await expect
+      .element(page.getByText(`${m.buildqueue_approval_auto()} · ${m.buildqueue_run_queued()}`))
+      .toBeInTheDocument();
   });
 
   it("renders status badges for done and active steps", async () => {

--- a/ui/src/lib/components/BuildQueuePanel.svelte
+++ b/ui/src/lib/components/BuildQueuePanel.svelte
@@ -108,6 +108,27 @@
     }
   }
 
+  // ------------- approved-header derived state -------------
+
+  const allResolved = $derived(
+    steps.length > 0 && steps.every((s) => s.status === "done" || s.status === "skipped"),
+  );
+  const anyRunning = $derived(steps.some((s) => s.status === "active" || s.status === "done"));
+  const runState = $derived(allResolved ? "done" : anyRunning ? "running" : "queued");
+
+  const approvalLabel = $derived(
+    queue?.approvalKind === "auto"
+      ? m.buildqueue_approval_auto()
+      : m.buildqueue_approval_operator(),
+  );
+  const runLabel = $derived(
+    runState === "done"
+      ? m.buildqueue_run_done()
+      : runState === "running"
+        ? m.buildqueue_run_running()
+        : m.buildqueue_run_queued(),
+  );
+
   // ------------- status badge helpers -------------
 
   function statusLabel(s: BuildStepStatus): string {
@@ -155,7 +176,7 @@
     >
       <span class="bqp-title">{m.buildqueue_panel_title()}</span>
       {#if approved && steps.length > 0}
-        <span class="bqp-approved">{m.buildqueue_approved_header()}</span>
+        <span class={["bqp-approved", `bqp-run-${runState}`]}>{approvalLabel} · {runLabel}</span>
       {/if}
       <span class="bqp-collapse-glyph" aria-hidden="true"
         >{buildQueueCollapse.collapsed ? "▴" : "▾"}</span
@@ -316,9 +337,22 @@
     font-size: var(--fs-micro);
     letter-spacing: 0.08em;
     text-transform: uppercase;
-    /* In-progress, not complete — amber. Green is reserved by the design system for
-       actionable-complete/READY, which a running queue is not. */
+    /* Color lives on the run-state modifier classes below. */
+  }
+
+  /* Run-state modifier colors (design-system rule 4 — tokens only, never literals).
+     running = in-progress amber; queued = faint (approved, not started);
+     done = slate (finished-but-parked; NOT green — green is reserved for actionable-complete/READY). */
+  .bqp-run-running {
     color: var(--color-amber);
+  }
+
+  .bqp-run-queued {
+    color: var(--color-faint);
+  }
+
+  .bqp-run-done {
+    color: var(--status-done);
   }
 
   /* The ▴/▾ glyph: pushed to the right edge, styled like the boxed toggle it

--- a/ui/src/lib/components/BuildQueuePanel.svelte
+++ b/ui/src/lib/components/BuildQueuePanel.svelte
@@ -113,8 +113,8 @@
   const allResolved = $derived(
     steps.length > 0 && steps.every((s) => s.status === "done" || s.status === "skipped"),
   );
-  const anyRunning = $derived(steps.some((s) => s.status === "active" || s.status === "done"));
-  const runState = $derived(allResolved ? "done" : anyRunning ? "running" : "queued");
+  const anyStarted = $derived(steps.some((s) => s.status === "active" || s.status === "done"));
+  const runState = $derived(allResolved ? "done" : anyStarted ? "running" : "queued");
 
   const approvalLabel = $derived(
     queue?.approvalKind === "auto"

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -14,6 +14,9 @@ export interface BuildQueue {
   sessionId: string;
   steps: BuildStep[];
   approved: boolean;
+  /** "auto" = autopilot pre-approval at spawn; "operator" = a human clicked Approve & run.
+   *  Absent for an unapproved queue or a legacy row → renders as plain "approved". */
+  approvalKind?: "auto" | "operator";
 }
 
 export interface RepoEntry {


### PR DESCRIPTION
## Problem

The build-queue panel header **always** read `approved · running` — a single hardcoded message string (`buildqueue_approved_header`), rendered whenever `approved && steps.length > 0`. Two ways this lied:

- **"running" was a literal** — never derived from step state. It showed even when every step was still `pending` (queue authored, nothing started) or when all steps were already `done`.
- **"approved" couldn't distinguish** an operator clicking **Approve & run** from autopilot's silent pre-approval at spawn (`shouldPreApproveBuildQueue`), which happens independently of the plan gate. So an autopilot session that hadn't passed the plan gate still showed a flat "approved".

## Fix

Header now reads `<approval> · <run-state>`, both derived from real state:

| Situation | Header |
| --- | --- |
| Autopilot pre-approved, all steps pending | `auto-approved · queued` |
| Autopilot, ≥1 step active/done | `auto-approved · running` |
| Operator clicked Approve & run | `approved · running` |
| All steps done/skipped | `approved · done` |
| Legacy approved queue (unknown kind) | `approved · <run-state>` |

**Server** — new optional `approvalKind?: "auto" \| "operator"` on `BuildQueue`, persisted in `build_queue_state` (additive nullable column + PRAGMA-guarded migration, safe on the live DB, no backfill). `service.ts` auto pre-approval writes `"auto"`; the `/queue/approve` endpoint writes `"operator"`. The field rides the existing `/approve` response and `queue:update` WS payload.

**UI** — `BuildQueuePanel.svelte` derives a **total** run-state from step statuses (`done` = all done/skipped; else `running` = any active/done; else `queued`) and the approval label from `approvalKind`. Colors are semantic tokens per design-system rule 4: running = amber, queued = faint, **done = `--status-done` (slate), never green** (a finished queue is finished-but-parked, not actionable-complete). Swapped the obsolete `buildqueue_approved_header` for five new EN+DE keys.

`approvalKind` is **optional**, not required-nullable: the store is the only real producer, `undefined` cleanly models legacy/unknown, and existing `BuildQueue` test fakes compile untouched.

## Tests

- Server: `approvalKind` round-trips through `getBuildQueue`, the `/approve` response, and the `queue:update` event; `"auto"` via store, `undefined` when unapproved.
- UI: new header-state tests for `auto·queued`, `auto·running`, `operator·done`, and operator-vs-auto; rewrote the assertion that referenced the deleted key.

Full gate set green locally (root lint/tsc/`bun test`; UI `check:i18n`/`check`/`test`; branch-hygiene/feature-catalog/glossary). Scope is a label-correctness **fix** — no new capability, so no feature-announcement/glossary entry (`fix(...)` subjects keep the feature-catalog gate disarmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
