### PR TITLE
[codex] respect Codex attended autopilot setting

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -522,10 +522,11 @@ const SINGLE_PR_INVARIANT =
 /**
  * Agent-facing notice (#1257) that tells a PR-authoring agent to DECLARE manual operator steps in the
  * PR body via the carriers `parseManualSteps()` (src/manual-steps.ts) understands, so the #1061
- * post-merge pipeline + the Owed lens get a live data source. Rides every CODE spawn (suppressed for
- * research) — Claude gets it via composeSystemPrompt, Codex inline via buildCodexSpawnArgv (Codex has
- * no --append-system-prompt). Not user-facing chrome (an instruction to the agent), so no i18n — same
- * precedent as SINGLE_PR_INVARIANT / AUTOPILOT_DIRECTIVE.
+ * post-merge pipeline + the Owed lens get a live data source. Claude gets it via composeSystemPrompt
+ * on code spawns (suppressed for research). Codex has no --append-system-prompt, so it would be
+ * visible inline; for Codex we only append it when the session is effectively in autopilot, keeping
+ * attended Codex starts aligned with the Claude Code New Task flow. Not user-facing chrome (an
+ * instruction to the agent), so no i18n — same precedent as SINGLE_PR_INVARIANT / AUTOPILOT_DIRECTIVE.
  *
  * IMPORTANT — the embedded fenced example is the SOURCE OF TRUTH for the carrier syntax and is pinned
  * to the parser by a unit test (`parseManualSteps(MANUAL_STEPS_NOTICE)` in test/manual-steps.test.ts).
@@ -1712,11 +1713,10 @@ export class SessionService {
   ): string[] {
     const argv = ["codex", "--no-alt-screen", "--dangerously-bypass-approvals-and-sandbox"];
     if (model) argv.push("--model", model);
-    // Codex has no --append-system-prompt, so the blocks Claude gets via composeSystemPrompt must
-    // ride inline on the prompt. The autopilot directive is gated by the caller on
-    // !research && isolated && effectiveAutopilot; the manual-steps notice (#1257) is gated only on
-    // !research (its single-pr-invariant equivalent — every code spawn, autopilot or not). See the
-    // buildCodexSpawnArgv call site.
+    // Codex has no --append-system-prompt, so extra blocks ride inline on the prompt. For attended
+    // sessions that would visibly turn the operator's prompt into PR workflow guidance, unlike the
+    // Claude Code New Task flow. The caller therefore gates both autopilot and PR/manual-steps text
+    // on the same effective-autopilot predicate.
     let prompt = promptArg;
     if (autopilotActive)
       prompt += `\n\n<autopilot-directive>\n${AUTOPILOT_DIRECTIVE}\n</autopilot-directive>`;
@@ -1924,6 +1924,14 @@ export class SessionService {
         ? "trusted"
         : this.researchSafeProfileOverride(spawnInput, repoConfig, sessionId);
     const baseUrl = this.resolveSpawnBaseUrl(profileOverride, spawnInput.repoPath);
+    const codexAutopilotActive =
+      agentProvider === "codex" &&
+      !spawnInput.research &&
+      wt.isolated &&
+      effectiveAutopilot(
+        { autopilotEnabled: spawnInput.autopilotEnabled ?? null },
+        repoConfig.autopilotEnabled,
+      );
     const argv =
       agentProvider === "codex"
         ? this.buildCodexSpawnArgv(
@@ -1935,15 +1943,10 @@ export class SessionService {
             // Do NOT align to Claude's repo-default-only behavior. Suppressed for research
             // (which replaces the autopilot directive) and non-isolated (which autopilot
             // stands down on — see eligible()).
-            !spawnInput.research &&
-              wt.isolated &&
-              effectiveAutopilot(
-                { autopilotEnabled: spawnInput.autopilotEnabled ?? null },
-                repoConfig.autopilotEnabled,
-              ),
-            // Manual-steps notice (#1257): rides every Codex code spawn, suppressed only for
-            // research — its single-pr-invariant equivalent, independent of the autopilot gate.
-            !spawnInput.research,
+            codexAutopilotActive,
+            // Codex cannot hide this in a system prompt; keep attended starts free of PR/body
+            // instructions and attach the manual-steps contract only for autonomous PR-bound runs.
+            codexAutopilotActive,
           )
         : this.buildSpawnArgv(
             spawnInput,

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -175,9 +175,8 @@ test("createSession: codex provider starts interactive codex; plan-gate forced o
     autopilotEnabled: false,
   });
 
-  // The fixed flags + model are exact; the prompt (last arg) now carries the #1257 manual-steps
-  // notice appended inline (every codex CODE spawn), so it starts with the user prompt rather than
-  // equalling it. Autopilot is off here → no autopilot directive.
+  // Autopilot is off here, so Codex gets the attended New Task shape: just the operator prompt,
+  // with no inline PR/manual-steps workflow guidance.
   expect(calls.start.argv.slice(0, 5)).toEqual([
     "codex",
     "--no-alt-screen",
@@ -186,9 +185,9 @@ test("createSession: codex provider starts interactive codex; plan-gate forced o
     "gpt-5.5",
   ]);
   const codexPrompt = calls.start.argv[5] as string;
-  expect(codexPrompt.startsWith("flatten it")).toBe(true);
+  expect(codexPrompt).toBe("flatten it");
   expect(codexPrompt).not.toContain("<autopilot-directive>");
-  expect(codexPrompt).toContain("<manual-steps-notice>");
+  expect(codexPrompt).not.toContain("<manual-steps-notice>");
   expect(s.agentProvider).toBe("codex");
   expect(s.model).toBe("gpt-5.5");
   expect(s.claudeSessionId).toBe("");
@@ -217,8 +216,8 @@ test("createSession: codex drops a carried Claude model and uses provider defaul
   ]);
   expect(calls.start.argv).not.toContain("--model");
   const codexPrompt = calls.start.argv[3] as string;
-  expect(codexPrompt.startsWith("flatten it")).toBe(true);
-  expect(codexPrompt).toContain("<manual-steps-notice>");
+  expect(codexPrompt).toBe("flatten it");
+  expect(codexPrompt).not.toContain("<manual-steps-notice>");
   expect(s.agentProvider).toBe("codex");
   expect(s.model).toBeNull();
   expect(store.get(s.id)?.model).toBeNull();
@@ -236,6 +235,7 @@ test("createSession: codex + isolated + autopilotEnabled=true → directive inje
     autopilotEnabled: true,
   });
   expect(hasDirective(calls.start.argv)).toBe(true);
+  expect(hasManualNotice(calls.start.argv)).toBe(true);
   expect(store.get(s.id)?.autopilotEnabled).toBe(true);
 });
 
@@ -253,6 +253,7 @@ test("createSession: codex + NON-isolated + autopilotEnabled=true → NO directi
   // Persistence honors the override; the directive is gated on isolation (eligibility/badge
   // surface the non-isolated stand-down).
   expect(hasDirective(calls.start.argv)).toBe(false);
+  expect(hasManualNotice(calls.start.argv)).toBe(false);
   expect(store.get(s.id)?.autopilotEnabled).toBe(true);
 });
 
@@ -271,6 +272,7 @@ test("createSession: codex + isolated + inherited-default ON (null override) →
     // autopilotEnabled omitted → null → inherits repo default ON
   });
   expect(hasDirective(calls.start.argv)).toBe(true);
+  expect(hasManualNotice(calls.start.argv)).toBe(true);
   expect(store.get(s.id)?.autopilotEnabled).toBe(null);
 });
 
@@ -286,6 +288,7 @@ test("createSession: codex + NON-isolated + inherited-default ON (null override)
     images: [],
   });
   expect(hasDirective(calls.start.argv)).toBe(false);
+  expect(hasManualNotice(calls.start.argv)).toBe(false);
   expect(store.get(s.id)?.autopilotEnabled).toBe(null);
 });
 
@@ -304,10 +307,9 @@ test("createSession: codex + isolated + research + repo-default ON → NO direct
   expect(hasDirective(calls.start.argv)).toBe(false);
 });
 
-// #1257: the manual-steps notice rides every codex CODE spawn (gated only on !research — its
-// single-pr-invariant equivalent), independent of the autopilot/isolation gate, and is suppressed
-// for a research spawn (which opens no code PR).
-test("createSession: codex code spawn carries the manual-steps notice, even with autopilot off", async () => {
+// #1257 + attended Codex parity: Codex cannot hide this in --append-system-prompt, so attended
+// Codex spawns omit the inline PR/manual-steps block; effective autopilot spawns still carry it.
+test("createSession: codex attended code spawn omits the manual-steps notice when autopilot is off", async () => {
   const { service, calls } = codexHarness(true);
   await service.create({
     repoPath: "/repo",
@@ -318,7 +320,7 @@ test("createSession: codex code spawn carries the manual-steps notice, even with
     images: [],
     autopilotEnabled: false,
   });
-  expect(hasManualNotice(calls.start.argv)).toBe(true);
+  expect(hasManualNotice(calls.start.argv)).toBe(false);
   expect(hasDirective(calls.start.argv)).toBe(false);
 });
 


### PR DESCRIPTION
## Summary
- Keep attended Codex New Task launches free of inline PR/manual-steps workflow guidance when Autopilot is off.
- Gate Codex's inline manual-steps notice on the same effective-autopilot predicate as the autopilot directive.
- Update service tests to pin attended Codex parity and the autonomous Codex cases.

## Root Cause
Codex cannot use Claude Code's `--append-system-prompt`, so Shepherd appended the manual-steps notice directly to the user prompt for every non-research Codex code spawn. That made attended Codex tasks look autonomous and PR-bound even when the New Task Autopilot toggle was off.

## Validation
- `bun test test/service.test.ts`
- `bun run lint`
- `bun run typecheck`
- pre-push hook: prettier, eslint, gates, tsc, extension check, root tests, UI check, fallow audit

Manual operator steps: none.
