### PR TITLE
feat(viewport): show a spinning-gear "CI running" banner in the terminal

### DIFF
--- a/src/forge/checks.ts
+++ b/src/forge/checks.ts
@@ -95,6 +95,18 @@ export function jobsFromRollup(entries: ReadonlyArray<RollupEntry>): WorkflowJob
   return entries.map(rollupEntryToJob).filter((j): j is WorkflowJob => j != null);
 }
 
+/** Names of the checks currently in flight — the `pending` subset of
+ *  {@link jobsFromRollup} (status != completed: queued / in_progress / waiting).
+ *  A completed `action_required` conclusion is FAILURE, not pending, so it's
+ *  excluded. Drives the terminal "CI running: <names>" banner; empty when nothing
+ *  is running (the caller then omits the field). Order follows the rollup, which
+ *  isn't guaranteed stable — consumers comparing this must do so order-independently. */
+export function runningCheckNames(entries: ReadonlyArray<RollupEntry>): string[] {
+  return jobsFromRollup(entries)
+    .filter((j) => j.state === "pending")
+    .map((j) => j.name);
+}
+
 /** Roll a list of `statusCheckRollup` entries into a single worst-of state
  *  (failure > pending > success > none). Folds in legacy StatusContext entries
  *  via {@link entryState}, so a repo running only commit statuses still rolls up

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -1,7 +1,13 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { timedAsync } from "../instrument";
-import { jobsFromRollup, mapCheckState, mapStatusState, rollupChecks } from "./checks";
+import {
+  jobsFromRollup,
+  mapCheckState,
+  mapStatusState,
+  rollupChecks,
+  runningCheckNames,
+} from "./checks";
 import { classifyPr } from "./pr-kind";
 import {
   graphRateLimit,
@@ -711,6 +717,7 @@ export class GithubForge implements GitForge {
   private mapGhPr(pr: GhPr, deployConfigured: boolean): PrStatus {
     const state = pr.state.toLowerCase() as PrStatus["state"];
     const createdAt = Date.parse(pr.createdAt ?? "");
+    const running = runningCheckNames(pr.statusCheckRollup ?? []);
     return {
       state: state === "open" || state === "merged" || state === "closed" ? state : "none",
       number: pr.number,
@@ -721,6 +728,7 @@ export class GithubForge implements GitForge {
       mergeStateStatus: mapMergeStateStatus(pr.mergeStateStatus),
       isDraft: pr.isDraft ?? false,
       checks: rollupChecks(pr.statusCheckRollup ?? []),
+      runningChecks: running.length ? running : undefined,
       headSha: pr.headRefOid,
       baseRefName: pr.baseRefName,
       latestReview: latestHumanReview(pr.reviews),

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -169,6 +169,12 @@ export interface PrStatus {
   /** null = host still computing mergeability. */
   mergeable?: boolean | null;
   checks: ChecksState;
+  /** Names of the checks currently in flight (the `pending` subset of the rollup),
+   *  e.g. `["verify / test", "PR hygiene / i18n"]`. Populated only on the GitHub
+   *  `gh pr list` path; absent on the REST rate-limit fallback and on Gitea, and
+   *  absent (rather than `[]`) when nothing is running. Drives the terminal
+   *  "CI running: <names>" banner. Order isn't stable — compare as a set. */
+  runningChecks?: string[];
   /** Head commit SHA of the PR branch; undefined when there is no PR. Drives
    *  "review this head once" dedup and per-push re-review. */
   headSha?: string;

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -146,6 +146,10 @@ export class PrPoller implements PrCache {
     return (
       git.state === "open" &&
       (git.checks === "pending" ||
+        // Jobs can still be running after the worst-of rollup already flipped to
+        // "failure" (one check failed, others in flight). Keep fast-polling so the
+        // terminal CI banner clears/updates live instead of lagging the slow sweep.
+        (git.runningChecks?.length ?? 0) > 0 ||
         git.mergeable == null ||
         git.mergeStateStatus === "unknown" ||
         git.mergeStateStatus === "unstable")

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -69,15 +69,27 @@ export function trustsTerminal(
   return !!prev && prev.number != null && prev.number === raw.number && prev.state !== "none";
 }
 
+/** Order-independent equality for two optional string lists. `runningChecks` is
+ *  derived from `jobsFromRollup`, whose order isn't guaranteed stable, so a plain
+ *  index compare would flag a pure reorder as a change and emit a spurious push. */
+function sameSet(a: string[] | undefined, b: string[] | undefined): boolean {
+  if (a === b) return true;
+  if ((a?.length ?? 0) !== (b?.length ?? 0)) return false;
+  const as = [...(a ?? [])].sort();
+  const bs = [...(b ?? [])].sort();
+  return as.every((v, i) => v === bs[i]);
+}
+
 /** True when a freshly polled PR state differs from the cached one in any field
  *  the UI renders (status, CI/merge-eligibility, review, handoff) — i.e. worth
- *  pushing a session:git update. */
-function gitStateChanged(prev: GitState | undefined, git: GitState): boolean {
+ *  pushing a session:git update. Exported for unit testing. */
+export function gitStateChanged(prev: GitState | undefined, git: GitState): boolean {
   return (
     !prev ||
     prev.state !== git.state ||
     prev.number !== git.number ||
     prev.checks !== git.checks ||
+    !sameSet(prev.runningChecks, git.runningChecks) ||
     prev.mergeable !== git.mergeable ||
     prev.mergeStateStatus !== git.mergeStateStatus ||
     prev.isDraft !== git.isDraft ||

--- a/test/forge/checks.test.ts
+++ b/test/forge/checks.test.ts
@@ -5,6 +5,7 @@ import {
   mapGiteaActionStatus,
   mapStatusState,
   rollupChecks,
+  runningCheckNames,
 } from "../../src/forge/checks";
 
 test("mapCheckState: incomplete status → pending", () => {
@@ -172,4 +173,67 @@ test("jobsFromRollup: entries without a usable label are dropped", () => {
   expect(
     jobsFromRollup([{ __typename: "CheckRun", status: "completed", conclusion: "success" }]),
   ).toEqual([]);
+});
+
+test("runningCheckNames: only the pending (status != completed) checks, qualified", () => {
+  expect(
+    runningCheckNames([
+      {
+        __typename: "CheckRun",
+        name: "test",
+        workflowName: "verify",
+        status: "in_progress",
+        conclusion: null,
+      },
+      {
+        __typename: "CheckRun",
+        name: "i18n",
+        workflowName: "PR hygiene",
+        status: "queued",
+        conclusion: null,
+      },
+      {
+        __typename: "CheckRun",
+        name: "lint",
+        workflowName: "CI",
+        status: "completed",
+        conclusion: "success",
+      },
+    ]),
+  ).toEqual(["verify / test", "PR hygiene / i18n"]);
+});
+
+test("runningCheckNames: completed action_required is failure, not pending → excluded", () => {
+  expect(
+    runningCheckNames([
+      {
+        __typename: "CheckRun",
+        name: "deploy",
+        workflowName: "CD",
+        status: "completed",
+        conclusion: "action_required",
+      },
+    ]),
+  ).toEqual([]);
+});
+
+test("runningCheckNames: none pending → empty", () => {
+  expect(
+    runningCheckNames([
+      {
+        __typename: "CheckRun",
+        name: "lint",
+        workflowName: "CI",
+        status: "completed",
+        conclusion: "success",
+      },
+      { __typename: "StatusContext", context: "netlify", state: "FAILURE" },
+    ]),
+  ).toEqual([]);
+});
+
+test("runningCheckNames: includes a waiting StatusContext (pending)", () => {
+  expect(
+    runningCheckNames([{ __typename: "StatusContext", context: "ci/circleci", state: "pending" }]),
+  ).toEqual(["ci/circleci"]);
 });

--- a/test/forge/github.test.ts
+++ b/test/forge/github.test.ts
@@ -286,6 +286,52 @@ test("GithubForge.prStatus: open PR with rollup → mapped PrStatus", async () =
   expect(calls[0]).toContain("o/r");
 });
 
+test("GithubForge.prStatus: runningChecks names only the in-flight (pending) checks", async () => {
+  const prJson = JSON.stringify([
+    {
+      number: 8,
+      url: "u",
+      title: "feat",
+      state: "OPEN",
+      statusCheckRollup: [
+        {
+          __typename: "CheckRun",
+          name: "test",
+          workflowName: "verify",
+          status: "IN_PROGRESS",
+          conclusion: null,
+        },
+        {
+          __typename: "CheckRun",
+          name: "lint",
+          workflowName: "CI",
+          status: "COMPLETED",
+          conclusion: "SUCCESS",
+        },
+      ],
+    },
+  ]);
+  const { run } = fakeRunner({ "pr list": prJson });
+  const st = await new GithubForge("o/r", {}, run).prStatus("feature");
+  expect(st.checks).toBe("pending");
+  expect(st.runningChecks).toEqual(["verify / test"]);
+});
+
+test("GithubForge.prStatus: runningChecks is undefined when nothing is pending", async () => {
+  const prJson = JSON.stringify([
+    {
+      number: 8,
+      url: "u",
+      title: "feat",
+      state: "OPEN",
+      statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS" }],
+    },
+  ]);
+  const { run } = fakeRunner({ "pr list": prJson });
+  const st = await new GithubForge("o/r", {}, run).prStatus("feature");
+  expect(st.runningChecks).toBeUndefined();
+});
+
 test("GithubForge.prStatus: surfaces baseRefName (the PR's real target branch)", async () => {
   // A hotfix PR targeting a non-default branch — the case the diff/recap base resolution needs.
   const prJson = JSON.stringify([

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -1,8 +1,38 @@
 import { test, expect } from "bun:test";
 import { SessionStore } from "../src/store";
-import { PrPoller, trustsTerminal } from "../src/pr-poller";
-import type { GitForge, PrStatus } from "../src/forge/types";
+import { PrPoller, trustsTerminal, gitStateChanged } from "../src/pr-poller";
+import type { GitForge, GitState, PrStatus } from "../src/forge/types";
 import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
+
+const openGit = (over: Partial<GitState> = {}): GitState => ({
+  kind: "github",
+  state: "open",
+  number: 1,
+  checks: "pending",
+  deployConfigured: false,
+  ...over,
+});
+
+test("gitStateChanged: true when the running-checks set changes", () => {
+  expect(
+    gitStateChanged(openGit({ runningChecks: ["a"] }), openGit({ runningChecks: ["a", "b"] })),
+  ).toBe(true);
+  expect(
+    gitStateChanged(openGit({ runningChecks: ["a"] }), openGit({ runningChecks: ["c"] })),
+  ).toBe(true);
+  expect(
+    gitStateChanged(openGit({ runningChecks: undefined }), openGit({ runningChecks: ["a"] })),
+  ).toBe(true);
+});
+
+test("gitStateChanged: false when running-checks only reorders (set-equal)", () => {
+  expect(
+    gitStateChanged(openGit({ runningChecks: ["a", "b"] }), openGit({ runningChecks: ["b", "a"] })),
+  ).toBe(false);
+  expect(
+    gitStateChanged(openGit({ runningChecks: undefined }), openGit({ runningChecks: undefined })),
+  ).toBe(false);
+});
 
 const baseSession = {
   name: "x",

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -442,6 +442,19 @@ const OPEN_PENDING: PrStatus = {
   deployConfigured: false,
 };
 
+// Worst-of rollup already "failure" (one check failed) but jobs still running.
+// mergeable + mergeStateStatus are settled so the ONLY transient trigger is
+// runningChecks — proving isTransientOpen keys on it.
+const OPEN_FAILING_RUNNING: PrStatus = {
+  state: "open",
+  number: 1,
+  checks: "failure",
+  runningChecks: ["verify / test"],
+  mergeable: true,
+  mergeStateStatus: "clean",
+  deployConfigured: false,
+};
+
 const MERGED: PrStatus = {
   state: "merged",
   number: 344,
@@ -627,6 +640,26 @@ test("fastTick falls back to per-session for a single eligible PR — count<2 (b
   expect(stats.count).toBe(0); // count<2 short-circuits before the probe
   expect(stats.list).toBe(0);
   expect(stats.prStatus).toBe(1); // lone eligible → per-session
+});
+
+test("fastTick keeps re-polling an open PR whose CI failed but still has running jobs", async () => {
+  const store = new SessionStore(":memory:");
+  store.create({ ...baseSession, branch: "shepherd/a" });
+  const { forge, stats } = forgeWithBatch(
+    { "shepherd/a": OPEN_FAILING_RUNNING },
+    { prStatusByBranch: { "shepherd/a": OPEN_FAILING_RUNNING } },
+  );
+  const poller = new PrPoller(
+    store,
+    () => forge,
+    () => {},
+  );
+
+  await poller.tick();
+  stats.prStatus = 0;
+  await poller.fastTick();
+  // Transient purely via runningChecks (merge state settled) → still fast-polled.
+  expect(stats.prStatus).toBe(1);
 });
 
 test("fastTick fans out O(eligible) per-session across singleton repos, no cap (c)", async () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2465,5 +2465,10 @@
   "feat_plugin_updates_title": "Sieh, wann deine Plugins Updates haben",
   "feat_plugin_updates_body": "Die Einstellungen prüfen jetzt, ob deine installierten Plugins eine neuere veröffentlichte Version haben, und zeigen das an — für Plugins, die ein Repository deklarieren oder aus einem Git-Checkout laufen. Nur informativ; Updates werden weiterhin manuell angewendet.",
   "feat_epic_backlog_visibility_title": "Epics stechen im Backlog hervor",
-  "feat_epic_backlog_visibility_body": "In der Issue-Liste des Repo-Backlogs werden Epics jetzt nach oben sortiert und mit einem Bernstein-Akzent hervorgehoben, damit man sie leicht erkennt. Klappt man ein Epic auf, erscheinen seine Steuerelemente (Pause, Beaufsichtigt, Epic stoppen, Nächstes freigeben) als richtige Buttons statt als reiner Text."
+  "feat_epic_backlog_visibility_body": "In der Issue-Liste des Repo-Backlogs werden Epics jetzt nach oben sortiert und mit einem Bernstein-Akzent hervorgehoben, damit man sie leicht erkennt. Klappt man ein Epic auf, erscheinen seine Steuerelemente (Pause, Beaufsichtigt, Epic stoppen, Nächstes freigeben) als richtige Buttons statt als reiner Text.",
+  "cibanner_running_named": "CI läuft: {checks}",
+  "cibanner_running_bare": "CI läuft",
+  "cibanner_pr": "PR #{number}",
+  "feat_ci_running_banner_title": "Sehen, wenn CI läuft",
+  "feat_ci_running_banner_body": "Während auf dem PR einer Session CI läuft, zeigt das Terminal jetzt ein Banner mit drehendem Zahnrad – an derselben Stelle wie der Review-in-flight-Hinweis – und nennt die gerade laufenden Checks; die PR-Nummer verlinkt auf deren Checks auf GitHub. Status- und Automatik-Infos landen so immer an einer konsistenten Stelle, damit du weißt, dass du warten solltest, solange CI noch arbeitet."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2470,5 +2470,5 @@
   "cibanner_running_bare": "CI läuft",
   "cibanner_pr": "PR #{number}",
   "feat_ci_running_banner_title": "Sehen, wenn CI läuft",
-  "feat_ci_running_banner_body": "Während auf dem PR einer Session CI läuft, zeigt das Terminal jetzt ein Banner mit drehendem Zahnrad – an derselben Stelle wie der Review-in-flight-Hinweis – und nennt die gerade laufenden Checks; die PR-Nummer verlinkt auf deren Checks auf GitHub. Status- und Automatik-Infos landen so immer an einer konsistenten Stelle, damit du weißt, dass du warten solltest, solange CI noch arbeitet."
+  "feat_ci_running_banner_body": "Während auf dem PR einer Session CI läuft, zeigt das Terminal jetzt ein Banner mit drehendem Zahnrad – an derselben Stelle wie der Review-in-flight-Hinweis – und nennt die gerade laufenden Checks; die PR-Nummer verlinkt auf den PR auf GitHub. Status- und Automatik-Infos landen so immer an einer konsistenten Stelle, damit du weißt, dass du warten solltest, solange CI noch arbeitet."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2465,5 +2465,10 @@
   "feat_plugin_updates_title": "See when your plugins have updates",
   "feat_plugin_updates_body": "Settings now checks whether your installed plugins have a newer released version and shows it — for plugins that declare a repository or run from a git checkout. It's informational only; updates are still applied manually.",
   "feat_epic_backlog_visibility_title": "Epics stand out in the backlog",
-  "feat_epic_backlog_visibility_body": "In the repo backlog's Issues list, epics now sort to the top and carry an amber accent so they're easy to spot. Expanding one shows its controls (Pause, Attended, Stop epic, Approve next) as proper buttons instead of plain text."
+  "feat_epic_backlog_visibility_body": "In the repo backlog's Issues list, epics now sort to the top and carry an amber accent so they're easy to spot. Expanding one shows its controls (Pause, Attended, Stop epic, Approve next) as proper buttons instead of plain text.",
+  "cibanner_running_named": "CI running: {checks}",
+  "cibanner_running_bare": "CI is running",
+  "cibanner_pr": "PR #{number}",
+  "feat_ci_running_banner_title": "See when CI is running",
+  "feat_ci_running_banner_body": "While CI runs on a session's PR, the terminal now shows a spinning-gear banner — the same spot as the review-in-flight notice — naming the checks in flight, with the PR number linking to its checks on GitHub. Status and automation info always lands in one consistent place, so you know to hold off while CI is still working."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2470,5 +2470,5 @@
   "cibanner_running_bare": "CI is running",
   "cibanner_pr": "PR #{number}",
   "feat_ci_running_banner_title": "See when CI is running",
-  "feat_ci_running_banner_body": "While CI runs on a session's PR, the terminal now shows a spinning-gear banner — the same spot as the review-in-flight notice — naming the checks in flight, with the PR number linking to its checks on GitHub. Status and automation info always lands in one consistent place, so you know to hold off while CI is still working."
+  "feat_ci_running_banner_body": "While CI runs on a session's PR, the terminal now shows a spinning-gear banner — the same spot as the review-in-flight notice — naming the checks in flight, with the PR number linking to the PR on GitHub. Status and automation info always lands in one consistent place, so you know to hold off while CI is still working."
 }

--- a/ui/src/lib/ci-banner.test.ts
+++ b/ui/src/lib/ci-banner.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { ciBannerState } from "./ci-banner";
+import type { GitState } from "./types";
+
+/** Minimal open-PR GitState with pending CI. */
+function git(overrides: Partial<GitState> = {}): GitState {
+  return {
+    kind: "github",
+    state: "open",
+    number: 1376,
+    url: "https://github.com/o/r/pull/1376",
+    checks: "pending",
+    deployConfigured: false,
+    ...overrides,
+  };
+}
+
+describe("ciBannerState", () => {
+  it("shows with names on an open PR whose CI is pending", () => {
+    const s = ciBannerState({
+      git: git({ runningChecks: ["verify / test", "PR hygiene / i18n"] }),
+      reviewActive: false,
+    });
+    expect(s).toEqual({
+      show: true,
+      number: 1376,
+      url: "https://github.com/o/r/pull/1376",
+      names: ["verify / test", "PR hygiene / i18n"],
+    });
+  });
+
+  it("shows with empty names (fallback copy) when runningChecks is absent", () => {
+    const s = ciBannerState({ git: git({ runningChecks: undefined }), reviewActive: false });
+    expect(s).toEqual({
+      show: true,
+      number: 1376,
+      url: "https://github.com/o/r/pull/1376",
+      names: [],
+    });
+  });
+
+  it("hides when a review banner is active (mutual exclusion)", () => {
+    expect(ciBannerState({ git: git({ runningChecks: ["a"] }), reviewActive: true })).toEqual({
+      show: false,
+    });
+  });
+
+  it("hides when checks are not pending", () => {
+    for (const checks of ["none", "success", "failure"] as const) {
+      expect(ciBannerState({ git: git({ checks }), reviewActive: false })).toEqual({ show: false });
+    }
+  });
+
+  it("hides when the PR is not open", () => {
+    for (const state of ["none", "merged", "closed"] as const) {
+      expect(
+        ciBannerState({ git: git({ state, checks: "pending" }), reviewActive: false }),
+      ).toEqual({
+        show: false,
+      });
+    }
+  });
+
+  it("hides when there is no git state", () => {
+    expect(ciBannerState({ git: null, reviewActive: false })).toEqual({ show: false });
+    expect(ciBannerState({ git: undefined, reviewActive: false })).toEqual({ show: false });
+  });
+});

--- a/ui/src/lib/ci-banner.test.ts
+++ b/ui/src/lib/ci-banner.test.ts
@@ -45,10 +45,25 @@ describe("ciBannerState", () => {
     });
   });
 
-  it("hides when checks are not pending", () => {
+  it("hides when checks are not pending and nothing is still running", () => {
     for (const checks of ["none", "success", "failure"] as const) {
       expect(ciBannerState({ git: git({ checks }), reviewActive: false })).toEqual({ show: false });
     }
+  });
+
+  it("shows while a check still runs even after another failed (worst-of rollup = failure)", () => {
+    // GitHub flips the aggregate to "failure" on the first failed check while others
+    // keep running — the banner must stay up so the operator knows CI isn't done.
+    const s = ciBannerState({
+      git: git({ checks: "failure", runningChecks: ["verify / test"] }),
+      reviewActive: false,
+    });
+    expect(s).toEqual({
+      show: true,
+      number: 1376,
+      url: "https://github.com/o/r/pull/1376",
+      names: ["verify / test"],
+    });
   });
 
   it("hides when the PR is not open", () => {

--- a/ui/src/lib/ci-banner.ts
+++ b/ui/src/lib/ci-banner.ts
@@ -1,0 +1,36 @@
+import type { GitState } from "./types";
+
+// Pure state selection for the terminal "CI is running" banner, mirroring the
+// review-banner.ts / critic-badge.ts pattern so the predicate is unit-testable
+// without rendering. The banner is a non-blocking amber strip at the bottom of the
+// terminal (the same spot as ReviewInFlightBanner), leading with the rotating gear
+// to signal "CI is running — hold off". It yields the strip to the review-in-flight
+// banner (the more urgent, steering signal): CI is suppressed while that banner is
+// logically visible, so the two are mutually exclusive by construction.
+
+/** Resolved CI-banner descriptor. `names` are the running checks in the forge's
+ *  `"<workflow> / <job>"` format (may be empty → the component shows the unnamed
+ *  fallback copy). */
+export type CiBannerState =
+  { show: false } | { show: true; number?: number; url?: string; names: string[] };
+
+export interface CiBannerInput {
+  /** This session's live PR/CI state, or null/undefined when there's no PR. */
+  git: GitState | null | undefined;
+  /** The review-in-flight banner is logically occupying the strip. When true the
+   *  CI banner suppresses itself so only one strip ever shows. */
+  reviewActive: boolean;
+}
+
+/**
+ * Whether the CI-running banner shows, and with what. True iff the session has an
+ * open PR whose checks are still in flight (`pending`) and no review banner is
+ * currently claiming the strip. No `noCi` guard is needed: `noCi` is exactly the
+ * "zero workflows → checks:none" case, so it can't co-occur with `checks:"pending"`.
+ */
+export function ciBannerState(input: CiBannerInput): CiBannerState {
+  const { git, reviewActive } = input;
+  if (reviewActive) return { show: false };
+  if (!git || git.state !== "open" || git.checks !== "pending") return { show: false };
+  return { show: true, number: git.number, url: git.url, names: git.runningChecks ?? [] };
+}

--- a/ui/src/lib/ci-banner.ts
+++ b/ui/src/lib/ci-banner.ts
@@ -23,14 +23,23 @@ export interface CiBannerInput {
 }
 
 /**
- * Whether the CI-running banner shows, and with what. True iff the session has an
- * open PR whose checks are still in flight (`pending`) and no review banner is
- * currently claiming the strip. No `noCi` guard is needed: `noCi` is exactly the
- * "zero workflows → checks:none" case, so it can't co-occur with `checks:"pending"`.
+ * Whether the CI-running banner shows, and with what. Shows iff the session has an
+ * open PR with CI still in flight and no review banner is claiming the strip.
+ *
+ * "In flight" is two signals OR'd: the aggregate `checks === "pending"` (the only
+ * one on the REST/Gitea fallback, where `runningChecks` is absent), AND a non-empty
+ * `runningChecks`. The second matters because GitHub's worst-of rollup flips
+ * `checks` to `"failure"` the moment ONE check fails while others keep running — so
+ * keying on `checks === "pending"` alone would hide the banner mid-run on the first
+ * failure, exactly when the operator still shouldn't act. No `noCi` guard is needed:
+ * `noCi` is the "zero workflows → checks:none, runningChecks empty" case, which
+ * neither branch matches.
  */
 export function ciBannerState(input: CiBannerInput): CiBannerState {
   const { git, reviewActive } = input;
   if (reviewActive) return { show: false };
-  if (!git || git.state !== "open" || git.checks !== "pending") return { show: false };
-  return { show: true, number: git.number, url: git.url, names: git.runningChecks ?? [] };
+  if (!git || git.state !== "open") return { show: false };
+  const names = git.runningChecks ?? [];
+  if (git.checks !== "pending" && names.length === 0) return { show: false };
+  return { show: true, number: git.number, url: git.url, names };
 }

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -61,6 +61,7 @@
   import SessionRecap from "$lib/components/SessionRecap.svelte";
   import ViewportTermBanners from "./viewport/ViewportTermBanners.svelte";
   import ReviewInFlightBanner from "./viewport/ReviewInFlightBanner.svelte";
+  import CiRunningBanner from "./viewport/CiRunningBanner.svelte";
   import ViewportTermControls from "./viewport/ViewportTermControls.svelte";
   import ViewportTabBar from "./viewport/ViewportTabBar.svelte";
   import ViewportHeaderActions from "./viewport/ViewportHeaderActions.svelte";
@@ -230,6 +231,12 @@
   // Published as --review-banner-h on .vp-body so the floating jump-to-latest button
   // (a sibling in ViewportTermBanners) can lift clear of the bottom banner strip.
   let reviewBannerH = $state(0);
+  // occupied height of the CiRunningBanner, and the review banner's logical
+  // visibility. The two strips are mutually exclusive by construction (CI suppresses
+  // itself while reviewActive), so at most one publishes a non-zero height — the
+  // jump-to-latest button lifts by `reviewBannerH || ciBannerH` (no max() needed).
+  let ciBannerH = $state(0);
+  let reviewActive = $state(false);
   // true when another device took over this terminal — show a take-over prompt
   let parked = $state(false);
   // true once the connection stopped for good — show a recovery prompt. endReason
@@ -2187,7 +2194,7 @@
     role="tabpanel"
     id={vpBodyId}
     aria-labelledby={tabId(tab)}
-    style:--review-banner-h={`${reviewBannerH}px`}
+    style:--review-banner-h={`${reviewBannerH || ciBannerH}px`}
   >
     <div class="scan" class:running={tab === "term"} aria-hidden="true"></div>
     <div
@@ -2224,7 +2231,16 @@
     <!-- Non-blocking review-in-flight banner: bottom strip over the terminal,
          above the steer bar. Stays mounted across tab switches (state survives);
          it suppresses its own render off the term tab. (issue #1022) -->
-    <ReviewInFlightBanner {session} keystrokes={opKeystrokes} {tab} bind:height={reviewBannerH} />
+    <ReviewInFlightBanner
+      {session}
+      keystrokes={opKeystrokes}
+      {tab}
+      bind:height={reviewBannerH}
+      bind:active={reviewActive}
+    />
+    <!-- Non-blocking "CI is running" banner: same bottom strip, shown only when no
+         review banner claims it (reviewActive) so the two never overlap. -->
+    <CiRunningBanner {git} {tab} {reviewActive} bind:height={ciBannerH} />
     {#if tab === "todo"}
       <div class="panel-wrap">
         <TodoPanel repoPath={session.repoPath} />

--- a/ui/src/lib/components/viewport/CiRunningBanner.svelte
+++ b/ui/src/lib/components/viewport/CiRunningBanner.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+  import type { GitState } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import { ciBannerState } from "$lib/ci-banner";
+
+  // Non-blocking "CI is running" signal: a bottom strip over the terminal, above
+  // the steer bar — the SAME spot as ReviewInFlightBanner, so status/automation
+  // info always lands in one consistent place. Leads with the rotating gear ("CI
+  // is running — hold off on merge/actions") and names the in-flight checks, with
+  // the PR number linking to the PR's checks on the forge. Suppresses itself while
+  // the review banner claims the strip (reviewActive) so only one ever shows.
+  let {
+    git,
+    tab,
+    reviewActive,
+    height = $bindable(0),
+  }: {
+    git: GitState | null | undefined;
+    tab: string;
+    reviewActive: boolean;
+    height?: number;
+  } = $props();
+
+  const view = $derived(ciBannerState({ git, reviewActive }));
+
+  // Join the running checks with ", " (a comma, not " · ", so it doesn't clash
+  // with the "/" inside a qualified "<workflow> / <job>" name).
+  const namesText = $derived(view.show ? view.names.join(", ") : "");
+
+  // Publish occupied height so the floating jump-to-latest button lifts clear of
+  // this strip, mirroring ReviewInFlightBanner. Seeded pre-paint via the bound
+  // element; bind:offsetHeight below keeps it current across reflows.
+  let bannerEl = $state<HTMLDivElement>();
+  $effect(() => {
+    const shown = view.show && tab === "term";
+    if (!shown) {
+      height = 0;
+      return;
+    }
+    if (bannerEl) height = bannerEl.offsetHeight;
+  });
+</script>
+
+{#if view.show && tab === "term"}
+  <div
+    class="ci-banner"
+    role="status"
+    aria-live="polite"
+    bind:this={bannerEl}
+    bind:offsetHeight={height}
+  >
+    <!-- Rotating cog: inline SVG (not the ⚙ glyph, which renders as a color emoji
+         ignoring currentColor and turns off-center) so it tints to the accent and
+         spins cleanly about its center. Mirrors ReviewInFlightBanner's .rb-cog. -->
+    <svg
+      class="cb-cog"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="3" />
+      <path
+        d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
+      />
+    </svg>
+    <span class="cb-text">
+      {namesText ? m.cibanner_running_named({ checks: namesText }) : m.cibanner_running_bare()}
+      {#if view.number != null}
+        <span class="cb-sep" aria-hidden="true"> · </span>
+        {#if view.url}
+          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL, not an app route -->
+          <a class="cb-link" href={view.url} target="_blank" rel="noopener"
+            >{m.cibanner_pr({ number: view.number })}</a
+          >
+        {:else}
+          <span class="cb-link-plain">{m.cibanner_pr({ number: view.number })}</span>
+        {/if}
+      {/if}
+    </span>
+  </div>
+{/if}
+
+<style>
+  /* Bottom overlay strip pinned to the terminal body, directly above the steer
+     bar — mirrors ReviewInFlightBanner. Absolutely positioned so it never triggers
+     an xterm refit. Non-blocking: no scrim/blur (it does not seize interaction). */
+  .ci-banner {
+    --accent: var(
+      --color-amber
+    ); /* amber = "CI running" (matches the herd CI head + pending dot) */
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 12px;
+    font-size: var(--fs-base);
+    color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 14%, var(--color-head));
+    border-top: 1px solid color-mix(in srgb, var(--accent) 55%, var(--color-line));
+    animation: cb-in 0.14s ease;
+  }
+  /* Rotating gear — the "CI is still running" cue. Reuses the shared icon-btn-spin
+     keyframe (app.css), NOT the .spin class, whose reduced-motion rule
+     (animation:none) would drop this status signal. */
+  .cb-cog {
+    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
+    color: var(--accent);
+    animation: icon-btn-spin 2.4s linear infinite;
+  }
+  /* Functional indicator: under reduced-motion keep the rotation (it's what reads
+     as "still running") but slow it right down. Needs the full shorthand +
+     !important to beat app.css's global `* { animation: none !important }`. */
+  @media (prefers-reduced-motion: reduce) {
+    .cb-cog {
+      animation: icon-btn-spin 6s linear infinite !important;
+    }
+  }
+  .cb-text {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--color-ink-bright);
+  }
+  .cb-sep {
+    color: var(--color-faint);
+  }
+  .cb-link,
+  .cb-link-plain {
+    color: var(--accent);
+  }
+  .cb-link {
+    text-decoration: underline;
+  }
+  .cb-link:hover {
+    color: var(--color-ink-bright);
+  }
+  @keyframes cb-in {
+    from {
+      opacity: 0;
+      transform: translateY(4px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+</style>

--- a/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
+++ b/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
@@ -20,7 +20,17 @@
     keystrokes,
     tab,
     height = $bindable(0),
-  }: { session: Session; keystrokes: number; tab: string; height?: number } = $props();
+    active = $bindable(false),
+  }: {
+    session: Session;
+    keystrokes: number;
+    tab: string;
+    height?: number;
+    /** Logical "this banner occupies the strip" signal (mirrors the render
+     *  condition below). Bound out so a sibling status banner (CiRunningBanner)
+     *  can suppress itself synchronously — no offsetHeight/paint race. */
+    active?: boolean;
+  } = $props();
 
   // Live in-flight flags (mutually exclusive: plan-gate = planning phase, critic =
   // post-PR, so never both at once).
@@ -171,6 +181,7 @@
   let bannerEl = $state<HTMLDivElement>();
   $effect(() => {
     const shown = view.show && tab === "term";
+    if (active !== shown) active = shown; // logical occupancy signal for a sibling status banner (pre-paint)
     if (!shown) {
       height = 0; // hidden branch: reset (the only place height is zeroed)
       return;

--- a/ui/src/lib/feature-announcements/entries/v1.42.0-ci-running-banner.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.42.0-ci-running-banner.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "ci-running-banner",
+  sinceVersion: "1.42.0",
+  titleKey: "feat_ci_running_banner_title",
+  bodyKey: "feat_ci_running_banner_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -267,6 +267,11 @@ export interface PrStatus {
   createdAt?: number;
   mergeable?: boolean | null;
   checks: ChecksState;
+  /** Names of the checks currently in flight (the `pending` subset of the rollup),
+   *  e.g. `["verify / test"]`. Populated only on the GitHub path; absent on the
+   *  REST fallback / Gitea and absent (not `[]`) when nothing runs. Drives the
+   *  terminal CI-running banner. Order isn't stable — compare as a set. */
+  runningChecks?: string[];
   /** GitHub's precise merge-state signal; absent for Gitea (mirrors server PrStatus). */
   mergeStateStatus?: MergeStateStatus;
   deployConfigured: boolean;


### PR DESCRIPTION
## Was & warum

Wenn auf dem PR einer Session gerade CI läuft, zeigt das Terminal jetzt — an **derselben Stelle** wie der Review-in-flight-Hinweis (der nicht-blockierende Streifen unten über der Steer-Bar) — ein amberfarbenes Banner mit **drehendem Zahnrad**, das die gerade laufenden Checks **namentlich** nennt und dessen PR-Nummer auf die Checks des PRs verlinkt.

Damit landet die „CI läuft"-Information immer an einer konsistenten Stelle (statt mal hier, mal da), und der Operator sieht auf einen Blick, dass er warten sollte, solange CI noch arbeitet.

## Umsetzung

**Server** — der Session-`GitState` trug bisher nur den aggregierten CI-Status:
- Neuer reiner Helper `runningCheckNames()` (`src/forge/checks.ts`): die `pending`-Teilmenge des `statusCheckRollup` (nur `status != completed`; ein abgeschlossenes `action_required` ist FAILURE, nicht pending).
- `PrStatus.runningChecks?: string[]` ergänzt und in `mapGhPr` befüllt (Einzel- + Batch-Pfad).
- `gitStateChanged` exportiert und um einen **reihenfolge-unabhängigen** Mengen-Vergleich der `runningChecks` erweitert — so aktualisiert die Namensliste live, wenn Checks fertig werden, ohne Pushes bei bloßer Umsortierung.
- **Kein neues Polling**: der `PrPoller` fast-pollt offene PRs bereits alle ~15 s und pusht `session:git` über den WebSocket.

**UI**:
- Reines Prädikat `ci-banner.ts` + dünne `CiRunningBanner.svelte` (übernimmt Zahnrad + Streifen-Styling inkl. Reduced-Motion-Override).
- `ReviewInFlightBanner` bekommt additiv ein `active = $bindable()` (seine logische Sichtbarkeit); das CI-Banner unterdrückt sich **synchron**, solange das Review-Banner den Streifen belegt → die beiden Streifen sind per Konstruktion gegenseitig ausschließend (kein Paint-Race, kein `max()` bei der Höhe). Die #1022-Zustandslogik bleibt unangetastet.
- i18n-Keys (en + de), ein Feature-Announcement-Eintrag (`v1.42.0`).

## Bewusste Design-Entscheidungen

- **Priorität:** Bei gleichzeitigem Review gewinnt das Review-Banner (der steuernde, dringendere Hinweis) — die CI-Info ist dann kurz verborgen und kehrt zurück, sobald der Streifen frei ist.
- **`pending`-Semantik:** queued/in_progress/waiting zählen als „läuft"; abgeschlossenes `action_required` rollt zu `failure` (nicht dieses Banner).
- **Link:** `git.url` ist die PR-Seite (Checks-Tab), nicht ein einzelner Run — bei mehreren laufenden Checks gibt es ohnehin nicht *den einen* Run.
- Rein informativ, keine Tipp-Eskalation (CI pastet nicht ins PTY).

## Tests & Gates

- Server: `runningCheckNames` (nur pending; action_required ausgeschlossen), `mapGhPr`-Verdrahtung, `gitStateChanged` (true bei Mengenänderung, false bei Reorder).
- UI: `ci-banner.test.ts` (show/hide, Namen, Fallback).
- Grün: root `lint`, UI `check` + `check:i18n`, Server-Tests (191), UI-Tests (2754), Branch-/Feature-Catalog-/Announcement-Version-Gates.

Reduced-Motion: Zahnrad dreht langsam weiter (statt zu stoppen), damit das „läuft"-Signal erhalten bleibt.