### PR TITLE
feat(plugins): allow plugins to add a single gear-menu item

### DIFF
--- a/docs-site/.gitignore
+++ b/docs-site/.gitignore
@@ -1,5 +1,6 @@
 # Pages generated at build time by scripts/sync-docs.mjs from in-repo markdown
 # (source of truth is docs/ and the repo-root CLAUDE.md; imported, not authored here).
+src/content/docs/reference/plugins.md
 src/content/docs/reference/external-task-api.md
 src/content/docs/reference/security.md
 src/content/docs/reference/house-rules.md

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -117,6 +117,7 @@ export default defineConfig({
           items: [
             { label: "Configuration", slug: "reference/configuration" },
             { label: "Concepts & glossary", slug: "reference/glossary" },
+            { label: "Plugins", slug: "reference/plugins" },
             { label: "External Task API", slug: "reference/external-task-api" },
             { label: "Security", slug: "reference/security" },
             // Repo-root CLAUDE.md, imported verbatim by scripts/sync-docs.mjs.

--- a/docs-site/scripts/sync-docs.mjs
+++ b/docs-site/scripts/sync-docs.mjs
@@ -40,6 +40,14 @@ const GITHUB_DOCS_BASE = `${GITHUB_BLOB_BASE}docs/`;
 const PAGES = [
   {
     srcDir: "docs",
+    src: "plugins.md",
+    dest: "reference/plugins.md",
+    linkBase: GITHUB_DOCS_BASE,
+    title: "Plugins",
+    description: "Write server-side plugins: spawn hooks, routes, status/UI panels, and gear-menu items.",
+  },
+  {
+    srcDir: "docs",
     src: "external-task-api.md",
     dest: "reference/external-task-api.md",
     linkBase: GITHUB_DOCS_BASE,

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -191,11 +191,13 @@ if (typeof ctx.publishUI === "function") {
 ```
 
 - `null` clears the last-published view.
-- `slot` must be `"settings-panel"` (v1 wires only this slot; other names are accepted by the
-  validator but not rendered).
+- `slot` must be `"settings-panel"` (v1 renders only this slot; the other two reserved values —
+  `"session-sidebar"` and `"dashboard-card"` — pass validation but are not yet rendered; any
+  other string fails validation and the view is dropped).
 - String props render **verbatim** — plugin data, not i18n keys.
 - Validation is **fail-open**: size-capped (64 KB), max depth 16, max 256 nodes, max 500
-  children per node. Invalid views are silently dropped; the prior view is kept.
+  children per node; array values in `props` are also capped at 500 entries. Invalid views
+  are silently dropped; the prior view is kept.
 
 ## Gear-menu item (`publishGearItem`)
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -93,6 +93,8 @@ permission-scoped / out-of-process) without changing your call sites.
 | `ctx.onSpawn(fn)`                  | Mutate how an agent launches (see below). The load-bearing capability.                                                                                         |
 | `ctx.events.subscribe(fn)`         | Observe the **read-only** core event stream (`session:hold`, `session:status`, …). Returns an unsubscribe fn. Plugins cannot _emit_ core events.               |
 | `ctx.publishStatus(json)`          | Push a small free-form JSON blob to the status panel (rendered verbatim).                                                                                      |
+| `ctx.publishUI(view)`              | Push a declarative UI view to the Settings → Plugins panel (`null` clears). Additive.                                                                          |
+| `ctx.publishGearItem(item)`        | Add a single item to the top-bar gear menu (`null` clears). Additive.                                                                                          |
 | `ctx.state`                        | Durable, **per-plugin-scoped** key/value: `get`/`set`/`delete`/`keys`. Values are JSON. Backed by a `plugin_state` table — you never touch the session schema. |
 | `ctx.route(method, path, handler)` | Register an HTTP route under `/api/plugins/<id>/<path>`. Sits behind operator auth.                                                                            |
 | `ctx.log`                          | Namespaced logger into `shepherd.log` (`ctx.log.log` / `ctx.log.warn`).                                                                                        |
@@ -170,6 +172,95 @@ last error, and the expandable JSON from your last `ctx.publishStatus(...)`.
 
 `publishStatus` emits a `plugin:status` event over the existing `/events` WebSocket, so the
 panel updates live.
+
+## Declarative UI panel (`publishUI`)
+
+`ctx.publishUI(view)` pushes a **declarative UI descriptor** to the plugin's card in
+Settings → Plugins. The view must conform to `PluginUIView`:
+
+```ts
+// Guard — additive API, absent on older cores.
+if (typeof ctx.publishUI === "function") {
+  ctx.publishUI({
+    schemaVersion: 1,
+    slot: "settings-panel",
+    title: "My plugin stats",
+    root: { type: "text", props: { text: "Hello from plugin." } },
+  });
+}
+```
+
+- `null` clears the last-published view.
+- `slot` must be `"settings-panel"` (v1 wires only this slot; other names are accepted by the
+  validator but not rendered).
+- String props render **verbatim** — plugin data, not i18n keys.
+- Validation is **fail-open**: size-capped (64 KB), max depth 16, max 256 nodes, max 500
+  children per node. Invalid views are silently dropped; the prior view is kept.
+
+## Gear-menu item (`publishGearItem`)
+
+`ctx.publishGearItem(item)` contributes **one item to the top-bar gear menu**. Each plugin
+may publish at most one item; the latest publish wins; `null` clears it.
+
+```ts
+// Guard every publishGearItem call — additive API, absent on older cores.
+if (typeof ctx.publishGearItem === "function") {
+  ctx.publishGearItem({
+    label: "My plugin", // required; ≤ 80 chars, non-empty
+    icon: "🔧", // optional; ≤ 8 chars
+    action: { kind: "panel" },
+  });
+}
+```
+
+### Three action kinds
+
+**`panel`** — opens Settings → Plugins, scrolled to this plugin's card. Works even if the
+plugin publishes no `publishUI` view, since the card always renders.
+
+```ts
+action: {
+  kind: "panel";
+}
+```
+
+**`route`** — calls the plugin's own `/api/plugins/<id>/<path>` route (must be registered
+via `ctx.route`) and shows the response text (≤ 200 chars) as a toast. `method` is `"GET"`
+or `"POST"`.
+
+```ts
+action: { kind: "route", method: "GET", path: "stats" }
+// fires GET /api/plugins/<your-plugin-id>/stats
+```
+
+**`url`** — opens an absolute URL in a new browser tab.
+
+```ts
+action: { kind: "url", href: "https://your-dashboard.example.com" }
+```
+
+### Validation & security
+
+Validation is **fail-open** — an invalid item is silently dropped and the prior item kept.
+Validation rules (enforced by the server; plugins are trusted authors but bad items are
+ignored):
+
+- **label** — required; non-empty after trim; ≤ 80 chars.
+- **icon** — optional; if present, must be a string ≤ 8 chars.
+- **route `path`** — non-empty, ≤ 256 chars; only `[A-Za-z0-9._/-]`; no leading `/`; no
+  `..` segments.
+- **url `href`** — must parse as a valid URL with `http:` or `https:` protocol.
+  `javascript:`, `data:`, and relative paths are rejected.
+- Total payload: ≤ 8 KB.
+
+**Label, icon, and route response text are verbatim plugin DATA** — they render as-is, are
+never i18n keys, and receive the same treatment as PR titles and tool-use summaries.
+
+### Additive guard
+
+Always guard with `typeof ctx.publishGearItem === "function"` — older Shepherd builds that
+predate this capability simply don't expose the method; the guard makes the plugin forward-
+and backward-compatible without a version check.
 
 ## HTTP routes
 

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -5,9 +5,9 @@ These are **teaching material** — they are **never auto-loaded** from the repo
 only ever scans `~/.shepherd/plugins/`, so the zero-plugin no-op invariant holds). Copy one
 into your plugins dir to actually run it.
 
-| Plugin                             | What it shows                                                                                                                                                                                  |
-| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`spawn-labeler/`](spawn-labeler/) | The recommended copy-me reference: a real `SpawnPatch` from `onSpawn` (injects a per-repo label env var), routes that read/write `state`, a non-trivial `publishStatus` payload, and `config`. |
+| Plugin                             | What it shows                                                                                                                                                                                                                                              |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`spawn-labeler/`](spawn-labeler/) | The recommended copy-me reference: a real `SpawnPatch` from `onSpawn` (injects a per-repo label env var), routes that read/write `state`, a non-trivial `publishStatus` payload, `config`, and a gear-menu item (`publishGearItem`) with a `panel` action. |
 
 > For the bare-minimum wiring (manifest + `register` + one route, a pure observer), see
 > the skeleton at [`test/fixtures/example-plugin/`](../../test/fixtures/example-plugin/) —
@@ -43,5 +43,18 @@ do **one** of:
 - **vendor the types**: copy `src/plugins/types.ts` into the folder and import from
   `"./types"`.
 
-See [`docs/plugins.md`](../../docs/plugins.md) for the full plugin API, the `onSpawn`
-contract, and a walkthrough of `spawn-labeler`.
+### Gear-menu item
+
+`spawn-labeler` publishes one item to the top-bar gear menu via `ctx.publishGearItem`:
+
+```ts
+ctx.publishGearItem({ label: "Spawn labeler", icon: "🏷️", action: { kind: "panel" } });
+```
+
+The three available action kinds are:
+
+- `{ kind: "panel" }` — opens Settings → Plugins, scrolled to this plugin's card.
+- `{ kind: "route", method: "GET"|"POST", path: "<route-path>" }` — calls one of the plugin's own routes and toasts the response text.
+- `{ kind: "url", href: "https://…" }` — opens an absolute http/https URL in a new tab.
+
+See [`docs/plugins.md`](../../docs/plugins.md) for the full spec (validation rules, all action kinds) and a walkthrough of `spawn-labeler`.

--- a/examples/plugins/spawn-labeler/index.ts
+++ b/examples/plugins/spawn-labeler/index.ts
@@ -133,6 +133,21 @@ export function register(ctx: PluginContext): () => void {
   // Publish an initial snapshot so the panel has data before the first spawn.
   publish();
 
+  // ── gear-menu item (ctx.publishGearItem) ────────────────────────────────────────────
+  // Contribute one item to the top-bar gear menu. Three action kinds are available:
+  //
+  //   panel  → opens Settings → Plugins, scrolled to this plugin's card (used below).
+  //   route  → calls one of this plugin's own routes and toasts the response text:
+  //     { kind: "route", method: "GET", path: "stats" }
+  //   url    → opens an absolute http/https URL in a new tab:
+  //     { kind: "url", href: "https://your-dashboard.example.com" }
+  //
+  // Additive guard: publishGearItem is absent on older cores — the guard makes the
+  // plugin safe across Shepherd versions without a manifest version check.
+  if (typeof ctx.publishGearItem === "function") {
+    ctx.publishGearItem({ label: "Spawn labeler", icon: "🏷️", action: { kind: "panel" } });
+  }
+
   // Teardown: nothing to unwind (no subscriptions, state already persisted on each spawn).
   return () => ctx.log.log("torn down");
 }

--- a/src/plugins/gear-validate.test.ts
+++ b/src/plugins/gear-validate.test.ts
@@ -32,7 +32,7 @@ describe("validatePluginGearItem — valid", () => {
   it("accepts http:// url action", () => {
     const result = validatePluginGearItem(urlItem("http://example.com"));
     expect(result).not.toBeNull();
-    expect((result?.action as { kind: "url"; href: string }).href).toBe("http://example.com");
+    expect((result?.action as { kind: "url"; href: string }).href).toBe("http://example.com/");
   });
 
   it("accepts a valid GET route action", () => {
@@ -130,6 +130,10 @@ describe("validatePluginGearItem — route rejections", () => {
 
   it("rejects path > 256 chars", () => {
     expect(validatePluginGearItem(routeItem("GET", "a".repeat(257)))).toBeNull();
+  });
+
+  it("accepts path of exactly 256 chars", () => {
+    expect(validatePluginGearItem(routeItem("GET", "a".repeat(256)))).not.toBeNull();
   });
 
   it("rejects path with invalid chars (space)", () => {

--- a/src/plugins/gear-validate.test.ts
+++ b/src/plugins/gear-validate.test.ts
@@ -1,0 +1,213 @@
+// Unit tests for validatePluginGearItem (src/plugins/ui-validate.ts).
+
+import { describe, expect, it } from "bun:test";
+import { validatePluginGearItem } from "./ui-validate";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const urlItem = (href: string) => ({
+  label: "Open",
+  action: { kind: "url", href },
+});
+
+const routeItem = (method: string, path: string) => ({
+  label: "Check",
+  action: { kind: "route", method, path },
+});
+
+const panelItem = () => ({
+  label: "Settings",
+  action: { kind: "panel" },
+});
+
+// ── valid cases ───────────────────────────────────────────────────────────────
+
+describe("validatePluginGearItem — valid", () => {
+  it("accepts a valid url action", () => {
+    const result = validatePluginGearItem(urlItem("https://example.com/path"));
+    expect(result).not.toBeNull();
+    expect(result?.action).toEqual({ kind: "url", href: "https://example.com/path" });
+  });
+
+  it("accepts http:// url action", () => {
+    const result = validatePluginGearItem(urlItem("http://example.com"));
+    expect(result).not.toBeNull();
+    expect((result?.action as { kind: "url"; href: string }).href).toBe("http://example.com");
+  });
+
+  it("accepts a valid GET route action", () => {
+    const result = validatePluginGearItem(routeItem("GET", "status/check"));
+    expect(result).not.toBeNull();
+    expect(result?.action).toEqual({ kind: "route", method: "GET", path: "status/check" });
+  });
+
+  it("accepts a valid POST route action", () => {
+    const result = validatePluginGearItem(routeItem("POST", "actions/run"));
+    expect(result).not.toBeNull();
+    expect(result?.action).toEqual({ kind: "route", method: "POST", path: "actions/run" });
+  });
+
+  it("accepts a panel action", () => {
+    const result = validatePluginGearItem(panelItem());
+    expect(result).not.toBeNull();
+    expect(result?.action).toEqual({ kind: "panel" });
+  });
+
+  it("accepts an optional icon within length limit", () => {
+    const item = { label: "Go", icon: "⚙️", action: { kind: "panel" } };
+    const result = validatePluginGearItem(item);
+    expect(result).not.toBeNull();
+    expect(result?.icon).toBe("⚙️");
+  });
+
+  it("returns normalized (re-parsed) item", () => {
+    const item = { label: "Go", action: { kind: "panel" }, extra: undefined };
+    const result = validatePluginGearItem(item);
+    expect(result).not.toBeNull();
+    // non-JSON props stripped; label/action preserved
+    expect(result?.label).toBe("Go");
+  });
+});
+
+// ── url action rejections ─────────────────────────────────────────────────────
+
+describe("validatePluginGearItem — url rejections", () => {
+  it("rejects javascript: url", () => {
+    expect(validatePluginGearItem(urlItem("javascript:alert(1)"))).toBeNull();
+  });
+
+  it("rejects data: url", () => {
+    expect(validatePluginGearItem(urlItem("data:text/html,<h1>hi</h1>"))).toBeNull();
+  });
+
+  it("rejects file: url", () => {
+    expect(validatePluginGearItem(urlItem("file:///etc/passwd"))).toBeNull();
+  });
+
+  it("rejects relative url", () => {
+    expect(validatePluginGearItem(urlItem("/relative/path"))).toBeNull();
+  });
+
+  it("rejects unparseable url", () => {
+    expect(validatePluginGearItem(urlItem("not a url at all"))).toBeNull();
+  });
+
+  it("rejects ftp: url", () => {
+    expect(validatePluginGearItem(urlItem("ftp://example.com"))).toBeNull();
+  });
+});
+
+// ── route action rejections ───────────────────────────────────────────────────
+
+describe("validatePluginGearItem — route rejections", () => {
+  it("rejects method PUT", () => {
+    expect(validatePluginGearItem(routeItem("PUT", "some/path"))).toBeNull();
+  });
+
+  it("rejects lowercase method get", () => {
+    expect(validatePluginGearItem(routeItem("get", "some/path"))).toBeNull();
+  });
+
+  it("rejects lowercase method post", () => {
+    expect(validatePluginGearItem(routeItem("post", "some/path"))).toBeNull();
+  });
+
+  it("rejects path with leading /", () => {
+    expect(validatePluginGearItem(routeItem("GET", "/absolute/path"))).toBeNull();
+  });
+
+  it("rejects path with .. segment", () => {
+    expect(validatePluginGearItem(routeItem("GET", "foo/../etc/passwd"))).toBeNull();
+  });
+
+  it("rejects path with leading .. segment", () => {
+    expect(validatePluginGearItem(routeItem("GET", "../secret"))).toBeNull();
+  });
+
+  it("rejects empty path", () => {
+    expect(validatePluginGearItem(routeItem("GET", ""))).toBeNull();
+  });
+
+  it("rejects path > 256 chars", () => {
+    expect(validatePluginGearItem(routeItem("GET", "a".repeat(257)))).toBeNull();
+  });
+
+  it("rejects path with invalid chars (space)", () => {
+    expect(validatePluginGearItem(routeItem("GET", "foo bar"))).toBeNull();
+  });
+});
+
+// ── label / icon rejections ───────────────────────────────────────────────────
+
+describe("validatePluginGearItem — label/icon rejections", () => {
+  it("rejects empty label", () => {
+    expect(validatePluginGearItem({ label: "", action: { kind: "panel" } })).toBeNull();
+  });
+
+  it("rejects whitespace-only label", () => {
+    expect(validatePluginGearItem({ label: "   ", action: { kind: "panel" } })).toBeNull();
+  });
+
+  it("rejects label > 80 chars", () => {
+    expect(validatePluginGearItem({ label: "a".repeat(81), action: { kind: "panel" } })).toBeNull();
+  });
+
+  it("accepts label of exactly 80 chars", () => {
+    expect(
+      validatePluginGearItem({ label: "a".repeat(80), action: { kind: "panel" } }),
+    ).not.toBeNull();
+  });
+
+  it("rejects icon > 8 chars", () => {
+    expect(
+      validatePluginGearItem({ label: "Go", icon: "123456789", action: { kind: "panel" } }),
+    ).toBeNull();
+  });
+
+  it("rejects icon that is not a string", () => {
+    expect(validatePluginGearItem({ label: "Go", icon: 42, action: { kind: "panel" } })).toBeNull();
+  });
+});
+
+// ── unknown kind ──────────────────────────────────────────────────────────────
+
+describe("validatePluginGearItem — unknown kind", () => {
+  it("rejects unknown action kind", () => {
+    expect(validatePluginGearItem({ label: "Go", action: { kind: "popup" } })).toBeNull();
+  });
+
+  it("rejects missing action", () => {
+    expect(validatePluginGearItem({ label: "Go" })).toBeNull();
+  });
+
+  it("rejects action that is not an object", () => {
+    expect(validatePluginGearItem({ label: "Go", action: "panel" })).toBeNull();
+  });
+});
+
+// ── structural / serialization rejections ─────────────────────────────────────
+
+describe("validatePluginGearItem — structural rejections", () => {
+  it("rejects null", () => {
+    expect(validatePluginGearItem(null)).toBeNull();
+  });
+
+  it("rejects undefined", () => {
+    expect(validatePluginGearItem(undefined)).toBeNull();
+  });
+
+  it("rejects a string", () => {
+    expect(validatePluginGearItem("panel")).toBeNull();
+  });
+
+  it("rejects a non-serializable (cyclic) object → null", () => {
+    const obj: Record<string, unknown> = { label: "Go", action: { kind: "panel" } };
+    obj.self = obj; // cycle
+    expect(validatePluginGearItem(obj)).toBeNull();
+  });
+
+  it("rejects oversized JSON (> 8 KB)", () => {
+    const big = { label: "Go", action: { kind: "panel" }, data: "x".repeat(9000) };
+    expect(validatePluginGearItem(big)).toBeNull();
+  });
+});

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1,0 +1,247 @@
+// Integration-style tests for PluginRegistry — specifically publishGearItem.
+// Uses a temp dir with a minimal plugin and an in-memory store / event bus.
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { PluginRegistry } from "./loader";
+import type { PluginEventBus, PluginStateStore } from "./loader";
+import type { PluginGearItem } from "./types";
+
+// ── fakes ──────────────────────────────────────────────────────────────────────
+
+function makeStore(): PluginStateStore {
+  const data = new Map<string, string>();
+  return {
+    getPluginState: (id, k) => data.get(`${id}:${k}`) ?? null,
+    setPluginState: (id, k, v) => {
+      data.set(`${id}:${k}`, v);
+    },
+    deletePluginState: (id, k) => {
+      data.delete(`${id}:${k}`);
+    },
+    listPluginStateKeys: (id) =>
+      [...data.keys()].filter((k) => k.startsWith(`${id}:`)).map((k) => k.slice(id.length + 1)),
+  };
+}
+
+interface Emitted {
+  event: string;
+  data: unknown;
+}
+
+function makeEventBus(): PluginEventBus & { emitted: Emitted[] } {
+  const subs: Array<(event: string, data: unknown) => void> = [];
+  const emitted: Emitted[] = [];
+  return {
+    emitted,
+    subscribe(fn) {
+      subs.push(fn);
+      return () => {
+        const i = subs.indexOf(fn);
+        if (i !== -1) subs.splice(i, 1);
+      };
+    },
+    emit(event, data) {
+      emitted.push({ event, data });
+      for (const fn of subs) fn(event, data);
+    },
+  };
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+async function makePluginDir(base: string, id: string, entryCode: string): Promise<string> {
+  const dir = join(base, id);
+  await mkdir(dir, { recursive: true });
+  const manifest = {
+    id,
+    name: id,
+    version: "0.1.0",
+    apiVersion: 1,
+  };
+  await writeFile(join(dir, "plugin.json"), JSON.stringify(manifest));
+  await writeFile(join(dir, "index.ts"), entryCode);
+  return dir;
+}
+
+// ── fixtures ───────────────────────────────────────────────────────────────────
+
+const VALID_GEAR_ITEM: PluginGearItem = {
+  label: "Open settings",
+  icon: "⚙️",
+  action: { kind: "panel" },
+};
+
+const VALID_GEAR_ITEM_URL: PluginGearItem = {
+  label: "Visit docs",
+  action: { kind: "url", href: "https://example.com" },
+};
+
+// ── tests ──────────────────────────────────────────────────────────────────────
+
+describe("publishGearItem", () => {
+  let tmpDir: string;
+  let bus: ReturnType<typeof makeEventBus>;
+  let registry: PluginRegistry;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "shepherd-plugin-test-"));
+    bus = makeEventBus();
+  });
+
+  afterEach(async () => {
+    registry?.teardown();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("emits plugin:gear event with valid item and item appears in list()", async () => {
+    await makePluginDir(
+      tmpDir,
+      "p-gear-valid",
+      `export function register(ctx) {
+        ctx.publishGearItem(${JSON.stringify(VALID_GEAR_ITEM)});
+      }`,
+    );
+
+    registry = new PluginRegistry({
+      pluginsDir: tmpDir,
+      store: makeStore(),
+      events: bus,
+      hookTimeoutMs: 500,
+    });
+    await registry.loadAll();
+
+    const gearEvents = bus.emitted.filter((e) => e.event === "plugin:gear");
+    expect(gearEvents).toHaveLength(1);
+    expect((gearEvents[0]!.data as { id: string; gearItem: PluginGearItem }).gearItem).toEqual(
+      VALID_GEAR_ITEM,
+    );
+
+    const info = registry.list().find((p) => p.id === "p-gear-valid");
+    expect(info).toBeDefined();
+    expect(info!.gearItem).toEqual(VALID_GEAR_ITEM);
+  });
+
+  it("publishGearItem(null) clears item and emits plugin:gear with null", async () => {
+    await makePluginDir(
+      tmpDir,
+      "p-gear-clear",
+      `export function register(ctx) {
+        ctx.publishGearItem(${JSON.stringify(VALID_GEAR_ITEM)});
+        ctx.publishGearItem(null);
+      }`,
+    );
+
+    registry = new PluginRegistry({
+      pluginsDir: tmpDir,
+      store: makeStore(),
+      events: bus,
+      hookTimeoutMs: 500,
+    });
+    await registry.loadAll();
+
+    const gearEvents = bus.emitted.filter((e) => e.event === "plugin:gear");
+    expect(gearEvents).toHaveLength(2);
+    // second event should have null
+    expect((gearEvents[1]!.data as { id: string; gearItem: null }).gearItem).toBeNull();
+
+    const info = registry.list().find((p) => p.id === "p-gear-clear");
+    expect(info!.gearItem).toBeNull();
+  });
+
+  it("invalid item is dropped and prior item is kept", async () => {
+    await makePluginDir(
+      tmpDir,
+      "p-gear-invalid",
+      `export function register(ctx) {
+        ctx.publishGearItem(${JSON.stringify(VALID_GEAR_ITEM)});
+        // now publish an invalid item (bad label + bad action)
+        ctx.publishGearItem({ label: "", action: { kind: "panel" } });
+      }`,
+    );
+
+    registry = new PluginRegistry({
+      pluginsDir: tmpDir,
+      store: makeStore(),
+      events: bus,
+      hookTimeoutMs: 500,
+    });
+    await registry.loadAll();
+
+    // Only one gear event (the valid one); the invalid publish is dropped, no event emitted.
+    const gearEvents = bus.emitted.filter((e) => e.event === "plugin:gear");
+    expect(gearEvents).toHaveLength(1);
+    expect((gearEvents[0]!.data as { id: string; gearItem: PluginGearItem }).gearItem).toEqual(
+      VALID_GEAR_ITEM,
+    );
+
+    const info = registry.list().find((p) => p.id === "p-gear-invalid");
+    // Prior item kept
+    expect(info!.gearItem).toEqual(VALID_GEAR_ITEM);
+  });
+
+  it("gearItem starts as null in list() before any publish", async () => {
+    await makePluginDir(
+      tmpDir,
+      "p-gear-noop",
+      `export function register(_ctx) { /* no publishGearItem call */ }`,
+    );
+
+    registry = new PluginRegistry({
+      pluginsDir: tmpDir,
+      store: makeStore(),
+      events: bus,
+      hookTimeoutMs: 500,
+    });
+    await registry.loadAll();
+
+    const info = registry.list().find((p) => p.id === "p-gear-noop");
+    expect(info!.gearItem).toBeNull();
+  });
+
+  it("supports url action gear item", async () => {
+    await makePluginDir(
+      tmpDir,
+      "p-gear-url",
+      `export function register(ctx) {
+        ctx.publishGearItem(${JSON.stringify(VALID_GEAR_ITEM_URL)});
+      }`,
+    );
+
+    registry = new PluginRegistry({
+      pluginsDir: tmpDir,
+      store: makeStore(),
+      events: bus,
+      hookTimeoutMs: 500,
+    });
+    await registry.loadAll();
+
+    const info = registry.list().find((p) => p.id === "p-gear-url");
+    expect(info!.gearItem).toEqual(VALID_GEAR_ITEM_URL);
+  });
+
+  it("later publish replaces earlier item", async () => {
+    const second: PluginGearItem = { label: "Second", action: { kind: "panel" } };
+    await makePluginDir(
+      tmpDir,
+      "p-gear-replace",
+      `export function register(ctx) {
+        ctx.publishGearItem(${JSON.stringify(VALID_GEAR_ITEM)});
+        ctx.publishGearItem(${JSON.stringify(second)});
+      }`,
+    );
+
+    registry = new PluginRegistry({
+      pluginsDir: tmpDir,
+      store: makeStore(),
+      events: bus,
+      hookTimeoutMs: 500,
+    });
+    await registry.loadAll();
+
+    const info = registry.list().find((p) => p.id === "p-gear-replace");
+    expect(info!.gearItem).toEqual(second);
+  });
+});

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -76,7 +76,7 @@ const VALID_GEAR_ITEM: PluginGearItem = {
 
 const VALID_GEAR_ITEM_URL: PluginGearItem = {
   label: "Visit docs",
-  action: { kind: "url", href: "https://example.com" },
+  action: { kind: "url", href: "https://example.com/" },
 };
 
 // ── tests ──────────────────────────────────────────────────────────────────────
@@ -240,6 +240,9 @@ describe("publishGearItem", () => {
       hookTimeoutMs: 500,
     });
     await registry.loadAll();
+
+    const gearEvents = bus.emitted.filter((e) => e.event === "plugin:gear");
+    expect(gearEvents).toHaveLength(2);
 
     const info = registry.list().find((p) => p.id === "p-gear-replace");
     expect(info!.gearItem).toEqual(second);

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -20,12 +20,13 @@ import {
   type PluginRegister,
   type PluginRouteHandler,
   type PluginState,
+  type PluginGearItem,
   type PluginUIView,
   type SpawnDescriptor,
   type SpawnHook,
   type SpawnPatch,
 } from "./types";
-import { validatePluginUIView } from "./ui-validate";
+import { validatePluginGearItem, validatePluginUIView } from "./ui-validate";
 
 const DEFAULT_HOOK_TIMEOUT_MS = 5_000;
 
@@ -51,13 +52,14 @@ export interface PluginRegistryDeps {
   hookTimeoutMs?: number;
 }
 
-/** Internal per-plugin record. `health`/`lastError`/`status`/`ui` back the status panel. */
+/** Internal per-plugin record. `health`/`lastError`/`status`/`ui`/`gearItem` back the status panel. */
 interface LoadedPlugin {
   manifest: PluginManifest;
   health: PluginInfo["health"];
   lastError: string | null;
   status: unknown;
   ui: PluginUIView | null;
+  gearItem: PluginGearItem | null;
   hooks: SpawnHook[];
   routes: Map<string, PluginRouteHandler>;
   unsubs: Array<() => void>;
@@ -163,6 +165,7 @@ export class PluginRegistry {
         lastError: `apiVersion ${manifest.apiVersion} != supported ${PLUGIN_API_VERSION}`,
         status: null,
         ui: null,
+        gearItem: null,
         hooks: [],
         routes: new Map(),
         unsubs: [],
@@ -181,6 +184,7 @@ export class PluginRegistry {
       lastError: null,
       status: null,
       ui: null,
+      gearItem: null,
       hooks: [],
       routes: new Map(),
       unsubs: [],
@@ -296,6 +300,23 @@ export class PluginRegistry {
         rec.ui = v;
         this.emitUI(rec);
       },
+      publishGearItem: (item) => {
+        // Treat both null and undefined as "clear the gear item".
+        if (item == null) {
+          rec.gearItem = null;
+          this.emitGear(rec);
+          return;
+        }
+        const v = validatePluginGearItem(item);
+        if (v === null) {
+          console.warn(
+            `[plugins] ${id} publishGearItem rejected an invalid item (dropped; prior item kept)`,
+          );
+          return; // leave rec.gearItem unchanged — fail-open, never crash the panel
+        }
+        rec.gearItem = v;
+        this.emitGear(rec);
+      },
       state,
       route: (method, path, handler) => {
         rec.routes.set(routeKey(method, path), handler);
@@ -336,6 +357,11 @@ export class PluginRegistry {
   /** Emit a `plugin:ui` event carrying this plugin's last validated UI view (or null). */
   private emitUI(rec: LoadedPlugin): void {
     this.deps.events.emit("plugin:ui", { id: rec.manifest.id, ui: rec.ui });
+  }
+
+  /** Emit a `plugin:gear` event carrying this plugin's last validated gear item (or null). */
+  private emitGear(rec: LoadedPlugin): void {
+    this.deps.events.emit("plugin:gear", { id: rec.manifest.id, gearItem: rec.gearItem });
   }
 
   /** Invoke one hook, timeout-bounded. Returns its patch, or null on a fail-open
@@ -399,6 +425,7 @@ export class PluginRegistry {
       lastError: r.lastError,
       status: r.status,
       ui: r.ui,
+      gearItem: r.gearItem,
     }));
   }
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -52,7 +52,7 @@ export interface PluginRegistryDeps {
   hookTimeoutMs?: number;
 }
 
-/** Internal per-plugin record. `health`/`lastError`/`status`/`ui`/`gearItem` back the status panel. */
+/** Internal per-plugin record. `health`/`lastError`/`status`/`ui` back the status panel; `gearItem` backs the gear menu. */
 interface LoadedPlugin {
   manifest: PluginManifest;
   health: PluginInfo["health"];

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -91,6 +91,9 @@ export interface PluginContext {
   /** Push a declarative UI view to the status panel (issue #1185); `null` clears it.
    *  Additive — plugins guard with `typeof ctx.publishUI === "function"`. */
   publishUI(view: PluginUIView | null): void;
+  /** Push (or replace) this plugin's single gear-menu item; `null` clears it.
+   *  Additive — plugins guard with `typeof ctx.publishGearItem === "function"`. */
+  publishGearItem(item: PluginGearItem | null): void;
   /** Durable, scoped per-plugin key/value (backed by the `plugin_state` table). */
   state: PluginState;
   /** Register an HTTP route under the fixed `/api/plugins/<id>/<path>` namespace. */
@@ -121,6 +124,23 @@ export class PluginSpawnAborted extends Error {
     super(reason);
     this.name = "PluginSpawnAborted";
   }
+}
+
+/** A declarative action a plugin's gear-menu item performs on click. Discriminated by `kind`.
+ *  All fields JSON-serializable; strings are verbatim plugin-authored DATA, never i18n keys. */
+export type PluginGearAction =
+  | { kind: "route"; method: "GET" | "POST"; path: string }
+  | { kind: "url"; href: string }
+  | { kind: "panel" };
+
+/** One gear-menu item a plugin contributes via `ctx.publishGearItem` (issue: gear-item).
+ *  At most ONE per plugin; latest publish wins; `null` clears it. */
+export interface PluginGearItem {
+  /** Verbatim plugin-authored label (NOT an i18n key). */
+  label: string;
+  /** Optional single glyph/emoji icon (verbatim). */
+  icon?: string;
+  action: PluginGearAction;
 }
 
 /** One node in a plugin-authored declarative UI descriptor (issue #1185). `type` must
@@ -173,4 +193,6 @@ export interface PluginInfo {
   status: unknown;
   /** Last `publishUI` view (validated/normalized), or null. */
   ui: PluginUIView | null;
+  /** Last `publishGearItem` (validated/normalized), or null. */
+  gearItem: PluginGearItem | null;
 }

--- a/src/plugins/ui-validate.ts
+++ b/src/plugins/ui-validate.ts
@@ -1,7 +1,7 @@
 // Seam validator for plugin-authored declarative UI descriptors (issue #1185).
 // Never throws; returns a normalized PluginUIView (re-parsed JSON) or null (invalid).
 
-import type { PluginUIView } from "./types";
+import type { PluginGearAction, PluginGearItem, PluginUIView } from "./types";
 
 /** Guards against a *buggy* (not malicious) trusted plugin — sizes are generous
  *  enough for a rich panel, small enough to catch runaway generators. */
@@ -39,6 +39,83 @@ function validateNode(node: unknown, depth: number, counter: { n: number }): boo
   if (children === undefined) return true;
   if (!Array.isArray(children) || children.length > MAX_ARRAY) return false;
   return children.every((child) => validateNode(child, depth + 1, counter));
+}
+
+/** Guards against a large gear item payload — a gear item is tiny in practice. */
+const MAX_GEAR_BYTES = 8 * 1024; // 8 KB
+
+/** Validate a `kind:"route"` action path: non-empty, safe charset, no leading `/`, no `..`. */
+function validRoutePath(path: string): boolean {
+  if (path.length === 0 || path.length > 256) return false;
+  if (!/^[A-Za-z0-9._/-]+$/.test(path)) return false;
+  if (path.startsWith("/")) return false;
+  return !path.split("/").some((seg) => seg === "..");
+}
+
+/** Validate and normalize the action sub-object of a gear item. */
+function validateGearAction(raw: unknown): PluginGearAction | null {
+  if (!isPlainObject(raw)) return null;
+  const kind = raw["kind"];
+  if (kind === "panel") return { kind: "panel" };
+  if (kind === "url") {
+    const href = raw["href"];
+    if (typeof href !== "string") return null;
+    try {
+      const u = new URL(href);
+      if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+    } catch {
+      return null;
+    }
+    return { kind: "url", href };
+  }
+  if (kind === "route") {
+    const method = raw["method"];
+    const path = raw["path"];
+    if (method !== "GET" && method !== "POST") return null;
+    if (typeof path !== "string" || !validRoutePath(path)) return null;
+    return { kind: "route", method, path };
+  }
+  return null; // unknown kind
+}
+
+/** Validate and normalize a plugin-authored gear-menu item.
+ *  Returns the re-parsed (normalized) PluginGearItem on success, or null if invalid.
+ *  NEVER throws — invalid publishGearItem calls are dropped fail-open. */
+export function validatePluginGearItem(item: unknown): PluginGearItem | null {
+  // 1. Serializability: catches cycles / BigInt.
+  let s: string;
+  try {
+    const raw = JSON.stringify(item);
+    if (raw === undefined) return null;
+    s = raw;
+  } catch {
+    return null;
+  }
+
+  // 2. Byte-size cap.
+  if (Buffer.byteLength(s, "utf8") > MAX_GEAR_BYTES) return null;
+
+  // 3. Re-parse then validate shape.
+  const parsed = JSON.parse(s) as unknown;
+  if (!isPlainObject(parsed)) return null;
+
+  // label: non-empty after trim, length ≤ 80 (store original, reject if trimmed empty).
+  const label = parsed["label"];
+  if (typeof label !== "string" || label.trim().length === 0 || label.length > 80) return null;
+
+  // icon: optional; if present must be string ≤ 8 chars.
+  const icon = parsed["icon"];
+  if (icon !== undefined) {
+    if (typeof icon !== "string" || icon.length > 8) return null;
+  }
+
+  // action: required.
+  const action = validateGearAction(parsed["action"]);
+  if (action === null) return null;
+
+  const result: PluginGearItem = { label, action };
+  if (icon !== undefined) result.icon = icon as string;
+  return result;
 }
 
 /** Validate and normalize a plugin-authored UI view descriptor.

--- a/src/plugins/ui-validate.ts
+++ b/src/plugins/ui-validate.ts
@@ -52,30 +52,41 @@ function validRoutePath(path: string): boolean {
   return !path.split("/").some((seg) => seg === "..");
 }
 
+/** Validate a `kind:"url"` action: absolute http/https only; returns the normalized href. */
+function validateUrlAction(raw: Record<string, unknown>): PluginGearAction | null {
+  const href = raw["href"];
+  if (typeof href !== "string") return null;
+  try {
+    const u = new URL(href);
+    if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+    return { kind: "url", href: u.href };
+  } catch {
+    return null;
+  }
+}
+
+/** Validate a `kind:"route"` action: method GET/POST + a safe relative path. */
+function validateRouteAction(raw: Record<string, unknown>): PluginGearAction | null {
+  const method = raw["method"];
+  const path = raw["path"];
+  if (method !== "GET" && method !== "POST") return null;
+  if (typeof path !== "string" || !validRoutePath(path)) return null;
+  return { kind: "route", method, path };
+}
+
 /** Validate and normalize the action sub-object of a gear item. */
 function validateGearAction(raw: unknown): PluginGearAction | null {
   if (!isPlainObject(raw)) return null;
-  const kind = raw["kind"];
-  if (kind === "panel") return { kind: "panel" };
-  if (kind === "url") {
-    const href = raw["href"];
-    if (typeof href !== "string") return null;
-    try {
-      const u = new URL(href);
-      if (u.protocol !== "http:" && u.protocol !== "https:") return null;
-      return { kind: "url", href: u.href };
-    } catch {
+  switch (raw["kind"]) {
+    case "panel":
+      return { kind: "panel" };
+    case "url":
+      return validateUrlAction(raw);
+    case "route":
+      return validateRouteAction(raw);
+    default:
       return null;
-    }
   }
-  if (kind === "route") {
-    const method = raw["method"];
-    const path = raw["path"];
-    if (method !== "GET" && method !== "POST") return null;
-    if (typeof path !== "string" || !validRoutePath(path)) return null;
-    return { kind: "route", method, path };
-  }
-  return null; // unknown kind
 }
 
 /** Validate and normalize a plugin-authored gear-menu item.

--- a/src/plugins/ui-validate.ts
+++ b/src/plugins/ui-validate.ts
@@ -63,10 +63,10 @@ function validateGearAction(raw: unknown): PluginGearAction | null {
     try {
       const u = new URL(href);
       if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+      return { kind: "url", href: u.href };
     } catch {
       return null;
     }
-    return { kind: "url", href };
   }
   if (kind === "route") {
     const method = raw["method"];
@@ -114,7 +114,7 @@ export function validatePluginGearItem(item: unknown): PluginGearItem | null {
   if (action === null) return null;
 
   const result: PluginGearItem = { label, action };
-  if (icon !== undefined) result.icon = icon as string;
+  if (icon !== undefined) result.icon = icon;
   return result;
 }
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2112,5 +2112,7 @@
   "feat_plugin_ui_charts_title": "Plugins können Diagramme anzeigen",
   "feat_plugin_ui_charts_body": "Plugins können jetzt Tacho-Anzeigen, Sparklines, Zeitreihen, Balkendiagramme und Zeitachsen unter Einstellungen → Plugins veröffentlichen — nicht nur Messanzeigen, Badges und Tabellen.",
   "plugin_gear_action_done": "Fertig",
-  "plugin_gear_action_failed": "Plugin-Aktion fehlgeschlagen"
+  "plugin_gear_action_failed": "Plugin-Aktion fehlgeschlagen",
+  "feat_plugin_gear_item_title": "Plugin-Einträge im Zahnradmenü",
+  "feat_plugin_gear_item_body": "Plugins können dem Zahnradmenü jetzt einen einzelnen Eintrag hinzufügen — der einen Link öffnet, eine Plugin-Aktion ausführt oder zum Plugin-Panel springt."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2110,5 +2110,7 @@
   "feat_plugin_ui_title": "Plugins zeigen echte Panels",
   "feat_plugin_ui_body": "Plugins können jetzt Kontingentmesser, Status-Badges und Tabellen in Einstellungen → Plugins anzeigen – anstelle eines rohen JSON-Dumps.",
   "feat_plugin_ui_charts_title": "Plugins können Diagramme anzeigen",
-  "feat_plugin_ui_charts_body": "Plugins können jetzt Tacho-Anzeigen, Sparklines, Zeitreihen, Balkendiagramme und Zeitachsen unter Einstellungen → Plugins veröffentlichen — nicht nur Messanzeigen, Badges und Tabellen."
+  "feat_plugin_ui_charts_body": "Plugins können jetzt Tacho-Anzeigen, Sparklines, Zeitreihen, Balkendiagramme und Zeitachsen unter Einstellungen → Plugins veröffentlichen — nicht nur Messanzeigen, Badges und Tabellen.",
+  "plugin_gear_action_done": "Fertig",
+  "plugin_gear_action_failed": "Plugin-Aktion fehlgeschlagen"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2112,5 +2112,7 @@
   "feat_plugin_ui_charts_title": "Plugins can show charts",
   "feat_plugin_ui_charts_body": "Plugins can now publish gauges, sparklines, time-series, bar charts and timelines in Settings → Plugins — not just meters, badges and tables.",
   "plugin_gear_action_done": "Done",
-  "plugin_gear_action_failed": "Plugin action failed"
+  "plugin_gear_action_failed": "Plugin action failed",
+  "feat_plugin_gear_item_title": "Plugin gear-menu items",
+  "feat_plugin_gear_item_body": "Plugins can now add a single item to the gear menu — opening a link, running a plugin action, or jumping to the plugin's panel."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2110,5 +2110,7 @@
   "feat_plugin_ui_title": "Plugins show real panels",
   "feat_plugin_ui_body": "Plugins can now render quota meters, status badges and tables in Settings → Plugins instead of a raw JSON dump.",
   "feat_plugin_ui_charts_title": "Plugins can show charts",
-  "feat_plugin_ui_charts_body": "Plugins can now publish gauges, sparklines, time-series, bar charts and timelines in Settings → Plugins — not just meters, badges and tables."
+  "feat_plugin_ui_charts_body": "Plugins can now publish gauges, sparklines, time-series, bar charts and timelines in Settings → Plugins — not just meters, badges and tables.",
+  "plugin_gear_action_done": "Done",
+  "plugin_gear_action_failed": "Plugin action failed"
 }

--- a/ui/src/lib/api.invokePluginRoute.test.ts
+++ b/ui/src/lib/api.invokePluginRoute.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+import { invokePluginRoute } from "./api";
+
+function mockFetchText(status: number, body: string): typeof fetch {
+  return vi.fn(async () => new Response(body, { status })) as unknown as typeof fetch;
+}
+
+describe("invokePluginRoute", () => {
+  it("returns trimmed text on ok response", async () => {
+    globalThis.fetch = mockFetchText(200, "  hello world  ");
+    const result = await invokePluginRoute("my-plugin", "GET", "status");
+    expect(result).toBe("hello world");
+  });
+
+  it("returns empty string when response body is empty", async () => {
+    globalThis.fetch = mockFetchText(200, "");
+    const result = await invokePluginRoute("my-plugin", "GET", "ping");
+    expect(result).toBe("");
+  });
+
+  it("caps response at 200 chars with ellipsis when longer", async () => {
+    const long = "x".repeat(250);
+    globalThis.fetch = mockFetchText(200, long);
+    const result = await invokePluginRoute("my-plugin", "GET", "data");
+    expect(result).toHaveLength(200);
+    expect(result).toBe("x".repeat(199) + "…");
+  });
+
+  it("does not truncate a response of exactly 200 chars", async () => {
+    const exact = "y".repeat(200);
+    globalThis.fetch = mockFetchText(200, exact);
+    const result = await invokePluginRoute("my-plugin", "GET", "data");
+    expect(result).toBe(exact);
+    expect(result).toHaveLength(200);
+  });
+
+  it("throws on non-ok response", async () => {
+    globalThis.fetch = mockFetchText(500, JSON.stringify({ error: "plugin error" }));
+    // The response body is JSON, which failed() will parse
+    await expect(invokePluginRoute("my-plugin", "GET", "boom")).rejects.toThrow();
+  });
+
+  it("sends the request to the correct URL with the given method", async () => {
+    const calls: { url: string; method: string }[] = [];
+    globalThis.fetch = vi.fn(async (url: unknown, init?: { method?: string }) => {
+      calls.push({ url: url as string, method: init?.method ?? "GET" });
+      return new Response("ok", { status: 200 });
+    }) as unknown as typeof fetch;
+    await invokePluginRoute("cap-plugin", "POST", "trigger");
+    expect(calls[0]).toEqual({ url: "/api/plugins/cap-plugin/trigger", method: "POST" });
+  });
+});

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1035,6 +1035,20 @@ export async function getPlugins(): Promise<PluginInfo[]> {
   return body.plugins ?? [];
 }
 
+/** Invoke a plugin-registered route at `/api/plugins/<id>/<path>` with the given method.
+ *  On success, returns the trimmed response text (capped to 200 chars; longer responses are
+ *  sliced to 199 chars with a trailing "…"). Strings are verbatim plugin-authored DATA. */
+export async function invokePluginRoute(
+  id: string,
+  method: "GET" | "POST",
+  path: string,
+): Promise<string> {
+  const r = await fetch(`/api/plugins/${id}/${path}`, { method });
+  if (!r.ok) throw await failed(r, "plugin route");
+  const text = (await r.text()).trim();
+  return text.length > 200 ? text.slice(0, 199) + "…" : text;
+}
+
 /** Run the verbatim remediation for a diagnostics check, then return the re-probed
  *  snapshot. Throws (via failed/apiError) on a non-2xx — the caller surfaces it as an
  *  explicit failure, never a silent pass. */

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -206,6 +206,7 @@ describe("Settings responsive tab navigation", () => {
       lastError: null,
       status: {},
       ui: null,
+      gearItem: null,
     },
   ];
 

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -83,6 +83,7 @@
     initialTab = "workspace",
     initialDiagnostics = null,
     plugins = [],
+    focusPluginId = null,
   }: {
     onclose?: () => void;
     onsaved?: (root: string) => void;
@@ -94,6 +95,8 @@
     initialDiagnostics?: DiagnosticCheck[] | null;
     /** Loaded server-side plugins (issue #1124); empty → the Plugins tab is hidden. */
     plugins?: PluginInfo[];
+    /** Plugin id to scroll into view + highlight on open (from gear-item panel action). */
+    focusPluginId?: string | null;
   } = $props();
 
   // initialTab seeds the starting tab; the user then freely switches it, so we
@@ -1062,7 +1065,7 @@
         aria-label={m.settings_tab_plugins()}
         hidden={tab !== "plugins"}
       >
-        <SettingsPluginsPanel {plugins} />
+        <SettingsPluginsPanel {plugins} focusId={focusPluginId} />
       </div>
     {/if}
   </div>

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -1928,3 +1928,60 @@ describe("TopBar — mobile gear sheet portals out of transformed ancestor", () 
     ).toBeGreaterThanOrEqual(window.innerHeight - 2);
   });
 });
+
+describe("TopBar — plugin gear items", () => {
+  const pluginBase = {
+    nowMs: 1_700_000_000_000,
+    connected: true,
+    sessions: [] as Session[],
+  };
+
+  it("desktop: plugin items render in the gear menu with verbatim label and icon", async () => {
+    await page.viewport(1280, 900);
+    document.body.style.width = "1280px";
+    render(TopBar, {
+      ...pluginBase,
+      ...FLAGS.desktop,
+      pluginItems: [{ id: "my-plugin", label: "My Action", icon: "🔌" }],
+    });
+    // Click the gear to open the menu (pluginItems forces gearOpensMenu=true)
+    await page.getByRole("button", { name: m.topbar_menu_aria() }).click();
+    // Plugin item button is visible with verbatim label
+    await expect.element(page.getByRole("menuitem", { name: "My Action" })).toBeVisible();
+    await expect.element(page.getByText("🔌")).toBeVisible();
+  });
+
+  it("desktop: clicking a plugin item calls onpluginitem with its id", async () => {
+    await page.viewport(1280, 900);
+    document.body.style.width = "1280px";
+    const onpluginitem = vi.fn();
+    render(TopBar, {
+      ...pluginBase,
+      ...FLAGS.desktop,
+      pluginItems: [{ id: "act-plugin", label: "Do Something" }],
+      onpluginitem,
+    });
+    await page.getByRole("button", { name: m.topbar_menu_aria() }).click();
+    await page.getByRole("menuitem", { name: "Do Something" }).click();
+    expect(onpluginitem).toHaveBeenCalledWith("act-plugin");
+  });
+
+  it("desktop: idle herd + pluginItems — gear opens a menu instead of going directly to settings", async () => {
+    await page.viewport(1280, 900);
+    document.body.style.width = "1280px";
+    const onsettings = vi.fn();
+    render(TopBar, {
+      ...pluginBase,
+      ...FLAGS.desktop,
+      pluginItems: [{ id: "p1", label: "Plugin Action" }],
+      onsettings,
+    });
+    // With pluginItems, gear is a menu button (not a direct-settings button)
+    const gear = page.getByRole("button", { name: m.topbar_menu_aria() });
+    await expect.element(gear).toBeVisible();
+    await gear.click();
+    // Menu is open — the plugin item is visible, settings was NOT called directly
+    await expect.element(page.getByRole("menuitem", { name: "Plugin Action" })).toBeVisible();
+    expect(onsettings).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -66,6 +66,8 @@
     onlearnings,
     heldCount = 0,
     onedithheld,
+    pluginItems = [],
+    onpluginitem,
   }: {
     sessions: Session[];
     nowMs: number;
@@ -104,6 +106,10 @@
     heldCount?: number;
     /** Edit a held task: page opens the New Task composer pre-filled from its input. */
     onedithheld?: (task: HeldTask) => void;
+    /** Plugin-contributed gear-menu items (verbatim plugin data). */
+    pluginItems?: { id: string; label: string; icon?: string }[];
+    /** Called when a plugin item is selected from the gear menu. */
+    onpluginitem?: (id: string) => void;
   } = $props();
 
   // tally click: toggle — clicking the active status clears the filter
@@ -532,7 +538,8 @@
   // under measured overflow (compactBadges), where the standalone docs link folds away,
   // so the gear must open the menu (which carries Documentation + Settings) to keep the
   // docs reachable even with an idle herd in that compact state.
-  const gearOpensMenu = $derived(mobile || haltable > 0 || compactBadges);
+  // Plugin items also force menu mode: their actions live in the menu, not the gear click.
+  const gearOpensMenu = $derived(mobile || haltable > 0 || compactBadges || pluginItems.length > 0);
   // Mobile only: every gear-area signal collapses into ONE dot, colored by the
   // most serious active tier (red > orange > yellow > blue). Desktop keeps its
   // halt-pip + dedicated badges, so this stays null off-mobile.
@@ -578,6 +585,11 @@
     disarmHalt();
     onusage?.();
   }
+  function choosePlugin(id: string) {
+    menuOpen = false;
+    disarmHalt();
+    onpluginitem?.(id);
+  }
   // On open, move focus to the first menu item (proper menu-button keyboard flow).
   $effect(() => {
     if (menuOpen) menuEl?.querySelector<HTMLElement>("[role='menuitem']")?.focus();
@@ -614,6 +626,12 @@
     // Under measured overflow the gear is a menu button even with an idle herd (it hosts
     // the folded-away docs link), so keep the menu open here too — just drop armed state.
     if (compactBadges) {
+      disarmHalt();
+      return;
+    }
+    // Plugin items keep the menu valid with an idle herd — a menu opened to reach a plugin
+    // action must not be dismissed just because the last agent finished while it was open.
+    if (pluginItems.length > 0) {
       disarmHalt();
       return;
     }
@@ -812,6 +830,8 @@
       {chooseUsage}
       {onMenuKey}
       {onFeedback}
+      {pluginItems}
+      onPluginItem={choosePlugin}
     />
   </div>
 </div>
@@ -853,6 +873,8 @@
     {onwhatsnew}
     {onlearnings}
     {onFeedback}
+    {pluginItems}
+    onPluginItem={choosePlugin}
   />
 {/if}
 

--- a/ui/src/lib/components/page/AppOverlays.svelte
+++ b/ui/src/lib/components/page/AppOverlays.svelte
@@ -129,6 +129,7 @@
     onnewnewproject,
     showSettings,
     settingsTab,
+    focusPluginId = null,
     onsettingsclose,
     onsettingsherdrupdate,
     onsettingswhatsnew,
@@ -228,7 +229,8 @@
     onnewfork: () => void;
     onnewnewproject: () => void;
     showSettings: boolean;
-    settingsTab: "workspace" | "session" | "device" | "diagnose";
+    settingsTab: "workspace" | "session" | "device" | "diagnose" | "plugins";
+    focusPluginId?: string | null;
     onsettingsclose: () => void;
     onsettingsherdrupdate: () => void;
     onsettingswhatsnew: () => void;
@@ -453,6 +455,7 @@
     initialTab={settingsTab}
     initialDiagnostics={store.diagnostics?.checks ?? null}
     plugins={store.plugins}
+    {focusPluginId}
     onclose={onsettingsclose}
     herdrUpdate={store.herdrUpdate}
     onherdrupdate={onsettingsherdrupdate}

--- a/ui/src/lib/components/settings/SettingsPluginsPanel.browser.test.ts
+++ b/ui/src/lib/components/settings/SettingsPluginsPanel.browser.test.ts
@@ -14,6 +14,7 @@ function plugin(overrides: Partial<PluginInfo> = {}): PluginInfo {
     lastError: null,
     status: { key: "value" },
     ui: null,
+    gearItem: null,
     ...overrides,
   };
 }

--- a/ui/src/lib/components/settings/SettingsPluginsPanel.browser.test.ts
+++ b/ui/src/lib/components/settings/SettingsPluginsPanel.browser.test.ts
@@ -95,4 +95,24 @@ describe("SettingsPluginsPanel", () => {
     await page.getByRole("button").click();
     await expect.element(page.getByText(/"side": true/)).toBeInTheDocument();
   });
+
+  it("each plugin card has a plugin-card-<id> DOM id", async () => {
+    render(SettingsPluginsPanel, {
+      plugins: [plugin({ id: "alpha" }), plugin({ id: "beta", name: "Beta Plugin" })],
+    });
+    expect(document.getElementById("plugin-card-alpha")).not.toBeNull();
+    expect(document.getElementById("plugin-card-beta")).not.toBeNull();
+  });
+
+  it("focusId applies focus-flash class to the matching card", async () => {
+    render(SettingsPluginsPanel, {
+      plugins: [plugin({ id: "target-plugin", name: "Target Plugin" })],
+      focusId: "target-plugin",
+    });
+    // The $effect runs after mount; wait a microtask for it to fire.
+    await new Promise((r) => setTimeout(r, 0));
+    const card = document.getElementById("plugin-card-target-plugin");
+    expect(card, "card exists").not.toBeNull();
+    expect(card!.classList.contains("focus-flash"), "focus-flash applied").toBe(true);
+  });
 });

--- a/ui/src/lib/components/settings/SettingsPluginsPanel.svelte
+++ b/ui/src/lib/components/settings/SettingsPluginsPanel.svelte
@@ -3,7 +3,8 @@
   import type { PluginInfo, PluginUIView } from "$lib/types";
   import PluginUIRenderer from "$lib/plugin-ui/PluginUIRenderer.svelte";
 
-  let { plugins = [] }: { plugins?: PluginInfo[] } = $props();
+  let { plugins = [], focusId = null }: { plugins?: PluginInfo[]; focusId?: string | null } =
+    $props();
 
   // Core-derived health → token + label. Design rule (mirrors DiagnoseRows): never
   // --color-green for healthy — ok is steady-state slate, not actionable-complete.
@@ -28,6 +29,18 @@
   function panelView(p: PluginInfo): PluginUIView | null {
     return p.ui && p.ui.slot === "settings-panel" ? p.ui : null;
   }
+
+  // When focusId changes (from a gear-item panel action), scroll the matching
+  // card into view and briefly apply a highlight flash.
+  $effect(() => {
+    if (!focusId) return;
+    const el = document.getElementById(`plugin-card-${focusId}`);
+    if (!el) return;
+    el.scrollIntoView({ block: "center" });
+    el.classList.add("focus-flash");
+    const t = setTimeout(() => el.classList.remove("focus-flash"), 1200);
+    return () => clearTimeout(t);
+  });
 </script>
 
 <div class="plugins">
@@ -35,7 +48,7 @@
   {#each plugins as p (p.id)}
     {@const h = HEALTH[p.health]}
     {@const view = panelView(p)}
-    <div class="row">
+    <div class="row" id={`plugin-card-${p.id}`}>
       <button
         type="button"
         class="head"
@@ -92,6 +105,14 @@
     border: 1px solid var(--color-line);
     background: var(--color-inset);
     padding: 8px 10px;
+    transition: outline 0.1s ease;
+  }
+  /* Brief highlight when a plugin card is scrolled into focus via gear-item action.
+     Uses an outline (not background change) so layout and border are undisturbed.
+     :global() because the class is added imperatively via classList.add. */
+  .row:global(.focus-flash) {
+    outline: 2px solid var(--color-amber);
+    outline-offset: 1px;
   }
   .head {
     display: flex;

--- a/ui/src/lib/components/top-bar/TopBarGear.svelte
+++ b/ui/src/lib/components/top-bar/TopBarGear.svelte
@@ -139,7 +139,6 @@
             class="menu-item"
             type="button"
             role="menuitem"
-            aria-label={item.label}
             onclick={() => onPluginItem?.(item.id)}
           >
             {#if item.icon}<span class="menu-glyph" aria-hidden="true">{item.icon}</span>{/if}

--- a/ui/src/lib/components/top-bar/TopBarGear.svelte
+++ b/ui/src/lib/components/top-bar/TopBarGear.svelte
@@ -23,6 +23,8 @@
     chooseUsage,
     onMenuKey,
     onFeedback,
+    pluginItems = [],
+    onPluginItem,
   }: {
     mobile: boolean;
     haltable: number;
@@ -40,6 +42,8 @@
     chooseUsage: () => void;
     onMenuKey: (e: KeyboardEvent) => void;
     onFeedback: (kind: FeedbackKind) => void;
+    pluginItems?: { id: string; label: string; icon?: string }[];
+    onPluginItem?: (id: string) => void;
   } = $props();
 </script>
 
@@ -128,6 +132,21 @@
         <span class="menu-glyph" aria-hidden="true">↗</span>
         <span class="menu-label">{m.topbar_docs()}</span>
       </a>
+      {#if pluginItems.length > 0}
+        <div class="menu-sep" role="separator"></div>
+        {#each pluginItems as item (item.id)}
+          <button
+            class="menu-item"
+            type="button"
+            role="menuitem"
+            aria-label={item.label}
+            onclick={() => onPluginItem?.(item.id)}
+          >
+            {#if item.icon}<span class="menu-glyph" aria-hidden="true">{item.icon}</span>{/if}
+            <span class="menu-label">{item.label}</span>
+          </button>
+        {/each}
+      {/if}
       <button class="menu-item" type="button" role="menuitem" onclick={() => onFeedback("bug")}>
         <span class="menu-glyph" aria-hidden="true">🐛</span>
         <span class="menu-label">{m.feedback_dialog_title_bug()}</span>

--- a/ui/src/lib/components/top-bar/TopBarMobileSheet.svelte
+++ b/ui/src/lib/components/top-bar/TopBarMobileSheet.svelte
@@ -71,6 +71,8 @@
     onwhatsnew,
     onlearnings,
     onFeedback,
+    pluginItems = [],
+    onPluginItem,
   }: {
     gauges: Gauge[];
     credits: CreditWindow | null;
@@ -107,6 +109,8 @@
     onwhatsnew: (() => void) | undefined;
     onlearnings: (() => void) | undefined;
     onFeedback: (kind: FeedbackKind) => void;
+    pluginItems?: { id: string; label: string; icon?: string }[];
+    onPluginItem?: (id: string) => void;
   } = $props();
 </script>
 
@@ -377,6 +381,24 @@
       <span class="sheet-label">{m.settings_title()}</span>
     </button>
     <div class="sheet-sep"></div>
+
+    <!-- Plugin items: verbatim plugin-authored label/icon (not i18n) -->
+    {#if pluginItems.length > 0}
+      {#each pluginItems as item (item.id)}
+        <button
+          type="button"
+          class="sheet-item"
+          onclick={() => {
+            closeMenu();
+            onPluginItem?.(item.id);
+          }}
+        >
+          {#if item.icon}<span class="sheet-glyph" aria-hidden="true">{item.icon}</span>{/if}
+          <span class="sheet-label">{item.label}</span>
+        </button>
+      {/each}
+      <div class="sheet-sep"></div>
+    {/if}
 
     <!-- Feedback -->
     <button type="button" class="sheet-item" onclick={() => onFeedback("bug")}>

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1780,4 +1780,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_plugin_ui_charts_title",
     bodyKey: "feat_plugin_ui_charts_body",
   },
+  {
+    // No targetId: the gear item only exists when a plugin publishes one, so there
+    // is no stable always-present anchor — surface via the What's-New drawer only.
+    // 1.38.0 is the latest released tag, so this ships in 1.39.0.
+    id: "plugin-gear-item",
+    sinceVersion: "1.39.0",
+    titleKey: "feat_plugin_gear_item_title",
+    bodyKey: "feat_plugin_gear_item_body",
+  },
 ];

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -114,6 +114,7 @@ test("plugin:status updates the matching plugin's health + published status in p
       lastError: null,
       status: null,
       ui: null,
+      gearItem: null,
     },
     {
       id: "p2",
@@ -123,6 +124,7 @@ test("plugin:status updates the matching plugin's health + published status in p
       lastError: null,
       status: null,
       ui: null,
+      gearItem: null,
     },
   ]);
   s.apply({ event: "plugin:status", data: { id: "p1", health: "errored", status: { n: 7 } } });
@@ -147,6 +149,7 @@ test("plugin:ui updates the matching plugin's ui descriptor in place", () => {
       lastError: null,
       status: null,
       ui: null,
+      gearItem: null,
     },
     {
       id: "p2",
@@ -156,6 +159,7 @@ test("plugin:ui updates the matching plugin's ui descriptor in place", () => {
       lastError: null,
       status: null,
       ui: null,
+      gearItem: null,
     },
   ]);
   const view = {
@@ -183,6 +187,7 @@ test("plugin:ui for an unknown id is a no-op (pre-bootstrap guard)", () => {
       lastError: null,
       status: null,
       ui: null,
+      gearItem: null,
     },
   ]);
   s.apply({
@@ -199,6 +204,66 @@ test("plugin:ui for an unknown id is a no-op (pre-bootstrap guard)", () => {
   // no new plugin row added; existing plugin untouched
   expect(s.plugins).toHaveLength(1);
   expect(s.plugins[0].ui).toBeNull();
+});
+
+test("plugin:gear updates the matching plugin's gear item in place", () => {
+  const s = new HerdStore();
+  s.setPlugins([
+    {
+      id: "p1",
+      name: "P1",
+      version: "1.0.0",
+      health: "ok",
+      lastError: null,
+      status: null,
+      ui: null,
+      gearItem: null,
+    },
+    {
+      id: "p2",
+      name: "P2",
+      version: "2.0.0",
+      health: "ok",
+      lastError: null,
+      status: null,
+      ui: null,
+      gearItem: null,
+    },
+  ]);
+  const item = { label: "Open settings", icon: "⚙️", action: { kind: "panel" as const } };
+  s.apply({ event: "plugin:gear", data: { id: "p1", gearItem: item } });
+  expect(s.plugins.find((p) => p.id === "p1")?.gearItem).toEqual(item);
+  // unrelated plugin untouched
+  expect(s.plugins.find((p) => p.id === "p2")?.gearItem).toBeNull();
+  // setting back to null is supported
+  s.apply({ event: "plugin:gear", data: { id: "p1", gearItem: null } });
+  expect(s.plugins.find((p) => p.id === "p1")?.gearItem).toBeNull();
+});
+
+test("plugin:gear for an unknown id is a no-op (pre-bootstrap guard)", () => {
+  const s = new HerdStore();
+  s.setPlugins([
+    {
+      id: "p1",
+      name: "P1",
+      version: "1.0.0",
+      health: "ok",
+      lastError: null,
+      status: null,
+      ui: null,
+      gearItem: null,
+    },
+  ]);
+  s.apply({
+    event: "plugin:gear",
+    data: {
+      id: "ghost",
+      gearItem: { label: "Ghost action", action: { kind: "panel" } },
+    },
+  });
+  // no new plugin row added; existing plugin untouched
+  expect(s.plugins).toHaveLength(1);
+  expect(s.plugins[0].gearItem).toBeNull();
 });
 
 test("backlog:update replaces the backlog snapshot so the overview stays live", () => {

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -5,6 +5,7 @@ import type {
   WsEvent,
   PluginInfo,
   PluginUIView,
+  PluginGearItem,
   UsageLimits,
   UpdateStatus,
   HerdrUpdateStatus,
@@ -172,6 +173,15 @@ export class HerdStore {
     const i = this.plugins.findIndex((p) => p.id === data.id);
     if (i === -1) return; // unknown id (pre-bootstrap race) — the GET seed will catch up
     this.plugins = this.plugins.map((p) => (p.id === data.id ? { ...p, ui: data.ui } : p));
+  }
+  /** Live `plugin:gear` push: update the matching plugin's gear-menu item in place.
+   *  Mirrors applyPluginUi, including the pre-bootstrap unknown-id no-op. */
+  private applyPluginGear(data: { id: string; gearItem: PluginGearItem | null }) {
+    const i = this.plugins.findIndex((p) => p.id === data.id);
+    if (i === -1) return; // unknown id (pre-bootstrap race) — the GET seed will catch up
+    this.plugins = this.plugins.map((p) =>
+      p.id === data.id ? { ...p, gearItem: data.gearItem } : p,
+    );
   }
   /** Seed (or replace) the preview-port map after a bootstrap GET. */
   setPreview(map: Record<string, number | null>) {
@@ -578,6 +588,9 @@ export class HerdStore {
         return true;
       case "plugin:ui":
         this.applyPluginUi(ev.data);
+        return true;
+      case "plugin:gear":
+        this.applyPluginGear(ev.data);
         return true;
       case "star-prompt:status":
         this.starPrompt = ev.data;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1158,6 +1158,23 @@ export interface PluginUIView {
   root: PluginUINode;
 }
 
+/** A declarative action a plugin's gear-menu item performs on click. Discriminated by `kind`.
+ *  All fields JSON-serializable; strings are verbatim plugin-authored DATA, never i18n keys. */
+export type PluginGearAction =
+  | { kind: "route"; method: "GET" | "POST"; path: string }
+  | { kind: "url"; href: string }
+  | { kind: "panel" };
+
+/** One gear-menu item a plugin contributes via `ctx.publishGearItem`. At most ONE per plugin;
+ *  latest publish wins; `null` clears it. Strings are verbatim plugin-authored DATA, not i18n. */
+export interface PluginGearItem {
+  /** Verbatim plugin-authored label (NOT an i18n key). */
+  label: string;
+  /** Optional single glyph/emoji icon (verbatim). */
+  icon?: string;
+  action: PluginGearAction;
+}
+
 /** A loaded server-side plugin as shown in Settings → Plugins (issue #1124). `health` is
  *  core-derived (unspoofable); `status` is the plugin's last publishStatus blob (verbatim). */
 export interface PluginInfo {
@@ -1168,6 +1185,8 @@ export interface PluginInfo {
   lastError: string | null;
   status: unknown;
   ui: PluginUIView | null;
+  /** Last `publishGearItem` (validated/normalized), or null. */
+  gearItem: PluginGearItem | null;
 }
 
 // Up Next (#1169) — cross-repo ranked queue of un-started work. Mirrors src/up-next-core.ts.
@@ -1269,6 +1288,7 @@ export type WsEvent =
       data: { id: string; health: PluginInfo["health"]; status: unknown };
     }
   | { event: "plugin:ui"; data: { id: string; ui: PluginUIView | null } }
+  | { event: "plugin:gear"; data: { id: string; gearItem: PluginGearItem | null } }
   | { event: "backlog:update"; data: BacklogPayload }
   | { event: "drain:status"; data: DrainStatus }
   | { event: "automerge:status"; data: AutoMergeStatus }

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -44,6 +44,7 @@
     getBuildQueues,
     listHeld,
     updateHeld,
+    invokePluginRoute,
   } from "$lib/api";
   import type {
     AgentProvider,
@@ -169,7 +170,10 @@
   let showNew = $state(false);
   let showSettings = $state(false);
   let showUsage = $state(false);
-  let settingsTab = $state<"workspace" | "session" | "device" | "diagnose">("workspace");
+  let settingsTab = $state<"workspace" | "session" | "device" | "diagnose" | "plugins">(
+    "workspace",
+  );
+  let focusPluginId = $state<string | null>(null);
   let showClone = $state(false);
   let showFork = $state(false);
   let showNewProject = $state(false);
@@ -1760,6 +1764,39 @@
     });
   }
 
+  // Plugin gear items: one entry per plugin that published a gearItem.
+  // Verbatim plugin-authored data — never run through i18n.
+  const pluginGearItems = $derived(
+    store.plugins
+      .filter((p) => p.gearItem)
+      .map((p) => ({ id: p.id, label: p.gearItem!.label, icon: p.gearItem!.icon })),
+  );
+
+  async function handlePluginGearItem(id: string) {
+    const item = store.plugins.find((p) => p.id === id)?.gearItem;
+    if (!item) return;
+    const a = item.action;
+    if (a.kind === "url") {
+      window.open(a.href, "_blank", "noopener,noreferrer");
+    } else if (a.kind === "panel") {
+      focusPluginId = id;
+      settingsTab = "plugins";
+      showSettings = true;
+    } else {
+      // route
+      try {
+        const text = await invokePluginRoute(id, a.method, a.path);
+        toasts.info(text.length > 0 ? text : m.plugin_gear_action_done());
+      } catch {
+        toasts.info(m.plugin_gear_action_failed(), {
+          duration: null,
+          alert: true,
+          key: `plugin-gear:${id}`,
+        });
+      }
+    }
+  }
+
   // Open the "clear all merged" confirm modal. The server is the source of truth
   // for which sessions are merged (same prCache the list partitions on) and for the
   // leftover count, so we ask it rather than trust the local snapshot.
@@ -2004,6 +2041,8 @@
         }}
         heldCount={store.heldCount}
         onedithheld={onEditHeld}
+        pluginItems={pluginGearItems}
+        onpluginitem={handlePluginGearItem}
       />
       <RepoSwitcher
         chips={repoChips}
@@ -2429,8 +2468,10 @@
   }}
   {showSettings}
   {settingsTab}
+  {focusPluginId}
   onsettingsclose={() => {
     showSettings = false;
+    focusPluginId = null;
     loadSettings();
   }}
   onsettingsherdrupdate={() => {


### PR DESCRIPTION
## What

Lets a plugin contribute **a single item** to the top-bar gear menu via a new `ctx.publishGearItem(item | null)` capability. Clicking it performs one of three declarative actions. Motivating case: the claude-swap plugin can surface its usage view from the gear menu (follow-up: erwins-enkel/shepherd-claude-swap#17).

```ts
ctx.publishGearItem({
  label: "Usage",            // ≤80 chars, verbatim
  icon: "▦",                  // optional glyph/emoji, ≤8 chars
  action: { kind: "panel" }, // | { kind:"url", href } | { kind:"route", method, path }
});
ctx.publishGearItem(null);   // clears it
```

- **`route`** → invokes the plugin's own `/api/plugins/<id>/<path>`, toasts the (≤200-char) response.
- **`url`** → opens an absolute **http/https** URL in a new tab (`javascript:`/`data:`/relative rejected).
- **`panel`** → opens Settings → Plugins scrolled to this plugin's card (works even with no published UI view).

One item per plugin (latest wins); additive seam — plugins guard with `typeof ctx.publishGearItem === "function"`. Renders in **both** the desktop dropdown and the mobile sheet.

## How

- **Server** (`src/plugins/`): `PluginGearItem`/`PluginGearAction` types + `publishGearItem` on `PluginContext` + `gearItem` on `PluginInfo`; `validatePluginGearItem` (fail-open: url scheme allowlist, route path sanitization — no `..`/leading `/`, char allowlist — label/icon/size caps); loader emits a `plugin:gear` event mirroring `plugin:ui` and includes `gearItem` in `GET /api/plugins`.
- **UI** (`ui/`): mirror types + `plugin:gear` `WsEvent`; `store.applyPluginGear`; `api.invokePluginRoute` (200-char cap); `TopBarGear` + `TopBarMobileSheet` render the item; `TopBar` derives items + dispatches actions; `gearOpensMenu` and the herd-idle auto-close `$effect` gated on `pluginItems.length` so an idle desktop herd still surfaces the item; `panel` opens Settings → Plugins (`focusPluginId` chain → scroll + transient highlight). Failure toast is persistent + assertive + per-tone dedupe key (house rule); plugin label/icon/response render verbatim (not i18n).
- **Discovery / docs**: feature-catalog entry (`plugin-gear-item`, 1.39.0) + EN/DE keys; `docs/plugins.md` documents `publishGearItem` **and** the previously-undocumented `publishUI`, now published on the docs site (`docs-site` sync + sidebar); `examples/plugins/spawn-labeler` demonstrates the capability.

## Testing

- Server: `validatePluginGearItem` unit tests (each action kind; rejects `javascript:` url, bad method, `..`/leading-slash path, oversize, empty/long label, bad icon) + loader emit/clear/keep-prior tests — 43 pass.
- UI: `TopBarGear` render+dispatch, `SettingsPluginsPanel` focus, store `applyPluginGear`, `invokePluginRoute` cap — full `ui` vitest suite 2259 pass.
- Green: root lint + `bun run test`; `ui` svelte-check + `check:i18n` (parity) + vitest; docs-site check; branch-hygiene + feature-catalog + glossary + `fallow audit`.

Reviewed task-by-task plus a final whole-branch review (verdict: ready to merge; security boundary validated end-to-end, no desktop gating regression with zero plugin items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
