### PR TITLE
Hand off held tasks across CLIs

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -83,6 +83,7 @@ import type { VerifyKeyResult } from "./verify-key";
 import type { StarPromptStatus } from "./star-prompt";
 import type {
   Session,
+  AgentProvider,
   Learning,
   LearningStatus,
   SignalKind,
@@ -3390,12 +3391,30 @@ function heldList(deps: AppDeps): Response {
   return json(deps.store.listHeldTasks());
 }
 
-async function heldSpawn(id: string, deps: AppDeps): Promise<Response> {
+function parseHeldSpawnProvider(body: unknown): { ok: true; value?: AgentProvider } | Response {
+  if (body == null) return { ok: true };
+  if (typeof body !== "object" || Array.isArray(body)) {
+    return json({ error: "body must be a non-null object" }, 400);
+  }
+  const obj = body as Record<string, unknown>;
+  for (const key of Object.keys(obj)) {
+    if (key !== "agentProvider") return json({ error: `unknown key: ${key}` }, 400);
+  }
+  if (!("agentProvider" in obj)) return { ok: true };
+  const provider = normalizeAgentProvider(obj.agentProvider);
+  if (provider === null) return json({ error: "agentProvider must be one of: claude, codex" }, 400);
+  return { ok: true, value: provider };
+}
+
+async function heldSpawn(id: string, deps: AppDeps, body: unknown = null): Promise<Response> {
   const h = deps.store.getHeldTask(id);
   if (!h) return json({ error: "not found" }, 404);
+  const provider = parseHeldSpawnProvider(body);
+  if (provider instanceof Response) return provider;
+  const input = provider.value ? { ...h.input, agentProvider: provider.value } : h.input;
   let s;
   try {
-    s = await deps.service.create(h.input);
+    s = await deps.service.create(input);
   } catch (e) {
     return createErrorResponse(e);
   }
@@ -3431,8 +3450,10 @@ async function handleHeld({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (req.method === "GET" && !parts[2]) return heldList(deps);
 
   // POST /api/held/:id/spawn — release one held task immediately
-  if (req.method === "POST" && parts[2] && parts[3] === "spawn" && !parts[4])
-    return heldSpawn(parts[2], deps);
+  if (req.method === "POST" && parts[2] && parts[3] === "spawn" && !parts[4]) {
+    const body = await req.json().catch(() => null);
+    return heldSpawn(parts[2], deps, body);
+  }
 
   // DELETE /api/held/:id — discard a held task
   if (req.method === "DELETE" && parts[2] && !parts[3]) return heldDiscard(parts[2], deps);

--- a/test/hold-gate.test.ts
+++ b/test/hold-gate.test.ts
@@ -279,6 +279,33 @@ test("POST /api/held/:id/spawn → calls service.create, removes row, returns 20
   expect((spawned!.data as { id: string }).id).toBe((await res.json()).id);
 });
 
+test("POST /api/held/:id/spawn accepts an agent provider override", async () => {
+  const { app, store, creates } = harness();
+
+  const input = {
+    repoPath: repoDir,
+    baseBranch: "main",
+    prompt: "task to hand off",
+    agentProvider: "claude" as const,
+    model: null,
+    images: [],
+  };
+  store.addHeldTask({ id: "held-1", repoPath: repoDir, input, createdAt: 1000 });
+
+  const res = await app.fetch(
+    new Request("http://x/api/held/held-1/spawn", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ agentProvider: "codex" }),
+    }),
+  );
+  expect(res.status).toBe(201);
+
+  expect(creates).toHaveLength(1);
+  expect((creates[0] as { agentProvider?: string }).agentProvider).toBe("codex");
+  expect(store.countHeldTasks()).toBe(0);
+});
+
 test("POST /api/held/:id/spawn with linked issue → re-stamps the drain claim", async () => {
   const { app, store, labeled } = harness();
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1610,6 +1610,8 @@
   "topbar_held_resets": "· Reset {time}",
   "topbar_held_title": "Zurückgehaltene Aufgaben",
   "topbar_held_spawn_now": "Jetzt starten",
+  "topbar_held_spawn_cli_label": "Starten mit",
+  "topbar_held_original_cli": "Zurückgestellt für {cli}",
   "topbar_held_discard": "Verwerfen",
   "topbar_held_empty": "Keine zurückgehaltenen Aufgaben",
   "topbar_held_why": "Zurückgehalten, weil die Nutzung hoch ist – sie starten automatisch beim nächsten Reset.",
@@ -1962,5 +1964,7 @@
   "settings_cli_codex_auth_hint": "Codex verwendet aktuell den lokalen CLI-Login, der dem Serverprozess zur Verfügung steht.",
   "settings_cli_codex_auth_local": "Lokaler Codex-CLI-Login",
   "feat_codex_cli_title": "Codex-CLI-Alpha",
-  "feat_codex_cli_body": "Neue Aufgaben können jetzt über die lokale Codex-CLI als Alpha/MVP-Provider laufen. Wähle Codex im Aufgabendialog oder lege es unter Einstellungen → Coding CLIs als Standard fest; Codex startet als steuerbare Terminal-Session, während CLI-spezifische Automation noch verdrahtet wird."
+  "feat_codex_cli_body": "Neue Aufgaben können jetzt über die lokale Codex-CLI als Alpha/MVP-Provider laufen. Wähle Codex im Aufgabendialog oder lege es unter Einstellungen → Coding CLIs als Standard fest; Codex startet als steuerbare Terminal-Session, während CLI-spezifische Automation noch verdrahtet wird.",
+  "feat_held_task_cli_handoff_title": "Zurückgestellte Aufgaben an eine andere CLI geben",
+  "feat_held_task_cli_handoff_body": "Zurückgestellte Aufgaben zeigen jetzt, für welche Coding-CLI sie ursprünglich eingereiht wurden. Öffne das Popover, stelle Starten mit auf einen anderen Provider und starte die Aufgabe dort, wo noch Kapazität frei ist."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1610,6 +1610,8 @@
   "topbar_held_resets": "· resets {time}",
   "topbar_held_title": "Held tasks",
   "topbar_held_spawn_now": "Spawn now",
+  "topbar_held_spawn_cli_label": "Run on",
+  "topbar_held_original_cli": "Held for {cli}",
   "topbar_held_discard": "Discard",
   "topbar_held_empty": "No held tasks",
   "topbar_held_why": "Held because usage is high — they start automatically when usage resets.",
@@ -1962,5 +1964,7 @@
   "settings_cli_codex_auth_hint": "Codex currently uses the local CLI login available to the server process.",
   "settings_cli_codex_auth_local": "Local Codex CLI login",
   "feat_codex_cli_title": "Codex CLI alpha",
-  "feat_codex_cli_body": "New tasks can now run through the local Codex CLI as an Alpha/MVP provider path. Choose Codex in the task dialog or set it as the default under Settings → Coding CLIs; Codex starts as a steerable terminal session while CLI-specific automation is still being wired."
+  "feat_codex_cli_body": "New tasks can now run through the local Codex CLI as an Alpha/MVP provider path. Choose Codex in the task dialog or set it as the default under Settings → Coding CLIs; Codex starts as a steerable terminal session while CLI-specific automation is still being wired.",
+  "feat_held_task_cli_handoff_title": "Hand off held tasks to another CLI",
+  "feat_held_task_cli_handoff_body": "Held tasks now show which coding CLI they were originally queued for. Open the held-tasks popover, switch Run on to another provider, and Spawn now to hand the task to a CLI that still has room."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -202,8 +202,12 @@ export async function listHeld(): Promise<HeldTask[]> {
 }
 
 /** Spawn a held task now (bypasses the usage hold). */
-export async function spawnHeld(id: string): Promise<Session> {
-  const r = await fetch(`/api/held/${id}/spawn`, { method: "POST", headers: JSON_HEADERS });
+export async function spawnHeld(id: string, agentProvider?: AgentProvider): Promise<Session> {
+  const r = await fetch(`/api/held/${id}/spawn`, {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify(agentProvider ? { agentProvider } : {}),
+  });
   if (!r.ok) throw await failed(r, "spawn held");
   return r.json();
 }

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -9,7 +9,7 @@
   import { displayStatus } from "$lib/display-status";
   import { gaugeList, hotterGauge, overspending, type GaugeKey } from "./usage-gauges";
   import { refreshUsage, listHeld, spawnHeld, discardHeld } from "$lib/api";
-  import type { HeldTask } from "$lib/types";
+  import type { AgentProvider, HeldTask } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { DOCS_URL } from "$lib/build-info";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
@@ -329,9 +329,9 @@
     else openHeldPop();
   }
 
-  async function doSpawnHeld(id: string) {
+  async function doSpawnHeld(id: string, agentProvider?: AgentProvider) {
     try {
-      await spawnHeld(id);
+      await spawnHeld(id, agentProvider);
       await loadHeld();
     } catch {
       // ignore; WS will update count

--- a/ui/src/lib/components/top-bar/TopBarHeldBadge.svelte
+++ b/ui/src/lib/components/top-bar/TopBarHeldBadge.svelte
@@ -2,7 +2,27 @@
   import { m } from "$lib/paraglide/messages";
   import { formatResetIn } from "$lib/format";
   import type { Gauge } from "../usage-gauges";
-  import type { HeldTask } from "$lib/types";
+  import { AGENT_PROVIDERS, type AgentProvider, type HeldTask } from "$lib/types";
+
+  const fallbackProvider: AgentProvider = "claude";
+
+  let spawnProviders = $state<Record<string, AgentProvider>>({});
+
+  function providerFor(task: HeldTask): AgentProvider {
+    return task.input.agentProvider ?? fallbackProvider;
+  }
+
+  function selectedProvider(task: HeldTask): AgentProvider {
+    return spawnProviders[task.id] ?? providerFor(task);
+  }
+
+  function setSpawnProvider(id: string, value: string) {
+    spawnProviders[id] = value === "codex" ? "codex" : "claude";
+  }
+
+  function providerLabel(provider: AgentProvider): string {
+    return provider === "claude" ? m.agent_provider_claude() : m.agent_provider_codex();
+  }
 
   let {
     heldCount,
@@ -32,7 +52,7 @@
     heldBadgeBtn: HTMLButtonElement | null;
     heldPopEl: HTMLDivElement | null;
     toggleHeldPop: () => void;
-    doSpawnHeld: (id: string) => void;
+    doSpawnHeld: (id: string, agentProvider?: AgentProvider) => void;
     doDiscardHeld: (id: string) => void;
   } = $props();
 </script>
@@ -80,17 +100,34 @@
           <div class="held-pop-empty">{m.topbar_held_empty()}</div>
         {:else}
           {#each heldItems as task (task.id)}
+            {@const originalProvider = providerFor(task)}
+            {@const spawnProvider = selectedProvider(task)}
             <div class="held-row">
               <div class="held-row-info">
                 <span class="held-row-prompt">{task.input.prompt}</span>
                 <span class="held-row-repo">{task.repoPath.split("/").at(-1) ?? task.repoPath}</span
                 >
+                <span class="held-row-cli">
+                  {m.topbar_held_original_cli({ cli: providerLabel(originalProvider) })}
+                </span>
               </div>
               <div class="held-row-actions">
+                <label class="held-cli">
+                  <span>{m.topbar_held_spawn_cli_label()}</span>
+                  <select
+                    value={spawnProvider}
+                    onchange={(e) => setSpawnProvider(task.id, e.currentTarget.value)}
+                  >
+                    {#each AGENT_PROVIDERS as provider (provider)}
+                      <option value={provider}>{providerLabel(provider)}</option>
+                    {/each}
+                  </select>
+                </label>
                 <button
                   type="button"
                   class="held-action held-spawn"
-                  onclick={() => doSpawnHeld(task.id)}>{m.topbar_held_spawn_now()}</button
+                  onclick={() => doSpawnHeld(task.id, spawnProvider)}
+                  >{m.topbar_held_spawn_now()}</button
                 >
                 <button
                   type="button"
@@ -153,7 +190,7 @@
     right: 0;
     z-index: 20;
     margin-top: 4px;
-    width: 340px;
+    width: 390px;
     max-width: 90vw;
     background: var(--color-inset);
     border: 1px solid var(--color-line);
@@ -205,7 +242,7 @@
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
-    gap: 10px;
+    gap: 12px;
     padding: 8px 14px;
     border-top: 1px solid var(--color-line);
   }
@@ -232,11 +269,47 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+  .held-row-cli {
+    font-size: var(--fs-micro);
+    color: var(--color-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
   .held-row-actions {
     display: flex;
     flex-direction: column;
     gap: 4px;
+    width: 124px;
     flex-shrink: 0;
+  }
+  .held-cli {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    color: var(--color-faint);
+    font-size: var(--fs-micro);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  .held-cli select {
+    width: 100%;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: var(--fs-meta);
+    letter-spacing: 0.04em;
+    padding: 3px 6px;
+    text-transform: none;
+    cursor: pointer;
+  }
+  .held-cli select:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
   }
   .held-action {
     background: transparent;
@@ -249,6 +322,7 @@
     cursor: pointer;
     white-space: nowrap;
     color: var(--color-ink);
+    width: 100%;
   }
   .held-action:hover {
     border-color: var(--color-amber);
@@ -260,5 +334,13 @@
   }
   .held-spawn:hover {
     background: color-mix(in srgb, var(--color-amber) 10%, transparent);
+  }
+  @media (max-width: 420px) {
+    .held-row {
+      flex-direction: column;
+    }
+    .held-row-actions {
+      width: 100%;
+    }
   }
 </style>

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1607,4 +1607,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_codex_cli_title",
     bodyKey: "feat_codex_cli_body",
   },
+  {
+    // Held tasks now show the coding CLI they were originally held for and can be manually
+    // spawned on a different provider, e.g. hand a Claude-held task to Codex while Claude usage is
+    // capped. No targetId — the held-task popover only mounts when the queue is non-empty. Ships
+    // in 1.37.0 alongside the Codex provider path.
+    id: "held-task-cli-handoff",
+    sinceVersion: "1.37.0",
+    titleKey: "feat_held_task_cli_handoff_title",
+    bodyKey: "feat_held_task_cli_handoff_body",
+  },
 ];


### PR DESCRIPTION
## Summary
- show which coding CLI each held task was originally queued for
- allow manually spawning a held task on another provider, e.g. Codex instead of Claude Code
- add API validation/tests plus i18n and feature catalog entries

## Tests
- bun run test
- cd ui && bun run test
- bun run typecheck
- bun run lint
- cd ui && bun run check:i18n
- cd ui && bun run check