### PR TITLE
fix(ui): keep running-sessions list visible in herdr-update dialog

### DIFF
--- a/ui/src/lib/components/HerdrUpdateModal.svelte
+++ b/ui/src/lib/components/HerdrUpdateModal.svelte
@@ -245,6 +245,11 @@
     display: flex;
     flex-direction: column;
     gap: 14px;
+    /* Last-resort scroll when even the shrinkable notes box can't free enough
+       space — e.g. no release notes at all (nothing shrinkable) plus a full
+       180px sessions list on a short viewport — so the action buttons are never
+       clipped below the 80dvh cap. (Mobile re-sets this in the media query.) */
+    overflow-y: auto;
     background: var(--color-panel);
     border: 1px solid var(--color-line-bright);
     padding: 18px 18px 16px;

--- a/ui/src/lib/components/HerdrUpdateModal.svelte
+++ b/ui/src/lib/components/HerdrUpdateModal.svelte
@@ -425,6 +425,14 @@
     /* keep a long list from pushing the actions off-screen on short viewports */
     max-height: 180px;
     overflow-y: auto;
+    /* Don't let the flex column collapse this list away. The card is capped at
+       80dvh and both this list and the release-notes box are scroll containers
+       (automatic min-size 0), so when long notes overflow the cap flexbox is
+       free to shrink BOTH to a sliver — which hid the running-sessions list
+       entirely. The notes box is the intended shrinkable one (min-height: 0);
+       the sessions list is this dialog's whole point, so pin it and let the
+       notes absorb the shrinkage instead. */
+    flex-shrink: 0;
   }
   .session {
     width: 100%;


### PR DESCRIPTION
## Problem

The herdr-update dialog lists the running sessions that the herdr restart would interrupt (#1130), so the operator can jump to each and wrap it up before updating. But that list — the whole point of the lower section — **renders invisibly** when the release notes are long.

Reported (DE): *"Leider lässt sich der untere Teil – die Sessions die ein Update verhindern – nicht anzeigen."*

## Cause

The modal `.card` is a flex column capped at `max-height: 80dvh`. Both the release-notes box and the running-sessions `<ul>` are scroll containers (`overflow-y: auto`), which gives them an **automatic minimum size of 0**. When long release notes push the content past the 80dvh cap, flexbox is free to shrink **both** scroll containers — and it collapses the sessions list down to a sliver, leaving just the label + an empty box (exactly what the screenshots show).

The data was always there (the "beendet 1 Session(s)" count proves `sessions.length === 1`); it was purely a layout collapse.

## Fix

One line of CSS: pin the sessions list with `flex-shrink: 0`. The release-notes box is explicitly the intended shrinkable element (it already carries `min-height: 0` and scrolls internally), so it now absorbs the shrinkage while the sessions list keeps its natural height (still capped at its own `max-height: 180px` with internal scroll for very long lists).

## Verification

- `cd ui && bun run check` → 0 errors / 0 warnings
- No new strings, no `feat` → i18n / feature-catalog gates N/A

[no-feature-entry]