### PR TITLE
fix(drain): gate extra-credit pause on imminent, not cumulative, spend

### DIFF
--- a/src/drain-core.ts
+++ b/src/drain-core.ts
@@ -84,7 +84,11 @@ export interface DrainRepoState {
   usageCeilingPct: number;
   /** The worse of the 5h / weekly usage windows, 0–100. */
   usagePct: number;
-  /** Paid extra-credit spend this monthly window (account-wide), 0 when none/stale/unknown. */
+  /** Paid extra-credit spend accrued since the current WEEKLY subscription window began
+   *  (account-wide), 0 when none/stale/unknown. NOT the raw month-to-date total: a nonzero
+   *  cumulative total with fresh weekly headroom is historical, not imminent, spend and reads 0
+   *  here (see DrainService.effectiveCreditSpent). This keeps the pause on the subscription
+   *  cadence instead of stuck until the monthly credit reset. */
   creditSpent: number;
   /** Account-wide ceiling (account currency units); spend strictly above it pauses the drain. */
   creditSpendCeiling: number;
@@ -230,7 +234,9 @@ export function computeNext(state: DrainRepoState): DrainDecision {
     return { kind: "hold", reason: { code: "usage", detail: String(state.usagePct) } };
   }
 
-  // Extra-credit cost guard: never keep spending real pay-as-you-go money unattended.
+  // Extra-credit cost guard: never keep spending NEW real pay-as-you-go money unattended.
+  // creditSpent is spend accrued since the weekly window began (see effectiveCreditSpent), so a
+  // nonzero month-to-date total with subscription headroom does NOT pause here.
   if (state.creditSpent > state.creditSpendCeiling) {
     return { kind: "hold", reason: { code: "credits", detail: String(state.creditSpent) } };
   }

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -475,16 +475,20 @@ export class DrainService {
       this.creditBaseline = { spent: credits.spent, weekResetAt };
       return 0;
     }
-    // Re-anchor when either window that bounds paid spend rolls over:
-    //  - credits.spent DROPS below the anchor → the monthly credit budget reset (the scraped
-    //    total is monotonic within a month, so any decrease is a reset boundary). Without this,
-    //    fresh spend in the NEW month is masked until it re-climbs past last month's anchor, and
-    //    the default-0 ceiling fails to pause on real new spend.
-    //  - the weekly subscription window rolls over → fresh headroom (temporarily) stops paid
-    //    spend, so last week's overage no longer gates this week's drain.
-    const weeklyRolled =
-      weekResetAt != null && b.weekResetAt != null && weekResetAt > b.weekResetAt;
-    if (credits.spent < b.spent || weeklyRolled) {
+    // Monthly credit budget rolled over — the scraped total is monotonic within a month, so any
+    // DROP below the anchor is a reset boundary and the new cycle starts at 0, making ALL of it
+    // new spend. Anchor at 0 (NOT the current reading, which would mask spend already accrued
+    // before this first post-reset observation — the default-0 ceiling would then fail to pause on
+    // it) and count the observed new-cycle total in full. Checked BEFORE the weekly roll so a
+    // coincident monthly+weekly reset still counts (the weekly branch's re-anchor-to-current masks).
+    if (credits.spent < b.spent) {
+      this.creditBaseline = { spent: 0, weekResetAt };
+      return credits.spent;
+    }
+    // Weekly subscription window rolled over → fresh headroom (temporarily) stops paid spend, so
+    // last week's overage no longer gates this week's drain. Anchor at the current total (spend in
+    // earlier weeks of the SAME month is historical, unlike the fresh-from-0 monthly case above).
+    if (weekResetAt != null && b.weekResetAt != null && weekResetAt > b.weekResetAt) {
       this.creditBaseline = { spent: credits.spent, weekResetAt };
       return 0;
     }

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -247,11 +247,16 @@ export class DrainService {
    *  exhausted — so a nonzero month-to-date total while the weekly window still has headroom is
    *  HISTORICAL spend, not imminent spend, and must not freeze the drain until the monthly credit
    *  reset. We anchor the total at first observation and re-anchor at each weekly-window reset AND
-   *  whenever the scraped total drops (the monthly credit budget rolled over), then gate on spend
-   *  accrued SINCE that anchor (see {@link effectiveCreditSpent}). null until first observed. On
-   *  restart the anchor re-captures the current total, which is why a deploy of this fix immediately
-   *  clears a stale historical-spend pause. */
-  private creditBaseline: { spent: number; weekResetAt: number | null } | null = null;
+   *  at each monthly credit-budget rollover (detected by the credit reset epoch advancing, with a
+   *  spend-drop fallback for an unparseable reset label), then gate on spend accrued SINCE that
+   *  anchor (see {@link effectiveCreditSpent}). null until first observed. On restart the anchor
+   *  re-captures the current total, which is why a deploy of this fix immediately clears a stale
+   *  historical-spend pause. */
+  private creditBaseline: {
+    spent: number;
+    weekResetAt: number | null;
+    monthResetAt: number | null;
+  } | null = null;
   private now: () => number;
   private issuesTtlMs: number;
   /** #1071: injectable seam; defaults to the real rebaseLandingBranch import. */
@@ -467,34 +472,42 @@ export class DrainService {
     const credits = limits.credits;
     if (!credits || credits.stale) return 0;
     const weekResetAt = limits.week?.resetAt ?? null;
+    const monthResetAt = credits.resetAt; // the monthly credit-budget reset epoch (null if unparsed)
     const b = this.creditBaseline;
     // First observation (incl. after a restart): anchor the historical total; govern only spend
     // from here. A subscription window with headroom means no paid spend is happening now, so
     // baselining out the pre-existing total is safe; any genuinely new spend still rises above it.
     if (!b) {
-      this.creditBaseline = { spent: credits.spent, weekResetAt };
+      this.creditBaseline = { spent: credits.spent, weekResetAt, monthResetAt };
       return 0;
     }
-    // Monthly credit budget rolled over — the scraped total is monotonic within a month, so any
-    // DROP below the anchor is a reset boundary and the new cycle starts at 0, making ALL of it
-    // new spend. Anchor at 0 (NOT the current reading, which would mask spend already accrued
-    // before this first post-reset observation — the default-0 ceiling would then fail to pause on
-    // it) and count the observed new-cycle total in full. Checked BEFORE the weekly roll so a
-    // coincident monthly+weekly reset still counts (the weekly branch's re-anchor-to-current masks).
-    if (credits.spent < b.spent) {
-      this.creditBaseline = { spent: 0, weekResetAt };
+    // Monthly credit budget rolled over → the new cycle starts at 0, so ALL of it is new spend.
+    // Detect via EITHER the monthly reset epoch advancing (the robust signal — catches a new cycle
+    // that already reached/exceeded last month's total before our first fresh scrape, e.g. Shepherd
+    // stale/down across the boundary; a spend-drop check alone would then subtract the old anchor
+    // and under-count) OR, as a fallback when the reset label was unparseable (null epoch), the
+    // scraped total dropping below the anchor. Anchor at 0 and count the observed new-cycle total in
+    // full — NEVER subtract the old-month anchor. Checked BEFORE the weekly roll so a coincident
+    // monthly+weekly reset still counts (the weekly branch re-anchors to current, which would mask).
+    const monthlyRolled =
+      (monthResetAt != null && b.monthResetAt != null && monthResetAt > b.monthResetAt) ||
+      credits.spent < b.spent;
+    if (monthlyRolled) {
+      this.creditBaseline = { spent: 0, weekResetAt, monthResetAt };
       return credits.spent;
     }
     // Weekly subscription window rolled over → fresh headroom (temporarily) stops paid spend, so
     // last week's overage no longer gates this week's drain. Anchor at the current total (spend in
     // earlier weeks of the SAME month is historical, unlike the fresh-from-0 monthly case above).
     if (weekResetAt != null && b.weekResetAt != null && weekResetAt > b.weekResetAt) {
-      this.creditBaseline = { spent: credits.spent, weekResetAt };
+      this.creditBaseline = { spent: credits.spent, weekResetAt, monthResetAt };
       return 0;
     }
-    // Adopt a late-arriving weekly anchor (calibration landed after we first observed credits)
-    // without disturbing the spend anchor — so future resets become detectable.
+    // Adopt late-arriving anchors (weekly calibration or a monthly reset label that only parsed
+    // after we first observed credits) without disturbing the spend anchor — so future resets
+    // stay detectable.
     if (b.weekResetAt == null && weekResetAt != null) b.weekResetAt = weekResetAt;
+    if (b.monthResetAt == null && monthResetAt != null) b.monthResetAt = monthResetAt;
     return Math.max(0, credits.spent - b.spent);
   }
 

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -242,6 +242,15 @@ export class DrainService {
    *  of an issue whose create() keeps throwing. Cleared on a successful spawn. In-memory. */
   private spawnFailures = new Map<string, number>();
   private approvedNext = new Set<string>();
+  /** Extra-credit cost-guard baseline (account-wide, in-memory/ephemeral). The scraped paid-credit
+   *  total is CUMULATIVE MONTHLY, but paid overage only accrues once a subscription window is
+   *  exhausted — so a nonzero month-to-date total while the weekly window still has headroom is
+   *  HISTORICAL spend, not imminent spend, and must not freeze the drain until the monthly credit
+   *  reset. We anchor the total at first observation and re-anchor at each weekly-window reset, then
+   *  gate on spend accrued SINCE that anchor (see {@link effectiveCreditSpent}). null until first
+   *  observed. On restart the anchor re-captures the current total, which is why a deploy of this
+   *  fix immediately clears a stale historical-spend pause. */
+  private creditBaseline: { spent: number; weekResetAt: number | null } | null = null;
   private now: () => number;
   private issuesTtlMs: number;
   /** #1071: injectable seam; defaults to the real rebaseLandingBranch import. */
@@ -441,6 +450,42 @@ export class DrainService {
 
   // ── state assembly ──────────────────────────────────────────────────────────
 
+  /**
+   * Effective extra-credit spend for the drain cost guard: paid pay-as-you-go overage accrued
+   * since the current weekly subscription window began (see {@link creditBaseline}), NOT the raw
+   * cumulative month-to-date total. Paid overage can only be spent while a subscription window is
+   * exhausted, so a nonzero month-to-date total with fresh weekly headroom is historical spend
+   * that must not pause the drain until the (much later) monthly credit reset — the bug this
+   * fixes. Returns 0 when credits are absent or stale (fail-safe: never pause on a missing/stale
+   * scrape). Idempotent within a pump: the anchor only advances on first observation and when the
+   * weekly reset boundary moves, so repeated per-repo calls in one pump (and the read-path
+   * snapshot()/queue()) can't drift it, and it never flaps — a credit pause holds until the weekly
+   * window actually resets rather than clearing the instant spawning stops.
+   */
+  private effectiveCreditSpent(limits: UsageLimits): number {
+    const credits = limits.credits;
+    if (!credits || credits.stale) return 0;
+    const weekResetAt = limits.week?.resetAt ?? null;
+    const b = this.creditBaseline;
+    // First observation (incl. after a restart): anchor the historical total; govern only spend
+    // from here. A subscription window with headroom means no paid spend is happening now, so
+    // baselining out the pre-existing total is safe; any genuinely new spend still rises above it.
+    if (!b) {
+      this.creditBaseline = { spent: credits.spent, weekResetAt };
+      return 0;
+    }
+    // Weekly window rolled over → fresh subscription headroom, so paid spend (temporarily) stops.
+    // Re-anchor to the current total so last week's overage no longer gates this week's drain.
+    if (weekResetAt != null && b.weekResetAt != null && weekResetAt > b.weekResetAt) {
+      this.creditBaseline = { spent: credits.spent, weekResetAt };
+      return 0;
+    }
+    // Adopt a late-arriving weekly anchor (calibration landed after we first observed credits)
+    // without disturbing the spend anchor — so future resets become detectable.
+    if (b.weekResetAt == null && weekResetAt != null) b.weekResetAt = weekResetAt;
+    return Math.max(0, credits.spent - b.spent);
+  }
+
   private async buildState(repoPath: string): Promise<{
     state: DrainRepoState & { epicParent: number | null };
     epic: Epic | null;
@@ -519,9 +564,11 @@ export class DrainService {
         maxAuto: cfg.maxAuto,
         usageCeilingPct: cfg.usageCeilingPct,
         usagePct,
-        // Extra-credit cost guard: paid overage spent this window (0 when credits is
-        // null/stale/post-reset — fail-safe), against the account-wide live ceiling.
-        creditSpent: limits.credits && !limits.credits.stale ? limits.credits.spent : 0,
+        // Extra-credit cost guard: paid overage accrued since the current weekly window began
+        // (0 when credits is null/stale/post-reset — fail-safe), against the account-wide live
+        // ceiling. NOT the raw month-to-date total — see effectiveCreditSpent for why (a nonzero
+        // cumulative total with fresh weekly headroom is historical, not imminent, spend).
+        creditSpent: this.effectiveCreditSpent(limits),
         creditSpendCeiling: config.extraCreditsDrainCeiling,
         autoSessions,
         mappedIssueNumbers,

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -246,10 +246,11 @@ export class DrainService {
    *  total is CUMULATIVE MONTHLY, but paid overage only accrues once a subscription window is
    *  exhausted — so a nonzero month-to-date total while the weekly window still has headroom is
    *  HISTORICAL spend, not imminent spend, and must not freeze the drain until the monthly credit
-   *  reset. We anchor the total at first observation and re-anchor at each weekly-window reset, then
-   *  gate on spend accrued SINCE that anchor (see {@link effectiveCreditSpent}). null until first
-   *  observed. On restart the anchor re-captures the current total, which is why a deploy of this
-   *  fix immediately clears a stale historical-spend pause. */
+   *  reset. We anchor the total at first observation and re-anchor at each weekly-window reset AND
+   *  whenever the scraped total drops (the monthly credit budget rolled over), then gate on spend
+   *  accrued SINCE that anchor (see {@link effectiveCreditSpent}). null until first observed. On
+   *  restart the anchor re-captures the current total, which is why a deploy of this fix immediately
+   *  clears a stale historical-spend pause. */
   private creditBaseline: { spent: number; weekResetAt: number | null } | null = null;
   private now: () => number;
   private issuesTtlMs: number;
@@ -474,9 +475,16 @@ export class DrainService {
       this.creditBaseline = { spent: credits.spent, weekResetAt };
       return 0;
     }
-    // Weekly window rolled over → fresh subscription headroom, so paid spend (temporarily) stops.
-    // Re-anchor to the current total so last week's overage no longer gates this week's drain.
-    if (weekResetAt != null && b.weekResetAt != null && weekResetAt > b.weekResetAt) {
+    // Re-anchor when either window that bounds paid spend rolls over:
+    //  - credits.spent DROPS below the anchor → the monthly credit budget reset (the scraped
+    //    total is monotonic within a month, so any decrease is a reset boundary). Without this,
+    //    fresh spend in the NEW month is masked until it re-climbs past last month's anchor, and
+    //    the default-0 ceiling fails to pause on real new spend.
+    //  - the weekly subscription window rolls over → fresh headroom (temporarily) stops paid
+    //    spend, so last week's overage no longer gates this week's drain.
+    const weeklyRolled =
+      weekResetAt != null && b.weekResetAt != null && weekResetAt > b.weekResetAt;
+    if (credits.spent < b.spent || weeklyRolled) {
       this.creditBaseline = { spent: credits.spent, weekResetAt };
       return 0;
     }

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -703,6 +703,26 @@ test("weekly window reset re-anchors credits → a credit pause clears at the re
   expect(h.statuses.at(-1)!.reason).not.toBe("credits"); // re-anchored to 15 → 0 → un-paused
 });
 
+// The monthly credit budget resets independently of the weekly window: the scraped total DROPS
+// (e.g. 46.47 → 0). The anchor must follow that drop, else fresh new-month spend is masked until
+// it re-climbs past last month's anchor and the default-0 ceiling fails to pause on real spend.
+test("monthly credit reset (total drops) re-anchors → fresh new-month spend still pauses", async () => {
+  let spent = 46.47;
+  const h = makeHarness({
+    maxAuto: 2,
+    issues: [issue(1)],
+    limitsImpl: usageWithCredit(() => ({ spent, weekResetAt: WEEK_RESET, weekPct: 50 })),
+  });
+  await h.drain.snapshot(); // anchor := 46.47 (end of month)
+  spent = 0; // monthly budget rolled over → cumulative total drops
+  await h.drain.snapshot(); // re-anchor := 0
+  spent = 5; // €5 of genuinely new spend in the fresh month
+  await h.drain.pump(REPO);
+  const last = h.statuses.at(-1)!;
+  expect(last.reason).toBe("credits"); // 5 > ceiling 0 → paused, NOT masked by the old anchor
+  expect(h.creates).toHaveLength(0);
+});
+
 test("merged → archive → advance chain: onGit(merged) closes issue, archives, drops, emits, and onArchived spawns #2", async () => {
   const advances: Promise<void>[] = [];
   const h = makeHarness({

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -144,6 +144,9 @@ function makeHarness(
     usagePct?: number;
     usageCeilingPct?: number;
     credits?: UsageLimitsType["credits"];
+    /** Full control over the usage source (overrides usagePct/credits) — lets a test drive a
+     *  CHANGING scrape across successive buildState calls (rising credit spend, weekly reset). */
+    limitsImpl?: () => UsageLimitsType;
     mergeImpl?: () => Promise<void>;
     listIssuesImpl?: () => Promise<Issue[]>;
     archiveImpl?: (id: string) => number | Promise<number>;
@@ -242,6 +245,7 @@ function makeHarness(
 
   const usage = {
     limits: (): UsageLimitsType => {
+      if (opts.limitsImpl) return opts.limitsImpl();
       const pct = opts.usagePct ?? 0;
       const base = pct > 0 ? { ...NO_USAGE, session5h: { pct, resetAt: 0 } } : { ...NO_USAGE };
       if (opts.credits !== undefined) base.credits = opts.credits;
@@ -629,18 +633,74 @@ test("stale credits snapshot → NO credits hold (drain proceeds, stale data dis
   expect(h.creates).toHaveLength(1); // spawned: not frozen on stale spend
 });
 
-// Control: same overage, fresh snapshot → DOES hold. Proves the !stale gate is the difference.
-test("fresh credits snapshot over ceiling → credits hold (paused)", async () => {
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+const WEEK_RESET = 1_700_000_000_000; // fixed epoch; injected verbatim (no rollForward in tests)
+
+// Build a usage source whose weekly window + credit spend can be mutated between pumps, to
+// exercise the "spend since the weekly window began" cost guard (effectiveCreditSpent).
+function usageWithCredit(
+  read: () => { spent: number; weekResetAt: number | null; weekPct?: number },
+) {
+  return (): UsageLimitsType => {
+    const { spent, weekResetAt, weekPct = 20 } = read();
+    return {
+      ...NO_USAGE,
+      week: weekResetAt == null ? null : { pct: weekPct, resetAt: weekResetAt },
+      credits: creditWindow({ spent, resetAt: WEEK_RESET + 2 * WEEK_MS }),
+    };
+  };
+}
+
+// THE FIX: a large month-to-date credit total with fresh weekly headroom is HISTORICAL spend
+// (paid overage can only accrue while a window is exhausted). It must NOT freeze the drain — the
+// old guard paused until the monthly credit reset even with plenty of subscription left.
+test("month-to-date credits but weekly headroom → NO credits hold (historical spend baselined out)", async () => {
   const h = makeHarness({
     maxAuto: 2,
     issues: [issue(1)],
-    credits: creditWindow({ spent: 999, stale: false }),
+    limitsImpl: usageWithCredit(() => ({ spent: 46.47, weekResetAt: WEEK_RESET, weekPct: 27 })),
   });
+  await h.drain.pump(REPO);
+  const last = h.statuses.at(-1)!;
+  expect(last.reason).not.toBe("credits");
+  expect(h.creates).toHaveLength(1); // drained: a pre-existing total doesn't pause it
+});
+
+// Control: NEW paid spend accruing after the baseline (window re-exhausted this week) → DOES hold.
+test("credits rising above the weekly baseline → credits hold (paused)", async () => {
+  let spent = 25; // anchored on first observation
+  const h = makeHarness({
+    maxAuto: 2,
+    issues: [issue(1)],
+    limitsImpl: usageWithCredit(() => ({ spent, weekResetAt: WEEK_RESET, weekPct: 50 })),
+  });
+  await h.drain.snapshot(); // first observation → anchor := 25
+  spent = 30; // +5 of genuinely new paid spend this weekly cycle
   await h.drain.pump(REPO);
   const last = h.statuses.at(-1)!;
   expect(last.reason).toBe("credits");
   expect(last.paused).toBe(true);
   expect(h.creates).toHaveLength(0);
+});
+
+// The pause tracks the SUBSCRIPTION cadence: a credit hold clears when the weekly window resets
+// (re-anchoring to the current total), not stuck until the monthly credit reset.
+test("weekly window reset re-anchors credits → a credit pause clears at the reset", async () => {
+  let spent = 10;
+  let weekResetAt = WEEK_RESET;
+  const h = makeHarness({
+    maxAuto: 2,
+    issues: [issue(1)],
+    limitsImpl: usageWithCredit(() => ({ spent, weekResetAt, weekPct: 50 })),
+  });
+  await h.drain.snapshot(); // anchor := 10 @ WEEK_RESET
+  spent = 15; // +5 new paid spend this week
+  await h.drain.pump(REPO);
+  expect(h.statuses.at(-1)!.reason).toBe("credits"); // paused: 5 > ceiling 0
+
+  weekResetAt = WEEK_RESET + WEEK_MS; // weekly window rolled over → fresh headroom
+  await h.drain.pump(REPO);
+  expect(h.statuses.at(-1)!.reason).not.toBe("credits"); // re-anchored to 15 → 0 → un-paused
 });
 
 test("merged → archive → advance chain: onGit(merged) closes issue, archives, drops, emits, and onArchived spawns #2", async () => {

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -14,6 +14,7 @@ import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { CreateSessionInput, ReviewDecision, Session } from "../src/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
 import type { Epic } from "../src/epic-core";
+import { config } from "../src/config";
 
 const REPO = "/repo";
 
@@ -635,18 +636,25 @@ test("stale credits snapshot → NO credits hold (drain proceeds, stale data dis
 
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 const WEEK_RESET = 1_700_000_000_000; // fixed epoch; injected verbatim (no rollForward in tests)
+const MONTH_RESET = WEEK_RESET + 2 * WEEK_MS; // the monthly credit-budget reset epoch
 
-// Build a usage source whose weekly window + credit spend can be mutated between pumps, to
-// exercise the "spend since the weekly window began" cost guard (effectiveCreditSpent).
+// Build a usage source whose weekly window + credit spend (+ monthly reset epoch) can be mutated
+// between pumps, to exercise the "spend since the weekly window began" cost guard
+// (effectiveCreditSpent).
 function usageWithCredit(
-  read: () => { spent: number; weekResetAt: number | null; weekPct?: number },
+  read: () => {
+    spent: number;
+    weekResetAt: number | null;
+    weekPct?: number;
+    monthResetAt?: number | null;
+  },
 ) {
   return (): UsageLimitsType => {
-    const { spent, weekResetAt, weekPct = 20 } = read();
+    const { spent, weekResetAt, weekPct = 20, monthResetAt = MONTH_RESET } = read();
     return {
       ...NO_USAGE,
       week: weekResetAt == null ? null : { pct: weekPct, resetAt: weekResetAt },
-      credits: creditWindow({ spent, resetAt: WEEK_RESET + 2 * WEEK_MS }),
+      credits: creditWindow({ spent, resetAt: monthResetAt }),
     };
   };
 }
@@ -739,6 +747,40 @@ test("monthly reset observed late (first post-reset total nonzero) → still pau
   const last = h.statuses.at(-1)!;
   expect(last.reason).toBe("credits"); // counts €5 from 0 — not masked by re-anchoring to it
   expect(h.creates).toHaveLength(0);
+});
+
+// A monthly reset with NO spend drop: the new cycle already reached/exceeded last month's total
+// before the first fresh scrape (Shepherd stale/down across the boundary). A spend-drop heuristic
+// can't see it, so we detect the rollover from the monthly reset EPOCH advancing and count from 0.
+// With a ceiling between the stale delta and the real new-cycle spend, the old code wouldn't pause.
+test("monthly reset with no spend drop (epoch advanced) → counts new cycle from 0, pauses", async () => {
+  const savedCeiling = config.extraCreditsDrainCeiling;
+  config.extraCreditsDrainCeiling = 10; // between the stale delta (50−46.47=3.53) and the real 50
+  try {
+    let spent = 46.47;
+    let monthResetAt = MONTH_RESET;
+    const h = makeHarness({
+      maxAuto: 2,
+      issues: [issue(1)],
+      limitsImpl: usageWithCredit(() => ({
+        spent,
+        weekResetAt: WEEK_RESET,
+        weekPct: 50,
+        monthResetAt,
+      })),
+    });
+    await h.drain.snapshot(); // anchor := { spent 46.47, monthResetAt MONTH_RESET }
+    spent = 50; // new month already spent €50 (> old baseline) before our first fresh scrape
+    monthResetAt = MONTH_RESET + 30 * 24 * 60 * 60 * 1000; // monthly reset epoch advanced
+    await h.drain.pump(REPO);
+    const last = h.statuses.at(-1)!;
+    // Old (drop-only) code: 50 ≥ 46.47 → no drop → delta 3.53 < ceiling 10 → no pause (the bug).
+    // New code: epoch advanced → count 50 from 0 → 50 > 10 → pause.
+    expect(last.reason).toBe("credits");
+    expect(h.creates).toHaveLength(0);
+  } finally {
+    config.extraCreditsDrainCeiling = savedCeiling;
+  }
 });
 
 test("merged → archive → advance chain: onGit(merged) closes issue, archives, drops, emits, and onArchived spawns #2", async () => {

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -723,6 +723,24 @@ test("monthly credit reset (total drops) re-anchors → fresh new-month spend st
   expect(h.creates).toHaveLength(0);
 });
 
+// A monthly reset observed LATE (stale across the boundary, or spend accrued before the first
+// post-reset scrape) shows a nonzero new-cycle total on first re-observation. Anchoring to that
+// value would mask it; the fresh cycle starts at 0, so the full observed total must count.
+test("monthly reset observed late (first post-reset total nonzero) → still pauses on that spend", async () => {
+  let spent = 46.47;
+  const h = makeHarness({
+    maxAuto: 2,
+    issues: [issue(1)],
+    limitsImpl: usageWithCredit(() => ({ spent, weekResetAt: WEEK_RESET, weekPct: 50 })),
+  });
+  await h.drain.snapshot(); // anchor := 46.47 (old month)
+  spent = 5; // monthly budget rolled over, but €5 already accrued before we first re-observed
+  await h.drain.pump(REPO);
+  const last = h.statuses.at(-1)!;
+  expect(last.reason).toBe("credits"); // counts €5 from 0 — not masked by re-anchoring to it
+  expect(h.creates).toHaveLength(0);
+});
+
 test("merged → archive → advance chain: onGit(merged) closes issue, archives, drops, emits, and onArchived spawns #2", async () => {
   const advances: Promise<void>[] = [];
   const h = makeHarness({

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1156,7 +1156,7 @@
   "topbar_credits_alert_aria": "Zusatzguthaben in Nutzung: {amount}",
   "topbar_credits_refresh": "Aktualisieren",
   "settings_extra_credits_ceiling_title": "Ausgabenlimit für Zusatzguthaben",
-  "settings_extra_credits_ceiling_hint": "Pausiert autonomen Drain und Autopilot, sobald die gemessenen Pay-as-you-go-Ausgaben für Zusatzguthaben (echtes Geld über dein Abo hinaus) diesen Betrag in deiner Kontowährung übersteigen. 0 pausiert bei jeglichen Zusatzguthaben-Ausgaben.",
+  "settings_extra_credits_ceiling_hint": "Pausiert autonomen Drain und Autopilot, sobald die seit dem letzten Reset des Wochenfensters angefallenen Pay-as-you-go-Ausgaben für Zusatzguthaben (echtes Geld über dein Abo hinaus) diesen Betrag in deiner Kontowährung übersteigen. 0 pausiert bei jeglichen neuen Zusatzguthaben-Ausgaben. Aus einer früheren Woche übernommene Ausgaben zählen nicht mehr, sobald das Wochenfenster zurücksetzt — die Pause folgt so deinem Abo-Rhythmus, nicht dem monatlichen Guthaben-Reset.",
   "settings_extra_credits_ceiling_label": "Pausieren, wenn Ausgaben übersteigen",
   "settings_extra_credits_ceiling_save_failed": "Ausgabenlimit für Zusatzguthaben konnte nicht geändert werden. Erneut versuchen.",
   "feat_extra_credits_title": "Anzeige für Zusatzguthaben",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1156,7 +1156,7 @@
   "topbar_credits_alert_aria": "Extra credits in use: {amount}",
   "topbar_credits_refresh": "Refresh",
   "settings_extra_credits_ceiling_title": "Extra-credit spend ceiling",
-  "settings_extra_credits_ceiling_hint": "Pauses autonomous drain and autopilot once measured pay-as-you-go extra-credit spend (real money beyond your subscription) exceeds this amount, in your account currency. 0 pauses on any extra-credit spend at all.",
+  "settings_extra_credits_ceiling_hint": "Pauses autonomous drain and autopilot once pay-as-you-go extra-credit spend (real money beyond your subscription) accrued since the weekly window reset exceeds this amount, in your account currency. 0 pauses on any new extra-credit spend. Overage carried over from an earlier week stops counting once the weekly window resets, so the pause tracks your subscription cadence — not the monthly credit reset.",
   "settings_extra_credits_ceiling_label": "Pause when spend exceeds",
   "settings_extra_credits_ceiling_save_failed": "Couldn't change the extra-credit spend ceiling. Retry.",
   "feat_extra_credits_title": "Extra-credit overage gauge",


### PR DESCRIPTION
## Problem

A space showed **"Paused: spending extra credits"** while the account had ample subscription headroom (5h 35 %, weekly 27 %). The Claude Code usage popover reported **Extra Credits €46.47 / €100.00**, and autonomous drain refused to spawn.

Diagnosis: the extra-credit cost guard (`drain-core.ts`) pauses when `creditSpent > creditSpendCeiling`. `creditSpent` was fed the **raw cumulative month-to-date** pay-as-you-go total scraped from Claude Code's `/usage-credits` panel (`drain.ts`). That total only resets **monthly**, while the subscription windows reset every 5h / weekly. So:

- Paid overage can only accrue while a subscription window is **exhausted**.
- Once *any* paid overage was spent this month, the cumulative total stayed above the **default-0** ceiling until the monthly reset.
- Result: the drain stayed frozen for the **rest of the month** — even after the weekly window reset and freed fresh headroom, at which point the next agent runs on subscription tokens and costs **nothing extra**.

The guard conflated *"real money was spent this month"* with *"the next agent will spend real money."*

## Fix

Feed the guard **spend accrued since the current weekly window began** instead of the raw month-to-date total:

- Anchor the credit total at first observation and **re-anchor at each weekly-window reset** (`DrainService.effectiveCreditSpent`).
- Gate on the delta (`spent − anchor`).

Consequences:
- A nonzero month-to-date total with weekly headroom is **historical, not imminent** spend → reads 0 → **no pause** (the reported bug).
- Genuinely **new** paid spend still trips the guard (backstop for when Shepherd's calibrated `usagePct` under-reads and Anthropic is already billing).
- The anchor only advances on **discrete reset events**, never on pause state → **no flapping** (a credit pause holds until the weekly window actually resets rather than clearing the instant spawning stops).
- On restart the anchor re-captures the current total, so **deploying this fix immediately clears a stale historical-spend pause**.
- Fail-safe unchanged: a missing/stale scrape still yields 0 (never pause on disregarded data).

The pure comparison in `drain-core.ts` is untouched — only the **meaning** of `creditSpent` changed (documented at the field + guard).

## Tests

`test/drain.test.ts` — added a mutable usage seam (`limitsImpl`) and:
- month-to-date credits + weekly headroom → **no** credits hold (drains) — the fix
- credits **rising** above the weekly anchor → credits hold (paused)
- **weekly reset re-anchors** → an active credit pause clears at the reset

Reworked the old *"fresh credits over ceiling → hold"* test, which encoded the buggy cumulative behavior, into the rising-spend semantics.

## Docs / i18n

Updated the Settings ceiling hint (EN + DE) to describe the weekly-cycle semantics. `check:i18n` green (2456 keys in parity).

## Verification

- `bun run lint` ✓
- `bun test ./test` — 5753 pass / 0 fail
- `cd ui && bun run check` — 0 errors · `bun run check:i18n` ✓