### PR TITLE
feat(plugins): fire onSpawn for review/plan-gate/doc-agent/standalone-critic spawns (#1205)

### DIFF
--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -13,8 +13,8 @@ import type { SessionStore } from "./store";
 import type { DocAgentOutcome, DocAgentRun, Session } from "./types";
 import type { SessionUsage } from "./usage";
 import { readSessionUsage } from "./usage";
-import { apiKeyPassthroughEnv, isApiKeyConfigured, isApiKeyMode } from "./spawn-auth";
-import { resolveSpawnMembrane, type MembraneSeams } from "./spawn-membrane";
+import { isApiKeyConfigured, isApiKeyMode } from "./spawn-auth";
+import { resolveAuxSpawn, type MembraneSeams } from "./spawn-membrane";
 import type { WorktreeMgr } from "./worktree";
 
 const execFileP = promisify(execFile);
@@ -517,7 +517,7 @@ export class DocAgentService {
       this.deps.store.setSetting(prSyncedKey(repoPath, prNumber), "1");
 
       const promptCtx: RetargetPromptCtx = { prNumber, prTitle: git.title ?? "" };
-      const launched = this.launchRun(
+      const launched = await this.launchRun(
         repoPath,
         headSha,
         base,
@@ -563,14 +563,14 @@ export class DocAgentService {
    * (retarget only) grounds the agent on the open PR's diff. Callers keep their own pre/post steps
    * (begin's stampLastSha, beginRetarget's prSyncedKey claim) outside this helper.
    */
-  private launchRun(
+  private async launchRun(
     repoPath: string,
     baseRef: string,
     base: string,
     extra: Partial<InFlight>,
     promptCtx?: RetargetPromptCtx,
     afterCreate?: (worktreePath: string) => void,
-  ): { ok: true } | { ok: false; result: DocAgentResult } {
+  ): Promise<{ ok: true } | { ok: false; result: DocAgentResult }> {
     const id8 = randomUUID().slice(0, 8);
     const wtName = DOC_BRANCH_PREFIX + id8;
     let wt;
@@ -587,13 +587,17 @@ export class DocAgentService {
 
     afterCreate?.(wt.worktreePath);
 
-    const spawned = this.spawnAgent(
+    const spawned = await this.spawnAgent(
       repoPath,
       wt.worktreePath,
       DOC_AGENT_LABEL + id8,
       base,
       promptCtx,
     );
+    if (spawned === "aborted") {
+      this.deps.worktree.remove(wt.worktreePath);
+      return { ok: false, result: { status: "skipped", reason: "plugin aborted spawn" } };
+    }
     if (!spawned) {
       this.deps.worktree.remove(wt.worktreePath);
       return { ok: false, result: { status: "error", reason: "spawn failed" } };
@@ -644,7 +648,7 @@ export class DocAgentService {
 
     // forget() can't race a manual trigger here, but a second trigger could have landed during the
     // awaits above — the `starting` claim (held until this returns) prevents that double-spawn.
-    const launched = this.launchRun(repoPath, resolved.baseRef, base, { mode: "fresh" });
+    const launched = await this.launchRun(repoPath, resolved.baseRef, base, { mode: "fresh" });
     if (!launched.ok) return launched.result;
     // Stamp the cadence marker from the SAME ref the nightly gate reads (`refs/remotes/origin/<base>`,
     // freshened by ensureBaseRef above) — NOT resolved.baseRef, which falls back to the branch
@@ -685,33 +689,44 @@ export class DocAgentService {
   }
 
   /** Build the scoped argv + membrane and spawn the agent via herdr. Returns the terminalId +
-   *  the agent's forced --session-id (the reviewer_spawns PK), or null on a spawn failure (logged).
-   *  profile "standard": the agent needs Anthropic egress (to run claude) but not GitHub — the
-   *  server pushes/opens the PR — mirroring ReviewService's spawn. */
-  private spawnAgent(
+   *  the agent's forced --session-id (the reviewer_spawns PK), or null on a spawn failure (logged),
+   *  or "aborted" when a plugin onSpawn hook aborts (distinct from a spawn failure). */
+  private async spawnAgent(
     repoPath: string,
     worktreePath: string,
     agentName: string,
     base: string,
     promptCtx?: RetargetPromptCtx,
-  ): { terminalId: string; spawnSessionId: string } | null {
+  ): Promise<{ terminalId: string; spawnSessionId: string } | null | "aborted"> {
     const { argv, sessionId } = buildTransientAgentArgv("doc", {
       model: this.deps.model ?? null,
       prompt: this.buildPrompt(base, promptCtx),
     });
-    const { wrapped, backend } = resolveSpawnMembrane({
+    // Fire plugin onSpawn hooks (issue #1205) + bind any patched env THROUGH the membrane.
+    // Session-less doc agent → no parentSessionId. abortSpawn → "aborted" so launchRun can reap
+    // the worktree and skip cleanly (distinct from a spawn failure).
+    const aux = await resolveAuxSpawn({
       argv,
       worktreePath,
       repoPath,
       worktree: this.deps.worktree,
       seams: this.deps,
+      descriptor: {
+        sessionId,
+        kind: "doc",
+        model: this.deps.model ?? null,
+      },
     });
+    if ("aborted" in aux) {
+      console.warn(`[doc-agent] onSpawn aborted for ${repoPath}: ${aux.aborted.reason}`);
+      return "aborted";
+    }
     try {
       const terminalId = this.deps.herdr.start(
         agentName,
         worktreePath,
-        wrapped,
-        apiKeyPassthroughEnv(backend !== null),
+        aux.wrapped,
+        aux.spawnEnv,
       ).terminalId;
       return { terminalId, spawnSessionId: sessionId };
     } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -770,6 +770,8 @@ const reviewService = new ReviewService({
   herdr,
   worktree,
   resolveForge,
+  // Plugin onSpawn hooks fire for reviewer-style aux spawns too (issue #1205); no-op until loadAll.
+  runSpawnHooks: (d) => pluginRegistry.runSpawnHooks(d),
   onChange: (id, verdict) => events.emit("session:review", { id, review: verdict }),
   onReviewing: (id, reviewing) => events.emit("session:reviewing", { id, reviewing }),
   onActivity: (id, summary) => events.emit("session:critic-activity", { id, summary }),
@@ -792,6 +794,8 @@ const standaloneCritic = new StandalonePrCriticService({
   herdr,
   worktree,
   resolveForge,
+  // Plugin onSpawn hooks fire for reviewer-style aux spawns too (issue #1205); no-op until loadAll.
+  runSpawnHooks: (d) => pluginRegistry.runSpawnHooks(d),
   repos: () => listRepos(config.repoRoot).map((r) => r.path),
   // Fresh per-sweep thunk (the service calls it each sweep, never caches) — branches
   // owned by a LIVE session, so a session-critic-owned PR is skipped when criticEnabled.
@@ -816,6 +820,8 @@ const planGate = new PlanGateService({
   herdr,
   worktree,
   resolveForge,
+  // Plugin onSpawn hooks fire for reviewer-style aux spawns too (issue #1205); no-op until loadAll.
+  runSpawnHooks: (d) => pluginRegistry.runSpawnHooks(d),
   reply: (id, text) => service.reply(id, text),
   release: (id) => service.releasePlanGate(id),
   onChange: (id, gate) => events.emit("session:plangate", { id, gate }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -748,6 +748,8 @@ const docAgent = new DocAgentService({
   herdr,
   worktree,
   resolveForge,
+  // Plugin onSpawn hooks fire for the doc-agent spawn too (issue #1205); no-op until loadAll.
+  runSpawnHooks: (d) => pluginRegistry.runSpawnHooks(d),
   repos: () => listRepos(config.repoRoot).map((r) => r.path),
   store,
   gitState: (id) => prPoller.get(id),

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -14,10 +14,10 @@ import {
   groundPlanBlocks,
 } from "./visual-blocks";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
-import { isApiKeyMode, isApiKeyConfigured, apiKeyPassthroughEnv } from "./spawn-auth";
+import { isApiKeyMode, isApiKeyConfigured } from "./spawn-auth";
 import { readSessionUsage, type SessionUsage } from "./usage";
 import { effectiveAutopilot } from "./effective-autopilot";
-import { resolveSpawnMembrane, type MembraneSeams } from "./spawn-membrane";
+import { resolveAuxSpawn, type MembraneSeams } from "./spawn-membrane";
 
 /** Outcome of an on-demand `consider()`: a reviewer actually spawned, the request was a no-op
  *  (plan unchanged / already approved / nothing to review), or a spawn attempt failed. The
@@ -298,22 +298,34 @@ export class PlanGateService {
       this.deps.worktree.remove(wt.worktreePath);
       return "error";
     }
-    const { wrapped, backend } = resolveSpawnMembrane({
+    // Fire plugin onSpawn hooks (issue #1205) + bind patched env THROUGH the membrane. An
+    // abortSpawn cleanly skips this plan review (worktree reaped); "skipped" — a deliberate
+    // plugin refusal is not an error, and the next sweep re-attempts like the tombstone skip.
+    const aux = await resolveAuxSpawn({
       argv,
       worktreePath: wt.worktreePath,
       repoPath: session.repoPath,
       worktree: this.deps.worktree,
       seams: this.deps,
+      descriptor: {
+        sessionId: reviewerSessionId,
+        kind: "plan-gate",
+        parentSessionId: session.id,
+        model: this.deps.model ?? null,
+      },
     });
+    if ("aborted" in aux) {
+      console.warn(`[plan-gate] onSpawn aborted for ${session.id}: ${aux.aborted.reason}`);
+      this.deps.worktree.remove(wt.worktreePath);
+      return "skipped";
+    }
     let terminalId: string;
     try {
       terminalId = this.deps.herdr.start(
         `plan-review ${session.desig}`,
         wt.worktreePath,
-        wrapped,
-        // No backend → passthrough (no membrane) → set CLAUDE_CONFIG_DIR to a
-        // credential-less mirror; with a backend the membrane masks creds in place.
-        apiKeyPassthroughEnv(backend !== null),
+        aux.wrapped,
+        aux.spawnEnv,
       ).terminalId;
     } catch (err) {
       console.warn(`[plan-gate] spawn failed for ${session.id}:`, err);

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -26,6 +26,14 @@ export interface PluginManifest {
  *  A COPY — mutating it does nothing; return a `SpawnPatch` to influence the spawn. */
 export interface SpawnDescriptor {
   sessionId: string;
+  /** What kind of spawn this is (issue #1205). `"session"` is a normal task session
+   *  (create/drain/resume); the others are the reviewer-style auto-process spawns that also
+   *  fire onSpawn so a plugin can route their quota (e.g. onto a pool account). */
+  kind: "session" | "review" | "plan-gate" | "doc";
+  /** For an aux spawn tied to a managed session (review, plan-gate): that session's id, so a
+   *  plugin can keep the aux spawn on the parent session's account. Undefined for a normal
+   *  session (it IS the parent) and for session-less aux spawns (doc-agent, standalone critic). */
+  parentSessionId?: string;
   repoRoot: string;
   model: string | null;
   agentProvider: string;

--- a/src/review.ts
+++ b/src/review.ts
@@ -6,7 +6,7 @@ import type { GitForge, GitState, PrStatus } from "./forge/types";
 import { CRITIC_REVIEW_MARKER, AUTHOR_RESPONSE_MARKER } from "./forge/types";
 import type { ReviewVerdict, Session, ReviewerSpawnRow } from "./types";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
-import { isApiKeyMode, isApiKeyConfigured, apiKeyPassthroughEnv } from "./spawn-auth";
+import { isApiKeyMode, isApiKeyConfigured } from "./spawn-auth";
 import { jsonlPathFor, readSessionUsage, type SessionUsage } from "./usage";
 import { readActivitySignal } from "./activity-signal";
 import { checksCleared } from "./checks-gate";
@@ -24,7 +24,7 @@ import {
   CRITIC_THINKING_TOKENS,
   type RawVerdict,
 } from "./critic-core";
-import { resolveSpawnMembrane, type MembraneSeams } from "./spawn-membrane";
+import { resolveAuxSpawn, type MembraneSeams } from "./spawn-membrane";
 
 // Session-agnostic critic helpers now live in ./critic-core (a forthcoming standalone-PR-critic
 // service reuses them). Re-exported here so existing importers (and tests) keep their paths.
@@ -350,22 +350,34 @@ export class ReviewService {
       authorNotes,
       issueBody,
     );
-    const { wrapped, backend } = resolveSpawnMembrane({
+    // Fire plugin onSpawn hooks for this reviewer-style spawn (issue #1205) and bind any patched
+    // env THROUGH the membrane (apiKeyPassthroughEnv handled inside). A hook that calls abortSpawn
+    // cleanly skips the review (worktree reaped), mirroring the spawn-failure path below.
+    const aux = await resolveAuxSpawn({
       argv,
       worktreePath: wt.worktreePath,
       repoPath: session.repoPath,
       worktree: this.deps.worktree,
       seams: this.deps,
+      descriptor: {
+        sessionId: criticSessionId,
+        kind: "review",
+        parentSessionId: session.id,
+        model: this.deps.model ?? null,
+      },
     });
+    if ("aborted" in aux) {
+      console.warn(`[review] onSpawn aborted for ${session.id}: ${aux.aborted.reason}`);
+      this.deps.worktree.remove(wt.worktreePath);
+      return;
+    }
     let terminalId: string;
     try {
       terminalId = this.deps.herdr.start(
         `review ${session.desig}`,
         wt.worktreePath,
-        wrapped,
-        // No backend → passthrough (no membrane) → set CLAUDE_CONFIG_DIR to a
-        // credential-less mirror; with a backend the membrane masks creds in place.
-        apiKeyPassthroughEnv(backend !== null),
+        aux.wrapped,
+        aux.spawnEnv,
       ).terminalId;
     } catch (err) {
       console.warn(`[review] spawn failed for ${session.id}:`, err);

--- a/src/service.ts
+++ b/src/service.ts
@@ -71,6 +71,7 @@ import {
   type EgressBackend,
 } from "./egress";
 import type { EgressWatcher } from "./egress-watch";
+import { foldSpawnPatch } from "./spawn-membrane";
 import { PluginSpawnAborted, type SpawnDescriptor, type SpawnPatch } from "./plugins/types";
 import { SHEPHERD_ISSUE_LOG_MARKER } from "./forge/types";
 import type { GitForge, GitState, IssueComment } from "./forge/types";
@@ -1304,6 +1305,9 @@ export class SessionService {
     try {
       patch = await this.deps.runSpawnHooks({
         sessionId: ctx.sessionId,
+        // A normal task session (create/drain/resume). The reviewer-style aux spawns pass
+        // their own kind (issue #1205). No parentSessionId — a session IS its own parent.
+        kind: "session",
         repoRoot: ctx.repoPath,
         model: ctx.model ?? null,
         agentProvider: ctx.agentProvider ?? config.defaultAgentProvider,
@@ -1317,13 +1321,10 @@ export class SessionService {
       }
       throw e;
     }
-    // credentialDir is sugar for env.CLAUDE_CONFIG_DIR and wins over it when both are set.
-    const patchEnv: Record<string, string> = {
-      ...(patch.env ?? {}),
-      ...(patch.credentialDir ? { CLAUDE_CONFIG_DIR: patch.credentialDir } : {}),
-    };
-    const finalInnerArgv = patch.extraArgs?.length ? [...innerArgv, ...patch.extraArgs] : innerArgv;
-    return { patchEnv, finalInnerArgv };
+    // credentialDir is sugar for env.CLAUDE_CONFIG_DIR and wins over it when both are set;
+    // extraArgs are appended. Shared with the reviewer-style aux spawns (issue #1205).
+    const { patchEnv, finalArgv } = foldSpawnPatch(innerArgv, patch);
+    return { patchEnv, finalInnerArgv: finalArgv };
   }
 
   private async prepareSpawn(

--- a/src/spawn-membrane.ts
+++ b/src/spawn-membrane.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import { config } from "./config";
-import { apiKeyMembraneFields } from "./spawn-auth";
+import { apiKeyMembraneFields, apiKeyPassthroughEnv } from "./spawn-auth";
+import { PluginSpawnAborted, type SpawnDescriptor, type SpawnPatch } from "./plugins/types";
 import {
   detectBackend as realDetectBackend,
   wrapArgv,
@@ -25,6 +26,9 @@ export interface MembraneSeams {
   detectBackend?: () => SandboxBackend;
   /** Injectable membrane env seam (tests inject a stub so no host paths are touched). */
   membraneEnv?: () => MembraneEnv;
+  /** Plugin onSpawn hook runner (issue #1124/#1205). Absent → no hooks run (tests / no
+   *  plugins / loader not yet loaded). Wired to PluginRegistry.runSpawnHooks in index.ts. */
+  runSpawnHooks?: (d: SpawnDescriptor) => Promise<SpawnPatch>;
 }
 
 /** Backend probe: injected seam (tests) or the real cached self-test. */
@@ -59,6 +63,10 @@ export function resolveSpawnMembrane(args: {
   repoPath: string;
   worktree: { gitCommonDir(p: string): string };
   seams: MembraneSeams;
+  /** Plugin SpawnPatch env (issue #1205), merged LAST over the membrane's passthrough extraEnv
+   *  so a patched CLAUDE_CONFIG_DIR rides the bwrap --setenv (carried THROUGH --clearenv), not
+   *  just the outer env. */
+  extraEnv?: Record<string, string>;
 }): { wrapped: string[]; backend: SandboxBackend } {
   const backend = resolveBackend(args.seams);
   const env = resolveMembraneEnv(args.seams);
@@ -70,10 +78,95 @@ export function resolveSpawnMembrane(args: {
     claudeDir: env.claudeDir,
     home: env.home,
     nodeBinReal: env.nodeBinReal,
-    extraEnv: env.extraEnv,
+    extraEnv: { ...env.extraEnv, ...(args.extraEnv ?? {}) },
     // api-key mode: a bwrap-wrapped reviewer masks the OAuth credential + binds the helper.
     ...apiKeyMembraneFields(),
   };
   const wrapped = wrapArgv(args.argv, { profile: "standard", backend, membrane });
   return { wrapped, backend };
+}
+
+/** Fold a plugin SpawnPatch (issue #1124/#1205) into spawn inputs: patch.env plus
+ *  credentialDir→CLAUDE_CONFIG_DIR (last — the sugar field wins over env.CLAUDE_CONFIG_DIR),
+ *  and extraArgs appended to the inner argv. Single source for this merge so the session path
+ *  (prepareSpawn) and the reviewer-style aux spawns can never drift. */
+export function foldSpawnPatch(
+  innerArgv: string[],
+  patch: SpawnPatch,
+): { patchEnv: Record<string, string>; finalArgv: string[] } {
+  const patchEnv: Record<string, string> = {
+    ...(patch.env ?? {}),
+    ...(patch.credentialDir ? { CLAUDE_CONFIG_DIR: patch.credentialDir } : {}),
+  };
+  const finalArgv = patch.extraArgs?.length ? [...innerArgv, ...patch.extraArgs] : innerArgv;
+  return { patchEnv, finalArgv };
+}
+
+/** Shared reviewer-style spawn tail (issue #937/#1205): fire plugin onSpawn hooks, fold the
+ *  returned patch, and assemble the membrane — so review / plan-gate / doc-agent / standalone
+ *  critic honor onSpawn exactly like a normal session spawn. The patched env is bound THROUGH
+ *  the membrane: patchEnv is merged LAST into both the bwrap --setenv (via resolveSpawnMembrane's
+ *  extraEnv) AND the herdr.start env, so a plugin's CLAUDE_CONFIG_DIR is not wiped by --clearenv.
+ *
+ *  Returns `{ aborted }` when a hook calls ctx.abortSpawn (the caller reaps the worktree + skips
+ *  the spawn cleanly). The returned `spawnEnv` is `undefined` when empty (subscription + no patch)
+ *  — NEVER an empty object — to preserve herdr.start's optional-env contract. */
+export async function resolveAuxSpawn(args: {
+  argv: string[];
+  worktreePath: string;
+  repoPath: string;
+  worktree: { gitCommonDir(p: string): string };
+  seams: MembraneSeams;
+  descriptor: {
+    sessionId: string;
+    kind: SpawnDescriptor["kind"];
+    parentSessionId?: string;
+    model?: string | null;
+    agentProvider?: string;
+  };
+}): Promise<
+  | { wrapped: string[]; spawnEnv: Record<string, string> | undefined }
+  | { aborted: PluginSpawnAborted }
+> {
+  const backend = resolveBackend(args.seams);
+  // No backend → passthrough (no membrane) → apiKeyPassthroughEnv carries the credential-less
+  // mirror dir; with a backend the membrane masks creds in place and this is undefined.
+  const baseEnv = apiKeyPassthroughEnv(backend !== null);
+
+  let patchEnv: Record<string, string> = {};
+  let finalArgv = args.argv;
+  if (args.seams.runSpawnHooks) {
+    let patch: SpawnPatch;
+    try {
+      patch = await args.seams.runSpawnHooks({
+        sessionId: args.descriptor.sessionId,
+        kind: args.descriptor.kind,
+        parentSessionId: args.descriptor.parentSessionId,
+        repoRoot: args.repoPath,
+        model: args.descriptor.model ?? null,
+        agentProvider: args.descriptor.agentProvider ?? config.defaultAgentProvider,
+        argv: [...args.argv],
+        env: baseEnv ?? {},
+        isolated: true,
+      });
+    } catch (e) {
+      if (e instanceof PluginSpawnAborted) return { aborted: e };
+      throw e;
+    }
+    ({ patchEnv, finalArgv } = foldSpawnPatch(args.argv, patch));
+  }
+
+  const { wrapped } = resolveSpawnMembrane({
+    argv: finalArgv,
+    worktreePath: args.worktreePath,
+    repoPath: args.repoPath,
+    worktree: args.worktree,
+    seams: args.seams,
+    extraEnv: patchEnv,
+  });
+
+  // patchEnv LAST so a patched CLAUDE_CONFIG_DIR wins over apiKeyPassthroughEnv's mirror.
+  const merged = { ...(baseEnv ?? {}), ...patchEnv };
+  const spawnEnv = Object.keys(merged).length ? merged : undefined;
+  return { wrapped, spawnEnv };
 }

--- a/src/standalone-critic.ts
+++ b/src/standalone-critic.ts
@@ -26,7 +26,7 @@ import { CRITIC_REVIEW_MARKER } from "./forge/types";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
 import { isEpicIntegrationBranch } from "./epic-branch";
 import { checksCleared, repoHasNoCiCached } from "./checks-gate";
-import { isApiKeyMode, isApiKeyConfigured, apiKeyPassthroughEnv } from "./spawn-auth";
+import { isApiKeyMode, isApiKeyConfigured } from "./spawn-auth";
 import { readSessionUsage, type SessionUsage } from "./usage";
 import {
   prReviewPrompt,
@@ -41,7 +41,7 @@ import {
 } from "./critic-core";
 import type { VerdictRead } from "./json-tolerant";
 import { reapTransientByLabel } from "./transient-tab-reaper";
-import { resolveSpawnMembrane, type MembraneSeams } from "./spawn-membrane";
+import { resolveAuxSpawn, type MembraneSeams } from "./spawn-membrane";
 
 /** One PR critic run between its spawn (begin) and its verdict (finalize). Carries everything
  *  finalize needs without re-querying — mirrors ReviewService's InFlight, minus the streak/note
@@ -418,23 +418,33 @@ export class StandalonePrCriticService {
       // the identical #597 VERIFY prompt and needs the same cross-file reasoning headroom.
       thinkingTokens: CRITIC_THINKING_TOKENS,
     });
-    const { wrapped, backend } = resolveSpawnMembrane({
+    // Fire plugin onSpawn hooks (issue #1205) + bind patched env THROUGH the membrane. Session-less
+    // PR critic → no parentSessionId. An abortSpawn cleanly skips (worktree reaped).
+    const aux = await resolveAuxSpawn({
       argv,
       worktreePath,
       repoPath,
       worktree: this.deps.worktree,
       seams: this.deps,
+      descriptor: {
+        sessionId: criticSessionId,
+        kind: "review",
+        model: this.deps.model ?? null,
+      },
     });
+    if ("aborted" in aux) {
+      this.log(`[pr-critic] onSpawn aborted for ${repoPath}#${pr.number}: ${aux.aborted.reason}`);
+      this.deps.worktree.remove(worktreePath);
+      return;
+    }
 
     let terminalId: string;
     try {
       terminalId = this.deps.herdr.start(
         `pr-critic ${repoPath}#${pr.number}`,
         worktreePath,
-        wrapped,
-        // No backend → passthrough (no membrane) → set CLAUDE_CONFIG_DIR to a credential-less
-        // mirror; with a backend the membrane masks creds in place.
-        apiKeyPassthroughEnv(backend !== null),
+        aux.wrapped,
+        aux.spawnEnv,
       ).terminalId;
     } catch (err) {
       this.log(`[pr-critic] spawn failed for ${repoPath}#${pr.number}: ${String(err)}`);

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -5,10 +5,12 @@ import {
   SERVER_INSTALL_ROOT,
   isDocRelevantMerge,
   type DocAgentFinalize,
+  type DocAgentDeps,
 } from "../src/doc-agent";
 import { config, parseHour } from "../src/config";
 import type { GitState } from "../src/forge/types";
 import type { Session } from "../src/types";
+import { PluginSpawnAborted } from "../src/plugins/types";
 
 function withAuth(
   mode: typeof config.authMode,
@@ -193,6 +195,8 @@ function mkHarness(opts?: {
   editPrThrows?: boolean;
   /** When true, forge has no editPr method (stale-body fallback test). */
   noEditPr?: boolean;
+  /** Inject a plugin onSpawn hook runner (issue #1205 abort-path test). */
+  runSpawnHooks?: (d: unknown) => Promise<unknown>;
 }): Harness {
   const o = {
     forgeKind: "github" as "github" | "local" | null,
@@ -445,6 +449,7 @@ function mkHarness(opts?: {
     },
     detectBackend: () => null,
     membraneEnv: () => ({ claudeDir: "/c", home: "/h", nodeBinReal: "/n", extraEnv: {} }),
+    runSpawnHooks: o.runSpawnHooks as DocAgentDeps["runSpawnHooks"],
     fileExists: (p: string) => {
       if (p.endsWith("docs-site/src/content/docs")) return o.docTreePresent;
       return o.inScopeFilesPresent;
@@ -1651,4 +1656,20 @@ test("roll-up: re-target merged-mid-run fallback with existing docs PR → rolls
   ).toBe(true);
   expect(h.editPrCalls[0]!.prNumber).toBe(5);
   expect(h.finalizes[0]).toEqual({ repoPath: "/repo", url: "https://forge/pr/5", outcome: "pr" });
+});
+
+// ── plugin onSpawn hook: abort → skipped (issue #1205) ───────────────────────
+
+test("onSpawn abortSpawn → doc run skipped, worktree reaped, no spawn", async () => {
+  const h = mkHarness({
+    act: true,
+    runSpawnHooks: async () => {
+      throw new PluginSpawnAborted("pool exhausted", "cswap");
+    },
+  });
+  const res = await h.svc.consider("/repo");
+  expect(res.status).toBe("skipped");
+  expect(res.reason).toBe("plugin aborted spawn");
+  expect(h.starts).toHaveLength(0); // herdr.start never reached
+  expect(h.removedWorktrees.length).toBeGreaterThan(0); // the doc worktree was reaped
 });

--- a/test/examples-plugin.test.ts
+++ b/test/examples-plugin.test.ts
@@ -14,6 +14,7 @@ const EXAMPLES_DIR = resolve(import.meta.dir, "../examples/plugins");
 
 const DESC: SpawnDescriptor = {
   sessionId: "sess-1",
+  kind: "session",
   repoRoot: "/home/me/myrepo",
   model: null,
   agentProvider: "claude",

--- a/test/plugins.test.ts
+++ b/test/plugins.test.ts
@@ -9,6 +9,7 @@ import { PluginSpawnAborted, type SpawnDescriptor } from "../src/plugins/types";
 
 const DESC: SpawnDescriptor = {
   sessionId: "sess-1",
+  kind: "session",
   repoRoot: "/repo",
   model: null,
   agentProvider: "claude",

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
 import { ReviewService, reviewPrompt, scopeFindings, CRITIC_THINKING_TOKENS } from "../src/review";
+import { PluginSpawnAborted } from "../src/plugins/types";
 import type { VerdictRead } from "../src/json-tolerant";
 import type { RawVerdict } from "../src/critic-core";
 
@@ -2582,4 +2583,37 @@ test("findSquatter: empty label does NOT match an unnamed agent whose cwd differ
 
   // The unrelated unnamed agent must not have been killed
   expect(closedTabs).toEqual([]);
+});
+
+test("critic: onSpawn fires (kind=review, parentSessionId) and binds credentialDir through to the spawn env", async () => {
+  let seen: any;
+  const { deps: d, started } = makeDeps({
+    runSpawnHooks: async (desc: any) => {
+      seen = desc;
+      return { credentialDir: "/pool/acct-2" };
+    },
+  });
+  await new ReviewService(d as any).consider(session(), OPEN_GREEN);
+  expect(seen.kind).toBe("review");
+  expect(seen.parentSessionId).toBe("s1"); // the reviewed session's id
+  expect(seen.sessionId).not.toBe("s1"); // the critic mints its own one-shot id
+  expect(started).toHaveLength(1);
+  // detectBackend()→null on the test host → passthrough → the patched dir rides the herdr env,
+  // winning over apiKeyPassthroughEnv. (The membrane --setenv path is covered in spawn-membrane.test.ts.)
+  expect(started[0]!.env!.CLAUDE_CONFIG_DIR).toBe("/pool/acct-2");
+});
+
+test("critic: onSpawn abortSpawn → review skipped, worktree reaped, no spawn", async () => {
+  const {
+    deps: d,
+    started,
+    removed,
+  } = makeDeps({
+    runSpawnHooks: async () => {
+      throw new PluginSpawnAborted("pool exhausted", "cswap");
+    },
+  });
+  await new ReviewService(d as any).consider(session(), OPEN_GREEN);
+  expect(started).toHaveLength(0);
+  expect(removed).toEqual(["/review-wt"]);
 });

--- a/test/spawn-membrane.test.ts
+++ b/test/spawn-membrane.test.ts
@@ -3,8 +3,11 @@ import {
   resolveBackend,
   resolveMembraneEnv,
   resolveSpawnMembrane,
+  foldSpawnPatch,
+  resolveAuxSpawn,
   type MembraneEnv,
 } from "../src/spawn-membrane";
+import { PluginSpawnAborted } from "../src/plugins/types";
 
 const stubEnv: MembraneEnv = {
   claudeDir: "/stub/.claude",
@@ -84,5 +87,170 @@ describe("resolveSpawnMembrane", () => {
     expect(lastSep).toBeGreaterThan(0);
     const innerArgv = wrapped.slice(lastSep + 1);
     expect(innerArgv).toEqual(argv);
+  });
+});
+
+describe("foldSpawnPatch", () => {
+  test("empty patch → patchEnv deep-equals {} and finalArgv === input array (no extraArgs)", () => {
+    const innerArgv = ["claude"];
+    const { patchEnv, finalArgv } = foldSpawnPatch(innerArgv, {});
+    expect(patchEnv).toEqual({});
+    expect(finalArgv).toBe(innerArgv);
+  });
+
+  test("{ env: { A: '1' } } → patchEnv is { A: '1' }", () => {
+    const { patchEnv } = foldSpawnPatch(["claude"], { env: { A: "1" } });
+    expect(patchEnv).toEqual({ A: "1" });
+  });
+
+  test("credentialDir sugar wins over env.CLAUDE_CONFIG_DIR when both set", () => {
+    const { patchEnv } = foldSpawnPatch(["claude"], {
+      env: { CLAUDE_CONFIG_DIR: "/from-env" },
+      credentialDir: "/from-cred",
+    });
+    expect(patchEnv.CLAUDE_CONFIG_DIR).toBe("/from-cred");
+  });
+
+  test("extraArgs appended to innerArgv", () => {
+    const { finalArgv } = foldSpawnPatch(["claude"], { extraArgs: ["--x", "y"] });
+    expect(finalArgv).toEqual(["claude", "--x", "y"]);
+  });
+});
+
+describe("resolveAuxSpawn", () => {
+  test("no runSpawnHooks seam → passthrough: wrapped deep-equals input argv, spawnEnv === undefined", async () => {
+    const argv = ["claude", "--some-flag"];
+    const result = await resolveAuxSpawn({
+      argv,
+      worktreePath: "/wt/task",
+      repoPath: "/repo",
+      worktree: worktreeStub(),
+      seams: {
+        detectBackend: () => null,
+        membraneEnv: () => stubEnv,
+      },
+      descriptor: { sessionId: "s-1", kind: "review" },
+    });
+
+    expect("aborted" in result).toBe(false);
+    if ("aborted" in result) throw new Error("unexpected abort");
+    expect(result.wrapped).toEqual(argv);
+    expect(result.spawnEnv).toBeUndefined();
+  });
+
+  test("hook fires with the descriptor fields", async () => {
+    let recorded: unknown;
+    const argv = ["claude", "--x"];
+    const result = await resolveAuxSpawn({
+      argv,
+      worktreePath: "/wt/task",
+      repoPath: "/repo",
+      worktree: worktreeStub(),
+      seams: {
+        detectBackend: () => null,
+        membraneEnv: () => stubEnv,
+        runSpawnHooks: async (d) => {
+          recorded = d;
+          return {};
+        },
+      },
+      descriptor: { sessionId: "crit-1", kind: "review", parentSessionId: "sess-9", model: "m" },
+    });
+
+    expect("aborted" in result).toBe(false);
+    const d = recorded as Record<string, unknown>;
+    expect(d.sessionId).toBe("crit-1");
+    expect(d.kind).toBe("review");
+    expect(d.parentSessionId).toBe("sess-9");
+    expect(d.repoRoot).toBe("/repo");
+    expect(d.isolated).toBe(true);
+    expect(d.model).toBe("m");
+    expect(typeof d.agentProvider).toBe("string");
+    expect((d.agentProvider as string).length).toBeGreaterThan(0);
+    expect(d.argv).toEqual(["claude", "--x"]);
+  });
+
+  test("patched credentialDir rides the membrane --setenv (backend present)", async () => {
+    const result = await resolveAuxSpawn({
+      argv: ["claude"],
+      worktreePath: "/wt/task",
+      repoPath: "/repo",
+      worktree: worktreeStub(),
+      seams: {
+        detectBackend: () => "bwrap",
+        membraneEnv: () => stubEnv,
+        runSpawnHooks: async () => ({ credentialDir: "/pool/acct-3" }),
+      },
+      descriptor: { sessionId: "s-1", kind: "review" },
+    });
+
+    expect("aborted" in result).toBe(false);
+    if ("aborted" in result) throw new Error("unexpected abort");
+    expect(result.wrapped[0]).toBe("bwrap");
+    const i = result.wrapped.lastIndexOf("CLAUDE_CONFIG_DIR");
+    expect(i).toBeGreaterThan(-1);
+    expect(result.wrapped[i + 1]).toBe("/pool/acct-3");
+  });
+
+  test("patched credentialDir in spawnEnv without a backend (passthrough)", async () => {
+    const result = await resolveAuxSpawn({
+      argv: ["claude"],
+      worktreePath: "/wt/task",
+      repoPath: "/repo",
+      worktree: worktreeStub(),
+      seams: {
+        detectBackend: () => null,
+        membraneEnv: () => stubEnv,
+        runSpawnHooks: async () => ({ credentialDir: "/pool/acct-7" }),
+      },
+      descriptor: { sessionId: "s-1", kind: "review" },
+    });
+
+    expect("aborted" in result).toBe(false);
+    if ("aborted" in result) throw new Error("unexpected abort");
+    expect(result.wrapped).toEqual(["claude"]);
+    expect(result.spawnEnv?.CLAUDE_CONFIG_DIR).toBe("/pool/acct-7");
+  });
+
+  test("extraArgs appended (passthrough)", async () => {
+    const result = await resolveAuxSpawn({
+      argv: ["claude"],
+      worktreePath: "/wt/task",
+      repoPath: "/repo",
+      worktree: worktreeStub(),
+      seams: {
+        detectBackend: () => null,
+        membraneEnv: () => stubEnv,
+        runSpawnHooks: async () => ({ extraArgs: ["--mcp-config", "/x.json"] }),
+      },
+      descriptor: { sessionId: "s-1", kind: "review" },
+    });
+
+    expect("aborted" in result).toBe(false);
+    if ("aborted" in result) throw new Error("unexpected abort");
+    expect(result.wrapped).toEqual(["claude", "--mcp-config", "/x.json"]);
+  });
+
+  test("abortSpawn → { aborted } with reason and pluginId", async () => {
+    const result = await resolveAuxSpawn({
+      argv: ["claude"],
+      worktreePath: "/wt/task",
+      repoPath: "/repo",
+      worktree: worktreeStub(),
+      seams: {
+        detectBackend: () => null,
+        membraneEnv: () => stubEnv,
+        runSpawnHooks: async () => {
+          throw new PluginSpawnAborted("pool exhausted", "cswap");
+        },
+      },
+      descriptor: { sessionId: "s-1", kind: "review" },
+    });
+
+    expect("aborted" in result).toBe(true);
+    if (!("aborted" in result)) throw new Error("expected abort");
+    expect(result.aborted).toBeInstanceOf(PluginSpawnAborted);
+    expect(result.aborted.reason).toBe("pool exhausted");
+    expect(result.aborted.pluginId).toBe("cswap");
   });
 });


### PR DESCRIPTION
## What & why

Closes #1205. The in-process plugin `onSpawn` hook (#1124) previously fired **only** for normal task sessions (via `prepareSpawn`) and was bypassed by the four reviewer-style auto-process spawns, which built their own argv and called `herdr.start()` directly. As a result, plugins like [`shepherd-claude-swap`](https://github.com/erwins-enkel/shepherd-claude-swap) could not route review/plan/doc quota onto a pool account — it all piled onto the default account.

This makes **all four** reviewer-style spawns honor `onSpawn`, and — critically — binds a hook's patched `CLAUDE_CONFIG_DIR`/`patch.env` **through the sandbox membrane** (merged last into both the bwrap `--setenv` and the `herdr.start` env) so it isn't wiped by `--clearenv`.

## Approach

- **`SpawnDescriptor`** gains a required `kind` (`"session" | "review" | "plan-gate" | "doc"`) + optional `parentSessionId` (set for review/plan-gate; undefined for the session-less doc-agent + standalone critic). Lets a plugin do fresh-pool-pick (Option A) now or reuse-parent-account (Option B) later with no second contract change.
- **`src/spawn-membrane.ts`** gains the shared reviewer-style tail (the duplicated tail flagged by closed #937):
  - `foldSpawnPatch` — the single source for the binding-critical merge (`credentialDir`→`CLAUDE_CONFIG_DIR` last; `extraArgs` appended). `prepareSpawn` now reuses it too.
  - `resolveAuxSpawn` — fires `onSpawn`, folds the patch, binds the env **through** the membrane, returns `{ aborted }` on `abortSpawn`, and returns `spawnEnv` as `undefined` when empty (preserves `herdr.start`'s optional-env contract).
- **Four sites wired** (`review.ts`, `plan-gate.ts`, `standalone-critic.ts`, `doc-agent.ts`) + `runSpawnHooks` passed into their constructors in `index.ts`. doc-agent's `spawnAgent`/`launchRun` became `async`; a hook abort yields a distinct `{ status: "skipped", reason: "plugin aborted spawn" }` (not the spawn-failure `error`).
- A hook `abortSpawn` cleanly skips each aux spawn: worktree reaped, no unhandled throw.

## Acceptance criteria

1. ✅ review / plan-gate / doc-agent / standalone-critic invoke `onSpawn`.
2. ✅ Patched `credentialDir` is bound **through** `resolveSpawnMembrane` — unit-proven via `wrapped.lastIndexOf("CLAUDE_CONFIG_DIR")` (rides the bwrap `--setenv`, last-wins) with a backend, and via `spawnEnv` last-wins without one. (Observed-identity end-to-end is verified downstream with the plugin installed.)
3. ✅ `abortSpawn` → worktree reaped, no spawn, no throw (per-site tests for review + doc-agent).
4. ✅ `SpawnDescriptor` carries `kind` + `parentSessionId`.

## Tests

`bun run lint`, `bun run typecheck`, and the root `bun test test/` suite are green (the only failures are the pre-existing, unrelated `config > persistConfig` Svelte-rune tests). New coverage: `foldSpawnPatch` + `resolveAuxSpawn` unit tests in `test/spawn-membrane.test.ts` (fire / membrane-binding w+wo backend / undefined-env / extraArgs / abort), plus per-site abort + hook-fires integration tests in `test/review.test.ts` and `test/doc-agent.test.ts`.

## Follow-up (not in this PR)

`doc-agent.ts` `beginRetarget` sets the `prSyncedKey` ownership claim **before** the spawn; **all** `!launched.ok` paths (worktree-fail, spawn-fail, and now abort) leave it set, permanently parking that PR's doc retarget. This is pre-existing behavior the abort path inherits; fixing only the abort arm would diverge from the identical failure paths, so it's deferred to a follow-up that addresses all of them. Also out of scope per the issue: the small transient LLM helpers (`namer-llm`, `distiller`, etc.).

[no-feature-entry] — server-only plumbing, no user-facing UI surface (feature-catalog/i18n/glossary gates N/A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)