### PR TITLE
fix(onboarding): unbreak harness + update.sh past the operator-auth gate (#1112)

### DIFF
--- a/ci/onboarding-harness/probe.ts
+++ b/ci/onboarding-harness/probe.ts
@@ -7,16 +7,26 @@ const BOOT_POLL_CEILING = 120; // seconds the poll waits for the HTTP API (was 6
 const SHEPHERD_LOG = "/var/log/shepherd.log"; // detached server's stdout+stderr
 const LOG_TAIL_LINES = 60; // lines of the boot log appended to a failure message
 
+/** Operator bearer token the harness boots Shepherd with so it can read the GATED
+ *  diagnostics snapshot. Single-operator auth (#1079/#1081) gates the whole `/api/*`
+ *  surface once `config.cookieSecret` is bootstrapped (always, at boot), so an
+ *  un-credentialed `/api/diagnostics` now 401s. The harness owns both ends — it sets
+ *  `SHEPHERD_TOKEN` (→ `config.token`) on the booted server (or the unit's
+ *  `~/.shepherd/env`) and sends `Authorization: Bearer ${HARNESS_TOKEN}` on the
+ *  snapshot probe (checkAuth's bearer branch). Liveness uses the public `/api/health`
+ *  and needs NO token. A fixed in-repo constant is correct here: this is test infra,
+ *  not a secret, and timing-safe compare only needs the two ends to match. #1112 */
+export const HARNESS_TOKEN = "onboarding-harness-probe-token";
+
 /** Start Shepherd detached inside the instance and poll until its HTTP API
  *  answers (or time out). Degraded boots are expected — we only need the server
  *  process up far enough to serve `/api/diagnostics`.
  *
- *  AUTH (point 7): `GET /api/diagnostics` passes through `checkAuth`, which only
- *  authorizes when `config.token` (`SHEPHERD_TOKEN`) is null. We boot with the
- *  var explicitly UNSET (`env -u SHEPHERD_TOKEN`) so the plain `curl` probe below
- *  is authorized — the harness controls the env, so this is safe and the simplest
- *  correct option. (If a future scenario needs a token, the probe must add
- *  `-H "Authorization: Bearer $SHEPHERD_TOKEN"` instead.) */
+ *  AUTH (#1112): single-operator auth (#1079/#1081) gates `/api/*`, so the boot poll
+ *  hits the PUBLIC liveness route `/api/health` (pollApiCmd) — no credential — and the
+ *  GATED diagnostics snapshot (probeDiagnostics) is authorized by a bearer token. We
+ *  therefore boot WITH `SHEPHERD_TOKEN=${HARNESS_TOKEN}` set (NOT unset) so the server's
+ *  `config.token` matches the `Authorization: Bearer` header the snapshot probe sends. */
 export async function bootShepherd(driver: IncusDriver, name: string): Promise<void> {
   // The launch command. `redirect` is the shell redirect for the server's log:
   // - `>`  truncates — the FIRST launch starts a clean log.
@@ -30,8 +40,10 @@ export async function bootShepherd(driver: IncusDriver, name: string): Promise<v
   // - PATH adds ~/.local/bin + ~/.bun/bin so binaries a remediation installs there
   //   (node symlink, claude, herdr) are visible to the running server's probes,
   //   which resolve each tool via PATH on every `?refresh=1`.
+  // - SHEPHERD_TOKEN=${HARNESS_TOKEN}: set (not unset) so the gated diagnostics probe
+  //   authorizes via `Authorization: Bearer` (single-operator auth #1081). #1112
   const launch = (redirect: ">" | ">>"): string =>
-    `cd ${SHEPHERD_DIR} && setsid env -u SHEPHERD_TOKEN ` +
+    `cd ${SHEPHERD_DIR} && setsid env SHEPHERD_TOKEN=${HARNESS_TOKEN} ` +
     `PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" ` +
     `~/.bun/bin/bun src/index.ts ${redirect}${SHEPHERD_LOG} 2>&1 </dev/null &`;
 
@@ -72,10 +84,13 @@ export async function bootShepherd(driver: IncusDriver, name: string): Promise<v
 }
 
 /** The poll command shared by the manual-boot retry path and `waitForApi`: poll
- *  the HTTP API until it answers or the ceiling elapses (degraded boots are
- *  expected — we only need the server up far enough to serve /api/diagnostics). */
+ *  the server until it answers or the ceiling elapses (degraded boots are expected —
+ *  we only need the process up far enough to serve HTTP). Hits the PUBLIC `/api/health`
+ *  liveness route (#1112): single-operator auth (#1081) gates `/api/diagnostics`, so an
+ *  un-credentialed poll of it now 401s and `curl -sf` would never succeed; health is
+ *  auth-exempt and needs no token. */
 const pollApiCmd = (): string =>
-  `for i in $(seq 1 ${BOOT_POLL_CEILING}); do curl -sf localhost:${PORT}/api/diagnostics >/dev/null 2>&1 && exit 0; sleep 1; done; exit 1`;
+  `for i in $(seq 1 ${BOOT_POLL_CEILING}); do curl -sf localhost:${PORT}/api/health >/dev/null 2>&1 && exit 0; sleep 1; done; exit 1`;
 
 /** Best-effort: append a tail of the boot log to `base`. On any failure (exec
  *  throws, non-zero, or empty/whitespace-only log) returns the bare `base` so the
@@ -120,7 +135,9 @@ export async function assertUnitActive(driver: IncusDriver, name: string): Promi
   }
 }
 
-/** Capture a fresh diagnostics snapshot from inside the instance. */
+/** Capture a fresh diagnostics snapshot from inside the instance. `/api/diagnostics`
+ *  is GATED by single-operator auth (#1081), so authorize with the operator bearer the
+ *  harness boots Shepherd with (HARNESS_TOKEN → config.token). #1112 */
 export async function probeDiagnostics(
   driver: IncusDriver,
   name: string,
@@ -128,7 +145,7 @@ export async function probeDiagnostics(
   const r = await driver.exec(name, [
     "sh",
     "-c",
-    `curl -s localhost:${PORT}/api/diagnostics?refresh=1`,
+    `curl -s -H "Authorization: Bearer ${HARNESS_TOKEN}" localhost:${PORT}/api/diagnostics?refresh=1`,
   ]);
   if (r.code !== 0 || !r.stdout.trim()) {
     throw new Error(`diagnostics probe failed in ${name}: ${r.stderr || "empty"}`);

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -5,7 +5,13 @@ import { dirname, join } from "node:path";
 import { IncusDriver } from "./incus";
 import { SCENARIOS } from "./scenarios";
 import { seedInstance } from "./seed";
-import { assertUnitActive, bootShepherd, probeDiagnostics, waitForApi } from "./probe";
+import {
+  assertUnitActive,
+  bootShepherd,
+  HARNESS_TOKEN,
+  probeDiagnostics,
+  waitForApi,
+} from "./probe";
 import { applyAgent, applyVerbatim } from "./apply";
 import { assertDetection } from "./assert";
 import { buildGapReport, gateGapScenarios, statusDescription } from "./report";
@@ -99,6 +105,14 @@ const INSTALL_SERVICE_CMD =
   "XDG_RUNTIME_DIR=/run/user/0 USER=root " +
   "SHEPHERD_SRC=/opt/shepherd SHEPHERD_DIR=/opt/shepherd bash /root/install.sh";
 
+/** Seed the operator bearer into the systemd unit's EnvironmentFile BEFORE install
+ *  (#1112). The unit owns the process and reads its env from `EnvironmentFile=-%h/.shepherd/env`
+ *  (%h=/root), NOT from INSTALL_SERVICE_CMD's exec env — so to let the GATED diagnostics
+ *  probe authorize (probeDiagnostics sends `Authorization: Bearer ${HARNESS_TOKEN}`), the
+ *  token must land in that file so the started unit's `config.token` matches. provision's
+ *  `mkdir -p ~/.shepherd` is idempotent and never clobbers this file. */
+const SEED_UNIT_TOKEN_SCRIPT = `mkdir -p /root/.shepherd && printf 'SHEPHERD_TOKEN=%s\\n' '${HARNESS_TOKEN}' > /root/.shepherd/env`;
+
 /** Inverse flow PLUS the real systemd USER-UNIT lifecycle: bare host → git-checkout
  *  /opt/shepherd → enable-linger + user bus → real deploy/install.sh THROUGH the
  *  service path → assert the `shepherd` unit is active → health-check through the
@@ -125,6 +139,15 @@ async function runInstallLifecycleE2E(
   const bus = await driver.exec(scenario.id, ["sh", "-c", BUS_ESTABLISH_SCRIPT]);
   if (bus.code !== 0) {
     throw new Error(`user bus did not come up in ${scenario.id}:\n${bus.stderr || bus.stdout}`);
+  }
+
+  // Seed the unit's EnvironmentFile token before install so the started service is
+  // bearer-authorizable for the gated diagnostics probe (#1112).
+  const envSeed = await driver.exec(scenario.id, ["sh", "-c", SEED_UNIT_TOKEN_SCRIPT]);
+  if (envSeed.code !== 0) {
+    throw new Error(
+      `unit token seed failed in ${scenario.id}:\n${envSeed.stderr || envSeed.stdout}`,
+    );
   }
 
   const install = await driver.exec(scenario.id, ["sh", "-c", INSTALL_SERVICE_CMD]);

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -77,9 +77,12 @@ note "restarting $UNIT"
 systemctl --user restart "$UNIT"
 
 # ── health check ───────────────────────────────────────────────────────────────
+# Hit the PUBLIC liveness route, not /api/sessions: single-operator auth (#1079/#1081) gates
+# the whole /api/* surface, so an un-credentialed deploy probe of a gated route now 401s
+# (never 200). /api/health is auth-exempt and proves the restarted server serves HTTP. #1112
 note "health check"
 for i in $(seq 1 10); do
-  code="$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 3 "http://127.0.0.1:${PORT}/api/sessions" 2>/dev/null || true)"
+  code="$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 3 "http://127.0.0.1:${PORT}/api/health" 2>/dev/null || true)"
   if [[ "$code" == "200" ]]; then
     printf '\033[32m✓ shepherd healthy on :%s (HTTP 200)\033[0m\n' "$PORT"
     exit 0

--- a/src/server.ts
+++ b/src/server.ts
@@ -400,6 +400,9 @@ function isPublicRequest(req: Request): boolean {
   const path = new URL(req.url).pathname;
   if (req.method === "POST" && path === "/api/login") return true;
   if (req.method === "GET" || req.method === "HEAD") {
+    // Public liveness (handleHealth): an un-credentialed probe deploy/update.sh + the
+    // onboarding harness can hit BEFORE login. Exempt it ahead of the /api reject below.
+    if (path === "/api/health") return true;
     if (path.startsWith("/api")) return false;
     if (path === "/events" || path.startsWith("/pty/")) return false;
     return true; // static SPA shell
@@ -4230,6 +4233,16 @@ function handlePing({ req, parts }: Ctx): Response | null {
   return json({ ok: true });
 }
 
+// Public liveness probe (issue #1112) — DISTINCT from handlePing on purpose. `handlePing`
+// is a POST behind checkAuth + checkOrigin (CSRF): a probe for an already-logged-in client.
+// This is the opposite: an un-credentialed GET that answers BEFORE login, so deploy/update.sh's
+// health check and the onboarding harness's boot poll can confirm the server serves HTTP
+// without a cookie/token (isPublicRequest exempts exactly this method+path). Discloses nothing.
+function handleHealth({ req, parts }: Ctx): Response | null {
+  if (req.method !== "GET" || parts[0] !== "api" || parts[1] !== "health" || parts[2]) return null;
+  return json({ ok: true });
+}
+
 // ── Epic API routes ──────────────────────────────────────────────────────────
 
 /** Build a default EpicRun from repo + parent when no stored run exists. */
@@ -5017,6 +5030,7 @@ const ROUTE_HANDLERS = [
   handleLogout,
   handleMe,
   handlePing,
+  handleHealth,
   handleGitSnapshot,
   handleActivitySnapshot,
   handleClaudeAliveSnapshot,

--- a/src/server.ts
+++ b/src/server.ts
@@ -4235,12 +4235,21 @@ function handlePing({ req, parts }: Ctx): Response | null {
 
 // Public liveness probe (issue #1112) — DISTINCT from handlePing on purpose. `handlePing`
 // is a POST behind checkAuth + checkOrigin (CSRF): a probe for an already-logged-in client.
-// This is the opposite: an un-credentialed GET that answers BEFORE login, so deploy/update.sh's
+// This is the opposite: an un-credentialed GET/HEAD that answers BEFORE login, so deploy/update.sh's
 // health check and the onboarding harness's boot poll can confirm the server serves HTTP
 // without a cookie/token (isPublicRequest exempts exactly this method+path). Discloses nothing.
+// Answers HEAD as well as GET — isPublicRequest exempts both, so a HEAD must not fall through
+// to the /api 404 (a liveness monitor probing with HEAD expects a bodyless 200).
 function handleHealth({ req, parts }: Ctx): Response | null {
-  if (req.method !== "GET" || parts[0] !== "api" || parts[1] !== "health" || parts[2]) return null;
-  return json({ ok: true });
+  if (
+    (req.method !== "GET" && req.method !== "HEAD") ||
+    parts[0] !== "api" ||
+    parts[1] !== "health" ||
+    parts[2]
+  ) {
+    return null;
+  }
+  return req.method === "HEAD" ? new Response(null, { status: 200 }) : json({ ok: true });
 }
 
 // ── Epic API routes ──────────────────────────────────────────────────────────

--- a/test/onboarding-harness/install-lifecycle.test.ts
+++ b/test/onboarding-harness/install-lifecycle.test.ts
@@ -62,6 +62,13 @@ describe("install-e2e-service runScenario (lifecycle)", () => {
     expect(bus).toBeDefined();
     expect(bus!).toContain("/run/user/0/bus");
 
+    // #1112: the unit's EnvironmentFile is seeded with the operator bearer BEFORE install,
+    // so the started service's config.token matches the gated diagnostics probe's bearer.
+    const envSeed = flat.find((c) => c.startsWith("exec") && c.includes("/root/.shepherd/env"));
+    expect(envSeed).toBeDefined();
+    expect(envSeed!).toContain("SHEPHERD_TOKEN="); // written into the unit's EnvironmentFile
+    expect(envSeed!).toContain("onboarding-harness-probe-token");
+
     // install.sh THROUGH the service path: correct env, and NO SHEPHERD_NO_SERVICE.
     const install = flat.find((c) => c.startsWith("exec") && c.includes("bash /root/install.sh"));
     expect(install).toBeDefined();
@@ -78,10 +85,11 @@ describe("install-e2e-service runScenario (lifecycle)", () => {
     // health-check through the running unit + probe.
     expect(flat.some((c) => c.includes("/api/diagnostics?refresh=1"))).toBe(true);
 
-    // ORDER: git-checkout → bus → install → is-active.
+    // ORDER: git-checkout → bus → env-seed → install → is-active.
     const idx = (needle: string) => flat.findIndex((c) => c.includes(needle));
     expect(idx("git init -q -b main")).toBeLessThan(idx("loginctl enable-linger root"));
-    expect(idx("loginctl enable-linger root")).toBeLessThan(idx("bash /root/install.sh"));
+    expect(idx("loginctl enable-linger root")).toBeLessThan(idx("/root/.shepherd/env"));
+    expect(idx("/root/.shepherd/env")).toBeLessThan(idx("bash /root/install.sh"));
     expect(idx("bash /root/install.sh")).toBeLessThan(idx("systemctl --user is-active shepherd"));
 
     // outcome

--- a/test/onboarding-harness/probe.test.ts
+++ b/test/onboarding-harness/probe.test.ts
@@ -53,6 +53,19 @@ describe("bootShepherd", () => {
     expect(boot).not.toContain("run start");
     expect(boot).toContain("setsid"); // survives the exec session
     expect(boot).toContain(".local/bin"); // remediation installs resolve on PATH
+    // #1112: boots WITH a bearer token (not unset) so the gated diagnostics probe authorizes.
+    expect(boot).toContain("SHEPHERD_TOKEN=onboarding-harness-probe-token");
+    expect(boot).not.toContain("env -u SHEPHERD_TOKEN");
+  });
+
+  // #1112: liveness polls the PUBLIC /api/health, never the now-gated /api/diagnostics.
+  it("polls the public /api/health liveness route, not the gated diagnostics route", async () => {
+    const { run, calls } = dispatcher({ launch: OK, poll: OK });
+    const d = new IncusDriver(run, "shep-onb-");
+    await bootShepherd(d, "node-too-old");
+    const poll = calls.find((c) => kindOf(c) === "poll")!.join(" ");
+    expect(poll).toContain("/api/health");
+    expect(poll).not.toContain("/api/diagnostics");
   });
 
   // (a) the poll ceiling was widened 60 → 120.
@@ -138,5 +151,7 @@ describe("probeDiagnostics", () => {
     const cmd = calls[0]!.join(" ");
     expect(cmd).toContain("curl");
     expect(cmd).toContain("/api/diagnostics?refresh=1");
+    // #1112: the gated snapshot carries the operator bearer the harness booted with.
+    expect(cmd).toContain("Authorization: Bearer onboarding-harness-probe-token");
   });
 });

--- a/test/server-auth.test.ts
+++ b/test/server-auth.test.ts
@@ -108,6 +108,20 @@ test("exemption: a static-shell GET is not gated (no 401)", async () => {
   expect(res.status).not.toBe(401); // serveStatic owns it (200 or 404), never the gate
 });
 
+test("exemption: GET /api/health is public 200 WHILE /api/diagnostics still 401s — same app (#1112)", async () => {
+  // Locks the exemption's NARROWNESS: in one bootstrapped app (gate active), the
+  // un-credentialed liveness route answers while a sibling gated /api route does not.
+  const app = makeApp(makeDeps());
+  const health = await app.fetch(new Request("http://x/api/health"));
+  expect(health.status).toBe(200);
+  expect(await health.json()).toEqual({ ok: true });
+  // /api/diagnostics is NOT exempt: an un-credentialed GET is rejected by checkAuth
+  // (before its handler — so it 401s even though deps.diagnostics is unwired here).
+  const diag = await app.fetch(new Request("http://x/api/diagnostics"));
+  expect(diag.status).toBe(401);
+  expect(await diag.json()).toEqual({ error: "unauthorized" });
+});
+
 test("exemption: POST /api/login is reachable un-credentialed; wrong password → handler 401", async () => {
   const app = makeApp(makeDeps());
   const res = await app.fetch(

--- a/test/server-auth.test.ts
+++ b/test/server-auth.test.ts
@@ -115,6 +115,10 @@ test("exemption: GET /api/health is public 200 WHILE /api/diagnostics still 401s
   const health = await app.fetch(new Request("http://x/api/health"));
   expect(health.status).toBe(200);
   expect(await health.json()).toEqual({ ok: true });
+  // HEAD is exempt too (isPublicRequest covers GET+HEAD) → bodyless 200, NOT the /api 404.
+  const headRes = await app.fetch(new Request("http://x/api/health", { method: "HEAD" }));
+  expect(headRes.status).toBe(200);
+  expect(await headRes.text()).toBe("");
   // /api/diagnostics is NOT exempt: an un-credentialed GET is rejected by checkAuth
   // (before its handler — so it 401s even though deps.diagnostics is unwired here).
   const diag = await app.fetch(new Request("http://x/api/diagnostics"));


### PR DESCRIPTION
## Why

Closes #1112. The nightly onboarding harness went **0/9** and the report's BOOT-CRASH log tails are misleading: the `herdr ENOENT` ("skipping tick") and `ui/build/index.html` lines are **pre-existing, tolerated noise**, not the failure.

**Real cause:** single-operator auth (#1079/**#1081**) gates the entire `/api/*` surface via `checkAuth`. `bootstrapAuth` always provisions a `cookieSecret` on boot, so the gate is live on every fresh host. Both the harness and `update.sh` probe the API **un-credentialed** → 401:

- `probe.ts` polls `GET /api/diagnostics` → 401 → all 7 BOOT scenarios + both install-e2e scenarios report "Shepherd did not come up".
- `update.sh` health-checks `GET /api/sessions` → 401 → `install-e2e-service` fails ("did not return 200 within 10s"). This means **every real `bun run update` deploy is currently broken** post-#1081 — the harness correctly caught a production regression.

## What

**Liveness stays public; the one sensitive call authenticates.**

- **server:** add public `GET /api/health` → `200 {ok:true}`, exempted in `isPublicRequest`. It is **deliberately distinct from `handlePing`** (`POST /api/ping`, which is auth+CSRF-origin **gated** — a probe for an already-logged-in client). Folding a public GET into `handlePing` would relax that route's security contract, so `handleHealth` is a separate route (cross-referenced in a code comment per house rules). `/api/diagnostics` stays gated (it discloses host environment).
- **update.sh:** health check `/api/sessions` → public `/api/health`. Fixes prod `bun run update` too.
- **harness:** boot/liveness poll → public `/api/health` (no token); the **gated** diagnostics snapshot authorizes with an operator **bearer token** — exactly the path `probe.ts` already documented. `bootShepherd` now boots **with** `SHEPHERD_TOKEN` set (was `env -u`); the service-lifecycle path seeds the unit's `~/.shepherd/env` (its `EnvironmentFile`) so the started service's `config.token` matches. **Rewrote the now-false AUTH doc-comment** in `probe.ts` that documented the opposite (token-unset) contract.

## Tests

- `test/server-auth.test.ts` — exemption **narrowness**: in one bootstrapped app (gate active), `GET /api/health` un-credentialed → `200 {ok:true}` **while** `GET /api/diagnostics` un-credentialed → `401`. (Verified there is no blanket "every `/api/*` is gated" assertion to break.)
- Harness tests assert: boot poll hits `/api/health` not `/api/diagnostics`; `bootShepherd` sets `SHEPHERD_TOKEN` (not `env -u`); `probeDiagnostics` sends `Authorization: Bearer`; the lifecycle seeds the unit token before install.

## Verification

`bunx tsc --noEmit`, `bun run lint`, `bun test ./test` (4949 pass / 0 fail), harness suite (72 pass), and `fallow audit` (no issues in changed files) all green locally. Pre-push gates passed.

## Notes

- Adds exactly one unauthenticated route returning `{ok:true}` (no host data) — a deliberate, audited liveness exemption.
- Server/infra fix, no user-facing UX → no feature-catalog entry, no i18n. `[no-feature-entry]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)