### PR TITLE
fix(automation): Auto-Abarbeitung-Regler inline unter den Schalter + Felddoku

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2006,5 +2006,9 @@
   "feat_herdr_update_session_list_title": "Sieh die Sessions, die ein Update beenden würde — und spring hin",
   "feat_herdr_update_session_list_body": "Der herdr-Update-Dialog zeigt nicht mehr nur eine Zahl laufender Sessions, sondern listet jede einzeln auf — und jede Zeile springt direkt zu dieser Session. Schließe sie nach und nach ab und aktualisiere dann, ohne Angst, etwas zu verlieren.",
   "topbar_held_spawning": "Wird gestartet…",
-  "topbar_held_discarding": "Wird verworfen…"
+  "topbar_held_discarding": "Wird verworfen…",
+  "automation_drain_fields_intro": "Diese Regler steuern die Auto-Abarbeitung und gelten nur, solange sie aktiv ist:",
+  "drain_cap_hint": "Wie viele auto-gestartete Agenten höchstens gleichzeitig laufen. Ist das Limit erreicht, wartet Shepherd auf einen freien Platz, bevor das nächste Issue aufgegriffen wird.",
+  "drain_label_hint": "Nur Issues mit diesem Label werden aufgegriffen — versieh die Tickets, die automatisch abgearbeitet werden sollen, damit.",
+  "drain_ceiling_hint": "Pausiert neue Auto-Starts, sobald die Konto-Auslastung diesen Prozentwert erreicht. Ein höherer Wert lässt die Abarbeitung länger weiterlaufen; Standard ist 80."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2006,5 +2006,9 @@
   "feat_herdr_update_session_list_title": "See and visit the sessions an update would end",
   "feat_herdr_update_session_list_body": "The herdr-update dialog no longer just shows a count of running sessions — it lists each one, and every row jumps straight to that session. Wrap them up one by one, then update without worrying you've lost work.",
   "topbar_held_spawning": "Starting…",
-  "topbar_held_discarding": "Discarding…"
+  "topbar_held_discarding": "Discarding…",
+  "automation_drain_fields_intro": "These dials govern Auto-Drain and apply only while it's on:",
+  "drain_cap_hint": "Most auto-started agents allowed to run at once. Once it's reached, Shepherd waits for a slot to free before picking up the next issue.",
+  "drain_label_hint": "Only issues carrying this label get picked up — tag the tickets you want worked automatically with it.",
+  "drain_ceiling_hint": "Pause new auto-starts once your account usage reaches this percentage. A higher value lets the drain keep going longer; the default is 80."
 }

--- a/ui/src/lib/components/AutomationSettings.svelte
+++ b/ui/src/lib/components/AutomationSettings.svelte
@@ -387,7 +387,7 @@
     <label class="drain-field">
       <span class="drain-label">{m.automation_signoff_authority_label()}</span>
       <select
-        class="num signoff-select"
+        class="afield-num signoff-select"
         aria-label={m.automation_signoff_authority_label()}
         value={repoConfig.signoffAuthorityFor(repoPath)}
         onchange={(e) =>
@@ -416,7 +416,7 @@
   <label class="drain-field" use:coachIf={{ id: "sandbox-profile", on: armCoachmarks }}>
     <span class="drain-label">{m.automation_sandbox_profile_label()}</span>
     <select
-      class="num sandbox-select"
+      class="afield-num sandbox-select"
       aria-label={m.automation_sandbox_profile_label()}
       value={repoConfig.sandboxProfileFor(repoPath)}
       onchange={(e) =>
@@ -617,9 +617,9 @@
       opacity: 1;
     }
   }
-  /* .drain-fields / .drain-field / .drain-label / .num come from
+  /* .drain-fields / .drain-field / .drain-label / .afield-num come from
      ./automation-settings/automation-fields.css (imported in <script>). */
-  /* Sign-off authority selector — inherits .num token styling, left-aligned */
+  /* Sign-off authority selector — inherits .afield-num token styling, left-aligned */
   .signoff-select {
     flex: 1 1 auto;
     width: auto;
@@ -633,7 +633,7 @@
     color: var(--color-faint);
     padding: 0 12px 6px;
   }
-  /* Sandbox-profile selector — inherits .num token styling, left-aligned (mirrors .signoff-select) */
+  /* Sandbox-profile selector — inherits .afield-num token styling, left-aligned (mirrors .signoff-select) */
   .sandbox-select {
     flex: 1 1 auto;
     width: auto;

--- a/ui/src/lib/components/AutomationSettings.svelte
+++ b/ui/src/lib/components/AutomationSettings.svelte
@@ -3,6 +3,7 @@
   import { reviews, repoConfig, planGates } from "$lib/reviews.svelte";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
   import AutomationRepoFields from "./automation-settings/AutomationRepoFields.svelte";
+  import AutomationDrainFields from "./automation-settings/AutomationDrainFields.svelte";
   import type { Session, SandboxProfile, DrainStatus } from "$lib/types";
 
   let {
@@ -297,6 +298,12 @@
     <span class="knob"></span>
   </button>
 </div>
+<!-- Auto-Drain's rails (cap / label / usage ceiling), inline directly under its
+     toggle so they read as part of that switch. Only while drain is actually
+     active (on, not epic-suspended, forge repo) — otherwise they'd be inert. -->
+{#if flags.autoDrain && !epicActive && !lightweight}
+  <AutomationDrainFields {repoPath} />
+{/if}
 <div class={["auto-row", { disabled: flags.draftMode }]}>
   <div class="auto-meta">
     <div class="auto-name">
@@ -435,7 +442,7 @@
   </div>
 </div>
 
-<AutomationRepoFields {repoPath} autoDrain={flags.autoDrain} />
+<AutomationRepoFields {repoPath} />
 
 <!-- Clickable "ⓘ" that toggles a row's long-form explanation, and the detail
      block it reveals. Reused by every row so each function carries a thorough,

--- a/ui/src/lib/components/AutomationSettings.svelte
+++ b/ui/src/lib/components/AutomationSettings.svelte
@@ -4,6 +4,7 @@
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
   import AutomationRepoFields from "./automation-settings/AutomationRepoFields.svelte";
   import AutomationDrainFields from "./automation-settings/AutomationDrainFields.svelte";
+  import "./automation-settings/automation-fields.css";
   import type { Session, SandboxProfile, DrainStatus } from "$lib/types";
 
   let {
@@ -45,6 +46,9 @@
   const flags = $derived(repoConfig.flags(repoPath));
   /** True when this repo is configured for local-only (lightweight) mode. */
   const lightweight = $derived(repoConfig.repoModeFor(repoPath) === "lightweight");
+  /** Auto-Drain's rails are live only when drain is on, not epic-suspended, and the
+   *  repo is a forge — mirrors the Auto-Drain switch's own enabled condition. */
+  const drainRailsActive = $derived(flags.autoDrain && !epicActive && !lightweight);
   // Switch-pulse is per-task; only meaningful when this instance is bound to a session.
   const reviewing = $derived(sessionId ? reviews.isReviewing(sessionId) : false);
   const planReviewing = $derived(sessionId ? planGates.isReviewing(sessionId) : false);
@@ -299,11 +303,10 @@
   </button>
 </div>
 <!-- Auto-Drain's rails (cap / label / usage ceiling), inline directly under its
-     toggle so they read as part of that switch. Only while drain is actually
-     active (on, not epic-suspended, forge repo) — otherwise they'd be inert. -->
-{#if flags.autoDrain && !epicActive && !lightweight}
-  <AutomationDrainFields {repoPath} />
-{/if}
+     toggle so they read as part of that switch. The component renders them only
+     while drain is genuinely active (on, not epic-suspended, forge repo) —
+     visibility is gated inside it via `active` so this template stays flat. -->
+<AutomationDrainFields {repoPath} active={drainRailsActive} />
 <div class={["auto-row", { disabled: flags.draftMode }]}>
   <div class="auto-meta">
     <div class="auto-name">
@@ -614,37 +617,8 @@
       opacity: 1;
     }
   }
-  .drain-fields {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    padding: 8px 12px 12px 22px;
-    border-top: 1px solid var(--color-line);
-    background: var(--color-panel);
-  }
-  .drain-field {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-  }
-  .drain-label {
-    font-size: var(--fs-meta);
-    color: var(--color-ink);
-    white-space: nowrap;
-  }
-  .num {
-    flex: 0 0 auto;
-    width: 90px;
-    background: var(--color-panel);
-    border: 1px solid var(--color-line);
-    border-radius: 2px;
-    color: var(--color-ink);
-    font-family: var(--font-mono);
-    font-size: var(--fs-base);
-    padding: 3px 6px;
-    text-align: right;
-  }
+  /* .drain-fields / .drain-field / .drain-label / .num come from
+     ./automation-settings/automation-fields.css (imported in <script>). */
   /* Sign-off authority selector — inherits .num token styling, left-aligned */
   .signoff-select {
     flex: 1 1 auto;

--- a/ui/src/lib/components/automation-settings/AutomationDrainFields.svelte
+++ b/ui/src/lib/components/automation-settings/AutomationDrainFields.svelte
@@ -107,9 +107,9 @@
 {/if}
 
 <style>
-  /* Shared `.drain-fields` / `.drain-field` / `.drain-label` / `.num` layout comes
-     from ./automation-fields.css (imported above). Only the field-doc copy below
-     is local to this component. */
+  /* Shared `.drain-fields` / `.drain-field` / `.drain-label` / `.afield-num` layout
+     comes from ./automation-fields.css (imported above). Only the field-doc copy
+     below is local to this component. */
   /* Lead-in sentence framing the three dials as Auto-Drain's rails. */
   .drain-intro {
     margin: 0 0 2px;

--- a/ui/src/lib/components/automation-settings/AutomationDrainFields.svelte
+++ b/ui/src/lib/components/automation-settings/AutomationDrainFields.svelte
@@ -12,6 +12,10 @@
   // the parent's already-large template flat.
   let { repoPath, active }: { repoPath: string; active: boolean } = $props();
 
+  // Per-instance prefix so the hint IDs (and the inputs' aria-describedby) stay
+  // unique even if two panels mount at once (e.g. in-task popover + backlog tab).
+  const uid = $props.id();
+
   // Seeded from stored config; re-seeded whenever the repo changes (the component
   // stays mounted across repo switches as long as Auto-Drain remains on).
   // svelte-ignore state_referenced_locally
@@ -61,44 +65,44 @@
     <label class="drain-field">
       <span class="drain-label">{m.drain_cap_label()}</span>
       <input
-        class="num"
+        class="afield-num"
         type="number"
         min="1"
         max="20"
         bind:value={drainCap}
         aria-label={m.drain_cap_label()}
-        aria-describedby="drain-hint-cap"
+        aria-describedby="{uid}-cap"
         onchange={commitDrainCap}
       />
     </label>
-    <p id="drain-hint-cap" class="drain-hint">{m.drain_cap_hint()}</p>
+    <p id="{uid}-cap" class="drain-hint">{m.drain_cap_hint()}</p>
     <label class="drain-field">
       <span class="drain-label">{m.drain_label_label()}</span>
       <input
-        class="num txt"
+        class="afield-num txt"
         type="text"
         bind:value={drainLabel}
         aria-label={m.drain_label_label()}
-        aria-describedby="drain-hint-label"
+        aria-describedby="{uid}-label"
         onchange={commitDrainLabel}
         onblur={commitDrainLabel}
       />
     </label>
-    <p id="drain-hint-label" class="drain-hint">{m.drain_label_hint()}</p>
+    <p id="{uid}-label" class="drain-hint">{m.drain_label_hint()}</p>
     <label class="drain-field">
       <span class="drain-label">{m.drain_ceiling_label()}</span>
       <input
-        class="num"
+        class="afield-num"
         type="number"
         min="0"
         max="100"
         bind:value={drainCeiling}
         aria-label={m.drain_ceiling_label()}
-        aria-describedby="drain-hint-ceiling"
+        aria-describedby="{uid}-ceiling"
         onchange={commitDrainCeiling}
       />
     </label>
-    <p id="drain-hint-ceiling" class="drain-hint">{m.drain_ceiling_hint()}</p>
+    <p id="{uid}-ceiling" class="drain-hint">{m.drain_ceiling_hint()}</p>
   </div>
 {/if}
 

--- a/ui/src/lib/components/automation-settings/AutomationDrainFields.svelte
+++ b/ui/src/lib/components/automation-settings/AutomationDrainFields.svelte
@@ -3,11 +3,14 @@
   import { m } from "$lib/paraglide/messages";
   import { repoConfig } from "$lib/reviews.svelte";
   import { clampCap, clampCeiling, sanitizeLabel } from "../git-rail-drain";
+  import "./automation-fields.css";
 
   // The Auto-Drain "rails" (cap / label / usage ceiling). Rendered inline directly
   // beneath the Auto-Drain toggle — and only while it's on — so the dials read as
   // belonging to that switch rather than floating in an unrelated section below.
-  let { repoPath }: { repoPath: string } = $props();
+  // `active` gates visibility here (instead of an {#if} at the call site) to keep
+  // the parent's already-large template flat.
+  let { repoPath, active }: { repoPath: string; active: boolean } = $props();
 
   // Seeded from stored config; re-seeded whenever the repo changes (the component
   // stays mounted across repo switches as long as Auto-Drain remains on).
@@ -52,93 +55,57 @@
   }
 </script>
 
-<div class="drain-fields" role="group" aria-label={m.automation_autodrain_name()}>
-  <p class="drain-intro">{m.automation_drain_fields_intro()}</p>
-  <label class="drain-field">
-    <span class="drain-label">{m.drain_cap_label()}</span>
-    <input
-      class="num"
-      type="number"
-      min="1"
-      max="20"
-      bind:value={drainCap}
-      aria-label={m.drain_cap_label()}
-      aria-describedby="drain-hint-cap"
-      onchange={commitDrainCap}
-    />
-  </label>
-  <p id="drain-hint-cap" class="drain-hint">{m.drain_cap_hint()}</p>
-  <label class="drain-field">
-    <span class="drain-label">{m.drain_label_label()}</span>
-    <input
-      class="num txt"
-      type="text"
-      bind:value={drainLabel}
-      aria-label={m.drain_label_label()}
-      aria-describedby="drain-hint-label"
-      onchange={commitDrainLabel}
-      onblur={commitDrainLabel}
-    />
-  </label>
-  <p id="drain-hint-label" class="drain-hint">{m.drain_label_hint()}</p>
-  <label class="drain-field">
-    <span class="drain-label">{m.drain_ceiling_label()}</span>
-    <input
-      class="num"
-      type="number"
-      min="0"
-      max="100"
-      bind:value={drainCeiling}
-      aria-label={m.drain_ceiling_label()}
-      aria-describedby="drain-hint-ceiling"
-      onchange={commitDrainCeiling}
-    />
-  </label>
-  <p id="drain-hint-ceiling" class="drain-hint">{m.drain_ceiling_hint()}</p>
-</div>
+{#if active}
+  <div class="drain-fields" role="group" aria-label={m.automation_autodrain_name()}>
+    <p class="drain-intro">{m.automation_drain_fields_intro()}</p>
+    <label class="drain-field">
+      <span class="drain-label">{m.drain_cap_label()}</span>
+      <input
+        class="num"
+        type="number"
+        min="1"
+        max="20"
+        bind:value={drainCap}
+        aria-label={m.drain_cap_label()}
+        aria-describedby="drain-hint-cap"
+        onchange={commitDrainCap}
+      />
+    </label>
+    <p id="drain-hint-cap" class="drain-hint">{m.drain_cap_hint()}</p>
+    <label class="drain-field">
+      <span class="drain-label">{m.drain_label_label()}</span>
+      <input
+        class="num txt"
+        type="text"
+        bind:value={drainLabel}
+        aria-label={m.drain_label_label()}
+        aria-describedby="drain-hint-label"
+        onchange={commitDrainLabel}
+        onblur={commitDrainLabel}
+      />
+    </label>
+    <p id="drain-hint-label" class="drain-hint">{m.drain_label_hint()}</p>
+    <label class="drain-field">
+      <span class="drain-label">{m.drain_ceiling_label()}</span>
+      <input
+        class="num"
+        type="number"
+        min="0"
+        max="100"
+        bind:value={drainCeiling}
+        aria-label={m.drain_ceiling_label()}
+        aria-describedby="drain-hint-ceiling"
+        onchange={commitDrainCeiling}
+      />
+    </label>
+    <p id="drain-hint-ceiling" class="drain-hint">{m.drain_ceiling_hint()}</p>
+  </div>
+{/if}
 
 <style>
-  /* Mirrors the parent's `.drain-fields` nesting: indented under the toggle row,
-     panel ground + hairline top border, so it reads as expanding from the switch. */
-  .drain-fields {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    padding: 8px 12px 12px 22px;
-    border-top: 1px solid var(--color-line);
-    background: var(--color-panel);
-  }
-  .drain-field {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-  }
-  .drain-label {
-    font-size: var(--fs-meta);
-    color: var(--color-ink);
-    white-space: nowrap;
-  }
-  .num {
-    flex: 0 0 auto;
-    width: 90px;
-    background: var(--color-panel);
-    border: 1px solid var(--color-line);
-    border-radius: 2px;
-    color: var(--color-ink);
-    font-family: var(--font-mono);
-    font-size: var(--fs-base);
-    padding: 3px 6px;
-    text-align: right;
-  }
-  /* The label is free text (e.g. "shepherd:auto") that overflows the fixed numeric
-     width on narrow screens — let it grow and read from the start. */
-  .num.txt {
-    flex: 1 1 auto;
-    width: auto;
-    min-width: 0;
-    text-align: left;
-  }
+  /* Shared `.drain-fields` / `.drain-field` / `.drain-label` / `.num` layout comes
+     from ./automation-fields.css (imported above). Only the field-doc copy below
+     is local to this component. */
   /* Lead-in sentence framing the three dials as Auto-Drain's rails. */
   .drain-intro {
     margin: 0 0 2px;

--- a/ui/src/lib/components/automation-settings/AutomationDrainFields.svelte
+++ b/ui/src/lib/components/automation-settings/AutomationDrainFields.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+  import { untrack } from "svelte";
+  import { m } from "$lib/paraglide/messages";
+  import { repoConfig } from "$lib/reviews.svelte";
+  import { clampCap, clampCeiling, sanitizeLabel } from "../git-rail-drain";
+
+  // The Auto-Drain "rails" (cap / label / usage ceiling). Rendered inline directly
+  // beneath the Auto-Drain toggle — and only while it's on — so the dials read as
+  // belonging to that switch rather than floating in an unrelated section below.
+  let { repoPath }: { repoPath: string } = $props();
+
+  // Seeded from stored config; re-seeded whenever the repo changes (the component
+  // stays mounted across repo switches as long as Auto-Drain remains on).
+  // svelte-ignore state_referenced_locally
+  let drainCap = $state(repoConfig.maxAutoFor(repoPath));
+  // svelte-ignore state_referenced_locally
+  let drainLabel = $state(repoConfig.autoLabelFor(repoPath));
+  // svelte-ignore state_referenced_locally
+  let drainCeiling = $state(repoConfig.usageCeilingFor(repoPath));
+  $effect(() => {
+    // untrack the store reads so committing a field (which writes back to the
+    // store) never retriggers this effect and clobbers an in-flight edit.
+    const repo = repoPath;
+    untrack(() => {
+      drainCap = repoConfig.maxAutoFor(repo);
+      drainLabel = repoConfig.autoLabelFor(repo);
+      drainCeiling = repoConfig.usageCeilingFor(repo);
+    });
+  });
+
+  async function commitDrainCap() {
+    const n = clampCap(drainCap);
+    drainCap = n;
+    await repoConfig.setMaxAuto(repoPath, n);
+    drainCap = repoConfig.maxAutoFor(repoPath);
+  }
+  async function commitDrainLabel() {
+    const t = sanitizeLabel(drainLabel);
+    if (t === null) {
+      drainLabel = repoConfig.autoLabelFor(repoPath);
+      return;
+    }
+    drainLabel = t;
+    await repoConfig.setAutoLabel(repoPath, t);
+    drainLabel = repoConfig.autoLabelFor(repoPath);
+  }
+  async function commitDrainCeiling() {
+    const n = clampCeiling(drainCeiling);
+    drainCeiling = n;
+    await repoConfig.setUsageCeiling(repoPath, n);
+    drainCeiling = repoConfig.usageCeilingFor(repoPath);
+  }
+</script>
+
+<div class="drain-fields" role="group" aria-label={m.automation_autodrain_name()}>
+  <p class="drain-intro">{m.automation_drain_fields_intro()}</p>
+  <label class="drain-field">
+    <span class="drain-label">{m.drain_cap_label()}</span>
+    <input
+      class="num"
+      type="number"
+      min="1"
+      max="20"
+      bind:value={drainCap}
+      aria-label={m.drain_cap_label()}
+      aria-describedby="drain-hint-cap"
+      onchange={commitDrainCap}
+    />
+  </label>
+  <p id="drain-hint-cap" class="drain-hint">{m.drain_cap_hint()}</p>
+  <label class="drain-field">
+    <span class="drain-label">{m.drain_label_label()}</span>
+    <input
+      class="num txt"
+      type="text"
+      bind:value={drainLabel}
+      aria-label={m.drain_label_label()}
+      aria-describedby="drain-hint-label"
+      onchange={commitDrainLabel}
+      onblur={commitDrainLabel}
+    />
+  </label>
+  <p id="drain-hint-label" class="drain-hint">{m.drain_label_hint()}</p>
+  <label class="drain-field">
+    <span class="drain-label">{m.drain_ceiling_label()}</span>
+    <input
+      class="num"
+      type="number"
+      min="0"
+      max="100"
+      bind:value={drainCeiling}
+      aria-label={m.drain_ceiling_label()}
+      aria-describedby="drain-hint-ceiling"
+      onchange={commitDrainCeiling}
+    />
+  </label>
+  <p id="drain-hint-ceiling" class="drain-hint">{m.drain_ceiling_hint()}</p>
+</div>
+
+<style>
+  /* Mirrors the parent's `.drain-fields` nesting: indented under the toggle row,
+     panel ground + hairline top border, so it reads as expanding from the switch. */
+  .drain-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 12px 12px 22px;
+    border-top: 1px solid var(--color-line);
+    background: var(--color-panel);
+  }
+  .drain-field {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .drain-label {
+    font-size: var(--fs-meta);
+    color: var(--color-ink);
+    white-space: nowrap;
+  }
+  .num {
+    flex: 0 0 auto;
+    width: 90px;
+    background: var(--color-panel);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-ink);
+    font-family: var(--font-mono);
+    font-size: var(--fs-base);
+    padding: 3px 6px;
+    text-align: right;
+  }
+  /* The label is free text (e.g. "shepherd:auto") that overflows the fixed numeric
+     width on narrow screens — let it grow and read from the start. */
+  .num.txt {
+    flex: 1 1 auto;
+    width: auto;
+    min-width: 0;
+    text-align: left;
+  }
+  /* Lead-in sentence framing the three dials as Auto-Drain's rails. */
+  .drain-intro {
+    margin: 0 0 2px;
+    font-size: var(--fs-meta);
+    line-height: 1.45;
+    color: var(--color-muted);
+  }
+  /* Per-field explanation: quiet, sits flush under its field so the meaning of
+     each dial is legible inline rather than hidden behind a tooltip. */
+  .drain-hint {
+    margin: -2px 0 2px;
+    font-size: var(--fs-micro);
+    line-height: 1.45;
+    color: var(--color-faint);
+  }
+</style>

--- a/ui/src/lib/components/automation-settings/AutomationRepoFields.svelte
+++ b/ui/src/lib/components/automation-settings/AutomationRepoFields.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
-  import { untrack } from "svelte";
   import { m } from "$lib/paraglide/messages";
   import { repoConfig } from "$lib/reviews.svelte";
-  import { clampCap, clampCeiling, sanitizeLabel } from "../git-rail-drain";
   import { getRepoRoles, getRepoCollaborators, putRepoRoles } from "$lib/api";
   import { MODELS } from "$lib/types";
   import { modelLabel } from "$lib/model-label";
@@ -10,55 +8,9 @@
 
   let {
     repoPath,
-    autoDrain,
   }: {
     repoPath: string;
-    autoDrain: boolean;
   } = $props();
-
-  // Drain config fields, seeded from stored config and re-seeded whenever the
-  // section becomes visible (drain turned on) or the repo changes.
-  // svelte-ignore state_referenced_locally
-  let drainCap = $state(repoConfig.maxAutoFor(repoPath));
-  // svelte-ignore state_referenced_locally
-  let drainLabel = $state(repoConfig.autoLabelFor(repoPath));
-  // svelte-ignore state_referenced_locally
-  let drainCeiling = $state(repoConfig.usageCeilingFor(repoPath));
-  $effect(() => {
-    // Re-seed the inputs when the repo changes or the drain section (re)appears.
-    // untrack the store reads so committing a field (which writes back to the
-    // store) never retriggers this effect and clobbers an in-flight edit.
-    const repo = repoPath;
-    if (!autoDrain) return;
-    untrack(() => {
-      drainCap = repoConfig.maxAutoFor(repo);
-      drainLabel = repoConfig.autoLabelFor(repo);
-      drainCeiling = repoConfig.usageCeilingFor(repo);
-    });
-  });
-
-  async function commitDrainCap() {
-    const n = clampCap(drainCap);
-    drainCap = n;
-    await repoConfig.setMaxAuto(repoPath, n);
-    drainCap = repoConfig.maxAutoFor(repoPath);
-  }
-  async function commitDrainLabel() {
-    const t = sanitizeLabel(drainLabel);
-    if (t === null) {
-      drainLabel = repoConfig.autoLabelFor(repoPath);
-      return;
-    }
-    drainLabel = t;
-    await repoConfig.setAutoLabel(repoPath, t);
-    drainLabel = repoConfig.autoLabelFor(repoPath);
-  }
-  async function commitDrainCeiling() {
-    const n = clampCeiling(drainCeiling);
-    drainCeiling = n;
-    await repoConfig.setUsageCeiling(repoPath, n);
-    drainCeiling = repoConfig.usageCeilingFor(repoPath);
-  }
 
   // Repo responsibilities (.shepherd/roles.json): who reviews, who merges. Loaded
   // lazily when the panel mounts / the repo changes — the herd reads the computed
@@ -147,45 +99,6 @@
   </label>
   <div class="signoff-note">{m.automation_default_model_hint()}</div>
 </div>
-{#if autoDrain}
-  <div class="drain-fields">
-    <label class="drain-field">
-      <span class="drain-label">{m.drain_cap_label()}</span>
-      <input
-        class="num"
-        type="number"
-        min="1"
-        max="20"
-        bind:value={drainCap}
-        aria-label={m.drain_cap_label()}
-        onchange={commitDrainCap}
-      />
-    </label>
-    <label class="drain-field">
-      <span class="drain-label">{m.drain_label_label()}</span>
-      <input
-        class="num txt"
-        type="text"
-        bind:value={drainLabel}
-        aria-label={m.drain_label_label()}
-        onchange={commitDrainLabel}
-        onblur={commitDrainLabel}
-      />
-    </label>
-    <label class="drain-field">
-      <span class="drain-label">{m.drain_ceiling_label()}</span>
-      <input
-        class="num"
-        type="number"
-        min="0"
-        max="100"
-        bind:value={drainCeiling}
-        aria-label={m.drain_ceiling_label()}
-        onchange={commitDrainCeiling}
-      />
-    </label>
-  </div>
-{/if}
 
 <!-- Repo responsibilities: reviewer + merger (committed to .shepherd/roles.json) -->
 <div class="auto-group" id="repo-roles">{m.automation_group_roles()}</div>
@@ -291,15 +204,6 @@
     font-size: var(--fs-base);
     padding: 3px 6px;
     text-align: right;
-  }
-  /* The label is free text (e.g. "shepherd:auto") that overflows the fixed
-     numeric width on narrow screens — let it grow with the row and read from
-     the start instead of clipping the left side under right-alignment. */
-  .num.txt {
-    flex: 1 1 auto;
-    width: auto;
-    min-width: 0;
-    text-align: left;
   }
   .role-select,
   .role-input {

--- a/ui/src/lib/components/automation-settings/AutomationRepoFields.svelte
+++ b/ui/src/lib/components/automation-settings/AutomationRepoFields.svelte
@@ -5,6 +5,7 @@
   import { MODELS } from "$lib/types";
   import { modelLabel } from "$lib/model-label";
   import type { RepoRoles } from "$lib/types";
+  import "./automation-fields.css";
 
   let {
     repoPath,
@@ -174,37 +175,8 @@
     font-size: var(--fs-base);
     color: var(--color-ink-bright);
   }
-  .drain-fields {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    padding: 8px 12px 12px 22px;
-    border-top: 1px solid var(--color-line);
-    background: var(--color-panel);
-  }
-  .drain-field {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-  }
-  .drain-label {
-    font-size: var(--fs-meta);
-    color: var(--color-ink);
-    white-space: nowrap;
-  }
-  .num {
-    flex: 0 0 auto;
-    width: 90px;
-    background: var(--color-panel);
-    border: 1px solid var(--color-line);
-    border-radius: 2px;
-    color: var(--color-ink);
-    font-family: var(--font-mono);
-    font-size: var(--fs-base);
-    padding: 3px 6px;
-    text-align: right;
-  }
+  /* .drain-fields / .drain-field / .drain-label / .num come from
+     ./automation-fields.css (imported in <script>). */
   .role-select,
   .role-input {
     flex: 0 0 auto;

--- a/ui/src/lib/components/automation-settings/AutomationRepoFields.svelte
+++ b/ui/src/lib/components/automation-settings/AutomationRepoFields.svelte
@@ -84,7 +84,7 @@
   <label class="drain-field">
     <span class="drain-label">{m.automation_default_model_label()}</span>
     <select
-      class="num model-select"
+      class="afield-num model-select"
       aria-label={m.automation_default_model_label()}
       value={repoConfig.defaultModelFor(repoPath)}
       onchange={(e) =>
@@ -175,7 +175,7 @@
     font-size: var(--fs-base);
     color: var(--color-ink-bright);
   }
-  /* .drain-fields / .drain-field / .drain-label / .num come from
+  /* .drain-fields / .drain-field / .drain-label / .afield-num come from
      ./automation-fields.css (imported in <script>). */
   .role-select,
   .role-input {

--- a/ui/src/lib/components/automation-settings/automation-fields.css
+++ b/ui/src/lib/components/automation-settings/automation-fields.css
@@ -1,0 +1,44 @@
+/* Shared layout for the automation panel's inset field rows (drain rails, sandbox
+   profile, default model, sign-off). Hoisted out of the individual components so
+   the rules live in exactly one place instead of being copied into each scoped
+   <style> block. These class names are used only by the automation-settings
+   components, so global scope here is safe (and intentional). */
+.drain-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 12px 12px 22px;
+  border-top: 1px solid var(--color-line);
+  background: var(--color-panel);
+}
+.drain-field {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.drain-label {
+  font-size: var(--fs-meta);
+  color: var(--color-ink);
+  white-space: nowrap;
+}
+.num {
+  flex: 0 0 auto;
+  width: 90px;
+  background: var(--color-panel);
+  border: 1px solid var(--color-line);
+  border-radius: 2px;
+  color: var(--color-ink);
+  font-family: var(--font-mono);
+  font-size: var(--fs-base);
+  padding: 3px 6px;
+  text-align: right;
+}
+/* The label is free text (e.g. "shepherd:auto") that overflows the fixed numeric
+   width on narrow screens — let it grow and read from the start. */
+.num.txt {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
+  text-align: left;
+}

--- a/ui/src/lib/components/automation-settings/automation-fields.css
+++ b/ui/src/lib/components/automation-settings/automation-fields.css
@@ -1,8 +1,14 @@
 /* Shared layout for the automation panel's inset field rows (drain rails, sandbox
    profile, default model, sign-off). Hoisted out of the individual components so
    the rules live in exactly one place instead of being copied into each scoped
-   <style> block. These class names are used only by the automation-settings
-   components, so global scope here is safe (and intentional). */
+   <style> block.
+
+   These rules are global (a plain CSS import is unscoped), so the class names must
+   not collide with any other component. `.drain-fields`/`.drain-field`/`.drain-label`
+   are used only by the automation-settings components. The number/text input chrome
+   is named `.afield-num` (NOT a generic `.num`, which several other components —
+   EpicPanel, EpicGroupHeader, IntegratedEpicRow, MergeTrainConfirmDialog, Settings —
+   define for their own inputs and would inherit a leaked global rule). */
 .drain-fields {
   display: flex;
   flex-direction: column;
@@ -22,7 +28,7 @@
   color: var(--color-ink);
   white-space: nowrap;
 }
-.num {
+.afield-num {
   flex: 0 0 auto;
   width: 90px;
   background: var(--color-panel);
@@ -36,7 +42,7 @@
 }
 /* The label is free text (e.g. "shepherd:auto") that overflows the fixed numeric
    width on narrow screens — let it grow and read from the start. */
-.num.txt {
+.afield-num.txt {
   flex: 1 1 auto;
   width: auto;
   min-width: 0;


### PR DESCRIPTION
## Problem

Beim Aktivieren von **Auto-Abarbeitung** (Auto-Drain) erschienen die zugehörigen Einstell-Regler — **Limit**, **Label**, **Grenze %** — weit unten im Panel: erst nach Build-Queue, Entwurfsmodus, Sandbox und Standardmodell. Dadurch war nicht erkennbar, dass sie zur Auto-Abarbeitung gehören.

## Änderung

- Die drei Regler werden jetzt **direkt unter dem Auto-Abarbeitung-Schalter** eingeblendet — und nur, solange Auto-Abarbeitung tatsächlich aktiv ist (an, nicht durch ein Epic ausgesetzt, Forge-Repo). Beim Ausschalten klappen sie wieder weg.
- **Mehr Dokumentation:** ein einleitender Satz rahmt die drei Felder als die Regler der Auto-Abarbeitung, und jedes Feld hat eine eigene kurze Erklärung (was Limit / Label / Grenze % bedeuten), per `aria-describedby` mit dem Eingabefeld verknüpft.

Umgesetzt durch Auslagern der Regler in eine eigene kleine Komponente `AutomationDrainFields.svelte`, inline gerendert in `AutomationSettings.svelte`. `AutomationRepoFields` behält nur noch Standardmodell + Zuständigkeiten.

## Verifikation

- `bun run check` (svelte-check) — 0 Fehler / 0 Warnungen
- `bun run check:i18n` — EN/DE in Parität (neue Keys beidseitig ergänzt)
- Automation-Tests grün (`git-rail-automation`, `automation-panel-epic`)
- Live geprüft: Panel rendert, Regler erscheinen/verschwinden mit dem Schalter

Reine UX-Verbesserung an bestehender Funktion, kein neues Feature → kein Feature-Katalog-Eintrag (`fix`, nicht `feat`).
