### PR TITLE
fix(reaper): reap orphaned PPID-1 background jobs on worktree teardown (#1133)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ import { tailLines } from "./blocked";
 import { recommendPrompt } from "./prompt-recommend";
 import { CountsService } from "./backlog";
 import { BacklogPoller } from "./backlog-poller";
-import { ProcessReaper } from "./process-reaper";
+import { ProcessReaper, reapDeletedWorktreeOrphans } from "./process-reaper";
 import { sweepClaudeTmp, compileCacheDir, reapFallowCaches, pruneRepoWorktrees } from "./tmp-sweep";
 import { runSessionUsageBackfill } from "./usage-backfill";
 import { PreviewService } from "./preview";
@@ -414,6 +414,18 @@ const fireTmpSweep = (phase: "boot" | "daily") => {
       ),
     )
     .catch((err) => console.warn(`[tmp-sweep] ${phase} fallow/prune failed:`, err));
+
+  // Safety net for #1133: reap detached PPID-1 orphans (leaked `yes`/load-gen busy-loops)
+  // whose cwd is an already-deleted shepherd worktree — leaks the teardown sweep missed
+  // (pre-fix, or a removal path that didn't run it). Deferred off the synchronous boot
+  // path; never throws onto the loop.
+  void Promise.resolve()
+    .then(() => {
+      const { reaped } = reapDeletedWorktreeOrphans();
+      if (reaped > 0)
+        console.warn(`[tmp-sweep] ${phase}: reaped ${reaped} deleted-worktree orphan(s)`);
+    })
+    .catch((err) => console.warn(`[tmp-sweep] ${phase} orphan reap failed:`, err));
 };
 
 fireTmpSweep("boot");

--- a/src/process-reaper.ts
+++ b/src/process-reaper.ts
@@ -59,10 +59,28 @@ export interface ReaperProbes {
    * Falls back to `portsForPid` when absent.
    */
   socketInodesForPid?(pid: number): number[];
+  /**
+   * Parent pid for a single process (the `PPid:` field of /proc/<pid>/status), or
+   * null when unreadable. Used by the orphan sweeps to recognise a process the
+   * kernel has reparented to PID 1 (its launching shell exited) — the load-bearing
+   * "this is an orphan, not a live child" signal. Optional + read per-candidate so
+   * the hot scanProcs() pollers never pay for it.
+   */
+  ppidForPid?(pid: number): number | null;
 }
 
 // The agent itself runs `claude` with cwd == worktree; never offer to kill it.
 const AGENT_COMMS = new Set(["claude", "codex"]);
+
+// Path segment every shepherd session/review worktree lives under. The orphan
+// sweeps refuse to act on any path lacking it, so a mistaken caller passing a repo
+// root (or any non-worktree path) can never SIGKILL unrelated host processes.
+const WORKTREE_MARKER = "/.shepherd-worktrees/";
+
+// readlink(/proc/<pid>/cwd) appends this once the directory is unlinked; the kernel
+// keeps the inode alive for the still-running process. A "(deleted)" cwd under the
+// worktree marker is the unambiguous signal of an orphan whose worktree is already gone.
+const DELETED_SUFFIX = " (deleted)";
 
 /** Stable selection key — lets the client echo a choice back without trusting raw pids. */
 export function leftoverKey(l: Pick<Leftover, "kind" | "name" | "port" | "pid">): string {
@@ -146,6 +164,18 @@ function listeningInodeToPort(): Map<number, number> {
   return map;
 }
 
+/** Read a process's parent pid from the `PPid:` line of /proc/<pid>/status. */
+function readPpid(pid: number): number | null {
+  let text: string;
+  try {
+    text = readFileSync(`/proc/${pid}/status`, "utf8");
+  } catch {
+    return null; // process gone, or not ours to inspect
+  }
+  const m = text.match(/^PPid:\s+(\d+)/m);
+  return m ? Number(m[1]) : null;
+}
+
 /** Read the socket inodes held open by a single process from /proc/<pid>/fd. */
 function readSocketInodes(pid: number): number[] {
   let fds: string[];
@@ -211,6 +241,9 @@ const defaultProbes: ReaperProbes = {
   },
   socketInodesForPid(pid) {
     return readSocketInodes(pid);
+  },
+  ppidForPid(pid) {
+    return readPpid(pid);
   },
   readTranscript(path) {
     try {
@@ -311,6 +344,41 @@ export class ProcessReaper {
     return count;
   }
 
+  /**
+   * Layer A (worktree teardown): SIGKILL every orphaned (PPID-1) process whose cwd is
+   * under `worktreePath`. This is the leak the port-based class-2 detector misses — a
+   * detached busy-loop (`yes &`, a load generator) listens on nothing, so the
+   * listening-port test never flags it, yet it pegs cores forever once its launching
+   * shell exits and reparents it to PID 1 (issue #1133).
+   *
+   * The PPID-1 filter is the orphan signal: a live agent-managed process has its
+   * herdr/PTY as parent, not 1, so this never touches a running child — making it safe
+   * at the generic teardown chokepoint regardless of whether the agent was stopped
+   * first. `claude`/`codex` and the shepherd server itself are always spared.
+   *
+   * Defensive precondition: refuses any path not under `/.shepherd-worktrees/`, so a
+   * caller that mistakenly passes a repo root cannot sweep unrelated host processes.
+   *
+   * Returns the count of processes signalled (signals SENT, not deaths confirmed).
+   */
+  reapOrphansUnder(worktreePath: string): number {
+    const root = worktreePath.replace(/\/+$/, "");
+    if (!(root + "/").includes(WORKTREE_MARKER)) return 0;
+    let count = 0;
+    for (const p of this.probes.scanProcs()) {
+      if (p.pid === process.pid || AGENT_COMMS.has(p.comm)) continue;
+      if (!isUnder(p.cwd, root)) continue;
+      if ((this.probes.ppidForPid?.(p.pid) ?? null) !== 1) continue;
+      try {
+        this.probes.killPid(p.pid, "SIGKILL");
+        count++;
+      } catch {
+        /* best-effort: process may have already exited */
+      }
+    }
+    return count;
+  }
+
   /** Best-effort terminate each leftover (kill pid / run counter-command). */
   reap(leftovers: Leftover[]): void {
     for (const l of leftovers) {
@@ -322,6 +390,42 @@ export class ProcessReaper {
       }
     }
   }
+}
+
+/**
+ * Layer B (boot + daily safety net): SIGKILL every orphaned (PPID-1) process whose cwd
+ * resolves to an already-DELETED shepherd worktree (`…/.shepherd-worktrees/… (deleted)`).
+ *
+ * This catches leaks the teardown sweep (`reapOrphansUnder`) could not — anything that
+ * leaked before this fix existed, or whose worktree was removed by a path that did not
+ * run the teardown sweep. The "(deleted)" cwd + worktree marker + PPID-1 conjunction is
+ * unambiguous, so this carries zero false-positive risk: it acts only on processes
+ * whose working directory is a gone shepherd worktree and that the kernel has
+ * reparented to PID 1. `claude`/`codex` and the shepherd server itself are spared.
+ *
+ * It deliberately does NOT touch orphans whose worktree still exists on disk (a quiet
+ * but possibly-active session) — that needs liveness checks and is out of scope (#1133).
+ *
+ * Returns the count of processes signalled (signals SENT, not deaths confirmed).
+ */
+export function reapDeletedWorktreeOrphans(probes: ReaperProbes = defaultProbes): {
+  reaped: number;
+} {
+  let reaped = 0;
+  for (const p of probes.scanProcs()) {
+    if (p.pid === process.pid || AGENT_COMMS.has(p.comm)) continue;
+    if (!p.cwd.endsWith(DELETED_SUFFIX)) continue;
+    const realCwd = p.cwd.slice(0, -DELETED_SUFFIX.length);
+    if (!(realCwd + "/").includes(WORKTREE_MARKER)) continue;
+    if ((probes.ppidForPid?.(p.pid) ?? null) !== 1) continue;
+    try {
+      probes.killPid(p.pid, "SIGKILL");
+      reaped++;
+    } catch {
+      /* best-effort: process may have already exited */
+    }
+  }
+  return { reaped };
 }
 
 // ── batched port scan ─────────────────────────────────────────────────────────

--- a/src/service.ts
+++ b/src/service.ts
@@ -394,7 +394,11 @@ const ENGINEERING_POSTURE =
   "style. Delete only the imports/vars/functions YOUR change orphaned; for pre-existing unrelated " +
   "dead code, surface it rather than silently expanding the diff.\n" +
   "- Goal-driven execution: turn the task into explicit, verifiable success criteria up front, then " +
-  "loop until they actually pass — never declare work done before verifying against them.";
+  "loop until they actually pass — never declare work done before verifying against them.\n" +
+  "- Ephemeral scaffolding self-cleans: never leave a detached `&` background job (load generator, " +
+  "busy-loop, dev server, watcher) running past the step that needs it. Backgrounded jobs reparent to " +
+  "PID 1 when their shell exits and outlive you — silently burning CPU for days. Kill what you spawn in " +
+  "the SAME shell, or wrap a throwaway repro script so a `trap` reaps its jobs on exit.";
 
 /**
  * Fixed, repo-independent standing guidance injected into every spawn (issue #347, sourced from

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -7,6 +7,7 @@ import { timedAsync } from "./instrument";
 import { ensureShepherdExclude } from "./shepherd-exclude";
 import { removeWorktreeScratch } from "./tmp-sweep";
 import { upstreamStatus } from "./upstream-status";
+import { ProcessReaper } from "./process-reaper";
 
 const execFileAsync = promisify(execFile);
 
@@ -46,6 +47,9 @@ export interface ResolvedBase {
 }
 
 export class WorktreeMgr {
+  /** Injectable so tests can assert the teardown orphan sweep fires without real /proc. */
+  constructor(private reaper: ProcessReaper = new ProcessReaper()) {}
+
   private isGit(repoPath: string): boolean {
     try {
       execFileSync("git", ["rev-parse", "--is-inside-work-tree"], { cwd: repoPath, stdio: "pipe" });
@@ -499,6 +503,16 @@ export class WorktreeMgr {
   }
 
   remove(worktreePath: string, opts?: { branch?: string | null; baseBranch?: string }): void {
+    // Reap detached orphans (PPID-1 busy-loops/servers the agent left running) BEFORE
+    // unlinking the worktree, while their cwd still resolves to the real path so the
+    // sweep can match them (#1133). Best-effort: a sweep failure must never block
+    // teardown. reapOrphansUnder self-guards against non-worktree paths.
+    try {
+      const reaped = this.reaper.reapOrphansUnder(worktreePath);
+      if (reaped > 0) console.warn(`[worktree] reaped ${reaped} orphan(s) under ${worktreePath}`);
+    } catch (err) {
+      console.warn("[worktree] orphan sweep failed:", err);
+    }
     let mainRepo: string | null = null;
     if (existsSync(worktreePath)) {
       try {

--- a/test/process-reaper.test.ts
+++ b/test/process-reaper.test.ts
@@ -3,6 +3,7 @@ import {
   ProcessReaper,
   leftoverKey,
   scanClaudeAliveByWorktree,
+  reapDeletedWorktreeOrphans,
   type ReaperProbes,
 } from "../src/process-reaper";
 import { jsonlPathFor } from "../src/usage";
@@ -372,4 +373,118 @@ test("claude-alive: every supplied worktree appears as a key; empty input is fin
   expect(scanClaudeAliveByWorktree([], makeProbes()).size).toBe(0);
   const out = scanClaudeAliveByWorktree(["/wt/a"], makeProbes());
   expect(out.get("/wt/a")).toBe(false);
+});
+
+// ── #1133: orphan reaping (PPID-1 busy-loops the port-based detector misses) ──
+
+const WT = "/home/u/Work/.shepherd-worktrees/repo-x"; // a real worktree path (has the marker)
+
+// killPid spy: record (pid, signal) so tests can assert SIGKILL + exactly-who.
+function killSpy() {
+  const killed: { pid: number; signal?: NodeJS.Signals }[] = [];
+  return {
+    killed,
+    killPid: (pid: number, signal?: NodeJS.Signals) => killed.push({ pid, signal }),
+  };
+}
+
+test("reapOrphansUnder: SIGKILLs a PPID-1 non-agent orphan whose cwd is under the worktree", () => {
+  const k = killSpy();
+  const reaper = new ProcessReaper(
+    makeProbes({
+      scanProcs: () => [{ pid: 4242, cwd: WT, comm: "yes" }],
+      ppidForPid: () => 1,
+      killPid: k.killPid,
+    }),
+  );
+  expect(reaper.reapOrphansUnder(WT)).toBe(1);
+  expect(k.killed).toEqual([{ pid: 4242, signal: "SIGKILL" }]);
+});
+
+test("reapOrphansUnder: spares self, agent comm, non-orphan (PPID!=1), and out-of-worktree procs", () => {
+  const k = killSpy();
+  const reaper = new ProcessReaper(
+    makeProbes({
+      scanProcs: () => [
+        { pid: process.pid, cwd: WT, comm: "bun" }, // self
+        { pid: 11, cwd: WT, comm: "claude" }, // agent comm
+        { pid: 12, cwd: WT, comm: "node" }, // PPID != 1 → live child, not orphan
+        { pid: 13, cwd: "/home/u/Work/.shepherd-worktrees/other", comm: "yes" }, // other worktree
+      ],
+      ppidForPid: (pid) => (pid === 12 ? 9000 : 1),
+      killPid: k.killPid,
+    }),
+  );
+  expect(reaper.reapOrphansUnder(WT)).toBe(0);
+  expect(k.killed).toEqual([]);
+});
+
+test("reapOrphansUnder: refuses a non-worktree path (no /.shepherd-worktrees/) and kills nothing", () => {
+  const k = killSpy();
+  const reaper = new ProcessReaper(
+    makeProbes({
+      // A matching PPID-1 orphan is present, but the target path is a repo root.
+      scanProcs: () => [{ pid: 999, cwd: "/home/u/Work/repo", comm: "yes" }],
+      ppidForPid: () => 1,
+      killPid: k.killPid,
+    }),
+  );
+  expect(reaper.reapOrphansUnder("/home/u/Work/repo")).toBe(0);
+  expect(k.killed).toEqual([]);
+});
+
+test("reapOrphansUnder: when ppidForPid is absent it can't confirm orphanhood, so it kills nothing", () => {
+  const k = killSpy();
+  const reaper = new ProcessReaper(
+    makeProbes({
+      scanProcs: () => [{ pid: 5, cwd: WT, comm: "yes" }],
+      killPid: k.killPid, // makeProbes omits ppidForPid
+    }),
+  );
+  expect(reaper.reapOrphansUnder(WT)).toBe(0);
+  expect(k.killed).toEqual([]);
+});
+
+test("reapDeletedWorktreeOrphans: SIGKILLs a PPID-1 orphan whose cwd is a deleted shepherd worktree", () => {
+  const k = killSpy();
+  const { reaped } = reapDeletedWorktreeOrphans(
+    makeProbes({
+      scanProcs: () => [{ pid: 808, cwd: `${WT} (deleted)`, comm: "yes" }],
+      ppidForPid: () => 1,
+      killPid: k.killPid,
+    }),
+  );
+  expect(reaped).toBe(1);
+  expect(k.killed).toEqual([{ pid: 808, signal: "SIGKILL" }]);
+});
+
+test("reapDeletedWorktreeOrphans: spares a live (non-deleted) cwd, even under the worktree marker", () => {
+  const k = killSpy();
+  const { reaped } = reapDeletedWorktreeOrphans(
+    makeProbes({
+      scanProcs: () => [{ pid: 809, cwd: WT, comm: "yes" }], // still-existing worktree → out of scope
+      ppidForPid: () => 1,
+      killPid: k.killPid,
+    }),
+  );
+  expect(reaped).toBe(0);
+  expect(k.killed).toEqual([]);
+});
+
+test("reapDeletedWorktreeOrphans: spares a deleted cwd that isn't a shepherd worktree, the agent, PPID!=1, and self", () => {
+  const k = killSpy();
+  const { reaped } = reapDeletedWorktreeOrphans(
+    makeProbes({
+      scanProcs: () => [
+        { pid: 20, cwd: "/tmp/scratch (deleted)", comm: "yes" }, // deleted but not a worktree
+        { pid: 21, cwd: `${WT} (deleted)`, comm: "claude" }, // agent comm
+        { pid: 22, cwd: `${WT} (deleted)`, comm: "node" }, // PPID != 1
+        { pid: process.pid, cwd: `${WT} (deleted)`, comm: "bun" }, // self
+      ],
+      ppidForPid: (pid) => (pid === 22 ? 5000 : 1),
+      killPid: k.killPid,
+    }),
+  );
+  expect(reaped).toBe(0);
+  expect(k.killed).toEqual([]);
 });

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join, dirname, basename } from "node:path";
 import { execFileSync } from "node:child_process";
 import { WorktreeMgr } from "../src/worktree";
+import { ProcessReaper } from "../src/process-reaper";
 
 let repo: string;
 beforeEach(() => {
@@ -35,6 +36,24 @@ test("create makes an isolated worktree on a shepherd/ branch", () => {
     cwd: repo,
   }).toString();
   expect(branches).toContain("shepherd/repo-flatten");
+});
+
+test("remove() sweeps the worktree for orphaned processes before tearing it down (#1133)", () => {
+  const calls: string[] = [];
+  const stubReaper = {
+    reapOrphansUnder: (p: string) => {
+      // assert the worktree still exists when the sweep runs — it must reap BEFORE removal,
+      // so a process' cwd still resolves to the real path the sweep matches on.
+      expect(existsSync(p)).toBe(true);
+      calls.push(p);
+      return 0;
+    },
+  } as unknown as ProcessReaper;
+  const wt = new WorktreeMgr(stubReaper);
+  const r = wt.create(repo, "main", "reap-orphans");
+  wt.remove(r.worktreePath);
+  expect(calls).toEqual([r.worktreePath]);
+  expect(existsSync(r.worktreePath)).toBe(false);
 });
 
 test("currentBranch reports the worktree's checked-out branch and follows a rename", () => {


### PR DESCRIPTION
Closes #1133.

## Problem

34 PID-1-reparented `yes` load-generators from a #817 session pegged ~30 cores for **6 days**, undetected. Each `yes &` was backgrounded in a separate `bash -c`; when that shell exited the kernel reparented the job to PID 1, so it outlived the agent and the (later deleted) worktree. The existing port-based class-2 detector can't catch these — a busy-loop listens on no port, which is exactly the signal that detector keys on.

## Fix — three complementary layers

Reuses the existing `ProcessReaper` + injectable `ReaperProbes` machinery; the new methods drop the port test and key on the **PPID-1 orphan signal** instead.

- **A. Teardown sweep (primary).** `ProcessReaper.reapOrphansUnder(worktreePath)` SIGKILLs every PPID-1, non-agent (`comm ∉ {claude,codex}`), non-self process whose cwd is under the worktree. `WorktreeMgr.remove()` calls it **before** unlinking (so cwds still resolve for matching), best-effort so a sweep failure never blocks teardown.
- **B. Boot/daily safety net (deleted-cwd only).** `reapDeletedWorktreeOrphans()`, wired into `fireTmpSweep`, SIGKILLs PPID-1 orphans whose cwd is an already-**deleted** `.shepherd-worktrees/*` path — reaps anything that leaked before this fix or via a removal that didn't run the teardown sweep. Zero false-positive risk.
- **C. Guardrail.** One bullet appended to the universal `ENGINEERING_POSTURE` spawn directive: don't leave detached `&` jobs past the step that needs them; `trap`-self-clean throwaway repro scripts.

**Shared kill predicate (both sweeps):** `pid ≠ shepherd` ∧ `comm ∉ {claude,codex}` ∧ `ppid == 1` ∧ cwd-under-worktree (A) / deleted-`.shepherd-worktrees` cwd (B). Signal = **SIGKILL** (throwaway orphans under a worktree being/already destroyed). A new `ppidForPid` probe reads `/proc/<pid>/status` per-candidate — kept off the hot `scanProcs()` pollers.

**Defensive precondition (A):** `reapOrphansUnder` refuses any path lacking `/.shepherd-worktrees/`, so a future caller passing a repo root cannot SIGKILL unrelated host processes (mirrors the existing non-isolated guard in `scanWorktreeProcs`/`detect`).

## Known residual gaps (deliberate, flagged per house rules)

1. **Abandoned-but-on-disk worktrees** (session gone, worktree still on disk): out of scope — needs liveness/session-state checks and risks killing a legit backgrounded process in a quiet-but-active worktree.
2. **chdir-out orphans** (agent `cd`s out of the worktree before backgrounding): cwd is neither under the worktree nor a deleted `.shepherd-worktrees` path, so it leaks like #817. The cwd heuristic catches the dominant case (#817's jobs kept their cwd in the worktree). **`pgid` alternative declined:** Shepherd records no per-session pgid; agent shells run under herdr/PTY, each `bash -c` is its own process, and `setsid`-away jobs defeat group tracking. The robust fix is a per-session PID namespace — which the autonomous **membrane already provides** via bwrap `--unshare-pid`; the residual is only the trusted/attended path.
3. **Non-isolated sessions get no protection.** `service.ts` calls `worktree.remove()` only `if (s.isolated)`; a non-isolated session's `worktreePath` *is* the shared repo root, which we deliberately never sweep (it hosts the shepherd server + unrelated processes — a PPID-1 sweep there would be more dangerous than the leak).

**`PPID === 1` assumption:** holds only for host-reparented trusted-path spawns. Membrane orphans (bwrap `--unshare-pid` + `--die-with-parent`) are PPID ≠ 1 from the host and correctly skipped. A future subreaper / PID-namespace on the *trusted* path would silently defeat the predicate — documented in the code Risks so it can't regress unnoticed.

## Tests

- `reapOrphansUnder`: SIGKILLs a matching orphan; spares self / agent comm / PPID≠1 / out-of-worktree; **refuses a non-worktree path**; no-ops when `ppidForPid` is absent.
- `reapDeletedWorktreeOrphans`: SIGKILLs a deleted-worktree orphan; spares live cwd, deleted-but-non-worktree cwd, agent comm, PPID≠1, self.
- `WorktreeMgr.remove()` invokes the sweep (injected reaper), and does so while the worktree still exists.
- Full root suite green (4947 pass / 0 fail); `bun run lint`, `tsc --noEmit`, and `fallow audit --fail-on-issues` all pass.

Server-only change, no user-facing UX. `[no-feature-entry]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)