### PR TITLE
[codex] add repo-local preview startup scripts

### DIFF
--- a/src/preview-launch.ts
+++ b/src/preview-launch.ts
@@ -1,0 +1,164 @@
+import { execFile } from "node:child_process";
+import { chmod, mkdir, stat, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { promisify } from "node:util";
+import { spawn } from "node:child_process";
+import { scanListeningPortsByWorktree } from "./process-reaper";
+import { resolveDevPort } from "./preview";
+
+const execFileAsync = promisify(execFile);
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+async function gitCommonDir(worktreePath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["rev-parse", "--git-common-dir"], {
+      cwd: worktreePath,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+    const raw = stdout.trim();
+    if (!raw) return null;
+    return resolve(worktreePath, raw);
+  } catch {
+    return null;
+  }
+}
+
+export async function previewScriptExists(path: string | null | undefined): Promise<boolean> {
+  if (!path) return false;
+  try {
+    return (await stat(path)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export async function resolvePreviewStartScriptPath(worktreePath: string): Promise<string | null> {
+  const commonDir = await gitCommonDir(worktreePath);
+  if (commonDir === null) return null;
+  return resolve(commonDir, "shepherd", "preview-start.sh");
+}
+
+export async function ensurePreviewStartScript(
+  worktreePath: string,
+  command: string,
+): Promise<string | null> {
+  const scriptPath = await resolvePreviewStartScriptPath(worktreePath);
+  if (scriptPath === null) return null;
+  const dir = resolve(scriptPath, "..");
+  const logPath = resolve(dir, "preview-start.log");
+  await mkdir(dir, { recursive: true });
+  const body = `#!/usr/bin/env bash
+set -euo pipefail
+
+WORKTREE_ROOT="\${SHEPHERD_WORKTREE_PATH:-$PWD}"
+cd "$WORKTREE_ROOT"
+export SHEPHERD_PREVIEW=1
+export SHEPHERD_PREVIEW_LOG=\${SHEPHERD_PREVIEW_LOG:-${shellQuote(logPath)}}
+COMMAND=${shellQuote(command)}
+
+log() {
+  printf '%s\\n' "$*" >> "$SHEPHERD_PREVIEW_LOG"
+}
+
+port_is_free() {
+  local port="$1"
+  ! (echo >"/dev/tcp/127.0.0.1/$port") >/dev/null 2>&1
+}
+
+pick_port() {
+  local start="\${SHEPHERD_PREVIEW_PORT:-\${SHEPHERD_PREVIEW_PORT_BASE:-5174}}"
+  if [[ ! "$start" =~ ^[0-9]+$ ]] || [ "$start" -lt 1 ] || [ "$start" -gt 65535 ]; then
+    start=5174
+  fi
+  local end=$((start + 200))
+  if [ "$end" -gt 65535 ]; then
+    end=65535
+  fi
+  local port
+  for ((port=start; port<=end; port++)); do
+    if port_is_free "$port"; then
+      printf '%s\\n' "$port"
+      return 0
+    fi
+  done
+  log "no free preview port found from $start to $end"
+  return 1
+}
+
+install_if_needed() {
+  local runner="$1"
+  if [ -d node_modules ] || [ ! -f package.json ]; then
+    return 0
+  fi
+  log "installing dependencies in $PWD with $runner"
+  case "$runner" in
+    bun) bun install ;;
+    npm) npm install ;;
+    pnpm) pnpm install ;;
+    yarn) yarn install ;;
+    *) return 1 ;;
+  esac
+}
+
+run_package_dev() {
+  local dir="$1"
+  local runner="$2"
+  if [ -n "$dir" ]; then
+    cd "$WORKTREE_ROOT/$dir"
+  fi
+  install_if_needed "$runner"
+  local port
+  port="$(pick_port)"
+  printf '%s\\n' "$port" > "$WORKTREE_ROOT/.shepherd-preview"
+  export PORT="$port"
+  export VITE_PORT="$port"
+  log "starting preview command on port $port: $COMMAND"
+  case "$runner" in
+    bun) exec bun run dev -- --port "$port" ;;
+    npm) exec npm run dev -- --port "$port" ;;
+    pnpm) exec pnpm run dev -- --port "$port" ;;
+    yarn) exec yarn dev --port "$port" ;;
+  esac
+}
+
+if [[ "$COMMAND" =~ ^cd[[:space:]]+([^;&|]+)[[:space:]]+\\&\\&[[:space:]]+(bun|npm|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?dev$ ]]; then
+  run_package_dev "\${BASH_REMATCH[1]}" "\${BASH_REMATCH[2]}"
+elif [[ "$COMMAND" =~ ^(bun|npm|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?dev$ ]]; then
+  run_package_dev "" "\${BASH_REMATCH[1]}"
+fi
+
+log "starting raw preview command: $COMMAND"
+exec env bash -lc "$COMMAND"
+`;
+  await writeFile(scriptPath, body, { encoding: "utf8", mode: 0o700 });
+  await chmod(scriptPath, 0o700);
+  return scriptPath;
+}
+
+export async function startPreviewScript(scriptPath: string, worktreePath: string): Promise<void> {
+  await new Promise<void>((resolvePromise, reject) => {
+    const child = spawn(scriptPath, {
+      cwd: worktreePath,
+      detached: true,
+      stdio: "ignore",
+      env: {
+        ...process.env,
+        SHEPHERD_WORKTREE_PATH: worktreePath,
+      },
+    });
+    child.once("error", reject);
+    child.once("spawn", () => {
+      child.unref();
+      resolvePromise();
+    });
+  });
+}
+
+export async function findPreviewDevPort(worktreePath: string): Promise<number | null> {
+  const ports = scanListeningPortsByWorktree([worktreePath]).get(worktreePath) ?? [];
+  return resolveDevPort(ports, worktreePath);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1228,6 +1228,12 @@ async function handleRepoConfig({ req, parts, url, deps }: Ctx): Promise<Respons
   // Load-bearing destructure: the automationConfirmed metadata is applied separately
   // by the service, never merged into the RepoConfig row.
   const { automationConfirmed, ...cfgPatch } = patch;
+  if (cfgPatch.previewStartScript !== undefined && cfgPatch.previewStartScript !== null) {
+    const canonicalScript = await resolvePreviewStartScriptPath(dir);
+    if (cfgPatch.previewStartScript !== canonicalScript) {
+      return json({ error: "previewStartScript must use the canonical repo-local path" }, 400);
+    }
+  }
   const r = repoConfigSvc(deps).patch(dir, cfgPatch, { automationConfirmed });
   if (!r.ok) return json({ error: r.error }, 400);
   return json(r.config);
@@ -2122,8 +2128,10 @@ async function startStoredPreviewScript(
   storedScript: string | null,
   command: string | null,
 ): Promise<Response | null> {
+  const canonicalScript = await launcher.scriptPath(s.worktreePath);
+  if (storedScript === null || storedScript !== canonicalScript) return null;
   const scriptStillExists = await launcher.scriptExists(storedScript);
-  if (!scriptStillExists || storedScript === null) return null;
+  if (!scriptStillExists) return null;
   try {
     await launcher.startScript(storedScript, s.worktreePath);
     return json({
@@ -2145,7 +2153,9 @@ async function sendPreviewSetupSteer(
   cfg: RepoConfig,
   command: string | null,
 ): Promise<Response | null> {
-  const setupScriptPath = cfg.previewStartScript ?? (await launcher.scriptPath(s.worktreePath));
+  const canonicalScript = await launcher.scriptPath(s.worktreePath);
+  const setupScriptPath =
+    cfg.previewStartScript === canonicalScript ? cfg.previewStartScript : canonicalScript;
   if (setupScriptPath === null) return null;
   deps.store.setRepoConfig(s.repoPath, {
     ...cfg,

--- a/src/server.ts
+++ b/src/server.ts
@@ -2106,6 +2106,7 @@ async function bindExistingPreviewServer(
   const devPort = await launcher.findDevPort(s.worktreePath);
   if (devPort === null) return null;
   const previewPort = deps.preview?.ensure?.(id, devPort) ?? null;
+  if (previewPort === null) return json({ error: "preview_slot_unavailable" }, 503);
   return json({
     ok: true,
     mode: "local",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
-import type { SessionStore } from "./store";
+import type { RepoConfig, SessionStore } from "./store";
 import type { PluginRegistry } from "./plugins/loader";
 import type { SessionService } from "./service";
-import { RestoreError } from "./service";
+import { PREVIEW_SETUP_STEER, RestoreError } from "./service";
 import { WorktreeRestoreError } from "./worktree";
 import { LearningsService } from "./learnings-service";
 import { RepoConfigService } from "./repo-config-service";
@@ -89,6 +89,13 @@ import { buildUsageBreakdown } from "./usage-breakdown";
 import { buildUsageTimeline } from "./usage-timeline";
 import { isApiKeyMode } from "./spawn-auth";
 import { detectDevCommand } from "./preview";
+import {
+  ensurePreviewStartScript,
+  findPreviewDevPort,
+  previewScriptExists,
+  resolvePreviewStartScriptPath,
+  startPreviewScript,
+} from "./preview-launch";
 import { sessionActivity } from "./activity";
 import { handleUpload, parseUploadFile, MAX_UPLOAD_BYTES } from "./uploads";
 import type { UsageLimits, UsageLimitsService } from "./usage-limits";
@@ -263,6 +270,16 @@ export interface AppDeps {
    *  `session:preview` events are emitted via PreviewService.onChange in index.ts. */
   preview?: {
     snapshot(): Record<string, SessionPreviewState>;
+    ensure?(sessionId: string, devPort: number): number | null;
+  };
+  /** Local preview launcher. Defaults to `.git/shepherd/preview-start.sh` scripts;
+   *  injectable so route tests never spawn real dev servers. */
+  previewLauncher?: {
+    findDevPort(worktreePath: string): Promise<number | null>;
+    scriptExists(path: string | null | undefined): Promise<boolean>;
+    scriptPath(worktreePath: string): Promise<string | null>;
+    ensureScript(worktreePath: string, command: string): Promise<string | null>;
+    startScript(scriptPath: string, worktreePath: string): Promise<void>;
   };
   /** Tailscale serve registration status per session slot; absent when auto-serve is
    *  disabled or tailscale is unavailable. Merged into /api/preview responses. */
@@ -1022,6 +1039,8 @@ type RepoCfgBody = {
   autoLabel?: unknown;
   usageCeilingPct?: unknown;
   repoMode?: unknown;
+  previewStartScript?: unknown;
+  previewStartCommand?: unknown;
   automationConfirmed?: unknown;
 };
 
@@ -1042,6 +1061,8 @@ type RepoCfgScalars = {
   defaultModel?: string;
   egressExtraHosts?: string[];
   repoMode?: "forge" | "lightweight";
+  previewStartScript?: string | null;
+  previewStartCommand?: string | null;
 };
 
 /** Adapt validateEgressExtraHosts (a Field result) to the scalar-parser contract:
@@ -1049,6 +1070,13 @@ type RepoCfgScalars = {
 function parseRepoEgressExtraHosts(v: unknown): unknown {
   const r = validateEgressExtraHosts(v);
   return r.ok ? r.value : { error: r.error };
+}
+
+function parseNullableString(v: unknown): string | null | { error: string } {
+  if (v === null) return null;
+  if (typeof v !== "string") return { error: "field must be a string or null" };
+  const trimmed = v.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 // Each non-boolean field paired with its validator. A validator returns the
@@ -1062,6 +1090,8 @@ const REPO_CFG_SCALAR_PARSERS: readonly [keyof RepoCfgScalars, (v: unknown) => u
   ["defaultModel", parseRepoDefaultModel],
   ["egressExtraHosts", parseRepoEgressExtraHosts],
   ["repoMode", parseRepoMode],
+  ["previewStartScript", parseNullableString],
+  ["previewStartCommand", parseNullableString],
 ];
 
 /** Validate the non-boolean (scalar/enum) repo-config fields, or the 400 Response to
@@ -1101,6 +1131,8 @@ async function parseRepoConfigPatch(req: Request): Promise<
       autoLabel?: string;
       usageCeilingPct?: number;
       repoMode?: "forge" | "lightweight";
+      previewStartScript?: string | null;
+      previewStartCommand?: string | null;
       automationConfirmed?: boolean;
     }
   | Response
@@ -1128,6 +1160,8 @@ async function parseRepoConfigPatch(req: Request): Promise<
     defaultModel,
     egressExtraHosts,
     repoMode,
+    previewStartScript,
+    previewStartCommand,
   } = scalars;
   const present =
     REPO_CFG_BOOL_FIELDS.some((k) => body[k] !== undefined) ||
@@ -1139,12 +1173,14 @@ async function parseRepoConfigPatch(req: Request): Promise<
     defaultModel !== undefined ||
     egressExtraHosts !== undefined ||
     repoMode !== undefined ||
+    previewStartScript !== undefined ||
+    previewStartCommand !== undefined ||
     body.automationConfirmed !== undefined;
   if (!present) {
     return json(
       {
         error:
-          "body must set at least one of: criticEnabled, autoAddressEnabled, learningsEnabled, autopilotEnabled, autoDrainEnabled, autoMergeEnabled, buildQueueEnabled, draftMode, autoOptimizeFlagged, hidden, signoffAuthority, sandboxProfile, defaultModel, egressExtraHosts, maxAuto, autoLabel, usageCeilingPct, repoMode, automationConfirmed",
+          "body must set at least one of: criticEnabled, autoAddressEnabled, learningsEnabled, autopilotEnabled, autoDrainEnabled, autoMergeEnabled, buildQueueEnabled, draftMode, autoOptimizeFlagged, hidden, signoffAuthority, sandboxProfile, defaultModel, egressExtraHosts, maxAuto, autoLabel, usageCeilingPct, repoMode, previewStartScript, previewStartCommand, automationConfirmed",
       },
       400,
     );
@@ -1171,6 +1207,8 @@ async function parseRepoConfigPatch(req: Request): Promise<
     autoLabel,
     usageCeilingPct,
     repoMode,
+    previewStartScript,
+    previewStartCommand,
     automationConfirmed: body.automationConfirmed as boolean | undefined,
   };
 }
@@ -2041,9 +2079,117 @@ async function handleSessionAnswerPlanQuestions({
   return json({ ok: true, delivered });
 }
 
-// POST /api/sessions/:id/preview/start — steer the agent to start its dev server.
-// Flow: already_bound? → 409. Resolve command (body.command ?? detectDevCommand). No
-// command? → 409. Steer → true → 200; false (dead pane / unknown) → 404.
+function previewLauncher(deps: AppDeps): NonNullable<AppDeps["previewLauncher"]> {
+  return {
+    findDevPort: deps.previewLauncher?.findDevPort ?? findPreviewDevPort,
+    scriptExists: deps.previewLauncher?.scriptExists ?? previewScriptExists,
+    scriptPath: deps.previewLauncher?.scriptPath ?? resolvePreviewStartScriptPath,
+    ensureScript: deps.previewLauncher?.ensureScript ?? ensurePreviewStartScript,
+    startScript: deps.previewLauncher?.startScript ?? startPreviewScript,
+  };
+}
+
+type PreviewLauncher = NonNullable<AppDeps["previewLauncher"]>;
+
+async function parsePreviewStartCommand(req: Request): Promise<string | undefined> {
+  const body = (await req.json().catch(() => null)) as { command?: unknown } | null;
+  const rawCommand = body && typeof body.command === "string" ? body.command.trim() : undefined;
+  return rawCommand || undefined;
+}
+
+async function bindExistingPreviewServer(
+  id: string,
+  s: Session,
+  deps: AppDeps,
+  launcher: PreviewLauncher,
+): Promise<Response | null> {
+  const devPort = await launcher.findDevPort(s.worktreePath);
+  if (devPort === null) return null;
+  const previewPort = deps.preview?.ensure?.(id, devPort) ?? null;
+  return json({
+    ok: true,
+    mode: "local",
+    alreadyRunning: true,
+    command: "existing dev server",
+    previewPort,
+  });
+}
+
+async function startStoredPreviewScript(
+  s: Session,
+  launcher: PreviewLauncher,
+  storedScript: string | null,
+  command: string | null,
+): Promise<Response | null> {
+  const scriptStillExists = await launcher.scriptExists(storedScript);
+  if (!scriptStillExists || storedScript === null) return null;
+  try {
+    await launcher.startScript(storedScript, s.worktreePath);
+    return json({
+      ok: true,
+      mode: "local",
+      command: command ?? storedScript,
+      script: storedScript,
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function sendPreviewSetupSteer(
+  id: string,
+  s: Session,
+  deps: AppDeps,
+  launcher: PreviewLauncher,
+  cfg: RepoConfig,
+  command: string | null,
+): Promise<Response | null> {
+  const setupScriptPath = cfg.previewStartScript ?? (await launcher.scriptPath(s.worktreePath));
+  if (setupScriptPath === null) return null;
+  deps.store.setRepoConfig(s.repoPath, {
+    ...cfg,
+    previewStartScript: setupScriptPath,
+    previewStartCommand: command,
+  });
+  const ok = deps.service.reply(
+    id,
+    PREVIEW_SETUP_STEER({
+      scriptPath: setupScriptPath,
+      worktreePath: s.worktreePath,
+      command,
+      agentProvider: s.agentProvider ?? "claude",
+    }),
+  );
+  return ok
+    ? json({
+        ok: true,
+        mode: "agent_setup",
+        command: command ?? "setup local preview script",
+        script: setupScriptPath,
+      })
+    : json({ error: "not found" }, 404);
+}
+
+async function sendLegacyPreviewStart(
+  id: string,
+  s: Session,
+  deps: AppDeps,
+  command: string | null,
+): Promise<Response> {
+  const resolved = command ?? (await detectDevCommand(s.worktreePath));
+  if (!resolved) return json({ error: "command_unknown" }, 409);
+  const ok = deps.service.startPreview(id, resolved);
+  return ok
+    ? json({ ok: true, mode: "agent", command: resolved })
+    : json({ error: "not found" }, 404);
+}
+
+// POST /api/sessions/:id/preview/start — start a dev-server preview.
+// Flow: already_bound? → 409. If a dev server already listens in the worktree,
+// bind the proxy immediately. Otherwise run the repo's stored local preview script
+// (`.git/shepherd/preview-start.sh`, path stored in repo_config). When the script
+// is missing, send a one-time setup steer so the agent can author repo-specific
+// local start logic instead of Shepherd guessing a generic dev command.
 async function handlePreviewStart({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (!(req.method === "POST" && parts[2] && parts[3] === "preview" && parts[4] === "start"))
     return null;
@@ -2060,17 +2206,34 @@ async function handlePreviewStart({ req, parts, deps }: Ctx): Promise<Response |
   const s = deps.store.get(id);
   if (!s) return json({ error: "not found" }, 404);
 
-  const body = (await req.json().catch(() => null)) as { command?: unknown } | null;
-  const rawCommand = body && typeof body.command === "string" ? body.command.trim() : undefined;
-  const bodyCommand = rawCommand || undefined;
+  const bodyCommand = await parsePreviewStartCommand(req);
+  const launcher = previewLauncher(deps);
 
-  // 2. Resolve command: explicit body.command OR auto-detect.
-  const command = bodyCommand ?? (await detectDevCommand(s.worktreePath));
-  if (!command) return json({ error: "command_unknown" }, 409);
+  // 2. If the server is already running in this worktree but the preview proxy
+  // has not bound yet, bind it now instead of spawning anything.
+  const existingServer = await bindExistingPreviewServer(id, s, deps, launcher);
+  if (existingServer) return existingServer;
 
-  // 3. Steer the agent.
-  const ok = deps.service.startPreview(id, command);
-  return ok ? json({ ok: true, command }) : json({ error: "not found" }, 404);
+  // 3. Prefer an existing local repo script. It lives under the repo's git common
+  // dir and is recorded in repo_config, so it is shared by sessions for this repo
+  // without entering the git-tracked working tree.
+  const cfg = deps.store.getRepoConfig(s.repoPath);
+  const storedScript = cfg.previewStartScript ?? null;
+  const storedCommand = cfg.previewStartCommand ?? null;
+  const detectedCommand = bodyCommand ?? storedCommand ?? (await detectDevCommand(s.worktreePath));
+
+  const localStart = await startStoredPreviewScript(s, launcher, storedScript, detectedCommand);
+  if (localStart) return localStart;
+
+  // 4. No script yet: ask the session agent once to create a repo-specific local
+  // script at the canonical path and remember that path in repo_config. Later
+  // sessions for this repo can then start the script directly without LLM work.
+  const setupStart = await sendPreviewSetupSteer(id, s, deps, launcher, cfg, detectedCommand);
+  if (setupStart) return setupStart;
+
+  // 5. Legacy fallback: if local script setup is not possible (for example no git
+  // common dir), steer the agent exactly like previous versions did.
+  return sendLegacyPreviewStart(id, s, deps, detectedCommand);
 }
 
 // POST /api/sessions/:id/preview/stop — force-stop the previewed dev server.

--- a/src/service.ts
+++ b/src/service.ts
@@ -807,6 +807,34 @@ export function PREVIEW_START_STEER(
   );
 }
 
+export function PREVIEW_SETUP_STEER({
+  scriptPath,
+  worktreePath,
+  command,
+  agentProvider = "claude",
+}: {
+  scriptPath: string;
+  worktreePath: string;
+  command: string | null;
+  agentProvider?: "claude" | "codex";
+}): string {
+  const prefix =
+    agentProvider === "codex"
+      ? "For Codex: set up this repo's local Shepherd preview script. "
+      : "For Claude Code: set up this repo's local Shepherd preview script. ";
+  const detected = command
+    ? `Shepherd detected this likely starting point: \`${command}\`, but adjust it if this repo needs a different local test/dev environment. `
+    : "Shepherd could not confidently detect a start command, so inspect the repo first. ";
+  return (
+    prefix +
+    detected +
+    `Create an executable script at \`${scriptPath}\`. This file is intentionally local-only under the git common dir; do not commit it, symlink it, or add a tracked repo file unless the repo genuinely needs that for its own setup. ` +
+    `The script must be repo-specific and safe to run repeatedly from any worktree of this repo. It should cd to \`\${SHEPHERD_WORKTREE_PATH:-${worktreePath}}\`, perform any required local setup such as installing missing dependencies or preparing local services, choose a free dev-server port when the default is busy, write the chosen port to \`${worktreePath}/.shepherd-preview\`, then exec the foreground dev/test server process. ` +
+    `If the repo needs Docker, databases, seed data, env files, or a non-Node toolchain, encode the local steps in that script with clear failure messages. ` +
+    `After creating the script, run it once in a managed/background terminal (not as a blocking foreground command), confirm the port it listens on, and then continue what you were doing.`
+  );
+}
+
 /** Steered into a planning session when its plan is approved and the operator hits Go (or an
  *  auto session auto-releases). Hands the agent from the grill/plan phase into execution. NOT i18n'd.
  *  When `draftMode` is true, appends the draft-PR note so the agent opens a draft PR. */

--- a/src/service.ts
+++ b/src/service.ts
@@ -829,7 +829,7 @@ export function PREVIEW_SETUP_STEER({
     prefix +
     detected +
     `Create an executable script at \`${scriptPath}\`. This file is intentionally local-only under the git common dir; do not commit it, symlink it, or add a tracked repo file unless the repo genuinely needs that for its own setup. ` +
-    `The script must be repo-specific and safe to run repeatedly from any worktree of this repo. It should cd to \`\${SHEPHERD_WORKTREE_PATH:-${worktreePath}}\`, perform any required local setup such as installing missing dependencies or preparing local services, choose a free dev-server port when the default is busy, write the chosen port to \`${worktreePath}/.shepherd-preview\`, then exec the foreground dev/test server process. ` +
+    `The script must be repo-specific and safe to run repeatedly from any worktree of this repo. It should set a runtime root variable such as \`WORKTREE_ROOT="\${SHEPHERD_WORKTREE_PATH:-${worktreePath}}"\`, cd there, perform any required local setup such as installing missing dependencies or preparing local services, choose a free dev-server port when the default is busy, write the chosen port to \`$WORKTREE_ROOT/.shepherd-preview\`, then exec the foreground dev/test server process. ` +
     `If the repo needs Docker, databases, seed data, env files, or a non-Node toolchain, encode the local steps in that script with clear failure messages. ` +
     `After creating the script, run it once in a managed/background terminal (not as a blocking foreground command), confirm the port it listens on, and then continue what you were doing.`
   );

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,4 @@
-import { Database } from "bun:sqlite";
+import { Database, type SQLQueryBindings } from "bun:sqlite";
 import { randomUUID } from "node:crypto";
 import type {
   Session,
@@ -114,6 +114,10 @@ export interface RepoConfig {
   /** Hidden from the Backlog repos panel (list-only declutter; never affects sessions/drain).
    *  Default OFF. */
   hidden: boolean;
+  /** Local, non-replicated script Shepherd can run to start a repo preview without steering an agent. */
+  previewStartScript?: string | null;
+  /** The command captured when the local preview script was generated; used to recreate stale scripts. */
+  previewStartCommand?: string | null;
 }
 
 export interface LocalPr {
@@ -426,6 +430,8 @@ type RepoCfgRow = {
   autoOptimizeFlagged: number;
   manualStepsIssueEnabled: number;
   hidden: number;
+  previewStartScript: string | null;
+  previewStartCommand: string | null;
 };
 
 /** Tolerantly parse the persisted mergeTrainPrs JSON back to number[] | null (never throws). */
@@ -551,6 +557,8 @@ function repoConfigFromRow(r: RepoCfgRow | null): RepoConfig {
       autoOptimizeFlagged: false,
       manualStepsIssueEnabled: false,
       hidden: false,
+      previewStartScript: null,
+      previewStartCommand: null,
     };
   }
   return {
@@ -575,7 +583,39 @@ function repoConfigFromRow(r: RepoCfgRow | null): RepoConfig {
     autoOptimizeFlagged: !!r.autoOptimizeFlagged,
     manualStepsIssueEnabled: !!r.manualStepsIssueEnabled,
     hidden: !!r.hidden,
+    previewStartScript: r.previewStartScript ?? null,
+    previewStartCommand: r.previewStartCommand ?? null,
   };
+}
+
+function repoConfigParams(repoPath: string, cfg: RepoConfig): SQLQueryBindings[] {
+  return [
+    repoPath,
+    Number(Boolean(cfg.criticEnabled)),
+    Number(Boolean(cfg.criticAllPrs)),
+    Number(Boolean(cfg.autoAddressEnabled)),
+    Number(Boolean(cfg.learningsEnabled)),
+    Number(Boolean(cfg.autopilotEnabled)),
+    Number(Boolean(cfg.planGateEnabled)),
+    Number(Boolean(cfg.autoDrainEnabled)),
+    Number(Boolean(cfg.autoMergeEnabled)),
+    Number(Boolean(cfg.buildQueueEnabled)),
+    Number(Boolean(cfg.draftMode)),
+    cfg.signoffAuthority,
+    cfg.maxAuto,
+    cfg.autoLabel,
+    cfg.usageCeilingPct,
+    cfg.sandboxProfile,
+    cfg.defaultModel,
+    JSON.stringify(cfg.egressExtraHosts ?? []),
+    cfg.repoMode,
+    Number(Boolean(cfg.autoOptimizeFlagged)),
+    Number(Boolean(cfg.manualStepsIssueEnabled)),
+    Number(Boolean(cfg.hidden)),
+    cfg.previewStartScript ?? null,
+    cfg.previewStartCommand ?? null,
+    Date.now(),
+  ];
 }
 
 type LocalPrRow = {
@@ -1087,7 +1127,7 @@ export class SessionStore implements CapStore, CreditStore {
         `SELECT criticEnabled, criticAllPrs, autoAddressEnabled, learningsEnabled, autopilotEnabled, planGateEnabled,
                 autoDrainEnabled, autoMergeEnabled, buildQueueEnabled, draftMode, signoffAuthority,
                 maxAuto, autoLabel, usageCeilingPct, sandboxProfile, defaultModel, egressExtraHosts, repoMode,
-                autoOptimizeFlagged, manualStepsIssueEnabled, hidden
+                autoOptimizeFlagged, manualStepsIssueEnabled, hidden, previewStartScript, previewStartCommand
          FROM repo_config WHERE repoPath = ?`,
       )
       .get(repoPath) as RepoCfgRow | null;
@@ -1100,8 +1140,8 @@ export class SessionStore implements CapStore, CreditStore {
          (repoPath, criticEnabled, criticAllPrs, autoAddressEnabled, learningsEnabled, autopilotEnabled, planGateEnabled,
           autoDrainEnabled, autoMergeEnabled, buildQueueEnabled, draftMode, signoffAuthority,
           maxAuto, autoLabel, usageCeilingPct, sandboxProfile, defaultModel, egressExtraHosts, repoMode,
-          autoOptimizeFlagged, manualStepsIssueEnabled, hidden, updatedAt)
-         VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+          autoOptimizeFlagged, manualStepsIssueEnabled, hidden, previewStartScript, previewStartCommand, updatedAt)
+         VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
        ON CONFLICT(repoPath) DO UPDATE SET criticEnabled = excluded.criticEnabled,
          criticAllPrs = excluded.criticAllPrs,
          autoAddressEnabled = excluded.autoAddressEnabled,
@@ -1123,32 +1163,10 @@ export class SessionStore implements CapStore, CreditStore {
          autoOptimizeFlagged = excluded.autoOptimizeFlagged,
          manualStepsIssueEnabled = excluded.manualStepsIssueEnabled,
          hidden = excluded.hidden,
+         previewStartScript = excluded.previewStartScript,
+         previewStartCommand = excluded.previewStartCommand,
          updatedAt = excluded.updatedAt`,
-      [
-        repoPath,
-        cfg.criticEnabled ? 1 : 0,
-        cfg.criticAllPrs ? 1 : 0,
-        cfg.autoAddressEnabled ? 1 : 0,
-        cfg.learningsEnabled ? 1 : 0,
-        cfg.autopilotEnabled ? 1 : 0,
-        cfg.planGateEnabled ? 1 : 0,
-        cfg.autoDrainEnabled ? 1 : 0,
-        cfg.autoMergeEnabled ? 1 : 0,
-        cfg.buildQueueEnabled ? 1 : 0,
-        cfg.draftMode ? 1 : 0,
-        cfg.signoffAuthority,
-        cfg.maxAuto,
-        cfg.autoLabel,
-        cfg.usageCeilingPct,
-        cfg.sandboxProfile,
-        cfg.defaultModel,
-        JSON.stringify(cfg.egressExtraHosts ?? []),
-        cfg.repoMode,
-        cfg.autoOptimizeFlagged ? 1 : 0,
-        cfg.manualStepsIssueEnabled ? 1 : 0,
-        cfg.hidden ? 1 : 0,
-        Date.now(),
-      ],
+      repoConfigParams(repoPath, cfg),
     );
   }
 
@@ -3003,6 +3021,9 @@ export class SessionStore implements CapStore, CreditStore {
     add("manualStepsIssueEnabled", `manualStepsIssueEnabled INTEGER NOT NULL DEFAULT 0`);
     // Hidden from the Backlog repos panel (list-only declutter). Default OFF.
     add("hidden", `hidden INTEGER NOT NULL DEFAULT 0`);
+    // Local preview launcher metadata. Nullable: absent until first successful script setup.
+    add("previewStartScript", `previewStartScript TEXT`);
+    add("previewStartCommand", `previewStartCommand TEXT`);
     // Issue #1025: first-task automation-confirmation. Nullable — new repos start unconfirmed.
     if (!cols.some((c) => c.name === "automationConfirmedAt")) {
       this.db.run(`ALTER TABLE repo_config ADD COLUMN automationConfirmedAt INTEGER`);

--- a/test/preview-launch.test.ts
+++ b/test/preview-launch.test.ts
@@ -1,0 +1,78 @@
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { ensurePreviewStartScript } from "../src/preview-launch";
+
+test("ensurePreviewStartScript: generated package dev wrapper installs deps and picks a free port", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-preview-launch-"));
+  try {
+    execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+
+    const scriptPath = await ensurePreviewStartScript(dir, "cd ui && bun run dev");
+    expect(scriptPath).not.toBeNull();
+    expect(scriptPath!.startsWith(join(dir, ".git", "shepherd"))).toBe(true);
+    execFileSync("bash", ["-n", scriptPath!]);
+
+    const body = readFileSync(scriptPath!, "utf8");
+    expect(body).toContain("install_if_needed");
+    expect(body).toContain("bun install");
+    expect(body).toContain("pick_port");
+    expect(body).toContain(`printf '%s\\n' "$port" > "$WORKTREE_ROOT/.shepherd-preview"`);
+    expect(body).toContain(`exec bun run dev -- --port "$port"`);
+    expect(body).toContain(`run_package_dev "\${BASH_REMATCH[1]}" "\${BASH_REMATCH[2]}"`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("ensurePreviewStartScript: package wrapper runs dev command with selected port", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-preview-launch-run-"));
+  try {
+    execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+    mkdirSync(join(dir, "ui", "node_modules"), { recursive: true });
+    writeFileSync(
+      join(dir, "ui", "package.json"),
+      JSON.stringify({ scripts: { dev: "vite dev" } }),
+    );
+
+    const fakeBin = join(dir, "bin");
+    const fakeBunOut = join(dir, "fake-bun.out");
+    mkdirSync(fakeBin);
+    const fakeBun = join(fakeBin, "bun");
+    writeFileSync(
+      fakeBun,
+      `#!/usr/bin/env bash
+{
+  printf 'cwd=%s\\n' "$PWD"
+  printf 'args=%s\\n' "$*"
+  printf 'PORT=%s\\n' "$PORT"
+} > "$FAKE_BUN_OUT"
+`,
+    );
+    chmodSync(fakeBun, 0o700);
+
+    const scriptPath = await ensurePreviewStartScript(dir, "cd ui && bun run dev");
+    expect(scriptPath).not.toBeNull();
+
+    execFileSync(scriptPath!, {
+      cwd: dir,
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        FAKE_BUN_OUT: fakeBunOut,
+        SHEPHERD_WORKTREE_PATH: dir,
+        SHEPHERD_PREVIEW_PORT: "45678",
+      },
+    });
+
+    const output = readFileSync(fakeBunOut, "utf8");
+    expect(output).toContain(`cwd=${join(dir, "ui")}`);
+    expect(output).toContain("args=run dev -- --port 45678");
+    expect(output).toContain("PORT=45678");
+    expect(readFileSync(join(dir, ".shepherd-preview"), "utf8")).toBe("45678\n");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/server-preview-start.test.ts
+++ b/test/server-preview-start.test.ts
@@ -268,6 +268,44 @@ test("preview/start: existing dev port binds preview without spawning or steerin
   expect(steered).toBe(false);
 });
 
+test("preview/start: existing dev port with no preview slot returns an error", async () => {
+  let spawned = false;
+  let steered = false;
+  const { store } = harness();
+  const id = makeSession(store, "/wt/no-slot");
+  const app = makeApp({
+    store,
+    service: {
+      startPreview: () => {
+        steered = true;
+        return true;
+      },
+    } as any,
+    events: new EventHub(),
+    usageLimits: { limits: () => ({}) } as any,
+    preview: {
+      snapshot: () => ({}),
+      ensure: () => null,
+    },
+    previewLauncher: {
+      findDevPort: async () => 5173,
+      scriptExists: async () => true,
+      scriptPath: async () => "/git/shepherd/preview-start.sh",
+      ensureScript: async () => "/git/shepherd/preview-start.sh",
+      startScript: async () => {
+        spawned = true;
+      },
+    },
+  });
+
+  const res = await app.fetch(postJson(`/api/sessions/${id}/preview/start`, {}));
+  expect(res.status).toBe(503);
+  const body = (await res.json()) as { error: string };
+  expect(body.error).toBe("preview_slot_unavailable");
+  expect(spawned).toBe(false);
+  expect(steered).toBe(false);
+});
+
 test("preview/start: dead pane → 404 when startPreview returns false", async () => {
   const { app, store } = harness({ startPreview: () => false }, {});
   const id = makeSession(store);

--- a/test/server-preview-start.test.ts
+++ b/test/server-preview-start.test.ts
@@ -159,6 +159,59 @@ test("preview/start: configured local script starts without steering the agent",
   expect(calls).toEqual(["/git/shepherd/preview-start.sh @ /wt/local-script"]);
 });
 
+test("preview/start: ignores a non-canonical stored local script path", async () => {
+  const replies: { id: string; text: string }[] = [];
+  let spawned = false;
+  const { store } = harness();
+  const id = makeSession(store, "/wt/non-canonical-script");
+  store.setRepoConfig("/r", {
+    ...store.getRepoConfig("/r"),
+    previewStartScript: "/tmp/run-anything.sh",
+    previewStartCommand: "bun run dev",
+  });
+
+  const app = makeApp({
+    store,
+    service: {
+      reply: (sessionId: string, text: string) => {
+        replies.push({ id: sessionId, text });
+        return true;
+      },
+      startPreview: () => {
+        throw new Error("legacy start steer must not be used");
+      },
+    } as any,
+    events: new EventHub(),
+    usageLimits: { limits: () => ({}) } as any,
+    preview: { snapshot: () => ({}) },
+    previewLauncher: {
+      findDevPort: async () => null,
+      scriptExists: async () => true,
+      scriptPath: async () => "/git/shepherd/preview-start.sh",
+      ensureScript: async () => {
+        throw new Error("setup steer should author the script");
+      },
+      startScript: async () => {
+        spawned = true;
+      },
+    },
+  });
+
+  const res = await app.fetch(postJson(`/api/sessions/${id}/preview/start`, {}));
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { ok: boolean; mode: string; script: string };
+  expect(body).toMatchObject({
+    ok: true,
+    mode: "agent_setup",
+    script: "/git/shepherd/preview-start.sh",
+  });
+  expect(spawned).toBe(false);
+  expect(replies).toHaveLength(1);
+  expect(replies[0]!.text).toContain("/git/shepherd/preview-start.sh");
+  expect(replies[0]!.text).not.toContain("/tmp/run-anything.sh");
+  expect(store.getRepoConfig("/r").previewStartScript).toBe("/git/shepherd/preview-start.sh");
+});
+
 test("preview/start: missing local script sends one-time repo setup steer", async () => {
   const replies: { id: string; text: string }[] = [];
   let spawned = false;

--- a/test/server-preview-start.test.ts
+++ b/test/server-preview-start.test.ts
@@ -111,6 +111,163 @@ test("preview/start: success → 200 {ok, command} when command provided in body
   expect(calls).toEqual([{ id, command: "bun run dev" }]);
 });
 
+test("preview/start: configured local script starts without steering the agent", async () => {
+  const calls: string[] = [];
+  const { store } = harness(
+    {
+      startPreview: () => {
+        throw new Error("agent steer must not be used");
+      },
+    },
+    {},
+  );
+  const id = makeSession(store, "/wt/local-script");
+  store.setRepoConfig("/r", {
+    ...store.getRepoConfig("/r"),
+    previewStartScript: "/git/shepherd/preview-start.sh",
+    previewStartCommand: "bun run dev",
+  });
+
+  const localDeps: AppDeps = {
+    store,
+    service: {
+      startPreview: () => {
+        throw new Error("agent steer must not be used");
+      },
+    } as any,
+    events: new EventHub(),
+    usageLimits: { limits: () => ({}) } as any,
+    preview: { snapshot: () => ({}) },
+    previewLauncher: {
+      findDevPort: async () => null,
+      scriptExists: async () => true,
+      scriptPath: async () => "/git/shepherd/preview-start.sh",
+      ensureScript: async () => {
+        throw new Error("script already exists");
+      },
+      startScript: async (scriptPath, worktreePath) => {
+        calls.push(`${scriptPath} @ ${worktreePath}`);
+      },
+    },
+  };
+  const localApp = makeApp(localDeps);
+
+  const res = await localApp.fetch(postJson(`/api/sessions/${id}/preview/start`, {}));
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { ok: boolean; mode: string; command: string };
+  expect(body).toMatchObject({ ok: true, mode: "local", command: "bun run dev" });
+  expect(calls).toEqual(["/git/shepherd/preview-start.sh @ /wt/local-script"]);
+});
+
+test("preview/start: missing local script sends one-time repo setup steer", async () => {
+  const replies: { id: string; text: string }[] = [];
+  let spawned = false;
+  let ensured = false;
+  const { store } = harness();
+  const id = makeSession(store, "/wt/setup-script");
+
+  const app = makeApp({
+    store,
+    service: {
+      reply: (sessionId: string, text: string) => {
+        replies.push({ id: sessionId, text });
+        return true;
+      },
+      startPreview: () => {
+        throw new Error("legacy start steer must not be used");
+      },
+    } as any,
+    events: new EventHub(),
+    usageLimits: { limits: () => ({}) } as any,
+    preview: { snapshot: () => ({}) },
+    previewLauncher: {
+      findDevPort: async () => null,
+      scriptExists: async () => false,
+      scriptPath: async () => "/git/shepherd/preview-start.sh",
+      ensureScript: async () => {
+        ensured = true;
+        return "/git/shepherd/preview-start.sh";
+      },
+      startScript: async () => {
+        spawned = true;
+      },
+    },
+  });
+
+  const res = await app.fetch(
+    postJson(`/api/sessions/${id}/preview/start`, { command: "cd ui && bun run dev" }),
+  );
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { ok: boolean; mode: string; command: string; script: string };
+  expect(body).toMatchObject({
+    ok: true,
+    mode: "agent_setup",
+    command: "cd ui && bun run dev",
+    script: "/git/shepherd/preview-start.sh",
+  });
+  expect(replies).toHaveLength(1);
+  expect(replies[0]!.id).toBe(id);
+  expect(replies[0]!.text).toContain("set up this repo's local Shepherd preview script");
+  expect(replies[0]!.text).toContain("/git/shepherd/preview-start.sh");
+  expect(store.getRepoConfig("/r").previewStartScript).toBe("/git/shepherd/preview-start.sh");
+  expect(store.getRepoConfig("/r").previewStartCommand).toBe("cd ui && bun run dev");
+  expect(spawned).toBe(false);
+  expect(ensured).toBe(false);
+});
+
+test("preview/start: existing dev port binds preview without spawning or steering", async () => {
+  const ensured: { id: string; port: number }[] = [];
+  let spawned = false;
+  let steered = false;
+  const { store } = harness();
+  const id = makeSession(store, "/wt/running");
+  const app = makeApp({
+    store,
+    service: {
+      startPreview: () => {
+        steered = true;
+        return true;
+      },
+    } as any,
+    events: new EventHub(),
+    usageLimits: { limits: () => ({}) } as any,
+    preview: {
+      snapshot: () => ({}),
+      ensure: (sessionId, devPort) => {
+        ensured.push({ id: sessionId, port: devPort });
+        return 8001;
+      },
+    },
+    previewLauncher: {
+      findDevPort: async () => 5173,
+      scriptExists: async () => true,
+      scriptPath: async () => "/git/shepherd/preview-start.sh",
+      ensureScript: async () => "/git/shepherd/preview-start.sh",
+      startScript: async () => {
+        spawned = true;
+      },
+    },
+  });
+
+  const res = await app.fetch(postJson(`/api/sessions/${id}/preview/start`, {}));
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as {
+    ok: boolean;
+    mode: string;
+    alreadyRunning: boolean;
+    previewPort: number;
+  };
+  expect(body).toMatchObject({
+    ok: true,
+    mode: "local",
+    alreadyRunning: true,
+    previewPort: 8001,
+  });
+  expect(ensured).toEqual([{ id, port: 5173 }]);
+  expect(spawned).toBe(false);
+  expect(steered).toBe(false);
+});
+
 test("preview/start: dead pane → 404 when startPreview returns false", async () => {
   const { app, store } = harness({ startPreview: () => false }, {});
   const id = makeSession(store);

--- a/test/server-reviews.test.ts
+++ b/test/server-reviews.test.ts
@@ -111,6 +111,8 @@ test("GET /api/repo-config defaults to critic on + auto-address off", async () =
     defaultModel: "inherit",
     egressExtraHosts: [],
     repoMode: "forge",
+    previewStartScript: null,
+    previewStartCommand: null,
     automationConfirmed: false,
     automationRowExists: false,
   });
@@ -166,6 +168,8 @@ test("PUT /api/repo-config sets criticEnabled=false, GET reflects it", async () 
     defaultModel: "inherit",
     egressExtraHosts: [],
     repoMode: "forge",
+    previewStartScript: null,
+    previewStartCommand: null,
     automationConfirmed: false,
     automationRowExists: true,
   });
@@ -194,6 +198,8 @@ test("PUT /api/repo-config sets criticEnabled=false, GET reflects it", async () 
     defaultModel: "inherit",
     egressExtraHosts: [],
     repoMode: "forge",
+    previewStartScript: null,
+    previewStartCommand: null,
     automationConfirmed: false,
     automationRowExists: true,
   });
@@ -232,6 +238,8 @@ test("PUT /api/repo-config toggles autoAddressEnabled independently of criticEna
     defaultModel: "inherit",
     egressExtraHosts: [],
     repoMode: "forge",
+    previewStartScript: null,
+    previewStartCommand: null,
     automationConfirmed: false,
     automationRowExists: true,
   });
@@ -270,6 +278,8 @@ test("PUT /api/repo-config sets learningsEnabled independently of criticEnabled"
     defaultModel: "inherit",
     egressExtraHosts: [],
     repoMode: "forge",
+    previewStartScript: null,
+    previewStartCommand: null,
     automationConfirmed: false,
     automationRowExists: true,
   });

--- a/test/server-reviews.test.ts
+++ b/test/server-reviews.test.ts
@@ -336,6 +336,22 @@ test("PUT /api/repo-config with repo outside root → 400", async () => {
   expect(res.status).toBe(400);
 });
 
+test("PUT /api/repo-config rejects non-canonical previewStartScript", async () => {
+  const { app, store } = harness();
+  const url = `http://x/api/repo-config?repo=${encodeURIComponent(repoDir)}`;
+  const res = await app.fetch(
+    new Request(url, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ previewStartScript: "/tmp/run-anything.sh" }),
+    }),
+  );
+  expect(res.status).toBe(400);
+  const body = (await res.json()) as { error: string };
+  expect(body.error).toContain("previewStartScript");
+  expect(store.getRepoConfig(repoDir).previewStartScript).toBeNull();
+});
+
 // ── repoMode ──────────────────────────────────────────────────────────────────
 
 test("PUT /api/repo-config repoMode=lightweight persists, GET returns lightweight", async () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -25,6 +25,7 @@ import {
   DRAFT_PR_NOTE,
   planGoSteer,
   PREVIEW_START_STEER,
+  PREVIEW_SETUP_STEER,
   buildQueueDirective,
 } from "../src/service";
 import { WorktreeRestoreError } from "../src/worktree";
@@ -3823,6 +3824,18 @@ test("composeSystemPrompt places <preview-hint-notice> after <branch-rename-noti
   expect(branchPos).toBeGreaterThan(-1);
   expect(phPos).toBeGreaterThan(branchPos);
   expect(sp).not.toContain("<build-queue>");
+});
+
+test("PREVIEW_SETUP_STEER tells reusable scripts to write the hint in the runtime worktree", () => {
+  const steer = PREVIEW_SETUP_STEER({
+    scriptPath: "/repo/.git/shepherd/preview-start.sh",
+    worktreePath: "/wt/setup",
+    command: "cd ui && bun run dev",
+    agentProvider: "codex",
+  });
+  expect(steer).toContain('WORKTREE_ROOT="${SHEPHERD_WORKTREE_PATH:-/wt/setup}"');
+  expect(steer).toContain("$WORKTREE_ROOT/.shepherd-preview");
+  expect(steer).not.toContain("/wt/setup/.shepherd-preview");
 });
 
 test("isolated spawn argv carries <preview-hint-notice> in system prompt", async () => {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -117,6 +117,8 @@ test("repo_config: defaults to critic on + auto-address off + learnings on, pers
     autoOptimizeFlagged: false,
     manualStepsIssueEnabled: false,
     hidden: false,
+    previewStartScript: null,
+    previewStartCommand: null,
   });
   store.setRepoConfig("/repo/a", {
     criticEnabled: false,
@@ -140,6 +142,8 @@ test("repo_config: defaults to critic on + auto-address off + learnings on, pers
     autoOptimizeFlagged: false,
     manualStepsIssueEnabled: false,
     hidden: false,
+    previewStartScript: null,
+    previewStartCommand: null,
   });
   expect(store.getRepoConfig("/repo/a")).toEqual({
     criticEnabled: false,
@@ -163,6 +167,8 @@ test("repo_config: defaults to critic on + auto-address off + learnings on, pers
     autoOptimizeFlagged: false,
     manualStepsIssueEnabled: false,
     hidden: false,
+    previewStartScript: null,
+    previewStartCommand: null,
   });
   store.setRepoConfig("/repo/a", {
     criticEnabled: true,
@@ -186,6 +192,8 @@ test("repo_config: defaults to critic on + auto-address off + learnings on, pers
     autoOptimizeFlagged: false,
     manualStepsIssueEnabled: false,
     hidden: false,
+    previewStartScript: null,
+    previewStartCommand: null,
   });
   expect(store.getRepoConfig("/repo/a")).toEqual({
     criticEnabled: true,
@@ -209,6 +217,8 @@ test("repo_config: defaults to critic on + auto-address off + learnings on, pers
     autoOptimizeFlagged: false,
     manualStepsIssueEnabled: false,
     hidden: false,
+    previewStartScript: null,
+    previewStartCommand: null,
   });
 });
 
@@ -244,6 +254,8 @@ test("repo_config: drain fields default off/cap-1/default-label/ceiling-80, pers
     autoOptimizeFlagged: false,
     manualStepsIssueEnabled: false,
     hidden: false,
+    previewStartScript: null,
+    previewStartCommand: null,
   });
   expect(store.getRepoConfig("/repo/d")).toMatchObject({
     autoDrainEnabled: true,

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -460,7 +460,7 @@
   "viewport_preview_open_new_tab": "In neuem Tab öffnen",
   "viewport_preview_setup_hint": "Leer? Stelle sicher, dass der Vorschau-Port über Tailscale erreichbar ist; siehe Setup.",
   "viewport_preview_start": "Devserver starten",
-  "viewport_preview_start_note": "Sendet die agent-spezifische Hintergrund-Startanweisung in das aktive Terminal",
+  "viewport_preview_start_note": "Startet das lokale Vorschau-Skript des Repos; falls es fehlt, richtet der Agent es einmalig ein",
   "viewport_preview_start_sent": "Vorschau-Start an {name} gesendet (läuft: {command})",
   "viewport_preview_start_failed": "Vorschau konnte nicht gestartet werden; Terminal auf Details prüfen",
   "viewport_preview_start_confirm_working": "Start bestätigen (Agent aktiv)",
@@ -2260,5 +2260,10 @@
   "prbadge_draft_toggle_failed": "PR-Zustand konnte nicht geändert werden: {reason}",
   "prbadge_unknown_error": "unbekannter Fehler",
   "feat_pr_badge_menu_title": "PR-Aktionen direkt auf Karten",
-  "feat_pr_badge_menu_body": "Session-Karten öffnen jetzt am PR-Badge ein kompaktes PR-Menü. Du kannst den Pull Request in einem neuen Tab öffnen oder einen offenen PR direkt aus der Herd-Ansicht zwischen Draft und Ready for Review umschalten."
+  "feat_pr_badge_menu_body": "Session-Karten öffnen jetzt am PR-Badge ein kompaktes PR-Menü. Du kannst den Pull Request in einem neuen Tab öffnen oder einen offenen PR direkt aus der Herd-Ansicht zwischen Draft und Ready for Review umschalten.",
+  "viewport_preview_start_local": "Vorschau-Skript für {name} gestartet ({command})",
+  "viewport_preview_setup_sent": "Vorschau-Einrichtung an {name} gesendet; künftige Starts nutzen das lokale Repo-Skript",
+  "viewport_preview_already_running": "Devserver läuft bereits; Vorschau wird geöffnet",
+  "feat_preview_local_script_title": "Lokale Vorschau-Startskripte",
+  "feat_preview_local_script_body": "Der Vorschau-Startbutton erstellt und nutzt jetzt ein lokales Skript in den Git-Metadaten des Repos. Spätere Sessions können denselben Devserver ohne Agent-Tokens starten, und Shepherd verwendet einen bereits laufenden Server statt eine zweite Kopie zu starten."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -460,7 +460,7 @@
   "viewport_preview_open_new_tab": "Open in new tab",
   "viewport_preview_setup_hint": "Blank? Ensure the preview port is reachable over Tailscale; see setup.",
   "viewport_preview_start": "Start dev server",
-  "viewport_preview_start_note": "Sends the agent-specific background-start instruction into the live terminal",
+  "viewport_preview_start_note": "Starts the repo-local preview script; if missing, asks the agent once to set it up",
   "viewport_preview_start_sent": "Preview start sent to {name} (running: {command})",
   "viewport_preview_start_failed": "Couldn't start preview; check terminal for details",
   "viewport_preview_start_confirm_working": "Confirm start (agent busy)",
@@ -2260,5 +2260,10 @@
   "prbadge_draft_toggle_failed": "Couldn't change PR state: {reason}",
   "prbadge_unknown_error": "unknown error",
   "feat_pr_badge_menu_title": "PR actions on cards",
-  "feat_pr_badge_menu_body": "Session cards now open a compact PR menu from the PR badge. Open the pull request in a new tab, or flip an open PR between Draft and Ready for Review without leaving the Herd view."
+  "feat_pr_badge_menu_body": "Session cards now open a compact PR menu from the PR badge. Open the pull request in a new tab, or flip an open PR between Draft and Ready for Review without leaving the Herd view.",
+  "viewport_preview_start_local": "Preview script started for {name} ({command})",
+  "viewport_preview_setup_sent": "Preview setup sent to {name}; future starts will use the local repo script",
+  "viewport_preview_already_running": "Dev server is already running; opening preview",
+  "feat_preview_local_script_title": "Local preview start scripts",
+  "feat_preview_local_script_body": "The Preview start button now creates and reuses a repo-local script under the repo's Git metadata. Later sessions can start the same dev server without spending agent tokens, and Shepherd reuses an already-running server instead of starting another copy."
 }

--- a/ui/src/lib/api.startPreview.test.ts
+++ b/ui/src/lib/api.startPreview.test.ts
@@ -14,6 +14,36 @@ describe("startPreview", () => {
     expect(result).toEqual({ ok: true, command: "npm run dev" });
   });
 
+  it("maps 200 local already-running preview metadata", async () => {
+    globalThis.fetch = mockFetch(200, {
+      ok: true,
+      command: "existing dev server",
+      mode: "local",
+      alreadyRunning: true,
+    });
+    const result = await startPreview("s1");
+    expect(result).toEqual({
+      ok: true,
+      command: "existing dev server",
+      mode: "local",
+      alreadyRunning: true,
+    });
+  });
+
+  it("maps 200 agent setup preview metadata", async () => {
+    globalThis.fetch = mockFetch(200, {
+      ok: true,
+      command: "setup local preview script",
+      mode: "agent_setup",
+    });
+    const result = await startPreview("s1");
+    expect(result).toEqual({
+      ok: true,
+      command: "setup local preview script",
+      mode: "agent_setup",
+    });
+  });
+
   it("maps 409 command_unknown → {needCommand: true}", async () => {
     globalThis.fetch = mockFetch(409, { error: "command_unknown" });
     const result = await startPreview("s1");

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1472,6 +1472,8 @@ export async function putRepoConfig(
       | "autoOptimizeFlagged"
       | "manualStepsIssueEnabled"
       | "hidden"
+      | "previewStartScript"
+      | "previewStartCommand"
     >
   > & { automationConfirmed?: boolean },
 ): Promise<RepoConfigResponse> {
@@ -1764,15 +1766,26 @@ export async function actStarPrompt(
   return r.json();
 }
 
-/** Steer the agent to start its dev-server preview.
- *  - `{ok, command}` — directive sent; the agent will start the server.
+/** Start the session's dev-server preview.
+ *  - `{ok, command, mode:"local"}` — Shepherd started the repo-local preview script.
+ *  - `{ok, command, mode:"agent_setup"}` — directive sent; the agent will create the local script.
+ *  - `{ok, command, mode:"agent"}` — legacy directive sent; the agent will start the server.
  *  - `{needCommand}` — no command auto-detected; caller must collect one and retry.
  *  - `{alreadyBound}` — a preview port is already live (benign race).
  *  Throws on 404 (unknown/dead session) or any other unexpected failure. */
 export async function startPreview(
   id: string,
   command?: string,
-): Promise<{ needCommand: true } | { alreadyBound: true } | { ok: true; command: string }> {
+): Promise<
+  | { needCommand: true }
+  | { alreadyBound: true }
+  | {
+      ok: true;
+      command: string;
+      mode?: "local" | "agent_setup" | "agent";
+      alreadyRunning?: boolean;
+    }
+> {
   const r = await fetch(`/api/sessions/${id}/preview/start`, {
     method: "POST",
     headers: JSON_HEADERS,
@@ -1783,8 +1796,23 @@ export async function startPreview(
     ok?: boolean;
     command?: string;
     error?: string;
+    mode?: "local" | "agent_setup" | "agent";
+    alreadyRunning?: boolean;
   };
-  if (r.ok) return { ok: true, command: body.command ?? "" };
+  if (r.ok) {
+    const result: {
+      ok: true;
+      command: string;
+      mode?: "local" | "agent_setup" | "agent";
+      alreadyRunning?: boolean;
+    } = {
+      ok: true,
+      command: body.command ?? "",
+    };
+    if (body.mode !== undefined) result.mode = body.mode;
+    if (body.alreadyRunning === true) result.alreadyRunning = true;
+    return result;
+  }
   if (r.status === 409 && body.error === "command_unknown") return { needCommand: true };
   if (r.status === 409 && body.error === "already_bound") return { alreadyBound: true };
   throw apiError(r.status, body, `startPreview failed: ${r.status}`);

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -73,6 +73,8 @@ function repoConfig(
     autoOptimizeFlagged: false,
     manualStepsIssueEnabled: false,
     hidden: false,
+    previewStartScript: null,
+    previewStartCommand: null,
     automationConfirmed: true,
     automationRowExists: true,
   };
@@ -983,6 +985,8 @@ function unconfirmedNewRepoConfig(): RepoConfig & {
     autoOptimizeFlagged: false,
     manualStepsIssueEnabled: false,
     hidden: false,
+    previewStartScript: null,
+    previewStartCommand: null,
     automationConfirmed: false,
     automationRowExists: false,
   };

--- a/ui/src/lib/components/viewport/ViewportTabBar.svelte
+++ b/ui/src/lib/components/viewport/ViewportTabBar.svelte
@@ -120,9 +120,24 @@
       return;
     }
 
-    // ok: directive sent. Set pending guard.
+    if (result.mode === "local" && result.alreadyRunning) {
+      toasts.info(m.viewport_preview_already_running());
+      return;
+    }
+
+    if (result.mode === "agent_setup") {
+      setPreviewPending(session.id);
+      toasts.info(m.viewport_preview_setup_sent({ name: session.name }));
+      return;
+    }
+
+    // ok: local script started or directive sent. Set pending guard.
     setPreviewPending(session.id);
-    toasts.info(m.viewport_preview_start_sent({ name: session.name, command: result.command }));
+    toasts.info(
+      result.mode === "local"
+        ? m.viewport_preview_start_local({ name: session.name, command: result.command })
+        : m.viewport_preview_start_sent({ name: session.name, command: result.command }),
+    );
   }
 
   async function onStartPreviewClick() {

--- a/ui/src/lib/demo/seed.ts
+++ b/ui/src/lib/demo/seed.ts
@@ -1423,6 +1423,8 @@ function buildRepoConfig(): Record<string, DemoRepoConfig> {
     autoOptimizeFlagged: false,
     manualStepsIssueEnabled: false,
     hidden: false,
+    previewStartScript: null,
+    previewStartCommand: null,
     automationConfirmed: true,
     automationRowExists: true,
   };

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1937,6 +1937,8 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     sinceVersion: "1.39.0",
     titleKey: "feat_pr_badge_menu_title",
     bodyKey: "feat_pr_badge_menu_body",
+  },
+  {
     // No targetId: the Start control only renders on sessions without a live preview;
     // most users will encounter this via the What's-New drawer rather than a stable anchor.
     id: "preview-local-script",

--- a/ui/src/lib/feature-announcements.ts
+++ b/ui/src/lib/feature-announcements.ts
@@ -1937,5 +1937,11 @@ export const featureAnnouncements: readonly FeatureAnnouncement[] = [
     sinceVersion: "1.39.0",
     titleKey: "feat_pr_badge_menu_title",
     bodyKey: "feat_pr_badge_menu_body",
+    // No targetId: the Start control only renders on sessions without a live preview;
+    // most users will encounter this via the What's-New drawer rather than a stable anchor.
+    id: "preview-local-script",
+    sinceVersion: "1.39.0",
+    titleKey: "feat_preview_local_script_title",
+    bodyKey: "feat_preview_local_script_body",
   },
 ];

--- a/ui/src/lib/reviews.svelte.test.ts
+++ b/ui/src/lib/reviews.svelte.test.ts
@@ -33,6 +33,8 @@ const rc = (overrides: Partial<RepoConfig> = {}): RepoConfig => ({
   autoOptimizeFlagged: false,
   manualStepsIssueEnabled: false,
   hidden: false,
+  previewStartScript: null,
+  previewStartCommand: null,
   ...overrides,
 });
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -573,6 +573,10 @@ export interface RepoConfig {
   manualStepsIssueEnabled: boolean;
   /** Hidden from the Backlog repos panel (list-only declutter; sessions/drain unaffected). Default off. */
   hidden: boolean;
+  /** Local, non-replicated preview start script path stored by Shepherd. */
+  previewStartScript?: string | null;
+  /** Command captured when Shepherd generated the local preview start script. */
+  previewStartCommand?: string | null;
 }
 
 /** Live per-repo merge-train status pushed to clients (mirrors server AutoMergeStatus). */


### PR DESCRIPTION
## Summary

Adds a repo-local preview startup flow so Shepherd can start previews without spending agent tokens after a one-time setup.

- Stores a local preview script path and command in repo config.
- Starts an existing configured local script directly when the Preview button is clicked.
- Sends a one-time setup steer when the repo has no local preview script yet, so the agent can create repo-specific startup logic under the git common dir.
- Detects already-running dev servers in the worktree and binds the preview without spawning another server.
- Updates UI/API handling, i18n strings, feature announcement metadata, and tests.

## Validation

- `bun test ./test/server-preview-start.test.ts ./test/preview-launch.test.ts ./test/preview.test.ts`
- `bun test ./test/service.test.ts ./test/store.test.ts ./test/server-preview-start.test.ts`
- `bun test ./test`
- `bun run typecheck`
- `bun run lint`
- `cd ui && bun run check`
- `cd ui && bun run check:i18n`
- `cd ui && bun run test:node src/lib/api.startPreview.test.ts`
- `cd extension && bun run check`
- Pre-push hook passed, including UI, extension, root tests, and fallow audit.
