### PR TITLE
perf(ui): lazy-import Shiki in CodeBlock to fix INEFFECTIVE_DYNAMIC_IMPORT

### DIFF
--- a/ui/src/lib/components/blocks/CodeBlock.svelte
+++ b/ui/src/lib/components/blocks/CodeBlock.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { VisualBlock } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
-  import { highlightLines } from "$lib/highlight";
   import { theme } from "$lib/theme.svelte";
 
   let { block }: { block: Extract<VisualBlock, { type: "code" }> } = $props();
@@ -17,7 +16,11 @@
     }
     let alive = true;
     const lines = code.split("\n");
-    highlightLines(lines, block.filename, resolved)
+    // Shiki is dynamically imported so the highlighter (and its registry/WASM
+    // engine) stays off the first-paint critical path — DiffFileBlock relies on
+    // the same lazy import, so a static import here would pull it back in.
+    import("$lib/highlight")
+      .then(({ highlightLines }) => highlightLines(lines, block.filename, resolved))
       .then((result) => {
         if (alive) highlightedLines = result;
       })


### PR DESCRIPTION
## What

`CodeBlock.svelte` imported `$lib/highlight` **statically** while `DiffFileBlock.svelte` imports it **dynamically** (specifically to keep Shiki off first paint). The static import won, neutralizing the lazy load — so Shiki's `createHighlighter` machinery, the 221-entry `bundledLanguages` index, and the Oniguruma WASM engine were all pulled into the first-paint chunk.

This mirrors `DiffFileBlock`'s pattern: move the import into the existing `$effect` as `import("$lib/highlight")`. These two were the only importers of the module repo-wide.

## Result

- `[INEFFECTIVE_DYNAMIC_IMPORT]` build warning **gone**.
- Shiki no longer in the first-paint static import closure.
- Main route chunk (`nodes/2`) drops **~153 kB** (1245 → 1092 kB); total first-paint JS 1939 → 1787 kB.
- `bun run check` ✓, `CodeBlock` + `DiffFileBlock` browser tests ✓ (4/4), `bun run build` ✓.

## Investigation of the other build messages (no action — documented for completeness)

- **`Some chunks are larger than 500 kB`** — **persists by design.** The remaining first-paint weight is `xterm` (`@xterm/xterm`), statically imported by `Viewport.svelte` (the terminal is core); lazy-loading it was descoped. This PR only removes Shiki's eager contribution.
- **`[PLUGIN_TIMINGS] vite-plugin-sveltekit-guard`** — SvelteKit's own built-in import-leak guard (scales with module-graph size); benign, not configurable.
- **`Overwriting build/index.html with fallback page`** — expected `@sveltejs/adapter-static` SPA-fallback; benign.

## Notes

No user-facing UX change (internal build-perf only) → no feature-catalog / i18n / glossary entries. No manual operator steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)