### PR TITLE
docs: list Plugins in the front-page and getting-started topic lists

### DIFF
--- a/docs-site/src/content/docs/getting-started.md
+++ b/docs-site/src/content/docs/getting-started.md
@@ -108,3 +108,4 @@ Open <http://localhost:7330>. To expose it (e.g. via Tailscale), set
 - [Operating Shepherd](/operating/) — run it as a service and deploy changes.
 - [Configuration](/reference/configuration/) — every environment variable.
 - [Concepts & glossary](/reference/glossary/) — the terms Shepherd uses.
+- [Plugins](/reference/plugins/) — extend Shepherd with server-side spawn hooks, routes, and UI.

--- a/docs-site/src/content/docs/index.md
+++ b/docs-site/src/content/docs/index.md
@@ -25,5 +25,7 @@ agents.
   Tailscale, and deploy code changes.
 - **[Configuration](/reference/configuration/)** — every environment variable.
 - **[Concepts & glossary](/reference/glossary/)** — the terms Shepherd uses.
+- **[Plugins](/reference/plugins/)** — extend Shepherd with server-side spawn
+  hooks, routes, and UI.
 - **[External Task API](/reference/external-task-api/)** — queue work over HTTP.
 - **[Security](/reference/security/)** — the sandbox membrane and egress firewall.


### PR DESCRIPTION
## What

The **Plugins** reference page (`/reference/plugins/`) already exists and is in the docs sidebar, but it was missing from the two curated topic lists that route readers to the major sections:

- Front-page **"Start here"** list (`docs-site/src/content/docs/index.md`)
- Getting Started **"Next steps"** list (`docs-site/src/content/docs/getting-started.md`)

This adds a Plugins bullet to each.

## Details

- Placed in **sidebar order** (after "Concepts & glossary", before "External Task API").
- Matches each list's existing link style: **bold** on the front page, **plain non-bold** in "Next steps".
- Identical wording in both: _extend Shepherd with server-side spawn hooks, routes, and UI._

## Verification

- `bun run build` in `docs-site/` completes cleanly; `/reference/plugins/`, `/index.html`, and `/getting-started/` all generate with no broken-link errors.

Docs-only; no user-facing app UX, so `[no-feature-entry]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)