### PR TITLE
feat: compose-bar mic → local Whisper transcription (core hook for voice-whisper plugin) (#76)

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2408,5 +2408,9 @@
   "epic_handsoff_apply_failed": "Ohne-Eingriff-Standards konnten nicht übernommen werden.",
   "epic_handsoff_guide": "Vollständige Anleitung ↗",
   "automation_handsoff_hint": "Empfohlen für Epics ohne Eingriff →",
-  "epic_handsoff_mode_failed": "Standards übernommen, aber der Epic konnte nicht auf Auto-Modus umgestellt werden — stelle den Epic-Modus in den Steuerelementen unten ein."
+  "epic_handsoff_mode_failed": "Standards übernommen, aber der Epic konnte nicht auf Auto-Modus umgestellt werden — stelle den Epic-Modus in den Steuerelementen unten ein.",
+  "composebar_transcribing": "Wird transkribiert…",
+  "composebar_transcribe_failed": "Transkription fehlgeschlagen – bitte erneut versuchen.",
+  "feat_voice_whisper_title": "Spracheingabe mit lokalem Whisper",
+  "feat_voice_whisper_body": "Installiere das optionale voice-whisper-Plugin, und das Mikrofon der Compose-Leiste transkribiert direkt auf deinem Rechner per whisper.cpp – gleichbleibende Qualität, nichts verlässt den Host, und endlich ein funktionierendes Mikrofon in der iOS-Homescreen-PWA."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2408,5 +2408,9 @@
   "epic_handsoff_apply_failed": "Couldn't apply hands-off defaults.",
   "epic_handsoff_guide": "Full guide ↗",
   "automation_handsoff_hint": "Recommended for hands-off epics →",
-  "epic_handsoff_mode_failed": "Applied the defaults, but couldn't switch the epic to auto mode — set Epic mode in the controls below."
+  "epic_handsoff_mode_failed": "Applied the defaults, but couldn't switch the epic to auto mode — set Epic mode in the controls below.",
+  "composebar_transcribing": "Transcribing…",
+  "composebar_transcribe_failed": "Couldn't transcribe that — try again.",
+  "feat_voice_whisper_title": "Voice input with local Whisper",
+  "feat_voice_whisper_body": "Install the optional voice-whisper plugin and the compose-bar mic transcribes on your own machine via whisper.cpp — consistent quality, nothing leaves the host, and finally a working mic in the iOS home-screen PWA."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -292,6 +292,55 @@ export async function uploadImage(file: File, sessionId?: string): Promise<strin
   return (await r.json()).path as string;
 }
 
+/** Detection status of the optional `voice-whisper` plugin (local Whisper transcription). */
+export interface VoiceStatus {
+  available: boolean;
+  engine: string | null;
+  model: string | null;
+  ffmpeg: boolean;
+  language: string;
+  /** When true, the mic should prefer local whisper even where Web Speech is supported. */
+  preferLocal: boolean;
+  hint: string;
+}
+
+const VOICE_ABSENT: VoiceStatus = {
+  available: false,
+  engine: null,
+  model: null,
+  ffmpeg: false,
+  language: "auto",
+  preferLocal: false,
+  hint: "",
+};
+
+let voiceStatusPromise: Promise<VoiceStatus> | null = null;
+
+/** Detection status of the voice-whisper plugin, memoized once per page load. A 404 (plugin
+ *  not installed) or any error resolves to an "unavailable" status and is cached — so the
+ *  compose-bar mic keeps the browser's Web Speech engine (or stays hidden) exactly as today,
+ *  with just this one cached probe as the difference. */
+export function getVoiceStatus(): Promise<VoiceStatus> {
+  if (!voiceStatusPromise) {
+    voiceStatusPromise = fetch("/api/plugins/voice-whisper/status")
+      .then((r) => (r.ok ? (r.json() as Promise<VoiceStatus>) : VOICE_ABSENT))
+      .catch(() => VOICE_ABSENT);
+  }
+  return voiceStatusPromise;
+}
+
+/** Transcribe a recorded audio clip via the voice-whisper plugin; returns the text. `lang`
+ *  (`"de"`/`"en"`) pins the transcription language when the plugin isn't configured to force one. */
+export async function transcribeAudio(blob: Blob, lang?: string): Promise<string> {
+  const fd = new FormData();
+  fd.append("file", blob, "clip.webm");
+  if (lang) fd.append("lang", lang);
+  // no content-type header: the browser sets the multipart boundary
+  const r = await fetch("/api/plugins/voice-whisper/transcribe", { method: "POST", body: fd });
+  if (!r.ok) throw await failed(r, "transcribe");
+  return (await r.json()).text as string;
+}
+
 /** Leftover subprocesses/proxies that would survive this session's close; [] when none. */
 export async function getLeftovers(id: string): Promise<Leftover[]> {
   const r = await fetch(`/api/sessions/${id}/leftovers`);

--- a/ui/src/lib/components/ComposeBar.svelte
+++ b/ui/src/lib/components/ComposeBar.svelte
@@ -233,41 +233,50 @@
     voiceErrorTimer = setTimeout(() => (voiceError = false), 4000);
   }
 
-  // Start recording. Called from an in-sheet mic tap — a FRESH user-activation gesture, never
-  // on mount, so getUserMedia stays inside its activation window across the async sheet mount.
+  // Start recording. Reached two ways, both within the getUserMedia activation window: an
+  // in-sheet mic tap, or the ◉ dictate entry (startDictation) auto-starting on mount when local
+  // is the engine — getVoiceStatus is memoized/pre-resolved by then, so the auto-start runs in
+  // the same turn as the chip tap. `acquiring` guards the getUserMedia await so an auto-start
+  // and a fast manual tap can't both open a stream.
+  let acquiring = false;
   async function startLocalRecording() {
-    if (listening || transcribing) return;
+    if (listening || transcribing || acquiring) return;
     if (!recorderSupported) {
       flashVoiceError();
       return;
     }
+    acquiring = true;
     voiceError = false;
     try {
-      mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    } catch {
-      flashVoiceError();
-      return;
+      try {
+        mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      } catch {
+        flashVoiceError();
+        return;
+      }
+      const mimeType = pickMimeType();
+      chunks = [];
+      // MediaRecorder construction or start() can throw (unsupported mimeType, hardware in use);
+      // release the just-acquired mic stream so it isn't left open on failure.
+      try {
+        mediaRecorder = new MediaRecorder(mediaStream, mimeType ? { mimeType } : undefined);
+        mediaRecorder.ondataavailable = (e) => {
+          if (e.data.size) chunks.push(e.data);
+        };
+        mediaRecorder.onstop = () => void finishLocalRecording();
+        mediaRecorder.start();
+      } catch {
+        mediaRecorder = null;
+        releaseStream();
+        flashVoiceError();
+        return;
+      }
+      listening = true;
+      activeEngine = "local";
+      recordTimer = setTimeout(() => stopLocalRecording(), MAX_RECORD_MS);
+    } finally {
+      acquiring = false;
     }
-    const mimeType = pickMimeType();
-    chunks = [];
-    // MediaRecorder construction or start() can throw (unsupported mimeType, hardware in use);
-    // release the just-acquired mic stream so it isn't left open on failure.
-    try {
-      mediaRecorder = new MediaRecorder(mediaStream, mimeType ? { mimeType } : undefined);
-      mediaRecorder.ondataavailable = (e) => {
-        if (e.data.size) chunks.push(e.data);
-      };
-      mediaRecorder.onstop = () => void finishLocalRecording();
-      mediaRecorder.start();
-    } catch {
-      mediaRecorder = null;
-      releaseStream();
-      flashVoiceError();
-      return;
-    }
-    listening = true;
-    activeEngine = "local";
-    recordTimer = setTimeout(() => stopLocalRecording(), MAX_RECORD_MS);
   }
 
   // User-initiated stop → let onstop fire finishLocalRecording (which uploads + inserts).
@@ -393,16 +402,22 @@
     // still edit the transcript inline
     ta?.focus();
     autogrow();
-    // Probe for the local-Whisper plugin (memoized once per page load). Never auto-starts
-    // local recording — that needs a fresh in-sheet tap for the getUserMedia gesture.
+    // Probe for the local-Whisper plugin (memoized once per page load, so this resolves in the
+    // same turn as the tap that opened the sheet). When the ◉ dictate entry opened us and local
+    // is the engine (e.g. iOS PWA, no Web Speech), start recording now — otherwise a local-only
+    // dictate chip would open an idle sheet. The status is pre-resolved by the time the chip is
+    // tappable, so getUserMedia is still inside the tap's activation window; a denial just flashes
+    // an error and leaves the in-sheet mic. Guarded against double-starting Web Speech below.
     getVoiceStatus()
       .then((s) => {
         localVoiceAvailable = s.available;
         preferLocal = s.preferLocal;
+        if (startDictation && useLocal && !listening && !transcribing) void startLocalRecording();
       })
       .catch(() => {});
-    // `startDictation` ("open already listening") is a Web-Speech affordance; the ◉ chip that
-    // sets it only appears where Web Speech works, so this never fights the local path.
+    // Web Speech "open already listening" — fires synchronously so it's never delayed by the
+    // probe. On a local-only client (no Web Speech) this is a no-op and the branch above starts
+    // local instead.
     if (startDictation && speechSupported) toggleDictation();
   });
 

--- a/ui/src/lib/components/ComposeBar.svelte
+++ b/ui/src/lib/components/ComposeBar.svelte
@@ -203,10 +203,16 @@
     !!navigator.mediaDevices?.getUserMedia;
   const localUsable = $derived(localVoiceAvailable && recorderSupported);
 
-  // The mic shows whenever *either* engine can run; it uses local when Web Speech is absent
-  // (iOS PWA) or when the plugin asks to be preferred, else the browser's live dictation.
+  // The mic shows whenever *either* engine can run; `useLocal` picks which engine a NEW tap
+  // starts — local when Web Speech is absent (iOS PWA) or the plugin asks to be preferred,
+  // else the browser's live dictation. It can flip mid-session (getVoiceStatus() resolving
+  // after an auto-started dictation), so it must NOT decide how to STOP an in-flight session.
   const micVisible = $derived(speechSupported || localUsable);
   const useLocal = $derived(localUsable && (!speechSupported || preferLocal));
+
+  // Which engine actually owns the live recording, fixed when it starts. tapMic stops THIS one
+  // rather than re-reading `useLocal`, so a mid-session flip never strands the active recorder.
+  let activeEngine = $state<"web" | "local" | null>(null);
 
   let mediaRecorder: MediaRecorder | null = null;
   let mediaStream: MediaStream | null = null;
@@ -260,6 +266,7 @@
       return;
     }
     listening = true;
+    activeEngine = "local";
     recordTimer = setTimeout(() => stopLocalRecording(), MAX_RECORD_MS);
   }
 
@@ -277,6 +284,7 @@
     const type = mediaRecorder?.mimeType || "audio/webm";
     releaseStream();
     mediaRecorder = null;
+    activeEngine = null;
     if (chunks.length === 0) return;
     const blob = new Blob(chunks, { type });
     chunks = [];
@@ -318,6 +326,7 @@
     releaseStream();
     chunks = [];
     listening = false;
+    activeEngine = null;
   }
 
   // Append transcribed text after whatever is already in the field (same join rule dictation uses).
@@ -353,12 +362,15 @@
     };
     recog.onend = () => {
       listening = false;
+      activeEngine = null;
     };
     recog.onerror = () => {
       listening = false;
+      activeEngine = null;
     };
     recog.start();
     listening = true;
+    activeEngine = "web";
   }
 
   // Keep the sheet centered in the *visible* viewport — i.e. the area above the
@@ -483,9 +495,14 @@
   function tapMic(e: PointerEvent) {
     e.preventDefault();
     if (transcribing) return;
-    if (useLocal) {
-      if (listening) stopLocalRecording();
-      else void startLocalRecording();
+    // A live session is stopped by the engine that STARTED it (not the current `useLocal`,
+    // which may have flipped mid-session) — otherwise the active recorder is never stopped.
+    if (activeEngine === "local") {
+      stopLocalRecording();
+    } else if (activeEngine === "web") {
+      recog?.stop();
+    } else if (useLocal) {
+      void startLocalRecording();
     } else {
       toggleDictation();
     }

--- a/ui/src/lib/components/ComposeBar.svelte
+++ b/ui/src/lib/components/ComposeBar.svelte
@@ -3,7 +3,7 @@
   import { m } from "$lib/paraglide/messages";
   import { getLocale } from "$lib/i18n";
   import { insertNewlineAt } from "$lib/compose";
-  import { getCommands } from "$lib/api";
+  import { getCommands, getVoiceStatus, transcribeAudio } from "$lib/api";
   import { matchSlashTrigger, filterCommands, applyCommandPick } from "$lib/slash";
   import type { SlashCommand } from "$lib/types";
   import SlashCommandMenu from "./SlashCommandMenu.svelte";
@@ -183,6 +183,151 @@
   let listening = $state(false);
   let recog: SpeechRecognitionInstance | null = null;
 
+  // ── local Whisper voice input (the optional voice-whisper plugin) ──────────────────
+  // Server-side transcription: record with MediaRecorder, POST the clip to the plugin, insert
+  // the returned text. This is the ONLY mic in an iOS home-screen PWA (no Web Speech there).
+  // Detection is memoized once per page load; absent (404) → we keep Web Speech / hide the mic
+  // exactly as before. The backend is the optional voice-whisper plugin (issue #76):
+  // https://github.com/erwins-enkel/shepherd-plugin-voice-whisper — install it into ~/.shepherd/plugins/.
+  let localVoiceAvailable = $state(false);
+  let preferLocal = $state(false);
+  let transcribing = $state(false);
+  let voiceError = $state(false);
+  let voiceErrorTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // The client must actually be able to record — MediaRecorder + getUserMedia. Without them a
+  // server-available plugin still can't be used from this browser, so treat local as unusable.
+  const recorderSupported =
+    typeof window !== "undefined" &&
+    typeof MediaRecorder !== "undefined" &&
+    !!navigator.mediaDevices?.getUserMedia;
+  const localUsable = $derived(localVoiceAvailable && recorderSupported);
+
+  // The mic shows whenever *either* engine can run; it uses local when Web Speech is absent
+  // (iOS PWA) or when the plugin asks to be preferred, else the browser's live dictation.
+  const micVisible = $derived(speechSupported || localUsable);
+  const useLocal = $derived(localUsable && (!speechSupported || preferLocal));
+
+  let mediaRecorder: MediaRecorder | null = null;
+  let mediaStream: MediaStream | null = null;
+  let chunks: Blob[] = [];
+  let recordTimer: ReturnType<typeof setTimeout> | null = null;
+  const MAX_RECORD_MS = 60_000; // cap a single clip so a forgotten mic can't record forever
+
+  function pickMimeType(): string | undefined {
+    if (typeof MediaRecorder === "undefined") return undefined;
+    for (const c of ["audio/webm;codecs=opus", "audio/webm", "audio/mp4", "audio/ogg"])
+      if (MediaRecorder.isTypeSupported(c)) return c;
+    return undefined; // let the browser choose its default container
+  }
+
+  function flashVoiceError() {
+    voiceError = true;
+    if (voiceErrorTimer) clearTimeout(voiceErrorTimer);
+    voiceErrorTimer = setTimeout(() => (voiceError = false), 4000);
+  }
+
+  // Start recording. Called from an in-sheet mic tap — a FRESH user-activation gesture, never
+  // on mount, so getUserMedia stays inside its activation window across the async sheet mount.
+  async function startLocalRecording() {
+    if (listening || transcribing) return;
+    if (!recorderSupported) {
+      flashVoiceError();
+      return;
+    }
+    voiceError = false;
+    try {
+      mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch {
+      flashVoiceError();
+      return;
+    }
+    const mimeType = pickMimeType();
+    chunks = [];
+    // MediaRecorder construction or start() can throw (unsupported mimeType, hardware in use);
+    // release the just-acquired mic stream so it isn't left open on failure.
+    try {
+      mediaRecorder = new MediaRecorder(mediaStream, mimeType ? { mimeType } : undefined);
+      mediaRecorder.ondataavailable = (e) => {
+        if (e.data.size) chunks.push(e.data);
+      };
+      mediaRecorder.onstop = () => void finishLocalRecording();
+      mediaRecorder.start();
+    } catch {
+      mediaRecorder = null;
+      releaseStream();
+      flashVoiceError();
+      return;
+    }
+    listening = true;
+    recordTimer = setTimeout(() => stopLocalRecording(), MAX_RECORD_MS);
+  }
+
+  // User-initiated stop → let onstop fire finishLocalRecording (which uploads + inserts).
+  function stopLocalRecording() {
+    if (recordTimer) {
+      clearTimeout(recordTimer);
+      recordTimer = null;
+    }
+    if (mediaRecorder && mediaRecorder.state !== "inactive") mediaRecorder.stop();
+    listening = false;
+  }
+
+  async function finishLocalRecording() {
+    const type = mediaRecorder?.mimeType || "audio/webm";
+    releaseStream();
+    mediaRecorder = null;
+    if (chunks.length === 0) return;
+    const blob = new Blob(chunks, { type });
+    chunks = [];
+    transcribing = true;
+    try {
+      const text = await transcribeAudio(blob, getLocale() === "de" ? "de" : "en");
+      if (text) appendTranscript(text);
+    } catch {
+      flashVoiceError();
+    } finally {
+      transcribing = false;
+    }
+  }
+
+  function releaseStream() {
+    mediaStream?.getTracks().forEach((t) => t.stop());
+    mediaStream = null;
+  }
+
+  // Tear down an in-progress recording WITHOUT uploading (dismiss/submit/destroy): drop the
+  // onstop handler first so stopping never triggers a transcription of a discarded clip.
+  function teardownRecording() {
+    if (recordTimer) {
+      clearTimeout(recordTimer);
+      recordTimer = null;
+    }
+    if (mediaRecorder) {
+      mediaRecorder.ondataavailable = null;
+      mediaRecorder.onstop = null;
+      if (mediaRecorder.state !== "inactive") {
+        try {
+          mediaRecorder.stop();
+        } catch {
+          /* already stopped */
+        }
+      }
+      mediaRecorder = null;
+    }
+    releaseStream();
+    chunks = [];
+    listening = false;
+  }
+
+  // Append transcribed text after whatever is already in the field (same join rule dictation uses).
+  function appendTranscript(text: string) {
+    const t = text.trim();
+    if (!t) return;
+    value = value.trim() ? value.trimEnd() + " " + t : t;
+    queueMicrotask(autogrow);
+  }
+
   function toggleDictation() {
     if (!SpeechRec) return;
     if (listening) {
@@ -236,11 +381,23 @@
     // still edit the transcript inline
     ta?.focus();
     autogrow();
+    // Probe for the local-Whisper plugin (memoized once per page load). Never auto-starts
+    // local recording — that needs a fresh in-sheet tap for the getUserMedia gesture.
+    getVoiceStatus()
+      .then((s) => {
+        localVoiceAvailable = s.available;
+        preferLocal = s.preferLocal;
+      })
+      .catch(() => {});
+    // `startDictation` ("open already listening") is a Web-Speech affordance; the ◉ chip that
+    // sets it only appears where Web Speech works, so this never fights the local path.
     if (startDictation && speechSupported) toggleDictation();
   });
 
   onDestroy(() => {
     recog?.stop();
+    teardownRecording();
+    if (voiceErrorTimer) clearTimeout(voiceErrorTimer);
     window.visualViewport?.removeEventListener("resize", syncViewport);
     window.visualViewport?.removeEventListener("scroll", syncViewport);
   });
@@ -254,7 +411,7 @@
 
   function submit() {
     recog?.stop();
-    listening = false;
+    teardownRecording();
     slashOpen = false;
     onsend(value);
     value = "";
@@ -263,7 +420,7 @@
 
   function cancel() {
     recog?.stop();
-    listening = false;
+    teardownRecording();
     onclose();
   }
 
@@ -325,7 +482,13 @@
   // (which would dismiss the mobile soft keyboard), matching ControlBar.
   function tapMic(e: PointerEvent) {
     e.preventDefault();
-    toggleDictation();
+    if (transcribing) return;
+    if (useLocal) {
+      if (listening) stopLocalRecording();
+      else void startLocalRecording();
+    } else {
+      toggleDictation();
+    }
   }
   function tapSend(e: PointerEvent) {
     e.preventDefault();
@@ -405,13 +568,22 @@
         {/each}
       </div>
     {/if}
+    {#if voiceError}
+      <div class="voice-hint" role="alert">{m.composebar_transcribe_failed()}</div>
+    {/if}
     <div class="actions">
-      {#if speechSupported}
+      {#if micVisible}
         <button
           type="button"
           class="btn mic"
           class:listening
-          aria-label={listening ? m.composebar_dictate_stop_aria() : m.composebar_dictate_aria()}
+          class:transcribing
+          disabled={transcribing}
+          aria-label={transcribing
+            ? m.composebar_transcribing()
+            : listening
+              ? m.composebar_dictate_stop_aria()
+              : m.composebar_dictate_aria()}
           aria-pressed={listening}
           onpointerdown={tapMic}>{m.composebar_dictate()}</button
         >
@@ -619,11 +791,16 @@
     font-size: var(--fs-lg);
     line-height: 1;
   }
-  /* while listening: highlighted + a soft pulse so it reads as "recording" */
-  .btn.mic.listening {
+  /* while listening/transcribing: highlighted + a soft pulse so it reads as "working" */
+  .btn.mic.listening,
+  .btn.mic.transcribing {
     background: var(--color-line-bright);
     border-color: var(--color-ink);
     animation: micPulse 1s ease-in-out infinite;
+  }
+  .btn.mic:disabled {
+    cursor: default;
+    opacity: 0.7;
   }
   @keyframes micPulse {
     0%,
@@ -635,8 +812,17 @@
     }
   }
   @media (prefers-reduced-motion: reduce) {
-    .btn.mic.listening {
+    .btn.mic.listening,
+    .btn.mic.transcribing {
       animation: none;
     }
+  }
+
+  /* transient error line above the action row when a transcription fails */
+  .voice-hint {
+    color: var(--color-red);
+    font-family: var(--font-mono);
+    font-size: var(--fs-base);
+    padding: 0 2px;
   }
 </style>

--- a/ui/src/lib/components/viewport/ViewportTermControls.svelte
+++ b/ui/src/lib/components/viewport/ViewportTermControls.svelte
@@ -5,6 +5,7 @@
   import ComposeBar from "$lib/components/ComposeBar.svelte";
   import type { ControlKey } from "$lib/controlKeys";
   import { m } from "$lib/paraglide/messages";
+  import { getVoiceStatus } from "$lib/api";
 
   let {
     mobile,
@@ -62,6 +63,20 @@
       (window as { SpeechRecognition?: unknown }).SpeechRecognition ??
       (window as { webkitSpeechRecognition?: unknown }).webkitSpeechRecognition
     );
+  // Also offer the ◉ chip where the local-Whisper plugin gives a mic even without Web Speech
+  // (iOS home-screen PWA). Requires the client to actually be able to record (MediaRecorder +
+  // getUserMedia). Memoized once per page load; absent → chip shows only under Web Speech,
+  // exactly as before. The sheet's own mic then records via the plugin on an in-sheet tap.
+  const recorderSupported =
+    typeof window !== "undefined" &&
+    typeof MediaRecorder !== "undefined" &&
+    !!navigator.mediaDevices?.getUserMedia;
+  let localVoiceAvailable = $state(false);
+  $effect(() => {
+    getVoiceStatus()
+      .then((s) => (localVoiceAvailable = s.available && recorderSupported))
+      .catch(() => {});
+  });
   function openDictate() {
     composeDictate = true;
     composeOpen = true;
@@ -192,7 +207,7 @@
         >
       {/if}
     </button>
-    {#if speechSupported}
+    {#if speechSupported || localVoiceAvailable}
       <button
         type="button"
         class="dictate"

--- a/ui/src/lib/feature-announcements/entries/v1.42.0-voice-whisper.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.42.0-voice-whisper.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "voice-whisper",
+  sinceVersion: "1.42.0",
+  titleKey: "feat_voice_whisper_title",
+  bodyKey: "feat_voice_whisper_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
Closes #76.

## What this PR is

The **core compose-bar hook** for local‑Whisper voice input. When a local transcription plugin is present and this browser can record, the mic records via `MediaRecorder`, POSTs the clip to the plugin, and inserts the returned transcript. Web Speech stays the default where it works; local fills the gap on the **iOS home‑screen PWA** (no Web Speech there) or when the plugin sets `preferLocal`.

## Where the engine lives (split feature)

Shepherd's plugin system is **server‑side/in‑process** — a plugin can't run browser JS (`getUserMedia`/`MediaRecorder`) or add a button to the compose bar. So audio **capture** must live in core (this PR), and the **transcription engine** is a standalone plugin:

➡️ **`erwins-enkel/shepherd-plugin-voice-whisper`** (private) — detects ffmpeg + the whisper.cpp CLI + a GGML model; `POST /api/plugins/voice-whisper/transcribe` (multipart → temp file → ffmpeg 16 kHz WAV → `whisper-cli -f` → text) and `GET status`; Settings→Plugins detection panel. Install: `git clone … ~/.shepherd/plugins/voice-whisper` + restart.

This PR ships **disabled until that plugin is installed** — a stock clone behaves exactly as before (one memoized `GET status` probe that 404s, then Web Speech / hidden mic as today). The core→plugin coupling is a single well‑known route id.

## Core changes (this PR)

- `ui/src/lib/api.ts` — memoized `getVoiceStatus()` (404/absent → cached "unavailable") + `transcribeAudio(blob, lang)`.
- `ui/src/lib/components/ComposeBar.svelte` — local `MediaRecorder` path: mic shows when `speechSupported || (localVoiceAvailable && recorderSupported)`; local used when Web Speech is absent or `preferLocal`. Recording starts on an **in‑sheet tap** (fresh `getUserMedia` activation), never on mount; `MediaRecorder` construction/start failures release the stream and flash an error. iOS mp4 works because the plugin buffers to a seekable temp file (not `-i pipe:0`).
- `ui/src/lib/components/viewport/ViewportTermControls.svelte` — ◉ chip mirrors the same client‑support gate.
- EN/DE message keys + a feature‑announcement entry (`v1.42.0`).

## Review‑feedback follow‑ups (this push)

- **Client MediaRecorder/getUserMedia gating + failure handling** — added (see ComposeBar/ViewportTermControls above).
- **`maxBytes` before body ingestion** — fixed in the plugin repo (Content‑Length pre‑check before `formData()`, `file.size` kept as authoritative cap).
- **HTTP‑server detection + download fallback** — deliberately deferred per the approved plan; tracked as `erwins-enkel/shepherd-plugin-voice-whisper#1`.

## Testing

- UI: `svelte-check` (0 errors) + full **vitest (2711 tests)** + `check:i18n` parity — all green. PR‑hygiene gates (branch‑hygiene, feature‑catalog, announcement‑versions, glossary) pass; rebased on latest `main`.
- Plugin repo carries its own 10‑test unit suite (mocked runner/IO: file‑based argv, temp‑file cleanup, 413/503, model scan) + a `smoke.ts` for a real end‑to‑end run.

⚠️ **Unverified (needs hardware):** the **iOS standalone‑PWA** end‑to‑end pass — the feature's headline platform — can't be driven from CI. Please exercise record → insert → Send in home‑screen display mode before relying on the iOS win.
