### PR TITLE
feat(sites): add Vercel Web Analytics to docs + marketing sites

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -57,7 +57,11 @@
     // via the `components: { SocialIcons: "./src/components/SiteBacklink.astro" }`
     // string path in astro.config.mjs, not a static import — so fallow reports it as
     // an unused file (same string-path-root class as custom.css above).
-    "docs-site/src/components/SiteBacklink.astro"
+    "docs-site/src/components/SiteBacklink.astro",
+    // Head overrides Starlight's `Head` slot to append Vercel Web Analytics. Loaded
+    // via the `components: { Head: "./src/components/Head.astro" }` string path in
+    // astro.config.mjs — same string-path-root class as SiteBacklink above.
+    "docs-site/src/components/Head.astro"
   ],
 
   // sw.js is the service worker: never imported statically — the browser fetches

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -36,6 +36,9 @@ export default defineConfig({
       // GitHub social icon below still appears. See src/components/SiteBacklink.astro.
       components: {
         SocialIcons: "./src/components/SiteBacklink.astro",
+        // Re-render the default Head + append Vercel Web Analytics. See
+        // src/components/Head.astro for why an override (vs the `head` config option).
+        Head: "./src/components/Head.astro",
       },
       // Generate the TypeScript API reference from the server package (../src)
       // with TypeDoc, so it CANNOT drift from source. Like syncDocs() above, this

--- a/docs-site/bun.lock
+++ b/docs-site/bun.lock
@@ -6,6 +6,7 @@
       "name": "shepherd-docs",
       "dependencies": {
         "@astrojs/starlight": "^0.40.0",
+        "@vercel/analytics": "^2.0.1",
         "astro": "^6.4.8",
       },
       "devDependencies": {
@@ -307,6 +308,8 @@
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
+
+    "@vercel/analytics": ["@vercel/analytics@2.0.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "nuxt": ">= 3", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "nuxt", "react", "svelte", "vue", "vue-router"] }, "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g=="],
 
     "@volar/kit": ["@volar/kit@2.4.28", "", { "dependencies": { "@volar/language-service": "2.4.28", "@volar/typescript": "2.4.28", "typesafe-path": "^0.2.2", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "typescript": "*" } }, "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg=="],
 

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.40.0",
+    "@vercel/analytics": "^2.0.1",
     "astro": "^6.4.8"
   },
   "devDependencies": {

--- a/docs-site/src/components/Head.astro
+++ b/docs-site/src/components/Head.astro
@@ -1,0 +1,19 @@
+---
+// Override of Starlight's `Head` component (registered in astro.config.mjs).
+// Re-renders the default `Head` unchanged, then appends the official Vercel Web
+// Analytics component so the docs site tracks page views like the marketing site.
+//
+// Why an override rather than Starlight's `head` config option (its recommended
+// path for analytics tags): `head` accepts only raw tag definitions and cannot
+// render the `@vercel/analytics/astro` component — using it would force hardcoding
+// Vercel's internal script path (/_vercel/insights/script.js) + inline queue init,
+// which can drift. The override reuses the same official component as the marketing
+// site (single source of truth), matching the in-repo `SocialIcons` → SiteBacklink
+// override pattern. `{...Astro.props}` is forwarded so the default Head keeps every
+// SEO/meta tag it renders; `<Analytics />` is purely additive.
+import Default from "@astrojs/starlight/components/Head.astro";
+import Analytics from "@vercel/analytics/astro";
+---
+
+<Default {...Astro.props} />
+<Analytics />

--- a/site/bun.lock
+++ b/site/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@fontsource/space-grotesk": "^5.2.10",
+        "@vercel/analytics": "^2.0.1",
         "astro": "^6.4.7",
       },
       "devDependencies": {
@@ -255,6 +256,8 @@
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
+
+    "@vercel/analytics": ["@vercel/analytics@2.0.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "nuxt": ">= 3", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "nuxt", "react", "svelte", "vue", "vue-router"] }, "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g=="],
 
     "@volar/kit": ["@volar/kit@2.4.28", "", { "dependencies": { "@volar/language-service": "2.4.28", "@volar/typescript": "2.4.28", "typesafe-path": "^0.2.2", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "typescript": "*" } }, "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg=="],
 

--- a/site/package.json
+++ b/site/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@fontsource/space-grotesk": "^5.2.10",
+    "@vercel/analytics": "^2.0.1",
     "astro": "^6.4.7"
   },
   "devDependencies": {

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -1,5 +1,6 @@
 ---
 import { Font } from "astro:assets";
+import Analytics from "@vercel/analytics/astro";
 import "../styles/global.css";
 
 interface Props {
@@ -56,6 +57,11 @@ const {
     -->
     <Font cssVariable="--font-space-grotesk" preload={[{ weight: 400 }]} />
     <Font cssVariable="--font-jetbrains-mono" preload={[{ weight: 400 }]} />
+
+    <!-- Vercel Web Analytics: injects the client script that loads
+         /_vercel/insights/script.js (served once Web Analytics is enabled for the
+         project). Component-only path — no @astrojs/vercel adapter needed for static. -->
+    <Analytics />
   </head>
   <body>
     <slot />


### PR DESCRIPTION
## What

Adds Vercel **Web Analytics** (`@vercel/analytics@^2.0.1`) to both static Astro sites deployed on Vercel:

- **Marketing site** (`site/`, shepherd.run) — `<Analytics />` in `Base.astro` `<head>`.
- **Docs site** (`docs-site/`, Starlight, docs.shepherd.run) — a `Head` component override (new `Head.astro` re-renders Starlight's default `Head` and appends `<Analytics />`), registered in `astro.config.mjs` alongside the existing `SocialIcons` override.

## Why the component-only path (no Vercel adapter)

Both sites are `output: "static"`. `@vercel/analytics`'s official `@vercel/analytics/astro` component (≥1.4.0) injects the client script on its own — no `@astrojs/vercel` adapter or `webAnalytics` config needed. Verified `@vercel/analytics@2.0.1` declares **no astro peer dependency** (its peers are all optional), so astro `^6.4.x` can't conflict; its `exports` includes `./astro`.

## Why a `Head` override for docs (not the `head` config)

Starlight's `head` config option only accepts raw tag definitions — it can't render the package's Astro component and would force hardcoding Vercel's internal script path. The override reuses the same official component as the marketing site (single source of truth) via the same mechanism already used in-repo for `SocialIcons` → `SiteBacklink.astro`. `Head.astro` re-renders the default `Head` unchanged, so all SEO/meta tags survive (asserted below). `.fallowrc.jsonc` gains an entry-point for it (string-path root, same as `SiteBacklink.astro`).

## Verification

- `site`: `bun run check` (0 errors) + `bun run build` succeed; built HTML contains `window.va` + `/_vercel/insights/script.js`.
- `docs-site`: `astro check` (0 errors) + `bun run build` (1103 pages) succeed; built HTML contains the analytics injection **and** retains the default Starlight head (`<title>`, `rel="canonical"`, generator) — override didn't drop default head content. Analytics also present on deep pages.
- No astro peer-dependency warnings at install/build for either site. Prettier + fallow pre-push clean.

## Manual operator steps

Web Analytics must be enabled per Vercel project or `/_vercel/insights/script.js` 404s (harmless, but no data collected).

```shepherd:manual-steps
- [ ] POST-MERGE: Enable Web Analytics for the shepherd-site Vercel project (dashboard → Analytics)
- [ ] POST-MERGE: Enable Web Analytics for the shepherd-docs Vercel project (dashboard → Analytics)
```

Out of scope: Speed Insights (`@vercel/speed-insights`) — trivial follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)