### PR TITLE
refactor(forge): push backlog-counts + lightweight checks behind GitForge seam

### DIFF
--- a/src/backlog.ts
+++ b/src/backlog.ts
@@ -1,30 +1,15 @@
-import { execFileSync } from "./instrument";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
-import { parseRemote } from "./forge/remote";
 import { detectForge } from "./forge";
 import { makeForgeMemo } from "./forge/resolve";
-import { classifyPr } from "./forge/pr-kind";
-import type { ForgeMap, GitForge } from "./forge/types";
+import type { GhRunner } from "./forge/github";
+import { EMPTY_BACKLOG_COUNTS } from "./forge/types";
+import type { ForgeMap, GitForge, RepoCounts } from "./forge/types";
 
-/** Default-branch CI rollup state, or null when unknown / no CI / non-GitHub. */
-export type CiStatus = "success" | "failure" | "pending" | null;
-
-export interface RepoCounts {
-  openIssues: number | null;
-  openPRs: number | null;
-  /** Default-branch CI health for the Actions tab marker. GitHub-only; null otherwise. */
-  ciStatus: CiStatus;
-  /** Open-PR breakdown by kind for the repo-list row. GitHub-only; null for Gitea/unknown. */
-  prKinds: { release: number; dependabot: number; regular: number } | null;
-}
-
-/**
- * Runs `gh` and returns stdout. Sync or async — the background warmer passes an
- * async runner so handleBacklog's per-repo `Promise.all` actually fans out in
- * parallel instead of serializing on a blocking `execFileSync`.
- */
-export type CountsRunner = (args: string[]) => string | Promise<string>;
+// RepoCounts now lives with the GitForge seam (each adapter returns it); re-export
+// so existing importers (backlog-poller, server) keep their "./backlog" path. (CiStatus
+// is exported from forge/types.ts directly — backlog.ts no longer has a consumer for it.)
+export type { RepoCounts } from "./forge/types";
 
 interface CacheEntry {
   at: number;
@@ -42,12 +27,7 @@ const TTL_MS = 60_000;
  */
 const DEFAULT_MAX_CONCURRENCY = 6;
 
-const NULL_COUNTS: RepoCounts = {
-  openIssues: null,
-  openPRs: null,
-  ciStatus: null,
-  prKinds: null,
-};
+const NULL_COUNTS = EMPTY_BACKLOG_COUNTS;
 
 /**
  * Minimal FIFO semaphore — bounds how many gated thunks run concurrently.
@@ -98,33 +78,6 @@ export function countDefinedWorkflows(repoDir: string): number {
   }
 }
 
-function originUrl(repoDir: string): string | null {
-  try {
-    return execFileSync("git", ["-C", repoDir, "remote", "get-url", "origin"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-  } catch {
-    return null;
-  }
-}
-
-/** GitHub StatusState rollup → our CiStatus. Unknown/absent → null. */
-function mapRollupState(state: string | undefined | null): CiStatus {
-  switch (state) {
-    case "SUCCESS":
-      return "success";
-    case "FAILURE":
-    case "ERROR":
-      return "failure";
-    case "PENDING":
-    case "EXPECTED":
-      return "pending";
-    default:
-      return null;
-  }
-}
-
 export class CountsService {
   /** Forge resolver: positives cached for the process lifetime, negatives (e.g. a repo
    *  whose `origin` is added later) re-probed after a TTL so they self-heal without a
@@ -139,7 +92,9 @@ export class CountsService {
 
   constructor(
     private readonly forges: ForgeMap,
-    private readonly run: CountsRunner,
+    /** `gh` runner forwarded to the resolved GitHub adapter (production: an untimed
+     *  async runner so per-repo GraphQL counts fan out in parallel; tests: a fake). */
+    private readonly run: GhRunner,
     private readonly fetchFn: typeof fetch = fetch,
     maxConcurrency = DEFAULT_MAX_CONCURRENCY,
     /** Optional: when provided, lightweight repos are treated as not-forge-backed.
@@ -149,7 +104,13 @@ export class CountsService {
     forgeMemoOpts?: { negativeTtlMs?: number; now?: () => number },
   ) {
     this.gate = new Semaphore(maxConcurrency);
-    this.resolveForgeCached = makeForgeMemo((dir) => detectForge(dir, this.forges), forgeMemoOpts);
+    // Resolve adapters with OUR runner/fetch so the counts call (forge.listBacklogCounts)
+    // uses them instead of the adapter's built-in defaults — load-bearing for both the
+    // injected test fakes and production's untimed runner.
+    this.resolveForgeCached = makeForgeMemo(
+      (dir) => detectForge(dir, this.forges, { ghRunner: this.run, fetchFn: this.fetchFn }),
+      forgeMemoOpts,
+    );
   }
 
   /**
@@ -210,112 +171,15 @@ export class CountsService {
 
   private async fetch(repoPath: string): Promise<RepoCounts> {
     // Lightweight repos have no remote forge — skip counts regardless of origin URL.
-    // Read repoMode per call so a runtime toggle propagates without a restart.
+    // Read repoMode per call so a runtime toggle propagates without a restart. (This is
+    // a config gate, NOT a forge-kind check: detectForge still yields a GithubForge for a
+    // lightweight github-origin repo, so we must short-circuit before resolving.)
     if (this.getRepoConfig?.(repoPath)?.repoMode === "lightweight") return NULL_COUNTS;
 
     const forge = this.resolveForgeCached(repoPath);
     if (!forge) return NULL_COUNTS;
 
-    if (forge.kind === "github") {
-      return this.fetchGitHub(forge.slug!);
-    }
-    return this.fetchGitea(forge.slug!, repoPath);
-  }
-
-  private async fetchGitHub(slug: string): Promise<RepoCounts> {
-    const [owner, name] = slug.split("/");
-    const out = await this.run([
-      "api",
-      "graphql",
-      "-F",
-      `owner=${owner}`,
-      "-F",
-      `name=${name}`,
-      "-f",
-      "query=query($owner:String!,$name:String!){repository(owner:$owner,name:$name){issues(states:OPEN){totalCount} pullRequests(states:OPEN, first:100){ totalCount nodes{ author{login} title headRefName labels(first:10){nodes{name}} } } defaultBranchRef{target{... on Commit{statusCheckRollup{state}}}}}}",
-    ]);
-    const json = JSON.parse(out) as {
-      data?: {
-        repository?: {
-          issues?: { totalCount?: number };
-          pullRequests?: {
-            totalCount?: number;
-            nodes?: Array<{
-              author?: { login?: string } | null;
-              title?: string;
-              headRefName?: string;
-              labels?: { nodes?: Array<{ name?: string } | null> } | null;
-            } | null>;
-          };
-          defaultBranchRef?: {
-            target?: { statusCheckRollup?: { state?: string } | null } | null;
-          } | null;
-        };
-      };
-    };
-    const repo = json.data?.repository;
-    const issues = repo?.issues?.totalCount;
-    const prs = repo?.pullRequests?.totalCount;
-    const openPRs = typeof prs === "number" ? prs : null;
-
-    // Open-PR breakdown for the repo-list row. We fetch only the first 100 open
-    // PRs (one page — no extra request); each node is classified once. `regular`
-    // is derived from the authoritative `totalCount` minus the bot kinds (clamped
-    // at 0), NOT by counting "regular" nodes — so a repo with >100 open PRs
-    // classifies the first page and its unfetched tail safely falls into
-    // `regular` rather than silently vanishing.
-    let prKinds: RepoCounts["prKinds"] = null;
-    if (openPRs !== null) {
-      const kinds = (repo?.pullRequests?.nodes ?? [])
-        .filter((n): n is NonNullable<typeof n> => !!n)
-        .map((n) =>
-          classifyPr({
-            author: n.author?.login ?? "",
-            title: n.title ?? "",
-            headRefName: n.headRefName ?? undefined,
-            labels: (n.labels?.nodes ?? [])
-              .map((l) => l?.name)
-              .filter((name): name is string => !!name),
-          }),
-        );
-      const release = kinds.filter((k) => k === "release").length;
-      const dependabot = kinds.filter((k) => k === "dependabot").length;
-      prKinds = { release, dependabot, regular: Math.max(0, openPRs - release - dependabot) };
-    }
-
-    return {
-      openIssues: typeof issues === "number" ? issues : null,
-      openPRs,
-      ciStatus: mapRollupState(repo?.defaultBranchRef?.target?.statusCheckRollup?.state),
-      prKinds,
-    };
-  }
-
-  private async fetchGitea(slug: string, repoPath: string): Promise<RepoCounts> {
-    const url = originUrl(repoPath);
-    if (!url) return NULL_COUNTS;
-    const remote = parseRemote(url);
-    if (!remote) return NULL_COUNTS;
-
-    const cfg = this.forges[remote.host] ?? {};
-    const base = (cfg.baseUrl ?? "").replace(/\/+$/, "");
-    const headers: Record<string, string> = { Accept: "application/json" };
-    if (cfg.token) headers.Authorization = `token ${cfg.token}`;
-
-    const res = await this.fetchFn(`${base}/api/v1/repos/${slug}`, { headers });
-    if (!res.ok) {
-      const text = await res.text().catch(() => "");
-      throw new Error(`gitea GET /api/v1/repos/${slug} → ${res.status}: ${text}`);
-    }
-    const data = (await res.json()) as {
-      open_issues_count?: number;
-      open_pr_counter?: number;
-    };
-    return {
-      openIssues: typeof data.open_issues_count === "number" ? data.open_issues_count : null,
-      openPRs: typeof data.open_pr_counter === "number" ? data.open_pr_counter : null,
-      ciStatus: null,
-      prKinds: null,
-    };
+    // Each adapter answers in its own way (GitHub GraphQL / Gitea REST / Local null).
+    return forge.listBacklogCounts();
   }
 }

--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -374,7 +374,7 @@ export class DocAgentService {
   /** Per-repo nightly decision: freshen origin/<base>, sha-gate, spawn on change. */
   private async considerNightly(repo: string): Promise<void> {
     const forge = this.deps.resolveForge(repo);
-    if (!forge || forge.kind === "local") return; // no PR surface; guardRepo would skip anyway
+    if (!forge || forge.isLightweight) return; // no PR surface; guardRepo would skip anyway
     let base: string;
     try {
       base = await forge.defaultBranch();
@@ -672,7 +672,7 @@ export class DocAgentService {
     const forge = this.deps.resolveForge(repoPath);
     if (!forge)
       return { ok: false, result: { status: "error", reason: "no forge configured for repo" } };
-    if (forge.kind === "local") {
+    if (forge.isLightweight) {
       return {
         ok: false,
         result: { status: "skipped", reason: "lightweight repo mode has no PR surface" },
@@ -1123,7 +1123,7 @@ export class DocAgentService {
       readopted = await this.reapOneWorktree(repo, path, branch, forge);
     }
     const protectedBranches = new Set<string>(readopted ? [this.inflight.get(repo)!.branch] : []);
-    if (forge && forge.kind !== "local") {
+    if (forge && !forge.isLightweight) {
       await this.reapOrphanRemoteBranches(repo, forge, protectedBranches);
     }
     return readopted;
@@ -1137,7 +1137,7 @@ export class DocAgentService {
     forge: GitForge | null,
   ): Promise<boolean> {
     // No PR surface (no forge / lightweight repo) → nothing to finalize against → prune.
-    if (!forge || forge.kind === "local") {
+    if (!forge || forge.isLightweight) {
       await this.pruneWorktree(repo, path, branch);
       return false;
     }

--- a/src/forge/gitea.ts
+++ b/src/forge/gitea.ts
@@ -13,6 +13,7 @@ import type {
   PrStatus,
   PullRequest,
   RedeployInput,
+  RepoCounts,
   WorkflowJob,
   WorkflowRun,
 } from "./types";
@@ -96,6 +97,21 @@ export class GiteaForge implements GitForge {
     if (res.status === 204) return null;
     const text = await res.text();
     return text ? JSON.parse(text) : null;
+  }
+
+  async listBacklogCounts(): Promise<RepoCounts> {
+    // The repo summary carries both open counts in one cheap call. Gitea exposes no
+    // default-branch CI rollup or PR-kind split, so those stay null (as today).
+    const data = (await this.req("GET", `/api/v1/repos/${this.slug}`)) as {
+      open_issues_count?: number;
+      open_pr_counter?: number;
+    };
+    return {
+      openIssues: typeof data?.open_issues_count === "number" ? data.open_issues_count : null,
+      openPRs: typeof data?.open_pr_counter === "number" ? data.open_pr_counter : null,
+      ciStatus: null,
+      prKinds: null,
+    };
   }
 
   async listIssues(): Promise<Issue[]> {

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -5,6 +5,7 @@ import { jobsFromRollup, mapCheckState, rollupChecks } from "./checks";
 import { classifyPr } from "./pr-kind";
 import { CRITIC_REVIEW_MARKER, EmptyDiffError } from "./types";
 import type {
+  CiStatus,
   ForgeConfig,
   GitForge,
   Issue,
@@ -19,6 +20,7 @@ import type {
   PrStatus,
   PullRequest,
   RedeployInput,
+  RepoCounts,
   RollupEntry,
   SubIssueRef,
   WorkflowJob,
@@ -167,6 +169,22 @@ function mapMergeable(v: string | undefined): boolean | null {
   return null; // UNKNOWN / undefined
 }
 
+/** GitHub StatusState rollup → our CiStatus. Unknown/absent → null. */
+function mapRollupState(state: string | undefined | null): CiStatus {
+  switch (state) {
+    case "SUCCESS":
+      return "success";
+    case "FAILURE":
+    case "ERROR":
+      return "failure";
+    case "PENDING":
+    case "EXPECTED":
+      return "pending";
+    default:
+      return null;
+  }
+}
+
 const MERGE_STATE_VALUES = new Set<string>([
   "behind",
   "blocked",
@@ -213,6 +231,75 @@ export class GithubForge implements GitForge {
   /** Fork mode = a fork slug was supplied (`slug` is the upstream it forked from). */
   get isFork(): boolean {
     return !!this.forkSlug;
+  }
+
+  async listBacklogCounts(): Promise<RepoCounts> {
+    const [owner, name] = this.slug.split("/");
+    const out = await this.run([
+      "api",
+      "graphql",
+      "-F",
+      `owner=${owner}`,
+      "-F",
+      `name=${name}`,
+      "-f",
+      "query=query($owner:String!,$name:String!){repository(owner:$owner,name:$name){issues(states:OPEN){totalCount} pullRequests(states:OPEN, first:100){ totalCount nodes{ author{login} title headRefName labels(first:10){nodes{name}} } } defaultBranchRef{target{... on Commit{statusCheckRollup{state}}}}}}",
+    ]);
+    const json = JSON.parse(out) as {
+      data?: {
+        repository?: {
+          issues?: { totalCount?: number };
+          pullRequests?: {
+            totalCount?: number;
+            nodes?: Array<{
+              author?: { login?: string } | null;
+              title?: string;
+              headRefName?: string;
+              labels?: { nodes?: Array<{ name?: string } | null> } | null;
+            } | null>;
+          };
+          defaultBranchRef?: {
+            target?: { statusCheckRollup?: { state?: string } | null } | null;
+          } | null;
+        };
+      };
+    };
+    const repo = json.data?.repository;
+    const issues = repo?.issues?.totalCount;
+    const prs = repo?.pullRequests?.totalCount;
+    const openPRs = typeof prs === "number" ? prs : null;
+
+    // Open-PR breakdown for the repo-list row. We fetch only the first 100 open
+    // PRs (one page — no extra request); each node is classified once. `regular`
+    // is derived from the authoritative `totalCount` minus the bot kinds (clamped
+    // at 0), NOT by counting "regular" nodes — so a repo with >100 open PRs
+    // classifies the first page and its unfetched tail safely falls into
+    // `regular` rather than silently vanishing.
+    let prKinds: RepoCounts["prKinds"] = null;
+    if (openPRs !== null) {
+      const kinds = (repo?.pullRequests?.nodes ?? [])
+        .filter((n): n is NonNullable<typeof n> => !!n)
+        .map((n) =>
+          classifyPr({
+            author: n.author?.login ?? "",
+            title: n.title ?? "",
+            headRefName: n.headRefName ?? undefined,
+            labels: (n.labels?.nodes ?? [])
+              .map((l) => l?.name)
+              .filter((name): name is string => !!name),
+          }),
+        );
+      const release = kinds.filter((k) => k === "release").length;
+      const dependabot = kinds.filter((k) => k === "dependabot").length;
+      prKinds = { release, dependabot, regular: Math.max(0, openPRs - release - dependabot) };
+    }
+
+    return {
+      openIssues: typeof issues === "number" ? issues : null,
+      openPRs,
+      ciStatus: mapRollupState(repo?.defaultBranchRef?.target?.statusCheckRollup?.state),
+      prKinds,
+    };
   }
 
   async listIssues(): Promise<Issue[]> {

--- a/src/forge/index.ts
+++ b/src/forge/index.ts
@@ -1,8 +1,18 @@
 import { execFileSync } from "../instrument";
-import { GithubForge } from "./github";
+import { GithubForge, type GhRunner } from "./github";
 import { GiteaForge } from "./gitea";
 import { parseRemote } from "./remote";
 import type { ForgeKind, ForgeMap, GitForge } from "./types";
+
+/** Optional I/O clients a caller can supply to the constructed adapters — lets
+ *  CountsService route its own `gh` runner / `fetch` (production: an untimed async
+ *  runner; tests: injected fakes) into the resolved forge. Omitted ⇒ each adapter
+ *  uses its built-in default (`defaultRunner` / global `fetch`). resolve.ts (the
+ *  app-wide resolver) intentionally passes nothing and keeps those defaults. */
+export interface ForgeDeps {
+  ghRunner?: GhRunner;
+  fetchFn?: typeof fetch;
+}
 
 /** Decide the forge kind for a host: explicit config wins, else github.com is github. */
 function kindFor(host: string, map: ForgeMap): ForgeKind | null {
@@ -24,16 +34,17 @@ export function buildIssueUrl(
   return `${webUrl}/issues/${issueNumber}`;
 }
 
-/** Build a GitForge from a remote URL + forge config map, or null if unsupported. */
-export function forgeFor(remoteUrl: string, map: ForgeMap): GitForge | null {
+/** Build a GitForge from a remote URL + forge config map, or null if unsupported.
+ *  `deps` optionally supplies the adapter's I/O clients (see {@link ForgeDeps}). */
+export function forgeFor(remoteUrl: string, map: ForgeMap, deps?: ForgeDeps): GitForge | null {
   const parsed = parseRemote(remoteUrl);
   if (!parsed) return null;
   const kind = kindFor(parsed.host, map);
   if (!kind) return null;
   const cfg = map[parsed.host] ?? {};
-  if (kind === "github") return new GithubForge(parsed.slug, cfg);
+  if (kind === "github") return new GithubForge(parsed.slug, cfg, deps?.ghRunner);
   if (kind === "local") return null; // local repos have no remote forge
-  return new GiteaForge(parsed.slug, cfg);
+  return new GiteaForge(parsed.slug, cfg, deps?.fetchFn);
 }
 
 /** Read a named remote's URL for a repo dir, or null if the remote is absent. */
@@ -68,7 +79,7 @@ function remoteUrl(repoDir: string, remote: string): string | null {
  * which detectForge — sync and hot-path cached — must avoid). Rename the remote to
  * opt out.
  */
-export function detectForge(repoDir: string, map: ForgeMap): GitForge | null {
+export function detectForge(repoDir: string, map: ForgeMap, deps?: ForgeDeps): GitForge | null {
   const origin = remoteUrl(repoDir, "origin");
   if (!origin) return null;
 
@@ -84,9 +95,9 @@ export function detectForge(repoDir: string, map: ForgeMap): GitForge | null {
       kindFor(originParsed.host, map) === "github"
     ) {
       const cfg = map[upstreamParsed.host] ?? {};
-      return new GithubForge(upstreamParsed.slug, cfg, undefined, originParsed.slug);
+      return new GithubForge(upstreamParsed.slug, cfg, deps?.ghRunner, originParsed.slug);
     }
   }
 
-  return forgeFor(origin, map);
+  return forgeFor(origin, map, deps);
 }

--- a/src/forge/local.ts
+++ b/src/forge/local.ts
@@ -3,6 +3,7 @@ import { promisify } from "node:util";
 import { timedAsync } from "../instrument";
 import type { SessionStore } from "../store";
 import {
+  EMPTY_BACKLOG_COUNTS,
   EmptyDiffError,
   type GitForge,
   type Issue,
@@ -10,6 +11,7 @@ import {
   type OpenPrInput,
   type PrStatus,
   type PullRequest,
+  type RepoCounts,
 } from "./types";
 
 const execFileAsync = promisify(execFile);
@@ -295,6 +297,7 @@ export class LocalForge implements GitForge {
   readonly mergeMethod: MergeMethod = "squash";
   readonly deployWorkflow = null;
   readonly webUrl = null;
+  readonly isLightweight = true;
 
   constructor(
     readonly repoPath: string,
@@ -311,6 +314,12 @@ export class LocalForge implements GitForge {
 
   async listPullRequests(): Promise<PullRequest[]> {
     return [];
+  }
+
+  /** No remote backlog surface — the overview shows blank counts for lightweight repos.
+   *  (CountsService never resolves a LocalForge, so this is belt-and-suspenders.) */
+  async listBacklogCounts(): Promise<RepoCounts> {
+    return EMPTY_BACKLOG_COUNTS;
   }
 
   async defaultBranch(): Promise<string> {

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -32,6 +32,31 @@ export interface Issue {
 export type ForgeKind = "github" | "gitea" | "local";
 export type MergeMethod = "merge" | "squash" | "rebase";
 
+/** Default-branch CI rollup state, or null when unknown / no CI / non-GitHub. */
+export type CiStatus = "success" | "failure" | "pending" | null;
+
+/** Lightweight per-repo counts for the overview/backlog row. Each forge answers in
+ *  its own way via {@link GitForge.listBacklogCounts}; null fields mean "unknown /
+ *  not supported by this host" (e.g. Gitea has no Actions rollup or PR-kind split). */
+export interface RepoCounts {
+  openIssues: number | null;
+  openPRs: number | null;
+  /** Default-branch CI health for the Actions tab marker. GitHub-only; null otherwise. */
+  ciStatus: CiStatus;
+  /** Open-PR breakdown by kind for the repo-list row. GitHub-only; null for Gitea/unknown. */
+  prKinds: { release: number; dependabot: number; regular: number } | null;
+}
+
+/** All-null counts — a forge with no remote backlog surface (LocalForge), a fetch
+ *  failure, or a not-yet-resolved repo. Shared so the seam, the caller's fallbacks,
+ *  and test doubles agree on one shape. */
+export const EMPTY_BACKLOG_COUNTS: RepoCounts = {
+  openIssues: null,
+  openPRs: null,
+  ciStatus: null,
+  prKinds: null,
+};
+
 /** Invisible marker appended to every critic-posted review body so the review
  *  fetch can tell the critic's own reviews apart from human ones (they share one
  *  gh identity). HTML comments don't render in GitHub's UI. */
@@ -279,9 +304,18 @@ export interface GitForge {
    *  upstream it was forked from (the `gh repo fork --clone` topology). Drives the
    *  repo picker's per-fork "Sync fork" affordance. Absent/false ⇒ not a fork. */
   readonly isFork?: boolean;
+  /** True only for the lightweight LocalForge (no remote/PR surface). Optional and
+   *  defined only where true — mirrors {@link isFork}; absent ⇒ falsy ⇒ not lightweight.
+   *  Lets callers gate the no-PR-surface paths (nightly docs, worktree reaping) without
+   *  branching on `kind`. NB: the issue (#1096) proposed a `isLightweight()` method; a
+   *  readonly property is used here for consistency with the other capability flags. */
+  readonly isLightweight?: boolean;
   listIssues(): Promise<Issue[]>;
   /** Open PRs for the backlog PRs tab (newest first), capped server-side. */
   listPullRequests(): Promise<PullRequest[]>;
+  /** Lightweight issue/PR counts (+ GitHub CI rollup / PR-kind split) for the overview
+   *  row. Each adapter answers in its own way; the caller never branches on `kind`. */
+  listBacklogCounts(): Promise<RepoCounts>;
   /** Latest run per workflow on the default branch, with per-job breakdown, for
    *  the backlog Actions tab. Optional: only hosts with an Actions API implement
    *  it (GitHub); others omit it and the tab shows a "GitHub only" state. */

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -334,6 +334,7 @@ function mkHarness(opts?: {
       ? null
       : ({
           kind: o.forgeKind,
+          isLightweight: o.forgeKind === "local",
           defaultBranch: async () => {
             if (o.defaultBranchThrows) throw new Error("forge offline");
             return "main";

--- a/test/drain-epic-autoland.test.ts
+++ b/test/drain-epic-autoland.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe } from "bun:test";
 import { DrainService } from "../src/drain";
 import { SessionStore } from "../src/store";
 import type { GitForge, Issue, MergeInput, PrStatus, SubIssueRef } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
 import type { CompletedEpic } from "../src/completed-epic";
 import { epicIntegrationBranch } from "../src/epic-branch";
@@ -62,6 +63,7 @@ function fakeForge(opts: {
     deployWorkflow: null,
     listIssues: async () => [],
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async (head: string) => {
       prStatusCalls.push(head);
       return (

--- a/test/drain-epic-completed.test.ts
+++ b/test/drain-epic-completed.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe } from "bun:test";
 import { DrainService } from "../src/drain";
 import { SessionStore } from "../src/store";
 import type { GitForge, Issue, PrStatus, SubIssueRef } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
 import type { CompletedEpic, CompletedEpicChild } from "../src/completed-epic";
 
@@ -29,6 +30,7 @@ function fakeForge(
     deployWorkflow: null,
     listIssues: async () => [],
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async () => ({ state: "none", checks: "none", deployConfigured: false }) as PrStatus,
     openPr: async () => ({ state: "open", checks: "none", deployConfigured: false }) as PrStatus,
     defaultBranch: async () => "main",

--- a/test/drain-epic-divergence.test.ts
+++ b/test/drain-epic-divergence.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe } from "bun:test";
 import { DrainService } from "../src/drain";
 import { SessionStore } from "../src/store";
 import type { GitForge, GitState, Issue, PrStatus, SubIssueRef } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { CreateSessionInput, Session } from "../src/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
 
@@ -31,6 +32,7 @@ function fakeForge(branchesRef: BranchesRef): GitForge {
     deployWorkflow: null,
     listIssues: async () => [],
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async () => ({ state: "none", checks: "none", deployConfigured: false }) as PrStatus,
     openPr: async () => ({ state: "open", checks: "none", deployConfigured: false }) as PrStatus,
     defaultBranch: async () => "main",

--- a/test/drain-epic-landing.test.ts
+++ b/test/drain-epic-landing.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, describe } from "bun:test";
 import { DrainService } from "../src/drain";
 import { SessionStore } from "../src/store";
-import { EmptyDiffError } from "../src/forge/types";
+import { EmptyDiffError, EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { GitForge, Issue, OpenPrInput, PrStatus, SubIssueRef } from "../src/forge/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
 import type { CompletedEpic } from "../src/completed-epic";
@@ -56,6 +56,7 @@ function fakeForge(opts: {
     deployWorkflow: null,
     listIssues: async () => [],
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async (head: string) => {
       prStatusCalls.push(head);
       return (

--- a/test/drain-epic-pin-branch.test.ts
+++ b/test/drain-epic-pin-branch.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe } from "bun:test";
 import { DrainService, type DrainStatus } from "../src/drain";
 import { SessionStore } from "../src/store";
 import type { GitForge, GitState, Issue, PrStatus, SubIssueRef } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { CreateSessionInput, ReviewDecision, Session } from "../src/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
 import type { Epic } from "../src/epic-core";
@@ -41,6 +42,7 @@ function fakeForge(
     deployWorkflow: null,
     listIssues: async () => [],
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async () => ({ state: "none", checks: "none", deployConfigured: false }) as PrStatus,
     openPr: async () => ({ state: "open", checks: "none", deployConfigured: false }) as PrStatus,
     defaultBranch: async () => "main",

--- a/test/drain-epic-rebase-landing.test.ts
+++ b/test/drain-epic-rebase-landing.test.ts
@@ -8,6 +8,7 @@ import { test, expect, describe } from "bun:test";
 import { DrainService } from "../src/drain";
 import { SessionStore } from "../src/store";
 import type { GitForge, Issue, MergeInput, PrStatus, SubIssueRef } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
 import type { CompletedEpic } from "../src/completed-epic";
 import type { LandingRebaseResult } from "../src/landing-rebase";
@@ -101,6 +102,7 @@ function fakeForge(opts: {
     deployWorkflow: null,
     listIssues: async () => [],
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async (branch: string) => {
       prStatusCalls.push(branch);
       return (

--- a/test/drain-epic-retire-base.test.ts
+++ b/test/drain-epic-retire-base.test.ts
@@ -9,6 +9,7 @@ import type {
   PrReviewMeta,
   PrStatus,
 } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { CreateSessionInput, ReviewDecision, Session } from "../src/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
 
@@ -48,6 +49,7 @@ function fakeForge(
     deployWorkflow: null,
     listIssues: async () => [],
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async () => ({ state: "none", checks: "none", deployConfigured: false }) as PrStatus,
     openPr: async () => ({ state: "open", checks: "none", deployConfigured: false }) as PrStatus,
     defaultBranch: async () => "main",

--- a/test/drain-epic-retire-merge.test.ts
+++ b/test/drain-epic-retire-merge.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe } from "bun:test";
 import { DrainService } from "../src/drain";
 import { SessionStore } from "../src/store";
 import type { GitForge, GitState, Issue, MergeMethod, PrStatus } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { CreateSessionInput, ReviewDecision, Session } from "../src/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
 
@@ -33,6 +34,7 @@ function fakeForge(rec: ForgeRec, opts: { merge?: () => Promise<void> } = {}): G
     deployWorkflow: null,
     listIssues: async () => [],
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async () => ({ state: "none", checks: "none", deployConfigured: false }) as PrStatus,
     openPr: async () => ({ state: "open", checks: "none", deployConfigured: false }) as PrStatus,
     defaultBranch: async () => "main",

--- a/test/drain-epic-spawn-base.test.ts
+++ b/test/drain-epic-spawn-base.test.ts
@@ -3,6 +3,7 @@ import { DrainService, type DrainStatus } from "../src/drain";
 import { ACTIVE_LABEL } from "../src/drain-core";
 import { SessionStore } from "../src/store";
 import type { GitForge, GitState, Issue, PrStatus, SubIssueRef } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { CreateSessionInput, ReviewDecision, Session } from "../src/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
 import type { Epic } from "../src/epic-core";
@@ -62,6 +63,7 @@ function fakeForge(
       return issues;
     },
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async () => ({ state: "none", checks: "none", deployConfigured: false }) as PrStatus,
     openPr: async () => ({ state: "open", checks: "none", deployConfigured: false }) as PrStatus,
     defaultBranch: async () => "main",

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -10,6 +10,7 @@ import type {
   PrStatus,
   SubIssueRef,
 } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { CreateSessionInput, ReviewDecision, Session } from "../src/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
 import type { Epic } from "../src/epic-core";
@@ -76,6 +77,7 @@ function fakeForge(
       return issues;
     },
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async () => ({ state: "none", checks: "none", deployConfigured: false }) as PrStatus,
     openPr: async () => ({ state: "open", checks: "none", deployConfigured: false }) as PrStatus,
     defaultBranch: async () => "main",

--- a/test/forge/gitea.test.ts
+++ b/test/forge/gitea.test.ts
@@ -32,6 +32,17 @@ function fakeFetch(routes: Record<string, { status?: number; json?: unknown }>) 
   return { fn: fn as unknown as typeof fetch, calls };
 }
 
+test("GiteaForge.listBacklogCounts: reads open counts from the repo summary (no CI/kinds)", async () => {
+  const { fn, calls } = fakeFetch({
+    "GET /api/v1/repos/team/proj": { json: { open_issues_count: 5, open_pr_counter: 2 } },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  const counts = await forge.listBacklogCounts();
+  expect(counts).toEqual({ openIssues: 5, openPRs: 2, ciStatus: null, prKinds: null });
+  expect(calls[0]!.url).toBe("https://git.example.com/api/v1/repos/team/proj");
+  expect(calls[0]!.headers.get("authorization")).toBe("token secret");
+});
+
 test("GiteaForge.listPullRequests: maps open PRs and fans out per-PR checks", async () => {
   const { fn, calls } = fakeFetch({
     "GET /api/v1/repos/team/proj/pulls?state=open&limit=200": {

--- a/test/forge/github.test.ts
+++ b/test/forge/github.test.ts
@@ -36,6 +36,37 @@ const ISSUES_JSON = JSON.stringify([
   },
 ]);
 
+test("GithubForge.listBacklogCounts: parses counts, CI rollup and PR-kind split", async () => {
+  const graphql = JSON.stringify({
+    data: {
+      repository: {
+        issues: { totalCount: 7 },
+        pullRequests: {
+          totalCount: 4,
+          nodes: [
+            { author: { login: "dependabot[bot]" }, title: "bump foo", labels: { nodes: [] } },
+            { author: { login: "me" }, title: "chore(main): release 1.0.0", labels: { nodes: [] } },
+            { author: { login: "me" }, title: "fix: a bug", labels: { nodes: [] } },
+            { author: { login: "me" }, title: "feat: a thing", labels: { nodes: [] } },
+          ],
+        },
+        defaultBranchRef: { target: { statusCheckRollup: { state: "FAILURE" } } },
+      },
+    },
+  });
+  const { run, calls } = fakeRunner({ "api graphql": graphql });
+  const forge = new GithubForge("o/r", {}, run);
+  const counts = await forge.listBacklogCounts();
+  expect(counts).toEqual({
+    openIssues: 7,
+    openPRs: 4,
+    ciStatus: "failure",
+    prKinds: { release: 1, dependabot: 1, regular: 2 },
+  });
+  expect(calls[0]).toContain("owner=o");
+  expect(calls[0]).toContain("name=r");
+});
+
 test("GithubForge.listIssues: parses gh issue list output (incl. assignee logins, #824)", async () => {
   const { run } = fakeRunner({ "issue list": ISSUES_JSON });
   const forge = new GithubForge("o/r", { deployWorkflow: "deploy.yml" }, run);

--- a/test/local-forge.test.ts
+++ b/test/local-forge.test.ts
@@ -82,6 +82,22 @@ test("gitVersionAtLeast: 2.37 rejected, 2.38 and 2.54 accepted", () => {
 
 // ── prStatus / openPr ───────────────────────────────────────────────────────
 
+test("LocalForge is lightweight and has no remote backlog counts", async () => {
+  const repo = mkRepo();
+  try {
+    const forge = new LocalForge(repo, new SessionStore(":memory:"));
+    expect(forge.isLightweight).toBe(true);
+    expect(await forge.listBacklogCounts()).toEqual({
+      openIssues: null,
+      openPRs: null,
+      ciStatus: null,
+      prKinds: null,
+    });
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
 test("prStatus for an unknown branch → state:none", async () => {
   const repo = mkRepo();
   try {

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "bun:test";
 import { SessionStore } from "../src/store";
 import { PrPoller, trustsTerminal } from "../src/pr-poller";
 import type { GitForge, PrStatus } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 
 const baseSession = {
   name: "x",
@@ -23,6 +24,7 @@ function forgeReturning(status: () => PrStatus): GitForge {
     deployWorkflow: null,
     listIssues: async () => [],
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async () => status(),
     openPr: async () => status(),
     merge: async () => {},
@@ -328,6 +330,7 @@ function forgeByBranch(byBranch: Record<string, PrStatus>): GitForge {
     deployWorkflow: null,
     listIssues: async () => [],
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async (head: string) => byBranch[head] ?? NONE,
     openPr: async () => NONE,
     merge: async () => {},

--- a/test/rename.test.ts
+++ b/test/rename.test.ts
@@ -8,6 +8,7 @@ import { SessionStore } from "../src/store";
 import { SessionService } from "../src/service";
 import { makeApp, type AppDeps } from "../src/server";
 import type { GitForge, GitState, PrStatus } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { PrCache } from "../src/pr-poller";
 
 const ORIGIN = "http://localhost";
@@ -123,6 +124,7 @@ function fakeForge(over: Partial<GitForge> = {}): GitForge & { log: string[] } {
     deployWorkflow: null,
     listIssues: async () => [],
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async () => ({ state: "open", checks: "none", deployConfigured: false }) as PrStatus,
     openPr: async () => ({ state: "open", checks: "none", deployConfigured: false }),
     merge: async () => {},

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -10,7 +10,11 @@ const adaptLegacyVerdict = (fn: () => RawVerdict | null) => (): VerdictRead<RawV
   const v = fn();
   return v == null ? { status: "absent" } : { status: "parsed", value: v, repaired: false };
 };
-import { CRITIC_REVIEW_MARKER, AUTHOR_RESPONSE_MARKER } from "../src/forge/types";
+import {
+  CRITIC_REVIEW_MARKER,
+  AUTHOR_RESPONSE_MARKER,
+  EMPTY_BACKLOG_COUNTS,
+} from "../src/forge/types";
 import { config } from "../src/config";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
 
@@ -114,6 +118,7 @@ function fakeForge(
     deployWorkflow: null,
     listIssues: async () => [],
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus,
     openPr: async () => OPEN_GREEN as PrStatus,
     merge: async () => {},

--- a/test/server-actions.test.ts
+++ b/test/server-actions.test.ts
@@ -6,6 +6,7 @@ import type { SessionStore } from "../src/store";
 import type { SessionService } from "../src/service";
 import type { EventHub } from "../src/events";
 import type { GitForge, WorkflowRun } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import { config } from "../src/config";
 
 let tmpRoot: string;
@@ -40,6 +41,7 @@ function fakeForge(over: Partial<GitForge> = {}): GitForge {
     deployWorkflow: null,
     listIssues: async () => [],
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     listWorkflowRuns: async () => [RUN],
     prStatus: async () => ({ state: "none", checks: "none", deployConfigured: false }),
     openPr: async () => ({ state: "none", checks: "none", deployConfigured: false }),

--- a/test/server-backlog.test.ts
+++ b/test/server-backlog.test.ts
@@ -17,6 +17,7 @@ import type { SessionStore } from "../src/store";
 import type { SessionService } from "../src/service";
 import type { EventHub } from "../src/events";
 import type { GitForge } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { RepoCounts } from "../src/backlog";
 import { config } from "../src/config";
 
@@ -54,6 +55,7 @@ function fakeForge(slug: string, kind: "github" | "gitea" = "github"): GitForge 
     deployWorkflow: null,
     listIssues: async () => [],
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async () => ({ state: "none", checks: "none", deployConfigured: false }),
     openPr: async () => ({ state: "none", checks: "none", deployConfigured: false }),
     merge: async () => {},

--- a/test/server-git.test.ts
+++ b/test/server-git.test.ts
@@ -5,6 +5,7 @@ import type { SessionService } from "../src/service";
 import type { EventHub } from "../src/events";
 import type { Session } from "../src/types";
 import type { GitForge, GitState, MergeMethod, PrStatus } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { PrCache } from "../src/pr-poller";
 
 const ORIGIN = "http://localhost";
@@ -69,6 +70,7 @@ function fakeForge(
     deployWorkflow: extras.deployWorkflow === undefined ? "deploy.yaml" : extras.deployWorkflow,
     listIssues: async () => [],
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async (head) => {
       log.push(`status:${head}`);
       return { state: "open", number: 5, checks: "success", deployConfigured: true } as PrStatus;

--- a/test/server-issues.test.ts
+++ b/test/server-issues.test.ts
@@ -6,6 +6,7 @@ import type { SessionStore } from "../src/store";
 import type { SessionService } from "../src/service";
 import type { EventHub } from "../src/events";
 import type { GitForge, Issue } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import { config } from "../src/config";
 
 let tmpRoot: string;
@@ -36,6 +37,7 @@ function fakeForge(over: Partial<GitForge> = {}): GitForge {
     deployWorkflow: null,
     listIssues: async () => [ISSUE],
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async () => ({ state: "none", checks: "none", deployConfigured: false }),
     openPr: async () => ({ state: "none", checks: "none", deployConfigured: false }),
     merge: async () => {},

--- a/test/server-prs.test.ts
+++ b/test/server-prs.test.ts
@@ -6,7 +6,7 @@ import type { SessionStore } from "../src/store";
 import type { SessionService } from "../src/service";
 import type { EventHub } from "../src/events";
 import type { GitForge, MergeInput, PullRequest } from "../src/forge/types";
-import { DEPENDABOT_REBASE_COMMAND } from "../src/forge/types";
+import { DEPENDABOT_REBASE_COMMAND, EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import { config } from "../src/config";
 
 let tmpRoot: string;
@@ -41,6 +41,7 @@ function fakeForge(over: Partial<GitForge> = {}): GitForge {
     deployWorkflow: null,
     listIssues: async () => [],
     listPullRequests: async () => [PR],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async () => ({ state: "none", checks: "none", deployConfigured: false }),
     openPr: async () => ({ state: "none", checks: "none", deployConfigured: false }),
     merge: async () => {},

--- a/test/server-quota-endpoints.test.ts
+++ b/test/server-quota-endpoints.test.ts
@@ -5,6 +5,7 @@ import type { SessionService } from "../src/service";
 import type { EventHub } from "../src/events";
 import type { Session, ReviewVerdict, PlanGate } from "../src/types";
 import type { GitForge, PrStatus } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { PrCache } from "../src/pr-poller";
 
 const ORIGIN = "http://localhost";
@@ -101,6 +102,7 @@ function fakeForge(state: PrStatus["state"] = "open", throws = false): GitForge 
     deployWorkflow: "deploy.yaml",
     listIssues: async () => [],
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async () => {
       if (throws) throw new Error("forge boom");
       return { state, number: 5, checks: "success", deployConfigured: true } as PrStatus;

--- a/test/server-relaunch.test.ts
+++ b/test/server-relaunch.test.ts
@@ -8,6 +8,7 @@ import type { SessionStore } from "../src/store";
 import type { SessionService } from "../src/service";
 import type { EventHub } from "../src/events";
 import type { GitForge, Issue } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { Session } from "../src/types";
 
 // Override-validation (validateRelaunchOverrides) confines a supplied `repoPath` to
@@ -180,6 +181,7 @@ function fakeForge(over: Partial<GitForge> = {}): GitForge {
     deployWorkflow: null,
     listIssues: async () => [],
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async () => ({ state: "none", checks: "none", deployConfigured: false }),
     openPr: async () => ({ state: "none", checks: "none", deployConfigured: false }),
     merge: async () => {},

--- a/test/server-review-pr.test.ts
+++ b/test/server-review-pr.test.ts
@@ -5,6 +5,7 @@ import type { SessionService } from "../src/service";
 import type { EventHub } from "../src/events";
 import type { Session } from "../src/types";
 import type { GitForge, GitState, PrStatus } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { PrCache } from "../src/pr-poller";
 import type { ReviewOutcome } from "../src/review";
 
@@ -67,6 +68,7 @@ function fakeForge(over: Partial<GitForge> = {}): GitForge & { log: string[] } {
     deployWorkflow: "deploy.yaml",
     listIssues: async () => [],
     listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async (head) => {
       log.push(`status:${head}`);
       return { state: "open", number: 5, checks: "success", deployConfigured: true } as PrStatus;

--- a/test/standalone-critic.test.ts
+++ b/test/standalone-critic.test.ts
@@ -2,7 +2,7 @@ import { test, expect, beforeEach, afterEach } from "bun:test";
 import { StandalonePrCriticService } from "../src/standalone-critic";
 import { CRITIC_THINKING_TOKENS, type RawVerdict } from "../src/critic-core";
 import type { VerdictRead } from "../src/json-tolerant";
-import { CRITIC_REVIEW_MARKER } from "../src/forge/types";
+import { CRITIC_REVIEW_MARKER, EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import { config } from "../src/config";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
 import type { GitForge, PrReviewMeta, PullRequest } from "../src/forge/types";
@@ -90,6 +90,7 @@ function makeForge(
     deployWorkflow: null,
     listIssues: async () => [],
     listPullRequests: async () => opts.prs ?? [pr()],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
     prStatus: async () => ({ state: "open", checks: "success", deployConfigured: false }),
     openPr: async () => ({ state: "open", checks: "success", deployConfigured: false }),
     merge: async () => {},


### PR DESCRIPTION
## What

Closes #1096. Stops two callers from branching on `forge.kind` by pushing the
logic behind capability members on the `GitForge` seam — so the caller learns one
member and a 4th forge needs no caller edits.

- **`backlog.ts`** — `CountsService.fetch()` no longer branches `kind === "github"`
  to call its own `fetchGitHub()` / `fetchGitea()`. Each adapter now answers via the
  new **mandatory** `listBacklogCounts(): Promise<RepoCounts>` (GitHub GraphQL /
  Gitea REST / Local null). The GitHub fetch + `mapRollupState` moved into
  `GithubForge`; the Gitea fetch became a one-liner over the adapter's existing
  `req()` helper.
- **`doc-agent.ts`** — the 4 `kind === "local"` fork-mode checks now read the new
  **optional** `isLightweight` flag (mirrors the existing `isFork?` idiom; only
  `LocalForge` sets it true).

### Deletion test
Deleting `GithubForge`/`GiteaForge`'s `listBacklogCounts` is a compile error — the
GitHub-vs-Gitea fetch logic lives behind the seam, not in the caller.

## Supporting changes
- `RepoCounts` / `CiStatus` moved to `forge/types.ts` (their natural home as a
  `GitForge` return type); `backlog.ts` re-exports `RepoCounts` for existing
  importers (`backlog-poller`, `server`).
- Shared `EMPTY_BACKLOG_COUNTS` const (in `forge/types.ts`) reused by `LocalForge`
  and the test doubles.
- `CountsService` threads its runner/fetch into the resolved adapter via an
  **optional `deps` param** on `detectForge`/`forgeFor`. This is load-bearing: it
  keeps the injected test runner reaching the forge **and** preserves production's
  untimed counts runner (the adapter's built-in `defaultRunner` wraps calls in
  `timedAsync`; `CountsService`'s does not). The app-wide resolver (`resolve.ts`)
  passes no deps and keeps the defaults.
- `CountsService.run` narrowed `CountsRunner` → `GhRunner` (the threading site
  demands it); the now-unused `CountsRunner` type and the orphaned
  `originUrl`/`mapRollupState` helpers + `parseRemote`/`classifyPr`/`execFileSync`
  imports were dropped.

## Deliberate deviation from the issue
The issue proposed `isLightweight(): boolean` (a method). This PR uses a **readonly
property** `isLightweight?` instead, for consistency with the other `GitForge`
capability flags (`kind`, `slug`, `isFork?`, `mergeMethod`). Documented in the
interface JSDoc as well.

## Scope
Narrow on purpose (per the issue). Only `backlog.ts` + `doc-agent.ts` change; all
other `kind` checks (promote, index, backlog-poller, server merge, drain) are honest
feature gates and are left untouched.

## Verification
- `bunx tsc --noEmit` — clean (the real gate for the mandatory-member sweep across
  ~22 typed `GitForge` test doubles + the runner-type bridge).
- `bun run lint` — clean.
- `bun test ./test` — 5137 pass, 0 fail.
- New focused tests: `GithubForge.listBacklogCounts` (counts/CI/PR-kinds),
  `GiteaForge.listBacklogCounts`, `LocalForge` lightweight + null counts.
- Server-only; no UI touched → no feature-catalog / i18n / glossary entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)