### PR TITLE
fix(spawn): strip NUL bytes from transient-agent prompt argv (#1235)

### DIFF
--- a/src/transient-agent-argv.ts
+++ b/src/transient-agent-argv.ts
@@ -149,7 +149,14 @@ export function buildTransientAgentArgv(
   argv.push("--allowedTools", ...preset.allowedTools);
   if (opts.model) argv.push("--model", opts.model);
   argv.push("--permission-mode", "dontAsk");
-  argv.push(opts.prompt);
+  // child_process.spawn REJECTS any argv arg containing a NUL ("must be a string without null
+  // bytes") — a hard throw, not a transient failure. The prompt is the ONLY argv slot that carries
+  // untrusted free text (plan / PR diff / issue body / repo rule / recap), and a stray \0 in
+  // agent-written text (e.g. the composite-key idiom `${slug}\0${forkOwner}`) would crash EVERY
+  // transient spawn site (issue #1235). Replace each NUL with its visible 2-char escape `\0` rather
+  // than stripping it, so the surrounding text's meaning survives for the reading agent. NUL is the
+  // only spawn-illegal char; other control chars are legal in argv and left untouched.
+  argv.push(opts.prompt.replaceAll("\0", "\\0"));
 
   return { argv, sessionId };
 }

--- a/test/transient-agent-argv.test.ts
+++ b/test/transient-agent-argv.test.ts
@@ -80,6 +80,36 @@ test("each call mints a fresh session id, echoed into --session-id", () => {
   expect(a.argv[a.argv.indexOf("--session-id") + 1]).toBe(a.sessionId);
 });
 
+// ── NUL sanitization: spawn() rejects a NUL in any argv arg (issue #1235) ────────────────────────
+
+test("every kind: a NUL in the prompt is escaped to `\\0`, leaving NO raw NUL anywhere in argv", () => {
+  for (const kind of ALL_KINDS) {
+    for (const model of [null, "claude-opus-4-8"]) {
+      // A composite-key idiom is the canonical way a stray NUL lands in agent-written text.
+      const { argv } = buildTransientAgentArgv(kind, {
+        model,
+        prompt: "keys by `${slug}\0${forkOwner}` when slug is non-null",
+      });
+      // No argv arg may contain a raw NUL — child_process.spawn would throw on it.
+      for (const arg of argv) expect(arg.includes("\0")).toBe(false);
+      // The trailing positional carries the visible 2-char escape where the NUL was.
+      expect(argv[argv.length - 1]).toBe("keys by `${slug}\\0${forkOwner}` when slug is non-null");
+    }
+  }
+});
+
+test("multiple NULs are each escaped", () => {
+  const { argv } = buildTransientAgentArgv("reviewer", { model: null, prompt: "a\0b\0c" });
+  expect(argv[argv.length - 1]).toBe("a\\0b\\0c");
+  for (const arg of argv) expect(arg.includes("\0")).toBe(false);
+});
+
+test("NUL-free prompts pass through byte-for-byte unchanged (no spurious escaping)", () => {
+  const prompt = "review the plan; key is `${slug}\\0${fork}` (already a literal escape)";
+  const { argv } = buildTransientAgentArgv("reviewer", { model: null, prompt });
+  expect(argv[argv.length - 1]).toBe(prompt);
+});
+
 // ── MCP-isolation coupling: ONE field drives BOTH flags, for every kind ─────────────────────────
 
 test("coupling: --safe-mode ⇔ enableAllProjectMcpServers, for every kind", () => {


### PR DESCRIPTION
## Problem

`child_process.spawn` rejects any argv argument containing a NUL byte (`\0`). `buildTransientAgentArgv` (`src/transient-agent-argv.ts`) pushes the prompt verbatim as the trailing argv positional, so a single stray `\0` in agent-written text threw at the `herdr.start` call, returned a misleading `"error"` ("Couldn't start the plan review. Try again."), and stranded the session forever — every retry failed identically because the NUL was durably persisted.

Observed on a real session (`batch-pr-polling`, #1233, TASK-1037) stuck at `REWORK · 1/5` after the planning agent wrote `${slug}` + NUL + `${forkOwner}` into `.shepherd-plan.md`.

Fixes #1235.

## Fix

Sanitize the prompt inside the single shared builder `buildTransientAgentArgv`, immediately before assembling argv: replace each NUL with its visible 2-char escape `\0`. The prompt is the **only** argv slot that carries untrusted free text (the `--settings` JSON is NUL-safe — `JSON.stringify` escapes a NUL to the six ASCII chars backslash-u-0-0-0-0 — and the model/flags/session-id are controlled), so one change closes the crash at **all ~11 transient-agent spawn sites** (defense-in-depth): plan reviewer, PR critic, standalone critic, recap, namer, distiller, doc-agent, merge-suggest, optimizer, herd-digest, autopilot-llm, verify-key.

- **NUL only.** NUL is the single character `spawn()` actually rejects; other C0 control chars are legal in argv and are left untouched.
- **Visible escape, not strip.** Replacing with `\0` keeps the surrounding text legible to the reading agent (e.g. composite-key idioms) instead of silently fusing the two sides. Matches the operational unstick already applied to TASK-1037.

## Tests

`test/transient-agent-argv.test.ts`:
- For every kind (× model present/absent): a NUL-bearing prompt yields **no raw NUL anywhere in argv** and a literal `\0` in the trailing positional.
- Multiple NULs each escaped.
- NUL-free prompts pass through **byte-for-byte unchanged** (guards the existing byte-identity regression gate).

`bun run lint` and `bun run test` (5347 pass / 0 fail) green.

## Deferred follow-up

The issue's *secondary* suggestion — distinguishing an unrecoverable-input spawn failure from a transient one so the UI stops telling the operator to "Try again" on a guaranteed-to-fail retry — is intentionally **out of scope** here. It touches the shared `PlanReviewTrigger` return type + the `PlanPanel` toast + i18n, and with NUL now sanitized the reported crash can no longer recur. Worth a separate change if the team wants `begin()` to surface unrecoverable conditions distinctly.

[no-feature-entry] — server-only plumbing fix, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
