### PR TITLE
fix(files): make whole Files tab the drop zone for uploads

### DIFF
--- a/ui/src/lib/components/viewport/FilesPanel.browser.test.ts
+++ b/ui/src/lib/components/viewport/FilesPanel.browser.test.ts
@@ -122,26 +122,44 @@ describe("FilesPanel — 413 too-large error surfaces inline", () => {
 });
 
 describe("FilesPanel — drag-and-drop calls uploadScratchpadFile", () => {
-  it("calls uploadScratchpadFile on drop with correct args", async () => {
+  it("calls uploadScratchpadFile on drop anywhere in the tab with correct args", async () => {
     mockUpload.mockResolvedValue("dropped.txt");
 
     render(FilesPanel, { sessionId: "sess-4" });
     await waitForPanel();
 
     const file = new File(["drop"], "dropped.txt", { type: "text/plain" });
-    const list = document.querySelector<HTMLDivElement>(".list")!;
-    expect(list).not.toBeNull();
+    // The whole .files tab is the drop zone, not just the inner list.
+    const tab = document.querySelector<HTMLDivElement>(".files")!;
+    expect(tab).not.toBeNull();
 
     const dt = new DataTransfer();
     dt.items.add(file);
-    list.dispatchEvent(
+    tab.dispatchEvent(
       new DragEvent("dragover", { bubbles: true, cancelable: true, dataTransfer: dt }),
     );
-    list.dispatchEvent(
-      new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: dt }),
-    );
+    tab.dispatchEvent(new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: dt }));
 
     await expect.poll(() => mockUpload.mock.calls.length).toBe(1);
     expect(mockUpload).toHaveBeenCalledWith("sess-4", file, undefined);
+  });
+
+  it("shows the whole-tab drop overlay on dragover and clears it on drop", async () => {
+    mockUpload.mockResolvedValue("dropped.txt");
+
+    render(FilesPanel, { sessionId: "sess-5" });
+    await waitForPanel();
+
+    const tab = document.querySelector<HTMLDivElement>(".files")!;
+    const dt = new DataTransfer();
+    dt.items.add(new File(["drop"], "dropped.txt", { type: "text/plain" }));
+
+    tab.dispatchEvent(
+      new DragEvent("dragover", { bubbles: true, cancelable: true, dataTransfer: dt }),
+    );
+    await expect.poll(() => document.querySelector(".drop-overlay")).toBeTruthy();
+
+    tab.dispatchEvent(new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: dt }));
+    await expect.poll(() => document.querySelector(".drop-overlay")).toBeFalsy();
   });
 });

--- a/ui/src/lib/components/viewport/FilesPanel.svelte
+++ b/ui/src/lib/components/viewport/FilesPanel.svelte
@@ -137,90 +137,94 @@
   ondrop={handleDrop}
 >
   {#if dragOver}
-    <!-- Whole-tab drop overlay; pointer-events:none so drag/drop events keep reaching .files -->
+    <!-- Whole-tab drop overlay; sits over (not inside) the scroll wrapper so it always covers the
+         visible area, and pointer-events:none keeps drag/drop events reaching .files -->
     <div class="drop-overlay" aria-hidden="true">
       <span class="drop-overlay-hint">{m.files_upload_drop_hint()}</span>
     </div>
   {/if}
-  <div class="toolbar">
-    <nav class="crumbs" aria-label={m.files_breadcrumb_aria()}>
-      {#each crumbs as c, i (c.path)}
-        {#if i > 0}<span class="crumb-sep" aria-hidden="true">/</span>{/if}
-        {#if i === crumbs.length - 1}
-          <span class="crumb current" aria-current="page">{c.label}</span>
-        {:else}
-          <button type="button" class="crumb" onclick={() => browse(c.path)}>{c.label}</button>
-        {/if}
-      {/each}
-    </nav>
-    <button
-      type="button"
-      class="gbtn upload-btn"
-      aria-label={m.files_upload_aria()}
-      disabled={listing === null}
-      onclick={openFilePicker}
-      use:coachTarget={"scratchpad-upload"}>{m.files_upload_button()}</button
-    >
-    <!-- Hidden real input; triggered by the upload button -->
-    <input
-      bind:this={fileInput}
-      type="file"
-      multiple
-      class="sr-only"
-      aria-hidden="true"
-      tabindex="-1"
-      onchange={handleFileInput}
-    />
-  </div>
+  <!-- Scroll wrapper; .files itself stays non-scrolling so the overlay anchors to the viewport -->
+  <div class="files-scroll">
+    <div class="toolbar">
+      <nav class="crumbs" aria-label={m.files_breadcrumb_aria()}>
+        {#each crumbs as c, i (c.path)}
+          {#if i > 0}<span class="crumb-sep" aria-hidden="true">/</span>{/if}
+          {#if i === crumbs.length - 1}
+            <span class="crumb current" aria-current="page">{c.label}</span>
+          {:else}
+            <button type="button" class="crumb" onclick={() => browse(c.path)}>{c.label}</button>
+          {/if}
+        {/each}
+      </nav>
+      <button
+        type="button"
+        class="gbtn upload-btn"
+        aria-label={m.files_upload_aria()}
+        disabled={listing === null}
+        onclick={openFilePicker}
+        use:coachTarget={"scratchpad-upload"}>{m.files_upload_button()}</button
+      >
+      <!-- Hidden real input; triggered by the upload button -->
+      <input
+        bind:this={fileInput}
+        type="file"
+        multiple
+        class="sr-only"
+        aria-hidden="true"
+        tabindex="-1"
+        onchange={handleFileInput}
+      />
+    </div>
 
-  <!-- Upload status lines -->
-  {#each uploads as u (u.id)}
-    {#if u.state === "uploading"}
-      <div class="upload-status">{m.files_uploading({ name: u.name })}</div>
-    {:else if u.state === "too_large"}
-      <div class="upload-status err">{m.files_upload_too_large({ name: u.name })}</div>
-    {:else if u.state === "failed"}
-      <div class="upload-status err">{m.files_upload_failed({ name: u.name })}</div>
-    {:else if u.state === "done"}
-      <div class="upload-status ok">{m.files_upload_done({ name: u.name })}</div>
-    {/if}
-  {/each}
+    <!-- Upload status lines -->
+    {#each uploads as u (u.id)}
+      {#if u.state === "uploading"}
+        <div class="upload-status">{m.files_uploading({ name: u.name })}</div>
+      {:else if u.state === "too_large"}
+        <div class="upload-status err">{m.files_upload_too_large({ name: u.name })}</div>
+      {:else if u.state === "failed"}
+        <div class="upload-status err">{m.files_upload_failed({ name: u.name })}</div>
+      {:else if u.state === "done"}
+        <div class="upload-status ok">{m.files_upload_done({ name: u.name })}</div>
+      {/if}
+    {/each}
 
-  <!-- File list; the whole .files tab is the drop zone (see handlers above) -->
-  <div class="list">
-    {#if loading && !listing}
-      <div class="placeholder">{m.common_loading()}</div>
-    {:else if error}
-      <div class="placeholder err">{m.files_load_error()}</div>
-    {:else if listing && listing.entries.length === 0}
-      <div class="placeholder empty-droppable">
-        <span>{m.files_empty()}</span>
-        <span class="drop-hint">{m.files_upload_drop_hint()}</span>
-      </div>
-    {:else if listing}
-      {#each listing.entries as e (e.path)}
-        {#if e.type === "dir"}
-          <button type="button" class="row" onclick={() => browse(e.path)}>
-            <span class="ico" aria-hidden="true">▸</span>
-            <span class="nm">{e.name}</span>
-            <span class="chev" aria-hidden="true">›</span>
-          </button>
-        {:else}
-          <!-- eslint-disable svelte/no-navigation-without-resolve -- server API download endpoint, not an app route -->
-          <a
-            class="row file"
-            href={scratchpadDownloadUrl(sessionId, e.path)}
-            download={e.name}
-            aria-label={m.files_download_aria({ name: e.name })}
-          >
-            <span class="ico" aria-hidden="true">▢</span>
-            <span class="nm">{e.name}</span>
-            <span class="dl" aria-hidden="true">↓</span>
-          </a>
-          <!-- eslint-enable svelte/no-navigation-without-resolve -->
-        {/if}
-      {/each}
-    {/if}
+    <!-- File list; the whole .files tab is the drop zone (see handlers above) -->
+    <div class="list">
+      {#if loading && !listing}
+        <div class="placeholder">{m.common_loading()}</div>
+      {:else if error}
+        <div class="placeholder err">{m.files_load_error()}</div>
+      {:else if listing && listing.entries.length === 0}
+        <div class="placeholder empty-droppable">
+          <span>{m.files_empty()}</span>
+          <span class="drop-hint">{m.files_upload_drop_hint()}</span>
+        </div>
+      {:else if listing}
+        {#each listing.entries as e (e.path)}
+          {#if e.type === "dir"}
+            <button type="button" class="row" onclick={() => browse(e.path)}>
+              <span class="ico" aria-hidden="true">▸</span>
+              <span class="nm">{e.name}</span>
+              <span class="chev" aria-hidden="true">›</span>
+            </button>
+          {:else}
+            <!-- eslint-disable svelte/no-navigation-without-resolve -- server API download endpoint, not an app route -->
+            <a
+              class="row file"
+              href={scratchpadDownloadUrl(sessionId, e.path)}
+              download={e.name}
+              aria-label={m.files_download_aria({ name: e.name })}
+            >
+              <span class="ico" aria-hidden="true">▢</span>
+              <span class="nm">{e.name}</span>
+              <span class="dl" aria-hidden="true">↓</span>
+            </a>
+            <!-- eslint-enable svelte/no-navigation-without-resolve -->
+          {/if}
+        {/each}
+      {/if}
+    </div>
   </div>
 </div>
 
@@ -229,10 +233,17 @@
     position: relative;
     display: flex;
     flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+  }
+  .files-scroll {
+    display: flex;
+    flex-direction: column;
     gap: 8px;
     padding: 10px 12px;
     overflow-y: auto;
-    height: 100%;
+    flex: 1;
+    min-height: 0;
   }
   .drop-overlay {
     position: absolute;

--- a/ui/src/lib/components/viewport/FilesPanel.svelte
+++ b/ui/src/lib/components/viewport/FilesPanel.svelte
@@ -128,7 +128,20 @@
   }
 </script>
 
-<div class="files">
+<div
+  class="files"
+  role="region"
+  aria-label={m.files_list_aria()}
+  ondragover={handleDragOver}
+  ondragleave={handleDragLeave}
+  ondrop={handleDrop}
+>
+  {#if dragOver}
+    <!-- Whole-tab drop overlay; pointer-events:none so drag/drop events keep reaching .files -->
+    <div class="drop-overlay" aria-hidden="true">
+      <span class="drop-overlay-hint">{m.files_upload_drop_hint()}</span>
+    </div>
+  {/if}
   <div class="toolbar">
     <nav class="crumbs" aria-label={m.files_breadcrumb_aria()}>
       {#each crumbs as c, i (c.path)}
@@ -173,15 +186,8 @@
     {/if}
   {/each}
 
-  <!-- Drop zone wrapping the file list -->
-  <div
-    class={["list", dragOver && "drop-active"]}
-    role="region"
-    aria-label={m.files_list_aria()}
-    ondragover={handleDragOver}
-    ondragleave={handleDragLeave}
-    ondrop={handleDrop}
-  >
+  <!-- File list; the whole .files tab is the drop zone (see handlers above) -->
+  <div class="list">
     {#if loading && !listing}
       <div class="placeholder">{m.common_loading()}</div>
     {:else if error}
@@ -220,12 +226,32 @@
 
 <style>
   .files {
+    position: relative;
     display: flex;
     flex-direction: column;
     gap: 8px;
     padding: 10px 12px;
     overflow-y: auto;
     height: 100%;
+  }
+  .drop-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+    pointer-events: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 6px;
+    border: 2px dashed var(--color-blue);
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--color-blue) 10%, var(--color-inset));
+  }
+  .drop-overlay-hint {
+    color: var(--color-blue);
+    font-family: var(--font-mono);
+    font-size: var(--fs-lg);
+    letter-spacing: 0.04em;
   }
   .toolbar {
     display: flex;
@@ -317,13 +343,6 @@
     border-radius: 2px;
     display: flex;
     flex-direction: column;
-    transition:
-      border-color 0.1s ease,
-      background 0.1s ease;
-  }
-  .list.drop-active {
-    border-color: var(--color-blue);
-    background: color-mix(in srgb, var(--color-blue) 8%, var(--color-inset));
   }
   .placeholder {
     padding: 14px 12px;


### PR DESCRIPTION
## What

The drag-and-drop upload target on the **Files** tab was limited to the inner `.list` element — small, and tiniest of all in the empty state where it was just the little "No files in the scratchpad yet." box. Files dropped anywhere else on the tab were ignored.

This moves the `ondragover`/`ondragleave`/`ondrop` handlers up to the outer `.files` container (the whole tab, already `height: 100%`), so **dropping anywhere on the Files tab uploads to the current directory**.

## How

- Handlers moved from `.list` → `.files`; child drop events bubble to the single handler.
- During an active drag, a **whole-tab overlay** (dashed blue border + tint + centered "Drop files to upload" hint) appears across the panel. It uses `pointer-events: none` so drag/drop events keep reaching `.files` and the existing `handleDragLeave` child-containment guard stays correct.
- Removed the old small `.list.drop-active` tint and its now-orphaned `transition`.
- The `region` role + aria-label moved with the handlers to `.files`; `.list` is now plain (no nested duplicate region).
- The empty-state resting hint is unchanged; the upload pipeline, file picker, and listing refresh are untouched.

## Notes

- Reuses the existing `files_upload_drop_hint` message — **no new i18n keys**.
- This is a refinement of the existing drag-drop feature (enlarging a too-small target), not a new capability, so **no feature-catalog entry** is required.
- Tokens only (`--color-blue`, `--fs-lg`, `--font-mono`); no raw literals.

## Verification

- `bun run check` — 0 errors, 0 warnings
- `vitest run --project browser FilesPanel` — 5/5 pass (incl. new drop-anywhere + overlay show/clear tests)
- `bun run check:i18n` — locales in parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)