### PR TITLE
fix(learnings): explain distill/suggest-merges actions with an info tooltip

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1653,6 +1653,8 @@
   "learnings_merge_now_started": "Suche nach zusammenführbaren Regeln in {repo}…",
   "learnings_merge_applied": "Regeln zusammengeführt",
   "learnings_merge_failed": "Regeln konnten nicht zusammengeführt werden",
+  "learnings_actions_help": "Beide Aktionen betreffen die Hausregeln dieses Repos. „Jetzt destillieren“ startet den Distiller sofort: Er wertet die jüngsten Agent-Sessions auf Signale aus — deine Korrekturen, Review-Funde, Blocks und Hänger — und schlägt wiederkehrende Muster als neue Regeln zur Prüfung vor (sonst läuft er nach Zeitplan). „Zusammenführungen vorschlagen“ findet nahezu doppelte Regeln und gruppiert sie als Zusammenführungsvorschläge, sodass du jede Gruppe mit einem Klick zu einer Regel zusammenfassen kannst — die überlebende Regel behält ihre Bilanz.",
+  "learnings_actions_help_aria": "Was bewirken diese Aktionen?",
   "learnings_recur_heading": "Wiederkehrend über Repos hinweg",
   "learnings_recur_lead": "Diese Regeln treten in mehreren Repos auf — erwäge, eine davon in deine globale CLAUDE.md aufzunehmen.",
   "learnings_recur_repos": "In {count} Repos: {repos}",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1653,6 +1653,8 @@
   "learnings_merge_now_started": "Looking for rules to merge in {repo}…",
   "learnings_merge_applied": "Rules consolidated",
   "learnings_merge_failed": "Couldn't merge rules",
+  "learnings_actions_help": "Both actions work on this repo's house rules. “Distill now” runs the distiller immediately: it scans recent agent sessions for signals — your corrections, review findings, blocks and stalls — and proposes recurring patterns as new rules for you to review (it otherwise runs on a schedule). “Suggest merges” finds near-duplicate rules and groups them as merge suggestions, so you can fold each group into one rule with a click — the surviving rule keeps its track record.",
+  "learnings_actions_help_aria": "What do these actions do?",
   "learnings_recur_heading": "Recurring across repos",
   "learnings_recur_lead": "These rules appear in several repos — consider adding one to your global CLAUDE.md.",
   "learnings_recur_repos": "In {count} repos: {repos}",

--- a/ui/src/lib/components/learnings-drawer/RepoGroup.svelte
+++ b/ui/src/lib/components/learnings-drawer/RepoGroup.svelte
@@ -21,6 +21,7 @@
   import ProposedRuleCard from "./ProposedRuleCard.svelte";
   import MergeSuggestCard from "./MergeSuggestCard.svelte";
   import RetiredRuleCard from "./RetiredRuleCard.svelte";
+  import InfoTip from "../InfoTip.svelte";
 
   let {
     group,
@@ -50,20 +51,26 @@
       <span class="repo-glyph" class:emoji={!!repoIcon} aria-hidden="true">{repoIcon ?? "▣"}</span
       >{basename(group.repoPath)}
     </span>
-    <button
-      class="distill"
-      onclick={() => ctx.onmergenow(group.repoPath)}
-      aria-label={m.learnings_merge_now_aria({ repo: basename(group.repoPath) })}
-    >
-      {m.learnings_merge_now()}
-    </button>
-    <button
-      class="distill"
-      onclick={() => ctx.ondistill(group.repoPath)}
-      aria-label={m.learnings_distill_aria({ repo: basename(group.repoPath) })}
-    >
-      {m.learnings_distill()}
-    </button>
+    <div class="actions">
+      <button
+        class="distill"
+        onclick={() => ctx.onmergenow(group.repoPath)}
+        aria-label={m.learnings_merge_now_aria({ repo: basename(group.repoPath) })}
+      >
+        {m.learnings_merge_now()}
+      </button>
+      <button
+        class="distill"
+        onclick={() => ctx.ondistill(group.repoPath)}
+        aria-label={m.learnings_distill_aria({ repo: basename(group.repoPath) })}
+      >
+        {m.learnings_distill()}
+      </button>
+      <!-- Explains both actions (distill / suggest-merges) in plain language —
+           the terms are Shepherd jargon, so a per-group info affordance sits
+           right where the actions are. -->
+      <InfoTip text={m.learnings_actions_help()} label={m.learnings_actions_help_aria()} />
+    </div>
   </div>
 
   {#if unseenRetiredCount(group.injectable) > 0}
@@ -208,6 +215,14 @@
   }
   .repo-glyph.emoji {
     font-size: var(--fs-base);
+  }
+  /* action buttons + their info affordance grouped to the header's right edge,
+     so the "i" hugs the buttons instead of being flung out by space-between */
+  .actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
   }
   .distill {
     font-size: var(--fs-meta);


### PR DESCRIPTION
## Problem

In the Learnings drawer, each repo group header carries two action buttons — **Zusammenführungen vorschlagen** ("Suggest merges") and **Jetzt destillieren** ("Distill now"). The terms are Shepherd-internal jargon (especially "destillieren" in German), and there was nothing on screen explaining what they mean or what clicking them does. No `title`, no tooltip, no glossary marker.

## Change

Add a single **`InfoTip`** (the design-system "ⓘ" affordance) right beside the two buttons in each repo header. Hovering/tapping it explains, in plain language, both actions and their mechanism:

- **Distill now** — runs the distiller immediately: scans recent agent sessions for signals (corrections, review findings, blocks, stalls) and proposes recurring patterns as new house rules to review. Otherwise runs on a schedule.
- **Suggest merges** — finds near-duplicate rules and groups them as merge suggestions; folding a group keeps the surviving rule's track record.

One info icon covers both actions (rather than two icons crowding the already-tight German header). The two buttons + tip are now wrapped in a `.actions` flex group so the icon hugs the buttons instead of being flung to the far edge by `space-between`.

## Notes

- New keys `learnings_actions_help` / `learnings_actions_help_aria` added to **both** `en.json` + `de.json` — `check:i18n` green (2120 keys each).
- `InfoTip` is a non-blocking `role="tooltip"` (text-only, no scrim) — consistent with how `learnings_evidence_help` is already surfaced per rule-card.
- Labeled `fix`, not `feat`: this clarifies existing buttons and ships no new capability, so no feature-catalog entry.
- `svelte-check`: 0 errors. Verified live on the dev server.