### PR TITLE
docs(issue-templates): enrich for public contributors + add docs & PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -2,6 +2,23 @@ name: Bug report
 description: Report something that isn't working
 labels: [bug]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        🔒 **Found a security vulnerability?** Do **not** file it here. Report it privately via a
+        [GitHub Security advisory](https://github.com/erwins-enkel/shepherd/security/advisories/new)
+        (see [SECURITY.md](https://github.com/erwins-enkel/shepherd/blob/main/SECURITY.md)).
+
+        Please search [existing issues](https://github.com/erwins-enkel/shepherd/issues?q=is%3Aissue)
+        first — your report may already be tracked.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you file
+      options:
+        - label: This is not a security vulnerability (those go to a private advisory).
+          required: true
+        - label: I searched existing issues and this isn't a duplicate.
   - type: textarea
     id: what-happened
     attributes:
@@ -17,9 +34,16 @@ body:
     id: steps
     attributes:
       label: Steps to reproduce
+      description: A minimal, reliable reproduction — the exact steps that trigger the bug.
+      placeholder: |
+        1. …
+        2. …
+        3. See error
   - type: textarea
     id: environment
     attributes:
       label: Environment
-      description: Auto-filled by Shepherd — please leave as-is.
+      description: >-
+        Auto-filled when you report from within Shepherd. If you're filing manually, paste your
+        Shepherd version, your OS, and how you run Shepherd (e.g. the agent CLI you drive).
       render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Report a security vulnerability (private)
+    url: https://github.com/erwins-enkel/shepherd/security/advisories/new
+    about: Please report vulnerabilities privately via a GitHub Security advisory — never as a public issue.
   - name: Questions & ideas (Discussions)
     url: https://github.com/erwins-enkel/shepherd/discussions
     about: Ask questions or discuss ideas that aren't a specific bug or feature request.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,27 @@
+name: Documentation
+description: Report something wrong, missing, or unclear in the docs
+labels: [documentation]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the docs. Please search
+        [existing issues](https://github.com/erwins-enkel/shepherd/issues?q=is%3Aissue) first.
+  - type: input
+    id: location
+    attributes:
+      label: Location
+      description: Which doc, page, or section? A link or file path is ideal.
+      placeholder: e.g. README.md → "ToS compliance model", or docs/sandbox-security.md
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's wrong or missing?
+      description: Describe the inaccuracy, gap, or confusion.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+      description: How should it read instead? Optional, but very helpful.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -2,6 +2,18 @@ name: Feature request
 description: Suggest an idea or improvement
 labels: [enhancement]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search [existing issues](https://github.com/erwins-enkel/shepherd/issues?q=is%3Aissue)
+        first. For open-ended ideas or questions, consider
+        [Discussions](https://github.com/erwins-enkel/shepherd/discussions) instead.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you file
+      options:
+        - label: I searched existing issues and discussions for this idea.
   - type: textarea
     id: problem
     attributes:
@@ -14,8 +26,15 @@ body:
     attributes:
       label: Proposed solution
   - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you've weighed, and why they fall short.
+  - type: textarea
     id: environment
     attributes:
       label: Environment
-      description: Auto-filled by Shepherd — please leave as-is.
+      description: >-
+        Auto-filled when you report from within Shepherd. If you're filing manually, paste your
+        Shepherd version, your OS, and how you run Shepherd (e.g. the agent CLI you drive).
       render: text

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -12,5 +12,7 @@ body:
     id: environment
     attributes:
       label: Environment
-      description: Auto-filled by Shepherd — please leave as-is.
+      description: >-
+        Auto-filled when you report from within Shepherd. If you're filing manually, paste your
+        Shepherd version, your OS, and how you run Shepherd (e.g. the agent CLI you drive).
       render: text

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+<!--
+Thanks for contributing to Shepherd! See CONTRIBUTING.md for setup and the full
+list of quality gates. Keep this PR to one feature, linear off `main`.
+-->
+
+## Summary
+
+<!-- What does this change and why? -->
+
+Closes #
+
+## Checklist
+
+- [ ] Conventional-commit PR title (`feat`, `fix`, `chore`, `docs`, …) — enforced in CI.
+- [ ] Branch is cut from latest `main` and kept linear (rebase, no merge commits).
+- [ ] `bun run lint` and `bun test` pass (and `cd ui && bun run check` + `bun test` when UI is touched).
+- [ ] User-facing text routes through the i18n catalogs (`en.json` + `de.json`, parity via `check:i18n`).
+- [ ] User-facing feature adds a `ui/src/lib/feature-announcements/entries/*.ts` entry (or `[no-feature-entry]` if none applies).
+- [ ] New UI follows the design system (tokens, not literals — see `/design-system`).
+- [ ] Docs updated for any changed public API, config, CLI flag, or user-facing behavior.


### PR DESCRIPTION
## Summary

Now that the repo is public, this develops the GitHub issue templates for **external / manual filers** — while preserving the deep-link contract that Shepherd's in-app "report → prefilled GitHub form" feature ([#971](https://github.com/erwins-enkel/shepherd/issues/971)) depends on.

- **`bug.yml`** — security-advisory callout at the top + a **required** "this is not a security vulnerability" checkbox; **optional** "searched existing issues" acknowledgement; reproduction guidance on the steps field; reworded `environment` so manual filers know to paste version/OS/how they run Shepherd.
- **`feature.yml`** — search acknowledgement (optional), new `alternatives` field, reworded `environment`.
- **`feedback.yml`** — reworded `environment`.
- **`documentation.yml`** — new template (`labels: [documentation]`) for docs issues.
- **`config.yml`** — new private **security-advisory** contact link; keeps the Discussions link and `blank_issues_enabled: false`.
- **`pull_request_template.md`** — new, keyed to the CONTRIBUTING quality gates.

## Contract preserved

`ui/src/lib/feedback-link.ts` deep-links these forms by **filename** (`bug.yml`/`feature.yml`/`feedback.yml`) and **field id** (`what-happened`/`problem`/`feedback`/`environment`). All are unchanged; `environment` stays a `render: text` textarea (else the prefill param is dropped). New fields are additive and optional — the one exception is the required security checkbox on `bug.yml`, which the in-app reporter can't pre-tick, so it adds one submit-time click to the in-app bug flow. That is a deliberate, accepted trade-off: the "searched issues" ack was deliberately left optional so the in-app path is never forced to attest something untrue.

## Verification

- `cd ui && bunx vitest run src/lib/feedback-link.test.ts` — 7/7 pass (prefill construction intact). Note: this validates URL construction only, not one-click submittability.
- All template YAML parses; every referenced label (`bug`, `enhancement`, `feedback`, `documentation`) confirmed present via `gh label list`.
- Full pre-push gate suite green (gates, tsc, ext, root-tests, ui, fallow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)