### PR TITLE
perf(ci): cache prettier + eslint across runs to speed up lint (#1192)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,32 @@ jobs:
         with:
           working-directory: extension
 
+      # Persist prettier + eslint caches across runs so the Lint step is a few
+      # seconds on a WARM cache instead of >1 min cold (#1192). Both linters write
+      # to repo-root .cache/ (--cache-location) with --cache-strategy content — the
+      # default `metadata` strategy keys on mtime, which a fresh CI checkout always
+      # busts, so it would silently no-op. Stable hash-only key + prefix restore-keys
+      # mirrors the docs-site bun-store cache below: one entry per config/lockfile
+      # lineage (no per-commit churn against GitHub's 10 GB LRU budget). Cold/miss
+      # runs (config/dep bump, eviction, fresh lineage) fall back to today's cost.
+      - name: Restore lint cache
+        uses: actions/cache@v6
+        with:
+          path: |
+            .cache
+            extension/.cache
+          key: ${{ runner.os }}-lint-${{ hashFiles('eslint.config.js', 'extension/eslint.config.js', '.prettierrc', '.prettierignore', 'bun.lock', 'extension/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-lint-
+
       - name: Lint (prettier + eslint)
+        # Per-command timing (#1192): attributes the Lint minute on real CI hardware
+        # (local cold total is only ~22s) and gives a cold→warm before/after across
+        # the PR's own runs. eslint cache flags live in the `lint` npm scripts.
         run: |
-          bunx prettier --check .
-          bun run lint
-          (cd extension && bun run lint)
+          s=$SECONDS; bunx prettier --check --cache --cache-strategy content --cache-location .cache/prettier .; echo "⏱ prettier --check: $((SECONDS - s))s"
+          s=$SECONDS; bun run lint; echo "⏱ eslint (root): $((SECONDS - s))s"
+          s=$SECONDS; (cd extension && bun run lint); echo "⏱ eslint (extension): $((SECONDS - s))s"
 
       - name: Typecheck (root tsc)
         run: bun run typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ ci/self-hosted-runner/.env
 # fallow analyzer cache
 .fallow/
 
+# Prettier + eslint caches (--cache-location .cache/...), persisted in CI (#1192)
+.cache/
+
 # Pre-push test capture logs (flake diagnosis, #817)
 .test-logs/
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -16,6 +16,11 @@ node_modules
 build
 dist
 
+# Prettier + eslint cache dirs (--cache-location .cache/...). prettier honors this
+# file, not .gitignore, so without this `prettier --check .` traverses & fails on the
+# restored cache JSON in CI (#1192). Bare `.cache` matches root + extension/.cache.
+.cache
+
 # Extension build artifacts copied into public/ (axe-core bundle + esbuild-built recorder/picker)
 extension/public/axe.min.js
 extension/public/recorder.js

--- a/extension/package.json
+++ b/extension/package.json
@@ -14,7 +14,7 @@
     "prepare": "paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide || echo ''",
     "check": "paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide && svelte-check --tsconfig ./tsconfig.json",
     "check:i18n": "node scripts/check-i18n.mjs",
-    "lint": "eslint --no-error-on-unmatched-pattern src",
+    "lint": "eslint --cache --cache-strategy content --cache-location .cache/eslint --no-error-on-unmatched-pattern src",
     "test": "vitest run"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "test": "bun test ./test",
-    "lint": "eslint --no-error-on-unmatched-pattern src test examples ui/src ci/onboarding-harness deploy",
+    "lint": "eslint --cache --cache-strategy content --cache-location .cache/eslint --no-error-on-unmatched-pattern src test examples ui/src ci/onboarding-harness deploy",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
     "start": "bun run src/index.ts",
@@ -17,8 +17,8 @@
     "check:glossary": "node scripts/check-glossary.mjs"
   },
   "lint-staged": {
-    "*.{ts,js,json,css,html,md,svelte}": "prettier --write",
-    "*.{ts,svelte}": "eslint --fix"
+    "*.{ts,js,json,css,html,md,svelte}": "prettier --write --cache --cache-strategy content --cache-location .cache/prettier",
+    "*.{ts,svelte}": "eslint --cache --cache-strategy content --cache-location .cache/eslint --fix"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.1.0",

--- a/scripts/pre-push.ts
+++ b/scripts/pre-push.ts
@@ -406,7 +406,20 @@ function buildLanes(
             cmd: "bunx",
             // `--` terminator: dash-leading paths are already dropped upstream by
             // `isSafePath` in `changedFiles`; this is the second layer guarding the spread.
-            args: withFileArgs(["prettier", "--check", "--ignore-unknown"], opts.changed),
+            // --cache flags mirror ci.yml (#1192); content strategy + .cache/ location.
+            args: withFileArgs(
+              [
+                "prettier",
+                "--check",
+                "--ignore-unknown",
+                "--cache",
+                "--cache-strategy",
+                "content",
+                "--cache-location",
+                ".cache/prettier",
+              ],
+              opts.changed,
+            ),
             cwd: repoRoot,
           },
         ],
@@ -420,7 +433,17 @@ function buildLanes(
         {
           label: "prettier --check (whole repo)",
           cmd: "bunx",
-          args: ["prettier", "--check", "."],
+          // --cache flags mirror ci.yml (#1192); content strategy + .cache/ location.
+          args: [
+            "prettier",
+            "--check",
+            "--cache",
+            "--cache-strategy",
+            "content",
+            "--cache-location",
+            ".cache/prettier",
+            ".",
+          ],
           cwd: repoRoot,
         },
       ],
@@ -437,7 +460,19 @@ function buildLanes(
         cmd: "bunx",
         // `--` terminator: defense-in-depth — `routeEslintFiles` only admits
         // `src/`/`test/`/`ui/src/`-prefixed paths, so these can't be dash-leading.
-        args: withFileArgs(["eslint", "--no-error-on-unmatched-pattern"], routed.root),
+        // --cache flags mirror the root `lint` npm script + ci.yml (#1192).
+        args: withFileArgs(
+          [
+            "eslint",
+            "--cache",
+            "--cache-strategy",
+            "content",
+            "--cache-location",
+            ".cache/eslint",
+            "--no-error-on-unmatched-pattern",
+          ],
+          routed.root,
+        ),
         cwd: repoRoot,
       });
     if (routed.ext.length)
@@ -445,7 +480,20 @@ function buildLanes(
         label: "eslint extension (delta)",
         cmd: "bunx",
         // `--` terminator: defense-in-depth — routed paths are `extension/src/`-prefixed.
-        args: withFileArgs(["eslint", "--no-error-on-unmatched-pattern"], routed.ext),
+        // --cache flags mirror the extension `lint` npm script + ci.yml (#1192);
+        // cwd=extension → .cache/eslint resolves to extension/.cache/eslint.
+        args: withFileArgs(
+          [
+            "eslint",
+            "--cache",
+            "--cache-strategy",
+            "content",
+            "--cache-location",
+            ".cache/eslint",
+            "--no-error-on-unmatched-pattern",
+          ],
+          routed.ext,
+        ),
         cwd: ext,
       });
     if (steps.length) lanes.push({ name: "eslint", timeoutMs: t(120_000), steps });


### PR DESCRIPTION
Closes #1192.

## What

Cache-first speedup for the CI **Lint** step (the lowest-risk option from the issue). **No linter swap** — both linters now write content-strategy caches to a repo-root `.cache/` dir, persisted across CI runs via `actions/cache`. Warm runs drop from >1 min to a few seconds; cold/cache-miss runs are unchanged (never a regression).

## Why both prettier and eslint

Local measurement showed they cost **equally**, so caching eslint alone (the issue's literal option-1 wording) would only fix half:

| Sub-step | Cold | Warm (`--cache-strategy content`) |
| --- | --- | --- |
| `prettier --check .` | 11.4s | **1.1s** |
| root eslint (~3k files) | 10.7s | **0.5s** |
| extension eslint | 0.8s | ~0.4s |

Two verified, non-obvious requirements:
- **`--cache-strategy content`** — the default `metadata` strategy keys on mtime, which a fresh CI checkout always busts, so it would silently no-op. Verified the content cache survives a full mtime bump.
- **`--cache-location .cache/`** — prettier's default cache lives in `node_modules/.cache`, which a fresh `bun install` wipes. Relocating to repo-root `.cache/` survives install; eslint auto-creates the dir.

## Cache key

Stable hash-only key + prefix `restore-keys`, **mirroring the existing `docs-site` bun-store cache** — *not* a rolling `github.sha` key. Rolling would write a ~700 KB entry per commit, churning GitHub's 10 GB LRU budget and risking eviction of the larger `docs-site` cache. Stable key = one entry per config/lockfile lineage; accepted trade-off is a bounded, self-healing warm-decay within a lineage (any dep/config bump opens a fresh lineage).

## Changes

- `package.json` / `extension/package.json` — `lint` scripts + `lint-staged` get the cache flags.
- `.github/workflows/ci.yml` — `actions/cache@v6` step before Lint; prettier cache flags + per-command `$SECONDS` timing on the Lint step.
- `scripts/pre-push.ts` — mirror the flags in the prettier (delta + whole-repo) and delta eslint lanes (whole-repo eslint inherits via `bun run lint`); kept in sync with CI per the in-file directive.
- `.prettierignore` — add `.cache` (prettier honors this, not `.gitignore`; without it `--check .` would fail on the restored cache JSON).
- `.gitignore` — add `.cache/`.

## Measurement / efficacy

Per-command timing is now emitted on the CI Lint step so the **before → after** can be read directly from this PR's runs: the first run is cold (no cache lineage on `main` yet) → baseline + attribution; a later run restores the branch cache → warm number. Local cold total is only ~22s, so the CI minute is attributed by measuring CI directly rather than extrapolating local numbers.

## Verification

- `bun run lint` warm **0.56s** (cold 10.7s); `prettier --check` warm **1.17s** (cold 11.8s); ext eslint warm 0.43s.
- `prettier --check .` does **not** flag the restored `.cache/` dir.
- `bun test ./test` — 5179 pass, 0 fail. `bun run typecheck` clean. `test/pre-push.test.ts` 11/11.
- `.cache/` correctly gitignored (clean `git status` after a lint run). pre-push hook green end-to-end.

## Deferred (out of scope, per the issue + operator decision)

- Oxlint/Biome **hybrid** fast-linter (issue option 2) and **formatter swap** (option 3) — this addresses the cold-path structural speedup and is left for a follow-up.
- Caching `node_modules`/bun store on `verify` (affects install time, not the Lint step).

[no-feature-entry] — CI/tooling-only change, no user-facing UX.