### PR TITLE
fix(commandbar): sync repo & status filter to the selected session

### DIFF
--- a/ui/src/lib/components/queue-strip.test.ts
+++ b/ui/src/lib/components/queue-strip.test.ts
@@ -15,6 +15,7 @@ import {
   nextRepoFilter,
   staleFilterRepos,
   shouldFollowFilterToRepo,
+  followRepoFilter,
 } from "./queue-strip";
 import type { RepoChip } from "./queue-strip";
 import type { BlockState } from "../triage";
@@ -548,6 +549,40 @@ describe("shouldFollowFilterToRepo", () => {
 
   it("TRUE when the active filter does not include the new task's repo — would hide it", () => {
     expect(shouldFollowFilterToRepo(new Set(["/repos/a"]), "/repos/b")).toBe(true);
+  });
+});
+
+// ─── followRepoFilter ─────────────────────────────────────────────────────────
+
+describe("followRepoFilter", () => {
+  it("no-op (false) on an empty filter — must not narrow the 'all repos' view", () => {
+    const f = new Set<string>();
+    expect(followRepoFilter(f, "/repos/a")).toBe(false);
+    expect([...f]).toEqual([]);
+  });
+
+  it("collapses a single mismatched repo onto the session's repo", () => {
+    const f = new Set(["/repos/a"]);
+    expect(followRepoFilter(f, "/repos/b")).toBe(true);
+    expect([...f]).toEqual(["/repos/b"]);
+  });
+
+  it("collapses a multi-selection onto the session's repo (not additive)", () => {
+    const f = new Set(["/repos/a", "/repos/b"]);
+    expect(followRepoFilter(f, "/repos/c")).toBe(true);
+    expect([...f]).toEqual(["/repos/c"]);
+  });
+
+  it("no-op (false) when a multi-selection already covers the session's repo", () => {
+    const f = new Set(["/repos/a", "/repos/b"]);
+    expect(followRepoFilter(f, "/repos/a")).toBe(false);
+    expect([...f].sort()).toEqual(["/repos/a", "/repos/b"]);
+  });
+
+  it("no-op (false) when the sole selected repo already covers the session's repo", () => {
+    const f = new Set(["/repos/a"]);
+    expect(followRepoFilter(f, "/repos/a")).toBe(false);
+    expect([...f]).toEqual(["/repos/a"]);
   });
 });
 

--- a/ui/src/lib/components/queue-strip.ts
+++ b/ui/src/lib/components/queue-strip.ts
@@ -137,6 +137,19 @@ export function shouldFollowFilterToRepo(
   return repoFilter.size > 0 && !repoFilter.has(repoPath);
 }
 
+/** Follow the repo filter onto `repoPath` for a session jump: when an active filter would
+ *  otherwise hide a session in that repo, collapse the filter to just that repo (mutating
+ *  `repoFilter` IN PLACE — the live SvelteSet is reactive) and return true; otherwise a
+ *  no-op returning false (empty filter = "all repos", or the repo is already covered).
+ *  Shared decision behind both the new-task follow (selectNewSession) and the command-bar
+ *  session select, so the two can't drift. Callers arm their follow latches on a true return. */
+export function followRepoFilter(repoFilter: Set<string>, repoPath: string): boolean {
+  if (!shouldFollowFilterToRepo(repoFilter, repoPath)) return false;
+  for (const p of [...repoFilter]) if (p !== repoPath) repoFilter.delete(p);
+  repoFilter.add(repoPath);
+  return true;
+}
+
 /**
  * The session the terminal should re-target onto after the user picks a repo chip.
  * Narrowing the herd to a repo would otherwise leave the terminal on whatever session

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -109,7 +109,7 @@
     pickRepoSwitchTarget,
     repoChipRows,
     staleFilterRepos,
-    shouldFollowFilterToRepo,
+    followRepoFilter,
   } from "$lib/components/queue-strip";
   import BacklogView from "$lib/components/BacklogView.svelte";
   import AppOverlays from "$lib/components/page/AppOverlays.svelte";
@@ -634,12 +634,19 @@
   // Shared by every create/relaunch path so the behaviour can't drift between them.
   // Arms both follow latches (declared near repoFilter) so the prune and re-target
   // effects coordinate until the new session arrives via WS.
-  function selectNewSession(id: string, repoPath: string) {
-    if (shouldFollowFilterToRepo(repoFilter, repoPath)) {
+  // Follow the herd's repo filter onto `repoPath` when an active filter would otherwise hide a
+  // session there, arming both follow latches so the prune + re-target effects don't fight it.
+  // The single shared follow step behind selectNewSession (new task) AND the command-bar session
+  // select, so the behaviour can't drift. followRepoFilter mutates repoFilter in place (collapse
+  // to the single repo) and reports whether it changed; the latches arm only on a real change.
+  function followFilterToRepo(repoPath: string) {
+    if (followRepoFilter(repoFilter, repoPath)) {
       followingRepo = repoPath;
       followingNewSession = true;
-      replaceRepoFilter([repoPath]);
     }
+  }
+  function selectNewSession(id: string, repoPath: string) {
+    followFilterToRepo(repoPath);
     selectedId = id;
   }
 
@@ -2816,7 +2823,14 @@
     showCommandBar = false;
     demoCommandFilter = "";
     showBacklog = false;
+    // A ⌘K session jump must land the session VISIBLE + highlighted in the herd list, which
+    // narrows by both the lens filter AND the sticky repo/status filters. Reset both stickies
+    // (herdFilter → all, statusFilter → null) and follow the repo filter onto the session's
+    // repo so a filter on a different repo/status can't strand it out of the list.
     herdFilter = "all";
+    statusFilter = null;
+    const repoPath = store.sessions.find((s) => s.id === id)?.repoPath;
+    if (repoPath) followFilterToRepo(repoPath);
     selectUnit(id);
   }}
   oncommandbarrepo={(path) => {


### PR DESCRIPTION
## Problem

Selecting a session from the command bar (⌘K) opened it in the terminal, but the sticky **repo filter** (and **status filter**) at the top of Mission Control stayed put. If the filter pointed at a different repo (or a status the session didn't match), the left herd list stayed scoped to the wrong repo/status — the picked session was neither listed nor highlighted, so the terminal and the sidebar disagreed.

## Root cause

The herd list (`herdSessions`) narrows by **both** `repoFilter` **and** `statusFilter`, while the highlight is the decoupled `selectedId`. The `oncommandbarsession` handler only reset the *lens* filter (`herdFilter = "all"`) and never touched `repoFilter`/`statusFilter`.

## Fix

On a command-bar session jump:
- Reset `statusFilter` too (alongside the existing `herdFilter` reset), so a sticky status filter can't hide the picked session.
- Follow the repo filter onto the session's repo when an active filter would otherwise hide it (collapse to that single repo). No change when the filter is empty ("all repos") or already covers the repo.

The follow decision is factored into a shared, unit-tested `followRepoFilter` helper (pure, mutates the passed set) plus a page-local `followFilterToRepo` wrapper that arms the follow latches. `selectNewSession` (new-task follow) is refactored onto the same wrapper so the two paths can't drift — its behaviour is unchanged. The command-bar handler keeps its own `selectUnit(id)` (focus + mobile-detail transition), so it does not reuse `selectNewSession` wholesale.

## Behaviour

| Active filter | Picked session | Result |
| --- | --- | --- |
| empty (all repos) | any | unchanged — already visible |
| repo A | repo B | repo filter → B (collapse) |
| A + B (multi) | repo C | repo filter → C (collapse, not additive) |
| A + B (multi) | repo A | unchanged — already covered |
| statusFilter = blocked | running session in B | status filter cleared + repo → B |

## Tests

New `describe("followRepoFilter")` suite in `queue-strip.test.ts` (5 cases: empty no-op, single collapse, multi→single collapse, already-covered no-ops). Full UI suite green (`bun run test` — 2711 passed), `bun run check` (0 errors) and `bun run check:i18n` (parity) pass. The handler glue itself has no `+page.svelte` test harness (`AppOverlays` mocks the handler), so the substantive logic lives in the tested pure helper; the glue is covered by review + manual verification — as `selectNewSession`'s follow was before.

No user-facing text changed (no i18n keys, no feature-catalog entry — this is a `fix`, not a new feature).