### PR TITLE
feat(viewport): read-only scratchpad file browser (#1164)

### DIFF
--- a/docs/external-task-api.md
+++ b/docs/external-task-api.md
@@ -123,5 +123,10 @@ Once a task exists, an external agent can also drive it:
 - `DELETE /api/sessions/:id` — archive (end) the session.
 - `GET /api/sessions` — list active sessions; `GET /api/sessions/:id/diff`,
   `/activity`, `/usage` for inspection.
+- `GET /api/sessions/:id/scratchpad[?path=]` — read-only browse of a live
+  session's own scratchpad subtree; `GET /api/sessions/:id/scratchpad/download?path=`
+  streams a single file. Paths are relative to the scratchpad root and
+  realpath-contained to it (`..`, absolute, and symlink escapes are rejected);
+  both `404` on a missing/archived session.
 
 All of these honor the same auth/origin rules as task creation.

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,13 @@ import { recommendPrompt } from "./prompt-recommend";
 import { CountsService } from "./backlog";
 import { BacklogPoller } from "./backlog-poller";
 import { ProcessReaper, reapDeletedWorktreeOrphans } from "./process-reaper";
-import { sweepClaudeTmp, compileCacheDir, reapFallowCaches, pruneRepoWorktrees } from "./tmp-sweep";
+import {
+  sweepClaudeTmp,
+  compileCacheDir,
+  reapFallowCaches,
+  pruneRepoWorktrees,
+  scratchpadHasFiles,
+} from "./tmp-sweep";
 import { runSessionUsageBackfill } from "./usage-backfill";
 import { PreviewService } from "./preview";
 import { listRepos, listReposPathForReal } from "./repos";
@@ -490,7 +496,25 @@ const hookIngest = new HookIngest();
 const poller = new StatusPoller(
   store,
   herdr,
-  (id, status) => events.emit("session:status", { id, status }),
+  (id, status) => {
+    // On turn-end transitions (idle/done — when the agent has finished writing files), fold a
+    // fresh scratchpad-non-empty flag into the status push so the UI's Files tab appears/hides
+    // without a second poll (#1164). Computed only here, not on every running↔idle flap, to keep
+    // a readdir off the hot poll path. Other transitions emit the bare {id, status}; the UI merge
+    // guards against undefined so a status-only push never clobbers the live flag.
+    if (status === "idle" || status === "done") {
+      const s = store.get(id);
+      if (s) {
+        void scratchpadHasFiles(s.worktreePath, s.claudeSessionId)
+          .then((hasScratchpadFiles) =>
+            events.emit("session:status", { id, status, hasScratchpadFiles }),
+          )
+          .catch(() => events.emit("session:status", { id, status }));
+        return;
+      }
+    }
+    events.emit("session:status", { id, status });
+  },
   (id, block) => events.emit("session:block", { id, block }),
   undefined, // intervalMs
   undefined, // reclassifyMs
@@ -1191,7 +1215,10 @@ const drain = new DrainService({
   dropPrCache: (id) => prPoller.drop(id),
   emitEpic: (epic) => events.emit("epic:update", epic),
   emitEpicCompleted: (e) => events.emit("epic:completed", e),
-  emitSessionNew: (s) => events.emit("session:new", s),
+  // A brand-new session's agent is only just starting — its scratchpad can't hold artifacts
+  // yet, so seed hasScratchpadFiles=false (#1164). The live truth thereafter rides the
+  // session:status (idle/done) push and the /api/sessions list enrichment.
+  emitSessionNew: (s) => events.emit("session:new", { ...s, hasScratchpadFiles: false }),
   // #1071: wire rebase cap + real rebaseLandingBranch (mirrors autopilot/automerge wiring).
   rebaseCap: config.autoMergeRebaseCap,
 });

--- a/src/scratchpad.ts
+++ b/src/scratchpad.ts
@@ -1,0 +1,159 @@
+import { promises as fsp } from "node:fs";
+import { join, relative, dirname, sep, normalize, isAbsolute } from "node:path";
+import { sessionScratchpadDir } from "./tmp-sweep";
+
+/**
+ * Read-only browser of a session's scratchpad subtree (#1164). Every path the operator supplies
+ * is treated as RELATIVE to the scratchpad root and is realpath-contained to it: `..`, absolute
+ * paths, and symlink escapes all resolve to null/dropped. The genuinely new power vs. the
+ * existing `/api/fs/dirs` browser is streaming file BYTES, so containment is the trust boundary.
+ */
+
+export interface ScratchEntry {
+  name: string;
+  type: "file" | "dir";
+  /** Path relative to the scratchpad root, forward-slash separated, no leading slash. */
+  path: string;
+}
+
+export interface ScratchListing {
+  /** The directory being listed, relative to the root ("" = root). */
+  path: string;
+  /** Parent dir relative to the root, or null at the root. */
+  parent: string | null;
+  entries: ScratchEntry[];
+}
+
+/** true when `real` is the root itself or lives inside it (realpath containment). */
+function within(real: string, rootReal: string): boolean {
+  return real === rootReal || real.startsWith(rootReal + sep);
+}
+
+/** Root-relative, forward-slash form of an absolute path known to be within `rootReal`. */
+function relFromRoot(rootReal: string, abs: string): string {
+  if (abs === rootReal) return "";
+  return relative(rootReal, abs).split(sep).join("/");
+}
+
+/**
+ * Resolve a caller-supplied RELATIVE path against the session scratchpad root, enforcing
+ * containment via realpath. Returns the canonical `{ rootReal, resolved }`, or null when:
+ * `claudeSessionId` is blank, the root is absent, the request escapes the root (`..`, absolute,
+ * symlink), or the target doesn't exist.
+ */
+export async function resolveScratchpadPath(
+  worktreePath: string,
+  claudeSessionId: string,
+  relPath: string,
+): Promise<{ rootReal: string; resolved: string } | null> {
+  if (!claudeSessionId) return null;
+  let rootReal: string;
+  try {
+    rootReal = await fsp.realpath(sessionScratchpadDir(worktreePath, claudeSessionId));
+  } catch {
+    return null; // root not created yet (agent wrote nothing) / unreadable
+  }
+  // Treat as root-relative. Reject any normalized path that climbs above the root (`..`) or is
+  // absolute; realpath containment below is the backstop (catches symlink escapes too).
+  const norm = normalize(relPath || "");
+  if (norm === ".." || norm.startsWith(".." + sep) || isAbsolute(norm)) return null;
+  const target = norm === "" || norm === "." ? rootReal : join(rootReal, norm);
+  let resolved: string;
+  try {
+    resolved = await fsp.realpath(target);
+  } catch {
+    return null;
+  }
+  if (!within(resolved, rootReal)) return null;
+  return { rootReal, resolved };
+}
+
+/**
+ * List one directory of the scratchpad subtree. Returns null when the path can't be resolved
+ * (escape / missing) or isn't a directory. Entries include files AND subdirs AND dotfiles
+ * (it's the operator's own scratchpad); per-entry realpath filtering drops anything that points
+ * outside the root (e.g. an out-pointing symlink) so it never renders as a clickable row.
+ * Sort: directories first, then locale-aware alphabetical within each group.
+ */
+export async function listScratchpad(
+  worktreePath: string,
+  claudeSessionId: string,
+  relPath: string,
+): Promise<ScratchListing | null> {
+  const r = await resolveScratchpadPath(worktreePath, claudeSessionId, relPath);
+  if (!r) return null;
+  const { rootReal, resolved } = r;
+
+  let dirents;
+  try {
+    dirents = await fsp.readdir(resolved, { withFileTypes: true });
+  } catch {
+    return null; // not a directory / unreadable
+  }
+
+  const entries: ScratchEntry[] = [];
+  for (const d of dirents) {
+    const abs = join(resolved, d.name);
+    let real: string;
+    try {
+      real = await fsp.realpath(abs);
+    } catch {
+      continue; // broken symlink / unreadable → skip
+    }
+    if (!within(real, rootReal)) continue; // never surface an entry that escapes the root
+    let isDir: boolean;
+    try {
+      isDir = (await fsp.stat(abs)).isDirectory();
+    } catch {
+      continue;
+    }
+    entries.push({ name: d.name, type: isDir ? "dir" : "file", path: relFromRoot(rootReal, abs) });
+  }
+
+  entries.sort((a, b) =>
+    a.type !== b.type ? (a.type === "dir" ? -1 : 1) : a.name.localeCompare(b.name),
+  );
+
+  const here = relFromRoot(rootReal, resolved);
+  return {
+    path: here,
+    parent: here === "" ? null : relFromRoot(rootReal, dirname(resolved)),
+    entries,
+  };
+}
+
+/**
+ * Resolve a scratchpad path that must be a regular FILE (for download). Returns the canonical
+ * absolute path, or null on escape / missing / not-a-regular-file.
+ */
+export async function resolveScratchpadFile(
+  worktreePath: string,
+  claudeSessionId: string,
+  relPath: string,
+): Promise<string | null> {
+  const r = await resolveScratchpadPath(worktreePath, claudeSessionId, relPath);
+  if (!r) return null;
+  try {
+    if (!(await fsp.stat(r.resolved)).isFile()) return null;
+  } catch {
+    return null;
+  }
+  return r.resolved;
+}
+
+/**
+ * Build a safe `Content-Disposition` header for an attachment download. Emits both an ASCII
+ * `filename="…"` (control chars / quote / backslash replaced) and an RFC 5987
+ * `filename*=UTF-8''…` so non-ASCII names survive without throwing an invalid-header (500) or
+ * allowing header injection on a CR/LF in the name.
+ */
+export function attachmentDisposition(name: string): string {
+  const ascii =
+    [...name]
+      .map((c) => {
+        const code = c.charCodeAt(0);
+        return code < 0x20 || code > 0x7e || c === '"' || c === "\\" ? "_" : c;
+      })
+      .join("") || "download";
+  return `attachment; filename="${ascii}"; filename*=UTF-8''${encodeURIComponent(name)}`;
+}

--- a/src/scratchpad.ts
+++ b/src/scratchpad.ts
@@ -155,5 +155,11 @@ export function attachmentDisposition(name: string): string {
         return code < 0x20 || code > 0x7e || c === '"' || c === "\\" ? "_" : c;
       })
       .join("") || "download";
-  return `attachment; filename="${ascii}"; filename*=UTF-8''${encodeURIComponent(name)}`;
+  // RFC 5987 ext-value: encodeURIComponent leaves `'()*` unescaped, but those are not valid
+  // `attr-char`s — percent-encode them too so the header is conformant.
+  const encoded = encodeURIComponent(name).replace(
+    /['()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+  return `attachment; filename="${ascii}"; filename*=UTF-8''${encoded}`;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -67,6 +67,8 @@ import { resolveDefaultBranch, fastForwardDefaultBranch } from "./pull";
 import { analyzeReadiness } from "./readiness";
 import { listCommands } from "./commands";
 import { listDirs, validateRoot, collapseHome } from "./dirs";
+import { scratchpadHasFiles } from "./tmp-sweep";
+import { listScratchpad, resolveScratchpadFile, attachmentDisposition } from "./scratchpad";
 import { loadSteers, saveSteers } from "./steers";
 import { loadIcons, setIcon } from "./project-icons";
 import { listBranches } from "./branches";
@@ -123,7 +125,7 @@ import {
 } from "./completed-epic";
 import { parseEpicBody } from "./epic-parse";
 import { countDefinedWorkflows, type CountsService, type RepoCounts } from "./backlog";
-import { join, normalize } from "node:path";
+import { join, normalize, basename } from "node:path";
 import { homedir } from "node:os";
 import type { ServerWebSocket } from "bun";
 import { markPtyEvent } from "./instrument";
@@ -1590,9 +1592,29 @@ async function sessionDiffRead(id: string, deps: AppDeps): Promise<Response> {
   }
 }
 
-function sessionRead(id: string, deps: AppDeps): Response {
+async function sessionRead(id: string, deps: AppDeps): Promise<Response> {
   const s = deps.store.get(id);
-  return s ? json(s) : json({ error: "not found" }, 404);
+  if (!s) return json({ error: "not found" }, 404);
+  if (s.status === "archived") return json(s);
+  return json({
+    ...s,
+    hasScratchpadFiles: await scratchpadHasFiles(s.worktreePath, s.claudeSessionId),
+  });
+}
+
+// Attach the transient, derived `hasScratchpadFiles` flag (#1164) to each ACTIVE session in
+// parallel — the cheap signal the UI's Files tab is gated on. Archived sessions keep their bare
+// row (the scratchpad is out of scope post-archive). Not persisted: computed at serialize time.
+async function withScratchpadFlags(
+  sessions: Session[],
+): Promise<Array<Session & { hasScratchpadFiles?: boolean }>> {
+  return Promise.all(
+    sessions.map(async (s) =>
+      s.status === "archived"
+        ? s
+        : { ...s, hasScratchpadFiles: await scratchpadHasFiles(s.worktreePath, s.claudeSessionId) },
+    ),
+  );
 }
 
 // Recently-archived sessions for the Done lens, each enriched with the web URL of its
@@ -1615,7 +1637,7 @@ function doneSessionsWithIssueUrl(deps: AppDeps): Array<Session & { issueUrl?: s
 // GET reads on /api/sessions[/:id[/usage|/activity|/diff|/leftovers]].
 async function handleSessionReads({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (req.method !== "GET") return null;
-  if (!parts[2]) return json(deps.store.list({ activeOnly: true }));
+  if (!parts[2]) return json(await withScratchpadFlags(deps.store.list({ activeOnly: true })));
   // "Done" lens: sessions archived within the last DONE_LENS_WINDOW_MS, newest-first.
   // Must precede the bare sessionRead fall-through so "done" isn't read as a session id.
   if (parts[2] === "done" && !parts[3]) return json(doneSessionsWithIssueUrl(deps));
@@ -1625,6 +1647,35 @@ async function handleSessionReads({ req, parts, deps }: Ctx): Promise<Response |
   // leftover subprocesses/proxies that would survive this session's close
   if (parts[3] === "leftovers") return json(deps.service.leftovers(parts[2]));
   if (!parts[3]) return sessionRead(parts[2], deps);
+  return null;
+}
+
+// ── scratchpad file browser: GET /api/sessions/:id/scratchpad[?path=] (list)
+//                            GET /api/sessions/:id/scratchpad/download?path= (file) ──
+// Read-only browse + single-file download, rooted at and realpath-contained to the session's
+// OWN scratchpad dir (#1164). Live sessions only: 404 on a missing/archived session. `path` is
+// relative to the scratchpad root; containment is enforced in src/scratchpad.ts.
+async function handleSessionScratchpad({ req, parts, url, deps }: Ctx): Promise<Response | null> {
+  if (req.method !== "GET" || parts[3] !== "scratchpad") return null;
+  const s = deps.store.get(parts[2] ?? "");
+  if (!s || s.status === "archived") return json({ error: "not found" }, 404);
+  const rel = url.searchParams.get("path") ?? "";
+
+  if (parts[4] === "download") {
+    const file = await resolveScratchpadFile(s.worktreePath, s.claudeSessionId, rel);
+    if (!file) return json({ error: "not found" }, 404);
+    const f = Bun.file(file);
+    return new Response(f, {
+      headers: {
+        "content-type": f.type || "application/octet-stream",
+        "content-disposition": attachmentDisposition(basename(file)),
+      },
+    });
+  }
+  if (!parts[4]) {
+    const listing = await listScratchpad(s.worktreePath, s.claudeSessionId, rel);
+    return listing ? json(listing) : json({ error: "not found" }, 404);
+  }
   return null;
 }
 
@@ -2402,6 +2453,7 @@ async function handleSessions(ctx: Ctx): Promise<Response | null> {
     handleSessionsClearMerged,
     handleSessionCreate,
     handleSessionReads,
+    handleSessionScratchpad,
     handleSessionDelete,
     handleSessionReply,
     handleSessionRecommend,

--- a/src/tmp-sweep.ts
+++ b/src/tmp-sweep.ts
@@ -69,6 +69,41 @@ export function worktreeScratchDir(worktreePath: string): string {
   return join(claudeTmpRoot(), `claude-${uid()}`, dashify(worktreePath));
 }
 
+/**
+ * The per-session SCRATCHPAD dir for a Shepherd session's OWN (top-level) claude agent:
+ * `<claudeTmpRoot>/<dashified-worktree>/<claudeSessionId>/scratchpad`.
+ *
+ * DISTINCT from `worktreeScratchDir` above: that helper models the doubled `claude-$uid` base
+ * a NESTED sub-agent derives (those dirs hold `<uuid>/tasks`, never a `scratchpad`). A session's
+ * own artifacts live under the SINGLE base, keyed by the claude session UUID. The issue (#1164)
+ * originally said to reuse `worktreeScratchDir` — that is the wrong base; verified empirically
+ * against the live tmp tree (the server runs with no TMPDIR override, so `claudeTmpRoot()` here
+ * matches the agent's). Reuses the same `claudeTmpRoot()` + `dashify()` primitives, dropping the
+ * nested `claude-$uid` segment and appending the session-scoped tail.
+ */
+export function sessionScratchpadDir(worktreePath: string, claudeSessionId: string): string {
+  return join(claudeTmpRoot(), dashify(worktreePath), claudeSessionId, "scratchpad");
+}
+
+/**
+ * Shallow, async, non-throwing "does this session's scratchpad hold any entry?" probe — the
+ * cheap signal that gates the UI's Files tab (#1164). Counts ANY entry (files OR subdirs,
+ * dotfiles included). Returns false on a blank `claudeSessionId` (pre-`--session-id` session /
+ * agent not yet started), a missing dir, or any read error. Single shallow `readdir`.
+ */
+export async function scratchpadHasFiles(
+  worktreePath: string,
+  claudeSessionId: string,
+): Promise<boolean> {
+  if (!claudeSessionId) return false;
+  try {
+    const entries = await fsp.readdir(sessionScratchpadDir(worktreePath, claudeSessionId));
+    return entries.length > 0;
+  } catch {
+    return false;
+  }
+}
+
 export interface SweepResult {
   swept: boolean;
   reason: string;

--- a/test/scratchpad-endpoint.test.ts
+++ b/test/scratchpad-endpoint.test.ts
@@ -1,0 +1,161 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { makeApp, type AppDeps } from "../src/server";
+import { SessionStore } from "../src/store";
+import { EventHub } from "../src/events";
+import { config } from "../src/config";
+import { sessionScratchpadDir } from "../src/tmp-sweep";
+
+let tmpRoot: string;
+let repoDir: string;
+let scratchRoot: string;
+const prevEnv = process.env.SHEPHERD_TMP_SWEEP_DIR;
+const SID = "claude-sess-1";
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(config.repoRoot, "shepherd-scratch-ep-"));
+  repoDir = join(tmpRoot, "repo");
+  mkdirSync(repoDir);
+  scratchRoot = mkdtempSync(join(config.repoRoot, "shepherd-scratch-tmp-"));
+  process.env.SHEPHERD_TMP_SWEEP_DIR = scratchRoot;
+});
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  rmSync(scratchRoot, { recursive: true, force: true });
+  if (prevEnv === undefined) delete process.env.SHEPHERD_TMP_SWEEP_DIR;
+  else process.env.SHEPHERD_TMP_SWEEP_DIR = prevEnv;
+});
+
+function harness() {
+  const store = new SessionStore(":memory:");
+  const hub = new EventHub();
+  const deps: AppDeps = {
+    store,
+    service: {} as any,
+    events: hub,
+    usageLimits: { limits: () => ({}) } as any,
+  };
+  return { app: makeApp(deps), store };
+}
+
+function makeSession(store: SessionStore) {
+  return store.create({
+    name: "scratch-session",
+    prompt: "p",
+    repoPath: repoDir,
+    baseBranch: "main",
+    branch: "shepherd/scratch",
+    worktreePath: repoDir,
+    isolated: false,
+    herdrSession: "sess-x",
+    herdrAgentId: "agent-x",
+    claudeSessionId: SID,
+    model: null,
+  });
+}
+
+/** Populate the session's scratchpad with a file, a dotfile, and a nested dir. */
+function seedScratchpad() {
+  const root = sessionScratchpadDir(repoDir, SID);
+  mkdirSync(join(root, "logs"), { recursive: true });
+  writeFileSync(join(root, "config.yaml"), "yaml: 1\n");
+  writeFileSync(join(root, ".env"), "X=1");
+  writeFileSync(join(root, "logs", "run.log"), "log");
+  return root;
+}
+
+test("GET scratchpad lists the root (dirs first, dotfiles shown)", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  seedScratchpad();
+
+  const res = await app.fetch(new Request(`http://x/api/sessions/${s.id}/scratchpad`));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.path).toBe("");
+  expect(body.parent).toBeNull();
+  expect(body.entries.map((e: { name: string }) => e.name)).toEqual([
+    "logs",
+    ".env",
+    "config.yaml",
+  ]);
+});
+
+test("GET scratchpad?path=logs descends into a subdir", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  seedScratchpad();
+
+  const res = await app.fetch(new Request(`http://x/api/sessions/${s.id}/scratchpad?path=logs`));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.path).toBe("logs");
+  expect(body.parent).toBe("");
+  expect(body.entries[0].path).toBe("logs/run.log");
+});
+
+test("GET scratchpad rejects a `..` escape with 404", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  seedScratchpad();
+
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${s.id}/scratchpad?path=${encodeURIComponent("../..")}`),
+  );
+  expect(res.status).toBe(404);
+});
+
+test("download streams a file with an attachment Content-Disposition", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  seedScratchpad();
+
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${s.id}/scratchpad/download?path=config.yaml`),
+  );
+  expect(res.status).toBe(200);
+  expect(res.headers.get("content-disposition")).toBe(
+    "attachment; filename=\"config.yaml\"; filename*=UTF-8''config.yaml",
+  );
+  expect(await res.text()).toBe("yaml: 1\n");
+});
+
+test("download of a directory is 404 (files only)", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  seedScratchpad();
+
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${s.id}/scratchpad/download?path=logs`),
+  );
+  expect(res.status).toBe(404);
+});
+
+test("scratchpad of an unknown session is 404", async () => {
+  const { app } = harness();
+  const res = await app.fetch(new Request("http://x/api/sessions/nope/scratchpad"));
+  expect(res.status).toBe(404);
+});
+
+test("scratchpad of an archived session is 404 (live only)", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  seedScratchpad();
+  store.update(s.id, { status: "archived" });
+
+  const res = await app.fetch(new Request(`http://x/api/sessions/${s.id}/scratchpad`));
+  expect(res.status).toBe(404);
+});
+
+test("GET /api/sessions enriches active sessions with hasScratchpadFiles", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  seedScratchpad();
+
+  const res = await app.fetch(new Request("http://x/api/sessions"));
+  expect(res.status).toBe(200);
+  const list = await res.json();
+  const row = list.find((r: { id: string }) => r.id === s.id);
+  expect(row.hasScratchpadFiles).toBe(true);
+});

--- a/test/scratchpad.test.ts
+++ b/test/scratchpad.test.ts
@@ -1,0 +1,157 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { sessionScratchpadDir, scratchpadHasFiles } from "../src/tmp-sweep";
+import {
+  listScratchpad,
+  resolveScratchpadPath,
+  resolveScratchpadFile,
+  attachmentDisposition,
+} from "../src/scratchpad";
+
+const WT = "/home/u/Work/proj";
+const SID = "sess-uuid-1";
+
+let tmpRoot: string; // SHEPHERD_TMP_SWEEP_DIR → claudeTmpRoot()
+let outside: string; // a sibling dir OUTSIDE the scratchpad root, for escape tests
+let root: string; // the resolved scratchpad root
+const prevEnv = process.env.SHEPHERD_TMP_SWEEP_DIR;
+
+beforeEach(() => {
+  tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), "shepherd-scratch-test-")));
+  outside = realpathSync(mkdtempSync(join(tmpdir(), "shepherd-scratch-out-")));
+  process.env.SHEPHERD_TMP_SWEEP_DIR = tmpRoot;
+
+  root = sessionScratchpadDir(WT, SID);
+  mkdirSync(root, { recursive: true });
+  // files + a subdir + a dotfile + nested content
+  writeFileSync(join(root, "config.yaml"), "yaml: 1");
+  writeFileSync(join(root, "alpha.txt"), "a");
+  writeFileSync(join(root, ".env"), "SECRET=1");
+  mkdirSync(join(root, "logs"));
+  writeFileSync(join(root, "logs", "run.log"), "log");
+  writeFileSync(join(outside, "secret.txt"), "leak");
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  rmSync(outside, { recursive: true, force: true });
+  if (prevEnv === undefined) delete process.env.SHEPHERD_TMP_SWEEP_DIR;
+  else process.env.SHEPHERD_TMP_SWEEP_DIR = prevEnv;
+});
+
+// ── scratchpadHasFiles ──────────────────────────────────────────────────────────
+
+test("scratchpadHasFiles: true for a non-empty scratchpad", async () => {
+  expect(await scratchpadHasFiles(WT, SID)).toBe(true);
+});
+
+test("scratchpadHasFiles: false for a blank claudeSessionId", async () => {
+  expect(await scratchpadHasFiles(WT, "")).toBe(false);
+});
+
+test("scratchpadHasFiles: false for a missing scratchpad dir", async () => {
+  expect(await scratchpadHasFiles(WT, "no-such-session")).toBe(false);
+});
+
+test("scratchpadHasFiles: true when only a dotfile is present", async () => {
+  const sid = "dot-only";
+  const d = sessionScratchpadDir(WT, sid);
+  mkdirSync(d, { recursive: true });
+  writeFileSync(join(d, ".hidden"), "x");
+  expect(await scratchpadHasFiles(WT, sid)).toBe(true);
+});
+
+test("scratchpadHasFiles: false for an empty scratchpad dir", async () => {
+  const sid = "empty";
+  mkdirSync(sessionScratchpadDir(WT, sid), { recursive: true });
+  expect(await scratchpadHasFiles(WT, sid)).toBe(false);
+});
+
+// ── listScratchpad ──────────────────────────────────────────────────────────────
+
+test("listScratchpad: lists files + dirs + dotfiles, directories first then alphabetical", async () => {
+  const l = await listScratchpad(WT, SID, "");
+  expect(l).not.toBeNull();
+  expect(l!.path).toBe("");
+  expect(l!.parent).toBeNull();
+  // dir (logs) first, then files alphabetically incl. the dotfile
+  expect(l!.entries.map((e) => `${e.type}:${e.name}`)).toEqual([
+    "dir:logs",
+    "file:.env",
+    "file:alpha.txt",
+    "file:config.yaml",
+  ]);
+  expect(l!.entries.find((e) => e.name === "logs")!.path).toBe("logs");
+});
+
+test("listScratchpad: descends into a subdir and exposes parent === root ('')", async () => {
+  const l = await listScratchpad(WT, SID, "logs");
+  expect(l).not.toBeNull();
+  expect(l!.path).toBe("logs");
+  expect(l!.parent).toBe("");
+  expect(l!.entries.map((e) => e.name)).toEqual(["run.log"]);
+  expect(l!.entries[0]!.path).toBe("logs/run.log");
+});
+
+test("listScratchpad: null for a blank claudeSessionId / missing root", async () => {
+  expect(await listScratchpad(WT, "", "")).toBeNull();
+  expect(await listScratchpad(WT, "no-such-session", "")).toBeNull();
+});
+
+test("listScratchpad: null when the target is a file, not a dir", async () => {
+  expect(await listScratchpad(WT, SID, "config.yaml")).toBeNull();
+});
+
+test("listScratchpad: rejects `..` and absolute-path escapes", async () => {
+  for (const rel of ["..", "../..", "../secret.txt", "/etc"]) {
+    expect(await listScratchpad(WT, SID, rel)).toBeNull();
+  }
+});
+
+test("listScratchpad: drops an entry whose symlink escapes the root", async () => {
+  symlinkSync(outside, join(root, "escape")); // → outside the scratchpad
+  symlinkSync(join(root, "config.yaml"), join(root, "inside-link")); // → inside, kept
+  const l = await listScratchpad(WT, SID, "");
+  const names = l!.entries.map((e) => e.name);
+  expect(names).not.toContain("escape");
+  expect(names).toContain("inside-link");
+});
+
+// ── resolveScratchpadPath / resolveScratchpadFile ─────────────────────────────────
+
+test("resolveScratchpadPath: resolves a contained path and rejects escapes", async () => {
+  expect(await resolveScratchpadPath(WT, SID, "logs")).not.toBeNull();
+  // a symlink that points outside resolves out → rejected
+  symlinkSync(join(outside, "secret.txt"), join(root, "out"));
+  expect(await resolveScratchpadPath(WT, SID, "out")).toBeNull();
+});
+
+test("resolveScratchpadFile: returns a file path, null for a dir / escape", async () => {
+  const f = await resolveScratchpadFile(WT, SID, "config.yaml");
+  expect(f).toBe(realpathSync(join(root, "config.yaml")));
+  expect(await resolveScratchpadFile(WT, SID, "logs")).toBeNull(); // a dir
+  expect(await resolveScratchpadFile(WT, SID, "../secret.txt")).toBeNull(); // escape
+});
+
+// ── attachmentDisposition ─────────────────────────────────────────────────────────
+
+test("attachmentDisposition: ASCII name passes through with an RFC 5987 copy", () => {
+  expect(attachmentDisposition("config.yaml")).toBe(
+    "attachment; filename=\"config.yaml\"; filename*=UTF-8''config.yaml",
+  );
+});
+
+test("attachmentDisposition: strips CR/LF/quote from the ASCII fallback (no header injection)", () => {
+  const d = attachmentDisposition('a"b\r\nc.txt');
+  expect(d).toContain('filename="a_b__c.txt"');
+  expect(d).not.toContain("\r");
+  expect(d).not.toContain("\n");
+});
+
+test("attachmentDisposition: percent-encodes a non-ASCII name in filename*", () => {
+  const d = attachmentDisposition("café.txt");
+  expect(d).toContain("filename*=UTF-8''caf%C3%A9.txt");
+  expect(d).toContain('filename="caf_.txt"'); // é replaced in the ASCII fallback
+});

--- a/test/scratchpad.test.ts
+++ b/test/scratchpad.test.ts
@@ -155,3 +155,9 @@ test("attachmentDisposition: percent-encodes a non-ASCII name in filename*", () 
   expect(d).toContain("filename*=UTF-8''caf%C3%A9.txt");
   expect(d).toContain('filename="caf_.txt"'); // é replaced in the ASCII fallback
 });
+
+test("attachmentDisposition: percent-encodes RFC 5987 non-attr-chars ('()*) in filename*", () => {
+  const d = attachmentDisposition("a'b(c)*d.txt");
+  // ' ( ) * → %27 %28 %29 %2A (encodeURIComponent would otherwise leave them raw)
+  expect(d).toContain("filename*=UTF-8''a%27b%28c%29%2Ad.txt");
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2044,5 +2044,13 @@
   "backlog_hide_repo": "Repo ausblenden",
   "backlog_unhide_repo": "Repo einblenden",
   "feat_hide_repos_title": "Repos aus dem Panel ausblenden",
-  "feat_hide_repos_body": "Räume das Backlog-Repos-Panel auf: Fahre über eine Repo-Zeile und klicke auf das Auge, um sie auszublenden. Ein „Ausgeblendet“-Chip zeigt ausgeblendete Repos wieder an, sodass du sie zurückholen kannst. Nur die Anzeige – Sessions, Drain und Summen bleiben unberührt."
+  "feat_hide_repos_body": "Räume das Backlog-Repos-Panel auf: Fahre über eine Repo-Zeile und klicke auf das Auge, um sie auszublenden. Ein „Ausgeblendet“-Chip zeigt ausgeblendete Repos wieder an, sodass du sie zurückholen kannst. Nur die Anzeige – Sessions, Drain und Summen bleiben unberührt.",
+  "viewport_files_tab": "Dateien",
+  "files_root_crumb": "Scratchpad",
+  "files_breadcrumb_aria": "Scratchpad-Pfad",
+  "files_empty": "Noch keine Dateien im Scratchpad.",
+  "files_load_error": "Scratchpad-Dateien konnten nicht geladen werden.",
+  "files_download_aria": "{name} herunterladen",
+  "feat_scratchpad_files_title": "Scratchpad einer Session durchsuchen & herunterladen",
+  "feat_scratchpad_files_body": "Die Ansicht einer laufenden Session hat jetzt einen Dateien-Tab, sobald ihr Scratchpad Artefakte enthält. Durchsuche die vom Agenten erstellten Ordner und lade jede Datei direkt auf deinen Rechner."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2044,5 +2044,13 @@
   "backlog_hide_repo": "Hide repo",
   "backlog_unhide_repo": "Unhide repo",
   "feat_hide_repos_title": "Hide repos from the panel",
-  "feat_hide_repos_body": "Declutter the Backlog repos panel: hover a repo row and click the eye to hide it. A \"Hidden\" chip reveals hidden repos so you can bring them back. It's list-only — the repo's sessions, drain and totals are untouched."
+  "feat_hide_repos_body": "Declutter the Backlog repos panel: hover a repo row and click the eye to hide it. A \"Hidden\" chip reveals hidden repos so you can bring them back. It's list-only — the repo's sessions, drain and totals are untouched.",
+  "viewport_files_tab": "Files",
+  "files_root_crumb": "scratchpad",
+  "files_breadcrumb_aria": "Scratchpad path",
+  "files_empty": "No files in the scratchpad yet.",
+  "files_load_error": "Couldn't load scratchpad files.",
+  "files_download_aria": "Download {name}",
+  "feat_scratchpad_files_title": "Browse & download a session's scratchpad",
+  "feat_scratchpad_files_body": "A live session's viewport now has a Files tab whenever its scratchpad holds artifacts. Browse the folders the agent wrote and download any file straight to your machine."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -17,6 +17,7 @@ import type {
   MergeMethod,
   Settings,
   DirListing,
+  ScratchListing,
   UpdateStatus,
   DeployState,
   HerdrUpdateStatus,
@@ -503,6 +504,21 @@ export async function listDirs(path?: string): Promise<DirListing> {
   const r = await fetch(`/api/fs/dirs${q}`);
   if (!r.ok) throw await failed(r, "dirs");
   return r.json();
+}
+
+/** List one directory of a session's read-only scratchpad subtree (#1164). `path` is relative
+ *  to the scratchpad root ("" / undefined = root). */
+export async function getScratchpadListing(id: string, path?: string): Promise<ScratchListing> {
+  const q = path ? `?path=${encodeURIComponent(path)}` : "";
+  const r = await fetch(`/api/sessions/${id}/scratchpad${q}`);
+  if (!r.ok) throw await failed(r, "scratchpad");
+  return r.json();
+}
+
+/** Same-origin download URL for one scratchpad file (#1164). Used as a plain `<a href download>`
+ *  target — the operator's HttpOnly auth cookie rides the GET automatically. */
+export function scratchpadDownloadUrl(id: string, path: string): string {
+  return `/api/sessions/${id}/scratchpad/download?path=${encodeURIComponent(path)}`;
 }
 
 export interface BranchList {

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -44,6 +44,7 @@
   import ActivityFeed from "$lib/components/ActivityFeed.svelte";
   import SubagentFanout from "$lib/components/SubagentFanout.svelte";
   import DiffPanel from "$lib/components/DiffPanel.svelte";
+  import FilesPanel from "./viewport/FilesPanel.svelte";
   import { enterKey } from "$lib/controlKeys";
   import { lockAxis, paneSwipeAction, type Axis } from "./swipe";
   import GitRail from "$lib/components/GitRail.svelte";
@@ -193,7 +194,7 @@
   let viewportEl: HTMLDivElement | undefined = $state();
   let swipeX = $state(0);
   let swiping = $state(false);
-  let tab = $state<"term" | "todo" | "activity" | "diff" | "preview">("term");
+  let tab = $state<"term" | "todo" | "activity" | "diff" | "files" | "preview">("term");
   // desktop only: reveals the git rail (PR / merge / critic / ready / verdict) as a
   // second header row, so the primary strip stays uncrowded until the operator asks
   let gitOpen = $state(false);
@@ -507,6 +508,14 @@
   // Don't strand the operator on a To-Do tab that just vanished (TODO.md removed).
   $effect(() => {
     if (todoExists === false && tab === "todo") tab = "term";
+  });
+
+  // The Files tab is gated on the server-derived hasScratchpadFiles flag (#1164) — folded into
+  // the session payload + refreshed by the session:status (idle/done) push, so no extra poll.
+  const hasFiles = $derived(session.hasScratchpadFiles === true);
+  // Don't strand the operator on a Files tab whose scratchpad just emptied.
+  $effect(() => {
+    if (!hasFiles && tab === "files") tab = "term";
   });
 
   // once a PR exists (open or merged) the session has delivered its work — surface
@@ -1843,6 +1852,7 @@
       {session}
       {previewPort}
       todoExists={!!todoExists}
+      {hasFiles}
       {hasPreview}
       {compact}
       {headerFolded}
@@ -2109,6 +2119,11 @@
     {#if tab === "diff"}
       <div class="panel-wrap">
         <DiffPanel sessionId={session.id} />
+      </div>
+    {/if}
+    {#if tab === "files"}
+      <div class="panel-wrap">
+        <FilesPanel sessionId={session.id} />
       </div>
     {/if}
     {#if tab === "preview" && previewUrl}

--- a/ui/src/lib/components/viewport/FilesPanel.svelte
+++ b/ui/src/lib/components/viewport/FilesPanel.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+  import { getScratchpadListing, scratchpadDownloadUrl } from "$lib/api";
+  import type { ScratchListing } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+
+  // Read-only browser of the session's scratchpad subtree (#1164). Click a directory to descend,
+  // click a file to download it. Server enforces containment to the scratchpad root.
+  let { sessionId }: { sessionId: string } = $props();
+
+  let listing = $state<ScratchListing | null>(null);
+  let loading = $state(false);
+  let error = $state(false);
+
+  async function browse(path: string) {
+    loading = true;
+    error = false;
+    try {
+      listing = await getScratchpadListing(sessionId, path || undefined);
+    } catch {
+      error = true;
+    } finally {
+      loading = false;
+    }
+  }
+
+  // (Re)load the root whenever the viewed session changes. Keyed on the id value so it only
+  // re-runs on an actual unit switch, not on session-object churn.
+  $effect(() => {
+    const id = sessionId;
+    listing = null;
+    error = false;
+    void browse("");
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- reactive dep
+    id;
+  });
+
+  // Breadcrumb segments from the current relative path; the first crumb is the scratchpad root.
+  const crumbs = $derived.by(() => {
+    const segs = listing?.path ? listing.path.split("/") : [];
+    const out: { label: string; path: string }[] = [{ label: m.files_root_crumb(), path: "" }];
+    let acc = "";
+    for (const s of segs) {
+      acc = acc ? `${acc}/${s}` : s;
+      out.push({ label: s, path: acc });
+    }
+    return out;
+  });
+</script>
+
+<div class="files">
+  <nav class="crumbs" aria-label={m.files_breadcrumb_aria()}>
+    {#each crumbs as c, i (c.path)}
+      {#if i > 0}<span class="crumb-sep" aria-hidden="true">/</span>{/if}
+      {#if i === crumbs.length - 1}
+        <span class="crumb current" aria-current="page">{c.label}</span>
+      {:else}
+        <button type="button" class="crumb" onclick={() => browse(c.path)}>{c.label}</button>
+      {/if}
+    {/each}
+  </nav>
+
+  <div class="list">
+    {#if loading && !listing}
+      <div class="placeholder">{m.common_loading()}</div>
+    {:else if error}
+      <div class="placeholder err">{m.files_load_error()}</div>
+    {:else if listing && listing.entries.length === 0}
+      <div class="placeholder">{m.files_empty()}</div>
+    {:else if listing}
+      {#each listing.entries as e (e.path)}
+        {#if e.type === "dir"}
+          <button type="button" class="row" onclick={() => browse(e.path)}>
+            <span class="ico" aria-hidden="true">▸</span>
+            <span class="nm">{e.name}</span>
+            <span class="chev" aria-hidden="true">›</span>
+          </button>
+        {:else}
+          <!-- eslint-disable svelte/no-navigation-without-resolve -- server API download endpoint, not an app route -->
+          <a
+            class="row file"
+            href={scratchpadDownloadUrl(sessionId, e.path)}
+            download={e.name}
+            aria-label={m.files_download_aria({ name: e.name })}
+          >
+            <span class="ico" aria-hidden="true">▢</span>
+            <span class="nm">{e.name}</span>
+            <span class="dl" aria-hidden="true">↓</span>
+          </a>
+          <!-- eslint-enable svelte/no-navigation-without-resolve -->
+        {/if}
+      {/each}
+    {/if}
+  </div>
+</div>
+
+<style>
+  .files {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 12px;
+    overflow-y: auto;
+    height: 100%;
+  }
+  .crumbs {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 4px;
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+  }
+  .crumb {
+    background: transparent;
+    border: 0;
+    color: var(--color-muted);
+    font: inherit;
+    padding: 2px 3px;
+    cursor: pointer;
+  }
+  .crumb:hover:not(.current) {
+    color: var(--color-ink-bright);
+  }
+  .crumb.current {
+    color: var(--color-ink-bright);
+    cursor: default;
+  }
+  .crumb-sep {
+    color: var(--color-faint);
+  }
+  .list {
+    border: 1px solid var(--color-line);
+    background: var(--color-inset);
+    border-radius: 2px;
+    display: flex;
+    flex-direction: column;
+  }
+  .placeholder {
+    padding: 14px 12px;
+    color: var(--color-faint);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.06em;
+  }
+  .placeholder.err {
+    color: var(--color-red);
+  }
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    background: transparent;
+    border: 0;
+    border-bottom: 1px solid var(--color-line);
+    color: var(--color-ink-bright);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    text-align: left;
+    text-decoration: none;
+    padding: 8px 11px;
+    cursor: pointer;
+  }
+  .row:last-child {
+    border-bottom: 0;
+  }
+  .row:hover {
+    background: var(--color-panel);
+  }
+  .ico {
+    color: var(--color-muted);
+    flex-shrink: 0;
+  }
+  .row.file .ico {
+    color: var(--color-faint);
+  }
+  .nm {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .chev,
+  .dl {
+    color: var(--color-faint);
+    flex-shrink: 0;
+  }
+  .row.file:hover .dl {
+    color: var(--color-ink-bright);
+  }
+
+  @media (max-width: 768px) {
+    .row {
+      min-height: 44px;
+    }
+  }
+</style>

--- a/ui/src/lib/components/viewport/ViewportTabBar.svelte
+++ b/ui/src/lib/components/viewport/ViewportTabBar.svelte
@@ -7,13 +7,14 @@
   import { SvelteMap } from "svelte/reactivity";
   import type { Session } from "$lib/types";
 
-  type Tab = "term" | "todo" | "activity" | "diff" | "preview";
+  type Tab = "term" | "todo" | "activity" | "diff" | "files" | "preview";
 
   let {
     tab = $bindable(),
     session,
     previewPort,
     todoExists,
+    hasFiles,
     hasPreview,
     compact,
     headerFolded,
@@ -25,6 +26,7 @@
     session: Session;
     previewPort: number | null;
     todoExists: boolean;
+    hasFiles: boolean;
     hasPreview: boolean;
     compact: boolean;
     headerFolded: boolean;
@@ -226,6 +228,20 @@
       aria-controls={vpBodyId}
       onclick={() => (tab = "diff")}>{m.viewport_diff_tab()}</button
     >
+    {#if hasFiles}
+      <!-- only when the session's scratchpad holds files (server-derived hasScratchpadFiles):
+           skips an empty browser. Updates live at turn-end via the session:status push. -->
+      <button
+        class="tab-btn"
+        class:active={tab === "files"}
+        role="tab"
+        id={tabId("files")}
+        aria-selected={tab === "files"}
+        aria-controls={vpBodyId}
+        use:coachTarget={"files-tab"}
+        onclick={() => (tab = "files")}>{m.viewport_files_tab()}</button
+      >
+    {/if}
   </div>
   {#if hasPreview}
     <!-- only while the server reports a bound preview listener (single source of

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1694,4 +1694,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_hide_repos_title",
     bodyKey: "feat_hide_repos_body",
   },
+  {
+    // Read-only scratchpad file browser (#1164): a Files tab on a live session's viewport,
+    // anchored via use:coachTarget={"files-tab"} in ViewportTabBar. 1.37.0 is the latest
+    // released tag, so this ships in 1.38.0.
+    id: "scratchpad-files",
+    sinceVersion: "1.38.0",
+    titleKey: "feat_scratchpad_files_title",
+    bodyKey: "feat_scratchpad_files_body",
+    targetId: "files-tab",
+  },
 ];

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -1,6 +1,7 @@
 import { SvelteMap } from "svelte/reactivity";
 import type {
   Session,
+  SessionStatus,
   WsEvent,
   PluginInfo,
   UsageLimits,
@@ -283,13 +284,22 @@ export class HerdStore {
     if (s) Object.assign(s, patch);
   }
 
+  /** Apply a session:status push. Merges the turn-end scratchpad flag (#1164) only when this
+   *  push carries it (idle/done transitions); the undefined guard stops a status-only push
+   *  (e.g. → running) from clobbering the live flag back to falsy. */
+  private applyStatus(d: { id: string; status: SessionStatus; hasScratchpadFiles?: boolean }) {
+    const patch: Partial<Session> = { status: d.status };
+    if (d.hasScratchpadFiles !== undefined) patch.hasScratchpadFiles = d.hasScratchpadFiles;
+    this.patchSession(d.id, patch);
+  }
+
   apply(ev: WsEvent) {
     switch (ev.event) {
       case "session:new":
         if (!this.byId(ev.data.id)) this.sessions = [...this.sessions, ev.data];
         break;
       case "session:status":
-        this.patchSession(ev.data.id, { status: ev.data.status });
+        this.applyStatus(ev.data);
         break;
       case "session:renamed":
         this.applyRenamed(ev.data.id, ev.data.name, ev.data.branch);

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -106,6 +106,21 @@ export interface DirListing {
   entries: DirEntry[];
 }
 
+/** One entry in a session scratchpad listing (#1164). `path` is relative to the scratchpad root. */
+export interface ScratchEntry {
+  name: string;
+  type: "file" | "dir";
+  path: string;
+}
+
+/** A directory listing within a session's scratchpad subtree (#1164). Paths are relative to the
+ *  scratchpad root ("" = root); `parent` is null at the root. */
+export interface ScratchListing {
+  path: string;
+  parent: string | null;
+  entries: ScratchEntry[];
+}
+
 export interface Issue {
   number: number;
   title: string;
@@ -758,6 +773,10 @@ export interface Session {
   manualSteps: ManualStep[];
   /** Epoch ms the operator acknowledged the manual steps; null until acknowledged (P2). */
   manualStepsAckedAt: number | null;
+  /** Transient, server-derived: true when the session's scratchpad holds any file/dir (#1164).
+   *  Gates the Files tab. Not persisted — folded into the /api/sessions payload + session:status
+   *  (idle/done) push; absent (undefined) on partial pushes that don't recompute it. */
+  hasScratchpadFiles?: boolean;
 }
 
 /** A manual operator step parsed from a PR's shepherd:manual-steps carrier (#1059). Mirrors the
@@ -1098,7 +1117,10 @@ export interface PluginInfo {
 
 export type WsEvent =
   | { event: "session:new"; data: Session }
-  | { event: "session:status"; data: { id: string; status: SessionStatus } }
+  | {
+      event: "session:status";
+      data: { id: string; status: SessionStatus; hasScratchpadFiles?: boolean };
+    }
   | { event: "session:ready"; data: { id: string; ready: boolean } }
   | {
       event: "session:merging";


### PR DESCRIPTION
Closes #1164.

A **read-only file browser** in the session viewport, rooted at the session's **scratchpad**, that descends into subdirectories and **downloads individual files**. Live sessions only.

## What ships
- **New "Files" tab** on a live session's viewport, shown only when the scratchpad holds files (mirrors how the To-Do tab hides). Click a directory to descend (breadcrumb navigation), click a file to download it immediately. Dotfiles shown; directories first, then alphabetical.
- **Server API** (both behind `checkAuth`):
  - `GET /api/sessions/:id/scratchpad?path=<relative>` → directory listing.
  - `GET /api/sessions/:id/scratchpad/download?path=<relative>` → file stream via `Bun.file` with a safe `Content-Disposition: attachment`.
  - Registered in the `handleSessions` sub-handler array, like every other `/api/sessions/:id/...` route.

## Security boundary
Containment is enforced server-side in `src/scratchpad.ts`: every request realpaths the root **and** the resolved target and rejects anything outside it (`..`, absolute paths, symlink escapes). The listing additionally drops per-entry symlinks that escape the root (mirrors `dirs.ts`), so an out-pointing link never renders as a clickable row. Download requires a regular file. The `Content-Disposition` filename is RFC 5987-encoded with a CR/LF/quote-stripped ASCII fallback (no thrown invalid-header / header injection). Archived sessions 404 (live only).

## Tab visibility — no second poll
`hasScratchpadFiles` is computed server-side (transient, derived — **not** a DB column) and folded into the `GET /api/sessions` payload + `session:new` + the existing **`session:status` (idle/done)** WebSocket push — i.e. it refreshes at turn-end, exactly when the agent has finished writing files, with **no new polling loop**. The UI merges it via a guarded patch that won't clobber the flag on a status-only (`→ running`) push. This was the grilled design decision (operator-confirmed) reconciling the issue's "no second poll" with its "mirror the todo tab" cue.

## ⚠️ Deviation from the issue (flagged per house rules)
The issue said the root should **reuse `worktreeScratchDir(worktreePath)`**. An on-disk spike showed that is the **wrong base**: `worktreeScratchDir` is the *nested sub-agent* doubled-`claude-$uid` base (those dirs hold `<uuid>/tasks`, never a `scratchpad`). A session's own artifacts live under the **single** base:

```
<claudeTmpRoot>/<dashify(worktreePath)>/<claudeSessionId>/scratchpad/
```

verified against this session's own scratchpad + 150+ live dirs, and against the running server's env (no `TMPDIR` override → `claudeTmpRoot()` matches the agent's). New helper `sessionScratchpadDir()` reuses the existing `claudeTmpRoot()` + `dashify()` primitives but drops the nested segment and appends the session-scoped tail. Flagged in the code comment on `sessionScratchpadDir` and the commit body.

**Lifecycle note:** `removeWorktreeScratch` deletes the nested base, not this single-base session scratchpad — so physical deletion on archive isn't guaranteed. "Live only" is enforced by us (tab gated on active session; routes 404 on archived), independent of dir lifetime. Post-archive retention stays out of scope.

## Project-rule compliance
- **i18n:** EN+DE keys added (`check:i18n` parity green — 2046 keys each).
- **Feature catalog:** one `feature-announcements.ts` entry (`sinceVersion 1.38.0`), `targetId: "files-tab"` coachmark anchor.
- **Design system:** semantic tokens only, reuses the SettingsWorkspacePanel / DiffFileBlock row recipes.
- No new glossary term.

## Tests / verification
- New `test/scratchpad.test.ts` (containment & `..`/absolute/symlink escapes, per-entry symlink drop, dirs-first + dotfile listing, `scratchpadHasFiles`, RFC 5987 disposition) and `test/scratchpad-endpoint.test.ts` (route auth/404/archived/download header/list enrichment).
- Green: root `bun run lint` + `bun test ./test` (5037 pass), `bunx tsc --noEmit`; UI `bun run check` + `bun run test` (2099 pass) + `check:i18n`; `prettier --check`, `bun run build`, `bunx fallow@2.100.0 audit` (0 issues in changed files). Pre-push hook passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)