### PR TITLE
fix(ui): route short viewports to the mobile layout (unfolded fold split-landscape)

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -340,15 +340,17 @@ button {
 
 /* iOS zoom-on-focus guard: mobile Safari zooms the whole page when a focused
    text control renders below 16px. Force every text-entry control to the 16px
-   rung (--fs-lg) on phones — systemic here so no individual component can
-   drift back under the threshold. The `:is()` wrapper deliberately lends the
+   rung (--fs-lg) on phones AND short-wide viewports (foldable split-screen /
+   phone landscape — the same height ≤600 branch that now routes to the mobile
+   layout) — systemic here so no individual component can drift back under the
+   threshold. The `:is()` wrapper deliberately lends the
    bare `textarea`/`select` the input arm's specificity (0,3,1), so this beats
    Svelte-scoped component rules like `.ep-search.svelte-x` (0,2,0) or
    `textarea.svelte-x` (0,1,1) that set a smaller desktop size.
    max(16px, …) keeps the guard hard: --fs-lg now scales with the iOS Text Size
    setting (--ui-scale), so a *smaller* Dynamic Type choice could otherwise push
    --fs-lg under 16px and bring the focus-zoom back; the floor stays absolute. */
-@media (max-width: 768px) {
+@media (max-width: 768px), (max-height: 600px) {
   :is(input:not([type="checkbox"]):not([type="radio"]):not([type="range"]), textarea, select) {
     font-size: max(16px, var(--fs-lg));
   }

--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -417,8 +417,11 @@
      regardless of `compact`, so there's always a label to reveal — the `.lbl-toggle`
      reveal below is viewport-only (1 class, so it ties the base `display: none` and
      wins by coming later in source order), independent of `.show-labels` so the
-     toggle stays visible to collapse back once ABC is pressed. */
-  @media (max-width: 768px) {
+     toggle stays visible to collapse back once ABC is pressed.
+     The (max-height: 600px) arm keeps this collapse consistent on short-wide
+     viewports (foldable split-screen / phone landscape) that now route to the
+     mobile layout but are wider than the 768px breakpoint. */
+  @media (max-width: 768px), (max-height: 600px) {
     .steer-bar:not(.show-labels) .chip.bc {
       min-width: 44px;
       padding: 0;

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2275,6 +2275,24 @@
     transition: none;
   }
 
+  /* Short viewports (unfolded foldable split-screen landscape, phone landscape):
+     the detail/terminal screen is a fixed-height .shell.mobile column — NOT the
+     document-scroll list shell. .viewport keeps its definite height:100%, so vp-body
+     fills the pane and the terminal keeps its own internal scroll while content fits
+     (no page scrollbar). Only at the extreme-short floor (column min-content > pane,
+     vp-body pinned to its 4rem min) would the bottom bars (SteerBar /
+     ViewportTermControls / SessionRecap) be clipped by overflow:hidden with no way to
+     reach them — so allow vertical page-scroll there. overflow-x stays hidden to
+     preserve the horizontal swipe-to-navigate clip. Safe to key on height alone: at
+     height ≤600 the app is in the mobile branch (the desktop Viewport instance is
+     unmounted), and tall mobile (height >600) never matches, so normal phone detail
+     is untouched. */
+  @media (max-height: 600px) {
+    .viewport {
+      overflow: hidden auto;
+    }
+  }
+
   /* phone session view: full-bleed terminal — the side borders + rounded corners
      cost two vertical lines plus gutters on a narrow phone, so drop them and
      stretch into the shell's base edge padding (--mobile-shell-pad, shared with

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -808,7 +808,13 @@
     };
   }
 
-  const mobile = new MediaQuery("max-width: 768px");
+  // Mobile layout fires when the viewport is narrow OR short: width ≤768px is the
+  // phone breakpoint; height ≤600px catches wide-but-short viewports (an unfolded
+  // foldable in split-screen landscape, ordinary phone landscape, a short desktop
+  // window) that would otherwise land in the desktop branch and get crushed — its
+  // fixed-height chrome assumes a tall viewport. Both terms are parenthesised so
+  // Svelte's MediaQuery passes the comma to matchMedia verbatim as a top-level OR.
+  const mobile = new MediaQuery("(max-width: 768px), (max-height: 600px)");
   // touch-primary device (e.g. unfolded foldable wider than the mobile breakpoint):
   // gets the control-key bar even in desktop layout, since there's no hardware keyboard
   const touch = new MediaQuery("(pointer: coarse)");
@@ -2716,6 +2722,20 @@
       max(var(--mobile-shell-pad), env(safe-area-inset-bottom))
       max(var(--mobile-shell-pad), env(safe-area-inset-left));
     gap: 10px;
+  }
+
+  /* Short viewports (foldable split-screen landscape, phone landscape): reclaim
+     vertical room for the cramped pane — tighten the inter-section gap and the
+     top/bottom breathing room (safe-area insets still win where present, e.g. a
+     notch). Horizontal padding is unchanged. The detail screen (.shell.mobile
+     without .list) is the main beneficiary; the .list rule below keeps its own
+     padding-top:0 / ActionBar padding-bottom by higher specificity. */
+  @media (max-height: 600px) {
+    .shell.mobile {
+      gap: 6px;
+      padding-top: max(6px, env(safe-area-inset-top));
+      padding-bottom: max(6px, env(safe-area-inset-bottom));
+    }
   }
 
   .chrome {


### PR DESCRIPTION
## Problem

An unfolded foldable in **split-screen landscape** (and ordinary phone landscape) hands Shepherd a viewport that is **wide (>768px) but very short**. Layout was chosen purely by width (`max-width: 768px`), so this fell into the **desktop** branch — whose fixed `height:100dvh` chrome assumes a tall viewport. The chrome crushed everything below it and content was clipped/unreachable.

| | |
|---|---|
| Before | wide + short → desktop branch → chrome eats the height, task list & New-Task bar clipped, no scroll |
| After | wide + short → mobile layout (document-scroll list; hardened fixed-height terminal) |

## Change

Widen the single layout `MediaQuery` to fire on **`max-height: 600px`** as well as `max-width: 768px`, and harden the parts the mobile layout does **not** already make short-safe.

- **`+page.svelte:811`** — `new MediaQuery("(max-width: 768px), (max-height: 600px)")`. The shell is prop/class-driven, so this single source-of-truth flip routes the whole app to its mobile rendering. Both terms are parenthesised so Svelte's `MediaQuery` passes the comma to `matchMedia` **verbatim** as a top-level OR (not re-wrapped).
- **`Viewport.svelte`** — the detail/terminal screen is a fixed-height `.shell.mobile` column (NOT the document-scroll list shell). The control bars (`SteerBar`/`ViewportTermControls`/`SessionRecap`) are siblings *inside* `.viewport` (`overflow:hidden`), so a gated `@media (max-height:600px){ .viewport{ overflow: hidden auto } }` lets them stay reachable by scroll at the extreme-short floor instead of being clipped. `.viewport` keeps its definite `height:100%`, so while content fits the terminal's internal scroll is the only scroll (no page scrollbar); page-scroll engages only below the ~240px floor. `overflow-x` stays hidden to preserve the horizontal swipe.
- **`app.css:351`** — the iOS focus-zoom 16px input floor is a *systemic* guard (not a cosmetic); its query is widened to follow the short-wide branch so focusing an input there doesn't zoom the page.
- **`+page.svelte` styles** — trim `.shell.mobile` padding/gap on short viewports to reclaim vertical room (the `.list` rule keeps its own `padding-top:0`/ActionBar reserve by higher specificity).
- **`SteerBar.svelte:421`** — widen the one cosmetic detail-path media query so the steer-bar collapse stays consistent on short-wide.

Desktop (height>600 **and** width>768), tablet landscape, and normal phone layouts are unchanged.

## Verification

- ✅ `bun run check` — 0 errors / 0 warnings (3638 files)
- ✅ `bun run test` — 2297 passed / 167 files
- ✅ **Trigger (deterministic):** replicated Svelte 5.56.4's `MediaQuery` constructor logic — `(max-width: 768px), (max-height: 600px)` passes its parenthesis check and is sent to `matchMedia` verbatim (top-level OR, no double-wrap); the existing `"max-width: 768px"` still wraps correctly.
- ✅ **Empirical before/after on the running app** (Playwright, real `app.css`): the login password input computes **16px at 1024×420** (height≤600 → new guard fires; pre-change it would have been 13px since 1024>768), **13px at 1024×800** (desktop unchanged), **16px at 390×844** (existing width arm). Confirms the `max-height:600` branch activates at the intended viewport and nowhere else.

### Remaining sign-off (per plan's Phase-0 gate)
The instance is password-protected, so the authenticated shell couldn't be driven headlessly. The **visual list + detail/terminal check at ~1024×420 and the on-device confirmation that the real fold reports `innerHeight ≤ 600`** (read via the in-app feedback link's `Viewport:` line) is the designated shipping gate. The DPR analysis estimates the split pane at ~257–385px CSS height (comfortably ≤600). If the real device ever reports >600, bump the single `600` constant. The optional `--app-vh` (from `window.innerHeight`, keyboard-stable) fallback for `100dvh` over-measure was **not** wired — no evidence it's needed, and the `overflow:auto` net covers the extreme case.

[no-feature-entry] responsive fix, surfaces no new discoverable affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)