### PR TITLE
feat(viewport): make review-in-flight banner prominent with a running-gear

### DIFF
--- a/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
+++ b/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
@@ -155,6 +155,11 @@
     view.show && view.phase === "conclusion" && view.tone !== "errored" ? "✓" : "⚠",
   );
 
+  // While a review is actively running, lead with a rotating gear ("Shepherd is
+  // working, wait with typing") instead of the static ⚠. The brief conclusion
+  // tiers keep the static icon above — nothing is running there. (issue #1022)
+  const inFlight = $derived(view.show && view.phase === "in-flight");
+
   // Publish the banner's occupied height so the floating jump-to-latest button can
   // lift clear of it (issue: scroll button obscured by this banner). The bound
   // element mirrors the {#if} below. offsetHeight (via bind: on the element) is the
@@ -178,13 +183,35 @@
   <div
     class="review-banner"
     data-tone={view.tone}
+    data-phase={view.phase}
     role="status"
     aria-live="polite"
     bind:this={bannerEl}
     bind:offsetHeight={height}
     use:coachTarget={"review-inflight"}
   >
-    <span class="rb-icon" aria-hidden="true">{icon}</span>
+    {#if inFlight}
+      <!-- Rotating cog: an inline SVG (not the ⚙ glyph, which renders as a color
+           emoji ignoring currentColor and rotates off-center) so it tints to the
+           tone accent and turns cleanly about its center. -->
+      <svg
+        class="rb-cog"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="3" />
+        <path
+          d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
+        />
+      </svg>
+    {:else}
+      <span class="rb-icon" aria-hidden="true">{icon}</span>
+    {/if}
     <span class="rb-text">{bannerText(view)}</span>
   </div>
 {/if}
@@ -209,9 +236,34 @@
     border-top: 1px solid color-mix(in srgb, var(--accent) 55%, var(--color-line));
     animation: rb-in 0.14s ease;
   }
+  /* Prominence bump scoped to the in-flight tier only: the "review is running"
+     message reads taller + larger, while the short-lived conclusion tiers keep
+     the compact base size above. */
+  .review-banner[data-phase="in-flight"] {
+    padding: 9px 12px;
+    font-size: var(--fs-base);
+  }
   .rb-icon {
     font-size: var(--fs-base);
     line-height: 1;
+  }
+  /* Rotating gear — the "Shepherd is working" cue. Tinted to the tone accent
+     (amber calm / warn escalated), echoing the amber REVIEWING pulse. Rotation
+     reuses the shared icon-btn-spin keyframe (app.css), NOT the .spin class,
+     whose reduced-motion rule (animation:none) would drop this state signal. */
+  .rb-cog {
+    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
+    color: var(--accent);
+    animation: icon-btn-spin 2.4s linear infinite;
+  }
+  /* Functional indicator: under reduced-motion swap rotation for the same
+     dot-pulse the REVIEWING dots use, so the "work happening" signal survives. */
+  @media (prefers-reduced-motion: reduce) {
+    .rb-cog {
+      animation: dot-pulse 1.1s ease-in-out infinite !important;
+    }
   }
   .rb-text {
     color: var(--color-ink-bright);


### PR DESCRIPTION
## What & why

The bottom-of-terminal banner that warns _„Eine Überprüfung läuft — sie steuert diese Sitzung, sobald sie fertig ist. Warte mit dem Tippen.“_ was easy to overlook. This makes the **wait-with-typing** signal unmissable and adds a **rotating gear** at its left edge meaning "Shepherd is doing something right now".

## Changes (single file: `ReviewInFlightBanner.svelte`)

- **More prominent, scoped to the in-flight tier.** Taller padding + `--fs-base` text via `.review-banner[data-phase="in-flight"]`. The short-lived conclusion tiers (delivered / nothing / error) keep their current compact `--fs-meta` size.
- **Rotating gear only while a review runs.** An inline-SVG cog leads the in-flight banner; conclusion tiers keep the static `✓`/`⚠` (nothing is running there).
- **Consistent with the existing motif.** Rotation reuses the shared `@keyframes icon-btn-spin` (2.4s), tinted to the tone accent (amber calm / warn escalated) to echo the amber REVIEWING pulse. Under `prefers-reduced-motion` it swaps rotation for the same `dot-pulse` the REVIEWING dots use, so the state signal survives.

### Design notes
- Inline SVG over the `⚙` (U+2699) glyph on purpose: the glyph renders as a color emoji that ignores `currentColor` (won't tint to the tone accent) and rotates off-center. The SVG inherits `currentColor`, is cross-platform stable, and turns cleanly about its center.
- No state-logic change (`review-banner.ts` untouched), no new i18n keys (gear is `aria-hidden`; message text unchanged).

## Feature catalog
`[no-feature-entry]` — prominence polish on the already-announced review-in-flight feature (`feat_review_inflight_*`), not a new capability.

## Verification
- `cd ui && bun run check` → 0 errors
- `cd ui && bun run test` → 2704 passed
- Pre-push gates (branch-hygiene, i18n parity, feature-catalog, fallow) all green