### PR TITLE
ci: pin workflows to ubuntu-latest, retire the CI_RUNNER self-hosted toggle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,11 @@ jobs:
     # push-to-main, so main still runs. NB: this only skips the JOB once the run
     # starts; GitHub's separate bot-PR "awaiting approval" gate is a repo setting.
     if: ${{ !(startsWith(github.head_ref, 'release-please--') && (github.event.pull_request.user.login == 'shepherd-release-please[bot]' || github.event.pull_request.user.login == 'github-actions[bot]')) }}
-    # Runner toggle for the closed-source phase: set the repo variable CI_RUNNER to
-    # 'self-hosted' to run on the local self-hosted runner (saves included minutes).
-    # Unset/empty falls back to ubuntu-latest. MUST be deleted before the repo goes
-    # public — a self-hosted runner on a public repo runs fork-PR code on the host.
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    # Pinned to GitHub-hosted: the repo is public, so hosted minutes are free and a
+    # self-hosted runner would execute fork-PR code on our host. Deliberately NOT the
+    # old `vars.CI_RUNNER ||` toggle — a single `gh variable set` must not be able to
+    # re-arm the self-hosted path (see ci/self-hosted-runner/README.md).
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -176,10 +176,8 @@ jobs:
     # the `verify` job's branch+bot-identity guard above (branch-name-only was a
     # fork-spoofable check-skip). head_ref is empty on push-to-main, so main runs.
     if: ${{ !(startsWith(github.head_ref, 'release-please--') && (github.event.pull_request.user.login == 'shepherd-release-please[bot]' || github.event.pull_request.user.login == 'github-actions[bot]')) }}
-    # Same self-hosted runner toggle as `verify`: set repo var CI_RUNNER to
-    # 'self-hosted' to use the local runner; unset falls back to ubuntu-latest.
-    # MUST be deleted before the repo goes public.
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    # Pinned to GitHub-hosted like `verify` — public repo, no CI_RUNNER toggle.
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/doc-automerge.yml
+++ b/.github/workflows/doc-automerge.yml
@@ -52,7 +52,7 @@ concurrency:
 jobs:
   automerge:
     name: merge green doc PRs
-    runs-on: ubuntu-latest # a tiny control job — kept off the self-hosted CI runner on purpose
+    runs-on: ubuntu-latest
     steps:
       # Give the job git context: `gh repo view` (and gh's repo auto-detection generally) falls back
       # to the local git remote, so without a checkout it dies with "fatal: not a git repository".

--- a/.github/workflows/extension-package.yml
+++ b/.github/workflows/extension-package.yml
@@ -16,7 +16,8 @@ permissions:
 
 jobs:
   package:
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    # Pinned to GitHub-hosted — public repo, no CI_RUNNER toggle (see ci.yml).
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/onboarding-release-gate.yml
+++ b/.github/workflows/onboarding-release-gate.yml
@@ -7,9 +7,7 @@ name: Onboarding release gate
 # open whenever a scenario regresses (closing it when green again). This gate
 # consults that issue when release-please's release PR is opened/updated, so a
 # release can't ship over a known onboarding regression. It only READS an issue —
-# no Incus, no host access — so it is safe and runs on a hosted runner (kept off
-# the CI_RUNNER toggle so it stays reliable when the self-hosted runner is down,
-# matching release-please.yml).
+# no Incus, no host access — so it is safe and runs on a hosted runner.
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -24,11 +24,8 @@ jobs:
     # this required check (skipped == passing to the ruleset). Non-release PRs run as
     # normal. This does NOT touch GitHub's separate bot-PR "awaiting approval" gate.
     if: ${{ !(startsWith(github.head_ref, 'release-please--') && (github.event.pull_request.user.login == 'shepherd-release-please[bot]' || github.event.pull_request.user.login == 'github-actions[bot]')) }}
-    # Runner toggle for the closed-source phase: set the repo variable CI_RUNNER to
-    # 'self-hosted' to run on the local self-hosted runner (saves included minutes).
-    # Unset/empty falls back to ubuntu-latest. MUST be deleted before the repo goes
-    # public — a self-hosted runner on a public repo runs fork-PR code on the host.
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    # Pinned to GitHub-hosted — public repo, no CI_RUNNER toggle (see ci.yml).
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head (the real branch tip, not the merge ref)
         uses: actions/checkout@v7

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -24,9 +24,8 @@ jobs:
     # pr-hygiene.yml, which guard off the same head_ref prefix AND the release-bot
     # identity (branch-name-only was a fork-spoofable required-check skip).
     if: ${{ !(startsWith(github.head_ref, 'release-please--') && (github.event.pull_request.user.login == 'shepherd-release-please[bot]' || github.event.pull_request.user.login == 'github-actions[bot]')) }}
-    # Runner toggle for the closed-source phase (see ci.yml): CI_RUNNER=self-hosted
-    # uses the local runner; unset falls back to ubuntu-latest.
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    # Pinned to GitHub-hosted — public repo, no CI_RUNNER toggle (see ci.yml).
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,9 +16,6 @@ concurrency:
 
 jobs:
   release-please:
-    # Intentionally NOT on the CI_RUNNER toggle (unlike verify + pr-hygiene): this
-    # runs only on push to main, is cheap, and must reliably cut releases even when
-    # the local self-hosted runner is down. See ci/self-hosted-runner/README.md.
     runs-on: ubuntu-latest
     steps:
       # release-please maintains a release PR that accrues a CHANGELOG from

--- a/ci/self-hosted-runner/README.md
+++ b/ci/self-hosted-runner/README.md
@@ -1,11 +1,17 @@
 # Shepherd self-hosted CI runner
 
-A locally-hosted GitHub Actions runner for `erwins-enkel/shepherd`, so CI for this
-**private** repo stops burning the account's included Actions minutes. The workflows
-(`.github/workflows/ci.yml`, `pr-hygiene.yml`) target it via
-`runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}` — set the repo Actions variable
-`CI_RUNNER=self-hosted` to route jobs here, delete it to fall straight back to
-GitHub-hosted runners.
+A locally-hosted GitHub Actions runner, built for `erwins-enkel/shepherd` while it was
+**private**, so CI stopped burning the account's included Actions minutes. **Status:
+retired for shepherd** — the repo is public (hosted minutes are free), and the
+workflows are now **pinned to `ubuntu-latest`** with the old
+`runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}` toggle removed, so a stray
+`gh variable set CI_RUNNER` can no longer route public fork-PR code to this host.
+
+The harness itself is repo-agnostic: `GH_REPO` / `REPO_URL` live in the host-side
+`~/.config/shepherd-ci-runner/.env`, so it can be repointed at any other **private**
+repo (e.g. `erwins-enkel/pulse`) by editing that file, re-registering the runners, and
+adding the same `vars.CI_RUNNER || 'ubuntu-latest'` toggle to that repo's workflows.
+The setup/operations sections below describe the mechanism generically.
 
 ## What & why — the cost trade-off
 
@@ -218,9 +224,9 @@ state:
 
 5. **Only now flip the repo to public.**
 
-> Optional hardening for the public phase: drop the `vars.CI_RUNNER ||` toggle from the
-> workflow files entirely, so a single `gh variable set` can't silently re-arm the
-> self-hosted path on a public repo.
+> Hardening for the public phase (**done** — PR that pinned the workflows): the
+> `vars.CI_RUNNER ||` toggle is dropped from the workflow files entirely, so a single
+> `gh variable set` can't silently re-arm the self-hosted path on a public repo.
 
 ## Egress real-machinery tests
 

--- a/ci/self-hosted-runner/README.md
+++ b/ci/self-hosted-runner/README.md
@@ -196,6 +196,12 @@ step's warning.
 
 ## ⚠️ MANDATORY public-repo cutover
 
+> **Status for shepherd:** steps 1–2 are done (`CI_RUNNER` deleted, hosted CI green)
+> and the workflow files are pinned to `ubuntu-latest`; steps 3–4 (runner teardown +
+> deregistration) are still pending on the host. The `erwins-enkel/shepherd` commands
+> below are that concrete instance — for any future private-repo deployment of this
+> harness, substitute that repo and run the same checklist before it goes public.
+
 A self-hosted runner attached to a **public** repo executes **fork-PR code on this
 host** — any internet stranger's pull request runs on your machine, beside production.
 This is GitHub's own loud warning, and here it's non-negotiable. Making the repo public


### PR DESCRIPTION
## Why

Actions-budget analysis of the org usage CSV (2026-07-01..04) shows **shepherd's minutes cost $0 net** since going public on 2026-07-01 — hosted runners are free+unlimited on public repos (every shepherd row is 100% discounted). The org's actual billable burn is **pulse** (~630 min/day ≈ 19k min/month projected), tracked in erwins-enkel/pulse#170.

What the analysis DID surface for this repo: the self-hosted runner README's **mandatory public-repo cutover** was left half-done. `CI_RUNNER` was deleted (step 1 ✓) and hosted CI is green (step 2 ✓), but the **4 runner replicas are still registered and online** against the now-public repo (steps 3–4 ✗), and the workflows still carry the `vars.CI_RUNNER || 'ubuntu-latest'` toggle — so a single `gh variable set CI_RUNNER` would silently route public fork-PR code onto the prod-adjacent host.

## What

- Pin `runs-on: ubuntu-latest` in `ci.yml` (verify + docs-site), `pr-hygiene.yml`, `pr-title.yml`, `extension-package.yml` — the README's own prescribed hardening: with the toggle gone, no repo variable can re-arm the self-hosted path.
- Update `ci/self-hosted-runner/README.md`: status is retired-for-shepherd; the harness is repo-agnostic (`GH_REPO`/`REPO_URL` in the host-side `.env`) and can be repointed at a private repo — the plan for pulse is erwins-enkel/pulse#170.

No behavior change for CI runs: `CI_RUNNER` is already unset, so every job already runs on `ubuntu-latest`.

## Verification

- All 7 workflow files YAML-parse clean; prettier check passes on touched files.
- Pre-push gates green (prettier, tsc, root-tests, ui, fallow audit — see push log).
- `gh api repos/erwins-enkel/shepherd/actions/runners` currently shows 4 online idle runners → hence the manual steps below.

```shepherd:manual-steps
- [ ] On the runner host: tear down the shepherd registrations per ci/self-hosted-runner/README.md "Teardown" — disable shepherd-ci-runner@1..4 + watchdog timer, then confirm `gh api repos/erwins-enkel/shepherd/actions/runners --jq .total_count` returns 0 (4 runners are still online against the public repo)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)