### PR TITLE
feat(owed): count badge on OWED lens + agent notice to declare manual steps

### DIFF
--- a/src/post-merge-steps.ts
+++ b/src/post-merge-steps.ts
@@ -92,7 +92,17 @@ export class PostMergeStepsService {
       console.warn(`[post-merge-steps] materialize for ${session.id} failed:`, err);
       return;
     }
-    if (inserted) this.deps.emitChange();
+    if (inserted) {
+      // Observability (#1257): a fresh owed record is the real-world signal that an agent actually
+      // declared manual steps in its PR body. Logging it lets the operator audit which PRs populate
+      // the Owed lens and watch the false-positive (fabricated-step) rate — the prompt notice that
+      // drives this is unverifiable in-PR, so this log is the verification path.
+      const pr = prNumber != null ? `pr#${prNumber}` : "no-pr";
+      console.info(
+        `[post-merge-steps] materialized ${steps.length} step(s) for ${session.desig} (${session.id}, ${pr})`,
+      );
+      this.deps.emitChange();
+    }
 
     await this.maybeOpenTrackingIssue(session, prNumber, steps, forge);
   }

--- a/src/service.ts
+++ b/src/service.ts
@@ -514,6 +514,40 @@ const SINGLE_PR_INVARIANT =
   "Never split the work across two PRs from this one session.";
 
 /**
+ * Agent-facing notice (#1257) that tells a PR-authoring agent to DECLARE manual operator steps in the
+ * PR body via the carriers `parseManualSteps()` (src/manual-steps.ts) understands, so the #1061
+ * post-merge pipeline + the Owed lens get a live data source. Rides every CODE spawn (suppressed for
+ * research) — Claude gets it via composeSystemPrompt, Codex inline via buildCodexSpawnArgv (Codex has
+ * no --append-system-prompt). Not user-facing chrome (an instruction to the agent), so no i18n — same
+ * precedent as SINGLE_PR_INVARIANT / AUTOPILOT_DIRECTIVE.
+ *
+ * IMPORTANT — the embedded fenced example is the SOURCE OF TRUTH for the carrier syntax and is pinned
+ * to the parser by a unit test (`parseManualSteps(MANUAL_STEPS_NOTICE)` in test/manual-steps.test.ts).
+ * The fence-open line must stay EXACTLY ```shepherd:manual-steps (FENCE_OPEN regex) and each step a
+ * column-0-or-indented `- [ ]` line (TASK_LINE) so a wording edit can never silently break parsing.
+ * The notice is emphatically default-empty: a fabricated step is worse than none.
+ */
+export const MANUAL_STEPS_NOTICE =
+  "Before you open the pull request, declare any MANUAL OPERATOR STEPS the change implies — work a " +
+  "human must do around merge/deploy that the diff itself cannot perform (flip a feature flag, set " +
+  "an env var, run a one-off backfill/migration, restart a worker, DNS cutover, seed a record). " +
+  "Shepherd parses these from the PR body and surfaces them on the Owed lens so they survive merge " +
+  "and teardown.\n" +
+  "Declare them in the PR body with EITHER carrier:\n" +
+  "- A fenced block — each `- [ ]` line is one step:\n" +
+  "```shepherd:manual-steps\n" +
+  "- [ ] Set the FEATURE_X env var in production\n" +
+  "- [ ] POST-MERGE: Run the data backfill once the PR is live\n" +
+  "```\n" +
+  "- Or column-0 `Manual-Step:` trailer lines (flush-left, outside any fence), e.g. a line reading " +
+  "exactly `Manual-Step: Rotate the signing key`.\n" +
+  "Prefix a step with `POST-MERGE:` when it must happen AFTER the PR merges.\n" +
+  "DEFAULT TO DECLARING NOTHING: most PRs need NO manual steps. Add a step ONLY for a real " +
+  "out-of-band action a human must take; if merging fully completes the change, OMIT the carrier " +
+  "entirely. NEVER invent steps to fill the block — a spurious step is worse than none. When in " +
+  "doubt, declare nothing.";
+
+/**
  * Injected as the highest-priority directive for an attended RESEARCH task (`research: true`).
  * A research session does open-ended web research with sub-agents and delivers a report-only PR
  * OR a GitHub issue — never code. It SUPPRESSES the plan-gate, autopilot, and build-queue
@@ -829,6 +863,10 @@ export function composeSystemPrompt(
   // redundant there and would muddy that deliverable.
   if (!opts.research) {
     blocks.push(`<single-pr-invariant>\n${SINGLE_PR_INVARIANT}\n</single-pr-invariant>`);
+    // Manual-operator-steps notice (#1257): rides every code spawn, suppressed for research (which
+    // opens no code PR) — same gate as the single-PR invariant. Gives the Owed lens a live data
+    // source by telling the agent to declare manual steps via the carriers parseManualSteps reads.
+    blocks.push(`<manual-steps-notice>\n${MANUAL_STEPS_NOTICE}\n</manual-steps-notice>`);
   }
   // Research is the highest-priority directive: it replaces BOTH the plan-gate and the autopilot
   // directive (none of those fit a report-PR/issue deliverable).
@@ -1660,15 +1698,20 @@ export class SessionService {
     promptArg: string,
     model: string | null,
     autopilotActive: boolean,
+    manualStepsNotice: boolean,
   ): string[] {
     const argv = ["codex", "--no-alt-screen", "--dangerously-bypass-approvals-and-sandbox"];
     if (model) argv.push("--model", model);
-    // Codex has no --append-system-prompt, so the autopilot directive (which Claude gets via
-    // composeSystemPrompt) must ride inline on the prompt. Gated by the caller on
-    // !research && isolated && effectiveAutopilot — see buildSpawnArgv call site.
-    const prompt = autopilotActive
-      ? `${promptArg}\n\n<autopilot-directive>\n${AUTOPILOT_DIRECTIVE}\n</autopilot-directive>`
-      : promptArg;
+    // Codex has no --append-system-prompt, so the blocks Claude gets via composeSystemPrompt must
+    // ride inline on the prompt. The autopilot directive is gated by the caller on
+    // !research && isolated && effectiveAutopilot; the manual-steps notice (#1257) is gated only on
+    // !research (its single-pr-invariant equivalent — every code spawn, autopilot or not). See the
+    // buildCodexSpawnArgv call site.
+    let prompt = promptArg;
+    if (autopilotActive)
+      prompt += `\n\n<autopilot-directive>\n${AUTOPILOT_DIRECTIVE}\n</autopilot-directive>`;
+    if (manualStepsNotice)
+      prompt += `\n\n<manual-steps-notice>\n${MANUAL_STEPS_NOTICE}\n</manual-steps-notice>`;
     argv.push(prompt);
     return argv;
   }
@@ -1892,6 +1935,9 @@ export class SessionService {
                   { autopilotEnabled: input.autopilotEnabled ?? null },
                   repoConfig.autopilotEnabled,
                 ),
+              // Manual-steps notice (#1257): rides every Codex code spawn, suppressed only for
+              // research — its single-pr-invariant equivalent, independent of the autopilot gate.
+              !input.research,
             )
           : this.buildSpawnArgv(
               input,

--- a/test/manual-steps.test.ts
+++ b/test/manual-steps.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, describe } from "bun:test";
 import { parseManualSteps } from "../src/manual-steps";
+import { MANUAL_STEPS_NOTICE } from "../src/service";
 
 const block = (lines: string) => "Some PR prose.\n\n```shepherd:manual-steps\n" + lines + "\n```\n";
 
@@ -79,6 +80,17 @@ describe("parseManualSteps — manual-operator-step carrier parsing (#1059)", ()
     expect(parseManualSteps(body)).toEqual([
       { id: "ms1", text: "block step", postMerge: false },
       { id: "ms2", text: "trailer step", postMerge: false },
+    ]);
+  });
+
+  // Drift guard (#1257): the carrier example embedded in the agent-facing MANUAL_STEPS_NOTICE must
+  // stay parseable by THIS parser. If a wording edit breaks the fence-open line, a checkbox line, or
+  // the POST-MERGE prefix, agents would emit non-parsing carriers and the Owed lens would silently
+  // never populate. Pinning the notice's own example to parseManualSteps catches that at CI time.
+  test("MANUAL_STEPS_NOTICE's embedded example parses to the documented steps (incl. POST-MERGE)", () => {
+    expect(parseManualSteps(MANUAL_STEPS_NOTICE)).toEqual([
+      { id: "ms1", text: "Set the FEATURE_X env var in production", postMerge: false },
+      { id: "ms2", text: "Run the data backfill once the PR is live", postMerge: true },
     ]);
   });
 });

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -159,6 +159,7 @@ function setRepoAutopilot(store: SessionStore, on: boolean) {
 }
 
 const hasDirective = (argv: string[]) => argv.some((a) => a.includes("<autopilot-directive>"));
+const hasManualNotice = (argv: string[]) => argv.some((a) => a.includes("<manual-steps-notice>"));
 
 test("createSession: codex provider starts interactive codex; plan-gate forced off, autopilot off → no directive", async () => {
   const { store, service, calls } = codexHarness(true);
@@ -174,14 +175,20 @@ test("createSession: codex provider starts interactive codex; plan-gate forced o
     autopilotEnabled: false,
   });
 
-  expect(calls.start.argv).toEqual([
+  // The fixed flags + model are exact; the prompt (last arg) now carries the #1257 manual-steps
+  // notice appended inline (every codex CODE spawn), so it starts with the user prompt rather than
+  // equalling it. Autopilot is off here → no autopilot directive.
+  expect(calls.start.argv.slice(0, 5)).toEqual([
     "codex",
     "--no-alt-screen",
     "--dangerously-bypass-approvals-and-sandbox",
     "--model",
     "gpt-5.5",
-    "flatten it",
   ]);
+  const codexPrompt = calls.start.argv[5] as string;
+  expect(codexPrompt.startsWith("flatten it")).toBe(true);
+  expect(codexPrompt).not.toContain("<autopilot-directive>");
+  expect(codexPrompt).toContain("<manual-steps-notice>");
   expect(s.agentProvider).toBe("codex");
   expect(s.model).toBe("gpt-5.5");
   expect(s.claudeSessionId).toBe("");
@@ -269,6 +276,38 @@ test("createSession: codex + isolated + research + repo-default ON → NO direct
     research: true,
   });
   expect(hasDirective(calls.start.argv)).toBe(false);
+});
+
+// #1257: the manual-steps notice rides every codex CODE spawn (gated only on !research — its
+// single-pr-invariant equivalent), independent of the autopilot/isolation gate, and is suppressed
+// for a research spawn (which opens no code PR).
+test("createSession: codex code spawn carries the manual-steps notice, even with autopilot off", async () => {
+  const { service, calls } = codexHarness(true);
+  await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "build it",
+    model: null,
+    agentProvider: "codex",
+    images: [],
+    autopilotEnabled: false,
+  });
+  expect(hasManualNotice(calls.start.argv)).toBe(true);
+  expect(hasDirective(calls.start.argv)).toBe(false);
+});
+
+test("createSession: codex research spawn omits the manual-steps notice", async () => {
+  const { service, calls } = codexHarness(true);
+  await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "research it",
+    model: null,
+    agentProvider: "codex",
+    images: [],
+    research: true,
+  });
+  expect(hasManualNotice(calls.start.argv)).toBe(false);
 });
 
 // Regression: the 1M-context model aliases ("opus[1m]"/"sonnet[1m]") must reach the
@@ -3159,6 +3198,29 @@ test("composeSystemPrompt rides the single-PR invariant on code spawns, never on
   // Suppressed for a research deliverable.
   expect(composeSystemPrompt(null, false, { research: true })).not.toContain(
     "<single-pr-invariant>",
+  );
+});
+
+test("composeSystemPrompt rides the manual-steps notice on code spawns, never on research", () => {
+  // #1257: the notice gives the Owed lens a live data source. Same gate as the single-PR invariant —
+  // every CODE spawn, suppressed only for research (which opens no code PR).
+  const withRules = `<${HOUSE_RULES_TAG}>\nintro\n- Use bun\n</${HOUSE_RULES_TAG}>`;
+  const codeSpawns = [
+    composeSystemPrompt(null),
+    composeSystemPrompt(withRules),
+    composeSystemPrompt(null, true),
+    composeSystemPrompt(null, true, { planGate: "interactive" }),
+    composeSystemPrompt(null, true, { planGate: "auto" }),
+  ];
+  for (const sp of codeSpawns) {
+    expect(sp).toContain("<manual-steps-notice>");
+    expect(sp).toContain("</manual-steps-notice>");
+    // Anchor on the stable carrier syntax (the parser contract) + the emphatic default-empty rule.
+    expect(sp).toContain("```shepherd:manual-steps");
+    expect(sp).toContain("DEFAULT TO DECLARING NOTHING");
+  }
+  expect(composeSystemPrompt(null, false, { research: true })).not.toContain(
+    "<manual-steps-notice>",
   );
 });
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1892,6 +1892,7 @@
   "automation_manual_steps_issue_name": "Manuelle Schritte als Issue verfolgen",
   "automation_manual_steps_issue_desc": "Beim Merge ein GitHub-Issue mit den manuellen Schritten des PRs öffnen",
   "herd_owed_title": "Manuelle Schritte nach dem Merge, die noch offen sind",
+  "herd_owed_count": "{count} gemergte PR(s) mit offenen Post-Merge-Schritten",
   "owed_main_hint": "Offene Schritte nach dem Merge werden im Herd-Panel links angezeigt.",
   "owed_title": "Offene Schritte nach dem Merge",
   "owed_empty": "Keine offenen Schritte nach dem Merge — alles erledigt.",
@@ -2186,6 +2187,8 @@
   "github_lens_no_data": "GitHub-Rate-Limit-Daten nicht verfügbar.",
   "feat_github_rate_limits_title": "GitHub-Rate-Limits im Verbrauch",
   "feat_github_rate_limits_body": "Die Verbrauchsansicht hat einen neuen GitHub-Tab, der dein REST- und GraphQL-API-Kontingent getrennt zeigt. Ist eines erschöpft, erklärt er, welche Funktionen bis zum Reset pausieren — ein leeres GraphQL-Kontingent wirkt so nicht mehr wie ein stiller Defekt.",
+  "feat_owed_badge_title": "Zähler-Badge der Owed-Linse",
+  "feat_owed_badge_body": "Die OWED-Herd-Linse zeigt jetzt ein Zähler-Badge, wenn gemergte PRs noch offene manuelle Post-Merge-Schritte haben — so verdient die Linse deine Aufmerksamkeit nur, wenn es etwas zu tun gibt, statt bei 0 oder 5 offenen Schritten gleich auszusehen.",
   "github_lens_paused": "Pausiert",
   "github_lens_graphql_backoff": "GraphQL-Polling pausiert, während ein Rate-Limit-Backoff abklingt — PR-, Issue- und Backlog-Updates laufen in ~{time} weiter."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1892,6 +1892,7 @@
   "automation_manual_steps_issue_name": "Track manual steps in an issue",
   "automation_manual_steps_issue_desc": "On merge, open a GitHub issue listing the PR's manual operator steps",
   "herd_owed_title": "Post-merge manual steps you still owe",
+  "herd_owed_count": "{count} merged PR(s) still owe post-merge steps",
   "owed_main_hint": "Owed post-merge steps are shown in the herd panel on the left.",
   "owed_title": "Post-merge steps owed",
   "owed_empty": "No post-merge steps owed — you're all caught up.",
@@ -2186,6 +2187,8 @@
   "github_lens_no_data": "GitHub rate-limit data unavailable.",
   "feat_github_rate_limits_title": "GitHub rate limits in Usage",
   "feat_github_rate_limits_body": "The Usage view has a new GitHub tab showing your REST and GraphQL API budgets separately. When one is exhausted it explains which features pause until reset — so an empty GraphQL budget no longer looks like a silent breakage.",
+  "feat_owed_badge_title": "Owed lens count badge",
+  "feat_owed_badge_body": "The OWED Herd lens now shows a count badge when merged PRs still owe post-merge manual steps — so the lens earns your attention only when there's something to do, instead of looking identical whether 0 or 5 steps are outstanding.",
   "github_lens_paused": "Paused",
   "github_lens_graphql_backoff": "GraphQL polling is paused while a rate-limit backoff clears — PR, issue and backlog updates resume in ~{time}."
 }

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -27,6 +27,12 @@
   import { displayStatus } from "$lib/display-status";
   import { reviews, planGates } from "$lib/reviews.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { postMergeSteps } from "$lib/post-merge-steps.svelte";
+
+  // Outstanding owed records (#1257) — drives the OWED lens count badge. The container reads the
+  // shared store; HerdLensStrip stays a pure prop-driven component. Loaded in +page.svelte (desktop
+  // eager load); 0 until then, which simply hides the badge.
+  const owedCount = $derived(postMergeSteps.records.length);
 
   let {
     sessions,
@@ -458,6 +464,7 @@
       {statusFilter}
       {statusLabel}
       {collapsible}
+      {owedCount}
       {onstatusfilter}
       {oncollapse}
     />

--- a/ui/src/lib/components/herd/HerdLensStrip.browser.test.ts
+++ b/ui/src/lib/components/herd/HerdLensStrip.browser.test.ts
@@ -69,3 +69,45 @@ describe("HerdLensStrip header bits", () => {
     expect(frame.querySelector(".statchip")).not.toBeNull();
   });
 });
+
+describe("HerdLensStrip OWED count badge (#1257)", () => {
+  it("hides the badge when owedCount is 0 (or default)", async () => {
+    const frame = mount300();
+    expect(frame.querySelector(".owed-badge")).toBeNull();
+  });
+
+  it("renders the badge with the count when owedCount > 0", async () => {
+    const frame = document.createElement("div");
+    frame.style.width = "300px";
+    document.body.appendChild(frame);
+    render(HerdLensStrip, { props: { ...base, owedCount: 3 }, target: frame });
+    const badge = frame.querySelector(".owed-badge");
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).toBe("3");
+    // The badge anchors to the OWED lens (absolute → inside a position:relative segment).
+    expect(frame.querySelector(".lens-owed .owed-badge")).not.toBeNull();
+  });
+
+  it("caps a large count at 99+", async () => {
+    const frame = document.createElement("div");
+    frame.style.width = "300px";
+    document.body.appendChild(frame);
+    render(HerdLensStrip, { props: { ...base, owedCount: 250 }, target: frame });
+    expect(frame.querySelector(".owed-badge")!.textContent).toBe("99+");
+  });
+
+  it("keeps all six lenses on a single row at the 300px floor with a 2-digit badge", async () => {
+    const frame = document.createElement("div");
+    frame.style.width = "300px";
+    document.body.appendChild(frame);
+    render(HerdLensStrip, { props: { ...base, owedCount: 42 }, target: frame });
+    const btns = [...frame.querySelectorAll<HTMLElement>(".lens")];
+    expect(btns).toHaveLength(6);
+    // single row ⇒ every segment shares the same offsetTop (the absolute badge adds no flow width)
+    expect(new Set(btns.map((b) => b.offsetTop)).size).toBe(1);
+    // the badge itself must not overflow the OWED segment's box
+    const owed = frame.querySelector<HTMLElement>(".lens-owed")!;
+    const badge = frame.querySelector<HTMLElement>(".owed-badge")!;
+    expect(badge.offsetWidth).toBeLessThanOrEqual(owed.offsetWidth);
+  });
+});

--- a/ui/src/lib/components/herd/HerdLensStrip.svelte
+++ b/ui/src/lib/components/herd/HerdLensStrip.svelte
@@ -8,6 +8,7 @@
     statusFilter,
     statusLabel,
     collapsible,
+    owedCount = 0,
     onstatusfilter,
     oncollapse,
   }: {
@@ -15,9 +16,14 @@
     statusFilter: "running" | "idle" | "blocked" | null;
     statusLabel: string;
     collapsible: boolean;
+    /** Outstanding post-merge owed records (#1257) — drives the OWED lens count badge; 0 hides it. */
+    owedCount?: number;
     onstatusfilter?: (status: "running" | "idle" | "blocked" | null) => void;
     oncollapse?: () => void;
   } = $props();
+
+  // Bound the badge width so a large count can't perturb the fixed 6-lens single-row grid.
+  const owedBadge = $derived(owedCount > 99 ? "99+" : String(owedCount));
 </script>
 
 <!-- Desktop / touch-wide lens strip: replaces the inline .fbtn filter row that overflowed
@@ -118,9 +124,9 @@
   </button>
   <button
     type="button"
-    class="lens"
+    class="lens lens-owed"
     class:on={statusFilter == null && filter === "owed"}
-    title={m.herd_owed_title()}
+    title={owedCount > 0 ? m.herd_owed_count({ count: owedCount }) : m.herd_owed_title()}
     aria-pressed={statusFilter == null && filter === "owed"}
     use:coachTarget={"owed-lens"}
     onclick={() => {
@@ -130,6 +136,11 @@
   >
     <span class="ic" aria-hidden="true">☑</span>
     <span class="lb">{m.herd_seg_owed()}</span>
+    {#if owedCount > 0}
+      <span class="owed-badge" aria-label={m.herd_owed_count({ count: owedCount })}
+        >{owedBadge}</span
+      >
+    {/if}
   </button>
 </div>
 
@@ -237,6 +248,30 @@
   .lens:focus-visible {
     outline: none;
     box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+  /* Anchor for the absolutely-positioned owed count badge so it overlays the segment's
+     top-right corner without consuming column width (keeps the 6-lens single-row grid intact). */
+  .lens-owed {
+    position: relative;
+  }
+  /* Owed count badge (#1257): mirrors UnitRow's .chip-manual-steps recipe (--status-warn border/
+     text + color-mix wash). --fs-micro is a deliberate sub-16px exception — same precedent as the
+     strip's own label and the UnitRow chip; it's a count overlay, not body text. */
+  .owed-badge {
+    position: absolute;
+    top: 3px;
+    right: 3px;
+    min-width: 14px;
+    box-sizing: border-box;
+    text-align: center;
+    font-size: var(--fs-micro);
+    line-height: 1.2;
+    letter-spacing: 0.02em;
+    padding: 0 3px;
+    border: 1px solid var(--status-warn);
+    border-radius: 7px;
+    color: var(--status-warn);
+    background: color-mix(in oklab, var(--status-warn) 14%, var(--color-panel));
   }
   /* Shrink the label when the strip itself is narrow so the longest DE label ("Nächstes")
      stays on one line and all six lenses keep to a single row at the 300px sidebar floor. */

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1855,4 +1855,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_github_rate_limits_title",
     bodyKey: "feat_github_rate_limits_body",
   },
+  {
+    // The OWED Herd lens now wears a count badge when merged PRs still owe post-merge
+    // manual steps. targetId "owed-lens" is the existing coachmark anchor on the lens
+    // segment, so the coachmark points right at the badge.
+    id: "owed-lens-count-badge",
+    sinceVersion: "1.39.0",
+    titleKey: "feat_owed_badge_title",
+    bodyKey: "feat_owed_badge_body",
+    targetId: "owed-lens",
+  },
 ];

--- a/ui/src/lib/post-merge-steps.svelte.ts
+++ b/ui/src/lib/post-merge-steps.svelte.ts
@@ -7,14 +7,22 @@ import { getOutstandingManualSteps, setManualStepDone, dismissManualSteps } from
 class PostMergeStepsStore {
   records = $state<PostMergeSteps[]>([]);
   loaded = $state(false);
+  /** In-flight guard (#1257): true while a `load()` GET is outstanding. Stops a viewport toggle (or
+   *  any re-entrant caller — eager badge load, lens-open fallback, WS refresh) from firing a
+   *  duplicate fetch before the first one resolves and flips `loaded`. */
+  private loading = false;
 
   /** Re-fetch the outstanding set. On failure leaves the existing list untouched (next call retries). */
   async load() {
+    if (this.loading) return; // a fetch is already in flight — don't duplicate it
+    this.loading = true;
     try {
       this.records = await getOutstandingManualSteps();
       this.loaded = true;
     } catch {
       /* best-effort; the next load retries */
+    } finally {
+      this.loading = false;
     }
   }
 

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1011,10 +1011,23 @@
     void doneSessions.load();
     void recaps.load();
   });
-  // Owed lens (#1061): (re)load the durable post-merge steps whenever the lens opens. Live updates
-  // arrive via the `post-merge-steps:changed` WS event (handled in store.svelte.ts).
+  // Owed lens count badge (#1257): eagerly load the durable post-merge steps on the DESKTOP layout
+  // so the OWED lens badge reflects the outstanding count before the lens is ever opened. Gated on
+  // `!mobile.current` because the mobile branch renders HerdSegRow, which has no OWED segment (no
+  // badge to feed) — and re-fires if the viewport later widens to desktop. Once-only via the
+  // store's `loaded` guard; the store's in-flight guard stops a viewport toggle mid-load from
+  // duplicating the GET. Live updates thereafter arrive via the `post-merge-steps:changed` WS event
+  // (handled in store.svelte.ts), whose `refreshIfLoaded()` is a no-op until `loaded` is true.
   $effect(() => {
-    if (herdFilter !== "owed") return;
+    if (mobile.current || postMergeStepsStore.loaded) return;
+    void postMergeStepsStore.load();
+  });
+  // Failure-recovery fallback (#1257): if the eager load above failed (`loaded` still false), opening
+  // the OWED lens retries — the operator's natural action when they suspect owed work. The `!loaded`
+  // guard makes this a no-op on the happy path (eager load already populated it), so there is no
+  // double-fetch when the lens opens normally.
+  $effect(() => {
+    if (herdFilter !== "owed" || postMergeStepsStore.loaded) return;
     void postMergeStepsStore.load();
   });
   $effect(() => {


### PR DESCRIPTION
Closes #1257.

The **Owed** Herd lens (#1061) was functionally sound but sat permanently empty and gave no attention signal. This addresses both findings from the verification report.

## Finding 2 — outstanding-count badge (primary)

The `☑ OWED` lens now wears a count badge when merged PRs still owe post-merge manual steps; nothing renders at 0, and the lens stays one of the six always-visible nav lenses (the `owed-lens` coachmark anchor is untouched).

- `HerdLensStrip` gains an `owedCount` prop and renders a badge on the OWED segment when `> 0` — absolutely positioned inside a `position: relative` segment so it never perturbs the fixed `auto-fit` 6-lens grid / 300px single-row floor, capped at `99+`, reusing UnitRow's `.chip-manual-steps` recipe (`--status-warn`).
- **Count = outstanding records** (`postMergeSteps.records.length`) — merged PRs still owing steps, matching the card list in the panel. (Note: this reuses UnitRow's chip *recipe*, not its *metric* — UnitRow counts steps on one session; this counts records across sessions.)
- `Herd` derives `owedCount` from the store; `+page.svelte` eager-loads it on the **desktop** layout so the badge populates before the lens is opened (no fetch in mobile flow, which has no OWED segment), with a `!loaded`-guarded **lens-open recovery fallback** if the eager load fails, and a store-level **in-flight guard** so a viewport toggle can't duplicate the GET.

## Finding 1 — give the lens a live data source

Verified that nothing told PR-authoring agents to declare manual operator steps via the `shepherd:manual-steps` fence / `Manual-Step:` trailers — so the #1061 pipeline never fired and the lens stayed empty by omission.

- New **`MANUAL_STEPS_NOTICE`** rides every **code** spawn (suppressed for research) — Claude via `composeSystemPrompt`, **Codex** inline via `buildCodexSpawnArgv` (Codex has no `--append-system-prompt`), gated `!research`.
- It is **emphatically default-empty** ("a spurious step is worse than none; when in doubt, declare nothing") to guard against the dominant failure mode — agents fabricating noise.
- `post-merge-steps` logs each materialized record (`console.info`) for real-world false-positive observability.

### ⚠️ Bundling / verifiability note
The two halves differ in testability, and bundling is intentional (it's #1257's combined scope, and the halves are complementary — the badge needs data, the data needs a signal):
- **Badge** — cleanly, deterministically tested in-PR.
- **Instruction** — an **unconditional, all-repos, behavior-changing** system-prompt injection whose real effect (do agents declare real steps vs. fabricate noise?) is **not verifiable in-PR**; there is **no automated over-declaration guard**. Safeguards are the default-empty wording, a **parser-drift unit test** (`parseManualSteps(MANUAL_STEPS_NOTICE)` pins the documented syntax to the parser), and the `console.info` for post-merge auditing.

### Spawn-path coverage
Both first-class PR-authoring coding spawns carry the notice (Claude + Codex). **doc-agent** and aux agents (critic/distiller/namer/recap/promote) are a documented exclusion — they author only doc-sync / non-feature PRs that carry no manual operator steps.

## Tests & checks
- Root: `service.test.ts` (composeSystemPrompt + Codex inline, present on code / absent on research), `manual-steps.test.ts` (parser-drift guard), `post-merge-steps.test.ts` — all green; `bun run lint` clean.
- UI: `HerdLensStrip.browser.test.ts` (badge present/absent, `99+` cap, single row preserved with 2-digit badge at 300px), `bun run check` (svelte-check 0 errors), `check:i18n` parity (EN+DE), full node suite (1540) green.
- i18n keys (EN+DE) + feature-catalog entry added for the badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)