### PR TITLE
fix(telemetry): normalize locale to Aptabase's 10-char limit

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -59,6 +59,18 @@ function osName(): string {
   }
 }
 
+/**
+ * Normalize a glibc `LANG` value (e.g. "en_US.UTF-8") to a short BCP-47-style tag
+ * Aptabase accepts. Aptabase's `SystemProps.Locale` field is capped at 10 chars and
+ * rejects the whole event with HTTP 400 otherwise — and because the flush is
+ * best-effort (errors swallowed), a too-long locale silently drops every event.
+ * Strip the ".<encoding>" suffix, turn "_" into "-", cap at 10, fall back to "en".
+ */
+export function normalizeLocale(lang: string | undefined): string {
+  const tag = ((lang ?? "").split(".")[0] ?? "").replace(/_/g, "-").trim();
+  return tag ? tag.slice(0, 10) : "en";
+}
+
 export class TelemetryService {
   private readonly appKey: string | null;
   private readonly host: string | null;
@@ -90,7 +102,7 @@ export class TelemetryService {
       osName: osName(),
       osVersion: os.release(),
       arch: process.arch,
-      locale: process.env.LANG ?? "unknown",
+      locale: normalizeLocale(process.env.LANG),
       appVersion: (pkg as { version: string }).version,
       engineName: process.versions.bun ? "bun" : "node",
       engineVersion: process.versions.bun ?? process.versions.node,

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -1,5 +1,10 @@
 import { test, expect } from "bun:test";
-import { TelemetryService, resolveAptabaseHost, type PostEventFn } from "../src/telemetry";
+import {
+  TelemetryService,
+  resolveAptabaseHost,
+  normalizeLocale,
+  type PostEventFn,
+} from "../src/telemetry";
 
 const sync = (fn: () => void) => fn();
 
@@ -19,6 +24,36 @@ function svc(over: Partial<ConstructorParameters<typeof TelemetryService>[0]> = 
   });
   return { s, calls };
 }
+
+test("normalizeLocale strips encoding, normalizes, caps at 10 (Aptabase's Locale limit)", () => {
+  // glibc LANG forms Aptabase rejects verbatim (encoding suffix + underscore + >10 chars)
+  expect(normalizeLocale("en_US.UTF-8")).toBe("en-US");
+  expect(normalizeLocale("de_DE.UTF-8")).toBe("de-DE");
+  // already-clean tags pass through
+  expect(normalizeLocale("en-US")).toBe("en-US");
+  // unset / empty fall back
+  expect(normalizeLocale(undefined)).toBe("en");
+  expect(normalizeLocale("")).toBe("en");
+  // never exceeds Aptabase's 10-char cap, even for a long tag
+  const long = normalizeLocale("ca_ES_valencia_extra.UTF-8");
+  expect(long.length).toBeLessThanOrEqual(10);
+});
+
+test("emitted systemProps.locale is <=10 chars for a glibc LANG", async () => {
+  const prev = process.env.LANG;
+  process.env.LANG = "en_US.UTF-8";
+  try {
+    const { s, calls } = svc();
+    s.event("app_launched");
+    await s.flush();
+    const locale = calls[0]!.batch[0].systemProps.locale as string;
+    expect(locale).toBe("en-US");
+    expect(locale.length).toBeLessThanOrEqual(10);
+  } finally {
+    if (prev === undefined) delete process.env.LANG;
+    else process.env.LANG = prev;
+  }
+});
 
 test("resolveAptabaseHost derives region host, requires override for SH", () => {
   expect(resolveAptabaseHost("A-US-x", null)).toBe("https://us.aptabase.com");


### PR DESCRIPTION
## Bug

Telemetry `app_launched` events from real installs were **silently rejected by Aptabase** and never reached the dashboard.

Root cause: `systemProps.locale` was sent as the raw `$LANG` value — e.g. `en_US.UTF-8` (11 chars). Aptabase's `SystemProps.Locale` field is **capped at 10 characters** and rejects the entire event with `HTTP 400`:

```
[0].SystemProps.Locale: "The field Locale must be a string with a maximum length of 10."
```

Because the flush is best-effort (errors are swallowed by design so telemetry never disrupts the app), the 400 was invisible — every real install's event was dropped and nothing appeared in Aptabase. It went unnoticed because the initial manual test POSTs used a short hardcoded `en-US`.

## Fix

Add `normalizeLocale()`: strip the `.<encoding>` suffix, normalize `_`→`-`, cap at 10, fall back to `en`. `en_US.UTF-8` → `en-US`; `de_DE.UTF-8` → `de-DE`. Then use it for `systemProps.locale`.

## Verification

- New regression tests: `normalizeLocale` cases + an assertion that the emitted `systemProps.locale` is ≤10 chars for a glibc `LANG`. `bun test ./test/telemetry.test.ts` → 9 pass.
- typecheck + lint clean.
- **End-to-end:** running the fixed code with a real `LANG=en_US.UTF-8` now sends `locale: "en-US"` and Aptabase returns **`200`** (was `400`). Confirmed against the live EU project.

## Impact

No manual steps. Existing installs that already opted in start reporting successfully on their next update + launch — no re-consent needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)