### PR TITLE
fix(epic): record epic_integrated on out-of-band / merge-train / manual-session merges

### DIFF
--- a/src/automerge.ts
+++ b/src/automerge.ts
@@ -8,7 +8,7 @@ import {
   type MergeRepoState,
   type MergeSessionView,
 } from "./automerge-core";
-import { settleMergedSession } from "./merge-teardown";
+import { recordEpicIntegrationIfChild, settleMergedSession } from "./merge-teardown";
 import { isFullAuto } from "./full-auto";
 
 /** Live per-repo merge-train status pushed to clients. */
@@ -50,6 +50,9 @@ export interface AutoMergeDeps {
     | "setAutoMergeState"
     | "setAutopilotState"
     | "isEpicIntegratedChild"
+    | "getEpicRun"
+    | "getEpicIntegrationBranch"
+    | "recordEpicIntegrated"
   >;
   service: {
     archive(id: string): Promise<number>;
@@ -306,6 +309,17 @@ export class AutoMergeService {
     // credit the train tracker directly (the poller-driven resolveMerging never fires
     // for this path). No-op unless the session was merge-train-flagged.
     this.deps.service.resolveMerging(sessionId, true);
+    // #1401: record epic integration BEFORE settleMergedSession so its isIntegratedEpicChild
+    // guard (#1037) sees the fresh row and archives-only. The base comes from the prCache
+    // snapshot (a merge doesn't change the base), with the helper's prReviewMeta fallback.
+    // Normally unreachable for epic children (isFullAuto excludes integration-branch bases),
+    // but a session whose PR was re-targeted to the epic branch can still be train-merged.
+    const git = this.deps.prCache.snapshot()[sessionId] ?? null;
+    await recordEpicIntegrationIfChild(
+      s,
+      { number: prNumber, url: git?.url, baseRefName: git?.baseRefName },
+      { store: this.deps.store, forge },
+    );
     await settleMergedSession(s, {
       resolveForge: this.deps.resolveForge,
       archive: (id) => this.deps.service.archive(id),

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -4,7 +4,7 @@ import type { CreateSessionInput, Session } from "./types";
 import type { SessionStateChange } from "./session-snapshot";
 import type { UsageLimits } from "./usage-limits";
 import type { TelemetryService } from "./telemetry";
-import { settleMergedSession } from "./merge-teardown";
+import { recordEpicIntegrationIfChild, settleMergedSession } from "./merge-teardown";
 import { isFullAuto } from "./full-auto";
 import {
   ACTIVE_LABEL,
@@ -56,6 +56,10 @@ const SPAWN_FAIL_COOLDOWN_MS = 5 * 60_000;
  *  `prReviewMeta` API call on every pump while the operator hasn't fixed it — recheck at most
  *  this often per child. Bounds the cost to ≤1 call/child/~60s while a child stays blocked. */
 const EPIC_BASE_RECHECK_TTL_MS = 60_000;
+/** #1401: one reconcile sweep per epic per this window (plus one on the first tick after a
+ *  restart — the throttle map is in-memory). Slow on purpose: the sweep is convergence repair
+ *  for merges whose event-time recording was missed, not a hot path. */
+const EPIC_RECONCILE_TTL_MS = 5 * 60_000;
 
 /** Cap on epic-landing-PR open attempts (#635, Stage B). A failed `openPr` flips the
  *  `epic_completed` row to `landingState:'error'` and increments `landingAttempts`; the
@@ -238,6 +242,10 @@ export class DrainService {
   // recomputing on restart is fine — no persisted column).
   private epicBranchScanCache = new Map<string, { at: number; divergent: string[] }>();
   private lastEpicSig = new Map<string, string>();
+  // #1401: `${repoPath}#${parentIssueNumber}` → last reconcile-sweep timestamp. In-memory on
+  // purpose: a restart sweeps immediately (deploy ⇒ a pre-existing stall self-heals within one
+  // tick), then settles to one sweep per EPIC_RECONCILE_TTL_MS.
+  private epicReconcileAt = new Map<string, number>();
   /** #790: `${repoPath}#${issueNumber}` → last spawn-failure timestamp; throttles re-spawn
    *  of an issue whose create() keeps throwing. Cleared on a successful spawn. In-memory. */
   private spawnFailures = new Map<string, number>();
@@ -1865,6 +1873,11 @@ export class DrainService {
   async handle(change: SessionStateChange): Promise<void> {
     const s = change.snapshot.session;
     if (change.kind === "git") {
+      // #1401: record epic integration BEFORE the auto gate — a manual (auto=0) session never
+      // reaches reapMerged, so this is the only event-time hook covering its merged PR. Also
+      // deliberately before settleMergedSession (via reapMerged below) so the #1037
+      // isIntegratedEpicChild guard sees the fresh row and archives-only.
+      if (change.git.state === "merged") await this.recordEpicIntegrationForMerge(s, change.git);
       if (!s.auto) return; // drain only manages auto sessions
       if (change.git.state === "merged") {
         await this.reapMerged(s);
@@ -1880,7 +1893,10 @@ export class DrainService {
   /** pr-poller observed a new git state for a session. */
   async onGit(id: string, git: GitState): Promise<void> {
     const s = this.deps.store.get(id);
-    if (!s || !s.auto) return; // drain only manages auto sessions
+    if (!s) return;
+    // #1401: record BEFORE the auto gate (see handle() — same manual-session coverage).
+    if (git.state === "merged") await this.recordEpicIntegrationForMerge(s, git);
+    if (!s.auto) return; // drain only manages auto sessions
     if (git.state === "merged") {
       await this.reapMerged(s);
       return;
@@ -1888,6 +1904,102 @@ export class DrainService {
     // open/green/other → the retire gate may now fire (e.g. CI just went green).
     // Skip drain-disabled repos — no spawn/retire there, just WS noise.
     await this.pumpIfEnabled(s.repoPath);
+  }
+
+  /** #1401: event-time epic-integration recording for a poller-observed merge. Thin adapter
+   *  over the shared helper (which owns the gates: issue-linked, active epic, merged base ==
+   *  pinned integration branch, never-throws). Ungated by `s.auto` — see handle()/onGit(). */
+  private async recordEpicIntegrationForMerge(s: Session, git: GitState): Promise<void> {
+    await recordEpicIntegrationIfChild(
+      s,
+      { number: git.number, url: git.url, baseRefName: git.baseRefName },
+      { store: this.deps.store, forge: this.deps.resolveForge(s.repoPath) },
+    );
+  }
+
+  /**
+   * #1401 reconcile sweep: backfill `epic_integrated` rows for children whose merged PR was
+   * settled without recording (out-of-band merges that predate the event-time fix, or whose
+   * event was missed). Event-time recording is one-shot and already consumed for such children,
+   * so a stalled epic can only converge through this pass. Runs from tick() ungated by the
+   * drain toggle, but is internally cheap: nothing for repos without an active epic, and one
+   * sweep per epic per {@link EPIC_RECONCILE_TTL_MS} otherwise.
+   *
+   * Mapping is session-records-only (ratified in the plan): every stored session row for the
+   * child (ANY status incl. archived, ANY auto flag) contributes its branch; each DISTINCT
+   * branch is probed via branch-keyed `prStatus` until one records. All rows — not first-match —
+   * because `store.list()` is createdAt-ordered, so a dead predecessor session (spawned first,
+   * never opened a PR) sorts before the manual respawn whose PR actually merged (#128's
+   * TASK-1248 vs TASK-1249 shape). Branches whose LIVE session currently shows an open PR are
+   * skipped — their merge will be recorded event-time; probing them every sweep would just burn
+   * forge reads on healthy in-flight children.
+   *
+   * Worst case: one `prStatus` per distinct not-open-PR branch per un-integrated child per TTL.
+   * After a backfill the same tick's pump reads the new row → handleEpicSideEffects completes
+   * the epic → the landing PR opens. No manual DB surgery.
+   */
+  private async reconcileEpicIntegrations(repoPath: string): Promise<void> {
+    const run = this.deps.store.getEpicRun(repoPath);
+    if (!run || (run.status !== "running" && run.status !== "paused")) return;
+    const key = `${repoPath}#${run.parentIssueNumber}`;
+    const last = this.epicReconcileAt.get(key);
+    if (last !== undefined && this.now() - last < EPIC_RECONCILE_TTL_MS) return;
+    this.epicReconcileAt.set(key, this.now());
+    const forge = this.deps.resolveForge(repoPath);
+    if (!forge) return;
+    const epic = await this.buildEpic(repoPath, run);
+    if (!epic) return;
+    const candidates = epic.children.filter((c) => !c.integrationMerged && !c.issueClosed);
+    if (candidates.length === 0) return;
+    const rows = this.deps.store
+      .list()
+      .filter((x) => x.repoPath === repoPath && x.issueNumber != null && x.branch);
+    for (const child of candidates) {
+      await this.probeChildIntegration(
+        forge,
+        repoPath,
+        child.number,
+        rows.filter((x) => x.issueNumber === child.number),
+      );
+    }
+  }
+
+  /** One child's probe pass for {@link reconcileEpicIntegrations}: try each DISTINCT branch
+   *  among the child's session rows until one records. Rows arrive in `store.list()`
+   *  (createdAt) order — dead predecessors first — which is exactly why every branch is tried.
+   *  A live row whose snapshot shows an OPEN PR is skipped (event-time recording owns it);
+   *  per-branch probe errors warn + continue. */
+  private async probeChildIntegration(
+    forge: GitForge,
+    repoPath: string,
+    childNumber: number,
+    rows: Session[],
+  ): Promise<void> {
+    const prSnap = this.deps.prCache.snapshot();
+    const seen = new Set<string>();
+    for (const row of rows) {
+      const branch = row.branch!;
+      if (seen.has(branch)) continue;
+      seen.add(branch);
+      // Live session with an open PR → event-time recording owns it; skip the probe.
+      if (row.status !== "archived" && prSnap[row.id]?.state === "open") continue;
+      let pr: PrStatus;
+      try {
+        pr = await forge.prStatus(branch);
+      } catch (err) {
+        console.warn(`[drain] epic reconcile prStatus(${branch}) failed for ${repoPath}:`, err);
+        continue;
+      }
+      if (pr.state !== "merged") continue;
+      // The helper re-applies the full gate set (active epic, base resolution incl. the
+      // base-incapable carve-out via THIS row's baseBranch, pinned match, idempotent upsert).
+      await recordEpicIntegrationIfChild(
+        row,
+        { number: pr.number, url: pr.url, baseRefName: pr.baseRefName },
+        { store: this.deps.store, forge },
+      );
+      if (this.deps.store.isEpicIntegratedChild(repoPath, childNumber)) return; // recorded
+    }
   }
 
   /** Reap a session whose PR was observed merged out-of-band — a human or GitHub
@@ -1984,6 +2096,14 @@ export class DrainService {
   /** Periodic sweep (~30s): catches newly-labeled issues + resumed usage windows. */
   async tick(): Promise<void> {
     for (const repoPath of this.deps.repos()) {
+      // #1401: backfill missed epic-integration rows BEFORE the pump so a stalled epic
+      // completes (and opens its landing PR) in this same tick. UNGATED by the drain toggle,
+      // like its neighbors; internally throttled + no-op without an active epic.
+      try {
+        await this.reconcileEpicIntegrations(repoPath);
+      } catch (err) {
+        console.warn(`[drain] epic reconcile failed for ${repoPath}:`, err);
+      }
       // UNGATED landing-PR retry: runs for EVERY repo, BEFORE the pump gate, so a completed
       // epic's PR is opened/retried even in a repo with autoDrain off and no running epic.
       // DB-gated internally → zero forge calls in steady state.

--- a/src/merge-teardown.ts
+++ b/src/merge-teardown.ts
@@ -1,5 +1,87 @@
 import type { GitForge } from "./forge/types";
 import type { Session } from "./types";
+import type { SessionStore } from "./store";
+
+/** Store surface for {@link recordEpicIntegrationIfChild}. */
+export type EpicIntegrationStore = Pick<
+  SessionStore,
+  "getEpicRun" | "getEpicIntegrationBranch" | "recordEpicIntegrated"
+>;
+
+/** The merged PR's facts as the caller observed them (poller GitState / prCache / prStatus). */
+export interface MergedPrFacts {
+  number?: number | null;
+  url?: string | null;
+  /** The PR's actual base ref when the payload supplies it (GitHub); absent on Gitea/local. */
+  baseRefName?: string | null;
+}
+
+/**
+ * #1401: record `epic_integrated` for a merged epic-child PR on the settle paths that are NOT
+ * the drain's retire path (poller reap of an out-of-band merge, merge train, local merge). Until
+ * this existed, `retireEpicChild` was the only writer, so any other merge left the epic stalled
+ * `running` forever (no completion, no landing PR).
+ *
+ * Call this BEFORE {@link settleMergedSession}: the just-written row is what its
+ * `isIntegratedEpicChild` guard (#1037) reads to archive-only instead of closing the child
+ * issue out of band.
+ *
+ * Deliberately NOT gated on `s.auto` — a manual (`auto=0`) respawn whose PR merges into the
+ * integration branch is exactly the escape hatch that stalled pulse epic #128.
+ *
+ * Base resolution (the PR is the source of truth, not the session's stored base):
+ *   1. `pr.baseRefName` from the caller's payload;
+ *   2. number-keyed `forge.prReviewMeta` fallback;
+ *   3. a forge that structurally cannot report a base (Gitea/local: no baseRefName, no
+ *      prReviewMeta) falls back to `s.baseBranch` — the same trust `retireEpicChild` and the
+ *      #645 `epicChildBaseBlocked` Gitea carve-out already extend;
+ *   4. a base-CAPABLE forge whose base stays unresolvable fails closed (no record; the
+ *      reconcile sweep retries later).
+ *
+ * Records only when the resolved base equals the PINNED integration branch (exact match —
+ * divergent `epic/*` bases stay fail-closed; #645 warnings surface those). Best-effort: never
+ * throws (the merge already happened; recording must not break teardown), and the store upsert
+ * is idempotent so double-recording with the retire path is harmless.
+ */
+export async function recordEpicIntegrationIfChild(
+  s: Session,
+  pr: MergedPrFacts,
+  deps: { store: EpicIntegrationStore; forge?: GitForge | null },
+): Promise<void> {
+  try {
+    if (s.issueNumber == null) return;
+    const run = deps.store.getEpicRun(s.repoPath);
+    // Mirrors the retire path's epicActive gate — an idle/absent epic never records.
+    if (!run || (run.status !== "running" && run.status !== "paused")) return;
+    const pinned = deps.store.getEpicIntegrationBranch(s.repoPath, run.parentIssueNumber);
+    if (pinned === null) return; // never pinned → this repo's epic never spawned a child
+    if ((await resolveMergedBase(s, pr, deps.forge)) !== pinned) return;
+    deps.store.recordEpicIntegrated(
+      s.repoPath,
+      run.parentIssueNumber,
+      s.issueNumber,
+      pr.number != null ? { number: pr.number, url: pr.url ?? "" } : undefined,
+      pinned,
+    );
+  } catch (err) {
+    console.warn(`[epic] record-integration failed for ${s.id} (issue #${s.issueNumber}):`, err);
+  }
+}
+
+/** The merged PR's actual base per the resolution order documented on
+ *  {@link recordEpicIntegrationIfChild}; null ⇒ unresolvable on a base-capable forge (fail closed). */
+async function resolveMergedBase(
+  s: Session,
+  pr: MergedPrFacts,
+  forge: GitForge | null | undefined,
+): Promise<string | null> {
+  if (pr.baseRefName != null) return pr.baseRefName;
+  // Base-incapable forge (Gitea/local) — the #645-style carve-out trusts the session's base.
+  if (!forge?.prReviewMeta) return s.baseBranch;
+  // Base-capable forge: resolve number-keyed; an unresolvable base fails closed.
+  if (pr.number == null) return null;
+  return (await forge.prReviewMeta(pr.number))?.baseRefName || null;
+}
 
 export interface MergeTeardownDeps {
   resolveForge: (repoPath: string) => GitForge | null;

--- a/src/server.ts
+++ b/src/server.ts
@@ -127,7 +127,7 @@ import { DEPENDABOT_REBASE_COMMAND, EmptyDiffError } from "./forge/types";
 import { buildIssueUrl } from "./forge";
 import type { GithubRateLimitPayload } from "./forge/github-rate-limit";
 import { BaseCheckoutBusyError, MergeConflictError } from "./forge/local";
-import { settleMergedSession } from "./merge-teardown";
+import { recordEpicIntegrationIfChild, settleMergedSession } from "./merge-teardown";
 import { type PrCache, guardStaleTerminal, trustsTerminal } from "./pr-poller";
 import {
   readRepoRoles,
@@ -3226,6 +3226,14 @@ async function forgeMerge(
   // AutoMergeService.doMerge's callbacks. Forge sessions keep the current behavior: a human
   // merges on the host and the poller-driven archive path handles teardown.
   if (forge.kind === "local") {
+    // #1401: record epic integration BEFORE settleMergedSession (the #1037 guard reads the
+    // fresh row to archive-only). LocalForge reports no PR base, so the helper's
+    // base-incapable carve-out trusts session.baseBranch — same as the retire path.
+    await recordEpicIntegrationIfChild(
+      session,
+      { number: cur.number, url: cur.url, baseRefName: cur.baseRefName },
+      { store: deps.store, forge },
+    );
     await settleMergedSession(session, {
       resolveForge: (repoPath) => deps.resolveForge?.(repoPath) ?? null,
       archive: (id) => deps.service.archive(id),

--- a/test/automerge.test.ts
+++ b/test/automerge.test.ts
@@ -34,6 +34,9 @@ function deps(over: Partial<AutoMergeDeps> = {}): AutoMergeDeps {
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
       isEpicIntegratedChild: () => false,
+      getEpicRun: () => null,
+      getEpicIntegrationBranch: () => null,
+      recordEpicIntegrated: mock(() => {}),
     } as any,
     service: {
       archive: mock(() => 1),
@@ -199,6 +202,9 @@ test("multi-session: merges ready A then steers rebase for behind B", async () =
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
       isEpicIntegratedChild: () => false,
+      getEpicRun: () => null,
+      getEpicIntegrationBranch: () => null,
+      recordEpicIntegrated: mock(() => {}),
     } as any,
     service: { archive, reply, resume: mock(() => true), resolveMerging: mock(() => {}) } as any,
     resolveForge: () =>
@@ -269,6 +275,9 @@ test("rebase_cap: behind session at cap → no reply steer, emitStatus rebase_ca
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
       isEpicIntegratedChild: () => false,
+      getEpicRun: () => null,
+      getEpicIntegrationBranch: () => null,
+      recordEpicIntegrated: mock(() => {}),
     } as any,
     worktree: { behindBase: async () => true } as any,
     service: {
@@ -305,6 +314,9 @@ test("manual_steps gate: otherwise-ready PR with an un-acked step → emitStatus
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
       isEpicIntegratedChild: () => false,
+      getEpicRun: () => null,
+      getEpicIntegrationBranch: () => null,
+      recordEpicIntegrated: mock(() => {}),
     } as any,
     resolveForge: () =>
       ({ kind: "github", mergeMethod: "squash", merge, closeIssue: mock(async () => {}) }) as any,
@@ -446,6 +458,9 @@ test("tick: skips repo with no full-auto session (no merge/steer)", async () => 
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
       isEpicIntegratedChild: () => false,
+      getEpicRun: () => null,
+      getEpicIntegrationBranch: () => null,
+      recordEpicIntegrated: mock(() => {}),
     } as any,
     resolveForge: () =>
       ({
@@ -486,6 +501,9 @@ test("per-session override true + repo default false → merges (repoHasFullAuto
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
       isEpicIntegratedChild: () => false,
+      getEpicRun: () => null,
+      getEpicIntegrationBranch: () => null,
+      recordEpicIntegrated: mock(() => {}),
     } as any,
     resolveForge: () =>
       ({ kind: "github", mergeMethod: "squash", merge, closeIssue: mock(async () => {}) }) as any,
@@ -573,6 +591,9 @@ test("merge-error backoff: after CAP failures the stuck PR is skipped, a ready s
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
       isEpicIntegratedChild: () => false,
+      getEpicRun: () => null,
+      getEpicIntegrationBranch: () => null,
+      recordEpicIntegrated: mock(() => {}),
     } as any,
     resolveForge: () => forge as any,
     service: {
@@ -626,6 +647,9 @@ test("status payload carries sessionId on rebase_cap hold", async () => {
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
       isEpicIntegratedChild: () => false,
+      getEpicRun: () => null,
+      getEpicIntegrationBranch: () => null,
+      recordEpicIntegrated: mock(() => {}),
     } as any,
     worktree: { behindBase: async () => true } as any,
     emitStatus,
@@ -653,6 +677,9 @@ test("rebase steer references origin/<baseBranch> from the session", async () =>
       setAutoMergeState: mock(() => {}),
       setAutopilotState: mock(() => {}),
       isEpicIntegratedChild: () => false,
+      getEpicRun: () => null,
+      getEpicIntegrationBranch: () => null,
+      recordEpicIntegrated: mock(() => {}),
     } as any,
     worktree: { behindBase: async () => true } as any,
     service: {
@@ -666,4 +693,61 @@ test("rebase steer references origin/<baseBranch> from the session", async () =>
   await svc.pump("/r");
   expect(reply.mock.calls.length).toBe(1);
   expect((reply as any).mock.calls[0][1]).toContain("origin/develop-trunk");
+});
+
+// ── #1401: doMerge records epic integration BEFORE settle ────────────────────
+
+test("doMerge: epic child records epic_integrated (pinned base) BEFORE archive", async () => {
+  const order: string[] = [];
+  const session = baseSession({ issueNumber: 12 });
+  const d = deps({
+    store: {
+      get: () => session as any,
+      list: () => [session as any],
+      getRepoConfig: () =>
+        ({ autoMergeEnabled: true, criticEnabled: false, autopilotEnabled: true }) as any,
+      getReview: () => null,
+      setAutoMergeState: mock(() => {}),
+      setAutopilotState: mock(() => {}),
+      isEpicIntegratedChild: () => false,
+      getEpicRun: () => ({ repoPath: "/r", parentIssueNumber: 5, mode: "auto", status: "running" }),
+      getEpicIntegrationBranch: () => "epic/5-x",
+      recordEpicIntegrated: mock(() => order.push("record")),
+    } as any,
+    prCache: {
+      snapshot: () => ({
+        s1: {
+          state: "open",
+          checks: "success",
+          mergeable: true,
+          number: 7,
+          headSha: "h1",
+          url: "http://pr/7",
+          baseRefName: "epic/5-x",
+        },
+      }),
+    } as any,
+    service: {
+      archive: mock(() => {
+        order.push("archive");
+        return 1;
+      }),
+      reply: mock(() => true),
+      resume: mock(() => true),
+      resolveMerging: mock(() => {}),
+    } as any,
+  });
+  const svc = new AutoMergeService(d);
+  await svc.pump("/r");
+  expect((d.store.recordEpicIntegrated as any).mock.calls).toEqual([
+    ["/r", 5, 12, { number: 7, url: "http://pr/7" }, "epic/5-x"],
+  ]);
+  expect(order).toEqual(["record", "archive"]); // #1037: row exists before settle reads it
+});
+
+test("doMerge: non-epic repo (no epic run) records nothing", async () => {
+  const d = deps();
+  const svc = new AutoMergeService(d);
+  await svc.pump("/r");
+  expect((d.store.recordEpicIntegrated as any).mock.calls.length).toBe(0);
 });

--- a/test/drain-epic-reconcile.test.ts
+++ b/test/drain-epic-reconcile.test.ts
@@ -1,0 +1,397 @@
+import { test, expect, describe } from "bun:test";
+import { DrainService } from "../src/drain";
+import { SessionStore } from "../src/store";
+import type { GitForge, GitState, Issue, PrStatus, SubIssueRef } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
+import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
+
+const REPO = "/repo";
+const PARENT = 128;
+const PINNED = "epic/128-feat-review";
+const ACTIVE_LABEL = "shepherd:active";
+
+const NO_USAGE: UsageLimitsType = {
+  session5h: null,
+  week: null,
+  perModelWeek: [],
+  credits: null,
+  stale: false,
+  calibratedAt: null,
+  subscriptionOnly: false,
+};
+
+function sub(number: number, closed: boolean, claimed = false): SubIssueRef {
+  return {
+    number,
+    title: `child ${number}`,
+    url: `https://x/${number}`,
+    body: "",
+    closed,
+    labels: claimed ? [ACTIVE_LABEL] : [],
+  };
+}
+
+interface Harness {
+  store: SessionStore;
+  drain: DrainService;
+  /** branch → PrStatus (or a thrower); branches without an entry resolve state:"none". */
+  prByBranch: Map<string, PrStatus | (() => never)>;
+  /** Every branch prStatus was called with, in order. */
+  prStatusCalls: string[];
+  closeIssueCalls: number[];
+  archiveCalls: string[];
+  prSnap: Record<string, GitState>;
+  clock: { now: number };
+}
+
+function makeHarness(opts: {
+  subIssues: SubIssueRef[];
+  epicStatus?: "running" | "paused" | null;
+}): Harness {
+  const store = new SessionStore(":memory:");
+  store.setRepoConfig(REPO, {
+    criticEnabled: false,
+    criticAllPrs: false,
+    autoAddressEnabled: false,
+    learningsEnabled: true,
+    autopilotEnabled: false,
+    planGateEnabled: false,
+    autoDrainEnabled: true,
+    autoMergeEnabled: false,
+    buildQueueEnabled: false,
+    draftMode: false,
+    signoffAuthority: "human",
+    maxAuto: 2,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+    sandboxProfile: "trusted",
+    defaultModel: "inherit",
+    egressExtraHosts: [],
+    repoMode: "forge",
+    autoOptimizeFlagged: false,
+    manualStepsIssueEnabled: false,
+    hidden: false,
+  });
+  if (opts.epicStatus !== null) {
+    store.setEpicRun({
+      repoPath: REPO,
+      parentIssueNumber: PARENT,
+      mode: "auto",
+      status: opts.epicStatus ?? "running",
+    });
+    // Pin explicitly so tests control the exact integration-branch name.
+    store.getOrInitEpicIntegrationBranch(REPO, PARENT, PINNED);
+  }
+
+  const prByBranch = new Map<string, PrStatus | (() => never)>();
+  const prStatusCalls: string[] = [];
+  const closeIssueCalls: number[] = [];
+  const archiveCalls: string[] = [];
+  const prSnap: Record<string, GitState> = {};
+  const clock = { now: 1_000_000 };
+
+  const forge: GitForge = {
+    kind: "github",
+    slug: "o/r",
+    mergeMethod: "squash",
+    deployWorkflow: null,
+    listIssues: async () => [],
+    listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
+    prStatus: async (branch: string): Promise<PrStatus> => {
+      prStatusCalls.push(branch);
+      const hit = prByBranch.get(branch);
+      if (typeof hit === "function") return hit();
+      return hit ?? ({ state: "none", checks: "none", deployConfigured: false } as PrStatus);
+    },
+    openPr: async () =>
+      ({
+        state: "open",
+        number: 999,
+        url: "https://x/pull/999",
+        checks: "none",
+        deployConfigured: false,
+      }) as PrStatus,
+    defaultBranch: async () => "main",
+    merge: async () => {},
+    redeploy: async () => {},
+    postReview: async () => ({}) as never,
+    closeIssue: async (n: number) => {
+      closeIssueCalls.push(n);
+    },
+    ensureIssueLink: async () => {},
+    addIssueLabel: async () => {},
+    removeIssueLabel: async () => {},
+    getIssue: async (n: number): Promise<Issue | null> =>
+      n === PARENT
+        ? {
+            number: PARENT,
+            title: "feat review",
+            body: "epic body",
+            url: `https://x/${PARENT}`,
+            labels: [],
+            createdAt: 0,
+            assignees: [],
+          }
+        : null,
+    listSubIssues: async () => opts.subIssues,
+    listBlockedBy: async () => [],
+  };
+
+  const drain = new DrainService({
+    store,
+    service: {
+      create: async () => {
+        throw new Error("spawn not expected in these tests");
+      },
+      archive: async (id: string) => {
+        archiveCalls.push(id);
+        return store.archive(id);
+      },
+    } as never,
+    resolveForge: () => forge,
+    prCache: { snapshot: () => prSnap },
+    usage: { limits: (): UsageLimitsType => NO_USAGE },
+    repos: () => [REPO],
+    emitStatus: () => {},
+    emitArchived: () => {},
+    dropPrCache: () => {},
+    emitEpic: () => {},
+    emitEpicCompleted: () => {},
+    now: () => clock.now,
+    rebaseCap: 5,
+  });
+
+  return { store, drain, prByBranch, prStatusCalls, closeIssueCalls, archiveCalls, prSnap, clock };
+}
+
+function addSession(
+  h: Harness,
+  over: { branch: string; auto: boolean; issueNumber: number; archived?: boolean },
+) {
+  const s = h.store.create({
+    name: over.branch,
+    prompt: "p",
+    repoPath: REPO,
+    baseBranch: PINNED,
+    branch: over.branch,
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "t",
+    auto: over.auto,
+    issueNumber: over.issueNumber,
+  });
+  if (over.archived) h.store.archive(s.id);
+  return s;
+}
+
+function mergedGit(over: Partial<GitState> = {}): GitState {
+  return {
+    kind: "github",
+    state: "merged",
+    number: 176,
+    url: "https://x/pull/176",
+    baseRefName: PINNED,
+    checks: "none",
+    deployConfigured: false,
+    ...over,
+  } as GitState;
+}
+
+// ── event-time recording (#1401): merged observations record BEFORE the auto gate ──
+
+describe("event-time epic-integration recording", () => {
+  test("manual (auto=0) session merged out-of-band → row recorded, session untouched", async () => {
+    const h = makeHarness({ subIssues: [sub(133, true), sub(134, false, true)] });
+    const s = addSession(h, { branch: "shepherd/134-manual", auto: false, issueNumber: 134 });
+
+    await h.drain.onGit(s.id, mergedGit());
+
+    expect(h.store.isEpicIntegratedChild(REPO, 134)).toBe(true);
+    const details = h.store.listEpicIntegratedDetails(REPO, PARENT);
+    expect(details).toHaveLength(1);
+    expect(details[0]).toMatchObject({
+      childNumber: 134,
+      prNumber: 176,
+      prUrl: "https://x/pull/176",
+      mergedBase: PINNED,
+    });
+    // The drain still leaves manual sessions alone (no reap/archive/close).
+    expect(h.archiveCalls).toHaveLength(0);
+    expect(h.closeIssueCalls).toHaveLength(0);
+  });
+
+  test("auto session reap: records first, then settles ARCHIVE-ONLY (no out-of-band close, #1037)", async () => {
+    const h = makeHarness({ subIssues: [sub(133, true), sub(134, false, true)] });
+    const s = addSession(h, { branch: "shepherd/134-auto", auto: true, issueNumber: 134 });
+
+    await h.drain.onGit(s.id, mergedGit());
+
+    expect(h.store.isEpicIntegratedChild(REPO, 134)).toBe(true);
+    expect(h.archiveCalls).toEqual([s.id]); // settled
+    expect(h.closeIssueCalls).toHaveLength(0); // close reserved for the landing PR merge
+  });
+
+  test("merged into a non-pinned base → no row; auto settle closes the issue as before", async () => {
+    const h = makeHarness({ subIssues: [sub(133, true), sub(134, false, true)] });
+    const s = addSession(h, { branch: "shepherd/134-auto", auto: true, issueNumber: 134 });
+
+    await h.drain.onGit(s.id, mergedGit({ baseRefName: "main" }));
+
+    expect(h.store.isEpicIntegratedChild(REPO, 134)).toBe(false);
+    expect(h.closeIssueCalls).toEqual([134]); // normal non-epic-child settle
+    expect(h.archiveCalls).toEqual([s.id]);
+  });
+});
+
+// ── reconcile sweep (#1401): tick() backfills stalled children ──────────────────
+
+describe("reconcileEpicIntegrations", () => {
+  test("acceptance shape (#128): dead predecessor row first, merged manual respawn second → probes BOTH branches, backfills, epic completes + landing PR opens in the same tick", async () => {
+    const h = makeHarness({ subIssues: [sub(133, true), sub(134, false, true)] });
+    // Older dead auto session: spawned first, died without a PR. createdAt-ordered store.list()
+    // returns it BEFORE the respawn — first-match would probe only this branch and miss the fix.
+    addSession(h, {
+      branch: "shepherd/134-attempt-1",
+      auto: true,
+      issueNumber: 134,
+      archived: true,
+    });
+    // Newer manual respawn whose PR actually merged into the pinned branch (TASK-1249 shape).
+    addSession(h, { branch: "shepherd/134-manual", auto: false, issueNumber: 134, archived: true });
+    h.prByBranch.set("shepherd/134-manual", {
+      state: "merged",
+      number: 176,
+      url: "https://x/pull/176",
+      baseRefName: PINNED,
+      checks: "none",
+      deployConfigured: false,
+    } as PrStatus);
+
+    await h.drain.tick();
+
+    // Both distinct branches probed, in row order.
+    expect(h.prStatusCalls.slice(0, 2)).toEqual(["shepherd/134-attempt-1", "shepherd/134-manual"]);
+    // Row backfilled with the merged PR's facts.
+    const details = h.store.listEpicIntegratedDetails(REPO, PARENT);
+    expect(details).toHaveLength(1);
+    expect(details[0]).toMatchObject({ childNumber: 134, prNumber: 176, mergedBase: PINNED });
+    // The normal pipeline took over: epic completed → landing PR opened — all within one tick.
+    expect(h.store.getEpicRun(REPO)?.status).toBe("idle");
+    const completed = h.store.listEpicCompleted(REPO);
+    expect(completed).toHaveLength(1);
+    expect(completed[0]!.landingState).toBe("open");
+    expect(completed[0]!.landingPrNumber).toBe(999);
+  });
+
+  test("throttle: no re-probe within EPIC_RECONCILE_TTL_MS; probes again after it", async () => {
+    const h = makeHarness({ subIssues: [sub(134, false, true)] });
+    // Child's only PR is still open on the host → probe finds nothing to record.
+    addSession(h, { branch: "shepherd/134-x", auto: true, issueNumber: 134, archived: true });
+    h.prByBranch.set("shepherd/134-x", {
+      state: "open",
+      number: 176,
+      checks: "pending",
+      deployConfigured: false,
+    } as PrStatus);
+
+    await h.drain.tick();
+    const probes = () => h.prStatusCalls.filter((b) => b === "shepherd/134-x").length;
+    expect(probes()).toBe(1);
+
+    h.clock.now += 60_000; // within the 5-min TTL
+    await h.drain.tick();
+    expect(probes()).toBe(1);
+
+    h.clock.now += 5 * 60_000; // past the TTL
+    await h.drain.tick();
+    expect(probes()).toBe(2);
+  });
+
+  test("live session with an open PR in the snapshot is skipped (event-time owns it)", async () => {
+    const h = makeHarness({ subIssues: [sub(134, false, true)] });
+    const live = addSession(h, { branch: "shepherd/134-live", auto: true, issueNumber: 134 });
+    h.prSnap[live.id] = {
+      kind: "github",
+      state: "open",
+      number: 176,
+      checks: "pending",
+      deployConfigured: false,
+    } as GitState;
+
+    await h.drain.tick();
+
+    expect(h.prStatusCalls).not.toContain("shepherd/134-live");
+    expect(h.store.isEpicIntegratedChild(REPO, 134)).toBe(false);
+  });
+
+  test("merged into the wrong base → no record", async () => {
+    const h = makeHarness({ subIssues: [sub(134, false, true)] });
+    addSession(h, { branch: "shepherd/134-x", auto: true, issueNumber: 134, archived: true });
+    h.prByBranch.set("shepherd/134-x", {
+      state: "merged",
+      number: 176,
+      baseRefName: "main",
+      checks: "none",
+      deployConfigured: false,
+    } as PrStatus);
+
+    await h.drain.tick();
+
+    expect(h.prStatusCalls).toContain("shepherd/134-x");
+    expect(h.store.isEpicIntegratedChild(REPO, 134)).toBe(false);
+    expect(h.store.getEpicRun(REPO)?.status).toBe("running"); // still stalled, fail-closed
+  });
+
+  test("probe error on one branch → warns, continues, records from the next", async () => {
+    const h = makeHarness({ subIssues: [sub(133, true), sub(134, false, true)] });
+    addSession(h, { branch: "shepherd/134-broken", auto: true, issueNumber: 134, archived: true });
+    addSession(h, { branch: "shepherd/134-good", auto: false, issueNumber: 134, archived: true });
+    h.prByBranch.set("shepherd/134-broken", () => {
+      throw new Error("api down");
+    });
+    h.prByBranch.set("shepherd/134-good", {
+      state: "merged",
+      number: 176,
+      url: "https://x/pull/176",
+      baseRefName: PINNED,
+      checks: "none",
+      deployConfigured: false,
+    } as PrStatus);
+
+    await h.drain.tick();
+
+    expect(h.store.isEpicIntegratedChild(REPO, 134)).toBe(true);
+  });
+
+  test("paused epic: sweep still backfills, but no completion until resumed", async () => {
+    const h = makeHarness({
+      subIssues: [sub(133, true), sub(134, false, true)],
+      epicStatus: "paused",
+    });
+    addSession(h, { branch: "shepherd/134-x", auto: false, issueNumber: 134, archived: true });
+    h.prByBranch.set("shepherd/134-x", {
+      state: "merged",
+      number: 176,
+      baseRefName: PINNED,
+      checks: "none",
+      deployConfigured: false,
+    } as PrStatus);
+
+    await h.drain.tick();
+
+    expect(h.store.isEpicIntegratedChild(REPO, 134)).toBe(true);
+    expect(h.store.getEpicRun(REPO)?.status).toBe("paused");
+    expect(h.store.listEpicCompleted(REPO)).toHaveLength(0);
+  });
+
+  test("no active epic → zero probes", async () => {
+    const h = makeHarness({ subIssues: [], epicStatus: null });
+    addSession(h, { branch: "shepherd/134-x", auto: true, issueNumber: 134, archived: true });
+
+    await h.drain.tick();
+
+    expect(h.prStatusCalls).toHaveLength(0);
+  });
+});

--- a/test/merge-teardown.test.ts
+++ b/test/merge-teardown.test.ts
@@ -1,5 +1,10 @@
 import { test, expect, mock } from "bun:test";
-import { settleMergedSession, type MergeTeardownDeps } from "../src/merge-teardown";
+import {
+  recordEpicIntegrationIfChild,
+  settleMergedSession,
+  type EpicIntegrationStore,
+  type MergeTeardownDeps,
+} from "../src/merge-teardown";
 
 function deps(over: Partial<MergeTeardownDeps> = {}): MergeTeardownDeps {
   return {
@@ -53,4 +58,138 @@ test("manual session (no issue): archives, no close, no retain", async () => {
   expect(close.mock.calls.length).toBe(0);
   expect((d.archive as any).mock.calls.length).toBe(1);
   expect((d.retainClaim as any).mock.calls.length).toBe(0);
+});
+
+// ── recordEpicIntegrationIfChild (#1401) ─────────────────────────────────────
+
+const PINNED = "epic/7-thing";
+
+function recStore(over: Partial<Record<keyof EpicIntegrationStore, unknown>> = {}) {
+  return {
+    getEpicRun: mock(() => ({
+      repoPath: "/r",
+      parentIssueNumber: 7,
+      mode: "autonomous",
+      status: "running",
+    })),
+    getEpicIntegrationBranch: mock(() => PINNED),
+    recordEpicIntegrated: mock(() => {}),
+    ...over,
+  } as unknown as EpicIntegrationStore;
+}
+
+function child(over: Record<string, unknown> = {}) {
+  return { id: "s1", issueNumber: 12, repoPath: "/r", baseBranch: PINNED, ...over } as any;
+}
+
+test("record: merged child PR on the pinned base records (with PR facts)", async () => {
+  const store = recStore();
+  await recordEpicIntegrationIfChild(
+    child(),
+    { number: 44, url: "http://pr/44", baseRefName: PINNED },
+    { store },
+  );
+  expect((store.recordEpicIntegrated as any).mock.calls).toEqual([
+    ["/r", 7, 12, { number: 44, url: "http://pr/44" }, PINNED],
+  ]);
+});
+
+test("record: NOT gated on s.auto — a manual (auto=0) session records too", async () => {
+  const store = recStore();
+  await recordEpicIntegrationIfChild(
+    child({ auto: false }),
+    { number: 44, url: "u", baseRefName: PINNED },
+    { store },
+  );
+  expect((store.recordEpicIntegrated as any).mock.calls.length).toBe(1);
+});
+
+test("no-op: session without an issueNumber", async () => {
+  const store = recStore();
+  await recordEpicIntegrationIfChild(
+    child({ issueNumber: null }),
+    { number: 44, baseRefName: PINNED },
+    { store },
+  );
+  expect((store.recordEpicIntegrated as any).mock.calls.length).toBe(0);
+});
+
+test("no-op: no epic run / idle epic run", async () => {
+  for (const run of [null, { repoPath: "/r", parentIssueNumber: 7, mode: "a", status: "idle" }]) {
+    const store = recStore({ getEpicRun: mock(() => run) });
+    await recordEpicIntegrationIfChild(child(), { number: 44, baseRefName: PINNED }, { store });
+    expect((store.recordEpicIntegrated as any).mock.calls.length).toBe(0);
+  }
+});
+
+test("record: paused epic still records (mirrors the retire path's epicActive)", async () => {
+  const store = recStore({
+    getEpicRun: mock(() => ({ repoPath: "/r", parentIssueNumber: 7, mode: "a", status: "paused" })),
+  });
+  await recordEpicIntegrationIfChild(child(), { number: 44, baseRefName: PINNED }, { store });
+  expect((store.recordEpicIntegrated as any).mock.calls.length).toBe(1);
+});
+
+test("no-op: unpinned integration branch", async () => {
+  const store = recStore({ getEpicIntegrationBranch: mock(() => null) });
+  await recordEpicIntegrationIfChild(child(), { number: 44, baseRefName: PINNED }, { store });
+  expect((store.recordEpicIntegrated as any).mock.calls.length).toBe(0);
+});
+
+test("no-op: base mismatch, incl. a divergent epic/* base (fail-closed)", async () => {
+  for (const base of ["main", "epic/7-old-title"]) {
+    const store = recStore();
+    await recordEpicIntegrationIfChild(child(), { number: 44, baseRefName: base }, { store });
+    expect((store.recordEpicIntegrated as any).mock.calls.length).toBe(0);
+  }
+});
+
+test("fallback: missing baseRefName resolves via number-keyed prReviewMeta", async () => {
+  const store = recStore();
+  const forge = { prReviewMeta: mock(async () => ({ baseRefName: PINNED })) } as any;
+  await recordEpicIntegrationIfChild(child(), { number: 44, url: "u" }, { store, forge });
+  expect(forge.prReviewMeta.mock.calls).toEqual([[44]]);
+  expect((store.recordEpicIntegrated as any).mock.calls.length).toBe(1);
+});
+
+test("fail closed: base-capable forge with unresolvable base does NOT record", async () => {
+  // prReviewMeta returns null (PR not found) and prReviewMeta throws — both no-record.
+  for (const meta of [async () => null, async () => Promise.reject(new Error("api down"))]) {
+    const store = recStore();
+    await recordEpicIntegrationIfChild(
+      child(),
+      { number: 44 },
+      { store, forge: { prReviewMeta: meta } as any },
+    );
+    expect((store.recordEpicIntegrated as any).mock.calls.length).toBe(0);
+  }
+});
+
+test("carve-out: base-incapable forge (no prReviewMeta) trusts s.baseBranch", async () => {
+  const store = recStore();
+  await recordEpicIntegrationIfChild(
+    child(),
+    { number: 44, url: "u" },
+    { store, forge: {} as any },
+  );
+  expect((store.recordEpicIntegrated as any).mock.calls).toEqual([
+    ["/r", 7, 12, { number: 44, url: "u" }, PINNED],
+  ]);
+  // ...and still fails closed when the session's base is not the pinned branch.
+  const store2 = recStore();
+  await recordEpicIntegrationIfChild(
+    child({ baseBranch: "main" }),
+    { number: 44 },
+    { store: store2, forge: {} as any },
+  );
+  expect((store2.recordEpicIntegrated as any).mock.calls.length).toBe(0);
+});
+
+test("never throws: a throwing store is swallowed (best-effort)", async () => {
+  const store = recStore({
+    getEpicRun: mock(() => {
+      throw new Error("db locked");
+    }),
+  });
+  await recordEpicIntegrationIfChild(child(), { number: 44, baseRefName: PINNED }, { store });
 });


### PR DESCRIPTION
Closes #1401

## Problem

`retireEpicChild` was the **only** writer of `epic_integrated`. An epic-child PR that merged outside the drain's retire path (poller-observed out-of-band merge, merge train, local merge — and especially a **manual `auto=0` respawn**) never got its row, so the epic stalled `running` forever: no `epic_completed`, no landing PR, no error surfaced. Real incident: pulse epic #128 / child #134 / PR erwins-enkel/pulse#176.

## Fix

**Event-time recording** — new `recordEpicIntegrationIfChild` (`src/merge-teardown.ts`), called on every merged-PR settle path **before** `settleMergedSession` so the #1037 `isIntegratedEpicChild` guard sees the fresh row and archives-only (child issues still close only via the landing-PR merge):

- `drain.handle`/`onGit`: hoisted **above** the `!s.auto` gate — manual sessions previously never reached any settle logic at all; this is the hook that covers the #128 escape hatch.
- `AutoMergeService.doMerge` and the local `forgeMerge` path in `server.ts`.
- Gates: session has an `issueNumber`, epic run `running`/`paused`, and the merged PR's **actual base** equals the **pinned** integration branch. Base resolution: payload `baseRefName` → number-keyed `prReviewMeta` → on base-incapable forges (Gitea/local: neither exists) fall back to `s.baseBranch`, mirroring the #645 Gitea carve-out; a base-capable forge with an unresolvable base fails closed. Divergent `epic/*` bases are never recorded (fail-closed; #645 divergence warnings surface them). Idempotent upsert; never throws; ungated by `s.auto`.

**Reconcile sweep** (repairs epics stalled *before* this ships — the settle moment is one-shot and already consumed): `reconcileEpicIntegrations` runs from `drain.tick()`, throttled to one sweep per epic per 5 min; the in-memory throttle means the **first tick after a restart sweeps immediately**, so deploying is what heals #128. For each un-integrated open child it probes **all distinct branches** across the child's session rows (any status/auto — `store.list()` is createdAt-ordered, so #128's dead predecessor TASK-1248 sorts before the merged respawn TASK-1249; first-match would miss it), skips live sessions whose snapshot shows an open PR (event-time owns those), and backfills on merged + pinned-base match. The normal pipeline then completes the epic and opens the landing PR in the same tick.

Cost: zero forge calls for repos without an active epic; otherwise ≤1 branch-keyed `prStatus` per distinct not-open-PR branch per un-integrated child per 5 min.

## Pre-deploy acceptance-shape verification (read-only, done)

Confirmed against the live pulse DB + GitHub — no writes, stall left in place on purpose:
- `epic_run` /home/patrick/Work/pulse #128 `running`; `epic_integrated` rows for #130–133 only.
- Pinned `epic_branch` = `epic/128-feat-autotask-time-entry-review-correcti`.
- TASK-1249: `issueNumber=134`, `auto=0`, archived, branch `shepherd/feat-time-review-s5` → `gh pr view` resolves **MERGED** PR #176 with exactly that base.
- TASK-1248 (dead predecessor, sorts first) has **no** PR → the probe-all-branches logic is required and exercised by a dedicated two-row test.

## Tests

- `test/merge-teardown.test.ts`: full record/no-op matrix for the helper (auto=0 records, idle/unpinned/mismatch/divergent no-op, `prReviewMeta` fallback, base-incapable carve-out both ways, never-throws).
- `test/drain-epic-reconcile.test.ts`: event-time (manual merged records + session untouched; auto reap records then archive-only, no `closeIssue`; wrong base → normal close) and the sweep (two-row #128 acceptance shape probing both branches → backfill → epic completes → landing PR opens in one tick; throttle; open-PR skip; wrong-base fail-closed; probe-error continue; paused records without completing; no epic → zero probes).
- `test/automerge.test.ts`: `doMerge` records before archive (#1037 order asserted); non-epic repo records nothing.

`bun run lint`, `tsc --noEmit`, `bun test ./test` (5865 pass / 0 fail), fallow audit: clean.

```shepherd:manual-steps
- [ ] POST-MERGE: Deploy and observe pulse epic #128 self-heal with zero manual intervention: reconcile backfills child #134 (PR erwins-enkel/pulse#176) → epic completes → landing PR epic/128-feat-autotask-time-entry-review-correcti → default opens by itself
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)