### PR TITLE
feat(skills): add shepherd-epic-authoring skill for attended epic flows

### DIFF
--- a/.claude/skills/shepherd-epic-authoring/SKILL.md
+++ b/.claude/skills/shepherd-epic-authoring/SKILL.md
@@ -18,7 +18,8 @@ an operator who asks for an epic **mid-session (steer-time)** gets no injected
 epic-shape guidance at all — the agent falls back on generic GitHub habits and
 ships an "epic" Shepherd never sees. This skill is the remedy for exactly that
 gap: invoke it whenever an epic ask arises, at spawn or mid-session. It is
-attended by construction (unattended drains run with skills disabled) and
+attended by default (unattended drains run with skills disabled unless the
+operator opts out of context trimming) and
 richer than the injected blocks: it drafts the whole tree, gates outward
 actions on approval, and wires native links.
 
@@ -132,8 +133,13 @@ additionally wires **native sub-issue + `blocked_by` links**. It is **not**
 automatic — trigger it per parent:
 
 ```bash
-curl -s -X POST "http://127.0.0.1:7330/api/epic/import?repo=$(git rev-parse --show-toplevel)&parent=<PARENT_NUM>"
+curl -s -X POST -G "http://127.0.0.1:7330/api/epic/import" \
+  --data-urlencode "repo=$(git rev-parse --show-toplevel)" \
+  --data-urlencode "parent=<PARENT_NUM>"
 ```
+
+(`-G --data-urlencode` keeps the POST while URL-encoding the query, so a repo
+path containing a space or `&` can't break the request.)
 
 (Use your Shepherd server's host/port; `7330` is the default.) The response
 reports `subIssuesAdded` / `dependenciesAdded` / `unresolved`. Re-check any

--- a/.claude/skills/shepherd-epic-authoring/SKILL.md
+++ b/.claude/skills/shepherd-epic-authoring/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: shepherd-epic-authoring
+description: Author a Shepherd-recognized epic in an attended session — decompose work into child issues, create them, and mark the parent body with the structural epic marker (fenced dag / task-list), optionally wiring native sub-issue + blocked_by links via epic import. Use when asked to create an epic with sub-issues, promote an existing issue #N to an epic, split an issue into child issues, or make a body of work drainable as an epic — especially mid-session, where no injected epic guidance exists.
+---
+
+# Shepherd Epic Authoring
+
+Turn an **attended** epic ask into structure Shepherd actually recognizes. Two
+flows share the same spine:
+
+- **Create** — "create an epic for X with sub-issues Y, Z".
+- **Promote** — "promote existing issue #N to an epic".
+
+Shepherd's spawn-time prompts already carry a short epic-shape contract (the
+single-PR invariant's promote hatch, plus an epic-authoring notice when the
+spawn prompt signals epic intent). But that detection is **spawn-time only**:
+an operator who asks for an epic **mid-session (steer-time)** gets no injected
+epic-shape guidance at all — the agent falls back on generic GitHub habits and
+ships an "epic" Shepherd never sees. This skill is the remedy for exactly that
+gap: invoke it whenever an epic ask arises, at spawn or mid-session. It is
+attended by construction (unattended drains run with skills disabled) and
+richer than the injected blocks: it drafts the whole tree, gates outward
+actions on approval, and wires native links.
+
+This skill is **self-contained**: it ships in the Shepherd repo and runs in
+_other_ operators' repos, so everything it needs is below.
+
+## The recognition contract
+
+Shepherd recognizes an epic **ONLY structurally** — the parent issue's body
+must reference each child's **REAL issue number**, via **either** marker:
+
+1. A fenced dag block. One `#<n>` line per child; `#<n> <- #<m>` when `#n` is
+   blocked by `#m` (multiple blockers comma-separated). The canonical example:
+
+   ````
+   ```epic-dag
+   #12
+   #13 <- #12
+   #14 <- #12, #13
+   ```
+   ````
+
+2. A task-list — one `- [ ] #12`-style line per child issue (members only, no
+   dependency edges).
+
+The body marker is **MANDATORY even when the children have no dependencies**.
+Only the **first** fenced dag block in a body is parsed — keep exactly one.
+
+**NOT recognized:** an `epic` label, an `[EPIC]` title prefix, a prose
+checklist without `#<n>` issue references, front-matter, or HTML markers. None
+of these exist in Shepherd's parser — don't reach for them.
+
+## Stages
+
+Work the stages in order; track one todo per stage. **Nothing outward (issue
+creation, body edits, epic import) happens before the Stage 2 approval gate.**
+
+### 0. Orient
+
+Pin two facts, then confirm them with the operator:
+
+**Flow** — create a new epic, or promote an existing issue `#N`? For
+promotion, read the current parent (`gh issue view <N> --json title,body`) so
+the draft builds on what's there.
+
+**Tracker** — GitHub-native or local/lightweight:
+
+```bash
+git remote -v                      # is there a GitHub remote?
+gh auth status 2>/dev/null         # is gh usable?
+```
+
+A working GitHub remote + `gh` ⇒ **GitHub-native** (issue creation + epic
+import available). Otherwise **local/lightweight**: programmatic creation and
+import are unavailable (import asserts a GitHub-native forge) — the deliverable
+becomes an importable markdown file instead (see Stage 3).
+
+### 1. Draft
+
+Decompose the work into **tracer-bullet vertical slices**: each child is a
+thin end-to-end cut with an observable result, sized so it lands in a single
+PR — **one slice = one PR = one Shepherd session**. A child too big for one PR
+is itself an epic; split it further. Each child gets a crisp title and a body
+stating the goal, the vertical cut, and a checkable acceptance criterion.
+
+Draft the **entire tree as markdown**: every child's title + body, and the
+parent body carrying the dag fence (or the task-list when there are no
+dependencies) with placeholder numbers to be filled in at Stage 3. This draft
+is both the approval artifact and the local/lightweight fallback.
+
+### 2. Approve (hard gate)
+
+Present the full draft — for promotion, show the parent-body change as
+before/after — then **stop**. Use `AskUserQuestion` to confirm, amend, or
+abort. If the operator amends, revise and re-present. Nothing is created or
+edited before this gate.
+
+### 3. Create (ordered)
+
+Only after approval. **GitHub-native repos** — order matters, because the
+parent marker must reference real child numbers:
+
+1. **Create the child issues first and capture their numbers.**
+   `gh issue create` prints the new issue URL; the trailing path segment is
+   the number:
+
+   ```bash
+   url=$(gh issue create --title "<title>" --body "<body>")
+   num=${url##*/}          # e.g. 142
+   ```
+
+   Repeat per child, recording each `num`.
+
+2. **Mark the parent body** with the captured numbers:
+   - **Create flow:** `gh issue create` the parent with the fence-bearing
+     body. Capture its number too.
+   - **Promote flow:** `gh issue edit <N> --body "<updated body>"` — the
+     existing body plus the fence/task-list. Creating the children while
+     leaving `#N`'s body unmarked leaves it a plain issue Shepherd never
+     recognizes; the parent edit **is** the promotion.
+
+**Local/lightweight repos** — do not attempt programmatic creation or import.
+Write the approved tree to an importable markdown file (e.g. `BACKLOG.md`) and
+tell the operator it's the manual reference / future-import source — say this
+explicitly rather than failing silently.
+
+### 4. Import (GitHub-native only)
+
+The body marker alone already makes the epic recognized and drainable; import
+additionally wires **native sub-issue + `blocked_by` links**. It is **not**
+automatic — trigger it per parent:
+
+```bash
+curl -s -X POST "http://127.0.0.1:7330/api/epic/import?repo=$(git rev-parse --show-toplevel)&parent=<PARENT_NUM>"
+```
+
+(Use your Shepherd server's host/port; `7330` is the default.) The response
+reports `subIssuesAdded` / `dependenciesAdded` / `unresolved`. Re-check any
+`unresolved` member numbers — they usually mean a typo'd or foreign issue
+reference in the parent body — fix the body and re-import.
+
+### 5. Verify + hand off
+
+Confirm the parent now carries the marker (and, if imported, the native
+links). Then stop and point:
+
+- **The epic itself is the deliverable — open NO pull request.** If this
+  session was spawned on the issue being promoted, the parent-body marker is
+  the finish line.
+- **Drain is operator-started.** Shepherd drains each child as its own session
+  and its own PR; an agent cannot trigger that itself. Tell the operator the
+  epic is ready to drain and name the **DAG roots** (children with no
+  blockers) as the first ones to start.
+
+## Gate rules (reference)
+
+- **Outward actions are gated** on the Stage 2 approval — drafting is always
+  safe; creating, editing, and importing are not.
+- **GitHub-only operations:** `gh issue create` / `gh issue edit` and the epic
+  import endpoint require a GitHub-native forge; local/lightweight repos get
+  the markdown fallback.
+- **Marker grammar:** members are `#<n>` lines inside the fenced dag block; an
+  edge is `#<dependent> <- #<blocker>[, #<blocker>…]`; the task-list variant
+  lists members only. Real numbers, one fence, marker mandatory.
+- **No PR:** when the ask is to author or promote an epic, stop once the
+  parent body carries the marker (and import, where available, reports no
+  `unresolved`).

--- a/.claude/skills/shepherd-onboarding/SKILL.md
+++ b/.claude/skills/shepherd-onboarding/SKILL.md
@@ -191,8 +191,13 @@ Only after approval. **GitHub-native repos** — order matters, because the pare
    automatic on creation, and the endpoint requires a **GitHub-native forge**:
 
    ```bash
-   curl -s -X POST "http://127.0.0.1:7330/api/epic/import?repo=$(git rev-parse --show-toplevel)&parent=<PARENT_NUM>"
+   curl -s -X POST -G "http://127.0.0.1:7330/api/epic/import" \
+     --data-urlencode "repo=$(git rev-parse --show-toplevel)" \
+     --data-urlencode "parent=<PARENT_NUM>"
    ```
+
+   (`-G --data-urlencode` keeps the POST while URL-encoding the query, so a
+   repo path containing a space or `&` can't break the request.)
 
    (Use your Shepherd server's host/port; `7330` is the default.) The response
    reports `subIssuesAdded` / `dependenciesAdded` / `unresolved`. Re-check any

--- a/test/epic-parse.test.ts
+++ b/test/epic-parse.test.ts
@@ -1,4 +1,6 @@
 import { test, expect, describe } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { parseEpicBody } from "../src/epic-parse";
 import { EPIC_SHAPE_CONTRACT } from "../src/service";
 
@@ -50,6 +52,34 @@ describe("EPIC_SHAPE_CONTRACT stays parseable by parseEpicBody", () => {
   });
   test("the taught checklist example is present verbatim and parses standalone", () => {
     expect(EPIC_SHAPE_CONTRACT).toContain("- [ ] #12");
+    expect(parseEpicBody("- [ ] #12")).toEqual({ members: [12], order: [12], edges: [] });
+  });
+});
+
+// #1393 — the shepherd-epic-authoring skill's canonical fence example is likewise a taught
+// grammar this parser must accept. FENCE_RE is non-global (only the FIRST fence in a body
+// parses), so the skill must carry exactly one fence — a second example would be silently
+// unpinned and could drift into an unparseable shape without failing anything.
+describe("shepherd-epic-authoring SKILL.md stays parseable by parseEpicBody", () => {
+  const skill = readFileSync(
+    join(import.meta.dir, "../.claude/skills/shepherd-epic-authoring/SKILL.md"),
+    "utf8",
+  );
+  test("carries exactly one epic-dag fence", () => {
+    expect(skill.split("```epic-dag").length - 1).toBe(1);
+  });
+  test("the canonical fence example parses to its literal members + edges", () => {
+    const r = parseEpicBody(skill);
+    expect(r.members).toEqual([12, 13, 14]);
+    expect(r.order).toEqual([12, 13, 14]);
+    expect(r.edges).toEqual([
+      { dependent: 13, blocker: 12 },
+      { dependent: 14, blocker: 12 },
+      { dependent: 14, blocker: 13 },
+    ]);
+  });
+  test("the taught checklist example is present verbatim and parses standalone", () => {
+    expect(skill).toContain("- [ ] #12");
     expect(parseEpicBody("- [ ] #12")).toEqual({ members: [12], order: [12], edges: [] });
   });
 });


### PR DESCRIPTION
Closes #1393. Tier 3 of #1391 (tiers 1+2 shipped in #1394).

## What

- **`.claude/skills/shepherd-epic-authoring/SKILL.md`** (new) — operator-invoked skill for rich **attended** epic flows, mirroring shepherd-onboarding Stages 3/5, scoped to epic authoring. Two flows (create a new epic / promote existing `#N`), one spine:
  - **Stage 0 Orient** — pin the flow + tracker (GitHub-native vs local/lightweight; import asserts a GitHub-native forge, local repos get an importable-markdown fallback).
  - **Stage 1 Draft** — decompose into single-PR tracer-bullet slices; draft the whole tree as markdown.
  - **Stage 2 Approve (hard gate)** — `AskUserQuestion`; nothing outward before approval.
  - **Stage 3 Create (ordered)** — children first via `gh issue create`, capture numbers (`${url##*/}`); then mark the parent body (create) or `gh issue edit #N` (promote — the parent edit IS the promotion).
  - **Stage 4 Import** — `POST /api/epic/import?repo=…&parent=<n>` to wire native sub-issue + `blocked_by` links; verify `unresolved` is empty.
  - **Stage 5 Verify + hand off** — the epic is the deliverable (no PR); drain is operator-started; point at the DAG roots.
  - States the recognition contract incl. the non-markers (`epic` label, `[EPIC]` title, prose checklist), and **names the known gap the injected tiers leave**: `detectEpicIntent` runs at spawn time only, so steer-time epic asks get no injected guidance — invoking this skill is the remedy.
- **`test/epic-parse.test.ts`** — pins the skill's taught grammar to the parser (same precedent as the `EPIC_SHAPE_CONTRACT` pin): the canonical fence example parses to its literal members/edges, the checklist example parses standalone, and the file carries **exactly one** `epic-dag` fence (`FENCE_RE` is non-global — a second fence would be silently unpinned).

## Why skill-gated

Complements, not replaces, the injected tier-1/2 guidance: skills are disabled in unattended drains, so this is attended-by-construction and can afford the richer flow (full-tree draft, approval gate, native-link import) the token-constrained injected blocks can't carry.

## Verification

- `bun run lint`, `bun run test` (5843 pass / 0 fail, incl. the new pins), `bun run typecheck` — all green.
- No UI/i18n surface; `feat` commit touches no `ui/src` globs, so the feature-catalog gate does not arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)