### PR TITLE
fix(ui): surface held-task spawn/discard failures inline

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1614,6 +1614,8 @@
   "topbar_held_spawn_cli_label": "Starten mit",
   "topbar_held_original_cli": "Zurückgestellt für {cli}",
   "topbar_held_discard": "Verwerfen",
+  "topbar_held_spawn_failed": "Aufgabe konnte nicht gestartet werden. Sie bleibt zurückgehalten – bitte erneut versuchen.",
+  "topbar_held_discard_failed": "Aufgabe konnte nicht verworfen werden. Bitte erneut versuchen.",
   "topbar_held_empty": "Keine zurückgehaltenen Aufgaben",
   "topbar_held_why": "Zurückgehalten, weil die Nutzung hoch ist – sie starten automatisch beim nächsten Reset.",
   "topbar_held_why_at": "Nächster Reset {time}.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1614,6 +1614,8 @@
   "topbar_held_spawn_cli_label": "Run on",
   "topbar_held_original_cli": "Held for {cli}",
   "topbar_held_discard": "Discard",
+  "topbar_held_spawn_failed": "Couldn't start the held task. It's still held — try again.",
+  "topbar_held_discard_failed": "Couldn't discard the held task. Try again.",
   "topbar_held_empty": "No held tasks",
   "topbar_held_why": "Held because usage is high — they start automatically when usage resets.",
   "topbar_held_why_at": "Next reset {time}.",

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -770,6 +770,49 @@ describe("TopBarHeldBadge — mobile held-task dialog", () => {
     await close.click();
     expect(closeHeldPop).toHaveBeenCalledWith(true);
   });
+
+  it("shows an inline error when a held-task spawn was refused server-side", async () => {
+    await page.viewport(390, 844);
+    document.body.style.width = "390px";
+    const heldItems: HeldTask[] = [
+      {
+        id: "held-1",
+        repoPath: "/work/shepherd",
+        createdAt: 1_700_000_000_000,
+        input: {
+          repoPath: "/work/shepherd",
+          baseBranch: "main",
+          prompt: "Die Buttons sind hier der Engpass auf meinem Smartphone",
+          agentProvider: "claude",
+          model: null,
+        },
+      },
+    ];
+
+    render(TopBarHeldBadge, {
+      heldCount: 1,
+      mobile: true,
+      compactBadges: false,
+      hotter: null,
+      nowMs: 1_700_000_000_000,
+      heldPopFlipUp: false,
+      heldItems,
+      heldLoading: false,
+      heldErrors: { "held-1": "spawn" },
+      heldPopOpen: true,
+      heldBadgeBtn: null,
+      heldPopEl: null,
+      toggleHeldPop: vi.fn(),
+      closeHeldPop: vi.fn(),
+      doSpawnHeld: vi.fn(),
+      doDiscardHeld: vi.fn(),
+    });
+    await nextFrame();
+
+    // The failure surfaces inline (a toast would render behind the fullscreen dialog),
+    // announced assertively so it reaches a screen reader.
+    await expect.element(page.getByRole("alert")).toHaveTextContent(m.topbar_held_spawn_failed());
+  });
 });
 
 describe("TopBar — working-while-blocked counts in the working tally, not blocked", () => {

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -329,21 +329,31 @@
     else openHeldPop();
   }
 
+  // Per-task action error, shown inline in the held popover. A spawn/discard can be
+  // refused server-side (sandbox block, name collision, herdr failure, already gone)
+  // and the task stays in the list — without feedback the button reads as dead. A
+  // toast won't do: the mobile popover is a fullscreen portal at the same z-index as
+  // the toast stack, so a bottom toast renders behind it. Inline feedback lives inside
+  // the surface and stays visible on both desktop and mobile.
+  let heldErrors = $state<Record<string, "spawn" | "discard">>({});
+
   async function doSpawnHeld(id: string, agentProvider?: AgentProvider) {
+    delete heldErrors[id];
     try {
       await spawnHeld(id, agentProvider);
       await loadHeld();
     } catch {
-      // ignore; WS will update count
+      heldErrors[id] = "spawn";
     }
   }
 
   async function doDiscardHeld(id: string) {
+    delete heldErrors[id];
     try {
       await discardHeld(id);
       await loadHeld();
     } catch {
-      // ignore
+      heldErrors[id] = "discard";
     }
   }
 
@@ -610,6 +620,7 @@
       {heldPopFlipUp}
       {heldItems}
       {heldLoading}
+      {heldErrors}
       bind:heldPopOpen
       bind:heldBadgeBtn
       bind:heldPopEl

--- a/ui/src/lib/components/top-bar/TopBarHeldBadge.svelte
+++ b/ui/src/lib/components/top-bar/TopBarHeldBadge.svelte
@@ -35,6 +35,7 @@
     heldPopFlipUp,
     heldItems,
     heldLoading,
+    heldErrors = {},
     heldPopOpen = $bindable(),
     heldBadgeBtn = $bindable(null),
     heldPopEl = $bindable(null),
@@ -51,6 +52,7 @@
     heldPopFlipUp: boolean;
     heldItems: HeldTask[];
     heldLoading: boolean;
+    heldErrors?: Record<string, "spawn" | "discard">;
     heldPopOpen: boolean;
     heldBadgeBtn: HTMLButtonElement | null;
     heldPopEl: HTMLDivElement | null;
@@ -100,6 +102,13 @@
             class="held-action held-discard"
             onclick={() => doDiscardHeld(task.id)}>{m.topbar_held_discard()}</button
           >
+          {#if heldErrors[task.id]}
+            <p class="held-row-error" role="alert">
+              {heldErrors[task.id] === "spawn"
+                ? m.topbar_held_spawn_failed()
+                : m.topbar_held_discard_failed()}
+            </p>
+          {/if}
         </div>
       </div>
     {/each}
@@ -419,6 +428,12 @@
     border-color: var(--color-amber);
     color: var(--color-amber);
   }
+  .held-row-error {
+    margin: 0;
+    color: var(--color-red);
+    font-size: var(--fs-micro);
+    line-height: 1.35;
+  }
   .held-spawn {
     color: var(--color-amber);
     border-color: var(--color-amber);
@@ -455,9 +470,13 @@
     gap: 8px;
     width: 100%;
   }
-  .held-fullscreen .held-cli {
+  .held-fullscreen .held-cli,
+  .held-fullscreen .held-row-error {
     grid-column: 1 / -1;
     gap: 4px;
+  }
+  .held-fullscreen .held-row-error {
+    font-size: var(--fs-meta);
   }
   .held-fullscreen .held-cli select,
   .held-fullscreen .held-action {


### PR DESCRIPTION
## Problem

On a phone (and desktop), tapping **Jetzt starten** / **Verwerfen** on a held task could appear to do **nothing** — "passiert einfach gar nix."

The tap *was* reaching the handler. The real cause was silent error-swallowing: `POST /api/held/:id/spawn` can legitimately fail (sandbox auto-refusal `403`, agent-name collision `409`, herdr/git failure `502`, bad request `400`) and the task stays in the held store — but `doSpawnHeld` / `doDiscardHeld` caught the error in an empty `catch {}` and showed no feedback. The row stayed put, the user re-tapped, still nothing.

## Fix

Surface a per-task **inline error** inside the held popover (`role="alert"`), e.g. _"Aufgabe konnte nicht gestartet werden. Sie bleibt zurückgehalten – bitte erneut versuchen."_ Retrying is just tapping the button again — the error clears on the next attempt.

### Why inline and not a toast

The mobile held dialog (#1103) is a **fullscreen portal at `z-index: 60`** appended to `<body>`, and the toast stack is *also* `z-index: 60` but earlier in DOM order — so a bottom-anchored toast would render **behind** the dialog and the user would still see nothing. Inline feedback lives inside the surface itself, so it's visible in both the desktop anchored popover and the mobile fullscreen dialog.

## Changes

- `TopBar.svelte` — track a per-id `heldErrors` map; set it when spawn/discard rejects, clear it at the start of each attempt.
- `TopBarHeldBadge.svelte` — render the inline `role="alert"` error per row (spans both columns in the fullscreen variant); tokens only (`--color-red`, `--fs-micro`/`--fs-meta`).
- `en.json` / `de.json` — `topbar_held_spawn_failed`, `topbar_held_discard_failed` (parity passes).
- Test — asserts the inline alert renders with the failure copy on iPhone width.

## Verification

- `bun run check:i18n` ✓ (parity, 1977 keys)
- `bun run check` (svelte-check) ✓ 0 errors
- `bun run test src/lib/components/TopBar.browser.test.ts` ✓ 62/62 (incl. new test)

Note: the full UI suite shows 4–5 flaky failures in `GitRail.browser.test.ts` (a `marked`+DOMPurify dynamic-import timeout under parallel CPU load) — unrelated to this diff; GitRail passes in isolation on both the pristine and modified trees.
