### PR TITLE
fix: prevent Claude model aliases on Codex spawns

### DIFF
--- a/src/default-model.ts
+++ b/src/default-model.ts
@@ -13,9 +13,18 @@
  * apply it — autonomous spawns must be deterministic and operator-controlled only.
  */
 
-import { AGENT_PROVIDERS, type AgentProvider, MODELS, MODELS_BY_PROVIDER } from "./types";
+import {
+  AGENT_PROVIDERS,
+  CODEX_MODELS,
+  CODEX_MODEL_RE,
+  type AgentProvider,
+  MODELS,
+  MODELS_BY_PROVIDER,
+} from "./types";
 
 const SETTING_VALUES = new Set<string>(["auto", "default", ...MODELS]);
+const CLAUDE_MODEL_VALUES = new Set<string>(MODELS);
+const CODEX_MODEL_VALUES = new Set<string>(CODEX_MODELS);
 
 // The per-repo override space is the global space plus an "inherit" sentinel,
 // which means "no repo override — fall back to the global default setting".
@@ -52,6 +61,31 @@ export function spawnModelForAvailability(
   fableAvailable: boolean,
 ): string | null {
   return model === "fable" && !fableAvailable ? "opus[1m]" : model;
+}
+
+/** True when `model` is a valid explicit model alias for `provider`.
+ *
+ * Codex accepts safe future-looking aliases so Shepherd can work with a newer installed CLI before
+ * the curated list is updated, but known Claude aliases are excluded from that free-form path.
+ */
+export function modelCompatibleWithProvider(
+  model: string | null,
+  provider: AgentProvider,
+): boolean {
+  if (model === null) return true;
+  if (provider === "claude") return CLAUDE_MODEL_VALUES.has(model);
+  return (
+    CODEX_MODEL_VALUES.has(model) || (CODEX_MODEL_RE.test(model) && !CLAUDE_MODEL_VALUES.has(model))
+  );
+}
+
+/** Clamp a stored model to the target provider's value space. Used when an existing task changes
+ * provider after its model was already validated for the original provider. */
+export function modelForProviderOrDefault(
+  model: string | null,
+  provider: AgentProvider,
+): string | null {
+  return modelCompatibleWithProvider(model, provider) ? model : null;
 }
 
 /**
@@ -150,6 +184,6 @@ export function resolveRoleEnvironment(
   const token = normalizeRoleModelToken(roleModel) ?? "default";
   if (token === "default") return { provider: cli, model: null };
   // Clamp: the stored model must belong to the chosen provider, else fall back to its default.
-  if (!MODELS_BY_PROVIDER[cli].includes(token)) return { provider: cli, model: null };
+  if (!modelCompatibleWithProvider(token, cli)) return { provider: cli, model: null };
   return { provider: cli, model: spawnModelForAvailability(token, fableAvailable) };
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -2006,7 +2006,7 @@ export class SessionService {
         model: spawnInput.model,
         auto: spawnInput.auto ?? false,
         issueNumber: spawnInput.issueRef?.number ?? null,
-        planGateEnabled: agentProvider === "claude" ? (input.planGateEnabled ?? null) : false,
+        planGateEnabled: agentProvider === "claude" ? (spawnInput.planGateEnabled ?? null) : false,
         autopilotEnabled: spawnInput.autopilotEnabled ?? null,
         planPhase: planGateOn ? "planning" : null,
         research: spawnInput.research ?? false,

--- a/src/service.ts
+++ b/src/service.ts
@@ -16,7 +16,6 @@ import type {
   RelaunchOverrides,
   Session,
 } from "./types";
-import { MODELS, CODEX_MODELS, CODEX_MODEL_RE } from "./types";
 import {
   copyStagedIntoWorktree,
   stagingDir,
@@ -26,7 +25,11 @@ import {
   worktreeUploadsDir,
 } from "./uploads";
 import { slugifyManual, isHeuristicNameStrong } from "./namer";
-import { spawnModelForAvailability } from "./default-model";
+import {
+  modelCompatibleWithProvider,
+  modelForProviderOrDefault,
+  spawnModelForAvailability,
+} from "./default-model";
 import {
   isApiKeyMode,
   isApiKeyConfigured,
@@ -935,17 +938,6 @@ function pickOverride<T>(override: T | undefined, original: T): T {
   return override !== undefined ? override : original;
 }
 
-/** True when `model` can be passed to `provider`'s --model flag. `null` (provider default) is
- *  always compatible. Claude takes its curated alias list; Codex takes its curated list plus any
- *  safe alias matching CODEX_MODEL_RE (the CLI may learn names before Shepherd does). Used to stop
- *  a relaunch from carrying a model across a provider switch (see relaunch()). */
-function modelCompatibleWith(model: string | null, provider: AgentProvider): boolean {
-  if (model === null) return true;
-  if (provider === "codex")
-    return (CODEX_MODELS as readonly string[]).includes(model) || CODEX_MODEL_RE.test(model);
-  return (MODELS as readonly string[]).includes(model);
-}
-
 /** Resolve the relaunch model for the EFFECTIVE provider. `validateRelaunchOverrides` is
  *  session-blind, so the pairing is reconciled here: an absent override keeps the original's
  *  model, but if that carried model is incompatible with a provider switch it falls back to the
@@ -956,7 +948,7 @@ function reconcileRelaunchModel(
   provider: AgentProvider,
 ): string | null {
   const model = pickOverride(overrideModel, originalModel);
-  if (modelCompatibleWith(model, provider)) return model;
+  if (modelCompatibleWithProvider(model, provider)) return model;
   if (overrideModel != null && overrideModel !== "default")
     throw new Error(`model "${overrideModel}" is not valid for provider ${provider}`);
   return null;
@@ -1422,24 +1414,10 @@ export class SessionService {
     // applies to BOTH interactive create (prepareSpawnOrThrow → throws) and
     // resume/drain (returns ok:false → null/caught).
     if (apiKeyAuth.hold) return { ok: false, holdReason: apiKeyAuth.hold };
-    const profile = resolveProfile(
+    const { profile, backend, egressBackend, hold } = this.resolveSpawnPreflight(
       ctx.profileOverride,
       repoConfig.sandboxProfile,
-      config.sandboxDefaultProfile,
     );
-    // Skip the (real subprocess) backend self-test for trusted: backend is irrelevant there
-    // — autoHoldReason/isDegraded/wrapArgv are all backend-independent for trusted (passthrough,
-    // never held, never degraded). This keeps a default/trusted install from paying a bwrap
-    // node/git probe on its first spawn.
-    const backend = profile === "trusted" ? null : this.detectBackend();
-    // Probe the egress backend ONLY for an autonomous spawn that already has an FS backend;
-    // otherwise leave it undefined so autoHoldReason's 2-arg semantics hold (egress not
-    // considered — standard/trusted are never egress-confined).
-    const egressBackend =
-      egressApplies(profile) && backend !== null ? this.detectEgressBackend() : undefined;
-    // 3-arg gate: an autonomous AUTO spawn refuses (loud EGRESS_UNAVAILABLE_REASON) when the
-    // egress backend is null. standard/trusted are unaffected (egressBackend undefined).
-    const hold = autoHoldReason(profile, backend, egressBackend);
     if (ctx.auto && hold) return { ok: false, holdReason: hold };
     const degraded = isDegraded(profile, backend);
     // egress WILL wrap iff autonomous + FS backend + egress backend all present (shared predicate).
@@ -1523,6 +1501,33 @@ export class SessionService {
       degraded,
       egressApplied: egressOn,
       egressDegraded,
+    };
+  }
+
+  private resolveSpawnPreflight(
+    profileOverride: string | null | undefined,
+    repoSandboxProfile: SandboxProfile,
+  ): {
+    profile: SandboxProfile;
+    backend: SandboxBackend;
+    egressBackend: EgressBackend | undefined;
+    hold: string | null;
+  } {
+    const profile = resolveProfile(
+      profileOverride,
+      repoSandboxProfile,
+      config.sandboxDefaultProfile,
+    );
+    // Trusted is passthrough, so no backend probe can change the result. Egress is considered only
+    // when autonomous already has a filesystem backend.
+    const backend = profile === "trusted" ? null : this.detectBackend();
+    const egressBackend =
+      egressApplies(profile) && backend !== null ? this.detectEgressBackend() : undefined;
+    return {
+      profile,
+      backend,
+      egressBackend,
+      hold: autoHoldReason(profile, backend, egressBackend),
     };
   }
 
@@ -1882,6 +1887,72 @@ export class SessionService {
     return baseRef;
   }
 
+  private async resolveCreateLaunch(
+    input: CreateSessionInput,
+    wt: { isolated: boolean },
+    promptArg: string,
+    sessionId: string,
+    claudeSessionId: string,
+  ): Promise<{
+    agentProvider: AgentProvider;
+    spawnInput: CreateSessionInput;
+    repoConfig: RepoConfig;
+    planGateOn: boolean;
+    profileOverride: string | null | undefined;
+    argv: string[];
+  }> {
+    const agentProvider = input.agentProvider ?? config.defaultAgentProvider;
+    const model = modelForProviderOrDefault(input.model, agentProvider);
+    const spawnInput = model === input.model ? input : { ...input, model };
+    if (input.model && model === null) {
+      console.warn(
+        `[spawn] dropping model "${input.model}" because it is not valid for ${agentProvider}; using provider default`,
+      );
+    }
+
+    const repoConfig = this.deps.store.getRepoConfig(spawnInput.repoPath);
+    const planGateOn =
+      agentProvider === "claude" ? this.resolvePlanGateOn(spawnInput, repoConfig) : false;
+    const trim = await this.trimFor(spawnInput.auto);
+    const profileOverride =
+      agentProvider === "codex"
+        ? "trusted"
+        : this.researchSafeProfileOverride(spawnInput, repoConfig, sessionId);
+    const baseUrl = this.resolveSpawnBaseUrl(profileOverride, spawnInput.repoPath);
+    const argv =
+      agentProvider === "codex"
+        ? this.buildCodexSpawnArgv(
+            promptArg,
+            spawnInput.model,
+            // Deliberate divergence from Claude (which gates its directive on the repo
+            // default only, see buildSpawnArgv): Codex uses effectiveAutopilot so the
+            // headline case (repo default OFF + per-session toggle ON) gets the directive.
+            // Do NOT align to Claude's repo-default-only behavior. Suppressed for research
+            // (which replaces the autopilot directive) and non-isolated (which autopilot
+            // stands down on — see eligible()).
+            !spawnInput.research &&
+              wt.isolated &&
+              effectiveAutopilot(
+                { autopilotEnabled: spawnInput.autopilotEnabled ?? null },
+                repoConfig.autopilotEnabled,
+              ),
+            // Manual-steps notice (#1257): rides every Codex code spawn, suppressed only for
+            // research — its single-pr-invariant equivalent, independent of the autopilot gate.
+            !spawnInput.research,
+          )
+        : this.buildSpawnArgv(
+            spawnInput,
+            claudeSessionId,
+            sessionId,
+            promptArg,
+            planGateOn,
+            wt.isolated,
+            trim,
+            baseUrl,
+          );
+    return { agentProvider, spawnInput, repoConfig, planGateOn, profileOverride, argv };
+  }
+
   async create(input: CreateSessionInput): Promise<Session> {
     const repoBasename = input.repoPath.split("/").filter(Boolean).at(-1) ?? "";
     const herdSlug = repoBasename ? slugifyManual(repoBasename) : undefined;
@@ -1901,54 +1972,8 @@ export class SessionService {
         input,
         wt.worktreePath,
       );
-      const repoConfig = this.deps.store.getRepoConfig(input.repoPath);
-      const agentProvider = input.agentProvider ?? config.defaultAgentProvider;
-      // Plan gate (#348): when on, spawn into a PLANNING phase with a grill directive that
-      // suppresses autopilot — interactive grills a present human, auto (drain) just writes the
-      // plan. See resolvePlanGateOn for the override + research semantics.
-      const planGateOn =
-        agentProvider === "claude" ? this.resolvePlanGateOn(input, repoConfig) : false;
-      const trim = await this.trimFor(input.auto);
-      // Research needs OPEN web egress; a research session resolving to autonomous is
-      // downgraded to standard for this spawn (see researchSafeProfileOverride). Resolved BEFORE
-      // buildSpawnArgv so resolveSpawnBaseUrl bakes the URL matching the SAME profile prepareSpawn
-      // will wrap with — buildSpawnArgv doesn't use the override otherwise, so reordering is safe.
-      const profileOverride =
-        agentProvider === "codex"
-          ? "trusted"
-          : this.researchSafeProfileOverride(input, repoConfig, sessionId);
-      const baseUrl = this.resolveSpawnBaseUrl(profileOverride, input.repoPath);
-      const argv =
-        agentProvider === "codex"
-          ? this.buildCodexSpawnArgv(
-              promptArg,
-              input.model,
-              // Deliberate divergence from Claude (which gates its directive on the repo
-              // default only, see buildSpawnArgv): codex uses effectiveAutopilot so the
-              // headline case (repo default OFF + per-session toggle ON) gets the directive.
-              // Do NOT align to Claude's repo-default-only behavior. Suppressed for research
-              // (which replaces the autopilot directive) and non-isolated (which autopilot
-              // stands down on — see eligible()).
-              !input.research &&
-                wt.isolated &&
-                effectiveAutopilot(
-                  { autopilotEnabled: input.autopilotEnabled ?? null },
-                  repoConfig.autopilotEnabled,
-                ),
-              // Manual-steps notice (#1257): rides every Codex code spawn, suppressed only for
-              // research — its single-pr-invariant equivalent, independent of the autopilot gate.
-              !input.research,
-            )
-          : this.buildSpawnArgv(
-              input,
-              claudeSessionId,
-              sessionId,
-              promptArg,
-              planGateOn,
-              wt.isolated,
-              trim,
-              baseUrl,
-            );
+      const { agentProvider, spawnInput, repoConfig, planGateOn, profileOverride, argv } =
+        await this.resolveCreateLaunch(input, wt, promptArg, sessionId, claudeSessionId);
       // Auto-refuse surfaces as a throw so the create() caller (route 4xx / drain catch) sees it.
       const outcome = await this.prepareSpawnOrThrow(argv, {
         sessionId,
@@ -1956,9 +1981,9 @@ export class SessionService {
         worktreePath: wt.worktreePath,
         repoPath: input.repoPath,
         isolated: wt.isolated,
-        auto: input.auto,
+        auto: spawnInput.auto,
         profileOverride,
-        model: input.model,
+        model: spawnInput.model,
         agentProvider,
       });
       const session = this.deps.store.create({
@@ -1978,19 +2003,19 @@ export class SessionService {
         egressDegraded: outcome.egressDegraded,
         claudeSessionId: agentProvider === "claude" ? claudeSessionId : "",
         agentProvider,
-        model: input.model,
-        auto: input.auto ?? false,
-        issueNumber: input.issueRef?.number ?? null,
+        model: spawnInput.model,
+        auto: spawnInput.auto ?? false,
+        issueNumber: spawnInput.issueRef?.number ?? null,
         planGateEnabled: agentProvider === "claude" ? (input.planGateEnabled ?? null) : false,
-        autopilotEnabled: input.autopilotEnabled ?? null,
+        autopilotEnabled: spawnInput.autopilotEnabled ?? null,
         planPhase: planGateOn ? "planning" : null,
-        research: input.research ?? false,
-        mergeTrainPrs: input.mergeTrainPrs,
+        research: spawnInput.research ?? false,
+        mergeTrainPrs: spawnInput.mergeTrainPrs,
       });
       // Attended sessions stay unapproved until a human clicks Approve in the UI.
       // Autopilot sessions are pre-approved so the agent can begin executing immediately
       // after authoring the queue without waiting for a human gate that will never come.
-      if (shouldPreApproveBuildQueue(repoConfig, session, input.research))
+      if (shouldPreApproveBuildQueue(repoConfig, session, spawnInput.research))
         this.deps.store.setBuildQueueApproved(sessionId, true, "auto");
       // An attached image was lost before spawn (staged upload swept after 24h). The session
       // started without it; surface that to the operator as a toast — they can relaunch with

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -5,7 +5,6 @@ import { timingSafeEqual, randomUUID } from "node:crypto";
 import {
   AGENT_PROVIDERS,
   CODEX_MODELS,
-  CODEX_MODEL_RE,
   MODELS,
   type AgentProvider,
   type CreateSessionInput,
@@ -15,6 +14,7 @@ import {
   type BuildStepInput,
   type BuildStepStatus,
 } from "./types";
+import { modelCompatibleWithProvider } from "./default-model";
 import { stagingDir } from "./uploads";
 import { parseRemote } from "./forge/remote";
 import { isSandboxProfile, SANDBOX_PROFILES, type SandboxProfile } from "./sandbox";
@@ -95,17 +95,15 @@ function validateAgentProvider(value: unknown): Field<AgentProvider | undefined>
 function validateModel(value: unknown, agentProvider?: AgentProvider): Field<string | null> {
   if (value == null || value === "default") return field(null);
   if (typeof value !== "string") return err("model must be a string");
-  if (agentProvider !== "codex" && (MODELS as readonly string[]).includes(value)) {
-    return field(value);
+  if (agentProvider) {
+    if (modelCompatibleWithProvider(value, agentProvider)) return field(value);
+    return agentProvider === "codex" ? err("invalid codex model") : err("unknown model");
   }
-  if (agentProvider !== "claude" && (CODEX_MODELS as readonly string[]).includes(value)) {
+  if (
+    (MODELS as readonly string[]).includes(value) ||
+    (CODEX_MODELS as readonly string[]).includes(value)
+  ) {
     return field(value);
-  }
-  if (agentProvider === "codex" && CODEX_MODEL_RE.test(value)) {
-    return field(value);
-  }
-  if (agentProvider === "codex") {
-    return err("invalid codex model");
   }
   return err("unknown model");
 }
@@ -918,8 +916,7 @@ export function validateEpicRunPatch(
   return out;
 }
 
-/** Validate a POST /api/broadcast payload. Returns null on any violation. */
-export function validateBroadcast(body: unknown): { text: string; ids: string[] } | null {
+function validateTextToIds(body: unknown): { text: string; ids: string[] } | null {
   if (body === null || typeof body !== "object" || Array.isArray(body)) return null;
   const o = body as Record<string, unknown>;
   if (typeof o.text !== "string") return null;
@@ -934,18 +931,12 @@ export function validateBroadcast(body: unknown): { text: string; ids: string[] 
   return { text, ids };
 }
 
+/** Validate a POST /api/broadcast payload. Returns null on any violation. */
+export function validateBroadcast(body: unknown): { text: string; ids: string[] } | null {
+  return validateTextToIds(body);
+}
+
 /** Validate a POST /api/retry payload. Returns null on any violation. */
 export function validateRetry(body: unknown): { text: string; ids: string[] } | null {
-  if (body === null || typeof body !== "object" || Array.isArray(body)) return null;
-  const o = body as Record<string, unknown>;
-  if (typeof o.text !== "string") return null;
-  const text = o.text.trim();
-  if (text.length === 0 || text.length > STEER_TEXT_MAX) return null;
-  if (!Array.isArray(o.ids)) return null;
-  const ids: string[] = [];
-  for (const id of o.ids) {
-    if (typeof id !== "string" || id.length === 0) return null;
-    ids.push(id);
-  }
-  return { text, ids };
+  return validateTextToIds(body);
 }

--- a/test/default-model.test.ts
+++ b/test/default-model.test.ts
@@ -9,6 +9,8 @@ import {
   drainSpawnModel,
   spawnModelForAvailability,
   normalizeFableAvailable,
+  modelCompatibleWithProvider,
+  modelForProviderOrDefault,
 } from "../src/default-model";
 import { MODELS } from "../src/types";
 
@@ -85,6 +87,24 @@ describe("drainSpawnModel", () => {
     expect(normalizeDefaultModelSetting("sonnet[1m]")).toBe("sonnet[1m]");
     expect(drainSpawnModel("opus[1m]")).toBe("opus[1m]");
     expect(drainSpawnModel("sonnet[1m]")).toBe("sonnet[1m]");
+  });
+});
+
+describe("modelCompatibleWithProvider", () => {
+  test("known Claude aliases are not accepted through Codex's future-alias regex", () => {
+    expect(modelCompatibleWithProvider("opus", "codex")).toBe(false);
+    expect(modelCompatibleWithProvider("opus[1m]", "codex")).toBe(false);
+    expect(modelForProviderOrDefault("opus", "codex")).toBeNull();
+  });
+
+  test("Codex accepts curated aliases and safe future aliases", () => {
+    expect(modelCompatibleWithProvider("gpt-5.5", "codex")).toBe(true);
+    expect(modelCompatibleWithProvider("gpt-5.6-codex", "codex")).toBe(true);
+  });
+
+  test("Claude accepts only Claude aliases", () => {
+    expect(modelCompatibleWithProvider("opus", "claude")).toBe(true);
+    expect(modelCompatibleWithProvider("gpt-5.5", "claude")).toBe(false);
   });
 });
 

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -210,12 +210,15 @@ test("createSession: codex drops a carried Claude model and uses provider defaul
     images: [],
   });
 
-  expect(calls.start.argv).toEqual([
+  expect(calls.start.argv.slice(0, 3)).toEqual([
     "codex",
     "--no-alt-screen",
     "--dangerously-bypass-approvals-and-sandbox",
-    "flatten it",
   ]);
+  expect(calls.start.argv).not.toContain("--model");
+  const codexPrompt = calls.start.argv[3] as string;
+  expect(codexPrompt.startsWith("flatten it")).toBe(true);
+  expect(codexPrompt).toContain("<manual-steps-notice>");
   expect(s.agentProvider).toBe("codex");
   expect(s.model).toBeNull();
   expect(store.get(s.id)?.model).toBeNull();

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -198,6 +198,29 @@ test("createSession: codex provider starts interactive codex; plan-gate forced o
   expect(store.get(s.id)?.model).toBe("gpt-5.5");
 });
 
+test("createSession: codex drops a carried Claude model and uses provider default", async () => {
+  const { store, service, calls } = codexHarness(true);
+
+  const s = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "flatten it",
+    agentProvider: "codex",
+    model: "opus",
+    images: [],
+  });
+
+  expect(calls.start.argv).toEqual([
+    "codex",
+    "--no-alt-screen",
+    "--dangerously-bypass-approvals-and-sandbox",
+    "flatten it",
+  ]);
+  expect(s.agentProvider).toBe("codex");
+  expect(s.model).toBeNull();
+  expect(store.get(s.id)?.model).toBeNull();
+});
+
 test("createSession: codex + isolated + autopilotEnabled=true → directive injected, persisted true", async () => {
   const { store, service, calls } = codexHarness(true);
   const s = await service.create({

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -112,6 +112,21 @@ test("unsafe codex model rejected", () => {
   if (!r.ok) expect(r.error).toMatch(/codex model/i);
 });
 
+test("known Claude model rejected when provider is codex", () => {
+  const r = validateCreate(
+    {
+      repoPath: validRepo,
+      baseBranch: "main",
+      prompt: "go",
+      agentProvider: "codex",
+      model: "opus",
+    },
+    root,
+  );
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.error).toMatch(/codex model/i);
+});
+
 test("agentProvider accepts claude and codex", () => {
   for (const agentProvider of ["claude", "codex"] as const) {
     const r = validateCreate(


### PR DESCRIPTION
## Summary
- reject known Claude model aliases for explicit Codex model selections
- clamp carried/stored models to the target provider before spawning, so held tasks switched to Codex use the Codex default instead of passing `opus`
- add regression coverage for provider/model compatibility and Codex spawn argv

## Verification
- bun test test/default-model.test.ts test/validate.test.ts test/service.test.ts
- bun run lint
- bun run test
- bunx fallow@2.100.0 audit --base origin/main --fail-on-issues
- pre-push hook passed: prettier, eslint, gates, tsc, extension, root-tests, ui, fallow
