### PR TITLE
chore(install): default SHEPHERD_DIR to ~/.shepherd/app for new installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Shepherd core  ──  Bun + TypeScript (src/)
 curl -fsSL https://raw.githubusercontent.com/erwins-enkel/shepherd/main/deploy/install.sh | bash
 ```
 
-Provisions prerequisites, clones to `~/Work/shepherd`, builds the UI, and on Linux installs and
+Provisions prerequisites, clones to `~/.shepherd/app`, builds the UI, and on Linux installs and
 enables the systemd user service. Idempotent — safe to re-run: it never clobbers an existing
 `~/.shepherd/` state dir and never force-resets a dirty checkout.
 
@@ -122,7 +122,7 @@ before running it. Read the script first:
 
 | Variable              | Default           | Purpose                                                                                       |
 | --------------------- | ----------------- | --------------------------------------------------------------------------------------------- |
-| `SHEPHERD_DIR`        | `~/Work/shepherd` | Where the repo is cloned / found                                                              |
+| `SHEPHERD_DIR`        | `~/.shepherd/app` | Where the repo is cloned / found                                                              |
 | `SHEPHERD_REF`        | `main`            | Git ref to clone or check out                                                                 |
 | `SHEPHERD_SRC`        | _(none)_          | Install from a local tarball or directory instead of cloning (used by the onboarding harness) |
 | `SHEPHERD_NO_SERVICE` | _(none)_          | Skip the systemd unit step (set automatically on macOS)                                       |
@@ -180,8 +180,8 @@ private), running the local script:
 
 ```bash
 gh auth login                                      # or a read-only PAT in the git credential helper
-gh repo clone erwins-enkel/shepherd ~/Work/shepherd
-bash ~/Work/shepherd/deploy/install.sh
+gh repo clone erwins-enkel/shepherd ~/.shepherd/app
+bash ~/.shepherd/app/deploy/install.sh
 ```
 
 This keeps them on `main` with `update.sh` / `git pull` for ongoing updates. Either way, full

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -21,8 +21,9 @@
 #                     Used by the onboarding harness + local checkouts. When unset,
 #                     the repo is git-cloned/updated.
 #   SHEPHERD_REF      Git ref to clone/checkout (default: main).
-#   SHEPHERD_DIR      Install dir (default: ~/Work/shepherd — matches the systemd
-#                     unit's WorkingDirectory).
+#   SHEPHERD_DIR      Install dir (default: ~/.shepherd/app — matches the systemd
+#                     unit's WorkingDirectory). Colocated under the ~/.shepherd/
+#                     state home (db, env, logs) so the whole install is self-contained.
 #   SHEPHERD_NO_SERVICE  Passed through to provision.ts: skip the systemd unit.
 #                        Set automatically on macOS (core-only mode).
 #
@@ -36,7 +37,7 @@ set -euo pipefail
 
 REPO_URL="https://github.com/erwins-enkel/shepherd.git"
 SHEPHERD_REF="${SHEPHERD_REF:-main}"
-SHEPHERD_DIR="${SHEPHERD_DIR:-$HOME/Work/shepherd}"
+SHEPHERD_DIR="${SHEPHERD_DIR:-$HOME/.shepherd/app}"
 
 # ── colored helpers (match update.sh) ─────────────────────────────────────────
 note() { printf '\033[36m▸ %s\033[0m\n' "$*"; }

--- a/deploy/provision.ts
+++ b/deploy/provision.ts
@@ -105,8 +105,8 @@ export function decideServicePath(
 }
 
 /** Template the systemd unit so its WorkingDirectory points at the ACTUAL checkout
- *  (`repo`) instead of the hardcoded `%h/Work/shepherd`. This makes the default
- *  (`~/Work/shepherd`) install byte-identical to today while making a custom
+ *  (`repo`) instead of the hardcoded `%h/.shepherd/app`. This makes the default
+ *  (`~/.shepherd/app`) install byte-identical while making a custom
  *  SHEPHERD_DIR correct — ExecStart stays `bun run src/index.ts` (relative to
  *  WorkingDirectory) and bun's path is independent of the checkout, so retargeting
  *  WorkingDirectory alone suffices. Replaces the single `WorkingDirectory=` line. */
@@ -265,7 +265,7 @@ export function installService(
   run("mkdir", ["-p", join(home, ".shepherd")]);
   // Template (not a verbatim copy): point WorkingDirectory at the ACTUAL checkout
   // so a custom SHEPHERD_DIR install runs against the right dir, not the unit's
-  // hardcoded %h/Work/shepherd. Default repo (~/Work/shepherd) ⇒ identical output.
+  // hardcoded %h/.shepherd/app. Default repo (~/.shepherd/app) ⇒ identical output.
   const unitSrc = fileIO.read(join(repo, "deploy", "shepherd.service"));
   fileIO.write(join(unitDir, "shepherd.service"), templateUnit(unitSrc, repo));
   // Hourly backup units (#1080), installed alongside the main service. The .service carries a

--- a/deploy/shepherd-backup.service
+++ b/deploy/shepherd-backup.service
@@ -4,7 +4,7 @@ Documentation=https://github.com/erwins-enkel/shepherd
 
 [Service]
 Type=oneshot
-WorkingDirectory=%h/Work/shepherd
+WorkingDirectory=%h/.shepherd/app
 ExecStart=%h/.bun/bin/bun run scripts/backup.ts
 
 # bun lives in ~/.bun/bin; keep the same resolvable PATH as shepherd.service

--- a/deploy/shepherd.service
+++ b/deploy/shepherd.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=%h/Work/shepherd
+WorkingDirectory=%h/.shepherd/app
 ExecStart=%h/.bun/bin/bun run src/index.ts
 Restart=on-failure
 RestartSec=2

--- a/docs-site/src/content/docs/getting-started.md
+++ b/docs-site/src/content/docs/getting-started.md
@@ -17,7 +17,7 @@ it matters.
 curl -fsSL https://raw.githubusercontent.com/erwins-enkel/shepherd/main/deploy/install.sh | bash
 ```
 
-The installer provisions prerequisites, clones the repo to `~/Work/shepherd`,
+The installer provisions prerequisites, clones the repo to `~/.shepherd/app`,
 builds the UI, and on Linux installs and enables the systemd user service. It is
 **idempotent** — safe to re-run: it never clobbers an existing `~/.shepherd/`
 state dir and never force-resets a dirty checkout.
@@ -46,7 +46,7 @@ before running it. Read it first:
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `SHEPHERD_DIR` | `~/Work/shepherd` | Where the repo is cloned / found |
+| `SHEPHERD_DIR` | `~/.shepherd/app` | Where the repo is cloned / found |
 | `SHEPHERD_REF` | `main` | Git ref to clone or check out |
 | `SHEPHERD_SRC` | _(none)_ | Install from a local tarball or directory instead of cloning |
 | `SHEPHERD_NO_SERVICE` | _(none)_ | Skip the systemd unit step (set automatically on macOS) |

--- a/test/provision.test.ts
+++ b/test/provision.test.ts
@@ -107,23 +107,23 @@ describe("decideServicePath", () => {
 describe("templateUnit", () => {
   const unit = readFileSync("deploy/shepherd.service", "utf8");
 
-  it("default repo (~/Work/shepherd) keeps output identical to the source unit", () => {
-    // The shipped unit hardcodes %h/Work/shepherd; templating the literal value back
-    // in is a no-op — proving the default install is byte-identical to today.
+  it("default repo (~/.shepherd/app) keeps output identical to the source unit", () => {
+    // The shipped unit hardcodes %h/.shepherd/app; templating the literal value back
+    // in is a no-op — proving the default install is byte-identical.
     const home = homedir();
-    const defaultRepo = join(home, "Work", "shepherd");
+    const defaultRepo = join(home, ".shepherd", "app");
     const templated = templateUnit(unit, defaultRepo);
     expect(templated).toContain(`WorkingDirectory=${defaultRepo}`);
     // only the WorkingDirectory line changed (from %h-form to absolute)
     expect(
-      templated.replace(`WorkingDirectory=${defaultRepo}`, "WorkingDirectory=%h/Work/shepherd"),
+      templated.replace(`WorkingDirectory=${defaultRepo}`, "WorkingDirectory=%h/.shepherd/app"),
     ).toBe(unit);
   });
 
   it("custom repo retargets WorkingDirectory and leaves ExecStart/Environment alone", () => {
     const templated = templateUnit(unit, "/srv/shepherd-prod");
     expect(templated).toContain("WorkingDirectory=/srv/shepherd-prod");
-    expect(templated).not.toContain("WorkingDirectory=%h/Work/shepherd");
+    expect(templated).not.toContain("WorkingDirectory=%h/.shepherd/app");
     expect(templated).toContain("ExecStart=%h/.bun/bin/bun run src/index.ts");
     expect(templated).toContain("EnvironmentFile=-%h/.shepherd/env");
   });
@@ -254,7 +254,7 @@ describe("provision orchestration (injected runner, no real installs)", () => {
     expect(target).toContain("systemd/user/shepherd.service");
     // WorkingDirectory points at the custom checkout — proves templating, not passthrough
     expect(content).toContain(`WorkingDirectory=${repo}`);
-    expect(content).not.toContain("WorkingDirectory=%h/Work/shepherd");
+    expect(content).not.toContain("WorkingDirectory=%h/.shepherd/app");
     // everything else is untouched (ExecStart still relative + %h-based)
     expect(content).toContain("ExecStart=%h/.bun/bin/bun run src/index.ts");
   });


### PR DESCRIPTION
## What

Changes the **default** fresh-install checkout location (`SHEPHERD_DIR`) from `~/Work/shepherd` to **`~/.shepherd/app`**.

## Why

`SHEPHERD_DIR` is only the *app checkout* location — the data home (`~/.shepherd/`: db, env, logs, plugins, backups) is already independent of it. That made the checkout the **one** Shepherd artifact still living in `~/Work`, a *personal-workspace* convention many hosts won't have (Shepherd is a daemon, not a user project). Colocating the checkout under `~/.shepherd/app` makes the whole install self-contained under one hidden home and stops polluting `~/Work`. Backups target only `~/.shepherd/shepherd.db` + `~/.shepherd/backups`, so the checkout does **not** get swept into backups.

## Scope

- `deploy/install.sh` — default (+ doc comment)
- `deploy/shepherd.service` **and** `deploy/shepherd-backup.service` — `WorkingDirectory` literal `%h/Work/shepherd` → `%h/.shepherd/app` (both templated through the same `templateUnit`, so they move in lockstep)
- `deploy/provision.ts` — comments only; **no provisioning logic change** (`templateUnit` already rewrites `WorkingDirectory` to the real checkout)
- `test/provision.test.ts` — retargets the byte-identity test (the load-bearing `defaultRepo` constant, the assertions, and the `it(...)` name) to the new default
- `README.md`, `docs-site/.../getting-started.md` — prose + env table + manual-clone example

A default install stays **byte-identical** after templating for both units.

## Migration / safety

**Change-default-only** — no auto-detect, no relocation helper. Existing installs are unaffected: `update.sh` derives its checkout from its own location and never reads `SHEPHERD_DIR`, so normal `bun run update` keeps pointing at `~/Work/shepherd`. The only way an existing install is touched is re-running `install.sh` (curl|bash) with `SHEPHERD_DIR` unset — an accepted footgun given there are only two existing installs, both already provisioned.

**Trade-off:** nesting the checkout under the state home couples two lifecycles that are separable today — `rm -rf ~/.shepherd` now removes the app checkout too. Judged acceptable for a single self-contained home.

## Verification

- `bun run lint`, `bunx tsc --noEmit`, prettier — clean
- `bun test ./test` — green (`test/provision.test.ts` + `test/install-sh.test.ts` pass; byte-identity invariant now exercises the new default)
- `grep -rn Work/shepherd deploy/` — no remaining install-default reference across both units

🤖 Generated with [Claude Code](https://claude.com/claude-code)