### PR TITLE
[codex] Add PR badge action menu

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2974,6 +2974,42 @@ async function forgeRedeploy(forge: GitForge, session: Session): Promise<Respons
   return json({ ok: true });
 }
 
+async function refreshSessionGit(
+  forge: GitForge,
+  session: Session,
+  deps: AppDeps,
+): Promise<GitState> {
+  const me = (await forge.currentUser?.()) ?? null;
+  const git: GitState = annotateHandoff(
+    { kind: forge.kind, ...(await forge.prStatus(session.branch ?? "")) },
+    session.repoPath,
+    me,
+  );
+  deps.prCache?.set(session.id, git);
+  deps.events.emit("session:git", { id: session.id, git });
+  return git;
+}
+
+async function forgeSetDraftState(
+  forge: GitForge,
+  session: Session,
+  draft: boolean,
+  deps: AppDeps,
+): Promise<Response> {
+  const cur = await forge.prStatus(session.branch ?? "");
+  if (cur.state !== "open" || !cur.number) {
+    return json({ error: "no open PR" }, 409);
+  }
+  if (!!cur.isDraft !== draft) {
+    const action = draft ? forge.convertToDraft : forge.markReady;
+    if (!action) {
+      return json({ error: "forge does not support changing draft state" }, 400);
+    }
+    await action.call(forge, cur.number);
+  }
+  return json(await refreshSessionGit(forge, session, deps));
+}
+
 async function dispatchForgeAction(
   forge: GitForge,
   session: Session,
@@ -2988,6 +3024,8 @@ async function dispatchForgeAction(
     if (parts[4] === "pr") return forgeOpenPr(forge, session, req, deps);
     if (parts[4] === "merge") return forgeMerge(forge, session, req, deps);
     if (parts[4] === "redeploy") return forgeRedeploy(forge, session);
+    if (parts[4] === "ready") return forgeSetDraftState(forge, session, false, deps);
+    if (parts[4] === "draft") return forgeSetDraftState(forge, session, true, deps);
   }
   return null;
 }

--- a/test/server-git.test.ts
+++ b/test/server-git.test.ts
@@ -253,6 +253,91 @@ test("POST git/redeploy → 400 when no deployWorkflow configured", async () => 
   expect(res.status).toBe(400);
 });
 
+test("POST git/ready promotes a draft PR and emits refreshed git state", async () => {
+  let isDraft = true;
+  const f = fakeForge({
+    prStatus: async () =>
+      ({
+        state: "open",
+        number: 5,
+        checks: "success",
+        deployConfigured: true,
+        isDraft,
+      }) as PrStatus,
+    markReady: async (n) => {
+      f.log.push(`ready:${n}`);
+      isDraft = false;
+    },
+  });
+  const deps = makeDeps(f);
+  const app = makeApp(deps);
+
+  const res = await app.fetch(post("/api/sessions/s1/git/ready"));
+
+  expect(res.status).toBe(200);
+  expect(f.log).toContain("ready:5");
+  expect(await res.json()).toMatchObject({ state: "open", number: 5, isDraft: false });
+  expect(deps.cacheWrites).toContain("s1");
+  expect(deps.emitted.find((e) => e.event === "session:git")?.data).toMatchObject({
+    id: "s1",
+    git: { isDraft: false },
+  });
+});
+
+test("POST git/draft converts a ready PR back to draft", async () => {
+  let isDraft = false;
+  const f = fakeForge({
+    prStatus: async () =>
+      ({
+        state: "open",
+        number: 5,
+        checks: "success",
+        deployConfigured: true,
+        isDraft,
+      }) as PrStatus,
+    convertToDraft: async (n) => {
+      f.log.push(`draft:${n}`);
+      isDraft = true;
+    },
+  });
+  const app = makeApp(makeDeps(f));
+
+  const res = await app.fetch(post("/api/sessions/s1/git/draft"));
+
+  expect(res.status).toBe(200);
+  expect(f.log).toContain("draft:5");
+  expect(await res.json()).toMatchObject({ state: "open", number: 5, isDraft: true });
+});
+
+test("POST git/draft → 400 when host cannot change draft state", async () => {
+  const f = fakeForge({
+    prStatus: async () =>
+      ({
+        state: "open",
+        number: 5,
+        checks: "success",
+        deployConfigured: true,
+        isDraft: false,
+      }) as PrStatus,
+  });
+  const app = makeApp(makeDeps(f));
+
+  const res = await app.fetch(post("/api/sessions/s1/git/draft"));
+
+  expect(res.status).toBe(400);
+});
+
+test("POST git/ready → 409 when there is no open PR", async () => {
+  const f = fakeForge({
+    prStatus: async () => ({ state: "none", checks: "none", deployConfigured: true }) as PrStatus,
+  });
+  const app = makeApp(makeDeps(f));
+
+  const res = await app.fetch(post("/api/sessions/s1/git/ready"));
+
+  expect(res.status).toBe(409);
+});
+
 test("GET /api/git returns the prCache snapshot", async () => {
   const deps = makeDeps(fakeForge());
   const app = makeApp(deps);

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2248,5 +2248,16 @@
   "experiment_continue_mode_summarize": "Erst zusammenfassen",
   "experiment_continue_mode_summarize_hint": "Worktree lesen, kurze Zusammenfassung schreiben und dann auf neue Instruktionen warten.",
   "feat_continue_with_handoff_title": "Session mit anderer CLI weiterführen",
-  "feat_continue_with_handoff_body": "Die alte Aktion „Ersetzen“ heißt jetzt „Weiterführen mit“. Sie behält dieselbe Shepherd-Session und denselben Worktree, lässt dich die nächste CLI samt Modell wählen und kann entweder den ursprünglichen Auftrag laden oder den neuen Agenten erst zusammenfassen und warten lassen."
+  "feat_continue_with_handoff_body": "Die alte Aktion „Ersetzen“ heißt jetzt „Weiterführen mit“. Sie behält dieselbe Shepherd-Session und denselben Worktree, lässt dich die nächste CLI samt Modell wählen und kann entweder den ursprünglichen Auftrag laden oder den neuen Agenten erst zusammenfassen und warten lassen.",
+  "prbadge_button_title": "{label}-Aktionen",
+  "prbadge_menu_label": "PR-Aktionen",
+  "prbadge_open_pr": "PR öffnen",
+  "prbadge_mark_ready": "Auf Ready for Review setzen",
+  "prbadge_mark_draft": "Auf Draft zurücksetzen",
+  "prbadge_marked_ready": "PR auf Ready for Review gesetzt",
+  "prbadge_marked_draft": "PR auf Draft zurückgesetzt",
+  "prbadge_draft_toggle_failed": "PR-Zustand konnte nicht geändert werden: {reason}",
+  "prbadge_unknown_error": "unbekannter Fehler",
+  "feat_pr_badge_menu_title": "PR-Aktionen direkt auf Karten",
+  "feat_pr_badge_menu_body": "Session-Karten öffnen jetzt am PR-Badge ein kompaktes PR-Menü. Du kannst den Pull Request in einem neuen Tab öffnen oder einen offenen PR direkt aus der Herd-Ansicht zwischen Draft und Ready for Review umschalten."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2254,6 +2254,7 @@
   "prbadge_open_pr": "PR öffnen",
   "prbadge_mark_ready": "Auf Ready for Review setzen",
   "prbadge_mark_draft": "Auf Draft zurücksetzen",
+  "prbadge_draft_unsupported": "Draft-Zustandswechsel sind für diesen Forge nicht verfügbar",
   "prbadge_marked_ready": "PR auf Ready for Review gesetzt",
   "prbadge_marked_draft": "PR auf Draft zurückgesetzt",
   "prbadge_draft_toggle_failed": "PR-Zustand konnte nicht geändert werden: {reason}",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2248,5 +2248,16 @@
   "experiment_continue_mode_summarize": "Summarize first",
   "experiment_continue_mode_summarize_hint": "Read the worktree, write a short summary, then wait for new instructions.",
   "feat_continue_with_handoff_title": "Continue a session with another CLI",
-  "feat_continue_with_handoff_body": "The old Replace action is now Continue with. It keeps the same Shepherd session and worktree, lets you pick the next CLI/model, and can either load the original task or ask the new agent to summarize first and wait."
+  "feat_continue_with_handoff_body": "The old Replace action is now Continue with. It keeps the same Shepherd session and worktree, lets you pick the next CLI/model, and can either load the original task or ask the new agent to summarize first and wait.",
+  "prbadge_button_title": "{label} actions",
+  "prbadge_menu_label": "PR actions",
+  "prbadge_open_pr": "Open PR",
+  "prbadge_mark_ready": "Set Ready for Review",
+  "prbadge_mark_draft": "Set back to Draft",
+  "prbadge_marked_ready": "PR marked Ready for Review",
+  "prbadge_marked_draft": "PR marked as Draft",
+  "prbadge_draft_toggle_failed": "Couldn't change PR state: {reason}",
+  "prbadge_unknown_error": "unknown error",
+  "feat_pr_badge_menu_title": "PR actions on cards",
+  "feat_pr_badge_menu_body": "Session cards now open a compact PR menu from the PR badge. Open the pull request in a new tab, or flip an open PR between Draft and Ready for Review without leaving the Herd view."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2254,6 +2254,7 @@
   "prbadge_open_pr": "Open PR",
   "prbadge_mark_ready": "Set Ready for Review",
   "prbadge_mark_draft": "Set back to Draft",
+  "prbadge_draft_unsupported": "Draft state changes are not available for this forge",
   "prbadge_marked_ready": "PR marked Ready for Review",
   "prbadge_marked_draft": "PR marked as Draft",
   "prbadge_draft_toggle_failed": "Couldn't change PR state: {reason}",

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -997,6 +997,15 @@ export async function gitState(id: string): Promise<GitState | null> {
   return r.json();
 }
 
+/** Flip an open session PR between draft and ready-for-review. The server emits
+ *  `session:git` after the forge confirms the new state, so callers don't need to
+ *  mutate the list snapshot optimistically. */
+export async function setPrDraftState(id: string, draft: boolean): Promise<GitState> {
+  const r = await fetch(`/api/sessions/${id}/git/${draft ? "draft" : "ready"}`, JSON_POST());
+  if (!r.ok) throw await failed(r, draft ? "mark PR draft" : "mark PR ready");
+  return r.json();
+}
+
 /** Snapshot of every active session's PR state, keyed by session id (for the
  *  list overview). Empty object when no forge is configured anywhere. */
 export async function gitStates(): Promise<Record<string, GitState>> {

--- a/ui/src/lib/components/PrBadge.browser.test.ts
+++ b/ui/src/lib/components/PrBadge.browser.test.ts
@@ -39,6 +39,26 @@ describe("PrBadge", () => {
       .toBeInTheDocument();
   });
 
+  it("opens the action menu on mouse hover", async () => {
+    vi.spyOn(window, "matchMedia").mockImplementation(
+      () =>
+        ({
+          matches: true,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        }) as unknown as MediaQueryList,
+    );
+    render(PrBadge, { props: { git: git(), sessionId: "s1" } });
+
+    document
+      .querySelector<HTMLButtonElement>(".pr-badge.as-button")!
+      .dispatchEvent(new MouseEvent("mouseenter"));
+
+    await expect
+      .element(page.getByRole("menuitem", { name: m.prbadge_open_pr() }))
+      .toBeInTheDocument();
+  });
+
   it("opens the PR URL in a new tab from the menu", async () => {
     const open = vi.spyOn(window, "open").mockImplementation(() => null);
     render(PrBadge, { props: { git: git(), sessionId: "s1" } });
@@ -73,5 +93,18 @@ describe("PrBadge", () => {
     await page.getByRole("menuitem", { name: m.prbadge_mark_ready() }).click();
 
     expect(fetch).toHaveBeenCalledWith("/api/sessions/s1/git/ready", expect.any(Object));
+  });
+
+  it("disables draft changes for unsupported forge kinds", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    render(PrBadge, { props: { git: git({ kind: "local" }), sessionId: "s1" } });
+
+    await page.getByRole("button", { name: m.prbadge_button_title({ label: "PR #12" }) }).click();
+    const draftAction = page.getByRole("menuitem", { name: m.prbadge_mark_draft() });
+
+    await expect.element(draftAction).toBeDisabled();
+    await draftAction.click({ force: true });
+    expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/lib/components/PrBadge.browser.test.ts
+++ b/ui/src/lib/components/PrBadge.browser.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import PrBadge from "./PrBadge.svelte";
+import { m } from "$lib/paraglide/messages";
+import type { GitState } from "$lib/types";
+
+function git(over: Partial<GitState> = {}): GitState {
+  return {
+    kind: "github",
+    state: "open",
+    number: 12,
+    url: "https://example.test/pr/12",
+    checks: "success",
+    deployConfigured: false,
+    isDraft: false,
+    ...over,
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("PrBadge", () => {
+  it("opens an action menu for open PR badges", async () => {
+    render(PrBadge, { props: { git: git(), sessionId: "s1" } });
+
+    await page.getByRole("button", { name: m.prbadge_button_title({ label: "PR #12" }) }).click();
+
+    await expect
+      .element(page.getByRole("menuitem", { name: m.prbadge_open_pr() }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByRole("menuitem", { name: m.prbadge_mark_draft() }))
+      .toBeInTheDocument();
+  });
+
+  it("opens the PR URL in a new tab from the menu", async () => {
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    render(PrBadge, { props: { git: git(), sessionId: "s1" } });
+
+    await page.getByRole("button", { name: m.prbadge_button_title({ label: "PR #12" }) }).click();
+    await page.getByRole("menuitem", { name: m.prbadge_open_pr() }).click();
+
+    expect(open).toHaveBeenCalledWith(
+      "https://example.test/pr/12",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("sets a ready PR back to draft", async () => {
+    const fetch = vi.fn(async () => new Response(JSON.stringify(git({ isDraft: true }))));
+    vi.stubGlobal("fetch", fetch);
+    render(PrBadge, { props: { git: git({ isDraft: false }), sessionId: "s1" } });
+
+    await page.getByRole("button", { name: m.prbadge_button_title({ label: "PR #12" }) }).click();
+    await page.getByRole("menuitem", { name: m.prbadge_mark_draft() }).click();
+
+    expect(fetch).toHaveBeenCalledWith("/api/sessions/s1/git/draft", expect.any(Object));
+  });
+
+  it("sets a draft PR ready for review", async () => {
+    const fetch = vi.fn(async () => new Response(JSON.stringify(git({ isDraft: false }))));
+    vi.stubGlobal("fetch", fetch);
+    render(PrBadge, { props: { git: git({ isDraft: true }), sessionId: "s1" } });
+
+    await page.getByRole("button", { name: m.prbadge_button_title({ label: "PR #12" }) }).click();
+    await page.getByRole("menuitem", { name: m.prbadge_mark_ready() }).click();
+
+    expect(fetch).toHaveBeenCalledWith("/api/sessions/s1/git/ready", expect.any(Object));
+  });
+});

--- a/ui/src/lib/components/PrBadge.svelte
+++ b/ui/src/lib/components/PrBadge.svelte
@@ -9,6 +9,7 @@
   let { git, sessionId }: { git?: GitState; sessionId?: string } = $props();
   const label = $derived(prBadgeLabel(git));
   const actionable = $derived(!!sessionId && git?.state === "open" && !!git.number);
+  const canToggleDraft = $derived(git?.kind === "github" || git?.kind === "gitea");
   // CI only matters on an open PR; `none` means no checks reported.
   const showCi = $derived(git?.state === "open" && git.checks !== "none");
   const review = $derived(git?.latestReview);
@@ -24,17 +25,36 @@
   // Draft marker: only on open PRs; never green — always slate.
   const showDraft = $derived(prBadgeIsDraft(git));
   let btnEl = $state<HTMLButtonElement>();
-  let menu = $state<{ anchor: DOMRect } | null>(null);
+  let menu = $state<{
+    anchor: DOMRect;
+    autoFocus: boolean;
+    openedBy: "click" | "hover";
+  } | null>(null);
   let busy = $state(false);
+
+  function openMenu(autoFocus: boolean, openedBy: "click" | "hover") {
+    if (!actionable || !btnEl) return;
+    menu = { anchor: btnEl.getBoundingClientRect(), autoFocus, openedBy };
+  }
 
   function toggleMenu(e: MouseEvent) {
     e.stopPropagation();
     if (!actionable) return;
     if (menu) {
+      if (menu.openedBy === "hover") {
+        openMenu(true, "click");
+        return;
+      }
       menu = null;
       return;
     }
-    if (btnEl) menu = { anchor: btnEl.getBoundingClientRect() };
+    openMenu(true, "click");
+  }
+
+  function openMenuOnHover() {
+    if (menu) return;
+    const canHover = window.matchMedia?.("(hover: hover) and (pointer: fine)").matches ?? true;
+    if (canHover) openMenu(false, "hover");
   }
 
   function openPr() {
@@ -44,7 +64,7 @@
   }
 
   async function toggleDraftState() {
-    if (!sessionId) return;
+    if (!sessionId || !canToggleDraft) return;
     const nextDraft = !showDraft;
     busy = true;
     try {
@@ -93,6 +113,7 @@
       aria-label={m.prbadge_button_title({ label })}
       aria-haspopup="menu"
       aria-expanded={!!menu}
+      onmouseenter={openMenuOnHover}
       onclick={toggleMenu}
     >
       {@render content()}
@@ -110,6 +131,8 @@
     opener={btnEl}
     isDraft={showDraft}
     canOpen={!!git?.url}
+    {canToggleDraft}
+    autoFocus={menu.autoFocus}
     {busy}
     onopen={openPr}
     ontoggledraft={toggleDraftState}

--- a/ui/src/lib/components/PrBadge.svelte
+++ b/ui/src/lib/components/PrBadge.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
   import type { GitState } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
+  import { setPrDraftState } from "$lib/api";
+  import { toasts } from "$lib/toasts.svelte";
   import { prBadgeLabel, prBadgeIsDraft } from "./pr-badge";
+  import PrBadgeMenu from "./PrBadgeMenu.svelte";
 
-  let { git }: { git?: GitState } = $props();
+  let { git, sessionId }: { git?: GitState; sessionId?: string } = $props();
   const label = $derived(prBadgeLabel(git));
+  const actionable = $derived(!!sessionId && git?.state === "open" && !!git.number);
   // CI only matters on an open PR; `none` means no checks reported.
   const showCi = $derived(git?.state === "open" && git.checks !== "none");
   const review = $derived(git?.latestReview);
@@ -19,10 +23,51 @@
   );
   // Draft marker: only on open PRs; never green — always slate.
   const showDraft = $derived(prBadgeIsDraft(git));
+  let btnEl = $state<HTMLButtonElement>();
+  let menu = $state<{ anchor: DOMRect } | null>(null);
+  let busy = $state(false);
+
+  function toggleMenu(e: MouseEvent) {
+    e.stopPropagation();
+    if (!actionable) return;
+    if (menu) {
+      menu = null;
+      return;
+    }
+    if (btnEl) menu = { anchor: btnEl.getBoundingClientRect() };
+  }
+
+  function openPr() {
+    menu = null;
+    if (!git?.url) return;
+    window.open(git.url, "_blank", "noopener,noreferrer");
+  }
+
+  async function toggleDraftState() {
+    if (!sessionId) return;
+    const nextDraft = !showDraft;
+    busy = true;
+    try {
+      await setPrDraftState(sessionId, nextDraft);
+      menu = null;
+      toasts.info(nextDraft ? m.prbadge_marked_draft() : m.prbadge_marked_ready(), {
+        key: `pr-draft:${sessionId}`,
+      });
+    } catch (err) {
+      toasts.info(
+        m.prbadge_draft_toggle_failed({
+          reason: err instanceof Error ? err.message : m.prbadge_unknown_error(),
+        }),
+        { alert: true, duration: null, key: `pr-draft:${sessionId}` },
+      );
+    } finally {
+      busy = false;
+    }
+  }
 </script>
 
 {#if label}
-  <span class="pr-badge pr-{git!.state}">
+  {#snippet content()}
     {#if showCi}
       <span
         class="dot dot-{git!.checks}"
@@ -36,7 +81,40 @@
     {#if showDraft}
       <span class="draft-marker" aria-label={m.prbadge_draft()}>{m.prbadge_draft()}</span>
     {/if}{label}
-  </span>
+  {/snippet}
+
+  {#if actionable}
+    <button
+      bind:this={btnEl}
+      type="button"
+      class="pr-badge pr-{git!.state} as-button"
+      class:open={!!menu}
+      title={m.prbadge_button_title({ label })}
+      aria-label={m.prbadge_button_title({ label })}
+      aria-haspopup="menu"
+      aria-expanded={!!menu}
+      onclick={toggleMenu}
+    >
+      {@render content()}
+    </button>
+  {:else}
+    <span class="pr-badge pr-{git!.state}">
+      {@render content()}
+    </span>
+  {/if}
+{/if}
+
+{#if menu}
+  <PrBadgeMenu
+    anchor={menu.anchor}
+    opener={btnEl}
+    isDraft={showDraft}
+    canOpen={!!git?.url}
+    {busy}
+    onopen={openPr}
+    ontoggledraft={toggleDraftState}
+    onclose={() => (menu = null)}
+  />
 {/if}
 
 <style>
@@ -52,6 +130,27 @@
     display: inline-flex;
     align-items: center;
     gap: 5px;
+  }
+  .as-button {
+    position: relative;
+    z-index: 1;
+    appearance: none;
+    margin: 0;
+    font-family: inherit;
+    line-height: inherit;
+    background: transparent;
+    cursor: pointer;
+  }
+  .as-button:hover,
+  .as-button.open {
+    color: var(--color-ink-bright);
+    border-color: var(--color-line-bright);
+    background: var(--color-hover);
+  }
+  .as-button:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+    color: var(--color-ink-bright);
   }
   /* `pr-open` is the brightest PR state via the default muted styling — no hue.
      Amber is reserved for the one actionable badge (critic CHANGES); PR

--- a/ui/src/lib/components/PrBadgeMenu.svelte
+++ b/ui/src/lib/components/PrBadgeMenu.svelte
@@ -7,6 +7,8 @@
     opener,
     isDraft,
     canOpen,
+    canToggleDraft,
+    autoFocus = true,
     busy = false,
     onopen,
     ontoggledraft,
@@ -16,6 +18,8 @@
     opener?: HTMLElement;
     isDraft: boolean;
     canOpen: boolean;
+    canToggleDraft: boolean;
+    autoFocus?: boolean;
     busy?: boolean;
     onopen: () => void;
     ontoggledraft: () => void;
@@ -35,15 +39,18 @@
     const top = below + r.height + margin > window.innerHeight && above > margin ? above : below;
     const left = Math.min(anchor.left, window.innerWidth - r.width - margin);
     pos = { left: Math.max(margin, left), top: Math.max(margin, top) };
-    items()[0]?.focus();
+    if (autoFocus) enabledItems()[0]?.focus();
   });
 
   function items(): HTMLButtonElement[] {
     return el ? Array.from(el.querySelectorAll<HTMLButtonElement>(".pm-item")) : [];
   }
+  function enabledItems(): HTMLButtonElement[] {
+    return items().filter((item) => !item.disabled);
+  }
 
   function onNav(e: KeyboardEvent) {
-    const list = items().filter((item) => !item.disabled);
+    const list = enabledItems();
     if (list.length === 0) return;
     const i = list.indexOf(document.activeElement as HTMLButtonElement);
     const fwd = (i + 1) % list.length;
@@ -107,8 +114,9 @@
     type="button"
     role="menuitem"
     tabindex="-1"
-    disabled={busy}
+    disabled={busy || !canToggleDraft}
     aria-busy={busy}
+    title={!canToggleDraft ? m.prbadge_draft_unsupported() : undefined}
     onclick={ontoggledraft}
   >
     <span class="pm-icon" aria-hidden="true">{isDraft ? "✓" : "□"}</span>{isDraft

--- a/ui/src/lib/components/PrBadgeMenu.svelte
+++ b/ui/src/lib/components/PrBadgeMenu.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import { portal } from "$lib/portal";
+
+  let {
+    anchor,
+    opener,
+    isDraft,
+    canOpen,
+    busy = false,
+    onopen,
+    ontoggledraft,
+    onclose,
+  }: {
+    anchor: DOMRect;
+    opener?: HTMLElement;
+    isDraft: boolean;
+    canOpen: boolean;
+    busy?: boolean;
+    onopen: () => void;
+    ontoggledraft: () => void;
+    onclose: () => void;
+  } = $props();
+
+  let el = $state<HTMLDivElement>();
+  let pos = $state<{ left: number; top: number } | null>(null);
+
+  $effect(() => {
+    const node = el;
+    if (!node) return;
+    const r = node.getBoundingClientRect();
+    const margin = 8;
+    const below = anchor.bottom + 4;
+    const above = anchor.top - r.height - 4;
+    const top = below + r.height + margin > window.innerHeight && above > margin ? above : below;
+    const left = Math.min(anchor.left, window.innerWidth - r.width - margin);
+    pos = { left: Math.max(margin, left), top: Math.max(margin, top) };
+    items()[0]?.focus();
+  });
+
+  function items(): HTMLButtonElement[] {
+    return el ? Array.from(el.querySelectorAll<HTMLButtonElement>(".pm-item")) : [];
+  }
+
+  function onNav(e: KeyboardEvent) {
+    const list = items().filter((item) => !item.disabled);
+    if (list.length === 0) return;
+    const i = list.indexOf(document.activeElement as HTMLButtonElement);
+    const fwd = (i + 1) % list.length;
+    const back = (i - 1 + list.length) % list.length;
+    let next: number;
+    if (e.key === "ArrowDown") next = fwd;
+    else if (e.key === "ArrowUp") next = back;
+    else if (e.key === "Home") next = 0;
+    else if (e.key === "End") next = list.length - 1;
+    else if (e.key === "Tab") next = e.shiftKey ? back : fwd;
+    else return;
+    e.preventDefault();
+    list[next]!.focus();
+  }
+
+  $effect(() => {
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key === "Escape") onclose();
+    }
+    function onPointer(e: Event) {
+      const t = e.target as Node;
+      if (el && !el.contains(t) && !opener?.contains(t)) onclose();
+    }
+    window.addEventListener("keydown", onKeydown);
+    window.addEventListener("pointerdown", onPointer, true);
+    window.addEventListener("scroll", onclose, true);
+    return () => {
+      window.removeEventListener("keydown", onKeydown);
+      window.removeEventListener("pointerdown", onPointer, true);
+      window.removeEventListener("scroll", onclose, true);
+      const target = opener;
+      queueMicrotask(() => {
+        if (target?.isConnected && document.activeElement === document.body) target.focus();
+      });
+    };
+  });
+</script>
+
+<div
+  bind:this={el}
+  use:portal
+  class="pr-menu"
+  role="menu"
+  tabindex="-1"
+  aria-label={m.prbadge_menu_label()}
+  style="left:{pos?.left ?? anchor.left}px;top:{pos?.top ?? anchor.bottom + 4}px"
+  onkeydown={onNav}
+>
+  <button
+    class="pm-item"
+    type="button"
+    role="menuitem"
+    tabindex="-1"
+    disabled={!canOpen}
+    onclick={onopen}
+  >
+    <span class="pm-icon" aria-hidden="true">↗</span>{m.prbadge_open_pr()}
+  </button>
+  <button
+    class="pm-item"
+    type="button"
+    role="menuitem"
+    tabindex="-1"
+    disabled={busy}
+    aria-busy={busy}
+    onclick={ontoggledraft}
+  >
+    <span class="pm-icon" aria-hidden="true">{isDraft ? "✓" : "□"}</span>{isDraft
+      ? m.prbadge_mark_ready()
+      : m.prbadge_mark_draft()}
+  </button>
+</div>
+
+<style>
+  .pr-menu {
+    position: fixed;
+    z-index: 60;
+    min-width: 190px;
+    max-width: calc(100vw - 16px);
+    padding: 4px;
+    background: var(--color-panel);
+    border: 1px solid var(--color-line-bright);
+    border-radius: 3px;
+    box-shadow: 0 8px 24px color-mix(in srgb, var(--color-bg) 70%, transparent);
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+  .pr-menu:focus {
+    outline: none;
+  }
+  .pm-item {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    width: 100%;
+    padding: 9px 11px;
+    border: 0;
+    border-radius: 2px;
+    background: transparent;
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: var(--fs-base);
+    text-align: left;
+    cursor: pointer;
+  }
+  .pm-item:hover:not(:disabled),
+  .pm-item:focus-visible {
+    background: var(--color-hover);
+    outline: none;
+  }
+  .pm-item:disabled {
+    cursor: not-allowed;
+    color: var(--color-faint);
+  }
+  .pm-icon {
+    font-size: var(--fs-meta);
+    width: 1em;
+    text-align: center;
+    flex-shrink: 0;
+    color: var(--color-muted);
+  }
+</style>

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -327,7 +327,7 @@
       <span class="elapsed" bind:this={elapsedEl}>{elapsed(session.createdAt, nowMs)}</span>
     {/if}
     <ResearchBadge {session} />
-    <PrBadge {git} />
+    <PrBadge {git} sessionId={session.id} />
     <CriticBadge sessionId={session.id} />
     <PlanGateBadge {session} allowView={false} />
     <!-- REVIEWING (in-flight critic) outranks the autopilot badge -->

--- a/ui/src/lib/components/unit-row/UnitRowRight.svelte
+++ b/ui/src/lib/components/unit-row/UnitRowRight.svelte
@@ -93,7 +93,7 @@
     >
   {/if}
   <ResearchBadge {session} />
-  {#if !stepperTerminal}<PrBadge {git} />{/if}
+  {#if !stepperTerminal}<PrBadge {git} sessionId={session.id} />{/if}
   <CriticBadge sessionId={session.id} />
   <BuildQueueBadge sessionId={session.id} />
   <PlanGateBadge {session} allowView={false} />

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1930,4 +1930,12 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     titleKey: "feat_continue_with_handoff_title",
     bodyKey: "feat_continue_with_handoff_body",
   },
+  {
+    // No targetId: the PR badge is per-card/dynamic and only exists once a session
+    // has an open PR, so surface via the What's-New drawer only. Ships in 1.39.0.
+    id: "pr-badge-menu",
+    sinceVersion: "1.39.0",
+    titleKey: "feat_pr_badge_menu_title",
+    bodyKey: "feat_pr_badge_menu_body",
+  },
 ];


### PR DESCRIPTION
## Summary

- Turn open PR badges on session cards into focused action buttons with a small anchored menu.
- Add menu actions to open the PR in a new browser tab and flip an open PR between Draft and Ready for Review.
- Add server endpoints for session PR draft-state changes and refresh the `session:git` cache/event after the forge confirms the change.
- Register the user-facing feature in What's New and add EN/DE strings.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `cd ui && bun run check`
- `cd ui && bun run check:i18n`
- `cd ui && bun run test`
- `cd extension && bun run check`
- `cd extension && bun run test`
- `scripts/check-feature-catalog.sh`
- `node scripts/check-glossary.mjs`
- `scripts/check-branch-hygiene.sh`

No manual operator steps.
