### PR TITLE
fix: keep PR polling alive under GitHub GraphQL limits

### DIFF
--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { timedAsync } from "../instrument";
-import { jobsFromRollup, mapCheckState, rollupChecks } from "./checks";
+import { jobsFromRollup, mapCheckState, mapStatusState, rollupChecks } from "./checks";
 import { classifyPr } from "./pr-kind";
 import {
   graphRateLimit,
@@ -11,6 +11,7 @@ import {
 } from "./rate-limit";
 import { CRITIC_REVIEW_MARKER, EmptyDiffError } from "./types";
 import type {
+  ChecksState,
   CiStatus,
   ForgeConfig,
   GitForge,
@@ -183,6 +184,30 @@ interface GhPr {
   headRepositoryOwner?: { login?: string };
 }
 
+interface RestPull {
+  number: number;
+  html_url?: string;
+  title?: string;
+  state?: "open" | "closed";
+  draft?: boolean;
+  created_at?: string;
+  merged_at?: string | null;
+  mergeable?: boolean | null;
+  mergeable_state?: string | null;
+  head?: {
+    ref?: string;
+    sha?: string;
+    repo?: { owner?: { login?: string | null } | null } | null;
+  } | null;
+  base?: { ref?: string | null } | null;
+  requested_reviewers?: Array<{ login?: string | null }> | null;
+}
+
+interface RestCheckRun {
+  status?: string | null;
+  conclusion?: string | null;
+}
+
 function mapMergeable(v: string | undefined): boolean | null {
   if (v === "MERGEABLE") return true;
   if (v === "CONFLICTING") return false;
@@ -220,6 +245,13 @@ function mapMergeStateStatus(v: string | undefined): MergeStateStatus | undefine
   if (!v) return undefined;
   const lower = v.toLowerCase();
   return MERGE_STATE_VALUES.has(lower) ? (lower as MergeStateStatus) : undefined;
+}
+
+function worstChecks(states: ChecksState[]): ChecksState {
+  if (states.includes("failure")) return "failure";
+  if (states.includes("pending")) return "pending";
+  if (states.includes("success")) return "success";
+  return "none";
 }
 
 /** GitHub forge driven through the `gh` CLI (operator's existing auth). */
@@ -652,8 +684,90 @@ export class GithubForge implements GitForge {
     };
   }
 
+  private async restChecksForHead(headSha?: string): Promise<ChecksState> {
+    if (!headSha) return "none";
+    const statusPath = `repos/${this.slug}/commits/${headSha}/status`;
+    const checksPath = `repos/${this.slug}/commits/${headSha}/check-runs`;
+    const [statusOut, checksOut] = await Promise.all([
+      this.run(["api", statusPath]).catch(() => null),
+      this.run(["api", checksPath]).catch(() => null),
+    ]);
+
+    const states: ChecksState[] = [];
+    if (statusOut != null) {
+      const parsed = JSON.parse(statusOut || "{}") as { state?: string | null };
+      states.push(mapStatusState(parsed.state));
+    }
+    if (checksOut != null) {
+      const parsed = JSON.parse(checksOut || "{}") as { check_runs?: RestCheckRun[] };
+      for (const run of parsed.check_runs ?? []) {
+        states.push(mapCheckState(run.status, run.conclusion));
+      }
+    }
+    return worstChecks(states);
+  }
+
+  private mapRestPull(pr: RestPull, deployConfigured: boolean, checks: ChecksState): PrStatus {
+    const state: PrStatus["state"] =
+      pr.state === "open" ? "open" : pr.merged_at ? "merged" : "closed";
+    const createdAt = Date.parse(pr.created_at ?? "");
+    return {
+      state,
+      number: pr.number,
+      url: pr.html_url ?? `https://github.com/${this.slug}/pull/${pr.number}`,
+      title: pr.title ?? "",
+      createdAt: Number.isFinite(createdAt) ? createdAt : undefined,
+      mergeable: typeof pr.mergeable === "boolean" ? pr.mergeable : null,
+      mergeStateStatus: mapMergeStateStatus(pr.mergeable_state ?? undefined),
+      isDraft: pr.draft ?? false,
+      checks,
+      headSha: pr.head?.sha,
+      baseRefName: pr.base?.ref ?? undefined,
+      requestedReviewers: (pr.requested_reviewers ?? [])
+        .map((r) => r.login ?? undefined)
+        .filter((login): login is string => !!login),
+      deployConfigured,
+    };
+  }
+
+  /** REST fallback for the herd's per-session PR status when GitHub's GraphQL
+   *  bucket is exhausted. It intentionally returns the same PrStatus shape but
+   *  only does extra REST check/status reads for open PRs; terminal PRs already
+   *  sort correctly from the pull state alone. */
+  private async prStatusRest(headBranch: string, deployConfigured: boolean): Promise<PrStatus> {
+    const owner = this.forkOwner ?? this.slug.split("/")[0];
+    const out = await this.run([
+      "api",
+      "--method",
+      "GET",
+      `repos/${this.slug}/pulls`,
+      "-f",
+      `head=${owner}:${headBranch}`,
+      "-f",
+      "state=all",
+      "-f",
+      "sort=created",
+      "-f",
+      "direction=desc",
+      "-f",
+      `per_page=${this.forkOwner ? "30" : "1"}`,
+    ]);
+    const prs = JSON.parse(out || "[]") as RestPull[];
+    const pr = this.forkOwner
+      ? prs.find((p) => p.head?.repo?.owner?.login === this.forkOwner)
+      : prs[0];
+    if (!pr) return { state: "none", checks: "none", deployConfigured };
+    const state: PrStatus["state"] =
+      pr.state === "open" ? "open" : pr.merged_at ? "merged" : "closed";
+    const checks = state === "open" ? await this.restChecksForHead(pr.head?.sha) : "none";
+    return this.mapRestPull(pr, deployConfigured, checks);
+  }
+
   async prStatus(headBranch: string): Promise<PrStatus> {
     const deployConfigured = Boolean(this.cfg.deployWorkflow);
+    if (graphRateLimit.blocked()) {
+      return this.prStatusRest(headBranch, deployConfigured);
+    }
     // `gh pr list --head` matches by bare branch ref name — it does NOT accept the
     // `<owner>:<branch>` qualifier (verified, gh 2.83.2: it silently returns []).
     // A bare `--head` DOES surface cross-repo (fork) PRs (verified against a real
@@ -667,20 +781,26 @@ export class GithubForge implements GitForge {
     // are `shepherd/<session>`, so this is effectively impossible. If it ever bites,
     // prStatus returns state:none and a duplicate PR could be opened — acceptable vs.
     // unbounded paging on a hot path.
-    const out = await this.run([
-      "pr",
-      "list",
-      "--repo",
-      this.slug,
-      "--head",
-      headBranch,
-      "--state",
-      "all",
-      "--json",
-      "number,url,title,state,createdAt,mergeable,mergeStateStatus,isDraft,statusCheckRollup,headRefOid,baseRefName,reviews,reviewRequests,headRepositoryOwner",
-      "--limit",
-      this.forkOwner ? "30" : "1",
-    ]);
+    let out: string;
+    try {
+      out = await this.run([
+        "pr",
+        "list",
+        "--repo",
+        this.slug,
+        "--head",
+        headBranch,
+        "--state",
+        "all",
+        "--json",
+        "number,url,title,state,createdAt,mergeable,mergeStateStatus,isDraft,statusCheckRollup,headRefOid,baseRefName,reviews,reviewRequests,headRepositoryOwner",
+        "--limit",
+        this.forkOwner ? "30" : "1",
+      ]);
+    } catch (err) {
+      if (isRateLimitError(err)) return this.prStatusRest(headBranch, deployConfigured);
+      throw err;
+    }
     const prs = JSON.parse(out || "[]") as GhPr[];
     const pr = this.forkOwner
       ? prs.find((p) => p.headRepositoryOwner?.login === this.forkOwner)

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -173,8 +173,9 @@ export class PrPoller implements PrCache {
      *  autonomous merge work is in flight). When cold, the fast sweep pauses
      *  entirely and the full sweep throttles to `idleIntervalMs`. */
     private warm: () => boolean = () => true,
-    /** True while the shared GraphQL backoff is engaged — skip every sweep so we
-     *  don't burn budget against an exhausted bucket. */
+    /** True while the shared GraphQL backoff is engaged. Full sweeps still run
+     *  through the per-session path so GitHub REST fallback can keep terminal PR
+     *  state moving; GraphQL batch work and fast sweeps are paused. */
     private rateLimited: () => boolean = () => false,
     /** Coarse full-sweep cadence while cold (no warmth) — the fast sweep is paused
      *  outright, so this is the only PR refresh path when nobody's watching. */
@@ -207,7 +208,7 @@ export class PrPoller implements PrCache {
   private lastNoneRecheckAt = 0;
 
   async tick(): Promise<void> {
-    if (this.rateLimited()) return; // GraphQL bucket exhausted — don't add to the backlog
+    const graphqlLimited = this.rateLimited();
     // Cold path: nobody's watching and no autonomous merge work — throttle the full
     // sweep to the coarse idle cadence instead of every `intervalMs`.
     if (!this.warm() && Date.now() - this.lastFullSweepAt < this.idleIntervalMs) return;
@@ -218,7 +219,9 @@ export class PrPoller implements PrCache {
       const sessions = [...this.store.list({ activeOnly: true })];
       const recheckNone = Date.now() - this.lastNoneRecheckAt >= this.noneRecheckMs;
       if (recheckNone) this.lastNoneRecheckAt = Date.now();
-      const batches = await this.buildBatches(sessions);
+      const batches = graphqlLimited
+        ? new Map<string, Map<string, PrStatus> | null>()
+        : await this.buildBatches(sessions);
       const active = new Set<string>();
       for (const s of sessions) {
         active.add(s.id);

--- a/test/forge/github.test.ts
+++ b/test/forge/github.test.ts
@@ -323,6 +323,55 @@ test("GithubForge.prStatus: no PR → state none", async () => {
   expect(st.deployConfigured).toBe(true);
 });
 
+test("GithubForge.prStatus: GraphQL rate limit falls back to REST PR status", async () => {
+  const calls: string[][] = [];
+  const run = async (args: string[]): Promise<string> => {
+    calls.push(args);
+    if (args[0] === "pr" && args[1] === "list") {
+      throw { stderr: "API rate limit exceeded for graphql resource" };
+    }
+    if (args[0] === "api" && args.includes("repos/o/r/pulls")) {
+      return JSON.stringify([
+        {
+          number: 7,
+          html_url: "https://github.com/o/r/pull/7",
+          title: "feat",
+          state: "open",
+          draft: false,
+          created_at: "2024-01-01T00:00:00Z",
+          mergeable: true,
+          mergeable_state: "clean",
+          head: { ref: "feature", sha: "abc123", repo: { owner: { login: "o" } } },
+          base: { ref: "main" },
+          requested_reviewers: [{ login: "reviewer" }],
+        },
+      ]);
+    }
+    if (args[0] === "api" && args.includes("repos/o/r/commits/abc123/status")) {
+      return JSON.stringify({ state: "success" });
+    }
+    if (args[0] === "api" && args.includes("repos/o/r/commits/abc123/check-runs")) {
+      return JSON.stringify({ check_runs: [] });
+    }
+    return "";
+  };
+  const forge = new GithubForge("o/r", {}, run);
+  const st = await forge.prStatus("feature");
+  expect(st).toMatchObject({
+    state: "open",
+    number: 7,
+    checks: "success",
+    mergeable: true,
+    mergeStateStatus: "clean",
+    baseRefName: "main",
+    requestedReviewers: ["reviewer"],
+  });
+  expect(calls.some((c) => c[0] === "pr" && c[1] === "list")).toBe(true);
+  const restList = calls.find((c) => c[0] === "api" && c.includes("repos/o/r/pulls"))!;
+  expect(restList).toBeDefined();
+  expect(restList.slice(1, 3)).toEqual(["--method", "GET"]);
+});
+
 test("GithubForge.merge: invokes gh pr merge with squash + delete-branch", async () => {
   const { run, calls } = fakeRunner({});
   const forge = new GithubForge("o/r", {}, run);

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -859,17 +859,28 @@ test("tick when not warm runs again with idleIntervalMs 0", async () => {
   expect(calls).toBe(2);
 });
 
-test("tick skips entirely when rateLimited() regardless of warm", async () => {
+test("tick under rateLimited() skips GraphQL batches but still polls sessions", async () => {
   const store = new SessionStore(":memory:");
   store.create(baseSession);
   let calls = 0;
+  let batchCalls = 0;
+  const forge: GitForge = {
+    ...forgeReturning(() => {
+      calls++;
+      return OPEN;
+    }),
+    countOpenPrs: async () => {
+      batchCalls++;
+      return 1;
+    },
+    listOpenPrSnapshot: async () => {
+      batchCalls++;
+      return { prs: [], statuses: new Map(), capped: false };
+    },
+  };
   const poller = new PrPoller(
     store,
-    () =>
-      forgeReturning(() => {
-        calls++;
-        return OPEN;
-      }),
+    () => forge,
     () => {},
     120_000,
     1000,
@@ -880,7 +891,8 @@ test("tick skips entirely when rateLimited() regardless of warm", async () => {
     () => true, // but rate limited
   );
   await poller.tick();
-  expect(calls).toBe(0);
+  expect(calls).toBe(1);
+  expect(batchCalls).toBe(0);
 });
 
 test("prunes cache entries for sessions no longer active", async () => {


### PR DESCRIPTION
## Summary
- keep the session PR full sweep running during GitHub GraphQL backoff
- fall back to GitHub REST for per-session PR status when GraphQL is exhausted
- add regression coverage for REST fallback and rate-limited poller behavior

## Tests
- bun run lint
- bun test test/forge/github.test.ts test/pr-poller.test.ts
- pre-push hook passed during git push
