### PR TITLE
fix(doc-agent): fail-closed on prettier failure — abort run + visible error outcome

### DIFF
--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -52,6 +52,20 @@ async function defaultPrettierWrite(args: {
   });
 }
 
+/** Thrown by stageInScope when `prettier --write` fails, so finalize can fail-closed:
+ *  abort the run (no commit/push/PR) and record an `error` outcome instead of swallowing
+ *  the failure and committing unformatted docs. */
+export class PrettierFormatError extends Error {
+  constructor(
+    readonly repoPath: string,
+    readonly files: string[],
+    options?: { cause?: unknown },
+  ) {
+    super(`prettier failed to format docs for ${repoPath}: ${files.join(", ")}`, options);
+    this.name = "PrettierFormatError";
+  }
+}
+
 /** Prefix for ephemeral doc-agent herdr names. Each run appends 8 hex of a fresh UUID so an
  *  orphaned husk (after a restart) can NEVER squat a stable name — a re-spawn always gets a new
  *  name, so `agent_name_taken` is impossible by construction (the distiller's fix; see
@@ -768,8 +782,9 @@ export class DocAgentService {
    *
    * Before staging it formats the `docs/`-prefixed in-scope files (abs paths) with the server's
    * pinned prettier so the PR passes CI's `prettier --check .` gate — docs-site/** is
-   * Astro/Starlight-governed and must NEVER be passed to root prettier. Prettier is best-effort: a
-   * failure warns loudly and the PR still opens (no worse than today's unformatted baseline).
+   * Astro/Starlight-governed and must NEVER be passed to root prettier. Prettier is fail-closed: a
+   * failure throws {@link PrettierFormatError}, which finalize catches to abort the run (no
+   * commit/push/PR) and record an `error` outcome. A skipped doc update beats a red un-mergeable PR.
    */
   private async stageInScope(f: InFlight): Promise<string> {
     const inScope = IN_SCOPE_PATHS.filter((p) => this.fileExists(join(f.worktreePath, p)));
@@ -785,10 +800,9 @@ export class DocAgentService {
           files: absDocs,
         });
       } catch (err) {
-        console.warn(
-          `[doc-agent] prettier format failed for ${f.repoPath} — PR may fail the lint gate:`,
-          err,
-        );
+        // Fail-closed: never commit unformatted docs. Abort the run (finalize catches this,
+        // records an `error` outcome, and cleans up); a skipped doc update beats a red PR.
+        throw new PrettierFormatError(f.repoPath, absDocs, { cause: err });
       }
     }
     await this.git(f.worktreePath, ["add", "--", ...inScope]);
@@ -798,11 +812,26 @@ export class DocAgentService {
   private async finalize(f: InFlight, sentinel: string | null): Promise<void> {
     let url: string | null = null;
     let hadStagedChanges = false;
+    let prettierFailed = false;
     try {
       const forge = this.deps.resolveForge(f.repoPath);
       if (forge) {
-        const stagedOut = await this.stageInScope(f);
-        if (stagedOut.length > 0) {
+        let stagedOut: string;
+        try {
+          stagedOut = await this.stageInScope(f);
+        } catch (err) {
+          if (err instanceof PrettierFormatError) {
+            prettierFailed = true;
+            console.error(
+              `[doc-agent] aborting run — prettier failed for ${f.repoPath}; refusing to commit unformatted docs (fail-closed): ${err.files.join(", ")}`,
+              err.cause ?? err,
+            );
+            stagedOut = "";
+          } else {
+            throw err; // unexpected — keep existing propagate-to-tick() behaviour
+          }
+        }
+        if (!prettierFailed && stagedOut.length > 0) {
           hadStagedChanges = true;
           url =
             f.mode === "retarget"
@@ -827,8 +856,13 @@ export class DocAgentService {
       }
     }
     // Compute outcome from locals set above (after try/finally so cleanup always runs first).
-    const outcome: DocAgentOutcome =
-      url !== null ? "pr" : hadStagedChanges && !this.act ? "observe" : "nochange";
+    const outcome: DocAgentOutcome = prettierFailed
+      ? "error"
+      : url !== null
+        ? "pr"
+        : hadStagedChanges && !this.act
+          ? "observe"
+          : "nochange";
     // Record the run in the durable per-repo history (additive alongside the cost-ledger spawn row).
     const run: DocAgentRun = { at: this.now(), url, outcome };
     this.deps.store.recordDocAgentRun(f.repoPath, run);

--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -253,6 +253,16 @@ export interface DocAgentDeps extends MembraneSeams {
  * branches with no PR, working even when the herdr daemon also restarted (it parses `git worktree
  * list`).
  */
+function computeDocAgentOutcome(
+  result: { url: string | null; hadStagedChanges: boolean; prettierFailed: boolean },
+  act: boolean,
+): DocAgentOutcome {
+  if (result.prettierFailed) return "error";
+  if (result.url !== null) return "pr";
+  if (result.hadStagedChanges && !act) return "observe";
+  return "nochange";
+}
+
 export class DocAgentService {
   private inflight = new Map<string, InFlight>();
   private starting = new Set<string>();
@@ -809,36 +819,42 @@ export class DocAgentService {
     return (await this.git(f.worktreePath, ["diff", "--cached", "--name-only"])).trim();
   }
 
-  private async finalize(f: InFlight, sentinel: string | null): Promise<void> {
-    let url: string | null = null;
-    let hadStagedChanges = false;
-    let prettierFailed = false;
+  /** Stage the in-scope docs and publish them. Returns the run's url (null if nothing
+   *  published / observe phase), whether anything was staged, and whether prettier aborted
+   *  the run (fail-closed). A non-PrettierFormatError propagates (handled by tick()). */
+  private async stageAndPublish(
+    f: InFlight,
+    sentinel: string | null,
+  ): Promise<{ url: string | null; hadStagedChanges: boolean; prettierFailed: boolean }> {
+    const forge = this.deps.resolveForge(f.repoPath);
+    if (!forge) return { url: null, hadStagedChanges: false, prettierFailed: false };
+    let stagedOut: string;
     try {
-      const forge = this.deps.resolveForge(f.repoPath);
-      if (forge) {
-        let stagedOut: string;
-        try {
-          stagedOut = await this.stageInScope(f);
-        } catch (err) {
-          if (err instanceof PrettierFormatError) {
-            prettierFailed = true;
-            console.error(
-              `[doc-agent] aborting run — prettier failed for ${f.repoPath}; refusing to commit unformatted docs (fail-closed): ${err.files.join(", ")}`,
-              err.cause ?? err,
-            );
-            stagedOut = "";
-          } else {
-            throw err; // unexpected — keep existing propagate-to-tick() behaviour
-          }
-        }
-        if (!prettierFailed && stagedOut.length > 0) {
-          hadStagedChanges = true;
-          url =
-            f.mode === "retarget"
-              ? await this.publishRetarget(f, sentinel, forge, stagedOut)
-              : await this.publishStaged(f, sentinel, forge, stagedOut);
-        }
+      stagedOut = await this.stageInScope(f);
+    } catch (err) {
+      if (err instanceof PrettierFormatError) {
+        console.error(
+          `[doc-agent] aborting run — prettier failed for ${f.repoPath}; refusing to commit unformatted docs (fail-closed): ${err.files.join(", ")}`,
+          err.cause ?? err,
+        );
+        return { url: null, hadStagedChanges: false, prettierFailed: true };
       }
+      throw err; // unexpected — keep existing propagate-to-tick() behaviour
+    }
+    if (stagedOut.length === 0)
+      return { url: null, hadStagedChanges: false, prettierFailed: false };
+    const url =
+      f.mode === "retarget"
+        ? await this.publishRetarget(f, sentinel, forge, stagedOut)
+        : await this.publishStaged(f, sentinel, forge, stagedOut);
+    return { url, hadStagedChanges: true, prettierFailed: false };
+  }
+
+  private async finalize(f: InFlight, sentinel: string | null): Promise<void> {
+    let result:
+      { url: string | null; hadStagedChanges: boolean; prettierFailed: boolean } | undefined;
+    try {
+      result = await this.stageAndPublish(f, sentinel);
     } finally {
       // Complete the durable cost row with real usage (best-effort) on EVERY finalize path (observe
       // and act) BEFORE the worktree is removed — mirrors herd-digest.ts / review.ts.
@@ -856,17 +872,13 @@ export class DocAgentService {
       }
     }
     // Compute outcome from locals set above (after try/finally so cleanup always runs first).
-    const outcome: DocAgentOutcome = prettierFailed
-      ? "error"
-      : url !== null
-        ? "pr"
-        : hadStagedChanges && !this.act
-          ? "observe"
-          : "nochange";
+    // result is always defined here — an error in stageAndPublish propagates out of finalize.
+    const r = result!;
+    const outcome: DocAgentOutcome = computeDocAgentOutcome(r, this.act);
     // Record the run in the durable per-repo history (additive alongside the cost-ledger spawn row).
-    const run: DocAgentRun = { at: this.now(), url, outcome };
+    const run: DocAgentRun = { at: this.now(), url: r.url, outcome };
     this.deps.store.recordDocAgentRun(f.repoPath, run);
-    this.deps.onChange?.({ repoPath: f.repoPath, url, outcome });
+    this.deps.onChange?.({ repoPath: f.repoPath, url: r.url, outcome });
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -497,7 +497,7 @@ export interface HerdDigest {
 
 // ── doc-agent run history ────────────────────────────────────────────────────
 /** Outcome of a completed doc-agent run, surfaced in the UI run history. */
-export type DocAgentOutcome = "pr" | "observe" | "nochange";
+export type DocAgentOutcome = "pr" | "observe" | "nochange" | "error";
 
 /** One completed doc-agent run, stored newest-first in the KV under
  *  `docagent:runs:<repoPath>` (capped at 10). */

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -3,6 +3,7 @@ import {
   DocAgentService,
   DOC_AGENT_LABEL,
   SERVER_INSTALL_ROOT,
+  PrettierFormatError,
   isDocRelevantMerge,
   type DocAgentFinalize,
   type DocAgentDeps,
@@ -1077,18 +1078,41 @@ test("prettier regression: docs-site paths are never passed to prettier", async 
   }
 });
 
-test("prettier failure path: throwing prettier stub still results in commit + push + PR (best-effort)", async () => {
+test("PrettierFormatError: is exported, carries repoPath + files, name is set correctly", () => {
+  const cause = new Error("binary not found");
+  const err = new PrettierFormatError("/repo", ["/wt/docs/a.md"], { cause });
+  expect(err).toBeInstanceOf(PrettierFormatError);
+  expect(err.name).toBe("PrettierFormatError");
+  expect(err.repoPath).toBe("/repo");
+  expect(err.files).toEqual(["/wt/docs/a.md"]);
+  expect(err.cause).toBe(cause);
+  expect(err.message).toContain("/repo");
+  expect(err.message).toContain("/wt/docs/a.md");
+});
+
+test("prettier failure path: throwing prettier ABORTS the run (no commit/push/PR), records error outcome, cleans up (fail-closed)", async () => {
   const h = mkHarness({ act: true, prettierThrows: true });
   await h.svc.consider("/repo");
   await h.svc.tick();
 
-  // prettier threw, but the act path is best-effort — commit/push/openPr must still fire
-  expect(h.gitCalls.some((c) => c.args[0] === "commit" && c.args.includes("--no-verify"))).toBe(
-    true,
-  );
-  expect(h.gitCalls.some((c) => c.args[0] === "push")).toBe(true);
-  expect(h.openPrInputs).toHaveLength(1);
-  expect(h.finalizes).toEqual([{ repoPath: "/repo", url: "https://forge/pr/42", outcome: "pr" }]);
+  // fail-closed: no commit, no push, no PR
+  expect(h.gitCalls.some((c) => c.args[0] === "commit")).toBe(false);
+  expect(h.gitCalls.some((c) => c.args[0] === "push")).toBe(false);
+  expect(h.openPrInputs).toHaveLength(0);
+
+  // error outcome recorded and fired through onChange
+  expect(h.finalizes).toHaveLength(1);
+  expect(h.finalizes[0]).toEqual({ repoPath: "/repo", url: null, outcome: "error" });
+
+  // recorded in store
+  const runs = h.kv.get("docagent:runs:/repo");
+  expect(runs).toBeDefined();
+  const parsed = JSON.parse(runs!) as { outcome: string; url: string | null }[];
+  expect(parsed[0]!.outcome).toBe("error");
+  expect(parsed[0]!.url).toBeNull();
+
+  // cleanup still ran: worktree removed
+  expect(h.removedWorktrees).toHaveLength(1);
 });
 
 // ── outcome tracking (issue #906) ────────────────────────────────────────────

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -82,6 +82,8 @@ interface Harness {
   startArgs: { name: string; cwd: string; argv: string[] }[];
   /** Captured editPr calls (prNumber + patch). */
   editPrCalls: { prNumber: number; title?: string; body?: string }[];
+  /** terminalIds passed to herdr.stop (mirrors removedWorktrees pattern). */
+  stoppedTerminals: string[];
   __merge: number;
 }
 
@@ -245,6 +247,7 @@ function mkHarness(opts?: {
   const completedRows: CompletedRow[] = [];
   const deletedRemote: string[] = [];
   const editPrCalls: { prNumber: number; title?: string; body?: string }[] = [];
+  const stoppedTerminals: string[] = [];
   const store = {
     getSetting: (key: string) => kv.get(key) ?? null,
     setSetting: (key: string, value: string) => {
@@ -390,7 +393,9 @@ function mkHarness(opts?: {
       startArgs.push({ name, cwd, argv: wrapped ?? [] });
       return { terminalId: "term-" + starts.length } as any;
     },
-    stop: () => {},
+    stop: (terminalId: string) => {
+      stoppedTerminals.push(terminalId);
+    },
     list: () =>
       o.herdrAgents.map(
         (a) =>
@@ -492,6 +497,7 @@ function mkHarness(opts?: {
     markers,
     startArgs,
     editPrCalls,
+    stoppedTerminals,
     mergeCalls: 0,
     get __merge() {
       return mergeCalls;
@@ -1111,8 +1117,9 @@ test("prettier failure path: throwing prettier ABORTS the run (no commit/push/PR
   expect(parsed[0]!.outcome).toBe("error");
   expect(parsed[0]!.url).toBeNull();
 
-  // cleanup still ran: worktree removed
+  // cleanup still ran: worktree removed AND herdr.stop called
   expect(h.removedWorktrees).toHaveLength(1);
+  expect(h.stoppedTerminals).toHaveLength(1);
 });
 
 // ── outcome tracking (issue #906) ────────────────────────────────────────────

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2190,5 +2190,7 @@
   "feat_owed_badge_title": "Zähler-Badge der Owed-Linse",
   "feat_owed_badge_body": "Die OWED-Herd-Linse zeigt jetzt ein Zähler-Badge, wenn gemergte PRs noch offene manuelle Post-Merge-Schritte haben — so verdient die Linse deine Aufmerksamkeit nur, wenn es etwas zu tun gibt, statt bei 0 oder 5 offenen Schritten gleich auszusehen.",
   "github_lens_paused": "Pausiert",
-  "github_lens_graphql_backoff": "GraphQL-Polling pausiert, während ein Rate-Limit-Backoff abklingt — PR-, Issue- und Backlog-Updates laufen in ~{time} weiter."
+  "github_lens_graphql_backoff": "GraphQL-Polling pausiert, während ein Rate-Limit-Backoff abklingt — PR-, Issue- und Backlog-Updates laufen in ~{time} weiter.",
+  "docagent_status_error": "Formatierung fehlgeschlagen",
+  "docagent_toast_error": "{repo}: Doku-Update abgebrochen — Prettier konnte die Doku nicht formatieren"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2190,5 +2190,7 @@
   "feat_owed_badge_title": "Owed lens count badge",
   "feat_owed_badge_body": "The OWED Herd lens now shows a count badge when merged PRs still owe post-merge manual steps — so the lens earns your attention only when there's something to do, instead of looking identical whether 0 or 5 steps are outstanding.",
   "github_lens_paused": "Paused",
-  "github_lens_graphql_backoff": "GraphQL polling is paused while a rate-limit backoff clears — PR, issue and backlog updates resume in ~{time}."
+  "github_lens_graphql_backoff": "GraphQL polling is paused while a rate-limit backoff clears — PR, issue and backlog updates resume in ~{time}.",
+  "docagent_status_error": "format failed",
+  "docagent_toast_error": "{repo}: doc update aborted — prettier couldn't format the docs"
 }

--- a/ui/src/lib/components/backlog-view/DocAgentControl.browser.test.ts
+++ b/ui/src/lib/components/backlog-view/DocAgentControl.browser.test.ts
@@ -103,6 +103,14 @@ describe("DocAgentControl", () => {
     expect(badgeBtn()!.textContent?.trim()).toBe(m.docagent_status_nochange());
   });
 
+  it("badge shows 'format failed' label and error class for an error outcome run", async () => {
+    const runs: DocAgentRun[] = [{ at: Date.now() - 60000, url: null, outcome: "error" }];
+    render(DocAgentControl, { ...defaultProps, runs });
+    await expect.poll(() => badgeBtn()).toBeTruthy();
+    expect(badgeBtn()!.textContent?.trim()).toBe(m.docagent_status_error());
+    expect(badgeBtn()!.classList.contains("error")).toBe(true);
+  });
+
   it("clicking badge opens history popover", async () => {
     const runs: DocAgentRun[] = [
       {

--- a/ui/src/lib/components/backlog-view/DocAgentControl.svelte
+++ b/ui/src/lib/components/backlog-view/DocAgentControl.svelte
@@ -40,10 +40,20 @@
         ? m.docagent_status_pr()
         : runs[0]?.outcome === "observe"
           ? m.docagent_status_observe()
-          : m.docagent_status_nochange(),
+          : runs[0]?.outcome === "error"
+            ? m.docagent_status_error()
+            : m.docagent_status_nochange(),
   );
 
-  const badgeVariant = $derived(running ? "running" : runs[0]?.outcome === "pr" ? "pr" : "muted");
+  const badgeVariant = $derived(
+    running
+      ? "running"
+      : runs[0]?.outcome === "pr"
+        ? "pr"
+        : runs[0]?.outcome === "error"
+          ? "error"
+          : "muted",
+  );
 
   // Position the popover below the badge whenever open + both elements exist.
   $effect(() => {
@@ -102,6 +112,7 @@
   function outcomeLabel(outcome: DocAgentRun["outcome"]): string {
     if (outcome === "pr") return m.docagent_status_pr();
     if (outcome === "observe") return m.docagent_status_observe();
+    if (outcome === "error") return m.docagent_status_error();
     return m.docagent_status_nochange();
   }
 </script>
@@ -270,6 +281,12 @@
   .status-badge.pr {
     color: var(--color-green);
     border-color: color-mix(in srgb, var(--color-green) 45%, transparent);
+  }
+
+  /* Error state — red (semantic danger token) */
+  .status-badge.error {
+    color: var(--color-red);
+    border-color: color-mix(in srgb, var(--color-red) 45%, transparent);
   }
 
   /* History popover surface — mirrors .filter-popover from IssueFilterPopover */

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -1087,6 +1087,22 @@ test("doc-agent:done outcome=nochange fires keyed toast", () => {
   expect(toasts.items.some((x) => x.key === "doc-agent-done:/repos/da-nochange")).toBe(true);
 });
 
+test("doc-agent:done outcome=error fires a persistent assertive toast keyed doc-agent-error:", () => {
+  toasts.items = [];
+  const s = new HerdStore();
+  s.docAgentEnabled = true;
+  s.apply({
+    event: "doc-agent:done",
+    data: { repoPath: "/repos/da-error", url: null, outcome: "error" },
+  });
+  const t = toasts.items.find((x) => x.key === "doc-agent-error:/repos/da-error");
+  expect(t).toBeDefined();
+  expect(t?.alert).toBe(true);
+  // persistent: no durationMs set (duration: null → undefined in the store)
+  expect(t?.durationMs).toBeUndefined();
+  expect(t?.text).toContain("da-error");
+});
+
 test("doc-agent:done dedupes repeated events for the same repo (same key)", () => {
   toasts.items = [];
   const s = new HerdStore();

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -555,6 +555,12 @@ export class HerdStore {
       });
     } else if (ev.data.outcome === "observe") {
       toasts.info(m.docagent_toast_observe({ repo }), { key });
+    } else if (ev.data.outcome === "error") {
+      toasts.info(m.docagent_toast_error({ repo }), {
+        key: `doc-agent-error:${ev.data.repoPath}`,
+        duration: null,
+        alert: true,
+      });
     } else {
       toasts.info(m.docagent_toast_no_changes({ repo }), { key });
     }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1197,7 +1197,7 @@ export interface DiagnosticsSnapshot {
   overall: DiagnosticState;
 }
 
-export type DocAgentOutcome = "pr" | "observe" | "nochange";
+export type DocAgentOutcome = "pr" | "observe" | "nochange" | "error";
 export interface DocAgentRun {
   at: number;
   url: string | null;


### PR DESCRIPTION
## What

Makes the PR-gated **doc-agent fail-closed** on a prettier failure. Previously, if
`prettier --write` threw during `stageInScope`, the error was **swallowed** and the
unformatted docs were committed / pushed / opened as a `shepherd/docs-update-*` PR anyway —
a red, un-mergeable PR (e.g. [run 28413195069](https://github.com/erwins-enkel/shepherd/actions/runs/28413195069), PR #1245).

Now a prettier failure **aborts the run** (no commit, no push, no PR) and is made
**visible**: a new `DocAgentOutcome` value `"error"` is recorded via `recordDocAgentRun`
and fired through `onChange` / the `doc-agent:done` WS event. The UI renders it — a
persistent, assertive (`alert`) toast plus a tone-distinct status label and error badge in
`DocAgentControl`. Cleanup (cost row, `herdr.stop`, `worktree.remove`, branch `-D`) still
runs on the abort path.

## Honest framing (please read)

This is a **forward-looking guarantee, not a fix for run 28413195069**. Investigation
**refuted** the "stale build" theory (the deployed SHA when PR #1245 was created already
contained #930 with the file in scope) and **could not reproduce** the failure (the exact
production invocation formats the file correctly; server-style and CI-style prettier output
are byte-identical; all three prettier installs are 3.8.5). So PR #1245's failure was
transient/unexplained, and **this change is a no-op relative to that specific run**. Its
value is structural: a prettier *throw* can never again ship an unformatted PR. The live
symptom (PR #1245 itself) is an operator action — not touched here.

## Deliberate decisions (carried, not oversights)

- **Check-divergence is residual risk, not guarded.** If prettier *succeeds* server-side
  but its output still fails CI's `prettier --check .` (config/ignore/version divergence),
  this change does nothing — a CI-faithful verify is unrunnable from a node_modules-less
  worktree and a same-config check is tautological. CI's `prettier --check .` remains the
  backstop. Empirically unobserved (versions aligned, in-scope docs not ignored).
- **Retarget mode does not release `prSyncedKey` on abort.** Docs for that code PR defer to
  the post-merge nightly standalone-PR path (the pre-#956 baseline — gated on `lastSha`, not
  `prSyncedKey`); no permanent loss. Operator action is optional, only to co-locate docs on
  that PR before merge.

## Changes

- `src/doc-agent.ts`: `PrettierFormatError`; `stageInScope` rethrows instead of swallowing;
  `stageAndPublish` helper + `computeDocAgentOutcome` keep `finalize` thin; the abort path
  records the `error` outcome + fires `onChange`; non-`PrettierFormatError` still propagates
  to `tick()`; cleanup always runs.
- `src/types.ts` + `ui/src/lib/types.ts`: `DocAgentOutcome += "error"`.
- `ui/src/lib/store.svelte.ts`: explicit `error` branch → persistent `alert` toast, dedupe
  key `doc-agent-error:<repo>` (distinct from the transient `doc-agent-done:` key).
- `ui/src/lib/components/backlog-view/DocAgentControl.svelte`: `error` status / label /
  badge variant + `.status-badge.error` using the semantic `--color-red` token.
- `ui/messages/{en,de}.json`: `docagent_status_error`, `docagent_toast_error` (EN↔DE parity).

## Validation

- Root: `lint` ✓, `typecheck` ✓, `prettier --check .` ✓, `bun test ./test` — **5483 pass / 0 fail**.
- UI: `check` ✓, `check:i18n` ✓ (2170 keys parity), node + browser tests pass.
- `fallow audit --base origin/main`: ✓ no issues in changed files. Pre-push gate set ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
