### PR TITLE
fix(autopilot): align Codex full-auto recovery

### DIFF
--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -47,7 +47,9 @@ export function epicBaseDirective(baseBranch: string): string {
 export function openPrSteer(draftMode: boolean, baseBranch: string): string {
   const steer = [
     "You're in autopilot and you've stopped, but there's no pull request yet. Commit your",
-    `work, push the branch, and open a PR (gh pr create --base ${baseBranch}). If something`,
+    `work, push the branch, and open a PR (gh pr create --base ${baseBranch}). Before committing,`,
+    "pushing, or opening the PR, run the relevant local lint/check/test commands from the repository",
+    "instructions for the files you touched, and fix failures before proceeding. If something",
     "genuinely blocks that, say specifically what you need.",
   ].join("\n");
   return draftMode ? `${steer} ${DRAFT_PR_NOTE}` : steer;

--- a/src/full-auto.ts
+++ b/src/full-auto.ts
@@ -15,17 +15,19 @@ import { isEpicIntegrationBranch } from "./epic-branch";
  * autoMergeEnabled override — draft PRs must go through sign-off before they can be landed.
  */
 export function isFullAuto(
-  s: Pick<Session, "autopilotEnabled" | "autoMergeEnabled" | "baseBranch" | "agentProvider">,
+  s: Pick<Session, "autopilotEnabled" | "autoMergeEnabled" | "baseBranch" | "agentProvider"> & {
+    isolated?: boolean;
+  },
   cfg: Pick<RepoConfig, "autopilotEnabled" | "autoMergeEnabled" | "draftMode">,
 ): boolean {
   // Epic children are squash-merged into their integration branch by the drain's retire path,
   // never carried by the merge train — exclude them regardless of repo auto-merge config.
   if (isEpicIntegrationBranch(s.baseBranch)) return false;
-  // Codex autopilot deliberately ends AT the open PR ("bis zum PR"): never landed by the merge
-  // train, never driven past the PR. (Codex autopilot is best-effort/Alpha; auto-merge for codex
-  // is explicitly out of scope.) The isolation guard in autopilot.ts eligible() does not cover
-  // the merge-train/drain legs, which call isFullAuto directly — so the cutoff lives here.
-  if ((s.agentProvider ?? "claude") === "codex") return false;
+  // Codex can only be carried by full-auto when Shepherd owns an isolated worktree. Rebase/CI
+  // recovery may resume the pane, and Codex resume is currently `codex resume --last`; in a shared
+  // cwd that can target a sibling Codex session. This mirrors autopilot.ts's isolated-session guard
+  // while still letting isolated Codex autopilot use the same post-PR recovery path as Claude.
+  if ((s.agentProvider ?? "claude") === "codex" && s.isolated !== true) return false;
   const autopilot = effectiveAutopilot(s, cfg.autopilotEnabled);
   const merge = cfg.draftMode ? false : (s.autoMergeEnabled ?? cfg.autoMergeEnabled);
   return autopilot && merge;

--- a/src/service.ts
+++ b/src/service.ts
@@ -476,7 +476,10 @@ const AUTOPILOT_DIRECTIVE =
   "You are running unattended in Shepherd autopilot. Do not stop to ask for permission on " +
   "procedural or workflow steps — writing a spec or plan, committing, pushing, or opening a " +
   "pull request. Make a reasonable decision and keep going until the task's deliverable is " +
-  "complete; for a code change that means an open PR (`gh pr create`). Only stop to ask when " +
+  "complete; for a code change that means verified local changes and an open PR (`gh pr create`). " +
+  "Before committing, pushing, or opening the PR for a code change, run the relevant local " +
+  "lint/check/test commands from the repository instructions for the files you touched, and fix " +
+  "failures before proceeding. Only stop to ask when " +
   "you hit a genuine product or requirements decision that only a human can make.";
 
 /**
@@ -808,8 +811,10 @@ export function PREVIEW_START_STEER(
  *  When `draftMode` is true, appends the draft-PR note so the agent opens a draft PR. */
 const PLAN_GO_STEER_BASE =
   "Plan approved. Execute `.shepherd-plan.md` now, autonomously — implement it fully, commit, push, " +
-  "and open a pull request (`gh pr create`). Don't re-litigate the plan; if you hit a genuine product " +
-  "decision that only the user can make, ask, otherwise keep going.";
+  "and open a pull request (`gh pr create`). Before committing, pushing, or opening the PR, run the " +
+  "relevant local lint/check/test commands from the repository instructions for the files you " +
+  "touched, and fix failures before proceeding. Don't re-litigate the plan; if you hit a genuine " +
+  "product decision that only the user can make, ask, otherwise keep going.";
 
 /** Returns the plan-go steer, appending the draft-mode note when `draftMode` is true. */
 export function planGoSteer(draftMode: boolean): string {

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -232,6 +232,12 @@ test("openPrSteer carries an explicit --base for the session's base branch", () 
   expect(openPrSteer(false, "main")).toContain("gh pr create --base main");
 });
 
+test("openPrSteer requires local verification before commit/push/PR", () => {
+  const steer = openPrSteer(false, "main");
+  expect(steer).toContain("Before committing");
+  expect(steer).toContain("lint/check/test");
+});
+
 test("openPrSteer(false, ...) omits the draft note", () => {
   expect(openPrSteer(false, "main")).not.toContain(DRAFT_PR_NOTE);
 });

--- a/test/full-auto.test.ts
+++ b/test/full-auto.test.ts
@@ -57,18 +57,19 @@ test("isFullAuto: draftMode off, autopilot off → false (unchanged behavior)", 
   expect(isFullAuto(session, fullAutoCfg)).toBe(false);
 });
 
-test("isFullAuto: codex provider → false even with autopilot + auto-merge both on (bis zum PR, never landed)", () => {
+test("isFullAuto: non-isolated codex provider → false even with autopilot + auto-merge both on", () => {
   const codexSession = {
     autopilotEnabled: true as boolean | null,
     autoMergeEnabled: true as boolean | null,
     baseBranch: "main",
     agentProvider: "codex" as const,
+    isolated: false,
   };
-  // Codex autopilot deliberately stops AT the open PR — the merge train must never carry it.
+  // Non-isolated Codex resume is unsafe (`codex resume --last` can target a sibling session).
   expect(isFullAuto(codexSession, fullAutoCfg)).toBe(false);
 });
 
-test("isFullAuto: codex provider → false even when it inherits repo auto-merge (session autoMerge null)", () => {
+test("isFullAuto: codex provider without an isolated flag → false fail-closed", () => {
   const codexInherits = {
     autopilotEnabled: true as boolean | null,
     autoMergeEnabled: null as boolean | null,
@@ -76,6 +77,28 @@ test("isFullAuto: codex provider → false even when it inherits repo auto-merge
     agentProvider: "codex" as const,
   };
   expect(isFullAuto(codexInherits, fullAutoCfg)).toBe(false);
+});
+
+test("isFullAuto: isolated codex provider → true with autopilot + auto-merge both on", () => {
+  const codexSession = {
+    autopilotEnabled: true as boolean | null,
+    autoMergeEnabled: true as boolean | null,
+    baseBranch: "main",
+    agentProvider: "codex" as const,
+    isolated: true,
+  };
+  expect(isFullAuto(codexSession, fullAutoCfg)).toBe(true);
+});
+
+test("isFullAuto: isolated codex provider → true when it inherits repo auto-merge", () => {
+  const codexInherits = {
+    autopilotEnabled: true as boolean | null,
+    autoMergeEnabled: null as boolean | null,
+    baseBranch: "main",
+    agentProvider: "codex" as const,
+    isolated: true,
+  };
+  expect(isFullAuto(codexInherits, fullAutoCfg)).toBe(true);
 });
 
 test("isFullAuto: claude provider with same config → true (codex guard does not regress claude)", () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -3066,6 +3066,8 @@ test("composeSystemPrompt adds the autopilot directive only when active", () => 
   const on = composeSystemPrompt(null, true);
   expect(on).toContain("<autopilot-directive>");
   expect(on).toContain("Shepherd autopilot");
+  expect(on).toContain("verified local changes");
+  expect(on).toContain("lint/check/test");
   expect(on).toContain("<branch-rename-notice>"); // still present alongside
 });
 
@@ -4068,6 +4070,7 @@ test("composeSystemPrompt <draft-mode> block is present alongside autopilot dire
 test("planGoSteer(false) matches the base text exactly (no draft note)", () => {
   const steer = planGoSteer(false);
   expect(steer).toContain("gh pr create");
+  expect(steer).toContain("lint/check/test");
   expect(steer).not.toContain(DRAFT_PR_NOTE);
 });
 


### PR DESCRIPTION
## Summary
- let isolated Codex autopilot sessions participate in the same full-auto post-PR recovery path as Claude, while keeping non-isolated Codex fail-closed because `codex resume --last` can target a sibling session
- require autopilot agents to run relevant local lint/check/test commands before commit, push, or PR creation in spawn-time, plan-go, and reactive open-PR steers
- update coverage for Codex full-auto eligibility and the verification wording

## Verification
- `bun test ./test/full-auto.test.ts`
- `bun test ./test/autopilot.test.ts`
- `bun test ./test/service.test.ts -t "autopilot directive|planGoSteer|codex"`
- `bun run lint`
- `bun run typecheck`
- `bun test ./test`
- `bunx prettier --check src/autopilot.ts src/full-auto.ts src/service.ts test/autopilot.test.ts test/full-auto.test.ts test/service.test.ts`
- pre-push hook: prettier, eslint, gates, tsc, ext, root-tests, ui, fallow audit