### PR TITLE
docs: link Discussions from README + add Q&A discussion form

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,31 @@
+title: "[Q&A] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for asking! The [README](https://github.com/erwins-enkel/shepherd#readme) and
+        [docs](https://docs.shepherd.run/) cover install, configuration, and the automation suite —
+        worth a quick scan first.
+
+        🔒 **Security vulnerabilities** don't go here — report them privately via a
+        [GitHub Security advisory](https://github.com/erwins-enkel/shepherd/security/advisories/new).
+        🐛 **Reproducible bugs** belong in [Issues](https://github.com/erwins-enkel/shepherd/issues/new/choose).
+  - type: textarea
+    id: question
+    attributes:
+      label: What are you trying to do?
+      description: Your question, with the goal you're after — not just the step that's stuck.
+    validations:
+      required: true
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      description: Commands you ran, settings you changed, output or errors you saw.
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: >-
+        Shepherd version, your OS, and how you run Shepherd (e.g. the agent CLI you drive).
+      render: text

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 > the Codex CLI in alpha) from your browser or phone, with best-practice guardrails built in. On
 > your own server, on your own subscription.
 
+[![GitHub Discussions](https://img.shields.io/github/discussions/erwins-enkel/shepherd?logo=github&label=Discussions)](https://github.com/erwins-enkel/shepherd/discussions)
+
 Shepherd spawns genuine interactive `claude` sessions (and, in alpha, `codex` sessions) in isolated
 git worktrees (via [`herdr`](https://herdr.dev), the interactive-pane manager), bridges each PTY to an `xterm.js` pane in
 the browser, and lets one operator run many agents in parallel — observing their status and steering
@@ -612,10 +614,12 @@ live PTY → browser, status lights, persistence/resume, repo + branch + model p
 sync, issue intake and git-host actions for GitHub and Gitea/Forgejo, usage tracking); the
 automation suite (Plan gate, Critic, Autopilot, Auto-drain, Merge train, Build queue); Learnings;
 Readiness; live previews of agents' dev servers; and a browser capture extension that turns a page
-into a spawned session or filed issue. See the [GitHub issues][issues] for the open backlog and
-`PRD.md` for the full feature set and roadmap.
+into a spawned session or filed issue. See the [GitHub issues][issues] for the open backlog,
+[Discussions][discussions] for questions and ideas, and `PRD.md` for the full feature set and
+roadmap.
 
 [issues]: https://github.com/erwins-enkel/shepherd/issues
+[discussions]: https://github.com/erwins-enkel/shepherd/discussions
 
 ### Usage tracking
 


### PR DESCRIPTION
Now that the repo is public, GitHub Discussions is live (it was already enabled; default categories in place). This PR wires the repo to it:

- **README**: shields Discussions badge under the tagline, plus a text link in **Status** next to the existing issues-backlog pointer.
- **`.github/DISCUSSION_TEMPLATE/q-a.yml`**: discussion form for the Q&A category — mirrors the issue-form house style (security-advisory redirect, bugs-go-to-Issues redirect, required question field, optional tried/environment fields).

Done out-of-band via the API (not part of this diff): seeded welcome post [#1412](https://github.com/erwins-enkel/shepherd/discussions/1412) in Announcements routing questions/ideas/bugs to the right venues.

`.github/ISSUE_TEMPLATE/config.yml` already links Discussions from the issue chooser — unchanged.

```shepherd:manual-steps
- [ ] Pin discussion #1412 (Discussions → open it → "Pin discussion") — GitHub exposes no API for pinning discussions
```

[no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)