### PR TITLE
ci(automerge): harden doc-automerge on author identity + path scope; fix checkout-less git failure (#1125)

### DIFF
--- a/.github/workflows/doc-automerge.yml
+++ b/.github/workflows/doc-automerge.yml
@@ -37,6 +37,10 @@ jobs:
     name: merge green doc PRs
     runs-on: ubuntu-latest # a tiny control job — kept off the self-hosted CI runner on purpose
     steps:
+      # Give the job git context: `gh repo view` (and gh's repo auto-detection generally) falls back
+      # to the local git remote, so without a checkout it dies with "fatal: not a git repository".
+      # A shallow checkout fixes every gh call deterministically — cheaper than per-command reasoning.
+      - uses: actions/checkout@v7
       - name: Merge eligible doc PRs
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/doc-automerge.yml
+++ b/.github/workflows/doc-automerge.yml
@@ -3,6 +3,11 @@ name: Auto-merge doc PRs
 # Auto-merges Shepherd's OWN documentation PRs — the ones the doc agent opens on
 # `shepherd/docs-update-*` branches — once they're green, instead of waiting on a human merge.
 #
+# Provenance is NOT established by the branch prefix alone (#1125): the per-PR loop also requires
+# authorAssociation ∈ {OWNER, MEMBER}, a same-repo (non-fork) head, and a diff confined to the doc
+# tree (`docs/` + `docs-site/`). A fork / outsider PR wearing the prefix but carrying arbitrary
+# changes is skipped, never merged.
+#
 # Why a workflow and not a Shepherd setting: the doc agent runs ONLY against this repo (its
 # in-scope file list + DOC_TREE_MARKER are this repo's own doc tree), and Shepherd lives only on
 # GitHub — so a per-repo Shepherd toggle would be a dead switch in every other repo. This keeps the
@@ -70,12 +75,36 @@ jobs:
 
           failed=0
           for n in "${prs[@]}"; do
-            info="$(gh pr view "$n" --json isDraft,mergeable,baseRefName,statusCheckRollup,reviews)"
+            info="$(gh pr view "$n" --json isDraft,mergeable,baseRefName,statusCheckRollup,reviews,isCrossRepository,files,changedFiles)"
 
             draft=$(jq -r '.isDraft' <<<"$info")
             mergeable=$(jq -r '.mergeable' <<<"$info")
             base=$(jq -r '.baseRefName' <<<"$info")
             total=$(jq '(.statusCheckRollup // []) | length' <<<"$info")
+            cross=$(jq -r '.isCrossRepository' <<<"$info")
+            nfiles=$(jq '(.files // []) | length' <<<"$info")
+            changed=$(jq -r '.changedFiles' <<<"$info")
+
+            # Identity hardening (#1125): the branch PREFIX alone is not proof of provenance — a fork
+            # or outside-collaborator PR can carry the same `shepherd/docs-update-*` name with
+            # ARBITRARY file changes. So gate on WHO opened it and WHAT it touches, not just the name.
+            #
+            #   authorAssociation ∈ {OWNER, MEMBER}: Shepherd's own bot/account. REST-only field (not
+            #     exposed by `gh pr view --json`), so fetched via the API.
+            #   isCrossRepository == false: blocks a fork head. DELIBERATELY beyond the issue's two
+            #     checkboxes — authorAssociation alone does NOT stop a fork (a MEMBER can open a PR
+            #     from their own fork and still read MEMBER); this is the direct answer to the issue's
+            #     "a fork PR" threat, and every legit doc PR is same-repo so it never mis-fires.
+            assoc="$(gh api "repos/$GH_REPO/pulls/$n" --jq '.author_association')"
+
+            # Path scope (#1125): the diff must touch ONLY the doc tree. We use the COARSE prefixes
+            # `docs/` + `docs-site/` rather than mirroring doc-agent.ts's exact IN_SCOPE_PATHS list —
+            # robust to in-scope-list edits with no YAML↔TS drift, while still blocking any change
+            # outside the doc tree (src/, .github/, package.json, lockfiles, …). `gh` returns at most
+            # 100 files, so we fail-closed when the list is truncated (changed != nfiles) — a PR can't
+            # pad past 100 doc files to smuggle a hidden non-doc path. Doc PRs touch ≤8 files.
+            nondoc=$(jq '[(.files // [])[].path
+              | select((startswith("docs/") or startswith("docs-site/")) | not)] | length' <<<"$info")
 
             # Every check must be a terminal success (SUCCESS/NEUTRAL/SKIPPED). statusCheckRollup
             # mixes CheckRun (.conclusion; null while pending) and StatusContext (.state) shapes —
@@ -90,6 +119,15 @@ jobs:
               | select((.body // "") | contains($m) | not)
               | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED")]
               | sort_by(.submittedAt) | last | (.state == "CHANGES_REQUESTED")' <<<"$info")
+
+            # Identity + path gates FIRST: an untrusted or out-of-scope PR is rejected before CI
+            # eligibility is even considered. Skip (loud log), never fail red — consistent with every
+            # gate below; the daily-cron cadence would otherwise turn a lingering suspicious PR into
+            # perpetual red noise, and skipping already meets the security goal (never merge it).
+            if [ "$assoc" != "OWNER" ] && [ "$assoc" != "MEMBER" ]; then echo "#$n: author_association=$assoc not OWNER/MEMBER — skip"; continue; fi
+            if [ "$cross" != "false" ];                 then echo "#$n: cross-repository (fork) head — skip";  continue; fi
+            if [ "$changed" -eq 0 ] || [ "$nfiles" != "$changed" ]; then echo "#$n: file list empty/truncated ($nfiles/$changed) — skip"; continue; fi
+            if [ "$nondoc" -ne 0 ];                     then echo "#$n: $nondoc non-doc path(s) changed — skip"; continue; fi
 
             if [ "$draft" != "false" ];                 then echo "#$n: draft — skip";                     continue; fi
             if [ "$base" != "$DEFAULT_BRANCH" ];        then echo "#$n: non-default base ($base) — skip";  continue; fi


### PR DESCRIPTION
Closes #1125. Also fixes the broken doc-automerge run [`28224241163`](https://github.com/erwins-enkel/shepherd/actions/runs/28224241163/job/83612295960).

Two independently-revertable commits in `.github/workflows/doc-automerge.yml`:

## Commit 1 — fix the blocking CI failure (operational)
The workflow had **no `actions/checkout`**, so `gh repo view` (line 54) fell back to local git and died with `fatal: not a git repository`, exiting the run **before any PR was evaluated** — doc-automerge was 100% broken. Added a shallow `actions/checkout@v7` (the repo's pinned convention in `ci.yml`/`pr-hygiene.yml`) as the job's first step, restoring git context deterministically for every `gh` call.

**Why checkout over a surgical `gh api` swap:** the run died at `gh repo view` *before* the first `gh pr list`, so there is no in-repo evidence that `gh pr list/view/merge` work checkout-less — only gh's documented `GH_REPO` support. (The repo's one checkout-less precedent, `onboarding-release-gate.yml`, uses `gh api`, not `gh pr`.) A checkout removes the per-command reasoning entirely.

## Commit 2 — identity + path-scope gates (#1125)
The branch prefix `shepherd/docs-update-*` was the **only** provenance signal: a fork / outside-collaborator PR wearing the prefix with arbitrary file changes would auto-merge once green. Three new skip-gates run **first** in the per-PR loop:

- **`authorAssociation` ∈ {OWNER, MEMBER}** — Shepherd's own account. REST-only field, fetched via `gh api .../pulls/$n`.
- **`isCrossRepository == false`** — blocks fork heads.
- **diff confined to the doc tree** (`docs/` + `docs-site/`), **fail-closed** when the ≤100-file list is truncated.

Ineligible PRs are **skipped (logged), not failed red** — consistent with every existing gate; the daily-cron cadence would otherwise turn a lingering suspicious PR into perpetual red noise, and skipping already meets the security goal (never merge it).

### Deliberate deviations (flagged per house rules — also in code comments)
1. **`isCrossRepository` is beyond the issue's two literal checkboxes.** `authorAssociation` alone does **not** block a fork — a MEMBER can open a PR *from their own fork* and still read `MEMBER`. This is the direct, zero-false-positive answer to the issue's stated "a fork PR" threat (all legit doc PRs are same-repo).
2. **Path scope uses coarse `docs/`+`docs-site/` prefixes, not doc-agent.ts's exact 8-path `IN_SCOPE_PATHS`.** Robust to in-scope-list edits with no YAML↔TS drift, while still blocking any non-doc path (`src/`, `.github/`, `package.json`, …). The agent's exact list stays the structural staging boundary; this CI gate is a deliberately coarser, independent safety net.
3. **Truncation guard (`changedFiles != returned-files → skip`)** is an extra fail-closed defense not named in the issue (gh caps file lists at 100). Doc PRs touch ≤8 files, so it never affects legitimate merges.

## Verification
- `bash -n` on the extracted script — passes (pre- and post-rebase).
- jq-logic harness over real + synthetic fixtures (9/9): doc PR `#1111`/`docs/*` → **MERGE**; code PR `#1123` shape → path-reject; fork → cross-reject; `CONTRIBUTOR`/`NONE` → identity-reject; truncated/empty list → reject; pending CI still held by the existing notgreen gate.
- Confirmed live that real doc PRs (`#1111`, `#1077`, `#1065`; author `scoop`) are `MEMBER` / same-repo / doc-tree-only — the gates pass every legitimate PR.
- **Commit 1 can't be proven by the jq harness** (it never runs `gh`). After merge I'll trigger a `workflow_dispatch` run to confirm it completes past line 54 with no git error; otherwise it's validated by the next live trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)