### PR TITLE
fix(epic): lead landing merge subject with conventional type

### DIFF
--- a/src/epic-landing.ts
+++ b/src/epic-landing.ts
@@ -6,9 +6,50 @@
  *  NEVER i18n'd. No forge calls, no store, no I/O — deterministic string building only. */
 import type { CompletedEpicChild } from "./completed-epic";
 
-/** `Land epic #<n>: <title>` — concise, stable PR title. */
+/** Conventional-commit types release-please recognizes at column 0 of a merge subject.
+ *  A subject NOT starting with one of these (a bare title, or a non-type `Word:` prefix) is
+ *  skipped by release-please — the bug this builder exists to avoid (#1206). Same set/spirit
+ *  as the type guard in `isDocRelevantMerge` (src/doc-agent.ts). */
+const RELEASE_TYPES = new Set([
+  "feat",
+  "fix",
+  "docs",
+  "style",
+  "refactor",
+  "perf",
+  "test",
+  "build",
+  "ci",
+  "chore",
+  "revert",
+]);
+
+/** Type used when the parent epic title carries no recognized conventional prefix. A landed
+ *  epic is almost always shipped feature work, so `feat` gives release-please a changelog
+ *  entry rather than letting the merge fall through unrecognized (#1206). */
+const FALLBACK_TYPE = "feat";
+
+/** Landing-PR title that doubles as the squash-merge **subject** release-please parses, so it
+ *  MUST lead with a recognized conventional `type(scope)!?:` at column 0 (#1206 — a subject
+ *  led by `Land epic #<n>:` pushes the real type mid-line and release-please skips the merge).
+ *  The epic framing moves to a trailing `(epic #<n>)`; GitHub appends ` (#<PR>)` at merge.
+ *
+ *  - Parent title already conventional with a recognized type → keep it (type lowercased,
+ *    scope/`!` verbatim), append ` (epic #<n>)`.
+ *  - Bare title, OR a non-type `Word:` prefix (e.g. `Comments: …`) → prepend `feat:`.
+ *  A trailing `[EPIC]`/`[epic]` tag is stripped either way. */
 export function buildLandingPrTitle(parentNumber: number, parentTitle: string): string {
-  return `Land epic #${parentNumber}: ${parentTitle}`;
+  const cleaned = parentTitle.trim().replace(/\s*\[epic\]\s*$/i, "");
+  const epicTag = `(epic #${parentNumber})`;
+
+  const m = /^(\w+)(\([^)]*\))?(!)?:\s*(.*)$/.exec(cleaned);
+  if (m && RELEASE_TYPES.has(m[1]!.toLowerCase())) {
+    const prefix = `${m[1]!.toLowerCase()}${m[2] ?? ""}${m[3] ?? ""}`;
+    const desc = m[4]!.trim();
+    return desc ? `${prefix}: ${desc} ${epicTag}` : `${prefix}: epic #${parentNumber}`;
+  }
+
+  return `${FALLBACK_TYPE}: ${cleaned} ${epicTag}`;
 }
 
 /** Sanitize a child title for a single Markdown table cell: escape pipes (a raw `|` would

--- a/test/epic-landing.test.ts
+++ b/test/epic-landing.test.ts
@@ -2,8 +2,46 @@ import { describe, expect, it } from "bun:test";
 import { buildLandingPrBody, buildLandingPrTitle } from "../src/epic-landing";
 
 describe("buildLandingPrTitle", () => {
-  it("renders `Land epic #<n>: <title>`", () => {
-    expect(buildLandingPrTitle(327, "EFI value map")).toBe("Land epic #327: EFI value map");
+  it("keeps a recognized conventional prefix at column 0 and appends the epic tag", () => {
+    expect(buildLandingPrTitle(535, "feat(comments): communication feed on Objectives")).toBe(
+      "feat(comments): communication feed on Objectives (epic #535)",
+    );
+  });
+
+  it("preserves a breaking-change `!` (with and without scope)", () => {
+    expect(buildLandingPrTitle(88, "fix(api)!: drop legacy route")).toBe(
+      "fix(api)!: drop legacy route (epic #88)",
+    );
+    expect(buildLandingPrTitle(89, "feat!: rework pipeline")).toBe(
+      "feat!: rework pipeline (epic #89)",
+    );
+  });
+
+  it("prepends the `feat:` fallback for a bare (non-conventional) title", () => {
+    expect(buildLandingPrTitle(327, "EFI value map")).toBe("feat: EFI value map (epic #327)");
+  });
+
+  it("falls back to `feat:` for a non-type `Word:` prefix (not a real conventional type)", () => {
+    expect(buildLandingPrTitle(90, "Comments: communication feed")).toBe(
+      "feat: Comments: communication feed (epic #90)",
+    );
+  });
+
+  it("lowercases a recognized but mixed-case type", () => {
+    expect(buildLandingPrTitle(91, "Feat(x): add y")).toBe("feat(x): add y (epic #91)");
+  });
+
+  it("strips a trailing `[EPIC]` tag (case-insensitive)", () => {
+    expect(buildLandingPrTitle(535, "feat(comments): comms feed [EPIC]")).toBe(
+      "feat(comments): comms feed (epic #535)",
+    );
+    expect(buildLandingPrTitle(328, "EFI value map [epic]")).toBe(
+      "feat: EFI value map (epic #328)",
+    );
+  });
+
+  it("guards an empty description after a recognized prefix", () => {
+    expect(buildLandingPrTitle(42, "chore:")).toBe("chore: epic #42");
   });
 });
 


### PR DESCRIPTION
## Problem

When the epic-merger lands an epic, the landing-PR title — which becomes the squash-merge **commit subject** release-please parses — led with `Land epic #<n>:`:

```
Land epic #535: feat(comments): communication feed … [EPIC] (#549)
```

release-please reads the conventional type from **column 0**, found `Land epic` there, and treated the merge as non-conventional → the epic got **no changelog entry and no version contribution**. Observed downstream in `ltdovr/flowagent` (v2.19.0 omitted its headline comms-feed epic).

## Fix

`buildLandingPrTitle` (`src/epic-landing.ts`) now emits a recognized conventional `type(scope)!?:` at column 0 and moves the epic framing to a trailing `(epic #<n>)`:

| Parent issue title | New landing subject |
| --- | --- |
| `feat(comments): comms feed [EPIC]` | `feat(comments): comms feed (epic #535)` |
| `fix(api)!: drop legacy route` | `fix(api)!: drop legacy route (epic #88)` |
| `EFI value map` (bare) | `feat: EFI value map (epic #327)` |
| `Comments: communication feed` (non-type `Word:`) | `feat: Comments: communication feed (epic #90)` |
| `Feat(x): add y` (mixed case) | `feat(x): add y (epic #91)` |

Rules:
- A prefix is treated as conventional **only** if its type is in the release-please set (`feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`) — mirrors the guard in `isDocRelevantMerge`. A non-type `Word:` falls through to the `feat:` fallback (otherwise release-please would still skip it).
- The captured type is **lowercased**; scope and `!` are preserved verbatim.
- A trailing `[EPIC]`/`[epic]` tag is stripped.
- Bare / non-type titles get the `feat:` fallback (landed epics are almost always shipped features).

GitHub appends ` (#<PR>)` at merge time. The PR **body** (`buildLandingPrBody`) is unchanged and still opens with "Lands epic **#n — …**", so the framing survives there too.

## Scope / known limitation

- The subject is **PR-title-derived**, not forced via `gh pr merge --subject`. It reaches release-please under every GitHub squash setting for the common multi-child epic; the one residual gap (repo squash setting = "commit message" **and** the epic branch has exactly **1** child commit) is accepted for now. The deterministic alternative (optional `subject` on `MergeInput` → `--subject` / Gitea `MergeTitleField`) is feasible as a follow-up if it ever bites.
- `squashMergeLocal` (branch-name subject, local-forge path) is unchanged — no release-please there.

## Tests

`test/epic-landing.test.ts` covers recognized prefix, breaking `!` (with/without scope), bare → `feat:`, non-type `Word:` fallback, mixed-case lowercasing, `[EPIC]` stripping, and the empty-description guard. `bun test test/epic-landing.test.ts` → 13 pass; `bun run lint` clean. Pre-existing unrelated failures (push/PWA/config) are identical with and without this change.

Closes #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)