### PR TITLE
fix(owed): scope Owed lens list + badge to the active repo chip

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1919,6 +1919,7 @@
   "owed_main_hint": "Offene Schritte nach dem Merge werden im Herd-Panel links angezeigt.",
   "owed_title": "Offene Schritte nach dem Merge",
   "owed_empty": "Keine offenen Schritte nach dem Merge — alles erledigt.",
+  "owed_repo_filter_empty": "Keine offenen Schritte nach dem Merge für {repo}.",
   "owed_note": "Dies sind alle manuellen Schritte, die die gemergten PRs deklariert haben. P2 erfasst die Bestätigung, nicht die Erledigung einzelner Schritte — daher erscheinen auch vor dem Merge bereits erledigte Schritte hier. Hake sie ab, um sie zu entfernen.",
   "owed_steps_count": "{done} von {total} erledigt",
   "owed_merged_ago": "vor {ago} gemergt",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1919,6 +1919,7 @@
   "owed_main_hint": "Owed post-merge steps are shown in the herd panel on the left.",
   "owed_title": "Post-merge steps owed",
   "owed_empty": "No post-merge steps owed — you're all caught up.",
+  "owed_repo_filter_empty": "No post-merge steps owed for {repo}.",
   "owed_note": "These are every manual step the merged PRs declared. P2 tracks acknowledgement, not per-step completion, so steps you already did before merge appear here too — tick them to clear them.",
   "owed_steps_count": "{done} of {total} done",
   "owed_merged_ago": "merged {ago} ago",

--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -4,7 +4,8 @@ import { page } from "vitest/browser";
 import "../../app.css";
 import Herd from "./Herd.svelte";
 import { reviews, planGates } from "$lib/reviews.svelte";
-import type { Session, GitState, Epic, EpicChild } from "$lib/types";
+import { postMergeSteps } from "$lib/post-merge-steps.svelte";
+import type { Session, GitState, Epic, EpicChild, PostMergeSteps } from "$lib/types";
 
 function session(partial: Partial<Session> & { id: string }): Session {
   return {
@@ -357,6 +358,68 @@ describe("Herd Done filter", () => {
       doneList: [],
     });
     await expect.element(page.getByText("No finished sessions yet.")).toBeInTheDocument();
+  });
+});
+
+describe("Herd owed lens respects the repo filter (#owed)", () => {
+  const owedRecord = (sessionId: string, desig: string, repoPath: string): PostMergeSteps => ({
+    sessionId,
+    desig,
+    repoPath,
+    prNumber: 1,
+    prTitle: "t",
+    steps: [{ id: "ms1", text: "do it", postMerge: false, doneAt: null }],
+    trackingIssueUrl: null,
+    trackingIssueNumber: null,
+    createdAt: 0,
+    updatedAt: 0,
+    clearedAt: null,
+  });
+
+  afterEach(() => {
+    postMergeSteps.records = [];
+  });
+
+  it("scopes the panel list AND the lens-strip badge count to repoFilter (real Herd→panel wiring)", async () => {
+    postMergeSteps.records = [
+      owedRecord("s1", "TASK-IN", "/repo/shepherd"),
+      owedRecord("s2", "TASK-OUT", "/repo/other"),
+      owedRecord("s3", "TASK-IN2", "/repo/shepherd"),
+    ];
+    const screen = render(Herd, {
+      ...base,
+      sessions: [],
+      git: {},
+      filter: "owed" as const,
+      repoFilter: "/repo/shepherd",
+    });
+    // panel list: only the active repo's records render
+    await expect.element(page.getByText("TASK-IN", { exact: true })).toBeInTheDocument();
+    await expect.element(page.getByText("TASK-IN2", { exact: true })).toBeInTheDocument();
+    await expect.element(page.getByText("TASK-OUT", { exact: true })).not.toBeInTheDocument();
+    // badge count reflects the filtered set (2 of the 3 records), proving Herd's owedCount is scoped
+    await expect
+      .poll(() => screen.container.querySelector(".owed-badge")?.textContent?.trim())
+      .toBe("2");
+  });
+
+  it("unfiltered (repoFilter null) lists every record and the badge shows the total", async () => {
+    postMergeSteps.records = [
+      owedRecord("s1", "TASK-IN", "/repo/shepherd"),
+      owedRecord("s2", "TASK-OUT", "/repo/other"),
+    ];
+    const screen = render(Herd, {
+      ...base,
+      sessions: [],
+      git: {},
+      filter: "owed" as const,
+      repoFilter: null,
+    });
+    await expect.element(page.getByText("TASK-IN")).toBeInTheDocument();
+    await expect.element(page.getByText("TASK-OUT")).toBeInTheDocument();
+    await expect
+      .poll(() => screen.container.querySelector(".owed-badge")?.textContent?.trim())
+      .toBe("2");
   });
 });
 

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -28,12 +28,7 @@
   import { displayStatus } from "$lib/display-status";
   import { reviews, planGates } from "$lib/reviews.svelte";
   import { m } from "$lib/paraglide/messages";
-  import { postMergeSteps } from "$lib/post-merge-steps.svelte";
-
-  // Outstanding owed records (#1257) — drives the OWED lens count badge. The container reads the
-  // shared store; HerdLensStrip stays a pure prop-driven component. Loaded in +page.svelte (desktop
-  // eager load); 0 until then, which simply hides the badge.
-  const owedCount = $derived(postMergeSteps.records.length);
+  import { postMergeSteps, owedRecordsForRepo } from "$lib/post-merge-steps.svelte";
 
   let {
     sessions,
@@ -209,6 +204,13 @@
     // open the Backlog overlay (Up Next empty-state link → page owns showBacklog)
     onbacklog?: () => void;
   } = $props();
+
+  // Outstanding owed records (#1257) — drives the OWED lens count badge. Scoped to the active repo
+  // chip filter (#owed) so the badge reflects the filtered list, matching the rest of the repo-scoped
+  // herd view. Shares owedRecordsForRepo with PostMergeStepsPanel so count and list can't drift. The
+  // container reads the shared store; HerdLensStrip stays a pure prop-driven component. Loaded in
+  // +page.svelte (desktop eager load); 0 until then, which simply hides the badge.
+  const owedCount = $derived(owedRecordsForRepo(postMergeSteps.records, repoFilter).length);
 
   // a critic post-PR review or a pre-execution plan-gate review currently in flight —
   // the reviewer is actively working the session, so it is NOT awaiting the operator.
@@ -497,6 +499,7 @@
       <!-- Owed lens: durable post-merge manual steps still owed, across merged sessions (#1061).
          Panel-only (no session list), persists beyond the Done lens's 48h window. -->
       <PostMergeStepsPanel
+        {repoFilter}
         focusSessionId={owedFocusId}
         focusSnapshot={owedFocusSnapshot}
         focusNonce={owedFocusNonce}

--- a/ui/src/lib/components/PostMergeStepsPanel.browser.test.ts
+++ b/ui/src/lib/components/PostMergeStepsPanel.browser.test.ts
@@ -94,6 +94,30 @@ describe("PostMergeStepsPanel", () => {
       .toBeInTheDocument();
   });
 
+  it("repo filter scopes the card list to the active repo path", async () => {
+    postMergeSteps.records = [
+      record({ sessionId: "s1", desig: "TASK-IN", repoPath: "/repo/shepherd" }),
+      record({ sessionId: "s2", desig: "TASK-OUT", repoPath: "/repo/other" }),
+    ];
+    render(PostMergeStepsPanel, { repoFilter: "/repo/shepherd" });
+    await expect.element(page.getByText("TASK-IN")).toBeInTheDocument();
+    await expect.element(page.getByText("TASK-OUT")).not.toBeInTheDocument();
+  });
+
+  it("repo filter with no matching records shows the repo-scoped empty copy, not the generic one", async () => {
+    postMergeSteps.records = [record({ sessionId: "s2", repoPath: "/repo/other" })];
+    render(PostMergeStepsPanel, { repoFilter: "/repo/shepherd" });
+    await expect
+      .element(page.getByText(m.owed_repo_filter_empty({ repo: "shepherd" })))
+      .toBeInTheDocument();
+    await expect.element(page.getByText(m.owed_empty())).not.toBeInTheDocument();
+  });
+
+  it("no repo filter (null) lists every record and uses the generic empty copy", async () => {
+    render(PostMergeStepsPanel, { repoFilter: null });
+    await expect.element(page.getByText(m.owed_empty())).toBeInTheDocument();
+  });
+
   it("renders the tracking-issue link when present", async () => {
     postMergeSteps.records = [
       record({ sessionId: "s1", trackingIssueUrl: "https://example.test/issues/9" }),
@@ -260,6 +284,40 @@ describe("PostMergeStepsPanel — focus (#1275)", () => {
     postMergeSteps.records = [record({ sessionId: "s1" })];
     await new Promise((r) => setTimeout(r, 50));
     expect(onfocusresolved).not.toHaveBeenCalled();
+  });
+
+  it("focus with a repo filter active: a chip-click focus on a session in the filtered repo still resolves to its live card (invariant survives filtering)", async () => {
+    // In practice onShowOwed fires from a herd row that is already repo-filtered, so the focused
+    // session's repo always matches the active filter. A decoy record in another repo proves the
+    // list IS filtered while the focus still resolves to the live card in the filtered repo.
+    postMergeSteps.records = [
+      record({ sessionId: "s1", desig: "TASK-77", repoPath: "/repo/shepherd" }),
+      record({ sessionId: "s2", desig: "TASK-OUT", repoPath: "/repo/other" }),
+    ];
+    postMergeSteps.loaded = true;
+    postMergeSteps.settled = true;
+    const onfocusresolved = vi.fn();
+    const screen = render(PostMergeStepsPanel, {
+      repoFilter: "/repo/shepherd",
+      focusSessionId: "s1",
+      focusSnapshot: snapshot({ sessionId: "s1" }),
+      focusNonce: 1,
+      focusHandledNonce: 0,
+      onfocusresolved,
+    });
+    // The #1275 "live record always wins / never a dead end" invariant survives filtering:
+    // focus resolves to the live card (not a frozen fallback), and it renders + flashes.
+    await expect.poll(() => onfocusresolved.mock.calls.length).toBe(1);
+    expect(onfocusresolved).toHaveBeenCalledWith(1);
+    expect(screen.container.querySelector(".ow-card--frozen")).toBeNull();
+    await expect
+      .poll(() =>
+        screen.container.querySelector('[data-session-id="s1"]')?.classList.contains("focus"),
+      )
+      .toBe(true);
+    await expect.element(page.getByText("TASK-77")).toBeInTheDocument();
+    // the decoy from the other repo stays filtered out of the list
+    await expect.element(page.getByText("TASK-OUT")).not.toBeInTheDocument();
   });
 
   it("live record wins: a pinned frozen card is suppressed once a live record for the same session arrives (even after its nonce is handled)", async () => {

--- a/ui/src/lib/components/PostMergeStepsPanel.svelte
+++ b/ui/src/lib/components/PostMergeStepsPanel.svelte
@@ -1,18 +1,23 @@
 <script lang="ts">
   import { onDestroy, tick } from "svelte";
   import type { PostMergeSteps, OwedFocusSnapshot } from "$lib/types";
-  import { postMergeSteps } from "$lib/post-merge-steps.svelte";
+  import { postMergeSteps, owedRecordsForRepo } from "$lib/post-merge-steps.svelte";
+  import { basename } from "$lib/components/learnings-drawer";
   import { formatAgo } from "$lib/format";
   import { clock } from "$lib/now.svelte";
   import { m } from "$lib/paraglide/messages";
 
   let {
+    repoFilter = null,
     focusSessionId = null,
     focusSnapshot = null,
     focusNonce = 0,
     focusHandledNonce = 0,
     onfocusresolved = undefined,
   }: {
+    /** Active repo chip filter (full repo path; null = all repos). Scopes the visible card list
+     *  and empty state — but NOT the focus/frozen-card resolution, which must see every repo. */
+    repoFilter?: string | null;
     focusSessionId?: string | null;
     focusSnapshot?: OwedFocusSnapshot | null;
     focusNonce?: number;
@@ -20,7 +25,12 @@
     onfocusresolved?: (nonce: number) => void;
   } = $props();
 
+  // Unfiltered store — the source of truth for focus/frozen-card resolution (the #1275
+  // "live record always wins / never a dead end" invariant must see records across ALL repos).
   const records = $derived(postMergeSteps.records);
+  // Repo-scoped view (#owed) — used ONLY by the card-list render and the empty gate. A null
+  // repoFilter passes records through unchanged.
+  const shownRecords = $derived(owedRecordsForRepo(records, repoFilter));
 
   // Owed-lens focus (#1275): a manual-steps chip click scrolls to + briefly highlights the target
   // session's card, or — when it has no live outstanding record (pre-merge, cleared, dismissed, or
@@ -127,8 +137,12 @@
     <span class="ow-title">{m.owed_title()}</span>
   </div>
 
-  {#if records.length === 0 && !frozenCard}
-    <div class="ow-empty">{m.owed_empty()}</div>
+  {#if shownRecords.length === 0 && !frozenCard}
+    <div class="ow-empty">
+      {#if repoFilter}{m.owed_repo_filter_empty({
+          repo: basename(repoFilter),
+        })}{:else}{m.owed_empty()}{/if}
+    </div>
   {:else}
     <p class="ow-note">{m.owed_note()}</p>
     {#if frozenCard}
@@ -164,7 +178,7 @@
       </section>
     {/if}
     <div class="ow-list">
-      {#each records as rec (rec.sessionId)}
+      {#each shownRecords as rec (rec.sessionId)}
         <section
           class="ow-card"
           data-session-id={rec.sessionId}

--- a/ui/src/lib/post-merge-steps.svelte.test.ts
+++ b/ui/src/lib/post-merge-steps.svelte.test.ts
@@ -6,8 +6,23 @@ vi.mock("./api", () => ({
   dismissManualSteps: vi.fn(),
 }));
 
-import { postMergeSteps } from "./post-merge-steps.svelte";
+import { postMergeSteps, owedRecordsForRepo } from "./post-merge-steps.svelte";
 import { getOutstandingManualSteps } from "./api";
+import type { PostMergeSteps } from "./types";
+
+const rec = (sessionId: string, repoPath: string): PostMergeSteps => ({
+  sessionId,
+  desig: sessionId,
+  repoPath,
+  prNumber: null,
+  prTitle: "",
+  steps: [],
+  trackingIssueUrl: null,
+  trackingIssueNumber: null,
+  createdAt: 0,
+  updatedAt: 0,
+  clearedAt: null,
+});
 
 beforeEach(() => {
   postMergeSteps.records = [];
@@ -32,4 +47,20 @@ test("failed load flips settled but not loaded", async () => {
   await postMergeSteps.load();
   expect(postMergeSteps.settled).toBe(true);
   expect(postMergeSteps.loaded).toBe(false);
+});
+
+test("owedRecordsForRepo: null filter returns records unchanged (same ref)", () => {
+  const records = [rec("a", "/repo/x"), rec("b", "/repo/y")];
+  expect(owedRecordsForRepo(records, null)).toBe(records);
+});
+
+test("owedRecordsForRepo: keeps only records matching the active repo path", () => {
+  const records = [rec("a", "/repo/x"), rec("b", "/repo/y"), rec("c", "/repo/x")];
+  const out = owedRecordsForRepo(records, "/repo/x");
+  expect(out.map((r) => r.sessionId)).toEqual(["a", "c"]);
+});
+
+test("owedRecordsForRepo: no match yields empty list", () => {
+  const records = [rec("a", "/repo/x")];
+  expect(owedRecordsForRepo(records, "/repo/z")).toEqual([]);
 });

--- a/ui/src/lib/post-merge-steps.svelte.ts
+++ b/ui/src/lib/post-merge-steps.svelte.ts
@@ -1,6 +1,18 @@
 import type { PostMergeSteps } from "./types";
 import { getOutstandingManualSteps, setManualStepDone, dismissManualSteps } from "./api";
 
+/** Scope owed records to the active repo chip filter (#owed): `repoFilter` is the full repo
+ *  path, `null` = all repos (unfiltered). Pure so both the Owed lens count badge (Herd.svelte)
+ *  and the panel list (PostMergeStepsPanel) share one filter and can't drift. Mirrors every
+ *  sibling consumer's `repoPath === repoFilter` client-side scope (UpNextPanel, herdSessions). */
+export function owedRecordsForRepo(
+  records: PostMergeSteps[],
+  repoFilter: string | null,
+): PostMergeSteps[] {
+  if (repoFilter == null) return records;
+  return records.filter((r) => r.repoPath === repoFilter);
+}
+
 /** Lazy client store of durable post-merge steps still owed across merged sessions (#1061),
  *  populated when the Owed lens opens and refreshed on the `post-merge-steps:changed` WS event
  *  (wired in store.svelte.ts). Independent of the 48h Done window — owed steps persist until done. */


### PR DESCRIPTION
## What

Make the **Owed** lens respect the repo chip filters. Previously the Owed lens (durable post-merge manual steps still owed across merged sessions) ignored the active repo chip and always listed **every** outstanding record — inconsistent with its sibling **Up Next** lens and the live session list, which already scope by `repoPath === repoFilter`.

Now, with a repo chip active, both the Owed panel's card list **and** the desktop lens-strip count badge scope to that repo.

## How

- **`post-merge-steps.svelte.ts`** — new pure `owedRecordsForRepo(records, repoFilter)` (returns records unchanged when `repoFilter == null`). Single source of filter truth shared by the badge count and the panel list so they can't drift.
- **`Herd.svelte`** — `owedCount` derives from the filtered set; passes `repoFilter` to the panel.
- **`PostMergeStepsPanel.svelte`** — adds a `repoFilter` prop and a distinct `shownRecords` derived used **only** by the card-list render and empty gate. The existing unfiltered `records` still backs the `frozenCard` guard and the focus-effect live lookup, preserving the #1275 *"live record always wins / never a dead end"* invariant. Repo-scoped empty copy `owed_repo_filter_empty` (via the shared `basename` helper) when a filter empties the list.
- **i18n** — `owed_repo_filter_empty` added to `en.json` + `de.json` (parity enforced by `check:i18n`).

### Decisions
- **Badge count** scopes to the active filter (consistent with the repo-scoped herd).
- **Frozen focus card** (chip-click deep-link) still resolves regardless of the filter — in practice the clicked session already matches the active filter (chips only appear on repo-filtered herd rows), so no dead-end.
- Framed as `fix:` (correcting an already-shipped lens's inconsistency), so no What's-New catalog entry.

## Tests
- Unit: `owedRecordsForRepo` (null passthrough, match, no-match).
- Panel browser: list scoping, repo-scoped empty copy vs generic, null-filter passthrough, and focus-with-filter-active resolving to the live card (invariant survives filtering).
- Herd browser: real Herd→panel wiring — filtered list **and** scoped badge count through the actual component tree; unfiltered totals.

Verified: `bun run check`, `check:i18n`, root `bun run lint`, and full UI suite (2550 tests) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)