### PR TITLE
fix(ui): reorder new-task toggles, lock plan-gate/autopilot while Research on

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1291,7 +1291,7 @@
   "feat_session_recap_title": "Sitzungszusammenfassung",
   "feat_session_recap_body": "Shepherd erstellt nach jeder Sitzung eine kompakte Zusammenfassung — mit Ergebnis, Überschrift und offenen Punkten — damit du auf einen Blick siehst, was passiert ist.",
   "newtask_research_label": "Recherche-Aufgabe",
-  "newtask_research_hint": "Webrecherche → ein Bericht-PR oder ein GitHub-Issue. Keine Code-Änderungen.",
+  "newtask_research_hint": "Webrecherche → ein Bericht-PR oder ein GitHub-Issue. Keine Code-Änderungen. Plan-Gate und Autopilot gelten hier nicht und sind deaktiviert.",
   "newtask_research_sandbox_note": "Recherche-Aufgaben können das autonome Profil nicht verwenden — Websuche benötigt offenen Netzwerkzugang.",
   "research_badge_label": "Recherche",
   "research_badge_title": "Rechercheaufgabe: Web-Recherche → ein Bericht-PR oder ein GitHub-Issue",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1292,6 +1292,7 @@
   "feat_session_recap_body": "Shepherd erstellt nach jeder Sitzung eine kompakte Zusammenfassung — mit Ergebnis, Überschrift und offenen Punkten — damit du auf einen Blick siehst, was passiert ist.",
   "newtask_research_label": "Recherche-Aufgabe",
   "newtask_research_hint": "Webrecherche → ein Bericht-PR oder ein GitHub-Issue. Keine Code-Änderungen. Plan-Gate und Autopilot gelten hier nicht und sind deaktiviert.",
+  "newtask_research_locked_aria": "Für Recherche-Aufgaben nicht verfügbar.",
   "newtask_research_sandbox_note": "Recherche-Aufgaben können das autonome Profil nicht verwenden — Websuche benötigt offenen Netzwerkzugang.",
   "research_badge_label": "Recherche",
   "research_badge_title": "Rechercheaufgabe: Web-Recherche → ein Bericht-PR oder ein GitHub-Issue",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1291,7 +1291,7 @@
   "feat_session_recap_title": "Session recap",
   "feat_session_recap_body": "Shepherd now generates a concise recap after each session — verdict, headline, and open items — so you can see what happened at a glance.",
   "newtask_research_label": "Research task",
-  "newtask_research_hint": "Web research → a report PR or a GitHub issue. No code changes.",
+  "newtask_research_hint": "Web research → a report PR or a GitHub issue. No code changes. Plan gate and autopilot don't apply and are disabled.",
   "newtask_research_sandbox_note": "Research can't use the autonomous profile — web search needs open network access.",
   "research_badge_label": "Research",
   "research_badge_title": "Research task: web research → a report PR or a GitHub issue",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1292,6 +1292,7 @@
   "feat_session_recap_body": "Shepherd now generates a concise recap after each session — verdict, headline, and open items — so you can see what happened at a glance.",
   "newtask_research_label": "Research task",
   "newtask_research_hint": "Web research → a report PR or a GitHub issue. No code changes. Plan gate and autopilot don't apply and are disabled.",
+  "newtask_research_locked_aria": "Not available for research tasks.",
   "newtask_research_sandbox_note": "Research can't use the autonomous profile — web search needs open network access.",
   "research_badge_label": "Research",
   "research_badge_title": "Research task: web research → a report PR or a GitHub issue",

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -249,7 +249,12 @@ describe("NewTask plan-gate inheritance", () => {
     return { promise, resolve, reject };
   }
 
-  const planGateBox = () => document.querySelector<HTMLInputElement>(".plan-gate input")!;
+  // Research renders first in the stack, so match the plan-gate row by label
+  // instead of grabbing the first `.plan-gate input`.
+  const planGateBox = () =>
+    Array.from(document.querySelectorAll<HTMLInputElement>(".plan-gate input")).find((el) =>
+      el.closest("label")?.textContent?.includes(m.newtask_plan_gate_label()),
+    )!;
   const submitBtn = () => document.querySelector<HTMLButtonElement>("button.run")!;
 
   async function fillAndSubmit() {
@@ -548,18 +553,21 @@ describe("NewTask research toggle", () => {
     expect(onsubmit.mock.calls[0]![0]).toMatchObject({ autopilotEnabled: false, research: true });
   });
 
-  it("toggling plan-gate on unchecks Research", async () => {
+  it("disables plan-gate and Autopilot while Research is on, re-enables on uncheck", async () => {
     render(NewTask, { props: base() });
     await expect.poll(() => researchBox()).toBeTruthy();
 
-    // tick Research on first
+    // tick Research on → both rows lock (visible exclusivity, not silent re-checkable)
     researchBox().click();
     await expect.poll(() => researchBox().checked).toBe(true);
+    await expect.poll(() => planGateBox().disabled).toBe(true);
+    await expect.poll(() => autopilotBox().disabled).toBe(true);
 
-    // then tick plan-gate → Research should clear
-    planGateBox().click();
-    await expect.poll(() => planGateBox().checked).toBe(true);
+    // untick Research → both rows unlock
+    researchBox().click();
     await expect.poll(() => researchBox().checked).toBe(false);
+    await expect.poll(() => planGateBox().disabled).toBe(false);
+    await expect.poll(() => autopilotBox().disabled).toBe(false);
   });
 
   it("disables the autonomous sandbox option when Research is on", async () => {

--- a/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
+++ b/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
@@ -100,7 +100,12 @@
 
   <!-- Plan gate + Autopilot don't apply to research tasks: while Research is checked
        they render disabled/muted (research-locked) instead of silently re-checkable.
-       The Research InfoTip carries the reason. -->
+       The Research InfoTip carries the visible reason; this hidden note carries it to
+       assistive tech via aria-describedby on both locked inputs. -->
+  {#if research}
+    <span class="sr-only" id="nt-research-locked-note">{m.newtask_research_locked_aria()}</span>
+  {/if}
+
   <div class="pg-row">
     <label class="plan-gate" class:research-locked={research} use:coachTarget={"plan-gate"}>
       <input
@@ -111,6 +116,7 @@
           onPlanGateTouched();
         }}
         disabled={planGateLoading || research}
+        aria-describedby={research ? "nt-research-locked-note" : undefined}
       />
       <span class="pg-label">{m.newtask_plan_gate_label()}</span>
     </label>
@@ -138,6 +144,7 @@
             onAutopilotTouched();
           }}
           disabled={autopilotLoading || research}
+          aria-describedby={research ? "nt-research-locked-note" : undefined}
         />
         <span class="pg-label">{m.newtask_autopilot_label()}</span>
       </label>
@@ -365,5 +372,17 @@
   .pg-hint {
     color: var(--color-muted);
     font-size: var(--fs-meta);
+  }
+  /* Screen-reader-only note (same recipe as TaskIdButton). */
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 </style>

--- a/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
+++ b/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
@@ -65,73 +65,14 @@
   });
 </script>
 
-<!-- Per-task run settings. Plan gate gets its own full-width row so its explainer
-     reads on one line; Model + Sandbox share a 50/50 row beneath. -->
+<!-- Per-task run settings. Each toggle gets its own full-width row so its explainer
+     reads on one line; Model + Sandbox share a 50/50 row beneath. Research leads the
+     stack: it's the mode switch that disables the two options under it. -->
 <div class="opts-row">
   <!-- Each toggle's long explainer now lives behind an InfoTip "i" rather than a
        wrapped hint paragraph — keeps this stack of options compact, which matters
        most on the phone sheet. The InfoTip is a sibling of the <label> (not nested
        inside it) so a tap on the "i" never toggles the checkbox. -->
-  <div class="pg-row">
-    <label class="plan-gate" use:coachTarget={"plan-gate"}>
-      <input
-        type="checkbox"
-        checked={planGate}
-        onchange={(e) => {
-          planGate = e.currentTarget.checked;
-          onPlanGateTouched();
-          if (planGate) research = false;
-        }}
-        disabled={planGateLoading}
-      />
-      <span class="pg-label">{m.newtask_plan_gate_label()}</span>
-    </label>
-    {#if planGateLoading}
-      <span class="pg-loading">{m.common_loading()}</span>
-    {/if}
-    <InfoTip
-      text={m.newtask_plan_gate_hint()}
-      label={m.newtask_info_aria({ topic: m.newtask_plan_gate_label() })}
-    />
-  </div>
-
-  <!-- Relaunch intentionally CARRIES the original session's autopilot value
-       (server-side, src/service.ts relaunch()), so RelaunchOverrides has no
-       autopilotEnabled field and the override wouldn't take effect here.
-       Hide the control in relaunch so it never implies an override it can't honor. -->
-  {#if !relaunch}
-    <div class="pg-row">
-      <label class="plan-gate" use:coachTarget={"task-autopilot"}>
-        <input
-          type="checkbox"
-          checked={autopilot}
-          onchange={(e) => {
-            autopilot = e.currentTarget.checked;
-            onAutopilotTouched();
-          }}
-          disabled={autopilotLoading}
-        />
-        <span class="pg-label">{m.newtask_autopilot_label()}</span>
-      </label>
-      <!-- The repo's standing default, shown alongside so it's clear how this repo
-           normally handles it — the checkbox is seeded from it on open, so unchecking
-           here is a visible, deliberate opt-out for this one task. -->
-      {#if autopilotLoading}
-        <span class="pg-loading">{m.common_loading()}</span>
-      {:else if repoPath}
-        <span class="repo-default" class:on={autopilotDefault}>
-          {autopilotDefault
-            ? m.newtask_autopilot_repo_default_on()
-            : m.newtask_autopilot_repo_default_off()}
-        </span>
-      {/if}
-      <InfoTip
-        text={m.newtask_autopilot_hint()}
-        label={m.newtask_info_aria({ topic: m.newtask_autopilot_label() })}
-      />
-    </div>
-  {/if}
-
   <div class="pg-row">
     <label class="plan-gate">
       <input
@@ -156,6 +97,68 @@
       label={m.newtask_info_aria({ topic: m.newtask_research_label() })}
     />
   </div>
+
+  <!-- Plan gate + Autopilot don't apply to research tasks: while Research is checked
+       they render disabled/muted (research-locked) instead of silently re-checkable.
+       The Research InfoTip carries the reason. -->
+  <div class="pg-row">
+    <label class="plan-gate" class:research-locked={research} use:coachTarget={"plan-gate"}>
+      <input
+        type="checkbox"
+        checked={planGate}
+        onchange={(e) => {
+          planGate = e.currentTarget.checked;
+          onPlanGateTouched();
+        }}
+        disabled={planGateLoading || research}
+      />
+      <span class="pg-label">{m.newtask_plan_gate_label()}</span>
+    </label>
+    {#if planGateLoading}
+      <span class="pg-loading">{m.common_loading()}</span>
+    {/if}
+    <InfoTip
+      text={m.newtask_plan_gate_hint()}
+      label={m.newtask_info_aria({ topic: m.newtask_plan_gate_label() })}
+    />
+  </div>
+
+  <!-- Relaunch intentionally CARRIES the original session's autopilot value
+       (server-side, src/service.ts relaunch()), so RelaunchOverrides has no
+       autopilotEnabled field and the override wouldn't take effect here.
+       Hide the control in relaunch so it never implies an override it can't honor. -->
+  {#if !relaunch}
+    <div class="pg-row">
+      <label class="plan-gate" class:research-locked={research} use:coachTarget={"task-autopilot"}>
+        <input
+          type="checkbox"
+          checked={autopilot}
+          onchange={(e) => {
+            autopilot = e.currentTarget.checked;
+            onAutopilotTouched();
+          }}
+          disabled={autopilotLoading || research}
+        />
+        <span class="pg-label">{m.newtask_autopilot_label()}</span>
+      </label>
+      <!-- The repo's standing default, shown alongside so it's clear how this repo
+           normally handles it — the checkbox is seeded from it on open, so unchecking
+           here is a visible, deliberate opt-out for this one task. -->
+      {#if autopilotLoading}
+        <span class="pg-loading">{m.common_loading()}</span>
+      {:else if repoPath}
+        <span class="repo-default" class:on={autopilotDefault}>
+          {autopilotDefault
+            ? m.newtask_autopilot_repo_default_on()
+            : m.newtask_autopilot_repo_default_off()}
+        </span>
+      {/if}
+      <InfoTip
+        text={m.newtask_autopilot_hint()}
+        label={m.newtask_info_aria({ topic: m.newtask_autopilot_label() })}
+      />
+    </div>
+  {/if}
 
   <div class="run-config">
     <div class="model-field">
@@ -348,6 +351,12 @@
   .plan-gate:has(input:disabled) {
     cursor: progress;
     opacity: 0.6;
+  }
+  /* Disabled because Research is on (permanent lock, not transient loading): scoped
+     with :has(input:disabled) so it outranks the progress rule above; when a row is
+     both loading and research-locked, the lock wins. */
+  .plan-gate.research-locked:has(input:disabled) {
+    cursor: not-allowed;
   }
   .pg-label {
     color: var(--color-ink-bright);


### PR DESCRIPTION
## What

In the new-task pane's run settings:

- **Reordered** the toggles to **Research → Plan gate → Autopilot** (was Plan gate → Autopilot → Research). The mode switch now leads the stack it governs.
- **Visible exclusivity**: while Research is checked, Plan gate + Autopilot render **disabled** (0.6 muting, `not-allowed` cursor) instead of silently unchecking yet staying re-checkable. The *reason* is folded into the existing Research InfoTip — extended `newtask_research_hint` EN+DE, no new standing note (the phone sheet stays compact; it already carries the sandbox note).
- **Fixes an asymmetry bug**: checking Autopilot previously did **not** clear Research, so `research: true` + `autopilotEnabled: true` could be submitted — a combo the Research handler forbids. Disabling the row while Research is on removes the path structurally. The now-unreachable `research = false` in the Plan gate handler is deleted.
- Cursor semantics: `not-allowed` = permanent research lock, `progress` = transient loading; the lock rule is scoped `.plan-gate.research-locked:has(input:disabled)` so it deterministically outranks the loading rule.

## Verification

- `cd ui && bun run check` — 0 errors (1 pre-existing CommandBar warning, untouched)
- `bun run check:i18n` — 2 locales in parity
- `bun run test` — 205 files, 2761 tests pass (updated the plan-gate-clears-Research test to the new disabled contract; fixed a first-`.plan-gate`-input selector that grabbed Research after the reorder)
- **In-browser** (demo mode): row order confirmed; checking Research unchecks + disables both rows with computed `opacity: 0.6` and `cursor: not-allowed` (asserted via `getComputedStyle`); InfoTip shows the extended hint; unchecking re-enables both.

Screenshot (Research checked, InfoTip open, rows locked):

_locked state: Research ✔, Plan gate + Autopilot muted/disabled, InfoTip explains why_

[no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)