### PR TITLE
fix(review): gate verdict finalize on process liveness, not agentStatus

### DIFF
--- a/src/json-tolerant.ts
+++ b/src/json-tolerant.ts
@@ -12,9 +12,16 @@
  * and reports whether repair was needed (`repaired`) — because a repaired parse is NOT trustworthy
  * on its own: jsonrepair will also "close up" a TRUNCATED partial write into a shape-valid but
  * incomplete object. Callers therefore trust a repaired parse only once the spawn has finished
- * (or the hard timeout fires), which `isSpawnWorking` answers.
+ * (or the hard timeout fires), which `isSpawnWorking` and `isSpawnAlive` answer.
  */
 import { jsonrepair } from "jsonrepair";
+
+/**
+ * Foreground process names that mean "just an idle shell" (a husk PTY). Shared with
+ * `src/tab-reaper.ts` (single source of truth — tab-reaper imports this constant back).
+ * A verdict spawn whose foreground is *only* shell entries has nothing running in it.
+ */
+export const SHELLS = new Set(["zsh", "bash", "sh", "fish", "dash"]);
 
 export type TolerantParse =
   | { status: "ok"; value: unknown; repaired: boolean } // repaired=false ⇒ strict JSON.parse succeeded
@@ -70,6 +77,48 @@ export function isSpawnWorking(
 ): boolean {
   const a = agents.find((x) => x.cwd === cwd);
   return !!a && a.agentStatus === "working";
+}
+
+/**
+ * Ground-truth process-liveness check for a verdict spawn. Uses `paneForegroundProcs`
+ * (the same signal `tab-reaper.ts` uses) instead of the transient `agentStatus` field,
+ * so a live-but-idle critic between API turns is never misclassified as finished.
+ *
+ * Decision table (applied only when `agentStatus !== "working"`):
+ *   - cwd absent from list              → **dead** — true absence under herdr 0.7.
+ *   - `list()` throws                   → **alive** (fail-closed; never reap on read error).
+ *   - `paneForegroundProcs` throws      → **alive** (fail-closed; transient herdr blip).
+ *   - empty proc list                   → **alive** (undeterminable; fail-closed).
+ *   - any non-shell proc present        → **alive** (claude/node/etc. still running).
+ *   - shell-only (`procs.every(SHELLS)`) → **dead** (husk PTY; matches observed startup-death shape).
+ *
+ * Fast path: `agentStatus === "working"` → **alive** without a `paneForegroundProcs` call.
+ *
+ * Never throws — all `list()` and `paneForegroundProcs` errors are caught internally so a
+ * transient herdr blip yields `finished=false → wait` rather than propagating and wedging
+ * the tick's try-catch. Callers may still wrap in their own try for defense-in-depth.
+ */
+export async function isSpawnAlive(
+  herdr: {
+    list: () => { cwd: string; paneId: string; agentStatus: string }[];
+    paneForegroundProcs: (paneId: string) => Promise<string[]>;
+  },
+  cwd: string,
+): Promise<boolean> {
+  try {
+    const agent = herdr.list().find((x) => x.cwd === cwd);
+    if (!agent) return false; // absent from list → genuinely dead (herdr 0.7: husks persist in list)
+    if (agent.agentStatus === "working") return true; // fast path — skip process-info call
+    try {
+      const procs = await herdr.paneForegroundProcs(agent.paneId);
+      if (procs.length === 0) return true; // undeterminable → fail-closed alive
+      return !procs.every((p) => SHELLS.has(p)); // shell-only → dead; any non-shell → alive
+    } catch {
+      return true; // paneForegroundProcs failure → fail-closed alive
+    }
+  } catch {
+    return true; // list() failure → fail-closed alive
+  }
 }
 
 /** What a verdict finalize-loop should do this tick. */

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -38,7 +38,6 @@ import { groundBlocks, type VisualBlock } from "./visual-blocks";
 import {
   tolerantParseJson,
   isSpawnAlive,
-  isSpawnWorking,
   decideVerdictAction,
   STARTUP_GRACE_MS,
 } from "./json-tolerant";
@@ -230,16 +229,6 @@ export class RecapService {
   /** Find a recap spawn's live terminal by its tmpdir cwd. "" when gone; herdr.stop("") is a no-op. */
   private resolveTerminal(cwd: string): string {
     return this.deps.herdr.list().find((a) => a.cwd === cwd)?.terminalId ?? "";
-  }
-
-  /**
-   * Has the recap spawn at `cwd` finished producing output? True when its herdr agent is gone or no
-   * longer "working" — used to gate acting on a repaired/unparseable verdict (don't trust/fail on a
-   * file that may still be mid-write). See isSpawnWorking for the residual-flicker race; the hard
-   * timeout in tick() is the true backstop.
-   */
-  private spawnFinished(cwd: string): boolean {
-    return !isSpawnWorking(this.deps.herdr.list(), cwd);
   }
 
   // ── reapGenerating ───────────────────────────────────────────────────────────
@@ -529,8 +518,9 @@ export class RecapService {
       this.finalizing.add(r.sessionId); // claim BEFORE the first await — race-safe (mirrors review.ts)
       let action: VerdictAction;
       let read: VerdictRead<unknown>;
-      const elapsed = this.now() - r.spawnedAt; // hoisted: also used in the finalize-null log below
+      let elapsed: number;
       try {
+        elapsed = this.now() - r.spawnedAt;
         read = this._readVerdict(r.cwd);
         const timedOut = elapsed > this.timeoutMs;
         // Ground-truth liveness via paneForegroundProcs (same signal as tab-reaper): a live-but-idle

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -542,20 +542,7 @@ export class RecapService {
       }
       // finalize-value carries the parsed verdict; finalize-null (timeout / fail-fast) → `failed`.
       const raw = action === "finalize-value" && read.status === "parsed" ? read.value : null;
-
-      // Observability: a `failed` recap used to be a black hole (no log, raw discarded), so an
-      // intermittent malformed write was undiagnosable. Surface WHY before finalizing.
-      if (action === "finalize-null") {
-        if (read.status === "unparseable") {
-          console.warn(
-            `[recap] ${r.sessionId}: verdict file present but unparseable even after jsonrepair — failing. snippet: ${recapSnippet(read.raw)}`,
-          );
-        } else {
-          console.warn(
-            `[recap] ${r.sessionId}: no verdict file after ${Math.round(elapsed / 1000)}s (spawn exited or hard timeout) — agent produced nothing.`,
-          );
-        }
-      }
+      if (action === "finalize-null") this.logUnproducedVerdict(r, read, elapsed);
 
       // finalizing flag stays set; always delete in finally so entry doesn't wedge after a throw.
       try {
@@ -563,6 +550,21 @@ export class RecapService {
       } finally {
         this.finalizing.delete(r.sessionId);
       }
+    }
+  }
+
+  /** Observability for a finalize-null recap (timeout / fail-fast): a `failed` recap used to be a
+   *  black hole (no log, raw discarded), so an intermittent malformed write was undiagnosable —
+   *  surface WHY before finalizing. Extracted from tick() to keep its cognitive complexity in bound. */
+  private logUnproducedVerdict(r: Recap, read: VerdictRead<unknown>, elapsed: number): void {
+    if (read.status === "unparseable") {
+      console.warn(
+        `[recap] ${r.sessionId}: verdict file present but unparseable even after jsonrepair — failing. snippet: ${recapSnippet(read.raw)}`,
+      );
+    } else {
+      console.warn(
+        `[recap] ${r.sessionId}: no verdict file after ${Math.round(elapsed / 1000)}s (spawn exited or hard timeout) — agent produced nothing.`,
+      );
     }
   }
 

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -37,11 +37,12 @@ import {
 import { groundBlocks, type VisualBlock } from "./visual-blocks";
 import {
   tolerantParseJson,
+  isSpawnAlive,
   isSpawnWorking,
   decideVerdictAction,
   STARTUP_GRACE_MS,
 } from "./json-tolerant";
-import type { VerdictRead } from "./json-tolerant";
+import type { VerdictAction, VerdictRead } from "./json-tolerant";
 
 const execFileAsync = promisify(execFile);
 
@@ -149,7 +150,7 @@ export interface RecapServiceDeps {
     | "list"
     | "setRecapPendingDiff"
   >;
-  herdr: Pick<HerdrDriver, "start" | "stop" | "list">;
+  herdr: Pick<HerdrDriver, "start" | "stop" | "list" | "paneForegroundProcs">;
   onChange: (id: string, recap: Recap | null) => void;
   model?: string | null;
   now?: () => number;
@@ -525,17 +526,30 @@ export class RecapService {
   async tick(): Promise<void> {
     for (const r of this.deps.store.generatingRecaps()) {
       if (this.finalizing.has(r.sessionId)) continue;
-
-      const read = this._readVerdict(r.cwd);
-      const elapsed = this.now() - r.spawnedAt;
-      const timedOut = elapsed > this.timeoutMs;
-      const action = decideVerdictAction(
-        read,
-        this.spawnFinished(r.cwd),
-        timedOut,
-        elapsed > STARTUP_GRACE_MS,
-      );
-      if (action === "wait") continue; // not-yet-written / repaired-or-unparseable while still working
+      this.finalizing.add(r.sessionId); // claim BEFORE the first await — race-safe (mirrors review.ts)
+      let action: VerdictAction;
+      let read: VerdictRead<unknown>;
+      const elapsed = this.now() - r.spawnedAt; // hoisted: also used in the finalize-null log below
+      try {
+        read = this._readVerdict(r.cwd);
+        const timedOut = elapsed > this.timeoutMs;
+        // Ground-truth liveness via paneForegroundProcs (same signal as tab-reaper): a live-but-idle
+        // recap spawn between API turns reads "idle" in agentStatus but still has non-shell procs.
+        // isSpawnAlive never throws; herdr errors → fail-closed alive.
+        const finished = !(await isSpawnAlive(this.deps.herdr, r.cwd));
+        action = decideVerdictAction(read, finished, timedOut, elapsed > STARTUP_GRACE_MS);
+      } catch (err) {
+        // _readVerdict or decideVerdictAction threw; isSpawnAlive itself never throws.
+        // Release the flag so the next tick retries — otherwise stays in finalizing forever,
+        // wedging the session's recap and leaking its tmpdir/terminal.
+        this.finalizing.delete(r.sessionId);
+        console.warn(`[recap] liveness/read failed for ${r.sessionId}, retrying next tick:`, err);
+        continue;
+      }
+      if (action === "wait") {
+        this.finalizing.delete(r.sessionId); // release: not finalizing this tick
+        continue; // not-yet-written / repaired-or-unparseable while still working
+      }
       // finalize-value carries the parsed verdict; finalize-null (timeout / fail-fast) → `failed`.
       const raw = action === "finalize-value" && read.status === "parsed" ? read.value : null;
 
@@ -553,7 +567,7 @@ export class RecapService {
         }
       }
 
-      this.finalizing.add(r.sessionId);
+      // finalizing flag stays set; always delete in finally so entry doesn't wedge after a throw.
       try {
         await this.finalize(r, raw);
       } finally {

--- a/src/review.ts
+++ b/src/review.ts
@@ -10,8 +10,8 @@ import { isApiKeyMode, isApiKeyConfigured } from "./spawn-auth";
 import { jsonlPathFor, readSessionUsage, type SessionUsage } from "./usage";
 import { readActivitySignal } from "./activity-signal";
 import { checksCleared } from "./checks-gate";
-import { isSpawnWorking, decideVerdictAction, STARTUP_GRACE_MS } from "./json-tolerant";
-import type { VerdictRead } from "./json-tolerant";
+import { isSpawnAlive, decideVerdictAction, STARTUP_GRACE_MS } from "./json-tolerant";
+import type { VerdictAction, VerdictRead } from "./json-tolerant";
 import {
   reviewPrompt,
   defaultReadVerdict,
@@ -117,7 +117,7 @@ export interface ReviewServiceDeps extends MembraneSeams {
     | "listReviewerSpawns"
     | "get"
   >;
-  herdr: Pick<HerdrDriver, "start" | "stop" | "list" | "closeTab">;
+  herdr: Pick<HerdrDriver, "start" | "stop" | "list" | "closeTab" | "paneForegroundProcs">;
   worktree: Pick<WorktreeMgr, "createDetached" | "remove" | "gitCommonDir">;
   resolveForge: (repoPath: string) => GitForge | null;
   onChange: (id: string, verdict: ReviewVerdict) => void;
@@ -631,17 +631,34 @@ export class ReviewService {
   async tick(): Promise<void> {
     for (const f of [...this.inflight.values()]) {
       if (f.finalizing) continue; // already being finalized by an overlapping tick
-      const read = this.readVerdict(f.worktreePath);
-      const elapsed = this.now() - f.startedAt;
-      const timedOut = elapsed > this.timeoutMs;
-      // Same finalize gate as RecapService.tick (shared decideVerdictAction): a repaired-truncated
-      // verdict must never silently drop findings or flip the decision in the merge gate, so it is
-      // trusted only once the critic spawn has finished; unparseable fails fast (raw=null → the
-      // existing transient-`error` verdict); absent fails fast once the critic has exited past the
-      // boot grace (a critic that died at startup wrote nothing), else waits for the hard timeout.
-      const finished = !isSpawnWorking(this.deps.herdr.list(), f.worktreePath);
-      const action = decideVerdictAction(read, finished, timedOut, elapsed > STARTUP_GRACE_MS);
+      f.finalizing = true; // claim BEFORE the first await — prevents a second overlapping tick
+      // from passing the guard above while we await isSpawnAlive below and both ticks racing
+      // to finalize the same entry (double-reap / double-putReview).
+      let action: VerdictAction;
+      let read: VerdictRead<RawVerdict>;
+      try {
+        read = this.readVerdict(f.worktreePath);
+        const elapsed = this.now() - f.startedAt;
+        const timedOut = elapsed > this.timeoutMs;
+        // Use ground-truth process liveness (paneForegroundProcs) rather than the transient
+        // agentStatus field: a live critic between API turns reads "idle"/"done" but still has
+        // claude/node-MainThread in its foreground — isSpawnAlive catches that and returns true
+        // (alive → finished=false → wait), preventing premature finalize-null + reap.
+        // isSpawnAlive never throws; any herdr error is caught internally → fail-closed alive.
+        const finished = !(await isSpawnAlive(this.deps.herdr, f.worktreePath));
+        // Same gate as RecapService.tick (shared decideVerdictAction): repaired verdict trusted
+        // only once finished; unparseable fails fast; absent fails fast past boot grace.
+        action = decideVerdictAction(read, finished, timedOut, elapsed > STARTUP_GRACE_MS);
+      } catch (err) {
+        // readVerdict or decideVerdictAction threw (isSpawnAlive itself never throws).
+        // Release the flag so the next tick retries — otherwise f.finalizing stays true forever,
+        // wedging the session's critic and leaking its worktree/terminal.
+        f.finalizing = false;
+        console.warn(`[review] liveness/read failed for ${f.sessionId}, retrying next tick:`, err);
+        continue;
+      }
       if (action === "wait") {
+        f.finalizing = false; // release: not finalizing this tick
         // still running (or gated, awaiting completion) — surface what the critic is doing right
         // now. Emit every tick (not only on change) so a reloaded client repopulates within one
         // tick; the client dedups identical summaries to stay quiet.
@@ -651,10 +668,9 @@ export class ReviewService {
       }
       const raw: RawVerdict | null =
         action === "finalize-value" && read.status === "parsed" ? read.value : null;
-      f.finalizing = true; // stay claimed in `inflight` so consider() won't re-spawn mid-finalize
-      // Always drop the entry, even if finalize throws — otherwise it stays
-      // `finalizing=true` and every later tick `continue`s past it, wedging the
-      // session's critic forever (and leaking its worktree/terminal).
+      // f.finalizing stays true; always drop the entry, even if finalize throws — otherwise it
+      // stays `finalizing=true` and every later tick `continue`s past it, wedging the session's
+      // critic forever (and leaking its worktree/terminal).
       try {
         await this.finalize(f, raw);
       } finally {

--- a/src/tab-reaper.ts
+++ b/src/tab-reaper.ts
@@ -4,6 +4,7 @@ import { PROBE_NAME } from "./usage-probe";
 import { DISTILL_LABEL } from "./distiller";
 import { OPTIMIZE_LABEL } from "./optimizer";
 import { MERGE_LABEL } from "./merge-suggest";
+import { SHELLS } from "./json-tolerant";
 
 export type ReapableHerdr = Pick<HerdrDriver, "closeTab" | "panes" | "paneForegroundProcs">;
 
@@ -61,9 +62,7 @@ export function isShepherdHelperLabel(label: string): boolean {
   );
 }
 
-/** Foreground process names that mean "just an idle shell" (a husk PTY). A helper pane
- *  whose foreground is *only* one of these has nothing running in it. */
-const SHELLS = new Set(["zsh", "bash", "sh", "fish", "dash"]);
+// SHELLS is defined in json-tolerant.ts and imported above — single source of truth.
 
 /** Breakdown of one reconciliation sweep. */
 export interface ReapResult {

--- a/test/json-tolerant.test.ts
+++ b/test/json-tolerant.test.ts
@@ -1,5 +1,10 @@
 import { expect, test, describe } from "bun:test";
-import { tolerantParseJson, isSpawnWorking, decideVerdictAction } from "../src/json-tolerant";
+import {
+  tolerantParseJson,
+  isSpawnWorking,
+  isSpawnAlive,
+  decideVerdictAction,
+} from "../src/json-tolerant";
 import type { VerdictRead } from "../src/json-tolerant";
 
 describe("tolerantParseJson", () => {
@@ -112,5 +117,90 @@ describe("decideVerdictAction", () => {
     expect(decideVerdictAction(absent, true, false, false)).toBe("wait");
     // Back-compat: callers that omit the grace flag keep the pre-grace "wait until timeout" behavior.
     expect(decideVerdictAction(absent, true, false)).toBe("wait");
+  });
+});
+
+// ── isSpawnAlive ─────────────────────────────────────────────────────────────
+// Ground-truth process-liveness helper: uses paneForegroundProcs to determine whether a
+// verdict spawn is actually alive, rather than relying on the transient agentStatus signal.
+
+/** Minimal herdr shape that isSpawnAlive accepts. */
+function makeHerdrStub(opts: {
+  agents?: { cwd: string; paneId: string; agentStatus: string }[];
+  procs?: string[] | Error;
+  listThrows?: boolean;
+}): {
+  list: () => { cwd: string; paneId: string; agentStatus: string }[];
+  paneForegroundProcs: () => Promise<string[]>;
+} {
+  return {
+    list: () => {
+      if (opts.listThrows) throw new Error("herdr unavailable");
+      return opts.agents ?? [];
+    },
+    paneForegroundProcs: async () => {
+      if (opts.procs instanceof Error) throw opts.procs;
+      return opts.procs ?? [];
+    },
+  };
+}
+
+describe("isSpawnAlive", () => {
+  const CWD = "/review-wt";
+  const agent = (agentStatus: string) => ({ cwd: CWD, paneId: "p1", agentStatus });
+
+  test("agentStatus=working → alive (fast path, no paneForegroundProcs call)", async () => {
+    let procsCalled = false;
+    const herdr = {
+      list: () => [agent("working")],
+      paneForegroundProcs: async () => {
+        procsCalled = true;
+        return ["zsh"];
+      },
+    };
+    expect(await isSpawnAlive(herdr, CWD)).toBe(true);
+    expect(procsCalled).toBe(false); // fast path skips the process-info call
+  });
+
+  test("idle + non-shell procs ['claude','node-MainThread'] → alive", async () => {
+    const herdr = makeHerdrStub({ agents: [agent("idle")], procs: ["claude", "node-MainThread"] });
+    expect(await isSpawnAlive(herdr, CWD)).toBe(true);
+  });
+
+  test("idle + non-shell procs ['claude','bash'] (critic mid-Bash) → alive", async () => {
+    const herdr = makeHerdrStub({ agents: [agent("idle")], procs: ["claude", "bash"] });
+    expect(await isSpawnAlive(herdr, CWD)).toBe(true);
+  });
+
+  test("idle + shell-only ['zsh'] (husk, startup-death shape) → dead", async () => {
+    const herdr = makeHerdrStub({ agents: [agent("idle")], procs: ["zsh"] });
+    expect(await isSpawnAlive(herdr, CWD)).toBe(false);
+  });
+
+  test("idle + empty procs [] (undeterminable) → alive (fail-closed)", async () => {
+    const herdr = makeHerdrStub({ agents: [agent("idle")], procs: [] });
+    expect(await isSpawnAlive(herdr, CWD)).toBe(true);
+  });
+
+  test("paneForegroundProcs throws → alive (fail-closed, never reap on read error)", async () => {
+    const herdr = makeHerdrStub({ agents: [agent("idle")], procs: new Error("ECONNREFUSED") });
+    expect(await isSpawnAlive(herdr, CWD)).toBe(true);
+  });
+
+  test("list() throws → alive (fail-closed, helper does not propagate)", async () => {
+    const herdr = makeHerdrStub({ listThrows: true });
+    expect(await isSpawnAlive(herdr, CWD)).toBe(true);
+  });
+
+  test("cwd absent from list → dead", async () => {
+    const herdr = makeHerdrStub({
+      agents: [{ cwd: "/other-wt", paneId: "p2", agentStatus: "working" }],
+    });
+    expect(await isSpawnAlive(herdr, CWD)).toBe(false);
+  });
+
+  test("empty list (no agents) → dead", async () => {
+    const herdr = makeHerdrStub({ agents: [] });
+    expect(await isSpawnAlive(herdr, CWD)).toBe(false);
   });
 });

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -611,7 +611,7 @@ test("tick unparseable: garbage verdict → state 'failed'", async () => {
 test("#822 tick fail-fast: unparseable + finished spawn → 'failed' before timeout", async () => {
   const rec = makeRecap({ state: "generating", cwd: "/tmp/recap-ff", spawnedAt: 1_000 });
   const store = makeStore([], [rec]);
-  // agent present but idle (finished its turn) at this cwd → spawnFinished = true.
+  // default ['zsh'] husk → isSpawnAlive=false → finished=true → fail-fast on unparseable.
   const herdr = makeHerdr([{ cwd: "/tmp/recap-ff", terminalId: "t-ff", agentStatus: "idle" }]);
   const cleaned: string[] = [];
 
@@ -945,11 +945,15 @@ test("generate/regenerate: herdr.start throws → returns 'error', no row, tmpdi
     started: [],
     stopped: [],
     livePanes: [],
+    procsOverride: new Map(),
+    defaultProcs: ["zsh"],
     start: () => {
       throw new Error("herdr start failed");
     },
     stop: (id) => herdr.stopped.push(id),
     list: () => herdr.livePanes,
+    paneForegroundProcs: async (paneId: string) =>
+      herdr.procsOverride.get(paneId) ?? herdr.defaultProcs,
   };
 
   const svc = buildSvc({

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -171,12 +171,16 @@ function makeStore(sessions: Session[] = [], recaps: Recap[] = []): FakeStore {
   return store;
 }
 
-type FakePaneEntry = { cwd: string; terminalId: string; agentStatus?: string };
+type FakePaneEntry = { cwd: string; terminalId: string; agentStatus?: string; paneId?: string };
 
 type FakeHerdr = {
   started: { label: string; cwd: string; argv: string[]; env?: Record<string, string> }[];
   stopped: string[];
   livePanes: FakePaneEntry[];
+  /** Per-pane procs override: paneId → procs. Falls back to defaultProcs. */
+  procsOverride: Map<string, string[]>;
+  /** Default procs for any pane not in procsOverride (default ['zsh'] = shell-only husk). */
+  defaultProcs: string[];
   start: (
     label: string,
     cwd: string,
@@ -185,13 +189,16 @@ type FakeHerdr = {
   ) => { terminalId: string };
   stop: (id: string) => void;
   list: () => FakePaneEntry[];
+  paneForegroundProcs: (paneId: string) => Promise<string[]>;
 };
 
-function makeHerdr(livePanes: FakePaneEntry[] = []): FakeHerdr {
+function makeHerdr(livePanes: FakePaneEntry[] = [], defaultProcs: string[] = ["zsh"]): FakeHerdr {
   const h: FakeHerdr = {
     started: [],
     stopped: [],
     livePanes,
+    procsOverride: new Map(),
+    defaultProcs,
     start: (label, cwd, argv, env) => {
       const tid = `tid-${h.started.length + 1}`;
       h.started.push({ label, cwd, argv, env });
@@ -200,6 +207,7 @@ function makeHerdr(livePanes: FakePaneEntry[] = []): FakeHerdr {
     },
     stop: (id) => h.stopped.push(id),
     list: () => h.livePanes,
+    paneForegroundProcs: async (paneId: string) => h.procsOverride.get(paneId) ?? h.defaultProcs,
   };
   return h;
 }
@@ -242,6 +250,12 @@ function buildSvc(opts: {
    *  Omit → { status:"absent" }. Use `verdictRead` for the repaired/unparseable statuses. */
   verdictJson?: unknown;
   verdictRead?: VerdictRead<unknown>;
+  /**
+   * A raw function override for readVerdict — called on EVERY tick instead of returning the
+   * static `verdictRead`/`verdictJson` value. Use when you need stateful behavior (e.g.
+   * throw-on-first-call, then succeed on second call).
+   */
+  readVerdictFn?: () => VerdictRead<unknown>;
   idleThresholdMs?: number;
   timeoutMs?: number;
   cleanup?: (d: string) => void;
@@ -264,11 +278,13 @@ function buildSvc(opts: {
     computeDiff: opts.computeDiff ?? (async () => (opts.diff ?? NON_EMPTY_DIFF) as any),
     readTranscript: (): ActivityEntry[] => [],
     readPlan: () => "",
-    readVerdict: (): VerdictRead<unknown> =>
-      opts.verdictRead ??
-      (opts.verdictJson !== undefined
-        ? { status: "parsed", value: opts.verdictJson, repaired: false }
-        : { status: "absent" }),
+    readVerdict: opts.readVerdictFn
+      ? opts.readVerdictFn
+      : (): VerdictRead<unknown> =>
+          opts.verdictRead ??
+          (opts.verdictJson !== undefined
+            ? { status: "parsed", value: opts.verdictJson, repaired: false }
+            : { status: "absent" }),
     readUsage: opts.readUsage ?? (async () => null),
     makeTmpDir: opts.makeTmpDir ?? (() => `/tmp/recap-test-${++tmpIdx}`),
     cleanup: opts.cleanup ?? (() => {}),
@@ -656,6 +672,112 @@ test("#822 tick gate: absent + finished spawn (not timed out) → stays generati
   await svc.tick();
   expect(store.getRecap("s1")?.state).toBe("generating"); // not fail-fasted
   expect(herdr.stopped).not.toContain("t-abs");
+});
+
+// ── TASK-1021 process-liveness regressions (recap mirror) ───────────────────
+// Mirrors the review regressions: a live-but-idle recap spawn must not be finalized-null;
+// a genuine husk (shell-only) must still fast-fail. isSpawnAlive uses paneForegroundProcs.
+
+test("[TASK-1021] recap: live-but-idle spawn past grace → stays generating, NOT finalized-null", async () => {
+  // spawnedAt=1_000; nowFn returns 91_000 → elapsed=90s > STARTUP_GRACE_MS (60s)
+  const rec = makeRecap({ state: "generating", cwd: "/tmp/recap-live", spawnedAt: 1_000 });
+  const store = makeStore([], [rec]);
+  // idle but with live procs → isSpawnAlive returns true → finished=false → wait
+  const herdr = makeHerdr(
+    [{ cwd: "/tmp/recap-live", terminalId: "t-live", paneId: "p-live", agentStatus: "idle" }],
+    ["claude", "node-MainThread"], // defaultProcs: live critic
+  );
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 91_000, // elapsed = 91000 - 1000 = 90s > STARTUP_GRACE_MS
+    timeoutMs: 300_000,
+    verdictRead: { status: "absent" },
+  });
+
+  await svc.tick();
+  expect(store.getRecap("s1")?.state).toBe("generating"); // NOT finalized
+  expect(herdr.stopped).not.toContain("t-live");
+});
+
+test("recap: husk (shell-only) past grace → finalize-null failed (fast-fail preserved)", async () => {
+  // spawnedAt=1_000; nowFn returns 91_000 → elapsed=90s > STARTUP_GRACE_MS (60s)
+  const rec = makeRecap({ state: "generating", cwd: "/tmp/recap-husk", spawnedAt: 1_000 });
+  const store = makeStore([], [rec]);
+  // shell-only pane → isSpawnAlive returns false → finished=true → finalize-null
+  const herdr = makeHerdr(
+    [{ cwd: "/tmp/recap-husk", terminalId: "t-husk", paneId: "p-husk", agentStatus: "idle" }],
+    ["zsh"], // defaultProcs: shell-only husk
+  );
+  const cleaned: string[] = [];
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 91_000, // elapsed = 91000 - 1000 = 90s > STARTUP_GRACE_MS
+    timeoutMs: 300_000,
+    verdictRead: { status: "absent" },
+    cleanup: (d) => cleaned.push(d),
+  });
+
+  await svc.tick();
+  expect(store.getRecap("s1")?.state).toBe("failed"); // finalize-null: fast-fail preserved
+  expect(herdr.stopped).toContain("t-husk");
+  expect(cleaned).toContain("/tmp/recap-husk");
+});
+
+// Overlapping-ticks regression: second concurrent tick must not double-finalize the same entry.
+test("recap overlapping ticks: second tick skips entry claimed by first tick", async () => {
+  const rec = makeRecap({ state: "generating", cwd: "/tmp/recap-overlap", spawnedAt: 1_000 });
+  const store = makeStore([], [rec]);
+  const herdr = makeHerdr(); // no panes → not in list → dead → finished=true; strict parse finalizes
+  const cleaned: string[] = [];
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    timeoutMs: 300_000,
+    verdictJson: VALID_VERDICT_JSON, // strict parse → finalize-value regardless of spawnFinished
+    cleanup: (d) => cleaned.push(d),
+  });
+
+  // Fire two ticks concurrently: tick1 claims finalizing before its first await; tick2 skips.
+  const tick1 = svc.tick();
+  const tick2 = svc.tick();
+  await Promise.all([tick1, tick2]);
+  // Exactly one finalize: state is 'ready' (not 'failed'), cleanup called once
+  expect(store.getRecap("s1")?.state).toBe("ready");
+  expect(cleaned.filter((d) => d === "/tmp/recap-overlap")).toHaveLength(1);
+});
+
+// Throw-after-claim regression: if readVerdict throws after the finalizing Set.add(),
+// the flag must be released so the next tick retries (no wedge/leak).
+test("recap throw-after-claim: finalizing flag released on readVerdict throw → next tick succeeds", async () => {
+  const rec = makeRecap({ state: "generating", cwd: "/tmp/recap-throw", spawnedAt: 1_000 });
+  const store = makeStore([], [rec]);
+  const herdr = makeHerdr();
+  let callCount = 0;
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    timeoutMs: 300_000,
+    readVerdictFn: () => {
+      callCount++;
+      if (callCount === 1) throw new Error("transient read error");
+      return { status: "parsed", value: VALID_VERDICT_JSON, repaired: false };
+    },
+  });
+
+  // First tick: readVerdict throws → flag released, stays generating
+  await svc.tick();
+  expect(store.getRecap("s1")?.state).toBe("generating"); // not finalized
+  // Second tick: succeeds → finalizes
+  await svc.tick();
+  expect(store.getRecap("s1")?.state).toBe("ready");
 });
 
 test("tick restart-safety: generating row in DB, no in-memory state → finalizes", async () => {

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -155,6 +155,18 @@ function makeDeps(
     verdictRead?: VerdictRead<RawVerdict>;
     /** agentStatus reported by herdr.list() for the critic at /review-wt (default "idle" = finished). */
     criticAgentStatus?: string;
+    /**
+     * Foreground processes returned by herdr.paneForegroundProcs for the critic pane.
+     * Default ['zsh'] (shell-only husk → isSpawnAlive returns false for non-working agents).
+     * Pass non-shell procs to simulate a live-but-idle critic.
+     */
+    criticProcs?: string[];
+    /**
+     * Raw readVerdict function override — bypasses adaptLegacyVerdict. Use when you need
+     * stateful behavior (e.g. throw on first call, succeed on second). Takes precedence over
+     * both `verdictRead` and `over.readVerdict`.
+     */
+    readVerdictFn?: () => VerdictRead<RawVerdict>;
   } = {},
 ) {
   const reviews: Record<string, ReviewVerdict> = {};
@@ -202,11 +214,24 @@ function makeDeps(
       stop(t: string) {
         this.recorded.push(t); // this.recorded → throws TypeError if called unbound
       }
-      // tick() consults agentStatus via isSpawnWorking to gate repaired/unparseable verdicts.
+      // tick() consults agentStatus + paneForegroundProcs via isSpawnAlive to gate verdicts.
       list() {
         return [
-          { cwd: "/review-wt", terminalId: "rt", agentStatus: opts.criticAgentStatus ?? "idle" },
+          {
+            cwd: "/review-wt",
+            terminalId: "rt",
+            paneId: "p1",
+            agentStatus: opts.criticAgentStatus ?? "idle",
+          },
         ] as any;
+      }
+      async paneForegroundProcs(): Promise<string[]> {
+        // Default: shell-only (husk) so non-working agents are treated as dead by isSpawnAlive.
+        // Tests that need a live-but-idle critic pass criticProcs with non-shell entries.
+        return opts.criticProcs ?? ["zsh"];
+      }
+      closeTab() {
+        /* forward-compat; used by other tests via the existing path */
       }
     })(),
     worktree: new (class {
@@ -236,13 +261,15 @@ function makeDeps(
     ...over,
     // Adapt the legacy `() => RawVerdict | null` reader (default or `over.readVerdict`) into the
     // 3-way VerdictRead the service now consumes — placed AFTER `...over` so the wrap always wins.
-    // `verdictRead` (raw 3-way) takes precedence for the #822 gate tests.
-    readVerdict: opts.verdictRead
-      ? () => opts.verdictRead!
-      : adaptLegacyVerdict(
-          over.readVerdict ??
-            (() => ({ decision: "request-changes", summary: "2 issues", body: "## findings" })),
-        ),
+    // Priority: readVerdictFn (raw stateful) > verdictRead (raw static) > adapted legacy reader.
+    readVerdict: opts.readVerdictFn
+      ? opts.readVerdictFn
+      : opts.verdictRead
+        ? () => opts.verdictRead!
+        : adaptLegacyVerdict(
+            over.readVerdict ??
+              (() => ({ decision: "request-changes", summary: "2 issues", body: "## findings" })),
+          ),
   };
   return {
     deps: base,
@@ -616,6 +643,116 @@ test("#822 review gate: absent + finished critic (not timed out) → not finaliz
   await svc.tick();
   expect(reviews["s1"]).toBeUndefined(); // not fail-fasted
   expect(removed).toEqual([]);
+});
+
+// ── TASK-1021 process-liveness regressions ────────────────────────────────────
+// A live-but-idle critic (agentStatus "idle" between API turns, but claude/node still running)
+// past the 60s startup grace must NOT be finalized-null and reaped — the root cause of
+// TASK-1021's three successive review failures (62s, 69s, 73s runs, all reaped while working).
+
+test("[TASK-1021] live-but-idle critic past grace: stays inflight, NOT finalized-null", async () => {
+  let t = 1000; // consider() sets startedAt=1000
+  const {
+    deps: d,
+    reviews,
+    stopped,
+    removed,
+  } = makeDeps(
+    { now: () => t, timeoutMs: 300_000 },
+    {
+      verdictRead: { status: "absent" },
+      criticAgentStatus: "idle",
+      criticProcs: ["claude", "node-MainThread"], // live critic mid-turn
+    },
+  );
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  t = 1000 + 90_000; // advance past STARTUP_GRACE_MS (60s); elapsed=90s
+  await svc.tick();
+  expect(reviews["s1"]).toBeUndefined(); // not finalized
+  expect(stopped).toEqual([]); // not reaped
+  expect(removed).toEqual([]);
+});
+
+test("husk critic (shell-only) past grace: finalize-null error (fast-fail preserved)", async () => {
+  let t = 1000; // consider() sets startedAt=1000
+  const {
+    deps: d,
+    reviews,
+    stopped,
+    removed,
+  } = makeDeps(
+    { now: () => t, timeoutMs: 300_000 },
+    {
+      verdictRead: { status: "absent" },
+      criticAgentStatus: "idle",
+      criticProcs: ["zsh"], // shell-only husk — genuinely dead
+    },
+  );
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  t = 1000 + 90_000; // advance past STARTUP_GRACE_MS (60s); elapsed=90s
+  await svc.tick();
+  expect(reviews["s1"]?.decision).toBe("error"); // finalize-null: fast-fail preserved
+  expect(stopped).not.toEqual([]); // reaped
+  expect(removed).not.toEqual([]);
+});
+
+// Overlapping-ticks regression: the second concurrent tick must skip an entry whose
+// finalizing flag was claimed by the first tick before the first async yield.
+test("overlapping ticks: second tick skips entry already claimed by first tick", async () => {
+  const {
+    deps: d,
+    stopped,
+    removed,
+  } = makeDeps(
+    { now: () => 1000, timeoutMs: 300_000 },
+    {
+      // strict parse → finalize-value regardless of spawnFinished, so tick will finalize
+      // criticProcs is default ['zsh'] (dead) — doesn't matter for strict parse
+    },
+  );
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  // Fire two ticks concurrently — tick1 claims finalizing before its first await;
+  // tick2 sees finalizing=true and skips the entry entirely.
+  const tick1 = svc.tick();
+  const tick2 = svc.tick();
+  await Promise.all([tick1, tick2]);
+  // Exactly one finalize: exactly one stop + one remove
+  expect(stopped.length).toBe(1);
+  expect(removed.length).toBe(1);
+});
+
+// Throw-after-claim regression: if something throws after finalizing is claimed (but before
+// finalize()), the flag must be released so the next tick can retry (no wedge/leak).
+test("throw-after-claim: finalizing flag released on readVerdict throw → next tick succeeds", async () => {
+  let callCount = 0;
+  const { deps: d, reviews } = makeDeps(
+    { now: () => 1000, timeoutMs: 300_000 },
+    {
+      // Raw fn (bypasses adaptLegacyVerdict) so the VerdictRead shapes are returned correctly.
+      // First call throws (simulates readVerdict failing after flag is claimed);
+      // second call returns a valid verdict so the subsequent tick can finalize.
+      readVerdictFn: (): VerdictRead<RawVerdict> => {
+        callCount++;
+        if (callCount === 1) throw new Error("transient read error");
+        return {
+          status: "parsed",
+          value: { decision: "request-changes", summary: "issue", body: "## findings" },
+          repaired: false,
+        };
+      },
+    },
+  );
+  const svc = new ReviewService(d as any);
+  await svc.consider(session(), OPEN_GREEN);
+  // First tick: readVerdict throws → flag released, entry stays inflight
+  await svc.tick();
+  expect(reviews["s1"]).toBeUndefined(); // not finalized yet (throw caused retry)
+  // Second tick: readVerdict succeeds → finalizes normally
+  await svc.tick();
+  expect(reviews["s1"]?.decision).toBe("changes_requested"); // finalized on retry
 });
 
 test("comment decision maps to COMMENT and never approves", async () => {


### PR DESCRIPTION
## Why

A verdict review kept failing on a task (surfaced via TASK-1021) with `error: "critic did not produce a verdict"` despite a small, clean diff. Root cause: **Shepherd was killing its own live critic.**

The finalize gate decided a verdict spawn had "finished" from `agentStatus === "working"` (`isSpawnWorking`). But `working` is a transient *activity* status — a live critic reads non-`working` during any tool call, between API turns, or at a permission prompt. For an **absent** verdict file, `decideVerdictAction` fast-fails when `spawnFinished && graceElapsed` (`elapsed > 60s STARTUP_GRACE_MS`). So the first non-`working` tick past 60s wrote a null `error` verdict, and `finalize()`'s `finally` called `reapRun` — terminating the still-working agent and deleting its worktree. Error verdicts store `patchId=""` (no dedup), so the same head re-reviewed and re-died → the "keeps failing" loop.

### Evidence
Three reviewer spawns on the same PR head, all `taskSessionId` = the affected task, each reaped just after crossing the 60s grace (62.6s / 69.3s / 73.0s) mid-`Read` — none hit the 10-min hard timeout, none aborted at spawn.

## What

Bring the verdict gate in line with `tab-reaper.ts`'s existing doctrine: **process liveness is ground truth; `agentStatus` is not.**

- New `isSpawnAlive` (`src/json-tolerant.ts`) using `herdr.paneForegroundProcs` — alive if a non-shell proc (`claude`/`node`) is present (even mid-tool) or `agentStatus === "working"` (fast path); dead only for a shell-only husk (`['zsh']`) or absent-from-list; **fail-closed → alive** on any herdr read error (never throws).
- Both `review.ts` and `recap.ts` `tick()` compute `spawnFinished` via `isSpawnAlive`, and are made **race-safe**: the `finalizing` claim is taken before the first `await` and released on the `wait` branch and on any throw (so a herdr read failure can't wedge the session) — kept through the finalize path.
- `SHELLS` single-sourced; `decideVerdictAction` signature unchanged.

Net: a live-but-idle critic past 60s now waits for its verdict or the hard timeout instead of being reaped; a genuinely-dead husk still fast-fails (the #1211/#822 win preserved); overlapping 15s ticks finalize+reap a spawn exactly once.

## Verification

- New unit + regression tests (review + recap): live-but-idle **not** reaped (reproduces the failure), husk fast-fails, overlapping-ticks single finalize+reap, throw-after-claim releases the flag. The live-but-idle and throw-after-claim tests fail against the old code.
- `bun test ./test` 5256 pass / 0 fail · `tsc --noEmit` clean · `bun run lint` clean · `prettier --check .` clean · `fallow audit` clean.
- The `['zsh']` husk shape was **directly observed** via a faithful startup-death (`herdr agent start … -- sh -c 'exit 0'`), confirming no 10-min-timeout regression.

## Scope / notes

- Server-only (`src/` + `test/`); no UI, so i18n/feature-catalog/glossary gates are N/A. `[no-feature-entry]`.
- Non-blocking follow-up candidates (from final review): the exported `isSpawnWorking` is now used only inside `isSpawnAlive`'s inlined fast path (plan mandated keeping it); and recap's finalize-null logging could fold inside the try for symmetry.
- An operator-gated live re-review of the affected task (with a healthy account pool) is the corroborating check; the regression suite is the non-deferrable proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
