### PR TITLE
docs(readme): add CI, release, license badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Shepherd
 
+[![CI](https://github.com/erwins-enkel/shepherd/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/erwins-enkel/shepherd/actions/workflows/ci.yml)
+[![Latest release](https://img.shields.io/github/v/release/erwins-enkel/shepherd)](https://github.com/erwins-enkel/shepherd/releases)
+[![License: BUSL-1.1](https://img.shields.io/badge/license-BUSL--1.1-blue)](./LICENSE)
+
 > Self-hosted mission control for **interactive** AI coding CLIs — and opinionated about how
 > agent-built software should ship. Spawn, watch, and steer a herd of real `claude` sessions (with
 > the Codex CLI in alpha) from your browser or phone, with best-practice guardrails built in. On


### PR DESCRIPTION
## What

Adds three badges under the README H1, each backed by a real, live signal:

- **CI** — native Actions badge for `ci.yml` on `main` (workflow runs on every main push; history is green).
- **Latest release** — shields.io GitHub-release badge; release-please cuts real tagged releases (currently v1.41.0), links to the releases page.
- **License: BUSL-1.1** — the repo uses the Business Source License, which is unusual enough that surfacing it up front helps visitors; links to `./LICENSE`.

## Why these and not more

Skipped coverage (not tracked), npm/downloads (not published as a package), and per-gate badges for the other workflows (PR-hygiene etc. run per-PR, not on main, so a branch badge would be meaningless). Three truthful badges beat a badge wall.

## Verification

- `bun run lint` passes; `prettier --check README.md` clean.
- Docs-only change — no runtime surface.

[no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)