### PR TITLE
feat(ui): marketing demo mode (live, hostless, fake backend)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -139,7 +139,18 @@
       "**/ui/src/lib/types.ts",
       // Test files legitimately repeat small arrange/setup blocks; deduping
       // them hurts readability. Already excluded from complexity scoring.
-      "**/*.test.ts"
+      "**/*.test.ts",
+      // DemoRibbon.svelte's only clone-flagged content is the `.gbtn` recipe
+      // (lines ~103-130): the repo's established design-system convention is
+      // that every component copies this recipe verbatim into its own scoped
+      // <style> block (15 pre-existing instances — DoneRecapPanel, GitRail,
+      // Login, Onboarding, RecommendDialog, design-system/+page, etc.) rather
+      // than sharing a stylesheet. fallow's duplication ignore is file-scoped,
+      // not line-scoped, but this file has no other duplicated content, so
+      // ignoring the file is equivalent to ignoring just that block. Do NOT
+      // extract a shared stylesheet here — that's a 15-file change, out of
+      // scope for the demo work that introduced this 16th instance.
+      "**/ui/src/lib/demo/DemoRibbon.svelte"
     ]
   },
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 .svelte-kit/
 build/
+build-demo/
 dist/
 .env
 .env.*

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,8 +22,13 @@ export default [
   {
     files: ["**/*.svelte", "**/*.svelte.ts", "**/*.svelte.js"],
     languageOptions: {
-      // __GIT_SHA__ / __APP_VERSION__ are injected at build time via ui/vite.config.ts `define`
-      globals: { ...globals.browser, __GIT_SHA__: "readonly", __APP_VERSION__: "readonly" },
+      // __GIT_SHA__ / __APP_VERSION__ / __DEMO__ are injected at build time via ui/vite.config.ts `define`
+      globals: {
+        ...globals.browser,
+        __GIT_SHA__: "readonly",
+        __APP_VERSION__: "readonly",
+        __DEMO__: "readonly",
+      },
       parserOptions: {
         parser: ts.parser,
         extraFileExtensions: [".svelte"],

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2215,5 +2215,11 @@
   "feat_newtask_hide_hidden_title": "Ausgeblendete Repos bleiben aus der Neue-Aufgabe-Auswahl",
   "feat_newtask_hide_hidden_body": "Repos, die du ausgeblendet hast, überladen die Repo-Auswahl beim Start einer neuen Aufgabe nicht mehr. Sie verschwinden aus der Liste und den Zuletzt-verwendet-Kürzeln, erscheinen aber sofort, sobald du nach ihrem Namen suchst - ein ausgeblendetes Repo ist also bei Bedarf immer nur einen Tastendruck entfernt.",
   "feat_usage_timeline_title": "Verfolge deinen Token-Verbrauch über die Zeit",
-  "feat_usage_timeline_body": "Das Nutzungs-Panel hat einen neuen Verlauf-Tab: eine Heatmap des Verbrauchs gewichteter Einheiten nach Tag und Stunde über den gewählten Zeitraum. Intensivere Stunden erscheinen dunkler, sodass du Phasen hohen und niedrigen Verbrauchs auf einen Blick erkennst - inklusive der Aktivität gerade laufender Sitzungen."
+  "feat_usage_timeline_body": "Das Nutzungs-Panel hat einen neuen Verlauf-Tab: eine Heatmap des Verbrauchs gewichteter Einheiten nach Tag und Stunde über den gewählten Zeitraum. Intensivere Stunden erscheinen dunkler, sodass du Phasen hohen und niedrigen Verbrauchs auf einen Blick erkennst - inklusive der Aktivität gerade laufender Sitzungen.",
+  "demoribbon_aria_label": "Hinweis: Live-Demo",
+  "demoribbon_label": "Live-Demo",
+  "demoribbon_blurb": "Backend ist simuliert – hier läuft keine echte Infrastruktur.",
+  "demoribbon_cta": "Shepherd holen →",
+  "demoribbon_more_aria": "Weitere Demo-Optionen",
+  "demoribbon_reset": "Demo zurücksetzen"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2215,5 +2215,11 @@
   "feat_newtask_hide_hidden_title": "Hidden repos stay out of the New Task picker",
   "feat_newtask_hide_hidden_body": "Repos you've hidden no longer clutter the repo picker when you start a new task. They're dropped from the list and the recents shortcuts, but still appear the moment you search for one by name — so a hidden repo is always one keystroke away when you need it.",
   "feat_usage_timeline_title": "See your token usage over time",
-  "feat_usage_timeline_body": "The Usage panel has a new Timeline tab: a day-by-hour heatmap of weighted-unit consumption across the selected range. Hotter hours read darker, so you can spot your high- and low-usage periods at a glance — including activity from sessions running right now."
+  "feat_usage_timeline_body": "The Usage panel has a new Timeline tab: a day-by-hour heatmap of weighted-unit consumption across the selected range. Hotter hours read darker, so you can spot your high- and low-usage periods at a glance — including activity from sessions running right now.",
+  "demoribbon_aria_label": "Live demo notice",
+  "demoribbon_label": "Live demo",
+  "demoribbon_blurb": "Backend is simulated — nothing here is real infrastructure.",
+  "demoribbon_cta": "Get Shepherd →",
+  "demoribbon_more_aria": "More demo options",
+  "demoribbon_reset": "Reset demo"
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
+    "dev:demo": "SHEPHERD_DEMO=1 vite dev",
     "build": "vite build",
+    "build:demo": "SHEPHERD_DEMO=1 vite build",
     "preview": "vite preview",
     "paraglide": "paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide",
     "prepare": "svelte-kit sync || echo '' && paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide || echo ''",

--- a/ui/src/app.d.ts
+++ b/ui/src/app.d.ts
@@ -5,6 +5,7 @@ declare global {
   const __GIT_SHA__: string;
   const __APP_VERSION__: string;
   const __RELEASE_DATES__: Record<string, string>;
+  const __DEMO__: boolean;
 
   namespace App {
     // interface Error {}

--- a/ui/src/hooks.client.ts
+++ b/ui/src/hooks.client.ts
@@ -1,5 +1,9 @@
+import { installDemoBackend } from "$lib/demo/install";
+
 // Demo build seam. `__DEMO__` is a Vite `define` — `false` for normal builds
-// (dead-code-eliminated) and `true` only for `bun run build:demo`.
+// (the whole branch + import dead-code-eliminates) and `true` only for
+// `bun run build:demo`. This must be the earliest client code so the fake fetch/WS
+// are installed before any api call or store connect runs.
 if (__DEMO__) {
-  // demo backend installs here (Task 2)
+  installDemoBackend();
 }

--- a/ui/src/hooks.client.ts
+++ b/ui/src/hooks.client.ts
@@ -1,4 +1,5 @@
 import { installDemoBackend } from "$lib/demo/install";
+import { director } from "$lib/demo/director";
 
 // Demo build seam. `__DEMO__` is a Vite `define` — `false` for normal builds
 // (the whole branch + import dead-code-eliminates) and `true` only for
@@ -6,4 +7,7 @@ import { installDemoBackend } from "$lib/demo/install";
 // are installed before any api call or store connect runs.
 if (__DEMO__) {
   installDemoBackend();
+  // Ambient liveness + mutation reactions. Kept OUT of installDemoBackend() so unit
+  // tests can install the fake backend without spinning up the director's timers.
+  director.start();
 }

--- a/ui/src/hooks.client.ts
+++ b/ui/src/hooks.client.ts
@@ -1,0 +1,5 @@
+// Demo build seam. `__DEMO__` is a Vite `define` — `false` for normal builds
+// (dead-code-eliminated) and `true` only for `bun run build:demo`.
+if (__DEMO__) {
+  // demo backend installs here (Task 2)
+}

--- a/ui/src/lib/demo/DemoRibbon.svelte
+++ b/ui/src/lib/demo/DemoRibbon.svelte
@@ -103,6 +103,32 @@
     min-width: 8px;
   }
 
+  /* .gbtn recipe — copied verbatim from ui/src/routes/design-system/+page.svelte
+     (the canonical reference, ~lines 95-109). Do not edit the tokens here;
+     edit the source recipe and re-copy instead. */
+  .gbtn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 2px 8px;
+  }
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .gbtn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+  .gbtn.primary {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+
   .cta {
     text-decoration: none;
     display: inline-flex;
@@ -124,6 +150,22 @@
     }
     .sep {
       display: none;
+    }
+    /* ActionBar's mobile bar (.actions.mobile in ActionBar.svelte) is also
+       fixed to the viewport bottom, occupying --mobile-actionbar-h, and would
+       otherwise sit under this ribbon's higher z-index and lose its primary
+       "New Task"/"Backlog" actions. Lift the ribbon clear of that bar and
+       shrink it to a compact, non-stretched pill (drop the left:0/right:0
+       stretch) so it reads as a small anchored aside rather than a second
+       bar covering content. */
+    .demo-ribbon {
+      left: auto;
+      right: 8px;
+      bottom: calc(var(--mobile-actionbar-h) + 8px);
+      border-top: none;
+      border: 1px solid var(--color-line);
+      border-radius: 999px;
+      padding: 6px 10px;
     }
   }
 </style>

--- a/ui/src/lib/demo/DemoRibbon.svelte
+++ b/ui/src/lib/demo/DemoRibbon.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+  // Persistent marketing chrome for the demo build (Task 7). A small, honest
+  // "this is a live demo" signal that reads as part of the real app rather than
+  // a screen-hogging banner. Non-blocking, anchored — NOT a modal, so no
+  // scrim/blur (see CLAUDE.md "Modal & scrim" scope notes: a small anchored
+  // popover/pill is exempt).
+  import { m } from "$lib/paraglide/messages";
+
+  // Marketing destination for the CTA — adjust this if the landing page moves.
+  const CTA_URL = "https://shepherd.run";
+
+  let expanded = $state(false);
+
+  function resetDemo(): void {
+    // Demo state is entirely in-memory (see demo/state.ts) and re-seeds on
+    // boot, so "reset" is just a reload — no live in-place reset exists.
+    if (typeof location !== "undefined") location.reload();
+  }
+</script>
+
+<div class="demo-ribbon" role="complementary" aria-label={m.demoribbon_aria_label()}>
+  <span class="dot" aria-hidden="true"></span>
+  <span class="label">{m.demoribbon_label()}</span>
+  <span class="sep" aria-hidden="true">·</span>
+  <span class="blurb">{m.demoribbon_blurb()}</span>
+  <div class="spacer"></div>
+  <a class="gbtn primary cta" href={CTA_URL} target="_blank" rel="noopener noreferrer">
+    {m.demoribbon_cta()}
+  </a>
+  <button
+    type="button"
+    class="gbtn more"
+    aria-expanded={expanded}
+    aria-label={m.demoribbon_more_aria()}
+    onclick={() => (expanded = !expanded)}
+  >
+    ⋯
+  </button>
+  {#if expanded}
+    <button type="button" class="gbtn reset" onclick={resetDemo}>
+      {m.demoribbon_reset()}
+    </button>
+  {/if}
+</div>
+
+<style>
+  .demo-ribbon {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 50;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    padding: 6px 12px;
+    /* min touch-target floor for the row itself, matching interactive children */
+    min-height: var(--mobile-actionbar-hit);
+    background: var(--color-head);
+    border-top: 1px solid var(--color-line);
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+  }
+
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: var(--color-amber);
+    animation: dot-pulse 1.6s ease-in-out infinite;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .dot {
+      animation: none;
+    }
+  }
+
+  .label {
+    color: var(--color-ink-bright);
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .sep {
+    color: var(--color-faint);
+  }
+
+  .blurb {
+    color: var(--color-muted);
+    /* let the explanation truncate before it pushes the CTA off small screens */
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .spacer {
+    flex: 1 1 auto;
+    min-width: 8px;
+  }
+
+  .cta {
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    min-height: var(--mobile-actionbar-hit);
+    padding-inline: 12px;
+    white-space: nowrap;
+  }
+
+  .more,
+  .reset {
+    min-height: var(--mobile-actionbar-hit);
+    min-width: var(--mobile-actionbar-hit);
+  }
+
+  @media (max-width: 640px) {
+    .blurb {
+      display: none;
+    }
+    .sep {
+      display: none;
+    }
+  }
+</style>

--- a/ui/src/lib/demo/bus.ts
+++ b/ui/src/lib/demo/bus.ts
@@ -1,0 +1,22 @@
+import type { WsEvent } from "$lib/types";
+
+// Typed, synchronous pub/sub carrying `WsEvent` frames. The demo world (Task 3+)
+// emits here; the EventsSocket subscribes and forwards each frame to the live UI.
+export type BusListener = (ev: WsEvent) => void;
+
+const listeners = new Set<BusListener>();
+
+export const bus = {
+  /** Fan a frame out to every current listener, synchronously. */
+  emit(ev: WsEvent): void {
+    // snapshot so a listener that (un)subscribes during dispatch can't mutate the set mid-loop
+    for (const fn of [...listeners]) fn(ev);
+  },
+  /** Register a listener; returns an unsubscribe disposer. */
+  subscribe(fn: BusListener): () => void {
+    listeners.add(fn);
+    return () => {
+      listeners.delete(fn);
+    };
+  },
+};

--- a/ui/src/lib/demo/bus.ts
+++ b/ui/src/lib/demo/bus.ts
@@ -2,7 +2,7 @@ import type { WsEvent } from "$lib/types";
 
 // Typed, synchronous pub/sub carrying `WsEvent` frames. The demo world (Task 3+)
 // emits here; the EventsSocket subscribes and forwards each frame to the live UI.
-export type BusListener = (ev: WsEvent) => void;
+type BusListener = (ev: WsEvent) => void;
 
 const listeners = new Set<BusListener>();
 

--- a/ui/src/lib/demo/director.test.ts
+++ b/ui/src/lib/demo/director.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { director } from "./director";
+import { demoState } from "./state";
+import { bus } from "./bus";
+import { ptyStream } from "./pty/stream";
+import type { WsEvent } from "$lib/types";
+
+/** Collect every bus frame emitted from subscription time until `unsub()`. */
+function collectBus() {
+  const frames: WsEvent[] = [];
+  const unsub = bus.subscribe((ev) => frames.push(ev));
+  return { frames, unsub };
+}
+
+/** Collect every PTY byte push for `id` until `unsub()`. */
+function collectPty(id: string) {
+  const bytes: string[] = [];
+  const unsub = ptyStream.subscribe(id, (b) => bytes.push(b));
+  return { bytes, unsub };
+}
+
+const idsOf = (frames: WsEvent[], event: string) =>
+  frames
+    .filter((f) => f.event === event)
+    .map((f) => (f.data as { id?: string }).id)
+    .filter((x): x is string => typeof x === "string");
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  demoState.reset();
+});
+
+afterEach(() => {
+  director.stopAll();
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe("director ambient liveness", () => {
+  it("emits evolving session:activity + PTY bytes for WORKING sessions only", () => {
+    const { frames, unsub } = collectBus();
+    const coupon = collectPty("coupon");
+    const child = collectPty("checkout-child");
+    const rounding = collectPty("rounding"); // READY, not working
+    const ogimg = collectPty("ogimg"); // MERGING, not working
+
+    director.start();
+    vi.advanceTimersByTime(15_000);
+
+    // Working sessions tick.
+    expect(idsOf(frames, "session:activity")).toContain("coupon");
+    expect(idsOf(frames, "session:activity")).toContain("checkout-child");
+    expect(coupon.bytes.length).toBeGreaterThan(0);
+    expect(child.bytes.length).toBeGreaterThan(0);
+
+    // Activity evolves (lastActivityTs strictly grows across ticks for coupon).
+    const couponActs = frames
+      .filter((f) => f.event === "session:activity" && (f.data as { id: string }).id === "coupon")
+      .map((f) => (f.data as { activity: { lastActivityTs: number } }).activity.lastActivityTs);
+    expect(couponActs.length).toBeGreaterThanOrEqual(2);
+    for (let i = 1; i < couponActs.length; i++)
+      expect(couponActs[i]).toBeGreaterThan(couponActs[i - 1]);
+
+    // Non-working sessions get NO ambient loop.
+    expect(idsOf(frames, "session:activity")).not.toContain("rounding");
+    expect(rounding.bytes.length).toBe(0);
+    expect(ogimg.bytes.length).toBe(0);
+
+    unsub();
+    coupon.unsub();
+    child.unsub();
+    rounding.unsub();
+    ogimg.unsub();
+  });
+
+  it("start() is idempotent — a double call does not double-spin loops", () => {
+    director.start();
+    director.start();
+    const { frames, unsub } = collectBus();
+
+    // A doubled loop would fire two ticks at the SAME timestamp each interval; assert
+    // every coupon tick has a distinct lastActivityTs (a single loop, not two).
+    vi.advanceTimersByTime(15_000);
+    const ts = frames
+      .filter((f) => f.event === "session:activity" && (f.data as { id: string }).id === "coupon")
+      .map((f) => (f.data as { activity: { lastActivityTs: number } }).activity.lastActivityTs);
+    expect(ts.length).toBeGreaterThan(0);
+    expect(new Set(ts).size).toBe(ts.length);
+
+    unsub();
+  });
+
+  it("stopAll() clears everything — no further emits or pushes after teardown", () => {
+    director.start();
+    vi.advanceTimersByTime(10_000);
+
+    director.stopAll();
+    const { frames, unsub } = collectBus();
+    const coupon = collectPty("coupon");
+    vi.advanceTimersByTime(60_000);
+
+    expect(frames.length).toBe(0);
+    expect(coupon.bytes.length).toBe(0);
+
+    unsub();
+    coupon.unsub();
+  });
+});
+
+describe("director mutation reactions", () => {
+  it("merge → lands the PR (git merged + status + mergetrain:landed), bounded", () => {
+    director.start();
+    const { frames, unsub } = collectBus();
+
+    demoState.mergePr("ogimg");
+    vi.advanceTimersByTime(20_000);
+
+    expect(idsOf(frames, "session:git")).toContain("ogimg");
+    expect(idsOf(frames, "session:status")).toContain("ogimg");
+    expect(frames.some((f) => f.event === "mergetrain:landed")).toBe(true);
+    expect(demoState.gitState("ogimg")?.state).toBe("merged");
+
+    // No infinite re-trigger: landed frames are bounded even over a long advance.
+    const landedBefore = frames.filter((f) => f.event === "mergetrain:landed").length;
+    vi.advanceTimersByTime(120_000);
+    const landedAfter = frames.filter((f) => f.event === "mergetrain:landed").length;
+    expect(landedAfter).toBe(landedBefore);
+
+    unsub();
+  });
+
+  it("plan-gate release → session starts working (status running + ambient begins)", () => {
+    // authstore is PLAN-GATE awaiting Go; approve the gate so release is permitted.
+    const gate = demoState.planGates()["authstore"];
+    if (gate) gate.approved = true;
+
+    director.start();
+    const { frames, unsub } = collectBus();
+    const term = collectPty("authstore");
+
+    demoState.releasePlanGate("authstore");
+    vi.advanceTimersByTime(15_000);
+
+    expect(idsOf(frames, "session:status")).toContain("authstore");
+    // Ambient now drives authstore: activity ticks + terminal bytes appear.
+    expect(idsOf(frames, "session:activity")).toContain("authstore");
+    expect(term.bytes.length).toBeGreaterThan(0);
+
+    unsub();
+    term.unsub();
+  });
+
+  it("steer/reply → agent responds with terminal lines + activity, then settles", () => {
+    director.start();
+    const term = collectPty("coupon");
+    const before = term.bytes.length;
+
+    demoState.reply("coupon", "also handle the expired-code path");
+    vi.advanceTimersByTime(8_000);
+
+    expect(term.bytes.length).toBeGreaterThan(before);
+
+    term.unsub();
+  });
+
+  it("epic advance → spawns the next child session and drives it", () => {
+    director.start();
+    const { frames, unsub } = collectBus();
+
+    demoState.approveEpicNext("/demo/acme/storefront", 100);
+    vi.advanceTimersByTime(15_000);
+
+    const spawned = frames
+      .filter((f) => f.event === "session:new")
+      .map((f) => (f.data as { id: string }).id);
+    expect(spawned.length).toBeGreaterThan(0);
+    const child = spawned[0];
+    // The freshly spawned child gets ambient activity.
+    expect(idsOf(frames, "session:activity")).toContain(child);
+
+    unsub();
+  });
+
+  it("spawn-from-held → drives the newly spawned session", () => {
+    director.start();
+    const { frames, unsub } = collectBus();
+
+    const held = demoState.held()[0];
+    const session = demoState.spawnHeld(held.id);
+    expect(session).not.toBeNull();
+    const sid = session!.id;
+    const term = collectPty(sid);
+
+    vi.advanceTimersByTime(15_000);
+
+    expect(idsOf(frames, "session:activity")).toContain(sid);
+    expect(term.bytes.length).toBeGreaterThan(0);
+
+    unsub();
+    term.unsub();
+  });
+});
+
+describe("director reset integration", () => {
+  it("reset stops old timers and restarts ambient for the re-seeded working set", () => {
+    director.start();
+    vi.advanceTimersByTime(10_000);
+
+    const { frames, unsub } = collectBus();
+    demoState.reset();
+    vi.advanceTimersByTime(12_000);
+
+    // Fresh ambient runs post-reset.
+    expect(idsOf(frames, "session:activity")).toContain("coupon");
+
+    // No double-emit from leaked pre-reset timers: coupon ticks carry distinct
+    // timestamps (a leaked+fresh loop would fire two ticks at the same instant).
+    const { frames: f2, unsub: u2 } = collectBus();
+    vi.advanceTimersByTime(15_000);
+    const ts = f2
+      .filter((f) => f.event === "session:activity" && (f.data as { id: string }).id === "coupon")
+      .map((f) => (f.data as { activity: { lastActivityTs: number } }).activity.lastActivityTs);
+    expect(ts.length).toBeGreaterThan(0);
+    expect(new Set(ts).size).toBe(ts.length);
+
+    unsub();
+    u2();
+  });
+});

--- a/ui/src/lib/demo/director.test.ts
+++ b/ui/src/lib/demo/director.test.ts
@@ -184,6 +184,58 @@ describe("director mutation reactions", () => {
     term.unsub();
   });
 
+  it("reply resuming a held session (neon) keeps ticking via ambient, not just the burst", () => {
+    director.start();
+    const { frames, unsub } = collectBus();
+    const term = collectPty("neon");
+
+    demoState.reply("neon", "use option B — keep the read replica");
+    vi.advanceTimersByTime(3_000); // let the one-shot burst + settle fire
+
+    const activityAfterBurst = idsOf(frames, "session:activity").filter(
+      (id) => id === "neon",
+    ).length;
+    const bytesAfterBurst = term.bytes.length;
+    expect(activityAfterBurst).toBeGreaterThan(0);
+    expect(bytesAfterBurst).toBeGreaterThan(0);
+
+    // Advance well past the burst window — an ambient loop (not a one-shot) keeps
+    // emitting session:activity + PTY bytes for neon.
+    vi.advanceTimersByTime(15_000);
+    const activityLater = idsOf(frames, "session:activity").filter((id) => id === "neon").length;
+    expect(activityLater).toBeGreaterThan(activityAfterBurst);
+    expect(term.bytes.length).toBeGreaterThan(bytesAfterBurst);
+
+    unsub();
+    term.unsub();
+  });
+
+  it("answering plan questions on a PLANNING session (authstore) skips the code-editing burst and ambient", () => {
+    director.start();
+    const { frames, unsub } = collectBus();
+    const term = collectPty("authstore");
+
+    demoState.answerPlanQuestions("authstore");
+    vi.advanceTimersByTime(15_000);
+
+    // No code-editing terminal lines — the plan-answer reaction is not the steer burst.
+    expect(term.bytes.some((b) => b.includes("apply.ts"))).toBe(false);
+    expect(term.bytes.some((b) => b.includes("folding that into the current change"))).toBe(false);
+
+    // Not treated as "working" — no ambient loop spun up for authstore.
+    const activityCount = idsOf(frames, "session:activity").filter(
+      (id) => id === "authstore",
+    ).length;
+    vi.advanceTimersByTime(15_000);
+    const activityCountLater = idsOf(frames, "session:activity").filter(
+      (id) => id === "authstore",
+    ).length;
+    expect(activityCountLater).toBe(activityCount);
+
+    unsub();
+    term.unsub();
+  });
+
   it("epic advance → spawns the next child session and drives it", () => {
     director.start();
     const { frames, unsub } = collectBus();

--- a/ui/src/lib/demo/director.test.ts
+++ b/ui/src/lib/demo/director.test.ts
@@ -236,6 +236,34 @@ describe("director mutation reactions", () => {
     term.unsub();
   });
 
+  it("reply to a plan-flagged session (authstore) resumes ambient — planPhase doesn't silence it", () => {
+    // reply() sets status running + lastState working WITHOUT clearing planPhase; the
+    // steer reaction must treat it as working (burst + ambient), not take the quiet
+    // plan-answer branch and leave it working-but-silent.
+    director.start();
+    const { frames, unsub } = collectBus();
+    const term = collectPty("authstore");
+
+    demoState.reply("authstore", "go with the token-rotation approach");
+    vi.advanceTimersByTime(3_000); // one-shot burst + settle
+    const activityAfterBurst = idsOf(frames, "session:activity").filter(
+      (id) => id === "authstore",
+    ).length;
+    expect(activityAfterBurst).toBeGreaterThan(0);
+    const bytesAfterBurst = term.bytes.length;
+
+    // Past the burst window, an ambient loop keeps authstore ticking.
+    vi.advanceTimersByTime(15_000);
+    const activityLater = idsOf(frames, "session:activity").filter(
+      (id) => id === "authstore",
+    ).length;
+    expect(activityLater).toBeGreaterThan(activityAfterBurst);
+    expect(term.bytes.length).toBeGreaterThan(bytesAfterBurst);
+
+    unsub();
+    term.unsub();
+  });
+
   it("epic advance → spawns the next child session and drives it", () => {
     director.start();
     const { frames, unsub } = collectBus();

--- a/ui/src/lib/demo/director.test.ts
+++ b/ui/src/lib/demo/director.test.ts
@@ -129,6 +129,27 @@ describe("director mutation reactions", () => {
     unsub();
   });
 
+  it("merge → also posts the recap payoff (session:recap), matching world.recaps", () => {
+    director.start();
+    const { frames, unsub } = collectBus();
+
+    demoState.mergePr("ogimg");
+    vi.advanceTimersByTime(20_000);
+
+    const recapFrames = frames.filter((f) => f.event === "session:recap");
+    expect(recapFrames.length).toBe(1);
+    const emitted = (recapFrames[0].data as { id: string; recap: unknown }).recap;
+    expect(emitted).toBeTruthy();
+    expect(demoState.recaps()["ogimg"]).toEqual(emitted);
+
+    // Landing again doesn't stack/duplicate the recap — content survives a re-land unchanged.
+    demoState.mergePr("ogimg");
+    vi.advanceTimersByTime(20_000);
+    expect(demoState.recaps()["ogimg"]).toEqual(emitted);
+
+    unsub();
+  });
+
   it("plan-gate release → session starts working (status running + ambient begins)", () => {
     // authstore is PLAN-GATE awaiting Go; approve the gate so release is permitted.
     const gate = demoState.planGates()["authstore"];
@@ -198,6 +219,36 @@ describe("director mutation reactions", () => {
 
     unsub();
     term.unsub();
+  });
+});
+
+describe("director archive stops the ambient loop", () => {
+  it("archiving a working session stops its loop — no further activity/PTY for that id", () => {
+    director.start();
+    const { frames, unsub } = collectBus();
+    const coupon = collectPty("coupon");
+
+    vi.advanceTimersByTime(5_000);
+    expect(coupon.bytes.length).toBeGreaterThan(0);
+
+    demoState.archiveSession("coupon");
+    const activityBefore = idsOf(frames, "session:activity").filter((id) => id === "coupon").length;
+    const bytesBefore = coupon.bytes.length;
+
+    vi.advanceTimersByTime(60_000);
+
+    const activityAfter = idsOf(frames, "session:activity").filter((id) => id === "coupon").length;
+    expect(activityAfter).toBe(activityBefore);
+    expect(coupon.bytes.length).toBe(bytesBefore);
+
+    unsub();
+    coupon.unsub();
+  });
+
+  it("archiving a session with no ambient loop is a safe no-op", () => {
+    director.start();
+    expect(() => demoState.archiveSession("rounding")).not.toThrow();
+    expect(() => demoState.archiveSession("does-not-exist")).not.toThrow();
   });
 });
 

--- a/ui/src/lib/demo/director.ts
+++ b/ui/src/lib/demo/director.ts
@@ -140,6 +140,17 @@ function startAmbientWorkingSet(): void {
   for (const id of workingIds()) startAmbient(id);
 }
 
+/** Stop (or no-op if absent) the ambient loop for `id` — an already-cleared or
+ *  never-started id is a safe no-op, so this can't throw on a stale/unknown id. */
+function stopAmbient(id: string): void {
+  const t = ambientLoops.get(id);
+  if (t !== undefined) {
+    clearTimeout(t);
+    timers.delete(t);
+  }
+  ambientLoops.delete(id);
+}
+
 // ── mutation reactions (each a BOUNDED, self-marked follow-up sequence) ──────────
 
 /** Push a small bounded burst of terminal lines on a staggered cadence. */
@@ -147,11 +158,15 @@ function pushBurst(id: string, lines: string[], baseDelay: number): void {
   lines.forEach((line, i) => schedule(() => ptyStream.push(id, line), baseDelay + i * 500));
 }
 
-/** merge → after a beat, land the PR (git merged + status + mergetrain:landed). */
+/** merge → after a beat, land the PR (git merged + status + mergetrain:landed) and
+ *  post the recap payoff (idempotent — a re-land of the same id is a no-op past
+ *  the first call, so it can never stack). */
 function reactMerge(id: string): void {
   pushBurst(id, [`${GRAY}  ⎿ merging…${RESET}${NL}`], 600);
   schedule(() => {
     asSelf(() => demoState.landMerge(id));
+    const recap = asSelf(() => demoState.landRecap(id));
+    if (recap) emit({ event: "session:recap", data: { id, recap } });
     ptyStream.push(id, `${GREEN}✓${RESET} Merged — landed on the default branch.${NL}`);
   }, 1800);
 }
@@ -238,6 +253,9 @@ function onBusEvent(ev: WsEvent): void {
       break;
     case "session:new":
       reactSpawn(ev.data.id);
+      break;
+    case "session:archived":
+      stopAmbient(ev.data.id);
       break;
   }
 }

--- a/ui/src/lib/demo/director.ts
+++ b/ui/src/lib/demo/director.ts
@@ -100,11 +100,17 @@ function intervalFor(id: string): number {
   return 3000 + (h % 5) * 350; // 3.0s–4.4s
 }
 
+/** Shared predicate for "actively WORKING" — reused by `workingIds()` and by
+ *  `reactSteer` to decide whether a reply-resumed session needs ambient liveness. */
+function isWorking(s: { status: string; lastState: string }): boolean {
+  return s.status === "running" && s.lastState === "working";
+}
+
 /** Ids of sessions that are actively WORKING in the CURRENT (post-seed/reset) world. */
 function workingIds(): string[] {
   return demoState
     .sessions()
-    .filter((s) => s.status === "running" && s.lastState === "working")
+    .filter(isWorking)
     .map((s) => s.id);
 }
 
@@ -188,8 +194,18 @@ function reactPlanGate(id: string): void {
   }, 1600);
 }
 
-/** steer/reply → after a beat the agent acknowledges, pushes a few lines, then settles. */
+/** steer/reply → after a beat the agent acknowledges, pushes a few lines, then settles
+ *  (and, if the reply resumed a held session into WORKING, keeps it ticking via ambient).
+ *  A plan-question answer (`answerPlanQuestions`) routes through the same
+ *  `session:activity` frame but the session is still PLANNING, not working — that gets
+ *  a short plan-appropriate acknowledgment instead of a code-editing burst. */
 function reactSteer(id: string): void {
+  const session = demoState.sessions().find((s) => s.id === id);
+  if (session?.planPhase === "planning") {
+    pushBurst(id, [`● Noted — folding the answer into the plan.${NL}`], 600);
+    return;
+  }
+
   pushBurst(
     id,
     [
@@ -213,6 +229,10 @@ function reactSteer(id: string): void {
         },
       },
     });
+    // A reply can resume a held/paused session (e.g. `neon`) straight to working —
+    // pick it up in the ambient set so the heartbeat/terminal keep ticking past the
+    // burst. Idempotent, so an already-ambient session (e.g. `coupon`) is unaffected.
+    if (workingIds().includes(id)) startAmbient(id);
   }, 2200);
 }
 

--- a/ui/src/lib/demo/director.ts
+++ b/ui/src/lib/demo/director.ts
@@ -1,0 +1,283 @@
+// The demo "liveness" engine. Two jobs:
+//
+//   1. Ambient liveness — for every WORKING session it periodically emits an
+//      evolving `session:activity` frame (so the heartbeat/heat-strip ticks) and
+//      pushes a short, tasteful terminal line to whatever `PtySocket` is attached
+//      (so the live terminal keeps flowing past the transcript's idle "Waiting…").
+//
+//   2. Mutation reactions — when a demo mutation's IMMEDIATE frame appears on the
+//      bus (e.g. `session:merging` from `mergePr`), it schedules the believable
+//      FOLLOW-UP sequence (land the PR, post the recap, …). The follow-ups emit
+//      their own frames, so each reaction is a BOUNDED sequence that can never
+//      re-trigger itself: while the director runs any of its own code it sets a
+//      re-entrancy flag, and its bus listener ignores frames raised under that flag
+//      (this covers both direct emits and emits raised by `demoState` mutators the
+//      director calls). External (router/mutator) frames alone drive reactions.
+//
+// Dependency direction is one-way: the director imports `demoState`; `state.ts`
+// never imports the director (it exposes `onReset` so the director can hook in).
+// EVERY timer is tracked and cleared in `stopAll()` — nothing leaks past teardown
+// or a reset.
+
+import type { WsEvent, SessionActivity } from "$lib/types";
+import { bus } from "./bus";
+import { demoState } from "./state";
+import { ptyStream } from "./pty/stream";
+
+// ── ANSI palette (xterm consumes raw bytes; colors close within each push) ──────
+const RESET = "\x1b[0m";
+const DIM = "\x1b[2m";
+const GREEN = "\x1b[32m";
+const CYAN = "\x1b[36m";
+const GRAY = "\x1b[90m";
+const NL = "\r\n";
+
+/** A short rolling set of plausible "still working" terminal lines. */
+const AMBIENT_LINES: string[] = [
+  `${CYAN}● Read(src/lib/pricing/apply.ts)${RESET}${NL}${GRAY}  ⎿ Read 42 lines${RESET}${NL}`,
+  `● Refining the rounding so the discount lands on whole cents.${NL}`,
+  `${CYAN}● Update(src/routes/checkout/Summary.svelte)${RESET}${NL}${GRAY}  ⎿ Updated  (+3 -1)${RESET}${NL}`,
+  `${CYAN}● Bash(bun test src/lib/pricing)${RESET}${NL}    ${GREEN}✓${RESET} 4 pass${DIM}, 0 fail${RESET}${NL}`,
+  `● Wiring the summary total to the new discount path.${NL}`,
+];
+
+/** Rolling tool-use summaries for the activity heartbeat (verbatim, like the server). */
+const AMBIENT_SUMMARIES: string[] = [
+  "Read(src/lib/pricing/apply.ts)",
+  "editing Summary.svelte",
+  "$ bun test src/lib/pricing",
+  'grep "discount" src/routes',
+  "running the type check",
+];
+
+// ── lifecycle state ─────────────────────────────────────────────────────────────
+let enabled = false; // whether the director is meant to be live
+let selfEmitting = false; // re-entrancy guard: ignore bus frames raised by our own code
+let busUnsub: (() => void) | null = null;
+let resetRegistered = false;
+
+/** Every pending timer the director owns. A tick removes its own timer as it fires,
+ *  so this set holds only still-pending timers; `stopAll()` clears whatever remains. */
+const timers = new Set<ReturnType<typeof setTimeout>>();
+
+/** The current pending ambient-loop timer per session id — presence means the loop
+ *  is live (used to keep `startAmbient` idempotent). */
+const ambientLoops = new Map<string, ReturnType<typeof setTimeout>>();
+
+/** Schedule `fn` after `ms`, tracked so `stopAll()` can clear it; self-removes on fire. */
+function schedule(fn: () => void, ms: number): ReturnType<typeof setTimeout> {
+  const t = setTimeout(() => {
+    timers.delete(t);
+    fn();
+  }, ms);
+  timers.add(t);
+  return t;
+}
+
+/** Run `fn` with the re-entrancy flag set so any bus frame it raises (directly or via
+ *  a `demoState` mutator) is ignored by our own listener — no reaction re-triggers. */
+function asSelf<T>(fn: () => T): T {
+  const prev = selfEmitting;
+  selfEmitting = true;
+  try {
+    return fn();
+  } finally {
+    selfEmitting = prev;
+  }
+}
+
+/** Emit a director-originated frame (marked self, so it never re-triggers a reaction). */
+function emit(ev: WsEvent): void {
+  asSelf(() => bus.emit(ev));
+}
+
+// ── ambient liveness ────────────────────────────────────────────────────────────
+
+/** Deterministic per-session cadence so the two working sessions don't tick in lockstep. */
+function intervalFor(id: string): number {
+  let h = 0;
+  for (const ch of id) h = (h * 31 + ch.charCodeAt(0)) >>> 0;
+  return 3000 + (h % 5) * 350; // 3.0s–4.4s
+}
+
+/** Ids of sessions that are actively WORKING in the CURRENT (post-seed/reset) world. */
+function workingIds(): string[] {
+  return demoState
+    .sessions()
+    .filter((s) => s.status === "running" && s.lastState === "working")
+    .map((s) => s.id);
+}
+
+/** Begin (or no-op if already running) an ambient loop for `id`: each tick emits an
+ *  evolving `session:activity` frame and pushes one rolling terminal line. */
+function startAmbient(id: string): void {
+  if (ambientLoops.has(id)) return; // idempotent — never double-spin a loop
+  const recentTs: number[] = [];
+  let step = 0;
+  const interval = intervalFor(id);
+
+  const tick = (): void => {
+    const now = Date.now();
+    recentTs.push(now);
+    if (recentTs.length > 12) recentTs.shift(); // bounded heat-strip window
+    const activity: SessionActivity = {
+      lastActivityTs: now,
+      summary: AMBIENT_SUMMARIES[step % AMBIENT_SUMMARIES.length],
+      recentTs: [...recentTs],
+      recentErrTs: [],
+    };
+    emit({ event: "session:activity", data: { id, activity } });
+    ptyStream.push(id, AMBIENT_LINES[step % AMBIENT_LINES.length]);
+    step++;
+    ambientLoops.set(id, schedule(tick, interval)); // chain the next tick
+  };
+
+  ambientLoops.set(id, schedule(tick, interval));
+}
+
+/** Start ambient loops for every currently-working session (idempotent per id). */
+function startAmbientWorkingSet(): void {
+  for (const id of workingIds()) startAmbient(id);
+}
+
+// ── mutation reactions (each a BOUNDED, self-marked follow-up sequence) ──────────
+
+/** Push a small bounded burst of terminal lines on a staggered cadence. */
+function pushBurst(id: string, lines: string[], baseDelay: number): void {
+  lines.forEach((line, i) => schedule(() => ptyStream.push(id, line), baseDelay + i * 500));
+}
+
+/** merge → after a beat, land the PR (git merged + status + mergetrain:landed). */
+function reactMerge(id: string): void {
+  pushBurst(id, [`${GRAY}  ⎿ merging…${RESET}${NL}`], 600);
+  schedule(() => {
+    asSelf(() => demoState.landMerge(id));
+    ptyStream.push(id, `${GREEN}✓${RESET} Merged — landed on the default branch.${NL}`);
+  }, 1800);
+}
+
+/** plan-gate release → after a beat the agent starts executing: status running,
+ *  terminal bytes, and ambient liveness takes over. */
+function reactPlanGate(id: string): void {
+  pushBurst(
+    id,
+    [
+      `● Plan approved — starting implementation.${NL}`,
+      `${CYAN}● Update(migrations/0007_refresh_tokens.sql)${RESET}${NL}`,
+    ],
+    700,
+  );
+  schedule(() => {
+    emit({ event: "session:status", data: { id, status: "running" } });
+    startAmbient(id);
+  }, 1600);
+}
+
+/** steer/reply → after a beat the agent acknowledges, pushes a few lines, then settles. */
+function reactSteer(id: string): void {
+  pushBurst(
+    id,
+    [
+      `● On it — folding that into the current change.${NL}`,
+      `${CYAN}● Update(src/lib/pricing/apply.ts)${RESET}${NL}${GRAY}  ⎿ Updated  (+5 -1)${RESET}${NL}`,
+      `${GREEN}✓${RESET} Done — continuing.${NL}`,
+    ],
+    600,
+  );
+  schedule(() => {
+    const now = Date.now();
+    emit({
+      event: "session:activity",
+      data: {
+        id,
+        activity: {
+          lastActivityTs: now,
+          summary: "editing apply.ts",
+          recentTs: [now],
+          recentErrTs: [],
+        },
+      },
+    });
+  }, 2200);
+}
+
+/** epic advance → after a beat, spawn the next child session and start driving it. */
+function reactEpic(repoPath: string, parent: number): void {
+  schedule(() => {
+    const child = asSelf(() => demoState.spawnEpicChild(repoPath, parent));
+    if (!child) return;
+    pushBurst(child.id, [`${DIM}  Spawning ${child.desig}…${RESET}${NL}`], 400);
+    startAmbient(child.id);
+  }, 1500);
+}
+
+/** spawn-from-held (or any external session:new) → drive the newcomer. */
+function reactSpawn(id: string): void {
+  schedule(() => {
+    ptyStream.push(id, `${DIM}  attaching…${RESET}${NL}`);
+    startAmbient(id);
+  }, 800);
+}
+
+/** Bus listener: react only to EXTERNAL (mutator/router) frames — anything the
+ *  director itself raised is flagged `selfEmitting` and skipped, so nothing loops. */
+function onBusEvent(ev: WsEvent): void {
+  if (selfEmitting) return;
+  switch (ev.event) {
+    case "session:merging":
+      reactMerge(ev.data.id);
+      break;
+    case "session:plangate":
+      if (ev.data.planPhase === "executing") reactPlanGate(ev.data.id);
+      break;
+    case "session:activity":
+      reactSteer(ev.data.id);
+      break;
+    case "epic:update":
+      reactEpic(ev.data.repoPath, ev.data.parentIssueNumber);
+      break;
+    case "session:new":
+      reactSpawn(ev.data.id);
+      break;
+  }
+}
+
+/** Clear every pending timer + ambient-loop bookkeeping (no lifecycle flag change). */
+function clearTimers(): void {
+  for (const t of timers) clearTimeout(t);
+  timers.clear();
+  ambientLoops.clear();
+}
+
+/** Reset hook (registered once): drop the previous run's timers and restart ambient
+ *  for the freshly re-seeded working set. Bus reactions stay subscribed. */
+function onReset(): void {
+  if (!enabled) return;
+  clearTimers();
+  startAmbientWorkingSet();
+}
+
+export const director = {
+  /** Idempotent: subscribe to the bus for reactions, register the reset hook (once),
+   *  and begin ambient loops for the current working set. */
+  start(): void {
+    if (enabled) return;
+    enabled = true;
+    if (!resetRegistered) {
+      demoState.onReset(onReset);
+      resetRegistered = true;
+    }
+    busUnsub = bus.subscribe(onBusEvent);
+    startAmbientWorkingSet();
+  },
+
+  /** Tear down: clear every timer and unsubscribe from the bus — leave nothing running. */
+  stopAll(): void {
+    enabled = false;
+    clearTimers();
+    if (busUnsub) {
+      busUnsub();
+      busUnsub = null;
+    }
+  },
+};

--- a/ui/src/lib/demo/director.ts
+++ b/ui/src/lib/demo/director.ts
@@ -201,7 +201,12 @@ function reactPlanGate(id: string): void {
  *  a short plan-appropriate acknowledgment instead of a code-editing burst. */
 function reactSteer(id: string): void {
   const session = demoState.sessions().find((s) => s.id === id);
-  if (session?.planPhase === "planning") {
+  // Plan-question answer: still PLANNING and not yet working (`answerPlanQuestions`
+  // touches neither status nor lastState) → a short plan-appropriate ack, no code burst.
+  // A `reply` to the SAME plan-gate session resumes it to working (status running +
+  // lastState working) without clearing planPhase, so gate on `!isWorking` — otherwise
+  // it would take the plan branch and never start ambient, going working-but-silent.
+  if (session && !isWorking(session) && session.planPhase === "planning") {
     pushBurst(id, [`● Noted — folding the answer into the plan.${NL}`], 600);
     return;
   }

--- a/ui/src/lib/demo/events.ts
+++ b/ui/src/lib/demo/events.ts
@@ -1,0 +1,24 @@
+import type { WsEvent } from "$lib/types";
+import { bus } from "./bus";
+import { FakeWebSocket } from "./fake-socket";
+
+// Fake WebSocket for the `/events` stream. On (async) open it subscribes to the
+// demo bus and forwards every `WsEvent` as a JSON `onmessage` frame — matching the
+// wire format `store.svelte.ts` decodes (`JSON.parse(e.data)`). Inbound presence
+// heartbeats are ignored; the subscription is torn down on close.
+export class EventsSocket extends FakeWebSocket {
+  #unsub: (() => void) | null = null;
+
+  protected onOpened(): void {
+    this.#unsub = bus.subscribe((ev: WsEvent) => this.emitMessage(JSON.stringify(ev)));
+  }
+
+  override send(): void {
+    // The only frame the client sends here is `{type:"presence"}` — a no-op in demo.
+  }
+
+  protected onTeardown(): void {
+    this.#unsub?.();
+    this.#unsub = null;
+  }
+}

--- a/ui/src/lib/demo/fake-socket.test.ts
+++ b/ui/src/lib/demo/fake-socket.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { FakeWebSocket } from "./fake-socket";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+describe("FakeWebSocket", () => {
+  it("exposes static readyState constants = 0/1/2/3", () => {
+    expect(FakeWebSocket.CONNECTING).toBe(0);
+    expect(FakeWebSocket.OPEN).toBe(1);
+    expect(FakeWebSocket.CLOSING).toBe(2);
+    expect(FakeWebSocket.CLOSED).toBe(3);
+  });
+
+  it("exposes instance readyState constants = 0/1/2/3", () => {
+    const ws = new FakeWebSocket("ws://x/events");
+    expect(ws.CONNECTING).toBe(0);
+    expect(ws.OPEN).toBe(1);
+    expect(ws.CLOSING).toBe(2);
+    expect(ws.CLOSED).toBe(3);
+    ws.close();
+  });
+
+  it("has a writable binaryType (default blob, no-op store)", () => {
+    const ws = new FakeWebSocket("ws://x/events");
+    expect(ws.binaryType).toBe("blob");
+    ws.binaryType = "arraybuffer";
+    expect(ws.binaryType).toBe("arraybuffer");
+    ws.close();
+  });
+
+  it("fires onopen ASYNCHRONOUSLY, never before the constructor returns", async () => {
+    let opened = false;
+    const ws = new FakeWebSocket("ws://x/events");
+    ws.onopen = () => {
+      opened = true;
+    };
+    // still CONNECTING synchronously — open must be deferred to a later tick
+    expect(ws.readyState).toBe(FakeWebSocket.CONNECTING);
+    expect(opened).toBe(false);
+    await tick();
+    expect(ws.readyState).toBe(FakeWebSocket.OPEN);
+    expect(opened).toBe(true);
+    ws.close();
+  });
+
+  it("close() transitions readyState to CLOSED and fires onclose", async () => {
+    const ws = new FakeWebSocket("ws://x/events");
+    await tick();
+    expect(ws.readyState).toBe(FakeWebSocket.OPEN);
+    let closed = false;
+    ws.onclose = () => {
+      closed = true;
+    };
+    ws.close();
+    expect(ws.readyState).toBe(FakeWebSocket.CLOSED);
+    expect(closed).toBe(true);
+  });
+
+  it("send() is a no-op that does not throw before or after open", async () => {
+    const ws = new FakeWebSocket("ws://x/events");
+    expect(() => ws.send("hi")).not.toThrow();
+    await tick();
+    expect(() => ws.send("hi")).not.toThrow();
+    ws.close();
+  });
+});

--- a/ui/src/lib/demo/fake-socket.ts
+++ b/ui/src/lib/demo/fake-socket.ts
@@ -1,0 +1,70 @@
+// Base class for the demo's fake WebSockets (/events, /pty/:id). It reproduces
+// exactly the slice of the WebSocket contract that the real callers touch —
+// `store.svelte.ts` reads `WebSocket.OPEN` (static) and assigns on* handlers;
+// `pty.ts` reads `ws.OPEN`/`ws.CLOSING` (instance), sets `ws.binaryType`, and
+// assigns on* handlers. Crucially, `onopen` (and the first `onmessage`) fire on a
+// LATER microtask, never synchronously in the constructor — both callers assign
+// their handlers AFTER `new WebSocket(...)`, so a synchronous open would be missed.
+
+type MessageEventLike = { data: unknown };
+type CloseEventLike = { code?: number };
+
+export class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readonly CONNECTING = 0;
+  readonly OPEN = 1;
+  readonly CLOSING = 2;
+  readonly CLOSED = 3;
+
+  url: string;
+  readyState = FakeWebSocket.CONNECTING;
+  /** Writable no-op store — `pty.ts` sets it to "arraybuffer"; we ignore it. */
+  binaryType = "blob";
+
+  onopen: (() => void) | null = null;
+  onmessage: ((e: MessageEventLike) => void) | null = null;
+  onclose: ((e?: CloseEventLike) => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    // Defer the OPEN transition so callers can wire handlers first.
+    queueMicrotask(() => this.#doOpen());
+  }
+
+  #doOpen(): void {
+    if (this.readyState !== this.CONNECTING) return; // closed before it opened
+    this.readyState = this.OPEN;
+    this.onopen?.();
+    this.onOpened();
+  }
+
+  /** Subclass hook — runs once, right after the socket reaches OPEN. */
+  protected onOpened(): void {}
+
+  /** Deliver a frame to the consumer; no-op unless OPEN. */
+  protected emitMessage(data: unknown): void {
+    if (this.readyState !== this.OPEN) return;
+    this.onmessage?.({ data });
+  }
+
+  send(data?: unknown): void {
+    // Demo sockets ignore client sends by default; subclasses may override.
+    void data;
+  }
+
+  close(code?: number): void {
+    if (this.readyState === this.CLOSING || this.readyState === this.CLOSED) return;
+    this.readyState = this.CLOSING;
+    this.onTeardown();
+    this.readyState = this.CLOSED;
+    this.onclose?.(code === undefined ? {} : { code });
+  }
+
+  /** Subclass hook — clean up timers/subscriptions on close. */
+  protected onTeardown(): void {}
+}

--- a/ui/src/lib/demo/install.test.ts
+++ b/ui/src/lib/demo/install.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { installDemoBackend } from "./install";
+import { EventsSocket } from "./events";
+import { PtySocket } from "./pty/socket";
+import { bus } from "./bus";
+import type { WsEvent } from "$lib/types";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+// wsUrl()/URL resolution in the real callers reads `location`; provide one for node.
+beforeAll(() => {
+  if (typeof globalThis.location === "undefined") {
+    (globalThis as unknown as { location: unknown }).location = {
+      protocol: "http:",
+      host: "localhost",
+      href: "http://localhost/",
+    };
+  }
+  installDemoBackend();
+});
+
+describe("installDemoBackend — fetch", () => {
+  it("resolves GET /api/me as 200 authenticated", async () => {
+    const r = await fetch("/api/me");
+    expect(r.ok).toBe(true);
+    expect(r.status).toBe(200);
+  });
+
+  it("resolves an unmatched /api endpoint with a benign 200", async () => {
+    const r = await fetch("/api/unknown");
+    expect(r.ok).toBe(true);
+    expect(r.status).toBe(200);
+    await expect(r.json()).resolves.toBeDefined();
+  });
+
+  it("resolves an unmatched mutation with { ok: true }", async () => {
+    const r = await fetch("/api/anything", { method: "POST", body: JSON.stringify({ a: 1 }) });
+    expect(r.ok).toBe(true);
+    await expect(r.json()).resolves.toEqual({ ok: true });
+  });
+});
+
+describe("installDemoBackend — WebSocket", () => {
+  it("routes /events to an EventsSocket and forwards bus frames to onmessage", async () => {
+    const ws = new WebSocket("ws://host/events");
+    expect(ws).toBeInstanceOf(EventsSocket);
+    const frames: unknown[] = [];
+    ws.onmessage = (e) => frames.push(e.data);
+    await tick(); // open + subscribe
+    const ev: WsEvent = { event: "session:ready", data: { id: "demo-1", ready: true } };
+    bus.emit(ev);
+    expect(frames).toContain(JSON.stringify(ev));
+    ws.close();
+  });
+
+  it("routes /pty/:id to a PtySocket that opens", async () => {
+    const ws = new WebSocket("ws://host/pty/abc?cols=80&rows=24");
+    expect(ws).toBeInstanceOf(PtySocket);
+    await tick();
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+    ws.close();
+  });
+
+  it("exposes static readyState constants on the patched WebSocket", () => {
+    expect(WebSocket.CONNECTING).toBe(0);
+    expect(WebSocket.OPEN).toBe(1);
+    expect(WebSocket.CLOSING).toBe(2);
+    expect(WebSocket.CLOSED).toBe(3);
+  });
+});

--- a/ui/src/lib/demo/install.ts
+++ b/ui/src/lib/demo/install.ts
@@ -1,0 +1,99 @@
+import { EventsSocket } from "./events";
+import { PtySocket } from "./pty/socket";
+import { handleApi } from "./router";
+
+// The single entry seam for demo mode. Called once under `__DEMO__` from
+// hooks.client.ts. Replaces `globalThis.fetch` + `globalThis.WebSocket` with the
+// in-browser fakes and neutralises the service worker so a returning visitor is
+// never served a stale cached demo build. Idempotent — a second call is a no-op.
+
+let installed = false;
+
+function base(): string {
+  return (globalThis as { location?: { href?: string } }).location?.href ?? "http://localhost/";
+}
+
+/** Resolve the request URL from any fetch input, tolerating relative paths. */
+function resolveUrl(input: RequestInfo | URL): URL {
+  const raw = input instanceof Request ? input.url : String(input);
+  return new URL(raw, base());
+}
+
+async function readBody(init: RequestInit | undefined, req: Request | null): Promise<unknown> {
+  const raw = init?.body ?? (req ? await req.clone().text() : undefined);
+  if (typeof raw !== "string" || raw === "") return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function patchFetch(): void {
+  const original = globalThis.fetch?.bind(globalThis);
+  globalThis.fetch = async function demoFetch(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const url = resolveUrl(input);
+    if (url.pathname.startsWith("/api/")) {
+      const req = input instanceof Request ? input : null;
+      const method = init?.method ?? req?.method ?? "GET";
+      const body = await readBody(init, req);
+      return handleApi(method, url, body);
+    }
+    // Non-API traffic (assets, external) still hits the real network.
+    if (!original) throw new TypeError("fetch is not available in this environment");
+    return original(input, init);
+  } as typeof fetch;
+}
+
+function patchWebSocket(): void {
+  const OriginalWebSocket = globalThis.WebSocket;
+
+  class DemoWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+
+    constructor(url: string | URL, protocols?: string | string[]) {
+      const u = new URL(String(url), base());
+      if (u.pathname === "/events") {
+        return new EventsSocket(String(url)) as unknown as DemoWebSocket;
+      }
+      if (u.pathname.startsWith("/pty/")) {
+        return new PtySocket(String(url)) as unknown as DemoWebSocket;
+      }
+      // Anything else (should not happen in demo) → a real socket, if one exists.
+      if (!OriginalWebSocket) {
+        throw new TypeError(`No WebSocket transport for ${u.pathname} in demo mode`);
+      }
+      return new OriginalWebSocket(url, protocols) as unknown as DemoWebSocket;
+    }
+  }
+
+  globalThis.WebSocket = DemoWebSocket as unknown as typeof WebSocket;
+}
+
+function neutraliseServiceWorker(): void {
+  try {
+    const sw = (globalThis as { navigator?: Navigator }).navigator?.serviceWorker;
+    if (!sw?.getRegistrations) return;
+    // Drop any SW a previous (non-demo) visit registered so its cache can't serve
+    // a stale build. `push.ts` is separately guarded to never (re)register in demo.
+    sw.getRegistrations()
+      .then((regs) => regs.forEach((r) => r.unregister().catch(() => {})))
+      .catch(() => {});
+  } catch {
+    /* no service-worker environment (node/jsdom) */
+  }
+}
+
+export function installDemoBackend(): void {
+  if (installed) return;
+  installed = true;
+  patchFetch();
+  patchWebSocket();
+  neutraliseServiceWorker();
+}

--- a/ui/src/lib/demo/integration.test.ts
+++ b/ui/src/lib/demo/integration.test.ts
@@ -27,13 +27,14 @@ describe("demo transport ↔ real callers", () => {
     dispose();
   });
 
-  it("connectPty() reaches OPEN and delivers the placeholder frame", async () => {
+  it("connectPty() reaches OPEN and delivers replayed transcript bytes", async () => {
     let data = "";
     const conn = connectPty("demo-session", 80, 24, (bytes) => {
       data += bytes;
     });
-    await tick();
-    expect(data.length).toBeGreaterThan(0); // placeholder byte-string arrived after open
+    await tick(); // open (microtask) → replay schedules the first frame
+    await tick(); // first frame's timer fires → bytes arrive
+    expect(data.length).toBeGreaterThan(0); // replayed byte-string arrived after open
     conn.close();
   });
 });

--- a/ui/src/lib/demo/integration.test.ts
+++ b/ui/src/lib/demo/integration.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { installDemoBackend } from "./install";
+import { HerdStore } from "$lib/store.svelte";
+import { connectPty } from "$lib/pty";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+// The real callers build ws URLs from `location`; provide one for node.
+beforeAll(() => {
+  if (typeof globalThis.location === "undefined") {
+    (globalThis as unknown as { location: unknown }).location = {
+      protocol: "http:",
+      host: "localhost",
+      href: "http://localhost/",
+    };
+  }
+  installDemoBackend();
+});
+
+describe("demo transport ↔ real callers", () => {
+  it("HerdStore.connect() flips connected true via the patched global WebSocket", async () => {
+    const store = new HerdStore();
+    const dispose = store.connect(); // default makeWs → global WebSocket (patched)
+    expect(store.connected).toBe(false); // async open, not yet
+    await tick();
+    expect(store.connected).toBe(true);
+    dispose();
+  });
+
+  it("connectPty() reaches OPEN and delivers the placeholder frame", async () => {
+    let data = "";
+    const conn = connectPty("demo-session", 80, 24, (bytes) => {
+      data += bytes;
+    });
+    await tick();
+    expect(data.length).toBeGreaterThan(0); // placeholder byte-string arrived after open
+    conn.close();
+  });
+});

--- a/ui/src/lib/demo/pty/replay.test.ts
+++ b/ui/src/lib/demo/pty/replay.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { playTranscript, type PtyFrame } from "./replay";
+
+describe("playTranscript", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("emits frames in order with accumulated delays", () => {
+    const frames: PtyFrame[] = [
+      { delayMs: 100, bytes: "a" },
+      { delayMs: 50, bytes: "b" },
+      { delayMs: 200, bytes: "c" },
+    ];
+    const got: string[] = [];
+    playTranscript(frames, (b) => got.push(b));
+
+    expect(got).toEqual([]); // delay is BEFORE the first frame
+    vi.advanceTimersByTime(100);
+    expect(got).toEqual(["a"]);
+    vi.advanceTimersByTime(50);
+    expect(got).toEqual(["a", "b"]); // accumulates from the previous emit
+    vi.advanceTimersByTime(199);
+    expect(got).toEqual(["a", "b"]);
+    vi.advanceTimersByTime(1);
+    expect(got).toEqual(["a", "b", "c"]);
+  });
+
+  it("cancel() prevents later frames from emitting", () => {
+    const frames: PtyFrame[] = [
+      { delayMs: 10, bytes: "a" },
+      { delayMs: 10, bytes: "b" },
+      { delayMs: 10, bytes: "c" },
+    ];
+    const got: string[] = [];
+    const cancel = playTranscript(frames, (b) => got.push(b));
+
+    vi.advanceTimersByTime(10);
+    expect(got).toEqual(["a"]);
+    cancel();
+    vi.advanceTimersByTime(1000);
+    expect(got).toEqual(["a"]); // b + c never fire
+  });
+
+  it("fires onDone after the last frame", () => {
+    const frames: PtyFrame[] = [
+      { delayMs: 10, bytes: "a" },
+      { delayMs: 10, bytes: "b" },
+    ];
+    const got: string[] = [];
+    const onDone = vi.fn();
+    playTranscript(frames, (b) => got.push(b), onDone);
+
+    vi.advanceTimersByTime(10);
+    expect(onDone).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(10);
+    expect(got).toEqual(["a", "b"]);
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel() suppresses onDone", () => {
+    const onDone = vi.fn();
+    const cancel = playTranscript([{ delayMs: 10, bytes: "a" }], () => {}, onDone);
+    cancel();
+    vi.advanceTimersByTime(1000);
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it("handles an empty transcript by firing onDone with no emits", () => {
+    const emit = vi.fn();
+    const onDone = vi.fn();
+    playTranscript([], emit, onDone);
+    vi.advanceTimersByTime(1);
+    expect(emit).not.toHaveBeenCalled();
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/lib/demo/pty/replay.ts
+++ b/ui/src/lib/demo/pty/replay.ts
@@ -1,0 +1,51 @@
+// The demo terminal replay engine. Given an authored transcript — an array of
+// timed byte-string frames — it emits each frame's bytes after its `delayMs`,
+// accumulating delays so the stream paints at a human-ish pace (the author varies
+// the delays into the data; the engine never invents timing, so it stays fully
+// deterministic under fake timers). `playTranscript` returns a `cancel()` that
+// stops the replay mid-flight (called when the pty socket closes) so no timer
+// fires after teardown.
+
+/** One transcript step: wait `delayMs`, then emit `bytes`. Delay is BEFORE the bytes. */
+export type PtyFrame = { delayMs: number; bytes: string };
+
+/**
+ * Schedule `frames` onto `emit`, one chained `setTimeout` per frame so delays
+ * accumulate from the previous emit. Fires `onDone` after the last frame. Returns
+ * a `cancel()` that clears the pending timer and suppresses any remaining frames
+ * (and `onDone`).
+ */
+export function playTranscript(
+  frames: PtyFrame[],
+  emit: (bytes: string) => void,
+  onDone?: () => void,
+): () => void {
+  let cancelled = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let i = 0;
+
+  const step = (): void => {
+    if (cancelled) return;
+    if (i >= frames.length) {
+      timer = null;
+      onDone?.();
+      return;
+    }
+    const frame = frames[i++];
+    timer = setTimeout(() => {
+      if (cancelled) return;
+      emit(frame.bytes);
+      step();
+    }, frame.delayMs);
+  };
+
+  step();
+
+  return () => {
+    cancelled = true;
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+}

--- a/ui/src/lib/demo/pty/socket.test.ts
+++ b/ui/src/lib/demo/pty/socket.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { PtySocket } from "./socket";
+import { ptyStream } from "./stream";
+
+// queueMicrotask is NOT faked by vitest fake timers, so `await Promise.resolve()`
+// flushes the socket's deferred open; `vi.advanceTimersByTime` then drives replay.
+const flushOpen = () => Promise.resolve();
+
+describe("PtySocket", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("parses id/cols/rows from the url", () => {
+    const ws = new PtySocket("ws://localhost/pty/coupon?cols=120&rows=40");
+    expect(ws.sessionId).toBe("coupon");
+    expect(ws.cols).toBe(120);
+    expect(ws.rows).toBe(40);
+  });
+
+  it("replays the coupon transcript after open", async () => {
+    const ws = new PtySocket("ws://localhost/pty/coupon?cols=80&rows=24");
+    const msgs: string[] = [];
+    ws.onmessage = (e) => msgs.push(e.data as string);
+
+    await flushOpen(); // onOpened → playTranscript schedules the first frame
+    expect(msgs).toEqual([]); // nothing before the first delay elapses
+
+    vi.advanceTimersByTime(120_000); // drive the whole transcript
+    expect(msgs.length).toBeGreaterThan(10);
+    expect(msgs[0]).toContain("Add coupon-code field to checkout");
+    expect(msgs.join("")).toContain("4 pass");
+    ws.close();
+  });
+
+  it("forwards a live ptyStream.push to onmessage after open", async () => {
+    const ws = new PtySocket("ws://localhost/pty/coupon?cols=80&rows=24");
+    const msgs: string[] = [];
+    ws.onmessage = (e) => msgs.push(e.data as string);
+    await flushOpen();
+
+    ptyStream.push("coupon", "LIVE-BYTES");
+    expect(msgs).toContain("LIVE-BYTES");
+
+    ptyStream.push("neon", "OTHER"); // different id — must not reach this socket
+    expect(msgs).not.toContain("OTHER");
+    ws.close();
+  });
+
+  it("cancels pending frames and unsubscribes on close", async () => {
+    const ws = new PtySocket("ws://localhost/pty/coupon?cols=80&rows=24");
+    const msgs: string[] = [];
+    ws.onmessage = (e) => msgs.push(e.data as string);
+    await flushOpen();
+
+    vi.advanceTimersByTime(500); // a few frames land
+    const beforeClose = msgs.length;
+    ws.close();
+
+    vi.advanceTimersByTime(120_000); // remaining replay frames must NOT fire
+    expect(msgs.length).toBe(beforeClose);
+
+    ptyStream.push("coupon", "AFTER-CLOSE"); // unsubscribed — must not emit
+    expect(msgs).not.toContain("AFTER-CLOSE");
+  });
+});

--- a/ui/src/lib/demo/pty/socket.ts
+++ b/ui/src/lib/demo/pty/socket.ts
@@ -1,14 +1,21 @@
 import { FakeWebSocket } from "../fake-socket";
+import { playTranscript } from "./replay";
+import { transcriptFor } from "./transcripts";
+import { ptyStream } from "./stream";
 
-// Fake WebSocket for the `/pty/:id?cols&rows` terminal attach. For Task 2 it only
-// proves the transport: on (async) open it pushes a short dim placeholder line so
-// xterm isn't blank. The authored transcript replay engine is Task 5 and will take
-// over the post-open stream (see the seam below).
+// Fake WebSocket for the `/pty/:id?cols&rows` terminal attach. On (async) open it
+// (a) replays the authored transcript for `sessionId` as timed byte-string frames
+// so xterm repaints a believable session, and (b) subscribes to `ptyStream` so the
+// Task 6 director's ambient live bytes for this id reach the terminal during/after
+// the replay. On close it cancels the replay and unsubscribes — no leaks, no
+// emit-after-close. A fresh attach (pty.ts reconnects with a new PtySocket) simply
+// replays again, which is the correct "repaint on re-attach".
 export class PtySocket extends FakeWebSocket {
   readonly sessionId: string;
   readonly cols: number;
   readonly rows: number;
-  #timers: ReturnType<typeof setTimeout>[] = [];
+  #cancelReplay: (() => void) | null = null;
+  #unsub: (() => void) | null = null;
 
   constructor(url: string) {
     super(url);
@@ -19,24 +26,16 @@ export class PtySocket extends FakeWebSocket {
   }
 
   protected onOpened(): void {
-    // Dim placeholder so the terminal repaints on attach instead of sitting blank.
-    this.emitMessage(`\x1b[2mattaching to demo session ${this.sessionId}…\x1b[0m\r\n`);
-    // Task 5: replay engine attaches here — stream the authored transcript for
-    // `this.sessionId` as timed byte-string frames via `this.pushBytes(...)`.
-  }
-
-  /** Emit terminal bytes to xterm — used by the Task 5 replay engine. */
-  protected pushBytes(bytes: string): void {
-    this.emitMessage(bytes);
-  }
-
-  /** Track a replay timer so it's cleared on close (no orphaned loops). */
-  protected track(id: ReturnType<typeof setTimeout>): void {
-    this.#timers.push(id);
+    // (a) replay the authored scrollback / working session for this id.
+    this.#cancelReplay = playTranscript(transcriptFor(this.sessionId), (b) => this.emitMessage(b));
+    // (b) live director bytes (Task 6) → this terminal, during and after the replay.
+    this.#unsub = ptyStream.subscribe(this.sessionId, (b) => this.emitMessage(b));
   }
 
   protected onTeardown(): void {
-    for (const id of this.#timers) clearTimeout(id);
-    this.#timers = [];
+    this.#cancelReplay?.();
+    this.#cancelReplay = null;
+    this.#unsub?.();
+    this.#unsub = null;
   }
 }

--- a/ui/src/lib/demo/pty/socket.ts
+++ b/ui/src/lib/demo/pty/socket.ts
@@ -1,0 +1,42 @@
+import { FakeWebSocket } from "../fake-socket";
+
+// Fake WebSocket for the `/pty/:id?cols&rows` terminal attach. For Task 2 it only
+// proves the transport: on (async) open it pushes a short dim placeholder line so
+// xterm isn't blank. The authored transcript replay engine is Task 5 and will take
+// over the post-open stream (see the seam below).
+export class PtySocket extends FakeWebSocket {
+  readonly sessionId: string;
+  readonly cols: number;
+  readonly rows: number;
+  #timers: ReturnType<typeof setTimeout>[] = [];
+
+  constructor(url: string) {
+    super(url);
+    const u = new URL(url, "http://localhost");
+    this.sessionId = decodeURIComponent(u.pathname.replace(/^\/pty\//, ""));
+    this.cols = Number(u.searchParams.get("cols")) || 80;
+    this.rows = Number(u.searchParams.get("rows")) || 24;
+  }
+
+  protected onOpened(): void {
+    // Dim placeholder so the terminal repaints on attach instead of sitting blank.
+    this.emitMessage(`\x1b[2mattaching to demo session ${this.sessionId}…\x1b[0m\r\n`);
+    // Task 5: replay engine attaches here — stream the authored transcript for
+    // `this.sessionId` as timed byte-string frames via `this.pushBytes(...)`.
+  }
+
+  /** Emit terminal bytes to xterm — used by the Task 5 replay engine. */
+  protected pushBytes(bytes: string): void {
+    this.emitMessage(bytes);
+  }
+
+  /** Track a replay timer so it's cleared on close (no orphaned loops). */
+  protected track(id: ReturnType<typeof setTimeout>): void {
+    this.#timers.push(id);
+  }
+
+  protected onTeardown(): void {
+    for (const id of this.#timers) clearTimeout(id);
+    this.#timers = [];
+  }
+}

--- a/ui/src/lib/demo/pty/stream.test.ts
+++ b/ui/src/lib/demo/pty/stream.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { ptyStream } from "./stream";
+
+describe("ptyStream", () => {
+  it("delivers pushed bytes to subscribers of the same id only", () => {
+    const a: string[] = [];
+    const b: string[] = [];
+    const unsubA = ptyStream.subscribe("coupon", (bytes) => a.push(bytes));
+    const unsubB = ptyStream.subscribe("neon", (bytes) => b.push(bytes));
+
+    ptyStream.push("coupon", "hi");
+    expect(a).toEqual(["hi"]);
+    expect(b).toEqual([]); // wrong id — not delivered
+
+    ptyStream.push("neon", "yo");
+    expect(a).toEqual(["hi"]);
+    expect(b).toEqual(["yo"]);
+
+    unsubA();
+    unsubB();
+  });
+
+  it("stops delivering after unsubscribe", () => {
+    const got: string[] = [];
+    const unsub = ptyStream.subscribe("coupon", (bytes) => got.push(bytes));
+    ptyStream.push("coupon", "one");
+    unsub();
+    ptyStream.push("coupon", "two");
+    expect(got).toEqual(["one"]);
+  });
+
+  it("push to an id with no subscribers is a silent no-op", () => {
+    expect(() => ptyStream.push("nobody", "x")).not.toThrow();
+  });
+
+  it("fans out to multiple subscribers of the same id", () => {
+    const a: string[] = [];
+    const b: string[] = [];
+    const unsubA = ptyStream.subscribe("coupon", (x) => a.push(x));
+    const unsubB = ptyStream.subscribe("coupon", (x) => b.push(x));
+    ptyStream.push("coupon", "z");
+    expect(a).toEqual(["z"]);
+    expect(b).toEqual(["z"]);
+    unsubA();
+    unsubB();
+  });
+});

--- a/ui/src/lib/demo/pty/stream.ts
+++ b/ui/src/lib/demo/pty/stream.ts
@@ -1,0 +1,34 @@
+// Per-session PTY byte pub/sub. Kept separate from `bus.ts` (which carries typed
+// `WsEvent` frames): terminal bytes are raw xterm strings, not domain events, and
+// are keyed by session id so a live byte push only reaches the terminal attached to
+// that session. The Task 6 director calls `push(id, bytes)` to stream ambient live
+// output to whichever `PtySocket` is currently subscribed for that id.
+
+type ByteListener = (bytes: string) => void;
+
+const listeners = new Map<string, Set<ByteListener>>();
+
+export const ptyStream = {
+  /** Fan `bytes` out to every current subscriber of `sessionId`, synchronously. */
+  push(sessionId: string, bytes: string): void {
+    const set = listeners.get(sessionId);
+    if (!set) return;
+    // snapshot so a listener that (un)subscribes during dispatch can't mutate mid-loop
+    for (const fn of [...set]) fn(bytes);
+  },
+  /** Subscribe to `sessionId`'s live bytes; returns an unsubscribe disposer. */
+  subscribe(sessionId: string, fn: ByteListener): () => void {
+    let set = listeners.get(sessionId);
+    if (!set) {
+      set = new Set();
+      listeners.set(sessionId, set);
+    }
+    set.add(fn);
+    return () => {
+      const s = listeners.get(sessionId);
+      if (!s) return;
+      s.delete(fn);
+      if (s.size === 0) listeners.delete(sessionId);
+    };
+  },
+};

--- a/ui/src/lib/demo/pty/transcripts.ts
+++ b/ui/src/lib/demo/pty/transcripts.ts
@@ -1,0 +1,264 @@
+// Authored PTY transcripts — the "watch the agent work" showpiece. Each is an
+// array of timed byte-string frames (see `replay.ts`) that, replayed, look like a
+// live Claude-Code-style agent session in xterm. Content is fictional, tasteful,
+// and PUBLIC (marketing) — no secrets, real names, or profanity.
+//
+// This file is DATA ONLY: the frames and the tiny helpers that build them. All
+// timing/scheduling logic lives in `replay.ts`. Transcripts are keyed by the
+// stable session ids from `seed.ts` — an unknown id falls back to a minimal
+// generic frame (never throws).
+
+import type { PtyFrame } from "./replay";
+
+// ── ANSI palette (xterm consumes these raw) ──────────────────────────────────
+const RESET = "\x1b[0m";
+const DIM = "\x1b[2m";
+const BOLD = "\x1b[1m";
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+const CYAN = "\x1b[36m";
+const GRAY = "\x1b[90m";
+const NL = "\r\n";
+
+const c = {
+  dim: (s: string) => DIM + s + RESET,
+  bold: (s: string) => BOLD + s + RESET,
+  green: (s: string) => GREEN + s + RESET,
+  red: (s: string) => RED + s + RESET,
+  cyan: (s: string) => CYAN + s + RESET,
+  gray: (s: string) => GRAY + s + RESET,
+};
+
+// Frame builder: `f(delayMs, line)` emits `line` + CRLF after `delayMs`.
+const f = (delayMs: number, line = ""): PtyFrame => ({ delayMs, bytes: line + NL });
+
+// Common line shapes so the transcripts read consistently.
+const bullet = (delayMs: number, text: string): PtyFrame => f(delayMs, "● " + text);
+const result = (delayMs: number, text: string): PtyFrame =>
+  f(delayMs, c.gray("  ⎿ ") + c.dim(text));
+const tool = (delayMs: number, call: string): PtyFrame => f(delayMs, "● " + c.cyan(call));
+const check = (delayMs: number, text: string): PtyFrame =>
+  f(delayMs, "    " + c.green("✓ ") + text);
+const add = (delayMs: number, text: string): PtyFrame => f(delayMs, "    " + c.green("+ " + text));
+const del = (delayMs: number, text: string): PtyFrame => f(delayMs, "    " + c.red("- " + text));
+const ctx = (delayMs: number, text: string): PtyFrame => f(delayMs, "    " + c.gray("  " + text));
+
+/** Header block every transcript opens with: task line + dim metadata line. */
+function header(title: string, meta: string): PtyFrame[] {
+  return [f(0, c.bold("● " + title)), f(30, c.dim("  " + meta)), f(120)];
+}
+
+// ── HERO: coupon — a rich, believable working session ────────────────────────
+function coupon(): PtyFrame[] {
+  return [
+    ...header(
+      "Add coupon-code field to checkout",
+      "TASK-41 · acme/storefront · shepherd/coupon-code-field · opus",
+    ),
+    bullet(140, "I'll add a coupon-code field to the checkout summary and apply the discount"),
+    f(40, "  to the order total. Let me find the checkout components first."),
+    f(260),
+
+    tool(180, 'Search(grep "checkout" src/routes)'),
+    result(220, "Found 4 files"),
+    ctx(60, "src/routes/checkout/+page.svelte"),
+    ctx(50, "src/routes/checkout/Summary.svelte"),
+    ctx(50, "src/lib/pricing/apply.ts"),
+    ctx(50, "src/lib/pricing/types.ts"),
+    f(240),
+
+    tool(200, "Read(src/routes/checkout/Summary.svelte)"),
+    result(300, "Read 86 lines"),
+    f(220),
+    bullet(160, "The summary lists line items and totals but has no promo input."),
+    f(40, "  I'll add a CouponField component, validate codes against the pricing"),
+    f(40, "  API, and fold the discount into the total."),
+    f(280),
+
+    tool(200, "Read(src/lib/pricing/apply.ts)"),
+    result(260, "Read 42 lines"),
+    f(60, c.dim("    applyPricing(cart) → { subtotal, shipping, total }")),
+    f(240),
+
+    bullet(180, "Adding the component."),
+    tool(120, "Create(src/routes/checkout/CouponField.svelte)"),
+    result(200, "Created file  (+38)"),
+    add(60, '<script lang="ts">'),
+    add(40, "  let { onApply } = $props();"),
+    add(40, "  let code = $state('');"),
+    add(40, "  let error = $state('');"),
+    ctx(30, "…"),
+    add(40, '<label class="coupon">'),
+    add(40, "  <span>Coupon code</span>"),
+    add(40, '  <input bind:value={code} placeholder="Enter code" />'),
+    add(40, "</label>"),
+    f(240),
+
+    tool(200, "Update(src/routes/checkout/Summary.svelte)"),
+    result(200, "Updated  (+7 -1)"),
+    ctx(40, "import CouponField from './CouponField.svelte';"),
+    add(50, "<CouponField onApply={applyCoupon} />"),
+    del(40, "const total = subtotal + shipping;"),
+    add(50, "const total = subtotal + shipping - discount;"),
+    f(240),
+
+    tool(200, "Update(src/lib/pricing/apply.ts)"),
+    result(200, "Updated  (+14)"),
+    add(50, "export function applyCoupon(code: string, subtotal: number) {"),
+    add(40, "  const promo = lookupPromo(code);"),
+    add(40, "  if (!promo) return { ok: false, reason: 'unknown' };"),
+    add(40, "  const discount = Math.round(subtotal * promo.rate);"),
+    add(40, "  return { ok: true, discount };"),
+    add(40, "}"),
+    f(300),
+
+    bullet(200, "Running the pricing tests."),
+    tool(120, "Bash(bun test src/lib/pricing)"),
+    f(500, c.dim("    bun test v1.2  (src/lib/pricing)")),
+    check(360, "applies a valid coupon to the subtotal"),
+    check(300, "rejects an unknown code"),
+    check(280, "ignores an expired coupon"),
+    check(300, "rounds the discount to whole cents"),
+    f(160, c.green("    4 pass") + c.dim(", 0 fail") + c.gray("  (238ms)")),
+    f(320),
+
+    bullet(
+      220,
+      c.green("✓ ") + "Coupon field added — the discount now applies to the summary total.",
+    ),
+    f(60, "  Next: a component test for the invalid-code path, then open a PR."),
+    f(200),
+    f(120, c.dim("  Waiting…")),
+  ];
+}
+
+// ── checkout-child — shorter working transcript (shipping estimator) ──────────
+function checkoutChild(): PtyFrame[] {
+  return [
+    ...header(
+      "Add a shipping-cost estimator to checkout",
+      "TASK-42 · acme/storefront · shepherd/shipping-estimator · autopilot",
+    ),
+    bullet(140, "Estimating shipping from cart weight + destination, shown in the summary."),
+    f(220),
+    tool(180, 'Search(grep "weight" src/lib/cart)'),
+    result(220, "Found 2 files"),
+    ctx(50, "src/lib/cart/item.ts"),
+    ctx(50, "src/lib/cart/totals.ts"),
+    f(220),
+    tool(180, "Create(src/lib/shipping/estimate.ts)"),
+    result(200, "Created file  (+26)"),
+    add(50, "export function estimateShipping(weightG: number, zone: Zone) {"),
+    add(40, "  const base = ZONE_BASE[zone];"),
+    add(40, "  return base + Math.ceil(weightG / 500) * ZONE_PER_500G[zone];"),
+    add(40, "}"),
+    f(240),
+    tool(180, "Update(src/routes/checkout/Summary.svelte)"),
+    result(200, "Updated  (+6)"),
+    add(50, "<li>Estimated shipping <b>{fmt(shipping)}</b></li>"),
+    f(240),
+    bullet(180, "Running the type check."),
+    tool(120, "Bash(bun run check)"),
+    f(500, c.dim("    svelte-check…")),
+    f(360, c.green("    ✓ 0 errors") + c.dim(", 0 warnings")),
+    f(280),
+    bullet(180, "Estimator wired into the summary. Continuing with a unit test."),
+    f(160, c.dim("  Waiting…")),
+  ];
+}
+
+// ── Static scrollbacks (paint fast; reflect each session's end-state) ─────────
+const NEON_QUESTION =
+  "The Neon branch starts empty — should I seed it from the current Postgres dump,";
+const NEON_QUESTION_2 = "or start clean and let migrations rebuild it?";
+
+function rounding(): PtyFrame[] {
+  return [
+    ...header(
+      "Fix cart-total rounding on 3-for-2 offers",
+      "TASK-38 · acme/storefront · shepherd/fix-cart-rounding · sonnet",
+    ),
+    bullet(30, "Switched the running total to integer cents and rounded once at the end."),
+    tool(20, "Bash(bun test src/lib/cart)"),
+    check(20, "rounds a 3-for-2 order without dropping a cent"),
+    check(15, "totals match to the cent"),
+    f(15, c.green("    2 pass") + c.dim(", 0 fail")),
+    bullet(20, c.green("✓ ") + "Opened PR #512 · CI green · ready to merge."),
+  ];
+}
+
+function authstore(): PtyFrame[] {
+  return [
+    ...header(
+      "Rework the auth session store to rotating refresh tokens",
+      "TASK-44 · acme/api · shepherd/auth-session-store · opus",
+    ),
+    bullet(30, "Drafted a plan: short-lived access token + rotating refresh token."),
+    ctx(20, "1. Add a refresh_tokens table (hashed, family id)"),
+    ctx(15, "2. Issue short-lived access + rotating refresh on login"),
+    ctx(15, "3. Rotate on refresh; revoke the family on reuse"),
+    ctx(15, "4. Migrate existing sessions on next login"),
+    bullet(25, c.green("✓ ") + "Plan approved. Waiting for your Go to start implementing."),
+  ];
+}
+
+function neon(): PtyFrame[] {
+  return [
+    ...header(
+      "Migrate the API database layer to Neon serverless Postgres",
+      "TASK-45 · acme/api · shepherd/neon-postgres · autopilot",
+    ),
+    bullet(30, "Provisioned a Neon branch and updated the connection layer."),
+    bullet(20, "One decision is needed before I continue:"),
+    f(20, "  " + NEON_QUESTION),
+    f(15, "  " + NEON_QUESTION_2),
+    f(20, c.dim("  Autopilot paused — waiting for your answer.")),
+  ];
+}
+
+function ogimg(): PtyFrame[] {
+  return [
+    ...header(
+      "Generate dynamic OG images for product pages",
+      "TASK-39 · acme/storefront · shepherd/og-images · sonnet",
+    ),
+    bullet(30, "Added an OG image endpoint and a per-product render cache."),
+    tool(20, "Bash(bun run check)"),
+    f(20, c.green("    ✓ 0 errors")),
+    bullet(20, "Opened PR #508 · CI green."),
+    bullet(20, c.green("✓ ") + "Added to the merge train — landing now."),
+  ];
+}
+
+function deps(): PtyFrame[] {
+  return [
+    ...header(
+      "Bump dependencies to latest and fix lint",
+      "TASK-37 · acme/storefront · shepherd/bump-deps · sonnet",
+    ),
+    bullet(30, "Upgraded 34 packages, regenerated the lockfile, fixed the new lint errors."),
+    tool(20, "Bash(bun run lint)"),
+    f(20, c.green("    ✓ 0 problems")),
+    bullet(20, c.green("✓ ") + "Merged PR #505."),
+    f(20, c.dim("  Owed: rotate the CI dependency-cache key (post-merge).")),
+  ];
+}
+
+function generic(id: string): PtyFrame[] {
+  return [f(0, c.dim(`attached to demo session ${id}`))];
+}
+
+const TRANSCRIPTS: Record<string, () => PtyFrame[]> = {
+  coupon,
+  "checkout-child": checkoutChild,
+  rounding,
+  authstore,
+  neon,
+  ogimg,
+  deps,
+};
+
+/** The authored transcript for `id`, or a minimal generic frame for unknown ids. */
+export function transcriptFor(id: string): PtyFrame[] {
+  return (TRANSCRIPTS[id] ?? (() => generic(id)))();
+}

--- a/ui/src/lib/demo/router.test.ts
+++ b/ui/src/lib/demo/router.test.ts
@@ -67,10 +67,10 @@ describe("polished GET handlers return the shape api.ts consumes", () => {
     expect(one.body.parentIssueNumber).toBe(100);
   });
 
-  it("GET /api/sessions/clear-merged returns the empty clearable shape (never throws)", async () => {
+  it("GET /api/sessions/clear-merged returns the merged, non-archived ids (deps)", async () => {
     const { status, body } = await get("/api/sessions/clear-merged");
     expect(status).toBe(200);
-    expect(body).toEqual({ ids: [], leftovers: 0 });
+    expect(body).toEqual({ ids: ["deps"], leftovers: 0 });
   });
 
   it("the rich scenario seeds seven sessions across two repos", async () => {
@@ -110,10 +110,25 @@ describe("mutation handlers call the mutator and return the caller's shape", () 
     expect(body).toHaveProperty("checks");
   });
 
-  it("POST /api/sessions/clear-merged returns the empty cleared shape", async () => {
+  it("POST /api/sessions/clear-merged with no ids clears nothing", async () => {
     const r = await handleApi("POST", u("/api/sessions/clear-merged"), { ids: [] });
     expect(r.status).toBe(200);
     expect(await r.json()).toEqual({ cleared: [], leftovers: 0 });
+  });
+
+  it("POST /api/sessions/clear-merged archives the merged session and it disappears", async () => {
+    const r = await handleApi("POST", u("/api/sessions/clear-merged"), { ids: ["deps"] });
+    expect(r.status).toBe(200);
+    expect(await r.json()).toEqual({ cleared: ["deps"], leftovers: 0 });
+    expect(demoState.sessions().find((s) => s.id === "deps")).toBeUndefined();
+    // re-querying the clearable set now returns none — deps is gone, not re-offered.
+    expect((await get("/api/sessions/clear-merged")).body).toEqual({ ids: [], leftovers: 0 });
+  });
+
+  it("POST /api/sessions/clear-merged ignores an id that isn't actually merged", async () => {
+    const r = await handleApi("POST", u("/api/sessions/clear-merged"), { ids: ["coupon"] });
+    expect(await r.json()).toEqual({ cleared: [], leftovers: 0 });
+    expect(demoState.sessions().find((s) => s.id === "coupon")).toBeDefined();
   });
 
   it("POST epic/approve-next returns the updated Epic", async () => {

--- a/ui/src/lib/demo/router.test.ts
+++ b/ui/src/lib/demo/router.test.ts
@@ -67,6 +67,23 @@ describe("polished GET handlers return the shape api.ts consumes", () => {
     expect(one.body.parentIssueNumber).toBe(100);
   });
 
+  it("GET /api/sessions/clear-merged returns the empty clearable shape (never throws)", async () => {
+    const { status, body } = await get("/api/sessions/clear-merged");
+    expect(status).toBe(200);
+    expect(body).toEqual({ ids: [], leftovers: 0 });
+  });
+
+  it("the rich scenario seeds seven sessions across two repos", async () => {
+    const { body } = await get("/api/sessions");
+    expect(body).toHaveLength(7);
+    expect(body.map((s: { id: string }) => s.id).sort()).toEqual(
+      ["authstore", "checkout-child", "coupon", "deps", "neon", "ogimg", "rounding"].sort(),
+    );
+    expect(new Set(body.map((s: { repoPath: string }) => s.repoPath))).toEqual(
+      new Set(["/demo/acme/storefront", "/demo/acme/api"]),
+    );
+  });
+
   it("unknown GET falls through to a benign empty object", async () => {
     expect(await get("/api/nonexistent-thing")).toEqual({ status: 200, body: {} });
   });
@@ -74,23 +91,29 @@ describe("polished GET handlers return the shape api.ts consumes", () => {
 
 describe("mutation handlers call the mutator and return the caller's shape", () => {
   it("POST reply → 200 {}", async () => {
-    const r = await handleApi("POST", u("/api/sessions/s1/reply"), { text: "go" });
+    const r = await handleApi("POST", u("/api/sessions/coupon/reply"), { text: "go" });
     expect(r.status).toBe(200);
-    expect(demoState.sessions().find((s) => s.id === "s1")?.status).toBe("running");
+    expect(demoState.sessions().find((s) => s.id === "coupon")?.status).toBe("running");
   });
 
   it("POST /go releases the approved plan gate → {ok:true}", async () => {
-    const r = await handleApi("POST", u("/api/sessions/s2/go"), undefined);
+    const r = await handleApi("POST", u("/api/sessions/authstore/go"), undefined);
     expect(r.status).toBe(200);
     expect(await r.json()).toEqual({ ok: true });
-    expect(demoState.sessions().find((s) => s.id === "s2")?.planPhase).toBe("executing");
+    expect(demoState.sessions().find((s) => s.id === "authstore")?.planPhase).toBe("executing");
   });
 
   it("POST git/merge returns a PrStatus", async () => {
-    const r = await handleApi("POST", u("/api/sessions/s3/git/merge"), {});
+    const r = await handleApi("POST", u("/api/sessions/rounding/git/merge"), {});
     const body = await r.json();
     expect(body).toHaveProperty("state");
     expect(body).toHaveProperty("checks");
+  });
+
+  it("POST /api/sessions/clear-merged returns the empty cleared shape", async () => {
+    const r = await handleApi("POST", u("/api/sessions/clear-merged"), { ids: [] });
+    expect(r.status).toBe(200);
+    expect(await r.json()).toEqual({ cleared: [], leftovers: 0 });
   });
 
   it("POST epic/approve-next returns the updated Epic", async () => {
@@ -104,17 +127,18 @@ describe("mutation handlers call the mutator and return the caller's shape", () 
   });
 
   it("POST held/:id/spawn returns the new Session", async () => {
+    const before = demoState.held().length;
     const heldId = demoState.held()[0].id;
     const r = await handleApi("POST", u(`/api/held/${heldId}/spawn`), undefined);
     const body = await r.json();
     expect(body).toHaveProperty("id");
-    expect(demoState.held().length).toBe(0);
+    expect(demoState.held().length).toBe(before - 1);
   });
 
   it("DELETE /api/sessions/:id archives", async () => {
-    const r = await handleApi("DELETE", u("/api/sessions/s1"), undefined);
+    const r = await handleApi("DELETE", u("/api/sessions/coupon"), undefined);
     expect(r.status).toBe(200);
-    expect(demoState.sessions().find((s) => s.id === "s1")).toBeUndefined();
+    expect(demoState.sessions().find((s) => s.id === "coupon")).toBeUndefined();
   });
 
   it("unknown mutation falls through to {ok:true}", async () => {

--- a/ui/src/lib/demo/router.test.ts
+++ b/ui/src/lib/demo/router.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { handleApi } from "./router";
+import { demoState } from "./state";
+
+const REPO = "/demo/acme/storefront";
+const u = (path: string) => new URL(path, "http://localhost");
+
+async function get(path: string) {
+  const r = await handleApi("GET", u(path), undefined);
+  return { status: r.status, body: await r.json() };
+}
+
+beforeEach(() => demoState.reset());
+
+describe("polished GET handlers return the shape api.ts consumes", () => {
+  it("/api/me authenticates", async () => {
+    expect(await get("/api/me")).toEqual({ status: 200, body: { authenticated: true } });
+  });
+
+  it("/api/sessions returns the session array", async () => {
+    const { status, body } = await get("/api/sessions");
+    expect(status).toBe(200);
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBeGreaterThan(0);
+  });
+
+  it("/api/usage/limits wraps limits + projections (caller reads r.limits)", async () => {
+    const { body } = await get("/api/usage/limits");
+    expect(body.limits).toBeDefined();
+    expect(body.limits.session5h).not.toBeNull();
+    expect(Array.isArray(body.projections)).toBe(true);
+  });
+
+  it("/api/plugins wraps the array under {plugins}", async () => {
+    const { body } = await get("/api/plugins");
+    expect(Array.isArray(body.plugins)).toBe(true);
+    expect(body.plugins.length).toBeGreaterThan(0);
+  });
+
+  it("map-shaped bootstrap GETs return keyed objects", async () => {
+    for (const p of ["/api/git", "/api/activity", "/api/holds", "/api/subagents", "/api/queues"]) {
+      const { status, body } = await get(p);
+      expect(status).toBe(200);
+      expect(Object.keys(body).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("array-shaped bootstrap GETs are non-empty", async () => {
+    for (const p of ["/api/drain", "/api/automerge", "/api/epics/completed", "/api/steers"]) {
+      const { status, body } = await get(p);
+      expect(status).toBe(200);
+      expect(Array.isArray(body)).toBe(true);
+      expect(body.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("inflight lens GETs return empty arrays", async () => {
+    expect((await get("/api/reviews/inflight")).body).toEqual([]);
+    expect((await get("/api/plan-gates/inflight")).body).toEqual([]);
+  });
+
+  it("/api/epics returns {epics, subIssues}; /api/epic returns one Epic", async () => {
+    const list = await get(`/api/epics?repo=${encodeURIComponent(REPO)}`);
+    expect(Array.isArray(list.body.epics)).toBe(true);
+    expect(Array.isArray(list.body.subIssues)).toBe(true);
+    const one = await get(`/api/epic?repo=${encodeURIComponent(REPO)}&parent=100`);
+    expect(one.body.parentIssueNumber).toBe(100);
+  });
+
+  it("unknown GET falls through to a benign empty object", async () => {
+    expect(await get("/api/nonexistent-thing")).toEqual({ status: 200, body: {} });
+  });
+});
+
+describe("mutation handlers call the mutator and return the caller's shape", () => {
+  it("POST reply → 200 {}", async () => {
+    const r = await handleApi("POST", u("/api/sessions/s1/reply"), { text: "go" });
+    expect(r.status).toBe(200);
+    expect(demoState.sessions().find((s) => s.id === "s1")?.status).toBe("running");
+  });
+
+  it("POST /go releases the approved plan gate → {ok:true}", async () => {
+    const r = await handleApi("POST", u("/api/sessions/s2/go"), undefined);
+    expect(r.status).toBe(200);
+    expect(await r.json()).toEqual({ ok: true });
+    expect(demoState.sessions().find((s) => s.id === "s2")?.planPhase).toBe("executing");
+  });
+
+  it("POST git/merge returns a PrStatus", async () => {
+    const r = await handleApi("POST", u("/api/sessions/s3/git/merge"), {});
+    const body = await r.json();
+    expect(body).toHaveProperty("state");
+    expect(body).toHaveProperty("checks");
+  });
+
+  it("POST epic/approve-next returns the updated Epic", async () => {
+    const r = await handleApi(
+      "POST",
+      u(`/api/epic/approve-next?repo=${encodeURIComponent(REPO)}&parent=100`),
+      undefined,
+    );
+    const body = await r.json();
+    expect(body.parentIssueNumber).toBe(100);
+  });
+
+  it("POST held/:id/spawn returns the new Session", async () => {
+    const heldId = demoState.held()[0].id;
+    const r = await handleApi("POST", u(`/api/held/${heldId}/spawn`), undefined);
+    const body = await r.json();
+    expect(body).toHaveProperty("id");
+    expect(demoState.held().length).toBe(0);
+  });
+
+  it("DELETE /api/sessions/:id archives", async () => {
+    const r = await handleApi("DELETE", u("/api/sessions/s1"), undefined);
+    expect(r.status).toBe(200);
+    expect(demoState.sessions().find((s) => s.id === "s1")).toBeUndefined();
+  });
+
+  it("unknown mutation falls through to {ok:true}", async () => {
+    const r = await handleApi("POST", u("/api/some/off-screen/thing"), undefined);
+    expect(await r.json()).toEqual({ ok: true });
+  });
+
+  it("handleApi never throws on a malformed request", async () => {
+    const r = await handleApi("GET", u("/api/sessions"), undefined);
+    expect(r.status).toBe(200);
+  });
+});

--- a/ui/src/lib/demo/router.test.ts
+++ b/ui/src/lib/demo/router.test.ts
@@ -166,3 +166,119 @@ describe("mutation handlers call the mutator and return the caller's shape", () 
     expect(r.status).toBe(200);
   });
 });
+
+// Task 8: the DONE lens threw `sessions.find is not a function` because GET
+// /api/sessions/done had no handler and fell through to the permissive `{}` fallback —
+// `done.svelte.ts` assigns that straight to a `Session[]` store with no shape check.
+describe("GET /api/sessions/done (Done lens) is populated, never the {} fallback", () => {
+  it("returns a non-empty Session[], distinct from the live /api/sessions list", async () => {
+    const { status, body } = await get("/api/sessions/done");
+    expect(status).toBe(200);
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBeGreaterThan(0);
+    const liveIds = new Set(demoState.sessions().map((s: { id: string }) => s.id));
+    for (const s of body as { id: string; archivedAt: number | null }[]) {
+      expect(liveIds.has(s.id)).toBe(false); // archived, not part of the live herd
+      expect(s.archivedAt).not.toBeNull();
+    }
+  });
+
+  it("every done session has a matching recap so its row shows content, not recap_unavailable", async () => {
+    const done = (await get("/api/sessions/done")).body as { id: string }[];
+    const recaps = (await get("/api/recaps")).body as Record<string, unknown>;
+    for (const s of done) expect(recaps[s.id]).toBeDefined();
+  });
+});
+
+// Task 8 sibling audit: every showcased session-detail-tab GET must resolve to the shape
+// its api.ts caller + Svelte consumer expect — never the empty-object fallback, which
+// throws downstream (`.find`/`.map`/`.length` on a non-array, or `.files.length` /
+// `.entries.length` on a property `{}` doesn't have).
+describe("session-detail tab GETs never fall back to {}", () => {
+  it("GET /api/sessions/:id/activity returns ActivityEntry[] (rich for the hero)", async () => {
+    const { status, body } = await get("/api/sessions/coupon/activity");
+    expect(status).toBe(200);
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBeGreaterThan(0);
+    // an unseeded session still gets a valid array, not {}
+    expect((await get("/api/sessions/rounding/activity")).body).toEqual([]);
+  });
+
+  it("GET /api/sessions/:id/diff returns a DiffResult with a `files` array (rich for the hero)", async () => {
+    const { status, body } = await get("/api/sessions/coupon/diff");
+    expect(status).toBe(200);
+    expect(Array.isArray(body.files)).toBe(true);
+    expect(body.files.length).toBeGreaterThan(0);
+    // an unseeded session still gets a valid DiffResult, not {} (files would be undefined)
+    const empty = await get("/api/sessions/rounding/diff");
+    expect(Array.isArray(empty.body.files)).toBe(true);
+  });
+
+  it("GET /api/sessions/:id/scratchpad returns a ScratchListing with an `entries` array", async () => {
+    const { status, body } = await get("/api/sessions/coupon/scratchpad");
+    expect(status).toBe(200);
+    expect(Array.isArray(body.entries)).toBe(true);
+    expect(body.entries.length).toBeGreaterThan(0);
+    const empty = await get("/api/sessions/rounding/scratchpad");
+    expect(Array.isArray(empty.body.entries)).toBe(true);
+  });
+
+  it("GET /api/sessions/:id/usage returns a SessionUsage record, never {}", async () => {
+    const { body } = await get("/api/sessions/coupon/usage");
+    expect(typeof body.total).toBe("number");
+    expect(body.total).toBeGreaterThan(0);
+    expect(typeof (await get("/api/sessions/rounding/usage")).body.total).toBe("number");
+  });
+
+  it("GET /api/sessions/:id/leftovers returns [], never {}", async () => {
+    expect((await get("/api/sessions/coupon/leftovers")).body).toEqual([]);
+  });
+
+  it("GET /api/sessions/:id/queue returns a BuildQueue with a `steps` array for every session", async () => {
+    const withQueue = await get("/api/sessions/coupon/queue");
+    expect(Array.isArray(withQueue.body.steps)).toBe(true);
+    expect(withQueue.body.steps.length).toBeGreaterThan(0);
+    // a session with no seeded queue still gets a valid empty BuildQueue, not {}
+    const noQueue = await get("/api/sessions/rounding/queue");
+    expect(noQueue.body).toEqual({ sessionId: "rounding", approved: false, steps: [] });
+  });
+
+  it("GET /api/repo-config, /api/commands, /api/todo resolve for a known repo", async () => {
+    const repo = encodeURIComponent(REPO);
+    const cfg = await get(`/api/repo-config?repo=${repo}`);
+    expect(cfg.body.buildQueueEnabled).toBe(true);
+    const cmds = await get(`/api/commands?repo=${repo}`);
+    expect(Array.isArray(cmds.body.commands)).toBe(true);
+    expect(cmds.body.commands.length).toBeGreaterThan(0);
+    const todo = await get(`/api/todo?repo=${repo}`);
+    expect(todo.body).toEqual({ exists: false, content: "" });
+  });
+});
+
+// Task 8 sibling audit: the Owed lens's `{#each}` silently no-ops on a non-array (Svelte's
+// `ensure_array_like` falls back to `Array.from`, which is `[]` for a plain `{}`), so this
+// gap never THREW — it just left a showcased lens (deps' one real owed step) empty.
+describe("GET /api/manual-steps/outstanding (Owed lens) is populated, never silently empty", () => {
+  it("returns deps' seeded owed step", async () => {
+    const { status, body } = await get("/api/manual-steps/outstanding");
+    expect(status).toBe(200);
+    expect(Array.isArray(body)).toBe(true);
+    expect(body).toHaveLength(1);
+    expect(body[0].sessionId).toBe("deps");
+    expect(body[0].steps).toHaveLength(1);
+    expect(body[0].steps[0].doneAt).toBeNull();
+  });
+
+  it("POST .../steps/:stepId ticks the step; dismiss clears the whole record", async () => {
+    const stepRes = await handleApi("POST", u("/api/manual-steps/deps/steps/deps-ms-1"), {
+      done: true,
+    });
+    expect(stepRes.status).toBe(200);
+    const stepBody = await stepRes.json();
+    expect(stepBody.steps[0].doneAt).not.toBeNull();
+
+    const dismissRes = await handleApi("POST", u("/api/manual-steps/deps/dismiss"), {});
+    expect(dismissRes.status).toBe(200);
+    expect((await get("/api/manual-steps/outstanding")).body).toEqual([]);
+  });
+});

--- a/ui/src/lib/demo/router.ts
+++ b/ui/src/lib/demo/router.ts
@@ -34,10 +34,10 @@ function handleGet(path: string, url: URL): Response | null {
     // ── bootstrap ──────────────────────────────────────────────────────────
     case "/api/sessions":
       return json(demoState.sessions());
-    // Admin "clear merged": the demo has no merged-branch sessions to clear, so the
-    // clearable set is empty. Shape matches getMergedClearable() in api.ts exactly.
+    // Admin "clear merged": derives the merged, non-archived session ids from live
+    // state (currently `deps`) — shape matches getMergedClearable() in api.ts exactly.
     case "/api/sessions/clear-merged":
-      return json({ ids: [], leftovers: 0 });
+      return json(demoState.mergedClearable());
     case "/api/held":
       return json(demoState.held());
     case "/api/usage/limits":
@@ -132,10 +132,10 @@ function handleGet(path: string, url: URL): Response | null {
 }
 
 function handleMutation(method: string, path: string, body: unknown): Response | null {
-  // POST /api/sessions/clear-merged — nothing merged to clear in the demo. Shape
-  // matches clearMerged() in api.ts. Handled before the /:id/<tail> patterns below.
+  // POST /api/sessions/clear-merged — archives the given merged ids in demoState.
+  // Shape matches clearMerged() in api.ts. Handled before the /:id/<tail> patterns below.
   if (method === "POST" && path === "/api/sessions/clear-merged") {
-    return json({ cleared: [], leftovers: 0 });
+    return json(demoState.clearMerged(field<string[]>(body, "ids") ?? []));
   }
   // POST /api/sessions/:id/reply
   if (method === "POST" && /^\/api\/sessions\/[^/]+\/reply$/.test(path)) {

--- a/ui/src/lib/demo/router.ts
+++ b/ui/src/lib/demo/router.ts
@@ -3,6 +3,12 @@
 // GET, every showcased-lens GET, and the demo-flow mutations — has an exact handler
 // returning the precise shape its `api.ts` caller consumes. Everything off-screen
 // falls through to a permissive, never-throwing stub. `handleApi` never throws.
+//
+// GET routes are exact-path lookups grouped into small tables by resource family
+// (bootstrap / lenses / epics), plus one regex-matched group for session-detail
+// tabs. Mutations are grouped the same way (sessions / held / manual-steps).
+// This keeps each dispatcher a flat lookup or a handful of same-shape checks
+// instead of one long branchy switch.
 
 import { demoState } from "./state";
 
@@ -26,133 +32,97 @@ function seg(path: string, index: number): string {
   return decodeURIComponent(path.split("/")[index] ?? "");
 }
 
-function handleGet(path: string, url: URL): Response | null {
-  switch (path) {
-    case "/api/me":
-      return json({ authenticated: true });
+/** Read the `repo` query param shared by most repo-scoped GET routes. */
+function repoParam(url: URL): string {
+  return url.searchParams.get("repo") ?? "";
+}
 
-    // ── bootstrap ──────────────────────────────────────────────────────────
-    case "/api/sessions":
-      return json(demoState.sessions());
-    // Admin "clear merged": derives the merged, non-archived session ids from live
-    // state (currently `deps`) — shape matches getMergedClearable() in api.ts exactly.
-    case "/api/sessions/clear-merged":
-      return json(demoState.mergedClearable());
-    // Done lens (#Task 8): archived sessions, distinct from the live `sessions` list.
-    // Must precede the `/api/sessions/:id/<tail>` regexes below — "done" isn't a session id.
-    case "/api/sessions/done":
-      return json(demoState.doneSessions());
-    case "/api/repo-config": {
-      const repo = url.searchParams.get("repo") ?? "";
-      return json(demoState.repoConfig(repo));
-    }
-    case "/api/commands": {
-      const repo = url.searchParams.get("repo") ?? "";
-      return json(demoState.commands(repo));
-    }
-    case "/api/todo": {
-      const repo = url.searchParams.get("repo") ?? "";
-      return json(demoState.todo(repo));
-    }
-    // Owed lens (#Task 8): durable post-merge step records — outstanding only. Svelte's
-    // `{#each}` silently no-ops on the old `{}` fallback, so this gap never threw; it
-    // just left the lens empty even though `deps` seeds one genuinely-owed step.
-    case "/api/manual-steps/outstanding":
-      return json(demoState.outstandingManualSteps());
-    case "/api/held":
-      return json(demoState.held());
-    case "/api/usage/limits":
-      return json(demoState.usageLimits());
-    case "/api/update":
-      return json(demoState.update());
-    case "/api/update/log":
-      return json({ phase: "idle", exitCode: null, log: "" });
-    case "/api/herdr-update":
-      return json(demoState.herdrUpdate());
-    case "/api/codex-update":
-      return json(demoState.codexUpdate());
-    case "/api/star-prompt":
-      return json(demoState.starPrompt());
-    case "/api/git":
-      return json(demoState.gitStates());
-    case "/api/activity":
-      return json(demoState.activityStates());
-    case "/api/claude-alive":
-      return json(demoState.claudeAliveStates());
-    case "/api/working-blocked":
-      return json(demoState.workingBlockedStates());
-    case "/api/holds":
-      return json(demoState.holdStates());
-    case "/api/subagents":
-      return json(demoState.subagentStates());
-    case "/api/preview":
-      return json(demoState.previewStates());
-    case "/api/drain":
-      return json(demoState.drain());
-    case "/api/automerge":
-      return json(demoState.autoMerge());
-    case "/api/epics/completed":
-      return json(demoState.completedEpics());
+type GetHandler = (url: URL) => Response;
 
-    // ── lenses / drawers ─────────────────────────────────────────────────────
-    case "/api/settings":
-      return json(demoState.settings());
-    case "/api/plugins":
-      return json({ plugins: demoState.plugins() });
-    case "/api/diagnostics":
-      return json(demoState.diagnostics());
-    case "/api/backlog":
-      return json(demoState.backlog());
-    case "/api/queues":
-      return json(demoState.buildQueues());
-    case "/api/reviews":
-      return json(demoState.reviews());
-    case "/api/reviews/inflight":
-      return json([]);
-    case "/api/plan-gates":
-      return json(demoState.planGates());
-    case "/api/plan-gates/inflight":
-      return json([]);
-    case "/api/recaps":
-      return json(demoState.recaps());
-    case "/api/herd/digest":
-      return json(demoState.herdDigest());
-    case "/api/up-next":
-      return json(demoState.upNext());
-    case "/api/steers":
-      return json(demoState.steers());
-    case "/api/project-icons":
-      return json(demoState.projectIcons());
-    case "/api/learnings/pending":
-      return json(demoState.pendingLearnings());
-    case "/api/learnings/injectable":
-      return json([]);
-    case "/api/learnings/merge-suggestions":
-      return json([]);
-    case "/api/learnings/health":
-      return json({ ok: true, consecutiveFailures: 0, lastFailure: null });
-    case "/api/epics": {
-      const repo = url.searchParams.get("repo") ?? "";
-      return json(demoState.epicSummaries(repo));
-    }
-    case "/api/epic": {
-      const repo = url.searchParams.get("repo") ?? "";
-      const parent = Number(url.searchParams.get("parent") ?? "0");
-      const epic = demoState.epic(repo, parent);
-      return epic ? json(epic) : new Response(null, { status: 404 });
-    }
-  }
+// ── bootstrap ──────────────────────────────────────────────────────────────
+const bootstrapGetRoutes: Record<string, GetHandler> = {
+  "/api/me": () => json({ authenticated: true }),
+  "/api/sessions": () => json(demoState.sessions()),
+  // Admin "clear merged": derives the merged, non-archived session ids from live
+  // state (currently `deps`) — shape matches getMergedClearable() in api.ts exactly.
+  "/api/sessions/clear-merged": () => json(demoState.mergedClearable()),
+  // Done lens (#Task 8): archived sessions, distinct from the live `sessions` list.
+  "/api/sessions/done": () => json(demoState.doneSessions()),
+  "/api/repo-config": (url) => json(demoState.repoConfig(repoParam(url))),
+  "/api/commands": (url) => json(demoState.commands(repoParam(url))),
+  "/api/todo": (url) => json(demoState.todo(repoParam(url))),
+  // Owed lens (#Task 8): durable post-merge step records — outstanding only. Svelte's
+  // `{#each}` silently no-ops on the old `{}` fallback, so this gap never threw; it
+  // just left the lens empty even though `deps` seeds one genuinely-owed step.
+  "/api/manual-steps/outstanding": () => json(demoState.outstandingManualSteps()),
+  "/api/held": () => json(demoState.held()),
+  "/api/usage/limits": () => json(demoState.usageLimits()),
+  "/api/update": () => json(demoState.update()),
+  "/api/update/log": () => json({ phase: "idle", exitCode: null, log: "" }),
+  "/api/herdr-update": () => json(demoState.herdrUpdate()),
+  "/api/codex-update": () => json(demoState.codexUpdate()),
+  "/api/star-prompt": () => json(demoState.starPrompt()),
+  "/api/git": () => json(demoState.gitStates()),
+  "/api/activity": () => json(demoState.activityStates()),
+  "/api/claude-alive": () => json(demoState.claudeAliveStates()),
+  "/api/working-blocked": () => json(demoState.workingBlockedStates()),
+  "/api/holds": () => json(demoState.holdStates()),
+  "/api/subagents": () => json(demoState.subagentStates()),
+  "/api/preview": () => json(demoState.previewStates()),
+  "/api/drain": () => json(demoState.drain()),
+  "/api/automerge": () => json(demoState.autoMerge()),
+  "/api/epics/completed": () => json(demoState.completedEpics()),
+};
 
-  // `/api/sessions/:id/git` — single-session PR state (404 → api returns null).
+// ── lenses / drawers ─────────────────────────────────────────────────────
+const lensGetRoutes: Record<string, GetHandler> = {
+  "/api/settings": () => json(demoState.settings()),
+  "/api/plugins": () => json({ plugins: demoState.plugins() }),
+  "/api/diagnostics": () => json(demoState.diagnostics()),
+  "/api/backlog": () => json(demoState.backlog()),
+  "/api/queues": () => json(demoState.buildQueues()),
+  "/api/reviews": () => json(demoState.reviews()),
+  "/api/reviews/inflight": () => json([]),
+  "/api/plan-gates": () => json(demoState.planGates()),
+  "/api/plan-gates/inflight": () => json([]),
+  "/api/recaps": () => json(demoState.recaps()),
+  "/api/herd/digest": () => json(demoState.herdDigest()),
+  "/api/up-next": () => json(demoState.upNext()),
+  "/api/steers": () => json(demoState.steers()),
+  "/api/project-icons": () => json(demoState.projectIcons()),
+  "/api/learnings/pending": () => json(demoState.pendingLearnings()),
+  "/api/learnings/injectable": () => json([]),
+  "/api/learnings/merge-suggestions": () => json([]),
+  "/api/learnings/health": () => json({ ok: true, consecutiveFailures: 0, lastFailure: null }),
+};
+
+// ── epics ────────────────────────────────────────────────────────────────
+const epicsGetRoutes: Record<string, GetHandler> = {
+  "/api/epics": (url) => json(demoState.epicSummaries(repoParam(url))),
+  "/api/epic": (url) => {
+    const parent = Number(url.searchParams.get("parent") ?? "0");
+    const epic = demoState.epic(repoParam(url), parent);
+    return epic ? json(epic) : new Response(null, { status: 404 });
+  },
+};
+
+const exactGetRoutes: Record<string, GetHandler> = {
+  ...bootstrapGetRoutes,
+  ...lensGetRoutes,
+  ...epicsGetRoutes,
+};
+
+// ── session-detail tabs (Task 8 sibling audit) ─────────────────────────────
+// Every GET a Viewport tab (or its always-on chrome) fires when a session is opened,
+// plus the single-session PR-state GET. Each returns a correctly-shaped, never-`{}`
+// response — see the matching demoState getter in state.ts for the exact fallback
+// shape per endpoint. Must run after the exact-match table above — "done" (etc.)
+// isn't a session id, so the exact routes take priority.
+function handleSessionDetailGet(path: string, url: URL): Response | null {
   if (/^\/api\/sessions\/[^/]+\/git$/.test(path)) {
     const git = demoState.gitState(seg(path, 3));
     return git ? json(git) : new Response(null, { status: 404 });
   }
-
-  // ── session-detail tabs (Task 8 sibling audit) ─────────────────────────
-  // Every GET a Viewport tab (or its always-on chrome) fires when a session is opened.
-  // Each returns a correctly-shaped, never-`{}` response — see the matching demoState
-  // getter in state.ts for the exact fallback shape per endpoint.
   if (/^\/api\/sessions\/[^/]+\/activity$/.test(path)) {
     return json(demoState.activityEntries(seg(path, 3)));
   }
@@ -175,59 +145,130 @@ function handleGet(path: string, url: URL): Response | null {
   if (/^\/api\/sessions\/[^/]+\/queue$/.test(path)) {
     return json(demoState.sessionBuildQueue(seg(path, 3)));
   }
-
   return null;
 }
 
-function handleMutation(method: string, path: string, body: unknown): Response | null {
+function handleGet(path: string, url: URL): Response | null {
+  const exact = exactGetRoutes[path];
+  if (exact) return exact(url);
+  return handleSessionDetailGet(path, url);
+}
+
+// ── session mutations ───────────────────────────────────────────────────────
+// The `/api/sessions/:id/<tail>` (+ `DELETE /api/sessions/:id`) family is
+// data-driven: one row per (method, tail pattern) rather than a chain of
+// `if (method === … && regex.test(path))` branches, so adding a route doesn't
+// grow this function's branching — only the table.
+type SessionMutationHandler = (path: string, body: unknown) => Response;
+
+const sessionIdMutationRoutes: ReadonlyArray<{
+  method: string;
+  pattern: RegExp;
+  handle: SessionMutationHandler;
+}> = [
+  {
+    // POST /api/sessions/:id/reply
+    method: "POST",
+    pattern: /^\/api\/sessions\/[^/]+\/reply$/,
+    handle: (path, body) => {
+      demoState.reply(seg(path, 3), field<string>(body, "text") ?? "");
+      return json({});
+    },
+  },
+  {
+    // PUT /api/sessions/:id/autopilot
+    method: "PUT",
+    pattern: /^\/api\/sessions\/[^/]+\/autopilot$/,
+    handle: (path, body) => {
+      demoState.setAutopilot(seg(path, 3), field<boolean | null>(body, "enabled") ?? null);
+      return json({});
+    },
+  },
+  {
+    // POST /api/sessions/:id/review-plan
+    method: "POST",
+    pattern: /^\/api\/sessions\/[^/]+\/review-plan$/,
+    handle: (path) => {
+      demoState.reviewPlan(seg(path, 3));
+      return json({ status: "started" });
+    },
+  },
+  {
+    // POST /api/sessions/:id/go  (release plan gate)
+    method: "POST",
+    pattern: /^\/api\/sessions\/[^/]+\/go$/,
+    handle: (path) => {
+      const ok = demoState.releasePlanGate(seg(path, 3));
+      return json({ ok }, ok ? 200 : 409);
+    },
+  },
+  {
+    // POST /api/sessions/:id/answer-plan-questions
+    method: "POST",
+    pattern: /^\/api\/sessions\/[^/]+\/answer-plan-questions$/,
+    handle: (path) => json(demoState.answerPlanQuestions(seg(path, 3))),
+  },
+  {
+    // POST /api/sessions/:id/git/merge
+    method: "POST",
+    pattern: /^\/api\/sessions\/[^/]+\/git\/merge$/,
+    handle: (path) => json(demoState.mergePr(seg(path, 3))),
+  },
+  {
+    // POST /api/sessions/:id/ready
+    method: "POST",
+    pattern: /^\/api\/sessions\/[^/]+\/ready$/,
+    handle: (path, body) => {
+      demoState.setReadyToMerge(seg(path, 3), field<boolean>(body, "ready") ?? true);
+      return json({});
+    },
+  },
+  {
+    // DELETE /api/sessions/:id  (archive)
+    method: "DELETE",
+    pattern: /^\/api\/sessions\/[^/]+$/,
+    handle: (path) => {
+      demoState.archiveSession(seg(path, 3));
+      return json({});
+    },
+  },
+];
+
+function handleSessionMutation(
+  method: string,
+  path: string,
+  url: URL,
+  body: unknown,
+): Response | null {
   // POST /api/sessions/clear-merged — archives the given merged ids in demoState.
-  // Shape matches clearMerged() in api.ts. Handled before the /:id/<tail> patterns below.
+  // Shape matches clearMerged() in api.ts. Handled before the /:id/<tail> table
+  // below — "clear-merged" isn't a session id.
   if (method === "POST" && path === "/api/sessions/clear-merged") {
     return json(demoState.clearMerged(field<string[]>(body, "ids") ?? []));
   }
-  // POST /api/sessions/:id/reply
-  if (method === "POST" && /^\/api\/sessions\/[^/]+\/reply$/.test(path)) {
-    demoState.reply(seg(path, 3), field<string>(body, "text") ?? "");
-    return json({});
+  // POST /api/epic/approve-next needs the URL query, so it's handled here alongside
+  // the other epic-shaped mutations rather than inline in handleApi.
+  if (method === "POST" && path === "/api/epic/approve-next") {
+    const parent = Number(url.searchParams.get("parent") ?? "0");
+    const epic = demoState.approveEpicNext(repoParam(url), parent);
+    return epic ? json(epic) : new Response(null, { status: 404 });
   }
-  // PUT /api/sessions/:id/autopilot
-  if (method === "PUT" && /^\/api\/sessions\/[^/]+\/autopilot$/.test(path)) {
-    demoState.setAutopilot(seg(path, 3), field<boolean | null>(body, "enabled") ?? null);
-    return json({});
-  }
-  // POST /api/sessions/:id/review-plan
-  if (method === "POST" && /^\/api\/sessions\/[^/]+\/review-plan$/.test(path)) {
-    demoState.reviewPlan(seg(path, 3));
-    return json({ status: "started" });
-  }
-  // POST /api/sessions/:id/go  (release plan gate)
-  if (method === "POST" && /^\/api\/sessions\/[^/]+\/go$/.test(path)) {
-    const ok = demoState.releasePlanGate(seg(path, 3));
-    return json({ ok }, ok ? 200 : 409);
-  }
-  // POST /api/sessions/:id/answer-plan-questions
-  if (method === "POST" && /^\/api\/sessions\/[^/]+\/answer-plan-questions$/.test(path)) {
-    return json(demoState.answerPlanQuestions(seg(path, 3)));
-  }
-  // POST /api/sessions/:id/git/merge
-  if (method === "POST" && /^\/api\/sessions\/[^/]+\/git\/merge$/.test(path)) {
-    return json(demoState.mergePr(seg(path, 3)));
-  }
-  // POST /api/sessions/:id/ready
-  if (method === "POST" && /^\/api\/sessions\/[^/]+\/ready$/.test(path)) {
-    demoState.setReadyToMerge(seg(path, 3), field<boolean>(body, "ready") ?? true);
-    return json({});
-  }
-  // DELETE /api/sessions/:id  (archive)
-  if (method === "DELETE" && /^\/api\/sessions\/[^/]+$/.test(path)) {
-    demoState.archiveSession(seg(path, 3));
-    return json({});
-  }
+  const route = sessionIdMutationRoutes.find((r) => r.method === method && r.pattern.test(path));
+  return route ? route.handle(path, body) : null;
+}
+
+// ── held-session mutations ───────────────────────────────────────────────────
+function handleHeldMutation(method: string, path: string): Response | null {
   // POST /api/held/:id/spawn
   if (method === "POST" && /^\/api\/held\/[^/]+\/spawn$/.test(path)) {
     const s = demoState.spawnHeld(seg(path, 3));
     return s ? json(s) : new Response(null, { status: 404 });
   }
+  return null;
+}
+
+// ── manual-steps (Owed lens) mutations ───────────────────────────────────────
+function handleManualStepsMutation(method: string, path: string, body: unknown): Response | null {
   // POST /api/manual-steps/:sessionId/steps/:stepId — tick/un-tick one owed step.
   if (method === "POST" && /^\/api\/manual-steps\/[^/]+\/steps\/[^/]+$/.test(path)) {
     const updated = demoState.setManualStepDone(
@@ -245,32 +286,26 @@ function handleMutation(method: string, path: string, body: unknown): Response |
   return null;
 }
 
+function handleMutation(method: string, path: string, url: URL, body: unknown): Response | null {
+  return (
+    handleSessionMutation(method, path, url, body) ??
+    handleHeldMutation(method, path) ??
+    handleManualStepsMutation(method, path, body)
+  );
+}
+
 /** Map an intercepted `/api/**` request to a Response. Always resolves; never throws. */
 export async function handleApi(method: string, url: URL, body: unknown): Promise<Response> {
   try {
     const path = url.pathname;
     const m = method.toUpperCase();
-
-    if (m === "GET") {
-      const res = handleGet(path, url);
-      if (res) return res;
-    } else {
-      // POST /api/epic/approve-next needs the URL query, so handle it here.
-      if (m === "POST" && path === "/api/epic/approve-next") {
-        const repo = url.searchParams.get("repo") ?? "";
-        const parent = Number(url.searchParams.get("parent") ?? "0");
-        const epic = demoState.approveEpicNext(repo, parent);
-        return epic ? json(epic) : new Response(null, { status: 404 });
-      }
-      const res = handleMutation(m, path, body);
-      if (res) return res;
-    }
+    const res = m === "GET" ? handleGet(path, url) : handleMutation(m, path, url, body);
+    if (res) return res;
 
     // Permissive fallback for off-screen endpoints: unmatched read → benign empty
     // object; unmatched mutation → a generic success. Keeps the demo UI from
     // erroring on endpoints no showcased screen touches.
-    if (m === "GET") return json({});
-    return json({ ok: true });
+    return json(m === "GET" ? {} : { ok: true });
   } catch {
     // Never throw out of the transport — a malformed request degrades to a stub.
     return json(method.toUpperCase() === "GET" ? {} : { ok: true });

--- a/ui/src/lib/demo/router.ts
+++ b/ui/src/lib/demo/router.ts
@@ -38,6 +38,27 @@ function handleGet(path: string, url: URL): Response | null {
     // state (currently `deps`) — shape matches getMergedClearable() in api.ts exactly.
     case "/api/sessions/clear-merged":
       return json(demoState.mergedClearable());
+    // Done lens (#Task 8): archived sessions, distinct from the live `sessions` list.
+    // Must precede the `/api/sessions/:id/<tail>` regexes below — "done" isn't a session id.
+    case "/api/sessions/done":
+      return json(demoState.doneSessions());
+    case "/api/repo-config": {
+      const repo = url.searchParams.get("repo") ?? "";
+      return json(demoState.repoConfig(repo));
+    }
+    case "/api/commands": {
+      const repo = url.searchParams.get("repo") ?? "";
+      return json(demoState.commands(repo));
+    }
+    case "/api/todo": {
+      const repo = url.searchParams.get("repo") ?? "";
+      return json(demoState.todo(repo));
+    }
+    // Owed lens (#Task 8): durable post-merge step records — outstanding only. Svelte's
+    // `{#each}` silently no-ops on the old `{}` fallback, so this gap never threw; it
+    // just left the lens empty even though `deps` seeds one genuinely-owed step.
+    case "/api/manual-steps/outstanding":
+      return json(demoState.outstandingManualSteps());
     case "/api/held":
       return json(demoState.held());
     case "/api/usage/limits":
@@ -128,6 +149,33 @@ function handleGet(path: string, url: URL): Response | null {
     return git ? json(git) : new Response(null, { status: 404 });
   }
 
+  // ── session-detail tabs (Task 8 sibling audit) ─────────────────────────
+  // Every GET a Viewport tab (or its always-on chrome) fires when a session is opened.
+  // Each returns a correctly-shaped, never-`{}` response — see the matching demoState
+  // getter in state.ts for the exact fallback shape per endpoint.
+  if (/^\/api\/sessions\/[^/]+\/activity$/.test(path)) {
+    return json(demoState.activityEntries(seg(path, 3)));
+  }
+  if (/^\/api\/sessions\/[^/]+\/diff$/.test(path)) {
+    return json(demoState.diff(seg(path, 3)));
+  }
+  if (/^\/api\/sessions\/[^/]+\/scratchpad$/.test(path)) {
+    // Root listing only (matches the demo's flat, non-nested scratchpad seeds); a
+    // non-root `path` query still returns a valid empty listing at that path, never {}.
+    const reqPath = url.searchParams.get("path") ?? "";
+    const root = demoState.scratchpadRoot(seg(path, 3));
+    return json(reqPath ? { path: reqPath, parent: "", entries: [] } : root);
+  }
+  if (/^\/api\/sessions\/[^/]+\/usage$/.test(path)) {
+    return json(demoState.sessionUsage(seg(path, 3)));
+  }
+  if (/^\/api\/sessions\/[^/]+\/leftovers$/.test(path)) {
+    return json(demoState.leftovers());
+  }
+  if (/^\/api\/sessions\/[^/]+\/queue$/.test(path)) {
+    return json(demoState.sessionBuildQueue(seg(path, 3)));
+  }
+
   return null;
 }
 
@@ -179,6 +227,20 @@ function handleMutation(method: string, path: string, body: unknown): Response |
   if (method === "POST" && /^\/api\/held\/[^/]+\/spawn$/.test(path)) {
     const s = demoState.spawnHeld(seg(path, 3));
     return s ? json(s) : new Response(null, { status: 404 });
+  }
+  // POST /api/manual-steps/:sessionId/steps/:stepId — tick/un-tick one owed step.
+  if (method === "POST" && /^\/api\/manual-steps\/[^/]+\/steps\/[^/]+$/.test(path)) {
+    const updated = demoState.setManualStepDone(
+      seg(path, 3),
+      seg(path, 5),
+      field<boolean>(body, "done") ?? true,
+    );
+    return updated ? json(updated) : new Response(null, { status: 404 });
+  }
+  // POST /api/manual-steps/:sessionId/dismiss — clear a whole owed record.
+  if (method === "POST" && /^\/api\/manual-steps\/[^/]+\/dismiss$/.test(path)) {
+    const updated = demoState.dismissManualSteps(seg(path, 3));
+    return updated ? json(updated) : new Response(null, { status: 404 });
   }
   return null;
 }

--- a/ui/src/lib/demo/router.ts
+++ b/ui/src/lib/demo/router.ts
@@ -1,0 +1,29 @@
+// Thin demo API router. Task 2 only needs the transport proven, so this is a
+// starter: an exact `/api/me` handler (200 authenticated, matching what `getMe`
+// in api.ts probes) plus a permissive, never-throwing fallback for everything
+// else. Task 3 replaces the fallback with state-backed handlers seeded from the
+// demo world, returning rich shapes for the showcased panels.
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** Map an intercepted `/api/**` request to a Response. Always resolves; never throws. */
+export async function handleApi(method: string, url: URL, body: unknown): Promise<Response> {
+  const path = url.pathname;
+  const m = method.toUpperCase();
+  void body; // reserved for the Task 3 state-backed handlers (mutations read it)
+
+  // `getMe` treats any 200 as authenticated (it only reads `r.ok`).
+  if (m === "GET" && path === "/api/me") return json({ authenticated: true });
+
+  // Task 3: state-backed handlers replace the permissive fallback below.
+
+  // Permissive fallback: unmatched read → benign empty object; unmatched mutation
+  // → a generic success. Keeps the demo UI from erroring on off-screen endpoints.
+  if (m === "GET") return json({});
+  return json({ ok: true });
+}

--- a/ui/src/lib/demo/router.ts
+++ b/ui/src/lib/demo/router.ts
@@ -1,8 +1,10 @@
-// Thin demo API router. Task 2 only needs the transport proven, so this is a
-// starter: an exact `/api/me` handler (200 authenticated, matching what `getMe`
-// in api.ts probes) plus a permissive, never-throwing fallback for everything
-// else. Task 3 replaces the fallback with state-backed handlers seeded from the
-// demo world, returning rich shapes for the showcased panels.
+// State-backed demo API router. Maps every intercepted `/api/**` request to a
+// Response drawn from the in-memory `demoState`. The POLISHED set — every bootstrap
+// GET, every showcased-lens GET, and the demo-flow mutations — has an exact handler
+// returning the precise shape its `api.ts` caller consumes. Everything off-screen
+// falls through to a permissive, never-throwing stub. `handleApi` never throws.
+
+import { demoState } from "./state";
 
 function json(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -11,19 +13,195 @@ function json(data: unknown, status = 200): Response {
   });
 }
 
+/** Body may be a parsed object (readBody JSON) or absent; read a field defensively. */
+function field<T>(body: unknown, key: string): T | undefined {
+  if (body && typeof body === "object" && key in body) {
+    return (body as Record<string, T>)[key];
+  }
+  return undefined;
+}
+
+/** Extract the `:id` from `/api/sessions/:id/<tail>` (or `/api/held/:id/<tail>`). */
+function seg(path: string, index: number): string {
+  return decodeURIComponent(path.split("/")[index] ?? "");
+}
+
+function handleGet(path: string, url: URL): Response | null {
+  switch (path) {
+    case "/api/me":
+      return json({ authenticated: true });
+
+    // ── bootstrap ──────────────────────────────────────────────────────────
+    case "/api/sessions":
+      return json(demoState.sessions());
+    case "/api/held":
+      return json(demoState.held());
+    case "/api/usage/limits":
+      return json(demoState.usageLimits());
+    case "/api/update":
+      return json(demoState.update());
+    case "/api/update/log":
+      return json({ phase: "idle", exitCode: null, log: "" });
+    case "/api/herdr-update":
+      return json(demoState.herdrUpdate());
+    case "/api/codex-update":
+      return json(demoState.codexUpdate());
+    case "/api/star-prompt":
+      return json(demoState.starPrompt());
+    case "/api/git":
+      return json(demoState.gitStates());
+    case "/api/activity":
+      return json(demoState.activityStates());
+    case "/api/claude-alive":
+      return json(demoState.claudeAliveStates());
+    case "/api/working-blocked":
+      return json(demoState.workingBlockedStates());
+    case "/api/holds":
+      return json(demoState.holdStates());
+    case "/api/subagents":
+      return json(demoState.subagentStates());
+    case "/api/preview":
+      return json(demoState.previewStates());
+    case "/api/drain":
+      return json(demoState.drain());
+    case "/api/automerge":
+      return json(demoState.autoMerge());
+    case "/api/epics/completed":
+      return json(demoState.completedEpics());
+
+    // ── lenses / drawers ─────────────────────────────────────────────────────
+    case "/api/settings":
+      return json(demoState.settings());
+    case "/api/plugins":
+      return json({ plugins: demoState.plugins() });
+    case "/api/diagnostics":
+      return json(demoState.diagnostics());
+    case "/api/backlog":
+      return json(demoState.backlog());
+    case "/api/queues":
+      return json(demoState.buildQueues());
+    case "/api/reviews":
+      return json(demoState.reviews());
+    case "/api/reviews/inflight":
+      return json([]);
+    case "/api/plan-gates":
+      return json(demoState.planGates());
+    case "/api/plan-gates/inflight":
+      return json([]);
+    case "/api/recaps":
+      return json(demoState.recaps());
+    case "/api/herd/digest":
+      return json(demoState.herdDigest());
+    case "/api/up-next":
+      return json(demoState.upNext());
+    case "/api/steers":
+      return json(demoState.steers());
+    case "/api/project-icons":
+      return json(demoState.projectIcons());
+    case "/api/learnings/pending":
+      return json(demoState.pendingLearnings());
+    case "/api/learnings/injectable":
+      return json([]);
+    case "/api/learnings/merge-suggestions":
+      return json([]);
+    case "/api/learnings/health":
+      return json({ ok: true, consecutiveFailures: 0, lastFailure: null });
+    case "/api/epics": {
+      const repo = url.searchParams.get("repo") ?? "";
+      return json(demoState.epicSummaries(repo));
+    }
+    case "/api/epic": {
+      const repo = url.searchParams.get("repo") ?? "";
+      const parent = Number(url.searchParams.get("parent") ?? "0");
+      const epic = demoState.epic(repo, parent);
+      return epic ? json(epic) : new Response(null, { status: 404 });
+    }
+  }
+
+  // `/api/sessions/:id/git` — single-session PR state (404 → api returns null).
+  if (/^\/api\/sessions\/[^/]+\/git$/.test(path)) {
+    const git = demoState.gitState(seg(path, 3));
+    return git ? json(git) : new Response(null, { status: 404 });
+  }
+
+  return null;
+}
+
+function handleMutation(method: string, path: string, body: unknown): Response | null {
+  // POST /api/sessions/:id/reply
+  if (method === "POST" && /^\/api\/sessions\/[^/]+\/reply$/.test(path)) {
+    demoState.reply(seg(path, 3), field<string>(body, "text") ?? "");
+    return json({});
+  }
+  // PUT /api/sessions/:id/autopilot
+  if (method === "PUT" && /^\/api\/sessions\/[^/]+\/autopilot$/.test(path)) {
+    demoState.setAutopilot(seg(path, 3), field<boolean | null>(body, "enabled") ?? null);
+    return json({});
+  }
+  // POST /api/sessions/:id/review-plan
+  if (method === "POST" && /^\/api\/sessions\/[^/]+\/review-plan$/.test(path)) {
+    demoState.reviewPlan(seg(path, 3));
+    return json({ status: "started" });
+  }
+  // POST /api/sessions/:id/go  (release plan gate)
+  if (method === "POST" && /^\/api\/sessions\/[^/]+\/go$/.test(path)) {
+    const ok = demoState.releasePlanGate(seg(path, 3));
+    return json({ ok }, ok ? 200 : 409);
+  }
+  // POST /api/sessions/:id/answer-plan-questions
+  if (method === "POST" && /^\/api\/sessions\/[^/]+\/answer-plan-questions$/.test(path)) {
+    return json(demoState.answerPlanQuestions(seg(path, 3)));
+  }
+  // POST /api/sessions/:id/git/merge
+  if (method === "POST" && /^\/api\/sessions\/[^/]+\/git\/merge$/.test(path)) {
+    return json(demoState.mergePr(seg(path, 3)));
+  }
+  // POST /api/sessions/:id/ready
+  if (method === "POST" && /^\/api\/sessions\/[^/]+\/ready$/.test(path)) {
+    demoState.setReadyToMerge(seg(path, 3), field<boolean>(body, "ready") ?? true);
+    return json({});
+  }
+  // DELETE /api/sessions/:id  (archive)
+  if (method === "DELETE" && /^\/api\/sessions\/[^/]+$/.test(path)) {
+    demoState.archiveSession(seg(path, 3));
+    return json({});
+  }
+  // POST /api/held/:id/spawn
+  if (method === "POST" && /^\/api\/held\/[^/]+\/spawn$/.test(path)) {
+    const s = demoState.spawnHeld(seg(path, 3));
+    return s ? json(s) : new Response(null, { status: 404 });
+  }
+  return null;
+}
+
 /** Map an intercepted `/api/**` request to a Response. Always resolves; never throws. */
 export async function handleApi(method: string, url: URL, body: unknown): Promise<Response> {
-  const path = url.pathname;
-  const m = method.toUpperCase();
-  void body; // reserved for the Task 3 state-backed handlers (mutations read it)
+  try {
+    const path = url.pathname;
+    const m = method.toUpperCase();
 
-  // `getMe` treats any 200 as authenticated (it only reads `r.ok`).
-  if (m === "GET" && path === "/api/me") return json({ authenticated: true });
+    if (m === "GET") {
+      const res = handleGet(path, url);
+      if (res) return res;
+    } else {
+      // POST /api/epic/approve-next needs the URL query, so handle it here.
+      if (m === "POST" && path === "/api/epic/approve-next") {
+        const repo = url.searchParams.get("repo") ?? "";
+        const parent = Number(url.searchParams.get("parent") ?? "0");
+        const epic = demoState.approveEpicNext(repo, parent);
+        return epic ? json(epic) : new Response(null, { status: 404 });
+      }
+      const res = handleMutation(m, path, body);
+      if (res) return res;
+    }
 
-  // Task 3: state-backed handlers replace the permissive fallback below.
-
-  // Permissive fallback: unmatched read → benign empty object; unmatched mutation
-  // → a generic success. Keeps the demo UI from erroring on off-screen endpoints.
-  if (m === "GET") return json({});
-  return json({ ok: true });
+    // Permissive fallback for off-screen endpoints: unmatched read → benign empty
+    // object; unmatched mutation → a generic success. Keeps the demo UI from
+    // erroring on endpoints no showcased screen touches.
+    if (m === "GET") return json({});
+    return json({ ok: true });
+  } catch {
+    // Never throw out of the transport — a malformed request degrades to a stub.
+    return json(method.toUpperCase() === "GET" ? {} : { ok: true });
+  }
 }

--- a/ui/src/lib/demo/router.ts
+++ b/ui/src/lib/demo/router.ts
@@ -34,6 +34,10 @@ function handleGet(path: string, url: URL): Response | null {
     // ── bootstrap ──────────────────────────────────────────────────────────
     case "/api/sessions":
       return json(demoState.sessions());
+    // Admin "clear merged": the demo has no merged-branch sessions to clear, so the
+    // clearable set is empty. Shape matches getMergedClearable() in api.ts exactly.
+    case "/api/sessions/clear-merged":
+      return json({ ids: [], leftovers: 0 });
     case "/api/held":
       return json(demoState.held());
     case "/api/usage/limits":
@@ -128,6 +132,11 @@ function handleGet(path: string, url: URL): Response | null {
 }
 
 function handleMutation(method: string, path: string, body: unknown): Response | null {
+  // POST /api/sessions/clear-merged — nothing merged to clear in the demo. Shape
+  // matches clearMerged() in api.ts. Handled before the /:id/<tail> patterns below.
+  if (method === "POST" && path === "/api/sessions/clear-merged") {
+    return json({ cleared: [], leftovers: 0 });
+  }
   // POST /api/sessions/:id/reply
   if (method === "POST" && /^\/api\/sessions\/[^/]+\/reply$/.test(path)) {
     demoState.reply(seg(path, 3), field<string>(body, "text") ?? "");

--- a/ui/src/lib/demo/seed.ts
+++ b/ui/src/lib/demo/seed.ts
@@ -904,10 +904,10 @@ function buildDiagnostics(): DiagnosticsSnapshot {
     generatedAt: NOW - HOUR,
     overall: "ok",
     checks: [
-      { id: "git", state: "ok", hintKey: "diag_git" },
-      { id: "gh", state: "ok", hintKey: "diag_gh" },
-      { id: "node", state: "ok", hintKey: "diag_node" },
-      { id: "bun", state: "ok", hintKey: "diag_bun" },
+      { id: "git", state: "ok", hintKey: "diagnostics_hint_git_ok" },
+      { id: "gh", state: "ok", hintKey: "diagnostics_hint_gh_ok" },
+      { id: "node", state: "ok", hintKey: "diagnostics_hint_node_ok" },
+      { id: "bun", state: "ok", hintKey: "diagnostics_hint_bun_ok" },
     ],
   };
 }
@@ -1091,7 +1091,10 @@ export function buildSeed(): DemoWorld {
     workingBlockedStates: {
       coupon: false,
       "checkout-child": false,
-      neon: true,
+      // neon is genuinely blocked (autopilot-paused on an unanswered question) — a
+      // `true` here would upgrade it to "running" in displayStatus() and hide it
+      // from the Blocked lens. No session in this scenario is a stale-resumed showcase.
+      neon: false,
     },
     holdStates: buildHolds(),
     subagentStates: buildSubagentStates(),

--- a/ui/src/lib/demo/seed.ts
+++ b/ui/src/lib/demo/seed.ts
@@ -1,0 +1,687 @@
+// Pure seed data for the demo world. `buildSeed()` returns a fresh, deep-cloneable
+// object graph — no timers, no bus, no imports from state/router/director. Every
+// record is typed against `$lib/types`, so `tsc` proves each shape matches what the
+// live UI consumes.
+//
+// Task 4: full scenario replaces/expands this seed. For now this is a MINIMAL but
+// internally-consistent scenario — 1 repo (`acme/storefront`), 1 epic ("Checkout
+// v2"), 3 sessions across running / planning / ready states — just enough that every
+// getter returns a non-empty, correctly-shaped value.
+
+import type {
+  Session,
+  GitState,
+  SessionActivity,
+  SubagentEntry,
+  HoldReason,
+  Epic,
+  CompletedEpic,
+  DrainStatus,
+  AutoMergeStatus,
+  BuildQueue,
+  Recap,
+  ReviewVerdict,
+  PlanGate,
+  HerdDigest,
+  UpNextSnapshot,
+  BacklogPayload,
+  Settings,
+  PluginInfo,
+  DiagnosticsSnapshot,
+  HeldTask,
+  Steer,
+  ProjectIcons,
+  Learning,
+  UsageLimitsResponse,
+  UpdateStatus,
+  HerdrUpdateStatus,
+  CodexUpdateStatus,
+  StarPromptStatus,
+} from "$lib/types";
+import type { DemoWorld } from "./types-world";
+
+const REPO = "/demo/acme/storefront";
+const EPIC_PARENT = 100;
+
+// A fixed clock anchor so the seed is deterministic (Task 6's director advances live
+// timestamps at runtime). Offsets below are relative to this.
+const NOW = Date.UTC(2026, 5, 30, 12, 0, 0);
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+
+/** Fill a full Session from a partial, defaulting every required field. */
+function mkSession(partial: Partial<Session> & Pick<Session, "id" | "desig" | "name">): Session {
+  return {
+    prompt: "",
+    repoPath: REPO,
+    baseBranch: "main",
+    branch: `shepherd/${partial.name}`,
+    worktreePath: `${REPO}/.worktrees/${partial.id}`,
+    isolated: true,
+    herdrSession: `herdr-${partial.id}`,
+    herdrAgentId: `agent-${partial.id}`,
+    claudeSessionId: `claude-${partial.id}`,
+    agentProvider: "claude",
+    model: "opus",
+    status: "running",
+    readyToMerge: false,
+    mergingSince: null,
+    mergingTrainId: null,
+    mergeTrainPrs: null,
+    autopilotEnabled: null,
+    autopilotStepCount: 0,
+    autopilotPaused: false,
+    autopilotComplete: false,
+    autopilotQuestion: null,
+    planGateEnabled: null,
+    planPhase: null,
+    autoMergeEnabled: null,
+    autoMergeRebaseCount: 0,
+    auto: false,
+    sandboxApplied: "standard",
+    sandboxDegraded: false,
+    research: false,
+    egressApplied: false,
+    egressDegraded: false,
+    issueNumber: null,
+    lastState: "running",
+    createdAt: NOW - 2 * HOUR,
+    updatedAt: NOW - 5 * MIN,
+    archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
+    experimentId: null,
+    experimentRole: null,
+    hasScratchpadFiles: false,
+    ...partial,
+  };
+}
+
+function buildSessions(): Session[] {
+  return [
+    mkSession({
+      id: "s1",
+      desig: "TASK-01",
+      name: "checkout-api",
+      prompt: "Implement the checkout payment-intent API endpoint",
+      status: "running",
+      autopilotEnabled: true,
+      autopilotStepCount: 3,
+      issueNumber: 101,
+      lastState: "working",
+      createdAt: NOW - 3 * HOUR,
+    }),
+    mkSession({
+      id: "s2",
+      desig: "TASK-02",
+      name: "checkout-ui",
+      prompt: "Build the checkout summary + confirm UI",
+      status: "blocked",
+      planGateEnabled: true,
+      planPhase: "planning",
+      issueNumber: 102,
+      lastState: "blocked",
+      createdAt: NOW - 90 * MIN,
+    }),
+    mkSession({
+      id: "s3",
+      desig: "TASK-03",
+      name: "checkout-tests",
+      prompt: "Add end-to-end checkout tests",
+      status: "idle",
+      readyToMerge: true,
+      issueNumber: 103,
+      lastState: "idle",
+      createdAt: NOW - 4 * HOUR,
+      updatedAt: NOW - 20 * MIN,
+    }),
+  ];
+}
+
+function buildGitStates(): Record<string, GitState> {
+  return {
+    s1: {
+      kind: "github",
+      state: "none",
+      checks: "none",
+      deployConfigured: false,
+    },
+    s3: {
+      kind: "github",
+      state: "open",
+      number: 412,
+      url: "https://github.com/acme/storefront/pull/412",
+      title: "TASK-03: add end-to-end checkout tests",
+      createdAt: NOW - 40 * MIN,
+      mergeable: true,
+      checks: "success",
+      mergeStateStatus: "clean",
+      deployConfigured: true,
+      headSha: "9f3a1c7",
+      issueUrl: "https://github.com/acme/storefront/issues/103",
+    },
+  };
+}
+
+function buildActivityStates(): Record<string, SessionActivity> {
+  return {
+    s1: {
+      lastActivityTs: NOW - 30_000,
+      summary: "edited payment-intent.ts",
+      recentTs: [NOW - 5 * MIN, NOW - 3 * MIN, NOW - 90_000, NOW - 30_000],
+      recentErrTs: [NOW - 3 * MIN],
+    },
+    s3: {
+      lastActivityTs: NOW - 20 * MIN,
+      summary: "$ bun test",
+      recentTs: [NOW - 25 * MIN, NOW - 20 * MIN],
+      recentErrTs: [],
+    },
+  };
+}
+
+function buildSubagentStates(): Record<string, SubagentEntry[]> {
+  return {
+    s1: [
+      {
+        agentId: "sub-s1-explore",
+        agentType: "Explore",
+        startedAt: NOW - 8 * MIN,
+        endedAt: NOW - 6 * MIN,
+      },
+      { agentId: "sub-s1-impl", agentType: "general-purpose", startedAt: NOW - 4 * MIN },
+    ],
+  };
+}
+
+function buildUsage(): UsageLimitsResponse {
+  return {
+    limits: {
+      session5h: { pct: 42, resetAt: NOW + 2 * HOUR },
+      week: { pct: 61, resetAt: NOW + 3 * 24 * HOUR },
+      credits: null,
+      stale: false,
+      calibratedAt: NOW - 10 * MIN,
+      subscriptionOnly: false,
+    },
+    projections: [
+      { window: "5H", projectedPct: 58, resetAt: NOW + 2 * HOUR, burnRatePerHour: 12 },
+      { window: "WK", projectedPct: 74, resetAt: NOW + 3 * 24 * HOUR, burnRatePerHour: 40 },
+    ],
+  };
+}
+
+function buildEpics(): Epic[] {
+  return [
+    {
+      repoPath: REPO,
+      parentIssueNumber: EPIC_PARENT,
+      parentTitle: "Checkout v2",
+      source: "native",
+      warnings: [],
+      run: { repoPath: REPO, parentIssueNumber: EPIC_PARENT, mode: "attended", status: "running" },
+      children: [
+        {
+          number: 101,
+          title: "Payment-intent API",
+          url: "https://github.com/acme/storefront/issues/101",
+          order: 0,
+          body: "Expose POST /api/checkout/intent.",
+          blockedBy: [],
+          state: "running",
+          sessionId: "s1",
+          prNumber: null,
+          issueClosed: false,
+          claimed: true,
+        },
+        {
+          number: 102,
+          title: "Checkout summary UI",
+          url: "https://github.com/acme/storefront/issues/102",
+          order: 1,
+          body: "Render the summary + confirm screen.",
+          blockedBy: [101],
+          state: "blocked",
+          sessionId: "s2",
+          prNumber: null,
+          issueClosed: false,
+          claimed: true,
+        },
+        {
+          number: 103,
+          title: "Checkout e2e tests",
+          url: "https://github.com/acme/storefront/issues/103",
+          order: 2,
+          body: "Playwright coverage for the happy path.",
+          blockedBy: [101],
+          state: "in-review",
+          sessionId: "s3",
+          prNumber: 412,
+          issueClosed: false,
+          claimed: true,
+        },
+      ],
+    },
+  ];
+}
+
+function buildCompletedEpics(): CompletedEpic[] {
+  return [
+    {
+      repoPath: REPO,
+      parentIssueNumber: 88,
+      parentTitle: "Cart refactor",
+      completedAt: NOW - 2 * 24 * HOUR,
+      children: [
+        {
+          number: 81,
+          title: "Cart store rewrite",
+          url: "https://github.com/acme/storefront/issues/81",
+          prNumber: 390,
+          prUrl: "https://github.com/acme/storefront/pull/390",
+          mergedAt: NOW - 2 * 24 * HOUR,
+          integrated: true,
+        },
+      ],
+      landingPrNumber: 395,
+      landingPrUrl: "https://github.com/acme/storefront/pull/395",
+      landingState: "merged",
+      migrationPaths: [],
+      migrationsAckedAt: null,
+    },
+  ];
+}
+
+function buildRecaps(): Record<string, Recap> {
+  return {
+    s3: {
+      sessionId: "s3",
+      state: "ready",
+      headSha: "9f3a1c7",
+      verdict: "ready",
+      headline: "End-to-end checkout tests added",
+      body: "Added Playwright coverage for the checkout happy path and a failing-card branch.",
+      openItems: [],
+      changedFiles: ["tests/checkout.spec.ts", "playwright.config.ts"],
+      spawnSessionId: "recap-s3",
+      cwd: `${REPO}/.worktrees/s3`,
+      model: "opus",
+      spawnedAt: NOW - 22 * MIN,
+      generatedAt: NOW - 20 * MIN,
+      updatedAt: NOW - 20 * MIN,
+    },
+  };
+}
+
+function buildReviews(): Record<string, ReviewVerdict> {
+  return {
+    s3: {
+      sessionId: "s3",
+      headSha: "9f3a1c7",
+      decision: "commented",
+      summary: "Solid coverage; one flaky selector to tighten.",
+      body: "The happy-path spec is clear. Consider a data-testid on the confirm button.",
+      findings: ["Use a stable data-testid for the confirm button"],
+      addressRound: 0,
+      addressCap: 3,
+      finalRoundPending: false,
+      finalRoundTimeoutMs: 120_000,
+      url: "https://github.com/acme/storefront/pull/412#review",
+      updatedAt: NOW - 18 * MIN,
+    },
+  };
+}
+
+function buildPlanGates(): Record<string, PlanGate> {
+  return {
+    s2: {
+      sessionId: "s2",
+      planHash: "plan-s2-hash-1",
+      decision: "approved",
+      summary: "Plan approved: build summary then confirm step.",
+      body: "The two-step plan is sound. Wire the confirm CTA to the intent API from TASK-01.",
+      findings: [],
+      round: 1,
+      cap: 3,
+      approved: true,
+      plan: "1. Render order summary\n2. Add confirm CTA\n3. Call payment-intent API",
+      updatedAt: NOW - 12 * MIN,
+    },
+  };
+}
+
+function buildHerdDigest(): HerdDigest {
+  return {
+    dayKey: "2026-06-30",
+    state: "ready",
+    overnight: "Cart refactor epic landed; checkout v2 is mid-flight across three tasks.",
+    decisions: [{ label: "Approved the checkout-ui plan gate", sessionId: "s2" }],
+    ciRework: [],
+    train: "No merge train running.",
+    focusNext: [{ label: "Review TASK-03 checkout tests PR", sessionId: "s3", pr: 412 }],
+    epicsToLand: [],
+    attentionFingerprint: { s2: ["plan-approved"] },
+    spawnSessionId: "digest-1",
+    cwd: REPO,
+    model: "opus",
+    spawnedAt: NOW - 6 * HOUR,
+    generatedAt: NOW - 6 * HOUR,
+    updatedAt: NOW - 6 * HOUR,
+  };
+}
+
+function buildUpNext(): UpNextSnapshot {
+  return {
+    generatedAt: NOW - 15 * MIN,
+    repoCount: 1,
+    fallback: null,
+    failedRepoCount: 0,
+    sections: [
+      {
+        kind: "repo",
+        repoPath: REPO,
+        repoSlug: "acme/storefront",
+        repoLabel: "acme/storefront",
+        totalCount: 1,
+        items: [
+          {
+            repoPath: REPO,
+            repoSlug: "acme/storefront",
+            repoLabel: "acme/storefront",
+            number: 120,
+            title: "Add saved-payment-methods selector",
+            url: "https://github.com/acme/storefront/issues/120",
+            kind: "feature",
+            priority: false,
+            createdAt: NOW - 26 * HOUR,
+            issueRef: {
+              number: 120,
+              url: "https://github.com/acme/storefront/issues/120",
+              title: "Add saved-payment-methods selector",
+              body: "Let returning customers pick a stored card at checkout.",
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function buildBacklog(): BacklogPayload {
+  return {
+    pinnedPath: REPO,
+    totals: { openIssues: 6, openPRs: 1 },
+    projects: [
+      {
+        path: REPO,
+        display: "acme/storefront",
+        slug: "acme/storefront",
+        kind: "github",
+        lastUsedAt: NOW - 5 * MIN,
+        recentAgentCount: 3,
+        openIssues: 6,
+        openPRs: 1,
+        prKinds: { release: 0, dependabot: 0, regular: 1 },
+        workflows: 2,
+        ciStatus: "success",
+        hidden: false,
+      },
+    ],
+  };
+}
+
+function buildBuildQueues(): Record<string, BuildQueue> {
+  return {
+    s1: {
+      sessionId: "s1",
+      approved: true,
+      approvalKind: "auto",
+      steps: [
+        { id: "step-1", title: "Draft payment-intent route", status: "done", position: 0 },
+        { id: "step-2", title: "Wire Stripe client", status: "active", position: 1 },
+        { id: "step-3", title: "Add unit tests", status: "pending", position: 2 },
+      ],
+    },
+  };
+}
+
+function buildHeld(): HeldTask[] {
+  return [
+    {
+      id: "held-1",
+      repoPath: REPO,
+      createdAt: NOW - 35 * MIN,
+      input: {
+        repoPath: REPO,
+        baseBranch: "main",
+        prompt: "Add refund flow to the checkout admin panel",
+        model: "opus",
+      },
+    },
+  ];
+}
+
+function buildSettings(): Settings {
+  return {
+    repoRoot: "/demo",
+    repoRootDisplay: "~/demo",
+    remoteControlAtStartup: false,
+    sessionHousekeepingEnabled: true,
+    defaultModel: "auto",
+    criticCli: "inherit",
+    criticModel: "default",
+    plannerCli: "inherit",
+    plannerModel: "default",
+    recapCli: "inherit",
+    recapModel: "default",
+    docAgentCli: "inherit",
+    docAgentModel: "default",
+    namerCli: "inherit",
+    namerModel: "default",
+    autopilotCli: "inherit",
+    autopilotModel: "default",
+    defaultAgentProvider: "claude",
+    authMode: "subscription",
+    hasApiKey: false,
+    prReviewCyclesCap: 3,
+    prReviewCyclesMin: 1,
+    prReviewCyclesMax: 6,
+    planReviewCyclesCap: 3,
+    planReviewCyclesMin: 1,
+    planReviewCyclesMax: 6,
+    extraCreditsDrainCeiling: 0,
+    sessionRetentionDays: 14,
+    sessionRetentionKeep: 50,
+    previewHost: null,
+    usageHoldEnabled: true,
+    usageHoldPct: 90,
+    usageHoldAutoRelease: true,
+    usageDowngradeEnabled: false,
+    usageDowngradePct: 80,
+    usageDowngradeModel: "auto",
+    fableAvailable: true,
+    tuiFullscreen: false,
+    tuiDisableMouse: false,
+    reducedPushMode: false,
+    docAgentEnabled: false,
+    docAgentAct: false,
+  };
+}
+
+function buildPlugins(): PluginInfo[] {
+  return [
+    {
+      id: "demo-linear",
+      name: "Linear sync",
+      version: "1.2.0",
+      health: "ok",
+      lastError: null,
+      status: {},
+      ui: null,
+      gearItem: null,
+    },
+  ];
+}
+
+function buildDiagnostics(): DiagnosticsSnapshot {
+  return {
+    generatedAt: NOW - HOUR,
+    overall: "ok",
+    checks: [
+      { id: "git", state: "ok", hintKey: "diag_git" },
+      { id: "gh", state: "ok", hintKey: "diag_gh" },
+      { id: "node", state: "ok", hintKey: "diag_node" },
+    ],
+  };
+}
+
+function buildSteers(): Steer[] {
+  return [
+    {
+      id: "steer-continue",
+      label: "Continue",
+      text: "Continue with the plan.",
+      emoji: "▶️",
+      inSteerBar: true,
+      onIssues: false,
+    },
+    {
+      id: "steer-tests",
+      label: "Run tests",
+      text: "Run the test suite and fix any failures.",
+      emoji: "🧪",
+      inSteerBar: true,
+      onIssues: false,
+    },
+  ];
+}
+
+function buildProjectIcons(): ProjectIcons {
+  return { [REPO]: "🛒" };
+}
+
+function buildDrain(): DrainStatus[] {
+  return [
+    {
+      repoPath: REPO,
+      enabled: true,
+      paused: false,
+      reason: null,
+      detail: null,
+      queued: 4,
+      inFlight: 1,
+      max: 3,
+      epicParent: EPIC_PARENT,
+    },
+  ];
+}
+
+function buildAutoMerge(): AutoMergeStatus[] {
+  return [{ repoPath: REPO, enabled: true, state: null, detail: null, sessionId: null }];
+}
+
+function buildPendingLearnings(): Learning[] {
+  return [
+    {
+      id: "learn-1",
+      repoPath: REPO,
+      rule: "Always add a data-testid to interactive checkout elements.",
+      rationale: "Tests kept flaking on text-based selectors.",
+      evidence: ["s3 review flagged a fragile selector"],
+      status: "proposed",
+      evidenceCount: 2,
+      ineffectiveCount: 0,
+      helpfulCount: 0,
+      injectedCount: 0,
+      lastUsedAt: null,
+      retiredAt: null,
+      retiredReason: null,
+      scopeGlobs: [],
+      createdAt: NOW - 30 * MIN,
+      updatedAt: NOW - 30 * MIN,
+      lastEvidenceAt: NOW - 30 * MIN,
+      promotedPrUrl: null,
+    },
+  ];
+}
+
+function buildUpdate(): UpdateStatus {
+  return {
+    behind: 0,
+    current: "v0.42.0",
+    latest: "v0.42.0",
+    commits: [],
+    checkedAt: NOW - 30 * MIN,
+  };
+}
+
+function buildHerdrUpdate(): HerdrUpdateStatus {
+  return {
+    current: "0.9.3",
+    latest: "0.9.3",
+    updateAvailable: false,
+    notes: null,
+    checkedAt: NOW - 30 * MIN,
+  };
+}
+
+function buildCodexUpdate(): CodexUpdateStatus {
+  return {
+    current: "0.30.0",
+    latest: "0.30.0",
+    updateAvailable: false,
+    notes: null,
+    checkedAt: NOW - 30 * MIN,
+  };
+}
+
+function buildStarPrompt(): StarPromptStatus {
+  return { shouldPrompt: false, starred: true };
+}
+
+function buildHolds(): Record<string, HoldReason> {
+  return {
+    s2: { code: "blocked-awaiting-input" },
+  };
+}
+
+/** Build a fresh, internally-consistent demo world. Pure — no shared references. */
+export function buildSeed(): DemoWorld {
+  return {
+    sessions: buildSessions(),
+    gitStates: buildGitStates(),
+    activityStates: buildActivityStates(),
+    claudeAliveStates: { s1: true, s2: true, s3: true },
+    workingBlockedStates: { s1: false, s2: false },
+    holdStates: buildHolds(),
+    subagentStates: buildSubagentStates(),
+    previewStates: { s1: { previewPort: 4173, serve: "ok" } },
+
+    usage: buildUsage(),
+    update: buildUpdate(),
+    herdrUpdate: buildHerdrUpdate(),
+    codexUpdate: buildCodexUpdate(),
+    starPrompt: buildStarPrompt(),
+    drain: buildDrain(),
+    autoMerge: buildAutoMerge(),
+
+    completedEpics: buildCompletedEpics(),
+    epics: buildEpics(),
+    settings: buildSettings(),
+    plugins: buildPlugins(),
+    diagnostics: buildDiagnostics(),
+    backlog: buildBacklog(),
+    buildQueues: buildBuildQueues(),
+    held: buildHeld(),
+    recaps: buildRecaps(),
+    reviews: buildReviews(),
+    planGates: buildPlanGates(),
+    herdDigest: buildHerdDigest(),
+    upNext: buildUpNext(),
+    steers: buildSteers(),
+    projectIcons: buildProjectIcons(),
+    pendingLearnings: buildPendingLearnings(),
+  };
+}

--- a/ui/src/lib/demo/seed.ts
+++ b/ui/src/lib/demo/seed.ts
@@ -47,8 +47,14 @@ import type {
   HerdrUpdateStatus,
   CodexUpdateStatus,
   StarPromptStatus,
+  ActivityEntry,
+  DiffResult,
+  ScratchListing,
+  SessionUsage,
+  SlashCommand,
+  PostMergeSteps,
 } from "$lib/types";
-import type { DemoWorld } from "./types-world";
+import type { DemoWorld, DemoRepoConfig } from "./types-world";
 
 const STOREFRONT = "/demo/acme/storefront";
 const API = "/demo/acme/api";
@@ -253,6 +259,75 @@ function buildSessions(): Session[] {
 }
 
 const gh = (repo: string) => repo.replace("/demo/", "https://github.com/");
+
+// ── Done lens (#Task 8): sessions ARCHIVED before this boot, distinct from the live
+// `sessions` list above. `deps` (TASK-37) is deliberately NOT duplicated here — it's
+// still live (done + one owed manual step), not yet archived, so it belongs only in
+// the main herd / Owed lens. These three are already-closed-out work so the Done lens
+// (and its recap-per-row) has real, varied content the moment it's opened.
+function buildDoneSessions(): Session[] {
+  return [
+    mkSession({
+      id: "navpills",
+      desig: "TASK-33",
+      name: "nav-active-pills",
+      repoPath: STOREFRONT,
+      branch: "shepherd/nav-active-pills",
+      prompt: "Add active-state pills to the category navigation",
+      model: "sonnet",
+      status: "archived",
+      lastState: "archived",
+      readyToMerge: true,
+      issueNumber: 130,
+      issueUrl: `${gh(STOREFRONT)}/issues/130`,
+      createdAt: NOW - 9 * HOUR,
+      updatedAt: NOW - 5 * HOUR,
+      archivedAt: NOW - 5 * HOUR,
+    }),
+    mkSession({
+      id: "ratelimit",
+      desig: "TASK-28",
+      name: "api-rate-limit",
+      repoPath: API,
+      branch: "shepherd/api-rate-limit",
+      prompt: "Add per-IP rate limiting to the public API",
+      model: "opus",
+      status: "archived",
+      lastState: "archived",
+      readyToMerge: true,
+      issueNumber: 210,
+      issueUrl: `${gh(API)}/issues/210`,
+      createdAt: NOW - 26 * HOUR,
+      updatedAt: NOW - 20 * HOUR,
+      archivedAt: NOW - 20 * HOUR,
+      manualSteps: [
+        {
+          id: "ratelimit-ms-1",
+          text: "Document the new 429 response shape in the API README",
+          postMerge: true,
+        },
+      ],
+      manualStepsAckedAt: NOW - 19 * HOUR,
+    }),
+    mkSession({
+      id: "imgopt",
+      desig: "TASK-30",
+      name: "responsive-product-images",
+      repoPath: STOREFRONT,
+      branch: "shepherd/responsive-product-images",
+      prompt: "Serve responsive srcset images on product cards",
+      model: "sonnet",
+      status: "archived",
+      lastState: "archived",
+      readyToMerge: true,
+      issueNumber: 132,
+      issueUrl: `${gh(STOREFRONT)}/issues/132`,
+      createdAt: NOW - 33 * HOUR,
+      updatedAt: NOW - 30 * HOUR,
+      archivedAt: NOW - 30 * HOUR,
+    }),
+  ];
+}
 
 function buildGitStates(): Record<string, GitState> {
   return {
@@ -576,6 +651,55 @@ function buildRecaps(): Record<string, Recap> {
       spawnedAt: NOW - 47 * MIN,
       generatedAt: NOW - 45 * MIN,
       updatedAt: NOW - 45 * MIN,
+    },
+    // ── Done lens recaps — one per archived session in buildDoneSessions() ────────
+    navpills: {
+      sessionId: "navpills",
+      state: "ready",
+      headSha: "f1a2b3c",
+      verdict: "ready",
+      headline: "Category nav now shows an active-state pill",
+      body: "Added a pill indicator that tracks the selected category via the route's active link state, with a subtle slide transition between categories. Covered by a component test for keyboard nav.",
+      openItems: [],
+      changedFiles: ["src/routes/(shop)/categories/CategoryNav.svelte", "src/lib/nav/active.ts"],
+      spawnSessionId: "recap-navpills",
+      cwd: `${STOREFRONT}/.worktrees/navpills`,
+      model: "sonnet",
+      spawnedAt: NOW - 5.5 * HOUR,
+      generatedAt: NOW - 5 * HOUR,
+      updatedAt: NOW - 5 * HOUR,
+    },
+    ratelimit: {
+      sessionId: "ratelimit",
+      state: "ready",
+      headSha: "a4b5c6d",
+      verdict: "needs_attention",
+      headline: "Per-IP rate limiting shipped; docs still owed",
+      body: "Added a token-bucket limiter in front of the public API routes (60 req/min per IP, 429 on trip) backed by the existing Redis instance. The new 429 response shape still needs a README callout for API consumers.",
+      openItems: ["Document the new 429 response shape in the API README (post-merge)"],
+      changedFiles: ["src/middleware/rateLimit.ts", "src/routes/api/index.ts"],
+      spawnSessionId: "recap-ratelimit",
+      cwd: `${API}/.worktrees/ratelimit`,
+      model: "opus",
+      spawnedAt: NOW - 20.5 * HOUR,
+      generatedAt: NOW - 20 * HOUR,
+      updatedAt: NOW - 20 * HOUR,
+    },
+    imgopt: {
+      sessionId: "imgopt",
+      state: "ready",
+      headSha: "b7c8d9e",
+      verdict: "ready",
+      headline: "Product images now serve responsive srcset variants",
+      body: "Product-card and PDP images now request a device-appropriate size via `srcset` + `sizes`, generated at build time from the existing asset pipeline. Verified against Lighthouse's LCP image-size audit.",
+      openItems: [],
+      changedFiles: ["src/lib/components/ProductImage.svelte", "src/lib/images/srcset.ts"],
+      spawnSessionId: "recap-imgopt",
+      cwd: `${STOREFRONT}/.worktrees/imgopt`,
+      model: "sonnet",
+      spawnedAt: NOW - 30.5 * HOUR,
+      generatedAt: NOW - 30 * HOUR,
+      updatedAt: NOW - 30 * HOUR,
     },
   };
 }
@@ -1073,10 +1197,304 @@ function buildHolds(): Record<string, HoldReason> {
   };
 }
 
+// ── session-detail tabs (Task 8 sibling audit) ────────────────────────────────────
+// Every GET a Viewport tab fires on open — Activity, Diff, Files, plus the always-on
+// usage badge / build-queue panel / slash-command linkifier. Richly seeded for the
+// hero (`coupon`) and its epic sibling (`checkout-child`); every OTHER live session
+// still gets a valid (if empty) response so no tab can throw on a shape mismatch.
+
+/** GET /api/sessions/:id/activity — only sessions actually doing visible work carry a
+ *  transcript; a session with no seeded entry falls back to `[]` in state.ts (never `{}`). */
+function buildActivityEntries(): Record<string, ActivityEntry[]> {
+  return {
+    coupon: [
+      {
+        ts: NOW - 6 * MIN,
+        tool: "Read",
+        summary: "src/routes/checkout/+page.svelte",
+        status: "ok",
+      },
+      {
+        ts: NOW - 5 * MIN,
+        tool: "Edit",
+        summary: "src/routes/checkout/CouponField.svelte",
+        status: "ok",
+      },
+      { ts: NOW - 4 * MIN, tool: "Bash", summary: "bun run check", status: "error" },
+      { ts: NOW - 3 * MIN, tool: "Edit", summary: "src/lib/cart/pricing.ts", status: "ok" },
+      { ts: NOW - 2 * MIN, tool: "Bash", summary: "bun test src/lib/cart", status: "ok" },
+      {
+        ts: NOW - 50 * SEC,
+        tool: "Edit",
+        summary: "src/routes/checkout/CouponField.svelte",
+        status: "ok",
+      },
+      { ts: NOW - 20 * SEC, tool: "Read", summary: "src/lib/cart/pricing.ts", status: "ok" },
+    ],
+    "checkout-child": [
+      { ts: NOW - 6 * MIN, tool: "Read", summary: "src/lib/cart/totals.ts", status: "ok" },
+      {
+        ts: NOW - 90 * SEC,
+        tool: "Edit",
+        summary: "src/routes/checkout/ShippingEstimate.svelte",
+        status: "ok",
+      },
+      { ts: NOW - 40 * SEC, tool: "Bash", summary: "bun run check", status: "ok" },
+    ],
+  };
+}
+
+/** GET /api/sessions/:id/diff — coupon's growing diff (hero, no PR yet) + a small one for
+ *  its epic-child sibling. A session with no seeded entry falls back to a valid empty
+ *  DiffResult in state.ts (base/head filled from the session, `files: []` — never `{}`). */
+function buildDiffs(): Record<string, DiffResult> {
+  return {
+    coupon: {
+      base: "main",
+      baseRef: "origin/main",
+      head: "shepherd/coupon-code-field",
+      fetchFailed: false,
+      truncated: false,
+      files: [
+        {
+          path: "src/routes/checkout/CouponField.svelte",
+          status: "added",
+          additions: 42,
+          deletions: 0,
+          binary: false,
+          hunks: [
+            {
+              header: "@@ -0,0 +1,12 @@",
+              lines: [
+                { kind: "add", content: '<script lang="ts">', newNo: 1 },
+                {
+                  kind: "add",
+                  content: "  let { onapply }: { onapply: (code: string) => void } = $props();",
+                  newNo: 2,
+                },
+                { kind: "add", content: '  let code = $state("");', newNo: 3 },
+                { kind: "add", content: "</script>", newNo: 4 },
+              ],
+            },
+          ],
+        },
+        {
+          path: "src/lib/cart/pricing.ts",
+          status: "modified",
+          additions: 18,
+          deletions: 4,
+          binary: false,
+          hunks: [
+            {
+              header: "@@ -20,8 +20,22 @@ export function computeTotal(",
+              lines: [
+                { kind: "ctx", content: "  let total = subtotal;", oldNo: 20, newNo: 20 },
+                { kind: "del", content: "  return total;", oldNo: 21 },
+                {
+                  kind: "add",
+                  content: "  if (coupon) total = applyCoupon(total, coupon);",
+                  newNo: 21,
+                },
+                { kind: "add", content: "  return total;", newNo: 22 },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    "checkout-child": {
+      base: "main",
+      baseRef: "origin/main",
+      head: "shepherd/shipping-estimator",
+      fetchFailed: false,
+      truncated: false,
+      files: [
+        {
+          path: "src/routes/checkout/ShippingEstimate.svelte",
+          status: "added",
+          additions: 26,
+          deletions: 0,
+          binary: false,
+          hunks: [
+            {
+              header: "@@ -0,0 +1,8 @@",
+              lines: [
+                { kind: "add", content: '<script lang="ts">', newNo: 1 },
+                {
+                  kind: "add",
+                  content: "  let { weightKg }: { weightKg: number } = $props();",
+                  newNo: 2,
+                },
+                { kind: "add", content: "</script>", newNo: 3 },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+/** GET /api/sessions/:id/scratchpad (root listing) — only sessions with
+ *  `hasScratchpadFiles: true` carry seeded entries; everyone else gets the same synthetic
+ *  empty listing the real server returns for a session with no scratchpad root yet. */
+function buildScratchpad(): Record<string, ScratchListing> {
+  return {
+    coupon: {
+      path: "",
+      parent: null,
+      entries: [
+        { name: "notes.md", type: "file", path: "notes.md" },
+        { name: "pricing-api-response.json", type: "file", path: "pricing-api-response.json" },
+      ],
+    },
+    "checkout-child": {
+      path: "",
+      parent: null,
+      entries: [{ name: "shipping-rates.json", type: "file", path: "shipping-rates.json" }],
+    },
+  };
+}
+
+/** GET /api/sessions/:id/usage — per-session token usage badge (polled while a session is
+ *  open). Only the hero has meaningfully large numbers; everyone else is a valid zeroed
+ *  record (`usage.total > 0` gates the badge, so a zero record renders nothing — safe, not empty-object). */
+function buildSessionUsage(): Record<string, SessionUsage> {
+  const zero: SessionUsage = {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    total: 0,
+    messageCount: 0,
+    lastActivity: null,
+    byModel: {},
+  };
+  return {
+    coupon: {
+      input: 42_000,
+      output: 8_900,
+      cacheRead: 120_000,
+      cacheWrite: 15_000,
+      total: 185_900,
+      messageCount: 34,
+      lastActivity: NOW - 20 * SEC,
+      byModel: { opus: 185_900 },
+    },
+    "checkout-child": {
+      input: 9_500,
+      output: 2_100,
+      cacheRead: 30_000,
+      cacheWrite: 4_000,
+      total: 45_600,
+      messageCount: 11,
+      lastActivity: NOW - 40 * SEC,
+      byModel: { opus: 45_600 },
+    },
+    rounding: { ...zero },
+    authstore: { ...zero },
+    neon: { ...zero },
+    ogimg: { ...zero },
+    deps: { ...zero },
+  };
+}
+
+/** GET /api/repo-config?repo= — automation flags per repo (gates the Build Queue panel +
+ *  the GitRail automation pill). Both demo repos have automation configured + confirmed. */
+function buildRepoConfig(): Record<string, DemoRepoConfig> {
+  const base: DemoRepoConfig = {
+    criticEnabled: true,
+    criticAllPrs: false,
+    autoAddressEnabled: false,
+    learningsEnabled: true,
+    autopilotEnabled: false,
+    autoDrainEnabled: true,
+    autoMergeEnabled: false,
+    buildQueueEnabled: true,
+    planGateEnabled: false,
+    draftMode: false,
+    signoffAuthority: "human",
+    sandboxProfile: "trusted",
+    defaultModel: "inherit",
+    maxAuto: 1,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+    repoMode: "forge",
+    autoOptimizeFlagged: false,
+    manualStepsIssueEnabled: false,
+    hidden: false,
+    automationConfirmed: true,
+    automationRowExists: true,
+  };
+  return {
+    [STOREFRONT]: { ...base, autoMergeEnabled: true, maxAuto: 3 },
+    [API]: { ...base, autopilotEnabled: true, planGateEnabled: true, maxAuto: 2 },
+  };
+}
+
+/** GET /api/commands?repo= — installed slash commands (terminal link provider). Same
+ *  small, plausible set for both demo repos. */
+function buildSlashCommands(): Record<string, SlashCommand[]> {
+  const commands: SlashCommand[] = [
+    { name: "test", description: "Run the test suite", scope: "project" },
+    { name: "lint", description: "Run lint + typecheck", scope: "project" },
+  ];
+  return { [STOREFRONT]: commands, [API]: commands };
+}
+
+/** GET /api/todo?repo= — neither demo repo has a TODO.md, so the To-Do tab stays hidden;
+ *  a real `{exists:false}` beats the permissive `{}` fallback (whose `.exists` is `undefined`,
+ *  not `false`, and would leave the tab's visibility effect stuck unresolved). */
+function buildTodo(): Record<string, { exists: boolean; content: string }> {
+  return {
+    [STOREFRONT]: { exists: false, content: "" },
+    [API]: { exists: false, content: "" },
+  };
+}
+
+/** GET /api/manual-steps/outstanding (Owed lens) — durable post-merge step records.
+ *  One row: `deps`'s single owed step (mirrors its `holdStates` entry + `manualSteps`
+ *  above). Svelte's `{#each}` silently no-ops on the permissive `{}` fallback
+ *  (`Array.from({})` → `[]`), so this gap never threw — it just left a showcased lens
+ *  silently empty instead of showing the one owed step the seed already promises. */
+function buildPostMergeSteps(): PostMergeSteps[] {
+  return [
+    {
+      sessionId: "deps",
+      desig: "TASK-37",
+      repoPath: STOREFRONT,
+      prNumber: 505,
+      prTitle: "TASK-37: bump dependencies + fix lint",
+      steps: [
+        {
+          id: "deps-ms-1",
+          text: "Rotate the CI dependency-cache key so the runners pick up the new lockfile",
+          postMerge: true,
+          doneAt: null,
+        },
+      ],
+      trackingIssueUrl: null,
+      trackingIssueNumber: null,
+      createdAt: NOW - 45 * MIN,
+      updatedAt: NOW - 45 * MIN,
+      clearedAt: null,
+    },
+  ];
+}
+
 /** Build a fresh, internally-consistent demo world. Pure — no shared references. */
 export function buildSeed(): DemoWorld {
   return {
     sessions: buildSessions(),
+    doneSessions: buildDoneSessions(),
+    activityEntries: buildActivityEntries(),
+    diffs: buildDiffs(),
+    scratchpad: buildScratchpad(),
+    sessionUsage: buildSessionUsage(),
+    repoConfig: buildRepoConfig(),
+    slashCommands: buildSlashCommands(),
+    todo: buildTodo(),
+    postMergeSteps: buildPostMergeSteps(),
     gitStates: buildGitStates(),
     activityStates: buildActivityStates(),
     claudeAliveStates: {

--- a/ui/src/lib/demo/seed.ts
+++ b/ui/src/lib/demo/seed.ts
@@ -3,10 +3,19 @@
 // record is typed against `$lib/types`, so `tsc` proves each shape matches what the
 // live UI consumes.
 //
-// Task 4: full scenario replaces/expands this seed. For now this is a MINIMAL but
-// internally-consistent scenario — 1 repo (`acme/storefront`), 1 epic ("Checkout
-// v2"), 3 sessions across running / planning / ready states — just enough that every
-// getter returns a non-empty, correctly-shaped value.
+// The scenario — the fictional herd the marketing demo shows off:
+//   Two repos: `acme/storefront` (SvelteKit storefront) + `acme/api` (bun API).
+//   One active epic "Checkout v2" on storefront, mid-drain.
+//   Seven sessions spanning states so every lens / badge / panel has a real subject:
+//     coupon         WORKING (hero)   live activity, subagents, growing diff, no PR yet
+//     rounding       READY            PR open, CI green, ready-to-merge
+//     authstore      PLAN GATE        plan-gate verdict awaiting the operator's Go
+//     neon           BLOCKED          autopilot question awaiting an answer
+//     ogimg          MERGING          in the merge train
+//     deps           DONE             recap + merged PR + one owed manual step
+//     checkout-child WORKING (auto)   epic child, drain-spawned
+// Session ids are STABLE + semantic — replay transcripts (Task 5) and the director
+// (Task 6) key off them.
 
 import type {
   Session,
@@ -24,6 +33,7 @@ import type {
   PlanGate,
   HerdDigest,
   UpNextSnapshot,
+  UpNextItem,
   BacklogPayload,
   Settings,
   PluginInfo,
@@ -40,23 +50,27 @@ import type {
 } from "$lib/types";
 import type { DemoWorld } from "./types-world";
 
-const REPO = "/demo/acme/storefront";
+const STOREFRONT = "/demo/acme/storefront";
+const API = "/demo/acme/api";
 const EPIC_PARENT = 100;
 
 // A fixed clock anchor so the seed is deterministic (Task 6's director advances live
-// timestamps at runtime). Offsets below are relative to this.
+// timestamps at runtime). Offsets below are relative to this — never `Date.now()`.
 const NOW = Date.UTC(2026, 5, 30, 12, 0, 0);
+const SEC = 1_000;
 const MIN = 60_000;
 const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
 
 /** Fill a full Session from a partial, defaulting every required field. */
-function mkSession(partial: Partial<Session> & Pick<Session, "id" | "desig" | "name">): Session {
+function mkSession(
+  partial: Partial<Session> & Pick<Session, "id" | "desig" | "name" | "repoPath">,
+): Session {
   return {
     prompt: "",
-    repoPath: REPO,
     baseBranch: "main",
     branch: `shepherd/${partial.name}`,
-    worktreePath: `${REPO}/.worktrees/${partial.id}`,
+    worktreePath: `${partial.repoPath}/.worktrees/${partial.id}`,
     isolated: true,
     herdrSession: `herdr-${partial.id}`,
     herdrAgentId: `agent-${partial.id}`,
@@ -99,84 +113,247 @@ function mkSession(partial: Partial<Session> & Pick<Session, "id" | "desig" | "n
   };
 }
 
+const NEON_QUESTION =
+  "The Neon branch starts empty — should I seed it from the current Postgres dump, or start clean and let migrations rebuild it?";
+
 function buildSessions(): Session[] {
   return [
+    // ── hero: live-working coupon field, growing diff, subagents, no PR yet ──
     mkSession({
-      id: "s1",
-      desig: "TASK-01",
-      name: "checkout-api",
-      prompt: "Implement the checkout payment-intent API endpoint",
+      id: "coupon",
+      desig: "TASK-41",
+      name: "coupon-code-field",
+      repoPath: STOREFRONT,
+      branch: "shepherd/coupon-code-field",
+      prompt: "Add a coupon-code field to the checkout summary and apply the discount",
+      model: "opus",
       status: "running",
-      autopilotEnabled: true,
-      autopilotStepCount: 3,
+      autopilotEnabled: null,
       issueNumber: 101,
       lastState: "working",
-      createdAt: NOW - 3 * HOUR,
+      createdAt: NOW - 55 * MIN,
+      updatedAt: NOW - 20 * SEC,
+      hasScratchpadFiles: true,
     }),
+    // ── ready: PR open, CI green, awaiting merge ────────────────────────────
     mkSession({
-      id: "s2",
-      desig: "TASK-02",
-      name: "checkout-ui",
-      prompt: "Build the checkout summary + confirm UI",
-      status: "blocked",
-      planGateEnabled: true,
-      planPhase: "planning",
-      issueNumber: 102,
-      lastState: "blocked",
-      createdAt: NOW - 90 * MIN,
-    }),
-    mkSession({
-      id: "s3",
-      desig: "TASK-03",
-      name: "checkout-tests",
-      prompt: "Add end-to-end checkout tests",
+      id: "rounding",
+      desig: "TASK-38",
+      name: "fix-cart-rounding",
+      repoPath: STOREFRONT,
+      branch: "shepherd/fix-cart-rounding",
+      prompt: "Fix the cart-total rounding bug that drops a cent on 3-for-2 offers",
+      model: "sonnet",
       status: "idle",
       readyToMerge: true,
       issueNumber: 103,
       lastState: "idle",
-      createdAt: NOW - 4 * HOUR,
-      updatedAt: NOW - 20 * MIN,
+      createdAt: NOW - 3 * HOUR,
+      updatedAt: NOW - 25 * MIN,
+    }),
+    // ── plan gate: verdict approved, awaiting the operator's Go ──────────────
+    mkSession({
+      id: "authstore",
+      desig: "TASK-44",
+      name: "auth-session-store",
+      repoPath: API,
+      branch: "shepherd/auth-session-store",
+      prompt: "Rework the auth session store to a rotating refresh-token scheme",
+      model: "opus",
+      status: "blocked",
+      planGateEnabled: true,
+      planPhase: "planning",
+      issueNumber: 220,
+      lastState: "blocked",
+      createdAt: NOW - 40 * MIN,
+      updatedAt: NOW - 8 * MIN,
+    }),
+    // ── blocked: autopilot paused on a hand-back question ───────────────────
+    mkSession({
+      id: "neon",
+      desig: "TASK-45",
+      name: "neon-postgres",
+      repoPath: API,
+      branch: "shepherd/neon-postgres",
+      prompt: "Migrate the API's database layer to Neon serverless Postgres",
+      model: "opus",
+      status: "blocked",
+      autopilotEnabled: true,
+      autopilotStepCount: 6,
+      autopilotPaused: true,
+      autopilotQuestion: NEON_QUESTION,
+      issueNumber: 221,
+      lastState: "blocked",
+      createdAt: NOW - 70 * MIN,
+      updatedAt: NOW - 4 * MIN,
+    }),
+    // ── merging: PR selected into the merge train ───────────────────────────
+    mkSession({
+      id: "ogimg",
+      desig: "TASK-39",
+      name: "og-images",
+      repoPath: STOREFRONT,
+      branch: "shepherd/og-images",
+      prompt: "Generate dynamic OG images for product pages",
+      model: "sonnet",
+      status: "running",
+      readyToMerge: true,
+      mergingSince: NOW - 90 * SEC,
+      mergingTrainId: "ogimg",
+      mergeTrainPrs: [508],
+      autoMergeEnabled: true,
+      issueNumber: 140,
+      lastState: "merging",
+      createdAt: NOW - 5 * HOUR,
+      updatedAt: NOW - 90 * SEC,
+    }),
+    // ── done: merged, recap present, one owed post-merge manual step ────────
+    mkSession({
+      id: "deps",
+      desig: "TASK-37",
+      name: "bump-deps",
+      repoPath: STOREFRONT,
+      branch: "shepherd/bump-deps",
+      prompt: "Bump dependencies to latest and fix the resulting lint errors",
+      model: "sonnet",
+      status: "done",
+      issueNumber: 137,
+      lastState: "done",
+      createdAt: NOW - 6 * HOUR,
+      updatedAt: NOW - 45 * MIN,
+      manualSteps: [
+        {
+          id: "deps-ms-1",
+          text: "Rotate the CI dependency-cache key so the runners pick up the new lockfile",
+          postMerge: true,
+        },
+      ],
+      manualStepsAckedAt: null,
+    }),
+    // ── working (autopilot): epic child spawned by the drain ────────────────
+    mkSession({
+      id: "checkout-child",
+      desig: "TASK-42",
+      name: "shipping-estimator",
+      repoPath: STOREFRONT,
+      branch: "shepherd/shipping-estimator",
+      prompt: "Add a shipping-cost estimator to the checkout summary",
+      model: "opus",
+      status: "running",
+      autopilotEnabled: true,
+      autopilotStepCount: 2,
+      auto: true,
+      issueNumber: 102,
+      lastState: "working",
+      createdAt: NOW - 18 * MIN,
+      updatedAt: NOW - 40 * SEC,
+      hasScratchpadFiles: true,
     }),
   ];
 }
 
+const gh = (repo: string) => repo.replace("/demo/", "https://github.com/");
+
 function buildGitStates(): Record<string, GitState> {
   return {
-    s1: {
-      kind: "github",
-      state: "none",
-      checks: "none",
-      deployConfigured: false,
-    },
-    s3: {
+    // hero — still building; no PR yet.
+    coupon: { kind: "github", state: "none", checks: "none", deployConfigured: true },
+    // ready to merge — open, green, clean.
+    rounding: {
       kind: "github",
       state: "open",
-      number: 412,
-      url: "https://github.com/acme/storefront/pull/412",
-      title: "TASK-03: add end-to-end checkout tests",
-      createdAt: NOW - 40 * MIN,
+      number: 512,
+      url: `${gh(STOREFRONT)}/pull/512`,
+      title: "TASK-38: fix cart-total rounding on 3-for-2 offers",
+      createdAt: NOW - 35 * MIN,
       mergeable: true,
       checks: "success",
       mergeStateStatus: "clean",
       deployConfigured: true,
-      headSha: "9f3a1c7",
-      issueUrl: "https://github.com/acme/storefront/issues/103",
+      headSha: "a1b2c3d",
+      issueUrl: `${gh(STOREFRONT)}/issues/103`,
     },
+    // plan gate — no code yet.
+    authstore: { kind: "github", state: "none", checks: "none", deployConfigured: false },
+    // blocked on a question — no PR yet.
+    neon: { kind: "github", state: "none", checks: "none", deployConfigured: false },
+    // in the merge train — open, green, being landed now.
+    ogimg: {
+      kind: "github",
+      state: "open",
+      number: 508,
+      url: `${gh(STOREFRONT)}/pull/508`,
+      title: "TASK-39: dynamic OG images for product pages",
+      createdAt: NOW - 2 * HOUR,
+      mergeable: true,
+      checks: "success",
+      mergeStateStatus: "clean",
+      deployConfigured: true,
+      headSha: "e4f5a6b",
+      issueUrl: `${gh(STOREFRONT)}/issues/140`,
+    },
+    // done — PR merged.
+    deps: {
+      kind: "github",
+      state: "merged",
+      number: 505,
+      url: `${gh(STOREFRONT)}/pull/505`,
+      title: "TASK-37: bump dependencies + fix lint",
+      createdAt: NOW - 5 * HOUR,
+      mergeable: true,
+      checks: "success",
+      mergeStateStatus: "clean",
+      deployConfigured: true,
+      headSha: "c7d8e9f",
+      issueUrl: `${gh(STOREFRONT)}/issues/137`,
+    },
+    // epic child — building; no PR yet.
+    "checkout-child": { kind: "github", state: "none", checks: "none", deployConfigured: true },
   };
 }
 
 function buildActivityStates(): Record<string, SessionActivity> {
   return {
-    s1: {
-      lastActivityTs: NOW - 30_000,
-      summary: "edited payment-intent.ts",
-      recentTs: [NOW - 5 * MIN, NOW - 3 * MIN, NOW - 90_000, NOW - 30_000],
-      recentErrTs: [NOW - 3 * MIN],
+    coupon: {
+      lastActivityTs: NOW - 20 * SEC,
+      summary: "edited src/routes/checkout/CouponField.svelte",
+      recentTs: [NOW - 6 * MIN, NOW - 4 * MIN, NOW - 2 * MIN, NOW - 50 * SEC, NOW - 20 * SEC],
+      recentErrTs: [NOW - 4 * MIN],
     },
-    s3: {
-      lastActivityTs: NOW - 20 * MIN,
-      summary: "$ bun test",
-      recentTs: [NOW - 25 * MIN, NOW - 20 * MIN],
+    "checkout-child": {
+      lastActivityTs: NOW - 40 * SEC,
+      summary: "$ bun run check",
+      recentTs: [NOW - 3 * MIN, NOW - 90 * SEC, NOW - 40 * SEC],
+      recentErrTs: [],
+    },
+    rounding: {
+      lastActivityTs: NOW - 25 * MIN,
+      summary: "$ bun test src/lib/cart",
+      recentTs: [NOW - 32 * MIN, NOW - 28 * MIN, NOW - 25 * MIN],
+      recentErrTs: [],
+    },
+    ogimg: {
+      lastActivityTs: NOW - 90 * SEC,
+      summary: "pushed shepherd/og-images",
+      recentTs: [NOW - 6 * MIN, NOW - 3 * MIN, NOW - 90 * SEC],
+      recentErrTs: [],
+    },
+    neon: {
+      lastActivityTs: NOW - 4 * MIN,
+      summary: "asked: seed from dump or start clean?",
+      recentTs: [NOW - 12 * MIN, NOW - 7 * MIN, NOW - 4 * MIN],
+      recentErrTs: [],
+    },
+    authstore: {
+      lastActivityTs: NOW - 8 * MIN,
+      summary: "drafted refresh-token rotation plan",
+      recentTs: [NOW - 20 * MIN, NOW - 12 * MIN, NOW - 8 * MIN],
+      recentErrTs: [],
+    },
+    deps: {
+      lastActivityTs: NOW - 45 * MIN,
+      summary: "merged shepherd/bump-deps",
+      recentTs: [NOW - 55 * MIN, NOW - 48 * MIN, NOW - 45 * MIN],
       recentErrTs: [],
     },
   };
@@ -184,14 +361,23 @@ function buildActivityStates(): Record<string, SessionActivity> {
 
 function buildSubagentStates(): Record<string, SubagentEntry[]> {
   return {
-    s1: [
+    coupon: [
       {
-        agentId: "sub-s1-explore",
+        agentId: "sub-coupon-explore",
         agentType: "Explore",
-        startedAt: NOW - 8 * MIN,
-        endedAt: NOW - 6 * MIN,
+        startedAt: NOW - 10 * MIN,
+        endedAt: NOW - 7 * MIN,
       },
-      { agentId: "sub-s1-impl", agentType: "general-purpose", startedAt: NOW - 4 * MIN },
+      {
+        agentId: "sub-coupon-pricing",
+        agentType: "general-purpose",
+        startedAt: NOW - 5 * MIN,
+        endedAt: NOW - 2 * MIN,
+      },
+      { agentId: "sub-coupon-ui", agentType: "general-purpose", startedAt: NOW - 90 * SEC },
+    ],
+    "checkout-child": [
+      { agentId: "sub-child-explore", agentType: "Explore", startedAt: NOW - 6 * MIN },
     ],
   };
 }
@@ -199,68 +385,100 @@ function buildSubagentStates(): Record<string, SubagentEntry[]> {
 function buildUsage(): UsageLimitsResponse {
   return {
     limits: {
-      session5h: { pct: 42, resetAt: NOW + 2 * HOUR },
-      week: { pct: 61, resetAt: NOW + 3 * 24 * HOUR },
+      session5h: { pct: 68, resetAt: NOW + 2 * HOUR },
+      week: { pct: 74, resetAt: NOW + 3 * DAY },
       credits: null,
       stale: false,
-      calibratedAt: NOW - 10 * MIN,
+      calibratedAt: NOW - 8 * MIN,
       subscriptionOnly: false,
     },
     projections: [
-      { window: "5H", projectedPct: 58, resetAt: NOW + 2 * HOUR, burnRatePerHour: 12 },
-      { window: "WK", projectedPct: 74, resetAt: NOW + 3 * 24 * HOUR, burnRatePerHour: 40 },
+      { window: "5H", projectedPct: 82, resetAt: NOW + 2 * HOUR, burnRatePerHour: 14 },
+      { window: "WK", projectedPct: 79, resetAt: NOW + 3 * DAY, burnRatePerHour: 6 },
     ],
   };
 }
 
 function buildEpics(): Epic[] {
+  const issue = (n: number) => `${gh(STOREFRONT)}/issues/${n}`;
   return [
     {
-      repoPath: REPO,
+      repoPath: STOREFRONT,
       parentIssueNumber: EPIC_PARENT,
       parentTitle: "Checkout v2",
       source: "native",
       warnings: [],
-      run: { repoPath: REPO, parentIssueNumber: EPIC_PARENT, mode: "attended", status: "running" },
+      run: {
+        repoPath: STOREFRONT,
+        parentIssueNumber: EPIC_PARENT,
+        mode: "attended",
+        status: "running",
+      },
       children: [
         {
           number: 101,
-          title: "Payment-intent API",
-          url: "https://github.com/acme/storefront/issues/101",
+          title: "Coupon-code field at checkout",
+          url: issue(101),
           order: 0,
-          body: "Expose POST /api/checkout/intent.",
+          body: "Add a coupon-code field to the summary and apply the discount to the total.",
           blockedBy: [],
           state: "running",
-          sessionId: "s1",
+          sessionId: "coupon",
           prNumber: null,
           issueClosed: false,
           claimed: true,
         },
         {
           number: 102,
-          title: "Checkout summary UI",
-          url: "https://github.com/acme/storefront/issues/102",
+          title: "Shipping-cost estimator",
+          url: issue(102),
           order: 1,
-          body: "Render the summary + confirm screen.",
-          blockedBy: [101],
-          state: "blocked",
-          sessionId: "s2",
+          body: "Estimate shipping cost from the cart weight + destination and show it in the summary.",
+          blockedBy: [],
+          state: "running",
+          sessionId: "checkout-child",
           prNumber: null,
           issueClosed: false,
           claimed: true,
         },
         {
           number: 103,
-          title: "Checkout e2e tests",
-          url: "https://github.com/acme/storefront/issues/103",
+          title: "Cart-total rounding fix",
+          url: issue(103),
           order: 2,
-          body: "Playwright coverage for the happy path.",
-          blockedBy: [101],
+          body: "Fix the rounding bug that drops a cent on 3-for-2 offers.",
+          blockedBy: [],
           state: "in-review",
-          sessionId: "s3",
-          prNumber: 412,
+          sessionId: "rounding",
+          prNumber: 512,
           issueClosed: false,
           claimed: true,
+        },
+        {
+          number: 104,
+          title: "Saved payment methods",
+          url: issue(104),
+          order: 3,
+          body: "Let returning customers pick a stored card at checkout.",
+          blockedBy: [101],
+          state: "blocked",
+          sessionId: null,
+          prNumber: null,
+          issueClosed: false,
+          claimed: false,
+        },
+        {
+          number: 105,
+          title: "Guest checkout",
+          url: issue(105),
+          order: 4,
+          body: "Allow checkout without an account, upgrading to one on confirmation.",
+          blockedBy: [101, 102],
+          state: "blocked",
+          sessionId: null,
+          prNumber: null,
+          issueClosed: false,
+          claimed: false,
         },
       ],
     },
@@ -270,23 +488,54 @@ function buildEpics(): Epic[] {
 function buildCompletedEpics(): CompletedEpic[] {
   return [
     {
-      repoPath: REPO,
+      repoPath: STOREFRONT,
       parentIssueNumber: 88,
       parentTitle: "Cart refactor",
-      completedAt: NOW - 2 * 24 * HOUR,
+      completedAt: NOW - 2 * DAY,
       children: [
         {
           number: 81,
           title: "Cart store rewrite",
-          url: "https://github.com/acme/storefront/issues/81",
+          url: `${gh(STOREFRONT)}/issues/81`,
           prNumber: 390,
-          prUrl: "https://github.com/acme/storefront/pull/390",
-          mergedAt: NOW - 2 * 24 * HOUR,
+          prUrl: `${gh(STOREFRONT)}/pull/390`,
+          mergedAt: NOW - 2 * DAY - 2 * HOUR,
+          integrated: true,
+        },
+        {
+          number: 82,
+          title: "Cart persistence to localStorage",
+          url: `${gh(STOREFRONT)}/issues/82`,
+          prNumber: 392,
+          prUrl: `${gh(STOREFRONT)}/pull/392`,
+          mergedAt: NOW - 2 * DAY,
           integrated: true,
         },
       ],
       landingPrNumber: 395,
-      landingPrUrl: "https://github.com/acme/storefront/pull/395",
+      landingPrUrl: `${gh(STOREFRONT)}/pull/395`,
+      landingState: "merged",
+      migrationPaths: [],
+      migrationsAckedAt: null,
+    },
+    {
+      repoPath: API,
+      parentIssueNumber: 200,
+      parentTitle: "Rate limiting",
+      completedAt: NOW - 5 * DAY,
+      children: [
+        {
+          number: 201,
+          title: "Token-bucket middleware",
+          url: `${gh(API)}/issues/201`,
+          prNumber: 310,
+          prUrl: `${gh(API)}/pull/310`,
+          mergedAt: NOW - 5 * DAY,
+          integrated: true,
+        },
+      ],
+      landingPrNumber: 312,
+      landingPrUrl: `${gh(API)}/pull/312`,
       landingState: "merged",
       migrationPaths: [],
       migrationsAckedAt: null,
@@ -296,58 +545,74 @@ function buildCompletedEpics(): CompletedEpic[] {
 
 function buildRecaps(): Record<string, Recap> {
   return {
-    s3: {
-      sessionId: "s3",
+    rounding: {
+      sessionId: "rounding",
       state: "ready",
-      headSha: "9f3a1c7",
+      headSha: "a1b2c3d",
       verdict: "ready",
-      headline: "End-to-end checkout tests added",
-      body: "Added Playwright coverage for the checkout happy path and a failing-card branch.",
+      headline: "Cart-total rounding fixed for multi-buy offers",
+      body: "Switched the running total to integer cents and rounded once at the end. Added a regression test for the 3-for-2 case that previously dropped a cent.",
       openItems: [],
-      changedFiles: ["tests/checkout.spec.ts", "playwright.config.ts"],
-      spawnSessionId: "recap-s3",
-      cwd: `${REPO}/.worktrees/s3`,
-      model: "opus",
-      spawnedAt: NOW - 22 * MIN,
-      generatedAt: NOW - 20 * MIN,
-      updatedAt: NOW - 20 * MIN,
+      changedFiles: ["src/lib/cart/total.ts", "src/lib/cart/total.test.ts"],
+      spawnSessionId: "recap-rounding",
+      cwd: `${STOREFRONT}/.worktrees/rounding`,
+      model: "sonnet",
+      spawnedAt: NOW - 27 * MIN,
+      generatedAt: NOW - 25 * MIN,
+      updatedAt: NOW - 25 * MIN,
+    },
+    deps: {
+      sessionId: "deps",
+      state: "ready",
+      headSha: "c7d8e9f",
+      verdict: "needs_attention",
+      headline: "Dependencies bumped; one post-merge step is owed",
+      body: "Upgraded 34 packages to latest, regenerated the lockfile, and fixed the lint errors the new rules surfaced. The CI cache key must be rotated so runners pick up the new lockfile.",
+      openItems: ["Rotate the CI dependency-cache key (post-merge)"],
+      changedFiles: ["package.json", "bun.lockb", "eslint.config.js"],
+      spawnSessionId: "recap-deps",
+      cwd: `${STOREFRONT}/.worktrees/deps`,
+      model: "sonnet",
+      spawnedAt: NOW - 47 * MIN,
+      generatedAt: NOW - 45 * MIN,
+      updatedAt: NOW - 45 * MIN,
     },
   };
 }
 
 function buildReviews(): Record<string, ReviewVerdict> {
   return {
-    s3: {
-      sessionId: "s3",
-      headSha: "9f3a1c7",
+    rounding: {
+      sessionId: "rounding",
+      headSha: "a1b2c3d",
       decision: "commented",
-      summary: "Solid coverage; one flaky selector to tighten.",
-      body: "The happy-path spec is clear. Consider a data-testid on the confirm button.",
-      findings: ["Use a stable data-testid for the confirm button"],
+      summary: "Correct fix; one edge case worth a note.",
+      body: "Moving to integer cents is the right call and the regression test covers the reported case. Consider a comment on why the final rounding happens once, so a future refactor doesn't reintroduce per-line rounding.",
+      findings: ["Add a comment explaining the single final-rounding step"],
       addressRound: 0,
       addressCap: 3,
       finalRoundPending: false,
       finalRoundTimeoutMs: 120_000,
-      url: "https://github.com/acme/storefront/pull/412#review",
-      updatedAt: NOW - 18 * MIN,
+      url: `${gh(STOREFRONT)}/pull/512#review`,
+      updatedAt: NOW - 22 * MIN,
     },
   };
 }
 
 function buildPlanGates(): Record<string, PlanGate> {
   return {
-    s2: {
-      sessionId: "s2",
-      planHash: "plan-s2-hash-1",
+    authstore: {
+      sessionId: "authstore",
+      planHash: "authstore-plan-1",
       decision: "approved",
-      summary: "Plan approved: build summary then confirm step.",
-      body: "The two-step plan is sound. Wire the confirm CTA to the intent API from TASK-01.",
+      summary: "Plan approved: rotating refresh tokens with a short-lived access token.",
+      body: "The rotation scheme is sound. Store refresh tokens hashed, rotate on every use, and revoke the family on reuse detection. Keep the access-token TTL at 15 minutes.",
       findings: [],
       round: 1,
       cap: 3,
       approved: true,
-      plan: "1. Render order summary\n2. Add confirm CTA\n3. Call payment-intent API",
-      updatedAt: NOW - 12 * MIN,
+      plan: "1. Add a refresh_tokens table (hashed, family id)\n2. Issue short-lived access + rotating refresh on login\n3. Rotate on refresh; revoke the family on reuse\n4. Migrate existing sessions on next login",
+      updatedAt: NOW - 8 * MIN,
     },
   };
 }
@@ -356,15 +621,19 @@ function buildHerdDigest(): HerdDigest {
   return {
     dayKey: "2026-06-30",
     state: "ready",
-    overnight: "Cart refactor epic landed; checkout v2 is mid-flight across three tasks.",
-    decisions: [{ label: "Approved the checkout-ui plan gate", sessionId: "s2" }],
+    overnight:
+      "The Cart-refactor epic landed. Checkout v2 is mid-drain across three tasks, and the API is picking up an auth-store rework plus a Neon migration.",
+    decisions: [{ label: "Approved the auth-session-store plan", sessionId: "authstore" }],
     ciRework: [],
-    train: "No merge train running.",
-    focusNext: [{ label: "Review TASK-03 checkout tests PR", sessionId: "s3", pr: 412 }],
+    train: "OG-images PR #508 is in the merge train.",
+    focusNext: [
+      { label: "Answer the Neon seeding question", sessionId: "neon" },
+      { label: "Merge the cart-rounding fix", sessionId: "rounding", pr: 512 },
+    ],
     epicsToLand: [],
-    attentionFingerprint: { s2: ["plan-approved"] },
+    attentionFingerprint: { neon: ["autopilot-paused"], authstore: ["plan-approved"] },
     spawnSessionId: "digest-1",
-    cwd: REPO,
+    cwd: STOREFRONT,
     model: "opus",
     spawnedAt: NOW - 6 * HOUR,
     generatedAt: NOW - 6 * HOUR,
@@ -373,36 +642,71 @@ function buildHerdDigest(): HerdDigest {
 }
 
 function buildUpNext(): UpNextSnapshot {
+  type Kind = UpNextItem["kind"];
+  const sfItem = (number: number, title: string, body: string, kind: Kind): UpNextItem => ({
+    repoPath: STOREFRONT,
+    repoSlug: "acme/storefront",
+    repoLabel: "acme/storefront",
+    number,
+    title,
+    url: `${gh(STOREFRONT)}/issues/${number}`,
+    kind,
+    priority: false,
+    createdAt: NOW - 26 * HOUR,
+    issueRef: { number, url: `${gh(STOREFRONT)}/issues/${number}`, title, body },
+  });
+  const apiItem = (number: number, title: string, body: string, kind: Kind): UpNextItem => ({
+    repoPath: API,
+    repoSlug: "acme/api",
+    repoLabel: "acme/api",
+    number,
+    title,
+    url: `${gh(API)}/issues/${number}`,
+    kind,
+    priority: false,
+    createdAt: NOW - 30 * HOUR,
+    issueRef: { number, url: `${gh(API)}/issues/${number}`, title, body },
+  });
   return {
     generatedAt: NOW - 15 * MIN,
-    repoCount: 1,
+    repoCount: 2,
     fallback: null,
     failedRepoCount: 0,
     sections: [
       {
         kind: "repo",
-        repoPath: REPO,
+        repoPath: STOREFRONT,
         repoSlug: "acme/storefront",
         repoLabel: "acme/storefront",
+        totalCount: 2,
+        items: [
+          sfItem(
+            121,
+            "Wishlist button on product cards",
+            "Let shoppers save items to a wishlist from the grid.",
+            "feature",
+          ),
+          sfItem(
+            122,
+            "Empty-cart illustration",
+            "Show a friendly empty state when the cart has no items.",
+            "feature",
+          ),
+        ],
+      },
+      {
+        kind: "repo",
+        repoPath: API,
+        repoSlug: "acme/api",
+        repoLabel: "acme/api",
         totalCount: 1,
         items: [
-          {
-            repoPath: REPO,
-            repoSlug: "acme/storefront",
-            repoLabel: "acme/storefront",
-            number: 120,
-            title: "Add saved-payment-methods selector",
-            url: "https://github.com/acme/storefront/issues/120",
-            kind: "feature",
-            priority: false,
-            createdAt: NOW - 26 * HOUR,
-            issueRef: {
-              number: 120,
-              url: "https://github.com/acme/storefront/issues/120",
-              title: "Add saved-payment-methods selector",
-              body: "Let returning customers pick a stored card at checkout.",
-            },
-          },
+          apiItem(
+            222,
+            "Add request-id correlation header",
+            "Thread a request id through logs for tracing.",
+            "feature",
+          ),
         ],
       },
     ],
@@ -411,19 +715,33 @@ function buildUpNext(): UpNextSnapshot {
 
 function buildBacklog(): BacklogPayload {
   return {
-    pinnedPath: REPO,
-    totals: { openIssues: 6, openPRs: 1 },
+    pinnedPath: STOREFRONT,
+    totals: { openIssues: 11, openPRs: 2 },
     projects: [
       {
-        path: REPO,
+        path: STOREFRONT,
         display: "acme/storefront",
         slug: "acme/storefront",
         kind: "github",
-        lastUsedAt: NOW - 5 * MIN,
-        recentAgentCount: 3,
-        openIssues: 6,
-        openPRs: 1,
-        prKinds: { release: 0, dependabot: 0, regular: 1 },
+        lastUsedAt: NOW - 20 * SEC,
+        recentAgentCount: 5,
+        openIssues: 8,
+        openPRs: 2,
+        prKinds: { release: 0, dependabot: 0, regular: 2 },
+        workflows: 3,
+        ciStatus: "success",
+        hidden: false,
+      },
+      {
+        path: API,
+        display: "acme/api",
+        slug: "acme/api",
+        kind: "github",
+        lastUsedAt: NOW - 4 * MIN,
+        recentAgentCount: 2,
+        openIssues: 3,
+        openPRs: 0,
+        prKinds: { release: 0, dependabot: 0, regular: 0 },
         workflows: 2,
         ciStatus: "success",
         hidden: false,
@@ -434,14 +752,49 @@ function buildBacklog(): BacklogPayload {
 
 function buildBuildQueues(): Record<string, BuildQueue> {
   return {
-    s1: {
-      sessionId: "s1",
+    coupon: {
+      sessionId: "coupon",
       approved: true,
       approvalKind: "auto",
       steps: [
-        { id: "step-1", title: "Draft payment-intent route", status: "done", position: 0 },
-        { id: "step-2", title: "Wire Stripe client", status: "active", position: 1 },
-        { id: "step-3", title: "Add unit tests", status: "pending", position: 2 },
+        {
+          id: "coupon-1",
+          title: "Add the coupon input to the summary",
+          status: "done",
+          position: 0,
+        },
+        {
+          id: "coupon-2",
+          title: "Wire coupon validation to the pricing API",
+          status: "active",
+          position: 1,
+        },
+        {
+          id: "coupon-3",
+          title: "Apply the discount to the total",
+          status: "pending",
+          position: 2,
+        },
+        { id: "coupon-4", title: "Add unit + component tests", status: "pending", position: 3 },
+      ],
+    },
+    authstore: {
+      sessionId: "authstore",
+      approved: false,
+      steps: [
+        {
+          id: "auth-1",
+          title: "Add the refresh_tokens table + migration",
+          status: "pending",
+          position: 0,
+        },
+        {
+          id: "auth-2",
+          title: "Issue rotating refresh tokens on login",
+          status: "pending",
+          position: 1,
+        },
+        { id: "auth-3", title: "Revoke the token family on reuse", status: "pending", position: 2 },
       ],
     },
   };
@@ -450,14 +803,25 @@ function buildBuildQueues(): Record<string, BuildQueue> {
 function buildHeld(): HeldTask[] {
   return [
     {
-      id: "held-1",
-      repoPath: REPO,
+      id: "held-refund-flow",
+      repoPath: STOREFRONT,
       createdAt: NOW - 35 * MIN,
       input: {
-        repoPath: REPO,
+        repoPath: STOREFRONT,
         baseBranch: "main",
-        prompt: "Add refund flow to the checkout admin panel",
+        prompt: "Add a refund flow to the checkout admin panel",
         model: "opus",
+      },
+    },
+    {
+      id: "held-api-openapi",
+      repoPath: API,
+      createdAt: NOW - 22 * MIN,
+      input: {
+        repoPath: API,
+        baseBranch: "main",
+        prompt: "Generate an OpenAPI spec from the route handlers",
+        model: "sonnet",
       },
     },
   ];
@@ -465,8 +829,8 @@ function buildHeld(): HeldTask[] {
 
 function buildSettings(): Settings {
   return {
-    repoRoot: "/demo",
-    repoRootDisplay: "~/demo",
+    repoRoot: "/demo/acme",
+    repoRootDisplay: "~/acme",
     remoteControlAtStartup: false,
     sessionHousekeepingEnabled: true,
     defaultModel: "auto",
@@ -522,6 +886,16 @@ function buildPlugins(): PluginInfo[] {
       ui: null,
       gearItem: null,
     },
+    {
+      id: "demo-slack",
+      name: "Slack notifier",
+      version: "0.7.1",
+      health: "ok",
+      lastError: null,
+      status: {},
+      ui: null,
+      gearItem: null,
+    },
   ];
 }
 
@@ -533,6 +907,7 @@ function buildDiagnostics(): DiagnosticsSnapshot {
       { id: "git", state: "ok", hintKey: "diag_git" },
       { id: "gh", state: "ok", hintKey: "diag_gh" },
       { id: "node", state: "ok", hintKey: "diag_node" },
+      { id: "bun", state: "ok", hintKey: "diag_bun" },
     ],
   };
 }
@@ -555,41 +930,69 @@ function buildSteers(): Steer[] {
       inSteerBar: true,
       onIssues: false,
     },
+    {
+      id: "steer-open-pr",
+      label: "Open PR",
+      text: "Open a pull request when the work is ready.",
+      emoji: "🚀",
+      inSteerBar: true,
+      onIssues: false,
+    },
   ];
 }
 
 function buildProjectIcons(): ProjectIcons {
-  return { [REPO]: "🛒" };
+  return { [STOREFRONT]: "🛒", [API]: "⚙️" };
 }
 
 function buildDrain(): DrainStatus[] {
   return [
     {
-      repoPath: REPO,
+      repoPath: STOREFRONT,
       enabled: true,
       paused: false,
       reason: null,
       detail: null,
-      queued: 4,
-      inFlight: 1,
+      queued: 2,
+      inFlight: 2,
       max: 3,
       epicParent: EPIC_PARENT,
+    },
+    {
+      repoPath: API,
+      enabled: true,
+      paused: false,
+      reason: null,
+      detail: null,
+      queued: 1,
+      inFlight: 2,
+      max: 2,
+      epicParent: null,
     },
   ];
 }
 
 function buildAutoMerge(): AutoMergeStatus[] {
-  return [{ repoPath: REPO, enabled: true, state: null, detail: null, sessionId: null }];
+  return [
+    {
+      repoPath: STOREFRONT,
+      enabled: true,
+      state: "merging",
+      detail: "TASK-39",
+      sessionId: "ogimg",
+    },
+    { repoPath: API, enabled: true, state: null, detail: null, sessionId: null },
+  ];
 }
 
 function buildPendingLearnings(): Learning[] {
   return [
     {
-      id: "learn-1",
-      repoPath: REPO,
-      rule: "Always add a data-testid to interactive checkout elements.",
-      rationale: "Tests kept flaking on text-based selectors.",
-      evidence: ["s3 review flagged a fragile selector"],
+      id: "learn-testid",
+      repoPath: STOREFRONT,
+      rule: "Add a stable data-testid to interactive checkout elements.",
+      rationale: "Tests kept flaking on text-based selectors during the cart work.",
+      evidence: ["rounding review flagged a fragile selector"],
       status: "proposed",
       evidenceCount: 2,
       ineffectiveCount: 0,
@@ -602,6 +1005,26 @@ function buildPendingLearnings(): Learning[] {
       createdAt: NOW - 30 * MIN,
       updatedAt: NOW - 30 * MIN,
       lastEvidenceAt: NOW - 30 * MIN,
+      promotedPrUrl: null,
+    },
+    {
+      id: "learn-migrations",
+      repoPath: API,
+      rule: "Every schema change ships with a reversible migration.",
+      rationale: "A forward-only change during the rate-limit epic blocked a rollback.",
+      evidence: ["rate-limit epic needed a manual down-migration"],
+      status: "proposed",
+      evidenceCount: 1,
+      ineffectiveCount: 0,
+      helpfulCount: 0,
+      injectedCount: 0,
+      lastUsedAt: null,
+      retiredAt: null,
+      retiredReason: null,
+      scopeGlobs: ["migrations/**"],
+      createdAt: NOW - 3 * HOUR,
+      updatedAt: NOW - 3 * HOUR,
+      lastEvidenceAt: NOW - 3 * HOUR,
       promotedPrUrl: null,
     },
   ];
@@ -643,7 +1066,10 @@ function buildStarPrompt(): StarPromptStatus {
 
 function buildHolds(): Record<string, HoldReason> {
   return {
-    s2: { code: "blocked-awaiting-input" },
+    // Autopilot paused, handing a question back to the operator.
+    neon: { code: "autopilot-paused", params: { question: NEON_QUESTION } },
+    // Done, but one post-merge manual step is still owed.
+    deps: { code: "manual-steps", params: { steps: 1 } },
   };
 }
 
@@ -653,11 +1079,23 @@ export function buildSeed(): DemoWorld {
     sessions: buildSessions(),
     gitStates: buildGitStates(),
     activityStates: buildActivityStates(),
-    claudeAliveStates: { s1: true, s2: true, s3: true },
-    workingBlockedStates: { s1: false, s2: false },
+    claudeAliveStates: {
+      coupon: true,
+      "checkout-child": true,
+      ogimg: true,
+      neon: true,
+      authstore: true,
+      rounding: false,
+      deps: false,
+    },
+    workingBlockedStates: {
+      coupon: false,
+      "checkout-child": false,
+      neon: true,
+    },
     holdStates: buildHolds(),
     subagentStates: buildSubagentStates(),
-    previewStates: { s1: { previewPort: 4173, serve: "ok" } },
+    previewStates: { coupon: { previewPort: 4173, serve: "ok" } },
 
     usage: buildUsage(),
     update: buildUpdate(),

--- a/ui/src/lib/demo/state.test.ts
+++ b/ui/src/lib/demo/state.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { demoState } from "./state";
 import { bus } from "./bus";
+import { displayStatus } from "$lib/display-status";
 import type { WsEvent } from "$lib/types";
 
 /** Collect every frame the bus emits while `fn` runs. */
@@ -118,6 +119,31 @@ describe("the rich 7-session scenario is seeded coherently", () => {
     expect(holds.deps.code).toBe("manual-steps");
   });
 
+  it("neon is NOT workingBlocked, so displayStatus renders it blocked (not upgraded to running)", () => {
+    const neon = demoState.sessions().find((s) => s.id === "neon")!;
+    expect(neon.status).toBe("blocked");
+    expect(demoState.workingBlockedStates().neon).toBe(false);
+    expect(displayStatus(neon, demoState.workingBlockedStates())).toBe("blocked");
+  });
+
+  it("no seeded session is stuck working-blocked (which would silently upgrade a blocked status)", () => {
+    const blocked = new Set(
+      demoState
+        .sessions()
+        .filter((s) => s.status === "blocked")
+        .map((s) => s.id),
+    );
+    for (const [id, isWorkingBlocked] of Object.entries(demoState.workingBlockedStates())) {
+      if (isWorkingBlocked) expect(blocked.has(id)).toBe(false);
+    }
+  });
+
+  it("diagnostics checks carry valid, existing hintKeys (diagnostics_hint_<tool>_<state>)", () => {
+    for (const check of demoState.diagnostics().checks) {
+      expect(check.hintKey).toMatch(/^diagnostics_hint_\w+_\w+$/);
+    }
+  });
+
   it("the showcased lens datasets are seeded and keyed to the scenario", () => {
     expect(demoState.reviews().rounding).toBeDefined();
     expect(demoState.planGates().authstore?.approved).toBe(true);
@@ -194,6 +220,25 @@ describe("demoState mutators emit the correct WsEvent frames", () => {
     const frames = capture(() => demoState.archiveSession("coupon"));
     expect(events(frames)).toEqual(["session:archived"]);
     expect(demoState.sessions().find((s) => s.id === "coupon")).toBeUndefined();
+  });
+
+  it("mergedClearable returns the merged, non-archived deps session", () => {
+    expect(demoState.mergedClearable()).toEqual({ ids: ["deps"], leftovers: 0 });
+  });
+
+  it("clearMerged archives the merged ids, emits session:archived, and deps disappears", () => {
+    let result: { cleared: string[]; leftovers: number } | undefined;
+    const frames = capture(() => (result = demoState.clearMerged(["deps"])));
+    expect(events(frames)).toEqual(["session:archived"]);
+    expect(result).toEqual({ cleared: ["deps"], leftovers: 0 });
+    expect(demoState.sessions().find((s) => s.id === "deps")).toBeUndefined();
+    expect(demoState.mergedClearable()).toEqual({ ids: [], leftovers: 0 });
+  });
+
+  it("clearMerged skips ids that aren't actually merged", () => {
+    const result = demoState.clearMerged(["coupon"]);
+    expect(result).toEqual({ cleared: [], leftovers: 0 });
+    expect(demoState.sessions().find((s) => s.id === "coupon")).toBeDefined();
   });
 
   it("answerPlanQuestions emits activity and reports delivered", () => {

--- a/ui/src/lib/demo/state.test.ts
+++ b/ui/src/lib/demo/state.test.ts
@@ -59,83 +59,146 @@ describe("demoState.reset() → bootstrap getters", () => {
   });
 
   it("epic getters derive from the seeded epic graph", () => {
-    const repo = demoState.sessions()[0].repoPath;
-    const epic = demoState.epic(repo, 100);
+    const epic = demoState.epic("/demo/acme/storefront", 100);
     expect(epic?.children.length).toBeGreaterThan(0);
-    const summaries = demoState.epicSummaries(repo);
+    const summaries = demoState.epicSummaries("/demo/acme/storefront");
     expect(summaries.epics[0].total).toBe(epic!.children.length);
     expect(summaries.subIssues).toContain(101);
   });
 });
 
+describe("the rich 7-session scenario is seeded coherently", () => {
+  it("all seven stable session ids are present with the expected states", () => {
+    const byId = new Map(demoState.sessions().map((s) => [s.id, s]));
+    expect([...byId.keys()].sort()).toEqual(
+      ["authstore", "checkout-child", "coupon", "deps", "neon", "ogimg", "rounding"].sort(),
+    );
+    expect(byId.get("coupon")!.status).toBe("running");
+    expect(byId.get("coupon")!.lastState).toBe("working");
+    expect(byId.get("rounding")!.status).toBe("idle");
+    expect(byId.get("rounding")!.readyToMerge).toBe(true);
+    expect(byId.get("authstore")!.planPhase).toBe("planning");
+    expect(byId.get("neon")!.status).toBe("blocked");
+    expect(byId.get("neon")!.autopilotPaused).toBe(true);
+    expect(byId.get("neon")!.autopilotQuestion).toBeTruthy();
+    expect(byId.get("ogimg")!.mergingSince).not.toBeNull();
+    expect(byId.get("deps")!.status).toBe("done");
+    expect(byId.get("deps")!.manualSteps.length).toBeGreaterThan(0);
+    expect(byId.get("checkout-child")!.autopilotEnabled).toBe(true);
+  });
+
+  it("spans two repos", () => {
+    const repos = new Set(demoState.sessions().map((s) => s.repoPath));
+    expect(repos).toEqual(new Set(["/demo/acme/storefront", "/demo/acme/api"]));
+  });
+
+  it("the Checkout v2 epic links its in-flight children to their sessions", () => {
+    const epic = demoState.epic("/demo/acme/storefront", 100)!;
+    expect(epic.parentTitle).toBe("Checkout v2");
+    const byNumber = new Map(epic.children.map((c) => [c.number, c]));
+    expect(byNumber.get(101)!.sessionId).toBe("coupon");
+    expect(byNumber.get(102)!.sessionId).toBe("checkout-child");
+    expect(byNumber.get(103)!.sessionId).toBe("rounding");
+    // A mid-drain epic keeps at least one un-started child for approveEpicNext.
+    expect(epic.children.some((c) => c.state === "blocked" || c.state === "ready")).toBe(true);
+  });
+
+  it("gitStates carry the PR states the scenario table demands", () => {
+    const git = demoState.gitStates();
+    expect(git.coupon.state).toBe("none"); // hero has no PR yet
+    expect(git.rounding.state).toBe("open"); // ready-to-merge
+    expect(git.rounding.checks).toBe("success");
+    expect(git.ogimg.state).toBe("open"); // in merge train
+    expect(git.deps.state).toBe("merged"); // done
+  });
+
+  it("holds cover the blocked question and the owed manual step", () => {
+    const holds = demoState.holdStates();
+    expect(holds.neon.code).toBe("autopilot-paused");
+    expect(holds.deps.code).toBe("manual-steps");
+  });
+
+  it("the showcased lens datasets are seeded and keyed to the scenario", () => {
+    expect(demoState.reviews().rounding).toBeDefined();
+    expect(demoState.planGates().authstore?.approved).toBe(true);
+    expect(demoState.recaps().deps).toBeDefined();
+    expect(Object.keys(demoState.buildQueues())).toContain("coupon");
+    expect(demoState.held().length).toBeGreaterThan(0);
+    expect(demoState.pendingLearnings().length).toBeGreaterThan(0);
+    expect(Object.keys(demoState.projectIcons())).toHaveLength(2);
+  });
+});
+
 describe("demoState mutators emit the correct WsEvent frames", () => {
   it("reply emits activity + hold-clear + status(running)", () => {
-    const frames = capture(() => demoState.reply("s1", "keep going"));
+    const frames = capture(() => demoState.reply("coupon", "keep going"));
     expect(events(frames)).toEqual(["session:activity", "session:hold", "session:status"]);
     const status = frames.find((f) => f.event === "session:status");
     expect(status && "status" in status.data && status.data.status).toBe("running");
   });
 
   it("setAutopilot emits session:autopilot with the new enabled flag", () => {
-    const frames = capture(() => demoState.setAutopilot("s1", false));
+    const frames = capture(() => demoState.setAutopilot("coupon", false));
     expect(events(frames)).toEqual(["session:autopilot"]);
     const f = frames[0];
     expect(f.event === "session:autopilot" && f.data.enabled).toBe(false);
   });
 
   it("releasePlanGate emits plangate(executing) + hold-clear + status", () => {
-    const frames = capture(() => demoState.releasePlanGate("s2"));
+    const frames = capture(() => demoState.releasePlanGate("authstore"));
     expect(events(frames)).toEqual(["session:plangate", "session:hold", "session:status"]);
     const pg = frames[0];
     expect(pg.event === "session:plangate" && pg.data.planPhase).toBe("executing");
-    expect(demoState.sessions().find((s) => s.id === "s2")?.planPhase).toBe("executing");
+    expect(demoState.sessions().find((s) => s.id === "authstore")?.planPhase).toBe("executing");
   });
 
   it("reviewPlan emits the reviewing latch", () => {
-    const frames = capture(() => demoState.reviewPlan("s2"));
+    const frames = capture(() => demoState.reviewPlan("authstore"));
     expect(events(frames)).toEqual(["session:plangate-reviewing"]);
   });
 
   it("mergePr emits session:merging with a since timestamp", () => {
-    const frames = capture(() => demoState.mergePr("s3"));
+    const frames = capture(() => demoState.mergePr("rounding"));
     expect(events(frames)).toEqual(["session:merging"]);
     const f = frames[0];
     expect(f.event === "session:merging" && typeof f.data.since).toBe("number");
-    expect(demoState.sessions().find((s) => s.id === "s3")?.mergingSince).not.toBeNull();
+    expect(demoState.sessions().find((s) => s.id === "rounding")?.mergingSince).not.toBeNull();
   });
 
   it("setReadyToMerge emits session:ready", () => {
-    const frames = capture(() => demoState.setReadyToMerge("s1", true));
+    const frames = capture(() => demoState.setReadyToMerge("coupon", true));
     expect(events(frames)).toEqual(["session:ready"]);
-    expect(demoState.sessions().find((s) => s.id === "s1")?.readyToMerge).toBe(true);
+    expect(demoState.sessions().find((s) => s.id === "coupon")?.readyToMerge).toBe(true);
   });
 
   it("approveEpicNext emits epic:update and advances a child", () => {
-    const repo = demoState.sessions()[0].repoPath;
+    const repo = "/demo/acme/storefront";
+    const before = demoState.epic(repo, 100)!.children.filter((c) => c.state === "running").length;
     const frames = capture(() => demoState.approveEpicNext(repo, 100));
     expect(events(frames)).toEqual(["epic:update"]);
     const running = demoState.epic(repo, 100)!.children.filter((c) => c.state === "running");
-    expect(running.length).toBeGreaterThan(1);
+    expect(running.length).toBe(before + 1);
   });
 
   it("spawnHeld emits session:new + held:changed and grows the herd", () => {
     const before = demoState.sessions().length;
+    const heldBefore = demoState.held().length;
     const heldId = demoState.held()[0].id;
     const frames = capture(() => demoState.spawnHeld(heldId));
     expect(events(frames)).toEqual(["session:new", "held:changed"]);
     expect(demoState.sessions().length).toBe(before + 1);
-    expect(demoState.held().length).toBe(0);
+    expect(demoState.held().length).toBe(heldBefore - 1);
   });
 
   it("archiveSession emits session:archived and removes the session", () => {
-    const frames = capture(() => demoState.archiveSession("s1"));
+    const frames = capture(() => demoState.archiveSession("coupon"));
     expect(events(frames)).toEqual(["session:archived"]);
-    expect(demoState.sessions().find((s) => s.id === "s1")).toBeUndefined();
+    expect(demoState.sessions().find((s) => s.id === "coupon")).toBeUndefined();
   });
 
   it("answerPlanQuestions emits activity and reports delivered", () => {
     let result: { delivered: boolean } | undefined;
-    const frames = capture(() => (result = demoState.answerPlanQuestions("s2")));
+    const frames = capture(() => (result = demoState.answerPlanQuestions("authstore")));
     expect(events(frames)).toEqual(["session:activity"]);
     expect(result?.delivered).toBe(true);
   });
@@ -145,12 +208,12 @@ describe("structuredClone isolation", () => {
   it("mutating live state never leaks into the seed across resets", () => {
     demoState.reset();
     const cleanCount = demoState.sessions().length;
-    demoState.archiveSession("s1");
+    demoState.archiveSession("coupon");
     demoState.spawnHeld(demoState.held()[0].id);
     demoState.reset();
     // A fresh reset restores the exact seeded herd — no leaked mutations.
     expect(demoState.sessions().length).toBe(cleanCount);
-    expect(demoState.sessions().find((s) => s.id === "s1")).toBeDefined();
+    expect(demoState.sessions().find((s) => s.id === "coupon")).toBeDefined();
     expect(demoState.held().length).toBeGreaterThan(0);
   });
 });

--- a/ui/src/lib/demo/state.test.ts
+++ b/ui/src/lib/demo/state.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { demoState } from "./state";
+import { bus } from "./bus";
+import type { WsEvent } from "$lib/types";
+
+/** Collect every frame the bus emits while `fn` runs. */
+function capture(fn: () => void): WsEvent[] {
+  const frames: WsEvent[] = [];
+  const unsub = bus.subscribe((ev) => frames.push(ev));
+  try {
+    fn();
+  } finally {
+    unsub();
+  }
+  return frames;
+}
+
+const events = (frames: WsEvent[]) => frames.map((f) => f.event);
+
+beforeEach(() => demoState.reset());
+
+describe("demoState.reset() → bootstrap getters", () => {
+  it("every bootstrap getter returns a non-empty, shaped value", () => {
+    expect(demoState.sessions().length).toBeGreaterThan(0);
+    expect(Object.keys(demoState.gitStates()).length).toBeGreaterThan(0);
+    expect(Object.keys(demoState.activityStates()).length).toBeGreaterThan(0);
+    expect(Object.keys(demoState.claudeAliveStates()).length).toBeGreaterThan(0);
+    expect(Object.keys(demoState.workingBlockedStates()).length).toBeGreaterThan(0);
+    expect(Object.keys(demoState.holdStates()).length).toBeGreaterThan(0);
+    expect(Object.keys(demoState.subagentStates()).length).toBeGreaterThan(0);
+    expect(Object.keys(demoState.previewStates()).length).toBeGreaterThan(0);
+
+    expect(demoState.usageLimits().limits.session5h).not.toBeNull();
+    expect(demoState.usageLimits().projections.length).toBeGreaterThan(0);
+    expect(demoState.update()).toHaveProperty("behind");
+    expect(demoState.herdrUpdate()).toHaveProperty("current");
+    expect(demoState.codexUpdate()).toHaveProperty("current");
+    expect(demoState.starPrompt()).toHaveProperty("shouldPrompt");
+    expect(demoState.drain().length).toBeGreaterThan(0);
+    expect(demoState.autoMerge().length).toBeGreaterThan(0);
+    expect(demoState.completedEpics().length).toBeGreaterThan(0);
+  });
+
+  it("every lens getter returns a non-empty, shaped value", () => {
+    expect(demoState.settings().repoRoot).toBeTruthy();
+    expect(demoState.plugins().length).toBeGreaterThan(0);
+    expect(demoState.diagnostics().checks.length).toBeGreaterThan(0);
+    expect(demoState.backlog().projects.length).toBeGreaterThan(0);
+    expect(Object.keys(demoState.buildQueues()).length).toBeGreaterThan(0);
+    expect(demoState.held().length).toBeGreaterThan(0);
+    expect(Object.keys(demoState.recaps()).length).toBeGreaterThan(0);
+    expect(Object.keys(demoState.reviews()).length).toBeGreaterThan(0);
+    expect(Object.keys(demoState.planGates()).length).toBeGreaterThan(0);
+    expect(demoState.herdDigest()).not.toBeNull();
+    expect(demoState.upNext()?.sections.length).toBeGreaterThan(0);
+    expect(demoState.steers().length).toBeGreaterThan(0);
+    expect(Object.keys(demoState.projectIcons()).length).toBeGreaterThan(0);
+    expect(demoState.pendingLearnings().length).toBeGreaterThan(0);
+  });
+
+  it("epic getters derive from the seeded epic graph", () => {
+    const repo = demoState.sessions()[0].repoPath;
+    const epic = demoState.epic(repo, 100);
+    expect(epic?.children.length).toBeGreaterThan(0);
+    const summaries = demoState.epicSummaries(repo);
+    expect(summaries.epics[0].total).toBe(epic!.children.length);
+    expect(summaries.subIssues).toContain(101);
+  });
+});
+
+describe("demoState mutators emit the correct WsEvent frames", () => {
+  it("reply emits activity + hold-clear + status(running)", () => {
+    const frames = capture(() => demoState.reply("s1", "keep going"));
+    expect(events(frames)).toEqual(["session:activity", "session:hold", "session:status"]);
+    const status = frames.find((f) => f.event === "session:status");
+    expect(status && "status" in status.data && status.data.status).toBe("running");
+  });
+
+  it("setAutopilot emits session:autopilot with the new enabled flag", () => {
+    const frames = capture(() => demoState.setAutopilot("s1", false));
+    expect(events(frames)).toEqual(["session:autopilot"]);
+    const f = frames[0];
+    expect(f.event === "session:autopilot" && f.data.enabled).toBe(false);
+  });
+
+  it("releasePlanGate emits plangate(executing) + hold-clear + status", () => {
+    const frames = capture(() => demoState.releasePlanGate("s2"));
+    expect(events(frames)).toEqual(["session:plangate", "session:hold", "session:status"]);
+    const pg = frames[0];
+    expect(pg.event === "session:plangate" && pg.data.planPhase).toBe("executing");
+    expect(demoState.sessions().find((s) => s.id === "s2")?.planPhase).toBe("executing");
+  });
+
+  it("reviewPlan emits the reviewing latch", () => {
+    const frames = capture(() => demoState.reviewPlan("s2"));
+    expect(events(frames)).toEqual(["session:plangate-reviewing"]);
+  });
+
+  it("mergePr emits session:merging with a since timestamp", () => {
+    const frames = capture(() => demoState.mergePr("s3"));
+    expect(events(frames)).toEqual(["session:merging"]);
+    const f = frames[0];
+    expect(f.event === "session:merging" && typeof f.data.since).toBe("number");
+    expect(demoState.sessions().find((s) => s.id === "s3")?.mergingSince).not.toBeNull();
+  });
+
+  it("setReadyToMerge emits session:ready", () => {
+    const frames = capture(() => demoState.setReadyToMerge("s1", true));
+    expect(events(frames)).toEqual(["session:ready"]);
+    expect(demoState.sessions().find((s) => s.id === "s1")?.readyToMerge).toBe(true);
+  });
+
+  it("approveEpicNext emits epic:update and advances a child", () => {
+    const repo = demoState.sessions()[0].repoPath;
+    const frames = capture(() => demoState.approveEpicNext(repo, 100));
+    expect(events(frames)).toEqual(["epic:update"]);
+    const running = demoState.epic(repo, 100)!.children.filter((c) => c.state === "running");
+    expect(running.length).toBeGreaterThan(1);
+  });
+
+  it("spawnHeld emits session:new + held:changed and grows the herd", () => {
+    const before = demoState.sessions().length;
+    const heldId = demoState.held()[0].id;
+    const frames = capture(() => demoState.spawnHeld(heldId));
+    expect(events(frames)).toEqual(["session:new", "held:changed"]);
+    expect(demoState.sessions().length).toBe(before + 1);
+    expect(demoState.held().length).toBe(0);
+  });
+
+  it("archiveSession emits session:archived and removes the session", () => {
+    const frames = capture(() => demoState.archiveSession("s1"));
+    expect(events(frames)).toEqual(["session:archived"]);
+    expect(demoState.sessions().find((s) => s.id === "s1")).toBeUndefined();
+  });
+
+  it("answerPlanQuestions emits activity and reports delivered", () => {
+    let result: { delivered: boolean } | undefined;
+    const frames = capture(() => (result = demoState.answerPlanQuestions("s2")));
+    expect(events(frames)).toEqual(["session:activity"]);
+    expect(result?.delivered).toBe(true);
+  });
+});
+
+describe("structuredClone isolation", () => {
+  it("mutating live state never leaks into the seed across resets", () => {
+    demoState.reset();
+    const cleanCount = demoState.sessions().length;
+    demoState.archiveSession("s1");
+    demoState.spawnHeld(demoState.held()[0].id);
+    demoState.reset();
+    // A fresh reset restores the exact seeded herd — no leaked mutations.
+    expect(demoState.sessions().length).toBe(cleanCount);
+    expect(demoState.sessions().find((s) => s.id === "s1")).toBeDefined();
+    expect(demoState.held().length).toBeGreaterThan(0);
+  });
+});

--- a/ui/src/lib/demo/state.test.ts
+++ b/ui/src/lib/demo/state.test.ts
@@ -191,6 +191,34 @@ describe("demoState mutators emit the correct WsEvent frames", () => {
     expect(demoState.sessions().find((s) => s.id === "rounding")?.mergingSince).not.toBeNull();
   });
 
+  it("landMerge + landRecap: a landed session gets a recap, idempotent across repeat lands", () => {
+    expect(demoState.recaps()["ogimg"]).toBeUndefined();
+    demoState.landMerge("ogimg");
+    const frames = capture(() => demoState.landRecap("ogimg"));
+    expect(events(frames)).toEqual([]); // landRecap only mutates world state; the director emits
+    const recap = demoState.recaps()["ogimg"];
+    expect(recap).toBeTruthy();
+    expect(recap?.sessionId).toBe("ogimg");
+    expect(recap?.headline).toContain("508"); // ogimg's seeded PR number
+
+    // Landing again is a no-op past the first call — same content, no duplicate/regeneration.
+    const again = demoState.landRecap("ogimg");
+    expect(again).toEqual(recap);
+    expect(demoState.recaps()["ogimg"]).toEqual(recap);
+  });
+
+  it("landRecap leaves an already-seeded recap untouched (deps has one from the seed)", () => {
+    const before = demoState.recaps()["deps"];
+    expect(before).toBeTruthy();
+    const result = demoState.landRecap("deps");
+    expect(result).toEqual(before);
+    expect(demoState.recaps()["deps"]).toEqual(before);
+  });
+
+  it("landRecap on an unknown session returns null and touches nothing", () => {
+    expect(demoState.landRecap("does-not-exist")).toBeNull();
+  });
+
   it("setReadyToMerge emits session:ready", () => {
     const frames = capture(() => demoState.setReadyToMerge("coupon", true));
     expect(events(frames)).toEqual(["session:ready"]);

--- a/ui/src/lib/demo/state.ts
+++ b/ui/src/lib/demo/state.ts
@@ -49,9 +49,12 @@ import type { DemoWorld, DemoRepoConfig } from "./types-world";
 
 // A canonical, never-mutated seed. Every `reset()` `structuredClone`s from THIS, so
 // live mutations can never leak back into the seed and a reset always restores clean.
-const SEED: DemoWorld = buildSeed();
+// `/*#__PURE__*/` so Rollup treats these module-eval calls as side-effect-free and
+// tree-shakes the whole demo tree out of the production bundle (it's referenced only
+// inside the `if (__DEMO__)` guard, which DCEs to `if (false)` in prod).
+const SEED: DemoWorld = /*#__PURE__*/ buildSeed();
 
-let world: DemoWorld = structuredClone(SEED);
+let world: DemoWorld = /*#__PURE__*/ structuredClone(SEED);
 
 // Task 6: director registers reset hook here — `reset()` invokes each so the liveness
 // engine can stop/restart its timers without state.ts importing director (no cycle).

--- a/ui/src/lib/demo/state.ts
+++ b/ui/src/lib/demo/state.ts
@@ -110,6 +110,14 @@ export const demoState = {
   projectIcons: (): ProjectIcons => world.projectIcons,
   pendingLearnings: (): Learning[] => world.pendingLearnings,
 
+  /** Merged, non-archived session ids — for the "Clear merged" confirm modal.
+   *  Matches `getMergedClearable()`'s `{ids, leftovers}` in api.ts exactly; the demo
+   *  has no real leftover subprocesses, so the count is always 0. */
+  mergedClearable: (): { ids: string[]; leftovers: number } => ({
+    ids: world.sessions.filter((s) => world.gitStates[s.id]?.state === "merged").map((s) => s.id),
+    leftovers: 0,
+  }),
+
   /** GET /api/epic — one epic by repo + parent issue number. */
   epic: (repoPath: string, parent: number): Epic | null =>
     world.epics.find((e) => e.repoPath === repoPath && e.parentIssueNumber === parent) ?? null,
@@ -273,5 +281,19 @@ export const demoState = {
     delete world.subagentStates[id];
     delete world.previewStates[id];
     emit({ event: "session:archived", data: { id } });
+  },
+
+  /** Archive every given id that's still merged (the server re-validates, same as
+   *  the real API) — clears the herd's "Merged" group. Matches `clearMerged()`'s
+   *  `{cleared, leftovers}` in api.ts; each archive emits its own `session:archived`. */
+  clearMerged(ids: string[]): { cleared: string[]; leftovers: number } {
+    const cleared: string[] = [];
+    for (const id of ids) {
+      if (world.gitStates[id]?.state === "merged" && find(id)) {
+        this.archiveSession(id);
+        cleared.push(id);
+      }
+    }
+    return { cleared, leftovers: 0 };
   },
 };

--- a/ui/src/lib/demo/state.ts
+++ b/ui/src/lib/demo/state.ts
@@ -35,10 +35,17 @@ import type {
   StarPromptStatus,
   PrStatus,
   WsEvent,
+  ActivityEntry,
+  DiffResult,
+  ScratchListing,
+  SessionUsage,
+  SlashCommand,
+  Leftover,
+  PostMergeSteps,
 } from "$lib/types";
 import { bus } from "./bus";
 import { buildSeed } from "./seed";
-import type { DemoWorld } from "./types-world";
+import type { DemoWorld, DemoRepoConfig } from "./types-world";
 
 // A canonical, never-mutated seed. Every `reset()` `structuredClone`s from THIS, so
 // live mutations can never leak back into the seed and a reset always restores clean.
@@ -85,6 +92,58 @@ export const demoState = {
   subagentStates: (): Record<string, SubagentEntry[]> => world.subagentStates,
   previewStates: (): Record<string, { previewPort: number | null; serve?: "ok" | "failed" }> =>
     world.previewStates,
+
+  // ── session-detail tabs (Task 8 sibling audit) ──────────────────────────
+  /** GET /api/sessions/done — archived sessions for the Done lens. */
+  doneSessions: (): Session[] => world.doneSessions,
+  /** GET /api/sessions/:id/activity — [] (never {}) when the session has no transcript seeded. */
+  activityEntries: (id: string): ActivityEntry[] => world.activityEntries[id] ?? [],
+  /** GET /api/sessions/:id/diff — a valid empty DiffResult (never {}) for an unseeded session. */
+  diff: (id: string): DiffResult =>
+    world.diffs[id] ?? {
+      base: "main",
+      baseRef: "origin/main",
+      head: find(id)?.branch ?? null,
+      fetchFailed: false,
+      truncated: false,
+      files: [],
+    },
+  /** GET /api/sessions/:id/scratchpad (root) — mirrors the real server's synthetic empty
+   *  listing for a session whose scratchpad root doesn't exist yet. */
+  scratchpadRoot: (id: string): ScratchListing =>
+    world.scratchpad[id] ?? { path: "", parent: null, entries: [] },
+  /** GET /api/sessions/:id/usage — a zeroed (never {}) record for an unseeded session. */
+  sessionUsage: (id: string): SessionUsage =>
+    world.sessionUsage[id] ?? {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
+      messageCount: 0,
+      lastActivity: null,
+      byModel: {},
+    },
+  /** GET /api/sessions/:id/leftovers — the demo never leaves real subprocesses running. */
+  leftovers: (): Leftover[] => [],
+  /** GET /api/sessions/:id/queue — the seeded queue if this session has one, else the same
+   *  empty-but-valid record the real server returns for a session with no queue yet. */
+  sessionBuildQueue: (id: string): BuildQueue =>
+    world.buildQueues[id] ?? { sessionId: id, approved: false, steps: [] },
+  /** GET /api/repo-config?repo= — automation flags; `{}` for an unrecognized repoPath (the
+   *  UI treats a missing field as its documented default, same as an unconfigured repo). */
+  repoConfig: (repoPath: string): DemoRepoConfig | Record<string, never> =>
+    world.repoConfig[repoPath] ?? {},
+  /** GET /api/commands?repo= — installed slash commands, [] for an unrecognized repoPath. */
+  commands: (repoPath: string): { commands: SlashCommand[] } => ({
+    commands: world.slashCommands[repoPath] ?? [],
+  }),
+  /** GET /api/todo?repo= — {exists:false} for an unrecognized repoPath. */
+  todo: (repoPath: string): { exists: boolean; content: string } =>
+    world.todo[repoPath] ?? { exists: false, content: "" },
+  /** GET /api/manual-steps/outstanding (Owed lens) — only still-outstanding records. */
+  outstandingManualSteps: (): PostMergeSteps[] =>
+    world.postMergeSteps.filter((r) => r.clearedAt == null),
 
   usageLimits: (): UsageLimitsResponse => world.usage,
   update: (): UpdateStatus => world.update,
@@ -332,6 +391,27 @@ export const demoState = {
     delete world.subagentStates[id];
     delete world.previewStates[id];
     emit({ event: "session:archived", data: { id } });
+  },
+
+  /** Tick / un-tick one materialized post-merge step (Owed lens checkbox). Returns the
+   *  updated record, or null if the session/step isn't found (mirrors the real 404). */
+  setManualStepDone(sessionId: string, stepId: string, done: boolean): PostMergeSteps | null {
+    const rec = world.postMergeSteps.find((r) => r.sessionId === sessionId);
+    const step = rec?.steps.find((s) => s.id === stepId);
+    if (!rec || !step) return null;
+    step.doneAt = done ? Date.now() : null;
+    rec.updatedAt = Date.now();
+    return rec;
+  },
+
+  /** Dismiss a whole post-merge record (Owed lens "clear" button) — marks it cleared so
+   *  it drops out of `outstandingManualSteps()`. Returns the updated record. */
+  dismissManualSteps(sessionId: string): PostMergeSteps | null {
+    const rec = world.postMergeSteps.find((r) => r.sessionId === sessionId);
+    if (!rec) return null;
+    rec.clearedAt = Date.now();
+    rec.updatedAt = rec.clearedAt;
+    return rec;
   },
 
   /** Archive every given id that's still merged (the server re-validates, same as

--- a/ui/src/lib/demo/state.ts
+++ b/ui/src/lib/demo/state.ts
@@ -222,6 +222,57 @@ export const demoState = {
     return git ?? { state: "open", checks: "success", deployConfigured: false };
   },
 
+  /** Land a merging PR (director follow-up to {@link mergePr}): flip git → merged,
+   *  clear the merging latch, mark the session done, and confirm the train landed. */
+  landMerge(id: string): void {
+    const s = find(id);
+    const git = world.gitStates[id];
+    if (git) git.state = "merged";
+    if (s) {
+      s.mergingSince = null;
+      s.mergingTrainId = null;
+      s.status = "done";
+      s.lastState = "done";
+      s.readyToMerge = true;
+    }
+    if (git) emit({ event: "session:git", data: { id, git } });
+    emit({ event: "session:status", data: { id, status: "done" } });
+    if (s) emit({ event: "mergetrain:landed", data: { repoPath: s.repoPath } });
+  },
+
+  /** Spawn a session for the epic child the director just advanced to "running"
+   *  (director follow-up to {@link approveEpicNext}). Emits `session:new`. */
+  spawnEpicChild(repoPath: string, parent: number): Session | null {
+    const epic = world.epics.find((e) => e.repoPath === repoPath && e.parentIssueNumber === parent);
+    if (!epic) return null;
+    const child = epic.children.find((c) => c.state === "running" && c.sessionId === null);
+    if (!child) return null;
+    const sid = `epic-${child.number}`;
+    const session: Session = {
+      ...world.sessions[0],
+      id: sid,
+      desig: `TASK-${child.number}`,
+      name: child.title,
+      prompt: child.body,
+      repoPath,
+      branch: `shepherd/epic-${child.number}`,
+      worktreePath: `${repoPath}/.worktrees/${sid}`,
+      status: "running",
+      lastState: "working",
+      readyToMerge: false,
+      mergingSince: null,
+      mergingTrainId: null,
+      autopilotEnabled: null,
+      planPhase: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    child.sessionId = sid;
+    world.sessions = [...world.sessions, session];
+    emit({ event: "session:new", data: session });
+    return session;
+  },
+
   /** Set the operator "ready to merge / parked" flag. */
   setReadyToMerge(id: string, ready: boolean): void {
     const s = find(id);

--- a/ui/src/lib/demo/state.ts
+++ b/ui/src/lib/demo/state.ts
@@ -302,6 +302,40 @@ export const demoState = {
     if (s) emit({ event: "mergetrain:landed", data: { repoPath: s.repoPath } });
   },
 
+  /** Generate + insert the "recap appears" payoff for a session that just landed
+   *  (director follow-up to {@link landMerge}, emits `session:recap`). Idempotent: a
+   *  session that already has a recap (seeded, or from a prior land) keeps it
+   *  unchanged rather than growing/duplicating — landing the same id twice is a
+   *  no-op past the first call. Returns null only if the session no longer exists. */
+  landRecap(id: string): Recap | null {
+    const s = find(id);
+    if (!s) return null;
+    const existing = world.recaps[id];
+    if (existing) return existing;
+    const git = world.gitStates[id];
+    const title = git?.title ?? s.name;
+    const prNumber = git?.number ?? null;
+    const now = Date.now();
+    const recap: Recap = {
+      sessionId: id,
+      state: "ready",
+      headSha: git?.headSha ?? "0000000",
+      verdict: "ready",
+      headline: prNumber ? `${title} — merged (PR #${prNumber})` : `${title} — merged`,
+      body: `Landed on the default branch${prNumber ? ` via PR #${prNumber}` : ""}. ${s.prompt}`.trim(),
+      openItems: [],
+      changedFiles: [],
+      spawnSessionId: `recap-${id}`,
+      cwd: s.worktreePath,
+      model: s.model,
+      spawnedAt: now - 2 * 60_000,
+      generatedAt: now,
+      updatedAt: now,
+    };
+    world.recaps = { ...world.recaps, [id]: recap };
+    return recap;
+  },
+
   /** Spawn a session for the epic child the director just advanced to "running"
    *  (director follow-up to {@link approveEpicNext}). Emits `session:new`. */
   spawnEpicChild(repoPath: string, parent: number): Session | null {

--- a/ui/src/lib/demo/state.ts
+++ b/ui/src/lib/demo/state.ts
@@ -1,0 +1,277 @@
+// The single mutable in-memory demo world. `reset()` deep-clones a canonical seed
+// into live state; getters return exactly what each `api.ts` caller consumes;
+// mutators MUTATE the world and `bus.emit(...)` the matching typed `WsEvent`(s) so
+// the live UI updates over the fake `/events` socket.
+
+import type {
+  Session,
+  GitState,
+  SessionActivity,
+  SubagentEntry,
+  HoldReason,
+  Epic,
+  EpicSummary,
+  CompletedEpic,
+  DrainStatus,
+  AutoMergeStatus,
+  BuildQueue,
+  Recap,
+  ReviewVerdict,
+  PlanGate,
+  HerdDigest,
+  UpNextSnapshot,
+  BacklogPayload,
+  Settings,
+  PluginInfo,
+  DiagnosticsSnapshot,
+  HeldTask,
+  Steer,
+  ProjectIcons,
+  Learning,
+  UsageLimitsResponse,
+  UpdateStatus,
+  HerdrUpdateStatus,
+  CodexUpdateStatus,
+  StarPromptStatus,
+  PrStatus,
+  WsEvent,
+} from "$lib/types";
+import { bus } from "./bus";
+import { buildSeed } from "./seed";
+import type { DemoWorld } from "./types-world";
+
+// A canonical, never-mutated seed. Every `reset()` `structuredClone`s from THIS, so
+// live mutations can never leak back into the seed and a reset always restores clean.
+const SEED: DemoWorld = buildSeed();
+
+let world: DemoWorld = structuredClone(SEED);
+
+// Task 6: director registers reset hook here — `reset()` invokes each so the liveness
+// engine can stop/restart its timers without state.ts importing director (no cycle).
+const resetHooks: Array<() => void> = [];
+
+function emit(ev: WsEvent): void {
+  bus.emit(ev);
+}
+
+function find(id: string): Session | undefined {
+  return world.sessions.find((s) => s.id === id);
+}
+
+export const demoState = {
+  /** Deep-clone the canonical seed into live state, then fire reset hooks. */
+  reset(): void {
+    world = structuredClone(SEED);
+    for (const cb of [...resetHooks]) cb();
+  },
+
+  /** Register a callback fired after every `reset()` (director wiring, Task 6). */
+  onReset(cb: () => void): () => void {
+    resetHooks.push(cb);
+    return () => {
+      const i = resetHooks.indexOf(cb);
+      if (i >= 0) resetHooks.splice(i, 1);
+    };
+  },
+
+  // ── getters (shaped to what api.ts callers expect) ───────────────────────
+  sessions: (): Session[] => world.sessions,
+  gitStates: (): Record<string, GitState> => world.gitStates,
+  gitState: (id: string): GitState | null => world.gitStates[id] ?? null,
+  activityStates: (): Record<string, SessionActivity> => world.activityStates,
+  claudeAliveStates: (): Record<string, boolean> => world.claudeAliveStates,
+  workingBlockedStates: (): Record<string, boolean> => world.workingBlockedStates,
+  holdStates: (): Record<string, HoldReason> => world.holdStates,
+  subagentStates: (): Record<string, SubagentEntry[]> => world.subagentStates,
+  previewStates: (): Record<string, { previewPort: number | null; serve?: "ok" | "failed" }> =>
+    world.previewStates,
+
+  usageLimits: (): UsageLimitsResponse => world.usage,
+  update: (): UpdateStatus => world.update,
+  herdrUpdate: (): HerdrUpdateStatus => world.herdrUpdate,
+  codexUpdate: (): CodexUpdateStatus => world.codexUpdate,
+  starPrompt: (): StarPromptStatus => world.starPrompt,
+  drain: (): DrainStatus[] => world.drain,
+  autoMerge: (): AutoMergeStatus[] => world.autoMerge,
+
+  completedEpics: (): CompletedEpic[] => world.completedEpics,
+  settings: (): Settings => world.settings,
+  plugins: (): PluginInfo[] => world.plugins,
+  diagnostics: (): DiagnosticsSnapshot => world.diagnostics,
+  backlog: (): BacklogPayload => world.backlog,
+  buildQueues: (): Record<string, BuildQueue> => world.buildQueues,
+  held: (): HeldTask[] => world.held,
+  recaps: (): Record<string, Recap> => world.recaps,
+  reviews: (): Record<string, ReviewVerdict> => world.reviews,
+  planGates: (): Record<string, PlanGate> => world.planGates,
+  herdDigest: (): HerdDigest | null => world.herdDigest,
+  upNext: (): UpNextSnapshot | null => world.upNext,
+  steers: (): Steer[] => world.steers,
+  projectIcons: (): ProjectIcons => world.projectIcons,
+  pendingLearnings: (): Learning[] => world.pendingLearnings,
+
+  /** GET /api/epic — one epic by repo + parent issue number. */
+  epic: (repoPath: string, parent: number): Epic | null =>
+    world.epics.find((e) => e.repoPath === repoPath && e.parentIssueNumber === parent) ?? null,
+
+  /** GET /api/epics — per-repo summaries + the set of child issue numbers. */
+  epicSummaries: (repoPath: string): { epics: EpicSummary[]; subIssues: number[] } => {
+    const epics = world.epics.filter((e) => e.repoPath === repoPath);
+    const subIssues = epics.flatMap((e) => e.children.map((c) => c.number));
+    return {
+      epics: epics.map((e) => ({
+        parentIssueNumber: e.parentIssueNumber,
+        parentTitle: e.parentTitle,
+        total: e.children.length,
+        merged: e.children.filter((c) => c.state === "merged").length,
+        status: e.run.status,
+        source: e.source,
+      })),
+      subIssues,
+    };
+  },
+
+  // ── mutators (called by the router; each emits WsEvent(s)) ───────────────
+
+  /** Steer/reply: the agent picks the message up and resumes working. */
+  reply(id: string, text: string): void {
+    const s = find(id);
+    if (!s) return;
+    const activity: SessionActivity = {
+      lastActivityTs: Date.now(),
+      summary: text.slice(0, 60),
+      recentTs: [...(world.activityStates[id]?.recentTs ?? []), Date.now()],
+      recentErrTs: world.activityStates[id]?.recentErrTs ?? [],
+    };
+    world.activityStates[id] = activity;
+    s.status = "running";
+    s.lastState = "working";
+    delete world.holdStates[id];
+    emit({ event: "session:activity", data: { id, activity } });
+    emit({ event: "session:hold", data: { id, hold: null } });
+    emit({ event: "session:status", data: { id, status: "running" } });
+  },
+
+  /** Toggle a session's autopilot override. */
+  setAutopilot(id: string, enabled: boolean | null): void {
+    const s = find(id);
+    if (!s) return;
+    s.autopilotEnabled = enabled;
+    emit({
+      event: "session:autopilot",
+      data: {
+        id,
+        paused: s.autopilotPaused,
+        complete: s.autopilotComplete,
+        question: s.autopilotQuestion,
+        enabled,
+      },
+    });
+  },
+
+  /** Trigger an on-demand plan review — the reviewing latch lights up. */
+  reviewPlan(id: string): void {
+    emit({ event: "session:plangate-reviewing", data: { id, reviewing: true } });
+  },
+
+  /** Release an approved plan gate → the agent flips from planning to executing. */
+  releasePlanGate(id: string): boolean {
+    const s = find(id);
+    const gate = world.planGates[id];
+    if (!s || !gate?.approved) return false;
+    s.planPhase = "executing";
+    s.status = "running";
+    delete world.holdStates[id];
+    emit({ event: "session:plangate", data: { id, planPhase: "executing" } });
+    emit({ event: "session:hold", data: { id, hold: null } });
+    emit({ event: "session:status", data: { id, status: "running" } });
+    return true;
+  },
+
+  /** Deliver operator answers to a plan's question form (planning agent steer). */
+  answerPlanQuestions(id: string): { delivered: boolean } {
+    const activity: SessionActivity = {
+      lastActivityTs: Date.now(),
+      summary: "answered plan questions",
+      recentTs: [...(world.activityStates[id]?.recentTs ?? []), Date.now()],
+      recentErrTs: world.activityStates[id]?.recentErrTs ?? [],
+    };
+    world.activityStates[id] = activity;
+    emit({ event: "session:activity", data: { id, activity } });
+    return { delivered: true };
+  },
+
+  /** Mark the session's PR as merging (director later lands it + posts a recap). */
+  mergePr(id: string): PrStatus {
+    const s = find(id);
+    const git = world.gitStates[id];
+    const since = Date.now();
+    if (s) {
+      s.mergingSince = since;
+      s.mergingTrainId = id;
+    }
+    emit({ event: "session:merging", data: { id, since, trainId: id } });
+    return git ?? { state: "open", checks: "success", deployConfigured: false };
+  },
+
+  /** Set the operator "ready to merge / parked" flag. */
+  setReadyToMerge(id: string, ready: boolean): void {
+    const s = find(id);
+    if (!s) return;
+    s.readyToMerge = ready;
+    emit({ event: "session:ready", data: { id, ready } });
+  },
+
+  /** Approve the epic's next child so it spawns — flips the first eligible child to running. */
+  approveEpicNext(repoPath: string, parent: number): Epic | null {
+    const epic = world.epics.find((e) => e.repoPath === repoPath && e.parentIssueNumber === parent);
+    if (!epic) return null;
+    const next = epic.children.find((c) => c.state === "blocked" || c.state === "ready");
+    if (next) next.state = "running";
+    emit({ event: "epic:update", data: epic });
+    return epic;
+  },
+
+  /** Spawn a held task → a fresh session joins the herd. */
+  spawnHeld(id: string): Session | null {
+    const idx = world.held.findIndex((h) => h.id === id);
+    if (idx < 0) return null;
+    const [task] = world.held.splice(idx, 1);
+    const sid = `spawned-${id}`;
+    const session: Session = {
+      ...world.sessions[0],
+      id: sid,
+      desig: "TASK-NEW",
+      name: `held-${id}`,
+      prompt: task.input.prompt,
+      repoPath: task.input.repoPath,
+      baseBranch: task.input.baseBranch,
+      branch: `shepherd/held-${id}`,
+      worktreePath: `${task.input.repoPath}/.worktrees/${sid}`,
+      status: "running",
+      lastState: "running",
+      readyToMerge: false,
+      mergingSince: null,
+      mergingTrainId: null,
+      autopilotEnabled: task.input.autopilotEnabled ?? null,
+      planPhase: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    world.sessions = [...world.sessions, session];
+    emit({ event: "session:new", data: session });
+    emit({ event: "held:changed", data: { count: world.held.length } });
+    return session;
+  },
+
+  /** Archive a session — it drops out of the live herd. */
+  archiveSession(id: string): void {
+    world.sessions = world.sessions.filter((s) => s.id !== id);
+    delete world.gitStates[id];
+    delete world.activityStates[id];
+    delete world.holdStates[id];
+    delete world.subagentStates[id];
+    delete world.previewStates[id];
+    emit({ event: "session:archived", data: { id } });
+  },
+};

--- a/ui/src/lib/demo/types-world.ts
+++ b/ui/src/lib/demo/types-world.ts
@@ -32,7 +32,21 @@ import type {
   HerdrUpdateStatus,
   CodexUpdateStatus,
   StarPromptStatus,
+  ActivityEntry,
+  DiffResult,
+  ScratchListing,
+  SessionUsage,
+  SlashCommand,
+  RepoConfig,
+  PostMergeSteps,
 } from "$lib/types";
+
+/** Mirrors `RepoConfigResponse` from `$lib/api` (`RepoConfig` + optimistic-automation
+ *  fields) without importing api.ts from the seed layer — keeps seed.ts import-clean. */
+export type DemoRepoConfig = RepoConfig & {
+  automationConfirmed?: boolean;
+  automationRowExists?: boolean;
+};
 
 /** The complete seeded demo world — one dataset per bootstrap/lens GET. */
 export interface DemoWorld {
@@ -45,6 +59,26 @@ export interface DemoWorld {
   holdStates: Record<string, HoldReason>;
   subagentStates: Record<string, SubagentEntry[]>;
   previewStates: Record<string, { previewPort: number | null; serve?: "ok" | "failed" }>;
+
+  // ── session-detail tabs (per-session GETs, Task 8 sibling audit) ─────────
+  /** GET /api/sessions/done (Done lens) — archived sessions, distinct from `sessions`. */
+  doneSessions: Session[];
+  /** GET /api/sessions/:id/activity (Activity tab). */
+  activityEntries: Record<string, ActivityEntry[]>;
+  /** GET /api/sessions/:id/diff (Diff tab + Activity tab's file-tree section). */
+  diffs: Record<string, DiffResult>;
+  /** GET /api/sessions/:id/scratchpad (Files tab, root listing only). */
+  scratchpad: Record<string, ScratchListing>;
+  /** GET /api/sessions/:id/usage (per-session token usage badge). */
+  sessionUsage: Record<string, SessionUsage>;
+  /** GET /api/repo-config?repo= (automation flags — gates the Build Queue panel + pill). */
+  repoConfig: Record<string, DemoRepoConfig>;
+  /** GET /api/commands?repo= (slash-command link provider). */
+  slashCommands: Record<string, SlashCommand[]>;
+  /** GET /api/todo?repo= (To-Do tab gate). */
+  todo: Record<string, { exists: boolean; content: string }>;
+  /** GET /api/manual-steps/outstanding (Owed lens) — durable post-merge step records. */
+  postMergeSteps: PostMergeSteps[];
 
   // ── ambient status ─────────────────────────────────────────────────────
   usage: UsageLimitsResponse;

--- a/ui/src/lib/demo/types-world.ts
+++ b/ui/src/lib/demo/types-world.ts
@@ -1,0 +1,75 @@
+// The single object graph the demo world holds. Every field is typed against the
+// real `$lib/types` domain shapes — NEVER a parallel shape — so `tsc` validates the
+// seed against exactly what the live UI consumes. `state.ts` deep-clones one of
+// these on every `reset()`; `seed.ts` builds a fresh, internally-consistent one.
+
+import type {
+  Session,
+  GitState,
+  SessionActivity,
+  SubagentEntry,
+  HoldReason,
+  Epic,
+  CompletedEpic,
+  DrainStatus,
+  AutoMergeStatus,
+  BuildQueue,
+  Recap,
+  ReviewVerdict,
+  PlanGate,
+  HerdDigest,
+  UpNextSnapshot,
+  BacklogPayload,
+  Settings,
+  PluginInfo,
+  DiagnosticsSnapshot,
+  HeldTask,
+  Steer,
+  ProjectIcons,
+  Learning,
+  UsageLimitsResponse,
+  UpdateStatus,
+  HerdrUpdateStatus,
+  CodexUpdateStatus,
+  StarPromptStatus,
+} from "$lib/types";
+
+/** The complete seeded demo world — one dataset per bootstrap/lens GET. */
+export interface DemoWorld {
+  // ── core herd ──────────────────────────────────────────────────────────
+  sessions: Session[];
+  gitStates: Record<string, GitState>;
+  activityStates: Record<string, SessionActivity>;
+  claudeAliveStates: Record<string, boolean>;
+  workingBlockedStates: Record<string, boolean>;
+  holdStates: Record<string, HoldReason>;
+  subagentStates: Record<string, SubagentEntry[]>;
+  previewStates: Record<string, { previewPort: number | null; serve?: "ok" | "failed" }>;
+
+  // ── ambient status ─────────────────────────────────────────────────────
+  usage: UsageLimitsResponse;
+  update: UpdateStatus;
+  herdrUpdate: HerdrUpdateStatus;
+  codexUpdate: CodexUpdateStatus;
+  starPrompt: StarPromptStatus;
+  drain: DrainStatus[];
+  autoMerge: AutoMergeStatus[];
+
+  // ── lenses / drawers ───────────────────────────────────────────────────
+  completedEpics: CompletedEpic[];
+  epics: Epic[];
+  settings: Settings;
+  plugins: PluginInfo[];
+  diagnostics: DiagnosticsSnapshot;
+  backlog: BacklogPayload;
+  buildQueues: Record<string, BuildQueue>;
+  held: HeldTask[];
+  recaps: Record<string, Recap>;
+  reviews: Record<string, ReviewVerdict>;
+  planGates: Record<string, PlanGate>;
+  herdDigest: HerdDigest | null;
+  upNext: UpNextSnapshot | null;
+  steers: Steer[];
+  projectIcons: ProjectIcons;
+  pendingLearnings: Learning[];
+}

--- a/ui/src/lib/push.ts
+++ b/ui/src/lib/push.ts
@@ -80,6 +80,9 @@ function supported(): boolean {
 
 /** Register the service worker (idempotent). Safe to call on every mount. */
 export async function registerSW(): Promise<void> {
+  // Demo mode never registers a SW — a stale cached demo build must not be served
+  // to a returning visitor (install.ts also unregisters any existing SW).
+  if (__DEMO__) return;
   if (!supported()) return;
   try {
     await navigator.serviceWorker.register("/sw.js", { scope: "/" });
@@ -96,6 +99,8 @@ export async function pushState(): Promise<PushStatus> {
 }
 
 export async function enablePush(): Promise<boolean> {
+  // Demo mode has no push backend and must not touch serviceWorker.ready.
+  if (__DEMO__) return false;
   if (!supported()) return false;
   const perm =
     Notification.permission === "granted" ? "granted" : await Notification.requestPermission();

--- a/ui/src/lib/push.ts
+++ b/ui/src/lib/push.ts
@@ -92,6 +92,8 @@ export async function registerSW(): Promise<void> {
 }
 
 export async function pushState(): Promise<PushStatus> {
+  // Demo mode never registers a SW and must not touch serviceWorker.ready.
+  if (__DEMO__) return { supported: false, permission: "unsupported", subscribed: false };
   if (!supported()) return { supported: false, permission: "unsupported", subscribed: false };
   const reg = await navigator.serviceWorker.ready;
   const sub = await reg.pushManager.getSubscription();
@@ -124,6 +126,8 @@ export async function enablePush(): Promise<boolean> {
 }
 
 export async function disablePush(): Promise<void> {
+  // Demo mode has no push backend and must not touch serviceWorker.ready.
+  if (__DEMO__) return;
   if (!supported()) return;
   const reg = await navigator.serviceWorker.ready;
   const sub = await reg.pushManager.getSubscription();

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -6,6 +6,10 @@
   import { auth } from "$lib/auth.svelte";
   import { getMe } from "$lib/api";
   import Login from "$lib/components/Login.svelte";
+  // Demo-only marketing chrome (Task 7). __DEMO__ is a compile-time constant
+  // (vite `define`), so the `{#if __DEMO__}` guard below dead-code-eliminates
+  // both this import and the component from a production build.
+  import DemoRibbon from "$lib/demo/DemoRibbon.svelte";
 
   let { children } = $props();
 
@@ -29,6 +33,10 @@
   <Login />
 {:else if auth.checked}
   {@render children()}
+{/if}
+
+{#if __DEMO__}
+  <DemoRibbon />
 {/if}
 
 <style>

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1328,7 +1328,10 @@
         // seeding lastSeenVersion below would otherwise make this gate false on
         // the same load. markSeen("onboarding") on dismiss keeps it from
         // reappearing on later loads (lastSeenVersion is no longer null then).
-        if (!featureDiscovery.isSeen("onboarding")) showOnboarding = true;
+        // The demo is a hosted marketing build with no local environment, so the
+        // "we checked your environment" onboarding checklist is meaningless there —
+        // skip it so visitors land straight in the seeded herd.
+        if (!__DEMO__ && !featureDiscovery.isSeen("onboarding")) showOnboarding = true;
         // Fresh install: seed baseline so future updates can diff against it.
         featureDiscovery.lastSeenVersion = version;
       } else {

--- a/ui/svelte.config.js
+++ b/ui/svelte.config.js
@@ -3,7 +3,7 @@ import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 
 // Demo builds (SHEPHERD_DEMO=1) write to a separate output dir so `build:demo`
 // can never clobber the prod `build/` bundle.
-const outDir = process.env.SHEPHERD_DEMO ? "build-demo" : "build";
+const outDir = process.env.SHEPHERD_DEMO === "1" ? "build-demo" : "build";
 
 export default {
   preprocess: vitePreprocess(),

--- a/ui/svelte.config.js
+++ b/ui/svelte.config.js
@@ -1,6 +1,11 @@
 import adapter from "@sveltejs/adapter-static";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+
+// Demo builds (SHEPHERD_DEMO=1) write to a separate output dir so `build:demo`
+// can never clobber the prod `build/` bundle.
+const outDir = process.env.SHEPHERD_DEMO ? "build-demo" : "build";
+
 export default {
   preprocess: vitePreprocess(),
-  kit: { adapter: adapter({ fallback: "index.html" }) },
+  kit: { adapter: adapter({ pages: outDir, assets: outDir, fallback: "index.html" }) },
 };

--- a/ui/vercel.json
+++ b/ui/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "buildCommand": "bun run build:demo",
+  "outputDirectory": "build-demo",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
     __GIT_SHA__: JSON.stringify(gitSha()),
     __APP_VERSION__: JSON.stringify(appVersion()),
     __RELEASE_DATES__: JSON.stringify(releaseDates()),
+    __DEMO__: JSON.stringify(process.env.SHEPHERD_DEMO === "1"),
   },
   plugins: [
     paraglideVitePlugin({


### PR DESCRIPTION
## Marketing demo mode — a live, hostless Shepherd

A fully interactive demo build of the real Shepherd UI, backed entirely by an **in-browser fake backend**. It deploys as a pure static bundle with **no herdr, no server, no GitHub, no subscription** — a visitor lands in a pre-seeded herd and can explore freely; the agent terminals replay authored transcripts, and core interactions produce plausible local effects.

`[no-feature-entry]` — this is a separate marketing build, not an in-product feature for existing users.

### How it works

The UI reaches its backend through exactly two browser primitives — `fetch("/api/…")` and `new WebSocket(…)`. A build-time flag `__DEMO__` (Vite `define`) lets a small `ui/src/lib/demo/` "FakeHerdr" **monkeypatch both globals**, so **none of the 162 `api.ts` functions, the stores, or `pty.ts` change**:

- **`install.ts`** — patches `globalThis.fetch` (`/api/*` → router) and `globalThis.WebSocket` (`/events` → event stream, `/pty/:id` → terminal), and neutralises the PWA service worker. The fake WebSocket matches the real callers exactly (static + instance `OPEN/CLOSING/CLOSED`, writable `binaryType`, async open).
- **`state.ts` + `seed.ts`** — a seeded, mutable world (7 sessions across every state, epic "Checkout v2", both repos, usage, drain, recaps, lenses…), served through **`router.ts`** with exact `api.ts` response shapes (rich, never empty on showcased surfaces).
- **`bus.ts` / `events.ts`** — typed `WsEvent` frames (tsc-validated against `store.apply`) over a fake `/events` socket.
- **`pty/`** — a byte-stream **replay engine** + authored terminal transcripts (the hero session types out real-looking edits/tests).
- **`director.ts`** — ambient liveness (working sessions keep emitting) + mutation reactions (steer → reply, merge → landed → recap, plan-gate → executing, epic advance → spawn, spawn-held → drive), all reset-safe with no leaked timers.
- **`DemoRibbon.svelte`** — a subtle persistent "● Live demo · Get Shepherd →" ribbon (i18n EN+DE, design-system tokens); "Reset demo" = reload (state is in-memory).

**Production is untouched:** every demo import sits behind `if (__DEMO__)`; normal `bun run build` **dead-code-eliminates the whole tree** (verified: the prod bundle contains zero demo seed/transcript/install strings). Only `bun run build:demo` includes it, emitting to a separate `build-demo/` output dir.

### Verification

- **Prod DCE proven**: `bun run build` → grep confirms no demo code in `build/`.
- **Headless browser walkthrough** (Playwright) of the demo build: **0 console/page errors** across boot, all lenses (Next/Ready/Done/Rundown/Owed/All), all session-detail tabs, and the done-session recap; the xterm terminal live-replays the authored transcript; the herd renders fully; auto-authenticated (no login wall).
- **Tests**: ui suite `2445/2445`, demo suite `101/101`, root `5531 pass / 0 fail`.
- **Gates**: `check`, `check:i18n` (parity), branch-hygiene, feature-catalog, glossary, and `fallow audit` all green.

### Deploy

`ui/vercel.json` configures the demo build (`build:demo` → `build-demo/`, SPA rewrite), scoped to `ui/` per the repo's per-project convention. See manual steps below to wire up the Vercel project.

### Known follow-ups (non-blocking, from final review)

- Editing/approving the demo build-queue silently no-ops (`putBuildQueue`/`approveBuildQueue` hit the generic stub).
- `director` steer reaction keys on any external `session:activity` (off-narrative terminal lines for `answerPlanQuestions`).
- Transcript header shows "autopilot" instead of the model name for two autopilot sessions.
- Ribbon toggle could add `aria-controls` + focus management on reveal.
- Optional CI hardening: grep `build/` for demo strings to guard the DCE invariant against future top-level side effects.

```shepherd:manual-steps
- [ ] POST-MERGE: Create a Vercel project pointing at this repo with Root Directory = `ui` (the demo build config lives in `ui/vercel.json`); every push then auto-builds `build:demo` and serves the static demo.
- [ ] POST-MERGE: (optional) Point a marketing subdomain (e.g. `demo.shepherd.run`) at that Vercel project.
- [ ] POST-MERGE: (optional) Update the ribbon CTA target `CTA_URL` in `ui/src/lib/demo/DemoRibbon.svelte` if the marketing destination differs from `https://shepherd.run`.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
