### PR TITLE
fix(gitrail): surface forge-error fallback so the PR rail never renders empty

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -92,6 +92,7 @@
   "gitrail_confirm_redeploy": "bestätigen ⟳",
   "gitrail_redeploy": "⟳ Redeploy",
   "gitrail_closed": "geschlossen",
+  "gitrail_status_failed": "PR-Status nicht verfügbar",
   "gitrail_pr_title_placeholder": "PR-Titel",
   "gitrail_pr_description_placeholder": "Beschreibung",
   "gitrail_cancel": "Abbrechen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -92,6 +92,7 @@
   "gitrail_confirm_redeploy": "confirm ⟳",
   "gitrail_redeploy": "⟳ Redeploy",
   "gitrail_closed": "closed",
+  "gitrail_status_failed": "PR status unavailable",
   "gitrail_pr_title_placeholder": "PR title",
   "gitrail_pr_description_placeholder": "Description",
   "gitrail_cancel": "Cancel",

--- a/ui/src/lib/components/GitRail.browser.test.ts
+++ b/ui/src/lib/components/GitRail.browser.test.ts
@@ -525,6 +525,53 @@ describe("GitRail — controls stay within the cell", () => {
   });
 });
 
+describe("GitRail — forge-error fallback (no silent-empty rail)", () => {
+  // Regression: a thrown gitState (forge 502 — e.g. GitHub rate-limited) used to set
+  // git=null and render NOTHING — no PR link, no error, no retry. The desktop PR
+  // disclosure strip then showed only the surrounding autopilot control, so the
+  // operator saw "missing buttons" and couldn't open the PR. The fetch retry was also
+  // gated on git?.state === "open", so a null (failed) state never recovered.
+  it("desktop — gitState rejects → shows error + Retry instead of an empty rail", async () => {
+    gitStateFn.mockRejectedValue(new Error("forge 502"));
+    await page.viewport(600, 900);
+    const h = host(600);
+    render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    // the error fallback appears (not a blank rail)
+    await vi.waitFor(() =>
+      expect(h.querySelector<HTMLElement>(".err")?.textContent?.trim()).toBe(
+        m.gitrail_status_failed(),
+      ),
+    );
+    // a Retry button is present and the full PR control set is NOT rendered
+    const retry = [...h.querySelectorAll<HTMLButtonElement>("button.gbtn")].find(
+      (b) => b.textContent?.trim() === m.common_retry(),
+    );
+    expect(retry, "Retry button present").not.toBeUndefined();
+    expect(h.querySelector("a[href]"), "no PR link while load failed").toBeNull();
+  });
+
+  it("desktop — Retry after the forge recovers renders the full PR rail", async () => {
+    gitStateFn.mockRejectedValue(new Error("forge 502"));
+    await page.viewport(600, 900);
+    const h = host(600);
+    render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await vi.waitFor(() => expect(h.querySelector(".err")).not.toBeNull());
+
+    // forge recovers; clicking Retry re-fetches and the rail self-heals
+    gitStateFn.mockResolvedValue(openPrState);
+    const retry = [...h.querySelectorAll<HTMLButtonElement>("button.gbtn")].find(
+      (b) => b.textContent?.trim() === m.common_retry(),
+    )!;
+    retry.click();
+    await vi.waitFor(() => {
+      const link = h.querySelector<HTMLAnchorElement>("a.prlink");
+      expect(link, "PR link rendered after retry").not.toBeNull();
+      expect(link!.getAttribute("href")).toBe(openPrState.url);
+    });
+    expect(h.querySelector(".err"), "error cleared after successful retry").toBeNull();
+  });
+});
+
 describe("GitRail — mobile scroll affordance", () => {
   it("mobile 360px — overflowing rail fades its trailing edge to cue the scroll", async () => {
     gitStateFn.mockResolvedValue(openPrState);

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -72,6 +72,11 @@
   let err = $state<string | null>(null);
   // which handler last failed, so the inline Retry re-invokes the same action
   let retry = $state<(() => void) | null>(null);
+  // the initial PR-status fetch threw (forge error, e.g. 502 when GitHub is
+  // rate-limited) — distinct from a legit 404 (gitState returns null silently for
+  // "no forge / no PR"). Drives the error+Retry fallback so the rail never renders
+  // silently empty, and keeps the poll retrying until the forge recovers.
+  let loadFailed = $state(false);
 
   // Open-PR popover
   let showPr = $state(false);
@@ -109,9 +114,18 @@
   async function load(id: string) {
     try {
       const g = await gitState(id);
-      if (id === sessionId) git = g;
+      if (id === sessionId) {
+        git = g;
+        loadFailed = false;
+      }
     } catch {
-      if (id === sessionId) git = null;
+      // The forge call failed (non-404 — gitState already maps 404 to a silent null
+      // for "no forge / no PR"). Flag it so the rail shows a Retry affordance instead
+      // of rendering empty, and so the poll below keeps retrying until it recovers.
+      if (id === sessionId) {
+        git = null;
+        loadFailed = true;
+      }
     }
   }
 
@@ -147,11 +161,14 @@
     showReview = false;
     showAutomation = false;
     awaitingPlanReview = false;
+    loadFailed = false;
     load(id);
-    // light poll only while a PR is open (CI/merge state can change);
-    // hidden-tab ticks are skipped, with a refresh on tab return
+    // light poll while a PR is open (CI/merge state can change) OR while the last load
+    // failed — a transient forge error (e.g. GitHub rate-limited) then clears on its own
+    // instead of leaving the rail permanently blank. Hidden-tab ticks are skipped, with
+    // a refresh on tab return.
     return pollWhileVisible(() => {
-      if (git?.state === "open") load(id);
+      if (loadFailed || git?.state === "open") load(id);
     }, 15000);
   });
 
@@ -771,6 +788,21 @@
         {/if}
       </div>
     {/if}
+  </span>
+{:else if loadFailed}
+  <!-- the forge call failed (e.g. 502 — GitHub rate-limited). Without this branch the
+       rail rendered nothing: no PR link, no error, no way to retry — the operator just
+       saw missing buttons and couldn't open the PR. Surface the failure + a manual
+       retry; the 15s poll also keeps retrying so a transient rate-limit clears itself. -->
+  <span class="git-rail-wrap" class:mobile>
+    <span class="rail" class:mobile use:edgeFades={mobile}>
+      <span class="err" role="alert" title={m.gitrail_status_failed()}
+        >{m.gitrail_status_failed()}</span
+      >
+      <button class="gbtn" type="button" disabled={busy} onclick={() => load(sessionId)}
+        >{m.common_retry()}</button
+      >
+    </span>
   </span>
 {/if}
 


### PR DESCRIPTION
## Problem

On the desktop focused view, clicking the **● PR ▾** disclosure sometimes revealed a strip with **no buttons** — no PR link, no Merge, no Ready/critic controls — so you couldn't open the PR (the user's report: *"fehlen jede menge schaltflächen — man kann nicht auf PR klicken um den offenen PR anzeigen"*).

## Root cause

`GitRail` fetches its PR status from `GET /api/sessions/:id/git`. That endpoint returns **502** when the forge call fails — e.g. when **GitHub is rate-limited** (fittingly, the session in the screenshot was the *github-rate-limits* one). On that throw the client set `git = null` **silently**:

- the entire rail lives under `{#if git}`, so a null state rendered **nothing** — no PR link, no error, no retry;
- the 15s recovery poll was gated on `git?.state === "open"`, so a `null` (failed) state **never retried** — the strip stayed permanently blank until remount.

The only thing left in the disclosure strip was the surrounding autopilot toggle → "missing buttons".

Reproduced deterministically by returning 502 from the git endpoint: the strip collapses to just the autopilot control.

## Fix

- Track the thrown-load case (`loadFailed`) separately from a legit 404 (which `gitState` already maps to a silent `null` for "no forge / no PR").
- Render an inline **"PR status unavailable" + Retry** fallback instead of an empty rail (reuses the existing `.err` / `.gbtn` recipe, EN+DE).
- Let the 15s poll keep retrying while the last load failed, so a transient rate-limit **clears itself** without operator action.

## Verification

- Drove the live UI with Playwright: 502 → error+Retry shown (no blank strip); Retry / poll after recovery → full PR rail restored (PR ↗, Merge, Ready, REVIEWED, Re-review, automation pill).
- Added 2 regression tests to `GitRail.browser.test.ts` (forge-error fallback + recovery). Full suite: **61 passed**.
- `check:i18n` (2114 keys parity), `bun run check` (0 errors) green.

[no-feature-entry] — bug fix, no new user-facing capability.