### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -13,6 +13,7 @@ lines), read by the systemd unit if present.
 | --- | --- | --- |
 | `SHEPHERD_PORT` | `7330` | HTTP/WS listen port |
 | `SHEPHERD_HOST` | `127.0.0.1` | Bind address; loopback-only by default (set `0.0.0.0` to expose all NICs) |
+| `SHEPHERD_AGENT_INGRESS_PORT` | `SHEPHERD_PORT + 1` (e.g. `7331`) | Pinned loopback port for the auth-exempt agent-ingress listener (agent hook callbacks). Stable so the URL baked into a live agent's `--settings` survives restarts/deploys; validated at startup against collisions with the main port, served port, or preview range. Set `0` for an ephemeral port (the pre-pinning behavior) |
 | `SHEPHERD_DB` | `~/.shepherd/shepherd.db` | SQLite session store path |
 | `SHEPHERD_BACKUP_DIR` | `~/.shepherd/backups` (next to the DB) | Destination dir for the automated hourly SQLite backups (Linux backup timer); see [Operating Shepherd](/operating/) |
 | `SHEPHERD_REPO_ROOT` | `~` (home) | Repos must live under this root (spawn is confined to it) |


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc update — sync to recent source changes

## Changes

- **`docs-site/src/content/docs/reference/configuration.md`** — Added a Core-table
  row for `SHEPHERD_AGENT_INGRESS_PORT`. This env var was introduced by #1083 /
  #1085 ("pin agent-ingress port so live sessions survive restarts") and is present
  in `src/config.ts` (the `agentIngressPort` field, default `mainPort + 1`, `0` =
  ephemeral, validated by `validateAgentIngressPort`) and already documented in the
  repo `README.md`, but was missing from the docs-site configuration reference. The
  new row mirrors the README wording (default `SHEPHERD_PORT + 1`, startup-validated
  against collisions with the main/served/preview ports, `0` for ephemeral).

## Uncertain / needs human judgment

- **Codex agent provider (alpha).** Recent commits (#1086 "add Codex coding CLI
  alpha path", #1091 Codex model selection, #1099, #1100) added a second agent
  provider alongside Claude Code: `AGENT_PROVIDERS = ["claude", "codex"]`
  (`src/types.ts`), a `SHEPHERD_DEFAULT_AGENT_PROVIDER` env var and `defaultModel`
  /`defaultAgentProvider` config (`src/config.ts`), and a curated Codex model list.
  None of the in-scope prose pages mention Codex, and the canonical `README.md`
  config table does **not** yet document `SHEPHERD_DEFAULT_AGENT_PROVIDER` either,
  so I treated this as an alpha/in-flight surface and did **not** add it. If Codex
  is meant to be operator-facing in the docs, candidates would be: a glossary entry
  ("agent provider"/"Codex"), a `SHEPHERD_DEFAULT_AGENT_PROVIDER` row in
  `configuration.md`, and softening the "Claude Code agents" framing in `index.md` /
  `getting-started.md`. Left for human judgment because the feature is flagged as
  alpha and not yet reflected in the README baseline.

- **Other curated env vars absent from `configuration.md`.** The Core table is a
  deliberately curated subset and omits several real env vars (e.g.
  `SHEPHERD_DEFAULT_MODEL`, `SHEPHERD_AUTH_MODE`, `SHEPHERD_FABLE_AVAILABLE`,
  `SHEPHERD_COOKIE_SECRET` is present but others are not). I did not add these — they
  are not new/stale relative to the page's existing scope, and expanding coverage is
  an editorial decision, not a staleness fix.

- **`sandbox-security.md` egress allowlist — verified, NOT changed.** I checked
  `src/egress.ts`: the autonomous-profile allowlist is still `api.anthropic.com` +
  `statsig.anthropic.com` + the GitHub host set + operator extras (no OpenAI/Codex
  hosts). The doc's description remains accurate, so no edit was made.

- **`token-usage-analysis.md` — NOT changed.** This is a point-in-time historical
  report of five specific tasks; it is not invalidated by later source changes.