### PR TITLE
refactor(learnings): collapse route→store orchestration behind service seam (#1092)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,8 @@ import { generateName } from "./namer";
 import { llmName } from "./namer-llm";
 import { EventHub } from "./events";
 import { SessionService } from "./service";
+import { LearningsService } from "./learnings-service";
+import { RepoConfigService } from "./repo-config-service";
 import { StatusPoller } from "./poller";
 import { PrPoller } from "./pr-poller";
 import { resolveDiffBase } from "./diff-base";
@@ -358,6 +360,12 @@ const service = new SessionService({
       () => {},
     ),
 });
+
+// Deep modules for the learnings + repo-config route seams (#1092). Singletons so every
+// route + every background onChange below emit through the SAME instance; the server's
+// total accessors return these when injected via appDeps.
+const learningsSvc = new LearningsService(store, events);
+const repoConfigSvc = new RepoConfigService(store);
 
 // Build-queue reconciliation nudge: settled-idle backstop to the forward-fill cascade in
 // store.setBuildStepStatus. Steers a drifted, settled-idle session to post its progress.
@@ -1434,7 +1442,7 @@ const distiller = new DistillerService({
   store,
   herdr,
   scratch: defaultScratch,
-  onChange: () => events.emit("learnings:update", { pending: store.pendingLearningCount() }),
+  onChange: () => learningsSvc.emitPending(),
 });
 distiller.reapOrphans(); // issue #1135: close orphaned __distill__ tabs left by a prior lifetime
 setInterval(() => {
@@ -1447,7 +1455,7 @@ const optimizer = new OptimizerService({
   herdr,
   scratch: defaultOptimizerScratch,
   promoter,
-  onChange: () => events.emit("learnings:update", { pending: store.pendingLearningCount() }),
+  onChange: () => learningsSvc.emitPending(),
 });
 optimizer.reapOrphans(); // issue #1135: close orphaned __optimize__ tabs left by a prior lifetime
 setInterval(() => {
@@ -1461,7 +1469,7 @@ const mergeSuggest = new MergeSuggestionService({
   store,
   herdr,
   scratch: defaultMergeScratch,
-  onChange: () => events.emit("learnings:update", { pending: store.pendingLearningCount() }),
+  onChange: () => learningsSvc.emitPending(),
 });
 mergeSuggest.reapOrphans(); // issue #1135: close orphaned __merge__ tabs left by a prior lifetime
 setInterval(() => {
@@ -1556,7 +1564,7 @@ const runDailySweep = () => {
   // nudge clients (banner refresh) when something actually changed.
   const retired = runAutoRetire({ store, optimizer });
   if (retired.length > 0) {
-    events.emit("learnings:update", { pending: store.pendingLearningCount() });
+    learningsSvc.emitPending();
     // Best-effort push so operators learn of background retirements without opening the
     // drawer (issue #852). One summary push across all repos; suppressed while the app is
     // active and for devices that muted the "agent" category. Guarded so a rejection can't
@@ -1579,7 +1587,7 @@ const runDailySweep = () => {
   const reaped = runReapStaleTrials({ store });
   const expired = runAutoExpire({ store });
   if (trialed.length + reaped.length + expired.length > 0) {
-    events.emit("learnings:update", { pending: store.pendingLearningCount() });
+    learningsSvc.emitPending();
   }
   if (trialed.length > 0) {
     // Best-effort push so operators learn of background trials without opening the drawer.
@@ -1763,6 +1771,8 @@ backlogPoller.start();
 const appDeps: AppDeps = {
   store,
   service,
+  learnings: learningsSvc,
+  repoConfig: repoConfigSvc,
   events,
   usageLimits,
   usageRollup,

--- a/src/learnings-service.ts
+++ b/src/learnings-service.ts
@@ -1,6 +1,6 @@
 import type { SessionStore } from "./store";
 import type { EventHub } from "./events";
-import type { Learning, SignalKind } from "./types";
+import type { EvidenceItem, Learning, SignalKind } from "./types";
 import { planHouseRulesInjection, prioritize } from "./house-rules";
 
 /** Flatten + clip a signal payload to a one-line evidence excerpt for the drawer. */
@@ -13,6 +13,13 @@ function evidenceExcerpt(payload: string, max = 140): string {
 export type ApplyMergeResult =
   | { ok: true }
   | { ok: false; reason: "not-found" | "already-resolved" | "stale" };
+
+/** A pending learning with its evidence resolved — both provenance fields (optional on
+ *  Learning, since they're only attached here) are always present on this projection. */
+export type PendingLearningRow = Learning & {
+  evidenceKinds: Partial<Record<SignalKind, number>>;
+  evidenceDetail: EvidenceItem[];
+};
 
 /** Narrow store interface this service needs — the seam, kept small. */
 type LearningsStore = Pick<
@@ -150,7 +157,7 @@ export class LearningsService {
    * provenance (per-kind breakdown + source session designation + excerpt) — the
    * drawer's N+N+1 read projection.
    */
-  pendingWithEvidence(): Learning[] {
+  pendingWithEvidence(): PendingLearningRow[] {
     return this.store.listPendingLearnings().map((l) => {
       const evidenceKinds: Partial<Record<SignalKind, number>> = {};
       const evidenceDetail = this.store.getSignalsByIds(l.evidence).map((s) => {

--- a/src/learnings-service.ts
+++ b/src/learnings-service.ts
@@ -1,0 +1,244 @@
+import type { SessionStore } from "./store";
+import type { EventHub } from "./events";
+import type { Learning, SignalKind } from "./types";
+import { planHouseRulesInjection, prioritize } from "./house-rules";
+
+/** Flatten + clip a signal payload to a one-line evidence excerpt for the drawer. */
+function evidenceExcerpt(payload: string, max = 140): string {
+  const flat = payload.replace(/\s+/g, " ").trim();
+  if (flat.length <= max) return flat;
+  return [...flat].slice(0, max - 1).join("") + "…";
+}
+
+export type ApplyMergeResult =
+  | { ok: true }
+  | { ok: false; reason: "not-found" | "already-resolved" | "stale" };
+
+/** Narrow store interface this service needs — the seam, kept small. */
+type LearningsStore = Pick<
+  SessionStore,
+  | "getMergeSuggestion"
+  | "getLearning"
+  | "mergeLearning"
+  | "retireLearningMerged"
+  | "setMergeSuggestionStatus"
+  | "pendingLearningCount"
+  | "listPendingLearnings"
+  | "getSignalsByIds"
+  | "get"
+  | "listMergeSuggestions"
+  | "setLearningStatus"
+  | "setLearningScope"
+  | "revertTrial"
+  | "restoreLearning"
+  | "listRepoPathsWithInjectableLearnings"
+  | "listRepoPathsWithRetiredLearnings"
+  | "listActiveLearnings"
+  | "listRetiredLearnings"
+  | "getRetiredSeenAt"
+  | "getRepoConfig"
+>;
+
+/**
+ * Deep module owning the learnings cluster (#1092) — every learnings mutation
+ * plus the cluster's read projections. It absorbs the multi-call store sequences
+ * that previously lived inline in `src/server.ts` route handlers, so the handlers
+ * shrink to validate-and-delegate and the store stops leaking row ordering.
+ *
+ * The single most-repeated sequence — `events.emit("learnings:update", { pending:
+ * store.pendingLearningCount() })` — lived in ~10 routes; it now has exactly one
+ * home (`emitPending`), and every mutation method emits through it on (and only
+ * on) a real store change, preserving the original conditional-emit semantics.
+ *
+ * HTTP-agnostic: methods return domain values / shaped DTO rows, never a Response
+ * or status code — so the service is testable directly, without booting makeApp.
+ *
+ * DEVIATION (flagged per house rules): issue #1092 says "give `src/service.ts` deep
+ * methods". This is a NEW module instead — `SessionService` (service.ts) is session-
+ * centric and ~2.9k lines; the repo's idiom is one domain-service per file (review.ts,
+ * plan-gate.ts, promote.ts, house-rules.ts). Same service seam, focused home.
+ */
+export class LearningsService {
+  constructor(
+    private store: LearningsStore,
+    private events: Pick<EventHub, "emit">,
+  ) {}
+
+  /** The single emit site: refresh the drawer/badge with the live pending count. */
+  emitPending(): void {
+    this.events.emit("learnings:update", { pending: this.store.pendingLearningCount() });
+  }
+
+  /**
+   * Apply an intra-repo merge suggestion: consolidate the group into the survivor
+   * (counters preserved) and soft-retire the other members with a citation, after
+   * re-validating every member is still active (a member promoted/retired/edited
+   * since the pass invalidates the merge → the suggestion is dismissed as stale).
+   * Emits on success AND on the stale-dismiss (both mutate the store); silent on
+   * the not-found / already-resolved branches (no mutation).
+   */
+  applyMergeSuggestion(id: string): ApplyMergeResult {
+    const s = this.store.getMergeSuggestion(id);
+    if (!s || s.kind !== "intra" || !s.targetId) return { ok: false, reason: "not-found" };
+    if (s.status !== "pending") return { ok: false, reason: "already-resolved" };
+    const members = [s.targetId, ...s.sourceIds].map((mid) => this.store.getLearning(mid));
+    if (members.some((m) => !m || m.status !== "active")) {
+      // A member changed since the pass — the merge no longer applies.
+      this.store.setMergeSuggestionStatus(id, "dismissed");
+      this.emitPending();
+      return { ok: false, reason: "stale" };
+    }
+    this.store.mergeLearning(s.targetId, s.mergedRule, s.mergedRationale || undefined);
+    for (const sid of s.sourceIds) this.store.retireLearningMerged(sid, s.targetId);
+    this.store.setMergeSuggestionStatus(id, "applied");
+    this.emitPending();
+    return { ok: true };
+  }
+
+  /** Dismiss a merge suggestion (intra or cross). Returns false (no emit) when not found. */
+  dismissMergeSuggestion(id: string): boolean {
+    const updated = this.store.setMergeSuggestionStatus(id, "dismissed");
+    if (!updated) return false;
+    this.emitPending();
+    return true;
+  }
+
+  /**
+   * Approve (→active) or dismiss a proposed rule. On approve, an edited rule is
+   * normalized to addLearning's contract (trim + 240 cap); an empty edit falls
+   * back to the stored rule. Returns null (no emit) when the rule isn't found.
+   */
+  setStatus(id: string, action: "approve" | "dismiss", ruleEdit?: string): Learning | null {
+    let rule: string | undefined;
+    if (action === "approve" && typeof ruleEdit === "string") {
+      const trimmed = ruleEdit.trim().slice(0, 240);
+      if (trimmed) rule = trimmed;
+    }
+    const status = action === "approve" ? "active" : "dismissed";
+    const updated = this.store.setLearningStatus(id, status, rule);
+    if (!updated) return null;
+    this.emitPending();
+    return updated;
+  }
+
+  /** Replace a rule's glob scope (empty = Always-rule). Null (no emit) when not found. */
+  setScope(id: string, globs: string[]): Learning | null {
+    const updated = this.store.setLearningScope(id, globs);
+    if (!updated) return null;
+    this.emitPending();
+    return updated;
+  }
+
+  /** Revert an auto-trial back to proposed/dismissed. Null (no emit) when not a revertable trial. */
+  revertTrial(id: string, target: "proposed" | "dismissed"): Learning | null {
+    const updated = this.store.revertTrial(id, target);
+    if (!updated) return null;
+    this.emitPending();
+    return updated;
+  }
+
+  /** Restore a retired rule to its previous status. Null (no emit) when not found. */
+  restore(id: string): Learning | null {
+    const updated = this.store.restoreLearning(id);
+    if (!updated) return null;
+    this.emitPending();
+    return updated;
+  }
+
+  /**
+   * All proposed rules across repos, each with its cited signals resolved into
+   * provenance (per-kind breakdown + source session designation + excerpt) — the
+   * drawer's N+N+1 read projection.
+   */
+  pendingWithEvidence(): Learning[] {
+    return this.store.listPendingLearnings().map((l) => {
+      const evidenceKinds: Partial<Record<SignalKind, number>> = {};
+      const evidenceDetail = this.store.getSignalsByIds(l.evidence).map((s) => {
+        evidenceKinds[s.kind] = (evidenceKinds[s.kind] ?? 0) + 1;
+        return {
+          id: s.id,
+          kind: s.kind,
+          desig: s.sessionId ? (this.store.get(s.sessionId)?.desig ?? null) : null,
+          excerpt: evidenceExcerpt(s.payload),
+          ts: s.ts,
+        };
+      });
+      return { ...l, evidenceKinds, evidenceDetail };
+    });
+  }
+
+  /**
+   * Cross-repo injected/over-budget view: one entry per repo with ≥1
+   * active/promoted or retired rule. Shares the planner (planHouseRulesInjection)
+   * with the spawn-time injection so the budget math can't drift. `budgetChars`
+   * is supplied by the caller (the route passes config.houseRulesBudgetChars) so
+   * this service stays config-free.
+   */
+  injectableOverview(budgetChars: number) {
+    // Union of repos with injectable (active/promoted) or retired rules — deduped,
+    // injectable-first order (so a retired-only repo still appears for the banner).
+    const injectableRepos = this.store.listRepoPathsWithInjectableLearnings();
+    const retiredRepos = this.store.listRepoPathsWithRetiredLearnings();
+    const seen = new Set(injectableRepos);
+    const allRepos = [...injectableRepos, ...retiredRepos.filter((r) => !seen.has(r))];
+    return allRepos.map((repoPath) => {
+      const rules = this.store.listActiveLearnings(repoPath);
+      const retired = this.store.listRetiredLearnings(repoPath);
+      const seenAt = this.store.getRetiredSeenAt(repoPath);
+      const unseenRetired = retired.filter((r) => (r.retiredAt ?? 0) > seenAt).length;
+      const enabled = this.store.getRepoConfig(repoPath).learningsEnabled;
+      if (!enabled) {
+        // Injection disabled: skip the planner; every rule uninjected, used 0.
+        return {
+          repoPath,
+          enabled,
+          budgetChars,
+          usedChars: 0,
+          rules: prioritize(rules).map((r) => ({
+            ...r,
+            injected: false,
+            scoped: r.scopeGlobs.length > 0,
+          })),
+          retired,
+          unseenRetired,
+        };
+      }
+      // No session here, so no target files: planHouseRulesInjection gates every scoped
+      // rule into `scoped` (its globs decide injection only at spawn). usedChars therefore
+      // reflects the Always-rules baseline only — scoped rules never count against budget.
+      const plan = planHouseRulesInjection(rules, budgetChars);
+      const injectedIds = new Set(plan.injected.map((r) => r.id));
+      // injected (priority order), then dropped (over budget), then scope-gated — same
+      // ordering the drawer renders; `scoped` marks the glob-conditional rules.
+      return {
+        repoPath,
+        enabled,
+        budgetChars,
+        usedChars: plan.usedChars,
+        rules: [...plan.injected, ...plan.dropped, ...plan.scoped].map((r) => ({
+          ...r,
+          injected: injectedIds.has(r.id),
+          scoped: r.scopeGlobs.length > 0,
+        })),
+        retired,
+        unseenRetired,
+      };
+    });
+  }
+
+  /**
+   * Pending Phase-4 merge suggestions (intra + cross), each with its member rules
+   * hydrated for the drawer. Stale members (no longer present) are dropped here;
+   * the daily pass sweeps fully-broken suggestions.
+   */
+  mergeSuggestionsWithMembers() {
+    return this.store.listMergeSuggestions({ status: "pending" }).map((s) => {
+      const memberIds = [...(s.targetId ? [s.targetId] : []), ...s.sourceIds];
+      const members = memberIds
+        .map((mid) => this.store.getLearning(mid))
+        .filter((l): l is Learning => l !== null)
+        .map((l) => ({ id: l.id, repoPath: l.repoPath, rule: l.rule, status: l.status }));
+      return { ...s, members };
+    });
+  }
+}

--- a/src/repo-config-service.ts
+++ b/src/repo-config-service.ts
@@ -1,0 +1,89 @@
+import type { SessionStore, RepoConfig } from "./store";
+
+/** The read-shape the repo-config route returns: the stored config plus the two
+ *  automation-metadata flags that live OUTSIDE RepoConfig (a deliberate split —
+ *  `markAutomationConfirmed` is metadata, never a config field). */
+export type RepoConfigView = RepoConfig & {
+  automationConfirmed: boolean;
+  automationRowExists: boolean;
+};
+
+/** A partial repo-config edit. Every field is a RepoConfig field (the route's
+ *  `automationConfirmed` metadata is passed separately, never here). */
+export type RepoConfigPatch = Partial<RepoConfig>;
+
+export type RepoConfigPatchResult =
+  | { ok: true; config: RepoConfigView }
+  | { ok: false; error: string };
+
+/** Narrow store interface this service needs — the seam, kept small. */
+type RepoConfigStore = Pick<
+  SessionStore,
+  | "getRepoConfig"
+  | "setRepoConfig"
+  | "markAutomationConfirmed"
+  | "isAutomationConfirmed"
+  | "automationRowExists"
+>;
+
+/**
+ * Deep module owning the repo-config read-modify-write (#1092). It absorbs the
+ * route's inline merge + cross-field validation + atomic write + automation-
+ * confirmation bookkeeping, so the handler shrinks to validate-and-delegate and
+ * the store stops leaking the read→merge→write ordering to the caller.
+ *
+ * HTTP-agnostic: returns domain values (a discriminated result / a view DTO),
+ * never a Response or status code — so it's testable without booting makeApp.
+ */
+export class RepoConfigService {
+  constructor(private store: RepoConfigStore) {}
+
+  /** The stored config plus its automation-metadata flags (the route response shape). */
+  read(dir: string): RepoConfigView {
+    return {
+      ...this.store.getRepoConfig(dir),
+      automationConfirmed: this.store.isAutomationConfirmed(dir),
+      automationRowExists: this.store.automationRowExists(dir),
+    };
+  }
+
+  /**
+   * Atomically apply a partial config edit: merge the patch over the current
+   * config, enforce the cross-field invariants, persist, then (when the operator
+   * confirmed automation) mark the row confirmed. Returns the fresh view on
+   * success or a validation error message on rejection — the route maps the error
+   * to a 400.
+   */
+  patch(
+    dir: string,
+    patch: RepoConfigPatch,
+    opts: { automationConfirmed?: boolean } = {},
+  ): RepoConfigPatchResult {
+    const merged = this.merge(this.store.getRepoConfig(dir), patch);
+    if (merged.draftMode && merged.autoMergeEnabled) {
+      return { ok: false, error: "draftMode and autoMergeEnabled are mutually exclusive" };
+    }
+    // A critic-reliant sign-off authority with the critic OFF can never promote a draft → it
+    // would deadlock as a permanent draft. (With the critic off, "either" also reduces to the
+    // human check, so it's equivalent to "human" anyway.) Force an explicit "human" authority.
+    if (merged.draftMode && !merged.criticEnabled && merged.signoffAuthority !== "human") {
+      return {
+        ok: false,
+        error: `signoffAuthority "${merged.signoffAuthority}" requires criticEnabled — it would never sign off (use "human")`,
+      };
+    }
+    this.store.setRepoConfig(dir, merged);
+    if (opts.automationConfirmed === true) this.store.markAutomationConfirmed(dir);
+    return { ok: true, config: this.read(dir) };
+  }
+
+  /** Overlay the defined patch fields onto the current config (undefined = leave as-is). */
+  private merge(cur: RepoConfig, patch: RepoConfigPatch): RepoConfig {
+    const out: RepoConfig = { ...cur };
+    const writable = out as unknown as Record<string, unknown>;
+    for (const [k, v] of Object.entries(patch)) {
+      if (v !== undefined) writable[k] = v;
+    }
+    return out;
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,7 @@
-import type { SessionStore, RepoConfig } from "./store";
+import type { SessionStore } from "./store";
 import type { SessionService } from "./service";
+import { LearningsService } from "./learnings-service";
+import { RepoConfigService } from "./repo-config-service";
 import type { CreateSessionInput } from "./types";
 import type { EventHub } from "./events";
 import { PtyBridge } from "./pty-bridge";
@@ -47,7 +49,6 @@ import {
 } from "./operator-auth";
 import { resolvePlanAnswers, planAnswerSteerText, type RawAnswer } from "./plan-gate";
 import { slugifyManual } from "./namer";
-import { planHouseRulesInjection, prioritize } from "./house-rules";
 import {
   listRepos,
   readTodo,
@@ -84,9 +85,7 @@ import type { StarPromptStatus } from "./star-prompt";
 import type {
   Session,
   AgentProvider,
-  Learning,
   LearningStatus,
-  SignalKind,
   SessionPreviewState,
   IssueRef,
   RelaunchOverrides,
@@ -175,6 +174,13 @@ export interface AppDeps {
   store: SessionStore;
   service: SessionService;
   events: EventHub;
+  /** Memo slots (#1092) for the learnings + repo-config deep modules. Optional so the
+   *  many test `makeDeps()` builders need no change; routes never read these directly —
+   *  they go through the total `learnings(deps)` / `repoConfig(deps)` accessors below,
+   *  which lazily build-and-cache an instance from `store`(+`events`) on first use.
+   *  `index.ts` injects explicit singletons so production shares one instance. */
+  learnings?: LearningsService;
+  repoConfig?: RepoConfigService;
   usageLimits: Pick<UsageLimitsService, "limits" | "projections">;
   /** Force a `/usage` re-scrape (calibration) and return fresh limits plus whether the probe
    *  actually returned a usable frame this run; absent in tests that don't wire the live
@@ -388,6 +394,21 @@ const sessionUsage = (s: Session) =>
 
 const json = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+/**
+ * Total accessors (#1092) for the learnings / repo-config deep modules. They lazily
+ * build-and-memoize an instance onto the `deps` object from the always-present
+ * `store`(+`events`), so a handler reached via ANY dispatch entry point (both
+ * `makeApp.fetch` and `serve().fetch`) always gets a defined instance — no `deps.x!`
+ * non-null assertion, no makeApp-only fallback to drift. `index.ts` injects explicit
+ * singletons, so in production these return that shared instance.
+ */
+function learnings(deps: AppDeps): LearningsService {
+  return (deps.learnings ??= new LearningsService(deps.store, deps.events));
+}
+function repoConfigSvc(deps: AppDeps): RepoConfigService {
+  return (deps.repoConfig ??= new RepoConfigService(deps.store));
+}
 
 /**
  * Requests that pass the gate UN-credentialed (issue #1079). Scoped deliberately tight:
@@ -977,58 +998,21 @@ async function parseRepoConfigPatch(req: Request): Promise<
 /** Merge a validated patch onto the current repo config, returning the new full config.
  *  Patch fields are only ever undefined (absent) or a valid value, so every defined
  *  field overrides and absent fields keep the current value. */
-function mergeRepoConfig(
-  cur: RepoConfig,
-  patch: Omit<
-    Exclude<Awaited<ReturnType<typeof parseRepoConfigPatch>>, Response>,
-    "automationConfirmed"
-  >,
-): RepoConfig {
-  const out: RepoConfig = { ...cur };
-  const writable = out as unknown as Record<string, unknown>;
-  for (const [k, v] of Object.entries(patch)) {
-    if (v !== undefined) writable[k] = v;
-  }
-  return out;
-}
-
-function repoConfigResponse(deps: Ctx["deps"], dir: string): Response {
-  return json({
-    ...deps.store.getRepoConfig(dir),
-    automationConfirmed: deps.store.isAutomationConfirmed(dir),
-    automationRowExists: deps.store.automationRowExists(dir),
-  });
-}
-
 async function handleRepoConfig({ req, parts, url, deps }: Ctx): Promise<Response | null> {
   if (!(parts[0] === "api" && parts[1] === "repo-config" && !parts[2])) return null;
   const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
   if (!dir) return json({ error: "invalid repo" }, 400);
-  if (req.method === "GET") return repoConfigResponse(deps, dir);
+  if (req.method === "GET") return json(repoConfigSvc(deps).read(dir));
   if (req.method !== "PUT") return null;
 
   const patch = await parseRepoConfigPatch(req);
   if (patch instanceof Response) return patch;
-  // Load-bearing destructure: keeps the metadata flag off the RepoConfig written by mergeRepoConfig.
+  // Load-bearing destructure: the automationConfirmed metadata is applied separately
+  // by the service, never merged into the RepoConfig row.
   const { automationConfirmed, ...cfgPatch } = patch;
-  const merged = mergeRepoConfig(deps.store.getRepoConfig(dir), cfgPatch);
-  if (merged.draftMode && merged.autoMergeEnabled) {
-    return json({ error: "draftMode and autoMergeEnabled are mutually exclusive" }, 400);
-  }
-  // A critic-reliant sign-off authority with the critic OFF can never promote a draft → it
-  // would deadlock as a permanent draft. (With the critic off, "either" also reduces to the
-  // human check, so it's equivalent to "human" anyway.) Force an explicit "human" authority.
-  if (merged.draftMode && !merged.criticEnabled && merged.signoffAuthority !== "human") {
-    return json(
-      {
-        error: `signoffAuthority "${merged.signoffAuthority}" requires criticEnabled — it would never sign off (use "human")`,
-      },
-      400,
-    );
-  }
-  deps.store.setRepoConfig(dir, merged);
-  if (automationConfirmed === true) deps.store.markAutomationConfirmed(dir);
-  return repoConfigResponse(deps, dir);
+  const r = repoConfigSvc(deps).patch(dir, cfgPatch, { automationConfirmed });
+  if (!r.ok) return json({ error: r.error }, 400);
+  return json(r.config);
 }
 
 // /api/repo-roles?repo=<path> — read (GET) / set (PUT) the committed reviewer +
@@ -1157,95 +1141,19 @@ async function handleLearnings(ctx: Ctx): Promise<Response | null> {
   return null;
 }
 
-/** Flatten a captured signal payload to a short single-line preview for the
- *  drawer's evidence list (terminal tails / corrections can be multi-line).
- *  Truncates on code points so an emoji at the cut never leaves a lone
- *  surrogate (�) before the ellipsis. */
-function evidenceExcerpt(payload: string, max = 140): string {
-  const flat = payload.replace(/\s+/g, " ").trim();
-  if (flat.length <= max) return flat;
-  return [...flat].slice(0, max - 1).join("") + "…";
-}
-
 function handleLearningsGet({ parts, url, deps }: Ctx): Response | null {
-  // GET /api/learnings/pending — all proposed rules across repos (drawer + badge).
-  // Resolve each rule's cited signal ids into provenance: a per-kind breakdown
-  // plus the source session + excerpt for each signal, so the drawer shows where
-  // the rule came from rather than a bare count.
+  // GET /api/learnings/pending — all proposed rules across repos (drawer + badge),
+  // each rule's cited signals resolved into provenance (kind breakdown + source
+  // session + excerpt). The N+N+1 read lives in LearningsService now.
   if (parts[2] === "pending") {
-    const pending = deps.store.listPendingLearnings().map((l) => {
-      const evidenceKinds: Partial<Record<SignalKind, number>> = {};
-      const evidenceDetail = deps.store.getSignalsByIds(l.evidence).map((s) => {
-        evidenceKinds[s.kind] = (evidenceKinds[s.kind] ?? 0) + 1;
-        return {
-          id: s.id,
-          kind: s.kind,
-          desig: s.sessionId ? (deps.store.get(s.sessionId)?.desig ?? null) : null,
-          excerpt: evidenceExcerpt(s.payload),
-          ts: s.ts,
-        };
-      });
-      return { ...l, evidenceKinds, evidenceDetail };
-    });
-    return json(pending);
+    return json(learnings(deps).pendingWithEvidence());
   }
 
   // GET /api/learnings/injectable — cross-repo injected/over-budget view (drawer).
-  // One entry per repo with ≥1 active/promoted or retired rule; the budget value
-  // flows from here so the UI never hardcodes it. Shares the planner
-  // (planHouseRulesInjection) with service.recordInjectedHouseRules.
+  // The budget value flows from here so the UI never hardcodes it; the per-repo
+  // aggregation + planner share live in LearningsService.injectableOverview.
   if (parts[2] === "injectable") {
-    const budgetChars = config.houseRulesBudgetChars;
-    // Union of repos with injectable (active/promoted) or retired rules — deduped,
-    // injectable-first order (so a retired-only repo still appears for the banner).
-    const injectableRepos = deps.store.listRepoPathsWithInjectableLearnings();
-    const retiredRepos = deps.store.listRepoPathsWithRetiredLearnings();
-    const seen = new Set(injectableRepos);
-    const allRepos = [...injectableRepos, ...retiredRepos.filter((r) => !seen.has(r))];
-    const out = allRepos.map((repoPath) => {
-      const rules = deps.store.listActiveLearnings(repoPath);
-      const retired = deps.store.listRetiredLearnings(repoPath);
-      const seenAt = deps.store.getRetiredSeenAt(repoPath);
-      const unseenRetired = retired.filter((r) => (r.retiredAt ?? 0) > seenAt).length;
-      const enabled = deps.store.getRepoConfig(repoPath).learningsEnabled;
-      if (!enabled) {
-        // Injection disabled: skip the planner; every rule uninjected, used 0.
-        return {
-          repoPath,
-          enabled,
-          budgetChars,
-          usedChars: 0,
-          rules: prioritize(rules).map((r) => ({
-            ...r,
-            injected: false,
-            scoped: r.scopeGlobs.length > 0,
-          })),
-          retired,
-          unseenRetired,
-        };
-      }
-      // No session here, so no target files: planHouseRulesInjection gates every scoped
-      // rule into `scoped` (its globs decide injection only at spawn). usedChars therefore
-      // reflects the Always-rules baseline only — scoped rules never count against budget.
-      const plan = planHouseRulesInjection(rules, budgetChars);
-      const injectedIds = new Set(plan.injected.map((r) => r.id));
-      // injected (priority order), then dropped (over budget), then scope-gated — same
-      // ordering the drawer renders; `scoped` marks the glob-conditional rules.
-      return {
-        repoPath,
-        enabled,
-        budgetChars,
-        usedChars: plan.usedChars,
-        rules: [...plan.injected, ...plan.dropped, ...plan.scoped].map((r) => ({
-          ...r,
-          injected: injectedIds.has(r.id),
-          scoped: r.scopeGlobs.length > 0,
-        })),
-        retired,
-        unseenRetired,
-      };
-    });
-    return json(out);
+    return json(learnings(deps).injectableOverview(config.houseRulesBudgetChars));
   }
 
   // GET /api/learnings/health — distiller health (fail-safe: safe default when absent)
@@ -1258,17 +1166,9 @@ function handleLearningsGet({ parts, url, deps }: Ctx): Response | null {
 
   // GET /api/learnings/merge-suggestions — pending Phase-4 merge suggestions (intra + cross),
   // each with its member rules hydrated for the drawer. Stale members (no longer present) are
-  // dropped here; pruneOrphanMergeSuggestions sweeps fully-broken suggestions on the daily pass.
+  // dropped; pruneOrphanMergeSuggestions sweeps fully-broken suggestions on the daily pass.
   if (parts[2] === "merge-suggestions") {
-    const out = deps.store.listMergeSuggestions({ status: "pending" }).map((s) => {
-      const memberIds = [...(s.targetId ? [s.targetId] : []), ...s.sourceIds];
-      const members = memberIds
-        .map((mid) => deps.store.getLearning(mid))
-        .filter((l): l is Learning => l !== null)
-        .map((l) => ({ id: l.id, repoPath: l.repoPath, rule: l.rule, status: l.status }));
-      return { ...s, members };
-    });
-    return json(out);
+    return json(learnings(deps).mergeSuggestionsWithMembers());
   }
 
   // GET /api/learnings?repo=&status=
@@ -1312,21 +1212,11 @@ async function handleMergeApply(req: Request, deps: AppDeps): Promise<Response> 
   const body = (await req.json().catch(() => ({}))) as { suggestionId?: unknown };
   const id = typeof body.suggestionId === "string" ? body.suggestionId : "";
   if (!id) return json({ error: "suggestionId required" }, 400);
-  const s = deps.store.getMergeSuggestion(id);
-  if (!s || s.kind !== "intra" || !s.targetId) return json({ error: "not found" }, 404);
-  if (s.status !== "pending") return json({ error: "already resolved" }, 409);
-  const members = [s.targetId, ...s.sourceIds].map((mid) => deps.store.getLearning(mid));
-  if (members.some((m) => !m || m.status !== "active")) {
-    // A member was promoted/retired/edited since the pass — the merge no longer applies.
-    deps.store.setMergeSuggestionStatus(id, "dismissed");
-    deps.events.emit("learnings:update", { pending: deps.store.pendingLearningCount() });
-    return json({ error: "stale" }, 409);
-  }
-  deps.store.mergeLearning(s.targetId, s.mergedRule, s.mergedRationale || undefined);
-  for (const sid of s.sourceIds) deps.store.retireLearningMerged(sid, s.targetId);
-  deps.store.setMergeSuggestionStatus(id, "applied");
-  deps.events.emit("learnings:update", { pending: deps.store.pendingLearningCount() });
-  return json({ ok: true });
+  const r = learnings(deps).applyMergeSuggestion(id);
+  if (r.ok) return json({ ok: true });
+  if (r.reason === "not-found") return json({ error: "not found" }, 404);
+  if (r.reason === "stale") return json({ error: "stale" }, 409);
+  return json({ error: "already resolved" }, 409); // already-resolved
 }
 
 /** Route the two Phase-4 merge-suggestion POSTs (`merge` apply, `merge-dismiss`). Returns
@@ -1357,8 +1247,10 @@ async function handleMergePromoteGlobal(req: Request, deps: AppDeps): Promise<Re
   if (!deps.promoter) return json({ error: "promote unavailable" }, 503);
   const res = await deps.promoter.promoteGlobal(sug.mergedRule);
   if (!res.ok) return json({ error: res.error }, res.status);
+  // Promoter-orchestrated (separate service): the suggestion bookkeeping stays inline; only
+  // the recurring emit tail unifies through the learnings service (#1092).
   deps.store.setMergeSuggestionStatus(id, "applied");
-  deps.events.emit("learnings:update", { pending: deps.store.pendingLearningCount() });
+  learnings(deps).emitPending();
   return json({ ok: true });
 }
 
@@ -1368,9 +1260,7 @@ async function handleMergeDismiss(req: Request, deps: AppDeps): Promise<Response
   const body = (await req.json().catch(() => ({}))) as { suggestionId?: unknown };
   const id = typeof body.suggestionId === "string" ? body.suggestionId : "";
   if (!id) return json({ error: "suggestionId required" }, 400);
-  const updated = deps.store.setMergeSuggestionStatus(id, "dismissed");
-  if (!updated) return json({ error: "not found" }, 404);
-  deps.events.emit("learnings:update", { pending: deps.store.pendingLearningCount() });
+  if (!learnings(deps).dismissMergeSuggestion(id)) return json({ error: "not found" }, 404);
   return json({ ok: true });
 }
 
@@ -1378,7 +1268,8 @@ async function handleLearningPromote(deps: AppDeps, id: string): Promise<Respons
   if (!deps.promoter) return json({ error: "promote unavailable" }, 503);
   const res = await deps.promoter.promote(id);
   if (!res.ok) return json({ error: res.error }, res.status);
-  deps.events.emit("learnings:update", { pending: deps.store.pendingLearningCount() });
+  // Promoter-orchestrated; only the emit tail unifies through the learnings service (#1092).
+  learnings(deps).emitPending();
   return json({ url: res.url });
 }
 
@@ -1413,9 +1304,8 @@ async function handleLearningIdAction(ctx: Ctx): Promise<Response | null> {
 
   // POST /api/learnings/:id/restore — restore a retired rule to its previous status
   if (parts[3] === "restore") {
-    const updated = deps.store.restoreLearning(parts[2]);
+    const updated = learnings(deps).restore(parts[2]);
     if (!updated) return json({ error: "not found" }, 404);
-    deps.events.emit("learnings:update", { pending: deps.store.pendingLearningCount() });
     return json(updated);
   }
 
@@ -1441,9 +1331,8 @@ async function handleLearningScope(req: Request, deps: AppDeps, id: string): Pro
   const globs = Array.isArray(body?.globs)
     ? body!.globs.filter((g): g is string => typeof g === "string")
     : [];
-  const updated = deps.store.setLearningScope(id, globs);
+  const updated = learnings(deps).setScope(id, globs);
   if (!updated) return json({ error: "not found" }, 404);
-  deps.events.emit("learnings:update", { pending: deps.store.pendingLearningCount() });
   return json(updated);
 }
 
@@ -1459,9 +1348,8 @@ async function handleLearningRevertTrial(
   const target = body?.target;
   if (target !== "proposed" && target !== "dismissed")
     return json({ error: "invalid target" }, 400);
-  const updated = deps.store.revertTrial(id, target);
+  const updated = learnings(deps).revertTrial(id, target);
   if (!updated) return json({ error: "not found" }, 404);
-  deps.events.emit("learnings:update", { pending: deps.store.pendingLearningCount() });
   return json(updated);
 }
 
@@ -1471,21 +1359,15 @@ async function handleLearningStatus(
   id: string,
   action: "approve" | "dismiss",
 ): Promise<Response> {
-  let rule: string | undefined;
+  // The edited-rule body is parsed here (HTTP concern); the service normalizes it (trim + 240
+  // cap, blank → fall back to the stored rule) to match addLearning's contract.
+  let ruleEdit: string | undefined;
   if (action === "approve") {
     const body = (await req.json().catch(() => null)) as { rule?: unknown } | null;
-    if (body && typeof body.rule === "string") {
-      // Normalize an edited rule to match addLearning's contract (trim + 240 cap).
-      // An empty/whitespace-only edit falls back to the stored rule rather than
-      // persisting a blank active rule (e.g. operator cleared the textarea).
-      const trimmed = body.rule.trim().slice(0, 240);
-      if (trimmed) rule = trimmed;
-    }
+    if (body && typeof body.rule === "string") ruleEdit = body.rule;
   }
-  const status = action === "approve" ? "active" : "dismissed";
-  const updated = deps.store.setLearningStatus(id, status, rule);
+  const updated = learnings(deps).setStatus(id, action, ruleEdit);
   if (!updated) return json({ error: "not found" }, 404);
-  deps.events.emit("learnings:update", { pending: deps.store.pendingLearningCount() });
   return json(updated);
 }
 

--- a/test/learnings-service.test.ts
+++ b/test/learnings-service.test.ts
@@ -1,0 +1,239 @@
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+import { LearningsService } from "../src/learnings-service";
+
+/** A store + an emit-spy + the service under test, wired the way production wires it. */
+function harness() {
+  const store = new SessionStore(":memory:");
+  const emitted: { event: string; data: unknown }[] = [];
+  const events = { emit: (event: string, data: unknown) => emitted.push({ event, data }) };
+  const svc = new LearningsService(store, events);
+  return { store, svc, emitted };
+}
+
+/** Counts of learnings:update emits (the only event the service emits). */
+const updates = (emitted: { event: string }[]) =>
+  emitted.filter((e) => e.event === "learnings:update").length;
+
+/** Add a rule already in `active` state (addLearning starts proposed). */
+function activeRule(store: SessionStore, repoPath: string, rule: string) {
+  const l = store.addLearning({ repoPath, rule, rationale: "", evidence: [] });
+  return store.setLearningStatus(l.id, "active")!;
+}
+
+function intraSuggestion(store: SessionStore, targetId: string, sourceIds: string[]) {
+  return store.addMergeSuggestion({
+    kind: "intra",
+    repoPath: "/r",
+    targetId,
+    sourceIds,
+    mergedRule: "consolidated rule",
+    mergedRationale: "merged",
+    repoPaths: null,
+    signature: `sig-${targetId}-${sourceIds.join(",")}`,
+  });
+}
+
+// ── applyMergeSuggestion ──────────────────────────────────────────────────────
+
+test("applyMergeSuggestion: success consolidates survivor, retires sources, emits once", () => {
+  const { store, svc, emitted } = harness();
+  const target = activeRule(store, "/r", "keep me");
+  const source = activeRule(store, "/r", "fold me");
+  const sug = intraSuggestion(store, target.id, [source.id]);
+
+  const r = svc.applyMergeSuggestion(sug.id);
+
+  expect(r).toEqual({ ok: true });
+  expect(store.getLearning(target.id)!.rule).toBe("consolidated rule");
+  const folded = store.getLearning(source.id)!;
+  expect(folded.status).toBe("retired");
+  expect(folded.mergedIntoId).toBe(target.id);
+  expect(store.getMergeSuggestion(sug.id)!.status).toBe("applied");
+  expect(updates(emitted)).toBe(1);
+});
+
+test("applyMergeSuggestion: unknown id → not-found, no emit", () => {
+  const { svc, emitted } = harness();
+  expect(svc.applyMergeSuggestion("nope")).toEqual({ ok: false, reason: "not-found" });
+  expect(updates(emitted)).toBe(0);
+});
+
+test("applyMergeSuggestion: already-resolved (re-apply) → no second emit", () => {
+  const { store, svc, emitted } = harness();
+  const target = activeRule(store, "/r", "keep me");
+  const source = activeRule(store, "/r", "fold me");
+  const sug = intraSuggestion(store, target.id, [source.id]);
+
+  expect(svc.applyMergeSuggestion(sug.id).ok).toBe(true);
+  const second = svc.applyMergeSuggestion(sug.id);
+
+  expect(second).toEqual({ ok: false, reason: "already-resolved" });
+  expect(updates(emitted)).toBe(1); // only the first apply emitted
+});
+
+test("applyMergeSuggestion: a non-active member → stale, suggestion dismissed, emits once", () => {
+  const { store, svc, emitted } = harness();
+  const target = activeRule(store, "/r", "keep me");
+  // source stays `proposed` (never activated) → the merge no longer applies.
+  const source = store.addLearning({
+    repoPath: "/r",
+    rule: "fold me",
+    rationale: "",
+    evidence: [],
+  });
+  const sug = intraSuggestion(store, target.id, [source.id]);
+
+  const r = svc.applyMergeSuggestion(sug.id);
+
+  expect(r).toEqual({ ok: false, reason: "stale" });
+  expect(store.getMergeSuggestion(sug.id)!.status).toBe("dismissed");
+  expect(updates(emitted)).toBe(1); // the stale-dismiss IS a store change → emits
+});
+
+// ── dismissMergeSuggestion ────────────────────────────────────────────────────
+
+test("dismissMergeSuggestion: found → true + emit; unknown → false + no emit", () => {
+  const { store, svc, emitted } = harness();
+  const t = activeRule(store, "/r", "a");
+  const sug = intraSuggestion(store, t.id, []);
+
+  expect(svc.dismissMergeSuggestion(sug.id)).toBe(true);
+  expect(store.getMergeSuggestion(sug.id)!.status).toBe("dismissed");
+  expect(updates(emitted)).toBe(1);
+
+  expect(svc.dismissMergeSuggestion("nope")).toBe(false);
+  expect(updates(emitted)).toBe(1); // unchanged
+});
+
+// ── setStatus ─────────────────────────────────────────────────────────────────
+
+test("setStatus: approve with edit normalizes (trim + 240) and activates; emits once", () => {
+  const { store, svc, emitted } = harness();
+  const l = store.addLearning({ repoPath: "/r", rule: "orig", rationale: "", evidence: [] });
+
+  const edited = svc.setStatus(l.id, "approve", "  cleaned up rule  ");
+
+  expect(edited!.status).toBe("active");
+  expect(edited!.rule).toBe("cleaned up rule");
+  expect(updates(emitted)).toBe(1);
+});
+
+test("setStatus: approve with blank edit falls back to the stored rule", () => {
+  const { store, svc } = harness();
+  const l = store.addLearning({ repoPath: "/r", rule: "orig", rationale: "", evidence: [] });
+  expect(svc.setStatus(l.id, "approve", "   ")!.rule).toBe("orig");
+});
+
+test("setStatus: long edit clipped to 240 chars", () => {
+  const { store, svc } = harness();
+  const l = store.addLearning({ repoPath: "/r", rule: "orig", rationale: "", evidence: [] });
+  expect(svc.setStatus(l.id, "approve", "x".repeat(300))!.rule.length).toBe(240);
+});
+
+test("setStatus: dismiss sets dismissed; unknown id → null + no emit", () => {
+  const { store, svc, emitted } = harness();
+  const l = store.addLearning({ repoPath: "/r", rule: "orig", rationale: "", evidence: [] });
+  expect(svc.setStatus(l.id, "dismiss")!.status).toBe("dismissed");
+  expect(updates(emitted)).toBe(1);
+  expect(svc.setStatus("nope", "approve")).toBeNull();
+  expect(updates(emitted)).toBe(1); // unchanged
+});
+
+// ── setScope / revertTrial / restore ──────────────────────────────────────────
+
+test("setScope: sets globs + emit; unknown → null + no emit", () => {
+  const { store, svc, emitted } = harness();
+  const l = activeRule(store, "/r", "scoped");
+  expect(svc.setScope(l.id, ["src/**"])!.scopeGlobs).toEqual(["src/**"]);
+  expect(updates(emitted)).toBe(1);
+  expect(svc.setScope("nope", ["x"])).toBeNull();
+  expect(updates(emitted)).toBe(1);
+});
+
+test("revertTrial: reverts an active trial + emit; non-trial → null + no emit", () => {
+  const { store, svc, emitted } = harness();
+  const l = store.addLearning({ repoPath: "/r", rule: "trial me", rationale: "", evidence: [] });
+  store.trialLearning(l.id); // proposed → active trial, so revert applies
+  const reverted = svc.revertTrial(l.id, "proposed");
+  expect(reverted!.status).toBe("proposed");
+  expect(updates(emitted)).toBe(1);
+
+  const plain = activeRule(store, "/r", "not a trial");
+  expect(svc.revertTrial(plain.id, "proposed")).toBeNull();
+  expect(updates(emitted)).toBe(1); // unchanged
+});
+
+test("restore: brings a merged-retired source back + emit; unknown → null + no emit", () => {
+  const { store, svc, emitted } = harness();
+  const target = activeRule(store, "/r", "keep");
+  const source = activeRule(store, "/r", "folded");
+  const sug = intraSuggestion(store, target.id, [source.id]);
+  svc.applyMergeSuggestion(sug.id); // retires source (emit #1)
+
+  const restored = svc.restore(source.id);
+  expect(restored!.status).not.toBe("retired");
+  expect(updates(emitted)).toBe(2);
+
+  expect(svc.restore("nope")).toBeNull();
+  expect(updates(emitted)).toBe(2); // unchanged
+});
+
+// ── emitPending ───────────────────────────────────────────────────────────────
+
+test("emitPending: emits learnings:update with the live pending count", () => {
+  const { store, svc, emitted } = harness();
+  store.addLearning({ repoPath: "/r", rule: "p1", rationale: "", evidence: [] });
+  store.addLearning({ repoPath: "/r", rule: "p2", rationale: "", evidence: [] });
+  svc.emitPending();
+  expect(emitted.at(-1)).toEqual({ event: "learnings:update", data: { pending: 2 } });
+});
+
+// ── read projections ──────────────────────────────────────────────────────────
+
+test("pendingWithEvidence: resolves evidence kinds + source designation + excerpt", () => {
+  const { store, svc } = harness();
+  const session = store.create({
+    name: "n",
+    prompt: "p",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/n",
+    worktreePath: "/r-wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_1",
+  });
+  const sig = store.addSignal({
+    repoPath: "/r",
+    sessionId: session.id,
+    kind: "critic",
+    payload: "  use   bun  not npm  ",
+  });
+  store.addLearning({ repoPath: "/r", rule: "prefer bun", rationale: "", evidence: [sig.id] });
+
+  const [row] = svc.pendingWithEvidence();
+  expect(row!.evidenceKinds).toEqual({ critic: 1 });
+  expect(row!.evidenceDetail).toHaveLength(1);
+  expect(row!.evidenceDetail![0]!.desig).toBe(session.desig);
+  expect(row!.evidenceDetail![0]!.excerpt).toBe("use bun not npm"); // flattened whitespace
+});
+
+test("injectableOverview: one entry per repo with active rules, budget threaded through", () => {
+  const { store, svc } = harness();
+  activeRule(store, "/r", "always rebase");
+  const out = svc.injectableOverview(5000);
+  const entry = out.find((e) => e.repoPath === "/r");
+  expect(entry).toBeTruthy();
+  expect(entry!.budgetChars).toBe(5000);
+  expect(entry!.rules.length).toBeGreaterThanOrEqual(1);
+});
+
+test("mergeSuggestionsWithMembers: hydrates member rules, drops vanished ones", () => {
+  const { store, svc } = harness();
+  const target = activeRule(store, "/r", "survivor");
+  intraSuggestion(store, target.id, ["ghost-id"]); // ghost member no longer exists
+  const [row] = svc.mergeSuggestionsWithMembers();
+  expect(row!.members).toHaveLength(1);
+  expect(row!.members![0]!.rule).toBe("survivor");
+});

--- a/test/repo-config-service.test.ts
+++ b/test/repo-config-service.test.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+import { RepoConfigService } from "../src/repo-config-service";
+
+function harness() {
+  const store = new SessionStore(":memory:");
+  const svc = new RepoConfigService(store);
+  return { store, svc };
+}
+
+test("read: returns the stored config plus automation-metadata flags", () => {
+  const { svc } = harness();
+  const view = svc.read("/r");
+  expect(view.criticEnabled).toBeDefined();
+  expect(view.automationConfirmed).toBe(false);
+  expect(view.automationRowExists).toBe(false);
+});
+
+test("patch: merges defined fields, persists, returns fresh view", () => {
+  const { store, svc } = harness();
+  const r = svc.patch("/r", { criticEnabled: false, maxAuto: 3 });
+  expect(r.ok).toBe(true);
+  if (!r.ok) throw new Error("expected ok");
+  expect(r.config.criticEnabled).toBe(false);
+  expect(r.config.maxAuto).toBe(3);
+  // Persisted, not just echoed.
+  expect(store.getRepoConfig("/r").maxAuto).toBe(3);
+});
+
+test("patch: undefined fields leave the current value untouched", () => {
+  const { svc } = harness();
+  svc.patch("/r", { maxAuto: 7 });
+  const r = svc.patch("/r", { criticEnabled: false }); // maxAuto omitted
+  expect(r.ok && r.config.maxAuto).toBe(7);
+});
+
+test("patch: rejects draftMode + autoMergeEnabled (mutually exclusive), no write", () => {
+  const { store, svc } = harness();
+  const r = svc.patch("/r", { draftMode: true, autoMergeEnabled: true });
+  expect(r).toEqual({
+    ok: false,
+    error: "draftMode and autoMergeEnabled are mutually exclusive",
+  });
+  expect(store.getRepoConfig("/r").draftMode).toBe(false); // unchanged
+});
+
+test("patch: rejects draftMode without critic when signoffAuthority isn't human", () => {
+  const { svc } = harness();
+  const r = svc.patch("/r", {
+    draftMode: true,
+    criticEnabled: false,
+    signoffAuthority: "critic",
+  });
+  expect(r.ok).toBe(false);
+  if (r.ok) throw new Error("expected rejection");
+  expect(r.error).toContain("requires criticEnabled");
+});
+
+test("patch: draftMode with critic enabled is allowed", () => {
+  const { svc } = harness();
+  const r = svc.patch("/r", { draftMode: true, criticEnabled: true, signoffAuthority: "critic" });
+  expect(r.ok).toBe(true);
+});
+
+test("patch: automationConfirmed flag marks the row confirmed", () => {
+  const { store, svc } = harness();
+  expect(store.isAutomationConfirmed("/r")).toBe(false);
+  const r = svc.patch("/r", { criticEnabled: true }, { automationConfirmed: true });
+  expect(r.ok).toBe(true);
+  expect(store.isAutomationConfirmed("/r")).toBe(true);
+  expect(svc.read("/r").automationConfirmed).toBe(true);
+});
+
+test("patch: without the automationConfirmed flag, confirmation stays untouched", () => {
+  const { store, svc } = harness();
+  svc.patch("/r", { criticEnabled: true });
+  expect(store.isAutomationConfirmed("/r")).toBe(false);
+});


### PR DESCRIPTION
Closes #1092.

## Problem
Route handlers in `src/server.ts` reached **past the service seam into the store**: the learnings + repo-config business operations sequenced 6+ `deps.store.*` calls inline. `handleMergeApply` was `getMergeSuggestion → getLearning×N → mergeLearning → retireLearningMerged×N → setMergeSuggestionStatus → emit`; the same `events.emit("learnings:update", { pending: store.pendingLearningCount() })` tail repeated **~10×** across every learnings-mutation route. A business op had no home, so the test surface was the whole HTTP server (`makeApp`).

## Deepening
Two new **deep modules** behind the service seam — handlers shrink to *validate-and-delegate*:

- **`src/learnings-service.ts`** (`LearningsService`) — `applyMergeSuggestion` · `dismissMergeSuggestion` · `setStatus` · `setScope` · `revertTrial` · `restore`, plus the `pending` / `injectable` / `merge-suggestions` read projections. Owns the once-repeated `learnings:update` emit via a single `emitPending()`. Every mutation emits **iff the store mutated** (so `applyMergeSuggestion` emits on success *and* on the stale-dismiss; silent on not-found / already-resolved) — the original conditional semantics, now lockable in a unit test.
- **`src/repo-config-service.ts`** (`RepoConfigService`) — atomic `patch(dir, delta)` (merge + both cross-field validations + write + automation-confirm) and `read(dir)`.

Both are **HTTP-agnostic** (return domain values / DTO rows, never a `Response`/status/`json()`), so they're tested directly without booting `makeApp`.

### Wiring
`AppDeps` gains optional `learnings?`/`repoConfig?` memo slots; routes reach them through **total accessors** `learnings(deps)` / `repoConfig(deps)` that lazily build-and-memoize from `store`(+`events`). No `deps.x!` non-null assertions, and robust across **both** dispatch entry points (`makeApp.fetch` *and* `serve().fetch`). `index.ts` injects explicit singletons and routes its 5 background `onChange` emits through the same `emitPending()`.

## Falsifiable results
| Metric | Before | After |
| --- | --- | --- |
| `deps.store.*` in `server.ts` | 151 | **114** (−37) |
| `learnings:update` literal in `server.ts` | 10 | **0** |
| `deps.learnings!`/`deps.repoConfig!` assertions | — | **0** |
| `server.ts` net lines | — | **−108** |

## Tests
- New `test/learnings-service.test.ts` (16) + `test/repo-config-service.test.ts` (8) hit the **services directly** against a real store — the new test surface, with explicit **per-branch emit-count** assertions.
- Existing route tests (`server-learnings`, `automation-confirm`, …) pass **unchanged** — behaviour preserved through the seam.
- Full suite: **4992 pass / 0 fail**. tsc + lint clean. `fallow audit` exit 0 (dead code 0, complexity 0; duplication is pre-existing/warn-only).

## ⚠️ Deliberate deviation (flagged per house rules)
Issue #1092 says *"Give `src/service.ts` deep methods"*. This PR puts them in **new domain-service files** instead. Rationale: `SessionService` (`service.ts`) is session-centric and ~2.9k lines; the repo's idiom is **one domain-service per file** (`review.ts`, `plan-gate.ts`, `promote.ts`, `house-rules.ts`). Same service seam, focused home. Also flagged in the `learnings-service.ts` header comment. (Scope agreed with operator at plan time: cohesive learnings cluster + repo-config; the other ~114 store calls are other domains and stay out — single-PR scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)