### PR TITLE
feat(ui): make epics in the backlog visible — sort to top, accent rows, real buttons

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2455,5 +2455,7 @@
   "settings_plugin_update_label": "Plugin-Updates verfügbar",
   "settings_plugin_update_count": "{count} deiner Plugins haben eine neuere Version",
   "feat_plugin_updates_title": "Sieh, wann deine Plugins Updates haben",
-  "feat_plugin_updates_body": "Die Einstellungen prüfen jetzt, ob deine installierten Plugins eine neuere veröffentlichte Version haben, und zeigen das an — für Plugins, die ein Repository deklarieren oder aus einem Git-Checkout laufen. Nur informativ; Updates werden weiterhin manuell angewendet."
+  "feat_plugin_updates_body": "Die Einstellungen prüfen jetzt, ob deine installierten Plugins eine neuere veröffentlichte Version haben, und zeigen das an — für Plugins, die ein Repository deklarieren oder aus einem Git-Checkout laufen. Nur informativ; Updates werden weiterhin manuell angewendet.",
+  "feat_epic_backlog_visibility_title": "Epics stechen im Backlog hervor",
+  "feat_epic_backlog_visibility_body": "In der Issue-Liste des Repo-Backlogs werden Epics jetzt nach oben sortiert und mit einem Bernstein-Akzent hervorgehoben, damit man sie leicht erkennt. Klappt man ein Epic auf, erscheinen seine Steuerelemente (Pause, Beaufsichtigt, Epic stoppen, Nächstes freigeben) als richtige Buttons statt als reiner Text."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2455,5 +2455,7 @@
   "settings_plugin_update_label": "Plugin updates available",
   "settings_plugin_update_count": "{count} of your plugins have a newer version",
   "feat_plugin_updates_title": "See when your plugins have updates",
-  "feat_plugin_updates_body": "Settings now checks whether your installed plugins have a newer released version and shows it — for plugins that declare a repository or run from a git checkout. It's informational only; updates are still applied manually."
+  "feat_plugin_updates_body": "Settings now checks whether your installed plugins have a newer released version and shows it — for plugins that declare a repository or run from a git checkout. It's informational only; updates are still applied manually.",
+  "feat_epic_backlog_visibility_title": "Epics stand out in the backlog",
+  "feat_epic_backlog_visibility_body": "In the repo backlog's Issues list, epics now sort to the top and carry an amber accent so they're easy to spot. Expanding one shows its controls (Pause, Attended, Stop epic, Approve next) as proper buttons instead of plain text."
 }

--- a/ui/src/lib/components/EpicHandsOffIntro.svelte
+++ b/ui/src/lib/components/EpicHandsOffIntro.svelte
@@ -215,4 +215,42 @@
   .ho-guide:hover {
     text-decoration: underline;
   }
+
+  /* Canonical .gbtn recipe from /design-system. Scoped-duplicated because Svelte
+     scopes styles per-component and there is no global .gbtn in app.css — without
+     it the Apply/Dismiss buttons render as bare unstyled text. */
+  .gbtn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 2px 8px;
+    cursor: pointer;
+  }
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .gbtn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+  .gbtn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  .gbtn.primary {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+
+  @media (max-width: 768px) {
+    .gbtn {
+      min-height: 40px;
+      padding: 2px 14px;
+    }
+  }
 </style>

--- a/ui/src/lib/components/EpicPanel.svelte
+++ b/ui/src/lib/components/EpicPanel.svelte
@@ -271,7 +271,58 @@
     padding-top: 2px;
   }
 
-  /* .gbtn and .gbtn.primary are global recipes from the design system;
-     they are defined app-wide (see /design-system) and work without local
-     duplication. */
+  /* ── progress badge ──────────────────────────────────────────────────────
+     Neutral pill for the "{merged}/{total} merged" head count — token-only,
+     mirrors the .label-chip / .chip recipe used elsewhere. */
+  .badge {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    padding: 1px 5px;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  /* ── buttons ─────────────────────────────────────────────────────────────
+     Canonical .gbtn recipe from /design-system. Copied into this component's
+     scoped style because Svelte scopes styles per-component and there is no
+     global .gbtn in app.css — every sibling that uses .gbtn duplicates it here
+     the same way. Without this the controls render as bare unstyled text. */
+  .gbtn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 2px 8px;
+    cursor: pointer;
+  }
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .gbtn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+  .gbtn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  .gbtn.primary {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+
+  @media (max-width: 768px) {
+    .gbtn {
+      min-height: 40px;
+      padding: 2px 14px;
+    }
+  }
 </style>

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -5,7 +5,13 @@
   import { steerAppliesToRepo } from "$lib/steer-scope";
   import type { Issue, Steer, EpicSummary, Epic } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
-  import { filterIssues, hideOthers, hideActive, hideSubIssues } from "./issues-panel";
+  import {
+    filterIssues,
+    hideOthers,
+    hideActive,
+    hideSubIssues,
+    sortEpicsFirst,
+  } from "./issues-panel";
   import { issuesFilter } from "$lib/issues-filter.svelte";
   import IssueRow from "./issues-panel/IssueRow.svelte";
   import IssueFilterPopover from "./IssueFilterPopover.svelte";
@@ -80,7 +86,9 @@
       epicParentNums,
     ),
   );
-  let visibleIssues = $derived(filterIssues(subFiltered, filter));
+  // Epic parents float to the top of the backlog (stable within each group), so
+  // epics are the first thing the operator sees. Applied after text filtering.
+  let visibleIssues = $derived(sortEpicsFirst(filterIssues(subFiltered, filter), epicParentNums));
   // True when there ARE open issues but the assignee filter hid them all — drives
   // the distinct "all assigned to others" empty state (vs the text no-match state).
   let allHiddenByAssignee = $derived(

--- a/ui/src/lib/components/issues-panel.test.ts
+++ b/ui/src/lib/components/issues-panel.test.ts
@@ -6,7 +6,14 @@
  * delegates to.
  */
 import { describe, it, expect } from "vitest";
-import { filterIssues, hideOthers, hideActive, hideSubIssues, ACTIVE_LABEL } from "./issues-panel";
+import {
+  filterIssues,
+  hideOthers,
+  hideActive,
+  hideSubIssues,
+  sortEpicsFirst,
+  ACTIVE_LABEL,
+} from "./issues-panel";
 import type { Issue } from "$lib/types";
 
 function issue(
@@ -184,5 +191,36 @@ describe("hideSubIssues", () => {
     const subs = new Set<number>([]);
     const parents = new Set<number>([2]);
     expect(hideSubIssues(all, true, subs, parents)).toEqual(all);
+  });
+});
+
+describe("sortEpicsFirst", () => {
+  const a = issue(122, "Regular A");
+  const epic1 = issue(100, "Epic one");
+  const b = issue(117, "Regular B");
+  const epic2 = issue(90, "Epic two");
+  const all = [a, epic1, b, epic2];
+
+  it("moves epic parents to the front", () => {
+    const parents = new Set<number>([100, 90]);
+    expect(sortEpicsFirst(all, parents)).toEqual([epic1, epic2, a, b]);
+  });
+
+  it("preserves relative order within each group (stable)", () => {
+    // epic2 appears after epic1 in the input, and a before b — both orders kept.
+    const parents = new Set<number>([100, 90]);
+    const result = sortEpicsFirst(all, parents);
+    expect(result.map((i) => i.number)).toEqual([100, 90, 122, 117]);
+  });
+
+  it("is an identity copy when there are no epic parents", () => {
+    const result = sortEpicsFirst(all, new Set<number>());
+    expect(result).toEqual(all);
+    expect(result).not.toBe(all); // new array, input not mutated
+  });
+
+  it("returns all issues when every issue is an epic parent", () => {
+    const parents = new Set<number>([122, 100, 117, 90]);
+    expect(sortEpicsFirst(all, parents)).toEqual(all);
   });
 });

--- a/ui/src/lib/components/issues-panel.ts
+++ b/ui/src/lib/components/issues-panel.ts
@@ -86,3 +86,23 @@ export function hideSubIssues(
   if (!enabled) return [...issues];
   return issues.filter((issue) => !(subIssues.has(issue.number) && !epicParents.has(issue.number)));
 }
+
+/**
+ * Reorder an issue list so epic parents (issues whose number is in `epicParents`)
+ * come first, followed by everything else. Stable — the relative order within
+ * each group is preserved (so the forge's newest-first ordering survives inside
+ * both groups). Returns a new array; the input is not mutated.
+ *
+ * A no-op (identity copy) when there are no epic parents in the list.
+ */
+export function sortEpicsFirst(
+  issues: readonly Issue[],
+  epicParents: ReadonlySet<number>,
+): Issue[] {
+  const epics: Issue[] = [];
+  const rest: Issue[] = [];
+  for (const issue of issues) {
+    (epicParents.has(issue.number) ? epics : rest).push(issue);
+  }
+  return [...epics, ...rest];
+}

--- a/ui/src/lib/components/issues-panel/IssueRow.svelte
+++ b/ui/src/lib/components/issues-panel/IssueRow.svelte
@@ -48,7 +48,7 @@
   const isEpicParent = $derived(!!epicSummary);
 </script>
 
-<div class="issue-row" id={`epic-issue-row-${issue.number}`}>
+<div class="issue-row" class:is-epic={isEpicParent} id={`epic-issue-row-${issue.number}`}>
   <div class="issue-top">
     <!-- eslint-disable svelte/no-navigation-without-resolve -- external GitHub URL, not an app route -->
     <a
@@ -163,6 +163,18 @@
     border: 1px solid var(--color-line);
     border-radius: 2px;
     background: var(--color-inset);
+  }
+
+  /* Epic parent rows stand out from ordinary issues: an amber (--status-running,
+     the epic/in-progress semantic) left accent + a faint amber wash. The tint is
+     deliberately low (6%) so the accent, the amber EPIC badge, and amber button
+     hovers on the same row read as one signal, not three competing ones. The
+     2px left border compensates 1px off the left padding to keep text aligned
+     with neighbouring non-epic rows. */
+  .issue-row.is-epic {
+    border-left: 2px solid var(--status-running);
+    padding-left: 7px;
+    background: color-mix(in oklab, var(--status-running) 6%, var(--color-inset));
   }
 
   .issue-top {

--- a/ui/src/lib/feature-announcements/entries/v1.42.0-epic-backlog-visibility.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.42.0-epic-backlog-visibility.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "epic-backlog-visibility",
+  sinceVersion: "1.42.0",
+  titleKey: "feat_epic_backlog_visibility_title",
+  bodyKey: "feat_epic_backlog_visibility_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## What & why

Makes epics in the repo backlog's **Issues** panel easier to find and act on. Three changes:

1. **Epic controls render as real buttons, not bare text.** `EpicPanel.svelte` (Pause / Attended / Stop epic / Approve next / Import structure + the `0/6 merged` badge) and `EpicHandsOffIntro.svelte` (Apply / Dismiss) used `class="gbtn"` (and `.badge`) but defined **no scoped rule** — a comment wrongly claimed `.gbtn` was "defined app-wide." There is no global `.gbtn`/`.badge` in `app.css`; every sibling component copies the canonical `/design-system` recipe into its own scoped `<style>`. Svelte scopes styles per-component, so these controls matched no rule and rendered as plain text. Added the canonical recipe to both components.

2. **Epics sort to the top.** New pure, stable `sortEpicsFirst()` helper (unit-tested) floats epic parents above ordinary issues in the Issues list; relative order within each group is preserved, and it's applied after text filtering so search still works.

3. **Epic rows stand out.** Epic parent rows get an amber (`--status-running`, the epic/in-progress semantic) left accent + a faint 6% wash. The tint is deliberately low so the accent, the amber `EPIC` badge, and amber button hovers on the same row read as one signal, not three competing ones.

## Before / after

The "Pause Attended Stop epic Approve next" bar previously appeared as unstyled inline text below the sub-issue list; it now renders as bordered `.gbtn` buttons (Approve next = amber primary). Epic rows now cluster at the top with an amber accent instead of blending into the list.

## Scope notes

- `.gbtn` is fixed **locally** in each affected component (matching every sibling), not promoted to a global — kept the diff surgical.
- An "EPICS" caption/separator between the epic block and the rest was considered and **deliberately dropped** (an unconfirmed extra; the accent + tint + sort already convey grouping).
- Client-only — no server/API changes.
- Ships one What's-New catalog entry (`v1.42.0-epic-backlog-visibility`) + EN/DE keys, per the feature-discovery gate.

## Testing

- `cd ui && bun run check` — 0 errors.
- `bun run check:i18n` — locales in parity.
- `bun run test` — full UI suite green, incl. 5 new `sortEpicsFirst` unit tests (2746 tests). (One pre-push run hit a known flaky `GitRail.browser.test.ts` timing timeout under concurrent-lane load — unrelated to this diff; passes 61/61 in isolation.)

No manual operator steps.
