### PR TITLE
fix(tab-reaper): boot-reap pr-critic + unclean-exit synchronous helper tabs (#1136)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import { resolveDiffBase } from "./diff-base";
 import { BranchPruner } from "./branch-pruner";
 import { reconcile } from "./reconcile";
 import { reapOrphanTabs, reapStaleReviewWorktrees } from "./tab-reaper";
+import { reapTransientByLabel } from "./transient-tab-reaper";
 import { scanClaudeAliveByWorktree } from "./process-reaper";
 import { serve, serveAgentIngress, buildBacklogPayload, type AppDeps } from "./server";
 import { PluginRegistry } from "./plugins/loader";
@@ -773,6 +774,7 @@ const standaloneCritic = new StandalonePrCriticService({
         .map((s) => s.branch!),
     ),
 });
+standaloneCritic.reapOrphans(); // issue #1136: close orphaned pr-critic tabs left by a prior lifetime
 
 // Pre-execution plan gate (#348): the planning-phase twin of the PR critic. An
 // adversarial reviewer reads the agent's `.shepherd-plan.md` BEFORE it writes code;
@@ -1485,6 +1487,15 @@ setInterval(() => {
   if (maintenance.active) return;
   void mergeSuggest.tick();
 }, 30_000);
+// Issue #1136: the synchronous block-and-clean helpers (namer / autopilot / verify-key) stop their
+// spawn in a `finally`, so they leave NO husk on a CLEAN exit — but a server restart mid-poll skips
+// that finally, orphaning an interactive `claude` that idles at the prompt forever (the husk-only
+// reaper spares it as a live non-shell proc). They track no inflight and none is running at this
+// synchronous boot point, so an empty owned set is correct: close every prior-lifetime orphan by
+// label prefix. Space-prefixed / multi-word labels can't collide with an `[a-z0-9-]` session slug.
+reapTransientByLabel(herdr, "name ", new Set(), "[namer]");
+reapTransientByLabel(herdr, "autopilot ", new Set(), "[autopilot]");
+reapTransientByLabel(herdr, "verify api key", new Set(), "[verify-key]");
 const gitignoreAdopter = new GitignoreAdopter({ worktree, resolveForge });
 // Daily: prune archived sessions, prune old signals, then consider a distill per repo
 // with enough recent signal.

--- a/src/standalone-critic.ts
+++ b/src/standalone-critic.ts
@@ -39,6 +39,7 @@ import {
   type RawVerdict,
 } from "./critic-core";
 import type { VerdictRead } from "./json-tolerant";
+import { reapTransientByLabel } from "./transient-tab-reaper";
 import { resolveSpawnMembrane, type MembraneSeams } from "./spawn-membrane";
 
 /** One PR critic run between its spawn (begin) and its verdict (finalize). Carries everything
@@ -74,7 +75,7 @@ export interface StandalonePrCriticDeps extends MembraneSeams {
     | "completeReviewerSpawn"
     | "listEpicCompleted"
   >;
-  herdr: Pick<HerdrDriver, "start" | "stop">;
+  herdr: Pick<HerdrDriver, "start" | "stop" | "list" | "closeTab">;
   worktree: Pick<WorktreeMgr, "createDetached" | "remove" | "gitCommonDir">;
   resolveForge: (repoPath: string) => GitForge | null;
   /** Candidate repos to consider each sweep. The sweep itself filters to those with
@@ -602,6 +603,20 @@ export class StandalonePrCriticService {
    *  these (a re-adopted #631 orphan's tick() still needs its worktree). */
   inflightWorktrees(): string[] {
     return [...this.inFlight.values()].map((f) => f.worktreePath);
+  }
+
+  /** Boot reconcile (#1136): close orphaned `pr-critic ` tabs left by a prior lifetime. The
+   *  standalone critic's `inFlight` is memory-only, so a restart loses tracking of a live run;
+   *  its interactive `claude` idles at the prompt forever (agent_status "done", pane alive) and
+   *  the husk-only {@link reapOrphanTabs} spares it as a non-shell `claude`. Mirrors the
+   *  distiller/optimizer/merge-suggest reap (#1135): scan herdr once at boot for `pr-critic `
+   *  agents NOT owned by a current-process inflight run and close their tabs. The disposable
+   *  `*-review-*` worktrees these orphans hold are reaped separately by `reapStaleReviewWorktrees`. */
+  reapOrphans(): void {
+    const ownedTerms = new Set(
+      [...this.inFlight.values()].map((f) => f.terminalId).filter(Boolean),
+    );
+    reapTransientByLabel(this.deps.herdr, "pr-critic ", ownedTerms, "[pr-critic]");
   }
 
   /** Tear down every in-flight run (reap its terminal + worktree). For process shutdown. */

--- a/src/transient-tab-reaper.ts
+++ b/src/transient-tab-reaper.ts
@@ -5,15 +5,22 @@ import type { HerdrDriver } from "./herdr";
  *
  * This is ONE of four distinct teardown mechanisms across the transient-agent fleet, and the only
  * one whose body was byte-identical across consumers (distiller / optimizer / merge-suggest) — so
- * only it is deduped here. The other seven consumers gain NO new boot reaping from #1093 BY DESIGN:
- * they already have appropriate teardown via a different lifecycle, and forcing them onto this
- * label-prefix scan would be wrong, not a missing feature —
+ * it was deduped here. The OTHER consumers reconcile via a different lifecycle, and forcing them
+ * onto this label-prefix scan would be wrong where they already have it —
  *   - persisted `reviewer_spawns` rows → adoptOrphans/reapOrphans (plan-gate / review / doc-agent);
- *   - store `generating` state → reapGenerating (recap / herd-digest);
- *   - synchronous block-and-clean — start→poll→stop in a `finally`, random temp dirs, no stable
- *     name to squat → no husk on clean exit (namer / autopilot / verify-key).
- * So #1093 delivers the argv consolidation across all 10 plus this one reaper dedup; a universal
- * "reap every kind" base is intentionally out of scope (see the PR description + issue #1093).
+ *   - store `generating` state → reapGenerating (recap / herd-digest).
+ * #1093 delivers the argv consolidation across all 10 plus this reaper dedup; a universal
+ * "reap every kind" base remains out of scope.
+ *
+ * **The exception: synchronous block-and-clean helpers — start→poll→stop in a `finally`, random
+ * temp dirs (`name ` / `autopilot ` / `verify api key`).** #1093 left these unreaped on the
+ * premise that the `finally` leaves no husk. That holds only on a CLEAN exit: a server restart
+ * mid-poll skips the `finally`, orphaning an interactive `claude` that idles at the prompt forever
+ * (the husk-only reaper spares it as a live non-shell proc). #1136 closes that gap by calling this
+ * same reaper for those three labels at boot with an EMPTY owned set — they track no inflight and
+ * none is running at the synchronous boot point, so every match is a prior-lifetime orphan. The
+ * standalone PR critic (`pr-critic `) — memory-only `inFlight`, no row/state reconcile — likewise
+ * gains an owned-set-gated boot reap here (#1136).
  *
  * Why this mechanism exists: `inflight` is memory-only, so a server restart loses tracking of live
  * runs; the spawned interactive `claude` idles at the prompt forever after writing its output

--- a/test/standalone-critic.test.ts
+++ b/test/standalone-critic.test.ts
@@ -747,3 +747,44 @@ test("stopAll: reaps in-flight run without throwing (regression: unbound this)",
   expect(spies.removed).toEqual(["/review-wt"]);
   expect(svc.inflightWorktrees()).toEqual([]);
 });
+
+// ── boot reapOrphans (issue #1136) ──────────────────────────────────────────
+
+test("reapOrphans closes orphaned pr-critic tabs, sparing unrelated names", () => {
+  const closed: string[] = [];
+  const listed = [
+    { name: "pr-critic /r#42", terminalId: "orphan1", tabId: "tabO", agentStatus: "done" },
+    { name: "my-feature-branch", terminalId: "u1", tabId: "tabU", agentStatus: "running" },
+    { name: "review TASK-09", terminalId: "rv1", tabId: "tabR", agentStatus: "done" },
+  ];
+  const { deps } = makeDeps({
+    herdr: {
+      start: () => ({ terminalId: "rt" }),
+      stop: () => {},
+      list: () => listed,
+      closeTab: (id: string) => closed.push(id),
+    },
+  });
+  const svc = new StandalonePrCriticService(deps as any);
+  svc.reapOrphans(); // no in-flight runs at boot → empty owned set
+  expect(closed).toEqual(["tabO"]); // only the pr-critic orphan; unrelated + sibling reviewer spared
+});
+
+test("reapOrphans is a no-op when herdr is unavailable", () => {
+  let closes = 0;
+  const { deps } = makeDeps({
+    herdr: {
+      start: () => ({ terminalId: "rt" }),
+      stop: () => {},
+      list: () => {
+        throw new Error("herdr unavailable");
+      },
+      closeTab: () => {
+        closes++;
+      },
+    },
+  });
+  const svc = new StandalonePrCriticService(deps as any);
+  expect(() => svc.reapOrphans()).not.toThrow();
+  expect(closes).toBe(0);
+});


### PR DESCRIPTION
Closes #1136.

## What changed (and why the approach was reworked mid-review)

When this branch was opened, #1135 was unfixed and I proposed a single **generalized un-gated** boot reaper over all helper labels. During review two things became clear:

1. **#1135 has since landed on main** — `distiller`/`optimizer`/`mergeSuggest` each gained an **ownership-gated** `reapOrphans()` (the shared `reapTransientByLabel`, wired synchronously at boot, index.ts:1458/1471/1485). My generalized reaper was therefore redundant for those, and — being un-gated — it *raced* the `+10s` daily-sweep that spawns live `__distill__`/`__merge__` tabs (the critic's last finding). Correct catch.
2. `reapTransientByLabel`'s own docstring documents the maintainers' deliberate fleet teardown design: a universal "reap every kind" base is **intentionally out of scope**; each helper family reconciles via its own lifecycle.

So I **reverted the generalized reaper entirely** (`tab-reaper.ts` is back to baseline) and closed the *remaining* #1136 leak surface using the **same established `reapTransientByLabel` pattern** as #1135:

- **standalone PR critic (`pr-critic `)** — memory-only `inFlight`, no row/state boot reconcile (index.ts wired only `tick`/`sweep`/`stopAll`). A restart orphans its interactive `claude`, which idles at the prompt forever and is spared by the husk-only reaper as a live non-shell proc. Added `StandalonePrCriticService.reapOrphans()` mirroring distiller (owned-set from `inFlight` terminalIds), wired synchronously at boot.
- **`name ` / `autopilot ` / `verify api key`** — the synchronous block-and-clean helpers. #1093 left them unreaped on the premise their `finally`-stop leaves no husk — true only on a **clean** exit. A restart mid-poll skips the `finally` and orphans the `claude`. This is the concrete #1136 evidence: @scoop measured **10-day-old `autopilot` husks**. They track no inflight and none runs at the synchronous boot point, so `reapTransientByLabel` with an **empty owned set** correctly closes every prior-lifetime orphan.

## Why this can't race a live spawn

Every reap runs **synchronously at boot**, in the same eval phase as the #1135 reaps — before any spawn timer (`+10s` daily sweep, `+3s` probe) or event fires. There is no async-chain window for a current-lifetime helper to be spawned into and then wrongly closed. Ownership-gating (pr-critic) is a second guard for any later re-run.

## Scope notes

- Server-only; no UI → no feature-catalog / i18n / glossary entries (`fix`).
- usage probe is untouched — it self-sweeps by name (`UsageProbeService.sweep()`).
- review / plan-review / recap / rundown keep their existing reconciles (persisted `reviewer_spawns` / `generating` state).
- Secondary #1136 finding (idle/done DB sessions never auto-archive — different root cause) split out to #1156.

## Files

- `src/standalone-critic.ts` — widen `herdr` dep to `list`+`closeTab`; add `reapOrphans()`.
- `src/index.ts` — wire `standaloneCritic.reapOrphans()` + three synchronous `reapTransientByLabel` calls for the mechanism-4 helpers.
- `src/transient-tab-reaper.ts` — update the design note: record the unclean-exit gap these boot reaps now close.
- `test/standalone-critic.test.ts` — `reapOrphans` closes orphaned `pr-critic ` tabs / no-ops when herdr is unavailable.

`bun run lint` ✓ · `bunx tsc --noEmit` ✓ · `bun test` (standalone-critic, transient-tab-reaper, distiller, tab-reaper: 115 pass) ✓
