### PR TITLE
fix(server): allowlist GET /api/sessions/:id/queue on agent ingress

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -6195,8 +6195,9 @@ export function isAgentIngressRoute(method: string, parts: string[]): boolean {
   if (!(parts[0] === "api" && parts[1] === "sessions" && parts[2])) return false;
   // POST /api/sessions/<id>/hooks
   if (method === "POST" && parts[3] === "hooks" && !parts[4]) return true;
-  // PUT /api/sessions/<id>/queue
-  if (method === "PUT" && parts[3] === "queue" && !parts[4]) return true;
+  // PUT /api/sessions/<id>/queue (author/replace) + GET (the directive's "inspect the current
+  // queue" / re-GET-for-ids path — read-only, strictly weaker than the PUT already allowed).
+  if ((method === "PUT" || method === "GET") && parts[3] === "queue" && !parts[4]) return true;
   // POST /api/sessions/<id>/queue/steps/<stepId>
   if (method === "POST" && parts[3] === "queue" && parts[4] === "steps" && parts[5] && !parts[6]) {
     return true;

--- a/test/agent-ingress.test.ts
+++ b/test/agent-ingress.test.ts
@@ -19,9 +19,10 @@ const SID = "step_abc";
 const parts = (p: string) => p.split("/").filter(Boolean);
 
 // ── isAgentIngressRoute: exhaustive allow/deny table ────────────────────────────
-test("isAgentIngressRoute: ALLOWS exactly the three agent→server routes", () => {
+test("isAgentIngressRoute: ALLOWS exactly the four agent→server routes", () => {
   expect(isAgentIngressRoute("POST", parts(`/api/sessions/${ID}/hooks`))).toBe(true);
   expect(isAgentIngressRoute("PUT", parts(`/api/sessions/${ID}/queue`))).toBe(true);
+  expect(isAgentIngressRoute("GET", parts(`/api/sessions/${ID}/queue`))).toBe(true);
   expect(isAgentIngressRoute("POST", parts(`/api/sessions/${ID}/queue/steps/${SID}`))).toBe(true);
 });
 
@@ -36,9 +37,10 @@ test("isAgentIngressRoute: DENIES everything else (containment property)", () =>
   // Wrong methods on the allowed paths.
   expect(isAgentIngressRoute("GET", parts(`/api/sessions/${ID}/hooks`))).toBe(false);
   expect(isAgentIngressRoute("PUT", parts(`/api/sessions/${ID}/hooks`))).toBe(false);
-  expect(isAgentIngressRoute("GET", parts(`/api/sessions/${ID}/queue`))).toBe(false);
   expect(isAgentIngressRoute("POST", parts(`/api/sessions/${ID}/queue`))).toBe(false);
+  expect(isAgentIngressRoute("DELETE", parts(`/api/sessions/${ID}/queue`))).toBe(false);
   expect(isAgentIngressRoute("PUT", parts(`/api/sessions/${ID}/queue/steps/${SID}`))).toBe(false);
+  expect(isAgentIngressRoute("GET", parts(`/api/sessions/${ID}/queue/steps/${SID}`))).toBe(false);
   // queue/steps without a step id, or with a trailing extra segment.
   expect(isAgentIngressRoute("POST", parts(`/api/sessions/${ID}/queue/steps`))).toBe(false);
   expect(isAgentIngressRoute("POST", parts(`/api/sessions/${ID}/queue/steps/${SID}/x`))).toBe(
@@ -165,6 +167,36 @@ test("makeAgentIngressApp: an ALLOWED route DELEGATES to the full app (reaches t
   const q = await ok.json();
   expect(q.steps.length).toBe(1);
   expect(q.steps[0].title).toBe("do a thing");
+});
+
+test("makeAgentIngressApp: GET /api/sessions/:id/queue delegates — the agent can read back the queue it authored", async () => {
+  // The spawn directive tells the agent to "inspect the current queue at any time" and to re-GET
+  // the queue to recover step ids. A gate that 404s this GET makes agents conclude the whole
+  // build-queue endpoint is dead and abandon the queue.
+  const deps = makeDeps();
+  const s = await deps.service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "go",
+    model: null,
+    images: [],
+  });
+  const app = makeAgentIngressApp(deps);
+
+  const put = await app.fetch(
+    new Request(`http://x/api/sessions/${s.id}/queue`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ steps: [{ id: "s1", title: "do a thing" }] }),
+    }),
+  );
+  expect(put.status).toBe(200);
+
+  const get = await app.fetch(new Request(`http://x/api/sessions/${s.id}/queue`));
+  expect(get.status).toBe(200);
+  const q = await get.json();
+  expect(q.steps.length).toBe(1);
+  expect(q.steps[0].id).toBe("s1");
 });
 
 test("makeAgentIngressApp: the ingress transport is EXEMPT from the human auth gate (issue #1079)", async () => {


### PR DESCRIPTION
## Problem

Multiple sessions reported the build-queue endpoint as broken: `GET /api/sessions/:id/queue` returned `404 {"error":"not found"}`, so agents concluded the endpoint "isn't active for this session" and abandoned the build queue entirely (falling back to plan files, leaving the operator's queue view empty).

## Root cause

Agents reach Shepherd through the restricted **agent-ingress** listener, gated by `isAgentIngressRoute`. That allowlist (introduced in #738) permits only `POST /hooks`, `PUT /queue`, and `POST /queue/steps/:id` — but the build-queue spawn directive (`buildQueueDirective` in `src/service.ts`) explicitly instructs agents to **GET** the queue ("Inspect the current queue at any time", "re-GET … to pick up the current ids"). The read route was never added to the allowlist, so the gate 404s every GET with `{"error":"not found"}` — reproduced live against a running session before the fix.

The 404 is what turns a transient hiccup into a permanent failure: GET is the agent's advertised diagnostic/recovery path, and it lies. In the reported transcript the agent's initial PUT failed for an unrelated, agent-side reason (curl exit 3 = malformed URL — the multi-line command was mangled; the plain-text `Method Not Allowed` matches no Shepherd handler, which all return lowercase JSON), then the follow-up GET probe hit this gate 404 and "confirmed" the endpoint was dead.

## Fix

Allowlist `GET /api/sessions/:id/queue` on the ingress. Read-only and strictly weaker than the already-allowed PUT on the same path; the per-session UUID capability model is unchanged and `POST /queue/approve` (the human gate) stays excluded.

## Tests

- Allow-table now asserts GET `/queue` is permitted; deny-table keeps DELETE `/queue`, GET `/queue/steps/:id`, and all prior containment cases.
- New app-level regression test: an agent PUTs its queue, then GETs it back through `makeAgentIngressApp` (was 404, now 200 echoing the steps).
- `bun run lint` clean; full root suite 5808 pass / 0 fail.

Takes effect for newly-observed traffic on the next server restart/deploy (no config or data migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)