### PR TITLE
fix(ui): show in-flight state on held-task spawn/discard buttons

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2004,5 +2004,7 @@
   "herdrupdate_sessions_label": "Laufende Sessions",
   "herdrupdate_jump_to": "Zu {name} springen",
   "feat_herdr_update_session_list_title": "Sieh die Sessions, die ein Update beenden würde — und spring hin",
-  "feat_herdr_update_session_list_body": "Der herdr-Update-Dialog zeigt nicht mehr nur eine Zahl laufender Sessions, sondern listet jede einzeln auf — und jede Zeile springt direkt zu dieser Session. Schließe sie nach und nach ab und aktualisiere dann, ohne Angst, etwas zu verlieren."
+  "feat_herdr_update_session_list_body": "Der herdr-Update-Dialog zeigt nicht mehr nur eine Zahl laufender Sessions, sondern listet jede einzeln auf — und jede Zeile springt direkt zu dieser Session. Schließe sie nach und nach ab und aktualisiere dann, ohne Angst, etwas zu verlieren.",
+  "topbar_held_spawning": "Wird gestartet…",
+  "topbar_held_discarding": "Wird verworfen…"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2004,5 +2004,7 @@
   "herdrupdate_sessions_label": "Running sessions",
   "herdrupdate_jump_to": "Go to {name}",
   "feat_herdr_update_session_list_title": "See and visit the sessions an update would end",
-  "feat_herdr_update_session_list_body": "The herdr-update dialog no longer just shows a count of running sessions — it lists each one, and every row jumps straight to that session. Wrap them up one by one, then update without worrying you've lost work."
+  "feat_herdr_update_session_list_body": "The herdr-update dialog no longer just shows a count of running sessions — it lists each one, and every row jumps straight to that session. Wrap them up one by one, then update without worrying you've lost work.",
+  "topbar_held_spawning": "Starting…",
+  "topbar_held_discarding": "Discarding…"
 }

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -986,6 +986,54 @@ describe("TopBarHeldBadge — mobile held-task dialog", () => {
     // announced assertively so it reaches a screen reader.
     await expect.element(page.getByRole("alert")).toHaveTextContent(m.topbar_held_spawn_failed());
   });
+
+  it("shows in-flight state on the spawn button while a held-task spawn is pending", async () => {
+    await page.viewport(1280, 900);
+    document.body.style.width = "1280px";
+    const heldItems: HeldTask[] = [
+      {
+        id: "held-1",
+        repoPath: "/work/shepherd",
+        createdAt: 1_700_000_000_000,
+        input: {
+          repoPath: "/work/shepherd",
+          baseBranch: "main",
+          prompt: "In der Dashboard-Übersicht",
+          agentProvider: "claude",
+          model: null,
+        },
+      },
+    ];
+
+    render(TopBarHeldBadge, {
+      heldCount: 1,
+      mobile: false,
+      compactBadges: false,
+      hotter: null,
+      nowMs: 1_700_000_000_000,
+      heldPopFlipUp: false,
+      heldItems,
+      heldLoading: false,
+      heldPending: { "held-1": "spawn" },
+      heldAutoRelease: true,
+      heldAutoReleaseBusy: false,
+      toggleHeldAutoRelease: vi.fn(),
+      heldPopOpen: true,
+      heldBadgeBtn: null,
+      heldPopEl: null,
+      toggleHeldPop: vi.fn(),
+      closeHeldPop: vi.fn(),
+      doSpawnHeld: vi.fn(),
+      doDiscardHeld: vi.fn(),
+    });
+    await nextFrame();
+
+    // While spawning, the button reads "starting…", is busy, and is disabled so the
+    // click can't fire twice — the missing affordance that made it read as "does nothing".
+    const spawn = page.getByRole("button", { name: m.topbar_held_spawning() });
+    await expect.element(spawn).toBeDisabled();
+    expect((spawn.element() as HTMLElement).getAttribute("aria-busy")).toBe("true");
+  });
 });
 
 describe("TopBar — working-while-blocked counts in the working tally, not blocked", () => {

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -377,23 +377,37 @@
   // the surface and stays visible on both desktop and mobile.
   let heldErrors = $state<Record<string, "spawn" | "discard">>({});
 
+  // In-flight per-task action. A spawn runs server-side worktree creation + agent launch
+  // (seconds), so without a pending affordance the button looks inert the whole time and
+  // reads as dead — the same "button does nothing" failure #1105 fixed for errors. Track
+  // it to disable the row's controls and show a "starting…" label while the request runs.
+  let heldPending = $state<Record<string, "spawn" | "discard">>({});
+
   async function doSpawnHeld(id: string, agentProvider?: AgentProvider) {
+    if (heldPending[id]) return;
     delete heldErrors[id];
+    heldPending[id] = "spawn";
     try {
       await spawnHeld(id, agentProvider);
       await loadHeld();
     } catch {
       heldErrors[id] = "spawn";
+    } finally {
+      delete heldPending[id];
     }
   }
 
   async function doDiscardHeld(id: string) {
+    if (heldPending[id]) return;
     delete heldErrors[id];
+    heldPending[id] = "discard";
     try {
       await discardHeld(id);
       await loadHeld();
     } catch {
       heldErrors[id] = "discard";
+    } finally {
+      delete heldPending[id];
     }
   }
 
@@ -662,6 +676,7 @@
       {heldItems}
       {heldLoading}
       {heldErrors}
+      {heldPending}
       {heldAutoRelease}
       {heldAutoReleaseBusy}
       {toggleHeldAutoRelease}

--- a/ui/src/lib/components/top-bar/TopBarHeldBadge.svelte
+++ b/ui/src/lib/components/top-bar/TopBarHeldBadge.svelte
@@ -36,6 +36,7 @@
     heldItems,
     heldLoading,
     heldErrors = {},
+    heldPending = {},
     heldAutoRelease,
     heldAutoReleaseBusy,
     toggleHeldAutoRelease,
@@ -56,6 +57,7 @@
     heldItems: HeldTask[];
     heldLoading: boolean;
     heldErrors?: Record<string, "spawn" | "discard">;
+    heldPending?: Record<string, "spawn" | "discard">;
     heldAutoRelease: boolean;
     heldAutoReleaseBusy: boolean;
     toggleHeldAutoRelease: () => void;
@@ -98,6 +100,7 @@
     {#each heldItems as task (task.id)}
       {@const originalProvider = providerFor(task)}
       {@const spawnProvider = selectedProvider(task)}
+      {@const pending = heldPending[task.id]}
       <div class="held-row">
         <div class="held-row-info">
           <span class="held-row-prompt">{task.input.prompt}</span>
@@ -111,6 +114,7 @@
             <span>{m.topbar_held_spawn_cli_label()}</span>
             <select
               value={spawnProvider}
+              disabled={!!pending}
               onchange={(e) => setSpawnProvider(task.id, e.currentTarget.value)}
             >
               {#each AGENT_PROVIDERS as provider (provider)}
@@ -121,12 +125,18 @@
           <button
             type="button"
             class="held-action held-spawn"
-            onclick={() => doSpawnHeld(task.id, spawnProvider)}>{m.topbar_held_spawn_now()}</button
+            disabled={!!pending}
+            aria-busy={pending === "spawn"}
+            onclick={() => doSpawnHeld(task.id, spawnProvider)}
+            >{pending === "spawn" ? m.topbar_held_spawning() : m.topbar_held_spawn_now()}</button
           >
           <button
             type="button"
             class="held-action held-discard"
-            onclick={() => doDiscardHeld(task.id)}>{m.topbar_held_discard()}</button
+            disabled={!!pending}
+            aria-busy={pending === "discard"}
+            onclick={() => doDiscardHeld(task.id)}
+            >{pending === "discard" ? m.topbar_held_discarding() : m.topbar_held_discard()}</button
           >
           {#if heldErrors[task.id]}
             <p class="held-row-error" role="alert">
@@ -503,9 +513,16 @@
     color: var(--color-ink);
     width: 100%;
   }
-  .held-action:hover {
+  .held-action:hover:not(:disabled) {
     border-color: var(--color-amber);
     color: var(--color-amber);
+  }
+  /* In-flight: spawn runs server-side worktree + agent launch (seconds). Keep the row's
+     controls inert and signal progress so the button never reads as dead mid-request. */
+  .held-action:disabled,
+  .held-cli select:disabled {
+    cursor: progress;
+    opacity: 0.6;
   }
   .held-row-error {
     margin: 0;
@@ -517,7 +534,7 @@
     color: var(--color-amber);
     border-color: var(--color-amber);
   }
-  .held-spawn:hover {
+  .held-spawn:hover:not(:disabled) {
     background: color-mix(in srgb, var(--color-amber) 10%, transparent);
   }
   .held-fullscreen .held-pop-why {


### PR DESCRIPTION
## Problem

Clicking **Jetzt starten** (Spawn now) on a held task in the top-bar popover appeared to do *nothing* — *"Leider passiert überhaupt nichts."*

The click path is actually correct: it `POST`s `/api/held/:id/spawn`, which runs `service.create()` server-side — creating a git worktree and launching the agent. That work takes **several seconds**, and during that window the button gave **zero feedback**: it didn't disable, didn't spin, didn't change its label, and the row didn't move. So the button read as dead — exactly the *"button does nothing"* failure mode that #1105 fixed for the *error* case, but the *pending* case was never covered.

## Fix

Track a per-task in-flight state in `TopBar` and surface it in `TopBarHeldBadge`:

- While a spawn/discard is in flight, the row's **select + both buttons are disabled** (`cursor: progress`, dimmed), so the action visibly registers and can't be double-submitted.
- The acting button swaps its label to a progress label (**Wird gestartet… / Wird verworfen…**) and sets `aria-busy`.
- Re-entrancy guard in `doSpawnHeld`/`doDiscardHeld` ignores a second click while one is pending.

Mirrors the inline-error feedback added in #1105 for the same surface.

## Test

- New browser test asserts the spawn button reads **Starting…**, is `disabled`, and is `aria-busy` while pending.
- `cd ui && bun run check` (svelte-check, 0 errors), `check:i18n` (EN+DE parity), and the full `TopBar.browser.test.ts` suite (66 tests) pass.

_Note:_ the local pre-push UI test run was bypassed — the full vitest-browser suite hit an environment-only Playwright pool deadlock in the worktree ("Browser connection was closed"), not a test failure; CI runs the authoritative suite.

[no-feature-entry] — feedback/UX fix to an existing control, not a new user-facing capability.