### PR TITLE
fix(learnings): boot reapOrphans for __distill__/__optimize__/__merge__ helpers (#1135)

### DIFF
--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -99,7 +99,7 @@ export interface DistillerDeps {
     | "retireLearning"
     | "getLearning"
   >;
-  herdr: Pick<HerdrDriver, "start" | "stop">;
+  herdr: Pick<HerdrDriver, "start" | "stop" | "list" | "closeTab">;
   scratch: { create: () => { dir: string }; remove: (dir: string) => void };
   onChange: () => void;
   model?: string | null;
@@ -290,6 +290,32 @@ export class DistillerService {
       startedAt: this.now(),
       signalIds: new Set(signals.map((s) => s.id)),
     });
+  }
+
+  /** Boot reconcile (issue #1135): close orphaned distiller tabs left by a PRIOR server
+   *  lifetime. `inflight` is memory-only, so a restart loses tracking of live runs; the
+   *  spawned interactive `claude` idles at the prompt forever after writing its output
+   *  (agent_status "done" = finished-turn, pane alive), and the husk-only tab reaper
+   *  (tab-reaper.ts) spares it as an alive (non-shell) `claude`. Scan herdr once for agents
+   *  whose name starts with DISTILL_LABEL and are NOT owned by a current-process inflight
+   *  run, and close their tabs. Name-based — no persisted state (the issue's preferred
+   *  approach); the prefix's underscores can't appear in a real session slug. */
+  reapOrphans(): void {
+    const ownedTerms = new Set(
+      [...this.inflight.values()].map((f) => f.terminalId).filter(Boolean),
+    );
+    let reaped = 0;
+    try {
+      for (const a of this.deps.herdr.list()) {
+        if (!a.name.startsWith(DISTILL_LABEL)) continue;
+        if (ownedTerms.has(a.terminalId)) continue; // spare a live run started by THIS process
+        this.deps.herdr.closeTab(a.tabId);
+        reaped++;
+      }
+    } catch (err) {
+      console.warn("[distill] reapOrphans:", err); // herdr may be unavailable at boot — no-op
+    }
+    if (reaped > 0) console.warn(`[distill] reapOrphans: closed ${reaped} orphan tab(s)`);
   }
 
   /** Finalize any run whose proposals file is ready or that timed out, then drain queue. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1436,6 +1436,7 @@ const distiller = new DistillerService({
   scratch: defaultScratch,
   onChange: () => events.emit("learnings:update", { pending: store.pendingLearningCount() }),
 });
+distiller.reapOrphans(); // issue #1135: close orphaned __distill__ tabs left by a prior lifetime
 setInterval(() => {
   if (maintenance.active) return;
   void distiller.tick();
@@ -1448,6 +1449,7 @@ const optimizer = new OptimizerService({
   promoter,
   onChange: () => events.emit("learnings:update", { pending: store.pendingLearningCount() }),
 });
+optimizer.reapOrphans(); // issue #1135: close orphaned __optimize__ tabs left by a prior lifetime
 setInterval(() => {
   if (maintenance.active) return;
   void optimizer.tick();
@@ -1461,6 +1463,7 @@ const mergeSuggest = new MergeSuggestionService({
   scratch: defaultMergeScratch,
   onChange: () => events.emit("learnings:update", { pending: store.pendingLearningCount() }),
 });
+mergeSuggest.reapOrphans(); // issue #1135: close orphaned __merge__ tabs left by a prior lifetime
 setInterval(() => {
   if (maintenance.active) return;
   void mergeSuggest.tick();

--- a/src/merge-suggest.ts
+++ b/src/merge-suggest.ts
@@ -68,7 +68,7 @@ export interface MergeSuggestionDeps {
     | "getMergePassSignature"
     | "setMergePassSignature"
   >;
-  herdr: Pick<HerdrDriver, "start" | "stop">;
+  herdr: Pick<HerdrDriver, "start" | "stop" | "list" | "closeTab">;
   scratch: { create: () => { dir: string }; remove: (dir: string) => void };
   onChange: () => void;
   model?: string | null;
@@ -281,6 +281,32 @@ export class MergeSuggestionService {
       members: new Map(input.map((l) => [l.id, l])),
       sig,
     });
+  }
+
+  /** Boot reconcile (issue #1135): close orphaned merge-suggestion tabs left by a PRIOR
+   *  server lifetime. `inflight` is memory-only, so a restart loses tracking of live runs;
+   *  the spawned interactive `claude` idles at the prompt forever after writing its output
+   *  (agent_status "done" = finished-turn, pane alive), and the husk-only tab reaper
+   *  (tab-reaper.ts) spares it as an alive (non-shell) `claude`. Scan herdr once for agents
+   *  whose name starts with MERGE_LABEL and are NOT owned by a current-process inflight run,
+   *  and close their tabs. Name-based — no persisted state (the issue's preferred approach);
+   *  the prefix's underscores can't appear in a real session slug. */
+  reapOrphans(): void {
+    const ownedTerms = new Set(
+      [...this.inflight.values()].map((f) => f.terminalId).filter(Boolean),
+    );
+    let reaped = 0;
+    try {
+      for (const a of this.deps.herdr.list()) {
+        if (!a.name.startsWith(MERGE_LABEL)) continue;
+        if (ownedTerms.has(a.terminalId)) continue; // spare a live run started by THIS process
+        this.deps.herdr.closeTab(a.tabId);
+        reaped++;
+      }
+    } catch (err) {
+      console.warn("[merge] reapOrphans:", err); // herdr may be unavailable at boot — no-op
+    }
+    if (reaped > 0) console.warn(`[merge] reapOrphans: closed ${reaped} orphan tab(s)`);
   }
 
   /** Finalize any run whose output file is ready or that timed out, then drain the queue. */

--- a/src/optimizer.ts
+++ b/src/optimizer.ts
@@ -58,7 +58,7 @@ export interface OptimizerDeps {
     SessionStore,
     "getLearning" | "listActiveLearnings" | "ineffectiveSignalsFor" | "reviseLearning"
   >;
-  herdr: Pick<HerdrDriver, "start" | "stop">;
+  herdr: Pick<HerdrDriver, "start" | "stop" | "list" | "closeTab">;
   scratch: { create: () => { dir: string }; remove: (dir: string) => void };
   promoter: Pick<Promoter, "resyncPromoted">;
   onChange: () => void;
@@ -265,6 +265,32 @@ export class OptimizerService {
       targetIds,
       promotedIds,
     });
+  }
+
+  /** Boot reconcile (issue #1135): close orphaned optimizer tabs left by a PRIOR server
+   *  lifetime. `inflight` is memory-only, so a restart loses tracking of live runs; the
+   *  spawned interactive `claude` idles at the prompt forever after writing its output
+   *  (agent_status "done" = finished-turn, pane alive), and the husk-only tab reaper
+   *  (tab-reaper.ts) spares it as an alive (non-shell) `claude`. Scan herdr once for agents
+   *  whose name starts with OPTIMIZE_LABEL and are NOT owned by a current-process inflight
+   *  run, and close their tabs. Name-based — no persisted state (the issue's preferred
+   *  approach); the prefix's underscores can't appear in a real session slug. */
+  reapOrphans(): void {
+    const ownedTerms = new Set(
+      [...this.inflight.values()].map((f) => f.terminalId).filter(Boolean),
+    );
+    let reaped = 0;
+    try {
+      for (const a of this.deps.herdr.list()) {
+        if (!a.name.startsWith(OPTIMIZE_LABEL)) continue;
+        if (ownedTerms.has(a.terminalId)) continue; // spare a live run started by THIS process
+        this.deps.herdr.closeTab(a.tabId);
+        reaped++;
+      }
+    } catch (err) {
+      console.warn("[optimize] reapOrphans:", err); // herdr may be unavailable at boot — no-op
+    }
+    if (reaped > 0) console.warn(`[optimize] reapOrphans: closed ${reaped} orphan tab(s)`);
   }
 
   /** Finalize any run whose output file is ready or that timed out, then drain queue. */

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -355,7 +355,12 @@ test("distiller increments ineffective for cited active rule ids with validated 
       retireLearning: () => null,
       getLearning: () => null,
     },
-    herdr: { start: () => ({ terminalId: "t1" }) as never, stop: () => {} },
+    herdr: {
+      start: () => ({ terminalId: "t1" }) as never,
+      stop: () => {},
+      list: () => [],
+      closeTab: () => {},
+    },
     scratch: { create: () => ({ dir: "/tmp/x" }), remove: () => {} },
     onChange: () => {},
     now: () => 1000,
@@ -1037,4 +1042,58 @@ test("reaffirm: proposedRules passed to writeSignals include proposed rules sort
   expect(capturedProposed[1]!.id).toBe(p1.id);
   // Should only contain id+rule (no other fields)
   expect(Object.keys(capturedProposed[0]!)).toEqual(["id", "rule"]);
+});
+
+// ── boot reapOrphans (issue #1135) ──────────────────────────────────────────
+
+test("reapOrphans closes orphaned __distill__ tabs, sparing unrelated + inflight-owned", () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+  const closed: string[] = [];
+  const listed = [
+    { name: DISTILL_LABEL + "deadbeef", terminalId: "orphan1", tabId: "tabO" },
+    { name: "my-feature-branch", terminalId: "u1", tabId: "tabU" },
+    { name: DISTILL_LABEL + "live0001", terminalId: "live1", tabId: "tabL" },
+  ];
+  const svc = new DistillerService({
+    store,
+    herdr: {
+      start: () => ({ terminalId: "live1" }),
+      stop: () => {},
+      list: () => listed,
+      closeTab: (id: string) => closed.push(id),
+    },
+    scratch: { create: () => ({ dir: "/s" }), remove: () => {} },
+    onChange: () => {},
+    now: () => 1000,
+    minSignals: 3,
+    writeSignals: () => {},
+    readProposals: () => null, // run stays in flight (not finalized)
+  } as never);
+  svc.distillNow("/r"); // in-flight run owns terminalId "live1"
+  svc.reapOrphans();
+  expect(closed).toEqual(["tabO"]); // orphan only — unrelated + in-flight-owned spared
+});
+
+test("reapOrphans is a no-op when herdr is unavailable", () => {
+  const store = new SessionStore(":memory:");
+  let closes = 0;
+  const svc = new DistillerService({
+    store,
+    herdr: {
+      start: () => ({ terminalId: "t" }),
+      stop: () => {},
+      list: () => {
+        throw new HerdrUnavailableError();
+      },
+      closeTab: () => {
+        closes++;
+      },
+    },
+    scratch: { create: () => ({ dir: "/s" }), remove: () => {} },
+    onChange: () => {},
+    now: () => 1000,
+  } as never);
+  expect(() => svc.reapOrphans()).not.toThrow();
+  expect(closes).toBe(0);
 });

--- a/test/merge-suggest.test.ts
+++ b/test/merge-suggest.test.ts
@@ -299,3 +299,60 @@ test("api-key mode without a configured key fails closed (no spawn)", () => {
     expect(started.length).toBe(0);
   });
 });
+
+// ── boot reapOrphans (issue #1135) ──────────────────────────────────────────
+
+test("reapOrphans closes orphaned __merge__ tabs, sparing unrelated + inflight-owned", () => {
+  const store = new SessionStore(":memory:");
+  seedActive(store, "/r", "Use bun, not npm");
+  seedActive(store, "/r", "Prefer bun over npm for installs");
+  const closed: string[] = [];
+  const listed = [
+    { name: MERGE_LABEL + "deadbeef", terminalId: "orphan1", tabId: "tabO" },
+    { name: "some-session", terminalId: "u1", tabId: "tabU" },
+    { name: MERGE_LABEL + "live0001", terminalId: "m1", tabId: "tabL" },
+  ];
+  const svc = new MergeSuggestionService({
+    store,
+    herdr: {
+      start: () => ({ terminalId: "m1" }),
+      stop: () => {},
+      list: () => listed,
+      closeTab: (t: string) => closed.push(t),
+    },
+    scratch: { create: () => ({ dir: "/s" }), remove: () => {} },
+    onChange: () => {},
+    now: () => 1000,
+    minRules: 2,
+    writeRules: () => {},
+    readOutput: () => null, // run stays in flight (not finalized)
+    log: () => {},
+  } as never);
+  svc.consider("/r"); // in-flight run owns terminalId "m1"
+  svc.reapOrphans();
+  expect(closed).toEqual(["tabO"]); // orphan only — unrelated + in-flight-owned spared
+});
+
+test("reapOrphans is a no-op when herdr is unavailable (merge-suggest)", () => {
+  const store = new SessionStore(":memory:");
+  let closes = 0;
+  const svc = new MergeSuggestionService({
+    store,
+    herdr: {
+      start: () => ({ terminalId: "t" }),
+      stop: () => {},
+      list: () => {
+        throw new Error("herdr down");
+      },
+      closeTab: () => {
+        closes++;
+      },
+    },
+    scratch: { create: () => ({ dir: "/s" }), remove: () => {} },
+    onChange: () => {},
+    now: () => 1000,
+    log: () => {},
+  } as never);
+  expect(() => svc.reapOrphans()).not.toThrow();
+  expect(closes).toBe(0);
+});

--- a/test/optimizer.test.ts
+++ b/test/optimizer.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
 import { OptimizerService, OPTIMIZE_LABEL, type OptimizerTarget } from "../src/optimizer";
 import { SessionStore } from "../src/store";
+import { HerdrUnavailableError } from "../src/herdr";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
 
 beforeEach(() => {
@@ -270,4 +271,60 @@ test("spawn argv follows the safe contract + unique __optimize__ name", () => {
   expect(write).toBeLessThan(mode);
   expect(argv).toContain('{"disableAllHooks":true}');
   expect(argv.length).toBeGreaterThan(mode + 2); // prompt trails dontAsk
+});
+
+// ── boot reapOrphans (issue #1135) ──────────────────────────────────────────
+
+test("reapOrphans closes orphaned __optimize__ tabs, sparing unrelated + inflight-owned", () => {
+  const store = new SessionStore(":memory:");
+  const id = seedActiveRule(store, "/r", "old rule");
+  flag(store, "/r", id);
+  const closed: string[] = [];
+  const listed = [
+    { name: OPTIMIZE_LABEL + "deadbeef", terminalId: "orphan1", tabId: "tabO" },
+    { name: "review TASK-09", terminalId: "u1", tabId: "tabU" },
+    { name: OPTIMIZE_LABEL + "live0001", terminalId: "live1", tabId: "tabL" },
+  ];
+  const svc = new OptimizerService({
+    store,
+    herdr: {
+      start: () => ({ terminalId: "live1" }),
+      stop: () => {},
+      list: () => listed,
+      closeTab: (t: string) => closed.push(t),
+    },
+    scratch: { create: () => ({ dir: "/s" }), remove: () => {} },
+    promoter: fakePromoter(),
+    onChange: () => {},
+    now: () => 1000,
+    writeInput: () => {},
+    readOutput: () => null, // run stays in flight (not finalized)
+  } as never);
+  svc.optimizeOne(id); // in-flight run owns terminalId "live1"
+  svc.reapOrphans();
+  expect(closed).toEqual(["tabO"]); // orphan only — unrelated + in-flight-owned spared
+});
+
+test("reapOrphans is a no-op when herdr is unavailable (optimizer)", () => {
+  const store = new SessionStore(":memory:");
+  let closes = 0;
+  const svc = new OptimizerService({
+    store,
+    herdr: {
+      start: () => ({ terminalId: "t" }),
+      stop: () => {},
+      list: () => {
+        throw new HerdrUnavailableError();
+      },
+      closeTab: () => {
+        closes++;
+      },
+    },
+    scratch: { create: () => ({ dir: "/s" }), remove: () => {} },
+    promoter: fakePromoter(),
+    onChange: () => {},
+    now: () => 1000,
+  } as never);
+  expect(() => svc.reapOrphans()).not.toThrow();
+  expect(closes).toBe(0);
 });


### PR DESCRIPTION
Closes #1135.

## Problem
The three learnings helpers (`distiller`, `optimizer`, `merge-suggest`) track in-flight runs only in a **memory-only `inflight` map**. On a server restart that tracking is lost, so:

- `tick()` (the 30s finalizer) never sees the prior-lifetime runs → never calls `herdr.stop`.
- Each run's spawned `claude` is **interactive** (`--permission-mode dontAsk`, no `-p`), so after writing its output it idles at the prompt forever (`agent_status:"done"` = finished-turn, pane alive).
- `reapOrphanTabs` (`src/tab-reaper.ts`) only closes a tab once its pane decays to a shell-only husk; an idle-but-alive `claude` is a non-shell proc, so it's classified `sparedLive` and spared.

Result: `__distill__<hex>` / `__optimize__<hex>` / `__merge__<hex>` agents pile up monotonically until manually reaped. PR #750's unique per-run names made it worse — pre-#750 a new run's shared name collided with the orphan and herdr's collision-retry evicted it; now nothing ever collides.

## Fix
Mirror the existing reviewer (`reviewService.reapOrphans`) / doc-agent (`docAgent.reapOrphans`) boot reconcile, adapted to these helpers' shape:

- Add a **name-based** `reapOrphans()` to each of the three services. It scans `herdr.list()` once for agents whose name `startsWith` the helper's exported `*_LABEL` and are **not** owned by a current-process `inflight` run (by `terminalId`), and `closeTab`s them. Best-effort: a herdr-unavailable `list()` at boot is caught and no-ops.
- Widen each service's `herdr` dep `Pick` to add `"list" | "closeTab"`.
- Call `distiller.reapOrphans()` / `optimizer.reapOrphans()` / `mergeSuggest.reapOrphans()` once at boot in `index.ts`, right after each service is constructed.

A **name-based scan** (no new persisted-spawns table) is the issue's explicitly-preferred approach — an orphan has already written or abandoned its output, so closing the idle tab is the whole job; no cross-restart timeout accounting is needed.

The `ownedTerms` guard means a run started by the **current** process is never reaped (at boot `inflight` is empty, so every matching tab is an orphan).

## Scope
Learnings trio only, per the issue's "Fix (handoff)". `review`/`plan-gate`/`pr-critic` already boot-reconcile; `recap`/`rundown` persist `reviewer_spawns` rows; `namer` is a short-lived `-p` spawn. The leaked `autopilot <id>` agents (@scoop's diagnostic) leak by the same mechanism but are a long-lived session driver where the "not in inflight" reap signal is unsafe — split out to **#1147** for a fix with autopilot-specific ownership reasoning.

## Tests
Per service (`test/{distiller,optimizer,merge-suggest}.test.ts`):
- **orphan closed** — a listed `*_LABEL` agent absent from `inflight` has its tab closed.
- **unrelated spared** — a real session-slug / `review TASK-09` agent is never closed.
- **in-flight-owned spared** — a seeded in-flight run (its `terminalId` present in the live list) is **not** closed (the issue's explicit verification ask).
- **herdr-unavailable no-throw** — `list()` throwing does not throw and closes nothing.

## Verification
- `bun run lint` clean; `bunx tsc --noEmit` clean.
- `bun test ./test` — 4953 pass / 0 fail (incl. 6 new tests).
- `bunx fallow@2.97.0 audit --base origin/main --fail-on-issues` — exit 0 (the 3 near-identical `reapOrphans` methods register as a duplication **warn**; these services are established structural siblings that already duplicate `health`/`tick`/`begin`, and mirroring the pattern across all three is what the issue mandates).

No user-facing strings (server-only plumbing) → i18n/feature-catalog/glossary gates N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)