### PR TITLE
feat(ui): Plan-Diagramme im Vollbild öffnen + Plan auf Desktop breiter

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2011,5 +2011,12 @@
   "automation_drain_fields_intro": "Diese Regler steuern die Auto-Abarbeitung und gelten nur, solange sie aktiv ist:",
   "drain_cap_hint": "Wie viele auto-gestartete Agenten höchstens gleichzeitig laufen. Ist das Limit erreicht, wartet Shepherd auf einen freien Platz, bevor das nächste Issue aufgegriffen wird.",
   "drain_label_hint": "Nur Issues mit diesem Label werden aufgegriffen — versieh die Tickets, die automatisch abgearbeitet werden sollen, damit.",
-  "drain_ceiling_hint": "Pausiert neue Auto-Starts, sobald die Konto-Auslastung diesen Prozentwert erreicht. Ein höherer Wert lässt die Abarbeitung länger weiterlaufen; Standard ist 80."
+  "drain_ceiling_hint": "Pausiert neue Auto-Starts, sobald die Konto-Auslastung diesen Prozentwert erreicht. Ein höherer Wert lässt die Abarbeitung länger weiterlaufen; Standard ist 80.",
+  "vblock_mermaid_expand": "Diagramm vergrößern",
+  "diagram_lightbox_title": "Diagramm",
+  "diagram_zoom_in": "Vergrößern",
+  "diagram_zoom_out": "Verkleinern",
+  "diagram_zoom_fit": "Einpassen",
+  "feat_diagram_lightbox_title": "Plan-Diagramme im Vollbild öffnen",
+  "feat_diagram_lightbox_body": "Klicke ein Diagramm im Plan an, um es nahezu im Vollbild zu öffnen — dann zoomen und ziehen, um auch feine Beschriftungen zu lesen. Die Plan-Ansicht ist auf dem Desktop zudem breiter, sodass Diagramme, Datenmodell-Karten und Diffs mehr Platz bekommen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2011,5 +2011,12 @@
   "automation_drain_fields_intro": "These dials govern Auto-Drain and apply only while it's on:",
   "drain_cap_hint": "Most auto-started agents allowed to run at once. Once it's reached, Shepherd waits for a slot to free before picking up the next issue.",
   "drain_label_hint": "Only issues carrying this label get picked up — tag the tickets you want worked automatically with it.",
-  "drain_ceiling_hint": "Pause new auto-starts once your account usage reaches this percentage. A higher value lets the drain keep going longer; the default is 80."
+  "drain_ceiling_hint": "Pause new auto-starts once your account usage reaches this percentage. A higher value lets the drain keep going longer; the default is 80.",
+  "vblock_mermaid_expand": "Enlarge diagram",
+  "diagram_lightbox_title": "Diagram",
+  "diagram_zoom_in": "Zoom in",
+  "diagram_zoom_out": "Zoom out",
+  "diagram_zoom_fit": "Fit to screen",
+  "feat_diagram_lightbox_title": "Open plan diagrams full-screen",
+  "feat_diagram_lightbox_body": "Click any diagram in a plan to open it near full-screen, then zoom and drag to read the fine labels. The plan view is also wider on desktop, so diagrams, data-model cards and diffs get more room."
 }

--- a/ui/src/lib/components/PlanPanel.svelte
+++ b/ui/src/lib/components/PlanPanel.svelte
@@ -237,7 +237,11 @@
   }
   .card {
     position: relative;
-    width: min(640px, 92vw);
+    /* Desktop plans carry diagrams, data-model cards, diffs and tables — give
+       them room. Running prose is capped to a readable measure separately
+       (.md/.summary/.findings) so widening the sheet helps structure without
+       letting paragraphs sprawl. */
+    width: min(1040px, 92vw);
     max-height: 86vh;
     overflow-y: auto;
     /* lock horizontal axis: long code/plan text wraps or scrolls inside its own
@@ -351,6 +355,7 @@
   }
   .summary {
     margin: 0;
+    max-width: 74ch;
     color: var(--color-ink-bright);
     font-size: var(--fs-base);
   }
@@ -364,6 +369,17 @@
     font-size: var(--fs-base);
     line-height: 1.45;
     overflow-wrap: anywhere;
+  }
+  /* Cap running text to a comfortable measure on wide desktop sheets; leave
+     pre/table free to use the full width. */
+  .md :global(p),
+  .md :global(ul),
+  .md :global(ol),
+  .md :global(h1),
+  .md :global(h2),
+  .md :global(h3),
+  .md :global(h4) {
+    max-width: 74ch;
   }
   .md :global(pre) {
     background: var(--color-panel);
@@ -382,6 +398,7 @@
   }
   .findings {
     margin: 0;
+    max-width: 74ch;
     padding-left: 18px;
     color: var(--color-ink);
     font-size: var(--fs-base);

--- a/ui/src/lib/components/blocks/DiagramLightbox.svelte
+++ b/ui/src/lib/components/blocks/DiagramLightbox.svelte
@@ -1,0 +1,310 @@
+<script lang="ts">
+  // Near-fullscreen inspector for a rendered diagram SVG. Opens fit-to-screen
+  // (scaled UP for small diagrams so they fill the table, fit-to-width with
+  // scroll for large ones), then zoom + drag-to-pan to read fine labels.
+  // The SVG arrives already rendered + themed from MermaidBlock; this component
+  // only sizes and frames it. Blocking modal → scrim+blur, focus trap, Esc.
+  import { dialog } from "$lib/a11yDialog";
+  import { portal } from "$lib/portal";
+  import { m } from "$lib/paraglide/messages";
+
+  let { svg, title, onclose }: { svg: string; title?: string; onclose: () => void } = $props();
+
+  let stage = $state<HTMLDivElement>();
+  // Natural diagram dimensions, read from the SVG's viewBox once mounted.
+  let natW = $state(0);
+  let natH = $state(0);
+  let scale = $state(1);
+
+  const MIN = 0.1;
+  const MAX = 8;
+  const clamp = (s: number) => Math.min(MAX, Math.max(MIN, s));
+
+  // Scale that makes the whole diagram fit the stage with a little breathing room.
+  // No upper cap → a tiny graph scales up to fill the inspector (the point of "see it bigger").
+  function fitScale() {
+    if (!stage || !natW || !natH) return 1;
+    const pad = 48;
+    const w = Math.max(1, stage.clientWidth - pad);
+    const h = Math.max(1, stage.clientHeight - pad);
+    return clamp(Math.min(w / natW, h / natH));
+  }
+
+  function measure() {
+    const el = stage?.querySelector("svg");
+    if (!el) return;
+    const vb = el.viewBox?.baseVal;
+    const rect = el.getBoundingClientRect();
+    natW = vb && vb.width ? vb.width : rect.width || 1;
+    natH = vb && vb.height ? vb.height : rect.height || 1;
+    // Hand sizing to our canvas wrapper: drop Mermaid's own width cap and let the
+    // SVG fill the (scaled) canvas, preserving aspect ratio via its viewBox.
+    el.style.maxWidth = "none";
+    el.style.width = "100%";
+    el.style.height = "100%";
+    scale = fitScale();
+  }
+
+  // Re-measure whenever the SVG markup changes (also covers the initial mount).
+  $effect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- reactive dep
+    svg;
+    measure();
+  });
+
+  function zoom(factor: number) {
+    scale = clamp(scale * factor);
+  }
+  function fit() {
+    scale = fitScale();
+  }
+
+  function onResize() {
+    fit();
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === "+" || e.key === "=") {
+      e.preventDefault();
+      zoom(1.25);
+    } else if (e.key === "-" || e.key === "_") {
+      e.preventDefault();
+      zoom(0.8);
+    } else if (e.key === "0") {
+      e.preventDefault();
+      fit();
+    }
+  }
+
+  // Drag-to-pan: grab the canvas and scroll the stage. Native scrollbars still work.
+  let dragging = $state(false);
+  let startX = 0;
+  let startY = 0;
+  let startL = 0;
+  let startT = 0;
+  function onPointerDown(e: PointerEvent) {
+    if (!stage) return;
+    dragging = true;
+    startX = e.clientX;
+    startY = e.clientY;
+    startL = stage.scrollLeft;
+    startT = stage.scrollTop;
+    stage.setPointerCapture(e.pointerId);
+  }
+  function onPointerMove(e: PointerEvent) {
+    if (!dragging || !stage) return;
+    stage.scrollLeft = startL - (e.clientX - startX);
+    stage.scrollTop = startT - (e.clientY - startY);
+  }
+  function onPointerUp(e: PointerEvent) {
+    if (!stage) return;
+    dragging = false;
+    if (stage.hasPointerCapture(e.pointerId)) stage.releasePointerCapture(e.pointerId);
+  }
+</script>
+
+<svelte:window onresize={onResize} onkeydown={onKeydown} />
+
+<div
+  class="scrim lb"
+  role="presentation"
+  use:portal
+  onclick={(e) => {
+    if (e.target === e.currentTarget) onclose();
+  }}
+>
+  <div
+    class="frame bracket"
+    role="dialog"
+    aria-modal="true"
+    aria-label={title || m.diagram_lightbox_title()}
+    use:dialog={{ onclose }}
+  >
+    <header class="lb-head">
+      <span class="lb-title" title={title || m.diagram_lightbox_title()}
+        >{title || m.diagram_lightbox_title()}</span
+      >
+      <div class="lb-tools">
+        <button
+          type="button"
+          class="step"
+          onclick={() => zoom(0.8)}
+          aria-label={m.diagram_zoom_out()}>−</button
+        >
+        <button type="button" class="pct" onclick={fit} aria-label={m.diagram_zoom_fit()}
+          >{Math.round(scale * 100)}%</button
+        >
+        <button
+          type="button"
+          class="step"
+          onclick={() => zoom(1.25)}
+          aria-label={m.diagram_zoom_in()}>+</button
+        >
+        <button type="button" class="close" onclick={onclose} aria-label={m.common_close()}
+          >✕</button
+        >
+      </div>
+    </header>
+
+    <!-- role=application: a custom pan/zoom canvas. Drag-to-pan layers on top of
+         native scroll; keyboard users get fit + zoom, which always frames the
+         whole diagram. -->
+    <div
+      class="stage"
+      class:dragging
+      role="application"
+      aria-label={title || m.diagram_lightbox_title()}
+      bind:this={stage}
+      onpointerdown={onPointerDown}
+      onpointermove={onPointerMove}
+      onpointerup={onPointerUp}
+      onpointercancel={onPointerUp}
+    >
+      <div class="canvas" style:width="{natW * scale}px" style:height="{natH * scale}px">
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -- mermaid securityLevel:"strict" output, already sanitized upstream -->
+        {@html svg}
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .lb {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 40;
+  }
+  .frame {
+    position: relative;
+    width: 96vw;
+    height: 92vh;
+    display: flex;
+    flex-direction: column;
+    background: var(--color-panel);
+    border: 1px solid var(--color-line-bright);
+    overflow: hidden;
+  }
+  /* corner brackets — the same draftsman frame the plan card wears */
+  .bracket::before,
+  .bracket::after {
+    content: "";
+    position: absolute;
+    width: 12px;
+    height: 12px;
+    border: 1px solid var(--color-line-bright);
+    z-index: 2;
+  }
+  .bracket::before {
+    top: -1px;
+    left: -1px;
+    border-right: 0;
+    border-bottom: 0;
+  }
+  .bracket::after {
+    bottom: -1px;
+    right: -1px;
+    border-left: 0;
+    border-top: 0;
+  }
+  .lb-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 8px 12px;
+    background: var(--color-head);
+    border-bottom: 1px solid var(--color-line);
+    flex-shrink: 0;
+  }
+  .lb-title {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .lb-tools {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+  }
+  .step,
+  .pct,
+  .close {
+    min-width: 44px;
+    height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-ink);
+    font: inherit;
+    cursor: pointer;
+  }
+  /* the percentage doubles as the fit-to-screen control — monospace so the
+     digits don't jitter the toolbar width as the value changes */
+  .pct {
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    padding: 0 10px;
+    color: var(--color-muted);
+  }
+  .step {
+    font-size: var(--fs-xl);
+    line-height: 1;
+  }
+  .step:hover,
+  .pct:hover,
+  .close:hover {
+    background: var(--color-hover);
+    color: var(--color-ink-bright);
+    border-color: var(--color-line-bright);
+  }
+  .step:focus-visible,
+  .pct:focus-visible,
+  .close:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+  /* the diagram floats on the app canvas, not the panel chrome — reads as a
+     blueprint on a light table rather than UI inside a box */
+  .stage {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+    background: var(--color-bg);
+    display: flex;
+    cursor: grab;
+    overscroll-behavior: contain;
+  }
+  .stage.dragging {
+    cursor: grabbing;
+  }
+  /* margin:auto centers when the diagram is smaller than the stage AND keeps the
+     overflow fully scrollable when it's larger (flex centering alone would clip
+     the top-left out of reach). */
+  .canvas {
+    margin: auto;
+    flex-shrink: 0;
+  }
+  .canvas :global(svg) {
+    display: block;
+  }
+  @media (max-width: 768px) {
+    .frame {
+      width: 100vw;
+      height: 100dvh;
+      border: 0;
+    }
+    .bracket::before,
+    .bracket::after {
+      display: none;
+    }
+  }
+</style>

--- a/ui/src/lib/components/blocks/MermaidBlock.svelte
+++ b/ui/src/lib/components/blocks/MermaidBlock.svelte
@@ -8,11 +8,15 @@
   import { m } from "$lib/paraglide/messages";
   import { theme } from "$lib/theme.svelte";
   import InferredBadge from "./InferredBadge.svelte";
+  import DiagramLightbox from "./DiagramLightbox.svelte";
 
   let { block }: { block: Extract<VisualBlock, { type: "mermaid" }> } = $props();
 
   let svg = $state<string | null>(null);
   let error = $state<boolean>(false);
+  // Click the diagram to inspect it near-fullscreen (zoom + pan) — inline it's
+  // capped to the plan column and complex graphs render too small to read.
+  let zoomed = $state(false);
 
   $effect(() => {
     // Read reactive deps at top so the effect re-runs on theme/contrast change.
@@ -91,15 +95,25 @@
       <pre class="mb-source">{block.source}</pre>
     </div>
   {:else if svg !== null}
-    <div class="mb-svg">
+    <button
+      type="button"
+      class="mb-svg"
+      onclick={() => (zoomed = true)}
+      aria-label={m.vblock_mermaid_expand()}
+    >
       <!-- eslint-disable-next-line svelte/no-at-html-tags -- mermaid securityLevel:"strict" sanitizes output -->
       {@html svg}
-    </div>
+      <span class="mb-zoom" aria-hidden="true">⤢</span>
+    </button>
   {/if}
   {#if block.caption}
     <p class="mb-caption">{block.caption}</p>
   {/if}
 </div>
+
+{#if zoomed && svg}
+  <DiagramLightbox {svg} title={block.caption} onclose={() => (zoomed = false)} />
+{/if}
 
 <style>
   .mermaid-block {
@@ -116,14 +130,51 @@
     padding: 4px 10px;
     border-bottom: 1px solid var(--color-line);
   }
+  /* the rendered SVG is the click target — reset the button, keep the inset look,
+     and hint that it opens larger (cursor + corner glyph on hover/focus) */
   .mb-svg {
+    position: relative;
+    display: block;
+    width: 100%;
     padding: 12px;
     overflow-x: auto;
+    background: transparent;
+    border: 0;
+    font: inherit;
+    text-align: left;
+    cursor: zoom-in;
   }
   .mb-svg :global(svg) {
     display: block;
     max-width: 100%;
     height: auto;
+  }
+  .mb-zoom {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    width: 22px;
+    height: 22px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--color-line-bright);
+    border-radius: 2px;
+    background: var(--color-panel);
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+    line-height: 1;
+    opacity: 0;
+    transition: opacity 0.12s;
+    pointer-events: none;
+  }
+  .mb-svg:hover .mb-zoom,
+  .mb-svg:focus-visible .mb-zoom {
+    opacity: 1;
+  }
+  .mb-svg:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
   }
   .mb-error {
     display: flex;

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1654,4 +1654,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_herdr_update_session_list_title",
     bodyKey: "feat_herdr_update_session_list_body",
   },
+  {
+    // No targetId: plan diagrams are per-plan (zero or many instances, only while the
+    // plan panel is open), so there's no single stable coachmark anchor — surface via
+    // the What's-New drawer only. 1.37.0 is the latest released tag, so this ships in 1.38.0.
+    id: "plan-diagram-lightbox",
+    sinceVersion: "1.38.0",
+    titleKey: "feat_diagram_lightbox_title",
+    bodyKey: "feat_diagram_lightbox_body",
+  },
 ];


### PR DESCRIPTION
## Was

Zwei zusammenhängende Verbesserungen an der **Plan-Ansicht** (`PlanPanel`), angestoßen vom Feedback: Diagramme im Plan sind zu klein zum Lesen, und der Plan könnte auf dem Desktop breiter sein.

### 1. Diagramm-Inspektor (Klick → nahezu Vollbild)
Plan-Diagramme (Mermaid) werden auf die Plan-Spalte gequetscht und sind bei komplexen Graphen unleserlich. Jetzt:

- **Klick auf ein Diagramm** öffnet einen nahezu vollbildigen Inspektor (`DiagramLightbox`).
- Öffnet **fit-to-screen**: kleine Graphen werden **hochskaliert** (füllen den Inspektor), große passen sich der Breite an und scrollen.
- **Zoom** über `−  /  %  /  +` (das Prozent ist zugleich der „Einpassen"-Button), **Ziehen zum Verschieben**, Tastatur `+` / `-` / `0`.
- Blockierender Modal nach Hausregel: Scrim + Blur, Focus-Trap, Esc, `aria-modal`, im gleichen Eck-Klammer-Rahmen wie die Plan-Karte.
- Hover/Focus auf dem Diagramm zeigt ein `⤢`-Hinweisglyph; Cursor `zoom-in`.

### 2. Plan auf dem Desktop breiter
- Karte `min(640px, 92vw)` → `min(1040px, 92vw)` auf dem Desktop, damit Diagramme, Datenmodell-Karten, Diffs und Tabellen echten Platz bekommen.
- Fließtext (`.md`, `.summary`, `.findings`) wird auf ein lesbares Maß (`74ch`) begrenzt — die Verbreiterung hilft der Struktur, ohne dass Absätze über die volle Breite zerlaufen.

## Verifiziert
- Headless (Playwright/vitest-browser) gerendert: Inline-Diagramm → Klick → Inspektor öffnet fit-to-screen (ganzer Flow sichtbar) → `+` vergrößert über 100 % mit Pan-Overflow. Focus-Ring/Titel/Mono-Prozent wie im Shepherd-Idiom.
- `bun run check` (0 Fehler), `bun run check:i18n` (Parität), bestehende `MermaidBlock`-Tests grün, ESLint sauber.

## Discovery / i18n
- Feature-Eintrag `plan-diagram-lightbox` (1.38.0) im Katalog, EN+DE-Keys ergänzt.
- Neue Strings (`vblock_mermaid_expand`, `diagram_lightbox_title`, `diagram_zoom_*`) in EN + DE.

## Hinweis (out of scope)
Die magenta-farbenen Mermaid-Kantenlabel-Hintergründe sind vorbestehendes Theming (nicht von diesem PR berührt) — könnten in einem Folge-PR an die Tokens angepasst werden.
