### PR TITLE
fix(review): fail-fast dead critic + surface onSpawn-abort reason

### DIFF
--- a/src/json-tolerant.ts
+++ b/src/json-tolerant.ts
@@ -76,6 +76,15 @@ export function isSpawnWorking(
 export type VerdictAction = "finalize-value" | "finalize-null" | "wait";
 
 /**
+ * Boot grace before an absent-verdict spawn may be fail-fasted as finished-without-output. Covers
+ * the window where a freshly-spawned agent reads as not-yet-working with no verdict file yet (it
+ * hasn't taken its first turn), which is indistinguishable from one that died at startup. Well under
+ * both the recap (5 min) and critic (10 min) hard timeouts, so the timeout still backstops a spawn
+ * that finishes within the grace.
+ */
+export const STARTUP_GRACE_MS = 60_000;
+
+/**
  * Shared finalize-gate decision for the recap (src/recap.ts) and critic (src/review.ts) verdict
  * loops, given the 3-way read plus the spawn/timeout state:
  *   - strict parse      → "finalize-value" now (a complete document; unchanged behavior).
@@ -83,13 +92,22 @@ export type VerdictAction = "finalize-value" | "finalize-null" | "wait";
  *                         "wait" — a repaired parse may be a truncated partial write jsonrepair
  *                         closed up, so it isn't trusted while the agent may still be writing.
  *   - unparseable       → "finalize-null" (fail fast) once finished (or timed out); else "wait".
- *   - absent            → "finalize-null" only at the hard timeout; else "wait". The "agent wrote
- *                         nothing" / genuine-hang class is deliberately NOT fail-fasted (#822).
+ *   - absent            → "finalize-null" at the hard timeout, OR once the spawn has finished AND
+ *                         the startup grace has elapsed (`graceElapsed`); else "wait". A spawn that
+ *                         exits without ever writing the verdict (e.g. the agent died at startup —
+ *                         no usable account) is finished-with-an-absent-file from its first tick;
+ *                         #822 left this class to the hard timeout, so it sat "working" for the full
+ *                         window. The grace gate reclaims that wait while still protecting a
+ *                         slow-booting agent: before its first turn an agent reads as not-working
+ *                         with no file yet, indistinguishable from a dead one, so we only fail-fast
+ *                         once it's both finished AND past the boot grace. A genuinely-hung agent
+ *                         (alive, mid-turn) reads `working` → not finished → still waits the timeout.
  */
 export function decideVerdictAction(
   read: VerdictRead<unknown>,
   spawnFinished: boolean,
   timedOut: boolean,
+  graceElapsed = false,
 ): VerdictAction {
   if (read.status === "parsed") {
     if (!read.repaired) return "finalize-value";
@@ -98,5 +116,5 @@ export function decideVerdictAction(
   if (read.status === "unparseable") {
     return spawnFinished || timedOut ? "finalize-null" : "wait";
   }
-  return timedOut ? "finalize-null" : "wait"; // absent
+  return timedOut || (spawnFinished && graceElapsed) ? "finalize-null" : "wait"; // absent
 }

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -35,7 +35,12 @@ import {
   needsRecap,
 } from "./recap-core";
 import { groundBlocks, type VisualBlock } from "./visual-blocks";
-import { tolerantParseJson, isSpawnWorking, decideVerdictAction } from "./json-tolerant";
+import {
+  tolerantParseJson,
+  isSpawnWorking,
+  decideVerdictAction,
+  STARTUP_GRACE_MS,
+} from "./json-tolerant";
 import type { VerdictRead } from "./json-tolerant";
 
 const execFileAsync = promisify(execFile);
@@ -522,8 +527,14 @@ export class RecapService {
       if (this.finalizing.has(r.sessionId)) continue;
 
       const read = this._readVerdict(r.cwd);
-      const timedOut = this.now() - r.spawnedAt > this.timeoutMs;
-      const action = decideVerdictAction(read, this.spawnFinished(r.cwd), timedOut);
+      const elapsed = this.now() - r.spawnedAt;
+      const timedOut = elapsed > this.timeoutMs;
+      const action = decideVerdictAction(
+        read,
+        this.spawnFinished(r.cwd),
+        timedOut,
+        elapsed > STARTUP_GRACE_MS,
+      );
       if (action === "wait") continue; // not-yet-written / repaired-or-unparseable while still working
       // finalize-value carries the parsed verdict; finalize-null (timeout / fail-fast) → `failed`.
       const raw = action === "finalize-value" && read.status === "parsed" ? read.value : null;
@@ -537,7 +548,7 @@ export class RecapService {
           );
         } else {
           console.warn(
-            `[recap] ${r.sessionId}: no verdict file after ${Math.round(this.timeoutMs / 1000)}s — agent produced nothing.`,
+            `[recap] ${r.sessionId}: no verdict file after ${Math.round(elapsed / 1000)}s (spawn exited or hard timeout) — agent produced nothing.`,
           );
         }
       }

--- a/src/review.ts
+++ b/src/review.ts
@@ -10,7 +10,7 @@ import { isApiKeyMode, isApiKeyConfigured } from "./spawn-auth";
 import { jsonlPathFor, readSessionUsage, type SessionUsage } from "./usage";
 import { readActivitySignal } from "./activity-signal";
 import { checksCleared } from "./checks-gate";
-import { isSpawnWorking, decideVerdictAction } from "./json-tolerant";
+import { isSpawnWorking, decideVerdictAction, STARTUP_GRACE_MS } from "./json-tolerant";
 import type { VerdictRead } from "./json-tolerant";
 import {
   reviewPrompt,
@@ -369,6 +369,11 @@ export class ReviewService {
     if ("aborted" in aux) {
       console.warn(`[review] onSpawn aborted for ${session.id}: ${aux.aborted.reason}`);
       this.deps.worktree.remove(wt.worktreePath);
+      // Surface WHY instead of failing silently: an onSpawn abort (e.g. the claude-swap pool has
+      // no usable account) becomes a visible `error` verdict carrying the reason, so the badge
+      // reads "REVIEW ERR: <reason>" rather than a generic failure or a misleading "critic did not
+      // produce a verdict". Self-heals — the next consider() that lands a real verdict overwrites it.
+      this.publishSpawnAbort(session, git, aux.aborted.reason, prior);
       return;
     }
     let terminalId: string;
@@ -624,13 +629,15 @@ export class ReviewService {
     for (const f of [...this.inflight.values()]) {
       if (f.finalizing) continue; // already being finalized by an overlapping tick
       const read = this.readVerdict(f.worktreePath);
-      const timedOut = this.now() - f.startedAt > this.timeoutMs;
+      const elapsed = this.now() - f.startedAt;
+      const timedOut = elapsed > this.timeoutMs;
       // Same finalize gate as RecapService.tick (shared decideVerdictAction): a repaired-truncated
       // verdict must never silently drop findings or flip the decision in the merge gate, so it is
       // trusted only once the critic spawn has finished; unparseable fails fast (raw=null → the
-      // existing transient-`error` verdict); absent waits for the hard timeout.
+      // existing transient-`error` verdict); absent fails fast once the critic has exited past the
+      // boot grace (a critic that died at startup wrote nothing), else waits for the hard timeout.
       const finished = !isSpawnWorking(this.deps.herdr.list(), f.worktreePath);
-      const action = decideVerdictAction(read, finished, timedOut);
+      const action = decideVerdictAction(read, finished, timedOut, elapsed > STARTUP_GRACE_MS);
       if (action === "wait") {
         // still running (or gated, awaiting completion) — surface what the critic is doing right
         // now. Emit every tick (not only on change) so a reloaded client repopulates within one
@@ -932,6 +939,50 @@ export class ReviewService {
       seenNoteIds: f.seenNoteIds, // carry the per-round note dedup set forward
       updatedAt: this.now(),
     };
+  }
+
+  /**
+   * Persist an onSpawn-abort (the critic never spawned — e.g. the claude-swap pool had no usable
+   * account) as a visible `error` verdict carrying the abort reason. Deduped on (headSha, reason)
+   * so a pool that stays cold across poll ticks does not churn putReview/onChange every tick. The
+   * verdict is intentionally NOT findings-bearing (findings:[]) and preserves the prior streak/error
+   * counters, so an abort neither trips the spawn ceiling nor escalates the consecutive-error stall
+   * — it is a pre-spawn refusal, not a finished critic run.
+   */
+  private publishSpawnAbort(
+    session: Session,
+    git: GitState,
+    reason: string,
+    prior: ReviewVerdict | null,
+  ): void {
+    const summary = reason.slice(0, 100);
+    if (
+      prior?.decision === "error" &&
+      prior.headSha === git.headSha! &&
+      prior.summary === summary
+    ) {
+      return; // already surfaced for this head — no churn
+    }
+    const verdict: ReviewVerdict = {
+      sessionId: session.id,
+      headSha: git.headSha!,
+      patchId: "", // transient: a later identical head must re-attempt, not inherit this abort
+      decision: "error",
+      summary,
+      body: "",
+      findings: [],
+      addressRound: prior?.addressRound ?? 0,
+      addressCap: this.cap,
+      streakReviews: prior?.streakReviews ?? 0,
+      reviewedPatchIds: prior?.reviewedPatchIds ?? [],
+      errorRound: prior?.errorRound ?? 0,
+      finalRoundPending: prior?.finalRoundPending ?? false,
+      finalRoundTimeoutMs: prior?.finalRoundTimeoutMs ?? DEFAULT_FINAL_ROUND_TIMEOUT_MS,
+      seenNoteIds: prior?.seenNoteIds ?? [],
+      updatedAt: this.now(),
+    };
+    this.deps.store.putReview(verdict);
+    this.deps.onChange(session.id, verdict);
   }
 
   /** Find a live herdr agent that was spawned for a review run, resolved by NAME first

--- a/src/review.ts
+++ b/src/review.ts
@@ -233,7 +233,10 @@ export class ReviewService {
     if (!this.deps.store.getRepoConfig(session.repoPath).criticEnabled) return "skipped";
     if (this.inflight.has(session.id) || this.starting.has(session.id)) return "skipped"; // in flight / mid-spawn
     const prior = this.deps.store.getReview(session.id);
-    if (!force && prior?.headSha === git.headSha) return "skipped"; // head already reviewed
+    // Head already reviewed → skip. EXCEPT a spawn-abort row: the critic never ran (e.g. the pool
+    // had no usable account), so the head is NOT reviewed — re-attempt it every poll (cheap: a
+    // still-cold pool aborts again pre-spawn) so the review self-heals once the pool warms.
+    if (!force && prior?.headSha === git.headSha && !prior.spawnAborted) return "skipped";
     // Per-streak spawn ceiling: review token spend is unbounded otherwise (consider() would
     // spawn a critic on every new CI-green head forever). Cap *findings-bearing* reviews per
     // outstanding-findings streak at 2*cap (the live cap, derived inline — a persisted
@@ -943,11 +946,13 @@ export class ReviewService {
 
   /**
    * Persist an onSpawn-abort (the critic never spawned — e.g. the claude-swap pool had no usable
-   * account) as a visible `error` verdict carrying the abort reason. Deduped on (headSha, reason)
-   * so a pool that stays cold across poll ticks does not churn putReview/onChange every tick. The
-   * verdict is intentionally NOT findings-bearing (findings:[]) and preserves the prior streak/error
-   * counters, so an abort neither trips the spawn ceiling nor escalates the consecutive-error stall
-   * — it is a pre-spawn refusal, not a finished critic run.
+   * account) as a visible `error` verdict carrying the abort reason. The row is flagged
+   * `spawnAborted` so consider()'s same-head dedup re-attempts it (the head was never reviewed) —
+   * which means consider() reaches here again every poll while the pool stays cold; the (headSha,
+   * reason) dedup below keeps that from churning putReview/onChange every tick. The verdict is
+   * intentionally NOT findings-bearing (findings:[]) and preserves the prior streak/error counters,
+   * so an abort neither trips the spawn ceiling nor escalates the consecutive-error stall — it is a
+   * pre-spawn refusal, not a finished critic run.
    */
   private publishSpawnAbort(
     session: Session,
@@ -979,6 +984,7 @@ export class ReviewService {
       finalRoundPending: prior?.finalRoundPending ?? false,
       finalRoundTimeoutMs: prior?.finalRoundTimeoutMs ?? DEFAULT_FINAL_ROUND_TIMEOUT_MS,
       seenNoteIds: prior?.seenNoteIds ?? [],
+      spawnAborted: true, // exempt from the same-head dedup → auto path re-attempts when the pool warms
       updatedAt: this.now(),
     };
     this.deps.store.putReview(verdict);

--- a/src/store.ts
+++ b/src/store.ts
@@ -284,6 +284,7 @@ type ReviewVerdictRow = {
   finalRoundTimeoutMs: number | null;
   seenNoteIds: string;
   url: string | null;
+  spawnAborted: number | null;
   updatedAt: number;
 };
 
@@ -2045,6 +2046,8 @@ export class SessionStore implements CapStore, CreditStore {
       finalRoundTimeoutMs: r.finalRoundTimeoutMs ?? 900_000,
       seenNoteIds: parseFindings(r.seenNoteIds), // same string[] JSON shape as findings
       url: r.url ?? undefined,
+      // Optional flag: present only on a pre-spawn abort row; a normal verdict omits it entirely.
+      spawnAborted: r.spawnAborted ? true : undefined,
     } as ReviewVerdict;
   }
 
@@ -2052,7 +2055,7 @@ export class SessionStore implements CapStore, CreditStore {
     const r = this.db
       .query(
         `SELECT sessionId, headSha, patchId, decision, summary, body, findings, addressRound,
-                addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, updatedAt
+                addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, spawnAborted, updatedAt
               FROM reviews WHERE sessionId = ?`,
       )
       .get(sessionId) as ReviewVerdictRow | null;
@@ -2062,8 +2065,8 @@ export class SessionStore implements CapStore, CreditStore {
   putReview(v: ReviewVerdict): void {
     this.db.run(
       `INSERT INTO reviews (sessionId, headSha, patchId, decision, summary, body, findings, addressRound,
-         addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, updatedAt)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+         addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, spawnAborted, updatedAt)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
        ON CONFLICT(sessionId) DO UPDATE SET headSha=excluded.headSha, patchId=excluded.patchId,
          decision=excluded.decision,
          summary=excluded.summary, body=excluded.body, findings=excluded.findings,
@@ -2071,7 +2074,7 @@ export class SessionStore implements CapStore, CreditStore {
          streakReviews=excluded.streakReviews, reviewedPatchIds=excluded.reviewedPatchIds,
          errorRound=excluded.errorRound, finalRoundPending=excluded.finalRoundPending,
          finalRoundTimeoutMs=excluded.finalRoundTimeoutMs, seenNoteIds=excluded.seenNoteIds,
-         url=excluded.url, updatedAt=excluded.updatedAt`,
+         url=excluded.url, spawnAborted=excluded.spawnAborted, updatedAt=excluded.updatedAt`,
       [
         v.sessionId,
         v.headSha,
@@ -2089,6 +2092,7 @@ export class SessionStore implements CapStore, CreditStore {
         v.finalRoundTimeoutMs ?? 900_000,
         JSON.stringify(v.seenNoteIds ?? []),
         v.url ?? null,
+        v.spawnAborted ? 1 : 0,
         v.updatedAt,
       ],
     );
@@ -2130,7 +2134,7 @@ export class SessionStore implements CapStore, CreditStore {
     const rows = this.db
       .query(
         `SELECT sessionId, headSha, patchId, decision, summary, body, findings, addressRound,
-                addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, updatedAt FROM reviews`,
+                addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, spawnAborted, updatedAt FROM reviews`,
       )
       .all() as ReviewVerdictRow[];
     const out: Record<string, ReviewVerdict> = {};
@@ -3028,6 +3032,9 @@ export class SessionStore implements CapStore, CreditStore {
     // 900000ms = 15min; one-time backfill for pre-existing rows, not an ongoing mirror —
     // live rows carry ReviewService's DEFAULT_FINAL_ROUND_TIMEOUT_MS.
     add("finalRoundTimeoutMs", `finalRoundTimeoutMs INTEGER NOT NULL DEFAULT 900000`);
+    // spawnAborted (#1211): marks a row that records a pre-spawn onSpawn abort (critic never ran),
+    // exempting it from the same-head re-review dedup. Pre-existing rows backfill to 0 (real reviews).
+    add("spawnAborted", `spawnAborted INTEGER NOT NULL DEFAULT 0`);
   }
 
   // ── learnings ─────────────────────────────────────────────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -337,6 +337,7 @@ export interface ReviewVerdict {
   finalRoundTimeoutMs: number; // live abandonment timeout; surfaced so the UI never hardcodes it
   seenNoteIds: string[]; // ids of author notes already fed to the critic, so each is injected only once
   url?: string; // posted PR-review URL, when the host returns one
+  spawnAborted?: boolean; // true ⇒ this row records a pre-spawn onSpawn abort (critic never ran — e.g. no usable account), surfaced for the badge but EXEMPT from the same-head dedup so the auto path re-attempts once the blocker clears. Cleared (omitted) on every real verdict.
   updatedAt: number;
 }
 

--- a/test/json-tolerant.test.ts
+++ b/test/json-tolerant.test.ts
@@ -96,9 +96,21 @@ describe("decideVerdictAction", () => {
     expect(decideVerdictAction(unparseable, false, true)).toBe("finalize-null"); // timeout
   });
 
-  test("absent → wait unless timed out (NOT fail-fasted even when finished)", () => {
+  test("absent → wait while the spawn is still working, regardless of grace", () => {
     expect(decideVerdictAction(absent, false, false)).toBe("wait");
-    expect(decideVerdictAction(absent, true, false)).toBe("wait"); // finished but no fail-fast
+    expect(decideVerdictAction(absent, false, false, true)).toBe("wait"); // grace up but still working
     expect(decideVerdictAction(absent, false, true)).toBe("finalize-null"); // only the hard timeout
+  });
+
+  test("absent → fail-fast once the spawn has finished AND the startup grace elapsed", () => {
+    // A critic/recap that exits without ever writing a verdict (e.g. died at startup — no usable
+    // account) used to sit "working" in the UI for the full hard timeout. Once the spawn is
+    // genuinely finished and past the boot grace, finalize it now rather than waiting it out.
+    expect(decideVerdictAction(absent, true, false, true)).toBe("finalize-null");
+    // ...but NOT during the boot grace: a slow-booting agent reads as not-yet-working before its
+    // first turn, and the verdict is legitimately absent then — don't kill it prematurely.
+    expect(decideVerdictAction(absent, true, false, false)).toBe("wait");
+    // Back-compat: callers that omit the grace flag keep the pre-grace "wait until timeout" behavior.
+    expect(decideVerdictAction(absent, true, false)).toBe("wait");
   });
 });

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -2617,3 +2617,39 @@ test("critic: onSpawn abortSpawn → review skipped, worktree reaped, no spawn",
   expect(started).toHaveLength(0);
   expect(removed).toEqual(["/review-wt"]);
 });
+
+test("critic: onSpawn abort surfaces the reason as an error verdict (not a silent failure)", async () => {
+  const {
+    deps: d,
+    reviews,
+    started,
+  } = makeDeps({
+    runSpawnHooks: async () => {
+      throw new PluginSpawnAborted("no usable ready account available", "cswap");
+    },
+  });
+  await new ReviewService(d as any).consider(session(), OPEN_GREEN);
+  expect(started).toHaveLength(0); // never spawned
+  const v = reviews["s1"];
+  expect(v?.decision).toBe("error");
+  expect(v?.summary).toBe("no usable ready account available");
+  expect(v?.headSha).toBe("abc");
+  expect(v?.findings).toEqual([]); // not findings-bearing → must not trip the spawn ceiling
+  expect(v?.patchId).toBe(""); // transient: a later identical head must re-attempt, not inherit it
+});
+
+test("critic: a repeated onSpawn abort for the same head does not churn the verdict", async () => {
+  let changes = 0;
+  const { deps: d } = makeDeps({
+    runSpawnHooks: async () => {
+      throw new PluginSpawnAborted("pool cold", "cswap");
+    },
+    onChange: () => {
+      changes++;
+    },
+  });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  await svc.consider(session(), OPEN_GREEN);
+  expect(changes).toBe(1); // surfaced once; the still-cold-pool retry is a no-op
+});

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -2636,11 +2636,31 @@ test("critic: onSpawn abort surfaces the reason as an error verdict (not a silen
   expect(v?.headSha).toBe("abc");
   expect(v?.findings).toEqual([]); // not findings-bearing → must not trip the spawn ceiling
   expect(v?.patchId).toBe(""); // transient: a later identical head must re-attempt, not inherit it
+  expect(v?.spawnAborted).toBe(true); // marks it exempt from the same-head dedup
+});
+
+test("critic: an abort verdict does NOT block re-attempting the same head — it self-heals", async () => {
+  // First pass: pool cold → abort persists a spawnAborted error verdict for head "abc".
+  let cold = true;
+  const { deps: d, started } = makeDeps({
+    runSpawnHooks: async () => {
+      if (cold) throw new PluginSpawnAborted("no usable ready account available", "cswap");
+      return {}; // pool warm → empty patch, the spawn proceeds
+    },
+  });
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  expect(started).toHaveLength(0); // aborted, nothing spawned
+
+  // Pool warms; the SAME head must re-attempt (the abort row is dedup-exempt) and now spawn.
+  cold = false;
+  await svc.consider(session(), OPEN_GREEN);
+  expect(started).toHaveLength(1); // re-attempted on the same head and spawned the critic
 });
 
 test("critic: a repeated onSpawn abort for the same head does not churn the verdict", async () => {
   let changes = 0;
-  const { deps: d } = makeDeps({
+  const { deps: d, removed } = makeDeps({
     runSpawnHooks: async () => {
       throw new PluginSpawnAborted("pool cold", "cswap");
     },
@@ -2651,5 +2671,9 @@ test("critic: a repeated onSpawn abort for the same head does not churn the verd
   const svc = new ReviewService(d as any);
   await svc.consider(session(), OPEN_GREEN);
   await svc.consider(session(), OPEN_GREEN);
-  expect(changes).toBe(1); // surfaced once; the still-cold-pool retry is a no-op
+  // begin() ran BOTH times (the abort row is dedup-exempt, so consider didn't bail at the
+  // same-head guard) — proven by two worktree reaps — yet the (headSha, reason) dedup inside
+  // publishSpawnAbort kept it to a single onChange.
+  expect(removed).toEqual(["/review-wt", "/review-wt"]);
+  expect(changes).toBe(1);
 });


### PR DESCRIPTION
## Problem

Operator reported: **can't start reviews for tasks — the review starts then fails** with `REVIEW ERR: critic did not produce a verdict`.

Traced end-to-end (server log + `shepherd.db` + critic transcripts) for the failing session (goal-changelog / PR #558, session `cad6bbca`):

- Critic spawn at **06:29:52** → **no transcript ever written** (the `claude` process died at startup) → error verdict persisted at **06:40:05**, exactly the **10-min hard timeout**.
- Subsequent auto-retries logged `[review] onSpawn aborted … no usable ready account available`.

Root cause is a tight **claude-swap** account pool: the recently-merged #1205 routes reviewer spawns through the plugin `onSpawn` hook, which aborts (or hands out a not-actually-ready account that dies at runtime) when no account is *warmed*. Two Shepherd-side behaviors made this confusing rather than clear:

1. A critic that exits **without writing a verdict** sat `REVIEWING` for the full 10-min timeout — `decideVerdictAction` treated an *absent* verdict as `wait` even once the spawn had finished (#822 left the "agent wrote nothing" class to the hard timeout).
2. An `onSpawn` abort failed **silently** (auto path) or as a generic toast (manual path) — the real reason ("no usable ready account available") only ever hit the server log.

This PR is the Shepherd-side **fail-fast + clear-error** half (the account-warming fix itself lives in the claude-swap plugin repo).

## Fix

**1. Fail-fast a dead reviewer/recap spawn.** `decideVerdictAction` gains a `graceElapsed` arg; an *absent* verdict now finalizes once the spawn is finished **AND** a 60s boot grace (`STARTUP_GRACE_MS`) has elapsed — turning the 10-min hang into ~60s. A slow-booting agent (not-yet-`working`, no file yet) is still protected during the grace; a genuinely-hung agent still reads `working` → not finished → still waits the hard timeout. Shared helper, so `recap` gets the same fix.

**2. Surface the onSpawn-abort reason.** A reviewer `onSpawn` abort now persists a visible `error` verdict carrying the reason → badge reads `REVIEW ERR: no usable ready account available` instead of a silent/generic failure. Deduped per `(headSha, reason)` so a cold pool doesn't churn `putReview`/`onChange`; not findings-bearing and preserves prior streak/error counters, so it neither trips the spawn ceiling nor escalates the consecutive-error stall. Self-heals — the next `consider()` that lands a real verdict overwrites it.

## Tests (TDD)

- `json-tolerant.test.ts`: absent + finished + grace → `finalize-null`; within-grace and still-working → `wait`; back-compat 3-arg default preserved.
- `review.test.ts`: onSpawn abort persists an `error` verdict with the reason (`findings:[]`, `patchId:""`); a repeated abort for the same head fires `onChange` once (no churn).

Gates: root `lint` + `tsc` + `bun test ./test` (5238 pass, 0 fail) all green. Server-only `fix` — no UI/i18n/feature-catalog changes.

## Not covered (follow-ups)

- The actual account-warming behavior is in the **claude-swap plugin** (separate repo) — when an account is usable but not yet "ready", reviewer spawns should warm/inherit rather than abort.
- `plan-gate` has the identical `onSpawn`-abort surface (`[plan-gate] onSpawn aborted …`) and its own verdict loop; left out to keep this PR scoped to reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)