### PR TITLE
perf(polling): reduce GitHub GraphQL polling pressure (#1230)

### DIFF
--- a/src/backlog-poller.ts
+++ b/src/backlog-poller.ts
@@ -27,9 +27,18 @@ export class BacklogPoller {
      * never sink the warm cadence.
      */
     private onWarmed?: () => void | Promise<void>,
+    /**
+     * Cadence gate. When this returns false the timer keeps running but the tick
+     * does nothing — no per-repo `gh` warm and no `onWarmed` broadcast. Lets the
+     * composition root pause backlog warming when no dashboard is open or the
+     * GraphQL bucket is exhausted, without tearing the timer down. (Named
+     * `shouldWarm` to avoid colliding with the `warm` warm-fn param above.)
+     */
+    private shouldWarm: () => boolean = () => true,
   ) {}
 
   async tick(): Promise<void> {
+    if (!this.shouldWarm()) return; // cold / rate-limited — skip warming and the broadcast
     const forgeRepos = this.listRepos().filter((r) => this.isForgeBacked(r.path));
     await Promise.all(forgeRepos.map((r) => this.warm(r.path).catch(() => null)));
     if (this.onWarmed) await Promise.resolve(this.onWarmed()).catch(() => null);

--- a/src/backlog-poller.ts
+++ b/src/backlog-poller.ts
@@ -6,7 +6,7 @@ import type { RepoCounts } from "./backlog";
  * visibly the cold first paint of an empty overview. Mirrors PrPoller's
  * boot-warmup + interval cadence.
  *
- * The default cadence is intentionally below CountsService's 60s read-TTL so a
+ * The default cadence is intentionally below CountsService's 120s read-TTL so a
  * forced refresh rewrites each entry before it can expire — the request path
  * then always finds a fresh value. Best-effort: a failing warm is swallowed so
  * one bad repo never sinks the tick or its siblings.
@@ -18,7 +18,7 @@ export class BacklogPoller {
     private listRepos: () => Array<{ path: string }>,
     private resolveForge: (repoPath: string) => { kind?: string } | null,
     private warm: (repoPath: string) => Promise<RepoCounts>,
-    private intervalMs = 45_000,
+    private intervalMs = 90_000,
     /**
      * Fired once per tick after every repo's counts are warm. Lets the caller
      * push the freshly-warmed overview to clients (a `backlog:update` WS frame)

--- a/src/backlog.ts
+++ b/src/backlog.ts
@@ -16,7 +16,7 @@ interface CacheEntry {
   value: RepoCounts;
 }
 
-const TTL_MS = 60_000;
+const TTL_MS = 120_000;
 
 /**
  * Cap on simultaneous count fetches. The async runner made the per-repo `gh`

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -261,7 +261,7 @@ export class GithubForge implements GitForge {
       "-F",
       `name=${name}`,
       "-f",
-      "query=query($owner:String!,$name:String!){repository(owner:$owner,name:$name){issues(states:OPEN){totalCount} pullRequests(states:OPEN, first:100){ totalCount nodes{ author{login} title headRefName } } defaultBranchRef{target{... on Commit{statusCheckRollup{state}}}}} rateLimit{ cost remaining resetAt }}",
+      "query=query($owner:String!,$name:String!){repository(owner:$owner,name:$name){issues(states:OPEN){totalCount} pullRequests(states:OPEN, first:100){ totalCount nodes{ author{login} title headRefName } } defaultBranchRef{target{... on Commit{statusCheckRollup{state}}}}} rateLimit{ remaining resetAt }}",
     ]);
     const json = JSON.parse(out) as {
       data?: {

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -261,7 +261,7 @@ export class GithubForge implements GitForge {
       "-F",
       `name=${name}`,
       "-f",
-      "query=query($owner:String!,$name:String!){repository(owner:$owner,name:$name){issues(states:OPEN){totalCount} pullRequests(states:OPEN, first:100){ totalCount nodes{ author{login} title headRefName labels(first:10){nodes{name}} } } defaultBranchRef{target{... on Commit{statusCheckRollup{state}}}}} rateLimit{ cost remaining resetAt }}",
+      "query=query($owner:String!,$name:String!){repository(owner:$owner,name:$name){issues(states:OPEN){totalCount} pullRequests(states:OPEN, first:100){ totalCount nodes{ author{login} title headRefName } } defaultBranchRef{target{... on Commit{statusCheckRollup{state}}}}} rateLimit{ cost remaining resetAt }}",
     ]);
     const json = JSON.parse(out) as {
       data?: {
@@ -273,7 +273,6 @@ export class GithubForge implements GitForge {
               author?: { login?: string } | null;
               title?: string;
               headRefName?: string;
-              labels?: { nodes?: Array<{ name?: string } | null> } | null;
             } | null>;
           };
           defaultBranchRef?: {
@@ -315,9 +314,6 @@ export class GithubForge implements GitForge {
             author: n.author?.login ?? "",
             title: n.title ?? "",
             headRefName: n.headRefName ?? undefined,
-            labels: (n.labels?.nodes ?? [])
-              .map((l) => l?.name)
-              .filter((name): name is string => !!name),
           }),
         );
       const release = kinds.filter((k) => k === "release").length;

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -3,6 +3,12 @@ import { promisify } from "node:util";
 import { timedAsync } from "../instrument";
 import { jobsFromRollup, mapCheckState, rollupChecks } from "./checks";
 import { classifyPr } from "./pr-kind";
+import {
+  graphRateLimit,
+  isGraphqlBucketCall,
+  isRateLimitError,
+  parseRetryAfter,
+} from "./rate-limit";
 import { CRITIC_REVIEW_MARKER, EmptyDiffError } from "./types";
 import type {
   CiStatus,
@@ -113,8 +119,20 @@ const execFileAsync = promisify(execFile);
 
 const defaultRunner: GhRunner = (args) =>
   timedAsync(`gh ${args[0]}`, async () => {
-    const { stdout } = await execFileAsync("gh", args, { maxBuffer: 16 * 1024 * 1024 });
-    return stdout.toString();
+    try {
+      const { stdout } = await execFileAsync("gh", args, { maxBuffer: 16 * 1024 * 1024 });
+      return stdout.toString();
+    } catch (err) {
+      // Detect GraphQL rate-limit errors and record them in the shared backoff
+      // state so pollers can pause before the next request. The error is always
+      // re-thrown so existing caller behaviour is unchanged.
+      if (isGraphqlBucketCall(args) && isRateLimitError(err)) {
+        graphRateLimit.noteLimitError(
+          parseRetryAfter(String((err as Record<string, unknown>)?.stderr ?? "")),
+        );
+      }
+      throw err;
+    }
   });
 
 interface GhReview {
@@ -243,7 +261,7 @@ export class GithubForge implements GitForge {
       "-F",
       `name=${name}`,
       "-f",
-      "query=query($owner:String!,$name:String!){repository(owner:$owner,name:$name){issues(states:OPEN){totalCount} pullRequests(states:OPEN, first:100){ totalCount nodes{ author{login} title headRefName labels(first:10){nodes{name}} } } defaultBranchRef{target{... on Commit{statusCheckRollup{state}}}}}}",
+      "query=query($owner:String!,$name:String!){repository(owner:$owner,name:$name){issues(states:OPEN){totalCount} pullRequests(states:OPEN, first:100){ totalCount nodes{ author{login} title headRefName labels(first:10){nodes{name}} } } defaultBranchRef{target{... on Commit{statusCheckRollup{state}}}}} rateLimit{ cost remaining resetAt }}",
     ]);
     const json = JSON.parse(out) as {
       data?: {
@@ -262,8 +280,21 @@ export class GithubForge implements GitForge {
             target?: { statusCheckRollup?: { state?: string } | null } | null;
           } | null;
         };
+        /** Top-level `rateLimit` selection — tracks GraphQL bucket consumption. */
+        rateLimit?: { remaining?: number; resetAt?: string };
       };
     };
+
+    // Feed the rateLimit reading into the shared backoff tracker so we can
+    // pause pollers before the bucket empties. Guard against malformed values.
+    const rl = json.data?.rateLimit;
+    if (typeof rl?.remaining === "number" && typeof rl?.resetAt === "string") {
+      const resetAtMs = Date.parse(rl.resetAt);
+      if (Number.isFinite(resetAtMs)) {
+        graphRateLimit.note({ remaining: rl.remaining, resetAt: resetAtMs });
+      }
+    }
+
     const repo = json.data?.repository;
     const issues = repo?.issues?.totalCount;
     const prs = repo?.pullRequests?.totalCount;

--- a/src/forge/rate-limit.ts
+++ b/src/forge/rate-limit.ts
@@ -1,0 +1,221 @@
+/**
+ * GraphQL rate-limit tracking for Shepherd's GitHub integration.
+ *
+ * GitHub GraphQL has its own 5,000-points-per-hour bucket, separate from the
+ * REST bucket used by `gh run` and `gh api <rest-path>`. This module tracks
+ * the last-seen budget from `rateLimit` query selections and exposes a shared
+ * backoff signal that pollers consult before issuing new requests.
+ *
+ * Design goals:
+ *  - Injectable `now` clock so tests are deterministic (no `Date.now()` calls
+ *    inside logic that isn't routed through the injected fn).
+ *  - Edge-triggered logging only: one `console.warn` on unblocked→blocked,
+ *    one on blocked→unblocked — never once per call.
+ *  - Pure helper functions (`isGraphqlBucketCall`, `isRateLimitError`,
+ *    `parseRetryAfter`) with no side-effects, easily unit-tested.
+ */
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+/** Immutable view of the current rate-limit state. */
+export interface RateLimitSnapshot {
+  /** Last-seen `remaining` from the GraphQL `rateLimit` field, or null if
+   *  no reading has been recorded yet. */
+  remaining: number | null;
+  /** Epoch-ms timestamp at which the bucket resets (`rateLimit.resetAt`
+   *  parsed via `Date.parse`), or null if unknown. */
+  resetAt: number | null;
+  /** Epoch-ms until which all GraphQL calls should be paused, or null when
+   *  the backoff is not engaged. A non-null value in the past means the
+   *  cooldown has naturally elapsed but no healthy reading has cleared it yet
+   *  (callers should treat `blocked` rather than inspecting this directly). */
+  pausedUntil: number | null;
+  /** True iff `pausedUntil` is set and `now() < pausedUntil`. */
+  blocked: boolean;
+}
+
+// ── GraphRateLimit ────────────────────────────────────────────────────────────
+
+/**
+ * Singleton-friendly tracker for the GitHub GraphQL rate-limit bucket.
+ *
+ * Construct with an injectable `now` function for deterministic testing:
+ *
+ *   const rl = new GraphRateLimit({ now: () => fakeTime });
+ *
+ * The module-level `graphRateLimit` export is the singleton used in production.
+ */
+export class GraphRateLimit {
+  private readonly _now: () => number;
+  private readonly _floor: number;
+  private readonly _defaultCooldownMs: number;
+
+  private _remaining: number | null = null;
+  private _resetAt: number | null = null;
+  private _pausedUntil: number | null = null;
+
+  /**
+   * True after we have emitted the "engaged" log, false after we emit the
+   * "cleared" log. Guards against duplicate edge logs.
+   */
+  private _notifiedBlocked = false;
+
+  constructor(opts?: { now?: () => number; floor?: number; defaultCooldownMs?: number }) {
+    this._now = opts?.now ?? (() => Date.now());
+    this._floor = opts?.floor ?? 100;
+    this._defaultCooldownMs = opts?.defaultCooldownMs ?? 60_000;
+  }
+
+  /**
+   * Record a fresh `rateLimit` reading from a GraphQL response.
+   *
+   * - If `remaining` is below the floor we are close to exhaustion: extend
+   *   `pausedUntil` to `max(existing, resetAt)` so a longer error cooldown is
+   *   never shortened.
+   * - If `remaining` is at or above the floor the bucket is healthy: clear the
+   *   backoff unconditionally (positive evidence we are not limited).
+   */
+  note(reading: { remaining: number; resetAt: number /* epoch ms */ }): void {
+    const { remaining, resetAt } = reading;
+    this._remaining = remaining;
+    this._resetAt = resetAt;
+
+    if (remaining < this._floor) {
+      // Budget nearly exhausted — wait until the bucket refills.
+      this._engage(resetAt);
+    } else {
+      // Healthy reading: positive evidence we can proceed.
+      this._clear();
+    }
+  }
+
+  /**
+   * Record a detected GraphQL rate-limit error from `gh`.
+   *
+   * Sets `pausedUntil = max(existing, now() + retryAfterMs)` where
+   * `retryAfterMs` defaults to `defaultCooldownMs`. A longer existing cooldown
+   * is never shortened.
+   *
+   * @param retryAfterSec Optional `Retry-After` header value in seconds.
+   */
+  noteLimitError(retryAfterSec?: number): void {
+    const cooldownMs =
+      retryAfterSec !== undefined ? retryAfterSec * 1_000 : this._defaultCooldownMs;
+    this._engage(this._now() + cooldownMs);
+  }
+
+  /**
+   * Returns true when there is an active backoff window (the GraphQL bucket is
+   * believed to be exhausted or rate-limited and `now()` is still inside the
+   * cooldown period).
+   */
+  blocked(): boolean {
+    return this._pausedUntil != null && this._now() < this._pausedUntil;
+  }
+
+  /** Returns an immutable snapshot of the current state. */
+  snapshot(): RateLimitSnapshot {
+    return {
+      remaining: this._remaining,
+      resetAt: this._resetAt,
+      pausedUntil: this._pausedUntil,
+      blocked: this.blocked(),
+    };
+  }
+
+  // ── private helpers ─────────────────────────────────────────────────────────
+
+  /**
+   * Extend the backoff window to `until` (taking the max of any existing value
+   * so a shorter new reading never shortens a longer existing cooldown). Logs
+   * once on the unblocked→blocked edge.
+   */
+  private _engage(until: number): void {
+    const next = this._pausedUntil != null ? Math.max(this._pausedUntil, until) : until;
+    const wasUnblocked = this._pausedUntil == null;
+    this._pausedUntil = next;
+
+    // Log only on the first engagement (transition from no backoff to backoff).
+    if (wasUnblocked && !this._notifiedBlocked) {
+      console.warn(`[rate-limit] GraphQL backoff engaged until ${new Date(next).toISOString()}`);
+      this._notifiedBlocked = true;
+    }
+  }
+
+  /**
+   * Clear the backoff window. Logs once on the blocked→unblocked edge (only
+   * when we previously emitted the "engaged" log).
+   */
+  private _clear(): void {
+    const wasSet = this._pausedUntil != null;
+    this._pausedUntil = null;
+    if (wasSet && this._notifiedBlocked) {
+      console.warn(`[rate-limit] GraphQL backoff cleared`);
+      this._notifiedBlocked = false;
+    }
+  }
+}
+
+// ── Module singleton ──────────────────────────────────────────────────────────
+
+/**
+ * Module-level singleton used by `github.ts` and `index.ts`. All GitHub
+ * GraphQL paths that can observe rate-limit signals funnel through this
+ * instance so the backoff state is shared across pollers.
+ */
+export const graphRateLimit: GraphRateLimit = new GraphRateLimit();
+
+// ── Pure helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Returns true iff the given `gh` arguments are routed through the GitHub
+ * GraphQL bucket (as opposed to the REST bucket).
+ *
+ * Rules (per issue #1230 analysis):
+ *  - `gh api graphql …`   → GraphQL bucket (true)
+ *  - `gh api <rest-path>` → REST bucket    (false) — must never trip the backoff
+ *  - `gh pr / issue / repo / search …` → GraphQL-backed subcommands (true)
+ *  - `gh run …` and everything else → REST or unrelated (false)
+ */
+export function isGraphqlBucketCall(args: string[]): boolean {
+  const sub = args[0];
+  if (sub === "api") {
+    // Only `gh api graphql` hits the GraphQL bucket; all other `gh api <path>`
+    // calls use the REST bucket and must NOT trigger GraphQL backoff.
+    return args[1] === "graphql";
+  }
+  // These high-level subcommands are powered by GraphQL internally.
+  return sub === "pr" || sub === "issue" || sub === "repo" || sub === "search";
+}
+
+/**
+ * Returns true when an error thrown by `gh` indicates a GraphQL primary or
+ * secondary rate limit.
+ *
+ * Matches both `"rate limit"` (primary / API rate limit exceeded) and
+ * `"rate_limited"` (secondary rate limit) anywhere in the error text,
+ * case-insensitively.
+ */
+export function isRateLimitError(err: unknown): boolean {
+  const text = String(
+    (err as Record<string, unknown>)?.stderr ??
+      (err as Record<string, unknown>)?.message ??
+      String(err),
+  ).toLowerCase();
+  return text.includes("rate limit") || text.includes("rate_limited");
+}
+
+/**
+ * Parse a `Retry-After` seconds value from `gh` stderr text.
+ *
+ * Matches patterns such as:
+ *  - `Retry-After: 60`
+ *  - `retry after 120`
+ *  - `retry-after:30`
+ *
+ * Returns the numeric seconds value, or `undefined` if not found.
+ */
+export function parseRetryAfter(text: string): number | undefined {
+  const m = /retry[- ]after[:\s]+(\d+)/i.exec(text);
+  return m ? Number(m[1]) : undefined;
+}

--- a/src/forge/rate-limit.ts
+++ b/src/forge/rate-limit.ts
@@ -128,15 +128,18 @@ export class GraphRateLimit {
   /**
    * Extend the backoff window to `until` (taking the max of any existing value
    * so a shorter new reading never shortens a longer existing cooldown). Logs
-   * once on the unblocked→blocked edge.
+   * once on the unblocked→blocked edge, using the observable `blocked()` state
+   * so a re-engagement after natural expiry also logs correctly.
    */
   private _engage(until: number): void {
+    const wasBlocked = this.blocked();
     const next = this._pausedUntil != null ? Math.max(this._pausedUntil, until) : until;
-    const wasUnblocked = this._pausedUntil == null;
     this._pausedUntil = next;
 
-    // Log only on the first engagement (transition from no backoff to backoff).
-    if (wasUnblocked && !this._notifiedBlocked) {
+    // Log on every unblocked→blocked transition (fresh engagement or
+    // re-engagement after natural expiry). `wasBlocked` is the authoritative
+    // edge trigger — no secondary `_notifiedBlocked` guard needed here.
+    if (!wasBlocked) {
       console.warn(`[rate-limit] GraphQL backoff engaged until ${new Date(next).toISOString()}`);
       this._notifiedBlocked = true;
     }
@@ -144,12 +147,15 @@ export class GraphRateLimit {
 
   /**
    * Clear the backoff window. Logs once on the blocked→unblocked edge (only
-   * when we previously emitted the "engaged" log).
+   * when the backoff was actively blocking at the time of the call, and we
+   * previously emitted the "engaged" log). A healthy reading that arrives after
+   * a cooldown has already elapsed naturally does NOT emit a spurious "cleared"
+   * log.
    */
   private _clear(): void {
-    const wasSet = this._pausedUntil != null;
+    const wasBlocked = this.blocked();
     this._pausedUntil = null;
-    if (wasSet && this._notifiedBlocked) {
+    if (wasBlocked && this._notifiedBlocked) {
       console.warn(`[rate-limit] GraphQL backoff cleared`);
       this._notifiedBlocked = false;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,12 @@ import { releaseHeldTasks } from "./held-release";
 import { snapshotSessionUsage } from "./usage-snapshot";
 import { hasCommittedChanges } from "./diff";
 import { HoldReasonService } from "./hold-service";
+import {
+  graphRateLimit,
+  isGraphqlBucketCall,
+  isRateLimitError,
+  parseRetryAfter,
+} from "./forge/rate-limit";
 
 const execFileAsync = promisify(execFile);
 
@@ -1802,8 +1808,20 @@ setInterval(checkDiagnostics, 6 * 60 * 60 * 1000);
 // parallel (a blocking execFileSync would serialize them on the event loop,
 // making the backlog load scale linearly with repo count).
 const ghRunnerAsync = async (args: string[]): Promise<string> => {
-  const { stdout } = await execFileAsync("gh", args, { maxBuffer: 16 * 1024 * 1024 });
-  return stdout.toString();
+  try {
+    const { stdout } = await execFileAsync("gh", args, { maxBuffer: 16 * 1024 * 1024 });
+    return stdout.toString();
+  } catch (err) {
+    // Detect GraphQL rate-limit errors and record them in the shared backoff
+    // state so pollers can pause before the next request. The error is always
+    // re-thrown so existing caller behaviour is unchanged.
+    if (isGraphqlBucketCall(args) && isRateLimitError(err)) {
+      graphRateLimit.noteLimitError(
+        parseRetryAfter(String((err as Record<string, unknown>)?.stderr ?? "")),
+      );
+    }
+    throw err;
+  }
 };
 const backlog = new CountsService(config.forges, ghRunnerAsync, fetch, undefined, (dir) =>
   store.getRepoConfig(dir),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1905,7 +1905,7 @@ const backlogPoller = new BacklogPoller(
   () => listRepos(config.repoRoot),
   resolveForge,
   (dir) => backlog.refresh(dir),
-  45_000,
+  90_000,
   broadcastBacklog,
   // Warm the backlog only while a dashboard is open and the GraphQL bucket is
   // healthy — backlog counts serve the overview, which nobody is reading when

--- a/src/index.ts
+++ b/src/index.ts
@@ -611,7 +611,20 @@ poller.start();
 // background Web Push: turn F3 state events into notifications for subscribed devices.
 // Suppress while any window is actively in use — clients report focus/visibility
 // over /events into `presence`, and the push gate reads it.
-const presence = new Presence();
+// When the first dashboard connects after a quiet spell, kick one immediate
+// catch-up sweep so it doesn't sit a full interval behind reality. Debounced
+// (~1.5s) so connect/disconnect flapping coalesces into a single catch-up. The
+// closure references `prPoller`/`backlogPoller` declared further down — fine, it
+// only runs at runtime when a socket actually opens, never during module init.
+let presenceCatchUp: ReturnType<typeof setTimeout> | null = null;
+const presence = new Presence(() => {
+  if (presenceCatchUp) clearTimeout(presenceCatchUp);
+  presenceCatchUp = setTimeout(() => {
+    presenceCatchUp = null;
+    void prPoller.fastTick();
+    void backlogPoller.tick();
+  }, 1_500);
+});
 const push = new PushService(store, undefined, undefined, undefined, () => presence.isActive());
 attachPush(events, store, push);
 
@@ -621,6 +634,28 @@ attachPush(events, store, push);
 // reused branch name — its head commit won't be reachable from this branch's tip.
 // Shared by the background poller and the on-demand git endpoint so they agree.
 const ownsPr = (s: Session, headSha: string) => worktree.containsCommit(s.worktreePath, headSha);
+
+// ── Poller cadence gate (#1230) ───────────────────────────────────────────────
+// The background pollers + critic sweep run at full cadence only while *warm*;
+// when truly idle they throttle/pause to spare the GraphQL bucket. Warmth is:
+//   warm() = a dashboard is open  ||  autonomous merge work is in flight
+// The second disjunct keeps a headless full-auto merge train moving even when
+// nobody is watching, so reducing polling never stalls autonomous work.
+//
+// `autonomousWorkInFlight` is a *hoisted function declaration* on purpose: it
+// references `service`, `mergeErrorSessions` (defined ~700 lines below) and
+// `store`, but only reads them when CALLED at runtime (a timer firing), never
+// during module init — so the forward reference is safe.
+function autonomousWorkInFlight(): boolean {
+  if (service.liveTrainPrs().length > 0) return true; // a live merge train
+  if (mergeErrorSessions.size > 0) return true; // train blocked/retrying — still working
+  // any non-archived full-auto session: the train may act on it without a watcher
+  return store
+    .list()
+    .some((s) => s.status !== "archived" && isFullAuto(s, store.getRepoConfig(s.repoPath)));
+}
+const warm = (): boolean => presence.hasClients() || autonomousWorkInFlight();
+
 const prPoller = new PrPoller(
   store,
   resolveForge,
@@ -633,6 +668,9 @@ const prPoller = new PrPoller(
   undefined,
   undefined,
   ownsPr,
+  warm, // full cadence only while warm; cold → fast sweep pauses, full sweep throttles
+  () => graphRateLimit.blocked(), // skip every sweep while the GraphQL bucket is exhausted
+  // idleIntervalMs: default (300s coarse full-sweep cadence while cold)
 );
 setTimeout(() => void prPoller.tick(), 3_000); // warm the cache shortly after boot
 prPoller.start();
@@ -1069,8 +1107,17 @@ setInterval(() => {
 // finalize tick above: a sweep lists every open PR per repo (a forge round-trip), far
 // heavier than reading verdict files, so it polls coarsely while verdicts still finalize
 // promptly on the shared 15s tick.
+let lastCriticSweepAt = 0;
+const criticIdleIntervalMs = 300_000;
 setInterval(() => {
   if (maintenance.active) return;
+  if (graphRateLimit.blocked()) return; // GraphQL bucket exhausted — skip the heavy enumeration
+  const now = Date.now();
+  // Cold path: no dashboard + no autonomous work → throttle the per-repo PR
+  // enumeration to the coarse idle cadence (the cheap 15s verdict-finalize tick
+  // above is untouched, so verdicts still settle promptly).
+  if (!warm() && now - lastCriticSweepAt < criticIdleIntervalMs) return;
+  lastCriticSweepAt = now;
   void standaloneCritic.sweep();
 }, 60_000);
 // archived sessions: reap any in-flight critic + drop the verdict, and reap any
@@ -1860,6 +1907,10 @@ const backlogPoller = new BacklogPoller(
   (dir) => backlog.refresh(dir),
   45_000,
   broadcastBacklog,
+  // Warm the backlog only while a dashboard is open and the GraphQL bucket is
+  // healthy — backlog counts serve the overview, which nobody is reading when
+  // there are no clients. (A reconnect fires the debounced presence catch-up.)
+  () => presence.hasClients() && !graphRateLimit.blocked(),
 );
 setTimeout(() => void backlogPoller.tick(), 3_000);
 backlogPoller.start();

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -155,10 +155,29 @@ export class PrPoller implements PrCache {
      *  returning a prior, already-merged PR that merely reused this branch name.
      *  `false` → discard the stale PR; `true`/`null` → trust it. */
     private ownsPr: (s: Session, headSha: string) => boolean | null = () => true,
+    /** Cadence gate: poll at full rate only while *warm* (a dashboard is open OR
+     *  autonomous merge work is in flight). When cold, the fast sweep pauses
+     *  entirely and the full sweep throttles to `idleIntervalMs`. */
+    private warm: () => boolean = () => true,
+    /** True while the shared GraphQL backoff is engaged — skip every sweep so we
+     *  don't burn budget against an exhausted bucket. */
+    private rateLimited: () => boolean = () => false,
+    /** Coarse full-sweep cadence while cold (no warmth) — the fast sweep is paused
+     *  outright, so this is the only PR refresh path when nobody's watching. */
+    private idleIntervalMs = 300_000,
   ) {}
 
+  /** Epoch-ms of the last full sweep that actually ran — gates the cold-path
+   *  throttle in `tick`. */
+  private lastFullSweepAt = 0;
+
   async tick(): Promise<void> {
+    if (this.rateLimited()) return; // GraphQL bucket exhausted — don't add to the backlog
+    // Cold path: nobody's watching and no autonomous merge work — throttle the full
+    // sweep to the coarse idle cadence instead of every `intervalMs`.
+    if (!this.warm() && Date.now() - this.lastFullSweepAt < this.idleIntervalMs) return;
     if (this.sweeping) return; // a fast tick is mid-flight — it'll be re-covered here next interval
+    this.lastFullSweepAt = Date.now();
     this.sweeping = true;
     try {
       const active = new Set<string>();
@@ -179,6 +198,9 @@ export class PrPoller implements PrCache {
    *  120s sweep's lag. Capped at `fastBatch` per tick, rotating so every open PR is
    *  covered across a few ticks rather than fanning out one `gh` per PR each time. */
   async fastTick(): Promise<void> {
+    // Cadence gate first (a later task layers an activity-aware filter after this):
+    // pause the fast sweep entirely when rate-limited or cold.
+    if (this.rateLimited() || !this.warm()) return;
     if (this.sweeping) return; // don't overlap (or double-poll behind) the full sweep
     const open = [...this.cache.entries()].filter(([, g]) => g.state === "open").map(([id]) => id);
     if (open.length === 0) {

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -220,8 +220,7 @@ export class PrPoller implements PrCache {
    *  120s sweep's lag. Capped at `fastBatch` per tick, rotating so every open PR is
    *  covered across a few ticks rather than fanning out one `gh` per PR each time. */
   async fastTick(): Promise<void> {
-    // Cadence gate first (a later task layers an activity-aware filter after this):
-    // pause the fast sweep entirely when rate-limited or cold.
+    // Cadence gate first: skip entirely when rate-limited or not warm, before the activity-aware filter below.
     if (this.rateLimited() || !this.warm()) return;
     if (this.sweeping) return; // don't overlap (or double-poll behind) the full sweep
     const open = [...this.cache.entries()].filter(([, g]) => g.state === "open").map(([id]) => id);
@@ -252,7 +251,7 @@ export class PrPoller implements PrCache {
       // below when the open-PR count drops back under the cap.
       if (!this.fastCapLogged) {
         console.warn(
-          `[pr-poller] ${eligible.length} open PRs exceed fast-poll cap ${this.fastBatch}; polling ${this.fastBatch}/tick round-robin`,
+          `[pr-poller] ${eligible.length} transient open PRs exceed fast-poll cap ${this.fastBatch}; polling ${this.fastBatch}/tick round-robin`,
         );
         this.fastCapLogged = true;
       }

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -123,6 +123,21 @@ export class PrPoller implements PrCache {
   private fastCursor = 0;
   /** Latched so the over-cap notice logs once on transition, not every fast tick. */
   private fastCapLogged = false;
+  /** Tracks when each open PR entered (or re-entered via a new headSha) a transient
+   *  state — used to time-bound how long `fastTick` keeps re-polling it. */
+  private transientSince = new Map<string, { since: number; headSha?: string }>();
+
+  /** True when an open PR can still move without a human action — i.e. it is worth
+   *  fast-polling. A PR that is fully settled (CI green, mergeable, clean) is parked. */
+  private isTransientOpen(git: GitState): boolean {
+    return (
+      git.state === "open" &&
+      (git.checks === "pending" ||
+        git.mergeable == null ||
+        git.mergeStateStatus === "unknown" ||
+        git.mergeStateStatus === "unstable")
+    );
+  }
 
   /** Run `fn` with the single-`gh` lock held; queues behind any in-flight poll. */
   private withGh<T>(fn: () => Promise<T>): Promise<T> {
@@ -165,6 +180,10 @@ export class PrPoller implements PrCache {
     /** Coarse full-sweep cadence while cold (no warmth) — the fast sweep is paused
      *  outright, so this is the only PR refresh path when nobody's watching. */
     private idleIntervalMs = 300_000,
+    /** How long a PR can remain transient (checks pending / mergeable unknown / merge
+     *  state unstable) before `fastTick` parks it and stops fast-polling it. A new
+     *  headSha resets the clock. Default: 5 minutes. */
+    private transientMaxMs = 300_000,
   ) {}
 
   /** Epoch-ms of the last full sweep that actually ran — gates the cold-path
@@ -186,7 +205,10 @@ export class PrPoller implements PrCache {
         await this.withGh(() => this.refresh(s));
       }
       for (const id of [...this.cache.keys()]) {
-        if (!active.has(id)) this.cache.delete(id);
+        if (!active.has(id)) {
+          this.cache.delete(id);
+          this.transientSince.delete(id);
+        }
       }
     } finally {
       this.sweeping = false;
@@ -207,16 +229,30 @@ export class PrPoller implements PrCache {
       this.fastCapLogged = false; // dropped under cap (to zero) → re-arm the notice
       return;
     }
-    let batch = open;
-    if (open.length > this.fastBatch) {
-      const start = this.fastCursor % open.length;
-      batch = [...open, ...open].slice(start, start + this.fastBatch);
-      this.fastCursor = (start + this.fastBatch) % open.length;
+    // Activity-aware filter: only re-poll PRs that are still transient AND within
+    // the time-bounded window. Stamp-missing (shouldn't happen normally) → eligible.
+    const now = Date.now();
+    const eligible = open.filter((id) => {
+      const git = this.cache.get(id)!;
+      if (!this.isTransientOpen(git)) return false;
+      const entry = this.transientSince.get(id);
+      const since = entry?.since ?? now;
+      return now - since < this.transientMaxMs;
+    });
+    if (eligible.length === 0) {
+      this.fastCapLogged = false;
+      return;
+    }
+    let batch = eligible;
+    if (eligible.length > this.fastBatch) {
+      const start = this.fastCursor % eligible.length;
+      batch = [...eligible, ...eligible].slice(start, start + this.fastBatch);
+      this.fastCursor = (start + this.fastBatch) % eligible.length;
       // Log once on entering the over-cap regime, not every 15s tick; re-arm
       // below when the open-PR count drops back under the cap.
       if (!this.fastCapLogged) {
         console.warn(
-          `[pr-poller] ${open.length} open PRs exceed fast-poll cap ${this.fastBatch}; polling ${this.fastBatch}/tick round-robin`,
+          `[pr-poller] ${eligible.length} open PRs exceed fast-poll cap ${this.fastBatch}; polling ${this.fastBatch}/tick round-robin`,
         );
         this.fastCapLogged = true;
       }
@@ -271,6 +307,17 @@ export class PrPoller implements PrCache {
     // Who's up (open+green): computed from .shepherd/roles.json + the operator's
     // login, so the herd can show "waiting on scoop" instead of "your turn".
     git = annotateHandoff(git, s.repoPath, me);
+    // Maintain the transient-window stamp regardless of whether visible state changed.
+    // A headSha change (new push) resets the clock; same headSha keeps the original since.
+    if (!this.isTransientOpen(git)) {
+      this.transientSince.delete(s.id);
+    } else {
+      const entry = this.transientSince.get(s.id);
+      if (!entry || entry.headSha !== git.headSha) {
+        this.transientSince.set(s.id, { since: Date.now(), headSha: git.headSha });
+      }
+      // else: same headSha → keep original since (preserves the window start time)
+    }
     if (gitStateChanged(prev, git)) {
       this.cache.set(s.id, git);
       this.onChange(s.id, git);
@@ -321,6 +368,7 @@ export class PrPoller implements PrCache {
   }
   drop(id: string): void {
     this.cache.delete(id);
+    this.transientSince.delete(id);
   }
 
   start(): void {

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -306,20 +306,27 @@ export class PrPoller implements PrCache {
     // Who's up (open+green): computed from .shepherd/roles.json + the operator's
     // login, so the herd can show "waiting on scoop" instead of "your turn".
     git = annotateHandoff(git, s.repoPath, me);
-    // Maintain the transient-window stamp regardless of whether visible state changed.
-    // A headSha change (new push) resets the clock; same headSha keeps the original since.
-    if (!this.isTransientOpen(git)) {
-      this.transientSince.delete(s.id);
-    } else {
-      const entry = this.transientSince.get(s.id);
-      if (!entry || entry.headSha !== git.headSha) {
-        this.transientSince.set(s.id, { since: Date.now(), headSha: git.headSha });
-      }
-      // else: same headSha → keep original since (preserves the window start time)
-    }
+    this.trackTransient(s.id, git);
     if (gitStateChanged(prev, git)) {
       this.cache.set(s.id, git);
       this.onChange(s.id, git);
+    }
+  }
+
+  /** Maintain the transient-window stamp for `id` from its latest observed `git`,
+   *  regardless of whether visible state changed. A non-transient state clears the
+   *  stamp; a headSha change (new push) resets the window; the same headSha keeps the
+   *  original `since` so the time-bound in `fastTick` measures from the first
+   *  transient observation. Extracted from `refresh` to keep that method's branch
+   *  count under the complexity gate. */
+  private trackTransient(id: string, git: GitState): void {
+    if (!this.isTransientOpen(git)) {
+      this.transientSince.delete(id);
+      return;
+    }
+    const entry = this.transientSince.get(id);
+    if (!entry || entry.headSha !== git.headSha) {
+      this.transientSince.set(id, { since: Date.now(), headSha: git.headSha });
     }
   }
 

--- a/src/presence.ts
+++ b/src/presence.ts
@@ -6,6 +6,17 @@
 
 export class Presence {
   private active = new Set<object>();
+  /** Every currently-connected /events client, focused or not. A connection means
+   *  a dashboard is *open* (so background pollers should run at full cadence) even
+   *  when its window is backgrounded — distinct from `active` (focused+visible). */
+  private connected = new Set<object>();
+  /** Latched so `onActivate` fires only on the empty→non-empty edge, re-armed
+   *  once `connected` drains back to empty. */
+  private activatedAtZero = true;
+
+  /** Fired on the 0→1 `connected` transition (a fresh dashboard appeared after a
+   *  quiet spell) so the caller can kick a one-off catch-up poll. */
+  constructor(private onActivate?: () => void) {}
 
   /** Record a client's active state. `client` is any stable per-connection key. */
   set(client: object, active: boolean): void {
@@ -13,13 +24,35 @@ export class Presence {
     else this.active.delete(client);
   }
 
-  /** Forget a client entirely (call on disconnect). */
-  drop(client: object): void {
-    this.active.delete(client);
+  /** Register an open connection (call on /events socket open). Invokes
+   *  `onActivate` once on the empty→non-empty edge so a dashboard reappearing
+   *  after an idle spell triggers an immediate catch-up sweep. */
+  connect(client: object): void {
+    const wasEmpty = this.connected.size === 0;
+    this.connected.add(client);
+    if (wasEmpty && this.activatedAtZero) {
+      this.activatedAtZero = false;
+      this.onActivate?.();
+    }
   }
 
-  /** True while at least one client is actively in use. */
+  /** Forget a client entirely (call on disconnect). Removes it from BOTH the
+   *  focus (`active`) and connection (`connected`) sets; re-arms `onActivate`
+   *  once `connected` empties. */
+  drop(client: object): void {
+    this.active.delete(client);
+    this.connected.delete(client);
+    if (this.connected.size === 0) this.activatedAtZero = true;
+  }
+
+  /** True while at least one client is actively in use (focused + visible). */
   isActive(): boolean {
     return this.active.size > 0;
+  }
+
+  /** True while at least one client is connected (a dashboard is open), regardless
+   *  of focus — the cadence gate for background pollers. */
+  hasClients(): boolean {
+    return this.connected.size > 0;
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -251,7 +251,7 @@ export interface AppDeps {
   /** Web Push delivery; absent in tests that don't exercise notifications. */
   push?: Pick<PushService, "publicKey" | "subscribe" | "unsubscribe">;
   /** Active-window tracker fed by /events presence frames; gates push suppression. */
-  presence?: Pick<Presence, "set" | "drop">;
+  presence?: Pick<Presence, "set" | "drop" | "connect">;
   /** Status poller; used to manually dismiss a stall flag (`acknowledgeStall`) and, when
    *  `hooksSignals` is on, as the Phase-1 signal sink the index.ts onSignal closure feeds
    *  push events to (`ingestActivity` / `ingestNotification` — issue #704). The route
@@ -5539,6 +5539,9 @@ export function serve(deps: AppDeps, port: number) {
             ws.send(JSON.stringify({ event, data })),
           );
           ws.data.unsub = unsub;
+          // A live /events socket = a dashboard is open (regardless of focus), so
+          // background pollers should run warm. `close` drops it again.
+          deps.presence?.connect(ws);
         } else {
           // Don't attach a terminal whose herdr agent is gone: attaching would make
           // herdr reply agent_not_found and the client would reconnect-loop on it.

--- a/test/backlog-poller.test.ts
+++ b/test/backlog-poller.test.ts
@@ -125,6 +125,48 @@ test("start/stop manage the interval timer without throwing", () => {
   expect(true).toBe(true);
 });
 
+// ── shouldWarm() gating ───────────────────────────────────────────────────────
+
+test("tick performs no warming and no broadcast when shouldWarm() is false", async () => {
+  const warmed: string[] = [];
+  let broadcasts = 0;
+  const poller = new BacklogPoller(
+    () => [{ path: "/a" }],
+    () => ({ kind: "github", slug: "o/r" }),
+    async (p) => {
+      warmed.push(p);
+      return { openIssues: 1, openPRs: 0, ciStatus: null, prKinds: null };
+    },
+    45_000,
+    () => {
+      broadcasts++;
+    },
+    () => false, // shouldWarm
+  );
+
+  await poller.tick();
+  expect(warmed).toEqual([]);
+  expect(broadcasts).toBe(0);
+});
+
+test("tick warms when shouldWarm() is true", async () => {
+  const warmed: string[] = [];
+  const poller = new BacklogPoller(
+    () => [{ path: "/a" }],
+    () => ({ kind: "github", slug: "o/r" }),
+    async (p) => {
+      warmed.push(p);
+      return { openIssues: 1, openPRs: 0, ciStatus: null, prKinds: null };
+    },
+    45_000,
+    undefined,
+    () => true, // shouldWarm
+  );
+
+  await poller.tick();
+  expect(warmed).toEqual(["/a"]);
+});
+
 // ── mode-aware forge-backed tests ─────────────────────────────────────────────
 
 test("local forge (kind=local) is NOT forge-backed — not warmed", async () => {

--- a/test/backlog.test.ts
+++ b/test/backlog.test.ts
@@ -113,7 +113,7 @@ test("CountsService: Gitea repo returns openIssues and openPRs from REST API", a
   expect(result.openPRs).toBe(1);
 });
 
-// 3. 60s TTL: two calls within the window invoke runner ONCE
+// 3. 120s TTL: two calls within the window invoke runner ONCE
 test("CountsService: TTL caches result — second call within window skips runner", async () => {
   const repoDir = gitInit(join(tmpBase, "gh-ttl"), "https://github.com/o/r");
   const forges: ForgeMap = {};
@@ -202,7 +202,7 @@ test("CountsService: failure yields null not 0", async () => {
 });
 
 // 7. TTL expiry: second call after TTL elapses re-invokes the runner
-test("CountsService: TTL expiry — call after 60s window re-fetches from runner", async () => {
+test("CountsService: TTL expiry — call after 120s window re-fetches from runner", async () => {
   const repoDir = gitInit(join(tmpBase, "gh-ttl-expire"), "https://github.com/o/ttl-expire");
   const forges: ForgeMap = {};
 
@@ -215,9 +215,9 @@ test("CountsService: TTL expiry — call after 60s window re-fetches from runner
   // First fetch — populates cache
   await svc.counts(repoDir);
 
-  // Backdate the cache entry's `at` field to simulate TTL expiry (> 60 000 ms ago)
+  // Backdate the cache entry's `at` field to simulate TTL expiry (> 120 000 ms ago)
   const entry = (svc as any).cache.get(repoDir);
-  entry.at = Date.now() - 61_000;
+  entry.at = Date.now() - 121_000;
 
   // Second fetch — cache is stale, runner should be called again
   await svc.counts(repoDir);
@@ -443,14 +443,10 @@ test("CountsService: prKinds breaks open PRs down by kind", async () => {
           pullRequests: {
             totalCount: 4,
             nodes: [
-              { author: { login: "dependabot[bot]" }, title: "bump foo", labels: { nodes: [] } },
-              {
-                author: { login: "me" },
-                title: "chore(main): release 1.0.0",
-                labels: { nodes: [] },
-              },
-              { author: { login: "me" }, title: "fix: a bug", labels: { nodes: [] } },
-              { author: { login: "me" }, title: "feat: a thing", labels: { nodes: [] } },
+              { author: { login: "dependabot[bot]" }, title: "bump foo" },
+              { author: { login: "me" }, title: "chore(main): release 1.0.0" },
+              { author: { login: "me" }, title: "fix: a bug" },
+              { author: { login: "me" }, title: "feat: a thing" },
             ],
           },
         },
@@ -469,8 +465,8 @@ test("CountsService: prKinds clamps the >100-PR tail into regular", async () => 
   const repoDir = gitInit(join(tmpBase, "gh-kinds-cap"), "https://github.com/o/kinds-cap");
   const nodes = Array.from({ length: 100 }, (_, i) =>
     i === 0
-      ? { author: { login: "dependabot[bot]" }, title: "bump foo", labels: { nodes: [] } }
-      : { author: { login: "me" }, title: "feat: thing", labels: { nodes: [] } },
+      ? { author: { login: "dependabot[bot]" }, title: "bump foo" }
+      : { author: { login: "me" }, title: "feat: thing" },
   );
   const { run } = fakeRunner(
     JSON.stringify({

--- a/test/pr-kind.test.ts
+++ b/test/pr-kind.test.ts
@@ -77,6 +77,20 @@ describe("classifyPr — release", () => {
   it("does NOT match a title that merely contains 'release'", () => {
     expect(classifyPr({ author: "alice", title: "feat: add release notes link" })).toBe("regular");
   });
+
+  it("classifies as release from branch alone — no labels needed", () => {
+    expect(
+      classifyPr({
+        author: "google-cloud-policy[bot]",
+        title: "chore: release",
+        headRefName: "release-please--branches--main--component--my-lib",
+      }),
+    ).toBe("release");
+  });
+
+  it("classifies as release from title alone — no labels needed", () => {
+    expect(classifyPr({ author: "alice", title: "chore: release 2.3.1" })).toBe("release");
+  });
 });
 
 describe("classifyPr — regular", () => {

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -656,6 +656,179 @@ test("serializes a targeted poll behind a sweep — one gh at a time", async () 
   expect(maxActive).toBe(1); // never two `gh` calls in flight at once
 });
 
+// ── warm() / rateLimited() cadence gating ─────────────────────────────────────
+
+test("fastTick skips when rateLimited() is true", async () => {
+  const store = new SessionStore(":memory:");
+  store.create({ ...baseSession, branch: "shepherd/a" });
+  let calls = 0;
+  const forge: GitForge = {
+    ...forgeByBranch({}),
+    prStatus: async () => {
+      calls++;
+      return OPEN_PENDING;
+    },
+  };
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    () => {},
+    120_000,
+    1000,
+    () => null,
+    15_000,
+    8,
+    () => true,
+    () => true, // warm
+    () => true, // rateLimited
+  );
+  await poller.tick(); // warm the cache (gated only on fastTick/tick, tick itself runs because warm)
+  calls = 0;
+  await poller.fastTick();
+  expect(calls).toBe(0);
+});
+
+test("fastTick skips when warm() is false and runs when warm & not limited", async () => {
+  const store = new SessionStore(":memory:");
+  store.create({ ...baseSession, branch: "shepherd/a" });
+  let calls = 0;
+  let warm = true;
+  const forge: GitForge = {
+    ...forgeByBranch({}),
+    prStatus: async () => {
+      calls++;
+      return OPEN_PENDING;
+    },
+  };
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    () => {},
+    120_000,
+    1000,
+    () => null,
+    15_000,
+    8,
+    () => true,
+    () => warm,
+    () => false,
+  );
+  await poller.tick(); // cache one open PR
+  calls = 0;
+  warm = false;
+  await poller.fastTick();
+  expect(calls).toBe(0); // not warm → skipped
+  warm = true;
+  await poller.fastTick();
+  expect(calls).toBe(1); // warm & not limited → runs
+});
+
+test("tick runs every call when warm() is true", async () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  let calls = 0;
+  const poller = new PrPoller(
+    store,
+    () =>
+      forgeReturning(() => {
+        calls++;
+        return OPEN;
+      }),
+    () => {},
+    120_000,
+    1000,
+    () => null,
+    15_000,
+    8,
+    () => true,
+    () => true, // warm
+    () => false,
+  );
+  await poller.tick();
+  await poller.tick();
+  expect(calls).toBe(2);
+});
+
+test("tick when not warm runs once then skips within idleIntervalMs", async () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  let calls = 0;
+  const poller = new PrPoller(
+    store,
+    () =>
+      forgeReturning(() => {
+        calls++;
+        return OPEN;
+      }),
+    () => {},
+    120_000,
+    1000,
+    () => null,
+    15_000,
+    8,
+    () => true,
+    () => false, // not warm
+    () => false,
+    600_000, // large idleIntervalMs → second call is throttled out
+  );
+  await poller.tick();
+  expect(calls).toBe(1); // first sweep proceeds and stamps lastFullSweepAt
+  await poller.tick();
+  expect(calls).toBe(1); // within idle window → skipped
+});
+
+test("tick when not warm runs again with idleIntervalMs 0", async () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  let calls = 0;
+  const poller = new PrPoller(
+    store,
+    () =>
+      forgeReturning(() => {
+        calls++;
+        return OPEN;
+      }),
+    () => {},
+    120_000,
+    1000,
+    () => null,
+    15_000,
+    8,
+    () => true,
+    () => false, // not warm
+    () => false,
+    0, // no idle throttle → every call sweeps
+  );
+  await poller.tick();
+  await poller.tick();
+  expect(calls).toBe(2);
+});
+
+test("tick skips entirely when rateLimited() regardless of warm", async () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  let calls = 0;
+  const poller = new PrPoller(
+    store,
+    () =>
+      forgeReturning(() => {
+        calls++;
+        return OPEN;
+      }),
+    () => {},
+    120_000,
+    1000,
+    () => null,
+    15_000,
+    8,
+    () => true,
+    () => true, // warm
+    () => true, // but rate limited
+  );
+  await poller.tick();
+  expect(calls).toBe(0);
+});
+
 test("prunes cache entries for sessions no longer active", async () => {
   const store = new SessionStore(":memory:");
   const s = store.create(baseSession);

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -662,6 +662,7 @@ test("fastTick skips when rateLimited() is true", async () => {
   const store = new SessionStore(":memory:");
   store.create({ ...baseSession, branch: "shepherd/a" });
   let calls = 0;
+  let rl = false;
   const forge: GitForge = {
     ...forgeByBranch({}),
     prStatus: async () => {
@@ -680,12 +681,14 @@ test("fastTick skips when rateLimited() is true", async () => {
     8,
     () => true,
     () => true, // warm
-    () => true, // rateLimited
+    () => rl,
   );
-  await poller.tick(); // warm the cache (gated only on fastTick/tick, tick itself runs because warm)
+  await poller.tick(); // cache one open PR (rl=false so tick runs)
   calls = 0;
+  rl = true; // engage the rate-limit gate
   await poller.fastTick();
-  expect(calls).toBe(0);
+  expect(calls).toBe(0); // rateLimited → skipped; cache still holds the open PR
+  expect(poller.snapshot()).toBeDefined(); // cache untouched
 });
 
 test("fastTick skips when warm() is false and runs when warm & not limited", async () => {

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -1010,3 +1010,186 @@ test("refresh signal (a): cold cache + marked + markedNumber matches, ownsPr=fal
   expect(emitted[0]!.number).toBe(344);
   expect(poller.snapshot()[s.id]?.state).toBe("merged");
 });
+
+// ── Task 3: activity-aware fast-sweep filter ───────────────────────────────────
+
+/** Open PR that is stable-green: CI passed, mergeable, clean merge state — not transient. */
+const OPEN_STABLE: PrStatus = {
+  state: "open",
+  number: 10,
+  checks: "success",
+  mergeable: true,
+  mergeStateStatus: "clean",
+  deployConfigured: false,
+};
+
+test("fastTick skips a stable-green open PR (not transient — parked)", async () => {
+  const store = new SessionStore(":memory:");
+  store.create({ ...baseSession, branch: "shepherd/stable" });
+  let fastPolled = 0;
+  const forge: GitForge = {
+    ...forgeByBranch({}),
+    prStatus: async () => {
+      fastPolled++;
+      return OPEN_STABLE;
+    },
+  };
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    () => {},
+  );
+
+  await poller.tick(); // seed cache; also calls prStatus (fastPolled++)
+  fastPolled = 0; // reset — only count fastTick polls
+  await poller.fastTick(); // stable PR → not eligible → 0 polls
+  expect(fastPolled).toBe(0);
+});
+
+test("fastTick polls a transient open PR (checks:pending)", async () => {
+  const store = new SessionStore(":memory:");
+  store.create({ ...baseSession, branch: "shepherd/pending-fast" });
+  let fastPolled = 0;
+  const forge: GitForge = {
+    ...forgeByBranch({}),
+    prStatus: async () => {
+      fastPolled++;
+      return OPEN_PENDING;
+    },
+  };
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    () => {},
+  );
+
+  await poller.tick();
+  fastPolled = 0;
+  await poller.fastTick(); // pending → transient → eligible → polled
+  expect(fastPolled).toBe(1);
+});
+
+test("fastTick parks a transient PR whose transientMaxMs window has expired", async () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create({ ...baseSession, branch: "shepherd/aged" });
+  let fastPolled = 0;
+  const forge: GitForge = {
+    ...forgeByBranch({}),
+    prStatus: async () => {
+      fastPolled++;
+      return OPEN_PENDING;
+    },
+  };
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    () => {},
+    120_000,
+    1000,
+    () => null,
+    15_000,
+    8,
+    () => true,
+    () => true,
+    () => false,
+    300_000,
+    300_000, // transientMaxMs
+  );
+
+  await poller.tick(); // seed cache + transientSince (since ≈ now)
+  fastPolled = 0;
+
+  // Age the transientSince entry past the 300s window
+  const ts = (poller as any).transientSince as Map<string, { since: number; headSha?: string }>;
+  ts.set(s.id, { since: Date.now() - 400_000, headSha: undefined });
+
+  await poller.fastTick(); // aged out → parked → 0 polls
+  expect(fastPolled).toBe(0);
+});
+
+test("headSha change restamps the transient window, making an aged-out PR eligible again", async () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create({ ...baseSession, branch: "shepherd/pushed" });
+  let cur: PrStatus = { ...OPEN_PENDING, headSha: "sha-aaa" };
+  let fastPolled = 0;
+  const forge: GitForge = {
+    ...forgeByBranch({}),
+    prStatus: async () => {
+      fastPolled++;
+      return cur;
+    },
+  };
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    () => {},
+    120_000,
+    1000,
+    () => null,
+    15_000,
+    8,
+    () => true,
+    () => true,
+    () => false,
+    300_000,
+    300_000, // transientMaxMs
+  );
+
+  await poller.tick(); // seed with sha-aaa
+
+  // Age out the entry so fastTick would park it
+  const ts = (poller as any).transientSince as Map<string, { since: number; headSha?: string }>;
+  ts.set(s.id, { since: Date.now() - 400_000, headSha: "sha-aaa" });
+
+  fastPolled = 0;
+  await poller.fastTick(); // aged out → 0 polls
+  expect(fastPolled).toBe(0);
+
+  // New push: headSha changes → refresh() sees sha-bbb ≠ sha-aaa → restamps since
+  cur = { ...OPEN_PENDING, headSha: "sha-bbb" };
+  await poller.tick(); // tick re-stamps transientSince with since ≈ now
+  fastPolled = 0;
+  await poller.fastTick(); // fresh window → eligible → polled
+  expect(fastPolled).toBe(1);
+});
+
+test("transientSince entry is deleted when a session is pruned in tick()", async () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create({ ...baseSession, branch: "shepherd/prune-tick" });
+  const poller = new PrPoller(
+    store,
+    () => forgeReturning(() => OPEN_PENDING),
+    () => {},
+  );
+
+  await poller.tick(); // seed cache + transientSince
+
+  const ts = (poller as any).transientSince as Map<string, { since: number; headSha?: string }>;
+  expect(ts.has(s.id)).toBe(true);
+
+  store.archive(s.id);
+  await poller.tick(); // session no longer active → pruned from cache + transientSince
+
+  expect(ts.has(s.id)).toBe(false);
+  expect(poller.snapshot()[s.id]).toBeUndefined();
+});
+
+test("transientSince entry is deleted on drop()", async () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create({ ...baseSession, branch: "shepherd/prune-drop" });
+  const poller = new PrPoller(
+    store,
+    () => forgeReturning(() => OPEN_PENDING),
+    () => {},
+  );
+
+  await poller.tick(); // seed transientSince
+
+  const ts = (poller as any).transientSince as Map<string, { since: number; headSha?: string }>;
+  expect(ts.has(s.id)).toBe(true);
+
+  poller.drop(s.id);
+
+  expect(ts.has(s.id)).toBe(false);
+  expect(poller.snapshot()[s.id]).toBeUndefined();
+});

--- a/test/presence.test.ts
+++ b/test/presence.test.ts
@@ -32,3 +32,56 @@ test("drop removes a client even if it was active (disconnect)", () => {
   p.drop(a);
   expect(p.isActive()).toBe(false);
 });
+
+test("connect makes hasClients() true; drop clears it", () => {
+  const p = new Presence();
+  const a = {};
+  expect(p.hasClients()).toBe(false);
+  p.connect(a);
+  expect(p.hasClients()).toBe(true);
+  p.drop(a);
+  expect(p.hasClients()).toBe(false);
+});
+
+test("connected and active are distinct sets — connect does not mark active", () => {
+  const p = new Presence();
+  const a = {};
+  p.connect(a);
+  expect(p.hasClients()).toBe(true);
+  expect(p.isActive()).toBe(false); // a connection is not yet a focused window
+});
+
+test("drop removes from BOTH connected and active", () => {
+  const p = new Presence();
+  const a = {};
+  p.connect(a);
+  p.set(a, true);
+  expect(p.hasClients()).toBe(true);
+  expect(p.isActive()).toBe(true);
+  p.drop(a);
+  expect(p.hasClients()).toBe(false);
+  expect(p.isActive()).toBe(false);
+});
+
+test("onActivate fires exactly once on the 0→1 transition, not on a second connect", () => {
+  let fires = 0;
+  const p = new Presence(() => fires++);
+  const a = {};
+  const b = {};
+  p.connect(a);
+  expect(fires).toBe(1);
+  p.connect(b); // 1→2, not an empty→non-empty edge
+  expect(fires).toBe(1);
+});
+
+test("onActivate re-arms after connected empties and a new connect arrives", () => {
+  let fires = 0;
+  const p = new Presence(() => fires++);
+  const a = {};
+  const b = {};
+  p.connect(a);
+  expect(fires).toBe(1);
+  p.drop(a); // connected now empty → re-armed
+  p.connect(b); // empty→non-empty again
+  expect(fires).toBe(2);
+});

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -191,12 +191,36 @@ describe("GraphRateLimit — logging", () => {
     const rl = new GraphRateLimit({ now: () => t, defaultCooldownMs: 60_000 });
     rl.noteLimitError(); // blocked
     warnSpy.mockClear();
-    t = 60_001; // past expiry
-    // Trigger a detection path that emits the clear log
-    rl.note({ remaining: 200, resetAt: 999_999 }); // healthy reading → clears
+    t = 30_000; // still WITHIN the cooldown window → blocked() is true
+    // Trigger a healthy reading while actively blocked → clears
+    rl.note({ remaining: 200, resetAt: 999_999 });
     expect(warnSpy).toHaveBeenCalledTimes(1);
     const msg = String(warnSpy.mock.calls[0]?.[0] ?? "");
     expect(msg).toContain("[rate-limit]");
+  });
+
+  it("logs 'engaged' on re-engagement after natural expiry", () => {
+    let t = 0;
+    const rl = new GraphRateLimit({ now: () => t, defaultCooldownMs: 60_000 });
+    rl.noteLimitError(); // first engagement at t=0
+    warnSpy.mockClear();
+    t = 70_000; // advance past expiry — blocked() is now false
+    // Re-engage after natural expiry: must log "engaged" again
+    rl.noteLimitError();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const msg = String(warnSpy.mock.calls[0]?.[0] ?? "");
+    expect(msg).toContain("[rate-limit]");
+    expect(msg).toContain("engaged");
+  });
+
+  it("does NOT log 'cleared' when healthy note() arrives after natural expiry", () => {
+    let t = 0;
+    const rl = new GraphRateLimit({ now: () => t, defaultCooldownMs: 60_000 });
+    rl.noteLimitError(); // engaged
+    warnSpy.mockClear();
+    t = 70_000; // advance past expiry — natural cooldown elapsed
+    rl.note({ remaining: 200, resetAt: 999_999 }); // healthy, but block already elapsed
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Tests for src/forge/rate-limit.ts — GraphQL bucket rate-limit tracking.
+ *
+ * Each test injects a deterministic clock (`now` option) so there is no
+ * wall-clock dependency. The module singleton (`graphRateLimit`) is NOT
+ * exercised here — we always construct a fresh instance with controlled opts.
+ */
+import { describe, it, expect, spyOn, beforeEach, afterEach } from "bun:test";
+import {
+  GraphRateLimit,
+  isGraphqlBucketCall,
+  isRateLimitError,
+  parseRetryAfter,
+} from "../src/forge/rate-limit";
+
+// ── GraphRateLimit: initial state ─────────────────────────────────────────────
+
+describe("GraphRateLimit — initial state", () => {
+  it("starts with all nulls and not blocked", () => {
+    const rl = new GraphRateLimit();
+    const snap = rl.snapshot();
+    expect(snap.remaining).toBeNull();
+    expect(snap.resetAt).toBeNull();
+    expect(snap.pausedUntil).toBeNull();
+    expect(snap.blocked).toBe(false);
+    expect(rl.blocked()).toBe(false);
+  });
+});
+
+// ── GraphRateLimit: note() — healthy reading ──────────────────────────────────
+
+describe("GraphRateLimit — note() healthy reading (remaining >= floor)", () => {
+  it("stores remaining and resetAt", () => {
+    const rl = new GraphRateLimit({ now: () => 1_000_000 });
+    rl.note({ remaining: 200, resetAt: 2_000_000 });
+    const snap = rl.snapshot();
+    expect(snap.remaining).toBe(200);
+    expect(snap.resetAt).toBe(2_000_000);
+  });
+
+  it("clears an existing block when remaining >= floor", () => {
+    const t = 1_000_000;
+    const rl = new GraphRateLimit({ now: () => t, defaultCooldownMs: 60_000 });
+    // Engage a block via error
+    rl.noteLimitError();
+    expect(rl.blocked()).toBe(true);
+    // A healthy reading clears it
+    rl.note({ remaining: 200, resetAt: 2_000_000 });
+    expect(rl.blocked()).toBe(false);
+    expect(rl.snapshot().pausedUntil).toBeNull();
+  });
+
+  it("does not block when remaining equals floor exactly", () => {
+    const rl = new GraphRateLimit({ now: () => 0, floor: 100 });
+    rl.note({ remaining: 100, resetAt: 9_999_999 });
+    expect(rl.blocked()).toBe(false);
+  });
+});
+
+// ── GraphRateLimit: note() — low reading (remaining < floor) ─────────────────
+
+describe("GraphRateLimit — note() low reading (remaining < floor)", () => {
+  it("sets pausedUntil = resetAt when below floor", () => {
+    const rl = new GraphRateLimit({ now: () => 1_000_000 });
+    rl.note({ remaining: 50, resetAt: 2_000_000 });
+    expect(rl.snapshot().pausedUntil).toBe(2_000_000);
+  });
+
+  it("marks blocked when now() < pausedUntil", () => {
+    const rl = new GraphRateLimit({ now: () => 1_000_000 });
+    rl.note({ remaining: 50, resetAt: 2_000_000 });
+    expect(rl.blocked()).toBe(true);
+  });
+
+  it("is NOT blocked when now() >= pausedUntil (time has passed)", () => {
+    const t = 2_000_001;
+    const rl = new GraphRateLimit({ now: () => t });
+    rl.note({ remaining: 50, resetAt: 2_000_000 });
+    expect(rl.blocked()).toBe(false);
+  });
+
+  it("takes max of existing pausedUntil and new resetAt (does not shorten)", () => {
+    const rl = new GraphRateLimit({ now: () => 0 });
+    // First error puts pausedUntil further in the future
+    rl.noteLimitError(120); // 120 s = 120_000 ms → pausedUntil = 120_000
+    expect(rl.snapshot().pausedUntil).toBe(120_000);
+    // note() with a resetAt that is sooner — must NOT shorten
+    rl.note({ remaining: 50, resetAt: 60_000 });
+    expect(rl.snapshot().pausedUntil).toBe(120_000);
+  });
+
+  it("updates pausedUntil when new resetAt is later (extends cooldown)", () => {
+    const rl = new GraphRateLimit({ now: () => 0 });
+    rl.note({ remaining: 50, resetAt: 60_000 });
+    rl.note({ remaining: 50, resetAt: 90_000 });
+    expect(rl.snapshot().pausedUntil).toBe(90_000);
+  });
+});
+
+// ── GraphRateLimit: noteLimitError() ─────────────────────────────────────────
+
+describe("GraphRateLimit — noteLimitError()", () => {
+  it("sets pausedUntil to now + defaultCooldownMs when no retryAfter given", () => {
+    const rl = new GraphRateLimit({ now: () => 1_000_000, defaultCooldownMs: 60_000 });
+    rl.noteLimitError();
+    expect(rl.snapshot().pausedUntil).toBe(1_060_000);
+  });
+
+  it("uses retryAfterSec when supplied", () => {
+    const rl = new GraphRateLimit({ now: () => 0, defaultCooldownMs: 60_000 });
+    rl.noteLimitError(90); // 90 seconds
+    expect(rl.snapshot().pausedUntil).toBe(90_000);
+  });
+
+  it("takes max — does not shorten an existing later pausedUntil", () => {
+    const rl = new GraphRateLimit({ now: () => 0, defaultCooldownMs: 60_000 });
+    rl.noteLimitError(120); // pausedUntil = 120_000
+    rl.noteLimitError(30); // would set 30_000, must not shorten
+    expect(rl.snapshot().pausedUntil).toBe(120_000);
+  });
+
+  it("extends pausedUntil when new value is later", () => {
+    const rl = new GraphRateLimit({ now: () => 0, defaultCooldownMs: 60_000 });
+    rl.noteLimitError(30); // pausedUntil = 30_000
+    rl.noteLimitError(120); // must extend to 120_000
+    expect(rl.snapshot().pausedUntil).toBe(120_000);
+  });
+
+  it("marks blocked after noteLimitError", () => {
+    const rl = new GraphRateLimit({ now: () => 0, defaultCooldownMs: 60_000 });
+    rl.noteLimitError();
+    expect(rl.blocked()).toBe(true);
+  });
+});
+
+// ── GraphRateLimit: snapshot() ────────────────────────────────────────────────
+
+describe("GraphRateLimit — snapshot()", () => {
+  it("reflects blocked=true when inside cooldown window", () => {
+    const rl = new GraphRateLimit({ now: () => 0, defaultCooldownMs: 60_000 });
+    rl.noteLimitError();
+    const snap = rl.snapshot();
+    expect(snap.blocked).toBe(true);
+    expect(snap.pausedUntil).toBe(60_000);
+  });
+
+  it("reflects blocked=false after the window elapses", () => {
+    let t = 0;
+    const rl = new GraphRateLimit({ now: () => t, defaultCooldownMs: 60_000 });
+    rl.noteLimitError();
+    t = 60_001;
+    const snap = rl.snapshot();
+    expect(snap.blocked).toBe(false);
+  });
+});
+
+// ── GraphRateLimit: logging (edge-triggered, no spam) ────────────────────────
+
+describe("GraphRateLimit — logging", () => {
+  let warnSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("logs once when transitioning from unblocked to blocked", () => {
+    const rl = new GraphRateLimit({ now: () => 0, defaultCooldownMs: 60_000 });
+    rl.noteLimitError();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const msg = String(warnSpy.mock.calls[0]?.[0] ?? "");
+    expect(msg).toContain("[rate-limit]");
+  });
+
+  it("does NOT log again on a subsequent blocked call (no per-call spam)", () => {
+    const rl = new GraphRateLimit({ now: () => 0, defaultCooldownMs: 60_000 });
+    rl.noteLimitError(); // transition → should log once
+    warnSpy.mockClear();
+    // Additional writes that don't change the blocked edge
+    rl.noteLimitError(30); // shorter — no-op due to max, no new transition
+    rl.blocked();
+    rl.snapshot();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs once when the block clears (blocked→unblocked edge)", () => {
+    let t = 0;
+    const rl = new GraphRateLimit({ now: () => t, defaultCooldownMs: 60_000 });
+    rl.noteLimitError(); // blocked
+    warnSpy.mockClear();
+    t = 60_001; // past expiry
+    // Trigger a detection path that emits the clear log
+    rl.note({ remaining: 200, resetAt: 999_999 }); // healthy reading → clears
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const msg = String(warnSpy.mock.calls[0]?.[0] ?? "");
+    expect(msg).toContain("[rate-limit]");
+  });
+});
+
+// ── isGraphqlBucketCall() ─────────────────────────────────────────────────────
+
+describe("isGraphqlBucketCall()", () => {
+  // gh api graphql → GraphQL bucket
+  it("returns true for ['api','graphql',...]", () => {
+    expect(isGraphqlBucketCall(["api", "graphql", "-f", "query=..."])).toBe(true);
+  });
+
+  // gh api <rest-path> → REST bucket, must be false
+  it("returns false for ['api','repos/o/r/issues']", () => {
+    expect(isGraphqlBucketCall(["api", "repos/o/r/issues"])).toBe(false);
+  });
+
+  it("returns false for ['api'] with no second arg", () => {
+    expect(isGraphqlBucketCall(["api"])).toBe(false);
+  });
+
+  // gh pr / issue / repo / search → GraphQL-backed
+  it("returns true for ['pr',...]", () => {
+    expect(isGraphqlBucketCall(["pr", "list"])).toBe(true);
+  });
+
+  it("returns true for ['issue',...]", () => {
+    expect(isGraphqlBucketCall(["issue", "list"])).toBe(true);
+  });
+
+  it("returns true for ['repo',...]", () => {
+    expect(isGraphqlBucketCall(["repo", "view"])).toBe(true);
+  });
+
+  it("returns true for ['search',...]", () => {
+    expect(isGraphqlBucketCall(["search", "issues", "..."])).toBe(true);
+  });
+
+  // gh run → REST bucket, must be false
+  it("returns false for ['run',...]", () => {
+    expect(isGraphqlBucketCall(["run", "list"])).toBe(false);
+  });
+
+  it("returns false for unknown subcommand", () => {
+    expect(isGraphqlBucketCall(["release", "list"])).toBe(false);
+  });
+
+  it("returns false for empty args", () => {
+    expect(isGraphqlBucketCall([])).toBe(false);
+  });
+});
+
+// ── isRateLimitError() ────────────────────────────────────────────────────────
+
+describe("isRateLimitError()", () => {
+  it("matches 'rate limit' in err.stderr", () => {
+    expect(isRateLimitError({ stderr: "API rate limit exceeded" })).toBe(true);
+  });
+
+  it("matches 'rate_limited' in err.message", () => {
+    expect(isRateLimitError({ message: "You are rate_limited by secondary quota" })).toBe(true);
+  });
+
+  it("matches 'secondary rate limit'", () => {
+    expect(isRateLimitError({ stderr: "secondary rate limit reached" })).toBe(true);
+  });
+
+  it("matches case-insensitively", () => {
+    expect(isRateLimitError({ stderr: "RATE LIMIT EXCEEDED" })).toBe(true);
+  });
+
+  it("returns false for an unrelated error", () => {
+    expect(isRateLimitError({ stderr: "not found", message: "404" })).toBe(false);
+  });
+
+  it("handles plain string errors via String(err)", () => {
+    expect(isRateLimitError("rate limit exceeded")).toBe(true);
+  });
+
+  it("handles Error objects", () => {
+    expect(isRateLimitError(new Error("rate limit hit"))).toBe(true);
+  });
+
+  it("returns false for non-rate-limit Error", () => {
+    expect(isRateLimitError(new Error("network timeout"))).toBe(false);
+  });
+});
+
+// ── parseRetryAfter() ─────────────────────────────────────────────────────────
+
+describe("parseRetryAfter()", () => {
+  it("parses 'Retry-After: 60'", () => {
+    expect(parseRetryAfter("Retry-After: 60")).toBe(60);
+  });
+
+  it("parses 'retry after 120'", () => {
+    expect(parseRetryAfter("retry after 120")).toBe(120);
+  });
+
+  it("parses 'retry-after:30' (no space after colon)", () => {
+    expect(parseRetryAfter("retry-after:30")).toBe(30);
+  });
+
+  it("parses embedded value in longer text", () => {
+    expect(parseRetryAfter("You are rate limited. Retry-After: 45 seconds")).toBe(45);
+  });
+
+  it("returns undefined when not present", () => {
+    expect(parseRetryAfter("something went wrong")).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(parseRetryAfter("")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #1230.

Reduces steady-state GitHub **GraphQL** call volume (separate 5,000 pts/hr bucket) so high-load operators stop tripping the limit. Implements cut-backs **1, 3, 4, 5** from #1230. The per-repo batching refactor (**item 2**) is deferred to **#1233** (highest regression risk — rewrites the dense `prStatus` path). **Server-only** change; no UI → `[no-feature-entry]`.

## What changed (4 levers)

**1 — `warm()`-gated cadence + idle throttles.** Background sweeps run at full cadence only while `warm() = presence.hasClients() || autonomousWorkInFlight()`; otherwise they throttle/pause:
- Fast sweep pauses when not warm (or rate-limited).
- Full sweep throttles 120s → 300s when not warm (autopilot heartbeat stays coarse-fresh).
- Backlog warm pauses when no dashboard is connected.
- 60s critic sweep throttles to 300s when not warm and skips while rate-limited.
- `autonomousWorkInFlight()` (live merge train / merge-error sessions / any full-auto session) keeps everything warm so **unattended merge trains never stall**.
- `Presence` gains a `connected` set + `hasClients()` + a debounced `onActivate` catch-up so a freshly-connected dashboard refreshes immediately.

**3 — Time-bounded activity-aware fast sweep.** Only fast-poll *transient* open PRs (CI pending / mergeable unknown / `mergeStateStatus` unknown|unstable); stable-green PRs park on the slow sweep. Bounded by `transientMaxMs` (5min) and restamped on a new `headSha`, with the `transientSince` map pruned alongside the cache.

**4 — Trim + slow the backlog query.** Drop `labels(first:10)` from `listBacklogCounts` (classify dependabot/release via author/branch/title); warm cadence 45s → 90s; read-TTL 60s → 120s (invariant: warm < TTL).

**5 — `rateLimit` visibility + GraphQL-scoped backoff.** New `src/forge/rate-limit.ts` singleton: records `rateLimit{remaining,resetAt}` from the counts query, backs off on low-remaining / rate-limit errors, and gates the pollers + critic. Error detection is scoped to the GraphQL bucket (`isGraphqlBucketCall`) so a REST-bucket limit (`gh run`, `gh api <rest>`) never trips it.

## Expected reduction (5 repos / 10 sessions / 12 PRs profile)

| Regime | GraphQL/hr | vs before (~2,920) |
|---|---|---|
| Attended | ~1,520 | ~48% ↓ |
| Truly idle (no client, no autonomous work) | ~180 | ~94% ↓ |
| Unattended **with** autonomous work | deliberately warm | savings from levers 3+4 only |

Attended per-session full-sweep fan-out is intentionally **not** reduced here — that's #1233 (item 2).

## Testing

- `bun run test` (server suite): **5336 pass / 0 fail**. `bun run lint` clean, `bunx tsc --noEmit` clean, `fallow audit` clean.
- New/extended unit tests: `test/rate-limit.test.ts` (backoff + helpers, incl. REST-not-tripping, edge-triggered logging), `test/pr-poller.test.ts` (gating, idle throttle, transient filter + window + map pruning), `test/presence.test.ts` (connect/hasClients/onActivate), `test/backlog-poller.test.ts` (warm gating), `test/backlog.test.ts` (120s TTL), `test/pr-kind.test.ts` (label-less release classification).
- Composition-root wiring in `src/index.ts` (`warm`/`autonomousWorkInFlight`, debounced catch-up, critic throttle) is not unit-tested; verified statically in review (TDZ-safe, hoisted `autonomousWorkInFlight`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)