### PR TITLE
fix(top-bar): collapse tallies under overflow on unfolded foldables

### DIFF
--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -408,6 +408,44 @@ describe("TopBar — touch-desktop (unfolded fold) overflow is measurement-drive
       "sweep exercises the full state (some wide width keeps clock + full labels)",
     ).toBe(true);
   });
+
+  it("tallies COLLAPSE under measured overflow and stay FULL when there's room (held + needsYou + gauges)", async () => {
+    // The reported bug: on an unfolded fold the right-side cluster compacts but the tallies
+    // (HERD/BUSY/IDLE/BLOCKED) stay full-label off-`mobile`, so the bar still overflows and
+    // clips the gear. The fix extends compaction to the tallies on touch. Asserted as the
+    // same coupling invariant the test above uses — but for the TALLIES — over a width sweep,
+    // so it's robust to the CI monospace fallback's font metrics (the exact transition width
+    // varies). Content mirrors the screenshot: held badge + needsYou + several sessions
+    // (non-zero tallies) + both usage gauges. `needsYou` is present so `drainFrames` (which
+    // keys off `.needsyou`) actually waits for the measurement to settle.
+    const states: { width: number; clockDropped: boolean; talliesCompact: boolean }[] = [];
+    for (const width of [800, 920, 1040, 1200, 1400, 1600]) {
+      const hud = await renderTD(width, { ...sessionsProp(4), heldCount: 3, needsYou: 2 });
+      await waitNoOverflow(hud);
+      await drainFrames(hud);
+      const clockDropped = hud.querySelector(".clock")!.classList.contains("no-time");
+      const talliesCompact = !!hud.querySelector(".tallies.compact");
+      // Coupling: tallies compact iff the measured-overflow signal fired (clock dropped).
+      expect(talliesCompact, `tallies coupled to overflow signal at ${width}px`).toBe(clockDropped);
+      // Whichever form rendered, it must be the right one — never both, never neither.
+      if (talliesCompact) {
+        expect(hud.querySelector(".tally"), `no full tally at ${width}px`).toBeNull();
+      } else {
+        expect(hud.querySelector(".tally"), `full tally present at ${width}px`).not.toBeNull();
+        expect(hud.querySelector(".micro"), `full tally label at ${width}px`).not.toBeNull();
+      }
+      assertControlsHittable(hud);
+      states.push({ width, clockDropped, talliesCompact });
+    }
+    expect(
+      states.some((s) => s.talliesCompact),
+      "sweep exercises the compacted state (a narrow fold collapses the tallies)",
+    ).toBe(true);
+    expect(
+      states.some((s) => !s.talliesCompact),
+      "sweep exercises the full state (a wide tablet keeps full tally labels — no over-compaction)",
+    ).toBe(true);
+  });
 });
 
 describe("TopBar — wide desktop keeps full labels (measurement does NOT over-compact)", () => {
@@ -610,6 +648,83 @@ describe("TopBar — async gauge arrival re-measures (reactivity gap)", () => {
       // a fitting form. waitNoOverflow re-runs until the rAF lands OR times out into a
       // real failure — a bar that genuinely keeps overflowing still fails here.
       await waitNoOverflow(hud!);
+      assertControlsHittable(hud!);
+    } finally {
+      globalThis.ResizeObserver = RealResizeObserver;
+    }
+  });
+});
+
+describe("TopBar — async held-task arrival re-measures (touch-desktop reactivity gap)", () => {
+  // The held badge (added in #1089) appears via the held:changed WS event AFTER first paint.
+  // Like the gauge-arrival case above, its arrival changes NEITHER mode NOR the .shell-capped
+  // box width — only inner content grows, going to scrollWidth — so unless the measure effect
+  // tracks held state, nothing re-fires and the bar silently overflows. Held is folded into
+  // ChromeState/badgeCount so the effect's `void badgeCount(chrome)` read covers it. On
+  // touch-desktop the recompaction also collapses the tallies (the fix), which is what lets
+  // the bar fit at this narrow fold width once held arrives.
+  //
+  // Same two rig details as the gauge test make it faithful AND able to catch the bug:
+  //   1. Harness flips ONLY heldCount (setHeld), not the whole prop bag (rerender would
+  //      re-read every prop and spuriously re-fire the effect, masking the gap).
+  //   2. ResizeObserver stubbed to a no-op so the effect is the SOLE recompaction path —
+  //      in production the RO doesn't fire on held arrival (the box stays put), but an
+  //      unconstrained test mount would jitter the box and self-heal, hiding the gap.
+  //
+  // Mutation check (verified): removing `held` from badgeCount (top-bar-layout.ts) OR from
+  // the `chrome` object (TopBar.svelte) makes this FAIL — with the RO stubbed nothing
+  // re-measures on held arrival, the bar stays full-tally and overflows. Restoring it passes.
+  it("touch-desktop 880 — a task is held after mount, bar re-compacts the tallies to fit", async () => {
+    // 880 is the window where the held badge is the deciding factor: held=0 fits with FULL
+    // tallies; held=3 overflows and only fits once the tallies collapse (probed). Wider and
+    // held fits without compaction; narrower and the bar is already compact before held.
+    await page.viewport(880, 900);
+    document.body.style.width = "880px";
+
+    const RealResizeObserver = globalThis.ResizeObserver;
+    class NoopResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    globalThis.ResizeObserver = NoopResizeObserver as unknown as typeof ResizeObserver;
+    try {
+      // Mount fitting: gauges present + constant, but heldCount starts 0 → the bar fits 800
+      // with full tallies (the existing lone-content touch-desktop 800 cases fit).
+      const { component } = render(TopBarLimitsHarness, {
+        nowMs: 1_700_000_000_000,
+        connected: true,
+        ...FLAGS["touch-desktop"],
+        ...sessionsProp(2),
+        initialLimits: fullLimits,
+        initialHeldCount: 0,
+      });
+      const hud = document.querySelector<HTMLElement>(".hud");
+      expect(hud, "TopBar .hud mounted").not.toBeNull();
+
+      // Settle the initial measurement and fully drain churn so no stale measuring frame is
+      // left pending that could self-heal after held arrives and mask the bug.
+      await waitNoOverflow(hud!);
+      await drainFrames(hud!);
+      expect(hud!.querySelector(".held-badge"), "no held badge before held arrives").toBeNull();
+      expect(
+        hud!.querySelector(".tallies.compact"),
+        "tallies full before held arrives (bar fits)",
+      ).toBeNull();
+
+      // ASYNC arrival: a task is held → the held badge renders, pushing the bar over 800.
+      // With the RO stubbed, ONLY the held-tracking measure effect can react and re-compact.
+      component.setHeld(3);
+      await nextFrame();
+      expect(hud!.querySelector(".held-badge"), "held badge renders after arrival").not.toBeNull();
+
+      // The re-measure (driven by the tracked badgeCount read now containing held) must
+      // re-compact the bar back to a fitting form — collapsing the tallies on touch-desktop.
+      await waitNoOverflow(hud!);
+      expect(
+        hud!.querySelector(".tallies.compact"),
+        "tallies collapse on held arrival so the bar fits",
+      ).not.toBeNull();
       assertControlsHittable(hud!);
     } finally {
       globalThis.ResizeObserver = RealResizeObserver;

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -655,6 +655,58 @@ describe("TopBar — async gauge arrival re-measures (reactivity gap)", () => {
   });
 });
 
+describe("TopBar — fine-pointer desktop tallies ALSO collapse under measured overflow", () => {
+  // Tally compaction is gated on the measured-overflow signal (`compactBadges`), matching the
+  // sibling NEEDS-YOU / held badges — NOT on `touch`, so a NARROW fine-pointer desktop window
+  // (a small/split-screen window, still wider than the 768px mobile breakpoint) doesn't keep
+  // full-label tallies after the right side has compacted and overflow the bar. Desktop renders
+  // BOTH usage gauges inline (wider than touch's single collapsed gauge-btn), so it overflows
+  // EARLIER than touch-desktop — exactly the case the `touch &&` guard would have left unfixed.
+  // Same font-robust coupling-sweep shape as the touch-desktop test above.
+  async function renderDesktopBar(width: number, extra: Record<string, unknown>) {
+    await page.viewport(width, 900);
+    document.body.style.width = `${width}px`;
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.desktop,
+      ...sessionsProp(2),
+      limits: fullLimits,
+      ...extra,
+    });
+    const hud = document.querySelector<HTMLElement>(".hud");
+    expect(hud, "TopBar .hud mounted").not.toBeNull();
+    return hud!;
+  }
+
+  it("narrow desktop window collapses the tallies to fit; wide keeps full labels (no over-compaction)", async () => {
+    const states: { width: number; clockDropped: boolean; talliesCompact: boolean }[] = [];
+    for (const width of [960, 1150, 1350, 1500, 1650]) {
+      const hud = await renderDesktopBar(width, { heldCount: 3, needsYou: 2 });
+      await waitNoOverflow(hud);
+      await drainFrames(hud);
+      const clockDropped = hud.querySelector(".clock")!.classList.contains("no-time");
+      const talliesCompact = !!hud.querySelector(".tallies.compact");
+      expect(talliesCompact, `tallies coupled to overflow signal at ${width}px`).toBe(clockDropped);
+      if (talliesCompact) {
+        expect(hud.querySelector(".tally"), `no full tally at ${width}px`).toBeNull();
+      } else {
+        expect(hud.querySelector(".tally"), `full tally present at ${width}px`).not.toBeNull();
+      }
+      assertControlsHittable(hud);
+      states.push({ width, clockDropped, talliesCompact });
+    }
+    expect(
+      states.some((s) => s.talliesCompact),
+      "sweep exercises the compacted state (a narrow desktop window collapses the tallies)",
+    ).toBe(true);
+    expect(
+      states.some((s) => !s.talliesCompact),
+      "sweep exercises the full state (a wide desktop keeps full tally labels — no over-compaction)",
+    ).toBe(true);
+  });
+});
+
 describe("TopBar — async held-task arrival re-measures (touch-desktop reactivity gap)", () => {
   // The held badge (added in #1089) appears via the held:changed WS event AFTER first paint.
   // Like the gauge-arrival case above, its arrival changes NEITHER mode NOR the .shell-capped

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -591,7 +591,7 @@
   <div class="sep"></div>
   <TopBarTallies
     {mobile}
-    compact={touch && compactBadges}
+    compact={compactBadges}
     total={sessions.length}
     {working}
     {idle}

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -122,6 +122,9 @@
     needsYou,
     whatsNew,
     learnings: learnings + learningsCurate,
+    // held arrives async via the held:changed WS event; counting it here makes the
+    // measure effect's `void badgeCount(chrome)` read re-fire on its arrival.
+    held: heldCount,
   });
 
   // ── Compaction is MEASURED, not count-based (desktop AND touch-desktop) ───────
@@ -588,6 +591,7 @@
   <div class="sep"></div>
   <TopBarTallies
     {mobile}
+    compact={touch && compactBadges}
     total={sessions.length}
     {working}
     {idle}

--- a/ui/src/lib/components/TopBarLimitsHarness.svelte
+++ b/ui/src/lib/components/TopBarLimitsHarness.svelte
@@ -10,6 +10,7 @@
   than the spurious full-props re-read that vitest-browser-svelte's rerender() causes.
 -->
 <script lang="ts">
+  import { untrack } from "svelte";
   import TopBar from "./TopBar.svelte";
   import type { Session, UsageLimits, UpdateStatus } from "$lib/types";
 
@@ -21,6 +22,8 @@
     touch = false,
     needsYou = 0,
     update = null,
+    initialLimits = null,
+    initialHeldCount = 0,
   }: {
     sessions: Session[];
     nowMs: number;
@@ -29,14 +32,31 @@
     touch?: boolean;
     needsYou?: number;
     update?: UpdateStatus | null;
+    /** Seed for the internal `limits` $state. Defaults to null so the gauge-arrival
+     *  test (which flips null→populated via setLimits) is unaffected; the held test
+     *  seeds it with gauges already present and constant. */
+    initialLimits?: UsageLimits | null;
+    /** Seed for the internal `heldCount` $state, flipped later via setHeld(). */
+    initialHeldCount?: number;
   } = $props();
 
-  // Starts null (no gauges) — the production first-paint state. The test flips it to a
-  // populated value AFTER mount via setLimits(), reproducing the async snapshot/SSE arrival.
-  let limits = $state<UsageLimits | null>(null);
+  // Starts at the seed (null by default → no gauges) — the production first-paint state.
+  // The gauge-arrival test flips it to a populated value AFTER mount via setLimits(),
+  // reproducing the async snapshot/SSE arrival. Seeded once from the prop on purpose
+  // (the prop is a one-time initial value; later changes come through setLimits()).
+  let limits = $state<UsageLimits | null>(untrack(() => initialLimits));
 
   export function setLimits(next: UsageLimits | null) {
     limits = next;
+  }
+
+  // Held tasks arrive async via the held:changed WS event. The held test flips ONLY this
+  // after mount via setHeld() — the same single-state-change faithfulness setLimits gives
+  // the gauge test — so held arrival is the sole change the measure effect must react to.
+  let heldCount = $state(untrack(() => initialHeldCount));
+
+  export function setHeld(next: number) {
+    heldCount = next;
   }
 </script>
 
@@ -50,7 +70,17 @@
   The host width is set by the test via document.body.style.width on this wrapper.
 -->
 <div class="shell-cap">
-  <TopBar {sessions} {nowMs} {connected} {mobile} {touch} {limits} {needsYou} {update} />
+  <TopBar
+    {sessions}
+    {nowMs}
+    {connected}
+    {mobile}
+    {touch}
+    {limits}
+    {needsYou}
+    {update}
+    {heldCount}
+  />
 </div>
 
 <style>

--- a/ui/src/lib/components/top-bar-layout.test.ts
+++ b/ui/src/lib/components/top-bar-layout.test.ts
@@ -7,10 +7,10 @@ import { badgeCount, type ChromeState } from "./top-bar-layout";
 // layer no longer has a render-plan to test — only `badgeCount`, the content-change
 // signal the measure effect tracks.
 
-// Build every ChromeState from a 5-bit mask over the five badge-presence inputs.
+// Build every ChromeState from a 6-bit mask over the six badge-presence inputs.
 // The halt e-stop is NOT a bar badge (it lives in the gear menu), so it never
 // appears here.
-const ALL = 0b11111; // all five badges present
+const ALL = 0b111111; // all six badges present
 function stateFromMask(mask: number): ChromeState {
   return {
     updateAvailable: !!(mask & 1),
@@ -18,6 +18,7 @@ function stateFromMask(mask: number): ChromeState {
     needsYou: mask & 4 ? 1 : 0,
     whatsNew: !!(mask & 8),
     learnings: mask & 16 ? 1 : 0,
+    held: mask & 32 ? 1 : 0,
   };
 }
 
@@ -28,12 +29,13 @@ function expectedCount(s: ChromeState): number {
     (s.herdrUpdateAvailable ? 1 : 0) +
     (s.needsYou > 0 ? 1 : 0) +
     (s.whatsNew ? 1 : 0) +
-    (s.learnings > 0 ? 1 : 0)
+    (s.learnings > 0 ? 1 : 0) +
+    (s.held > 0 ? 1 : 0)
   );
 }
 
 describe("badgeCount", () => {
-  it("counts each present badge once across all 32 presence combos", () => {
+  it("counts each present badge once across all 64 presence combos", () => {
     for (let mask = 0; mask <= ALL; mask++) {
       const s = stateFromMask(mask);
       expect(badgeCount(s)).toBe(expectedCount(s));
@@ -47,6 +49,7 @@ describe("badgeCount", () => {
       needsYou: 0,
       whatsNew: false,
       learnings: 0,
+      held: 0,
     };
     expect(badgeCount(s)).toBe(0);
   });
@@ -58,6 +61,7 @@ describe("badgeCount", () => {
       needsYou: 0,
       whatsNew: false,
       learnings: 3,
+      held: 0,
     };
     expect(badgeCount(withLearnings)).toBe(1);
 
@@ -67,6 +71,7 @@ describe("badgeCount", () => {
       needsYou: 0,
       whatsNew: false,
       learnings: 0,
+      held: 0,
     };
     expect(badgeCount(noLearnings)).toBe(0);
   });
@@ -78,7 +83,23 @@ describe("badgeCount", () => {
       needsYou: 1,
       whatsNew: false,
       learnings: 2,
+      held: 0,
     };
     expect(badgeCount(s)).toBe(2);
+  });
+
+  it("counts held badge: held:2 → 1, held:0 → 0", () => {
+    const withHeld: ChromeState = {
+      updateAvailable: false,
+      herdrUpdateAvailable: false,
+      needsYou: 0,
+      whatsNew: false,
+      learnings: 0,
+      held: 2,
+    };
+    expect(badgeCount(withHeld)).toBe(1);
+
+    const noHeld: ChromeState = { ...withHeld, held: 0 };
+    expect(badgeCount(noHeld)).toBe(0);
   });
 });

--- a/ui/src/lib/components/top-bar-layout.ts
+++ b/ui/src/lib/components/top-bar-layout.ts
@@ -20,6 +20,9 @@ export interface ChromeState {
   whatsNew: boolean;
   /** pending learnings to review across all repos; >0 renders the global learnings badge */
   learnings: number;
+  /** held tasks; >0 renders the held badge (added async via the held:changed WS event,
+   *  so it MUST be a counted input or the measure effect won't re-fire on its arrival) */
+  held: number;
 }
 
 /** Derive the layout mode from the bar's mobile/touch flags. */
@@ -36,6 +39,7 @@ export function badgeCount(s: ChromeState): number {
     (s.herdrUpdateAvailable ? 1 : 0) +
     (s.needsYou > 0 ? 1 : 0) +
     (s.whatsNew ? 1 : 0) +
-    (s.learnings > 0 ? 1 : 0)
+    (s.learnings > 0 ? 1 : 0) +
+    (s.held > 0 ? 1 : 0)
   );
 }

--- a/ui/src/lib/components/top-bar/TopBarTallies.svelte
+++ b/ui/src/lib/components/top-bar/TopBarTallies.svelte
@@ -6,6 +6,7 @@
 
   let {
     mobile,
+    compact = false,
     total,
     working,
     idle,
@@ -15,6 +16,9 @@
     clickStatus,
   }: {
     mobile: boolean;
+    /** Collapse to the dot+digit form under measured overflow on touch-desktop (the
+     *  unfolded fold) — the same compact form phones get from `mobile`. */
+    compact?: boolean;
     total: number;
     working: number;
     idle: number;
@@ -25,7 +29,7 @@
   } = $props();
 </script>
 
-{#if mobile}
+{#if mobile || compact}
   <div class="tallies compact">
     <!-- aria-labels carry the COUNT alongside the action (the visible text is a
          bare digit, and an action-only label would hide the tally from screen

--- a/ui/src/lib/components/top-bar/TopBarTallies.svelte
+++ b/ui/src/lib/components/top-bar/TopBarTallies.svelte
@@ -16,8 +16,9 @@
     clickStatus,
   }: {
     mobile: boolean;
-    /** Collapse to the dot+digit form under measured overflow on touch-desktop (the
-     *  unfolded fold) — the same compact form phones get from `mobile`. */
+    /** Collapse to the dot+digit form under measured overflow (desktop AND touch-desktop /
+     *  the unfolded fold) — the same compact form phones get from `mobile`. Matches the
+     *  sibling NEEDS-YOU / held badges, which also compact on the measured-overflow signal. */
     compact?: boolean;
     total: number;
     working: number;
@@ -198,12 +199,19 @@
     font: inherit;
     color: inherit;
     cursor: pointer;
-    /* 44px touch floor in HEIGHT only (matches .hud.mobile .gear/.needsyou); a
-       44px width floor for four buttons would blow the ~260px usable line-1
-       budget on fold-cover phones. 24px min width keeps even the bare-digit
-       Idle segment at the WCAG 2.5.8 (AA) target size. */
-    min-height: 44px;
+    /* WCAG 2.5.8 (AA) 24px target floor on ALL pointers — keeps even the bare-digit
+       Idle segment hittable when the compact tallies render on a fine-pointer desktop
+       under measured overflow. Coarse pointers (phones, foldables) get the larger 44px
+       touch floor in HEIGHT below. A 44px WIDTH floor for four buttons would blow the
+       ~260px usable line-1 budget on fold-cover phones, so width stays at 24px. */
+    min-height: 24px;
     min-inline-size: 24px;
+  }
+  /* Coarse-pointer touch floor: 44px height (matches .hud.mobile .gear/.needsyou). */
+  @media (pointer: coarse) {
+    .ctally {
+      min-height: 44px;
+    }
   }
   .ctally.active {
     background: var(--color-inset);


### PR DESCRIPTION
## Problem

On an **unfolded foldable** (touch-desktop: coarse pointer, viewport > 768px) the top bar overflows and clips the right-most control (the gear / a status dot). The reported screenshot shows full tally labels (`HERD 2 BUSY 2 IDLE 0 BLOCKED 0`) alongside an already-compacted right side (square `[3]` held badge, dot-only clock) — i.e. compaction fired but wasn't enough.

## Root cause

1. **Tallies never compact off-`mobile`.** `TopBarTallies` only renders the compact dot+digit form when the `mobile` prop is set. In desktop / touch-desktop mode it always renders full labels — the widest text on the bar — so the measured-overflow path (`measuredCompact` → `compactBadges`) shrank only the right-side cluster (clock, badges, held, needs-you) and never the tallies. The bar still overflowed once narrow enough.
2. **Held state wasn't a measurement dependency.** The overflow-measuring `$effect` tracks `mode` / `badgeCount(chrome)` / `gauges.length`, but `badgeCount`/`ChromeState` had no held input. The held badge (#1089) appears async via the `held:changed` WS event, growing the bar without re-firing the effect or the ResizeObserver — the same async class already guarded for gauges.

## Fix

- Add a `compact` prop to `TopBarTallies`; render the compact dot+digit form when `mobile || compact`. `TopBar` passes `compact={compactBadges}`, so the tallies collapse under measured overflow on **both desktop and touch-desktop** — matching the sibling NEEDS-YOU / held badges, which already compact on the same signal. The compact tally's 44px touch floor is scoped to coarse pointers; fine-pointer desktop keeps the WCAG 2.5.8 (AA) 24px target so the collapsed digits fit the bar height.
- Fold `held` into `ChromeState` + `badgeCount` and set `held: heldCount` in `TopBar`'s `chrome`, so the existing `void badgeCount(chrome)` read re-fires the measure effect on async held arrival.

No new user-facing strings (reuses the existing compact-tally aria messages) → no i18n/feature-catalog/glossary changes. `fix`, not a feature.

## Tests

- **Tally-compaction width sweeps** (`TopBar.browser.test.ts`): one for **touch-desktop** (`[800…1600]`, gauges collapse to a gauge-btn) and one for **fine-pointer desktop** (`[960…1650]`, both gauges inline → overflows earlier). Each asserts no overflow + controls hittable at every width, *clock-dropped iff tallies-compact*, and that the sweep exercises **both** compact (narrow) and full (wide) states — font-robust under the CI monospace fallback, guarding against over-compaction when wide.
- **Async held self-heal**: `heldCount` 0→N after mount (via a generalized `TopBarLimitsHarness.setHeld`, `ResizeObserver` stubbed) must re-measure and self-heal the overflow; mutation-checked (remove `held` from `badgeCount`/`chrome` → fails), mirroring the existing gauge-arrival test.
- **Unit**: `badgeCount` matrix extended to a 6-bit mask including `held`.

## Verification

- `cd ui && bun run check` → 0 errors, 0 warnings
- `cd ui && bun run test` → 146 files, 2083 tests pass
- eslint + prettier clean; i18n / glossary / branch-hygiene / fallow delta gates green

🤖 Generated with [Claude Code](https://claude.com/claude-code)