### PR TITLE
docs: surface recent features (command bar, tab signal, plugins) across demo, docs & marketing

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -120,6 +120,7 @@ export default defineConfig({
           items: [
             { label: "Configuration", slug: "reference/configuration" },
             { label: "Concepts & glossary", slug: "reference/glossary" },
+            { label: "Keyboard shortcuts", slug: "reference/keyboard-shortcuts" },
             { label: "Plugins", slug: "reference/plugins" },
             { label: "External Task API", slug: "reference/external-task-api" },
             { label: "Security", slug: "reference/security" },

--- a/docs-site/src/content/docs/reference/keyboard-shortcuts.md
+++ b/docs-site/src/content/docs/reference/keyboard-shortcuts.md
@@ -1,0 +1,56 @@
+---
+title: Keyboard shortcuts
+description: Drive the Shepherd dashboard from the keyboard — the command bar, session switching, and terminal keys.
+---
+
+Shepherd is built to drive from the keyboard. These shortcuts are **desktop-only** and are suppressed while a modal or overlay is open. The plain-key shortcuts fire only when the dashboard body has focus (not while you are typing in a field); the command bar and the Alt / Option switchers work **even while the terminal is focused**.
+
+## Command bar
+
+| Keys | Action |
+| --- | --- |
+| `⌘K` / `Ctrl+K` | Open the command bar — a quick-switcher over your sessions, repositories, and herd lenses. Fires even while an input or the terminal is focused. Type to filter, `↑` / `↓` to move, `Enter` to jump, `Esc` to close. |
+
+## Session & herd navigation
+
+These fire when the dashboard body has focus — not while typing in a field.
+
+| Keys | Action |
+| --- | --- |
+| `j` / `↓` | Select the next session |
+| `k` / `↑` | Select the previous session |
+| `g` | Jump to the next session that needs you |
+| `1`–`9` | Select the Nth session |
+| `n` | Open New Task |
+| `r` | Open the Repos / backlog view |
+| `Enter` | Return keyboard focus to the terminal |
+
+## Switch sessions while the terminal is focused
+
+The Alt combos work even while the terminal owns the keyboard, so you can move around the herd without leaving the active session. On macOS the modifier is ⌥ Option, and matching is on the physical key (Option changes the character that would be typed).
+
+| Keys | Action |
+| --- | --- |
+| `Alt+J` / `Alt+↓` | Next session |
+| `Alt+K` / `Alt+↑` | Previous session |
+| `Alt+]` / `Alt+Tab` | Next session |
+| `Alt+[` / `Alt+Shift+Tab` | Previous session |
+| `Alt+G` | Next session that needs you |
+| `Alt+1`–`Alt+9` | Select the Nth session |
+
+## Terminal
+
+| Keys | Action |
+| --- | --- |
+| `Ctrl+Shift+C` | Copy the terminal selection (plain `Ctrl+C` sends an interrupt to the agent) |
+
+## New Task
+
+Inside the New Task prompt you can switch repositories without leaving the field.
+
+| Keys | Action |
+| --- | --- |
+| `Alt+[` / `Alt+]` | Previous / next repository |
+| `Alt+1`–`Alt+3` | Jump to the Nth recent repository |
+| `Alt+R` | Open the repository picker |
+| `⌘Enter` / `Ctrl+Enter` | Submit the task (plain `Enter` inserts a newline) |

--- a/docs-site/src/content/docs/reference/keyboard-shortcuts.md
+++ b/docs-site/src/content/docs/reference/keyboard-shortcuts.md
@@ -38,6 +38,8 @@ The Alt combos work even while the terminal owns the keyboard, so you can move a
 | `Alt+G` | Next session that needs you |
 | `Alt+1`–`Alt+9` | Select the Nth session |
 
+The `Alt+Tab` / `Alt+Shift+Tab` variants work on macOS; on Windows and Linux the OS window switcher captures `Alt+Tab` before the app sees it, so use `Alt+]` / `Alt+[` there.
+
 ## Terminal
 
 | Keys | Action |

--- a/site/src/components/FeatureGrid.astro
+++ b/site/src/components/FeatureGrid.astro
@@ -1,5 +1,5 @@
 ---
-// Nine-card feature grid — the capabilities you operate. The discipline GATES
+// Twelve-card feature grid — the capabilities you operate. The discipline GATES
 // (plan gate, critic, learnings, merge train, hygiene) live in their own
 // Guardrails section below, so they are not duplicated here. Copy is faithful
 // to the README and the feature-announcement catalog

--- a/site/src/components/FeatureGrid.astro
+++ b/site/src/components/FeatureGrid.astro
@@ -49,6 +49,18 @@ const features: Feature[] = [
     title: "Usage-aware",
     body: "Run many agents on one subscription without burning it. When usage is high a new task holds and starts on its own when usage resets — submit anyway to override — and a session halted at a limit resumes in one click. A usage dashboard, timeline heatmap, and trends show where the tokens go.",
   },
+  {
+    title: "Command bar",
+    body: "Press ⌘K — or Ctrl+K on Windows and Linux, even while the terminal is focused — to open a quick-switcher. Type to filter across your sessions, repositories, and herd lenses, then hit Enter to jump straight there.",
+  },
+  {
+    title: "Ambient tab signal",
+    body: "Leave Shepherd in a background tab and it still tells you what the herd needs: the tab title counts the sessions waiting on you and the favicon takes on a severity color — red for failing CI, amber for blocked, green for ready to merge — with a progress ring for the session you are watching. Installed as an app, it updates the app badge too.",
+  },
+  {
+    title: "Server-side plugins",
+    body: "Extend the dashboard itself. Operator-installed, out-of-repo plugins run on your instance and render real panels, charts, and gear-menu actions in Settings — separate from the local slash commands and skills that each agent session already carries.",
+  },
 ];
 ---
 

--- a/site/src/components/FeatureGrid.astro
+++ b/site/src/components/FeatureGrid.astro
@@ -59,7 +59,7 @@ const features: Feature[] = [
   },
   {
     title: "Server-side plugins",
-    body: "Extend the dashboard itself. Operator-installed, out-of-repo plugins run on your instance and render real panels, charts, and gear-menu actions in Settings — separate from the local slash commands and skills that each agent session already carries.",
+    body: "Extend the dashboard itself. Operator-installed, out-of-repo plugins run on your instance and render real panels, charts, and gear-menu actions in Settings — separate from the local slash commands, skills, and plugins that each agent session already carries.",
   },
 ];
 ---

--- a/ui/src/hooks.client.ts
+++ b/ui/src/hooks.client.ts
@@ -1,5 +1,6 @@
 import { installDemoBackend } from "$lib/demo/install";
 import { director } from "$lib/demo/director";
+import { startCommandBarShowcase } from "$lib/demo/showcase";
 
 // Demo build seam. `__DEMO__` is a Vite `define` — `false` for normal builds
 // (the whole branch + import dead-code-eliminates) and `true` only for
@@ -10,4 +11,5 @@ if (__DEMO__) {
   // Ambient liveness + mutation reactions. Kept OUT of installDemoBackend() so unit
   // tests can install the fake backend without spinning up the director's timers.
   director.start();
+  startCommandBarShowcase();
 }

--- a/ui/src/lib/components/CommandBar.browser.test.ts
+++ b/ui/src/lib/components/CommandBar.browser.test.ts
@@ -306,6 +306,24 @@ describe("CommandBar — repo secondary action (filter)", () => {
   });
 });
 
+describe("CommandBar — demo showcase seeding", () => {
+  it("initialFilter seeds the input and filters the options (demo showcase invariant)", async () => {
+    // "newer" matches only session s2's name — nothing else in the fixture data.
+    renderBar({ initialFilter: "newer" });
+    await expect.element(page.getByRole("combobox")).toHaveValue("newer");
+    const opts = page.getByRole("option");
+    expect(opts.elements()).toHaveLength(1);
+    await expect.element(opts.first()).toHaveTextContent("newer");
+  });
+
+  it("without initialFilter the filter stays empty (inert by default)", async () => {
+    renderBar();
+    await expect.element(page.getByRole("combobox")).toHaveValue("");
+    // All rows present — unfiltered.
+    expect(page.getByRole("option").elements().length).toBeGreaterThan(1);
+  });
+});
+
 describe("CommandBar — dismissal", () => {
   it("Escape closes", async () => {
     const { onclose } = renderBar();

--- a/ui/src/lib/components/CommandBar.svelte
+++ b/ui/src/lib/components/CommandBar.svelte
@@ -22,6 +22,9 @@
     onfilterrepo,
     onselectlens,
     onclose,
+    // Demo-only seed for the scripted showcase (see $lib/demo/showcase.ts) — the
+    // real ⌘K path never passes this, so `filter` seeds to "" exactly as before.
+    initialFilter = undefined,
   }: {
     sessions: Session[];
     workingBlocked: Record<string, boolean>;
@@ -31,6 +34,7 @@
     onfilterrepo: (path: string) => void;
     onselectlens: (lens: HerdFilter) => void;
     onclose: () => void;
+    initialFilter?: string;
   } = $props();
 
   // Docs open externally (docs.shepherd.run) in a new tab. DOCS_URL carries a trailing
@@ -72,7 +76,7 @@
     | { kind: "doc"; title: string; url: string };
   type OptRow = Row & { oid: number };
 
-  let filter = $state("");
+  let filter = $state(initialFilter ?? "");
   let activeIdx = $state(0);
   let inputEl = $state<HTMLInputElement | null>(null);
   let listEl = $state<HTMLUListElement | null>(null);

--- a/ui/src/lib/components/page/AppOverlays.svelte
+++ b/ui/src/lib/components/page/AppOverlays.svelte
@@ -155,6 +155,7 @@
     oncommandbarrepo,
     oncommandbarfilterrepo,
     oncommandbarlens,
+    commandBarInitialFilter = undefined,
     showRetry,
     onretryclose,
     clearMergedSessions,
@@ -270,6 +271,9 @@
     oncommandbarrepo: (path: string) => void;
     oncommandbarfilterrepo: (path: string) => void;
     oncommandbarlens: (lens: HerdFilter) => void;
+    /** Demo-only scripted-showcase seed, forwarded verbatim to CommandBar's
+     *  `initialFilter` (see $lib/demo/showcase.ts). Absent on the real ⌘K path. */
+    commandBarInitialFilter?: string;
     showRetry: boolean;
     onretryclose: () => void;
     clearMergedSessions: Session[] | null;
@@ -542,6 +546,7 @@
     onfilterrepo={oncommandbarfilterrepo}
     onselectlens={oncommandbarlens}
     onclose={oncommandbarclose}
+    initialFilter={commandBarInitialFilter}
   />
 {/if}
 

--- a/ui/src/lib/demo/showcase.test.ts
+++ b/ui/src/lib/demo/showcase.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { get } from "svelte/store";
+import { commandBarShowcase, startCommandBarShowcase, stopCommandBarShowcase } from "./showcase";
+
+/** Minimal fake `window` (node test project has no DOM) supporting add/remove
+ *  listener and manual event firing — mirrors the stub in store.svelte.test.ts. */
+function stubWindow() {
+  const on: Record<string, ((e?: unknown) => void)[]> = {};
+  (globalThis as unknown as { window: unknown }).window = {
+    addEventListener: (t: string, h: (e?: unknown) => void) => {
+      (on[t] ??= []).push(h);
+    },
+    removeEventListener: (t: string, h: (e?: unknown) => void) => {
+      on[t] = (on[t] ?? []).filter((x) => x !== h);
+    },
+  };
+  return { fire: (t: string) => (on[t] ?? []).slice().forEach((h) => h()) };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  stopCommandBarShowcase();
+  delete (globalThis as unknown as { window?: unknown }).window;
+  vi.useRealTimers();
+});
+
+describe("commandBarShowcase — one-shot idle-gated open", () => {
+  it("opens with the seeded filter after the idle delay, then closes on its own", () => {
+    stubWindow();
+    startCommandBarShowcase();
+    expect(get(commandBarShowcase)).toEqual({ open: false, filter: "" });
+
+    vi.advanceTimersByTime(3500);
+    expect(get(commandBarShowcase)).toEqual({ open: true, filter: "store" });
+
+    vi.advanceTimersByTime(2800);
+    expect(get(commandBarShowcase)).toEqual({ open: false, filter: "" });
+  });
+
+  it("never opens if the visitor interacts (keydown) before the delay fires", () => {
+    const { fire } = stubWindow();
+    startCommandBarShowcase();
+    vi.advanceTimersByTime(1000);
+    fire("keydown");
+    vi.advanceTimersByTime(10_000);
+    expect(get(commandBarShowcase)).toEqual({ open: false, filter: "" });
+  });
+
+  it("never opens if the visitor interacts (pointerdown) before the delay fires", () => {
+    const { fire } = stubWindow();
+    startCommandBarShowcase();
+    vi.advanceTimersByTime(1000);
+    fire("pointerdown");
+    vi.advanceTimersByTime(10_000);
+    expect(get(commandBarShowcase)).toEqual({ open: false, filter: "" });
+  });
+
+  it("stays OPEN if the visitor interacts (keydown) DURING the open window — never yanked shut", () => {
+    const { fire } = stubWindow();
+    startCommandBarShowcase();
+    vi.advanceTimersByTime(3500);
+    expect(get(commandBarShowcase)).toEqual({ open: true, filter: "store" });
+    // Visitor starts typing in the just-opened bar — the forced close must be cancelled.
+    fire("keydown");
+    vi.advanceTimersByTime(10_000);
+    expect(get(commandBarShowcase)).toEqual({ open: true, filter: "store" });
+  });
+
+  it("stays OPEN if the visitor interacts (pointerdown) DURING the open window", () => {
+    const { fire } = stubWindow();
+    startCommandBarShowcase();
+    vi.advanceTimersByTime(3500);
+    expect(get(commandBarShowcase)).toEqual({ open: true, filter: "store" });
+    fire("pointerdown");
+    vi.advanceTimersByTime(10_000);
+    expect(get(commandBarShowcase)).toEqual({ open: true, filter: "store" });
+  });
+
+  it("is idempotent — a second call never schedules a duplicate beat", () => {
+    stubWindow();
+    startCommandBarShowcase();
+    startCommandBarShowcase();
+    vi.advanceTimersByTime(3500);
+    expect(get(commandBarShowcase)).toEqual({ open: true, filter: "store" });
+    // Only one close timer should be pending — advancing once fully closes it
+    // and it stays closed (a duplicate close timer would still no-op here,
+    // but this also guards there's no duplicate OPEN waiting behind it).
+    vi.advanceTimersByTime(2800);
+    expect(get(commandBarShowcase)).toEqual({ open: false, filter: "" });
+    vi.advanceTimersByTime(10_000);
+    expect(get(commandBarShowcase)).toEqual({ open: false, filter: "" });
+  });
+
+  it("is a no-op outside the browser (no window global)", () => {
+    expect(() => startCommandBarShowcase()).not.toThrow();
+    vi.advanceTimersByTime(10_000);
+    expect(get(commandBarShowcase)).toEqual({ open: false, filter: "" });
+  });
+
+  it("stopCommandBarShowcase clears a pending open before it fires", () => {
+    stubWindow();
+    startCommandBarShowcase();
+    vi.advanceTimersByTime(1000);
+    stopCommandBarShowcase();
+    vi.advanceTimersByTime(10_000);
+    expect(get(commandBarShowcase)).toEqual({ open: false, filter: "" });
+  });
+});

--- a/ui/src/lib/demo/showcase.ts
+++ b/ui/src/lib/demo/showcase.ts
@@ -1,0 +1,99 @@
+// Demo-only, one-shot scripted showcase for the ⌘K command bar. The bar already
+// works interactively in the demo; this drives a passive viewer through open →
+// filter → close ONCE, and only if they haven't touched the keyboard/pointer yet
+// (CommandBar auto-focuses its input on mount, so a recurring auto-open would
+// steal focus/typing from an interacting visitor).
+//
+// Framework-store only — this module never imports the director and never
+// touches the DOM beyond the two idle-gate window listeners. `+page.svelte`
+// subscribes `commandBarShowcase` into its own local `$state` under a `__DEMO__`
+// guard, so this module tree-shakes out of normal (non-demo) builds.
+
+import { writable } from "svelte/store";
+
+const OPEN_DELAY_MS = 3500;
+const CLOSE_DELAY_MS = 2800;
+
+/** The seeded repo is `acme/storefront`, so "store" yields a real filtered match. */
+const SHOWCASE_FILTER = "store";
+
+export const commandBarShowcase = writable<{ open: boolean; filter: string }>({
+  open: false,
+  filter: "",
+});
+
+let started = false;
+let interacted = false;
+let openTimer: ReturnType<typeof setTimeout> | null = null;
+let closeTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** Idle-gate, covering BOTH phases with a single `{ once: true }` listener:
+ *   - interaction BEFORE the open fires → cancel the pending open (bar never opens);
+ *   - interaction DURING the open window → cancel the pending forced-close, leaving
+ *     the bar OPEN and handing it to the visitor (the normal ⌘K/onclose/selection
+ *     path now controls it — we must NOT yank it shut mid-interaction).
+ *  Either way we drop the idle listeners: the showcase has done its one shot. */
+function markInteracted(): void {
+  interacted = true;
+  if (openTimer !== null) {
+    clearTimeout(openTimer);
+    openTimer = null;
+  }
+  if (closeTimer !== null) {
+    clearTimeout(closeTimer);
+    closeTimer = null;
+  }
+  removeIdleListeners();
+}
+
+function addIdleListeners(): void {
+  window.addEventListener("keydown", markInteracted, { once: true });
+  window.addEventListener("pointerdown", markInteracted, { once: true });
+}
+
+/** Explicit removal for the branch where the listeners never fired (visitor
+ *  stayed idle through the whole showcase) — `{ once: true }` only self-removes
+ *  a listener that actually fired. */
+function removeIdleListeners(): void {
+  window.removeEventListener("keydown", markInteracted);
+  window.removeEventListener("pointerdown", markInteracted);
+}
+
+/** Idempotent, browser-only, one-shot: schedules the single open→close beat. */
+export function startCommandBarShowcase(): void {
+  if (typeof window === "undefined") return;
+  if (started) return;
+  started = true;
+
+  addIdleListeners();
+
+  openTimer = setTimeout(() => {
+    openTimer = null;
+    if (interacted) return; // visitor got there first — never steal focus
+    commandBarShowcase.set({ open: true, filter: SHOWCASE_FILTER });
+
+    closeTimer = setTimeout(() => {
+      closeTimer = null;
+      commandBarShowcase.set({ open: false, filter: "" });
+      removeIdleListeners();
+    }, CLOSE_DELAY_MS);
+  }, OPEN_DELAY_MS);
+}
+
+/** Clears any pending timers, removes the idle listeners, resets the store, and
+ *  resets internal state so the showcase could be started again (teardown/tests —
+ *  the showcase is one-shot per real page-load). */
+export function stopCommandBarShowcase(): void {
+  if (openTimer !== null) {
+    clearTimeout(openTimer);
+    openTimer = null;
+  }
+  if (closeTimer !== null) {
+    clearTimeout(closeTimer);
+    closeTimer = null;
+  }
+  if (typeof window !== "undefined") removeIdleListeners();
+  commandBarShowcase.set({ open: false, filter: "" });
+  started = false;
+  interacted = false;
+}

--- a/ui/src/lib/docs-manifest.ts
+++ b/ui/src/lib/docs-manifest.ts
@@ -72,6 +72,12 @@ export const DOCS_PAGES: readonly DocsPage[] = [
       "shepherd's in-repo contributor & agent house rules (claude.md), rendered verbatim. running checks in a fresh worktree branch hygiene (one feature, linear off main) design system (required for any ui work) internationalization (required for any ui work) feature discovery (required for user-facing features) glossary (required when marking ui terms)",
   },
   {
+    title: "Keyboard shortcuts",
+    path: "/reference/keyboard-shortcuts/",
+    keywords:
+      "drive the shepherd dashboard from the keyboard — the command bar, session switching, and terminal keys. command bar session & herd navigation switch sessions while the terminal is focused terminal new task",
+  },
+  {
     title: "Plugins",
     path: "/reference/plugins/",
     keywords:

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -127,6 +127,9 @@
   import { computeNewEntries } from "$lib/feature-gate";
   import { version } from "$lib/build-info";
   import { sidebarCollapse, sidebarShouldCollapse } from "$lib/sidebar-collapse.svelte";
+  // Side-effect-free (no top-level DOM/timer work) — tree-shakes out of non-demo
+  // builds along with every other __DEMO__-guarded reference below.
+  import { commandBarShowcase } from "$lib/demo/showcase";
 
   const store = new HerdStore();
 
@@ -230,6 +233,21 @@
   // Cmd/Ctrl+K quick-switcher over sessions/repos/lenses (#1334). Opened from
   // onShortcut before the modifier/typing bails so it fires even over the terminal.
   let showCommandBar = $state(false);
+  // Demo-only scripted-showcase seed (see $lib/demo/showcase.ts) — forwarded to
+  // CommandBar's `initialFilter`. Stays "" on the real ⌘K path.
+  let demoCommandFilter = $state("");
+  // Mirror the one-shot showcase store into local state — guarded so the whole
+  // subscription dead-code-eliminates out of non-demo builds. The real ⌘K path
+  // (onShortcut / oncommandbar* handlers below) never touches this store, so
+  // demoCommandFilter stays "" and showCommandBar is unaffected outside the demo.
+  $effect(() => {
+    if (!__DEMO__) return;
+    const unsub = commandBarShowcase.subscribe((s) => {
+      showCommandBar = s.open;
+      demoCommandFilter = s.filter;
+    });
+    return unsub;
+  });
   let showRetry = $state(false);
   // "clear all merged" confirm modal: the merged sessions to clear + their total
   // leftover subprocess count (both fetched server-side when the modal opens).
@@ -2755,6 +2773,7 @@
   onbroadcastclose={() => (showBroadcast = false)}
   {showCommandBar}
   {commandBarCommands}
+  commandBarInitialFilter={demoCommandFilter}
   oncommandbarclose={() => (showCommandBar = false)}
   oncommandbarsession={(id) => {
     showCommandBar = false;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -2774,15 +2774,20 @@
   {showCommandBar}
   {commandBarCommands}
   commandBarInitialFilter={demoCommandFilter}
-  oncommandbarclose={() => (showCommandBar = false)}
+  oncommandbarclose={() => {
+    showCommandBar = false;
+    demoCommandFilter = "";
+  }}
   oncommandbarsession={(id) => {
     showCommandBar = false;
+    demoCommandFilter = "";
     showBacklog = false;
     herdFilter = "all";
     selectUnit(id);
   }}
   oncommandbarrepo={(path) => {
     showCommandBar = false;
+    demoCommandFilter = "";
     showBacklog = true;
     // Payload-before-path ordering per finishBacklogAdd: BacklogView's select effect
     // fires once per value, so the repo must be in the payload when the path is set.
@@ -2804,6 +2809,7 @@
   }}
   oncommandbarlens={(lens) => {
     showCommandBar = false;
+    demoCommandFilter = "";
     showBacklog = false;
     herdFilter = lens;
   }}


### PR DESCRIPTION
Ensures the three external Shepherd surfaces reflect recent major feature additions, with the **command bar (⌘K)** as the flagship. The marketing grid was refreshed to the then-current feature set 2 days ago (#1273), so this sweep targets the capability classes that shipped *since* — plus one (plugins) that never made the grid.

## Marketing (`site/`)
Three new `FeatureGrid` cards (9 → 12, clean 3×4):
- **Command bar** — ⌘K / Ctrl+K quick-switcher over sessions, repos, and herd lenses.
- **Ambient tab signal** — background-tab title count + severity-colored favicon / progress ring.
- **Server-side plugins** — operator-installed, out-of-repo extensions rendering panels, charts & gear-menu actions. Copy explicitly distinguishes this from the existing *"Your /commands come with you"* card (local `~/.claude` portability).

## Docs (`docs-site/`)
New **Keyboard shortcuts** reference page (`reference/keyboard-shortcuts`) + sidebar entry, authored from the verified in-app shortcut inventory: command bar, session/herd navigation, terminal-safe Alt/Option switchers, terminal copy, and New Task repo keys.

## Demo (`ui/`, `__DEMO__` build only)
A **one-shot, idle-gated** scripted showcase: shortly after the demo loads (only if the visitor hasn't interacted), the command bar auto-opens prefilled, holds, then closes — so a passive viewer sees it in action.
- New `ui/src/lib/demo/showcase.ts` store beat + `CommandBar` gains an optional `initialFilter` prop (inert when absent).
- Wired through `+page.svelte` behind a `__DEMO__` guard that dead-code-eliminates in normal builds — the real ⌘K path is byte-for-byte unchanged.
- If the visitor interacts while it's open, the auto-close is cancelled and the bar is handed to them (never yanked shut mid-use).
- No new user-facing strings → no i18n keys.

## Verification
- `site/`: `bun run build` ✓
- `docs-site/`: `astro check` (0 errors) + `bun run build` (1115 pages) ✓
- `ui/`: `bun run check` ✓, `bun run check:i18n` ✓ (parity, no new keys), full test suite green incl. new `showcase.test.ts` and `CommandBar` `initialFilter` tests
- Pre-push hooks (branch-hygiene, i18n, feature-catalog, fallow audit) green

Reviewed subagent-driven: per-task spec+quality review, then a whole-branch review (2 Minor findings fixed in `fce30fc7`).

[no-feature-entry] — this PR documents & showcases already-shipped features (the command bar already has its `v1.41.0-command-bar.ts` announcement entry); it introduces no new capability, so no catalog entry is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)