### PR TITLE
fix(settings): make mobile section dropdown recognizable

### DIFF
--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -649,11 +649,13 @@
            full-screen card would clip the overflow), so the tabs collapse into a
            dropdown. The tablist isn't rendered here, so no tab carries a dangling
            aria-controls; the panels below stay labelled tabpanels. -->
-      <select class="tab-select" aria-label={m.settings_tabs_aria()} bind:value={tab}>
-        {#each visibleTabs as t (t.id)}
-          <option value={t.id}>{t.label()}</option>
-        {/each}
-      </select>
+      <div class="tab-select-wrap">
+        <select class="tab-select" aria-label={m.settings_tabs_aria()} bind:value={tab}>
+          {#each visibleTabs as t (t.id)}
+            <option value={t.id}>{t.label()}</option>
+          {/each}
+        </select>
+      </div>
     {:else}
       <div class="tabs" role="tablist" aria-label={m.settings_tabs_aria()}>
         {#each visibleTabs as t, i (t.id)}
@@ -1128,17 +1130,38 @@
     border-bottom: 1px solid var(--color-line);
   }
   /* Narrow viewport: the strip becomes a dropdown (full-width, on the shared
-     select recipe) so all tabs stay reachable inside the full-screen card. */
+     select recipe) so all tabs stay reachable inside the full-screen card.
+     The wrapper carries the chevron so the box reads as a dropdown, not a
+     heading — a pseudo-element on the <select> itself wouldn't render. */
+  .tab-select-wrap {
+    position: relative;
+  }
+  /* Custom chevron (the app's standard fold glyph) instead of the native
+     browser arrow, kept on-token for cross-theme consistency. Decorative —
+     pointer-events:none so taps pass through to the select. */
+  .tab-select-wrap::after {
+    content: "▾";
+    position: absolute;
+    top: 50%;
+    right: 12px;
+    transform: translateY(-50%);
+    color: var(--color-muted);
+    font-size: var(--fs-base);
+    pointer-events: none;
+  }
   .tab-select {
+    box-sizing: border-box;
     width: 100%;
+    min-height: 44px;
     background: var(--color-inset);
     border: 1px solid var(--color-line-bright);
     color: var(--color-ink-bright);
     font: inherit;
     font-size: var(--fs-base);
-    padding: 8px 10px;
+    padding: 8px 32px 8px 10px;
     border-radius: 2px;
     appearance: none;
+    -webkit-appearance: none;
     cursor: pointer;
   }
   .tab-select:focus {


### PR DESCRIPTION
## Problem

On mobile the Settings dialog collapses its section navigation into a native `<select>` (`.tab-select` in `Settings.svelte`). It set `appearance: none` but never replaced the browser's dropdown arrow — so the box (e.g. "Workspace") read like a heading or text field, and users didn't recognize it as a tappable section selector.


## Fix (Option A, operator-chosen)

Wrap the `<select>` in `.tab-select-wrap` and render the app's standard fold chevron (`▾`) via a wrapper `::after` (decorative, `pointer-events:none`, not announced to AT). A pseudo-element on the `<select>` itself wouldn't render, hence the wrapper.

On `.tab-select`:
- `box-sizing: border-box` — no global border-box reset exists; without it `padding-right` would overflow the wrapper and mis-place the chevron (mirrors `NewTask.svelte`).
- `padding-right: 32px` — value text clears the chevron.
- `min-height: 44px` — a11y tap-target floor; with border-box this renders an **exact** 44px.
- `-webkit-appearance: none` alongside `appearance: none` — avoids a native-arrow + custom-chevron double arrow on older iOS Safari.

Desktop (`≥768px`) `role="tablist"` strip is untouched.

## Notes
- Tokens only (chevron `var(--color-muted)`, `var(--fs-base)`) — works across all four themes.
- ≥16px text floor already enforced globally by `app.css:351-354`.
- No i18n key (decorative CSS `content` glyph; the select's `aria-label` already routes through `m.settings_tabs_aria()`).
- No feature-catalog entry — affordance polish on an existing control shipped as `fix:`, not `feat:`.

## Verification
- `cd ui && bun run check` → 0 errors, 0 warnings.
- `bunx prettier --check` + `bunx eslint` on the file → clean; pre-push hooks passed.
- Before/after render of the committed CSS confirms the chevron shows, value text clears it, and the control is an exact 44px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
