### PR TITLE
fix(tmp-sweep): skip non-git work-dir folders in worktree prune

### DIFF
--- a/src/tmp-sweep.ts
+++ b/src/tmp-sweep.ts
@@ -447,6 +447,8 @@ export async function reapFallowCaches(opts?: ReapFallowOpts): Promise<ReapFallo
 interface PruneOpts {
   /** Injectable git-exec hook for tests. Receives the same args as `git -C <repo> worktree prune`. */
   execGit?: (repo: string, args: string[]) => Promise<void>;
+  /** Injectable git-repo predicate for tests. Defaults to an async `.git` presence check. */
+  isGitRepo?: (repo: string) => Promise<boolean>;
   log?: (msg: string) => void;
 }
 
@@ -456,10 +458,13 @@ export interface PruneResult {
 }
 
 /**
- * Runs `git worktree prune` for each supplied repo path. Unconditional — prunes every
+ * Runs `git worktree prune` for each supplied repo path that is a git repo — prunes every
  * orphaned record (missing working dir) regardless of how the dir vanished (reboot,
- * tmpfiles, manual rm). Per-repo try/catch: a failing repo is logged and skipped; the
- * rest still run. Never rejects. Returns `{ pruned, failed }`.
+ * tmpfiles, manual rm). The caller enumerates *every* work-dir folder (not just git repos),
+ * so a non-git folder is skipped silently up front — neither logged nor counted — rather
+ * than spawning git and logging its `fatal: not a git repository` as a failure. Per-repo
+ * try/catch on the rest: a git repo whose prune truly errors is logged and skipped while the
+ * others still run. Never rejects. Returns `{ pruned, failed }`.
  */
 export async function pruneRepoWorktrees(
   repoPaths: string[],
@@ -468,10 +473,20 @@ export async function pruneRepoWorktrees(
   const log = opts?.log ?? console.warn;
   const execGit =
     opts?.execGit ?? ((repo: string, args: string[]) => execFileAsync("git", args).then(() => {}));
+  const isGitRepo =
+    opts?.isGitRepo ??
+    ((repo: string) =>
+      fsp.access(join(repo, ".git")).then(
+        () => true,
+        () => false,
+      ));
 
   let pruned = 0;
   let failed = 0;
   for (const repo of repoPaths) {
+    // Skip non-git folders silently: the work dir holds plain project folders alongside
+    // repos, and pruning those only yields a benign "not a git repository" error.
+    if (!(await isGitRepo(repo))) continue;
     try {
       // `--expire=now` makes the immediate-prune intent explicit. A bare `git worktree prune`
       // already defaults to `--expire=TIME_MAX` (prune every orphaned record regardless of age),

--- a/test/tmp-sweep.test.ts
+++ b/test/tmp-sweep.test.ts
@@ -540,6 +540,7 @@ describe("pruneRepoWorktrees", () => {
 
     const res = await pruneRepoWorktrees(["/repo/a", "/repo/b"], {
       execGit: fakeExecGit,
+      isGitRepo: async () => true,
       log: () => {},
     });
 
@@ -559,12 +560,29 @@ describe("pruneRepoWorktrees", () => {
 
     const res = await pruneRepoWorktrees(["/repo/bad", "/repo/good"], {
       execGit: fakeExecGit,
+      isGitRepo: async () => true,
       log: () => {},
     });
 
     expect(res.pruned).toBe(1);
     expect(res.failed).toBe(1);
     expect(calls).toEqual(["/repo/good"]);
+  });
+
+  test("skips non-git folders silently — no prune, no failure, no log", async () => {
+    const calls: string[] = [];
+    const logs: string[] = [];
+    const res = await pruneRepoWorktrees(["/work/gdpr", "/work/repo"], {
+      execGit: async (repo) => {
+        calls.push(repo);
+      },
+      isGitRepo: async (repo) => repo === "/work/repo",
+      log: (msg) => logs.push(msg),
+    });
+
+    expect(res).toEqual({ pruned: 1, failed: 0 });
+    expect(calls).toEqual(["/work/repo"]);
+    expect(logs).toEqual([]);
   });
 
   test("never rejects; empty list returns zeroes", async () => {


### PR DESCRIPTION
## Problem

Every boot/daily tmp-sweep logged a warning for each plain (non-git) folder sitting in the work dir:

```
[tmp-sweep] git worktree prune failed for /Users/patrick/Work/gdpr: Error: Command failed:
git -C /Users/patrick/Work/gdpr worktree prune --expire=now
fatal: not a git repository (or any of the parent directories): .git
```

`fireTmpSweep` feeds **every** work-dir folder into `pruneRepoWorktrees` — `listRepos` returns all directories, not just git repos — which then runs `git worktree prune` unconditionally. A plain project folder makes git exit `fatal: not a git repository`, logged as a per-repo failure and counted in `failed`.

This was the only noisy path: the sibling doc-agent orphan sweep (`reapRepoWorktrees`) already ignores non-git folders silently.

## Fix

Guard `pruneRepoWorktrees` with an injectable async `isGitRepo` predicate (default: `.git` presence check via `fsp.access`, covering both a main clone's `.git` dir and a linked worktree's `.git` file). A non-git folder is skipped **fully silently** — before the try/catch, so it is neither logged nor counted in `pruned`/`failed`. Real git repos are pruned exactly as before; a genuine prune error on a real repo is still logged and counted.

## Tests

- `test/tmp-sweep.test.ts`: existing prune tests inject `isGitRepo: async () => true` (they use synthetic paths that don't exist on disk); added a test asserting a non-git folder is skipped — no `execGit` call, not counted, no log.
- `bun run lint` and `bun test test/tmp-sweep.test.ts` (24 pass) green. Pre-existing DOM/browser test failures at root are unrelated (confirmed identical with this diff stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)