### PR TITLE
fix(ui): remove redundant working-line spinner from session cards

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2057,8 +2057,6 @@
   "topbar_tokens_window": "{period} Tokens",
   "feat_codex_usage_topbar_title": "Codex-Auslastung in der Topbar",
   "feat_codex_usage_topbar_body": "Das Auslastungs-Popover in der Topbar zeigt jetzt auch Codex-Token-Telemetrie, wenn eine lokale Codex-CLI konfiguriert ist. So bleiben Claude- und Codex-Kapazität an derselben Stelle sichtbar.",
-  "feat_working_line_title": "Eine Arbeitslinie statt „AKTIV“",
-  "feat_working_line_body": "Eine laufende Sitzung zeigt jetzt eine dünne animierte Linie dort, wo zuvor „AKTIV“ stand. Leerlaufende und wartende Sitzungen zeigen dort nichts an — Status-Punkt und Herzschlag tragen den Zustand bereits, sodass die Karte ruhiger wirkt und die Zeit mehr Platz hat.",
   "session_autopilot_unavailable_label": "AP nicht verfügbar",
   "session_autopilot_unavailable_title": "Codex-Autopilot braucht eine isolierte Worktree-Session; diese Session teilt sich ihr Arbeitsverzeichnis, daher steht der Autopilot still.",
   "feat_codex_autopilot_title": "Autopilot für Codex (Alpha)",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2057,8 +2057,6 @@
   "topbar_tokens_window": "{period} tokens",
   "feat_codex_usage_topbar_title": "Codex usage in the topbar",
   "feat_codex_usage_topbar_body": "The topbar usage popover now includes Codex token telemetry when a local Codex CLI is configured, so Claude and Codex capacity are visible from the same place.",
-  "feat_working_line_title": "A working line, not a BUSY label",
-  "feat_working_line_body": "A running session now shows a thin animated line where the BUSY label used to be. Idle and waiting sessions show nothing there — the status pip and heartbeat already carry the state, so the card stays calmer and the time has more room.",
   "session_autopilot_unavailable_label": "AP unavailable",
   "session_autopilot_unavailable_title": "Codex autopilot needs an isolated worktree session; this session shares its working directory, so autopilot stands down.",
   "feat_codex_autopilot_title": "Autopilot for Codex (Alpha)",

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -315,37 +315,6 @@ body {
     opacity: 0.55;
   }
 }
-/* WORKING line — replaces the BUSY text badge on a running session. A very thin
-   muted glint sweeping a transparent rail, à la a working/indeterminate bar; its
-   mere presence means "busy", its absence means parked/idle. Deliberately quiet
-   (muted ink, not amber): the left StatusPip already pulses amber and the
-   heartbeat strip also encodes activity, so this third running signal must not
-   add to the amber wall. */
-.busy-line {
-  width: 48px;
-  height: 1.5px;
-  position: relative;
-  overflow: hidden;
-  flex-shrink: 0;
-}
-.busy-line::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(90deg, transparent, var(--color-ink-bright), transparent);
-  opacity: 0.7;
-  transform: translateX(-100%);
-  animation: busy-sweep 1.5s ease-in-out infinite;
-}
-@keyframes busy-sweep {
-  0% {
-    transform: translateX(-100%);
-  }
-  60%,
-  100% {
-    transform: translateX(100%);
-  }
-}
 
 /* Blanket-disable decorative motion under reduced-motion. Functional status
    indicators ("work happening": CI dot-pulse, pip-pulse, critic rev-pulse,
@@ -357,14 +326,6 @@ body {
   *::before,
   *::after {
     animation: none !important;
-  }
-  /* The working line is functional, not decorative: with the sweep stilled the
-     glint would park off-rail (invisible), dropping the busy signal — so fall
-     back to a static muted line that still reads as "busy". */
-  .busy-line::before {
-    transform: none;
-    background: var(--color-muted);
-    opacity: 0.6;
   }
 }
 

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -208,10 +208,10 @@ describe("UnitRow inline repo emoji filter", () => {
 describe("UnitRow working-while-blocked (full working treatment)", () => {
   // What the FULL working treatment looks like on a row — asserted identically
   // for a raw-running session and a blocked+flagged one, so the two renders
-  // can't drift apart: the thin working line (not the BLOCKED text), the working
-  // pip (not the red "!" alarm badge), the typing caret, and the live activity line.
+  // can't drift apart: the working pip (not the red "!" alarm badge), the typing
+  // caret, and the live activity line. The amber StatusPip carries the running
+  // state on a row, so there's no separate working-line element to assert.
   async function expectWorkingAffordances(root: HTMLElement) {
-    expect(root.querySelector(".busy-line"), "working line present").not.toBeNull();
     await expect.element(page.getByText(m.status_blocked())).not.toBeInTheDocument();
     const pipLabel = m.statuspip_status_aria({ status: m.status_working() });
     await expect.element(page.getByRole("img", { name: pipLabel })).toBeInTheDocument();
@@ -252,9 +252,8 @@ describe("UnitRow working-while-blocked (full working treatment)", () => {
       onselect: () => {},
       workingBlocked: {},
     });
-    // The status slot is empty for a blocked row (no working line, no text) — the
-    // red "!" alarm StatusPip on the left carries the blocked state instead.
-    expect(document.body.querySelector(".busy-line"), "no working line when blocked").toBeNull();
+    // The status slot is empty for a blocked row (no text) — the red "!" alarm
+    // StatusPip on the left carries the blocked state instead.
     expect(document.body.querySelector(".pip.badge"), "red ! alarm pip").not.toBeNull();
     expect(document.body.querySelector(".car"), "no typing caret").toBeNull();
   });

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -16,13 +16,7 @@
 
 <script lang="ts">
   import type { Session, GitState, SessionActivity, HoldReason } from "$lib/types";
-  import {
-    STATUS_COLOR,
-    hideStatusBadge,
-    autopilotBadgeShown,
-    canResume,
-    canRelaunch,
-  } from "$lib/format";
+  import { STATUS_COLOR, canResume, canRelaunch } from "$lib/format";
   import { displayStatus } from "$lib/display-status";
   import { resumeSession } from "$lib/api";
   import CardMenu from "./CardMenu.svelte";
@@ -33,7 +27,7 @@
   import TimePopover from "./TimePopover.svelte";
   import HeartbeatStrip from "./HeartbeatStrip.svelte";
   import Stepper from "./Stepper.svelte";
-  import { reviews, repoConfig } from "$lib/reviews.svelte";
+  import { reviews } from "$lib/reviews.svelte";
   import { toasts } from "$lib/toasts.svelte";
   import { projectIcons } from "$lib/projectIcons.svelte";
   import { m } from "$lib/paraglide/messages";
@@ -182,22 +176,16 @@
   });
 
   const reviewing = $derived(reviews.isReviewing(session.id));
-  const autopilotShown = $derived(
-    autopilotBadgeShown(session, repoConfig.isAutopilotEnabled(session.repoPath)),
-  );
-  const hideStatus = $derived(hideStatusBadge(dStatus, reviewing, autopilotShown));
 
-  // The status slot renders for merging / ready / a running working-line; every
-  // other state shows nothing, so only then does #u-status-{id} exist. Build the
-  // overlay's aria-describedby so it omits that id when the slot is empty
-  // (idle/done/blocked, or reviewing) — no dangling IDREF.
+  // The status slot renders only for merging / ready; every other state (incl.
+  // running — the left StatusPip carries that) shows nothing, so only then does
+  // #u-status-{id} exist. Build the overlay's aria-describedby so it omits that id
+  // when the slot is empty — no dangling IDREF.
   const describedBy = $derived(
     [
       `u-repo-${session.id}`,
       `u-sub-${session.id}`,
-      isMerging(session, nowMs) || session.readyToMerge || (!hideStatus && dStatus === "running")
-        ? `u-status-${session.id}`
-        : null,
+      isMerging(session, nowMs) || session.readyToMerge ? `u-status-${session.id}` : null,
     ]
       .filter(Boolean)
       .join(" "),
@@ -429,10 +417,8 @@
       {onpreview}
       {quotaKind}
       {reviewing}
-      {hideStatus}
       {stepperTerminal}
       {decom}
-      {dStatus}
       coarsePointer={coarse.current}
       {pressDecommission}
       bind:elapsedEl

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -69,10 +69,11 @@
   );
   const hideStatus = $derived(hideStatusBadge(dStatus, reviewing, autopilotShown));
 
-  // The status slot renders for ready / a running working-line / a blocked alert
-  // chip; idle & done show nothing, so only then does #tile-status-{id} exist.
-  // Build the overlay's aria-describedby so it omits that id when the slot is
-  // empty (idle/done, or reviewing) — no dangling IDREF.
+  // The status slot renders for ready / an sr-only running label / a blocked alert
+  // chip; idle & done show nothing, so only then does #tile-status-{id} exist. The
+  // tile has no StatusPip, so running keeps a screen-reader-only status (the live
+  // terminal carries it visually). Build the overlay's aria-describedby so it omits
+  // that id when the slot is empty (idle/done, or reviewing) — no dangling IDREF.
   const describedBy = $derived(
     [
       session.readyToMerge || (!hideStatus && (dStatus === "running" || dStatus === "blocked"))
@@ -316,14 +317,10 @@
            alert chip as the grid's attention grab. -->
       <span class="badge alert" id="tile-status-{session.id}">{statusLabel(dStatus)}</span>
     {:else if !hideStatus && dStatus === "running"}
-      <!-- Running shows the thin working line (replaces the redundant BUSY text);
-           idle/done show nothing here — absence = parked. -->
-      <span
-        class="busy-line"
-        id="tile-status-{session.id}"
-        role="img"
-        aria-label={m.status_working()}
-      ></span>
+      <!-- Running shows nothing visible — the live terminal + elapsed clock carry
+           it (idle/done show nothing either). The tile has no StatusPip, so keep a
+           screen-reader-only running label so assistive tech still gets the state. -->
+      <span class="sr-only" id="tile-status-{session.id}">{m.status_working()}</span>
     {/if}
     <TaskIdButton {session} id="tile-desig-{session.id}" />
   </div>
@@ -350,6 +347,21 @@
 {/if}
 
 <style>
+  /* Visually-hidden running status: the tile has no StatusPip, so the running
+     state is announced to assistive tech here while the live terminal carries it
+     visually. (No global .sr-only util in app.css — matches the per-component
+     pattern in UnitRow/GitRail.) */
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
   .tile {
     position: relative;
     display: flex;

--- a/ui/src/lib/components/unit-row/UnitRowRight.svelte
+++ b/ui/src/lib/components/unit-row/UnitRowRight.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Session, GitState, SessionStatus } from "$lib/types";
+  import type { Session, GitState } from "$lib/types";
   import { elapsed } from "$lib/format";
   import { isMerging } from "../merge-train";
   import { m } from "$lib/paraglide/messages";
@@ -21,10 +21,8 @@
     onpreview,
     quotaKind = null,
     reviewing,
-    hideStatus,
     stepperTerminal,
     decom,
-    dStatus,
     coarsePointer,
     pressDecommission,
     elapsedEl = $bindable(),
@@ -38,10 +36,8 @@
     onpreview?: (id: string) => void;
     quotaKind?: "rework" | "review" | "error" | "plan" | null;
     reviewing: boolean;
-    hideStatus: boolean;
     stepperTerminal: boolean;
     decom: "idle" | "armed";
-    dStatus: SessionStatus;
     coarsePointer: boolean;
     pressDecommission: () => void;
     elapsedEl?: HTMLSpanElement;
@@ -158,12 +154,6 @@
     <span class="badge merging" id="u-status-{session.id}">{m.status_merging()}</span>
   {:else if session.readyToMerge}
     <span class="badge" id="u-status-{session.id}">{m.status_ready_to_merge()}</span>
-  {:else if !hideStatus && dStatus === "running"}
-    <!-- BUSY/WAITING text was redundant with the StatusPip + heartbeat. Running
-         now shows a thin working line; every other state shows nothing here
-         (absence = parked/idle — blocked still reads via its red StatusPip). -->
-    <span class="busy-line" id="u-status-{session.id}" role="img" aria-label={m.status_working()}
-    ></span>
   {/if}
   <span class="elapsed" bind:this={elapsedEl}>{elapsed(session.createdAt, nowMs)}</span>
 </div>

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1714,16 +1714,6 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     targetId: "files-tab",
   },
   {
-    // No targetId: the working line only renders on a running session card (idle/
-    // parked cards show nothing in that slot), so there's no stable coachmark
-    // anchor — surface via the What's-New drawer only. 1.37.0 is the latest
-    // released tag, so this ships in the next release (1.38.0).
-    id: "working-line",
-    sinceVersion: "1.38.0",
-    titleKey: "feat_working_line_title",
-    bodyKey: "feat_working_line_body",
-  },
-  {
     // Autopilot-until-PR is now selectable for Codex tasks (previously Claude-only). The
     // checkbox carries coachTarget "task-autopilot" in NewTaskRunSettings, so the coachmark
     // can point at it.


### PR DESCRIPTION
## Why

The thin animated **working line** added in #1168 is a redundant third running signal. On **list rows** the left amber StatusPip already pulses for running and the HeartbeatStrip encodes activity; on **tiles** the embedded live terminal + elapsed clock already show work happening. Running cards now show nothing in that status slot — absence = the pip/terminal carries the state.

This continues #1168's intent (the BUSY/WAITING text was redundant and is **not** restored); it only removes the line that replaced it.

## What

- Remove the `.busy-line` element + CSS (rule, `busy-sweep` keyframes, reduced-motion fallback).
- **List rows** (`UnitRowRight`): drop the running working-line branch; prune the now-orphaned status-text prop chain (`hideStatus`/`dStatus` props, `hideStatusBadge`/`autopilotBadgeShown` imports, `autopilotShown` derived) and fix `UnitRow`'s `aria-describedby` so it no longer references an absent `#u-status` id for running.
- **Tiles** (`UnitTile`): tiles have no StatusPip, so the visible line is replaced by a visually-hidden (`sr-only`) running label — a screen reader still announces "working", no a11y regression. The blocked alert chip is unchanged.
- Remove the unreleased `working-line` feature announcement + `feat_working_line_*` i18n keys (EN + DE).

Scope (rows **and** tiles) confirmed with the operator before implementation.

## Verification

- `bun run check` — 0 errors / 0 warnings
- `bun run check:i18n` — locales in parity (2072 keys each)
- `bun run test:browser` — 663 pass · `bun run test:node` — 1473 pass

[no-feature-entry] — this removes a feature; no catalog entry to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)