### PR TITLE
fix(checks): treat no-CI GitHub repos as CI-cleared across the autonomous pipeline

### DIFF
--- a/src/automerge-core.ts
+++ b/src/automerge-core.ts
@@ -2,6 +2,7 @@ import type { ChecksState, PrStatus } from "./forge/types";
 import type { ReviewDecision } from "./types";
 import type { ManualStep } from "./manual-steps";
 import { signedOff, type SignoffAuthority } from "./signoff";
+import { checksCleared } from "./checks-gate";
 
 /** Why the merge train is holding — surfaced on automerge:status. */
 export interface MergeHoldReason {
@@ -23,6 +24,9 @@ export interface MergeSessionView {
   desig: string;
   state: PrStatus["state"];
   checks: ChecksState;
+  /** True when the repo has no CI to wait on (GitHub + zero workflows): a terminal checks:"none"
+   *  counts as cleared for merge. Projected from the cached GitState's noCi. */
+  noCi: boolean;
   /** null = host still computing; treat as not-yet-mergeable. */
   mergeable: boolean | null;
   number: number | null;
@@ -101,7 +105,7 @@ function readyExceptManualSteps(
   authority: SignoffAuthority,
 ): boolean {
   if (s.mergeBlocked) return false; // backed off after repeated merge failures → skip, try siblings
-  if (s.state !== "open" || s.checks !== "success" || s.mergeable !== true || !s.number)
+  if (s.state !== "open" || !checksCleared(s.checks, s.noCi) || s.mergeable !== true || !s.number)
     return false;
   if (s.behind !== false) return false; // true=stale, null=unknown → not now
   if (draftMode && !signedOff(authority, signoffView(s))) return false; // backstop: never merge an unsigned draft
@@ -136,7 +140,7 @@ function needsRebase(
   draftMode: boolean,
   authority: SignoffAuthority,
 ): boolean {
-  if (s.state !== "open" || s.checks !== "success" || !s.number) return false;
+  if (s.state !== "open" || !checksCleared(s.checks, s.noCi) || !s.number) return false;
   // A rebase for this exact head is already outstanding/in-progress → not actionable
   // (computeMerge falls through to an idle hold rather than re-steer + re-bump).
   if (s.headSha !== null && s.rebaseSteeredHead === s.headSha) return false;

--- a/src/automerge.ts
+++ b/src/automerge.ts
@@ -134,6 +134,7 @@ export class AutoMergeService {
     return {
       state: git?.state ?? ("none" as const),
       checks: git?.checks ?? ("none" as const),
+      noCi: git?.noCi ?? false,
       mergeable: git?.mergeable ?? null,
       number: git?.number ?? null,
       headSha: git?.headSha ?? null,

--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -5,6 +5,7 @@ import type { GitState } from "./forge/types";
 import type { SessionStateChange } from "./session-snapshot";
 import { effectiveAutopilot } from "./effective-autopilot";
 import { signedOff } from "./signoff";
+import { checksCleared } from "./checks-gate";
 import { DRAFT_PR_NOTE } from "./service";
 
 /**
@@ -614,7 +615,13 @@ export class AutopilotService {
     if (this.pending.has(s.id)) return null; // a classify (onDone/onBlock) is mid-flight — don't race it
     if (this.deps.fullAuto(s.id)) return null; // full-auto is the merge train's job, not autopilot's
     const git = this.deps.prGit(s.id);
-    if (!git || git.state !== "open" || git.isDraft || git.checks !== "success") return null;
+    if (
+      !git ||
+      git.state !== "open" ||
+      git.isDraft ||
+      !checksCleared(git.checks, git.noCi ?? false)
+    )
+      return null;
     return this.rebaseReviewPassed(s, git) ? git : null;
   }
 

--- a/src/checks-gate.ts
+++ b/src/checks-gate.ts
@@ -1,0 +1,48 @@
+/**
+ * No-CI gate helpers. A GitHub repo that defines ZERO workflows has no CI to wait on, so its
+ * head commit's `statusCheckRollup` is permanently empty and rolls up to `checks: "none"` — which
+ * every `checks === "success"` gate would otherwise treat identically to "CI hasn't gone green
+ * yet" and block forever (no auto-review, no auto-merge, never surfaced as awaiting-merge).
+ *
+ * `checks: "none"` is therefore ambiguous: a no-CI repo (terminal — review/merge now) vs. a CI
+ * repo whose checks haven't registered yet (a transient pre-CI race — keep waiting). We resolve it
+ * with the repo's DEFINED workflow count: a CI repo has workflow files on disk, a no-CI repo has
+ * none. Scoped to GitHub on purpose — the workflow glob is `.github/workflows`-only (Gitea uses
+ * `.gitea/workflows`), and LocalForge already auto-greens its pseudo-PRs, so other forges keep the
+ * strict green gate.
+ */
+import { countDefinedWorkflows } from "./backlog";
+import type { ChecksState, ForgeKind } from "./forge/types";
+
+/** True when `forgeKind` is GitHub AND the repo defines zero workflows ⇒ no CI to wait on. */
+export function repoHasNoCi(forgeKind: ForgeKind, definedWorkflows: number): boolean {
+  return forgeKind === "github" && definedWorkflows === 0;
+}
+
+/** Whether a PR's CI is "cleared" for an autonomous action (review / merge / surface): green CI
+ *  always clears; a no-CI repo's terminal `checks:"none"` clears too. A CI repo's transient
+ *  `"none"` does NOT (its `noCi` is false because it has workflows on disk), so it keeps waiting. */
+export function checksCleared(checks: ChecksState, noCi: boolean): boolean {
+  return checks === "success" || (noCi && checks === "none");
+}
+
+const CACHE_TTL_MS = 60_000;
+const countCache = new Map<string, { at: number; count: number }>();
+
+/** {@link repoHasNoCi} for production call sites, with the `countDefinedWorkflows` readdir
+ *  TTL-memoized per repo (workflow files change rarely). Keeps the hot paths — the standalone
+ *  critic's per-PR sweep, the per-poll `annotateHandoff`, the epic-landing enrich — from doing a
+ *  readdir per candidate. Tests use the pure {@link repoHasNoCi} with an explicit count. */
+export function repoHasNoCiCached(
+  forgeKind: ForgeKind,
+  repoPath: string,
+  now: () => number = Date.now,
+): boolean {
+  if (forgeKind !== "github") return false;
+  const t = now();
+  const hit = countCache.get(repoPath);
+  if (hit && t - hit.at < CACHE_TTL_MS) return hit.count === 0;
+  const count = countDefinedWorkflows(repoPath);
+  countCache.set(repoPath, { at: t, count });
+  return count === 0;
+}

--- a/src/completed-epic.ts
+++ b/src/completed-epic.ts
@@ -1,5 +1,6 @@
 import type { EpicChild } from "./epic-core";
-import type { ChecksState, PrStatus } from "./forge/types";
+import type { ChecksState, ForgeKind, PrStatus } from "./forge/types";
+import { checksCleared, repoHasNoCiCached } from "./checks-gate";
 
 export interface CompletedEpicChild {
   number: number;
@@ -60,12 +61,15 @@ export const EPIC_LANDING_STRANDED_MS = 6 * 60 * 60_000;
  *  - "blocked": branch-protection rules are blocking the merge; the app-triggered merge would fail,
  *    so we must NOT show an enabled CTA that fires a doomed merge call.
  *  - "behind", "dirty", "unstable", "draft", "unknown": also not mergeable.
- *  When mergeStateStatus is undefined (Gitea), we fall back to state+checks+mergeable alone. */
+ *  When mergeStateStatus is undefined (Gitea), we fall back to state+checks+mergeable alone.
+ *  `noCi` (GitHub repo with zero workflows) lets a terminal checks:"none" count as cleared — a
+ *  no-CI repo's landing PR is still mergeable (mergeStateStatus stays the authoritative gate). */
 export function computeLandingReady(
   pr: Pick<PrStatus, "state" | "checks" | "mergeable" | "mergeStateStatus">,
+  noCi = false,
 ): boolean {
   if (pr.state !== "open") return false;
-  if (pr.checks !== "success") return false;
+  if (!checksCleared(pr.checks, noCi)) return false;
   if (pr.mergeable !== true) return false;
   if (pr.mergeStateStatus === undefined) return true; // Gitea fallback
   return pr.mergeStateStatus === "clean" || pr.mergeStateStatus === "has_hooks";
@@ -92,7 +96,7 @@ export interface EnrichLandingDeps {
   getEpicIntegrationBranch: (repoPath: string, parentIssueNumber: number) => string | null;
   resolveForge: (
     repoPath: string,
-  ) => { prStatus: (headBranch: string) => Promise<PrStatus> } | null | undefined;
+  ) => { kind: ForgeKind; prStatus: (headBranch: string) => Promise<PrStatus> } | null | undefined;
   now: number;
 }
 
@@ -116,7 +120,7 @@ export async function enrichLandingEpics(
         const pr = await forge.prStatus(branch);
         row.landingChecks = pr.checks;
         row.landingMergeable = pr.mergeable ?? null;
-        const landingReady = computeLandingReady(pr);
+        const landingReady = computeLandingReady(pr, repoHasNoCiCached(forge.kind, row.repoPath));
         row.landingReady = landingReady;
         row.landingStranded = computeLandingStranded({
           landingState: "open",

--- a/src/drain-core.ts
+++ b/src/drain-core.ts
@@ -1,6 +1,7 @@
 import type { Issue, GitState } from "./forge/types";
 import type { SessionStatus, ReviewDecision } from "./types";
 import { signedOff, type SignoffAuthority, type SignoffView } from "./signoff";
+import { checksCleared } from "./checks-gate";
 
 /** Issues carrying this label jump to the head of the drain queue. Fixed (the
  *  per-repo `autoLabel` is configurable, but the priority marker is a constant
@@ -134,7 +135,13 @@ function readyToRetire(
   authority: SignoffAuthority,
 ): boolean {
   const g = s.git;
-  if (!g || g.state !== "open" || g.checks !== "success" || g.mergeable !== true || !g.number) {
+  if (
+    !g ||
+    g.state !== "open" ||
+    !checksCleared(g.checks, g.noCi ?? false) ||
+    g.mergeable !== true ||
+    !g.number
+  ) {
     return false;
   }
   if (draftMode) {
@@ -158,7 +165,13 @@ function awaitingSignoff(
 ): boolean {
   if (!draftMode) return false;
   const g = s.git;
-  if (!g || g.state !== "open" || g.checks !== "success" || g.mergeable !== true || !g.number) {
+  if (
+    !g ||
+    g.state !== "open" ||
+    !checksCleared(g.checks, g.noCi ?? false) ||
+    g.mergeable !== true ||
+    !g.number
+  ) {
     return false;
   }
   return !signedOff(authority, signoffView(s));

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -29,6 +29,7 @@ import {
   type EpicLandingState,
 } from "./completed-epic";
 import { buildLandingPrTitle, buildLandingPrBody } from "./epic-landing";
+import { repoHasNoCiCached } from "./checks-gate";
 import { EmptyDiffError } from "./forge/types";
 import { mapBounded } from "./map-bounded";
 import { config } from "./config";
@@ -1278,7 +1279,8 @@ export class DrainService {
       return;
     }
     if (pr.isDraft) return; // never merge a draft (computeLandingReady's Gitea fallback can't tell)
-    if (!computeLandingReady(pr)) return; // not green / mergeable yet
+    // not green / mergeable yet (no-CI repos: a terminal checks:"none" + clean mergeStateStatus is ready)
+    if (!computeLandingReady(pr, repoHasNoCiCached(forge.kind, repoPath))) return;
     const key = `${repoPath}#${parentIssueNumber}`;
     if (this.landMergeBlocked(key, pr.headSha ?? "")) return; // backed off on this head
     try {

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -197,6 +197,11 @@ export interface PrStatus {
  *  payload and the value cached/pushed for the list overview. */
 export interface GitState extends PrStatus {
   kind: ForgeKind;
+  /** True when the repo has no CI to wait on (GitHub + zero defined workflows), so a terminal
+   *  `checks:"none"` should be treated as cleared for review/merge/surface rather than as a
+   *  not-yet-green CI race. Stamped once in `annotateHandoff` (the poller + on-demand `/git`
+   *  chokepoint); consumed via `checksCleared`. Absent ⇒ false. */
+  noCi?: boolean;
   /** Who is up once the PR is open + green, when it isn't the operator — computed
    *  server-side from `.shepherd/roles.json` + the operator's login. Absent = the
    *  operator's turn (today's "awaiting merge"). Drives the herd's

--- a/src/issue-log.ts
+++ b/src/issue-log.ts
@@ -1,6 +1,7 @@
 import { SHEPHERD_ISSUE_LOG_MARKER } from "./forge/types";
 import type { GitForge, GitState } from "./forge/types";
 import type { Session } from "./types";
+import { checksCleared } from "./checks-gate";
 
 /**
  * Issue-log: the workflow protocol on a session's backlog issue. For a session
@@ -43,7 +44,12 @@ export function issueLogEntries(
   // the full condition so a stale/hand-rolled GitState can't comment early. An
   // auto-inferred handoff (no roles.json) is excluded — the outward comment is
   // opt-in to explicitly-configured roles (see module doc).
-  if (git.state === "open" && git.checks === "success" && git.handoff && !git.handoffInferred) {
+  if (
+    git.state === "open" &&
+    checksCleared(git.checks, git.noCi ?? false) &&
+    git.handoff &&
+    !git.handoffInferred
+  ) {
     const key = `waiting:${git.number}`;
     if (!alreadyLogged(key)) out.push({ key, body: stamp(waitingBody(git, git.number)) });
   }

--- a/src/ready-stage.ts
+++ b/src/ready-stage.ts
@@ -4,6 +4,7 @@
 import type { Session, SessionStatus } from "./types";
 import type { GitState } from "./forge/types";
 import { isMerging } from "./rundown-core";
+import { checksCleared } from "./checks-gate";
 
 /** Display-side session status — port of ui/src/lib/display-status.ts.
  *  A session herdr reports "blocked" but the server flagged as working-while-blocked
@@ -72,7 +73,7 @@ function stageOf(
   // the partition and doesn't need threading through here.
   const greenIdle =
     g?.state === "open" &&
-    g.checks === "success" &&
+    checksCleared(g.checks, g.noCi ?? false) &&
     s.status !== "running" &&
     s.status !== "blocked";
   return greenIdle ? handoffStage(g) : "active";

--- a/src/repo-roles.ts
+++ b/src/repo-roles.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { rmSync } from "node:fs";
 import type { GitState, PrStatus } from "./forge/types";
+import { checksCleared, repoHasNoCiCached } from "./checks-gate";
 
 /** Per-repo responsibility config, committed to `.shepherd/roles.json` at the repo
  *  root. Values are GitHub logins (the merger/reviewer for this repo) or null when
@@ -147,11 +148,15 @@ function readRolesFromRef(repoPath: string): RepoRoles {
  *  an open + green PR carries a handoff (the only point the herd consults it);
  *  everything else is returned without one. */
 export function annotateHandoff(state: GitState, repoPath: string, me: string | null): GitState {
-  const base: GitState = { ...state };
+  // Stamp noCi on EVERY state (the poller + on-demand /git chokepoint) so all downstream gates can
+  // read git.noCi without re-deriving it. A no-CI repo (GitHub + zero workflows) treats a terminal
+  // checks:"none" as cleared — see checks-gate.ts.
+  const noCi = repoHasNoCiCached(state.kind, repoPath);
+  const base: GitState = { ...state, noCi };
   delete base.handoff; // drop any stale handoff so a role change clears it
   delete base.handoffWho;
   delete base.handoffInferred;
-  if (base.state !== "open" || base.checks !== "success") return base;
+  if (base.state !== "open" || !checksCleared(base.checks, noCi)) return base;
   const { handoff, handoffWho, inferred } = computeHandoff(
     readRepoRoles(repoPath),
     me,

--- a/src/review.ts
+++ b/src/review.ts
@@ -9,6 +9,7 @@ import { buildTransientAgentArgv } from "./transient-agent-argv";
 import { isApiKeyMode, isApiKeyConfigured, apiKeyPassthroughEnv } from "./spawn-auth";
 import { jsonlPathFor, readSessionUsage, type SessionUsage } from "./usage";
 import { readActivitySignal } from "./activity-signal";
+import { checksCleared } from "./checks-gate";
 import { isSpawnWorking, decideVerdictAction } from "./json-tolerant";
 import type { VerdictRead } from "./json-tolerant";
 import {
@@ -221,7 +222,12 @@ export class ReviewService {
     opts?: { force?: boolean },
   ): Promise<ReviewOutcome> {
     const force = opts?.force === true;
-    if (git.state !== "open" || git.checks !== "success" || !git.headSha || !git.number)
+    if (
+      git.state !== "open" ||
+      !checksCleared(git.checks, git.noCi ?? false) ||
+      !git.headSha ||
+      !git.number
+    )
       return "skipped";
     if (!session.branch) return "skipped";
     if (!this.deps.store.getRepoConfig(session.repoPath).criticEnabled) return "skipped";

--- a/src/server.ts
+++ b/src/server.ts
@@ -125,6 +125,7 @@ import {
   enrichLandingEpics,
   type CompletedEpic,
 } from "./completed-epic";
+import { repoHasNoCiCached } from "./checks-gate";
 import { parseEpicBody } from "./epic-parse";
 import { countDefinedWorkflows, type CountsService, type RepoCounts } from "./backlog";
 import { join, normalize, basename } from "node:path";
@@ -5166,7 +5167,8 @@ async function resolveLandTarget(
     return { error: json({ error: msg }, 502) };
   }
 
-  if (!computeLandingReady(pr)) return { error: json({ error: "landing PR not ready" }, 409) };
+  if (!computeLandingReady(pr, repoHasNoCiCached(forge.kind, dir)))
+    return { error: json({ error: "landing PR not ready" }, 409) };
 
   return { dir, parent, row, forge, branch, pr };
 }

--- a/src/standalone-critic.ts
+++ b/src/standalone-critic.ts
@@ -25,6 +25,7 @@ import type { GitForge, PrReviewMeta, PullRequest } from "./forge/types";
 import { CRITIC_REVIEW_MARKER } from "./forge/types";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
 import { isEpicIntegrationBranch } from "./epic-branch";
+import { checksCleared, repoHasNoCiCached } from "./checks-gate";
 import { isApiKeyMode, isApiKeyConfigured, apiKeyPassthroughEnv } from "./spawn-auth";
 import { readSessionUsage, type SessionUsage } from "./usage";
 import {
@@ -216,6 +217,9 @@ export class StandalonePrCriticService {
     // repo lands in the swept set apart: flag ON → review every eligible PR (old behavior); flag OFF
     // → this repo is here ONLY for its epic landing PR, so eligible() restricts to that one PR.
     const criticAllPrs = cfg.criticAllPrs;
+    // Resolve no-CI status ONCE per repo per sweep (not per candidate PR): a GitHub repo with zero
+    // workflows has no CI to wait on, so its PRs' terminal checks:"none" is reviewable.
+    const noCi = repoHasNoCiCached(forge.kind, repoPath);
 
     let prs: PullRequest[];
     try {
@@ -226,7 +230,7 @@ export class StandalonePrCriticService {
     }
 
     const candidates = prs.filter((pr) =>
-      this.eligible(repoPath, pr, managed, criticEnabled, criticAllPrs),
+      this.eligible(repoPath, pr, managed, criticEnabled, criticAllPrs, noCi),
     );
     let deferred = 0;
     for (const pr of candidates) {
@@ -253,11 +257,13 @@ export class StandalonePrCriticService {
     managed: Set<string>,
     criticEnabled: boolean,
     criticAllPrs: boolean,
+    noCi: boolean,
   ): boolean {
     if (pr.isDraft) return false;
     // Best-effort TOCTOU gate: the rollup can change between enumeration and spawn, but a green
-    // read here is the right cheap filter (a finalize-time live-state recheck backstops the rest).
-    if (pr.checks !== "success") return false;
+    // (or no-CI terminal) read here is the right cheap filter (a finalize-time live-state recheck
+    // backstops the rest).
+    if (!checksCleared(pr.checks, noCi)) return false;
     if (pr.kind !== "regular") return false; // Dependabot / release-please bots — not for the critic
     if (!pr.headSha || !pr.headRefName) {
       this.log(`[pr-critic] ${repoPath}#${pr.number} missing headSha/headRefName — skipping`);

--- a/test/automerge-core.test.ts
+++ b/test/automerge-core.test.ts
@@ -7,6 +7,7 @@ function sess(o: Partial<MergeSessionView> = {}): MergeSessionView {
     desig: "TASK-01",
     state: "open",
     checks: "success",
+    noCi: false,
     mergeable: true,
     number: 7,
     headSha: "h1",
@@ -43,6 +44,24 @@ test("disabled → hold", () => {
 test("open+green+mergeable+current → merge (critic off)", () => {
   const d = computeMerge(state([sess()]));
   expect(d).toEqual({ kind: "merge", sessionId: "s1", prNumber: 7, headSha: "h1" });
+});
+
+test("no-CI repo (noCi + checks:none) → merge", () => {
+  // A GitHub repo with zero workflows reports checks:"none" forever; with noCi it's mergeable.
+  const d = computeMerge(state([sess({ checks: "none", noCi: true })]));
+  expect(d).toEqual({ kind: "merge", sessionId: "s1", prNumber: 7, headSha: "h1" });
+});
+
+test("checks:none WITHOUT noCi → hold (CI repo pre-green, not merged)", () => {
+  expect(computeMerge(state([sess({ checks: "none", noCi: false })])).kind).toBe("hold");
+});
+
+test("no-CI repo but not mergeable → rebase (mergeable gate still bites)", () => {
+  expect(computeMerge(state([sess({ checks: "none", noCi: true, mergeable: false })]))).toEqual({
+    kind: "rebase",
+    sessionId: "s1",
+    headSha: "h1",
+  });
 });
 
 test("behind → rebase", () => {

--- a/test/checks-gate.test.ts
+++ b/test/checks-gate.test.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "bun:test";
+import { repoHasNoCi, checksCleared, repoHasNoCiCached } from "../src/checks-gate";
+
+test("repoHasNoCi: github + zero workflows → true", () => {
+  expect(repoHasNoCi("github", 0)).toBe(true);
+});
+
+test("repoHasNoCi: github + ≥1 workflow → false", () => {
+  expect(repoHasNoCi("github", 1)).toBe(false);
+});
+
+test("repoHasNoCi: non-github → false even with zero workflows", () => {
+  expect(repoHasNoCi("gitea", 0)).toBe(false);
+  expect(repoHasNoCi("local", 0)).toBe(false);
+});
+
+test("checksCleared: success always clears (noCi irrelevant)", () => {
+  expect(checksCleared("success", false)).toBe(true);
+  expect(checksCleared("success", true)).toBe(true);
+});
+
+test("checksCleared: none clears only when noCi", () => {
+  expect(checksCleared("none", true)).toBe(true);
+  expect(checksCleared("none", false)).toBe(false);
+});
+
+test("checksCleared: pending/failure never clear", () => {
+  expect(checksCleared("pending", true)).toBe(false);
+  expect(checksCleared("failure", true)).toBe(false);
+});
+
+test("checksCleared(checks, false) ≡ checks === 'success' (back-compat)", () => {
+  for (const c of ["none", "pending", "success", "failure"] as const) {
+    expect(checksCleared(c, false)).toBe(c === "success");
+  }
+});
+
+test("repoHasNoCiCached: non-github short-circuits without a readdir", () => {
+  // A path that doesn't exist would count 0 workflows, but non-github must still be false.
+  expect(repoHasNoCiCached("gitea", "/no/such/repo")).toBe(false);
+});
+
+test("repoHasNoCiCached: memoizes within the TTL window", () => {
+  let t = 0;
+  const now = () => t;
+  const repo = "/tmp/checks-gate-nonexistent-" + "memo"; // missing dir ⇒ count 0 ⇒ true (github)
+  expect(repoHasNoCiCached("github", repo, now)).toBe(true);
+  // Same answer on a cache hit; advancing past the TTL re-reads (still 0 → true).
+  t = 1000;
+  expect(repoHasNoCiCached("github", repo, now)).toBe(true);
+  t = 120_000;
+  expect(repoHasNoCiCached("github", repo, now)).toBe(true);
+});

--- a/test/completed-epic.test.ts
+++ b/test/completed-epic.test.ts
@@ -191,6 +191,35 @@ describe("computeLandingReady", () => {
     expect(computeLandingReady({ state: "open", checks: "success", mergeable: true })).toBe(true);
   });
 
+  it("no-CI repo (noCi + checks:none + clean) → ready", () => {
+    expect(
+      computeLandingReady(
+        { state: "open", checks: "none", mergeable: true, mergeStateStatus: "clean" },
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it("checks:none WITHOUT noCi → NOT ready (CI repo pre-green)", () => {
+    expect(
+      computeLandingReady({
+        state: "open",
+        checks: "none",
+        mergeable: true,
+        mergeStateStatus: "clean",
+      }),
+    ).toBe(false);
+  });
+
+  it("no-CI but blocked mergeStateStatus → NOT ready (mergeStateStatus still authoritative)", () => {
+    expect(
+      computeLandingReady(
+        { state: "open", checks: "none", mergeable: true, mergeStateStatus: "blocked" },
+        true,
+      ),
+    ).toBe(false);
+  });
+
   it("not-open → NOT ready", () => {
     expect(
       computeLandingReady({
@@ -310,7 +339,7 @@ describe("enrichLandingEpics", () => {
     const rows = [baseEpic({ completedAt: 0 })];
     await enrichLandingEpics(rows, {
       getEpicIntegrationBranch: () => "epic/7",
-      resolveForge: () => ({ prStatus: async () => prStatus() }),
+      resolveForge: () => ({ kind: "local", prStatus: async () => prStatus() }),
       now: EPIC_LANDING_STRANDED_MS + 1, // completed long ago → stranded
     });
     expect(rows[0]?.landingReady).toBe(true);
@@ -323,7 +352,10 @@ describe("enrichLandingEpics", () => {
     const rows = [baseEpic({ completedAt: 0 })];
     await enrichLandingEpics(rows, {
       getEpicIntegrationBranch: () => "epic/7",
-      resolveForge: () => ({ prStatus: async () => prStatus({ checks: "failure" }) }),
+      resolveForge: () => ({
+        kind: "local",
+        prStatus: async () => prStatus({ checks: "failure" }),
+      }),
       now: EPIC_LANDING_STRANDED_MS + 1,
     });
     expect(rows[0]?.landingReady).toBe(false);
@@ -334,7 +366,7 @@ describe("enrichLandingEpics", () => {
     const rows = [baseEpic({ landingState: "merged" })];
     await enrichLandingEpics(rows, {
       getEpicIntegrationBranch: () => "epic/7",
-      resolveForge: () => ({ prStatus: async () => prStatus() }),
+      resolveForge: () => ({ kind: "local", prStatus: async () => prStatus() }),
       now: 0,
     });
     expect(rows[0]?.landingReady).toBeUndefined();
@@ -344,7 +376,7 @@ describe("enrichLandingEpics", () => {
     const rows = [baseEpic()];
     await enrichLandingEpics(rows, {
       getEpicIntegrationBranch: () => null,
-      resolveForge: () => ({ prStatus: async () => prStatus() }),
+      resolveForge: () => ({ kind: "local", prStatus: async () => prStatus() }),
       now: 0,
     });
     expect(rows[0]?.landingReady).toBeUndefined();
@@ -365,6 +397,7 @@ describe("enrichLandingEpics", () => {
     await enrichLandingEpics(rows, {
       getEpicIntegrationBranch: () => "epic/7",
       resolveForge: () => ({
+        kind: "local",
         prStatus: async () => {
           throw new Error("network");
         },

--- a/test/drain-core.test.ts
+++ b/test/drain-core.test.ts
@@ -194,6 +194,27 @@ describe("computeNext", () => {
     expect(d).toEqual({ kind: "retire", sessionId: "sX", prNumber: 7 });
   });
 
+  test("retire: no-CI repo (noCi + checks:none + mergeable) → retire", () => {
+    const noCiGit: GitState = { ...MERGEABLE, checks: "none", noCi: true };
+    const d = computeNext(
+      state({
+        autoSessions: [autoSession({ id: "sX", git: noCiGit, reviewDecision: null })],
+      }),
+    );
+    expect(d).toEqual({ kind: "retire", sessionId: "sX", prNumber: 7 });
+  });
+
+  test("retire: checks:none WITHOUT noCi → does NOT retire (CI repo pre-green)", () => {
+    const preGreen: GitState = { ...MERGEABLE, checks: "none" };
+    const d = computeNext(
+      state({
+        autoSessions: [autoSession({ id: "sX", git: preGreen, reviewDecision: null })],
+        candidates: [],
+      }),
+    );
+    expect(d.kind).not.toBe("retire");
+  });
+
   test("retire: commented review still retires", () => {
     const d = computeNext(
       state({

--- a/test/issue-log.test.ts
+++ b/test/issue-log.test.ts
@@ -40,6 +40,22 @@ test("handoff without a login → generic waiting wording", () => {
   expect(e).toEqual([{ key: "waiting:7", body: stamped("⏸️ Waiting on PR #7 to merge.") }]);
 });
 
+test("no-CI repo (noCi + checks:none) + merger handoff → waiting entry", () => {
+  const e = issueLogEntries(
+    open({ checks: "none", noCi: true, handoff: "merger", handoffWho: "scoop" }),
+    never,
+  );
+  expect(e).toEqual([{ key: "waiting:7", body: stamped("⏸️ Waiting on @scoop to merge PR #7.") }]);
+});
+
+test("checks:none WITHOUT noCi + handoff → NO waiting entry (CI repo pre-green)", () => {
+  const e = issueLogEntries(
+    open({ checks: "none", handoff: "merger", handoffWho: "scoop" }),
+    never,
+  );
+  expect(e).toEqual([]);
+});
+
 test("merged → one merged entry, phrased issue-state-agnostic", () => {
   const e = issueLogEntries(open({ state: "merged" }), never);
   expect(e).toEqual([{ key: "merged:7", body: stamped("✅ PR #7 merged.") }]);

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -40,7 +40,10 @@ const OPEN: PrStatus = { state: "open", number: 7, checks: "pending", deployConf
 test("emits session git state on first poll and only again on change", async () => {
   const store = new SessionStore(":memory:");
   const s = store.create(baseSession);
-  const emitted: { id: string; git: { state: string; number?: number; kind: string } }[] = [];
+  const emitted: {
+    id: string;
+    git: { state: string; number?: number; kind: string; noCi?: boolean };
+  }[] = [];
   let cur = OPEN;
   const poller = new PrPoller(
     store,
@@ -49,7 +52,8 @@ test("emits session git state on first poll and only again on change", async () 
   );
 
   await poller.tick();
-  expect(emitted).toEqual([{ id: s.id, git: { ...OPEN, kind: "github" } }]);
+  // annotateHandoff stamps noCi (repoPath "/r" has no .github/workflows ⇒ GitHub no-CI repo).
+  expect(emitted).toEqual([{ id: s.id, git: { ...OPEN, kind: "github", noCi: true } }]);
 
   await poller.tick(); // unchanged → no new emit
   expect(emitted.length).toBe(1);

--- a/test/ready-stage.test.ts
+++ b/test/ready-stage.test.ts
@@ -120,6 +120,26 @@ describe("isReadyForNotify", () => {
     expect(isReadyForNotify(s, git, noReview, noBlocked, NOW)).toBe(true);
   });
 
+  test("no-CI repo (noCi + checks:none) + idle, no handoff (awaitingMerge) → READY", () => {
+    const s = makeSession({ status: "idle" });
+    const git = makeGit({ state: "open", checks: "none", noCi: true });
+    expect(isReadyForNotify(s, git, noReview, noBlocked, NOW)).toBe(true);
+  });
+
+  test("no-CI repo (noCi + checks:none) + idle + handoff=merger (waitingOnMerger) → NOT ready", () => {
+    // Proves noCi engages greenIdle → the handoff routing (not 'active').
+    const s = makeSession({ status: "idle" });
+    const git = makeGit({ state: "open", checks: "none", noCi: true, handoff: "merger" });
+    expect(isReadyForNotify(s, git, noReview, noBlocked, NOW)).toBe(false);
+  });
+
+  test("checks:none WITHOUT noCi + idle + handoff=merger → stays active (handoff ignored)", () => {
+    // A CI repo's pre-green 'none' is NOT greenIdle, so handoffStage never runs → 'active'.
+    const s = makeSession({ status: "idle" });
+    const git = makeGit({ state: "open", checks: "none", handoff: "merger" });
+    expect(isReadyForNotify(s, git, noReview, noBlocked, NOW)).toBe(true);
+  });
+
   test("open PR + checks success + idle + isDraft (draftAwaitingSignoff) → READY", () => {
     const s = makeSession({ status: "idle" });
     const git = makeGit({ state: "open", checks: "success", isDraft: true });

--- a/test/repo-roles.test.ts
+++ b/test/repo-roles.test.ts
@@ -1,8 +1,21 @@
 import { test, expect } from "bun:test";
-import { computeHandoff, parseRoles, normalizeLogin } from "../src/repo-roles";
-import type { PrStatus } from "../src/forge/types";
+import { annotateHandoff, computeHandoff, parseRoles, normalizeLogin } from "../src/repo-roles";
+import type { GitState, PrStatus } from "../src/forge/types";
 
 const approved: PrStatus["latestReview"] = { state: "approved", author: "scoop", submittedAt: 1 };
+
+const gitState = (over: Partial<GitState> = {}): GitState =>
+  ({ kind: "github", state: "open", checks: "none", deployConfigured: false, ...over }) as GitState;
+
+test("annotateHandoff stamps noCi=true for a GitHub repo with no workflows", () => {
+  const g = annotateHandoff(gitState(), "/no/such/repo", "kai");
+  expect(g.noCi).toBe(true);
+});
+
+test("annotateHandoff stamps noCi=false for a non-GitHub forge", () => {
+  const g = annotateHandoff(gitState({ kind: "gitea" }), "/no/such/repo", "kai");
+  expect(g.noCi).toBe(false);
+});
 
 test("merger = self → self (today's 'your turn')", () => {
   const r = computeHandoff({ reviewer: null, merger: "kai" }, "kai", undefined);

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -509,6 +509,21 @@ test("skips when CI not green / PR not open", () => {
   expect(started).toHaveLength(0);
 });
 
+test("no-CI repo (noCi + checks:none) → reviews", async () => {
+  const { deps: d, started } = makeDeps({});
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), { ...OPEN_GREEN, checks: "none", noCi: true });
+  expect(started).toHaveLength(1);
+});
+
+test("checks:none WITHOUT noCi → skipped (CI repo pre-green)", async () => {
+  const { deps: d, started } = makeDeps({});
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), { ...OPEN_GREEN, checks: "none", noCi: false });
+  await svc.consider(session(), { ...OPEN_GREEN, checks: "none" }); // noCi absent ⇒ false
+  expect(started).toHaveLength(0);
+});
+
 test("timeout with no verdict → error verdict, still reaps", async () => {
   let t = 1000;
   const {

--- a/test/standalone-critic.test.ts
+++ b/test/standalone-critic.test.ts
@@ -270,6 +270,27 @@ test("skips draft / non-green / bot PRs", async () => {
   }
 });
 
+test("no-CI GitHub repo (zero workflows) reviews a checks:none PR", async () => {
+  // repos() defaults to "/r" (no .github/workflows) ⇒ repoHasNoCiCached(github) → true.
+  const local = makeDeps({}, { forge: undefined });
+  local.deps.resolveForge = () =>
+    makeForge(local.spies, { prs: [pr({ number: 1, checks: "none" })] });
+  const svc = new StandalonePrCriticService(local.deps as any);
+  await svc.sweep();
+  expect(local.spies.started).toHaveLength(1);
+});
+
+test("non-GitHub forge never treats checks:none as no-CI → skips", async () => {
+  const local = makeDeps({}, { forge: undefined });
+  local.deps.resolveForge = () => ({
+    ...makeForge(local.spies, { prs: [pr({ number: 1, checks: "none" })] }),
+    kind: "gitea",
+  });
+  const svc = new StandalonePrCriticService(local.deps as any);
+  await svc.sweep();
+  expect(local.spies.started).toHaveLength(0);
+});
+
 // tiny helper for tests that re-wire the forge with throwaway spies
 function spies0(): Spies {
   return {

--- a/test/task5-completion-barrier.test.ts
+++ b/test/task5-completion-barrier.test.ts
@@ -252,6 +252,7 @@ test("computeMerge → merge for a LocalForge-shaped ready view (proves auto-mer
     desig: "TASK-01",
     state: "open",
     checks: "success",
+    noCi: false,
     mergeable: true,
     number: 1,
     headSha: "h1",

--- a/ui/src/lib/checks-cleared.test.ts
+++ b/ui/src/lib/checks-cleared.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "vitest";
+import { checksCleared } from "./checks-cleared";
+
+test("success always clears (noCi irrelevant)", () => {
+  expect(checksCleared("success", false)).toBe(true);
+  expect(checksCleared("success", true)).toBe(true);
+});
+
+test("none clears only when noCi", () => {
+  expect(checksCleared("none", true)).toBe(true);
+  expect(checksCleared("none", false)).toBe(false);
+  expect(checksCleared("none", undefined)).toBe(false);
+});
+
+test("pending / failure never clear", () => {
+  expect(checksCleared("pending", true)).toBe(false);
+  expect(checksCleared("failure", true)).toBe(false);
+});

--- a/ui/src/lib/checks-cleared.ts
+++ b/ui/src/lib/checks-cleared.ts
@@ -1,0 +1,10 @@
+import type { GitState } from "./types";
+
+/** Mirror of the server's `checksCleared` (src/checks-gate.ts): a PR's CI is "cleared" for
+ *  handoff / review / merge when CI is green, OR the repo has no CI to wait on (`noCi` — a GitHub
+ *  repo with zero workflows, stamped server-side) and the checks are at their terminal `"none"`.
+ *  Single source of truth for the UI mirror sites (herd-partition `greenIdle`, TimePopover
+ *  `handedOff`, GitRail `canReview`) so they can't drift from the server or each other. */
+export function checksCleared(checks: GitState["checks"], noCi: boolean | undefined): boolean {
+  return checks === "success" || (noCi === true && checks === "none");
+}

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -12,6 +12,7 @@
   import { toasts } from "$lib/toasts.svelte";
   import { m } from "$lib/paraglide/messages";
   import { reviews, repoConfig, planGates } from "$lib/reviews.svelte";
+  import { checksCleared } from "$lib/checks-cleared";
   import { criticChip, criticBadgeLabel } from "./critic-badge";
   import RailStatusActions from "./git-rail/RailStatusActions.svelte";
   import AutomationPanel from "./AutomationPanel.svelte";
@@ -342,11 +343,14 @@
   const reviewing = $derived(reviews.isReviewing(sessionId));
   const pillReviewing = $derived(reviewing || planGates.isReviewing(sessionId));
   const chip = $derived(criticChip(verdict, reviewing));
-  // Manual critic trigger: only when the auto path's own precondition holds (open PR, green
-  // CI) AND the repo has the critic enabled. Mirrors the server's forceReview guard so a
-  // shown button is never server-rejected. Reviewing is allowed (label becomes "Restart").
+  // Manual critic trigger: only when the auto path's own precondition holds (open PR, CI
+  // cleared — green OR a no-CI repo's terminal "none") AND the repo has the critic enabled.
+  // Mirrors the server's forceReview guard (checksCleared) so a shown button is never
+  // server-rejected. Reviewing is allowed (label becomes "Restart").
   const canReview = $derived(
-    git?.state === "open" && git?.checks === "success" && repoConfig.flags(repoPath).critic,
+    git?.state === "open" &&
+      checksCleared(git.checks, git.noCi) &&
+      repoConfig.flags(repoPath).critic,
   );
   const reviewLabel = $derived(
     armed === "review"

--- a/ui/src/lib/components/TimePopover.svelte
+++ b/ui/src/lib/components/TimePopover.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Session, GitState, SessionActivity } from "$lib/types";
   import { elapsed, formatAgo, waitTier } from "$lib/format";
+  import { checksCleared } from "$lib/checks-cleared";
   import { m } from "$lib/paraglide/messages";
 
   let {
@@ -73,13 +74,14 @@
   );
   // The "who's up next" lines (waiting-on-reviewer/merger and the neutral
   // ready-to-merge fallback) only apply once the PR is actually handed off. Mirror
-  // herd-partition.ts's `greenIdle` gate exactly: open + green + non-draft AND the
-  // session no longer in the agent's court (raw "running" OR "blocked" both keep it
-  // in the herd's `active` group). So an ACTIVE/blocked session never claims a
+  // herd-partition.ts's `greenIdle` gate exactly via the shared `checksCleared`
+  // helper (green, OR a no-CI repo's terminal "none") + non-draft AND the session no
+  // longer in the agent's court (raw "running" OR "blocked" both keep it in the
+  // herd's `active` group). So an ACTIVE/blocked session never claims a
   // reviewer/merger/operator is up — matching the card badge and the herd grouping.
   const handedOff = $derived(
     git?.state === "open" &&
-      git.checks === "success" &&
+      checksCleared(git.checks, git.noCi) &&
       !git.isDraft &&
       session.status !== "running" &&
       session.status !== "blocked",

--- a/ui/src/lib/components/herd-partition.test.ts
+++ b/ui/src/lib/components/herd-partition.test.ts
@@ -61,6 +61,20 @@ test("ready sessions land in the ready group, active stay on top", () => {
   expect(merged).toHaveLength(0);
 });
 
+test("no-CI repo (noCi + checks:none) idle PR → awaitingMerge, not active", () => {
+  const list = [session("x", false, "idle")];
+  const p = partitionSessions(list, { x: { ...git("open", "none"), noCi: true } });
+  expect(p.awaitingMerge.map((s) => s.id)).toEqual(["x"]);
+  expect(p.active).toHaveLength(0);
+});
+
+test("checks:none WITHOUT noCi idle PR → stays active (pre-CI race)", () => {
+  const list = [session("x", false, "idle")];
+  const p = partitionSessions(list, { x: git("open", "none") });
+  expect(p.active.map((s) => s.id)).toEqual(["x"]);
+  expect(p.awaitingMerge).toHaveLength(0);
+});
+
 test("merged-PR sessions land in the merged group", () => {
   const list = [session("a"), session("m1"), session("b")];
   const { active, ready, merged } = partitionSessions(list, { m1: git("merged") });

--- a/ui/src/lib/components/herd-partition.ts
+++ b/ui/src/lib/components/herd-partition.ts
@@ -1,5 +1,6 @@
 import type { Session, GitState } from "$lib/types";
 import { displayStatus } from "$lib/display-status";
+import { checksCleared } from "$lib/checks-cleared";
 import { isMerging } from "./merge-train";
 
 /** Split sessions into stage groups, preserving input order within each:
@@ -147,7 +148,7 @@ function stageOf(
   // the partition and doesn't need threading through here.
   const greenIdle =
     g?.state === "open" &&
-    (g.checks === "success" || (g.noCi === true && g.checks === "none")) &&
+    checksCleared(g.checks, g.noCi) &&
     s.status !== "running" &&
     s.status !== "blocked";
   return greenIdle ? handoffStage(g) : "active";

--- a/ui/src/lib/components/herd-partition.ts
+++ b/ui/src/lib/components/herd-partition.ts
@@ -33,7 +33,9 @@ import { isMerging } from "./merge-train";
  *  A draft outranks the handed-off groups: a green idle DRAFT is awaiting sign-off
  *  regardless of who the roles file names. An open PR with `none` checks (no CI reported
  *  yet) stays in `active` to avoid flicker into the "Your turn" group before CI registers
- *  as pending. The groups render top→bottom as active → ciRunning → ciFailed →
+ *  as pending — UNLESS the repo has no CI at all (`g.noCi`, GitHub + zero workflows), where
+ *  `none` is terminal and the PR is handed off like a green one. The groups render top→bottom as
+ *  active → ciRunning → ciFailed →
  *  reviewerRunning → waitingOnReviewer → waitingOnMerger → draftAwaitingSignoff →
  *  awaitingMerge → ready → merging → merged (Herd.svelte's template order, mirrored
  *  by herd-keynav's railOrder via flattenByStage), tracking the session lifecycle. `isReviewing`
@@ -145,7 +147,7 @@ function stageOf(
   // the partition and doesn't need threading through here.
   const greenIdle =
     g?.state === "open" &&
-    g.checks === "success" &&
+    (g.checks === "success" || (g.noCi === true && g.checks === "none")) &&
     s.status !== "running" &&
     s.status !== "blocked";
   return greenIdle ? handoffStage(g) : "active";

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -677,6 +677,10 @@ export interface QueuedItem {
 /** GET /api/sessions/:id/git payload: forge kind + current PR status. */
 export interface GitState extends PrStatus {
   kind: ForgeKind;
+  /** True when the repo has no CI to wait on (GitHub + zero workflows): a terminal `checks:"none"`
+   *  is treated as cleared (reviewed/merge-ready/awaiting-merge) rather than as a pre-CI race.
+   *  Stamped server-side; mirror of the server GitState field. Absent ⇒ false. */
+  noCi?: boolean;
   /** Who is up once the PR is open + green, when it isn't the operator (computed
    *  server-side from `.shepherd/roles.json`). Absent = the operator's turn. */
   handoff?: "reviewer" | "merger";


### PR DESCRIPTION
## Problem

A GitHub-backed repo with **no CI** (e.g. the claude-swap plugin repo, `github.com/erwins-enkel/shepherd-claude-swap`, TASK-985) is stranded by Shepherd's autonomous pipeline. Its PRs have zero check runs, so `statusCheckRollup` rolls up to `checks: "none"` forever — and **every** `checks === "success"` gate treats that identically to "CI hasn't gone green yet":

- the critic never auto-spawns (no review),
- auto-merge never lands the PR,
- and when auto-merge is off, the PR never even surfaces as *awaiting merge* / push-notifies — so the operator isn't told to merge by hand either.

Verified live: the repo has **zero `.github/workflows`** (confirmed 3 ways: `ls`=0, `gh api …/actions/workflows total_count`=0, PR #12 `statusCheckRollup: []`), so `checks` can only ever be `"none"` — `"pending"` is structurally impossible. `criticEnabled=1`, `autoMergeEnabled=1`, yet PR #12 had to be merged manually.

## Fix

Treat `checks:"none"` as **cleared** when the repo has no CI to wait on — a **GitHub** repo defining **zero workflows** (`countDefinedWorkflows`). A CI repo's transient pre-CI `"none"` still waits (it has workflow files on disk → `noCi` is false), so there's no premature action.

- New pure helpers `repoHasNoCi` / `checksCleared` + TTL-memoized `repoHasNoCiCached` (`src/checks-gate.ts`).
- Add `noCi?: boolean` to `GitState`, **stamped once** in `annotateHandoff` (the poller + on-demand `/git` chokepoint); every `GitState`-fed gate just reads `git.noCi`. The standalone critic and epic-landing paths (not `GitState`-fed) call `repoHasNoCiCached` directly.
- **Forge-scoped:** the `.github/workflows` glob is GitHub-only (Gitea uses `.gitea/workflows`); LocalForge already auto-greens. Non-GitHub forges keep the strict green gate.

### Gates relaxed (audited every `checks === "success"` site)

| Gate | |
|---|---|
| `review.ts` consider (auto-review) | ✅ |
| `standalone-critic.ts` eligible | ✅ |
| `automerge-core.ts` ready / needsRebase | ✅ (mergeable + critic-pass unchanged) |
| `drain-core.ts` readyToRetire / awaitingSignoff | ✅ (mergeable unchanged) |
| `ready-stage.ts` greenIdle + UI `herd-partition.ts` | ✅ → surfaces as awaitingMerge + push-notifies |
| `repo-roles.ts` annotateHandoff | ✅ (chokepoint + handoff calc) |
| `issue-log.ts` handoff comment | ✅ (outward; opt-in via `.shepherd/roles.json`) |
| `autopilot.ts` rebaseCandidate | ✅ |
| `completed-epic.ts` computeLandingReady (+drain/server land) | ✅ (keeps its `mergeStateStatus` gate) |

**Out of scope:** `doc-agent` (DOC_TREE opt-in feature, orthogonal); `pending`/`failure`/red-signal/change-detection sites (`none` falls through correctly).

## Why workflow-count, not `mergeStateStatus`

`mergeStateStatus` conflates mergeability (review must act on non-mergeable PRs), is absent on the standalone PR-list path, and goes `BLOCKED` under required-review branch protection (would defeat the fix). Workflow-count keys on repo config. `completed-epic` *keeps* its `mergeStateStatus` gate because there mergeability **is** required to land.

## Known limitation (open)

A GitHub repo **with** workflows that never trigger for a PR (path/branch filters) also stays `checks:"none"` (count ≥ 1) → keeps waiting (unchanged, not a regression). A global staleness-timeout was rejected (would review real CI repos pre-CI); a per-repo opt-out flag is the fallback if this surfaces.

## Tests

New no-CI cases across `checks-gate`, `review`, `standalone-critic`, `automerge-core`, `drain-core`, `ready-stage`, `repo-roles`, `issue-log`, `completed-epic`, `pr-poller`, and UI `herd-partition`. Root: 5210 pass / 0 fail; UI node: 1504 pass; typecheck + lint + `bun run check` all green.

`[no-feature-entry]` — behavior fix to existing surfaces, no new user-facing strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)