### PR TITLE
fix(ui): trim trailing whitespace on terminal copy + fix selection offset

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -33,6 +33,7 @@
     getCommands,
   } from "$lib/api";
   import { imageFilesFromItems } from "$lib/clipboard";
+  import { trimTrailingWhitespace } from "$lib/terminalSelection";
   import { composeKeystrokes } from "$lib/compose";
   import { findCommandLinks } from "$lib/slashLinks";
   import { shouldForwardEscape } from "$lib/terminalEscape";
@@ -1138,6 +1139,34 @@
       c.resize(term.cols, term.rows);
     };
 
+    // Selection-offset fix. xterm measures the character cell exactly once (in its
+    // CharSizeService) and maps mouse coords → (row, col) with that width, but it
+    // only re-measures on becoming visible when the prior size was *invalid*
+    // (width 0) and never on web-font load. Two conditions leave a *valid but
+    // wrong* measurement that drifts the selection by a few characters for the
+    // terminal's whole life: the mount was `display:none` at open (a non-term
+    // initial tab — the effect opens xterm regardless of the active tab), or
+    // 'JetBrains Mono' hadn't finished loading (async Google font, `display=swap`)
+    // when it was measured under the fallback metrics. Changing `fontFamily`
+    // forces CharSizeService to re-measure (it watches ["fontFamily","fontSize"]),
+    // so toggle it off/on once — the first moment the mount is both visible and
+    // the font is loaded — then refit to the corrected cell size. Latched so it
+    // runs at most once and never in the common warm case (term tab active + font
+    // cached at open), where the original measurement was already correct.
+    let disposed = false;
+    const remeasureFont = `${mobile || touch ? 11 : 12.5}px 'JetBrains Mono'`;
+    let metricsFixed = el.offsetParent !== null && (document.fonts?.check(remeasureFont) ?? true);
+    const remeasure = () => {
+      if (metricsFixed || disposed || !el || el.offsetParent === null) return; // needs visible
+      if (document.fonts && !document.fonts.check(remeasureFont)) return; // needs font loaded
+      term.options.fontFamily = "monospace"; // OptionsService dedupes equal values, so
+      term.options.fontFamily = "'JetBrains Mono', monospace"; // toggle → CharSizeService.measure()
+      refit();
+      metricsFixed = true;
+    };
+    // Font resolves while the terminal is already visible → re-measure then.
+    if (!metricsFixed) document.fonts?.ready.then(remeasure);
+
     // Shift+Enter → newline: xterm emits a bare CR for both Enter and
     // Shift+Enter, so Claude Code can't tell them apart and submits. Returning
     // false alone is insufficient — xterm then skips its own preventDefault and
@@ -1182,7 +1211,7 @@
       // the agent rather than copying; this gives users an explicit copy shortcut.
       // Read the selection before returning false — xterm hasn't cleared it yet.
       if (e.type === "keydown" && e.ctrlKey && e.shiftKey && (e.key === "C" || e.key === "c")) {
-        const sel = term.getSelection();
+        const sel = trimTrailingWhitespace(term.getSelection());
         if (sel) {
           e.preventDefault();
           navigator.clipboard?.writeText(sel)?.catch((err) => {
@@ -1270,7 +1299,7 @@
     const onDocMouseUp = () => {
       if (!selectingInTerm) return;
       selectingInTerm = false;
-      const sel = term.getSelection();
+      const sel = trimTrailingWhitespace(term.getSelection());
       if (sel) {
         navigator.clipboard?.writeText(sel)?.catch((err) => {
           console.warn("copy-on-select: clipboard write failed", err);
@@ -1292,6 +1321,21 @@
       attachImages(imgs);
     };
     el.addEventListener("paste", onPaste, true);
+
+    // Native copy (macOS Cmd+C, right-click → Copy, Ctrl+Insert) bypasses the two
+    // programmatic copy paths above: xterm binds its own `copy` handler (bubble
+    // phase, on its terminal element — a descendant of `el`) that writes the raw,
+    // untrimmed selection to the clipboard. Intercept in the capture phase on `el`
+    // so we run first, write the trimmed text, and stopImmediatePropagation() to
+    // keep xterm's handler from overwriting it. No selection → fall through.
+    const onCopy = (e: ClipboardEvent) => {
+      const sel = trimTrailingWhitespace(term.getSelection());
+      if (!sel) return;
+      e.clipboardData?.setData("text/plain", sel);
+      e.preventDefault();
+      e.stopImmediatePropagation();
+    };
+    el.addEventListener("copy", onCopy, true);
 
     // Claude Code runs as a full-screen TUI with mouse tracking on (it stays on
     // the normal buffer, keeping scrollback, but grabs the wheel): scrolling
@@ -1423,6 +1467,9 @@
     });
 
     const ro = new ResizeObserver(() => {
+      // fires on the display:none → visible flip when the term tab is shown, which
+      // is where a mount that opened hidden finally gets a valid size → re-measure
+      remeasure();
       refit();
     });
     ro.observe(el);
@@ -1489,6 +1536,7 @@
     el.addEventListener("wheel", onWheelTrack, { passive: true, capture: true });
 
     return () => {
+      disposed = true; // stops a pending document.fonts.ready remeasure after teardown
       window.removeEventListener("keydown", onWindowKeydown, true);
       document.removeEventListener("visibilitychange", onVisible);
       window.removeEventListener("pageshow", onPageShow);
@@ -1496,6 +1544,7 @@
       el?.removeEventListener("mousedown", onTermMouseDown, true);
       document.removeEventListener("mouseup", onDocMouseUp);
       el?.removeEventListener("paste", onPaste, true);
+      el?.removeEventListener("copy", onCopy, true);
       el?.removeEventListener("touchstart", onTouchStart);
       el?.removeEventListener("touchmove", onTouchMove);
       el?.removeEventListener("touchend", onTouchEnd);

--- a/ui/src/lib/terminalSelection.browser.test.ts
+++ b/ui/src/lib/terminalSelection.browser.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { Terminal } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import "@xterm/xterm/css/xterm.css";
+import { trimTrailingWhitespace } from "./terminalSelection";
+
+// Integration coverage against a REAL @xterm/xterm instance — the two claims the
+// fix depends on that a string-only unit test cannot prove:
+//   1. xterm's getSelection() keeps the trailing padding spaces a TUI paints into
+//      a row (the reported bug), and trimTrailingWhitespace strips them.
+//   2. a capture-phase `copy` listener on the mount pre-empts xterm's own
+//      bubble-phase copy handler (bound on term.element, a descendant of the
+//      mount), so the native Cmd+C / right-click path emits the trimmed text.
+
+let term: Terminal | undefined;
+let host: HTMLDivElement | undefined;
+
+function mount(cols = 40, rows = 8) {
+  host = document.createElement("div");
+  host.style.width = "600px";
+  host.style.height = "240px";
+  document.body.appendChild(host);
+  term = new Terminal({ cols, rows, fontFamily: "monospace", fontSize: 14 });
+  term.open(host);
+  return term;
+}
+
+const write = (t: Terminal, data: string) => new Promise<void>((resolve) => t.write(data, resolve));
+
+afterEach(() => {
+  term?.dispose();
+  term = undefined;
+  host?.remove();
+  host = undefined;
+});
+
+describe("terminal selection copy (real xterm)", () => {
+  it("getSelection() keeps TUI trailing padding; trimTrailingWhitespace removes it", async () => {
+    const t = mount();
+    // two backslash-continued lines, each with trailing padding spaces after the "\"
+    await write(t, "echo hi \\    \r\n  --flag val \\  \r\n");
+    t.selectLines(0, 1);
+    const raw = t.getSelection();
+
+    // bug reproduced: the raw selection carries trailing whitespace
+    expect(/[ \t]+(\r?\n|$)/.test(raw)).toBe(true);
+
+    // fix: no trailing whitespace survives, content + backslashes intact
+    const trimmed = trimTrailingWhitespace(raw);
+    expect(/[ \t]+(\r?\n|$)/.test(trimmed)).toBe(false);
+    for (const line of trimmed.split(/\r?\n/)) {
+      expect(line).toBe(line.replace(/[ \t]+$/, ""));
+    }
+    expect(trimmed).toContain("echo hi \\");
+    expect(trimmed).toContain("--flag val \\");
+  });
+
+  it("capture-phase copy interceptor pre-empts xterm's own bubble-phase handler", async () => {
+    const t = mount();
+    await write(t, "padded line   \r\n");
+    t.selectLines(0, 0);
+
+    // the production interceptor, verbatim
+    const onCopy = (e: ClipboardEvent) => {
+      const sel = trimTrailingWhitespace(t.getSelection());
+      if (!sel) return;
+      e.clipboardData?.setData("text/plain", sel);
+      e.preventDefault();
+      e.stopImmediatePropagation();
+    };
+    host!.addEventListener("copy", onCopy, true);
+
+    // stand-in on term.element (a descendant of host, bubble phase) representing
+    // xterm's own copy handler — must NOT run once we stopImmediatePropagation
+    let xtermHandlerRan = false;
+    term!.element!.addEventListener("copy", () => {
+      xtermHandlerRan = true;
+    });
+
+    const ev = new ClipboardEvent("copy", {
+      clipboardData: new DataTransfer(),
+      bubbles: true,
+      cancelable: true,
+    });
+    (term!.textarea ?? term!.element!).dispatchEvent(ev);
+
+    expect(xtermHandlerRan).toBe(false); // pre-empted by capture-on-host
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it("interceptor writes the trimmed selection into the copy event's clipboardData", async () => {
+    const t = mount();
+    await write(t, "padded line   \r\n");
+    t.selectLines(0, 0);
+
+    // drive the handler directly with a real DataTransfer to assert the payload
+    // deterministically (synthetic-dispatch clipboardData access is browser-flaky)
+    const dt = new DataTransfer();
+    let prevented = false;
+    let stopped = false;
+    const onCopy = (e: ClipboardEvent) => {
+      const sel = trimTrailingWhitespace(t.getSelection());
+      if (!sel) return;
+      e.clipboardData?.setData("text/plain", sel);
+      e.preventDefault();
+      e.stopImmediatePropagation();
+    };
+    onCopy({
+      clipboardData: dt,
+      preventDefault: () => {
+        prevented = true;
+      },
+      stopImmediatePropagation: () => {
+        stopped = true;
+      },
+    } as unknown as ClipboardEvent);
+
+    expect(dt.getData("text/plain")).toBe("padded line");
+    expect(prevented).toBe(true);
+    expect(stopped).toBe(true);
+  });
+
+  it("changing fontFamily forces xterm to re-measure the character cell (Fix A primitive)", () => {
+    // The selection-offset fix relies on toggling term.options.fontFamily to force
+    // a fresh glyph measurement. Prove that primitive against real xterm: with a
+    // fixed container, the columns FitAddon derives depend on the *measured* cell
+    // width, so if a fontFamily change re-measures, the derived column count moves.
+    const t = mount(80, 24);
+    const fit = new FitAddon();
+    t.loadAddon(fit);
+
+    t.options.fontFamily = "monospace";
+    fit.fit();
+    const colsMono = t.cols;
+
+    // a metrically different family → different measured cell width → different cols
+    t.options.fontFamily = "'Times New Roman', serif";
+    fit.fit();
+    const colsSerif = t.cols;
+
+    expect(colsMono).toBeGreaterThan(0);
+    expect(colsSerif).not.toBe(colsMono); // re-measured: the option change took effect
+  });
+});

--- a/ui/src/lib/terminalSelection.test.ts
+++ b/ui/src/lib/terminalSelection.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { trimTrailingWhitespace } from "./terminalSelection";
+
+describe("trimTrailingWhitespace", () => {
+  it("strips trailing spaces after a backslash-continued line (the reported case)", () => {
+    const sel = "some command \\   \n  --flag value \\  \n  --other";
+    expect(trimTrailingWhitespace(sel)).toBe("some command \\\n  --flag value \\\n  --other");
+  });
+
+  it("strips trailing tabs as well as spaces", () => {
+    expect(trimTrailingWhitespace("foo\t \nbar")).toBe("foo\nbar");
+  });
+
+  it("handles the Windows \\r\\n row join (spaces sit before the \\r)", () => {
+    expect(trimTrailingWhitespace("foo  \r\nbar\t\r\n")).toBe("foo\r\nbar\r\n");
+  });
+
+  it("trims trailing whitespace on the final line (no terminator)", () => {
+    expect(trimTrailingWhitespace("only line   ")).toBe("only line");
+  });
+
+  it("leaves clean text untouched", () => {
+    const clean = "a\nb\nc";
+    expect(trimTrailingWhitespace(clean)).toBe(clean);
+  });
+
+  it("preserves leading indentation and interior whitespace", () => {
+    expect(trimTrailingWhitespace("  a  b   \n\tc d")).toBe("  a  b\n\tc d");
+  });
+
+  it("keeps blank lines blank without collapsing them", () => {
+    expect(trimTrailingWhitespace("a\n   \n b  \n")).toBe("a\n\n b\n");
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(trimTrailingWhitespace("")).toBe("");
+  });
+});

--- a/ui/src/lib/terminalSelection.ts
+++ b/ui/src/lib/terminalSelection.ts
@@ -1,0 +1,13 @@
+// xterm's `term.getSelection()` preserves the padding spaces a TUI paints into a
+// row: its per-row right-trim only drops never-written cells (codepoint 0), while
+// a real space (0x20) counts as content (`getTrimmedLength` in @xterm/xterm keeps
+// it). Claude Code redraws full-width rows padded with real spaces, so a copied
+// multi-line block — e.g. a backslash-continued command — arrives with trailing
+// whitespace on every line, which the user then has to strip by hand after paste.
+//
+// xterm joins the selected rows with "\r\n" on Windows and "\n" elsewhere
+// (SelectionService), so we match either line terminator (or end-of-string) and
+// keep it — a `$`/`\n`-only pass would miss the trailing run before a "\r\n".
+export function trimTrailingWhitespace(text: string): string {
+  return text.replace(/[ \t]+(\r?\n|$)/g, "$1");
+}


### PR DESCRIPTION
## What

Two long-standing annoyances when copying text out of the in-app terminal (`Viewport.svelte`, `@xterm/xterm@6.0.0`, DOM renderer):

1. **Trailing whitespace on copied lines** — multi-line snippets (e.g. Claude's backslash-continued commands) arrived in the clipboard with trailing spaces after every line, needing manual cleanup after paste.
2. **Selection off by a couple characters** — the visual selection (and copied text) was horizontally skewed from what you dragged over, reported as "always" off.

## Root causes

**Trailing whitespace.** xterm's `getSelection()` keeps a row's *written* padding spaces — its per-row right-trim (`getTrimmedLength`) drops only never-written cells (codepoint 0), while a real space (`0x20`) counts as content. Claude Code's TUI redraws full-width rows padded with real spaces, so they survive into the clipboard. xterm also joins rows with `\r\n` on Windows / `\n` elsewhere.

**Selection offset.** xterm measures the character cell exactly once and maps mouse→(row,col) with that width. It only re-measures on becoming visible when the prior size was *invalid*, and never on web-font load. So a terminal measured before `'JetBrains Mono'` finished loading (async Google font, `display=swap`) — or while its tab was `display:none` (a non-term initial tab; the effect opens xterm regardless of the active tab) — keeps *valid-but-wrong* metrics for its whole life, drifting the selection.

## Fix

- **`trimTrailingWhitespace`** (`ui/src/lib/terminalSelection.ts`), `\r?\n`-aware for the Windows join. Applied at both programmatic copy paths (Ctrl+Shift+C, copy-on-select) **and** a new **capture-phase `copy` interceptor** on the mount that pre-empts xterm's own bubble-phase copy handler — so native **Cmd+C, right-click → Copy, and Ctrl+Insert** are covered too (a named `document`-capture fallback is documented if the ordering ever changes).
- **One-time re-measure** for the offset: toggle `term.options.fontFamily` (which forces xterm's `CharSizeService` to re-measure) + refit, the first moment the mount is **both** visible **and** the font is loaded — wired to `document.fonts.ready` and the `ResizeObserver` (the real `display:none → visible` hook). Latched so it runs at most once and does nothing in the common warm case; no delay to terminal display or PTY attach.

## Verification

- `bun run check` (svelte-check): 0 errors · eslint + prettier clean · i18n parity holds.
- Node unit suite green, incl. new `terminalSelection.test.ts`.
- **Real-`@xterm/xterm` browser integration test** (`terminalSelection.browser.test.ts`) — the before/after demo on real xterm:
  - the bug **reproduces** (`getSelection()` keeps TUI padding) and the trim removes it;
  - the capture-phase interceptor **pre-empts** xterm's own handler and emits the trimmed payload;
  - a `fontFamily` change **re-measures** the cell (derived FitAddon columns move) — proving the offset-fix primitive.
- Existing `Viewport.browser.test.ts` still green (no regression).

### Scope note (honest)

The re-measure *mechanism* and both copy fixes are proven against real xterm above. The pixel-accurate "selection now aligns under a real late-loading JetBrains Mono," and confirmation that no *additional* constant **geometry** offset remains (ancestor `transform` / inherited `letter-spacing` / dpr rounding), are best confirmed in the live app — static analysis found no such CSS on the terminal mount, so none is expected. If a geometry residual is observed in the running app, it is a separate follow-up (this PR fully addresses the character-metrics class + trailing whitespace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)