### PR TITLE
feat(new-task): hide hidden repos in repo picker, reveal on search

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3325,7 +3325,13 @@ async function handleRepos({ req, parts, deps }: Ctx): Promise<Response | null> 
       const recentCounts = deps.store.recentSessionCountsByRepo(
         Date.now() - RECENT_WINDOW_DAYS * 24 * 60 * 60 * 1000,
       );
-      const repos = listRepos(config.repoRoot).map((r) => ({
+      const baseRepos = listRepos(config.repoRoot);
+      // repo_config keys are safeRepoDir/realpath-resolved while listRepos enumerates the
+      // raw join(repoRoot, name) path; reconcile the hidden set into raw space (same as the
+      // backlog payload) so a persisted hide matches its repo even under a symlinked root.
+      // The picker (NewTask) hides these by default but reveals them on name search.
+      const hiddenSet = reconcileRealPathsToRaw(deps.store.hiddenRepoPaths(), baseRepos);
+      const repos = baseRepos.map((r) => ({
         ...r,
         lastUsedAt: lastUsed[r.path],
         recentAgentCount: recentCounts[r.path],
@@ -3333,6 +3339,7 @@ async function handleRepos({ req, parts, deps }: Ctx): Promise<Response | null> 
         // can offer "Sync fork" only on fork repos. resolveForge is cached per dir
         // and shared with the backlog poller — no extra git shell on a warm cache.
         isFork: deps.resolveForge?.(r.path)?.isFork ?? false,
+        hidden: hiddenSet.has(r.path),
       }));
       // Return the window alongside the repos so the picker labels the count with
       // the exact day count it was computed over — single source of truth.

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2202,5 +2202,7 @@
   "files_upload_failed": "{name} konnte nicht hochgeladen werden",
   "feat_scratchpad_upload_title": "Dateien ins Scratchpad hochladen",
   "feat_scratchpad_upload_body": "Du kannst jetzt direkt aus dem Dateien-Tab Dateien in das Scratchpad einer Session laden - per Klick auf Hochladen oder per Drag-and-drop. Der Agent kann alles lesen, was du dort ablegst.",
-  "files_list_aria": "Scratchpad-Dateien"
+  "files_list_aria": "Scratchpad-Dateien",
+  "feat_newtask_hide_hidden_title": "Ausgeblendete Repos bleiben aus der Neue-Aufgabe-Auswahl",
+  "feat_newtask_hide_hidden_body": "Repos, die du ausgeblendet hast, überladen die Repo-Auswahl beim Start einer neuen Aufgabe nicht mehr. Sie verschwinden aus der Liste und den Zuletzt-verwendet-Kürzeln, erscheinen aber sofort, sobald du nach ihrem Namen suchst - ein ausgeblendetes Repo ist also bei Bedarf immer nur einen Tastendruck entfernt."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2202,5 +2202,7 @@
   "files_upload_failed": "Upload of {name} failed",
   "feat_scratchpad_upload_title": "Upload files to the scratchpad",
   "feat_scratchpad_upload_body": "You can now upload files directly into a session's scratchpad from the Files tab — click Upload or drag-and-drop files onto the list. The agent can read anything you drop there.",
-  "files_list_aria": "Scratchpad files"
+  "files_list_aria": "Scratchpad files",
+  "feat_newtask_hide_hidden_title": "Hidden repos stay out of the New Task picker",
+  "feat_newtask_hide_hidden_body": "Repos you've hidden no longer clutter the repo picker when you start a new task. They're dropped from the list and the recents shortcuts, but still appear the moment you search for one by name — so a hidden repo is always one keystroke away when you need it."
 }

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -1457,4 +1457,42 @@ describe("NewTask — hidden repos excluded from keyboard selection paths", () =
     // Alt+1 = first NON-hidden recent (realtop), never the higher-count hidden "secret".
     await expect.poll(() => selectedRepo()).toBe("realtop");
   });
+
+  it("cycle from a hidden current repo enters the visible subset at its boundary", async () => {
+    const vis1: RepoEntry = { name: "vis1", path: "/repo/hh-bnd-1", display: "vis1" };
+    const hiddenCur: RepoEntry = {
+      name: "hcur",
+      path: "/repo/hh-bnd-hidden",
+      display: "hcur",
+      hidden: true,
+    };
+    const vis2: RepoEntry = { name: "vis2", path: "/repo/hh-bnd-2", display: "vis2" };
+    mockListRepos.mockResolvedValue({ repos: [vis1, hiddenCur, vis2], recentWindowDays: 30 });
+    // Seeded selection is the hidden repo (still shown in the trigger), so cur === -1 in
+    // the visible subset [vis1, vis2].
+    render(NewTask, { props: base({ initialRepoPath: hiddenCur.path }) });
+
+    await expect.poll(() => selectedRepo()).toBe("hcur");
+    // Forward enters at the FIRST visible repo (not the second).
+    altChord("BracketRight");
+    await expect.poll(() => selectedRepo()).toBe("vis1");
+  });
+
+  it("backward cycle from a hidden current repo enters at the last visible repo", async () => {
+    const vis1: RepoEntry = { name: "vis1", path: "/repo/hh-bnd-b1", display: "vis1" };
+    const hiddenCur: RepoEntry = {
+      name: "hcur",
+      path: "/repo/hh-bnd-b-hidden",
+      display: "hcur",
+      hidden: true,
+    };
+    const vis2: RepoEntry = { name: "vis2", path: "/repo/hh-bnd-b2", display: "vis2" };
+    mockListRepos.mockResolvedValue({ repos: [vis1, hiddenCur, vis2], recentWindowDays: 30 });
+    render(NewTask, { props: base({ initialRepoPath: hiddenCur.path }) });
+
+    await expect.poll(() => selectedRepo()).toBe("hcur");
+    // Backward enters at the LAST visible repo.
+    altChord("BracketLeft");
+    await expect.poll(() => selectedRepo()).toBe("vis2");
+  });
 });

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -1383,3 +1383,78 @@ describe("FirstTaskAutomationConfirm", () => {
     expect(confirmBtn?.textContent?.trim()).toContain(m.firsttask_confirm_cta());
   });
 });
+
+describe("NewTask — hidden repos excluded from keyboard selection paths", () => {
+  // The bold name in the repo picker's trigger reflects the currently-selected repo.
+  const selectedRepo = () => document.querySelector(".rs-trigger b")?.textContent ?? "";
+
+  // The repo Alt-tier shortcuts listen on the dialog <form> (keydown bubbles up from the
+  // prompt textarea), keyed on physical e.code. Dispatch there to drive them in a test.
+  function altChord(code: string) {
+    document
+      .querySelector("form")!
+      .dispatchEvent(new KeyboardEvent("keydown", { code, altKey: true, bubbles: true }));
+  }
+
+  it("default selection skips a hidden repo even when it's the most-recently-used", async () => {
+    const visible: RepoEntry = {
+      name: "visible",
+      path: "/repo/hh-default-visible",
+      display: "visible",
+      lastUsedAt: 100,
+    };
+    const secret: RepoEntry = {
+      name: "secret",
+      path: "/repo/hh-default-secret",
+      display: "secret",
+      lastUsedAt: 999, // most-recently-used, but hidden → must not be auto-selected
+      hidden: true,
+    };
+    mockListRepos.mockResolvedValue({ repos: [secret, visible], recentWindowDays: 30 });
+    render(NewTask, { props: base() });
+
+    await expect.poll(() => selectedRepo()).toBe("visible");
+  });
+
+  it("Alt+] cycle steps over a hidden repo instead of surfacing it", async () => {
+    const a: RepoEntry = { name: "aaa", path: "/repo/hh-cyc-a", display: "aaa" };
+    const hidden: RepoEntry = {
+      name: "hhh",
+      path: "/repo/hh-cyc-hidden",
+      display: "hhh",
+      hidden: true,
+    };
+    const c: RepoEntry = { name: "ccc", path: "/repo/hh-cyc-c", display: "ccc" };
+    mockListRepos.mockResolvedValue({ repos: [a, hidden, c], recentWindowDays: 30 });
+    render(NewTask, { props: base({ initialRepoPath: a.path }) });
+
+    await expect.poll(() => selectedRepo()).toBe("aaa");
+    altChord("BracketRight");
+    // The cycle skips the hidden "hhh" between aaa and ccc and lands on ccc.
+    await expect.poll(() => selectedRepo()).toBe("ccc");
+  });
+
+  it("Alt+1 digit shortcut never targets a hidden repo", async () => {
+    const secret: RepoEntry = {
+      name: "secret",
+      path: "/repo/hh-dig-secret",
+      display: "secret",
+      recentAgentCount: 9, // would be the #1 recent if not hidden
+      hidden: true,
+    };
+    const realtop: RepoEntry = {
+      name: "realtop",
+      path: "/repo/hh-dig-top",
+      display: "realtop",
+      recentAgentCount: 5,
+    };
+    const other: RepoEntry = { name: "other", path: "/repo/hh-dig-other", display: "other" };
+    mockListRepos.mockResolvedValue({ repos: [secret, realtop, other], recentWindowDays: 30 });
+    render(NewTask, { props: base({ initialRepoPath: other.path }) });
+
+    await expect.poll(() => selectedRepo()).toBe("other");
+    altChord("Digit1");
+    // Alt+1 = first NON-hidden recent (realtop), never the higher-count hidden "secret".
+    await expect.poll(() => selectedRepo()).toBe("realtop");
+  });
+});

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -570,8 +570,13 @@
     const n = list.length;
     if (n === 0) return;
     const cur = list.findIndex((r) => r.path === repoPath);
-    const i = cur === -1 ? 0 : cur;
-    repoPath = list[(i + dir + n) % n]!.path;
+    // Current repo hidden (cur === -1): enter the visible subset at its boundary — the
+    // first repo on a forward step, the last on a backward step — so neither end is skipped.
+    if (cur === -1) {
+      repoPath = list[dir === 1 ? 0 : n - 1]!.path;
+      return;
+    }
+    repoPath = list[(cur + dir + n) % n]!.path;
   }
 
   // Alt-tier repo switchers, keyed on physical e.code so they work on any layout

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -275,7 +275,11 @@
       .then(({ repos: r, recentWindowDays }) => {
         repos = r;
         recentRepoWindowDays = recentWindowDays;
-        if (!repoPath && r.length > 0) repoPath = defaultRepoPath(r);
+        // Prefer the most-recently-used NON-hidden repo so the picker never opens
+        // pre-selected on a hidden repo; if every repo is hidden, fall back to the full
+        // list so repoPath is never left empty.
+        if (!repoPath && r.length > 0)
+          repoPath = defaultRepoPath(r.filter((repo) => !repo.hidden)) || r[0]!.path;
       })
       .catch(() => {});
     // Focus the prompt so the user can type immediately when the dialog opens.
@@ -560,11 +564,14 @@
   }
 
   function cycleRepo(dir: 1 | -1) {
-    const n = repos.length;
+    // Cycle only the non-hidden subset so Alt+[/] can never surface a hidden repo in the
+    // trigger label. If the current repo is hidden (cur === -1) we enter the visible subset.
+    const list = repos.filter((r) => !r.hidden);
+    const n = list.length;
     if (n === 0) return;
-    const cur = repos.findIndex((r) => r.path === repoPath);
+    const cur = list.findIndex((r) => r.path === repoPath);
     const i = cur === -1 ? 0 : cur;
-    repoPath = repos[(i + dir + n) % n]!.path;
+    repoPath = list[(i + dir + n) % n]!.path;
   }
 
   // Alt-tier repo switchers, keyed on physical e.code so they work on any layout
@@ -587,7 +594,9 @@
       case "Digit1":
       case "Digit2":
       case "Digit3": {
-        const target = recentRepos(repos)[Number(e.code.slice(5)) - 1];
+        // Filter hidden BEFORE recentRepos' top-N slice so the digit index matches the
+        // picker's pinned recents group exactly (shared single source of truth).
+        const target = recentRepos(repos.filter((r) => !r.hidden))[Number(e.code.slice(5)) - 1];
         if (target) repoPath = target.path; // out of range → no selection change
         break; // still swallow the chord below
       }
@@ -796,6 +805,7 @@
           {onnewproject}
           onsync={handleSync}
           onescape={() => promptInput?.focus()}
+          hideHidden
         />
       </div>
 

--- a/ui/src/lib/components/RepoSelect.browser.test.ts
+++ b/ui/src/lib/components/RepoSelect.browser.test.ts
@@ -89,3 +89,64 @@ describe("RepoSelect — keyboard cursor on open", () => {
     await expect.element(firstOption).toHaveTextContent("alpha");
   });
 });
+
+describe("RepoSelect — hideHidden", () => {
+  // "secret" has the highest recentAgentCount, so without hiding it would lead the pinned
+  // recents group; it must be absent from BOTH the recents and the main list by default.
+  function makeReposWithHidden(): RepoEntry[] {
+    return [
+      { name: "alpha", path: "/repos/alpha", display: "~/repos/alpha", recentAgentCount: 5 },
+      { name: "beta", path: "/repos/beta", display: "~/repos/beta", recentAgentCount: 3 },
+      {
+        name: "secret",
+        path: "/repos/secret",
+        display: "~/repos/secret",
+        recentAgentCount: 9,
+        hidden: true,
+      },
+    ];
+  }
+
+  it("omits hidden repos from the default list and recents when hideHidden is on", async () => {
+    render(RepoSelect, {
+      repos: makeReposWithHidden(),
+      value: "/repos/alpha",
+      onchange: noop,
+      windowDays: 7,
+      hideHidden: true,
+    });
+
+    await page.getByRole("button", { name: /alpha/ }).click();
+    // Wait for the dropdown to render before asserting absence.
+    await expect.element(page.getByRole("option").first()).toBeVisible();
+    expect(page.getByRole("option", { name: /secret/ }).elements()).toHaveLength(0);
+  });
+
+  it("reveals a hidden repo once its name is searched", async () => {
+    render(RepoSelect, {
+      repos: makeReposWithHidden(),
+      value: "/repos/alpha",
+      onchange: noop,
+      windowDays: 7,
+      hideHidden: true,
+    });
+
+    await page.getByRole("button", { name: /alpha/ }).click();
+    await page.getByPlaceholder(m.reposelect_filter_placeholder()).fill("secret");
+
+    const revealed = page.getByRole("option", { name: /secret/ });
+    await expect.element(revealed).toBeVisible();
+  });
+
+  it("keeps hidden repos visible when hideHidden is off (other consumers unaffected)", async () => {
+    render(RepoSelect, {
+      repos: makeReposWithHidden(),
+      value: "/repos/alpha",
+      onchange: noop,
+      windowDays: 7,
+    });
+
+    await page.getByRole("button", { name: /alpha/ }).click();
+    await expect.element(page.getByRole("option", { name: /secret/ }).first()).toBeVisible();
+  });
+});

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -18,6 +18,7 @@
     onsync,
     windowDays,
     onescape,
+    hideHidden = false,
   }: {
     repos: RepoEntry[];
     value: string;
@@ -33,6 +34,10 @@
     /** Invoked when an open panel is dismissed via Escape, so the parent can restore
      *  focus — e.g. NewTask refocuses its prompt. */
     onescape?: () => void;
+    /** Opt-in: drop repos flagged `hidden` from the default list + recents, but reveal
+     *  them once a name search matches. Off by default so the other (backlog/steers/card)
+     *  RepoSelect consumers are unaffected. */
+    hideHidden?: boolean;
   } = $props();
 
   let open = $state(false);
@@ -73,16 +78,32 @@
       : m.reposelect_recent_agents_other({ count, days: windowDays });
   }
 
+  // Selected-row lookup stays over the FULL list so an already-selected (e.g. relaunch-
+  // seeded) repo still renders in the trigger label even when hideHidden drops it from
+  // the dropdown.
   const selected = $derived(repos.find((r) => r.path === value) ?? null);
 
+  // Active search term — drives reveal-on-search: with hideHidden on, hidden repos are
+  // absent from the empty-search list but reappear once a matching term is typed.
+  const searching = $derived(filter.trim() !== "");
+
   const filtered = $derived(
-    repos.filter((r) => (r.name + " " + r.display).toLowerCase().includes(filter.toLowerCase())),
+    repos
+      // Hide flagged repos only while not searching; typing a name reveals them so a
+      // hidden repo can still be picked to start a task.
+      .filter((r) => !hideHidden || searching || !r.hidden)
+      .filter((r) => (r.name + " " + r.display).toLowerCase().includes(filter.toLowerCase())),
   );
 
   // The top few repos we've run the most agents on lately (desc by count, then by
   // most-recently-used). Only shown when the list isn't being filtered — once the
   // user types, the shortcut just gets in the way of the search they asked for.
-  const recents = $derived(filter.trim() === "" ? recentRepos(repos) : []);
+  // Filter hidden BEFORE recentRepos' top-N slice so the pinned rows stay index-aligned
+  // with NewTask's Alt+digit shortcut (which filters before too) — recentRepos is the
+  // single source of truth for both (see recentRepos.ts).
+  const recents = $derived(
+    searching ? [] : recentRepos(hideHidden ? repos.filter((r) => !r.hidden) : repos),
+  );
 
   // Single option sequence the keyboard cursor walks: pinned recents first, then the
   // full list. Pinned repos intentionally re-appear below — the group is a shortcut,

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1875,4 +1875,15 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_scratchpad_upload_body",
     targetId: "scratchpad-upload",
   },
+  {
+    // Hidden repos are now dropped from the New Task repo picker (default list + recents
+    // + Alt cycle/digit shortcuts) and revealed only on name search. targetId "nt-repo"
+    // is the existing coachmark anchor on the repo field in NewTask.svelte, so the
+    // coachmark points at the picker when the New Task dialog is open. Ships in 1.39.0.
+    id: "newtask-hide-hidden-repos",
+    sinceVersion: "1.39.0",
+    titleKey: "feat_newtask_hide_hidden_title",
+    bodyKey: "feat_newtask_hide_hidden_body",
+    targetId: "nt-repo",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -35,6 +35,9 @@ export interface RepoEntry {
   /** True when the repo is a fork (origin = fork, upstream = original) — the repo
    *  picker shows a "Sync fork" action on these. Absent/false ⇒ not a fork. */
   isFork?: boolean;
+  /** True when the repo is flagged hidden (RepoConfig.hidden). The New Task picker
+   *  hides these by default but reveals them on name search. Absent/false ⇒ visible. */
+  hidden?: boolean;
 }
 
 export interface Settings {


### PR DESCRIPTION
## What

Repos flagged **hidden** (`RepoConfig.hidden` — the same flag the Backlog repos panel already honors) no longer clutter the **New Task** repo picker. They're dropped from the default list, the recents shortcut, and the keyboard selection paths — but **reappear the moment a name search matches**, so a hidden repo is always one keystroke away when you actually need it.

## Why

The Backlog already declutters via `hidden`, but the New Task picker showed every repo. This brings the picker in line while keeping hidden repos reachable (you can still start a task on one by searching for it).

## How

- **Server** (`src/server.ts`): `GET /api/repos` now marks each repo with `hidden`, reconciling the persisted hidden set realpath→raw exactly as the Backlog payload does (`reconcileRealPathsToRaw`), so a hide matches its repo even under a symlinked root.
- **`RepoSelect.svelte`**: new **opt-in** `hideHidden` prop (default `false`). When on: hidden repos are excluded from the default list + pinned recents, and revealed on name search. Default-off means the four other `RepoSelect` consumers (Backlog, SteersEditor, CardMenu, …) are untouched.
- **`NewTask.svelte`**: passes `hideHidden`, and excludes hidden repos from every path that bypasses the dropdown's filtering — `defaultRepoPath` (with a full-list fallback so `repoPath` is never left empty when *all* repos are hidden), the Alt+[ / Alt+] cycle, and the Alt+1/2/3 digit shortcut. Recents are filtered **before** `recentRepos`' top-N slice in both the picker and the digit shortcut, so the pinned rows stay index-aligned with the digit keys (single source of truth preserved).
- Types: `RepoEntry` gains optional `hidden?: boolean`.
- Feature discovery: one `feature-announcements.ts` entry (`1.39.0`, anchored to the repo field) + EN/DE message keys.

## Tests

- `RepoSelect.browser.test.ts`: hidden omitted by default, revealed on search, and still shown when `hideHidden` is off.
- `NewTask.browser.test.ts`: default selection skips a hidden (most-recently-used) repo; Alt+] cycle steps over a hidden repo; Alt+1 never targets a higher-count hidden repo.
- Green: root lint + `bun test ./test` (5507), UI `check` + `check:i18n` + full vitest suite (2338).

🤖 Generated with [Claude Code](https://claude.com/claude-code)