### PR TITLE
fix(ui): honor default-CLI setting in New Task; restore gate/autopilot on switch-back

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1947,7 +1947,7 @@
   "newtask_agent_provider_label": "Coding CLI",
   "newtask_agent_provider_codex_alpha_badge": "Alpha MVP",
   "newtask_agent_provider_codex_alpha_note": "Die Codex-Integration ist eine Alpha/MVP-Funktion und wird gerade intensiv weiterentwickelt.",
-  "newtask_agent_provider_codex_suggested_for_hold": "Claude Code ist am Nutzungsrückhalt-Schwellenwert, deshalb hat Shepherd für diese Aufgabe Codex ausgewählt. Wechsle zurück zu Claude Code, wenn du bis zum Reset zurückhalten oder trotzdem einreichen möchtest.",
+  "newtask_agent_provider_codex_suggested_for_hold": "Claude Code ist am Nutzungsrückhalt-Schwellenwert, daher umgeht das Ausführen dieser Aufgabe auf Codex den Rückhalt. Wechsle die Coding-CLI zurück zu Claude Code, um sie stattdessen bis zum Reset zurückzuhalten oder trotzdem einzureichen.",
   "newtask_agent_provider_codex_note": "Codex startet als interaktive Terminal-Session. Plan Gate und Autopilot sind für diese Aufgabe aus; die Modellauswahl nutzt Codex-CLI-Modelle.",
   "agent_provider_claude": "Claude Code",
   "agent_provider_codex": "Codex",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1947,7 +1947,7 @@
   "newtask_agent_provider_label": "Coding CLI",
   "newtask_agent_provider_codex_alpha_badge": "Alpha MVP",
   "newtask_agent_provider_codex_alpha_note": "Codex integration is an Alpha/MVP feature and is under heavy development.",
-  "newtask_agent_provider_codex_suggested_for_hold": "Claude Code is at the usage-hold threshold, so Shepherd selected Codex for this task. Switch back to Claude Code if you want to hold it until the reset or submit anyway.",
+  "newtask_agent_provider_codex_suggested_for_hold": "Claude Code is at the usage-hold threshold, so running this task on Codex sidesteps the hold. Switch the coding CLI back to Claude Code to hold it until the reset or submit anyway instead.",
   "newtask_agent_provider_codex_note": "Codex starts as an interactive terminal session. Plan Gate and Autopilot are off for this task; the model picker uses Codex CLI models.",
   "agent_provider_claude": "Claude Code",
   "agent_provider_codex": "Codex",

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -996,22 +996,67 @@ async function fillPromptAndClickRun() {
 }
 
 describe("NewTask first-task confirm step", () => {
-  it("likely Claude hold selects Codex and explains why", async () => {
-    const repoPath = "/repo/hold-prefers-codex";
+  it("usage hold keeps the operator's Claude default and offers a manual handoff", async () => {
+    const repoPath = "/repo/hold-keeps-claude";
     mockGetRepoConfig.mockResolvedValue(confirmedRepoConfig());
     const onsubmit = vi.fn().mockResolvedValue(undefined);
+    // Default CLI is Claude; a usage hold must NOT silently switch it to Codex.
     render(NewTask, { props: { onsubmit, initialRepoPath: repoPath, holdLikely: true } });
 
     const provider = () => document.querySelector<HTMLSelectElement>("#nt-agent-provider")!;
+    await expect.poll(() => provider().value).toBe("claude");
+    // Held → the dual Hold-for-reset / Submit-anyway buttons offer the handoff
+    // without hijacking the selected CLI.
+    await expect.poll(() => document.querySelector("button.run-hold")).toBeTruthy();
+    expect(document.querySelector("button.run-anyway")).toBeTruthy();
+
+    // The Codex hold note only appears once the operator picks Codex by hand.
+    provider().value = "codex";
+    provider().dispatchEvent(new Event("change", { bubbles: true }));
     await expect.poll(() => provider().value).toBe("codex");
     await expect
       .element(page.getByText(m.newtask_agent_provider_codex_suggested_for_hold()))
       .toBeInTheDocument();
-    expect(document.querySelector("button.run-hold")).toBeNull();
+  });
 
-    await fillPromptAndClickRun();
-    await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
-    expect(onsubmit.mock.calls[0]?.[0]?.agentProvider).toBe("codex");
+  it("switching Codex→Claude restores plan gate / autopilot in one flip", async () => {
+    const repoPath = "/repo/codex-restore";
+    // Repo defaults both automation toggles ON.
+    mockGetRepoConfig.mockResolvedValue({
+      ...confirmedRepoConfig(),
+      planGateEnabled: true,
+      autopilotEnabled: true,
+    });
+    const onsubmit = vi.fn().mockResolvedValue(undefined);
+    render(NewTask, { props: { onsubmit, initialRepoPath: repoPath } });
+
+    const provider = () => document.querySelector<HTMLSelectElement>("#nt-agent-provider")!;
+    const boxByLabel = (label: string) =>
+      Array.from(document.querySelectorAll<HTMLInputElement>(".plan-gate input")).find((el) =>
+        el.closest("label")?.textContent?.includes(label),
+      )!;
+    const planGateBox = () => boxByLabel(m.newtask_plan_gate_label());
+    const autopilotBox = () => boxByLabel(m.newtask_autopilot_label());
+
+    // Seeded ON from the repo default.
+    await expect.poll(() => planGateBox().checked).toBe(true);
+    await expect.poll(() => autopilotBox().checked).toBe(true);
+
+    // Codex can't plan-gate/autopilot → both forced off and disabled.
+    provider().value = "codex";
+    provider().dispatchEvent(new Event("change", { bubbles: true }));
+    await expect.poll(() => planGateBox().checked).toBe(false);
+    await expect.poll(() => autopilotBox().checked).toBe(false);
+    expect(planGateBox().disabled).toBe(true);
+    expect(autopilotBox().disabled).toBe(true);
+
+    // Back to Claude in a single flip → restored to the repo default, not stuck off.
+    provider().value = "claude";
+    provider().dispatchEvent(new Event("change", { bubbles: true }));
+    await expect.poll(() => planGateBox().checked).toBe(true);
+    await expect.poll(() => autopilotBox().checked).toBe(true);
+    expect(planGateBox().disabled).toBe(false);
+    expect(autopilotBox().disabled).toBe(false);
   });
 
   it("confirmed repo: Run calls onsubmit directly, no confirm step shown", async () => {

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -1059,6 +1059,41 @@ describe("NewTask first-task confirm step", () => {
     expect(autopilotBox().disabled).toBe(false);
   });
 
+  it("preserves a manual plan-gate / autopilot override across a Codex round-trip", async () => {
+    const repoPath = "/repo/codex-preserve-override";
+    // Repo defaults both automation toggles OFF.
+    mockGetRepoConfig.mockResolvedValue(confirmedRepoConfig());
+    const onsubmit = vi.fn().mockResolvedValue(undefined);
+    render(NewTask, { props: { onsubmit, initialRepoPath: repoPath } });
+
+    const provider = () => document.querySelector<HTMLSelectElement>("#nt-agent-provider")!;
+    const boxByLabel = (label: string) =>
+      Array.from(document.querySelectorAll<HTMLInputElement>(".plan-gate input")).find((el) =>
+        el.closest("label")?.textContent?.includes(label),
+      )!;
+    const planGateBox = () => boxByLabel(m.newtask_plan_gate_label());
+    const autopilotBox = () => boxByLabel(m.newtask_autopilot_label());
+
+    // Settle, then manually turn BOTH on — differs from the repo default.
+    await expect.poll(() => planGateBox().disabled).toBe(false);
+    planGateBox().click();
+    autopilotBox().click();
+    await expect.poll(() => planGateBox().checked).toBe(true);
+    await expect.poll(() => autopilotBox().checked).toBe(true);
+
+    // Codex displays them off (state is preserved underneath, not mutated).
+    provider().value = "codex";
+    provider().dispatchEvent(new Event("change", { bubbles: true }));
+    await expect.poll(() => planGateBox().checked).toBe(false);
+    await expect.poll(() => autopilotBox().checked).toBe(false);
+
+    // Back to Claude → the manual override survives the round-trip.
+    provider().value = "claude";
+    provider().dispatchEvent(new Event("change", { bubbles: true }));
+    await expect.poll(() => planGateBox().checked).toBe(true);
+    await expect.poll(() => autopilotBox().checked).toBe(true);
+  });
+
   it("confirmed repo: Run calls onsubmit directly, no confirm step shown", async () => {
     const repoPath = "/repo/ftac-confirmed";
     mockGetRepoConfig.mockResolvedValue(confirmedRepoConfig());

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, untrack } from "svelte";
+  import { onMount } from "svelte";
   import { MediaQuery } from "svelte/reactivity";
   import {
     listRepos,
@@ -139,12 +139,12 @@
   // discuss/iterate and approve each step yourself — without changing the repo default.
   let autopilot = $state(false);
   let autopilotTouched = $state(false);
-  let agentProvider = $state<AgentProvider>(
-    untrack(() =>
-      holdLikely && defaultAgentProvider === "claude" ? "codex" : defaultAgentProvider,
-    ),
-  );
-  let agentProviderTouched = $state(false);
+  // Seeds once from the operator's explicit default-CLI setting. A usage hold no
+  // longer auto-switches this to Codex — that silently overrode an explicit choice.
+  // When held, Claude stays selected and the dual Hold-for-reset / Submit-anyway
+  // buttons below offer the handoff; Codex remains one manual pick away.
+  // svelte-ignore state_referenced_locally
+  let agentProvider = $state<AgentProvider>(defaultAgentProvider);
   // Research task kind: web research → report PR or issue; mutually exclusive w/ plan-gate.
   let research = $state(false);
   // Per-spawn sandbox override; "default" → omit (inherit the repo's configured profile).
@@ -332,7 +332,10 @@
     !!repoPath && !planGateTouched && !repoConfig.isConfigSettled(repoPath),
   );
   $effect(() => {
-    // mirror the repo default until the user makes a manual choice
+    // mirror the repo default until the user makes a manual choice. Codex yields
+    // to the force-off effect below; leaving Codex re-runs this and restores the
+    // repo default in a single dropdown flip.
+    if (agentProvider === "codex") return;
     if (!planGateTouched) planGate = planGateDefault;
   });
 
@@ -342,24 +345,18 @@
     !!repoPath && !autopilotTouched && !repoConfig.isConfigSettled(repoPath),
   );
   $effect(() => {
+    if (agentProvider === "codex") return;
     if (!autopilotTouched) autopilot = autopilotDefault;
   });
 
+  // Codex can't plan-gate or autopilot yet, so show both off while it's selected.
+  // Non-pinning on purpose: it must NOT set the *Touched flags — switching back to
+  // Claude then re-seeds from the repo default (above) in one flip. The submit path
+  // sends these off for Codex regardless of this display state.
   $effect(() => {
     if (agentProvider !== "codex") return;
-    if (planGate) {
-      planGate = false;
-      planGateTouched = true;
-    }
-    if (autopilot) {
-      autopilot = false;
-      autopilotTouched = true;
-    }
-  });
-
-  $effect(() => {
-    if (!holdLikely || agentProviderTouched || agentProvider !== "claude") return;
-    agentProvider = "codex";
+    if (planGate) planGate = false;
+    if (autopilot) autopilot = false;
   });
 
   // Effective default model = repo override (if not "inherit") → global default → promo.
@@ -582,6 +579,14 @@
     e.stopPropagation();
   }
 
+  // Per-task plan-gate / autopilot flag at submit. Codex can't plan-gate or
+  // autopilot yet, so force both off; otherwise send the user's manual choice, or
+  // null to inherit the repo default.
+  function automationFlag(touched: boolean, value: boolean): boolean | null {
+    if (agentProvider === "codex") return false;
+    return touched ? value : null;
+  }
+
   async function doSpawn(force = false) {
     submitting = true;
     error = null;
@@ -602,8 +607,8 @@
               body: issueRef.body,
             }
           : undefined,
-        planGateEnabled: planGateTouched ? planGate : null,
-        autopilotEnabled: autopilotTouched ? autopilot : null,
+        planGateEnabled: automationFlag(planGateTouched, planGate),
+        autopilotEnabled: automationFlag(autopilotTouched, autopilot),
         sandboxProfile: sandboxProfile === "default" ? undefined : sandboxProfile,
         research,
         force: force || undefined,
@@ -908,7 +913,6 @@
         {holdLikely}
         onPlanGateTouched={() => (planGateTouched = true)}
         onAutopilotTouched={() => (autopilotTouched = true)}
-        onAgentProviderTouched={() => (agentProviderTouched = true)}
         onModelTouched={() => (modelTouched = true)}
         {planGateLoading}
         {autopilotLoading}

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -332,10 +332,7 @@
     !!repoPath && !planGateTouched && !repoConfig.isConfigSettled(repoPath),
   );
   $effect(() => {
-    // mirror the repo default until the user makes a manual choice. Codex yields
-    // to the force-off effect below; leaving Codex re-runs this and restores the
-    // repo default in a single dropdown flip.
-    if (agentProvider === "codex") return;
+    // mirror the repo default until the user makes a manual choice
     if (!planGateTouched) planGate = planGateDefault;
   });
 
@@ -345,19 +342,14 @@
     !!repoPath && !autopilotTouched && !repoConfig.isConfigSettled(repoPath),
   );
   $effect(() => {
-    if (agentProvider === "codex") return;
     if (!autopilotTouched) autopilot = autopilotDefault;
   });
 
-  // Codex can't plan-gate or autopilot yet, so show both off while it's selected.
-  // Non-pinning on purpose: it must NOT set the *Touched flags — switching back to
-  // Claude then re-seeds from the repo default (above) in one flip. The submit path
-  // sends these off for Codex regardless of this display state.
-  $effect(() => {
-    if (agentProvider !== "codex") return;
-    if (planGate) planGate = false;
-    if (autopilot) autopilot = false;
-  });
+  // Codex can't plan-gate or autopilot yet. Rather than mutate planGate/autopilot
+  // (which would silently lose a manual override across a Codex round-trip), the
+  // checkboxes just DISPLAY off + disabled while Codex is selected (see
+  // NewTaskRunSettings) and submit forces them off via automationFlag — the
+  // underlying Claude-context choice is preserved untouched.
 
   // Effective default model = repo override (if not "inherit") → global default → promo.
   // Re-seeds the picker when the repo config loads / the repo changes, unless an explicit

--- a/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
+++ b/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
@@ -81,8 +81,9 @@
     <label class="plan-gate" use:coachTarget={"plan-gate"}>
       <input
         type="checkbox"
-        bind:checked={planGate}
-        onchange={() => {
+        checked={agentProvider === "codex" ? false : planGate}
+        onchange={(e) => {
+          planGate = e.currentTarget.checked;
           onPlanGateTouched();
           if (planGate) research = false;
         }}
@@ -108,8 +109,11 @@
       <label class="plan-gate" use:coachTarget={"task-autopilot"}>
         <input
           type="checkbox"
-          bind:checked={autopilot}
-          onchange={() => onAutopilotTouched()}
+          checked={agentProvider === "codex" ? false : autopilot}
+          onchange={(e) => {
+            autopilot = e.currentTarget.checked;
+            onAutopilotTouched();
+          }}
           disabled={autopilotLoading || agentProvider === "codex"}
         />
         <span class="pg-label">{m.newtask_autopilot_label()}</span>

--- a/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
+++ b/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
@@ -20,7 +20,6 @@
     sandboxProfile = $bindable(),
     onPlanGateTouched,
     onAutopilotTouched,
-    onAgentProviderTouched,
     onModelTouched,
     planGateLoading,
     autopilotLoading,
@@ -40,7 +39,6 @@
     // (write-only `$bindable` would trip no-useless-assignment here)
     onPlanGateTouched: () => void;
     onAutopilotTouched: () => void;
-    onAgentProviderTouched: () => void;
     onModelTouched: () => void;
     planGateLoading: boolean;
     autopilotLoading: boolean;
@@ -60,7 +58,6 @@
   }
 
   function agentProviderChanged() {
-    onAgentProviderTouched();
     if (!modelAvailableForProvider(model)) {
       model = agentProvider === "codex" ? CODEX_MODELS[0] : "default";
     }


### PR DESCRIPTION
## Problem

With **Claude Code** set as the default coding CLI in Settings, the New Task dialog still defaulted the **CODING CLI** dropdown to **Codex**, against the explicit setting. Two coupled defects:

1. **CLI ignores the setting.** The dropdown was seeded — and an effect re-forced — to Codex whenever a usage hold was *likely* (`holdLikely`). Because `usageHoldEnabled` **defaults on** (`src/config.ts:578`) at `usageHoldPct=80`, any heavy Claude user sitting ≥80% usage got Codex *every* time, silently overriding `defaultAgentProvider=claude`. The callout even admitted it: *"Shepherd selected Codex for this task."*
2. **Plan gate / Autopilot can't be re-enabled.** Selecting Codex force-unchecked Plan gate + Autopilot **and pinned** their `*Touched` flags. Switching the dropdown back to Claude left them off and pinned — they never re-seeded from the repo defaults. That's the "two flips and they're still off" symptom (repo default `Autopilot: on`, yet unchecked after switching back).

## Fix

- Seed `agentProvider` from the explicit `defaultAgentProvider` setting; **drop the `holdLikely → codex` auto-flip and the forced re-switch effect**. When held, Claude stays selected and the existing **Hold for reset / Submit anyway** buttons still offer the handoff — Codex is one manual dropdown-pick away.
- Make the Codex plan-gate/autopilot disabling **non-pinning**, and gate the repo-default re-seed to yield to it, so **codex → claude restores the repo defaults in a single flip**.
- Force both flags off at submit for Codex via a small `automationFlag` helper (also keeps `doSpawn` under the fallow cognitive-complexity threshold).
- Reword the now-inaccurate "Shepherd selected Codex" hold note (EN + DE).
- Remove the orphaned `agentProviderTouched` state + `onAgentProviderTouched` plumbing (no consumer once the auto-switch is gone).

## Deliberate deviation (flagged per house rules)

This intentionally changes the behavior introduced by **c9546519** (auto-preselect Codex on usage hold). Rationale: an **explicit operator setting must win** over the hold prediction. The handoff itself is preserved — it just no longer hijacks the selected CLI; the operator opts in via the dropdown or the Submit-anyway / Hold-for-reset buttons.

Out of scope (separate, larger efforts): generalizing Plan Gate to *run on* Codex (#1087) and hardening the Codex plan gate (#1088).

## Verification

- `cd ui && bun run check` — 0 errors; `check:i18n` — locales in parity.
- New/updated tests in `NewTask.browser.test.ts` (57 pass): usage hold keeps the Claude default + offers the manual handoff; **codex → claude restores plan gate / autopilot in one flip**.
- `bunx fallow@2.100.0 audit --base origin/main` — no issues in changed files; pre-push gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)