### PR TITLE
feat(ui): filter session list from command bar repo results

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2362,5 +2362,8 @@
   "commandbar_cmd_next_needs_you_kw": "wartend blockiert aufmerksamkeit",
   "feat_command_bar_v2_title": "Befehlsleiste führt jetzt Befehle aus und durchsucht die Doku",
   "feat_command_bar_v2_body": "⌘K/Strg+K kann mehr als nur zwischen Sessions springen. Eine Gruppe „Befehle“ führt Verben aus — Neue Aufgabe, Broadcast, Einstellungen, Nutzung, Erneut versuchen, Zur nächsten Session springen, die dich braucht — und eine Gruppe „Doku“ durchsucht die Dokumentation und öffnet die Seite in einem neuen Tab. Tippe einfach, was du tun möchtest.",
-  "commandbar_prompt_match": "passt zur Beschreibung"
+  "commandbar_prompt_match": "passt zur Beschreibung",
+  "commandbar_repo_filter_affordance": "⇧↵ filtern",
+  "feat_command_bar_repo_filter_title": "Sitzungen aus der Befehlsleiste filtern",
+  "feat_command_bar_repo_filter_body": "Wähle in der Befehlsleiste ein Repository aus und drücke dann ⇧↵ (oder ⌘/Strg+↵), um die Sitzungsliste auf die aktiven Sitzungen dieses Repos zu filtern. Mit einfachem ↵ öffnest du weiterhin sein Backlog."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2362,5 +2362,8 @@
   "commandbar_cmd_next_needs_you_kw": "waiting blocked attention",
   "feat_command_bar_v2_title": "Command bar now runs commands and searches docs",
   "feat_command_bar_v2_body": "⌘K/Ctrl+K does more than jump between sessions now. A Commands group runs verbs — New task, Broadcast, Settings, Usage, Retry, Jump to next needs-you — and a Docs group searches the documentation and opens the page in a new tab. Just start typing what you want to do.",
-  "commandbar_prompt_match": "matches description"
+  "commandbar_prompt_match": "matches description",
+  "commandbar_repo_filter_affordance": "⇧↵ filter",
+  "feat_command_bar_repo_filter_title": "Filter sessions from the command bar",
+  "feat_command_bar_repo_filter_body": "Pick a repository in the command bar, then press ⇧↵ (or ⌘/Ctrl+↵) to filter the session list to that repo's active sessions. Plain ↵ still opens its backlog."
 }

--- a/ui/src/lib/components/CommandBar.browser.test.ts
+++ b/ui/src/lib/components/CommandBar.browser.test.ts
@@ -58,11 +58,15 @@ function session(partial: Partial<Session> & { id: string }): Session {
 }
 
 function seedRepos(): RepoEntry[] {
-  // beta has the higher lastUsedAt → sorts before alpha.
+  // beta has the higher lastUsedAt → sorts before alpha. gamma has NO live session
+  // (no seedSessions entry references it), so its filter affordance/action is inert.
   return [
     {
+      // Symlinked repo root: entry path differs from realPath. session s1.repoPath is
+      // the realpath'd form ("/repos/alpha"), matching realPath — so the filter action
+      // must key on realPath, while the backlog (onselectrepo) keys on the raw path.
       name: "alpha",
-      path: "/repos/alpha",
+      path: "/repos/alpha-link",
       display: "~/repos/alpha",
       realPath: "/repos/alpha",
       lastUsedAt: 100,
@@ -73,6 +77,13 @@ function seedRepos(): RepoEntry[] {
       display: "~/repos/beta",
       realPath: "/repos/beta",
       lastUsedAt: 200,
+    },
+    {
+      name: "gamma",
+      path: "/repos/gamma",
+      display: "~/repos/gamma",
+      realPath: "/repos/gamma",
+      lastUsedAt: 50,
     },
   ];
 }
@@ -88,6 +99,7 @@ function seedSessions(): Session[] {
 function renderBar(overrides: Partial<Parameters<typeof CommandBar>[1]> = {}) {
   const onselectsession = vi.fn();
   const onselectrepo = vi.fn();
+  const onfilterrepo = vi.fn();
   const onselectlens = vi.fn();
   const onclose = vi.fn();
   render(CommandBar, {
@@ -96,11 +108,12 @@ function renderBar(overrides: Partial<Parameters<typeof CommandBar>[1]> = {}) {
     commands: [],
     onselectsession,
     onselectrepo,
+    onfilterrepo,
     onselectlens,
     onclose,
     ...overrides,
   });
-  return { onselectsession, onselectrepo, onselectlens, onclose };
+  return { onselectsession, onselectrepo, onfilterrepo, onselectlens, onclose };
 }
 
 beforeEach(() => {
@@ -206,6 +219,90 @@ describe("CommandBar — selection", () => {
     const { onselectlens } = renderBar();
     await page.getByRole("option", { name: new RegExp(m.herd_seg_owed()) }).click();
     expect(onselectlens).toHaveBeenCalledWith("owed");
+  });
+});
+
+describe("CommandBar — repo secondary action (filter)", () => {
+  // options at rest: [s2, s1, (Repos header), beta, alpha, gamma, (Lenses header)…].
+  // Two ArrowDowns from idx0 lands on beta (idx2) — a repo WITH a live session.
+  it("Shift+Enter on a live-session repo filters instead of selecting", async () => {
+    const { onfilterrepo, onselectrepo } = renderBar();
+    await page.getByRole("combobox").click();
+    await userEvent.keyboard("{ArrowDown}{ArrowDown}");
+    await userEvent.keyboard("{Shift>}{Enter}{/Shift}");
+    expect(onfilterrepo).toHaveBeenCalledWith("/repos/beta");
+    expect(onselectrepo).not.toHaveBeenCalled();
+  });
+
+  it("Cmd+Enter on a live-session repo filters", async () => {
+    const { onfilterrepo, onselectrepo } = renderBar();
+    await page.getByRole("combobox").click();
+    await userEvent.keyboard("{ArrowDown}{ArrowDown}");
+    await userEvent.keyboard("{Meta>}{Enter}{/Meta}");
+    expect(onfilterrepo).toHaveBeenCalledWith("/repos/beta");
+    expect(onselectrepo).not.toHaveBeenCalled();
+  });
+
+  it("Ctrl+Enter on a live-session repo filters", async () => {
+    const { onfilterrepo, onselectrepo } = renderBar();
+    await page.getByRole("combobox").click();
+    await userEvent.keyboard("{ArrowDown}{ArrowDown}");
+    await userEvent.keyboard("{Control>}{Enter}{/Control}");
+    expect(onfilterrepo).toHaveBeenCalledWith("/repos/beta");
+    expect(onselectrepo).not.toHaveBeenCalled();
+  });
+
+  it("plain Enter on a repo still selects it (opens backlog), never filters", async () => {
+    const { onselectrepo, onfilterrepo } = renderBar();
+    await page.getByRole("combobox").click();
+    await userEvent.keyboard("{ArrowDown}{ArrowDown}{Enter}");
+    expect(onselectrepo).toHaveBeenCalledWith("/repos/beta");
+    expect(onfilterrepo).not.toHaveBeenCalled();
+  });
+
+  // gamma (idx4) has no live session → the modifier is inert and falls back to select.
+  it("Shift+Enter on a session-less repo falls back to selecting", async () => {
+    const { onselectrepo, onfilterrepo } = renderBar();
+    await page.getByRole("combobox").click();
+    await userEvent.keyboard("{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}");
+    await userEvent.keyboard("{Shift>}{Enter}{/Shift}");
+    expect(onselectrepo).toHaveBeenCalledWith("/repos/gamma");
+    expect(onfilterrepo).not.toHaveBeenCalled();
+  });
+
+  // alpha (idx3) is a symlinked repo: entry path "/repos/alpha-link" ≠ realPath
+  // "/repos/alpha", and s1.repoPath is the realpath'd "/repos/alpha". The filter must
+  // apply the realPath (what the herd repoFilter compares against), not the raw path.
+  it("filters on the realPath for a symlinked repo root", async () => {
+    const { onfilterrepo, onselectrepo } = renderBar();
+    await page.getByRole("combobox").click();
+    await userEvent.keyboard("{ArrowDown}{ArrowDown}{ArrowDown}");
+    await userEvent.keyboard("{Shift>}{Enter}{/Shift}");
+    expect(onfilterrepo).toHaveBeenCalledWith("/repos/alpha");
+    expect(onselectrepo).not.toHaveBeenCalled();
+  });
+
+  it("still opens the backlog on the raw path for a symlinked repo root", async () => {
+    const { onselectrepo, onfilterrepo } = renderBar();
+    await page.getByRole("combobox").click();
+    await userEvent.keyboard("{ArrowDown}{ArrowDown}{ArrowDown}{Enter}");
+    expect(onselectrepo).toHaveBeenCalledWith("/repos/alpha-link");
+    expect(onfilterrepo).not.toHaveBeenCalled();
+  });
+
+  it("shows the filter hint on live-session repos but not on session-less ones", async () => {
+    renderBar();
+    // A live repo (beta) row carries both the "Repository" label and the ⇧↵ hint.
+    await page.getByRole("combobox").fill("beta");
+    const betaRow = page.getByRole("option", {
+      name: new RegExp(m.commandbar_repo_affordance()),
+    });
+    await expect.element(betaRow).toHaveTextContent(m.commandbar_repo_filter_affordance());
+    // The session-less repo (gamma) keeps "Repository" but shows no filter hint.
+    await page.getByRole("combobox").fill("gamma");
+    const gammaRow = page.getByRole("option").first();
+    await expect.element(gammaRow).toHaveTextContent(m.commandbar_repo_affordance());
+    expect(gammaRow.element().textContent).not.toContain(m.commandbar_repo_filter_affordance());
   });
 });
 

--- a/ui/src/lib/components/CommandBar.svelte
+++ b/ui/src/lib/components/CommandBar.svelte
@@ -19,6 +19,7 @@
     commands,
     onselectsession,
     onselectrepo,
+    onfilterrepo,
     onselectlens,
     onclose,
   }: {
@@ -27,6 +28,7 @@
     commands: Command[];
     onselectsession: (id: string) => void;
     onselectrepo: (path: string) => void;
+    onfilterrepo: (path: string) => void;
     onselectlens: (lens: HerdFilter) => void;
     onclose: () => void;
   } = $props();
@@ -53,7 +55,18 @@
         // match — drives the "matches description" affordance so the row isn't unexplained.
         promptMatch: boolean;
       }
-    | { kind: "repo"; path: string; name: string; display: string; hl: number[] }
+    | {
+        kind: "repo";
+        // `path` is the raw entry path (backlog is keyed on it); `realPath` is the
+        // realpath'd form that session.repoPath / the herd repoFilter use — they differ
+        // for a symlinked repo root, so the filter action keys on realPath, backlog on path.
+        path: string;
+        realPath: string;
+        name: string;
+        display: string;
+        hl: number[];
+        hasLiveSession: boolean;
+      }
     | { kind: "lens"; lens: HerdFilter; label: string; icon: string; hl: number[] }
     | { kind: "command"; id: string; label: string; run: () => void }
     | { kind: "doc"; title: string; url: string };
@@ -112,6 +125,14 @@
       })),
   );
 
+  // A repo can be filtered onto the session list only if it has a live (non-archived)
+  // session — same liveness rule as repoChipRows. Filtering a session-less repo would be
+  // auto-cleared by the page (shouldClearRepoFilter) and strand an empty herd, so the
+  // secondary action + its hint are gated on this. Keyed on session.repoPath (the
+  // realpath'd form), so the repo lookup below must compare r.realPath, not r.path.
+  const liveRepoPaths = $derived(
+    new Set(sessions.filter((s) => s.status !== "archived").map((s) => s.repoPath)),
+  );
   const repoRows = $derived<Row[]>(
     repos.entries
       .map((r) => ({ r, res: fuzzyScore(q, r.name + " " + r.display) }))
@@ -120,9 +141,11 @@
       .map(({ r, res }) => ({
         kind: "repo",
         path: r.path,
+        realPath: r.realPath,
         name: r.name,
         display: r.display,
         hl: res!.positions.filter((p) => p < r.name.length),
+        hasLiveSession: liveRepoPaths.has(r.realPath),
       })),
   );
 
@@ -232,10 +255,18 @@
     return out;
   }
 
-  function selectOption(row: OptRow) {
+  // `secondary` (a modifier held with Enter/click) picks a row's secondary verb. Today
+  // only repo rows have one — filter the session list to that repo — and only when it has
+  // a live session; every other row (and a session-less repo) ignores the modifier and
+  // runs its primary action.
+  function selectOption(row: OptRow, secondary = false) {
     if (row.kind === "session") onselectsession(row.id);
-    else if (row.kind === "repo") onselectrepo(row.path);
-    else if (row.kind === "lens") onselectlens(row.lens);
+    else if (row.kind === "repo") {
+      // Filter keys on realPath (matches session.repoPath / herd repoFilter); backlog
+      // keys on the raw path.
+      if (secondary && row.hasLiveSession) onfilterrepo(row.realPath);
+      else onselectrepo(row.path);
+    } else if (row.kind === "lens") onselectlens(row.lens);
     else if (row.kind === "command") {
       // run() mutates page state (opens an overlay / jumps); the bar closes itself since
       // firing the verb doesn't flip showCommandBar the way the navigation callbacks do.
@@ -268,7 +299,8 @@
       case "Enter": {
         e.preventDefault();
         const row = options[activeIdx];
-        if (row) selectOption(row);
+        // Shift / Cmd / Ctrl + Enter fires the row's secondary action (repo → filter).
+        if (row) selectOption(row, e.shiftKey || e.metaKey || e.ctrlKey);
         break;
       }
       // Escape is handled by use:dialog (focus-trap + onclose).
@@ -337,9 +369,10 @@
             role="option"
             aria-selected={row.oid === activeIdx}
             tabindex="-1"
-            onclick={() => selectOption(row)}
+            onclick={(e) => selectOption(row, e.shiftKey || e.metaKey || e.ctrlKey)}
             onkeydown={(e) => {
-              if (e.key === "Enter" || e.key === " ") selectOption(row);
+              if (e.key === "Enter") selectOption(row, e.shiftKey || e.metaKey || e.ctrlKey);
+              else if (e.key === " ") selectOption(row);
             }}
           >
             {#if row.kind === "session"}
@@ -356,6 +389,11 @@
               <span class="cb-ic" aria-hidden="true">{projectIcons.iconFor(row.path) ?? "▣"}</span>
               <b class="cb-primary">{@render primary(row.name, row.hl)}</b>
               <span class="cb-sub">{row.display} · {m.commandbar_repo_affordance()}</span>
+              {#if row.hasLiveSession}
+                <!-- Secondary-action hint. Separate non-shrinking element so a long
+                     display path truncates .cb-sub, never this discoverability cue. -->
+                <span class="cb-hint">{m.commandbar_repo_filter_affordance()}</span>
+              {/if}
             {:else if row.kind === "lens"}
               <span class="cb-ic" aria-hidden="true">{row.icon}</span>
               <b class="cb-primary">{@render primary(row.label, row.hl)}</b>
@@ -512,6 +550,16 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     min-width: 0;
+  }
+
+  /* Secondary-action cue, pinned to the row's right edge and never clipped —
+     margin-left:auto pushes it right, flex-shrink:0 protects it when .cb-sub truncates. */
+  .cb-hint {
+    flex-shrink: 0;
+    margin-left: auto;
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+    white-space: nowrap;
   }
 
   .cb-empty {

--- a/ui/src/lib/components/page/AppOverlays.browser.test.ts
+++ b/ui/src/lib/components/page/AppOverlays.browser.test.ts
@@ -100,6 +100,7 @@ function baseProps(): Props {
     oncommandbarclose: vi.fn(),
     oncommandbarsession: vi.fn(),
     oncommandbarrepo: vi.fn(),
+    oncommandbarfilterrepo: vi.fn(),
     oncommandbarlens: vi.fn(),
     showRetry: false,
     onretryclose: vi.fn(),

--- a/ui/src/lib/components/page/AppOverlays.svelte
+++ b/ui/src/lib/components/page/AppOverlays.svelte
@@ -153,6 +153,7 @@
     oncommandbarclose,
     oncommandbarsession,
     oncommandbarrepo,
+    oncommandbarfilterrepo,
     oncommandbarlens,
     showRetry,
     onretryclose,
@@ -267,6 +268,7 @@
     oncommandbarclose: () => void;
     oncommandbarsession: (id: string) => void;
     oncommandbarrepo: (path: string) => void;
+    oncommandbarfilterrepo: (path: string) => void;
     oncommandbarlens: (lens: HerdFilter) => void;
     showRetry: boolean;
     onretryclose: () => void;
@@ -537,6 +539,7 @@
     commands={commandBarCommands}
     onselectsession={oncommandbarsession}
     onselectrepo={oncommandbarrepo}
+    onfilterrepo={oncommandbarfilterrepo}
     onselectlens={oncommandbarlens}
     onclose={oncommandbarclose}
   />

--- a/ui/src/lib/feature-announcements/entries/v1.41.0-command-bar-repo-filter.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.41.0-command-bar-repo-filter.ts
@@ -1,0 +1,15 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // Secondary command-bar action (#1338 follow-up): ⇧↵ / ⌘/Ctrl+↵ on a repository
+  // result filters the session list to that repo (the same repoFilter the RepoSwitcher
+  // chips drive), while plain ↵ keeps opening its backlog. Offered only for repos with
+  // a live session, so the announcement body scopes the claim to "active sessions".
+  // No targetId — the command bar's only opener is the ⌘/Ctrl+K chord, no stable anchor.
+  id: "command-bar-repo-filter",
+  sinceVersion: "1.41.0",
+  titleKey: "feat_command_bar_repo_filter_title",
+  bodyKey: "feat_command_bar_repo_filter_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -2774,6 +2774,15 @@
       })
       .catch(() => {});
   }}
+  oncommandbarfilterrepo={(path) => {
+    // Secondary repo action: scope the herd to this repo (same state the RepoSwitcher
+    // chips drive). Close the bar + backlog so the filtered session list is visible;
+    // the repoFilter effect re-targets selection onto a session in the repo. Only fired
+    // for repos with a live session, so shouldClearRepoFilter won't immediately null it.
+    showCommandBar = false;
+    showBacklog = false;
+    repoFilter = path;
+  }}
   oncommandbarlens={(lens) => {
     showCommandBar = false;
     showBacklog = false;


### PR DESCRIPTION
## What

Adds a **secondary action** to repository results in the command bar (⌘/Ctrl+K).

- **Plain ↵** — unchanged: opens the repo's per-repo **Backlog** overlay.
- **⇧↵ / ⌘↵ / Ctrl↵** — new: applies the repo as the herd `repoFilter` (the same
  state the RepoSwitcher chips drive), scoping the session list to that repo. The
  bar and backlog close so the filtered herd is visible, and the existing
  `repoFilter` effect re-targets terminal selection onto a session in that repo.

## Why gated on a live session

An existing effect (`shouldClearRepoFilter`, `+page.svelte`) auto-clears
`repoFilter` when the target repo has no live (non-archived) session — filtering to
a session-less repo would strand an empty herd with no clearing chip. So the
secondary action is offered **only** for repos that currently have a live session
(`hasLiveSession`, same liveness rule as `repoChipRows`). Session-less repos ignore
the modifier and fall back to opening the backlog.

## Discoverability

Every repo row keeps its `Repository` sub-label (the primary-action signal). Live
rows additionally show a `⇧↵ filter` hint as a **separate, right-pinned,
non-shrinking** element (`.cb-hint`), so a long display path truncates the
sub-label — never the hint. Session-less rows show no hint, which is what signals
the modifier is inert there. No touch affordance is needed: the bar's only opener
is the ⌘/Ctrl+K chord, so every user of it has a keyboard.

## Notes

- New i18n keys (EN + DE parity): `commandbar_repo_filter_affordance`,
  `feat_command_bar_repo_filter_title/body`. The announcement body scopes the claim
  to a repo's *active sessions* so it doesn't over-promise for session-less repos.
- Feature-announcement entry `v1.41.0-command-bar-repo-filter.ts` added (feature
  discovery catalog).

## Testing

- `cd ui && bun run check` — 0 errors, `bun run check:i18n` — parity (2365 keys).
- `bun run test:browser` (868) + `test:node` (1771) pass, incl. new CommandBar
  cases: ⇧/⌘/Ctrl+Enter filter a live repo, plain Enter still selects, modifier on
  a session-less repo falls back to select, and the hint shows only on live rows.
- PR-hygiene gates (branch hygiene, announcement versions, feature catalog) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)