### PR TITLE
fix(up-next): honor issue assignee (mine & unassigned)

### DIFF
--- a/src/up-next-core.ts
+++ b/src/up-next-core.ts
@@ -63,6 +63,10 @@ export interface EpicUnitInput {
   parentUrl: string;
   parentCreatedAt: number;
   parentLabels: string[];
+  /** The epic parent's assignees. The unit is filtered by these (#824) — the candidate child
+   *  is synthesized with `assignees: []`, so the parent is the assignee-bearing issue (matching
+   *  what the Backlog hides). */
+  parentAssignees: string[];
   /** All epic member issue numbers — removed from the flat per-repo list (dedup). */
   memberNumbers: number[];
   /** selectEpicCandidates()[0], or null when no child is actionable (suppress the unit). */
@@ -74,6 +78,10 @@ export interface RepoInput {
   repoSlug: string | null;
   repoLabel: string;
   lastUsedAt: number | null;
+  /** The operator's own login on this repo's forge (`forge.currentUser()`), or null when it
+   *  can't be resolved (local forge / un-authed / no identity API). Drives the "mine &
+   *  unassigned" filter (#824); null fails open (no assignee filtering — show everything). */
+  viewer: string | null;
   openIssues: Issue[];
   epics: EpicUnitInput[];
   /** All native sub-issue numbers in the repo (from listSubIssueSummaries). Removed from the
@@ -117,6 +125,15 @@ function classifyKind(labelSet: Set<string>): "bug" | "feature" {
   return intersects(labelSet, BUG_LABELS) ? "bug" : "feature";
 }
 
+/** The "mine & unassigned" predicate (#824): true when the issue is assigned to at least one
+ *  person and the viewer is NOT among them (i.e. assigned solely to others → hide). Fails open
+ *  when `viewer` is null (unknown "me"): unassigned and mine-assigned always pass. Mirrors the
+ *  Backlog's `hideOthers` (ui/src/lib/components/issues-panel.ts). */
+function isAssignedToOthers(assignees: string[], viewer: string | null): boolean {
+  if (viewer == null) return false;
+  return assignees.length > 0 && !assignees.includes(viewer);
+}
+
 /** Standalone-issue exclusions applied before ranking. Epic membership + PR-linkage are
  *  handled by the caller (they need cross-issue context). */
 function isExcludedIssue(issue: Issue, labelSet: Set<string>): boolean {
@@ -130,6 +147,7 @@ function isExcludedIssue(issue: Issue, labelSet: Set<string>): boolean {
 function standaloneItem(repo: RepoInput, issue: Issue, linkedSet: Set<number>): UpNextItem | null {
   const labelSet = lc(issue.labels);
   if (isExcludedIssue(issue, labelSet)) return null;
+  if (isAssignedToOthers(issue.assignees, repo.viewer)) return null; // #824 mine & unassigned
   if (linkedSet.has(issue.number)) return null; // best-effort secondary
   return {
     repoPath: repo.repoPath,
@@ -153,6 +171,7 @@ function epicItem(repo: RepoInput, e: EpicUnitInput, linkedSet: Set<number>): Up
   const parentLabelSet = lc(e.parentLabels);
   if (hasLabel(parentLabelSet, ACTIVE_LABEL)) return null;
   if (intersects(parentLabelSet, EXCLUDE_LABELS)) return null;
+  if (isAssignedToOthers(e.parentAssignees, repo.viewer)) return null; // #824 (keyed on parent)
   if (linkedSet.has(c.number)) return null; // the child already has a PR in flight
   return {
     repoPath: repo.repoPath,

--- a/src/up-next.ts
+++ b/src/up-next.ts
@@ -138,6 +138,10 @@ export class UpNextService {
   ): Promise<RepoInput | "fetch_failed" | null> {
     const forge = this.deps.resolveForge(r.repoPath);
     if (!forge) return null; // forge vanished mid-compute → benign skip, not a fetch failure
+    // The operator's own login on this forge, for the "mine & unassigned" filter (#824). Cached
+    // per-forge (`gh api user`), so ~free after the first call. null when the host can't resolve
+    // it (local/un-authed/no identity API) → the core fails open and filters nothing.
+    const viewer = (await forge.currentUser?.().catch(() => null)) ?? null;
     let openIssues: Awaited<ReturnType<GitForge["listIssues"]>>;
     try {
       openIssues = await forge.listIssues();
@@ -158,6 +162,7 @@ export class UpNextService {
       repoSlug: r.repoSlug,
       repoLabel: r.repoLabel,
       lastUsedAt: lastUsed[r.repoPath] ?? null,
+      viewer,
       openIssues,
       epics,
       subIssueNumbers: summaries.subIssueNumbers,
@@ -190,6 +195,7 @@ export class UpNextService {
         parentUrl: parent.url,
         parentCreatedAt: parent.createdAt,
         parentLabels: parent.labels,
+        parentAssignees: parent.assignees,
         memberNumbers: epic.children.map((c) => c.number),
         candidate: selectEpicCandidates(epic.children)[0] ?? null,
       });

--- a/test/up-next-core.test.ts
+++ b/test/up-next-core.test.ts
@@ -31,6 +31,7 @@ function repo(over: Partial<RepoInput> = {}): RepoInput {
     repoSlug: "o/a",
     repoLabel: "a",
     lastUsedAt: 0,
+    viewer: null,
     openIssues: [],
     epics: [],
     subIssueNumbers: [],
@@ -46,6 +47,7 @@ function epic(over: Partial<EpicUnitInput> = {}): EpicUnitInput {
     parentUrl: "https://x/100",
     parentCreatedAt: 100,
     parentLabels: [],
+    parentAssignees: [],
     memberNumbers: [],
     candidate: null,
     ...over,
@@ -110,6 +112,58 @@ describe("exclusions", () => {
   test("fully-excluded repo emits no section", () => {
     const r = [repo({ openIssues: [issue(1, { labels: ["shepherd:active"] })] })];
     expect(repoSection(r, "/r/a")).toBeUndefined();
+  });
+});
+
+describe("assignee filter — mine & unassigned (#824)", () => {
+  test("standalone: keeps unassigned & mine, drops assigned-solely-to-others", () => {
+    const r = [
+      repo({
+        viewer: "me",
+        openIssues: [
+          issue(1), // unassigned → keep
+          issue(2, { assignees: ["me"] }), // mine → keep
+          issue(3, { assignees: ["other"] }), // solely others → drop
+          issue(4, { assignees: ["other", "me"] }), // mine + others → keep
+        ],
+      }),
+    ];
+    expect(repoSection(r, "/r/a")!.items.map((i) => i.number)).toEqual([1, 2, 4]);
+  });
+  test("standalone: viewer null fails open (no assignee filtering)", () => {
+    const r = [
+      repo({
+        viewer: null,
+        openIssues: [issue(1, { assignees: ["other"] }), issue(2, { assignees: ["a", "b"] })],
+      }),
+    ];
+    expect(repoSection(r, "/r/a")!.items.map((i) => i.number)).toEqual([1, 2]);
+  });
+  test("epic unit: filtered by PARENT assignees, not the candidate child", () => {
+    // Parent assigned solely to "other" → unit hidden even though the candidate child carries
+    // no assignees (the child is synthesized with assignees:[]).
+    const r = [
+      repo({
+        viewer: "me",
+        epics: [epic({ parentAssignees: ["other"], memberNumbers: [2], candidate: issue(2) })],
+      }),
+    ];
+    expect(repoSection(r, "/r/a")).toBeUndefined();
+  });
+  test("epic unit: parent unassigned / mine surfaces; viewer null keeps it", () => {
+    const mkRepo = (viewer: string | null, parentAssignees: string[]) =>
+      repo({
+        viewer,
+        epics: [epic({ parentAssignees, memberNumbers: [2], candidate: issue(2) })],
+      });
+    for (const r of [
+      mkRepo("me", []), // parent unassigned → keep
+      mkRepo("me", ["me"]), // parent mine → keep
+      mkRepo(null, ["other"]), // unknown "me" → fail open → keep
+    ]) {
+      const items = repoSection([r], "/r/a")!.items;
+      expect(items.filter((i) => i.kind === "epic")).toHaveLength(1);
+    }
   });
 });
 

--- a/test/up-next.test.ts
+++ b/test/up-next.test.ts
@@ -152,6 +152,73 @@ describe("UpNextService.refresh", () => {
         .sort(),
     ).toEqual([1]);
   });
+
+  test("threads forge.currentUser as viewer → filters standalone issues assigned to others (#824)", async () => {
+    const s = svc({
+      resolveForge: () =>
+        fakeForge({
+          currentUser: async () => "me",
+          issues: [issue(1), issue(2, { assignees: ["me"] }), issue(3, { assignees: ["other"] })],
+        }),
+    });
+    const snap = await s.refresh();
+    const items = snap.sections.find((x) => x.kind === "repo")!.items;
+    // #3 (assigned solely to "other") is filtered out; unassigned #1 and mine #2 remain.
+    expect(items.map((i) => i.number)).toEqual([1, 2]);
+  });
+
+  test("no currentUser → viewer null → fails open (others' issues still shown)", async () => {
+    const s = svc({
+      resolveForge: () => fakeForge({ issues: [issue(1), issue(2, { assignees: ["other"] })] }), // no currentUser
+    });
+    const snap = await s.refresh();
+    const items = snap.sections.find((x) => x.kind === "repo")!.items;
+    expect(items.map((i) => i.number)).toEqual([1, 2]);
+  });
+
+  test("threads epic parent assignees → hides epic unit whose parent is assigned to others (#824)", async () => {
+    const epic: Epic = {
+      repoPath: "/r/a",
+      parentIssueNumber: 100,
+      parentTitle: "epic",
+      source: "native",
+      run: { repoPath: "/r/a", parentIssueNumber: 100, mode: "auto", status: "idle" } as EpicRun,
+      warnings: [],
+      children: [
+        {
+          number: 2,
+          title: "child-2",
+          url: "https://x/2",
+          order: 0,
+          body: "b2",
+          blockedBy: [],
+          state: "ready",
+          sessionId: null,
+          prNumber: null,
+          issueClosed: false,
+          integrationMerged: false,
+          claimed: false,
+        },
+      ],
+    };
+    const s = svc({
+      resolveForge: () =>
+        fakeForge({
+          currentUser: async () => "me",
+          issues: [
+            issue(1),
+            issue(2),
+            issue(100, { assignees: ["other"], body: "```epic-dag\n#2\n```" }),
+          ],
+        }),
+      buildEpic: async () => epic,
+    });
+    const snap = await s.refresh();
+    const items = snap.sections.find((x) => x.kind === "repo")!.items;
+    // Parent #100 assigned solely to "other" → epic unit suppressed; only standalone #1 remains.
+    expect(items.filter((i) => i.kind === "epic")).toHaveLength(0);
+    expect(items.map((i) => i.number)).toEqual([1]);
+  });
 });
 
 describe("startSerially", () => {


### PR DESCRIPTION
## What

**Up Next** previously ranked *every* open issue regardless of who it was assigned to — issues assigned to other people appeared identically to unassigned ones. This brings Up Next to parity with the Backlog's existing "mine & unassigned" filter (#824): it now surfaces only issues that are **unassigned OR assigned to me**.

## How

Filtering happens **server-side at compute time** (the cached snapshot arrives pre-filtered — no UI/GET plumbing). "Me" is per-forge, so the viewer login is resolved per repo via `forge.currentUser()` (already used by the Backlog's issues endpoint), where the forge is already in hand — no new `UpNextDeps` field, no `index.ts` wiring.

- **Standalone issues** filter on their own `assignees`.
- **Epic units** filter on the **parent's** `assignees` (threaded as `EpicUnitInput.parentAssignees`). The epic candidate child is synthesized with `assignees: []`, so the parent is the assignee-bearing issue — matching what the Backlog hides.
- **Fails open**: when the viewer login can't be resolved (local forge / un-authed / no identity API), no assignee filtering happens.

## Decisions (confirmed with operator)

- **Always on, no toggle** — permanent server-side filter; others' issues remain visible on the Backlog, not in Up Next. A future toggle would need snapshot + UI re-plumbing (known follow-up, not in scope).
- **Epic parents are filtered too** — full #824 parity, not a divergence.

## Behavior change to note

A `shepherd:priority` issue — or a whole repo whose only work is assigned solely to others — now drops out of Up Next. Intended (that's the filter's purpose), but visible.

## Not a feature announcement

Server-only change; no `ui/src/lib/components/**` or `routes/**` touched, so the feature-catalog gate correctly does not fire. Framed as a consistency **fix** bringing Up Next to Backlog #824 parity.

## Tests

- `test/up-next-core.test.ts` — standalone (mine / unassigned / others / both / null-viewer) + epic-parent (mine / unassigned / others / null-viewer) cases.
- `test/up-next.test.ts` — asserts `resolveRepo` threads `currentUser` → viewer, `resolveEpics` threads parent assignees, and fail-open when the forge has no `currentUser`.

`bun test` (5678 pass, 0 fail), `bun run lint`, and `tsc --noEmit` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)