### PR TITLE
fix(orchestration): fire auto plan-gate before the awaited drain chain (#1193)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1241,8 +1241,9 @@ const sessionRouter = new SessionRouter(
   {
     // Plan-gate is an independent status side-effect (not a [drain,autopilot] consumer): a
     // planning-phase session that just settled likely finished writing .shepherd-plan.md → kick the
-    // adversarial review. Runs after the consumer chain, reached regardless of a consumer throwing.
-    onStatusSettled: (change) => {
+    // adversarial review. Fires BEFORE the awaited consumer chain so a slow/hanging drain pump can
+    // never starve it (#1193); consider() is self-contained and claims its slot synchronously.
+    onStatusIndependent: (change) => {
       const sess = change.snapshot.session;
       if (change.status === "done" && sess.planPhase === "planning")
         void planGate.consider(sess).catch((err) => console.warn("[plan-gate] consider:", err));

--- a/src/session-router.ts
+++ b/src/session-router.ts
@@ -9,16 +9,20 @@ export interface SessionConsumer {
 }
 
 export interface SessionRouterHooks {
-  /** Fired on a `status` change AFTER the consumer chain — an independent side-effect
-   *  (plan-gate). Reached regardless of any consumer throwing. */
-  onStatusSettled?: (change: Extract<SessionStateChange, { kind: "status" }>) => void;
+  /** Fired on a `status` change as an INDEPENDENT side-effect (plan-gate) — kicked off
+   *  BEFORE the awaited consumer chain so a slow or hanging consumer can never starve it
+   *  (#1193). It is synchronous (only kicks `void planGate.consider`), so firing it first
+   *  costs nothing and leaves the drain→autopilot ordering below intact. */
+  onStatusIndependent?: (change: Extract<SessionStateChange, { kind: "status" }>) => void;
 }
 
 /** The single "what happens next" seam. Builds the shared snapshot ONCE per change and
  *  dispatches `consumers` strictly in order, AWAITING each fully before the next — this
- *  is what kills the retire-vs-steer race (fire-and-forget could not). Each consumer (and
- *  each hook) is isolated in try/catch so one failure is logged and does NOT prevent the
- *  next consumer or the settled hook from running; ordering still holds on the success path. */
+ *  is what kills the retire-vs-steer race (fire-and-forget could not). The independent
+ *  status hook (plan-gate) fires BEFORE this chain, so it never waits on it (#1193). Each
+ *  consumer and the hook are isolated in try/catch so one failure is logged and does NOT
+ *  prevent the next consumer from running; the drain→autopilot ordering still holds on the
+ *  success path. */
 export class SessionRouter {
   constructor(
     private acc: SnapshotAccessors,
@@ -31,14 +35,19 @@ export class SessionRouter {
   async onStatus(id: string, status: string): Promise<void> {
     const change = buildSnapshot(this.acc, id, { kind: "status", status });
     if (!change) return;
+    // Plan-gate is an INDEPENDENT per-session side-effect — kick it BEFORE awaiting the
+    // drain→autopilot chain so a slow or hanging consumer (e.g. an unbounded drain pump)
+    // can never starve it (#1193). It only fires `void planGate.consider`, so running it
+    // first is free and does not perturb the ordered dispatch below.
+    this.safeSync(
+      () =>
+        this.hooks.onStatusIndependent?.(change as Extract<SessionStateChange, { kind: "status" }>),
+      "independent",
+    );
     // No up-front PR-prewarm hook: drain runs before autopilot, and autopilot.onDone
     // kicks refreshPr right before its classify, so the PR-poll↔classify overlap is
     // preserved without a separate kick (see autopilot.handle).
     await this.dispatch(change);
-    this.safeSync(
-      () => this.hooks.onStatusSettled?.(change as Extract<SessionStateChange, { kind: "status" }>),
-      "settled",
-    );
   }
 
   async onGit(id: string, git: GitState): Promise<void> {

--- a/test/process-reaper.test.ts
+++ b/test/process-reaper.test.ts
@@ -379,6 +379,13 @@ test("claude-alive: every supplied worktree appears as a key; empty input is fin
 
 const WT = "/home/u/Work/.shepherd-worktrees/repo-x"; // a real worktree path (has the marker)
 
+// A synthetic orphan PID guaranteed to differ from the test runner's own process.pid.
+// The reapers spare `p.pid === process.pid` (don't SIGKILL self); a hardcoded literal can
+// collide with the runner's PID in CI containers (which hand out small PIDs — a literal like
+// 808 once matched), sparing the orphan and flipping a "reaps 1" assertion to 0. Deriving it
+// from process.pid can never collide.
+const ORPHAN_PID = process.pid + 1;
+
 // killPid spy: record (pid, signal) so tests can assert SIGKILL + exactly-who.
 function killSpy() {
   const killed: { pid: number; signal?: NodeJS.Signals }[] = [];
@@ -392,13 +399,13 @@ test("reapOrphansUnder: SIGKILLs a PPID-1 non-agent orphan whose cwd is under th
   const k = killSpy();
   const reaper = new ProcessReaper(
     makeProbes({
-      scanProcs: () => [{ pid: 4242, cwd: WT, comm: "yes" }],
+      scanProcs: () => [{ pid: ORPHAN_PID, cwd: WT, comm: "yes" }],
       ppidForPid: () => 1,
       killPid: k.killPid,
     }),
   );
   expect(reaper.reapOrphansUnder(WT)).toBe(1);
-  expect(k.killed).toEqual([{ pid: 4242, signal: "SIGKILL" }]);
+  expect(k.killed).toEqual([{ pid: ORPHAN_PID, signal: "SIGKILL" }]);
 });
 
 test("reapOrphansUnder: spares self, agent comm, non-orphan (PPID!=1), and out-of-worktree procs", () => {
@@ -449,13 +456,13 @@ test("reapDeletedWorktreeOrphans: SIGKILLs a PPID-1 orphan whose cwd is a delete
   const k = killSpy();
   const { reaped } = reapDeletedWorktreeOrphans(
     makeProbes({
-      scanProcs: () => [{ pid: 808, cwd: `${WT} (deleted)`, comm: "yes" }],
+      scanProcs: () => [{ pid: ORPHAN_PID, cwd: `${WT} (deleted)`, comm: "yes" }],
       ppidForPid: () => 1,
       killPid: k.killPid,
     }),
   );
   expect(reaped).toBe(1);
-  expect(k.killed).toEqual([{ pid: 808, signal: "SIGKILL" }]);
+  expect(k.killed).toEqual([{ pid: ORPHAN_PID, signal: "SIGKILL" }]);
 });
 
 test("reapDeletedWorktreeOrphans: spares a live (non-deleted) cwd, even under the worktree marker", () => {

--- a/test/session-router.test.ts
+++ b/test/session-router.test.ts
@@ -155,16 +155,16 @@ test("getSession is called exactly once per onGit even with two consumers", asyn
 
 test("unknown session (getSession null) calls no consumer and no hooks", async () => {
   const log: string[] = [];
-  let settled = 0;
+  let fired = 0;
   const router = new SessionRouter(
     { getSession: () => null },
     [recordingConsumer("drain", log), recordingConsumer("autopilot", log)],
-    { onStatusIndependent: () => settled++ },
+    { onStatusIndependent: () => fired++ },
   );
   await router.onStatus("missing", "idle");
   await router.onGit("missing", GIT_STATE);
   expect(log).toEqual([]);
-  expect(settled).toBe(0);
+  expect(fired).toBe(0);
 });
 
 // ── 4. Failure isolation ──────────────────────────────────────────────────────
@@ -172,7 +172,7 @@ test("unknown session (getSession null) calls no consumer and no hooks", async (
 test("a throwing first consumer is caught; second consumer still runs (independent hook already fired)", async () => {
   const log: string[] = [];
   const warnings: string[] = [];
-  let settled = 0;
+  let fired = 0;
 
   const failing: SessionConsumer = {
     name: "drain",
@@ -185,7 +185,7 @@ test("a throwing first consumer is caught; second consumer still runs (independe
   const router = new SessionRouter(
     { getSession: () => makeSession("s1", "/r") },
     [failing, recordingConsumer("autopilot", log)],
-    { onStatusIndependent: () => settled++ },
+    { onStatusIndependent: () => fired++ },
     (msg) => warnings.push(msg),
   );
 
@@ -193,7 +193,7 @@ test("a throwing first consumer is caught; second consumer still runs (independe
   await router.onStatus("s1", "idle");
 
   expect(log).toEqual(["drain:start", "autopilot:start", "autopilot:finish"]);
-  expect(settled).toBe(1);
+  expect(fired).toBe(1);
   expect(warnings.some((w) => w.includes("drain"))).toBe(true);
 });
 

--- a/test/session-router.test.ts
+++ b/test/session-router.test.ts
@@ -159,7 +159,7 @@ test("unknown session (getSession null) calls no consumer and no hooks", async (
   const router = new SessionRouter(
     { getSession: () => null },
     [recordingConsumer("drain", log), recordingConsumer("autopilot", log)],
-    { onStatusSettled: () => settled++ },
+    { onStatusIndependent: () => settled++ },
   );
   await router.onStatus("missing", "idle");
   await router.onGit("missing", GIT_STATE);
@@ -169,7 +169,7 @@ test("unknown session (getSession null) calls no consumer and no hooks", async (
 
 // ── 4. Failure isolation ──────────────────────────────────────────────────────
 
-test("a throwing first consumer is caught; second consumer and settled hook still run", async () => {
+test("a throwing first consumer is caught; second consumer still runs (independent hook already fired)", async () => {
   const log: string[] = [];
   const warnings: string[] = [];
   let settled = 0;
@@ -185,7 +185,7 @@ test("a throwing first consumer is caught; second consumer and settled hook stil
   const router = new SessionRouter(
     { getSession: () => makeSession("s1", "/r") },
     [failing, recordingConsumer("autopilot", log)],
-    { onStatusSettled: () => settled++ },
+    { onStatusIndependent: () => settled++ },
     (msg) => warnings.push(msg),
   );
 
@@ -197,9 +197,9 @@ test("a throwing first consumer is caught; second consumer and settled hook stil
   expect(warnings.some((w) => w.includes("drain"))).toBe(true);
 });
 
-// ── 5. Settled hook ordering ───────────────────────────────────────────────────
+// ── 5. Independent hook ordering (#1193) ───────────────────────────────────────
 
-test("onStatus fires the settled hook after the consumer chain", async () => {
+test("onStatus fires the independent hook BEFORE the consumer chain", async () => {
   const log: string[] = [];
   const gate = deferred();
 
@@ -213,27 +213,54 @@ test("onStatus fires the settled hook after the consumer chain", async () => {
   };
 
   const router = new SessionRouter({ getSession: () => makeSession("s1", "/r") }, [slow], {
-    onStatusSettled: () => log.push("settled"),
+    onStatusIndependent: () => log.push("independent"),
   });
 
   const done = router.onStatus("s1", "idle");
   await Promise.resolve();
   await Promise.resolve();
-  // Settled has NOT fired yet — the chain is still parked on the deferred.
-  expect(log).toEqual(["consumer:start"]);
+  // The independent hook fired first; the consumer chain is now parked on the deferred.
+  expect(log).toEqual(["independent", "consumer:start"]);
 
   gate.resolve();
   await done;
-  expect(log).toEqual(["consumer:start", "consumer:finish", "settled"]);
+  expect(log).toEqual(["independent", "consumer:start", "consumer:finish"]);
 });
 
-test("onGit invokes the settled hook never", async () => {
+// The regression that caused #1193: a consumer that hangs (slow/never-resolving drain pump)
+// must NOT starve the independent hook (plan-gate). Before the fix the hook ran only after
+// `await dispatch()`, so a non-resolving consumer blocked it forever.
+test("a never-resolving consumer does not starve the independent hook", async () => {
+  const log: string[] = [];
+
+  const hanging: SessionConsumer = {
+    name: "drain",
+    handle(): Promise<void> {
+      log.push("consumer:start");
+      return new Promise<void>(() => {}); // never resolves
+    },
+  };
+
+  const router = new SessionRouter({ getSession: () => makeSession("s1", "/r") }, [hanging], {
+    onStatusIndependent: () => log.push("independent"),
+  });
+
+  // Intentionally NOT awaited — onStatus never settles while the consumer hangs.
+  void router.onStatus("s1", "idle");
+  await Promise.resolve();
+  await Promise.resolve();
+
+  // The hook fired despite the consumer hanging forever.
+  expect(log).toEqual(["independent", "consumer:start"]);
+});
+
+test("onGit invokes the independent hook never", async () => {
   const log: string[] = [];
   const router = new SessionRouter(
     { getSession: () => makeSession("s1", "/r") },
     [recordingConsumer("drain", log)],
     {
-      onStatusSettled: () => log.push("settled"),
+      onStatusIndependent: () => log.push("independent"),
     },
   );
   await router.onGit("s1", GIT_STATE);


### PR DESCRIPTION
Fixes #1193.

## Problem
Auto plan review (initial **and** re-review) became flaky since #1170 — it frequently never starts, while the manual **Review plan** button always works.

`#1170` moved the plan-gate from an independent fire-and-forget `session:status` subscriber into `SessionRouter`'s status hook, which ran **after** the awaited consumer chain:

```
onStatus → buildSnapshot → await dispatch()   // drain pump THEN autopilot, each awaited
                         → onStatusSettled()   // plan-gate ran ONLY here, last
```

`drain.handle()` runs an unbounded, timeout-free pump (up to 100 steps of forge/network calls). The router's `try/catch` only protects against a consumer that *throws* — one that merely **hangs** leaves `await consumer.handle()` pending forever, so the plan-gate hook never fires. Manual review works because `POST /api/sessions/:id/review-plan` calls `planGate.consider()` directly.

## Fix (Option 1 — decouple, per the issue)
Kick the independent status hook **before** awaiting `dispatch()`, so a slow/hanging consumer can never starve it. The drain→autopilot ordering (built for the retire-vs-steer race) is untouched; the plan-gate was never part of that race.

`PlanGateService.consider()` is self-contained — it reads `.shepherd-plan.md` and claims its in-flight slot **synchronously** — so firing it concurrently with the pump is safe and restores the pre-#1170 independence (no double-spawn).

- `src/session-router.ts` — `onStatus` fires the hook before `await dispatch()`; renamed `onStatusSettled` → `onStatusIndependent`; corrected the now-false "AFTER the chain" comments.
- `src/index.ts` — renamed the hook key at the construction site; `consider()` logic unchanged.
- `test/session-router.test.ts` — rewrote the ordering test to assert the hook fires **before** the chain, and added a regression test proving a **never-resolving** consumer no longer starves the hook. Drain→autopilot ordering, failure-isolation, unknown-session, and onGit tests unchanged.

**Out of scope:** Option 2 (timeout/AbortSignal on consumer awaits) — the pump's missing timeouts are a separate pre-existing concern; aborting mid-merge carries its own risk and isn't needed here.

Server-only change — no UI / i18n / feature-catalog / glossary surface.

## Verification
- `bun run lint` ✓
- `bun run typecheck` ✓
- `bun test test/session-router.test.ts` → 10 pass
- `bun test test/plan-gate-service.test.ts test/server-plan-gate.test.ts` → 72 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)