### PR TITLE
fix(ui): follow herd repo filter onto a newly started task's repo

### DIFF
--- a/ui/src/lib/components/queue-strip.test.ts
+++ b/ui/src/lib/components/queue-strip.test.ts
@@ -13,6 +13,7 @@ import {
   queueOpenable,
   repoChipRows,
   shouldClearRepoFilter,
+  shouldFollowFilterToRepo,
 } from "./queue-strip";
 import type { RepoChip } from "./queue-strip";
 import type { BlockState } from "../triage";
@@ -471,6 +472,22 @@ describe("shouldClearRepoFilter", () => {
 
   it("TRUE when no chips remain (all sessions ended)", () => {
     expect(shouldClearRepoFilter("/repos/a", [])).toBe(true);
+  });
+});
+
+// ─── shouldFollowFilterToRepo ─────────────────────────────────────────────────
+
+describe("shouldFollowFilterToRepo", () => {
+  it("false when no filter is active (null) — 'all repos' already shows the task", () => {
+    expect(shouldFollowFilterToRepo(null, "/repos/a")).toBe(false);
+  });
+
+  it("false when the filter already points at the new task's repo", () => {
+    expect(shouldFollowFilterToRepo("/repos/a", "/repos/a")).toBe(false);
+  });
+
+  it("TRUE when the filter is pinned to a different repo — would hide the new task", () => {
+    expect(shouldFollowFilterToRepo("/repos/a", "/repos/b")).toBe(true);
   });
 });
 

--- a/ui/src/lib/components/queue-strip.ts
+++ b/ui/src/lib/components/queue-strip.ts
@@ -98,6 +98,14 @@ export function shouldClearRepoFilter(repoFilter: string | null, chips: RepoChip
   return repoFilter !== null && !chips.some((c) => c.repoPath === repoFilter);
 }
 
+/** Whether the herd's repo filter should follow a just-started task onto its repo.
+ *  A new task lands in `repoPath`; if the filter is pinned to a *different* repo the
+ *  task would be hidden behind that stale filter — so follow it. A null filter ("all
+ *  repos") already shows the task, and a filter already on `repoPath` needs no change. */
+export function shouldFollowFilterToRepo(repoFilter: string | null, repoPath: string): boolean {
+  return repoFilter !== null && repoFilter !== repoPath;
+}
+
 /**
  * The session the terminal should re-target onto after the user picks a repo chip.
  * Narrowing the herd to a repo would otherwise leave the terminal on whatever session

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -95,6 +95,7 @@
     pickRepoSwitchTarget,
     repoChipRows,
     shouldClearRepoFilter,
+    shouldFollowFilterToRepo,
   } from "$lib/components/queue-strip";
   import BacklogView from "$lib/components/BacklogView.svelte";
   import AppOverlays from "$lib/components/page/AppOverlays.svelte";
@@ -217,6 +218,14 @@
   $effect(() => {
     const rf = repoFilter;
     if (rf == null) return; // "all repos" view keeps selection whole
+    // selectNewSession already pointed selection at a just-created session in `rf`
+    // (not in the store yet — it arrives via WS), so skip the one re-target that
+    // would otherwise grab a *different* existing session in the repo. Plain `let`,
+    // not $state: reading/clearing it here must not feed back into reactivity.
+    if (followingNewSession) {
+      followingNewSession = false;
+      return;
+    }
     untrack(() => {
       const target = pickRepoSwitchTarget(
         rf,
@@ -427,6 +436,23 @@
 
   const selected = $derived(store.sessions.find((s) => s.id === selectedId) ?? null);
 
+  // One-shot guard: suppress the repo-switch re-target effect for the single filter
+  // change that selectNewSession makes (see that effect above). Non-reactive on purpose.
+  let followingNewSession = false;
+
+  // Select a freshly-started session and follow the herd's repo filter onto its repo.
+  // A new task lands in `repoPath`; if the filter is pinned to a *different* repo the
+  // task would be hidden behind that stale filter (the user just launched it but can't
+  // see it). null filter = "all repos" already shows it, so leave that view whole.
+  // Shared by every create/relaunch path so the behaviour can't drift between them.
+  function selectNewSession(id: string, repoPath: string) {
+    if (shouldFollowFilterToRepo(repoFilter, repoPath)) {
+      followingNewSession = true;
+      repoFilter = repoPath;
+    }
+    selectedId = id;
+  }
+
   // Retry-halted gate: how many sessions are usage-halted, and is usage back below the threshold?
   const haltedCount = $derived(store.sessions.filter((s) => s.haltReason === "usage_limit").length);
   const usageBelow = $derived(
@@ -618,7 +644,7 @@
         },
       });
       if ("held" in r) return;
-      selectedId = r.id;
+      selectNewSession(r.id, repoPath);
       showBacklog = false;
       if (mobile.current) mobileScreen = "detail";
     } catch {
@@ -659,7 +685,7 @@
             force: true,
           });
           if ("held" in r) return;
-          selectedId = r.id;
+          selectNewSession(r.id, repoPath);
           showBacklog = false;
           if (mobile.current) mobileScreen = "detail";
         } catch {
@@ -692,7 +718,7 @@
             force: true,
           });
           if ("held" in r) return;
-          selectedId = r.id;
+          selectNewSession(r.id, repoPath);
           showBacklog = false;
           if (mobile.current) mobileScreen = "detail";
         } catch {
@@ -1344,7 +1370,7 @@
         throw new Error(m.relaunch_issue_unresolved(), { cause: e });
       throw e instanceof Error ? e : new Error(m.relaunch_failed(), { cause: e });
     }
-    selectedId = result.session.id;
+    selectNewSession(result.session.id, input.repoPath);
     showNew = false;
     resetCompose();
     if (result.archived) toasts.info(m.relaunch_done({ desig: result.session.desig }));
@@ -1416,7 +1442,7 @@
       resetCompose();
       return;
     }
-    selectedId = r.id;
+    selectNewSession(r.id, input.repoPath);
     showNew = false;
     resetCompose();
   }

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -198,6 +198,17 @@
   // card's inline repo emoji; null = all repos. Only narrows the herd list views —
   // selection and global counts stay whole.
   let repoFilter = $state<string | null>(null);
+  // Latches set by selectNewSession when the herd filter follows a just-started task
+  // onto its repo. That session isn't in the store yet (it arrives via WS), so two
+  // effects below need coordinating until it does. Both are plain `let` (NON-reactive):
+  // reading/clearing them inside an effect must not feed back into reactivity.
+  //   • followingRepo — the followed repo path; holds the auto-clear effect off that
+  //     repo until its chip appears (else shouldClearRepoFilter, seeing no chip yet,
+  //     would immediately null the filter we just set). Released once the chip lands.
+  //   • followingNewSession — one-shot; suppresses the repo-switch re-target for the
+  //     single filter change selectNewSession makes (selection is already on the new task).
+  let followingRepo: string | null = null;
+  let followingNewSession = false;
   // Chips for the repo switcher: one per repo with a live session, computed from the
   // unfiltered herd (selection/global counts stay whole). Single source — passed to the switcher.
   const repoChips = $derived(
@@ -207,6 +218,15 @@
   // Clear the filter only when its repo has no live session left (no chip) —
   // a filter on a vanished repo would strand an empty view.
   $effect(() => {
+    // Release the follow latch once the just-started task's session has arrived (its
+    // chip now exists). repoChips is reactive, so its WS-driven change re-runs this.
+    if (followingRepo !== null && repoChips.some((c) => c.repoPath === followingRepo)) {
+      followingRepo = null;
+    }
+    // A just-followed repo has no chip until its session arrives — that gap is expected,
+    // not a vanished repo, so don't auto-clear the filter we just set onto it. Scoped to
+    // repoFilter === followingRepo so a *different* active filter still auto-clears normally.
+    if (repoFilter !== null && repoFilter === followingRepo) return;
     if (shouldClearRepoFilter(repoFilter, repoChips)) repoFilter = null;
   });
   // Picking a repo chip narrows the herd list to that repo — but the terminal would
@@ -217,15 +237,16 @@
   // session/block update that would yank the user off their session.
   $effect(() => {
     const rf = repoFilter;
+    // Consume the one-shot suppression FIRST — before any early return — so it can't
+    // leak (if the auto-clear effect nulled the filter this same flush, an early
+    // `rf == null` return would otherwise strand the flag true and suppress the next
+    // legitimate repo-chip re-target). selectNewSession already pointed selection at a
+    // just-started session in `rf` (not in the store yet — it arrives via WS), so when
+    // set this skips the one re-target that would grab a *different* existing session.
+    const skipFollow = followingNewSession;
+    followingNewSession = false;
     if (rf == null) return; // "all repos" view keeps selection whole
-    // selectNewSession already pointed selection at a just-created session in `rf`
-    // (not in the store yet — it arrives via WS), so skip the one re-target that
-    // would otherwise grab a *different* existing session in the repo. Plain `let`,
-    // not $state: reading/clearing it here must not feed back into reactivity.
-    if (followingNewSession) {
-      followingNewSession = false;
-      return;
-    }
+    if (skipFollow) return;
     untrack(() => {
       const target = pickRepoSwitchTarget(
         rf,
@@ -436,17 +457,16 @@
 
   const selected = $derived(store.sessions.find((s) => s.id === selectedId) ?? null);
 
-  // One-shot guard: suppress the repo-switch re-target effect for the single filter
-  // change that selectNewSession makes (see that effect above). Non-reactive on purpose.
-  let followingNewSession = false;
-
   // Select a freshly-started session and follow the herd's repo filter onto its repo.
   // A new task lands in `repoPath`; if the filter is pinned to a *different* repo the
   // task would be hidden behind that stale filter (the user just launched it but can't
   // see it). null filter = "all repos" already shows it, so leave that view whole.
   // Shared by every create/relaunch path so the behaviour can't drift between them.
+  // Arms both follow latches (declared near repoFilter) so the auto-clear and re-target
+  // effects coordinate until the new session arrives via WS.
   function selectNewSession(id: string, repoPath: string) {
     if (shouldFollowFilterToRepo(repoFilter, repoPath)) {
+      followingRepo = repoPath;
       followingNewSession = true;
       repoFilter = repoPath;
     }


### PR DESCRIPTION
## Problem

Starting a task in repo **X** while the herd was filtered to repo **Y** left the repo filter pinned to **Y** — so the freshly launched task was hidden behind the stale filter. Confusing, since the user just launched it and expects to see it. (Reported from the FleetView: a new task started in SHEPHERD, but the repo filter chip stayed on a different repo.)

## Fix

Every session-create path now routes selection through a shared `selectNewSession(id, repoPath)` helper that **follows the herd's repo filter onto the new task's repo**:

- `onsubmit` (New Task dialog)
- `submitRelaunch` (relaunch-elsewhere — can re-target a different repo)
- `onquickissue` (quick-start from the backlog)
- merge-train launches (`onmergetrain`, `onlaunchtrain`)

A `null` ("all repos") filter is left whole — it already shows the new task. A filter already on the task's repo needs no change.

The follow decision is a pure, tested predicate `shouldFollowFilterToRepo()` in `queue-strip.ts`, matching the existing `shouldClearRepoFilter` / `pickRepoSwitchTarget` helpers.

### Subtlety: re-target effect guard

`createSession` doesn't populate the store synchronously — the new session arrives via WebSocket. Changing `repoFilter` would otherwise fire the existing repo-switch re-target `$effect`, which (with the new session not yet in the store) would grab a *different* existing session in that repo and clobber the selection we just set. A one-shot non-reactive `followingNewSession` guard suppresses exactly that single re-target.

## Tests

- New unit tests for `shouldFollowFilterToRepo` (null filter, same-repo no-op, different-repo follow).
- `bun run check`, `check:i18n`, and the affected browser test files all pass. No new user-facing strings (bugfix), so no i18n keys or feature-catalog entry needed.