### PR TITLE
fix(plugins): follow symlinked plugin dirs in the loader (#1176)

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -231,7 +231,9 @@ Settings → Plugins panel:
 env var name (`envVar`) and label template (`labelTemplate`); both default sensibly when
 absent.
 
-**Copy it to run it.** `cp -r examples/plugins/spawn-labeler ~/.shepherd/plugins/`, then —
+**Copy it to run it.** `cp -r examples/plugins/spawn-labeler ~/.shepherd/plugins/` (or
+`ln -s "$PWD/examples/plugins/spawn-labeler" ~/.shepherd/plugins/` to run it straight from a
+checkout — the loader follows symlinked plugin dirs, so `git pull` keeps it current), then —
 because the example's `import type` uses a repo-relative path that won't resolve out-of-repo
 — **drop the `import type` line or vendor `src/plugins/types.ts`** (the import is erased at
 runtime, so loading is unaffected either way), and restart Shepherd. See

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -18,13 +18,16 @@ into your plugins dir to actually run it.
 ```sh
 # 1. Copy the folder into your plugins dir (override the dir with SHEPHERD_PLUGINS_DIR).
 cp -r examples/plugins/spawn-labeler ~/.shepherd/plugins/
+# …or symlink it from a checkout so `git pull` keeps the installed plugin current:
+ln -s "$PWD/examples/plugins/spawn-labeler" ~/.shepherd/plugins/
 
 # 2. Restart Shepherd to load it. (Optional: fix the type import first — see below —
 #    for editor/type-check ergonomics; it is NOT required to run the plugin.)
 systemctl --user restart shepherd
 ```
 
-Plugins load **at boot only** — edit the folder, then restart.
+Plugins load **at boot only** — edit the folder, then restart. A **symlinked** plugin dir
+loads identically to a copied one (the loader follows the link).
 
 ### Fix the type import for editor/type-check ergonomics (optional)
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -100,11 +100,24 @@ export class PluginRegistry {
   async loadAll(): Promise<void> {
     let names: string[];
     try {
+      // `readdir(..., { withFileTypes: true })` does NOT follow symlinks: a
+      // symlink-to-directory Dirent reports isDirectory()===false. Resolve such
+      // entries with stat() (which follows the link) so a symlinked install — the
+      // natural "run a plugin from its checkout" workflow — loads like a copy (#1176).
       const entries = await readdir(this.deps.pluginsDir, { withFileTypes: true });
-      names = entries
-        .filter((e) => e.isDirectory())
-        .map((e) => e.name)
-        .sort();
+      names = [];
+      for (const e of entries) {
+        if (e.isDirectory()) {
+          names.push(e.name);
+        } else if (e.isSymbolicLink()) {
+          try {
+            if ((await stat(join(this.deps.pluginsDir, e.name))).isDirectory()) names.push(e.name);
+          } catch {
+            /* dangling symlink — skip */
+          }
+        }
+      }
+      names.sort();
     } catch {
       return; // missing dir → nothing to load
     }

--- a/test/plugins.test.ts
+++ b/test/plugins.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { SessionStore } from "../src/store";
@@ -133,6 +133,34 @@ test("loadAll: enabled:false is skipped", async () => {
   await registry.loadAll();
   expect(registry.loadedCount()).toBe(0);
   rmSync(root, { recursive: true, force: true });
+});
+
+// ── loader: symlinked plugin dirs (#1176) ────────────────────────────────────
+test("loadAll: a symlinked plugin dir loads identically to a copied one", async () => {
+  // The plugin's real folder lives outside the plugins dir; only a symlink to it
+  // is placed inside — the natural "run a plugin from its checkout" install.
+  const src = tmpDir();
+  writePlugin(src, "linked", { index: "export function register(){}" });
+  const pluginsDir = tmpDir();
+  symlinkSync(join(src, "linked"), join(pluginsDir, "linked"));
+
+  const { registry } = makeRegistry(pluginsDir);
+  await registry.loadAll();
+
+  const info = registry.list().find((p) => p.id === "linked");
+  expect(info).toBeDefined();
+  expect(info!.health).toBe("ok");
+  rmSync(pluginsDir, { recursive: true, force: true });
+  rmSync(src, { recursive: true, force: true });
+});
+
+test("loadAll: a dangling symlink is ignored without throwing", async () => {
+  const pluginsDir = tmpDir();
+  symlinkSync(join(pluginsDir, "no-such-target"), join(pluginsDir, "dangling"));
+  const { registry } = makeRegistry(pluginsDir);
+  await registry.loadAll(); // must not throw
+  expect(registry.loadedCount()).toBe(0);
+  rmSync(pluginsDir, { recursive: true, force: true });
 });
 
 // ── loader: example fixture (also the public template) ───────────────────────


### PR DESCRIPTION
## Problem

`PluginRegistry.loadAll` enumerated the plugins dir with `readdir(..., { withFileTypes: true })` and filtered on `e.isDirectory()`. That call **does not follow symlinks**: a symlink-to-directory Dirent reports `isDirectory() === false` (and `isSymbolicLink() === true`), so a `ln -s … ~/.shepherd/plugins/<name>` install was silently filtered out — no manifest read, no error, nothing in the status panel. Plugins had to be `cp -r`'d, which breaks running a plugin straight from its git checkout (so `git pull` keeps it current).

Surfaced deploying the `claude-swap` plugin: a symlink install loaded nothing; `cp -r` fixed it.

## Fix

`src/plugins/loader.ts` — resolve symlinked entries before the directory check: plain dirs pass as before; for a symlink entry, `stat()` it (which **follows** the link) and include it only when the target is a directory. A dangling/broken symlink throws from `stat()` and is skipped. `stat` was already imported; downstream `loadOne` already reads through the link, so nothing else changes. The whole-`readdir` try/catch (missing-dir → clean no-op) is untouched.

## Tests

`test/plugins.test.ts`:
- a **symlinked** plugin dir (real folder outside, symlink inside) loads with `ok` health, identically to a copy;
- a **dangling** symlink is ignored without throwing (loadedCount 0).

Existing missing/empty/zero-plugin no-op tests still pass.

## Docs

`docs/plugins.md` + `examples/plugins/README.md` note the `ln -s …` install now works (loader follows the link).

## Acceptance criteria

- [x] Symlinked dir loads identically to a copied one (manifest read, `register` called, in `list()`).
- [x] Dangling symlink ignored without throwing.
- [x] Zero-plugin / missing-dir / empty-dir no-op invariants preserved.
- [x] Loader test covers the symlinked-plugin case.

## Verification

`bun test ./test` → 5102 pass / 0 fail · `bun run lint` clean · `bunx tsc --noEmit` clean · `fallow audit` no issues.

Server-only fix (no UI / i18n / feature-catalog entry needed). Closes #1176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)