### PR TITLE
feat(ui): hold Alt to jump to command-bar results by number

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2368,5 +2368,7 @@
   "topbar_search": "Suchen",
   "topbar_search_aria": "Suchen oder Befehl ausführen",
   "feat_command_bar_search_field_title": "Suche in der oberen Leiste",
-  "feat_command_bar_search_field_body": "Die Befehlsleiste hat jetzt ein Suchfeld in der oberen Leiste mit einem ⌘K / Strg-K-Kürzel. Dokumentation und Erkenntnisse sind dorthin umgezogen — durchsuche die Dokumente und öffne Erkenntnisse direkt aus der Leiste."
+  "feat_command_bar_search_field_body": "Die Befehlsleiste hat jetzt ein Suchfeld in der oberen Leiste mit einem ⌘K / Strg-K-Kürzel. Dokumentation und Erkenntnisse sind dorthin umgezogen — durchsuche die Dokumente und öffne Erkenntnisse direkt aus der Leiste.",
+  "feat_command_bar_jump_title": "Mit Alt zu Befehlsleisten-Ergebnissen springen",
+  "feat_command_bar_jump_body": "Halte bei geöffneter Befehlsleiste Alt gedrückt, um Ziffernhinweise (1–9, dann 0) auf den ersten zehn Ergebnissen einzublenden, und drücke dann die Ziffer, um direkt dorthin zu springen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2368,5 +2368,7 @@
   "topbar_search": "Search",
   "topbar_search_aria": "Search or run a command",
   "feat_command_bar_search_field_title": "Search from the top bar",
-  "feat_command_bar_search_field_body": "The command bar now has a search field in the top bar with a ⌘K / Ctrl K shortcut. Documentation and Learnings live inside it — search the docs and open Learnings straight from the bar."
+  "feat_command_bar_search_field_body": "The command bar now has a search field in the top bar with a ⌘K / Ctrl K shortcut. Documentation and Learnings live inside it — search the docs and open Learnings straight from the bar.",
+  "feat_command_bar_jump_title": "Jump to command-bar results with Alt",
+  "feat_command_bar_jump_body": "Hold Alt with the command bar open to reveal number hints (1–9, then 0) on the first ten results, then press the digit to jump straight to it."
 }

--- a/ui/src/lib/components/CommandBar.browser.test.ts
+++ b/ui/src/lib/components/CommandBar.browser.test.ts
@@ -488,6 +488,24 @@ describe("CommandBar — Alt+digit quick-jump", () => {
     expect(onselectlens).toHaveBeenCalledWith("rundown");
   });
 
+  it("jumps regardless of focused element — e.g. Alt+1 from the ✕ button", async () => {
+    // Reveal is window-scoped, so the jump is too: it must fire even when focus is on a
+    // non-input element inside the dialog (here the close button), not only the search field.
+    const { onselectsession, onclose } = renderBar();
+    const closeBtn = document.querySelector("button.x") as HTMLButtonElement;
+    closeBtn.focus();
+    closeBtn.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        code: "Digit1",
+        altKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    expect(onselectsession).toHaveBeenCalledWith("s2");
+    expect(onclose).not.toHaveBeenCalled();
+  });
+
   it("on an empty result set, Alt+digit is preventDefaulted and fires nothing", async () => {
     // With no rows, the combo must still be swallowed so no macOS Option-glyph leaks into the
     // field. A manual dispatch lets us read defaultPrevented directly.

--- a/ui/src/lib/components/CommandBar.browser.test.ts
+++ b/ui/src/lib/components/CommandBar.browser.test.ts
@@ -437,3 +437,84 @@ describe("CommandBar — All lens", () => {
     expect(onselectlens).toHaveBeenCalledWith("all");
   });
 });
+
+describe("CommandBar — Alt+digit quick-jump", () => {
+  // Seeded open state = eleven selectable rows; only the first ten (oid 0–9) get a digit badge:
+  //   0 s2 "newer" · 1 s1 "older" · 2 beta · 3 alpha · 4 gamma · 5 all · 6 next · 7 ready ·
+  //   8 done · 9 rundown · (10 owed — beyond the tenth, no badge)
+  it("reveals digit hints on the first ten rows only while Alt is held", async () => {
+    renderBar();
+    await page.getByRole("combobox").click();
+    expect(document.querySelectorAll(".cb-kbd")).toHaveLength(0);
+
+    await userEvent.keyboard("{Alt>}");
+    await vi.waitFor(() =>
+      expect([...document.querySelectorAll(".cb-kbd")].map((b) => b.textContent)).toEqual([
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "0",
+      ]),
+    );
+    await userEvent.keyboard("{/Alt}");
+    await vi.waitFor(() => expect(document.querySelectorAll(".cb-kbd")).toHaveLength(0));
+  });
+
+  it("Alt+1 opens the most-recent session via onselectsession", async () => {
+    const { onselectsession } = renderBar();
+    await page.getByRole("combobox").click();
+    await userEvent.keyboard("{Alt>}1{/Alt}");
+    expect(onselectsession).toHaveBeenCalledWith("s2");
+  });
+
+  it("Alt+3 jumps to the first repo via onselectrepo", async () => {
+    const { onselectrepo, onselectsession } = renderBar();
+    await page.getByRole("combobox").click();
+    await userEvent.keyboard("{Alt>}3{/Alt}");
+    expect(onselectrepo).toHaveBeenCalledWith("/repos/beta");
+    expect(onselectsession).not.toHaveBeenCalled();
+  });
+
+  it("Alt+0 jumps to the tenth row (rundown lens) via onselectlens", async () => {
+    const { onselectlens } = renderBar();
+    await page.getByRole("combobox").click();
+    await userEvent.keyboard("{Alt>}0{/Alt}");
+    expect(onselectlens).toHaveBeenCalledWith("rundown");
+  });
+
+  it("on an empty result set, Alt+digit is preventDefaulted and fires nothing", async () => {
+    // With no rows, the combo must still be swallowed so no macOS Option-glyph leaks into the
+    // field. A manual dispatch lets us read defaultPrevented directly.
+    const { onselectlens, onselectsession, onselectrepo } = renderBar();
+    await page.getByRole("combobox").fill("zzzznomatch");
+    await expect.element(page.getByText(m.commandbar_no_matches())).toBeVisible();
+    const input = document.querySelector(".cb-input") as HTMLInputElement;
+    const ev = new KeyboardEvent("keydown", {
+      code: "Digit5",
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    input.dispatchEvent(ev);
+    expect(ev.defaultPrevented).toBe(true);
+    expect(onselectlens).not.toHaveBeenCalled();
+    expect(onselectsession).not.toHaveBeenCalled();
+    expect(onselectrepo).not.toHaveBeenCalled();
+  });
+
+  it("exposes each shortcut to assistive tech via aria-keyshortcuts", async () => {
+    renderBar();
+    await expect.element(page.getByRole("option").first()).toBeVisible();
+    const rows = [...document.querySelectorAll(".cb-row")];
+    expect(rows[0].getAttribute("aria-keyshortcuts")).toBe("Alt+1");
+    expect(rows[9].getAttribute("aria-keyshortcuts")).toBe("Alt+0");
+    // The eleventh row is past the tenth — no shortcut, no badge.
+    expect(rows[10].getAttribute("aria-keyshortcuts")).toBeNull();
+  });
+});

--- a/ui/src/lib/components/CommandBar.svelte
+++ b/ui/src/lib/components/CommandBar.svelte
@@ -296,16 +296,6 @@
   }
 
   function onKey(e: KeyboardEvent) {
-    // Alt+digit quick-jump — handled BEFORE the empty-list guard so the combo is always
-    // swallowed (preventDefault), suppressing the macOS Option-glyph even when there is no
-    // row to jump to. Activates options[i] (Enter-equivalent) only when that row exists.
-    const jump = jumpDigitIndex(e);
-    if (jump !== null) {
-      e.preventDefault();
-      const row = options[jump];
-      if (row) selectOption(row);
-      return;
-    }
     if (options.length === 0) return;
     switch (e.key) {
       case "ArrowDown":
@@ -329,15 +319,34 @@
     }
   }
 
-  // Reveal/hide the digit hints as Alt is pressed/released. keydown & keyup both carry the
-  // live modifier state via getModifierState, so a single handler covers both edges (including
-  // the case where Alt is pressed with the search field focused).
-  function syncAltHeld(e: KeyboardEvent) {
+  // Reveal/hide the digit hints as Alt is pressed/released, AND run the Alt+digit jump — both
+  // at window scope so reveal and action cover the same focus states: the jump fires no matter
+  // which element inside the focus-trapped dialog holds focus (search field, a row, or the ✕
+  // button), matching the window-scoped hint reveal. The combo is always preventDefault-ed
+  // (suppressing the macOS Option-glyph) even with no row to jump to; activation is
+  // Enter-equivalent only when options[jump] exists. Safe globally while the bar is open:
+  // +page's own Alt+1-9 session-switch bails on anyOverlayOpen() (which includes the command
+  // bar), so there is no double action. keydown/keyup both carry the live modifier via
+  // getModifierState; window blur resets it so a held Alt can't stick when focus leaves the tab.
+  function onWindowKeydown(e: KeyboardEvent) {
+    altHeld = e.getModifierState("Alt");
+    const jump = jumpDigitIndex(e);
+    if (jump !== null) {
+      e.preventDefault();
+      const row = options[jump];
+      if (row) selectOption(row);
+    }
+  }
+  function onWindowKeyup(e: KeyboardEvent) {
     altHeld = e.getModifierState("Alt");
   }
 </script>
 
-<svelte:window onkeydown={syncAltHeld} onkeyup={syncAltHeld} onblur={() => (altHeld = false)} />
+<svelte:window
+  onkeydown={onWindowKeydown}
+  onkeyup={onWindowKeyup}
+  onblur={() => (altHeld = false)}
+/>
 
 <!-- Primary text with fuzzy-matched chars wrapped in <mark> for highlighting. Shared by the
      fuzzy-matched navigation rows (session / repo / lens); the split runs concatenate back to

--- a/ui/src/lib/components/CommandBar.svelte
+++ b/ui/src/lib/components/CommandBar.svelte
@@ -11,6 +11,7 @@
   import { DOCS_PAGES } from "$lib/docs-manifest";
   import type { Command } from "$lib/command-registry";
   import { fuzzyScore } from "$lib/fuzzy";
+  import { jumpDigitIndex } from "$lib/components/herd-keynav";
   import { m } from "$lib/paraglide/messages";
 
   let {
@@ -80,6 +81,13 @@
   let activeIdx = $state(0);
   let inputEl = $state<HTMLInputElement | null>(null);
   let listEl = $state<HTMLUListElement | null>(null);
+  // True while Alt is held — reveals the digit jump-hints on the first ten rows. Alt is the
+  // browser-viable substitute for the requested Cmd/Ctrl+digit (which the browser reserves for
+  // tab-switch / reset-zoom). Tracked off keyboard/blur events since the DOM can't be polled
+  // for modifier state; window blur resets it so a held Alt can't get stuck when the user
+  // switches apps mid-hold. Only the first ten rows (oid 0–9) get a hint.
+  let altHeld = $state(false);
+  const HINT_LABELS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"];
 
   const q = $derived(filter.trim().toLowerCase());
 
@@ -288,6 +296,16 @@
   }
 
   function onKey(e: KeyboardEvent) {
+    // Alt+digit quick-jump — handled BEFORE the empty-list guard so the combo is always
+    // swallowed (preventDefault), suppressing the macOS Option-glyph even when there is no
+    // row to jump to. Activates options[i] (Enter-equivalent) only when that row exists.
+    const jump = jumpDigitIndex(e);
+    if (jump !== null) {
+      e.preventDefault();
+      const row = options[jump];
+      if (row) selectOption(row);
+      return;
+    }
     if (options.length === 0) return;
     switch (e.key) {
       case "ArrowDown":
@@ -310,7 +328,16 @@
       // Escape is handled by use:dialog (focus-trap + onclose).
     }
   }
+
+  // Reveal/hide the digit hints as Alt is pressed/released. keydown & keyup both carry the
+  // live modifier state via getModifierState, so a single handler covers both edges (including
+  // the case where Alt is pressed with the search field focused).
+  function syncAltHeld(e: KeyboardEvent) {
+    altHeld = e.getModifierState("Alt");
+  }
 </script>
+
+<svelte:window onkeydown={syncAltHeld} onkeyup={syncAltHeld} onblur={() => (altHeld = false)} />
 
 <!-- Primary text with fuzzy-matched chars wrapped in <mark> for highlighting. Shared by the
      fuzzy-matched navigation rows (session / repo / lens); the split runs concatenate back to
@@ -372,6 +399,7 @@
             class:kbd-active={row.oid === activeIdx}
             role="option"
             aria-selected={row.oid === activeIdx}
+            aria-keyshortcuts={row.oid < 10 ? `Alt+${HINT_LABELS[row.oid]}` : undefined}
             tabindex="-1"
             onclick={(e) => selectOption(row, e.shiftKey || e.metaKey || e.ctrlKey)}
             onkeydown={(e) => {
@@ -408,6 +436,11 @@
               <span class="cb-ic" aria-hidden="true">📄</span>
               <b class="cb-primary">{row.title}</b>
               <span class="cb-sub">{m.commandbar_docs_affordance()}</span>
+            {/if}
+            <!-- Digit jump-hint, first ten rows only, revealed while Alt is held. Decorative
+                 (aria-hidden) — the shortcut is exposed to AT via the row's aria-keyshortcuts. -->
+            {#if row.oid < 10 && altHeld}
+              <kbd class="cb-kbd" aria-hidden="true">{HINT_LABELS[row.oid]}</kbd>
             {/if}
           </li>
         {/each}
@@ -564,6 +597,31 @@
     color: var(--color-muted);
     font-size: var(--fs-meta);
     white-space: nowrap;
+  }
+
+  /* Digit jump-hint badge — pinned to the row's trailing edge, after the .cb-hint cue when
+     both are present. --fs-meta is below the 16px body floor, the same precedented exception as
+     .cb-sub: this is a keyboard-shortcut affordance (and aria-hidden), not body copy. Uses the
+     :last-child margin-left:auto so a row with BOTH a .cb-hint and a badge doesn't split the
+     free space across two auto margins. Token-only per the design system. */
+  .cb-kbd {
+    flex-shrink: 0;
+    font: inherit;
+    font-size: var(--fs-meta);
+    line-height: 1;
+    color: var(--color-muted);
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    padding: 3px 7px;
+    min-width: 1.5em;
+    text-align: center;
+  }
+  /* Only push off free space when the badge is the first trailing element — i.e. no .cb-hint
+     already claimed the auto-margin (session / lens / doc rows). On a repo row the .cb-hint
+     owns margin-left:auto and the badge just follows it flush. */
+  .cb-kbd:not(.cb-hint + .cb-kbd) {
+    margin-left: auto;
   }
 
   .cb-empty {

--- a/ui/src/lib/components/herd-keynav.test.ts
+++ b/ui/src/lib/components/herd-keynav.test.ts
@@ -6,6 +6,7 @@ import {
   nextNeedsYou,
   nextNeedsYouTarget,
   altComboKey,
+  jumpDigitIndex,
 } from "./herd-keynav";
 import type { Session, GitState, Epic, EpicChild, SessionStatus } from "$lib/types";
 
@@ -350,4 +351,59 @@ test("altComboKey returns null for non-combo codes", () => {
   expect(altComboKey("Numpad1")).toBeNull();
   expect(altComboKey("Escape")).toBeNull();
   expect(altComboKey("")).toBeNull();
+});
+
+// jumpDigitIndex — command-bar Alt+digit → 0-based result index
+
+function altDigit(
+  code: string,
+  mods: Partial<Pick<KeyboardEvent, "altKey" | "ctrlKey" | "metaKey" | "shiftKey">> = {},
+): KeyboardEvent {
+  // Only the fields jumpDigitIndex reads; `key` intentionally differs from `code` to prove
+  // the helper keys off physical `e.code` (macOS Option+1 emits "¡", not "1").
+  return {
+    code,
+    key: code === "Digit1" ? "¡" : code,
+    altKey: true,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    ...mods,
+  } as KeyboardEvent;
+}
+
+test("jumpDigitIndex maps Alt+Digit1–9 to indices 0–8", () => {
+  for (let n = 1; n <= 9; n++) {
+    expect(jumpDigitIndex(altDigit(`Digit${n}`))).toBe(n - 1);
+  }
+});
+
+test("jumpDigitIndex maps Alt+Digit0 to index 9 (the tenth row)", () => {
+  expect(jumpDigitIndex(altDigit("Digit0"))).toBe(9);
+});
+
+test("jumpDigitIndex keys off physical e.code, not e.key (macOS Option glyph)", () => {
+  // Alt+1 on a US Mac layout reports key "¡" but code "Digit1".
+  const e = altDigit("Digit1");
+  expect(e.key).toBe("¡");
+  expect(jumpDigitIndex(e)).toBe(0);
+});
+
+test("jumpDigitIndex rejects Numpad digits (Windows alt-code input method)", () => {
+  for (let n = 0; n <= 9; n++) {
+    expect(jumpDigitIndex(altDigit(`Numpad${n}`))).toBeNull();
+  }
+});
+
+test("jumpDigitIndex requires Alt with no other modifier", () => {
+  expect(jumpDigitIndex(altDigit("Digit1", { altKey: false }))).toBeNull();
+  expect(jumpDigitIndex(altDigit("Digit1", { ctrlKey: true }))).toBeNull();
+  expect(jumpDigitIndex(altDigit("Digit1", { metaKey: true }))).toBeNull();
+  expect(jumpDigitIndex(altDigit("Digit1", { shiftKey: true }))).toBeNull();
+});
+
+test("jumpDigitIndex returns null for non-digit codes", () => {
+  expect(jumpDigitIndex(altDigit("KeyA"))).toBeNull();
+  expect(jumpDigitIndex(altDigit("Enter"))).toBeNull();
+  expect(jumpDigitIndex(altDigit("Minus"))).toBeNull();
 });

--- a/ui/src/lib/components/herd-keynav.ts
+++ b/ui/src/lib/components/herd-keynav.ts
@@ -97,6 +97,27 @@ export function altComboKey(code: string): string | null {
   return null;
 }
 
+/** Command-bar quick-jump: maps an `Alt`+digit KeyboardEvent to the 0-based index of the
+ *  result row to activate, or null when the event is not a bare `Alt`+`Digit` combo.
+ *
+ *  `Digit1`–`Digit9` → 0–8 and `Digit0` → 9 (the tenth row), so the on-screen hints read
+ *  1…9,0. Strict single-Alt — Ctrl/Meta/Shift must all be absent — so it never collides with
+ *  the Cmd/Ctrl+K open chord or any Shift-modified combo. Matches on physical `e.code`, not
+ *  `e.key`, because macOS Option+1 emits "¡" (and other layouts vary).
+ *
+ *  `Numpad0`–`Numpad9` are deliberately NOT accepted — the same reason altComboKey drops them:
+ *  `Alt`+Numpad is the Windows alt-code text-input method, and `e.code` reports Numpad*
+ *  regardless of NumLock, so accepting them would shadow OS alt-code entry. Cmd/Ctrl+digit was
+ *  the originally-requested chord but is impossible in a browser (1–9 switch tabs, 0 resets
+ *  zoom, all non-cancellable), so `Alt` is the single-modifier substitute. */
+export function jumpDigitIndex(e: KeyboardEvent): number | null {
+  if (!e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return null;
+  const m = /^Digit([0-9])$/.exec(e.code);
+  if (!m) return null;
+  const d = Number(m[1]);
+  return d === 0 ? 9 : d - 1;
+}
+
 /** Next blocked session after `currentId` in `blockedIds` (oldest-first, the
  *  NEEDS-YOU set), wrapping around; cycles among several, skips the current one.
  *  Null when none are blocked or the only blocked session is already selected. */

--- a/ui/src/lib/feature-announcements/entries/v1.41.0-command-bar-jump.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.41.0-command-bar-jump.ts
@@ -1,0 +1,15 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // Command-bar Alt+digit quick-jump: hold Alt with the command bar open to reveal 1–9,0 hints
+  // on the first ten results, then press the digit to jump straight to it. (Cmd/Ctrl+digit is
+  // browser-reserved for tab-switch/reset-zoom, so Alt is the single-modifier substitute.)
+  // 1.40.0 is the latest released tag, so this ships in 1.41.0. No targetId — the command bar
+  // opens via a chord and has no persistent anchor to arm a Coachmark on; What's-New only.
+  id: "command-bar-jump",
+  sinceVersion: "1.41.0",
+  titleKey: "feat_command_bar_jump_title",
+  bodyKey: "feat_command_bar_jump_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## What

Hold **Alt** with the command bar open to reveal one-digit shortcut hints (**1–9, then 0**) on the first ten results. Keep Alt held and press the digit to jump straight to that result — the same effect as arrowing to it and pressing Enter (navigate a session/repo/lens, run a command, open a doc).

![behaviour] Hints appear only while Alt is held; releasing Alt (or the window losing focus) hides them.

## Why Alt, not the requested Cmd/Ctrl

The original request was `Cmd/Ctrl + digit`. That is **impossible in a browser**: `Cmd/Ctrl + 1…9` switch browser tabs and `Cmd/Ctrl + 0` resets zoom, and browsers make these **non-cancellable** — `preventDefault()` can't stop them ([Mozilla 1052569](https://bugzilla.mozilla.org/show_bug.cgi?id=1052569), [Chrome Help](https://support.google.com/chrome/thread/163238070)). There is no viable digit subset.

`Alt+digit` is the single-modifier substitute — same hold-and-press ergonomics, and it's **already the app's idiom** (`Alt+1-9` = switch session in `+page.svelte`, suppressed while overlays are open via `anyOverlayOpen()`, so there's no conflict inside the bar). The alternative `Cmd/Ctrl+Shift+digit` was rejected: two-key hold, and on macOS `Cmd+Shift+3/4/5` are OS screenshot shortcuts that would break results 3–5.

> **Decision note:** the modifier (Alt vs Cmd/Ctrl+Shift) was posed to the operator twice via the plan gate; both times AFK, so the plan-recommended **Alt** default was taken on plan approval. Flag if you'd prefer Cmd/Ctrl+Shift — the swap is isolated to `jumpDigitIndex` + the reveal key + the badge label.

## How

- New pure helper `jumpDigitIndex(e)` in `herd-keynav.ts` (beside `isCommandBarChord`/`altComboKey`): maps a bare-Alt `Digit0-9` event → index `0..9` (`0`→10th), else `null`. Matches on **physical `e.code`** (macOS `Option+1` emits `"¡"`), strict single-Alt, and **excludes `Numpad`** for the same reason `altComboKey` does (Alt+Numpad is the Windows alt-code input method).
- `CommandBar.svelte`: `<svelte:window>` tracks Alt-held (with a `blur` reset so it can't stick); `onKey` handles the jump **before** the empty-list early return, so the combo is always `preventDefault`ed (no leaked macOS Option-glyph) even with zero results.
- Digit badges render on the first ten rows only while Alt is held; badges are `aria-hidden`, with the shortcut exposed to assistive tech via `aria-keyshortcuts` on each row.

## a11y waiver (please confirm)

The digit badge renders at `--fs-meta` (below the 16px body-text floor) — the **same precedented exception already used by `.cb-sub`**. It's a keyboard-shortcut affordance (and `aria-hidden`), not body copy. Token-only, no raw colors/sizes.

## Testing

- `jumpDigitIndex` unit tests: all digits (incl. `0`→9), `Numpad→null`, macOS symbol-key regression (`e.key="¡"` still maps via `e.code`), modifier-exclusivity.
- `CommandBar.browser.test.ts` (real chromium): hints reveal only while Alt held (1–9,0), `Alt+1`→session / `Alt+3`→repo / `Alt+0`→10th lens via the **real** `onselect*` callbacks, empty-set `Alt+digit` is `preventDefault`ed and fires nothing, and `aria-keyshortcuts` present.
- Full suite green: `bun run check`, `check:i18n` (EN+DE parity), root ESLint/Prettier, `2659` UI tests. Feature-catalog + announcement-version + branch-hygiene gates pass. Announcement entry `v1.41.0-command-bar-jump` added.

**Note (not a blocking manual step):** the macOS `Option+digit`-glyph suppression path can't be exercised on the Linux CI/dev box; the `preventDefault` that handles it is covered by tests, but a real-mac spot-check is worth a reviewer's minute if one's handy.