### PR TITLE
fix(viewport): lift jump-to-latest button clear of review-in-flight banner

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -226,6 +226,10 @@
   // ReviewInFlightBanner's client-side escalation (issue #1022). Pure UI signal,
   // independent of the server-side lastOperatorKeystrokeAt seam.
   let opKeystrokes = $state(0);
+  // occupied height (px) of the ReviewInFlightBanner while it's shown, 0 otherwise.
+  // Published as --review-banner-h on .vp-body so the floating jump-to-latest button
+  // (a sibling in ViewportTermBanners) can lift clear of the bottom banner strip.
+  let reviewBannerH = $state(0);
   // true when another device took over this terminal — show a take-over prompt
   let parked = $state(false);
   // true once the connection stopped for good — show a recovery prompt. endReason
@@ -2136,7 +2140,14 @@
   {/if}
 
   <!-- scan overlay + terminal (terminal stays mounted across tab switches) -->
-  <div class="vp-body" data-swipe-page role="tabpanel" id={vpBodyId} aria-labelledby={tabId(tab)}>
+  <div
+    class="vp-body"
+    data-swipe-page
+    role="tabpanel"
+    id={vpBodyId}
+    aria-labelledby={tabId(tab)}
+    style:--review-banner-h={`${reviewBannerH}px`}
+  >
     <div class="scan" class:running={tab === "term"} aria-hidden="true"></div>
     <div
       class="term-mount"
@@ -2171,7 +2182,7 @@
     <!-- Non-blocking review-in-flight banner: bottom strip over the terminal,
          above the steer bar. Stays mounted across tab switches (state survives);
          it suppresses its own render off the term tab. (issue #1022) -->
-    <ReviewInFlightBanner {session} keystrokes={opKeystrokes} {tab} />
+    <ReviewInFlightBanner {session} keystrokes={opKeystrokes} {tab} bind:height={reviewBannerH} />
     {#if tab === "todo"}
       <div class="panel-wrap">
         <TodoPanel repoPath={session.repoPath} />

--- a/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
+++ b/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
@@ -15,8 +15,12 @@
   // actually land per current toggles; escalates if the operator types mid-review;
   // flips to a brief auto-dismissing conclusion tier. The future stage-and-apply
   // guard is out of scope — this is the signal only.
-  let { session, keystrokes, tab }: { session: Session; keystrokes: number; tab: string } =
-    $props();
+  let {
+    session,
+    keystrokes,
+    tab,
+    height = $bindable(0),
+  }: { session: Session; keystrokes: number; tab: string; height?: number } = $props();
 
   // Live in-flight flags (mutually exclusive: plan-gate = planning phase, critic =
   // post-PR, so never both at once).
@@ -150,6 +154,24 @@
   const icon = $derived(
     view.show && view.phase === "conclusion" && view.tone !== "errored" ? "✓" : "⚠",
   );
+
+  // Publish the banner's occupied height so the floating jump-to-latest button can
+  // lift clear of it (issue: scroll button obscured by this banner). The bound
+  // element mirrors the {#if} below. offsetHeight (via bind: on the element) is the
+  // true occupied height incl. the 1px border-top. We ALSO seed it synchronously
+  // here: this effect runs after DOM insertion but before paint, so the shared CSS
+  // var is already correct on the button's first painted frame — no one-frame flash
+  // under the banner, no spurious mount-time slide. bind:offsetHeight then keeps it
+  // current across reflows (e.g. an orientation change re-wrapping the text).
+  let bannerEl = $state<HTMLDivElement>();
+  $effect(() => {
+    const shown = view.show && tab === "term";
+    if (!shown) {
+      height = 0; // hidden branch: reset (the only place height is zeroed)
+      return;
+    }
+    if (bannerEl) height = bannerEl.offsetHeight; // shown: seed pre-paint; never writes 0
+  });
 </script>
 
 {#if view.show && tab === "term"}
@@ -158,6 +180,8 @@
     data-tone={view.tone}
     role="status"
     aria-live="polite"
+    bind:this={bannerEl}
+    bind:offsetHeight={height}
     use:coachTarget={"review-inflight"}
   >
     <span class="rb-icon" aria-hidden="true">{icon}</span>

--- a/ui/src/lib/components/viewport/ViewportTermBanners.svelte
+++ b/ui/src/lib/components/viewport/ViewportTermBanners.svelte
@@ -108,7 +108,10 @@
      sits above xterm content (z-index 2) but below the parked/resume overlays (3) */
   .scroll-bottom {
     position: absolute;
-    bottom: 12px;
+    /* Lift clear of the ReviewInFlightBanner's bottom strip when it's shown:
+       --review-banner-h (published on .vp-body) is that banner's occupied height,
+       0 when hidden — so this reduces to the resting 12px with no banner. */
+    bottom: calc(12px + var(--review-banner-h, 0px));
     right: 14px;
     z-index: 2;
     display: flex;
@@ -133,7 +136,8 @@
       background 0.12s ease,
       color 0.12s ease,
       box-shadow 0.12s ease,
-      transform 0.12s ease;
+      transform 0.12s ease,
+      bottom 0.12s ease;
     /* slide in, then pulse the amber glow twice to draw the eye; the pulse ends
        and the button rests on the steady halo set above. */
     animation:


### PR DESCRIPTION
## Problem

On the terminal tab, when the **review-in-flight banner** ("You're typing — an incoming directive may collide with your input. Consider waiting.") is showing, the floating circular **jump-to-latest (↓)** button is drawn *behind* it and obscured. It's worse on narrow phones, where the banner wraps to two lines and covers even more of the button (see the reported screenshot).

## Root cause

Both are `position: absolute` siblings inside `.vp-body` with the **same `z-index: 2`**:

- `.scroll-bottom` (floating ↓) — `bottom: 12px; right: 14px`
- `.review-banner` (warning strip) — `bottom: 0`, full-width

The banner owns the bottom edge; the button, only 12px up, overlaps it and (being earlier in DOM order) renders underneath. The banner's height varies (1 line desktop / 2 lines narrow phone), so the offset must track its **measured** height.

## Fix

Publish the banner's occupied height as a CSS custom property and offset the button by it:

1. **`ReviewInFlightBanner.svelte`** — exposes its height via a `$bindable`, using `bind:offsetHeight` (**offsetHeight, not clientHeight** — includes the `1px border-top`, so the 12px clearance is real). Seeded **synchronously in a pre-paint `$effect`** so the shared var is correct on the button's first painted frame — no one-frame flash under the banner, no spurious mount-time slide; `bind:offsetHeight` then keeps it fresh across reflows (e.g. orientation change re-wrapping the text). Height is reset to `0` **only** in the not-shown branch, so a live measurement is never clobbered.
2. **`Viewport.svelte`** — relays it into `--review-banner-h` on the shared `.vp-body`.
3. **`ViewportTermBanners.svelte`** — `.scroll-bottom { bottom: calc(12px + var(--review-banner-h, 0px)); }` with `bottom` added to the transition so the lift animates. The `0px` default preserves the original `bottom: 12px` when no banner is present.

Confirmed with the operator: lift the button above the banner (keeps the affordance visible on desktop + mobile) rather than hiding it during review.

## Verification

- `cd ui && bun run check` → 0 errors / 0 warnings
- `eslint` + `prettier --check` on all three files → clean
- `review-banner` unit tests → 24 passed
- No new user-facing strings (no i18n keys); `fix`, not `feat`, so no feature-catalog entry; no glossary terms.

**Not yet done:** a live visual confirmation of the overlap fix — it requires a session paused mid-review with the terminal scrolled up, which isn't reproducible headlessly here. Reviewer visual check on a narrow viewport with the banner escalated is recommended.