### PR TITLE
feat(extension): allowlist the published Chrome Web Store ID (Task 5)

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -119,10 +119,11 @@ single default **Repo path**. Each rule is a `pattern → repo path` pair:
 
 **No pairing step is required.** The extension's `fetch` sends
 `Origin: chrome-extension://<id>`; Shepherd's origin guard allowlists by the URL
-**hostname**, which for that origin is the **raw extension ID**. That fixed ID
-(`bflahkibnmcbijbhelmpjbohpfhlbaig`, pinned by the manifest `key`) is **baked into
-the server's default allowlist**, so a stock `bun run start` accepts captures from
-this extension out of the box:
+**hostname**, which for that origin is the **raw extension ID**. Both the published
+Web Store ID (`liknmighjkhplpbocaefaljokofaifgi`) and the pinned unpacked-dev ID
+(`bflahkibnmcbijbhelmpjbohpfhlbaig`, from the manifest `key`) are **baked into the
+server's default allowlist**, so a stock `bun run start` accepts captures from a
+store-installed **or** load-unpacked build out of the box:
 
 ```bash
 bun run start

--- a/extension/STORE_LISTING.md
+++ b/extension/STORE_LISTING.md
@@ -126,15 +126,18 @@ The body below is the source of truth the hosted page mirrors — keep the two i
 - ~~**Host the privacy policy** body above at a public URL and add a contact address.~~ ✅ Done —
   hosted at https://shepherd.run/privacy (`site/src/pages/privacy.astro`).
 - Produce the **screenshot(s)** and **promo tile**.
-- After registration, read back the item's **final assigned ID** and reconcile it — see below.
 
-## Task 5 — ID reconciliation (follow-up after registration)
+## Task 5 — ID reconciliation
 
-The store may assign a different ID than the self-generated manifest `key`. Once the final
-published ID is known, update it in **two** places so unpacked dev builds and the published item
-share one ID:
+**Done (server allowlist):** the item is registered with the permanent published ID
+`liknmighjkhplpbocaefaljokofaifgi` (assigned while pending review). It is baked into the server's
+default allowlist as `SHEPHERD_CAPTURE_EXTENSION_ID` in `src/config.ts`, so store-installed
+extensions work with no pairing. The pinned unpacked dev ID `bflahkibnmcbijbhelmpjbohpfhlbaig`
+stays allowed too (`SHEPHERD_CAPTURE_UNPACKED_DEV_ID`).
 
-- `SHEPHERD_CAPTURE_EXTENSION_ID` in `src/config.ts` (the server's default allowlist entry), and
-- `key` in `extension/manifest.config.ts`.
-
-Interim value (the pinned unpacked ID): `bflahkibnmcbijbhelmpjbohpfhlbaig`.
+**Optional (unify the two IDs):** a Chrome extension's ID is a one-way hash of the manifest's
+public `key`, and the store signs the published item with **its own** key — which is why the
+published ID differs from the manifest-key-derived unpacked ID. To make unpacked dev builds share
+the **published** ID (and drop the dev-only allowlist entry), copy the store item's **public key**
+from the CWS dashboard and set it as `key` in `extension/manifest.config.ts`. The public key is
+**not** derivable from the ID, so this needs the dashboard value. Not required for store users.

--- a/extension/manifest.config.ts
+++ b/extension/manifest.config.ts
@@ -32,6 +32,13 @@ export default defineManifest({
   // the base64 DER SPKI of an RSA keypair; only the public half lives here (the
   // private key is kept out of the repo, needed only to re-pack a .crx later).
   //
+  // NOTE: the PUBLISHED Chrome Web Store item is signed with the STORE's own key,
+  // so it has a DIFFERENT id (liknmighjkhplpbocaefaljokofaifgi) — both ids are
+  // allowlisted server-side (see SHEPHERD_CAPTURE_EXTENSION_ID +
+  // SHEPHERD_CAPTURE_UNPACKED_DEV_ID in src/config.ts). To UNIFY unpacked builds
+  // with the published id, replace this `key` with the store item's PUBLIC key
+  // (copy it from the CWS dashboard — it is NOT derivable from the id).
+  //
   // Re-derive the ID from this key to confirm it matches the README/allowlist:
   //   node -e 'const c=require("crypto"),der=Buffer.from(KEY,"base64"); \
   //     console.log([...c.createHash("sha256").update(der).digest("hex").slice(0,32)] \

--- a/src/config.ts
+++ b/src/config.ts
@@ -371,31 +371,40 @@ const mainPort = Number(process.env.SHEPHERD_PORT ?? 7330);
 // Shepherd Capture (the MV3 Chrome extension in `extension/`) sends its captures with
 // `Origin: chrome-extension://<id>`; the origin guard allowlists by hostname, and for that
 // origin the hostname IS the extension ID (see originAllowed in validate.ts). Baking the fixed
-// ID into the default allowlist removes the manual `SHEPHERD_ALLOWED_HOSTS` pairing step: a
+// IDs into the default allowlist removes the manual `SHEPHERD_ALLOWED_HOSTS` pairing step: a
 // stock install accepts captures with no env tweak. This is CSRF origin hygiene, not auth — a
 // web page can't forge a `chrome-extension://` origin, and `SHEPHERD_TOKEN` remains the real
-// auth boundary — so shipping a public, fixed ID as allowed-by-default grants nothing exploitable.
+// auth boundary — so shipping public, fixed IDs as allowed-by-default grants nothing exploitable.
 //
-// TODO(#1360 Task 5): reconcile with the final PUBLISHED Chrome Web Store ID once the item is
-// registered — the store may assign a different ID than the self-generated manifest `key`
-// (extension/manifest.config.ts). This is the pinned UNPACKED id; update both in lockstep.
-export const SHEPHERD_CAPTURE_EXTENSION_ID = "bflahkibnmcbijbhelmpjbohpfhlbaig";
+// TWO IDs are allowed because a Chrome extension's ID is a one-way hash of the manifest's public
+// `key`, and the Web Store signs published items with ITS OWN key — so the published ID differs
+// from the one the repo's manifest `key` (extension/manifest.config.ts) derives for unpacked dev
+// builds. Both origins are real and must work with no pairing:
+//   - SHEPHERD_CAPTURE_EXTENSION_ID       — the PUBLISHED Web Store item (what real users install).
+//   - SHEPHERD_CAPTURE_UNPACKED_DEV_ID    — the pinned load-unpacked dev build.
+// TODO(#1360 Task 5): to UNIFY them, set the manifest `key` to the store item's PUBLIC key (from
+// the CWS dashboard — it is NOT derivable from the ID); unpacked builds then share the published
+// ID and the dev-only entry below can be dropped.
+export const SHEPHERD_CAPTURE_EXTENSION_ID = "liknmighjkhplpbocaefaljokofaifgi";
+export const SHEPHERD_CAPTURE_UNPACKED_DEV_ID = "bflahkibnmcbijbhelmpjbohpfhlbaig";
 
 /**
  * Resolve the origin allowlist from `SHEPHERD_ALLOWED_HOSTS` (comma-separated), always appending
- * the built-in Capture extension ID. The env value overrides the built-in localhost defaults, but
- * the Capture ID is appended UNCONDITIONALLY (deduped) — it's origin hygiene the operator would
- * not want to drop, so it survives even a custom `SHEPHERD_ALLOWED_HOSTS`. Consequence: the env
- * var is no longer fully authoritative over the allowlist. Entries are trimmed and empties dropped
- * (a hostname with stray whitespace would never match `URL.hostname`); real entries — including
- * `::1` and bracketed `[::1]` — are preserved verbatim. Exported for tests.
+ * the built-in Capture extension IDs. The env value overrides the built-in localhost defaults, but
+ * the Capture IDs are appended UNCONDITIONALLY (deduped) — they're origin hygiene the operator
+ * would not want to drop, so they survive even a custom `SHEPHERD_ALLOWED_HOSTS`. Consequence: the
+ * env var is no longer fully authoritative over the allowlist. Entries are trimmed and empties
+ * dropped (a hostname with stray whitespace would never match `URL.hostname`); real entries —
+ * including `::1` and bracketed `[::1]` — are preserved verbatim. Exported for tests.
  */
 export function resolveAllowedOriginHosts(envValue: string | undefined): string[] {
   const hosts = (envValue ?? "localhost,127.0.0.1,::1,[::1]")
     .split(",")
     .map((h) => h.trim())
     .filter(Boolean);
-  if (!hosts.includes(SHEPHERD_CAPTURE_EXTENSION_ID)) hosts.push(SHEPHERD_CAPTURE_EXTENSION_ID);
+  for (const id of [SHEPHERD_CAPTURE_EXTENSION_ID, SHEPHERD_CAPTURE_UNPACKED_DEV_ID]) {
+    if (!hosts.includes(id)) hosts.push(id);
+  }
   return hosts;
 }
 

--- a/test/config-origin.test.ts
+++ b/test/config-origin.test.ts
@@ -1,28 +1,49 @@
 import { test, expect } from "bun:test";
-import { resolveAllowedOriginHosts, SHEPHERD_CAPTURE_EXTENSION_ID } from "../src/config";
+import {
+  resolveAllowedOriginHosts,
+  SHEPHERD_CAPTURE_EXTENSION_ID,
+  SHEPHERD_CAPTURE_UNPACKED_DEV_ID,
+} from "../src/config";
 
-// The Capture extension ID must be allowed by default (no SHEPHERD_ALLOWED_HOSTS pairing).
-test("resolveAllowedOriginHosts: default includes localhost set + the Capture ID", () => {
+// Both Capture IDs (published store item + unpacked dev build) must be allowed by default so
+// neither install path needs a SHEPHERD_ALLOWED_HOSTS pairing step.
+test("resolveAllowedOriginHosts: default includes localhost set + both Capture IDs", () => {
   const hosts = resolveAllowedOriginHosts(undefined);
-  expect(hosts).toEqual(["localhost", "127.0.0.1", "::1", "[::1]", SHEPHERD_CAPTURE_EXTENSION_ID]);
+  expect(hosts).toEqual([
+    "localhost",
+    "127.0.0.1",
+    "::1",
+    "[::1]",
+    SHEPHERD_CAPTURE_EXTENSION_ID,
+    SHEPHERD_CAPTURE_UNPACKED_DEV_ID,
+  ]);
 });
 
-// The un-removable-entry behavior change: env overrides the localhost defaults, but the Capture
-// ID is appended even when the operator's SHEPHERD_ALLOWED_HOSTS omits it.
-test("resolveAllowedOriginHosts: env omitting the ID still includes it (appended)", () => {
+// The un-removable-entry behavior change: env overrides the localhost defaults, but both Capture
+// IDs are appended even when the operator's SHEPHERD_ALLOWED_HOSTS omits them.
+test("resolveAllowedOriginHosts: env omitting the IDs still includes them (appended)", () => {
   const hosts = resolveAllowedOriginHosts("example.internal");
-  expect(hosts).toEqual(["example.internal", SHEPHERD_CAPTURE_EXTENSION_ID]);
+  expect(hosts).toEqual([
+    "example.internal",
+    SHEPHERD_CAPTURE_EXTENSION_ID,
+    SHEPHERD_CAPTURE_UNPACKED_DEV_ID,
+  ]);
 });
 
-// Dedup: an env value that already lists the ID must not double it.
-test("resolveAllowedOriginHosts: env already listing the ID is not doubled", () => {
+// Dedup: an env value that already lists an ID must not double it.
+test("resolveAllowedOriginHosts: env already listing an ID is not doubled", () => {
   const hosts = resolveAllowedOriginHosts(`a,${SHEPHERD_CAPTURE_EXTENSION_ID}`);
-  expect(hosts).toEqual(["a", SHEPHERD_CAPTURE_EXTENSION_ID]);
+  expect(hosts).toEqual(["a", SHEPHERD_CAPTURE_EXTENSION_ID, SHEPHERD_CAPTURE_UNPACKED_DEV_ID]);
   expect(hosts.filter((h) => h === SHEPHERD_CAPTURE_EXTENSION_ID)).toHaveLength(1);
 });
 
 // Trim + empty-filter must preserve real entries verbatim, including bracketed IPv6.
 test("resolveAllowedOriginHosts: trims whitespace, drops empties, preserves [::1]", () => {
   const hosts = resolveAllowedOriginHosts("localhost, , [::1] ,");
-  expect(hosts).toEqual(["localhost", "[::1]", SHEPHERD_CAPTURE_EXTENSION_ID]);
+  expect(hosts).toEqual([
+    "localhost",
+    "[::1]",
+    SHEPHERD_CAPTURE_EXTENSION_ID,
+    SHEPHERD_CAPTURE_UNPACKED_DEV_ID,
+  ]);
 });


### PR DESCRIPTION
Follow-up to #1360 / #1365 (now merged) — **Task 5 (ID reconciliation)**, which was gated on the human store registration.

## What happened
The Chrome Web Store item was registered and assigned its permanent ID **`liknmighjkhplpbocaefaljokofaifgi`** (while still pending review — CWS IDs are stable once assigned, so it's safe to bake in now).

## The two-ID subtlety
A Chrome extension's ID is a **one-way hash of the manifest's public `key`**, and the store signs the published item with **its own** key — so the published ID differs from the ID our repo's manifest `key` derives for unpacked dev builds (`bflahkibnmcbijbhelmpjbohpfhlbaig`). Both are real origins that must work with no pairing, so the server now allowlists **both** by default:

- `SHEPHERD_CAPTURE_EXTENSION_ID` → published store item (`liknmig…`) — what real users install.
- `SHEPHERD_CAPTURE_UNPACKED_DEV_ID` → pinned load-unpacked build (`bflah…`) — the dev workflow.

`resolveAllowedOriginHosts()` appends both (deduped); tests updated to assert both are present (incl. the env-omits / dedup / trim+IPv6 cases).

## Docs
README §Server setup, `manifest.config.ts` comment, and STORE_LISTING §Task 5 now explain that **unifying** the two IDs requires copying the store item's **public key** from the CWS dashboard into the manifest `key` — it is *not* derivable from the ID, so that's an optional follow-up, not required for store users.

## Why a new PR (not amending #1365)
#1365 was **squash-merged** and its branch auto-deleted before this info arrived; `main` has since moved ahead. This is genuine post-merge follow-up, so it's a fresh branch off latest `main` with just the Task 5 commit. (The privacy-policy page from #1368 already merged too — STORE_LISTING reflects that.)

## Verify
Root `typecheck` + `lint` + config/validate tests (149 pass); extension `check`; prettier clean; pre-push gates passed.

Refs #1360. Follows #1365.