### PR TITLE
fix(up-next): exclude hidden repos from the ranked queue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ import { tailLines } from "./blocked";
 import { recommendPrompt } from "./prompt-recommend";
 import { CountsService } from "./backlog";
 import { BacklogPoller } from "./backlog-poller";
-import { UpNextService } from "./up-next";
+import { UpNextService, buildUpNextRepos } from "./up-next";
 import { ProcessReaper, reapDeletedWorktreeOrphans } from "./process-reaper";
 import {
   sweepClaudeTmp,
@@ -95,7 +95,7 @@ import {
 } from "./tmp-sweep";
 import { runSessionUsageBackfill } from "./usage-backfill";
 import { PreviewService } from "./preview";
-import { listRepos, listReposPathForReal } from "./repos";
+import { listRepos, listReposPathForReal, reconcileRealPathsToRaw } from "./repos";
 import { enrichLandingEpics, type CompletedEpic } from "./completed-epic";
 import { DistillerService, defaultScratch } from "./distiller";
 import { OptimizerService, defaultOptimizerScratch } from "./optimizer";
@@ -1841,16 +1841,14 @@ backlogPoller.start();
 // by a 15-min background loop; reuses the drain's epic pipeline for ready-child gating and
 // pushes each fresh snapshot to clients over the WS (upnext:snapshot).
 const upNext = new UpNextService({
-  // Forge-backed repos only (skip local/lightweight repos — no cold-issue source to rank).
+  // Forge-backed, non-hidden repos only. buildUpNextRepos owns forge-kind filtering,
+  // the realpath→raw reconcile, hidden-repo filtering, and the exact field mapping.
   listForgeRepos: () =>
-    listRepos(config.repoRoot)
-      .map((r) => ({ entry: r, forge: resolveForge(r.path) }))
-      .filter((x) => x.forge != null && x.forge.kind !== "local")
-      .map((x) => ({
-        repoPath: x.entry.path,
-        repoSlug: x.forge!.slug,
-        repoLabel: x.entry.display,
-      })),
+    buildUpNextRepos({
+      repos: listRepos(config.repoRoot),
+      resolveForge,
+      hiddenRealPaths: store.hiddenRepoPaths(),
+    }),
   resolveForge,
   lastUsedByRepo: () => store.lastUsedByRepo(),
   buildEpic: (repoPath, run) => drain.buildEpic(repoPath, run),
@@ -1913,6 +1911,8 @@ const appDeps: AppDeps = {
   upNext: {
     snapshot: () => upNext.snapshot(),
     refresh: () => upNext.refresh(),
+    hiddenRepoPathsRaw: () =>
+      reconcileRealPathsToRaw(store.hiddenRepoPaths(), listRepos(config.repoRoot)),
   },
   verifyKey: () => verifyApiKey({ herdr }),
   backlog,

--- a/src/server.ts
+++ b/src/server.ts
@@ -140,6 +140,7 @@ import {
   resolveDefaultModelSetting,
 } from "./default-model";
 import { startSerially } from "./up-next";
+import { excludeHiddenSections } from "./up-next-core";
 import type { UpNextSnapshot } from "./up-next-core";
 import { normalizeAgentProvider } from "./agent-provider";
 import { normalizeAuthModeSetting, writeApiKeyHelper, clearApiKeyHelper } from "./auth-mode";
@@ -313,6 +314,8 @@ export interface AppDeps {
   upNext?: {
     snapshot(): UpNextSnapshot | null;
     refresh(): Promise<UpNextSnapshot>;
+    /** Raw-path-space hidden set (reconciled), applied at read time for instant freshness. */
+    hiddenRepoPathsRaw(): Set<string>;
   };
   /** Verify the configured api-key authenticates end-to-end (the /settings/verify-key route);
    *  absent in environments where it isn't wired. Returns only {ok,reason?,detail?} — no key/path. */
@@ -759,7 +762,13 @@ async function handleHerdDigest({ req, parts, deps }: Ctx): Promise<Response | n
  *  a session that never opens the lens costs zero cross-repo `gh` fan-out (the 15-min loop +
  *  lens-open keep it fresh). */
 function handleUpNextGet(url: URL, deps: AppDeps): Response {
-  const snap = deps.upNext?.snapshot() ?? null;
+  const cached = deps.upNext?.snapshot() ?? null;
+  // Apply a read-time hidden filter so a repo hidden after the last background compute is
+  // excluded on the very next GET without waiting for the next recompute cycle (≤15 min).
+  const snap =
+    cached && deps.upNext
+      ? excludeHiddenSections(cached, deps.upNext.hiddenRepoPathsRaw())
+      : cached;
   if (!url.searchParams.has("peek") && deps.upNext)
     void deps.upNext.refresh().catch((err) => console.warn("[up-next] open:", err));
   return json(snap);

--- a/src/up-next-core.ts
+++ b/src/up-next-core.ts
@@ -260,3 +260,46 @@ export function buildSnapshot(
 
   return { generatedAt: now, sections, repoCount: repos.length, fallback };
 }
+
+/**
+ * Apply a read-time hidden-repo filter to an already-computed snapshot.
+ *
+ * Used by handleUpNextGet so that a repo hidden *after* the last background compute is
+ * invisible on the very next GET, without waiting for the next recompute cycle (≤15 min).
+ * The source filter (buildUpNextRepos) prevents wasted forge fan-out for the next compute;
+ * this filter gives instant freshness for the cached payload in between.
+ *
+ * `hiddenRaw` must already be in the raw join(repoRoot,name) path-space (reconciled by the
+ * caller, e.g. via reconcileRealPathsToRaw — keeping path-space concerns out of this module).
+ */
+export function excludeHiddenSections(
+  snap: UpNextSnapshot,
+  hiddenRaw: Set<string>,
+): UpNextSnapshot {
+  if (hiddenRaw.size === 0) return snap;
+
+  let removedRepoSections = 0;
+  const sections: UpNextSection[] = [];
+
+  for (const section of snap.sections) {
+    if (section.kind === "repo") {
+      if (section.repoPath != null && hiddenRaw.has(section.repoPath)) {
+        removedRepoSections++;
+        continue; // drop this section entirely
+      }
+      sections.push(section);
+    } else if (section.kind === "priority") {
+      const filteredItems = section.items.filter((item) => !hiddenRaw.has(item.repoPath));
+      if (filteredItems.length === 0) continue; // drop priority section when it empties
+      sections.push({ ...section, items: filteredItems, totalCount: filteredItems.length });
+    } else {
+      sections.push(section);
+    }
+  }
+
+  return {
+    ...snap,
+    sections,
+    repoCount: Math.max(0, snap.repoCount - removedRepoSections),
+  };
+}

--- a/src/up-next.ts
+++ b/src/up-next.ts
@@ -8,6 +8,7 @@ import { mapBounded } from "./map-bounded";
 import { parseEpicBody } from "./epic-parse";
 import { selectEpicCandidates, type Epic, type EpicRun } from "./epic-core";
 import type { GitForge } from "./forge/types";
+import { reconcileRealPathsToRaw, type RepoEntry } from "./repos";
 import {
   buildSnapshot,
   type RepoInput,
@@ -19,6 +20,38 @@ export interface UpNextRepo {
   repoPath: string;
   repoSlug: string | null;
   repoLabel: string;
+}
+
+/**
+ * Build the list of forge-backed, non-hidden repos to feed into the Up Next ranked queue.
+ *
+ * Deliberate divergence from the Backlog: the Backlog includes hidden repos in its payload
+ * and flags them `hidden:true` so users can reach per-repo settings. Up Next FULLY EXCLUDES
+ * hidden repos — it has no settings drill-down and exists only to rank actionable work, so a
+ * hidden repo contributes no section or items to the queue.
+ *
+ * Path-space note: `hiddenRealPaths` are realpath/safeRepoDir-resolved keys (from
+ * store.hiddenRepoPaths()), while `repos` carries the raw join(repoRoot,name) paths that
+ * listRepos enumerates. reconcileRealPathsToRaw translates between the two so a hide under
+ * a symlinked repoRoot is still honored.
+ */
+export function buildUpNextRepos(args: {
+  repos: readonly RepoEntry[];
+  resolveForge: (p: string) => GitForge | null;
+  hiddenRealPaths: Set<string>;
+}): UpNextRepo[] {
+  // Reconcile realpath-keyed hidden set → raw join(repoRoot,name) space that listRepos uses.
+  const hiddenRaw = reconcileRealPathsToRaw(args.hiddenRealPaths, args.repos);
+  const result: UpNextRepo[] = [];
+  for (const entry of args.repos) {
+    const forge = args.resolveForge(entry.path);
+    // Skip non-forge and local repos — no cold-issue source to rank.
+    if (forge == null || forge.kind === "local") continue;
+    // Skip hidden repos — see deliberate full-exclude note above.
+    if (hiddenRaw.has(entry.path)) continue;
+    result.push({ repoPath: entry.path, repoSlug: forge.slug, repoLabel: entry.display });
+  }
+  return result;
 }
 
 export interface UpNextDeps {

--- a/test/server-up-next.test.ts
+++ b/test/server-up-next.test.ts
@@ -5,7 +5,7 @@ import { makeApp, type AppDeps } from "../src/server";
 import { SessionStore } from "../src/store";
 import { EventHub } from "../src/events";
 import { config } from "../src/config";
-import type { UpNextSnapshot } from "../src/up-next-core";
+import type { UpNextSnapshot, UpNextSection } from "../src/up-next-core";
 import type { Session } from "../src/types";
 
 let tmpRoot: string;
@@ -28,6 +28,7 @@ const SNAP: UpNextSnapshot = {
 function harness(
   opts: {
     snapshot?: UpNextSnapshot | null;
+    hiddenRepoPathsRaw?: () => Set<string>;
     create?: (input: { repoPath: string; issueRef?: { number: number } }) => Promise<Session>;
     defaultBranch?: () => Promise<string>;
   } = {},
@@ -62,6 +63,7 @@ function harness(
         refreshCalls++;
         return SNAP;
       },
+      hiddenRepoPathsRaw: opts.hiddenRepoPathsRaw ?? (() => new Set<string>()),
     },
   };
   return { app: makeApp(deps), createCalls, labelCalls, refreshCalls: () => refreshCalls };
@@ -140,4 +142,41 @@ test("POST /api/up-next/start rejects an empty / malformed body", async () => {
   expect((await app.fetch(startReq([]))).status).toBe(400);
   const bad = await app.fetch(startReq([{ repoPath: repoDir, issueRef: { number: "x" } }]));
   expect(bad.status).toBe(400);
+});
+
+test("GET /api/up-next?peek strips hidden-repo sections via hiddenRepoPathsRaw", async () => {
+  const hiddenPath = "/r/hidden";
+  const visiblePath = "/r/visible";
+  const hiddenSection: UpNextSection = {
+    kind: "repo",
+    repoPath: hiddenPath,
+    repoSlug: "hidden",
+    repoLabel: "hidden",
+    items: [],
+    totalCount: 0,
+  };
+  const visibleSection: UpNextSection = {
+    kind: "repo",
+    repoPath: visiblePath,
+    repoSlug: "visible",
+    repoLabel: "visible",
+    items: [],
+    totalCount: 0,
+  };
+  const snap: UpNextSnapshot = {
+    generatedAt: 999,
+    repoCount: 2,
+    fallback: null,
+    sections: [hiddenSection, visibleSection],
+  };
+  const { app } = harness({
+    snapshot: snap,
+    hiddenRepoPathsRaw: () => new Set([hiddenPath]),
+  });
+  const res = await app.fetch(new Request("http://x/api/up-next?peek=1"));
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as UpNextSnapshot;
+  const repoPaths = body.sections.map((s) => s.repoPath);
+  expect(repoPaths).not.toContain(hiddenPath);
+  expect(repoPaths).toContain(visiblePath);
 });

--- a/test/up-next-core.test.ts
+++ b/test/up-next-core.test.ts
@@ -1,10 +1,14 @@
 import { test, expect, describe } from "bun:test";
 import {
   buildSnapshot,
+  excludeHiddenSections,
   PRIORITY_CAP,
   REPO_CAP,
   type RepoInput,
   type EpicUnitInput,
+  type UpNextSnapshot,
+  type UpNextSection,
+  type UpNextItem,
 } from "../src/up-next-core";
 import type { Issue } from "../src/forge/types";
 
@@ -269,5 +273,102 @@ describe("snapshot shape", () => {
   });
   test("empty input → no sections", () => {
     expect(buildSnapshot([], NOW).sections).toEqual([]);
+  });
+});
+
+// ── excludeHiddenSections ────────────────────────────────────────────────────
+
+function makeItem(repoPath: string, num: number): UpNextItem {
+  return {
+    repoPath,
+    repoSlug: "o/r",
+    repoLabel: "r",
+    number: num,
+    title: `t${num}`,
+    url: `https://x/${num}`,
+    kind: "feature",
+    priority: false,
+    createdAt: num,
+    issueRef: { number: num, url: `https://x/${num}`, title: `t${num}`, body: "" },
+  };
+}
+
+function makeRepoSection(repoPath: string, items: UpNextItem[] = []): UpNextSection {
+  return {
+    kind: "repo",
+    repoPath,
+    repoSlug: "o/r",
+    repoLabel: "r",
+    items,
+    totalCount: items.length,
+  };
+}
+
+function makePrioritySection(items: UpNextItem[]): UpNextSection {
+  return {
+    kind: "priority",
+    repoPath: null,
+    repoSlug: null,
+    repoLabel: null,
+    items,
+    totalCount: items.length,
+  };
+}
+
+function makeSnap(sections: UpNextSection[], repoCount: number): UpNextSnapshot {
+  return { generatedAt: 1000, sections, repoCount, fallback: null };
+}
+
+describe("excludeHiddenSections", () => {
+  test("(e) hidden repo section removed; repoCount decremented", () => {
+    const snap = makeSnap([makeRepoSection("/r/a"), makeRepoSection("/r/b")], 2);
+    const result = excludeHiddenSections(snap, new Set(["/r/a"]));
+    expect(result.sections).toHaveLength(1);
+    expect(result.sections[0]!.repoPath).toBe("/r/b");
+    expect(result.repoCount).toBe(1);
+    expect(result.generatedAt).toBe(snap.generatedAt);
+    expect(result.fallback).toBe(snap.fallback);
+  });
+
+  test("(f) hidden repo item dropped from priority; section dropped when empty", () => {
+    const item = makeItem("/r/a", 1);
+    const snap = makeSnap([makePrioritySection([item]), makeRepoSection("/r/a", [item])], 1);
+    const result = excludeHiddenSections(snap, new Set(["/r/a"]));
+    expect(result.sections).toHaveLength(0);
+    expect(result.repoCount).toBe(0);
+  });
+
+  test("(f2) priority section partially filtered; totalCount recomputed; non-hidden repo kept", () => {
+    const itemA = makeItem("/r/a", 1);
+    const itemB = makeItem("/r/b", 2);
+    const snap = makeSnap(
+      [
+        makePrioritySection([itemA, itemB]),
+        makeRepoSection("/r/a", [itemA]),
+        makeRepoSection("/r/b", [itemB]),
+      ],
+      2,
+    );
+    const result = excludeHiddenSections(snap, new Set(["/r/a"]));
+    const pSec = result.sections.find((s) => s.kind === "priority");
+    expect(pSec).toBeDefined();
+    expect(pSec!.items.map((i) => i.number)).toEqual([2]);
+    expect(pSec!.totalCount).toBe(1);
+    const repoSecs = result.sections.filter((s) => s.kind === "repo");
+    expect(repoSecs).toHaveLength(1);
+    expect(repoSecs[0]!.repoPath).toBe("/r/b");
+    expect(result.repoCount).toBe(1);
+  });
+
+  test("(g) empty hiddenRaw → same snapshot reference returned (fast-path)", () => {
+    const snap = makeSnap([makeRepoSection("/r/a")], 1);
+    expect(excludeHiddenSections(snap, new Set())).toBe(snap);
+  });
+
+  test("(g2) non-empty hiddenRaw with no match → sections and repoCount unchanged", () => {
+    const snap = makeSnap([makeRepoSection("/r/a")], 1);
+    const result = excludeHiddenSections(snap, new Set(["/r/z"]));
+    expect(result.sections).toHaveLength(1);
+    expect(result.repoCount).toBe(1);
   });
 });

--- a/test/up-next.test.ts
+++ b/test/up-next.test.ts
@@ -1,5 +1,9 @@
 import { test, expect, describe } from "bun:test";
-import { UpNextService, startSerially, type UpNextDeps } from "../src/up-next";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { UpNextService, startSerially, buildUpNextRepos, type UpNextDeps } from "../src/up-next";
+import { listRepos } from "../src/repos";
 import type { Epic, EpicRun } from "../src/epic-core";
 import type { GitForge, Issue } from "../src/forge/types";
 
@@ -172,5 +176,80 @@ describe("startSerially", () => {
     };
     await expect(startSerially([1, 2, 3], spawn)).rejects.toThrow("nope");
     expect(seen).toEqual([1, 2]); // #3 never attempted
+  });
+});
+
+describe("buildUpNextRepos", () => {
+  const forge = fakeForge({ kind: "github", slug: "o/r" });
+  const localForge = fakeForge({ kind: "local", slug: "local/r" });
+
+  test("(a) local and non-forge repos are excluded", () => {
+    const repos = [
+      { name: "a", path: "/r/a", display: "/r/a" },
+      { name: "b", path: "/r/b", display: "/r/b" },
+      { name: "c", path: "/r/c", display: "/r/c" },
+    ];
+    // repo a → null forge, repo b → local forge, repo c → github forge
+    const resolveForge = (p: string) => {
+      if (p === "/r/a") return null;
+      if (p === "/r/b") return localForge;
+      return forge;
+    };
+    const result = buildUpNextRepos({ repos, resolveForge, hiddenRealPaths: new Set() });
+    expect(result.map((r) => r.repoPath)).toEqual(["/r/c"]);
+  });
+
+  test("(b) a hidden repo (raw path in hiddenRealPaths) is excluded", () => {
+    const repos = [
+      { name: "a", path: "/r/a", display: "/r/a" },
+      { name: "b", path: "/r/b", display: "/r/b" },
+    ];
+    const result = buildUpNextRepos({
+      repos,
+      resolveForge: () => forge,
+      hiddenRealPaths: new Set(["/r/a"]),
+    });
+    expect(result.map((r) => r.repoPath)).toEqual(["/r/b"]);
+  });
+
+  test("(c) hidden by realpath under a symlinked repoRoot — reconcile excludes the repo", () => {
+    const realRoot = mkdtempSync(join(tmpdir(), "shepherd-up-next-c-real-"));
+    const linkRoot = join(tmpdir(), `shepherd-up-next-c-link-${process.pid}`);
+    mkdirSync(join(realRoot, "myrepo"));
+    symlinkSync(realRoot, linkRoot, "dir");
+    try {
+      // listRepos(linkRoot) enumerates raw join(linkRoot, "myrepo") paths.
+      const repos = listRepos(linkRoot);
+      // safeRepoDir / store keys are realpath-resolved.
+      const realMyrepo = realpathSync(join(linkRoot, "myrepo"));
+      // Precondition: raw path != realpath (confirms symlink divergence).
+      expect(realMyrepo).not.toBe(join(linkRoot, "myrepo"));
+      // Put the realpath form in hiddenRealPaths — must still be excluded once reconciled.
+      const result = buildUpNextRepos({
+        repos,
+        resolveForge: () => forge,
+        hiddenRealPaths: new Set([realMyrepo]),
+      });
+      expect(result).toHaveLength(0);
+    } finally {
+      rmSync(linkRoot, { force: true });
+      rmSync(realRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("(d) survivors carry exact repoPath / repoSlug / repoLabel", () => {
+    const repos = [{ name: "myrepo", path: "/r/myrepo", display: "~/myrepo" }];
+    const myForge = fakeForge({ kind: "github", slug: "acme/myrepo" });
+    const result = buildUpNextRepos({
+      repos,
+      resolveForge: () => myForge,
+      hiddenRealPaths: new Set(),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      repoPath: "/r/myrepo",
+      repoSlug: "acme/myrepo",
+      repoLabel: "~/myrepo",
+    });
   });
 });


### PR DESCRIPTION
## What

The **Up Next** cross-repo ranked queue (#1169/#1172) surfaced un-started work from **every** forge-backed repo, ignoring the per-repo `hidden` flag — a repo hidden in the Backlog repos panel still appeared in Up Next. This makes Up Next honor `hidden`, so a hidden repo contributes **no** section/items to the queue.

## Root cause

`listForgeRepos` (the thunk passed to `UpNextService` in `src/index.ts`) filtered only by forge kind and never consulted `store.hiddenRepoPaths()`, unlike `buildBacklogPayload` (`src/server.ts`).

## Approach — two complementary filters

1. **Source filter (`buildUpNextRepos`, `src/up-next.ts`)** — runs at compute. Forge-filter + the realpath→raw reconcile (`reconcileRealPathsToRaw`) + hidden-filter + the exact field mapping, all inside one tested helper. Also avoids wasted forge `listIssues` fan-out for hidden repos.
2. **Read-time filter (`excludeHiddenSections`, `src/up-next-core.ts`)** — pure; applied to the cached snapshot in `handleUpNextGet` against the live reconciled hidden set (`upNext.hiddenRepoPathsRaw()`). Reflects a hide on the **next GET** — instant, no forge fan-out — so a repo hidden *after* the last compute doesn't linger in the cached payload.

**Path-space note:** `repo_config` keys are realpath/`safeRepoDir`-resolved, but the snapshot/`listRepos` paths are raw `join(repoRoot,name)`. Both filter sites reconcile the hidden set to raw space (the same dance the Backlog does) so a persisted hide matches under a symlinked `repoRoot`.

## Deliberate deviation from prior art (per house rules)

The **Backlog** *includes* hidden repos in its payload and merely flags them `hidden: true` (the UI collapses them, keeping per-repo settings reachable). **Up Next instead fully excludes** them — it has no settings drill-down and exists only to rank actionable work, so a hidden repo should contribute nothing. This divergence is documented inline (`src/up-next.ts`) and here.

A second framing note: the read-time filter (instant on next GET, no fan-out) supersedes an earlier "eventual / next-tick" framing — it removes the up-to-15-min staleness without wiring a reactive refresh, matching the Backlog's request-driven freshness.

## Tests

- `buildUpNextRepos`: local/non-forge excluded; hidden raw-path excluded; **real reconcile via a symlinked `repoRoot`** (realpath ≠ raw); survivors carry exact `repoPath`/`repoSlug`/`repoLabel` (no label regression).
- `excludeHiddenSections`: hidden repo-section dropped + `repoCount` decremented; hidden item pulled from the priority section (section dropped when emptied) + `totalCount` recomputed; no-match/empty snapshot returned unchanged.
- Server integration: `GET /api/up-next?peek` strips hidden-repo sections via `hiddenRepoPathsRaw()`.

Verified: `bun run typecheck` clean · `bun run lint` clean · full `bun test` 5144 pass · branch hygiene linear off `main`.

Server-only behavior `fix(...)` touching only `src/**` + `test/**` — i18n / feature-catalog gates do not arm. `[no-feature-entry]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
