### PR TITLE
fix(build-queue): suppress reconcile nudge during plan gate

### DIFF
--- a/src/build-queue-reminder.ts
+++ b/src/build-queue-reminder.ts
@@ -17,11 +17,14 @@
 //   - `sawRunning` evidence gate — an approved+all-pending queue is indistinguishable from
 //     "just approved, not yet started", so we only nudge after observing the agent actually
 //     run, which also avoids colliding with the APPROVE_STEER "Begin now" steer.
+//   - plan-gate gate — while planPhase is "planning", an auto-approved queue is legitimately
+//     all-pending (no execution step has begun), so we never nudge; the gate's flip to
+//     "executing" is the re-arm point. See the considerSession guard for the full rationale.
 //   - once per idle episode + a per-session lifetime cap (runaway guard).
 // Agent-facing text is fixed English (precedent: APPROVE_STEER, AUTOPILOT_DIRECTIVE).
 
 import type { SessionStore } from "./store";
-import type { BuildQueue, SessionStatus } from "./types";
+import type { BuildQueue, Session, SessionStatus } from "./types";
 
 const DEFAULT_IDLE_THRESHOLD_MS = 120_000;
 const DEFAULT_MAX_NUDGES = 3;
@@ -107,7 +110,7 @@ export class BuildQueueReminderService {
     const live = new Set<string>();
     for (const s of this.deps.store.list({ activeOnly: true })) {
       live.add(s.id);
-      this.considerSession(s.id, s.status, now);
+      this.considerSession(s.id, s.status, s.planPhase, now);
     }
     // Forget sessions that are no longer active/listed.
     for (const id of [...this.debounce.keys()]) {
@@ -116,7 +119,12 @@ export class BuildQueueReminderService {
   }
 
   /** Advance one session's debounce and nudge it if it's a drifted, settled-idle queue. */
-  private considerSession(id: string, status: SessionStatus, now: number): void {
+  private considerSession(
+    id: string,
+    status: SessionStatus,
+    planPhase: Session["planPhase"],
+    now: number,
+  ): void {
     const q = this.deps.store.getBuildQueue(id);
     // No approved queue yet (or none authored) → nothing to reconcile; drop any state.
     if (!q.approved || q.steps.length === 0) {
@@ -124,6 +132,19 @@ export class BuildQueueReminderService {
       return;
     }
     const e = this.entry(id);
+
+    // Plan gate: while the session is still "planning", an auto-approved queue is legitimately
+    // all-pending — no execution step has begun, so all-pending is correct, not drift. Return
+    // BEFORE the status switch so planning-phase running never sets sawRunning (readyToNudge
+    // ANDs on sawRunning, so this alone suppresses the nudge) and idle time can't accrue toward
+    // a post-gate nudge. NOTE: execution CAN occur while still "planning" (operator manually
+    // steers instead of clicking Go); we suppress there too by design — the PR-open flip to
+    // "executing" (service.advanceToExecutionOnPr) is the deliberate re-arm point, after which
+    // a fresh execution-running tick sets sawRunning and genuine drift nudges normally.
+    if (planPhase === "planning") {
+      this.resetEpisode(e);
+      return;
+    }
 
     // Only `idle` is eligible. `running` records work-seen; everything else (done/blocked/
     // archived) is skipped without steering. All non-idle states reset the idle episode.

--- a/test/build-queue-reminder.test.ts
+++ b/test/build-queue-reminder.test.ts
@@ -16,20 +16,25 @@ function queue(approved: boolean, statuses: BuildStepStatus[]): BuildQueue {
   return { sessionId: "S", approved, steps: statuses.map((st, i) => step(i, st)) };
 }
 
-function session(status: SessionStatus): Session {
-  // Only id + status are read by the service; the rest is filler to satisfy the type.
-  return { id: "S", status } as unknown as Session;
+function session(status: SessionStatus, planPhase: Session["planPhase"] = null): Session {
+  // Only id + status + planPhase are read by the service; the rest is filler.
+  return { id: "S", status, planPhase } as unknown as Session;
 }
 
 const THRESHOLD = 1000;
 
 /** Build a service over a single session whose status + queue are mutable between sweeps. */
 function harness(initialStatus: SessionStatus, initialQueue: BuildQueue) {
-  const state = { status: initialStatus, queue: initialQueue, t: 0 };
+  const state = {
+    status: initialStatus,
+    queue: initialQueue,
+    planPhase: null as Session["planPhase"],
+    t: 0,
+  };
   const steers: string[] = [];
   const svc = new BuildQueueReminderService({
     store: {
-      list: () => [session(state.status)],
+      list: () => [session(state.status, state.planPhase)],
       getBuildQueue: () => state.queue,
     } as never,
     steer: (_id, text) => {
@@ -132,6 +137,46 @@ test("negatives: has-active / all-done / unapproved / empty → no steer", () =>
     settleAndSweep(h);
     expect(h.steers).toHaveLength(0);
   }
+});
+
+// ── sweep: plan gate ────────────────────────────────────────────────────────
+
+test("plan gate: planning + drifted + settled idle → no steer", () => {
+  const h = harness("idle", queue(true, ["pending", "pending"]));
+  h.state.planPhase = "planning";
+  // Run during planning (must NOT set sawRunning), then settle idle and tick past threshold.
+  h.state.status = "running";
+  h.svc.sweep();
+  h.state.status = "idle";
+  h.svc.sweep(); // first idle tick (reset by the planning guard anyway)
+  h.state.t += THRESHOLD + 1;
+  h.svc.sweep(); // settled — but still planning → suppressed
+  expect(h.steers).toHaveLength(0);
+});
+
+test("plan gate: planning suppresses, then executing nudges once after a post-flip run", () => {
+  const h = harness("idle", queue(true, ["pending", "pending"]));
+  h.state.planPhase = "planning";
+
+  // Phase 1 — run + settle idle while still planning: no steer, and sawRunning stays false.
+  h.state.status = "running";
+  h.svc.sweep();
+  h.state.status = "idle";
+  h.svc.sweep();
+  h.state.t += THRESHOLD + 1;
+  h.svc.sweep();
+  expect(h.steers).toHaveLength(0);
+
+  // Phase 2 — gate opens. A fresh execution run is required to arm sawRunning (the planning
+  // run above never counted), so drive running AFTER the flip, then settle idle.
+  h.state.planPhase = "executing";
+  h.state.status = "running";
+  h.svc.sweep(); // sawRunning set now
+  h.state.status = "idle";
+  h.svc.sweep(); // first idle tick of a fresh episode
+  h.state.t += THRESHOLD + 1;
+  h.svc.sweep(); // settled, executing, drifted → nudge
+  expect(h.steers).toEqual([RECONCILE_STEER]);
 });
 
 // ── sweep: episode reset + lifetime cap + retry ─────────────────────────────


### PR DESCRIPTION
## Problem

The build-queue reconciliation nudge (`RECONCILE_STEER`) mis-fired at sessions still in the **plan gate**. During planning, Shepherd auto-approves the queue for visibility, so it sits `approved` with every step `pending`. The agent runs (grilling/planning/authoring the plan + queue) — tripping the `sawRunning` evidence gate — then settles idle awaiting plan review. The drift test `isQueueDrifted` (approved + pending + no active) is satisfied, so the nudge fired, telling the agent to mark a step `active`/`done` when **all-pending is the correct pre-execution state**. The agent correctly pushed back, proving the nudge fired pointlessly.

## Fix

Suppress the nudge while `session.planPhase === "planning"`. `sweep()` threads `planPhase` into `considerSession`, which returns **before** the status switch while planning:

- **`sawRunning` never arms** — `readyToNudge` ANDs on it, so this alone suppresses the nudge (planning-phase running isn't counted as execution-work-seen).
- **`idleSince` is reset** — idle time can't pre-arm a post-gate nudge.

The queue stays auto-approved (visibility intact); only the *nudge* is gated on execution having started. After the gate opens — `"executing"` via Go-click (`releasePlanGate`) or the PR-driven `advanceToExecutionOnPr` manual-steer path, or `null` when the gate is off — the guard is inert and a fresh execution-`running` tick re-arms normally.

### Manual-steer window (intentional)

`advanceToExecutionOnPr` (service.ts:2628) means code *can* execute while `planPhase === "planning"` (operator manually steers instead of clicking Go). The guard suppresses nudges across that window **by design** — the session is officially still in the gate, and the PR-open flip to `"executing"` is the deliberate re-arm point.

## Tests

- planning + drifted + settled idle → **no steer**
- planning suppresses, then `"executing"` nudges once **after a post-flip `running` observation** (load-bearing: `sawRunning` is never set during planning)
- Existing 11 tests unchanged (`session()` fixture leaves `planPhase` undefined).

`bun test ./test`: 5182 pass, 0 fail. `bun run lint`: clean.

[no-feature-entry] — server-only plumbing; `RECONCILE_STEER` is fixed English by existing precedent. No UI/i18n/glossary surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)