### PR TITLE
fix(issues): distinguish failed issue fetch from 'no open issues'

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3552,8 +3552,17 @@ async function handleIssues({ req, parts, url, deps }: Ctx): Promise<Response | 
         viewer: (await forge.currentUser?.()) ?? null,
       });
     } catch {
-      // missing/un-authed CLI or network error → graceful empty (matches prior behavior)
-      return json({ slug: forge.slug, webUrl: forge.webUrl ?? null, issues: [], viewer: null });
+      // missing/un-authed CLI, network error, or a rate-limited forge (gh issue
+      // list runs on GitHub's GraphQL quota, which can hit 0) → empty list, but
+      // flag it as a fetch failure so the UI can say "couldn't load" instead of
+      // the indistinguishable "no open issues".
+      return json({
+        slug: forge.slug,
+        webUrl: forge.webUrl ?? null,
+        issues: [],
+        viewer: null,
+        error: "fetch_failed",
+      });
     }
   }
   return null;

--- a/test/server-issues.test.ts
+++ b/test/server-issues.test.ts
@@ -76,7 +76,7 @@ test("GET /api/issues with no forge for repo → {slug:null, issues:[]}", async 
   expect(await res.json()).toEqual({ slug: null, webUrl: null, issues: [], viewer: null });
 });
 
-test("GET /api/issues swallows forge errors → {slug, issues:[]}", async () => {
+test("GET /api/issues flags forge errors → {slug, issues:[], error}", async () => {
   const app = makeApp(
     makeDeps(() =>
       fakeForge({
@@ -88,11 +88,14 @@ test("GET /api/issues swallows forge errors → {slug, issues:[]}", async () => 
   );
   const res = await app.fetch(req(repoDir));
   expect(res.status).toBe(200);
+  // Empty issues but error set, so the UI can say "couldn't load" instead of
+  // the indistinguishable "no open issues" (e.g. a rate-limited forge).
   expect(await res.json()).toEqual({
     slug: "team/proj",
     webUrl: null,
     issues: [],
     viewer: null,
+    error: "fetch_failed",
   });
 });
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -23,6 +23,7 @@
   "herdrupdate_log_label": "Update-Protokoll",
   "herdrupdate_all_notes_link": "Alle Release-Notes ansehen",
   "common_needs_you": "BRAUCHT DICH · {count}",
+  "common_issues_load_failed": "Issues konnten nicht geladen werden – evtl. GitHub-Rate-Limit. Gleich nochmal versuchen.",
   "common_no_open_issues": "keine offenen Issues",
   "main_no_unit_selected": "KEINE AUFGABE GEWÄHLT",
   "unit_open_aria": "{name} öffnen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -23,6 +23,7 @@
   "herdrupdate_log_label": "Update log",
   "herdrupdate_all_notes_link": "View all release notes",
   "common_needs_you": "NEEDS YOU · {count}",
+  "common_issues_load_failed": "Couldn't load issues — GitHub may be rate-limited. Try again shortly.",
   "common_no_open_issues": "no open issues",
   "main_no_unit_selected": "NO TASK SELECTED",
   "unit_open_aria": "Open {name}",

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -728,6 +728,10 @@ export async function listIssues(repoPath: string): Promise<{
    *  resolved (offline/unauth/local forge). Drives the "mine & unassigned"
    *  filter (#824); null → fail open (show all). */
   viewer: string | null;
+  /** Set when the forge listing threw (missing/un-authed CLI, network, or a
+   *  rate-limited forge): the empty issues[] is a failure, not a genuine zero.
+   *  Lets the UI distinguish "couldn't load" from "no open issues". */
+  error?: string | null;
 }> {
   const r = await fetch(`/api/issues?repo=${encodeURIComponent(repoPath)}`);
   if (!r.ok) throw await failed(r, "issues");

--- a/ui/src/lib/components/PromptSources.browser.test.ts
+++ b/ui/src/lib/components/PromptSources.browser.test.ts
@@ -140,6 +140,27 @@ describe("PromptSources filter bar (popover + sticky coverage)", () => {
     issuesFilter.setActive(false);
   });
 
+  it("Issues tab: a flagged fetch error shows 'couldn't load', not 'no open issues'", async () => {
+    // Empty list but error set (e.g. rate-limited forge) — must read as a
+    // failure, not as the repo genuinely having zero open issues.
+    mockListIssues.mockResolvedValue({
+      slug: "owner/repo",
+      webUrl: null,
+      issues: [],
+      viewer: null,
+      error: "fetch_failed",
+    });
+
+    render(PromptSources, { repoPath: "/repo", onpick: noop, onpickissue: noop });
+
+    await expect
+      .poll(() => document.querySelector(".ps-body")?.textContent)
+      .toContain(m.common_issues_load_failed());
+    expect(document.querySelector(".ps-body")?.textContent).not.toContain(
+      m.common_no_open_issues(),
+    );
+  });
+
   it("Commands tab: search-input bar covers the rows behind it", async () => {
     mockListIssues.mockResolvedValue({
       slug: "owner/repo",

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -32,6 +32,9 @@
   let slug = $state<string | null>(null);
   let viewer = $state<string | null>(null);
   let loading = $state(false);
+  // True when the issue fetch failed (rate-limit/unauth/network) rather than the
+  // repo genuinely having no open issues — drives a distinct empty state.
+  let loadError = $state(false);
   // "Mine & unassigned" filter (#824), shared with IssuesPanel via issuesFilter.
   // No-op identity when the chip is hidden (viewer unknown) → fail open. Composed
   // with the viewer-agnostic "hide in progress" filter; the explicit
@@ -133,6 +136,7 @@
           slug = r.slug;
           issues = r.issues;
           viewer = r.viewer;
+          loadError = r.error != null;
           loading = false;
         })
         .catch(() => {
@@ -140,6 +144,7 @@
           slug = null;
           issues = [];
           viewer = null;
+          loadError = true;
           loading = false;
         });
     }
@@ -239,7 +244,9 @@
       <!-- Issues path: only reachable when allowIssues. The "issues" tab is
            absent and the no-TODO auto-switch is redirected to Commands when
            !allowIssues, so this branch is provably unreachable in that mode. -->
-      {#if slug === null}
+      {#if loadError}
+        <div class="muted">{m.common_issues_load_failed()}</div>
+      {:else if slug === null}
         <div class="muted">{m.promptsources_no_github()}</div>
       {:else if issues.length === 0}
         <div class="muted">{m.common_no_open_issues()}</div>


### PR DESCRIPTION
## Problem

Der „Neue Aufgabe"-Issue-Picker zeigte **„keine offenen Issues"**, obwohl das Repo 22 offene Issues hat (siehe Screenshot des Reporters).

Ursache: `gh issue list` läuft auf GitHubs **GraphQL-Quota**. Ist die erschöpft (`graphql.remaining: 0/5000`), wirft `forge.listIssues()`. Der Handler in `src/server.ts` fing **jeden** Fehler still ab und lieferte eine leere Liste zurück — für das Frontend ununterscheidbar von „dieses Repo hat wirklich 0 offene Issues". So sahen 22 Issues wie keine aus.

## Fix

Den Fehlerzustand sichtbar machen statt verschlucken:

- **`src/server.ts`** — der `catch` in `GET /api/issues` setzt jetzt `error: "fetch_failed"` (Liste bleibt leer).
- **`ui/src/lib/api.ts`** — `listIssues`-Rückgabetyp um optionales `error` erweitert.
- **`PromptSources.svelte`** — neuer `loadError`-Zustand; rendert eine eigene Meldung „Issues konnten nicht geladen werden – evtl. GitHub-Rate-Limit. Gleich nochmal versuchen." mit Vorrang vor dem `no open issues`-Leerzustand.
- **Messages** — `common_issues_load_failed` in `en.json` + `de.json` (Parität geprüft).

Rein diagnostisch — die eigentliche Rate-Limit-Erschöpfung ist transient (Reset stündlich); dieser PR sorgt nur dafür, dass der Picker den Unterschied **anzeigt**, statt fälschlich „leer" zu suggerieren.

## Tests

- `test/server-issues.test.ts` — der Fehler-Pfad-Test erwartet jetzt `error: "fetch_failed"`.
- `PromptSources.browser.test.ts` — neuer Fall: geflaggter Fetch-Fehler zeigt die „couldn't load"-Meldung, **nicht** „no open issues".

Grün: `check:i18n`, `lint`, `check` (svelte-check, 0 Fehler), `bun test test/server-issues.test.ts` (16/16), UI-Tests PromptSources/NewTask/IssuesPanel.

[no-feature-entry] — Fehler-/Leerzustand-Bugfix, kein neues nutzerseitiges Feature.