### PR TITLE
feat(orchestration): one ordered 'what happens next' seam for the autonomous engine (#1094)

### DIFF
--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -347,8 +347,8 @@ export class AutopilotService {
    *  autopilot MUST re-read the live row (its eligible() rechecks at entry + post-classify
    *  are the correctness guard), so it deliberately does NOT consume snapshot.session.
    *  Ordering note: the seam runs drain before this. onDone kicks refreshPr immediately
-   *  before its classify (line ~358); drain-first shifts BOTH together, so the PR-poll↔classify
-   *  overlap is preserved — no separate up-front prewarm is needed (#1094). */
+   *  before its classify (see onDone below); drain-first shifts BOTH together, so the
+   *  PR-poll↔classify overlap is preserved — no separate up-front prewarm is needed (#1094). */
   async handle(change: SessionStateChange): Promise<void> {
     const { id } = change.snapshot;
     if (change.kind === "status") {

--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -2,6 +2,7 @@ import type { SessionStore } from "./store";
 import type { Session, AutopilotVerdict, ReviewVerdict } from "./types";
 import type { BlockReason } from "./blocked";
 import type { GitState } from "./forge/types";
+import type { SessionStateChange } from "./session-snapshot";
 import { effectiveAutopilot } from "./effective-autopilot";
 import { signedOff } from "./signoff";
 import { DRAFT_PR_NOTE } from "./service";
@@ -340,6 +341,22 @@ export class AutopilotService {
     const cur = this.eligible(id);
     if (!cur) return;
     await this.dispatch(cur, v);
+  }
+
+  /** SessionConsumer entry (#1094 seam). Delegates to the existing handlers by id —
+   *  autopilot MUST re-read the live row (its eligible() rechecks at entry + post-classify
+   *  are the correctness guard), so it deliberately does NOT consume snapshot.session.
+   *  Ordering note: the seam runs drain before this. onDone kicks refreshPr immediately
+   *  before its classify (line ~358); drain-first shifts BOTH together, so the PR-poll↔classify
+   *  overlap is preserved — no separate up-front prewarm is needed (#1094). */
+  async handle(change: SessionStateChange): Promise<void> {
+    const { id } = change.snapshot;
+    if (change.kind === "status") {
+      this.onStatus(id, change.status); // clears a pause on operator reply
+      if (change.status === "done") await this.onDone(id);
+      return;
+    }
+    this.onGit(id, change.git); // sync; PR-open handoff + red-CI recovery
   }
 
   /** session:block handler. Only steerable shapes are eligible; menu/stall surface as-is. */

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -1,6 +1,7 @@
 import type { SessionStore } from "./store";
 import type { GitForge, GitState, Issue, PrStatus, SubIssueRef } from "./forge/types";
 import type { CreateSessionInput, Session } from "./types";
+import type { SessionStateChange } from "./session-snapshot";
 import type { UsageLimits } from "./usage-limits";
 import { settleMergedSession } from "./merge-teardown";
 import { isFullAuto } from "./full-auto";
@@ -1778,6 +1779,24 @@ export class DrainService {
   }
 
   // ── event handlers (public surface) ───────────────────────────────────────────
+
+  /** SessionConsumer entry (#1094 seam). Sources the trigger row from the shared snapshot
+   *  instead of a fresh store.get — drain runs FIRST in the ordered chain, so the snapshot
+   *  (built this tick) is current for its purposes. Mirrors onGit/onStatus exactly. */
+  async handle(change: SessionStateChange): Promise<void> {
+    const s = change.snapshot.session;
+    if (change.kind === "git") {
+      if (!s.auto) return; // drain only manages auto sessions
+      if (change.git.state === "merged") {
+        await this.reapMerged(s);
+        return;
+      }
+      await this.pumpIfEnabled(s.repoPath);
+      return;
+    }
+    // kind === "status"
+    await this.pumpIfEnabled(s.repoPath);
+  }
 
   /** pr-poller observed a new git state for a session. */
   async onGit(id: string, git: GitState): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ import { createIssueLogger } from "./issue-log";
 import { PlanGateService } from "./plan-gate";
 import { AutopilotService } from "./autopilot";
 import { DrainService } from "./drain";
+import { SessionRouter, type SessionConsumer } from "./session-router";
 import { AutoMergeService } from "./automerge";
 import { DraftReconcileService } from "./draft-reconcile";
 import { isFullAuto } from "./full-auto";
@@ -1151,29 +1152,14 @@ const autopilot = new AutopilotService({
   rebaseCap: config.autoMergeRebaseCap,
 });
 
-// Drive autopilot off the same poller events the rest of the system already emits.
+// Drive autopilot's block handling off the poller events. `session:status`/`session:git`
+// no longer fan out here — they flow through the ordered SessionRouter seam (built after
+// `drain`) so drain (retire) is awaited before autopilot (steer). Only `session:block`
+// stays an independent autopilot subscription.
 events.subscribe((event, data) => {
-  if (event === "session:block") {
-    const { id, block } = data as { id: string; block: import("./blocked").BlockReason | null };
-    void autopilot.onBlock(id, block).catch((err) => console.warn("[autopilot] onBlock:", err));
-  } else if (event === "session:status") {
-    const { id, status } = data as { id: string; status: string };
-    autopilot.onStatus(id, status); // clears a pause when the operator replies
-    if (status === "done") {
-      void autopilot.onDone(id).catch((err) => console.warn("[autopilot] onDone:", err));
-      // A planning-phase session that just settled has likely finished writing
-      // `.shepherd-plan.md` — kick off the adversarial plan review (no-op unless it's
-      // in the planning phase with a fresh, un-reviewed plan).
-      const sess = store.get(id);
-      if (sess?.planPhase === "planning")
-        void planGate.consider(sess).catch((err) => console.warn("[plan-gate] consider:", err));
-    }
-  } else if (event === "session:git") {
-    const { id, git } = data as { id: string; git: import("./forge/types").GitState };
-    // PR-open handoff to the critic loop AND red-CI recovery (the critic skips a red PR, so
-    // autopilot drives the agent to fix its own failing checks).
-    autopilot.onGit(id, git);
-  }
+  if (event !== "session:block") return;
+  const { id, block } = data as { id: string; block: import("./blocked").BlockReason | null };
+  void autopilot.onBlock(id, block).catch((err) => console.warn("[autopilot] onBlock:", err));
 });
 
 // Self-draining work queue (#222): when an auto session's PR merges, archive it and
@@ -1196,20 +1182,51 @@ const drain = new DrainService({
   rebaseCap: config.autoMergeRebaseCap,
 });
 
-// Drive the drain off the poller events the rest of the system already emits.
+// Drive the drain's archived/review handling off the poller events. `session:git`/`session:status`
+// flow through the ordered SessionRouter seam below (drain before autopilot); only the
+// archived/review side-effects stay independent drain subscriptions.
 events.subscribe((event, data) => {
-  if (event === "session:git") {
-    const { id, git } = data as { id: string; git: import("./forge/types").GitState };
-    void drain.onGit(id, git).catch((err) => console.warn("[drain] onGit:", err));
-  } else if (event === "session:status") {
-    const { id } = data as { id: string };
-    void drain.onStatus(id).catch((err) => console.warn("[drain] onStatus:", err));
-  } else if (event === "session:archived") {
+  if (event === "session:archived") {
     const { id } = data as { id: string };
     void drain.onArchived(id).catch((err) => console.warn("[drain] onArchived:", err));
   } else if (event === "session:review") {
     const { id } = data as { id: string };
     void drain.onReview(id).catch((err) => console.warn("[drain] onReview:", err));
+  }
+});
+
+// #1094: one ordered "what happens next" seam. `session:status`/`session:git` used to fan out to
+// two fire-and-forget subscriptions (drain retire + autopilot steer) that interleaved within a
+// single poller tick and raced. The router builds the shared per-session snapshot once and dispatches
+// consumers in order, AWAITING each — drain (retire) before autopilot (steer) — so a ready session is
+// retired/handed off before autopilot spends a classify on it, and autopilot never steers a row drain
+// is about to archive. autoMerge + every other session:git/status subscriber stay independent.
+const sessionRouter = new SessionRouter(
+  { getSession: (id) => store.get(id) },
+  [
+    { name: "drain", handle: (change) => drain.handle(change) },
+    { name: "autopilot", handle: (change) => autopilot.handle(change) },
+  ] satisfies SessionConsumer[],
+  {
+    // Plan-gate is an independent status side-effect (not a [drain,autopilot] consumer): a
+    // planning-phase session that just settled likely finished writing .shepherd-plan.md → kick the
+    // adversarial review. Runs after the consumer chain, reached regardless of a consumer throwing.
+    onStatusSettled: (change) => {
+      const sess = change.snapshot.session;
+      if (change.status === "done" && sess.planPhase === "planning")
+        void planGate.consider(sess).catch((err) => console.warn("[plan-gate] consider:", err));
+    },
+  },
+);
+events.subscribe((event, data) => {
+  if (event === "session:status") {
+    const { id, status } = data as { id: string; status: string };
+    void sessionRouter
+      .onStatus(id, status)
+      .catch((err) => console.warn("[session-router] onStatus:", err));
+  } else if (event === "session:git") {
+    const { id, git } = data as { id: string; git: import("./forge/types").GitState };
+    void sessionRouter.onGit(id, git).catch((err) => console.warn("[session-router] onGit:", err));
   }
 });
 // Slow sweep: catch newly-labeled issues and resumed-usage windows (~30s).

--- a/src/session-router.ts
+++ b/src/session-router.ts
@@ -1,0 +1,68 @@
+import { buildSnapshot, type SessionStateChange, type SnapshotAccessors } from "./session-snapshot";
+import type { GitState } from "./forge/types";
+
+/** A consumer of session changes. Implementations adapt drain / autopilot. `name` is
+ *  used only for the router's error log line. */
+export interface SessionConsumer {
+  readonly name: string;
+  handle(change: SessionStateChange): Promise<void>;
+}
+
+export interface SessionRouterHooks {
+  /** Fired on a `status` change BEFORE the consumer chain is awaited — used to hoist
+   *  autopilot's PR-prewarm kick so awaiting drain doesn't delay it. Best-effort/sync. */
+  onStatusPrewarm?: (id: string) => void;
+  /** Fired on a `status` change AFTER the consumer chain — an independent side-effect
+   *  (plan-gate). Reached regardless of any consumer throwing. */
+  onStatusSettled?: (change: Extract<SessionStateChange, { kind: "status" }>) => void;
+}
+
+/** The single "what happens next" seam. Builds the shared snapshot ONCE per change and
+ *  dispatches `consumers` strictly in order, AWAITING each fully before the next — this
+ *  is what kills the retire-vs-steer race (fire-and-forget could not). Each consumer (and
+ *  each hook) is isolated in try/catch so one failure is logged and does NOT prevent the
+ *  next consumer or the settled hook from running; ordering still holds on the success path. */
+export class SessionRouter {
+  constructor(
+    private acc: SnapshotAccessors,
+    /** Ordered. Pass [drainConsumer, autopilotConsumer] — drain before autopilot. */
+    private consumers: SessionConsumer[],
+    private hooks: SessionRouterHooks = {},
+    private warn: (msg: string, err: unknown) => void = (m, e) => console.warn(m, e),
+  ) {}
+
+  async onStatus(id: string, status: string): Promise<void> {
+    const change = buildSnapshot(this.acc, id, { kind: "status", status });
+    if (!change) return;
+    this.safeSync(() => this.hooks.onStatusPrewarm?.(id), "prewarm");
+    await this.dispatch(change);
+    this.safeSync(
+      () => this.hooks.onStatusSettled?.(change as Extract<SessionStateChange, { kind: "status" }>),
+      "settled",
+    );
+  }
+
+  async onGit(id: string, git: GitState): Promise<void> {
+    const change = buildSnapshot(this.acc, id, { kind: "git", git });
+    if (!change) return;
+    await this.dispatch(change);
+  }
+
+  private async dispatch(change: SessionStateChange): Promise<void> {
+    for (const c of this.consumers) {
+      try {
+        await c.handle(change);
+      } catch (err) {
+        this.warn(`[session-router] ${c.name} ${change.kind}:`, err);
+      }
+    }
+  }
+
+  private safeSync(fn: () => void, label: string): void {
+    try {
+      fn();
+    } catch (err) {
+      this.warn(`[session-router] ${label}:`, err);
+    }
+  }
+}

--- a/src/session-router.ts
+++ b/src/session-router.ts
@@ -9,9 +9,6 @@ export interface SessionConsumer {
 }
 
 export interface SessionRouterHooks {
-  /** Fired on a `status` change BEFORE the consumer chain is awaited — used to hoist
-   *  autopilot's PR-prewarm kick so awaiting drain doesn't delay it. Best-effort/sync. */
-  onStatusPrewarm?: (id: string) => void;
   /** Fired on a `status` change AFTER the consumer chain — an independent side-effect
    *  (plan-gate). Reached regardless of any consumer throwing. */
   onStatusSettled?: (change: Extract<SessionStateChange, { kind: "status" }>) => void;
@@ -34,7 +31,9 @@ export class SessionRouter {
   async onStatus(id: string, status: string): Promise<void> {
     const change = buildSnapshot(this.acc, id, { kind: "status", status });
     if (!change) return;
-    this.safeSync(() => this.hooks.onStatusPrewarm?.(id), "prewarm");
+    // No up-front PR-prewarm hook: drain runs before autopilot, and autopilot.onDone
+    // kicks refreshPr right before its classify, so the PR-poll↔classify overlap is
+    // preserved without a separate kick (see autopilot.handle).
     await this.dispatch(change);
     this.safeSync(
       () => this.hooks.onStatusSettled?.(change as Extract<SessionStateChange, { kind: "status" }>),

--- a/src/session-snapshot.ts
+++ b/src/session-snapshot.ts
@@ -3,12 +3,12 @@ import type { GitState } from "./forge/types";
 
 /** The shared per-session view for a status/git event — the single `store.get(id)`
  *  result, handed to every consumer so they don't each re-fetch the trigger row.
- *  Deliberately minimal: consumers read repoPath (to pump) and the session row
- *  (auto flag, planPhase, reapMerged). Review/activity are NOT here — they are read
- *  inside drain's buildState / autopilot's internal getReview, never at the seam. */
+ *  Deliberately minimal: `id` for autopilot's delegate-by-id, and the session row
+ *  (drain reads `auto`/`repoPath` and passes it to `reapMerged`; the plan-gate hook
+ *  reads `planPhase`). Review/activity are NOT here — they are read inside drain's
+ *  buildState / autopilot's internal getReview, never at the seam. */
 export interface SessionSnapshot {
   id: string;
-  repoPath: string;
   session: Session;
 }
 
@@ -34,7 +34,7 @@ export function buildSnapshot(
 ): SessionStateChange | null {
   const session = acc.getSession(id);
   if (session === null) return null;
-  const snapshot: SessionSnapshot = { id, repoPath: session.repoPath, session };
+  const snapshot: SessionSnapshot = { id, session };
   if (payload.kind === "status") {
     return { kind: "status", status: payload.status, snapshot };
   }

--- a/src/session-snapshot.ts
+++ b/src/session-snapshot.ts
@@ -1,0 +1,42 @@
+import type { Session } from "./types";
+import type { GitState } from "./forge/types";
+
+/** The shared per-session view for a status/git event — the single `store.get(id)`
+ *  result, handed to every consumer so they don't each re-fetch the trigger row.
+ *  Deliberately minimal: consumers read repoPath (to pump) and the session row
+ *  (auto flag, planPhase, reapMerged). Review/activity are NOT here — they are read
+ *  inside drain's buildState / autopilot's internal getReview, never at the seam. */
+export interface SessionSnapshot {
+  id: string;
+  repoPath: string;
+  session: Session;
+}
+
+/** A routed change. The event payload (status string / git state) rides the change;
+ *  the snapshot carries the shared session view. */
+export type SessionStateChange =
+  | { kind: "status"; status: string; snapshot: SessionSnapshot }
+  | { kind: "git"; git: GitState; snapshot: SessionSnapshot };
+
+/** Accessors the builder needs. Single-method so tests pass a trivial fake. */
+export interface SnapshotAccessors {
+  getSession: (id: string) => Session | null;
+}
+
+export type ChangePayload = { kind: "status"; status: string } | { kind: "git"; git: GitState };
+
+/** Build the shared view for a change. Returns null when the session is unknown
+ *  (e.g. already pruned) — the caller then skips dispatch entirely. */
+export function buildSnapshot(
+  acc: SnapshotAccessors,
+  id: string,
+  payload: ChangePayload,
+): SessionStateChange | null {
+  const session = acc.getSession(id);
+  if (session === null) return null;
+  const snapshot: SessionSnapshot = { id, repoPath: session.repoPath, session };
+  if (payload.kind === "status") {
+    return { kind: "status", status: payload.status, snapshot };
+  }
+  return { kind: "git", git: payload.git, snapshot };
+}

--- a/test/session-router.test.ts
+++ b/test/session-router.test.ts
@@ -155,17 +155,15 @@ test("getSession is called exactly once per onGit even with two consumers", asyn
 
 test("unknown session (getSession null) calls no consumer and no hooks", async () => {
   const log: string[] = [];
-  let prewarm = 0;
   let settled = 0;
   const router = new SessionRouter(
     { getSession: () => null },
     [recordingConsumer("drain", log), recordingConsumer("autopilot", log)],
-    { onStatusPrewarm: () => prewarm++, onStatusSettled: () => settled++ },
+    { onStatusSettled: () => settled++ },
   );
   await router.onStatus("missing", "idle");
   await router.onGit("missing", GIT_STATE);
   expect(log).toEqual([]);
-  expect(prewarm).toBe(0);
   expect(settled).toBe(0);
 });
 
@@ -199,9 +197,9 @@ test("a throwing first consumer is caught; second consumer and settled hook stil
   expect(warnings.some((w) => w.includes("drain"))).toBe(true);
 });
 
-// ── 5. Prewarm / settled hook ordering ────────────────────────────────────────
+// ── 5. Settled hook ordering ───────────────────────────────────────────────────
 
-test("onStatus fires prewarm before the consumer chain and settled after it", async () => {
+test("onStatus fires the settled hook after the consumer chain", async () => {
   const log: string[] = [];
   const gate = deferred();
 
@@ -215,28 +213,26 @@ test("onStatus fires prewarm before the consumer chain and settled after it", as
   };
 
   const router = new SessionRouter({ getSession: () => makeSession("s1", "/r") }, [slow], {
-    onStatusPrewarm: () => log.push("prewarm"),
     onStatusSettled: () => log.push("settled"),
   });
 
   const done = router.onStatus("s1", "idle");
   await Promise.resolve();
   await Promise.resolve();
-  // Prewarm fired before the chain; settled has NOT fired yet.
-  expect(log).toEqual(["prewarm", "consumer:start"]);
+  // Settled has NOT fired yet — the chain is still parked on the deferred.
+  expect(log).toEqual(["consumer:start"]);
 
   gate.resolve();
   await done;
-  expect(log).toEqual(["prewarm", "consumer:start", "consumer:finish", "settled"]);
+  expect(log).toEqual(["consumer:start", "consumer:finish", "settled"]);
 });
 
-test("onGit invokes neither prewarm nor settled hook", async () => {
+test("onGit invokes the settled hook never", async () => {
   const log: string[] = [];
   const router = new SessionRouter(
     { getSession: () => makeSession("s1", "/r") },
     [recordingConsumer("drain", log)],
     {
-      onStatusPrewarm: () => log.push("prewarm"),
       onStatusSettled: () => log.push("settled"),
     },
   );

--- a/test/session-router.test.ts
+++ b/test/session-router.test.ts
@@ -1,0 +1,265 @@
+import { test, expect } from "bun:test";
+import { SessionRouter, type SessionConsumer } from "../src/session-router";
+import type { SessionStateChange, SnapshotAccessors } from "../src/session-snapshot";
+import type { Session } from "../src/types";
+import type { GitState } from "../src/forge/types";
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+function makeSession(id: string, repoPath: string): Session {
+  return { id, repoPath } as unknown as Session;
+}
+
+const GIT_STATE: GitState = {
+  kind: "github",
+  state: "open",
+  checks: "success",
+  deployConfigured: false,
+};
+
+/** Counting accessor — records how many times getSession was read. */
+function countingAcc(session: Session | null): SnapshotAccessors & { calls: number } {
+  const acc = {
+    calls: 0,
+    getSession(): Session | null {
+      acc.calls++;
+      return session;
+    },
+  };
+  return acc;
+}
+
+/** A consumer that records its handle start/finish in a shared log. */
+function recordingConsumer(name: string, log: string[]): SessionConsumer {
+  return {
+    name,
+    async handle(): Promise<void> {
+      log.push(`${name}:start`);
+      log.push(`${name}:finish`);
+    },
+  };
+}
+
+// A manually-controlled deferred so ordering is proven deterministically, not by timing.
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+// ── 1. Ordering / serialization (the key test) ────────────────────────────────
+
+test("autopilot handle starts only after drain handle fully resolves (onGit)", async () => {
+  const log: string[] = [];
+  const gate = deferred();
+
+  const drain: SessionConsumer = {
+    name: "drain",
+    async handle(): Promise<void> {
+      log.push("drain:start");
+      await gate.promise; // block until the test releases it
+      log.push("drain:finish");
+    },
+  };
+  const autopilot: SessionConsumer = {
+    name: "autopilot",
+    async handle(): Promise<void> {
+      log.push("autopilot:start");
+    },
+  };
+
+  const router = new SessionRouter({ getSession: () => makeSession("s1", "/r") }, [
+    drain,
+    autopilot,
+  ]);
+
+  const done = router.onGit("s1", GIT_STATE);
+
+  // Let microtasks flush: drain has started and is parked on the deferred.
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(log).toEqual(["drain:start"]);
+  // Autopilot must NOT have started while drain is still unresolved.
+  expect(log).not.toContain("autopilot:start");
+
+  // Release drain — only now may autopilot begin.
+  gate.resolve();
+  await done;
+
+  expect(log).toEqual(["drain:start", "drain:finish", "autopilot:start"]);
+});
+
+test("autopilot handle starts only after drain handle fully resolves (onStatus)", async () => {
+  const log: string[] = [];
+  const gate = deferred();
+
+  const drain: SessionConsumer = {
+    name: "drain",
+    async handle(): Promise<void> {
+      log.push("drain:start");
+      await gate.promise;
+      log.push("drain:finish");
+    },
+  };
+  const autopilot: SessionConsumer = {
+    name: "autopilot",
+    async handle(): Promise<void> {
+      log.push("autopilot:start");
+    },
+  };
+
+  const router = new SessionRouter({ getSession: () => makeSession("s1", "/r") }, [
+    drain,
+    autopilot,
+  ]);
+
+  const done = router.onStatus("s1", "idle");
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(log).toEqual(["drain:start"]);
+  expect(log).not.toContain("autopilot:start");
+
+  gate.resolve();
+  await done;
+
+  expect(log).toEqual(["drain:start", "drain:finish", "autopilot:start"]);
+});
+
+// ── 2. Single build per call ──────────────────────────────────────────────────
+
+test("getSession is called exactly once per onStatus even with two consumers", async () => {
+  const log: string[] = [];
+  const acc = countingAcc(makeSession("s1", "/r"));
+  const router = new SessionRouter(acc, [
+    recordingConsumer("drain", log),
+    recordingConsumer("autopilot", log),
+  ]);
+  await router.onStatus("s1", "idle");
+  expect(acc.calls).toBe(1);
+});
+
+test("getSession is called exactly once per onGit even with two consumers", async () => {
+  const log: string[] = [];
+  const acc = countingAcc(makeSession("s1", "/r"));
+  const router = new SessionRouter(acc, [
+    recordingConsumer("drain", log),
+    recordingConsumer("autopilot", log),
+  ]);
+  await router.onGit("s1", GIT_STATE);
+  expect(acc.calls).toBe(1);
+});
+
+// ── 3. Unknown session ────────────────────────────────────────────────────────
+
+test("unknown session (getSession null) calls no consumer and no hooks", async () => {
+  const log: string[] = [];
+  let prewarm = 0;
+  let settled = 0;
+  const router = new SessionRouter(
+    { getSession: () => null },
+    [recordingConsumer("drain", log), recordingConsumer("autopilot", log)],
+    { onStatusPrewarm: () => prewarm++, onStatusSettled: () => settled++ },
+  );
+  await router.onStatus("missing", "idle");
+  await router.onGit("missing", GIT_STATE);
+  expect(log).toEqual([]);
+  expect(prewarm).toBe(0);
+  expect(settled).toBe(0);
+});
+
+// ── 4. Failure isolation ──────────────────────────────────────────────────────
+
+test("a throwing first consumer is caught; second consumer and settled hook still run", async () => {
+  const log: string[] = [];
+  const warnings: string[] = [];
+  let settled = 0;
+
+  const failing: SessionConsumer = {
+    name: "drain",
+    async handle(): Promise<void> {
+      log.push("drain:start");
+      throw new Error("boom");
+    },
+  };
+
+  const router = new SessionRouter(
+    { getSession: () => makeSession("s1", "/r") },
+    [failing, recordingConsumer("autopilot", log)],
+    { onStatusSettled: () => settled++ },
+    (msg) => warnings.push(msg),
+  );
+
+  // Must not throw.
+  await router.onStatus("s1", "idle");
+
+  expect(log).toEqual(["drain:start", "autopilot:start", "autopilot:finish"]);
+  expect(settled).toBe(1);
+  expect(warnings.some((w) => w.includes("drain"))).toBe(true);
+});
+
+// ── 5. Prewarm / settled hook ordering ────────────────────────────────────────
+
+test("onStatus fires prewarm before the consumer chain and settled after it", async () => {
+  const log: string[] = [];
+  const gate = deferred();
+
+  const slow: SessionConsumer = {
+    name: "drain",
+    async handle(): Promise<void> {
+      log.push("consumer:start");
+      await gate.promise;
+      log.push("consumer:finish");
+    },
+  };
+
+  const router = new SessionRouter({ getSession: () => makeSession("s1", "/r") }, [slow], {
+    onStatusPrewarm: () => log.push("prewarm"),
+    onStatusSettled: () => log.push("settled"),
+  });
+
+  const done = router.onStatus("s1", "idle");
+  await Promise.resolve();
+  await Promise.resolve();
+  // Prewarm fired before the chain; settled has NOT fired yet.
+  expect(log).toEqual(["prewarm", "consumer:start"]);
+
+  gate.resolve();
+  await done;
+  expect(log).toEqual(["prewarm", "consumer:start", "consumer:finish", "settled"]);
+});
+
+test("onGit invokes neither prewarm nor settled hook", async () => {
+  const log: string[] = [];
+  const router = new SessionRouter(
+    { getSession: () => makeSession("s1", "/r") },
+    [recordingConsumer("drain", log)],
+    {
+      onStatusPrewarm: () => log.push("prewarm"),
+      onStatusSettled: () => log.push("settled"),
+    },
+  );
+  await router.onGit("s1", GIT_STATE);
+  expect(log).toEqual(["drain:start", "drain:finish"]);
+});
+
+// ── 6. Same snapshot object reaches both consumers (identity) ──────────────────
+
+test("the same snapshot object instance reaches every consumer (not rebuilt)", async () => {
+  const seen: SessionStateChange[] = [];
+  const capture = (name: string): SessionConsumer => ({
+    name,
+    async handle(change): Promise<void> {
+      seen.push(change);
+    },
+  });
+  const router = new SessionRouter({ getSession: () => makeSession("s1", "/r") }, [
+    capture("drain"),
+    capture("autopilot"),
+  ]);
+  await router.onGit("s1", GIT_STATE);
+  expect(seen.length).toBe(2);
+  expect(seen[0]).toBe(seen[1]); // identical change object
+  expect(seen[0]!.snapshot).toBe(seen[1]!.snapshot); // identical snapshot
+});

--- a/test/session-snapshot.test.ts
+++ b/test/session-snapshot.test.ts
@@ -31,7 +31,6 @@ test("buildSnapshot with status payload returns kind=status with snapshot", () =
   if (result.kind !== "status") throw new Error("unreachable");
   expect(result.status).toBe("idle");
   expect(result.snapshot.id).toBe("sess-1");
-  expect(result.snapshot.repoPath).toBe("/repos/alpha");
   expect(result.snapshot.session).toBe(session);
 });
 
@@ -46,7 +45,6 @@ test("buildSnapshot with git payload returns kind=git with snapshot", () => {
   if (result.kind !== "git") throw new Error("unreachable");
   expect(result.git).toBe(GIT_STATE);
   expect(result.snapshot.id).toBe("sess-2");
-  expect(result.snapshot.repoPath).toBe("/repos/beta");
   expect(result.snapshot.session).toBe(session);
 });
 
@@ -58,14 +56,16 @@ test("buildSnapshot returns null when getSession returns null", () => {
   expect(result).toBeNull();
 });
 
-// ── buildSnapshot: repoPath comes from session, not id ───────────────────────
+// ── buildSnapshot: carries the session row verbatim ──────────────────────────
 
-test("snapshot repoPath is sourced from session row, not echoed from id", () => {
-  // id and repoPath are intentionally different so echoing id would be detected
+test("snapshot carries the looked-up session row verbatim (id distinct from repoPath)", () => {
+  // id and repoPath are intentionally different so consumers reading session.repoPath
+  // off the row get the repo, not the id.
   const session = makeSession("task-99", "/home/user/projects/my-project");
   const acc = makeAcc(session);
   const result = buildSnapshot(acc, "task-99", { kind: "status", status: "done" });
   if (!result) throw new Error("expected non-null result");
-  expect(result.snapshot.repoPath).toBe("/home/user/projects/my-project");
-  expect(result.snapshot.repoPath).not.toBe("task-99");
+  expect(result.snapshot.id).toBe("task-99");
+  expect(result.snapshot.session).toBe(session);
+  expect(result.snapshot.session.repoPath).toBe("/home/user/projects/my-project");
 });

--- a/test/session-snapshot.test.ts
+++ b/test/session-snapshot.test.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "bun:test";
+import { buildSnapshot } from "../src/session-snapshot";
+import type { Session } from "../src/types";
+import type { GitState } from "../src/forge/types";
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+function makeSession(id: string, repoPath: string): Session {
+  return { id, repoPath } as unknown as Session;
+}
+
+function makeAcc(session: Session | null) {
+  return { getSession: () => session };
+}
+
+const GIT_STATE: GitState = {
+  kind: "github",
+  state: "open",
+  checks: "success",
+  deployConfigured: false,
+};
+
+// ── buildSnapshot: status payload ─────────────────────────────────────────────
+
+test("buildSnapshot with status payload returns kind=status with snapshot", () => {
+  const session = makeSession("sess-1", "/repos/alpha");
+  const acc = makeAcc(session);
+  const result = buildSnapshot(acc, "sess-1", { kind: "status", status: "idle" });
+  if (!result) throw new Error("expected non-null result");
+  expect(result.kind).toBe("status");
+  if (result.kind !== "status") throw new Error("unreachable");
+  expect(result.status).toBe("idle");
+  expect(result.snapshot.id).toBe("sess-1");
+  expect(result.snapshot.repoPath).toBe("/repos/alpha");
+  expect(result.snapshot.session).toBe(session);
+});
+
+// ── buildSnapshot: git payload ────────────────────────────────────────────────
+
+test("buildSnapshot with git payload returns kind=git with snapshot", () => {
+  const session = makeSession("sess-2", "/repos/beta");
+  const acc = makeAcc(session);
+  const result = buildSnapshot(acc, "sess-2", { kind: "git", git: GIT_STATE });
+  if (!result) throw new Error("expected non-null result");
+  expect(result.kind).toBe("git");
+  if (result.kind !== "git") throw new Error("unreachable");
+  expect(result.git).toBe(GIT_STATE);
+  expect(result.snapshot.id).toBe("sess-2");
+  expect(result.snapshot.repoPath).toBe("/repos/beta");
+  expect(result.snapshot.session).toBe(session);
+});
+
+// ── buildSnapshot: null when session unknown ──────────────────────────────────
+
+test("buildSnapshot returns null when getSession returns null", () => {
+  const acc = makeAcc(null);
+  const result = buildSnapshot(acc, "missing", { kind: "status", status: "running" });
+  expect(result).toBeNull();
+});
+
+// ── buildSnapshot: repoPath comes from session, not id ───────────────────────
+
+test("snapshot repoPath is sourced from session row, not echoed from id", () => {
+  // id and repoPath are intentionally different so echoing id would be detected
+  const session = makeSession("task-99", "/home/user/projects/my-project");
+  const acc = makeAcc(session);
+  const result = buildSnapshot(acc, "task-99", { kind: "status", status: "done" });
+  if (!result) throw new Error("expected non-null result");
+  expect(result.snapshot.repoPath).toBe("/home/user/projects/my-project");
+  expect(result.snapshot.repoPath).not.toBe("task-99");
+});


### PR DESCRIPTION
## What & why

Closes #1094. The autonomous engine had no single "what happens next" place: one poller event fanned out to **two uncoordinated, fire-and-forget subscriptions** — `drain` (retire) and `autopilot` (steer). `EventHub.emit` dispatches synchronously but each subscriber ran `void asyncFn()`, so subscription order fixed *dispatch* but never *completion* order. Within one poller tick they interleaved and **raced**: a session could be retired by drain mid-classify while autopilot was steering it, and vice-versa.

This routes `session:status` and `session:git` through **one ordered seam** that dispatches consumers **drain → autopilot, awaited in order**.

## How

- **`src/session-snapshot.ts`** — `SessionSnapshot { id, repoPath, session }`, the `SessionStateChange` union, and pure `buildSnapshot` (returns `null` for an unknown session → dispatch skipped). Right-sized to what entry consumers actually read.
- **`src/session-router.ts`** — `SessionRouter` builds the snapshot **once** and dispatches `[drain, autopilot]`, **awaiting each fully before the next**; per-consumer try/catch isolation; an `onStatusSettled` hook for the independent plan-gate side-effect.
- **`drain.handle()` / `autopilot.handle()`** — each becomes a `SessionConsumer`. `drain` sources the trigger row from the snapshot (it runs first; its retire logic still re-derives live state via `buildState`/`computeNext`). `autopilot` deliberately **re-reads live state** — its entry + post-classify `eligible()` rechecks are the correctness guard and must see post-drain state.
- **`src/index.ts`** — hard cutover: status/git route only through the router; `session:block` stays autopilot-only; `session:archived`/`session:review` stay drain-only; **autoMerge and every other subscriber untouched**.

## What the ordering buys (precise)

Autopilot's post-classify `eligible()` recheck already prevented double-acting. Ordering adds: **determinism**, **skipping a wasted classify** (drain-first lets autopilot's *entry* gate return early instead of classifying then discarding), and **closing the steer-then-archive window** (drain acts on the live row before autopilot flips it).

## Deliberate deviations (flagged per house rules)

- **PR-prewarm hoist dropped.** The plan (responding to the plan reviewer) specced an `autopilot.prewarmPr` kick hoisted ahead of the awaited drain, with a "prewarm-before-drain" success criterion. During implementation this proved **both ineffective and unnecessary**: `onDone` already kicks `refreshPr` immediately before its classify, and `pollSession` debounces — a second prewarm kick would just re-delay the poll (double-kick). Because the refreshPr↔classify overlap is *intrinsic to `onDone`*, drain-first shifts both together and the overlap is preserved; only negligible steady-state latency is added. This satisfies the reviewer's "confirm the timing still holds" branch. The hook was removed from the router; rationale is in `autopilot.ts` (`handle`) and `session-router.ts` (`onStatus`). The "prewarm test" success criterion is intentionally not met.
- **autoMerge left out of the seam.** The issue names only the drain↔autopilot race. autoMerge stays on its own independent subscription — the router serializes drain only relative to autopilot, never autoMerge, so drain↔autoMerge concurrency is byte-for-byte unchanged and already idempotent-safe (`store.archive` is an idempotent `UPDATE`). No new double-archive window.
- **Snapshot trimmed** to `{ id, repoPath, session }` — the issue's literal "git+review+activity+status" field list was speculative; review/activity are read inside the kept cores, not at the seam.

## Scope kept

The already-deep cores — `drain-core`/`computeNext`, `stall`, `activity-signal` — are **unmodified**. This deepens the wiring above them.

## Tests / verification

- New `test/session-router.test.ts` (ordering proven deterministically via a manually-controlled deferred: autopilot cannot start until drain's promise settles), single-build, unknown-session, failure-isolation, identity. New `test/session-snapshot.test.ts`.
- Full root suite **5029 pass / 0 fail**; `bunx tsc --noEmit` clean; `bun run lint` clean; `fallow audit` exit 0; i18n / glossary / feature-catalog gates pass.
- Server-only orchestration plumbing, no user-facing UX → `[no-feature-entry]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
