### PR TITLE
chore(extension): bump version to 1.1.0 for marquee capture mode

### DIFF
--- a/extension/manifest.config.ts
+++ b/extension/manifest.config.ts
@@ -25,7 +25,7 @@ import { defineManifest } from "@crxjs/vite-plugin";
 export default defineManifest({
   manifest_version: 3,
   name: "Shepherd Capture",
-  version: "1.0.0",
+  version: "1.1.0",
   // Pins the unpacked-load extension ID to a constant
   // (bflahkibnmcbijbhelmpjbohpfhlbaig) so the server's SHEPHERD_ALLOWED_HOSTS
   // allowlist entry is set once and never drifts per directory/machine. This is

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "extension",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Follow-up to #1426 (marquee drag-rectangle capture mode), which shipped without a version bump.

## What

Bumps the Shepherd Capture extension **1.0.0 → 1.1.0** in the two lockstep sources:
- `extension/manifest.config.ts` `version` — what Chrome uses for the installed extension.
- `extension/package.json` `version` — drives the store zip name (`scripts/package.mjs`).

The extension version is manual (not release-please managed — that only tracks the root package), and hadn't been bumped since the store packaging landed, so the store is still on 1.0.0. A new user-facing feature → minor bump.

## Verified

`bun run build` → `dist/manifest.json` reports `1.1.0`; `bun run package` emits `shepherd-capture-1.1.0.zip`. Pre-push gate green.

## Note — store publish still owed

This only bumps the version in-repo. Publishing to the Chrome Web Store is a manual step (dispatch `extension-package.yml` / push a `capture-v1.1.0` tag → download the zip → upload to the CWS dashboard, per `extension/STORE_LISTING.md`). Tracking that separately per our discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)