### PR TITLE
[codex] fix update modal scrollbars

### DIFF
--- a/ui/src/lib/components/CodexUpdateModal.browser.test.ts
+++ b/ui/src/lib/components/CodexUpdateModal.browser.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import type { CodexUpdateStatus } from "$lib/types";
+
+vi.mock("$lib/api", async (orig) => ({
+  ...((await orig()) as object),
+  applyCodexUpdate: vi.fn(() => new Promise(() => {})),
+}));
+
+import CodexUpdateModal from "./CodexUpdateModal.svelte";
+
+const update: CodexUpdateStatus = {
+  current: "0.142.4",
+  latest: "0.142.5",
+  updateAvailable: true,
+  notes: null,
+  checkedAt: 0,
+};
+
+afterEach(async () => {
+  document.body.innerHTML = "";
+  await page.viewport(1280, 900);
+});
+
+describe("CodexUpdateModal", () => {
+  it("keeps modal chrome from creating stray scrollbars with an active update log", async () => {
+    await page.viewport(800, 600);
+
+    render(CodexUpdateModal, {
+      props: {
+        update,
+        log: [
+          "=== codex-update 2026-07-01T07:10:00Z 0.142.4 -> 0.142.5 ===",
+          ">>> codex-update: running npm install -g @openai/codex",
+          "changed 2 packages in 5s",
+          "Reshimming mise 24.14.1...",
+          ">>> codex-update: npm install exited rc=0",
+        ],
+      },
+    });
+
+    document.querySelector<HTMLButtonElement>(".run")?.click();
+    await vi.waitFor(() => expect(document.querySelector(".log")).not.toBeNull());
+
+    const card = document.querySelector<HTMLElement>(".card");
+    expect(card).not.toBeNull();
+    expect(card!.scrollWidth, "dialog should not have horizontal overflow").toBeLessThanOrEqual(
+      card!.clientWidth,
+    );
+    expect(
+      card!.scrollHeight,
+      "dialog should not need its own vertical scrollbar",
+    ).toBeLessThanOrEqual(card!.clientHeight + 1);
+  });
+});

--- a/ui/src/lib/components/CodexUpdateModal.svelte
+++ b/ui/src/lib/components/CodexUpdateModal.svelte
@@ -144,11 +144,13 @@
   }
   .card {
     position: relative;
+    box-sizing: border-box;
     width: min(520px, 100%);
     max-height: 80dvh;
     display: flex;
     flex-direction: column;
     gap: 14px;
+    overflow-x: clip;
     overflow-y: auto;
     background: var(--color-panel);
     border: 1px solid var(--color-line-bright);
@@ -164,14 +166,14 @@
     border: 1px solid var(--color-line-bright);
   }
   .bracket::before {
-    top: -1px;
-    left: -1px;
+    top: 0;
+    left: 0;
     border-right: 0;
     border-bottom: 0;
   }
   .bracket::after {
-    bottom: -1px;
-    right: -1px;
+    bottom: 0;
+    right: 0;
     border-left: 0;
     border-top: 0;
   }
@@ -237,7 +239,9 @@
     margin-bottom: -8px;
   }
   .log {
+    flex: 1 1 96px;
     margin: 0;
+    min-height: 96px;
     max-height: 180px;
     overflow-y: auto;
     border: 1px solid var(--color-line);

--- a/ui/src/lib/components/HerdrUpdateModal.browser.test.ts
+++ b/ui/src/lib/components/HerdrUpdateModal.browser.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import type { HerdrUpdateStatus } from "$lib/types";
+
+vi.mock("$lib/api", async (orig) => ({
+  ...((await orig()) as object),
+  applyHerdrUpdate: vi.fn(() => new Promise(() => {})),
+}));
+
+import HerdrUpdateModal from "./HerdrUpdateModal.svelte";
+
+const update: HerdrUpdateStatus = {
+  current: "0.6.9",
+  latest: "0.6.10",
+  updateAvailable: true,
+  notes: null,
+  checkedAt: 0,
+};
+
+afterEach(async () => {
+  document.body.innerHTML = "";
+  await page.viewport(1280, 900);
+});
+
+describe("HerdrUpdateModal", () => {
+  it("keeps modal chrome from creating stray scrollbars with an active update log", async () => {
+    await page.viewport(800, 600);
+
+    render(HerdrUpdateModal, {
+      props: {
+        update,
+        log: [
+          "=== herdr-update 2026-07-01T07:10:00Z 0.6.9 -> 0.6.10 ===",
+          ">>> herdr-update: downloading release asset",
+          "stopping live panes",
+          "installing herdr 0.6.10",
+          ">>> herdr-update: install still running",
+        ],
+      },
+    });
+
+    document.querySelector<HTMLButtonElement>(".run")?.click();
+    await vi.waitFor(() => expect(document.querySelector(".log")).not.toBeNull());
+
+    const card = document.querySelector<HTMLElement>(".card");
+    expect(card).not.toBeNull();
+    expect(card!.scrollWidth, "dialog should not have horizontal overflow").toBeLessThanOrEqual(
+      card!.clientWidth,
+    );
+    expect(
+      card!.scrollHeight,
+      "dialog should not need its own vertical scrollbar",
+    ).toBeLessThanOrEqual(card!.clientHeight + 1);
+  });
+});

--- a/ui/src/lib/components/HerdrUpdateModal.svelte
+++ b/ui/src/lib/components/HerdrUpdateModal.svelte
@@ -240,6 +240,7 @@
   }
   .card {
     position: relative;
+    box-sizing: border-box;
     width: min(520px, 100%);
     max-height: 80dvh;
     display: flex;
@@ -249,6 +250,7 @@
        space — e.g. no release notes at all (nothing shrinkable) plus a full
        180px sessions list on a short viewport — so the action buttons are never
        clipped below the 80dvh cap. (Mobile re-sets this in the media query.) */
+    overflow-x: clip;
     overflow-y: auto;
     background: var(--color-panel);
     border: 1px solid var(--color-line-bright);
@@ -264,14 +266,14 @@
     border: 1px solid var(--color-line-bright);
   }
   .bracket::before {
-    top: -1px;
-    left: -1px;
+    top: 0;
+    left: 0;
     border-right: 0;
     border-bottom: 0;
   }
   .bracket::after {
-    bottom: -1px;
-    right: -1px;
+    bottom: 0;
+    right: 0;
     border-left: 0;
     border-top: 0;
   }
@@ -495,7 +497,9 @@
     margin-bottom: -8px;
   }
   .log {
+    flex: 1 1 96px;
     margin: 0;
+    min-height: 96px;
     max-height: 180px;
     overflow-y: auto;
     border: 1px solid var(--color-line);

--- a/ui/src/lib/components/UpdateModal.browser.test.ts
+++ b/ui/src/lib/components/UpdateModal.browser.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import type { DeployState, UpdateStatus } from "$lib/types";
+
+vi.mock("$lib/api", async (orig) => ({
+  ...((await orig()) as object),
+  applyUpdate: vi.fn(() => new Promise(() => {})),
+}));
+
+import UpdateModal from "./UpdateModal.svelte";
+
+const update: UpdateStatus = {
+  behind: 1,
+  current: "abc1234",
+  latest: "def5678",
+  commits: [{ sha: "def5678", subject: "Fix update modal scrollbar overflow" }],
+  checkedAt: 0,
+};
+
+const deploy: DeployState = {
+  phase: "running",
+  exitCode: null,
+  log: [
+    "=== shepherd-update 2026-07-01T07:10:00Z abc1234 -> def5678 ===",
+    "bun install",
+    "bun run build",
+    "restarting shepherd",
+    "waiting for server",
+  ].join("\n"),
+};
+
+afterEach(async () => {
+  document.body.innerHTML = "";
+  await page.viewport(1280, 900);
+});
+
+describe("UpdateModal", () => {
+  it("keeps modal chrome from creating stray scrollbars with an active deploy log", async () => {
+    await page.viewport(800, 600);
+
+    render(UpdateModal, {
+      props: {
+        update,
+        updating: true,
+        deploy,
+      },
+    });
+
+    await vi.waitFor(() => expect(document.querySelector(".log")).not.toBeNull());
+
+    const card = document.querySelector<HTMLElement>(".card");
+    expect(card).not.toBeNull();
+    expect(card!.scrollWidth, "dialog should not have horizontal overflow").toBeLessThanOrEqual(
+      card!.clientWidth,
+    );
+    expect(
+      card!.scrollHeight,
+      "dialog should not need its own vertical scrollbar",
+    ).toBeLessThanOrEqual(card!.clientHeight + 1);
+  });
+});

--- a/ui/src/lib/components/UpdateModal.svelte
+++ b/ui/src/lib/components/UpdateModal.svelte
@@ -157,6 +157,7 @@
   }
   .card {
     position: relative;
+    box-sizing: border-box;
     width: min(520px, 100%);
     max-height: 80dvh;
     display: flex;
@@ -165,6 +166,7 @@
     background: var(--color-panel);
     border: 1px solid var(--color-line-bright);
     padding: 18px 18px 16px;
+    overflow-x: clip;
     box-shadow: inset 0 0 30px -16px var(--color-amber);
   }
   .bracket::before,
@@ -176,14 +178,14 @@
     border: 1px solid var(--color-line-bright);
   }
   .bracket::before {
-    top: -1px;
-    left: -1px;
+    top: 0;
+    left: 0;
     border-right: 0;
     border-bottom: 0;
   }
   .bracket::after {
-    bottom: -1px;
-    right: -1px;
+    bottom: 0;
+    right: 0;
     border-left: 0;
     border-top: 0;
   }
@@ -315,7 +317,9 @@
     color: var(--color-muted);
   }
   .log {
+    flex: 1 1 96px;
     margin: 0;
+    min-height: 96px;
     max-height: 200px;
     overflow: auto;
     padding: 8px 10px;


### PR DESCRIPTION
## Summary
- Keep update-modal bracket corners inside the dialog box so decorative chrome no longer creates stray scroll area.
- Prevent horizontal modal overflow and make update logs shrink into their own scroll region on short desktop viewports.
- Add a browser regression test for the Codex update modal at the reported 800x600 layout.

## Root Cause
The bracket pseudo-elements were positioned one pixel outside scrollable dialog cards. With vertical overflow enabled, that decorative overflow became part of the scrollable area, producing the visible right and bottom scrollbars. The active update log could also force the whole card to scroll instead of shrinking internally.

## Validation
- cd ui && bun run test:browser -- CodexUpdateModal.browser.test.ts
- cd ui && bun run check
- cd ui && bun run check:i18n
- scripts/check-branch-hygiene.sh