### PR TITLE
fix(top-bar): homogenize text size in mobile held popover

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1618,7 +1618,7 @@
   "topbar_held_discard_failed": "Aufgabe konnte nicht verworfen werden. Bitte erneut versuchen.",
   "topbar_held_empty": "Keine zurückgehaltenen Aufgaben",
   "topbar_held_why": "Zurückgehalten, weil die Nutzung hoch ist – sie starten automatisch beim nächsten Reset.",
-  "topbar_held_why_at": "Nächster Reset {time}.",
+  "topbar_held_why_at": " Nächster Reset {time}.",
   "retry_title": "Halted wiederholen",
   "retry_confirm": "{count} Sitzungen wiederholen",
   "retry_arm": "Wiederholen bestätigen ({count})?",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1618,7 +1618,7 @@
   "topbar_held_discard_failed": "Couldn't discard the held task. Try again.",
   "topbar_held_empty": "No held tasks",
   "topbar_held_why": "Held because usage is high — they start automatically when usage resets.",
-  "topbar_held_why_at": "Next reset {time}.",
+  "topbar_held_why_at": " Next reset {time}.",
   "retry_title": "Retry halted",
   "retry_confirm": "Retry {count} sessions",
   "retry_arm": "Confirm retry {count}?",

--- a/ui/src/lib/components/top-bar/TopBarHeldBadge.svelte
+++ b/ui/src/lib/components/top-bar/TopBarHeldBadge.svelte
@@ -480,16 +480,21 @@
     text-overflow: clip;
     white-space: normal;
     line-height: 1.35;
+    /* Match the select, which the iOS zoom-guard (app.css) floors to
+       max(16px, var(--fs-lg)) on mobile — keep title/buttons on the same
+       expression so the fullscreen popover reads as one size at every scale. */
+    font-size: max(16px, var(--fs-lg));
   }
+  /* Single full-width column: at enlarged iOS Dynamic Type (--ui-scale up to
+     1.5 → 24px) a 16px label like the German "Jetzt starten" truncates inside a
+     2-up grid at 320px; full-width buttons render every locale's labels in full. */
   .held-fullscreen .held-row-actions {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    display: flex;
+    flex-direction: column;
     gap: 8px;
     width: 100%;
   }
-  .held-fullscreen .held-cli,
-  .held-fullscreen .held-row-error {
-    grid-column: 1 / -1;
+  .held-fullscreen .held-cli {
     gap: 4px;
   }
   .held-fullscreen .held-row-error {
@@ -501,10 +506,9 @@
     padding: 0 12px;
   }
   .held-fullscreen .held-action {
-    font-size: var(--fs-base);
+    /* Same expression as the iOS-floored select (see .held-row-prompt above). */
+    font-size: max(16px, var(--fs-lg));
     letter-spacing: 0.04em;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
   @media (max-width: 420px) {
     .held-pop:not(.held-fullscreen) .held-row {


### PR DESCRIPTION
## What

Homogenize the text size in the **mobile fullscreen** Held-tasks popover and fix a missing space in its "why" line.

| Before | After |
| --- | --- |
| `Claude Code` `<select>` towers over the 13px task title and `Spawn now` / `Discard` buttons | title, select, and buttons all render at one size |
| `…when usage resets.Next reset 1d.` (no space) | `…when usage resets. Next reset 1d.` |

## Why

On mobile the global iOS zoom-guard (`ui/src/app.css:342`) floors every `<select>` to `max(16px, var(--fs-lg))` — focusing a sub-16px form control zooms the whole page, so that floor is deliberate and must stay. In the popover's fullscreen layout the floored select therefore sat at 16px while its neighbours were 13px, so it dwarfed them. The fix matches the neighbours **up** to the select's locked size (shrinking the select would reintroduce the focus-zoom).

## Changes

- `TopBarHeldBadge.svelte` — in `.held-fullscreen`, set the task title (`.held-row-prompt`) and action buttons (`.held-action`) to the same `max(16px, var(--fs-lg))` the guard pins the select to.
- Switch the fullscreen actions from a 2-column grid to a **single full-width column**. At enlarged iOS Dynamic Type (`--ui-scale` up to its 1.5 cap → 24px), a 16px German label like *"Jetzt starten"* truncates to *"tzt start"* inside the 2-up grid at 320px; full-width buttons render every locale's labels in full.
- Add the join space via a leading space on `topbar_held_why_at` (EN + DE).

## Scope

**Mobile fullscreen only.** The anchored layout renders only above 768px, where the select is *not* floored — select and buttons are both 11px and the title is 13px (intended title>controls hierarchy, no oversizing anomaly). The anchored/desktop layout is unchanged.

## Deliberate deviations from the approved plan (flagged per house rules)

- **Join space:** the plan used a `{" "}` template literal at both render sites; ESLint's `svelte/no-useless-mustaches` rejects that. Moved the space into the message catalog instead (leading space on `topbar_held_why_at`, which is only ever appended after `topbar_held_why`). Same rendered result; both render sites fixed; `check:i18n` parity unaffected.
- **Single-column actions:** beyond pure font-size, but a necessary consequence of homogenizing up (larger text needs full width) and the review-sanctioned remedy for the German-label truncation.
- **Token form:** title/buttons use `max(16px, var(--fs-lg))` (the guard's exact expression), not a bare `var(--fs-lg)` token, so they never drift from the floored select under a non-default `--ui-scale`. Noted in a code comment.

## Verification

`cd ui && bun run check` (svelte-check 0 errors), `check:i18n` (parity), and 2072 UI tests pass. Rendered with the final CSS across the matrix — title = select = buttons at one size, no label truncation, why-line spaced:

| Viewport | Locale | Dynamic Type | Result |
| --- | --- | --- | --- |
| 360px | en | 1.0 | uniform; `…resets. Next reset 1d.` |
| 320px | de | 1.5 (24px) | uniform; *"Jetzt starten" / "Verwerfen"* full, no truncation; `…Reset. Nächster Reset 1d.` |
| ≥769px | en | 1.0 | anchored/desktop layout unchanged |
