### PR TITLE
fix(session): replace agent in same worktree

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2538,6 +2538,39 @@ async function handleSessionRelaunch({ req, parts, deps }: Ctx): Promise<Respons
   }
 }
 
+const inFlightReplace = new Set<string>();
+
+// POST /api/sessions/:id/replace — stop the current agent process and start a new provider/model
+// in the SAME Shepherd session and worktree. This is intentionally not relaunch: no new branch,
+// no new worktree, no archive event.
+async function handleSessionReplace({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (!(req.method === "POST" && parts[2] && parts[3] === "replace")) return null;
+  const id = parts[2];
+
+  if (inFlightReplace.has(id))
+    return json({ error: "replace already in progress", code: "in_progress" }, 409);
+  inFlightReplace.add(id);
+  try {
+    const original = deps.store.get(id);
+    if (!original) return json({ error: "not found" }, 404);
+    if (original.status === "archived") return json({ error: "already archived" }, 409);
+
+    const choice = await parseModelChoice(req);
+    if (!choice.ok) return choice.res;
+
+    let session: Session;
+    try {
+      session = await deps.service.replaceAgent(id, choice.value);
+    } catch (e) {
+      return json({ error: e instanceof Error ? e.message : "replace failed" }, 502);
+    }
+    deps.events.emit("session:status", session);
+    return json({ session }, 200);
+  } finally {
+    inFlightReplace.delete(id);
+  }
+}
+
 // Serialize concurrent same-key calls behind a 409: add the key, run, always remove. Shared by
 // the variant + compare routes (the relaunch route keeps its own copy with bespoke messaging).
 async function guardInFlight(
@@ -2816,6 +2849,7 @@ async function handleSessions(ctx: Ctx): Promise<Response | null> {
     handleSessionAutopilot,
     handleSessionAutoMerge,
     handleSessionRelaunch,
+    handleSessionReplace,
     handleSessionVariant,
     handleSessionRestore,
     handleRelaunchUploads,

--- a/src/service.ts
+++ b/src/service.ts
@@ -2065,6 +2065,15 @@ export class SessionService {
     return copied;
   }
 
+  private listWorktreeUploads(worktreePath: string): string[] {
+    const dir = worktreeUploadsDir(worktreePath);
+    if (!existsSync(dir)) return [];
+    return readdirSync(dir)
+      .sort()
+      .map((name) => join(dir, name))
+      .filter((p) => statSync(p).isFile());
+  }
+
   /**
    * Spawn a fresh replacement for an existing task, carrying its prompt and all
    * per-task settings — including the spawn-baked ones that can't be changed after
@@ -2155,6 +2164,105 @@ export class SessionService {
 
     // Re-fetch AFTER the override writes so the returned session reflects them.
     return this.deps.store.get(newSession.id)!;
+  }
+
+  /**
+   * Replace the live agent process for an existing Shepherd session without creating a new
+   * worktree or session row. Used by "Replace with…" when the operator wants the same task and
+   * same checked-out worktree to continue under a different CLI/model (e.g. Claude → Codex).
+   */
+  async replaceAgent(
+    id: string,
+    opts: { agentProvider?: AgentProvider; model: string | null },
+  ): Promise<Session> {
+    const s = this.deps.store.get(id);
+    if (!s || s.status === "archived")
+      throw new Error(`cannot replace agent for ${id}: missing or archived`);
+
+    const agentProvider = opts.agentProvider ?? s.agentProvider ?? "claude";
+    const model = modelForProviderOrDefault(opts.model, agentProvider);
+    const claudeSessionId = agentProvider === "claude" ? randomUUID() : "";
+    const carriedImages = this.listWorktreeUploads(s.worktreePath);
+    const promptImages = carriedImages.slice(0, MAX_IMAGES);
+    if (carriedImages.length > promptImages.length)
+      console.warn(
+        `[replace] ${s.id}: ${carriedImages.length} images exceed cap ${MAX_IMAGES}; dropped ${carriedImages.length - promptImages.length}`,
+      );
+    const input: CreateSessionInput = {
+      repoPath: s.repoPath,
+      baseBranch: s.baseBranch,
+      prompt: s.prompt,
+      agentProvider,
+      model,
+      images: [],
+      planGateEnabled: s.planGateEnabled,
+      autopilotEnabled: s.autopilotEnabled,
+      research: s.research,
+      auto: false,
+    };
+    const composed = await this.composePromptArg(input, s.worktreePath);
+    const promptArg =
+      promptImages.length > 0
+        ? `${composed.promptArg}\n\nAttached images:\n${promptImages.join("\n")}`
+        : composed.promptArg;
+    const launch = await this.resolveCreateLaunch(
+      input,
+      { isolated: s.isolated },
+      promptArg,
+      s.id,
+      claudeSessionId,
+    );
+
+    const outcome = await this.prepareSpawnOrThrow(launch.argv, {
+      sessionId: s.id,
+      name: s.name,
+      worktreePath: s.worktreePath,
+      repoPath: s.repoPath,
+      isolated: s.isolated,
+      auto: false,
+      profileOverride: launch.profileOverride,
+      model: launch.spawnInput.model,
+      agentProvider,
+    });
+
+    try {
+      this.deps.store.update(s.id, {
+        herdrAgentId: outcome.terminalId,
+        claudeSessionId: agentProvider === "claude" ? claudeSessionId : "",
+        agentProvider,
+        model: launch.spawnInput.model,
+        status: "running",
+        lastState: "idle",
+        readyToMerge: false,
+        mergingSince: null,
+        mergingTrainId: null,
+        mergingPrNumber: null,
+        planGateEnabled:
+          agentProvider === "claude" ? (launch.spawnInput.planGateEnabled ?? null) : false,
+        planPhase: launch.planGateOn ? "planning" : null,
+      });
+      this.deps.store.setSandboxState(s.id, {
+        applied: outcome.applied,
+        degraded: outcome.degraded,
+        egressApplied: outcome.egressApplied,
+        egressDegraded: outcome.egressDegraded,
+      });
+    } catch (e) {
+      try {
+        this.deps.herdr.stop(outcome.terminalId);
+      } catch {
+        /* best-effort: leave the original agent registered if persistence failed */
+      }
+      throw e;
+    }
+
+    try {
+      this.deps.herdr.stop(s.herdrAgentId);
+    } catch {
+      /* best-effort: the replacement is already persisted */
+    }
+
+    return this.deps.store.get(s.id)!;
   }
 
   /**

--- a/src/store.ts
+++ b/src/store.ts
@@ -1814,10 +1814,15 @@ export class SessionStore implements CapStore, CreditStore {
         | "lastState"
         | "branch"
         | "herdrAgentId"
+        | "claudeSessionId"
+        | "agentProvider"
+        | "model"
         | "readyToMerge"
         | "mergingSince"
         | "mergingTrainId"
         | "mergingPrNumber"
+        | "planGateEnabled"
+        | "planPhase"
       >
     >,
   ) {
@@ -1825,17 +1830,22 @@ export class SessionStore implements CapStore, CreditStore {
     if (!cur) return;
     const next = { ...cur, ...patch, updatedAt: Date.now() };
     this.db.run(
-      `UPDATE sessions SET name=?, status=?, lastState=?, branch=?, herdrAgentId=?, readyToMerge=?, mergingSince=?, mergingTrainId=?, mergingPrNumber=?, updatedAt=? WHERE id=?`,
+      `UPDATE sessions SET name=?, status=?, lastState=?, branch=?, herdrAgentId=?, claudeSessionId=?, agentProvider=?, model=?, readyToMerge=?, mergingSince=?, mergingTrainId=?, mergingPrNumber=?, planGateEnabled=?, planPhase=?, updatedAt=? WHERE id=?`,
       [
         next.name,
         next.status,
         next.lastState,
         next.branch,
         next.herdrAgentId,
+        next.claudeSessionId,
+        next.agentProvider ?? "claude",
+        next.model,
         next.readyToMerge ? 1 : 0,
         next.mergingSince,
         next.mergingTrainId,
         next.mergingPrNumber,
+        next.planGateEnabled === null ? null : next.planGateEnabled ? 1 : 0,
+        next.planPhase,
         next.updatedAt,
         id,
       ],

--- a/test/server-variant-compare.test.ts
+++ b/test/server-variant-compare.test.ts
@@ -14,11 +14,13 @@ function harness(opts: {
   original?: Partial<Session> | null;
   startVariant?: (id: string, choice: unknown) => Promise<{ variant: Session; original: Session }>;
   startComparison?: (experimentId: string, choice: unknown) => Promise<Session>;
+  replaceAgent?: (id: string, choice: unknown) => Promise<Session>;
 }) {
   const emitted: Spy[] = [];
   const calls = {
     startVariant: [] as Array<{ id: string; choice: unknown }>,
     startComparison: [] as Array<{ experimentId: string; choice: unknown }>,
+    replaceAgent: [] as Array<{ id: string; choice: unknown }>,
   };
 
   const originalSession =
@@ -57,6 +59,17 @@ function harness(opts: {
         experimentRole: "comparison",
       } as unknown as Session;
     },
+    replaceAgent: async (id: string, choice: unknown) => {
+      calls.replaceAgent.push({ id, choice });
+      if (opts.replaceAgent) return opts.replaceAgent(id, choice);
+      return {
+        ...originalSession,
+        id,
+        agentProvider: "codex",
+        model: "gpt-5.5",
+        worktreePath: "/same-wt",
+      } as unknown as Session;
+    },
   } as unknown as SessionService;
 
   const events = {
@@ -86,6 +99,17 @@ function variantReq(
 
 function compareReq(experimentId = "exp", body: unknown = { model: "opus" }): Request {
   return new Request(`http://localhost/api/experiments/${experimentId}/compare`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function replaceReq(
+  id = "orig",
+  body: unknown = { agentProvider: "codex", model: "gpt-5.5" },
+): Request {
+  return new Request(`http://localhost/api/sessions/${id}/replace`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
@@ -129,6 +153,33 @@ test("variant: 400 on an invalid model/provider pair", async () => {
   const res = await h.app.fetch(variantReq("orig", { agentProvider: "claude", model: "gpt-5.5" }));
   expect(res.status).toBe(400);
   expect(h.calls.startVariant).toHaveLength(0);
+});
+
+test("replace: updates the existing session and emits no new/archive events", async () => {
+  const h = harness({ original: { worktreePath: "/same-wt", agentProvider: "claude" } });
+  const res = await h.app.fetch(replaceReq());
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { session: Session };
+  expect(body.session.id).toBe("orig");
+  expect(body.session.worktreePath).toBe("/same-wt");
+  expect(h.calls.replaceAgent[0]).toEqual({
+    id: "orig",
+    choice: { agentProvider: "codex", model: "gpt-5.5" },
+  });
+  expect(h.emitted.map((e) => e.event)).toEqual(["session:status"]);
+  expect(h.emitted[0]?.data).toMatchObject({
+    id: "orig",
+    status: "running",
+    worktreePath: "/same-wt",
+    agentProvider: "codex",
+  });
+});
+
+test("replace: 400 on an invalid model/provider pair", async () => {
+  const h = harness({});
+  const res = await h.app.fetch(replaceReq("orig", { agentProvider: "claude", model: "gpt-5.5" }));
+  expect(res.status).toBe(400);
+  expect(h.calls.replaceAgent).toHaveLength(0);
 });
 
 test("compare: spawns, returns 201 and emits session:new", async () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -4580,8 +4580,13 @@ function relaunchHarness(store: SessionStore) {
     started: { name: string; cwd: string; argv: string[] }[];
     stopped: string[];
     removed: string[];
-  } = { started: [], stopped: [], removed: [] };
+    order: string[];
+  } = { started: [], stopped: [], removed: [], order: [] };
   let n = 0;
+  let failStart = false;
+  const breakStart = () => {
+    failStart = true;
+  };
   // Make the post-create override step throw (called only after seeding the original).
   const breakOverride = () => {
     store.setAutopilotState = () => {
@@ -4602,16 +4607,21 @@ function relaunchHarness(store: SessionStore) {
     } as any,
     herdr: {
       start: (name: string, cwd: string, argv: string[]) => {
+        if (failStart) throw new Error("spawn failed");
         calls.started.push({ name, cwd, argv });
+        calls.order.push("start");
         return { terminalId: `term_${n}`, agentStatus: "working" } as any;
       },
       list: () => [],
-      stop: (id: string) => calls.stopped.push(id),
+      stop: (id: string) => {
+        calls.stopped.push(id);
+        calls.order.push(`stop:${id}`);
+      },
     } as any,
     copyUploads: (images: string[], worktreePath: string) =>
       images.map((i) => `${worktreePath}/.shepherd-uploads/${i.split("/").pop()}`),
   });
-  return { service, calls, breakOverride };
+  return { service, calls, breakOverride, breakStart };
 }
 
 /** Seed a non-archived "original" session with the per-task settings to be copied. */
@@ -4736,6 +4746,96 @@ test("relaunch does NOT archive the original", async () => {
   expect(store.get(orig.id)?.status).not.toBe("archived");
   expect(calls.stopped).not.toContain("term_orig"); // original agent left running
   expect(calls.removed).not.toContain("/wt/orig"); // original worktree left in place
+});
+
+test("replaceAgent swaps provider in the same session and worktree", async () => {
+  const store = new SessionStore(":memory:");
+  const { service, calls } = relaunchHarness(store);
+  const orig = originalSession(store, { claudeSessionId: "claude-old", agentProvider: "claude" });
+  store.update(orig.id, {
+    status: "done",
+    lastState: "done",
+    readyToMerge: true,
+    mergingSince: 1234,
+    mergingTrainId: "train-1",
+    mergingPrNumber: 42,
+  });
+
+  const replaced = await service.replaceAgent(orig.id, {
+    agentProvider: "codex",
+    model: "gpt-5.5",
+  });
+
+  expect(replaced.id).toBe(orig.id);
+  expect(replaced.desig).toBe(orig.desig);
+  expect(replaced.worktreePath).toBe("/wt/orig");
+  expect(replaced.agentProvider).toBe("codex");
+  expect(replaced.model).toBe("gpt-5.5");
+  expect(replaced.claudeSessionId).toBe("");
+  expect(replaced.herdrAgentId).not.toBe("term_orig");
+  expect(replaced.status).toBe("running");
+  expect(replaced.lastState).toBe("idle");
+  expect(replaced.readyToMerge).toBe(false);
+  expect(replaced.mergingSince).toBeNull();
+  expect(replaced.mergingTrainId).toBeNull();
+  expect(replaced.mergingPrNumber).toBeNull();
+  expect(calls.stopped).toEqual(["term_orig"]);
+  expect(calls.order).toEqual(["start", "stop:term_orig"]);
+  expect(calls.started).toHaveLength(1);
+  expect(calls.started[0]).toMatchObject({ name: orig.name, cwd: "/wt/orig" });
+  expect(calls.started[0]!.argv.slice(0, 5)).toEqual([
+    "codex",
+    "--no-alt-screen",
+    "--dangerously-bypass-approvals-and-sandbox",
+    "--model",
+    "gpt-5.5",
+  ]);
+  expect(calls.removed).toEqual([]);
+});
+
+test("replaceAgent keeps the old agent registered if replacement spawn fails", async () => {
+  const store = new SessionStore(":memory:");
+  const { service, calls, breakStart } = relaunchHarness(store);
+  const orig = originalSession(store, { claudeSessionId: "claude-old", agentProvider: "claude" });
+  breakStart();
+
+  await expect(
+    service.replaceAgent(orig.id, { agentProvider: "codex", model: "gpt-5.5" }),
+  ).rejects.toThrow("spawn failed");
+
+  const persisted = store.get(orig.id)!;
+  expect(persisted.herdrAgentId).toBe("term_orig");
+  expect(persisted.agentProvider).toBe("claude");
+  expect(persisted.claudeSessionId).toBe("claude-old");
+  expect(calls.stopped).toEqual([]);
+});
+
+test("replaceAgent re-attaches existing uploads without copying them back into the same worktree", async () => {
+  const store = new SessionStore(":memory:");
+  const root = mkdtempSync(join(tmpdir(), "replace-root-"));
+  const wt = mkdtempSync(join(tmpdir(), "replace-wt-"));
+  const uploads = join(wt, ".shepherd-uploads");
+  mkdirSync(uploads, { recursive: true });
+  writeFileSync(join(uploads, "diagram.png"), "PNGDATA");
+
+  const prevRoot = config.repoRoot;
+  config.repoRoot = root;
+  try {
+    const { service, calls } = relaunchHarness(store);
+    const orig = originalSession(store, { worktreePath: wt });
+
+    await service.replaceAgent(orig.id, { agentProvider: "codex", model: null });
+    await service.replaceAgent(orig.id, { agentProvider: "claude", model: null });
+
+    const promptArg = calls.started[0]!.argv.at(-1)!;
+    expect(promptArg).toContain("Attached images:");
+    expect(promptArg).toContain(join(uploads, "diagram.png"));
+    expect(calls.started[1]!.argv.at(-1)!).toContain(join(uploads, "diagram.png"));
+    expect(readdirSync(uploads)).toEqual(["diagram.png"]);
+    expect(existsSync(join(root, ".shepherd-uploads-staging"))).toBe(false);
+  } finally {
+    config.repoRoot = prevRoot;
+  }
 });
 
 test("relaunch tears down the just-created session if a post-create step throws (no orphan)", async () => {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -42,6 +42,32 @@ test("session agentProvider defaults to claude and round-trips codex", () => {
   expect(s.get(codex.id)?.agentProvider).toBe("codex");
 });
 
+test("update can replace a session's agent identity without changing the row", () => {
+  const s = mk();
+  const orig = s.create({ ...base, claudeSessionId: "claude-old", model: "opus" });
+
+  s.update(orig.id, {
+    herdrAgentId: "term_codex",
+    claudeSessionId: "",
+    agentProvider: "codex",
+    model: "gpt-5.5",
+    status: "running",
+    lastState: "idle",
+    planGateEnabled: false,
+    planPhase: null,
+  });
+
+  const got = s.get(orig.id)!;
+  expect(got.id).toBe(orig.id);
+  expect(got.worktreePath).toBe(orig.worktreePath);
+  expect(got.herdrAgentId).toBe("term_codex");
+  expect(got.claudeSessionId).toBe("");
+  expect(got.agentProvider).toBe("codex");
+  expect(got.model).toBe("gpt-5.5");
+  expect(got.planGateEnabled).toBe(false);
+  expect(got.planPhase).toBeNull();
+});
+
 test("lastUsedByRepo returns max createdAt per repoPath", () => {
   const s = mk();
   s.create({ ...base, repoPath: "/a", herdrAgentId: "t1" });

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -769,6 +769,16 @@ export interface VariantChoice {
   model: string | null;
 }
 
+/** Replace the agent CLI/model in-place, keeping the same Shepherd session + worktree. */
+export async function replaceSessionAgent(id: string, choice: VariantChoice): Promise<Session> {
+  const { session } = await postJson<{ session: Session }>(
+    `/api/sessions/${id}/replace`,
+    choice,
+    "replace",
+  );
+  return session;
+}
+
 /**
  * Start a parallel comparison VARIANT of a session: same task, different model/CLI. The original
  * stays alive; both are linked into one comparison experiment. Returns the new variant session.

--- a/ui/src/lib/components/ExperimentPicker.svelte
+++ b/ui/src/lib/components/ExperimentPicker.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { m } from "$lib/paraglide/messages";
   import type { AgentProvider } from "$lib/types";
-  import { startVariant, startComparison, relaunchSession } from "$lib/api";
+  import { startVariant, startComparison, replaceSessionAgent } from "$lib/api";
   import { toasts } from "$lib/toasts.svelte";
   import ModelCliPicker from "./new-task/ModelCliPicker.svelte";
 
@@ -57,14 +57,7 @@
     id: string,
     choice: { agentProvider: AgentProvider; model: string | null },
   ) {
-    const { session, archived } = await relaunchSession(id, choice);
-    if (archived) toasts.info(m.relaunch_done({ desig: session.desig }));
-    else
-      toasts.info(m.relaunch_archive_failed(), {
-        duration: null,
-        alert: true,
-        key: `relaunch-fail:${id}`,
-      });
+    const session = await replaceSessionAgent(id, choice);
     onselect(session.id);
   }
 

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -105,6 +105,29 @@ test("session:ready patches the target session's readyToMerge", () => {
   expect(s.byId("s1")?.readyToMerge).toBe(false);
 });
 
+test("session:status with session fields patches the existing row in place", () => {
+  const s = new HerdStore();
+  const original = session("s1");
+  s.setAll([original]);
+  s.apply({
+    event: "session:status",
+    data: {
+      ...original,
+      herdrAgentId: "term_codex",
+      claudeSessionId: "",
+      agentProvider: "codex",
+      model: "gpt-5.5",
+      status: "running",
+      worktreePath: "/wt",
+    },
+  });
+  expect(s.sessions).toHaveLength(1);
+  expect(s.byId("s1")?.worktreePath).toBe("/wt");
+  expect(s.byId("s1")?.herdrAgentId).toBe("term_codex");
+  expect(s.byId("s1")?.agentProvider).toBe("codex");
+  expect(s.byId("s1")?.model).toBe("gpt-5.5");
+});
+
 test("session:experiment links the target into a comparison group live", () => {
   const s = new HerdStore();
   s.setAll([session("s1"), session("s2")]);

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -311,8 +311,10 @@ export class HerdStore {
   /** Apply a session:status push. Merges the turn-end scratchpad flag (#1164) only when this
    *  push carries it (idle/done transitions); the undefined guard stops a status-only push
    *  (e.g. → running) from clobbering the live flag back to falsy. */
-  private applyStatus(d: { id: string; status: SessionStatus; hasScratchpadFiles?: boolean }) {
-    const patch: Partial<Session> = { status: d.status };
+  private applyStatus(
+    d: { id: string; status: SessionStatus; hasScratchpadFiles?: boolean } & Partial<Session>,
+  ) {
+    const patch: Partial<Session> = { ...d, status: d.status };
     if (d.hasScratchpadFiles !== undefined) patch.hasScratchpadFiles = d.hasScratchpadFiles;
     this.patchSession(d.id, patch);
   }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1324,7 +1324,7 @@ export type WsEvent =
   | { event: "session:new"; data: Session }
   | {
       event: "session:status";
-      data: { id: string; status: SessionStatus; hasScratchpadFiles?: boolean };
+      data: { id: string; status: SessionStatus; hasScratchpadFiles?: boolean } & Partial<Session>;
     }
   | { event: "session:ready"; data: { id: string; ready: boolean } }
   | {


### PR DESCRIPTION
## Summary
- add in-place agent replacement for existing sessions using the same DB row and worktree
- wire the Replace with picker to the new replace endpoint and update clients via session status payloads
- cover the route, service, store, and UI session-event behavior with tests

## Tests
- bun run lint
- bun run test
- cd ui && bun run test
- cd ui && bun run check
- cd ui && bun run check:i18n
- cd extension && bun run check

Manual steps: None.