### PR TITLE
feat(ui): ambient browser-tab state signaling (#1327)

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2310,5 +2310,9 @@
   "model_guidance_codex_5": "Sparsames allgemeines GPT-5-Profil für leichte Aufgaben.",
   "model_guidance_codex_o3": "Reasoning-lastige Option. Gut für Analyse, teuer für Routine-Coding.",
   "feat_model_cost_guidance_title": "Modell-Auswahl zeigt Kostenorientierung",
-  "feat_model_cost_guidance_body": "Modell-Menüs zeigen jetzt relative Kostenmarker und passende Einsatzprofile. Das gewählte Modell erklärt außerdem kurz, wann es seine Kosten wert ist. Die Orientierung erscheint in Neue Aufgabe, Einstellungen, Repo-Standards und im Vergleichs- oder Weiterführen-Picker."
+  "feat_model_cost_guidance_body": "Modell-Menüs zeigen jetzt relative Kostenmarker und passende Einsatzprofile. Das gewählte Modell erklärt außerdem kurz, wann es seine Kosten wert ist. Die Orientierung erscheint in Neue Aufgabe, Einstellungen, Repo-Standards und im Vergleichs- oder Weiterführen-Picker.",
+  "tab_attention_count": "Sitzungen, die deine Aufmerksamkeit brauchen: {count}",
+  "tab_attention_none": "Keine Sitzungen brauchen deine Aufmerksamkeit",
+  "feat_tab_signaling_title": "Dein Browser-Tab signalisiert jetzt die Herde",
+  "feat_tab_signaling_body": "Wenn Shepherd in einem Hintergrund-Tab geöffnet ist, zeigt der Tab-Titel die Anzahl der Sitzungen, die dich brauchen, und das Favicon nimmt eine Signalfarbe an — Rot für fehlgeschlagene CI, Bernstein für blockiert, Grün für merge-bereit. Ein kurzes Häkchen erscheint, wenn die Herde abgearbeitet ist. Als App installiert, wird zusätzlich das App-Badge aktualisiert."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2310,5 +2310,9 @@
   "model_guidance_codex_5": "Budget general GPT-5 profile for light tasks.",
   "model_guidance_codex_o3": "Reasoning-heavy option. Good for analysis, expensive for routine coding.",
   "feat_model_cost_guidance_title": "Model pickers show cost guidance",
-  "feat_model_cost_guidance_body": "Model menus now show relative cost markers and task-fit tags, and the selected model explains when it is worth using. The guidance appears in New Task, Settings, repo defaults and the compare or continue picker."
+  "feat_model_cost_guidance_body": "Model menus now show relative cost markers and task-fit tags, and the selected model explains when it is worth using. The guidance appears in New Task, Settings, repo defaults and the compare or continue picker.",
+  "tab_attention_count": "Sessions needing your attention: {count}",
+  "tab_attention_none": "No sessions need your attention",
+  "feat_tab_signaling_title": "Your browser tab now signals the herd",
+  "feat_tab_signaling_body": "When Shepherd is open in a background tab, the tab title shows a count of sessions needing you, and the favicon takes on a severity color — red for failing CI, amber for blocked, green for ready to merge. A brief check mark appears when the herd drains. Installed as an app, it also updates the app badge."
 }

--- a/ui/src/lib/feature-announcements/entries/v1.41.0-tab-signaling.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.41.0-tab-signaling.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "tab-signaling",
+  sinceVersion: "1.41.0",
+  titleKey: "feat_tab_signaling_title",
+  bodyKey: "feat_tab_signaling_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -55,6 +55,12 @@ export class HerdStore {
   sessions = $state<Session[]>([]);
   blocks = $state<Record<string, BlockState>>({});
   connected = $state(false);
+  /** True when THIS tab is focused+visible (the "attended" tier of the attention
+   *  ladder — same `active()` notion connect() reports for push suppression). The
+   *  ambient tab-signal (tab-signal.svelte.ts) suppresses its title/favicon/badge
+   *  while attended and shows them only when the tab is backgrounded. Set on every
+   *  presence edge in connect(); false during SSR. */
+  attended = $state(false);
   usageLimits = $state<UsageLimits | null>(null);
   update = $state<UpdateStatus | null>(null);
   herdrUpdate = $state<HerdrUpdateStatus | null>(null);
@@ -776,6 +782,14 @@ export class HerdStore {
         ws.send(JSON.stringify({ type: "presence", active: active() }));
       }
     };
+    // Mirror the same focus/visibility read into reactive state for the ambient
+    // tab-signal. Set DIRECTLY in each presence handler below (not only here or in
+    // wake()): on a become-visible-with-dead-socket edge onVisible→wake()→open()
+    // defers presence to ws.onopen, and pageshow only wakes when persisted, so
+    // routing attended through reportPresence/wake alone would let it lag.
+    const syncAttended = () => {
+      this.attended = active();
+    };
     const open = () => {
       // Drop the previous socket's handlers before replacing it so a superseded
       // socket's late onclose can't schedule a second, parallel reconnect.
@@ -827,16 +841,29 @@ export class HerdStore {
       if (ws && ws.readyState === WebSocket.OPEN) reportPresence();
       else open(); // CONNECTING/CLOSING/CLOSED/none — resume the stream now
     };
-    const onVisible = () => (document.visibilityState === "visible" ? wake() : reportPresence());
+    const onVisible = () => {
+      syncAttended();
+      return document.visibilityState === "visible" ? wake() : reportPresence();
+    };
+    const onFocus = () => {
+      syncAttended();
+      reportPresence();
+    };
+    const onBlur = () => {
+      syncAttended();
+      reportPresence();
+    };
     const onPageShow = (e: PageTransitionEvent) => {
+      syncAttended();
       if (e.persisted) wake();
     };
     if (typeof document !== "undefined") {
       document.addEventListener("visibilitychange", onVisible);
-      window.addEventListener("focus", reportPresence);
-      window.addEventListener("blur", reportPresence);
+      window.addEventListener("focus", onFocus);
+      window.addEventListener("blur", onBlur);
       window.addEventListener("pageshow", onPageShow);
     }
+    syncAttended(); // correct initial value before the first open()
     open();
     return () => {
       stopped = true;
@@ -846,8 +873,8 @@ export class HerdStore {
       }
       if (typeof document !== "undefined") {
         document.removeEventListener("visibilitychange", onVisible);
-        window.removeEventListener("focus", reportPresence);
-        window.removeEventListener("blur", reportPresence);
+        window.removeEventListener("focus", onFocus);
+        window.removeEventListener("blur", onBlur);
         window.removeEventListener("pageshow", onPageShow);
       }
       ws?.close();

--- a/ui/src/lib/tab-signal.browser.test.ts
+++ b/ui/src/lib/tab-signal.browser.test.ts
@@ -1,0 +1,89 @@
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { createTabSignal } from "./tab-signal.svelte";
+
+// Exercises the side-effecting controller against a real DOM (real <link>, real
+// canvas, real document.title) — the part deriveTabState's unit tests can't cover.
+
+let link: HTMLLinkElement;
+let setBadge: ReturnType<typeof vi.fn>;
+let clearBadge: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  document.title = "Shepherd";
+  document.querySelectorAll('link[rel="icon"]').forEach((n) => n.remove());
+  link = document.createElement("link");
+  link.rel = "icon";
+  link.type = "image/svg+xml";
+  link.href = "/favicon.svg";
+  document.head.appendChild(link);
+  setBadge = vi.fn(() => Promise.resolve());
+  clearBadge = vi.fn(() => Promise.resolve());
+  (navigator as unknown as { setAppBadge: unknown }).setAppBadge = setBadge;
+  (navigator as unknown as { clearAppBadge: unknown }).clearAppBadge = clearBadge;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  link.remove();
+});
+
+const flush = () => vi.advanceTimersByTime(400); // past the debounce
+
+test("background tier: title count, PNG favicon swap, App Badge set", () => {
+  const signal = createTabSignal();
+  signal.update({ count: 3, severity: "amber", attended: false });
+  flush();
+
+  expect(document.title).toBe("(3) Shepherd");
+  expect(link.type).toBe("image/png");
+  expect(link.href.startsWith("data:image/png")).toBe(true);
+  expect(setBadge).toHaveBeenLastCalledWith(3);
+  expect(signal.announcement).toContain("3");
+});
+
+test("attended tier: suppresses the tab signal and clears the badge", () => {
+  const signal = createTabSignal();
+  signal.update({ count: 3, severity: "amber", attended: false });
+  flush();
+  expect(document.title).toBe("(3) Shepherd");
+
+  signal.update({ count: 3, severity: "amber", attended: true });
+  flush();
+  expect(document.title).toBe("Shepherd");
+  expect(link.type).toBe("image/svg+xml");
+  expect(link.href).toContain("/favicon.svg");
+  expect(clearBadge).toHaveBeenCalled();
+});
+
+test("N → 0 while backgrounded flourishes, then restores the default favicon", () => {
+  const signal = createTabSignal();
+  signal.update({ count: 2, severity: "amber", attended: false });
+  flush();
+  expect(link.href.startsWith("data:image/png")).toBe(true);
+
+  signal.update({ count: 0, severity: "none", attended: false });
+  flush();
+  // flourish: still a PNG (the ✓), title cleared, badge cleared
+  expect(link.href.startsWith("data:image/png")).toBe(true);
+  expect(document.title).toBe("Shepherd");
+  expect(clearBadge).toHaveBeenCalled();
+
+  // after the flourish window, the default favicon is restored
+  vi.advanceTimersByTime(2500);
+  expect(link.type).toBe("image/svg+xml");
+  expect(link.href).toContain("/favicon.svg");
+});
+
+test("dispose restores title/favicon and clears the badge", () => {
+  const signal = createTabSignal();
+  signal.update({ count: 1, severity: "red", attended: false });
+  flush();
+  expect(document.title).toBe("(1) Shepherd");
+
+  signal.dispose();
+  expect(document.title).toBe("Shepherd");
+  expect(link.type).toBe("image/svg+xml");
+  expect(link.href).toContain("/favicon.svg");
+  expect(clearBadge).toHaveBeenCalled();
+});

--- a/ui/src/lib/tab-signal.svelte.test.ts
+++ b/ui/src/lib/tab-signal.svelte.test.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "vitest";
+import { deriveTabState } from "./tab-signal.svelte";
+import type { Session, GitState, SessionStatus, ChecksState } from "./types";
+
+const sess = (id: string, status: SessionStatus, readyToMerge = false): Session =>
+  ({ id, status, readyToMerge }) as unknown as Session;
+
+const git = (checks: ChecksState, handoff?: "reviewer" | "merger"): GitState =>
+  ({ checks, handoff }) as unknown as GitState;
+
+test("no sessions → count 0, severity none", () => {
+  expect(deriveTabState([], {}, {})).toEqual({ count: 0, severity: "none" });
+});
+
+test("blocked session counts as amber", () => {
+  expect(deriveTabState([sess("s1", "blocked")], {}, {})).toEqual({ count: 1, severity: "amber" });
+});
+
+test("working-blocked session (mid-turn) is excluded — renders as running", () => {
+  expect(deriveTabState([sess("s1", "blocked")], {}, { s1: true })).toEqual({
+    count: 0,
+    severity: "none",
+  });
+});
+
+test("ci-red (git.checks === failure) counts as red", () => {
+  expect(deriveTabState([sess("s1", "running")], { s1: git("failure") }, {})).toEqual({
+    count: 1,
+    severity: "red",
+  });
+});
+
+test("blocked + CI-red on one session reads red, not amber (no primary-hold masking)", () => {
+  // The whole point of reading git.checks directly rather than the primary-only
+  // store.holds: a blocked session that is ALSO CI-red must surface red.
+  expect(deriveTabState([sess("s1", "blocked")], { s1: git("failure") }, {})).toEqual({
+    count: 1,
+    severity: "red",
+  });
+});
+
+test("ready-to-merge counts as green", () => {
+  expect(deriveTabState([sess("s1", "done", true)], {}, {})).toEqual({
+    count: 1,
+    severity: "green",
+  });
+});
+
+test("ready-to-merge handed to a merger is excluded (awaiting-merge, not ready)", () => {
+  expect(deriveTabState([sess("s1", "done", true)], { s1: git("success", "merger") }, {})).toEqual({
+    count: 0,
+    severity: "none",
+  });
+});
+
+test("ready-to-merge handed to a reviewer still counts as green", () => {
+  expect(
+    deriveTabState([sess("s1", "done", true)], { s1: git("success", "reviewer") }, {}),
+  ).toEqual({ count: 1, severity: "green" });
+});
+
+test("critic-rework / plain running sessions are not counted", () => {
+  // deriveTabState never inspects review verdicts, so an agent-turn session
+  // (e.g. critic-rework) with no blocked/ci-red/ready signal produces nothing.
+  expect(deriveTabState([sess("s1", "running")], {}, {})).toEqual({ count: 0, severity: "none" });
+});
+
+test("severity precedence across sessions: red > amber > green; count is distinct sessions", () => {
+  const sessions = [sess("green", "done", true), sess("amber", "blocked"), sess("red", "running")];
+  const g = { red: git("failure") };
+  expect(deriveTabState(sessions, g, {})).toEqual({ count: 3, severity: "red" });
+});
+
+test("non-failure CI does not count", () => {
+  const sessions = [sess("s1", "running"), sess("s2", "idle")];
+  const g = { s1: git("success"), s2: git("pending") };
+  expect(deriveTabState(sessions, g, {})).toEqual({ count: 0, severity: "none" });
+});

--- a/ui/src/lib/tab-signal.svelte.ts
+++ b/ui/src/lib/tab-signal.svelte.ts
@@ -1,0 +1,285 @@
+// Ambient browser-tab state signaling (#1327). Fills the "backgrounded-but-open"
+// rung of the attention ladder: attended (this tab focused) → no tab signal;
+// background → title count + severity-dot favicon + App Badge; away → existing push.
+//
+// deriveTabState is a PURE function mirroring the in-scope server ATTENTION_RULES
+// (src/rundown-core.ts) from the same client-side inputs those rules use — NOT the
+// primary-only `store.holds` projection, which would mask ci-red under a co-tier-1
+// hold. createTabSignal() owns the side effects (title / <link rel=icon> canvas
+// swap / setAppBadge / aria-live) and is driven by one $effect in +page.svelte.
+
+import type { Session, GitState } from "./types";
+import { displayStatus } from "./display-status";
+import { m } from "$lib/paraglide/messages";
+
+export type Severity = "red" | "amber" | "green" | "none";
+
+export interface TabState {
+  /** Count of sessions needing the operator now (blocked · ci-red · ready-to-merge). */
+  count: number;
+  /** Highest severity across those sessions (red › amber › green › none). */
+  severity: Severity;
+}
+
+const SEVERITY_RANK: Record<Severity, number> = { none: 0, green: 1, amber: 2, red: 3 };
+
+/** Severity for a single session, or "none" when it needs no operator action.
+ *  Mirrors the three in-scope ATTENTION_RULES using their exact inputs:
+ *   - ci-red     → git.checks === "failure"            (rundown-core.ts:126)
+ *   - blocked    → displayStatus === "blocked"          (blocked-decision, :116)
+ *   - ready      → readyToMerge && handoff !== "merger" (ready-merge, :149-151)
+ *  Read git.checks directly (not holds) so ci-red is never masked by a co-signal;
+ *  read displayStatus so a working-blocked session (mid-turn) is excluded. */
+function sessionSeverity(
+  s: Session,
+  git: GitState | undefined,
+  workingBlocked: Record<string, boolean>,
+): Severity {
+  if (git?.checks === "failure") return "red";
+  if (displayStatus(s, workingBlocked) === "blocked") return "amber";
+  if (s.readyToMerge && git?.handoff !== "merger") return "green";
+  return "none";
+}
+
+/** Pure: derive the tab count + highest severity from the store's session/git state. */
+export function deriveTabState(
+  sessions: Session[],
+  git: Record<string, GitState>,
+  workingBlocked: Record<string, boolean>,
+): TabState {
+  let count = 0;
+  let severity: Severity = "none";
+  for (const s of sessions) {
+    const sev = sessionSeverity(s, git[s.id], workingBlocked);
+    if (sev === "none") continue;
+    count++;
+    if (SEVERITY_RANK[sev] > SEVERITY_RANK[severity]) severity = sev;
+  }
+  return { count, severity };
+}
+
+// ── side-effecting controller ────────────────────────────────────────────────
+
+const DEBOUNCE_MS = 400;
+const FLOURISH_MS = 2500;
+
+// Last-resort hex fallbacks (mirror app.css dark-theme --red/--amber/--green), used
+// only if getComputedStyle returns empty or an unresolved var() string.
+const SEVERITY_TOKENS: Record<Exclude<Severity, "none">, [string, string, string]> = {
+  red: ["--color-red", "--red", "#e5484d"],
+  amber: ["--color-amber", "--amber", "#e8a13a"],
+  green: ["--color-green", "--green", "#5ad19a"],
+};
+
+/** Resolve a severity color at paint time, guarding the var() chain (review point 8):
+ *  semantic token → leaf palette token → safe hex, so canvas fillStyle is always concrete. */
+function resolveColor(sev: Exclude<Severity, "none">): string {
+  const [semantic, leaf, hex] = SEVERITY_TOKENS[sev];
+  const cs = getComputedStyle(document.documentElement);
+  for (const name of [semantic, leaf]) {
+    const v = cs.getPropertyValue(name).trim();
+    if (v && !v.startsWith("var(")) return v;
+  }
+  return hex;
+}
+
+/** Resolve the favicon-ground color (behind the dot) for contrast; safe fallback. */
+function groundColor(): string {
+  const v = getComputedStyle(document.documentElement).getPropertyValue("--color-bg").trim();
+  return v && !v.startsWith("var(") ? v : "#0a0d0c";
+}
+
+class TabSignal {
+  #announcement = $state("");
+  /** Localized aria-live string, mirrored into a polite region by +page.svelte. */
+  get announcement(): string {
+    return this.#announcement;
+  }
+
+  #initialized = false;
+  #baseTitle = "Shepherd";
+  #link: HTMLLinkElement | null = null;
+  #originalHref = "";
+  #originalType = "";
+  #baseImg: HTMLImageElement | null = null;
+
+  #debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  #flourishTimer: ReturnType<typeof setTimeout> | null = null;
+  #next: { count: number; severity: Severity; attended: boolean } | null = null;
+  #lastCount = 0;
+
+  #lazyInit() {
+    if (this.#initialized) return;
+    this.#initialized = true;
+    this.#baseTitle = document.title || "Shepherd";
+    const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+    if (link) {
+      this.#link = link;
+      // Capture the runtime-resolved href/type (review point 6) so a non-root
+      // base/assets path restores the correct default icon — never hardcode a path.
+      this.#originalHref = link.href;
+      this.#originalType = link.getAttribute("type") ?? "image/svg+xml";
+      const img = new Image();
+      img.src = this.#originalHref; // preload the base mark for canvas compositing
+      this.#baseImg = img;
+    }
+  }
+
+  /** Debounced entry point, driven by the root $effect. */
+  update(next: { count: number; severity: Severity; attended: boolean }) {
+    this.#next = next;
+    if (this.#debounceTimer) clearTimeout(this.#debounceTimer);
+    this.#debounceTimer = setTimeout(() => {
+      this.#debounceTimer = null;
+      this.#apply(next);
+    }, DEBOUNCE_MS);
+  }
+
+  #apply({ count, severity, attended }: { count: number; severity: Severity; attended: boolean }) {
+    this.#lazyInit();
+    this.#announce(count);
+
+    // Completion flourish: herd drained (>0 → 0) while backgrounded.
+    const drained = this.#lastCount > 0 && count === 0 && !attended;
+    this.#lastCount = count;
+
+    if (attended) {
+      // Attended tier: the live UI is the signal — suppress the tab channel.
+      this.#setTitle(this.#baseTitle);
+      this.#clearBadge();
+      this.#cancelFlourish();
+      this.#restoreFavicon();
+      return;
+    }
+
+    // Background tier.
+    this.#setTitle(count > 0 ? `(${count}) ${this.#baseTitle}` : this.#baseTitle);
+    if (count > 0) this.#setBadge(count);
+    else this.#clearBadge();
+
+    if (drained) {
+      this.#flourish();
+      return;
+    }
+    if (this.#flourishTimer) return; // an in-progress flourish owns the favicon
+    if (severity === "none") this.#restoreFavicon();
+    else this.#setFavicon(this.#renderDot(severity));
+  }
+
+  #announce(count: number) {
+    const msg = count > 0 ? m.tab_attention_count({ count }) : m.tab_attention_none();
+    if (msg !== this.#announcement) this.#announcement = msg;
+  }
+
+  #setTitle(title: string) {
+    if (document.title !== title) document.title = title;
+  }
+
+  #setBadge(n: number) {
+    // Progressive enhancement — no-op where unsupported / not installed.
+    if ("setAppBadge" in navigator) void navigator.setAppBadge(n).catch(() => {});
+  }
+
+  #clearBadge() {
+    if ("clearAppBadge" in navigator) void navigator.clearAppBadge().catch(() => {});
+  }
+
+  #setFavicon(dataUrl: string) {
+    if (!this.#link) return;
+    this.#link.type = "image/png";
+    this.#link.href = dataUrl;
+  }
+
+  #restoreFavicon() {
+    if (!this.#link || !this.#originalHref) return;
+    // Restore both href AND type (review point 5) — the swap set type=image/png.
+    this.#link.type = this.#originalType;
+    this.#link.href = this.#originalHref;
+  }
+
+  #cancelFlourish() {
+    if (this.#flourishTimer) {
+      clearTimeout(this.#flourishTimer);
+      this.#flourishTimer = null;
+    }
+  }
+
+  #flourish() {
+    this.#setFavicon(this.#renderCheck());
+    this.#cancelFlourish();
+    this.#flourishTimer = setTimeout(() => {
+      this.#flourishTimer = null;
+      // Restore to whatever the latest state warrants (may have changed since drain).
+      const n = this.#next;
+      if (!n || n.attended || n.severity === "none") this.#restoreFavicon();
+      else this.#setFavicon(this.#renderDot(n.severity));
+    }, FLOURISH_MS);
+  }
+
+  #canvas(): [HTMLCanvasElement, CanvasRenderingContext2D, number] {
+    const size = Math.round(32 * (window.devicePixelRatio || 1));
+    const canvas = document.createElement("canvas");
+    canvas.width = size;
+    canvas.height = size;
+    const ctx = canvas.getContext("2d")!;
+    if (this.#baseImg && this.#baseImg.complete && this.#baseImg.naturalWidth > 0) {
+      ctx.drawImage(this.#baseImg, 0, 0, size, size);
+    }
+    return [canvas, ctx, size];
+  }
+
+  /** Draw a ground-ringed filled disc in the bottom-right corner; returns its center. */
+  #corner(ctx: CanvasRenderingContext2D, size: number, r: number, fill: string): [number, number] {
+    const cx = size - r - size * 0.05;
+    const cy = size - r - size * 0.05;
+    ctx.beginPath();
+    ctx.arc(cx, cy, r + size * 0.06, 0, Math.PI * 2);
+    ctx.fillStyle = groundColor();
+    ctx.fill();
+    ctx.beginPath();
+    ctx.arc(cx, cy, r, 0, Math.PI * 2);
+    ctx.fillStyle = fill;
+    ctx.fill();
+    return [cx, cy];
+  }
+
+  /** Base mark + a severity dot in the bottom-right corner, ringed for contrast. */
+  #renderDot(sev: Severity): string {
+    const [canvas, ctx, size] = this.#canvas();
+    if (sev !== "none") this.#corner(ctx, size, size * 0.28, resolveColor(sev));
+    return canvas.toDataURL("image/png");
+  }
+
+  /** Base mark + a green ✓ disc — the brief completion flourish. */
+  #renderCheck(): string {
+    const [canvas, ctx, size] = this.#canvas();
+    const r = size * 0.3;
+    const [cx, cy] = this.#corner(ctx, size, r, resolveColor("green"));
+    // check stroke
+    ctx.strokeStyle = "#0a0d0c";
+    ctx.lineWidth = Math.max(1, size * 0.05);
+    ctx.lineCap = "round";
+    ctx.lineJoin = "round";
+    ctx.beginPath();
+    ctx.moveTo(cx - r * 0.45, cy + r * 0.02);
+    ctx.lineTo(cx - r * 0.08, cy + r * 0.4);
+    ctx.lineTo(cx + r * 0.5, cy - r * 0.35);
+    ctx.stroke();
+    return canvas.toDataURL("image/png");
+  }
+
+  /** Cancel timers and restore the tab to its default title / favicon / badge. */
+  dispose() {
+    if (this.#debounceTimer) clearTimeout(this.#debounceTimer);
+    this.#cancelFlourish();
+    if (this.#initialized) {
+      this.#setTitle(this.#baseTitle);
+      this.#restoreFavicon();
+      this.#clearBadge();
+    }
+  }
+}
+
+export function createTabSignal(): TabSignal {
+  return new TabSignal();
+}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount, tick, untrack } from "svelte";
   import { MediaQuery, SvelteSet } from "svelte/reactivity";
   import { HerdStore } from "$lib/store.svelte";
+  import { createTabSignal, deriveTabState } from "$lib/tab-signal.svelte";
   import {
     listSessions,
     createSession,
@@ -124,6 +125,19 @@
   import { sidebarCollapse, sidebarShouldCollapse } from "$lib/sidebar-collapse.svelte";
 
   const store = new HerdStore();
+
+  // Ambient tab-state signaling (#1327): when THIS tab is backgrounded, mirror the
+  // count of sessions needing the operator (blocked · ci-red · ready-to-merge) into
+  // the tab title + a severity-dot favicon + the App Badge. Driven by one $effect off
+  // the store here (where the HerdStore instance lives, not +layout); the aria-live
+  // region below mirrors changes for screen readers. Disposed on unmount.
+  const tabSignal = createTabSignal();
+  $effect(() => {
+    const { count, severity } = deriveTabState(store.sessions, store.git, store.workingBlocked);
+    tabSignal.update({ count, severity, attended: store.attended });
+  });
+  $effect(() => () => tabSignal.dispose());
+
   // PR identity keys (`${repoPath}#${number}`) currently owned by a running merge
   // train — a session that's flagged merging and has an open PR number. Threaded
   // down to the backlog PRs panel so each in-train row shows a badge + its manual
@@ -2118,6 +2132,10 @@
        h1 to orient by. Always present, even on the phone terminal screen where the
        chrome is hidden. -->
   <h1 class="sr-only">{m.app_shell_heading()}</h1>
+  <!-- a11y: the ambient tab signal (title/favicon/App Badge) is invisible to screen
+       readers and title changes aren't reliably announced, so mirror every count
+       change into a polite live region (#1327). -->
+  <div class="sr-only" role="status" aria-live="polite">{tabSignal.announcement}</div>
   <!-- On a phone in the terminal-focus screen the top bar is subsumed by the
        viewport's merged header (repo · session + back + status tint), so it's
        hidden there; settings + global chrome stay on the herd overview. -->


### PR DESCRIPTION
Closes #1327 (tracer slice: title count + severity favicon + App Badge).

## What

Fills the missing **backgrounded-but-open** rung of the attention ladder. Today a focused tab shows the live UI and an away device gets Web Push, but a background tab is silent (`<title>Shepherd</title>` + static favicon). This adds an **ambient tab channel**:

- **Title count** — `(N) Shepherd` when `N>0`, else `Shepherd` (front-paren survives right-truncation).
- **Severity favicon** — canvas→PNG swap with a corner dot: **red** (CI failed) › **amber** (blocked) › **green** (ready-to-merge) › neutral. Rendered at `32·devicePixelRatio`; colors resolved from `--color-*` tokens at paint time.
- **App Badge** — feature-detected `setAppBadge(N)`/`clearAppBadge()`, progressive enhancement (silent no-op where unsupported/not-installed).
- **Attention ladder** — attended (this tab focused+visible) → no tab signal; background → ambient channel; away → existing push (untouched). Reuses the presence read already in `store.connect()` via a new reactive `attended` flag; **no new server signal**.
- **Completion flourish** — a brief ✓ favicon when the herd drains (`N`: >0→0) in the background tier, then restore.
- **A11y** — every count change mirrors into an `aria-live="polite"` region (favicon/title are invisible to screen readers). No blinking (WCAG 2.2.2).

## `N` + severity derivation

`deriveTabState` is a **pure function** mirroring the three in-scope `classifyAttention` rules (`src/rundown-core.ts`) from **their exact client inputs** — deliberately *not* the primary-only `store.holds` projection, which masks `ci-red` under a co-tier-1 hold:

| Category | Source | Severity |
| --- | --- | --- |
| CI failed | `git.checks === "failure"` | red |
| Blocked / awaiting-input | `displayStatus === "blocked"` (excludes working-blocked) | amber |
| Ready-to-merge | `readyToMerge && git.handoff !== "merger"` (excludes awaiting-merge) | green |

Each counted member maps to an existing push kind (`ci`/`blocked`/`ready`), so the tab count never counts a state the server would stay silent on. `critic-rework` is **excluded** (its copy is "steered back to the agent" — the agent's turn, not the operator's).

## Deferred (follow-up #1332)

Item-3 of #1327 — **plan-gate/critic question awaiting an answer (#803)** — is deferred: that state has no client-observable answered/unanswered signal today (ephemeral component state only; absent from `classifyAttention`/push), so faithful counting needs new server plumbing. #1332 tracks it, plus the remaining bonus sub-features (progress-ring, glyph-ticker, quiet-mode, IdleDetector, SW-set badge).

## Files

- **New** `ui/src/lib/tab-signal.svelte.ts` — pure `deriveTabState` + `createTabSignal()` controller (title / favicon canvas swap / App Badge / flourish / debounce / aria-live).
- **Edit** `ui/src/lib/store.svelte.ts` — reactive `attended`, set on every presence edge in `connect()`.
- **Edit** `ui/src/routes/+page.svelte` — one driving `$effect` (store lives here, not `+layout`) + the aria-live region.
- i18n keys (EN+DE), feature-announcement entry `v1.41.0-tab-signaling.ts`.

## Verification

- `deriveTabState` unit tests (11) incl. working-blocked exclusion, `ci-red` unmasked when co-blocked, ready excluded on merger-handoff, severity precedence.
- Browser tests (4) drive the real controller against a real DOM: `(N) Shepherd` title, `type=image/png` favicon swap + restore, App Badge set/clear across attended↔background, drain flourish then restore, dispose cleanup.
- `bun run check` (0 errors), `check:i18n` (parity), `eslint`, `prettier`, `fallow audit` (no new findings), branch-hygiene, feature-catalog, glossary — all green locally.