### PR TITLE
fix(onboarding-harness): boot past #1313 herdr fail-fast in seeded scenarios

### DIFF
--- a/ci/onboarding-harness/probe.ts
+++ b/ci/onboarding-harness/probe.ts
@@ -83,6 +83,31 @@ export async function bootShepherd(driver: IncusDriver, name: string): Promise<v
   }
 }
 
+/** Boot Shepherd in the FOREGROUND expecting the #1313 herdr fail-fast, and return
+ *  its exit code + combined output. Used only by the `herdr-missing` runner: with
+ *  herdr removed, preflight prints the banner and exits 78 BEFORE binding the HTTP
+ *  server, so there is nothing to poll — we capture the process's exit directly.
+ *
+ *  Mirrors `bootShepherd`'s launch env exactly (same `cd`, `~/.bun/bin/bun
+ *  src/index.ts`, and PATH ordering) so the ONLY behavioral difference from a real
+ *  boot is the removed herdr. It intentionally OMITS `SHEPHERD_TOKEN` (which
+ *  `bootShepherd` sets): harmless, because preflight runs and exits before any
+ *  token/auth/store use and this path never reaches the server. `timeout 30` is a
+ *  defensive guard — the caller must treat ONLY exit 78 as the expected fail-fast
+ *  (timeout's 124, or any other code, means Shepherd did NOT fail-fast). */
+export async function bootExpectingPreflightExit(
+  driver: IncusDriver,
+  name: string,
+): Promise<{ code: number; output: string }> {
+  const r = await driver.exec(name, [
+    "sh",
+    "-c",
+    `cd ${SHEPHERD_DIR} && timeout 30 env PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH" ` +
+      `~/.bun/bin/bun src/index.ts 2>&1`,
+  ]);
+  return { code: r.code, output: r.stdout };
+}
+
 /** The poll command shared by the manual-boot retry path and `waitForApi`: poll
  *  the server until it answers or the ceiling elapses (degraded boots are expected —
  *  we only need the process up far enough to serve HTTP). Hits the PUBLIC `/api/health`

--- a/ci/onboarding-harness/run.ts
+++ b/ci/onboarding-harness/run.ts
@@ -7,6 +7,7 @@ import { SCENARIOS } from "./scenarios";
 import { seedInstance } from "./seed";
 import {
   assertUnitActive,
+  bootExpectingPreflightExit,
   bootShepherd,
   HARNESS_TOKEN,
   probeDiagnostics,
@@ -17,6 +18,7 @@ import { assertDetection } from "./assert";
 import { buildGapReport, gateGapScenarios, statusDescription } from "./report";
 import { reportToGitHub, publishStatus } from "./issue";
 import { remediationsFor } from "../../src/remediations";
+import { HERDR_MISSING_EXIT_CODE, HERDR_MISSING_MARKER } from "../../src/preflight";
 import type { DetectionResult, Scenario, ScenarioResult } from "./types";
 import type { DiagnosticsSnapshot } from "../../src/types";
 
@@ -172,6 +174,60 @@ async function runInstallLifecycleE2E(
   };
 }
 
+/** Fail-fast PREFLIGHT flow (`herdr-missing`). Since #1313 a missing herdr prints
+ *  the banner and exits 78 BEFORE the HTTP server binds, so the standard boot+probe
+ *  detection path can't run. The baseline installs a herdr STUB; the seed removes
+ *  it, restoring the real fail-fast. We:
+ *   1. boot in the foreground and assert exit 78 + the banner marker (detection);
+ *   2. apply the REAL verbatim herdr remediation (via the production REMEDIATIONS
+ *      map — a full synthetic snapshot, so remediationsFor resolves the install);
+ *   3. re-boot normally (herdr now present) and assert the herdr check is `ok`.
+ *  Throws fail-closed at each step — a failure is caught by runScenario as a gating
+ *  BOOT CRASH, which is correct: a preflight that didn't fire, or a remediation that
+ *  didn't heal, is a real regression, not something to swallow. */
+async function runHerdrPreflightE2E(
+  driver: IncusDriver,
+  scenario: Scenario,
+  base: ScenarioBase,
+  tarball: string,
+): Promise<ScenarioResult> {
+  await seedInstance(driver, scenario, tarball);
+
+  // Detection: with herdr removed, boot must fail-fast with the banner + exit 78.
+  // ONLY exit 78 passes — timeout's 124 (or any other code) means it did NOT
+  // fail-fast, i.e. a real regression to surface.
+  const boot = await bootExpectingPreflightExit(driver, scenario.id);
+  if (boot.code !== HERDR_MISSING_EXIT_CODE || !boot.output.includes(HERDR_MISSING_MARKER)) {
+    throw new Error(
+      `${scenario.id}: expected herdr fail-fast (exit ${HERDR_MISSING_EXIT_CODE} + banner), ` +
+        `got exit ${boot.code}:\n${boot.output.slice(-800)}`,
+    );
+  }
+
+  // Apply the real verbatim remediation. remediationsFor iterates snapshot.checks,
+  // so this MUST be a full DiagnosticsSnapshot (a bare check object → no checks →
+  // [] → silent no-op). This resolves diagnostics_hint_herdr_missing → the real
+  // herdr install from src/remediations.ts (no hardcoded copy).
+  const synthetic: DiagnosticsSnapshot = {
+    checks: [{ id: "herdr", state: "error", hintKey: "diagnostics_hint_herdr_missing" }],
+    generatedAt: 0,
+    overall: "error",
+  };
+  if (!(await applyVerbatim(driver, scenario.id, synthetic))) {
+    throw new Error(`${scenario.id}: verbatim herdr remediation failed`);
+  }
+
+  // Re-boot normally (herdr now present) and confirm the check recovered to ok.
+  await bootShepherd(driver, scenario.id);
+  const after = await probeDiagnostics(driver, scenario.id);
+  return {
+    ...base,
+    detection: { scenarioId: scenario.id, detected: true, misses: [] },
+    appliedVia: "verbatim",
+    reachedGreen: after.checks.find((c) => c.id === "herdr")?.state === "ok",
+  };
+}
+
 /** Pick + run the standard-path remediation: detection-only (by design or
  *  agent-incompatible), verbatim, or agent. Returns the chosen `appliedVia` and
  *  whether this was a detection-only (no-apply) run. */
@@ -215,6 +271,8 @@ export async function runScenario(
     if (scenario.serviceLifecycle)
       return await runInstallLifecycleE2E(driver, scenario, base, tarball);
     if (scenario.installE2E) return await runInstallE2E(driver, scenario, base, tarball);
+    if (scenario.preflightFailFast)
+      return await runHerdrPreflightE2E(driver, scenario, base, tarball);
 
     await seedInstance(driver, scenario, tarball);
     await bootShepherd(driver, scenario.id);

--- a/ci/onboarding-harness/scenarios.ts
+++ b/ci/onboarding-harness/scenarios.ts
@@ -77,11 +77,18 @@ export const SCENARIOS: Scenario[] = [
     detectionOnly: true,
   },
   {
+    // Since #1313 a missing herdr fail-fasts (banner + exit 78) BEFORE the HTTP
+    // server binds, so the boot+probe path can't detect it. The baseline installs a
+    // herdr STUB (seed.ts) which this seed removes, restoring the real fail-fast;
+    // `preflightFailFast` selects the runner that asserts the banner/exit, then
+    // applies the verbatim REMEDIATIONS herdr install and re-boots to green. Stays
+    // `structured` (gate-eligible) — it exercises the real new first-run UX.
     id: "herdr-missing",
     image: "images:archlinux",
     seed: ["rm -f /usr/local/bin/herdr ~/.local/bin/herdr"],
     expect: [{ id: "herdr", state: "error" }],
     coaching: "structured",
+    preflightFailFast: true,
   },
   {
     // claudeProbe is PRESENCE-ONLY (a successful `claude --version` ⇒ ok; there is

--- a/ci/onboarding-harness/seed.ts
+++ b/ci/onboarding-harness/seed.ts
@@ -30,9 +30,36 @@ function ensureToolchain(): string {
   );
 }
 
+/** Write a network-free `herdr` STUB onto PATH so Shepherd's boot preflight
+ *  (`herdr --version`) passes without a live `herdr.dev` fetch. Since #1313 a
+ *  missing herdr fail-fasts (exit 78) BEFORE the HTTP server binds, so the 6
+ *  non-herdr scenarios — which don't test herdr — just need preflight satisfied.
+ *
+ *  The stub emits a single VALID JSON line for EVERY invocation. This is
+ *  load-bearing, not decorative:
+ *   - diagnostics' `herdrProbe` extracts a semver via `SEMVER_RE` from the output,
+ *     so the JSON's `99.99.99` (≥ HERDR_MIN_VERSION) reads `ok`;
+ *   - on-loop `HerdrDriver.list()/tabs()/panes()` do an UNGUARDED `JSON.parse` then
+ *     `parsed?.result?.… ?? []`. A plain-text `herdr 99.99.99` would throw a
+ *     SyntaxError every tick (a different throw than the pre-#1313 ENOENT), so valid
+ *     JSON is required — it parses cleanly to `[]` and never throws.
+ *  A final `test -x` makes it a CHECKED step (fail-closes the baseline). */
+function herdrStub(): string {
+  return (
+    'mkdir -p "$HOME/.local/bin"\n' +
+    "cat > \"$HOME/.local/bin/herdr\" <<'HERDR_STUB'\n" +
+    "#!/bin/sh\n" +
+    'echo \'{"version":"99.99.99"}\'\n' +
+    "HERDR_STUB\n" +
+    'chmod +x "$HOME/.local/bin/herdr"\n' +
+    'test -x "$HOME/.local/bin/herdr"'
+  );
+}
+
 /** Commands that turn a fresh instance into a bootable-Shepherd baseline: bun
- *  runtime + the pushed working-tree build + deps + the claude CLI (agent path).
- *  Defects are layered AFTER this so degraded Shepherd can still boot. */
+ *  runtime + the pushed working-tree build + deps + the claude CLI (agent path) +
+ *  a herdr stub that satisfies the boot preflight (#1313). Defects are layered
+ *  AFTER this so degraded Shepherd can still boot. */
 function baselineCommands(): string[] {
   return [
     ensurePkg("curl"),
@@ -60,6 +87,9 @@ function baselineCommands(): string[] {
     `cd ${SHEPHERD_DIR} && ~/.bun/bin/bun install`,
     // claude CLI for the agent apply path; harmless if a scenario removes it later.
     "curl -fsSL https://claude.ai/install.sh | bash || true",
+    // herdr stub so the boot preflight (#1313) passes with zero network; the
+    // herdr-missing scenario removes it in its seed to exercise the real fail-fast.
+    herdrStub(),
   ];
 }
 

--- a/ci/onboarding-harness/types.ts
+++ b/ci/onboarding-harness/types.ts
@@ -37,6 +37,13 @@ export interface Scenario {
    *  scenario.seed and only pushes the tarball + install.sh; run.ts runs the
    *  installer, boots, probes, and compares the snapshot against `expect`. */
   installE2E?: true;
+  /** Fail-fast PREFLIGHT scenario (`herdr-missing`). Since #1313 a missing herdr
+   *  makes Shepherd print an actionable banner and exit 78 BEFORE the HTTP server
+   *  binds, so the boot+probe detection path can't run. Instead the runner boots in
+   *  the foreground, asserts the banner + exit code (detection), applies the real
+   *  verbatim herdr remediation, then re-boots normally and asserts `herdr:ok`
+   *  (green). Stays `structured` / gate-eligible — it tests the real new UX. */
+  preflightFailFast?: true;
   /** Real systemd-unit LIFECYCLE path. Implies the `installE2E` bare-host seeding
    *  and the same INSTALL-GAP reporting/gate classification, but additionally
    *  exercises the full service lifecycle the plain `install-e2e` deliberately

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -6,7 +6,12 @@
 
 export const HERDR_MISSING_EXIT_CODE = 78; // EX_CONFIG
 
-const BANNER = `⚠  herdr not found on PATH — Shepherd cannot run.
+// The banner's distinctive line, exported so out-of-tree consumers (the onboarding
+// harness's fail-fast probe) can match the fail-fast output without hardcoding a
+// copy that a future reword would break silently.
+export const HERDR_MISSING_MARKER = "herdr not found on PATH";
+
+const BANNER = `⚠  ${HERDR_MISSING_MARKER} — Shepherd cannot run.
    herdr owns the interactive claude PTYs; nothing works without it.
    Install:  curl -fsSL https://herdr.dev/install.sh | bash
    It installs to ~/.local/bin — ensure that's on PATH:

--- a/test/onboarding-harness/herdr-preflight.test.ts
+++ b/test/onboarding-harness/herdr-preflight.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "bun:test";
+import { IncusDriver } from "../../ci/onboarding-harness/incus";
+import { runScenario } from "../../ci/onboarding-harness/run";
+import { SCENARIOS } from "../../ci/onboarding-harness/scenarios";
+import { HERDR_MISSING_EXIT_CODE, HERDR_MISSING_MARKER } from "../../src/preflight";
+import type { IncusExec } from "../../ci/onboarding-harness/types";
+import type { DiagnosticsSnapshot } from "../../src/types";
+
+const herdrMissing = SCENARIOS.find((s) => s.id === "herdr-missing")!;
+
+/** After the remediation re-installs herdr, the re-boot probe sees herdr `ok`
+ *  (the other throw-away-host non-ok checks are irrelevant to this scenario). */
+function greenAfterFix(): DiagnosticsSnapshot {
+  return {
+    checks: [
+      { id: "herdr", state: "ok", hintKey: "diagnostics_hint_herdr_ok" },
+      { id: "gh", state: "error", hintKey: "diagnostics_hint_gh_not_authenticated" },
+    ],
+    generatedAt: 1,
+    overall: "error",
+  };
+}
+
+/** The foreground fail-fast boot is the ONLY `src/index.ts` invocation carrying
+ *  `timeout` (bootExpectingPreflightExit); the re-boot uses `setsid`. Keying on
+ *  `timeout` lets the recorder answer the two boots differently. */
+const isFailFastBoot = (joined: string): boolean =>
+  joined.includes("src/index.ts") && joined.includes("timeout");
+
+/** Recorder: fail-fast boot returns the given exit code + banner output; the
+ *  diagnostics probe returns `snapshot`; everything else succeeds (code 0). */
+function recorder(failFastCode: number, snapshot: DiagnosticsSnapshot) {
+  const calls: string[][] = [];
+  const run = async (args: string[]): Promise<IncusExec> => {
+    calls.push(args);
+    const joined = args.join(" ");
+    if (isFailFastBoot(joined)) {
+      const output = failFastCode === HERDR_MISSING_EXIT_CODE ? `⚠  ${HERDR_MISSING_MARKER}\n` : "";
+      return { stdout: output, stderr: "", code: failFastCode };
+    }
+    if (joined.includes("/api/diagnostics?refresh=1")) {
+      return { stdout: JSON.stringify(snapshot), stderr: "", code: 0 };
+    }
+    return { stdout: "", stderr: "", code: 0 };
+  };
+  return { calls, run };
+}
+
+describe("herdr-missing catalog entry", () => {
+  it("is preflightFailFast, structured (gate-eligible), and removes herdr in its seed", () => {
+    expect(herdrMissing.preflightFailFast).toBe(true);
+    expect(herdrMissing.coaching).toBe("structured");
+    expect(herdrMissing.detectionOnly).toBeUndefined();
+    expect(herdrMissing.seed.some((c) => c.includes("herdr"))).toBe(true);
+  });
+});
+
+describe("herdr-missing runScenario (fail-fast preflight path)", () => {
+  it("asserts fail-fast (exit 78 + banner), applies the verbatim herdr install, re-boots to green, and tears down", async () => {
+    const { calls, run } = recorder(HERDR_MISSING_EXIT_CODE, greenAfterFix());
+    const d = new IncusDriver(run, "shep-onb-");
+    const result = await runScenario(d, herdrMissing, "/tmp/shepherd.tar");
+
+    const flat = calls.map((c) => c.join(" "));
+    // Foreground fail-fast boot happened (timeout guard, no setsid/token).
+    expect(flat.some((c) => isFailFastBoot(c))).toBe(true);
+    // The REAL verbatim remediation ran (production REMEDIATIONS → herdr.dev install).
+    expect(flat.some((c) => c.includes("herdr.dev/install.sh"))).toBe(true);
+    // Re-boot used the normal detached launch (setsid) + probed diagnostics.
+    expect(flat.some((c) => c.includes("src/index.ts") && c.includes("setsid"))).toBe(true);
+    expect(flat.some((c) => c.includes("/api/diagnostics?refresh=1"))).toBe(true);
+    // Outcome: detected + green, verbatim, gate-eligible.
+    expect(result.detection.detected).toBe(true);
+    expect(result.reachedGreen).toBe(true);
+    expect(result.appliedVia).toBe("verbatim");
+    expect(result.gateEligible).toBe(true);
+    // Teardown ran (finally → delete).
+    expect(calls.some((c) => c[0] === "delete")).toBe(true);
+  });
+
+  it("fail-closes (gating BOOT CRASH) when boot does NOT fail-fast — a timeout kill (124) is never a pass", async () => {
+    const { calls, run } = recorder(124, greenAfterFix()); // timeout kill, not exit 78
+    const d = new IncusDriver(run, "shep-onb-");
+    const result = await runScenario(d, herdrMissing, "/tmp/shepherd.tar");
+
+    // Threw before detection → runScenario's catch: not green, still gate-eligible,
+    // installE2E flag absent so report.ts classifies it BOOT CRASH (which gates).
+    expect(result.reachedGreen).toBe(false);
+    expect(result.detection.detected).toBe(false);
+    expect(result.gateEligible).toBe(true);
+    expect(result.installE2E).toBeUndefined();
+    expect(result.error).toContain("expected herdr fail-fast");
+    // Never proceeded to the remediation after a non-78 boot.
+    expect(calls.map((c) => c.join(" ")).some((c) => c.includes("herdr.dev/install.sh"))).toBe(
+      false,
+    );
+    // Still torn down.
+    expect(calls.some((c) => c[0] === "delete")).toBe(true);
+  });
+});

--- a/test/onboarding-harness/scenarios.test.ts
+++ b/test/onboarding-harness/scenarios.test.ts
@@ -37,6 +37,16 @@ describe("scenario catalog", () => {
   // repoRoot ($HOME) — else the probe downgrades to `warning` and the gap reopens.
   // This guards against the `mkdir`-seed being silently deleted; it does NOT prove
   // the mechanism (that is the diagnostics behavioral test).
+  // herdr-missing uses the fail-fast preflight runner (since #1313 a missing herdr
+  // exits 78 before the HTTP server binds), and MUST stay gate-eligible (structured,
+  // not detection-only) — it exercises the real new first-run UX end-to-end.
+  it("herdr-missing is preflightFailFast and structured (gate-eligible)", () => {
+    const s = SCENARIOS.find((x) => x.id === "herdr-missing")!;
+    expect(s.preflightFailFast).toBe(true);
+    expect(s.coaching).toBe("structured");
+    expect(s.detectionOnly).toBeUndefined();
+  });
+
   it("every scenario expecting gh:error seeds a repo dir under repoRoot", () => {
     const ghErrorScenarios = SCENARIOS.filter((s) =>
       s.expect.some((e) => e.id === "gh" && e.state === "error"),

--- a/test/onboarding-harness/seed.test.ts
+++ b/test/onboarding-harness/seed.test.ts
@@ -45,6 +45,30 @@ describe("seedInstance", () => {
     // unzip (bun installer prereq) + a build toolchain (node-pty) are ensured
     expect(flat.some((c) => c.includes("unzip"))).toBe(true);
     expect(flat.some((c) => c.includes("build-essential"))).toBe(true);
+
+    // baseline writes the network-free herdr STUB (satisfies the #1313 preflight
+    // with zero network) before the scenario seed — NOT a herdr.dev fetch.
+    const stubIdx = flat.findIndex((c) => c.includes(".local/bin/herdr") && c.includes("chmod +x"));
+    expect(stubIdx).toBeGreaterThanOrEqual(0);
+    expect(stubIdx).toBeLessThan(seedIdx);
+    // the herdr step must be the stub, never a live herdr.dev install in the baseline
+    expect(flat.some((c) => c.includes("herdr.dev"))).toBe(false);
+  });
+
+  it("the herdr stub is a CHECKED baseline step (a failure aborts the seed)", async () => {
+    const calls: string[][] = [];
+    const run = async (args: string[]): Promise<IncusExec> => {
+      calls.push(args);
+      // Fail only the herdr-stub write; everything else succeeds.
+      if (args.join(" ").includes(".local/bin/herdr")) {
+        return { stdout: "", stderr: "no space left on device", code: 1 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+    const d = new IncusDriver(run, "shep-onb-");
+    await expect(seedInstance(d, scenario, "/tmp/shepherd.tar")).rejects.toThrow(
+      /baseline step failed/,
+    );
   });
 
   it("pushes the Shepherd build tarball into the instance", async () => {

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -1,5 +1,10 @@
 import { test, expect } from "bun:test";
-import { HERDR_MISSING_EXIT_CODE, isBinaryMissingError, preflightHerdr } from "../src/preflight";
+import {
+  HERDR_MISSING_EXIT_CODE,
+  HERDR_MISSING_MARKER,
+  isBinaryMissingError,
+  preflightHerdr,
+} from "../src/preflight";
 
 // ── isBinaryMissingError ─────────────────────────────────────────────────────
 
@@ -66,6 +71,26 @@ test("preflightHerdr: missing binary → logs one banner and exits 78", () => {
   expect(logs).toHaveLength(1);
   expect(logs[0]).toContain("herdr not found on PATH");
   expect(logs[0]).toContain("https://herdr.dev/install.sh");
+});
+
+test("emitted banner contains the exported HERDR_MISSING_MARKER (no drift for out-of-tree matchers)", () => {
+  const logs: string[] = [];
+  const { exit } = fakeExit();
+
+  expect(() =>
+    preflightHerdr({
+      runVersion: () => {
+        throw { code: "ENOENT" };
+      },
+      log: (msg) => logs.push(msg),
+      exit,
+    }),
+  ).toThrow(ExitSentinel);
+
+  // The onboarding harness's fail-fast probe matches on this exported constant, so
+  // the banner MUST keep containing it verbatim.
+  expect(HERDR_MISSING_MARKER).toBe("herdr not found on PATH");
+  expect(logs[0]).toContain(HERDR_MISSING_MARKER);
 });
 
 test("preflightHerdr: success → neither log nor exit called", () => {


### PR DESCRIPTION
## Problem

The nightly onboarding harness reported **7 / 9 scenarios BOOT CRASH** (#1322), every one with the same tail:

```
⚠  herdr not found on PATH — Shepherd cannot run.
```

## Root cause

PR #1313 (`feat: optimize first-run experience`) added an **unconditional** `preflightHerdr` in `src/index.ts` that prints an actionable banner and **exits 78 _before_ the HTTP server binds** when `herdr` isn't on PATH. The harness baseline (`ci/onboarding-harness/seed.ts`) never installed herdr — it relied on Shepherd booting **degraded** so `/api/diagnostics` could self-report. Post-#1313 that degraded boot is gone, so:

- the **6 non-herdr** seeded scenarios crash at boot (herdr was never present), and
- **herdr-missing** removes herdr on purpose → the new fail-fast fires → the old boot+probe detection path can't run.

`install-e2e` / `install-e2e-service` kept passing because they run the real `deploy/install.sh`, which auto-installs herdr.

## Fix (adapts the harness; keeps #1313's fail-fast intact)

- **Network-free herdr stub in the baseline.** The 6 non-herdr scenarios don't test herdr — they only need preflight satisfied. The baseline now writes a tiny local `~/.local/bin/herdr` stub that emits a single **valid JSON** line (`{"version":"99.99.99"}`) for every call. This is load-bearing, not decorative: it satisfies both the semver `--version` probe **and** the *unguarded* `JSON.parse` in `HerdrDriver.list/tabs/panes` (parses cleanly to `[]`, so the on-loop path never throws a `SyntaxError`). Zero network → no `herdr.dev` release-gate SPOF for these scenarios.
- **`herdr-missing` gets a fail-fast-aware path** (`preflightFailFast`). It boots in the foreground, asserts the banner + **exit 78 exactly** (a `timeout` kill / 124 is never a pass), applies the **real** verbatim `REMEDIATIONS` herdr install, then re-boots and asserts `herdr:ok`. Stays `structured` / gate-eligible — it exercises the real new first-run UX end-to-end. Dispatched inside `runScenario`'s `try` so it inherits teardown + fail-closed BOOT-CRASH gating.
- **`export HERDR_MISSING_MARKER`** from `src/preflight.ts` (export-only, no behavior change) so the probe matches the banner without a hardcoded copy that a reword could silently break.

Real-install coverage is retained where it belongs (`herdr-missing` remediation + the two `install-e2e` scenarios), so **no new** `herdr.dev` gate dependency is introduced and no `report.ts` change is needed.

## Verification

- `bun test` (preflight + onboarding-harness): **87 pass**, incl. new fail-fast runner tests (happy path + the 124-is-not-a-pass fail-closed case). `bun run lint` + `bun run typecheck` clean.
- **End-to-end on Incus** (real instances, this fix):
  - `herdr-missing` (archlinux) → **PASS** (fail-fast → verbatim install → `herdr:ok`)
  - `node-too-old` (debian/12) → **PASS** (boots degraded **with the stub**, detects `node:warning`, heals to green)

The authoritative signal remains the operator's nightly on the Incus host; these per-scenario runs confirm both halves of the fix.

Fixes #1322