### PR TITLE
fix(ui): tidy stale Codex autopilot copy + exclude research from unavailable badge

### DIFF
--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -373,11 +373,13 @@
     if (!autopilotTouched) autopilot = autopilotDefault;
   });
 
-  // Codex can't plan-gate or autopilot yet. Rather than mutate planGate/autopilot
-  // (which would silently lose a manual override across a Codex round-trip), the
-  // checkboxes just DISPLAY off + disabled while Codex is selected (see
-  // NewTaskRunSettings) and submit forces them off via automationFlag — the
-  // underlying Claude-context choice is preserved untouched.
+  // Codex can't plan-gate yet (no spawn directives via --append-system-prompt, so the
+  // plan-gate wiring isn't available for it). Rather than mutate planGate (which would
+  // silently lose a manual override across a Codex round-trip), the plan-gate checkbox
+  // just DISPLAYS off + disabled while Codex is selected (see NewTaskRunSettings) and
+  // submit forces it off via planGateFlag — the underlying Claude-context choice is
+  // preserved untouched. Autopilot, by contrast, is now available for isolated Codex
+  // sessions (#1140) and flows through automationFlag like Claude.
 
   // Effective default model = repo override (if not "inherit") → global default → promo.
   // Re-seeds the picker when the repo config loads / the repo changes, unless an explicit

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -167,6 +167,19 @@ describe("autopilotBadgeShown", () => {
         false,
       ),
     ).toBe(false));
+
+  it("returns false for codex + non-isolated + research (directive suppressed at spawn)", () =>
+    expect(
+      autopilotBadgeShown(
+        session({
+          agentProvider: "codex",
+          isolated: false,
+          autopilotEnabled: true,
+          research: true,
+        }),
+        false,
+      ),
+    ).toBe(false));
 });
 
 describe("relativeAge", () => {

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -176,10 +176,14 @@ export function autopilotBadgeShown(s: Session, repoAutopilotDefault: boolean): 
  * The badge surfaces that as an explicit "unavailable" state so an opted-in toggle is
  * never silently inert. Needs the repo default to catch the inherited-default-ON case
  * where the per-session override is null — mirrors `effectiveAutopilot` (override ?? default).
+ *
+ * Excludes research tasks: a research session's autopilot directive is suppressed at spawn
+ * regardless of provider/isolation (it delivers a report-PR/issue, never code-PR-steered),
+ * so "unavailable" would be misleading noise rather than a real stood-down toggle.
  */
 export function codexAutopilotUnavailable(s: Session, repoAutopilotDefault: boolean): boolean {
   const on = s.autopilotEnabled ?? repoAutopilotDefault;
-  return on && (s.agentProvider ?? "claude") === "codex" && !s.isolated;
+  return on && (s.agentProvider ?? "claude") === "codex" && !s.isolated && !s.research;
 }
 
 export function statusLabel(s: SessionStatus): string {


### PR DESCRIPTION
Tidies the two non-blocking items deferred from #1140 (Codex autopilot-to-PR alpha), flagged by the critic and tracked in #1173.

## Changes
1. **Stale comment** in `NewTask.svelte` — still said "Codex can't plan-gate **or autopilot** yet." Autopilot is now enabled for isolated Codex sessions (#1140), flowing through `automationFlag` like Claude. Narrowed the comment to plan-gate only (which genuinely stays Codex-forced-off via `planGateFlag`, since Codex gets no `--append-system-prompt` directive wiring).
2. **`codexAutopilotUnavailable` badge** — didn't exclude `research`, so a non-isolated Codex *research* task with autopilot-on showed the "autopilot unavailable" badge even though a research session's autopilot directive is suppressed at spawn regardless of provider/isolation. Added `&& !s.research` so the badge matches actual behavior, plus a regression test.

Both are UI-copy/derivation tidies; no functional change to spawn or gating logic.

## Verification
- `cd ui && bun test src/lib/format.test.ts` → 60 pass (incl. new research-exclusion case)
- `cd ui && bun run check` → 0 errors

Closes #1173. Context: PR #1140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
