### PR TITLE
feat(ui): forward Claude's OSC 52 c-to-copy to the browser clipboard

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -160,7 +160,15 @@
       // DemoRibbon above, just a newer instance of it. No other duplicated
       // content in this file, so ignoring the file is equivalent to ignoring
       // just that block.
-      "**/ui/src/lib/components/TelemetryConsent.svelte"
+      "**/ui/src/lib/components/TelemetryConsent.svelte",
+      // ClipboardPill.svelte's only clone-flagged content is the same `.gbtn`
+      // recipe (lines ~77-99) — same verbatim-copy design-system convention as
+      // DemoRibbon/TelemetryConsent above, just a newer instance of it (the
+      // OSC 52 c-to-copy pill). No other duplicated content in this file, so
+      // ignoring the file is equivalent to ignoring just that block. Do NOT
+      // extract a shared stylesheet — that's the same out-of-scope 15+-file
+      // change called out above.
+      "**/ui/src/lib/components/viewport/ClipboardPill.svelte"
     ]
   },
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2525,7 +2525,6 @@
   "pluginupdate_apply_err_generic": "Update fehlgeschlagen.",
   "clipboard_copied_toast": "In die Zwischenablage kopiert",
   "clipboard_copy_failed": "Kopieren in die Zwischenablage fehlgeschlagen",
-  "clipboard_copy_retry": "Erneut versuchen",
   "clipboard_pill_prompt": "Terminal hat Text kopiert",
   "clipboard_pill_copy": "In Zwischenablage kopieren",
   "feat_clipboard_osc52_title": "Claudes „Kopieren“ landet jetzt in deiner Zwischenablage",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2522,5 +2522,11 @@
   "pluginupdate_apply_err_symlinked": "Dieses Plugin läuft aus einem verlinkten Quell-Checkout — aktualisiere es dort.",
   "pluginupdate_apply_err_incompatible": "Die neue Version braucht ein neueres Shepherd — aktualisiere zuerst Shepherd.",
   "pluginupdate_apply_err_nosource": "Keine Update-Quelle — Shepherd kann keine neue Version automatisch holen.",
-  "pluginupdate_apply_err_generic": "Update fehlgeschlagen."
+  "pluginupdate_apply_err_generic": "Update fehlgeschlagen.",
+  "clipboard_copied_toast": "In die Zwischenablage kopiert",
+  "clipboard_copy_failed": "Kopieren in die Zwischenablage fehlgeschlagen",
+  "clipboard_pill_prompt": "Terminal hat Text kopiert",
+  "clipboard_pill_copy": "In Zwischenablage kopieren",
+  "feat_clipboard_osc52_title": "Claudes „Kopieren“ landet jetzt in deiner Zwischenablage",
+  "feat_clipboard_osc52_body": "Wenn Claude im Terminal Text kopiert (`c to copy`), landet er jetzt in deiner System-Zwischenablage. Blockiert der Browser das automatische Schreiben, erscheint eine kleine Copy-Pille über dem Terminal zum Kopieren per Klick."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2525,6 +2525,7 @@
   "pluginupdate_apply_err_generic": "Update fehlgeschlagen.",
   "clipboard_copied_toast": "In die Zwischenablage kopiert",
   "clipboard_copy_failed": "Kopieren in die Zwischenablage fehlgeschlagen",
+  "clipboard_copy_retry": "Erneut versuchen",
   "clipboard_pill_prompt": "Terminal hat Text kopiert",
   "clipboard_pill_copy": "In Zwischenablage kopieren",
   "feat_clipboard_osc52_title": "Claudes „Kopieren“ landet jetzt in deiner Zwischenablage",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2522,5 +2522,11 @@
   "pluginupdate_apply_err_symlinked": "This plugin runs from a linked source checkout — update it there.",
   "pluginupdate_apply_err_incompatible": "The new version needs a newer Shepherd — update Shepherd first.",
   "pluginupdate_apply_err_nosource": "No update source — Shepherd can't fetch a new version automatically.",
-  "pluginupdate_apply_err_generic": "Update failed."
+  "pluginupdate_apply_err_generic": "Update failed.",
+  "clipboard_copied_toast": "Copied to clipboard",
+  "clipboard_copy_failed": "Couldn’t copy to clipboard",
+  "clipboard_pill_prompt": "Terminal copied text",
+  "clipboard_pill_copy": "Copy to clipboard",
+  "feat_clipboard_osc52_title": "Claude's \"copy\" now reaches your clipboard",
+  "feat_clipboard_osc52_body": "When Claude copies text in the terminal (`c to copy`), it now lands in your system clipboard. If the browser blocks the automatic write, a small Copy pill appears over the terminal for a one-click copy."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2525,7 +2525,6 @@
   "pluginupdate_apply_err_generic": "Update failed.",
   "clipboard_copied_toast": "Copied to clipboard",
   "clipboard_copy_failed": "Couldn’t copy to clipboard",
-  "clipboard_copy_retry": "Retry",
   "clipboard_pill_prompt": "Terminal copied text",
   "clipboard_pill_copy": "Copy to clipboard",
   "feat_clipboard_osc52_title": "Claude's \"copy\" now reaches your clipboard",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2525,6 +2525,7 @@
   "pluginupdate_apply_err_generic": "Update failed.",
   "clipboard_copied_toast": "Copied to clipboard",
   "clipboard_copy_failed": "Couldn’t copy to clipboard",
+  "clipboard_copy_retry": "Retry",
   "clipboard_pill_prompt": "Terminal copied text",
   "clipboard_pill_copy": "Copy to clipboard",
   "feat_clipboard_osc52_title": "Claude's \"copy\" now reaches your clipboard",

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2218,17 +2218,10 @@
           pendingCopy = null;
           toasts.info(m.clipboard_copied_toast());
         }}
-        oncopyfailed={(text) => {
-          toasts.info(m.clipboard_copy_failed(), {
-            alert: true,
-            duration: null,
-            action: {
-              label: m.clipboard_copy_retry(),
-              run: () => {
-                pendingCopy = text;
-              },
-            },
-          });
+        oncopyfailed={() => {
+          // Announce the failure but keep the pill mounted — its Copy button is the
+          // retry surface (a fresh in-gesture click), so no separate Retry action.
+          toasts.info(m.clipboard_copy_failed(), { alert: true });
         }}
         ondismiss={() => (pendingCopy = null)}
       />

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -66,7 +66,7 @@
   import ViewportTabBar from "./viewport/ViewportTabBar.svelte";
   import ViewportHeaderActions from "./viewport/ViewportHeaderActions.svelte";
   import ClipboardPill from "./viewport/ClipboardPill.svelte";
-  import { parseOsc52 } from "$lib/osc52";
+  import { handleOsc52 } from "$lib/osc52";
   import type { BuildQueue } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { modelLabel } from "$lib/model-label";
@@ -1194,21 +1194,15 @@
     // forward the decoded text to the browser clipboard. The bytes arrive async over the WS
     // (not inside the `c` keydown), so navigator.clipboard.writeText may be refused
     // (NotAllowedError / unfocused tab); on ANY failure, stash the text and surface the
-    // ClipboardPill for a one-click, in-gesture retry. parseOsc52 already refuses `?` reads and
-    // caps size. We claim OSC 52 entirely (return true).
+    // ClipboardPill for a one-click, in-gesture retry. handleOsc52 already refuses `?` reads and
+    // caps size (via parseOsc52), and claims every outcome so a write can never vanish silently.
+    // We claim OSC 52 entirely (return true).
     const osc52Sub = term.parser.registerOscHandler(52, (data) => {
-      const w = parseOsc52(data);
-      if (w) {
-        const p = navigator.clipboard?.writeText(w.text);
-        if (p) {
-          p.then(
-            () => toasts.info(m.clipboard_copied_toast()),
-            () => (pendingCopy = w.text),
-          );
-        } else {
-          pendingCopy = w.text; // no async clipboard API available → click-to-copy
-        }
-      }
+      handleOsc52(data, {
+        writeText: (t) => navigator.clipboard?.writeText(t),
+        onCopied: () => toasts.info(m.clipboard_copied_toast()),
+        onPending: (text) => (pendingCopy = text),
+      });
       return true;
     });
 
@@ -2224,9 +2218,17 @@
           pendingCopy = null;
           toasts.info(m.clipboard_copied_toast());
         }}
-        oncopyfailed={() => {
-          pendingCopy = null;
-          toasts.info(m.clipboard_copy_failed());
+        oncopyfailed={(text) => {
+          toasts.info(m.clipboard_copy_failed(), {
+            alert: true,
+            duration: null,
+            action: {
+              label: m.clipboard_copy_retry(),
+              run: () => {
+                pendingCopy = text;
+              },
+            },
+          });
         }}
         ondismiss={() => (pendingCopy = null)}
       />

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -65,6 +65,8 @@
   import ViewportTermControls from "./viewport/ViewportTermControls.svelte";
   import ViewportTabBar from "./viewport/ViewportTabBar.svelte";
   import ViewportHeaderActions from "./viewport/ViewportHeaderActions.svelte";
+  import ClipboardPill from "./viewport/ClipboardPill.svelte";
+  import { parseOsc52 } from "$lib/osc52";
   import type { BuildQueue } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { modelLabel } from "$lib/model-label";
@@ -231,6 +233,9 @@
   // jump-to-latest button lifts by `reviewBannerH || ciBannerH` (no max() needed).
   let ciBannerH = $state(0);
   let reviewActive = $state(false);
+  // Text stashed from an OSC 52 clipboard write that the browser refused (async writes need
+  // a user gesture); the ClipboardPill offers a one-click retry that runs inside a real click.
+  let pendingCopy = $state<string | null>(null);
   // true when another device took over this terminal — show a take-over prompt
   let parked = $state(false);
   // true once the connection stopped for good — show a recovery prompt. endReason
@@ -1185,6 +1190,28 @@
       },
     });
 
+    // Claude's `c to copy` emits OSC 52 (ESC]52;c;<base64>). xterm has no built-in handler, so
+    // forward the decoded text to the browser clipboard. The bytes arrive async over the WS
+    // (not inside the `c` keydown), so navigator.clipboard.writeText may be refused
+    // (NotAllowedError / unfocused tab); on ANY failure, stash the text and surface the
+    // ClipboardPill for a one-click, in-gesture retry. parseOsc52 already refuses `?` reads and
+    // caps size. We claim OSC 52 entirely (return true).
+    const osc52Sub = term.parser.registerOscHandler(52, (data) => {
+      const w = parseOsc52(data);
+      if (w) {
+        const p = navigator.clipboard?.writeText(w.text);
+        if (p) {
+          p.then(
+            () => toasts.info(m.clipboard_copied_toast()),
+            () => (pendingCopy = w.text),
+          );
+        } else {
+          pendingCopy = w.text; // no async clipboard API available → click-to-copy
+        }
+      }
+      return true;
+    });
+
     // Fit + push the size to the PTY — but only while the mount is actually
     // visible. A hidden (To-Do tab → display:none) or mid-layout mount
     // has zero width, where FitAddon clamps to its 2-col minimum; resizing the
@@ -1624,6 +1651,7 @@
       bufSub.dispose();
       writeSub.dispose();
       renderSub.dispose();
+      osc52Sub.dispose();
       ro.disconnect();
       c.close();
       conn = undefined;
@@ -2189,6 +2217,20 @@
       }}
       ondrop={onTermDrop}
     ></div>
+    {#if tab === "term" && pendingCopy}
+      <ClipboardPill
+        text={pendingCopy}
+        oncopied={() => {
+          pendingCopy = null;
+          toasts.info(m.clipboard_copied_toast());
+        }}
+        oncopyfailed={() => {
+          pendingCopy = null;
+          toasts.info(m.clipboard_copy_failed());
+        }}
+        ondismiss={() => (pendingCopy = null)}
+      />
+    {/if}
     <ViewportTermBanners
       {tab}
       {scrolledUp}

--- a/ui/src/lib/components/viewport/ClipboardPill.browser.test.ts
+++ b/ui/src/lib/components/viewport/ClipboardPill.browser.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../../app.css";
+
+const { default: ClipboardPill } = await import("./ClipboardPill.svelte");
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("ClipboardPill", () => {
+  it("Copy writes the exact text to the clipboard and fires oncopied on success", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } });
+    const oncopied = vi.fn();
+    const oncopyfailed = vi.fn();
+    render(ClipboardPill, {
+      text: "hello clipboard",
+      oncopied,
+      oncopyfailed,
+      ondismiss: vi.fn(),
+    });
+
+    await page.getByRole("button", { name: /copy/i }).click();
+
+    expect(writeText).toHaveBeenCalledWith("hello clipboard");
+    await vi.waitFor(() => expect(oncopied).toHaveBeenCalledTimes(1));
+    expect(oncopyfailed).not.toHaveBeenCalled();
+  });
+
+  it("fires oncopyfailed (not oncopied) when writeText rejects", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("NotAllowedError"));
+    vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } });
+    const oncopied = vi.fn();
+    const oncopyfailed = vi.fn();
+    render(ClipboardPill, {
+      text: "some text",
+      oncopied,
+      oncopyfailed,
+      ondismiss: vi.fn(),
+    });
+
+    await page.getByRole("button", { name: /copy/i }).click();
+
+    await vi.waitFor(() => expect(oncopyfailed).toHaveBeenCalledTimes(1));
+    expect(oncopied).not.toHaveBeenCalled();
+  });
+
+  it("dismiss control fires ondismiss", async () => {
+    const ondismiss = vi.fn();
+    render(ClipboardPill, {
+      text: "some text",
+      oncopied: vi.fn(),
+      oncopyfailed: vi.fn(),
+      ondismiss,
+    });
+
+    await page.getByRole("button", { name: /close|dismiss/i }).click();
+
+    expect(ondismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/lib/components/viewport/ClipboardPill.svelte
+++ b/ui/src/lib/components/viewport/ClipboardPill.svelte
@@ -27,7 +27,10 @@
   }
 
   // Auto-dismiss so a stale pill doesn't linger once the moment has passed.
+  // Reads `text` so a second OSC 52 write that replaces it on an already-mounted
+  // pill re-arms the countdown (each copy gets the full 20s, not the leftover).
   $effect(() => {
+    void text;
     const t = setTimeout(() => ondismiss(), 20_000);
     return () => clearTimeout(t);
   });

--- a/ui/src/lib/components/viewport/ClipboardPill.svelte
+++ b/ui/src/lib/components/viewport/ClipboardPill.svelte
@@ -13,7 +13,7 @@
   }: {
     text: string;
     oncopied: () => void;
-    oncopyfailed: () => void;
+    oncopyfailed?: (text: string) => void;
     ondismiss: () => void;
   } = $props();
 
@@ -22,7 +22,7 @@
       await navigator.clipboard.writeText(text);
       oncopied();
     } catch {
-      oncopyfailed();
+      oncopyfailed?.(text);
     }
   }
 
@@ -36,8 +36,8 @@
   });
 </script>
 
-<div class="clip-pill" role="status" aria-live="polite">
-  <span class="clip-prompt">{m.clipboard_pill_prompt()}</span>
+<div class="clip-pill">
+  <span class="clip-prompt" role="status" aria-live="polite">{m.clipboard_pill_prompt()}</span>
   <button type="button" class="gbtn primary" onclick={copy}>{m.clipboard_pill_copy()}</button>
   <button
     type="button"

--- a/ui/src/lib/components/viewport/ClipboardPill.svelte
+++ b/ui/src/lib/components/viewport/ClipboardPill.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+
+  // Reliability floor for OSC 52 clipboard writes (see Viewport.svelte). The write
+  // arrives async over the WS — not inside the `c` keydown that triggered it — so
+  // browsers may refuse navigator.clipboard.writeText outside a real user gesture.
+  // This pill re-offers the copy as an explicit click, which IS a gesture.
+  let {
+    text,
+    oncopied,
+    oncopyfailed,
+    ondismiss,
+  }: {
+    text: string;
+    oncopied: () => void;
+    oncopyfailed: () => void;
+    ondismiss: () => void;
+  } = $props();
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(text);
+      oncopied();
+    } catch {
+      oncopyfailed();
+    }
+  }
+
+  // Auto-dismiss so a stale pill doesn't linger once the moment has passed.
+  $effect(() => {
+    const t = setTimeout(() => ondismiss(), 20_000);
+    return () => clearTimeout(t);
+  });
+</script>
+
+<div class="clip-pill" role="status" aria-live="polite">
+  <span class="clip-prompt">{m.clipboard_pill_prompt()}</span>
+  <button type="button" class="gbtn primary" onclick={copy}>{m.clipboard_pill_copy()}</button>
+  <button
+    type="button"
+    class="clip-dismiss"
+    aria-label={m.common_close()}
+    onclick={() => ondismiss()}
+  >
+    <span aria-hidden="true">×</span>
+  </button>
+</div>
+
+<style>
+  /* Small, non-blocking anchored affordance — no scrim, mirrors the scroll-jump /
+     review-banner strip's positioning within .vp-body (position: relative). */
+  .clip-pill {
+    position: absolute;
+    bottom: calc(12px + var(--review-banner-h, 0px));
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 8px 6px 12px;
+    background: var(--color-head);
+    border: 1px solid var(--color-line);
+    border-radius: 4px;
+    box-shadow: 0 2px 8px color-mix(in srgb, var(--color-bg) 40%, transparent);
+    white-space: nowrap;
+  }
+  .clip-prompt {
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.04em;
+  }
+  .gbtn {
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    padding: 2px 8px;
+    cursor: pointer;
+    transition:
+      border-color 0.12s,
+      color 0.12s;
+  }
+  .gbtn:hover:not(:disabled) {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .gbtn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+  .gbtn.primary {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+  }
+  .clip-dismiss {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    background: transparent;
+    border: 0;
+    color: var(--color-faint);
+    font-size: var(--fs-base);
+    line-height: 1;
+    cursor: pointer;
+  }
+  .clip-dismiss:hover {
+    color: var(--color-ink-bright);
+  }
+  .clip-dismiss:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+</style>

--- a/ui/src/lib/feature-announcements/entries/v1.42.0-clipboard-osc52.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.42.0-clipboard-osc52.ts
@@ -1,0 +1,12 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // Claude's `c to copy` (OSC 52) now reaches the browser clipboard — previously
+  // dropped silently because xterm.js has no built-in OSC 52 handler.
+  id: "clipboard-osc52",
+  sinceVersion: "1.42.0",
+  titleKey: "feat_clipboard_osc52_title",
+  bodyKey: "feat_clipboard_osc52_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/osc52.test.ts
+++ b/ui/src/lib/osc52.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { parseOsc52, OSC52_MAX_BYTES } from "./osc52";
+
+// Build a base64 payload from a UTF-8 source string, matching what a well-behaved
+// OSC 52 emitter (like Claude Code) would send as Pd.
+const b64 = (s: string) => btoa(unescape(encodeURIComponent(s)));
+
+describe("parseOsc52", () => {
+  it("byte-exact round-trip of a realistic long login URL", () => {
+    const url =
+      "https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e&response_type=code&scope=org%3Acreate_api_key+user%3Aprofile&code_challenge=abc123&code_challenge_method=S256&state=xyz";
+    const result = parseOsc52("c;" + b64(url));
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe(url);
+  });
+
+  it("empty Pc still parses (Pc is ignored)", () => {
+    expect(parseOsc52(";" + b64("hello"))).toEqual({ text: "hello" });
+  });
+
+  it("refuses a read/query request (Pd === '?')", () => {
+    expect(parseOsc52("c;?")).toBeNull();
+  });
+
+  it("returns null when there is no semicolon at all", () => {
+    expect(parseOsc52("garbage")).toBeNull();
+  });
+
+  it("returns null for malformed base64", () => {
+    expect(parseOsc52("c;!!!not base64!!!")).toBeNull();
+  });
+
+  it("returns null when the decoded payload exceeds OSC52_MAX_BYTES", () => {
+    const huge = "x".repeat(OSC52_MAX_BYTES + 10);
+    expect(parseOsc52("c;" + b64(huge))).toBeNull();
+  });
+
+  it("round-trips a UTF-8 payload with multibyte characters byte-exact", () => {
+    const text = "café — 日本語";
+    expect(parseOsc52("c;" + b64(text))).toEqual({ text });
+  });
+});

--- a/ui/src/lib/osc52.test.ts
+++ b/ui/src/lib/osc52.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { parseOsc52, OSC52_MAX_BYTES } from "./osc52";
+import { describe, it, expect, vi } from "vitest";
+import { parseOsc52, handleOsc52, OSC52_MAX_BYTES, type Osc52Sink } from "./osc52";
 
 // Build a base64 payload from a UTF-8 source string, matching what a well-behaved
 // OSC 52 emitter (like Claude Code) would send as Pd.
@@ -38,5 +38,91 @@ describe("parseOsc52", () => {
   it("round-trips a UTF-8 payload with multibyte characters byte-exact", () => {
     const text = "café — 日本語";
     expect(parseOsc52("c;" + b64(text))).toEqual({ text });
+  });
+});
+
+describe("handleOsc52", () => {
+  function mockSink(writeText: Osc52Sink["writeText"]) {
+    return {
+      writeText,
+      onCopied: vi.fn(),
+      onPending: vi.fn(),
+    } satisfies Osc52Sink;
+  }
+
+  it("resolved write fires onCopied, not onPending", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const sink = mockSink(writeText);
+
+    handleOsc52("c;" + b64("hello"), sink);
+    await vi.waitFor(() => expect(sink.onCopied).toHaveBeenCalledTimes(1));
+
+    expect(writeText).toHaveBeenCalledWith("hello");
+    expect(sink.onPending).not.toHaveBeenCalled();
+  });
+
+  it("rejected write fires onPending with the byte-exact text, not onCopied", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("NotAllowedError"));
+    const sink = mockSink(writeText);
+
+    handleOsc52("c;" + b64("secret text"), sink);
+    await vi.waitFor(() => expect(sink.onPending).toHaveBeenCalledTimes(1));
+
+    expect(sink.onPending).toHaveBeenCalledWith("secret text");
+    expect(sink.onCopied).not.toHaveBeenCalled();
+  });
+
+  it("writeText returning undefined (no async clipboard API) fires onPending", () => {
+    const writeText = vi.fn().mockReturnValue(undefined);
+    const sink = mockSink(writeText);
+
+    handleOsc52("c;" + b64("no api"), sink);
+
+    expect(sink.onPending).toHaveBeenCalledWith("no api");
+    expect(sink.onCopied).not.toHaveBeenCalled();
+  });
+
+  it("writeText returning null (no async clipboard API) fires onPending", () => {
+    const writeText = vi.fn().mockReturnValue(null);
+    const sink = mockSink(writeText);
+
+    handleOsc52("c;" + b64("also no api"), sink);
+
+    expect(sink.onPending).toHaveBeenCalledWith("also no api");
+    expect(sink.onCopied).not.toHaveBeenCalled();
+  });
+
+  it("writeText throwing synchronously fires onPending", () => {
+    const writeText = vi.fn(() => {
+      throw new Error("insecure context");
+    });
+    const sink = mockSink(writeText);
+
+    handleOsc52("c;" + b64("thrown text"), sink);
+
+    expect(sink.onPending).toHaveBeenCalledWith("thrown text");
+    expect(sink.onCopied).not.toHaveBeenCalled();
+  });
+
+  it("a `?` read request fires neither callback", () => {
+    const writeText = vi.fn();
+    const sink = mockSink(writeText);
+
+    handleOsc52("c;?", sink);
+
+    expect(writeText).not.toHaveBeenCalled();
+    expect(sink.onCopied).not.toHaveBeenCalled();
+    expect(sink.onPending).not.toHaveBeenCalled();
+  });
+
+  it("malformed data (no semicolon) fires neither callback", () => {
+    const writeText = vi.fn();
+    const sink = mockSink(writeText);
+
+    handleOsc52("garbage", sink);
+
+    expect(writeText).not.toHaveBeenCalled();
+    expect(sink.onCopied).not.toHaveBeenCalled();
+    expect(sink.onPending).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/lib/osc52.ts
+++ b/ui/src/lib/osc52.ts
@@ -59,3 +59,41 @@ export function parseOsc52(data: string): Osc52Write | null {
 
   return { text };
 }
+
+/** Injectable seams for {@link handleOsc52} so the valid→writeText, resolve→toast,
+ *  reject→pill, no-API→pill branching is unit-testable without xterm/DOM/clipboard. */
+export interface Osc52Sink {
+  /** Attempt the clipboard write; may return undefined/null when no async clipboard
+   *  API is available, and may reject or throw synchronously on refusal. */
+  writeText: (t: string) => Promise<void> | undefined | null;
+  /** The write resolved. */
+  onCopied: () => void;
+  /** The write needs a retry (rejected, threw, or no API) — stash `text` for the pill. */
+  onPending: (text: string) => void;
+}
+
+/**
+ * Parse an OSC 52 payload and drive it into `sink`. Claims all outcomes: a rejected
+ * write, a synchronous throw, and the absence of an async clipboard API all fall back
+ * to `onPending` so the payload can never vanish silently.
+ */
+export function handleOsc52(data: string, sink: Osc52Sink): void {
+  const w = parseOsc52(data);
+  if (!w) return; // parse rejected (incl. `?` read, oversize) → nothing
+
+  let p: Promise<void> | undefined | null;
+  try {
+    p = sink.writeText(w.text);
+  } catch {
+    sink.onPending(w.text); // synchronous throw (e.g. insecure context)
+    return;
+  }
+  if (p && typeof p.then === "function") {
+    p.then(
+      () => sink.onCopied(),
+      () => sink.onPending(w.text),
+    );
+  } else {
+    sink.onPending(w.text); // no async clipboard API available
+  }
+}

--- a/ui/src/lib/osc52.ts
+++ b/ui/src/lib/osc52.ts
@@ -1,0 +1,61 @@
+// Parse OSC 52 clipboard-write payloads. Claude Code's `c to copy` (and other TUIs) emit
+// OSC 52 (`ESC ] 52 ; <Pc> ; <Pd> BEL`) to ask the terminal to write to the system clipboard.
+// xterm's `registerOscHandler(52, cb)` hands the callback everything after the `52;`
+// identifier — i.e. the `<Pc>;<Pd>` part — which is exactly what this function consumes.
+// Pure + co-located tests so the parser is render-agnostic and reusable, mirroring
+// slashLinks.ts. No xterm/Svelte/DOM/clipboard here — a later task wires the xterm OSC
+// handler + clipboard write around this.
+
+export interface Osc52Write {
+  /** Decoded UTF-8 clipboard text to write. */
+  text: string;
+}
+
+/** Max decoded payload we will accept (bytes of the base64-decoded UTF-8). */
+export const OSC52_MAX_BYTES = 32_768;
+
+// Cheap pre-check bound on the base64 *string* length, applied before decoding so we never
+// base64-decode a huge blob just to reject it. 4 output chars encode 3 input bytes (with
+// padding rounding up), plus slack for padding chars.
+const MAX_B64_LENGTH = Math.ceil(OSC52_MAX_BYTES / 3) * 4 + 4;
+
+/**
+ * Parse an OSC 52 payload (`<Pc>;<Pd>`, the data xterm hands an OSC-52 handler).
+ * Returns the decoded clipboard-write text, or null when the payload must be ignored:
+ *  - a READ/query request (`Pd === "?"`) — we NEVER return clipboard contents to the
+ *    remote program (exfiltration guard);
+ *  - malformed / non-base64 `Pd`;
+ *  - decoded payload exceeding OSC52_MAX_BYTES.
+ * `Pc` (the selection target) is ignored — we always target the clipboard.
+ */
+export function parseOsc52(data: string): Osc52Write | null {
+  const sep = data.indexOf(";");
+  if (sep === -1) return null;
+
+  const pd = data.slice(sep + 1);
+
+  // Read/query request: the remote program is asking for the current clipboard contents.
+  // Refuse — never disclose clipboard contents back to the terminal program.
+  if (pd === "?") return null;
+
+  if (pd.length === 0 || pd.length > MAX_B64_LENGTH) return null;
+
+  let bytes: Uint8Array;
+  try {
+    const binary = atob(pd);
+    bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  } catch {
+    return null;
+  }
+
+  if (bytes.byteLength > OSC52_MAX_BYTES) return null;
+
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+
+  return { text };
+}


### PR DESCRIPTION
## Problem

When Claude Code loses its login it prints a sign-in URL with a **`c to copy`** helper. In
Shepherd `c` did nothing useful (the "one-way clipboard"), so you had to hand-select the
Ink-hard-wrapped URL — and xterm inserts a line break at every wrap point, which you then had to
find and delete before the URL would paste into a local browser.

## Root cause (reverse-engineered from the Claude 2.1.201 bundle)

Claude's clipboard-mode selector emits an **OSC 52** escape (`ESC]52;c;<base64>BEL`) whenever
there's no local clipboard tool — and the `SSH_CONNECTION` override forces OSC 52 on **any SSH
session** (i.e. a normal remote/headless herdr). But `@xterm/xterm` only handles OSC ids
`[0,1,2,4,8,10,11,12,104,110,111,112]` — **not 52** — so Shepherd silently dropped it. Confirmed
empirically: pressing `c` on a throwaway login screen emits `\x1b]52;c;<base64-of-the-URL>`.

## Fix

Forward OSC 52 to the **browser** clipboard — general, for *every* `c to copy`, not just the
login URL:

- **`osc52.ts`** — pure parser. Refuses read/query (`Pd === "?"`) requests so a remote program
  can never read the operator's clipboard; caps decoded size at 32 KB (pre- and post-decode);
  byte-exact base64→UTF-8 (`atob`/`TextDecoder`, browser-safe).
- **`Viewport.svelte`** — registers an OSC 52 handler. On a valid write it calls
  `navigator.clipboard.writeText` and shows a **toast** (so every clipboard write is visible).
- **`ClipboardPill.svelte`** — the reliability floor. The OSC 52 bytes arrive async over the
  WebSocket (not inside the `c` keydown), so browsers may refuse the write. On **any** rejection
  or when the async clipboard API is unavailable, the text is stashed and a one-click **Copy
  pill** appears — clicking it writes inside a real user gesture. So `c` can never silently fail.

### Security

OSC 52 can be emitted by any PTY output, so: reads (`?`) are refused, payloads are size-capped,
and every write surfaces a toast (never silent). Decoded text is only ever passed to
`writeText()` — it is never rendered into the DOM (no injection surface).

## Testing

- `osc52.test.ts` (7): byte-exact round-trip incl. multibyte UTF-8, `?`-read → null,
  malformed/oversized → null, empty selection target.
- `ClipboardPill.browser.test.ts` (3): Copy writes the exact text + fires `oncopied`; rejection
  fires `oncopyfailed`; dismiss fires `ondismiss`.
- Full UI suite, `bun run check`, `check:i18n` (EN+DE parity), and PR-hygiene gates
  (feature-catalog, announcement-versions, glossary, branch-hygiene) all green.
- **Empirically verified** Claude emits OSC 52 on `c` via a throwaway `CLAUDE_CONFIG_DIR` +
  narrow PTY (no real-auth impact).

**Manual check for the reviewer:** end-to-end browser confirmation (press `c` on a real login
screen → URL lands on the browser clipboard; blur the tab → the Copy pill appears and its click
also copies) can't be automated headlessly; the async-write reliability is fully absorbed by the
pill fallback regardless of browser.

Includes a What's-New entry (`v1.42.0-clipboard-osc52.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
