### PR TITLE
chore(ui): dev proxy reads SHEPHERD_PORT, drop stray HERDR_PORT

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -69,11 +69,12 @@ export default defineConfig({
     // so Vite doesn't reject the forwarded Host header (*.ts.net).
     allowedHosts: [".ts.net"],
     proxy: {
-      // Backend port defaults to 7330; override with HERDR_PORT to point the dev UI at
-      // a worktree backend (e.g. testing a branch without disturbing the main instance).
-      "/api": `http://localhost:${process.env.HERDR_PORT ?? 7330}`,
-      "/events": { target: `ws://localhost:${process.env.HERDR_PORT ?? 7330}`, ws: true },
-      "/pty": { target: `ws://localhost:${process.env.HERDR_PORT ?? 7330}`, ws: true },
+      // Backend port defaults to 7330; override with SHEPHERD_PORT — the same var the
+      // backend reads (src/config.ts) — to point the dev UI at a worktree backend
+      // (e.g. testing a branch without disturbing the main instance).
+      "/api": `http://localhost:${process.env.SHEPHERD_PORT ?? 7330}`,
+      "/events": { target: `ws://localhost:${process.env.SHEPHERD_PORT ?? 7330}`, ws: true },
+      "/pty": { target: `ws://localhost:${process.env.SHEPHERD_PORT ?? 7330}`, ws: true },
     },
   },
   test: {


### PR DESCRIPTION
## Summary

Closes #1246. The dev-UI Vite proxy read `HERDR_PORT` while the backend reads `SHEPHERD_PORT` (`src/config.ts:368`) — two names for the same thing, the backend port. `HERDR_PORT` existed nowhere else in the repo, so an operator running the backend on a non-default port (`SHEPHERD_PORT=7331`, e.g. a worktree backend) had to *also* set the differently-named `HERDR_PORT` or the dev UI silently proxied to the wrong port.

This unifies on **`SHEPHERD_PORT`** as the single source of truth and drops the stray `HERDR_PORT`.

## Change

`ui/vite.config.ts` — the 3 proxy targets (`/api`, `/events`, `/pty`) now read `process.env.SHEPHERD_PORT ?? 7330`; the adjacent comment names `SHEPHERD_PORT` and points at the backend pairing.

Default dev flow is unchanged (`SHEPHERD_PORT` already defaults to 7330).

## Why drop instead of keep as fallback

`HERDR_PORT` has zero other references in the repo (no docs, scripts, or other code — confirmed by `grep -rn HERDR_PORT`), so there is nothing to stay compatible with, and a fallback chain would re-introduce the two-name confusion this issue closes.

## Verification

- `grep -rn HERDR_PORT` → no remaining references.
- `cd ui && bun run check` → 0 errors, 0 warnings.

## Scope notes

Dev-ergonomics only — no runtime/user-facing impact. Exempt from feature-catalog / i18n / glossary / design-system gates (no user-facing UX, no UI strings or components). `[no-feature-entry]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)