### PR TITLE
fix(ui): stabilize settings dialog tabs

### DIFF
--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -268,6 +268,50 @@ describe("Settings responsive tab navigation", () => {
   });
 });
 
+describe("Settings dialog layout stability", () => {
+  afterEach(async () => {
+    await page.viewport(1280, 900);
+  });
+
+  function cardMetrics() {
+    const card = document.querySelector<HTMLElement>(".card");
+    expect(card).not.toBeNull();
+    const rect = card!.getBoundingClientRect();
+    return {
+      top: rect.top,
+      height: rect.height,
+      computedHeight: getComputedStyle(card!).height,
+    };
+  }
+
+  it("desktop tab switches keep the modal shell stable", async () => {
+    await page.viewport(1280, 900);
+    render(Settings, { onclose: noop, onsaved: noop });
+
+    await expect
+      .element(page.getByRole("tabpanel", { name: m.settings_tab_workspace() }))
+      .toBeInTheDocument();
+    const before = cardMetrics();
+
+    await page.getByRole("tab", { name: m.settings_tab_session() }).click();
+    await expect
+      .element(page.getByRole("tabpanel", { name: m.settings_tab_session() }))
+      .toBeInTheDocument();
+
+    const sessionPanel = document.querySelector<HTMLElement>("#settings-panel-session");
+    expect(sessionPanel).not.toBeNull();
+    expect(getComputedStyle(sessionPanel!).overflowY).toBe("auto");
+
+    const after = cardMetrics();
+    expect(after.computedHeight).toBe(before.computedHeight);
+
+    if (before.height > 0 && after.height > 0) {
+      expect(after.height).toBeCloseTo(before.height, 0);
+      expect(after.top).toBeCloseTo(before.top, 0);
+    }
+  });
+});
+
 // Regression guard for the issue's "no false success" criterion (PR #703): the green
 // "Fixed" toast must only fire when the RE-PROBED snapshot shows the targeted check ok.
 // A command that exits 0 but leaves the check non-ok (e.g. installer succeeds but its

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -1549,6 +1549,7 @@
   .card {
     position: relative;
     width: min(560px, 92vw);
+    height: min(680px, 86vh);
     max-height: 86vh;
     border: 1px solid var(--color-line-bright);
     background: var(--color-panel);


### PR DESCRIPTION
## Summary
- Give the settings modal a stable desktop height so tab switches do not move or resize the shell.
- Keep existing tab content mounted and scrolling inside the active panel.
- Add a browser regression for desktop modal geometry across tab switches.

## Verification
- cd ui && bun run check
- cd ui && bun run test:browser -- src/lib/components/Settings.browser.test.ts
- cd ui && bun run test
- pre-push hook passed