### PR TITLE
chore(license): switch Apache-2.0 → BUSL 1.1 (source-available)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,5 +170,5 @@ _typing into a real interactive terminal_ — that's the bar every feature must 
 
 ## License
 
-Shepherd is licensed under [Apache-2.0](./LICENSE). By submitting a contribution
-you agree it is licensed under the same terms.
+Shepherd is licensed under the [Business Source License 1.1](./LICENSE). By
+submitting a contribution you agree it is licensed under the same terms.

--- a/LICENSE
+++ b/LICENSE
@@ -40,7 +40,7 @@ Additional Use Grant: You may make production use of the Licensed Work, provided
                       offering. Erwins Enkel GmbH considers your organization to
                       include all of your affiliates under common control.
 
-Change Date:          2030-07-01
+Change Date:          Four years from the date the Licensed Work is published.
 
 Change License:       Apache License, Version 2.0
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,202 +1,93 @@
+License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
 
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Parameters
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Licensor:             Erwins Enkel GmbH
 
-   1. Definitions.
+Licensed Work:        Shepherd Version 1.38.0 or later. The Licensed Work is
+                      (c) 2026 Erwins Enkel GmbH.
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+Additional Use Grant: You may make production use of the Licensed Work, provided
+                      Your use does not include offering the Licensed Work to third
+                      parties on a hosted or embedded basis in order to compete with
+                      Erwins Enkel GmbH's paid version(s) of the Licensed Work. For
+                      purposes of this license:
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+                      A "competitive offering" is a Product that is offered to third
+                      parties on a paid basis, including through paid support
+                      arrangements, that significantly overlaps with the capabilities
+                      of Erwins Enkel GmbH's paid version(s) of the Licensed Work. If
+                      Your Product is not a competitive offering when You first make
+                      it generally available, it will not become a competitive
+                      offering later due to Erwins Enkel GmbH releasing a new version
+                      of the Licensed Work with additional capabilities. In addition,
+                      Products that are not provided on a paid basis are not
+                      competitive.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+                      "Product" means software that is offered to end users to manage
+                      in their own environments or offered as a service on a hosted
+                      basis.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+                      "Embedded" means including the source code or executable code
+                      from the Licensed Work in a competitive offering. "Embedded"
+                      also means packaging the competitive offering in such a way
+                      that the Licensed Work must be accessed or downloaded for the
+                      competitive offering to operate.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+                      Hosting or using the Licensed Work(s) for internal purposes
+                      within an organization is not considered a competitive
+                      offering. Erwins Enkel GmbH considers your organization to
+                      include all of your affiliates under common control.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+Change Date:          2030-07-01
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+Change License:       Apache License, Version 2.0
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+For information about alternative licensing arrangements for the Licensed Work,
+please contact Erwins Enkel GmbH.
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+Notice
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+Business Source License 1.1
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+Terms
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production use.
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2026 Erwins Enkel GmbH
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
+Business Source License 1.1
+
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
 "Business Source License" is a trademark of MariaDB Corporation Ab.
 
 Parameters
@@ -47,15 +49,12 @@ Change License:       Apache License, Version 2.0
 For information about alternative licensing arrangements for the Licensed Work,
 please contact Erwins Enkel GmbH.
 
-Notice
-
-Business Source License 1.1
-
 Terms
 
 The Licensor hereby grants you the right to copy, modify, create derivative
 works, redistribute, and make non-production use of the Licensed Work. The
-Licensor may make an Additional Use Grant, above, permitting limited production use.
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
 
 Effective on the Change Date, or the fourth anniversary of the first publicly
 available distribution of a specific version of the Licensed Work under this
@@ -91,3 +90,34 @@ AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
 EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
 MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
 TITLE.
+
+MariaDB hereby grants you permission to use this License's text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
+
+Covenants of Licensor
+
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.

--- a/README.md
+++ b/README.md
@@ -623,5 +623,6 @@ Shepherd is **source-available**, not open source. You may read, modify, and mak
 non-production use freely, and production use is permitted **except** offering
 Shepherd to third parties as a competing hosted or embedded commercial service
 (see the Additional Use Grant in [`LICENSE`](./LICENSE)). Each version converts to
-the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) on its Change
-Date (**2030-07-01**). For other arrangements, contact Erwins Enkel GmbH.
+the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) **four years
+after that version is published** (its Change Date). For other arrangements,
+contact Erwins Enkel GmbH.

--- a/README.md
+++ b/README.md
@@ -617,4 +617,11 @@ JSONL location with `CLAUDE_CONFIG_DIR` or `CLAUDE_PROJECTS_DIR` if non-default.
 
 ## License
 
-[Apache-2.0](./LICENSE) © 2026 Erwins Enkel GmbH
+[Business Source License 1.1](./LICENSE) © 2026 Erwins Enkel GmbH
+
+Shepherd is **source-available**, not open source. You may read, modify, and make
+non-production use freely, and production use is permitted **except** offering
+Shepherd to third parties as a competing hosted or embedded commercial service
+(see the Additional Use Grant in [`LICENSE`](./LICENSE)). Each version converts to
+the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) on its Change
+Date (**2030-07-01**). For other arrangements, contact Erwins Enkel GmbH.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "module": "src/index.ts",
   "type": "module",
   "private": true,
-  "license": "Apache-2.0",
+  "license": "BUSL-1.1",
   "scripts": {
     "test": "bun test ./test",
     "lint": "eslint --cache --cache-strategy content --cache-location .cache/eslint --no-error-on-unmatched-pattern src test examples ui/src ci/onboarding-harness deploy",

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,6 +1,6 @@
 ---
-// Footer landmark: GitHub link, exact license (Apache-2.0 © 2026 Erwins Enkel
-// GmbH, from ./LICENSE), and a no-affiliation disclaimer.
+// Footer landmark: GitHub link, exact license (Business Source License 1.1 ©
+// 2026 Erwins Enkel GmbH, from ./LICENSE), and a no-affiliation disclaimer.
 const GITHUB_URL = "https://github.com/erwins-enkel/shepherd";
 const LICENSE_URL =
   "https://github.com/erwins-enkel/shepherd/blob/main/LICENSE";
@@ -23,7 +23,7 @@ const DOCS_URL = "https://docs.shepherd.run";
     </div>
 
     <p class="license">
-      Apache-2.0 © 2026 Erwins Enkel GmbH
+      Business Source License 1.1 © 2026 Erwins Enkel GmbH
     </p>
 
     <p class="disclaimer">


### PR DESCRIPTION
## Why

Shepherd is a company-owned commercial product. Under **Apache-2.0** anyone — including a cloud provider — could take the code and sell a competing hosted Shepherd with no obligation beyond attribution. To keep the source visible while blocking resale, this switches to the **Business Source License 1.1** (the model used by HashiCorp, MariaDB, CockroachDB): source-available, free for everything *except* a competing commercial offering, auto-reverting to true OSS on a Change Date.

## Changes

- **`LICENSE`** — replaced Apache-2.0 with the canonical BUSL 1.1 template (verbatim from HashiCorp Vault's copy), parameterized for Shepherd.
- **`package.json`** — `license` → `BUSL-1.1` (SPDX identifier).
- **`README.md`** — License section now states source-available terms + the reversion note.

## License parameters — ⚠️ need legal/business sign-off before merge

These are my proposed defaults, not legal advice. Please confirm each:

| Parameter | Value | Note |
|---|---|---|
| Licensor | Erwins Enkel GmbH | matches existing copyright |
| Change License | Apache License 2.0 | what it reverts to (kept the prior license) |
| **Change Date** | **4 years from each version's publish date** (relative) | self-adjusts per version, no per-release maintenance — HashiCorp's default; adjust the interval to policy |
| **Additional Use Grant** | competing hosted/embedded offering blocked | standard HashiCorp wording; confirm the carve-out matches intent |

Also confirm before merge:
- **Right to relicense** — Erwins Enkel GmbH must own (or hold contributor agreements for) all copyright in the code being relicensed. Any prior Apache-2.0 releases remain Apache-2.0 for those versions.
- **`BUSL-1.1` SPDX id** — recognized by SPDX; some tooling may flag it as non-OSI. Packages are already `private: true` so npm publishing is unaffected.

## Follow-up (out of scope here)

`docs/research/effort-maturity-and-open-source-launch.md` still frames an **open-source Apache-2.0 launch** — its premise now conflicts with this decision. Left untouched deliberately (it's strategy prose, a human call). Flagging for a separate revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
