### PR TITLE
fix(ui): scroll plugin gear-item card to panel top, not center (#1254)

### DIFF
--- a/ui/src/lib/components/settings/SettingsPluginsPanel.browser.test.ts
+++ b/ui/src/lib/components/settings/SettingsPluginsPanel.browser.test.ts
@@ -104,6 +104,28 @@ describe("SettingsPluginsPanel", () => {
     expect(document.getElementById("plugin-card-beta")).not.toBeNull();
   });
 
+  it("focusId scrolls the card to the top of the panel (block:start, not center)", async () => {
+    // #1254: a tall plugin card centered (block:center) lands the operator mid-panel;
+    // it must align its top to the panel viewport instead.
+    const calls: ScrollIntoViewOptions[] = [];
+    const orig = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = function (arg?: boolean | ScrollIntoViewOptions) {
+      calls.push((arg ?? {}) as ScrollIntoViewOptions);
+    };
+    try {
+      render(SettingsPluginsPanel, {
+        plugins: [plugin({ id: "tall-plugin", name: "Tall Plugin" })],
+        focusId: "tall-plugin",
+      });
+      // The $effect runs after mount; wait a microtask for it to fire.
+      await new Promise((r) => setTimeout(r, 0));
+      expect(calls.length, "scrollIntoView was called").toBeGreaterThan(0);
+      expect(calls[0].block).toBe("start");
+    } finally {
+      Element.prototype.scrollIntoView = orig;
+    }
+  });
+
   it("focusId applies focus-flash class to the matching card", async () => {
     render(SettingsPluginsPanel, {
       plugins: [plugin({ id: "target-plugin", name: "Target Plugin" })],

--- a/ui/src/lib/components/settings/SettingsPluginsPanel.svelte
+++ b/ui/src/lib/components/settings/SettingsPluginsPanel.svelte
@@ -36,7 +36,7 @@
     if (!focusId) return;
     const el = document.getElementById(`plugin-card-${focusId}`);
     if (!el) return;
-    el.scrollIntoView({ block: "center" });
+    el.scrollIntoView({ block: "start" });
     el.classList.add("focus-flash");
     const t = setTimeout(() => el.classList.remove("focus-flash"), 1200);
     return () => clearTimeout(t);


### PR DESCRIPTION
## Problem

Clicking a plugin gear-menu item with `action: { kind: "panel" }` opens Settings → Plugins and scrolls the matching card into view — but for a tall plugin panel (config + meters + gauges + sparklines + charts + timeline) it landed the operator **mid-panel**.

## Cause

`ui/src/lib/components/settings/SettingsPluginsPanel.svelte` used `el.scrollIntoView({ block: "center" })`, which centers the whole card; a tall card's top scrolls above the viewport.

## Fix

`block: "center"` → `block: "start"`, so the card's top aligns to the panel viewport top. The scroll container (`.panel` in `Settings.svelte`) has no sticky header inside it, so no `scroll-margin-top` is needed. The plugin contract (`PluginGearAction` / `PluginUIView`) exposes no scroll-alignment lever, so this is fixable host-side only.

## Test

Added a browser-test case spying on `Element.prototype.scrollIntoView` that asserts `focusId` triggers it with `{ block: "start" }`. All 766 UI browser tests pass; `bun run check` clean.

Closes #1254

🤖 Generated with [Claude Code](https://claude.com/claude-code)