### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -30,6 +30,9 @@ lines), read by the systemd unit if present.
 | `SHEPHERD_USAGE_HOLD_ENABLED` | `true` | Queue newly submitted tasks instead of spawning them while account usage is high (auto-released as usage falls). Set `0`/`false` to always spawn immediately |
 | `SHEPHERD_USAGE_HOLD_PCT` | `80` | Hold threshold: when the higher of the 5-hour / weekly usage window reaches this percent, new tasks are held. Range `0`–`100` |
 | `SHEPHERD_USAGE_HOLD_AUTO_RELEASE` | `true` | When on, the ~30 s sweeper auto-starts held tasks once usage drops back below the threshold. Set `0`/`false` to keep held tasks queued until the operator starts (or discards) each one manually from the held-tasks popover. Turning the gate off entirely (`SHEPHERD_USAGE_HOLD_ENABLED=0`) still flushes everything regardless of this flag |
+| `SHEPHERD_USAGE_DOWNGRADE_ENABLED` | `false` | Companion to the usage hold: when on, every newly spawned agent (main task agents **and** the role agents) runs on `SHEPHERD_USAGE_DOWNGRADE_MODEL` instead of its configured model once usage reaches the downgrade threshold — work keeps flowing, just cheaper. Opt-in (no behavior change when off); set `1`/`true` to enable |
+| `SHEPHERD_USAGE_DOWNGRADE_PCT` | `70` | Downgrade threshold: when the higher of the 5-hour / weekly usage window reaches this percent, new spawns are downgraded. Range `0`–`100`; default `70` is deliberately **below** `SHEPHERD_USAGE_HOLD_PCT` (`80`) so usage downgrades first and only later holds |
+| `SHEPHERD_USAGE_DOWNGRADE_MODEL` | `haiku` | Model the downgrade routes spawns to while active — a default-model setting (`auto` / `default` / `<alias>`) |
 
 ## Live preview
 
@@ -127,7 +130,8 @@ one (a per-repo in-flight guard means at most one run per repo at a time):
 | --- | --- | --- |
 | `SHEPHERD_DOC_AGENT` | `0` (off) | Set `1` to enable the doc agent (**Phase-0 observe**): manual trigger, nightly + merge-triggered cadence, and the boot reconcile. Finalize is **log-only** (no PR) until `SHEPHERD_DOC_AGENT_ACT` is also set |
 | `SHEPHERD_DOC_AGENT_ACT` | `0` (off) | **Phase-1 act.** Set `1` to escalate finalize to actually commit, push, and open the **pull request**. Meaningful only when `SHEPHERD_DOC_AGENT` is also on |
-| `SHEPHERD_DOC_AGENT_MODEL` | _(none)_ | Model alias for the doc-agent spawn; unset uses the spawn default |
+| `SHEPHERD_DOC_AGENT_CLI` | `inherit` | Agent CLI for the doc-agent spawn: `inherit` follows the global default provider, or pin `claude` / `codex`. Seeds a fresh DB; persisted + UI-configurable |
+| `SHEPHERD_DOC_AGENT_MODEL` | `default` | Model for the doc-agent spawn: `default` follows the global default model, or pin a `<model alias>`. Seeds a fresh DB; persisted + UI-configurable |
 | `SHEPHERD_DOC_AGENT_NIGHTLY_HOUR` | `3` | Local hour (0–23) at/after which the nightly sweep evaluates each repo; invalid values fall back to `3` |
 
 ## Per-agent sandbox / permission profiles


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc update — sync to recent source changes

## Changes

- **`docs-site/src/content/docs/reference/configuration.md`** — two stale spots in the
  env-var reference fixed:
  - Added the **usage-aware model downgrade** vars (`SHEPHERD_USAGE_DOWNGRADE_ENABLED`,
    `_PCT`, `_MODEL`) to the Core table. These are the direct companion to the already
    documented usage-**hold** gate but were entirely undocumented. Source: `src/config.ts`
    L640–645 (`usageDowngradeEnabled`/`usageDowngradePct`/`usageDowngradeModel`, defaults
    off / `70` / `haiku`, with the `70 < 80` two-tier escalation called out in the config
    comment), introduced in commit `e7931c7e` ("provider-agnostic per-role agent
    environments + usage-aware downgrade") and tuned by `e0077393`/`afc40722`.
  - Added the missing `SHEPHERD_DOC_AGENT_CLI` row to the "Documentation automation"
    table (which already documented the matching `SHEPHERD_DOC_AGENT_MODEL`) and aligned
    the `SHEPHERD_DOC_AGENT_MODEL` default/description with the per-role-environment model
    (`default` = follow global). Source: `src/config.ts` L472–473 (`docAgentCli`
    default `"inherit"`, `docAgentModel` default `"default"`), commit `e7931c7e`.

## Uncertain / needs human judgment

- **Multi-provider (Claude + Codex) is undocumented across the curated docs-site.**
  `src/types.ts` now defines `AGENT_PROVIDERS = ["claude", "codex"]`, `CODEX_MODELS`, and
  `MODELS_BY_PROVIDER`; `src/config.ts` adds `SHEPHERD_DEFAULT_AGENT_PROVIDER`, `CODEX_BIN`,
  the codex-update audit log, and per-role CLI/model knobs for every role
  (`SHEPHERD_{NAMER,AUTOPILOT,CRITIC,PLANNER,RECAP}_{CLI,MODEL}`). None of these appear in
  configuration.md. I documented only `SHEPHERD_DOC_AGENT_CLI` (because its table already
  carried the matching `_MODEL` knob) and avoided introducing the broader codex/per-role
  surface — properly covering it likely warrants new prose or a dedicated page, which is
  out of scope here. Recommend a human decide how much of the multi-provider story to add.

- **`docs/external-task-api.md` request schema is incomplete but not wrong.**
  `POST /api/sessions` now also accepts `agentProvider`, `issueRef`, `planGateEnabled`,
  `autopilotEnabled`, `sandboxProfile`, `research`, and `mergeTrainPrs`
  (`ALLOWED_KEYS`, `src/validate.ts` L37–51), and `model` is validated against the chosen
  provider. The documented fields (`repoPath`/`baseBranch`/`prompt`/`model`/`images`/
  `force`) and the Claude `model` enum still match source exactly, and "unknown keys are
  rejected" is still true. I left it unchanged rather than introduce the undocumented
  `agentProvider`/codex concept into an API contract doc without a phrasing decision.

- **Other undocumented env vars in `src/config.ts`** (e.g. `SHEPHERD_AUTH_MODE`,
  `SHEPHERD_DEFAULT_MODEL`, `SHEPHERD_FABLE_AVAILABLE`, `SHEPHERD_EXTRA_CREDITS_DRAIN_CEILING`,
  `SHEPHERD_AUTOMERGE_REBASE_CAP`, `SHEPHERD_REVIEW_CYCLES_CAP`,
  `SHEPHERD_PLAN_REVIEW_CYCLES_CAP`, `SHEPHERD_HOUSE_RULES_BUDGET_CHARS`,
  `SHEPHERD_SESSION_HOUSEKEEPING`, `SHEPHERD_LLM_NAMING`, `SHEPHERD_STANDARD_COMMAND`,
  push/VAPID vars, etc.) are absent from configuration.md. The page has always been a
  curated subset (it never listed these), so this reads as deliberate scoping, not
  staleness. Left untouched — a human should decide whether to broaden the reference.

- **`docs-site/src/content/docs/operating.md` — logrotate timer.** Commit `7bfc4827`
  added a `shepherd-logrotate.timer` systemd unit to size-cap `shepherd.log`. operating.md
  documents the backup timer but not this one. It doesn't contradict the doc (which never
  claimed to list every timer), so I left it; worth a human deciding whether to add a note.

- **`docs/sandbox-security.md`, `docs/token-usage-analysis.md`, `index.md`,
  `getting-started.md`, `glossary.md`** — reviewed against source and found current. The
  sandbox.ts line references (`:317`, `:310`, `:413`, `:438`, `:554`, `:565-570`), the
  egress allowlist, the Claude `MODELS` enum, and the glossary terms all still match. No
  changes made.