### PR TITLE
feat(viewport): add jump-to-session-start control

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2377,5 +2377,8 @@
   "feat_command_bar_search_field_title": "Suche in der oberen Leiste",
   "feat_command_bar_search_field_body": "Die Befehlsleiste hat jetzt ein Suchfeld in der oberen Leiste mit einem ⌘K / Strg-K-Kürzel. Dokumentation und Erkenntnisse sind dorthin umgezogen — durchsuche die Dokumente und öffne Erkenntnisse direkt aus der Leiste.",
   "feat_command_bar_jump_title": "Mit Alt zu Befehlsleisten-Ergebnissen springen",
-  "feat_command_bar_jump_body": "Halte bei geöffneter Befehlsleiste Alt gedrückt, um Ziffernhinweise (1–9, dann 0) auf den ersten zehn Ergebnissen einzublenden, und drücke dann die Ziffer, um direkt dorthin zu springen."
+  "feat_command_bar_jump_body": "Halte bei geöffneter Befehlsleiste Alt gedrückt, um Ziffernhinweise (1–9, dann 0) auf den ersten zehn Ergebnissen einzublenden, und drücke dann die Ziffer, um direkt dorthin zu springen.",
+  "viewport_scroll_to_top": "Zum Anfang der Session springen",
+  "feat_scroll_to_session_start_title": "Zum Session-Anfang springen",
+  "feat_scroll_to_session_start_body": "Wenn du ältere Terminal-Ausgabe liest, zeigt die schwebende Scroll-Schaltfläche jetzt zusätzlich einen ↑-Button für den Anfang der Session neben dem bestehenden ↓-Sprung zurück zum aktuellen Prompt."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2377,5 +2377,8 @@
   "feat_command_bar_search_field_title": "Search from the top bar",
   "feat_command_bar_search_field_body": "The command bar now has a search field in the top bar with a ⌘K / Ctrl K shortcut. Documentation and Learnings live inside it — search the docs and open Learnings straight from the bar.",
   "feat_command_bar_jump_title": "Jump to command-bar results with Alt",
-  "feat_command_bar_jump_body": "Hold Alt with the command bar open to reveal number hints (1–9, then 0) on the first ten results, then press the digit to jump straight to it."
+  "feat_command_bar_jump_body": "Hold Alt with the command bar open to reveal number hints (1–9, then 0) on the first ten results, then press the digit to jump straight to it.",
+  "viewport_scroll_to_top": "Jump to session start",
+  "feat_scroll_to_session_start_title": "Jump to session start",
+  "feat_scroll_to_session_start_body": "When you're reading older terminal output, the floating scroll control now includes an ↑ button for the start of the session next to the existing ↓ jump back to the latest prompt."
 }

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -40,7 +40,7 @@
   import { shouldForwardEscape } from "$lib/terminalEscape";
   import { altComboKey, isCommandBarChord } from "./herd-keynav";
   import { detectNotesKey } from "$lib/notesAffordance";
-  import { isScrolledAwayFromBottom } from "$lib/scrollAffordance";
+  import { isScrolledAwayFromBottom, SCROLL_UP_PX } from "$lib/scrollAffordance";
   import { pollWhileVisible } from "$lib/visibility";
   import TodoPanel from "$lib/components/TodoPanel.svelte";
   import ActivityFeed from "$lib/components/ActivityFeed.svelte";
@@ -312,6 +312,10 @@
   // plain (non-reactive) — only `scrolledUp` drives the UI. Reset on re-attach,
   // buffer switch, and a jump-to-bottom.
   let scrollDepth = 0;
+  // Agent-owned top jumps move a remote TUI whose real position xterm cannot
+  // observe. Until the user explicitly jumps back down (or the terminal resets),
+  // do not let local wheel/touch bookkeeping claim we verified the bottom.
+  let agentTopJumpNeedsExplicitBottom = false;
   // agent-owned regime only: new output landed while the reader was scrolled up
   // (any amount). xterm's viewport stays pinned there, so a sub-threshold nudge
   // followed by fresh agent output — common while the pane is backgrounded —
@@ -901,6 +905,19 @@
   const agentOwnsScroll = (term: Terminal): boolean =>
     term.buffer.active.type === "alternate" || term.modes.mouseTrackingMode !== "none";
 
+  function clearAgentScrollState() {
+    scrollDepth = 0;
+    contentBelowScroll = false;
+    agentTopJumpNeedsExplicitBottom = false;
+  }
+
+  function trackAgentScrollDelta(deltaY: number) {
+    scrollDepth = Math.max(0, scrollDepth - deltaY);
+    if (agentTopJumpNeedsExplicitBottom) {
+      scrollDepth = Math.max(scrollDepth, SCROLL_UP_PX + 1);
+    }
+  }
+
   function scrollToBottom() {
     const term = termRef;
     if (!term) return;
@@ -912,8 +929,7 @@
     } else {
       term.scrollToBottom();
     }
-    scrollDepth = 0;
-    contentBelowScroll = false;
+    clearAgentScrollState();
     scrolledUp = false;
   }
 
@@ -925,6 +941,10 @@
       // documented top shortcut is Ctrl+Home; PageUp spam is a defensive fallback
       // for renderer/terminal combinations that ignore that CSI variant.
       conn?.send("\x1b[1;5H" + "\x1b[5~".repeat(500));
+      agentTopJumpNeedsExplicitBottom = true;
+      scrollDepth = Math.max(scrollDepth, SCROLL_UP_PX + 1);
+      contentBelowScroll = true;
+      scrolledUp = true;
     } else {
       term.scrollToTop();
     }
@@ -1030,8 +1050,7 @@
     if (!el) return;
     parked = false; // fresh attach for this unit
     scrolledUp = false; // fresh terminal starts pinned to the bottom
-    scrollDepth = 0;
-    contentBelowScroll = false;
+    clearAgentScrollState();
     notesKey = null; // no prompt scraped yet on this fresh terminal
 
     // initial palette: non-reactive DOM read so this effect doesn't depend on
@@ -1423,7 +1442,7 @@
     // jump-to-bottom affordance and forward the wheel to xterm's screen.
     const dispatchScroll = (dy: number) => {
       if (agentOwnsScroll(term)) {
-        scrollDepth = Math.max(0, scrollDepth - dy);
+        trackAgentScrollDelta(dy);
       }
       recomputeScrolled();
       const target = el!.querySelector<HTMLElement>(".xterm-screen") ?? el!;
@@ -1529,7 +1548,7 @@
     // arrival matters are documented in `isScrolledAwayFromBottom`.
     const recomputeScrolled = () => {
       const b = term.buffer.active;
-      if (scrollDepth === 0) contentBelowScroll = false; // back at the bottom → re-arm
+      if (scrollDepth === 0) contentBelowScroll = false; // verified bottom → re-arm
       scrolledUp = isScrolledAwayFromBottom({
         agentOwnsScroll: agentOwnsScroll(term),
         scrollDepth,
@@ -1539,7 +1558,7 @@
     };
     const scrollSub = term.onScroll(recomputeScrolled);
     const bufSub = term.buffer.onBufferChange(() => {
-      scrollDepth = 0;
+      clearAgentScrollState();
       recomputeScrolled();
     });
     // When the agent owns the scroll xterm's viewport never moves, so onScroll
@@ -1580,7 +1599,7 @@
     // >0 = toward latest.
     const onWheelTrack = (e: WheelEvent) => {
       if (!e.isTrusted || !agentOwnsScroll(term)) return;
-      scrollDepth = Math.max(0, scrollDepth - e.deltaY);
+      trackAgentScrollDelta(e.deltaY);
       recomputeScrolled();
     };
     el.addEventListener("wheel", onWheelTrack, { passive: true, capture: true });

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -917,6 +917,19 @@
     scrolledUp = false;
   }
 
+  function scrollToTop() {
+    const term = termRef;
+    if (!term) return;
+    if (agentOwnsScroll(term)) {
+      // Claude owns the visible scroll in fullscreen/mouse-tracking mode. Its
+      // documented top shortcut is Ctrl+Home; PageUp spam is a defensive fallback
+      // for renderer/terminal combinations that ignore that CSI variant.
+      conn?.send("\x1b[1;5H" + "\x1b[5~".repeat(500));
+    } else {
+      term.scrollToTop();
+    }
+  }
+
   // bring a finished session back: ask the server to respawn the provider resume in
   // the worktree, then bump the epoch so the terminal effect rebuilds and attaches
   // to the fresh agent (the old PtyConn stopped for good on the ended-close).
@@ -2183,6 +2196,7 @@
       {resuming}
       {resumeFailed}
       {resumable}
+      {scrollToTop}
       {scrollToBottom}
       {takeover}
       {reattach}

--- a/ui/src/lib/components/viewport/ViewportTermBanners.svelte
+++ b/ui/src/lib/components/viewport/ViewportTermBanners.svelte
@@ -10,6 +10,7 @@
     resuming,
     resumeFailed,
     resumable,
+    scrollToTop,
     scrollToBottom,
     takeover,
     reattach,
@@ -23,6 +24,7 @@
     resuming: boolean;
     resumeFailed: boolean;
     resumable: boolean;
+    scrollToTop: () => void;
     scrollToBottom: () => void;
     takeover: () => void;
     reattach: () => void;
@@ -31,15 +33,26 @@
 </script>
 
 {#if tab === "term" && scrolledUp && !parked}
-  <button
-    class="scroll-bottom"
-    type="button"
-    onclick={scrollToBottom}
-    title={m.viewport_scroll_to_bottom()}
-    aria-label={m.viewport_scroll_to_bottom()}
-  >
-    <span aria-hidden="true">↓</span>
-  </button>
+  <div class="scroll-jump">
+    <button
+      class="scroll-jump-btn"
+      type="button"
+      onclick={scrollToTop}
+      title={m.viewport_scroll_to_top()}
+      aria-label={m.viewport_scroll_to_top()}
+    >
+      <span aria-hidden="true">↑</span>
+    </button>
+    <button
+      class="scroll-jump-btn"
+      type="button"
+      onclick={scrollToBottom}
+      title={m.viewport_scroll_to_bottom()}
+      aria-label={m.viewport_scroll_to_bottom()}
+    >
+      <span aria-hidden="true">↓</span>
+    </button>
+  </div>
 {/if}
 {#if parked && tab === "term"}
   <button class="parked" type="button" onclick={takeover}>
@@ -104,9 +117,9 @@
     opacity: 0.7;
   }
 
-  /* jump-to-bottom: small round affordance, bottom-right of the terminal body.
-     sits above xterm content (z-index 2) but below the parked/resume overlays (3) */
-  .scroll-bottom {
+  /* jump controls: small round affordances, bottom-right of the terminal body.
+     sit above xterm content (z-index 2) but below the parked/resume overlays (3) */
+  .scroll-jump {
     position: absolute;
     /* Lift clear of the ReviewInFlightBanner's bottom strip when it's shown:
        --review-banner-h (published on .vp-body) is that banner's occupied height,
@@ -114,6 +127,13 @@
     bottom: calc(12px + var(--review-banner-h, 0px));
     right: 14px;
     z-index: 2;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--mobile-shell-pad);
+  }
+  .scroll-jump-btn {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -136,15 +156,14 @@
       background 0.12s ease,
       color 0.12s ease,
       box-shadow 0.12s ease,
-      transform 0.12s ease,
-      bottom 0.12s ease;
+      transform 0.12s ease;
     /* slide in, then pulse the amber glow twice to draw the eye; the pulse ends
-       and the button rests on the steady halo set above. */
+       and the buttons rest on the steady halo set above. */
     animation:
       scroll-bottom-in 0.14s ease,
       scroll-bottom-glow 1.5s ease-in-out 0.14s 2;
   }
-  .scroll-bottom:hover {
+  .scroll-jump-btn:hover {
     background: var(--color-hover);
     color: var(--color-amber);
     transform: translateY(-1px);
@@ -160,7 +179,7 @@
      element itself is simplest — stays round, stays flat. Desktop (fine pointer)
      keeps the 38px glyph. */
   @media (pointer: coarse) {
-    .scroll-bottom {
+    .scroll-jump-btn {
       min-width: 44px;
       min-height: 44px;
     }

--- a/ui/src/lib/feature-announcements/entries/v1.41.0-scroll-to-session-start.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.41.0-scroll-to-session-start.ts
@@ -1,0 +1,12 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // The scrollback affordance now offers both directions when the reader is away
+  // from the live prompt. No targetId: it only mounts while scrolled up.
+  id: "scroll-to-session-start",
+  sinceVersion: "1.41.0",
+  titleKey: "feat_scroll_to_session_start_title",
+  bodyKey: "feat_scroll_to_session_start_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/feature-announcements/entries/v1.42.0-scroll-to-session-start.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.42.0-scroll-to-session-start.ts
@@ -4,7 +4,7 @@ const entry = {
   // The scrollback affordance now offers both directions when the reader is away
   // from the live prompt. No targetId: it only mounts while scrolled up.
   id: "scroll-to-session-start",
-  sinceVersion: "1.41.0",
+  sinceVersion: "1.42.0",
   titleKey: "feat_scroll_to_session_start_title",
   bodyKey: "feat_scroll_to_session_start_body",
 } satisfies FeatureAnnouncement;


### PR DESCRIPTION
## Summary
- add an upward scroll affordance beside the existing jump-to-latest control
- route the top jump through Claude's scroll shortcut with PageUp fallback when the agent owns scroll
- add EN/DE strings and a What's New entry

## Verification
- cd ui && bun run check:i18n
- cd ui && bun run check
- scripts/check-branch-hygiene.sh && scripts/check-feature-catalog.sh
- cd ui && bun run test:browser -- src/lib/components/Viewport.browser.test.ts