### PR TITLE
refactor(critic): retire dead MAX_THINKING_TOKENS channel, --effort is sole reasoning lever

### DIFF
--- a/src/critic-core.ts
+++ b/src/critic-core.ts
@@ -17,16 +17,6 @@ import type { VerdictRead } from "./json-tolerant";
 
 const execFileAsync = promisify(execFile);
 
-/** Extended thinking budget (MAX_THINKING_TOKENS) handed to BOTH PR critic spawns — the session
- *  critic (`review.ts`) and the standalone PR critic (`standalone-critic.ts`). They share the
- *  #597 VERIFY prompt (grep/resolve every identifier, confirm locale parity, check callers), which
- *  needs reasoning headroom to do cross-file checking instead of one-pass pattern-matching. 8000 is
- *  the "think harder" tier. The plan reviewer (`plan-gate.ts`) deliberately stays unbudgeted.
- *  A one-line tunable: worst-case ~6 critic spawns/PR (DEFAULT_CAP), so ~8–48k thinking tokens/PR.
- *  Only takes effect on a thinking-capable resolved model (no-op otherwise — gate verified before
- *  ship: see issue #604). */
-export const CRITIC_THINKING_TOKENS = 8000;
-
 /** Self-contained instructions for the critic agent. NOT UI chrome — never i18n'd.
  *  `diffBase` is the RESOLVED base commit (a SHA captured by computePatchId from the same fresh
  *  fetch it fingerprints), NOT a branch name — so the review diffs the identical base the

--- a/src/review.ts
+++ b/src/review.ts
@@ -22,14 +22,13 @@ import {
   shouldSkipForPatchId,
   captureUsage,
   reapRun,
-  CRITIC_THINKING_TOKENS,
   type RawVerdict,
 } from "./critic-core";
 import { resolveAuxSpawn, type MembraneSeams } from "./spawn-membrane";
 
 // Session-agnostic critic helpers now live in ./critic-core (a forthcoming standalone-PR-critic
 // service reuses them). Re-exported here so existing importers (and tests) keep their paths.
-export { reviewPrompt, defaultComputePatchId, scopeFindings, CRITIC_THINKING_TOKENS };
+export { reviewPrompt, defaultComputePatchId, scopeFindings };
 
 /** Outcome of a consider()/forceReview() call: a critic was spawned, the run was declined
  *  (preconditions unmet / dedup / ceiling / race guard), or begin() bailed before spawning. */
@@ -576,8 +575,6 @@ export class ReviewService {
       model: env.model,
       effort: env.effort,
       prompt: reviewPrompt(diffBase, session.prompt, priorFindings, authorNotes, issueBody),
-      // Extended thinking budget (#604) — reasoning headroom for the #597 cross-file VERIFY pass.
-      thinkingTokens: CRITIC_THINKING_TOKENS,
     });
   }
 

--- a/src/standalone-critic.ts
+++ b/src/standalone-critic.ts
@@ -37,7 +37,6 @@ import {
   shouldSkipForPatchId,
   captureUsage,
   reapRun,
-  CRITIC_THINKING_TOKENS,
   type RawVerdict,
 } from "./critic-core";
 import type { VerdictRead } from "./json-tolerant";
@@ -419,9 +418,6 @@ export class StandalonePrCriticService {
       model: env.model,
       effort: env.effort,
       prompt: prReviewPrompt(diffBase, pr.title, prBody),
-      // Same extended thinking budget as the session critic (#604): the standalone PR critic runs
-      // the identical #597 VERIFY prompt and needs the same cross-file reasoning headroom.
-      thinkingTokens: CRITIC_THINKING_TOKENS,
     });
     // Fire plugin onSpawn hooks (issue #1205) + bind patched env THROUGH the membrane. Session-less
     // PR critic → no parentSessionId. An abortSpawn cleanly skips (worktree reaped).

--- a/src/transient-agent-argv.ts
+++ b/src/transient-agent-argv.ts
@@ -16,7 +16,7 @@ import type { AgentProvider } from "./types";
  *   claude
  *     --session-id <uuid>          forced so the transcript lands at a predictable path
  *     --settings <json>            { disableAllHooks:true, [enableAllProjectMcpServers:true],
- *                                    [env:{MAX_THINKING_TOKENS}], ...apiKeySettingsFragment() }
+ *                                    ...apiKeySettingsFragment() }
  *     --disable-slash-commands
  *     [--safe-mode]                emitted IFF the preset is mcpIsolated (see coupling note)
  *     --allowedTools <tools…>      VARIADIC — swallows every following token until the next --flag
@@ -39,8 +39,8 @@ import type { AgentProvider } from "./types";
  * --disable-slash-commands removes skills entirely.
  *
  * --settings key order is preserved (disableAllHooks first, then enableAllProjectMcpServers, then
- * env, then the apiKeySettingsFragment() spread) so subscription mode stays BYTE-FOR-BYTE identical
- * to the historical per-site output — the consumer argv tests are the byte-identity regression gate.
+ * the apiKeySettingsFragment() spread) so subscription mode stays BYTE-FOR-BYTE identical to the
+ * historical per-site output — the consumer argv tests are the byte-identity regression gate.
  *
  * ── MCP isolation: ONE coupled field, not two independent flags ─────────────────────────────────
  *
@@ -72,15 +72,11 @@ export interface TransientAgentArgvOptions {
   model: string | null;
   /** The agent's task — the trailing positional. */
   prompt: string;
-  /** Optional extended-thinking budget; folds into --settings env.MAX_THINKING_TOKENS only when set.
-   *  The ONLY knob that grants a spawned session's initial positional prompt a thinking budget (the
-   *  think/ultrathink magic words do NOT fire from it); a no-op on a non-thinking model. Passed by
-   *  the reviewer/doc callers only. */
-  thinkingTokens?: number;
   /** Optional reasoning-effort tier; emits `--effort` (Claude) / `-c model_reasoning_effort=`
-   *  (Codex) when set. Opt-in per call site, exactly like `thinkingTokens` — most transient roles
-   *  omit it. In-repo only the plan reviewer (plan-gate.ts) passes it in this release; the two
-   *  critic sites deliberately do NOT, keeping their spawn argv byte-unchanged. */
+   *  (Codex) when set. Opt-in per call site — most transient roles omit it. In-repo the plan
+   *  reviewer (plan-gate.ts) and both PR-critic sites (review.ts, standalone-critic.ts) pass it;
+   *  on the critic this is the reasoning channel that replaced the retired thinking-budget env
+   *  channel (issue #1419), running at `--effort high` by default. */
   effort?: string | null;
 }
 
@@ -144,14 +140,13 @@ export function buildTransientAgentArgv(
 
   // Codex CLI path: a headless, workspace-write-sandboxed `codex exec` runs the same prompt (which
   // writes the kind's result/verdict file). None of the Claude-only flags (--settings, --safe-mode,
-  // --allowedTools, thinkingTokens) have a Codex equivalent; the sandbox shape is enforced by
+  // --allowedTools) have a Codex equivalent; the sandbox shape is enforced by
   // `--sandbox workspace-write`. sessionId is returned for shape but unused (no Claude transcript).
   if (opts.provider === "codex")
     return { argv: codexRoleArgv(opts.model, opts.prompt, opts.effort ?? null), sessionId };
 
   const settings: Record<string, unknown> = { disableAllHooks: true };
   if (preset.mcpIsolated) settings.enableAllProjectMcpServers = true;
-  if (opts.thinkingTokens) settings.env = { MAX_THINKING_TOKENS: String(opts.thinkingTokens) };
   // api-key mode folds in `apiKeyHelper` AFTER the existing keys (stable order; subscription spreads
   // {} → byte-identical JSON). The membrane masks the operator's OAuth credential in place.
   Object.assign(settings, apiKeySettingsFragment());

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
-import { ReviewService, reviewPrompt, scopeFindings, CRITIC_THINKING_TOKENS } from "../src/review";
+import { ReviewService, reviewPrompt, scopeFindings } from "../src/review";
 import { PluginSpawnAborted } from "../src/plugins/types";
 import type { VerdictRead } from "../src/json-tolerant";
 import type { RawVerdict } from "../src/critic-core";
@@ -462,12 +462,11 @@ test("critic spawns read-only: no skip-permissions, dontAsk + scoped allowlist",
   expect(argv).toContain("--disable-slash-commands");
   const settingsRaw = argv[argv.indexOf("--settings") + 1];
   expect(settingsRaw).toBeDefined();
-  // The session critic carries an extended thinking budget (issue #604) so it has the
-  // reasoning headroom for the #597 cross-file verification its prompt now demands.
+  // The thinking-budget env channel was retired (issue #1419): the critic's reasoning headroom
+  // for the #597 cross-file verification now rides on --effort, so its --settings carries NO env key.
   expect(JSON.parse(settingsRaw!)).toEqual({
     disableAllHooks: true,
     enableAllProjectMcpServers: true,
-    env: { MAX_THINKING_TOKENS: String(CRITIC_THINKING_TOKENS) },
   });
   expect(argv).toContain("--safe-mode");
 });

--- a/test/standalone-critic.test.ts
+++ b/test/standalone-critic.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
 import { StandalonePrCriticService } from "../src/standalone-critic";
-import { CRITIC_THINKING_TOKENS, type RawVerdict } from "../src/critic-core";
+import type { RawVerdict } from "../src/critic-core";
 import type { VerdictRead } from "../src/json-tolerant";
 import { CRITIC_REVIEW_MARKER, EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import { config } from "../src/config";
@@ -247,11 +247,11 @@ test("reviews a fresh open green regular session-less PR", async () => {
   expect(spies.started[0]!.name).toBe("pr-critic /r#7");
   expect(spies.recordedSpawns).toHaveLength(1);
   expect(spies.recordedSpawns[0]!.taskSessionId).toBe("pr:/r#7");
-  // The standalone PR critic shares the session critic's VERIFY prompt (#597), so it gets
-  // the same extended thinking budget (#604): MAX_THINKING_TOKENS in its --settings.
+  // The thinking-budget env channel was retired (issue #1419): the standalone PR critic's
+  // reasoning now rides on --effort, so its --settings carries NO env key.
   const argv = spies.started[0]!.argv;
   const settings = JSON.parse(argv[argv.indexOf("--settings") + 1]!);
-  expect(settings.env).toEqual({ MAX_THINKING_TOKENS: String(CRITIC_THINKING_TOKENS) });
+  expect(settings.env).toBeUndefined();
 });
 
 test("threads env.effort into the standalone critic argv (issue #1418)", async () => {

--- a/test/transient-agent-argv.test.ts
+++ b/test/transient-agent-argv.test.ts
@@ -34,9 +34,9 @@ function extractAllowedTools(argv: string[]): string[] {
 
 const ALL_KINDS: TransientAgentKind[] = ["reviewer", "doc", "writer-ro", "writer-only"];
 
-// ── reasoning effort (issue #1417): opt-in per call site, like thinkingTokens ────────────────────
+// ── reasoning effort (issue #1417): opt-in per call site ─────────────────────────────────────────
 
-test("effort omitted (the critic-site posture) → no --effort, argv byte-unchanged", () => {
+test("effort omitted → no --effort, argv byte-unchanged", () => {
   const withEffort = buildTransientAgentArgv("reviewer", { model: "opus", prompt: "P" }).argv;
   expect(withEffort).not.toContain("--effort");
 });
@@ -175,17 +175,12 @@ test("coupling: --safe-mode precedes --allowedTools", () => {
   }
 });
 
-// ── thinkingTokens (reviewer/doc callers) ───────────────────────────────────────────────────────
+// ── settings carry NO env block (thinking-budget env channel retired, issue #1419) ────────────────
 
-test("thinkingTokens: omitted → no env; provided → env.MAX_THINKING_TOKENS as a string", () => {
-  expect(
-    settingsOf(buildTransientAgentArgv("reviewer", { model: null, prompt: "p" }).argv).env,
-  ).toBeUndefined();
-  const s = settingsOf(
-    buildTransientAgentArgv("reviewer", { model: null, prompt: "p", thinkingTokens: 8000 }).argv,
-  );
-  expect(s.env).toEqual({ MAX_THINKING_TOKENS: "8000" });
-  // budget must not disturb the other reviewer invariants
+test("reviewer --settings never carries an env block (thinking-budget channel retired, #1419)", () => {
+  const s = settingsOf(buildTransientAgentArgv("reviewer", { model: null, prompt: "p" }).argv);
+  expect(s.env).toBeUndefined();
+  // the retirement must not disturb the other reviewer invariants
   expect(s.disableAllHooks).toBe(true);
   expect(s.enableAllProjectMcpServers).toBe(true);
 });
@@ -208,7 +203,6 @@ test("reviewer allowlist is a CLOSED read-only set (R4): widening it fails the t
     const { argv } = buildTransientAgentArgv("reviewer", {
       model,
       prompt: "p",
-      thinkingTokens: model ? 8000 : undefined,
     });
     const tools = extractAllowedTools(argv);
     expect([...tools].sort()).toEqual([...READONLY_GIT, "Write"].sort());
@@ -312,7 +306,7 @@ test("writer-only + model 'haiku' reproduces verify-key's historical argv shape"
 // ── Codex CLI branch ────────────────────────────────────────────────────────────────────────────
 // provider "codex" routes every kind to a headless, workspace-write-sandboxed `codex exec`. The
 // file-based result contract is identical, so the caller's verdict reading is unchanged; only the
-// argv differs. None of the Claude-only flags (--settings/--safe-mode/--allowedTools/thinking) leak.
+// argv differs. None of the Claude-only flags (--settings/--safe-mode/--allowedTools) leak.
 
 test("codex provider: every kind → `codex exec --sandbox workspace-write [-m <model>] <prompt>`", () => {
   for (const kind of ALL_KINDS) {
@@ -320,7 +314,6 @@ test("codex provider: every kind → `codex exec --sandbox workspace-write [-m <
       provider: "codex",
       model: "gpt-5.5",
       prompt: "DO_IT",
-      thinkingTokens: 8000, // Claude-only; must be ignored on the Codex path
     }).argv;
     expect(withModel).toEqual([
       "codex",


### PR DESCRIPTION
## What & why

Follow-up to #1417 (effort seam) and #1418 (per-role effort matrix + critic wiring). Since #1418, each PR-critic spawn emitted **both** reasoning channels: `--effort high` (via `criticEffort` default `high`) **and** `--settings env.MAX_THINKING_TOKENS=8000`. On the default Opus-4.8 model the thinking-budget channel is dead weight, so this retires it and leaves `--effort` as the **sole** reasoning lever.

`thinkingTokens` was passed by only the two critic sites, so removing it fully orphans the mechanism — a clean, surgical retire:
- delete `CRITIC_THINKING_TOKENS` (`critic-core.ts`);
- drop `thinkingTokens` at both critic call sites (`review.ts`, `standalone-critic.ts`);
- remove the `thinkingTokens` param + the `MAX_THINKING_TOKENS` `--settings.env` fold from `buildTransientAgentArgv` (`transient-agent-argv.ts`);
- update the three critic argv tests to assert `--settings` carries **no** `env` block.

No `config.ts` change: `criticEffort` stays `high` (see gate below). Server-only internal plumbing — no UX surface (effort was already user-visible from #1418), so no i18n / design-system / feature-catalog / glossary work.

## Empirical gate (house rule: demonstrate, don't assert)

Ran the **real** `reviewPrompt` (#597 VERIFY) against a scratch repo carrying a **planted stale-caller defect** (`greet()` gains a required 2nd param; an in-diff caller still passes one arg) on **Opus 4.8 / Claude Code 2.1.201**, N=3 per config. The measured pair is the **actual** before/after argv — combined vs effort-alone — not channels in isolation:

| Config | Defect caught | Decision | Avg output tokens |
| --- | --- | --- | --- |
| **BEFORE** — `--effort high` + `MAX_THINKING_TOKENS=8000` (combined) | **3/3** | request-changes | 2516 |
| **AFTER** — `--effort high` alone | **3/3** | request-changes | 3507 |
| `--effort xhigh` alone (fallback candidate) | 3/3 | request-changes | 4541 |

**Findings:**
1. `MAX_THINKING_TOKENS=8000` on Opus 4.8 **exits 0 — it does not 400** (correcting the #1417 "400s on Opus 4.8" claim to **no-op**).
2. Removing it is **not a rigor regression**: AFTER catches the planted defect exactly as reliably as BEFORE (3/3) and yields *more* reasoning volume (3507 ≥ 2516) — the thinking budget added nothing on top of `--effort high`.
3. `--effort` is the live lever (monotone: high 3507 < xhigh 4541).

**Decision (data-driven):** since `high`-alone matches-or-exceeds the combined baseline on both signals, keep `criticEffort = high` — no bump to `xhigh` needed. Not merged on parse-green alone.

## Deferred scope

The #1417 decision-record guardrail "**lowering the critic effort warns**" is **out of scope** here to keep this a focused, low-risk channel switch. Tracked in **#1430**. This PR uses `Refs #1419` (not `Closes`) so #1419 is not marked fully complete while that Task line remains.

## Verification

- `bun run lint` ✓ · `bunx tsc --noEmit` ✓ (exit 0)
- Affected tests (`review` / `standalone-critic` / `transient-agent-argv`): 188 pass, 0 fail
- Full `bun test`: no new failures — the pre-existing UI/browser-domain failures (xterm/PWA/favicon/push) are identical with this change stashed (they run green via `cd ui && bun test`).

Refs #1419 · Follow-up #1430

🤖 Generated with [Claude Code](https://claude.com/claude-code)