### PR TITLE
feat(plugins): bind a routed credentialDir into the reviewer sandbox (#1213)

### DIFF
--- a/docs/sandbox-security.md
+++ b/docs/sandbox-security.md
@@ -12,7 +12,7 @@ The egress firewall (slirp4netns + nftables + dnsmasq, shipped in **PR #601**,
 closed **#551** — `src/egress.ts`) confines outbound traffic to
 `api.anthropic.com` + `statsig.anthropic.com` + the GitHub hosts, and watches
 for DNS drops. Egress is keyed to the **autonomous profile**, not to
-attendedness (`src/sandbox.ts` `egressApplies`, ~L532).
+attendedness (`src/sandbox.ts` `egressApplies`, ~L554).
 
 This note records two residuals the operator has **accepted** after the audit.
 
@@ -21,12 +21,12 @@ This note records two residuals the operator has **accepted** after the audit.
 The membrane keeps two token surfaces readable to any in-membrane tool call:
 
 - `~/.claude/.credentials.json` — bound **RW** so OAuth refresh writes back
-  (`src/sandbox.ts:309-311`, `--bind-try`); the whole `~/.claude` dir is
-  `--ro-bind`ed at `src/sandbox.ts:302-304`.
+  (`src/sandbox.ts:315-317`, `--bind-try`); the whole `~/.claude` dir is
+  `--ro-bind`ed at `src/sandbox.ts:308-310`.
 - `~/.config/gh` — bound **RO** (the gh token, needed to `git push` /
-  `gh pr create`) at `src/sandbox.ts:392`.
+  `gh pr create`) at `src/sandbox.ts:413`.
 
-`--clearenv` (`src/sandbox.ts:417`) strips **all** inherited env
+`--clearenv` (`src/sandbox.ts:438`) strips **all** inherited env
 (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `GH_TOKEN`, `SHEPHERD_TOKEN`,
 …), re-setting only HOME/PATH/TERM + non-secret locale vars — so these two
 **bound files** are the only token surfaces left inside the membrane.
@@ -51,7 +51,7 @@ secrets out of the membrane entirely.
 ## Attended-mode egress coverage
 
 Egress confinement is keyed to the autonomous **profile**, not to whether a human
-is watching (`willEgressConfine`, `src/sandbox.ts:544-549`; applied at
+is watching (`willEgressConfine`, `src/sandbox.ts:565-570`; applied at
 `src/service.ts:1374`): the wrap applies iff the autonomous profile resolves
 **and** the fs + egress backends are present, independent of `ctx.auto`.
 Consequences:
@@ -68,7 +68,7 @@ in the repo's Settings panel, or globally via `SHEPHERD_SANDBOX_DEFAULT_PROFILE`
 
 - **Autonomous task agents** run `--dangerously-skip-permissions`, but behind
   **both** the filesystem and the egress membrane. `standard` auto-spawns are
-  refused outright (`src/sandbox.ts` `autoHoldReason`, ~L480-481).
+  refused outright (`src/sandbox.ts` `autoHoldReason`, ~L501-502).
 - **Unattended reviewers** (PR critic + plan-gate) run **read-only**, not
   skip-permissions: `--safe-mode --disable-slash-commands --allowedTools Read
 Grep Glob Bash(git diff *) Bash(git log *) Bash(git show *) Bash(git status)

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -28,7 +28,8 @@ export interface SpawnDescriptor {
   sessionId: string;
   /** What kind of spawn this is (issue #1205). `"session"` is a normal task session
    *  (create/drain/resume); the others are the reviewer-style auto-process spawns that also
-   *  fire onSpawn so a plugin can route their quota (e.g. onto a pool account). */
+   *  fire onSpawn so a plugin can route their quota (e.g. onto a pool account) — see
+   *  {@link SpawnPatch.credentialDir} for how a returned credentialDir is bound (#1213). */
   kind: "session" | "review" | "plan-gate" | "doc";
   /** For an aux spawn tied to a managed session (review, plan-gate): that session's id, so a
    *  plugin can keep the aux spawn on the parent session's account. Undefined for a normal
@@ -61,7 +62,22 @@ export interface SpawnPatch {
   env?: Record<string, string>;
   /** Appended to the inner agent argv. */
   extraArgs?: string[];
-  /** Convenience for `env.CLAUDE_CONFIG_DIR`; overrides it when both are set. */
+  /** Convenience for `env.CLAUDE_CONFIG_DIR`; overrides it when both are set.
+   *
+   *  ROUTING (#1213): for a reviewer-style AUX spawn (`kind` ∈ review/plan-gate/doc) this dir is
+   *  BIND-MOUNTED into the bwrap sandbox (not merely `--setenv`'d), so the reviewer is genuinely
+   *  authenticated under that dir's account — e.g. to route review quota onto a pool account.
+   *  Contract:
+   *   - The dir MUST exist on host (it is hard-bound); a missing dir is ignored with a log and the
+   *     spawn falls open to the active account.
+   *   - Its `projects` subtree is transparently redirected to Shepherd's active projects dir so the
+   *     reviewer transcript stays where usage/activity readback looks — the routed dir need not (and
+   *     does not) accumulate transcripts.
+   *   - The reviewer reads/writes ONLY this dir's own `.claude.json` (its `oauthAccount` is a
+   *     cosmetic display field, not a login); the operator's `~/.claude.json` is never touched, so
+   *     there is no identity cross-contamination or account-mismatch prompt.
+   *   - Routing REQUIRES a sandbox backend: with no backend in api-key mode the credential-less
+   *     mirror is kept (the patched dir's real OAuth creds would otherwise conflict with the key). */
   credentialDir?: string;
 }
 

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -187,6 +187,12 @@ export interface MembraneInputs {
    *  credential-less CLAUDE_CONFIG_DIR mirror (auth-config-dir.ts). Also skips
    *  the rw credentials bind. So no "Use custom API key?"/re-auth prompt fires. */
   maskCredentials?: boolean;
+  /** Host dir to bind AS `<claudeDir>/projects` inside the sandbox. Default
+   *  `<claudeDir>/projects` (source == dest — byte-identical). A plugin-redirected aux
+   *  spawn (#1213) sets this to the ACTIVE projects dir so the reviewer transcript lands
+   *  where Shepherd's usage/activity readback looks (config.claudeProjectsDir via
+   *  jsonlPathFor) even though auth comes from the (pool) claudeDir. */
+  projectsBindSource?: string;
 }
 
 /**
@@ -349,9 +355,12 @@ export function buildMembraneFlags(inputs: MembraneInputs, deps: PathProbeDeps =
     // ── claude config: base RO (auth + commands + skills) ────────────────
     // Subscription: whole-dir RO. api-key: per-child RO minus `.credentials.json`.
     ...claudeDirBaseBinds,
-    // RW: agent writes transcript; host reads it after.
+    // RW: agent writes transcript; host reads it after. The SOURCE defaults to
+    // `<claudeDir>/projects` (source == dest) but a plugin-redirected aux spawn (#1213)
+    // overrides it with the ACTIVE projects dir so the transcript lands where Shepherd's
+    // usage/activity readback looks even when claudeDir is a (pool) config dir.
     "--bind",
-    `${claudeDir}/projects`,
+    inputs.projectsBindSource ?? `${claudeDir}/projects`,
     `${claudeDir}/projects`,
     "--bind-try",
     `${claudeDir}/todos`,
@@ -383,6 +392,18 @@ export function buildMembraneFlags(inputs: MembraneInputs, deps: PathProbeDeps =
     `${home}/.local/bin`,
     `${home}/.local/bin`,
   ];
+
+  // ── config-dir .claude.json (non-default CLAUDE_CONFIG_DIR) ───────────────
+  // When CLAUDE_CONFIG_DIR is non-default (a plugin-redirected pool dir #1213, or a
+  // custom-config-dir operator), Claude reads/writes `.claude.json` from the CONFIG dir
+  // — NOT `$HOME/.claude.json` (see auth-config-dir.ts). The whole-dir/masked binds above
+  // mount that file RO, so rw-override it here (same guard as the CLAUDE_CONFIG_DIR setenv
+  // below) — else Claude can't persist onboarding/project state and non-interactive auto
+  // hangs on onboarding (the same failure the `$HOME/.claude.json` rw bind guards). For the
+  // default `~/.claude` (guard false) nothing is added → flags stay byte-identical.
+  if (claudeDir !== `${home}/.claude`) {
+    f.push("--bind-try", `${claudeDir}/.claude.json`, `${claudeDir}/.claude.json`);
+  }
 
   // ── node toolchain (binary's libs must resolve) ──────────────────────────
   f.push(...nodeToolchainFlags(inputs, exists));

--- a/src/spawn-membrane.ts
+++ b/src/spawn-membrane.ts
@@ -85,7 +85,7 @@ export function resolveSpawnMembrane(args: {
   // (directly or via SpawnPatch.credentialDir). For the credential to actually EXIST inside the
   // bwrap sandbox it must be BOUND, not just --setenv'd: bind the patched dir AS the membrane's
   // claudeDir so buildMembraneFlags mounts it (+ masks/credential-binds + rw-binds its
-  // .claude.json + re-sets CLAUDE_CONFIG_DIR from the bind at sandbox.ts:424). The patched dir's
+  // .claude.json + re-sets CLAUDE_CONFIG_DIR from the bind at sandbox.ts:445). The patched dir's
   // existence is validated upstream (resolveAuxSpawn) so a missing dir never reaches the hard
   // --ro-bind here. To preserve readback, the (pool) claudeDir's `projects` is sourced from the
   // ACTIVE projects dir so the transcript lands where Shepherd's usage/activity readback looks.

--- a/src/spawn-membrane.ts
+++ b/src/spawn-membrane.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { config } from "./config";
 import { apiKeyMembraneFields, apiKeyPassthroughEnv } from "./spawn-auth";
@@ -16,6 +17,10 @@ export interface MembraneEnv {
   home: string;
   nodeBinReal: string;
   extraEnv?: Record<string, string>;
+  /** The ACTIVE projects dir (config.claudeProjectsDir) — where Shepherd's usage/activity
+   *  readback looks. A plugin-redirected aux spawn (#1213) binds THIS as the (pool)
+   *  claudeDir's `projects` so the transcript still lands where readback reads it. */
+  projectsDir?: string;
 }
 
 /** Injectable spawn/membrane seams shared by every reviewer-style spawner. Tests override
@@ -29,6 +34,10 @@ export interface MembraneSeams {
   /** Plugin onSpawn hook runner (issue #1124/#1205). Absent → no hooks run (tests / no
    *  plugins / loader not yet loaded). Wired to PluginRegistry.runSpawnHooks in index.ts. */
   runSpawnHooks?: (d: SpawnDescriptor) => Promise<SpawnPatch>;
+  /** Host path-existence probe (#1213). Default `fs.existsSync`; tests inject. Used to
+   *  validate-and-skip a plugin's patched credentialDir that does not exist on host (the
+   *  wrapped membrane hard `--ro-bind`s it — bwrap would crash on a missing source). */
+  pathExists?: (p: string) => boolean;
 }
 
 /** Backend probe: injected seam (tests) or the real cached self-test. */
@@ -49,6 +58,7 @@ export function resolveMembraneEnv(seams: MembraneSeams): MembraneEnv {
     home: homedir(),
     nodeBinReal: safeRealpath(config.nodeBin),
     extraEnv: collectPassthroughEnv(),
+    projectsDir: config.claudeProjectsDir,
   };
 }
 
@@ -70,15 +80,33 @@ export function resolveSpawnMembrane(args: {
 }): { wrapped: string[]; backend: SandboxBackend } {
   const backend = resolveBackend(args.seams);
   const env = resolveMembraneEnv(args.seams);
+
+  // #1213: a plugin can route the aux spawn onto a pool account by patching CLAUDE_CONFIG_DIR
+  // (directly or via SpawnPatch.credentialDir). For the credential to actually EXIST inside the
+  // bwrap sandbox it must be BOUND, not just --setenv'd: bind the patched dir AS the membrane's
+  // claudeDir so buildMembraneFlags mounts it (+ masks/credential-binds + rw-binds its
+  // .claude.json + re-sets CLAUDE_CONFIG_DIR from the bind at sandbox.ts:424). The patched dir's
+  // existence is validated upstream (resolveAuxSpawn) so a missing dir never reaches the hard
+  // --ro-bind here. To preserve readback, the (pool) claudeDir's `projects` is sourced from the
+  // ACTIVE projects dir so the transcript lands where Shepherd's usage/activity readback looks.
+  const extraEnv = { ...env.extraEnv, ...(args.extraEnv ?? {}) };
+  const patchedDir = args.extraEnv?.CLAUDE_CONFIG_DIR;
+  const redirecting = typeof patchedDir === "string" && patchedDir !== env.claudeDir;
+  if (redirecting) {
+    // buildMembraneFlags re-sets CLAUDE_CONFIG_DIR from the bound claudeDir; drop the duplicate.
+    delete extraEnv.CLAUDE_CONFIG_DIR;
+  }
+
   const membrane: MembraneInputs = {
     worktreePath: args.worktreePath,
     gitCommonDir: args.worktree.gitCommonDir(args.worktreePath),
     isolated: true,
     repoPath: args.repoPath,
-    claudeDir: env.claudeDir,
+    claudeDir: redirecting ? (patchedDir as string) : env.claudeDir,
     home: env.home,
     nodeBinReal: env.nodeBinReal,
-    extraEnv: { ...env.extraEnv, ...(args.extraEnv ?? {}) },
+    extraEnv,
+    ...(redirecting ? { projectsBindSource: env.projectsDir ?? `${env.claudeDir}/projects` } : {}),
     // api-key mode: a bwrap-wrapped reviewer masks the OAuth credential + binds the helper.
     ...apiKeyMembraneFields(),
   };
@@ -99,6 +127,64 @@ export function foldSpawnPatch(
     ...(patch.credentialDir ? { CLAUDE_CONFIG_DIR: patch.credentialDir } : {}),
   };
   const finalArgv = patch.extraArgs?.length ? [...innerArgv, ...patch.extraArgs] : innerArgv;
+  return { patchEnv, finalArgv };
+}
+
+/** Run the plugin onSpawn hook (if wired), fold the returned patch, and validate-and-skip a
+ *  routed credentialDir (#1213). Returns the folded `{ patchEnv, finalArgv }`, or `{ aborted }`
+ *  when a hook calls ctx.abortSpawn. Extracted from resolveAuxSpawn to keep that tail flat. */
+async function foldAuxPatch(
+  args: {
+    argv: string[];
+    repoPath: string;
+    seams: MembraneSeams;
+    descriptor: {
+      sessionId: string;
+      kind: SpawnDescriptor["kind"];
+      parentSessionId?: string;
+      model?: string | null;
+      agentProvider?: string;
+    };
+  },
+  baseEnv: Record<string, string> | undefined,
+): Promise<
+  { patchEnv: Record<string, string>; finalArgv: string[] } | { aborted: PluginSpawnAborted }
+> {
+  if (!args.seams.runSpawnHooks) return { patchEnv: {}, finalArgv: args.argv };
+
+  let patch: SpawnPatch;
+  try {
+    patch = await args.seams.runSpawnHooks({
+      sessionId: args.descriptor.sessionId,
+      kind: args.descriptor.kind,
+      parentSessionId: args.descriptor.parentSessionId,
+      repoRoot: args.repoPath,
+      model: args.descriptor.model ?? null,
+      agentProvider: args.descriptor.agentProvider ?? config.defaultAgentProvider,
+      argv: [...args.argv],
+      env: baseEnv ?? {},
+      isolated: true,
+    });
+  } catch (e) {
+    if (e instanceof PluginSpawnAborted) return { aborted: e };
+    throw e;
+  }
+
+  const { patchEnv, finalArgv } = foldSpawnPatch(args.argv, patch);
+
+  // #1213 validate-and-skip: a routed credentialDir must EXIST on host. The wrapped membrane hard
+  // `--ro-bind`s it (bwrap crashes on a missing source); the unwrapped path would create an empty
+  // dir → unauthenticated. Either way, drop a non-existent dir and fall OPEN to the active account,
+  // logging so the misconfig is visible (rather than an opaque crash or silent re-login).
+  const routed = patchEnv.CLAUDE_CONFIG_DIR;
+  const pathExists = args.seams.pathExists ?? existsSync;
+  if (typeof routed === "string" && routed.length > 0 && !pathExists(routed)) {
+    console.warn(
+      `[spawn] plugin credentialDir not found on host; falling back to the active account: ${routed}`,
+    );
+    delete patchEnv.CLAUDE_CONFIG_DIR;
+  }
+
   return { patchEnv, finalArgv };
 }
 
@@ -133,28 +219,9 @@ export async function resolveAuxSpawn(args: {
   // mirror dir; with a backend the membrane masks creds in place and this is undefined.
   const baseEnv = apiKeyPassthroughEnv(backend !== null);
 
-  let patchEnv: Record<string, string> = {};
-  let finalArgv = args.argv;
-  if (args.seams.runSpawnHooks) {
-    let patch: SpawnPatch;
-    try {
-      patch = await args.seams.runSpawnHooks({
-        sessionId: args.descriptor.sessionId,
-        kind: args.descriptor.kind,
-        parentSessionId: args.descriptor.parentSessionId,
-        repoRoot: args.repoPath,
-        model: args.descriptor.model ?? null,
-        agentProvider: args.descriptor.agentProvider ?? config.defaultAgentProvider,
-        argv: [...args.argv],
-        env: baseEnv ?? {},
-        isolated: true,
-      });
-    } catch (e) {
-      if (e instanceof PluginSpawnAborted) return { aborted: e };
-      throw e;
-    }
-    ({ patchEnv, finalArgv } = foldSpawnPatch(args.argv, patch));
-  }
+  const folded = await foldAuxPatch(args, baseEnv);
+  if ("aborted" in folded) return folded;
+  const { patchEnv, finalArgv } = folded;
 
   const { wrapped } = resolveSpawnMembrane({
     argv: finalArgv,
@@ -165,8 +232,14 @@ export async function resolveAuxSpawn(args: {
     extraEnv: patchEnv,
   });
 
-  // patchEnv LAST so a patched CLAUDE_CONFIG_DIR wins over apiKeyPassthroughEnv's mirror.
-  const merged = { ...(baseEnv ?? {}), ...patchEnv };
+  // Merge order. Normally patchEnv LAST so a patched CLAUDE_CONFIG_DIR wins over
+  // apiKeyPassthroughEnv's mirror. EXCEPTION (#1213): api-key + NO backend — baseEnv is truthy ONLY
+  // then (the credential-less mirror) and there is NO sandbox to mask creds, so a pool
+  // CLAUDE_CONFIG_DIR (real .credentials.json on host) would reintroduce the "Use custom API key?"
+  // prompt / misbill the pool's OAuth subscription. There the mirror WINS; credential routing onto
+  // a pool account requires a sandbox backend (which masks creds in place).
+  const merged =
+    backend === null && baseEnv ? { ...patchEnv, ...baseEnv } : { ...(baseEnv ?? {}), ...patchEnv };
   const spawnEnv = Object.keys(merged).length ? merged : undefined;
   return { wrapped, spawnEnv };
 }

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -2588,6 +2588,9 @@ test("findSquatter: empty label does NOT match an unnamed agent whose cwd differ
 test("critic: onSpawn fires (kind=review, parentSessionId) and binds credentialDir through to the spawn env", async () => {
   let seen: any;
   const { deps: d, started } = makeDeps({
+    // The plugin's pool dir exists on host (#1213 validate-and-skip would otherwise drop a
+    // non-existent dir and fall open to the active account).
+    pathExists: () => true,
     runSpawnHooks: async (desc: any) => {
       seen = desc;
       return { credentialDir: "/pool/acct-2" };

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -563,6 +563,65 @@ describe("buildMembraneFlags", () => {
     expect(hasTriple(f, "--ro-bind-try", "/h/x.sh", "/h/x.sh")).toBe(true);
   });
 
+  test("projectsBindSource overrides the projects bind SOURCE; dest stays <claudeDir>/projects (#1213)", () => {
+    // source = active projects dir, dest = pool projects → transcript lands where readback looks.
+    const f = buildMembraneFlags(
+      fakeMembrane({ claudeDir: "/pool/x", projectsBindSource: "/active/projects" }),
+      detDeps,
+    );
+    expect(hasTriple(f, "--bind", "/active/projects", "/pool/x/projects")).toBe(true);
+    // absent → source == dest → byte-identical default.
+    const g = buildMembraneFlags(fakeMembrane({ claudeDir: "/pool/x" }), detDeps);
+    expect(hasTriple(g, "--bind", "/pool/x/projects", "/pool/x/projects")).toBe(true);
+  });
+
+  test("config-dir .claude.json rw bind only when CLAUDE_CONFIG_DIR is non-default (#1213)", () => {
+    // Non-default config dir (pool redirect / custom operator) → rw-bind <claudeDir>/.claude.json
+    // so Claude can persist onboarding/project state (it reads .claude.json from the config dir).
+    const f = buildMembraneFlags(fakeMembrane({ home: "/home/me", claudeDir: "/pool/x" }), detDeps);
+    expect(hasTriple(f, "--bind-try", "/pool/x/.claude.json", "/pool/x/.claude.json")).toBe(true);
+    // Default ~/.claude → NOT added (default path stays byte-identical; Claude reads $HOME/.claude.json).
+    const g = buildMembraneFlags(
+      fakeMembrane({ home: "/home/me", claudeDir: "/home/me/.claude" }),
+      detDeps,
+    );
+    expect(
+      hasTriple(g, "--bind-try", "/home/me/.claude/.claude.json", "/home/me/.claude/.claude.json"),
+    ).toBe(false);
+  });
+
+  test("api-key redirect: masks the POOL dir per-child minus creds, projects source=active, .claude.json rw (#1213)", () => {
+    const f = buildMembraneFlags(
+      fakeMembrane({
+        home: "/home/me",
+        claudeDir: "/pool/x",
+        maskCredentials: true,
+        apiKeyHelperPath: "/helper.sh",
+        projectsBindSource: "/active/projects",
+      }),
+      {
+        ...detDeps,
+        readdir: () => [".credentials.json", "projects", "settings.json", ".claude.json"],
+      },
+    );
+    // The POOL dir is masked per-child (no whole-dir RO bind); its mount point exists via --dir.
+    expect(hasTriple(f, "--ro-bind", "/pool/x", "/pool/x")).toBe(false);
+    const di = f.indexOf("--dir");
+    expect(f[di + 1]).toBe("/pool/x");
+    // Per-child RO bind for a non-credential child of the POOL dir.
+    expect(hasTriple(f, "--ro-bind-try", "/pool/x/settings.json", "/pool/x/settings.json")).toBe(
+      true,
+    );
+    // The POOL dir's .credentials.json is NEVER bound (genuinely absent) — no rw cred bind either.
+    expect(f.includes("/pool/x/.credentials.json")).toBe(false);
+    // api-key helper bound RO.
+    expect(hasTriple(f, "--ro-bind-try", "/helper.sh", "/helper.sh")).toBe(true);
+    // projects bind SOURCE = active projects dir (readback preserved).
+    expect(hasTriple(f, "--bind", "/active/projects", "/pool/x/projects")).toBe(true);
+    // config-dir .claude.json rw override (beats the masked per-child RO).
+    expect(hasTriple(f, "--bind-try", "/pool/x/.claude.json", "/pool/x/.claude.json")).toBe(true);
+  });
+
   test("session-env tmpfs carve-out present in subscription mode", () => {
     const f = buildMembraneFlags(fakeMembrane(), detDeps);
     const claudeDir = "/home/me/.claude";

--- a/test/spawn-membrane.test.ts
+++ b/test/spawn-membrane.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
 import {
   resolveBackend,
   resolveMembraneEnv,
@@ -8,13 +8,51 @@ import {
   type MembraneEnv,
 } from "../src/spawn-membrane";
 import { PluginSpawnAborted } from "../src/plugins/types";
+import { config } from "../src/config";
+import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
 
 const stubEnv: MembraneEnv = {
   claudeDir: "/stub/.claude",
   home: "/stub/home",
   nodeBinReal: "/stub/bin/node",
   extraEnv: { LANG: "C.UTF-8" },
+  // Active projects dir — distinct from claudeDir so #1213 redirect assertions are unambiguous.
+  projectsDir: "/stub/projects",
 };
+
+const MIRROR = "/tmp/shepherd-test-apikey-config";
+beforeEach(() => {
+  __setApiKeyConfigDirProvisionForTest(() => MIRROR);
+});
+afterEach(() => {
+  __setApiKeyConfigDirProvisionForTest(null);
+});
+
+/** Run `fn` with `config.authMode`/helper swapped (api-key tests), restored after. */
+async function withAuth<T>(
+  mode: typeof config.authMode,
+  helper: string | null,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prevMode = config.authMode;
+  const prevPath = config.authApiKeyHelperPath;
+  config.authMode = mode;
+  config.authApiKeyHelperPath = helper;
+  try {
+    return await fn();
+  } finally {
+    config.authMode = prevMode;
+    config.authApiKeyHelperPath = prevPath;
+  }
+}
+
+/** Assert `flags` contains the contiguous triple [flag, a, b]. */
+function hasTriple(flags: string[], flag: string, a: string, b: string): boolean {
+  for (let i = 0; i + 2 < flags.length; i++) {
+    if (flags[i] === flag && flags[i + 1] === a && flags[i + 2] === b) return true;
+  }
+  return false;
+}
 
 function worktreeStub(gitCommonDirCalls?: string[]) {
   return {
@@ -170,7 +208,7 @@ describe("resolveAuxSpawn", () => {
     expect(d.argv).toEqual(["claude", "--x"]);
   });
 
-  test("patched credentialDir rides the membrane --setenv (backend present)", async () => {
+  test("patched credentialDir is BOUND as claudeDir in the membrane, projects source=active (#1213)", async () => {
     const result = await resolveAuxSpawn({
       argv: ["claude"],
       worktreePath: "/wt/task",
@@ -179,6 +217,7 @@ describe("resolveAuxSpawn", () => {
       seams: {
         detectBackend: () => "bwrap",
         membraneEnv: () => stubEnv,
+        pathExists: () => true,
         runSpawnHooks: async () => ({ credentialDir: "/pool/acct-3" }),
       },
       descriptor: { sessionId: "s-1", kind: "review" },
@@ -186,10 +225,153 @@ describe("resolveAuxSpawn", () => {
 
     expect("aborted" in result).toBe(false);
     if ("aborted" in result) throw new Error("unexpected abort");
-    expect(result.wrapped[0]).toBe("bwrap");
-    const i = result.wrapped.lastIndexOf("CLAUDE_CONFIG_DIR");
-    expect(i).toBeGreaterThan(-1);
-    expect(result.wrapped[i + 1]).toBe("/pool/acct-3");
+    const f = result.wrapped;
+    expect(f[0]).toBe("bwrap");
+    // The pool dir is actually BOUND (the bug: previously only --setenv, never mounted).
+    expect(hasTriple(f, "--ro-bind", "/pool/acct-3", "/pool/acct-3")).toBe(true);
+    // projects bind SOURCE = active projects dir, DEST = pool projects → readback preserved.
+    expect(hasTriple(f, "--bind", "/stub/projects", "/pool/acct-3/projects")).toBe(true);
+    // config-dir .claude.json rw-bound so onboarding/project state persists.
+    expect(
+      hasTriple(f, "--bind-try", "/pool/acct-3/.claude.json", "/pool/acct-3/.claude.json"),
+    ).toBe(true);
+    // CLAUDE_CONFIG_DIR set from the bind, exactly once (no duplicate from the patch env).
+    expect(f.filter((x) => x === "CLAUDE_CONFIG_DIR").length).toBe(1);
+    const i = f.lastIndexOf("CLAUDE_CONFIG_DIR");
+    expect(f[i + 1]).toBe("/pool/acct-3");
+  });
+
+  test("api-key WRAPPED redirect: masks the pool dir, binds helper, projects source=active (#1213)", async () => {
+    const result = await withAuth("api-key", "/helper.sh", async () =>
+      resolveAuxSpawn({
+        argv: ["claude"],
+        worktreePath: "/wt/task",
+        repoPath: "/repo",
+        worktree: worktreeStub(),
+        seams: {
+          detectBackend: () => "bwrap",
+          membraneEnv: () => stubEnv,
+          pathExists: () => true,
+          runSpawnHooks: async () => ({ credentialDir: "/pool/acct-5" }),
+        },
+        descriptor: { sessionId: "s-1", kind: "review" },
+      }),
+    );
+
+    expect("aborted" in result).toBe(false);
+    if ("aborted" in result) throw new Error("unexpected abort");
+    const f = result.wrapped;
+    // maskCredentials path: NO whole-dir RO bind of the pool dir; masked mount point via --dir.
+    expect(hasTriple(f, "--ro-bind", "/pool/acct-5", "/pool/acct-5")).toBe(false);
+    const di = f.indexOf("--dir");
+    expect(f[di + 1]).toBe("/pool/acct-5");
+    // No rw credential bind of the pool dir (creds masked absent).
+    expect(
+      hasTriple(
+        f,
+        "--bind-try",
+        "/pool/acct-5/.credentials.json",
+        "/pool/acct-5/.credentials.json",
+      ),
+    ).toBe(false);
+    // api-key helper RO-bound.
+    expect(hasTriple(f, "--ro-bind-try", "/helper.sh", "/helper.sh")).toBe(true);
+    // projects bind SOURCE = active projects dir (readback preserved even under api-key routing).
+    expect(hasTriple(f, "--bind", "/stub/projects", "/pool/acct-5/projects")).toBe(true);
+  });
+
+  test("api-key + NO backend: credential-less mirror WINS over a routed credentialDir (#1213)", async () => {
+    const result = await withAuth("api-key", "/helper.sh", async () =>
+      resolveAuxSpawn({
+        argv: ["claude"],
+        worktreePath: "/wt/task",
+        repoPath: "/repo",
+        worktree: worktreeStub(),
+        seams: {
+          detectBackend: () => null,
+          membraneEnv: () => stubEnv,
+          pathExists: () => true, // dir EXISTS, yet the mirror must still win (no sandbox to mask).
+          runSpawnHooks: async () => ({ credentialDir: "/pool/acct-9" }),
+        },
+        descriptor: { sessionId: "s-1", kind: "review" },
+      }),
+    );
+
+    expect("aborted" in result).toBe(false);
+    if ("aborted" in result) throw new Error("unexpected abort");
+    // The pool dir's real OAuth creds would conflict with the key — the mirror wins.
+    expect(result.spawnEnv?.CLAUDE_CONFIG_DIR).toBe(MIRROR);
+  });
+
+  test("non-existent credentialDir is ignored → fails open to the active account (#1213)", async () => {
+    const prevWarn = console.warn;
+    let warned = "";
+    console.warn = (...a: unknown[]) => {
+      warned += a.map(String).join(" ");
+    };
+    let result;
+    try {
+      result = await resolveAuxSpawn({
+        argv: ["claude"],
+        worktreePath: "/wt/task",
+        repoPath: "/repo",
+        worktree: worktreeStub(),
+        seams: {
+          detectBackend: () => "bwrap",
+          membraneEnv: () => stubEnv,
+          pathExists: () => false, // the patched dir does not exist on host
+          runSpawnHooks: async () => ({ credentialDir: "/pool/missing" }),
+        },
+        descriptor: { sessionId: "s-1", kind: "review" },
+      });
+    } finally {
+      console.warn = prevWarn;
+    }
+
+    expect("aborted" in result).toBe(false);
+    if ("aborted" in result) throw new Error("unexpected abort");
+    const f = result.wrapped;
+    // NOT redirected: the missing pool dir is never referenced; the active dir is bound instead.
+    expect(f.some((x) => x.includes("/pool/missing"))).toBe(false);
+    expect(hasTriple(f, "--ro-bind", "/stub/.claude", "/stub/.claude")).toBe(true);
+    expect(warned).toContain("/pool/missing");
+  });
+
+  test("redirect to ${home}/.claude with a custom active dir: no CLAUDE_CONFIG_DIR setenv (relies on default) (#1213)", async () => {
+    // Edge (reviewer point 4): pool dir == ${home}/.claude while the active config dir is custom.
+    // The guard `claudeDir !== ${home}/.claude` (shared by the setenv + the config-dir .claude.json
+    // bind) is FALSE → no CLAUDE_CONFIG_DIR is set (Claude defaults to ~/.claude, which IS bound)
+    // and no config-dir .claude.json bind is added. Intentional and benign.
+    const result = await resolveAuxSpawn({
+      argv: ["claude"],
+      worktreePath: "/wt/task",
+      repoPath: "/repo",
+      worktree: worktreeStub(),
+      seams: {
+        detectBackend: () => "bwrap",
+        membraneEnv: () => stubEnv, // claudeDir "/stub/.claude", home "/stub/home"
+        pathExists: () => true,
+        runSpawnHooks: async () => ({ credentialDir: "/stub/home/.claude" }),
+      },
+      descriptor: { sessionId: "s-1", kind: "review" },
+    });
+
+    expect("aborted" in result).toBe(false);
+    if ("aborted" in result) throw new Error("unexpected abort");
+    const f = result.wrapped;
+    // pool (== ~/.claude) is bound; projects source = active projects dir.
+    expect(hasTriple(f, "--ro-bind", "/stub/home/.claude", "/stub/home/.claude")).toBe(true);
+    expect(hasTriple(f, "--bind", "/stub/projects", "/stub/home/.claude/projects")).toBe(true);
+    // No CLAUDE_CONFIG_DIR setenv (relies on Claude's default) and no config-dir .claude.json bind.
+    expect(f.includes("CLAUDE_CONFIG_DIR")).toBe(false);
+    expect(
+      hasTriple(
+        f,
+        "--bind-try",
+        "/stub/home/.claude/.claude.json",
+        "/stub/home/.claude/.claude.json",
+      ),
+    ).toBe(false);
   });
 
   test("patched credentialDir in spawnEnv without a backend (passthrough)", async () => {
@@ -201,6 +383,7 @@ describe("resolveAuxSpawn", () => {
       seams: {
         detectBackend: () => null,
         membraneEnv: () => stubEnv,
+        pathExists: () => true,
         runSpawnHooks: async () => ({ credentialDir: "/pool/acct-7" }),
       },
       descriptor: { sessionId: "s-1", kind: "review" },


### PR DESCRIPTION
Closes #1213.

## Problem

Since #1205, `onSpawn` fires for reviewer-style aux spawns (`kind` ∈ `review`/`plan-gate`/`doc`/standalone-critic), so a plugin can route their quota onto a pool account. But it couldn't work end-to-end: aux spawns run in a bwrap `"standard"` sandbox that bind-mounts **only** the active `claudeDir`. A plugin's patched `CLAUDE_CONFIG_DIR` was threaded into `--setenv` **only**, never the bind list — so a routed pool dir resolved to the empty tmpfs `HOME` → the reviewer launched **unauthenticated** (re-login + theme prompt). The env var and the bind were decoupled.

## Fix (Option 1 + 2, minimal)

- **Bind the patched dir as the membrane `claudeDir`** (`resolveSpawnMembrane`) when a plugin patches `CLAUDE_CONFIG_DIR`, so `buildMembraneFlags` mounts it, masks/credential-binds it, and re-sets the env **from the bind** (no duplicate `--setenv`).
- **Preserve readback**: redirect only the pool dir's `projects` bind *source* to the active projects dir (new `MembraneInputs.projectsBindSource`), so the reviewer transcript still lands in `config.claudeProjectsDir` where usage + the live activity signal are read.
- **`.claude.json` rw bind**: when `CLAUDE_CONFIG_DIR` is non-default, rw-bind `<claudeDir>/.claude.json` (Claude reads/writes it from the config dir, not `$HOME` — verified in `auth-config-dir.ts`) so onboarding/project state persists and the run doesn't hang on onboarding. Its `oauthAccount` is a display-only field, so the operator's `~/.claude.json` is never touched — no identity cross-contamination or account-mismatch prompt.
- **Validate-and-fail-open**: a `credentialDir` that doesn't exist on host is dropped with a log (falls back to the active account) — never a raw bwrap crash on the hard `--ro-bind`.
- **api-key + no backend**: keep the credential-less mirror (there's no sandbox to mask creds → a pool dir's real OAuth creds would conflict with the key / misbill). Credential routing requires a sandbox backend; documented.
- **Contract documented** in `src/plugins/types.ts` (`SpawnPatch.credentialDir`).

### Auth-mode correctness

| backend | mode | result |
| --- | --- | --- |
| present | subscription | pool dir bound RO + `.credentials.json` rw → pool OAuth; `.claude.json` rw → no onboarding hang |
| present | api-key | `maskCredentials` masks pool `.credentials.json` + binds helper → key bills, no prompt |
| null | subscription | unsandboxed on host fs, `CLAUDE_CONFIG_DIR=<pool>` → pool creds+config directly → pool OAuth |
| null | api-key | credential-less mirror **wins** → key bills, no prompt (routing no-op) |

## Tests

`test/spawn-membrane.test.ts` + `test/sandbox.test.ts`: subscription & api-key **wrapped** redirect (pool dir bound/masked, helper bound, no rw cred bind, `projects` source = active, `.claude.json` rw, `CLAUDE_CONFIG_DIR` set exactly once); api-key + no-backend mirror-wins; missing-dir fail-open; the `pool == ~/.claude` vs custom-active edge; `projectsBindSource` default stays byte-identical. `test/review.test.ts` updated for the new validation seam.

Default (no plugin patch, default `~/.claude`) membrane flags are **byte-for-byte unchanged**. Server-only — no UI / i18n / feature-catalog impact. `bun run lint`, `bun run typecheck`, `bun test ./test` (5242 pass) and `fallow audit` all green. `[no-feature-entry]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)