### PR TITLE
fix(ui): pin the Repos modal to a fixed height, like the Settings modal

### DIFF
--- a/ui/src/lib/components/BacklogOverlay.browser.test.ts
+++ b/ui/src/lib/components/BacklogOverlay.browser.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import BacklogOverlay from "./BacklogOverlay.svelte";
+import type { BacklogPayload, BacklogProject } from "$lib/types";
+
+const noop = () => {};
+
+function project(path: string): BacklogProject {
+  return {
+    path,
+    display: path,
+    slug: `org/${path}`,
+    kind: "github",
+    openIssues: 3,
+    openPRs: 1,
+    prKinds: null,
+    workflows: null,
+    ciStatus: null,
+    hidden: false,
+  };
+}
+
+// n projects → the master list wants to be n·rows tall; pre-fix (max-height only)
+// the shell grows to fit that, so busy vs sparse payloads yield different shell heights.
+function payload(n: number): BacklogPayload {
+  return {
+    pinnedPath: null,
+    projects: Array.from({ length: n }, (_, i) => project(`/r/repo-${i}`)),
+    totals: { openIssues: 0, openPRs: 0 },
+  };
+}
+
+function props(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    payload: payload(40),
+    mobile: false,
+    onissue: noop,
+    onpr: noop,
+    onadopt: noop,
+    onlaunchtrain: noop,
+    onclose: noop,
+    onaddclone: noop,
+    onaddfork: noop,
+    onaddnewproject: noop,
+    ...over,
+  };
+}
+
+// Mirrors the "Settings dialog layout stability" guard added in PR #1369 for the
+// Settings modal: the Repos modal shell (.card in BacklogOverlay) carries a fixed
+// height: min(720px, 88vh), so switching between a content-heavy and a sparse repo
+// list must NOT resize the shell — the master list scrolls inside instead.
+describe("BacklogOverlay (Repos) shell layout stability", () => {
+  afterEach(async () => {
+    await page.viewport(1280, 900);
+  });
+
+  it("keeps the modal shell height stable across content changes", async () => {
+    await page.viewport(1280, 900);
+    const { rerender } = render(BacklogOverlay, props({ payload: payload(40) }));
+
+    const card = document.querySelector<HTMLElement>(".card");
+    expect(card).not.toBeNull();
+    // desktop shell, not the mobile full-screen sheet (whose height rules differ)
+    expect(card!.classList.contains("mobile")).toBe(false);
+
+    const before = card!.getBoundingClientRect();
+    // Fixed height = min(720px, 88vh); at this viewport it resolves to the px clamp,
+    // i.e. NOT the taller content-driven height a 40-repo list would otherwise force.
+    const expected = Math.min(720, 0.88 * window.innerHeight);
+    expect(Math.abs(before.height - expected)).toBeLessThanOrEqual(3);
+
+    // The repo list — not the shell — is the scroller that absorbs overflow.
+    const master = document.querySelector<HTMLElement>(".master-pane");
+    expect(master).not.toBeNull();
+    expect(getComputedStyle(master!).overflowY).toBe("auto");
+
+    // Swap to a sparse payload: pre-fix this collapses the shell to its content;
+    // with the fixed height the shell geometry must be unchanged.
+    await rerender(props({ payload: payload(2) }));
+    const after = document.querySelector<HTMLElement>(".card")!.getBoundingClientRect();
+    expect(after.height).toBeCloseTo(before.height, 0);
+    expect(after.top).toBeCloseTo(before.top, 0);
+  });
+});

--- a/ui/src/lib/components/BacklogOverlay.svelte
+++ b/ui/src/lib/components/BacklogOverlay.svelte
@@ -109,6 +109,7 @@
   }
   .card {
     width: min(960px, 94vw);
+    height: min(720px, 88vh);
     max-height: 88vh;
     border: 1px solid var(--color-line-bright);
     background: var(--color-panel);


### PR DESCRIPTION
## What

The **Repos** modal (`BacklogOverlay`, labeled *Repos*) sized itself to its content — its `.card` had only `max-height: 88vh`. Switching between a sparse repo and a busy one, or between the Issues/PRs/Automation tabs, made the whole modal shell grow and shrink.

This adopts the exact fix **#1369** applied to the **Settings** modal: give `.card` a fixed `height`, so the shell stays put and the inner content scrolls instead.

```css
.card {
  width: min(960px, 94vw);
  height: min(720px, 88vh);   /* new */
  max-height: 88vh;
}
```

## Notes

- **`720`, not `680`** (what #1369 used for Settings) — the Repos modal is wider (960px) and hosts a two-column browser, so it wants more vertical room. Intentional divergence, verified against an interactive mockup.
- **Scroll lands where it already did:** the repo list `.master-pane` and the tab content in `BacklogTabContent` are the `overflow-y:auto` scrollers; `.detail-pane` stays `overflow:hidden`. No inner-layout change was needed.
- **Mobile unaffected:** `.card.mobile` (`height:100%; max-height:none`) has higher specificity and still wins, so the full-screen mobile sheet is unchanged.

## Test

Adds `BacklogOverlay.browser.test.ts` mirroring #1369's stability guard: at a desktop viewport it captures the `.card` geometry, swaps a busy (40-repo) payload for a sparse (2-repo) one, and asserts `height`/`top` are unchanged. Verified it **fails** when the `height` line is removed and passes with it.

`bun run check` clean; `bun run test:browser BacklogOverlay` green.

[no-feature-entry] — layout polish mirroring a merged fix; no new user-facing capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)