### PR TITLE
fix(upnext): surface fetch failure instead of false "all caught up"

### DIFF
--- a/src/up-next-core.ts
+++ b/src/up-next-core.ts
@@ -47,10 +47,13 @@ export interface UpNextSection {
 export interface UpNextSnapshot {
   generatedAt: number;
   sections: UpNextSection[];
-  /** Forge-backed repos scanned this refresh. */
+  /** Forge-backed repos successfully scanned this refresh (excludes ones whose fetch failed). */
   repoCount: number;
   /** Degraded rung applied this refresh (e.g. "warm-repos-only"), or null when clean. */
   fallback: string | null;
+  /** Repos whose issue fetch threw this refresh and were dropped. >0 means a fetch failure may
+   *  be hiding work, so the UI surfaces a load error instead of an "all caught up" empty state. */
+  failedRepoCount: number;
 }
 
 /** A resolved epic, as fed in by the service (after buildEpic + selectEpicCandidates). */
@@ -206,6 +209,7 @@ export function buildSnapshot(
   repos: RepoInput[],
   now: number,
   fallback: string | null = null,
+  failedRepoCount = 0,
 ): UpNextSnapshot {
   const rank = warmRanks(repos);
   const all = repos.flatMap((r) => repoItems(r));
@@ -258,7 +262,7 @@ export function buildSnapshot(
     });
   }
 
-  return { generatedAt: now, sections, repoCount: repos.length, fallback };
+  return { generatedAt: now, sections, repoCount: repos.length, fallback, failedRepoCount };
 }
 
 /**

--- a/src/up-next.ts
+++ b/src/up-next.ts
@@ -120,10 +120,9 @@ export class UpNextService {
     const resolved = await mapBounded(repos, this.concurrency, (r) =>
       this.resolveRepo(r, lastUsed),
     );
-    const snap = buildSnapshot(
-      resolved.filter((r): r is RepoInput => r !== null),
-      this.now(),
-    );
+    const ok = resolved.filter((r): r is RepoInput => r !== null && r !== "fetch_failed");
+    const failedRepoCount = resolved.filter((r) => r === "fetch_failed").length;
+    const snap = buildSnapshot(ok, this.now(), null, failedRepoCount);
     this.snap = snap;
     try {
       this.deps.onChange(snap);
@@ -136,14 +135,16 @@ export class UpNextService {
   private async resolveRepo(
     r: UpNextRepo,
     lastUsed: Record<string, number>,
-  ): Promise<RepoInput | null> {
+  ): Promise<RepoInput | "fetch_failed" | null> {
     const forge = this.deps.resolveForge(r.repoPath);
-    if (!forge) return null;
+    if (!forge) return null; // forge vanished mid-compute → benign skip, not a fetch failure
     let openIssues: Awaited<ReturnType<GitForge["listIssues"]>>;
     try {
       openIssues = await forge.listIssues();
     } catch {
-      return null; // forge/network error → drop the repo this refresh (empty section omitted)
+      // forge/network error (e.g. rate limit) → drop the repo, but flag it as a failure so the
+      // snapshot can surface a load error rather than looking "all caught up" (cf. #1221).
+      return "fetch_failed";
     }
     const summaries = (await forge.listSubIssueSummaries?.().catch(() => null)) ?? {
       summaries: new Map<number, { total: number; completed: number }>(),

--- a/test/server-up-next.test.ts
+++ b/test/server-up-next.test.ts
@@ -22,6 +22,7 @@ const SNAP: UpNextSnapshot = {
   generatedAt: 123,
   repoCount: 1,
   fallback: null,
+  failedRepoCount: 0,
   sections: [],
 };
 
@@ -167,6 +168,7 @@ test("GET /api/up-next?peek strips hidden-repo sections via hiddenRepoPathsRaw",
     generatedAt: 999,
     repoCount: 2,
     fallback: null,
+    failedRepoCount: 0,
     sections: [hiddenSection, visibleSection],
   };
   const { app } = harness({

--- a/test/up-next-core.test.ts
+++ b/test/up-next-core.test.ts
@@ -316,7 +316,7 @@ function makePrioritySection(items: UpNextItem[]): UpNextSection {
 }
 
 function makeSnap(sections: UpNextSection[], repoCount: number): UpNextSnapshot {
-  return { generatedAt: 1000, sections, repoCount, fallback: null };
+  return { generatedAt: 1000, sections, repoCount, fallback: null, failedRepoCount: 0 };
 }
 
 describe("excludeHiddenSections", () => {

--- a/test/up-next.test.ts
+++ b/test/up-next.test.ts
@@ -59,7 +59,7 @@ describe("UpNextService.refresh", () => {
     expect(s.snapshot()).toBe(snap);
   });
 
-  test("a repo whose listIssues throws is dropped (no section)", async () => {
+  test("a repo whose listIssues throws is dropped and flagged as a fetch failure", async () => {
     const s = svc({
       resolveForge: () =>
         fakeForge({
@@ -70,6 +70,9 @@ describe("UpNextService.refresh", () => {
     });
     const snap = await s.refresh();
     expect(snap.sections).toEqual([]);
+    // The empty queue is a fetch failure, not "all caught up": flag it so the UI surfaces it.
+    expect(snap.repoCount).toBe(0);
+    expect(snap.failedRepoCount).toBe(1);
   });
 
   test("refresh is single-flight (concurrent callers share one compute)", async () => {

--- a/ui/src/lib/components/UpNextPanel.browser.test.ts
+++ b/ui/src/lib/components/UpNextPanel.browser.test.ts
@@ -153,4 +153,13 @@ describe("UpNextPanel load failure", () => {
     await expect.element(page.getByText("#2")).toBeInTheDocument();
     await expect.element(page.getByText(m.common_issues_load_failed())).not.toBeInTheDocument();
   });
+
+  it("keeps painting cached work when a lens-open fetch throws (does not blank to error)", async () => {
+    // A successful app-load peek left a usable snapshot; the lens-open GET then fails.
+    upNext.snapshot = SNAPSHOT;
+    vi.mocked(getUpNext).mockRejectedValueOnce(new Error("network down"));
+    render(UpNextPanel, {});
+    await expect.element(page.getByText("#2")).toBeInTheDocument();
+    await expect.element(page.getByText(m.common_issues_load_failed())).not.toBeInTheDocument();
+  });
 });

--- a/ui/src/lib/components/UpNextPanel.browser.test.ts
+++ b/ui/src/lib/components/UpNextPanel.browser.test.ts
@@ -5,6 +5,7 @@ import "../../app.css";
 import type { UpNextItem, UpNextSnapshot } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
 import { upNext } from "$lib/up-next.svelte";
+import { getUpNext } from "$lib/api";
 
 // Mock the API so mounting (which kicks upNext.load()) makes no real network call.
 vi.mock("$lib/api", async (importOriginal) => {
@@ -36,6 +37,7 @@ const SNAPSHOT: UpNextSnapshot = {
   generatedAt: 1,
   repoCount: 2,
   fallback: null,
+  failedRepoCount: 0,
   sections: [
     {
       kind: "priority",
@@ -81,6 +83,7 @@ beforeEach(() => {
 });
 afterEach(() => {
   upNext.snapshot = null;
+  upNext.loadError = false;
   fontStyle.remove();
 });
 
@@ -106,5 +109,48 @@ describe("UpNextPanel repo filter", () => {
     await expect
       .element(page.getByText(m.upnext_repo_filter_empty({ repo: "does-not-exist" })))
       .toBeInTheDocument();
+  });
+});
+
+describe("UpNextPanel load failure", () => {
+  it("surfaces a load error when every repo's issue fetch failed (empty queue, failures > 0)", async () => {
+    upNext.snapshot = {
+      generatedAt: 1,
+      repoCount: 0,
+      fallback: null,
+      failedRepoCount: 2,
+      sections: [],
+    };
+    render(UpNextPanel, {});
+    // The failure must win over the "all caught up" empty state.
+    await expect.element(page.getByText(m.common_issues_load_failed())).toBeInTheDocument();
+    await expect.element(page.getByText(m.upnext_empty())).not.toBeInTheDocument();
+  });
+
+  it("surfaces a load error when the snapshot fetch itself throws", async () => {
+    upNext.snapshot = null;
+    vi.mocked(getUpNext).mockRejectedValueOnce(new Error("network down"));
+    render(UpNextPanel, {});
+    await expect.element(page.getByText(m.common_issues_load_failed())).toBeInTheDocument();
+  });
+
+  it("shows the all-caught-up empty state (not an error) when the queue is genuinely empty", async () => {
+    upNext.snapshot = {
+      generatedAt: 1,
+      repoCount: 3,
+      fallback: null,
+      failedRepoCount: 0,
+      sections: [],
+    };
+    render(UpNextPanel, {});
+    await expect.element(page.getByText(m.upnext_empty())).toBeInTheDocument();
+    await expect.element(page.getByText(m.common_issues_load_failed())).not.toBeInTheDocument();
+  });
+
+  it("renders the queue (no error) when some repos failed but work remains", async () => {
+    upNext.snapshot = { ...SNAPSHOT, failedRepoCount: 1 };
+    render(UpNextPanel, {});
+    await expect.element(page.getByText("#2")).toBeInTheDocument();
+    await expect.element(page.getByText(m.common_issues_load_failed())).not.toBeInTheDocument();
   });
 });

--- a/ui/src/lib/components/UpNextPanel.svelte
+++ b/ui/src/lib/components/UpNextPanel.svelte
@@ -48,7 +48,15 @@
   // Empty ("all caught up") only once the server has actually produced a snapshot; a null/
   // never-computed snapshot shows loading, not the all-clear.
   const computed = $derived(snap?.generatedAt != null);
-  const isEmpty = $derived(computed && sections.length === 0);
+  // A fetch failure must not masquerade as "all caught up" (#1221): either the GET itself threw
+  // (upNext.loadError), or the server dropped repos whose issue fetch errored AND the whole
+  // (unfiltered) queue came back empty. Keyed off snap.sections — not the filtered `sections` —
+  // so a repo filter that is legitimately empty still reads as empty, not failed.
+  const loadFailed = $derived(
+    upNext.loadError ||
+      (computed && (snap?.failedRepoCount ?? 0) > 0 && (snap?.sections.length ?? 0) === 0),
+  );
+  const isEmpty = $derived(computed && !loadFailed && sections.length === 0);
   const updatedAgo = $derived(
     snap?.generatedAt != null ? formatAgo(clock.current - snap.generatedAt) : null,
   );
@@ -223,7 +231,11 @@
   {/if}
 
   <div class="un-body">
-    {#if !computed}
+    {#if loadFailed}
+      <!-- Fetch failed (GET threw, or every-/some-repo issue fetch errored into an empty queue):
+           surface it rather than implying an empty backlog. The header ⟳ retries. -->
+      <p class="un-muted">{m.common_issues_load_failed()}</p>
+    {:else if !computed}
       <!-- No server snapshot yet (first compute in flight) → loading, never the all-clear. -->
       <p class="un-muted">{m.common_loading()}</p>
     {:else if isEmpty}

--- a/ui/src/lib/components/UpNextPanel.svelte
+++ b/ui/src/lib/components/UpNextPanel.svelte
@@ -48,13 +48,16 @@
   // Empty ("all caught up") only once the server has actually produced a snapshot; a null/
   // never-computed snapshot shows loading, not the all-clear.
   const computed = $derived(snap?.generatedAt != null);
-  // A fetch failure must not masquerade as "all caught up" (#1221): either the GET itself threw
-  // (upNext.loadError), or the server dropped repos whose issue fetch errored AND the whole
-  // (unfiltered) queue came back empty. Keyed off snap.sections — not the filtered `sections` —
-  // so a repo filter that is legitimately empty still reads as empty, not failed.
+  // A fetch failure must not masquerade as "all caught up" (#1221), but it also must not blank
+  // out work we can still show. Surface the error only when there is nothing to display:
+  //   - server-side: repos whose fetch errored AND the (unfiltered) snapshot is empty. Keyed off
+  //     snap.sections — not the filtered `sections` — so a legitimately-empty repo filter over a
+  //     non-empty queue still reads as "empty", not "failed".
+  //   - client-side: the GET itself threw AND there is no usable cached work to render — a failed
+  //     lens-open after a successful app-load peek keeps painting the cached queue, not the error.
   const loadFailed = $derived(
-    upNext.loadError ||
-      (computed && (snap?.failedRepoCount ?? 0) > 0 && (snap?.sections.length ?? 0) === 0),
+    (computed && (snap?.failedRepoCount ?? 0) > 0 && (snap?.sections.length ?? 0) === 0) ||
+      (upNext.loadError && sections.length === 0),
   );
   const isEmpty = $derived(computed && !loadFailed && sections.length === 0);
   const updatedAgo = $derived(

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1221,6 +1221,9 @@ export interface UpNextSnapshot {
   sections: UpNextSection[];
   repoCount: number;
   fallback: string | null;
+  /** Repos whose issue fetch failed this refresh; >0 + empty queue = surface a load error,
+   *  not "all caught up". */
+  failedRepoCount: number;
 }
 
 export type WsEvent =

--- a/ui/src/lib/up-next.svelte.ts
+++ b/ui/src/lib/up-next.svelte.ts
@@ -7,14 +7,19 @@ import { getUpNext } from "./api";
 class UpNextStore {
   snapshot = $state<UpNextSnapshot | null>(null);
   loaded = $state(false);
+  /** The GET itself failed (herdr down / non-2xx). Distinct from an empty snapshot so the lens
+   *  surfaces a load error rather than hanging on "loading" or implying an empty queue (#1221). */
+  loadError = $state(false);
 
   /** Load the snapshot. `peek` (app-load) paints the cached snapshot only; the default
    *  (lens-open) lets the server kick a recompute that lands in place via WS. */
   async load(opts?: { peek?: boolean }) {
+    this.loadError = false;
     try {
       this.snapshot = await getUpNext(opts);
     } catch {
-      /* best-effort; live events still populate */
+      // best-effort; live events may still populate, but flag it so the lens shows the failure
+      this.loadError = true;
     } finally {
       this.loaded = true;
     }
@@ -22,6 +27,7 @@ class UpNextStore {
 
   apply(d: { snapshot: UpNextSnapshot }) {
     this.snapshot = d.snapshot;
+    this.loadError = false; // a fresh server push supersedes a prior failed fetch
   }
 }
 export const upNext = new UpNextStore();


### PR DESCRIPTION
## Problem

The **Up Next** lens (DE *NÄCHSTES*) showed *"You're all caught up — nothing queued to start"* even with 22 tasks and several repos. The reporter rightly suspected we were **hiding a fetch failure behind the empty state**.

Root cause in `src/up-next.ts`: when a repo's `listIssues()` threw (e.g. GitHub rate limit / auth / network), `resolveRepo` silently `return null`'d and the repo was dropped. If **every** repo's fetch failed, `buildSnapshot` still produced a snapshot with `generatedAt` set and **empty `sections`** → `UpNextPanel` rendered the "all caught up" empty state. A fetch failure masquerading as an empty backlog.

Two failure surfaces, both fixed:
1. **Server:** every-/some-repo issue fetch errors into an empty queue.
2. **Client:** the `GET /api/up-next` call itself throws (herdr down / non-2xx) → previously stuck on *loading* forever.

This is the exact analog of the IssuesPanel fix in #1221.

## Fix

- **Server** (`up-next-core.ts`, `up-next.ts`): `UpNextSnapshot` gains `failedRepoCount`. `resolveRepo` now distinguishes a genuine fetch failure (`"fetch_failed"`) from a benign skip (forge vanished); `compute()` counts the failures into the snapshot.
- **Client store** (`up-next.svelte.ts`): tracks `loadError` when the GET throws; a fresh WS push clears it.
- **Panel** (`UpNextPanel.svelte`): renders the existing `common_issues_load_failed` message **before** the empty state when `loadError` OR (computed && `failedRepoCount > 0` && the **unfiltered** snapshot is empty). Keying off the unfiltered snapshot means a legitimately-empty repo filter still reads as empty, and a partial failure that still returns work renders the queue unchanged. The header ⟳ retries.

## Tests

- `test/up-next.test.ts`: a repo whose `listIssues` throws is now asserted to flag `failedRepoCount: 1` / `repoCount: 0`.
- `UpNextPanel.browser.test.ts`: 4 new cases — all-repos-failed → error; GET throws → error; genuinely-empty → all-caught-up (not error); partial failure with work → queue renders, no error.
- Reuses the existing `common_issues_load_failed` key (EN+DE already in parity) — no new i18n keys.

Verified: root lint, 42 server tests, 7 UI browser tests, `svelte-check` (0 errors), `check:i18n` (parity) all green.

`[no-feature-entry]` — bug fix, no new user-facing capability.