### PR TITLE
fix(install): show install dir in first-run output so operator can cd to start

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -68,7 +68,7 @@ decide() {
       MODE="core-only"
       export SHEPHERD_NO_SERVICE=1
       # The authoritative degraded-capability list lives in provision.ts
-      # (MACOS_DEGRADED_BANNER) — the layer that actually proceeds core-only and
+      # (macosDegradedBanner) — the layer that actually proceeds core-only and
       # prints it. Keep this to a one-liner so the two don't drift.
       warn "macOS detected → core-only / DEGRADED mode (no systemd unit); details below."
       ;;

--- a/deploy/provision.ts
+++ b/deploy/provision.ts
@@ -114,9 +114,12 @@ export function templateUnit(unit: string, repo: string): string {
   return unit.replace(/^WorkingDirectory=.*$/m, `WorkingDirectory=${repo}`);
 }
 
-/** Final guidance follow-ups that need a human secret and are NEVER auto-run. */
-export function guidanceNextSteps(): string[] {
+/** Final guidance follow-ups that need a human secret and are NEVER auto-run.
+ *  Leads with the checkout dir so every platform (incl. Linux/systemd) shows
+ *  where install.sh landed Shepherd. */
+export function guidanceNextSteps(repo: string): string[] {
   return [
+    `Installed to: ${repo}`,
     "Shepherd will be available at http://localhost:7330",
     "",
     "A few steps need a human secret and were NOT run for you:",
@@ -130,23 +133,41 @@ export function guidanceNextSteps(): string[] {
   ];
 }
 
-const MACOS_DEGRADED_BANNER = [
-  "",
-  "════════════════════════════════════════════════════════════════════",
-  "  ⚠  macOS: running in DEGRADED mode",
-  "════════════════════════════════════════════════════════════════════",
-  "  The following Linux-only capabilities are UNAVAILABLE on macOS:",
-  "    • sandbox membrane (per-spawn credential isolation)",
-  "    • egress allowlist (autonomous netns firewall)",
-  "    • auto-drain",
-  "    • tailscale-serve previews",
-  "    • no automated install proof (the onboarding harness is Linux-only)",
-  "",
-  "  No launchd unit is installed. Start Shepherd manually with:",
-  "    bun run start",
-  "════════════════════════════════════════════════════════════════════",
-  "",
-];
+/** macOS degraded-mode banner. Takes the actual checkout dir (`repo`) so the
+ *  manual-start line is copy-pasteable — the operator otherwise has no idea
+ *  where install.sh landed Shepherd (default ~/.shepherd/app, but SHEPHERD_DIR
+ *  can retarget it). */
+export function macosDegradedBanner(repo: string): string[] {
+  return [
+    "",
+    "════════════════════════════════════════════════════════════════════",
+    "  ⚠  macOS: running in DEGRADED mode",
+    "════════════════════════════════════════════════════════════════════",
+    "  The following Linux-only capabilities are UNAVAILABLE on macOS:",
+    "    • sandbox membrane (per-spawn credential isolation)",
+    "    • egress allowlist (autonomous netns firewall)",
+    "    • auto-drain",
+    "    • tailscale-serve previews",
+    "    • no automated install proof (the onboarding harness is Linux-only)",
+    "",
+    "  No launchd unit is installed. Start Shepherd manually with:",
+    `    cd "${repo}" && bun run start`,
+    "════════════════════════════════════════════════════════════════════",
+    "",
+  ];
+}
+
+/** Manual-start hint for the Linux no-service path (SHEPHERD_NO_SERVICE): no
+ *  systemd unit was installed, so — like macOS — the operator must start
+ *  Shepherd by hand and needs to know the checkout dir. */
+export function noServiceStartHint(repo: string): string[] {
+  return [
+    "",
+    "  No systemd unit was installed (SHEPHERD_NO_SERVICE). Start Shepherd manually with:",
+    `    cd "${repo}" && bun run start`,
+    "",
+  ];
+}
 
 // ── side-effect seam ──────────────────────────────────────────────────────────
 
@@ -350,13 +371,24 @@ export function provision(opts: ProvisionOpts = {}): void {
     buildOnly(repo, run, buildEnv);
   }
 
+  printClosingGuidance(decision, repo);
+}
+
+/** Emit the closing banners + next-steps guidance. Extracted from provision() so
+ *  the manual-start branching (macOS degraded vs Linux no-service) doesn't push
+ *  provision over its complexity budget. */
+function printClosingGuidance(decision: ServiceDecision, repo: string): void {
   if (decision.degradedBanner) {
-    for (const line of MACOS_DEGRADED_BANNER) process.stdout.write(`\x1b[33m${line}\x1b[0m\n`);
+    for (const line of macosDegradedBanner(repo)) process.stdout.write(`\x1b[33m${line}\x1b[0m\n`);
+  } else if (!decision.service) {
+    // Linux no-service path (SHEPHERD_NO_SERVICE): nothing auto-starts and no
+    // degraded banner fires, so surface the manual-start command + dir here.
+    for (const line of noServiceStartHint(repo)) process.stdout.write(`\x1b[33m${line}\x1b[0m\n`);
   }
 
   // final summary + guidance
   process.stdout.write("\n");
-  for (const line of guidanceNextSteps()) process.stdout.write(`${line}\n`);
+  for (const line of guidanceNextSteps(repo)) process.stdout.write(`${line}\n`);
 }
 
 // Run when invoked directly (not when imported by tests).

--- a/test/install-sh.test.ts
+++ b/test/install-sh.test.ts
@@ -55,7 +55,7 @@ describe("detect_os + decide (OS → mode)", () => {
     expect(r.stdout).toContain("mode: core-only");
     expect(r.stdout).toContain("NO_SERVICE=1");
     // Concise degraded notice (printed via warn → stderr); the full capability
-    // list now lives in provision.ts (MACOS_DEGRADED_BANNER), not exercised here.
+    // list now lives in provision.ts (macosDegradedBanner), not exercised here.
     const all = r.stdout + r.stderr;
     expect(all).toContain("DEGRADED");
     expect(all).toContain("core-only");

--- a/test/provision.test.ts
+++ b/test/provision.test.ts
@@ -9,6 +9,8 @@ import {
   needsInstall,
   decideServicePath,
   guidanceNextSteps,
+  macosDegradedBanner,
+  noServiceStartHint,
   templateUnit,
   installPrereqs,
   ensureNodeGyp,
@@ -461,11 +463,32 @@ describe("provision — low-memory advisory wiring", () => {
 
 describe("guidanceNextSteps", () => {
   it("includes the local URL and the human-secret follow-ups", () => {
-    const steps = guidanceNextSteps().join("\n");
+    const steps = guidanceNextSteps("/home/op/.shepherd/app").join("\n");
     expect(steps).toContain("http://localhost:7330");
     expect(steps.toLowerCase()).toContain("claude");
     expect(steps).toContain("gh auth login");
     expect(steps).toContain("tailscale serve");
     expect(steps).toContain("SHEPHERD_ALLOWED_HOSTS");
+  });
+
+  it("leads with the checkout dir so the operator knows where it landed", () => {
+    const steps = guidanceNextSteps("/opt/custom/shepherd").join("\n");
+    expect(steps).toContain("Installed to: /opt/custom/shepherd");
+  });
+});
+
+describe("macosDegradedBanner", () => {
+  it("makes the manual-start line copy-pasteable with the checkout dir", () => {
+    const banner = macosDegradedBanner("/home/op/.shepherd/app").join("\n");
+    expect(banner).toContain("DEGRADED");
+    expect(banner).toContain('cd "/home/op/.shepherd/app" && bun run start');
+  });
+});
+
+describe("noServiceStartHint", () => {
+  it("gives the Linux no-service path a manual-start command with the dir", () => {
+    const hint = noServiceStartHint("/opt/custom/shepherd").join("\n");
+    expect(hint).toContain("SHEPHERD_NO_SERVICE");
+    expect(hint).toContain('cd "/opt/custom/shepherd" && bun run start');
   });
 });


### PR DESCRIPTION
## Problem

After `install.sh` finishes, the first-run output never says **where** it landed Shepherd, so the operator can't tell which directory to `cd` into before `bun run start`. Concretely, the macOS degraded banner reads:

```
  No launchd unit is installed. Start Shepherd manually with:
    bun run start
```

…with no path — and the Linux `SHEPHERD_NO_SERVICE` manual path printed **no** start command or directory at all.

## Root cause

The closing guidance in `deploy/provision.ts` already has the install dir in scope as `repo` (`opts.repo ?? process.cwd()`, which `install.sh` sets by `cd "$SHEPHERD_DIR"` before handoff). It was simply never threaded into the printed text.

## Change

Thread `repo` into the closing output (one product file + its test):

| Install path | Before | After |
| --- | --- | --- |
| macOS (degraded) | `bun run start` — no dir | `cd "<dir>" && bun run start` |
| Linux + `SHEPHERD_NO_SERVICE` | no start hint at all | manual-start hint incl. dir |
| Linux (systemd, default) | auto-started, dir unknown | `Installed to: <dir>` summary line |

- `MACOS_DEGRADED_BANNER` const → pure `macosDegradedBanner(repo)`.
- New `noServiceStartHint(repo)` for the Linux no-service branch.
- `guidanceNextSteps(repo)` leads with `Installed to: <repo>` (all platforms).
- Path is double-quoted so a `$SHEPHERD_DIR` with spaces stays valid.
- Extracted the closing-output block into `printClosingGuidance()` to keep `provision()` under its complexity budget (`fallow audit`).

Server/deploy CLI-output change only — no UI, i18n, or feature-catalog surface. `[no-feature-entry]`

## Verification

- `bun run lint` — clean
- `bun test test/provision.test.ts test/install-sh.test.ts` — 49 pass; full-run test confirms `Installed to: <dir>` renders live
- `fallow audit` (pre-push) — clean
- New unit tests assert the dir appears in the macOS banner, the no-service hint, and the guidance summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)