### PR TITLE
feat(telemetry): wire session_created / epic_drained / pr_opened events (#1329)

### DIFF
--- a/docs/superpowers/specs/2026-07-02-aptabase-telemetry-design.md
+++ b/docs/superpowers/specs/2026-07-02-aptabase-telemetry-design.md
@@ -173,7 +173,15 @@ a deploy-time env value; both are first-class.
 
 - Persistent anonymous install ID for accurate unique counts, or none?
   (recommended: **none** — max anonymity, approximate counts)
-- Confirm v1 event set (`app_launched`, `session_created`, `epic_drained`,
-  `pr_opened`) — right four, or adjust?
+- ~~Confirm v1 event set (`app_launched`, `session_created`, `epic_drained`,
+  `pr_opened`) — right four, or adjust?~~ **RESOLVED (issue #1329):** the four-event
+  set is ratified. Wiring decisions: `session_created` fires at the
+  `SessionService.create()` choke point for every session; `epic_drained` at the
+  drain's running→idle completion edge; `pr_opened` on a session's non-open→open PR
+  transition (session PRs only — epic landing PRs are covered by `epic_drained`).
+  Props are a primitive allowlist — `session_created`:
+  `{ agentProvider, autopilot, research, planGate, fromIssue }`, `epic_drained`:
+  `{ childCount }`, `pr_opened`: `{ agentProvider, isDraft }` — with **no `model`**
+  (a `--model` value can be arbitrary free-form text).
 - Data scope confirm: **health + feature usage** (the assumed default while you
   were away) — keep, or narrow to health-only / widen to include errors?

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -3,6 +3,7 @@ import type { GitForge, GitState, Issue, PrStatus, SubIssueRef } from "./forge/t
 import type { CreateSessionInput, Session } from "./types";
 import type { SessionStateChange } from "./session-snapshot";
 import type { UsageLimits } from "./usage-limits";
+import type { TelemetryService } from "./telemetry";
 import { settleMergedSession } from "./merge-teardown";
 import { isFullAuto } from "./full-auto";
 import {
@@ -169,6 +170,9 @@ export interface DrainDeps {
   emitEpicCompleted?: (epic: CompletedEpic) => void;
   /** → events.emit("session:new", s). Optional — absent in tests that don't need it. */
   emitSessionNew?: (s: Session) => void;
+  /** Anonymous product telemetry. `event()` no-ops unless consent is granted (src/telemetry.ts),
+   *  so no call-site gating is needed. Absent in tests that don't assert emission. */
+  telemetry?: Pick<TelemetryService, "event">;
   now?: () => number;
   /** Short cache for listIssues (default 10s). */
   issuesTtlMs?: number;
@@ -633,6 +637,7 @@ export class DrainService {
       // Emit a final epic:update reflecting the completed/idle state before
       // the next buildState sees idle and stops emitting epicParent.
       this.emitEpicIfChanged(repoPath, { ...epic, run: completedRun });
+      this.deps.telemetry?.event("epic_drained", { childCount: epic.children.length });
       return true;
     } else {
       this.emitEpicIfChanged(repoPath, epic);

--- a/src/index.ts
+++ b/src/index.ts
@@ -495,6 +495,14 @@ function roleEnv(cli: string, model: string): RoleEnvironment {
   return env;
 }
 
+// Anonymous product telemetry (Aptabase). No-op unless the operator has explicitly
+// granted consent (config.telemetryConsent === "granted") and DO_NOT_TRACK isn't set.
+const telemetry = new TelemetryService({
+  appKey: config.aptabaseAppKey,
+  hostOverride: config.aptabaseHostOverride,
+  enabled: () => config.telemetryConsent === "granted" && !config.doNotTrack,
+});
+
 const service = new SessionService({
   store,
   worktree,
@@ -536,6 +544,7 @@ const service = new SessionService({
     Promise.all([recapService.considerForArchive(s), snapshotSessionUsage(s, store)]).then(
       () => {},
     ),
+  telemetry,
 });
 
 // Deep modules for the learnings + repo-config route seams (#1092). Singletons so every
@@ -543,14 +552,6 @@ const service = new SessionService({
 // total accessors return these when injected via appDeps.
 const learningsSvc = new LearningsService(store, events);
 const repoConfigSvc = new RepoConfigService(store);
-
-// Anonymous product telemetry (Aptabase). No-op unless the operator has explicitly
-// granted consent (config.telemetryConsent === "granted") and DO_NOT_TRACK isn't set.
-const telemetry = new TelemetryService({
-  appKey: config.aptabaseAppKey,
-  hostOverride: config.aptabaseHostOverride,
-  enabled: () => config.telemetryConsent === "granted" && !config.doNotTrack,
-});
 
 // Build-queue reconciliation nudge: settled-idle backstop to the forward-fill cascade in
 // store.setBuildStepStatus. Steers a drifted, settled-idle session to post its progress.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1478,6 +1478,7 @@ const drain = new DrainService({
   // yet, so seed hasScratchpadFiles=false (#1164). The live truth thereafter rides the
   // session:status (idle/done) push and the /api/sessions list enrichment.
   emitSessionNew: (s) => events.emit("session:new", { ...s, hasScratchpadFiles: false }),
+  telemetry,
   // #1071: wire rebase cap + real rebaseLandingBranch (mirrors autopilot/automerge wiring).
   rebaseCap: config.autoMergeRebaseCap,
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ import { CodexUpdateService } from "./codex-update";
 import { DiagnosticsService } from "./diagnostics";
 import { TelemetryService } from "./telemetry";
 import { normalizeTelemetryConsent } from "./telemetry-consent";
+import { wirePrOpenedTelemetry } from "./pr-opened-telemetry";
 import { StarPromptService } from "./star-prompt";
 import {
   PushService,
@@ -893,6 +894,10 @@ events.subscribe((event, data) => {
   manualStepsHeadSeen.set(id, headSha);
   void detectAndPersistManualSteps(id, git.number);
 });
+
+// Anonymous product telemetry: emit `pr_opened` the first time a session's tracked PR
+// transitions to open (see src/pr-opened-telemetry.ts for the transition/dedup design).
+wirePrOpenedTelemetry({ events, store, telemetry });
 
 // Drive tailscale serve mappings: register when a preview port binds, unregister
 // on teardown. Listens on session:preview (NOT session:preview-serve to avoid

--- a/src/pr-opened-telemetry.ts
+++ b/src/pr-opened-telemetry.ts
@@ -1,0 +1,50 @@
+import type { EventHub } from "./events";
+import type { SessionStore } from "./store";
+import type { GitState } from "./forge/types";
+import type { TelemetryService } from "./telemetry";
+
+/**
+ * Emit `pr_opened` the first time a session's tracked PR transitions to open.
+ *
+ * A PR is opened externally by the agent (`gh pr create`); Shepherd only *discovers* it by
+ * polling, so the git-state transition broadcast as `session:git` is the detection substrate.
+ * Guards:
+ *  - transition: emit only on a genuine previously-seen-non-open → open transition (with a PR number).
+ *  - cold-start skip: if no prior state was seen for the session (fresh process, or a PR already
+ *    open before a restart), record the state WITHOUT emitting — a cold re-observation of a
+ *    pre-existing open PR never false-fires.
+ *  - once-per-session: an emitted set bounds emission to one per session per process. Combined with
+ *    the single-threaded synchronous event dispatch, it also serializes the poller's concurrent
+ *    tick()-vs-pollSession() refreshes so they cannot double-emit.
+ * Counts are therefore approximate across restarts — consistent with the anonymity design (spec §7).
+ */
+export function wirePrOpenedTelemetry(deps: {
+  events: Pick<EventHub, "subscribe">;
+  store: Pick<SessionStore, "get">;
+  telemetry: Pick<TelemetryService, "event">;
+}): void {
+  const lastState = new Map<string, GitState["state"]>();
+  const emitted = new Set<string>();
+  deps.events.subscribe((event, data) => {
+    if (event === "session:archived") {
+      const { id } = data as { id: string };
+      lastState.delete(id);
+      emitted.delete(id);
+      return;
+    }
+    if (event !== "session:git") return;
+    const { id, git } = data as { id: string; git: GitState };
+    const prev = lastState.get(id);
+    lastState.set(id, git.state);
+    if (emitted.has(id)) return;
+    if (prev !== undefined && prev !== "open" && git.state === "open" && git.number != null) {
+      const s = deps.store.get(id);
+      if (!s) return;
+      emitted.add(id);
+      deps.telemetry.event("pr_opened", {
+        agentProvider: s.agentProvider ?? "claude",
+        isDraft: git.isDraft ?? false,
+      });
+    }
+  });
+}

--- a/src/service.ts
+++ b/src/service.ts
@@ -39,6 +39,7 @@ import {
 } from "./spawn-auth";
 import type { Leftover, ProcessReaper } from "./process-reaper";
 import type { PreviewService } from "./preview";
+import type { TelemetryService } from "./telemetry";
 import { extractTargetPaths, planHouseRulesInjection, renderHouseRulesBlock } from "./house-rules";
 import { isGoodOutcome } from "./learnings-lifecycle";
 import { effectiveAutopilot } from "./effective-autopilot";
@@ -177,6 +178,9 @@ export interface ServiceDeps {
    *  thread into the prompt (see composePromptArg). Absent (tests) or a host without
    *  listIssueComments → the spawn prompt stays body-only. */
   resolveForge?: (repoPath: string) => GitForge | null;
+  /** Anonymous product telemetry. `event()` no-ops unless consent is granted (see src/telemetry.ts),
+   *  so no call-site gating is needed. Absent in tests that don't assert emission. */
+  telemetry?: Pick<TelemetryService, "event">;
 }
 
 /**
@@ -2085,6 +2089,13 @@ export class SessionService {
         this.deps.events?.emit("session:uploads-dropped", { id: sessionId, count: droppedImages });
       this.scheduleRefine(session, herdSlug);
       this.#maybeRegisterTrain(session, input);
+      this.deps.telemetry?.event("session_created", {
+        agentProvider,
+        autopilot: spawnInput.autopilotEnabled ?? false,
+        research: session.research,
+        planGate: planGateOn,
+        fromIssue: session.issueNumber != null,
+      });
       return session;
     } catch (e) {
       // best-effort rollback; surface the original failure, not any cleanup error

--- a/test/drain-epic-completed.test.ts
+++ b/test/drain-epic-completed.test.ts
@@ -81,6 +81,7 @@ interface Harness {
   store: SessionStore;
   drain: DrainService;
   completedEmits: CompletedEpic[];
+  telemetryEvents: { name: string; props: any }[];
 }
 
 function makeHarness(opts: HarnessOpts): Harness {
@@ -121,6 +122,7 @@ function makeHarness(opts: HarnessOpts): Harness {
 
   const forge = fakeForge(opts.subIssues, opts.listBlockedByImpl);
   const completedEmits: CompletedEpic[] = [];
+  const telemetryEvents: { name: string; props: any }[] = [];
 
   const service = {
     create: async () => {
@@ -141,10 +143,11 @@ function makeHarness(opts: HarnessOpts): Harness {
     dropPrCache: () => {},
     emitEpic: () => {},
     emitEpicCompleted: (e) => completedEmits.push(e),
+    telemetry: { event: (name, props) => telemetryEvents.push({ name, props }) },
     rebaseCap: 5,
   });
 
-  return { store, drain, completedEmits };
+  return { store, drain, completedEmits, telemetryEvents };
 }
 
 describe("epic auto-complete → record before idle flip (#635)", () => {
@@ -186,6 +189,18 @@ describe("epic auto-complete → record before idle flip (#635)", () => {
     expect(h.store.getEpicRun(REPO)?.status).toBe("running"); // NOT idle
     expect(h.store.listEpicCompleted(REPO)).toHaveLength(0);
     expect(h.completedEmits).toHaveLength(0);
+    expect(h.telemetryEvents.filter((e) => e.name === "epic_drained")).toHaveLength(0);
+  });
+
+  test("fires epic_drained exactly once on completion with childCount", async () => {
+    const h = makeHarness({ subIssues: [sub(320, true), sub(321, true)] });
+
+    await h.drain.pump(REPO);
+
+    const drained = h.telemetryEvents.filter((e) => e.name === "epic_drained");
+    expect(drained).toHaveLength(1);
+    expect(drained[0]!.props).toEqual({ childCount: 2 });
+    expect(typeof drained[0]!.props.childCount).toBe("number");
   });
 
   test("not all merged: no record, run stays running", async () => {

--- a/test/pr-opened-telemetry.test.ts
+++ b/test/pr-opened-telemetry.test.ts
@@ -1,0 +1,153 @@
+import { test, expect } from "bun:test";
+import { EventHub } from "../src/events";
+import { SessionStore } from "../src/store";
+import { wirePrOpenedTelemetry } from "../src/pr-opened-telemetry";
+import type { GitState } from "../src/forge/types";
+
+function harness() {
+  const events = new EventHub();
+  const store = new SessionStore(":memory:");
+  const emitted: { name: string; props: Record<string, unknown> }[] = [];
+  wirePrOpenedTelemetry({
+    events,
+    store,
+    telemetry: { event: (name, props = {}) => emitted.push({ name, props }) },
+  });
+  return { events, store, emitted };
+}
+
+function makeSession(
+  store: SessionStore,
+  overrides: Partial<{ agentProvider: "claude" | "codex" }> = {},
+) {
+  return store.create({
+    name: "x",
+    prompt: "x",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/x",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_a",
+    ...overrides,
+  });
+}
+
+function git(overrides: Partial<GitState> = {}): GitState {
+  return {
+    kind: "github",
+    state: "none",
+    checks: "none",
+    deployConfigured: false,
+    ...overrides,
+  } as GitState;
+}
+
+function prOpenedEvents(emitted: { name: string; props: Record<string, unknown> }[]) {
+  return emitted.filter((e) => e.name === "pr_opened");
+}
+
+test("none -> open fires once with agentProvider + isDraft props", () => {
+  const { events, store, emitted } = harness();
+  const s = makeSession(store, { agentProvider: "codex" });
+
+  events.emit("session:git", { id: s.id, git: git({ state: "none" }) });
+  events.emit("session:git", { id: s.id, git: git({ state: "open", number: 42, isDraft: false }) });
+
+  const fired = prOpenedEvents(emitted);
+  expect(fired).toHaveLength(1);
+  expect(fired[0]?.props).toEqual({ agentProvider: "codex", isDraft: false });
+});
+
+test("cold-start skip: first-ever session:git already open does not fire", () => {
+  const { events, store, emitted } = harness();
+  const s = makeSession(store);
+
+  events.emit("session:git", { id: s.id, git: git({ state: "open", number: 7, isDraft: false }) });
+
+  expect(prOpenedEvents(emitted)).toHaveLength(0);
+});
+
+test("open -> open does not re-fire", () => {
+  const { events, store, emitted } = harness();
+  const s = makeSession(store);
+
+  events.emit("session:git", { id: s.id, git: git({ state: "none" }) });
+  events.emit("session:git", { id: s.id, git: git({ state: "open", number: 42, isDraft: false }) });
+  // checks changed but still open
+  events.emit("session:git", {
+    id: s.id,
+    git: git({ state: "open", number: 42, isDraft: false, checks: "pending" }),
+  });
+
+  expect(prOpenedEvents(emitted)).toHaveLength(1);
+});
+
+test("double-fire dedup: two back-to-back open events after none only fire once", () => {
+  const { events, store, emitted } = harness();
+  const s = makeSession(store);
+
+  events.emit("session:git", { id: s.id, git: git({ state: "none" }) });
+  events.emit("session:git", { id: s.id, git: git({ state: "open", number: 42, isDraft: false }) });
+  events.emit("session:git", { id: s.id, git: git({ state: "open", number: 42, isDraft: false }) });
+
+  expect(prOpenedEvents(emitted)).toHaveLength(1);
+});
+
+test("isDraft passthrough: none -> open with isDraft true", () => {
+  const { events, store, emitted } = harness();
+  const s = makeSession(store);
+
+  events.emit("session:git", { id: s.id, git: git({ state: "none" }) });
+  events.emit("session:git", { id: s.id, git: git({ state: "open", number: 42, isDraft: true }) });
+
+  const fired = prOpenedEvents(emitted);
+  expect(fired).toHaveLength(1);
+  expect(fired[0]?.props.isDraft).toBe(true);
+});
+
+test("open with no number does not fire", () => {
+  const { events, store, emitted } = harness();
+  const s = makeSession(store);
+
+  events.emit("session:git", { id: s.id, git: git({ state: "none" }) });
+  events.emit("session:git", {
+    id: s.id,
+    git: git({ state: "open", number: undefined, isDraft: false }),
+  });
+
+  expect(prOpenedEvents(emitted)).toHaveLength(0);
+});
+
+test("session:archived clears per-session state so a later cold-start open does not false-fire", () => {
+  const { events, store, emitted } = harness();
+  const s = makeSession(store);
+
+  events.emit("session:git", { id: s.id, git: git({ state: "none" }) });
+  events.emit("session:git", { id: s.id, git: git({ state: "open", number: 42, isDraft: false }) });
+  expect(prOpenedEvents(emitted)).toHaveLength(1);
+
+  events.emit("session:archived", { id: s.id });
+
+  // A fresh "cold" open observation post-archive (e.g. id reused/re-seen) should not
+  // fire again since it is now an unseen id — cold-start skip applies.
+  events.emit("session:git", { id: s.id, git: git({ state: "open", number: 42, isDraft: false }) });
+  expect(prOpenedEvents(emitted)).toHaveLength(1);
+});
+
+test("reopen does not re-fire: none -> open -> closed -> open only emits once", () => {
+  const { events, store, emitted } = harness();
+  const s = makeSession(store);
+
+  events.emit("session:git", { id: s.id, git: git({ state: "none" }) });
+  events.emit("session:git", { id: s.id, git: git({ state: "open", number: 42, isDraft: false }) });
+  expect(prOpenedEvents(emitted)).toHaveLength(1);
+
+  events.emit("session:git", { id: s.id, git: git({ state: "closed", number: 42 }) });
+  // Reopen: closed -> open satisfies the `prev !== "open"` transition guard, so ONLY the
+  // once-per-session `emitted` guard prevents a second emit here.
+  events.emit("session:git", { id: s.id, git: git({ state: "open", number: 42, isDraft: false }) });
+
+  expect(prOpenedEvents(emitted)).toHaveLength(1);
+});

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -97,6 +97,95 @@ test("createSession: names, makes worktree, starts herdr, persists", async () =>
   expect(store.get(s.id)?.claudeSessionId).toBe(s.claudeSessionId);
 });
 
+test("createSession: emits session_created telemetry exactly once with primitive-only props", async () => {
+  const store = new SessionStore(":memory:");
+  const events: { name: string; props: any }[] = [];
+  const telemetry = { event: (name: string, props: any) => events.push({ name, props }) };
+  const service = new SessionService({
+    store,
+    namer: async () => "repo-flatten",
+    worktree: {
+      ensureBaseRef: async () => {},
+      branchExists: () => false,
+      create: () => ({
+        worktreePath: "/wt/repo-flatten",
+        branch: "shepherd/repo-flatten",
+        isolated: true,
+      }),
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: () => ({
+        terminalId: "term_z",
+        cwd: "/wt/repo-flatten",
+        agent: "claude",
+        agentStatus: "working",
+        paneId: "p",
+        tabId: "t",
+        workspaceId: "w",
+      }),
+      list: () => [],
+    } as any,
+    telemetry,
+  });
+
+  await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "flatten it",
+    model: null,
+    images: [],
+  });
+
+  const created = events.filter((e) => e.name === "session_created");
+  expect(created).toHaveLength(1);
+  expect(created[0]!.props).toEqual({
+    agentProvider: "claude",
+    autopilot: false,
+    research: false,
+    planGate: false,
+    fromIssue: false,
+  });
+  for (const v of Object.values(created[0]!.props)) {
+    expect(["string", "number", "boolean"]).toContain(typeof v);
+  }
+});
+
+test("createSession: does NOT emit session_created when create() rolls back (spawn failure)", async () => {
+  const store = new SessionStore(":memory:");
+  const events: { name: string; props: any }[] = [];
+  const telemetry = { event: (name: string, props: any) => events.push({ name, props }) };
+  const service = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: {
+      ensureBaseRef: async () => {},
+      branchExists: () => false,
+      create: () => ({ worktreePath: "/wt/x", branch: "shepherd/x", isolated: true }),
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: () => {
+        throw new Error("herdr start failed");
+      },
+      list: () => [],
+    } as any,
+    telemetry,
+  });
+
+  await expect(
+    service.create({
+      repoPath: "/repo",
+      baseBranch: "main",
+      prompt: "go",
+      model: null,
+      images: [],
+    }),
+  ).rejects.toThrow(/herdr start failed/);
+
+  expect(events.filter((e) => e.name === "session_created")).toHaveLength(0);
+});
+
 // Build a SessionService whose worktree.create yields the given `isolated`, capturing the
 // spawned argv. Used by the codex-autopilot directive tests below.
 function codexHarness(isolated: boolean) {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -186,6 +186,63 @@ test("createSession: does NOT emit session_created when create() rolls back (spa
   expect(events.filter((e) => e.name === "session_created")).toHaveLength(0);
 });
 
+test("createSession: session_created props map each to its own source (distinct-value permutation)", async () => {
+  const store = new SessionStore(":memory:");
+  const events: { name: string; props: any }[] = [];
+  const telemetry = { event: (name: string, props: any) => events.push({ name, props }) };
+  const service = new SessionService({
+    store,
+    namer: async () => "repo-flatten",
+    worktree: {
+      ensureBaseRef: async () => {},
+      branchExists: () => false,
+      create: () => ({
+        worktreePath: "/wt/repo-flatten",
+        branch: "shepherd/repo-flatten",
+        isolated: true,
+      }),
+      remove: () => {},
+    } as any,
+    herdr: {
+      start: () => ({
+        terminalId: "term_z",
+        cwd: "/wt/repo-flatten",
+        agent: "claude",
+        agentStatus: "working",
+        paneId: "p",
+        tabId: "t",
+        workspaceId: "w",
+      }),
+      list: () => [],
+    } as any,
+    telemetry,
+  });
+
+  // Distinct permutation so a boolean-mapping swap can't hide: autopilot on, plan-gate on,
+  // attached to an issue, research OFF (research true would force plan-gate false).
+  await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "flatten it",
+    model: null,
+    images: [],
+    autopilotEnabled: true,
+    planGateEnabled: true,
+    research: false,
+    issueRef: { number: 42, url: "https://x/42", title: "t", body: "b" },
+  });
+
+  const created = events.filter((e) => e.name === "session_created");
+  expect(created).toHaveLength(1);
+  expect(created[0]!.props).toEqual({
+    agentProvider: "claude",
+    autopilot: true,
+    research: false,
+    planGate: true,
+    fromIssue: true,
+  });
+});
+
 // Build a SessionService whose worktree.create yields the given `isolated`, capturing the
 // spawned argv. Used by the codex-autopilot directive tests below.
 function codexHarness(isolated: boolean) {


### PR DESCRIPTION
Wires the three remaining v1 telemetry events at their confirmed emit sites. `app_launched` already shipped; `TelemetryService.event()` already no-ops internally unless consent is granted, so **no gating is added at any call site**. Props are a strict primitive allowlist (bounded enums / bools / counts) — no strings, paths, free-form text, or PII — preserving the anonymity guarantee.

Closes #1329.

## Events wired

| Event | Emit site | Props |
| --- | --- | --- |
| `session_created` | `SessionService.create()` choke point — once per successful create (never on the spawn-failure rollback) | `{ agentProvider, autopilot, research, planGate, fromIssue }` |
| `epic_drained` | `DrainService.handleEpicSideEffects()` running→idle completion edge — once per epic | `{ childCount }` |
| `pr_opened` | new `session:git` subscriber (`src/pr-opened-telemetry.ts`) — on a session PR's non-open→open transition | `{ agentProvider, isDraft }` |

**No `model` prop** — `--model` accepts arbitrary free-form text.

## Why these sites (choke-point vs. event bus)

- `session_created` / `epic_drained` each have a single authoritative in-process moment, so telemetry is injected directly there. The obvious bus events over-count: `session:new` fires from ~9 sites (held-release, variants, relaunch, server routes); `epic:completed` re-fires on every landing-state change (`drain.ts` `emitCompleted`).
- `pr_opened` is different: a PR is opened externally by the agent (`gh pr create`) and only *discovered* by polling, so the git-state transition broadcast as `session:git` is the natural detection substrate. `PrPoller` is left untouched.

## `pr_opened` correctness

The poller alone can't guarantee once-only (a full-sweep `refresh` and a turn-end `pollSession` can both read `prev=non-open`), so the subscriber owns the state:
- **transition guard** — emit only on a genuine previously-seen-non-open → open (with a PR number);
- **cold-start skip** — a first-ever observation of an already-open PR (e.g. after a restart) records state without emitting, so it never false-fires;
- **once-per-session dedup** — an emitted set plus synchronous single-thread event dispatch bound emission to once per session per process (reopen included).

Counts are therefore approximate across restarts — consistent with the anonymity design (spec §7).

## Testing

- `session_created`: emits with correct props on success; **not** on rollback; a distinct-permutation test proves each prop maps to its own source (catches a boolean-mapping swap).
- `epic_drained`: fires exactly once at the completion edge; not when the record fails / not all merged.
- `pr_opened`: none→open fires once; cold-start / open→open / double-fire / reopen / no-number all suppressed; `isDraft` + `agentProvider` passthrough.
- Server suite: 5664 pass / 0 fail; lint clean. (The `ui/` package was not touched.)

Also resolves spec open-question #2 (v1 event set ratified) in `docs/superpowers/specs/2026-07-02-aptabase-telemetry-design.md`.

Server-only change, no user-facing UI. `[no-feature-entry]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
