### PR TITLE
fix(ui): equalize compact NEEDS YOU + held-badge height

### DIFF
--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -955,6 +955,11 @@
     padding: 8px 10px;
     letter-spacing: 0;
     font-variant-numeric: tabular-nums;
+    /* pin the line box to 1×font-size so the compact badge height is
+       font-independent and matches .held-badge.compact: this badge renders in the
+       UA button font (no font-family set) while the held badge uses `font: inherit`
+       (mono), so their `normal` line-heights otherwise differ by ~2px. */
+    line-height: 1;
   }
   .needsyou.compact .ny-icon {
     font-weight: 700;

--- a/ui/src/lib/components/top-bar/TopBarHeldBadge.svelte
+++ b/ui/src/lib/components/top-bar/TopBarHeldBadge.svelte
@@ -122,6 +122,7 @@
       bind:this={heldBadgeBtn}
       class="held-badge"
       class:compact={mobile || compactBadges}
+      class:mobile
       type="button"
       aria-haspopup="dialog"
       aria-expanded={heldPopOpen}
@@ -232,6 +233,22 @@
     justify-content: center;
     min-width: 44px;
     letter-spacing: 0;
+    /* mirror .needsyou.compact padding so both compact badges share the same box
+       height when neither carries a min-height floor (fine-pointer desktop overflow) */
+    padding: 8px 10px;
+    /* pin the line box to 1×font-size so height is font-independent: `.needsyou`
+       renders in the UA button font while this badge uses `font: inherit` (mono),
+       and their `normal` line-heights differ by ~2px. `.needsyou.compact` carries
+       the matching `line-height: 1`. */
+    line-height: 1;
+  }
+  /* Width-gated 44px floor mirroring `.hud.mobile .needsyou` (TopBar.svelte): `mobile`
+     is width-only (≤768px), so fine-pointer narrow viewports need this — the coarse-
+     pointer floor below does not cover them. Keyed off `mobile`, NOT `.compact`, so it
+     never fires in the desktop measured-overflow case where needsyou has no floor (~36px),
+     which would otherwise make held the taller box. */
+  .held-badge.mobile {
+    min-height: 44px;
   }
   .held-badge .held-n {
     font-weight: 600;


### PR DESCRIPTION
## What

In the top bar's right-side cluster, the **NEEDS YOU** badge and the **held-tasks** badge sit side by side. In their **compact** form they rendered at unequal heights. This equalizes them across every context.

## Root cause — three diverging height drivers

1. **Padding.** `.held-badge.compact` never overrode the base `3px 8px`, while `.needsyou.compact` uses `8px 10px` → needsyou ~10px taller.
2. **Line box (the subtle one).** `.needsyou` sets no `font-family`, so it renders in the **UA button font** (sans; `normal` line-height ≈ 1.09), while `.held-badge` uses `font: inherit` → **monospace** (`normal` ≈ 1.27). There's no global `button { font: inherit }` reset, so even after matching padding a **~2px residual** remained.
3. **`min-height` floor.** needsyou gets a *width-gated* 44px floor via `.hud.mobile .needsyou` (not pointer-gated); the held badge's only floor was `@media (pointer: coarse)`, so a **narrow fine-pointer (≤768px)** viewport left it short.

## Fix

In `TopBarHeldBadge.svelte`:
- `padding: 8px 10px` on `.held-badge.compact` (mirror `.needsyou.compact`)
- `line-height: 1` on `.held-badge.compact` (font-independent line box)
- `class:mobile` on the badge button + `.held-badge.mobile { min-height: 44px }` mirroring the needsyou width-gated floor

In `TopBar.svelte`:
- matching `line-height: 1` on `.needsyou.compact`

## ⚠️ Deliberate deviation from the approved plan

The plan scoped this to **one file** (`TopBarHeldBadge.svelte`). Execution-time browser measurement revealed the font-driven ~2px residual (driver #2), which can only be fixed font-independently by pinning `line-height: 1` on **both** badges — so `.needsyou.compact` in `TopBar.svelte` is also touched. Flagged here, in code comments on both rules, and in `.shepherd-plan.md`.

## Verification

Measured computed box heights in a headless-Chromium harness replicating the exact winning CSS for all four contexts (font-independence confirmed by testing needsyou in both sans and mono):

| Context (`mobile` / pointer / `compactBadges`) | needsyou | held | equal |
| --- | --- | --- | --- |
| Desktop overflow — false / fine / compact | 29px | 29px | ✓ |
| Coarse wide — false / coarse | 44px | 44px | ✓ |
| Narrow fine — true / fine (≤768px) | 44px | 44px | ✓ |
| Narrow coarse — true / coarse | 44px | 44px | ✓ |

`cd ui && bun run check` passes (0 errors, 0 warnings). Pre-push gates (branch-hygiene, i18n, feature-catalog, fallow) green. No new user-facing strings; not a `feat`, so no feature-catalog entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)