### PR TITLE
ci: harden verify-job bun installs against flaky tarball-extraction (#1134)

### DIFF
--- a/.github/actions/bun-install-retry/action.yml
+++ b/.github/actions/bun-install-retry/action.yml
@@ -1,0 +1,38 @@
+name: bun install (retry on tarball-extraction flake)
+description: >
+  Run `bun install --frozen-lockfile` with up to 3 attempts, purging the bun
+  store (~/.bun/install/cache) before the FINAL attempt so a poisoned half-written
+  native tarball is re-downloaded fresh rather than re-hit identically. Absorbs a
+  one-off tarball-extraction flake (#944 docs-site / #1134 verify) without masking
+  a genuine lockfile error. --frozen-lockfile is kept so lockfile integrity is still
+  enforced. Only the install is wrapped — callers run check/build/lint outside, so a
+  real error still fails fast.
+
+inputs:
+  working-directory:
+    description: Directory containing the package to install (default repo root).
+    required: false
+    default: "."
+
+runs:
+  using: composite
+  steps:
+    # `shell: bash` is MANDATORY for composite run steps — unlike a workflow `run:`
+    # they have no default shell and fail to load without it.
+    - shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        n=0
+        until bun install --frozen-lockfile; do
+          n=$((n + 1))
+          if [ "$n" -ge 3 ]; then
+            echo "bun install failed after $n attempts" >&2
+            exit 1
+          fi
+          if [ "$n" -eq 2 ]; then
+            echo "purging bun store before final retry…" >&2
+            rm -rf ~/.bun/install/cache
+          fi
+          echo "bun install failed (attempt $n) — retrying in 5s…" >&2
+          sleep 5
+        done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,14 +48,21 @@ jobs:
           bun-version: latest
 
       # Three packages, each with its own lockfile (root server + ui/ + extension/).
+      # Each install goes through the shared retry-with-store-purge composite action
+      # (.github/actions/bun-install-retry) so a one-off native-tarball-extraction flake
+      # self-heals instead of redding the whole job (#1134, extending docs-site's #944).
       - name: Install (root)
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install-retry
 
       - name: Install (ui)
-        run: cd ui && bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install-retry
+        with:
+          working-directory: ui
 
       - name: Install (extension)
-        run: cd extension && bun install --frozen-lockfile
+        uses: ./.github/actions/bun-install-retry
+        with:
+          working-directory: extension
 
       - name: Lint (prettier + eslint)
         run: |
@@ -164,27 +171,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-docs-site-
 
-      # Retry `bun install` to absorb a one-off @pagefind tarball-extraction flake
-      # (#944). Only the install is retried — re-running check/build on a genuine
-      # type/content error would just burn 3× the time. Before the FINAL attempt the
-      # bun store is purged so a poisoned half-written tarball is re-downloaded fresh
-      # rather than re-hit identically.
+      # Install via the shared retry-with-store-purge composite action
+      # (.github/actions/bun-install-retry) so a one-off @pagefind tarball-extraction
+      # flake (#944) self-heals: it purges the bun store before the final attempt so a
+      # poisoned half-written tarball is re-downloaded fresh. Only the install is
+      # retried — re-running check/build on a genuine type/content error would burn 3×
+      # the time. The cache step above still precedes (and is purged by) this install.
+      - name: Install (docs-site)
+        uses: ./.github/actions/bun-install-retry
+        with:
+          working-directory: docs-site
+
       - name: Build (docs-site)
+        working-directory: docs-site
         run: |
-          cd docs-site
-          n=0
-          until bun install --frozen-lockfile; do
-            n=$((n + 1))
-            if [ "$n" -ge 3 ]; then
-              echo "bun install failed after $n attempts" >&2
-              exit 1
-            fi
-            if [ "$n" -eq 2 ]; then
-              echo "purging bun store before final retry…" >&2
-              rm -rf ~/.bun/install/cache
-            fi
-            echo "bun install failed (attempt $n) — retrying in 5s…" >&2
-            sleep 5
-          done
           bun run check
           bun run build


### PR DESCRIPTION
Closes #1134.

## Problem

`verify`'s three `bun install --frozen-lockfile` steps (root, `ui/`, `extension/`) ran with no retry, so a one-off native-binary **tarball-extraction flake** (e.g. `Fail extracting tarball for "lightningcss-linux-x64-gnu"`) red the whole job and forced a no-change re-run. #944 already fixed this *class* of flake — but for the `docs-site` job only.

## Fix

Factor #944's retry-with-store-purge loop into the repo's **first composite action**, `.github/actions/bun-install-retry`, and route **all four** install sites through it (3 in `verify` + the 1 in `docs-site`). One source of truth instead of growing the loop to 4 inline copies.

Loop semantics are **identical to #944** — only the location moved:
- up to **3** attempts of `bun install --frozen-lockfile`;
- purge `~/.bun/install/cache` before the **final** attempt so a poisoned half-written tarball is re-downloaded fresh;
- `sleep 5` between attempts; fail hard after 3;
- **only the install is wrapped** → a genuine lockfile/type error still fails fast (no 3× retry of check/build/lint);
- `--frozen-lockfile` kept everywhere.

## Deliberate deviation from prior art

#944 inlined the loop; this PR **extracts it to a composite action** — the DRY option the issue explicitly endorses ("removes the existing duplication"). The `docs-site` change is mechanical/behaviorally identical: same loop, same `working-directory: docs-site`, same cache step still preceding (and purged by) the install. Its `check`/`build` moved to a sibling step that sets `working-directory: docs-site` so they don't run in the repo root.

Note for reviewers: composite `run:` steps have **no default shell**, so the action declares `shell: bash` explicitly (mandatory, not stylistic).

## Verification

Local pre-flight (necessary, not sufficient): `ci.yml` + `action.yml` parse; `actionlint` clean; loop dry-run proves all three paths — success-first-try (0 retries, no purge), fail-then-pass (1 retry, no purge), always-fail (3 attempts, purge before final, non-zero exit).

**Authoritative acceptance = this PR's own CI run** going green on **both** `verify` (now installing through the action) **and** `docs-site` — local checks can't exercise the composite wiring (input plumbing, `working-directory` resolution, shell, local `uses: ./…` resolution).

CI-only change: no user-facing UX → no feature-catalog / i18n / glossary entries; commit is `ci:`, not `feat:`. `.husky/pre-push` unchanged — it doesn't run installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)