### PR TITLE
fix(prettier): ignore .shepherd-* session artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,16 +17,12 @@ dist/
 .shaping/
 .squad/
 
-# Runtime upload staging (New-Task attachments, screenshots)
-.shepherd-uploads/
-
-# Plan-gate working artifacts written into the live worktree (never committed)
-.shepherd-plan.md
-.shepherd-plan-blocks.json
-.shepherd-plan-review.json
-
-# Agent-declared live-preview port hint (transient, never committed)
-.shepherd-preview
+# Shepherd per-session scratch artifacts — plan-gate docs, preview-port hint, upload
+# staging (New-Task attachments/screenshots), recap/name/learnings/… . This catch-all
+# glob mirrors the LOCAL-ONLY .git/info/exclude block (SHEPHERD_IGNORE_GLOB in
+# src/shepherd-exclude.ts) so teammates & CI ignore every artifact too. Matches
+# .shepherd-uploads/ as well as all .shepherd-* files.
+.shepherd-*
 
 # Onboarding-harness gap report — generated into cwd by ci/onboarding-harness/run.ts
 onboarding-gap-report.md
@@ -45,6 +41,5 @@ ci/self-hosted-runner/.env
 # Pre-push test capture logs (flake diagnosis, #817)
 .test-logs/
 
-# SDD subagent scratch (briefs) + plan sidecar
+# SDD subagent scratch (briefs); the plan sidecar is covered by .shepherd-* above
 briefs/
-.shepherd-plan-blocks.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -29,10 +29,11 @@ extension/public/picker.js
 # Transient agent worktrees (nested checkouts; not project source)
 .claude/worktrees
 
-# Shepherd per-session scratch artifacts. Shepherd hides these via the LOCAL-ONLY
-# .git/info/exclude (the .shepherd-* glob, src/shepherd-exclude.ts) — which prettier
-# does NOT read — so without this line `prettier --check .` flags the ones not also
-# named in .gitignore (e.g. .shepherd-recap.json). Same rationale as .cache above.
+# Shepherd per-session scratch artifacts (the .shepherd-* glob, src/shepherd-exclude.ts).
+# This is the RELIABLE ignore: although .shepherd-* is also in .gitignore, prettier's
+# .gitignore support is only partial (it skips nested .gitignore, and per #1192 still
+# traversed gitignored .cache) and it never reads the LOCAL-ONLY .git/info/exclude where
+# Shepherd hides these on every worktree. Same rationale as .cache above.
 .shepherd-*
 
 # Agent-generated planning artifacts — leave their formatting alone

--- a/.prettierignore
+++ b/.prettierignore
@@ -29,6 +29,12 @@ extension/public/picker.js
 # Transient agent worktrees (nested checkouts; not project source)
 .claude/worktrees
 
+# Shepherd per-session scratch artifacts. Shepherd hides these via the LOCAL-ONLY
+# .git/info/exclude (the .shepherd-* glob, src/shepherd-exclude.ts) — which prettier
+# does NOT read — so without this line `prettier --check .` flags the ones not also
+# named in .gitignore (e.g. .shepherd-recap.json). Same rationale as .cache above.
+.shepherd-*
+
 # Agent-generated planning artifacts — leave their formatting alone
 docs/superpowers
 

--- a/src/readiness.ts
+++ b/src/readiness.ts
@@ -13,6 +13,7 @@
 
 import { existsSync, readFileSync, readdirSync, type Dirent } from "node:fs";
 import { join } from "node:path";
+import { SHEPHERD_IGNORE_GLOB } from "./shepherd-exclude";
 
 export type GuardrailId =
   | "formatter"
@@ -401,6 +402,14 @@ re-explain a mechanical defect.
 ## Adopt these guardrails (highest leverage first)
 
 ${adoptLines}
+
+## Ignore Shepherd's session artifacts in your formatter
+
+Shepherd writes \`${SHEPHERD_IGNORE_GLOB}\` scratch files into your worktree, hidden
+locally via \`.git/info/exclude\` — which Prettier does NOT read. So if you run
+Prettier, add \`${SHEPHERD_IGNORE_GLOB}\` to your \`.prettierignore\` (run
+\`echo '${SHEPHERD_IGNORE_GLOB}' >> .prettierignore\`), or it will reformat Shepherd's
+artifacts. \`.gitignore\` alone is not reliable here.
 `;
 }
 

--- a/test/readiness.test.ts
+++ b/test/readiness.test.ts
@@ -203,6 +203,23 @@ test("generated CLAUDE.md is non-empty, encodes the surgical posture, and names 
   expect(r.claudeMd.toLowerCase()).toContain("prettier");
 });
 
+test("CLAUDE.md always tells the repo to add .shepherd-* to .prettierignore, even when prettier is already present", () => {
+  // Prettier present → the formatter guardrail is satisfied and emits no adopt-step,
+  // but the artifact note must still render (this is the higher-impact case: an
+  // existing prettier would otherwise reformat Shepherd's scratch files).
+  pkg({
+    name: "has-prettier",
+    devDependencies: { prettier: "^3" },
+    scripts: { format: "prettier --write ." },
+  });
+  write(".prettierrc", "{}");
+  const r = analyzeReadiness(dir);
+  expect(present("formatter", r)).toBe(true);
+  expect(r.claudeMd).toContain(".shepherd-*");
+  expect(r.claudeMd).toContain(".prettierignore");
+  expect(r.claudeMd).toContain("echo '.shepherd-*' >> .prettierignore");
+});
+
 test("adopt-list (absent guardrails sorted by leverage) leads with pre-push CI mirror", () => {
   pkg({ name: "empty-ish" });
   const r = analyzeReadiness(dir);


### PR DESCRIPTION
## Problem

Prettier does **not** read `.git/info/exclude`, which is Shepherd's primary
hide mechanism for its per-session scratch files (the `.shepherd-*` glob, written
by `src/shepherd-exclude.ts` on every worktree). So `prettier --check .` flags any
`.shepherd-*` file not *also* named in the committed `.gitignore` — verified: a
misformatted `.shepherd-recap.json` was flagged.

Empirically re-verified (prettier 3.8.5, deliberately misformatted files):

| File | Ignored via | `prettier --check` |
|------|-------------|--------------------|
| `.shepherd-recap.json` | `.git/info/exclude` only | **FLAGGED** |
| `zzqtest/ignored.json` | nested `.gitignore` | **FLAGGED** |
| `.shepherd-plan.md`, `.test-logs/`, `.fallow/` | root `.gitignore` | not flagged |
| `CHANGELOG.md` (tracked) | `.prettierignore` only | not flagged |

Prettier's `.gitignore` support is partial (nested `.gitignore` not honored) and
diverges from git — matching the repo's #1192 history. So `.prettierignore` is
treated as the only **reliable** mechanism.

## Changes

- **`.prettierignore`** — add `.shepherd-*` (primary fix; same rationale as `.cache`).
- **`.gitignore`** — consolidate the named `.shepherd-*` entries + a stray duplicate
  into one `.shepherd-*` glob block (orthogonal git/CI/teammate hygiene; mirrors the
  `info/exclude` glob). Not relied on for the Prettier fix.
- **`src/readiness.ts`** — add an always-shown note to the generated AI-readiness
  `CLAUDE.md` telling 3rd-party repos that adopt Prettier to add `.shepherd-*` to
  their `.prettierignore`. Shown regardless of whether the repo already runs Prettier
  (that's the higher-impact case). Glob sourced from `SHEPHERD_IGNORE_GLOB` — no second
  hardcoded string.
- **`test/readiness.test.ts`** — assert the note renders even when a formatter is
  already present.

## Verification

- Misformatted `.shepherd-recap.json` no longer flagged by `prettier --check .`.
- `bun run lint` clean; `bun test ./test` (readiness 21/21) green; full `prettier --check .` clean.
- All pre-push gates pass (incl. fallow audit, ui, root-tests).

Notes: generated `claudeMd` is a verbatim target-repo artifact (i18n-exempt); server-only
content change with no new UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)