### PR TITLE
feat(usage): add Timeline tab — day×hour token-usage heatmap

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -85,6 +85,7 @@ import { computeDiff } from "./diff";
 import { resolveDiffBase } from "./diff-base";
 import { sessionTokens, jsonlPathFor, type SessionUsageRollup } from "./usage";
 import { buildUsageBreakdown } from "./usage-breakdown";
+import { buildUsageTimeline } from "./usage-timeline";
 import { isApiKeyMode } from "./spawn-auth";
 import { detectDevCommand } from "./preview";
 import { sessionActivity } from "./activity";
@@ -3076,6 +3077,26 @@ async function handleUsageBreakdown({ req, parts, url, deps }: Ctx): Promise<Res
   return json(breakdown);
 }
 
+async function handleUsageTimeline({ req, parts, url, deps }: Ctx): Promise<Response | null> {
+  if (!(
+    req.method === "GET" &&
+    parts[0] === "api" &&
+    parts[1] === "usage" &&
+    parts[2] === "timeline"
+  ))
+    return null;
+  const raw = url.searchParams.get("range") ?? "7d";
+  if (raw !== "24h" && raw !== "7d" && raw !== "30d" && raw !== "all")
+    return json({ error: "invalid range" }, 400);
+  const timeline = await buildUsageTimeline({
+    store: deps.store,
+    range: raw,
+    now: Date.now(),
+    usageRollup: deps.usageRollup,
+  });
+  return json(timeline);
+}
+
 // ── self-update: status + trigger ──────────────────────────────────────
 function updateStatus(deps: AppDeps): Response {
   return json(
@@ -5552,6 +5573,7 @@ const ROUTE_HANDLERS = [
   handleSessionGit,
   handleUsageLimits,
   handleUsageBreakdown,
+  handleUsageTimeline,
   handleUpdate,
   handleHerdrUpdate,
   handleCodexUpdate,

--- a/src/store.ts
+++ b/src/store.ts
@@ -4403,6 +4403,25 @@ export class SessionStore implements CapStore, CreditStore {
     return result;
   }
 
+  /** Sum weighted units per hour across ALL sessions' persisted buckets, for the timeline.
+   *  Selects rows WHERE bucketStart >= floorHour(cutoff) AND bucketStart != 0 (the timeless
+   *  bucket has no placeable hour). cutoff===0 ⇒ all timestamped buckets. Returns a map keyed
+   *  by bucketStart (ms-epoch hour) → Σ weightedUnits. */
+  sumUsageUnitsByHourSince(cutoff: number): Map<number, number> {
+    const floorHour = cutoff - (cutoff % 3_600_000);
+    const rows = this.db
+      .query(
+        `SELECT bucketStart, SUM(weightedUnits) AS units
+         FROM session_usage_bucket
+         WHERE bucketStart != 0 AND bucketStart >= ?
+         GROUP BY bucketStart`,
+      )
+      .all(floorHour) as { bucketStart: number; units: number }[];
+    const result = new Map<number, number>();
+    for (const row of rows) result.set(row.bucketStart, row.units);
+    return result;
+  }
+
   /** Distinct sessionIds that have at least one bucket row. */
   bucketedSessionIds(): Set<string> {
     const rows = this.db.query(`SELECT DISTINCT sessionId FROM session_usage_bucket`).all() as {

--- a/src/store.ts
+++ b/src/store.ts
@@ -4406,19 +4406,22 @@ export class SessionStore implements CapStore, CreditStore {
   /** Sum weighted units per hour across ALL sessions' persisted buckets, for the timeline.
    *  Selects rows WHERE bucketStart >= floorHour(cutoff) AND bucketStart != 0 (the timeless
    *  bucket has no placeable hour). cutoff===0 ⇒ all timestamped buckets. Returns a map keyed
-   *  by bucketStart (ms-epoch hour) → Σ weightedUnits. */
+   *  by bucketStart (ms-epoch hour) → Σ weightedUnits.
+   *  Folds in JS (no SQL SUM) so float math matches archive-time folding, exactly as
+   *  sumSessionUsageBucketsSince does. */
   sumUsageUnitsByHourSince(cutoff: number): Map<number, number> {
     const floorHour = cutoff - (cutoff % 3_600_000);
     const rows = this.db
       .query(
-        `SELECT bucketStart, SUM(weightedUnits) AS units
+        `SELECT bucketStart, weightedUnits
          FROM session_usage_bucket
-         WHERE bucketStart != 0 AND bucketStart >= ?
-         GROUP BY bucketStart`,
+         WHERE bucketStart != 0 AND bucketStart >= ?`,
       )
-      .all(floorHour) as { bucketStart: number; units: number }[];
+      .all(floorHour) as { bucketStart: number; weightedUnits: number }[];
     const result = new Map<number, number>();
-    for (const row of rows) result.set(row.bucketStart, row.units);
+    for (const row of rows) {
+      result.set(row.bucketStart, (result.get(row.bucketStart) ?? 0) + row.weightedUnits);
+    }
     return result;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -862,6 +862,22 @@ export interface UsageBreakdown {
   repos: UsageRepoBreakdown[];
 }
 
+// One hour of weighted-unit consumption — mirror of UsageTimelineHour in ui/src/lib/types.ts.
+export interface UsageTimelineHour {
+  hourStart: number; // ms epoch, floored to the hour (UTC boundary); never 0 (timeless rows excluded)
+  units: number; // weighted units consumed in that hour (authoring + live + satellite)
+}
+
+// GET /api/usage/timeline response — mirror of UsageTimeline in ui/src/lib/types.ts.
+// `hours` is ASC by hourStart, non-empty hours only; totalUnits/peakHourUnits span the full range.
+export interface UsageTimeline {
+  range: UsageRange;
+  generatedAt: number;
+  hours: UsageTimelineHour[];
+  totalUnits: number;
+  peakHourUnits: number;
+}
+
 // Runtime key-lists — drift sentinels (TS types vanish at runtime).
 // Mirrors UsageTokens:
 export const USAGE_TOKENS_KEYS = ["input", "output", "cacheRead", "cacheWrite"] as const;
@@ -900,6 +916,16 @@ export const USAGE_BREAKDOWN_KEYS = [
   "satelliteByKind",
   "dollars",
   "repos",
+] as const;
+// Mirrors UsageTimelineHour:
+export const USAGE_TIMELINE_HOUR_KEYS = ["hourStart", "units"] as const;
+// Mirrors UsageTimeline:
+export const USAGE_TIMELINE_KEYS = [
+  "range",
+  "generatedAt",
+  "hours",
+  "totalUnits",
+  "peakHourUnits",
 ] as const;
 
 // ── per-session hold reason ("Why parked?") ──────────────────────────────────

--- a/src/usage-timeline.ts
+++ b/src/usage-timeline.ts
@@ -1,0 +1,124 @@
+import type { SessionStore } from "./store";
+import type { UsageRange, UsageTimeline, UsageTimelineHour } from "./types";
+import { isOperationalArchetype } from "./usage-archetype";
+import { floorHour, type SessionUsageRollup } from "./usage";
+import { weightedUnits } from "./pricing";
+
+/** Compute the ms-epoch cutoff for the given range (0 ⇒ all-time). Mirrors usage-breakdown. */
+function rangeCutoff(range: UsageRange, now: number): number {
+  if (range === "24h") return now - 86_400_000;
+  if (range === "7d") return now - 7 * 86_400_000;
+  if (range === "30d") return now - 30 * 86_400_000;
+  return 0;
+}
+
+/** Add `units` into `map` at hour key `h` (no-op for non-positive units). */
+function addHour(map: Map<number, number>, h: number, units: number): void {
+  if (units <= 0) return;
+  map.set(h, (map.get(h) ?? 0) + units);
+}
+
+/** Live rollup contribution: refresh, then fold each active, non-bucketed session's hours. */
+async function foldLiveSessions(
+  hourMap: Map<number, number>,
+  usageRollup: SessionUsageRollup,
+  eligible: ReturnType<SessionStore["list"]>,
+  bucketed: Set<string>,
+  cutoff: number,
+  now: number,
+): Promise<void> {
+  // Refresh here — nothing else does before this runs, so the Timeline tab would otherwise
+  // show stale/empty live data when opened before Spend/Overhead.
+  await usageRollup.refresh(
+    eligible.map((s) => ({
+      id: s.id,
+      worktreePath: s.worktreePath,
+      claudeSessionId: s.claudeSessionId,
+    })),
+    now,
+  );
+  for (const s of eligible) {
+    if (bucketed.has(s.id)) continue; // persisted wins — avoid double-counting
+    for (const [h, units] of usageRollup.hourlyUnits(s.id, cutoff)) addHour(hourMap, h, units);
+  }
+}
+
+/** Reviewer-spawn (satellite) contribution: fold finalized spawns by their completion hour. */
+function foldSpawns(hourMap: Map<number, number>, store: SessionStore, cutoff: number): void {
+  for (const sp of store.listReviewerSpawns()) {
+    if (sp.totalTokens == null) continue; // not finalized
+    const t = sp.completedAt ?? sp.spawnedAt;
+    if (t === 0 || t < cutoff) continue; // timeless or out of window
+    const wu = weightedUnits(
+      {
+        input: sp.inputTokens ?? 0,
+        output: sp.outputTokens ?? 0,
+        cacheRead: sp.cacheReadTokens ?? 0,
+        cacheWrite5m: sp.cacheWriteTokens ?? 0,
+        cacheWrite1h: 0,
+      },
+      sp.model ?? "unknown",
+    );
+    addHour(hourMap, floorHour(t), wu);
+  }
+}
+
+/** Collapse the hour→units map into the public timeline shape (ASC hours, totals, peak). */
+function summarize(hourMap: Map<number, number>): {
+  hours: UsageTimelineHour[];
+  totalUnits: number;
+  peakHourUnits: number;
+} {
+  const hours: UsageTimelineHour[] = [...hourMap.entries()]
+    .map(([hourStart, units]) => ({ hourStart, units }))
+    .sort((a, b) => a.hourStart - b.hourStart);
+  let totalUnits = 0;
+  let peakHourUnits = 0;
+  for (const h of hours) {
+    totalUnits += h.units;
+    if (h.units > peakHourUnits) peakHourUnits = h.units;
+  }
+  return { hours, totalUnits, peakHourUnits };
+}
+
+/**
+ * Per-hour weighted-unit timeline for the Timeline lens's day×hour heatmap.
+ *
+ * Sources, deduped the same way as buildUsageBreakdown ("persisted wins"):
+ *  - persisted hourly buckets across all archived/snapshotted sessions (store),
+ *  - live SessionUsageRollup hours for active eligible sessions NOT yet bucketed,
+ *  - finalized reviewer spawns, bucketed by their own completedAt ?? spawnedAt.
+ *
+ * The rollup is refreshed here because nothing else does it before this runs — without it the
+ * Timeline tab would show stale/empty live data when opened before Spend/Overhead.
+ *
+ * Timeless data (bucketStart/ts/spawn-time === 0) is excluded — it has no placeable hour.
+ */
+export async function buildUsageTimeline(opts: {
+  store: SessionStore;
+  range: UsageRange;
+  now: number;
+  usageRollup?: SessionUsageRollup;
+}): Promise<UsageTimeline> {
+  const { store, range, now } = opts;
+  const cutoff = rangeCutoff(range, now);
+
+  // 1. Persisted hourly buckets (archived/snapshotted sessions).
+  const hourMap = store.sumUsageUnitsByHourSince(cutoff);
+
+  // 2. Live rollup — active sessions not yet bucketed (refreshed inside the helper).
+  const bucketed = store.bucketedSessionIds();
+  const eligible = store
+    .list({ activeOnly: true })
+    .filter((s) => s.claudeSessionId && !isOperationalArchetype(s));
+  if (opts.usageRollup) {
+    await foldLiveSessions(hourMap, opts.usageRollup, eligible, bucketed, cutoff, now);
+  }
+
+  // 3. Reviewer spawns (satellite passes) — by their own completion time, the same timestamp
+  //    axis satelliteUnitsByKind uses, so the timeline total tracks the Spend tab.
+  foldSpawns(hourMap, store, cutoff);
+
+  // 4. Emit ASC, non-empty hours only; totals span the full range.
+  return { range, generatedAt: now, ...summarize(hourMap) };
+}

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -343,7 +343,7 @@ export class AccountUsageIndex {
 // ── Session bucket fold ───────────────────────────────────────────────────────
 
 /** floor-hour: truncate ms-epoch to the start of its UTC hour. ts=0 → 0. */
-function floorHour(ts: number): number {
+export function floorHour(ts: number): number {
   return ts - (ts % 3_600_000);
 }
 
@@ -685,5 +685,22 @@ export class SessionUsageRollup {
       dominantModel: dominantModelOf(rawByModel),
       messageCount,
     };
+  }
+
+  /** Per-hour weighted units for one session's in-window records, keyed by floorHour(ts).
+   *  Timeless records (ts=0) are excluded — they have no placeable hour, so they cannot sit on
+   *  a timeline. cutoff===0 ⇒ every timestamped record; cutoff>0 ⇒ records with ts>=cutoff.
+   *  Returns an empty map for an unknown session. Feeds buildUsageTimeline's live contribution. */
+  hourlyUnits(sessionId: string, cutoff: number): Map<number, number> {
+    const out = new Map<number, number>();
+    const st = this.sessions.get(sessionId);
+    if (!st) return out;
+    for (const rec of st.records) {
+      if (rec.ts === 0) continue; // timeless — not placeable on a timeline
+      if (rec.ts < cutoff) continue; // out of window (cutoff===0 keeps all ts>0)
+      const h = floorHour(rec.ts);
+      out.set(h, (out.get(h) ?? 0) + rec.weighted);
+    }
+    return out;
   }
 }

--- a/test/server-usage-timeline.test.ts
+++ b/test/server-usage-timeline.test.ts
@@ -1,0 +1,95 @@
+import { test, expect } from "bun:test";
+import { makeApp, type AppDeps } from "../src/server";
+import { SessionStore } from "../src/store";
+import { EventHub } from "../src/events";
+import { USAGE_TIMELINE_KEYS, USAGE_TIMELINE_HOUR_KEYS } from "../src/types";
+import type { SessionUsageSnapshot } from "../src/types";
+
+function harness(): { app: ReturnType<typeof makeApp>; store: SessionStore } {
+  const store = new SessionStore(":memory:");
+  const deps: AppDeps = {
+    store,
+    service: {} as any,
+    events: new EventHub(),
+    usageLimits: { limits: () => ({}) } as any,
+  };
+  return { app: makeApp(deps), store };
+}
+
+function exactKeys(obj: object, keys: readonly string[]): void {
+  expect(Object.keys(obj).sort()).toEqual([...keys].sort());
+}
+
+const NOW = Date.now();
+const HOUR = 3_600_000;
+
+function seedHour(store: SessionStore, sessionId: string, units: number): number {
+  const hour = NOW - HOUR - ((NOW - HOUR) % HOUR);
+  const snap: SessionUsageSnapshot = {
+    sessionId,
+    desig: "TASK-01",
+    name: "feat",
+    repoPath: "/repos/x",
+    model: "claude-opus-4-8",
+    input: 1,
+    output: 1,
+    cacheRead: 0,
+    cacheWrite: 0,
+    total: 2,
+    weightedUnits: units,
+    cacheReadUnits: 0,
+    messageCount: 1,
+    byModel: { "claude-opus-4-8": units },
+    createdAt: NOW - 2 * HOUR,
+    archivedAt: NOW - 500,
+    snapshotAt: NOW - 500,
+  };
+  store.upsertSessionUsage(snap);
+  store.replaceSessionUsageBuckets(sessionId, [
+    {
+      sessionId,
+      bucketStart: hour,
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      weightedUnits: units,
+      cacheReadUnits: 0,
+      byModel: { "claude-opus-4-8": units },
+    },
+  ]);
+  return hour;
+}
+
+test("GET /api/usage/timeline?range=7d → 200 with correct shape", async () => {
+  const { app, store } = harness();
+  const hour = seedHour(store, "sess-1", 0.5);
+
+  const res = await app.fetch(new Request("http://x/api/usage/timeline?range=7d"));
+  expect(res.status).toBe(200);
+
+  const body = await res.json();
+  exactKeys(body, USAGE_TIMELINE_KEYS);
+  expect(body.range).toBe("7d");
+  expect(Array.isArray(body.hours)).toBe(true);
+  expect(body.hours).toHaveLength(1);
+  exactKeys(body.hours[0], USAGE_TIMELINE_HOUR_KEYS);
+  expect(body.hours[0].hourStart).toBe(hour);
+  expect(body.hours[0].units).toBeCloseTo(0.5, 9);
+  expect(body.totalUnits).toBeCloseTo(0.5, 9);
+  expect(body.peakHourUnits).toBeCloseTo(0.5, 9);
+});
+
+test("GET /api/usage/timeline (no range) → defaults to 7d", async () => {
+  const { app } = harness();
+  const res = await app.fetch(new Request("http://x/api/usage/timeline"));
+  expect(res.status).toBe(200);
+  expect((await res.json()).range).toBe("7d");
+});
+
+test("GET /api/usage/timeline?range=bogus → 400", async () => {
+  const { app } = harness();
+  const res = await app.fetch(new Request("http://x/api/usage/timeline?range=bogus"));
+  expect(res.status).toBe(400);
+  expect((await res.json()).error).toBe("invalid range");
+});

--- a/test/usage-timeline.test.ts
+++ b/test/usage-timeline.test.ts
@@ -1,0 +1,236 @@
+import { test, expect } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { SessionStore } from "../src/store";
+import { buildUsageTimeline } from "../src/usage-timeline";
+import { SessionUsageRollup, floorHour } from "../src/usage";
+import { weightedUnits } from "../src/pricing";
+import type { SessionUsageBucket, SessionUsageSnapshot } from "../src/types";
+
+const NOW = 1_750_000_000_000; // fixed epoch ms
+const HOUR = 3_600_000;
+const H24 = 86_400_000;
+const MODEL = "claude-opus-4-8";
+
+function wu(input: number, output: number): number {
+  return weightedUnits({ input, output, cacheRead: 0, cacheWrite5m: 0, cacheWrite1h: 0 }, MODEL);
+}
+
+/** Upsert a parent session_usage row (FK target) + its hourly bucket rows. */
+function seedBuckets(
+  store: SessionStore,
+  sessionId: string,
+  repoPath: string,
+  buckets: Omit<SessionUsageBucket, "sessionId">[],
+): void {
+  const snap: SessionUsageSnapshot = {
+    sessionId,
+    desig: `T-${sessionId}`,
+    name: sessionId,
+    repoPath,
+    model: MODEL,
+    input: 1,
+    output: 1,
+    cacheRead: 0,
+    cacheWrite: 0,
+    total: 2,
+    weightedUnits: 0,
+    cacheReadUnits: 0,
+    messageCount: 1,
+    byModel: { [MODEL]: 0 },
+    createdAt: NOW - H24,
+    archivedAt: NOW - 500,
+    snapshotAt: NOW - 500,
+  };
+  store.upsertSessionUsage(snap);
+  store.replaceSessionUsageBuckets(
+    sessionId,
+    buckets.map((b) => ({ ...b, sessionId })),
+  );
+}
+
+function bucket(bucketStart: number, units: number): Omit<SessionUsageBucket, "sessionId"> {
+  return {
+    bucketStart,
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    weightedUnits: units,
+    cacheReadUnits: 0,
+    byModel: { [MODEL]: units },
+  };
+}
+
+class TestRollup extends SessionUsageRollup {
+  constructor(private dir: string) {
+    super();
+  }
+  protected override pathFor(_worktreePath: string, claudeSessionId: string): string {
+    return join(this.dir, `${claudeSessionId}.jsonl`);
+  }
+}
+
+function asstLine(ts: number, input: number, output: number, requestId: string): string {
+  return JSON.stringify({
+    type: "assistant",
+    timestamp: new Date(ts).toISOString(),
+    requestId,
+    message: {
+      model: MODEL,
+      usage: {
+        input_tokens: input,
+        output_tokens: output,
+        cache_read_input_tokens: 0,
+        cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 0 },
+      },
+    },
+  });
+}
+
+// ── persisted buckets: cross-session aggregation, cutoff, timeless exclusion ────
+
+test("persisted buckets aggregate per hour across sessions; bucketStart=0 excluded", async () => {
+  const store = new SessionStore(":memory:");
+  const sharedHour = floorHour(NOW - HOUR); // both sessions active this hour
+  const otherHour = floorHour(NOW - 2 * HOUR);
+
+  seedBuckets(store, "s1", "/repos/a", [
+    bucket(sharedHour, wu(100, 50)),
+    bucket(otherHour, wu(40, 10)),
+    bucket(0, wu(999, 999)), // timeless — must be excluded from the timeline
+  ]);
+  seedBuckets(store, "s2", "/repos/b", [bucket(sharedHour, wu(200, 60))]);
+
+  const tl = await buildUsageTimeline({ store, range: "all", now: NOW });
+
+  // Two distinct hours (timeless dropped), ASC.
+  expect(tl.hours.map((h) => h.hourStart)).toEqual([otherHour, sharedHour]);
+
+  // sharedHour sums s1 + s2.
+  const shared = tl.hours.find((h) => h.hourStart === sharedHour)!;
+  expect(shared.units).toBeCloseTo(wu(100, 50) + wu(200, 60), 9);
+
+  // totals span the (non-timeless) hours; peak is the bigger hour.
+  expect(tl.totalUnits).toBeCloseTo(wu(40, 10) + wu(100, 50) + wu(200, 60), 9);
+  expect(tl.peakHourUnits).toBeCloseTo(wu(100, 50) + wu(200, 60), 9);
+});
+
+test("range cutoff drops hours older than the window", async () => {
+  const store = new SessionStore(":memory:");
+  const recentHour = floorHour(NOW - HOUR); // inside 24h
+  const oldHour = floorHour(NOW - 2 * H24); // outside 24h, inside 30d
+
+  seedBuckets(store, "s1", "/repos/a", [
+    bucket(recentHour, wu(100, 50)),
+    bucket(oldHour, wu(80, 20)),
+  ]);
+
+  const tl24 = await buildUsageTimeline({ store, range: "24h", now: NOW });
+  expect(tl24.hours.map((h) => h.hourStart)).toEqual([recentHour]);
+
+  const tl30 = await buildUsageTimeline({ store, range: "30d", now: NOW });
+  expect(tl30.hours.map((h) => h.hourStart)).toEqual([oldHour, recentHour]);
+});
+
+// ── satellite spawns fold in by completion hour ────────────────────────────────
+
+test("finalized reviewer spawns add units at floorHour(completedAt); unfinalized excluded", async () => {
+  const store = new SessionStore(":memory:");
+  const spawnHour = floorHour(NOW - HOUR);
+
+  store.recordReviewerSpawn({
+    reviewerSessionId: "rev-1",
+    taskSessionId: "task-a",
+    kind: "review",
+    worktreePath: "/wt",
+    model: MODEL,
+    spawnedAt: NOW - HOUR - 1000,
+  });
+  store.completeReviewerSpawn(
+    "rev-1",
+    {
+      input: 300,
+      output: 150,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 450,
+      messageCount: 1,
+      lastActivity: NOW - HOUR,
+      byModel: { [MODEL]: 450 },
+      fullRecaches: 0,
+      sidechainCount: 0,
+    },
+    NOW - HOUR, // completedAt → lands in spawnHour
+  );
+
+  // Unfinalized spawn (never completed) must be ignored.
+  store.recordReviewerSpawn({
+    reviewerSessionId: "rev-2",
+    taskSessionId: "task-b",
+    kind: "plan_gate",
+    worktreePath: "/wt",
+    model: MODEL,
+    spawnedAt: NOW - HOUR - 2000,
+  });
+
+  const tl = await buildUsageTimeline({ store, range: "all", now: NOW });
+  expect(tl.hours).toHaveLength(1);
+  expect(tl.hours[0]!.hourStart).toBe(spawnHour);
+  expect(tl.hours[0]!.units).toBeCloseTo(wu(300, 150), 9);
+});
+
+// ── live rollup: refresh + fold; persisted wins (no double count) ──────────────
+
+test("live rollup contributes hours for an active, non-bucketed session (refreshed in builder)", async () => {
+  const dir = join(tmpdir(), `usage-timeline-rollup-${NOW}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  try {
+    const store = new SessionStore(":memory:");
+    const csid = "live-csid";
+    const sess = store.create({
+      name: "TASK-LIVE",
+      prompt: "x",
+      repoPath: "/repos/live",
+      baseBranch: "main",
+      branch: "shepherd/live",
+      worktreePath: "/wt/live",
+      isolated: true,
+      herdrSession: "default",
+      herdrAgentId: "a1",
+      sandboxApplied: null,
+      sandboxDegraded: false,
+      egressApplied: false,
+      egressDegraded: false,
+      research: false,
+    });
+    // @ts-expect-error internal db access for test setup
+    store.db.run(`UPDATE sessions SET claudeSessionId = ? WHERE id = ?`, [csid, sess.id]);
+
+    const liveTs = NOW - HOUR; // inside 24h
+    await Bun.write(join(dir, `${csid}.jsonl`), asstLine(liveTs, 200, 80, "live-r1") + "\n");
+
+    const rollup = new TestRollup(dir);
+    // Builder must refresh the rollup itself (nothing else does before this runs).
+    const tl = await buildUsageTimeline({ store, range: "24h", now: NOW, usageRollup: rollup });
+
+    expect(tl.hours).toHaveLength(1);
+    expect(tl.hours[0]!.hourStart).toBe(floorHour(liveTs));
+    expect(tl.hours[0]!.units).toBeCloseTo(wu(200, 80), 9);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── empty ──────────────────────────────────────────────────────────────────────
+
+test("no data → empty hours, zero totals", async () => {
+  const store = new SessionStore(":memory:");
+  const tl = await buildUsageTimeline({ store, range: "7d", now: NOW });
+  expect(tl.hours).toEqual([]);
+  expect(tl.totalUnits).toBe(0);
+  expect(tl.peakHourUnits).toBe(0);
+  expect(tl.range).toBe("7d");
+  expect(tl.generatedAt).toBe(NOW);
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1760,6 +1760,15 @@
   "usage_page_title": "Nutzung",
   "usage_spend_tab": "Verbrauch",
   "usage_overhead_tab": "Overhead",
+  "usage_timeline_tab": "Verlauf",
+  "usage_timeline_heading": "Verbrauch über Zeit",
+  "usage_timeline_peak": "Spitze {units}/h",
+  "usage_timeline_total": "gesamt {units}",
+  "usage_timeline_legend_low": "niedrig",
+  "usage_timeline_legend_high": "hoch",
+  "usage_timeline_empty": "In diesem Zeitraum noch kein Verbrauch erfasst",
+  "usage_timeline_more_days": "+{count} frühere Tage nicht angezeigt",
+  "usage_timeline_cell_aria": "{day} {hour}: {units} gewichtete Einheiten",
   "usage_limits_tab": "Limits",
   "usage_range_label": "Zeitraum",
   "usage_range_24h": "24h",
@@ -2204,5 +2213,7 @@
   "feat_scratchpad_upload_body": "Du kannst jetzt direkt aus dem Dateien-Tab Dateien in das Scratchpad einer Session laden - per Klick auf Hochladen oder per Drag-and-drop. Der Agent kann alles lesen, was du dort ablegst.",
   "files_list_aria": "Scratchpad-Dateien",
   "feat_newtask_hide_hidden_title": "Ausgeblendete Repos bleiben aus der Neue-Aufgabe-Auswahl",
-  "feat_newtask_hide_hidden_body": "Repos, die du ausgeblendet hast, überladen die Repo-Auswahl beim Start einer neuen Aufgabe nicht mehr. Sie verschwinden aus der Liste und den Zuletzt-verwendet-Kürzeln, erscheinen aber sofort, sobald du nach ihrem Namen suchst - ein ausgeblendetes Repo ist also bei Bedarf immer nur einen Tastendruck entfernt."
+  "feat_newtask_hide_hidden_body": "Repos, die du ausgeblendet hast, überladen die Repo-Auswahl beim Start einer neuen Aufgabe nicht mehr. Sie verschwinden aus der Liste und den Zuletzt-verwendet-Kürzeln, erscheinen aber sofort, sobald du nach ihrem Namen suchst - ein ausgeblendetes Repo ist also bei Bedarf immer nur einen Tastendruck entfernt.",
+  "feat_usage_timeline_title": "Verfolge deinen Token-Verbrauch über die Zeit",
+  "feat_usage_timeline_body": "Das Nutzungs-Panel hat einen neuen Verlauf-Tab: eine Heatmap des Verbrauchs gewichteter Einheiten nach Tag und Stunde über den gewählten Zeitraum. Intensivere Stunden erscheinen dunkler, sodass du Phasen hohen und niedrigen Verbrauchs auf einen Blick erkennst - inklusive der Aktivität gerade laufender Sitzungen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1760,6 +1760,15 @@
   "usage_page_title": "Usage",
   "usage_spend_tab": "Spend",
   "usage_overhead_tab": "Overhead",
+  "usage_timeline_tab": "Timeline",
+  "usage_timeline_heading": "Usage over time",
+  "usage_timeline_peak": "peak {units}/h",
+  "usage_timeline_total": "total {units}",
+  "usage_timeline_legend_low": "low",
+  "usage_timeline_legend_high": "high",
+  "usage_timeline_empty": "No usage recorded in this range yet",
+  "usage_timeline_more_days": "+{count} earlier days not shown",
+  "usage_timeline_cell_aria": "{day} {hour}: {units} weighted units",
   "usage_limits_tab": "Limits",
   "usage_range_label": "Time range",
   "usage_range_24h": "24h",
@@ -2204,5 +2213,7 @@
   "feat_scratchpad_upload_body": "You can now upload files directly into a session's scratchpad from the Files tab — click Upload or drag-and-drop files onto the list. The agent can read anything you drop there.",
   "files_list_aria": "Scratchpad files",
   "feat_newtask_hide_hidden_title": "Hidden repos stay out of the New Task picker",
-  "feat_newtask_hide_hidden_body": "Repos you've hidden no longer clutter the repo picker when you start a new task. They're dropped from the list and the recents shortcuts, but still appear the moment you search for one by name — so a hidden repo is always one keystroke away when you need it."
+  "feat_newtask_hide_hidden_body": "Repos you've hidden no longer clutter the repo picker when you start a new task. They're dropped from the list and the recents shortcuts, but still appear the moment you search for one by name — so a hidden repo is always one keystroke away when you need it.",
+  "feat_usage_timeline_title": "See your token usage over time",
+  "feat_usage_timeline_body": "The Usage panel has a new Timeline tab: a day-by-hour heatmap of weighted-unit consumption across the selected range. Hotter hours read darker, so you can spot your high- and low-usage periods at a glance — including activity from sessions running right now."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -11,6 +11,7 @@ import type {
   UsageLimits,
   UsageLimitsResponse,
   UsageBreakdown,
+  UsageTimeline,
   UsageRange,
   GithubRateLimit,
   GitState,
@@ -656,6 +657,12 @@ export async function getUsageLimits(): Promise<UsageLimitsResponse> {
 export async function getUsageBreakdown(range: UsageRange): Promise<UsageBreakdown> {
   const r = await fetch(`/api/usage/breakdown?range=${range}`);
   if (!r.ok) throw await failed(r, "breakdown");
+  return r.json();
+}
+
+export async function getUsageTimeline(range: UsageRange): Promise<UsageTimeline> {
+  const r = await fetch(`/api/usage/timeline?range=${range}`);
+  if (!r.ok) throw await failed(r, "timeline");
   return r.json();
 }
 

--- a/ui/src/lib/components/Usage.browser.test.ts
+++ b/ui/src/lib/components/Usage.browser.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
-import type { UsageLimits, UsageProjection, UsageRange } from "$lib/types";
+import type { UsageLimits, UsageProjection, UsageRange, UsageTimeline } from "$lib/types";
 import { formatTokenLabel } from "$lib/format";
 import { m } from "$lib/paraglide/messages";
 import * as api from "$lib/api";
@@ -45,11 +45,23 @@ const inlineProjections: UsageProjection[] = [
   { window: "WK", projectedPct: 41, resetAt: BASE + 58 * H, burnRatePerHour: 31_000 },
 ];
 
+const inlineTimeline: UsageTimeline = {
+  range: "7d",
+  generatedAt: BASE,
+  hours: [
+    { hourStart: BASE - 2 * H - (BASE % H), units: 12 },
+    { hourStart: BASE - H - (BASE % H), units: 40 },
+  ],
+  totalUnits: 52,
+  peakHourUnits: 40,
+};
+
 // Mock the API so tests are deterministic and backend-independent.
 vi.mock("$lib/api", async () => {
   const { mockBreakdown } = await import("$lib/usage-mock");
   return {
     getUsageBreakdown: vi.fn((range: UsageRange) => Promise.resolve(mockBreakdown(range))),
+    getUsageTimeline: vi.fn((range: UsageRange) => Promise.resolve({ ...inlineTimeline, range })),
     getUsageLimits: vi.fn(() =>
       Promise.resolve({ limits: inlineLimits, projections: inlineProjections }),
     ),
@@ -114,6 +126,25 @@ describe("Usage modal component", () => {
     // Range selector must not be present on the Limits tab
     const rangeGroup = document.querySelector('[role="group"][aria-label]');
     expect(rangeGroup, "range selector hidden on Limits tab").toBeNull();
+  });
+
+  it("clicking the Timeline tab renders the heatmap and keeps the range selector", async () => {
+    render(Usage, { onclose: vi.fn() });
+
+    const timelineBtn = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
+      (b) => b.textContent?.trim() === m.usage_timeline_tab(),
+    );
+    expect(timelineBtn, "Timeline tab button exists").not.toBeNull();
+
+    timelineBtn!.click();
+
+    // The lazily-loaded heatmap appears: at least one day row with 24 hour cells.
+    await expect.poll(() => document.querySelectorAll(".tl-row").length).toBeGreaterThan(0);
+    expect(document.querySelectorAll(".tl-row .tl-cell").length).toBe(24);
+
+    // Timeline is a ranged tab — the range selector stays visible.
+    const rangeGroup = document.querySelector('[role="group"][aria-label]');
+    expect(rangeGroup, "range selector present on Timeline tab").not.toBeNull();
   });
 
   it("clicking the GitHub tab shows REST + GraphQL buckets and the GraphQL-paused banner", async () => {

--- a/ui/src/lib/components/Usage.svelte
+++ b/ui/src/lib/components/Usage.svelte
@@ -1,13 +1,19 @@
 <script lang="ts">
   import type {
     UsageBreakdown,
+    UsageTimeline,
     UsageLimits,
     UsageProjection,
     UsageRange,
     GithubRateLimit,
   } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
-  import { getUsageBreakdown, getUsageLimits, getGithubRateLimit } from "$lib/api";
+  import {
+    getUsageBreakdown,
+    getUsageTimeline,
+    getUsageLimits,
+    getGithubRateLimit,
+  } from "$lib/api";
   import { dialog } from "$lib/a11yDialog";
   import { formatTokenLabel } from "$lib/format";
   import { codexTokenUsage } from "$lib/components/usage-gauges";
@@ -15,15 +21,18 @@
   import OverheadLens from "$lib/components/usage/OverheadLens.svelte";
   import LimitsLens from "$lib/components/usage/LimitsLens.svelte";
   import GithubLens from "$lib/components/usage/GithubLens.svelte";
+  import TimelineLens from "$lib/components/usage/TimelineLens.svelte";
 
   let { onclose }: { onclose?: () => void } = $props();
 
-  type Tab = "spend" | "overhead" | "limits" | "github";
+  type Tab = "spend" | "overhead" | "timeline" | "limits" | "github";
 
   let tab = $state<Tab>("spend");
   let range = $state<UsageRange>("7d");
 
   let breakdown = $state<UsageBreakdown | null>(null);
+  let timeline = $state<UsageTimeline | null>(null);
+  let timelineError = $state(false);
   let limits = $state<UsageLimits | null>(null);
   let projections = $state<UsageProjection[]>([]);
   let github = $state<GithubRateLimit | null>(null);
@@ -89,30 +98,56 @@
     loadBreakdown(range);
   });
 
+  // Timeline is range-dependent and loaded lazily (only while its tab is active), with its own
+  // monotonic token so a stale range's response can't overwrite a newer one.
+  let timelineReqToken = 0;
+
+  async function loadTimeline(r: UsageRange) {
+    const my = ++timelineReqToken;
+    timelineError = false;
+    try {
+      const t = await getUsageTimeline(r);
+      if (my !== timelineReqToken) return;
+      timeline = t;
+    } catch {
+      if (my !== timelineReqToken) return;
+      timelineError = true;
+    }
+  }
+
+  $effect(() => {
+    if (tab === "timeline") loadTimeline(range);
+  });
+
   // Retry re-fetches ALL tracks so any failure surface recovers.
   function retry() {
     loadBreakdown(range);
+    loadTimeline(range);
     loadLimits();
     loadGithub();
   }
 
   // Template-state derivations (kept out of the markup to keep the template's
   // branching shallow). `showRange`: spend/overhead are the only ranged tabs.
-  const showRange = $derived(tab === "spend" || tab === "overhead");
-  const showBreakdownError = $derived(error && showRange);
+  const showRange = $derived(tab === "spend" || tab === "overhead" || tab === "timeline");
+  // Non-blocking refetch banner — Spend/Overhead use `breakdown`'s error track, Timeline its own.
+  const showBreakdownError = $derived(error && (tab === "spend" || tab === "overhead"));
+  const showTimelineError = $derived(timelineError && tab === "timeline");
   // The active tab has data to render its lens (else we show loading/error chrome).
   const hasContent = $derived(
     ((tab === "spend" || tab === "overhead") && !!breakdown) ||
+      (tab === "timeline" && !!timeline) ||
       (tab === "limits" && !!limits) ||
       (tab === "github" && !!github),
   );
   // No content yet, and the failing fetch for this tab errored (not still loading).
-  // (Spend/Overhead surface their error via the banner above, never inline.)
+  // (Spend/Overhead/Timeline surface their error via the banner above, never inline.)
   const bodyError = $derived(
     !hasContent && ((tab === "limits" && limitsError) || (tab === "github" && githubError)),
   );
   const bodyLoading = $derived(
-    (showRange && !breakdown && loading) ||
+    ((tab === "spend" || tab === "overhead") && !breakdown && loading) ||
+      (tab === "timeline" && !timeline && !timelineError) ||
       (tab === "limits" && !limits && !limitsError) ||
       (tab === "github" && !github && !githubError),
   );
@@ -154,6 +189,13 @@
         class:seg-active={tab === "overhead"}
         aria-pressed={tab === "overhead"}
         onclick={() => (tab = "overhead")}>{m.usage_overhead_tab()}</button
+      >
+      <button
+        type="button"
+        class="seg-btn"
+        class:seg-active={tab === "timeline"}
+        aria-pressed={tab === "timeline"}
+        onclick={() => (tab = "timeline")}>{m.usage_timeline_tab()}</button
       >
       <button
         type="button"
@@ -228,7 +270,7 @@
       <!-- Breakdown-error banner for the Spend/Overhead tabs. Shown even when a stale
            `breakdown` is still present (a failed range-change refetch) so the user isn't
            silently left on old-range data with no indication the new range failed. -->
-      {#if showBreakdownError}
+      {#if showBreakdownError || showTimelineError}
         <div class="usage-error-banner" role="alert">
           <span class="usage-status-line usage-error">{m.usage_load_error()}</span>
           <button type="button" class="gbtn gbtn-secondary" onclick={retry}
@@ -241,6 +283,8 @@
         <SpendLens {breakdown} />
       {:else if tab === "overhead" && breakdown}
         <OverheadLens {breakdown} />
+      {:else if tab === "timeline" && timeline}
+        <TimelineLens {timeline} />
       {:else if tab === "limits" && limits}
         <LimitsLens {limits} {projections} />
       {:else if tab === "github" && github}

--- a/ui/src/lib/components/usage/TimelineLens.browser.test.ts
+++ b/ui/src/lib/components/usage/TimelineLens.browser.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../../app.css";
+import type { UsageTimeline, UsageTimelineHour } from "$lib/types";
+
+const { default: TimelineLens } = await import("./TimelineLens.svelte");
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+/** Build a timeline from local-time hour specs; peak/total derived from the data. */
+function makeTimeline(hours: UsageTimelineHour[]): UsageTimeline {
+  let total = 0;
+  let peak = 0;
+  for (const h of hours) {
+    total += h.units;
+    if (h.units > peak) peak = h.units;
+  }
+  return { range: "7d", generatedAt: Date.now(), hours, totalUnits: total, peakHourUnits: peak };
+}
+
+/** Local-time hour epoch (y, monthIndex, day, hour). */
+function hr(y: number, mon: number, day: number, hour: number, units: number): UsageTimelineHour {
+  return { hourStart: new Date(y, mon, day, hour, 0, 0, 0).getTime(), units };
+}
+
+describe("TimelineLens", () => {
+  it("renders one row per local day with 24 cells each, newest first", async () => {
+    const tl = makeTimeline([
+      hr(2025, 5, 10, 14, 100), // peak
+      hr(2025, 5, 10, 3, 10), // low, same day
+      hr(2025, 5, 9, 9, 50), // previous day
+    ]);
+    render(TimelineLens, { timeline: tl });
+
+    const rows = document.querySelectorAll(".tl-row");
+    expect(rows.length, "two distinct local days").toBe(2);
+    for (const row of rows) {
+      expect(row.querySelectorAll(".tl-cell").length, "24 hour cells per row").toBe(24);
+    }
+  });
+
+  it("scales cell intensity by units / peak (floored for nonzero, inset for zero)", async () => {
+    const tl = makeTimeline([hr(2025, 5, 10, 14, 100), hr(2025, 5, 10, 3, 10)]);
+    render(TimelineLens, { timeline: tl });
+
+    const cells = document.querySelectorAll<HTMLElement>(".tl-row .tl-cell");
+    const iOf = (el: HTMLElement) => Number(el.style.getPropertyValue("--i"));
+
+    // Hour 14 (peak) → 100; hour 3 (10/100) → floored 8 + 9.2 = 17.2; an empty hour → 0.
+    expect(iOf(cells[14]!)).toBeCloseTo(100, 5);
+    expect(iOf(cells[3]!)).toBeCloseTo(17.2, 5);
+    expect(iOf(cells[0]!), "empty hour reads as inset (0)").toBe(0);
+  });
+
+  it("shows peak and total stats", async () => {
+    const tl = makeTimeline([hr(2025, 5, 10, 14, 100), hr(2025, 5, 9, 9, 50)]);
+    render(TimelineLens, { timeline: tl });
+
+    const stats = document.querySelector(".tl-stats")?.textContent ?? "";
+    expect(stats).toContain("100"); // peak
+    expect(stats).toContain("150"); // total
+  });
+
+  it("renders the empty state when there are no hours", async () => {
+    render(TimelineLens, { timeline: makeTimeline([]) });
+    await expect.element(page.getByText(/no usage recorded/i)).toBeInTheDocument();
+    expect(document.querySelectorAll(".tl-row").length).toBe(0);
+  });
+
+  it("caps the grid at 35 rows and shows the '+N earlier days' note", async () => {
+    // 40 consecutive days, one hour each → 35 rows shown, 5 hidden.
+    const hours: UsageTimelineHour[] = [];
+    for (let d = 1; d <= 40; d++) hours.push(hr(2025, 0, d, 12, 10));
+    render(TimelineLens, { timeline: makeTimeline(hours) });
+
+    expect(document.querySelectorAll(".tl-row").length, "capped at 35 rows").toBe(35);
+    const more = document.querySelector(".tl-more");
+    expect(more, "more-days note present").not.toBeNull();
+    expect(more?.textContent ?? "").toContain("5");
+  });
+});

--- a/ui/src/lib/components/usage/TimelineLens.svelte
+++ b/ui/src/lib/components/usage/TimelineLens.svelte
@@ -133,14 +133,17 @@
           <span class="tl-row-label">{row.label}</span>
           <div class="tl-cells">
             {#each row.cells as units, h (h)}
+              {@const label = m.usage_timeline_cell_aria({
+                day: row.label,
+                hour: hourLabel(h),
+                units: formatUnits(units),
+              })}
               <span
                 class="tl-cell"
                 style="--i: {intensity(units)}"
-                title={m.usage_timeline_cell_aria({
-                  day: row.label,
-                  hour: hourLabel(h),
-                  units: formatUnits(units),
-                })}
+                role="img"
+                aria-label={label}
+                title={label}
               ></span>
             {/each}
           </div>

--- a/ui/src/lib/components/usage/TimelineLens.svelte
+++ b/ui/src/lib/components/usage/TimelineLens.svelte
@@ -1,0 +1,289 @@
+<script lang="ts">
+  import type { UsageTimeline } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import InfoTip from "$lib/components/InfoTip.svelte";
+  import { formatUnits } from "./format";
+
+  const { timeline }: { timeline: UsageTimeline } = $props();
+
+  // Grid is capped so the "all" range can't grow a 365-row scroll that defeats the point
+  // (spotting hot/cold periods). Older days still count toward peak/total — see the note line.
+  const MAX_HEATMAP_DAYS = 35;
+  const HOUR_TICKS = [0, 6, 12, 18, 23];
+
+  const HOURS = Array.from({ length: 24 }, (_unused, i) => i);
+
+  /** ms-epoch of the local midnight starting `ts`'s day. Plain Date — pure local math, not state. */
+  function startOfLocalDay(ts: number): number {
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity
+    const d = new Date(ts);
+    d.setHours(0, 0, 0, 0);
+    return d.getTime();
+  }
+
+  /** Local midnight of the day before `dayStart` (DST-safe — decrements the calendar date). */
+  function prevLocalDay(dayStart: number): number {
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity
+    const d = new Date(dayStart);
+    d.setDate(d.getDate() - 1);
+    d.setHours(0, 0, 0, 0);
+    return d.getTime();
+  }
+
+  // Locale-aware row label (weekday + date) — formatted, not a hardcoded string.
+  const dayFmt = new Intl.DateTimeFormat(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+
+  interface Row {
+    dayStart: number;
+    label: string;
+    cells: number[]; // 24 hour buckets of weighted units
+  }
+
+  const model = $derived.by(() => {
+    const empty = { rows: [] as Row[], hiddenDays: 0 };
+    if (timeline.hours.length === 0) return empty;
+
+    // Fold hours into local day → hour-of-day units (DST collisions sum harmlessly).
+    // Plain Map — pure computation inside $derived, not reactive UI state.
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity
+    const byDay = new Map<number, number[]>();
+    for (const h of timeline.hours) {
+      const dayStart = startOfLocalDay(h.hourStart);
+      const hour = new Date(h.hourStart).getHours();
+      let cells = byDay.get(dayStart);
+      if (!cells) {
+        cells = new Array(24).fill(0) as number[];
+        byDay.set(dayStart, cells);
+      }
+      cells[hour] += h.units;
+    }
+
+    const dataDays = [...byDay.keys()].sort((a, b) => a - b);
+    const earliest = dataDays[0]!;
+    const latest = dataDays[dataDays.length - 1]!;
+
+    // Contiguous calendar days, newest first, capped at MAX_HEATMAP_DAYS, never past earliest.
+    const rows: Row[] = [];
+    let day = latest;
+    for (let i = 0; i < MAX_HEATMAP_DAYS; i++) {
+      rows.push({
+        dayStart: day,
+        label: dayFmt.format(new Date(day)),
+        cells: byDay.get(day) ?? (new Array(24).fill(0) as number[]),
+      });
+      if (day <= earliest) break;
+      day = prevLocalDay(day);
+    }
+
+    const shownEarliest = rows[rows.length - 1]!.dayStart;
+    const hiddenDays = dataDays.filter((d) => d < shownEarliest).length;
+    return { rows, hiddenDays };
+  });
+
+  const peak = $derived(timeline.peakHourUnits > 0 ? timeline.peakHourUnits : 1);
+
+  /** Color-mix percentage for a cell (0 ⇒ inset; nonzero floored to 8% so it stays visible). */
+  function intensity(units: number): number {
+    if (units <= 0) return 0;
+    return Math.min(100, 8 + 92 * (units / peak));
+  }
+
+  function hourLabel(h: number): string {
+    return `${String(h).padStart(2, "0")}:00`;
+  }
+</script>
+
+<div class="timeline-lens">
+  <div class="tl-header">
+    <h2 class="tl-heading">{m.usage_timeline_heading()}</h2>
+    <span class="tl-units-label">
+      <span>{m.usage_units_label()}</span>
+      <InfoTip
+        text={m.gloss_weighted_units_def()}
+        label={m.newtask_info_aria({ topic: m.gloss_weighted_units_term() })}
+      />
+    </span>
+    <span class="tl-stats">
+      {m.usage_timeline_peak({ units: formatUnits(timeline.peakHourUnits) })} ·
+      {m.usage_timeline_total({ units: formatUnits(timeline.totalUnits) })}
+    </span>
+  </div>
+
+  {#if model.rows.length === 0}
+    <p class="tl-empty">{m.usage_timeline_empty()}</p>
+  {:else}
+    <div class="tl-grid-wrap">
+      <!-- Column ticks (hour-of-day) -->
+      <div class="tl-axis" aria-hidden="true">
+        <span class="tl-row-label"></span>
+        <div class="tl-ticks">
+          {#each HOURS as h (h)}
+            <span class="tl-tick">{HOUR_TICKS.includes(h) ? hourLabel(h) : ""}</span>
+          {/each}
+        </div>
+      </div>
+
+      <!-- Day rows -->
+      {#each model.rows as row (row.dayStart)}
+        <div class="tl-row">
+          <span class="tl-row-label">{row.label}</span>
+          <div class="tl-cells">
+            {#each row.cells as units, h (h)}
+              <span
+                class="tl-cell"
+                style="--i: {intensity(units)}"
+                title={m.usage_timeline_cell_aria({
+                  day: row.label,
+                  hour: hourLabel(h),
+                  units: formatUnits(units),
+                })}
+              ></span>
+            {/each}
+          </div>
+        </div>
+      {/each}
+    </div>
+
+    {#if model.hiddenDays > 0}
+      <p class="tl-more">{m.usage_timeline_more_days({ count: model.hiddenDays })}</p>
+    {/if}
+
+    <!-- Legend -->
+    <div class="tl-legend" aria-hidden="true">
+      <span class="tl-legend-label">{m.usage_timeline_legend_low()}</span>
+      {#each [0, 25, 50, 75, 100] as p (p)}
+        <span class="tl-swatch" style="--i: {p === 0 ? 0 : 8 + 0.92 * p}"></span>
+      {/each}
+      <span class="tl-legend-label">{m.usage_timeline_legend_high()}</span>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .timeline-lens {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .tl-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .tl-heading {
+    font-size: var(--fs-lg);
+    font-weight: 600;
+    color: var(--color-ink-bright);
+    margin: 0;
+  }
+
+  .tl-units-label {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+  }
+
+  .tl-stats {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    font-variant-numeric: tabular-nums;
+    margin-left: auto;
+  }
+
+  .tl-grid-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .tl-axis,
+  .tl-row {
+    display: grid;
+    grid-template-columns: 3.5rem 1fr;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .tl-row-label {
+    font-size: var(--fs-micro);
+    color: var(--color-muted);
+    text-align: right;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .tl-ticks,
+  .tl-cells {
+    display: grid;
+    grid-template-columns: repeat(24, 1fr);
+    gap: 2px;
+  }
+
+  .tl-tick {
+    font-size: var(--fs-micro);
+    color: var(--color-faint);
+    text-align: left;
+    overflow: visible;
+    white-space: nowrap;
+  }
+
+  .tl-cell {
+    aspect-ratio: 1;
+    min-height: 10px;
+    border-radius: 2px;
+    background: color-mix(in oklab, var(--color-amber) calc(var(--i) * 1%), var(--color-inset));
+  }
+
+  .tl-more {
+    font-size: var(--fs-micro);
+    color: var(--color-faint);
+    font-style: italic;
+    margin: 0;
+  }
+
+  .tl-empty {
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+    margin: 24px 0 8px;
+  }
+
+  .tl-legend {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 0.25rem;
+  }
+
+  .tl-legend-label {
+    font-size: var(--fs-micro);
+    color: var(--color-muted);
+  }
+
+  .tl-swatch {
+    width: 14px;
+    height: 14px;
+    border-radius: 2px;
+    background: color-mix(in oklab, var(--color-amber) calc(var(--i) * 1%), var(--color-inset));
+  }
+
+  @media (max-width: 480px) {
+    .tl-axis,
+    .tl-row {
+      grid-template-columns: 2.75rem 1fr;
+      gap: 0.3rem;
+    }
+    .tl-cell {
+      min-height: 8px;
+    }
+  }
+</style>

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1886,4 +1886,13 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     bodyKey: "feat_newtask_hide_hidden_body",
     targetId: "nt-repo",
   },
+  {
+    // New Timeline tab in the Usage modal: a day×hour heatmap of weighted-unit consumption.
+    // No targetId — the Usage modal isn't mounted until opened, so there's no stable anchor
+    // (same rationale as github-rate-limits). What's-New drawer only.
+    id: "usage-timeline",
+    sinceVersion: "1.39.0",
+    titleKey: "feat_usage_timeline_title",
+    bodyKey: "feat_usage_timeline_body",
+  },
 ];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1014,6 +1014,23 @@ export interface UsageBreakdown {
   repos: UsageRepoBreakdown[];
 }
 
+/** One hour of weighted-unit consumption (mirrors server UsageTimelineHour). */
+export interface UsageTimelineHour {
+  hourStart: number; // ms epoch, floored to the hour (UTC boundary); never 0 (timeless rows excluded)
+  units: number; // weighted units consumed in that hour (authoring + live + satellite)
+}
+
+/** GET /api/usage/timeline response — the Timeline lens's per-hour series.
+ *  `hours` is ASC by `hourStart` and contains only non-empty hours; `totalUnits`
+ *  and `peakHourUnits` span the full range even when the UI grid is row-capped. */
+export interface UsageTimeline {
+  range: UsageRange;
+  generatedAt: number; // ms epoch
+  hours: UsageTimelineHour[];
+  totalUnits: number; // Σ units across all in-range hours
+  peakHourUnits: number; // max single-hour units (0 when empty) — heatmap color reference
+}
+
 /** Burn-down projection for the Limits lens. */
 export interface UsageProjection {
   window: "5H" | "WK";


### PR DESCRIPTION
## What

Adds a 5th tab — **Timeline** — to the token-usage panel that visualizes weighted-unit consumption over time as a **local day × hour heatmap**. Rows are calendar days (newest first), columns are the 24 hours of the day, and cell darkness scales with usage — so high- and low-usage periods are visible at a glance. It honors the existing range selector (24h / 7d / 30d / all) and includes activity from **currently-running sessions**.


## How

The data already existed — `session_usage_bucket` stores per-session hourly `weightedUnits`, and live sessions keep timestamped records in `SessionUsageRollup`. This PR aggregates both, server-side, into a per-hour series.

**Server**
- `UsageTimeline` / `UsageTimelineHour` shared types (mirrored in `src/types.ts` + `ui/src/lib/types.ts`, with `USAGE_TIMELINE_*_KEYS` drift sentinels).
- `store.sumUsageUnitsByHourSince(cutoff)` — sums persisted buckets per hour (excludes the timeless `bucketStart = 0`).
- `SessionUsageRollup.hourlyUnits(...)` + exported `floorHour`.
- `buildUsageTimeline` (`src/usage-timeline.ts`) folds **persisted buckets + live rollup + reviewer spawns** into the series. It **refreshes the rollup itself** (nothing else does before this path runs), so opening Timeline first still reflects live work. Dedup mirrors `buildUsageBreakdown` ("persisted wins").
- `GET /api/usage/timeline?range=…` (`handleUsageTimeline`).

**UI**
- `TimelineLens.svelte` renders the heatmap in the browser's local timezone — amber `color-mix` intensity, hour ticks, low→high legend, peak/total stats, per-cell tooltips, empty state.
- Capped at **35 day-rows**; for "all" with more history, older days are noted ("+N earlier days not shown") while peak/total stay range-complete.
- New lazy-loaded tab wired into `Usage.svelte`; `getUsageTimeline` in `api.ts`.

## Metric

Consistent with Spend/Overhead, the value is **weighted units** (labeled "weighted units" everywhere, with the existing `gloss_weighted_units` InfoTip — never the bare word "tokens").

## Tests / gates

- `test/usage-timeline.test.ts` — cross-session aggregation, range cutoff, timeless exclusion, satellite folding, live-rollup refresh+fold, empty.
- `test/server-usage-timeline.test.ts` — endpoint shape + drift sentinels + range validation.
- `TimelineLens.browser.test.ts` + a Timeline-tab case in `Usage.browser.test.ts`.
- Green: root `lint` + `bun test` (new suites), `ui` `check` + full vitest (171 files / 2348), `check:i18n`, feature-catalog, glossary, branch-hygiene, fallow audit.

i18n: EN + DE keys added. Feature discovery: catalog entry `usage-timeline` (sinceVersion `1.39.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)