### PR TITLE
fix(ui): surface the real cause when a held task fails to start

### DIFF
--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -968,7 +968,7 @@ describe("TopBarHeldBadge — mobile held-task dialog", () => {
       heldPopFlipUp: false,
       heldItems,
       heldLoading: false,
-      heldErrors: { "held-1": "spawn" },
+      heldErrors: { "held-1": { kind: "spawn", detail: "task name already in use, retry" } },
       heldAutoRelease: true,
       heldAutoReleaseBusy: false,
       toggleHeldAutoRelease: vi.fn(),
@@ -985,6 +985,10 @@ describe("TopBarHeldBadge — mobile held-task dialog", () => {
     // The failure surfaces inline (a toast would render behind the fullscreen dialog),
     // announced assertively so it reaches a screen reader.
     await expect.element(page.getByRole("alert")).toHaveTextContent(m.topbar_held_spawn_failed());
+    // …and carries the server's real cause so the operator can see *why* it failed.
+    await expect
+      .element(page.getByRole("alert"))
+      .toHaveTextContent("task name already in use, retry");
   });
 
   it("shows in-flight state on the spawn button while a held-task spawn is pending", async () => {

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -375,7 +375,14 @@
   // toast won't do: the mobile popover is a fullscreen portal at the same z-index as
   // the toast stack, so a bottom toast renders behind it. Inline feedback lives inside
   // the surface and stays visible on both desktop and mobile.
-  let heldErrors = $state<Record<string, "spawn" | "discard">>({});
+  let heldErrors = $state<Record<string, { kind: "spawn" | "discard"; detail?: string }>>({});
+
+  // Carry the server's real `{error}` cause (agent-name-taken, worktree/create failure,
+  // sandbox refusal, …) so the popover can show *why* it failed, not just "try again".
+  function heldErrorDetail(e: unknown): string | undefined {
+    const msg = e instanceof Error ? e.message.trim() : "";
+    return msg ? msg : undefined;
+  }
 
   // In-flight per-task action. A spawn runs server-side worktree creation + agent launch
   // (seconds), so without a pending affordance the button looks inert the whole time and
@@ -390,8 +397,8 @@
     try {
       await spawnHeld(id, agentProvider);
       await loadHeld();
-    } catch {
-      heldErrors[id] = "spawn";
+    } catch (e) {
+      heldErrors[id] = { kind: "spawn", detail: heldErrorDetail(e) };
     } finally {
       delete heldPending[id];
     }
@@ -404,8 +411,8 @@
     try {
       await discardHeld(id);
       await loadHeld();
-    } catch {
-      heldErrors[id] = "discard";
+    } catch (e) {
+      heldErrors[id] = { kind: "discard", detail: heldErrorDetail(e) };
     } finally {
       delete heldPending[id];
     }

--- a/ui/src/lib/components/top-bar/TopBarHeldBadge.svelte
+++ b/ui/src/lib/components/top-bar/TopBarHeldBadge.svelte
@@ -56,7 +56,7 @@
     heldPopFlipUp: boolean;
     heldItems: HeldTask[];
     heldLoading: boolean;
-    heldErrors?: Record<string, "spawn" | "discard">;
+    heldErrors?: Record<string, { kind: "spawn" | "discard"; detail?: string }>;
     heldPending?: Record<string, "spawn" | "discard">;
     heldAutoRelease: boolean;
     heldAutoReleaseBusy: boolean;
@@ -139,10 +139,12 @@
             >{pending === "discard" ? m.topbar_held_discarding() : m.topbar_held_discard()}</button
           >
           {#if heldErrors[task.id]}
+            {@const err = heldErrors[task.id]}
             <p class="held-row-error" role="alert">
-              {heldErrors[task.id] === "spawn"
-                ? m.topbar_held_spawn_failed()
-                : m.topbar_held_discard_failed()}
+              {err.kind === "spawn" ? m.topbar_held_spawn_failed() : m.topbar_held_discard_failed()}
+              {#if err.detail}
+                <span class="held-row-error-detail">{err.detail}</span>
+              {/if}
             </p>
           {/if}
         </div>
@@ -529,6 +531,14 @@
     color: var(--color-red);
     font-size: var(--fs-micro);
     line-height: 1.35;
+  }
+  /* The server's verbatim cause (pass-through data, not app chrome → exempt from i18n).
+     Muted + word-broken so a long technical message wraps inside the narrow column. */
+  .held-row-error-detail {
+    display: block;
+    margin-top: 2px;
+    color: var(--color-muted);
+    overflow-wrap: anywhere;
   }
   .held-spawn {
     color: var(--color-amber);


### PR DESCRIPTION
## Problem

When a held task fails to start from the held-tasks popover ("Jetzt starten"), the UI only showed a generic, dead-end message:

> Aufgabe konnte nicht gestartet werden. Sie bleibt zurückgehalten – bitte erneut versuchen.

The operator had **no way to tell *why*** it failed — the screenshot that prompted this said exactly that: *"hier ist nicht zu erkennen warum das nicht funktioniert."* The server already returns the real cause in its `{error}` body (agent-name-taken, worktree/create failure, sandbox auto-refusal, …) and `spawnHeld`/`discardHeld` throw it as the error message — but `doSpawnHeld`/`doDiscardHeld` caught it and threw the message away.

## Fix

- `heldErrors` now carries `{ kind: "spawn" | "discard"; detail?: string }` instead of a bare kind string.
- `doSpawnHeld`/`doDiscardHeld` capture the caught error's `.message` as `detail`.
- The popover renders that real cause as a muted, word-broken line beneath the generic message. It's verbatim pass-through server data, so it's i18n-exempt (consistent with the existing rule for tool-use summaries / designations).

## Tests

- Extended the existing held-spawn-failure browser test to assert the server cause surfaces in the alert.
- `bun run check` clean; `TopBar.browser` suite green (65/65).

Note: the pre-push `root-tests`/`ui` lanes timed out (~882s) on the known Shepherd-worktree test-hang (zombie git / pool deadlock), not a real failure — lint/eslint/gates/tsc/ext all passed and the targeted UI suite is green. Full suite runs in CI.
