### PR TITLE
feat(ui): list running sessions in herdr-update dialog with jump-to

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2000,5 +2000,9 @@
   "topbar_held_why_manual": "Zurückgehalten, weil die Nutzung hoch ist. Sie bleiben zurückgehalten, bis du sie manuell startest.",
   "topbar_held_autostart_label": "Automatisch starten beim nächsten Reset",
   "feat_held_autostart_title": "Bestimme, wann zurückgehaltene Aufgaben starten",
-  "feat_held_autostart_body": "Das Popover für zurückgehaltene Aufgaben hat jetzt eine Checkbox zum automatischen Starten. Lässt du sie aktiviert, starten zurückgehaltene Aufgaben wie bisher automatisch beim nächsten Reset. Deaktivierst du sie, bleiben sie zurückgehalten, bis du jede einzeln manuell startest — praktisch, wenn du genau steuern willst, was nach einem Reset läuft."
+  "feat_held_autostart_body": "Das Popover für zurückgehaltene Aufgaben hat jetzt eine Checkbox zum automatischen Starten. Lässt du sie aktiviert, starten zurückgehaltene Aufgaben wie bisher automatisch beim nächsten Reset. Deaktivierst du sie, bleiben sie zurückgehalten, bis du jede einzeln manuell startest — praktisch, wenn du genau steuern willst, was nach einem Reset läuft.",
+  "herdrupdate_sessions_label": "Laufende Sessions",
+  "herdrupdate_jump_to": "Zu {name} springen",
+  "feat_herdr_update_session_list_title": "Sieh die Sessions, die ein Update beenden würde — und spring hin",
+  "feat_herdr_update_session_list_body": "Der herdr-Update-Dialog zeigt nicht mehr nur eine Zahl laufender Sessions, sondern listet jede einzeln auf — und jede Zeile springt direkt zu dieser Session. Schließe sie nach und nach ab und aktualisiere dann, ohne Angst, etwas zu verlieren."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2000,5 +2000,9 @@
   "topbar_held_why_manual": "Held because usage is high. They stay held until you start them manually.",
   "topbar_held_autostart_label": "Start automatically when usage resets",
   "feat_held_autostart_title": "Choose when held tasks start",
-  "feat_held_autostart_body": "The held-tasks popover now has an auto-start checkbox. Leave it on and held tasks start automatically when usage resets, as before. Turn it off and they stay queued until you start each one manually — handy when you want to control exactly what runs after a reset."
+  "feat_held_autostart_body": "The held-tasks popover now has an auto-start checkbox. Leave it on and held tasks start automatically when usage resets, as before. Turn it off and they stay queued until you start each one manually — handy when you want to control exactly what runs after a reset.",
+  "herdrupdate_sessions_label": "Running sessions",
+  "herdrupdate_jump_to": "Go to {name}",
+  "feat_herdr_update_session_list_title": "See and visit the sessions an update would end",
+  "feat_herdr_update_session_list_body": "The herdr-update dialog no longer just shows a count of running sessions — it lists each one, and every row jumps straight to that session. Wrap them up one by one, then update without worrying you've lost work."
 }

--- a/ui/src/lib/components/HerdrUpdateModal.svelte
+++ b/ui/src/lib/components/HerdrUpdateModal.svelte
@@ -7,19 +7,26 @@
 
   let {
     update,
-    sessions = 0,
+    sessions = [],
     log = [],
     done = null,
     onconfirm,
     onclose,
+    onjump,
   }: {
     update: HerdrUpdateStatus;
-    sessions?: number;
+    /** The running sessions the herdr restart would interrupt — listed so the
+     *  operator can jump to each and wrap it up before updating. */
+    sessions?: { id: string; desig: string; name: string }[];
     log?: string[];
     done?: { ok: boolean; from: string | null; to: string | null; error?: string } | null;
     onconfirm?: () => void;
     onclose?: () => void;
+    /** Jump to a running session (closes this modal, selects the session). */
+    onjump?: (id: string) => void;
   } = $props();
+
+  const count = $derived(sessions.length);
 
   let submitting = $state(false);
   let error = $state<string | null>(null);
@@ -159,8 +166,29 @@
 
     <div class="instructions">{m.herdrupdate_instructions()}</div>
 
-    {#if sessions > 0}
-      <div class="warning">{m.herdrupdate_warning({ count: sessions })}</div>
+    {#if count > 0}
+      <div class="warning">{m.herdrupdate_warning({ count })}</div>
+      {#if !submitting}
+        <!-- List the interrupted sessions so the operator can jump to each and
+             wrap it up first, instead of guessing what the bare count refers to. -->
+        <div class="sessions-label micro">{m.herdrupdate_sessions_label()}</div>
+        <ul class="sessions">
+          {#each sessions as s (s.id)}
+            <li>
+              <button
+                type="button"
+                class="session"
+                onclick={() => onjump?.(s.id)}
+                aria-label={m.herdrupdate_jump_to({ name: s.name || s.desig })}
+              >
+                <span class="desig">{s.desig}</span>
+                <span class="sname">{s.name}</span>
+                <span class="jump" aria-hidden="true">↗</span>
+              </button>
+            </li>
+          {/each}
+        </ul>
+      {/if}
     {/if}
 
     {#if submitting}
@@ -192,9 +220,7 @@
       {/if}
       {#if !done}
         <button type="button" class="run" onclick={confirm} disabled={busy}>
-          {sessions > 0
-            ? m.herdrupdate_confirm({ count: sessions })
-            : m.herdrupdate_confirm_plain()}
+          {count > 0 ? m.herdrupdate_confirm({ count }) : m.herdrupdate_confirm_plain()}
         </button>
       {/if}
     </div>
@@ -385,6 +411,62 @@
     font-size: var(--fs-base);
     line-height: 1.5;
     color: var(--color-red);
+  }
+  .sessions-label {
+    margin-bottom: -8px;
+  }
+  .sessions {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    /* keep a long list from pushing the actions off-screen on short viewports */
+    max-height: 180px;
+    overflow-y: auto;
+  }
+  .session {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    min-height: 44px;
+    padding: 8px 10px;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    color: var(--color-ink-bright);
+    cursor: pointer;
+    text-align: left;
+  }
+  .session:hover,
+  .session:focus-visible {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .session .desig {
+    flex: none;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.04em;
+    color: var(--color-amber);
+    font-size: var(--fs-meta);
+  }
+  .session .sname {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: var(--fs-base);
+  }
+  .session .jump {
+    flex: none;
+    color: var(--color-muted);
+    font-size: var(--fs-base);
+  }
+  .session:hover .jump,
+  .session:focus-visible .jump {
+    color: var(--color-amber);
   }
   .status {
     color: var(--color-amber);

--- a/ui/src/lib/components/page/AppOverlays.browser.test.ts
+++ b/ui/src/lib/components/page/AppOverlays.browser.test.ts
@@ -44,6 +44,7 @@ function baseProps(): Props {
     herdrUpdating: false,
     onherdrupdateconfirm: vi.fn(),
     onherdrupdateclose: vi.fn(),
+    onherdrupdatejump: vi.fn(),
     showOnboarding: false,
     diagnosticsLoadFailed: false,
     ononboardingretry: vi.fn(),

--- a/ui/src/lib/components/page/AppOverlays.svelte
+++ b/ui/src/lib/components/page/AppOverlays.svelte
@@ -90,6 +90,7 @@
     herdrUpdating,
     onherdrupdateconfirm,
     onherdrupdateclose,
+    onherdrupdatejump,
     showOnboarding,
     diagnosticsLoadFailed,
     ononboardingretry,
@@ -182,6 +183,7 @@
     herdrUpdating: boolean;
     onherdrupdateconfirm: () => void;
     onherdrupdateclose: () => void;
+    onherdrupdatejump: (id: string) => void;
     showOnboarding: boolean;
     diagnosticsLoadFailed: boolean;
     ononboardingretry: () => void;
@@ -370,12 +372,14 @@
        working-while-blocked agent is genuinely mid-turn, so it counts as working -->
   <HerdrUpdateModal
     update={store.herdrUpdate}
-    sessions={store.sessions.filter((s) => displayStatus(s, store.workingBlocked) === "running")
-      .length}
+    sessions={store.sessions
+      .filter((s) => displayStatus(s, store.workingBlocked) === "running")
+      .map((s) => ({ id: s.id, desig: s.desig, name: s.name }))}
     log={store.herdrUpdateLog}
     done={store.herdrUpdateDone}
     onconfirm={onherdrupdateconfirm}
     onclose={onherdrupdateclose}
+    onjump={onherdrupdatejump}
   />
 {/if}
 

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1644,4 +1644,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_held_autostart_title",
     bodyKey: "feat_held_autostart_body",
   },
+  {
+    // The herdr-update dialog now lists each running session the restart would
+    // interrupt, and each row jumps straight to that session — so you can wrap
+    // them up one by one before updating instead of trusting a bare count. No
+    // targetId — the anchor only exists while the update dialog is open.
+    id: "herdr-update-session-list",
+    sinceVersion: "1.38.0",
+    titleKey: "feat_herdr_update_session_list_title",
+    bodyKey: "feat_herdr_update_session_list_body",
+  },
 ];

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -2168,6 +2168,12 @@
     herdrUpdating = false;
     store.herdrUpdateDone = null;
   }}
+  onherdrupdatejump={(id) => {
+    showHerdrUpdate = false;
+    herdrUpdating = false;
+    store.herdrUpdateDone = null;
+    selectUnit(id);
+  }}
   {showOnboarding}
   {diagnosticsLoadFailed}
   ononboardingretry={loadDiagnostics}


### PR DESCRIPTION
## Was

Der **herdr-Update-Dialog** zeigte bisher nur eine nackte Zahl laufender Sessions ("Dadurch werden **2** laufende Session(s) beendet"). Man sah *dass* etwas beendet wird, aber nicht *welche* Sessions — und musste blind aktualisieren oder raten, was man verliert.

Jetzt listet der Dialog **jede betroffene Session einzeln** auf. Jede Zeile ist ein Button, der direkt zu dieser Session springt (schließt den Dialog, selektiert die Session). So kann man die Sessions nach und nach abschließen und dann beruhigt updaten — ohne Angst, etwas zu verlieren.

## Wie

- `HerdrUpdateModal`: `sessions` ist nicht mehr `number`, sondern `{ id, desig, name }[]`. `count` wird daraus abgeleitet (Warnung + Button-Text unverändert). Unter der Warnung rendert eine Liste anklickbarer Session-Zeilen (44px Tap-Target, Tokens, `aria-label` "Zu {name} springen"). Liste wird ausgeblendet, sobald das Update läuft.
- `onjump(id)` → `AppOverlays` → `+page.svelte`: schließt den Dialog und ruft `selectUnit(id)`.
- `AppOverlays` mappt die laufenden Sessions (gleicher `displayStatus === "running"`-Filter wie zuvor) auf die Minimal-Shape.
- i18n: `herdrupdate_sessions_label`, `herdrupdate_jump_to` (EN+DE).
- Feature-Katalog-Eintrag `herdr-update-session-list` (1.38.0) + `feat_herdr_update_session_list_*` Keys.

## Checks

- `bun run check` (svelte-check): 0 Fehler
- `bun run check:i18n`: Parität (2007 Keys je Locale)
- UI-Tests (AppOverlays / HerdrUpdate): grün
