### PR TITLE
chore(site): pre-release banner "release soon" → "now in pre-release"

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -22,8 +22,7 @@ const DEMO_URL = "https://demo.shepherd.run";
   <p class="prerelease" role="status">
     <span class="pulse" aria-hidden="true"></span>
     <span>
-      <strong>Public release in a few days.</strong> The GitHub repo and the one-line
-      installer below aren’t live yet — they go public at launch.
+      <strong>Now in pre-release.</strong> Grab the GitHub repo and the one-line installer below.
     </span>
   </p>
 


### PR DESCRIPTION
## What

Updates the public marketing site's Hero banner (`site/src/components/Hero.astro`).

- **Before:** _"**Public release in a few days.** The GitHub repo and the one-line installer below aren't live yet — they go public at launch."_
- **After:** _"**Now in pre-release.** Grab the GitHub repo and the one-line installer below."_

## Why

Shepherd is now in pre-release rather than "coming in a few days". The links go live at merge, so the "aren't live yet" caveat would be false the moment this copy deploys — it's dropped, and the banner now points at the live links.

Deployment is automated: `shepherd.run` auto-deploys from Vercel on merge to `main`, and `shepherd.run/install.sh` is a Vercel 302 redirect to the already-committed `deploy/install.sh` (via `site/vercel.json`). No publish step is needed.

## Verification

- `cd site && bun run build` → passes (static build, 1 page).
- Copy-only change; no logic, styling, or i18n touched. `site/` is the standalone Astro marketing page, separate from the SvelteKit `ui/` app and its Paraglide catalogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)