### PR TITLE
fix(ci): grant actions:read so doc-automerge can read statusCheckRollup

### DIFF
--- a/.github/workflows/doc-automerge.yml
+++ b/.github/workflows/doc-automerge.yml
@@ -37,6 +37,12 @@ permissions:
   # dies with "Resource not accessible by integration" the moment a PR has any check.
   checks: read
   statuses: read
+  # The same statusCheckRollup query ALSO traverses CheckRun → checkSuite → workflowRun
+  # (gh's fixed GraphQL fragment fetches the run's workflow name). Reading the workflowRun
+  # node needs `actions: read` — `checks`/`statuses` above cover only the leaf verdicts, not
+  # this node. Without it the query still dies "Resource not accessible by integration
+  # (...checkSuite.workflowRun)" on any Actions-checked PR (the #1163 scope fix missed it).
+  actions: read
 
 # One merge pass at a time; never cancel a pass mid-merge.
 concurrency:


### PR DESCRIPTION
## Problem

The **Auto-merge doc PRs** workflow (`doc-automerge.yml`) fails red on every trigger before it evaluates any PR — so no doc PR ever auto-merges. [Run 28313713755](https://github.com/erwins-enkel/shepherd/actions/runs/28313713755):

```
Found 1 open doc PR(s): 1191
GraphQL: Resource not accessible by integration (...statusCheckRollup...checkSuite.workflowRun)
##[error]Process completed with exit code 1.
```

## Root cause

The failure is at the `gh pr view --json statusCheckRollup` call, *before* any eligibility gate. That JSON field issues a fixed GraphQL query that, for every `CheckRun`, traverses `checkSuite → workflowRun → workflow { name }`. Reading the `workflowRun` node requires the **`actions: read`** permission.

The earlier scope fix (#1163, commit f13a69b7) added `checks: read` + `statuses: read` — which cover the check-run / legacy-status *leaves* the query reads, but **not** the `workflowRun` node the same query also walks. With an explicit `permissions:` block, every unlisted scope defaults to `none`, so `actions` was `none` and the call died the moment a PR had any Actions check. Under `set -euo pipefail` the failed command substitution aborts the job. That's why it "still failed" after the prior fix — two of the three scopes the one query needs were granted.

## Fix

Add `actions: read` (read-only) to the `permissions:` block, with a comment documenting the `checkSuite.workflowRun` traversal. One line; no write scopes added; consistent with the workflow's least-privilege intent.

## Verification (pre-merge, real restricted GITHUB_TOKEN)

`workflow_dispatch` runs the *dispatched ref's* workflow definition (the trigger already exists on `main`), so dispatching this branch exercises the edited `permissions:` under the same scoped token that failed. Dispatched [run 28315626893](https://github.com/erwins-enkel/shepherd/actions/runs/28315626893) with doc PR #1191 open:

```
Found 1 open doc PR(s): 1191
#1191: author_association=CONTRIBUTOR not OWNER/MEMBER — skip
```

The job got **past** the previously-failing `gh pr view` call into the per-PR eligibility gates, with no `Resource not accessible` error — empirically confirming `actions: read` was the last missing scope (the `#1191` skip is a legitimate provenance gate, not a failure).

[no-feature-entry] — server-only CI plumbing, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)