### PR TITLE
fix(ui): wrap RedrawMenu hint text within the popover

### DIFF
--- a/ui/src/lib/components/RedrawMenu.svelte
+++ b/ui/src/lib/components/RedrawMenu.svelte
@@ -172,6 +172,11 @@
     display: flex;
     flex-direction: column;
     gap: 1px;
+    /* The menu is a DOM child of .vp-head, which sets white-space:nowrap to keep
+       the toolbar single-line. white-space inherits down the DOM tree (even
+       across position:fixed), so without this reset the hint text never wraps
+       and spills past the menu's fixed width. */
+    white-space: normal;
   }
   .redraw-menu:focus {
     outline: none;


### PR DESCRIPTION
## Problem

Im **RedrawMenu**-Popover ("Redraw variants", hinter dem ↔-Icon im Terminal-Header) liefen die Beschreibungstexte (`.rm-hint`) einzeilig rechts aus dem Menürahmen heraus, statt innerhalb der Menübreite umzubrechen.

## Ursache

`RedrawMenu` wird als **DOM-Kind von `.vp-head`** gerendert (`Viewport.svelte:2075`, innerhalb des Header-`div`). `.vp-head` setzt `white-space: nowrap` (Zeile 2445), damit die Toolbar-Buttons einzeilig bleiben. `white-space` ist eine **vererbte** Eigenschaft und folgt dem **DOM-Baum** — auch bei `position: fixed`. Dadurch erbten `.rm-label`/`.rm-hint` das `nowrap`, brachen nie um und überschossen die feste `width: min(320px, calc(100vw - 16px))` nach rechts.

## Fix

Eine Zeile `white-space: normal;` auf `.redraw-menu` in `RedrawMenu.svelte` — das self-contained Popover erbt die Textfluss-Regel der Toolbar nicht mehr. Kein Markup-Change, `.vp-head` unangetastet, Design-System-konform (keine Literale/neuen Tokens).

## Verifikation

- `cd ui && bun run check` → 0 Fehler
- `cd ui && bun run test` → 2727 Tests grün (inkl. `RedrawMenu.browser.test.ts`)

## Scope

Chirurgisch auf die gemeldete Stelle beschränkt. Geschwister-Popover, die ebenfalls im `.vp-head`-Teilbaum gerendert werden, könnten dasselbe latente Vererbungsmuster haben, falls sie mehrzeiligen Text zeigen — aktuell nicht beobachtet und daher nicht Teil dieses PRs.
