### PR TITLE
chore(examples): ship fuller public example plugin (spawn-labeler) (#1153)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -62,7 +62,14 @@
 
   // sw.js is the service worker: never imported statically — the browser fetches
   // it via navigator.serviceWorker.register("/sw.js") in ui/src/lib/push.ts.
-  "dynamicallyLoaded": ["ui/static/sw.js"],
+  //
+  // examples/plugins/*/index.ts are example-plugin entry modules: the plugin loader
+  // (src/plugins/loader.ts) `import()`s a plugin's entry at runtime — there is no
+  // static import — so fallow reports each as an unused file. They are reference
+  // teaching material loaded dynamically (the same string/runtime-loaded class as
+  // sw.js above), not dead code. Narrow to the entry index; the rest of each folder
+  // (plugin.json/config.json) is non-TS and not analyzed.
+  "dynamicallyLoaded": ["ui/static/sw.js", "examples/plugins/*/index.ts"],
 
   // tailwindcss is pulled in through `@import "tailwindcss"` in app.css + the
   // @tailwindcss/vite plugin, not an ESM import — so fallow sees it as unlisted.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -206,7 +206,7 @@ ctx.onSpawn((d): SpawnPatch => {
 operator auth:
 
 ```
-GET  /api/plugins/spawn-labeler/stats   → { envVar, totalSpawns, repos, lastSpawn }
+GET  /api/plugins/spawn-labeler/stats   → { envVar, labelTemplate, totalSpawns, repos, lastSpawn }
 POST /api/plugins/spawn-labeler/reset   → { ok: true, cleared: true }
 ```
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -71,7 +71,16 @@ export function register(ctx: PluginContext): void | (() => void) {
 > imports) or vendor the type definitions from `src/plugins/types.ts`. The `import type`
 > line is erased at runtime, so it never affects loading.
 
-See **`test/fixtures/example-plugin/`** for a complete, generic "hello world" you can copy.
+**Two examples ship with the repo:**
+
+- **`examples/plugins/spawn-labeler/`** — the **recommended copy-me reference**: a fuller,
+  documented plugin that returns a real `SpawnPatch`, has routes that read/write `state`,
+  and publishes a non-trivial status payload. Start here. See the walkthrough below.
+- **`test/fixtures/example-plugin/`** — the **minimal skeleton**: the bare-minimum wiring
+  as a pure observer (its `onSpawn` returns nothing). It exists mainly to back the loader
+  tests — reach for it only when you want the smallest possible starting point.
+
+Neither auto-loads from the repo (the loader only ever scans `~/.shepherd/plugins/`).
 
 ## The `ctx` capability seam
 
@@ -167,3 +176,60 @@ panel updates live.
 `ctx.route("GET", "status", handler)` serves at `GET /api/plugins/<id>/status`. All plugin
 routes sit **behind operator auth** (the same cookie/token gate as the rest of `/api`). An
 unknown plugin or sub-route returns 404.
+
+## A fuller example: `spawn-labeler`
+
+The skeleton fixture shows the wiring; **`examples/plugins/spawn-labeler/`** shows the seam
+doing real work. It stamps every spawned agent with a per-repo label env var (e.g.
+`SHEPHERD_SPAWN_LABEL=shepherd#3` — "the 3rd agent spawned in the `shepherd` repo"). It's a
+deliberately benign, public-safe analog of the private `claude-swap` env-injection seam —
+same `onSpawn → { env }` mechanic, no credential logic. Read it end to end; the highlights:
+
+**A real `SpawnPatch` from `onSpawn`.** It increments this repo's spawn count, formats a
+label, and returns an actual env overlay the agent then sees. The label is built **only
+from `SpawnDescriptor` fields** — `{repo}` = `basename(d.repoRoot)`, `{n}` = the per-repo
+count, `{session}` = `d.sessionId`:
+
+```ts
+ctx.onSpawn((d): SpawnPatch => {
+  const repo = basename(d.repoRoot);
+  const n = (repoCounts[repo] ?? 0) + 1; // noUncheckedIndexedAccess → guard the read
+  repoCounts = { ...repoCounts, [repo]: n };
+  const label = template.replaceAll("{repo}", repo).replaceAll("{n}", String(n));
+  ctx.state.set("repoCounts", repoCounts); // spawns are infrequent → a write here is fine
+  return { env: { [envVar]: label } };
+});
+```
+
+**Routes that read _and_ write `state`.** `GET stats` returns the live counters;
+`POST reset` clears them — so persisted state is both surfaced and mutated over HTTP, behind
+operator auth:
+
+```
+GET  /api/plugins/spawn-labeler/stats   → { envVar, totalSpawns, repos, lastSpawn }
+POST /api/plugins/spawn-labeler/reset   → { ok: true, cleared: true }
+```
+
+**A non-trivial `publishStatus` payload.** Instead of a bare counter it publishes the config
+in effect plus live totals, the per-repo breakdown, and the last spawn — all rendered in the
+Settings → Plugins panel:
+
+```jsonc
+{
+  "envVar": "SHEPHERD_SPAWN_LABEL",
+  "labelTemplate": "{repo}#{n}",
+  "totalSpawns": 4,
+  "repos": { "shepherd": 3, "ui": 1 },
+  "lastSpawn": { "sessionId": "…", "repoRoot": "…", "label": "shepherd#3", "at": "…" },
+}
+```
+
+**Driven by `config.json`.** `ctx.config` (the folder's `config.json`, parsed) overrides the
+env var name (`envVar`) and label template (`labelTemplate`); both default sensibly when
+absent.
+
+**Copy it to run it.** `cp -r examples/plugins/spawn-labeler ~/.shepherd/plugins/`, then —
+because the example's `import type` uses a repo-relative path that won't resolve out-of-repo
+— **drop the `import type` line or vendor `src/plugins/types.ts`** (the import is erased at
+runtime, so loading is unaffected either way), and restart Shepherd. See
+`examples/plugins/README.md`.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -195,7 +195,10 @@ ctx.onSpawn((d): SpawnPatch => {
   const repo = basename(d.repoRoot);
   const n = (repoCounts[repo] ?? 0) + 1; // noUncheckedIndexedAccess → guard the read
   repoCounts = { ...repoCounts, [repo]: n };
-  const label = template.replaceAll("{repo}", repo).replaceAll("{n}", String(n));
+  const label = template
+    .replaceAll("{repo}", repo)
+    .replaceAll("{n}", String(n))
+    .replaceAll("{session}", d.sessionId);
   ctx.state.set("repoCounts", repoCounts); // spawns are infrequent → a write here is fine
   return { env: { [envVar]: label } };
 });

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -19,19 +19,21 @@ into your plugins dir to actually run it.
 # 1. Copy the folder into your plugins dir (override the dir with SHEPHERD_PLUGINS_DIR).
 cp -r examples/plugins/spawn-labeler ~/.shepherd/plugins/
 
-# 2. Fix the type import for out-of-repo use (see below), then restart Shepherd.
+# 2. Restart Shepherd to load it. (Optional: fix the type import first — see below —
+#    for editor/type-check ergonomics; it is NOT required to run the plugin.)
 systemctl --user restart shepherd
 ```
 
 Plugins load **at boot only** — edit the folder, then restart.
 
-### Fix the type import when copying out-of-repo
+### Fix the type import for editor/type-check ergonomics (optional)
 
 Each example's `index.ts` imports the plugin contract with a **repo-relative** path
 (`../../../src/plugins/types`) so it type-checks against the real source in CI. That
-`import type` line is **erased at runtime**, so it never affects loading — but the path
-**won't resolve** once the folder lives under `~/.shepherd/plugins/` and you open or
-type-check it there. So after copying, do **one** of:
+`import type` line is **erased at runtime**, so the plugin **runs fine unfixed** — but
+the path **won't resolve** once the folder lives under `~/.shepherd/plugins/`, so your
+editor / `tsc` will flag it there. Only if you want clean type-checking out-of-repo,
+do **one** of:
 
 - **delete the `import type … from "…/src/plugins/types"` line** — the entry runs fine
   untyped; or

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -1,0 +1,42 @@
+# Example Shepherd plugins
+
+Reference implementations of Shepherd's [server-side plugin system](../../docs/plugins.md).
+These are **teaching material** — they are **never auto-loaded** from the repo (Shepherd
+only ever scans `~/.shepherd/plugins/`, so the zero-plugin no-op invariant holds). Copy one
+into your plugins dir to actually run it.
+
+| Plugin                             | What it shows                                                                                                                                                                                  |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`spawn-labeler/`](spawn-labeler/) | The recommended copy-me reference: a real `SpawnPatch` from `onSpawn` (injects a per-repo label env var), routes that read/write `state`, a non-trivial `publishStatus` payload, and `config`. |
+
+> For the bare-minimum wiring (manifest + `register` + one route, a pure observer), see
+> the skeleton at [`test/fixtures/example-plugin/`](../../test/fixtures/example-plugin/) —
+> it's intentionally trivial and exists mainly to back the loader tests.
+
+## Run one
+
+```sh
+# 1. Copy the folder into your plugins dir (override the dir with SHEPHERD_PLUGINS_DIR).
+cp -r examples/plugins/spawn-labeler ~/.shepherd/plugins/
+
+# 2. Fix the type import for out-of-repo use (see below), then restart Shepherd.
+systemctl --user restart shepherd
+```
+
+Plugins load **at boot only** — edit the folder, then restart.
+
+### Fix the type import when copying out-of-repo
+
+Each example's `index.ts` imports the plugin contract with a **repo-relative** path
+(`../../../src/plugins/types`) so it type-checks against the real source in CI. That
+`import type` line is **erased at runtime**, so it never affects loading — but the path
+**won't resolve** once the folder lives under `~/.shepherd/plugins/` and you open or
+type-check it there. So after copying, do **one** of:
+
+- **delete the `import type … from "…/src/plugins/types"` line** — the entry runs fine
+  untyped; or
+- **vendor the types**: copy `src/plugins/types.ts` into the folder and import from
+  `"./types"`.
+
+See [`docs/plugins.md`](../../docs/plugins.md) for the full plugin API, the `onSpawn`
+contract, and a walkthrough of `spawn-labeler`.

--- a/examples/plugins/spawn-labeler/config.json
+++ b/examples/plugins/spawn-labeler/config.json
@@ -1,0 +1,4 @@
+{
+  "envVar": "SHEPHERD_SPAWN_LABEL",
+  "labelTemplate": "{repo}#{n}"
+}

--- a/examples/plugins/spawn-labeler/index.ts
+++ b/examples/plugins/spawn-labeler/index.ts
@@ -1,0 +1,138 @@
+// spawn-labeler — a fuller, real-world Shepherd example plugin (issue #1153).
+//
+// This is the RECOMMENDED copy-me reference. It goes beyond the minimal echo skeleton
+// in `test/fixtures/example-plugin/` by exercising the `ctx` seam the way a real plugin
+// does: it returns an actual `SpawnPatch` from `onSpawn`, has one route that READS state
+// and one that WRITES it, and publishes a non-trivial status payload the Settings →
+// Plugins panel renders. See docs/plugins.md → "A fuller example: spawn-labeler".
+//
+// What it does: stamps every agent Shepherd spawns with a per-repo label env var
+// (e.g. SHEPHERD_SPAWN_LABEL=shepherd#3 — "the 3rd agent spawned in the shepherd repo").
+// It's a deliberately BENIGN, public-safe analog of the private `claude-swap` plugin's
+// env-injection seam — same `onSpawn → { env }` mechanic, no credential logic.
+//
+// ── Types & portability ──────────────────────────────────────────────────────────────
+// This in-repo example imports the contract for type-checking against the real source.
+// The `import type` line is ERASED at runtime, so it never affects loading — BUT the
+// relative `../../../src/plugins/types` path only resolves inside this repo. When you
+// COPY this folder into ~/.shepherd/plugins/ and open/type-check it out-of-repo, that
+// path breaks. So on copy, do ONE of:
+//   • delete the `import type` line (the entry runs fine untyped), or
+//   • vendor `src/plugins/types.ts` into the folder and import from "./types".
+// (Same note as the fixture header.)
+import type { PluginContext, SpawnDescriptor, SpawnPatch } from "../../../src/plugins/types";
+
+/** Shape of this plugin's own config.json (all fields optional — sensible defaults). */
+interface SpawnLabelerConfig {
+  /** Env var name to set on each spawn. Default: "SHEPHERD_SPAWN_LABEL". */
+  envVar?: string;
+  /** Label template. Tokens (all sourced from the SpawnDescriptor — there is no issue
+   *  number in the descriptor): {repo} = basename(repoRoot), {n} = per-repo spawn count,
+   *  {session} = sessionId. Default: "{repo}#{n}". */
+  labelTemplate?: string;
+}
+
+/** What we persist for the most recent spawn (powers `GET stats` + the status panel). */
+interface LastSpawn {
+  sessionId: string;
+  repoRoot: string;
+  label: string;
+  at: string;
+}
+
+/** Last path segment of a repo root, e.g. "/home/me/shepherd" → "shepherd". Inlined so
+ *  the example carries no `node:path` dependency; falls back to the full root if empty. */
+function basename(p: string): string {
+  const segs = p.split("/").filter(Boolean);
+  return segs[segs.length - 1] ?? p;
+}
+
+export function register(ctx: PluginContext): () => void {
+  // ── config (ctx.config) ──────────────────────────────────────────────────────────
+  // ctx.config is this plugin's own config.json, parsed (or {} when absent). We read it
+  // once at register time and fall back to defaults for any missing/blank field.
+  const cfg = ctx.config as SpawnLabelerConfig;
+  const envVar = typeof cfg.envVar === "string" && cfg.envVar ? cfg.envVar : "SHEPHERD_SPAWN_LABEL";
+  const template =
+    typeof cfg.labelTemplate === "string" && cfg.labelTemplate ? cfg.labelTemplate : "{repo}#{n}";
+
+  ctx.log.log(`registering — envVar=${envVar} template=${template}`);
+
+  // ── durable state (ctx.state) ────────────────────────────────────────────────────
+  // Per-repo spawn counts live in ONE durable key as a { [repo]: count } object, plus a
+  // `lastSpawn` record. We seed in-memory copies from state at load so the hot path reads
+  // memory, and write back on each spawn (spawns are infrequent, so a state write here is
+  // within the single-loop discipline — see docs/plugins.md). `noUncheckedIndexedAccess`
+  // makes every index access `T | undefined`, so reads are guarded with `?? …`.
+  let repoCounts = ctx.state.get<Record<string, number>>("repoCounts") ?? {};
+  let lastSpawn = ctx.state.get<LastSpawn>("lastSpawn");
+
+  const totalSpawns = (): number => Object.values(repoCounts).reduce((a, b) => a + b, 0);
+
+  /** The non-trivial status blob the panel renders verbatim (config in effect + live
+   *  totals + per-repo breakdown + last spawn). */
+  const publish = (): void =>
+    ctx.publishStatus({
+      envVar,
+      labelTemplate: template,
+      totalSpawns: totalSpawns(),
+      repos: repoCounts,
+      lastSpawn: lastSpawn ?? null,
+    });
+
+  // ── the load-bearing capability: onSpawn → SpawnPatch ──────────────────────────────
+  // Fires just before each agent launches (create + resume). We increment this repo's
+  // count, format the label from DESCRIPTOR FIELDS ONLY, persist, refresh the panel, and
+  // RETURN a real patch: an env overlay the agent will see. (A real account-switcher
+  // would instead return { credentialDir } / { env: { CLAUDE_CONFIG_DIR } } here.)
+  ctx.onSpawn((d: SpawnDescriptor): SpawnPatch => {
+    const repo = basename(d.repoRoot);
+    const n = (repoCounts[repo] ?? 0) + 1;
+    repoCounts = { ...repoCounts, [repo]: n };
+    const label = template
+      .replaceAll("{repo}", repo)
+      .replaceAll("{n}", String(n))
+      .replaceAll("{session}", d.sessionId);
+    lastSpawn = {
+      sessionId: d.sessionId,
+      repoRoot: d.repoRoot,
+      label,
+      at: new Date().toISOString(),
+    };
+
+    ctx.state.set("repoCounts", repoCounts);
+    ctx.state.set("lastSpawn", lastSpawn);
+    ctx.log.log(`labeling session=${d.sessionId} ${envVar}=${label}`);
+    publish();
+
+    return { env: { [envVar]: label } };
+  });
+
+  // ── routes (ctx.route) — one reads state, one writes it ────────────────────────────
+  // GET /api/plugins/spawn-labeler/stats — serves the live counters (reads state).
+  ctx.route("GET", "stats", () =>
+    Response.json({
+      envVar,
+      labelTemplate: template,
+      totalSpawns: totalSpawns(),
+      repos: repoCounts,
+      lastSpawn: lastSpawn ?? null,
+    }),
+  );
+
+  // POST /api/plugins/spawn-labeler/reset — clears the counters (writes state).
+  ctx.route("POST", "reset", () => {
+    repoCounts = {};
+    lastSpawn = null;
+    ctx.state.set("repoCounts", repoCounts);
+    ctx.state.delete("lastSpawn");
+    publish();
+    return Response.json({ ok: true, cleared: true });
+  });
+
+  // Publish an initial snapshot so the panel has data before the first spawn.
+  publish();
+
+  // Teardown: nothing to unwind (no subscriptions, state already persisted on each spawn).
+  return () => ctx.log.log("torn down");
+}

--- a/examples/plugins/spawn-labeler/plugin.json
+++ b/examples/plugins/spawn-labeler/plugin.json
@@ -1,0 +1,7 @@
+{
+  "id": "spawn-labeler",
+  "name": "Spawn Labeler",
+  "version": "1.0.0",
+  "apiVersion": 1,
+  "capabilities": ["spawn", "state", "routes", "status"]
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "test": "bun test ./test",
-    "lint": "eslint --no-error-on-unmatched-pattern src test ui/src ci/onboarding-harness deploy",
+    "lint": "eslint --no-error-on-unmatched-pattern src test examples ui/src ci/onboarding-harness deploy",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
     "start": "bun run src/index.ts",

--- a/test/examples-plugin.test.ts
+++ b/test/examples-plugin.test.ts
@@ -1,0 +1,75 @@
+// Runtime smoke test for the canonical teaching example, examples/plugins/spawn-labeler/.
+// The throwaway echo fixture has loader tests (plugins.test.ts); this gives the
+// recommended copy-me reference the same loader-level coverage — not just typecheck — so
+// it can't silently rot. Additive: points a registry at examples/plugins/ and exercises
+// the real load → onSpawn patch → routes path.
+import { test, expect } from "bun:test";
+import { resolve } from "node:path";
+import { SessionStore } from "../src/store";
+import { EventHub } from "../src/events";
+import { PluginRegistry } from "../src/plugins/loader";
+import type { SpawnDescriptor } from "../src/plugins/types";
+
+const EXAMPLES_DIR = resolve(import.meta.dir, "../examples/plugins");
+
+const DESC: SpawnDescriptor = {
+  sessionId: "sess-1",
+  repoRoot: "/home/me/myrepo",
+  model: null,
+  agentProvider: "claude",
+  argv: ["claude", "--session-id", "x"],
+  env: {},
+  isolated: true,
+};
+
+test("spawn-labeler example loads, patches the spawn env, and serves its routes", async () => {
+  const store = new SessionStore(":memory:");
+  const events = new EventHub();
+  const registry = new PluginRegistry({ pluginsDir: EXAMPLES_DIR, store, events });
+  await registry.loadAll();
+
+  // loads with ok health
+  const info = registry.list().find((p) => p.id === "spawn-labeler");
+  expect(info).toBeDefined();
+  expect(info!.health).toBe("ok");
+
+  // onSpawn returns a real SpawnPatch built from descriptor fields (basename#count)
+  expect(await registry.runSpawnHooks(DESC)).toEqual({ env: { SHEPHERD_SPAWN_LABEL: "myrepo#1" } });
+  // a second spawn in the same repo increments the per-repo count
+  expect(await registry.runSpawnHooks(DESC)).toEqual({ env: { SHEPHERD_SPAWN_LABEL: "myrepo#2" } });
+
+  // GET stats reads state
+  const statsRes = await registry.handleRoute(
+    "GET",
+    "spawn-labeler",
+    "stats",
+    new Request("http://x/"),
+  );
+  expect(statsRes?.status).toBe(200);
+  const stats = (await statsRes!.json()) as { totalSpawns: number; repos: Record<string, number> };
+  expect(stats.totalSpawns).toBe(2);
+  expect(stats.repos).toEqual({ myrepo: 2 });
+
+  // POST reset writes state
+  const resetRes = await registry.handleRoute(
+    "POST",
+    "spawn-labeler",
+    "reset",
+    new Request("http://x/", { method: "POST" }),
+  );
+  expect(resetRes?.status).toBe(200);
+  expect(await resetRes!.json()).toEqual({ ok: true, cleared: true });
+
+  const after = await registry.handleRoute(
+    "GET",
+    "spawn-labeler",
+    "stats",
+    new Request("http://x/"),
+  );
+  const afterStats = (await after!.json()) as {
+    totalSpawns: number;
+    repos: Record<string, number>;
+  };
+  expect(afterStats.totalSpawns).toBe(0);
+  expect(afterStats.repos).toEqual({});
+});

--- a/test/fixtures/example-plugin/index.ts
+++ b/test/fixtures/example-plugin/index.ts
@@ -1,6 +1,9 @@
-// Example Shepherd plugin — a generic "echo/status" demo. It doubles as the public
-// "hello world" template: copy this folder into ~/.shepherd/plugins/ and edit. It is a
-// pure OBSERVER (its onSpawn returns nothing), so it is always safe to load.
+// Minimal Shepherd plugin skeleton — a generic "echo/status" demo. This is the
+// bare-minimum wiring (manifest, register, one route, state, publishStatus, teardown)
+// and exists mainly to back the loader tests; it is a pure OBSERVER (its onSpawn returns
+// nothing), so it is always safe to load. For a fuller, real-world copy-me reference —
+// one that returns an actual SpawnPatch and reads/writes state through routes — see
+// examples/plugins/spawn-labeler/ (docs/plugins.md → "A fuller example").
 //
 // Types: this in-repo fixture imports the contract for type-checking. An out-of-repo
 // plugin can drop the `import type` line (entry runs untyped) or vendor the type defs —


### PR DESCRIPTION
Closes #1153. Follow-up to #1124/#1152, which shipped a deliberately minimal echo/status fixture. This adds a **fuller, documented reference plugin** as public copy-me teaching material — beyond the bare skeleton.

## What

A new, discoverable **`examples/plugins/spawn-labeler/`** — the recommended copy-me reference. It stamps every spawned agent with a per-repo label env var (e.g. `SHEPHERD_SPAWN_LABEL=shepherd#3`), a deliberately benign, public-safe analog of the private `claude-swap` env-injection seam (same `onSpawn → { env }` mechanic, no credential logic).

It exercises the `ctx` seam meaningfully:

- **`onSpawn` returns a real `SpawnPatch`** — an env overlay built **only from `SpawnDescriptor` fields** (`{repo}` = `basename(repoRoot)`, `{n}` = per-repo count, `{session}` = `sessionId`; there is no issue number in the descriptor). `noUncheckedIndexedAccess` respected.
- **`GET stats` reads `state`; `POST reset` writes `state`** (both behind operator auth).
- **Non-trivial `publishStatus` payload** the Settings → Plugins panel renders verbatim (config in effect + totals + per-repo breakdown + last spawn).
- **`ctx.config`-driven** (`envVar` / `labelTemplate`, sensible defaults); `log` + teardown.

Capability scope is honest — it does **not** use `ctx.events.subscribe` (no session event a labeler must react to), so `events` is omitted from the manifest rather than mirrored for show; the fixture already demonstrates `events`.

## Docs repositioned (not just appended)

`docs/plugins.md` + the fixture header are rewritten so the echo **fixture reads as the minimal, test-bound skeleton** and **`spawn-labeler` is the single recommended copy-me reference** — no two competing "copy me" sources. Adds an end-to-end `spawn-labeler` walkthrough.

The **type-import portability caveat** (the repo-relative `../../../src/plugins/types` import is runtime-erased but breaks out-of-repo → drop the `import type` line or vendor the types) is carried into both the `index.ts` comments and `examples/plugins/README.md`.

## Tests & gates

- New **`test/examples-plugin.test.ts`**: runtime smoke test (load → expected env patch → `GET stats` / `POST reset`), giving the teaching example loader-level coverage, not just typecheck.
- `examples/` added to the eslint lint glob; the dynamically-`import()`-loaded example entry modeled narrowly in `.fallowrc.jsonc` (`dynamicallyLoaded`, same class as `sw.js`).
- `bun run typecheck`, `bun run lint`, `bun test ./test` (5017 pass) all green; pre-push fallow audit clean. UI untouched.

## Invariants preserved

No core/loader change. Examples **never auto-load** (the loader only ever scans `~/.shepherd/plugins/` / `SHEPHERD_PLUGINS_DIR`), so the zero-plugin no-op invariant holds and existing `test/plugins*.test.ts` still pass against the unchanged fixture. No `claude-swap` identity in core (out of scope per #1124's open-source-hygiene invariants).

Ships no user-facing UX (the panel already renders `publishStatus` verbatim) → `chore`, no feature-catalog entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)