### PR TITLE
docs(site): refresh landing page + README to current feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Shepherd
 
-> Self-hosted mission control for **interactive** Claude Code — and opinionated about how
-> agent-built software should ship. Spawn, watch, and steer a herd of real `claude` sessions from
-> your browser or phone, with best-practice guardrails built in. On your own server, on your own
-> subscription.
+> Self-hosted mission control for **interactive** AI coding CLIs — and opinionated about how
+> agent-built software should ship. Spawn, watch, and steer a herd of real `claude` sessions (with
+> the Codex CLI in alpha) from your browser or phone, with best-practice guardrails built in. On
+> your own server, on your own subscription.
 
-Shepherd spawns genuine interactive `claude` sessions in isolated git worktrees (via `herdr`, the
-interactive-pane manager), bridges each PTY to an `xterm.js` pane in the browser, and lets one
-operator run many agents in parallel — observing their status and steering them by typing, exactly
-like a human at a terminal. Around those sessions it adds the engineering discipline that parallel
-agent work otherwise erodes: every plan and PR faces adversarial review, and nothing merges while
-behind its base — a stale PR is rebased and re-verified first.
+Shepherd spawns genuine interactive `claude` sessions (and, in alpha, `codex` sessions) in isolated
+git worktrees (via `herdr`, the interactive-pane manager), bridges each PTY to an `xterm.js` pane in
+the browser, and lets one operator run many agents in parallel — observing their status and steering
+them by typing, exactly like a human at a terminal. Around those sessions it adds the engineering
+discipline that parallel agent work otherwise erodes: every plan and PR faces adversarial review,
+and nothing merges while behind its base — a stale PR is rebased and re-verified first.
 
 ## Opinionated by design
 
@@ -43,6 +43,9 @@ This is the defining constraint, not a footnote. Shepherd runs on the operator's
 subscription, so it **only drives interactive terminal sessions** — it never uses the Agent SDK or
 `claude -p`. It observes (reads the terminal + agent status) and steers (injects keystrokes into the
 live pane). Auth is the operator's own login; no token relay, no impersonation, single operator.
+
+The Codex CLI (alpha) is driven the same way — a genuine interactive terminal session, never a
+headless or scripted invocation.
 
 If a feature can't be done by typing into a real terminal, it doesn't ship. See `PRD.md` for the
 full rationale.

--- a/site/src/components/FeatureGrid.astro
+++ b/site/src/components/FeatureGrid.astro
@@ -1,9 +1,12 @@
 ---
-// Nine-card feature grid. Copy is faithful to the README "Opinionated by
-// design" + intro and the feature-announcement catalog
+// Nine-card feature grid — the capabilities you operate. The discipline GATES
+// (plan gate, critic, learnings, merge train, hygiene) live in their own
+// Guardrails section below, so they are not duplicated here. Copy is faithful
+// to the README and the feature-announcement catalog
 // (ui/src/lib/feature-announcements.ts) — describes what ships, no invented
-// capabilities. Body text is rendered verbatim (no markdown), so copy stays
-// plain prose with no backticks.
+// capabilities. Codex is alpha; never stated at parity with Claude. Body text
+// is rendered verbatim (no markdown), so copy stays plain prose with no
+// backticks.
 interface Feature {
   title: string;
   body: string;
@@ -12,39 +15,39 @@ interface Feature {
 const features: Feature[] = [
   {
     title: "Interactive agent control",
-    body: "Spawn, watch, and steer a herd of real claude sessions in isolated git worktrees, from your browser or phone.",
+    body: "Spawn, watch, and steer a herd of real agent sessions in isolated git worktrees, from your browser or phone.",
+  },
+  {
+    title: "Multi-CLI",
+    body: "Drive Claude Code today, with the Codex CLI in alpha — both as genuine interactive terminal sessions, never headless. A held task can hand off from one CLI to the other.",
   },
   {
     title: "Your /commands come with you",
-    body: "Every slash command, skill, and plugin you use locally is available — each session is a genuine interactive claude against your own ~/.claude. The cloud Claude Code can't carry that.",
+    body: "Every slash command, skill, and plugin you use locally is available — each Claude session is a genuine interactive claude against your own ~/.claude. The cloud Claude Code can't carry that.",
   },
   {
     title: "Readiness",
     body: "Scores a JS/TS repo's guardrails — typecheck, lint, tests, CI, house rules — before you point agents at it, turning gaps into an install task.",
   },
   {
-    title: "Plan gate",
-    body: "Before an autonomous run, the agent writes a plan a separate read-only reviewer grills adversarially; only a plan that survives review is released to implement.",
+    title: "Autopilot",
+    body: "Hand a task the whole loop: the agent plans, implements, opens a PR, addresses the critic's findings, and merges when it's ready — or completes research and issue-creation tasks that never produce a PR. Opt in per task, where you trust it.",
+  },
+  {
+    title: "Epics & sub-issues",
+    body: "Run an epic as many coordinated branches, backed by native GitHub sub-issues and grouped by epic. The landing PR auto-lands once every piece is green.",
   },
   {
     title: "Visual plans & recaps",
-    body: "Plan-gate plans render as a scannable document — file trees, diagrams, data models — not a wall of text. When a session finishes, its recap does the same: a tree of what changed, the annotated diff, and toned callouts.",
+    body: "Plan-gate plans render as a scannable document — file trees, diagrams, data models — not a wall of text. When a session finishes, its recap does the same: a tree of what changed, the annotated diff, toned callouts, and Mermaid diagrams.",
   },
   {
-    title: "Critic",
-    body: "The moment a PR's CI goes green, an isolated read-only agent reviews the full diff and posts a verdict; with Auto-Address on, findings flow back to the author until the list is empty.",
-  },
-  {
-    title: "Learnings",
-    body: "Distills past sessions' failure signals into proposed house rules; the ones you approve are injected into every new agent in the repo. Rules that stop helping retire themselves, can be scoped to matching paths, and — when they recur across repos — promote to your global config.",
-  },
-  {
-    title: "Merge train",
-    body: "A finished PR lands only when it's open, CI-green, conflict-free, and up to date; one that has fallen behind is rebased and fully re-verified first.",
+    title: "Dev-server preview",
+    body: "When a session starts a dev server, Shepherd serves it over Tailscale and drops a preview into the session — open the agent's running app from your phone, with no setup.",
   },
   {
     title: "Usage-aware",
-    body: "Run many agents on one subscription without burning it. When usage is high and a session is already running, new tasks hold and start on their own when usage resets — submit anyway to override. A session halted at a usage limit resumes in one click.",
+    body: "Run many agents on one subscription without burning it. When usage is high a new task holds and starts on its own when usage resets — submit anyway to override — and a session halted at a limit resumes in one click. A usage dashboard, timeline heatmap, and trends show where the tokens go.",
   },
 ];
 ---
@@ -53,9 +56,11 @@ const features: Feature[] = [
   <div class="inner">
     <header class="sec-head">
       <p class="eyebrow">What's in the herd</p>
-      <h2 id="features-h">
-        The discipline that keeps parallel agent work shippable
-      </h2>
+      <h2 id="features-h">Everything you operate the herd with</h2>
+      <p class="sub">
+        The review gates that keep its output shippable get their own section
+        below.
+      </p>
     </header>
 
     <ul class="grid">
@@ -101,6 +106,12 @@ const features: Feature[] = [
     font-weight: 700;
     font-size: clamp(1.6rem, 4vw, 2.4rem);
     letter-spacing: -0.02em;
+  }
+
+  .sub {
+    margin-top: 0.8rem;
+    color: var(--ink-muted);
+    font-size: 1rem;
   }
 
   .grid {

--- a/site/src/components/Guardrails.astro
+++ b/site/src/components/Guardrails.astro
@@ -17,11 +17,15 @@ const gates: Gate[] = [
   },
   {
     name: "Learnings",
-    body: "Approved house rules distilled from past failures are injected into every new agent in the repo.",
+    body: "House rules distilled from past failures are injected into every new agent in the repo; ones that stop helping retire themselves, and recurring ones promote across repos.",
   },
   {
     name: "Merge train",
     body: "Nothing lands while behind its base — a stale PR is rebased and fully re-verified first.",
+  },
+  {
+    name: "Manual operator steps",
+    body: "Human-only steps a PR declares — env vars, migrations, DNS cutovers — are surfaced and hold auto-merge until they are acknowledged.",
   },
   {
     name: "Hygiene gates",

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -18,15 +18,15 @@ const DOCS_URL = "https://docs.shepherd.run";
     </p>
 
     <h1 class="headline">
-      Run a herd of real Claude Code agents
+      Run a herd of real coding agents
       <span class="emph">ship only what survives review.</span>
     </h1>
 
     <p class="pitch">
-      Self-hosted mission control for interactive Claude Code — spawn, watch,
-      and steer a herd of real <code>claude</code> sessions from your browser or
-      phone, with best-practice guardrails built in. On your own server, on your
-      own subscription.
+      Self-hosted mission control for interactive AI coding CLIs — spawn, watch,
+      and steer a herd of real <code>claude</code> sessions (with the Codex CLI
+      in alpha) from your browser or phone, with best-practice guardrails built
+      in. On your own server, on your own subscription.
     </p>
 
     <div class="ctas">

--- a/site/src/components/LiveUpdates.astro
+++ b/site/src/components/LiveUpdates.astro
@@ -20,7 +20,7 @@ interface Split {
 const splits: Split[] = [
   {
     title: "herdr holds the sessions",
-    body: "The PTYs your claude agents run in live in herdr, not in Shepherd. A Shepherd restart never reaches into them — when the dashboard comes back, it just reattaches to the herd that kept running.",
+    body: "The PTYs your agents run in live in herdr, not in Shepherd. A Shepherd restart never reaches into them — when the dashboard comes back, it just reattaches to the herd that kept running.",
   },
   {
     title: "One click, in place",
@@ -42,8 +42,8 @@ const splits: Split[] = [
 
     <div class="claim">
       <p class="big">
-        herdr durably <strong>owns the interactive <code>claude</code> PTYs</strong>;
-        Shepherd is the <strong>control plane</strong> that bridges them to your
+        herdr durably <strong>owns the interactive agent PTYs</strong>; Shepherd
+        is the <strong>control plane</strong> that bridges them to your
         browser. So you can pull, rebuild, and restart Shepherd while agents are
         mid-task — the dashboard reloads, the sessions <strong>keep running and
         reattach</strong>. Nothing lost, no run interrupted.

--- a/site/src/components/Requirements.astro
+++ b/site/src/components/Requirements.astro
@@ -13,13 +13,13 @@ const osMatrix: OsRow[] = [
     os: "Linux",
     mode: "Full",
     modeKind: "full",
-    note: "systemd + unprivileged userns — sandbox membrane, egress allowlist, auto-drain, previews, and the systemd unit.",
+    note: "systemd + unprivileged userns — sandbox membrane, egress allowlist, auto-drain, tailscale-served dev-server previews, and the systemd unit.",
   },
   {
     os: "macOS",
     mode: "Core-only",
     modeKind: "degraded",
-    note: "Installs and builds, but no sandbox, egress allowlist, auto-drain, previews, or systemd unit. Run bun run start manually.",
+    note: "Installs and builds, but no sandbox, egress allowlist, auto-drain, dev-server previews, or systemd unit. Run bun run start manually.",
   },
   {
     os: "Windows",
@@ -31,8 +31,8 @@ const osMatrix: OsRow[] = [
 
 const needs = [
   "Bun — backend runtime + package manager",
-  "herdr on PATH — owns the interactive claude PTYs",
-  "The claude CLI, logged in",
+  "herdr on PATH — owns the interactive agent PTYs",
+  "The claude CLI, logged in (the Codex CLI too, for the alpha path)",
   "Node.js — for the PTY helper subprocess",
 ];
 ---

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -10,11 +10,11 @@ interface Props {
 const SITE_URL = "https://shepherd.run/";
 const OG_IMAGE = "https://shepherd.run/og-image.png";
 const OG_IMAGE_ALT =
-  "Shepherd — run a herd of real Claude Code agents; ship only what survives review.";
+  "Shepherd — run a herd of real coding agents; ship only what survives review.";
 
 const {
-  title = "Shepherd — run a herd of real Claude Code agents",
-  description = "Self-hosted mission control for interactive Claude Code — spawn, watch, and steer a herd of real claude sessions from your browser or phone, with best-practice guardrails built in.",
+  title = "Shepherd — run a herd of real coding agents",
+  description = "Self-hosted mission control for interactive AI coding CLIs — spawn, watch, and steer a herd of real claude sessions (Codex CLI in alpha) from your browser or phone, with best-practice guardrails built in.",
 } = Astro.props;
 ---
 


### PR DESCRIPTION
## Why

The marketing landing page (`site/`, Astro) had copy mapped to features through ~**v1.34**; the live feature catalog (`ui/src/lib/feature-announcements.ts`) is now at **v1.39.0**. The page was stale by several releases and missing whole systems. Per operator direction this also **broadens positioning from Claude-only to multi-CLI** (Claude primary, Codex labeled **alpha**) and **updates the README** to match.

## Highlights: what changed (the named deliverable)

The FeatureGrid and the Guardrails section overlapped — Plan gate, Critic, Learnings, and Merge train appeared in both. Each section now has a distinct job: **FeatureGrid = capabilities you operate**, **Guardrails = the discipline gates**.

**Removed from the grid** (they remain in Guardrails, with a new cross-reference line so they stay findable): Plan gate · Critic · Learnings · Merge train.

**Added** (shipped but previously absent): **Multi-CLI** (Claude + Codex alpha) · **Autopilot** · **Epics & sub-issues** · **Dev-server preview**.

**Kept (refreshed)**: Interactive agent control · `/commands` come with you · Readiness · Visual plans & recaps · Usage-aware (now covers the usage dashboard / timeline / trends).

Grid header re-framed from "The discipline that keeps parallel agent work shippable" to a capability framing, so it no longer promises discipline the grid no longer displays.

## Other sections

- **Hero + `Base.astro` meta/OG** — multi-CLI framing; the prerelease banner is left **byte-for-byte unchanged** (operator decision).
- **Guardrails** — refreshed Learnings; added a **Manual operator steps** gate.
- **LiveUpdates / Requirements** — generalized "interactive `claude` PTYs" → agent PTYs; aligned the three preview/live concepts (LiveUpdates self-redeploy vs. **dev-server preview** card vs. OS-matrix preview line); noted Codex (alpha) in needs. **ToS-compliance + auth language preserved intact.**
- **README** — intro/positioning broadened to multi-CLI, consistent with the site.

Every claim traces to a shipped catalog entry; Codex is labeled **alpha** wherever it appears.

## Verification

- `cd site && bun run check` (astro check): **0 errors** (1 pre-existing hint in InstallBlock, unrelated).
- `prettier --check` on all changed files: clean; pre-push hygiene gates (branch linearity, i18n parity, feature-catalog) passed.
- ⚠️ `bun run build` could **not** complete in this environment: Astro's `<Font>` integration fails fetching `@fontsource/space-grotesk@5.2.10/files/space-grotesk-vietnamese-400-normal.woff2` (HTTP **404** from jsdelivr). This is a **pre-existing, environmental/upstream** issue — the diff changes no `<Font>` line, so `main` fails identically. Flagging rather than expanding scope to fix it here.

[no-feature-entry] — marketing site + README only; no in-app UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)