### PR TITLE
feat(sessions): bring back a marked-as-done session from the Done lens

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,8 @@
 import type { SessionStore } from "./store";
 import type { PluginRegistry } from "./plugins/loader";
 import type { SessionService } from "./service";
+import { RestoreError } from "./service";
+import { WorktreeRestoreError } from "./worktree";
 import { LearningsService } from "./learnings-service";
 import { RepoConfigService } from "./repo-config-service";
 import type { CreateSessionInput } from "./types";
@@ -2156,6 +2158,7 @@ async function handleSessionAutoMerge({ req, parts, deps }: Ctx): Promise<Respon
 // — a re-opened menu or a second client isn't covered. Module-level so it's shared
 // across requests within a process.
 const inFlightRelaunch = new Set<string>();
+const inFlightRestore = new Set<string>();
 
 // Re-resolve a relaunch original's linked issue (by number) in the route — the service
 // has no forge access. The issue BODY rides the argv into the new prompt, so an
@@ -2318,6 +2321,39 @@ async function handleSessionRelaunch({ req, parts, deps }: Ctx): Promise<Respons
   }
 }
 
+// POST /api/sessions/:id/restore — bring an archived session back into the active Herd.
+// Re-creates the worktree (if isolated), resumes the Claude conversation, clears archivedAt.
+async function handleSessionRestore({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (!(req.method === "POST" && parts[2] && parts[3] === "restore")) return null;
+  const id = parts[2];
+
+  if (inFlightRestore.has(id))
+    return json({ error: "restore already in progress", code: "in_progress" }, 409);
+  inFlightRestore.add(id);
+  try {
+    let s: import("./types").Session | null;
+    try {
+      s = await deps.service.restore(id);
+    } catch (e) {
+      if (e instanceof RestoreError) {
+        return json({ error: e.message, code: e.code }, 409);
+      }
+      if (e instanceof WorktreeRestoreError) {
+        return json({ error: e.message, code: e.code }, 409);
+      }
+      throw e;
+    }
+    if (!s) {
+      if (!deps.store.get(id)) return json({ error: "not found" }, 404);
+      return json({ error: "could not restore", code: "spawn_refused" }, 409);
+    }
+    deps.events.emit("session:new", s);
+    return json(s);
+  } finally {
+    inFlightRestore.delete(id);
+  }
+}
+
 // POST /api/sessions/:id/relaunch-uploads — stage the original's uploaded images so a
 // relaunch composer can seed them as carried-over chips. Read-only on the session: it
 // copies (not moves) the originals into staging and returns { images: [{ path, name }] }.
@@ -2473,6 +2509,7 @@ async function handleSessions(ctx: Ctx): Promise<Response | null> {
     handleSessionAutopilot,
     handleSessionAutoMerge,
     handleSessionRelaunch,
+    handleSessionRestore,
     handleRelaunchUploads,
   ]) {
     const res = await sub(ctx);

--- a/src/service.ts
+++ b/src/service.ts
@@ -81,6 +81,13 @@ import type { GitForge, GitState, IssueComment } from "./forge/types";
  *  started in clearMergingForTrain. NOTE: per-session marks are NOT aged out by
  *  this — they persist for the life of the train (see sweepStaleMerging, which
  *  releases a mark only when its train leaves #liveTrains). */
+export class RestoreError extends Error {
+  constructor(public readonly code: "not_archived" | "cannot_restore") {
+    super(`restore failed: ${code}`);
+    this.name = "RestoreError";
+  }
+}
+
 export const MERGE_STALE_MS = 30 * 60_000;
 
 /** Absolute backstop for a STILL-RUNNING merge-train completion-tracker entry: a
@@ -102,6 +109,7 @@ export interface ServiceDeps {
     | "commitsAhead"
     | "currentBranch"
     | "gitCommonDir"
+    | "restoreExisting"
   >;
   herdr: Pick<HerdrDriver, "start" | "list" | "stop" | "send" | "relabel">;
   namer: (prompt: string) => string | Promise<string>;
@@ -2243,6 +2251,52 @@ export class SessionService {
       return null;
     }
     return this.finishResumeSpawn(session, outcome);
+  }
+
+  /**
+   * Restore an archived session: re-create its worktree (if isolated), resume the Claude
+   * conversation via `--resume`, and clear `archivedAt` so the session re-enters the Herd.
+   *
+   * Returns the updated Session on success, null on spawn failure (callers map that to
+   * a generic 409). Throws `RestoreError` for precondition violations, and propagates
+   * `WorktreeRestoreError` from the worktree layer so the route can map specific codes to 409.
+   */
+  async restore(id: string): Promise<Session | null> {
+    const s = this.deps.store.get(id);
+    if (!s) return null;
+
+    if (s.status !== "archived") throw new RestoreError("not_archived");
+
+    const provider = s.agentProvider ?? "claude";
+    if (provider !== "claude" || !s.claudeSessionId) throw new RestoreError("cannot_restore");
+
+    let worktreeCreated = false;
+    if (s.isolated && s.branch) {
+      // WorktreeRestoreError propagates to the route; it is a hard stop (no rollback needed
+      // since the worktree either wasn't created or was a stale one we just removed).
+      this.deps.worktree.restoreExisting(s.repoPath, s.branch, s.worktreePath);
+      worktreeCreated = true;
+    }
+
+    const trim = await this.trimFor(s.auto);
+    const outcome = await this.prepareResumeSpawn(s, this.buildResumeArgv(s, provider, trim));
+    if (!outcome.ok) {
+      console.warn(`[restore] spawn refused for ${s.id}: ${outcome.holdReason}`);
+      if (worktreeCreated) {
+        try {
+          this.deps.worktree.remove(s.worktreePath, {
+            branch: s.branch,
+            baseBranch: s.baseBranch,
+          });
+        } catch {
+          /* best-effort rollback */
+        }
+      }
+      return null;
+    }
+
+    this.deps.store.unarchive(s.id);
+    return this.finishResumeSpawn(s, outcome);
   }
 
   /**

--- a/src/service.ts
+++ b/src/service.ts
@@ -2284,10 +2284,10 @@ export class SessionService {
       console.warn(`[restore] spawn refused for ${s.id}: ${outcome.holdReason}`);
       if (worktreeCreated) {
         try {
-          this.deps.worktree.remove(s.worktreePath, {
-            branch: s.branch,
-            baseBranch: s.baseBranch,
-          });
+          // No branch opts — rollback must only remove the worktree, never prune
+          // the branch (pruneMergedBranch would delete a merged branch, making a
+          // retry fail with branch_gone).
+          this.deps.worktree.remove(s.worktreePath);
         } catch {
           /* best-effort rollback */
         }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1941,6 +1941,11 @@ export class SessionStore implements CapStore, CreditStore {
     ]);
   }
 
+  unarchive(id: string) {
+    const now = Date.now();
+    this.db.run(`UPDATE sessions SET archivedAt=NULL, updatedAt=? WHERE id=?`, [now, id]);
+  }
+
   // ── usage limit caps (CapStore) ──────────────────────────────────────────
   getCaps(): CapRow[] {
     return this.db

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -46,6 +46,13 @@ export interface ResolvedBase {
     | "none";
 }
 
+export class WorktreeRestoreError extends Error {
+  constructor(public readonly code: "branch_gone" | "branch_in_use") {
+    super(`worktree restore failed: ${code}`);
+    this.name = "WorktreeRestoreError";
+  }
+}
+
 export class WorktreeMgr {
   /** Injectable so tests can assert the teardown orphan sweep fires without real /proc. */
   constructor(private reaper: ProcessReaper = new ProcessReaper()) {}
@@ -631,6 +638,53 @@ export class WorktreeMgr {
       execFileAsync("git", ["worktree", "add", "--detach", worktreePath, sha], { cwd: repoPath }),
     );
     return { worktreePath, branch: null, isolated: true };
+  }
+
+  /**
+   * Attach an existing branch to a new worktree path. Unlike `create()`, does NOT create
+   * a new branch — it checks out an existing one. Used by `restore()` to re-surface an
+   * archived session whose branch survived on disk.
+   *
+   * Steps:
+   * 1. Validate `branch` refname.
+   * 2. Remove any stale `worktreePath` (no branch opts — must not prune the branch).
+   * 3. Verify the branch ref exists; throw `WorktreeRestoreError("branch_gone")` if not.
+   * 4. Ensure the parent directory exists.
+   * 5. `git worktree add <worktreePath> <branch>` (no -b).
+   *    - Already checked out elsewhere → `WorktreeRestoreError("branch_in_use")`.
+   *    - Any other failure → rethrow.
+   * 6. Return `worktreePath`.
+   */
+  restoreExisting(repoPath: string, branch: string, worktreePath: string): string {
+    if (!/^(?!-)[A-Za-z0-9._/-]{1,200}$/.test(branch)) {
+      throw new Error("invalid branch");
+    }
+    if (existsSync(worktreePath)) {
+      this.remove(worktreePath); // no branch opts → never prunes the branch
+    }
+    // Pre-check: branch ref must exist
+    try {
+      execFileSync("git", ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`], {
+        cwd: repoPath,
+        stdio: "pipe",
+      });
+    } catch {
+      throw new WorktreeRestoreError("branch_gone");
+    }
+    mkdirSync(dirname(worktreePath), { recursive: true });
+    try {
+      execFileSync("git", ["worktree", "add", worktreePath, branch], {
+        cwd: repoPath,
+        stdio: "pipe",
+      });
+    } catch (err) {
+      const stderr = this.gitStderr(err);
+      if (/already checked out|is already used by worktree/i.test(stderr)) {
+        throw new WorktreeRestoreError("branch_in_use");
+      }
+      throw err;
+    }
+    return worktreePath;
   }
 
   /** Delete `branch` iff it is fully merged into `baseBranch`; otherwise retain it. */

--- a/test/server-restore.test.ts
+++ b/test/server-restore.test.ts
@@ -1,0 +1,160 @@
+import { test, expect } from "bun:test";
+import { makeApp, type AppDeps } from "../src/server";
+import { RestoreError } from "../src/service";
+import { WorktreeRestoreError } from "../src/worktree";
+import type { SessionStore } from "../src/store";
+import type { SessionService } from "../src/service";
+import type { EventHub } from "../src/events";
+import type { Session } from "../src/types";
+
+type Spy = { event: string; data: unknown };
+
+function harness(opts: {
+  session?: Partial<Session> | null; // null → store.get returns undefined (404)
+  restoreResult?: Session | null; // what service.restore resolves to
+  restoreThrows?: unknown;
+}) {
+  const emitted: Spy[] = [];
+  const calls = { restore: [] as string[] };
+
+  const baseSession =
+    opts.session === null
+      ? undefined
+      : ({
+          id: "sess",
+          status: "archived",
+          archivedAt: Date.now() - 1000,
+          claudeSessionId: "abc-123",
+          agentProvider: "claude",
+          repoPath: "/r",
+          ...opts.session,
+        } as unknown as Session);
+
+  const restoredSession =
+    opts.restoreResult !== undefined
+      ? opts.restoreResult
+      : ({
+          id: "sess",
+          status: "running",
+          archivedAt: null,
+          claudeSessionId: "abc-123",
+          agentProvider: "claude",
+          repoPath: "/r",
+        } as unknown as Session);
+
+  const store = {
+    get: (id: string) => (id === "sess" ? baseSession : undefined),
+  } as unknown as SessionStore;
+
+  const service = {
+    restore: async (id: string) => {
+      calls.restore.push(id);
+      if (opts.restoreThrows) throw opts.restoreThrows;
+      return restoredSession;
+    },
+  } as unknown as SessionService;
+
+  const events = {
+    emit: (event: string, data: unknown) => {
+      emitted.push({ event, data });
+    },
+  } as unknown as EventHub;
+
+  const deps: AppDeps = {
+    store,
+    service,
+    events,
+    usageLimits: { limits: () => ({}) } as never,
+  };
+
+  return { app: makeApp(deps), emitted, calls };
+}
+
+function restoreReq(id = "sess"): Request {
+  return new Request(`http://localhost/api/sessions/${id}/restore`, { method: "POST" });
+}
+
+test("happy path: emits session:new, returns the restored session (200)", async () => {
+  const h = harness({});
+  const res = await h.app.fetch(restoreReq());
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as Session;
+  expect(body.id).toBe("sess");
+  expect(body.status).toBe("running");
+  expect(h.emitted).toHaveLength(1);
+  expect(h.emitted[0]?.event).toBe("session:new");
+  expect(h.emitted[0]?.data).toMatchObject({ id: "sess" });
+  expect(h.calls.restore).toEqual(["sess"]);
+});
+
+test("missing session: service returns null + store has no row → 404", async () => {
+  const h = harness({ session: null, restoreResult: null });
+  const res = await h.app.fetch(restoreReq());
+  expect(res.status).toBe(404);
+});
+
+test("RestoreError not_archived → 409 with code", async () => {
+  const h = harness({ restoreThrows: new RestoreError("not_archived") });
+  const res = await h.app.fetch(restoreReq());
+  expect(res.status).toBe(409);
+  const body = await res.json();
+  expect(body.code).toBe("not_archived");
+});
+
+test("RestoreError cannot_restore → 409 with code", async () => {
+  const h = harness({ restoreThrows: new RestoreError("cannot_restore") });
+  const res = await h.app.fetch(restoreReq());
+  expect(res.status).toBe(409);
+  const body = await res.json();
+  expect(body.code).toBe("cannot_restore");
+});
+
+test("WorktreeRestoreError branch_gone → 409 with code", async () => {
+  const h = harness({ restoreThrows: new WorktreeRestoreError("branch_gone") });
+  const res = await h.app.fetch(restoreReq());
+  expect(res.status).toBe(409);
+  const body = await res.json();
+  expect(body.code).toBe("branch_gone");
+});
+
+test("WorktreeRestoreError branch_in_use → 409 with code", async () => {
+  const h = harness({ restoreThrows: new WorktreeRestoreError("branch_in_use") });
+  const res = await h.app.fetch(restoreReq());
+  expect(res.status).toBe(409);
+  const body = await res.json();
+  expect(body.code).toBe("branch_in_use");
+});
+
+test("null return from service + row exists → 409 spawn_refused", async () => {
+  const h = harness({ restoreResult: null });
+  const res = await h.app.fetch(restoreReq());
+  expect(res.status).toBe(409);
+  const body = await res.json();
+  expect(body.code).toBe("spawn_refused");
+});
+
+test("null return from service + row missing (unknown id) → 404", async () => {
+  const h = harness({ session: null, restoreResult: null });
+  const res = await h.app.fetch(
+    new Request("http://localhost/api/sessions/unknown/restore", { method: "POST" }),
+  );
+  // "unknown" never matches store.get → 404
+  expect(res.status).toBe(404);
+});
+
+test("wrong method → no match (null)", async () => {
+  const h = harness({});
+  const res = await h.app.fetch(
+    new Request("http://localhost/api/sessions/sess/restore", { method: "GET" }),
+  );
+  // GET /restore is not handled → falls through to 404 from makeApp
+  expect(res.status).toBe(404);
+});
+
+test("in_progress guard: concurrent restore of same id → 409", async () => {
+  // We can't easily test the concurrent guard in isolation without real concurrency,
+  // but we can verify the code path exists by checking the module exports.
+  // The guard is module-level state — a real concurrent test would need two overlapping requests.
+  // Covered implicitly by the integration: the Set is initialised + cleaned up in finally.
+  expect(true).toBe(true); // placeholder so the describe block is not empty
+});

--- a/test/server-restore.test.ts
+++ b/test/server-restore.test.ts
@@ -152,9 +152,55 @@ test("wrong method → no match (null)", async () => {
 });
 
 test("in_progress guard: concurrent restore of same id → 409", async () => {
-  // We can't easily test the concurrent guard in isolation without real concurrency,
-  // but we can verify the code path exists by checking the module exports.
-  // The guard is module-level state — a real concurrent test would need two overlapping requests.
-  // Covered implicitly by the integration: the Set is initialised + cleaned up in finally.
-  expect(true).toBe(true); // placeholder so the describe block is not empty
+  // Make service.restore hang until released so two requests overlap.
+  let release!: () => void;
+  const gate = new Promise<void>((r) => (release = r));
+  let restoreCalls = 0;
+
+  const deps: AppDeps = {
+    store: {
+      get: (id: string) =>
+        id === "sess"
+          ? ({
+              id: "sess",
+              status: "archived",
+              archivedAt: Date.now() - 1000,
+              claudeSessionId: "abc-123",
+              agentProvider: "claude",
+              repoPath: "/r",
+            } as unknown as Session)
+          : undefined,
+    } as unknown as SessionStore,
+    service: {
+      restore: async () => {
+        restoreCalls++;
+        await gate;
+        return {
+          id: "sess",
+          status: "running",
+          archivedAt: null,
+          claudeSessionId: "abc-123",
+          agentProvider: "claude",
+          repoPath: "/r",
+        } as unknown as Session;
+      },
+    } as unknown as SessionService,
+    events: {
+      emit: () => {},
+    } as unknown as EventHub,
+    usageLimits: { limits: () => ({}) } as never,
+  };
+  const app = makeApp(deps);
+
+  const first = app.fetch(restoreReq()); // starts, hangs waiting for gate
+  // give the first request time to advance through the dispatch chain and register in inFlightRestore
+  await new Promise((r) => setTimeout(r, 10));
+  const secondRes = await app.fetch(restoreReq());
+  expect(secondRes.status).toBe(409);
+  expect((await secondRes.json()).code).toBe("in_progress");
+  expect(restoreCalls).toBe(1); // second did NOT invoke restore
+
+  release();
+  const firstRes = await first;
+  expect(firstRes.status).toBe(200);
 });

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -13,6 +13,7 @@ import { join } from "node:path";
 import { SessionStore } from "../src/store";
 import {
   SessionService,
+  RestoreError,
   spawnSettingsOverlay,
   buildHooksFragment,
   composeSystemPrompt,
@@ -26,6 +27,7 @@ import {
   PREVIEW_START_STEER,
   buildQueueDirective,
 } from "../src/service";
+import { WorktreeRestoreError } from "../src/worktree";
 import { HOUSE_RULES_TAG } from "../src/house-rules";
 import { config, parseTrimAutoContext } from "../src/config";
 import { MAX_IMAGES } from "../src/validate";
@@ -1616,6 +1618,7 @@ test("archive without a reaper just closes the session (no leftover handling)", 
       commitsAhead: () => 0,
       currentBranch: () => null,
       gitCommonDir: () => "/wt/.git",
+      restoreExisting: () => "",
     },
     herdr: { start: () => ({}) as any, list: () => [], stop: () => {} } as any,
   });
@@ -1658,6 +1661,7 @@ test("leftovers proxies to the reaper for the session; [] for unknown id", () =>
       commitsAhead: () => 0,
       currentBranch: () => null,
       gitCommonDir: () => "/wt/.git",
+      restoreExisting: () => "",
     },
     herdr: { start: () => ({}) as any, list: () => [], stop: () => {} } as any,
     reaper: { detect: detect as any, reap: () => {}, stopListenersOnPort: () => 0 },
@@ -1702,6 +1706,7 @@ test("archive reaps only the selected leftovers, re-detected (no trusting raw cl
       commitsAhead: () => 0,
       currentBranch: () => null,
       gitCommonDir: () => "/wt/.git",
+      restoreExisting: () => "",
     },
     herdr: { start: () => ({}) as any, list: () => [], stop: () => {} } as any,
     reaper: {
@@ -1744,6 +1749,7 @@ test("archive with no reap keys never calls the reaper", async () => {
       commitsAhead: () => 0,
       currentBranch: () => null,
       gitCommonDir: () => "/wt/.git",
+      restoreExisting: () => "",
     },
     herdr: { start: () => ({}) as any, list: () => [], stop: () => {} } as any,
     reaper: {
@@ -1973,6 +1979,239 @@ test("resume returns null for unknown, archived, or pre-feature sessions", async
 
   const preFeature = resumable(store, { claudeSessionId: "" });
   expect(await svc.resume(preFeature.id)).toBeNull(); // nothing pinned to resume
+});
+
+// ── restore ──────────────────────────────────────────────────────────────────
+
+function archivedWithSession(
+  store: SessionStore,
+  over: Partial<Parameters<SessionStore["create"]>[0]> = {},
+) {
+  const s = store.create({
+    name: "x",
+    prompt: "x",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/x",
+    worktreePath: "/wt/x",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_old",
+    claudeSessionId: "abc-123",
+    ...over,
+  });
+  store.archive(s.id);
+  return store.get(s.id)!;
+}
+
+function makeRestoreSvc(
+  store: SessionStore,
+  calls: Record<string, unknown>,
+  opts: { startFails?: boolean; restoreExistingThrows?: unknown } = {},
+) {
+  return new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: {
+      create: () => ({}) as any,
+      ensureBaseRef: async () => {},
+      remove: () => {},
+      branchExists: () => false,
+      restoreExisting: (repoPath: string, branch: string, worktreePath: string) => {
+        calls.restoreExisting = { repoPath, branch, worktreePath };
+        if (opts.restoreExistingThrows) throw opts.restoreExistingThrows;
+        return worktreePath;
+      },
+    } as any,
+    herdr: {
+      start: (_name: string, _cwd: string, argv: string[]) => {
+        calls.start = argv;
+        if (opts.startFails) return null as any;
+        return { terminalId: "term_new", cwd: "/wt/x", agentStatus: "working" } as any;
+      },
+      list: () => [],
+      stop: () => {},
+      send: () => {},
+    } as any,
+  });
+}
+
+test("restore: happy path — calls restoreExisting, unarchives, returns running session", async () => {
+  const store = new SessionStore(":memory:");
+  const calls: any = {};
+  const svc = makeRestoreSvc(store, calls);
+  const s = archivedWithSession(store);
+
+  const out = await svc.restore(s.id);
+  expect(out).not.toBeNull();
+  expect(out?.status).toBe("running");
+  expect(out?.archivedAt).toBeNull();
+  expect(out?.herdrAgentId).toBe("term_new");
+  expect(calls.restoreExisting).toMatchObject({
+    repoPath: "/r",
+    branch: "shepherd/x",
+    worktreePath: "/wt/x",
+  });
+  // claude --resume with the pinned session id
+  expect(calls.start).toContain("--resume");
+  expect(calls.start).toContain("abc-123");
+});
+
+test("restore: returns null for unknown id (route maps to 404)", async () => {
+  const store = new SessionStore(":memory:");
+  const svc = makeRestoreSvc(store, {});
+  expect(await svc.restore("ghost")).toBeNull();
+});
+
+test("restore: not_archived error for non-archived row", async () => {
+  const store = new SessionStore(":memory:");
+  const calls: any = {};
+  const svc = makeRestoreSvc(store, calls);
+  const s = store.create({
+    name: "x",
+    prompt: "x",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/x",
+    worktreePath: "/wt/x",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_old",
+    claudeSessionId: "abc-123",
+  });
+  let err: unknown;
+  try {
+    await svc.restore(s.id);
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeInstanceOf(RestoreError);
+  expect((err as RestoreError).code).toBe("not_archived");
+});
+
+test("restore: cannot_restore for codex session", async () => {
+  const store = new SessionStore(":memory:");
+  const svc = makeRestoreSvc(store, {});
+  const s = archivedWithSession(store, { agentProvider: "codex", claudeSessionId: "" });
+  let err: unknown;
+  try {
+    await svc.restore(s.id);
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeInstanceOf(RestoreError);
+  expect((err as RestoreError).code).toBe("cannot_restore");
+});
+
+test("restore: cannot_restore for claude with empty claudeSessionId", async () => {
+  const store = new SessionStore(":memory:");
+  const svc = makeRestoreSvc(store, {});
+  const s = archivedWithSession(store, { claudeSessionId: "" });
+  let err: unknown;
+  try {
+    await svc.restore(s.id);
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeInstanceOf(RestoreError);
+  expect((err as RestoreError).code).toBe("cannot_restore");
+});
+
+test("restore: branch_gone error propagates from worktree", async () => {
+  const store = new SessionStore(":memory:");
+  const calls: any = {};
+  const svc = makeRestoreSvc(store, calls, {
+    restoreExistingThrows: new WorktreeRestoreError("branch_gone"),
+  });
+  const s = archivedWithSession(store);
+  let err: unknown;
+  try {
+    await svc.restore(s.id);
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeInstanceOf(WorktreeRestoreError);
+  expect((err as WorktreeRestoreError).code).toBe("branch_gone");
+  // row stays archived — no unarchive happened
+  expect(store.get(s.id)?.status).toBe("archived");
+});
+
+test("restore: non-isolated session skips restoreExisting", async () => {
+  const store = new SessionStore(":memory:");
+  const calls: any = {};
+  const svc = makeRestoreSvc(store, calls);
+  const s = archivedWithSession(store, { isolated: false, branch: null });
+  const out = await svc.restore(s.id);
+  expect(out?.status).toBe("running");
+  expect(calls.restoreExisting).toBeUndefined();
+});
+
+test("restore: legacy archived row with null archivedAt still restores", async () => {
+  const store = new SessionStore(":memory:");
+  const calls: any = {};
+  const svc = makeRestoreSvc(store, calls);
+  const s = store.create({
+    name: "x",
+    prompt: "x",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/x",
+    worktreePath: "/wt/x",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_old",
+    claudeSessionId: "abc-123",
+  });
+  // legacy: status flipped without stamping archivedAt
+  store.update(s.id, { status: "archived" });
+  const row = store.get(s.id)!;
+  expect(row.archivedAt).toBeNull();
+  const out = await svc.restore(s.id);
+  expect(out?.status).toBe("running");
+});
+
+test("restore: spawn failure rolls back worktree and returns null", async () => {
+  // Force a hold via api-key mode with no helper path — prepareSpawn returns {ok:false}
+  // without ever calling herdr.start, matching the real spawn-refused contract.
+  const prevMode = config.authMode;
+  const prevPath = config.authApiKeyHelperPath;
+  const store = new SessionStore(":memory:");
+  const calls: any = { removed: [] };
+  const svc = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: {
+      create: () => ({}) as any,
+      ensureBaseRef: async () => {},
+      remove: (path: string, opts: unknown) => {
+        calls.removed.push({ path, opts });
+      },
+      branchExists: () => false,
+      restoreExisting: () => "/wt/x",
+      gitCommonDir: () => "/wt/x/.git",
+    } as any,
+    herdr: {
+      start: () => ({ terminalId: "t" }) as any,
+      list: () => [],
+      stop: () => {},
+      send: () => {},
+    } as any,
+  });
+  try {
+    config.authMode = "api-key";
+    config.authApiKeyHelperPath = null;
+    const s = archivedWithSession(store);
+    const out = await svc.restore(s.id);
+    expect(out).toBeNull();
+    // worktree was rolled back
+    expect(calls.removed.length).toBeGreaterThan(0);
+    expect(calls.removed[0].path).toBe("/wt/x");
+    // row stays archived
+    expect(store.get(s.id)?.status).toBe("archived");
+  } finally {
+    config.authMode = prevMode;
+    config.authApiKeyHelperPath = prevPath;
+  }
 });
 
 test("reply delivers the text as a bracketed paste, then submits with a carriage return", () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -2203,9 +2203,10 @@ test("restore: spawn failure rolls back worktree and returns null", async () => 
     const s = archivedWithSession(store);
     const out = await svc.restore(s.id);
     expect(out).toBeNull();
-    // worktree was rolled back
+    // worktree was rolled back without branch opts (must not prune the branch)
     expect(calls.removed.length).toBeGreaterThan(0);
     expect(calls.removed[0].path).toBe("/wt/x");
+    expect(calls.removed[0].opts).toBeUndefined();
     // row stays archived
     expect(store.get(s.id)?.status).toBe("archived");
   } finally {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -389,6 +389,27 @@ test("get / list / update / archive", () => {
   expect(s.list({ activeOnly: true }).length).toBe(0);
 });
 
+test("unarchive clears archivedAt to null", () => {
+  const s = mk();
+  const a = s.create(base);
+  s.archive(a.id);
+  expect(s.get(a.id)?.archivedAt).toBeGreaterThan(0);
+  s.unarchive(a.id);
+  expect(s.get(a.id)?.archivedAt).toBeNull();
+  // status stays archived (finishResumeSpawn updates it separately)
+  expect(s.get(a.id)?.status).toBe("archived");
+});
+
+test("unarchive is a no-op for an already-null archivedAt (legacy row)", () => {
+  const s = mk();
+  const a = s.create(base);
+  // legacy: status flipped without stamping archivedAt
+  s.update(a.id, { status: "archived" });
+  expect(s.get(a.id)?.archivedAt).toBeNull();
+  s.unarchive(a.id); // must not throw
+  expect(s.get(a.id)?.archivedAt).toBeNull();
+});
+
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
 

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -490,20 +490,49 @@ test("restoreExisting: removes a stale worktree dir before re-attaching", () => 
   const wt = new WorktreeMgr();
   const r = wt.create(repo, "main", "restore-stale");
   const { worktreePath, branch } = r;
-  // branch+worktree both exist — simulates a stale partial state
-  // detach the registered worktree but leave the directory via a plain remove
-  // (we can't easily simulate a "stale dir" without going through git,
-  //  so we remove+restore to prove the method handles re-attach correctly)
+  // Properly tear down the worktree (dir + git registration removed, branch kept).
   wt.remove(worktreePath);
+  expect(existsSync(worktreePath)).toBe(false);
+
+  // Plant a stale leftover at the target path to exercise the `if (existsSync) this.remove`
+  // branch inside restoreExisting (simulates a crash between dir creation and git add).
+  mkdirSync(worktreePath, { recursive: true });
+  writeFileSync(join(worktreePath, "leftover.txt"), "stale");
+  expect(existsSync(worktreePath)).toBe(true);
+
   const got = wt.restoreExisting(repo, branch!, worktreePath);
   expect(got).toBe(worktreePath);
   expect(existsSync(worktreePath)).toBe(true);
+  // stale file is gone; the branch is freshly checked out
+  expect(existsSync(join(worktreePath, "leftover.txt"))).toBe(false);
+  expect(wt.currentBranch(worktreePath)).toBe(branch);
   wt.remove(worktreePath);
 });
 
 test("restoreExisting: invalid branch name throws", () => {
   const wt = new WorktreeMgr();
   expect(() => wt.restoreExisting(repo, "--bad-branch", "/some/path")).toThrow("invalid branch");
+});
+
+test("restoreExisting: branch_in_use when branch is already checked out elsewhere", () => {
+  const wt = new WorktreeMgr();
+  // Create a worktree so the branch is actively checked out at worktreePath.
+  const r = wt.create(repo, "main", "in-use");
+  const { worktreePath, branch } = r;
+
+  // Attempt to attach the SAME branch to a DIFFERENT path — git refuses with
+  // "already checked out", which maps to WorktreeRestoreError("branch_in_use").
+  const altPath = worktreePath + "-alt";
+  let err: unknown;
+  try {
+    wt.restoreExisting(repo, branch!, altPath);
+  } catch (e) {
+    err = e;
+  }
+  wt.remove(worktreePath);
+
+  expect(err).toBeInstanceOf(WorktreeRestoreError);
+  expect((err as WorktreeRestoreError).code).toBe("branch_in_use");
 });
 
 test("behindBase: false when up-to-date, true when base advanced", async () => {

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import { join, dirname, basename } from "node:path";
 import { execFileSync } from "node:child_process";
-import { WorktreeMgr } from "../src/worktree";
+import { WorktreeMgr, WorktreeRestoreError } from "../src/worktree";
 import { ProcessReaper } from "../src/process-reaper";
 
 let repo: string;
@@ -453,6 +453,58 @@ test("create: cleanupPartial removes leftover dir → retry succeeds", () => {
 });
 
 // ── end Task A tests ──────────────────────────────────────────────────────────
+
+test("restoreExisting: attaches to an existing branch at the given path", () => {
+  const wt = new WorktreeMgr();
+  // create + remove a worktree so the branch survives but its worktree dir is gone
+  const r = wt.create(repo, "main", "restore-me");
+  const { worktreePath, branch } = r;
+  wt.remove(worktreePath); // no branch opts → branch kept
+  expect(existsSync(worktreePath)).toBe(false);
+
+  const got = wt.restoreExisting(repo, branch!, worktreePath);
+  expect(got).toBe(worktreePath);
+  expect(existsSync(worktreePath)).toBe(true);
+  // worktree checks out the branch
+  expect(wt.currentBranch(worktreePath)).toBe(branch);
+  wt.remove(worktreePath);
+});
+
+test("restoreExisting: branch_gone when the branch no longer exists", () => {
+  const wt = new WorktreeMgr();
+  let err: unknown;
+  try {
+    wt.restoreExisting(
+      repo,
+      "shepherd/nonexistent-branch",
+      join(dirname(repo), ".shepherd-worktrees/x-restore-gone"),
+    );
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeInstanceOf(WorktreeRestoreError);
+  expect((err as WorktreeRestoreError).code).toBe("branch_gone");
+});
+
+test("restoreExisting: removes a stale worktree dir before re-attaching", () => {
+  const wt = new WorktreeMgr();
+  const r = wt.create(repo, "main", "restore-stale");
+  const { worktreePath, branch } = r;
+  // branch+worktree both exist — simulates a stale partial state
+  // detach the registered worktree but leave the directory via a plain remove
+  // (we can't easily simulate a "stale dir" without going through git,
+  //  so we remove+restore to prove the method handles re-attach correctly)
+  wt.remove(worktreePath);
+  const got = wt.restoreExisting(repo, branch!, worktreePath);
+  expect(got).toBe(worktreePath);
+  expect(existsSync(worktreePath)).toBe(true);
+  wt.remove(worktreePath);
+});
+
+test("restoreExisting: invalid branch name throws", () => {
+  const wt = new WorktreeMgr();
+  expect(() => wt.restoreExisting(repo, "--bad-branch", "/some/path")).toThrow("invalid branch");
+});
 
 test("behindBase: false when up-to-date, true when base advanced", async () => {
   const dir = mkdtempSync(join(tmpdir(), "wt-"));

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2062,5 +2062,16 @@
   "session_autopilot_unavailable_label": "AP nicht verfügbar",
   "session_autopilot_unavailable_title": "Codex-Autopilot braucht eine isolierte Worktree-Session; diese Session teilt sich ihr Arbeitsverzeichnis, daher steht der Autopilot still.",
   "feat_codex_autopilot_title": "Autopilot für Codex (Alpha)",
-  "feat_codex_autopilot_body": "Autopilot-bis-zum-PR ist jetzt für Codex-Aufgaben verfügbar. Schalte ihn im Neue-Aufgabe-Dialog ein, und Codex läuft unbeaufsichtigt bis zu einem offenen PR. Es ist best-effort (Alpha): nur isolierte Sessions werden getrieben, und es stoppt am offenen PR — niemals automatischer Merge."
+  "feat_codex_autopilot_body": "Autopilot-bis-zum-PR ist jetzt für Codex-Aufgaben verfügbar. Schalte ihn im Neue-Aufgabe-Dialog ein, und Codex läuft unbeaufsichtigt bis zu einem offenen PR. Es ist best-effort (Alpha): nur isolierte Sessions werden getrieben, und es stoppt am offenen PR — niemals automatischer Merge.",
+  "donerecap_bringback": "Zurückholen",
+  "donerecap_bringback_confirm": "Zurückholen?",
+  "restore_done": "{desig} wurde zur Herde zurückgeholt",
+  "restore_cannot": "Diese Session kann nicht zurückgeholt werden — starte sie stattdessen neu",
+  "restore_branch_gone": "Ihr Branch wurde gemergt und entfernt — starte sie stattdessen neu",
+  "restore_branch_in_use": "Ihr Branch ist anderswo ausgecheckt",
+  "restore_not_archived": "Diese Session ist nicht abgeschlossen",
+  "restore_in_progress": "Wird bereits zurückgeholt…",
+  "restore_failed": "Zurückholen fehlgeschlagen",
+  "feat_bring_back_title": "Eine abgeschlossene Session zurückholen",
+  "feat_bring_back_body": "Wähle eine Session in der Fertig-Ansicht aus und klicke auf Zurückholen, um sie fortzusetzen — Shepherd stellt deine committeten Branch-Änderungen wieder her und führt das Gespräch dort weiter, wo es aufgehört hat. Nicht committete Änderungen werden nicht wiederhergestellt."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2062,5 +2062,16 @@
   "session_autopilot_unavailable_label": "AP unavailable",
   "session_autopilot_unavailable_title": "Codex autopilot needs an isolated worktree session; this session shares its working directory, so autopilot stands down.",
   "feat_codex_autopilot_title": "Autopilot for Codex (Alpha)",
-  "feat_codex_autopilot_body": "Autopilot-until-PR is now available for Codex tasks. Toggle it on in New Task and Codex runs unattended toward an open PR. It is best-effort (Alpha): it drives isolated sessions only and stops at the open PR — it never auto-merges."
+  "feat_codex_autopilot_body": "Autopilot-until-PR is now available for Codex tasks. Toggle it on in New Task and Codex runs unattended toward an open PR. It is best-effort (Alpha): it drives isolated sessions only and stops at the open PR — it never auto-merges.",
+  "donerecap_bringback": "Bring back",
+  "donerecap_bringback_confirm": "Bring back?",
+  "restore_done": "Brought {desig} back to the herd",
+  "restore_cannot": "Can't bring this one back — relaunch it instead",
+  "restore_branch_gone": "Its branch was merged and removed — relaunch instead",
+  "restore_branch_in_use": "Its branch is checked out elsewhere",
+  "restore_not_archived": "This session isn't done",
+  "restore_in_progress": "Already bringing this one back…",
+  "restore_failed": "Couldn't bring it back",
+  "feat_bring_back_title": "Bring back a done session",
+  "feat_bring_back_body": "Select any session in the Done lens and click Bring back to resume it — Shepherd restores your committed branch work and continues the conversation from where it left off. Uncommitted edits are not recovered."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -697,6 +697,20 @@ export async function relaunchSession(
 }
 
 /**
+ * Restore an archived session from the Done lens: re-creates the worktree on its
+ * surviving branch and resumes the conversation. Returns the restored `Session` on
+ * success. On a non-ok response throws an {@link ApiError} carrying the HTTP `status`
+ * and the server's stable `code` so the caller can branch on the failure mode.
+ */
+export async function restoreSession(id: string): Promise<Session> {
+  const r = await fetch(`/api/sessions/${id}/restore`, { method: "POST" });
+  if (r.ok) return r.json();
+  const body = (await r.json().catch(() => null)) as { error?: string; code?: string } | null;
+  const base = apiError(r.status, body, `restore failed: ${r.status}`);
+  throw new ApiError(r.status, base.message, body?.code);
+}
+
+/**
  * Stage the original session's uploads for a relaunch-elsewhere so the composer
  * can seed them as removable chips. Returns the carried images (server path +
  * display name); throws a `failed` error on a non-2xx response.

--- a/ui/src/lib/components/DoneRecapPanel.browser.test.ts
+++ b/ui/src/lib/components/DoneRecapPanel.browser.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
 import DoneRecapPanel from "./DoneRecapPanel.svelte";
 import { recaps } from "$lib/recaps.svelte";
+import { m } from "$lib/paraglide/messages";
 import type { Session, Recap } from "$lib/types";
 
 function session(partial: Partial<Session> & { id: string }): Session {
@@ -210,6 +211,68 @@ describe("DoneRecapPanel generating state", () => {
     recaps.map = { g1: recap({ sessionId: "g1", state: "generating" }) };
     render(DoneRecapPanel, { session: session({ id: "g1" }) });
     await expect.element(page.getByText("Generating recap…")).toBeInTheDocument();
+  });
+});
+
+describe("DoneRecapPanel bring-back button", () => {
+  it("renders Bring back button only when onbringback is provided", async () => {
+    recaps.map = { bb1: recap({ sessionId: "bb1" }) };
+
+    // without onbringback: no button at all
+    const { rerender } = render(DoneRecapPanel, { session: session({ id: "bb1" }) });
+    expect(
+      page.getByRole("button", { name: m.donerecap_bringback() }).query(),
+      "no button without onbringback",
+    ).toBeNull();
+
+    // with onbringback: button appears
+    await rerender({ session: session({ id: "bb1" }), onbringback: vi.fn() });
+    await expect
+      .element(page.getByRole("button", { name: m.donerecap_bringback() }))
+      .toBeInTheDocument();
+  });
+
+  it("first click arms (no callback yet), second click fires onbringback once", async () => {
+    recaps.map = { bb2: recap({ sessionId: "bb2" }) };
+    const onbringback = vi.fn();
+    render(DoneRecapPanel, { session: session({ id: "bb2" }), onbringback });
+
+    const btn = page.getByRole("button", { name: m.donerecap_bringback() });
+    await btn.click();
+
+    // armed: callback NOT yet fired, label switches to confirm
+    expect(onbringback).not.toHaveBeenCalled();
+    const confirmBtn = page.getByRole("button", { name: m.donerecap_bringback_confirm() });
+    await expect.element(confirmBtn).toBeInTheDocument();
+
+    // second click fires it exactly once with the session id
+    await confirmBtn.click();
+    expect(onbringback).toHaveBeenCalledTimes(1);
+    expect(onbringback).toHaveBeenCalledWith("bb2");
+  });
+
+  it("auto-disarms after the arm window without firing the callback", async () => {
+    vi.useFakeTimers();
+    try {
+      recaps.map = { bb3: recap({ sessionId: "bb3" }) };
+      const onbringback = vi.fn();
+      render(DoneRecapPanel, { session: session({ id: "bb3" }), onbringback });
+
+      const btn = page.getByRole("button", { name: m.donerecap_bringback() });
+      await btn.click();
+      await expect
+        .element(page.getByRole("button", { name: m.donerecap_bringback_confirm() }))
+        .toBeInTheDocument();
+
+      // advance past the ~3s arm window → disarms back to idle label, no fire
+      vi.advanceTimersByTime(3500);
+      await expect
+        .element(page.getByRole("button", { name: m.donerecap_bringback() }))
+        .toBeInTheDocument();
+      expect(onbringback).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/ui/src/lib/components/DoneRecapPanel.svelte
+++ b/ui/src/lib/components/DoneRecapPanel.svelte
@@ -6,7 +6,33 @@
   import { m } from "$lib/paraglide/messages";
   import VisualReview from "./VisualReview.svelte";
 
-  let { session }: { session: Session } = $props();
+  let {
+    session,
+    onbringback,
+  }: {
+    session: Session;
+    onbringback?: (id: string) => void;
+  } = $props();
+
+  // Two-step arm → confirm for Bring back: mirroring CardMenu's relaunchArmed pattern.
+  // First click arms (label switches to confirm text, danger-wash applied); only a
+  // second click within the window fires onbringback. Auto-disarms after ~3s.
+  // Timer cleared on destroy so a dangling timer never fires after panel teardown.
+  const BRING_BACK_ARM_MS = 3000;
+  let bringBackArmed = $state(false);
+  let bringBackTimer: ReturnType<typeof setTimeout> | undefined;
+  function onBringBackClick() {
+    if (bringBackArmed) {
+      clearTimeout(bringBackTimer);
+      bringBackArmed = false;
+      onbringback?.(session.id);
+      return;
+    }
+    bringBackArmed = true;
+    clearTimeout(bringBackTimer);
+    bringBackTimer = setTimeout(() => (bringBackArmed = false), BRING_BACK_ARM_MS);
+  }
+  $effect(() => () => clearTimeout(bringBackTimer));
 
   const recap = $derived(recaps.map[session.id]);
 
@@ -70,6 +96,13 @@
   <header class="dr-head">
     <span class="dr-desig">{session.desig}</span>
     <span class="dr-finished">{m.done_recap_finished({ ago: finishedAgo })}</span>
+    {#if onbringback}
+      <div class="dr-actions">
+        <button type="button" class="gbtn" class:armed={bringBackArmed} onclick={onBringBackClick}
+          >{bringBackArmed ? m.donerecap_bringback_confirm() : m.donerecap_bringback()}</button
+        >
+      </div>
+    {/if}
     {#if session.issueNumber != null}
       {#if session.issueUrl}
         <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL, not an app route -->
@@ -163,6 +196,47 @@
   .dr-finished {
     font-size: var(--fs-meta);
     color: var(--color-muted);
+  }
+
+  /* Action cluster: sits right after the muted stamps; the issue link's auto margin
+     pushes them both to the right edge, keeping the header layout intact. */
+  .dr-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  /* Bring-back button: canonical .gbtn recipe from the design system (token-only). */
+  .gbtn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 2px 8px;
+    cursor: pointer;
+    transition:
+      border-color 0.12s,
+      color 0.12s;
+  }
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .gbtn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+  /* Armed state mirrors CardMenu's armed danger-wash so the second click reads as hot. */
+  .gbtn.armed {
+    border-color: var(--color-red);
+    color: var(--color-red);
+    background: color-mix(in srgb, var(--color-red) 14%, var(--color-panel));
+  }
+  .gbtn.armed:hover {
+    background: color-mix(in srgb, var(--color-red) 22%, var(--color-panel));
   }
 
   .dr-issue {

--- a/ui/src/lib/done.svelte.test.ts
+++ b/ui/src/lib/done.svelte.test.ts
@@ -28,3 +28,15 @@ test("load() swallows api errors and leaves the list untouched (best-effort)", a
   await expect(doneSessions.load()).resolves.toBeUndefined();
   expect(doneSessions.sessions).toEqual([session("prev")]);
 });
+
+test("remove() drops the matching session by id", () => {
+  doneSessions.sessions = [session("a"), session("b"), session("c")];
+  doneSessions.remove("b");
+  expect(doneSessions.sessions.map((s) => s.id)).toEqual(["a", "c"]);
+});
+
+test("remove() is a no-op when the id is not in the list", () => {
+  doneSessions.sessions = [session("x"), session("y")];
+  doneSessions.remove("z");
+  expect(doneSessions.sessions.map((s) => s.id)).toEqual(["x", "y"]);
+});

--- a/ui/src/lib/done.svelte.ts
+++ b/ui/src/lib/done.svelte.ts
@@ -18,5 +18,10 @@ class DoneSessionsStore {
       /* best-effort; the next lens open retries */
     }
   }
+
+  /** Drop a restored session from the Done list immediately on success. */
+  remove(id: string) {
+    this.sessions = this.sessions.filter((s) => s.id !== id);
+  }
 }
 export const doneSessions = new DoneSessionsStore();

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1733,4 +1733,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_codex_autopilot_body",
     targetId: "task-autopilot",
   },
+  {
+    // Bring back a marked-as-done session from the Done lens: re-creates the worktree on its
+    // surviving branch and resumes the conversation. Recovers committed work only. 1.37.0 is the
+    // latest released tag, so this ships in 1.38.0. No targetId — the button only renders when a
+    // done session is selected in the Done lens, so there's no always-present anchor.
+    id: "bring-back-done",
+    sinceVersion: "1.38.0",
+    titleKey: "feat_bring_back_title",
+    bodyKey: "feat_bring_back_body",
+  },
 ];

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -7,6 +7,7 @@
     createSession,
     archiveSession,
     relaunchSession,
+    restoreSession,
     stageRelaunchImages,
     ApiError,
     getUsageLimits,
@@ -1644,6 +1645,32 @@
     }
   }
 
+  // Restore an archived session from the Done lens: re-creates the worktree on its
+  // surviving branch and resumes the conversation (recovers committed work only).
+  // The two-step arm lives in DoneRecapPanel, so by the time this fires the operator
+  // has already confirmed. The live Herd row arrives via session:new — no manual
+  // store mutation needed beyond dropping the row from the Done list on success.
+  async function onBringBack(id: string) {
+    const fail = (text: string) =>
+      toasts.info(text, { duration: null, alert: true, key: `restore-fail:${id}` });
+    try {
+      const s = await restoreSession(id);
+      doneSessions.remove(id);
+      toasts.info(m.restore_done({ desig: s.desig }));
+    } catch (e) {
+      if (e instanceof ApiError) {
+        if (e.code === "cannot_restore") fail(m.restore_cannot());
+        else if (e.code === "branch_gone") fail(m.restore_branch_gone());
+        else if (e.code === "branch_in_use") fail(m.restore_branch_in_use());
+        else if (e.code === "not_archived") fail(m.restore_not_archived());
+        else if (e.code === "in_progress") fail(m.restore_in_progress());
+        else fail(m.restore_failed());
+      } else {
+        fail(m.restore_failed());
+      }
+    }
+  }
+
   // Fleet-wide emergency stop. Interrupting every working agent is consequential, so
   // the guard against an accidental tap is the TopBar's two-step arm→confirm gesture
   // (first activation arms the red "Halt N?" pill, a second commits) — by the time
@@ -2013,7 +2040,7 @@
             >{m.done_back_to_list()}</button
           >
           {#if doneSelected}
-            <DoneRecapPanel session={doneSelected} />
+            <DoneRecapPanel session={doneSelected} onbringback={(id) => onBringBack(id)} />
           {:else}
             <div class="empty">{m.herd_done_empty()}</div>
           {/if}
@@ -2150,7 +2177,7 @@
         {:else if herdFilter === "done"}
           <!-- Done lens: read-only recap for the picked archived session -->
           {#if doneSelected}
-            <DoneRecapPanel session={doneSelected} />
+            <DoneRecapPanel session={doneSelected} onbringback={(id) => onBringBack(id)} />
           {:else}
             <div class="empty">{m.herd_done_empty()}</div>
           {/if}


### PR DESCRIPTION
## What

Adds a **Bring back** action that restores a marked-as-done (archived) session from the **Done lens** into the active Herd: it re-creates the session's worktree on its surviving branch, restarts its Claude agent with the prior conversation **resumed** (`claude --resume`), and clears its archived state. Closes the gap where archiving was a one-way door.

## How it works

- New `POST /api/sessions/:id/restore` → `service.restore(id)`:
  1. Validates `status === "archived"` (keyed off status, **not** `archivedAt`, so legacy rows with a null stamp restore too).
  2. **Resumability guard** (resume-only MVP): only a **claude** row with a non-empty `claudeSessionId` is restorable; codex rows and empty-session rows get a clear `409 cannot_restore`.
  3. Re-creates the worktree on the surviving branch via the new `worktree.restoreExisting()` (`git worktree add <path> <branch>`, no `-b`), distinguishing `branch_gone` (merged/pruned) from `branch_in_use`.
  4. Reuses the existing resume machinery verbatim (`buildResumeArgv` / `prepareResumeSpawn` / `finishResumeSpawn`); on spawn failure it rolls the worktree back (without pruning the branch) and leaves the row archived.
  5. `store.unarchive()` clears `archivedAt`; the route emits `session:new` so the live Herd re-adds the row (the proven held-release/relaunch pattern).
- UI: a two-step arm-then-confirm **Bring back** button in `DoneRecapPanel` → `restoreSession(id)`; on success drops the row from the Done lens (the live row arrives via `session:new`) and toasts; ApiError codes map to per-id-deduped persistent failure toasts.

## Why resume works after archive

Archive `rmSync`s the worktree but the Claude transcript lives at `~/.claude/projects/<dashified-cwd>/<claudeSessionId>.jsonl` — **outside** the worktree — so re-creating the worktree at the same path yields an identical cwd-keyed project dir and `claude --resume` resolves the surviving transcript. Verified empirically (Phase-0 go/no-go gate) before building.

## Honest scope

Restore recovers **committed branch work + the resumed conversation** — uncommitted mid-edit changes were deleted at archive and are **not** recovered. All UI copy (button, toast, What's-New entry) reflects this and never implies a mid-edit tree returns.

## Tests

Layered: route taxonomy + concurrent-guard (`server-restore.test.ts`), service happy/guard/rollback paths incl. legacy-null (`service.test.ts`), real-git `restoreExisting` incl. `branch_gone`/`branch_in_use`/stale-dir/invalid-name (`worktree.test.ts`), `store.unarchive` (`store.test.ts`), and UI arm→confirm→fire + auto-disarm + `done.remove` (`DoneRecapPanel.browser.test.ts`, `done.svelte.test.ts`). Root: 5100 pass. UI: 2138 pass. `check:i18n`, feature-catalog, glossary, branch-hygiene, `fallow audit` (dead code 0, complexity 0) all green.

## Deferred (not in this PR)

- **Fresh-agent restore variant** (restore committed work but start a brand-new agent when no resumable conversation exists) — would lose chat context; non-trivial `buildSpawnArgv` surface.
- **Codex resume restore** — blocked pending a persisted provider-native Codex session id (`codex resume --last` can target the wrong session for a shared cwd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
