### PR TITLE
feat(deploy): size-cap shepherd.log via logrotate timer (#1212)

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -111,7 +111,11 @@ install_os_prereqs() {
   # logrotate backs the OPTIONAL log-rotation timer (#1212), Linux service path only. Best-effort
   # (warn, never die) and Linux-gated: a failed optional install must not abort the whole install,
   # and macOS/core-only installs no timer (and has none of ensure_pkg's package managers).
-  [ "$OS_KIND" = "Linux" ] && ensure_logrotate
+  # NB: a proper `if` (not `[ … ] && …`) so the non-Linux skip leaves a 0 exit — else this last
+  # command returns 1 on macOS and `set -e` aborts the installer.
+  if [ "$OS_KIND" = "Linux" ]; then
+    ensure_logrotate
+  fi
 }
 
 # ensure_pkg <bin> <pkg>: install <pkg> via apt/apk/dnf/pacman if <bin> is absent.

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -108,6 +108,10 @@ install_os_prereqs() {
   ensure_pkg git git
   ensure_pkg unzip unzip
   ensure_toolchain
+  # logrotate backs the OPTIONAL log-rotation timer (#1212), Linux service path only. Best-effort
+  # (warn, never die) and Linux-gated: a failed optional install must not abort the whole install,
+  # and macOS/core-only installs no timer (and has none of ensure_pkg's package managers).
+  [ "$OS_KIND" = "Linux" ] && ensure_logrotate
 }
 
 # ensure_pkg <bin> <pkg>: install <pkg> via apt/apk/dnf/pacman if <bin> is absent.
@@ -128,6 +132,21 @@ ensure_toolchain() {
   note "installing C/C++ build toolchain + python3 (node-pty native build)"
   $sp sh -c "(apt-get update && apt-get install -y build-essential python3) || apk add --no-cache build-base python3 || dnf install -y gcc-c++ make python3 || pacman -Sy --noconfirm base-devel python3" \
     || die "failed to install a C/C++ toolchain + python3 with any supported package manager"
+}
+
+# ensure_logrotate: best-effort install of logrotate for the optional log-rotation timer (#1212).
+# Unlike ensure_pkg this NEVER dies — logrotate is optional, so a failed install just means
+# provision.ts soft-skips the timer (the log stays unbounded, as before). Detection searches
+# /usr/sbin:/sbin where logrotate usually lives (a curl|bash non-login PATH often omits sbin).
+ensure_logrotate() {
+  local sp
+  PATH="$PATH:/usr/sbin:/sbin" command -v logrotate >/dev/null 2>&1 && return 0
+  # sudo_prefix dies if it can't elevate; run it in a subshell so that exit can't abort us — an
+  # empty prefix then makes the install attempt fail unprivileged and fall through to the warn.
+  sp="$(sudo_prefix logrotate 2>/dev/null || true)"
+  note "installing logrotate (optional — log-rotation timer)"
+  $sp sh -c "(apt-get update && apt-get install -y logrotate) || apk add --no-cache logrotate || dnf install -y logrotate || pacman -Sy --noconfirm logrotate" \
+    || warn "could not install logrotate — log-rotation timer will be skipped (log stays unbounded)"
 }
 
 # ── Bun ───────────────────────────────────────────────────────────────────────

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -144,10 +144,13 @@ ensure_toolchain() {
 # /usr/sbin:/sbin where logrotate usually lives (a curl|bash non-login PATH often omits sbin).
 ensure_logrotate() {
   local sp
-  PATH="$PATH:/usr/sbin:/sbin" command -v logrotate >/dev/null 2>&1 && return 0
-  # sudo_prefix dies if it can't elevate; run it in a subshell so that exit can't abort us — an
-  # empty prefix then makes the install attempt fail unprivileged and fall through to the warn.
-  sp="$(sudo_prefix logrotate 2>/dev/null || true)"
+  # Detect against the SAME dir list the shepherd-logrotate.service unit puts on PATH, so we never
+  # consider logrotate "present" in a dir the timer can't reach at runtime (keep these in lockstep).
+  PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" command -v logrotate >/dev/null 2>&1 && return 0
+  # sudo_prefix dies if it can't elevate; the `|| true` is OUTSIDE the substitution — `exit 1`
+  # inside terminates the subshell before any in-substitution `|| true` could run, so the failed
+  # substitution would otherwise abort us under `set -e`. Empty prefix ⇒ unprivileged attempt ⇒ warn.
+  sp="$(sudo_prefix logrotate 2>/dev/null)" || true
   note "installing logrotate (optional — log-rotation timer)"
   $sp sh -c "(apt-get update && apt-get install -y logrotate) || apk add --no-cache logrotate || dnf install -y logrotate || pacman -Sy --noconfirm logrotate" \
     || warn "could not install logrotate — log-rotation timer will be skipped (log stays unbounded)"

--- a/deploy/provision.ts
+++ b/deploy/provision.ts
@@ -121,10 +121,22 @@ export function templateLogrotateConfig(cfg: string, home: string): string {
   return cfg.replaceAll("%h", home);
 }
 
-/** logrotate commonly lives in /usr/sbin (or /sbin), which a `curl | bash` non-login shell's
- *  inherited PATH frequently omits — so a bare `logrotate` probe can false-negative. Search the
- *  sbin candidates explicitly. */
-const LOGROTATE_CANDIDATES = ["logrotate", "/usr/sbin/logrotate", "/sbin/logrotate"] as const;
+/** The dirs the shepherd-logrotate.service unit puts on PATH — MUST stay in lockstep with that
+ *  unit's `Environment=PATH` (and install.sh/update.sh detection). logrotate commonly lives in
+ *  /usr/sbin, which a `curl | bash` non-login PATH often omits. */
+const LOGROTATE_DIRS = [
+  "/usr/local/sbin",
+  "/usr/local/bin",
+  "/usr/sbin",
+  "/usr/bin",
+  "/sbin",
+  "/bin",
+] as const;
+
+/** Absolute candidates only — NO bare `logrotate`: a bare probe resolves against the inherited
+ *  PATH, which can match a dir absent from the unit's PATH, so the timer would install yet fail to
+ *  exec logrotate at runtime. Absolute paths make detection ≡ execution. */
+const LOGROTATE_CANDIDATES = LOGROTATE_DIRS.map((dir) => `${dir}/logrotate`);
 
 /** First logrotate candidate that responds to `--version`, or null if none is found. Gates the
  *  (optional) log-rotation timer install; null ⇒ soft-skip. */

--- a/deploy/provision.ts
+++ b/deploy/provision.ts
@@ -114,6 +114,27 @@ export function templateUnit(unit: string, repo: string): string {
   return unit.replace(/^WorkingDirectory=.*$/m, `WorkingDirectory=${repo}`);
 }
 
+/** logrotate config paths are literal — logrotate does NOT expand %h/~. So the repo config uses
+ *  %h as a placeholder and we template it to the real home before writing the on-disk copy the
+ *  timer runs. (Unit files DO get %h from systemd, so only the config needs this.) #1212 */
+export function templateLogrotateConfig(cfg: string, home: string): string {
+  return cfg.replaceAll("%h", home);
+}
+
+/** logrotate commonly lives in /usr/sbin (or /sbin), which a `curl | bash` non-login shell's
+ *  inherited PATH frequently omits — so a bare `logrotate` probe can false-negative. Search the
+ *  sbin candidates explicitly. */
+const LOGROTATE_CANDIDATES = ["logrotate", "/usr/sbin/logrotate", "/sbin/logrotate"] as const;
+
+/** First logrotate candidate that responds to `--version`, or null if none is found. Gates the
+ *  (optional) log-rotation timer install; null ⇒ soft-skip. */
+export function resolveLogrotate(probe: (bin: string) => string | null): string | null {
+  for (const candidate of LOGROTATE_CANDIDATES) {
+    if (probe(candidate) !== null) return candidate;
+  }
+  return null;
+}
+
 /** Final guidance follow-ups that need a human secret and are NEVER auto-run. */
 export function guidanceNextSteps(): string[] {
   return [
@@ -253,6 +274,7 @@ export function installService(
   env: NodeJS.ProcessEnv,
   home: string,
   buildEnv: NodeJS.ProcessEnv,
+  probe: (bin: string) => string | null = probeVersion,
 ): void {
   log("installing systemd user unit");
   const unitDir = join(home, ".config", "systemd", "user");
@@ -274,6 +296,29 @@ export function installService(
   fileIO.write(join(unitDir, "shepherd-backup.service"), templateUnit(backupSvc, repo));
   const backupTimer = fileIO.read(join(repo, "deploy", "shepherd-backup.timer"));
   fileIO.write(join(unitDir, "shepherd-backup.timer"), backupTimer);
+  // Log-rotation units (#1212) — OPTIONAL: gated on the logrotate binary being present (search
+  // sbin too, where it usually lives). If absent we soft-skip (no crash) — the log just stays
+  // unbounded as before, same posture as the "no systemd user manager" skip. Template the
+  // config's %h log path to the real home (logrotate won't expand %h) → ~/.shepherd; the units'
+  // own %h paths are expanded by systemd, so they copy verbatim.
+  const logrotateBin = resolveLogrotate(probe);
+  if (logrotateBin) {
+    const lrCfg = fileIO.read(join(repo, "deploy", "shepherd.logrotate"));
+    fileIO.write(
+      join(home, ".shepherd", "shepherd.logrotate"),
+      templateLogrotateConfig(lrCfg, home),
+    );
+    fileIO.write(
+      join(unitDir, "shepherd-logrotate.service"),
+      fileIO.read(join(repo, "deploy", "shepherd-logrotate.service")),
+    );
+    fileIO.write(
+      join(unitDir, "shepherd-logrotate.timer"),
+      fileIO.read(join(repo, "deploy", "shepherd-logrotate.timer")),
+    );
+  } else {
+    log("  logrotate not found (searched PATH + /usr/sbin:/sbin) — skipping log-rotation timer");
+  }
   run("systemctl", ["--user", "daemon-reload"]);
   const user = env.USER;
   if (!user) throw new Error("cannot enable-linger: $USER is not set");
@@ -285,6 +330,11 @@ export function installService(
   run("mkdir", ["-p", resolveBackupDir(env)]);
   fileIO.write(backupConfiguredMarker(env), "shepherd-backup.timer enabled\n");
   run("systemctl", ["--user", "enable", "--now", "shepherd-backup.timer"]);
+  // Enable the (already-written) hourly log-rotation timer. Skipped silently when logrotate is
+  // absent — the units were never written above. #1212
+  if (logrotateBin) {
+    run("systemctl", ["--user", "enable", "--now", "shepherd-logrotate.timer"]);
+  }
   // No immediate `start shepherd-backup.service` here: on a fresh install the DB does not exist yet
   // (the server is started below by update.sh), so a read-only snapshot would fail the oneshot and
   // abort provision. update.sh runs its own GUARDED kick once deps are built, and the staleness
@@ -324,7 +374,7 @@ export function provision(opts: ProvisionOpts = {}): void {
 
   const decision = decideServicePath(platform, env.SHEPHERD_NO_SERVICE);
   if (decision.service) {
-    installService(repo, run, fileIO, env, home, buildEnv);
+    installService(repo, run, fileIO, env, home, buildEnv, probe);
   } else {
     buildOnly(repo, run, buildEnv);
   }

--- a/deploy/shepherd-logrotate.service
+++ b/deploy/shepherd-logrotate.service
@@ -8,8 +8,10 @@ Type=oneshot
 # config's own log path is pre-templated to the real home by provision.ts/update.sh).
 ExecStart=logrotate --state %h/.shepherd/logrotate.state %h/.shepherd/shepherd.logrotate
 
-# logrotate commonly lives in /usr/sbin — include sbin so the timer-driven run resolves it even
-# under a minimal inherited PATH (the backup unit's PATH omits sbin).
-Environment=PATH=/usr/sbin:/usr/bin:/sbin:/bin
+# logrotate commonly lives in /usr/sbin — include sbin (and /usr/local) so the timer-driven run
+# resolves it even under a minimal inherited PATH (the backup unit's PATH omits sbin). This list
+# MUST stay in lockstep with the detection PATH in install.sh/update.sh and resolveLogrotate's
+# candidates in provision.ts — else detection could match a logrotate this run can't exec.
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Output goes to journald: `journalctl --user -u shepherd-logrotate`

--- a/deploy/shepherd-logrotate.service
+++ b/deploy/shepherd-logrotate.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Shepherd — rotate ~/.shepherd/shepherd.log (size-cap via copytruncate)
+Documentation=https://github.com/erwins-enkel/shepherd
+
+[Service]
+Type=oneshot
+# The config + state live under ~/.shepherd. systemd expands %h here (logrotate does NOT — the
+# config's own log path is pre-templated to the real home by provision.ts/update.sh).
+ExecStart=logrotate --state %h/.shepherd/logrotate.state %h/.shepherd/shepherd.logrotate
+
+# logrotate commonly lives in /usr/sbin — include sbin so the timer-driven run resolves it even
+# under a minimal inherited PATH (the backup unit's PATH omits sbin).
+Environment=PATH=/usr/sbin:/usr/bin:/sbin:/bin
+
+# Output goes to journald: `journalctl --user -u shepherd-logrotate`

--- a/deploy/shepherd-logrotate.timer
+++ b/deploy/shepherd-logrotate.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Shepherd — hourly log-rotation timer
+Documentation=https://github.com/erwins-enkel/shepherd
+
+[Timer]
+OnCalendar=hourly
+# Catch up if the host was off when a window was due. A size-triggered rotation is only as tight
+# as how often it's checked: hourly bounds the live file's overshoot past 50M to ~1h of output
+# (the server's 1s poller + many setIntervals are continuously chatty), matching shepherd-backup.timer.
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/shepherd.logrotate
+++ b/deploy/shepherd.logrotate
@@ -1,0 +1,20 @@
+# Shepherd — size-cap the persistent app log (#1212).
+#
+# shepherd.service redirects StandardOutput/StandardError append: into this file and holds the
+# fd open O_APPEND for the life of the process, so a rename+create rotation would NOT reclaim
+# space — the server keeps writing to the old inode. copytruncate copies the file aside and
+# truncates the original IN PLACE, which the held fd respects. The size trigger is the rotation
+# condition; cadence (how often this is checked) is set by shepherd-logrotate.timer, NOT a
+# daily/weekly directive here — `size` overrides any time interval anyway.
+#
+# %h is a placeholder: logrotate does NOT expand %h/~, so deploy/provision.ts (and update.sh)
+# template it to the real home and write the result to ~/.shepherd/shepherd.logrotate before the
+# timer runs it. Operator-facing deploy config: plain English, not internationalized.
+%h/.shepherd/shepherd.log {
+    size 50M
+    rotate 7
+    missingok
+    notifempty
+    compress
+    copytruncate
+}

--- a/deploy/shepherd.service
+++ b/deploy/shepherd.service
@@ -20,7 +20,8 @@ Environment=SHEPHERD_ALLOWED_HOSTS=localhost,127.0.0.1,::1,[::1],shepherd.chicke
 EnvironmentFile=-%h/.shepherd/env
 
 # app output keeps appending to the existing log file; unit lifecycle (start/stop/restart)
-# is still in journald via `journalctl --user -u shepherd`
+# is still in journald via `journalctl --user -u shepherd`. The file is size-bounded by
+# shepherd-logrotate.timer (copytruncate keeps this held fd writing to the truncated inode). #1212
 StandardOutput=append:%h/.shepherd/shepherd.log
 StandardError=append:%h/.shepherd/shepherd.log
 

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -71,11 +71,12 @@ if command -v systemctl >/dev/null 2>&1 && systemctl --user show-environment >/d
 
   # ── sync log-rotation units (#1212) ──────────────────────────────────────────
   # Mirrors the backup-timer self-heal so an existing host picks up the optional log-rotation
-  # timer. Optional: only when logrotate is present (search /usr/sbin:/sbin where it usually
-  # lives). Template the config's %h log path to the real home (logrotate won't expand %h) →
-  # ~/.shepherd; copy units verbatim (systemd expands their %h); reload + enable --now the hourly
-  # timer. Soft-skip with a warning otherwise (log stays unbounded, as before).
-  if PATH="$PATH:/usr/sbin:/sbin" command -v logrotate >/dev/null 2>&1; then
+  # timer. Optional: only when logrotate is present. Detect against the SAME dir list the
+  # shepherd-logrotate.service unit puts on PATH (keep in lockstep), so we never "find" a logrotate
+  # the timer can't exec at runtime. Template the config's %h log path to the real home (logrotate
+  # won't expand %h) → ~/.shepherd; copy units verbatim (systemd expands their %h); reload +
+  # enable --now the hourly timer. Soft-skip with a warning otherwise (log stays unbounded).
+  if PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" command -v logrotate >/dev/null 2>&1; then
     note "syncing log-rotation timer units"
     mkdir -p "$HOME/.shepherd"
     sed "s|%h|${HOME}|g" "$REPO/deploy/shepherd.logrotate" >"$HOME/.shepherd/shepherd.logrotate"

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -68,6 +68,24 @@ if command -v systemctl >/dev/null 2>&1 && systemctl --user show-environment >/d
   # Kick one backup now (the timer's first scheduled run is at the next hour boundary), so a freshly
   # adopted host has a .last-success well before the daily-sweep staleness probe runs (#1080).
   systemctl --user start shepherd-backup.service || warn "initial backup run did not start"
+
+  # ── sync log-rotation units (#1212) ──────────────────────────────────────────
+  # Mirrors the backup-timer self-heal so an existing host picks up the optional log-rotation
+  # timer. Optional: only when logrotate is present (search /usr/sbin:/sbin where it usually
+  # lives). Template the config's %h log path to the real home (logrotate won't expand %h) →
+  # ~/.shepherd; copy units verbatim (systemd expands their %h); reload + enable --now the hourly
+  # timer. Soft-skip with a warning otherwise (log stays unbounded, as before).
+  if PATH="$PATH:/usr/sbin:/sbin" command -v logrotate >/dev/null 2>&1; then
+    note "syncing log-rotation timer units"
+    mkdir -p "$HOME/.shepherd"
+    sed "s|%h|${HOME}|g" "$REPO/deploy/shepherd.logrotate" >"$HOME/.shepherd/shepherd.logrotate"
+    cp "$REPO/deploy/shepherd-logrotate.service" "$UNIT_DIR/shepherd-logrotate.service"
+    cp "$REPO/deploy/shepherd-logrotate.timer" "$UNIT_DIR/shepherd-logrotate.timer"
+    systemctl --user daemon-reload
+    systemctl --user enable --now shepherd-logrotate.timer
+  else
+    warn "logrotate not found — skipping log-rotation timer (shepherd.log stays unbounded)"
+  fi
 else
   warn "no systemd user manager — skipping backup timer sync (no automated backups on this host)"
 fi

--- a/test/provision.test.ts
+++ b/test/provision.test.ts
@@ -153,13 +153,21 @@ describe("templateLogrotateConfig", () => {
   });
 });
 
-describe("resolveLogrotate (sbin-aware detection)", () => {
-  it("returns the bare name when it is on PATH", () => {
-    expect(resolveLogrotate((b) => (b === "logrotate" ? "3.21.0" : null))).toBe("logrotate");
+describe("resolveLogrotate (absolute-path detection ≡ execution)", () => {
+  it("only probes absolute paths — never a bare `logrotate` (detection must match the unit PATH)", () => {
+    const probed: string[] = [];
+    resolveLogrotate((b) => {
+      probed.push(b);
+      return null;
+    });
+    expect(probed.length).toBeGreaterThan(0);
+    expect(probed).not.toContain("logrotate");
+    expect(probed.every((p) => p.startsWith("/"))).toBe(true);
+    // every candidate dir is one the shepherd-logrotate.service unit puts on PATH
+    expect(probed).toContain("/usr/sbin/logrotate");
   });
 
-  it("falls back to /usr/sbin when the bare name is not on PATH", () => {
-    // Mirrors a curl|bash non-login shell whose PATH omits sbin: bare lookup misses, sbin hits.
+  it("returns the matching absolute candidate (e.g. the common /usr/sbin)", () => {
     const probe = (b: string) => (b === "/usr/sbin/logrotate" ? "3.21.0" : null);
     expect(resolveLogrotate(probe)).toBe("/usr/sbin/logrotate");
   });

--- a/test/provision.test.ts
+++ b/test/provision.test.ts
@@ -10,6 +10,8 @@ import {
   decideServicePath,
   guidanceNextSteps,
   templateUnit,
+  templateLogrotateConfig,
+  resolveLogrotate,
   installPrereqs,
   ensureNodeGyp,
   installService,
@@ -131,6 +133,39 @@ describe("templateUnit", () => {
   it("replaces exactly one WorkingDirectory line", () => {
     const templated = templateUnit(unit, "/x");
     expect(templated.match(/^WorkingDirectory=/gm)?.length).toBe(1);
+  });
+});
+
+describe("templateLogrotateConfig", () => {
+  const cfg = readFileSync("deploy/shepherd.logrotate", "utf8");
+
+  it("expands every %h to the real home (logrotate won't)", () => {
+    const out = templateLogrotateConfig(cfg, "/home/op");
+    expect(out).toContain("/home/op/.shepherd/shepherd.log");
+    expect(out).not.toContain("%h");
+  });
+
+  it("keeps the copytruncate + size policy intact", () => {
+    const out = templateLogrotateConfig(cfg, "/home/op");
+    expect(out).toContain("copytruncate");
+    expect(out).toContain("size 50M");
+    expect(out).toContain("rotate 7");
+  });
+});
+
+describe("resolveLogrotate (sbin-aware detection)", () => {
+  it("returns the bare name when it is on PATH", () => {
+    expect(resolveLogrotate((b) => (b === "logrotate" ? "3.21.0" : null))).toBe("logrotate");
+  });
+
+  it("falls back to /usr/sbin when the bare name is not on PATH", () => {
+    // Mirrors a curl|bash non-login shell whose PATH omits sbin: bare lookup misses, sbin hits.
+    const probe = (b: string) => (b === "/usr/sbin/logrotate" ? "3.21.0" : null);
+    expect(resolveLogrotate(probe)).toBe("/usr/sbin/logrotate");
+  });
+
+  it("returns null when logrotate is nowhere (soft-skip signal)", () => {
+    expect(resolveLogrotate(() => null)).toBeNull();
   });
 });
 
@@ -305,7 +340,9 @@ describe("extracted helpers (direct)", () => {
 
   it("installService templates+writes the unit, enables, delegates build, throws without $USER", () => {
     const { calls, writes, run, fileIO } = recorder();
-    installService("/repo", run, fileIO, { USER: "me" }, "/home/op", { PATH: "/x" });
+    // logrotate present (explicit probe ⇒ deterministic regardless of the host's real binary).
+    const yesLogrotate = () => "3.21.0";
+    installService("/repo", run, fileIO, { USER: "me" }, "/home/op", { PATH: "/x" }, yesLogrotate);
     const flat = calls.map((c) => c.join(" "));
     expect([...writes.keys()].some((p) => p.endsWith("systemd/user/shepherd.service"))).toBe(true);
     expect(flat.some((c) => c.includes("daemon-reload"))).toBe(true);
@@ -335,10 +372,41 @@ describe("extracted helpers (direct)", () => {
     const updateIdx = calls.findIndex((c) => c.join(" ").includes("deploy/update.sh"));
     expect(shepherdMkdirIdx).toBeLessThan(updateIdx);
 
+    // logrotate units: written, config templated to ~/.shepherd with %h → real home, copytruncate
+    // present; the hourly timer enabled --now. #1212
+    const lrCfgWrite = [...writes.entries()].find(([p]) =>
+      p.endsWith(".shepherd/shepherd.logrotate"),
+    );
+    expect(lrCfgWrite).toBeDefined();
+    expect(lrCfgWrite![0]).toBe(join("/home/op", ".shepherd", "shepherd.logrotate"));
+    expect(lrCfgWrite![1]).toContain("/home/op/.shepherd/shepherd.log");
+    expect(lrCfgWrite![1]).not.toContain("%h");
+    expect(lrCfgWrite![1]).toContain("copytruncate");
+    expect(
+      [...writes.keys()].some((p) => p.endsWith("systemd/user/shepherd-logrotate.service")),
+    ).toBe(true);
+    expect(
+      [...writes.keys()].some((p) => p.endsWith("systemd/user/shepherd-logrotate.timer")),
+    ).toBe(true);
+    expect(flat.some((c) => c.includes("enable --now shepherd-logrotate.timer"))).toBe(true);
+
     const fresh = recorder();
     expect(() =>
-      installService("/repo", fresh.run, fresh.fileIO, {}, "/home/op", { PATH: "/x" }),
+      installService("/repo", fresh.run, fresh.fileIO, {}, "/home/op", { PATH: "/x" }, () => null),
     ).toThrow(/\$USER/);
+  });
+
+  it("installService soft-skips the log-rotation timer when logrotate is absent", () => {
+    const { calls, writes, run, fileIO } = recorder();
+    installService("/repo", run, fileIO, { USER: "me" }, "/home/op", { PATH: "/x" }, () => null);
+    const flat = calls.map((c) => c.join(" "));
+    // Backup units still installed (independent of logrotate); logrotate units NOT written.
+    expect([...writes.keys()].some((p) => p.endsWith("systemd/user/shepherd-backup.timer"))).toBe(
+      true,
+    );
+    expect([...writes.keys()].some((p) => p.includes("shepherd-logrotate"))).toBe(false);
+    expect([...writes.keys()].some((p) => p.endsWith(".shepherd/shepherd.logrotate"))).toBe(false);
+    expect(flat.some((c) => c.includes("shepherd-logrotate.timer"))).toBe(false);
   });
 
   it("buildOnly installs deps + builds UI with the build env, no systemd", () => {


### PR DESCRIPTION
Closes #1212.

## Problem

`~/.shepherd/shepherd.log` grows **unbounded**: `shepherd.service` redirects both streams `append:` and holds the log fd open `O_APPEND` for the life of the process. Nothing rotates, truncates, or size-caps it — a slow-burn disk filler. The held fd is the wrinkle: a naïve `rename`+`create` rotation won't reclaim space (the process keeps writing to the old inode).

## Approach

Ship a logrotate config driven by a **user-space systemd timer**, mirroring the existing hourly-backup unit pattern (Shepherd installs entirely under `systemctl --user`, no root after prereqs — so `/etc/logrotate.d` + system cron would be the wrong layer).

**Policy** (`deploy/shepherd.logrotate`): `copytruncate` (mandatory for the held fd — copies aside, truncates the original in place), `size 50M`, `rotate 7`, `compress`. Bound: ~50M live + 7 gzipped archives.

**Cadence**: hourly `shepherd-logrotate.timer` (matches `shepherd-backup.timer`). A `size` trigger is only as tight as how often it's checked — hourly bounds the live file's overshoot past 50M to ~1h of output (the 1s poller + many `setInterval`s are continuously chatty). The config is size-only; the timer provides the cadence.

## Wiring

- `provision.ts:installService` — installs the config + units on a fresh box; `update.sh` self-heals them on existing hosts (both mirror the backup-timer plumbing).
- `install.sh` — best-effort installs `logrotate`.

## Optional / fail-safe

logrotate is **optional** and never blocks an install:
- `install.sh` install is **best-effort (warn-not-die)** and **Linux-only** (macOS core-only has no timer and none of `ensure_pkg`'s package managers).
- `provision.ts` / `update.sh` **soft-skip** the timer (with a warning) if the binary is absent — the log just stays unbounded as before.
- **Detection searches `/usr/sbin:/sbin`** (where logrotate usually lives) at all three sites — a `curl | bash` non-login PATH often omits sbin, which would otherwise false-negative and silently skip the feature.

logrotate doesn't expand `%h`, so the config's `%h` log path is templated to the real home before the on-disk copy (`~/.shepherd/shepherd.logrotate`) is written; the units' own `%h` is expanded by systemd.

## Tests

`test/provision.test.ts`: config + units written (home-expanded, `copytruncate`), hourly timer `enable --now`, **soft-skip when logrotate absent**, plus `templateLogrotateConfig` + sbin-aware `resolveLogrotate` unit tests. Verified: `bun run typecheck`, `bun test ./test` (5241 pass), `bun run lint`, `bunx fallow audit` all green.

`[no-feature-entry]` — operator-facing deploy plumbing, no user-facing UI (and deploy tooling is explicitly not i18n'd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)