### PR TITLE
fix(ui): add Owed lens to mobile herd tab row (HerdSegRow)

### DIFF
--- a/ui/src/lib/components/herd/HerdSegRow.svelte
+++ b/ui/src/lib/components/herd/HerdSegRow.svelte
@@ -16,14 +16,16 @@
 
 <!-- Mobile-only segmented control: replaces the .fbtn filter row in flow
      mode. A direct child of the already-full-bleed .panel.flow, so it spans
-     the full phone width without its own negative margin. Equal-width segments,
-     44px touch targets, no leading glyphs. Labels are --fs-base (13px), a
-     DELIBERATE exception to the ≥16px label floor (NOT an oversight): five
-     equal segments on a 390px phone leave ~78px each, but the longest label
-     ("Nächstes", DE) needs ~83px at 16px — so ≥16px would truncate it, which
-     breaks the "keep full text labels" criterion. 13px is the largest size
-     that fits the full word; contrast is held high to compensate (active
-     --color-amber 8.49:1, inactive --color-muted 5.27:1). -->
+     the full phone width without its own negative margin. Six equal-width
+     segments (#1198 added Owed), 44px touch targets, no leading glyphs. Labels
+     are --fs-meta (11px), a DELIBERATE exception to the ≥16px label floor (NOT
+     an oversight): six equal segments on a 390px phone leave ~65px each (~60px
+     content after padding/border), but the longest label ("Nächstes", DE)
+     measures ~67px at 13px — it would truncate, breaking the "keep full text
+     labels" criterion. 11px shrinks it to ~57px so all six full labels fit
+     (matching the desktop HerdLensStrip's --fs-meta labels); contrast is held
+     high to compensate (active --color-amber 8.49:1, inactive --color-muted
+     5.27:1, both > 4.5:1 AA). -->
 <div class="seg-row" use:coachTarget={"mobile-seg-ctrl"}>
   <button
     type="button"
@@ -81,18 +83,32 @@
       onstatusfilter?.(null);
     }}>{m.herd_seg_rundown()}</button
   >
+  <button
+    type="button"
+    class="seg-btn"
+    class:seg-active={statusFilter == null && filter === "owed"}
+    title={m.herd_owed_title()}
+    aria-pressed={statusFilter == null && filter === "owed"}
+    use:coachTarget={"owed-lens"}
+    onclick={() => {
+      filter = "owed";
+      onstatusfilter?.(null);
+    }}>{m.herd_seg_owed()}</button
+  >
 </div>
 
 <style>
   /* Mobile-only segmented control: replaces the .fbtn filter row in flow mode.
      A direct child of the already-full-bleed .panel.flow, so it spans the full
-     phone width without its own negative margin. Equal-width segments, 44px touch
-     targets. Labels are --fs-base (13px) — a DELIBERATE sub-16px exception, not an
-     oversight: at the 390px reference five equal segments give ~78px each and the
-     longest label "Nächstes" (DE) measures ~83px at 16px (it would truncate),
-     vs ~67px at 13px (fits). The ≥16px floor is waived for this one control to keep
-     full text labels; high contrast (amber active / muted inactive) compensates.
-     A text-overflow:ellipsis below handles even-narrower fold-cover widths. */
+     phone width without its own negative margin. Six equal-width segments (#1198
+     added Owed), 44px touch targets. Labels are --fs-meta (11px) — a DELIBERATE
+     sub-16px exception, not an oversight: at the 390px reference six equal
+     segments give ~65px each (~60px content) and the longest label "Nächstes"
+     (DE) measures ~67px at 13px (it would truncate) vs ~57px at 11px (fits).
+     The ≥16px floor is waived for this one control to keep full text labels
+     (matching the desktop HerdLensStrip's 11px labels); high contrast (amber
+     active / muted inactive) compensates. A text-overflow:ellipsis below handles
+     even-narrower fold-cover widths. */
   .seg-row {
     display: flex;
     border-bottom: 1px solid var(--color-line);
@@ -105,7 +121,7 @@
     border-right: 1px solid var(--color-line);
     background: none;
     font-family: inherit;
-    font-size: var(--fs-base);
+    font-size: var(--fs-meta);
     cursor: pointer;
     padding: 0 2px;
     color: var(--color-muted);

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1013,8 +1013,8 @@
   });
   // Owed lens count badge (#1257): eagerly load the durable post-merge steps on the DESKTOP layout
   // so the OWED lens badge reflects the outstanding count before the lens is ever opened. Gated on
-  // `!mobile.current` because the mobile branch renders HerdSegRow, which has no OWED segment (no
-  // badge to feed) — and re-fires if the viewport later widens to desktop. Once-only via the
+  // `!mobile.current` because the mobile branch renders HerdSegRow, whose OWED segment (#1198)
+  // carries no count badge to feed — and re-fires if the viewport later widens to desktop. Once-only via the
   // store's `loaded` guard; the store's in-flight guard stops a viewport toggle mid-load from
   // duplicating the GET. Live updates thereafter arrive via the `post-merge-steps:changed` WS event
   // (handled in store.svelte.ts), whose `refreshIfLoaded()` is a no-op until `loaded` is true.


### PR DESCRIPTION
Closes #1198.

Follow-up from the herd lens-strip redesign. The desktop/touch-wide `HerdLensStrip` exposes the **Owed** lens (post-merge manual steps still owed); the mobile tab row `HerdSegRow` did not — so on a phone there was no way to reach it. This adds the 6th segment.

## What

- **`HerdSegRow.svelte`** — add an **Owed** segment mirroring the rundown one: `filter = "owed"`, `title={m.herd_owed_title()}`, `use:coachTarget={"owed-lens"}`, label `{m.herd_seg_owed()}`. Reuses existing catalog keys — **no new i18n keys**.
- **Width budget** — six equal cells at the 390px reference give ~65px each (~60px content). The longest label `Nächstes` (DE) is ~67px at 13px and would truncate, breaking the "keep full text labels" criterion. Label font dropped `--fs-base` (13px) → `--fs-meta` (11px), where `Nächstes` is ~57px and **all six EN+DE labels fit** — matching the desktop `HerdLensStrip`'s 11px labels. Both block comments updated with the new math + the reviewer-confirmable sub-16px waiver (44px tap target preserved; contrast unchanged, amber active / muted inactive both > 4.5:1).
- **`+page.svelte`** — one-line comment fix: mobile now *has* an Owed segment but still carries no count badge, so the eager owed-load stays `!mobile.current`. No logic change.

## Out of scope (deliberate)

No count badge / `owedCount` plumbing on mobile (deferred with the rest of the badge treatment). The lens itself was already wired for any viewport — `Herd.svelte` renders `PostMergeStepsPanel` for `filter === "owed"`, and `+page.svelte`'s fallback effect lazy-loads owed records on lens-open regardless of viewport.

## Design review

Rendered both 6-up options (11px vs 13px) at 390px in EN+DE with live truncation measurement; operator picked the 11px option (all labels whole).

## Verification

- `cd ui && bun run check` → 0 errors, 0 warnings
- `cd ui && bun run check:i18n` → 2 locales in parity (2216 keys each; no new keys)
- eslint + prettier clean on both files

[no-feature-entry] — surfaces an existing lens on an existing control; no new user-facing capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)