### PR TITLE
fix(ui): single post-merge toast, drop auto local-checkout offer

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -694,8 +694,6 @@
   "toast_merge_train_no_prs": "Keine merge-bereiten PRs für einen Merge-Train vorhanden",
   "toast_merge_train_failed": "Merge-Train konnte nicht gestartet werden",
   "toast_merged": "{name} gemergt",
-  "toast_update_main_offer": "PR gemergt. Deinen lokalen Standard-Branch aktualisieren?",
-  "toast_update_main_action": "Aktualisieren",
   "toast_update_main_done": "Lokalen {branch} auf den neuesten Stand gebracht",
   "toast_update_main_uptodate": "Lokaler {branch} ist bereits aktuell",
   "toast_update_main_wrong_branch": "Lokaler Checkout ist nicht auf {branch}; unverändert gelassen",
@@ -1997,5 +1995,6 @@
   "recommend_err_timeout": "Die Analyse hat keine Empfehlung geliefert. Versuch es erneut.",
   "recommend_err_unavailable": "Promptempfehlungen sind derzeit nicht verfügbar.",
   "feat_taskid_recommend_title": "Task-ID anklicken für Aktionen",
-  "feat_taskid_recommend_body": "Die Task-ID auf jeder Karte ist jetzt ein Button. Klicke darauf, um die ID zu kopieren, oder lass einen zweiten Agenten (Opus oder GPT-5.5) den Terminal-Verlauf der Session analysieren und den nächsten Prompt empfehlen — fertig zum Kopieren oder direkt in die Session einfügen."
+  "feat_taskid_recommend_body": "Die Task-ID auf jeder Karte ist jetzt ein Button. Klicke darauf, um die ID zu kopieren, oder lass einen zweiten Agenten (Opus oder GPT-5.5) den Terminal-Verlauf der Session analysieren und den nächsten Prompt empfehlen — fertig zum Kopieren oder direkt in die Session einfügen.",
+  "toast_mergetrain_landed": "Merge-Train in {repo} gelandet"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -694,8 +694,6 @@
   "toast_merge_train_no_prs": "No ready-to-merge PRs to run a merge train on",
   "toast_merge_train_failed": "Couldn't start the merge train",
   "toast_merged": "Merged {name}",
-  "toast_update_main_offer": "PR merged. Update your local default branch?",
-  "toast_update_main_action": "Update",
   "toast_update_main_done": "Updated local {branch} to latest",
   "toast_update_main_uptodate": "Local {branch} already up to date",
   "toast_update_main_wrong_branch": "Local checkout isn't on {branch}; left it untouched",
@@ -1997,5 +1995,6 @@
   "recommend_err_timeout": "The analysis didn't return a recommendation. Try again.",
   "recommend_err_unavailable": "Prompt recommendations are unavailable right now.",
   "feat_taskid_recommend_title": "Click a task ID for actions",
-  "feat_taskid_recommend_body": "The task ID on each card is now a button. Click it to copy the ID, or have a second agent (Opus or GPT-5.5) analyze the session's terminal history and recommend the next prompt — ready to copy or inject straight into the session."
+  "feat_taskid_recommend_body": "The task ID on each card is now a button. Click it to copy the ID, or have a second agent (Opus or GPT-5.5) analyze the session's terminal history and recommend the next prompt — ready to copy or inject straight into the session.",
+  "toast_mergetrain_landed": "Merge train landed in {repo}"
 }

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -20,7 +20,6 @@
   import { featureDiscovery } from "$lib/featureDiscovery.svelte";
   import { featureAnnouncements } from "$lib/feature-announcements";
   import Coachmark from "$lib/components/Coachmark.svelte";
-  import { offerUpdateMain } from "$lib/pull-offer";
   import { pollWhileVisible } from "$lib/visibility";
 
   let {
@@ -33,8 +32,6 @@
     status = "idle",
     showReady = true,
     planPhase = null,
-    isolated = false,
-    baseBranch = "",
     drain = null,
     autopilotOn = false,
     issueNumber = null,
@@ -49,8 +46,6 @@
     status?: SessionStatus;
     showReady?: boolean;
     planPhase?: Session["planPhase"];
-    isolated?: boolean;
-    baseBranch?: string;
     /** Live drain status for this session's repo; passed through to AutomationPanel. */
     drain?: DrainStatus | null;
     /** Effective autopilot state. When on, the agent opens the PR itself, so the manual
@@ -282,10 +277,6 @@
           key: `decommission-offer:${mergedId}`,
         });
       }
-      // A non-isolated session has its feature branch checked out in the canonical
-      // clone, so there's no separate default-branch checkout to fast-forward — the
-      // offer would always report wrong_branch. Only offer for isolated sessions.
-      if (isolated) offerUpdateMain(repoPath, baseBranch);
     } catch (e) {
       // prefer the known local cause over a raw server string
       err =

--- a/ui/src/lib/components/PrRow.svelte
+++ b/ui/src/lib/components/PrRow.svelte
@@ -3,7 +3,6 @@
   import type { PullRequest } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { mergeBacklogPr, requestDependabotRebase } from "$lib/api";
-  import { offerUpdateMain } from "$lib/pull-offer";
   import { showRebaseOffer } from "./pr-row";
   import { relativeAge } from "$lib/format";
   import { clock } from "$lib/now.svelte";
@@ -105,7 +104,6 @@
     try {
       await mergeBacklogPr(repoPath, pr.number);
       onmerged(pr.number);
-      offerUpdateMain(repoPath);
     } catch {
       failed = true;
       mergeBusy = false;

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1980,8 +1980,6 @@
         ready={session.readyToMerge}
         status={dStatus}
         planPhase={session.planPhase}
-        isolated={session.isolated}
-        baseBranch={session.baseBranch}
         {drain}
         autopilotOn={autopilotEffective}
         issueNumber={session.issueNumber}

--- a/ui/src/lib/pull-offer.test.ts
+++ b/ui/src/lib/pull-offer.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, vi, beforeEach, afterEach } from "vitest";
 import { toasts } from "./toasts.svelte";
-import { offerUpdateMain, pullMainAndToast } from "./pull-offer";
+import { pullMainAndToast } from "./pull-offer";
 import { pullRepo } from "$lib/api";
 
 vi.mock("$lib/api", () => ({ pullRepo: vi.fn() }));
@@ -14,46 +14,6 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
-});
-
-test("offer toast auto-dismisses after 15s when ignored", async () => {
-  offerUpdateMain("/repo/a");
-  expect(toasts.items).toHaveLength(1);
-
-  await vi.advanceTimersByTimeAsync(14_999);
-  expect(toasts.items).toHaveLength(1);
-  await vi.advanceTimersByTimeAsync(1);
-  expect(toasts.items).toHaveLength(0);
-});
-
-test("re-offer for the same repo re-arms one toast, gone 15s after the second offer", async () => {
-  offerUpdateMain("/repo/a");
-  await vi.advanceTimersByTimeAsync(10_000);
-
-  offerUpdateMain("/repo/a");
-  expect(toasts.items).toHaveLength(1); // keyed dedupe: still exactly one
-
-  await vi.advanceTimersByTimeAsync(14_999); // 24.999s after the FIRST offer
-  expect(toasts.items).toHaveLength(1);
-  await vi.advanceTimersByTimeAsync(1);
-  expect(toasts.items).toHaveLength(0);
-});
-
-test("failure toast from the offer's action stays persistent", async () => {
-  vi.mocked(pullRepo).mockResolvedValue({ ok: false, reason: "error" });
-
-  offerUpdateMain("/repo/a");
-  const offer = toasts.items.find((t) => t.key === "update-main-offer:/repo/a");
-  expect(offer).toBeDefined();
-  toasts.act(offer!.id); // drops the offer, runs pullRepo
-  await vi.advanceTimersByTimeAsync(0); // flush the async run
-
-  expect(pullRepo).toHaveBeenCalledWith("/repo/a", undefined);
-  expect(toasts.items).toHaveLength(1);
-  expect(toasts.items.find((t) => t.key === "update-main:/repo/a")).toBeDefined();
-
-  await vi.advanceTimersByTimeAsync(120_000); // far past 15s
-  expect(toasts.items).toHaveLength(1); // duration null: must not vanish
 });
 
 // ── pullMainAndToast PullResult → toast mapping ──────────────────────────────

--- a/ui/src/lib/pull-offer.ts
+++ b/ui/src/lib/pull-offer.ts
@@ -38,16 +38,3 @@ export async function pullMainAndToast(repoPath: string, branch?: string): Promi
       return;
   }
 }
-
-/** After a PR merge, offer a one-click fast-forward of the repo's local default-branch
- *  checkout. Auto-dismisses after 15s (paused while hovered/focused) and per-repo
- *  deduped so repeated merges to one repo re-arm a single offer. */
-export function offerUpdateMain(repoPath: string, branch?: string): void {
-  if (!repoPath) return;
-
-  toasts.info(m.toast_update_main_offer(), {
-    action: { label: m.toast_update_main_action(), run: () => pullMainAndToast(repoPath, branch) },
-    duration: 15_000,
-    key: `update-main-offer:${repoPath}`,
-  });
-}

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -2,8 +2,6 @@ import { test, expect, vi, afterEach } from "vitest";
 import { HerdStore } from "./store.svelte";
 import { toasts } from "./toasts.svelte";
 
-vi.mock("./pull-offer", () => ({ offerUpdateMain: vi.fn() }));
-import { offerUpdateMain } from "./pull-offer";
 import type {
   AutoMergeStatus,
   BacklogPayload,
@@ -687,12 +685,14 @@ test("setBuildQueue does not clobber other sessions", () => {
 
 // ── mergetrain:landed ──────────────────────────────────────────────────────
 
-test("mergetrain:landed calls offerUpdateMain with the repoPath", () => {
-  vi.mocked(offerUpdateMain).mockClear();
+test("mergetrain:landed enqueues a repo-keyed landed confirmation toast", () => {
+  toasts.items = [];
   const s = new HerdStore();
   s.apply({ event: "mergetrain:landed", data: { repoPath: "/repos/my-project" } });
-  expect(offerUpdateMain).toHaveBeenCalledOnce();
-  expect(offerUpdateMain).toHaveBeenCalledWith("/repos/my-project");
+  const t = toasts.items.find((x) => x.key === "mergetrain-landed:/repos/my-project");
+  expect(t).toBeDefined();
+  expect(t!.text).toContain("my-project"); // repo basename interpolated, no Update action
+  expect(t!.actionLabel).toBeUndefined();
 });
 
 // ── draftreconcile:status ──────────────────────────────────────────────────

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -29,7 +29,6 @@ import { herdDigest } from "./herd-digest.svelte";
 import { learnings } from "./learnings.svelte";
 import { toasts } from "./toasts.svelte";
 import { m } from "$lib/paraglide/messages";
-import { offerUpdateMain } from "./pull-offer";
 import { buildQueues as buildQueuesStore } from "./buildQueues.svelte";
 import { postMergeSteps as postMergeStepsStore } from "./post-merge-steps.svelte";
 
@@ -573,12 +572,20 @@ export class HerdStore {
         toasts.info(m.halt_done({ count: ev.data.halted }), { key: "halt-done" });
         break;
       case "mergetrain:landed":
-        offerUpdateMain(ev.data.repoPath);
+        this.confirmMergeTrainLanded(ev.data.repoPath);
         break;
       case "draftreconcile:status":
         this.applyDraftReconcile(ev.data);
         break;
     }
+  }
+
+  /** Confirm a merge train landed. A train lands a batch (no single PR number), so this
+   *  is a plain repo-keyed info toast — no per-merge update offer. The local default-branch
+   *  checkout stays updatable on demand via BacklogView's Fast-forward button. */
+  private confirmMergeTrainLanded(repoPath: string): void {
+    const repo = repoPath.split("/").pop() ?? repoPath;
+    toasts.info(m.toast_mergetrain_landed({ repo }), { key: `mergetrain-landed:${repoPath}` });
   }
 
   /** Handle a draft-reconcile status push. On error: raise a persistent, assertive


### PR DESCRIPTION
## Why

After a PR merges, the UI stacked **two competing 15s toasts** at once:

1. `Merged {name}` + **Decommission**
2. `PR merged. Update your local default branch?` + **Update** (isolated sessions)

Now that new task spawns always start from `origin` HEAD of the default branch, a stale local checkout no longer blocks anything, so the second offer is low-value. This collapses the post-merge moment to a **single, clear next step** — Decommission.

## What changed

- **Manual-merge paths** (`GitRail.svelte`, `PrRow.svelte`): drop the auto update-local offer; the only post-merge toast is `Merged …` + Decommission.
- **Merge-train path** (`store.svelte.ts`, `mergetrain:landed` — previously the *sole* signal a train landed): replaced the update offer with a plain repo-keyed `Merge train landed in {repo}` info toast.
  - ⚠️ **Behavior change (not just copy):** this path **loses its one-click fast-forward _action_** — the replacement is a no-action info toast. Updating the local checkout after a train lands remains possible via BacklogView's existing **Fast-forward** button (`pullMainAndToast` is retained untouched).
- Deleted the now-dead `offerUpdateMain` helper and its orphaned `isolated`/`baseBranch` GitRail props (removed from both `GitRail` and its sole `Viewport` call site, in lockstep, to avoid an excess-prop error).
- Removed the orphaned `toast_update_main_offer` / `toast_update_main_action` message keys (EN+DE); added `toast_mergetrain_landed`. All other `toast_update_main_*` keys stay (used by the surviving manual pull).

### Deviation notes (house rules)
- The merge-train confirmation names the repo by its **path basename** (via the existing `store.svelte.ts` `.split("/").pop()` idiom) rather than a PR number, because the `mergetrain:landed` event carries no PR number and a train lands a *batch*.
- Shipped as `fix(ui):` — this is a refinement/removal, not a new capability, so no What's-New feature-catalog entry (`[no-feature-entry]` not needed; the gate only arms on `feat`). "Merge train" is already an established product term, so no glossary entry.

## Verification
- `cd ui && bun run check` — 0 errors
- `cd ui && bun run check:i18n` — locales in parity
- `cd ui && bun run test` — 2076 passed
- `bunx fallow audit --base origin/main --fail-on-issues` — no issues in changed files

[no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)