### PR TITLE
feat(site): host Shepherd Capture privacy policy at /privacy

### DIFF
--- a/extension/STORE_LISTING.md
+++ b/extension/STORE_LISTING.md
@@ -71,7 +71,11 @@ research report (#1359, `docs/research/extension-chrome-web-store-readiness.md` 
   lending**. The extension transmits captures **only** to the user's own configured Shepherd
   server and to no other destination.
 
-## Privacy policy (body text — host at a public URL, then paste the URL into the dashboard)
+## Privacy policy — hosted at https://shepherd.run/privacy
+
+**Published:** the policy is live at **https://shepherd.run/privacy** (source:
+`site/src/pages/privacy.astro`). Paste that URL into the CWS dashboard's Privacy-practices tab.
+The body below is the source of truth the hosted page mirrors — keep the two in sync if either changes.
 
 > **Shepherd Capture — Privacy Policy**
 >
@@ -98,7 +102,7 @@ research report (#1359, `docs/research/extension-chrome-web-store-readiness.md` 
 > access (all-sites recording; Tailscale) is granted at runtime and revocable at any time from
 > `chrome://extensions`.
 >
-> **Contact.** <add a contact email or link before publishing>
+> **Contact.** hallo@erwins-enkel.dev
 
 ---
 
@@ -112,13 +116,15 @@ research report (#1359, `docs/research/extension-chrome-web-store-readiness.md` 
 3. Upload listing assets: the 128×128 store icon (`store-assets/store-icon-128.png`), ≥1
    screenshot at 1280×800, and the 440×280 promo tile (see `store-assets/README.md`).
 4. Fill the **Privacy practices** tab with the single-purpose statement, per-permission +
-   per-host justifications, and data-usage certifications above; set the privacy-policy URL.
+   per-host justifications, and data-usage certifications above; set the privacy-policy URL to
+   `https://shepherd.run/privacy`.
 5. Set **remote code = No**, visibility **Unlisted**, and submit for review.
 
 ## Out-of-scope prerequisites (human/ops — not doable in code)
 
 - Register the CWS developer account + pay the one-time **$5** fee; declare **Trader/Non-Trader**.
-- **Host the privacy policy** body above at a public URL and add a contact address.
+- ~~**Host the privacy policy** body above at a public URL and add a contact address.~~ ✅ Done —
+  hosted at https://shepherd.run/privacy (`site/src/pages/privacy.astro`).
 - Produce the **screenshot(s)** and **promo tile**.
 - After registration, read back the item's **final assigned ID** and reconcile it — see below.
 

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -8,6 +8,8 @@ const LICENSE_URL =
 const DOCS_URL = "https://docs.shepherd.run";
 // Legal notice (§ 5 DDG) — first-party page, same-tab navigation.
 const IMPRESSUM_URL = "/impressum";
+// Privacy policy for the Shepherd Capture extension — first-party page, same-tab.
+const PRIVACY_URL = "/privacy";
 // Operating company behind Shepherd.
 const ERWINS_ENKEL_URL = "https://www.erwins-enkel.dev/";
 ---
@@ -28,6 +30,7 @@ const ERWINS_ENKEL_URL = "https://www.erwins-enkel.dev/";
         <a href={LICENSE_URL} rel="noopener noreferrer" target="_blank"
           >License</a
         >
+        <a href={PRIVACY_URL}>Privacy</a>
         <a href={IMPRESSUM_URL}>Imprint</a>
       </nav>
     </div>

--- a/site/src/pages/privacy.astro
+++ b/site/src/pages/privacy.astro
@@ -1,0 +1,156 @@
+---
+// Privacy policy for the Shepherd Capture browser extension. Hosted here so the
+// Chrome Web Store listing can point at a stable public URL (https://shepherd.run/privacy).
+// Body text is reproduced VERBATIM from the reviewed policy in
+// extension/STORE_LISTING.md (§"Privacy policy"); only structural mapping (bold
+// lead-ins → <h2>) and <code>/<strong> formatting are applied. Kept in English to
+// match the rest of the marketing site, like the imprint. Modeled on impressum.astro.
+//
+// Angle-bracket note: `<host>` in the Tailscale URL is escaped as `&lt;host&gt;` —
+// a bare <host> would be parsed as an empty HTML element and its surrounding text
+// silently dropped.
+import Base from "../layouts/Base.astro";
+import Nav from "../components/Nav.astro";
+import Footer from "../components/Footer.astro";
+---
+
+<Base
+  title="Privacy Policy — Shepherd Capture"
+  description="Privacy policy for the Shepherd Capture browser extension: what it handles, where captured data goes, and how it is stored."
+>
+  <Nav />
+  <main id="top" class="legal">
+    <div class="inner">
+      <h1>Shepherd Capture — Privacy Policy</h1>
+
+      <p>
+        Shepherd Capture is a companion to a self-hosted Shepherd instance that the
+        user runs and controls. It exists to send captured browser context to that
+        server and nowhere else.
+      </p>
+
+      <section>
+        <h2>What it handles</h2>
+        <p>
+          When you invoke a capture, the extension collects: the current page's URL
+          and title; a screenshot of the visible tab, the full page, or a picked
+          element; and — only when you explicitly enable them — an <code>axe-core</code>
+          accessibility report, buffered <code>console.error</code>/<code>warn</code>
+          and uncaught-error messages, and failed network-request URLs. Note that
+          failed-request URLs can contain query-string tokens; enable console/network
+          recording with that in mind. The extension also stores your settings and
+          Shepherd access token.
+        </p>
+      </section>
+
+      <section>
+        <h2>Where it goes</h2>
+        <p>
+          Captured data is transmitted <strong>only</strong> to the Shepherd server
+          you configure (<code>http://localhost:7330</code> on your own machine, or
+          your own <code>https://&lt;host&gt;.ts.net</code> core over Tailscale). It is
+          <strong>never</strong> sent to the extension's developers or to any third
+          party. The developers receive nothing and act as no kind of data controller
+          or processor for your captures.
+        </p>
+      </section>
+
+      <section>
+        <h2>Local storage</h2>
+        <p>
+          Your settings and access token are kept in <code>chrome.storage.local</code>
+          on your device. They are never synced to any account and never leave your
+          browser except as the <code>Authorization</code> header on requests to your
+          own configured server.
+        </p>
+      </section>
+
+      <section>
+        <h2>Your control</h2>
+        <p>
+          Uninstalling the extension removes all locally-stored settings. Optional host
+          access (all-sites recording; Tailscale) is granted at runtime and revocable
+          at any time from <code>chrome://extensions</code>.
+        </p>
+      </section>
+
+      <section>
+        <h2>Contact</h2>
+        <p>
+          Email: <a href="mailto:hallo@erwins-enkel.dev">hallo@erwins-enkel.dev</a>
+        </p>
+      </section>
+    </div>
+  </main>
+  <Footer />
+</Base>
+
+<style>
+  .legal {
+    padding: clamp(3rem, 8vw, 5.5rem) 1.5rem;
+  }
+
+  .inner {
+    max-width: 46rem;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  }
+
+  h1 {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: clamp(2rem, 5vw, 2.75rem);
+    letter-spacing: -0.02em;
+    color: var(--ink);
+  }
+
+  h2 {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 1.15rem;
+    color: var(--ink);
+    margin-bottom: 0.4rem;
+  }
+
+  p {
+    color: var(--ink-muted);
+  }
+
+  strong {
+    color: var(--ink);
+    font-weight: 700;
+  }
+
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    word-break: break-word;
+  }
+
+  a {
+    color: var(--ink);
+    border-bottom: 1px solid var(--panel-2);
+    transition:
+      color 0.15s ease,
+      border-color 0.15s ease;
+  }
+
+  a:hover {
+    color: var(--ink);
+    border-color: var(--green);
+  }
+
+  a:focus-visible {
+    outline: 2px solid var(--green);
+    outline-offset: 3px;
+    border-radius: 2px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    a {
+      transition: none;
+    }
+  }
+</style>


### PR DESCRIPTION
Closes #1368. Follow-up to #1360 / PR #1365 (Chrome Web Store readiness).

## What
Publishes the already-reviewed **Shepherd Capture privacy policy** as a dedicated static page at a stable **`https://shepherd.run/privacy`**, so the CWS submission can point at a permanent public URL. Modeled on the existing `/impressum` legal page.

- **`site/src/pages/privacy.astro`** (new) — Base + Nav + Footer, mirrors the impressum's `.legal` styling, English-only. Policy text reproduced **verbatim** from `extension/STORE_LISTING.md` (§"Privacy policy"); bold lead-ins → `<h2>` sections. Contact placeholder filled with `hallo@erwins-enkel.dev` (same as `/impressum`).
- **`site/src/components/Footer.astro`** — adds a `Privacy` → `/privacy` link beside `Imprint`.
- **`extension/STORE_LISTING.md`** — now that #1365 has landed, points the privacy-policy reference at the hosted `https://shepherd.run/privacy`, fills the doc's contact placeholder with `hallo@erwins-enkel.dev` to match the live page, and marks the "host the privacy policy" prerequisite done. (This folds in what was previously a post-merge manual step.)

## Render-fidelity notes
- `<host>` in the Tailscale URL is escaped as `&lt;host&gt;` — a bare `<host>` would be parsed as an empty HTML element and its surrounding text silently dropped. Verified in the built `dist/privacy/index.html` that `https://<host>.ts.net` renders and no `<host>` / `<add a contact…>` source token survives.
- Inline `**only**` / `**never**` (in "Where it goes") render as `<strong>`; all technical tokens as `<code>`.

## Verification
- `cd site && bun run build` → clean, emits `dist/privacy/index.html`.
- `bun run check` (astro check) → 0 errors (one pre-existing hint in `InstallBlock.astro`, unrelated).
- `prettier --check` on all touched files → passes.
- Grepped built HTML: all policy blocks present, real contact present, no dropped angle-bracket tokens.

## Note on the duplicated policy body
The policy prose now lives in both `extension/STORE_LISTING.md` (source of truth) and `site/src/pages/privacy.astro` (the hosted mirror). This is intentional and flagged in the doc ("keep the two in sync"); the `jscpd` duplication check emits a non-blocking warn for it.

## Scope notes
- The related **"also add /impressum"** item is already done — that route exists and is footer-linked; nothing added.

## Manual operator steps
```shepherd:manual-steps
- [ ] POST-MERGE: Paste https://shepherd.run/privacy into the Chrome Web Store dashboard's Privacy-practices tab
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)