### PR TITLE
fix(viewport): keep review-banner gear rotating under reduced-motion

### DIFF
--- a/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
+++ b/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
@@ -258,11 +258,13 @@
     color: var(--accent);
     animation: icon-btn-spin 2.4s linear infinite;
   }
-  /* Functional indicator: under reduced-motion swap rotation for the same
-     dot-pulse the REVIEWING dots use, so the "work happening" signal survives. */
+  /* Functional indicator: under reduced-motion keep the rotation (it's what
+     reads as "still working" here) but slow it way down instead of stopping
+     it, per WCAG guidance that gentle, non-essential motion is fine — only
+     the duration changes, not the keyframe. */
   @media (prefers-reduced-motion: reduce) {
     .rb-cog {
-      animation: dot-pulse 1.1s ease-in-out infinite !important;
+      animation-duration: 6s;
     }
   }
   .rb-text {

--- a/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
+++ b/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
@@ -260,11 +260,13 @@
   }
   /* Functional indicator: under reduced-motion keep the rotation (it's what
      reads as "still working" here) but slow it way down instead of stopping
-     it, per WCAG guidance that gentle, non-essential motion is fine — only
-     the duration changes, not the keyframe. */
+     it, per WCAG guidance that gentle, non-essential motion is fine. Needs
+     the full shorthand + !important: app.css's global reduced-motion rule
+     (`* { animation: none !important }`) otherwise wins over a bare
+     animation-duration override and the gear goes fully static. */
   @media (prefers-reduced-motion: reduce) {
     .rb-cog {
-      animation-duration: 6s;
+      animation: icon-btn-spin 6s linear infinite !important;
     }
   }
   .rb-text {


### PR DESCRIPTION
## Summary
- The review-in-flight banner's cog (`ReviewInFlightBanner.svelte`) already rotates via CSS (`icon-btn-spin`, shipped in #1363), but under `prefers-reduced-motion: reduce` it swapped to a pulsing-dot animation instead, so it read as static.
- Reported from a live screenshot: "it is pulsing, but not rotating ... a slowly rotate please."
- Fix: under reduced-motion, keep the same rotation but slow the duration to 6s instead of swapping to a different animation. Gentle, slow rotation is acceptable non-essential motion per WCAG guidance, and preserves the "still working" signal for reduced-motion users.

## Test plan
- [x] `cd ui && bun run check` — 0 errors
- [x] `cd ui && bun run test` — 203 test files / 2727 tests passed
- [x] Pre-push hooks (root tests, ui tests, fallow audit) passed