### PR TITLE
fix(ci): cap ui browser-test concurrency to stop flaky OOM (exit 137)

### DIFF
--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -65,7 +65,7 @@
     { id: "diagnose", label: m.settings_tab_diagnose },
   ] as const;
   type TabId = (typeof ALL_TABS)[number]["id"];
-  let tabEls: HTMLButtonElement[] = [];
+  let tabEls = $state<HTMLButtonElement[]>([]);
 
   function onTabKey(e: KeyboardEvent, i: number) {
     const tabs = visibleTabs;

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -92,6 +92,18 @@ export default defineConfig({
         test: {
           name: "browser",
           include: ["src/**/*.browser.test.ts"],
+          // CI memory headroom (#1261 OOM, exit 137): on a many-core self-hosted
+          // runner vitest defaults maxWorkers to nproc, so the browser project
+          // spawns ~nproc concurrent chromium pages AND overlaps the full-parallel
+          // node project — peak RSS hit ~8.9 GiB on a 32-core box and intermittently
+          // OOM-killed the run. Cap browser file-parallelism to 2 and give it a
+          // distinct sequence.groupOrder so it runs AFTER the node project instead
+          // of concurrently (vitest requires unique groupOrder when projects differ
+          // on maxWorkers). Together this ~halves peak RSS (~8.9→~4.8 GiB) with both
+          // projects green. CI-only (GitHub Actions sets CI=true) so local
+          // `bun run test` is unchanged. Note: a global `--maxWorkers` CLI flag does
+          // NOT cap the browser pool — it must live in the project's test config.
+          ...(process.env.CI ? { maxWorkers: 2, sequence: { groupOrder: 1 } } : {}),
           browser: {
             enabled: true,
             provider: playwright(),


### PR DESCRIPTION
## Problem

CI run [28425535712](https://github.com/erwins-enkel/shepherd/actions/runs/28425535712/job/84227708895) (push of #1261) failed the **Test (ui)** step with **exit 137** even though *every* UI test passed ✓. 137 = 128 + 9 (SIGKILL): the kernel OOM-killer killed `bun run test`, not an assertion failure. A re-run of the same commit **passed** → marginal/flaky, right at the runner's RAM edge.

## Root cause (measured, not assumed)

The job runs on a **self-hosted** runner (`CI_RUNNER=self-hosted`). `bun run test` = `vitest run` sets no `maxWorkers`, so vitest 4 defaults it to **nproc**. On a many-core box the **browser** project spawns ~nproc concurrent chromium pages *and* runs **concurrently with the full-parallel node project** (both default to the same `sequence.groupOrder`).

Empirical before/after of the full `bun run test` on a 32-core box (peak summed RSS of the run's cgroup process tree; cgroup `memory.peak` was discarded as it counts reclaimable page cache):

| | peak RSS | concurrent renderers | wall |
|---|---|---|---|
| **baseline** | **8904 MiB** | 14 | 16s |
| **this PR** | **4765 MiB** | 4 | 28s |

~**−46% peak RSS (−4.0 GiB)**, both runs green (170 files / 2330 tests). #1261 added the 86th browser test file, nudging peak past the edge on the smaller/shared runner-2.

## Fix

In `ui/vite.config.ts`, for the **browser** project only, gated behind `CI`:
- `maxWorkers: 2` — caps concurrent chromium pages.
- `sequence: { groupOrder: 1 }` — runs the browser project **after** the node project instead of concurrently (vitest *requires* a unique `groupOrder` when projects differ on `maxWorkers` — capping browser alone without this throws `Projects … have different 'maxWorkers' but same 'sequence.groupOrder'`).

Notes:
- **CI-only** (`process.env.CI`; GitHub Actions sets `CI=true`) → local `bun run test` is byte-for-byte unchanged (verified).
- A global `--maxWorkers` CLI flag was tried first and **does not** cap the browser pool — the setting must live in the project's `test` config.
- Also flips `tabEls` to a `$state` rune in `Settings.svelte`, killing the `binding_property_non_reactive` warning that flooded test stderr (pre-existing; unrelated to the OOM).

## Honest limitations

- The cap reduces **per-run** peak. The workflow `concurrency` group is **ref-scoped**, so different PRs still run concurrently on the shared runner pool and could collectively OOM. A durable cure is operator infra — a **runner-level memory limit** (systemd `MemoryMax`/`MemoryHigh` on the runner service, or a container `--memory`). See manual steps.
- OOM can't be reproduced locally (this box has 62 GB; runner-2 differs). The gate here is the demonstrated peak-RSS reduction, **not** a local OOM repro — so a single green CI run should not be treated as proof; watch for absence of exit-137 across several runs.

## Verification

- Full `cd ui && CI=true bun run test` → 170 files / 2330 tests pass, capped + sequenced.
- Full `cd ui && bun run test` (local) → passes, no config error (gate off).
- `bun run check` → 0 errors; prettier + eslint clean; `binding_property_non_reactive` flood gone.

```shepherd:manual-steps
- [ ] POST-MERGE (recommended, operator infra — not in this PR): apply a memory limit to the self-hosted CI runner (systemd MemoryMax/MemoryHigh on the runner service, or run CI jobs in a container with --memory) so one job can't OOM the host. Covers the cross-run contention this per-run cap cannot.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)