### PR TITLE
fix(ui): order Settings above feedback links in mobile gear sheet

### DIFF
--- a/ui/src/lib/components/top-bar/TopBarMobileSheet.svelte
+++ b/ui/src/lib/components/top-bar/TopBarMobileSheet.svelte
@@ -325,6 +325,13 @@
       <div class="sheet-sep"></div>
     {/if}
 
+    <!-- Settings -->
+    <button type="button" class="sheet-item" onclick={chooseSettings}>
+      <span class="sheet-glyph" aria-hidden="true">⚙</span>
+      <span class="sheet-label">{m.settings_title()}</span>
+    </button>
+    <div class="sheet-sep"></div>
+
     <!-- Feedback -->
     <button type="button" class="sheet-item" onclick={() => onFeedback("bug")}>
       <span class="sheet-glyph" aria-hidden="true">🐛</span>
@@ -337,13 +344,6 @@
     <button type="button" class="sheet-item" onclick={() => onFeedback("feedback")}>
       <span class="sheet-glyph" aria-hidden="true">💬</span>
       <span class="sheet-label">{m.feedback_dialog_title_feedback()}</span>
-    </button>
-    <div class="sheet-sep"></div>
-
-    <!-- Settings -->
-    <button type="button" class="sheet-item" onclick={chooseSettings}>
-      <span class="sheet-glyph" aria-hidden="true">⚙</span>
-      <span class="sheet-label">{m.settings_title()}</span>
     </button>
 
     <!-- Docs + version footer -->


### PR DESCRIPTION
## What

In the **mobile gear bottom sheet** (`TopBarMobileSheet.svelte`), move **Settings** above the three feedback links (Report a bug / Request a feature / Send feedback).

Before: …Feedback links → divider → Settings
After: …Settings → divider → Feedback links

## Why

The **desktop** gear menu (`TopBarGear.svelte`) already lists Settings above the feedback links. The mobile sheet had them reversed — this aligns mobile with the established desktop ordering (per the attached screenshot request).

## Scope

- Pure markup reorder in one file; the single `sheet-sep` divider is preserved between the two groups and before the Docs footer.
- No logic, props, handlers, styles, or strings changed — reuses existing i18n keys.
- No new user-facing capability, so no feature-catalog entry (`[no-feature-entry]`). Desktop menu untouched.

## Verification

- `cd ui && bun run check` → 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)