### PR TITLE
fix(issues): surface fetch failure in IssuesPanel instead of empty state

### DIFF
--- a/ui/src/lib/components/IssuesPanel.browser.test.ts
+++ b/ui/src/lib/components/IssuesPanel.browser.test.ts
@@ -79,6 +79,45 @@ describe("IssuesPanel repo slug link", () => {
   });
 });
 
+describe("IssuesPanel empty vs fetch-failed", () => {
+  it("shows the no-open-issues message when the listing is a genuine zero", async () => {
+    mockListIssues.mockResolvedValue({
+      slug: "owner/repo",
+      webUrl: null,
+      issues: [],
+      viewer: null,
+    });
+    mockGetEpics.mockResolvedValue({ epics: [], subIssues: [] });
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
+
+    await expect
+      .poll(() => document.querySelector(".issues-list")?.textContent)
+      .toContain(m.common_no_open_issues());
+    expect(document.querySelector(".issues-list")?.textContent).not.toContain(
+      m.common_issues_load_failed(),
+    );
+  });
+
+  it("shows the load-failed message when the forge listing errored (e.g. rate limit)", async () => {
+    mockListIssues.mockResolvedValue({
+      slug: "owner/repo",
+      webUrl: null,
+      issues: [],
+      viewer: null,
+      error: "fetch_failed",
+    });
+    mockGetEpics.mockResolvedValue({ epics: [], subIssues: [] });
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
+
+    await expect
+      .poll(() => document.querySelector(".issues-list")?.textContent)
+      .toContain(m.common_issues_load_failed());
+    expect(document.querySelector(".issues-list")?.textContent).not.toContain(
+      m.common_no_open_issues(),
+    );
+  });
+});
+
 describe("IssuesPanel epic badge", () => {
   function issue(number: number, title: string): Issue {
     return {

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -47,6 +47,10 @@
   let repoUrl = $state<string | null>(null);
   let viewer = $state<string | null>(null);
   let loading = $state(true);
+  // True when the forge listing failed (rate-limited gh, network, un-authed CLI):
+  // the empty issues[] is a fetch failure, not a genuine zero. Mirrors
+  // PromptSources — distinguishes "couldn't load" from "no open issues".
+  let loadError = $state(false);
   let filter = $state("");
   // Epic summaries for this repo: number → EpicSummary.
   let epicByNumber = $state<Map<number, EpicSummary>>(new Map());
@@ -101,6 +105,7 @@
   $effect(() => {
     const rp = repoPath;
     loading = true;
+    loadError = false;
     filter = "";
     expanded.clear();
     epicByNumber = new Map();
@@ -114,9 +119,11 @@
         repoUrl = r.webUrl;
         issues = r.issues;
         viewer = r.viewer;
+        loadError = r.error != null;
         loading = false;
       })
       .catch(() => {
+        loadError = true;
         loading = false;
       });
     getEpics(rp)
@@ -193,6 +200,8 @@
   <div class="issues-list">
     {#if loading}
       <div class="muted">{m.common_loading()}</div>
+    {:else if loadError}
+      <div class="muted">{m.common_issues_load_failed()}</div>
     {:else if slug === null}
       <div class="muted">{m.issuespanel_no_host()}</div>
     {:else if issues.length === 0}

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -123,6 +123,10 @@
         loading = false;
       })
       .catch(() => {
+        // Mirror the success path's staleness guard: a rejection from a
+        // previously-selected repo must not stamp a sticky load-failed banner
+        // onto the repo now showing.
+        if (rp !== repoPath) return;
         loadError = true;
         loading = false;
       });


### PR DESCRIPTION
## Why

In the **Repos** panel, the Issues tab showed **"keine offenen Issues"** for a repo that has open issues. Nothing was broken with the repo — GitHub's **GraphQL API quota was exhausted** (`gh issue list` runs on that quota), so the fetch failed.

The server already handles this: `GET /api/issues` (`src/server.ts:3802-3813`) catches the rate-limited/failed listing and returns an empty `issues[]` **plus** `error: "fetch_failed"`, with a comment that it's flagged *"so the UI can say 'couldn't load' instead of the indistinguishable 'no open issues'"*.

But `IssuesPanel.svelte` **ignored that flag** and fell through to the generic `common_no_open_issues` empty state — making a transient rate limit look like an empty backlog. The New Task picker (`PromptSources.svelte`) already reads `r.error`; `IssuesPanel` just never got the same treatment.

## What

- `IssuesPanel` now tracks `loadError`, set from `r.error` (and on a thrown `listIssues`), and renders the existing `common_issues_load_failed` message ahead of the empty state.
- Added two browser tests covering the empty-vs-fetch-failed distinction.

No new i18n keys (reuses `common_issues_load_failed`, in both locales). Bugfix, no user-facing feature → no catalog entry.

## Verification

- `cd ui && bun run check` → 0 errors
- `bun run check:i18n` → 2 locales in parity
- `bun run test src/lib/components/IssuesPanel.browser.test.ts` → 19 passed
