### PR TITLE
feat(plugins): interactive action-button node for publishUI

### DIFF
--- a/docs/research/plugin-ui-widgets.md
+++ b/docs/research/plugin-ui-widgets.md
@@ -155,24 +155,26 @@ Start with **one slot** (`settings-panel`) — claude-swap's panel renders insid
 
 1. **Phase 0 (spike / go-no-go):** `publishUI` + renderer + the seeded registry (`stack`/`text`/`badge`/`meter`/`table`/`key-value`/`callout`), wired only into the Plugins panel; port claude-swap's status blob to a `PluginUIView`. Validates the contract end-to-end against a real plugin before any further investment.
 2. **Phase 1:** harden validation (depth/size caps, prop sanitization, malformed-view handling), i18n the `title`/`text` plumbing, feature-announcement entry, `/design-system` recipes for the new `Pui*` primitives.
-3. **Phase 2 (only if demanded):** additional slots; interactivity (a constrained `action` node → `POST /api/plugins/<id>/<action>`, reusing `ctx.route`) — note the jump from _display_ to _interaction_ is the real complexity cliff; keep v1 display-only.
+3. **Phase 2:** additional slots; interactivity — **landed via #1209** as the `action-button` node (`POST /api/plugins/<thisPluginId>/<path>` with a plugin-authored body, reusing `ctx.route`), scoped to the plugin's own namespace. The jump from _display_ to _interaction_ was the anticipated complexity cliff; #1209 took it on with a constrained, POST-only, namespace-scoped primitive rather than general forms. (The "display-only" framing in §5 below is historical — superseded.)
 
 ### 4.5 Cost / surface
 
 Net-new: ~1 server type + 1 `ctx` method + transport reuse; ~1 renderer + ~6 small Svelte components + 1 registry; ~1 panel edit. No new runtime dependency (DOMPurify already present and **not even needed** for the descriptor path). Gates touched: feature-announcements, i18n (EN+DE for any chrome the primitives author), `/design-system` recipes.
 
+**Component vocabulary (current):** display nodes `stack`, `text`, `badge`, `meter`, `table`, `key-value`, `callout` (Phase 0) + `gauge`, `sparkline`, `time-series`, `bar-chart`, `timeline` (#1189); and the first **interactive** node, `action-button` (#1209) — POSTs a plugin-authored body to the plugin's own route, with an optional `confirm` gate.
+
 ---
 
 ## 5. Risks & settled decisions
 
-- **Display vs interaction.** v1 is **display-only**. Buttons/forms mean wiring `action` nodes back to plugin routes + CSRF/auth + optimistic state — a distinct, larger effort. Hold the line at display for the spike.
+- **Display vs interaction.** _v1 was display-only_ (this was the spike's deliberate scope). **Superseded by #1209:** interactivity now exists as the single, constrained `action-button` node — POST-only, scoped to the plugin's own route namespace, behind operator auth, with an optional confirm gate. General forms/optimistic-state remain out of scope; the cliff was crossed narrowly, not wholesale.
 - **Trust boundary is real but narrow.** Plugins are trusted, so the descriptor guards against _bugs_ (runaway trees, bad props), not _attackers_. Keep the caps anyway — fail-open, never crash the panel.
 - **Don't reach for `{@html}`/iframe/web-components.** They solve problems Shepherd doesn't have and route around the design-system/i18n gates. Iframe is the _only_ future-justified escape hatch, and only for arbitrary external web content.
 - **Schema evolution.** `schemaVersion` + unknown-node fallback tile = forward-compatible; one author owning both ends keeps the SDUI versioning tax negligible.
 
 **Decisions (settled with operator):**
 
-1. **Display-only v1.** No `action` node / interactivity in v1 — it's the complexity cliff (auth/CSRF, optimistic state) and claude-swap needs none of it. `POST /reset` stays an operator-only route. Interactivity is a deferred later phase.
+1. **Display-only v1 — superseded by #1209.** v1 deliberately shipped no interactivity (the auth/CSRF + optimistic-state complexity cliff, and claude-swap needed none then). #1209 reopened this once a concrete consumer (a per-account "Make primary" picker) needed it, adding the constrained `action-button` node: POST-only, scoped to the plugin's own namespace, behind the existing operator auth. The original "deferred later phase" decision is now realized.
 2. **Settings → Plugins panel is the only wired slot for v1.** The descriptor still carries a `slot` field, but the host mounts only `settings-panel`; `session-sidebar` / `dashboard-card` are added later as pure host-wiring with no schema change.
 3. **Registry grows on demand.** Seed with what claude-swap needs (`stack`, `text`, `badge`, `meter`, `table`, `key-value`, `callout`); add new node types when a real plugin requires one (component + first use ship together). `schemaVersion` + unknown-node fallback tile keep it forward-compatible — no fixed/frozen vocabulary.
 4. **claude-swap is the Phase-0 consumer.** The go/no-go spike ports claude-swap's existing status blob to a `PluginUIView` — real, rich, typed data that exercises every seeded component — rather than a synthetic in-repo demo.

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -162,6 +162,18 @@ export interface PluginGearItem {
  *                     props: { bars: { label: string; value: number; tone?: Tone }[]; max?: number; orientation?: "horizontal" | "vertical" }
  *  - `timeline`     — recent discrete events.
  *                     props: { events: { at: string; label: string; caption?: string; tone?: Tone }[] }
+ *
+ *  Interactive node (issue #1209) — the first non-display node:
+ *
+ *  - `action-button` — a clickable control that POSTs a plugin-authored body to one of THIS
+ *                      plugin's own routes (`/api/plugins/<thisPluginId>/<route.path>`). The
+ *                      host resolves the path under the plugin's own namespace (never an
+ *                      arbitrary URL) and validates it (no leading `/`, no `..`); `route.method`
+ *                      MUST be `"POST"` (a GET fetch with a body throws). `body` is opaque
+ *                      plugin-authored JSON sent VERBATIM. An optional `confirm` string gates
+ *                      the POST behind a confirmation dialog. `label`/`confirm` are verbatim DATA.
+ *                      props: { label: string; tone?: Tone; route: { method: "POST"; path: string };
+ *                               body?: unknown; confirm?: string }
  */
 export interface PluginUINode {
   type: string;
@@ -170,7 +182,9 @@ export interface PluginUINode {
 }
 
 /** A declarative UI view a plugin pushes via `ctx.publishUI` (issue #1185). Rendered by the
- *  host from a whitelisted Svelte registry (Server-Driven-UI). Display-only in v1. */
+ *  host from a whitelisted Svelte registry (Server-Driven-UI). Originally display-only;
+ *  interactivity landed via #1209 — the `action-button` node POSTs a plugin-authored body to
+ *  the plugin's own route namespace, so the "display-only" framing is superseded. */
 export interface PluginUIView {
   schemaVersion: 1;
   /** Contribution point. Only `settings-panel` is host-wired in v1; the others are

--- a/src/plugins/ui-validate.ts
+++ b/src/plugins/ui-validate.ts
@@ -24,6 +24,24 @@ function propsWithinBounds(props: Record<string, unknown>): boolean {
   return true;
 }
 
+/** Per-type validation for the interactive `action-button` node (issue #1209). The host POSTs
+ *  the plugin-authored `body` verbatim to `/api/plugins/<thisPluginId>/<route.path>`, so the
+ *  route is hard-validated: method MUST be POST (a GET fetch with a body throws), and the path
+ *  is namespace-relative (no leading `/`, no `..`) via the same `validRoutePath` the gear route
+ *  action uses. Invalid → the whole view is dropped fail-open, consistent with the tree's
+ *  all-or-nothing semantics. `body`/`confirm`/`tone`/`label` carry no extra structural checks
+ *  here (the renderer coerces them defensively); `body` is bounded by the overall byte cap. */
+function validActionButtonProps(props: Record<string, unknown>): boolean {
+  const label = props["label"];
+  if (typeof label !== "string" || label.trim().length === 0) return false;
+  const route = props["route"];
+  if (!isPlainObject(route)) return false;
+  if (route["method"] !== "POST") return false;
+  const path = route["path"];
+  if (typeof path !== "string" || !validRoutePath(path)) return false;
+  return true;
+}
+
 /** Recursively validate one node (re-parsed JSON) against the structural caps.
  *  `counter` accumulates the total node count across the whole tree. */
 function validateNode(node: unknown, depth: number, counter: { n: number }): boolean {
@@ -34,6 +52,13 @@ function validateNode(node: unknown, depth: number, counter: { n: number }): boo
 
   const props = node["props"];
   if (props !== undefined && (!isPlainObject(props) || !propsWithinBounds(props))) return false;
+
+  // Interactive node: validate its route up front (security-relevant — see helper).
+  if (
+    node["type"] === "action-button" &&
+    !validActionButtonProps(isPlainObject(props) ? props : {})
+  )
+    return false;
 
   const children = node["children"];
   if (children === undefined) return true;

--- a/test/plugins-ui.test.ts
+++ b/test/plugins-ui.test.ts
@@ -167,6 +167,80 @@ test("validatePluginUIView: function prop is accepted but stripped from result",
   expect(result!.root.props?.["label"]).toBe("click");
 });
 
+// ── action-button node validation (issue #1209) ──────────────────────────────
+
+/** A view whose root is an `action-button` with the given props. */
+function abView(props: unknown) {
+  return { schemaVersion: 1, slot: "settings-panel", root: { type: "action-button", props } };
+}
+
+test("action-button: valid node round-trips, preserving body and confirm", () => {
+  const props = {
+    label: "Make primary",
+    tone: "neutral",
+    route: { method: "POST", path: "switch-primary" },
+    body: { mode: "specific", account: 2 },
+    confirm: "Switch the primary account?",
+  };
+  const result = validatePluginUIView(abView(props));
+  expect(result).not.toBeNull();
+  expect(result!.root.props).toEqual(props);
+});
+
+test("action-button: valid node nested inside a stack is accepted", () => {
+  const view = {
+    schemaVersion: 1,
+    slot: "settings-panel",
+    root: {
+      type: "stack",
+      children: [
+        { type: "action-button", props: { label: "Go", route: { method: "POST", path: "go" } } },
+      ],
+    },
+  };
+  expect(validatePluginUIView(view)).not.toBeNull();
+});
+
+test("action-button: missing/empty label drops the whole view", () => {
+  expect(validatePluginUIView(abView({ route: { method: "POST", path: "go" } }))).toBeNull();
+  expect(
+    validatePluginUIView(abView({ label: "   ", route: { method: "POST", path: "go" } })),
+  ).toBeNull();
+});
+
+test("action-button: non-POST method (incl. GET) drops the whole view", () => {
+  expect(
+    validatePluginUIView(abView({ label: "x", route: { method: "GET", path: "go" } })),
+  ).toBeNull();
+  expect(
+    validatePluginUIView(abView({ label: "x", route: { method: "DELETE", path: "go" } })),
+  ).toBeNull();
+});
+
+test("action-button: missing or malformed route drops the whole view", () => {
+  expect(validatePluginUIView(abView({ label: "x" }))).toBeNull();
+  expect(validatePluginUIView(abView({ label: "x", route: "go" }))).toBeNull();
+  expect(validatePluginUIView(abView({ label: "x", route: { method: "POST" } }))).toBeNull();
+});
+
+test("action-button: namespace-escaping path is rejected (leading slash, .., bad charset)", () => {
+  expect(
+    validatePluginUIView(abView({ label: "x", route: { method: "POST", path: "/abs" } })),
+  ).toBeNull();
+  expect(
+    validatePluginUIView(abView({ label: "x", route: { method: "POST", path: "../escape" } })),
+  ).toBeNull();
+  expect(
+    validatePluginUIView(abView({ label: "x", route: { method: "POST", path: "a/../b" } })),
+  ).toBeNull();
+  expect(
+    validatePluginUIView(abView({ label: "x", route: { method: "POST", path: "has space" } })),
+  ).toBeNull();
+  expect(
+    validatePluginUIView(abView({ label: "x", route: { method: "POST", path: "" } })),
+  ).toBeNull();
+});
+
 // ── loader integration tests ─────────────────────────────────────────────────
 
 test("publishUI: valid view sets list().ui and emits plugin:ui event", async () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2113,6 +2113,9 @@
   "feat_plugin_ui_charts_body": "Plugins können jetzt Tacho-Anzeigen, Sparklines, Zeitreihen, Balkendiagramme und Zeitachsen unter Einstellungen → Plugins veröffentlichen — nicht nur Messanzeigen, Badges und Tabellen.",
   "plugin_gear_action_done": "Fertig",
   "plugin_gear_action_failed": "Plugin-Aktion fehlgeschlagen",
+  "plugin_action_done": "Fertig",
+  "plugin_action_failed": "Plugin-Aktion fehlgeschlagen",
+  "plugin_action_confirm_title": "Aktion bestätigen",
   "feat_plugin_gear_item_title": "Plugin-Einträge im Zahnradmenü",
   "feat_plugin_gear_item_body": "Plugins können dem Zahnradmenü jetzt einen einzelnen Eintrag hinzufügen — der einen Link öffnet, eine Plugin-Aktion ausführt oder zum Plugin-Panel springt."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2113,6 +2113,9 @@
   "feat_plugin_ui_charts_body": "Plugins can now publish gauges, sparklines, time-series, bar charts and timelines in Settings → Plugins — not just meters, badges and tables.",
   "plugin_gear_action_done": "Done",
   "plugin_gear_action_failed": "Plugin action failed",
+  "plugin_action_done": "Done",
+  "plugin_action_failed": "Plugin action failed",
+  "plugin_action_confirm_title": "Confirm action",
   "feat_plugin_gear_item_title": "Plugin gear-menu items",
   "feat_plugin_gear_item_body": "Plugins can now add a single item to the gear menu — opening a link, running a plugin action, or jumping to the plugin's panel."
 }

--- a/ui/src/lib/api.invokePluginRoute.test.ts
+++ b/ui/src/lib/api.invokePluginRoute.test.ts
@@ -49,4 +49,36 @@ describe("invokePluginRoute", () => {
     await invokePluginRoute("cap-plugin", "POST", "trigger");
     expect(calls[0]).toEqual({ url: "/api/plugins/cap-plugin/trigger", method: "POST" });
   });
+
+  // ── body encoding (issue #1209) ────────────────────────────────────────────
+  function captureInit(): { init?: RequestInit } {
+    const cap: { init?: RequestInit } = {};
+    globalThis.fetch = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      cap.init = init;
+      return new Response("ok", { status: 200 });
+    }) as unknown as typeof fetch;
+    return cap;
+  }
+
+  it("POST with a body sends JSON-stringified body + content-type header", async () => {
+    const cap = captureInit();
+    const body = { mode: "specific", account: 2 };
+    await invokePluginRoute("cap-plugin", "POST", "switch-primary", body);
+    expect(cap.init?.body).toBe(JSON.stringify(body));
+    expect(cap.init?.headers).toEqual({ "content-type": "application/json" });
+  });
+
+  it("call without a body sends neither header nor request body (no-body callers unchanged)", async () => {
+    const cap = captureInit();
+    await invokePluginRoute("cap-plugin", "POST", "trigger");
+    expect(cap.init?.body).toBeUndefined();
+    expect(cap.init?.headers).toBeUndefined();
+  });
+
+  it("GET never attaches a body, even if one is mistakenly passed", async () => {
+    const cap = captureInit();
+    await invokePluginRoute("cap-plugin", "GET", "status", { should: "not-send" });
+    expect(cap.init?.body).toBeUndefined();
+    expect(cap.init?.headers).toBeUndefined();
+  });
 });

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1037,13 +1037,24 @@ export async function getPlugins(): Promise<PluginInfo[]> {
 
 /** Invoke a plugin-registered route at `/api/plugins/<id>/<path>` with the given method.
  *  On success, returns the trimmed response text (capped to 200 chars; longer responses are
- *  sliced to 199 chars with a trailing "…"). Strings are verbatim plugin-authored DATA. */
+ *  sliced to 199 chars with a trailing "…"). Strings are verbatim plugin-authored DATA.
+ *
+ *  `body` (issue #1209, the `action-button` node) is plugin-authored opaque JSON sent
+ *  verbatim. It is attached ONLY for a POST — a GET fetch with a body throws TypeError, so
+ *  even a mis-paired caller never reaches that footgun. No-body callers (gear routes) are
+ *  unchanged: no Content-Type header, no request body. */
 export async function invokePluginRoute(
   id: string,
   method: "GET" | "POST",
   path: string,
+  body?: unknown,
 ): Promise<string> {
-  const r = await fetch(`/api/plugins/${id}/${path}`, { method });
+  const init: RequestInit = { method };
+  if (method === "POST" && body !== undefined) {
+    init.headers = { "content-type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  const r = await fetch(`/api/plugins/${id}/${path}`, init);
   if (!r.ok) throw await failed(r, "plugin route");
   const text = (await r.text()).trim();
   return text.length > 200 ? text.slice(0, 199) + "…" : text;

--- a/ui/src/lib/components/settings/SettingsPluginsPanel.svelte
+++ b/ui/src/lib/components/settings/SettingsPluginsPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { m } from "$lib/paraglide/messages";
   import type { PluginInfo, PluginUIView } from "$lib/types";
-  import PluginUIRenderer from "$lib/plugin-ui/PluginUIRenderer.svelte";
+  import PluginUIRoot from "$lib/plugin-ui/PluginUIRoot.svelte";
 
   let { plugins = [], focusId = null }: { plugins?: PluginInfo[]; focusId?: string | null } =
     $props();
@@ -68,7 +68,7 @@
           <p class="view-title">{view.title}</p>
         {/if}
         <div class="view-body">
-          <PluginUIRenderer node={view.root} />
+          <PluginUIRoot pluginId={p.id} node={view.root} />
         </div>
         {#if expanded[p.id]}
           <p class="raw-label micro">{m.plugins_raw_json()}</p>

--- a/ui/src/lib/plugin-ui/PluginUIRoot.svelte
+++ b/ui/src/lib/plugin-ui/PluginUIRoot.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  // Root of a plugin's published UI view (issue #1209). Publishes the owning plugin id into
+  // Svelte context so a nested `action-button` can POST to that plugin's own route namespace,
+  // then renders the descriptor tree through the normal recursive renderer. A thin wrapper so
+  // the plugin id flows to descendants without prop-drilling through every container node.
+  import { setContext } from "svelte";
+  import type { PluginUINode } from "$lib/types";
+  import { PLUGIN_ID_CONTEXT } from "./context";
+  import PluginUIRenderer from "./PluginUIRenderer.svelte";
+
+  let { pluginId, node }: { pluginId: string; node: PluginUINode } = $props();
+  // Capture-once is correct: each plugin card is a keyed {#each} instance, so its pluginId
+  // never changes for the life of this component — the context value is stable by construction.
+  // svelte-ignore state_referenced_locally
+  setContext(PLUGIN_ID_CONTEXT, pluginId);
+</script>
+
+<PluginUIRenderer {node} />

--- a/ui/src/lib/plugin-ui/PuiActionButton.browser.test.ts
+++ b/ui/src/lib/plugin-ui/PuiActionButton.browser.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { tick } from "svelte";
+import "../../app.css";
+import PluginUIRoot from "./PluginUIRoot.svelte";
+import PuiActionButton from "./PuiActionButton.svelte";
+import type { PluginUINode } from "$lib/types";
+
+/** Mount an action-button inside its PluginUIRoot wrapper (so the plugin-id context is set,
+ *  exactly as the Settings panel mounts it) and resolve it through the live registry. */
+function renderInPlugin(pluginId: string, props: Record<string, unknown>) {
+  const node: PluginUINode = { type: "stack", children: [{ type: "action-button", props }] };
+  return render(PluginUIRoot, { pluginId, node });
+}
+
+function mockFetch(impl: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  const fn = vi.fn(async (url: unknown, init?: RequestInit) => impl(url as string, init));
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+const ROUTE = { method: "POST", path: "switch-primary" };
+
+describe("PuiActionButton", () => {
+  beforeEach(() => {
+    globalThis.fetch = mockFetch(() => new Response("ok", { status: 200 }));
+  });
+
+  it("renders the label", async () => {
+    const { container } = renderInPlugin("acct", { label: "Make primary", route: ROUTE });
+    const btn = container.querySelector(".pui-action") as HTMLButtonElement;
+    expect(btn).toBeTruthy();
+    expect(btn.textContent?.trim()).toBe("Make primary");
+    expect(btn.disabled).toBe(false);
+  });
+
+  it("click (no confirm) POSTs the body to the plugin's own namespaced route", async () => {
+    const calls: { url: string; init?: RequestInit }[] = [];
+    mockFetch((url, init) => {
+      calls.push({ url, init });
+      return new Response("switched", { status: 200 });
+    });
+    const body = { mode: "specific", account: 2 };
+    const { container } = renderInPlugin("acct", { label: "Make primary", route: ROUTE, body });
+    (container.querySelector(".pui-action") as HTMLButtonElement).click();
+    await vi.waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0].url).toBe("/api/plugins/acct/switch-primary");
+    expect(calls[0].init?.method).toBe("POST");
+    expect(calls[0].init?.body).toBe(JSON.stringify(body));
+  });
+
+  it("with confirm set, a click opens a dialog and only Confirm fires the POST", async () => {
+    const fetchFn = mockFetch(() => new Response("ok", { status: 200 }));
+    const { container } = renderInPlugin("acct", {
+      label: "Make primary",
+      route: ROUTE,
+      confirm: "Switch the primary account?",
+    });
+    // First click opens the confirm dialog — no fetch yet.
+    (container.querySelector(".pui-action") as HTMLButtonElement).click();
+    await vi.waitFor(() => expect(container.querySelector(".card")).toBeTruthy());
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(container.querySelector(".card .desc")?.textContent).toBe("Switch the primary account?");
+
+    // Cancel closes the dialog without firing.
+    (container.querySelector(".card .actions .gbtn:not(.primary)") as HTMLButtonElement).click();
+    await tick();
+    expect(container.querySelector(".card")).toBeNull();
+    expect(fetchFn).not.toHaveBeenCalled();
+
+    // Re-open and Confirm fires the POST.
+    (container.querySelector(".pui-action") as HTMLButtonElement).click();
+    await vi.waitFor(() => expect(container.querySelector(".card .primary")).toBeTruthy());
+    (container.querySelector(".card .primary") as HTMLButtonElement).click();
+    await vi.waitFor(() => expect(fetchFn).toHaveBeenCalledTimes(1));
+  });
+
+  it("a failed POST does not throw and re-enables the button", async () => {
+    mockFetch(() => new Response("boom", { status: 500 }));
+    const { container } = renderInPlugin("acct", { label: "Go", route: ROUTE });
+    const btn = container.querySelector(".pui-action") as HTMLButtonElement;
+    btn.click();
+    // Button disables while in flight, then re-enables after the (rejected) request settles.
+    await vi.waitFor(() => expect(btn.disabled).toBe(false));
+  });
+
+  it("an unsafe route path renders disabled and never fetches", async () => {
+    const fetchFn = mockFetch(() => new Response("ok", { status: 200 }));
+    const { container } = renderInPlugin("acct", {
+      label: "Escape",
+      route: { method: "POST", path: "../../etc" },
+    });
+    const btn = container.querySelector(".pui-action") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    btn.click();
+    await tick();
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("without a plugin-id context (bare mount) renders disabled and never fetches", async () => {
+    const fetchFn = mockFetch(() => new Response("ok", { status: 200 }));
+    // Rendered directly, NOT via PluginUIRoot — no context.
+    const { container } = render(PuiActionButton, {
+      node: { type: "action-button", props: { label: "Orphan", route: ROUTE } },
+    });
+    const btn = container.querySelector(".pui-action") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    btn.click();
+    await tick();
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/lib/plugin-ui/PuiActionButton.svelte
+++ b/ui/src/lib/plugin-ui/PuiActionButton.svelte
@@ -35,9 +35,9 @@
   const body = $derived(p.body);
 
   // Client-side namespace guard, mirroring the server's validRoutePath (defense in depth):
-  // non-empty, safe charset, no leading "/", no ".." segment.
+  // non-empty, length-capped, safe charset, no leading "/", no ".." segment.
   function safePath(x: string): boolean {
-    if (x.length === 0 || x.startsWith("/")) return false;
+    if (x.length === 0 || x.length > 256 || x.startsWith("/")) return false;
     if (!/^[A-Za-z0-9._/-]+$/.test(x)) return false;
     return !x.split("/").some((seg) => seg === "..");
   }

--- a/ui/src/lib/plugin-ui/PuiActionButton.svelte
+++ b/ui/src/lib/plugin-ui/PuiActionButton.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+  // Interactive `action-button` node (issue #1209): a clickable control that POSTs a
+  // plugin-authored JSON body to one of THIS plugin's own routes. The owning plugin id comes
+  // from context (PluginUIRoot), never from node props — that is what scopes the request to
+  // the plugin's own namespace. `label`/`confirm` are verbatim plugin DATA (never i18n).
+  import { getContext } from "svelte";
+  import type { PluginUINode } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import { invokePluginRoute } from "$lib/api";
+  import { toasts } from "$lib/toasts.svelte";
+  import { dialog } from "$lib/a11yDialog";
+  import { toneColor } from "./tones";
+  import { PLUGIN_ID_CONTEXT } from "./context";
+
+  let { node }: { node: PluginUINode } = $props();
+
+  // Context-absent (a bare PluginUIRenderer mount with no PluginUIRoot wrapper): with no
+  // plugin id there is no well-formed route — render disabled and never fetch.
+  const pluginId = getContext<string | undefined>(PLUGIN_ID_CONTEXT);
+
+  const p = $derived(node.props ?? {});
+  const label = $derived(String(p.label ?? ""));
+  const accent = $derived(toneColor(p.tone));
+  const confirmText = $derived(
+    typeof p.confirm === "string" && p.confirm.trim().length > 0 ? p.confirm : null,
+  );
+
+  function isObj(x: unknown): x is Record<string, unknown> {
+    return !!x && typeof x === "object" && !Array.isArray(x);
+  }
+
+  const route = $derived(isObj(p.route) ? p.route : null);
+  const method = $derived(route?.["method"] === "POST" ? "POST" : null);
+  const path = $derived(typeof route?.["path"] === "string" ? (route["path"] as string) : "");
+  const body = $derived(p.body);
+
+  // Client-side namespace guard, mirroring the server's validRoutePath (defense in depth):
+  // non-empty, safe charset, no leading "/", no ".." segment.
+  function safePath(x: string): boolean {
+    if (x.length === 0 || x.startsWith("/")) return false;
+    if (!/^[A-Za-z0-9._/-]+$/.test(x)) return false;
+    return !x.split("/").some((seg) => seg === "..");
+  }
+
+  // Actionable only with a plugin id (context present) AND a valid POST route.
+  const ready = $derived(!!pluginId && method === "POST" && safePath(path));
+
+  let pending = $state(false);
+  let confirming = $state(false);
+
+  function onclick() {
+    if (!ready || pending) return;
+    if (confirmText) {
+      confirming = true;
+      return;
+    }
+    void fire();
+  }
+
+  async function fire() {
+    confirming = false;
+    if (!ready || pending || !pluginId) return;
+    pending = true;
+    try {
+      const text = await invokePluginRoute(pluginId, "POST", path, body);
+      toasts.info(text.length > 0 ? text : m.plugin_action_done());
+    } catch {
+      toasts.info(m.plugin_action_failed(), {
+        duration: null,
+        alert: true,
+        key: `plugin-action:${pluginId}:${path}`,
+      });
+    } finally {
+      pending = false;
+    }
+  }
+</script>
+
+<button
+  type="button"
+  class="gbtn pui-action"
+  style:--accent={accent}
+  disabled={!ready || pending}
+  aria-busy={pending}
+  {onclick}>{label}</button
+>
+
+{#if confirming && confirmText}
+  <div
+    class="overlay"
+    role="presentation"
+    onclick={(e) => {
+      if (e.target === e.currentTarget) confirming = false;
+    }}
+  >
+    <div
+      class="card"
+      role="dialog"
+      aria-modal="true"
+      aria-label={m.plugin_action_confirm_title()}
+      use:dialog={{ onclose: () => (confirming = false) }}
+    >
+      <p class="desc">{confirmText}</p>
+      <div class="actions">
+        <button type="button" class="gbtn" onclick={() => (confirming = false)}
+          >{m.common_cancel()}</button
+        >
+        <button type="button" class="gbtn primary" style:--accent={accent} onclick={fire}
+          >{label}</button
+        >
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  /* Canonical .gbtn recipe (see /design-system). Tone tints the resting border/text via
+     --accent so the button reads with its semantic hue; hover/focus keep the amber affordance. */
+  .gbtn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 2px 8px;
+    cursor: pointer;
+    transition:
+      border-color 0.12s,
+      color 0.12s;
+  }
+  .pui-action {
+    color: var(--accent, var(--color-muted));
+    border-color: var(--accent, var(--color-line));
+  }
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .gbtn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+  .gbtn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  .gbtn.primary {
+    border-color: var(--accent, var(--color-amber));
+    color: var(--accent, var(--color-amber));
+  }
+
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--color-scrim);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 20;
+  }
+  .card {
+    width: min(380px, 92vw);
+    border: 1px solid var(--color-line-bright);
+    background: var(--color-panel);
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .desc {
+    margin: 0;
+    color: var(--color-ink);
+    font-size: var(--fs-base);
+    line-height: 1.4;
+    word-break: break-word;
+  }
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+</style>

--- a/ui/src/lib/plugin-ui/context.ts
+++ b/ui/src/lib/plugin-ui/context.ts
@@ -1,0 +1,12 @@
+// Shared Svelte context for the plugin-UI renderer tree (issue #1209).
+//
+// The renderer chain (PluginUIRenderer → PuiStack → PluginUIRenderer → …) passes only the
+// node, so a deeply-nested interactive node has no idea which plugin it belongs to. The
+// `action-button` node needs the owning plugin id to POST to `/api/plugins/<id>/<path>` —
+// and crucially, sourcing it from context (NOT from node props) is what scopes a button to
+// its OWN plugin namespace: a plugin cannot target another plugin's routes.
+//
+// PluginUIRoot calls setContext(PLUGIN_ID_CONTEXT, id) once at the view root; descendants
+// read it with getContext. A Symbol key avoids collision with any plugin-authored data.
+
+export const PLUGIN_ID_CONTEXT = Symbol("plugin-ui:plugin-id");

--- a/ui/src/lib/plugin-ui/registry.ts
+++ b/ui/src/lib/plugin-ui/registry.ts
@@ -11,6 +11,7 @@ import PuiSparkline from "./PuiSparkline.svelte";
 import PuiTimeSeries from "./PuiTimeSeries.svelte";
 import PuiBarChart from "./PuiBarChart.svelte";
 import PuiTimeline from "./PuiTimeline.svelte";
+import PuiActionButton from "./PuiActionButton.svelte";
 
 /** Whitelist of plugin UI node types. Unknown types fall through to UnknownNodeTile. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -27,4 +28,5 @@ export const PLUGIN_UI_REGISTRY: Record<string, Component<any>> = {
   "time-series": PuiTimeSeries,
   "bar-chart": PuiBarChart,
   timeline: PuiTimeline,
+  "action-button": PuiActionButton,
 };


### PR DESCRIPTION
Closes #1209.

Adds an additive, interactive **`action-button`** node to the declarative plugin UI (`publishUI`, #1185) — the first non-display node. On click it POSTs a **plugin-authored JSON body** to one of the plugin's **own** routes (`/api/plugins/<thisPluginId>/<path>`), unlocking per-item parameterized actions (e.g. a per-account "Make primary" button in Settings → Plugins).

## Node shape

```jsonc
{
  "type": "action-button",
  "props": {
    "label": "Make primary",                                  // required, verbatim plugin text
    "tone": "neutral",                                        // optional: neutral|ok|warn|error|info
    "route": { "method": "POST", "path": "switch-primary" },  // required; method MUST be POST
    "body": { "mode": "specific", "account": 2 },             // optional, opaque plugin JSON
    "confirm": "Switch the primary account?"                  // optional verbatim text; gate the POST
  }
}
```

## Design & safety

- **Namespace-scoped, defense in depth.** `pluginId` flows via Svelte context (`PluginUIRoot` wrapper), **never** node props — so a button can only ever hit its own plugin's routes. `route.path` is rejected server-side via the existing `validRoutePath()` (no leading `/`, no `..`) **and** re-checked client-side; an unsafe/missing route (or absent context) renders the button **disabled and never fetches**.
- **POST-only.** A GET fetch with a body throws `TypeError`; `action-button` exists to send a body, so the method is constrained to POST server- and client-side. The client helper attaches a body **only** for POST.
- **Invalid → whole view dropped fail-open** (consistent with `validateNode`'s all-or-nothing tree semantics; a route typo visibly stops the panel updating + logs a `publishUI rejected` warn).
- **Optional `confirm`** gates the POST behind a scrim+blur confirm dialog (canonical modal recipe); the button disables while in-flight to block double-submit.

## Files

- **Server:** `ui-validate.ts` (per-type validation), `types.ts` (node-type JSDoc + reconcile the superseded "display-only v1" line).
- **UI:** `api.ts` (optional JSON body), new `context.ts` / `PluginUIRoot.svelte` / `PuiActionButton.svelte`, `registry.ts`, `SettingsPluginsPanel.svelte`, EN/DE messages.
- **Docs:** `docs/research/plugin-ui-widgets.md` — interactivity reconciled as landed via #1209 (no longer self-contradictory).
- **Tests:** server validation cases (`plugins-ui.test.ts`), body-encoding cases (`api.invokePluginRoute.test.ts`), new browser test (render / click-POST / confirm flow / error / unsafe-path & context-absent guards).

## Reviewer notes

- **`[no-feature-entry]` (intentional).** Per the issue's renderer-gating note, **no deployed plugin emits `action-button` yet**, so this PR ships **no operator-visible UX** — a What's-New entry would announce a feature operators cannot see (`UnknownNodeTile` placeholders until a host advertises the renderer). The opt-out is loud, in the commit subject + here.
- **a11y sizing waiver.** `PuiActionButton` reuses the design system's canonical **`.gbtn`** recipe (sub-44px, `--fs-meta`), matching every other button in the app, rather than introducing a 44×44px outlier. Flagging per the a11y-floor house rule; confirm acceptable.
- **Glossary confirmation.** Please confirm the new EN/DE strings read well: `plugin_action_done` ("Done"/"Fertig"), `plugin_action_failed` ("Plugin action failed"/"Plugin-Aktion fehlgeschlagen"), `plugin_action_confirm_title` ("Confirm action"/"Aktion bestätigen").

## Verification

- Root: `bun run lint` clean; `bun test test/plugins-ui.test.ts` 26 pass.
- UI: `bun run check` 0 errors/0 warnings; `bun run test` 2273 pass (incl. 15 new); `bun run check:i18n` parity (2118 keys each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)