### PR TITLE
feat(settings): one-click shepherd restart from settings and plugin banners

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ import { UpdateService } from "./update";
 import { HerdrUpdateService } from "./herdr-update";
 import { CodexUpdateService } from "./codex-update";
 import { PluginUpdateService } from "./plugin-update";
+import { RestartService } from "./restart";
 import { DiagnosticsService } from "./diagnostics";
 import { TelemetryService } from "./telemetry";
 import { normalizeTelemetryConsent } from "./telemetry-consent";
@@ -2074,6 +2075,10 @@ const refreshUsage = () => calibrate();
 // watch origin/main for new commits and push the result to clients; the badge in
 // the UI keys off `behind > 0`, so it only appears when main has moved ahead.
 const updates = new UpdateService();
+
+// one-click restart of the shepherd unit (optionally herdr live-handoff first);
+// self-guarded: refuses unless this process IS the systemd unit's activation.
+const restart = new RestartService();
 const checkUpdates = async () => events.emit("update:status", await updates.check(Date.now()));
 setTimeout(checkUpdates, 3_000);
 setInterval(checkUpdates, 5 * 60 * 1000);
@@ -2241,6 +2246,7 @@ const appDeps: AppDeps = {
   // is quota-exempt, so it works even when the GraphQL bucket is at zero.
   githubRateLimit: () => fetchGithubRateLimit(ghRunnerAsync),
   updates,
+  restart,
   herdrUpdates,
   codexUpdates,
   pluginUpdates,

--- a/src/restart.ts
+++ b/src/restart.ts
@@ -1,0 +1,132 @@
+import { spawnSync } from "node:child_process";
+
+/**
+ * One-click restart of the shepherd systemd unit, optionally preceded by a
+ * graceful herdr daemon restart (`herdr server live-handoff` — panes are handed
+ * to the new server, so no agent session ends).
+ *
+ * Deliberately minimal compared to UpdateService: a successful restart kills
+ * this very process within seconds, so deploy-style exit markers / stale-log
+ * self-healing would be inert. A relaunch window debounces double-clicks and
+ * self-clears, and the transient unit's output lands in the journal
+ * (`journalctl --user -u shepherd-restart`) for post-mortems.
+ *
+ * Like the deploy (update.ts), the restart runs in a detached transient unit
+ * via `systemd-run --user`: a plain child in the service cgroup would be
+ * killed by the very `systemctl restart` it issues.
+ */
+
+/** systemd unit this shepherd runs as (matches deploy/shepherd.service). */
+const UNIT = "shepherd";
+/** transient unit name for the detached restart script */
+const RESTART_UNIT = "shepherd-restart";
+/** refuse a re-launch this soon after the last one; self-clears so a restart
+ *  that never killed us (systemctl failed inside the transient unit) can be
+ *  retried without bouncing shepherd first */
+const RELAUNCH_WINDOW_MS = 60_000;
+
+const shq = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`;
+
+/** The two-liner the transient unit runs. herdr goes FIRST so a freshly booted
+ *  shepherd finds a settled daemon instead of the mid-handoff window (ordering
+ *  is politeness, not safety — a down daemon can't trip the exit-78 preflight,
+ *  which only fires on a missing binary). `|| true` keeps a failed handoff from
+ *  blocking the shepherd restart; the old herdr server stays up in that case. */
+export function buildRestartScript(opts: { herdr: boolean }): string {
+  const lines: string[] = [];
+  if (opts.herdr) lines.push("herdr server live-handoff || true");
+  lines.push(`systemctl --user restart ${shq(UNIT)}`);
+  return lines.join("\n");
+}
+
+export interface RestartDeps {
+  /** this process's systemd invocation id; default reads $INVOCATION_ID */
+  ownInvocationId?: () => string | undefined;
+  /** the shepherd unit's live InvocationID per systemd; default asks systemctl */
+  unitInvocationId?: () => string;
+  /** inject point for tests; defaults to launching the script detached */
+  launch?: (script: string) => void;
+  /** clock inject for the relaunch window */
+  now?: () => number;
+}
+
+export class RestartService {
+  private ownInvocationId: () => string | undefined;
+  private unitInvocationId: () => string;
+  private launch: (script: string) => void;
+  private now: () => number;
+  private launchedAt = 0;
+
+  constructor(deps: RestartDeps = {}) {
+    this.ownInvocationId = deps.ownInvocationId ?? (() => process.env.INVOCATION_ID);
+    this.unitInvocationId = deps.unitInvocationId ?? defaultUnitInvocationId;
+    this.launch = deps.launch ?? defaultLaunch;
+    this.now = deps.now ?? Date.now;
+  }
+
+  /** True only when this process IS the systemd unit's current activation:
+   *  $INVOCATION_ID is stamped per activation and inherited by children (so the
+   *  check survives bun ever spawning the entry point in a subprocess), and it
+   *  must match what systemd reports for the `shepherd` unit. A dev-worktree
+   *  shepherd (terminal / herdr pane) has no or a foreign id → guarded off, so
+   *  a dev UI can never bounce the production unit. */
+  private underUnit(): boolean {
+    const own = this.ownInvocationId()?.trim();
+    if (!own) return false;
+    let unit: string;
+    try {
+      unit = this.unitInvocationId().trim();
+    } catch {
+      return false;
+    }
+    return unit.length > 0 && unit === own;
+  }
+
+  /** Kick off the detached restart. Never throws — returns a stable error code
+   *  (`not_systemd`, `already_restarting`) or the launcher's message so the UI
+   *  can map it; the caller decides the HTTP shape. */
+  apply(opts: { herdr: boolean }): { started: boolean; error?: string } {
+    if (!this.underUnit()) return { started: false, error: "not_systemd" };
+    if (this.now() - this.launchedAt < RELAUNCH_WINDOW_MS) {
+      return { started: false, error: "already_restarting" };
+    }
+    try {
+      this.launch(buildRestartScript(opts));
+    } catch (e) {
+      return {
+        started: false,
+        error: e instanceof Error ? e.message : "could not launch the restart",
+      };
+    }
+    this.launchedAt = this.now();
+    return { started: true };
+  }
+}
+
+function defaultUnitInvocationId(): string {
+  const r = spawnSync("systemctl", ["--user", "show", UNIT, "-p", "InvocationID", "--value"], {
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+  if (r.error) throw r.error;
+  if (typeof r.status === "number" && r.status !== 0) {
+    throw new Error(`systemctl show exited ${r.status}`);
+  }
+  return (r.stdout ?? "").trim();
+}
+
+/** Launch the restart script in its own transient unit so it survives the
+ *  `systemctl restart shepherd` it issues (same pattern as update.ts). PATH is
+ *  forwarded because a transient --user unit gets a bare environment but the
+ *  script needs herdr + systemctl. Output goes to the journal via --collect. */
+function defaultLaunch(script: string): void {
+  const args = ["--user", "--collect", `--unit=${RESTART_UNIT}`];
+  if (process.env.PATH) args.push(`--setenv=PATH=${process.env.PATH}`);
+  args.push("bash", "-c", script);
+  const r = spawnSync("systemd-run", args, { stdio: ["ignore", "ignore", "pipe"] });
+  if (r.error) throw new Error(`could not launch the restart: ${r.error.message}`);
+  if (typeof r.status === "number" && r.status !== 0) {
+    const stderr = r.stderr?.toString().trim();
+    throw new Error(`restart launcher exited ${r.status}${stderr ? `: ${stderr}` : ""}`);
+  }
+}

--- a/src/restart.ts
+++ b/src/restart.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { config } from "./config";
 
 /**
  * One-click restart of the shepherd systemd unit, optionally preceded by a
@@ -31,10 +32,12 @@ const shq = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`;
  *  shepherd finds a settled daemon instead of the mid-handoff window (ordering
  *  is politeness, not safety — a down daemon can't trip the exit-78 preflight,
  *  which only fires on a missing binary). `|| true` keeps a failed handoff from
- *  blocking the shepherd restart; the old herdr server stays up in that case. */
-export function buildRestartScript(opts: { herdr: boolean }): string {
+ *  blocking the shepherd restart; the old herdr server stays up in that case.
+ *  `herdrBin` is the configured binary (HERDR_BIN / config.herdrBin) — a
+ *  custom-binary install must hand off via the same herdr it runs. */
+export function buildRestartScript(opts: { herdr: boolean }, herdrBin = config.herdrBin): string {
   const lines: string[] = [];
-  if (opts.herdr) lines.push("herdr server live-handoff || true");
+  if (opts.herdr) lines.push(`${shq(herdrBin)} server live-handoff || true`);
   lines.push(`systemctl --user restart ${shq(UNIT)}`);
   return lines.join("\n");
 }
@@ -48,6 +51,8 @@ export interface RestartDeps {
   launch?: (script: string) => void;
   /** clock inject for the relaunch window */
   now?: () => number;
+  /** herdr binary for the live-handoff line; defaults to config.herdrBin */
+  herdrBin?: string;
 }
 
 export class RestartService {
@@ -55,6 +60,7 @@ export class RestartService {
   private unitInvocationId: () => string;
   private launch: (script: string) => void;
   private now: () => number;
+  private herdrBin: string;
   private launchedAt = 0;
 
   constructor(deps: RestartDeps = {}) {
@@ -62,6 +68,7 @@ export class RestartService {
     this.unitInvocationId = deps.unitInvocationId ?? defaultUnitInvocationId;
     this.launch = deps.launch ?? defaultLaunch;
     this.now = deps.now ?? Date.now;
+    this.herdrBin = deps.herdrBin ?? config.herdrBin;
   }
 
   /** True only when this process IS the systemd unit's current activation:
@@ -91,7 +98,7 @@ export class RestartService {
       return { started: false, error: "already_restarting" };
     }
     try {
-      this.launch(buildRestartScript(opts));
+      this.launch(buildRestartScript(opts, this.herdrBin));
     } catch (e) {
       return {
         started: false,

--- a/src/server.ts
+++ b/src/server.ts
@@ -108,6 +108,7 @@ import type { UpdateService } from "./update";
 import type { HerdrUpdateService } from "./herdr-update";
 import type { CodexUpdateService } from "./codex-update";
 import type { PluginUpdateService } from "./plugin-update";
+import type { RestartService } from "./restart";
 import type { DiagnosticsService } from "./diagnostics";
 import type { VerifyKeyResult } from "./verify-key";
 import type { StarPromptStatus } from "./star-prompt";
@@ -262,6 +263,9 @@ export interface AppDeps {
    *  an on-demand re-scan, `apply()` to fetch-and-swap a plugin's new version on disk
    *  (issue #1124); absent when unwired. */
   pluginUpdates?: Pick<PluginUpdateService, "current" | "apply" | "check">;
+  /** one-click shepherd restart (optionally with a herdr live-handoff first);
+   *  absent in environments where it isn't wired (tests). */
+  restart?: Pick<RestartService, "apply">;
   /** environment-readiness diagnostics (issue #623); absent in tests that don't wire it. */
   diagnostics?: Pick<DiagnosticsService, "current" | "check" | "fix">;
   /** GitHub-star nudge: tracks first-use + the operator's choice, stars the repo
@@ -3595,6 +3599,29 @@ function handleCodexUpdate({ req, parts, deps }: Ctx): Response | null {
   return json({ ok: r.started }, r.started ? 202 : 409);
 }
 
+// ── shepherd restart: relaunch the systemd unit on demand ──────────────
+// POST /api/restart `{ herdr?: boolean }` → 202 once the detached restart is
+// launched. `herdr: true` runs a graceful `herdr server live-handoff` first
+// (panes survive). No GET: the UI detects completion by /api/health answering
+// again after the restart. Errors carry a stable code (`not_systemd` when this
+// process isn't the systemd unit — e.g. a dev worktree — so a dev UI can never
+// bounce the production instance).
+async function handleRestart({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (!(parts[0] === "api" && parts[1] === "restart" && !parts[2])) return null;
+  if (req.method !== "POST") return null;
+  if (!deps.restart) return json({ started: false, error: "not_available" }, 503);
+  let herdr = false;
+  try {
+    const body = (await req.json()) as { herdr?: unknown };
+    herdr = body?.herdr === true;
+  } catch {
+    // an empty/absent body is a plain shepherd-only restart
+  }
+  const r = deps.restart.apply({ herdr });
+  if (r.started) return json({ started: true }, 202);
+  return json({ started: false, error: r.error ?? "could not start the restart" }, 409);
+}
+
 // ── plugin update: status (informational) + on-demand check + in-place apply ──
 //  - GET  /api/plugin-update        → PluginUpdatesStatus (cached snapshot; badge/list)
 //  - POST /api/plugin-update/check  → force a fresh scan NOW, broadcast the snapshot on
@@ -6248,6 +6275,7 @@ const ROUTE_HANDLERS = [
   handleHerdrUpdate,
   handleCodexUpdate,
   handlePluginUpdate,
+  handleRestart,
   handleDiagnostics,
   handleDiagnosticsFix,
   handleStarPrompt,

--- a/test/restart.test.ts
+++ b/test/restart.test.ts
@@ -1,0 +1,87 @@
+import { test, expect } from "bun:test";
+import { RestartService, buildRestartScript, type RestartDeps } from "../src/restart";
+
+/** Service that IS the systemd unit (matching invocation ids) with an
+ *  injectable launch + clock; overrides let each test break one leg. */
+function makeService(overrides: RestartDeps = {}) {
+  const launched: string[] = [];
+  const svc = new RestartService({
+    ownInvocationId: () => "abc-123",
+    unitInvocationId: () => "abc-123\n",
+    launch: (script) => launched.push(script),
+    now: () => 1_000_000,
+    ...overrides,
+  });
+  return { svc, launched };
+}
+
+test("plain restart: launches the systemctl-only script", () => {
+  const { svc, launched } = makeService();
+  expect(svc.apply({ herdr: false })).toEqual({ started: true });
+  expect(launched).toHaveLength(1);
+  expect(launched[0]).toBe("systemctl --user restart 'shepherd'");
+});
+
+test("herdr restart: live-handoff runs BEFORE the shepherd restart", () => {
+  const { svc, launched } = makeService();
+  expect(svc.apply({ herdr: true }).started).toBe(true);
+  const lines = launched[0]!.split("\n");
+  expect(lines[0]).toBe("herdr server live-handoff || true");
+  expect(lines[1]).toBe("systemctl --user restart 'shepherd'");
+});
+
+test("no own INVOCATION_ID (dev worktree) → not_systemd, nothing launched", () => {
+  const { svc, launched } = makeService({ ownInvocationId: () => undefined });
+  expect(svc.apply({ herdr: false })).toEqual({ started: false, error: "not_systemd" });
+  expect(launched).toHaveLength(0);
+});
+
+test("foreign INVOCATION_ID (child of another unit) → not_systemd", () => {
+  const { svc, launched } = makeService({ ownInvocationId: () => "other-unit-id" });
+  expect(svc.apply({ herdr: false }).error).toBe("not_systemd");
+  expect(launched).toHaveLength(0);
+});
+
+test("systemctl show failing (no systemd at all) → not_systemd, not a throw", () => {
+  const { svc } = makeService({
+    unitInvocationId: () => {
+      throw new Error("System has not been booted with systemd");
+    },
+  });
+  expect(svc.apply({ herdr: false })).toEqual({ started: false, error: "not_systemd" });
+});
+
+test("double-click inside the relaunch window → already_restarting", () => {
+  const { svc, launched } = makeService();
+  expect(svc.apply({ herdr: false }).started).toBe(true);
+  expect(svc.apply({ herdr: false })).toEqual({ started: false, error: "already_restarting" });
+  expect(launched).toHaveLength(1);
+});
+
+test("relaunch window self-clears: a restart that never killed us can be retried", () => {
+  let now = 1_000_000;
+  const { svc, launched } = makeService({ now: () => now });
+  expect(svc.apply({ herdr: false }).started).toBe(true);
+  now += 61_000; // past RELAUNCH_WINDOW_MS
+  expect(svc.apply({ herdr: false }).started).toBe(true);
+  expect(launched).toHaveLength(2);
+});
+
+test("launcher failure surfaces its message and does NOT arm the debounce", () => {
+  let fail = true;
+  const { svc, launched } = makeService({
+    launch: (script) => {
+      if (fail) throw new Error("systemd-run missing");
+      launched.push(script);
+    },
+  });
+  expect(svc.apply({ herdr: false })).toEqual({ started: false, error: "systemd-run missing" });
+  fail = false;
+  // an immediate retry must work — the failed launch must not count as "restarting"
+  expect(svc.apply({ herdr: false }).started).toBe(true);
+});
+
+test("buildRestartScript omits herdr line unless asked", () => {
+  expect(buildRestartScript({ herdr: false })).not.toContain("herdr");
+  expect(buildRestartScript({ herdr: true })).toContain("herdr server live-handoff");
+});

--- a/test/restart.test.ts
+++ b/test/restart.test.ts
@@ -10,6 +10,7 @@ function makeService(overrides: RestartDeps = {}) {
     unitInvocationId: () => "abc-123\n",
     launch: (script) => launched.push(script),
     now: () => 1_000_000,
+    herdrBin: "herdr",
     ...overrides,
   });
   return { svc, launched };
@@ -26,8 +27,14 @@ test("herdr restart: live-handoff runs BEFORE the shepherd restart", () => {
   const { svc, launched } = makeService();
   expect(svc.apply({ herdr: true }).started).toBe(true);
   const lines = launched[0]!.split("\n");
-  expect(lines[0]).toBe("herdr server live-handoff || true");
+  expect(lines[0]).toBe("'herdr' server live-handoff || true");
   expect(lines[1]).toBe("systemctl --user restart 'shepherd'");
+});
+
+test("herdr restart uses the configured binary, shell-quoted", () => {
+  const { svc, launched } = makeService({ herdrBin: "/opt/o'dd/herdr" });
+  expect(svc.apply({ herdr: true }).started).toBe(true);
+  expect(launched[0]!.split("\n")[0]).toBe(`'/opt/o'\\''dd/herdr' server live-handoff || true`);
 });
 
 test("no own INVOCATION_ID (dev worktree) → not_systemd, nothing launched", () => {
@@ -82,6 +89,6 @@ test("launcher failure surfaces its message and does NOT arm the debounce", () =
 });
 
 test("buildRestartScript omits herdr line unless asked", () => {
-  expect(buildRestartScript({ herdr: false })).not.toContain("herdr");
-  expect(buildRestartScript({ herdr: true })).toContain("herdr server live-handoff");
+  expect(buildRestartScript({ herdr: false }, "herdr")).not.toContain("herdr");
+  expect(buildRestartScript({ herdr: true }, "herdr")).toContain("'herdr' server live-handoff");
 });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2537,5 +2537,20 @@
   "clipboard_pill_prompt": "Terminal hat Text kopiert",
   "clipboard_pill_copy": "In Zwischenablage kopieren",
   "feat_clipboard_osc52_title": "Claudes „Kopieren“ landet jetzt in deiner Zwischenablage",
-  "feat_clipboard_osc52_body": "Wenn Claude im Terminal Text kopiert (`c to copy`), landet er jetzt in deiner System-Zwischenablage. Blockiert der Browser das automatische Schreiben, erscheint eine kleine Copy-Pille über dem Terminal zum Kopieren per Klick."
+  "feat_clipboard_osc52_body": "Wenn Claude im Terminal Text kopiert (`c to copy`), landet er jetzt in deiner System-Zwischenablage. Blockiert der Browser das automatische Schreiben, erscheint eine kleine Copy-Pille über dem Terminal zum Kopieren per Klick.",
+  "restart_title": "Shepherd neu starten",
+  "restart_settings_hint": "Startet den Shepherd-Dienst direkt neu. Laufende Agent-Sessions sind nicht betroffen — sie leben in herdr, nicht in Shepherd.",
+  "restart_button": "Neu starten…",
+  "restart_now": "Jetzt neu starten",
+  "restart_confirm_body": "Shepherd startet neu und diese Seite lädt neu, sobald er wieder da ist — normalerweise innerhalb weniger Sekunden. Laufende Agent-Sessions sind nicht betroffen.",
+  "restart_herdr_label": "Auch den herdr-Daemon neu starten",
+  "restart_herdr_note": "Der Daemon übergibt seine Panes an einen frischen Server (Live-Handoff). Agent-Sessions überleben; verbundene Terminal-Clients verbinden sich kurz neu.",
+  "restart_confirm_go": "Neu starten",
+  "restart_in_progress": "Shepherd startet neu — warte, bis er wieder da ist…",
+  "restart_timeout": "Shepherd ist nicht rechtzeitig zurückgekommen. Prüfe den Dienst oder starte ihn manuell neu:",
+  "restart_err_not_systemd": "Diese Shepherd-Instanz wird nicht von systemd verwaltet (eine Dev-Instanz?) und kann sich daher nicht selbst neu starten. Starte sie manuell neu:",
+  "restart_err_already": "Ein Neustart läuft bereits.",
+  "restart_err_generic": "Der Neustart konnte nicht gestartet werden. Starte bei anhaltenden Problemen manuell neu:",
+  "feat_restart_shepherd_title": "Shepherd direkt aus der UI neu starten",
+  "feat_restart_shepherd_body": "Einstellungen → Session hat jetzt eine „Shepherd neu starten“-Aktion, und die Plugin-Restart-Banner haben einen „Jetzt neu starten“-Button — kein Kopieren des systemctl-Befehls mehr. Optional startet auch der herdr-Daemon neu, und zwar sanft: Live-Panes werden per Handoff übergeben und überleben."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2537,5 +2537,20 @@
   "clipboard_pill_prompt": "Terminal copied text",
   "clipboard_pill_copy": "Copy to clipboard",
   "feat_clipboard_osc52_title": "Claude's \"copy\" now reaches your clipboard",
-  "feat_clipboard_osc52_body": "When Claude copies text in the terminal (`c to copy`), it now lands in your system clipboard. If the browser blocks the automatic write, a small Copy pill appears over the terminal for a one-click copy."
+  "feat_clipboard_osc52_body": "When Claude copies text in the terminal (`c to copy`), it now lands in your system clipboard. If the browser blocks the automatic write, a small Copy pill appears over the terminal for a one-click copy.",
+  "restart_title": "Restart Shepherd",
+  "restart_settings_hint": "Restart the Shepherd service in place. Running agent sessions are not affected — they live in herdr, not in Shepherd.",
+  "restart_button": "Restart…",
+  "restart_now": "Restart now",
+  "restart_confirm_body": "Shepherd restarts and this page reloads once it is back — usually within a few seconds. Running agent sessions are not affected.",
+  "restart_herdr_label": "Also restart the herdr daemon",
+  "restart_herdr_note": "The daemon hands its panes to a fresh server (live-handoff). Agent sessions survive; attached terminal clients reconnect briefly.",
+  "restart_confirm_go": "Restart",
+  "restart_in_progress": "Restarting Shepherd — waiting for it to come back…",
+  "restart_timeout": "Shepherd did not come back in time. Check the service, or restart it manually:",
+  "restart_err_not_systemd": "This Shepherd instance is not managed by systemd (a dev instance?), so it cannot restart itself. Restart it manually:",
+  "restart_err_already": "A restart is already in progress.",
+  "restart_err_generic": "Could not start the restart. Restart manually if the problem persists:",
+  "feat_restart_shepherd_title": "Restart Shepherd from the UI",
+  "feat_restart_shepherd_body": "Settings → Session now has a Restart Shepherd action, and the plugin restart banners gained a Restart-now button — no more copy-pasting the systemctl command. Optionally the herdr daemon restarts too, gracefully: live panes are handed off and survive."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1403,6 +1403,21 @@ export async function applyCodexUpdate(): Promise<void> {
   }
 }
 
+/** Restart the shepherd service in place (optionally preceded by a graceful
+ *  `herdr server live-handoff` — agent panes survive the daemon swap). 202 means
+ *  the detached restart launched; the caller detects completion by /api/health
+ *  answering again. Discriminated result — `error` is a stable server CODE
+ *  (`not_systemd`, `already_restarting`, …) the caller maps to a message. */
+export async function triggerRestart(opts: {
+  herdr: boolean;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  const r = await fetch("/api/restart", JSON_POST({ herdr: opts.herdr }));
+  if (r.ok) return { ok: true };
+  flagIfUnauthorized(r.status);
+  const body = (await r.json().catch(() => ({}))) as { error?: string };
+  return { ok: false, error: typeof body.error === "string" ? body.error : "restart_failed" };
+}
+
 /** Trigger the deploy script (pull → rebuild → restart). Server restarts on success. */
 export async function applyUpdate(): Promise<void> {
   const r = await fetch("/api/update", { method: "POST", headers: JSON_HEADERS });

--- a/ui/src/lib/components/PluginUpdatesModal.browser.test.ts
+++ b/ui/src/lib/components/PluginUpdatesModal.browser.test.ts
@@ -5,7 +5,9 @@ import "../../app.css";
 import type { PluginUpdatesStatus } from "$lib/types";
 
 const { applyMock } = vi.hoisted(() => ({ applyMock: vi.fn() }));
-vi.mock("$lib/api", () => ({ applyPluginUpdate: applyMock }));
+// triggerRestart is pulled in by the nested RestartShepherdDialog; the mock only
+// needs the export to exist for these tests (the dialog opens on click only).
+vi.mock("$lib/api", () => ({ applyPluginUpdate: applyMock, triggerRestart: vi.fn() }));
 
 import PluginUpdatesModal from "./PluginUpdatesModal.svelte";
 

--- a/ui/src/lib/components/PluginUpdatesModal.svelte
+++ b/ui/src/lib/components/PluginUpdatesModal.svelte
@@ -3,6 +3,7 @@
   import { dialog } from "$lib/a11yDialog";
   import { m } from "$lib/paraglide/messages";
   import { applyPluginUpdate } from "$lib/api";
+  import RestartShepherdDialog from "$lib/components/RestartShepherdDialog.svelte";
 
   let {
     status,
@@ -42,6 +43,7 @@
     { kind: "live" | "restart"; version: string } | { kind: "error"; msg: string; detail?: string };
   let outcome = $state<Record<string, Outcome>>({});
   let copied = $state(false);
+  let restartOpen = $state(false); // the one-click Restart-Shepherd dialog
   // True for the duration of an "Update all" serial run. Locks every per-row Update button
   // too, so a manual click can't race the bulk loop's snapshot and get re-applied under it.
   let bulk = $state(false);
@@ -164,6 +166,9 @@
         <button type="button" class="gbtn copy" onclick={copyRestart}>
           {copied ? m.plugins_copied() : m.plugins_copy()}
         </button>
+        <button type="button" class="gbtn upd" onclick={() => (restartOpen = true)}>
+          {m.restart_now()}
+        </button>
       </div>
     {/if}
 
@@ -232,6 +237,10 @@
     </div>
   </div>
 </div>
+
+{#if restartOpen}
+  <RestartShepherdDialog onclose={() => (restartOpen = false)} />
+{/if}
 
 <style>
   .overlay {

--- a/ui/src/lib/components/RestartShepherdDialog.svelte
+++ b/ui/src/lib/components/RestartShepherdDialog.svelte
@@ -1,0 +1,296 @@
+<script lang="ts">
+  import { dialog } from "$lib/a11yDialog";
+  import { m } from "$lib/paraglide/messages";
+  import { triggerRestart } from "$lib/api";
+
+  let { onclose }: { onclose?: () => void } = $props();
+
+  const RESTART_CMD = "systemctl --user restart shepherd";
+  /** give systemctl this long to take the old process down before assuming the
+   *  down-blink happened between two polls and reloading anyway */
+  const DOWN_WINDOW_MS = 30_000;
+  /** once the server was seen down, wait this long for it to come back */
+  const UP_TIMEOUT_MS = 90_000;
+  const POLL_MS = 700;
+
+  let phase = $state<"confirm" | "restarting" | "failed">("confirm");
+  let alsoHerdr = $state(false);
+  let error = $state<string | null>(null);
+
+  /** Map a stable server error CODE to a message (never render the raw code). */
+  function restartErr(code: string): string {
+    switch (code) {
+      case "not_systemd":
+        return m.restart_err_not_systemd();
+      case "already_restarting":
+        return m.restart_err_already();
+      default:
+        return m.restart_err_generic();
+    }
+  }
+
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+  /** Ride through the restart: wait for /api/health to go down, then come back,
+   *  then reload so the page reattaches (and picks up fresh assets). A restart
+   *  faster than one poll interval never shows a down sample — after
+   *  DOWN_WINDOW_MS of continuous "up" we assume the blink was missed and
+   *  reload anyway (harmless when wrong). */
+  async function rideThrough() {
+    const start = Date.now();
+    let sawDown = false;
+    for (;;) {
+      let up: boolean;
+      try {
+        up = (await fetch("/api/health", { cache: "no-store" })).ok;
+      } catch {
+        up = false;
+      }
+      if (!up) sawDown = true;
+      if (up && sawDown) break;
+      if (up && Date.now() - start > DOWN_WINDOW_MS) break;
+      if (sawDown && Date.now() - start > UP_TIMEOUT_MS) {
+        phase = "failed";
+        return;
+      }
+      await sleep(POLL_MS);
+    }
+    location.reload();
+  }
+
+  async function confirm() {
+    error = null;
+    const res = await triggerRestart({ herdr: alsoHerdr });
+    if (!res.ok) {
+      error = restartErr(res.error);
+      return;
+    }
+    phase = "restarting";
+    void rideThrough();
+  }
+
+  // the dialog blocks dismissal mid-restart: there is nothing sensible to go
+  // back to while the server is down
+  const closable = $derived(phase !== "restarting");
+</script>
+
+<div
+  class="overlay"
+  role="presentation"
+  onclick={(e) => {
+    if (e.target === e.currentTarget && closable) onclose?.();
+  }}
+>
+  <div
+    class="card bracket"
+    role="dialog"
+    aria-modal="true"
+    aria-label={m.restart_title()}
+    use:dialog={{ onclose: () => closable && onclose?.() }}
+  >
+    <div class="chead">
+      <span class="micro">{m.restart_title()}</span>
+      {#if closable}
+        <button type="button" class="x" onclick={() => onclose?.()} aria-label={m.common_close()}
+          >✕</button
+        >
+      {/if}
+    </div>
+
+    {#if phase === "confirm"}
+      <p class="body">{m.restart_confirm_body()}</p>
+      <label class="herdr">
+        <input type="checkbox" bind:checked={alsoHerdr} />
+        <span>
+          <span class="herdr-label">{m.restart_herdr_label()}</span>
+          <span class="herdr-note">{m.restart_herdr_note()}</span>
+        </span>
+      </label>
+      {#if error}
+        <div class="err" role="alert">
+          {error}
+          <code class="cmd">{RESTART_CMD}</code>
+        </div>
+      {/if}
+      <div class="actions">
+        <button type="button" class="later" onclick={() => onclose?.()}>{m.common_cancel()}</button>
+        <button type="button" class="gbtn go" onclick={confirm}>{m.restart_confirm_go()}</button>
+      </div>
+    {:else if phase === "restarting"}
+      <div class="status" aria-live="polite">{m.restart_in_progress()}</div>
+    {:else}
+      <div class="err" role="alert">
+        {m.restart_timeout()}
+        <code class="cmd">{RESTART_CMD}</code>
+      </div>
+      <div class="actions">
+        <button type="button" class="later" onclick={() => onclose?.()}>{m.common_close()}</button>
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--color-scrim);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    /* above the Settings modal (20) and the plugin-updates modal (30) — this
+       dialog is opened from inside both */
+    z-index: 40;
+    padding: 16px;
+  }
+  .card {
+    position: relative;
+    box-sizing: border-box;
+    width: min(440px, 100%);
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    background: var(--color-panel);
+    border: 1px solid var(--color-line-bright);
+    padding: 18px 18px 16px;
+    box-shadow: inset 0 0 30px -16px var(--color-blue);
+  }
+  .bracket::before,
+  .bracket::after {
+    content: "";
+    position: absolute;
+    width: 9px;
+    height: 9px;
+    border: 1px solid var(--color-line-bright);
+  }
+  .bracket::before {
+    top: 0;
+    left: 0;
+    border-right: 0;
+    border-bottom: 0;
+  }
+  .bracket::after {
+    bottom: 0;
+    right: 0;
+    border-left: 0;
+    border-top: 0;
+  }
+  .chead {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .micro {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+  .x {
+    background: transparent;
+    border: 0;
+    color: var(--color-muted);
+    cursor: pointer;
+    font-size: var(--fs-base);
+  }
+  .body {
+    margin: 0;
+    font-size: var(--fs-base);
+    line-height: 1.5;
+    color: var(--color-ink-bright);
+  }
+  .herdr {
+    display: flex;
+    align-items: flex-start;
+    gap: 9px;
+    cursor: pointer;
+    border: 1px solid var(--color-line);
+    background: var(--color-inset);
+    padding: 10px 12px;
+  }
+  .herdr input {
+    margin-top: 3px;
+    accent-color: var(--color-amber);
+  }
+  .herdr-label {
+    display: block;
+    font-size: var(--fs-base);
+    color: var(--color-ink);
+  }
+  .herdr-note {
+    display: block;
+    margin-top: 3px;
+    font-size: var(--fs-meta);
+    line-height: 1.5;
+    color: var(--color-muted);
+  }
+  .status {
+    font-size: var(--fs-base);
+    color: var(--color-amber);
+  }
+  .err {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: var(--fs-meta);
+    line-height: 1.5;
+    color: var(--color-red);
+  }
+  .cmd {
+    font-family: var(--font-mono, monospace);
+    font-size: var(--fs-micro);
+    background: var(--color-panel);
+    border: 1px solid var(--color-line);
+    padding: 3px 6px;
+    color: var(--color-ink);
+    align-self: flex-start;
+  }
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+  }
+  .later {
+    background: transparent;
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-muted);
+    padding: 8px 14px;
+    cursor: pointer;
+    letter-spacing: 0.06em;
+  }
+  .later:hover {
+    color: var(--color-amber);
+    border-color: var(--color-amber);
+  }
+  /* Base gear button recipe (from /design-system); Restart is the primary action. */
+  .gbtn {
+    border: 1px solid var(--color-line-bright);
+    background: transparent;
+    color: var(--color-ink);
+    padding: 8px 14px;
+    font: inherit;
+    font-size: var(--fs-meta);
+    letter-spacing: 0.06em;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .gbtn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+  .gbtn.go {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  @media (max-width: 768px) {
+    .later,
+    .gbtn {
+      min-height: 44px;
+      flex: 1;
+    }
+  }
+</style>

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -50,6 +50,7 @@
   import SettingsDevicePanel from "$lib/components/settings/SettingsDevicePanel.svelte";
   import SettingsDiagnosePanel from "$lib/components/settings/SettingsDiagnosePanel.svelte";
   import SettingsPluginsPanel from "$lib/components/settings/SettingsPluginsPanel.svelte";
+  import RestartShepherdDialog from "$lib/components/RestartShepherdDialog.svelte";
   import ModelGuidance from "$lib/components/ModelGuidance.svelte";
   import { dialog } from "$lib/a11yDialog";
   import { openFeedback } from "$lib/feedback-dialog.svelte";
@@ -228,6 +229,7 @@
 
   let remoteControl = $state(false); // Claude Code Remote Control auto-start in sessions
   let rcBusy = $state(false);
+  let restartOpen = $state(false); // the Restart-Shepherd confirm dialog
   let telemetryOn = $state(false);
   let telemetryAvailable = $state(false);
   let telemetryBusy = $state(false);
@@ -1456,6 +1458,13 @@
         </label>
       </div>
       <div class="rc">
+        <span class="micro">{m.restart_title()}</span>
+        <p class="hint">{m.restart_settings_hint()}</p>
+        <button type="button" class="gbtn" onclick={() => (restartOpen = true)}>
+          {m.restart_button()}
+        </button>
+      </div>
+      <div class="rc">
         <span class="micro">{m.settings_logout_title()}</span>
         <p class="hint">{m.settings_logout_hint()}</p>
         <button type="button" class="gbtn" onclick={() => logout()}>
@@ -1673,6 +1682,10 @@
     </div>
   </div>
 </div>
+
+{#if restartOpen}
+  <RestartShepherdDialog onclose={() => (restartOpen = false)} />
+{/if}
 
 <style>
   .overlay {

--- a/ui/src/lib/components/settings/SettingsPluginsPanel.svelte
+++ b/ui/src/lib/components/settings/SettingsPluginsPanel.svelte
@@ -17,6 +17,7 @@
   } from "$lib/types";
   import PluginLoadedCard from "./PluginLoadedCard.svelte";
   import PluginConfirmDialog from "./PluginConfirmDialog.svelte";
+  import RestartShepherdDialog from "$lib/components/RestartShepherdDialog.svelte";
 
   let {
     plugins = [],
@@ -59,6 +60,7 @@
   type Confirm =
     { kind: "install"; url: string } | { kind: "uninstall"; folder: string; name: string };
   let confirm = $state<Confirm | null>(null);
+  let restartOpen = $state(false); // the one-click Restart-Shepherd dialog
 
   const RESTART_CMD = "systemctl --user restart shepherd";
 
@@ -408,6 +410,9 @@
       <button type="button" class="gbtn copy" onclick={copyRestart}>
         {copied ? m.plugins_copied() : m.plugins_copy()}
       </button>
+      <button type="button" class="gbtn restart-now" onclick={() => (restartOpen = true)}>
+        {m.restart_now()}
+      </button>
     </div>
   {/if}
 
@@ -502,6 +507,10 @@
   <PluginConfirmDialog {confirm} onconfirm={onConfirm} oncancel={() => (confirm = null)} />
 {/if}
 
+{#if restartOpen}
+  <RestartShepherdDialog onclose={() => (restartOpen = false)} />
+{/if}
+
 <style>
   .plugins {
     display: flex;
@@ -582,15 +591,17 @@
   }
   .gbtn.del,
   .gbtn.copy,
+  .gbtn.restart-now,
   .gbtn.activate,
   .gbtn.check,
   .gbtn.upd {
     font-size: var(--fs-micro);
     padding: 5px 9px;
   }
-  /* Activate / Update are the row's primary action — amber accent like the install button. */
+  /* Activate / Update / Restart are the row's primary action — amber accent like the install button. */
   .gbtn.activate,
-  .gbtn.upd {
+  .gbtn.upd,
+  .gbtn.restart-now {
     border-color: var(--color-amber);
     color: var(--color-amber);
   }

--- a/ui/src/lib/feature-announcements/entries/v1.42.0-restart-shepherd.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.42.0-restart-shepherd.ts
@@ -1,0 +1,14 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // One-click Restart Shepherd: a Session-tab settings action plus Restart-now
+  // buttons on the plugin restart banners, replacing the copy-paste systemctl
+  // command. The confirm dialog optionally restarts the herdr daemon too, via a
+  // graceful live-handoff (panes survive).
+  id: "restart-shepherd",
+  sinceVersion: "1.42.0",
+  titleKey: "feat_restart_shepherd_title",
+  bodyKey: "feat_restart_shepherd_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## What

Adds an in-UI **Restart Shepherd** action. Until now the UI only displayed `systemctl --user restart shepherd` as copy-paste text in the two plugin restart banners.

- **`POST /api/restart { herdr?: boolean }`** — relaunches the shepherd systemd unit from a detached `systemd-run --user --collect --unit=shepherd-restart` transient unit (the same survive-your-own-restart pattern as the deploy in `update.ts`). Output lands in the journal.
- **`herdr: true`** additionally runs a graceful **`herdr server live-handoff`** *before* the shepherd restart: the daemon hands its live panes to a fresh server — agent sessions survive. (A `server stop`+`start` approach was deliberately rejected: targets outlive the server, so stop never ends sessions but a dead server orphans panes — see `herdr-update.ts:73-79`; `herdr server start` doesn't even exist in herdr 0.7.1, see follow-up #1410.)
- **Dev-safety guard:** the endpoint refuses (stable code `not_systemd`) unless the process's inherited `$INVOCATION_ID` matches `systemctl --user show shepherd -p InvocationID --value` — a dev-worktree UI can never bounce the production unit. `INVOCATION_ID` (not MainPID) keeps the guard correct even if bun ran the entry point in a subprocess.
- **UI:** a shared `RestartShepherdDialog` (confirm → progress → `/api/health` ride-through → page reload; timeout and error states show the manual command as fallback) with an off-by-default "Also restart the herdr daemon" checkbox. Wired into three places:
  1. Settings → **Session** tab ("Restart Shepherd" row),
  2. Settings → **Plugins** tab restart banner ("Restart now" next to Copy),
  3. **Plugin Updates modal** restart banner (same).
- i18n: all strings EN+DE; feature-announcement fragment `v1.42.0-restart-shepherd`.

## Tests

- `test/restart.test.ts`: guard pass/refuse (missing/foreign/failing InvocationID), script shape (`live-handoff` before `systemctl`, omitted without the flag), relaunch-window debounce + self-clear, launcher failure not arming the debounce.
- Existing suites: root `bun test ./test` 5875 green, UI `bun run check` / `check:i18n` / vitest 2816 green, all PR-hygiene gates pass.
- Dev-instance behavior (the `not_systemd` refusal path) is what a reviewer will see when trying the button locally — that is the guard working as designed.

## Follow-up

- #1410 — pre-existing: `herdr-update.ts` failure recovery invokes the nonexistent `herdr server start` (silent no-op). Surfaced during this work, out of scope here.

```shepherd:manual-steps
- [ ] POST-MERGE: Trigger Restart Shepherd once from the deployed UI (Settings → Session) to validate the InvocationID guard passes under the real systemd unit and the service comes back.
```