### PR TITLE
feat(sites): track marketing CTA custom events via Vercel Analytics

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -13,9 +13,14 @@ const DOCS_URL = "https://docs.shepherd.run";
     <div class="top">
       <span class="wordmark">shepherd</span>
       <nav class="flinks" aria-label="Footer">
-        <a href={GITHUB_URL} rel="noopener noreferrer" target="_blank">GitHub</a
+        <a
+          href={GITHUB_URL}
+          rel="noopener noreferrer"
+          target="_blank"
+          data-track="cta_github"
+          data-track-location="footer">GitHub</a
         >
-        <a href={DOCS_URL}>Docs</a>
+        <a href={DOCS_URL} data-track="cta_docs" data-track-location="footer">Docs</a>
         <a href={LICENSE_URL} rel="noopener noreferrer" target="_blank"
           >License</a
         >

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -44,16 +44,25 @@ const DEMO_URL = "https://demo.shepherd.run";
         class="btn btn-primary"
         href={DEMO_URL}
         rel="noopener noreferrer"
-        target="_blank">Try the live demo</a
+        target="_blank"
+        data-track="cta_demo"
+        data-track-location="hero">Try the live demo</a
       >
       <a class="btn btn-ghost" href="#install">Install</a>
       <a
         class="btn btn-ghost"
         href={GITHUB_URL}
         rel="noopener noreferrer"
-        target="_blank">View on GitHub</a
+        target="_blank"
+        data-track="cta_github"
+        data-track-location="hero">View on GitHub</a
       >
-      <a class="btn btn-ghost" href={DOCS_URL}>Read the docs</a>
+      <a
+        class="btn btn-ghost"
+        href={DOCS_URL}
+        data-track="cta_docs"
+        data-track-location="hero">Read the docs</a
+      >
     </div>
   </div>
 

--- a/site/src/components/InstallBlock.astro
+++ b/site/src/components/InstallBlock.astro
@@ -26,6 +26,8 @@ const INSTALL_CMD = "curl -fsSL https://shepherd.run/install.sh | bash";
 </div>
 
 <script>
+  import { track } from "@vercel/analytics";
+
   const block = document.getElementById("install");
   const btn = block?.querySelector<HTMLButtonElement>(".copy");
   const label = btn?.querySelector<HTMLElement>(".copy-label");
@@ -54,6 +56,9 @@ const INSTALL_CMD = "curl -fsSL https://shepherd.run/install.sh | bash";
     if (label) label.textContent = "Copied!";
     btn.classList.add("is-copied");
     if (affirm) affirm.textContent = "Install command copied to clipboard.";
+    // Custom event: the strongest conversion signal on the page. Anonymous —
+    // no data payload. See Base.astro for the CTA-click tracker + plan caveat.
+    track("install_copy");
     clearTimeout(resetTimer);
     resetTimer = setTimeout(() => {
       if (label) label.textContent = "Copy";

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -31,13 +31,24 @@ const DEMO_URL = "https://demo.shepherd.run";
 
     <ul class="links">
       <li>
-        <a href={DEMO_URL} rel="noopener noreferrer" target="_blank">Demo</a>
+        <a
+          href={DEMO_URL}
+          rel="noopener noreferrer"
+          target="_blank"
+          data-track="cta_demo"
+          data-track-location="nav">Demo</a
+        >
       </li>
       <li><a href="#features">Features</a></li>
       <li><a href="#install">Install</a></li>
-      <li><a href={DOCS_URL}>Docs</a></li>
+      <li><a href={DOCS_URL} data-track="cta_docs" data-track-location="nav">Docs</a></li>
       <li>
-        <a href={GITHUB_URL} rel="noopener noreferrer" target="_blank">GitHub</a
+        <a
+          href={GITHUB_URL}
+          rel="noopener noreferrer"
+          target="_blank"
+          data-track="cta_github"
+          data-track-location="nav">GitHub</a
         >
       </li>
     </ul>

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -65,5 +65,25 @@ const {
   </head>
   <body>
     <slot />
+
+    <script>
+      import { track } from "@vercel/analytics";
+
+      // Discrete custom events for the marketing CTAs. Anonymous by design:
+      // event name + a coarse `location` (hero/nav/footer) only — never PII.
+      // Delegated at the document so Nav/Hero/Footer links share one handler
+      // (no per-component script); track() is fire-and-forget (uses a beacon),
+      // so it never blocks the anchor's navigation. Custom events require the
+      // project's Vercel team to be on Pro+ (Hobby silently drops them).
+      document.addEventListener("click", (event) => {
+        const el = (event.target as Element | null)?.closest<HTMLElement>(
+          "[data-track]",
+        );
+        const name = el?.dataset.track;
+        if (!name) return;
+        const location = el.dataset.trackLocation;
+        track(name, location ? { location } : undefined);
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## What

Adds Vercel Web Analytics **custom events** to the marketing site (`site/`), building on the page-view tracking from #1321. Instruments the site's real conversion actions so we can see *what* visitors do, not just that they arrived.

Scope is deliberately **marketing-only** — `docs-site/` (Starlight) is content that page-views already cover; its only custom-event candidate (copy-code-block) has no clean hook and low ROI, so it's excluded.

## Events (discrete names, anonymous)

| Event | Trigger | Locations |
| --- | --- | --- |
| `install_copy` | Copy the one-line installer | install block |
| `cta_demo` | "Try the live demo" | hero, nav |
| `cta_github` | "View on GitHub" | hero, nav, footer |
| `cta_docs` | "Read the docs" | hero, nav, footer |

Anonymous by design: event name + a single coarse `location` prop (`hero` / `nav` / `footer`) — no PII, no free text. One property, within Pro's 2-property cap. Consistent with the cookieless/consent-free model of the existing page-view analytics.

## How

- A single **delegated** click listener in `Base.astro` reads `data-track` / `data-track-location` off the anchors, so Nav / Hero / Footer share one handler with no per-component script.
- `install_copy` fires from the **existing** `InstallBlock` copy handler on a successful copy.
- No new deps — `@vercel/analytics@2.0.1` was already added in #1321. `track()` is fire-and-forget (beacon), so it never blocks the anchors' navigation.

## Plan requirement

Custom events require the marketing project's Vercel team to be on **Pro+** (Hobby silently drops them). **Confirmed already set** — no new manual step beyond the Web Analytics enablement from #1321.

## Verification

- `bun run check` → 0 errors (pre-existing `execCommand` hint only)
- `bun run build` → passes; verified in `dist/`: delegated listener + `install_copy` bundled, `data-track` attrs present (cta_demo ×2, cta_docs ×3, cta_github ×3).

[no-feature-entry] — marketing-site instrumentation, not a Shepherd-app user-facing feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)