### PR TITLE
docs: acknowledge Can Celik's herdr across README, docs site, landing page

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -12,7 +12,7 @@ The job to be done: parallelize many real interactive `claude` sessions without 
 
 ## Product Purpose
 
-Shepherd is self-hosted mission control for **interactive** Claude Code. It spawns genuine `claude` sessions in isolated git worktrees (via `herdr`), bridges each PTY to a browser terminal, and lets one operator observe and steer a whole herd in parallel.
+Shepherd is self-hosted mission control for **interactive** Claude Code. It spawns genuine `claude` sessions in isolated git worktrees (via [`herdr`](https://herdr.dev), [Can Celik](https://github.com/ogulcancelik)'s agent multiplexer — the substrate without which this whole project wouldn't be possible), bridges each PTY to a browser terminal, and lets one operator observe and steer a whole herd in parallel.
 
 The defining constraint is the ToS-compliance model, not a footnote: Shepherd only **observes** (reads the terminal and agent status) and **steers** (injects keystrokes into the live pane). By default it uses no Agent SDK or `claude -p`; if a feature cannot be done by typing into a real terminal, it does not ship. This model is Shepherd's **design stance** — running on the operator's own subscription through genuine interactive sessions — rather than an official Anthropic ruling; operators who prefer a clearly-compliant path can opt into metered API-key auth. This constraint shapes the product's soul, and the UI should make that interactive-terminal reality felt, not hidden behind abstraction.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > your own server, on your own subscription.
 
 Shepherd spawns genuine interactive `claude` sessions (and, in alpha, `codex` sessions) in isolated
-git worktrees (via `herdr`, the interactive-pane manager), bridges each PTY to an `xterm.js` pane in
+git worktrees (via [`herdr`](https://herdr.dev), the interactive-pane manager), bridges each PTY to an `xterm.js` pane in
 the browser, and lets one operator run many agents in parallel — observing their status and steering
 them by typing, exactly like a human at a terminal. Around those sessions it adds the engineering
 discipline that parallel agent work otherwise erodes: every plan and PR faces adversarial review,
@@ -626,6 +626,15 @@ through an ephemeral interactive session — ToS-pure, no `-p`) to learn the pla
 `%` is recomputed live from local JSONL between calibrations. No dollar figures (you're on a
 subscription); pricing is used only internally as relative weights for the limit math. Override the
 JSONL location with `CLAUDE_CONFIG_DIR` or `CLAUDE_PROJECTS_DIR` if non-default.
+
+## Acknowledgements
+
+Shepherd exists because of [herdr](https://herdr.dev), the agent multiplexer by
+[Can Celik](https://github.com/ogulcancelik) — without it, this whole project wouldn't be possible.
+herdr owns the real interactive PTYs that everything above is built on: it is what lets Shepherd
+drive genuine `claude` sessions instead of a headless SDK (the entire ToS-compliance model), and
+what lets sessions survive a Shepherd restart untouched. Thank you, Can. The source lives at
+[github.com/ogulcancelik/herdr](https://github.com/ogulcancelik/herdr).
 
 ## License
 

--- a/docs-site/src/content/docs/getting-started.md
+++ b/docs-site/src/content/docs/getting-started.md
@@ -105,7 +105,9 @@ Open <http://localhost:7330>. To expose it (e.g. via Tailscale), set
 ### Requirements
 
 - [Bun](https://bun.sh) — backend runtime + package manager
-- `herdr` on `PATH` — manages the interactive `claude` panes (owns the PTYs)
+- `herdr` on `PATH` — [Can Celik](https://github.com/ogulcancelik)'s agent
+  multiplexer ([herdr.dev](https://herdr.dev)); manages the interactive `claude`
+  panes (owns the PTYs)
 - The `claude` CLI, logged in with your Max/Pro subscription
 - Node.js — for the PTY helper subprocess
 

--- a/docs-site/src/content/docs/index.md
+++ b/docs-site/src/content/docs/index.md
@@ -31,3 +31,10 @@ agents.
   hooks, routes, and UI.
 - **[External Task API](/reference/external-task-api/)** — queue work over HTTP.
 - **[Security](/reference/security/)** — the sandbox membrane and egress firewall.
+
+## Acknowledgements
+
+Shepherd is built on [herdr](https://herdr.dev), the agent multiplexer by
+[Can Celik](https://github.com/ogulcancelik) — it owns the real interactive PTYs
+that every Shepherd session runs in, and without it this whole project wouldn't
+be possible. Thank you, Can.

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -12,6 +12,9 @@ const IMPRESSUM_URL = "/impressum";
 const PRIVACY_URL = "/privacy";
 // Operating company behind Shepherd.
 const ERWINS_ENKEL_URL = "https://www.erwins-enkel.dev/";
+// herdr credit — the agent multiplexer Shepherd is built on.
+const HERDR_URL = "https://herdr.dev";
+const HERDR_AUTHOR_URL = "https://github.com/ogulcancelik";
 ---
 
 <footer class="footer" aria-label="Site footer">
@@ -41,6 +44,14 @@ const ERWINS_ENKEL_URL = "https://www.erwins-enkel.dev/";
         rel="noopener noreferrer"
         target="_blank">Erwins Enkel GmbH</a
       >
+    </p>
+
+    <p class="credit">
+      Built on <a href={HERDR_URL} rel="noopener noreferrer" target="_blank"
+        >herdr</a
+      > by <a href={HERDR_AUTHOR_URL} rel="noopener noreferrer" target="_blank"
+        >Can Celik</a
+      > — without it, Shepherd wouldn't exist.
     </p>
 
     <p class="disclaimer">
@@ -112,17 +123,26 @@ const ERWINS_ENKEL_URL = "https://www.erwins-enkel.dev/";
     color: var(--ink-muted);
   }
 
-  .license a {
+  .credit {
+    font-size: 0.85rem;
+    color: var(--ink-muted);
+    max-width: 40rem;
+  }
+
+  .license a,
+  .credit a {
     color: var(--ink);
     border-bottom: 1px solid var(--panel-2);
     transition: border-color 0.15s ease;
   }
 
-  .license a:hover {
+  .license a:hover,
+  .credit a:hover {
     border-color: var(--green);
   }
 
-  .license a:focus-visible {
+  .license a:focus-visible,
+  .credit a:focus-visible {
     outline: 2px solid var(--green);
     outline-offset: 3px;
     border-radius: 2px;
@@ -136,7 +156,8 @@ const ERWINS_ENKEL_URL = "https://www.erwins-enkel.dev/";
 
   @media (prefers-reduced-motion: reduce) {
     .flinks a,
-    .license a {
+    .license a,
+    .credit a {
       transition: none;
     }
   }

--- a/site/src/components/LiveUpdates.astro
+++ b/site/src/components/LiveUpdates.astro
@@ -49,6 +49,17 @@ const splits: Split[] = [
         reattach</strong>. Nothing lost, no run interrupted.
       </p>
       <p class="rule">“The orchestrator is disposable. Your running agents are not.”</p>
+      <p class="credit">
+        This split exists because of <a
+          href="https://herdr.dev"
+          rel="noopener noreferrer"
+          target="_blank">herdr</a
+        >, the agent multiplexer by <a
+          href="https://github.com/ogulcancelik"
+          rel="noopener noreferrer"
+          target="_blank">Can Celik</a
+        > — without it, Shepherd wouldn't be possible.
+      </p>
     </div>
 
     <ul class="grid">
@@ -124,6 +135,34 @@ const splits: Split[] = [
     font-family: var(--font-mono);
     font-size: 0.95rem;
     color: var(--ink-muted);
+  }
+
+  .credit {
+    margin-top: 1rem;
+    font-size: 0.9rem;
+    color: var(--ink-muted);
+  }
+
+  .credit a {
+    color: var(--ink);
+    border-bottom: 1px solid var(--panel-2);
+    transition: border-color 0.15s ease;
+  }
+
+  .credit a:hover {
+    border-color: var(--green);
+  }
+
+  .credit a:focus-visible {
+    outline: 2px solid var(--green);
+    outline-offset: 3px;
+    border-radius: 2px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .credit a {
+      transition: none;
+    }
   }
 
   .grid {


### PR DESCRIPTION
## What

Adds a warm, genuine acknowledgement that Shepherd wouldn't be possible without **herdr** by **Can Celik** ([herdr.dev](https://herdr.dev), [github.com/ogulcancelik](https://github.com/ogulcancelik)) to every doc surface:

- **README.md** — new `## Acknowledgements` section before `## License`; first prose mention of herdr now links to herdr.dev (tool-name anchor; the existing line-104 installer-origin link is deliberately untouched).
- **PRODUCT.md** — credit woven into the Product Purpose `(via herdr)` mention.
- **docs-site** (docs.shepherd.run) — Acknowledgements section on the index; credit in getting-started's herdr requirements bullet.
- **Landing page** (shepherd.run) — credit sentence in the LiveUpdates "claim" block (the section that already explains the herdr/Shepherd split) and a credit line in the Footer next to license/disclaimer. Both reuse the site's existing CSS custom properties and link styles; no new colors/sizes.

## Name verification

Chosen public spelling is exactly **"Can Celik"** (no diacritics), verified against three independent sources: GitHub profile display name, herdr commit bylines ("Can Celik"/"Ogulcan Celik", both diacritic-free), and his blog oddbit.ai (8× "Can Celik", 0× "Çelik"). herdr.dev carries no byline.

## Verification

- Name grep over the six files: every human-readable credit reads exactly `Can Celik`; only other matches are the correct `ogulcancelik` URLs.
- `bun run lint` (root) — clean; `prettier --check` on all six files — clean.
- `site/` `astro build` — 3 pages, complete; `docs-site/` `astro build` — 1161 pages, complete.

`[no-feature-entry]` — docs-only, no `ui/src` UX change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)