### PR TITLE
fix(ui): render terminal via WebGL to fix selection offset on HiDPI

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -8,7 +8,7 @@
         "@floating-ui/dom": "^1.7.6",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
-        "@xterm/addon-webgl": "0.19.0",
+        "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "dompurify": "^3.4.11",
         "marked": "^18.0.5",

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -8,6 +8,7 @@
         "@floating-ui/dom": "^1.7.6",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
+        "@xterm/addon-webgl": "0.19.0",
         "@xterm/xterm": "^6.0.0",
         "dompurify": "^3.4.11",
         "marked": "^18.0.5",
@@ -350,6 +351,8 @@
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
 
     "@xterm/addon-web-links": ["@xterm/addon-web-links@0.12.0", "", {}, "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw=="],
+
+    "@xterm/addon-webgl": ["@xterm/addon-webgl@0.19.0", "", {}, "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A=="],
 
     "@xterm/xterm": ["@xterm/xterm@6.0.0", "", {}, "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -42,7 +42,7 @@
     "@floating-ui/dom": "^1.7.6",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
-    "@xterm/addon-webgl": "0.19.0",
+    "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "dompurify": "^3.4.11",
     "marked": "^18.0.5",

--- a/ui/package.json
+++ b/ui/package.json
@@ -42,6 +42,7 @@
     "@floating-ui/dom": "^1.7.6",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
+    "@xterm/addon-webgl": "0.19.0",
     "@xterm/xterm": "^6.0.0",
     "dompurify": "^3.4.11",
     "marked": "^18.0.5",

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -3,6 +3,7 @@
   import { Terminal, type IBufferLine, type IBufferCell } from "@xterm/xterm";
   import { FitAddon } from "@xterm/addon-fit";
   import { WebLinksAddon } from "@xterm/addon-web-links";
+  import { WebglAddon } from "@xterm/addon-webgl";
   import type {
     DrainStatus,
     GitState,
@@ -1053,6 +1054,26 @@
     );
     term.open(el);
     fit.fit();
+
+    // WebGL renderer. The default DOM renderer flows text with a per-glyph
+    // letter-spacing derived from a fractional cell width; at a non-integer
+    // fontSize (12.5) on a HiDPI display (devicePixelRatio 2) xterm's glyph
+    // measurement and its computed cell width disagree by half a device pixel,
+    // so the rendered text drifts ~0.25px/char off the hit-test grid and the
+    // selection lands a few characters short by the end of a long line. The
+    // WebGL renderer rasterizes each glyph into its exact grid cell (no flowed
+    // text, no letter-spacing), so text, the selection overlay and mouse
+    // hit-testing all share one grid. Loaded after open() as the addon requires.
+    // Guarded: if WebGL is unavailable (context creation throws, or is lost and
+    // unrecoverable) we dispose it and fall back to the DOM renderer rather than
+    // leaving the terminal blank.
+    try {
+      const webgl = new WebglAddon();
+      webgl.onContextLoss(() => webgl.dispose());
+      term.loadAddon(webgl);
+    } catch (err) {
+      console.warn("webgl renderer unavailable; using DOM renderer", err);
+    }
 
     // assign the local first; reading the `conn` $state back inside this effect
     // would make the effect depend on a value it writes → infinite update loop


### PR DESCRIPTION
Follow-up to #1291 (which fixed the trailing-whitespace half). That PR's font re-measure did **not** fix the selection *offset*, because the offset isn't a measurement race — it's the DOM renderer drifting on HiDPI displays.

## Root cause (measured in the live app)

xterm's DOM renderer flows each row's text with a per-glyph `letter-spacing = cellWidth − measured("W")`. At the desktop `fontSize: 12.5px` on a `devicePixelRatio: 2` display, xterm's two internal glyph measurements disagree by half a device pixel:

| | value |
|---|---|
| hit-test grid cell width (`screenWidth/cols` = `825/110`) | **7.5px** |
| rendered per-char advance (`textWidth/chars` = `797.5/110`) | **7.25px** |
| applied `letter-spacing` | **−0.25px** |

So the text is squeezed ~0.25px/char and creeps left of the hit-test grid — ~3–4 cells over a full 110-col line. Clicking a glyph near the right maps to a *lower* grid column, so the selection lands a few characters short (worst at line end — "obfuscates the last character"). `jetbrainsLoaded: true` in the diagnostic confirms it's not the font-load path.

## Fix

Load `@xterm/addon-webgl` after `open()`. The WebGL renderer rasterizes each glyph into its exact grid cell (no flowed text, no `letter-spacing`), so text, the selection overlay, and mouse hit-testing all share one grid.

- **Version:** `0.19.0` — the stable renderer addon published alongside `@xterm/xterm@6.0.0` (same release day as `addon-fit@0.11.0`). `addon-canvas` has no stable xterm-6 build yet (0.7.0 is xterm-5-era; only 0.8.0 betas after), so WebGL is the supported stable choice.
- **Guarded:** if WebGL is unavailable (context creation throws) or the context is lost and unrecoverable, we `dispose()` the addon and fall back to the DOM renderer rather than blanking the terminal.

## Verification

- `bun run check` (svelte-check) 0 errors · eslint + prettier clean.
- `Viewport.browser.test.ts` (mounts the real Viewport, now loading WebGL) green.
- Root cause quantified with a live DevTools diagnostic (table above).

### Pending live confirmation
The exact drift only manifests at `devicePixelRatio: 2` (a real HiDPI display), which the headless test browser can't reproduce, so the *fix* is verified by architecture + the measured root cause rather than an automated dpr-2 before/after. Requesting a quick re-test on the reporter's HiDPI display: selection should now track the cursor to the last character.

🤖 Generated with [Claude Code](https://claude.com/claude-code)