### PR TITLE
feat(usage): surface GitHub REST + GraphQL rate limits

### DIFF
--- a/src/forge/github-rate-limit.ts
+++ b/src/forge/github-rate-limit.ts
@@ -1,0 +1,106 @@
+/**
+ * Live GitHub rate-limit readings for Shepherd's usage view.
+ *
+ * GitHub maintains *separate* hourly buckets for its REST API (`resources.core`,
+ * used by `gh run` and `gh api <rest-path>`) and its GraphQL API
+ * (`resources.graphql`, used by `gh pr`/`issue`/`repo`/`search` and the backlog
+ * counts query). When the GraphQL bucket is exhausted, PR/issue polling silently
+ * stops while REST-backed actions keep working — confusing unless the two budgets
+ * are shown apart.
+ *
+ * `gh api rate_limit` returns every bucket in one call and — crucially — does
+ * **not** itself count against any bucket, so we can poll it for display even
+ * while a bucket is at zero. We pair the live readings with Shepherd's own
+ * GraphQL backoff state ({@link graphRateLimit}) so the UI can explain *why*
+ * polling is paused, not just that a budget is low.
+ */
+
+import { graphRateLimit, type RateLimitSnapshot } from "./rate-limit";
+
+/** A single GitHub rate-limit bucket (REST core / GraphQL / search). */
+export interface GhRateBucket {
+  /** Per-hour ceiling for this bucket. */
+  limit: number;
+  /** Points/requests consumed this window. */
+  used: number;
+  /** Points/requests left this window. */
+  remaining: number;
+  /** Epoch-ms timestamp at which the bucket refills. */
+  resetAt: number;
+}
+
+/** Snapshot of the GitHub rate-limit buckets relevant to Shepherd, plus the
+ *  GraphQL backoff state that gates background polling. */
+export interface GithubRateLimitPayload {
+  /** REST bucket (`resources.core`). Null if the response lacked it. */
+  rest: GhRateBucket | null;
+  /** GraphQL bucket (`resources.graphql`). Null if the response lacked it. */
+  graphql: GhRateBucket | null;
+  /** Search bucket (`resources.search`). Null if the response lacked it. */
+  search: GhRateBucket | null;
+  /** Epoch-ms when these readings were fetched. */
+  fetchedAt: number;
+  /** Shepherd's GraphQL backoff state — non-null `pausedUntil`/`blocked`
+   *  explains a polling pause even before a bucket is fully empty. */
+  backoff: RateLimitSnapshot;
+}
+
+type GhRun = (args: string[]) => Promise<string>;
+
+/** Short TTL so repeated UI opens / refresh clicks don't spawn a `gh` subprocess
+ *  per request. `gh api rate_limit` is quota-exempt, so this is purely to bound
+ *  subprocess churn, not to conserve budget. */
+const TTL_MS = 15_000;
+
+let cache: { at: number; payload: GithubRateLimitPayload } | null = null;
+
+/** Parse one `resources.<name>` object into a bucket, tolerating missing fields. */
+function parseBucket(raw: unknown): GhRateBucket | null {
+  const b = raw as Record<string, unknown> | undefined;
+  if (!b || typeof b.remaining !== "number") return null;
+  return {
+    limit: typeof b.limit === "number" ? b.limit : 0,
+    used: typeof b.used === "number" ? b.used : 0,
+    remaining: b.remaining,
+    // GitHub returns `reset` as epoch *seconds*; surface epoch-ms for the UI.
+    resetAt: typeof b.reset === "number" ? b.reset * 1_000 : 0,
+  };
+}
+
+/**
+ * Fetch the current GitHub REST + GraphQL + search rate-limit buckets via
+ * `gh api rate_limit`, cached for {@link TTL_MS}. The GraphQL backoff snapshot is
+ * always read live (it's free). Throws if `gh` fails or returns unparseable JSON.
+ *
+ * @param run  injected `gh` runner (production passes the shared async runner).
+ * @param now  injectable clock for deterministic tests.
+ */
+export async function fetchGithubRateLimit(
+  run: GhRun,
+  now: () => number = () => Date.now(),
+): Promise<GithubRateLimitPayload> {
+  const t = now();
+  if (cache && t - cache.at < TTL_MS) {
+    // Refresh only the (free) backoff view so a cached buckets reading still
+    // reflects a backoff that engaged since the last `gh` call.
+    return { ...cache.payload, backoff: graphRateLimit.snapshot() };
+  }
+
+  const out = await run(["api", "rate_limit"]);
+  const json = JSON.parse(out) as { resources?: Record<string, unknown> };
+  const r = json.resources ?? {};
+  const payload: GithubRateLimitPayload = {
+    rest: parseBucket(r.core),
+    graphql: parseBucket(r.graphql),
+    search: parseBucket(r.search),
+    fetchedAt: t,
+    backoff: graphRateLimit.snapshot(),
+  };
+  cache = { at: t, payload };
+  return payload;
+}
+
+/** Test-only: drop the module cache so each case starts cold. */
+export function __resetGithubRateLimitCache(): void {
+  cache = null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,6 +150,7 @@ import {
   isRateLimitError,
   parseRetryAfter,
 } from "./forge/rate-limit";
+import { fetchGithubRateLimit } from "./forge/github-rate-limit";
 
 const execFileAsync = promisify(execFile);
 
@@ -2067,6 +2068,9 @@ const appDeps: AppDeps = {
   usageLimits,
   usageRollup,
   refreshUsage,
+  // Live GitHub REST + GraphQL buckets for the usage view. `gh api rate_limit`
+  // is quota-exempt, so it works even when the GraphQL bucket is at zero.
+  githubRateLimit: () => fetchGithubRateLimit(ghRunnerAsync),
   updates,
   herdrUpdates,
   codexUpdates,

--- a/src/server.ts
+++ b/src/server.ts
@@ -103,6 +103,7 @@ import { matchAgent } from "./herdr";
 import type { GitForge, GitState, MergeMethod, PrStatus, WorkflowRun } from "./forge/types";
 import { DEPENDABOT_REBASE_COMMAND, EmptyDiffError } from "./forge/types";
 import { buildIssueUrl } from "./forge";
+import type { GithubRateLimitPayload } from "./forge/github-rate-limit";
 import { BaseCheckoutBusyError, MergeConflictError } from "./forge/local";
 import { settleMergedSession } from "./merge-teardown";
 import { type PrCache, guardStaleTerminal, trustsTerminal } from "./pr-poller";
@@ -209,6 +210,9 @@ export interface AppDeps {
   refreshUsage?: () => Promise<{ limits: UsageLimits; scraped: boolean }>;
   /** Incremental per-session rollup; absent in tests → breakdown falls back to re-parsing JSONL. */
   usageRollup?: SessionUsageRollup;
+  /** Live GitHub REST + GraphQL rate-limit buckets (via `gh api rate_limit`, which is
+   *  itself quota-exempt); absent in tests → `/api/usage/github` 503s. */
+  githubRateLimit?: () => Promise<GithubRateLimitPayload>;
   /** Resolve the git forge for a repo dir; null when none is configured. */
   resolveForge?: (repoDir: string) => GitForge | null;
   /** Self-update tracker; absent in environments where it isn't wired. */
@@ -2946,6 +2950,19 @@ async function handleSessionGit(ctx: Ctx): Promise<Response | null> {
   }
 }
 
+/** GET /api/usage/github — live REST + GraphQL rate-limit buckets. Extracted so the
+ *  unavailable/try-catch branches don't inflate handleUsageLimits's complexity. */
+async function githubRateLimitResponse(deps: AppDeps): Promise<Response> {
+  if (!deps.githubRateLimit) {
+    return json({ error: "github rate limit unavailable" }, 503);
+  }
+  try {
+    return json(await deps.githubRateLimit());
+  } catch (e) {
+    return json({ error: e instanceof Error ? e.message : "github rate limit error" }, 502);
+  }
+}
+
 async function handleUsageLimits({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (
     req.method === "POST" &&
@@ -2971,6 +2988,9 @@ async function handleUsageLimits({ req, parts, deps }: Ctx): Promise<Response | 
       limits: deps.usageLimits.limits(now),
       projections: deps.usageLimits.projections(now),
     });
+  }
+  if (req.method === "GET" && parts[0] === "api" && parts[1] === "usage" && parts[2] === "github") {
+    return githubRateLimitResponse(deps);
   }
   if (
     req.method === "GET" &&

--- a/test/github-rate-limit.test.ts
+++ b/test/github-rate-limit.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for src/forge/github-rate-limit.ts — live `gh api rate_limit` parsing,
+ * TTL caching, and bucket extraction.
+ *
+ * A deterministic clock (`now`) is injected so the TTL window is testable without
+ * wall-clock dependence. The module cache is reset before each test.
+ */
+import { describe, it, expect, beforeEach } from "bun:test";
+import { fetchGithubRateLimit, __resetGithubRateLimitCache } from "../src/forge/github-rate-limit";
+
+// A trimmed but realistic `gh api rate_limit` payload (epoch *seconds* for reset).
+const SAMPLE = JSON.stringify({
+  resources: {
+    core: { limit: 5000, used: 173, remaining: 4827, reset: 1782756461 },
+    graphql: { limit: 5000, used: 5002, remaining: 0, reset: 1782756188 },
+    search: { limit: 30, used: 0, remaining: 30, reset: 1782755499 },
+    integration_manifest: { limit: 5000, used: 0, remaining: 5000, reset: 1 },
+  },
+  rate: { limit: 5000, used: 173, remaining: 4827, reset: 1782756461 },
+});
+
+beforeEach(() => __resetGithubRateLimitCache());
+
+describe("fetchGithubRateLimit — parsing", () => {
+  it("extracts REST/core, GraphQL and search buckets with reset in epoch-ms", async () => {
+    const out = await fetchGithubRateLimit(
+      async () => SAMPLE,
+      () => 1000,
+    );
+    expect(out.rest).toEqual({ limit: 5000, used: 173, remaining: 4827, resetAt: 1782756461000 });
+    expect(out.graphql).toEqual({ limit: 5000, used: 5002, remaining: 0, resetAt: 1782756188000 });
+    expect(out.search).toEqual({ limit: 30, used: 0, remaining: 30, resetAt: 1782755499000 });
+    expect(out.fetchedAt).toBe(1000);
+  });
+
+  it("includes the GraphQL backoff snapshot", async () => {
+    const out = await fetchGithubRateLimit(
+      async () => SAMPLE,
+      () => 1000,
+    );
+    expect(out.backoff).toHaveProperty("blocked");
+    expect(out.backoff).toHaveProperty("remaining");
+  });
+
+  it("returns null buckets when resources are absent", async () => {
+    const out = await fetchGithubRateLimit(
+      async () => JSON.stringify({ resources: {} }),
+      () => 1000,
+    );
+    expect(out.rest).toBeNull();
+    expect(out.graphql).toBeNull();
+    expect(out.search).toBeNull();
+  });
+});
+
+describe("fetchGithubRateLimit — caching", () => {
+  it("serves a cached reading inside the TTL window (no second gh call)", async () => {
+    let calls = 0;
+    const run = async () => {
+      calls++;
+      return SAMPLE;
+    };
+    await fetchGithubRateLimit(run, () => 1000);
+    await fetchGithubRateLimit(run, () => 1000 + 5_000); // within 15s TTL
+    expect(calls).toBe(1);
+  });
+
+  it("re-fetches once the TTL has elapsed", async () => {
+    let calls = 0;
+    const run = async () => {
+      calls++;
+      return SAMPLE;
+    };
+    await fetchGithubRateLimit(run, () => 1000);
+    await fetchGithubRateLimit(run, () => 1000 + 20_000); // past 15s TTL
+    expect(calls).toBe(2);
+  });
+
+  it("propagates a gh failure (no stale cache to fall back on)", async () => {
+    await expect(
+      fetchGithubRateLimit(
+        async () => {
+          throw new Error("gh boom");
+        },
+        () => 1000,
+      ),
+    ).rejects.toThrow("gh boom");
+  });
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2186,5 +2186,6 @@
   "github_lens_no_data": "GitHub-Rate-Limit-Daten nicht verfügbar.",
   "feat_github_rate_limits_title": "GitHub-Rate-Limits im Verbrauch",
   "feat_github_rate_limits_body": "Die Verbrauchsansicht hat einen neuen GitHub-Tab, der dein REST- und GraphQL-API-Kontingent getrennt zeigt. Ist eines erschöpft, erklärt er, welche Funktionen bis zum Reset pausieren — ein leeres GraphQL-Kontingent wirkt so nicht mehr wie ein stiller Defekt.",
-  "github_lens_paused": "Pausiert"
+  "github_lens_paused": "Pausiert",
+  "github_lens_graphql_backoff": "GraphQL-Polling pausiert, während ein Rate-Limit-Backoff abklingt — PR-, Issue- und Backlog-Updates laufen in ~{time} weiter."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2171,5 +2171,19 @@
   "taskid_copy_payload": "{label} — Shepherd-Task · Repo: {repoPath} · Branch: {branch} · Worktree: {worktreePath}",
   "feat_taskid_copy_payload_title": "„ID kopieren“ trägt jetzt die Task-Details",
   "feat_taskid_copy_payload_body": "Beim Kopieren einer Task-ID landen jetzt zusätzlich Repo, Branch und Worktree-Pfad in der Zwischenablage. Fügst du sie in einen Coding-Agenten ein, weiß er sofort, worum es bei der Task geht und wo ihre Arbeit liegt — ohne Nachschlagen, ohne verschwendete Tokens.",
-  "taskid_copy_payload_inrepo": "{label} — Shepherd-Task · Repo: {repoPath} · Branch: {branch}"
+  "taskid_copy_payload_inrepo": "{label} — Shepherd-Task · Repo: {repoPath} · Branch: {branch}",
+  "usage_github_tab": "GitHub",
+  "github_lens_intro": "GitHub begrenzt REST- und GraphQL-Zugriffe in getrennten Stundenkontingenten. Ist eines aufgebraucht, pausieren die davon abhängigen Funktionen bis zum Reset — das andere arbeitet weiter.",
+  "github_lens_rest_label": "REST-API",
+  "github_lens_rest_desc": "CI-Status, Merges, Run-Logs",
+  "github_lens_graphql_label": "GraphQL-API",
+  "github_lens_graphql_desc": "PR-, Issue- & Backlog-Updates",
+  "github_lens_search_label": "Suche",
+  "github_lens_search_desc": "Issue- & Code-Suche",
+  "github_lens_exhausted": "Erschöpft",
+  "github_lens_graphql_paused": "GraphQL-Kontingent erschöpft — PR-, Issue- und Backlog-Updates pausieren noch ~{time}.",
+  "github_lens_rest_paused": "REST-Kontingent erschöpft — CI-Status und Merge-Aktionen pausieren noch ~{time}.",
+  "github_lens_no_data": "GitHub-Rate-Limit-Daten nicht verfügbar.",
+  "feat_github_rate_limits_title": "GitHub-Rate-Limits im Verbrauch",
+  "feat_github_rate_limits_body": "Die Verbrauchsansicht hat einen neuen GitHub-Tab, der dein REST- und GraphQL-API-Kontingent getrennt zeigt. Ist eines erschöpft, erklärt er, welche Funktionen bis zum Reset pausieren — ein leeres GraphQL-Kontingent wirkt so nicht mehr wie ein stiller Defekt."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2185,5 +2185,6 @@
   "github_lens_rest_paused": "REST-Kontingent erschöpft — CI-Status und Merge-Aktionen pausieren noch ~{time}.",
   "github_lens_no_data": "GitHub-Rate-Limit-Daten nicht verfügbar.",
   "feat_github_rate_limits_title": "GitHub-Rate-Limits im Verbrauch",
-  "feat_github_rate_limits_body": "Die Verbrauchsansicht hat einen neuen GitHub-Tab, der dein REST- und GraphQL-API-Kontingent getrennt zeigt. Ist eines erschöpft, erklärt er, welche Funktionen bis zum Reset pausieren — ein leeres GraphQL-Kontingent wirkt so nicht mehr wie ein stiller Defekt."
+  "feat_github_rate_limits_body": "Die Verbrauchsansicht hat einen neuen GitHub-Tab, der dein REST- und GraphQL-API-Kontingent getrennt zeigt. Ist eines erschöpft, erklärt er, welche Funktionen bis zum Reset pausieren — ein leeres GraphQL-Kontingent wirkt so nicht mehr wie ein stiller Defekt.",
+  "github_lens_paused": "Pausiert"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2185,5 +2185,6 @@
   "github_lens_rest_paused": "REST budget exhausted — CI status and merge actions are paused for ~{time}.",
   "github_lens_no_data": "GitHub rate-limit data unavailable.",
   "feat_github_rate_limits_title": "GitHub rate limits in Usage",
-  "feat_github_rate_limits_body": "The Usage view has a new GitHub tab showing your REST and GraphQL API budgets separately. When one is exhausted it explains which features pause until reset — so an empty GraphQL budget no longer looks like a silent breakage."
+  "feat_github_rate_limits_body": "The Usage view has a new GitHub tab showing your REST and GraphQL API budgets separately. When one is exhausted it explains which features pause until reset — so an empty GraphQL budget no longer looks like a silent breakage.",
+  "github_lens_paused": "Paused"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2186,5 +2186,6 @@
   "github_lens_no_data": "GitHub rate-limit data unavailable.",
   "feat_github_rate_limits_title": "GitHub rate limits in Usage",
   "feat_github_rate_limits_body": "The Usage view has a new GitHub tab showing your REST and GraphQL API budgets separately. When one is exhausted it explains which features pause until reset — so an empty GraphQL budget no longer looks like a silent breakage.",
-  "github_lens_paused": "Paused"
+  "github_lens_paused": "Paused",
+  "github_lens_graphql_backoff": "GraphQL polling is paused while a rate-limit backoff clears — PR, issue and backlog updates resume in ~{time}."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2171,5 +2171,19 @@
   "taskid_copy_payload": "{label} — Shepherd task · repo: {repoPath} · branch: {branch} · worktree: {worktreePath}",
   "feat_taskid_copy_payload_title": "Copy ID now carries the task's details",
   "feat_taskid_copy_payload_body": "Copying a task ID now puts its repo, branch and worktree path on the clipboard alongside the id. Paste it into a coding agent and it knows exactly what the task is and where its work lives — no lookup, no wasted tokens researching.",
-  "taskid_copy_payload_inrepo": "{label} — Shepherd task · repo: {repoPath} · branch: {branch}"
+  "taskid_copy_payload_inrepo": "{label} — Shepherd task · repo: {repoPath} · branch: {branch}",
+  "usage_github_tab": "GitHub",
+  "github_lens_intro": "GitHub limits REST and GraphQL access in separate hourly budgets. When one runs out, the features that depend on it pause until it resets — the other keeps working.",
+  "github_lens_rest_label": "REST API",
+  "github_lens_rest_desc": "CI status, merges, run logs",
+  "github_lens_graphql_label": "GraphQL API",
+  "github_lens_graphql_desc": "PR, issue & backlog updates",
+  "github_lens_search_label": "Search",
+  "github_lens_search_desc": "Issue & code search",
+  "github_lens_exhausted": "Exhausted",
+  "github_lens_graphql_paused": "GraphQL budget exhausted — PR, issue and backlog updates are paused for ~{time}.",
+  "github_lens_rest_paused": "REST budget exhausted — CI status and merge actions are paused for ~{time}.",
+  "github_lens_no_data": "GitHub rate-limit data unavailable.",
+  "feat_github_rate_limits_title": "GitHub rate limits in Usage",
+  "feat_github_rate_limits_body": "The Usage view has a new GitHub tab showing your REST and GraphQL API budgets separately. When one is exhausted it explains which features pause until reset — so an empty GraphQL budget no longer looks like a silent breakage."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   UsageLimitsResponse,
   UsageBreakdown,
   UsageRange,
+  GithubRateLimit,
   GitState,
   PrStatus,
   MergeMethod,
@@ -643,6 +644,12 @@ export async function getUsageBreakdown(range: UsageRange): Promise<UsageBreakdo
 export async function refreshUsage(): Promise<UsageLimits> {
   const r = await fetch("/api/usage/refresh", { method: "POST" });
   if (!r.ok) throw await failed(r, "refresh");
+  return r.json();
+}
+
+export async function getGithubRateLimit(): Promise<GithubRateLimit> {
+  const r = await fetch("/api/usage/github");
+  if (!r.ok) throw await failed(r, "github");
   return r.json();
 }
 

--- a/ui/src/lib/components/Usage.browser.test.ts
+++ b/ui/src/lib/components/Usage.browser.test.ts
@@ -53,6 +53,15 @@ vi.mock("$lib/api", async () => {
     getUsageLimits: vi.fn(() =>
       Promise.resolve({ limits: inlineLimits, projections: inlineProjections }),
     ),
+    getGithubRateLimit: vi.fn(() =>
+      Promise.resolve({
+        rest: { limit: 5000, used: 173, remaining: 4827, resetAt: BASE + H },
+        graphql: { limit: 5000, used: 5002, remaining: 0, resetAt: BASE + H },
+        search: { limit: 30, used: 0, remaining: 30, resetAt: BASE + H },
+        fetchedAt: BASE,
+        backoff: { remaining: 0, resetAt: BASE + H, pausedUntil: BASE + H, blocked: true },
+      }),
+    ),
   };
 });
 
@@ -105,6 +114,26 @@ describe("Usage modal component", () => {
     // Range selector must not be present on the Limits tab
     const rangeGroup = document.querySelector('[role="group"][aria-label]');
     expect(rangeGroup, "range selector hidden on Limits tab").toBeNull();
+  });
+
+  it("clicking the GitHub tab shows REST + GraphQL buckets and the GraphQL-paused banner", async () => {
+    render(Usage, { onclose: vi.fn() });
+
+    const githubBtn = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
+      (b) => b.textContent?.trim() === "GitHub",
+    );
+    expect(githubBtn, "GitHub tab button exists").not.toBeNull();
+
+    githubBtn!.click();
+
+    // Both bucket labels render; the exhausted GraphQL bucket surfaces a paused banner.
+    await expect.element(page.getByText(m.github_lens_rest_label())).toBeInTheDocument();
+    await expect.element(page.getByText(m.github_lens_graphql_label())).toBeInTheDocument();
+    await expect.element(page.getByRole("alert")).toBeInTheDocument();
+
+    // Range selector must not be present on the GitHub tab.
+    const rangeGroup = document.querySelector('[role="group"][aria-label]');
+    expect(rangeGroup, "range selector hidden on GitHub tab").toBeNull();
   });
 
   it("range selector is present on the Spend tab", async () => {

--- a/ui/src/lib/components/Usage.svelte
+++ b/ui/src/lib/components/Usage.svelte
@@ -1,17 +1,24 @@
 <script lang="ts">
-  import type { UsageBreakdown, UsageLimits, UsageProjection, UsageRange } from "$lib/types";
+  import type {
+    UsageBreakdown,
+    UsageLimits,
+    UsageProjection,
+    UsageRange,
+    GithubRateLimit,
+  } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
-  import { getUsageBreakdown, getUsageLimits } from "$lib/api";
+  import { getUsageBreakdown, getUsageLimits, getGithubRateLimit } from "$lib/api";
   import { dialog } from "$lib/a11yDialog";
   import { formatTokenLabel } from "$lib/format";
   import { codexTokenUsage } from "$lib/components/usage-gauges";
   import SpendLens from "$lib/components/usage/SpendLens.svelte";
   import OverheadLens from "$lib/components/usage/OverheadLens.svelte";
   import LimitsLens from "$lib/components/usage/LimitsLens.svelte";
+  import GithubLens from "$lib/components/usage/GithubLens.svelte";
 
   let { onclose }: { onclose?: () => void } = $props();
 
-  type Tab = "spend" | "overhead" | "limits";
+  type Tab = "spend" | "overhead" | "limits" | "github";
 
   let tab = $state<Tab>("spend");
   let range = $state<UsageRange>("7d");
@@ -19,6 +26,8 @@
   let breakdown = $state<UsageBreakdown | null>(null);
   let limits = $state<UsageLimits | null>(null);
   let projections = $state<UsageProjection[]>([]);
+  let github = $state<GithubRateLimit | null>(null);
+  let githubError = $state(false);
   let loading = $state(true);
   let error = $state(false);
   // Limits has its own error track (the Limits tab doesn't use `breakdown`), so a
@@ -40,6 +49,20 @@
   }
   $effect(() => {
     loadLimits();
+  });
+
+  // GitHub rate-limit buckets (range-independent). `github === null && !githubError`
+  // ⇒ still loading.
+  async function loadGithub() {
+    githubError = false;
+    try {
+      github = await getGithubRateLimit();
+    } catch {
+      githubError = true;
+    }
+  }
+  $effect(() => {
+    loadGithub();
   });
 
   // Monotonic token: latest request always wins; stale requests discard their results.
@@ -66,11 +89,33 @@
     loadBreakdown(range);
   });
 
-  // Retry re-fetches BOTH tracks so either failure surface recovers.
+  // Retry re-fetches ALL tracks so any failure surface recovers.
   function retry() {
     loadBreakdown(range);
     loadLimits();
+    loadGithub();
   }
+
+  // Template-state derivations (kept out of the markup to keep the template's
+  // branching shallow). `showRange`: spend/overhead are the only ranged tabs.
+  const showRange = $derived(tab === "spend" || tab === "overhead");
+  const showBreakdownError = $derived(error && showRange);
+  // The active tab has data to render its lens (else we show loading/error chrome).
+  const hasContent = $derived(
+    ((tab === "spend" || tab === "overhead") && !!breakdown) ||
+      (tab === "limits" && !!limits) ||
+      (tab === "github" && !!github),
+  );
+  // No content yet, and the failing fetch for this tab errored (not still loading).
+  // (Spend/Overhead surface their error via the banner above, never inline.)
+  const bodyError = $derived(
+    !hasContent && ((tab === "limits" && limitsError) || (tab === "github" && githubError)),
+  );
+  const bodyLoading = $derived(
+    (showRange && !breakdown && loading) ||
+      (tab === "limits" && !limits && !limitsError) ||
+      (tab === "github" && !github && !githubError),
+  );
 </script>
 
 <div
@@ -117,10 +162,17 @@
         aria-pressed={tab === "limits"}
         onclick={() => (tab = "limits")}>{m.usage_limits_tab()}</button
       >
+      <button
+        type="button"
+        class="seg-btn"
+        class:seg-active={tab === "github"}
+        aria-pressed={tab === "github"}
+        onclick={() => (tab = "github")}>{m.usage_github_tab()}</button
+      >
     </div>
 
     <!-- Range selector (Spend + Overhead only) -->
-    {#if tab !== "limits"}
+    {#if showRange}
       <div class="seg-row range-row" role="group" aria-label={m.usage_range_label()}>
         <button
           type="button"
@@ -176,7 +228,7 @@
       <!-- Breakdown-error banner for the Spend/Overhead tabs. Shown even when a stale
            `breakdown` is still present (a failed range-change refetch) so the user isn't
            silently left on old-range data with no indication the new range failed. -->
-      {#if error && tab !== "limits"}
+      {#if showBreakdownError}
         <div class="usage-error-banner" role="alert">
           <span class="usage-status-line usage-error">{m.usage_load_error()}</span>
           <button type="button" class="gbtn gbtn-secondary" onclick={retry}
@@ -185,25 +237,19 @@
         </div>
       {/if}
 
-      {#if tab === "spend"}
-        {#if breakdown}
-          <SpendLens {breakdown} />
-        {:else if loading}
-          <p class="usage-status-line">{m.common_loading()}</p>
-        {/if}
-      {:else if tab === "overhead"}
-        {#if breakdown}
-          <OverheadLens {breakdown} />
-        {:else if loading}
-          <p class="usage-status-line">{m.common_loading()}</p>
-        {/if}
-      {:else if limits}
+      {#if tab === "spend" && breakdown}
+        <SpendLens {breakdown} />
+      {:else if tab === "overhead" && breakdown}
+        <OverheadLens {breakdown} />
+      {:else if tab === "limits" && limits}
         <LimitsLens {limits} {projections} />
-      {:else if limitsError}
+      {:else if tab === "github" && github}
+        <GithubLens data={github} />
+      {:else if bodyError}
         <p class="usage-status-line usage-error">{m.usage_load_error()}</p>
         <button type="button" class="gbtn gbtn-secondary" onclick={retry}>{m.common_retry()}</button
         >
-      {:else}
+      {:else if bodyLoading}
         <p class="usage-status-line">{m.common_loading()}</p>
       {/if}
     </div>

--- a/ui/src/lib/components/usage/GithubLens.browser.test.ts
+++ b/ui/src/lib/components/usage/GithubLens.browser.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../../app.css";
+import type { GithubRateLimit } from "$lib/types";
+import { m } from "$lib/paraglide/messages";
+import GithubLens from "./GithubLens.svelte";
+
+const BASE = Date.now();
+const H = 3_600_000;
+
+function fixture(over: Partial<GithubRateLimit> = {}): GithubRateLimit {
+  return {
+    rest: { limit: 5000, used: 173, remaining: 4827, resetAt: BASE + H },
+    graphql: { limit: 5000, used: 5002, remaining: 0, resetAt: BASE + H },
+    search: { limit: 30, used: 0, remaining: 30, resetAt: BASE + H },
+    fetchedAt: BASE,
+    backoff: { remaining: 0, resetAt: BASE + H, pausedUntil: BASE + H, blocked: true },
+    ...over,
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("GithubLens", () => {
+  it("renders REST and GraphQL bucket labels", async () => {
+    render(GithubLens, { data: fixture() });
+    await expect.element(page.getByText(m.github_lens_rest_label())).toBeInTheDocument();
+    await expect.element(page.getByText(m.github_lens_graphql_label())).toBeInTheDocument();
+  });
+
+  it("marks an empty GraphQL bucket Exhausted, not Paused", async () => {
+    render(GithubLens, { data: fixture() }); // graphql.remaining = 0
+    // exact:true so the pill match isn't satisfied by the "…exhausted…" banner prose.
+    await expect
+      .element(page.getByText(m.github_lens_exhausted(), { exact: true }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText(m.github_lens_paused(), { exact: true }))
+      .not.toBeInTheDocument();
+  });
+
+  it("marks a backed-off-but-non-empty GraphQL bucket Paused, not Exhausted", async () => {
+    // Bucket still has budget, but Shepherd's backoff is engaged (transient secondary
+    // rate-limit error) — the pill must read "Paused", never "Exhausted".
+    const data = fixture({
+      graphql: { limit: 5000, used: 1000, remaining: 4000, resetAt: BASE + H },
+      backoff: { remaining: 4000, resetAt: BASE + H, pausedUntil: BASE + H, blocked: true },
+    });
+    render(GithubLens, { data });
+    await expect
+      .element(page.getByText(m.github_lens_paused(), { exact: true }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText(m.github_lens_exhausted(), { exact: true }))
+      .not.toBeInTheDocument();
+  });
+
+  it("shows no pill when both buckets are healthy and backoff is clear", async () => {
+    const data = fixture({
+      graphql: { limit: 5000, used: 1000, remaining: 4000, resetAt: BASE + H },
+      backoff: { remaining: 4000, resetAt: BASE + H, pausedUntil: null, blocked: false },
+    });
+    render(GithubLens, { data });
+    await expect.element(page.getByText(m.github_lens_rest_label())).toBeInTheDocument();
+    expect(document.body.textContent).not.toContain(m.github_lens_exhausted());
+    expect(document.body.textContent).not.toContain(m.github_lens_paused());
+  });
+});

--- a/ui/src/lib/components/usage/GithubLens.browser.test.ts
+++ b/ui/src/lib/components/usage/GithubLens.browser.test.ts
@@ -56,6 +56,14 @@ describe("GithubLens", () => {
     await expect
       .element(page.getByText(m.github_lens_exhausted(), { exact: true }))
       .not.toBeInTheDocument();
+    // The banner must use the backoff copy, not the contradictory "exhausted" copy.
+    // Match the time-independent clause (the interpolated "~{time}" floors to 59m/1h).
+    await expect
+      .element(page.getByText("rate-limit backoff clears", { exact: false }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText("GraphQL budget exhausted", { exact: false }))
+      .not.toBeInTheDocument();
   });
 
   it("shows no pill when both buckets are healthy and backoff is clear", async () => {

--- a/ui/src/lib/components/usage/GithubLens.svelte
+++ b/ui/src/lib/components/usage/GithubLens.svelte
@@ -49,11 +49,11 @@
     return b.limit > 0 ? Math.min(Math.max((b.used / b.limit) * 100, 0), 100) : 0;
   }
 
-  // GraphQL is paused either because its bucket is empty or because Shepherd's own
-  // backoff is engaged (an error tripped it before the live reading caught up).
-  const graphqlPaused = $derived(
-    (!!data.graphql && data.graphql.remaining <= 0) || data.backoff.blocked,
-  );
+  // Two distinct GraphQL-paused causes, kept apart so the banner copy matches the
+  // row pill: a truly drained bucket ("exhausted") vs. a backoff engaged while the
+  // bucket still has budget ("paused" — a transient secondary-rate-limit error).
+  const graphqlExhausted = $derived(!!data.graphql && data.graphql.remaining <= 0);
+  const graphqlBackedOff = $derived(!graphqlExhausted && data.backoff.blocked);
   const restPaused = $derived(!!data.rest && data.rest.remaining <= 0);
 
   // When to resume GraphQL: the later of the bucket reset and any active backoff window.
@@ -74,9 +74,13 @@
 <div class="github-lens panel">
   <p class="intro">{m.github_lens_intro()}</p>
 
-  {#if graphqlPaused}
+  {#if graphqlExhausted}
     <div class="paused-banner" role="alert">
       {m.github_lens_graphql_paused({ time: formatResetIn(graphqlResumeAt, nowMs) })}
+    </div>
+  {:else if graphqlBackedOff}
+    <div class="paused-banner" role="alert">
+      {m.github_lens_graphql_backoff({ time: formatResetIn(graphqlResumeAt, nowMs) })}
     </div>
   {/if}
   {#if restPaused && data.rest}

--- a/ui/src/lib/components/usage/GithubLens.svelte
+++ b/ui/src/lib/components/usage/GithubLens.svelte
@@ -1,0 +1,227 @@
+<script lang="ts">
+  import type { GithubRateLimit, GhRateBucket } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import { gaugeColor } from "$lib/components/usage-gauges";
+  import { formatResetIn } from "$lib/format";
+
+  const { data }: { data: GithubRateLimit } = $props();
+
+  const nowMs = $derived(Date.now());
+
+  type Row = {
+    bucket: GhRateBucket;
+    label: string;
+    desc: string;
+    /** True when this is the GraphQL bucket — drives the backoff-aware paused banner. */
+    isGraphql: boolean;
+  };
+
+  // Build only the buckets we actually received, in fixed order (REST, GraphQL, Search).
+  function buildRows(d: GithubRateLimit): Row[] {
+    const out: Row[] = [];
+    if (d.rest)
+      out.push({
+        bucket: d.rest,
+        label: m.github_lens_rest_label(),
+        desc: m.github_lens_rest_desc(),
+        isGraphql: false,
+      });
+    if (d.graphql)
+      out.push({
+        bucket: d.graphql,
+        label: m.github_lens_graphql_label(),
+        desc: m.github_lens_graphql_desc(),
+        isGraphql: true,
+      });
+    if (d.search)
+      out.push({
+        bucket: d.search,
+        label: m.github_lens_search_label(),
+        desc: m.github_lens_search_desc(),
+        isGraphql: false,
+      });
+    return out;
+  }
+  const rows = $derived(buildRows(data));
+
+  // Consumed percentage of a bucket (higher = closer to its cap → hotter color).
+  function usedPct(b: GhRateBucket): number {
+    return b.limit > 0 ? Math.min(Math.max((b.used / b.limit) * 100, 0), 100) : 0;
+  }
+
+  // GraphQL is paused either because its bucket is empty or because Shepherd's own
+  // backoff is engaged (an error tripped it before the live reading caught up).
+  const graphqlPaused = $derived(
+    (!!data.graphql && data.graphql.remaining <= 0) || data.backoff.blocked,
+  );
+  const restPaused = $derived(!!data.rest && data.rest.remaining <= 0);
+
+  // When to resume GraphQL: the later of the bucket reset and any active backoff window.
+  const graphqlResumeAt = $derived(
+    Math.max(data.graphql?.resetAt ?? 0, data.backoff.pausedUntil ?? 0),
+  );
+</script>
+
+<div class="github-lens panel">
+  <p class="intro">{m.github_lens_intro()}</p>
+
+  {#if graphqlPaused}
+    <div class="paused-banner" role="alert">
+      {m.github_lens_graphql_paused({ time: formatResetIn(graphqlResumeAt, nowMs) })}
+    </div>
+  {/if}
+  {#if restPaused && data.rest}
+    <div class="paused-banner" role="alert">
+      {m.github_lens_rest_paused({ time: formatResetIn(data.rest.resetAt, nowMs) })}
+    </div>
+  {/if}
+
+  {#if rows.length === 0}
+    <p class="no-data">{m.github_lens_no_data()}</p>
+  {:else}
+    {#each rows as row (row.label)}
+      {@const pct = usedPct(row.bucket)}
+      {@const color = gaugeColor(pct)}
+      {@const empty = row.bucket.remaining <= 0}
+      <div class="window-block">
+        <div class="window-header">
+          <span class="window-label">{row.label}</span>
+          {#if empty || (row.isGraphql && data.backoff.blocked)}
+            <span class="exhausted-pill">{m.github_lens_exhausted()}</span>
+          {/if}
+          <span class="window-count" style="color:{color}">
+            {row.bucket.remaining.toLocaleString()} / {row.bucket.limit.toLocaleString()}
+          </span>
+        </div>
+
+        <div
+          class="meter-wrap"
+          role="meter"
+          aria-valuenow={Math.round(pct)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={row.label}
+        >
+          <div class="meter-track">
+            <div class="meter-fill" style="width:{pct}%;background:{color}"></div>
+          </div>
+        </div>
+
+        <div class="window-meta">
+          <span class="desc">{row.desc}</span>
+          <span class="reset-time"
+            >{m.usage_limits_resets_in({ time: formatResetIn(row.bucket.resetAt, nowMs) })}</span
+          >
+        </div>
+      </div>
+    {/each}
+  {/if}
+</div>
+
+<style>
+  .github-lens {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
+  .intro {
+    margin: 0;
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    line-height: 1.5;
+  }
+
+  .no-data {
+    color: var(--color-muted);
+    font-size: var(--fs-base);
+    margin: 0;
+  }
+
+  .paused-banner {
+    border: 1px solid var(--color-red);
+    border-radius: 3px;
+    background: var(--color-inset);
+    color: var(--color-red);
+    font-size: var(--fs-meta);
+    line-height: 1.5;
+    padding: 8px 10px;
+  }
+
+  .window-block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .window-header {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+
+  .window-label {
+    font-size: var(--fs-base);
+    font-weight: 600;
+    color: var(--color-ink-bright);
+    flex: 1;
+  }
+
+  .window-count {
+    font-size: var(--fs-base);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+  }
+
+  .exhausted-pill {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-red);
+    border: 1px solid var(--color-red);
+    border-radius: 2px;
+    padding: 0 5px;
+  }
+
+  .meter-wrap {
+    width: 100%;
+  }
+
+  .meter-track {
+    position: relative;
+    width: 100%;
+    height: 10px;
+    background: var(--color-line);
+    border: 1px solid var(--color-line-bright);
+    border-radius: 3px;
+    overflow: hidden;
+  }
+
+  .meter-fill {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    border-radius: 3px 0 0 3px;
+    transition: width 0.4s ease;
+  }
+
+  .window-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem 1rem;
+  }
+
+  .desc {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+  }
+
+  .reset-time {
+    font-size: var(--fs-meta);
+    color: var(--color-faint);
+  }
+</style>

--- a/ui/src/lib/components/usage/GithubLens.svelte
+++ b/ui/src/lib/components/usage/GithubLens.svelte
@@ -60,6 +60,15 @@
   const graphqlResumeAt = $derived(
     Math.max(data.graphql?.resetAt ?? 0, data.backoff.pausedUntil ?? 0),
   );
+
+  // Status pill for a row: "Exhausted" only when the bucket is truly empty;
+  // "Paused" when GraphQL polling is backed off while the bucket still has budget
+  // (a transient secondary-rate-limit error, not a drained quota); none otherwise.
+  function pillLabel(row: Row): string | null {
+    if (row.bucket.remaining <= 0) return m.github_lens_exhausted();
+    if (row.isGraphql && data.backoff.blocked) return m.github_lens_paused();
+    return null;
+  }
 </script>
 
 <div class="github-lens panel">
@@ -82,12 +91,12 @@
     {#each rows as row (row.label)}
       {@const pct = usedPct(row.bucket)}
       {@const color = gaugeColor(pct)}
-      {@const empty = row.bucket.remaining <= 0}
+      {@const pill = pillLabel(row)}
       <div class="window-block">
         <div class="window-header">
           <span class="window-label">{row.label}</span>
-          {#if empty || (row.isGraphql && data.backoff.blocked)}
-            <span class="exhausted-pill">{m.github_lens_exhausted()}</span>
+          {#if pill}
+            <span class="exhausted-pill">{pill}</span>
           {/if}
           <span class="window-count" style="color:{color}">
             {row.bucket.remaining.toLocaleString()} / {row.bucket.limit.toLocaleString()}

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1847,4 +1847,12 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feature_model_comparison_title",
     bodyKey: "feature_model_comparison_body",
   },
+  {
+    // No targetId: the GitHub tab lives inside the Usage modal, which isn't mounted
+    // until opened — no stable always-present anchor. What's-New drawer only.
+    id: "github-rate-limits",
+    sinceVersion: "1.39.0",
+    titleKey: "feat_github_rate_limits_title",
+    bodyKey: "feat_github_rate_limits_body",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -937,6 +937,35 @@ export type UsageProviderSnapshot =
 
 export type UsageRange = "24h" | "7d" | "30d" | "all";
 
+/** One GitHub rate-limit bucket (REST core / GraphQL / search). Mirrors the
+ *  server `GhRateBucket`. */
+export interface GhRateBucket {
+  limit: number;
+  used: number;
+  remaining: number;
+  /** Epoch-ms when this bucket refills. */
+  resetAt: number;
+}
+
+/** GitHub REST + GraphQL rate-limit state shown in the usage view's GitHub tab.
+ *  Mirrors the server `GithubRateLimitPayload`. GitHub runs the REST and GraphQL
+ *  buckets independently, so one can be exhausted while the other is healthy. */
+export interface GithubRateLimit {
+  rest: GhRateBucket | null;
+  graphql: GhRateBucket | null;
+  search: GhRateBucket | null;
+  /** Epoch-ms when these readings were fetched. */
+  fetchedAt: number;
+  /** Shepherd's GraphQL backoff state — explains a polling pause even before a
+   *  bucket is fully empty. */
+  backoff: {
+    remaining: number | null;
+    resetAt: number | null;
+    pausedUntil: number | null;
+    blocked: boolean;
+  };
+}
+
 /** Raw token detail (authoring side). */
 export interface UsageTokens {
   input: number;


### PR DESCRIPTION
## Was & Warum

GitHub führt für REST- und GraphQL-Zugriffe **getrennte** Stundenkontingente (je 5.000). Ist das GraphQL-Bucket erschöpft, stoppt Shepherd das PR-/Issue-/Backlog-Polling still — während REST-Aktionen (CI-Status, Merge) weiterlaufen. Ohne Sichtbarkeit wirkt das wie ein Defekt. (Genau dieser Fall trat hier auf: `graphql used 5002/5000, remaining 0`, core gesund.)

Dieser PR macht beide Budgets im **Verbrauch**-Dialog sichtbar — separiert in einem eigenen **GitHub**-Tab — und erklärt, *welche* Funktionen pausieren und bis wann.

## Umsetzung

**Server**
- `src/forge/github-rate-limit.ts` — neuer `fetchGithubRateLimit()`: liest `gh api rate_limit` (dieser Endpoint zählt **selbst nicht** gegen ein Budget, funktioniert also auch bei erschöpftem Bucket), parst REST/`core`, GraphQL, Search → `{ limit, used, remaining, resetAt }`, 15 s TTL-Cache gegen Subprozess-Spam. Bündelt zusätzlich die bestehende GraphQL-Backoff-Snapshot (`graphRateLimit`), die erklärt *warum* Shepherd selbst pausiert.
- `GET /api/usage/github` (in `handleUsageLimits`, ausgelagerte Helper-Funktion), verdrahtet via `appDeps.githubRateLimit` mit dem geteilten async `gh`-Runner.

**UI**
- Neuer **GitHub**-Tab im `Usage`-Dialog mit `GithubLens.svelte`: REST- + GraphQL- (+ Search-)Bucket je als Meter (Verbrauch %, `gaugeColor`-Ladder), Restbudget, Reset-Countdown. Bei Erschöpfung ein roter Banner, der die betroffenen Funktionen + Reset-Zeit nennt.
- `getGithubRateLimit()` in `api.ts`, Typen `GithubRateLimit`/`GhRateBucket`.

## Vorgaben (CLAUDE.md)
- i18n: EN+DE Keys ergänzt, `check:i18n` grün (Parität).
- Feature-Catalog-Eintrag `github-rate-limits` (1.39.0) + What's-New-Keys.
- Nur Design-Tokens, kanonisches Meter-/`.gbtn`-Recipe wiederverwendet. Kein Glossar-Term nötig (REST/GraphQL nicht markiert).

## Tests
- `test/github-rate-limit.test.ts` — Parsing (epoch-s→ms), TTL-Cache-Hit/-Miss, fehlende Resources, gh-Fehler-Propagation.
- `Usage.browser.test.ts` — neuer GitHub-Tab zeigt beide Buckets + Paused-Banner, Range-Selector ausgeblendet.
- typecheck, `bun run check`, root-lint, fallow-Audit, alle Gates grün.
