### PR TITLE
fix(boot): de-dupe near-boot tmp-sweep + quiet two spurious log lines

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -591,7 +591,7 @@ const fireTmpSweep = (phase: "boot" | "daily") => {
       pruneRepoWorktrees(listRepos(config.repoRoot).map((r) => r.path)).then(
         ({ pruned, failed }) => {
           console.warn(
-            `[tmp-sweep] ${phase}: fallow reap removed ${removed}, worktree prune pruned ${pruned}${failed ? `, failed ${failed}` : ""}`,
+            `[tmp-sweep] ${phase}: fallow reap removed ${removed}, worktree prune ran on ${pruned} repo(s)${failed ? `, failed ${failed}` : ""}`,
           );
         },
       ),
@@ -1876,7 +1876,7 @@ const checkBackupStaleness = async (): Promise<void> => {
     .catch((err) => console.warn("[push] backup_stale notify failed:", err));
 };
 
-const runDailySweep = () => {
+const runDailySweep = (opts?: { skipTmpSweep?: boolean }) => {
   if (maintenance.active) return;
   if (config.sessionHousekeepingEnabled)
     store.pruneArchivedSessions({
@@ -1944,12 +1944,14 @@ const runDailySweep = () => {
   // Reclaim session_injected_learnings rows for sessions that vanished without archive()
   // (force-removed/crashed) — archive() consumes the rest.
   store.pruneOrphanInjectedLearnings();
-  fireTmpSweep("daily");
+  // Skip on the boot-time run: fireTmpSweep("boot") already ran the fallow/worktree
+  // sweep seconds earlier, so re-running it here only duplicates the work (and the log).
+  if (!opts?.skipTmpSweep) fireTmpSweep("daily");
   // Read-only backup-staleness probe (#1080); fire-and-forget so it never blocks the sweep.
   void checkBackupStaleness();
 };
 deferredStarts.push(() => {
-  setTimeout(runDailySweep, 10_000); // once shortly after boot
+  setTimeout(() => runDailySweep({ skipTmpSweep: true }), 10_000); // once shortly after boot
   setInterval(runDailySweep, 24 * 60 * 60 * 1000);
 });
 

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -44,6 +44,9 @@ const warned = new Set<string>();
 
 function weightsFor(model: string): ModelWeights {
   for (const { match, w } of TABLE) if (match.test(model)) return w;
+  // Sentinel ids like "<synthetic>" (synthetic/interrupt messages) carry no real pricing —
+  // use the default weights silently instead of warning once per sentinel.
+  if (/^<.+>$/.test(model)) return DEFAULT;
   if (!warned.has(model)) {
     warned.add(model);
     console.warn(`[usage] unknown model "${model}" — using default limit weights`);

--- a/test/pricing.test.ts
+++ b/test/pricing.test.ts
@@ -14,3 +14,19 @@ test("cacheWriteUnits — opus 1h-only: 1M tokens = 10 units", () => {
 test("cacheWriteUnits — both zero → 0 (no contamination from other kinds)", () => {
   expect(cacheWriteUnits({ cacheWrite5m: 0, cacheWrite1h: 0 }, "claude-opus-4-8")).toBe(0);
 });
+
+test("weightsFor — sentinel id like <synthetic> defaults silently, real unknown id warns once", () => {
+  const warns: string[] = [];
+  const orig = console.warn;
+  console.warn = (...args: unknown[]) => void warns.push(args.map(String).join(" "));
+  try {
+    // Sentinel ids fall back to default weights without a warning.
+    cacheWriteUnits({ cacheWrite5m: 0, cacheWrite1h: 0 }, "<synthetic>");
+    expect(warns).toHaveLength(0);
+    // A genuinely-unknown real model id still warns (regression watchdog intact).
+    cacheWriteUnits({ cacheWrite5m: 0, cacheWrite1h: 0 }, "totally-made-up-model-x");
+    expect(warns.some((w) => w.includes("totally-made-up-model-x"))).toBe(true);
+  } finally {
+    console.warn = orig;
+  }
+});


### PR DESCRIPTION
## What

Three surgical fixes surfaced by a macOS boot log — all server-only boot hygiene, no user-facing UX.

1. **Redundant near-boot sweep.** `fireTmpSweep("boot")` runs at startup, then `setTimeout(runDailySweep, 10_000)` re-ran the same fallow-reap + worktree-prune across every repo via `fireTmpSweep("daily")` ~10s later. `runDailySweep` now takes `{ skipTmpSweep }`, passed from the boot-time `setTimeout`, so the duplicate sweep is skipped. The 24h `setInterval` sweep is unchanged (still runs `fireTmpSweep("daily")`).
2. **Misleading prune count.** `PruneResult.pruned` counts *repos scanned*, not worktrees removed (git exposes no removed-count). Log reworded from `worktree prune pruned N` → `worktree prune ran on N repo(s)`.
3. **Spurious model warning.** `[usage] unknown model "<synthetic>"` — `<synthetic>` is a Claude Code sentinel id, not a real model. `weightsFor` now returns default weights silently for `<…>` sentinel ids; genuinely-unknown real ids still warn once.

## Why

Every boot did two full fallow/worktree sweeps back-to-back and emitted a confusing duplicate `[tmp-sweep] boot:`/`daily:` pair plus a bogus pricing warning. Idempotent, so nothing was broken — just wasted spawns and log noise.

## Testing

- `bun run lint`, `bun run typecheck`, `bun test` (pricing / tmp-sweep / usage) all green.
- New test: sentinel `<synthetic>` defaults silently while a real unknown id still warns once.
- #1 has no unit-test seat (`runDailySweep` is an inline closure in `index.ts`); verified by reading the change — boot now emits one `[tmp-sweep]` sweep, not two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)