### PR TITLE
fix(ui): height-lock top-bar left tallies to --topbar-ctl-h (#1131)

### DIFF
--- a/ui/src/lib/components/top-bar/TopBarTallies.svelte
+++ b/ui/src/lib/components/top-bar/TopBarTallies.svelte
@@ -153,12 +153,21 @@
     align-items: center;
   }
   .tally {
+    box-sizing: border-box;
     display: flex;
     gap: 7px;
     align-items: center;
+    /* shared bar control height (matches the right cluster); box-sizing keeps the
+       rendered box at exactly --topbar-ctl-h despite the 1px border, and the text
+       centers via align-items instead of vertical padding driving the height */
+    min-height: var(--topbar-ctl-h);
+    line-height: 1;
     background: none;
     border: 1px solid transparent;
-    padding: 2px 4px;
+    /* horizontal-only: vertical padding no longer drives height. Side padding stays
+       4px so the full-label width — what the measured compaction threshold reads — is
+       unchanged */
+    padding: 0 4px;
     font: inherit;
     color: inherit;
     cursor: pointer;
@@ -189,6 +198,7 @@
     flex-shrink: 0;
   }
   .ctally {
+    box-sizing: border-box;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -196,18 +206,23 @@
     background: none;
     border: 1px solid transparent;
     padding: 0 5px;
+    line-height: 1;
     font: inherit;
     color: inherit;
     cursor: pointer;
-    /* WCAG 2.5.8 (AA) 24px target floor on ALL pointers — keeps even the bare-digit
-       Idle segment hittable when the compact tallies render on a fine-pointer desktop
-       under measured overflow. Coarse pointers (phones, foldables) get the larger 44px
-       touch floor in HEIGHT below. A 44px WIDTH floor for four buttons would blow the
-       ~260px usable line-1 budget on fold-cover phones, so width stays at 24px. */
-    min-height: 24px;
+    /* HEIGHT: shares the bar's --topbar-ctl-h so the compact tallies sit flush with the
+       right cluster (#1131). box-sizing makes that a true 30px box despite the 1px
+       border; 30px > the 24px WCAG 2.5.8 (AA) target minimum, so the AA height floor is
+       still met. WIDTH: min-inline-size keeps the 24px AA target floor on the narrow
+       axis — now a true 24px border-box width (content-box previously inflated it to
+       ~36px). A 44px WIDTH floor for four buttons would blow the ~260px usable line-1
+       budget on fold-cover phones, so width stays at the 24px floor. */
+    min-height: var(--topbar-ctl-h);
     min-inline-size: 24px;
   }
-  /* Coarse-pointer touch floor: 44px height (matches .hud.mobile .gear/.needsyou). */
+  /* Coarse-pointer touch floor: 44px height (matches .hud.mobile .gear/.needsyou).
+     With box-sizing:border-box above this renders a true 44px box (was ~46px content-box)
+     and still overrides the 30px shared height since 44 > 30. */
   @media (pointer: coarse) {
     .ctally {
       min-height: 44px;


### PR DESCRIPTION
Closes #1131.

Follow-up to the "zoo of heights" top-bar fix (which equalized only the **right-side** cluster). **Decision** (confirmed with the operator against a rendered before/after mockup): **yes, height-lock** the left-side tallies — matches the issue title.

## What changed (CSS-only, `TopBarTallies.svelte` `<style>`)

`.tally` (full-label) and `.ctally` (compact) now adopt the right-cluster recipe so the whole bar locks to one 30px control height:

`box-sizing: border-box; min-height: var(--topbar-ctl-h); line-height: 1` + horizontal-only padding.

- **`.tally`**: `+box-sizing/min-height/line-height`; padding `2px 4px` → `0 4px`.
- **`.ctally`**: `+box-sizing/line-height`; `min-height: 24px` → `var(--topbar-ctl-h)`; padding (`0 5px`) and `min-inline-size: 24px` kept; coarse `@media` `44px` untouched.

`box-sizing: border-box` is **required** (not cosmetic): with the 1px border, content-box would render 32px and miss the cluster.

## Deliberate deviation flagged

The existing `.ctally` comment says *"width stays at 24px"*, but content-box had silently inflated the rendered width to **~36px**. Adding `box-sizing` makes `min-inline-size: 24px` a **true 24px border-box** floor — so bare-digit compact buttons shrink **~36px → 24px**. This is **accepted on purpose**: it honors the comment's stated intent, stays ≥ the WCAG 2.5.8 AA 24×24 minimum, and helps the *"~260px usable line-1 budget on fold-cover phones"* the same comment worries about. The alternative (bump `min-inline-size` to freeze ~36px) was rejected. The in-code comment was updated to state the new border-box semantics.

## Floors preserved (WCAG 2.5.8 AA, empirically measured via `getBoundingClientRect`)

| Element | Fine pointer | Coarse pointer |
|---|---|---|
| `.tally` (full-label) | 30px tall | 30px tall |
| `.ctally` bare-digit | **24 × 30px** | 24 × **44px** |
| `.ctally` dot+digit | 31.6 × 30px (content-driven, not clipped) | 31.6 × **44px** |

`@media (pointer: coarse)` `min-height: 44px` renders a true **44px** border-box (was ~46px content-box) — still ≥ the touch floor, still overrides the 30px shared height.

**Full-label `.tally` width is untouched** (no horizontal dimension changed), so the measured desktop compaction threshold (`hudEl.scrollWidth`) can't drift. The compact width shrink only affects the already-compacted bar and can only help it fit.

## Verification

- `cd ui && bun run check` → 0 errors / 0 warnings.
- `bunx prettier --check` on the file → clean.
- Rendered dimensions confirmed empirically (Playwright, fine + coarse pointer) — table above.
- Diff limited to `TopBarTallies.svelte` `<style>` (+ its comment).

Not a `feat` (visual consistency refinement, no new capability) → no feature-catalog entry, no i18n/glossary changes. `[no-feature-entry]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)