### PR TITLE
fix(extension): strip manifest `key` from the Chrome Web Store zip

### DIFF
--- a/extension/scripts/package.mjs
+++ b/extension/scripts/package.mjs
@@ -6,19 +6,28 @@
 // the dist/ directory itself. The version comes from package.json (kept in lockstep
 // with manifest.config.ts), so the artifact name tracks the shipped version.
 //
+// The manifest's `key` field is STRIPPED from the zip: CWS rejects an upload whose
+// manifest carries `key` ("key field is not allowed in manifest"). `key` exists in
+// manifest.config.ts only to pin the *unpacked* dev-load extension ID
+// (bflahkibnmcbijbhelmpjbohpfhlbaig); the published item gets its ID assigned by the
+// store on first upload (reconciled per STORE_LISTING.md "Task 5"). We strip it from a
+// staged copy so `dist/manifest.json` on disk keeps `key` for local unpacked loads.
+//
 // PREREQUISITE: the system `zip` binary must be on PATH (preinstalled on macOS and
 // the CI ubuntu runner; `apt-get install zip` / `brew install zip` otherwise). A
 // missing binary surfaces as an ENOENT with an install hint below rather than a
 // silent failure.
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const extRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const dist = join(extRoot, "dist");
+const manifestPath = join(dist, "manifest.json");
 
-if (!existsSync(join(dist, "manifest.json"))) {
+if (!existsSync(manifestPath)) {
   console.error(
     "✗ dist/manifest.json not found — run `bun run build` first (or `bun run package`).",
   );
@@ -32,17 +41,38 @@ const zipPath = join(extRoot, zipName);
 // A stale same-name zip would otherwise be UPDATED (files merged) rather than replaced.
 rmSync(zipPath, { force: true });
 
-// `-r` recurse, `-X` drop extra file attributes for a deterministic archive. `.` from
-// cwd=dist packs dist's contents at the zip root.
-const res = spawnSync("zip", ["-r", "-X", zipPath, "."], { cwd: dist, stdio: "inherit" });
-if (res.error) {
-  const hint =
-    res.error.code === "ENOENT"
-      ? " — the `zip` binary is not on PATH; install it (`apt-get install zip` / `brew install zip`)"
-      : "";
-  console.error(`✗ failed to run \`zip\`: ${res.error.message}${hint}`);
-  process.exit(1);
-}
-if (res.status !== 0) process.exit(res.status ?? 1);
+// Stage a `key`-free manifest.json outside dist so the on-disk dist copy is untouched.
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+const strippedKey = "key" in manifest;
+delete manifest.key;
+const stageDir = mkdtempSync(join(tmpdir(), "shepherd-capture-pkg-"));
+writeFileSync(join(stageDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
 
-console.log(`✓ packaged ${zipName} (upload this to the Chrome Web Store dashboard)`);
+// `-r` recurse, `-X` drop extra file attributes for a deterministic archive. `.` from
+// cwd=dist packs dist's contents at the zip root; `-x` omits the original manifest so
+// the staged `key`-free one can take its place at the root in the second pass.
+const runZip = (args, cwd) => {
+  const res = spawnSync("zip", args, { cwd, stdio: "inherit" });
+  if (res.error) {
+    const hint =
+      res.error.code === "ENOENT"
+        ? " — the `zip` binary is not on PATH; install it (`apt-get install zip` / `brew install zip`)"
+        : "";
+    console.error(`✗ failed to run \`zip\`: ${res.error.message}${hint}`);
+    rmSync(stageDir, { recursive: true, force: true });
+    process.exit(1);
+  }
+  if (res.status !== 0) {
+    rmSync(stageDir, { recursive: true, force: true });
+    process.exit(res.status ?? 1);
+  }
+};
+
+runZip(["-r", "-X", zipPath, ".", "-x", "manifest.json", "./manifest.json"], dist);
+runZip(["-X", zipPath, "manifest.json"], stageDir);
+
+rmSync(stageDir, { recursive: true, force: true });
+
+console.log(
+  `✓ packaged ${zipName}${strippedKey ? " (stripped manifest `key`)" : ""} — upload this to the Chrome Web Store dashboard`,
+);


### PR DESCRIPTION
## Problem
Uploading `shepherd-capture-<version>.zip` to the Chrome Web Store fails with:

> There was a problem uploading your file. Please try again.
> **key field is not allowed in manifest.**

The manifest carries a `key` field (from `extension/manifest.config.ts`). CWS forbids `key` on upload — it exists only to pin the **unpacked dev-load** extension ID (`bflahkibnmcbijbhelmpjbohpfhlbaig`) so the server's allowlist entry never drifts. The **published** item gets its ID assigned by the store on first upload (already anticipated by STORE_LISTING.md's "Task 5 — ID reconciliation").

## Fix
`extension/scripts/package.mjs` now strips `key` from the manifest **in the zip only**: it stages a `key`-free `manifest.json` in a temp dir, packs `dist/` while excluding the original manifest, then adds the staged one at the zip root. `dist/manifest.json` on disk is left untouched, so local unpacked loads keep their pinned ID.

## Verification (`cd extension && bun run package`)
- Zip's `manifest.json`: **no `key`**; all other 13 fields intact; present exactly once at the root.
- `dist/manifest.json` on disk: **still has `key`** (unpacked dev unaffected).
- Zip file set is **identical** to `dist/` (set-diff empty both directions — nothing dropped by the exclude).
- `bun run check` → 0 errors, 0 warnings.

## Notes
- Separate from #1375 (privacy-policy hosting) — different concern, own PR.
- This unblocks the manual CWS upload step; re-run `bun run package` and upload the regenerated zip.

Refs #1360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)