### PR TITLE
feat: Autopilot bis zum PR für Codex-Sessions (Alpha)

### DIFF
--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -203,6 +203,17 @@ export class AutopilotService {
     if (!s || s.status === "archived") return null;
     if (s.planPhase === "planning") return null; // plan gate owns a planning session; autopilot stands down until it's released into execution
     if (!this.enabled(s)) return null;
+    // Codex autopilot only on isolated sessions: an exited pane triggers resume() →
+    // `codex resume --last`, which in a shared-cwd (non-isolated) session would resume and
+    // steer a SIBLING codex session (corruption). An isolated worktree holds exactly one
+    // codex session per cwd, so --last targets correctly. Manual + automerge resume are
+    // unaffected — only the autopilot-driven path is constrained here.
+    if ((s.agentProvider ?? "claude") === "codex" && !s.isolated) {
+      console.warn(
+        `[autopilot] codex ${s.id}: standing down — autopilot requires an isolated session`,
+      );
+      return null;
+    }
     if (s.autopilotPaused) return null; // already handed back; waits for operator
     if (s.autopilotComplete) return null; // terminal: task delivered (non-PR), nothing to drive
     // A PR exists → autopilot normally stands down (critic territory). EXCEPTION: a full-auto

--- a/src/full-auto.ts
+++ b/src/full-auto.ts
@@ -15,12 +15,17 @@ import { isEpicIntegrationBranch } from "./epic-branch";
  * autoMergeEnabled override — draft PRs must go through sign-off before they can be landed.
  */
 export function isFullAuto(
-  s: Pick<Session, "autopilotEnabled" | "autoMergeEnabled" | "baseBranch">,
+  s: Pick<Session, "autopilotEnabled" | "autoMergeEnabled" | "baseBranch" | "agentProvider">,
   cfg: Pick<RepoConfig, "autopilotEnabled" | "autoMergeEnabled" | "draftMode">,
 ): boolean {
   // Epic children are squash-merged into their integration branch by the drain's retire path,
   // never carried by the merge train — exclude them regardless of repo auto-merge config.
   if (isEpicIntegrationBranch(s.baseBranch)) return false;
+  // Codex autopilot deliberately ends AT the open PR ("bis zum PR"): never landed by the merge
+  // train, never driven past the PR. (Codex autopilot is best-effort/Alpha; auto-merge for codex
+  // is explicitly out of scope.) The isolation guard in autopilot.ts eligible() does not cover
+  // the merge-train/drain legs, which call isFullAuto directly — so the cutoff lives here.
+  if ((s.agentProvider ?? "claude") === "codex") return false;
   const autopilot = effectiveAutopilot(s, cfg.autopilotEnabled);
   const merge = cfg.draftMode ? false : (s.autoMergeEnabled ?? cfg.autoMergeEnabled);
   return autopilot && merge;

--- a/src/service.ts
+++ b/src/service.ts
@@ -1598,10 +1598,20 @@ export class SessionService {
     return argv;
   }
 
-  private buildCodexSpawnArgv(promptArg: string, model: string | null): string[] {
+  private buildCodexSpawnArgv(
+    promptArg: string,
+    model: string | null,
+    autopilotActive: boolean,
+  ): string[] {
     const argv = ["codex", "--no-alt-screen", "--dangerously-bypass-approvals-and-sandbox"];
     if (model) argv.push("--model", model);
-    argv.push(promptArg);
+    // Codex has no --append-system-prompt, so the autopilot directive (which Claude gets via
+    // composeSystemPrompt) must ride inline on the prompt. Gated by the caller on
+    // !research && isolated && effectiveAutopilot — see buildSpawnArgv call site.
+    const prompt = autopilotActive
+      ? `${promptArg}\n\n<autopilot-directive>\n${AUTOPILOT_DIRECTIVE}\n</autopilot-directive>`
+      : promptArg;
+    argv.push(prompt);
     return argv;
   }
 
@@ -1809,7 +1819,22 @@ export class SessionService {
       const baseUrl = this.resolveSpawnBaseUrl(profileOverride, input.repoPath);
       const argv =
         agentProvider === "codex"
-          ? this.buildCodexSpawnArgv(promptArg, input.model)
+          ? this.buildCodexSpawnArgv(
+              promptArg,
+              input.model,
+              // Deliberate divergence from Claude (which gates its directive on the repo
+              // default only, see buildSpawnArgv): codex uses effectiveAutopilot so the
+              // headline case (repo default OFF + per-session toggle ON) gets the directive.
+              // Do NOT align to Claude's repo-default-only behavior. Suppressed for research
+              // (which replaces the autopilot directive) and non-isolated (which autopilot
+              // stands down on — see eligible()).
+              !input.research &&
+                wt.isolated &&
+                effectiveAutopilot(
+                  { autopilotEnabled: input.autopilotEnabled ?? null },
+                  repoConfig.autopilotEnabled,
+                ),
+            )
           : this.buildSpawnArgv(
               input,
               claudeSessionId,
@@ -1853,7 +1878,7 @@ export class SessionService {
         auto: input.auto ?? false,
         issueNumber: input.issueRef?.number ?? null,
         planGateEnabled: agentProvider === "claude" ? (input.planGateEnabled ?? null) : false,
-        autopilotEnabled: agentProvider === "claude" ? (input.autopilotEnabled ?? null) : false,
+        autopilotEnabled: input.autopilotEnabled ?? null,
         planPhase: planGateOn ? "planning" : null,
         research: input.research ?? false,
         mergeTrainPrs: input.mergeTrainPrs,

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -734,6 +734,35 @@ test("eligible() returns null while planPhase === 'planning' (autopilot suppress
   expect(h.events.some((e) => "steer" in e)).toBe(false); // never steered
 });
 
+test("eligible() stands down a NON-isolated codex session (resume --last sibling guard)", async () => {
+  // Codex autopilot only drives isolated sessions: a non-isolated pane's resume would run
+  // `codex resume --last` against a shared cwd and could steer a sibling. Must not classify/steer.
+  let classified = false;
+  const h = harness({
+    session: sess({ agentProvider: "codex", isolated: false, status: "done" }),
+    repoEnabled: true,
+    verdict: { kind: "finished", summary: "x" },
+  });
+  (h.svc as any).deps.classify = async () => {
+    classified = true;
+    return { kind: "finished", summary: "x" };
+  };
+  await h.svc.onDone("s1");
+  expect(classified).toBe(false);
+  expect(h.events.some((e) => "steer" in e)).toBe(false);
+});
+
+test("eligible() drives an ISOLATED codex session normally (positive control)", async () => {
+  // Same as above but isolated: the guard does not fire, so onDone classifies + steers.
+  const h = harness({
+    session: sess({ agentProvider: "codex", isolated: true, status: "done" }),
+    repoEnabled: true,
+    verdict: { kind: "finished", summary: "done" },
+  });
+  await h.svc.onDone("s1");
+  expect(h.classifyCount()).toBeGreaterThan(0);
+});
+
 // ───────────────── tick() idle re-engagement (the silent-hang fix) ─────────────────
 // onGit/considerCi fires only on a red-CI STATE CHANGE; the PR poller emits no `session:git`
 // for an UNCHANGED red head, so an idle full-auto agent sitting on the same red PR is reached

--- a/test/full-auto.test.ts
+++ b/test/full-auto.test.ts
@@ -57,6 +57,37 @@ test("isFullAuto: draftMode off, autopilot off → false (unchanged behavior)", 
   expect(isFullAuto(session, fullAutoCfg)).toBe(false);
 });
 
+test("isFullAuto: codex provider → false even with autopilot + auto-merge both on (bis zum PR, never landed)", () => {
+  const codexSession = {
+    autopilotEnabled: true as boolean | null,
+    autoMergeEnabled: true as boolean | null,
+    baseBranch: "main",
+    agentProvider: "codex" as const,
+  };
+  // Codex autopilot deliberately stops AT the open PR — the merge train must never carry it.
+  expect(isFullAuto(codexSession, fullAutoCfg)).toBe(false);
+});
+
+test("isFullAuto: codex provider → false even when it inherits repo auto-merge (session autoMerge null)", () => {
+  const codexInherits = {
+    autopilotEnabled: true as boolean | null,
+    autoMergeEnabled: null as boolean | null,
+    baseBranch: "main",
+    agentProvider: "codex" as const,
+  };
+  expect(isFullAuto(codexInherits, fullAutoCfg)).toBe(false);
+});
+
+test("isFullAuto: claude provider with same config → true (codex guard does not regress claude)", () => {
+  const claudeSession = {
+    autopilotEnabled: true as boolean | null,
+    autoMergeEnabled: true as boolean | null,
+    baseBranch: "main",
+    agentProvider: "claude" as const,
+  };
+  expect(isFullAuto(claudeSession, fullAutoCfg)).toBe(true);
+});
+
 test("isFullAuto: epic-child base (epic/9-x) → false even when autopilot + auto-merge both on", () => {
   const epicChild = {
     autopilotEnabled: true as boolean | null,

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -94,7 +94,9 @@ test("createSession: names, makes worktree, starts herdr, persists", async () =>
   expect(store.get(s.id)?.claudeSessionId).toBe(s.claudeSessionId);
 });
 
-test("createSession: codex provider starts interactive codex and disables claude-only automation", async () => {
+// Build a SessionService whose worktree.create yields the given `isolated`, capturing the
+// spawned argv. Used by the codex-autopilot directive tests below.
+function codexHarness(isolated: boolean) {
   const store = new SessionStore(":memory:");
   const calls: any = {};
   const service = new SessionService({
@@ -106,7 +108,7 @@ test("createSession: codex provider starts interactive codex and disables claude
       create: () => ({
         worktreePath: "/wt/repo-codex",
         branch: "shepherd/repo-codex",
-        isolated: true,
+        isolated,
       }),
       remove: () => {},
     } as any,
@@ -126,6 +128,38 @@ test("createSession: codex provider starts interactive codex and disables claude
       list: () => [],
     } as any,
   });
+  return { store, service, calls };
+}
+
+function setRepoAutopilot(store: SessionStore, on: boolean) {
+  store.setRepoConfig("/repo", {
+    criticEnabled: true,
+    criticAllPrs: false,
+    autoAddressEnabled: false,
+    learningsEnabled: false,
+    autopilotEnabled: on,
+    planGateEnabled: false,
+    autoDrainEnabled: false,
+    autoMergeEnabled: false,
+    buildQueueEnabled: false,
+    draftMode: false,
+    signoffAuthority: "human",
+    maxAuto: 1,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+    sandboxProfile: "trusted",
+    defaultModel: "inherit",
+    egressExtraHosts: [],
+    repoMode: "forge",
+    autoOptimizeFlagged: false,
+    manualStepsIssueEnabled: false,
+  } as any);
+}
+
+const hasDirective = (argv: string[]) => argv.some((a) => a.includes("<autopilot-directive>"));
+
+test("createSession: codex provider starts interactive codex; plan-gate forced off, autopilot off → no directive", async () => {
+  const { store, service, calls } = codexHarness(true);
 
   const s = await service.create({
     repoPath: "/repo",
@@ -134,8 +168,8 @@ test("createSession: codex provider starts interactive codex and disables claude
     agentProvider: "codex",
     model: "gpt-5.5",
     images: [],
-    planGateEnabled: true,
-    autopilotEnabled: true,
+    planGateEnabled: true, // forced off for codex
+    autopilotEnabled: false,
   });
 
   expect(calls.start.argv).toEqual([
@@ -149,10 +183,90 @@ test("createSession: codex provider starts interactive codex and disables claude
   expect(s.agentProvider).toBe("codex");
   expect(s.model).toBe("gpt-5.5");
   expect(s.claudeSessionId).toBe("");
-  expect(s.planGateEnabled).toBe(false);
+  expect(s.planGateEnabled).toBe(false); // plan-gate stays codex-forced-off
   expect(s.autopilotEnabled).toBe(false);
   expect(store.get(s.id)?.agentProvider).toBe("codex");
   expect(store.get(s.id)?.model).toBe("gpt-5.5");
+});
+
+test("createSession: codex + isolated + autopilotEnabled=true → directive injected, persisted true", async () => {
+  const { store, service, calls } = codexHarness(true);
+  const s = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "build it",
+    model: null,
+    agentProvider: "codex",
+    images: [],
+    autopilotEnabled: true,
+  });
+  expect(hasDirective(calls.start.argv)).toBe(true);
+  expect(store.get(s.id)?.autopilotEnabled).toBe(true);
+});
+
+test("createSession: codex + NON-isolated + autopilotEnabled=true → NO directive, persisted true", async () => {
+  const { store, service, calls } = codexHarness(false);
+  const s = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "build it",
+    model: null,
+    agentProvider: "codex",
+    images: [],
+    autopilotEnabled: true,
+  });
+  // Persistence honors the override; the directive is gated on isolation (eligibility/badge
+  // surface the non-isolated stand-down).
+  expect(hasDirective(calls.start.argv)).toBe(false);
+  expect(store.get(s.id)?.autopilotEnabled).toBe(true);
+});
+
+// Inherited-default path (review point 3): autopilotEnabled=null + repo-default ON, across
+// isolated AND non-isolated — persistence, directive, and the effectiveAutopilot resolution agree.
+test("createSession: codex + isolated + inherited-default ON (null override) → directive injected, persisted null", async () => {
+  const { store, service, calls } = codexHarness(true);
+  setRepoAutopilot(store, true);
+  const s = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "build it",
+    model: null,
+    agentProvider: "codex",
+    images: [],
+    // autopilotEnabled omitted → null → inherits repo default ON
+  });
+  expect(hasDirective(calls.start.argv)).toBe(true);
+  expect(store.get(s.id)?.autopilotEnabled).toBe(null);
+});
+
+test("createSession: codex + NON-isolated + inherited-default ON (null override) → NO directive, persisted null", async () => {
+  const { store, service, calls } = codexHarness(false);
+  setRepoAutopilot(store, true);
+  const s = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "build it",
+    model: null,
+    agentProvider: "codex",
+    images: [],
+  });
+  expect(hasDirective(calls.start.argv)).toBe(false);
+  expect(store.get(s.id)?.autopilotEnabled).toBe(null);
+});
+
+test("createSession: codex + isolated + research + repo-default ON → NO directive (research precedence)", async () => {
+  const { store, service, calls } = codexHarness(true);
+  setRepoAutopilot(store, true);
+  await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "research it",
+    model: null,
+    agentProvider: "codex",
+    images: [],
+    research: true,
+  });
+  expect(hasDirective(calls.start.argv)).toBe(false);
 });
 
 // Regression: the 1M-context model aliases ("opus[1m]"/"sonnet[1m]") must reach the

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1967,7 +1967,7 @@
   "newtask_agent_provider_codex_alpha_badge": "Alpha MVP",
   "newtask_agent_provider_codex_alpha_note": "Die Codex-Integration ist eine Alpha/MVP-Funktion und wird gerade intensiv weiterentwickelt.",
   "newtask_agent_provider_codex_suggested_for_hold": "Claude Code ist am Nutzungsrückhalt-Schwellenwert, daher umgeht das Ausführen dieser Aufgabe auf Codex den Rückhalt. Wechsle die Coding-CLI zurück zu Claude Code, um sie stattdessen bis zum Reset zurückzuhalten oder trotzdem einzureichen.",
-  "newtask_agent_provider_codex_note": "Codex startet als interaktive Terminal-Session. Plan Gate und Autopilot sind für diese Aufgabe aus; die Modellauswahl nutzt Codex-CLI-Modelle.",
+  "newtask_agent_provider_codex_note": "Codex startet als interaktive Terminal-Session und läuft unbeaufsichtigt unter --dangerously-bypass-approvals-and-sandbox (Sandbox-Profil fest auf trusted). Plan Gate ist aus. Autopilot ist best-effort (Alpha) und treibt eine isolierte Session bis zu einem offenen PR. Die Modellauswahl nutzt Codex-CLI-Modelle.",
   "agent_provider_claude": "Claude Code",
   "agent_provider_codex": "Codex",
   "agent_provider_codex_alpha": "Codex (Alpha MVP)",
@@ -2058,5 +2058,9 @@
   "feat_codex_usage_topbar_title": "Codex-Auslastung in der Topbar",
   "feat_codex_usage_topbar_body": "Das Auslastungs-Popover in der Topbar zeigt jetzt auch Codex-Token-Telemetrie, wenn eine lokale Codex-CLI konfiguriert ist. So bleiben Claude- und Codex-Kapazität an derselben Stelle sichtbar.",
   "feat_working_line_title": "Eine Arbeitslinie statt „AKTIV“",
-  "feat_working_line_body": "Eine laufende Sitzung zeigt jetzt eine dünne animierte Linie dort, wo zuvor „AKTIV“ stand. Leerlaufende und wartende Sitzungen zeigen dort nichts an — Status-Punkt und Herzschlag tragen den Zustand bereits, sodass die Karte ruhiger wirkt und die Zeit mehr Platz hat."
+  "feat_working_line_body": "Eine laufende Sitzung zeigt jetzt eine dünne animierte Linie dort, wo zuvor „AKTIV“ stand. Leerlaufende und wartende Sitzungen zeigen dort nichts an — Status-Punkt und Herzschlag tragen den Zustand bereits, sodass die Karte ruhiger wirkt und die Zeit mehr Platz hat.",
+  "session_autopilot_unavailable_label": "AP nicht verfügbar",
+  "session_autopilot_unavailable_title": "Codex-Autopilot braucht eine isolierte Worktree-Session; diese Session teilt sich ihr Arbeitsverzeichnis, daher steht der Autopilot still.",
+  "feat_codex_autopilot_title": "Autopilot für Codex (Alpha)",
+  "feat_codex_autopilot_body": "Autopilot-bis-zum-PR ist jetzt für Codex-Aufgaben verfügbar. Schalte ihn im Neue-Aufgabe-Dialog ein, und Codex läuft unbeaufsichtigt bis zu einem offenen PR. Es ist best-effort (Alpha): nur isolierte Sessions werden getrieben, und es stoppt am offenen PR — niemals automatischer Merge."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1967,7 +1967,7 @@
   "newtask_agent_provider_codex_alpha_badge": "Alpha MVP",
   "newtask_agent_provider_codex_alpha_note": "Codex integration is an Alpha/MVP feature and is under heavy development.",
   "newtask_agent_provider_codex_suggested_for_hold": "Claude Code is at the usage-hold threshold, so running this task on Codex sidesteps the hold. Switch the coding CLI back to Claude Code to hold it until the reset or submit anyway instead.",
-  "newtask_agent_provider_codex_note": "Codex starts as an interactive terminal session. Plan Gate and Autopilot are off for this task; the model picker uses Codex CLI models.",
+  "newtask_agent_provider_codex_note": "Codex starts as an interactive terminal session, running unattended under --dangerously-bypass-approvals-and-sandbox (sandbox profile forced to trusted). Plan Gate is off. Autopilot is best-effort (Alpha) and drives an isolated session toward an open PR. The model picker uses Codex CLI models.",
   "agent_provider_claude": "Claude Code",
   "agent_provider_codex": "Codex",
   "agent_provider_codex_alpha": "Codex (Alpha MVP)",
@@ -2058,5 +2058,9 @@
   "feat_codex_usage_topbar_title": "Codex usage in the topbar",
   "feat_codex_usage_topbar_body": "The topbar usage popover now includes Codex token telemetry when a local Codex CLI is configured, so Claude and Codex capacity are visible from the same place.",
   "feat_working_line_title": "A working line, not a BUSY label",
-  "feat_working_line_body": "A running session now shows a thin animated line where the BUSY label used to be. Idle and waiting sessions show nothing there — the status pip and heartbeat already carry the state, so the card stays calmer and the time has more room."
+  "feat_working_line_body": "A running session now shows a thin animated line where the BUSY label used to be. Idle and waiting sessions show nothing there — the status pip and heartbeat already carry the state, so the card stays calmer and the time has more room.",
+  "session_autopilot_unavailable_label": "AP unavailable",
+  "session_autopilot_unavailable_title": "Codex autopilot needs an isolated worktree session; this session shares its working directory, so autopilot stands down.",
+  "feat_codex_autopilot_title": "Autopilot for Codex (Alpha)",
+  "feat_codex_autopilot_body": "Autopilot-until-PR is now available for Codex tasks. Toggle it on in New Task and Codex runs unattended toward an open PR. It is best-effort (Alpha): it drives isolated sessions only and stops at the open PR — it never auto-merges."
 }

--- a/ui/src/lib/components/AutopilotBadge.svelte
+++ b/ui/src/lib/components/AutopilotBadge.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import type { Session } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
+  import { codexAutopilotUnavailable } from "$lib/format";
 
-  let { session }: { session: Session } = $props();
+  let { session, repoAutopilotDefault }: { session: Session; repoAutopilotDefault: boolean } =
+    $props();
 </script>
 
 <!-- Keep in sync with autopilotBadgeShown() in $lib/format — both must list the same states or card status-badge suppression desyncs. -->
@@ -24,11 +26,21 @@
   >
     {m.session_autopilot_complete_label()}
   </span>
+{:else if codexAutopilotUnavailable(session, repoAutopilotDefault)}
+  <span
+    class="ap-unavailable"
+    title={m.session_autopilot_unavailable_title()}
+    role="img"
+    aria-label={m.session_autopilot_unavailable_label()}
+  >
+    {m.session_autopilot_unavailable_label()}
+  </span>
 {/if}
 
 <style>
   .ap-paused,
-  .ap-complete {
+  .ap-complete,
+  .ap-unavailable {
     font-size: var(--fs-micro);
     letter-spacing: 0.12em;
     text-transform: uppercase;
@@ -42,5 +54,9 @@
   .ap-complete {
     border-color: var(--color-green);
     color: var(--color-green);
+  }
+  .ap-unavailable {
+    border-color: var(--color-slate);
+    color: var(--color-slate);
   }
 </style>

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -1021,7 +1021,7 @@ describe("NewTask first-task confirm step", () => {
       .toBeInTheDocument();
   });
 
-  it("switching Codex→Claude restores plan gate / autopilot in one flip", async () => {
+  it("switching Codex→Claude: plan-gate forced off (restored on flip back), autopilot available throughout", async () => {
     const repoPath = "/repo/codex-restore";
     // Repo defaults both automation toggles ON.
     mockGetRepoConfig.mockResolvedValue({
@@ -1044,15 +1044,15 @@ describe("NewTask first-task confirm step", () => {
     await expect.poll(() => planGateBox().checked).toBe(true);
     await expect.poll(() => autopilotBox().checked).toBe(true);
 
-    // Codex can't plan-gate/autopilot → both forced off and disabled.
+    // Codex: plan-gate forced off + disabled; autopilot stays available (on + enabled).
     provider().value = "codex";
     provider().dispatchEvent(new Event("change", { bubbles: true }));
     await expect.poll(() => planGateBox().checked).toBe(false);
-    await expect.poll(() => autopilotBox().checked).toBe(false);
     expect(planGateBox().disabled).toBe(true);
-    expect(autopilotBox().disabled).toBe(true);
+    await expect.poll(() => autopilotBox().checked).toBe(true);
+    expect(autopilotBox().disabled).toBe(false);
 
-    // Back to Claude in a single flip → restored to the repo default, not stuck off.
+    // Back to Claude in a single flip → plan-gate restored to the repo default, not stuck off.
     provider().value = "claude";
     provider().dispatchEvent(new Event("change", { bubbles: true }));
     await expect.poll(() => planGateBox().checked).toBe(true);
@@ -1061,7 +1061,7 @@ describe("NewTask first-task confirm step", () => {
     expect(autopilotBox().disabled).toBe(false);
   });
 
-  it("preserves a manual plan-gate / autopilot override across a Codex round-trip", async () => {
+  it("preserves a manual plan-gate override (forced-off display) and keeps autopilot on across a Codex round-trip", async () => {
     const repoPath = "/repo/codex-preserve-override";
     // Repo defaults both automation toggles OFF.
     mockGetRepoConfig.mockResolvedValue(confirmedRepoConfig());
@@ -1083,13 +1083,14 @@ describe("NewTask first-task confirm step", () => {
     await expect.poll(() => planGateBox().checked).toBe(true);
     await expect.poll(() => autopilotBox().checked).toBe(true);
 
-    // Codex displays them off (state is preserved underneath, not mutated).
+    // Codex displays plan-gate off (state preserved underneath, not mutated); autopilot stays on.
     provider().value = "codex";
     provider().dispatchEvent(new Event("change", { bubbles: true }));
     await expect.poll(() => planGateBox().checked).toBe(false);
-    await expect.poll(() => autopilotBox().checked).toBe(false);
+    await expect.poll(() => autopilotBox().checked).toBe(true);
+    expect(autopilotBox().disabled).toBe(false);
 
-    // Back to Claude → the manual override survives the round-trip.
+    // Back to Claude → the manual plan-gate override survives the round-trip.
     provider().value = "claude";
     provider().dispatchEvent(new Event("change", { bubbles: true }));
     await expect.poll(() => planGateBox().checked).toBe(true);

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -599,10 +599,16 @@
     e.stopPropagation();
   }
 
-  // Per-task plan-gate / autopilot flag at submit. Codex can't plan-gate or
-  // autopilot yet, so force both off; otherwise send the user's manual choice, or
-  // null to inherit the repo default.
+  // Per-task autopilot flag at submit: send the user's manual choice, or null to inherit
+  // the repo default — for both providers. Codex autopilot is best-effort/Alpha and the
+  // server stands it down for non-isolated sessions (see AutopilotBadge for the surfacing).
   function automationFlag(touched: boolean, value: boolean): boolean | null {
+    return touched ? value : null;
+  }
+
+  // Plan-gate stays codex-forced-off: codex gets no spawn directives via
+  // --append-system-prompt, so the plan-gate wiring is not available for it yet.
+  function planGateFlag(touched: boolean, value: boolean): boolean | null {
     if (agentProvider === "codex") return false;
     return touched ? value : null;
   }
@@ -627,7 +633,7 @@
               body: issueRef.body,
             }
           : undefined,
-        planGateEnabled: automationFlag(planGateTouched, planGate),
+        planGateEnabled: planGateFlag(planGateTouched, planGate),
         autopilotEnabled: automationFlag(autopilotTouched, autopilot),
         sandboxProfile: sandboxProfile === "default" ? undefined : sandboxProfile,
         research,

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -33,7 +33,7 @@
   import TimePopover from "./TimePopover.svelte";
   import HeartbeatStrip from "./HeartbeatStrip.svelte";
   import Stepper from "./Stepper.svelte";
-  import { reviews } from "$lib/reviews.svelte";
+  import { reviews, repoConfig } from "$lib/reviews.svelte";
   import { toasts } from "$lib/toasts.svelte";
   import { projectIcons } from "$lib/projectIcons.svelte";
   import { m } from "$lib/paraglide/messages";
@@ -182,7 +182,9 @@
   });
 
   const reviewing = $derived(reviews.isReviewing(session.id));
-  const autopilotShown = $derived(autopilotBadgeShown(session));
+  const autopilotShown = $derived(
+    autopilotBadgeShown(session, repoConfig.isAutopilotEnabled(session.repoPath)),
+  );
   const hideStatus = $derived(hideStatusBadge(dStatus, reviewing, autopilotShown));
 
   // The status slot renders for merging / ready / a running working-line; every

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -23,7 +23,7 @@
   import PrBadge from "./PrBadge.svelte";
   import TimePopover from "./TimePopover.svelte";
   import CriticBadge from "./CriticBadge.svelte";
-  import { reviews } from "$lib/reviews.svelte";
+  import { reviews, repoConfig } from "$lib/reviews.svelte";
   import { toasts } from "$lib/toasts.svelte";
   import { m } from "$lib/paraglide/messages";
   import AutopilotBadge from "./AutopilotBadge.svelte";
@@ -64,7 +64,9 @@
   const dStatus = $derived(displayStatus(session, workingBlocked));
 
   const reviewing = $derived(reviews.isReviewing(session.id));
-  const autopilotShown = $derived(autopilotBadgeShown(session));
+  const autopilotShown = $derived(
+    autopilotBadgeShown(session, repoConfig.isAutopilotEnabled(session.repoPath)),
+  );
   const hideStatus = $derived(hideStatusBadge(dStatus, reviewing, autopilotShown));
 
   // The status slot renders for ready / a running working-line / a blocked alert
@@ -302,7 +304,10 @@
     <CriticBadge sessionId={session.id} />
     <PlanGateBadge {session} allowView={false} />
     <!-- REVIEWING (in-flight critic) outranks the autopilot badge -->
-    {#if !reviewing}<AutopilotBadge {session} />{/if}
+    {#if !reviewing}<AutopilotBadge
+        {session}
+        repoAutopilotDefault={repoConfig.isAutopilotEnabled(session.repoPath)}
+      />{/if}
     <AutoPip {session} />
     {#if session.readyToMerge}
       <span class="badge" id="tile-status-{session.id}">{m.status_ready_to_merge()}</span>

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1948,7 +1948,10 @@
       <!-- REVIEWING (in-flight critic, surfaced in the GitRail/auto-pill) outranks the
            autopilot badge — mirror the cards' precedence so NEEDS YOU/DELIVERED never
            co-renders with REVIEWING anywhere. -->
-      {#if !reviews.isReviewing(session.id)}<AutopilotBadge {session} />{/if}
+      {#if !reviews.isReviewing(session.id)}<AutopilotBadge
+          {session}
+          repoAutopilotDefault={repoConfig.isAutopilotEnabled(session.repoPath)}
+        />{/if}
     {/if}
     <ViewportHeaderActions
       {compact}

--- a/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
+++ b/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
@@ -109,12 +109,12 @@
       <label class="plan-gate" use:coachTarget={"task-autopilot"}>
         <input
           type="checkbox"
-          checked={agentProvider === "codex" ? false : autopilot}
+          checked={autopilot}
           onchange={(e) => {
             autopilot = e.currentTarget.checked;
             onAutopilotTouched();
           }}
-          disabled={autopilotLoading || agentProvider === "codex"}
+          disabled={autopilotLoading}
         />
         <span class="pg-label">{m.newtask_autopilot_label()}</span>
       </label>

--- a/ui/src/lib/components/unit-row/UnitRowRight.svelte
+++ b/ui/src/lib/components/unit-row/UnitRowRight.svelte
@@ -9,6 +9,7 @@
   import BuildQueueBadge from "../BuildQueueBadge.svelte";
   import PlanGateBadge from "../PlanGateBadge.svelte";
   import AutopilotBadge from "../AutopilotBadge.svelte";
+  import { repoConfig } from "$lib/reviews.svelte";
 
   let {
     session,
@@ -110,7 +111,10 @@
     >
   {/if}
   <!-- REVIEWING (in-flight critic) outranks the autopilot badge -->
-  {#if !reviewing}<AutopilotBadge {session} />{/if}
+  {#if !reviewing}<AutopilotBadge
+      {session}
+      repoAutopilotDefault={repoConfig.isAutopilotEnabled(session.repoPath)}
+    />{/if}
   <!-- Sandbox state: degraded/unconfined are warnings (amber); confined profiles
        are quiet informational badges (slate). Trusted-manual renders nothing. -->
   {#if session.sandboxDegraded}

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1723,4 +1723,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_working_line_title",
     bodyKey: "feat_working_line_body",
   },
+  {
+    // Autopilot-until-PR is now selectable for Codex tasks (previously Claude-only). The
+    // checkbox carries coachTarget "task-autopilot" in NewTaskRunSettings, so the coachmark
+    // can point at it.
+    id: "codex-autopilot",
+    sinceVersion: "1.38.0",
+    titleKey: "feat_codex_autopilot_title",
+    bodyKey: "feat_codex_autopilot_body",
+    targetId: "task-autopilot",
+  },
 ];

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -109,16 +109,64 @@ describe("hideStatusBadge", () => {
 
 describe("autopilotBadgeShown", () => {
   const session = (over: Partial<Session>): Session =>
-    ({ autopilotPaused: false, autopilotComplete: false, ...over }) as Session;
+    ({
+      autopilotPaused: false,
+      autopilotComplete: false,
+      autopilotEnabled: null,
+      agentProvider: "claude",
+      isolated: true,
+      ...over,
+    }) as Session;
 
   it("returns true when autopilotPaused", () =>
-    expect(autopilotBadgeShown(session({ autopilotPaused: true }))).toBe(true));
+    expect(autopilotBadgeShown(session({ autopilotPaused: true }), false)).toBe(true));
 
   it("returns true when autopilotComplete", () =>
-    expect(autopilotBadgeShown(session({ autopilotComplete: true }))).toBe(true));
+    expect(autopilotBadgeShown(session({ autopilotComplete: true }), false)).toBe(true));
 
-  it("returns false when neither paused nor complete", () =>
-    expect(autopilotBadgeShown(session({}))).toBe(false));
+  it("returns false when neither paused nor complete (claude)", () =>
+    expect(autopilotBadgeShown(session({}), false)).toBe(false));
+
+  // Codex non-isolated "unavailable" state — both explicit-true and inherited-default-ON.
+  it("returns true for codex + non-isolated + autopilotEnabled=true", () =>
+    expect(
+      autopilotBadgeShown(
+        session({ agentProvider: "codex", isolated: false, autopilotEnabled: true }),
+        false,
+      ),
+    ).toBe(true));
+
+  it("returns true for codex + non-isolated + inherited-default-ON (autopilotEnabled=null)", () =>
+    expect(
+      autopilotBadgeShown(
+        session({ agentProvider: "codex", isolated: false, autopilotEnabled: null }),
+        true, // repo default ON
+      ),
+    ).toBe(true));
+
+  it("returns false for codex + isolated (autopilot available)", () =>
+    expect(
+      autopilotBadgeShown(
+        session({ agentProvider: "codex", isolated: true, autopilotEnabled: true }),
+        false,
+      ),
+    ).toBe(false));
+
+  it("returns false for codex + non-isolated when autopilot resolves OFF", () =>
+    expect(
+      autopilotBadgeShown(
+        session({ agentProvider: "codex", isolated: false, autopilotEnabled: null }),
+        false, // repo default OFF, no override → not on → nothing to surface
+      ),
+    ).toBe(false));
+
+  it("returns false for claude + non-isolated (guard is codex-only)", () =>
+    expect(
+      autopilotBadgeShown(
+        session({ agentProvider: "claude", isolated: false, autopilotEnabled: true }),
+        false,
+      ),
+    ).toBe(false));
 });
 
 describe("relativeAge", () => {

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -159,9 +159,27 @@ export function hideStatusBadge(
  * IMPORTANT: if a new autopilot state is added, it MUST be reflected in BOTH
  * this helper AND `AutopilotBadge.svelte`'s render condition, or status-badge
  * suppression silently desyncs.
+ *
+ * Takes the repo's autopilot default so the codex-non-isolated "unavailable" state
+ * can resolve the inherited-default case (autopilotEnabled === null) — see
+ * codexAutopilotUnavailable.
  */
-export function autopilotBadgeShown(s: Session): boolean {
-  return s.autopilotPaused || s.autopilotComplete;
+export function autopilotBadgeShown(s: Session, repoAutopilotDefault: boolean): boolean {
+  return (
+    s.autopilotPaused || s.autopilotComplete || codexAutopilotUnavailable(s, repoAutopilotDefault)
+  );
+}
+
+/**
+ * Codex autopilot stands down on non-isolated sessions (server-side `eligible()` gate:
+ * an exited pane's `codex resume --last` could steer a sibling session in a shared cwd).
+ * The badge surfaces that as an explicit "unavailable" state so an opted-in toggle is
+ * never silently inert. Needs the repo default to catch the inherited-default-ON case
+ * where the per-session override is null — mirrors `effectiveAutopilot` (override ?? default).
+ */
+export function codexAutopilotUnavailable(s: Session, repoAutopilotDefault: boolean): boolean {
+  const on = s.autopilotEnabled ?? repoAutopilotDefault;
+  return on && (s.agentProvider ?? "claude") === "codex" && !s.isolated;
 }
 
 export function statusLabel(s: SessionStatus): string {


### PR DESCRIPTION
## Was

Macht **„Autopilot bis zum PR"** für **Codex**-Sessions verfügbar (vorher Claude-only, im New-Task-Dialog hart deaktiviert). Codex-Autopilot ist **best-effort / Alpha** und **stoppt am offenen PR** (kein Auto-Merge). Plan-Gate bleibt für Codex bewusst aus (out of scope).

Behebt: „wenn ich auf Codex wechsle ist AUTOPILOT BIS ZUM PR noch nicht verfügbar."

## Warum es funktioniert

Die `AutopilotService`-Schleife ist bereits provider-agnostisch (treibt über `session:status`/`session:git`-Events). Es fehlten nur: das Honorieren des Flags und — weil Codex kein `--append-system-prompt` hat — die `AUTOPILOT_DIRECTIVE` inline am Prompt.

## Änderungen

**Server**
- `service.ts`: `autopilotEnabled` wird für Codex gespeichert (statt hart `false`). `AUTOPILOT_DIRECTIVE` wird in den Codex-Prompt injiziert, **gated auf `!research && isolated && effectiveAutopilot(...)`**. Bewusste Divergenz zu Claude (das nur den Repo-Default gated) — so greift der Headline-Fall (Repo-Default OFF + pro-Session-Toggle ON).
- `autopilot.ts` `eligible()`: Codex-Autopilot nur für **isolierte** Sessions. Ein exited Pane triggert `resume()` → `codex resume --last`, das in einer shared-cwd (non-isolated) eine **Geschwister-Session** steuern könnte. Stand-down + Warn.
- `full-auto.ts` `isFullAuto()`: Codex wird ausgeschlossen → der Merge-Train trägt einen Codex-PR **nie über den offenen PR hinaus** (*bis zum PR*).

**UI**
- New-Task: Autopilot-Checkbox für Codex ent-sperrt; Plan-Gate bleibt codex-forced-off (split `planGateFlag`).
- `AutopilotBadge`: neuer **„nicht verfügbar"**-Zustand für non-isolated Codex-Sessions. Der Repo-Default wird durchgereicht, damit auch der inherited-default-ON-Fall (`autopilotEnabled === null`) erkannt wird — Badge **und** `autopilotBadgeShown()` im Lockstep (sonst desynct die Status-Badge-Suppression).
- Codex-Provider-Note auf best-effort/Alpha umgeschrieben; Feature-Katalog-Eintrag `codex-autopilot` + EN/DE-Keys.

## Tests

- `full-auto.test.ts`: Codex nie full-auto (auch mit Autopilot + Auto-Merge); claude unverändert `true`.
- `autopilot.test.ts`: non-isolated Codex → stand-down (kein classify/steer); isolated Codex → treibt normal.
- `service.test.ts`: Direktiven-Injektion über `create()` mit gefaktem `wt.isolated`, inkl. **inherited-default-Pfad** (null-Override + Repo-Default-ON) für isolated **und** non-isolated; Research-Präzedenz.
- `format.test.ts` / `NewTask.browser.test.ts`: Badge-States + Checkbox-Verhalten.
- Grün: root lint, `ui check`, `check:i18n`, Branch-Hygiene, Feature-Katalog, Glossary, pre-push (tsc/eslint/root-tests/ui).

## Noch offen (manuell)

**Phase 0 / Live-Run** aus dem Plan (Codex-Event-Spine empirisch + echter Autopilot-Lauf bis PR) erfordern eine laufende Shepherd-Instanz + codex CLI und sind hier nicht ausgeführt. Empfehlung: vor dem Mergen einen echten isolierten Codex-Autopilot-Lauf gegen ein Scratch-Repo verifizieren (Kriterium: `session:status` settled → re-steer → offener PR; in einem Auto-Merge-Repo bestätigen, dass am PR gestoppt wird).
