### PR TITLE
ci(automerge): auto-merge Shepherd's own doc PRs via GitHub Action

### DIFF
--- a/.github/workflows/doc-automerge.yml
+++ b/.github/workflows/doc-automerge.yml
@@ -53,9 +53,13 @@ jobs:
 
           DEFAULT_BRANCH="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')"
 
-          mapfile -t prs < <(gh pr list --state open --limit 50 \
-            --json number,headRefName \
-            --jq ".[] | select(.headRefName | startswith(\"$PREFIX\")) | .number")
+          # Capture into a variable FIRST: a `gh` failure here propagates under `set -e` (assignment
+          # from command substitution carries the command's exit status), unlike a failure hidden
+          # inside `mapfile < <(gh ...)` process substitution — which would silently look like "no
+          # PRs" and exit 0 on a transient API error.
+          prs_json="$(gh pr list --state open --limit 50 --json number,headRefName)"
+          mapfile -t prs < <(jq -r --arg p "$PREFIX" \
+            '.[] | select(.headRefName | startswith($p)) | .number' <<<"$prs_json")
 
           if [ "${#prs[@]}" -eq 0 ]; then echo "No open doc PRs."; exit 0; fi
           echo "Found ${#prs[@]} open doc PR(s): ${prs[*]}"

--- a/.github/workflows/doc-automerge.yml
+++ b/.github/workflows/doc-automerge.yml
@@ -1,0 +1,94 @@
+name: Auto-merge doc PRs
+
+# Auto-merges Shepherd's OWN documentation PRs — the ones the doc agent opens on
+# `shepherd/docs-update-*` branches — once they're green, instead of waiting on a human merge.
+#
+# Why a workflow and not a Shepherd setting: the doc agent runs ONLY against this repo (its
+# in-scope file list + DOC_TREE_MARKER are this repo's own doc tree), and Shepherd lives only on
+# GitHub — so a per-repo Shepherd toggle would be a dead switch in every other repo. This keeps the
+# convenience where it actually applies, and it works even when the Shepherd server is offline.
+#
+# Trigger: after the PR CI workflows finish (workflow_run fires even when the upstream run was
+# driven by GITHUB_TOKEN, unlike check_suite), plus a periodic safety net and a manual button. Each
+# run re-derives eligibility from the live PR state, so it's idempotent and order-independent.
+
+on:
+  workflow_run:
+    workflows: ["CI", "PR hygiene"]
+    types: [completed]
+  schedule:
+    - cron: "*/30 * * * *" # safety net for any missed workflow_run event
+  workflow_dispatch:
+
+# Least privilege: merge a PR + delete its branch. NB: a merge performed with GITHUB_TOKEN does not
+# itself re-trigger push-driven workflows (e.g. release-please) — the next human merge to main
+# reconciles the changelog. Swap GH_TOKEN to a PAT below if you want doc merges to trigger them.
+permissions:
+  contents: write
+  pull-requests: write
+
+# One merge pass at a time; never cancel a pass mid-merge.
+concurrency:
+  group: doc-automerge
+  cancel-in-progress: false
+
+jobs:
+  automerge:
+    name: merge green doc PRs
+    runs-on: ubuntu-latest # a tiny control job — kept off the self-hosted CI runner on purpose
+    steps:
+      - name: Merge eligible doc PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Branch prefix every doc-agent PR carries: the agent's worktree stem is `docs-update-*`
+          # and worktree.create() prepends `shepherd/`. Keep in sync with doc-agent.ts.
+          PREFIX="shepherd/docs-update-"
+          # Invisible marker the critic stamps on its own reviews (forge/types.ts CRITIC_REVIEW_MARKER)
+          # so we can tell a human "changes requested" apart from the critic's advisory one.
+          CRITIC_MARKER="<!-- shepherd-critic -->"
+
+          DEFAULT_BRANCH="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')"
+
+          mapfile -t prs < <(gh pr list --state open --limit 50 \
+            --json number,headRefName \
+            --jq ".[] | select(.headRefName | startswith(\"$PREFIX\")) | .number")
+
+          if [ "${#prs[@]}" -eq 0 ]; then echo "No open doc PRs."; exit 0; fi
+          echo "Found ${#prs[@]} open doc PR(s): ${prs[*]}"
+
+          for n in "${prs[@]}"; do
+            info="$(gh pr view "$n" --json isDraft,mergeable,baseRefName,statusCheckRollup,reviews)"
+
+            draft=$(jq -r '.isDraft' <<<"$info")
+            mergeable=$(jq -r '.mergeable' <<<"$info")
+            base=$(jq -r '.baseRefName' <<<"$info")
+            total=$(jq '(.statusCheckRollup // []) | length' <<<"$info")
+
+            # Every check must be a terminal success (SUCCESS/NEUTRAL/SKIPPED). statusCheckRollup
+            # mixes CheckRun (.conclusion; null while pending) and StatusContext (.state) shapes —
+            # a missing/null verdict ⇒ "PENDING" ⇒ counted as not-green, so a pending check holds.
+            notgreen=$(jq '[(.statusCheckRollup // [])[]
+              | ((.conclusion // .state) // "PENDING") | ascii_upcase
+              | select(. != "SUCCESS" and . != "NEUTRAL" and . != "SKIPPED")] | length' <<<"$info")
+
+            # Latest HUMAN review verdict (critic-marked reviews excluded; only APPROVED /
+            # CHANGES_REQUESTED carry a decision). A human's "changes requested" holds the merge.
+            human_block=$(jq --arg m "$CRITIC_MARKER" '[(.reviews // [])[]
+              | select((.body // "") | contains($m) | not)
+              | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED")]
+              | sort_by(.submittedAt) | last | (.state == "CHANGES_REQUESTED")' <<<"$info")
+
+            if [ "$draft" != "false" ];                 then echo "#$n: draft — skip";                     continue; fi
+            if [ "$base" != "$DEFAULT_BRANCH" ];        then echo "#$n: non-default base ($base) — skip";  continue; fi
+            if [ "$mergeable" != "MERGEABLE" ];         then echo "#$n: mergeable=$mergeable — skip";       continue; fi
+            if [ "$total" -eq 0 ];                      then echo "#$n: no checks yet — skip";              continue; fi
+            if [ "$notgreen" -ne 0 ];                   then echo "#$n: $notgreen check(s) not green — skip"; continue; fi
+            if [ "$human_block" = "true" ];             then echo "#$n: human changes-requested — skip";    continue; fi
+
+            echo "#$n: eligible — merging (squash, delete branch)"
+            gh pr merge "$n" --squash --delete-branch
+          done

--- a/.github/workflows/doc-automerge.yml
+++ b/.github/workflows/doc-automerge.yml
@@ -64,6 +64,7 @@ jobs:
           if [ "${#prs[@]}" -eq 0 ]; then echo "No open doc PRs."; exit 0; fi
           echo "Found ${#prs[@]} open doc PR(s): ${prs[*]}"
 
+          failed=0
           for n in "${prs[@]}"; do
             info="$(gh pr view "$n" --json isDraft,mergeable,baseRefName,statusCheckRollup,reviews)"
 
@@ -94,5 +95,12 @@ jobs:
             if [ "$human_block" = "true" ];             then echo "#$n: human changes-requested — skip";    continue; fi
 
             echo "#$n: eligible — merging (squash, delete branch)"
-            gh pr merge "$n" --squash --delete-branch
+            # Tolerate a per-PR merge failure: log it and keep going so one stuck PR doesn't block
+            # the rest of this pass. Still flag the run red at the end so the failure isn't swallowed.
+            if ! gh pr merge "$n" --squash --delete-branch; then
+              echo "#$n: merge FAILED — continuing with remaining PRs"
+              failed=1
+            fi
           done
+
+          if [ "$failed" -ne 0 ]; then echo "One or more doc PR merges failed."; exit 1; fi

--- a/.github/workflows/doc-automerge.yml
+++ b/.github/workflows/doc-automerge.yml
@@ -17,7 +17,7 @@ on:
     workflows: ["CI", "PR hygiene"]
     types: [completed]
   schedule:
-    - cron: "*/30 * * * *" # safety net for any missed workflow_run event
+    - cron: "17 6 * * *" # once-daily safety net for any missed workflow_run event
   workflow_dispatch:
 
 # Least privilege: merge a PR + delete its branch. NB: a merge performed with GITHUB_TOKEN does not


### PR DESCRIPTION
Auto-merges Shepherd's own documentation PRs — the ones the doc agent opens on `shepherd/docs-update-*` branches (e.g. #1111) — once they're green, instead of waiting on a human merge.

> **Pivoted from a server-side service.** This PR originally added a per-repo `DocAutoMergeService` + `docAutoMergeEnabled` Settings toggle. As discussed, the doc agent is **effectively Shepherd-self-only** (its in-scope file list + `DOC_TREE_MARKER` are *this* repo's doc tree) and Shepherd is **GitHub-only** — so a per-repo Shepherd setting would be a dead switch in every other repo, and the multi-forge argument doesn't apply. A repo workflow is the right home: it keeps the convenience where it actually applies, adds ~0 server surface, and works even when the Shepherd server is offline. The branch was reset to main and now contains **only** `.github/workflows/doc-automerge.yml`.

## How it works

- **Trigger:** `workflow_run` on the **CI** and **PR hygiene** workflows completing (`workflow_run` fires even when the upstream run was driven by `GITHUB_TOKEN`, unlike `check_suite`), plus a 30-min safety-net `schedule` and `workflow_dispatch`.
- **Idempotent:** each run re-derives eligibility from live PR state and enumerates all open doc PRs, so it's order-independent and safe to fire repeatedly.
- **Eligibility:** open `shepherd/docs-update-*` PR that is non-draft, targets the default branch, host-`MERGEABLE`, **every check green** (pending/failing holds — the i18n/glossary/feature-catalog/verify gates are the real safety net), and has **no human `CHANGES_REQUESTED`** review (critic-marked reviews are excluded via the `<!-- shepherd-critic -->` marker, so the critic stays advisory).
- **Merge:** `gh pr merge --squash --delete-branch` (repo allows squash/rebase only).

## Decisions / tradeoffs

- **Runner:** `ubuntu-latest`, deliberately kept off the self-hosted CI runner — it's a tiny control job, not CI.
- **Token:** uses `GITHUB_TOKEN` (least-priv: `contents: write`, `pull-requests: write`). A merge by `GITHUB_TOKEN` does **not** itself re-trigger push-driven workflows like release-please; the next human merge to main reconciles the changelog. Commented inline how to swap to a PAT if you'd rather doc merges trigger them immediately.
- **Human hold:** convert the PR to draft, push, or request changes to stop an auto-merge.
- **Security:** no untrusted `${{ github.event.* }}` interpolation in `run:` steps — all PR data flows through `gh --json` → `jq` → quoted shell vars.

## Test

YAML validated; logic reviewed against `gh pr view --json` shapes (`statusCheckRollup` mixes CheckRun/StatusContext; null/pending → not-green). Full pre-push gate suite green on the reset branch. End-to-end firing is verifiable only once the workflow is on the default branch — the `workflow_dispatch` button + the safety-net cron make that easy to confirm post-merge against the next doc PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)