### PR TITLE
fix(upnext): apply repo filter to the Up Next (NÄCHSTES) lens

### DIFF
--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -203,10 +203,14 @@ test("dominantModelOf returns null when only 'unknown' is present", () => {
 // ── foldSessionBuckets ────────────────────────────────────────────────────────
 
 // Fixture: two different hours + one ts=0 record, with distinct models and multiple token kinds.
-// Hour A: 2026-05-30T09:00:00.000Z
-// Hour B: 2026-05-30T10:00:00.000Z
-const TS_A = "2026-05-30T09:31:01.000Z"; // in hour A
-const TS_B = "2026-05-30T10:15:00.000Z"; // in hour B
+// Anchored relative to "now" (~1 day ago) so the records always sit well inside the rollup's
+// 30-day prune window. These used to be hard-coded 2026-05-30 calendar dates, which crossed the
+// 30-day horizon as real time advanced and broke `verify` on every PR (issue #1222). Hour A and
+// hour B are adjacent, distinct hour buckets — the fold/window/cutoff tests below depend on that.
+const HOUR_MS = 3_600_000;
+const HOUR_A_FLOOR = Math.floor((Date.now() - 86_400_000) / HOUR_MS) * HOUR_MS;
+const TS_A = new Date(HOUR_A_FLOOR + 31 * 60_000 + 1_000).toISOString(); // hour A, :31:01
+const TS_B = new Date(HOUR_A_FLOOR + HOUR_MS + 15 * 60_000).toISOString(); // hour B (= A+1h), :15:00
 
 // Make a ts=0 record by using an invalid timestamp
 function asstNoTs(opts: Parameters<typeof asst>[0]): string {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2073,6 +2073,7 @@
   "upnext_updated_ago": "aktualisiert vor {ago}",
   "upnext_refresh": "Aktualisieren",
   "upnext_empty": "Alles erledigt — nichts zum Starten in der Warteschlange.",
+  "upnext_repo_filter_empty": "Nichts zum Starten für {repo}.",
   "upnext_open_backlog": "Backlog öffnen",
   "upnext_main_hint": "Als Nächstes wird im Herd-Panel links angezeigt.",
   "upnext_priority_section": "Priorität",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2073,6 +2073,7 @@
   "upnext_updated_ago": "updated {ago} ago",
   "upnext_refresh": "Refresh",
   "upnext_empty": "You're all caught up — nothing queued to start.",
+  "upnext_repo_filter_empty": "Nothing queued to start for {repo}.",
   "upnext_open_backlog": "Open the Backlog",
   "upnext_main_hint": "Up Next is shown in the herd panel on the left.",
   "upnext_priority_section": "Priority",

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -446,7 +446,7 @@
   <div class="units" class:flow>
     {#if filter === "next"}
       <!-- Up Next lens (#1169): cross-repo ranked queue of un-started work, no session list. -->
-      <UpNextPanel {onbacklog} />
+      <UpNextPanel {onbacklog} {repoFilter} />
     {:else if filter === "rundown"}
       <!-- Rundown lens: the daily Herd Rundown digest panel, no session list. -->
       <RundownPanel onitemselect={onrundownitem} onepicland={onrundownepic} />

--- a/ui/src/lib/components/UpNextPanel.browser.test.ts
+++ b/ui/src/lib/components/UpNextPanel.browser.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import type { UpNextItem, UpNextSnapshot } from "$lib/types";
+import { m } from "$lib/paraglide/messages";
+import { upNext } from "$lib/up-next.svelte";
+
+// Mock the API so mounting (which kicks upNext.load()) makes no real network call.
+vi.mock("$lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/api")>();
+  return {
+    ...actual,
+    getUpNext: vi.fn(async (): Promise<UpNextSnapshot | null> => upNext.snapshot),
+    refreshUpNext: vi.fn(async () => {}),
+    startUpNext: vi.fn(async () => ({ created: [], errors: [] })),
+  };
+});
+
+const { default: UpNextPanel } = await import("./UpNextPanel.svelte");
+
+const item = (repoPath: string, number: number, priority = false): UpNextItem => ({
+  repoPath,
+  repoSlug: null,
+  repoLabel: repoPath.split("/").at(-1) ?? repoPath,
+  number,
+  title: `issue ${number}`,
+  url: `https://example.test/${number}`,
+  kind: "feature",
+  priority,
+  createdAt: 0,
+  issueRef: { number, url: `https://example.test/${number}`, title: `issue ${number}`, body: "" },
+});
+
+const SNAPSHOT: UpNextSnapshot = {
+  generatedAt: 1,
+  repoCount: 2,
+  fallback: null,
+  sections: [
+    {
+      kind: "priority",
+      repoPath: null,
+      repoSlug: null,
+      repoLabel: null,
+      totalCount: 2,
+      items: [
+        item("~/projects/homeassistant", 1, true),
+        item("~/projects/car-gas-tracker", 5, true),
+      ],
+    },
+    {
+      kind: "repo",
+      repoPath: "~/projects/homeassistant",
+      repoSlug: null,
+      repoLabel: "homeassistant",
+      totalCount: 1,
+      items: [item("~/projects/homeassistant", 2)],
+    },
+    {
+      kind: "repo",
+      repoPath: "~/projects/car-gas-tracker",
+      repoSlug: null,
+      repoLabel: "car-gas-tracker",
+      totalCount: 1,
+      items: [item("~/projects/car-gas-tracker", 6)],
+    },
+  ],
+};
+
+let fontStyle: HTMLStyleElement;
+beforeEach(() => {
+  upNext.snapshot = SNAPSHOT;
+  fontStyle = document.createElement("style");
+  fontStyle.textContent = `:root {
+    --color-panel:#1a1a1a;--color-line:#333;--color-line-bright:#555;--color-inset:#111;
+    --color-bg:#000;--color-ink:#ccc;--color-ink-bright:#fff;--color-muted:#666;--color-faint:#444;
+    --color-amber:#f5a623;--color-green:#4caf50;--color-red:#f44336;
+    --fs-lg:16px;--fs-meta:12px;--fs-micro:10px;
+  }`;
+  document.head.appendChild(fontStyle);
+});
+afterEach(() => {
+  upNext.snapshot = null;
+  fontStyle.remove();
+});
+
+describe("UpNextPanel repo filter", () => {
+  it("shows all repos when unfiltered", async () => {
+    render(UpNextPanel, {});
+    await expect.element(page.getByText("#2")).toBeInTheDocument();
+    await expect.element(page.getByText("#6")).toBeInTheDocument();
+  });
+
+  it("scopes sections and priority items to the active repo filter", async () => {
+    render(UpNextPanel, { repoFilter: "~/projects/homeassistant" });
+    // homeassistant repo section + its priority item remain
+    await expect.element(page.getByText("#2")).toBeInTheDocument();
+    await expect.element(page.getByText("#1")).toBeInTheDocument();
+    // the other repo's section row AND its cross-repo priority item are gone
+    await expect.element(page.getByText("#6")).not.toBeInTheDocument();
+    await expect.element(page.getByText("#5")).not.toBeInTheDocument();
+  });
+
+  it("shows a repo-scoped empty note when the filtered repo has nothing queued", async () => {
+    render(UpNextPanel, { repoFilter: "~/projects/does-not-exist" });
+    await expect
+      .element(page.getByText(m.upnext_repo_filter_empty({ repo: "does-not-exist" })))
+      .toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/components/UpNextPanel.svelte
+++ b/ui/src/lib/components/UpNextPanel.svelte
@@ -10,7 +10,10 @@
   import { onMount } from "svelte";
 
   // Open the Backlog overlay from the empty state (threaded up through Herd to +page).
-  let { onbacklog }: { onbacklog?: () => void } = $props();
+  // repoFilter: full repoPath of the active chip-rail filter (null = unfiltered) — scopes the
+  // queue to one repo, identical to how the session lenses filter.
+  let { onbacklog, repoFilter = null }: { onbacklog?: () => void; repoFilter?: string | null } =
+    $props();
 
   // On lens-open: repaint the cached snapshot and kick a server recompute (GET /api/up-next
   // triggers a background refresh that lands in place via the upnext:snapshot WS event), so the
@@ -28,7 +31,20 @@
   const CONFIRM_THRESHOLD = 3;
 
   const snap = $derived(upNext.snapshot);
-  const sections = $derived(snap?.sections ?? []);
+  // The chip-rail repo filter scopes the queue to one repo, identical to the session lenses.
+  // Repo sections drop unless they match; the cross-repo priority section keeps only its items
+  // from the active repo (re-counting totalCount so "show all N" stays honest).
+  const sections = $derived.by(() => {
+    const all = snap?.sections ?? [];
+    if (!repoFilter) return all;
+    return all
+      .map((s): UpNextSection | null => {
+        if (s.kind === "repo") return s.repoPath === repoFilter ? s : null;
+        const items = s.items.filter((it) => it.repoPath === repoFilter);
+        return items.length > 0 ? { ...s, items, totalCount: items.length } : null;
+      })
+      .filter((s): s is UpNextSection => s !== null);
+  });
   // Empty ("all caught up") only once the server has actually produced a snapshot; a null/
   // never-computed snapshot shows loading, not the all-clear.
   const computed = $derived(snap?.generatedAt != null);
@@ -212,7 +228,11 @@
       <p class="un-muted">{m.common_loading()}</p>
     {:else if isEmpty}
       <div class="un-empty">
-        <p class="un-muted">{m.upnext_empty()}</p>
+        <p class="un-muted">
+          {repoFilter
+            ? m.upnext_repo_filter_empty({ repo: repoBase(repoFilter) })
+            : m.upnext_empty()}
+        </p>
         {#if onbacklog}
           <button type="button" class="un-backlog-link" onclick={() => onbacklog?.()}
             >{m.upnext_open_backlog()}</button


### PR DESCRIPTION
## Problem

The repo filter chips in Mission Control scoped every session lens (ALLE / BEREIT / OFFEN), but the **NÄCHSTES** (Up Next) lens kept showing items from *all* repos even with a repo selected.

## Cause

`UpNextPanel` reads `upNext.snapshot` directly and was never handed the active `repoFilter` — the session lenses get their sessions pre-filtered at page level, but the panel had no equivalent. So the filter chip had no effect there.

## Fix

- Thread `repoFilter` (the active repo's full path) from `Herd.svelte` into `UpNextPanel`.
- Scope the snapshot's sections client-side, identical to how the session lenses behave:
  - **repo sections** drop unless they match the active repo;
  - the cross-repo **priority section** keeps only its items from the active repo (re-counting `totalCount` so "show all N" stays honest).
- When the filtered repo has nothing queued, show a repo-scoped empty note (`upnext_repo_filter_empty`) instead of the misleading "you're all caught up".

Scoped to the NÄCHSTES lens per the report. The other panel-only lenses (Rundown / Owed / Done) have the same architectural gap but were out of scope here.

## Tests

- New `UpNextPanel.browser.test.ts`: unfiltered shows all repos; an active filter scopes both repo sections and cross-repo priority items; an empty filtered repo shows the repo-scoped note.
- `cd ui && bun run check` + `check:i18n` green; EN/DE catalogs in parity.

Note: this is a `fix` and touches no glossary terms. The one failing root test (`SessionUsageRollup: dedupe before accumulate`) is pre-existing on `main` and unrelated — this branch changes only `ui/` files.