### PR TITLE
feat(steers): right-click a steer chip to run or edit it

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2107,5 +2107,10 @@
   "codexupdate_all_notes_link": "Alle Release-Notes ansehen",
   "settings_codex_update_label": "Codex-Update verfügbar",
   "feat_codex_update_title": "Codex-CLI-Update-Check",
-  "feat_codex_update_body": "Shepherd prüft jetzt npm auf eine neuere @openai/codex und zeigt ein Badge, sobald eine erscheint — wie das herdr-Badge. Ein Klick führt das Update aus; laufende codex-Panes werden nicht unterbrochen."
+  "feat_codex_update_body": "Shepherd prüft jetzt npm auf eine neuere @openai/codex und zeigt ein Badge, sobald eine erscheint — wie das herdr-Badge. Ein Klick führt das Update aus; laufende codex-Panes werden nicht unterbrochen.",
+  "steermenu_label": "Aktionen für Steer: {label}",
+  "steermenu_run": "Ausführen",
+  "steermenu_edit": "Bearbeiten",
+  "feat_steer_context_menu_title": "Rechtsklick auf einen Steer zum Bearbeiten oder Ausführen",
+  "feat_steer_context_menu_body": "Rechtsklick auf einen Steer-Chip in der Leiste öffnet ein kleines Menü: ausführen (wie ein Antippen) oder direkt in den Editor springen, fokussiert auf diesen Steer."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2107,5 +2107,10 @@
   "codexupdate_all_notes_link": "View all release notes",
   "settings_codex_update_label": "Codex update available",
   "feat_codex_update_title": "Codex CLI update check",
-  "feat_codex_update_body": "Shepherd now watches npm for a newer @openai/codex and shows a badge when one ships — like the herdr badge. One click runs the update; running codex panes are not interrupted."
+  "feat_codex_update_body": "Shepherd now watches npm for a newer @openai/codex and shows a badge when one ships — like the herdr badge. One click runs the update; running codex panes are not interrupted.",
+  "steermenu_label": "Actions for steer: {label}",
+  "steermenu_run": "Run",
+  "steermenu_edit": "Edit",
+  "feat_steer_context_menu_title": "Right-click a steer to edit or run it",
+  "feat_steer_context_menu_body": "Right-click a steer chip in the bar to open a small menu: run it (the same as a tap) or jump straight into the editor focused on that steer."
 }

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -87,6 +87,7 @@
     initialDiagnostics = null,
     plugins = [],
     focusPluginId = null,
+    focusSteerId = null,
   }: {
     onclose?: () => void;
     onsaved?: (root: string) => void;
@@ -102,6 +103,8 @@
     plugins?: PluginInfo[];
     /** Plugin id to scroll into view + highlight on open (from gear-item panel action). */
     focusPluginId?: string | null;
+    /** Steer id to expand + focus in the steers editor on open (from a chip's right-click). */
+    focusSteerId?: string | null;
   } = $props();
 
   // initialTab seeds the starting tab; the user then freely switches it, so we
@@ -121,7 +124,9 @@
   );
 
   onMount(() => {
-    if (initialTab === "session") {
+    // Skip the scroll-to-top when a specific steer is targeted — SteersEditor scrolls
+    // that row into view itself, and a competing top-scroll would fight it.
+    if (initialTab === "session" && !focusSteerId) {
       requestAnimationFrame(() => steersEl?.scrollIntoView({ behavior: "auto", block: "start" }));
     }
     if (typeof matchMedia === "undefined") return;
@@ -1050,7 +1055,7 @@
           >
         </button>
       </div>
-      <div bind:this={steersEl}><SteersEditor /></div>
+      <div bind:this={steersEl}><SteersEditor {focusSteerId} /></div>
     </div>
 
     <div

--- a/ui/src/lib/components/SteerBar.browser.test.ts
+++ b/ui/src/lib/components/SteerBar.browser.test.ts
@@ -13,6 +13,7 @@ vi.mock("$lib/api", async (importOriginal) => {
 
 const { default: SteerBar } = await import("./SteerBar.svelte");
 const { steers } = await import("$lib/steers.svelte");
+const api = await import("$lib/api");
 
 const LABELS_KEY = "shepherd:steer-labels";
 const COACH_KEY = "shepherd:steer-coach-seen";
@@ -216,5 +217,69 @@ describe("SteerBar edit-steers button", () => {
     const abc = document.querySelector(".lbl-toggle") as HTMLElement;
     expect(getComputedStyle(editBtn).display, "edit hidden on mobile").toBe("none");
     expect(getComputedStyle(abc).display, "ABC revealed by mobile rule").not.toBe("none");
+  });
+});
+
+describe("SteerBar steer context menu", () => {
+  beforeEach(() => {
+    vi.mocked(api.replySession).mockClear();
+  });
+
+  // The steer chip carries an emoji, so `.chip.has-emoji` uniquely targets it
+  // (the leading broadcast chip is `.chip.bc`).
+  const steerChip = () => document.querySelector(".steer-bar .chip.has-emoji") as HTMLElement;
+
+  it("right-clicking a chip opens a menu with Run and Edit, and does not send", async () => {
+    render(SteerBar, { focusedId: "s1", onbroadcast: () => {} });
+    await tick();
+
+    steerChip().dispatchEvent(
+      new MouseEvent("contextmenu", { button: 2, clientX: 40, clientY: 40, bubbles: true }),
+    );
+    await tick();
+
+    const menu = document.querySelector(".steer-menu") as HTMLElement;
+    expect(menu, "context menu opened").not.toBeNull();
+    const items = menu.querySelectorAll(".sm-item");
+    expect(items.length).toBe(2);
+    expect(menu.getAttribute("role")).toBe("menu");
+    // The right-click itself must never fire the steer (the menu is the deliberate path).
+    expect(api.replySession).not.toHaveBeenCalled();
+  });
+
+  it("Run sends the steer to the focused session", async () => {
+    render(SteerBar, { focusedId: "s1", onbroadcast: () => {} });
+    await tick();
+
+    steerChip().dispatchEvent(
+      new MouseEvent("contextmenu", { button: 2, clientX: 40, clientY: 40, bubbles: true }),
+    );
+    await tick();
+
+    const runItem = document.querySelectorAll(".steer-menu .sm-item")[0] as HTMLElement;
+    runItem.click();
+    await tick();
+
+    expect(api.replySession).toHaveBeenCalledWith("s1", "ship it");
+    expect(document.querySelector(".steer-menu"), "menu closes after Run").toBeNull();
+  });
+
+  it("Edit fires onedit with the steer id and does not send", async () => {
+    const onedit = vi.fn();
+    render(SteerBar, { focusedId: "s1", onbroadcast: () => {}, onedit });
+    await tick();
+
+    steerChip().dispatchEvent(
+      new MouseEvent("contextmenu", { button: 2, clientX: 40, clientY: 40, bubbles: true }),
+    );
+    await tick();
+
+    const editItem = document.querySelectorAll(".steer-menu .sm-item")[1] as HTMLElement;
+    editItem.click();
+    await tick();
+
+    expect(onedit).toHaveBeenCalledWith("1");
+    expect(api.replySession).not.toHaveBeenCalled();
+    expect(document.querySelector(".steer-menu"), "menu closes after Edit").toBeNull();
   });
 });

--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -4,6 +4,8 @@
   import { toasts } from "$lib/toasts.svelte";
   import { fitLabels } from "$lib/fit-labels";
   import { m } from "$lib/paraglide/messages";
+  import SteerMenu from "$lib/components/SteerMenu.svelte";
+  import type { Steer } from "$lib/types";
 
   let {
     focusedId,
@@ -18,7 +20,7 @@
     onretry?: () => void;
     retryHaltedCount?: number;
     retryReady?: boolean;
-    onedit?: () => void;
+    onedit?: (steerId?: string) => void;
   } = $props();
 
   // Only steer-bar-scoped entries render here; issue-scoped ones live on backlog rows.
@@ -83,6 +85,9 @@
   let startY = 0;
 
   function down(e: PointerEvent) {
+    // Only a primary (left / touch / pen) press arms a tap. A secondary press is a
+    // right-click — the contextmenu handler owns it, so it must not also fire send().
+    if (e.button !== 0) return;
     armedId = e.pointerId;
     startX = e.clientX;
     startY = e.clientY;
@@ -119,6 +124,15 @@
         action: { label: m.common_retry(), run: () => send(text) },
       });
     });
+  }
+
+  // Right-click a chip → a small anchored menu offering the two things you might
+  // want with a steer: run it (same as a tap) or jump into the editor focused on it.
+  // A plain left tap keeps firing send() directly — the menu is the deliberate path.
+  let menu = $state<{ steer: Steer; x: number; y: number; opener: HTMLElement } | null>(null);
+  function openMenu(e: MouseEvent, s: Steer) {
+    e.preventDefault();
+    menu = { steer: s, x: e.clientX, y: e.clientY, opener: e.currentTarget as HTMLElement };
   }
 </script>
 
@@ -182,6 +196,7 @@
         class:has-emoji={!!s.emoji}
         title={s.text}
         aria-label={m.steerbar_send_aria({ label: s.label })}
+        oncontextmenu={(e) => openMenu(e, s)}
         onpointerdown={down}
         onpointermove={move}
         onpointercancel={cancel}
@@ -229,6 +244,26 @@
     onpointerup={(e) => tap(e, () => onedit?.())}>✎</button
   >
 </div>
+
+{#if menu}
+  <SteerMenu
+    x={menu.x}
+    y={menu.y}
+    label={menu.steer.label}
+    opener={menu.opener}
+    onrun={() => {
+      const text = menu?.steer.text;
+      menu = null;
+      if (text) send(text);
+    }}
+    onedit={() => {
+      const id = menu?.steer.id;
+      menu = null;
+      onedit?.(id);
+    }}
+    onclose={() => (menu = null)}
+  />
+{/if}
 
 <style>
   /* Row = scrolling chip bar (flex:1) + a right-hand slot holding exactly one of two

--- a/ui/src/lib/components/SteerMenu.svelte
+++ b/ui/src/lib/components/SteerMenu.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+
+  // Small anchored, non-blocking context menu for a steer chip (right-click on
+  // desktop). Per the design system's popover rule it gets NO scrim/blur — it
+  // dismisses on outside-click, Esc or scroll instead. The bar owns its open/close
+  // state; this component only positions + renders the two actions. Modelled on
+  // CardMenu, trimmed to the steer's two choices: run it, or edit it.
+  let {
+    x,
+    y,
+    label,
+    opener,
+    onrun,
+    onedit,
+    onclose,
+  }: {
+    // viewport coordinates of the right-click that opened the menu
+    x: number;
+    y: number;
+    // the steer's label, woven into the menu's accessible name
+    label: string;
+    // the chip that opened the menu — focus returns here on close
+    opener?: HTMLElement;
+    onrun: () => void;
+    onedit: () => void;
+    onclose: () => void;
+  } = $props();
+
+  let el = $state<HTMLDivElement>();
+
+  // Clamp the menu inside the viewport so it never spills off the bottom/right edge
+  // when opened near them (the steer bar lives at the bottom, so the menu usually
+  // opens upward from the clamp). Measured after mount; until then the template
+  // falls back to the raw pointer position (x/y).
+  let pos = $state<{ left: number; top: number } | null>(null);
+  $effect(() => {
+    const node = el;
+    if (!node) return;
+    const r = node.getBoundingClientRect();
+    const margin = 8;
+    const left = Math.min(x, window.innerWidth - r.width - margin);
+    const top = Math.min(y, window.innerHeight - r.height - margin);
+    pos = { left: Math.max(margin, left), top: Math.max(margin, top) };
+    items()[0]?.focus(); // open with the first item focused, per the menu pattern
+  });
+
+  function items(): HTMLButtonElement[] {
+    return el ? Array.from(el.querySelectorAll<HTMLButtonElement>(".sm-item")) : [];
+  }
+  // Arrow / Home / End roving focus, as a role="menu" is expected to support. Tab is
+  // trapped (cycled like the arrows) so focus can't escape the open menu — the only
+  // ways out are Esc, an action, or an outside click, all of which close it.
+  function onNav(e: KeyboardEvent) {
+    const list = items();
+    if (list.length === 0) return;
+    const i = list.indexOf(document.activeElement as HTMLButtonElement);
+    const fwd = (i + 1) % list.length;
+    const back = (i - 1 + list.length) % list.length;
+    let next: number;
+    if (e.key === "ArrowDown") next = fwd;
+    else if (e.key === "ArrowUp") next = back;
+    else if (e.key === "Home") next = 0;
+    else if (e.key === "End") next = list.length - 1;
+    else if (e.key === "Tab") next = e.shiftKey ? back : fwd;
+    else return;
+    e.preventDefault();
+    list[next]!.focus();
+  }
+
+  $effect(() => {
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key === "Escape") onclose();
+    }
+    function onPointer(e: Event) {
+      if (el && !el.contains(e.target as Node)) onclose();
+    }
+    window.addEventListener("keydown", onKeydown);
+    // capture so we beat the chip's own handlers; scroll dismisses (the anchor moves)
+    window.addEventListener("pointerdown", onPointer, true);
+    window.addEventListener("scroll", onclose, true);
+    return () => {
+      window.removeEventListener("keydown", onKeydown);
+      window.removeEventListener("pointerdown", onPointer, true);
+      window.removeEventListener("scroll", onclose, true);
+      // Every close path unmounts the menu, so returning focus to the opener here
+      // covers them all. Deferred to a microtask so the browser has applied any
+      // click-driven focus first, then only restore when focus actually fell to
+      // <body> — an action that moved focus elsewhere (e.g. into the editor) keeps it.
+      const target = opener;
+      queueMicrotask(() => {
+        if (target?.isConnected && document.activeElement === document.body) target.focus();
+      });
+    };
+  });
+</script>
+
+<div
+  bind:this={el}
+  class="steer-menu"
+  role="menu"
+  tabindex="-1"
+  aria-label={m.steermenu_label({ label })}
+  style="left:{pos?.left ?? x}px;top:{pos?.top ?? y}px"
+  onkeydown={onNav}
+>
+  <button class="sm-item" type="button" role="menuitem" tabindex="-1" onclick={onrun}>
+    <span class="sm-icon" aria-hidden="true">▷</span>{m.steermenu_run()}
+  </button>
+  <button class="sm-item" type="button" role="menuitem" tabindex="-1" onclick={onedit}>
+    <span class="sm-icon" aria-hidden="true">✎</span>{m.steermenu_edit()}
+  </button>
+</div>
+
+<style>
+  .steer-menu {
+    position: fixed;
+    z-index: 60;
+    min-width: 160px;
+    max-width: calc(100vw - 16px);
+    padding: 4px;
+    background: var(--color-panel);
+    border: 1px solid var(--color-line-bright);
+    border-radius: 3px;
+    /* established popover shadow (matches CardMenu/AutomationPanel) — no token exists */
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+  .steer-menu:focus {
+    outline: none;
+  }
+  .sm-item {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    width: 100%;
+    padding: 8px 11px;
+    border: 0;
+    border-radius: 2px;
+    background: transparent;
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: var(--fs-base);
+    text-align: left;
+    cursor: pointer;
+  }
+  .sm-item:hover,
+  .sm-item:focus-visible {
+    background: var(--color-hover);
+    outline: none;
+  }
+  .sm-icon {
+    font-size: var(--fs-meta);
+    width: 1em;
+    text-align: center;
+    flex-shrink: 0;
+  }
+</style>

--- a/ui/src/lib/components/SteersEditor.browser.test.ts
+++ b/ui/src/lib/components/SteersEditor.browser.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { tick } from "svelte";
+import "../../app.css";
+import type { Steer } from "$lib/types";
+
+// Stub the api so mount never hits the network: getCommands feeds the slash menu,
+// and getSteers is skipped because we pre-mark the store loaded.
+vi.mock("$lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/api")>();
+  return {
+    ...actual,
+    getCommands: vi.fn(async () => ({ commands: [] })),
+    putSteers: vi.fn(async (s: Steer[]) => s),
+  };
+});
+
+const { default: SteersEditor } = await import("./SteersEditor.svelte");
+const { steers } = await import("$lib/steers.svelte");
+
+const steer = (p: Partial<Steer>): Steer => ({
+  id: "1",
+  label: "Ship",
+  text: "ship it",
+  inSteerBar: true,
+  onIssues: false,
+  ...p,
+});
+
+beforeEach(() => {
+  steers.list = [
+    steer({ id: "a", label: "Alpha", text: "do alpha" }),
+    steer({ id: "b", label: "Bravo", text: "do bravo" }),
+  ];
+  steers.loaded = true; // skip the network load on mount
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+// rAF settle helper — SteersEditor focuses the targeted row on the next frame.
+const frames = (n = 2) =>
+  new Promise<void>((r) => {
+    let i = 0;
+    const step = () => (++i >= n ? r() : requestAnimationFrame(step));
+    requestAnimationFrame(step);
+  });
+
+describe("SteersEditor focusSteerId", () => {
+  it("expands and focuses the targeted steer's row", async () => {
+    render(SteersEditor, { focusSteerId: "b" });
+    await tick();
+    await frames();
+
+    const row = document.querySelector('.srow[data-steer-id="b"]') as HTMLElement;
+    expect(row, "targeted row rendered").not.toBeNull();
+    expect(row.classList.contains("editing"), "targeted row expanded").toBe(true);
+    const ta = row.querySelector("textarea.text") as HTMLTextAreaElement;
+    expect(document.activeElement, "targeted prompt field focused").toBe(ta);
+
+    // The other row stays collapsed.
+    const other = document.querySelector('.srow[data-steer-id="a"]') as HTMLElement;
+    expect(other.classList.contains("editing")).toBe(false);
+  });
+
+  it("leaves every row collapsed when no steer is targeted", async () => {
+    render(SteersEditor, {});
+    await tick();
+    await frames();
+
+    const editing = document.querySelectorAll(".srow.editing");
+    expect(editing.length).toBe(0);
+  });
+});

--- a/ui/src/lib/components/SteersEditor.svelte
+++ b/ui/src/lib/components/SteersEditor.svelte
@@ -11,8 +11,13 @@
   import type { Steer, SlashCommand } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
 
+  // Steer to expand + focus on open (from a steer chip's right-click → "Edit"). The
+  // editor lists every steer; this jumps straight to the one the operator picked.
+  let { focusSteerId = null }: { focusSteerId?: string | null } = $props();
+
   const flipDurationMs = 150;
 
+  let rootEl = $state<HTMLDivElement | null>(null);
   let draft = $state<Steer[]>([]);
   let saving = $state(false);
   let error = $state<string | null>(null);
@@ -53,6 +58,18 @@
     getCommands("")
       .then((r) => (allCommands = r.commands))
       .catch(() => (allCommands = []));
+    // Targeted edit: scroll the chosen steer's row into view and focus its prompt
+    // field. Focusing fires onTextFocus, which expands the row (editingId) and
+    // autogrows the field — so the operator lands directly in the steer they picked.
+    if (focusSteerId && draft.some((s) => s.id === focusSteerId)) {
+      requestAnimationFrame(() => {
+        const ta = rootEl?.querySelector<HTMLTextAreaElement>(
+          `.srow[data-steer-id="${CSS.escape(focusSteerId!)}"] textarea.text`,
+        );
+        ta?.scrollIntoView({ block: "center" });
+        ta?.focus();
+      });
+    }
   });
 
   // Grow the focused prompt field to fit its content; at rest it collapses back to
@@ -199,7 +216,7 @@
   }
 </script>
 
-<div class="editor">
+<div class="editor" bind:this={rootEl}>
   <span class="micro">{m.steerseditor_title()}</span>
   <p class="hint">{m.steerseditor_hint()}</p>
   <div
@@ -213,6 +230,7 @@
       <div
         class="srow"
         class:editing={editingId === s.id}
+        data-steer-id={s.id}
         animate:flip={{ duration: flipDurationMs }}
       >
         <span

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -113,7 +113,7 @@
     onretry?: () => void;
     retryHaltedCount?: number;
     retryReady?: boolean;
-    onedit?: () => void;
+    onedit?: (steerId?: string) => void;
     mobile?: boolean;
     touch?: boolean;
     // ordered ids of sessions currently waiting on the operator ("needs you"),
@@ -2184,7 +2184,7 @@
       onretry={() => onretry?.()}
       {retryHaltedCount}
       {retryReady}
-      onedit={() => onedit?.()}
+      onedit={(id) => onedit?.(id)}
     />
   {/if}
 

--- a/ui/src/lib/components/page/AppOverlays.svelte
+++ b/ui/src/lib/components/page/AppOverlays.svelte
@@ -123,6 +123,7 @@
     showSettings,
     settingsTab,
     focusPluginId = null,
+    focusSteerId = null,
     onsettingsclose,
     onsettingsherdrupdate,
     onsettingscodexupdate,
@@ -221,6 +222,7 @@
     showSettings: boolean;
     settingsTab: "workspace" | "session" | "device" | "diagnose" | "plugins";
     focusPluginId?: string | null;
+    focusSteerId?: string | null;
     onsettingsclose: () => void;
     onsettingsherdrupdate: () => void;
     onsettingscodexupdate: () => void;
@@ -443,6 +445,7 @@
     initialDiagnostics={store.diagnostics?.checks ?? null}
     plugins={store.plugins}
     {focusPluginId}
+    {focusSteerId}
     onclose={onsettingsclose}
     herdrUpdate={store.herdrUpdate}
     onherdrupdate={onsettingsherdrupdate}

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1801,4 +1801,15 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_codex_update_title",
     bodyKey: "feat_codex_update_body",
   },
+  {
+    // Right-clicking a steer chip now opens a small context menu offering Run (the
+    // same as a tap) or Edit (jumps into the steers editor focused on that steer).
+    // No targetId — the steer bar only mounts on a focused session's terminal tab,
+    // so there's no always-present anchor; surface via the What's-New drawer only.
+    // 1.38.0 is the latest released tag, so this ships in 1.39.0.
+    id: "steer-context-menu",
+    sinceVersion: "1.39.0",
+    titleKey: "feat_steer_context_menu_title",
+    bodyKey: "feat_steer_context_menu_body",
+  },
 ];

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -173,6 +173,9 @@
     "workspace",
   );
   let focusPluginId = $state<string | null>(null);
+  // Steer id to expand + focus in the steers editor when Settings opens (set from the
+  // steer chip's right-click → "Edit" action; null when the editor is opened plainly).
+  let focusSteerId = $state<string | null>(null);
   let showClone = $state(false);
   let showFork = $state(false);
   let showNewProject = $state(false);
@@ -526,6 +529,15 @@
       usageHoldPct,
   );
   const retryReady = $derived(haltedCount > 0 && usageBelow);
+
+  // Open Settings on the steers editor. An optional steer id (from a steer chip's
+  // right-click → "Edit") expands + focuses that row; omitted for the plain pencil.
+  // Defined here, not inline, so the nullish branch stays out of the route template.
+  function openSteersEditor(id?: string) {
+    settingsTab = "session";
+    focusSteerId = id ?? null;
+    showSettings = true;
+  }
 
   function loadSettings() {
     getSettings()
@@ -2156,10 +2168,7 @@
             onretry={() => (showRetry = true)}
             retryHaltedCount={haltedCount}
             {retryReady}
-            onedit={() => {
-              settingsTab = "session";
-              showSettings = true;
-            }}
+            onedit={openSteersEditor}
             drain={store.drain[selected.repoPath] ?? null}
             subagents={store.subagents}
           />
@@ -2308,10 +2317,7 @@
             onretry={() => (showRetry = true)}
             retryHaltedCount={haltedCount}
             {retryReady}
-            onedit={() => {
-              settingsTab = "session";
-              showSettings = true;
-            }}
+            onedit={openSteersEditor}
             drain={store.drain[selected.repoPath] ?? null}
             subagents={store.subagents}
           />
@@ -2444,9 +2450,11 @@
   {showSettings}
   {settingsTab}
   {focusPluginId}
+  {focusSteerId}
   onsettingsclose={() => {
     showSettings = false;
     focusPluginId = null;
+    focusSteerId = null;
     loadSettings();
   }}
   onsettingsherdrupdate={() => {


### PR DESCRIPTION
## Was

Rechtsklick auf einen Steer-Chip in der Steer-Leiste öffnet jetzt ein kleines Kontextmenü mit zwei Aktionen:

- **Ausführen** — sendet den Steer an die fokussierte Session (wie ein normaler Tap)
- **Bearbeiten** — öffnet den Steers-Editor, gescrollt zu und fokussiert auf genau diesen Steer

Ein normaler Linksklick/Tap feuert den Steer weiterhin direkt — das Menü ist der bewusste Pfad, wenn man wählen will.

## Wie

- Neue Komponente `SteerMenu.svelte` — kleines, verankertes, nicht-blockierendes Popover (modelliert nach `CardMenu`: kein Scrim/Blur, schließt bei Esc / Außen-Klick / Scroll; `role="menu"` mit Pfeil-/Tab-Navigation). Folgt der Design-System-Regel für anchored non-blocking popovers.
- `SteerBar`: `oncontextmenu` auf den Steer-Chips öffnet das Menü an der Klick-Position. Die Tap-Erkennung (`down`) ignoriert jetzt nicht-primäre Buttons, damit ein Rechtsklick niemals zusätzlich `send()` auslöst.
- Die gewählte Steer-ID läuft durch `onedit` → `Viewport` → `+page` → `Settings` → `SteersEditor` (spiegelt das bestehende `focusPluginId`-Muster). `SteersEditor` expandiert + fokussiert die Zeile des Ziel-Steers beim Öffnen.
- EN/DE-Keys `steermenu_*`, Eintrag im Feature-Katalog (`steer-context-menu`, 1.39.0).

## Hinweis

Reines Desktop-Feature (Rechtsklick) — Touch-Nutzer tippen weiterhin zum Ausführen und nutzen den Stift-Button zum Bearbeiten. Keine Änderung am vorhandenen Tap-/Drag-Verhalten der Leiste.

## Tests

- `SteerBar.browser.test.ts`: Rechtsklick öffnet Menü (Run + Edit), Run sendet, Edit feuert `onedit` mit Steer-ID, Rechtsklick sendet nicht.
- `SteersEditor.browser.test.ts` (neu): `focusSteerId` expandiert + fokussiert die richtige Zeile; ohne Ziel bleibt alles eingeklappt.
- `bun run check` (0 errors), `check:i18n` (Parität), `check-glossary`, `check-feature-catalog`, fallow audit — alle grün.
