### PR TITLE
fix(compose): send mode=partial for live-preview transcriptions

### DIFF
--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -333,10 +333,17 @@ export function getVoiceStatus(): Promise<VoiceStatus> {
 
 /** Transcribe a recorded audio clip via the voice-whisper plugin; returns the text. `lang`
  *  (`"de"`/`"en"`) pins the transcription language when the plugin isn't configured to force one. */
-export async function transcribeAudio(blob: Blob, lang?: string): Promise<string> {
+export async function transcribeAudio(
+  blob: Blob,
+  lang?: string,
+  mode?: "partial" | "final",
+): Promise<string> {
   const fd = new FormData();
   fd.append("file", blob, "clip.webm");
   if (lang) fd.append("lang", lang);
+  // `partial` marks a disposable live-preview clip so the plugin keeps a slot reserved for the
+  // final and never 429-starves it under load; omitted ⇒ the plugin treats it as the final.
+  if (mode) fd.append("mode", mode);
   // no content-type header: the browser sets the multipart boundary
   const r = await fetch("/api/plugins/voice-whisper/transcribe", { method: "POST", body: fd });
   if (!r.ok) throw await failed(r, "transcribe");

--- a/ui/src/lib/components/ComposeBar.svelte
+++ b/ui/src/lib/components/ComposeBar.svelte
@@ -308,7 +308,7 @@
     interimBusy = true;
     const seq = ++interimSeq;
     try {
-      const text = await transcribeAudio(blob, getLocale() === "de" ? "de" : "en");
+      const text = await transcribeAudio(blob, getLocale() === "de" ? "de" : "en", "partial");
       if (seq === interimSeq && listening && text)
         value = dictationBase.trim() ? dictationBase.trimEnd() + " " + text.trim() : text.trim();
       queueMicrotask(autogrow);
@@ -416,7 +416,7 @@
     chunks = [];
     transcribing = true;
     try {
-      const text = await transcribeAudio(blob, getLocale() === "de" ? "de" : "en");
+      const text = await transcribeAudio(blob, getLocale() === "de" ? "de" : "en", "final");
       // The accurate full-clip result replaces whatever the live preview last showed. On error we
       // keep the last interim text rather than discarding what the user just dictated.
       value = dictationBase;


### PR DESCRIPTION
Companion to voice-whisper plugin [#4](https://github.com/erwins-enkel/shepherd-plugin-voice-whisper/pull/4).

The live read-along (shipped in #1379) fires a transcription every ~2.5s while dictating. This tags those requests `mode=partial` (and the final stop-transcription `mode=final`) so the plugin's concurrency gate can **reserve a slot for the final** — a burst of disposable preview requests can then never `429`-starve the transcription the user actually keeps.

- `transcribeAudio(blob, lang, mode?)` gains an optional `mode` form field.
- `ComposeBar`: interim posts send `partial`, the final sends `final`.

Verified: `bun run check` (svelte-check) 0 errors.