### PR TITLE
fix(preview): steer Codex dev server starts

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -705,17 +705,25 @@ export const DRAFT_PR_NOTE =
 
 /**
  * Build the steer text sent to an agent to start its dev server in the background.
- * Must instruct the agent to run the command in the background so it does NOT block
- * on the dev server (a foreground dev server never exits and would hang the agent's
- * turn forever), and to report the tailnet HTTPS URL — operators reach previews over
- * the tailnet, so a localhost-only confirmation is useless to them. The FQDN is
- * resolved by the agent at runtime (never baked into this prompt — it would leak the
- * operator's tailnet name into every transcript template). Agent-facing, NOT i18n'd.
+ * Must instruct the agent to run the command in an agent-appropriate background
+ * mechanism so it does NOT block on the dev server (a foreground dev server never
+ * exits and would hang the agent's turn forever), and to report the tailnet HTTPS
+ * URL — operators reach previews over the tailnet, so a localhost-only confirmation
+ * is useless to them. The FQDN is resolved by the agent at runtime (never baked into
+ * this prompt — it would leak the operator's tailnet name into every transcript
+ * template). Agent-facing, NOT i18n'd.
  */
-export function PREVIEW_START_STEER(command: string): string {
+export function PREVIEW_START_STEER(
+  command: string,
+  agentProvider: "claude" | "codex" = "claude",
+): string {
+  const startDirective =
+    agentProvider === "codex"
+      ? `For Codex: please start \`${command}\` as a Codex-managed long-running/background terminal command, not as a blocking foreground command. In Codex CLI, keep it in a background terminal so it can be inspected with \`/ps\` and stopped with \`/stop\`; in the Codex app, use the integrated terminal or a project Action for the dev server. `
+      : `For Claude Code: please run \`${command}\` in the background (use Claude Code's background run / append \`&\` so it does NOT block your turn — a foreground dev server never exits and would hang you forever). `;
+
   return (
-    `Please run \`${command}\` in the background (use Claude Code's background run / append \`&\` so it ` +
-    `does NOT block your turn — a foreground dev server never exits and would hang you forever). ` +
+    startDirective +
     `Confirm the port it's listening on once it starts. Then ALWAYS report the tailnet HTTPS URL, ` +
     `not just localhost: ensure the mapping \`tailscale serve --bg --https <port> http://localhost:<port>\` ` +
     `is registered, resolve this node's MagicDNS name (e.g. \`tailscale status --json\` → Self.DNSName), ` +
@@ -2112,12 +2120,14 @@ export class SessionService {
 
   /**
    * Steer the agent for session `id` to start its dev server with `command` running
-   * in the background. The agent's PTY is a live Claude Code session — we can't spawn
-   * processes ourselves, so we deliver a directive asking the agent to do it. Returns
-   * false for an unknown id or a dead pane (same semantics as reply()).
+   * in the background. The agent's PTY is a live CLI session — we can't spawn processes
+   * ourselves, so we deliver a directive asking the agent to do it. Returns false for
+   * an unknown id or a dead pane (same semantics as reply()).
    */
   startPreview(id: string, command: string): boolean {
-    return this.reply(id, PREVIEW_START_STEER(command));
+    const s = this.deps.store.get(id);
+    if (!s) return false;
+    return this.reply(id, PREVIEW_START_STEER(command, s.agentProvider ?? "claude"));
   }
 
   /**

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -3564,7 +3564,11 @@ test("create with draftMode=false: system prompt has no <draft-mode> block", asy
 
 // ── startPreview ──────────────────────────────────────────────────────────────
 
-function makePreviewSvc(opts: { terminalId: string; liveIds: string[] }) {
+function makePreviewSvc(opts: {
+  terminalId: string;
+  liveIds: string[];
+  agentProvider?: "claude" | "codex";
+}) {
   const sent: { target: string; text: string }[] = [];
   const store = new SessionStore(":memory:");
   const s = store.create({
@@ -3577,6 +3581,7 @@ function makePreviewSvc(opts: { terminalId: string; liveIds: string[] }) {
     isolated: true,
     herdrSession: "default",
     herdrAgentId: opts.terminalId,
+    agentProvider: opts.agentProvider,
   });
   const svc = new SessionService({
     store,
@@ -3616,6 +3621,29 @@ test("startPreview: sends PREVIEW_START_STEER as bracketed paste + CR, returns t
 test("startPreview: steer contains the command in backticks", () => {
   const steer = PREVIEW_START_STEER("cd ui && npm run dev");
   expect(steer).toContain("`cd ui && npm run dev`");
+});
+
+test("startPreview: claude steer keeps the Claude Code background wording", () => {
+  const steer = PREVIEW_START_STEER("bun run dev");
+  expect(steer).toContain("For Claude Code:");
+  expect(steer).toContain("use Claude Code's background run / append `&`");
+  expect(steer).not.toContain("For Codex:");
+});
+
+test("startPreview: codex steer uses Codex background terminal wording", () => {
+  const { svc, s, sent } = makePreviewSvc({
+    terminalId: "term_c",
+    liveIds: ["term_c"],
+    agentProvider: "codex",
+  });
+  const result = svc.startPreview(s.id, "bun run dev");
+  expect(result).toBe(true);
+  const [paste] = sent;
+  expect(paste!.text).toContain("For Codex:");
+  expect(paste!.text).toContain("Codex-managed long-running/background terminal command");
+  expect(paste!.text).toContain("`/ps`");
+  expect(paste!.text).toContain("`/stop`");
+  expect(paste!.text).not.toContain("For Claude Code:");
 });
 
 test("startPreview: steer demands the tailnet HTTPS URL, not just localhost", () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -471,7 +471,7 @@
   "viewport_preview_open_new_tab": "In neuem Tab öffnen",
   "viewport_preview_setup_hint": "Leer? Stelle sicher, dass der Vorschau-Port über Tailscale erreichbar ist; siehe Setup.",
   "viewport_preview_start": "Devserver starten",
-  "viewport_preview_start_note": "Tippt einen Entwicklungsserver-Startbefehl in das aktive Terminal des Agenten",
+  "viewport_preview_start_note": "Sendet die agent-spezifische Hintergrund-Startanweisung in das aktive Terminal",
   "viewport_preview_start_sent": "Vorschau-Start an {name} gesendet (läuft: {command})",
   "viewport_preview_start_failed": "Vorschau konnte nicht gestartet werden; Terminal auf Details prüfen",
   "viewport_preview_start_confirm_working": "Start bestätigen (Agent aktiv)",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -471,7 +471,7 @@
   "viewport_preview_open_new_tab": "Open in new tab",
   "viewport_preview_setup_hint": "Blank? Ensure the preview port is reachable over Tailscale; see setup.",
   "viewport_preview_start": "Start dev server",
-  "viewport_preview_start_note": "Types a dev-server start command into the agent's live terminal",
+  "viewport_preview_start_note": "Sends the agent-specific background-start instruction into the live terminal",
   "viewport_preview_start_sent": "Preview start sent to {name} (running: {command})",
   "viewport_preview_start_failed": "Couldn't start preview; check terminal for details",
   "viewport_preview_start_confirm_working": "Confirm start (agent busy)",


### PR DESCRIPTION
## Summary
- send provider-specific dev-server start steers from the preview start action
- keep the Claude Code background-run wording intact and add Codex background-terminal wording
- update the preview start tooltip copy in EN/DE

## Verification
- bun test test/service.test.ts --test-name-pattern startPreview
- bun run lint
- cd ui && bun run check:i18n
- cd ui && bun run check
- pre-push hook passed (prettier, eslint, tsc, ext, root-tests, ui, gates; fallow reported one inherited duplicate outside this change)