### PR TITLE
fix(uploads): copy staged images into worktree so held-task spawns survive retries

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -17,7 +17,7 @@ import type {
   Session,
 } from "./types";
 import {
-  moveStagedIntoWorktree,
+  copyStagedIntoWorktree,
   stagingDir,
   sweepStaging,
   STAGING_TTL_MS,
@@ -108,8 +108,8 @@ export interface ServiceDeps {
   refineName?: (args: { taskText: string; label: string }) => Promise<string | null>;
   /** Event bus for live state pushes (e.g. session:ready); absent in tests that skip it. */
   events?: Pick<EventHub, "emit">;
-  /** Inject point for tests; defaults to the real fs move. */
-  moveUploads?: (images: string[], worktreePath: string) => string[];
+  /** Inject point for tests; defaults to the real fs copy (copyStagedIntoWorktree). */
+  copyUploads?: (images: string[], worktreePath: string) => string[];
   /** Detects/terminates leftover subprocesses at close; absent in tests that skip it. */
   reaper?: Pick<ProcessReaper, "detect" | "reap" | "stopListenersOnPort">;
   /** Live preview service; provides devPortFor for stopPreview. Absent → stopPreview returns not_found. */
@@ -1049,13 +1049,30 @@ export class SessionService {
    * against the 8000-char human-prompt guard (the same approach for each). The comment
    * thread is the human discussion that refined the original request; fetching it is
    * best-effort (see fetchIssueCommentsBlock) so a spawn never fails on comments.
+   *
+   * Returns the prompt plus `dropped`: the count of attached images whose staged source
+   * was gone (e.g. swept after 24h) so copyStagedIntoWorktree skipped it. The spawn still
+   * proceeds without them; the caller emits an operator-visible signal for the drop.
    */
-  private async composePromptArg(input: CreateSessionInput, worktreePath: string): Promise<string> {
+  private async composePromptArg(
+    input: CreateSessionInput,
+    worktreePath: string,
+  ): Promise<{ promptArg: string; dropped: number }> {
     let promptArg = input.prompt;
+    let dropped = 0;
     if (input.images.length > 0) {
-      const move = this.deps.moveUploads ?? moveStagedIntoWorktree;
-      const moved = move(input.images, worktreePath);
-      promptArg = `${promptArg}\n\nAttached images:\n${moved.join("\n")}`;
+      const copy = this.deps.copyUploads ?? copyStagedIntoWorktree;
+      const copied = copy(input.images, worktreePath);
+      if (copied.length > 0) promptArg = `${promptArg}\n\nAttached images:\n${copied.join("\n")}`;
+      dropped = input.images.length - copied.length;
+      if (dropped > 0) {
+        // A staged upload vanished before spawn (swept after STAGING_TTL_MS, or otherwise
+        // lost). Note it in-prompt so the agent knows an attachment is missing, and warn.
+        promptArg = `${promptArg}\n\n[Note: ${dropped} attached image(s) could not be restored — the upload expired and is unavailable for this session.]`;
+        console.warn(
+          `[uploads] ${dropped}/${input.images.length} staged image(s) missing at spawn; proceeding without them`,
+        );
+      }
     }
     if (input.issueRef) {
       const r = input.issueRef;
@@ -1063,7 +1080,7 @@ export class SessionService {
       const comments = await this.fetchIssueCommentsBlock(input.repoPath, r.number);
       if (comments) promptArg = `${promptArg}\n\n${comments}`;
     }
-    return promptArg;
+    return { promptArg, dropped };
   }
 
   /** Best-effort fetch + compose of an attached issue's comment thread. Any missing forge,
@@ -1684,7 +1701,10 @@ export class SessionService {
       // before the store row exists — the store.create() call below receives this id explicitly.
       const sessionId = randomUUID();
 
-      const promptArg = await this.composePromptArg(input, wt.worktreePath);
+      const { promptArg, dropped: droppedImages } = await this.composePromptArg(
+        input,
+        wt.worktreePath,
+      );
       const repoConfig = this.deps.store.getRepoConfig(input.repoPath);
       const agentProvider = input.agentProvider ?? config.defaultAgentProvider;
       // Plan gate (#348): when on, spawn into a PLANNING phase with a grill directive that
@@ -1756,6 +1776,12 @@ export class SessionService {
       // after authoring the queue without waiting for a human gate that will never come.
       if (shouldPreApproveBuildQueue(repoConfig, session, input.research))
         this.deps.store.setBuildQueueApproved(sessionId, true, "auto");
+      // An attached image was lost before spawn (staged upload swept after 24h). The session
+      // started without it; surface that to the operator as a toast — they can relaunch with
+      // the image re-attached if it was essential. Emitted after the store row exists so the
+      // UI can map the toast to the session.
+      if (droppedImages > 0)
+        this.deps.events?.emit("session:uploads-dropped", { id: sessionId, count: droppedImages });
       this.scheduleRefine(session, herdSlug);
       this.#maybeRegisterTrain(session, input);
       return session;

--- a/src/uploads.ts
+++ b/src/uploads.ts
@@ -1,13 +1,5 @@
 import { randomUUID } from "node:crypto";
-import {
-  mkdirSync,
-  renameSync,
-  copyFileSync,
-  rmSync,
-  readdirSync,
-  statSync,
-  existsSync,
-} from "node:fs";
+import { mkdirSync, copyFileSync, rmSync, readdirSync, statSync, existsSync } from "node:fs";
 import { join, basename } from "node:path";
 import type { SessionStore } from "./store";
 
@@ -44,23 +36,26 @@ export function uploadFilename(ext: string): string {
 }
 
 /**
- * Move each staged file into the worktree's uploads dir; return new absolute
- * paths (basename preserved). Falls back to copy+unlink across devices.
+ * Copy each staged file into the worktree's uploads dir; return new absolute paths
+ * (basename preserved) for the files that actually existed. COPY-not-move keeps the
+ * staged original recoverable: a spawn that fails after this runs (or a "Jetzt starten"
+ * retry of a held task) finds the source still present, so the move is idempotent — the
+ * old renameSync made a failed first spawn permanently un-retryable (ENOENT). The
+ * sweepStaging TTL reclaims the leftover staged copies. A source that is genuinely gone
+ * (e.g. already swept after 24h) is skipped, not thrown on, so the spawn proceeds without
+ * it; the caller surfaces the drop.
  */
-export function moveStagedIntoWorktree(images: string[], worktreePath: string): string[] {
+export function copyStagedIntoWorktree(images: string[], worktreePath: string): string[] {
   const dir = worktreeUploadsDir(worktreePath);
   mkdirSync(dir, { recursive: true });
-  return images.map((src) => {
+  const copied: string[] = [];
+  for (const src of images) {
+    if (!existsSync(src)) continue; // source swept/lost — skip, caller reports the drop
     const dest = join(dir, basename(src));
-    try {
-      renameSync(src, dest);
-    } catch (e) {
-      if ((e as NodeJS.ErrnoException).code !== "EXDEV") throw e;
-      copyFileSync(src, dest);
-      rmSync(src, { force: true });
-    }
-    return dest;
-  });
+    copyFileSync(src, dest);
+    copied.push(dest);
+  }
+  return copied;
 }
 
 /** Best-effort: delete staged files older than maxAgeMs. No-op if dir absent. */

--- a/src/uploads.ts
+++ b/src/uploads.ts
@@ -39,7 +39,7 @@ export function uploadFilename(ext: string): string {
  * Copy each staged file into the worktree's uploads dir; return new absolute paths
  * (basename preserved) for the files that actually existed. COPY-not-move keeps the
  * staged original recoverable: a spawn that fails after this runs (or a "Jetzt starten"
- * retry of a held task) finds the source still present, so the move is idempotent — the
+ * retry of a held task) finds the source still present, so this copy is repeatable — the
  * old renameSync made a failed first spawn permanently un-retryable (ENOENT). The
  * sweepStaging TTL reclaims the leftover staged copies. A source that is genuinely gone
  * (e.g. already swept after 24h) is skipped, not thrown on, so the spawn proceeds without

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -878,7 +878,7 @@ test("createSession: passes --model and persists it when a model is chosen", asy
   expect(store.get(s.id)?.model).toBe("opus");
 });
 
-test("createSession: moves images into worktree and appends paths to the prompt", async () => {
+test("createSession: copies images into worktree and appends paths to the prompt", async () => {
   const store = new SessionStore(":memory:");
   const calls: any = {};
   const service = new SessionService({
@@ -905,7 +905,7 @@ test("createSession: moves images into worktree and appends paths to the prompt"
       },
       list: () => [],
     } as any,
-    moveUploads: (images: string[], worktreePath: string) =>
+    copyUploads: (images: string[], worktreePath: string) =>
       images.map((i) => `${worktreePath}/.shepherd-uploads/${i.split("/").pop()}`),
   });
 
@@ -917,12 +917,67 @@ test("createSession: moves images into worktree and appends paths to the prompt"
     images: ["/stage/a.png", "/stage/b.png"],
   });
 
-  // prompt argv (last element) carries the user text + the moved image paths
+  // prompt argv (last element) carries the user text + the copied image paths
   expect(calls.argv[calls.argv.length - 1]).toBe(
     "look at this\n\nAttached images:\n/wt/repo-x/.shepherd-uploads/a.png\n/wt/repo-x/.shepherd-uploads/b.png",
   );
   // stored prompt stays the clean user text
   expect(store.get(s.id)?.prompt).toBe("look at this");
+});
+
+test("createSession: a dropped (swept) image still spawns, notes the loss, emits a toast event", async () => {
+  const store = new SessionStore(":memory:");
+  const calls: any = {};
+  const events: { event: string; data: any }[] = [];
+  const service = new SessionService({
+    store,
+    namer: async () => "repo-x",
+    worktree: {
+      ensureBaseRef: async () => {},
+      branchExists: () => false,
+      create: () => ({ worktreePath: "/wt/repo-x", branch: "shepherd/repo-x", isolated: true }),
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: (_n: string, _c: string, argv: string[]) => {
+        calls.argv = argv;
+        return {
+          terminalId: "term_y",
+          cwd: "/wt/repo-x",
+          agent: "claude",
+          agentStatus: "working",
+          paneId: "p",
+          tabId: "t",
+          workspaceId: "w",
+        };
+      },
+      list: () => [],
+    } as any,
+    events: { emit: (event: string, data: unknown) => events.push({ event, data }) },
+    // One of two staged images is gone — the copy seam returns only the survivor.
+    copyUploads: (images: string[], worktreePath: string) =>
+      images
+        .filter((i) => !i.includes("gone"))
+        .map((i) => `${worktreePath}/.shepherd-uploads/${i.split("/").pop()}`),
+  });
+
+  const s = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "look at this",
+    model: null,
+    images: ["/stage/gone.png", "/stage/kept.png"],
+  });
+
+  const prompt = calls.argv[calls.argv.length - 1] as string;
+  // The surviving image is still attached, and the loss is noted in-prompt.
+  expect(prompt).toContain("Attached images:\n/wt/repo-x/.shepherd-uploads/kept.png");
+  expect(prompt).toContain("1 attached image(s) could not be restored");
+  // Operator-visible signal emitted against the new session id.
+  expect(events).toContainEqual({
+    event: "session:uploads-dropped",
+    data: { id: s.id, count: 1 },
+  });
 });
 
 test("createSession: no images leaves the prompt argv unchanged", async () => {
@@ -4108,7 +4163,7 @@ function relaunchHarness(store: SessionStore) {
       list: () => [],
       stop: (id: string) => calls.stopped.push(id),
     } as any,
-    moveUploads: (images: string[], worktreePath: string) =>
+    copyUploads: (images: string[], worktreePath: string) =>
       images.map((i) => `${worktreePath}/.shepherd-uploads/${i.split("/").pop()}`),
   });
   return { service, calls, breakOverride };
@@ -4204,7 +4259,7 @@ test("relaunch carries images over (staged copies created, originals untouched)"
     expect(staged).toHaveLength(2);
     expect(staged.filter((f) => f.endsWith(".png"))).toHaveLength(1);
     expect(staged.filter((f) => f.endsWith(".jpg"))).toHaveLength(1);
-    // both images flowed into the spawn argv (via moveUploads mock)
+    // both images flowed into the spawn argv (via copyUploads mock)
     const argv = calls.started[0]!.argv;
     expect(argv[argv.length - 1]).toContain("Attached images:");
   } finally {

--- a/test/uploads.test.ts
+++ b/test/uploads.test.ts
@@ -15,7 +15,7 @@ import {
   MAX_UPLOAD_BYTES,
   stagingDir,
   worktreeUploadsDir,
-  moveStagedIntoWorktree,
+  copyStagedIntoWorktree,
   sweepStaging,
   uploadFilename,
   handleUpload,
@@ -47,7 +47,7 @@ beforeEach(() => {
 });
 afterEach(() => rmSync(root, { recursive: true, force: true }));
 
-test("moveStagedIntoWorktree moves files in and returns new absolute paths", () => {
+test("copyStagedIntoWorktree copies files in, keeping the staged source recoverable", () => {
   const staging = stagingDir(root);
   mkdirSync(staging, { recursive: true });
   const a = join(staging, "a.png");
@@ -57,16 +57,33 @@ test("moveStagedIntoWorktree moves files in and returns new absolute paths", () 
   const wt = join(root, "wt");
   mkdirSync(wt);
 
-  const moved = moveStagedIntoWorktree([a, b], wt);
+  const copied = copyStagedIntoWorktree([a, b], wt);
 
-  expect(moved).toEqual([
+  expect(copied).toEqual([
     join(worktreeUploadsDir(wt), "a.png"),
     join(worktreeUploadsDir(wt), "b.jpg"),
   ]);
-  expect(existsSync(a)).toBe(false); // moved, not copied
-  expect(existsSync(b)).toBe(false);
-  expect(readFileSync(moved[0]!, "utf8")).toBe("AAA");
-  expect(readFileSync(moved[1]!, "utf8")).toBe("BBB");
+  expect(existsSync(a)).toBe(true); // copied, not moved — survives a failed/retried spawn
+  expect(existsSync(b)).toBe(true);
+  expect(readFileSync(copied[0]!, "utf8")).toBe("AAA");
+  expect(readFileSync(copied[1]!, "utf8")).toBe("BBB");
+});
+
+test("copyStagedIntoWorktree skips a missing source and copies the rest", () => {
+  const staging = stagingDir(root);
+  mkdirSync(staging, { recursive: true });
+  const present = join(staging, "present.png");
+  const gone = join(staging, "gone.png"); // never created — simulates a swept upload
+  writeFileSync(present, "OK");
+  const wt = join(root, "wt");
+  mkdirSync(wt);
+
+  const copied = copyStagedIntoWorktree([gone, present], wt);
+
+  // The missing source is skipped (not thrown on); only the present one is copied through.
+  expect(copied).toEqual([join(worktreeUploadsDir(wt), "present.png")]);
+  expect(existsSync(join(worktreeUploadsDir(wt), "gone.png"))).toBe(false);
+  expect(readFileSync(copied[0]!, "utf8")).toBe("OK");
 });
 
 test("sweepStaging deletes files older than maxAge, keeps fresh ones", () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1158,6 +1158,7 @@
   "session_sandbox_egress_degraded_label": "Netzwerk offen",
   "session_sandbox_egress_degraded_title": "Autonome Dateisystem-Sandbox aktiv, aber das Netzwerk-Egress-Backend ist nicht verfügbar, daher ist ausgehender Verkehr uneingeschränkt — Tokens sind exfiltrierbar. Diese Sitzung nicht überschätzen.",
   "toast_egress_drop": "Egress zu {host} blockiert",
+  "toast_uploads_dropped": "{count} angehängte(s) Bild(er) abgelaufen und nicht wiederherstellbar — die Session startete ohne sie",
   "feat_egress_title": "Netzwerk-Egress-Allowlist",
   "feat_egress_body": "Autonome Agenten sind jetzt auf eine Allowlist von Hosts beschränkt (Anthropic + den Forge-Host, plus operator-Extras); alle anderen ausgehenden Verbindungen werden blockiert. Blockierte Versuche erscheinen als Inline-Warnungen. Wenn das Backend nicht verfügbar ist, erscheint ein sichtbares Warn-Badge, damit klar ist, dass die Sitzung mit uneingeschränktem Netzwerk läuft.",
   "settings_contrast_title": "Hoher Kontrast",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1158,6 +1158,7 @@
   "session_sandbox_egress_degraded_label": "Network open",
   "session_sandbox_egress_degraded_title": "Autonomous filesystem sandbox active, but the network-egress backend is unavailable, so outbound is unrestricted — tokens are exfiltratable. Don't over-trust this run.",
   "toast_egress_drop": "Blocked egress to {host}",
+  "toast_uploads_dropped": "{count} attached image(s) expired and could not be restored — the session started without them",
   "feat_egress_title": "Network egress allowlist",
   "feat_egress_body": "Autonomous agents are now confined to an allowlist of hosts (Anthropic + the forge, plus operator extras); all other outbound connections are blocked. Blocked attempts surface as inline alerts. When the backend is unavailable, a visible warning badge appears so you know the session is running with unrestricted network.",
   "settings_contrast_title": "High contrast",

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -341,6 +341,12 @@ export class HerdStore {
           alert: true,
         });
         break;
+      case "session:uploads-dropped":
+        toasts.info(m.toast_uploads_dropped({ count: ev.data.count }), {
+          key: "uploads-dropped-" + ev.data.id,
+          alert: true,
+        });
+        break;
       default:
         // Simple data-update, review/plan-gate, and app-global events are handled
         // out of line to keep this dispatch switch under the complexity gate.

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1153,6 +1153,7 @@ export type WsEvent =
   | { event: "epic:completed"; data: CompletedEpic }
   | { event: "epic:completed-cleared"; data: { repoPath: string; parentIssueNumber: number } }
   | { event: "session:egress-drop"; data: { id: string; host: string } }
+  | { event: "session:uploads-dropped"; data: { id: string; count: number } }
   | { event: "held:changed"; data: { count: number } }
   | { event: "post-merge-steps:changed"; data: Record<string, never> }
   | {


### PR DESCRIPTION
## Problem

Held tasks with an attached **screenshot** could fail to start with `ENOENT: no such file or directory, rename '…/.shepherd-uploads-staging/…png' → '…/.shepherd-uploads/…png'` — and then stay permanently wedged at the head of the held queue (re-blocking every retry).

Root cause: attached images stage in `.shepherd-uploads-staging/` and were **moved** (`renameSync`) into the worktree at spawn time (`moveStagedIntoWorktree`, `src/uploads.ts`). The move is destructive and non-idempotent:

1. **Failed first spawn** — if `service.create` failed *after* the move, the task stayed held (head-of-line, `held-release.ts`) but the staged source was already gone. Every "Jetzt starten" retry pointed at the now-empty staging path → `ENOENT`.
2. **24h sweep** — `sweepStaging` (`STAGING_TTL_MS = 24h`) deletes long-staged files → same `ENOENT`.

Tasks without an image retry cleanly — images are the only spawn input with a consumable, destructive staging step. Hence "specifically screenshots".

## Fix

- **Copy-not-move** (`moveStagedIntoWorktree` → `copyStagedIntoWorktree`): `copyFileSync` instead of `renameSync`. The staged original stays recoverable, so a failed first spawn and any retry both succeed; `sweepStaging` reclaims the leftover copy after 24h. This mirrors the existing `copyOriginalUploads` rationale already in the relaunch path (_"keeps the original recoverable on a spawn failure"_).
- **Skip a genuinely-gone source** instead of throwing — the spawn proceeds without it.
- **Operator-visible signal** for the (now rare, >24h-sweep-only) drop: a note in the session prompt, a `console.warn`, and a toast via a new `session:uploads-dropped` WS event — mirrored exactly on the existing `session:egress-drop` plumbing. The operator can relaunch with the image re-attached if it was essential.

## Tests

- `test/uploads.test.ts`: copy keeps the staged source (`existsSync` flips `false`→`true`); new test for skip-missing-source.
- `test/service.test.ts`: seam `moveUploads`→`copyUploads`; new test asserting a dropped image still spawns, notes the loss in-prompt, and emits `session:uploads-dropped`.
- Root `bun run lint` + targeted `bun test` green; UI `bun run check` + `check:i18n` (2012 keys parity) + `store.svelte.test.ts` green.

## Notes

- Server-side bugfix + a small UI toast; new i18n key `toast_uploads_dropped` (EN+DE).
- Not a `feat` and the toast handler lives outside the feature-catalog gate globs — no catalog entry needed.