### PR TITLE
feat(ui): files tab worktree/scratchpad source switch

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -276,6 +276,14 @@
         "maxCognitive": 20,
         "maxCrap": 1000,
         "reason": "Codex/default-provider persistence extends the existing hydrate migration path by one branch; keep capped until hydrate migrations are extracted."
+      },
+      {
+        "files": ["ui/src/lib/demo/router.ts"],
+        "functions": ["handleSessionDetailGet"],
+        "maxCyclomatic": 20,
+        "maxCognitive": 20,
+        "maxCrap": 1000,
+        "reason": "Demo session-detail GET dispatch chain gained the /worktree route (one branch over the cognitive default); keep capped until the GET routes move to the data-driven table the mutations already use (#855)."
       }
     ],
 

--- a/docs/external-task-api.md
+++ b/docs/external-task-api.md
@@ -130,6 +130,13 @@ Once a task exists, an external agent can also drive it:
   streams a single file. Paths are relative to the scratchpad root and
   realpath-contained to it (`..`, absolute, and symlink escapes are rejected);
   both `404` on a missing/archived session.
+- `GET /api/sessions/:id/worktree[?path=]` — browse a live session's git
+  worktree subtree (read-only); `GET /api/sessions/:id/worktree/download?path=`
+  streams a single file. Paths are relative to the worktree root and
+  realpath-contained to it. `.git` is hidden at any level, and symlinks that
+  resolve outside the worktree are surfaced as non-navigable `linkOutside`
+  entries rather than dropped. There is no worktree upload route; both `404` on
+  a missing/archived session.
 - `POST /api/sessions/:id/scratchpad/upload[?path=<relDir>]` — upload an
   arbitrary binary file (multipart `file` field, no MIME restriction) into the
   session's scratchpad. `?path` selects a relative subdirectory within the

--- a/src/fs-browse.ts
+++ b/src/fs-browse.ts
@@ -1,4 +1,4 @@
-import { promises as fsp } from "node:fs";
+import { promises as fsp, type Dirent } from "node:fs";
 import { join, relative, dirname, sep, normalize, isAbsolute } from "node:path";
 
 /**
@@ -87,6 +87,75 @@ export async function resolveInRoot(
 }
 
 /**
+ * Classify a symlink dirent that has already realpath'd to `real`: within root → resolve its
+ * target type and surface it normally; escaping the root → surface as a marked `linkOutside`
+ * entry when `onEscape: "mark"`, else drop it silently (default). Split out of `classifyDirent`
+ * so each stays under the complexity bar — same drop/mark semantics as before, just factored.
+ */
+async function classifySymlinkTarget(
+  dirent: Dirent,
+  abs: string,
+  real: string,
+  rootReal: string,
+  opts?: BrowseOptions,
+): Promise<BrowseEntry | null> {
+  if (within(real, rootReal)) {
+    let isDir: boolean;
+    try {
+      isDir = (await fsp.stat(abs)).isDirectory();
+    } catch {
+      return null;
+    }
+    return { name: dirent.name, type: isDir ? "dir" : "file", path: relFromRoot(rootReal, abs) };
+  }
+  if (opts?.onEscape === "mark") {
+    let type: "file" | "dir" = "file";
+    try {
+      type = (await fsp.stat(abs)).isDirectory() ? "dir" : "file";
+    } catch {
+      // best-effort — default to "file" on throw
+    }
+    return { name: dirent.name, type, path: relFromRoot(rootReal, abs), linkOutside: true };
+  }
+  // else ("drop" / default): never surface an entry that escapes the root
+  return null;
+}
+
+/**
+ * Classify a single directory entry into a `BrowseEntry`, or null when it should be dropped
+ * (broken symlink, escaping symlink under the default "drop" policy, or an unsurfaced type like
+ * a socket/fifo/device). Extracted from `listDir`'s per-dirent loop — same drop/mark semantics,
+ * same `linkOutside`, same types, just factored out for readability.
+ */
+async function classifyDirent(
+  dirent: Dirent,
+  resolved: string,
+  rootReal: string,
+  opts?: BrowseOptions,
+): Promise<BrowseEntry | null> {
+  const abs = join(resolved, dirent.name);
+
+  if (dirent.isSymbolicLink()) {
+    let real: string;
+    try {
+      real = await fsp.realpath(abs);
+    } catch {
+      return null; // broken symlink / unreadable → skip
+    }
+    return classifySymlinkTarget(dirent, abs, real, rootReal, opts);
+  }
+
+  if (dirent.isDirectory()) {
+    // No realpath/stat — a non-symlink child of an in-root dir is provably in-root.
+    return { name: dirent.name, type: "dir", path: relFromRoot(rootReal, abs) };
+  } else if (dirent.isFile()) {
+    return { name: dirent.name, type: "file", path: relFromRoot(rootReal, abs) };
+  }
+  // else: sockets/fifos/devices are not surfaced
+  return null;
+}
+
+/**
  * List one directory under `root`. Returns null on escape/missing/not-a-directory.
  * Sort: directories first, then locale-aware alphabetical within each group.
  */
@@ -109,52 +178,8 @@ export async function listDir(
   const entries: BrowseEntry[] = [];
   for (const d of dirents) {
     if (opts?.hideSegment?.(d.name)) continue;
-    const abs = join(resolved, d.name);
-
-    if (d.isSymbolicLink()) {
-      let real: string;
-      try {
-        real = await fsp.realpath(abs);
-      } catch {
-        continue; // broken symlink / unreadable → skip
-      }
-      if (within(real, rootReal)) {
-        let isDir: boolean;
-        try {
-          isDir = (await fsp.stat(abs)).isDirectory();
-        } catch {
-          continue;
-        }
-        entries.push({
-          name: d.name,
-          type: isDir ? "dir" : "file",
-          path: relFromRoot(rootReal, abs),
-        });
-      } else if (opts?.onEscape === "mark") {
-        let type: "file" | "dir" = "file";
-        try {
-          type = (await fsp.stat(abs)).isDirectory() ? "dir" : "file";
-        } catch {
-          // best-effort — default to "file" on throw
-        }
-        entries.push({
-          name: d.name,
-          type,
-          path: relFromRoot(rootReal, abs),
-          linkOutside: true,
-        });
-      }
-      // else ("drop" / default): never surface an entry that escapes the root
-      continue;
-    }
-
-    if (d.isDirectory()) {
-      // No realpath/stat — a non-symlink child of an in-root dir is provably in-root.
-      entries.push({ name: d.name, type: "dir", path: relFromRoot(rootReal, abs) });
-    } else if (d.isFile()) {
-      entries.push({ name: d.name, type: "file", path: relFromRoot(rootReal, abs) });
-    }
-    // else: sockets/fifos/devices are not surfaced
+    const entry = await classifyDirent(d, resolved, rootReal, opts);
+    if (entry) entries.push(entry);
   }
 
   entries.sort((a, b) =>

--- a/src/fs-browse.ts
+++ b/src/fs-browse.ts
@@ -1,0 +1,189 @@
+import { promises as fsp } from "node:fs";
+import { join, relative, dirname, sep, normalize, isAbsolute } from "node:path";
+
+/**
+ * Generic, root-parameterized read-only filesystem browse core. Every path a caller supplies is
+ * treated as RELATIVE to `root` and is realpath-contained to it: `..`, absolute paths, and
+ * symlink escapes all resolve to null/dropped. Shared by the session scratchpad browser
+ * (`src/scratchpad.ts`) and, eventually, a worktree browser — both need the same containment
+ * trust boundary, just with a different root and (for worktrees) a `.git` hideSegment.
+ */
+
+export interface BrowseEntry {
+  name: string;
+  type: "file" | "dir";
+  /** Path relative to the root, forward-slash separated, no leading slash. */
+  path: string;
+  /** true when this entry is a symlink that resolves OUTSIDE the root (only set in onEscape:"mark"). */
+  linkOutside?: boolean;
+}
+
+export interface BrowseListing {
+  /** The directory being listed, relative to the root ("" = root). */
+  path: string;
+  /** Parent dir relative to the root, or null at the root. */
+  parent: string | null;
+  entries: BrowseEntry[];
+}
+
+export interface BrowseOptions {
+  /** Reject/skip any path whose relative segments include a match. Used to hide `.git`. */
+  hideSegment?: (seg: string) => boolean;
+  /**
+   * How listDir treats a symlink that resolves outside the root:
+   *  - "drop" (default): omit it silently (scratchpad behavior).
+   *  - "mark": surface it as a non-navigable entry with `linkOutside: true`.
+   */
+  onEscape?: "drop" | "mark";
+}
+
+/** true when `real` is the root itself or lives inside it (realpath containment). */
+export function within(real: string, rootReal: string): boolean {
+  return real === rootReal || real.startsWith(rootReal + sep);
+}
+
+/** Root-relative, forward-slash form of an absolute path known to be within `rootReal`. */
+export function relFromRoot(rootReal: string, abs: string): string {
+  if (abs === rootReal) return "";
+  return relative(rootReal, abs).split(sep).join("/");
+}
+
+/**
+ * Resolve a caller-supplied RELATIVE path against `root`, enforcing containment via realpath.
+ * Returns `{ rootReal, resolved }`, or null when: root is absent/unreadable, the request escapes
+ * the root (`..`, absolute, symlink), the target doesn't exist, or a relative segment matches
+ * `hideSegment`.
+ */
+export async function resolveInRoot(
+  root: string,
+  relPath: string,
+  opts?: BrowseOptions,
+): Promise<{ rootReal: string; resolved: string } | null> {
+  let rootReal: string;
+  try {
+    rootReal = await fsp.realpath(root);
+  } catch {
+    return null; // root not created / unreadable
+  }
+  // Treat as root-relative. Reject any normalized path that climbs above the root (`..`) or is
+  // absolute; realpath containment below is the backstop (catches symlink escapes too).
+  const norm = normalize(relPath || "");
+  if (norm === ".." || norm.startsWith(".." + sep) || isAbsolute(norm)) return null;
+
+  if (opts?.hideSegment) {
+    const segments = norm.split(sep);
+    if (segments.some((seg) => opts.hideSegment!(seg))) return null;
+  }
+
+  const target = norm === "" || norm === "." ? rootReal : join(rootReal, norm);
+  let resolved: string;
+  try {
+    resolved = await fsp.realpath(target);
+  } catch {
+    return null;
+  }
+  if (!within(resolved, rootReal)) return null;
+  return { rootReal, resolved };
+}
+
+/**
+ * List one directory under `root`. Returns null on escape/missing/not-a-directory.
+ * Sort: directories first, then locale-aware alphabetical within each group.
+ */
+export async function listDir(
+  root: string,
+  relPath: string,
+  opts?: BrowseOptions,
+): Promise<BrowseListing | null> {
+  const r = await resolveInRoot(root, relPath, opts);
+  if (!r) return null;
+  const { rootReal, resolved } = r;
+
+  let dirents;
+  try {
+    dirents = await fsp.readdir(resolved, { withFileTypes: true });
+  } catch {
+    return null; // not a directory / unreadable
+  }
+
+  const entries: BrowseEntry[] = [];
+  for (const d of dirents) {
+    if (opts?.hideSegment?.(d.name)) continue;
+    const abs = join(resolved, d.name);
+
+    if (d.isSymbolicLink()) {
+      let real: string;
+      try {
+        real = await fsp.realpath(abs);
+      } catch {
+        continue; // broken symlink / unreadable → skip
+      }
+      if (within(real, rootReal)) {
+        let isDir: boolean;
+        try {
+          isDir = (await fsp.stat(abs)).isDirectory();
+        } catch {
+          continue;
+        }
+        entries.push({
+          name: d.name,
+          type: isDir ? "dir" : "file",
+          path: relFromRoot(rootReal, abs),
+        });
+      } else if (opts?.onEscape === "mark") {
+        let type: "file" | "dir" = "file";
+        try {
+          type = (await fsp.stat(abs)).isDirectory() ? "dir" : "file";
+        } catch {
+          // best-effort — default to "file" on throw
+        }
+        entries.push({
+          name: d.name,
+          type,
+          path: relFromRoot(rootReal, abs),
+          linkOutside: true,
+        });
+      }
+      // else ("drop" / default): never surface an entry that escapes the root
+      continue;
+    }
+
+    if (d.isDirectory()) {
+      // No realpath/stat — a non-symlink child of an in-root dir is provably in-root.
+      entries.push({ name: d.name, type: "dir", path: relFromRoot(rootReal, abs) });
+    } else if (d.isFile()) {
+      entries.push({ name: d.name, type: "file", path: relFromRoot(rootReal, abs) });
+    }
+    // else: sockets/fifos/devices are not surfaced
+  }
+
+  entries.sort((a, b) =>
+    a.type !== b.type ? (a.type === "dir" ? -1 : 1) : a.name.localeCompare(b.name),
+  );
+
+  const here = relFromRoot(rootReal, resolved);
+  return {
+    path: here,
+    parent: here === "" ? null : relFromRoot(rootReal, dirname(resolved)),
+    entries,
+  };
+}
+
+/**
+ * Resolve a path under `root` that must be a regular FILE (for download). Returns the canonical
+ * absolute path, or null on escape / missing / not-a-regular-file / hideSegment match.
+ */
+export async function resolveFileInRoot(
+  root: string,
+  relPath: string,
+  opts?: BrowseOptions,
+): Promise<string | null> {
+  const r = await resolveInRoot(root, relPath, opts);
+  if (!r) return null;
+  try {
+    if (!(await fsp.stat(r.resolved)).isFile()) return null;
+  } catch {
+    return null;
+  }
+  return r.resolved;
+}

--- a/src/scratchpad.ts
+++ b/src/scratchpad.ts
@@ -7,7 +7,6 @@ import {
   resolveInRoot,
   listDir,
   resolveFileInRoot,
-  type BrowseEntry,
   type BrowseListing,
 } from "./fs-browse";
 
@@ -20,7 +19,6 @@ import {
  * just binds it to the per-session scratchpad root.
  */
 
-export type ScratchEntry = BrowseEntry;
 export type ScratchListing = BrowseListing;
 
 /**

--- a/src/scratchpad.ts
+++ b/src/scratchpad.ts
@@ -1,39 +1,27 @@
 import { promises as fsp } from "node:fs";
-import { join, relative, dirname, basename, extname, sep, normalize, isAbsolute } from "node:path";
+import { join, basename, extname, sep, normalize, isAbsolute } from "node:path";
 import { sessionScratchpadDir } from "./tmp-sweep";
+import {
+  within,
+  relFromRoot,
+  resolveInRoot,
+  listDir,
+  resolveFileInRoot,
+  type BrowseEntry,
+  type BrowseListing,
+} from "./fs-browse";
 
 /**
  * Read-only browser of a session's scratchpad subtree (#1164). Every path the operator supplies
  * is treated as RELATIVE to the scratchpad root and is realpath-contained to it: `..`, absolute
  * paths, and symlink escapes all resolve to null/dropped. The genuinely new power vs. the
  * existing `/api/fs/dirs` browser is streaming file BYTES, so containment is the trust boundary.
+ * The containment core lives in `./fs-browse` (shared with the worktree browser); this module
+ * just binds it to the per-session scratchpad root.
  */
 
-export interface ScratchEntry {
-  name: string;
-  type: "file" | "dir";
-  /** Path relative to the scratchpad root, forward-slash separated, no leading slash. */
-  path: string;
-}
-
-export interface ScratchListing {
-  /** The directory being listed, relative to the root ("" = root). */
-  path: string;
-  /** Parent dir relative to the root, or null at the root. */
-  parent: string | null;
-  entries: ScratchEntry[];
-}
-
-/** true when `real` is the root itself or lives inside it (realpath containment). */
-function within(real: string, rootReal: string): boolean {
-  return real === rootReal || real.startsWith(rootReal + sep);
-}
-
-/** Root-relative, forward-slash form of an absolute path known to be within `rootReal`. */
-function relFromRoot(rootReal: string, abs: string): string {
-  if (abs === rootReal) return "";
-  return relative(rootReal, abs).split(sep).join("/");
-}
+export type ScratchEntry = BrowseEntry;
+export type ScratchListing = BrowseListing;
 
 /**
  * Resolve a caller-supplied RELATIVE path against the session scratchpad root, enforcing
@@ -47,25 +35,7 @@ export async function resolveScratchpadPath(
   relPath: string,
 ): Promise<{ rootReal: string; resolved: string } | null> {
   if (!claudeSessionId) return null;
-  let rootReal: string;
-  try {
-    rootReal = await fsp.realpath(sessionScratchpadDir(worktreePath, claudeSessionId));
-  } catch {
-    return null; // root not created yet (agent wrote nothing) / unreadable
-  }
-  // Treat as root-relative. Reject any normalized path that climbs above the root (`..`) or is
-  // absolute; realpath containment below is the backstop (catches symlink escapes too).
-  const norm = normalize(relPath || "");
-  if (norm === ".." || norm.startsWith(".." + sep) || isAbsolute(norm)) return null;
-  const target = norm === "" || norm === "." ? rootReal : join(rootReal, norm);
-  let resolved: string;
-  try {
-    resolved = await fsp.realpath(target);
-  } catch {
-    return null;
-  }
-  if (!within(resolved, rootReal)) return null;
-  return { rootReal, resolved };
+  return resolveInRoot(sessionScratchpadDir(worktreePath, claudeSessionId), relPath);
 }
 
 /**
@@ -80,46 +50,8 @@ export async function listScratchpad(
   claudeSessionId: string,
   relPath: string,
 ): Promise<ScratchListing | null> {
-  const r = await resolveScratchpadPath(worktreePath, claudeSessionId, relPath);
-  if (!r) return null;
-  const { rootReal, resolved } = r;
-
-  let dirents;
-  try {
-    dirents = await fsp.readdir(resolved, { withFileTypes: true });
-  } catch {
-    return null; // not a directory / unreadable
-  }
-
-  const entries: ScratchEntry[] = [];
-  for (const d of dirents) {
-    const abs = join(resolved, d.name);
-    let real: string;
-    try {
-      real = await fsp.realpath(abs);
-    } catch {
-      continue; // broken symlink / unreadable → skip
-    }
-    if (!within(real, rootReal)) continue; // never surface an entry that escapes the root
-    let isDir: boolean;
-    try {
-      isDir = (await fsp.stat(abs)).isDirectory();
-    } catch {
-      continue;
-    }
-    entries.push({ name: d.name, type: isDir ? "dir" : "file", path: relFromRoot(rootReal, abs) });
-  }
-
-  entries.sort((a, b) =>
-    a.type !== b.type ? (a.type === "dir" ? -1 : 1) : a.name.localeCompare(b.name),
-  );
-
-  const here = relFromRoot(rootReal, resolved);
-  return {
-    path: here,
-    parent: here === "" ? null : relFromRoot(rootReal, dirname(resolved)),
-    entries,
-  };
+  if (!claudeSessionId) return null;
+  return listDir(sessionScratchpadDir(worktreePath, claudeSessionId), relPath);
 }
 
 /**
@@ -131,14 +63,8 @@ export async function resolveScratchpadFile(
   claudeSessionId: string,
   relPath: string,
 ): Promise<string | null> {
-  const r = await resolveScratchpadPath(worktreePath, claudeSessionId, relPath);
-  if (!r) return null;
-  try {
-    if (!(await fsp.stat(r.resolved)).isFile()) return null;
-  } catch {
-    return null;
-  }
-  return r.resolved;
+  if (!claudeSessionId) return null;
+  return resolveFileInRoot(sessionScratchpadDir(worktreePath, claudeSessionId), relPath);
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -81,6 +81,7 @@ import {
   resolveScratchpadUploadDir,
   placeScratchpadUpload,
 } from "./scratchpad";
+import { listWorktree, resolveWorktreeFile } from "./worktree-files";
 import { loadSteers, saveSteers } from "./steers";
 import { loadIcons, setIcon } from "./project-icons";
 import { listBranches } from "./branches";
@@ -1966,6 +1967,39 @@ async function handleSessionScratchpad({ req, parts, url, deps }: Ctx): Promise<
   return null;
 }
 
+// ── worktree file browser: GET /api/sessions/:id/worktree[?path=] (list)
+//                           GET /api/sessions/:id/worktree/download?path= (file) ──
+// Read-only browse + single-file download, rooted at and realpath-contained to the session's
+// worktree. `.git` is hidden; out-of-root symlinks are surfaced disabled. Live sessions only:
+// 404 on a missing/archived session. Containment is enforced in src/worktree-files.ts.
+async function worktreeDownload(s: Session, rel: string): Promise<Response> {
+  const file = await resolveWorktreeFile(s.worktreePath, rel);
+  if (!file) return json({ error: "not found" }, 404);
+  const f = Bun.file(file);
+  return new Response(f, {
+    headers: {
+      "content-type": f.type || "application/octet-stream",
+      "content-disposition": attachmentDisposition(basename(file)),
+    },
+  });
+}
+
+async function worktreeList(s: Session, rel: string): Promise<Response> {
+  const listing = await listWorktree(s.worktreePath, rel);
+  if (listing) return json(listing);
+  return json({ error: "not found" }, 404);
+}
+
+async function handleSessionWorktree({ req, parts, url, deps }: Ctx): Promise<Response | null> {
+  if (req.method !== "GET" || parts[3] !== "worktree") return null;
+  const s = deps.store.get(parts[2] ?? "");
+  if (!s || s.status === "archived") return json({ error: "not found" }, 404);
+  const rel = url.searchParams.get("path") ?? "";
+  if (parts[4] === "download") return worktreeDownload(s, rel);
+  if (!parts[4]) return worktreeList(s, rel);
+  return null;
+}
+
 // ── scratchpad upload: POST /api/sessions/:id/scratchpad/upload[?path=] ──
 // Accepts any binary file (no MIME restriction) up to MAX_UPLOAD_BYTES. The `?path` param
 // is a relative subdir within the scratchpad root (default: root). The scratchpad root is
@@ -3089,6 +3123,7 @@ async function handleSessions(ctx: Ctx): Promise<Response | null> {
     handleSessionReads,
     handleSessionScratchpad,
     handleSessionScratchpadUpload,
+    handleSessionWorktree,
     handleSessionDelete,
     handleSessionReply,
     handleSessionRecommend,

--- a/src/worktree-files.ts
+++ b/src/worktree-files.ts
@@ -1,0 +1,25 @@
+import { listDir, resolveFileInRoot, type BrowseListing } from "./fs-browse";
+
+/** Hide `.git` at any level — matches by NAME, so it covers the normal dir, the
+ *  `git worktree add` gitdir-pointer FILE, and nested submodule `.git` dirs alike. */
+const hideGit = (seg: string): boolean => seg === ".git";
+
+/**
+ * List one directory of a session's worktree (read-only). `.git` is hidden; symlinks that
+ * resolve outside the worktree are surfaced as non-navigable `linkOutside` entries rather than
+ * dropped, so the tree isn't misleadingly incomplete. Returns null on escape/missing/not-a-dir.
+ */
+export function listWorktree(worktreePath: string, relPath: string): Promise<BrowseListing | null> {
+  if (!worktreePath) return Promise.resolve(null); // guard: never fall back to realpath(".")
+  return listDir(worktreePath, relPath, { hideSegment: hideGit, onEscape: "mark" });
+}
+
+/**
+ * Resolve a worktree path that must be a regular FILE for download. Rejects `.git` traversal,
+ * root escapes (`..`, absolute), and symlinks resolving outside the worktree. Returns the
+ * canonical absolute path or null.
+ */
+export function resolveWorktreeFile(worktreePath: string, relPath: string): Promise<string | null> {
+  if (!worktreePath) return Promise.resolve(null);
+  return resolveFileInRoot(worktreePath, relPath, { hideSegment: hideGit });
+}

--- a/test/fs-browse.test.ts
+++ b/test/fs-browse.test.ts
@@ -1,0 +1,74 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveInRoot, listDir } from "../src/fs-browse";
+
+// The scratchpad test suite (test/scratchpad.test.ts) already exercises the shared
+// resolveInRoot/listDir paths end-to-end (containment, drop-on-escape, sort). These tests cover
+// only the two NEW behaviors not reachable through scratchpad: hideSegment and onEscape:"mark".
+
+let root: string;
+let outside: string;
+
+beforeEach(() => {
+  root = realpathSync(mkdtempSync(join(tmpdir(), "shepherd-fsbrowse-test-")));
+  outside = realpathSync(mkdtempSync(join(tmpdir(), "shepherd-fsbrowse-out-")));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+  rmSync(outside, { recursive: true, force: true });
+});
+
+const hideGit = (seg: string) => seg === ".git";
+
+test("resolveInRoot: hideSegment rejects a path with a matching segment, even though realpath is in-root", async () => {
+  mkdirSync(join(root, ".git"), { recursive: true });
+  writeFileSync(join(root, ".git", "config"), "x");
+  const r = await resolveInRoot(root, ".git/config", { hideSegment: hideGit });
+  expect(r).toBeNull();
+});
+
+test("resolveInRoot: hideSegment does not affect unrelated paths", async () => {
+  mkdirSync(join(root, "src"));
+  writeFileSync(join(root, "src", "index.ts"), "x");
+  const r = await resolveInRoot(root, "src/index.ts", { hideSegment: hideGit });
+  expect(r).not.toBeNull();
+});
+
+test("listDir: hideSegment skips a matching child (e.g. .git) entirely", async () => {
+  mkdirSync(join(root, ".git"));
+  writeFileSync(join(root, "readme.md"), "x");
+  const l = await listDir(root, "", { hideSegment: hideGit });
+  expect(l).not.toBeNull();
+  expect(l!.entries.map((e) => e.name)).toEqual(["readme.md"]);
+});
+
+test('listDir: onEscape "drop" (default) omits a symlink resolving outside the root', async () => {
+  writeFileSync(join(outside, "secret.txt"), "leak");
+  symlinkSync(join(outside, "secret.txt"), join(root, "escapee"));
+  const l = await listDir(root, "");
+  expect(l).not.toBeNull();
+  expect(l!.entries.map((e) => e.name)).toEqual([]);
+});
+
+test('listDir: onEscape "mark" surfaces an out-pointing symlink as non-navigable with linkOutside: true', async () => {
+  writeFileSync(join(outside, "secret.txt"), "leak");
+  symlinkSync(join(outside, "secret.txt"), join(root, "escapee"));
+  const l = await listDir(root, "", { onEscape: "mark" });
+  expect(l).not.toBeNull();
+  expect(l!.entries).toEqual([
+    { name: "escapee", type: "file", path: "escapee", linkOutside: true },
+  ]);
+});
+
+test('listDir: onEscape "mark" also marks an out-pointing symlink to a directory', async () => {
+  mkdirSync(join(outside, "otherdir"));
+  symlinkSync(join(outside, "otherdir"), join(root, "escapee-dir"));
+  const l = await listDir(root, "", { onEscape: "mark" });
+  expect(l).not.toBeNull();
+  expect(l!.entries).toEqual([
+    { name: "escapee-dir", type: "dir", path: "escapee-dir", linkOutside: true },
+  ]);
+});

--- a/test/worktree-endpoint.test.ts
+++ b/test/worktree-endpoint.test.ts
@@ -1,0 +1,113 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { makeApp, type AppDeps } from "../src/server";
+import { SessionStore } from "../src/store";
+import { EventHub } from "../src/events";
+import { config } from "../src/config";
+
+let tmpRoot: string;
+let repoDir: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(config.repoRoot, "shepherd-worktree-ep-"));
+  repoDir = join(tmpRoot, "repo");
+  mkdirSync(repoDir);
+});
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function harness() {
+  const store = new SessionStore(":memory:");
+  const hub = new EventHub();
+  const deps: AppDeps = {
+    store,
+    service: {} as any,
+    events: hub,
+    usageLimits: { limits: () => ({}) } as any,
+  };
+  return { app: makeApp(deps), store };
+}
+
+function makeSession(store: SessionStore) {
+  return store.create({
+    name: "worktree-session",
+    prompt: "p",
+    repoPath: repoDir,
+    baseBranch: "main",
+    branch: "shepherd/worktree",
+    worktreePath: repoDir,
+    isolated: false,
+    herdrSession: "sess-x",
+    herdrAgentId: "agent-x",
+    claudeSessionId: "claude-sess-1",
+    model: null,
+  });
+}
+
+/** Populate the session's worktree with a file, a nested dir, and a `.git` pointer file. */
+function seedWorktree() {
+  mkdirSync(join(repoDir, "src"), { recursive: true });
+  writeFileSync(join(repoDir, "README.md"), "# hi\n");
+  writeFileSync(join(repoDir, "src", "index.ts"), "export {};\n");
+  writeFileSync(join(repoDir, ".git"), "gitdir: /some/path/.git/worktrees/x\n");
+}
+
+test("GET worktree lists the root with .git hidden", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  seedWorktree();
+
+  const res = await app.fetch(new Request(`http://x/api/sessions/${s.id}/worktree`));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.path).toBe("");
+  expect(body.parent).toBeNull();
+  const names = body.entries.map((e: { name: string }) => e.name);
+  expect(names).not.toContain(".git");
+  expect(names).toContain("README.md");
+  expect(names).toContain("src");
+});
+
+test("GET worktree of an unknown session is 404", async () => {
+  const { app } = harness();
+  const res = await app.fetch(new Request("http://x/api/sessions/nope/worktree"));
+  expect(res.status).toBe(404);
+});
+
+test("GET worktree of an archived session is 404 (live only)", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  seedWorktree();
+  store.update(s.id, { status: "archived" });
+
+  const res = await app.fetch(new Request(`http://x/api/sessions/${s.id}/worktree`));
+  expect(res.status).toBe(404);
+});
+
+test("download streams a worktree file with an attachment Content-Disposition", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  seedWorktree();
+
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${s.id}/worktree/download?path=README.md`),
+  );
+  expect(res.status).toBe(200);
+  expect(res.headers.get("content-disposition")).toBe(
+    "attachment; filename=\"README.md\"; filename*=UTF-8''README.md",
+  );
+  expect(await res.text()).toBe("# hi\n");
+});
+
+test("download of a .git path is 404 (hidden segment)", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  seedWorktree();
+
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${s.id}/worktree/download?path=.git`),
+  );
+  expect(res.status).toBe(404);
+});

--- a/test/worktree-files.test.ts
+++ b/test/worktree-files.test.ts
@@ -1,0 +1,107 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { listWorktree, resolveWorktreeFile } from "../src/worktree-files";
+
+let root: string;
+let outside: string;
+
+beforeEach(() => {
+  root = realpathSync(mkdtempSync(join(tmpdir(), "shepherd-worktree-test-")));
+  outside = realpathSync(mkdtempSync(join(tmpdir(), "shepherd-worktree-out-")));
+
+  // Regular file + subdir.
+  writeFileSync(join(root, "README.md"), "# hi\n");
+  mkdirSync(join(root, "src"));
+  writeFileSync(join(root, "src", "index.ts"), "export {};\n");
+
+  // Dotfile (not hidden — only `.git` is hidden).
+  writeFileSync(join(root, ".env"), "X=1\n");
+
+  // `.git` FILE (as created by `git worktree add`) — a realistic gitdir pointer.
+  writeFileSync(join(root, ".git"), "gitdir: /some/path/.git/worktrees/x\n");
+
+  // Nested submodule dir with its own `.git` DIRECTORY.
+  mkdirSync(join(root, "vendor", "lib"), { recursive: true });
+  mkdirSync(join(root, "vendor", "lib", ".git"));
+  writeFileSync(join(root, "vendor", "lib", ".git", "config"), "[core]\n");
+  writeFileSync(join(root, "vendor", "lib", "package.json"), "{}\n");
+
+  // Out-of-root symlink.
+  writeFileSync(join(outside, "secret.txt"), "leak");
+  symlinkSync(join(outside, "secret.txt"), join(root, "escapee"));
+
+  // Broken symlink.
+  symlinkSync(join(root, "does-not-exist"), join(root, "broken-link"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+  rmSync(outside, { recursive: true, force: true });
+});
+
+test("listWorktree(root, ''): hides .git, shows others, marks out-of-root symlink, drops broken symlink, dirs before files", async () => {
+  const listing = await listWorktree(root, "");
+  expect(listing).not.toBeNull();
+  const names = listing!.entries.map((e) => e.name);
+
+  expect(names).not.toContain(".git");
+  expect(names).not.toContain("broken-link");
+  expect(names).toContain("README.md");
+  expect(names).toContain("src");
+  expect(names).toContain(".env");
+  expect(names).toContain("vendor");
+  expect(names).toContain("escapee");
+
+  const escapee = listing!.entries.find((e) => e.name === "escapee");
+  expect(escapee?.linkOutside).toBe(true);
+
+  // dirs sort before files
+  const dirIdx = listing!.entries.findIndex((e) => e.type === "dir");
+  const fileIdx = listing!.entries.findIndex((e) => e.type === "file");
+  expect(dirIdx).toBeLessThan(fileIdx);
+});
+
+test("listWorktree(root, 'vendor/lib'): nested .git directory is absent", async () => {
+  const listing = await listWorktree(root, "vendor/lib");
+  expect(listing).not.toBeNull();
+  const names = listing!.entries.map((e) => e.name);
+  expect(names).not.toContain(".git");
+  expect(names).toContain("package.json");
+});
+
+test("resolveWorktreeFile(root, '.git') -> null (hidden segment rejected even inside root)", async () => {
+  const r = await resolveWorktreeFile(root, ".git");
+  expect(r).toBeNull();
+});
+
+test("resolveWorktreeFile(root, 'vendor/lib/.git/config') -> null (mid-path hideSegment match)", async () => {
+  const r = await resolveWorktreeFile(root, "vendor/lib/.git/config");
+  expect(r).toBeNull();
+});
+
+test("escape via '..' is rejected for both list and resolve", async () => {
+  const rel = await resolveWorktreeFile(root, join("..", "secret.txt"));
+  expect(rel).toBeNull();
+  const listing = await listWorktree(root, "..");
+  expect(listing).toBeNull();
+});
+
+test("resolveWorktreeFile rejects the out-of-root symlink", async () => {
+  const r = await resolveWorktreeFile(root, "escapee");
+  expect(r).toBeNull();
+});
+
+test("resolveWorktreeFile(root, 'README.md') -> canonical absolute path (happy path)", async () => {
+  const r = await resolveWorktreeFile(root, "README.md");
+  expect(r).toBe(join(root, "README.md"));
+});
+
+test("blank worktreePath guard: listWorktree('', '') -> null (never falls back to cwd)", async () => {
+  expect(await listWorktree("", "")).toBeNull();
+});
+
+test("blank worktreePath guard: resolveWorktreeFile('', 'README.md') -> null", async () => {
+  expect(await resolveWorktreeFile("", "README.md")).toBeNull();
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2471,5 +2471,14 @@
   "cibanner_running_bare": "CI läuft",
   "cibanner_pr": "PR #{number}",
   "feat_ci_running_banner_title": "Sehen, wenn CI läuft",
-  "feat_ci_running_banner_body": "Während auf dem PR einer Session CI läuft, zeigt das Terminal jetzt ein Banner mit drehendem Zahnrad – an derselben Stelle wie der Review-in-flight-Hinweis – und nennt die gerade laufenden Checks; die PR-Nummer verlinkt auf den PR auf GitHub. Status- und Automatik-Infos landen so immer an einer konsistenten Stelle, damit du weißt, dass du warten solltest, solange CI noch arbeitet."
+  "feat_ci_running_banner_body": "Während auf dem PR einer Session CI läuft, zeigt das Terminal jetzt ein Banner mit drehendem Zahnrad – an derselben Stelle wie der Review-in-flight-Hinweis – und nennt die gerade laufenden Checks; die PR-Nummer verlinkt auf den PR auf GitHub. Status- und Automatik-Infos landen so immer an einer konsistenten Stelle, damit du weißt, dass du warten solltest, solange CI noch arbeitet.",
+  "files_source_switch_aria": "Dateiquelle",
+  "files_source_scratchpad": "Scratchpad",
+  "files_source_worktree": "Worktree",
+  "files_worktree_root_crumb": "Worktree",
+  "files_worktree_breadcrumb_aria": "Worktree-Pfad",
+  "files_worktree_empty": "Keine Dateien im Worktree.",
+  "files_worktree_load_error": "Worktree-Dateien konnten nicht geladen werden.",
+  "files_worktree_list_aria": "Worktree-Dateien",
+  "files_link_outside_title": "Symlink zeigt aus dem Worktree heraus"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2480,5 +2480,7 @@
   "files_worktree_empty": "Keine Dateien im Worktree.",
   "files_worktree_load_error": "Worktree-Dateien konnten nicht geladen werden.",
   "files_worktree_list_aria": "Worktree-Dateien",
-  "files_link_outside_title": "Symlink zeigt aus dem Worktree heraus"
+  "files_link_outside_title": "Symlink zeigt aus dem Worktree heraus",
+  "feat_worktree_files_title": "Worktree im Dateien-Tab durchsuchen",
+  "feat_worktree_files_body": "Der Dateien-Tab hat jetzt einen Scratchpad-/Worktree-Umschalter — wechsle zu Worktree, um jede Datei aus dem Arbeitsbaum der Sitzung anzusehen und herunterzuladen (schreibgeschützt, .git ausgeblendet). Scratchpad bleibt Standard und nimmt weiterhin Uploads entgegen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2480,5 +2480,7 @@
   "files_worktree_empty": "No files in the worktree.",
   "files_worktree_load_error": "Couldn't load worktree files.",
   "files_worktree_list_aria": "Worktree files",
-  "files_link_outside_title": "Symlink points outside the worktree"
+  "files_link_outside_title": "Symlink points outside the worktree",
+  "feat_worktree_files_title": "Browse the worktree from the Files tab",
+  "feat_worktree_files_body": "The Files tab now has a Scratchpad / Worktree switch — flip to Worktree to browse and download any file from the session's working tree (read-only, .git hidden). Scratchpad stays the default and still takes uploads."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2471,5 +2471,14 @@
   "cibanner_running_bare": "CI is running",
   "cibanner_pr": "PR #{number}",
   "feat_ci_running_banner_title": "See when CI is running",
-  "feat_ci_running_banner_body": "While CI runs on a session's PR, the terminal now shows a spinning-gear banner — the same spot as the review-in-flight notice — naming the checks in flight, with the PR number linking to the PR on GitHub. Status and automation info always lands in one consistent place, so you know to hold off while CI is still working."
+  "feat_ci_running_banner_body": "While CI runs on a session's PR, the terminal now shows a spinning-gear banner — the same spot as the review-in-flight notice — naming the checks in flight, with the PR number linking to the PR on GitHub. Status and automation info always lands in one consistent place, so you know to hold off while CI is still working.",
+  "files_source_switch_aria": "File source",
+  "files_source_scratchpad": "Scratchpad",
+  "files_source_worktree": "Worktree",
+  "files_worktree_root_crumb": "worktree",
+  "files_worktree_breadcrumb_aria": "Worktree path",
+  "files_worktree_empty": "No files in the worktree.",
+  "files_worktree_load_error": "Couldn't load worktree files.",
+  "files_worktree_list_aria": "Worktree files",
+  "files_link_outside_title": "Symlink points outside the worktree"
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -614,6 +614,20 @@ export function scratchpadDownloadUrl(id: string, path: string): string {
   return `/api/sessions/${id}/scratchpad/download?path=${encodeURIComponent(path)}`;
 }
 
+/** List one directory of a session's read-only worktree subtree. `path` is relative to the
+ *  worktree root ("" / undefined = root). `.git` is hidden server-side. */
+export async function getWorktreeListing(id: string, path?: string): Promise<ScratchListing> {
+  const q = path ? `?path=${encodeURIComponent(path)}` : "";
+  const r = await fetch(`/api/sessions/${id}/worktree${q}`);
+  if (!r.ok) throw await failed(r, "worktree");
+  return r.json();
+}
+
+/** Same-origin download URL for one worktree file. Used as a plain `<a href download>` target. */
+export function worktreeDownloadUrl(id: string, path: string): string {
+  return `/api/sessions/${id}/worktree/download?path=${encodeURIComponent(path)}`;
+}
+
 /** Upload one arbitrary file into a session's scratchpad dir (#1258). Returns the root-relative path.
  *  Throws an ApiError so callers can branch on status (e.g. 413 = too large, max 10 MB). */
 export async function uploadScratchpadFile(

--- a/ui/src/lib/components/viewport/FilesPanel.browser.test.ts
+++ b/ui/src/lib/components/viewport/FilesPanel.browser.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
 import "../../../app.css";
 import { ApiError } from "$lib/api";
 import { m } from "$lib/paraglide/messages";
@@ -12,14 +13,17 @@ vi.mock("$lib/api", async (importOriginal) => {
     getScratchpadListing: vi.fn(),
     scratchpadDownloadUrl: vi.fn((id: string, path: string) => `/dl/${id}/${path}`),
     uploadScratchpadFile: vi.fn(),
+    getWorktreeListing: vi.fn(),
+    worktreeDownloadUrl: vi.fn((id: string, path: string) => `/wt/${id}/${path}`),
   };
 });
 
 const { default: FilesPanel } = await import("./FilesPanel.svelte");
 
-const { getScratchpadListing, uploadScratchpadFile } = await import("$lib/api");
+const { getScratchpadListing, uploadScratchpadFile, getWorktreeListing } = await import("$lib/api");
 const mockListing = vi.mocked(getScratchpadListing);
 const mockUpload = vi.mocked(uploadScratchpadFile);
+const mockWorktreeListing = vi.mocked(getWorktreeListing);
 
 const EMPTY_LISTING = { path: "", parent: null, entries: [] };
 
@@ -27,9 +31,11 @@ let fontStyle: HTMLStyleElement;
 beforeEach(() => {
   mockListing.mockReset();
   mockUpload.mockReset();
+  mockWorktreeListing.mockReset();
 
   // Default: empty listing so the panel renders without hanging on the initial browse
   mockListing.mockResolvedValue(EMPTY_LISTING);
+  mockWorktreeListing.mockResolvedValue(EMPTY_LISTING);
 
   fontStyle = document.createElement("style");
   fontStyle.textContent = `:root {
@@ -161,5 +167,75 @@ describe("FilesPanel — drag-and-drop calls uploadScratchpadFile", () => {
 
     tab.dispatchEvent(new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: dt }));
     await expect.poll(() => document.querySelector(".drop-overlay")).toBeFalsy();
+  });
+});
+
+// Helper: click the Worktree segmented-control button (trusted click via the browser locator)
+async function clickWorktreeSegButton() {
+  await page.getByRole("button", { name: m.files_source_worktree() }).click();
+}
+
+describe("FilesPanel — source switch (scratchpad/worktree)", () => {
+  it("defaults to scratchpad and fetches scratchpad listing", async () => {
+    render(FilesPanel, { sessionId: "sess-6" });
+    await waitForPanel();
+
+    await expect.poll(() => mockListing.mock.calls.length).toBeGreaterThan(0);
+    expect(mockWorktreeListing).not.toHaveBeenCalled();
+  });
+
+  it("switching to Worktree fetches the worktree listing and uses worktree download URLs", async () => {
+    mockListing.mockResolvedValue(EMPTY_LISTING);
+    mockWorktreeListing.mockResolvedValue({
+      path: "",
+      parent: null,
+      entries: [{ name: "readme.md", type: "file", path: "readme.md" }],
+    });
+
+    render(FilesPanel, { sessionId: "sess-7" });
+    await waitForPanel();
+
+    await clickWorktreeSegButton();
+
+    await expect.poll(() => mockWorktreeListing.mock.calls.length).toBeGreaterThan(0);
+    expect(mockWorktreeListing).toHaveBeenCalledWith("sess-7", undefined);
+
+    await expect.poll(() => document.querySelector("a.row.file")).toBeTruthy();
+    const fileRow = document.querySelector<HTMLAnchorElement>("a.row.file")!;
+    expect(fileRow.getAttribute("href")).toBe("/wt/sess-7/readme.md");
+  });
+
+  it("hides the upload button in worktree mode", async () => {
+    render(FilesPanel, { sessionId: "sess-8" });
+    await waitForPanel();
+
+    expect(document.querySelector("button.upload-btn")).toBeTruthy();
+
+    await clickWorktreeSegButton();
+
+    await expect.poll(() => document.querySelector("button.upload-btn")).toBeFalsy();
+  });
+
+  it("renders a linkOutside entry as a disabled, non-interactive row", async () => {
+    mockWorktreeListing.mockResolvedValue({
+      path: "",
+      parent: null,
+      entries: [{ name: "escaped-link", type: "file", path: "escaped-link", linkOutside: true }],
+    });
+
+    render(FilesPanel, { sessionId: "sess-9" });
+    await waitForPanel();
+
+    await clickWorktreeSegButton();
+
+    await expect.poll(() => document.querySelector(".row.link-outside")).toBeTruthy();
+    const row = document.querySelector(".row.link-outside")!;
+    expect(row.tagName).toBe("DIV");
+    expect(row.getAttribute("aria-disabled")).toBe("true");
+    expect(row.textContent).toContain("escaped-link");
+    // Not rendered as a navigable/actionable element
+    expect(row.querySelector("a")).toBeNull();
+    expect(row.closest("a")).toBeNull();
+    expect(row.tagName).not.toBe("BUTTON");
   });
 });

--- a/ui/src/lib/components/viewport/FilesPanel.svelte
+++ b/ui/src/lib/components/viewport/FilesPanel.svelte
@@ -53,6 +53,7 @@
     if (s === source) return;
     source = s;
     uploads = []; // upload statuses belong to the scratchpad session
+    listing = null; // avoid a stale-source listing flashing under the new source's labels/hrefs
     void browse(""); // reset to root and reload from the new source
   }
 

--- a/ui/src/lib/components/viewport/FilesPanel.svelte
+++ b/ui/src/lib/components/viewport/FilesPanel.svelte
@@ -3,15 +3,21 @@
     getScratchpadListing,
     scratchpadDownloadUrl,
     uploadScratchpadFile,
+    getWorktreeListing,
+    worktreeDownloadUrl,
     ApiError,
   } from "$lib/api";
   import type { ScratchListing } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
+  import { untrack } from "svelte";
 
   // Read/upload browser of the session's scratchpad subtree (#1164, #1258). Click a directory to
   // descend, click a file to download it. Upload via button or drag-and-drop into the current dir.
   let { sessionId }: { sessionId: string } = $props();
+
+  let source = $state<"scratchpad" | "worktree">("scratchpad");
+  const readOnly = $derived(source === "worktree");
 
   let listing = $state<ScratchListing | null>(null);
   let loading = $state(false);
@@ -32,7 +38,10 @@
     loading = true;
     error = false;
     try {
-      listing = await getScratchpadListing(sessionId, path || undefined);
+      listing =
+        source === "worktree"
+          ? await getWorktreeListing(sessionId, path || undefined)
+          : await getScratchpadListing(sessionId, path || undefined);
     } catch {
       error = true;
     } finally {
@@ -40,22 +49,45 @@
     }
   }
 
+  function switchSource(s: "scratchpad" | "worktree") {
+    if (s === source) return;
+    source = s;
+    uploads = []; // upload statuses belong to the scratchpad session
+    void browse(""); // reset to root and reload from the new source
+  }
+
+  const downloadUrl = (p: string) =>
+    source === "worktree" ? worktreeDownloadUrl(sessionId, p) : scratchpadDownloadUrl(sessionId, p);
+
   // (Re)load the root whenever the viewed session changes. Keyed on the id value so it only
-  // re-runs on an actual unit switch, not on session-object churn.
+  // re-runs on an actual unit switch, not on session-object churn. The reset/reload itself is
+  // wrapped in `untrack` so reading `source` inside `browse()` doesn't make this effect
+  // (wrongly) re-fire whenever the user flips the source switch — it must only key off sessionId.
   $effect(() => {
     const id = sessionId;
-    listing = null;
-    error = false;
-    uploads = [];
-    void browse("");
+    untrack(() => {
+      source = "scratchpad";
+      listing = null;
+      error = false;
+      uploads = [];
+      void browse("");
+    });
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- reactive dep
     id;
   });
 
-  // Breadcrumb segments from the current relative path; the first crumb is the scratchpad root.
+  const rootCrumbLabel = $derived(readOnly ? m.files_worktree_root_crumb() : m.files_root_crumb());
+  const breadcrumbAria = $derived(
+    readOnly ? m.files_worktree_breadcrumb_aria() : m.files_breadcrumb_aria(),
+  );
+  const listAria = $derived(readOnly ? m.files_worktree_list_aria() : m.files_list_aria());
+  const emptyText = $derived(readOnly ? m.files_worktree_empty() : m.files_empty());
+  const loadErrorText = $derived(readOnly ? m.files_worktree_load_error() : m.files_load_error());
+
+  // Breadcrumb segments from the current relative path; the first crumb is the source root.
   const crumbs = $derived.by(() => {
     const segs = listing?.path ? listing.path.split("/") : [];
-    const out: { label: string; path: string }[] = [{ label: m.files_root_crumb(), path: "" }];
+    const out: { label: string; path: string }[] = [{ label: rootCrumbLabel, path: "" }];
     let acc = "";
     for (const s of segs) {
       acc = acc ? `${acc}/${s}` : s;
@@ -105,17 +137,20 @@
   }
 
   function handleDragOver(e: DragEvent) {
+    if (readOnly) return;
     e.preventDefault();
     dragOver = true;
   }
 
   function handleDragLeave(e: DragEvent) {
+    if (readOnly) return;
     // Ignore leave events triggered by crossing into a child element — only clear on a real exit.
     if (e.relatedTarget && (e.currentTarget as Node).contains(e.relatedTarget as Node)) return;
     dragOver = false;
   }
 
   function handleDrop(e: DragEvent) {
+    if (readOnly) return;
     e.preventDefault();
     dragOver = false;
     if (!listing) return; // still loading
@@ -131,11 +166,27 @@
 <div
   class="files"
   role="region"
-  aria-label={m.files_list_aria()}
+  aria-label={listAria}
   ondragover={handleDragOver}
   ondragleave={handleDragLeave}
   ondrop={handleDrop}
 >
+  <div class="seg-row" role="group" aria-label={m.files_source_switch_aria()}>
+    <button
+      type="button"
+      class="seg-btn"
+      class:seg-active={source === "scratchpad"}
+      aria-pressed={source === "scratchpad"}
+      onclick={() => switchSource("scratchpad")}>{m.files_source_scratchpad()}</button
+    >
+    <button
+      type="button"
+      class="seg-btn"
+      class:seg-active={source === "worktree"}
+      aria-pressed={source === "worktree"}
+      onclick={() => switchSource("worktree")}>{m.files_source_worktree()}</button
+    >
+  </div>
   {#if dragOver}
     <!-- Whole-tab drop overlay; sits over (not inside) the scroll wrapper so it always covers the
          visible area, and pointer-events:none keeps drag/drop events reaching .files -->
@@ -146,7 +197,7 @@
   <!-- Scroll wrapper; .files itself stays non-scrolling so the overlay anchors to the viewport -->
   <div class="files-scroll">
     <div class="toolbar">
-      <nav class="crumbs" aria-label={m.files_breadcrumb_aria()}>
+      <nav class="crumbs" aria-label={breadcrumbAria}>
         {#each crumbs as c, i (c.path)}
           {#if i > 0}<span class="crumb-sep" aria-hidden="true">/</span>{/if}
           {#if i === crumbs.length - 1}
@@ -156,24 +207,26 @@
           {/if}
         {/each}
       </nav>
-      <button
-        type="button"
-        class="gbtn upload-btn"
-        aria-label={m.files_upload_aria()}
-        disabled={listing === null}
-        onclick={openFilePicker}
-        use:coachTarget={"scratchpad-upload"}>{m.files_upload_button()}</button
-      >
-      <!-- Hidden real input; triggered by the upload button -->
-      <input
-        bind:this={fileInput}
-        type="file"
-        multiple
-        class="sr-only"
-        aria-hidden="true"
-        tabindex="-1"
-        onchange={handleFileInput}
-      />
+      {#if !readOnly}
+        <button
+          type="button"
+          class="gbtn upload-btn"
+          aria-label={m.files_upload_aria()}
+          disabled={listing === null}
+          onclick={openFilePicker}
+          use:coachTarget={"scratchpad-upload"}>{m.files_upload_button()}</button
+        >
+        <!-- Hidden real input; triggered by the upload button -->
+        <input
+          bind:this={fileInput}
+          type="file"
+          multiple
+          class="sr-only"
+          aria-hidden="true"
+          tabindex="-1"
+          onchange={handleFileInput}
+        />
+      {/if}
     </div>
 
     <!-- Upload status lines -->
@@ -194,15 +247,22 @@
       {#if loading && !listing}
         <div class="placeholder">{m.common_loading()}</div>
       {:else if error}
-        <div class="placeholder err">{m.files_load_error()}</div>
+        <div class="placeholder err">{loadErrorText}</div>
       {:else if listing && listing.entries.length === 0}
         <div class="placeholder empty-droppable">
-          <span>{m.files_empty()}</span>
-          <span class="drop-hint">{m.files_upload_drop_hint()}</span>
+          <span>{emptyText}</span>
+          {#if !readOnly}
+            <span class="drop-hint">{m.files_upload_drop_hint()}</span>
+          {/if}
         </div>
       {:else if listing}
         {#each listing.entries as e (e.path)}
-          {#if e.type === "dir"}
+          {#if e.linkOutside}
+            <div class="row link-outside" aria-disabled="true" title={m.files_link_outside_title()}>
+              <span class="ico" aria-hidden="true">↗</span>
+              <span class="nm">{e.name}</span>
+            </div>
+          {:else if e.type === "dir"}
             <button type="button" class="row" onclick={() => browse(e.path)}>
               <span class="ico" aria-hidden="true">▸</span>
               <span class="nm">{e.name}</span>
@@ -212,7 +272,7 @@
             <!-- eslint-disable svelte/no-navigation-without-resolve -- server API download endpoint, not an app route -->
             <a
               class="row file"
-              href={scratchpadDownloadUrl(sessionId, e.path)}
+              href={downloadUrl(e.path)}
               download={e.name}
               aria-label={m.files_download_aria({ name: e.name })}
             >
@@ -244,6 +304,43 @@
     overflow-y: auto;
     flex: 1;
     min-height: 0;
+  }
+  .seg-row {
+    display: flex;
+    border-bottom: 1px solid var(--color-line);
+    flex-shrink: 0;
+  }
+  .seg-btn {
+    flex: 1;
+    min-width: 0;
+    min-height: 44px;
+    border: 0;
+    border-right: 1px solid var(--color-line);
+    background: none;
+    font-family: inherit;
+    font-size: var(--fs-base);
+    cursor: pointer;
+    padding: 0 2px;
+    color: var(--color-muted);
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .seg-btn:last-child {
+    border-right: 0;
+  }
+  .seg-btn:hover {
+    color: var(--color-ink);
+  }
+  .seg-btn.seg-active {
+    color: var(--color-amber);
+    background: var(--color-inset);
+    box-shadow: inset 0 -2px 0 var(--color-amber);
+  }
+  .seg-btn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
   }
   .drop-overlay {
     position: absolute;
@@ -401,6 +498,16 @@
   }
   .row.file .ico {
     color: var(--color-faint);
+  }
+  .row.link-outside {
+    color: var(--color-faint);
+    cursor: default;
+  }
+  .row.link-outside .ico {
+    color: var(--color-faint);
+  }
+  .row.link-outside:hover {
+    background: transparent;
   }
   .nm {
     flex: 1;

--- a/ui/src/lib/demo/router.test.ts
+++ b/ui/src/lib/demo/router.test.ts
@@ -223,6 +223,16 @@ describe("session-detail tab GETs never fall back to {}", () => {
     expect(Array.isArray(empty.body.entries)).toBe(true);
   });
 
+  it("GET /api/sessions/:id/worktree returns a ScratchListing with an `entries` array, never {}", async () => {
+    const { status, body } = await get("/api/sessions/coupon/worktree");
+    expect(status).toBe(200);
+    expect(Array.isArray(body.entries)).toBe(true);
+    const withPath = await get("/api/sessions/coupon/worktree?path=src");
+    expect(withPath.status).toBe(200);
+    expect(Array.isArray(withPath.body.entries)).toBe(true);
+    expect(withPath.body.path).toBe("src");
+  });
+
   it("GET /api/sessions/:id/usage returns a SessionUsage record, never {}", async () => {
     const { body } = await get("/api/sessions/coupon/usage");
     expect(typeof body.total).toBe("number");

--- a/ui/src/lib/demo/router.ts
+++ b/ui/src/lib/demo/router.ts
@@ -136,6 +136,12 @@ function handleSessionDetailGet(path: string, url: URL): Response | null {
     const root = demoState.scratchpadRoot(seg(path, 3));
     return json(reqPath ? { path: reqPath, parent: "", entries: [] } : root);
   }
+  if (/^\/api\/sessions\/[^/]+\/worktree$/.test(path)) {
+    // Demo has no seeded worktree tree; return a valid (empty) listing so the Files-tab
+    // Worktree view renders its empty state instead of crashing on a shapeless {} body.
+    const reqPath = url.searchParams.get("path") ?? "";
+    return json({ path: reqPath, parent: reqPath ? "" : null, entries: [] });
+  }
   if (/^\/api\/sessions\/[^/]+\/usage$/.test(path)) {
     return json(demoState.sessionUsage(seg(path, 3)));
   }

--- a/ui/src/lib/feature-announcements/entries/v1.42.0-worktree-files.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.42.0-worktree-files.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "worktree-files",
+  sinceVersion: "1.42.0",
+  titleKey: "feat_worktree_files_title",
+  bodyKey: "feat_worktree_files_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -153,6 +153,9 @@ export interface ScratchEntry {
   name: string;
   type: "file" | "dir";
   path: string;
+  /** true when this entry is a symlink resolving outside the root (worktree view only);
+   *  rendered as a disabled, non-navigable row. */
+  linkOutside?: boolean;
 }
 
 /** A directory listing within a session's scratchpad subtree (#1164). Paths are relative to the


### PR DESCRIPTION
## What

Adds a **Scratchpad | Worktree** segmented switch inside the Files tab so an operator can browse either the session's scratchpad (unchanged default) **or** its git worktree, without leaving the tab.

- **Scratchpad** (default): today's behavior — browse, download, upload.
- **Worktree** (new): **read-only** browse + download of the session's working tree. `.git` is hidden; symlinks that resolve outside the worktree are shown as disabled, non-navigable rows so the tree isn't misleadingly incomplete.

## How

**Server**
- Extracted the scratchpad's realpath-containment browsing into a shared core `src/fs-browse.ts` (`resolveInRoot` / `listDir` / `resolveFileInRoot`, with `hideSegment` + `onEscape` options). `src/scratchpad.ts` now delegates to it — public API and behavior unchanged.
- New `src/worktree-files.ts` (thin wrappers: hide `.git` by name, mark out-of-root symlinks) and two read-only routes in `src/server.ts`, mirroring the scratchpad routes:
  - `GET /api/sessions/:id/worktree[?path=]` (list)
  - `GET /api/sessions/:id/worktree/download?path=` (file bytes)
- Containment is enforced by realpath: `..`, absolute paths, and symlink escapes are all rejected; `.git` is rejected on **both** listing and download. A `worktreePath`-empty guard prevents any cwd fallback.

**UI**
- `FilesPanel.svelte` gains the `.seg-row` switch (canonical design-system recipe, 44px targets), source-aware labels, and a read-only mode (no upload button, no drop zone) when Worktree is active. `linkOutside` entries render disabled.
- `getWorktreeListing` / `worktreeDownloadUrl` in `api.ts`; `linkOutside?: boolean` added to the `ScratchEntry` type; demo mock router gets a `/worktree` route so the public demo doesn't crash on switch.

## Resolved decisions

- Worktree is **read-only** (no upload into a git working tree).
- Filter **hides `.git` only** (file, dir, or submodule); dotfiles and `node_modules` are shown (lazy, per-directory).
- Default source is **Scratchpad** — existing behavior is untouched.
- Download is **unfiltered** for non-`.git` files (incl. `.env`/secrets): Shepherd is a localhost single-operator tool where the operator already has shell read access to the worktree, and the scratchpad download already streams arbitrary bytes — so this is not a new disclosure boundary.

## Accepted-risk note

`.git` is hidden by path-segment name. A hypothetical symlink *inside* the worktree named e.g. `foo` pointing at `.git/config` would resolve within-root and be downloadable — but that is functionally the operator reading their own `.git` under a different name (they have shell access), and is within the same accepted risk as the unfiltered-download decision above. Not hardened by design.

## Feature discovery / i18n

- Adds `ui/src/lib/feature-announcements/entries/v1.42.0-worktree-files.ts` (What's-New entry).
- All new UI strings added to `en.json` + `de.json` (parity enforced by `check:i18n`).

## Testing

- New: `test/fs-browse.test.ts`, `test/worktree-files.test.ts`, `test/worktree-endpoint.test.ts` (containment, `.git`-as-file + submodule hiding, out-of-root symlink marking, escape rejection, endpoint wiring). Extended `FilesPanel.browser.test.ts` (switch fetches worktree, upload hidden, disabled link row) and `demo/router.test.ts`.
- Green: root `bun run lint` + `bun run test` (5777 pass / 0 fail); UI `bun run check` (0 errors) + `check:i18n` (parity) + `bun run test` (2753 pass); `fallow@2.100.0 audit` exit 0; pre-push all lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
