### PR TITLE
feat: plugin UI widgets — Phase 0 declarative descriptor (publishUI) → whitelisted Svelte registry (#1185)

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -20,10 +20,12 @@ import {
   type PluginRegister,
   type PluginRouteHandler,
   type PluginState,
+  type PluginUIView,
   type SpawnDescriptor,
   type SpawnHook,
   type SpawnPatch,
 } from "./types";
+import { validatePluginUIView } from "./ui-validate";
 
 const DEFAULT_HOOK_TIMEOUT_MS = 5_000;
 
@@ -49,12 +51,13 @@ export interface PluginRegistryDeps {
   hookTimeoutMs?: number;
 }
 
-/** Internal per-plugin record. `health`/`lastError`/`status` back the status panel. */
+/** Internal per-plugin record. `health`/`lastError`/`status`/`ui` back the status panel. */
 interface LoadedPlugin {
   manifest: PluginManifest;
   health: PluginInfo["health"];
   lastError: string | null;
   status: unknown;
+  ui: PluginUIView | null;
   hooks: SpawnHook[];
   routes: Map<string, PluginRouteHandler>;
   unsubs: Array<() => void>;
@@ -159,6 +162,7 @@ export class PluginRegistry {
         health: "errored",
         lastError: `apiVersion ${manifest.apiVersion} != supported ${PLUGIN_API_VERSION}`,
         status: null,
+        ui: null,
         hooks: [],
         routes: new Map(),
         unsubs: [],
@@ -176,6 +180,7 @@ export class PluginRegistry {
       health: "ok",
       lastError: null,
       status: null,
+      ui: null,
       hooks: [],
       routes: new Map(),
       unsubs: [],
@@ -274,6 +279,22 @@ export class PluginRegistry {
         rec.status = status;
         this.emitStatus(rec);
       },
+      publishUI: (view) => {
+        if (view === null) {
+          rec.ui = null;
+          this.emitUI(rec);
+          return;
+        }
+        const v = validatePluginUIView(view);
+        if (v === null) {
+          console.warn(
+            `[plugins] ${id} publishUI rejected an invalid view (dropped; prior view kept)`,
+          );
+          return; // leave rec.ui unchanged — fail-open, never crash the panel
+        }
+        rec.ui = v;
+        this.emitUI(rec);
+      },
       state,
       route: (method, path, handler) => {
         rec.routes.set(routeKey(method, path), handler);
@@ -309,6 +330,11 @@ export class PluginRegistry {
       health: rec.health,
       status: rec.status,
     });
+  }
+
+  /** Emit a `plugin:ui` event carrying this plugin's last validated UI view (or null). */
+  private emitUI(rec: LoadedPlugin): void {
+    this.deps.events.emit("plugin:ui", { id: rec.manifest.id, ui: rec.ui });
   }
 
   /** Invoke one hook, timeout-bounded. Returns its patch, or null on a fail-open
@@ -371,6 +397,7 @@ export class PluginRegistry {
       health: r.health,
       lastError: r.lastError,
       status: r.status,
+      ui: r.ui,
     }));
   }
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -280,7 +280,8 @@ export class PluginRegistry {
         this.emitStatus(rec);
       },
       publishUI: (view) => {
-        if (view === null) {
+        // Treat both null and undefined as "clear the view".
+        if (view == null) {
           rec.ui = null;
           this.emitUI(rec);
           return;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -88,6 +88,9 @@ export interface PluginContext {
   events: { subscribe(fn: (event: string, data: unknown) => void): () => void };
   /** Push a small free-form JSON blob to the status panel (rendered verbatim). */
   publishStatus(status: unknown): void;
+  /** Push a declarative UI view to the status panel (issue #1185); `null` clears it.
+   *  Additive — plugins guard with `typeof ctx.publishUI === "function"`. */
+  publishUI(view: PluginUIView | null): void;
   /** Durable, scoped per-plugin key/value (backed by the `plugin_state` table). */
   state: PluginState;
   /** Register an HTTP route under the fixed `/api/plugins/<id>/<path>` namespace. */
@@ -119,6 +122,28 @@ export class PluginSpawnAborted extends Error {
   }
 }
 
+/** One node in a plugin-authored declarative UI descriptor (issue #1185). `type` must
+ *  match a host registry key, else the UI renders a fallback tile. `props` are
+ *  JSON-serializable only; string props render VERBATIM (plugin-authored DATA, never an
+ *  i18n key — consistent with the verbatim-data rule for tool-use summaries / PR titles). */
+export interface PluginUINode {
+  type: string;
+  props?: Record<string, unknown>;
+  children?: PluginUINode[];
+}
+
+/** A declarative UI view a plugin pushes via `ctx.publishUI` (issue #1185). Rendered by the
+ *  host from a whitelisted Svelte registry (Server-Driven-UI). Display-only in v1. */
+export interface PluginUIView {
+  schemaVersion: 1;
+  /** Contribution point. Only `settings-panel` is host-wired in v1; the others are
+   *  reserved (validator accepts them, but the Settings panel renders only settings-panel). */
+  slot: "settings-panel" | "session-sidebar" | "dashboard-card";
+  /** Optional panel heading — verbatim plugin-authored text, NOT an i18n key. */
+  title?: string;
+  root: PluginUINode;
+}
+
 /** Panel/list view of a loaded plugin — core-derived health is authoritative. */
 export interface PluginInfo {
   id: string;
@@ -129,4 +154,6 @@ export interface PluginInfo {
   lastError: string | null;
   /** Last `publishStatus` blob (verbatim plugin-authored JSON), or null. */
   status: unknown;
+  /** Last `publishUI` view (validated/normalized), or null. */
+  ui: PluginUIView | null;
 }

--- a/src/plugins/ui-validate.ts
+++ b/src/plugins/ui-validate.ts
@@ -12,6 +12,35 @@ const MAX_DEPTH = 16; // max nesting depth (root = depth 1)
 
 const VALID_SLOTS = new Set<string>(["settings-panel", "session-sidebar", "dashboard-card"]);
 
+function isPlainObject(x: unknown): x is Record<string, unknown> {
+  return !!x && typeof x === "object" && !Array.isArray(x);
+}
+
+/** True when no array value in `props` exceeds MAX_ARRAY. */
+function propsWithinBounds(props: Record<string, unknown>): boolean {
+  for (const val of Object.values(props)) {
+    if (Array.isArray(val) && val.length > MAX_ARRAY) return false;
+  }
+  return true;
+}
+
+/** Recursively validate one node (re-parsed JSON) against the structural caps.
+ *  `counter` accumulates the total node count across the whole tree. */
+function validateNode(node: unknown, depth: number, counter: { n: number }): boolean {
+  if (depth > MAX_DEPTH) return false;
+  if (!isPlainObject(node)) return false;
+  if (++counter.n > MAX_NODES) return false;
+  if (typeof node["type"] !== "string" || node["type"].length === 0) return false;
+
+  const props = node["props"];
+  if (props !== undefined && (!isPlainObject(props) || !propsWithinBounds(props))) return false;
+
+  const children = node["children"];
+  if (children === undefined) return true;
+  if (!Array.isArray(children) || children.length > MAX_ARRAY) return false;
+  return children.every((child) => validateNode(child, depth + 1, counter));
+}
+
 /** Validate and normalize a plugin-authored UI view descriptor.
  *  Returns the re-parsed (normalized) PluginUIView on success, or null if invalid.
  *  NEVER throws — invalid publishUI calls are dropped fail-open. */
@@ -31,78 +60,11 @@ export function validatePluginUIView(view: unknown): PluginUIView | null {
   // 2. Byte-size cap: rejects a buggy huge single node.
   if (Buffer.byteLength(s, "utf8") > MAX_BYTES) return null;
 
-  // 3. Re-parse (normalizes away non-JSON props) then walk the tree once.
+  // 3. Re-parse (normalizes away non-JSON props) then validate shape + tree.
   const parsed = JSON.parse(s) as unknown;
+  if (!isPlainObject(parsed)) return null;
+  if (parsed["schemaVersion"] !== 1) return null;
+  if (typeof parsed["slot"] !== "string" || !VALID_SLOTS.has(parsed["slot"])) return null;
 
-  // Top-level shape.
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
-  const v = parsed as Record<string, unknown>;
-  if (v["schemaVersion"] !== 1) return null;
-  if (typeof v["slot"] !== "string" || !VALID_SLOTS.has(v["slot"])) return null;
-  if (!v["root"] || typeof v["root"] !== "object" || Array.isArray(v["root"])) return null;
-
-  // Walk the tree collecting violations; short-circuit on first.
-  const violations: string[] = [];
-  let nodeCount = 0;
-
-  function walkNode(node: unknown, depth: number): void {
-    if (violations.length > 0) return;
-
-    if (!node || typeof node !== "object" || Array.isArray(node)) {
-      violations.push("node must be a plain object");
-      return;
-    }
-
-    nodeCount++;
-    if (nodeCount > MAX_NODES) {
-      violations.push(`node count exceeds ${MAX_NODES}`);
-      return;
-    }
-    if (depth > MAX_DEPTH) {
-      violations.push(`depth exceeds ${MAX_DEPTH}`);
-      return;
-    }
-
-    const n = node as Record<string, unknown>;
-
-    if (typeof n["type"] !== "string" || n["type"].length === 0) {
-      violations.push("node.type must be a non-empty string");
-      return;
-    }
-
-    if (n["props"] !== undefined) {
-      const props = n["props"];
-      if (!props || typeof props !== "object" || Array.isArray(props)) {
-        violations.push("node.props must be a plain object");
-        return;
-      }
-      for (const val of Object.values(props as Record<string, unknown>)) {
-        if (Array.isArray(val) && val.length > MAX_ARRAY) {
-          violations.push(`props array length exceeds ${MAX_ARRAY}`);
-          return;
-        }
-      }
-    }
-
-    if (n["children"] !== undefined) {
-      const children = n["children"];
-      if (!Array.isArray(children)) {
-        violations.push("node.children must be an array");
-        return;
-      }
-      if (children.length > MAX_ARRAY) {
-        violations.push(`children array length exceeds ${MAX_ARRAY}`);
-        return;
-      }
-      for (const child of children) {
-        if (violations.length > 0) return;
-        walkNode(child, depth + 1);
-      }
-    }
-  }
-
-  walkNode(v["root"], 1);
-  if (violations.length > 0) return null;
-
-  return parsed as PluginUIView;
+  return validateNode(parsed["root"], 1, { n: 0 }) ? (parsed as unknown as PluginUIView) : null;
 }

--- a/src/plugins/ui-validate.ts
+++ b/src/plugins/ui-validate.ts
@@ -1,0 +1,108 @@
+// Seam validator for plugin-authored declarative UI descriptors (issue #1185).
+// Never throws; returns a normalized PluginUIView (re-parsed JSON) or null (invalid).
+
+import type { PluginUIView } from "./types";
+
+/** Guards against a *buggy* (not malicious) trusted plugin — sizes are generous
+ *  enough for a rich panel, small enough to catch runaway generators. */
+const MAX_BYTES = 64 * 1024; // 64 KB JSON ceiling
+const MAX_ARRAY = 500; // max length of any props array or children array
+const MAX_NODES = 256; // max total nodes in the tree
+const MAX_DEPTH = 16; // max nesting depth (root = depth 1)
+
+const VALID_SLOTS = new Set<string>(["settings-panel", "session-sidebar", "dashboard-card"]);
+
+/** Validate and normalize a plugin-authored UI view descriptor.
+ *  Returns the re-parsed (normalized) PluginUIView on success, or null if invalid.
+ *  NEVER throws — invalid publishUI calls are dropped fail-open. */
+export function validatePluginUIView(view: unknown): PluginUIView | null {
+  // 1. Serializability via JSON.stringify: catches cycles/BigInt (they throw).
+  //    Functions/undefined/symbols are silently stripped; the stored view is the
+  //    re-parsed form so those props are dropped, not rejected.
+  let s: string;
+  try {
+    const raw = JSON.stringify(view);
+    if (raw === undefined) return null;
+    s = raw;
+  } catch {
+    return null;
+  }
+
+  // 2. Byte-size cap: rejects a buggy huge single node.
+  if (Buffer.byteLength(s, "utf8") > MAX_BYTES) return null;
+
+  // 3. Re-parse (normalizes away non-JSON props) then walk the tree once.
+  const parsed = JSON.parse(s) as unknown;
+
+  // Top-level shape.
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const v = parsed as Record<string, unknown>;
+  if (v["schemaVersion"] !== 1) return null;
+  if (typeof v["slot"] !== "string" || !VALID_SLOTS.has(v["slot"])) return null;
+  if (!v["root"] || typeof v["root"] !== "object" || Array.isArray(v["root"])) return null;
+
+  // Walk the tree collecting violations; short-circuit on first.
+  const violations: string[] = [];
+  let nodeCount = 0;
+
+  function walkNode(node: unknown, depth: number): void {
+    if (violations.length > 0) return;
+
+    if (!node || typeof node !== "object" || Array.isArray(node)) {
+      violations.push("node must be a plain object");
+      return;
+    }
+
+    nodeCount++;
+    if (nodeCount > MAX_NODES) {
+      violations.push(`node count exceeds ${MAX_NODES}`);
+      return;
+    }
+    if (depth > MAX_DEPTH) {
+      violations.push(`depth exceeds ${MAX_DEPTH}`);
+      return;
+    }
+
+    const n = node as Record<string, unknown>;
+
+    if (typeof n["type"] !== "string" || n["type"].length === 0) {
+      violations.push("node.type must be a non-empty string");
+      return;
+    }
+
+    if (n["props"] !== undefined) {
+      const props = n["props"];
+      if (!props || typeof props !== "object" || Array.isArray(props)) {
+        violations.push("node.props must be a plain object");
+        return;
+      }
+      for (const val of Object.values(props as Record<string, unknown>)) {
+        if (Array.isArray(val) && val.length > MAX_ARRAY) {
+          violations.push(`props array length exceeds ${MAX_ARRAY}`);
+          return;
+        }
+      }
+    }
+
+    if (n["children"] !== undefined) {
+      const children = n["children"];
+      if (!Array.isArray(children)) {
+        violations.push("node.children must be an array");
+        return;
+      }
+      if (children.length > MAX_ARRAY) {
+        violations.push(`children array length exceeds ${MAX_ARRAY}`);
+        return;
+      }
+      for (const child of children) {
+        if (violations.length > 0) return;
+        walkNode(child, depth + 1);
+      }
+    }
+  }
+
+  walkNode(v["root"], 1);
+  if (violations.length > 0) return null;
+
+  return parsed as PluginUIView;
+}

--- a/test/plugins-ui.test.ts
+++ b/test/plugins-ui.test.ts
@@ -1,0 +1,236 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionStore } from "../src/store";
+import { EventHub } from "../src/events";
+import { PluginRegistry } from "../src/plugins/loader";
+import { validatePluginUIView } from "../src/plugins/ui-validate";
+import type { PluginUINode, PluginUIView } from "../src/plugins/types";
+
+function tmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "shep-plugins-ui-"));
+}
+
+function writePlugin(root: string, id: string, opts: { index?: string } = {}): void {
+  const dir = join(root, id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "plugin.json"),
+    JSON.stringify({ id, name: id, version: "1.0.0", apiVersion: 1 }),
+  );
+  if (opts.index !== undefined) writeFileSync(join(dir, "index.js"), opts.index);
+}
+
+function makeRegistry(pluginsDir: string) {
+  const store = new SessionStore(":memory:");
+  const events = new EventHub();
+  const registry = new PluginRegistry({ pluginsDir, store, events });
+  return { registry, store, events };
+}
+
+// ── validator unit tests ─────────────────────────────────────────────────────
+
+test("validatePluginUIView: valid minimal view round-trips and normalizes", () => {
+  const view: PluginUIView = {
+    schemaVersion: 1,
+    slot: "settings-panel",
+    root: { type: "Label", props: { text: "hello" } },
+  };
+  expect(validatePluginUIView(view)).toEqual(view);
+});
+
+test("validatePluginUIView: non-object / null / array returns null", () => {
+  expect(validatePluginUIView(null)).toBeNull();
+  expect(validatePluginUIView("string")).toBeNull();
+  expect(validatePluginUIView(42)).toBeNull();
+  expect(validatePluginUIView([])).toBeNull();
+});
+
+test("validatePluginUIView: missing root returns null", () => {
+  expect(validatePluginUIView({ schemaVersion: 1, slot: "settings-panel" })).toBeNull();
+});
+
+test("validatePluginUIView: wrong schemaVersion returns null", () => {
+  expect(
+    validatePluginUIView({ schemaVersion: 2, slot: "settings-panel", root: { type: "X" } }),
+  ).toBeNull();
+  expect(
+    validatePluginUIView({ schemaVersion: "1", slot: "settings-panel", root: { type: "X" } }),
+  ).toBeNull();
+});
+
+test("validatePluginUIView: unknown or missing slot returns null", () => {
+  expect(
+    validatePluginUIView({ schemaVersion: 1, slot: "unknown-slot", root: { type: "X" } }),
+  ).toBeNull();
+  expect(validatePluginUIView({ schemaVersion: 1, slot: null, root: { type: "X" } })).toBeNull();
+});
+
+test("validatePluginUIView: all valid slots are accepted", () => {
+  for (const slot of ["settings-panel", "session-sidebar", "dashboard-card"] as const) {
+    expect(validatePluginUIView({ schemaVersion: 1, slot, root: { type: "X" } })).not.toBeNull();
+  }
+});
+
+test("validatePluginUIView: view exceeding 64 KB returns null", () => {
+  const big = {
+    schemaVersion: 1,
+    slot: "settings-panel",
+    root: { type: "Label", props: { text: "x".repeat(70_000) } },
+  };
+  expect(validatePluginUIView(big)).toBeNull();
+});
+
+test("validatePluginUIView: props array > 500 entries returns null", () => {
+  const big = {
+    schemaVersion: 1,
+    slot: "settings-panel",
+    root: { type: "Table", props: { rows: Array(501).fill({ v: 1 }) } },
+  };
+  expect(validatePluginUIView(big)).toBeNull();
+});
+
+test("validatePluginUIView: children array > 500 entries returns null", () => {
+  const big = {
+    schemaVersion: 1,
+    slot: "settings-panel",
+    root: { type: "List", children: Array(501).fill({ type: "Item" }) },
+  };
+  expect(validatePluginUIView(big)).toBeNull();
+});
+
+test("validatePluginUIView: depth > 16 returns null", () => {
+  // Build a tree 17 levels deep (root = depth 1, leaf = depth 17).
+  let node: PluginUINode = { type: "Leaf" };
+  for (let i = 0; i < 16; i++) {
+    node = { type: "Container", children: [node] };
+  }
+  expect(validatePluginUIView({ schemaVersion: 1, slot: "settings-panel", root: node })).toBeNull();
+});
+
+test("validatePluginUIView: depth 16 is accepted", () => {
+  // Build a tree 16 levels deep (root = depth 1, leaf = depth 16).
+  let node: PluginUINode = { type: "Leaf" };
+  for (let i = 0; i < 15; i++) {
+    node = { type: "Container", children: [node] };
+  }
+  expect(
+    validatePluginUIView({ schemaVersion: 1, slot: "settings-panel", root: node }),
+  ).not.toBeNull();
+});
+
+test("validatePluginUIView: node count > 256 returns null", () => {
+  // Root + 256 children = 257 nodes total → rejected.
+  const children = Array(256).fill({ type: "Item" });
+  expect(
+    validatePluginUIView({
+      schemaVersion: 1,
+      slot: "settings-panel",
+      root: { type: "List", children },
+    }),
+  ).toBeNull();
+});
+
+test("validatePluginUIView: node count 256 is accepted", () => {
+  // Root + 255 children = 256 nodes total → accepted.
+  const children = Array(255).fill({ type: "Item" });
+  expect(
+    validatePluginUIView({
+      schemaVersion: 1,
+      slot: "settings-panel",
+      root: { type: "List", children },
+    }),
+  ).not.toBeNull();
+});
+
+test("validatePluginUIView: cyclic object returns null (does not throw)", () => {
+  const o: Record<string, unknown> = {
+    schemaVersion: 1,
+    slot: "settings-panel",
+    root: { type: "Panel", props: {} },
+  };
+  (o["root"] as Record<string, unknown>)["props"] = { self: o };
+  expect(() => validatePluginUIView(o)).not.toThrow();
+  expect(validatePluginUIView(o)).toBeNull();
+});
+
+test("validatePluginUIView: function prop is accepted but stripped from result", () => {
+  const view = {
+    schemaVersion: 1,
+    slot: "settings-panel",
+    root: { type: "Button", props: { label: "click", onClick: () => {} } },
+  };
+  const result = validatePluginUIView(view);
+  expect(result).not.toBeNull();
+  expect(result!.root.props?.["onClick"]).toBeUndefined();
+  expect(result!.root.props?.["label"]).toBe("click");
+});
+
+// ── loader integration tests ─────────────────────────────────────────────────
+
+test("publishUI: valid view sets list().ui and emits plugin:ui event", async () => {
+  const root = tmpDir();
+  const view = {
+    schemaVersion: 1,
+    slot: "settings-panel",
+    root: { type: "Label", props: { text: "hi" } },
+  };
+  writePlugin(root, "ui-pub", {
+    index: `export function register(ctx) { ctx.publishUI(${JSON.stringify(view)}); }`,
+  });
+  const { registry, events } = makeRegistry(root);
+  const uiEvents: Array<{ id: string; ui: unknown }> = [];
+  events.subscribe((event, data) => {
+    if (event === "plugin:ui") uiEvents.push(data as { id: string; ui: unknown });
+  });
+  await registry.loadAll();
+  const info = registry.list().find((p) => p.id === "ui-pub")!;
+  expect(info.ui).toEqual(view);
+  expect(uiEvents).toContainEqual({ id: "ui-pub", ui: view });
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("publishUI(null): clears list().ui to null and emits", async () => {
+  const root = tmpDir();
+  const view = { schemaVersion: 1, slot: "settings-panel", root: { type: "Label" } };
+  writePlugin(root, "ui-null", {
+    index: `export function register(ctx) {
+      ctx.publishUI(${JSON.stringify(view)});
+      ctx.publishUI(null);
+    }`,
+  });
+  const { registry, events } = makeRegistry(root);
+  const uiEvents: Array<{ id: string; ui: unknown }> = [];
+  events.subscribe((event, data) => {
+    if (event === "plugin:ui") uiEvents.push(data as { id: string; ui: unknown });
+  });
+  await registry.loadAll();
+  expect(registry.list().find((p) => p.id === "ui-null")!.ui).toBeNull();
+  expect(uiEvents.at(-1)).toEqual({ id: "ui-null", ui: null });
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("publishUI: invalid view is dropped; prior view retained", async () => {
+  const root = tmpDir();
+  const good = { schemaVersion: 1, slot: "settings-panel", root: { type: "Label" } };
+  writePlugin(root, "ui-drop", {
+    index: `export function register(ctx) {
+      ctx.publishUI(${JSON.stringify(good)});
+      ctx.publishUI({ schemaVersion: 99 }); // invalid — dropped, prior kept
+    }`,
+  });
+  const { registry } = makeRegistry(root);
+  await registry.loadAll();
+  expect(registry.list().find((p) => p.id === "ui-drop")!.ui).toEqual(good);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("publishUI: plugin that never calls publishUI has ui === null (back-compat)", async () => {
+  const root = tmpDir();
+  writePlugin(root, "ui-none", { index: "export function register(ctx) {}" });
+  const { registry } = makeRegistry(root);
+  await registry.loadAll();
+  expect(registry.list().find((p) => p.id === "ui-none")!.ui).toBeNull();
+  rmSync(root, { recursive: true, force: true });
+});

--- a/test/plugins-ui.test.ts
+++ b/test/plugins-ui.test.ts
@@ -175,7 +175,7 @@ test("publishUI: valid view sets list().ui and emits plugin:ui event", async () 
     schemaVersion: 1,
     slot: "settings-panel",
     root: { type: "Label", props: { text: "hi" } },
-  };
+  } satisfies PluginUIView;
   writePlugin(root, "ui-pub", {
     index: `export function register(ctx) { ctx.publishUI(${JSON.stringify(view)}); }`,
   });
@@ -213,7 +213,11 @@ test("publishUI(null): clears list().ui to null and emits", async () => {
 
 test("publishUI: invalid view is dropped; prior view retained", async () => {
   const root = tmpDir();
-  const good = { schemaVersion: 1, slot: "settings-panel", root: { type: "Label" } };
+  const good = {
+    schemaVersion: 1,
+    slot: "settings-panel",
+    root: { type: "Label" },
+  } satisfies PluginUIView;
   writePlugin(root, "ui-drop", {
     index: `export function register(ctx) {
       ctx.publishUI(${JSON.stringify(good)});
@@ -232,5 +236,25 @@ test("publishUI: plugin that never calls publishUI has ui === null (back-compat)
   const { registry } = makeRegistry(root);
   await registry.loadAll();
   expect(registry.list().find((p) => p.id === "ui-none")!.ui).toBeNull();
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("publishUI(undefined): clears list().ui to null and emits (nullish clear)", async () => {
+  const root = tmpDir();
+  const view = { schemaVersion: 1, slot: "settings-panel", root: { type: "Label" } };
+  writePlugin(root, "ui-undef", {
+    index: `export function register(ctx) {
+      ctx.publishUI(${JSON.stringify(view)});
+      ctx.publishUI(undefined);
+    }`,
+  });
+  const { registry, events } = makeRegistry(root);
+  const uiEvents: Array<{ id: string; ui: unknown }> = [];
+  events.subscribe((event, data) => {
+    if (event === "plugin:ui") uiEvents.push(data as { id: string; ui: unknown });
+  });
+  await registry.loadAll();
+  expect(registry.list().find((p) => p.id === "ui-undef")!.ui).toBeNull();
+  expect(uiEvents.at(-1)).toEqual({ id: "ui-undef", ui: null });
   rmSync(root, { recursive: true, force: true });
 });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2101,5 +2101,8 @@
   "feat_add_repo_title": "Repo aus dem Backlog hinzufügen",
   "feat_add_repo_body": "Der Repo-Bereich im Backlog hat jetzt einen Button „+ Repo hinzufügen“ — neues Projekt anlegen, klonen oder ein Repo forken, ohne die Browse-Ansicht zu verlassen oder die Kommandozeile zu öffnen. Das neue Repo wird automatisch ausgewählt, sobald es bereit ist.",
   "backlog_add_repo": "+ Repo hinzufügen",
-  "backlog_add_repo_menu": "Repository hinzufügen"
+  "backlog_add_repo_menu": "Repository hinzufügen",
+  "plugin_ui_unknown_node": "Nicht unterstützte Komponente",
+  "plugin_ui_table_empty": "Keine Daten.",
+  "plugin_ui_kv_empty": "Keine Einträge."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2104,5 +2104,8 @@
   "backlog_add_repo_menu": "Repository hinzufügen",
   "plugin_ui_unknown_node": "Nicht unterstützte Komponente",
   "plugin_ui_table_empty": "Keine Daten.",
-  "plugin_ui_kv_empty": "Keine Einträge."
+  "plugin_ui_kv_empty": "Keine Einträge.",
+  "plugins_raw_json": "Rohdaten",
+  "feat_plugin_ui_title": "Plugins zeigen echte Panels",
+  "feat_plugin_ui_body": "Plugins können jetzt Kontingentmesser, Status-Badges und Tabellen in Einstellungen → Plugins anzeigen – anstelle eines rohen JSON-Dumps."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2104,5 +2104,8 @@
   "backlog_add_repo_menu": "Add a repository",
   "plugin_ui_unknown_node": "Unsupported component",
   "plugin_ui_table_empty": "No data.",
-  "plugin_ui_kv_empty": "No entries."
+  "plugin_ui_kv_empty": "No entries.",
+  "plugins_raw_json": "Raw data",
+  "feat_plugin_ui_title": "Plugins show real panels",
+  "feat_plugin_ui_body": "Plugins can now render quota meters, status badges and tables in Settings → Plugins instead of a raw JSON dump."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2101,5 +2101,8 @@
   "feat_add_repo_title": "Add a repo from the Backlog",
   "feat_add_repo_body": "The Backlog repos panel now has a \"+ Add repo\" button — create a new project, clone, or fork a repo without leaving the browse view or touching the command line. The new repo is selected automatically when it's ready.",
   "backlog_add_repo": "+ Add repo",
-  "backlog_add_repo_menu": "Add a repository"
+  "backlog_add_repo_menu": "Add a repository",
+  "plugin_ui_unknown_node": "Unsupported component",
+  "plugin_ui_table_empty": "No data.",
+  "plugin_ui_kv_empty": "No entries."
 }

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -205,6 +205,7 @@ describe("Settings responsive tab navigation", () => {
       health: "ok" as const,
       lastError: null,
       status: {},
+      ui: null,
     },
   ];
 

--- a/ui/src/lib/components/settings/SettingsPluginsPanel.browser.test.ts
+++ b/ui/src/lib/components/settings/SettingsPluginsPanel.browser.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../../app.css";
+import SettingsPluginsPanel from "./SettingsPluginsPanel.svelte";
+import type { PluginInfo } from "$lib/types";
+
+function plugin(overrides: Partial<PluginInfo> = {}): PluginInfo {
+  return {
+    id: "p1",
+    name: "Test Plugin",
+    version: "1.0.0",
+    health: "ok",
+    lastError: null,
+    status: { key: "value" },
+    ui: null,
+    ...overrides,
+  };
+}
+
+describe("SettingsPluginsPanel", () => {
+  it("renders a settings-panel view always-visible (no click needed)", async () => {
+    render(SettingsPluginsPanel, {
+      plugins: [
+        plugin({
+          ui: {
+            schemaVersion: 1,
+            slot: "settings-panel",
+            title: "Quota Info",
+            root: { type: "text", props: { value: "95 % used" } },
+          },
+        }),
+      ],
+    });
+    // The rendered view text is visible without expanding
+    await expect.element(page.getByText("95 % used")).toBeVisible();
+    // The view title (verbatim plugin text) is visible
+    await expect.element(page.getByText("Quota Info")).toBeVisible();
+  });
+
+  it("raw JSON is hidden until expand for a view-bearing plugin", async () => {
+    render(SettingsPluginsPanel, {
+      plugins: [
+        plugin({
+          status: { secret: 99 },
+          ui: {
+            schemaVersion: 1,
+            slot: "settings-panel",
+            root: { type: "text", props: { value: "panel content" } },
+          },
+        }),
+      ],
+    });
+    // Status JSON must NOT be visible before expanding
+    expect(document.querySelector("pre")).toBeNull();
+
+    // Expand via the toggle button
+    await page.getByRole("button").click();
+    // Now raw JSON dump appears (status value is present)
+    await expect.element(page.getByText(/"secret": 99/)).toBeInTheDocument();
+  });
+
+  it("null-ui plugin shows JSON dump behind toggle (back-compat)", async () => {
+    render(SettingsPluginsPanel, {
+      plugins: [plugin({ ui: null, status: { n: 42 } })],
+    });
+    // JSON is hidden initially
+    expect(document.querySelector("pre")).toBeNull();
+
+    // Click expand
+    await page.getByRole("button").click();
+    // Status dump now visible
+    await expect.element(page.getByText(/"n": 42/)).toBeInTheDocument();
+  });
+
+  it("slot-gated: session-sidebar ui does NOT render the view (falls back to JSON path)", async () => {
+    render(SettingsPluginsPanel, {
+      plugins: [
+        plugin({
+          ui: {
+            schemaVersion: 1,
+            slot: "session-sidebar",
+            root: { type: "text", props: { value: "sidebar only content" } },
+          },
+          status: { side: true },
+        }),
+      ],
+    });
+    // The sidebar view text must NOT appear (slot gate)
+    expect(document.body.textContent).not.toContain("sidebar only content");
+
+    // JSON is behind the toggle (falls back to status dump)
+    expect(document.querySelector("pre")).toBeNull();
+    await page.getByRole("button").click();
+    await expect.element(page.getByText(/"side": true/)).toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/components/settings/SettingsPluginsPanel.svelte
+++ b/ui/src/lib/components/settings/SettingsPluginsPanel.svelte
@@ -59,7 +59,11 @@
         </div>
         {#if expanded[p.id]}
           <p class="raw-label micro">{m.plugins_raw_json()}</p>
-          <pre class="status">{pretty(p.status)}</pre>
+          {#if p.status != null}
+            <pre class="status">{pretty(p.status)}</pre>
+          {:else}
+            <p class="empty micro">{m.plugins_no_status()}</p>
+          {/if}
         {/if}
       {:else}
         {#if expanded[p.id]}

--- a/ui/src/lib/components/settings/SettingsPluginsPanel.svelte
+++ b/ui/src/lib/components/settings/SettingsPluginsPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { m } from "$lib/paraglide/messages";
-  import type { PluginInfo } from "$lib/types";
+  import type { PluginInfo, PluginUIView } from "$lib/types";
+  import PluginUIRenderer from "$lib/plugin-ui/PluginUIRenderer.svelte";
 
   let { plugins = [] }: { plugins?: PluginInfo[] } = $props();
 
@@ -12,7 +13,7 @@
     errored: { color: "var(--color-red)", label: m.plugins_health_errored },
   };
 
-  // Which rows are expanded to show the published status blob.
+  // Which rows are expanded to show the published status blob / raw-JSON debug dump.
   let expanded = $state<Record<string, boolean>>({});
 
   function pretty(status: unknown): string {
@@ -22,12 +23,18 @@
       return String(status);
     }
   }
+
+  /** Returns the view only when it targets this panel's slot. */
+  function panelView(p: PluginInfo): PluginUIView | null {
+    return p.ui && p.ui.slot === "settings-panel" ? p.ui : null;
+  }
 </script>
 
 <div class="plugins">
   <p class="intro micro">{m.plugins_intro()}</p>
   {#each plugins as p (p.id)}
     {@const h = HEALTH[p.health]}
+    {@const view = panelView(p)}
     <div class="row">
       <button
         type="button"
@@ -43,11 +50,24 @@
       {#if p.lastError}
         <p class="err micro" title={p.lastError}>{m.plugins_last_error()}: {p.lastError}</p>
       {/if}
-      {#if expanded[p.id]}
-        {#if p.status !== null && p.status !== undefined}
+      {#if view}
+        {#if view.title}
+          <p class="view-title">{view.title}</p>
+        {/if}
+        <div class="view-body">
+          <PluginUIRenderer node={view.root} />
+        </div>
+        {#if expanded[p.id]}
+          <p class="raw-label micro">{m.plugins_raw_json()}</p>
           <pre class="status">{pretty(p.status)}</pre>
-        {:else}
-          <p class="empty micro">{m.plugins_no_status()}</p>
+        {/if}
+      {:else}
+        {#if expanded[p.id]}
+          {#if p.status !== null && p.status !== undefined}
+            <pre class="status">{pretty(p.status)}</pre>
+          {:else}
+            <p class="empty micro">{m.plugins_no_status()}</p>
+          {/if}
         {/if}
       {/if}
     </div>
@@ -105,6 +125,21 @@
   .empty {
     color: var(--color-muted);
     margin: 6px 0 0;
+  }
+  .view-title {
+    font-size: var(--fs-micro);
+    font-weight: 600;
+    color: var(--color-muted);
+    margin: 8px 0 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .view-body {
+    margin: 6px 0 0;
+  }
+  .raw-label {
+    color: var(--color-muted);
+    margin: 8px 0 2px;
   }
   .status {
     margin: 6px 0 0;

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1757,4 +1757,16 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_add_repo_title",
     bodyKey: "feat_add_repo_body",
   },
+  {
+    // Plugin UI descriptor (#1185): plugins can publishUI() a declarative view (meters,
+    // badges, tables, key-value) rendered from a whitelisted registry in Settings → Plugins,
+    // replacing the raw JSON dump. 1.37.0 is the latest released tag, so this ships in 1.38.0.
+    // No targetId — the Settings → Plugins tab is conditionally mounted (hidden when no
+    // plugins) and isn't a Coachmark arming host, so any targetId would be a dead anchor
+    // (same single-host limitation noted on backlog-add-repo); surface via What's-New only.
+    id: "plugin-ui-panels",
+    sinceVersion: "1.38.0",
+    titleKey: "feat_plugin_ui_title",
+    bodyKey: "feat_plugin_ui_body",
+  },
 ];

--- a/ui/src/lib/plugin-ui/PluginUIRenderer.browser.test.ts
+++ b/ui/src/lib/plugin-ui/PluginUIRenderer.browser.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import PluginUIRenderer from "./PluginUIRenderer.svelte";
+
+describe("PluginUIRenderer", () => {
+  it("dispatches a known type (text) to the correct component", async () => {
+    render(PluginUIRenderer, {
+      node: { type: "text", props: { value: "Hello plugin" } },
+    });
+    await expect.element(page.getByText("Hello plugin")).toBeInTheDocument();
+  });
+
+  it("renders UnknownNodeTile for an unknown type", async () => {
+    render(PluginUIRenderer, {
+      node: { type: "exotic-widget", props: {} },
+    });
+    await expect.element(page.getByText("Unsupported component")).toBeInTheDocument();
+    await expect.element(page.getByText("exotic-widget")).toBeInTheDocument();
+  });
+
+  it("renders a nested tree via PuiStack → PuiText", async () => {
+    render(PluginUIRenderer, {
+      node: {
+        type: "stack",
+        children: [
+          { type: "text", props: { value: "First" } },
+          { type: "text", props: { value: "Second" } },
+        ],
+      },
+    });
+    await expect.element(page.getByText("First")).toBeInTheDocument();
+    await expect.element(page.getByText("Second")).toBeInTheDocument();
+  });
+
+  it("renders callout node verbatim — no markdown parsing", async () => {
+    render(PluginUIRenderer, {
+      node: { type: "callout", props: { text: "**bold** stays literal" } },
+    });
+    await expect.element(page.getByText("**bold** stays literal")).toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/plugin-ui/PluginUIRenderer.browser.test.ts
+++ b/ui/src/lib/plugin-ui/PluginUIRenderer.browser.test.ts
@@ -40,4 +40,20 @@ describe("PluginUIRenderer", () => {
     });
     await expect.element(page.getByText("**bold** stays literal")).toBeInTheDocument();
   });
+
+  it("renders UnknownNodeTile for prototype key 'constructor' (not a crash)", async () => {
+    render(PluginUIRenderer, {
+      node: { type: "constructor", props: {} },
+    });
+    await expect.element(page.getByText("Unsupported component")).toBeInTheDocument();
+    await expect.element(page.getByText("constructor")).toBeInTheDocument();
+  });
+
+  it("renders UnknownNodeTile for prototype key 'toString' (not a crash)", async () => {
+    render(PluginUIRenderer, {
+      node: { type: "toString", props: {} },
+    });
+    await expect.element(page.getByText("Unsupported component")).toBeInTheDocument();
+    await expect.element(page.getByText("toString")).toBeInTheDocument();
+  });
 });

--- a/ui/src/lib/plugin-ui/PluginUIRenderer.svelte
+++ b/ui/src/lib/plugin-ui/PluginUIRenderer.svelte
@@ -4,7 +4,9 @@
   import UnknownNodeTile from "./UnknownNodeTile.svelte";
 
   let { node }: { node: PluginUINode } = $props();
-  const Comp = $derived(PLUGIN_UI_REGISTRY[node.type]);
+  const Comp = $derived(
+    Object.hasOwn(PLUGIN_UI_REGISTRY, node.type) ? PLUGIN_UI_REGISTRY[node.type] : undefined,
+  );
 </script>
 
 {#if Comp}<Comp {node} />{:else}<UnknownNodeTile type={node.type} />{/if}

--- a/ui/src/lib/plugin-ui/PluginUIRenderer.svelte
+++ b/ui/src/lib/plugin-ui/PluginUIRenderer.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { PluginUINode } from "$lib/types";
+  import { PLUGIN_UI_REGISTRY } from "./registry";
+  import UnknownNodeTile from "./UnknownNodeTile.svelte";
+
+  let { node }: { node: PluginUINode } = $props();
+  const Comp = $derived(PLUGIN_UI_REGISTRY[node.type]);
+</script>
+
+{#if Comp}<Comp {node} />{:else}<UnknownNodeTile type={node.type} />{/if}

--- a/ui/src/lib/plugin-ui/PuiBadge.browser.test.ts
+++ b/ui/src/lib/plugin-ui/PuiBadge.browser.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import PuiBadge from "./PuiBadge.svelte";
+
+describe("PuiBadge", () => {
+  it("renders the label text", async () => {
+    render(PuiBadge, {
+      node: { type: "badge", props: { label: "OPEN", tone: "neutral" } },
+    });
+    await expect.element(page.getByText("OPEN")).toBeInTheDocument();
+  });
+
+  it("applies ok tone color (green)", async () => {
+    const { container } = render(PuiBadge, {
+      node: { type: "badge", props: { label: "READY", tone: "ok" } },
+    });
+    const el = container.querySelector(".pui-badge") as HTMLElement | null;
+    expect(el?.style.color).toBe("var(--color-green)");
+  });
+
+  it("applies error tone color (red)", async () => {
+    const { container } = render(PuiBadge, {
+      node: { type: "badge", props: { label: "FAIL", tone: "error" } },
+    });
+    const el = container.querySelector(".pui-badge") as HTMLElement | null;
+    expect(el?.style.color).toBe("var(--color-red)");
+  });
+
+  it("applies warn tone color", async () => {
+    const { container } = render(PuiBadge, {
+      node: { type: "badge", props: { label: "CAUTION", tone: "warn" } },
+    });
+    const el = container.querySelector(".pui-badge") as HTMLElement | null;
+    expect(el?.style.color).toBe("var(--status-warn)");
+  });
+
+  it("defaults to neutral for unknown tone", async () => {
+    const { container } = render(PuiBadge, {
+      node: { type: "badge", props: { label: "X", tone: "bogus-tone" } },
+    });
+    const el = container.querySelector(".pui-badge") as HTMLElement | null;
+    expect(el?.style.color).toBe("var(--color-muted)");
+  });
+});

--- a/ui/src/lib/plugin-ui/PuiBadge.svelte
+++ b/ui/src/lib/plugin-ui/PuiBadge.svelte
@@ -26,5 +26,11 @@
 <style>
   .pui-badge {
     display: inline-block;
+    font-size: var(--fs-micro);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 1px 6px;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
   }
 </style>

--- a/ui/src/lib/plugin-ui/PuiBadge.svelte
+++ b/ui/src/lib/plugin-ui/PuiBadge.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import type { PluginUINode } from "$lib/types";
+
+  let { node }: { node: PluginUINode } = $props();
+
+  const p = $derived(node.props ?? {});
+  const label = $derived(String(p.label ?? ""));
+
+  type BadgeTone = "neutral" | "ok" | "warn" | "error" | "info";
+  const TONE_COLOR: Record<BadgeTone, string> = {
+    neutral: "var(--color-muted)",
+    ok: "var(--color-green)",
+    warn: "var(--status-warn)",
+    error: "var(--color-red)",
+    info: "var(--color-blue)",
+  };
+
+  const rawTone = $derived(p.tone as string | undefined);
+  const toneColor = $derived(
+    rawTone && rawTone in TONE_COLOR ? TONE_COLOR[rawTone as BadgeTone] : TONE_COLOR.neutral,
+  );
+</script>
+
+<span class="badge pui-badge" style:color={toneColor} style:border-color={toneColor}>{label}</span>
+
+<style>
+  .pui-badge {
+    display: inline-block;
+  }
+</style>

--- a/ui/src/lib/plugin-ui/PuiCallout.svelte
+++ b/ui/src/lib/plugin-ui/PuiCallout.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import type { PluginUINode } from "$lib/types";
+
+  let { node }: { node: PluginUINode } = $props();
+
+  const p = $derived(node.props ?? {});
+  const text = $derived(String(p.text ?? ""));
+
+  type CalloutTone = "info" | "warn" | "error";
+  const TONE_COLOR: Record<CalloutTone, string> = {
+    info: "var(--color-blue)",
+    warn: "var(--color-amber)",
+    error: "var(--color-red)",
+  };
+
+  const rawTone = $derived(p.tone as string | undefined);
+  const toneColor = $derived(
+    rawTone && rawTone in TONE_COLOR ? TONE_COLOR[rawTone as CalloutTone] : TONE_COLOR.info,
+  );
+</script>
+
+<div class="pui-callout" style:border-left-color={toneColor}>
+  <span class="pui-callout-text">{text}</span>
+</div>
+
+<style>
+  .pui-callout {
+    border-left: 3px solid var(--color-blue);
+    background: var(--color-inset);
+    padding: 8px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .pui-callout-text {
+    font-size: var(--fs-meta);
+    color: var(--color-ink);
+    line-height: 1.5;
+  }
+</style>

--- a/ui/src/lib/plugin-ui/PuiCallout.svelte
+++ b/ui/src/lib/plugin-ui/PuiCallout.svelte
@@ -9,7 +9,7 @@
   type CalloutTone = "info" | "warn" | "error";
   const TONE_COLOR: Record<CalloutTone, string> = {
     info: "var(--color-blue)",
-    warn: "var(--color-amber)",
+    warn: "var(--status-warn)",
     error: "var(--color-red)",
   };
 

--- a/ui/src/lib/plugin-ui/PuiKeyValue.browser.test.ts
+++ b/ui/src/lib/plugin-ui/PuiKeyValue.browser.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import PuiKeyValue from "./PuiKeyValue.svelte";
+
+describe("PuiKeyValue", () => {
+  it("renders key and value pairs", async () => {
+    render(PuiKeyValue, {
+      node: {
+        type: "key-value",
+        props: {
+          pairs: [
+            { key: "Version", value: "1.2.3" },
+            { key: "Status", value: "active" },
+          ],
+        },
+      },
+    });
+    await expect.element(page.getByText("Version")).toBeInTheDocument();
+    await expect.element(page.getByText("1.2.3")).toBeInTheDocument();
+    await expect.element(page.getByText("Status")).toBeInTheDocument();
+    await expect.element(page.getByText("active")).toBeInTheDocument();
+  });
+
+  it("shows empty state for empty pairs array", async () => {
+    render(PuiKeyValue, {
+      node: { type: "key-value", props: { pairs: [] } },
+    });
+    await expect.element(page.getByText("No entries.")).toBeInTheDocument();
+  });
+
+  it("handles missing props without throwing", () => {
+    expect(() => render(PuiKeyValue, { node: { type: "key-value" } })).not.toThrow();
+  });
+
+  it("coerces non-string values to string", async () => {
+    render(PuiKeyValue, {
+      node: {
+        type: "key-value",
+        props: { pairs: [{ key: "Count", value: 42 }] },
+      },
+    });
+    await expect.element(page.getByText("42")).toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/plugin-ui/PuiKeyValue.svelte
+++ b/ui/src/lib/plugin-ui/PuiKeyValue.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import type { PluginUINode } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+
+  let { node }: { node: PluginUINode } = $props();
+
+  const p = $derived(node.props ?? {});
+  const pairs = $derived(
+    Array.isArray(p.pairs)
+      ? (p.pairs as unknown[]).map((item) => {
+          const entry =
+            item != null && typeof item === "object" ? (item as Record<string, unknown>) : {};
+          return { key: String(entry.key ?? ""), value: String(entry.value ?? "") };
+        })
+      : [],
+  );
+</script>
+
+{#if pairs.length === 0}
+  <p class="pui-kv-empty">{m.plugin_ui_kv_empty()}</p>
+{:else}
+  <dl class="pui-kv">
+    {#each pairs as pair, i (i)}
+      <dt class="pui-kv-key">{pair.key}</dt>
+      <dd class="pui-kv-value">{pair.value}</dd>
+    {/each}
+  </dl>
+{/if}
+
+<style>
+  .pui-kv-empty {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    margin: 0;
+  }
+  .pui-kv {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    column-gap: 16px;
+    row-gap: 4px;
+    margin: 0;
+    font-size: var(--fs-meta);
+  }
+  .pui-kv-key {
+    font-weight: 600;
+    color: var(--color-muted);
+    font-size: var(--fs-micro);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    white-space: nowrap;
+    align-self: baseline;
+  }
+  .pui-kv-value {
+    color: var(--color-ink);
+    margin: 0;
+    align-self: baseline;
+    word-break: break-word;
+  }
+</style>

--- a/ui/src/lib/plugin-ui/PuiMeter.browser.test.ts
+++ b/ui/src/lib/plugin-ui/PuiMeter.browser.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import PuiMeter from "./PuiMeter.svelte";
+
+describe("PuiMeter", () => {
+  it("renders label and value/max", async () => {
+    render(PuiMeter, {
+      node: { type: "meter", props: { value: 42, max: 100, label: "Tokens" } },
+    });
+    await expect.element(page.getByText("Tokens")).toBeInTheDocument();
+    await expect.element(page.getByText("42/100")).toBeInTheDocument();
+  });
+
+  it("clamps value above max to 100%", async () => {
+    const { container } = render(PuiMeter, {
+      node: { type: "meter", props: { value: 200, max: 100 } },
+    });
+    const fill = container.querySelector(".pui-meter-fill") as HTMLElement | null;
+    expect(fill?.style.width).toBe("100%");
+  });
+
+  it("clamps negative value to 0%", async () => {
+    const { container } = render(PuiMeter, {
+      node: { type: "meter", props: { value: -10, max: 100 } },
+    });
+    const fill = container.querySelector(".pui-meter-fill") as HTMLElement | null;
+    expect(fill?.style.width).toBe("0%");
+  });
+
+  it("renders caption when provided", async () => {
+    render(PuiMeter, {
+      node: { type: "meter", props: { value: 50, caption: "Monthly limit" } },
+    });
+    await expect.element(page.getByText("Monthly limit")).toBeInTheDocument();
+  });
+
+  it("renders without label or caption", () => {
+    expect(() =>
+      render(PuiMeter, {
+        node: { type: "meter", props: { value: 50 } },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/ui/src/lib/plugin-ui/PuiMeter.svelte
+++ b/ui/src/lib/plugin-ui/PuiMeter.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  import type { PluginUINode } from "$lib/types";
+
+  let { node }: { node: PluginUINode } = $props();
+
+  const p = $derived(node.props ?? {});
+  const rawValue = $derived(Number(p.value ?? 0));
+  const max = $derived(Math.max(1, Number(p.max ?? 100)));
+  const label = $derived(p.label != null ? String(p.label) : null);
+  const caption = $derived(p.caption != null ? String(p.caption) : null);
+
+  // Clamp ratio to [0, 1]
+  const ratio = $derived(Math.min(1, Math.max(0, rawValue / max)));
+  const pct = $derived(Math.round(ratio * 100));
+
+  type MeterTone = "neutral" | "ok" | "warn" | "error" | "info";
+  const TONE_COLOR: Record<MeterTone, string> = {
+    neutral: "var(--color-muted)",
+    ok: "var(--color-green)",
+    warn: "var(--status-warn)",
+    error: "var(--color-red)",
+    info: "var(--color-blue)",
+  };
+
+  const rawTone = $derived(p.tone as string | undefined);
+  const barColor = $derived(
+    rawTone && rawTone in TONE_COLOR ? TONE_COLOR[rawTone as MeterTone] : TONE_COLOR.neutral,
+  );
+</script>
+
+<div class="pui-meter">
+  {#if label}
+    <div class="pui-meter-header">
+      <span class="pui-meter-label">{label}</span>
+      <span class="pui-meter-value" style:color={barColor}>{rawValue}/{max}</span>
+    </div>
+  {/if}
+  <div
+    class="pui-meter-track"
+    role="meter"
+    aria-valuenow={rawValue}
+    aria-valuemin={0}
+    aria-valuemax={max}
+  >
+    <div class="pui-meter-fill" style:width="{pct}%" style:background={barColor}></div>
+  </div>
+  {#if caption}
+    <span class="pui-meter-caption">{caption}</span>
+  {/if}
+</div>
+
+<style>
+  .pui-meter {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .pui-meter-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 8px;
+  }
+  .pui-meter-label {
+    font-size: var(--fs-meta);
+    color: var(--color-ink);
+    font-weight: 600;
+  }
+  .pui-meter-value {
+    font-size: var(--fs-micro);
+    font-variant-numeric: tabular-nums;
+  }
+  .pui-meter-track {
+    height: 6px;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    border-radius: 3px;
+    overflow: hidden;
+  }
+  .pui-meter-fill {
+    height: 100%;
+    border-radius: 3px;
+    transition: width 0.2s ease;
+  }
+  .pui-meter-caption {
+    font-size: var(--fs-micro);
+    color: var(--color-muted);
+  }
+</style>

--- a/ui/src/lib/plugin-ui/PuiMeter.svelte
+++ b/ui/src/lib/plugin-ui/PuiMeter.svelte
@@ -4,7 +4,10 @@
   let { node }: { node: PluginUINode } = $props();
 
   const p = $derived(node.props ?? {});
-  const rawValue = $derived(Number(p.value ?? 0));
+  const rawValue = $derived.by(() => {
+    const v = Number(p.value ?? 0);
+    return Number.isFinite(v) ? v : 0;
+  });
   const max = $derived(Math.max(1, Number(p.max ?? 100)));
   const label = $derived(p.label != null ? String(p.label) : null);
   const caption = $derived(p.caption != null ? String(p.caption) : null);
@@ -29,15 +32,16 @@
 </script>
 
 <div class="pui-meter">
-  {#if label}
+  {#if label != null || Number.isFinite(rawValue)}
     <div class="pui-meter-header">
-      <span class="pui-meter-label">{label}</span>
+      {#if label != null}<span class="pui-meter-label">{label}</span>{/if}
       <span class="pui-meter-value" style:color={barColor}>{rawValue}/{max}</span>
     </div>
   {/if}
   <div
     class="pui-meter-track"
     role="meter"
+    aria-label={label ?? caption ?? undefined}
     aria-valuenow={rawValue}
     aria-valuemin={0}
     aria-valuemax={max}

--- a/ui/src/lib/plugin-ui/PuiStack.svelte
+++ b/ui/src/lib/plugin-ui/PuiStack.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import type { PluginUINode } from "$lib/types";
+  import PluginUIRenderer from "./PluginUIRenderer.svelte";
+
+  let { node }: { node: PluginUINode } = $props();
+
+  const p = $derived(node.props ?? {});
+  const direction = $derived(
+    (p.direction as string | undefined) === "horizontal" ? "horizontal" : "vertical",
+  );
+  const gap = $derived(
+    (p.gap as string | undefined) === "sm"
+      ? "4px"
+      : (p.gap as string | undefined) === "lg"
+        ? "16px"
+        : "8px",
+  );
+  const children = $derived(Array.isArray(node.children) ? node.children : []);
+</script>
+
+<div
+  class="pui-stack"
+  style:flex-direction={direction === "horizontal" ? "row" : "column"}
+  style:gap
+>
+  {#each children as child, i (i)}
+    <PluginUIRenderer node={child} />
+  {/each}
+</div>
+
+<style>
+  .pui-stack {
+    display: flex;
+    flex-wrap: wrap;
+  }
+</style>

--- a/ui/src/lib/plugin-ui/PuiStack.svelte
+++ b/ui/src/lib/plugin-ui/PuiStack.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
   import type { PluginUINode } from "$lib/types";
+  // Intentional cycle: a stack recursively renders its children through the same
+  // renderer (registry → PuiStack → PluginUIRenderer → registry). This is the
+  // canonical recursive-component pattern for a tree renderer and Svelte resolves
+  // it at runtime; there is no non-deprecated way to recurse without the back-edge.
+  // fallow-ignore-next-line circular-dependency
   import PluginUIRenderer from "./PluginUIRenderer.svelte";
 
   let { node }: { node: PluginUINode } = $props();

--- a/ui/src/lib/plugin-ui/PuiTable.browser.test.ts
+++ b/ui/src/lib/plugin-ui/PuiTable.browser.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import PuiTable from "./PuiTable.svelte";
+
+describe("PuiTable", () => {
+  it("renders column headers", async () => {
+    render(PuiTable, {
+      node: {
+        type: "table",
+        props: {
+          columns: ["Name", "Status"],
+          rows: [["widget-a", "ok"]],
+        },
+      },
+    });
+    await expect.element(page.getByText("Name")).toBeInTheDocument();
+    await expect.element(page.getByText("Status")).toBeInTheDocument();
+  });
+
+  it("renders row cells", async () => {
+    const { container } = render(PuiTable, {
+      node: {
+        type: "table",
+        props: {
+          columns: ["Key", "Val"],
+          rows: [["host", "localhost"]],
+        },
+      },
+    });
+    const cells = Array.from(container.querySelectorAll(".pui-td"));
+    const texts = cells.map((c) => c.textContent ?? "");
+    expect(texts).toContain("host");
+    expect(texts).toContain("localhost");
+  });
+
+  it("shows empty state when no columns and no rows", async () => {
+    render(PuiTable, {
+      node: { type: "table", props: { columns: [], rows: [] } },
+    });
+    await expect.element(page.getByText("No data.")).toBeInTheDocument();
+  });
+
+  it("handles ragged rows without throwing", () => {
+    expect(() =>
+      render(PuiTable, {
+        node: {
+          type: "table",
+          props: { columns: ["A", "B", "C"], rows: [["only-one"]] },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("handles missing props without throwing", () => {
+    expect(() => render(PuiTable, { node: { type: "table" } })).not.toThrow();
+  });
+});

--- a/ui/src/lib/plugin-ui/PuiTable.svelte
+++ b/ui/src/lib/plugin-ui/PuiTable.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  import type { PluginUINode } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+
+  let { node }: { node: PluginUINode } = $props();
+
+  const p = $derived(node.props ?? {});
+  const columns = $derived(Array.isArray(p.columns) ? (p.columns as unknown[]).map(String) : []);
+  const rows = $derived(
+    Array.isArray(p.rows)
+      ? (p.rows as unknown[]).map((r) => (Array.isArray(r) ? (r as unknown[]).map(String) : []))
+      : [],
+  );
+</script>
+
+{#if columns.length === 0 && rows.length === 0}
+  <p class="pui-table-empty">{m.plugin_ui_table_empty()}</p>
+{:else}
+  <div class="pui-table-wrapper">
+    <table class="pui-table">
+      {#if columns.length > 0}
+        <thead>
+          <tr>
+            {#each columns as col, i (i)}
+              <th class="pui-th">{col}</th>
+            {/each}
+          </tr>
+        </thead>
+      {/if}
+      <tbody>
+        {#each rows as row, ri (ri)}
+          <tr>
+            {#each row as cell, ci (ci)}
+              <td class="pui-td">{cell}</td>
+            {/each}
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+{/if}
+
+<style>
+  .pui-table-empty {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    margin: 0;
+  }
+  .pui-table-wrapper {
+    overflow-x: auto;
+  }
+  .pui-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--fs-meta);
+    color: var(--color-ink);
+  }
+  .pui-th {
+    padding: 4px 10px;
+    text-align: left;
+    font-weight: 600;
+    font-size: var(--fs-micro);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-muted);
+    border-bottom: 2px solid var(--color-line);
+    white-space: nowrap;
+  }
+  .pui-td {
+    padding: 4px 10px;
+    border-bottom: 1px solid var(--color-line);
+    vertical-align: top;
+  }
+  tbody tr:last-child .pui-td {
+    border-bottom: none;
+  }
+</style>

--- a/ui/src/lib/plugin-ui/PuiText.svelte
+++ b/ui/src/lib/plugin-ui/PuiText.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import type { PluginUINode } from "$lib/types";
+
+  let { node }: { node: PluginUINode } = $props();
+
+  const p = $derived(node.props ?? {});
+  const value = $derived(String(p.value ?? ""));
+  const size = $derived(
+    (p.size as string | undefined) === "micro"
+      ? "var(--fs-micro)"
+      : (p.size as string | undefined) === "lg"
+        ? "var(--fs-lg)"
+        : "var(--fs-base)",
+  );
+  const color = $derived(
+    (p.tone as string | undefined) === "muted" ? "var(--color-muted)" : "var(--color-ink)",
+  );
+  const fontWeight = $derived((p.weight as string | undefined) === "bold" ? "600" : "400");
+</script>
+
+<span class="pui-text" style:font-size={size} style:color style:font-weight={fontWeight}
+  >{value}</span
+>
+
+<style>
+  .pui-text {
+    display: block;
+    line-height: 1.5;
+  }
+</style>

--- a/ui/src/lib/plugin-ui/UnknownNodeTile.svelte
+++ b/ui/src/lib/plugin-ui/UnknownNodeTile.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+
+  let { type }: { type: string } = $props();
+</script>
+
+<div class="pui-unknown">
+  <span class="pui-unknown-label">{m.plugin_ui_unknown_node()}</span>
+  <code class="pui-unknown-type">{type}</code>
+</div>
+
+<style>
+  .pui-unknown {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    font-size: var(--fs-micro);
+    color: var(--color-muted);
+  }
+  .pui-unknown-label {
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .pui-unknown-type {
+    font-family: monospace;
+    color: var(--color-ink);
+  }
+</style>

--- a/ui/src/lib/plugin-ui/registry.ts
+++ b/ui/src/lib/plugin-ui/registry.ts
@@ -1,0 +1,20 @@
+import type { Component } from "svelte";
+import PuiStack from "./PuiStack.svelte";
+import PuiText from "./PuiText.svelte";
+import PuiBadge from "./PuiBadge.svelte";
+import PuiMeter from "./PuiMeter.svelte";
+import PuiTable from "./PuiTable.svelte";
+import PuiKeyValue from "./PuiKeyValue.svelte";
+import PuiCallout from "./PuiCallout.svelte";
+
+/** Whitelist of plugin UI node types. Unknown types fall through to UnknownNodeTile. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const PLUGIN_UI_REGISTRY: Record<string, Component<any>> = {
+  stack: PuiStack,
+  text: PuiText,
+  badge: PuiBadge,
+  meter: PuiMeter,
+  table: PuiTable,
+  "key-value": PuiKeyValue,
+  callout: PuiCallout,
+};

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -106,8 +106,24 @@ test("session:ready patches the target session's readyToMerge", () => {
 test("plugin:status updates the matching plugin's health + published status in place", () => {
   const s = new HerdStore();
   s.setPlugins([
-    { id: "p1", name: "P1", version: "1.0.0", health: "ok", lastError: null, status: null },
-    { id: "p2", name: "P2", version: "2.0.0", health: "ok", lastError: null, status: null },
+    {
+      id: "p1",
+      name: "P1",
+      version: "1.0.0",
+      health: "ok",
+      lastError: null,
+      status: null,
+      ui: null,
+    },
+    {
+      id: "p2",
+      name: "P2",
+      version: "2.0.0",
+      health: "ok",
+      lastError: null,
+      status: null,
+      ui: null,
+    },
   ]);
   s.apply({ event: "plugin:status", data: { id: "p1", health: "errored", status: { n: 7 } } });
   expect(s.plugins.find((p) => p.id === "p1")).toMatchObject({

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -136,6 +136,71 @@ test("plugin:status updates the matching plugin's health + published status in p
   expect(s.plugins).toHaveLength(2);
 });
 
+test("plugin:ui updates the matching plugin's ui descriptor in place", () => {
+  const s = new HerdStore();
+  s.setPlugins([
+    {
+      id: "p1",
+      name: "P1",
+      version: "1.0.0",
+      health: "ok",
+      lastError: null,
+      status: null,
+      ui: null,
+    },
+    {
+      id: "p2",
+      name: "P2",
+      version: "2.0.0",
+      health: "ok",
+      lastError: null,
+      status: null,
+      ui: null,
+    },
+  ]);
+  const view = {
+    schemaVersion: 1 as const,
+    slot: "settings-panel" as const,
+    root: { type: "text", props: { value: "hello" } },
+  };
+  s.apply({ event: "plugin:ui", data: { id: "p1", ui: view } });
+  expect(s.plugins.find((p) => p.id === "p1")?.ui).toEqual(view);
+  // unrelated plugin untouched
+  expect(s.plugins.find((p) => p.id === "p2")?.ui).toBeNull();
+  // setting back to null is supported
+  s.apply({ event: "plugin:ui", data: { id: "p1", ui: null } });
+  expect(s.plugins.find((p) => p.id === "p1")?.ui).toBeNull();
+});
+
+test("plugin:ui for an unknown id is a no-op (pre-bootstrap guard)", () => {
+  const s = new HerdStore();
+  s.setPlugins([
+    {
+      id: "p1",
+      name: "P1",
+      version: "1.0.0",
+      health: "ok",
+      lastError: null,
+      status: null,
+      ui: null,
+    },
+  ]);
+  s.apply({
+    event: "plugin:ui",
+    data: {
+      id: "ghost",
+      ui: {
+        schemaVersion: 1,
+        slot: "settings-panel",
+        root: { type: "text", props: { value: "x" } },
+      },
+    },
+  });
+  // no new plugin row added; existing plugin untouched
+  expect(s.plugins).toHaveLength(1);
+  expect(s.plugins[0].ui).toBeNull();
+});
+
 test("backlog:update replaces the backlog snapshot so the overview stays live", () => {
   const s = new HerdStore();
   expect(s.backlog).toBeNull();

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -4,6 +4,7 @@ import type {
   SessionStatus,
   WsEvent,
   PluginInfo,
+  PluginUIView,
   UsageLimits,
   UpdateStatus,
   HerdrUpdateStatus,
@@ -164,6 +165,13 @@ export class HerdStore {
     this.plugins = this.plugins.map((p) =>
       p.id === data.id ? { ...p, health: data.health, status: data.status } : p,
     );
+  }
+  /** Live `plugin:ui` push: update the matching plugin's descriptor view in place.
+   *  Mirrors applyPluginStatus, including the pre-bootstrap unknown-id no-op. */
+  private applyPluginUi(data: { id: string; ui: PluginUIView | null }) {
+    const i = this.plugins.findIndex((p) => p.id === data.id);
+    if (i === -1) return; // unknown id (pre-bootstrap race) — the GET seed will catch up
+    this.plugins = this.plugins.map((p) => (p.id === data.id ? { ...p, ui: data.ui } : p));
   }
   /** Seed (or replace) the preview-port map after a bootstrap GET. */
   setPreview(map: Record<string, number | null>) {
@@ -567,6 +575,9 @@ export class HerdStore {
         return true;
       case "plugin:status":
         this.applyPluginStatus(ev.data);
+        return true;
+      case "plugin:ui":
+        this.applyPluginUi(ev.data);
         return true;
       case "star-prompt:status":
         this.starPrompt = ev.data;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1250,6 +1250,7 @@ export type WsEvent =
       event: "plugin:status";
       data: { id: string; health: PluginInfo["health"]; status: unknown };
     }
+  | { event: "plugin:ui"; data: { id: string; ui: PluginUIView | null } }
   | { event: "backlog:update"; data: BacklogPayload }
   | { event: "drain:status"; data: DrainStatus }
   | { event: "automerge:status"; data: AutoMergeStatus }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1126,6 +1126,20 @@ export interface DocAgentRun {
   outcome: DocAgentOutcome;
 }
 
+/** Mirror of src/plugins/types.ts PluginUINode/PluginUIView (issue #1185). Keep in sync —
+ *  plugin string props render VERBATIM (data, not i18n keys). */
+export interface PluginUINode {
+  type: string;
+  props?: Record<string, unknown>;
+  children?: PluginUINode[];
+}
+export interface PluginUIView {
+  schemaVersion: 1;
+  slot: "settings-panel" | "session-sidebar" | "dashboard-card";
+  title?: string;
+  root: PluginUINode;
+}
+
 /** A loaded server-side plugin as shown in Settings → Plugins (issue #1124). `health` is
  *  core-derived (unspoofable); `status` is the plugin's last publishStatus blob (verbatim). */
 export interface PluginInfo {
@@ -1135,6 +1149,7 @@ export interface PluginInfo {
   health: "ok" | "errored" | "timed-out";
   lastError: string | null;
   status: unknown;
+  ui: PluginUIView | null;
 }
 
 // Up Next (#1169) — cross-repo ranked queue of un-started work. Mirrors src/up-next-core.ts.

--- a/ui/src/routes/design-system/+page.svelte
+++ b/ui/src/routes/design-system/+page.svelte
@@ -131,6 +131,25 @@ input, select, textarea {
 }
 /* state colors come from the accent/status tokens, applied to color + border */`;
 
+  const meterMarkup = `<!-- PuiMeter — plugin UI primitive (issue #1185); rendered via PluginUIRenderer -->
+<div class="pui-meter">
+  <div class="pui-meter-header">
+    <span class="pui-meter-label">Tokens used</span>
+    <span class="pui-meter-value" style:color="var(--color-blue)">42/100</span>
+  </div>
+  <div class="pui-meter-track" role="meter" aria-valuenow={42} aria-valuemin={0} aria-valuemax={100}>
+    <div class="pui-meter-fill" style:width="42%" style:background="var(--color-blue)"></div>
+  </div>
+  <span class="pui-meter-caption">Monthly budget</span>
+</div>
+
+/* All sizing via tokens; tone color applied to value text + fill bar via style: */
+.pui-meter-track  { height:6px; background:var(--color-inset); border:1px solid var(--color-line); border-radius:3px; overflow:hidden; }
+.pui-meter-fill   { height:100%; border-radius:3px; transition:width .2s ease; }
+.pui-meter-label  { font-size:var(--fs-meta); color:var(--color-ink); font-weight:600; }
+.pui-meter-value  { font-size:var(--fs-micro); font-variant-numeric:tabular-nums; }
+.pui-meter-caption{ font-size:var(--fs-micro); color:var(--color-muted); }`;
+
   const glossMarkup = `<!-- In a message value, wrap a term with [[id|Label]]: -->
 <!-- "Shepherd groups sessions under an [[epic|epic]]." -->
 
@@ -579,6 +598,41 @@ input, select, textarea {
   </section>
 
   <section class="panel">
+    <h2>Plugin UI · meter</h2>
+    <p class="when">
+      <strong>When:</strong> a plugin publishes a <code>meter</code> node via
+      <code>ctx.publishUI</code>
+      to display a numeric progress value relative to a maximum (e.g. token budget, rate-limit usage,
+      task completion). The filled bar and value text share the same tone color; ratio is clamped to [0,
+      1]. <strong>When not:</strong> for determinate process progress inside Shepherd's own chrome,
+      prefer a loading indicator; <code>PuiMeter</code> is plugin-data only.
+    </p>
+    <div class="demo">
+      <div class="pui-meter-demo">
+        <div class="pui-meter-header-demo">
+          <span class="pui-meter-label-demo">Tokens used</span>
+          <span class="pui-meter-value-demo" style:color="var(--color-blue)">42/100</span>
+        </div>
+        <div
+          class="pui-meter-track-demo"
+          role="meter"
+          aria-valuenow={42}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <div
+            class="pui-meter-fill-demo"
+            style:width="42%"
+            style:background="var(--color-blue)"
+          ></div>
+        </div>
+        <span class="pui-meter-caption-demo">Monthly budget</span>
+      </div>
+    </div>
+    <pre><code>{meterMarkup}</code></pre>
+  </section>
+
+  <section class="panel">
     <h2>Glossary term</h2>
     <p class="when">
       <strong>When:</strong> a dashed underline marks a term that has a definition in the glossary
@@ -883,6 +937,43 @@ input, select, textarea {
     padding: 1px 6px;
     border: 1px solid var(--color-line);
     border-radius: 2px;
+    color: var(--color-muted);
+  }
+  /* PuiMeter demo styles (mirrors PuiMeter.svelte) */
+  .pui-meter-demo {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-width: 280px;
+  }
+  .pui-meter-header-demo {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 8px;
+  }
+  .pui-meter-label-demo {
+    font-size: var(--fs-meta);
+    color: var(--color-ink);
+    font-weight: 600;
+  }
+  .pui-meter-value-demo {
+    font-size: var(--fs-micro);
+    font-variant-numeric: tabular-nums;
+  }
+  .pui-meter-track-demo {
+    height: 6px;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    border-radius: 3px;
+    overflow: hidden;
+  }
+  .pui-meter-fill-demo {
+    height: 100%;
+    border-radius: 3px;
+  }
+  .pui-meter-caption-demo {
+    font-size: var(--fs-micro);
     color: var(--color-muted);
   }
   .mini-panel {


### PR DESCRIPTION
Closes #1185. Handoff from the design research in #1182 (`docs/research/plugin-ui-widgets.md`).

Gives plugins a way to display **real UI** (not a raw JSON dump) by pushing a **declarative component descriptor** (`PluginUIView`) that the host renders from a **whitelisted registry of native Svelte components** (Server-Driven-UI). Phase 0 — display-only, one wired slot, validated end-to-end against the real `claude-swap` plugin.

## What ships

**Server (`src/plugins/`)**
- `PluginUINode` / `PluginUIView` types + additive `ctx.publishUI(view | null)` beside `publishStatus`. **No `PLUGIN_API_VERSION` bump** — plugins guard with `typeof ctx.publishUI === "function"`.
- `ui-validate.ts` — seam validator that **never throws** (fail-open). Caps a *buggy* (not malicious) plugin: serializability via `JSON.stringify` (cycles/BigInt → reject; functions/`undefined` → stripped, stored as the re-parsed normalized form), ≤64 KB serialized, ≤500 entries/array, ≤256 nodes, ≤16 depth, `schemaVersion === 1`, known slot. Invalid `publishUI` is dropped (warn) with the **prior view retained**; `publishUI(null)` clears.
- Reuses the `publishStatus` transport: `ui` stored on `PluginInfo`, emitted as a `plugin:ui` event over `/events`, surfaced via `GET /api/plugins`.

**UI (`ui/src/lib/plugin-ui/`)**
- `PluginUIRenderer.svelte` — dumb recursive renderer over a 7-component whitelist (`stack`, `text`, `badge`, `meter`, `table`, `key-value`, `callout`); unknown type → `UnknownNodeTile`. Registry lookup guarded with `Object.hasOwn` so prototype keys (`constructor`, …) can't bypass the whitelist.
- 7 `Pui*` primitives, design-system compliant (tokens only, reuse the `.badge` recipe; new **meter** recipe added to `/design-system`). Plugin strings render **verbatim** — no `{@html}`, XSS-safe.
- `SettingsPluginsPanel` renders the view when `slot === "settings-panel"` (the only wired slot — unwired slots fall back to the JSON dump), **always-visible**, with the per-row expand toggle repurposed as a raw-JSON debug reveal. A plugin emitting only `publishStatus` is unchanged (back-compat).
- `plugin:ui` store handler mirrors `applyPluginStatus`, incl. the pre-bootstrap unknown-id no-op.

**First consumer:** `claude-swap` ports its status blob to a `PluginUIView` (quota meters, ready/rate-limited badges, assignment table, config/last-spawn key-value) — companion PR: **erwins-enkel/shepherd-claude-swap#6**. The Shepherd side is self-contained and independently green via an inline test plugin, so it doesn't depend on that PR merging.

## Deliberate deviation from the report sketch
The report (#1182) floated `title` as an i18n key (`title: i18n key OR {key,params}`). **This PR renders plugin descriptor strings verbatim as DATA instead** (operator-confirmed). Rationale: CLAUDE.md's verbatim-data rule (tool-use summaries / PR titles are passed through, not translated), and message-key indirection would force separate-repo plugins to ship into Shepherd's `ui/messages` catalog. Only host-authored `Pui*` chrome (unknown-tile label, empty states, raw-data toggle) is i18n'd. Documented inline on the `PluginUINode` type.

## Gates (per CLAUDE.md)
- i18n EN+DE parity (`check:i18n` ✓, 2108 keys) — chrome keyed, plugin data not.
- One feature-announcements entry (`plugin-ui-panels`, since 1.38.0; no `targetId` — the Plugins tab is conditionally mounted and isn't a Coachmark host, same caveat as `backlog-add-repo`).
- `/design-system` meter recipe added; tokens-only.
- No new glossary term introduced (the panel just renders data).
- Type mirror kept in sync across `src/plugins/types.ts` ↔ `ui/src/lib/types.ts`.

## Verification
Root `bun run lint` clean · `bun test ./test` 5154 pass · `tsc` clean · UI `bun run check` 0 errors/0 warnings · `check:i18n` parity · UI vitest 2179 pass · `bun run build` ✓ · `prettier --check` clean · branch-hygiene + feature-catalog + glossary + **fallow audit** all pass.

A multi-agent review pass found and fixed: PuiBadge now applies the badge recipe (was rendering as bare text); registry prototype-key whitelist bypass guarded; meter value read-out + a11y; callout `warn` token harmonized; panel null-status empty state; `publishUI(undefined)` treated as clear. The recursive renderer's intentional import cycle carries a narrow `fallow-ignore` with rationale.

## Non-goals (deferred)
Interactivity (`action` nodes / buttons → routes), additional slots (`session-sidebar`/`dashboard-card`), iframe/web-component delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)