### PR TITLE
fix: make PR badge menu click-only

### DIFF
--- a/ui/src/lib/components/PrBadge.browser.test.ts
+++ b/ui/src/lib/components/PrBadge.browser.test.ts
@@ -39,24 +39,27 @@ describe("PrBadge", () => {
       .toBeInTheDocument();
   });
 
-  it("opens the action menu on mouse hover", async () => {
-    vi.spyOn(window, "matchMedia").mockImplementation(
-      () =>
-        ({
-          matches: true,
-          addEventListener: vi.fn(),
-          removeEventListener: vi.fn(),
-        }) as unknown as MediaQueryList,
-    );
+  it("does not open the action menu on mouse hover", async () => {
     render(PrBadge, { props: { git: git(), sessionId: "s1" } });
 
     document
       .querySelector<HTMLButtonElement>(".pr-badge.as-button")!
       .dispatchEvent(new MouseEvent("mouseenter"));
 
+    expect(document.querySelector("[role='menu']")).toBeNull();
+  });
+
+  it("closes the action menu when the pointer moves away", async () => {
+    render(PrBadge, { props: { git: git(), sessionId: "s1" } });
+
+    await page.getByRole("button", { name: m.prbadge_button_title({ label: "PR #12" }) }).click();
     await expect
       .element(page.getByRole("menuitem", { name: m.prbadge_open_pr() }))
       .toBeInTheDocument();
+
+    window.dispatchEvent(new PointerEvent("pointermove", { clientX: -100, clientY: -100 }));
+
+    await vi.waitFor(() => expect(document.querySelector("[role='menu']")).toBeNull());
   });
 
   it("opens the PR URL in a new tab from the menu", async () => {

--- a/ui/src/lib/components/PrBadge.svelte
+++ b/ui/src/lib/components/PrBadge.svelte
@@ -28,33 +28,19 @@
   let menu = $state<{
     anchor: DOMRect;
     autoFocus: boolean;
-    openedBy: "click" | "hover";
   } | null>(null);
   let busy = $state(false);
 
-  function openMenu(autoFocus: boolean, openedBy: "click" | "hover") {
+  function openMenu(autoFocus: boolean) {
     if (!actionable || !btnEl) return;
-    menu = { anchor: btnEl.getBoundingClientRect(), autoFocus, openedBy };
+    menu = { anchor: btnEl.getBoundingClientRect(), autoFocus };
   }
 
   function toggleMenu(e: MouseEvent) {
     e.stopPropagation();
     if (!actionable) return;
-    if (menu) {
-      if (menu.openedBy === "hover") {
-        openMenu(true, "click");
-        return;
-      }
-      menu = null;
-      return;
-    }
-    openMenu(true, "click");
-  }
-
-  function openMenuOnHover() {
-    if (menu) return;
-    const canHover = window.matchMedia?.("(hover: hover) and (pointer: fine)").matches ?? true;
-    if (canHover) openMenu(false, "hover");
+    if (menu) menu = null;
+    else openMenu(true);
   }
 
   function openPr() {
@@ -113,7 +99,6 @@
       aria-label={m.prbadge_button_title({ label })}
       aria-haspopup="menu"
       aria-expanded={!!menu}
-      onmouseenter={openMenuOnHover}
       onclick={toggleMenu}
     >
       {@render content()}

--- a/ui/src/lib/components/PrBadgeMenu.svelte
+++ b/ui/src/lib/components/PrBadgeMenu.svelte
@@ -49,6 +49,32 @@
     return items().filter((item) => !item.disabled);
   }
 
+  function containsPoint(rect: DOMRect, x: number, y: number, pad = 0) {
+    return (
+      x >= rect.left - pad &&
+      x <= rect.right + pad &&
+      y >= rect.top - pad &&
+      y <= rect.bottom + pad
+    );
+  }
+
+  function insidePointerKeepalive(x: number, y: number) {
+    if (!el) return false;
+    const menuRect = el.getBoundingClientRect();
+    const openerRect = opener?.getBoundingClientRect();
+    if (containsPoint(menuRect, x, y, 4)) return true;
+    if (openerRect && containsPoint(openerRect, x, y, 4)) return true;
+    if (!openerRect) return false;
+
+    const bridge = new DOMRect(
+      Math.min(menuRect.left, openerRect.left),
+      Math.min(menuRect.top, openerRect.top),
+      Math.max(menuRect.right, openerRect.right) - Math.min(menuRect.left, openerRect.left),
+      Math.max(menuRect.bottom, openerRect.bottom) - Math.min(menuRect.top, openerRect.top),
+    );
+    return containsPoint(bridge, x, y, 8);
+  }
+
   function onNav(e: KeyboardEvent) {
     const list = enabledItems();
     if (list.length === 0) return;
@@ -74,12 +100,17 @@
       const t = e.target as Node;
       if (el && !el.contains(t) && !opener?.contains(t)) onclose();
     }
+    function onPointerMove(e: PointerEvent) {
+      if (!insidePointerKeepalive(e.clientX, e.clientY)) onclose();
+    }
     window.addEventListener("keydown", onKeydown);
     window.addEventListener("pointerdown", onPointer, true);
+    window.addEventListener("pointermove", onPointerMove, true);
     window.addEventListener("scroll", onclose, true);
     return () => {
       window.removeEventListener("keydown", onKeydown);
       window.removeEventListener("pointerdown", onPointer, true);
+      window.removeEventListener("pointermove", onPointerMove, true);
       window.removeEventListener("scroll", onclose, true);
       const target = opener;
       queueMicrotask(() => {

--- a/ui/src/lib/components/PrBadgeMenu.svelte
+++ b/ui/src/lib/components/PrBadgeMenu.svelte
@@ -51,10 +51,7 @@
 
   function containsPoint(rect: DOMRect, x: number, y: number, pad = 0) {
     return (
-      x >= rect.left - pad &&
-      x <= rect.right + pad &&
-      y >= rect.top - pad &&
-      y <= rect.bottom + pad
+      x >= rect.left - pad && x <= rect.right + pad && y >= rect.top - pad && y <= rect.bottom + pad
     );
   }
 


### PR DESCRIPTION
## Summary

- Stops the PR badge action menu from opening on hover.
- Keeps click-to-toggle behavior for actionable PR badges.
- Closes the portaled PR badge menu when the pointer moves away from the badge/menu area.

## Validation

- `cd ui && bun run test:browser -- PrBadge.browser.test.ts`
- `cd ui && bun run check`
- `cd ui && bun run check:i18n`
- `cd ui && bun test` was attempted, but the full suite emitted unrelated existing failures (`$state` unavailable, mocked `importOriginal` undefined, `JSON_HEADERS` initialization errors in unrelated tests) and then hung; the hanging `bun test` process was killed after no further output.

No manual operator steps.
