### PR TITLE
feat(ui): fuzzy matching for the command bar

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2341,7 +2341,7 @@
   "commandbar_repo_affordance": "Repository",
   "commandbar_no_matches": "Keine Treffer",
   "feat_command_bar_title": "Befehlsleiste — mit ⌘K zu allem springen",
-  "feat_command_bar_body": "Drücke ⌘K (macOS) oder Strg+K (Windows/Linux) — auch bei fokussiertem Terminal — um einen Schnellumschalter zu öffnen. Tippe, um deine Sessions, Repositories und Herden-Ansichten zu filtern, und springe mit Enter direkt dorthin.",
+  "feat_command_bar_body": "Drücke ⌘K (macOS) oder Strg+K (Windows/Linux) — auch bei fokussiertem Terminal — um einen Schnellumschalter zu öffnen. Tippe, um deine Sessions, Repositories und Herden-Ansichten unscharf zu durchsuchen — passende Buchstaben werden hervorgehoben, und Sessions werden auch anhand ihrer Beschreibung gefunden — und springe mit Enter direkt dorthin.",
   "settings_tab_ticker_title": "Kompakter Tab-Titel",
   "settings_tab_ticker_hint": "Zeigt im Hintergrund-Tab gruppierte Symbolzähler (⚠ CI fehlgeschlagen · ✋ blockiert · ✓ bereit · ▶ läuft) statt einer einzelnen Zahl. Standardmäßig aus.",
   "settings_tab_ticker_on": "Kompakter Tab-Titel an",
@@ -2361,5 +2361,6 @@
   "commandbar_cmd_next_needs_you": "Zur nächsten Session springen, die dich braucht",
   "commandbar_cmd_next_needs_you_kw": "wartend blockiert aufmerksamkeit",
   "feat_command_bar_v2_title": "Befehlsleiste führt jetzt Befehle aus und durchsucht die Doku",
-  "feat_command_bar_v2_body": "⌘K/Strg+K kann mehr als nur zwischen Sessions springen. Eine Gruppe „Befehle“ führt Verben aus — Neue Aufgabe, Broadcast, Einstellungen, Nutzung, Erneut versuchen, Zur nächsten Session springen, die dich braucht — und eine Gruppe „Doku“ durchsucht die Dokumentation und öffnet die Seite in einem neuen Tab. Tippe einfach, was du tun möchtest."
+  "feat_command_bar_v2_body": "⌘K/Strg+K kann mehr als nur zwischen Sessions springen. Eine Gruppe „Befehle“ führt Verben aus — Neue Aufgabe, Broadcast, Einstellungen, Nutzung, Erneut versuchen, Zur nächsten Session springen, die dich braucht — und eine Gruppe „Doku“ durchsucht die Dokumentation und öffnet die Seite in einem neuen Tab. Tippe einfach, was du tun möchtest.",
+  "commandbar_prompt_match": "passt zur Beschreibung"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2341,7 +2341,7 @@
   "commandbar_repo_affordance": "Repository",
   "commandbar_no_matches": "No matches",
   "feat_command_bar_title": "Command bar — jump to anything with ⌘K",
-  "feat_command_bar_body": "Press ⌘K (macOS) or Ctrl+K (Windows/Linux) — even while the terminal is focused — to open a quick-switcher. Type to filter across your sessions, repositories, and herd lenses, then hit Enter to jump straight there.",
+  "feat_command_bar_body": "Press ⌘K (macOS) or Ctrl+K (Windows/Linux) — even while the terminal is focused — to open a quick-switcher. Type to fuzzy-search across your sessions, repositories, and herd lenses — matched letters are highlighted, and sessions match on their description too — then hit Enter to jump straight there.",
   "settings_tab_ticker_title": "Compact tab title",
   "settings_tab_ticker_hint": "When a background tab needs you, show grouped glyph counts (⚠ CI failed · ✋ blocked · ✓ ready · ▶ running) instead of a single number. Off by default.",
   "settings_tab_ticker_on": "Compact tab title on",
@@ -2361,5 +2361,6 @@
   "commandbar_cmd_next_needs_you": "Jump to next needs-you",
   "commandbar_cmd_next_needs_you_kw": "waiting blocked attention",
   "feat_command_bar_v2_title": "Command bar now runs commands and searches docs",
-  "feat_command_bar_v2_body": "⌘K/Ctrl+K does more than jump between sessions now. A Commands group runs verbs — New task, Broadcast, Settings, Usage, Retry, Jump to next needs-you — and a Docs group searches the documentation and opens the page in a new tab. Just start typing what you want to do."
+  "feat_command_bar_v2_body": "⌘K/Ctrl+K does more than jump between sessions now. A Commands group runs verbs — New task, Broadcast, Settings, Usage, Retry, Jump to next needs-you — and a Docs group searches the documentation and opens the page in a new tab. Just start typing what you want to do.",
+  "commandbar_prompt_match": "matches description"
 }

--- a/ui/src/lib/components/CommandBar.browser.test.ts
+++ b/ui/src/lib/components/CommandBar.browser.test.ts
@@ -118,13 +118,17 @@ describe("CommandBar — grouping & recency", () => {
     await expect.element(page.getByRole("option").first()).toHaveTextContent("newer");
   });
 
-  it("filters by substring across sessions, repos and lenses", async () => {
+  it("filters fuzzily across sessions, repos and lenses", async () => {
     renderBar();
-    // "rundown" matches only the lens (no session/repo carries that text).
+    // "rundown" surfaces the rundown lens; no seeded session/repo carries that text, so the
+    // Sessions and Repositories groups drop out entirely. (Docs match by keyword and are out
+    // of scope here — asserted separately in the Docs group tests.)
     await page.getByRole("combobox").fill("rundown");
-    const opts = page.getByRole("option");
-    await expect.element(opts.first()).toHaveTextContent(m.herd_seg_rundown());
-    expect(opts.elements()).toHaveLength(1);
+    await expect
+      .element(page.getByRole("option", { name: new RegExp(m.herd_seg_rundown()) }))
+      .toBeVisible();
+    expect(page.getByText(m.commandbar_group_sessions()).elements()).toHaveLength(0);
+    expect(page.getByText(m.commandbar_group_repos()).elements()).toHaveLength(0);
   });
 
   it("shows the empty state when nothing matches", async () => {
@@ -132,6 +136,50 @@ describe("CommandBar — grouping & recency", () => {
     await page.getByRole("combobox").fill("zzzznomatch");
     await expect.element(page.getByText(m.commandbar_no_matches())).toBeVisible();
     expect(page.getByRole("option").elements()).toHaveLength(0);
+  });
+});
+
+describe("CommandBar — fuzzy matching", () => {
+  it("matches a non-contiguous subsequence", async () => {
+    renderBar();
+    // "nwr" is a subsequence of "newer" (n·e·w·e·r) — which a substring filter would miss —
+    // but not of "older", so the fuzzy matcher surfaces the former and drops the latter.
+    await page.getByRole("combobox").fill("nwr");
+    await expect.element(page.getByRole("option", { name: /newer/ })).toBeVisible();
+    expect(page.getByRole("option", { name: /older/ }).elements()).toHaveLength(0);
+  });
+
+  it("ranks the best match first, ahead of a more-recent weaker match", async () => {
+    // "deploy" is a whole-word prefix of d1 but starts mid-word in the more-recent d2 —
+    // the higher-scoring d1 must win despite d2's larger updatedAt.
+    const { onselectsession } = renderBar({
+      sessions: [
+        session({ id: "d1", name: "deploy", updatedAt: 10 }),
+        session({ id: "d2", name: "redeploy", updatedAt: 99 }),
+      ],
+    });
+    await page.getByRole("combobox").fill("deploy");
+    await userEvent.keyboard("{Enter}");
+    expect(onselectsession).toHaveBeenCalledWith("d1");
+  });
+
+  it("surfaces a session matched only by its prompt, with a 'matches description' affordance", async () => {
+    renderBar({
+      sessions: [session({ id: "p1", name: "zeta", prompt: "implement oauth login flow" })],
+    });
+    // "oauth" is absent from the title/desig/repo but present in the prompt (description).
+    await page.getByRole("combobox").fill("oauth");
+    await expect.element(page.getByRole("option", { name: /zeta/ })).toBeVisible();
+    await expect.element(page.getByText(m.commandbar_prompt_match())).toBeVisible();
+  });
+
+  it("highlights matched characters without altering the option's accessible name", async () => {
+    renderBar();
+    await page.getByRole("combobox").fill("nw");
+    // Matched letters are wrapped for highlighting…
+    expect(document.querySelectorAll("mark.cb-hl").length).toBeGreaterThan(0);
+    // …yet the option still reads as the full, untouched title.
+    await expect.element(page.getByRole("option").first()).toHaveTextContent("newer");
   });
 });
 

--- a/ui/src/lib/components/CommandBar.svelte
+++ b/ui/src/lib/components/CommandBar.svelte
@@ -10,6 +10,7 @@
   import { DOCS_URL } from "$lib/build-info";
   import { DOCS_PAGES } from "$lib/docs-manifest";
   import type { Command } from "$lib/command-registry";
+  import { fuzzyScore } from "$lib/fuzzy";
   import { m } from "$lib/paraglide/messages";
 
   let {
@@ -37,6 +38,8 @@
   // Row unions the three navigation targets. `oid` (assigned when the flat option
   // list is built) is a row's index within the SELECTABLE-only sequence — group
   // header rows are never part of it, so the roving cursor structurally skips them.
+  // `hl` holds the indices within the row's PRIMARY text that the query matched, for
+  // highlighting; empty when there is no query or the match landed outside the primary.
   type Row =
     | {
         kind: "session";
@@ -45,9 +48,13 @@
         repoPath: string;
         repoName: string | null;
         status: string;
+        hl: number[];
+        // Surfaced via a `prompt` (description) substring while the title itself did not
+        // match — drives the "matches description" affordance so the row isn't unexplained.
+        promptMatch: boolean;
       }
-    | { kind: "repo"; path: string; name: string; display: string }
-    | { kind: "lens"; lens: HerdFilter; label: string; icon: string }
+    | { kind: "repo"; path: string; name: string; display: string; hl: number[] }
+    | { kind: "lens"; lens: HerdFilter; label: string; icon: string; hl: number[] }
     | { kind: "command"; id: string; label: string; run: () => void }
     | { kind: "doc"; title: string; url: string };
   type OptRow = Row & { oid: number };
@@ -71,39 +78,65 @@
     { id: "owed", label: () => m.herd_seg_owed() },
   ];
 
-  // Recency-first, per group (see plan: updatedAt / lastUsedAt are the last-activity
-  // signals — railOrder() is a stage/epic partition, not a recency sort).
+  // Fuzzy-match + rank, per group. The fuzzy matcher runs only over the SHORT display
+  // fields (title/desig/repo name) so a short query can't subsequence-match nearly every
+  // long prompt; the haystack starts with the primary text so matched positions below its
+  // length map straight onto the highlighted primary. A blank query scores every row 0, so
+  // the sort falls back to recency — preserving the previous unfiltered ordering exactly.
+  // (updatedAt / lastUsedAt are the last-activity signals; lenses keep their fixed order.)
   const sessionRows = $derived<Row[]>(
     sessions
-      .filter((s) => {
+      .map((s) => {
+        const title = s.name || s.desig;
         const repoName = repos.nameFor(s.repoPath) ?? "";
-        return (s.name + " " + s.desig + " " + repoName).toLowerCase().includes(q);
+        return {
+          s,
+          title,
+          res: fuzzyScore(q, title + " " + s.desig + " " + repoName),
+          // `prompt` (description) is matched by a contiguous SUBSTRING, not fuzzily —
+          // selective enough to stay useful over long prompts.
+          promptMatch: q !== "" && s.prompt.toLowerCase().includes(q),
+        };
       })
-      .sort((a, b) => b.updatedAt - a.updatedAt)
-      .map((s) => ({
+      .filter((e) => e.res !== null || e.promptMatch)
+      .sort((a, b) => (b.res?.score ?? 0) - (a.res?.score ?? 0) || b.s.updatedAt - a.s.updatedAt)
+      .map(({ s, title, res, promptMatch }) => ({
         kind: "session",
         id: s.id,
-        title: s.name || s.desig,
+        title,
         repoPath: s.repoPath,
         repoName: repos.nameFor(s.repoPath),
         status: statusLabel(displayStatus(s, workingBlocked)),
+        hl: (res?.positions ?? []).filter((p) => p < title.length),
+        promptMatch,
       })),
   );
 
   const repoRows = $derived<Row[]>(
     repos.entries
-      .filter((r) => (r.name + " " + r.display).toLowerCase().includes(q))
-      .sort((a, b) => (b.lastUsedAt ?? 0) - (a.lastUsedAt ?? 0))
-      .map((r) => ({ kind: "repo", path: r.path, name: r.name, display: r.display })),
+      .map((r) => ({ r, res: fuzzyScore(q, r.name + " " + r.display) }))
+      .filter((e) => e.res !== null)
+      .sort((a, b) => b.res!.score - a.res!.score || (b.r.lastUsedAt ?? 0) - (a.r.lastUsedAt ?? 0))
+      .map(({ r, res }) => ({
+        kind: "repo",
+        path: r.path,
+        name: r.name,
+        display: r.display,
+        hl: res!.positions.filter((p) => p < r.name.length),
+      })),
   );
 
   const lensRows = $derived<Row[]>(
-    LENSES.filter((l) => l.label().toLowerCase().includes(q)).map((l) => ({
-      kind: "lens",
-      lens: l.id,
-      label: l.label(),
-      icon: lensGlyph[l.id],
-    })),
+    LENSES.map((l, i) => ({ l, i, label: l.label(), res: fuzzyScore(q, l.label()) }))
+      .filter((e) => e.res !== null)
+      .sort((a, b) => b.res!.score - a.res!.score || a.i - b.i)
+      .map(({ l, label, res }) => ({
+        kind: "lens",
+        lens: l.id,
+        label,
+        icon: lensGlyph[l.id],
+        hl: res!.positions, // the whole label is the primary text
+      })),
   );
 
   // Commands + Docs are search-driven, so they stay hidden until the user types: with an
@@ -111,6 +144,9 @@
   // burying the recency-ordered sessions/repos/lenses that make it a quick-switcher.
   // Commands match on label + optional localized keyword synonyms; docs on their title +
   // the generated keyword haystack (description + headings), so non-title queries resolve.
+  // These match by SUBSTRING (not the fuzzy scorer used for the navigation groups): their
+  // keyword haystacks are long free text, over which a short fuzzy subsequence would match
+  // nearly everything and flood the bar.
   const commandRows = $derived<Row[]>(
     q === ""
       ? []
@@ -174,6 +210,28 @@
     }
   }
 
+  // Split text into on/off runs at the matched positions, so matched chars can be wrapped
+  // in <mark> for highlighting. The rendered text is unchanged (runs concatenate back to the
+  // original), so a row's accessible name is preserved.
+  function segs(text: string, hl: number[]): { t: string; on: boolean }[] {
+    if (hl.length === 0) return [{ t: text, on: false }];
+    const on = new Set(hl);
+    const out: { t: string; on: boolean }[] = [];
+    let cur = "";
+    let curOn = on.has(0);
+    for (let i = 0; i < text.length; i++) {
+      const isOn = on.has(i);
+      if (isOn === curOn) cur += text[i];
+      else {
+        out.push({ t: cur, on: curOn });
+        cur = text[i];
+        curOn = isOn;
+      }
+    }
+    out.push({ t: cur, on: curOn });
+    return out;
+  }
+
   function selectOption(row: OptRow) {
     if (row.kind === "session") onselectsession(row.id);
     else if (row.kind === "repo") onselectrepo(row.path);
@@ -217,6 +275,13 @@
     }
   }
 </script>
+
+<!-- Primary text with fuzzy-matched chars wrapped in <mark> for highlighting. Shared by the
+     fuzzy-matched navigation rows (session / repo / lens); the split runs concatenate back to
+     the original, so the accessible name is preserved. -->
+{#snippet primary(text: string, hl: number[])}{#each segs(text, hl) as seg, i (i)}{#if seg.on}<mark
+        class="cb-hl">{seg.t}</mark
+      >{:else}{seg.t}{/if}{/each}{/snippet}
 
 <div
   class="overlay"
@@ -281,18 +346,19 @@
               <span class="cb-ic" aria-hidden="true"
                 >{projectIcons.iconFor(row.repoPath) ?? "▣"}</span
               >
-              <b class="cb-primary">{row.title}</b>
+              <b class="cb-primary">{@render primary(row.title, row.hl)}</b>
               <span class="cb-sub">
                 {#if row.repoName}{row.repoName} ·
-                {/if}{row.status}
+                {/if}{row.status}{#if row.promptMatch && row.hl.length === 0}
+                  · {m.commandbar_prompt_match()}{/if}
               </span>
             {:else if row.kind === "repo"}
               <span class="cb-ic" aria-hidden="true">{projectIcons.iconFor(row.path) ?? "▣"}</span>
-              <b class="cb-primary">{row.name}</b>
+              <b class="cb-primary">{@render primary(row.name, row.hl)}</b>
               <span class="cb-sub">{row.display} · {m.commandbar_repo_affordance()}</span>
             {:else if row.kind === "lens"}
               <span class="cb-ic" aria-hidden="true">{row.icon}</span>
-              <b class="cb-primary">{row.label}</b>
+              <b class="cb-primary">{@render primary(row.label, row.hl)}</b>
             {:else if row.kind === "command"}
               <span class="cb-ic" aria-hidden="true">⌘</span>
               <b class="cb-primary">{row.label}</b>
@@ -430,6 +496,13 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+  /* Matched-character highlight. Reset the UA <mark> yellow fill; emphasize with the amber
+     accent (the same attention hue as the keyboard cursor) — token-only per the design system. */
+  .cb-hl {
+    background: transparent;
+    color: var(--color-amber);
+    font-weight: 700;
   }
   /* Secondary detail — meta size is a precedented exception for dim sub-text. */
   .cb-sub {

--- a/ui/src/lib/feature-announcements/entries/v1.41.0-command-bar.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.41.0-command-bar.ts
@@ -2,6 +2,9 @@ import type { FeatureAnnouncement } from "../../feature-announcements";
 
 const entry = {
   // Cmd/Ctrl+K quick-switcher over sessions, repositories and herd lenses (#1334).
+  // Now fuzzy: matches are subsequence-scored with matched letters highlighted, and
+  // sessions also match on their description — folded into this same entry rather than a
+  // second card since the command bar is still unreleased on this train.
   // No targetId — the trigger is a global keyboard shortcut with no stable anchor
   // element to coach against.
   // v1.41.0 is the current unreleased train (matches the newest sibling entries).

--- a/ui/src/lib/fuzzy.test.ts
+++ b/ui/src/lib/fuzzy.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { fuzzyScore } from "./fuzzy";
+
+describe("fuzzyScore", () => {
+  it("empty query matches everything with score 0 and no positions", () => {
+    expect(fuzzyScore("", "anything")).toEqual({ score: 0, positions: [] });
+  });
+
+  it("returns null when the query is not a subsequence", () => {
+    expect(fuzzyScore("xyz", "abc")).toBeNull();
+  });
+
+  it("respects order — chars must appear in sequence", () => {
+    expect(fuzzyScore("ba", "abc")).toBeNull();
+  });
+
+  it("matches a contiguous substring and reports its positions", () => {
+    expect(fuzzyScore("bc", "abc")).toEqual({ score: expect.any(Number), positions: [1, 2] });
+  });
+
+  it("matches a non-contiguous subsequence", () => {
+    expect(fuzzyScore("ac", "abc")?.positions).toEqual([0, 2]);
+  });
+
+  it("is case-insensitive", () => {
+    expect(fuzzyScore("AB", "ab")?.positions).toEqual([0, 1]);
+  });
+
+  it("reports positions against the original text even when lowercasing changes length", () => {
+    // "İ".toLowerCase() is two code units ("i̇"), so matching against a lowercased copy would
+    // report index 2 for the "x"; against the original text it must be index 1.
+    expect(fuzzyScore("x", "İx")?.positions).toEqual([1]);
+  });
+
+  it("ranks a prefix match above the same query matched mid-word", () => {
+    // "deploy" is a whole-word prefix of "deploy" but starts mid-word in "redeploy".
+    const exact = fuzzyScore("deploy", "deploy");
+    const mid = fuzzyScore("deploy", "redeploy");
+    expect(exact).not.toBeNull();
+    expect(mid).not.toBeNull();
+    expect(exact!.score).toBeGreaterThan(mid!.score);
+  });
+
+  it("rewards a word-boundary match over a mid-word one", () => {
+    const boundary = fuzzyScore("h", "hello"); // index 0
+    const midWord = fuzzyScore("o", "hello"); // index 4, no separator before
+    expect(boundary!.score).toBeGreaterThan(midWord!.score);
+  });
+
+  it("rewards a match after a separator as a boundary", () => {
+    const afterSep = fuzzyScore("w", "hello-world"); // 'w' preceded by '-'
+    const midWord = fuzzyScore("e", "hello"); // 'e' mid-word
+    expect(afterSep!.score).toBeGreaterThan(midWord!.score);
+  });
+});

--- a/ui/src/lib/fuzzy.ts
+++ b/ui/src/lib/fuzzy.ts
@@ -1,0 +1,48 @@
+/** Result of a successful fuzzy match: a relevance `score` (higher is better) and the
+ *  indices in the ORIGINAL `text` that the query matched — the latter drive match
+ *  highlighting, so they must line up with the un-lowercased string. */
+export interface FuzzyResult {
+  score: number;
+  positions: number[];
+}
+
+const BASE = 1; // every consumed query char
+const BOUNDARY_BONUS = 10; // match at index 0 or right after a separator (prefixes win)
+const CONSEC_BONUS = 5; // match adjacent to the previous one (contiguous runs win)
+const SEPARATOR = /[\s\-_/.]/;
+
+/**
+ * Case-insensitive fuzzy subsequence match with relevance scoring.
+ *
+ * Returns `null` when `query` is not a subsequence of `text` (all query chars must appear in
+ * order). An empty query matches everything with score 0 and no positions — callers rely on
+ * this to preserve their default (unfiltered) ordering.
+ *
+ * Matching is greedy left-to-right: each query char binds to the earliest remaining occurrence.
+ * This is not an optimal alignment (a DP would find the highest-scoring one), but it is simple,
+ * allocation-light, and more than adequate for the short strings a command bar searches.
+ */
+export function fuzzyScore(query: string, text: string): FuzzyResult | null {
+  if (query.length === 0) return { score: 0, positions: [] };
+  const q = query.toLowerCase();
+  // Compare case-insensitively per character against the ORIGINAL text — not a pre-lowercased
+  // copy — so `positions` index the original string. Lowercasing the whole haystack can shift
+  // indices when a char's lowercase form has a different length (e.g. "İ" → "i̇"), which would
+  // misplace the highlight.
+  const positions: number[] = [];
+  let score = 0;
+  let qi = 0;
+  let prev = -2; // guarantees the first match is never counted as "consecutive"
+  for (let ti = 0; ti < text.length && qi < q.length; ti++) {
+    if (text[ti].toLowerCase() === q[qi]) {
+      let bonus = BASE;
+      if (ti === 0 || SEPARATOR.test(text[ti - 1])) bonus += BOUNDARY_BONUS;
+      if (ti === prev + 1) bonus += CONSEC_BONUS;
+      score += bonus;
+      positions.push(ti);
+      prev = ti;
+      qi++;
+    }
+  }
+  return qi === q.length ? { score, positions } : null;
+}


### PR DESCRIPTION
## What

Replaces the command bar's plain **substring** filter with **fuzzy subsequence matching + relevance ranking**, and highlights the matched characters. Typing `nwr` now finds `newer`, `dpl` finds a `deploy` session.

## How

- **New `ui/src/lib/fuzzy.ts`** — a small, dependency-free subsequence scorer returning `{ score, positions } | null`. Word-boundary (+10) and consecutive-run (+5) bonuses make prefix/contiguous matches rank highest; a non-subsequence returns `null` (row excluded). Fully unit-tested in `fuzzy.test.ts`.
- **`CommandBar.svelte`** — each group now filters + ranks by score (tie-broken by recency), and matched chars in the primary text render in `<mark class="cb-hl">` (amber token). Fuzzy runs over the **short fields only** (title/desig/repo name) so a short query can't subsequence-match nearly every long prompt.
- **Sessions also match on their `prompt` (description)** via a contiguous substring — a session surfaced *only* via its description shows a **"matches description"** affordance so its presence is explained. (Contiguous substring, not fuzzy, keeps it selective over long prompts.)
- **Blank query preserves today's behavior byte-for-byte** — it scores every row 0, so ordering falls back to recency exactly as before.

## Accessibility

`<mark>` split runs concatenate back to the original text, so each `role="option"`'s accessible name is unchanged — asserted by test. Highlight color is the `--color-amber` semantic token; the UA `<mark>` background is reset.

## Feature discovery

The command bar is still unreleased (same `1.41.0` train as its What's-New entry), so this folds into the existing `v1.41.0-command-bar` announcement — reworded body copy (EN+DE) + updated entry comment — rather than adding a redundant second card.

## Tests

- `ui/src/lib/fuzzy.test.ts` — 9 scorer unit tests.
- `CommandBar.browser.test.ts` — added fuzzy subsequence, best-match ordering (score beats recency), prompt-only inclusion + affordance, and highlight/accessible-name tests; renamed the substring test to `filters fuzzily…`.
- Full `ui` suite (2604 tests), `bun run check`, `check:i18n`, eslint, prettier, and the pre-push PR-hygiene gate all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)