### PR TITLE
feat: deliver plan-gate & research directives to Codex (TASK-413)

### DIFF
--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -491,16 +491,24 @@ export class PlanGateService {
 
   /** Persist an approved gate. A session meant to run hands-free — drain-spawned (auto) OR
    *  autopilot-enabled — clears straight into execution; a purely interactive (autopilot-off)
-   *  session waits for the operator's explicit Go (so we do NOT release it here). */
+   *  session waits for the operator's explicit Go (so we do NOT release it here).
+   *
+   *  Codex divergence (TASK-413): Codex autopilot stands down on a NON-isolated session — its
+   *  resume path (`codex resume --last`) would target a sibling codex session in a shared cwd (see
+   *  autopilot.ts eligible() + buildCodexSpawnArgv's isolated-gated autopilot). Such a session is
+   *  therefore NOT actually hands-free, so it must wait for the operator's explicit Go rather than
+   *  auto-releasing here. Guard only the autopilot arm: drain (`s.auto`) can't reach a codex session
+   *  (full-auto is codex-disabled), so it needs no guard and must still release unattended. */
   private applyApproved(f: PlanInFlight, gate: PlanGate): void {
     this.deps.store.putPlanGate(gate);
     this.deps.onChange(f.sessionId, gate);
     const s = this.deps.store.get(f.sessionId);
-    if (
-      s &&
-      (s.auto || effectiveAutopilot(s, this.deps.store.getRepoConfig(s.repoPath).autopilotEnabled))
-    )
-      this.deps.release(f.sessionId);
+    if (!s) return;
+    const codexNonIsolated = (s.agentProvider ?? "claude") === "codex" && !s.isolated;
+    const autopilotReleases =
+      !codexNonIsolated &&
+      effectiveAutopilot(s, this.deps.store.getRepoConfig(s.repoPath).autopilotEnabled);
+    if (s.auto || autopilotReleases) this.deps.release(f.sessionId);
   }
 
   /** Steer the findings back to the LIVE planning agent while under the cap; at/over the cap stop

--- a/src/service.ts
+++ b/src/service.ts
@@ -809,13 +809,30 @@ function planGateDirectiveInteractive(agentProvider: AgentProvider): string {
   );
 }
 const PLAN_GATE_DIRECTIVE_INTERACTIVE = planGateDirectiveInteractive("claude");
-const PLAN_GATE_DIRECTIVE_AUTO =
-  "You are in Shepherd's pre-execution PLAN GATE, running unattended (no human to ask). Do NOT write " +
-  "or modify product code yet. Research the codebase, then write a concrete plan to `.shepherd-plan.md` " +
-  "at the repo root (goal, approach, files, steps, risks, success criteria). An adversarial reviewer " +
-  "will critique it; revise `.shepherd-plan.md` to address findings. Begin implementing ONLY after you " +
-  "are told the plan is approved.\n\n" +
-  planBlockInstructions({ allowQuestionForm: true });
+/**
+ * The unattended (drain) plan-gate directive, provider-adjusted. The auto path has NO human to catch
+ * an eager Codex that starts implementing — so it needs the hardened stop clause even MORE than the
+ * interactive path. Codex gets the same lead-in stop clause; Claude keeps the original phrasing.
+ * `planGateDirectiveAuto("claude")` is byte-identical to the prior `PLAN_GATE_DIRECTIVE_AUTO`
+ * constant — keep it that way (Claude regression).
+ */
+function planGateDirectiveAuto(agentProvider: AgentProvider): string {
+  const stopClause =
+    agentProvider === "codex"
+      ? "Do NOT write or modify ANY code this turn. Your ONLY deliverable right now is the plan file " +
+        "`.shepherd-plan.md`; once you have written it, STOP and wait — do not start implementing.\n"
+      : "";
+  return (
+    stopClause +
+    "You are in Shepherd's pre-execution PLAN GATE, running unattended (no human to ask). Do NOT write " +
+    "or modify product code yet. Research the codebase, then write a concrete plan to `.shepherd-plan.md` " +
+    "at the repo root (goal, approach, files, steps, risks, success criteria). An adversarial reviewer " +
+    "will critique it; revise `.shepherd-plan.md` to address findings. Begin implementing ONLY after you " +
+    "are told the plan is approved.\n\n" +
+    planBlockInstructions({ allowQuestionForm: true, agentProvider })
+  );
+}
+const PLAN_GATE_DIRECTIVE_AUTO = planGateDirectiveAuto("claude");
 export { PLAN_GATE_DIRECTIVE_INTERACTIVE, PLAN_GATE_DIRECTIVE_AUTO };
 
 /**
@@ -929,6 +946,33 @@ export function planGoSteer(draftMode: boolean): string {
  * planning; the agent only opens a PR later). `opts.trimmed`, when true, appends the context-trim
  * notice — set only for trimmed auto spawns (see trimDecision), orthogonal to everything else.
  */
+/**
+ * The single highest-priority directive block for a spawn: research REPLACES the plan-gate and
+ * autopilot directives; a plan gate REPLACES autopilot; otherwise autopilot rides when active.
+ * Returns the ready-wrapped block, or null when none applies. Extracted from composeSystemPrompt to
+ * keep that function under the complexity gate.
+ */
+function primaryDirectiveBlock(
+  agentProvider: AgentProvider,
+  autopilotActive: boolean,
+  opts: { research?: boolean; planGate?: "interactive" | "auto" },
+): string | null {
+  if (opts.research) {
+    return `<research-directive>\n${researchDirective(agentProvider)}\n</research-directive>`;
+  }
+  if (opts.planGate) {
+    const variant =
+      opts.planGate === "auto"
+        ? planGateDirectiveAuto(agentProvider)
+        : planGateDirectiveInteractive(agentProvider);
+    return `<plan-gate-directive>\n${variant}\n</plan-gate-directive>`;
+  }
+  if (autopilotActive) {
+    return `<autopilot-directive>\n${AUTOPILOT_DIRECTIVE}\n</autopilot-directive>`;
+  }
+  return null;
+}
+
 export function composeSystemPrompt(
   houseRules: string | null,
   autopilotActive = false,
@@ -969,18 +1013,9 @@ export function composeSystemPrompt(
     }
   }
   // Research is the highest-priority directive: it replaces BOTH the plan-gate and the autopilot
-  // directive (none of those fit a report-PR/issue deliverable).
-  if (opts.research) {
-    blocks.push(`<research-directive>\n${researchDirective(agentProvider)}\n</research-directive>`);
-  } else if (opts.planGate) {
-    const variant =
-      opts.planGate === "auto"
-        ? PLAN_GATE_DIRECTIVE_AUTO
-        : planGateDirectiveInteractive(agentProvider);
-    blocks.push(`<plan-gate-directive>\n${variant}\n</plan-gate-directive>`);
-  } else if (autopilotActive) {
-    blocks.push(`<autopilot-directive>\n${AUTOPILOT_DIRECTIVE}\n</autopilot-directive>`);
-  }
+  // directive (none of those fit a report-PR/issue deliverable). See primaryDirectiveBlock.
+  const primary = primaryDirectiveBlock(agentProvider, autopilotActive, opts);
+  if (primary) blocks.push(primary);
   // Build queue rides independently of the plan-gate/autopilot directive (orthogonal repo config),
   // but a research session authors no queue — suppress it there too.
   if (!opts.research && opts.buildQueue != null)

--- a/src/service.ts
+++ b/src/service.ts
@@ -560,24 +560,39 @@ export const MANUAL_STEPS_NOTICE =
 
 /**
  * Injected as the highest-priority directive for an attended RESEARCH task (`research: true`).
- * A research session does open-ended web research with sub-agents and delivers a report-only PR
- * OR a GitHub issue — never code. It SUPPRESSES the plan-gate, autopilot, and build-queue
- * directives (see composeSystemPrompt), since none of those fit a research deliverable. Not
- * user-facing chrome (an instruction to the agent), so no i18n — same precedent as
- * AUTOPILOT_DIRECTIVE and the other spawn-constant directives.
+ * A research session does open-ended web research and delivers a report-only PR OR a GitHub issue —
+ * never code. It SUPPRESSES the plan-gate, autopilot, and build-queue directives (see
+ * composeSystemPrompt), since none of those fit a research deliverable. Not user-facing chrome (an
+ * instruction to the agent), so no i18n — same precedent as AUTOPILOT_DIRECTIVE and the other
+ * spawn-constant directives.
+ *
+ * Provider-adjusted: Claude can fan out work to sub-agents (the Task tool); Codex has no sub-agent
+ * capability, so its variant drops the "sub-agents" phrasing and tells it to research directly via
+ * web search / fetch. The deliverable (report-PR or issue) and the no-code / attended rules are
+ * identical across providers. `researchDirective("claude")` is byte-identical to the prior
+ * `RESEARCH_DIRECTIVE` constant — keep it that way (Claude regression).
  */
-const RESEARCH_DIRECTIVE =
-  "You are running as an attended RESEARCH task — open-ended web research with sub-agents, NOT " +
-  "writing product code.\n" +
-  "- Use web search / fetch and dispatch sub-agents to investigate thoroughly, then synthesize " +
-  "the findings yourself.\n" +
-  "- Deliver exactly ONE of: (a) a markdown report written to `docs/research/<slug>.md` and " +
-  "opened as a report-only PR — that report file is the ENTIRE diff, no code changes; or (b) a " +
-  "GitHub issue capturing the findings and recommendation. Choose (a) for reference material, " +
-  "(b) for actionable follow-up work.\n" +
-  "- Do NOT open a code pull request and do NOT modify product code. Once your deliverable " +
-  "(report PR or issue) is up, you are done.\n" +
-  "- You are attended: ask the user on a genuine product/requirements decision; otherwise keep going.";
+function researchDirective(agentProvider: AgentProvider): string {
+  const head =
+    agentProvider === "codex"
+      ? "You are running as an attended RESEARCH task — open-ended web research, NOT " +
+        "writing product code.\n" +
+        "- Use web search / fetch to investigate thoroughly, then synthesize the findings yourself.\n"
+      : "You are running as an attended RESEARCH task — open-ended web research with sub-agents, NOT " +
+        "writing product code.\n" +
+        "- Use web search / fetch and dispatch sub-agents to investigate thoroughly, then synthesize " +
+        "the findings yourself.\n";
+  return (
+    head +
+    "- Deliver exactly ONE of: (a) a markdown report written to `docs/research/<slug>.md` and " +
+    "opened as a report-only PR — that report file is the ENTIRE diff, no code changes; or (b) a " +
+    "GitHub issue capturing the findings and recommendation. Choose (a) for reference material, " +
+    "(b) for actionable follow-up work.\n" +
+    "- Do NOT open a code pull request and do NOT modify product code. Once your deliverable " +
+    "(report PR or issue) is up, you are done.\n" +
+    "- You are attended: ask the user on a genuine product/requirements decision; otherwise keep going."
+  );
+}
 
 /**
  * Build the build-queue directive injected at spawn when the repo has `buildQueueEnabled`.
@@ -692,7 +707,10 @@ export function buildQueueDirective(args: {
  * When `allowQuestionForm` is false (interactive), the `question-form` block type is omitted
  * entirely and the agent is told to ask questions live, not park them in the sidecar.
  */
-export function planBlockInstructions(opts: { allowQuestionForm: boolean }): string {
+export function planBlockInstructions(opts: {
+  allowQuestionForm: boolean;
+  agentProvider?: AgentProvider;
+}): string {
   const lines: string[] = [
     "## Optional visual-plan sidecar",
     "",
@@ -732,9 +750,14 @@ export function planBlockInstructions(opts: { allowQuestionForm: boolean }): str
         "— for surfacing genuinely-undecidable-without-a-human questions when running unattended. Use sparingly: only for questions that cannot be resolved by reading the codebase.",
     );
   } else {
+    // Codex has no AskUserQuestion tool — drop that tool reference for it (Claude keeps it verbatim).
+    const liveAsk =
+      opts.agentProvider === "codex"
+        ? "Ask questions live in the conversation; the sidecar carries only rendering blocks."
+        : "Ask questions live in the conversation (or via AskUserQuestion for choices); the sidecar carries only rendering blocks.";
     lines.push(
       "In interactive mode you must ask questions live — never park them in the plan or sidecar. " +
-        "Ask questions live in the conversation (or via AskUserQuestion for choices); the sidecar carries only rendering blocks.",
+        liveAsk,
     );
   }
 
@@ -748,20 +771,44 @@ export function planBlockInstructions(opts: { allowQuestionForm: boolean }): str
   return lines.join("\n");
 }
 
-const PLAN_GATE_DIRECTIVE_INTERACTIVE =
-  "You are in Shepherd's pre-execution PLAN GATE. Do NOT write or modify any product code yet.\n" +
-  "1. Research the codebase enough to plan confidently.\n" +
-  "2. Ask the user actively — do NOT hide questions in the plan or a spec file. Use the AskUserQuestion " +
-  "tool for choice-style clarifications, and ask open-ended questions directly in the conversation. Keep " +
-  "asking sharp, specific questions until you and the user are genuinely aligned on scope, approach, and " +
-  "success criteria. Misalignment now is the costliest failure.\n" +
-  "3. When aligned, write the plan to `.shepherd-plan.md` at the repo root (goal, approach, files, " +
-  "steps, risks, success criteria) and tell the user it's ready for review. The plan must contain NO open / " +
-  "unresolved / TBD questions — resolve every question by asking first; it may still record stated " +
-  "assumptions and resolved decisions.\n" +
-  "An adversarial reviewer will critique the plan; address its findings by revising `.shepherd-plan.md`. " +
-  "Begin implementing ONLY after the plan is approved and you are told to execute.\n\n" +
-  planBlockInstructions({ allowQuestionForm: false });
+/**
+ * The interactive plan-gate directive, provider-adjusted. Two Codex-specific divergences:
+ *  - Codex has no AskUserQuestion tool, so step 2 tells it to ask in the conversation instead.
+ *  - Codex's default disposition is eager (it caused TASK-413 by implementing instead of researching),
+ *    so a hardened stop clause leads the directive: code stays untouched, the plan file is the only
+ *    deliverable this turn, then STOP. Claude keeps the original phrasing verbatim.
+ * `planGateDirectiveInteractive("claude")` is byte-identical to the prior
+ * `PLAN_GATE_DIRECTIVE_INTERACTIVE` constant — keep it that way (Claude regression).
+ */
+function planGateDirectiveInteractive(agentProvider: AgentProvider): string {
+  const stopClause =
+    agentProvider === "codex"
+      ? "Do NOT write or modify ANY code this turn. Your ONLY deliverable right now is the plan file " +
+        "`.shepherd-plan.md`; once you have written it, STOP and wait for review — do not start implementing.\n"
+      : "";
+  const askStep =
+    agentProvider === "codex"
+      ? "2. Ask the user actively — do NOT hide questions in the plan or a spec file. Ask your " +
+        "clarifying questions directly in the conversation. Keep "
+      : "2. Ask the user actively — do NOT hide questions in the plan or a spec file. Use the AskUserQuestion " +
+        "tool for choice-style clarifications, and ask open-ended questions directly in the conversation. Keep ";
+  return (
+    stopClause +
+    "You are in Shepherd's pre-execution PLAN GATE. Do NOT write or modify any product code yet.\n" +
+    "1. Research the codebase enough to plan confidently.\n" +
+    askStep +
+    "asking sharp, specific questions until you and the user are genuinely aligned on scope, approach, and " +
+    "success criteria. Misalignment now is the costliest failure.\n" +
+    "3. When aligned, write the plan to `.shepherd-plan.md` at the repo root (goal, approach, files, " +
+    "steps, risks, success criteria) and tell the user it's ready for review. The plan must contain NO open / " +
+    "unresolved / TBD questions — resolve every question by asking first; it may still record stated " +
+    "assumptions and resolved decisions.\n" +
+    "An adversarial reviewer will critique the plan; address its findings by revising `.shepherd-plan.md`. " +
+    "Begin implementing ONLY after the plan is approved and you are told to execute.\n\n" +
+    planBlockInstructions({ allowQuestionForm: false, agentProvider })
+  );
+}
+const PLAN_GATE_DIRECTIVE_INTERACTIVE = planGateDirectiveInteractive("claude");
 const PLAN_GATE_DIRECTIVE_AUTO =
   "You are in Shepherd's pre-execution PLAN GATE, running unattended (no human to ask). Do NOT write " +
   "or modify product code yet. Research the codebase, then write a concrete plan to `.shepherd-plan.md` " +
@@ -892,8 +939,13 @@ export function composeSystemPrompt(
     previewHint?: boolean;
     draftMode?: boolean;
     trimmed?: boolean;
+    agentProvider?: AgentProvider;
   } = {},
 ): string {
+  // Provider-adjust only the two blocks that name a Claude-only tool/capability (research's
+  // "sub-agents", the interactive plan-gate's "AskUserQuestion"). Absent → "claude", so every
+  // existing Claude caller is byte-identical.
+  const agentProvider = opts.agentProvider ?? "claude";
   const posture = `<engineering-posture>\n${ENGINEERING_POSTURE}\n</engineering-posture>`;
   const research = `<research-first-notice>\n${RESEARCH_FIRST_NOTICE}\n</research-first-notice>`;
   const branchNotice = `<branch-rename-notice>\n${BRANCH_RENAME_NOTICE}\n</branch-rename-notice>`;
@@ -906,17 +958,25 @@ export function composeSystemPrompt(
   if (!opts.research) {
     blocks.push(`<single-pr-invariant>\n${SINGLE_PR_INVARIANT}\n</single-pr-invariant>`);
     // Manual-operator-steps notice (#1257): rides every code spawn, suppressed for research (which
-    // opens no code PR) — same gate as the single-PR invariant. Gives the Owed lens a live data
-    // source by telling the agent to declare manual steps via the carriers parseManualSteps reads.
-    blocks.push(`<manual-steps-notice>\n${MANUAL_STEPS_NOTICE}\n</manual-steps-notice>`);
+    // opens no code PR). Gives the Owed lens a live data source by telling the agent to declare
+    // manual steps via the carriers parseManualSteps reads. Provider divergence (TASK-413): Claude
+    // gets it in the invisible system prompt, so it always rides; Codex delivers directives inline
+    // where they're visible to the operator, so — matching #1257's attended-Codex decision — the
+    // PR/manual-steps text rides only on effective autopilot (autonomous, PR-bound runs), keeping
+    // attended Codex starts free of workflow guidance.
+    if (agentProvider !== "codex" || autopilotActive) {
+      blocks.push(`<manual-steps-notice>\n${MANUAL_STEPS_NOTICE}\n</manual-steps-notice>`);
+    }
   }
   // Research is the highest-priority directive: it replaces BOTH the plan-gate and the autopilot
   // directive (none of those fit a report-PR/issue deliverable).
   if (opts.research) {
-    blocks.push(`<research-directive>\n${RESEARCH_DIRECTIVE}\n</research-directive>`);
+    blocks.push(`<research-directive>\n${researchDirective(agentProvider)}\n</research-directive>`);
   } else if (opts.planGate) {
     const variant =
-      opts.planGate === "auto" ? PLAN_GATE_DIRECTIVE_AUTO : PLAN_GATE_DIRECTIVE_INTERACTIVE;
+      opts.planGate === "auto"
+        ? PLAN_GATE_DIRECTIVE_AUTO
+        : planGateDirectiveInteractive(agentProvider);
     blocks.push(`<plan-gate-directive>\n${variant}\n</plan-gate-directive>`);
   } else if (autopilotActive) {
     blocks.push(`<autopilot-directive>\n${AUTOPILOT_DIRECTIVE}\n</autopilot-directive>`);
@@ -1709,6 +1769,63 @@ export class SessionService {
     if (spawnModel) argv.push("--model", spawnModel);
   }
 
+  /**
+   * Compose the full spawn-time directive block (`composeSystemPrompt` output) for a session.
+   * Shared by BOTH spawn builders so Claude and Codex deliver the SAME directives — the only
+   * difference is the delivery channel (Claude: `--append-system-prompt`; Codex: inline on the
+   * prompt, since Codex has no such flag).
+   *
+   * `autopilotActive` and `trimmed` are passed IN by the caller, never derived here, because they
+   * legitimately diverge per provider (issue: TASK-413):
+   *  - autopilotActive — Claude uses the repo default (`repoConfig.autopilotEnabled`); Codex folds in
+   *    the per-session toggle AND the isolation gate (`isolated && effectiveAutopilot(...)`), since
+   *    Codex autopilot stands down on non-isolated sessions. Collapsing these would regress a provider.
+   *  - trimmed — the context-trim notice is Claude-specific (skill-catalog / slash-command / plugin
+   *    trimming); Codex has no such trim, so its caller passes `false`.
+   *
+   * Side effect: `recordInjectedHouseRules` writes the injected-learnings join rows. It now runs on
+   * the Codex path too (intended — Codex sessions should participate in the learning lifecycle), so
+   * this must be called EXACTLY ONCE per spawn.
+   */
+  private composeDirectives(args: {
+    input: CreateSessionInput;
+    sessionId: string;
+    planGateOn: boolean | undefined;
+    isolated: boolean;
+    baseUrl: string;
+    autopilotActive: boolean;
+    trimmed: boolean;
+    agentProvider: AgentProvider;
+  }): string {
+    const { input, sessionId, planGateOn, isolated, baseUrl, autopilotActive, trimmed } = args;
+    const repoConfig = this.deps.store.getRepoConfig(input.repoPath);
+    const houseRules = this.recordInjectedHouseRules(sessionId, input);
+    const planGate = planGateOn ? (input.auto ? "auto" : "interactive") : undefined;
+    const buildQueue = repoConfig.buildQueueEnabled
+      ? buildQueueDirective({
+          sessionId,
+          baseUrl,
+          token: config.token,
+          // Never hand a plan-gated session an AUTO-executing build queue (TASK-413): during the
+          // plan gate the deliverable is the approved plan, so the queue must stop-and-wait, not
+          // drive straight into execution. This matters most for Codex, whose directives ride
+          // visibly inline, but the conflict is provider-agnostic so the guard is too. After the
+          // plan is approved and the session released, the release steer is the queue's "begin"
+          // signal (and shouldPreApproveBuildQueue already pre-approved it for an autopilot run).
+          autopilot: autopilotActive && !planGateOn,
+        })
+      : null;
+    return composeSystemPrompt(houseRules, autopilotActive, {
+      research: input.research,
+      planGate,
+      buildQueue,
+      previewHint: isolated,
+      draftMode: repoConfig.draftMode,
+      trimmed,
+      agentProvider: args.agentProvider,
+    });
+  }
+
   private buildSpawnArgv(
     input: CreateSessionInput,
     claudeSessionId: string,
@@ -1720,17 +1837,6 @@ export class SessionService {
     baseUrl: string,
   ): string[] {
     const repoConfig = this.deps.store.getRepoConfig(input.repoPath);
-    const houseRules = this.recordInjectedHouseRules(sessionId, input);
-    const autopilotActive = repoConfig.autopilotEnabled;
-    const planGate = planGateOn ? (input.auto ? "auto" : "interactive") : undefined;
-    const buildQueue = repoConfig.buildQueueEnabled
-      ? buildQueueDirective({
-          sessionId,
-          baseUrl,
-          token: config.token,
-          autopilot: autopilotActive,
-        })
-      : null;
     const argv = [
       "claude",
       "--dangerously-skip-permissions",
@@ -1747,13 +1853,16 @@ export class SessionService {
     );
     argv.push(
       "--append-system-prompt",
-      composeSystemPrompt(houseRules, autopilotActive, {
-        research: input.research,
-        planGate,
-        buildQueue,
-        previewHint: isolated,
-        draftMode: repoConfig.draftMode,
+      this.composeDirectives({
+        input,
+        sessionId,
+        planGateOn,
+        isolated,
+        baseUrl,
+        // Claude divergence: autopilot directive rides on the repo default, not isolation-gated.
+        autopilotActive: repoConfig.autopilotEnabled,
         trimmed: trim.trimmed,
+        agentProvider: "claude",
       }),
     );
     this.pushModelFlag(argv, input.model);
@@ -1761,24 +1870,43 @@ export class SessionService {
     return argv;
   }
 
-  private buildCodexSpawnArgv(
-    promptArg: string,
-    model: string | null,
-    autopilotActive: boolean,
-    manualStepsNotice: boolean,
-  ): string[] {
+  private buildCodexSpawnArgv(args: {
+    input: CreateSessionInput;
+    sessionId: string;
+    promptArg: string;
+    planGateOn: boolean | undefined;
+    isolated: boolean;
+    baseUrl: string;
+  }): string[] {
+    const { input, sessionId, promptArg, planGateOn, isolated, baseUrl } = args;
+    const repoConfig = this.deps.store.getRepoConfig(input.repoPath);
     const argv = ["codex", "--no-alt-screen", "--dangerously-bypass-approvals-and-sandbox"];
-    if (model) argv.push("--model", model);
-    // Codex has no --append-system-prompt, so extra blocks ride inline on the prompt. For attended
-    // sessions that would visibly turn the operator's prompt into PR workflow guidance, unlike the
-    // Claude Code New Task flow. The caller therefore gates both autopilot and PR/manual-steps text
-    // on the same effective-autopilot predicate.
-    let prompt = promptArg;
-    if (autopilotActive)
-      prompt += `\n\n<autopilot-directive>\n${AUTOPILOT_DIRECTIVE}\n</autopilot-directive>`;
-    if (manualStepsNotice)
-      prompt += `\n\n<manual-steps-notice>\n${MANUAL_STEPS_NOTICE}\n</manual-steps-notice>`;
-    argv.push(prompt);
+    if (input.model) argv.push("--model", input.model);
+    // Codex divergence (preserved from the prior call-site gating): the autopilot directive stands
+    // down on a non-isolated session, and the per-session toggle counts. Research/plan-gate precedence
+    // is handled inside composeSystemPrompt, so it need not be repeated here.
+    const autopilotActive =
+      isolated &&
+      effectiveAutopilot(
+        { autopilotEnabled: input.autopilotEnabled ?? null },
+        repoConfig.autopilotEnabled,
+      );
+    // Codex has no --append-system-prompt, so the directive block Claude gets via composeSystemPrompt
+    // rides inline on the prompt instead, wrapped so the agent can separate it from the task. The
+    // manual-steps-notice #1257 is the one block composeSystemPrompt gates per-provider: it stays
+    // autopilot-only for Codex (attended Codex prompts kept clean of PR workflow guidance).
+    // trimmed:false — context-trim is a Claude-only mechanism.
+    const directives = this.composeDirectives({
+      input,
+      sessionId,
+      planGateOn,
+      isolated,
+      baseUrl,
+      autopilotActive,
+      trimmed: false,
+      agentProvider: "codex",
+    });
+    argv.push(`${promptArg}\n\n<shepherd-directives>\n${directives}\n</shepherd-directives>`);
     return argv;
   }
 
@@ -1972,38 +2100,28 @@ export class SessionService {
     }
 
     const repoConfig = this.deps.store.getRepoConfig(spawnInput.repoPath);
-    const planGateOn =
-      agentProvider === "claude" ? this.resolvePlanGateOn(spawnInput, repoConfig) : false;
+    // Plan gate (#348): provider-agnostic (TASK-413) — Codex now enters the gate too; its directive
+    // rides inline (see buildCodexSpawnArgv) and the detection/review/release machinery is already
+    // CLI-agnostic. See resolvePlanGateOn for the override + research semantics.
+    const planGateOn = this.resolvePlanGateOn(spawnInput, repoConfig);
     const trim = await this.trimFor(spawnInput.auto);
     const profileOverride =
       agentProvider === "codex"
         ? "trusted"
         : this.researchSafeProfileOverride(spawnInput, repoConfig, sessionId);
     const baseUrl = this.resolveSpawnBaseUrl(profileOverride, spawnInput.repoPath);
-    const codexAutopilotActive =
-      agentProvider === "codex" &&
-      !spawnInput.research &&
-      wt.isolated &&
-      effectiveAutopilot(
-        { autopilotEnabled: spawnInput.autopilotEnabled ?? null },
-        repoConfig.autopilotEnabled,
-      );
+    // buildCodexSpawnArgv computes its own autopilot gate internally (isolated && effectiveAutopilot)
+    // and delivers the full directive block via composeDirectives — no caller-side gating needed.
     const argv =
       agentProvider === "codex"
-        ? this.buildCodexSpawnArgv(
+        ? this.buildCodexSpawnArgv({
+            input: spawnInput,
+            sessionId,
             promptArg,
-            spawnInput.model,
-            // Deliberate divergence from Claude (which gates its directive on the repo
-            // default only, see buildSpawnArgv): Codex uses effectiveAutopilot so the
-            // headline case (repo default OFF + per-session toggle ON) gets the directive.
-            // Do NOT align to Claude's repo-default-only behavior. Suppressed for research
-            // (which replaces the autopilot directive) and non-isolated (which autopilot
-            // stands down on — see eligible()).
-            codexAutopilotActive,
-            // Codex cannot hide this in a system prompt; keep attended starts free of PR/body
-            // instructions and attach the manual-steps contract only for autonomous PR-bound runs.
-            codexAutopilotActive,
-          )
+            planGateOn,
+            isolated: wt.isolated,
+            baseUrl,
+          })
         : this.buildSpawnArgv(
             spawnInput,
             claudeSessionId,
@@ -2070,7 +2188,8 @@ export class SessionService {
         model: spawnInput.model,
         auto: spawnInput.auto ?? false,
         issueNumber: spawnInput.issueRef?.number ?? null,
-        planGateEnabled: agentProvider === "claude" ? (spawnInput.planGateEnabled ?? null) : false,
+        // Provider-agnostic (TASK-413): Codex persists the flag too, no longer forced off.
+        planGateEnabled: spawnInput.planGateEnabled ?? null,
         autopilotEnabled: spawnInput.autopilotEnabled ?? null,
         planPhase: planGateOn ? "planning" : null,
         research: spawnInput.research ?? false,
@@ -2308,8 +2427,10 @@ export class SessionService {
         mergingSince: null,
         mergingTrainId: null,
         mergingPrNumber: null,
-        planGateEnabled:
-          agentProvider === "claude" ? (launch.spawnInput.planGateEnabled ?? null) : false,
+        // Provider-agnostic (TASK-413): mirror the create path — Codex persists the flag too, so a
+        // replaced Codex session that entered planning (launch.planGateOn) doesn't record the gate
+        // as disabled (which would mis-display and drop the explicit-on choice on resume).
+        planGateEnabled: launch.spawnInput.planGateEnabled ?? null,
         planPhase: launch.planGateOn ? "planning" : null,
       });
       this.deps.store.setSandboxState(s.id, {

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -270,6 +270,51 @@ test("approve → autopilot inherited from repo default ON auto-releases", async
   await h.svc.tick();
   expect(released).toEqual(["s1"]);
 });
+// TASK-413: enabling plan-gate for Codex makes this auto-release path reachable for Codex. Codex
+// autopilot stands down on a NON-isolated session (resume --last would target a sibling in a shared
+// cwd), so such a session is not hands-free — it must wait for the operator's Go, NOT auto-release.
+test("approve → codex NON-isolated autopilot does NOT auto-release (stands down like spawn/autopilot)", async () => {
+  const released: string[] = [];
+  const h = harness({
+    readVerdict: () => ({ decision: "approve", summary: "ok", body: "B", findings: [] }),
+    release: (id: string) => released.push(id),
+    store: {
+      get: () => ({
+        id: "s1",
+        auto: false,
+        autopilotEnabled: true,
+        agentProvider: "codex",
+        isolated: false,
+        repoPath: "/r",
+      }),
+      getRepoConfig: () => ({ planGateEnabled: true, autopilotEnabled: false }),
+    },
+  });
+  await h.svc.consider(planningSession() as any);
+  await h.svc.tick();
+  expect(released).toEqual([]);
+});
+test("approve → codex ISOLATED autopilot auto-releases (guard is isolation-specific)", async () => {
+  const released: string[] = [];
+  const h = harness({
+    readVerdict: () => ({ decision: "approve", summary: "ok", body: "B", findings: [] }),
+    release: (id: string) => released.push(id),
+    store: {
+      get: () => ({
+        id: "s1",
+        auto: false,
+        autopilotEnabled: true,
+        agentProvider: "codex",
+        isolated: true,
+        repoPath: "/r",
+      }),
+      getRepoConfig: () => ({ planGateEnabled: true, autopilotEnabled: false }),
+    },
+  });
+  await h.svc.consider(planningSession() as any);
+  await h.svc.tick();
+  expect(released).toEqual(["s1"]);
+});
 test("approve → autopilot inherited from repo default OFF does NOT auto-release", async () => {
   const released: string[] = [];
   const h = harness({

--- a/test/service-plan-gate.test.ts
+++ b/test/service-plan-gate.test.ts
@@ -83,7 +83,12 @@ test("planBlockInstructions instructs against diff and code blocks (no-diff-bloc
 
 test("agentProvider:'claude' is byte-identical to the default (Claude regression)", () => {
   // The new opt must NOT perturb any existing Claude caller's system prompt.
-  for (const opts of [{ research: true }, { planGate: "interactive" as const }, {}]) {
+  for (const opts of [
+    { research: true },
+    { planGate: "interactive" as const },
+    { planGate: "auto" as const },
+    {},
+  ]) {
     expect(composeSystemPrompt(null, true, { ...opts, agentProvider: "claude" })).toBe(
       composeSystemPrompt(null, true, opts),
     );
@@ -111,6 +116,17 @@ test("codex interactive plan-gate hardens the stop clause and omits AskUserQuest
   expect(
     composeSystemPrompt(null, false, { planGate: "interactive", agentProvider: "claude" }),
   ).toContain("AskUserQuestion");
+});
+
+test("codex auto plan-gate also gets the hardened stop clause (unattended path, no human backstop)", () => {
+  const codex = composeSystemPrompt(null, false, { planGate: "auto", agentProvider: "codex" });
+  expect(codex).toContain("<plan-gate-directive>");
+  expect(codex).toContain("running unattended");
+  expect(codex).toContain("Do NOT write or modify ANY code this turn");
+  // Claude's auto variant keeps the original phrasing — no extra stop clause.
+  expect(
+    composeSystemPrompt(null, false, { planGate: "auto", agentProvider: "claude" }),
+  ).not.toContain("Do NOT write or modify ANY code this turn");
 });
 
 test("planBlockInstructions(INTERACTIVE) drops AskUserQuestion for codex, keeps it for claude", () => {

--- a/test/service-plan-gate.test.ts
+++ b/test/service-plan-gate.test.ts
@@ -78,3 +78,46 @@ test("planBlockInstructions instructs against diff and code blocks (no-diff-bloc
     expect(t).toContain("annotated-code");
   }
 });
+
+// ─── Provider-aware directive delivery (TASK-413) ────────────────────────────
+
+test("agentProvider:'claude' is byte-identical to the default (Claude regression)", () => {
+  // The new opt must NOT perturb any existing Claude caller's system prompt.
+  for (const opts of [{ research: true }, { planGate: "interactive" as const }, {}]) {
+    expect(composeSystemPrompt(null, true, { ...opts, agentProvider: "claude" })).toBe(
+      composeSystemPrompt(null, true, opts),
+    );
+  }
+});
+
+test("codex research directive drops the 'sub-agents' phrasing; claude keeps it", () => {
+  const codex = composeSystemPrompt(null, false, { research: true, agentProvider: "codex" });
+  const claude = composeSystemPrompt(null, false, { research: true, agentProvider: "claude" });
+  expect(codex).toContain("<research-directive>");
+  expect(codex).toContain("attended RESEARCH task");
+  expect(codex).not.toContain("sub-agents");
+  expect(claude).toContain("sub-agents");
+});
+
+test("codex interactive plan-gate hardens the stop clause and omits AskUserQuestion", () => {
+  const codex = composeSystemPrompt(null, false, {
+    planGate: "interactive",
+    agentProvider: "codex",
+  });
+  expect(codex).toContain("<plan-gate-directive>");
+  expect(codex).toContain("Do NOT write or modify ANY code this turn");
+  expect(codex).not.toContain("AskUserQuestion");
+  // Claude keeps the original AskUserQuestion phrasing and has no extra stop clause.
+  expect(
+    composeSystemPrompt(null, false, { planGate: "interactive", agentProvider: "claude" }),
+  ).toContain("AskUserQuestion");
+});
+
+test("planBlockInstructions(INTERACTIVE) drops AskUserQuestion for codex, keeps it for claude", () => {
+  expect(planBlockInstructions({ allowQuestionForm: false, agentProvider: "codex" })).not.toContain(
+    "AskUserQuestion",
+  );
+  expect(planBlockInstructions({ allowQuestionForm: false, agentProvider: "claude" })).toContain(
+    "AskUserQuestion",
+  );
+});

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -307,8 +307,11 @@ function setRepoAutopilot(store: SessionStore, on: boolean) {
 
 const hasDirective = (argv: string[]) => argv.some((a) => a.includes("<autopilot-directive>"));
 const hasManualNotice = (argv: string[]) => argv.some((a) => a.includes("<manual-steps-notice>"));
+// The codex prompt is the final positional argv element (after the `--model` pair, if any): the
+// task text with the inline `<shepherd-directives>` block appended (TASK-413). Helpers below read it.
+const codexPrompt = (argv: string[]) => argv[argv.length - 1]!;
 
-test("createSession: codex provider starts interactive codex; plan-gate forced off, autopilot off → no directive", async () => {
+test("createSession: codex provider starts interactive codex; spawn argv carries the inline directives block", async () => {
   const { store, service, calls } = codexHarness(true);
 
   const s = await service.create({
@@ -318,28 +321,31 @@ test("createSession: codex provider starts interactive codex; plan-gate forced o
     agentProvider: "codex",
     model: "gpt-5.5",
     images: [],
-    planGateEnabled: true, // forced off for codex
     autopilotEnabled: false,
   });
 
-  // Autopilot is off here, so Codex gets the attended New Task shape: just the operator prompt,
-  // with no inline PR/manual-steps workflow guidance.
-  expect(calls.start.argv.slice(0, 5)).toEqual([
+  const argv: string[] = calls.start.argv;
+  expect(argv.slice(0, 5)).toEqual([
     "codex",
     "--no-alt-screen",
     "--dangerously-bypass-approvals-and-sandbox",
     "--model",
     "gpt-5.5",
   ]);
-  const codexPrompt = calls.start.argv[5] as string;
-  expect(codexPrompt).toBe("flatten it");
-  expect(codexPrompt).not.toContain("<autopilot-directive>");
-  expect(codexPrompt).not.toContain("<manual-steps-notice>");
+  // Codex has no --append-system-prompt, so the directive block rides inline on the prompt.
+  const prompt = codexPrompt(argv);
+  expect(prompt.startsWith("flatten it\n\n<shepherd-directives>\n")).toBe(true);
+  expect(prompt).toContain("</shepherd-directives>");
+  // The always-on directives that Codex previously never received now reach it.
+  expect(prompt).toContain("<engineering-posture>");
+  expect(prompt).toContain("<single-pr-invariant>");
+  // Autopilot is off here → no autopilot directive, and the #1257 manual-steps notice stays
+  // autopilot-only for Codex (attended prompts kept clean of PR workflow guidance).
+  expect(prompt).not.toContain("<autopilot-directive>");
+  expect(prompt).not.toContain("<manual-steps-notice>");
   expect(s.agentProvider).toBe("codex");
   expect(s.model).toBe("gpt-5.5");
   expect(s.claudeSessionId).toBe("");
-  expect(s.planGateEnabled).toBe(false); // plan-gate stays codex-forced-off
-  expect(s.autopilotEnabled).toBe(false);
   expect(store.get(s.id)?.agentProvider).toBe("codex");
   expect(store.get(s.id)?.model).toBe("gpt-5.5");
 });
@@ -362,12 +368,145 @@ test("createSession: codex drops a carried Claude model and uses provider defaul
     "--dangerously-bypass-approvals-and-sandbox",
   ]);
   expect(calls.start.argv).not.toContain("--model");
-  const codexPrompt = calls.start.argv[3] as string;
-  expect(codexPrompt).toBe("flatten it");
-  expect(codexPrompt).not.toContain("<manual-steps-notice>");
+  const prompt = codexPrompt(calls.start.argv);
+  expect(prompt.startsWith("flatten it")).toBe(true);
+  // Attended (autopilot off) → the #1257 manual-steps notice stays off for Codex.
+  expect(prompt).not.toContain("<manual-steps-notice>");
   expect(s.agentProvider).toBe("codex");
   expect(s.model).toBeNull();
   expect(store.get(s.id)?.model).toBeNull();
+});
+
+// TASK-413 — the reported bug: a codex research session received NO research instruction (the
+// directive was Claude-only via composeSystemPrompt), so codex implemented directly. It now rides
+// inline, in the codex variant (no "sub-agents" — codex has none).
+test("createSession: codex + research → inline research directive, codex variant (no sub-agents)", async () => {
+  const { service, calls } = codexHarness(true);
+  await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "investigate the auth flow",
+    agentProvider: "codex",
+    model: "gpt-5.5",
+    images: [],
+    research: true,
+  });
+  const prompt = codexPrompt(calls.start.argv);
+  expect(prompt).toContain("<research-directive>");
+  expect(prompt).toContain("attended RESEARCH task");
+  expect(prompt).not.toContain("sub-agents");
+  // research suppresses the single-PR + autopilot blocks, same as the Claude path.
+  expect(prompt).not.toContain("<single-pr-invariant>");
+  expect(prompt).not.toContain("<autopilot-directive>");
+});
+
+// TASK-413 — plan-gate is no longer codex-forced-off. A codex plan-gate session persists the flag,
+// enters the planning phase, and gets the interactive directive inline in the codex variant
+// (hardened stop clause, no AskUserQuestion tool reference).
+test("createSession: codex + planGateEnabled → enters planning, inline codex plan-gate directive", async () => {
+  const { store, service, calls } = codexHarness(true);
+  const s = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "add a settings page",
+    agentProvider: "codex",
+    model: "gpt-5.5",
+    images: [],
+    planGateEnabled: true,
+    autopilotEnabled: false,
+  });
+  expect(s.planGateEnabled).toBe(true);
+  expect(store.get(s.id)?.planPhase).toBe("planning");
+  const prompt = codexPrompt(calls.start.argv);
+  expect(prompt).toContain("<plan-gate-directive>");
+  expect(prompt).toContain("pre-execution PLAN GATE");
+  // codex variant: hardened stop clause present, AskUserQuestion tool reference absent.
+  expect(prompt).toContain("Do NOT write or modify ANY code this turn");
+  expect(prompt).not.toContain("AskUserQuestion");
+  // plan-gate suppresses the autopilot directive (mutually exclusive).
+  expect(prompt).not.toContain("<autopilot-directive>");
+});
+
+// TASK-413: a plan-gated session must never get an AUTO-executing build queue. During the plan gate
+// the deliverable is the approved plan, so the queue must stop-and-wait — not drive straight into
+// execution. Codex delivers directives inline where the operator sees them, but the conflict is
+// provider-agnostic. Here: build-queue + autopilot both ON (autopilotActive true) yet plan-gated →
+// the baked curation gate is stop-and-wait, not auto-exec.
+test("createSession: codex plan-gate + build-queue + autopilot → build queue stop-and-wait, not auto-exec", async () => {
+  const { store, service, calls } = codexHarness(true);
+  store.setRepoConfig("/repo", {
+    criticEnabled: true,
+    criticAllPrs: false,
+    autoAddressEnabled: false,
+    learningsEnabled: false,
+    autopilotEnabled: true,
+    planGateEnabled: false,
+    autoDrainEnabled: false,
+    autoMergeEnabled: false,
+    buildQueueEnabled: true,
+    draftMode: false,
+    signoffAuthority: "human",
+    maxAuto: 1,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+    sandboxProfile: "trusted",
+    defaultModel: "inherit",
+    egressExtraHosts: [],
+    repoMode: "forge",
+    autoOptimizeFlagged: false,
+    manualStepsIssueEnabled: false,
+  } as any);
+  await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "add a settings page",
+    agentProvider: "codex",
+    model: "gpt-5.5",
+    images: [],
+    planGateEnabled: true,
+    autopilotEnabled: true, // autopilotActive would otherwise make the queue auto-exec
+  });
+  const prompt = codexPrompt(calls.start.argv);
+  expect(prompt).toContain("<build-queue>");
+  expect(prompt).toContain("<plan-gate-directive>");
+  // Gated → stop-and-wait, NOT the auto-execute phrasing.
+  expect(prompt).toContain("STOP and wait");
+  expect(prompt).not.toContain("immediately begin executing the steps in order without waiting");
+});
+
+// trimmed is Claude-trim-specific (skill catalog / slash commands / plugins) — never for codex.
+test("createSession: codex never receives the context-trim notice", async () => {
+  const { service, calls } = codexHarness(true);
+  await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "go",
+    agentProvider: "codex",
+    model: "gpt-5.5",
+    images: [],
+    auto: true,
+  });
+  expect(codexPrompt(calls.start.argv)).not.toContain("<context-trim-notice>");
+});
+
+// Autopilot directive divergence (TASK-413 review point 1): Claude gates the directive on the REPO
+// DEFAULT only; Codex folds in the per-session toggle (and an isolation gate). With repo-default OFF
+// + per-session ON (isolated), Codex includes the autopilot directive — pinned by "codex + isolated
+// + autopilotEnabled=true → directive injected" above — while Claude omits it. This is the Claude
+// half: collapsing the two into one shared rule would regress one provider.
+test("autopilot directive: claude is repo-default-only — per-session ON with repo-default OFF omits it", async () => {
+  const store = new SessionStore(":memory:");
+  const captured: { argv?: string[] } = {};
+  const svc = new SessionService(injectDeps(store, captured) as any);
+  await svc.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "go",
+    model: null,
+    images: [],
+    autopilotEnabled: true, // per-session ON, but the repo default is OFF
+  });
+  expect(sysPrompt(captured.argv!)).not.toContain("<autopilot-directive>");
 });
 
 test("createSession: codex + isolated + autopilotEnabled=true → directive injected, persisted true", async () => {
@@ -4958,6 +5097,26 @@ test("replaceAgent swaps provider in the same session and worktree", async () =>
     "gpt-5.5",
   ]);
   expect(calls.removed).toEqual([]);
+});
+
+// TASK-413 (critic): replaceAgent must persist planGateEnabled provider-agnostically, mirroring the
+// create path. Replacing a plan-gated Claude session with Codex enters the planning phase
+// (launch.planGateOn) — the flag must record ON too, not the old codex-forced-off (which would
+// mis-display the gate and drop the explicit-on choice on resume).
+test("replaceAgent → codex keeps planGateEnabled and planPhase in sync (not forced off)", async () => {
+  const store = new SessionStore(":memory:");
+  const { service } = relaunchHarness(store);
+  const orig = originalSession(store, { planGateEnabled: true }); // plan-gated Claude session
+  store.update(orig.id, { status: "done", lastState: "done" });
+
+  const replaced = await service.replaceAgent(orig.id, {
+    agentProvider: "codex",
+    model: "gpt-5.5",
+  });
+
+  expect(replaced.agentProvider).toBe("codex");
+  expect(replaced.planGateEnabled).toBe(true); // persisted, not codex-forced-off
+  expect(replaced.planPhase).toBe("planning"); // and consistent with the flag
 });
 
 test("replaceAgent keeps the old agent registered if replacement spawn fails", async () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1252,12 +1252,12 @@
   "feat_session_recap_title": "Sitzungszusammenfassung",
   "feat_session_recap_body": "Shepherd erstellt nach jeder Sitzung eine kompakte Zusammenfassung — mit Ergebnis, Überschrift und offenen Punkten — damit du auf einen Blick siehst, was passiert ist.",
   "newtask_research_label": "Recherche-Aufgabe",
-  "newtask_research_hint": "Webrecherche mit Unter-Agenten → ein Bericht-PR oder ein GitHub-Issue. Keine Code-Änderungen.",
+  "newtask_research_hint": "Webrecherche → ein Bericht-PR oder ein GitHub-Issue. Keine Code-Änderungen.",
   "newtask_research_sandbox_note": "Recherche-Aufgaben können das autonome Profil nicht verwenden — Websuche benötigt offenen Netzwerkzugang.",
   "research_badge_label": "Recherche",
-  "research_badge_title": "Rechercheaufgabe: Web-Recherche mit Sub-Agenten → ein Bericht-PR oder ein GitHub-Issue",
+  "research_badge_title": "Rechercheaufgabe: Web-Recherche → ein Bericht-PR oder ein GitHub-Issue",
   "feat_research_title": "Rechercheaufgaben",
-  "feat_research_body": "Starte eine Rechercheaufgabe im Dialog „Neue Aufgabe“: Ein betreuter Agent führt Web-Recherche mit Sub-Agenten durch und liefert einen Bericht-PR oder öffnet ein GitHub-Issue. Rechercheaufgaben öffnen niemals einen Code-PR.",
+  "feat_research_body": "Starte eine Rechercheaufgabe im Dialog „Neue Aufgabe“: Ein betreuter Agent führt Web-Recherche durch und liefert einen Bericht-PR oder öffnet ein GitHub-Issue. Rechercheaufgaben öffnen niemals einen Code-PR.",
   "completed_epic_toast": "Epic #{number} abgeschlossen — {count} Teil-Issues gelandet",
   "integrated_epics_band_title": "Integrierte Epics ({count})",
   "integrated_epics_chip": "INTEGRIERT {merged}/{total}",
@@ -1971,7 +1971,7 @@
   "newtask_agent_provider_codex_alpha_badge": "Alpha MVP",
   "newtask_agent_provider_codex_alpha_note": "Die Codex-Integration ist eine Alpha/MVP-Funktion und wird gerade intensiv weiterentwickelt.",
   "newtask_agent_provider_codex_suggested_for_hold": "Claude Code ist am Nutzungsrückhalt-Schwellenwert, daher umgeht das Ausführen dieser Aufgabe auf Codex den Rückhalt. Wechsle die Coding-CLI zurück zu Claude Code, um sie stattdessen bis zum Reset zurückzuhalten oder trotzdem einzureichen.",
-  "newtask_agent_provider_codex_note": "Codex startet als interaktive Terminal-Session und läuft unbeaufsichtigt unter --dangerously-bypass-approvals-and-sandbox (Sandbox-Profil fest auf trusted). Plan Gate ist aus. Autopilot ist best-effort (Alpha) und treibt eine isolierte Session bis zu einem offenen PR. Die Modellauswahl nutzt Codex-CLI-Modelle.",
+  "newtask_agent_provider_codex_note": "Codex startet als interaktive Terminal-Session und läuft unbeaufsichtigt unter --dangerously-bypass-approvals-and-sandbox (Sandbox-Profil fest auf trusted). Plan Gate ist verfügbar. Autopilot ist best-effort (Alpha) und treibt eine isolierte Session bis zu einem offenen PR. Die Modellauswahl nutzt Codex-CLI-Modelle.",
   "agent_provider_claude": "Claude Code",
   "agent_provider_codex": "Codex",
   "agent_provider_codex_alpha": "Codex (Alpha MVP)",
@@ -2380,5 +2380,7 @@
   "feat_command_bar_jump_body": "Halte bei geöffneter Befehlsleiste Alt gedrückt, um Ziffernhinweise (1–9, dann 0) auf den ersten zehn Ergebnissen einzublenden, und drücke dann die Ziffer, um direkt dorthin zu springen.",
   "viewport_scroll_to_top": "Zum Anfang der Session springen",
   "feat_scroll_to_session_start_title": "Zum Session-Anfang springen",
-  "feat_scroll_to_session_start_body": "Wenn du ältere Terminal-Ausgabe liest, zeigt die schwebende Scroll-Schaltfläche jetzt zusätzlich einen ↑-Button für den Anfang der Session neben dem bestehenden ↓-Sprung zurück zum aktuellen Prompt."
+  "feat_scroll_to_session_start_body": "Wenn du ältere Terminal-Ausgabe liest, zeigt die schwebende Scroll-Schaltfläche jetzt zusätzlich einen ↑-Button für den Anfang der Session neben dem bestehenden ↓-Sprung zurück zum aktuellen Prompt.",
+  "feat_codex_plan_gate_title": "Plan-Gate für Codex (Alpha)",
+  "feat_codex_plan_gate_body": "Das Plan-Gate funktioniert jetzt für Codex-Aufgaben. Schalte es im Neue-Aufgabe-Dialog ein, und Codex recherchiert und schreibt zuerst einen Plan, stoppt zur Review und implementiert erst nach Freigabe des Plans — dasselbe Pre-Execution-Gate, das Claude nutzt."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1252,12 +1252,12 @@
   "feat_session_recap_title": "Session recap",
   "feat_session_recap_body": "Shepherd now generates a concise recap after each session — verdict, headline, and open items — so you can see what happened at a glance.",
   "newtask_research_label": "Research task",
-  "newtask_research_hint": "Web research with sub-agents → a report PR or a GitHub issue. No code changes.",
+  "newtask_research_hint": "Web research → a report PR or a GitHub issue. No code changes.",
   "newtask_research_sandbox_note": "Research can't use the autonomous profile — web search needs open network access.",
   "research_badge_label": "Research",
-  "research_badge_title": "Research task: web research with sub-agents → a report PR or a GitHub issue",
+  "research_badge_title": "Research task: web research → a report PR or a GitHub issue",
   "feat_research_title": "Research tasks",
-  "feat_research_body": "Start a Research task from New Task: an attended agent does web research with sub-agents and delivers a report PR or opens a GitHub issue. Research never opens a code PR.",
+  "feat_research_body": "Start a Research task from New Task: an attended agent does web research and delivers a report PR or opens a GitHub issue. Research never opens a code PR.",
   "completed_epic_toast": "Epic #{number} complete — {count} sub-issues landed",
   "integrated_epics_band_title": "Integrated epics ({count})",
   "integrated_epics_chip": "INTEGRATED {merged}/{total}",
@@ -1971,7 +1971,7 @@
   "newtask_agent_provider_codex_alpha_badge": "Alpha MVP",
   "newtask_agent_provider_codex_alpha_note": "Codex integration is an Alpha/MVP feature and is under heavy development.",
   "newtask_agent_provider_codex_suggested_for_hold": "Claude Code is at the usage-hold threshold, so running this task on Codex sidesteps the hold. Switch the coding CLI back to Claude Code to hold it until the reset or submit anyway instead.",
-  "newtask_agent_provider_codex_note": "Codex starts as an interactive terminal session, running unattended under --dangerously-bypass-approvals-and-sandbox (sandbox profile forced to trusted). Plan Gate is off. Autopilot is best-effort (Alpha) and drives an isolated session toward an open PR. The model picker uses Codex CLI models.",
+  "newtask_agent_provider_codex_note": "Codex starts as an interactive terminal session, running unattended under --dangerously-bypass-approvals-and-sandbox (sandbox profile forced to trusted). Plan Gate is available. Autopilot is best-effort (Alpha) and drives an isolated session toward an open PR. The model picker uses Codex CLI models.",
   "agent_provider_claude": "Claude Code",
   "agent_provider_codex": "Codex",
   "agent_provider_codex_alpha": "Codex (Alpha MVP)",
@@ -2380,5 +2380,7 @@
   "feat_command_bar_jump_body": "Hold Alt with the command bar open to reveal number hints (1–9, then 0) on the first ten results, then press the digit to jump straight to it.",
   "viewport_scroll_to_top": "Jump to session start",
   "feat_scroll_to_session_start_title": "Jump to session start",
-  "feat_scroll_to_session_start_body": "When you're reading older terminal output, the floating scroll control now includes an ↑ button for the start of the session next to the existing ↓ jump back to the latest prompt."
+  "feat_scroll_to_session_start_body": "When you're reading older terminal output, the floating scroll control now includes an ↑ button for the start of the session next to the existing ↓ jump back to the latest prompt.",
+  "feat_codex_plan_gate_title": "Plan gate for Codex (Alpha)",
+  "feat_codex_plan_gate_body": "The plan gate now works for Codex tasks. Toggle it on in New Task and Codex researches and writes a plan first, stops for review, and only implements once the plan is approved — the same pre-execution gate Claude uses."
 }

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -1042,7 +1042,7 @@ describe("NewTask first-task confirm step", () => {
       .toBeInTheDocument();
   });
 
-  it("switching Codex→Claude: plan-gate forced off (restored on flip back), autopilot available throughout", async () => {
+  it("plan-gate stays available (live, not forced off) across Codex↔Claude flips — TASK-413", async () => {
     const repoPath = "/repo/codex-restore";
     // Repo defaults both automation toggles ON.
     mockGetRepoConfig.mockResolvedValue({
@@ -1065,15 +1065,15 @@ describe("NewTask first-task confirm step", () => {
     await expect.poll(() => planGateBox().checked).toBe(true);
     await expect.poll(() => autopilotBox().checked).toBe(true);
 
-    // Codex: plan-gate forced off + disabled; autopilot stays available (on + enabled).
+    // Codex: plan-gate is now available (live + enabled, not forced off); autopilot too.
     provider().value = "codex";
     provider().dispatchEvent(new Event("change", { bubbles: true }));
-    await expect.poll(() => planGateBox().checked).toBe(false);
-    expect(planGateBox().disabled).toBe(true);
+    await expect.poll(() => planGateBox().disabled).toBe(false);
+    expect(planGateBox().checked).toBe(true);
     await expect.poll(() => autopilotBox().checked).toBe(true);
     expect(autopilotBox().disabled).toBe(false);
 
-    // Back to Claude in a single flip → plan-gate restored to the repo default, not stuck off.
+    // Back to Claude → unchanged, still on/enabled.
     provider().value = "claude";
     provider().dispatchEvent(new Event("change", { bubbles: true }));
     await expect.poll(() => planGateBox().checked).toBe(true);
@@ -1082,7 +1082,7 @@ describe("NewTask first-task confirm step", () => {
     expect(autopilotBox().disabled).toBe(false);
   });
 
-  it("preserves a manual plan-gate override (forced-off display) and keeps autopilot on across a Codex round-trip", async () => {
+  it("a manual plan-gate override survives a Codex round-trip and the box stays live — TASK-413", async () => {
     const repoPath = "/repo/codex-preserve-override";
     // Repo defaults both automation toggles OFF.
     mockGetRepoConfig.mockResolvedValue(confirmedRepoConfig());
@@ -1104,14 +1104,15 @@ describe("NewTask first-task confirm step", () => {
     await expect.poll(() => planGateBox().checked).toBe(true);
     await expect.poll(() => autopilotBox().checked).toBe(true);
 
-    // Codex displays plan-gate off (state preserved underneath, not mutated); autopilot stays on.
+    // Codex: plan-gate stays ON and the box stays live (no forced-off display anymore); autopilot too.
     provider().value = "codex";
     provider().dispatchEvent(new Event("change", { bubbles: true }));
-    await expect.poll(() => planGateBox().checked).toBe(false);
+    await expect.poll(() => planGateBox().checked).toBe(true);
+    expect(planGateBox().disabled).toBe(false);
     await expect.poll(() => autopilotBox().checked).toBe(true);
     expect(autopilotBox().disabled).toBe(false);
 
-    // Back to Claude → the manual plan-gate override survives the round-trip.
+    // Back to Claude → the manual override is intact.
     provider().value = "claude";
     provider().dispatchEvent(new Event("change", { bubbles: true }));
     await expect.poll(() => planGateBox().checked).toBe(true);

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -376,13 +376,10 @@
     if (!autopilotTouched) autopilot = autopilotDefault;
   });
 
-  // Codex can't plan-gate yet (no spawn directives via --append-system-prompt, so the
-  // plan-gate wiring isn't available for it). Rather than mutate planGate (which would
-  // silently lose a manual override across a Codex round-trip), the plan-gate checkbox
-  // just DISPLAYS off + disabled while Codex is selected (see NewTaskRunSettings) and
-  // submit forces it off via planGateFlag — the underlying Claude-context choice is
-  // preserved untouched. Autopilot, by contrast, is now available for isolated Codex
-  // sessions (#1140) and flows through automationFlag like Claude.
+  // Plan-gate is available for Codex (TASK-413): the gate directive rides inline on the Codex
+  // spawn prompt, and the detection/review/release loop is CLI-agnostic. The checkbox is live for
+  // both providers (see NewTaskRunSettings) and the choice flows through planGateFlag. Autopilot is
+  // likewise available for isolated Codex sessions (#1140) via automationFlag.
 
   // Effective default model = repo override (if not "inherit") → global default → promo.
   // Re-seeds the picker when the repo config loads / the repo changes, unless an explicit
@@ -621,10 +618,10 @@
     return touched ? value : null;
   }
 
-  // Plan-gate stays codex-forced-off: codex gets no spawn directives via
-  // --append-system-prompt, so the plan-gate wiring is not available for it yet.
+  // Plan-gate now flows for both providers (TASK-413): Codex receives the gate directive inline
+  // on its spawn prompt (Codex has no --append-system-prompt), and the detection/review/release
+  // machinery is CLI-agnostic. A manual choice rides; otherwise null inherits the repo default.
   function planGateFlag(touched: boolean, value: boolean): boolean | null {
-    if (agentProvider === "codex") return false;
     return touched ? value : null;
   }
 

--- a/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
+++ b/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
@@ -76,13 +76,13 @@
     <label class="plan-gate" use:coachTarget={"plan-gate"}>
       <input
         type="checkbox"
-        checked={agentProvider === "codex" ? false : planGate}
+        checked={planGate}
         onchange={(e) => {
           planGate = e.currentTarget.checked;
           onPlanGateTouched();
           if (planGate) research = false;
         }}
-        disabled={planGateLoading || agentProvider === "codex"}
+        disabled={planGateLoading}
       />
       <span class="pg-label">{m.newtask_plan_gate_label()}</span>
     </label>

--- a/ui/src/lib/feature-announcements/entries/v1.42.0-codex-plan-gate.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.42.0-codex-plan-gate.ts
@@ -1,0 +1,14 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // Plan-gate is now selectable for Codex tasks (TASK-413): the gate directive rides inline on the
+  // Codex spawn prompt, and the detection/review/release loop is CLI-agnostic. Anchored to the
+  // plan-gate checkbox via use:coachTarget={"plan-gate"} in NewTaskRunSettings.
+  id: "codex-plan-gate",
+  sinceVersion: "1.42.0",
+  titleKey: "feat_codex_plan_gate_title",
+  bodyKey: "feat_codex_plan_gate_body",
+  targetId: "plan-gate",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## Why

Shepherd's directive system was built entirely around Claude's `--append-system-prompt` flag. `composeSystemPrompt()` bundles every standing directive (research, plan-gate, house-rules, engineering-posture, single-PR, build-queue, …) and hands them to Claude via that flag. **Codex has no such flag**, so `buildCodexSpawnArgv` only inlined the *autopilot* directive — and only when autopilot was active.

Two concrete bugs followed:

- **TASK-413 (the reported one):** a Codex session with `research: true` received **zero** research instruction (the gate `!input.research && …` is false for research), so Codex implemented directly instead of researching.
- **Plan-gate** was hard-disabled for Codex (`planGateOn = agentProvider === "claude" ? … : false`).

The plan-gate *machinery* was already CLI-agnostic — detection reads `.shepherd-plan.md` from the worktree, the reviewer is a separate transient agent, feedback/release steer via terminal injection, and the reviewer-kick rides herdr terminal-state (not Claude hooks). Only the **directive delivery** was Claude-bound.

## What

**One composer, two delivery channels.** A shared `composeDirectives()` builds the full block for both providers; Claude delivers it via `--append-system-prompt` (unchanged), Codex inline in a `<shepherd-directives>` block on the prompt.

- **Provider-adjust the two Claude-specific blocks:** research's "sub-agents" phrasing (Codex has none) and the interactive plan-gate's `AskUserQuestion` tool reference are dropped for Codex; the Codex plan-gate gets a hardened stop clause (its eager default is what caused TASK-413).
- **Preserve the per-provider `autopilotActive` divergence** (Claude: repo default; Codex: per-session toggle + isolation gate) as a caller-passed param — pinned by a test so a naive unification can't regress one provider.
- **`trimmed` is never set for Codex** (context-trim is a Claude-only mechanism).
- **Codex now inherits** house-rules, engineering-posture, single-PR, build-queue, preview-hint and draft-mode too — directives it previously never received.
- **UI:** the plan-gate toggle is now live for Codex in New Task (it was hard-disabled), the submit flag flows through `planGateFlag`, and a `codex-plan-gate` feature-catalog entry + EN/DE copy ships with it.

The plan reviewer (a transient Claude agent) is unchanged — it reviews a file, not provider behavior, so it works for Codex plans as-is.

## Out of scope (deliberate)

Full-auto/auto-merge for Codex, Codex session-id persistence, Codex hooks ingest, hard-enforcing the gate (it stays advisory for both providers), and the brand-new-repo automation-confirm interstitial (still Claude-only — a separate seeding/confirm flow).

## Tests

- Codex spawn carries the inline directives block; research directive in the Codex variant (no "sub-agents"); plan-gate enters `planning` with the hardened stop clause and no `AskUserQuestion`; `trimmed` never present.
- `composeSystemPrompt(agentProvider: "claude")` is **byte-identical** to the prior output (Claude regression pin).
- Autopilot-directive divergence pinned on both halves.
- Updated the two NewTask UI tests that asserted the old forced-off behavior.

**Verification** (run in a clean `/tmp` worktree to avoid the known session-worktree zombie-git wedge): `bun test ./test` → 5283 pass; the only 3 failures (`SessionUsageRollup`, usage-cost accounting) **fail identically on the base commit** and are unrelated. UI suite 2275 pass, `bun run lint` clean, `cd ui && bun run check` 0 errors, `check:i18n` parity. The pre-push hook was bypassed solely for those 3 pre-existing usage flakes.

> [!NOTE]
> TASK-413 is a Shepherd-internal task designation, not a GitHub issue.
