### PR TITLE
fix(prs): evict open-PR snapshot on merge so the panel drops the merged PR

### DIFF
--- a/src/open-pr-snapshot.ts
+++ b/src/open-pr-snapshot.ts
@@ -63,6 +63,24 @@ export class OpenPrSnapshotService {
     return this.cache.get(forge.slug!)?.value ?? null;
   }
 
+  /**
+   * Drop the cached entry (and any in-flight fetch pointer) for forge.slug so the
+   * NEXT get() is a guaranteed miss that starts a fresh fetch. Call after a write
+   * that mutates the open-PR set (e.g. a merge) so a client refetch can't read the
+   * stale snapshot. No-op for incapable forges.
+   *
+   * Clearing the inflight pointer means a get() after this won't join a fetch that
+   * started BEFORE the write (which would still carry the pre-write list); the
+   * promise-identity guard in load() then prevents that abandoned fetch from
+   * writing its stale value back once it resolves.
+   */
+  invalidate(forge: GitForge): void {
+    if (!this.isCapable(forge)) return;
+    const slug = forge.slug!;
+    this.cache.delete(slug);
+    this.inflight.delete(slug);
+  }
+
   /** True when the forge can supply a snapshot (non-null slug + method present). */
   private isCapable(forge: GitForge): boolean {
     return forge.slug != null && forge.listOpenPrSnapshot !== undefined;
@@ -78,19 +96,28 @@ export class OpenPrSnapshotService {
       // Shared raw fetch: writes to cache on success, clears inflight on
       // both branches, and re-throws on failure so each caller can apply
       // its OWN preserve-on-error policy below.
-      raw = this.gate
+      //
+      // Both the cache write and the inflight clear are guarded on promise
+      // identity: if invalidate() (or a newer fetch) has replaced this slug's
+      // inflight pointer since we started, this fetch is stale (its list
+      // predates the write that invalidated). It must neither write that stale
+      // value back nor clear a newer fetch's inflight slot.
+      const p: Promise<OpenPrSnapshot> = this.gate
         .run(() => forge.listOpenPrSnapshot!())
         .then(
           (v) => {
-            this.cache.set(slug, { at: this.now(), value: v });
-            this.inflight.delete(slug);
+            if (this.inflight.get(slug) === p) {
+              this.cache.set(slug, { at: this.now(), value: v });
+              this.inflight.delete(slug);
+            }
             return v;
           },
           (err) => {
-            this.inflight.delete(slug);
+            if (this.inflight.get(slug) === p) this.inflight.delete(slug);
             throw err;
           },
         );
+      raw = p;
       this.inflight.set(slug, raw);
       // Suppress the unhandled-rejection warning on the shared raw promise;
       // each caller's derived chain below provides the actual handler.

--- a/src/server.ts
+++ b/src/server.ts
@@ -343,8 +343,11 @@ export interface AppDeps {
   /** Backlog counts service; absent in tests that don't exercise it. */
   backlog?: Pick<CountsService, "counts">;
   /** Shared per-repo open-PR snapshot cache (read by the PRs tab; warmed by the pr-poller).
+   *  `invalidate` is evicted after an interactive merge so the panel's refetch misses the
+   *  stale snapshot. It is optional so `get`-only test stubs keep compiling.
    *  Absent in tests that don't exercise it — the PRs route then fetches fresh. */
-  openPrSnapshot?: Pick<OpenPrSnapshotService, "get">;
+  openPrSnapshot?: Pick<OpenPrSnapshotService, "get"> &
+    Partial<Pick<OpenPrSnapshotService, "invalidate">>;
   /** Force-refresh one repo's backlog counts (bypassing the read-TTL) and push the
    *  rebuilt overview to every client. Fired after a mutation that changes a repo's
    *  open issue/PR counts (e.g. a merge) so the counters + headline drop the item
@@ -2884,6 +2887,10 @@ async function forgeMerge(
       );
     throw err;
   }
+  // Evict the repo's open-PR snapshot so the backlog PRs panel for this repo can't
+  // re-list this merged PR from a still-TTL-fresh cache. No-op for incapable forges
+  // (local / null slug), so it's safe on both the local and host branches below.
+  deps.openPrSnapshot?.invalidate?.(forge);
   // Lightweight (local) merge happened in-tree — nobody else tears the session down (no host
   // poller path, no merge train), so the worktree/branch would leak. Settle it here, mirroring
   // AutoMergeService.doMerge's callbacks. Forge sessions keep the current behavior: a human
@@ -4354,6 +4361,11 @@ async function handlePrMerge({ req, parts, deps }: Ctx): Promise<Response | null
       method: body.method ?? forge.mergeMethod,
       deleteBranch: body.deleteBranch ?? true,
     });
+    // Evict the open-PR snapshot for this repo so the panel's silent refetch
+    // (GET /api/prs, right after this 200) misses the cache and fetches fresh —
+    // otherwise the still-TTL-fresh snapshot re-lists the just-merged PR. Sync,
+    // before the response, so the refetch can't race a cache that still has it.
+    deps.openPrSnapshot?.invalidate?.(forge);
     // Detached, best-effort: the merge already succeeded, so a refresh/broadcast
     // hiccup must not fail the response, and the GraphQL refetch must not delay the
     // "merged" feedback. Pushes the merged PR (and any auto-closed linked issue) out

--- a/test/open-pr-snapshot.test.ts
+++ b/test/open-pr-snapshot.test.ts
@@ -309,3 +309,61 @@ test("interleaving: joining refresh gets stale-on-error; get gets null; single-f
   expect(refreshResult).toEqual(staleSnap); // refresh keeps last-known-good
   expect(callCount).toBe(1); // single-flight: only one forge call
 });
+
+test("invalidate: evicts the cached entry so the next get refetches within TTL", async () => {
+  const now = 0; // clock never advances — entry would stay fresh without invalidation
+  const svc = new OpenPrSnapshotService(() => now);
+  const forge = makeForge();
+
+  await svc.get(forge); // warm cache (id=1)
+  expect(forge.calls).toBe(1);
+
+  svc.invalidate(forge);
+  expect(svc.peek(forge)).toBeNull(); // entry gone, even though still within TTL
+
+  const snap = await svc.get(forge); // miss → refetch (id=2)
+  expect(forge.calls).toBe(2);
+  expect(snap!.prs[0]!.number).toBe(2);
+});
+
+test("invalidate: clears inflight — a later get starts a fresh fetch and a late pre-invalidate fetch can't poison the cache", async () => {
+  const now = 0;
+  const svc = new OpenPrSnapshotService(() => now);
+  const forge = makeForge();
+
+  // Controllable, ordered resolutions so we can interleave invalidate between fetches.
+  const resolvers: Array<(v: OpenPrSnapshot) => void> = [];
+  let callCount = 0;
+  (forge as unknown as Record<string, unknown>).listOpenPrSnapshot = () => {
+    callCount++;
+    return new Promise<OpenPrSnapshot>((res) => resolvers.push(res));
+  };
+
+  const a = svc.get(forge); // fetch A in flight (call #1)
+  svc.invalidate(forge); // drop cache + inflight pointer
+  const b = svc.get(forge); // must NOT join A — starts fetch B (call #2)
+  expect(callCount).toBe(2);
+
+  // Resolve A (the abandoned pre-invalidate fetch) FIRST, then B.
+  resolvers[0]!(makeSnapshot(1)); // A's stale value
+  resolvers[1]!(makeSnapshot(2)); // B's fresh value
+  const [av, bv] = await Promise.all([a, b]);
+
+  // Each caller still receives the value it fetched…
+  expect(av!.prs[0]!.number).toBe(1);
+  expect(bv!.prs[0]!.number).toBe(2);
+  // …but only B (the current inflight) repopulated the cache; A's late resolution was dropped.
+  expect(svc.peek(forge)!.prs[0]!.number).toBe(2);
+});
+
+test("invalidate: no-op for incapable forges (null slug / no listOpenPrSnapshot)", async () => {
+  const svc = new OpenPrSnapshotService();
+  const nullSlug = makeForge(null);
+  const noMethod = makeForge("org/repo", { noSnapshot: true });
+
+  // Should neither throw nor touch the forge.
+  expect(() => svc.invalidate(nullSlug)).not.toThrow();
+  expect(() => svc.invalidate(noMethod)).not.toThrow();
+  expect(nullSlug.calls).toBe(0);
+  expect(noMethod.calls).toBe(0);
+});

--- a/test/server-prs.test.ts
+++ b/test/server-prs.test.ts
@@ -7,6 +7,7 @@ import type { SessionService } from "../src/service";
 import type { EventHub } from "../src/events";
 import type { GitForge, MergeInput, OpenPrSnapshot, PullRequest } from "../src/forge/types";
 import { DEPENDABOT_REBASE_COMMAND, EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
+import { OpenPrSnapshotService } from "../src/open-pr-snapshot";
 import { config } from "../src/config";
 
 let tmpRoot: string;
@@ -340,4 +341,34 @@ test("GET /api/prs swallows snapshot service error → {slug, prs:[]}", async ()
   const res = await app.fetch(getReq(repoDir));
   expect(res.status).toBe(200);
   expect(await res.json()).toEqual({ slug: "team/proj", webUrl: null, prs: [] });
+});
+
+// End-to-end against a REAL OpenPrSnapshotService (not a get-only stub) so the
+// assertion can't pass vacuously: warm the cache, merge, then prove the next
+// GET misses the still-TTL-fresh entry and returns the post-merge list.
+test("POST /api/prs/merge invalidates the snapshot so the next GET /api/prs drops the merged PR", async () => {
+  let merged = false;
+  const forge = fakeForge({
+    merge: async () => {
+      merged = true;
+    },
+    // Open PR present before merge, gone after — what `gh pr list --state open` would report.
+    listOpenPrSnapshot: async () => fakeSnapshot(merged ? [] : [PR]),
+  });
+  const deps = makeDeps(() => forge);
+  deps.openPrSnapshot = new OpenPrSnapshotService(); // real cache + invalidate
+  const app = makeApp(deps);
+
+  // 1. Warm the snapshot cache — lists the open PR.
+  const before = await (await app.fetch(getReq(repoDir))).json();
+  expect(before.prs).toEqual([PR]);
+
+  // 2. Merge it (handler invalidates the snapshot for this repo).
+  const mergeRes = await app.fetch(mergeReq({ repo: repoDir, number: PR.number }));
+  expect(mergeRes.status).toBe(200);
+
+  // 3. Refetch — without invalidation the entry is still TTL-fresh and would re-list
+  //    the merged PR; with it the GET misses and fetches the post-merge (empty) list.
+  const after = await (await app.fetch(getReq(repoDir))).json();
+  expect(after.prs).toEqual([]);
 });


### PR DESCRIPTION
## Problem

Since the open-PR snapshot cache landed (#1253), merging a PR from the **repos PRs panel** re-listed the just-merged PR. The UI already does the right thing client-side — `PrsPanel.onmerged` optimistically drops the row, then silently refetches `GET /api/prs` — but that refetch reads the server's `OpenPrSnapshotService` cache (keyed by `forge.slug`, **120s TTL**), which still contained the merged PR, so it came right back. The merge handler only refreshed backlog *counts*, never the PR listing cache.

## Fix

Re-trigger a real fetch on the write by evicting the snapshot:

- **`OpenPrSnapshotService.invalidate(forge)`** — drops the cache **and** the in-flight entry for `forge.slug`, so the next `get()` is a guaranteed miss that starts a fresh fetch. No-op for incapable forges.
- Called **synchronously before the response** on the two interactive merge paths — `handlePrMerge` (`POST /api/prs/merge`, the reported bug) and `forgeMerge` (session-detail merge) — so the panel's refetch can't race a cache that still holds the PR.
- A **promise-identity guard** (`inflight.get(slug) === p`) in `load()` stops a fetch that started *before* the invalidation (e.g. a concurrent pr-poller refresh) from writing its stale, pre-merge list back into the cache after eviction.

**Why evict, not `refresh()`:** a detached `refresh()` keeps the stale entry until the new fetch resolves (a concurrent `get()` still returns stale); an awaited `refresh()` single-flight-*joins* a pre-merge in-flight fetch and returns/caches that stale snapshot. Eviction clears the inflight pointer so the next read is a genuinely fresh post-merge fetch.

## Scope

`forge.merge()` has six call sites. The two **interactive** ones are fixed here. The four **autonomous / non-panel** paths (`automerge` merge train, two `drain` auto-land paths, the epic-landing CTA) are left poller-reconciled (full-sweep cadence == TTL): no client does the optimistic-remove+refetch dance that exposes the window, and wiring the cache through those services is out of scope. `dependabot-rebase` isn't a merge (PR stays open) so needs no invalidation.

## Tests

- `test/open-pr-snapshot.test.ts` — `invalidate` evicts (next `get` refetches within TTL); clears inflight so a later `get` starts a fresh fetch and a late pre-invalidate fetch can't poison the cache; no-op for incapable forges.
- `test/server-prs.test.ts` — end-to-end against a **real `OpenPrSnapshotService`** (not a `get`-only stub, so it can't pass vacuously): warm → merge → the next `GET /api/prs` misses the still-TTL-fresh entry and returns the post-merge (empty) list.

Server-only change (no UI diff). Root `bun run lint` + `bun test ./test` pass (5524 tests, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)