### PR TITLE
perf(pr-poller): batch PR polling per-repo (collapse full-sweep fan-out)

### DIFF
--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -175,6 +175,7 @@ interface GhPr {
   isDraft?: boolean;
   statusCheckRollup?: RollupEntry[];
   headRefOid?: string;
+  headRefName?: string;
   baseRefName?: string;
   reviews?: GhReview[];
   reviewRequests?: { login?: string }[];
@@ -229,6 +230,9 @@ export class GithubForge implements GitForge {
    *  {@link forkSlug}. Used to qualify `pr create --head <forkOwner>:<branch>` and
    *  to disambiguate `prStatus`'s cross-repo match. Undefined for non-fork repos. */
   private readonly forkOwner?: string;
+  /** Latch: true once we've emitted the ≥200 open-PR cap warning so it fires at
+   *  most once per forge instance (on transition into the capped regime). */
+  private openPrCapLogged = false;
   constructor(
     readonly slug: string,
     private readonly cfg: ForgeConfig,
@@ -641,6 +645,31 @@ export class GithubForge implements GitForge {
     await this.run(["run", "cancel", String(runId), "--repo", this.slug]);
   }
 
+  /** Map a raw GhPr node to a PrStatus. Shared by prStatus (single-PR path) and
+   *  listOpenPrStatuses (batch path) so both produce identical field values. */
+  private mapGhPr(pr: GhPr, deployConfigured: boolean): PrStatus {
+    const state = pr.state.toLowerCase() as PrStatus["state"];
+    const createdAt = Date.parse(pr.createdAt ?? "");
+    return {
+      state: state === "open" || state === "merged" || state === "closed" ? state : "none",
+      number: pr.number,
+      url: pr.url,
+      title: pr.title,
+      createdAt: Number.isFinite(createdAt) ? createdAt : undefined,
+      mergeable: mapMergeable(pr.mergeable),
+      mergeStateStatus: mapMergeStateStatus(pr.mergeStateStatus),
+      isDraft: pr.isDraft ?? false,
+      checks: rollupChecks(pr.statusCheckRollup ?? []),
+      headSha: pr.headRefOid,
+      baseRefName: pr.baseRefName,
+      latestReview: latestHumanReview(pr.reviews),
+      requestedReviewers: (pr.reviewRequests ?? [])
+        .map((r) => r.login)
+        .filter((l): l is string => !!l),
+      deployConfigured,
+    };
+  }
+
   async prStatus(headBranch: string): Promise<PrStatus> {
     const deployConfigured = Boolean(this.cfg.deployWorkflow);
     // `gh pr list --head` matches by bare branch ref name — it does NOT accept the
@@ -675,26 +704,77 @@ export class GithubForge implements GitForge {
       ? prs.find((p) => p.headRepositoryOwner?.login === this.forkOwner)
       : prs[0];
     if (!pr) return { state: "none", checks: "none", deployConfigured };
-    const state = pr.state.toLowerCase() as PrStatus["state"];
-    const createdAt = Date.parse(pr.createdAt ?? "");
-    return {
-      state: state === "open" || state === "merged" || state === "closed" ? state : "none",
-      number: pr.number,
-      url: pr.url,
-      title: pr.title,
-      createdAt: Number.isFinite(createdAt) ? createdAt : undefined,
-      mergeable: mapMergeable(pr.mergeable),
-      mergeStateStatus: mapMergeStateStatus(pr.mergeStateStatus),
-      isDraft: pr.isDraft ?? false,
-      checks: rollupChecks(pr.statusCheckRollup ?? []),
-      headSha: pr.headRefOid,
-      baseRefName: pr.baseRefName,
-      latestReview: latestHumanReview(pr.reviews),
-      requestedReviewers: (pr.reviewRequests ?? [])
-        .map((r) => r.login)
-        .filter((l): l is string => !!l),
-      deployConfigured,
-    };
+    return this.mapGhPr(pr, deployConfigured);
+  }
+
+  /** Open PRs for this repo as full poll-grade PrStatus objects keyed by head
+   *  branch name, fetched in ONE `gh pr list --state open` call — the per-repo
+   *  batch the PrPoller matches sessions against locally (collapsing N× per-branch
+   *  prStatus to O(repos)). Fork mode keeps only PRs whose head lives on OUR fork
+   *  (mirrors prStatus's headRepositoryOwner filter). */
+  async listOpenPrStatuses(): Promise<Map<string, PrStatus>> {
+    const deployConfigured = Boolean(this.cfg.deployWorkflow);
+    const out = await this.run([
+      "pr",
+      "list",
+      "--repo",
+      this.slug,
+      "--state",
+      "open",
+      "--json",
+      "number,url,title,state,createdAt,mergeable,mergeStateStatus,isDraft,statusCheckRollup,headRefOid,headRefName,baseRefName,reviews,reviewRequests,headRepositoryOwner",
+      "--limit",
+      "200",
+    ]);
+    const prs = JSON.parse(out || "[]") as GhPr[];
+
+    if (prs.length >= 200 && !this.openPrCapLogged) {
+      this.openPrCapLogged = true;
+      console.warn(
+        `[github] ${this.slug} has ≥200 open PRs; batch truncated — tail branches fall back to per-session`,
+      );
+    }
+
+    // Deterministic dedup when two open PRs share a headRefName (e.g. an internal
+    // branch PR and a fork PR for the same name). The expectedOwner-owned entry
+    // always wins regardless of array order; if no entry matches, first-seen wins
+    // (mirrors prStatus's prs[0] no-match fallback).
+    const expectedOwner = this.forkOwner ?? this.slug.split("/")[0];
+    const result = new Map<string, PrStatus>();
+
+    for (const pr of prs) {
+      if (!pr.headRefName) continue;
+      const key = pr.headRefName;
+      const existing = result.get(key);
+      if (!existing) {
+        result.set(key, this.mapGhPr(pr, deployConfigured));
+      } else if (pr.headRepositoryOwner?.login === expectedOwner) {
+        // Current entry's owner matches: overwrite whatever was first-seen
+        result.set(key, this.mapGhPr(pr, deployConfigured));
+      }
+      // else: existing is already the right entry — keep it
+    }
+
+    return result;
+  }
+
+  /** Cheap open-PR count (`gh pr list --state open --json number --limit 200`).
+   *  Returns the array length; capped at 200 (≥200 means "at least 200"). */
+  async countOpenPrs(): Promise<number> {
+    const out = await this.run([
+      "pr",
+      "list",
+      "--repo",
+      this.slug,
+      "--state",
+      "open",
+      "--json",
+      "number",
+      "--limit",
+      "200",
+    ]);
+    const prs = JSON.parse(out || "[]") as { number: number }[];
+    return prs.length;
   }
 
   private cachedDefaultBranch?: string;

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -710,8 +710,13 @@ export class GithubForge implements GitForge {
   /** Open PRs for this repo as full poll-grade PrStatus objects keyed by head
    *  branch name, fetched in ONE `gh pr list --state open` call — the per-repo
    *  batch the PrPoller matches sessions against locally (collapsing N× per-branch
-   *  prStatus to O(repos)). Fork mode keeps only PRs whose head lives on OUR fork
-   *  (mirrors prStatus's headRepositoryOwner filter). */
+   *  prStatus to O(repos)). When two open PRs share a headRefName (e.g. an
+   *  internal-branch PR and a fork PR for the same name) the entry owned by
+   *  `forkOwner ?? owner(slug)` wins regardless of array order — a deterministic
+   *  collision dedup, NOT a fork filter (all open PRs are returned). The poller
+   *  does not call this in fork mode (`batchForRepo` skips `isFork` repos →
+   *  per-session `prStatus`); the `forkOwner` arm of the dedup key is just
+   *  defensive. */
   async listOpenPrStatuses(): Promise<Map<string, PrStatus>> {
     const deployConfigured = Boolean(this.cfg.deployWorkflow);
     const out = await this.run([

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -478,9 +478,11 @@ export interface GitForge {
   /** Open PRs for this repo as full poll-grade PrStatus objects keyed by head
    *  branch name, fetched in ONE `gh pr list --state open` call — the per-repo
    *  batch the PrPoller matches sessions against locally (collapsing N× per-branch
-   *  prStatus to O(repos)). Fork mode keeps only PRs whose head lives on OUR fork
-   *  (mirrors prStatus's headRepositoryOwner filter). Optional: forges without it
-   *  (Gitea/Local) fall back to per-session prStatus. */
+   *  prStatus to O(repos)). On a headRefName collision the implementation may
+   *  deterministically prefer the repo-owned PR, but it does NOT filter by owner —
+   *  every open PR is returned. Optional: forges without it (Gitea/Local), and
+   *  fork-mode repos (which the poller routes around → per-session), fall back to
+   *  per-session prStatus. */
   listOpenPrStatuses?(): Promise<Map<string, PrStatus>>;
   /** Cheap open-PR count (`gh pr list --state open --json number --limit 200`,
    *  ~1 GraphQL point regardless of count) — the poller's count-gate uses it to

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -475,6 +475,18 @@ export interface GitForge {
    *  without it, or a transient failure, yields an empty set and the exclusion degrades to
    *  `shepherd:active`-only. Optional: only hosts with the GraphQL field implement it. */
   listOpenPrClosingIssues?(): Promise<number[]>;
+  /** Open PRs for this repo as full poll-grade PrStatus objects keyed by head
+   *  branch name, fetched in ONE `gh pr list --state open` call — the per-repo
+   *  batch the PrPoller matches sessions against locally (collapsing N× per-branch
+   *  prStatus to O(repos)). Fork mode keeps only PRs whose head lives on OUR fork
+   *  (mirrors prStatus's headRepositoryOwner filter). Optional: forges without it
+   *  (Gitea/Local) fall back to per-session prStatus. */
+  listOpenPrStatuses?(): Promise<Map<string, PrStatus>>;
+  /** Cheap open-PR count (`gh pr list --state open --json number --limit 200`,
+   *  ~1 GraphQL point regardless of count) — the poller's count-gate uses it to
+   *  decide whether the full listOpenPrStatuses batch is cheaper than per-session
+   *  for this repo. Capped at 200 (a ≥200 result means "at least 200"). Optional. */
+  countOpenPrs?(): Promise<number>;
 }
 
 /** Per-host configuration loaded from ~/.shepherd/forges.json. */

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -250,14 +250,17 @@ export class PrPoller implements PrCache {
       else byKey.set(forge.slug, { forge, count: 1 });
     }
     for (const [key, { forge, count }] of byKey) {
-      if (!forge.listOpenPrStatuses || !forge.countOpenPrs || forge.isFork) {
+      // count < 2: batching costs 2 gh calls (countOpenPrs + listOpenPrStatuses) vs
+      // S = count per-session calls; break-even is S ≥ 2, so a single-session repo
+      // is a strict regression — skip both probe and list call.
+      if (!forge.listOpenPrStatuses || !forge.countOpenPrs || forge.isFork || count < 2) {
         out.set(key, null);
         continue;
       }
       try {
         const p = await this.withGh(() => forge.countOpenPrs!());
-        if (p > this.batchOpenRatio * count) {
-          out.set(key, null); // count-gate: batch would cost more points than per-session
+        if (p >= 200 || p > this.batchOpenRatio * count) {
+          out.set(key, null); // cap-hit (truncated batch) or count-gate → per-session
           continue;
         }
         out.set(key, await this.withGh(() => forge.listOpenPrStatuses!()));

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -232,6 +232,30 @@ export class PrPoller implements PrCache {
     }
   }
 
+  /** Fetch the batch status for one repo. Returns the open-PR map, or null when
+   *  the repo should fall back to per-session polling (no batch methods, fork,
+   *  count-gate trip, or a transient fetch failure). All `gh` calls under `withGh`.
+   *  count < 2: batching costs 2 gh calls (countOpenPrs + listOpenPrStatuses) vs
+   *  S = count per-session calls; break-even is S ≥ 2, so a single-session repo
+   *  is a strict regression — skip both probe and list call. */
+  private async batchForRepo(
+    forge: GitForge,
+    count: number,
+  ): Promise<Map<string, PrStatus> | null> {
+    if (!forge.listOpenPrStatuses || !forge.countOpenPrs || forge.isFork || count < 2) {
+      return null;
+    }
+    try {
+      const p = await this.withGh(() => forge.countOpenPrs!());
+      if (p >= 200 || p > this.batchOpenRatio * count) {
+        return null; // cap-hit (truncated batch) or count-gate → per-session
+      }
+      return await this.withGh(() => forge.listOpenPrStatuses!());
+    } catch {
+      return null; // transient failure → per-session this sweep
+    }
+  }
+
   /** One open-PR batch per distinct non-fork repo, subject to the count-gate.
    *  Maps `forge.slug` → its `Map<headRefName, PrStatus>`, or `null` when that
    *  repo must use the per-session path (no batch methods, fork mode, count-gate
@@ -250,23 +274,7 @@ export class PrPoller implements PrCache {
       else byKey.set(forge.slug, { forge, count: 1 });
     }
     for (const [key, { forge, count }] of byKey) {
-      // count < 2: batching costs 2 gh calls (countOpenPrs + listOpenPrStatuses) vs
-      // S = count per-session calls; break-even is S ≥ 2, so a single-session repo
-      // is a strict regression — skip both probe and list call.
-      if (!forge.listOpenPrStatuses || !forge.countOpenPrs || forge.isFork || count < 2) {
-        out.set(key, null);
-        continue;
-      }
-      try {
-        const p = await this.withGh(() => forge.countOpenPrs!());
-        if (p >= 200 || p > this.batchOpenRatio * count) {
-          out.set(key, null); // cap-hit (truncated batch) or count-gate → per-session
-          continue;
-        }
-        out.set(key, await this.withGh(() => forge.listOpenPrStatuses!()));
-      } catch {
-        out.set(key, null); // transient failure → per-session this sweep
-      }
+      out.set(key, await this.batchForRepo(forge, count));
     }
     return out;
   }
@@ -421,8 +429,15 @@ export class PrPoller implements PrCache {
     const hit = batch.get(s.branch!);
     if (hit) return guard({ kind: forge.kind, ...hit });
 
-    let git: GitState | null = null;
     const needsConfirm = marked || prev == null || prev.state !== "none" || recheckNone;
+    const noneGit = (): GitState => ({
+      kind: forge.kind,
+      state: "none",
+      checks: "none",
+      deployConfigured: !!forge.deployWorkflow,
+    });
+
+    let git: GitState | null = null;
     if (needsConfirm) {
       try {
         git = guard({ kind: forge.kind, ...(await forge.prStatus(s.branch!)) });
@@ -430,29 +445,22 @@ export class PrPoller implements PrCache {
         return null;
       }
     }
-    if (git == null || git.state === "none") {
-      const live = this.reconcileBranch(s);
-      if (live && live !== s.branch) {
-        const liveHit = batch.get(live);
-        if (liveHit) {
-          git = guard({ kind: forge.kind, ...liveHit });
-        } else if (needsConfirm) {
-          try {
-            git = guard({ kind: forge.kind, ...(await forge.prStatus(live)) });
-          } catch {
-            return null;
-          }
-        }
-      }
+
+    if (git != null && git.state !== "none") return git;
+
+    const live = this.reconcileBranch(s);
+    if (!live || live === s.branch) return git ?? noneGit();
+
+    const liveHit = batch.get(live);
+    if (liveHit) return guard({ kind: forge.kind, ...liveHit });
+
+    if (!needsConfirm) return git ?? noneGit();
+
+    try {
+      return guard({ kind: forge.kind, ...(await forge.prStatus(live)) });
+    } catch {
+      return null;
     }
-    return (
-      git ?? {
-        kind: forge.kind,
-        state: "none",
-        checks: "none",
-        deployConfigured: !!forge.deployWorkflow,
-      }
-    );
   }
 
   /** Maintain the transient-window stamp for `id` from its latest observed `git`,

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -1,6 +1,6 @@
 import type { SessionStore } from "./store";
 import type { Session } from "./types";
-import type { GitForge, GitState } from "./forge/types";
+import type { GitForge, GitState, PrStatus } from "./forge/types";
 import { annotateHandoff } from "./repo-roles";
 
 /** Read/write handle the HTTP layer uses to serve snapshots and apply instant
@@ -184,11 +184,24 @@ export class PrPoller implements PrCache {
      *  state unstable) before `fastTick` parks it and stops fast-polling it. A new
      *  headSha resets the clock. Default: 5 minutes. */
     private transientMaxMs = 300_000,
+    /** Batch the full sweep for a non-fork repo only while its open-PR count
+     *  `P ≤ batchOpenRatio × (sessions with a branch in that repo)`. Above it,
+     *  the per-repo full-rollup batch costs more GraphQL points than per-session,
+     *  so fall back. Measured cost ≈ 0.4 pt/open-PR vs ~1 pt/session ⇒ default 2. */
+    private batchOpenRatio = 2,
+    /** Coarse cadence at which cached-`none` sessions are re-confirmed via
+     *  per-session `prStatus` (a `--state open` batch can't surface a PR that was
+     *  created and reached terminal between sweeps). Bounds stuck-`none` self-heal
+     *  latency without per-sweep O(none-sessions) fan-out. */
+    private noneRecheckMs = 600_000,
   ) {}
 
   /** Epoch-ms of the last full sweep that actually ran — gates the cold-path
    *  throttle in `tick`. */
   private lastFullSweepAt = 0;
+
+  /** Epoch-ms of the last sweep that re-confirmed cached-`none` sessions. */
+  private lastNoneRecheckAt = 0;
 
   async tick(): Promise<void> {
     if (this.rateLimited()) return; // GraphQL bucket exhausted — don't add to the backlog
@@ -199,10 +212,14 @@ export class PrPoller implements PrCache {
     this.lastFullSweepAt = Date.now();
     this.sweeping = true;
     try {
+      const sessions = [...this.store.list({ activeOnly: true })];
+      const recheckNone = Date.now() - this.lastNoneRecheckAt >= this.noneRecheckMs;
+      if (recheckNone) this.lastNoneRecheckAt = Date.now();
+      const batches = await this.buildBatches(sessions);
       const active = new Set<string>();
-      for (const s of this.store.list({ activeOnly: true })) {
+      for (const s of sessions) {
         active.add(s.id);
-        await this.withGh(() => this.refresh(s));
+        await this.withGh(() => this.refresh(s, this.batchFor(s, batches), recheckNone));
       }
       for (const id of [...this.cache.keys()]) {
         if (!active.has(id)) {
@@ -213,6 +230,53 @@ export class PrPoller implements PrCache {
     } finally {
       this.sweeping = false;
     }
+  }
+
+  /** One open-PR batch per distinct non-fork repo, subject to the count-gate.
+   *  Maps `forge.slug` → its `Map<headRefName, PrStatus>`, or `null` when that
+   *  repo must use the per-session path (no batch methods, fork mode, count-gate
+   *  over ratio, or a transient fetch failure). All `gh` under `withGh`. */
+  private async buildBatches(
+    sessions: Session[],
+  ): Promise<Map<string, Map<string, PrStatus> | null>> {
+    const out = new Map<string, Map<string, PrStatus> | null>();
+    const byKey = new Map<string, { forge: GitForge; count: number }>();
+    for (const s of sessions) {
+      if (!s.branch) continue;
+      const forge = this.resolveForge(s.repoPath);
+      if (!forge || forge.slug == null) continue;
+      const e = byKey.get(forge.slug);
+      if (e) e.count++;
+      else byKey.set(forge.slug, { forge, count: 1 });
+    }
+    for (const [key, { forge, count }] of byKey) {
+      if (!forge.listOpenPrStatuses || !forge.countOpenPrs || forge.isFork) {
+        out.set(key, null);
+        continue;
+      }
+      try {
+        const p = await this.withGh(() => forge.countOpenPrs!());
+        if (p > this.batchOpenRatio * count) {
+          out.set(key, null); // count-gate: batch would cost more points than per-session
+          continue;
+        }
+        out.set(key, await this.withGh(() => forge.listOpenPrStatuses!()));
+      } catch {
+        out.set(key, null); // transient failure → per-session this sweep
+      }
+    }
+    return out;
+  }
+
+  /** The prefetched batch for `s`'s repo, or null (→ per-session path). */
+  private batchFor(
+    s: Session,
+    batches: Map<string, Map<string, PrStatus> | null>,
+  ): Map<string, PrStatus> | null {
+    if (!s.branch) return null;
+    const forge = this.resolveForge(s.repoPath);
+    if (!forge || forge.slug == null) return null;
+    return batches.get(forge.slug) ?? null;
   }
 
   /** Accelerated re-poll of in-flight PRs (cached `state === "open"`) so the list
@@ -273,8 +337,15 @@ export class PrPoller implements PrCache {
   }
 
   /** Poll one session and emit `session:git` if its PR state moved. Shared by
-   *  the full sweep and the targeted `pollSession` path. */
-  private async refresh(s: Session): Promise<void> {
+   *  the full sweep (which passes the prefetched per-repo `batch`) and the
+   *  targeted `pollSession`/`fastTick` paths (no batch → per-session). The
+   *  post-processing (handoff / transient stamp / change-emit) is shared; only
+   *  raw-status resolution differs (`statusFromBatch` vs `statusPerSession`). */
+  private async refresh(
+    s: Session,
+    batch?: Map<string, PrStatus> | null,
+    recheckNone = false,
+  ): Promise<void> {
     const forge = s.branch ? this.resolveForge(s.repoPath) : null;
     if (!forge || !s.branch) return; // no PR possible — leave uncached
     const me = (await forge.currentUser?.()) ?? null;
@@ -283,11 +354,34 @@ export class PrPoller implements PrCache {
     const markedNumber = s.mergingPrNumber ?? null;
     const guard = (raw: GitState): GitState =>
       trustsTerminal(prev, raw, marked, markedNumber) ? raw : this.rejectStaleTerminal(s, raw);
+
+    const raw = batch
+      ? await this.statusFromBatch(s, forge, batch, prev, marked, recheckNone, guard)
+      : await this.statusPerSession(s, forge, guard);
+    if (raw === null) return; // transient gh failure → keep last cached value
+
+    // Who's up (open+green): computed from .shepherd/roles.json + the operator's
+    // login, so the herd can show "waiting on scoop" instead of "your turn".
+    const git = annotateHandoff(raw, s.repoPath, me);
+    this.trackTransient(s.id, git);
+    if (gitStateChanged(prev, git)) {
+      this.cache.set(s.id, git);
+      this.onChange(s.id, git);
+    }
+  }
+
+  /** Per-session raw status — TODAY'S logic verbatim (the no-batch fallback).
+   *  Returns null on a transient `gh` throw ("keep last cached value"). */
+  private async statusPerSession(
+    s: Session,
+    forge: GitForge,
+    guard: (raw: GitState) => GitState,
+  ): Promise<GitState | null> {
     let git: GitState;
     try {
-      git = guard({ kind: forge.kind, ...(await forge.prStatus(s.branch)) });
+      git = guard({ kind: forge.kind, ...(await forge.prStatus(s.branch!)) });
     } catch {
-      return; // transient gh failure → keep last cached value
+      return null;
     }
     // No PR for the stored branch — the agent may have renamed the worktree's
     // branch out from under us. Adopt the live branch and retry against it. The
@@ -299,18 +393,63 @@ export class PrPoller implements PrCache {
         try {
           git = guard({ kind: forge.kind, ...(await forge.prStatus(live)) });
         } catch {
-          return;
+          return null;
         }
       }
     }
-    // Who's up (open+green): computed from .shepherd/roles.json + the operator's
-    // login, so the herd can show "waiting on scoop" instead of "your turn".
-    git = annotateHandoff(git, s.repoPath, me);
-    this.trackTransient(s.id, git);
-    if (gitStateChanged(prev, git)) {
-      this.cache.set(s.id, git);
-      this.onChange(s.id, git);
+    return git;
+  }
+
+  /** Raw status from the per-repo open-PR batch. A batch hit is the live open PR.
+   *  On a miss: confirm a terminal/none via per-session `prStatus` only when
+   *  bounded (`marked || prev == null || prev.state !== "none" || recheckNone`);
+   *  then `reconcileBranch` every sweep (local git) and look the renamed branch up
+   *  in the batch first (no GraphQL) so an open-rename is adopted at the normal
+   *  sweep cadence; finally synthesize a definitive `none`. */
+  private async statusFromBatch(
+    s: Session,
+    forge: GitForge,
+    batch: Map<string, PrStatus>,
+    prev: GitState | undefined,
+    marked: boolean,
+    recheckNone: boolean,
+    guard: (raw: GitState) => GitState,
+  ): Promise<GitState | null> {
+    const hit = batch.get(s.branch!);
+    if (hit) return guard({ kind: forge.kind, ...hit });
+
+    let git: GitState | null = null;
+    const needsConfirm = marked || prev == null || prev.state !== "none" || recheckNone;
+    if (needsConfirm) {
+      try {
+        git = guard({ kind: forge.kind, ...(await forge.prStatus(s.branch!)) });
+      } catch {
+        return null;
+      }
     }
+    if (git == null || git.state === "none") {
+      const live = this.reconcileBranch(s);
+      if (live && live !== s.branch) {
+        const liveHit = batch.get(live);
+        if (liveHit) {
+          git = guard({ kind: forge.kind, ...liveHit });
+        } else if (needsConfirm) {
+          try {
+            git = guard({ kind: forge.kind, ...(await forge.prStatus(live)) });
+          } catch {
+            return null;
+          }
+        }
+      }
+    }
+    return (
+      git ?? {
+        kind: forge.kind,
+        state: "none",
+        checks: "none",
+        deployConfigured: !!forge.deployWorkflow,
+      }
+    );
   }
 
   /** Maintain the transient-window stamp for `id` from its latest observed `git`,

--- a/test/forge/github.test.ts
+++ b/test/forge/github.test.ts
@@ -1265,3 +1265,196 @@ test("GithubForge.prReviewMeta: missing fields default to empty/false", async ()
   const meta = await new GithubForge("o/r", {}, run).prReviewMeta!(7);
   expect(meta).toEqual({ body: "", baseRefName: "", isCrossRepository: false, state: "open" });
 });
+
+// ── listOpenPrStatuses + countOpenPrs ────────────────────────────────────────
+
+/** A complete GhPr-shaped node exercising every field that mapGhPr touches. */
+const FULL_PR_NODE = {
+  number: 42,
+  url: "https://github.com/o/r/pull/42",
+  title: "feat: full parity",
+  state: "OPEN",
+  createdAt: "2025-01-15T12:00:00Z",
+  mergeable: "MERGEABLE",
+  mergeStateStatus: "CLEAN",
+  isDraft: false,
+  statusCheckRollup: [
+    {
+      __typename: "CheckRun",
+      name: "ci",
+      workflowName: "CI",
+      status: "COMPLETED",
+      conclusion: "SUCCESS",
+      detailsUrl: "https://gh/job/ci",
+    },
+  ],
+  headRefOid: "deadbeef1234",
+  headRefName: "feat/full",
+  baseRefName: "main",
+  reviews: [
+    {
+      author: { login: "alice" },
+      state: "APPROVED",
+      body: "",
+      submittedAt: "2025-01-14T00:00:00Z",
+    },
+  ],
+  reviewRequests: [{ login: "bob" }],
+  headRepositoryOwner: { login: "o" },
+};
+
+test("mapGhPr parity: prStatus and listOpenPrStatuses produce identical PrStatus fields", async () => {
+  const prListJson = JSON.stringify([FULL_PR_NODE]);
+  const { run } = fakeRunner({ "pr list": prListJson });
+  const forge = new GithubForge("o/r", { deployWorkflow: "deploy.yml" }, run);
+
+  const fromPrStatus = await forge.prStatus("feat/full");
+
+  const map = await forge.listOpenPrStatuses!();
+  const fromBatch = map.get("feat/full");
+
+  expect(fromBatch).toBeDefined();
+  const fields = [
+    "state",
+    "number",
+    "url",
+    "title",
+    "createdAt",
+    "mergeable",
+    "mergeStateStatus",
+    "isDraft",
+    "checks",
+    "headSha",
+    "baseRefName",
+    "latestReview",
+    "requestedReviewers",
+    "deployConfigured",
+  ] as const;
+  for (const f of fields) {
+    expect(fromBatch![f]).toEqual(fromPrStatus[f]);
+  }
+});
+
+test("listOpenPrStatuses: non-fork selects expected-owner PR regardless of array order", async () => {
+  const internalPr = {
+    number: 10,
+    url: "u10",
+    title: "internal",
+    state: "OPEN",
+    headRefName: "feat/shared",
+    headRepositoryOwner: { login: "o" },
+  };
+  const forkPr = {
+    number: 20,
+    url: "u20",
+    title: "forker",
+    state: "OPEN",
+    headRefName: "feat/shared",
+    headRepositoryOwner: { login: "someforker" },
+  };
+
+  // Sub-case A: internal PR first in array
+  {
+    const { run } = fakeRunner({ "pr list": JSON.stringify([internalPr, forkPr]) });
+    const map = await new GithubForge("o/r", {}, run).listOpenPrStatuses!();
+    expect(map.get("feat/shared")!.number).toBe(10);
+  }
+
+  // Sub-case B: forker PR first in array — must still resolve to internal
+  {
+    const { run } = fakeRunner({ "pr list": JSON.stringify([forkPr, internalPr]) });
+    const map = await new GithubForge("o/r", {}, run).listOpenPrStatuses!();
+    expect(map.get("feat/shared")!.number).toBe(10);
+  }
+});
+
+test("listOpenPrStatuses: fork forge selects fork-owner PR over upstream-owner", async () => {
+  const upstreamPr = {
+    number: 5,
+    url: "u5",
+    title: "upstream",
+    state: "OPEN",
+    headRefName: "feat/thing",
+    headRepositoryOwner: { login: "up" },
+  };
+  const forkPr = {
+    number: 9,
+    url: "u9",
+    title: "fork",
+    state: "OPEN",
+    headRefName: "feat/thing",
+    headRepositoryOwner: { login: "me" },
+  };
+
+  // forkSlug "me/r", slug "up/r" → forkOwner = "me"
+  const { run } = fakeRunner({ "pr list": JSON.stringify([upstreamPr, forkPr]) });
+  const forge = new GithubForge("up/r", {}, run, "me/r");
+  const map = await forge.listOpenPrStatuses!();
+  expect(map.get("feat/thing")!.number).toBe(9);
+});
+
+test("listOpenPrStatuses: distinct headRefNames → distinct keys; missing headRefName skipped", async () => {
+  const prs = [
+    {
+      number: 1,
+      url: "u1",
+      title: "a",
+      state: "OPEN",
+      headRefName: "branch-a",
+      headRepositoryOwner: { login: "o" },
+    },
+    {
+      number: 2,
+      url: "u2",
+      title: "b",
+      state: "OPEN",
+      headRefName: "branch-b",
+      headRepositoryOwner: { login: "o" },
+    },
+    { number: 3, url: "u3", title: "c", state: "OPEN" /* no headRefName */ },
+  ];
+  const { run } = fakeRunner({ "pr list": JSON.stringify(prs) });
+  const forge = new GithubForge("o/r", {}, run);
+  const map = await forge.listOpenPrStatuses!();
+  expect(map.size).toBe(2);
+  expect(map.has("branch-a")).toBe(true);
+  expect(map.has("branch-b")).toBe(true);
+  expect(map.get("branch-a")!.number).toBe(1);
+  expect(map.get("branch-b")!.number).toBe(2);
+});
+
+test("listOpenPrStatuses: cap log fires once at ≥200, latches on second call", async () => {
+  const prs200 = Array.from({ length: 200 }, (_, i) => ({
+    number: i + 1,
+    url: `u${i + 1}`,
+    title: `pr${i + 1}`,
+    state: "OPEN",
+    headRefName: `branch-${i + 1}`,
+  }));
+  const { run } = fakeRunner({ "pr list": JSON.stringify(prs200) });
+  const forge = new GithubForge("o/r", {}, run);
+
+  const warnCalls: unknown[][] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => warnCalls.push(args);
+  try {
+    await forge.listOpenPrStatuses!();
+    await forge.listOpenPrStatuses!(); // second call: latch must suppress
+  } finally {
+    console.warn = origWarn;
+  }
+
+  expect(warnCalls.length).toBe(1);
+  expect(String(warnCalls[0]![0])).toContain("≥200");
+});
+
+test("countOpenPrs: returns array length from --json number response", async () => {
+  const prs = Array.from({ length: 7 }, (_, i) => ({ number: i + 1 }));
+  const { run, calls } = fakeRunner({ "pr list": JSON.stringify(prs) });
+  const forge = new GithubForge("o/r", {}, run);
+  const count = await forge.countOpenPrs!();
+  expect(count).toBe(7);
+  const listCall = calls.find((c) => c[0] === "pr" && c[1] === "list")!;
+  expect(listCall).toContain("number");
+  expect(listCall).toContain("open");
+});

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -1242,8 +1242,9 @@ function forgeWithBatch(
 test("batch hit: open PR served from batch, no per-session prStatus", async () => {
   const store = new SessionStore(":memory:");
   const s = store.create(baseSession); // branch shepherd/x
+  store.create({ ...baseSession, branch: "shepherd/dummy" }); // second session — satisfies count≥2 floor
   const emitted: { id: string; state: string }[] = [];
-  const { forge, stats } = forgeWithBatch({ "shepherd/x": OPEN });
+  const { forge, stats } = forgeWithBatch({ "shepherd/x": OPEN, "shepherd/dummy": NONE });
   const poller = new PrPoller(
     store,
     () => forge,
@@ -1251,7 +1252,7 @@ test("batch hit: open PR served from batch, no per-session prStatus", async () =
   );
 
   await poller.tick();
-  expect(emitted).toEqual([{ id: s.id, state: "open" }]);
+  expect(emitted).toContainEqual({ id: s.id, state: "open" });
   expect(stats.prStatus).toBe(0);
   expect(stats.list).toBe(1);
 });
@@ -1296,13 +1297,14 @@ test("fork mode never batches — falls back to per-session prStatus", async () 
 });
 
 test("count-gate: over-ratio falls back to per-session, under-ratio batches", async () => {
-  // over-ratio: 100 open PRs vs 1 session → 100 > 2×1 → per-session
+  // over-ratio: 100 open PRs vs 2 sessions → 100 > 2×2=4 → per-session (ratio gate)
   {
     const store = new SessionStore(":memory:");
-    store.create(baseSession);
+    store.create({ ...baseSession, branch: "shepherd/a" });
+    store.create({ ...baseSession, branch: "shepherd/b" });
     const { forge, stats } = forgeWithBatch(
-      { "shepherd/x": OPEN },
-      { count: 100, prStatusByBranch: { "shepherd/x": OPEN } },
+      {},
+      { count: 100, prStatusByBranch: { "shepherd/a": OPEN, "shepherd/b": OPEN } },
     );
     const poller = new PrPoller(
       store,
@@ -1312,13 +1314,17 @@ test("count-gate: over-ratio falls back to per-session, under-ratio batches", as
     await poller.tick();
     expect(stats.count).toBe(1);
     expect(stats.list).toBe(0); // gate fails → no batch list
-    expect(stats.prStatus).toBe(1); // per-session
+    expect(stats.prStatus).toBe(2); // per-session for both
   }
-  // under-ratio: 1 open PR vs 1 session → 1 ≤ 2 → batch
+  // under-ratio: 1 open PR vs 2 sessions → 1 ≤ 2×2=4 → batch
   {
     const store = new SessionStore(":memory:");
-    store.create(baseSession);
-    const { forge, stats } = forgeWithBatch({ "shepherd/x": OPEN }, { count: 1 });
+    store.create({ ...baseSession, branch: "shepherd/a" });
+    store.create({ ...baseSession, branch: "shepherd/b" });
+    const { forge, stats } = forgeWithBatch(
+      { "shepherd/a": OPEN, "shepherd/b": NONE },
+      { count: 1 },
+    );
     const poller = new PrPoller(
       store,
       () => forge,
@@ -1332,8 +1338,10 @@ test("count-gate: over-ratio falls back to per-session, under-ratio batches", as
 
 test("merged transition: batch miss + prev-open → per-session confirm emits merged", async () => {
   const store = new SessionStore(":memory:");
-  store.create(baseSession);
-  const open: Record<string, PrStatus> = { "shepherd/x": OPEN }; // #7
+  // dummy created FIRST so it is processed first in tick, shepherd/x last → emitted.at(-1) tracks shepherd/x
+  store.create({ ...baseSession, branch: "shepherd/dummy" }); // second session — satisfies count≥2 floor
+  store.create(baseSession); // shepherd/x
+  const open: Record<string, PrStatus> = { "shepherd/x": OPEN, "shepherd/dummy": NONE }; // #7
   const prByBranch: Record<string, PrStatus> = {};
   const { forge, stats } = forgeWithBatch(open, { prStatusByBranch: prByBranch });
   const emitted: { state: string; number?: number }[] = [];
@@ -1396,8 +1404,10 @@ test("stale-terminal guard under batch: reused-name merged dropped to none", asy
 
 test("rename present in batch adopted next sweep with no extra prStatus", async () => {
   const store = new SessionStore(":memory:");
+  // dummy created FIRST (always in batch) so it never calls prStatus; shepherd/x SECOND
+  store.create({ ...baseSession, branch: "shepherd/dummy" }); // satisfies count≥2 floor
   store.create(baseSession); // shepherd/x
-  const open: Record<string, PrStatus> = {}; // miss for shepherd/x
+  const open: Record<string, PrStatus> = { "shepherd/dummy": NONE }; // dummy always in batch; shepherd/x initially missing
   let live: string | null = null;
   const { forge, stats } = forgeWithBatch(open, { prStatusByBranch: {} });
   const emitted: { state: string; number?: number }[] = [];
@@ -1410,9 +1420,9 @@ test("rename present in batch adopted next sweep with no extra prStatus", async 
     () => live,
   );
 
-  await poller.tick(); // tick1: miss + prev null → one confirm (none) → reconcile null → none
-  expect(stats.prStatus).toBe(1);
-  expect(emitted.at(-1)?.state).toBe("none");
+  await poller.tick(); // tick1: dummy batch hit (none); shepherd/x miss → one confirm (none) → reconcile null → none
+  expect(stats.prStatus).toBe(1); // only shepherd/x called prStatus
+  expect(emitted.at(-1)?.state).toBe("none"); // shepherd/x processed last
 
   // tick2 (within noneRecheckMs): rename visible + open PR present on renamed branch
   live = "shepherd/renamed";
@@ -1443,8 +1453,9 @@ test("rename via pollSession (per-session path) adopts the renamed branch", asyn
 
 test("cold-cache none: confirmed once then skipped within the recheck window", async () => {
   const store = new SessionStore(":memory:");
-  store.create(baseSession);
-  const { forge, stats } = forgeWithBatch({}, { prStatusByBranch: {} });
+  store.create(baseSession); // shepherd/x
+  store.create({ ...baseSession, branch: "shepherd/dummy" }); // satisfies count≥2 floor; always hits batch → no prStatus
+  const { forge, stats } = forgeWithBatch({ "shepherd/dummy": NONE }, { prStatusByBranch: {} });
   const poller = new PrPoller(
     store,
     () => forge,
@@ -1454,9 +1465,9 @@ test("cold-cache none: confirmed once then skipped within the recheck window", a
     () => null,
   );
 
-  await poller.tick(); // prev null → confirm once → none cached
+  await poller.tick(); // shepherd/x: prev null → confirm once → none cached; dummy: batch hit
   expect(stats.prStatus).toBe(1);
-  await poller.tick(); // within noneRecheckMs, prev none → no re-confirm
+  await poller.tick(); // shepherd/x: within noneRecheckMs, prev none → no re-confirm; dummy: batch hit unchanged
   expect(stats.prStatus).toBe(1);
 });
 
@@ -1501,10 +1512,13 @@ test("stuck-none heals after noneRecheckMs via a per-session re-confirm", async 
 
 test("multi-repo: one batch call per distinct slug", async () => {
   const store = new SessionStore(":memory:");
-  store.create({ ...baseSession, repoPath: "/a", branch: "shepherd/a" });
-  store.create({ ...baseSession, repoPath: "/b", branch: "shepherd/b" });
-  const a = forgeWithBatch({ "shepherd/a": OPEN }, { slug: "o/a" });
-  const b = forgeWithBatch({ "shepherd/b": OPEN }, { slug: "o/b" });
+  // Two sessions per repo so each slug has count≥2 and passes the single-session floor
+  store.create({ ...baseSession, repoPath: "/a", branch: "shepherd/a1" });
+  store.create({ ...baseSession, repoPath: "/a", branch: "shepherd/a2" });
+  store.create({ ...baseSession, repoPath: "/b", branch: "shepherd/b1" });
+  store.create({ ...baseSession, repoPath: "/b", branch: "shepherd/b2" });
+  const a = forgeWithBatch({ "shepherd/a1": OPEN, "shepherd/a2": NONE }, { slug: "o/a" });
+  const b = forgeWithBatch({ "shepherd/b1": OPEN, "shepherd/b2": NONE }, { slug: "o/b" });
   const poller = new PrPoller(
     store,
     (repo) => (repo === "/a" ? a.forge : b.forge),
@@ -1568,4 +1582,81 @@ test("single-gh: batch (count/list) + per-session never overlap (maxActive 1)", 
   await sweep;
   await new Promise((r) => setTimeout(r, 60));
   expect(maxActive).toBe(1);
+});
+
+// ── M1: single-session floor + M2: P≥200 cap-hit ─────────────────────────────
+
+test("single-session floor: count<2 skips count probe and batch, serves via prStatus", async () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession); // one session → count=1 in buildBatches
+  const { forge, stats } = forgeWithBatch(
+    { "shepherd/x": OPEN },
+    { prStatusByBranch: { "shepherd/x": OPEN } },
+  );
+  const emitted: { state: string }[] = [];
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    (_id, g) => emitted.push({ state: g.state }),
+  );
+
+  await poller.tick();
+  // count<2 floor fires before count probe — neither countOpenPrs nor listOpenPrStatuses called
+  expect(stats.count).toBe(0);
+  expect(stats.list).toBe(0);
+  expect(stats.prStatus).toBe(1); // per-session fallback
+  expect(emitted).toEqual([{ state: "open" }]);
+});
+
+test("single-session floor boundary: 2 sessions for same repo still batch", async () => {
+  // regression guard: count=2 is the break-even point — must not be floored
+  const store = new SessionStore(":memory:");
+  store.create({ ...baseSession, branch: "shepherd/a" });
+  store.create({ ...baseSession, branch: "shepherd/b" });
+  const { forge, stats } = forgeWithBatch({ "shepherd/a": OPEN, "shepherd/b": NONE }, { count: 1 });
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    () => {},
+  );
+
+  await poller.tick();
+  expect(stats.count).toBe(1); // count=2 passes floor → count probe runs
+  expect(stats.list).toBe(1); // batch list called
+  expect(stats.prStatus).toBe(0); // no per-session calls
+});
+
+test("cap-hit: countOpenPrs≥200 forces per-session regardless of ratio", async () => {
+  // 3 sessions + batchOpenRatio=1000 → ratio gate (200 > 1000×3=3000) cannot trip;
+  // only the explicit p≥200 cap-hit clause forces per-session here.
+  const store = new SessionStore(":memory:");
+  for (let i = 0; i < 3; i++) store.create({ ...baseSession, branch: `shepherd/${i}` });
+  const { forge, stats } = forgeWithBatch(
+    { "shepherd/0": OPEN, "shepherd/1": OPEN, "shepherd/2": OPEN },
+    {
+      count: 200,
+      prStatusByBranch: { "shepherd/0": OPEN, "shepherd/1": OPEN, "shepherd/2": OPEN },
+    },
+  );
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    () => {},
+    120_000,
+    1000,
+    () => null,
+    15_000,
+    8,
+    () => true,
+    () => true,
+    () => false,
+    300_000,
+    300_000,
+    1000, // very high batchOpenRatio — only p≥200 can force per-session here
+  );
+
+  await poller.tick();
+  expect(stats.count).toBe(1); // count probe ran (count=3 passes floor)
+  expect(stats.list).toBe(0); // cap-hit (p=200 ≥ 200) → no list
+  expect(stats.prStatus).toBe(3); // per-session for all 3 sessions
 });

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -1193,3 +1193,379 @@ test("transientSince entry is deleted on drop()", async () => {
   expect(ts.has(s.id)).toBe(false);
   expect(poller.snapshot()[s.id]).toBeUndefined();
 });
+
+// ── Task 2: per-repo batch full sweep (count-gate + bounds) ────────────────────
+
+/** A forge double implementing the batch methods (`listOpenPrStatuses` /
+ *  `countOpenPrs`). `openByBranch` / `prStatusByBranch` are read live on each call,
+ *  so tests can mutate them between ticks. `stats` counts each path's calls. */
+function forgeWithBatch(
+  openByBranch: Record<string, PrStatus>,
+  opts: {
+    isFork?: boolean;
+    count?: number;
+    slug?: string;
+    prStatusByBranch?: Record<string, PrStatus>;
+  } = {},
+): { forge: GitForge; stats: { list: number; count: number; prStatus: number } } {
+  const stats = { list: 0, count: 0, prStatus: 0 };
+  const forge: GitForge = {
+    kind: "github",
+    slug: opts.slug ?? "o/r",
+    mergeMethod: "squash",
+    deployWorkflow: null,
+    isFork: opts.isFork,
+    listIssues: async () => [],
+    listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
+    prStatus: async (head: string) => {
+      stats.prStatus++;
+      return opts.prStatusByBranch?.[head] ?? NONE;
+    },
+    listOpenPrStatuses: async () => {
+      stats.list++;
+      return new Map(Object.entries(openByBranch));
+    },
+    countOpenPrs: async () => {
+      stats.count++;
+      return opts.count ?? Object.keys(openByBranch).length;
+    },
+    openPr: async () => NONE,
+    merge: async () => {},
+    redeploy: async () => {},
+    postReview: async () => ({}),
+    defaultBranch: async () => "main",
+  };
+  return { forge, stats };
+}
+
+test("batch hit: open PR served from batch, no per-session prStatus", async () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession); // branch shepherd/x
+  const emitted: { id: string; state: string }[] = [];
+  const { forge, stats } = forgeWithBatch({ "shepherd/x": OPEN });
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    (id, git) => emitted.push({ id, state: git.state }),
+  );
+
+  await poller.tick();
+  expect(emitted).toEqual([{ id: s.id, state: "open" }]);
+  expect(stats.prStatus).toBe(0);
+  expect(stats.list).toBe(1);
+});
+
+test("O(repos): five sessions on one forge resolve via a single batch call", async () => {
+  const store = new SessionStore(":memory:");
+  for (let i = 0; i < 5; i++) store.create({ ...baseSession, branch: `shepherd/${i}` });
+  const open: Record<string, PrStatus> = {};
+  for (let i = 0; i < 5; i++) open[`shepherd/${i}`] = { ...OPEN, number: i + 1 };
+  const emitted: string[] = [];
+  const { forge, stats } = forgeWithBatch(open);
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    (_id, g) => emitted.push(g.state),
+  );
+
+  await poller.tick();
+  expect(stats.list).toBe(1);
+  expect(stats.prStatus).toBe(0);
+  expect(emitted.filter((s) => s === "open").length).toBe(5);
+});
+
+test("fork mode never batches — falls back to per-session prStatus", async () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  const { forge, stats } = forgeWithBatch(
+    { "shepherd/x": OPEN },
+    { isFork: true, prStatusByBranch: { "shepherd/x": OPEN } },
+  );
+  const emitted: string[] = [];
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    (_id, g) => emitted.push(g.state),
+  );
+
+  await poller.tick();
+  expect(stats.list).toBe(0); // fork → never batched
+  expect(stats.prStatus).toBe(1); // per-session fallback
+  expect(emitted).toEqual(["open"]);
+});
+
+test("count-gate: over-ratio falls back to per-session, under-ratio batches", async () => {
+  // over-ratio: 100 open PRs vs 1 session → 100 > 2×1 → per-session
+  {
+    const store = new SessionStore(":memory:");
+    store.create(baseSession);
+    const { forge, stats } = forgeWithBatch(
+      { "shepherd/x": OPEN },
+      { count: 100, prStatusByBranch: { "shepherd/x": OPEN } },
+    );
+    const poller = new PrPoller(
+      store,
+      () => forge,
+      () => {},
+    );
+    await poller.tick();
+    expect(stats.count).toBe(1);
+    expect(stats.list).toBe(0); // gate fails → no batch list
+    expect(stats.prStatus).toBe(1); // per-session
+  }
+  // under-ratio: 1 open PR vs 1 session → 1 ≤ 2 → batch
+  {
+    const store = new SessionStore(":memory:");
+    store.create(baseSession);
+    const { forge, stats } = forgeWithBatch({ "shepherd/x": OPEN }, { count: 1 });
+    const poller = new PrPoller(
+      store,
+      () => forge,
+      () => {},
+    );
+    await poller.tick();
+    expect(stats.list).toBe(1);
+    expect(stats.prStatus).toBe(0);
+  }
+});
+
+test("merged transition: batch miss + prev-open → per-session confirm emits merged", async () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  const open: Record<string, PrStatus> = { "shepherd/x": OPEN }; // #7
+  const prByBranch: Record<string, PrStatus> = {};
+  const { forge, stats } = forgeWithBatch(open, { prStatusByBranch: prByBranch });
+  const emitted: { state: string; number?: number }[] = [];
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    (_id, g) => emitted.push({ state: g.state, number: g.number }),
+  );
+
+  await poller.tick(); // batch hit open #7
+  expect(emitted.at(-1)).toEqual({ state: "open", number: 7 });
+  const before = stats.prStatus;
+
+  // tick 2: batch miss + per-session reports merged #7 (prev open #7 → trustsTerminal)
+  delete open["shepherd/x"];
+  prByBranch["shepherd/x"] = {
+    state: "merged",
+    number: 7,
+    checks: "success",
+    headSha: "h7",
+    deployConfigured: false,
+  };
+  await poller.tick();
+  expect(stats.prStatus).toBe(before + 1); // exactly one confirm call
+  expect(emitted.at(-1)?.state).toBe("merged");
+});
+
+test("stale-terminal guard under batch: reused-name merged dropped to none", async () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  const open: Record<string, PrStatus> = { "shepherd/x": OPEN }; // #7
+  const prByBranch: Record<string, PrStatus> = {};
+  const { forge } = forgeWithBatch(open, { prStatusByBranch: prByBranch });
+  const emitted: { state: string; number?: number }[] = [];
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    (_id, g) => emitted.push({ state: g.state, number: g.number }),
+    120_000,
+    1000,
+    () => null,
+    15_000,
+    8,
+    () => false, // ownsPr false → reused-name terminal rejected
+  );
+
+  await poller.tick(); // open #7 cached
+  delete open["shepherd/x"];
+  prByBranch["shepherd/x"] = {
+    state: "merged",
+    number: 8,
+    checks: "success",
+    headSha: "x",
+    deployConfigured: false,
+  };
+  await poller.tick(); // miss → confirm merged #8 (different number) → guard → none
+  expect(emitted.at(-1)).toEqual({ state: "none", number: undefined });
+  expect(poller.snapshot()[s.id]?.state).toBe("none");
+});
+
+test("rename present in batch adopted next sweep with no extra prStatus", async () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession); // shepherd/x
+  const open: Record<string, PrStatus> = {}; // miss for shepherd/x
+  let live: string | null = null;
+  const { forge, stats } = forgeWithBatch(open, { prStatusByBranch: {} });
+  const emitted: { state: string; number?: number }[] = [];
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    (_id, g) => emitted.push({ state: g.state, number: g.number }),
+    120_000,
+    1000,
+    () => live,
+  );
+
+  await poller.tick(); // tick1: miss + prev null → one confirm (none) → reconcile null → none
+  expect(stats.prStatus).toBe(1);
+  expect(emitted.at(-1)?.state).toBe("none");
+
+  // tick2 (within noneRecheckMs): rename visible + open PR present on renamed branch
+  live = "shepherd/renamed";
+  open["shepherd/renamed"] = OPEN;
+  await poller.tick();
+  expect(stats.prStatus).toBe(1); // adopted from batch — no extra GraphQL
+  expect(emitted.at(-1)).toEqual({ state: "open", number: 7 });
+});
+
+test("rename via pollSession (per-session path) adopts the renamed branch", async () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  const { forge } = forgeWithBatch({}, { prStatusByBranch: { "shepherd/renamed": OPEN } });
+  const emitted: { state: string }[] = [];
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    (_id, g) => emitted.push({ state: g.state }),
+    120_000,
+    0, // no debounce
+    () => "shepherd/renamed",
+  );
+
+  poller.pollSession(s.id);
+  await tick();
+  expect(emitted.at(-1)).toEqual({ state: "open" });
+});
+
+test("cold-cache none: confirmed once then skipped within the recheck window", async () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  const { forge, stats } = forgeWithBatch({}, { prStatusByBranch: {} });
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    () => {},
+    120_000,
+    1000,
+    () => null,
+  );
+
+  await poller.tick(); // prev null → confirm once → none cached
+  expect(stats.prStatus).toBe(1);
+  await poller.tick(); // within noneRecheckMs, prev none → no re-confirm
+  expect(stats.prStatus).toBe(1);
+});
+
+test("stuck-none heals after noneRecheckMs via a per-session re-confirm", async () => {
+  const store = new SessionStore(":memory:");
+  store.create(baseSession);
+  const prByBranch: Record<string, PrStatus> = {};
+  const { forge } = forgeWithBatch({}, { prStatusByBranch: prByBranch });
+  const emitted: { state: string }[] = [];
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    (_id, g) => emitted.push({ state: g.state }),
+    120_000,
+    1000,
+    () => null,
+    15_000,
+    8,
+    () => true, // ownsPr true → keep the merge
+    () => true,
+    () => false,
+    300_000,
+    300_000,
+    2, // batchOpenRatio
+    0, // noneRecheckMs → every sweep re-confirms a cached none
+  );
+
+  await poller.tick(); // none cached
+  expect(emitted.at(-1)?.state).toBe("none");
+
+  // PR merged between sweeps — a --state open batch can't surface it
+  prByBranch["shepherd/x"] = {
+    state: "merged",
+    number: 5,
+    checks: "success",
+    headSha: "h5",
+    deployConfigured: false,
+  };
+  await poller.tick(); // recheckNone → confirm → merged
+  expect(emitted.at(-1)?.state).toBe("merged");
+});
+
+test("multi-repo: one batch call per distinct slug", async () => {
+  const store = new SessionStore(":memory:");
+  store.create({ ...baseSession, repoPath: "/a", branch: "shepherd/a" });
+  store.create({ ...baseSession, repoPath: "/b", branch: "shepherd/b" });
+  const a = forgeWithBatch({ "shepherd/a": OPEN }, { slug: "o/a" });
+  const b = forgeWithBatch({ "shepherd/b": OPEN }, { slug: "o/b" });
+  const poller = new PrPoller(
+    store,
+    (repo) => (repo === "/a" ? a.forge : b.forge),
+    () => {},
+  );
+
+  await poller.tick();
+  expect(a.stats.list).toBe(1);
+  expect(b.stats.list).toBe(1);
+  expect(a.stats.prStatus).toBe(0);
+  expect(b.stats.prStatus).toBe(0);
+});
+
+test("single-gh: batch (count/list) + per-session never overlap (maxActive 1)", async () => {
+  const store = new SessionStore(":memory:");
+  for (let i = 0; i < 3; i++) store.create({ ...baseSession, branch: `shepherd/${i}` });
+  let active = 0;
+  let maxActive = 0;
+  const bump = async () => {
+    active++;
+    maxActive = Math.max(maxActive, active);
+    await new Promise((r) => setTimeout(r, 5));
+    active--;
+  };
+  const forge: GitForge = {
+    kind: "github",
+    slug: "o/r",
+    mergeMethod: "squash",
+    deployWorkflow: null,
+    listIssues: async () => [],
+    listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
+    prStatus: async () => {
+      await bump();
+      return NONE;
+    },
+    listOpenPrStatuses: async () => {
+      await bump();
+      return new Map();
+    },
+    countOpenPrs: async () => {
+      await bump();
+      return 0;
+    },
+    openPr: async () => NONE,
+    merge: async () => {},
+    redeploy: async () => {},
+    postReview: async () => ({}),
+    defaultBranch: async () => "main",
+  };
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    () => {},
+    120_000,
+    0, // fire the targeted poll immediately so it races the sweep
+  );
+
+  const sweep = poller.tick();
+  poller.pollSession(store.list({ activeOnly: true })[0]!.id);
+  await sweep;
+  await new Promise((r) => setTimeout(r, 60));
+  expect(maxActive).toBe(1);
+});


### PR DESCRIPTION
Closes #1233. Follow-up to #1230 (item 2).

## What

Collapse the PR poller's **full sweep** from one `gh pr list --head <branch>` **per active session** (O(sessions) GraphQL calls every 120s) into **one `gh pr list --state open` per repo** (O(repos)), matching results to sessions locally by `headRefName`. GitHub-only; Gitea/Local transparently keep the per-session path.

## How

- **`GithubForge.listOpenPrStatuses()`** — one `gh pr list --state open --limit 200` → `Map<headRefName, PrStatus>`. Shares one extracted `mapGhPr` with `prStatus` for **field-mapping parity**; deterministic head-owner dedup (`forkOwner ?? owner(slug)`) — an intended, pinned divergence from `prStatus`'s order-dependent `prs[0]` in the rare cross-fork `headRefName` collision.
- **`GithubForge.countOpenPrs()`** — cheap `gh pr list --json number --limit 200` (~1 GraphQL pt) gating the batch.
- **`PrPoller.tick`** prefetches one batch per distinct repo (`buildBatches`, keyed by slug) and matches locally. `fastTick`/`refreshOne`/`pollSession` are unchanged.

## Cost guards (this is a GraphQL-**points** change, not just request count)

Measured: a full-rollup batch costs **~0.4 pt/open-PR** vs **~1 pt/session** per-session — so the batch only wins points when open-PRs (`P`) aren't ≫ sessions (`S`). Guards keep the steady state at the cheaper of {batch, baseline} per repo:

- **Fork mode → never batch** (upstream `P` = every contributor's PRs; e.g. a 100-PR upstream = ~44 pts × 30 sweeps/hr).
- **Non-fork count-gate** — batch only when `S ≥ 2` **and** `P ≤ 2·S` **and** `P < 200` (cap-hit); else per-session. The `S ≥ 2` floor avoids a single-session repo paying 2 calls where per-session paid 1.

**Verify (vs baseline, both axes):** common Shepherd repo (S=P=10) 300→**150** pts/hr & 300→**60** req/hr; low-S/high-P non-fork falls back (≤~30 pts/hr count-probe overhead, avoids a ~1200 pts/hr blow-up); fork upstream falls back with zero overhead. No points regression on any profile.

## Behavior preserved (all tested)

A `--state open` batch can't return terminal PRs, so a batch miss confirms via per-session `prStatus` (`--state all`) only when `marked || prev == null || prev.state !== "none" || recheckNone`. `reconcileBranch` still runs **every sweep** (local git) with a batch-first lookup, so open-rename adoption stays at the 120s cadence; only a terminal/absent-rename for a cached-`none` session coarsens to ≤ `noneRecheckMs` (600s) — `pollSession` adopts promptly. Stale-terminal guard (`guard`/`trustsTerminal`/`ownsPr`), handoff annotation, transient tracking, and the single-`gh` (`withGh`) invariant all hold under the batch path.

## Tests

`mapGhPr` parity, fork/non-fork owner dedup, cap-log latch, count-gate (S≥2 floor, ratio, P≥200), merged-transition confirm, stale-terminal-under-batch, rename-via-batch / rename-via-pollSession / rename-heal-after-window, cold-none confirm-then-skip, stuck-none heal, multi-repo one-call-per-slug, and a single-`gh` race (maxActive=1). Full suite **5357 pass / 0 fail**; lint, typecheck, `fallow audit`, branch hygiene clean.

## Out of scope / follow-ups

- Fast sweep (`fastTick`) → literal O(repos): #1241 (already bounded to a constant cap, so it meets "not O(sessions+PRs)" today). Trimmed custom-GraphQL variant rides the same issue.
- Unify the three per-repo open-PR queries behind one cached snapshot: #1240.

[no-feature-entry] server-only polling change, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
