### PR TITLE
feat(compose): live read-along preview during local Whisper dictation (iOS MVP)

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2443,6 +2443,8 @@
   "composebar_transcribe_failed": "Transkription fehlgeschlagen – bitte erneut versuchen.",
   "feat_voice_whisper_title": "Spracheingabe mit lokalem Whisper",
   "feat_voice_whisper_body": "Installiere das optionale voice-whisper-Plugin, und das Mikrofon der Compose-Leiste transkribiert direkt auf deinem Rechner per whisper.cpp – gleichbleibende Qualität, nichts verlässt den Host, und endlich ein funktionierendes Mikrofon in der iOS-Homescreen-PWA.",
+  "feat_live_dictation_title": "Live-Transkription beim Sprechen",
+  "feat_live_dictation_body": "Das lokale-Whisper-Mikrofon der Compose-Leiste zeigt deine Worte jetzt live beim Diktieren – eine laufende Vorschau, die sich alle paar Sekunden aktualisiert und beim Stoppen durch das genaue Transkript ersetzt wird. Funktioniert auch in der iOS-Homescreen-PWA und bleibt komplett auf deinem Rechner.",
   "pluginupdate_title": "Plugin-Updates",
   "pluginupdate_intro": "Update-Status deiner installierten Plugins. Rein informativ — Updates werden nicht automatisch angewendet.",
   "pluginupdate_empty": "Keine Plugins installiert.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2443,6 +2443,8 @@
   "composebar_transcribe_failed": "Couldn't transcribe that — try again.",
   "feat_voice_whisper_title": "Voice input with local Whisper",
   "feat_voice_whisper_body": "Install the optional voice-whisper plugin and the compose-bar mic transcribes on your own machine via whisper.cpp — consistent quality, nothing leaves the host, and finally a working mic in the iOS home-screen PWA.",
+  "feat_live_dictation_title": "Live transcription while you speak",
+  "feat_live_dictation_body": "The local-Whisper compose mic now shows your words live as you dictate — a running preview that updates every couple of seconds, replaced by the precise transcript when you stop. It works even in the iOS home-screen PWA, and stays entirely on your machine.",
   "pluginupdate_title": "Plugin updates",
   "pluginupdate_intro": "Update status of your installed plugins. This is informational — updates are not applied automatically.",
   "pluginupdate_empty": "No plugins installed.",

--- a/ui/src/lib/components/ComposeBar.svelte
+++ b/ui/src/lib/components/ComposeBar.svelte
@@ -4,6 +4,7 @@
   import { getLocale } from "$lib/i18n";
   import { insertNewlineAt } from "$lib/compose";
   import { getCommands, getVoiceStatus, transcribeAudio } from "$lib/api";
+  import { pcmChunksToWavBlob } from "$lib/wav";
   import { matchSlashTrigger, filterCommands, applyCommandPick } from "$lib/slash";
   import type { SlashCommand } from "$lib/types";
   import SlashCommandMenu from "./SlashCommandMenu.svelte";
@@ -220,6 +221,35 @@
   let recordTimer: ReturnType<typeof setTimeout> | null = null;
   const MAX_RECORD_MS = 60_000; // cap a single clip so a forgotten mic can't record forever
 
+  // ── live interim transcription (progressive read-along) ────────────────────────────
+  // While MediaRecorder captures the authoritative clip, we ALSO tap the SAME mic stream via
+  // Web Audio, accumulate raw PCM, and every INTERIM_MS post the growing clip — encoded as a WAV,
+  // which is valid at every prefix — to the plugin, showing the returned text live in the field.
+  // On stop the accurate full-clip transcription replaces it. This is the ONLY way to get
+  // read-along on an iOS home-screen PWA: there is no Web Speech, and an iOS MediaRecorder mp4
+  // writes its `moov` atom only on stop so it can't be transcribed mid-recording. Everything stays
+  // local (the whisper plugin runs on the host), so — unlike a Web-Speech hybrid — nothing leaves
+  // the machine. The final MediaRecorder path is untouched, so a browser without Web Audio simply
+  // gets no interim and the same batch result as before.
+  interface AudioWindow extends Window {
+    webkitAudioContext?: typeof AudioContext;
+  }
+  const AudioCtx: typeof AudioContext | undefined =
+    typeof window !== "undefined"
+      ? (window.AudioContext ?? (window as AudioWindow).webkitAudioContext)
+      : undefined;
+  const INTERIM_MS = 2500; // how often to re-transcribe the growing clip for the live preview
+  let audioCtx: AudioContext | null = null;
+  let audioSource: MediaStreamAudioSourceNode | null = null;
+  let audioProc: ScriptProcessorNode | null = null;
+  let audioSink: GainNode | null = null;
+  let pcmChunks: Float32Array[] = [];
+  let pcmRate = 0;
+  let interimTimer: ReturnType<typeof setInterval> | null = null;
+  let interimBusy = false; // one interim request in flight at a time — never stack transcriptions
+  let interimSeq = 0; // bumped to discard a stale/late interim response (incl. after stop)
+  let dictationBase = ""; // field text when recording started; interim/final render after it
+
   function pickMimeType(): string | undefined {
     if (typeof MediaRecorder === "undefined") return undefined;
     for (const c of ["audio/webm;codecs=opus", "audio/webm", "audio/mp4", "audio/ogg"])
@@ -231,6 +261,88 @@
     voiceError = true;
     if (voiceErrorTimer) clearTimeout(voiceErrorTimer);
     voiceErrorTimer = setTimeout(() => (voiceError = false), 4000);
+  }
+
+  // Tap the live mic stream with Web Audio and start the interim-transcription loop. Best-effort:
+  // if Web Audio is unavailable or setup throws, we bail quietly and the final clip still runs.
+  function startInterimCapture(stream: MediaStream) {
+    if (!AudioCtx) return;
+    try {
+      // Ask for 16 kHz directly so the browser resamples for us; fall back to the device rate.
+      try {
+        audioCtx = new AudioCtx({ sampleRate: 16000 });
+      } catch {
+        audioCtx = new AudioCtx();
+      }
+      void audioCtx.resume?.().catch(() => {});
+      pcmRate = audioCtx.sampleRate;
+      pcmChunks = [];
+      audioSource = audioCtx.createMediaStreamSource(stream);
+      // ScriptProcessor is deprecated in favour of AudioWorklet, but the worklet needs a separately
+      // bundled module; ScriptProcessor is the simplest path that also works in an iOS PWA. A 60 s
+      // dictation on the main thread is well within its budget.
+      audioProc = audioCtx.createScriptProcessor(4096, 1, 1);
+      audioProc.onaudioprocess = (e) => {
+        pcmChunks.push(new Float32Array(e.inputBuffer.getChannelData(0)));
+      };
+      // Route through a muted gain into the destination so the processor actually runs, without
+      // echoing the mic back to the speakers.
+      audioSink = audioCtx.createGain();
+      audioSink.gain.value = 0;
+      audioSource.connect(audioProc);
+      audioProc.connect(audioSink);
+      audioSink.connect(audioCtx.destination);
+      interimTimer = setInterval(() => void runInterim(), INTERIM_MS);
+    } catch {
+      stopInterimCapture();
+    }
+  }
+
+  // One interim tick: transcribe the clip captured so far and show it live. Guarded so only one
+  // request is ever in flight, and a stale/late response (a newer tick, or one arriving after we
+  // stopped) is discarded via the sequence number.
+  async function runInterim() {
+    if (interimBusy || transcribing || !listening) return;
+    if (pcmChunks.length === 0 || pcmRate === 0) return;
+    const blob = pcmChunksToWavBlob(pcmChunks, pcmRate);
+    interimBusy = true;
+    const seq = ++interimSeq;
+    try {
+      const text = await transcribeAudio(blob, getLocale() === "de" ? "de" : "en");
+      if (seq === interimSeq && listening && text)
+        value = dictationBase.trim() ? dictationBase.trimEnd() + " " + text.trim() : text.trim();
+      queueMicrotask(autogrow);
+    } catch {
+      // interim is best-effort — a failed/blocked tick is silently skipped; the final clip still runs
+    } finally {
+      interimBusy = false;
+    }
+  }
+
+  function stopInterimCapture() {
+    if (interimTimer) {
+      clearInterval(interimTimer);
+      interimTimer = null;
+    }
+    interimSeq++; // invalidate any in-flight interim response
+    interimBusy = false;
+    if (audioProc) audioProc.onaudioprocess = null;
+    try {
+      audioProc?.disconnect();
+      audioSource?.disconnect();
+      audioSink?.disconnect();
+    } catch {
+      /* nodes already torn down */
+    }
+    audioProc = null;
+    audioSource = null;
+    audioSink = null;
+    if (audioCtx) {
+      void audioCtx.close().catch(() => {});
+      audioCtx = null;
+    }
+    pcmChunks = [];
+    pcmRate = 0;
   }
 
   // Start recording. Reached two ways, both within the getUserMedia activation window: an
@@ -274,6 +386,10 @@
       listening = true;
       activeEngine = "local";
       recordTimer = setTimeout(() => stopLocalRecording(), MAX_RECORD_MS);
+      // Start the live read-along preview off the same stream (best-effort; the final clip above
+      // is authoritative and runs regardless of whether interim capture succeeds).
+      dictationBase = value;
+      if (mediaStream) startInterimCapture(mediaStream);
     } finally {
       acquiring = false;
     }
@@ -291,6 +407,7 @@
 
   async function finishLocalRecording() {
     const type = mediaRecorder?.mimeType || "audio/webm";
+    stopInterimCapture();
     releaseStream();
     mediaRecorder = null;
     activeEngine = null;
@@ -300,6 +417,9 @@
     transcribing = true;
     try {
       const text = await transcribeAudio(blob, getLocale() === "de" ? "de" : "en");
+      // The accurate full-clip result replaces whatever the live preview last showed. On error we
+      // keep the last interim text rather than discarding what the user just dictated.
+      value = dictationBase;
       if (text) appendTranscript(text);
     } catch {
       flashVoiceError();
@@ -332,6 +452,7 @@
       }
       mediaRecorder = null;
     }
+    stopInterimCapture();
     releaseStream();
     chunks = [];
     listening = false;

--- a/ui/src/lib/feature-announcements/entries/v1.42.0-live-dictation.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.42.0-live-dictation.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "live-dictation",
+  sinceVersion: "1.42.0",
+  titleKey: "feat_live_dictation_title",
+  bodyKey: "feat_live_dictation_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/wav.test.ts
+++ b/ui/src/lib/wav.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { resample, encodeWav16, pcmChunksToWav } from "./wav";
+
+function readAscii(view: DataView, offset: number, len: number): string {
+  let s = "";
+  for (let i = 0; i < len; i++) s += String.fromCharCode(view.getUint8(offset + i));
+  return s;
+}
+
+describe("resample", () => {
+  it("is identity when rates match", () => {
+    const input = new Float32Array([0, 0.5, -0.5, 1]);
+    expect(resample(input, 16000, 16000)).toBe(input);
+  });
+
+  it("halves the length when downsampling 2:1", () => {
+    const input = new Float32Array(100).fill(0.25);
+    const out = resample(input, 32000, 16000);
+    expect(out.length).toBe(50);
+    // constant signal stays constant through linear interpolation
+    expect(out[10]).toBeCloseTo(0.25, 5);
+  });
+
+  it("handles empty input", () => {
+    expect(resample(new Float32Array(0), 48000, 16000).length).toBe(0);
+  });
+});
+
+describe("encodeWav16", () => {
+  it("writes a valid 44-byte mono 16-bit PCM header", () => {
+    const samples = new Float32Array([0, 1, -1]);
+    const buf = encodeWav16(samples, 16000);
+    const view = new DataView(buf);
+    expect(buf.byteLength).toBe(44 + samples.length * 2);
+    expect(readAscii(view, 0, 4)).toBe("RIFF");
+    expect(readAscii(view, 8, 4)).toBe("WAVE");
+    expect(readAscii(view, 12, 4)).toBe("fmt ");
+    expect(readAscii(view, 36, 4)).toBe("data");
+    expect(view.getUint16(20, true)).toBe(1); // PCM
+    expect(view.getUint16(22, true)).toBe(1); // mono
+    expect(view.getUint32(24, true)).toBe(16000); // sample rate
+    expect(view.getUint16(34, true)).toBe(16); // bits
+    expect(view.getUint32(40, true)).toBe(samples.length * 2); // data size
+  });
+
+  it("clamps and scales samples to int16", () => {
+    const view = new DataView(encodeWav16(new Float32Array([1, -1, 2, -2]), 16000));
+    expect(view.getInt16(44, true)).toBe(0x7fff); // +1 full scale
+    expect(view.getInt16(46, true)).toBe(-0x8000); // -1 full scale
+    expect(view.getInt16(48, true)).toBe(0x7fff); // +2 clamped
+    expect(view.getInt16(50, true)).toBe(-0x8000); // -2 clamped
+  });
+});
+
+describe("pcmChunksToWav", () => {
+  it("merges chunks and downsamples before encoding", () => {
+    const chunks = [new Float32Array(64).fill(0.1), new Float32Array(64).fill(0.1)];
+    const buf = pcmChunksToWav(chunks, 48000, 16000);
+    const view = new DataView(buf);
+    // 128 samples @48k → ~42 samples @16k
+    const dataBytes = view.getUint32(40, true);
+    expect(dataBytes).toBe(Math.floor(128 / 3) * 2);
+    expect(view.getUint32(24, true)).toBe(16000);
+  });
+});

--- a/ui/src/lib/wav.ts
+++ b/ui/src/lib/wav.ts
@@ -1,0 +1,85 @@
+// Encode raw Float32 PCM (as captured from a Web Audio tap) into a 16 kHz mono 16-bit WAV.
+//
+// Why this exists: the compose-bar live dictation needs to transcribe the audio *while it is
+// still being spoken*. An iOS `MediaRecorder` mp4 writes its `moov` atom only on stop, so a
+// mid-recording clip cannot be demuxed — but a WAV built from the PCM captured so far is valid
+// at *every* prefix. So we tap the mic with Web Audio, accumulate Float32 frames, and encode a
+// fresh WAV each interim tick. 16 kHz mono matches what whisper.cpp wants and keeps the upload
+// small (~32 KB/s), which matters because each tick re-sends the whole growing clip.
+
+/** Concatenate the captured Float32 frames into one contiguous buffer. */
+function mergeChunks(chunks: Float32Array[]): Float32Array {
+  let len = 0;
+  for (const c of chunks) len += c.length;
+  const out = new Float32Array(len);
+  let off = 0;
+  for (const c of chunks) {
+    out.set(c, off);
+    off += c.length;
+  }
+  return out;
+}
+
+/** Linear-interpolation resample from `inRate` to `outRate`. Identity when the rates match. */
+export function resample(input: Float32Array, inRate: number, outRate: number): Float32Array {
+  if (inRate === outRate || input.length === 0) return input;
+  const ratio = inRate / outRate;
+  const outLen = Math.max(0, Math.floor(input.length / ratio));
+  const out = new Float32Array(outLen);
+  for (let i = 0; i < outLen; i++) {
+    const pos = i * ratio;
+    const i0 = Math.floor(pos);
+    const i1 = Math.min(i0 + 1, input.length - 1);
+    out[i] = input[i0]! * (1 - (pos - i0)) + input[i1]! * (pos - i0);
+  }
+  return out;
+}
+
+function writeAscii(view: DataView, offset: number, s: string): void {
+  for (let i = 0; i < s.length; i++) view.setUint8(offset + i, s.charCodeAt(i));
+}
+
+/** Encode mono Float32 samples as a 16-bit PCM WAV (44-byte header + data). */
+export function encodeWav16(samples: Float32Array, sampleRate: number): ArrayBuffer {
+  const buffer = new ArrayBuffer(44 + samples.length * 2);
+  const view = new DataView(buffer);
+  const byteRate = sampleRate * 2; // mono, 2 bytes/sample
+  writeAscii(view, 0, "RIFF");
+  view.setUint32(4, 36 + samples.length * 2, true);
+  writeAscii(view, 8, "WAVE");
+  writeAscii(view, 12, "fmt ");
+  view.setUint32(16, 16, true); // fmt chunk size
+  view.setUint16(20, 1, true); // PCM
+  view.setUint16(22, 1, true); // mono
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, byteRate, true);
+  view.setUint16(32, 2, true); // block align
+  view.setUint16(34, 16, true); // bits per sample
+  writeAscii(view, 36, "data");
+  view.setUint32(40, samples.length * 2, true);
+  let off = 44;
+  for (let i = 0; i < samples.length; i++) {
+    const s = Math.max(-1, Math.min(1, samples[i]!));
+    view.setInt16(off, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+    off += 2;
+  }
+  return buffer;
+}
+
+/** Merge + resample captured PCM frames to `targetRate` mono and encode a 16-bit WAV buffer. */
+export function pcmChunksToWav(
+  chunks: Float32Array[],
+  inputRate: number,
+  targetRate = 16000,
+): ArrayBuffer {
+  return encodeWav16(resample(mergeChunks(chunks), inputRate, targetRate), targetRate);
+}
+
+/** Browser convenience: the same as {@link pcmChunksToWav}, wrapped as an `audio/wav` Blob. */
+export function pcmChunksToWavBlob(
+  chunks: Float32Array[],
+  inputRate: number,
+  targetRate = 16000,
+): Blob {
+  return new Blob([pcmChunksToWav(chunks, inputRate, targetRate)], { type: "audio/wav" });
+}


### PR DESCRIPTION
## Was & warum

Beim lokalen Whisper-Diktat (voice-whisper-Plugin) erschien der Text bisher **erst nach dem Stoppen** komplett auf einmal. Dieser PR zeigt den gesprochenen Text **schon während des Sprechens** live im Compose-Feld ("Read-along") — verzögert, aber lesbar.

**Scope: iOS-PWA-MVP / Version 1.** Bei Default `preferLocal:false` wird Whisper genau dort benutzt, wo Web Speech fehlt — die iOS-Home-Screen-PWA. Das ist der Ziel-Fall.

## Ansatz (P-PCM, additiv)

Warum nicht einfach den `MediaRecorder`-Clip periodisch posten: eine iOS-`MediaRecorder`-mp4 schreibt ihr `moov`-Atom erst beim Stopp → ein Mid-Recording-Clip ist nicht dekodierbar. Und Web Speech gibt es in der iOS-PWA nicht.

Lösung: Wir tappen **denselben** Mic-Stream zusätzlich mit **Web Audio**, sammeln rohes PCM und posten alle 2,5 s den bisherigen Clip als **WAV** (an jedem Präfix gültig) an das bestehende `/transcribe`; das Ergebnis erscheint live im Feld. Beim Stopp ersetzt die genaue Voll-Transkription (unveränderter `MediaRecorder`-Final-Pfad) die Vorschau.

- **Additiv & regressionsarm:** Der Final-Pfad ist unangetastet. Ein Browser ohne Web Audio bekommt einfach keine Vorschau und dasselbe Batch-Ergebnis wie bisher.
- **Lokal & privat:** Whisper läuft auf dem Host — anders als ein Web-Speech-Hybrid verlässt **nichts** die Maschine.
- **Kein Plugin-Change nötig:** Der Client postet WAV; `/transcribe` verarbeitet WAV bereits. Single-in-flight + Sequenz-Guard verhindern gestapelte/veraltete Transkriptionen.

## Dateien
- `ui/src/lib/wav.ts` — 16 kHz mono 16-bit WAV-Encoder für die PCM-Frames (+ Unit-Tests).
- `ui/src/lib/components/ComposeBar.svelte` — Web-Audio-Capture + Interim-Loop, additiv zum bestehenden lokalen Aufnahme-Flow.

## Verifiziert
- `bun run check` (svelte-check): 0 Errors.
- `bun run test:node wav`: 6/6 grün.

## Noch offen (siehe manuelle Schritte)
- On-Device-Test in einer echten iOS-PWA steht aus (lässt sich nicht in CI abbilden).
- Latenz-Messung auf dem Zielmodell `small` mit realer, langer Äußerung (O(n²): jeder Tick re-transkribiert den wachsenden Clip).

```shepherd:manual-steps
- [ ] Auf einer echten iOS-Home-Screen-PWA verifizieren, dass beim Diktat Live-Text erscheint (voice-whisper-Plugin installiert + GGML-Modell vorhanden)
- [ ] Interim-Latenz auf Zielmodell `small` mit realer, langer Äußerung messen; bei p95 > ~2,5 s INTERIM_MS erhöhen oder den plugin-seitigen Schnellpfad (greedy/Concurrency-Cap) nachziehen
```
