### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -29,6 +29,7 @@ lines), read by the systemd unit if present.
 | `SHEPHERD_TRIM_AUTO_CONTEXT` | `true` | Trim the per-turn context of auto-spawned (drain) agents (skill catalog + optional plugins disabled per-spawn). Interactive sessions untouched. Set `false`/`0`/`off` if drain quality regresses |
 | `SHEPHERD_USAGE_HOLD_ENABLED` | `true` | Queue newly submitted tasks instead of spawning them while account usage is high (auto-released as usage falls). Set `0`/`false` to always spawn immediately |
 | `SHEPHERD_USAGE_HOLD_PCT` | `80` | Hold threshold: when the higher of the 5-hour / weekly usage window reaches this percent, new tasks are held. Range `0`–`100` |
+| `SHEPHERD_USAGE_HOLD_AUTO_RELEASE` | `true` | When on, the ~30 s sweeper auto-starts held tasks once usage drops back below the threshold. Set `0`/`false` to keep held tasks queued until the operator starts (or discards) each one manually from the held-tasks popover. Turning the gate off entirely (`SHEPHERD_USAGE_HOLD_ENABLED=0`) still flushes everything regardless of this flag |
 
 ## Live preview
 


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc-update summary

## Changes

- **`docs-site/src/content/docs/reference/configuration.md`** — Added a `SHEPHERD_USAGE_HOLD_AUTO_RELEASE`
  row to the Core env-var table, directly under its two already-documented siblings
  (`SHEPHERD_USAGE_HOLD_ENABLED`, `SHEPHERD_USAGE_HOLD_PCT`). The doc's usage-hold coverage was
  incomplete: the feature gained a third knob that materially changes behavior (whether held tasks
  auto-release once usage drops, vs. staying queued for manual start). Grounded in `src/config.ts:588-595`
  (`usageHoldAutoRelease`, default on) introduced by commit `f6023b6b` (feat: auto-start toggle for
  held tasks, #1117).

## Uncertain / needs human judgment

- **Codex / multi-provider support (`SHEPHERD_DEFAULT_AGENT_PROVIDER`, `agentProvider` field).** Commits
  `f5c7e3ce` (#1086, "Codex coding CLI alpha path") and `56ef947b` (#1091, codex model selection) added a
  first-class second agent provider (`AGENT_PROVIDERS = ["claude", "codex"]`, `src/types.ts:7`), a new
  config knob `defaultAgentProvider` (`src/config.ts:521-522`), and an `agentProvider` key accepted by
  `validateCreate` (`src/validate.ts:36-50,85-91`). Several in-scope docs predate this and remain
  Claude-only:
  - `index.md` / `getting-started.md` describe Shepherd as mission control for "Claude Code agents" and
    list only the `claude` CLI under Requirements.
  - `docs/external-task-api.md`'s request-schema table omits `agentProvider` and documents only the
    Claude model enum.
  - `configuration.md` does not list `SHEPHERD_DEFAULT_AGENT_PROVIDER`.
  I did **not** edit these because (a) the source comments label Codex an "alpha path" and the default
  provider stays `claude`, so how prominently to feature it is an editorial call, and (b) the
  external-task-api request table is deliberately a *curated* subset of `validateCreate`'s accepted keys
  (it already omits `issueRef`, `planGateEnabled`, `autopilotEnabled`, `sandboxProfile`, `research`,
  `mergeTrainPrs`), so an omission there is consistent with the doc's scope rather than clearly stale.
  A human should decide whether/how to surface Codex across these pages.

- **`docs/external-task-api.md` usage-hold release wording.** The "Held tasks are released FIFO
  automatically by a ~30 s sweeper" sentence is correct for the default config but is now conditional on
  `SHEPHERD_USAGE_HOLD_AUTO_RELEASE` (above). Left as-is because it accurately describes the default
  behavior and the gate-decision env vars it cites ("two env vars") are still the two that govern *holding*;
  the new flag governs *release*. A maintainer may still want to cross-reference the new flag here.

- **`docs/token-usage-analysis.md`** — Left untouched: it is an explicitly point-in-time analytical
  report of five named historical task-sessions, not living reference prose. Its source references
  (`scripts/usage-report.ts`, `src/pricing.ts`, `src/usage-hold.ts`) still resolve; nothing was
  demonstrably falsified by recent commits.

- **`docs/sandbox-security.md`** — Left untouched. It already reflects the `#1093` transient-agent-argv
  refactor (it cites `src/transient-agent-argv.ts` / `buildTransientAgentArgv("reviewer", …)`). Its
  remaining `src/*.ts:NNN` line citations are approximate ("~L…") and may have drifted slightly, but I
  could not confirm any are wrong without exact re-derivation, so per the "don't guess" rule I left them.