### PR TITLE
feat: upload arbitrary binary files to a session's scratchpad via the Files tab (#1258)

### DIFF
--- a/docs/external-task-api.md
+++ b/docs/external-task-api.md
@@ -124,10 +124,19 @@ Once a task exists, an external agent can also drive it:
 - `DELETE /api/sessions/:id` — archive (end) the session.
 - `GET /api/sessions` — list active sessions; `GET /api/sessions/:id/diff`,
   `/activity`, `/usage` for inspection.
-- `GET /api/sessions/:id/scratchpad[?path=]` — read-only browse of a live
-  session's own scratchpad subtree; `GET /api/sessions/:id/scratchpad/download?path=`
+- `GET /api/sessions/:id/scratchpad[?path=]` — browse a live session's own
+  scratchpad subtree; `GET /api/sessions/:id/scratchpad/download?path=`
   streams a single file. Paths are relative to the scratchpad root and
   realpath-contained to it (`..`, absolute, and symlink escapes are rejected);
   both `404` on a missing/archived session.
+- `POST /api/sessions/:id/scratchpad/upload[?path=<relDir>]` — upload an
+  arbitrary binary file (multipart `file` field, no MIME restriction) into the
+  session's scratchpad. `?path` selects a relative subdirectory within the
+  scratchpad root (default: the root); the root is created on demand but the
+  subdir must already exist. The same realpath-containment rules apply. Returns
+  `{ "path": "<relpath>" }` (a colliding name is given a numeric suffix rather
+  than overwriting). `400` on a missing `file` field, `413` when the file
+  exceeds the upload size limit (10 MiB), and `404` on a missing/archived
+  session or an out-of-root `path`.
 
 All of these honor the same auth/origin rules as task creation.

--- a/src/scratchpad.ts
+++ b/src/scratchpad.ts
@@ -1,5 +1,5 @@
 import { promises as fsp } from "node:fs";
-import { join, relative, dirname, sep, normalize, isAbsolute } from "node:path";
+import { join, relative, dirname, basename, extname, sep, normalize, isAbsolute } from "node:path";
 import { sessionScratchpadDir } from "./tmp-sweep";
 
 /**
@@ -162,4 +162,125 @@ export function attachmentDisposition(name: string): string {
     (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
   );
   return `attachment; filename="${ascii}"; filename*=UTF-8''${encoded}`;
+}
+
+/**
+ * Resolve the target upload directory for a session scratchpad upload. Creates the scratchpad
+ * root on demand (start-of-session uploads before the agent has written anything). Returns
+ * `{ rootReal, dirReal }` or `null` when: `claudeSessionId` is blank, `relDir` escapes the
+ * root (`..", absolute paths, symlinks pointing outside), the subdirectory doesn't exist, or
+ * the path resolves to a file rather than a directory.
+ *
+ * IMPORTANT: only the scratchpad root is ever created — never the requested subdir — to avoid
+ * silently creating unexpected paths.
+ */
+export async function resolveScratchpadUploadDir(
+  worktreePath: string,
+  claudeSessionId: string,
+  relDir: string,
+): Promise<{ rootReal: string; dirReal: string } | null> {
+  if (!claudeSessionId) return null;
+
+  // Ensure the root exists — async mkdir so the event loop isn't blocked.
+  const root = sessionScratchpadDir(worktreePath, claudeSessionId);
+  await fsp.mkdir(root, { recursive: true });
+
+  let rootReal: string;
+  try {
+    rootReal = await fsp.realpath(root);
+  } catch {
+    return null;
+  }
+
+  // Reject any normalized path that climbs above the root or is absolute.
+  const norm = normalize(relDir || "");
+  if (norm === ".." || norm.startsWith(".." + sep) || isAbsolute(norm)) return null;
+
+  // Resolve target dir: root itself when empty/dot, else realpath of the join.
+  let dirReal: string;
+  if (norm === "" || norm === ".") {
+    dirReal = rootReal;
+  } else {
+    try {
+      dirReal = await fsp.realpath(join(rootReal, norm));
+    } catch {
+      return null; // subdir doesn't exist
+    }
+  }
+
+  // Containment check via realpath.
+  if (!within(dirReal, rootReal)) return null;
+
+  // Must be a directory: prevents a ?path pointing at a file from reaching Bun.write and
+  // throwing ENOTDIR as an uncaught 500.
+  try {
+    if (!(await fsp.stat(dirReal)).isDirectory()) return null;
+  } catch {
+    return null;
+  }
+
+  return { rootReal, dirReal };
+}
+
+/**
+ * Sanitize a raw upload filename to a single safe path segment. Takes the basename, strips path
+ * separators and control characters, and maps blank/dot/dotdot/all-dot names to "upload".
+ * Must run BEFORE any join — `basename("..") === ".."` would otherwise escape the root.
+ */
+function sanitizeUploadName(rawName: string): string {
+  // Take basename first to eliminate any directory components.
+  let name = basename(rawName);
+  // Strip path separators (/ and \) and control characters (U+0000–U+001F, U+007F).
+  // eslint-disable-next-line no-control-regex
+  name = name.replace(/[/\\]/g, "").replace(/[\x00-\x1f\x7f]/g, "");
+  // Map blank, ".", "..", and all-dot names to a generated fallback.
+  if (!name || /^\.+$/.test(name)) return "upload";
+  return name;
+}
+
+/**
+ * Choose a non-colliding path for an uploaded file within `dirReal`.
+ *
+ * Collision detection uses `lstat` (not `stat`/`existsSync`) so that symlinks at the target
+ * name are treated as collisions and skipped — this prevents a planted/dangling symlink from
+ * being followed out of the root by `Bun.write`. The candidate is the first lstat-ENOENT name.
+ *
+ * NOTE: the lstat→Bun.write window is not atomic; two concurrent same-name uploads could pick
+ * the same suffix. Acceptable for a single-operator tool — no lock needed.
+ *
+ * Returns `{ abs, rel }` or `null` if the final abs path fails the backstop containment check.
+ */
+export async function placeScratchpadUpload(
+  rootReal: string,
+  dirReal: string,
+  rawName: string,
+): Promise<{ abs: string; rel: string } | null> {
+  const name = sanitizeUploadName(rawName);
+
+  // Split into stem and extension for collision suffixing.
+  const ext = extname(name); // e.g. ".pdf" or "" for extensionless
+  const stem = ext ? name.slice(0, -ext.length) : name;
+
+  let candidate = name;
+  let n = 1;
+  for (;;) {
+    const target = join(dirReal, candidate);
+    try {
+      await fsp.lstat(target); // throws ENOENT when absent
+      // Entry exists (any type, incl. symlinks) — try next suffix.
+      n++;
+      candidate = ext ? `${stem} (${n})${ext}` : `${stem} (${n})`;
+    } catch {
+      // ENOENT — this candidate is free.
+      break;
+    }
+  }
+
+  const abs = join(dirReal, candidate);
+
+  // Backstop containment re-validation.
+  if (!within(abs, rootReal)) return null;
+
+  const rel = relFromRoot(rootReal, abs);
+  return { abs, rel };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -71,7 +71,13 @@ import { analyzeReadiness } from "./readiness";
 import { listCommands } from "./commands";
 import { listDirs, validateRoot, collapseHome } from "./dirs";
 import { scratchpadHasFiles } from "./tmp-sweep";
-import { listScratchpad, resolveScratchpadFile, attachmentDisposition } from "./scratchpad";
+import {
+  listScratchpad,
+  resolveScratchpadFile,
+  attachmentDisposition,
+  resolveScratchpadUploadDir,
+  placeScratchpadUpload,
+} from "./scratchpad";
 import { loadSteers, saveSteers } from "./steers";
 import { loadIcons, setIcon } from "./project-icons";
 import { listBranches } from "./branches";
@@ -82,7 +88,7 @@ import { buildUsageBreakdown } from "./usage-breakdown";
 import { isApiKeyMode } from "./spawn-auth";
 import { detectDevCommand } from "./preview";
 import { sessionActivity } from "./activity";
-import { handleUpload } from "./uploads";
+import { handleUpload, parseUploadFile, MAX_UPLOAD_BYTES } from "./uploads";
 import type { UsageLimits, UsageLimitsService } from "./usage-limits";
 import type { UpdateService } from "./update";
 import type { HerdrUpdateService } from "./herdr-update";
@@ -1825,28 +1831,67 @@ async function handleSessionReads({ req, parts, deps }: Ctx): Promise<Response |
 // Read-only browse + single-file download, rooted at and realpath-contained to the session's
 // OWN scratchpad dir (#1164). Live sessions only: 404 on a missing/archived session. `path` is
 // relative to the scratchpad root; containment is enforced in src/scratchpad.ts.
+// Stream one contained scratchpad file as an attachment download.
+async function scratchpadDownload(s: Session, rel: string): Promise<Response> {
+  const file = await resolveScratchpadFile(s.worktreePath, s.claudeSessionId, rel);
+  if (!file) return json({ error: "not found" }, 404);
+  const f = Bun.file(file);
+  return new Response(f, {
+    headers: {
+      "content-type": f.type || "application/octet-stream",
+      "content-disposition": attachmentDisposition(basename(file)),
+    },
+  });
+}
+
+// List one scratchpad directory. A missing ROOT for a started session (agent hasn't written
+// yet) returns a synthetic empty listing so the Files tab doesn't error before the first
+// upload/write; a missing non-root path still 404s.
+async function scratchpadList(s: Session, rel: string): Promise<Response> {
+  const listing = await listScratchpad(s.worktreePath, s.claudeSessionId, rel);
+  if (listing) return json(listing);
+  if (rel === "" && s.claudeSessionId) return json({ path: "", parent: null, entries: [] });
+  return json({ error: "not found" }, 404);
+}
+
 async function handleSessionScratchpad({ req, parts, url, deps }: Ctx): Promise<Response | null> {
   if (req.method !== "GET" || parts[3] !== "scratchpad") return null;
   const s = deps.store.get(parts[2] ?? "");
   if (!s || s.status === "archived") return json({ error: "not found" }, 404);
   const rel = url.searchParams.get("path") ?? "";
-
-  if (parts[4] === "download") {
-    const file = await resolveScratchpadFile(s.worktreePath, s.claudeSessionId, rel);
-    if (!file) return json({ error: "not found" }, 404);
-    const f = Bun.file(file);
-    return new Response(f, {
-      headers: {
-        "content-type": f.type || "application/octet-stream",
-        "content-disposition": attachmentDisposition(basename(file)),
-      },
-    });
-  }
-  if (!parts[4]) {
-    const listing = await listScratchpad(s.worktreePath, s.claudeSessionId, rel);
-    return listing ? json(listing) : json({ error: "not found" }, 404);
-  }
+  if (parts[4] === "download") return scratchpadDownload(s, rel);
+  if (!parts[4]) return scratchpadList(s, rel);
   return null;
+}
+
+// ── scratchpad upload: POST /api/sessions/:id/scratchpad/upload[?path=] ──
+// Accepts any binary file (no MIME restriction) up to MAX_UPLOAD_BYTES. The `?path` param
+// is a relative subdir within the scratchpad root (default: root). The scratchpad root is
+// created on demand (start-of-session path). Live sessions only; 404 on archived/unknown.
+async function handleSessionScratchpadUpload({
+  req,
+  parts,
+  url,
+  deps,
+}: Ctx): Promise<Response | null> {
+  if (!(req.method === "POST" && parts[3] === "scratchpad" && parts[4] === "upload")) return null;
+  const s = deps.store.get(parts[2] ?? "");
+  if (!s || s.status === "archived") return json({ error: "not found" }, 404);
+
+  const file = await parseUploadFile(req);
+  if (file instanceof Response) return file;
+
+  if (file.size > MAX_UPLOAD_BYTES) return json({ error: "file too large" }, 413);
+
+  const rel = url.searchParams.get("path") ?? "";
+  const dir = await resolveScratchpadUploadDir(s.worktreePath, s.claudeSessionId, rel);
+  if (!dir) return json({ error: "not found" }, 404);
+
+  const placed = await placeScratchpadUpload(dir.rootReal, dir.dirReal, file.name);
+  if (!placed) return json({ error: "not found" }, 404);
+
+  await Bun.write(placed.abs, file);
+  return json({ path: placed.rel });
 }
 
 // Active sessions whose cached PR state is "merged" — the set "clear all merged"
@@ -2747,6 +2792,7 @@ async function handleSessions(ctx: Ctx): Promise<Response | null> {
     handleSessionCreate,
     handleSessionReads,
     handleSessionScratchpad,
+    handleSessionScratchpadUpload,
     handleSessionDelete,
     handleSessionReply,
     handleSessionRecommend,

--- a/src/uploads.ts
+++ b/src/uploads.ts
@@ -80,11 +80,22 @@ export interface UploadDeps {
   repoRoot: string;
 }
 
-/** POST /api/uploads — multipart `file`; optional `?session=<id>`. Returns { path }. */
-export async function handleUpload(req: Request, deps: UploadDeps): Promise<Response> {
+/**
+ * Parse the multipart `file` field from a request. Returns the `File` on success, or a
+ * 400 `Response` when the field is absent / the body can't be parsed. Does NOT perform size
+ * or MIME checks — those are caller responsibilities.
+ */
+export async function parseUploadFile(req: Request): Promise<File | Response> {
   const form = await req.formData().catch(() => null);
   const file = form?.get("file");
   if (!(file instanceof File)) return j({ error: "missing file field" }, 400);
+  return file;
+}
+
+/** POST /api/uploads — multipart `file`; optional `?session=<id>`. Returns { path }. */
+export async function handleUpload(req: Request, deps: UploadDeps): Promise<Response> {
+  const file = await parseUploadFile(req);
+  if (file instanceof Response) return file;
 
   const ext = extForMime(file.type);
   if (!ext) return j({ error: "unsupported image type" }, 415);

--- a/test/scratchpad-upload.test.ts
+++ b/test/scratchpad-upload.test.ts
@@ -1,0 +1,339 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+import { makeApp, type AppDeps } from "../src/server";
+import { SessionStore } from "../src/store";
+import { EventHub } from "../src/events";
+import { config } from "../src/config";
+import { sessionScratchpadDir } from "../src/tmp-sweep";
+import { MAX_UPLOAD_BYTES } from "../src/uploads";
+
+let tmpRoot: string;
+let repoDir: string;
+let scratchRoot: string;
+const prevEnv = process.env.SHEPHERD_TMP_SWEEP_DIR;
+const SID = "claude-sess-upload-1";
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(config.repoRoot, "shepherd-scratch-up-"));
+  repoDir = join(tmpRoot, "repo");
+  mkdirSync(repoDir);
+  scratchRoot = mkdtempSync(join(config.repoRoot, "shepherd-scratch-tmp-up-"));
+  process.env.SHEPHERD_TMP_SWEEP_DIR = scratchRoot;
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  rmSync(scratchRoot, { recursive: true, force: true });
+  if (prevEnv === undefined) delete process.env.SHEPHERD_TMP_SWEEP_DIR;
+  else process.env.SHEPHERD_TMP_SWEEP_DIR = prevEnv;
+});
+
+function harness() {
+  const store = new SessionStore(":memory:");
+  const hub = new EventHub();
+  const deps: AppDeps = {
+    store,
+    service: {} as any,
+    events: hub,
+    usageLimits: { limits: () => ({}) } as any,
+  };
+  return { app: makeApp(deps), store };
+}
+
+function makeSession(store: SessionStore) {
+  return store.create({
+    name: "upload-session",
+    prompt: "p",
+    repoPath: repoDir,
+    baseBranch: "main",
+    branch: "shepherd/upload",
+    worktreePath: repoDir,
+    isolated: false,
+    herdrSession: "sess-x",
+    herdrAgentId: "agent-x",
+    claudeSessionId: SID,
+    model: null,
+  });
+}
+
+function makeUploadRequest(sessionId: string, file: File, path = ""): Request {
+  const form = new FormData();
+  form.append("file", file);
+  const url = `http://x/api/sessions/${sessionId}/scratchpad/upload${path ? `?path=${encodeURIComponent(path)}` : ""}`;
+  return new Request(url, { method: "POST", body: form });
+}
+
+// ── Root absent → upload creates it and the file lands ──────────────────────
+
+test("POST upload: root absent → creates it, file lands at root, returns { path }", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  // Do NOT pre-create scratchpad root — this is the start-of-session path
+
+  const content = new Uint8Array([1, 2, 3, 4]);
+  const file = new File([content], "hello.bin", { type: "application/octet-stream" });
+  const res = await app.fetch(makeUploadRequest(s.id, file));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.path).toBe("hello.bin");
+
+  const root = sessionScratchpadDir(repoDir, SID);
+  const abs = join(root, "hello.bin");
+  const written = await Bun.file(abs).bytes();
+  expect(written).toEqual(content);
+});
+
+// ── Upload into an existing subdir ──────────────────────────────────────────
+
+test("POST upload: existing subdir → file lands there, path is sub/<name>", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+
+  const root = sessionScratchpadDir(repoDir, SID);
+  mkdirSync(join(root, "sub"), { recursive: true });
+
+  const file = new File(["subdata"], "note.txt", { type: "text/plain" });
+  const res = await app.fetch(makeUploadRequest(s.id, file, "sub"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.path).toBe("sub/note.txt");
+
+  const abs = join(root, "sub", "note.txt");
+  expect(await Bun.file(abs).text()).toBe("subdata");
+});
+
+// ── Path-escape destinations → 404 ──────────────────────────────────────────
+
+test("POST upload: ?path=.. → 404", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  const root = sessionScratchpadDir(repoDir, SID);
+  mkdirSync(root, { recursive: true });
+
+  const file = new File(["x"], "f.txt", { type: "text/plain" });
+  const res = await app.fetch(makeUploadRequest(s.id, file, ".."));
+  expect(res.status).toBe(404);
+});
+
+test("POST upload: ?path=/etc → 404", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  const root = sessionScratchpadDir(repoDir, SID);
+  mkdirSync(root, { recursive: true });
+
+  const file = new File(["x"], "f.txt", { type: "text/plain" });
+  const res = await app.fetch(makeUploadRequest(s.id, file, "/etc"));
+  expect(res.status).toBe(404);
+});
+
+test("POST upload: symlink dir pointing outside → 404", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  const root = sessionScratchpadDir(repoDir, SID);
+  mkdirSync(root, { recursive: true });
+
+  // Create a dir outside the root and symlink it in
+  const outside = mkdtempSync(join(tmpRoot, "outside-"));
+  mkdirSync(outside, { recursive: true });
+  symlinkSync(outside, join(root, "escape-link"));
+
+  const file = new File(["x"], "f.txt", { type: "text/plain" });
+  const res = await app.fetch(makeUploadRequest(s.id, file, "escape-link"));
+  expect(res.status).toBe(404);
+});
+
+// ── ?path pointing at a file → 404 (not 500) ────────────────────────────────
+
+test("POST upload: ?path pointing at existing file → 404", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  const root = sessionScratchpadDir(repoDir, SID);
+  mkdirSync(root, { recursive: true });
+  writeFileSync(join(root, "existing.txt"), "content");
+
+  const file = new File(["y"], "new.txt", { type: "text/plain" });
+  const res = await app.fetch(makeUploadRequest(s.id, file, "existing.txt"));
+  expect(res.status).toBe(404);
+});
+
+// ── Oversize → 413 ──────────────────────────────────────────────────────────
+
+test("POST upload: oversize file → 413", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  const root = sessionScratchpadDir(repoDir, SID);
+  mkdirSync(root, { recursive: true });
+
+  const bigData = new Uint8Array(MAX_UPLOAD_BYTES + 1);
+  const file = new File([bigData], "big.bin", { type: "application/octet-stream" });
+  const res = await app.fetch(makeUploadRequest(s.id, file));
+  expect(res.status).toBe(413);
+});
+
+// ── Missing file field → 400 ────────────────────────────────────────────────
+
+test("POST upload: missing file field → 400", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  const root = sessionScratchpadDir(repoDir, SID);
+  mkdirSync(root, { recursive: true });
+
+  const form = new FormData();
+  form.append("not-file", "value");
+  const req = new Request(`http://x/api/sessions/${s.id}/scratchpad/upload`, {
+    method: "POST",
+    body: form,
+  });
+  const res = await app.fetch(req);
+  expect(res.status).toBe(400);
+});
+
+// ── Filename sanitization ────────────────────────────────────────────────────
+
+test("POST upload: filename with path separators sanitized to single segment", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  const root = sessionScratchpadDir(repoDir, SID);
+  mkdirSync(root, { recursive: true });
+
+  // A filename with path traversal attempts
+  const file = new File(["data"], "../evil/../../etc/passwd", { type: "text/plain" });
+  const res = await app.fetch(makeUploadRequest(s.id, file));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  // Path must be a single segment (no slashes, no dots-only)
+  expect(body.path).not.toContain("/");
+  expect(body.path).not.toContain("\\");
+  expect(body.path).not.toBe("..");
+  expect(body.path).not.toBe(".");
+  // File must be inside the root
+  const abs = join(realpathSync(root), body.path);
+  expect(abs.startsWith(realpathSync(root))).toBe(true);
+});
+
+test("POST upload: filename '.' → sanitized to fallback", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  const root = sessionScratchpadDir(repoDir, SID);
+  mkdirSync(root, { recursive: true });
+
+  const file = new File(["data"], ".", { type: "text/plain" });
+  const res = await app.fetch(makeUploadRequest(s.id, file));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.path).not.toBe(".");
+  expect(body.path.length).toBeGreaterThan(0);
+});
+
+// ── Collision → numeric suffix ───────────────────────────────────────────────
+
+test("POST upload: collision → second file gets numeric suffix (e.g. report (2).pdf)", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  const root = sessionScratchpadDir(repoDir, SID);
+  mkdirSync(root, { recursive: true });
+
+  const file1 = new File(["first"], "report.pdf", { type: "application/pdf" });
+  const res1 = await app.fetch(makeUploadRequest(s.id, file1));
+  expect(res1.status).toBe(200);
+  expect((await res1.json()).path).toBe("report.pdf");
+
+  const file2 = new File(["second"], "report.pdf", { type: "application/pdf" });
+  const res2 = await app.fetch(makeUploadRequest(s.id, file2));
+  expect(res2.status).toBe(200);
+  expect((await res2.json()).path).toBe("report (2).pdf");
+
+  // Original untouched
+  expect(await Bun.file(join(root, "report.pdf")).text()).toBe("first");
+  expect(await Bun.file(join(root, "report (2).pdf")).text()).toBe("second");
+});
+
+test("POST upload: collision on extensionless name → suffix without extension", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  const root = sessionScratchpadDir(repoDir, SID);
+  mkdirSync(root, { recursive: true });
+
+  const file1 = new File(["a"], "report", { type: "application/octet-stream" });
+  const res1 = await app.fetch(makeUploadRequest(s.id, file1));
+  expect(res1.status).toBe(200);
+  expect((await res1.json()).path).toBe("report");
+
+  const file2 = new File(["b"], "report", { type: "application/octet-stream" });
+  const res2 = await app.fetch(makeUploadRequest(s.id, file2));
+  expect(res2.status).toBe(200);
+  expect((await res2.json()).path).toBe("report (2)");
+});
+
+// ── lstat symlink-escape on the leaf name ────────────────────────────────────
+
+test("POST upload: symlink at target name pointing outside → treated as collision, suffix used", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  const root = sessionScratchpadDir(repoDir, SID);
+  mkdirSync(root, { recursive: true });
+
+  // Plant a symlink at "target.txt" pointing outside the root
+  const outside = mkdtempSync(join(tmpRoot, "outside2-"));
+  const outsideFile = join(outside, "victim.txt");
+  writeFileSync(outsideFile, "original");
+  symlinkSync(outsideFile, join(root, "target.txt"));
+
+  const file = new File(["safe"], "target.txt", { type: "text/plain" });
+  const res = await app.fetch(makeUploadRequest(s.id, file));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  // Must not be the symlink name itself (collision detected via lstat)
+  expect(body.path).not.toBe("target.txt");
+  // The outside file must NOT be overwritten
+  expect(await Bun.file(outsideFile).text()).toBe("original");
+  // The actual written file must be inside the root
+  const writtenPath = join(realpathSync(root), body.path);
+  expect(writtenPath.startsWith(realpathSync(root))).toBe(true);
+});
+
+// ── Unknown / archived session → 404 ────────────────────────────────────────
+
+test("POST upload: unknown session → 404", async () => {
+  const { app } = harness();
+  const file = new File(["x"], "f.txt", { type: "text/plain" });
+  const res = await app.fetch(makeUploadRequest("no-such-session", file));
+  expect(res.status).toBe(404);
+});
+
+test("POST upload: archived session → 404", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  store.update(s.id, { status: "archived" });
+
+  const file = new File(["x"], "f.txt", { type: "text/plain" });
+  const res = await app.fetch(makeUploadRequest(s.id, file));
+  expect(res.status).toBe(404);
+});
+
+// ── GET empty-root → synthetic empty listing ─────────────────────────────────
+
+test("GET scratchpad: fresh session with no root → empty listing (not 404)", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  // Do NOT create the scratchpad root
+
+  const res = await app.fetch(new Request(`http://x/api/sessions/${s.id}/scratchpad`));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.path).toBe("");
+  expect(body.parent).toBeNull();
+  expect(body.entries).toEqual([]);
+});
+
+test("GET scratchpad: missing non-root subdir still 404s", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  // Do NOT create the scratchpad root
+
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${s.id}/scratchpad?path=nonexistent`),
+  );
+  expect(res.status).toBe(404);
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2192,5 +2192,14 @@
   "github_lens_paused": "Pausiert",
   "github_lens_graphql_backoff": "GraphQL-Polling pausiert, während ein Rate-Limit-Backoff abklingt — PR-, Issue- und Backlog-Updates laufen in ~{time} weiter.",
   "docagent_status_error": "Formatierung fehlgeschlagen",
-  "docagent_toast_error": "{repo}: Doku-Update abgebrochen — Prettier konnte die Doku nicht formatieren"
+  "docagent_toast_error": "{repo}: Doku-Update abgebrochen — Prettier konnte die Doku nicht formatieren",
+  "files_upload_button": "Hochladen",
+  "files_upload_aria": "Dateien ins Scratchpad hochladen",
+  "files_upload_drop_hint": "Dateien zum Hochladen hierher ziehen",
+  "files_uploading": "{name} wird hochgeladen…",
+  "files_upload_done": "{name} hochgeladen",
+  "files_upload_too_large": "{name} ist zu groß (max. 10 MB)",
+  "files_upload_failed": "{name} konnte nicht hochgeladen werden",
+  "feat_scratchpad_upload_title": "Dateien ins Scratchpad hochladen",
+  "feat_scratchpad_upload_body": "Du kannst jetzt direkt aus dem Dateien-Tab Dateien in das Scratchpad einer Session laden - per Klick auf Hochladen oder per Drag-and-drop. Der Agent kann alles lesen, was du dort ablegst."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2201,5 +2201,6 @@
   "files_upload_too_large": "{name} ist zu groß (max. 10 MB)",
   "files_upload_failed": "{name} konnte nicht hochgeladen werden",
   "feat_scratchpad_upload_title": "Dateien ins Scratchpad hochladen",
-  "feat_scratchpad_upload_body": "Du kannst jetzt direkt aus dem Dateien-Tab Dateien in das Scratchpad einer Session laden - per Klick auf Hochladen oder per Drag-and-drop. Der Agent kann alles lesen, was du dort ablegst."
+  "feat_scratchpad_upload_body": "Du kannst jetzt direkt aus dem Dateien-Tab Dateien in das Scratchpad einer Session laden - per Klick auf Hochladen oder per Drag-and-drop. Der Agent kann alles lesen, was du dort ablegst.",
+  "files_list_aria": "Scratchpad-Dateien"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2201,5 +2201,6 @@
   "files_upload_too_large": "{name} is too large (max 10 MB)",
   "files_upload_failed": "Upload of {name} failed",
   "feat_scratchpad_upload_title": "Upload files to the scratchpad",
-  "feat_scratchpad_upload_body": "You can now upload files directly into a session's scratchpad from the Files tab — click Upload or drag-and-drop files onto the list. The agent can read anything you drop there."
+  "feat_scratchpad_upload_body": "You can now upload files directly into a session's scratchpad from the Files tab — click Upload or drag-and-drop files onto the list. The agent can read anything you drop there.",
+  "files_list_aria": "Scratchpad files"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2192,5 +2192,14 @@
   "github_lens_paused": "Paused",
   "github_lens_graphql_backoff": "GraphQL polling is paused while a rate-limit backoff clears — PR, issue and backlog updates resume in ~{time}.",
   "docagent_status_error": "format failed",
-  "docagent_toast_error": "{repo}: doc update aborted — prettier couldn't format the docs"
+  "docagent_toast_error": "{repo}: doc update aborted — prettier couldn't format the docs",
+  "files_upload_button": "Upload",
+  "files_upload_aria": "Upload files to scratchpad",
+  "files_upload_drop_hint": "Drop files to upload",
+  "files_uploading": "Uploading {name}…",
+  "files_upload_done": "{name} uploaded",
+  "files_upload_too_large": "{name} is too large (max 10 MB)",
+  "files_upload_failed": "Upload of {name} failed",
+  "feat_scratchpad_upload_title": "Upload files to the scratchpad",
+  "feat_scratchpad_upload_body": "You can now upload files directly into a session's scratchpad from the Files tab — click Upload or drag-and-drop files onto the list. The agent can read anything you drop there."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -557,6 +557,24 @@ export function scratchpadDownloadUrl(id: string, path: string): string {
   return `/api/sessions/${id}/scratchpad/download?path=${encodeURIComponent(path)}`;
 }
 
+/** Upload one arbitrary file into a session's scratchpad dir (#1258). Returns the root-relative path.
+ *  Throws an ApiError so callers can branch on status (e.g. 413 = too large, max 10 MB). */
+export async function uploadScratchpadFile(
+  id: string,
+  file: File,
+  dirPath?: string,
+): Promise<string> {
+  const fd = new FormData();
+  fd.append("file", file);
+  const q = dirPath ? `?path=${encodeURIComponent(dirPath)}` : "";
+  const r = await fetch(`/api/sessions/${id}/scratchpad/upload${q}`, { method: "POST", body: fd });
+  if (!r.ok) {
+    const body = (await r.json().catch(() => null)) as { error?: string } | null;
+    throw new ApiError(r.status, body?.error ?? `upload failed: ${r.status}`);
+  }
+  return (await r.json()).path as string;
+}
+
 export interface BranchList {
   branches: string[];
   current: string | null;

--- a/ui/src/lib/api.uploadScratchpadFile.test.ts
+++ b/ui/src/lib/api.uploadScratchpadFile.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { uploadScratchpadFile, ApiError } from "./api";
+
+function mockFetch(status: number, body: unknown): typeof fetch {
+  return vi.fn(
+    async () => new Response(JSON.stringify(body), { status }),
+  ) as unknown as typeof fetch;
+}
+
+describe("uploadScratchpadFile", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it("returns root-relative path on 200", async () => {
+    globalThis.fetch = mockFetch(200, { path: "uploads/foo.txt" });
+    const result = await uploadScratchpadFile("sess-1", new File(["x"], "foo.txt"));
+    expect(result).toBe("uploads/foo.txt");
+  });
+
+  it("uses the session id and file in the request", async () => {
+    const calls: { url: string; method: string }[] = [];
+    globalThis.fetch = vi.fn(async (url: unknown, init?: RequestInit) => {
+      calls.push({ url: String(url), method: init?.method ?? "GET" });
+      return new Response(JSON.stringify({ path: "uploads/bar.png" }), { status: 200 });
+    }) as unknown as typeof fetch;
+    await uploadScratchpadFile("sess-abc", new File(["data"], "bar.png"));
+    expect(calls[0]?.url).toBe("/api/sessions/sess-abc/scratchpad/upload");
+    expect(calls[0]?.method).toBe("POST");
+  });
+
+  it("appends ?path= when dirPath is given", async () => {
+    const calls: { url: string }[] = [];
+    globalThis.fetch = vi.fn(async (url: unknown) => {
+      calls.push({ url: String(url) });
+      return new Response(JSON.stringify({ path: "sub/file.txt" }), { status: 200 });
+    }) as unknown as typeof fetch;
+    await uploadScratchpadFile("s1", new File(["x"], "file.txt"), "sub");
+    expect(calls[0]?.url).toBe("/api/sessions/s1/scratchpad/upload?path=sub");
+  });
+
+  it("throws ApiError with status 413 on too-large response", async () => {
+    globalThis.fetch = mockFetch(413, { error: "file too large" });
+    const err = await uploadScratchpadFile("s1", new File(["x"], "big.zip")).catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(413);
+    expect((err as ApiError).message).toBe("file too large");
+  });
+
+  it("throws ApiError with status 400 on missing file error", async () => {
+    globalThis.fetch = mockFetch(400, { error: "no file" });
+    const err = await uploadScratchpadFile("s1", new File([""], "empty")).catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(400);
+  });
+
+  it("throws ApiError with status 404 on unknown session", async () => {
+    globalThis.fetch = mockFetch(404, { error: "session not found" });
+    const err = await uploadScratchpadFile("bad-id", new File(["x"], "x.txt")).catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(404);
+  });
+
+  it("falls back to status message when body carries no error field", async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response("not json", { status: 500 }),
+    ) as unknown as typeof fetch;
+    const err = await uploadScratchpadFile("s1", new File(["x"], "x.txt")).catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(500);
+    expect((err as ApiError).message).toContain("upload failed: 500");
+  });
+});

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -510,9 +510,10 @@
     if (todoExists === false && tab === "todo") tab = "term";
   });
 
-  // The Files tab is gated on the server-derived hasScratchpadFiles flag (#1164) — folded into
-  // the session payload + refreshed by the session:status (idle/done) push, so no extra poll.
-  const hasFiles = $derived(session.hasScratchpadFiles === true);
+  // The Files tab is shown for any live session that has a claudeSessionId (#1258). This lets an
+  // operator upload files even before the agent writes anything. hasScratchpadFiles is subsumed —
+  // it can only be true for a live session with a claudeSessionId — so it no longer drives visibility.
+  const hasFiles = $derived(session.claudeSessionId !== "" && session.status !== "archived");
   // Don't strand the operator on a Files tab whose scratchpad just emptied.
   $effect(() => {
     if (!hasFiles && tab === "files") tab = "term";

--- a/ui/src/lib/components/viewport/FilesPanel.browser.test.ts
+++ b/ui/src/lib/components/viewport/FilesPanel.browser.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import "../../../app.css";
+import { ApiError } from "$lib/api";
+import { m } from "$lib/paraglide/messages";
+
+// Mock the entire API module — no real network calls
+vi.mock("$lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/api")>();
+  return {
+    ...actual,
+    getScratchpadListing: vi.fn(),
+    scratchpadDownloadUrl: vi.fn((id: string, path: string) => `/dl/${id}/${path}`),
+    uploadScratchpadFile: vi.fn(),
+  };
+});
+
+const { default: FilesPanel } = await import("./FilesPanel.svelte");
+
+const { getScratchpadListing, uploadScratchpadFile } = await import("$lib/api");
+const mockListing = vi.mocked(getScratchpadListing);
+const mockUpload = vi.mocked(uploadScratchpadFile);
+
+const EMPTY_LISTING = { path: "", parent: null, entries: [] };
+
+let fontStyle: HTMLStyleElement;
+beforeEach(() => {
+  mockListing.mockReset();
+  mockUpload.mockReset();
+
+  // Default: empty listing so the panel renders without hanging on the initial browse
+  mockListing.mockResolvedValue(EMPTY_LISTING);
+
+  fontStyle = document.createElement("style");
+  fontStyle.textContent = `:root {
+    --font-mono: ui-monospace, monospace;
+    --color-panel: #1a1a1a;
+    --color-line: #333;
+    --color-inset: #111;
+    --color-ink: #ccc;
+    --color-ink-bright: #fff;
+    --color-muted: #666;
+    --color-faint: #444;
+    --color-amber: #f5a623;
+    --color-blue: #4a9eff;
+    --color-green: #4caf50;
+    --color-red: #f44336;
+    --fs-meta: 12px;
+    --fs-micro: 10px;
+  }
+  *, *::before, *::after { box-sizing: border-box; }
+  body { margin: 0; }`;
+  document.head.appendChild(fontStyle);
+});
+afterEach(() => {
+  fontStyle.remove();
+  document.body.innerHTML = "";
+});
+
+// Helper: wait for the upload button to be present (listing loaded)
+async function waitForPanel() {
+  await expect.poll(() => document.querySelector("button.upload-btn")).toBeTruthy();
+}
+
+describe("FilesPanel — file select calls uploadScratchpadFile", () => {
+  it("calls uploadScratchpadFile(sessionId, file, currentPath) on file input change", async () => {
+    mockUpload.mockResolvedValue("subdir/test.txt");
+    // seed a second browse call after upload
+    mockListing.mockResolvedValue(EMPTY_LISTING);
+
+    render(FilesPanel, { sessionId: "sess-1" });
+    await waitForPanel();
+
+    const file = new File(["hello"], "test.txt", { type: "text/plain" });
+    const input = document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    expect(input).not.toBeNull();
+
+    // Simulate file selection via the hidden input
+    Object.defineProperty(input, "files", { value: [file], configurable: true });
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+
+    // uploadScratchpadFile should be called with (sessionId, file, undefined) — root path is ""
+    await expect.poll(() => mockUpload.mock.calls.length).toBe(1);
+    expect(mockUpload).toHaveBeenCalledWith("sess-1", file, undefined);
+  });
+
+  it("refreshes the listing (getScratchpadListing) after a successful upload", async () => {
+    mockUpload.mockResolvedValue("test.txt");
+
+    render(FilesPanel, { sessionId: "sess-2" });
+    await waitForPanel();
+
+    const callsBefore = mockListing.mock.calls.length;
+
+    const file = new File(["data"], "test.txt", { type: "text/plain" });
+    const input = document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    Object.defineProperty(input, "files", { value: [file], configurable: true });
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+
+    // After upload settles, browse() is called again → getScratchpadListing should be called
+    await expect.poll(() => mockListing.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+});
+
+describe("FilesPanel — 413 too-large error surfaces inline", () => {
+  it("shows files_upload_too_large message inline when upload returns 413", async () => {
+    mockUpload.mockRejectedValue(new ApiError(413, "file too large"));
+
+    render(FilesPanel, { sessionId: "sess-3" });
+    await waitForPanel();
+
+    const file = new File(["x".repeat(100)], "bigfile.bin", { type: "application/octet-stream" });
+    const input = document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    Object.defineProperty(input, "files", { value: [file], configurable: true });
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+
+    const expectedMsg = m.files_upload_too_large({ name: "bigfile.bin" });
+    await expect
+      .poll(() => document.querySelector(".upload-status.err")?.textContent?.trim())
+      .toBe(expectedMsg);
+  });
+});
+
+describe("FilesPanel — drag-and-drop calls uploadScratchpadFile", () => {
+  it("calls uploadScratchpadFile on drop with correct args", async () => {
+    mockUpload.mockResolvedValue("dropped.txt");
+
+    render(FilesPanel, { sessionId: "sess-4" });
+    await waitForPanel();
+
+    const file = new File(["drop"], "dropped.txt", { type: "text/plain" });
+    const list = document.querySelector<HTMLDivElement>(".list")!;
+    expect(list).not.toBeNull();
+
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    list.dispatchEvent(
+      new DragEvent("dragover", { bubbles: true, cancelable: true, dataTransfer: dt }),
+    );
+    list.dispatchEvent(
+      new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: dt }),
+    );
+
+    await expect.poll(() => mockUpload.mock.calls.length).toBe(1);
+    expect(mockUpload).toHaveBeenCalledWith("sess-4", file, undefined);
+  });
+});

--- a/ui/src/lib/components/viewport/FilesPanel.svelte
+++ b/ui/src/lib/components/viewport/FilesPanel.svelte
@@ -17,8 +17,13 @@
   let loading = $state(false);
   let error = $state(false);
 
-  type UploadStatus = { name: string; state: "uploading" | "done" | "failed" | "too_large" };
+  type UploadStatus = {
+    id: number;
+    name: string;
+    state: "uploading" | "done" | "failed" | "too_large";
+  };
   let uploads = $state<UploadStatus[]>([]);
+  let nextUploadId = 0;
   let dragOver = $state(false);
 
   let fileInput: HTMLInputElement;
@@ -63,20 +68,25 @@
     if (!files.length) return;
     const dirPath = listing?.path || undefined;
 
-    // Add each file to the status list as "uploading"
-    const newUploads: UploadStatus[] = files.map((f) => ({ name: f.name, state: "uploading" }));
+    // Add each file to the status list as "uploading"; assign stable unique ids
+    const newUploads: UploadStatus[] = files.map((f) => ({
+      id: nextUploadId++,
+      name: f.name,
+      state: "uploading",
+    }));
     uploads = [...uploads, ...newUploads];
 
     await Promise.all(
-      files.map(async (file, idx) => {
-        const statusIdx = uploads.length - files.length + idx;
+      newUploads.map(async (entry, idx) => {
+        const uid = entry.id;
+        const file = files[idx];
         try {
           await uploadScratchpadFile(sessionId, file, dirPath);
-          uploads = uploads.map((u, i) => (i === statusIdx ? { ...u, state: "done" } : u));
+          uploads = uploads.map((u) => (u.id === uid ? { ...u, state: "done" } : u));
         } catch (e) {
           const isTooLarge = e instanceof ApiError && e.status === 413;
-          uploads = uploads.map((u, i) =>
-            i === statusIdx ? { ...u, state: isTooLarge ? "too_large" : "failed" } : u,
+          uploads = uploads.map((u) =>
+            u.id === uid ? { ...u, state: isTooLarge ? "too_large" : "failed" } : u,
           );
         }
       }),
@@ -99,7 +109,9 @@
     dragOver = true;
   }
 
-  function handleDragLeave() {
+  function handleDragLeave(e: DragEvent) {
+    // Ignore leave events triggered by crossing into a child element — only clear on a real exit.
+    if (e.relatedTarget && (e.currentTarget as Node).contains(e.relatedTarget as Node)) return;
     dragOver = false;
   }
 
@@ -149,7 +161,7 @@
   </div>
 
   <!-- Upload status lines -->
-  {#each uploads as u (u.name + u.state)}
+  {#each uploads as u (u.id)}
     {#if u.state === "uploading"}
       <div class="upload-status">{m.files_uploading({ name: u.name })}</div>
     {:else if u.state === "too_large"}
@@ -165,7 +177,7 @@
   <div
     class={["list", dragOver && "drop-active"]}
     role="region"
-    aria-label={m.files_upload_aria()}
+    aria-label={m.files_list_aria()}
     ondragover={handleDragOver}
     ondragleave={handleDragLeave}
     ondrop={handleDrop}
@@ -248,6 +260,28 @@
   .crumb-sep {
     color: var(--color-faint);
   }
+  .gbtn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 2px 8px;
+    cursor: pointer;
+    transition:
+      border-color 0.12s,
+      color 0.12s;
+  }
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .gbtn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
   .upload-btn {
     font-size: var(--fs-meta);
     padding: 4px 10px;
@@ -288,8 +322,8 @@
       background 0.1s ease;
   }
   .list.drop-active {
-    border-color: var(--color-accent);
-    background: color-mix(in srgb, var(--color-accent) 8%, var(--color-inset));
+    border-color: var(--color-blue);
+    background: color-mix(in srgb, var(--color-blue) 8%, var(--color-inset));
   }
   .placeholder {
     padding: 14px 12px;

--- a/ui/src/lib/components/viewport/FilesPanel.svelte
+++ b/ui/src/lib/components/viewport/FilesPanel.svelte
@@ -1,15 +1,27 @@
 <script lang="ts">
-  import { getScratchpadListing, scratchpadDownloadUrl } from "$lib/api";
+  import {
+    getScratchpadListing,
+    scratchpadDownloadUrl,
+    uploadScratchpadFile,
+    ApiError,
+  } from "$lib/api";
   import type { ScratchListing } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
+  import { coachTarget } from "$lib/actions/coachTarget.svelte";
 
-  // Read-only browser of the session's scratchpad subtree (#1164). Click a directory to descend,
-  // click a file to download it. Server enforces containment to the scratchpad root.
+  // Read/upload browser of the session's scratchpad subtree (#1164, #1258). Click a directory to
+  // descend, click a file to download it. Upload via button or drag-and-drop into the current dir.
   let { sessionId }: { sessionId: string } = $props();
 
   let listing = $state<ScratchListing | null>(null);
   let loading = $state(false);
   let error = $state(false);
+
+  type UploadStatus = { name: string; state: "uploading" | "done" | "failed" | "too_large" };
+  let uploads = $state<UploadStatus[]>([]);
+  let dragOver = $state(false);
+
+  let fileInput: HTMLInputElement;
 
   async function browse(path: string) {
     loading = true;
@@ -29,6 +41,7 @@
     const id = sessionId;
     listing = null;
     error = false;
+    uploads = [];
     void browse("");
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- reactive dep
     id;
@@ -45,27 +58,127 @@
     }
     return out;
   });
+
+  async function uploadFiles(files: File[]) {
+    if (!files.length) return;
+    const dirPath = listing?.path || undefined;
+
+    // Add each file to the status list as "uploading"
+    const newUploads: UploadStatus[] = files.map((f) => ({ name: f.name, state: "uploading" }));
+    uploads = [...uploads, ...newUploads];
+
+    await Promise.all(
+      files.map(async (file, idx) => {
+        const statusIdx = uploads.length - files.length + idx;
+        try {
+          await uploadScratchpadFile(sessionId, file, dirPath);
+          uploads = uploads.map((u, i) => (i === statusIdx ? { ...u, state: "done" } : u));
+        } catch (e) {
+          const isTooLarge = e instanceof ApiError && e.status === 413;
+          uploads = uploads.map((u, i) =>
+            i === statusIdx ? { ...u, state: isTooLarge ? "too_large" : "failed" } : u,
+          );
+        }
+      }),
+    );
+
+    // Refresh listing once all uploads have settled
+    void browse(listing?.path ?? "");
+  }
+
+  function handleFileInput(e: Event) {
+    const input = e.currentTarget as HTMLInputElement;
+    if (input.files?.length) {
+      void uploadFiles(Array.from(input.files));
+      input.value = "";
+    }
+  }
+
+  function handleDragOver(e: DragEvent) {
+    e.preventDefault();
+    dragOver = true;
+  }
+
+  function handleDragLeave() {
+    dragOver = false;
+  }
+
+  function handleDrop(e: DragEvent) {
+    e.preventDefault();
+    dragOver = false;
+    if (!listing) return; // still loading
+    const files = e.dataTransfer?.files;
+    if (files?.length) void uploadFiles(Array.from(files));
+  }
+
+  function openFilePicker() {
+    fileInput.click();
+  }
 </script>
 
 <div class="files">
-  <nav class="crumbs" aria-label={m.files_breadcrumb_aria()}>
-    {#each crumbs as c, i (c.path)}
-      {#if i > 0}<span class="crumb-sep" aria-hidden="true">/</span>{/if}
-      {#if i === crumbs.length - 1}
-        <span class="crumb current" aria-current="page">{c.label}</span>
-      {:else}
-        <button type="button" class="crumb" onclick={() => browse(c.path)}>{c.label}</button>
-      {/if}
-    {/each}
-  </nav>
+  <div class="toolbar">
+    <nav class="crumbs" aria-label={m.files_breadcrumb_aria()}>
+      {#each crumbs as c, i (c.path)}
+        {#if i > 0}<span class="crumb-sep" aria-hidden="true">/</span>{/if}
+        {#if i === crumbs.length - 1}
+          <span class="crumb current" aria-current="page">{c.label}</span>
+        {:else}
+          <button type="button" class="crumb" onclick={() => browse(c.path)}>{c.label}</button>
+        {/if}
+      {/each}
+    </nav>
+    <button
+      type="button"
+      class="gbtn upload-btn"
+      aria-label={m.files_upload_aria()}
+      disabled={listing === null}
+      onclick={openFilePicker}
+      use:coachTarget={"scratchpad-upload"}>{m.files_upload_button()}</button
+    >
+    <!-- Hidden real input; triggered by the upload button -->
+    <input
+      bind:this={fileInput}
+      type="file"
+      multiple
+      class="sr-only"
+      aria-hidden="true"
+      tabindex="-1"
+      onchange={handleFileInput}
+    />
+  </div>
 
-  <div class="list">
+  <!-- Upload status lines -->
+  {#each uploads as u (u.name + u.state)}
+    {#if u.state === "uploading"}
+      <div class="upload-status">{m.files_uploading({ name: u.name })}</div>
+    {:else if u.state === "too_large"}
+      <div class="upload-status err">{m.files_upload_too_large({ name: u.name })}</div>
+    {:else if u.state === "failed"}
+      <div class="upload-status err">{m.files_upload_failed({ name: u.name })}</div>
+    {:else if u.state === "done"}
+      <div class="upload-status ok">{m.files_upload_done({ name: u.name })}</div>
+    {/if}
+  {/each}
+
+  <!-- Drop zone wrapping the file list -->
+  <div
+    class={["list", dragOver && "drop-active"]}
+    role="region"
+    aria-label={m.files_upload_aria()}
+    ondragover={handleDragOver}
+    ondragleave={handleDragLeave}
+    ondrop={handleDrop}
+  >
     {#if loading && !listing}
       <div class="placeholder">{m.common_loading()}</div>
     {:else if error}
       <div class="placeholder err">{m.files_load_error()}</div>
     {:else if listing && listing.entries.length === 0}
-      <div class="placeholder">{m.files_empty()}</div>
+      <div class="placeholder empty-droppable">
+        <span>{m.files_empty()}</span>
+        <span class="drop-hint">{m.files_upload_drop_hint()}</span>
+      </div>
     {:else if listing}
       {#each listing.entries as e (e.path)}
         {#if e.type === "dir"}
@@ -102,6 +215,12 @@
     overflow-y: auto;
     height: 100%;
   }
+  .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
   .crumbs {
     display: flex;
     align-items: center;
@@ -109,6 +228,7 @@
     gap: 4px;
     font-family: var(--font-mono);
     font-size: var(--fs-meta);
+    flex: 1;
   }
   .crumb {
     background: transparent;
@@ -128,12 +248,48 @@
   .crumb-sep {
     color: var(--color-faint);
   }
+  .upload-btn {
+    font-size: var(--fs-meta);
+    padding: 4px 10px;
+    min-height: 28px;
+    flex-shrink: 0;
+  }
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+  .upload-status {
+    padding: 5px 12px;
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    letter-spacing: 0.04em;
+  }
+  .upload-status.err {
+    color: var(--color-red);
+  }
+  .upload-status.ok {
+    color: var(--color-muted);
+  }
   .list {
     border: 1px solid var(--color-line);
     background: var(--color-inset);
     border-radius: 2px;
     display: flex;
     flex-direction: column;
+    transition:
+      border-color 0.1s ease,
+      background 0.1s ease;
+  }
+  .list.drop-active {
+    border-color: var(--color-accent);
+    background: color-mix(in srgb, var(--color-accent) 8%, var(--color-inset));
   }
   .placeholder {
     padding: 14px 12px;
@@ -143,6 +299,16 @@
   }
   .placeholder.err {
     color: var(--color-red);
+  }
+  .empty-droppable {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .drop-hint {
+    color: var(--color-faint);
+    font-size: var(--fs-meta);
+    font-style: italic;
   }
   .row {
     display: flex;
@@ -190,6 +356,10 @@
   @media (max-width: 768px) {
     .row {
       min-height: 44px;
+    }
+    .upload-btn {
+      min-height: 44px;
+      padding: 8px 14px;
     }
   }
 </style>

--- a/ui/src/lib/components/viewport/ViewportTabBar.svelte
+++ b/ui/src/lib/components/viewport/ViewportTabBar.svelte
@@ -229,8 +229,9 @@
       onclick={() => (tab = "diff")}>{m.viewport_diff_tab()}</button
     >
     {#if hasFiles}
-      <!-- only when the session's scratchpad holds files (server-derived hasScratchpadFiles):
-           skips an empty browser. Updates live at turn-end via the session:status push. -->
+      <!-- shown for any live session with a claudeSessionId, so files can be uploaded before the
+           agent writes anything (#1258). hasScratchpadFiles is now subsumed — it can only be true
+           for a live session with a claudeSessionId. Tab visibility is refreshed via session:status push. -->
       <button
         class="tab-btn"
         class:active={tab === "files"}

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1865,4 +1865,14 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_owed_badge_body",
     targetId: "owed-lens",
   },
+  {
+    // Upload button is always mounted on the Files tab for any live session — a reliable
+    // persistent anchor. use:coachTarget={"scratchpad-upload"} is on the Upload button
+    // in FilesPanel.svelte. Ships in 1.39.0 (1.38.0 is the latest released tag).
+    id: "scratchpad-upload",
+    sinceVersion: "1.39.0",
+    titleKey: "feat_scratchpad_upload_title",
+    bodyKey: "feat_scratchpad_upload_body",
+    targetId: "scratchpad-upload",
+  },
 ];


### PR DESCRIPTION
Closes #1258.

Lets an operator upload **arbitrary binary files** into a live session's **scratchpad** from the read-only **Files tab** (`FilesPanel`). Files land in the folder currently shown so the agent picks them up on its next turn (passive drop — no path injection or steer). Write-counterpart to the read-only browser from #1164.

## What's new
- **Server** — `POST /api/sessions/:id/scratchpad/upload?path=<dir>` (`handleSessionScratchpadUpload`): accepts any file type (no MIME whitelist), keeps the 10 MB cap (`MAX_UPLOAD_BYTES`), preserves the real filename, suffixes on collision (`report (2).pdf`), live sessions only.
- **Start-of-session upload** — the Files tab now shows for any live session with a `claudeSessionId` (not just when the scratchpad already has files), and the upload creates the scratchpad **root** on demand, so an operator can drop a file *before* the agent writes anything. The GET listing returns an empty listing for a fresh session so the tab opens to an empty, droppable list.
- **UI** — Upload button (`.gbtn`) + drag-and-drop onto the list/empty-state in `FilesPanel`, with per-file inline status (uploading / done / too-large / failed) and a refresh on success.

## Security (write path)
Same trust boundary as the read browser — **realpath containment** to the scratchpad root:
- Destination dir resolved + realpath-contained and verified to be an existing **directory** (a `?path` at a file → 404, not an ENOTDIR 500).
- Filename sanitized to a single path segment **before** any join (`basename("..")` can't escape).
- Collision loop uses **`lstat`** (not `existsSync`) so a planted symlink at the target name can't be followed out of the root; the final joined path is re-validated `within(root)` before write.
- Only the known-safe scratchpad **root** is ever `mkdir`'d — never an attacker-supplied subdir.

## Scope decisions
- Suffix on collision (never overwrite); per-file batch errors (partial success OK); 10 MB cap retained; errors shown inline (not a global toast). Terminal drag/paste stays image-only.

## Cross-cutting gates
- i18n: new `files_*` + `feat_scratchpad_upload_*` keys added to EN **and** DE (parity passes).
- Feature discovery: one `feature-announcements.ts` entry (`scratchpad-upload`, since `1.39.0`) + coachmark target.

## Tests
- Server: `test/scratchpad-upload.test.ts` — root-absent mkdir+land, subdir land, `..`/absolute/symlink-escape → 404, `?path`-at-file → 404, oversize → 413, missing field → 400, sanitization, collision suffix, leaf-symlink escape, archived → 404, GET empty-root.
- UI: `api.uploadScratchpadFile.test.ts` (contract incl. 413) and `FilesPanel.browser.test.ts` (upload call args, refresh, 413 inline, drag-drop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
