### PR TITLE
fix(ui): heartbeat full width in compact herd sidebar

### DIFF
--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -824,9 +824,9 @@
     line-height: 1.3;
     color: var(--color-muted);
   }
-  /* The heartbeat claims the whole activity line on every device. Scoped under
-     .u-activity so the strip override can't leak to a future global .strip; kept
-     before the narrow @container block so that block's 64px override still wins. */
+  /* The heartbeat claims the whole activity line on every device — including the
+     narrow ≤300px sidebar (no container-query override pins it back). Scoped under
+     .u-activity so the rule can't leak to a future global .strip. */
   .u-activity :global(.strip) {
     flex: 1 1 auto;
     width: auto;

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -935,17 +935,14 @@
       -webkit-line-clamp: 1;
       line-clamp: 1;
     }
-    /* keep the heartbeat (tiny), drop the stepper so a narrow sidebar row stays
-       dense and doesn't balloon */
+    /* drop the stepper so a narrow sidebar row stays dense and doesn't balloon.
+       The heartbeat strip is deliberately NOT pinned narrow here (was flex:none/
+       width:64px): on the unfolded-foldable compact sidebar that left it a ~64px
+       stub, so it now inherits the full-width default above and spans the activity
+       row on every device — matching the strip's "claims the whole activity line"
+       intent. */
     .meta-stepper {
       display: none;
-    }
-    /* the strip IS the heartbeat here — keep it, just narrower. Scoped under
-       .u-activity so the override can't leak to a future global .strip. flex:none
-       overrides the full-width grow above so the narrow strip stays at 64px. */
-    .u-activity :global(.strip) {
-      flex: none;
-      width: 64px;
     }
   }
 


### PR DESCRIPTION
## Problem

On an unfolded foldable, the live-activity **heartbeat strip** under a running session's row rendered as a ~64px stub instead of spanning the activity row (see report screenshot).

## Root cause

The unfolded foldable uses the **two-column desktop layout** with the **compact sidebar** (`.grid.compact` → `grid-template-columns: minmax(244px, 288px) 1fr`, `ui/src/routes/+page.svelte`). That makes the herd `.units` container (`container: herd / inline-size`) ≤300px wide, triggering `@container herd (max-width: 300px)` in `UnitRow.svelte`, which pinned the strip to `flex: none; width: 64px` — overriding the full-width default (`flex: 1 1 auto; width: auto; max-width: none`).

Mobile phones (flow mode, full-width container >300px) never hit the query and were already full-width; only the narrow sidebar got the stub.

## Fix

Remove the 64px strip override from the 300px container query so the strip inherits the full-width default in every ≤300px sidebar. Per operator decision, this applies to **all** narrow sidebars (foldable compact + narrow desktop), with no `pointer: coarse` guard — consistent with the strip's documented "claims the whole activity line on every device" intent.

The unrelated density choices in that block are kept: dropped stepper (`.meta-stepper { display: none }`), single-line prompt clamp, tighter column-gap.

## Deliberate deviation (house rule)

This **reverts a deliberately documented density pin** (the `64px` width was an intentional choice in the 300px container query). Flagged in the code comment and here per the repo's prior-art-deviation rule. It aligns with the strip's own stated principle and the user's report.

## Verification

- `cd ui && bun run check` — 0 errors, 0 warnings.
- `UnitRow.browser.test.ts` — 19/19 pass.
- Branch-hygiene gate + fallow pre-push gate pass.
- CSS-cascade reasoning: removing the override leaves the proven full-width default (already known-good at wider sidebar widths); the container-query removal cannot make the strip narrower than that default.

[no-feature-entry] — no new user-facing feature; an existing element's width changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)