### PR TITLE
fix(ci): grant doc-automerge checks/statuses read scope

### DIFF
--- a/.github/workflows/doc-automerge.yml
+++ b/.github/workflows/doc-automerge.yml
@@ -31,6 +31,12 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # statusCheckRollup walks the head commit's check runs (CheckRun) AND legacy commit
+  # statuses (StatusContext); reading them needs these scopes. Without them the explicit
+  # permissions block defaults them to `none` and `gh pr view --json statusCheckRollup`
+  # dies with "Resource not accessible by integration" the moment a PR has any check.
+  checks: read
+  statuses: read
 
 # One merge pass at a time; never cancel a pass mid-merge.
 concurrency:


### PR DESCRIPTION
## Problem

The **Auto-merge doc PRs** workflow keeps failing ([run 28293837702](https://github.com/erwins-enkel/shepherd/actions/runs/28293837702)) once an open doc PR exists. It dies on `gh pr view --json statusCheckRollup` with:

```
GraphQL: Resource not accessible by integration
(repository.pullRequest.statusCheckRollup.nodes.0.commit.statusCheckRollup)
```

Under `set -euo pipefail` that propagates and the job exits 1.

## Root cause

The workflow declares an explicit `permissions:` block, which defaults every unlisted scope to `none`. `statusCheckRollup` walks the head commit's `CheckRun` nodes (needs `checks: read`) and legacy `StatusContext` nodes (needs `statuses: read`) — neither was granted, so GitHub rejects the nested query. It only surfaces now because the sub-resource is only read when a PR actually has checks.

## Fix

Add `checks: read` + `statuses: read` to `permissions:`. Least-privilege, read-only — no change to the merge logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)