### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs/sandbox-security.md
+++ b/docs/sandbox-security.md
@@ -51,8 +51,8 @@ secrets out of the membrane entirely.
 ## Attended-mode egress coverage
 
 Egress confinement is keyed to the autonomous **profile**, not to whether a human
-is watching (`willEgressConfine`, `src/sandbox.ts:543-549`; applied at
-`src/service.ts:1246`): the wrap applies iff the autonomous profile resolves
+is watching (`willEgressConfine`, `src/sandbox.ts:544-549`; applied at
+`src/service.ts:1374`): the wrap applies iff the autonomous profile resolves
 **and** the fs + egress backends are present, independent of `ctx.auto`.
 Consequences:
 
@@ -76,19 +76,19 @@ Write --permission-mode dontAsk` (`src/transient-agent-argv.ts`,
   `buildTransientAgentArgv("reviewer", …)`).
 - **Research is the deliberately egress-UNCONFINED surface.** A research session
   that would resolve to `autonomous` is **downgraded to `standard`**
-  (`src/service.ts` `researchSafeProfileOverride`, ~L1478-1496, warns once),
+  (`src/service.ts` `researchSafeProfileOverride`, ~L1749-1767, warns once),
   because research needs **open** web egress (search/fetch + sub-agents) that the
   autonomous firewall would block. It is operator-_created_ (cannot be
   auto-drained — `standard` refuses auto-spawn) but **autopilot-steerable, so it
   runs unattended in practice** (`RESEARCH_PROCEED_STEER`,
-  `src/autopilot.ts:23-28`, dispatched at L295). It ingests **untrusted web**
+  `src/autopilot.ts:24-29`, dispatched at L307). It ingests **untrusted web**
   content on `trusted`/`standard` with the **network open**, and can
   `gh pr create` / open issues via the bound gh token — so a hijacked research
   agent has **both** readable tokens **and** open egress.
 
   **Compensating factors:** the downgrade is explicit and warns once; research
   delivers a **report PR or GitHub issue only, never a code PR**
-  (`src/autopilot.ts:299-301`). The residual is **accepted**.
+  (`src/autopilot.ts:309-313`). The residual is **accepted**.
 
 ## See also
 


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc-update summary

Recent source changes (the GitForge seam refactor #1184, the capacity-hold change
#1187, and the up-next work) shifted several `src/` line numbers. I checked all
eight in-scope pages against the current source. The prose was accurate
everywhere; the only demonstrable staleness was a set of out-of-range source
line references in `docs/sandbox-security.md`, which I corrected.

## Changes

- **`docs/sandbox-security.md`** — corrected four drifted source line references
  (the behavioral prose was unchanged and remains accurate):
  - `willEgressConfine` apply site: `src/service.ts:1246` → `:1374` (current call
    site for `const egressOn = willEgressConfine(...)`), and its definition span
    `src/sandbox.ts:543-549` → `:544-549`.
  - `researchSafeProfileOverride`: `~L1478-1496` → `~L1749-1767` (the function now
    lives at `src/service.ts:1749`; a ~270-line drift).
  - `RESEARCH_PROCEED_STEER` / autopilot dispatch: `src/autopilot.ts:23-28,
    dispatched at L295` → `:24-29, dispatched at L307` (the `case "gate"` steer
    dispatch is now `src/autopilot.ts:307`).
  - "report PR or GitHub issue … never a code PR": `src/autopilot.ts:299-301` →
    `:309-313` (the `case "finished"` research branch).
  Source: current `src/sandbox.ts`, `src/service.ts`, `src/autopilot.ts`. The R3
  references (`sandbox.ts:302-304`, `:309-311`, `:392`, `:417`) and the intro
  `egressApplies ~L532` were re-verified as still accurate and left untouched.

No changes were needed in: `docs/external-task-api.md`,
`docs/token-usage-analysis.md`, `docs-site/src/content/docs/index.md`,
`docs-site/src/content/docs/getting-started.md`,
`docs-site/src/content/docs/operating.md`,
`docs-site/src/content/docs/reference/configuration.md`,
`docs-site/src/content/docs/reference/glossary.md`.

Spot-checked and confirmed current:
- Glossary (`glossary.md`) matches the registry `ui/src/lib/glossary.ts` exactly
  (same 11 terms); no `Up Next` or other term was added to the registry.
- Configuration env defaults match `src/config.ts` (agent-ingress port =
  `mainPort+1`, usage-hold pct `80`, preview base `8001`/count `16`, doc-agent
  nightly hour `3`, etc.).
- The egress allowlist hosts in `docs/sandbox-security.md` /
  `configuration.md` still match `ANTHROPIC_EGRESS_HOSTS` +
  `GITHUB_EGRESS_HOSTS` in `src/egress.ts`.

## Uncertain / needs human judgment

- **Capacity hold in `docs/external-task-api.md` (#1187).** The hold gate section
  documents only the *usage-aware* hold and states a submission is held "only
  when both" usage conditions hold, releasing FIFO. As of #1187, a plugin that
  calls `ctx.abortSpawn()` during create now also parks the task in `held_tasks`
  with `reason='capacity'`, returning the same `200 { held: true, id, count }`
  shape, and the release order changed to drain usage-held before capacity-held
  (`ORDER BY (reason = 'capacity'), createdAt ASC`). I did **not** edit the doc:
  the capacity path only arises from private server-side plugins (out of scope of
  the external HTTP API the page describes), and the documented response shape is
  unchanged, so the page is not wrong for its stated scope — but a human may want
  to add a one-line note that "held" can also mean a plugin-refused capacity hold.

- **Line-number references generally.** I updated the four clearly out-of-range
  pointers above, but source line numbers are inherently fragile and will drift
  again on the next refactor. A human may prefer to drop precise line numbers in
  favor of symbol names only.