### PR TITLE
feat(usage): codex rate-limit gauges in usage popover like claude

### DIFF
--- a/src/codex-usage.ts
+++ b/src/codex-usage.ts
@@ -1,18 +1,38 @@
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
-import type { UsageProviderSnapshot, UsageProviderSource } from "./usage-limits";
+import type { LimitWindow, UsageProviderSnapshot, UsageProviderSource } from "./usage-limits";
 
 const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 const STALE_MS = 24 * 60 * 60 * 1000;
+/** How many recent OpenAI rollouts to scan for the latest rate-limit event. The most recently
+ *  touched session almost always carries it; a small fan-out covers a freshly-started session
+ *  whose first turn hasn't logged a rate-limit event yet (the limit is account-global, so an
+ *  older session's last reading is still current). */
+const ROLLOUT_SCAN_LIMIT = 8;
 
 interface CodexUsageRow {
   totalTokens: number | null;
   session5hTokens: number | null;
   weekTokens: number | null;
   updatedAt: number | null;
+}
+
+/** Tokens summary + recent rollout paths, read from one Codex state DB open. */
+interface CodexState {
+  totalTokens: number;
+  session5hTokens: number;
+  weekTokens: number;
+  updatedAt: number;
+  rolloutPaths: string[];
+}
+
+/** The 5h + weekly rate-limit windows parsed out of a Codex rollout log. */
+export interface CodexRateLimits {
+  session5h: LimitWindow | null;
+  week: LimitWindow | null;
 }
 
 function codexHome(): string {
@@ -37,7 +57,8 @@ export function latestCodexStateDb(home = codexHome()): string | null {
   return candidates[0] ? join(home, candidates[0].name) : null;
 }
 
-export function readCodexTokenUsage(dbPath: string, now: number): UsageProviderSnapshot | null {
+/** Read the token summary + recent rollout paths from a Codex state DB (single open). */
+function readCodexState(dbPath: string, now: number): CodexState | null {
   if (!existsSync(dbPath)) return null;
   let db: Database | null = null;
   try {
@@ -56,14 +77,29 @@ export function readCodexTokenUsage(dbPath: string, now: number): UsageProviderS
       )
       .get(now - FIVE_HOURS_MS, now - WEEK_MS);
     if (!row || row.updatedAt === null) return null;
+    // Defensive: older Codex schemas (and the unit-test fixtures) lack `rollout_path`. A failure
+    // here must not sink the token reading, so the rollout query has its own guard.
+    let rolloutPaths: string[] = [];
+    try {
+      rolloutPaths = db
+        .query<{ rollout_path: string }, [number]>(
+          `
+          SELECT rollout_path FROM threads
+          WHERE model_provider = 'openai' AND rollout_path <> ''
+          ORDER BY updated_at_ms DESC LIMIT ?
+        `,
+        )
+        .all(ROLLOUT_SCAN_LIMIT)
+        .map((r) => r.rollout_path);
+    } catch {
+      rolloutPaths = [];
+    }
     return {
-      provider: "codex",
-      kind: "tokens",
       totalTokens: row.totalTokens ?? 0,
       session5hTokens: row.session5hTokens ?? 0,
       weekTokens: row.weekTokens ?? 0,
       updatedAt: row.updatedAt,
-      stale: now - row.updatedAt > STALE_MS,
+      rolloutPaths,
     };
   } catch {
     return null;
@@ -72,11 +108,126 @@ export function readCodexTokenUsage(dbPath: string, now: number): UsageProviderS
   }
 }
 
+/** Build the base (rate-limit-free) Codex token snapshot. */
+function tokenSnapshot(st: CodexState, now: number): UsageProviderSnapshot {
+  return {
+    provider: "codex",
+    kind: "tokens",
+    totalTokens: st.totalTokens,
+    session5hTokens: st.session5hTokens,
+    weekTokens: st.weekTokens,
+    updatedAt: st.updatedAt,
+    stale: now - st.updatedAt > STALE_MS,
+    session5h: null,
+    week: null,
+  };
+}
+
+export function readCodexTokenUsage(dbPath: string, now: number): UsageProviderSnapshot | null {
+  const st = readCodexState(dbPath, now);
+  return st ? tokenSnapshot(st, now) : null;
+}
+
+/** One rollout's `rate_limits.primary`/`.secondary` shape (Codex CLI session log). */
+interface RolloutLimitWindow {
+  used_percent?: number;
+  window_minutes?: number;
+  resets_at?: number; // epoch SECONDS
+}
+
+function toLimitWindow(w: RolloutLimitWindow | null | undefined, now: number): LimitWindow | null {
+  if (!w || typeof w.used_percent !== "number") return null;
+  // resets_at is epoch seconds; fall back to now + window when absent so a bar still has a reset.
+  const resetAt =
+    typeof w.resets_at === "number"
+      ? w.resets_at * 1000
+      : now + (typeof w.window_minutes === "number" ? w.window_minutes * 60_000 : 0);
+  return { pct: Math.max(0, Math.min(100, Math.round(w.used_percent))), resetAt };
+}
+
+/**
+ * Extract the most recent rate-limit windows from one rollout JSONL file's content. Codex appends a
+ * `{type:"event_msg", payload:{type:"token_count", rate_limits:{primary,secondary}}}` line on each
+ * turn; `primary` is the 5h window, `secondary` the weekly. The last such line is the current state.
+ *
+ * This is a line-based scan, which assumes the JSONL invariant of one complete JSON object per line
+ * (Codex writes exactly that) — a pretty-printed, multi-line object would not parse. The pre-filter
+ * matches only the `"rate_limits"` key (not `"rate_limits":{`) so whitespace after the colon is
+ * tolerated; a `"rate_limits":null` line passes the filter but is dropped by the null check below.
+ */
+export function parseCodexRateLimits(content: string, now: number): CodexRateLimits | null {
+  const lines = content.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    // Cheap pre-filter: skip the vast majority of lines that carry no rate-limit reading at all.
+    if (!line || !line.includes('"rate_limits"')) continue;
+    let obj: {
+      payload?: { rate_limits?: { primary?: RolloutLimitWindow; secondary?: RolloutLimitWindow } };
+    };
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const rl = obj?.payload?.rate_limits;
+    if (!rl) continue;
+    const session5h = toLimitWindow(rl.primary, now);
+    const week = toLimitWindow(rl.secondary, now);
+    if (!session5h && !week) continue;
+    return { session5h, week };
+  }
+  return null;
+}
+
+/** Read the freshest rate-limit windows from the given rollout paths (newest first). */
+export function readCodexRateLimits(paths: string[], now: number): CodexRateLimits | null {
+  for (const path of paths) {
+    let content: string;
+    try {
+      content = readFileSync(path, "utf8");
+    } catch {
+      continue;
+    }
+    const rl = parseCodexRateLimits(content, now);
+    if (rl) return rl;
+  }
+  return null;
+}
+
 export class CodexUsageProvider implements UsageProviderSource {
   constructor(private stateDbPath?: string) {}
 
+  // Rollout files reach several MB and `snapshot()` runs on every usage recompute (per request,
+  // per poller tick). Cache the parsed rate limits keyed on the freshest rollout's path + mtime so
+  // a re-read only happens after Codex actually logs a new turn.
+  private rlCache: { key: string; value: CodexRateLimits | null } | null = null;
+
   snapshot(now: number): UsageProviderSnapshot | null {
     const path = this.stateDbPath ?? latestCodexStateDb();
-    return path ? readCodexTokenUsage(path, now) : null;
+    if (!path) return null;
+    const st = readCodexState(path, now);
+    if (!st) return null;
+    const base = tokenSnapshot(st, now);
+    const rl = this.rateLimits(st.rolloutPaths, now);
+    return { ...base, session5h: rl?.session5h ?? null, week: rl?.week ?? null };
+  }
+
+  private rateLimits(paths: string[], now: number): CodexRateLimits | null {
+    if (!paths.length) return null;
+    // Cache key is the freshest rollout's path + mtime only. Edge case: a rate-limit update that
+    // lands in an OLDER rollout while the freshest one is untouched is served stale until the
+    // freshest rollout's mtime changes. Tolerated on purpose — the rate limit is account-global, so
+    // the most recently active session's rollout is the one that gets each turn's reading; any agent
+    // actually consuming quota bumps the freshest mtime, evicting the cache within one turn.
+    let key = paths[0]!;
+    try {
+      key = `${paths[0]}:${statSync(paths[0]!).mtimeMs}`;
+    } catch {
+      // stat failure ⇒ fall through to the bare path as the key and re-read
+    }
+    if (this.rlCache?.key === key) return this.rlCache.value;
+    const value = readCodexRateLimits(paths, now);
+    this.rlCache = { key, value };
+    return value;
   }
 }

--- a/src/codex-usage.ts
+++ b/src/codex-usage.ts
@@ -1,17 +1,27 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readSync,
+  readdirSync,
+  statSync,
+  type Dirent,
+} from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import type { LimitWindow, UsageProviderSnapshot, UsageProviderSource } from "./usage-limits";
 
+type CodexTokenSnapshot = Extract<UsageProviderSnapshot, { provider: "codex"; kind: "tokens" }>;
+
 const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 const STALE_MS = 24 * 60 * 60 * 1000;
 /** How many recent OpenAI rollouts to scan for the latest rate-limit event. The most recently
- *  touched session almost always carries it; a small fan-out covers a freshly-started session
- *  whose first turn hasn't logged a rate-limit event yet (the limit is account-global, so an
- *  older session's last reading is still current). */
-const ROLLOUT_SCAN_LIMIT = 8;
+ *  touched session almost always carries it; a bounded fan-out covers fresh sessions that haven't
+ *  logged one yet and stale DB rollout paths by also considering $CODEX_HOME/sessions. */
+const ROLLOUT_SCAN_LIMIT = 24;
+const ROLLOUT_TAIL_BYTES = 1_000_000;
 
 interface CodexUsageRow {
   totalTokens: number | null;
@@ -33,10 +43,68 @@ interface CodexState {
 export interface CodexRateLimits {
   session5h: LimitWindow | null;
   week: LimitWindow | null;
+  source: "rollout";
+  checkedAt: number;
+  filesScanned: number;
+  latestEventAt: number | null;
+}
+
+interface RolloutCandidate {
+  path: string;
+  mtimeMs: number;
+  size: number;
 }
 
 function codexHome(): string {
   return process.env.CODEX_HOME || join(homedir(), ".codex");
+}
+
+function rolloutCandidate(path: string): RolloutCandidate | null {
+  try {
+    const st = statSync(path);
+    if (!st.isFile()) return null;
+    return { path, mtimeMs: st.mtimeMs, size: st.size };
+  } catch {
+    return null;
+  }
+}
+
+function dedupeRolloutCandidates(paths: string[], extra: RolloutCandidate[]): RolloutCandidate[] {
+  const byPath = new Map<string, RolloutCandidate>();
+  for (const path of paths) {
+    const c = rolloutCandidate(path);
+    if (c) byPath.set(c.path, c);
+  }
+  for (const c of extra) byPath.set(c.path, c);
+  return [...byPath.values()].sort((a, b) => b.mtimeMs - a.mtimeMs).slice(0, ROLLOUT_SCAN_LIMIT);
+}
+
+export function recentCodexRolloutPaths(home = codexHome(), limit = ROLLOUT_SCAN_LIMIT): string[] {
+  const root = join(home, "sessions");
+  const out: RolloutCandidate[] = [];
+  function walk(dir: string): void {
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(path);
+        continue;
+      }
+      if (!entry.isFile() || !/^rollout-.*\.jsonl$/.test(entry.name)) continue;
+      const c = rolloutCandidate(path);
+      if (c) out.push(c);
+    }
+  }
+  walk(root);
+  return out
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+    .slice(0, limit)
+    .map((c) => c.path);
 }
 
 export function latestCodexStateDb(home = codexHome()): string | null {
@@ -109,7 +177,7 @@ function readCodexState(dbPath: string, now: number): CodexState | null {
 }
 
 /** Build the base (rate-limit-free) Codex token snapshot. */
-function tokenSnapshot(st: CodexState, now: number): UsageProviderSnapshot {
+function tokenSnapshot(st: CodexState, now: number): CodexTokenSnapshot {
   return {
     provider: "codex",
     kind: "tokens",
@@ -135,6 +203,15 @@ interface RolloutLimitWindow {
   resets_at?: number; // epoch SECONDS
 }
 
+interface RolloutTokenCountEvent {
+  type?: string;
+  timestamp?: string;
+  payload?: {
+    type?: string;
+    rate_limits?: { primary?: RolloutLimitWindow; secondary?: RolloutLimitWindow } | null;
+  };
+}
+
 function toLimitWindow(w: RolloutLimitWindow | null | undefined, now: number): LimitWindow | null {
   if (!w || typeof w.used_percent !== "number") return null;
   // resets_at is epoch seconds; fall back to now + window when absent so a bar still has a reset.
@@ -143,6 +220,52 @@ function toLimitWindow(w: RolloutLimitWindow | null | undefined, now: number): L
       ? w.resets_at * 1000
       : now + (typeof w.window_minutes === "number" ? w.window_minutes * 60_000 : 0);
   return { pct: Math.max(0, Math.min(100, Math.round(w.used_percent))), resetAt };
+}
+
+function readFileTail(path: string, maxBytes: number): string {
+  const st = statSync(path);
+  const start = Math.max(0, st.size - maxBytes);
+  const length = st.size - start;
+  const buf = Buffer.alloc(length);
+  const fd = openSync(path, "r");
+  try {
+    readSync(fd, buf, 0, length, start);
+  } finally {
+    closeSync(fd);
+  }
+  return buf.toString("utf8");
+}
+
+function parseRolloutLine(line: string): RolloutTokenCountEvent | null {
+  if (!line || !line.includes('"rate_limits"')) return null;
+  try {
+    return JSON.parse(line) as RolloutTokenCountEvent;
+  } catch {
+    return null;
+  }
+}
+
+function eventTimestampMs(timestamp: string | undefined): number | null {
+  if (typeof timestamp !== "string") return null;
+  const ms = Date.parse(timestamp);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function rateLimitsFromEvent(obj: RolloutTokenCountEvent, now: number): CodexRateLimits | null {
+  if (obj.type !== "event_msg" || obj.payload?.type !== "token_count") return null;
+  const rl = obj.payload.rate_limits;
+  if (!rl) return null;
+  const session5h = toLimitWindow(rl.primary, now);
+  const week = toLimitWindow(rl.secondary, now);
+  if (!session5h && !week) return null;
+  return {
+    session5h,
+    week,
+    source: "rollout",
+    checkedAt: now,
+    filesScanned: 0,
+    latestEventAt: eventTimestampMs(obj.timestamp),
+  };
 }
 
 /**
@@ -158,75 +281,73 @@ function toLimitWindow(w: RolloutLimitWindow | null | undefined, now: number): L
 export function parseCodexRateLimits(content: string, now: number): CodexRateLimits | null {
   const lines = content.split("\n");
   for (let i = lines.length - 1; i >= 0; i--) {
-    const line = lines[i];
-    // Cheap pre-filter: skip the vast majority of lines that carry no rate-limit reading at all.
-    if (!line || !line.includes('"rate_limits"')) continue;
-    let obj: {
-      payload?: { rate_limits?: { primary?: RolloutLimitWindow; secondary?: RolloutLimitWindow } };
-    };
-    try {
-      obj = JSON.parse(line);
-    } catch {
-      continue;
-    }
-    const rl = obj?.payload?.rate_limits;
-    if (!rl) continue;
-    const session5h = toLimitWindow(rl.primary, now);
-    const week = toLimitWindow(rl.secondary, now);
-    if (!session5h && !week) continue;
-    return { session5h, week };
+    const obj = parseRolloutLine(lines[i] ?? "");
+    if (!obj) continue;
+    const rl = rateLimitsFromEvent(obj, now);
+    if (rl) return rl;
   }
   return null;
 }
 
 /** Read the freshest rate-limit windows from the given rollout paths (newest first). */
 export function readCodexRateLimits(paths: string[], now: number): CodexRateLimits | null {
+  let filesScanned = 0;
   for (const path of paths) {
     let content: string;
     try {
-      content = readFileSync(path, "utf8");
+      content = readFileTail(path, ROLLOUT_TAIL_BYTES);
+      filesScanned++;
     } catch {
       continue;
     }
     const rl = parseCodexRateLimits(content, now);
-    if (rl) return rl;
+    if (rl) return { ...rl, checkedAt: now, filesScanned };
   }
   return null;
 }
 
 export class CodexUsageProvider implements UsageProviderSource {
-  constructor(private stateDbPath?: string) {}
+  constructor(
+    private stateDbPath?: string,
+    private home = codexHome(),
+  ) {}
 
   // Rollout files reach several MB and `snapshot()` runs on every usage recompute (per request,
-  // per poller tick). Cache the parsed rate limits keyed on the freshest rollout's path + mtime so
-  // a re-read only happens after Codex actually logs a new turn.
+  // per poller tick). Cache the parsed rate limits keyed on candidate path + mtime + size so a
+  // re-read only happens after Codex actually logs a new turn.
   private rlCache: { key: string; value: CodexRateLimits | null } | null = null;
 
   snapshot(now: number): UsageProviderSnapshot | null {
-    const path = this.stateDbPath ?? latestCodexStateDb();
+    const path = this.stateDbPath ?? latestCodexStateDb(this.home);
     if (!path) return null;
     const st = readCodexState(path, now);
     if (!st) return null;
     const base = tokenSnapshot(st, now);
-    const rl = this.rateLimits(st.rolloutPaths, now);
-    return { ...base, session5h: rl?.session5h ?? null, week: rl?.week ?? null };
+    const fsCandidates = recentCodexRolloutPaths(this.home).flatMap((p) => {
+      const c = rolloutCandidate(p);
+      return c ? [c] : [];
+    });
+    const candidates = dedupeRolloutCandidates(st.rolloutPaths, fsCandidates);
+    const rl = this.rateLimits(candidates, now);
+    return {
+      ...base,
+      session5h: rl?.session5h ?? null,
+      week: rl?.week ?? null,
+      rateLimitSource: rl ? "rollout" : "missing",
+      rateLimitCheckedAt: now,
+      rateLimitFilesScanned: rl?.filesScanned ?? candidates.length,
+      rateLimitLatestEventAt: rl?.latestEventAt ?? null,
+    };
   }
 
-  private rateLimits(paths: string[], now: number): CodexRateLimits | null {
-    if (!paths.length) return null;
-    // Cache key is the freshest rollout's path + mtime only. Edge case: a rate-limit update that
-    // lands in an OLDER rollout while the freshest one is untouched is served stale until the
-    // freshest rollout's mtime changes. Tolerated on purpose — the rate limit is account-global, so
-    // the most recently active session's rollout is the one that gets each turn's reading; any agent
-    // actually consuming quota bumps the freshest mtime, evicting the cache within one turn.
-    let key = paths[0]!;
-    try {
-      key = `${paths[0]}:${statSync(paths[0]!).mtimeMs}`;
-    } catch {
-      // stat failure ⇒ fall through to the bare path as the key and re-read
-    }
+  private rateLimits(candidates: RolloutCandidate[], now: number): CodexRateLimits | null {
+    if (!candidates.length) return null;
+    const key = candidates.map((c) => `${c.path}:${c.mtimeMs}:${c.size}`).join("|");
     if (this.rlCache?.key === key) return this.rlCache.value;
-    const value = readCodexRateLimits(paths, now);
+    const value = readCodexRateLimits(
+      candidates.map((c) => c.path),
+      now,
+    );
     this.rlCache = { key, value };
     return value;
   }

--- a/src/usage-limits.ts
+++ b/src/usage-limits.ts
@@ -335,6 +335,11 @@ export type UsageProviderSnapshot =
       weekTokens: number;
       updatedAt: number | null;
       stale: boolean;
+      // Rate-limit windows scraped from Codex's own session rollout logs (the same
+      // 5h/weekly used-% + reset that `codex` reports). null when no rollout carries
+      // a rate-limit event yet, so the UI falls back to the raw token counts.
+      session5h: LimitWindow | null;
+      week: LimitWindow | null;
     };
 
 export interface UsageProviderSource {

--- a/src/usage-limits.ts
+++ b/src/usage-limits.ts
@@ -340,6 +340,10 @@ export type UsageProviderSnapshot =
       // a rate-limit event yet, so the UI falls back to the raw token counts.
       session5h: LimitWindow | null;
       week: LimitWindow | null;
+      rateLimitSource?: "rollout" | "missing";
+      rateLimitCheckedAt?: number;
+      rateLimitFilesScanned?: number;
+      rateLimitLatestEventAt?: number | null;
     };
 
 export interface UsageProviderSource {

--- a/test/codex-usage.test.ts
+++ b/test/codex-usage.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
@@ -7,6 +7,7 @@ import {
   CodexUsageProvider,
   latestCodexStateDb,
   parseCodexRateLimits,
+  recentCodexRolloutPaths,
   readCodexRateLimits,
   readCodexTokenUsage,
 } from "../src/codex-usage";
@@ -123,9 +124,13 @@ test("parseCodexRateLimits reads the latest primary/secondary windows", () => {
     rolloutLine(43, 9, resetSec), // newest reading wins
   ].join("\n");
 
-  expect(parseCodexRateLimits(content, NOW)).toEqual({
+  expect(parseCodexRateLimits(content, NOW)).toMatchObject({
     session5h: { pct: 43, resetAt: resetSec * 1000 },
     week: { pct: 9, resetAt: (resetSec + 600) * 1000 },
+    source: "rollout",
+    checkedAt: NOW,
+    filesScanned: 0,
+    latestEventAt: Date.parse("2026-06-25T15:59:00.000Z"),
   });
 });
 
@@ -140,7 +145,7 @@ test("parseCodexRateLimits tolerates whitespace after the rate_limits colon", ()
   const spaced = rolloutLine(7, 3, resetSec).replace('"rate_limits":{', '"rate_limits": {');
   expect(spaced).toContain('"rate_limits": {');
 
-  expect(parseCodexRateLimits(spaced, NOW)).toEqual({
+  expect(parseCodexRateLimits(spaced, NOW)).toMatchObject({
     session5h: { pct: 7, resetAt: resetSec * 1000 },
     week: { pct: 3, resetAt: (resetSec + 600) * 1000 },
   });
@@ -154,9 +159,30 @@ test("parseCodexRateLimits skips a null rate_limits line and keeps scanning", ()
   ].join("\n");
 
   // The trailing null reading must not shadow the real one above it.
-  expect(parseCodexRateLimits(content, NOW)).toEqual({
+  expect(parseCodexRateLimits(content, NOW)).toMatchObject({
     session5h: { pct: 11, resetAt: resetSec * 1000 },
     week: { pct: 4, resetAt: (resetSec + 600) * 1000 },
+  });
+});
+
+test("parseCodexRateLimits ignores non-token-count payloads that mention rate_limits", () => {
+  const resetSec = Math.floor(NOW / 1000) + 3600;
+  const content = [
+    rolloutLine(15, 5, resetSec),
+    JSON.stringify({
+      type: "response_item",
+      payload: {
+        type: "tool_call",
+        internal_chat_message_metadata_passthrough: {
+          rate_limits: { primary: { used_percent: 99 } },
+        },
+      },
+    }),
+  ].join("\n");
+
+  expect(parseCodexRateLimits(content, NOW)).toMatchObject({
+    session5h: { pct: 15, resetAt: resetSec * 1000 },
+    week: { pct: 5, resetAt: (resetSec + 600) * 1000 },
   });
 });
 
@@ -168,9 +194,65 @@ test("readCodexRateLimits skips files without a reading and uses the first that 
   writeFileSync(empty, '{"type":"event_msg","payload":{"type":"agent_message"}}\n');
   writeFileSync(withData, rolloutLine(50, 20, resetSec));
 
-  expect(readCodexRateLimits([empty, withData, "/no/such/file.jsonl"], NOW)).toEqual({
+  expect(readCodexRateLimits([empty, withData, "/no/such/file.jsonl"], NOW)).toMatchObject({
     session5h: { pct: 50, resetAt: resetSec * 1000 },
     week: { pct: 20, resetAt: (resetSec + 600) * 1000 },
+    filesScanned: 2,
+  });
+});
+
+test("recentCodexRolloutPaths lists newest rollout files under CODEX_HOME sessions", () => {
+  const dir = tempDir();
+  const sessions = join(dir, "sessions", "2026", "06", "25");
+  mkdirSync(sessions, { recursive: true });
+  const oldPath = join(sessions, "rollout-old.jsonl");
+  const newPath = join(sessions, "rollout-new.jsonl");
+  writeFileSync(oldPath, "{}\n");
+  writeFileSync(newPath, "{}\n");
+  writeFileSync(join(sessions, "notes.txt"), "{}\n");
+  utimesSync(oldPath, new Date(NOW - H), new Date(NOW - H));
+  utimesSync(newPath, new Date(NOW), new Date(NOW));
+
+  expect(recentCodexRolloutPaths(dir, 2)).toEqual([newPath, oldPath]);
+});
+
+test("CodexUsageProvider falls back to recent session rollouts when DB paths carry no limits", () => {
+  const dir = tempDir();
+  const dbPath = join(dir, "state_5.sqlite");
+  const sessions = join(dir, "sessions", "2026", "06", "25");
+  mkdirSync(sessions, { recursive: true });
+  const newest = join(sessions, "rollout-newest.jsonl");
+  const older = join(sessions, "rollout-older.jsonl");
+  const resetSec = Math.floor(NOW / 1000) + 3600;
+  writeFileSync(newest, '{"type":"event_msg","payload":{"type":"agent_message","text":"hi"}}\n');
+  writeFileSync(older, rolloutLine(61, 33, resetSec));
+  utimesSync(older, new Date(NOW - H), new Date(NOW - H));
+  utimesSync(newest, new Date(NOW), new Date(NOW));
+
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE threads (
+      id TEXT PRIMARY KEY,
+      model_provider TEXT NOT NULL,
+      tokens_used INTEGER NOT NULL DEFAULT 0,
+      updated_at_ms INTEGER NOT NULL,
+      rollout_path TEXT NOT NULL DEFAULT ''
+    )
+  `);
+  db.query(
+    "INSERT INTO threads (id, model_provider, tokens_used, updated_at_ms, rollout_path) VALUES (?, ?, ?, ?, ?)",
+  ).run("recent", "openai", 1_000, NOW - H, "");
+  db.close();
+
+  const snap = new CodexUsageProvider(dbPath, dir).snapshot(NOW);
+
+  expect(snap).toMatchObject({
+    provider: "codex",
+    kind: "tokens",
+    session5h: { pct: 61, resetAt: resetSec * 1000 },
+    week: { pct: 33, resetAt: (resetSec + 600) * 1000 },
+    rateLimitSource: "rollout",
+    rateLimitFilesScanned: 2,
   });
 });
 
@@ -196,7 +278,7 @@ test("CodexUsageProvider.snapshot merges token counts with rollout rate limits",
   ).run("recent", "openai", 1_000, NOW - H, rollout);
   db.close();
 
-  const snap = new CodexUsageProvider(dbPath).snapshot(NOW);
+  const snap = new CodexUsageProvider(dbPath, dir).snapshot(NOW);
 
   expect(snap).toMatchObject({
     provider: "codex",
@@ -204,5 +286,6 @@ test("CodexUsageProvider.snapshot merges token counts with rollout rate limits",
     totalTokens: 1_000,
     session5h: { pct: 38, resetAt: resetSec * 1000 },
     week: { pct: 22, resetAt: (resetSec + 600) * 1000 },
+    rateLimitSource: "rollout",
   });
 });

--- a/test/codex-usage.test.ts
+++ b/test/codex-usage.test.ts
@@ -3,7 +3,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { afterEach, expect, test } from "bun:test";
-import { latestCodexStateDb, readCodexTokenUsage } from "../src/codex-usage";
+import {
+  CodexUsageProvider,
+  latestCodexStateDb,
+  parseCodexRateLimits,
+  readCodexRateLimits,
+  readCodexTokenUsage,
+} from "../src/codex-usage";
 
 const NOW = Date.parse("2026-06-25T16:00:00.000Z");
 const H = 60 * 60 * 1000;
@@ -86,4 +92,117 @@ test("readCodexTokenUsage returns null when no OpenAI Codex threads exist", () =
   db.close();
 
   expect(readCodexTokenUsage(path, NOW)).toBeNull();
+});
+
+/** A Codex rollout `token_count` line carrying a rate-limit reading. */
+function rolloutLine(primaryPct: number, secondaryPct: number, primaryReset: number): string {
+  return JSON.stringify({
+    timestamp: "2026-06-25T15:59:00.000Z",
+    type: "event_msg",
+    payload: {
+      type: "token_count",
+      info: { total_token_usage: { total_tokens: 1 } },
+      rate_limits: {
+        limit_id: "codex",
+        primary: { used_percent: primaryPct, window_minutes: 300, resets_at: primaryReset },
+        secondary: {
+          used_percent: secondaryPct,
+          window_minutes: 10080,
+          resets_at: primaryReset + 600,
+        },
+      },
+    },
+  });
+}
+
+test("parseCodexRateLimits reads the latest primary/secondary windows", () => {
+  const resetSec = Math.floor(NOW / 1000) + 3600;
+  const content = [
+    rolloutLine(1, 1, resetSec - 60),
+    '{"type":"event_msg","payload":{"type":"agent_message","text":"hi"}}',
+    rolloutLine(43, 9, resetSec), // newest reading wins
+  ].join("\n");
+
+  expect(parseCodexRateLimits(content, NOW)).toEqual({
+    session5h: { pct: 43, resetAt: resetSec * 1000 },
+    week: { pct: 9, resetAt: (resetSec + 600) * 1000 },
+  });
+});
+
+test("parseCodexRateLimits returns null when no rate-limit event is present", () => {
+  const content = '{"type":"event_msg","payload":{"type":"agent_message","text":"hi"}}';
+  expect(parseCodexRateLimits(content, NOW)).toBeNull();
+});
+
+test("parseCodexRateLimits tolerates whitespace after the rate_limits colon", () => {
+  const resetSec = Math.floor(NOW / 1000) + 3600;
+  // A line whose key reads `"rate_limits": {` (space after colon) must still be recognized.
+  const spaced = rolloutLine(7, 3, resetSec).replace('"rate_limits":{', '"rate_limits": {');
+  expect(spaced).toContain('"rate_limits": {');
+
+  expect(parseCodexRateLimits(spaced, NOW)).toEqual({
+    session5h: { pct: 7, resetAt: resetSec * 1000 },
+    week: { pct: 3, resetAt: (resetSec + 600) * 1000 },
+  });
+});
+
+test("parseCodexRateLimits skips a null rate_limits line and keeps scanning", () => {
+  const resetSec = Math.floor(NOW / 1000) + 3600;
+  const content = [
+    rolloutLine(11, 4, resetSec),
+    '{"type":"event_msg","payload":{"type":"token_count","rate_limits":null}}',
+  ].join("\n");
+
+  // The trailing null reading must not shadow the real one above it.
+  expect(parseCodexRateLimits(content, NOW)).toEqual({
+    session5h: { pct: 11, resetAt: resetSec * 1000 },
+    week: { pct: 4, resetAt: (resetSec + 600) * 1000 },
+  });
+});
+
+test("readCodexRateLimits skips files without a reading and uses the first that has one", () => {
+  const dir = tempDir();
+  const empty = join(dir, "empty.jsonl");
+  const withData = join(dir, "with-data.jsonl");
+  const resetSec = Math.floor(NOW / 1000) + 3600;
+  writeFileSync(empty, '{"type":"event_msg","payload":{"type":"agent_message"}}\n');
+  writeFileSync(withData, rolloutLine(50, 20, resetSec));
+
+  expect(readCodexRateLimits([empty, withData, "/no/such/file.jsonl"], NOW)).toEqual({
+    session5h: { pct: 50, resetAt: resetSec * 1000 },
+    week: { pct: 20, resetAt: (resetSec + 600) * 1000 },
+  });
+});
+
+test("CodexUsageProvider.snapshot merges token counts with rollout rate limits", () => {
+  const dir = tempDir();
+  const dbPath = join(dir, "state_5.sqlite");
+  const rollout = join(dir, "rollout.jsonl");
+  const resetSec = Math.floor(NOW / 1000) + 3600;
+  writeFileSync(rollout, rolloutLine(38, 22, resetSec));
+
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE threads (
+      id TEXT PRIMARY KEY,
+      model_provider TEXT NOT NULL,
+      tokens_used INTEGER NOT NULL DEFAULT 0,
+      updated_at_ms INTEGER NOT NULL,
+      rollout_path TEXT NOT NULL DEFAULT ''
+    )
+  `);
+  db.query(
+    "INSERT INTO threads (id, model_provider, tokens_used, updated_at_ms, rollout_path) VALUES (?, ?, ?, ?, ?)",
+  ).run("recent", "openai", 1_000, NOW - H, rollout);
+  db.close();
+
+  const snap = new CodexUsageProvider(dbPath).snapshot(NOW);
+
+  expect(snap).toMatchObject({
+    provider: "codex",
+    kind: "tokens",
+    totalTokens: 1_000,
+    session5h: { pct: 38, resetAt: resetSec * 1000 },
+    week: { pct: 22, resetAt: (resetSec + 600) * 1000 },
+  });
 });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2384,5 +2384,6 @@
   "feat_codex_plan_gate_title": "Plan-Gate für Codex (Alpha)",
   "feat_codex_plan_gate_body": "Das Plan-Gate funktioniert jetzt für Codex-Aufgaben. Schalte es im Neue-Aufgabe-Dialog ein, und Codex recherchiert und schreibt zuerst einen Plan, stoppt zur Review und implementiert erst nach Freigabe des Plans — dasselbe Pre-Execution-Gate, das Claude nutzt.",
   "feat_codex_usage_gauges_title": "Codex-Auslastungsbalken",
-  "feat_codex_usage_gauges_body": "Das Auslastungs-Popover zeigt die 5-Stunden- und Wochen-Limits von Codex jetzt als Prozentbalken mit Reset-Zeiten — im selben Format wie Claude, sodass du beide CLIs auf einen Blick vergleichen kannst. Die reinen Token-Zahlen stehen weiterhin unter den Balken."
+  "feat_codex_usage_gauges_body": "Das Auslastungs-Popover zeigt die 5-Stunden- und Wochen-Limits von Codex jetzt als Prozentbalken mit Reset-Zeiten — im selben Format wie Claude, sodass du beide CLIs auf einen Blick vergleichen kannst. Die reinen Token-Zahlen stehen weiterhin unter den Balken.",
+  "topbar_codex_limits_unavailable": "Codex-Limits nicht gefunden; zeige Token-Nutzung."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2382,5 +2382,7 @@
   "feat_scroll_to_session_start_title": "Zum Session-Anfang springen",
   "feat_scroll_to_session_start_body": "Wenn du ältere Terminal-Ausgabe liest, zeigt die schwebende Scroll-Schaltfläche jetzt zusätzlich einen ↑-Button für den Anfang der Session neben dem bestehenden ↓-Sprung zurück zum aktuellen Prompt.",
   "feat_codex_plan_gate_title": "Plan-Gate für Codex (Alpha)",
-  "feat_codex_plan_gate_body": "Das Plan-Gate funktioniert jetzt für Codex-Aufgaben. Schalte es im Neue-Aufgabe-Dialog ein, und Codex recherchiert und schreibt zuerst einen Plan, stoppt zur Review und implementiert erst nach Freigabe des Plans — dasselbe Pre-Execution-Gate, das Claude nutzt."
+  "feat_codex_plan_gate_body": "Das Plan-Gate funktioniert jetzt für Codex-Aufgaben. Schalte es im Neue-Aufgabe-Dialog ein, und Codex recherchiert und schreibt zuerst einen Plan, stoppt zur Review und implementiert erst nach Freigabe des Plans — dasselbe Pre-Execution-Gate, das Claude nutzt.",
+  "feat_codex_usage_gauges_title": "Codex-Auslastungsbalken",
+  "feat_codex_usage_gauges_body": "Das Auslastungs-Popover zeigt die 5-Stunden- und Wochen-Limits von Codex jetzt als Prozentbalken mit Reset-Zeiten — im selben Format wie Claude, sodass du beide CLIs auf einen Blick vergleichen kannst. Die reinen Token-Zahlen stehen weiterhin unter den Balken."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2384,5 +2384,6 @@
   "feat_codex_plan_gate_title": "Plan gate for Codex (Alpha)",
   "feat_codex_plan_gate_body": "The plan gate now works for Codex tasks. Toggle it on in New Task and Codex researches and writes a plan first, stops for review, and only implements once the plan is approved — the same pre-execution gate Claude uses.",
   "feat_codex_usage_gauges_title": "Codex usage gauges",
-  "feat_codex_usage_gauges_body": "The usage popover now shows Codex's 5-hour and weekly rate limits as percentage bars with reset times — the same format as Claude, so you can compare both CLIs at a glance. Raw token counts still show below the bars."
+  "feat_codex_usage_gauges_body": "The usage popover now shows Codex's 5-hour and weekly rate limits as percentage bars with reset times — the same format as Claude, so you can compare both CLIs at a glance. Raw token counts still show below the bars.",
+  "topbar_codex_limits_unavailable": "Codex limits not found; showing token usage."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2382,5 +2382,7 @@
   "feat_scroll_to_session_start_title": "Jump to session start",
   "feat_scroll_to_session_start_body": "When you're reading older terminal output, the floating scroll control now includes an ↑ button for the start of the session next to the existing ↓ jump back to the latest prompt.",
   "feat_codex_plan_gate_title": "Plan gate for Codex (Alpha)",
-  "feat_codex_plan_gate_body": "The plan gate now works for Codex tasks. Toggle it on in New Task and Codex researches and writes a plan first, stops for review, and only implements once the plan is approved — the same pre-execution gate Claude uses."
+  "feat_codex_plan_gate_body": "The plan gate now works for Codex tasks. Toggle it on in New Task and Codex researches and writes a plan first, stops for review, and only implements once the plan is approved — the same pre-execution gate Claude uses.",
+  "feat_codex_usage_gauges_title": "Codex usage gauges",
+  "feat_codex_usage_gauges_body": "The usage popover now shows Codex's 5-hour and weekly rate limits as percentage bars with reset times — the same format as Claude, so you can compare both CLIs at a glance. Raw token counts still show below the bars."
 }

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -1357,6 +1357,8 @@ describe("TopBar — CR extra-credit gauge", () => {
           weekTokens: 92_600_000,
           updatedAt: 1_700_000_000_000,
           stale,
+          session5h: null,
+          week: null,
         },
       ],
     };

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -1562,6 +1562,7 @@ describe("TopBar — CR extra-credit gauge", () => {
     expect(pop, "popover rendered").not.toBeNull();
     const text = pop!.textContent ?? "";
     expect(text, "codex provider label").toContain(m.agent_provider_codex());
+    expect(text, "codex limits fallback").toContain(m.topbar_codex_limits_unavailable());
     expect(text, "5H token row").toContain(m.topbar_tokens_window({ period: "5H" }));
     expect(text, "weekly token row").toContain(m.topbar_tokens_window({ period: "WK" }));
   });
@@ -1575,6 +1576,29 @@ describe("TopBar — CR extra-credit gauge", () => {
       m.agent_provider_codex(),
     );
     expect(toggle!.classList.contains("stale"), "stale codex-only toggle is dimmed").toBe(true);
+  });
+
+  it("mobile sheet: codex-only without rate limits explains the token-only fallback", async () => {
+    await page.viewport(390, 800);
+    document.body.style.width = "390px";
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.mobile,
+      ...sessionsProp(0),
+      limits: codexOnly(),
+    });
+
+    await page.getByRole("button", { name: m.topbar_menu_aria() }).click();
+    const sheet = document.querySelector<HTMLElement>(".gear-sheet");
+    expect(sheet, "mobile sheet rendered").not.toBeNull();
+    const text = sheet!.textContent ?? "";
+    expect(text, "codex fallback visible in mobile sheet").toContain(
+      m.topbar_codex_limits_unavailable(),
+    );
+    expect(text, "codex token rows remain visible").toContain(
+      m.topbar_tokens_window({ period: "5H" }),
+    );
   });
 
   it("fail-closed: a rejected refresh surfaces the error state, not silent success", async () => {

--- a/ui/src/lib/components/Usage.browser.test.ts
+++ b/ui/src/lib/components/Usage.browser.test.ts
@@ -38,6 +38,8 @@ const inlineLimits: UsageLimits = {
       weekTokens: 87_654_321,
       updatedAt: BASE - 60_000,
       stale: false,
+      session5h: null,
+      week: null,
     },
   ],
 };

--- a/ui/src/lib/components/top-bar/CodexTokenDetail.svelte
+++ b/ui/src/lib/components/top-bar/CodexTokenDetail.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { m } from "$lib/paraglide/messages";
-  import { formatTokenLabel, formatResetIn, formatReset } from "$lib/format";
+  import { formatTokenLabel } from "$lib/format";
   import type { UsageProviderSnapshot } from "$lib/types";
-  import { gaugeColor, codexGaugeList, type GaugeKey } from "../usage-gauges";
+  import { codexGaugeList, type GaugeKey } from "../usage-gauges";
+  import LimitGaugeRow from "./LimitGaugeRow.svelte";
 
   let {
     usage,
@@ -15,36 +16,19 @@
   } = $props();
 
   // The 5h/weekly rate-limit windows Codex reports — rendered as Claude-style gauges so the two
-  // CLIs read side by side. Empty when Codex hasn't logged a rate-limit event yet (then we show
-  // only the raw token counts below).
+  // CLIs read side by side. Empty when Shepherd cannot find a rate-limit event in Codex rollouts.
   const windows = $derived(codexGaugeList(usage));
 </script>
 
-<div class="gp-head">
-  <span class="gp-period">{m.agent_provider_codex()}</span>
+<div class="provider-head">
+  <span class="provider-name">{m.agent_provider_codex()}</span>
 </div>
 {#each windows as g (g.label)}
-  <div class="codex-gauge">
-    <div class="codex-gauge-head">
-      <span class="gp-period">{periodLabel(g.label)}</span>
-      <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
-    </div>
-    <span class="g-bar"
-      ><span
-        class="g-fill"
-        style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) / 100});background:{gaugeColor(
-          g.w.pct,
-        )}"
-      ></span></span
-    >
-    <div class="micro">
-      {m.topbar_gauge_reset_rel({
-        rel: formatResetIn(g.w.resetAt, nowMs),
-        abs: formatReset(g.w.resetAt, nowMs),
-      })}
-    </div>
-  </div>
+  <LimitGaugeRow label={periodLabel(g.label)} limit={g.w} {nowMs} />
 {/each}
+{#if windows.length === 0}
+  <div class="limits-unavailable micro">{m.topbar_codex_limits_unavailable()}</div>
+{/if}
 <div class="token-row">
   <span>{m.topbar_tokens_window({ period: "5H" })}</span>
   <span>{formatTokenLabel(usage.session5hTokens)}</span>
@@ -59,47 +43,25 @@
 </div>
 
 <style>
-  .gp-head {
+  .provider-head {
     display: flex;
     align-items: baseline;
     justify-content: space-between;
     font-variant-numeric: tabular-nums;
   }
-  .gp-period {
+  .provider-name {
     color: var(--color-text);
     font-size: var(--fs-meta);
     text-transform: capitalize;
   }
-  .codex-gauge {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
+  .limits-unavailable {
     margin: 4px 0 6px;
-  }
-  .codex-gauge-head {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    font-variant-numeric: tabular-nums;
-  }
-  .g-bar {
-    width: 100%;
-    height: 6px;
-    background: var(--color-line);
-    border: 1px solid var(--color-line-bright);
-    overflow: hidden;
-  }
-  .g-fill {
-    display: block;
-    width: 100%;
-    height: 100%;
-    transform-origin: left;
-    transition: transform 0.6s ease;
-  }
-  .g-pct {
-    font-size: var(--fs-meta);
-    min-width: 30px;
-    text-align: right;
+    padding: 6px 0;
+    border-top: 1px solid var(--color-line);
+    border-bottom: 1px solid var(--color-line);
+    color: var(--color-faint);
+    letter-spacing: 0.08em;
+    line-height: 1.35;
   }
   .token-row {
     display: flex;

--- a/ui/src/lib/components/top-bar/CodexTokenDetail.svelte
+++ b/ui/src/lib/components/top-bar/CodexTokenDetail.svelte
@@ -1,18 +1,50 @@
 <script lang="ts">
   import { m } from "$lib/paraglide/messages";
-  import { formatTokenLabel } from "$lib/format";
+  import { formatTokenLabel, formatResetIn, formatReset } from "$lib/format";
   import type { UsageProviderSnapshot } from "$lib/types";
+  import { gaugeColor, codexGaugeList, type GaugeKey } from "../usage-gauges";
 
   let {
     usage,
+    nowMs,
+    periodLabel,
   }: {
     usage: Extract<UsageProviderSnapshot, { provider: "codex"; kind: "tokens" }>;
+    nowMs: number;
+    periodLabel: (k: GaugeKey) => string;
   } = $props();
+
+  // The 5h/weekly rate-limit windows Codex reports — rendered as Claude-style gauges so the two
+  // CLIs read side by side. Empty when Codex hasn't logged a rate-limit event yet (then we show
+  // only the raw token counts below).
+  const windows = $derived(codexGaugeList(usage));
 </script>
 
 <div class="gp-head">
   <span class="gp-period">{m.agent_provider_codex()}</span>
 </div>
+{#each windows as g (g.label)}
+  <div class="codex-gauge">
+    <div class="codex-gauge-head">
+      <span class="gp-period">{periodLabel(g.label)}</span>
+      <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
+    </div>
+    <span class="g-bar"
+      ><span
+        class="g-fill"
+        style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) / 100});background:{gaugeColor(
+          g.w.pct,
+        )}"
+      ></span></span
+    >
+    <div class="micro">
+      {m.topbar_gauge_reset_rel({
+        rel: formatResetIn(g.w.resetAt, nowMs),
+        abs: formatReset(g.w.resetAt, nowMs),
+      })}
+    </div>
+  </div>
+{/each}
 <div class="token-row">
   <span>{m.topbar_tokens_window({ period: "5H" })}</span>
   <span>{formatTokenLabel(usage.session5hTokens)}</span>
@@ -38,6 +70,37 @@
     font-size: var(--fs-meta);
     text-transform: capitalize;
   }
+  .codex-gauge {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin: 4px 0 6px;
+  }
+  .codex-gauge-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    font-variant-numeric: tabular-nums;
+  }
+  .g-bar {
+    width: 100%;
+    height: 6px;
+    background: var(--color-line);
+    border: 1px solid var(--color-line-bright);
+    overflow: hidden;
+  }
+  .g-fill {
+    display: block;
+    width: 100%;
+    height: 100%;
+    transform-origin: left;
+    transition: transform 0.6s ease;
+  }
+  .g-pct {
+    font-size: var(--fs-meta);
+    min-width: 30px;
+    text-align: right;
+  }
   .token-row {
     display: flex;
     justify-content: space-between;
@@ -50,5 +113,11 @@
     color: var(--color-faint);
     text-transform: uppercase;
     letter-spacing: 0.08em;
+  }
+  .micro {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
   }
 </style>

--- a/ui/src/lib/components/top-bar/LimitGaugeRow.svelte
+++ b/ui/src/lib/components/top-bar/LimitGaugeRow.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+  import { formatReset, formatResetIn } from "$lib/format";
+  import { m } from "$lib/paraglide/messages";
+  import type { LimitWindow } from "$lib/types";
+  import { gaugeColor } from "../usage-gauges";
+
+  let {
+    label,
+    limit,
+    nowMs,
+    inline = false,
+  }: {
+    label: string;
+    limit: LimitWindow;
+    nowMs: number;
+    inline?: boolean;
+  } = $props();
+
+  const fill = $derived(Math.min(Math.max(limit.pct, 0), 100) / 100);
+  const color = $derived(gaugeColor(limit.pct));
+</script>
+
+{#if inline}
+  <div class="gauge-pop-row">
+    <span class="g-label micro">{label}</span>
+    <span class="g-bar g-bar-wide"
+      ><span class="g-fill" style="transform:scaleX({fill});background:{color}"></span></span
+    >
+    <span class="g-pct" style="color:{color}">{limit.pct}%</span>
+  </div>
+  <div class="gauge-pop-reset micro">
+    {m.topbar_gauge_reset_rel({
+      rel: formatResetIn(limit.resetAt, nowMs),
+      abs: formatReset(limit.resetAt, nowMs),
+    })}
+  </div>
+{:else}
+  <div class="sheet-gauge-row">
+    <div class="sheet-gauge-head">
+      <span class="gp-period">{label}</span>
+      <span class="g-pct" style="color:{color}">{limit.pct}%</span>
+    </div>
+    <span class="g-bar g-bar-wide"
+      ><span class="g-fill" style="transform:scaleX({fill});background:{color}"></span></span
+    >
+    <div class="gauge-pop-reset micro">
+      {m.topbar_gauge_reset_rel({
+        rel: formatResetIn(limit.resetAt, nowMs),
+        abs: formatReset(limit.resetAt, nowMs),
+      })}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .sheet-gauge-row {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+  .sheet-gauge-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    font-variant-numeric: tabular-nums;
+  }
+  .gauge-pop-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-variant-numeric: tabular-nums;
+  }
+  .g-label {
+    color: var(--color-muted);
+  }
+  .gp-period {
+    color: var(--color-text);
+    font-size: var(--fs-meta);
+    text-transform: capitalize;
+  }
+  .g-bar {
+    width: 46px;
+    height: 5px;
+    background: var(--color-line);
+    border: 1px solid var(--color-line-bright);
+    overflow: hidden;
+  }
+  .g-bar-wide {
+    width: 100%;
+    height: 6px;
+  }
+  .gauge-pop-row .g-bar-wide {
+    flex: 1;
+    width: auto;
+    height: 6px;
+  }
+  .g-fill {
+    display: block;
+    width: 100%;
+    height: 100%;
+    transform-origin: left;
+    transition: transform 0.6s ease;
+  }
+  .g-pct {
+    font-size: var(--fs-meta);
+    min-width: 30px;
+    text-align: right;
+  }
+  .gauge-pop-row .g-pct {
+    min-width: 34px;
+  }
+  .gauge-pop-reset {
+    margin: 0 0 6px 30px;
+    text-transform: none;
+    letter-spacing: 0.04em;
+    color: var(--color-faint);
+  }
+  .gauge-pop-reset:last-child {
+    margin-bottom: 0;
+  }
+  .sheet-gauge-row .g-bar-wide {
+    width: 100%;
+    height: 6px;
+  }
+  .sheet-gauge-row .gauge-pop-reset {
+    margin: 0 0 6px;
+  }
+  .micro {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+</style>

--- a/ui/src/lib/components/top-bar/TopBarMobileSheet.svelte
+++ b/ui/src/lib/components/top-bar/TopBarMobileSheet.svelte
@@ -11,9 +11,10 @@
   import { theme, type ThemePref } from "$lib/theme.svelte";
   import ThemeIcon from "$lib/components/ThemeIcon.svelte";
   import CreditDetail from "./CreditDetail.svelte";
+  import LimitGaugeRow from "./LimitGaugeRow.svelte";
   import ModelWeekGauge from "../usage/ModelWeekGauge.svelte";
-  import { gaugeColor, codexGaugeList } from "../usage-gauges";
-  import { formatResetIn, formatReset, formatTokenLabel } from "$lib/format";
+  import { codexGaugeList } from "../usage-gauges";
+  import { formatTokenLabel } from "$lib/format";
   import { REPO_URL, DOCS_URL, version } from "$lib/build-info";
   import type { FeedbackKind } from "$lib/feedback-link";
   import { fly } from "svelte/transition";
@@ -122,7 +123,7 @@
   } = $props();
 
   // Codex's own 5h/weekly rate-limit windows as Claude-style gauges, so both CLIs read alike.
-  // Empty until Codex logs a rate-limit event (then only the raw token counts show).
+  // Empty when Shepherd cannot find a rate-limit event in Codex rollouts.
   const codexWindows = $derived(codexGaugeList(codexUsage));
 </script>
 
@@ -193,28 +194,10 @@
       {:else}
         <div class="sheet-gauges {stale ? 'stale' : ''}">
           {#each gauges as g (g.label)}
-            <div class="sheet-gauge-row">
-              <div class="sheet-gauge-head">
-                <span class="gp-period">{periodLabel(g.label)}</span>
-                <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
-              </div>
-              <span class="g-bar g-bar-wide"
-                ><span
-                  class="g-fill"
-                  style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) /
-                    100});background:{gaugeColor(g.w.pct)}"
-                ></span></span
-              >
-              <div class="gauge-pop-reset micro">
-                {m.topbar_gauge_reset_rel({
-                  rel: formatResetIn(g.w.resetAt, nowMs),
-                  abs: formatReset(g.w.resetAt, nowMs),
-                })}
-              </div>
-            </div>
+            <LimitGaugeRow label={periodLabel(g.label)} limit={g.w} {nowMs} />
           {/each}
           {#each perModel as entry (entry.model)}
-            <div class="sheet-gauge-row">
+            <div class="sheet-model-row">
               <ModelWeekGauge {entry} {nowMs} />
             </div>
           {/each}
@@ -230,31 +213,16 @@
           />
           {#if codexUsage}
             <div class="sheet-token-row" class:stale={codexUsage.stale}>
-              <div class="sheet-gauge-head">
-                <span class="gp-period">{m.agent_provider_codex()}</span>
+              <div class="token-head">
+                <span class="token-provider">{m.agent_provider_codex()}</span>
                 <span class="token-total">{formatTokenLabel(codexUsage.totalTokens)}</span>
               </div>
               {#each codexWindows as g (g.label)}
-                <div class="sheet-gauge-row">
-                  <div class="sheet-gauge-head">
-                    <span class="gp-period">{periodLabel(g.label)}</span>
-                    <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
-                  </div>
-                  <span class="g-bar g-bar-wide"
-                    ><span
-                      class="g-fill"
-                      style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) /
-                        100});background:{gaugeColor(g.w.pct)}"
-                    ></span></span
-                  >
-                  <div class="gauge-pop-reset micro">
-                    {m.topbar_gauge_reset_rel({
-                      rel: formatResetIn(g.w.resetAt, nowMs),
-                      abs: formatReset(g.w.resetAt, nowMs),
-                    })}
-                  </div>
-                </div>
+                <LimitGaugeRow label={periodLabel(g.label)} limit={g.w} {nowMs} />
               {/each}
+              {#if codexWindows.length === 0}
+                <div class="limits-unavailable micro">{m.topbar_codex_limits_unavailable()}</div>
+              {/if}
               <div class="token-line">
                 <span>{m.topbar_tokens_window({ period: "5H" })}</span>
                 <span>{formatTokenLabel(codexUsage.session5hTokens)}</span>
@@ -597,17 +565,7 @@
   .sheet-gauges.stale {
     opacity: 0.5;
   }
-  .sheet-gauge-row {
-    display: flex;
-    flex-direction: column;
-    gap: 5px;
-  }
-  .sheet-gauge-head {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    font-variant-numeric: tabular-nums;
-  }
+  .sheet-model-row,
   .sheet-token-row {
     display: flex;
     flex-direction: column;
@@ -617,6 +575,25 @@
   }
   .sheet-token-row.stale {
     opacity: 0.5;
+  }
+  .token-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    font-variant-numeric: tabular-nums;
+  }
+  .token-provider {
+    color: var(--color-text);
+    font-size: var(--fs-meta);
+    text-transform: capitalize;
+  }
+  .limits-unavailable {
+    padding: 6px 0;
+    border-top: 1px solid var(--color-line);
+    border-bottom: 1px solid var(--color-line);
+    color: var(--color-faint);
+    letter-spacing: 0.08em;
+    line-height: 1.35;
   }
   .token-total,
   .token-line {
@@ -786,51 +763,6 @@
     height: var(--fs-lg);
     display: block;
     flex-shrink: 0;
-  }
-  /* Base gauge classes used by the usage section in this sheet. */
-  .g-bar {
-    width: 46px;
-    height: 5px;
-    background: var(--color-line);
-    border: 1px solid var(--color-line-bright);
-    overflow: hidden;
-  }
-  .g-fill {
-    display: block;
-    width: 100%;
-    height: 100%;
-    transform-origin: left;
-    transition: transform 0.6s ease;
-  }
-  .g-pct {
-    font-size: var(--fs-meta);
-    min-width: 30px;
-    text-align: right;
-  }
-  .g-bar-wide {
-    width: 100%;
-    height: 6px;
-  }
-  .gauge-pop-reset {
-    margin: 0 0 6px 30px;
-    text-transform: none;
-    letter-spacing: 0.04em;
-    color: var(--color-faint);
-  }
-  .gauge-pop-reset:last-child {
-    margin-bottom: 0;
-  }
-  .gp-period {
-    color: var(--color-text);
-    font-size: var(--fs-meta);
-    text-transform: capitalize;
-  }
-  .sheet-gauge-row .g-bar-wide {
-    width: 100%;
-    height: 6px;
-  }
-  .sheet-gauge-row .gauge-pop-reset {
-    margin: 0;
   }
   .micro {
     font-size: var(--fs-meta);

--- a/ui/src/lib/components/top-bar/TopBarMobileSheet.svelte
+++ b/ui/src/lib/components/top-bar/TopBarMobileSheet.svelte
@@ -12,7 +12,7 @@
   import ThemeIcon from "$lib/components/ThemeIcon.svelte";
   import CreditDetail from "./CreditDetail.svelte";
   import ModelWeekGauge from "../usage/ModelWeekGauge.svelte";
-  import { gaugeColor } from "../usage-gauges";
+  import { gaugeColor, codexGaugeList } from "../usage-gauges";
   import { formatResetIn, formatReset, formatTokenLabel } from "$lib/format";
   import { REPO_URL, DOCS_URL, version } from "$lib/build-info";
   import type { FeedbackKind } from "$lib/feedback-link";
@@ -120,6 +120,10 @@
     pluginItems?: { id: string; label: string; icon?: string }[];
     onPluginItem?: (id: string) => void;
   } = $props();
+
+  // Codex's own 5h/weekly rate-limit windows as Claude-style gauges, so both CLIs read alike.
+  // Empty until Codex logs a rate-limit event (then only the raw token counts show).
+  const codexWindows = $derived(codexGaugeList(codexUsage));
 </script>
 
 <!-- Blur backdrop behind the opened mobile bottom sheet, so the panel reads as the focus
@@ -230,6 +234,27 @@
                 <span class="gp-period">{m.agent_provider_codex()}</span>
                 <span class="token-total">{formatTokenLabel(codexUsage.totalTokens)}</span>
               </div>
+              {#each codexWindows as g (g.label)}
+                <div class="sheet-gauge-row">
+                  <div class="sheet-gauge-head">
+                    <span class="gp-period">{periodLabel(g.label)}</span>
+                    <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
+                  </div>
+                  <span class="g-bar g-bar-wide"
+                    ><span
+                      class="g-fill"
+                      style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) /
+                        100});background:{gaugeColor(g.w.pct)}"
+                    ></span></span
+                  >
+                  <div class="gauge-pop-reset micro">
+                    {m.topbar_gauge_reset_rel({
+                      rel: formatResetIn(g.w.resetAt, nowMs),
+                      abs: formatReset(g.w.resetAt, nowMs),
+                    })}
+                  </div>
+                </div>
+              {/each}
               <div class="token-line">
                 <span>{m.topbar_tokens_window({ period: "5H" })}</span>
                 <span>{formatTokenLabel(codexUsage.session5hTokens)}</span>

--- a/ui/src/lib/components/top-bar/TopBarUsagePopover.svelte
+++ b/ui/src/lib/components/top-bar/TopBarUsagePopover.svelte
@@ -140,7 +140,7 @@
   {/if}
   {#if codexUsage}
     <div class="gp-window token-window" class:stale={codexUsage.stale}>
-      <CodexTokenDetail usage={codexUsage} />
+      <CodexTokenDetail usage={codexUsage} {nowMs} {periodLabel} />
     </div>
   {/if}
   <button type="button" class="gauge-pop-link" aria-haspopup="dialog" onclick={onOpenUsage}>

--- a/ui/src/lib/components/top-bar/TopBarUsagePopover.svelte
+++ b/ui/src/lib/components/top-bar/TopBarUsagePopover.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { dialog } from "$lib/a11yDialog";
-  import { formatResetIn, formatReset } from "$lib/format";
   import { m } from "$lib/paraglide/messages";
   import type { CreditWindow, ModelWeekWindow, UsageProviderSnapshot } from "$lib/types";
-  import { gaugeColor, type GaugeKey } from "../usage-gauges";
+  import { type GaugeKey } from "../usage-gauges";
   import type { Gauge } from "../usage-gauges";
   import CodexTokenDetail from "./CodexTokenDetail.svelte";
   import CreditDetail from "./CreditDetail.svelte";
+  import LimitGaugeRow from "./LimitGaugeRow.svelte";
   import ModelWeekGauge from "../usage/ModelWeekGauge.svelte";
 
   let {
@@ -64,23 +64,7 @@
   {#if desktop}
     {#each gauges as g (g.label)}
       <div class="gp-window">
-        <div class="gp-head">
-          <span class="gp-period">{periodLabel(g.label)}</span>
-          <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
-        </div>
-        <span class="g-bar g-bar-wide"
-          ><span
-            class="g-fill"
-            style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) /
-              100});background:{gaugeColor(g.w.pct)}"
-          ></span></span
-        >
-        <div class="gauge-pop-reset micro">
-          {m.topbar_gauge_reset_rel({
-            rel: formatResetIn(g.w.resetAt, nowMs),
-            abs: formatReset(g.w.resetAt, nowMs),
-          })}
-        </div>
+        <LimitGaugeRow label={periodLabel(g.label)} limit={g.w} {nowMs} />
       </div>
     {/each}
     {#each perModel as entry (entry.model)}
@@ -104,23 +88,7 @@
     {/if}
   {:else}
     {#each gauges as g (g.label)}
-      <div class="gauge-pop-row">
-        <span class="g-label micro">{g.label}</span>
-        <span class="g-bar g-bar-wide"
-          ><span
-            class="g-fill"
-            style="transform:scaleX({Math.min(Math.max(g.w.pct, 0), 100) /
-              100});background:{gaugeColor(g.w.pct)}"
-          ></span></span
-        >
-        <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
-      </div>
-      <div class="gauge-pop-reset micro">
-        {m.topbar_gauge_reset_rel({
-          rel: formatResetIn(g.w.resetAt, nowMs),
-          abs: formatReset(g.w.resetAt, nowMs),
-        })}
-      </div>
+      <LimitGaugeRow label={g.label} limit={g.w} {nowMs} inline />
     {/each}
     {#each perModel as entry (entry.model)}
       <div class="gauge-pop-row-model">
@@ -171,29 +139,6 @@
   .gauge-pop-title {
     margin-bottom: 6px;
   }
-  .gauge-pop-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-variant-numeric: tabular-nums;
-  }
-  .gauge-pop-row .g-bar-wide {
-    flex: 1;
-    width: auto;
-    height: 6px;
-  }
-  .gauge-pop-row .g-pct {
-    min-width: 34px;
-  }
-  .gauge-pop-reset {
-    margin: 0 0 6px 30px;
-    text-transform: none;
-    letter-spacing: 0.04em;
-    color: var(--color-faint);
-  }
-  .gauge-pop-reset:last-child {
-    margin-bottom: 0;
-  }
   .gauge-pop-row-model {
     margin-bottom: 6px;
   }
@@ -229,48 +174,8 @@
     padding-top: 10px;
     border-top: 1px solid var(--color-line);
   }
-  .gp-head {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    font-variant-numeric: tabular-nums;
-  }
-  .gp-period {
-    color: var(--color-text);
-    font-size: var(--fs-meta);
-    text-transform: capitalize;
-  }
   .token-window.stale {
     opacity: 0.5;
-  }
-  .gauge-pop-desk .g-bar-wide {
-    width: 100%;
-    height: 6px;
-  }
-  .gauge-pop-desk .gauge-pop-reset {
-    margin: 0;
-  }
-  .g-label {
-    color: var(--color-muted);
-  }
-  .g-bar {
-    width: 46px;
-    height: 5px;
-    background: var(--color-line);
-    border: 1px solid var(--color-line-bright);
-    overflow: hidden;
-  }
-  .g-fill {
-    display: block;
-    width: 100%;
-    height: 100%;
-    transform-origin: left;
-    transition: transform 0.6s ease;
-  }
-  .g-pct {
-    font-size: var(--fs-meta);
-    min-width: 30px;
-    text-align: right;
   }
   .micro {
     font-size: var(--fs-meta);

--- a/ui/src/lib/components/usage-gauges.test.ts
+++ b/ui/src/lib/components/usage-gauges.test.ts
@@ -92,6 +92,8 @@ describe("providerSnapshots", () => {
           weekTokens: 9_000,
           updatedAt: 123,
           stale: false,
+          session5h: null,
+          week: null,
         },
       ],
     });

--- a/ui/src/lib/components/usage-gauges.ts
+++ b/ui/src/lib/components/usage-gauges.ts
@@ -16,6 +16,18 @@ export function gaugeList(limits: UsageLimits | null): Gauge[] {
   return out;
 }
 
+type CodexTokenSnapshot = Extract<UsageProviderSnapshot, { provider: "codex"; kind: "tokens" }>;
+
+/** Codex's 5H/WK rate-limit windows as gauges, in display order — the same shape `gaugeList`
+ *  produces for Claude so both render identically. Empty until Codex logs a rate-limit event. */
+export function codexGaugeList(usage: CodexTokenSnapshot | null): Gauge[] {
+  if (!usage) return [];
+  const out: Gauge[] = [];
+  if (usage.session5h) out.push({ label: "5H", w: usage.session5h });
+  if (usage.week) out.push({ label: "WK", w: usage.week });
+  return out;
+}
+
 export function providerSnapshots(limits: UsageLimits | null): UsageProviderSnapshot[] {
   if (!limits) return [];
   if (limits.providers?.length) return limits.providers;

--- a/ui/src/lib/feature-announcements/entries/v1.39.0-codex-usage-gauges.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.39.0-codex-usage-gauges.ts
@@ -1,0 +1,12 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // No targetId: the gauges live inside the usage popover (opened from the topbar usage
+  // button), not a persistently-mounted anchor — surface via the What's-New drawer only.
+  id: "codex-usage-gauges",
+  sinceVersion: "1.39.0",
+  titleKey: "feat_codex_usage_gauges_title",
+  bodyKey: "feat_codex_usage_gauges_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/feature-announcements/entries/v1.42.0-codex-usage-gauges.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.42.0-codex-usage-gauges.ts
@@ -4,7 +4,7 @@ const entry = {
   // No targetId: the gauges live inside the usage popover (opened from the topbar usage
   // button), not a persistently-mounted anchor — surface via the What's-New drawer only.
   id: "codex-usage-gauges",
-  sinceVersion: "1.39.0",
+  sinceVersion: "1.42.0",
   titleKey: "feat_codex_usage_gauges_title",
   bodyKey: "feat_codex_usage_gauges_body",
 } satisfies FeatureAnnouncement;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -982,6 +982,10 @@ export type UsageProviderSnapshot =
       weekTokens: number;
       updatedAt: number | null;
       stale: boolean;
+      /** 5h/weekly used-% + reset scraped from Codex's own session rollout logs; null when no
+       *  rate-limit event has been logged yet (UI then shows just the raw token counts). */
+      session5h: LimitWindow | null;
+      week: LimitWindow | null;
     };
 
 export type UsageRange = "24h" | "7d" | "30d" | "all";

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -986,6 +986,10 @@ export type UsageProviderSnapshot =
        *  rate-limit event has been logged yet (UI then shows just the raw token counts). */
       session5h: LimitWindow | null;
       week: LimitWindow | null;
+      rateLimitSource?: "rollout" | "missing";
+      rateLimitCheckedAt?: number;
+      rateLimitFilesScanned?: number;
+      rateLimitLatestEventAt?: number | null;
     };
 
 export type UsageRange = "24h" | "7d" | "30d" | "all";


### PR DESCRIPTION
## Why

In the topbar usage popover, **Claude** shows 5-hour and weekly usage as percentage **bars + reset times**, but **Codex** only showed raw token counts — so you couldn't compare the two CLIs at a glance or see how much headroom each has left.

## What

Codex already logs its own rate limits to its session rollout files — each turn appends a `token_count` event carrying `rate_limits.primary` (5h) and `.secondary` (weekly) with `used_percent` + `resets_at`, exactly mirroring Claude's `{pct, resetAt}`. This reads the freshest reading and renders it as the same gauges.

- **`src/codex-usage.ts`** — parse `rate_limits` from the most recent OpenAI rollout JSONL (newest-first, with a small fan-out for a brand-new session that hasn't logged one yet). The read is **mtime-cached** because rollouts reach several MB and `snapshot()` runs on every usage recompute. The codex snapshot now carries `session5h` / `week` `LimitWindow`s.
- **`TopBarUsagePopover` + mobile sheet** — render Codex's 5h/weekly **bars + % + reset** matching Claude; the raw token counts stay below as supplementary detail.
- **Graceful fallback** — when no rate-limit reading exists yet, it shows token-only (the previous behavior).

Verified against real local Codex data: produces `session5h 5%` / `week 2%` with correct reset times.

## Tests / checks
- `bun test ./test/codex-usage.test.ts` — 8 pass (new: rollout parse, file-scan skip, provider end-to-end merge)
- `bun run lint`, `ui: bun run check`, `check:i18n` (2 locales in parity), affected vitest suites (TopBar/Usage browser, usage-gauges) all green
- Feature-announcements catalog entry + EN/DE keys added (`codex-usage-gauges`)



Closes #1160 — Codex usage/headroom is now surfaced in the topbar (per the triage decision; the residual per-session cached-token accounting in `usage.ts` was judged low-value).
