### PR TITLE
feat(viewport): combine decommission & local fast-forward in post-merge toast

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2120,5 +2120,8 @@
   "plugin_action_failed": "Plugin-Aktion fehlgeschlagen",
   "plugin_action_confirm_title": "Aktion bestätigen",
   "feat_plugin_gear_item_title": "Plugin-Einträge im Zahnradmenü",
-  "feat_plugin_gear_item_body": "Plugins können dem Zahnradmenü jetzt einen einzelnen Eintrag hinzufügen — der einen Link öffnet, eine Plugin-Aktion ausführt oder zum Plugin-Panel springt."
+  "feat_plugin_gear_item_body": "Plugins können dem Zahnradmenü jetzt einen einzelnen Eintrag hinzufügen — der einen Link öffnet, eine Plugin-Aktion ausführt oder zum Plugin-Panel springt.",
+  "gitrail_decommission_update_action": "Stilllegen & lokal aktualisieren",
+  "feat_decommission_update_local_title": "Stilllegen & lokal aktualisieren",
+  "feat_decommission_update_local_body": "Wenn du den PR einer isolierten Session mergst, bietet die Bestätigungsmeldung jetzt eine Aktion, die die Session entfernt und deinen lokalen Standard-Branch mit einem Klick auf den neuesten Stand bringt."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2120,5 +2120,8 @@
   "plugin_action_failed": "Plugin action failed",
   "plugin_action_confirm_title": "Confirm action",
   "feat_plugin_gear_item_title": "Plugin gear-menu items",
-  "feat_plugin_gear_item_body": "Plugins can now add a single item to the gear menu — opening a link, running a plugin action, or jumping to the plugin's panel."
+  "feat_plugin_gear_item_body": "Plugins can now add a single item to the gear menu — opening a link, running a plugin action, or jumping to the plugin's panel.",
+  "gitrail_decommission_update_action": "Decommission & update local",
+  "feat_decommission_update_local_title": "Decommission & update local",
+  "feat_decommission_update_local_body": "When you merge an isolated session's PR, the confirmation toast now offers one action that tears the session down and fast-forwards your local default branch in a single click."
 }

--- a/ui/src/lib/components/GitRail.browser.test.ts
+++ b/ui/src/lib/components/GitRail.browser.test.ts
@@ -1489,6 +1489,60 @@ describe("GitRail — post-merge decommission offer", () => {
     ).not.toHaveBeenCalledWith("/other", "release");
   });
 
+  it("combo action captures the isolated flag at merge time, not at click time", async () => {
+    // Regression: the `isolated` flag must be snapshotted before the merge await alongside
+    // the FF target. Merging an isolated session, then switching to a NON-isolated session
+    // within the 15s window, must still fast-forward (captured isolated=true wins) rather
+    // than reading the rebound live flag and silently skipping the pull.
+    const { mergePr: mergePrMock } = await import("$lib/api");
+    (mergePrMock as ReturnType<typeof vi.fn>).mockResolvedValue({
+      kind: "github",
+      state: "merged",
+      checks: "none",
+      deployConfigured: false,
+    });
+    gitStateFn.mockResolvedValue(openPrState);
+
+    const ondecommission = vi.fn();
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, {
+      target: h,
+      props: {
+        ...baseProps,
+        sessionId: "sess-A",
+        mobile: false,
+        isolated: true,
+        baseBranch: "main",
+        ondecommission,
+      },
+    });
+    await expect.element(screen.getByTitle("PR #12345")).toBeVisible();
+
+    await armAndConfirmMerge(h);
+    await vi.waitFor(() => expect(toastsInfo).toHaveBeenCalledTimes(1));
+
+    const [, opts] = toastsInfo.mock.calls[0] as [
+      string,
+      { action?: { label: string; run: () => void } },
+    ];
+
+    // Switch to a NON-isolated session before clicking the toast action.
+    await screen.rerender({
+      ...baseProps,
+      sessionId: "sess-B",
+      mobile: false,
+      isolated: false,
+      ondecommission,
+    });
+
+    opts!.action!.run();
+    expect(
+      pullMainAndToast,
+      "pull still fires with captured isolated=true despite live isolated=false",
+    ).toHaveBeenCalledWith("/repo", "main");
+  });
+
   it("local-forge merge → no decommission offer action", async () => {
     const { mergePr: mergePrMock } = await import("$lib/api");
     (mergePrMock as ReturnType<typeof vi.fn>).mockResolvedValue({

--- a/ui/src/lib/components/GitRail.browser.test.ts
+++ b/ui/src/lib/components/GitRail.browser.test.ts
@@ -56,6 +56,9 @@ vi.mock("$lib/toasts.svelte", () => ({
   toasts: { info: toastsInfo },
 }));
 
+// Mock pull-offer so the combined decommission+update action doesn't issue real fetch calls.
+vi.mock("$lib/pull-offer", () => ({ pullMainAndToast: vi.fn() }));
+
 // Import the component AFTER the mock is registered.
 const { default: GitRail } = await import("./GitRail.svelte");
 // Test-only wrapper that flips ONLY autopilotOn (sessionId stable) — see the
@@ -66,6 +69,8 @@ const { default: GitRailAutopilotHarness } = await import("./GitRailAutopilotHar
 // component reads so toggling it reactively updates the rendered pill.
 // repoConfig drives the critic-enabled flag the manual-review button gates on.
 const { planGates, reviews, repoConfig } = await import("$lib/reviews.svelte");
+// Mocked pull-offer fn — imported for assertions in the post-merge suite.
+const { pullMainAndToast } = await import("$lib/pull-offer");
 
 // Deterministic measurement: pin the rail's font so CI (no Berkeley Mono) and
 // local agree. The rail mounts into a fixed-width host cell. On desktop the
@@ -1314,6 +1319,7 @@ describe("GitRail — post-merge decommission offer", () => {
   beforeEach(() => {
     toastsInfo.mockClear();
     mergePrFn.mockClear();
+    (pullMainAndToast as ReturnType<typeof vi.fn>).mockClear();
   });
 
   // Helper: arm and confirm the merge button (two-click pattern used across the suite)
@@ -1331,8 +1337,8 @@ describe("GitRail — post-merge decommission offer", () => {
     h.querySelector<HTMLButtonElement>("button.gbtn:not(.auto-pill)")!.click();
   }
 
-  it("remote-forge merge shows decommission offer with the merged session id", async () => {
-    // mergePr returns a github-kind merged status
+  it("remote-forge merge (non-isolated) shows plain decommission offer with the merged session id", async () => {
+    // mergePr returns a github-kind merged status; baseProps has isolated unset (→ false)
     const { mergePr: mergePrMock } = await import("$lib/api");
     (mergePrMock as ReturnType<typeof vi.fn>).mockResolvedValue({
       kind: "github",
@@ -1356,12 +1362,13 @@ describe("GitRail — post-merge decommission offer", () => {
     // Wait for toasts.info to be called
     await vi.waitFor(() => expect(toastsInfo).toHaveBeenCalledTimes(1));
 
-    // The toast must have an action with the decommission label
+    // The toast must have an action with the plain decommission label (not combo)
     const [, opts] = toastsInfo.mock.calls[0] as [
       string,
       { action?: { label: string; run: () => void }; duration?: number; key?: string },
     ];
     expect(opts?.action, "toast has action").toBeDefined();
+    expect(opts?.action?.label, "plain decommission label").toBe(m.gitrail_decommission_action());
     expect(opts?.duration, "toast has 15s duration").toBe(15_000);
     expect(opts?.key, "toast has decommission key").toBe("decommission-offer:sess-A");
 
@@ -1369,6 +1376,117 @@ describe("GitRail — post-merge decommission offer", () => {
     // not whatever session might be focused at click time.
     opts!.action!.run();
     expect(ondecommission, "ondecommission called with captured id").toHaveBeenCalledWith("sess-A");
+    expect(pullMainAndToast, "pullMainAndToast NOT called for non-isolated").not.toHaveBeenCalled();
+  });
+
+  it("remote-forge merge (isolated) shows combo decommission & update offer", async () => {
+    const { mergePr: mergePrMock } = await import("$lib/api");
+    (mergePrMock as ReturnType<typeof vi.fn>).mockResolvedValue({
+      kind: "github",
+      state: "merged",
+      checks: "none",
+      deployConfigured: false,
+    });
+    gitStateFn.mockResolvedValue(openPrState);
+
+    const ondecommission = vi.fn();
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, {
+      target: h,
+      props: {
+        ...baseProps,
+        sessionId: "sess-A",
+        mobile: false,
+        isolated: true,
+        baseBranch: "main",
+        ondecommission,
+      },
+    });
+    await expect.element(screen.getByTitle("PR #12345")).toBeVisible();
+
+    await armAndConfirmMerge(h);
+
+    await vi.waitFor(() => expect(toastsInfo).toHaveBeenCalledTimes(1));
+
+    const [, opts] = toastsInfo.mock.calls[0] as [
+      string,
+      { action?: { label: string; run: () => void }; duration?: number; key?: string },
+    ];
+    expect(opts?.action, "toast has action").toBeDefined();
+    expect(opts?.action?.label, "combo label").toBe(m.gitrail_decommission_update_action());
+    expect(opts?.duration, "toast has 15s duration").toBe(15_000);
+    expect(opts?.key, "toast has decommission key").toBe("decommission-offer:sess-A");
+
+    opts!.action!.run();
+    expect(ondecommission, "ondecommission called with captured id").toHaveBeenCalledWith("sess-A");
+    expect(
+      pullMainAndToast,
+      "pullMainAndToast called with repoPath and baseBranch",
+    ).toHaveBeenCalledWith("/repo", "main");
+  });
+
+  it("combo action captures repoPath/baseBranch at merge time, not at click time", async () => {
+    // Regression: GitRail is reused across session switches (no {#key} wrapper in Viewport).
+    // Merging session A (repoPath "/repo"), then switching to session B (repoPath "/other")
+    // within the 15s toast window must still FF "/repo", not "/other".
+    const { mergePr: mergePrMock } = await import("$lib/api");
+    (mergePrMock as ReturnType<typeof vi.fn>).mockResolvedValue({
+      kind: "github",
+      state: "merged",
+      checks: "none",
+      deployConfigured: false,
+    });
+    gitStateFn.mockResolvedValue(openPrState);
+
+    const ondecommission = vi.fn();
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, {
+      target: h,
+      props: {
+        ...baseProps,
+        sessionId: "sess-A",
+        mobile: false,
+        isolated: true,
+        baseBranch: "main",
+        ondecommission,
+      },
+    });
+    await expect.element(screen.getByTitle("PR #12345")).toBeVisible();
+
+    await armAndConfirmMerge(h);
+
+    await vi.waitFor(() => expect(toastsInfo).toHaveBeenCalledTimes(1));
+
+    const [, opts] = toastsInfo.mock.calls[0] as [
+      string,
+      { action?: { label: string; run: () => void }; duration?: number; key?: string },
+    ];
+    expect(opts?.action, "toast has action").toBeDefined();
+
+    // Simulate session switch: rebind the component to a different session (repo Y)
+    // before the operator clicks the toast action — mirrors the live Viewport behaviour.
+    await screen.rerender({
+      ...baseProps,
+      sessionId: "sess-B",
+      mobile: false,
+      isolated: true,
+      repoPath: "/other",
+      baseBranch: "release",
+      ondecommission,
+    });
+
+    // Invoke the captured action — must use the values snapshotted at merge time.
+    opts!.action!.run();
+    expect(
+      pullMainAndToast,
+      "pullMainAndToast called with captured (/repo, main), not live (/other, release)",
+    ).toHaveBeenCalledWith("/repo", "main");
+    expect(
+      pullMainAndToast,
+      "pullMainAndToast NOT called with live props",
+    ).not.toHaveBeenCalledWith("/other", "release");
   });
 
   it("local-forge merge → no decommission offer action", async () => {

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -22,6 +22,7 @@
   import { featureAnnouncements } from "$lib/feature-announcements";
   import Coachmark from "$lib/components/Coachmark.svelte";
   import { pollWhileVisible } from "$lib/visibility";
+  import { pullMainAndToast } from "$lib/pull-offer";
 
   let {
     sessionId,
@@ -36,6 +37,8 @@
     drain = null,
     autopilotOn = false,
     issueNumber = null,
+    isolated = false,
+    baseBranch = "",
     ondecommission = undefined,
   }: {
     sessionId: string;
@@ -55,6 +58,11 @@
     /** Backlog issue this session was spawned for; drives the leftmost open-issue link.
         null = no linked issue. */
     issueNumber?: number | null;
+    /** When true and repoPath is set, the post-merge toast offers a combined
+        "Decommission & update local" action that also fast-forwards the local default branch. */
+    isolated?: boolean;
+    /** The session's base branch (e.g. "main"); used by the combined fast-forward action. */
+    baseBranch?: string;
     /** Offer to tear down THIS session after its PR is merged; called with the merged session's id. */
     ondecommission?: (id: string) => void;
   } = $props();
@@ -268,12 +276,23 @@
     retry = null;
     try {
       const mergedId = sessionId;
+      const ffPath = repoPath; // capture FF target at merge time, like mergedId —
+      const ffBranch = baseBranch; // the toast lives 15s and the GitRail instance rebinds on session switch
       git = { kind: git?.kind ?? "github", ...(await mergePr(sessionId)) };
       if (git.kind === "local") {
         toasts.info(m.toast_merged({ name: name || mergedId }));
       } else {
+        const update = isolated && !!ffPath;
         toasts.info(m.toast_merged({ name: name || mergedId }), {
-          action: { label: m.gitrail_decommission_action(), run: () => ondecommission?.(mergedId) },
+          action: {
+            label: update
+              ? m.gitrail_decommission_update_action()
+              : m.gitrail_decommission_action(),
+            run: () => {
+              ondecommission?.(mergedId);
+              if (update) pullMainAndToast(ffPath, ffBranch);
+            },
+          },
           duration: 15_000,
           key: `decommission-offer:${mergedId}`,
         });

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -271,14 +271,22 @@
   // Queue the post-merge confirmation toast. Local-forge merges get a plain confirmation;
   // remote-forge merges add a one-click Decommission, upgraded to "Decommission & update
   // local" for isolated sessions (which also fast-forwards the local default branch). The
-  // FF target (ffPath/ffBranch) is captured by the caller at merge time — see doMerge.
-  function showMergedToast(kind: string, mergedId: string, ffPath: string, ffBranch: string) {
+  // FF target + isolation (isIsolated/ffPath/ffBranch) are captured by the caller at merge
+  // time — see doMerge. They MUST travel together: mixing a freshly-rebound isolated flag
+  // with the prior session's FF target would fast-forward the wrong checkout.
+  function showMergedToast(
+    kind: string,
+    mergedId: string,
+    isIsolated: boolean,
+    ffPath: string,
+    ffBranch: string,
+  ) {
     const text = m.toast_merged({ name: name || mergedId });
     if (kind === "local") {
       toasts.info(text);
       return;
     }
-    const update = isolated && !!ffPath;
+    const update = isIsolated && !!ffPath;
     toasts.info(text, {
       action: {
         label: update ? m.gitrail_decommission_update_action() : m.gitrail_decommission_action(),
@@ -300,10 +308,14 @@
     retry = null;
     try {
       const mergedId = sessionId;
-      const ffPath = repoPath; // capture FF target at merge time, like mergedId —
-      const ffBranch = baseBranch; // the toast lives 15s and the GitRail instance rebinds on session switch
+      // Capture the session identity AND its FF target/isolation before the await —
+      // the GitRail instance rebinds on a session switch, and the toast lives 15s, so
+      // a live read could pair a new session's isolated flag with the old FF target.
+      const isIsolated = isolated;
+      const ffPath = repoPath;
+      const ffBranch = baseBranch;
       git = { kind: git?.kind ?? "github", ...(await mergePr(sessionId)) };
-      showMergedToast(git.kind, mergedId, ffPath, ffBranch);
+      showMergedToast(git.kind, mergedId, isIsolated, ffPath, ffBranch);
     } catch (e) {
       // prefer the known local cause over a raw server string
       err =

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -268,6 +268,30 @@
     }
   }
 
+  // Queue the post-merge confirmation toast. Local-forge merges get a plain confirmation;
+  // remote-forge merges add a one-click Decommission, upgraded to "Decommission & update
+  // local" for isolated sessions (which also fast-forwards the local default branch). The
+  // FF target (ffPath/ffBranch) is captured by the caller at merge time — see doMerge.
+  function showMergedToast(kind: string, mergedId: string, ffPath: string, ffBranch: string) {
+    const text = m.toast_merged({ name: name || mergedId });
+    if (kind === "local") {
+      toasts.info(text);
+      return;
+    }
+    const update = isolated && !!ffPath;
+    toasts.info(text, {
+      action: {
+        label: update ? m.gitrail_decommission_update_action() : m.gitrail_decommission_action(),
+        run: () => {
+          ondecommission?.(mergedId);
+          if (update) pullMainAndToast(ffPath, ffBranch);
+        },
+      },
+      duration: 15_000,
+      key: `decommission-offer:${mergedId}`,
+    });
+  }
+
   // skipArm lets the inline Retry re-run a confirmed action without a second arm tap
   async function doMerge(skipArm = false) {
     if (!skipArm && !arm("merge")) return;
@@ -279,24 +303,7 @@
       const ffPath = repoPath; // capture FF target at merge time, like mergedId —
       const ffBranch = baseBranch; // the toast lives 15s and the GitRail instance rebinds on session switch
       git = { kind: git?.kind ?? "github", ...(await mergePr(sessionId)) };
-      if (git.kind === "local") {
-        toasts.info(m.toast_merged({ name: name || mergedId }));
-      } else {
-        const update = isolated && !!ffPath;
-        toasts.info(m.toast_merged({ name: name || mergedId }), {
-          action: {
-            label: update
-              ? m.gitrail_decommission_update_action()
-              : m.gitrail_decommission_action(),
-            run: () => {
-              ondecommission?.(mergedId);
-              if (update) pullMainAndToast(ffPath, ffBranch);
-            },
-          },
-          duration: 15_000,
-          key: `decommission-offer:${mergedId}`,
-        });
-      }
+      showMergedToast(git.kind, mergedId, ffPath, ffBranch);
     } catch (e) {
       // prefer the known local cause over a raw server string
       err =

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1996,6 +1996,8 @@
         {drain}
         autopilotOn={autopilotEffective}
         issueNumber={session.issueNumber}
+        isolated={session.isolated}
+        baseBranch={session.baseBranch}
         ondecommission={confirmDecommission}
         mobile
       />

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1790,7 +1790,7 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_plugin_gear_item_body",
   },
   {
-    // #<PR>: isolated-session post-merge toast now offers a combined "Decommission &
+    // #1226: isolated-session post-merge toast now offers a combined "Decommission &
     // update local" action (restores the local fast-forward removed in #1121, folded
     // into the one Decommission offer). No targetId — a transient toast action is not a
     // stable coachmark anchor; What's-New drawer only. 1.38.0 is the latest released tag.

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1789,4 +1789,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_plugin_gear_item_title",
     bodyKey: "feat_plugin_gear_item_body",
   },
+  {
+    // #<PR>: isolated-session post-merge toast now offers a combined "Decommission &
+    // update local" action (restores the local fast-forward removed in #1121, folded
+    // into the one Decommission offer). No targetId — a transient toast action is not a
+    // stable coachmark anchor; What's-New drawer only. 1.38.0 is the latest released tag.
+    id: "decommission-and-update-local",
+    sinceVersion: "1.39.0",
+    titleKey: "feat_decommission_update_local_title",
+    bodyKey: "feat_decommission_update_local_body",
+  },
 ];


### PR DESCRIPTION
## What

After a manual PR merge of an **isolated** session on a remote forge, the confirmation toast's single action becomes **"Decommission & update local"** — it tears the finished session down *and* fast-forwards the repo's local default-branch checkout in one click. This restores the post-merge local fast-forward removed in #1121, folded into the existing Decommission offer instead of stacking a second competing toast.

- **Isolated, remote forge** → `Decommission & update local` (runs `ondecommission` then `pullMainAndToast(repoPath, baseBranch)`).
- **Non-isolated, remote forge** → plain `Decommission` (unchanged; their feature branch is in the canonical clone, so a fast-forward would always report `wrong_branch`).
- **Local forge** → plain "Merged" toast, no action (unchanged).

## Why this is safe re #1121

#1121 removed `offerUpdateMain()` because it stacked **two competing 15s offer toasts**. This design keeps **one** offer; clicking it produces sequential *result* toasts, not two competing *asks*. It reuses the retained `pullMainAndToast` helper + `POST /api/repos/pull` (strict `--ff-only`, fail-closed) rather than resurrecting the deleted wrapper. Decommission removes the session **worktree**; the pull fast-forwards the **canonical clone** — different dirs, no race.

The fast-forward **target is captured at merge time** (`ffPath`/`ffBranch`, symmetric with `mergedId`), so switching the focused session during the 15s toast window can't redirect the pull at the wrong repo — covered by a regression test.

## Out of scope (intentional)

- The backlog **PrRow** merge path (no session/worktree to decommission — already covered by BacklogView's standalone Fast-forward button).
- The **merge-train landed** toast (no single PR/session).

## Tests / gates

- New + updated `GitRail.browser.test.ts`: isolated combo asserts `pullMainAndToast("/repo","main")` + `ondecommission`; non-isolated asserts plain label + no pull; capture regression test rerenders with different props before clicking.
- `svelte-check` 0 errors · `check:i18n` parity (3 keys × EN+DE) · feature-catalog entry `decommission-and-update-local` (1.39.0) · full UI suite green.

> ⚠️ Note: the local pre-push `root-tests` lane reports 3 failing `test/usage.test.ts` (`SessionUsageRollup` model-cost windowing) tests — **pre-existing on `main`** (verified at the merge-base) and unrelated to this UI-only diff. Not fixed here to keep the branch single-feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)