### PR TITLE
feat(hold): park plugin-refused New Tasks in the hold queue instead of losing them

### DIFF
--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -106,9 +106,10 @@ export type PluginRegister = (
   ctx: PluginContext,
 ) => void | (() => void) | Promise<void | (() => void)>;
 
-/** Thrown by `ctx.abortSpawn`; caught in the spawn path and converted to a hold so it
- *  rides the existing auto-refuse machinery (create rolls back, resume returns null)
- *  rather than escaping as an unhandled throw. */
+/** Thrown by `ctx.abortSpawn`; caught in the spawn path. A plugin-refused **New-Task
+ *  create** is parked in the `held_tasks` queue (reason `'capacity'`) and retried when
+ *  the sweeper next fires — the task is not lost. A plugin-refused **resume** still
+ *  returns null (caller skips / 409) rather than escaping as an unhandled throw. */
 export class PluginSpawnAborted extends Error {
   constructor(
     public readonly reason: string,

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -493,10 +493,11 @@ export function autoHoldReason(
 /** Thrown when an auto spawn is refused (auto hold reason present). */
 export class SandboxAutoRefused extends Error {
   readonly holdReason: string;
-  constructor(holdReason: string) {
+  constructor(holdReason: string, cause?: unknown) {
     super(holdReason);
     this.name = "SandboxAutoRefused";
     this.holdReason = holdReason;
+    if (cause !== undefined) this.cause = cause;
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -154,6 +154,7 @@ import { fingerprintDiffCount } from "./rundown-core";
 import { quotaBlockReason } from "./blocked";
 import { upstreamStatus } from "./upstream-status";
 import { shouldHold } from "./usage-hold";
+import { PluginSpawnAborted } from "./plugins/types";
 import { randomUUID } from "node:crypto";
 
 const UI_DIR = join(import.meta.dir, "..", "ui", "build");
@@ -1634,6 +1635,18 @@ function createErrorResponse(e: unknown): Response {
 
 /** Check hold gate; if triggered, persist the held task and return the 200 response.
  *  Returns null when the task should proceed to normal creation. */
+function persistHeldTask(
+  value: CreateSessionInput,
+  deps: AppDeps,
+  reason: "usage" | "capacity",
+): Response {
+  const id = randomUUID();
+  const createdAt = Date.now();
+  deps.store.addHeldTask({ id, repoPath: value.repoPath, input: value, createdAt, reason });
+  deps.events.emit("held:changed", { count: deps.store.countHeldTasks() });
+  return json({ held: true, id, count: deps.store.countHeldTasks() }, 200);
+}
+
 function tryHoldNewTask(body: unknown, value: CreateSessionInput, deps: AppDeps): Response | null {
   const provider = normalizeAgentProvider(value.agentProvider ?? config.defaultAgentProvider);
   if (provider !== "claude") return null;
@@ -1656,11 +1669,7 @@ function tryHoldNewTask(body: unknown, value: CreateSessionInput, deps: AppDeps)
     })
   )
     return null;
-  const id = randomUUID();
-  const createdAt = Date.now();
-  deps.store.addHeldTask({ id, repoPath: value.repoPath, input: value, createdAt });
-  deps.events.emit("held:changed", { count: deps.store.countHeldTasks() });
-  return json({ held: true, id, count: deps.store.countHeldTasks() }, 200);
+  return persistHeldTask(value, deps, "usage");
 }
 
 // POST /api/sessions — create a session.
@@ -1680,6 +1689,10 @@ async function handleSessionCreate({ req, parts, deps }: Ctx): Promise<Response 
   try {
     s = await deps.service.create(result.value);
   } catch (e) {
+    // Plugin-refused create: park in held_tasks as a capacity hold for retry.
+    if (e instanceof SandboxAutoRefused && e.cause instanceof PluginSpawnAborted) {
+      return persistHeldTask(result.value, deps, "capacity");
+    }
     // create shells out to herdr (and git); surface the real reason instead of a
     // bare 500 so the New Task dialog can show it.
     return createErrorResponse(e);

--- a/src/service.ts
+++ b/src/service.ts
@@ -936,7 +936,9 @@ type SpawnSuccess = {
   /** True when an interactive autonomous session ran FS-only because egress was unavailable. */
   egressDegraded: boolean;
 };
-type SpawnOutcome = SpawnSuccess | { ok: false; holdReason: string };
+type SpawnOutcome =
+  | SpawnSuccess
+  | { ok: false; holdReason: string; abortCause?: PluginSpawnAborted };
 
 /** Total char budget for the issue-comment block appended to a spawn prompt. Generous —
  *  comments ride out-of-band like the body, so they don't count against the 8000-char
@@ -1286,7 +1288,8 @@ export class SessionService {
       apiKeyPassthrough: Record<string, string>;
     },
   ): Promise<
-    { patchEnv: Record<string, string>; finalInnerArgv: string[] } | { holdReason: string }
+    | { patchEnv: Record<string, string>; finalInnerArgv: string[] }
+    | { holdReason: string; abortCause?: PluginSpawnAborted }
   > {
     if (!this.deps.runSpawnHooks) return { patchEnv: {}, finalInnerArgv: innerArgv };
     // ADVISORY descriptor env: the explicit overlay Shepherd sets ON TOP OF the inherited
@@ -1310,7 +1313,7 @@ export class SessionService {
       });
     } catch (e) {
       if (e instanceof PluginSpawnAborted) {
-        return { holdReason: `plugin ${e.pluginId} aborted spawn: ${e.reason}` };
+        return { holdReason: `plugin ${e.pluginId} aborted spawn: ${e.reason}`, abortCause: e };
       }
       throw e;
     }
@@ -1395,7 +1398,8 @@ export class SessionService {
       rendererEnv,
       apiKeyPassthrough,
     });
-    if ("holdReason" in hook) return { ok: false, holdReason: hook.holdReason };
+    if ("holdReason" in hook)
+      return { ok: false, holdReason: hook.holdReason, abortCause: hook.abortCause };
     const { patchEnv, finalInnerArgv } = hook;
 
     const membrane: MembraneInputs = willWrap
@@ -1507,7 +1511,7 @@ export class SessionService {
     ctx: Parameters<SessionService["prepareSpawn"]>[1],
   ): Promise<SpawnSuccess> {
     const outcome = await this.prepareSpawn(innerArgv, ctx);
-    if (!outcome.ok) throw new SandboxAutoRefused(outcome.holdReason);
+    if (!outcome.ok) throw new SandboxAutoRefused(outcome.holdReason, outcome.abortCause);
     return outcome;
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -690,8 +690,10 @@ export class SessionStore implements CapStore, CreditStore {
       id TEXT PRIMARY KEY,
       repoPath TEXT NOT NULL,
       input TEXT NOT NULL,
-      createdAt INTEGER NOT NULL
+      createdAt INTEGER NOT NULL,
+      reason TEXT NOT NULL DEFAULT 'usage'
     )`);
+    this.migrateHeldTaskColumns();
     // small key/value store for runtime-configurable settings (e.g. repoRoot)
     this.db.run(`CREATE TABLE IF NOT EXISTS settings (
       key TEXT PRIMARY KEY, value TEXT NOT NULL)`);
@@ -2905,6 +2907,15 @@ export class SessionStore implements CapStore, CreditStore {
     })();
   }
 
+  /** Add columns to held_tasks that postdate the original schema (existing rows default
+   *  to 'usage' — they were all usage-gate holds before capacity-hold support was added). */
+  private migrateHeldTaskColumns(): void {
+    const cols = this.db.query(`PRAGMA table_info(held_tasks)`).all() as { name: string }[];
+    if (!cols.some((c) => c.name === "reason")) {
+      this.db.run(`ALTER TABLE held_tasks ADD COLUMN reason TEXT NOT NULL DEFAULT 'usage'`);
+    }
+  }
+
   // migrate repo_config that predates these opt-in columns. auto-address defaults
   // OFF (the spendier loop — existing repos opt in explicitly); learnings defaults ON.
   private migrateRepoConfigColumns(): void {
@@ -4134,28 +4145,49 @@ export class SessionStore implements CapStore, CreditStore {
     repoPath: string;
     input: CreateSessionInput;
     createdAt: number;
+    reason?: "usage" | "capacity";
   }): void {
-    this.db.run(`INSERT INTO held_tasks (id, repoPath, input, createdAt) VALUES (?, ?, ?, ?)`, [
-      row.id,
-      row.repoPath,
-      JSON.stringify(row.input),
-      row.createdAt,
-    ]);
+    this.db.run(
+      `INSERT INTO held_tasks (id, repoPath, input, createdAt, reason) VALUES (?, ?, ?, ?, ?)`,
+      [row.id, row.repoPath, JSON.stringify(row.input), row.createdAt, row.reason ?? "usage"],
+    );
   }
 
   listHeldTasks(): HeldTask[] {
     const rows = this.db
-      .query(`SELECT id, repoPath, input, createdAt FROM held_tasks ORDER BY createdAt ASC`)
-      .all() as { id: string; repoPath: string; input: string; createdAt: number }[];
-    return rows.map((r) => ({ ...r, input: JSON.parse(r.input) as CreateSessionInput }));
+      .query(
+        `SELECT id, repoPath, input, createdAt, reason FROM held_tasks ORDER BY (reason = 'capacity'), createdAt ASC`,
+      )
+      .all() as {
+      id: string;
+      repoPath: string;
+      input: string;
+      createdAt: number;
+      reason: string;
+    }[];
+    return rows.map((r) => ({
+      ...r,
+      input: JSON.parse(r.input) as CreateSessionInput,
+      reason: r.reason as "usage" | "capacity",
+    }));
   }
 
   getHeldTask(id: string): HeldTask | null {
     const r = this.db
-      .query(`SELECT id, repoPath, input, createdAt FROM held_tasks WHERE id = ?`)
-      .get(id) as { id: string; repoPath: string; input: string; createdAt: number } | null;
+      .query(`SELECT id, repoPath, input, createdAt, reason FROM held_tasks WHERE id = ?`)
+      .get(id) as {
+      id: string;
+      repoPath: string;
+      input: string;
+      createdAt: number;
+      reason: string;
+    } | null;
     if (!r) return null;
-    return { ...r, input: JSON.parse(r.input) as CreateSessionInput };
+    return {
+      ...r,
+      input: JSON.parse(r.input) as CreateSessionInput,
+      reason: r.reason as "usage" | "capacity",
+    };
   }
 
   removeHeldTask(id: string): void {

--- a/src/store.ts
+++ b/src/store.ts
@@ -4145,11 +4145,11 @@ export class SessionStore implements CapStore, CreditStore {
     repoPath: string;
     input: CreateSessionInput;
     createdAt: number;
-    reason?: "usage" | "capacity";
+    reason: "usage" | "capacity";
   }): void {
     this.db.run(
       `INSERT INTO held_tasks (id, repoPath, input, createdAt, reason) VALUES (?, ?, ?, ?, ?)`,
-      [row.id, row.repoPath, JSON.stringify(row.input), row.createdAt, row.reason ?? "usage"],
+      [row.id, row.repoPath, JSON.stringify(row.input), row.createdAt, row.reason],
     );
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -692,6 +692,8 @@ export interface HeldTask {
   /** The original CreateSessionInput, replayed through service.create() when released. */
   input: CreateSessionInput;
   createdAt: number;
+  /** Hold reason: `'usage'` = usage-gate hold; `'capacity'` = plugin-refused (no account). */
+  reason: "usage" | "capacity";
 }
 
 // ── per-session usage snapshot ────────────────────────────────────────────────

--- a/test/held-release.test.ts
+++ b/test/held-release.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "bun:test";
 import { releaseHeldTasks, type HeldReleaseDeps } from "../src/held-release";
 import type { CreateSessionInput, Session } from "../src/types";
 import type { UsageLimits } from "../src/usage-limits";
+import { SandboxAutoRefused } from "../src/sandbox";
 
 // Minimal Session stub — these tests only ever read `.id` off the created session
 // (it's the session:new payload), so a full literal would be noise.
@@ -29,7 +30,12 @@ function makeDeps(
   creates: CreateSessionInput[];
   labeled: number[];
 } {
-  const rows = tasks.map((t, i) => ({ ...t, repoPath: "/tmp/repo", createdAt: i + 1 }));
+  const rows = tasks.map((t, i) => ({
+    reason: "usage" as const,
+    ...t,
+    repoPath: "/tmp/repo",
+    createdAt: i + 1,
+  }));
   const emitted: { event: string; data: unknown }[] = [];
   const creates: CreateSessionInput[] = [];
   const labeled: number[] = [];
@@ -253,4 +259,77 @@ test("released task with linked issue → re-stamps the drain claim", async () =
   expect(result.released).toBe(2);
   // only the issue-linked task stamps ACTIVE_LABEL (one claim, for #42)
   expect(deps.labeled).toEqual([42]);
+});
+
+// ── capacity-last ordering ────────────────────────────────────────────────────
+// These tests simulate what the store's capacity-last ORDER BY produces:
+// listHeldTasks() returns usage-held tasks first, capacity-held tasks last.
+
+function makeRowsWithReason(
+  tasks: { id: string; input: CreateSessionInput; reason: "usage" | "capacity" }[],
+) {
+  return tasks.map((t, i) => ({ ...t, repoPath: "/tmp/repo", createdAt: i + 1 }));
+}
+
+test("capacity-last: usage-held task released before capacity-held (store ordering honored)", async () => {
+  // Store returns usage-held first, capacity-held last — simulate real listHeldTasks ordering.
+  const usageTask = { id: "u1", input: makeInput("usage task"), reason: "usage" as const };
+  const capTask = { id: "c1", input: makeInput("cap task"), reason: "capacity" as const };
+  const rows = makeRowsWithReason([usageTask, capTask]);
+
+  const creates: CreateSessionInput[] = [];
+  const deps = makeDeps([], {}, async (input) => {
+    creates.push(input);
+    return fakeSession("fake");
+  });
+  // Override the store to return capacity-last list
+  deps.store.listHeldTasks = () => [...rows] as import("../src/types").HeldTask[];
+  let rowsCopy = [...rows];
+  deps.store.removeHeldTask = (id: string) => {
+    rowsCopy = rowsCopy.filter((r) => r.id !== id);
+  };
+  deps.store.countHeldTasks = () => rowsCopy.length;
+
+  const result = await releaseHeldTasks(
+    deps,
+    { enabled: false, holdPct: 80, autoRelease: true },
+    Date.now(),
+    10,
+  );
+  expect(result.released).toBe(2);
+  expect(creates[0]!.prompt).toBe("usage task"); // usage released first
+  expect(creates[1]!.prompt).toBe("cap task");
+});
+
+test("capacity-last: failing capacity task does not block releasable usage task ahead of it", async () => {
+  // List: usage (u1) first, capacity (c1) last — capacity-last ordering from store.
+  const usageTask = { id: "u1", input: makeInput("usage task"), reason: "usage" as const };
+  const capTask = { id: "c1", input: makeInput("cap task"), reason: "capacity" as const };
+  const rows = makeRowsWithReason([usageTask, capTask]);
+
+  const creates: CreateSessionInput[] = [];
+  const deps = makeDeps([], {}, async (input) => {
+    if (input.prompt === "cap task") throw new SandboxAutoRefused("no accounts");
+    creates.push(input);
+    return fakeSession("fake");
+  });
+  let rowsCopy = [...rows];
+  deps.store.listHeldTasks = () => [...rowsCopy] as import("../src/types").HeldTask[];
+  deps.store.removeHeldTask = (id: string) => {
+    rowsCopy = rowsCopy.filter((r) => r.id !== id);
+  };
+  deps.store.countHeldTasks = () => rowsCopy.length;
+
+  const result = await releaseHeldTasks(
+    deps,
+    { enabled: false, holdPct: 80, autoRelease: true },
+    Date.now(),
+    10,
+  );
+  // u1 succeeds (released=1), c1 fails (break) — usage not blocked by capacity at end
+  expect(result.released).toBe(1);
+  expect(creates).toHaveLength(1);
+  expect(creates[0]!.prompt).toBe("usage task");
+  // c1 still queued
+  expect(rowsCopy.some((r) => r.id === "c1")).toBe(true);
 });

--- a/test/hold-gate.test.ts
+++ b/test/hold-gate.test.ts
@@ -231,6 +231,7 @@ test("GET /api/held returns FIFO held tasks", async () => {
       images: [],
     },
     createdAt: 1000,
+    reason: "usage",
   });
   store.addHeldTask({
     id: "held-2",
@@ -243,6 +244,7 @@ test("GET /api/held returns FIFO held tasks", async () => {
       images: [],
     },
     createdAt: 2000,
+    reason: "usage",
   });
 
   const res = await app.fetch(new Request("http://x/api/held"));
@@ -264,7 +266,7 @@ test("POST /api/held/:id/spawn → calls service.create, removes row, returns 20
     model: null,
     images: [],
   };
-  store.addHeldTask({ id: "held-1", repoPath: repoDir, input, createdAt: 1000 });
+  store.addHeldTask({ id: "held-1", repoPath: repoDir, input, createdAt: 1000, reason: "usage" });
 
   const res = await app.fetch(new Request("http://x/api/held/held-1/spawn", { method: "POST" }));
   expect(res.status).toBe(201);
@@ -290,7 +292,7 @@ test("POST /api/held/:id/spawn accepts an agent provider override", async () => 
     model: null,
     images: [],
   };
-  store.addHeldTask({ id: "held-1", repoPath: repoDir, input, createdAt: 1000 });
+  store.addHeldTask({ id: "held-1", repoPath: repoDir, input, createdAt: 1000, reason: "usage" });
 
   const res = await app.fetch(
     new Request("http://x/api/held/held-1/spawn", {
@@ -321,6 +323,7 @@ test("POST /api/held/:id/spawn with linked issue → re-stamps the drain claim",
       issueRef: { number: 99, url: "http://x/i/99", title: "t", body: "" },
     },
     createdAt: 1000,
+    reason: "usage",
   });
 
   const res = await app.fetch(new Request("http://x/api/held/held-1/spawn", { method: "POST" }));
@@ -352,6 +355,7 @@ test("DELETE /api/held/:id → removes row, returns {ok:true}", async () => {
       images: [],
     },
     createdAt: 1000,
+    reason: "usage",
   });
 
   const res = await app.fetch(new Request("http://x/api/held/held-1", { method: "DELETE" }));
@@ -384,6 +388,7 @@ test("PATCH /api/held/:id → replaces input, stays held, emits held:changed", a
     repoPath: repoDir,
     input: { repoPath: repoDir, baseBranch: "main", prompt: "old prompt", model: null, images: [] },
     createdAt: 1000,
+    reason: "usage",
   });
 
   const res = await patchHeld(app, "held-1", {
@@ -420,6 +425,7 @@ test("PATCH /api/held/:id preserves merge-train membership the composer can't ed
       mergeTrainPrs: [11, 22],
     },
     createdAt: 1000,
+    reason: "usage",
   });
 
   // The edit composer never sends mergeTrainPrs; the held row's value must survive.
@@ -457,6 +463,7 @@ test("PATCH /api/held/:id with invalid input → 400, row unchanged", async () =
     repoPath: repoDir,
     input: { repoPath: repoDir, baseBranch: "main", prompt: "keep me", model: null, images: [] },
     createdAt: 1000,
+    reason: "usage",
   });
 
   // empty prompt fails validateCreate

--- a/test/plugins-spawn.test.ts
+++ b/test/plugins-spawn.test.ts
@@ -173,7 +173,32 @@ test("plugin abort on create surfaces as SandboxAutoRefused with PluginSpawnAbor
 });
 
 test("non-plugin refusal (api-key hold) surfaces as SandboxAutoRefused with cause === undefined", async () => {
-  // A non-plugin SandboxAutoRefused (e.g. api-key hold) has no cause.
-  const err = new SandboxAutoRefused("api-key hold reason");
-  expect(err.cause).toBeUndefined();
+  // Trigger the real service-level non-plugin refusal: api-key mode with no
+  // helper path configured → prepareSpawn returns holdReason without abortCause
+  // → prepareSpawnOrThrow throws SandboxAutoRefused(holdReason, undefined)
+  // → cause is undefined (contrasting the plugin-abort case which sets cause).
+  const prevMode = config.authMode;
+  const prevPath = config.authApiKeyHelperPath;
+  config.authMode = "api-key";
+  config.authApiKeyHelperPath = null;
+  try {
+    const { service } = makeService(NOOP_HOOKS);
+    let caught: unknown;
+    try {
+      await service.create({
+        repoPath: "/repo",
+        baseBranch: "main",
+        prompt: "go",
+        model: null,
+        images: [],
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(SandboxAutoRefused);
+    expect((caught as SandboxAutoRefused).cause).toBeUndefined();
+  } finally {
+    config.authMode = prevMode;
+    config.authApiKeyHelperPath = prevPath;
+  }
 });

--- a/test/plugins-spawn.test.ts
+++ b/test/plugins-spawn.test.ts
@@ -7,6 +7,7 @@ import { SessionService } from "../src/service";
 import { config } from "../src/config";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
 import { PluginSpawnAborted, type SpawnDescriptor, type SpawnPatch } from "../src/plugins/types";
+import { SandboxAutoRefused } from "../src/sandbox";
 
 type Hooks = (d: SpawnDescriptor) => Promise<SpawnPatch>;
 
@@ -145,4 +146,34 @@ test("no runSpawnHooks dep → spawn proceeds unchanged (no-op invariant)", asyn
   expect(started).toBe(true);
   expect(s.herdrAgentId).toBe("term_z");
   void NOOP_HOOKS;
+});
+
+// ── SandboxAutoRefused.cause plumbing ─────────────────────────────────────────
+
+test("plugin abort on create surfaces as SandboxAutoRefused with PluginSpawnAborted cause", async () => {
+  const hooks = { fn: async () => Promise.reject(new PluginSpawnAborted("no creds", "swap")) };
+  const { service } = makeService(hooks as { fn: Hooks });
+
+  let caught: unknown;
+  try {
+    await service.create({
+      repoPath: "/repo",
+      baseBranch: "main",
+      prompt: "go",
+      model: null,
+      images: [],
+    });
+  } catch (e) {
+    caught = e;
+  }
+
+  expect(caught).toBeInstanceOf(SandboxAutoRefused);
+  expect((caught as SandboxAutoRefused).cause).toBeInstanceOf(PluginSpawnAborted);
+  expect(((caught as SandboxAutoRefused).cause as PluginSpawnAborted).pluginId).toBe("swap");
+});
+
+test("non-plugin refusal (api-key hold) surfaces as SandboxAutoRefused with cause === undefined", async () => {
+  // A non-plugin SandboxAutoRefused (e.g. api-key hold) has no cause.
+  const err = new SandboxAutoRefused("api-key hold reason");
+  expect(err.cause).toBeUndefined();
 });

--- a/test/server-hold-capacity.test.ts
+++ b/test/server-hold-capacity.test.ts
@@ -1,0 +1,123 @@
+// server-hold-capacity.test.ts — TDD tests for plugin-refused New-Task capacity hold
+// Step 5 of feat/hold-on-plugin-capacity-refuse
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { SessionStore } from "../src/store";
+import { EventHub } from "../src/events";
+import { makeApp, type AppDeps } from "../src/server";
+import { SandboxAutoRefused } from "../src/sandbox";
+import { PluginSpawnAborted } from "../src/plugins/types";
+import { config } from "../src/config";
+
+let tmpRoot: string;
+let validRepo: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(config.repoRoot, "shepherd-cap-test-"));
+  validRepo = join(tmpRoot, "repo");
+  mkdirSync(validRepo);
+});
+
+afterEach(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+function postSessions(app: ReturnType<typeof makeApp>, body: unknown) {
+  return app.fetch(
+    new Request("http://x/api/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+function makeBody() {
+  return { repoPath: validRepo, baseBranch: "main", prompt: "go" };
+}
+
+function makeDeps(): AppDeps {
+  const store = new SessionStore(":memory:");
+  const events = new EventHub();
+  const usageLimits = {
+    limits: () => ({
+      session5h: null,
+      week: null,
+      credits: null,
+      stale: false,
+      calibratedAt: null,
+      subscriptionOnly: false,
+    }),
+    projections: () => [],
+  };
+  const distiller = { distillNow: () => {} };
+  return { store, events, usageLimits, distiller } as unknown as AppDeps;
+}
+
+// ── New-Task create: plugin-refused → 200 { held:true } + capacity row ────────
+
+test("POST /api/sessions: SandboxAutoRefused with PluginSpawnAborted cause → 200 held:true", async () => {
+  const deps = makeDeps();
+  const pluginErr = new PluginSpawnAborted("no accounts", "claude-swap");
+  deps.service = {
+    create: async () => {
+      throw new SandboxAutoRefused("plugin claude-swap aborted spawn: no accounts", pluginErr);
+    },
+  } as unknown as AppDeps["service"];
+
+  const res = await postSessions(makeApp(deps), makeBody());
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.held).toBe(true);
+  expect(typeof body.id).toBe("string");
+  expect(typeof body.count).toBe("number");
+});
+
+test("POST /api/sessions: capacity hold inserts row with reason='capacity'", async () => {
+  const deps = makeDeps();
+  const pluginErr = new PluginSpawnAborted("no accounts", "claude-swap");
+  deps.service = {
+    create: async () => {
+      throw new SandboxAutoRefused("plugin aborted: no accounts", pluginErr);
+    },
+  } as unknown as AppDeps["service"];
+
+  await postSessions(makeApp(deps), makeBody());
+
+  const held = deps.store.listHeldTasks();
+  expect(held).toHaveLength(1);
+  expect(held[0]!.reason).toBe("capacity");
+  expect(held[0]!.input.repoPath).toBe(validRepo);
+});
+
+test("POST /api/sessions: SandboxAutoRefused WITHOUT cause → 403 (unchanged behavior)", async () => {
+  const deps = makeDeps();
+  deps.service = {
+    create: async () => {
+      throw new SandboxAutoRefused("autonomous mode requires sandbox");
+    },
+  } as unknown as AppDeps["service"];
+
+  const res = await postSessions(makeApp(deps), makeBody());
+  expect(res.status).toBe(403);
+  const body = await res.json();
+  expect(body.held).toBeUndefined();
+  expect(deps.store.listHeldTasks()).toHaveLength(0);
+});
+
+test("POST /api/sessions: held:changed event emitted on capacity hold", async () => {
+  const deps = makeDeps();
+  const emitted: unknown[] = [];
+  deps.events.subscribe((event, d) => {
+    if (event === "held:changed") emitted.push(d);
+  });
+
+  const pluginErr = new PluginSpawnAborted("no accounts", "claude-swap");
+  deps.service = {
+    create: async () => {
+      throw new SandboxAutoRefused("plugin aborted: no accounts", pluginErr);
+    },
+  } as unknown as AppDeps["service"];
+
+  await postSessions(makeApp(deps), makeBody());
+  expect(emitted).toHaveLength(1);
+});

--- a/test/store.held.test.ts
+++ b/test/store.held.test.ts
@@ -1,4 +1,8 @@
 import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
 import { SessionStore } from "../src/store";
 import type { CreateSessionInput } from "../src/types";
 
@@ -19,12 +23,19 @@ const sampleInput: CreateSessionInput = {
 
 test("held_tasks: listHeldTasks returns FIFO order", () => {
   const s = new SessionStore(":memory:");
-  s.addHeldTask({ id: "h1", repoPath: "/repo/a", input: sampleInput, createdAt: 1000 });
+  s.addHeldTask({
+    id: "h1",
+    repoPath: "/repo/a",
+    input: sampleInput,
+    createdAt: 1000,
+    reason: "usage",
+  });
   s.addHeldTask({
     id: "h2",
     repoPath: "/repo/b",
     input: { ...sampleInput, prompt: "second task" },
     createdAt: 2000,
+    reason: "usage",
   });
   const list = s.listHeldTasks();
   expect(list).toHaveLength(2);
@@ -35,14 +46,32 @@ test("held_tasks: listHeldTasks returns FIFO order", () => {
 test("held_tasks: countHeldTasks returns correct count", () => {
   const s = new SessionStore(":memory:");
   expect(s.countHeldTasks()).toBe(0);
-  s.addHeldTask({ id: "h1", repoPath: "/repo/a", input: sampleInput, createdAt: 1000 });
-  s.addHeldTask({ id: "h2", repoPath: "/repo/b", input: sampleInput, createdAt: 2000 });
+  s.addHeldTask({
+    id: "h1",
+    repoPath: "/repo/a",
+    input: sampleInput,
+    createdAt: 1000,
+    reason: "usage",
+  });
+  s.addHeldTask({
+    id: "h2",
+    repoPath: "/repo/b",
+    input: sampleInput,
+    createdAt: 2000,
+    reason: "usage",
+  });
   expect(s.countHeldTasks()).toBe(2);
 });
 
 test("held_tasks: getHeldTask round-trips full input", () => {
   const s = new SessionStore(":memory:");
-  s.addHeldTask({ id: "h1", repoPath: "/repo/a", input: sampleInput, createdAt: 1000 });
+  s.addHeldTask({
+    id: "h1",
+    repoPath: "/repo/a",
+    input: sampleInput,
+    createdAt: 1000,
+    reason: "usage",
+  });
   const got = s.getHeldTask("h1");
   expect(got).not.toBeNull();
   expect(got?.id).toBe("h1");
@@ -58,7 +87,13 @@ test("held_tasks: getHeldTask returns null for unknown id", () => {
 
 test("held_tasks: updateHeldTask replaces input and mirrors repoPath", () => {
   const s = new SessionStore(":memory:");
-  s.addHeldTask({ id: "h1", repoPath: "/repo/a", input: sampleInput, createdAt: 1000 });
+  s.addHeldTask({
+    id: "h1",
+    repoPath: "/repo/a",
+    input: sampleInput,
+    createdAt: 1000,
+    reason: "usage",
+  });
 
   const edited: CreateSessionInput = {
     ...sampleInput,
@@ -77,8 +112,20 @@ test("held_tasks: updateHeldTask replaces input and mirrors repoPath", () => {
 
 test("held_tasks: removeHeldTask removes row and leaves others intact", () => {
   const s = new SessionStore(":memory:");
-  s.addHeldTask({ id: "h1", repoPath: "/repo/a", input: sampleInput, createdAt: 1000 });
-  s.addHeldTask({ id: "h2", repoPath: "/repo/b", input: sampleInput, createdAt: 2000 });
+  s.addHeldTask({
+    id: "h1",
+    repoPath: "/repo/a",
+    input: sampleInput,
+    createdAt: 1000,
+    reason: "usage",
+  });
+  s.addHeldTask({
+    id: "h2",
+    repoPath: "/repo/b",
+    input: sampleInput,
+    createdAt: 2000,
+    reason: "usage",
+  });
 
   s.removeHeldTask("h1");
 
@@ -103,10 +150,15 @@ test("held_tasks: addHeldTask with reason='capacity' round-trips via getHeldTask
   expect(got?.reason).toBe("capacity");
 });
 
-test("held_tasks: addHeldTask defaults reason to 'usage' when omitted", () => {
+test("held_tasks: addHeldTask with reason='usage' round-trips via getHeldTask", () => {
   const s = new SessionStore(":memory:");
-  // reason is optional; omitting it should default to 'usage' in the store
-  s.addHeldTask({ id: "u1", repoPath: "/repo/a", input: sampleInput, createdAt: 1000 });
+  s.addHeldTask({
+    id: "u1",
+    repoPath: "/repo/a",
+    input: sampleInput,
+    createdAt: 1000,
+    reason: "usage",
+  });
   const got = s.getHeldTask("u1");
   expect(got?.reason).toBe("usage");
 });
@@ -134,26 +186,34 @@ test("held_tasks: listHeldTasks orders usage before capacity regardless of creat
   expect(list[1]!.id).toBe("c1"); // capacity last
 });
 
-test("held_tasks: migration adds reason to pre-existing rows defaulting to 'usage'", () => {
-  // Simulate a pre-existing DB without the reason column by using a fresh store
-  // (the migration is guarded — on a brand-new :memory: store the CREATE TABLE includes
-  // the column, so we test via the normal path: insert with explicit usage and verify).
-  const s = new SessionStore(":memory:");
-  s.addHeldTask({
-    id: "old",
-    repoPath: "/repo/a",
-    input: sampleInput,
-    createdAt: 500,
-    reason: "usage",
-  });
-  s.addHeldTask({
-    id: "new",
-    repoPath: "/repo/b",
-    input: sampleInput,
-    createdAt: 600,
-    reason: "capacity",
-  });
-  const list = s.listHeldTasks();
-  expect(list.find((t) => t.id === "old")?.reason).toBe("usage");
-  expect(list.find((t) => t.id === "new")?.reason).toBe("capacity");
+test("held_tasks: migrateHeldTaskColumns ALTER path — legacy DB without reason column", () => {
+  // Build a pre-existing DB with the OLD held_tasks schema (no reason column),
+  // insert a legacy row, then open SessionStore on the same file so the
+  // constructor's migrateHeldTaskColumns() runs ALTER TABLE and the legacy row
+  // surfaces with reason === 'usage' (the DEFAULT).
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-held-migration-"));
+  const dbPath = join(dir, "test.db");
+  try {
+    const raw = new Database(dbPath);
+    raw.run(`CREATE TABLE held_tasks (
+      id TEXT PRIMARY KEY,
+      repoPath TEXT NOT NULL,
+      input TEXT NOT NULL,
+      createdAt INTEGER NOT NULL
+    )`);
+    raw.run(
+      `INSERT INTO held_tasks (id, repoPath, input, createdAt)
+       VALUES ('legacy-1', '/repo/a', '${JSON.stringify(sampleInput)}', 500)`,
+    );
+    raw.close();
+
+    // Opening the store triggers migrateHeldTaskColumns → ALTER TABLE ADD COLUMN reason
+    const s = new SessionStore(dbPath);
+    const list = s.listHeldTasks();
+    expect(list).toHaveLength(1);
+    expect(list[0]!.id).toBe("legacy-1");
+    expect(list[0]!.reason).toBe("usage"); // DEFAULT 'usage' applied by ALTER
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/test/store.held.test.ts
+++ b/test/store.held.test.ts
@@ -87,3 +87,73 @@ test("held_tasks: removeHeldTask removes row and leaves others intact", () => {
   expect(s.getHeldTask("h2")).not.toBeNull();
   expect(s.listHeldTasks()[0]!.id).toBe("h2");
 });
+
+// ── capacity hold: reason column + ordering ───────────────────────────────────
+
+test("held_tasks: addHeldTask with reason='capacity' round-trips via getHeldTask", () => {
+  const s = new SessionStore(":memory:");
+  s.addHeldTask({
+    id: "c1",
+    repoPath: "/repo/a",
+    input: sampleInput,
+    createdAt: 1000,
+    reason: "capacity",
+  });
+  const got = s.getHeldTask("c1");
+  expect(got?.reason).toBe("capacity");
+});
+
+test("held_tasks: addHeldTask defaults reason to 'usage' when omitted", () => {
+  const s = new SessionStore(":memory:");
+  // reason is optional; omitting it should default to 'usage' in the store
+  s.addHeldTask({ id: "u1", repoPath: "/repo/a", input: sampleInput, createdAt: 1000 });
+  const got = s.getHeldTask("u1");
+  expect(got?.reason).toBe("usage");
+});
+
+test("held_tasks: listHeldTasks orders usage before capacity regardless of createdAt", () => {
+  const s = new SessionStore(":memory:");
+  // capacity added earlier (lower createdAt), usage added later
+  s.addHeldTask({
+    id: "c1",
+    repoPath: "/repo/a",
+    input: sampleInput,
+    createdAt: 1000,
+    reason: "capacity",
+  });
+  s.addHeldTask({
+    id: "u1",
+    repoPath: "/repo/b",
+    input: sampleInput,
+    createdAt: 2000,
+    reason: "usage",
+  });
+  const list = s.listHeldTasks();
+  expect(list).toHaveLength(2);
+  expect(list[0]!.id).toBe("u1"); // usage first even though later
+  expect(list[1]!.id).toBe("c1"); // capacity last
+});
+
+test("held_tasks: migration adds reason to pre-existing rows defaulting to 'usage'", () => {
+  // Simulate a pre-existing DB without the reason column by using a fresh store
+  // (the migration is guarded — on a brand-new :memory: store the CREATE TABLE includes
+  // the column, so we test via the normal path: insert with explicit usage and verify).
+  const s = new SessionStore(":memory:");
+  s.addHeldTask({
+    id: "old",
+    repoPath: "/repo/a",
+    input: sampleInput,
+    createdAt: 500,
+    reason: "usage",
+  });
+  s.addHeldTask({
+    id: "new",
+    repoPath: "/repo/b",
+    input: sampleInput,
+    createdAt: 600,
+    reason: "capacity",
+  });
+  const list = s.listHeldTasks();
+  expect(list.find((t) => t.id === "old")?.reason).toBe("usage");
+  expect(list.find((t) => t.id === "new")?.reason).toBe("capacity");
+});


### PR DESCRIPTION
## Problem

When an in-process plugin (the private `claude-swap` account-rotation plugin) refuses a spawn via `ctx.abortSpawn(reason)` because no Claude account is free, an operator-submitted **New Task** was **lost**: the refusal surfaced as `SandboxAutoRefused` inside `service.create()`, which rolled back the worktree and returned `403`. Shepherd already has a hold queue (`held_tasks` + the 30s `releaseHeldTasks` sweeper), but it only triggered on Shepherd's own usage %, so a plugin's "pool exhausted" refusal never reached it.

## What this does

Routes a **plugin-refused New-Task create** into the existing `held_tasks` hold queue (tagged `reason='capacity'`) so it is retried by the sweeper until an account frees up, instead of being rolled back and lost. **No public plugin-API change** — detection is internal via `error.cause`.

### How
- **`SandboxAutoRefused`** carries an optional standard `Error.cause` (`sandbox.ts`).
- **`service.ts`** preserves the original `PluginSpawnAborted` as `abortCause` through the spawn-outcome chain instead of flattening it to a string, and passes it as the `cause` when throwing `SandboxAutoRefused`. API-key / autonomous-gate refusals carry **no** cause.
- **`handleSessionCreate`** (`server.ts`) — and only this create path — diverts to `persistHeldTask(..., 'capacity')` when `err.cause instanceof PluginSpawnAborted`; every other refusal still returns `403` unchanged.
- **`held_tasks`** gains a `reason` column (`'usage' | 'capacity'`) via a guarded, idempotent migration (existing rows default `'usage'`). `listHeldTasks` sorts **capacity-held last** (`ORDER BY (reason='capacity'), createdAt`) so a stuck pool-exhausted task never starves usage-held work; `releaseHeldTasks`' break-on-failure retry is unchanged.

### Deliberately out of scope (verified to already retry/retain — not lost)
`handleUpNextStart` (item stays in the up-next lens), `heldSpawn` (row retained on failure), and autonomous **drain** spawns (`SPAWN_FAIL_COOLDOWN_MS` backoff + `ACTIVE_LABEL` re-claim) keep their own retry engines and intentionally do **not** enter `held_tasks`. **Resume/restore** is a verified no-op (returns `null` on refusal; never inspects `cause`).

## Behavior tradeoff
Capacity-held tasks sort after usage-held tasks, so a sustained usage-hold can defer a capacity-held task at the tail; conversely a permanently-unspawnable capacity task is retried each tick until it spawns or the operator discards it. Both are deliberate; the escape hatch is the existing held-tasks discard.

## Tests
- `test/plugins-spawn.test.ts` — a hook throwing `PluginSpawnAborted` surfaces as `SandboxAutoRefused` with `.cause` set; a non-plugin (api-key) refusal flows through the real service path with `cause === undefined`.
- `test/server-hold-capacity.test.ts` — New-Task create whose `service.create` throws a cause-bearing `SandboxAutoRefused` → `200 { held: true }` + a `held_tasks` row with `reason: 'capacity'`; cause-less refusal → `403`, no row.
- `test/store.held.test.ts` — migration adds `reason` to a **legacy DB lacking the column** (exercises the `ALTER TABLE` path; legacy rows default `'usage'`); capacity-last ordering.
- `test/held-release.test.ts` — usage-held released ahead of a stuck capacity-held task; the failing capacity task stays queued without blocking releasable work.

Full suite: **5150 pass / 0 fail**, `tsc --noEmit` clean, eslint clean.

## Follow-up
The private `claude-swap` plugin's docs (PRD/README) describe the old "create rolls back" behavior and should be updated to reflect held-and-retried; tracked as a separate docs-only change in that repo (no code/contract dependency on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
