### PR TITLE
fix(security): resolve CodeQL alerts — table escaping, error exposure, url guard

### DIFF
--- a/scripts/usage-report.ts
+++ b/scripts/usage-report.ts
@@ -828,8 +828,10 @@ function renderMarkdownTable(rows: string[][]): string {
   const body = rows.map((r) => `| ${r.map(mdCell).join(" | ")} |`);
   return [head, sep, ...body].join("\n");
 }
-function mdCell(s: string): string {
-  return s.replace(/\|/g, "\\|");
+export function mdCell(s: string): string {
+  // Order matters: normalize newlines (a raw newline splits the row), then escape backslashes
+  // BEFORE pipes so the `\` we add for each `|` isn't itself doubled. Mirrors epic-landing's cellSafe.
+  return s.replace(/\r?\n/g, " ").replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
 }
 
 function renderPlainTable(rows: string[][]): string {

--- a/src/epic-landing.ts
+++ b/src/epic-landing.ts
@@ -52,11 +52,13 @@ export function buildLandingPrTitle(parentNumber: number, parentTitle: string): 
   return `${FALLBACK_TYPE}: ${cleaned} ${epicTag}`;
 }
 
-/** Sanitize a child title for a single Markdown table cell: escape pipes (a raw `|` would
- *  add a spurious column and corrupt the row) and collapse any newlines to spaces (a row
- *  must stay single-line). Minimal — only the two characters that break a table row. */
+/** Sanitize a child title for a single Markdown table cell: collapse newlines to spaces (a
+ *  row must stay single-line), then escape backslashes BEFORE pipes so a title like `a\|b`
+ *  can't defeat the pipe-escape (escaping `|` first would leave a preceding `\` unescaped,
+ *  rendering as escaped-backslash + a bare delimiter and adding a spurious column). Minimal
+ *  — only what breaks a table row. */
 function cellSafe(title: string): string {
-  return title.replace(/\r?\n/g, " ").replace(/\|/g, "\\|");
+  return title.replace(/\r?\n/g, " ").replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
 }
 
 export function buildLandingPrBody(input: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1288,12 +1288,12 @@ async function setRepoRoles(
     if (!forge) throw new Error("no forge configured for repo");
     writeRepoRoles(dir, next, await forge.defaultBranch());
   } catch (e) {
-    // Push rejected (protected branch / no-ff / auth) or no forge — surface it so
-    // the dialog can tell the user instead of silently dropping the change.
-    return json(
-      { roles: readRepoRoles(dir), me, pushError: String((e as Error)?.message ?? e) },
-      502,
-    );
+    // Push rejected (protected branch / no-ff / auth) or no forge. Log the detail
+    // server-side; return a generic, non-error-derived message so raw error/stack text
+    // never reaches the client (CodeQL js/stack-trace-exposure #14). The dialog still
+    // shows its localized "roles push failed" message alongside this.
+    console.error("[repo-roles] role push failed:", e);
+    return json({ roles: readRepoRoles(dir), me, pushError: "push rejected" }, 502);
   }
   repushHandoff(deps, dir, me);
   return json({ roles: next, me });
@@ -5766,8 +5766,10 @@ async function resolveLandTarget(
   try {
     pr = await forge.prStatus(branch);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return { error: json({ error: msg }, 502) };
+    // Log the forge error server-side; return a generic message so raw error/stack text
+    // never reaches the client (CodeQL js/stack-trace-exposure #14).
+    console.error("[epic-land] landing PR status check failed:", err);
+    return { error: json({ error: "landing PR status check failed" }, 502) };
   }
 
   if (!computeLandingReady(pr, repoHasNoCiCached(forge.kind, dir)))
@@ -5800,8 +5802,10 @@ async function handleEpicsCompletedLand({ req, parts, deps }: Ctx): Promise<Resp
     // branch state, not method availability), making the CTA fire a doomed merge there.
     await forge.merge(row.landingPrNumber!, { method: forge.mergeMethod, deleteBranch: true });
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return json({ error: msg }, 502);
+    // Log the merge error server-side; return a generic message so raw error/stack text
+    // never reaches the client (CodeQL js/stack-trace-exposure #14).
+    console.error("[epic-land] landing merge failed:", err);
+    return json({ error: "landing merge failed" }, 502);
   }
 
   deps.store.setEpicLandingPr(dir, parent, {

--- a/test/epic-landing.test.ts
+++ b/test/epic-landing.test.ts
@@ -105,6 +105,18 @@ describe("buildLandingPrBody", () => {
     expect(cells).toEqual(["#70", "a \\| b", "#700"]);
   });
 
+  it("escapes a backslash before a pipe so the pipe-escape can't be defeated", () => {
+    // `a\|b`: escaping only `|` would yield `a\\|b` = escaped-backslash + a BARE delimiter,
+    // adding a spurious column. Escaping `\` first yields `a\\\|b` — one real cell.
+    const children = [{ number: 71, title: "a\\|b", prNumber: 710, prUrl: null }];
+    const body = buildLandingPrBody({ ...base, children });
+    const row = body.split("\n").find((l) => l.startsWith("| #71"))!;
+    const segments = row.split(/(?<!\\)\|/);
+    expect(segments.length).toBe(5); // still exactly 3 cells (no injected column)
+    const cells = segments.slice(1, -1).map((s) => s.trim());
+    expect(cells).toEqual(["#71", "a\\\\\\|b", "#710"]);
+  });
+
   it("collapses newlines in a child title to keep the row single-line", () => {
     const children = [{ number: 80, title: "line1\nline2", prNumber: 800, prUrl: null }];
     const body = buildLandingPrBody({ ...base, children });

--- a/test/epic-server-land.test.ts
+++ b/test/epic-server-land.test.ts
@@ -258,8 +258,8 @@ describe("POST /api/epics/completed/land", () => {
     expect(mergeCalls).toHaveLength(0);
   });
 
-  test("prStatus throws → 502", async () => {
-    const { forge } = makeForge({ prStatusThrows: new Error("network failure") });
+  test("prStatus throws → 502 with a generic message, not the raw error (CodeQL #14)", async () => {
+    const { forge } = makeForge({ prStatusThrows: new Error("network failure at 10.0.0.5:6443") });
     const { app, store } = landHarness(() => forge);
     seedCompletedEpic(store, repoDir, 42, "open", 77);
     store.getOrInitEpicIntegrationBranch(repoDir, 42, "epic/42-my-epic");
@@ -272,11 +272,14 @@ describe("POST /api/epics/completed/land", () => {
     );
     expect(res.status).toBe(502);
     const body = await res.json();
-    expect(body.error).toMatch(/network failure/);
+    expect(body.error).toBe("landing PR status check failed");
+    expect(body.error).not.toContain("10.0.0.5"); // raw error/stack never leaks to the client
   });
 
-  test("forge.merge throws → 502", async () => {
-    const { forge } = makeForge({ mergeThrows: new Error("merge commits disabled") });
+  test("forge.merge throws → 502 with a generic message, not the raw error (CodeQL #14)", async () => {
+    const { forge } = makeForge({
+      mergeThrows: new Error("merge commits disabled at /srv/secret"),
+    });
     const { app, store } = landHarness(() => forge);
     seedCompletedEpic(store, repoDir, 42, "open", 77);
     store.getOrInitEpicIntegrationBranch(repoDir, 42, "epic/42-my-epic");
@@ -289,7 +292,8 @@ describe("POST /api/epics/completed/land", () => {
     );
     expect(res.status).toBe(502);
     const body = await res.json();
-    expect(body.error).toMatch(/merge commits disabled/);
+    expect(body.error).toBe("landing merge failed");
+    expect(body.error).not.toContain("/srv/secret"); // raw error/stack never leaks to the client
   });
 
   test("happy path: forge.merge called with the host mergeMethod + deleteBranch, setEpicLandingPr state merged, epic:completed emitted, 200 ok", async () => {

--- a/test/repo-roles.test.ts
+++ b/test/repo-roles.test.ts
@@ -1,6 +1,10 @@
 import { test, expect } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
 import { annotateHandoff, computeHandoff, parseRoles, normalizeLogin } from "../src/repo-roles";
-import type { GitState, PrStatus } from "../src/forge/types";
+import type { GitForge, GitState, PrStatus } from "../src/forge/types";
+import { makeApp, type AppDeps } from "../src/server";
+import { config } from "../src/config";
 
 const approved: PrStatus["latestReview"] = { state: "approved", author: "scoop", submittedAt: 1 };
 
@@ -124,4 +128,39 @@ test("normalizeLogin trims, drops a leading @, empties to null", () => {
   expect(normalizeLogin("  @scoop ")).toBe("scoop");
   expect(normalizeLogin("")).toBeNull();
   expect(normalizeLogin(42)).toBeNull();
+});
+
+test("PUT /api/repo-roles: push failure → 502 generic pushError, raw error not leaked (CodeQL #14)", async () => {
+  const dir = mkdtempSync(join(config.repoRoot, "shepherd-roles-test-"));
+  try {
+    const forge = {
+      currentUser: async () => "me",
+      // The push fails with a message that carries a sensitive-looking internal detail.
+      defaultBranch: async () => {
+        throw new Error("remote rejected: protected branch at git@secret-host:22");
+      },
+    } as unknown as GitForge;
+    const deps: AppDeps = {
+      store: {} as never,
+      service: {} as never,
+      events: { emit: () => {} } as never,
+      usageLimits: { limits: () => ({}) } as never,
+      resolveForge: () => forge,
+    };
+    const app = makeApp(deps);
+    const res = await app.fetch(
+      new Request(`http://x/api/repo-roles?repo=${encodeURIComponent(dir)}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ reviewer: "alice" }),
+      }),
+    );
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.pushError).toBe("push rejected");
+    // Raw error/stack text must never reach the client.
+    expect(JSON.stringify(body)).not.toContain("secret-host");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/test/usage-report.test.ts
+++ b/test/usage-report.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { HEADERS, rowCells, totalsCells, type ReportRow } from "../scripts/usage-report";
+import { HEADERS, rowCells, totalsCells, mdCell, type ReportRow } from "../scripts/usage-report";
 
 const ROW: ReportRow = {
   desig: "TASK-001",
@@ -29,6 +29,14 @@ const ROW: ReportRow = {
   satTags: "db×1",
   reviewMultiplier: 0.4,
 };
+
+test("mdCell escapes backslash before pipe and collapses newlines", () => {
+  expect(mdCell("a | b")).toBe("a \\| b");
+  // `a\|b`: escaping only `|` would leave the `\` unescaped (escaped-backslash + bare
+  // delimiter → spurious column). Escaping `\` first yields `a\\\|b` — one intact cell.
+  expect(mdCell("a\\|b")).toBe("a\\\\\\|b");
+  expect(mdCell("line1\nline2")).toBe("line1 line2");
+});
 
 test("rowCells length matches HEADERS", () => {
   expect(rowCells(ROW).length).toBe(HEADERS.length);

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -1088,6 +1088,20 @@ test("doc-agent:done outcome=pr with null url fires toast without action", () =>
   expect(t?.actionLabel).toBeUndefined();
 });
 
+test("doc-agent:done outcome=pr with a non-http(s) url fires toast without action (CodeQL #3)", () => {
+  toasts.items = [];
+  const s = new HerdStore();
+  s.docAgentEnabled = true;
+  s.apply({
+    event: "doc-agent:done",
+    // A dangerous scheme must never be wired into window.open.
+    data: { repoPath: "/repos/da-pr-evil", url: "javascript:alert(1)", outcome: "pr" },
+  });
+  const t = toasts.items.find((x) => x.key === "doc-agent-done:/repos/da-pr-evil");
+  expect(t).toBeDefined();
+  expect(t?.actionLabel).toBeUndefined();
+});
+
 test("doc-agent:done outcome=observe fires keyed toast", () => {
   toasts.items = [];
   const s = new HerdStore();

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -39,6 +39,18 @@ import { m } from "$lib/paraglide/messages";
 import { buildQueues as buildQueuesStore } from "./buildQueues.svelte";
 import { postMergeSteps as postMergeStepsStore } from "./post-merge-steps.svelte";
 
+/** Only follow http(s) URLs when opening a link from event-carried data — a `javascript:`
+ *  (or other-scheme) value would be an open-redirect / script-execution vector
+ *  (CodeQL js/client-side-unvalidated-url-redirection #3). */
+function isSafeHttpUrl(raw: string): boolean {
+  try {
+    const { protocol } = new URL(raw);
+    return protocol === "https:" || protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
 export class HerdStore {
   sessions = $state<Session[]>([]);
   blocks = $state<Record<string, BlockState>>({});
@@ -544,13 +556,16 @@ export class HerdStore {
     const key = `doc-agent-done:${ev.data.repoPath}`;
     if (ev.data.outcome === "pr") {
       const url = ev.data.url;
+      // Only wire the "view PR" action for a validated http(s) URL — never open an
+      // unvalidated event-carried value (CodeQL js/client-side-unvalidated-url-redirection #3).
+      const safeUrl = url != null && isSafeHttpUrl(url) ? url : null;
       toasts.info(m.docagent_toast_pr_opened({ repo }), {
         key,
-        ...(url != null
+        ...(safeUrl != null
           ? {
               action: {
                 label: m.docagent_toast_view_pr(),
-                run: () => window.open(url, "_blank", "noopener"),
+                run: () => window.open(safeUrl, "_blank", "noopener"),
               },
             }
           : {}),


### PR DESCRIPTION
Triage and resolution of the 12 open CodeQL code-scanning alerts on `main`. Each site was verified against the analysis SARIF code-flows (`analysis 1431689613`, commit `fea4a5c0`). **3 real defects are fixed here; 9 confirmed false-positive / test-only alerts are dismissed by the operator** (see the table + manual steps below).

## Fixed in this PR

| # | Rule | Fix |
|---|------|-----|
| **#1** | `js/incomplete-sanitization` (`scripts/usage-report.ts` `mdCell`) | Escape `\` **before** `\|` (and collapse newlines) so a title like `a\|b` can't defeat the pipe-escape and inject a table column. |
| **#2** | `js/incomplete-sanitization` (`src/epic-landing.ts` `cellSafe`) | Same missing backslash-escape in the epic landing PR-body table cell. |
| **#14** | `js/stack-trace-exposure` | The 3 flagged 5xx sinks now log the real error server-side and return a generic, non-error-derived message so raw error/stack text never reaches the client. |

New/updated unit tests cover each: backslash+newline escaping (`usage-report`, `epic-landing`) and the 3 generic-error responses (`epic-server-land`, `repo-roles`).

### #14 scope — narrow by design

CodeQL alert #14 is a single result with **4 flows across 3 sink sites**, all fixed here:
- `src/server.ts` repo-roles push handler (`pushError`)
- `src/server.ts` epic-land `prStatus` catch
- `src/server.ts` epic-land `merge` catch

`server.ts` has ~19 **other** handlers with the same `err.message`→5xx shape that CodeQL does **not** flag (only these 3 have a query-modeled taint path from a throwing exception). Those are deliberately left untouched — **this is not a class-wide stack-trace-exposure fix.** A shared `errorResponse(err)` helper unifying all 5xx error bodies is a reasonable **follow-up**, out of scope here.

### #3 — hardened, but dismissed as a false positive

This PR also adds an `isSafeHttpUrl()` scheme guard on the doc-agent "view PR" `window.open` (`ui/src/lib/store.svelte.ts`) as defense-in-depth (blocks a `javascript:`/other-scheme value). **CodeQL still flags it** because `js/client-side-unvalidated-url-redirection` is about the redirect *host/origin*, not the scheme — a protocol check doesn't clear this query. The flagged value (`ev.data.url`) is a **forge-produced PR `html_url`** returned by `forge.openPr()` and delivered over the app's own `doc-agent:done` WS event (`src/doc-agent.ts:846` → `src/index.ts:969`) — not attacker-controlled. It is therefore dismissed as a false positive (same over-approximation class as #9–#12), with the scheme guard retained as hardening.

## Operator action — dismiss the 9 false-positive / test-only alerts

These are **not** code defects. `gh api` dismissal is an outward action the plan gates behind operator confirmation, so this PR does **not** auto-dismiss them — it delivers the exact reason + proof per alert. Dismiss in the Security UI: https://github.com/erwins-enkel/shepherd/security/code-scanning

| Alert | Rule | Location | Reason | Proof |
|-------|------|----------|--------|-------|
| **#3** | client-side-unvalidated-url-redirection | `ui/src/lib/store.svelte.ts` | `false positive` | Value is a forge-produced PR `html_url` (`forge.openPr()`) delivered over the app's own `doc-agent:done` WS event — not attacker input. `isSafeHttpUrl` scheme guard added as defense-in-depth; CodeQL wants host validation, which is N/A for a trusted server-produced URL. |
| **#9** | clear-text-logging | `src/drain.ts:1771` | `false positive` | Source `apiKeyAuth` (`service.ts:1473`); value reaching the sink is `apiKeyAuth.hold`, a constant string (`service.ts:1385`), wrapped as `SandboxAutoRefused`→`err` (`service.ts:1648`). The secret (`passthroughEnv`) never reaches the sink. |
| **#10** | clear-text-logging | `src/held-release.ts:73` | `false positive` | Same as #9 — logs the `SandboxAutoRefused` `err` whose message is the constant `apiKeyAuth.hold`. |
| **#11** | clear-text-logging | `src/service.ts:2676` | `false positive` | Logs `outcome.holdReason` = `apiKeyAuth.hold` (constant, `service.ts:1473`/`1385`); secret never reaches the sink. |
| **#12** | clear-text-logging | `src/service.ts:2710` | `false positive` | Same as #11. |
| **#5** | shell-command-injection-from-environment | `deploy/provision.ts:179` | `won't fix` | `defaultRunner` uses `spawnSync` with an **args array** (no `shell:true`); operator-run provisioning script, trusted env, no shell interpolation of env values. |
| **#6** | shell-command-injection-from-environment | `test/install-sh.test.ts:22` | `used in tests` | Test-harness code; not shipped, not attacker-reachable. |
| **#7** | unnecessary-use-of-cat | `test/install-sh.test.ts:109` | `used in tests` | Test-harness code; style nit only. |
| **#8** | bad-code-sanitization | `test/plugins-ui.test.ts:254` | `used in tests` | Test-harness code; not shipped, not attacker-reachable. |

## Verification

- Root: `bun run lint` clean; `bun test ./test` — changed-area suites green (48/48 across the 4 touched files). (Pre-existing flaky tests in `landing-rebase` git-push and a `doc-agent` prettier-stub are unrelated to this change.)
- UI: `bun run check` — 0 errors / 0 warnings; `bun test src/lib/store.svelte.test.ts` — 78/78 (includes the scheme-guard test, which still verifies the hardening even though #3 is dismissed).

```shepherd:manual-steps
- [ ] POST-MERGE: Dismiss CodeQL alert #3 (js/client-side-unvalidated-url-redirection, store.svelte.ts) as "false positive" — forge-produced PR html_url over the app's own WS event, not attacker input (scheme guard added as defense-in-depth)
- [ ] POST-MERGE: Dismiss CodeQL alert #9 (js/clear-text-logging, drain.ts) as "false positive" — logs apiKeyAuth.hold (constant); secret never reaches the sink
- [ ] POST-MERGE: Dismiss CodeQL alert #10 (js/clear-text-logging, held-release.ts) as "false positive" — same as #9
- [ ] POST-MERGE: Dismiss CodeQL alert #11 (js/clear-text-logging, service.ts:2676) as "false positive" — logs constant holdReason (apiKeyAuth.hold); secret never reaches the sink
- [ ] POST-MERGE: Dismiss CodeQL alert #12 (js/clear-text-logging, service.ts:2710) as "false positive" — same as #11
- [ ] POST-MERGE: Dismiss CodeQL alert #5 (js/shell-command-injection-from-environment, deploy/provision.ts) as "won't fix" — spawnSync args-array, no shell, trusted operator env
- [ ] POST-MERGE: Dismiss CodeQL alert #6 (js/shell-command-injection-from-environment, test/install-sh.test.ts) as "used in tests"
- [ ] POST-MERGE: Dismiss CodeQL alert #7 (js/unnecessary-use-of-cat, test/install-sh.test.ts) as "used in tests"
- [ ] POST-MERGE: Dismiss CodeQL alert #8 (js/bad-code-sanitization, test/plugins-ui.test.ts) as "used in tests"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
