### PR TITLE
feat(site): full-width release banner + install command in hero

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -11,15 +11,23 @@ const DEMO_URL = "https://demo.shepherd.run";
 ---
 
 <section class="hero">
-  <div class="copy">
-    <p class="prerelease" role="status">
-      <span class="pulse" aria-hidden="true"></span>
-      <span>
-        <strong>Public release in a few days.</strong> The GitHub repo and the one-line
-        installer below aren’t live yet — they go public at launch.
-      </span>
-    </p>
+  <!--
+    DOM source order is content/mobile order: banner → copy → install → visual.
+    grid-template-areas reorders these VISUALLY per breakpoint, but tab and
+    screen-reader order follow this DOM order (WCAG 2.4.3 / 1.3.2). The
+    install-vs-screenshot order flips between breakpoints, so we author the
+    logical/mobile-matching sequence and let the desktop screenshot (a
+    supplementary demo link) trail in DOM.
+  -->
+  <p class="prerelease" role="status">
+    <span class="pulse" aria-hidden="true"></span>
+    <span>
+      <strong>Public release in a few days.</strong> The GitHub repo and the one-line
+      installer below aren’t live yet — they go public at launch.
+    </span>
+  </p>
 
+  <div class="copy">
     <h1 class="headline">
       Run a herd of real coding agents
       <span class="emph">ship only what survives review.</span>
@@ -48,7 +56,9 @@ const DEMO_URL = "https://demo.shepherd.run";
       >
       <a class="btn btn-ghost" href={DOCS_URL}>Read the docs</a>
     </div>
+  </div>
 
+  <div class="install-slot">
     <InstallBlock />
   </div>
 
@@ -61,7 +71,12 @@ const DEMO_URL = "https://demo.shepherd.run";
   .hero {
     display: grid;
     grid-template-columns: 1fr;
-    gap: 2.5rem;
+    grid-template-areas:
+      "banner"
+      "copy"
+      "install"
+      "visual";
+    row-gap: 2rem;
     align-items: center;
     max-width: 72rem;
     margin: 0 auto;
@@ -69,17 +84,22 @@ const DEMO_URL = "https://demo.shepherd.run";
   }
 
   .copy {
+    grid-area: copy;
+    align-self: start;
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
   }
 
+  .install-slot {
+    grid-area: install;
+  }
+
   .prerelease {
-    display: inline-flex;
+    grid-area: banner;
+    display: flex;
     align-items: center;
     gap: 0.6rem;
-    align-self: flex-start;
-    max-width: 38rem;
     padding: 0.6rem 0.9rem;
     border: 1px solid color-mix(in srgb, var(--amber) 45%, transparent);
     border-radius: 0.6rem;
@@ -191,13 +211,19 @@ const DEMO_URL = "https://demo.shepherd.run";
   }
 
   .visual {
+    grid-area: visual;
     width: 100%;
   }
 
   @media (min-width: 900px) {
     .hero {
       grid-template-columns: 1.05fr 0.95fr;
-      gap: 3.5rem;
+      grid-template-areas:
+        "banner  banner"
+        "copy    visual"
+        "install install";
+      column-gap: 3.5rem;
+      row-gap: 2rem;
     }
   }
 

--- a/site/src/components/InstallBlock.astro
+++ b/site/src/components/InstallBlock.astro
@@ -65,8 +65,8 @@ const INSTALL_CMD = "curl -fsSL https://shepherd.run/install.sh | bash";
 
 <style>
   .install {
+    /* Fills its grid area — the hero widens this to a full-width bottom row. */
     width: 100%;
-    max-width: 34rem;
     background: var(--panel);
     border: 1px solid var(--panel-2);
     border-radius: 0.75rem;


### PR DESCRIPTION
## What

On the marketing landing page (`site/`, Astro), the pre-release banner and the one-line install command now span the **full width of the hero** — banner as a full-width row across the top, install command as a full-width row across the bottom — with the text + screenshot two-column split in between. Previously both were boxed into the left text column and further capped by their own `max-width` (38rem / 34rem), so they read as narrow.

## How

- **`Hero.astro`** — rebuilt `.hero` with `grid-template-areas` (`banner` / `copy` `visual` / `install`). Promoted `.prerelease` and the install block (wrapped in `.install-slot`) to hero-level grid items so they span both columns.
- **DOM source order** is content/mobile order `banner → copy → install → visual`. `grid-template-areas` reorders *visually only*; tab and screen-reader order follow DOM order (WCAG 2.4.3 / 1.3.2). The install-vs-screenshot order flips between breakpoints, so we author the logical/mobile-matching sequence and let the desktop screenshot (a supplementary demo link) trail in DOM.
- `align-self: start` on `.copy` so the headline anchors under the full-width banner instead of vertically centering against the taller screenshot.
- `.prerelease` → `display: flex` (full-width amber bar, left-aligned content) with `max-width`/`align-self` removed.
- **`InstallBlock.astro`** — dropped `max-width: 34rem` (kept `width: 100%`) so it fills the full-width bottom row. Only consumer is Hero, so nothing else is affected.

Purely presentational CSS/markup reshuffle — no copy, tokens, or behavior changes.

## Verification

- `astro check` — 0 errors (pre-existing `execCommand` deprecation hint untouched).
- `astro build` — passes.
- Headless-Chromium screenshots at desktop (1280px) and mobile (390px):
  - Desktop: full-width banner on top, two-column middle, full-width install command on the bottom; headline anchored under the banner.
  - Mobile: single column stacks banner → copy/CTAs → install → screenshot.

## Notes

- `site/` is the standalone Astro marketing site; the repo's i18n / design-system / feature-catalog gates apply to `ui/`, not here — no feature-announcement entry or message keys required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)