### PR TITLE
fix(readiness): prescribe stack-correct dependabot ecosystem in adopt prompt

### DIFF
--- a/src/readiness.ts
+++ b/src/readiness.ts
@@ -369,8 +369,11 @@ function generateClaudeMd(scan: RepoScan, checks: GuardrailCheck[]): string {
     ? missing
         .map((c) => {
           const head = `- ${TOOLING_LABEL[c.id]} — ${CHURN_PLAIN[c.id]}`;
-          const cmds = INSTALL_STEPS[c.id](verbs);
-          return cmds.length ? `${head}\n${cmds.map((cmd) => `    $ ${cmd}`).join("\n")}` : head;
+          const lines = [
+            ...(PRESCRIPTION_NOTE[c.id]?.(scan) ?? []),
+            ...INSTALL_STEPS[c.id](verbs).map((cmd) => `$ ${cmd}`),
+          ];
+          return lines.length ? `${head}\n${lines.map((l) => `    ${l}`).join("\n")}` : head;
         })
         .join("\n")
     : "- None — your deterministic guardrails already cover the baseline.";
@@ -456,6 +459,32 @@ export const PM_VERBS: Record<PackageManager, { add: string; exec: string }> = {
   pnpm: { add: "pnpm add -D", exec: "pnpm dlx" },
   yarn: { add: "yarn add -D", exec: "yarn dlx" },
   npm: { add: "npm i -D", exec: "npx" },
+};
+
+/**
+ * Extra prose guidance lines per guardrail, rendered under the adopt line (no `$ `
+ * prefix — guidance, not shell commands). Only for guardrails whose bootstrap is
+ * file-creation the agent would otherwise guess wrong: dependency_automation must
+ * name the Dependabot ecosystem, because agents default to `npm`, which never
+ * updates bun.lock on a bun repo (pnpm/yarn ARE served by the npm ecosystem —
+ * only bun has a dedicated one).
+ */
+const PRESCRIPTION_NOTE: Partial<Record<GuardrailId, (s: RepoScan) => string[]>> = {
+  dependency_automation: (s) => {
+    if (s.pm === "bun") {
+      const lines = [
+        `Create \`.github/dependabot.yml\` with \`package-ecosystem: "bun"\` — this repo uses bun; the npm ecosystem would not update bun.lock.`,
+      ];
+      if (!s.has("bun.lock"))
+        lines.push(
+          `Dependabot's bun ecosystem needs the text lockfile: run \`bun install --save-text-lockfile\` first (it reads bun.lock only; the binary bun.lockb is not supported).`,
+        );
+      return lines;
+    }
+    return [
+      `Create \`.github/dependabot.yml\` with \`package-ecosystem: "npm"\` (also correct for pnpm/yarn lockfiles).`,
+    ];
+  },
 };
 
 /**

--- a/test/readiness.test.ts
+++ b/test/readiness.test.ts
@@ -265,6 +265,43 @@ test("a bare bun repo emits exactly the installable-guardrail commands, all bun"
   expect(INSTALL_STEPS.dependency_automation(PM_VERBS.bun)).toEqual([]);
 });
 
+test("dependabot note prescribes the bun ecosystem for a bun repo", () => {
+  pkg({ name: "bare" });
+  write("bun.lock", "");
+  const r = analyzeReadiness(dir);
+  expect(r.claudeMd).toContain('package-ecosystem: "bun"');
+  expect(r.claudeMd).not.toContain('package-ecosystem: "npm"');
+  // Text lockfile already present — no migration hint.
+  expect(r.claudeMd).not.toContain("--save-text-lockfile");
+});
+
+test("dependabot note prescribes the npm ecosystem for npm and pnpm repos", () => {
+  pkg({ name: "bare" });
+  write("package-lock.json", "{}");
+  expect(analyzeReadiness(dir).claudeMd).toContain('package-ecosystem: "npm"');
+  expect(analyzeReadiness(dir).claudeMd).not.toContain('package-ecosystem: "bun"');
+  rmSync(join(dir, "package-lock.json"));
+  write("pnpm-lock.yaml", "");
+  expect(analyzeReadiness(dir).claudeMd).toContain('package-ecosystem: "npm"');
+});
+
+test("dependabot note adds the text-lockfile migration hint for bun.lockb-only repos", () => {
+  pkg({ name: "bare" });
+  write("bun.lockb", "");
+  const r = analyzeReadiness(dir);
+  expect(r.claudeMd).toContain('package-ecosystem: "bun"');
+  expect(r.claudeMd).toContain("bun install --save-text-lockfile");
+});
+
+test("no dependabot note when dependency automation is already present", () => {
+  pkg({ name: "bare" });
+  write("bun.lock", "");
+  write(".github/dependabot.yml", "version: 2");
+  const r = analyzeReadiness(dir);
+  expect(present("dependency_automation", r)).toBe(true);
+  expect(r.claudeMd).not.toContain("package-ecosystem");
+});
+
 test("a present guardrail emits no install command for itself", () => {
   pkg({ name: "x", devDependencies: { eslint: "^9" }, scripts: { lint: "eslint ." } });
   write("package-lock.json", "{}");


### PR DESCRIPTION
## Problem

Bootstrapping Dependabot from the Readiness panel's adopt prompt installed it with the **npm** ecosystem config even on bun repos. The `dependency_automation` guardrail's prescription line in the generated `claudeMd` artifact carried no stack guidance (`INSTALL_STEPS.dependency_automation` returns `[]`), so the spawned agent defaulted to `package-ecosystem: "npm"` — which never updates `bun.lock`, shipping a silently-broken Dependabot config.

## Fix

The analyzer already resolves the package manager (`RepoScan.pm` via `pickPackageManager`); it just never fed it into this prescription. Add a `PRESCRIPTION_NOTE` map rendered as prose guidance lines (no `$ ` prefix — not shell commands) under the adopt line in `generateClaudeMd`:

- `bun` → create `.github/dependabot.yml` with `package-ecosystem: "bun"` (the npm ecosystem would not update bun.lock)
- `npm`/`pnpm`/`yarn` → `package-ecosystem: "npm"` (Dependabot's npm ecosystem natively covers pnpm/yarn lockfiles; only bun has a dedicated one — same as this repo's own dependabot.yml)
- bun with only the binary `bun.lockb` → additionally prescribe `bun install --save-text-lockfile` first, since Dependabot's bun ecosystem requires the text lockfile

The note only renders when the guardrail is absent, matching the existing adopt-list path. Server-only; `claudeMd` is a verbatim generated artifact (i18n-exempt), no UI change.

## Tests

- bun repo → prompt contains `package-ecosystem: "bun"`, not `"npm"`
- npm + pnpm repos → `package-ecosystem: "npm"`
- `bun.lockb`-only repo → text-lockfile migration hint
- guardrail present → no note emitted
- existing `$ `-command-count test stays green (note lines carry no `$ ` prefix)

`bun run lint` + `bun run test`: 5817 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)