### PR TITLE
fix(up-next): recompute after start once the claim label lands

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2256,6 +2256,7 @@ const appDeps: AppDeps = {
   upNext: {
     snapshot: () => upNext.snapshot(),
     refresh: () => upNext.refresh(),
+    recomputeUntilCleared: (started) => upNext.recomputeUntilCleared(started),
     hiddenRepoPathsRaw: () =>
       reconcileRealPathsToRaw(store.hiddenRepoPaths(), listRepos(config.repoRoot)),
   },

--- a/src/server.ts
+++ b/src/server.ts
@@ -361,6 +361,12 @@ export interface AppDeps {
   upNext?: {
     snapshot(): UpNextSnapshot | null;
     refresh(): Promise<UpNextSnapshot>;
+    /** Recompute (guaranteed-fresh, verify-and-retry) until the just-started items drop from
+     *  the lens — i.e. their `shepherd:active` claim labels have landed. Backgrounded by the
+     *  caller so it never blocks the start response. */
+    recomputeUntilCleared(
+      started: readonly { repoPath: string; issueNumber: number }[],
+    ): Promise<void>;
     /** Raw-path-space hidden set (reconciled), applied at read time for instant freshness. */
     hiddenRepoPathsRaw(): Set<string>;
   };
@@ -858,6 +864,11 @@ interface UpNextStartItem {
   issueRef: { number: number; url: string; title: string; body: string };
 }
 
+/** Cap on how long the backgrounded post-start recompute waits for the claim label writes
+ *  to settle before recomputing anyway — a hung `gh` must not stall it (verify-and-retry and
+ *  the 15-min interval loop still backstop). */
+const CLAIM_SETTLE_TIMEOUT_MS = 8_000;
+
 /** Validate the POST /api/up-next/start body into safe, repo-scoped start items. */
 function parseUpNextStartItems(body: unknown): UpNextStartItem[] | null {
   const itemsRaw = (body as { items?: unknown } | null)?.items;
@@ -896,6 +907,8 @@ async function handleUpNextStart(req: Request, deps: AppDeps): Promise<Response>
 
   const created: Session[] = [];
   const errors: { number: number; error: string }[] = [];
+  const claims: Promise<void>[] = [];
+  const startedRefs: { repoPath: string; issueNumber: number }[] = [];
   // Strictly serial — concurrent `git worktree add` on the same repo would contend.
   await startSerially(items, async (it) => {
     const forge = deps.resolveForge?.(it.dir) ?? null;
@@ -923,7 +936,10 @@ async function handleUpNextStart(req: Request, deps: AppDeps): Promise<Response>
       created.push(s);
       deps.events.emit("session:new", s);
       // Stamp the drain claim so the board reflects it's being worked (mirrors New Task).
-      void claimLinkedIssue(forge, it.issueRef.number);
+      // Keep the handle so the post-start recompute can wait for the label write to land
+      // before re-reading issues — an immediate refresh re-surfaces the just-started item.
+      claims.push(claimLinkedIssue(forge, it.issueRef.number));
+      startedRefs.push({ repoPath: it.dir, issueNumber: it.issueRef.number });
     } catch (e) {
       errors.push({
         number: it.issueRef.number,
@@ -932,9 +948,20 @@ async function handleUpNextStart(req: Request, deps: AppDeps): Promise<Response>
     }
   });
 
-  // Drop the just-started items from the lens promptly.
-  if (deps.upNext)
-    void deps.upNext.refresh().catch((err) => console.warn("[up-next] post-start:", err));
+  // Drop the just-started items from the lens promptly. Backgrounded (never blocks this
+  // response, which already paid for the serial worktree creates): wait for the claim label
+  // writes to return — behind a timeout guard so a hung `gh` can't stall it — then
+  // verify-and-retry recompute until the items clear (handles read-after-write lag).
+  if (deps.upNext && startedRefs.length > 0) {
+    const up = deps.upNext;
+    void (async () => {
+      await Promise.race([
+        Promise.allSettled(claims),
+        new Promise<void>((r) => setTimeout(r, CLAIM_SETTLE_TIMEOUT_MS).unref?.()),
+      ]);
+      await up.recomputeUntilCleared(startedRefs);
+    })().catch((err) => console.warn("[up-next] post-start:", err));
+  }
   return json({ created, errors }, created.length > 0 ? 201 : 502);
 }
 

--- a/src/up-next.ts
+++ b/src/up-next.ts
@@ -4,6 +4,7 @@
 // fan-out shape (mapBounded, ~6 concurrent) and the REAL epic pipeline (drain.buildEpic +
 // selectEpicCandidates) so epic readiness gates on store session/integration/claim/PR facts,
 // never on raw listIssues (which lacks them and would mis-gate).
+import { realpathSync } from "node:fs";
 import { mapBounded } from "./map-bounded";
 import { parseEpicBody } from "./epic-parse";
 import { selectEpicCandidates, type Epic, type EpicRun } from "./epic-core";
@@ -68,10 +69,26 @@ export interface UpNextDeps {
   now?: () => number;
   concurrency?: number;
   intervalMs?: number;
+  /** Backoff (ms) between post-start recompute attempts; first is immediate. See
+   *  `recomputeUntilCleared`. Injectable so tests can drive the loop with tiny delays. */
+  postStartRetryDelaysMs?: number[];
+  /** realpath resolver, injectable for tests. Used only to reconcile started-item paths
+   *  (safeRepoDir/realpath space) against snapshot paths (raw listRepos space). */
+  realpath?: (p: string) => string;
+}
+
+/** A just-started item, keyed for the post-start membership check. `repoPath` is in
+ *  safeRepoDir/realpath space (as `handleUpNextStart` produces via `safeRepoDir`). */
+export interface PostStartRef {
+  repoPath: string;
+  issueNumber: number;
 }
 
 const DEFAULT_CONCURRENCY = 6;
 const DEFAULT_INTERVAL_MS = 15 * 60_000;
+/** Immediate first attempt (claim writes have already settled by the caller), then two
+ *  retries covering GitHub read-after-write lag; ~10s worst case, vs the 15-min interval. */
+const DEFAULT_POST_START_RETRY_DELAYS = [0, 3_000, 7_000];
 
 /** Spawn items strictly one-at-a-time (never overlapping). WorktreeMgr.create() uses
  *  synchronous `git worktree add` and is NOT parallel-safe per repo — concurrent spawns
@@ -93,11 +110,15 @@ export class UpNextService {
   private readonly now: () => number;
   private readonly concurrency: number;
   private readonly intervalMs: number;
+  private readonly postStartRetryDelays: number[];
+  private readonly realpath: (p: string) => string;
 
   constructor(private deps: UpNextDeps) {
     this.now = deps.now ?? (() => Date.now());
     this.concurrency = deps.concurrency ?? DEFAULT_CONCURRENCY;
     this.intervalMs = deps.intervalMs ?? DEFAULT_INTERVAL_MS;
+    this.postStartRetryDelays = deps.postStartRetryDelaysMs ?? DEFAULT_POST_START_RETRY_DELAYS;
+    this.realpath = deps.realpath ?? realpathSync;
   }
 
   snapshot(): UpNextSnapshot | null {
@@ -130,6 +151,63 @@ export class UpNextService {
       console.warn("[up-next] onChange:", err);
     }
     return snap;
+  }
+
+  /** A recompute guaranteed to START after this call. `refresh` is single-flight, so a bare
+   *  call could join a compute that began BEFORE a just-written claim label landed (a 15-min
+   *  tick or a GET-triggered refresh) and cache that stale snapshot. We await any in-flight
+   *  compute first, then start a fresh one — which also makes our push land AFTER the stale
+   *  one, so a pre-existing compute can't re-show a cleared item. */
+  private async recompute(): Promise<UpNextSnapshot> {
+    if (this.inFlight) await this.inFlight.catch(() => {});
+    return this.refresh();
+  }
+
+  /** Does the snapshot still list any of the just-started items? Reconciles path-space:
+   *  `started` carry safeRepoDir/realpath paths, while snapshot items carry raw
+   *  join(repoRoot,name) paths (see buildUpNextRepos). Under a symlinked repoRoot these
+   *  differ, so we map real→raw via the current repo set (mirrors reconcileRealPathsToRaw)
+   *  and match on (raw repoPath, issue number) — number alone collides across repos. */
+  private stillPresent(snap: UpNextSnapshot, started: readonly PostStartRef[]): boolean {
+    const rawByReal = new Map<string, string>();
+    for (const r of this.deps.listForgeRepos()) {
+      try {
+        rawByReal.set(this.realpath(r.repoPath), r.repoPath);
+      } catch {
+        // vanished/broken path — can't be reconciled, skip it
+      }
+    }
+    const wanted = started.map((s) => ({
+      repoPath: rawByReal.get(s.repoPath) ?? s.repoPath,
+      number: s.issueNumber,
+    }));
+    return snap.sections.some((sec) =>
+      sec.items.some((it) =>
+        wanted.some((w) => w.repoPath === it.repoPath && w.number === it.issueRef.number),
+      ),
+    );
+  }
+
+  /** Recompute (guaranteed-fresh) until none of `started` appear in the snapshot — their
+   *  claim labels have landed and propagated — or the bounded attempts run out (then the
+   *  15-min interval loop is the backstop). Fixes the post-start staleness where an immediate
+   *  refresh re-read issues before the fire-and-forget `shepherd:active` label landed and
+   *  re-surfaced the just-started item. Backgrounded by the caller — never blocks the response. */
+  async recomputeUntilCleared(started: readonly PostStartRef[]): Promise<void> {
+    if (started.length === 0) return;
+    for (let i = 0; i < this.postStartRetryDelays.length; i++) {
+      const delay = this.postStartRetryDelays[i]!;
+      if (delay > 0) await new Promise<void>((r) => setTimeout(r, delay).unref?.());
+      try {
+        const snap = await this.recompute();
+        if (!this.stillPresent(snap, started)) return;
+      } catch (err) {
+        // A transient compute failure (e.g. a briefly-locked store dep) must NOT abort the
+        // remaining attempts — retrying past a hiccup is the whole point. Log and try again;
+        // the 15-min interval loop backstops if every attempt fails.
+        console.warn("[up-next] post-start recompute attempt failed:", err);
+      }
+    }
   }
 
   private async resolveRepo(

--- a/test/server-up-next.test.ts
+++ b/test/server-up-next.test.ts
@@ -37,6 +37,7 @@ function harness(
   const store = new SessionStore(":memory:");
   const createCalls: Array<{ at: number; repoPath: string; number: number | undefined }> = [];
   const labelCalls: number[] = [];
+  const recomputeCalls: Array<Array<{ repoPath: string; issueNumber: number }>> = [];
   let refreshCalls = 0;
   let n = 0;
   const deps: AppDeps = {
@@ -64,10 +65,19 @@ function harness(
         refreshCalls++;
         return SNAP;
       },
+      recomputeUntilCleared: async (started) => {
+        recomputeCalls.push(started.map((s) => ({ ...s })));
+      },
       hiddenRepoPathsRaw: opts.hiddenRepoPathsRaw ?? (() => new Set<string>()),
     },
   };
-  return { app: makeApp(deps), createCalls, labelCalls, refreshCalls: () => refreshCalls };
+  return {
+    app: makeApp(deps),
+    createCalls,
+    labelCalls,
+    refreshCalls: () => refreshCalls,
+    recomputeCalls,
+  };
 }
 
 const startReq = (items: unknown) =>
@@ -110,10 +120,22 @@ test("POST /api/up-next/start spawns one session and stamps the claim", async ()
   expect(body.errors).toHaveLength(0);
   expect(createCalls).toHaveLength(1);
   expect(createCalls[0]!.number).toBe(7);
-  // claim is stamped asynchronously (setTimeout 0 inside claimLinkedIssue's caller is not used
-  // here — we call it directly), so it should have recorded #7.
+  // claim is stamped asynchronously, so it should have recorded #7.
   await new Promise((r) => setTimeout(r, 5));
   expect(labelCalls).toContain(7);
+});
+
+test("POST /api/up-next/start recomputes the lens via recomputeUntilCleared (not an immediate refresh)", async () => {
+  const { app, refreshCalls, recomputeCalls } = harness();
+  const res = await app.fetch(
+    startReq([{ repoPath: repoDir, issueRef: { number: 7, url: "u", title: "t", body: "b" } }]),
+  );
+  expect(res.status).toBe(201);
+  // The recompute is backgrounded behind the claim-settle race — let it run.
+  await new Promise((r) => setTimeout(r, 20));
+  expect(refreshCalls()).toBe(0); // no stale immediate refresh
+  expect(recomputeCalls).toHaveLength(1);
+  expect(recomputeCalls[0]).toEqual([{ repoPath: repoDir, issueNumber: 7 }]);
 });
 
 test("POST /api/up-next/start serializes multiple spawns (no overlap)", async () => {

--- a/test/up-next.test.ts
+++ b/test/up-next.test.ts
@@ -154,6 +154,120 @@ describe("UpNextService.refresh", () => {
   });
 });
 
+describe("UpNextService.recomputeUntilCleared", () => {
+  test("(a) clears after one compute when the started issue is absent", async () => {
+    let computes = 0;
+    const s = svc({
+      resolveForge: () => fakeForge({ issues: [issue(2)] }),
+      onChange: () => computes++,
+      postStartRetryDelaysMs: [0, 1, 1],
+    });
+    await s.recomputeUntilCleared([{ repoPath: "/r/a", issueNumber: 1 }]);
+    expect(computes).toBe(1); // #1 not in the snapshot → done on attempt 1
+  });
+
+  test("(b) retries then succeeds once the label lands", async () => {
+    let calls = 0;
+    let computes = 0;
+    const s = svc({
+      // #1 present on the first read (label not landed), gone afterwards.
+      resolveForge: () =>
+        fakeForge({ listIssues: async () => (++calls === 1 ? [issue(1), issue(2)] : [issue(2)]) }),
+      onChange: () => computes++,
+      postStartRetryDelaysMs: [0, 1, 1],
+    });
+    await s.recomputeUntilCleared([{ repoPath: "/r/a", issueNumber: 1 }]);
+    expect(computes).toBe(2); // attempt 1 still shows #1, attempt 2 cleared
+  });
+
+  test("(c) bounded — gives up after the configured attempts if it never clears", async () => {
+    let computes = 0;
+    const s = svc({
+      resolveForge: () => fakeForge({ issues: [issue(1), issue(2)] }), // #1 always present
+      onChange: () => computes++,
+      postStartRetryDelaysMs: [0, 1, 1],
+    });
+    await s.recomputeUntilCleared([{ repoPath: "/r/a", issueNumber: 1 }]);
+    expect(computes).toBe(3); // exactly delays.length attempts, then stop (15-min loop backstops)
+  });
+
+  test("(d) non-coalescing — starts a fresh compute after an in-flight one", async () => {
+    let computes = 0;
+    const s = svc({
+      // Slow read so the initial refresh() is still in flight when recomputeUntilCleared runs.
+      resolveForge: () =>
+        fakeForge({
+          listIssues: async () => {
+            await new Promise((r) => setTimeout(r, 10));
+            return [issue(2)];
+          },
+        }),
+      onChange: () => computes++,
+      postStartRetryDelaysMs: [0],
+    });
+    const inflight = s.refresh(); // compute #1 begins (single-flight, in flight)
+    await s.recomputeUntilCleared([{ repoPath: "/r/a", issueNumber: 1 }]); // must not join #1
+    await inflight;
+    expect(computes).toBe(2); // joined would be 1; a fresh post-call compute makes it 2
+  });
+
+  test("(e) reconciles realpath (started) vs raw (snapshot) path-space under a symlinked root", async () => {
+    let computes = 0;
+    const s = svc({
+      // Snapshot items carry the RAW listRepos path…
+      listForgeRepos: () => [{ repoPath: "/raw/a", repoSlug: "o/a", repoLabel: "a" }],
+      resolveForge: () => fakeForge({ issues: [issue(1)] }),
+      // …while realpath maps that raw path to a DIFFERENT real path (symlinked repoRoot).
+      realpath: (p) => (p === "/raw/a" ? "/real/a" : p),
+      onChange: () => computes++,
+      postStartRetryDelaysMs: [0, 1],
+    });
+    // The started ref is in realpath space (as safeRepoDir produces). Naive equality against
+    // the raw snapshot path would miss it and wrongly clear on attempt 1; reconciliation must
+    // detect it as present and retry (both attempts still show #1 → 2 computes).
+    await s.recomputeUntilCleared([{ repoPath: "/real/a", issueNumber: 1 }]);
+    expect(computes).toBe(2);
+  });
+
+  test("(e-control) identity path-space (raw == real) also matches", async () => {
+    let computes = 0;
+    const s = svc({
+      listForgeRepos: () => [{ repoPath: "/raw/a", repoSlug: "o/a", repoLabel: "a" }],
+      resolveForge: () => fakeForge({ issues: [issue(1)] }),
+      realpath: (p) => p, // no symlink
+      onChange: () => computes++,
+      postStartRetryDelaysMs: [0, 1],
+    });
+    await s.recomputeUntilCleared([{ repoPath: "/raw/a", issueNumber: 1 }]);
+    expect(computes).toBe(2); // present both attempts
+  });
+
+  test("(g) a transient compute throw does not abort the remaining retries", async () => {
+    let lastUsedCalls = 0;
+    let computes = 0;
+    const s = svc({
+      // Throw on the first compute (simulates a briefly-locked store dep), succeed after.
+      lastUsedByRepo: () => {
+        if (++lastUsedCalls === 1) throw new Error("db locked");
+        return {};
+      },
+      resolveForge: () => fakeForge({ issues: [issue(2)] }), // #1 absent once compute succeeds
+      onChange: () => computes++,
+      postStartRetryDelaysMs: [0, 1, 1],
+    });
+    // Must not reject; attempt 1 throws (caught) → attempt 2 computes and clears.
+    await s.recomputeUntilCleared([{ repoPath: "/r/a", issueNumber: 1 }]);
+    expect(computes).toBe(1); // onChange fires only on the successful compute
+  });
+
+  test("(f) no started refs → no compute", async () => {
+    let computes = 0;
+    const s = svc({ onChange: () => computes++, postStartRetryDelaysMs: [0, 1] });
+    await s.recomputeUntilCleared([]);
+    expect(computes).toBe(0);
+  });
+});
+
 describe("startSerially", () => {
   test("never overlaps spawns (max concurrency 1)", async () => {
     let active = 0;


### PR DESCRIPTION
## Problem

After starting task(s) from the **Up Next** lens, its contents went stale: the just-started items lingered until the next 15-min interval tick, a manual refresh, or a lens re-open.

**Root cause (async write/read race).** `handleUpNextStart` stamped the `shepherd:active` exclusion label **fire-and-forget** (`void claimLinkedIssue(...)`, an async two-`gh`-subprocess write) and then kicked `void deps.upNext.refresh()` in the **same tick**. `compute()` re-read issues via an uncached `gh issue list` *before* the label landed, so `isExcludedIssue()` didn't filter the item and it re-surfaced in the pushed snapshot. (The `execFileSync` comments elsewhere in `server.ts` are stale — `addIssueLabel` is async via `promisify(execFile)`.)

## Fix

Replace the immediate refresh with a **backgrounded, guaranteed-fresh, verify-and-retry** recompute owned by `UpNextService`:

- **Await the claim writes first** (behind an 8s timeout guard so a hung `gh` can't stall it) — makes the common case need exactly one recompute.
- **`recomputeUntilCleared(startedRefs)`** recomputes until none of the started items appear in the snapshot, or the bounded attempts (`[0, 3s, 7s]`) run out. Keying on *the item being gone* — not elapsed time — handles GitHub read-after-write lag; a single blind delay beaten by lag would fall back to the 15-min tick (the original bug).
- **Non-coalescing recompute** — awaits any in-flight compute (a 15-min tick / GET refresh that may predate the claim) then starts a fresh one, so a stale in-flight compute can't cache a pre-label snapshot or re-show a cleared item.
- **Path-space reconciliation** — started refs carry `safeRepoDir`/realpath paths while snapshot items carry raw `join(repoRoot,name)` paths; membership maps real→raw (mirrors `reconcileRealPathsToRaw`) and matches on `(raw repoPath, issue number)`, so a symlinked `repoRoot` can't silently defeat the check.
- A transient compute throw no longer aborts the remaining retries.

All backgrounded — the start response is never blocked. The 15-min interval loop remains the ultimate backstop. Common case = one `compute()` (no steady-state cost regression); extra fan-outs only on the rare lag path, bounded at 3.

## Tests

- `test/up-next.test.ts` — `recomputeUntilCleared`: clears-in-one, retries-then-succeeds, bounded, non-coalescing, symlinked-root path-space (+ identity control), no-refs no-op, and transient-throw resilience.
- `test/server-up-next.test.ts` — start uses `recomputeUntilCleared(startedRefs)`, not an immediate `refresh`.
- `bun run lint`, `bun run typecheck`, `bun run test` (5687 tests) all green. Server-only change — no UI/i18n/feature-catalog/glossary impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)