### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs/sandbox-security.md
+++ b/docs/sandbox-security.md
@@ -51,7 +51,7 @@ secrets out of the membrane entirely.
 
 Egress confinement is keyed to the autonomous **profile**, not to whether a human
 is watching (`willEgressConfine`, `src/sandbox.ts:565-570`; applied at
-`src/service.ts:1409`): the wrap applies iff the autonomous profile resolves
+`src/service.ts:1661`): the wrap applies iff the autonomous profile resolves
 **and** the fs + egress backends are present, independent of `ctx.auto`.
 Consequences:
 
@@ -75,7 +75,7 @@ Write --permission-mode dontAsk` (`src/transient-agent-argv.ts`,
   `buildTransientAgentArgv("reviewer", …)`).
 - **Research is the deliberately egress-UNCONFINED surface.** A research session
   that would resolve to `autonomous` is **downgraded to `standard`**
-  (`src/service.ts` `researchSafeProfileOverride`, ~L1796-1814, warns once),
+  (`src/service.ts` `researchSafeProfileOverride`, ~L2153-2171, warns once),
   because research needs **open** web egress (search/fetch + sub-agents) that the
   autonomous firewall would block. It is operator-_created_ (cannot be
   auto-drained — `standard` refuses auto-spawn) but **autopilot-steerable, so it


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc update summary

The in-scope prose docs are largely current — `src/config.ts` is unchanged since
the last docs-sync commit (`2cb9283b`, #1398), the configuration table already
reflects it, the external-task-API model aliases match `src/types.ts`
(`CLAUDE_MODELS`), and the egress allowlist described in the sandbox docs matches
`src/egress.ts`. The only demonstrable staleness was two internal source
line-references in `docs/sandbox-security.md` that had drifted by hundreds of
lines as the referenced code moved.

## Changes

- **`docs/sandbox-security.md`** — corrected two stale `src/service.ts` line
  references (behavior descriptions were still accurate; only the line pointers
  had drifted):
  - "applied at `src/service.ts:1409`" → **`src/service.ts:1661`**, the current
    location of the `egressOn = willEgressConfine(...)` wrap decision in
    `prepareSpawn` (verified in `src/service.ts:1661`).
  - "`researchSafeProfileOverride`, ~L1796-1814" → **~L2153-2171**, the current
    location of that method (verified: it now begins at `src/service.ts:2153`).

  Other exact references in the same file were re-verified and are still correct
  and left untouched: `egressApplies` ~L554, the `~/.claude` `--ro-bind`
  (:308-310), the `.credentials.json` `--bind-try` (:315-317), `~/.config/gh`
  RO bind (:413), `--clearenv` (:438), `willEgressConfine` (:565-570), and
  `autoHoldReason` ~L501-502.

## Uncertain / needs human judgment

- **`docs/sandbox-security.md` autopilot line-refs (left as-is).** Three pointers
  into `src/autopilot.ts` are off by a few lines but still land the reader inside
  the correct construct, so I did not touch them (they use the doc's `~L`
  approximate convention and churn on every commit):
  - "`RESEARCH_PROCEED_STEER`, `src/autopilot.ts:24-29`" — the const is now at
    lines 25-30 (comment at 23-24); off by one.
  - "dispatched at L307" — the `dispatch()` method starts at L307, but the actual
    `driveSteer(..., RESEARCH_PROCEED_STEER)` call is now at L310.
  - "never a code PR (`src/autopilot.ts:309-313`)" — the research→`markComplete`
    branch that enforces "no code PR" is now at ~L312-317 (the `case "finished"`
    research short-circuit).
  A human may want to tighten these, or drop precise line numbers in favor of
  symbol names, to stop the recurring drift.

- **`docs/token-usage-analysis.md` (not changed).** This is a point-in-time
  analysis of specific historical task-sessions (TASK-286…295) with pricing
  weights and figures frozen at capture time. It is not "stale vs. source" in the
  maintainable sense — editing its numbers would falsify the historical record —
  so it was deliberately left untouched.

- **`configuration.md` coverage (not changed).** The page's description says
  "Every environment variable," but it documents a curated operator-facing subset
  of the ~60 env knobs in `src/config.ts` (e.g. the per-role CLI/model vars,
  `SHEPHERD_AUTH_MODE`, `SHEPHERD_EXTRA_CREDITS_DRAIN_CEILING`,
  `SHEPHERD_HOOKS_INGEST/SIGNALS`, telemetry/push internals are omitted). This is
  a long-standing editorial choice, not recent drift, so I did not expand it — but
  a human may want to reconcile the "every" wording with the curated scope.