### PR TITLE
perf(pr-poller): batch the fast sweep per-repo (drop fastBatch cap/round-robin) (#1241)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -754,7 +754,6 @@ const prPoller = new PrPoller(
   // is recognized instead of staying invisible against the stale stored branch
   (s) => service.syncWorktreeBranch(s.id),
   undefined,
-  undefined,
   ownsPr,
   warm, // full cadence only while warm; cold → fast sweep pauses, full sweep throttles
   () => graphRateLimit.blocked(), // skip every sweep while the GraphQL bucket is exhausted

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -101,8 +101,12 @@ function gitStateChanged(prev: GitState | undefined, git: GitState): boolean {
  * `checks: "pending"` is short-lived and the 120s sweep routinely sampled `none`
  * then `success` two sweeps later, never recording the running state, so the
  * list jumped straight to green and never showed the pulsing "CI running" dot.
- * The fast sweep is capped at `fastBatch` open PRs per tick (round-robin beyond
- * it) so it never fans out one blocking `gh` per PR over an unbounded backlog.
+ * The fast sweep routes its eligible (transient, in-window) open PRs through the
+ * same per-repo batch path as `tick` (`buildBatches`/`batchForRepo` + count-gate):
+ * a repo whose transient PRs dominate its open set is refreshed with one
+ * `listOpenPrStatuses`; a repo with many stable open PRs beyond the few transient
+ * ones falls back to bounded per-session polls (the gate protects the 15s points
+ * budget). No per-PR cap or round-robin — every eligible PR is covered each tick.
  */
 export class PrPoller implements PrCache {
   private timer: ReturnType<typeof setInterval> | null = null;
@@ -119,10 +123,6 @@ export class PrPoller implements PrCache {
    *  up a backlog of queued ticks. The targeted poll does NOT consult it — it
    *  serializes via `ghChain` instead, so a turn-end poll is never dropped. */
   private sweeping = false;
-  /** Round-robin offset into the open-PR list when it exceeds `fastBatch`. */
-  private fastCursor = 0;
-  /** Latched so the over-cap notice logs once on transition, not every fast tick. */
-  private fastCapLogged = false;
   /** Tracks when each open PR entered (or re-entered via a new headSha) a transient
    *  state — used to time-bound how long `fastTick` keeps re-polling it. */
   private transientSince = new Map<string, { since: number; headSha?: string }>();
@@ -163,8 +163,6 @@ export class PrPoller implements PrCache {
     private reconcileBranch: (s: Session) => string | null = () => null,
     /** Fast cadence for re-polling open PRs (in-flight CI/merge state). */
     private fastIntervalMs = 15_000,
-    /** Max open PRs polled per fast tick; the rest rotate in on later ticks. */
-    private fastBatch = 8,
     /** Whether a name-matched terminal (merged/closed) PR's head commit actually
      *  belongs to the session's branch. Guards against `gh pr list --head <name>`
      *  returning a prior, already-merged PR that merely reused this branch name.
@@ -292,17 +290,19 @@ export class PrPoller implements PrCache {
 
   /** Accelerated re-poll of in-flight PRs (cached `state === "open"`) so the list
    *  overview tracks CI running/transition as live as the detail view, without the
-   *  120s sweep's lag. Capped at `fastBatch` per tick, rotating so every open PR is
-   *  covered across a few ticks rather than fanning out one `gh` per PR each time. */
+   *  120s sweep's lag. Routes the eligible (transient, in-window) open PRs through
+   *  the same per-repo batch path as the full sweep (`buildBatches`/`batchFor` +
+   *  count-gate): a repo whose transient PRs dominate its open set is refreshed
+   *  with one `listOpenPrStatuses`; a repo with stable open PRs beyond the few
+   *  transient ones trips the gate and falls back to bounded per-session polls. No
+   *  per-PR cap or round-robin — every eligible PR is covered each tick, O(repos)
+   *  when transient-dominant, O(eligible) per-session otherwise. */
   async fastTick(): Promise<void> {
     // Cadence gate first: skip entirely when rate-limited or not warm, before the activity-aware filter below.
     if (this.rateLimited() || !this.warm()) return;
     if (this.sweeping) return; // don't overlap (or double-poll behind) the full sweep
     const open = [...this.cache.entries()].filter(([, g]) => g.state === "open").map(([id]) => id);
-    if (open.length === 0) {
-      this.fastCapLogged = false; // dropped under cap (to zero) → re-arm the notice
-      return;
-    }
+    if (open.length === 0) return;
     // Activity-aware filter: only re-poll PRs that are still transient AND within
     // the time-bounded window. Stamp-missing (shouldn't happen normally) → eligible.
     const now = Date.now();
@@ -313,29 +313,28 @@ export class PrPoller implements PrCache {
       const since = entry?.since ?? now;
       return now - since < this.transientMaxMs;
     });
-    if (eligible.length === 0) {
-      this.fastCapLogged = false;
-      return;
-    }
-    let batch = eligible;
-    if (eligible.length > this.fastBatch) {
-      const start = this.fastCursor % eligible.length;
-      batch = [...eligible, ...eligible].slice(start, start + this.fastBatch);
-      this.fastCursor = (start + this.fastBatch) % eligible.length;
-      // Log once on entering the over-cap regime, not every 15s tick; re-arm
-      // below when the open-PR count drops back under the cap.
-      if (!this.fastCapLogged) {
-        console.warn(
-          `[pr-poller] ${eligible.length} transient open PRs exceed fast-poll cap ${this.fastBatch}; polling ${this.fastBatch}/tick round-robin`,
-        );
-        this.fastCapLogged = true;
-      }
-    } else {
-      this.fastCapLogged = false;
-    }
+    if (eligible.length === 0) return;
+    // Resolve to live sessions (an archived/gone session is pruned by the next full
+    // tick); the count-gate is fed only this eligible-transient set, so it weighs a
+    // batch against the per-session calls we'd actually make this tick.
+    const sessions = eligible
+      .map((id) => this.store.get(id))
+      .filter((s): s is Session => !!s && s.status !== "archived");
+    if (sessions.length === 0) return;
+    // Flag BEFORE buildBatches so its countOpenPrs/listOpenPrStatuses probe runs
+    // inside the mutual-exclusion window — a concurrent full tick can't interleave.
     this.sweeping = true;
     try {
-      for (const id of batch) await this.refreshOne(id);
+      const batches = await this.buildBatches(sessions);
+      for (const s of sessions) {
+        if (this.inFlight.has(s.id)) continue; // a targeted pollSession is already covering it
+        this.inFlight.add(s.id);
+        try {
+          await this.withGh(() => this.refresh(s, this.batchFor(s, batches)));
+        } finally {
+          this.inFlight.delete(s.id);
+        }
+      }
     } finally {
       this.sweeping = false;
     }

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -432,7 +432,6 @@ test("discards a merged PR whose head commit isn't on this session's branch (nam
     1000,
     () => null, // no other branch to adopt
     15_000,
-    8,
     () => false, // head commit does NOT belong to this session's branch
   );
 
@@ -454,7 +453,6 @@ test("keeps a merged PR whose head commit is on this session's branch", async ()
     1000,
     () => null,
     15_000,
-    8,
     () => true, // genuinely this session's own merged PR
   );
 
@@ -474,7 +472,6 @@ test("keeps a merged PR when ownership is unknowable (null) rather than hiding i
     1000,
     () => null,
     15_000,
-    8,
     () => null, // bad worktree / git error → don't mask a real merge
   );
 
@@ -494,7 +491,6 @@ test("never runs the ownership check for an open PR (name match is current)", as
     1000,
     () => null,
     15_000,
-    8,
     () => {
       ownsCalls++;
       return false;
@@ -518,7 +514,6 @@ test("applies the ownership guard to an adopted live branch's terminal PR too", 
     1000,
     () => "shepherd/renamed", // agent renamed the worktree branch
     15_000,
-    8,
     () => false, // the adopted branch's merged head isn't this session's commit
   );
 
@@ -556,74 +551,136 @@ test("fast tick re-polls only open PRs — accelerating in-flight CI", async () 
   expect(polled).toEqual(["shepherd/a"]);
 });
 
-test("fast tick caps open-PR polling per tick and rotates to cover all", async () => {
+test("fastTick batches a transient-dominant repo via one listOpenPrStatuses (a)", async () => {
   const store = new SessionStore(":memory:");
-  for (let i = 0; i < 5; i++) store.create({ ...baseSession, branch: `shepherd/${i}` });
-  const polled: string[] = [];
-  const forge: GitForge = {
-    ...forgeByBranch({}),
-    prStatus: async (head: string) => {
-      polled.push(head);
-      return OPEN_PENDING;
-    },
-  };
+  store.create({ ...baseSession, branch: "shepherd/a" });
+  store.create({ ...baseSession, branch: "shepherd/b" });
+  // P == eligible: the open set is exactly the two transient PRs → P ≤ ratio×count → batch.
+  const { forge, stats } = forgeWithBatch({
+    "shepherd/a": OPEN_PENDING,
+    "shepherd/b": OPEN_PENDING,
+  });
   const poller = new PrPoller(
     store,
     () => forge,
     () => {},
-    120_000,
-    1000,
-    () => null,
-    15_000,
-    2, // fastBatch cap
+  );
+
+  await poller.tick(); // seed cache (both open+transient) + transientSince
+  stats.list = 0;
+  stats.count = 0;
+  stats.prStatus = 0;
+  await poller.fastTick();
+  expect(stats.count).toBe(1); // one count-gate probe for the repo
+  expect(stats.list).toBe(1); // one batch refresh covers both PRs
+  expect(stats.prStatus).toBe(0); // no per-PR fan-out
+});
+
+test("fastTick falls back to per-session for a single eligible PR — count<2 (b)", async () => {
+  const store = new SessionStore(":memory:");
+  store.create({ ...baseSession, branch: "shepherd/a" });
+  const { forge, stats } = forgeWithBatch(
+    { "shepherd/a": OPEN_PENDING },
+    { prStatusByBranch: { "shepherd/a": OPEN_PENDING } },
+  );
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    () => {},
   );
 
   await poller.tick();
-  polled.length = 0;
-  await poller.fastTick(); // 2 polled
-  await poller.fastTick(); // next 2
-  await poller.fastTick(); // wraps; 2 more
-  expect(polled.length).toBe(6); // capped at 2 per tick
-  expect(new Set(polled).size).toBe(5); // every open PR covered across ticks
+  stats.list = 0;
+  stats.count = 0;
+  stats.prStatus = 0;
+  await poller.fastTick();
+  expect(stats.count).toBe(0); // count<2 short-circuits before the probe
+  expect(stats.list).toBe(0);
+  expect(stats.prStatus).toBe(1); // lone eligible → per-session
 });
 
-test("over-cap notice re-logs after the open-PR count drops to zero and back", async () => {
+test("fastTick fans out O(eligible) per-session across singleton repos, no cap (c)", async () => {
   const store = new SessionStore(":memory:");
-  for (let i = 0; i < 3; i++) store.create({ ...baseSession, branch: `shepherd/${i}` });
-  let cur: PrStatus = OPEN_PENDING;
-  let warnings = 0;
-  const orig = console.warn;
-  console.warn = (msg?: unknown) => {
-    if (typeof msg === "string" && msg.includes("exceed fast-poll cap")) warnings++;
-  };
-  try {
-    const poller = new PrPoller(
-      store,
-      () => ({ ...forgeByBranch({}), prStatus: async () => cur }),
-      () => {},
-      120_000,
-      1000,
-      () => null,
-      15_000,
-      1, // fastBatch=1 → 3 open PRs are over-cap
+  const REPOS = 10; // exceeds the old fastBatch=8 cap → proves no cap remains
+  const forges: Record<string, GitForge> = {};
+  let prStatusCalls = 0;
+  let listCalls = 0;
+  for (let i = 0; i < REPOS; i++) {
+    const repoPath = `/r${i}`;
+    store.create({ ...baseSession, repoPath, branch: `shepherd/${i}` });
+    const { forge } = forgeWithBatch(
+      { [`shepherd/${i}`]: OPEN_PENDING },
+      { slug: `o/r${i}`, prStatusByBranch: { [`shepherd/${i}`]: OPEN_PENDING } },
     );
-    await poller.tick(); // cache 3 open PRs
-    await poller.fastTick(); // over-cap → logs once
-    await poller.fastTick(); // still over-cap → latched, no re-log
-    expect(warnings).toBe(1);
-
-    cur = { state: "merged", number: 1, checks: "success", deployConfigured: false };
-    await poller.tick(); // PRs settle → cache holds no open entries
-    await poller.fastTick(); // zero open → re-arms the latch
-    expect(warnings).toBe(1);
-
-    cur = OPEN_PENDING;
-    await poller.tick(); // open again, still over-cap
-    await poller.fastTick(); // latch re-armed → logs again
-    expect(warnings).toBe(2);
-  } finally {
-    console.warn = orig;
+    forges[repoPath] = {
+      ...forge,
+      prStatus: async () => {
+        prStatusCalls++;
+        return OPEN_PENDING;
+      },
+      listOpenPrStatuses: async () => {
+        listCalls++;
+        return new Map();
+      },
+    };
   }
+  const poller = new PrPoller(
+    store,
+    (rp) => forges[rp] ?? null,
+    () => {},
+  );
+
+  await poller.tick();
+  prStatusCalls = 0;
+  listCalls = 0;
+  await poller.fastTick();
+  expect(prStatusCalls).toBe(REPOS); // every singleton repo polled per-session in one tick
+  expect(listCalls).toBe(0); // count<2 each → never batched
+});
+
+test("fastTick covers all eligible PRs of one repo in a single tick — no rotation (d)", async () => {
+  const store = new SessionStore(":memory:");
+  const open: Record<string, PrStatus> = {};
+  for (let i = 0; i < 10; i++) open[`shepherd/${i}`] = { ...OPEN_PENDING, number: i + 1 };
+  for (let i = 0; i < 10; i++) store.create({ ...baseSession, branch: `shepherd/${i}` });
+  const { forge, stats } = forgeWithBatch(open);
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    () => {},
+  );
+
+  await poller.tick();
+  stats.list = 0;
+  stats.prStatus = 0;
+  await poller.fastTick();
+  expect(stats.list).toBe(1); // single batch covers all 10 (old code rotated 8/tick)
+  expect(stats.prStatus).toBe(0);
+});
+
+test("fastTick keeps a mixed repo (P ≫ eligible) per-session via the count-gate (e)", async () => {
+  const store = new SessionStore(":memory:");
+  store.create({ ...baseSession, branch: "shepherd/a" });
+  store.create({ ...baseSession, branch: "shepherd/b" });
+  // Only 2 transient PRs eligible, but the repo has 20 open PRs total → 20 > 2×2 → per-session.
+  const { forge, stats } = forgeWithBatch(
+    { "shepherd/a": OPEN_PENDING, "shepherd/b": OPEN_PENDING },
+    { count: 20, prStatusByBranch: { "shepherd/a": OPEN_PENDING, "shepherd/b": OPEN_PENDING } },
+  );
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    () => {},
+  );
+
+  await poller.tick();
+  stats.list = 0;
+  stats.count = 0;
+  stats.prStatus = 0;
+  await poller.fastTick();
+  expect(stats.count).toBe(1); // probed countOpenPrs
+  expect(stats.list).toBe(0); // gate tripped → no full-rollup batch
+  expect(stats.prStatus).toBe(2); // refreshed the 2 eligible per-session
 });
 
 test("serializes a targeted poll behind a sweep — one gh at a time", async () => {
@@ -678,7 +735,6 @@ test("fastTick skips when rateLimited() is true", async () => {
     1000,
     () => null,
     15_000,
-    8,
     () => true,
     () => true, // warm
     () => rl,
@@ -711,7 +767,6 @@ test("fastTick skips when warm() is false and runs when warm & not limited", asy
     1000,
     () => null,
     15_000,
-    8,
     () => true,
     () => warm,
     () => false,
@@ -742,7 +797,6 @@ test("tick runs every call when warm() is true", async () => {
     1000,
     () => null,
     15_000,
-    8,
     () => true,
     () => true, // warm
     () => false,
@@ -768,7 +822,6 @@ test("tick when not warm runs once then skips within idleIntervalMs", async () =
     1000,
     () => null,
     15_000,
-    8,
     () => true,
     () => false, // not warm
     () => false,
@@ -796,7 +849,6 @@ test("tick when not warm runs again with idleIntervalMs 0", async () => {
     1000,
     () => null,
     15_000,
-    8,
     () => true,
     () => false, // not warm
     () => false,
@@ -823,7 +875,6 @@ test("tick skips entirely when rateLimited() regardless of warm", async () => {
     1000,
     () => null,
     15_000,
-    8,
     () => true,
     () => true, // warm
     () => true, // but rate limited
@@ -963,7 +1014,6 @@ test("refresh signal (b): prior-owned PR transitions to merged, bypasses guard w
     1000,
     () => null,
     15_000,
-    8,
     () => false, // ownsPr always returns false
   );
 
@@ -1000,7 +1050,6 @@ test("refresh signal (a): cold cache + marked + markedNumber matches, ownsPr=fal
     1000,
     () => null,
     15_000,
-    8,
     () => false, // ownsPr always returns false
   );
 
@@ -1088,7 +1137,6 @@ test("fastTick parks a transient PR whose transientMaxMs window has expired", as
     1000,
     () => null,
     15_000,
-    8,
     () => true,
     () => true,
     () => false,
@@ -1127,7 +1175,6 @@ test("headSha change restamps the transient window, making an aged-out PR eligib
     1000,
     () => null,
     15_000,
-    8,
     () => true,
     () => true,
     () => false,
@@ -1384,7 +1431,6 @@ test("stale-terminal guard under batch: reused-name merged dropped to none", asy
     1000,
     () => null,
     15_000,
-    8,
     () => false, // ownsPr false → reused-name terminal rejected
   );
 
@@ -1485,7 +1531,6 @@ test("stuck-none heals after noneRecheckMs via a per-session re-confirm", async 
     1000,
     () => null,
     15_000,
-    8,
     () => true, // ownsPr true → keep the merge
     () => true,
     () => false,
@@ -1646,7 +1691,6 @@ test("cap-hit: countOpenPrs≥200 forces per-session regardless of ratio", async
     1000,
     () => null,
     15_000,
-    8,
     () => true,
     () => true,
     () => false,


### PR DESCRIPTION
Closes #1241.

Follow-up to #1233, which collapsed the **full** sweep (`tick`, 120s) to one per-repo batch (`buildBatches`/`batchForRepo`/`batchFor` + count-gate). The **fast** sweep (`fastTick`, 15s) was left on its per-PR path: ≤ `fastBatch`(=8) transient open PRs/tick, round-robin, with an over-cap log. This reworks `fastTick` to reuse #1233's exact machinery over its eligible-transient subset.

## What changed

`fastTick` now: filter eligible (transient + within `transientMaxMs`) open PRs → resolve to live `Session`s → `buildBatches(eligible)` → `refresh(s, batchFor(s, batches))` under `withGh`. Removed: the `fastBatch` ctor param, `fastCursor`, `fastCapLogged`, the round-robin slice, and the over-cap `console.warn`.

## Honest bound (not an unconditional O(repos) collapse)

The count-gate is reused as #1233 directs, so it governs the fast path the same way: `count` = the **eligible-transient** sessions but `P = countOpenPrs()` = the repo's **total** open PRs.

- **Transient-dominant repo** (`P ≤ ratio × eligible`): one `listOpenPrStatuses`/tick — O(repos).
- **Mixed repo** (`P ≫ eligible`, stable PRs beyond the transient few): gate trips → bounded per-session (now uncapped/no-rotation). This is deliberate — feeding the gate all-branch session counts instead would green-light a full-rollup batch over all `P` PRs to refresh ~2 transient ones, a ~10× points regression at 8× cadence (the exact blow-up the deferred GraphQL variant guards against).

Literal single-batch O(repos) at the fast cadence is the gate's **ceiling**, not a guarantee. Making the fast batch cheap enough to apply more broadly is the deferred companion: **#1249** (trimmed `gh api graphql` `first:N` variant, gated on a points-cost measurement).

## Correctness notes

- `sweeping = true` is set **before** `buildBatches` (matching `tick`), so the `countOpenPrs`/`listOpenPrStatuses` probe runs inside the mutual-exclusion window — a concurrent full `tick` can't interleave and duplicate the sweep.
- The `inFlight` dedup the old `refreshOne`-based path provided is preserved: the loop skips any session already in `inFlight` and brackets each `refresh` with add/delete, so a concurrent `pollSession` doesn't double-poll.
- `fastTick` still does not prune the cache; transient-window / warm / rate-limit gating unchanged.

## Tests

Deleted the two cap/round-robin tests; removed the now-stale `fastBatch` positional arg from every surviving instantiation. Added, on `forgeWithBatch` with `OPEN_PENDING` (transient) entries:
- **(a)** transient-dominant repo → one `listOpenPrStatuses`, zero per-PR `prStatus`.
- **(b)** single eligible PR → `count < 2` → per-session.
- **(c)** 10 singleton repos → 10 per-session in one tick (exceeds old cap=8 → proves no cap).
- **(d)** 10 eligible in one repo → one batch covers all in a single tick (no rotation).
- **(e)** mixed repo `P=20 ≫ eligible=2` → count-gate trips → per-session, no full-rollup batch.

`bun run typecheck` / `bun run lint` / `bun run test` (root, 5448 pass) all green.

`[no-feature-entry]` — server-only polling change, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)