### PR TITLE
fix(top-bar): equalize right-cluster box heights via shared token

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -108,6 +108,14 @@
   --icon-btn-hit: 28px; /* desktop square hit area for header icon buttons */
   --icon-btn-glyph: 18px; /* canonical inline-SVG glyph size */
 
+  /* Shared height for the top bar's right-cluster boxed controls (needsyou/held/
+     update/learnings badges, what's-new, docs link, gear) — single source so a
+     box's glyph or padding can't drift its height (the recurring "zoo of heights").
+     A fixed chrome height: NOT scaled by --ui-scale; consumers use it as a
+     min-height so content can still grow under iOS Dynamic Type. The coarse-pointer
+     /mobile 44px floors override it on touch. */
+  --topbar-ctl-h: 30px;
+
   --status-running: var(--color-amber);
   /* done = WAITING (finished turn, parked for the operator's next steer). It is
      NOT actionable-complete, so it must not read green/"ignore me" — it reads as

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -867,12 +867,19 @@
     color: var(--color-muted);
   }
   .needsyou {
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    /* shared bar control height; glyph/text centers, padding no longer drives height */
+    min-height: var(--topbar-ctl-h);
+    line-height: 1;
     background: color-mix(in srgb, var(--color-red) 18%, transparent);
     border: 1px solid var(--color-red);
     color: var(--color-red);
     letter-spacing: 0.14em;
     font-size: var(--fs-meta);
-    padding: 5px 10px;
+    padding: 0 10px;
     cursor: pointer;
     white-space: nowrap;
     flex-shrink: 0;
@@ -898,11 +905,14 @@
   /* Standalone docs link: a quiet icon button matching the gear's at-rest muted ink,
      going amber on hover/focus. Coarse-pointer 44px floor handled in the shared block. */
   .docs-link {
+    box-sizing: border-box;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    min-height: var(--topbar-ctl-h);
+    line-height: 1;
     color: var(--color-muted);
-    padding: 5px 8px;
+    padding: 0 8px;
     flex-shrink: 0;
   }
   .docs-link:hover,
@@ -985,7 +995,7 @@
      so .hud.mobile .gauge-btn can never match — verified dead (#855). */
   .hud.mobile .needsyou {
     min-height: 44px;
-    padding: 8px 12px;
+    padding: 0 12px;
   }
   /* Phone: collapse the badge to an icon+count chip so the NEEDS YOU call-out
      fits on line 1 next to the gauge/gear instead of forcing the right-side
@@ -996,7 +1006,7 @@
     justify-content: center;
     gap: 4px;
     min-width: 44px;
-    padding: 8px 10px;
+    padding: 0 10px;
     letter-spacing: 0;
     font-variant-numeric: tabular-nums;
     /* pin the line box to 1×font-size so the compact badge height is

--- a/ui/src/lib/components/top-bar/TopBarBadges.svelte
+++ b/ui/src/lib/components/top-bar/TopBarBadges.svelte
@@ -166,10 +166,15 @@
 
 <style>
   .update-badge {
+    box-sizing: border-box;
     display: flex;
     align-items: center;
+    justify-content: center;
+    /* shared bar control height; glyph centers, padding no longer drives height */
+    min-height: var(--topbar-ctl-h);
+    line-height: 1;
     gap: 6px;
-    padding: 5px 11px;
+    padding: 0 11px;
     background: color-mix(in srgb, var(--color-amber) 14%, transparent);
     border: 1px solid var(--color-amber);
     color: var(--color-amber);
@@ -212,10 +217,14 @@
   /* What's New affordance — blue informational accent (shared with the herdr cue),
      distinct from amber (app-update). */
   .whatsnew-badge {
+    box-sizing: border-box;
     display: flex;
     align-items: center;
+    justify-content: center;
+    min-height: var(--topbar-ctl-h);
+    line-height: 1;
     gap: 6px;
-    padding: 5px 11px;
+    padding: 0 11px;
     background: color-mix(in srgb, var(--color-blue) 14%, transparent);
     border: 1px solid var(--color-blue);
     color: var(--color-blue);
@@ -232,19 +241,22 @@
   .whatsnew-badge .wn-dot {
     font-size: var(--fs-micro);
   }
-  /* Phone-only: bare pip button, no label. */
+  /* Compact-only: bare pip button, no label (desktop measured-overflow + phone). */
   .whatsnew-dot-btn {
+    box-sizing: border-box;
     position: relative;
     background: transparent;
     border: 1px solid var(--color-line-bright);
     color: var(--color-muted);
     font-size: var(--fs-lg);
     line-height: 1;
-    padding: 5px 8px;
+    padding: 0 8px;
     border-radius: 2px;
     cursor: pointer;
-    min-height: 44px;
-    min-width: 44px;
+    /* token height on fine-pointer desktop; the 44px touch floor is coarse-gated
+       below so it no longer makes this a desktop outlier among the bar's boxes */
+    min-height: var(--topbar-ctl-h);
+    min-width: var(--topbar-ctl-h);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -290,8 +302,12 @@
     background: var(--color-red);
   }
   .learnings-btn {
+    box-sizing: border-box;
     display: inline-flex;
     align-items: center;
+    justify-content: center;
+    min-height: var(--topbar-ctl-h);
+    line-height: 1;
     gap: 6px;
     background: transparent;
     border: 1px solid var(--color-line-bright);
@@ -300,7 +316,7 @@
     text-transform: uppercase;
     font: inherit;
     font-size: var(--fs-meta);
-    padding: 5px 10px;
+    padding: 0 10px;
     border-radius: 2px;
     cursor: pointer;
     white-space: nowrap;
@@ -322,7 +338,7 @@
   .learnings-btn.compact {
     justify-content: center;
     min-width: 44px;
-    padding: 8px 10px;
+    padding: 0 10px;
     letter-spacing: 0;
   }
   .learn-n {
@@ -330,9 +346,13 @@
     font-weight: 700;
   }
 
-  /* Coarse pointers (touch, any layout width): secondary icon buttons need ≥44px hit area. */
+  /* Coarse pointers (touch, any layout width): secondary icon buttons need ≥44px hit area.
+     The 44px floor lives here (not unconditionally) so on a fine-pointer desktop these
+     boxes drop to --topbar-ctl-h and stay equal-height with their siblings. */
   @media (pointer: coarse) {
     .update-badge,
+    .whatsnew-badge,
+    .whatsnew-dot-btn,
     .learnings-btn {
       min-height: 44px;
       min-width: 44px;

--- a/ui/src/lib/components/top-bar/TopBarGear.svelte
+++ b/ui/src/lib/components/top-bar/TopBarGear.svelte
@@ -236,13 +236,20 @@
     background: var(--color-line);
   }
   .gear {
+    box-sizing: border-box;
     position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    /* shared bar control height — its 20px glyph defined the token, so it's unchanged;
+       border-box keeps this borderless button level with the 1px-bordered badges */
+    min-height: var(--topbar-ctl-h);
     background: transparent;
     border: none;
     color: var(--color-muted);
     font-size: var(--fs-xl);
     line-height: 1;
-    padding: 5px 8px;
+    padding: 0 8px;
     cursor: pointer;
   }
   .gear:hover {
@@ -294,7 +301,7 @@
   .gear.mobile {
     min-height: 44px;
     min-width: 44px;
-    padding: 5px 11px;
+    padding: 0 11px;
     font-size: var(--fs-xl);
   }
 

--- a/ui/src/lib/components/top-bar/TopBarHeldBadge.svelte
+++ b/ui/src/lib/components/top-bar/TopBarHeldBadge.svelte
@@ -242,8 +242,14 @@
     position: relative;
   }
   .held-badge {
+    box-sizing: border-box;
     display: inline-flex;
     align-items: center;
+    justify-content: center;
+    /* shared bar control height; the hourglass glyph (#1122) centers instead of
+       stretching the box, so it stays equal-height with its siblings */
+    min-height: var(--topbar-ctl-h);
+    line-height: 1;
     gap: 5px;
     background: transparent;
     border: 1px solid var(--color-amber);
@@ -252,7 +258,7 @@
     font: inherit;
     font-size: var(--fs-meta);
     letter-spacing: 0.06em;
-    padding: 3px 8px;
+    padding: 0 8px;
     cursor: pointer;
     white-space: nowrap;
   }
@@ -267,9 +273,9 @@
     justify-content: center;
     min-width: 44px;
     letter-spacing: 0;
-    /* mirror .needsyou.compact padding so both compact badges share the same box
-       height when neither carries a min-height floor (fine-pointer desktop overflow) */
-    padding: 8px 10px;
+    /* horizontal-only: box height comes from the shared --topbar-ctl-h min-height on
+       the base rule, so this matches .needsyou.compact without padding tuning */
+    padding: 0 10px;
     /* pin the line box to 1×font-size so height is font-independent: `.needsyou`
        renders in the UA button font while this badge uses `font: inherit` (mono),
        and their `normal` line-heights differ by ~2px. `.needsyou.compact` carries


### PR DESCRIPTION
## What

The top bar's right-side cluster had a "zoo of heights": each boxed control derived its height from its own ad-hoc vertical `padding` **plus** whatever glyph it carried, so they fanned out (~25–34px). `✦ 314` was tallest (16px ✦ + 8px compact padding); `▲ 6` shortest. Prior fixes were pairwise patches — #1115 equalized only NEEDS YOU + held (compact); #1122 then re-broke held by adding the hourglass glyph.

This replaces the whack-a-mole with **one shared control-height token** every boxed control derives from, so a box's glyph or padding can no longer drift its height.

## How

- **New token** `--topbar-ctl-h: 30px` in `app.css` `:root`, in the fixed-chrome-heights group beside `--icon-btn-hit` / `--mobile-actionbar-hit`. 30px = the gear's current box height (its 20px glyph is the tallest mandatory content), so the dominant element is unchanged and the others meet it.
- Every **boxed** control gets `box-sizing:border-box; min-height:var(--topbar-ctl-h); line-height:1` + flex centering, with **vertical padding removed** on base *and* compact/mobile rules: `.needsyou`, `.held-badge`, `.update-badge`(+`.herdr`), `.whatsnew-badge`, `.whatsnew-dot-btn`, `.learnings-btn`, `.docs-link`, `.gear`.
- `min-height` (not `height`) so content can still grow under iOS Dynamic Type (`--ui-scale` up to 1.5); identical to `height` at desktop scale.
- `box-sizing:border-box` is added explicitly to every touched rule so the borderless gear/docs land on the *same* 30px as the 1px-bordered badges.
- `.whatsnew-dot-btn`'s **unconditional** `min-height/min-width:44px` is moved into `@media (pointer:coarse)` so it drops to the token height on fine-pointer desktop instead of being a 44px outlier; the coarse/mobile 44px floors elsewhere are preserved (they override the smaller token).

### Deliberate scoping (flagged per house rules)
- **`.health-pip`** (round 22px circle) is **not** box-sized — forcing `min-height:30px` with `width:22px` would ovalize it. It stays a centered 22px dot.
- **Gauges / clock** (`5 H`, `WK`, `%`, `●`) are non-boxed inline content, left centered.
- **Left-side tallies** are deferred to a tracked follow-up (#1131) — they're deliberately tighter chips and a separate visual decision.

## Verification
- `cd ui && bun run check` → 0 errors; prettier clean.
- Measured the final CSS (real glyphs, both full-label and compact states) in a headless Chromium: **all boxes render exactly 30px** (`distinctHeights: [30]`, `allEqual: true`).

Closes the "still a zoo of heights in the top bar" report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)