### PR TITLE
fix: recover the plugin-injected account when herdr restart re-drives a session

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -280,10 +280,10 @@
       {
         "files": ["src/store.ts"],
         "functions": ["hydrate"],
-        "maxCyclomatic": 20,
-        "maxCognitive": 20,
+        "maxCyclomatic": 22,
+        "maxCognitive": 22,
         "maxCrap": 1000,
-        "reason": "Codex/default-provider persistence extends the existing hydrate migration path by one branch; keep capped until hydrate migrations are extracted."
+        "reason": "Codex/default-provider persistence + the spawn-identity columns (spawnTerminalId/spawnAccountDir, herdr-restart account recovery) extend the flat hydrate row→Session mapping by two nullable-field branches. Cyclomatic is field-count-driven, not logic — keep capped until hydrate migrations are extracted."
       },
       {
         "files": ["src/store.ts"],

--- a/src/automerge.ts
+++ b/src/automerge.ts
@@ -69,6 +69,8 @@ export interface AutoMergeDeps {
   prCache: { snapshot(): Record<string, GitState> };
   /** Whether the session's herdr pane is live (so a steer lands). */
   paneAlive: (id: string) => boolean;
+  /** Defer steering while a herdr-restored account pane still needs a re-drive (SessionService.shouldDeferSteer). */
+  deferSteer?: (id: string) => boolean;
   repos: () => string[];
   emitStatus: (s: AutoMergeStatus) => void;
   emitArchived: (id: string) => void;
@@ -355,7 +357,9 @@ export class AutoMergeService {
     const s = this.deps.store.get(sessionId);
     if (!s) return;
     this.deps.emitStatus(this.status(repoPath, true, "rebasing", s.desig, s.id));
-    if (!this.deps.paneAlive(sessionId)) {
+    if (!this.deps.paneAlive(sessionId) || this.deps.deferSteer?.(sessionId)) {
+      // Not live, OR a herdr-restored account husk that must be re-driven first (else the rebase steer
+      // lands on the wrong-account pane). resume() re-drives (Locus B) before we reply below.
       if (!(await this.deps.service.resume(sessionId))) return;
     }
     if (this.deps.service.reply(sessionId, rebaseSteer(s.baseBranch))) {

--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -116,6 +116,8 @@ export interface AutopilotDeps {
   resume: (id: string) => unknown;
   /** Whether the session's herdr pane is currently live. */
   paneAlive: (id: string) => boolean;
+  /** Defer steering while a herdr-restored account pane still needs a re-drive (SessionService.shouldDeferSteer). */
+  deferSteer?: (id: string) => boolean;
   /** Visible terminal tail for a session (herdr.read → tailLines). */
   readTail: (id: string) => string[];
   /** Whether the session already has a PR in any state (open/merged/closed). True → autopilot
@@ -290,9 +292,10 @@ export class AutopilotService {
   /** Send `text` into the session, resuming an exited pane first. Returns whether the steer
    *  landed; does NOT bump the step (the caller decides whether the attempt counts). */
   private async sendSteer(s: Session, text: string): Promise<boolean> {
-    if (!this.deps.paneAlive(s.id)) {
-      // Exited pane: resume so there's something to steer. resume() resolves falsy when it
-      // can't (archived / no pinned session id) — then there's nothing to do.
+    if (!this.deps.paneAlive(s.id) || this.deps.deferSteer?.(s.id)) {
+      // Not live, OR a herdr-restored account husk to re-drive first (Locus B) so the steer lands on the
+      // re-driven pane, not the wrong-account husk. resume() resolves falsy when it can't (archived /
+      // no pinned session id) — then there's nothing to do.
       if (!(await this.deps.resume(s.id))) return false;
     }
     return this.deps.steer(s.id, text);

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -121,6 +121,20 @@ export function matchAgent(
 }
 
 /**
+ * True when `agent` is a pane herdr re-created (its terminalId is NOT the one Shepherd last spawned
+ * on the owning account) for a session that HAS an owning plugin account. Such a pane is a bare
+ * `claude --resume` under the wrong CLAUDE_CONFIG_DIR and must be re-driven through onSpawn, not
+ * adopted/steered. Keys on spawnTerminalId (written only by the spawn-finish path, never by
+ * reconcile/poller) so their re-pointing of herdrAgentId cannot mask a herdr-restored husk.
+ */
+export function needsAccountRedrive(
+  s: { spawnAccountDir: string | null; spawnTerminalId: string | null },
+  agent: { terminalId: string },
+): boolean {
+  return s.spawnAccountDir !== null && agent.terminalId !== s.spawnTerminalId;
+}
+
+/**
  * Pick the cwd-fallback agent for one still-unmatched session from the untaken
  * candidates. When the session contends for its cwd with another active session, only
  * an unambiguous agent-NAME match is safe; a sole session adopts its lone cwd agent via

--- a/src/hold-service.test.ts
+++ b/src/hold-service.test.ts
@@ -57,6 +57,8 @@ function makeSession(overrides: Partial<Session> = {}): Session {
     experimentId: null,
     experimentRole: null,
     completionRepromptCount: 0,
+    spawnTerminalId: null,
+    spawnAccountDir: null,
     ...overrides,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1048,7 +1048,10 @@ const reviewService = new ReviewService({
   // auto-address: steer critic findings straight into the task agent's PTY (same path
   // as a human "send review to agent"). Gated per-repo by autoAddressEnabled; the
   // round cap below stops it ping-ponging forever.
-  autoAddress: (id, text) => service.reply(id, text),
+  // Defer while a herdr-restored account pane still needs a re-drive: return false (round holds,
+  // retries next cycle) rather than steer findings into the wrong-account husk. The poller heals it
+  // within ~1 tick (Locus A); shouldDeferSteer goes false once healed or bounded-out (degraded).
+  autoAddress: (id, text) => (service.shouldDeferSteer(id) ? false : service.reply(id, text)),
   // global, UI-configurable max auto-address rounds before escalating to the human.
   // A thunk so a settings change takes effect on the next critic run, no restart.
   cap: () => config.prReviewCyclesCap,
@@ -1096,7 +1099,10 @@ const planGate = new PlanGateService({
   resolveForge,
   // Plugin onSpawn hooks fire for reviewer-style aux spawns too (issue #1205); no-op until loadAll.
   runSpawnHooks: (d) => pluginRegistry.runSpawnHooks(d),
-  reply: (id, text) => service.reply(id, text),
+  // Defer while a herdr-restored account pane still needs a re-drive: return false so the plan-gate
+  // round holds (retries next cycle) instead of steering findings into the wrong-account husk. The
+  // poller heals it within ~1 tick (Locus A); shouldDeferSteer clears once healed or degraded.
+  reply: (id, text) => (service.shouldDeferSteer(id) ? false : service.reply(id, text)),
   release: (id) => service.releasePlanGate(id),
   // Per-role plan-reviewer model thunk (read per spawn → live settings).
   env: () => roleEnv(config.plannerCli, config.plannerModel, config.plannerEffort),

--- a/src/index.ts
+++ b/src/index.ts
@@ -755,6 +755,10 @@ const poller = new StatusPoller(
   usageLimits,
 );
 
+// Proactively re-drive a herdr-restored plugin/account pane (herdr's bare `claude --resume` lost the
+// account's CLAUDE_CONFIG_DIR). Fire-and-forget; reDriveAccount is per-session guarded + bounded.
+poller.reDrive = (id) => void service.reDriveAccount(id);
+
 // Phase-1 push-hook signal wiring (issue #704): feed received hook events into the
 // poller (the single owner of per-session signal dedup + state). Only when
 // `config.hooksSignals` is on AND ingest is too — with ingest off no events ever

--- a/src/index.ts
+++ b/src/index.ts
@@ -757,7 +757,12 @@ const poller = new StatusPoller(
 
 // Proactively re-drive a herdr-restored plugin/account pane (herdr's bare `claude --resume` lost the
 // account's CLAUDE_CONFIG_DIR). Fire-and-forget; reDriveAccount is per-session guarded + bounded.
-poller.reDrive = (id) => void service.reDriveAccount(id);
+// Swallow rejections so an unexpected internal throw can't surface as an unhandled rejection off the
+// 1s poll path (the expected refusals already resolve to "refused", never reject).
+poller.reDrive = (id) =>
+  void service.reDriveAccount(id).catch((err) => {
+    console.warn(`[poller] account re-drive failed for ${id}:`, err);
+  });
 
 // Phase-1 push-hook signal wiring (issue #704): feed received hook events into the
 // poller (the single owner of per-session signal dedup + state). Only when

--- a/src/index.ts
+++ b/src/index.ts
@@ -1392,6 +1392,7 @@ const autopilot = new AutopilotService({
     const s = store.get(id);
     return !!s && matchAgent(s, herdr.list()) !== null;
   },
+  deferSteer: (id) => service.shouldDeferSteer(id),
   readTail: (id) => {
     const s = store.get(id);
     if (!s) return [];
@@ -1586,6 +1587,7 @@ const autoMerge = new AutoMergeService({
     const s = store.get(id);
     return !!s && matchAgent(s, herdr.list()) !== null;
   },
+  deferSteer: (id) => service.shouldDeferSteer(id),
   repos: () => listRepos(config.repoRoot).map((r) => r.path),
   emitStatus: (status) => events.emit("automerge:status", status),
   emitArchived: (id) => events.emit("session:archived", { id }),

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -1,6 +1,12 @@
 import type { SessionStore } from "./store";
 import type { Session } from "./types";
-import { mapState, matchAgents, type HerdrDriver, type HerdrAgent } from "./herdr";
+import {
+  mapState,
+  matchAgents,
+  needsAccountRedrive,
+  type HerdrDriver,
+  type HerdrAgent,
+} from "./herdr";
 import {
   classifyBlocked,
   hasActiveSpinner,
@@ -82,6 +88,10 @@ export interface LivenessWiring {
 }
 
 export class StatusPoller {
+  /** Fire-and-forget re-drive of a herdr-restored account pane (wired to service.reDriveAccount in
+   *  index.ts). Left undefined in tests that don't exercise it. */
+  reDrive?: (id: string) => void;
+
   private timer: ReturnType<typeof setInterval> | null = null;
   private lastReadAt = new Map<string, number>();
   private lastSig = new Map<string, string>();
@@ -411,6 +421,17 @@ export class StatusPoller {
 
   /** Sync a live agent's status into the store and route its block/stall handling. */
   private reconcileAgent(s: Session, agent: HerdrAgent): void {
+    // A herdr-restored account pane (its terminalId is not the one Shepherd spawned on the owning
+    // account). Fire a proactive re-drive so onSpawn re-applies the account; reDriveAccount is
+    // guarded (coalesces with any concurrent resume) and bounded (gives up after CAP). Non-blocking:
+    // tick() runs on a bare setInterval and must never throw.
+    if (needsAccountRedrive(s, agent) && this.reDrive) {
+      try {
+        this.reDrive(s.id);
+      } catch (err) {
+        console.warn(`[poller] account re-drive dispatch failed for ${s.id}:`, err);
+      }
+    }
     const status = mapState(agent.agentStatus);
     const idChanged = agent.terminalId !== s.herdrAgentId;
     if (idChanged || status !== s.status || agent.agentStatus !== s.lastState) {

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -420,18 +420,23 @@ export class StatusPoller {
   }
 
   /** Sync a live agent's status into the store and route its block/stall handling. */
-  private reconcileAgent(s: Session, agent: HerdrAgent): void {
-    // A herdr-restored account pane (its terminalId is not the one Shepherd spawned on the owning
-    // account). Fire a proactive re-drive so onSpawn re-applies the account; reDriveAccount is
-    // guarded (coalesces with any concurrent resume) and bounded (gives up after CAP). Non-blocking:
-    // tick() runs on a bare setInterval and must never throw.
-    if (needsAccountRedrive(s, agent) && this.reDrive) {
-      try {
-        this.reDrive(s.id);
-      } catch (err) {
-        console.warn(`[poller] account re-drive dispatch failed for ${s.id}:`, err);
-      }
+  /**
+   * A herdr-restored account pane (its terminalId is not the one Shepherd spawned on the owning
+   * account) → fire a proactive re-drive so onSpawn re-applies the account. reDriveAccount is guarded
+   * (coalesces with any concurrent resume) and bounded (gives up after CAP). Non-blocking + swallows
+   * throws: tick() runs on a bare setInterval and must never throw.
+   */
+  private maybeReDriveRestoredAccount(s: Session, agent: HerdrAgent): void {
+    if (!needsAccountRedrive(s, agent) || !this.reDrive) return;
+    try {
+      this.reDrive(s.id);
+    } catch (err) {
+      console.warn(`[poller] account re-drive dispatch failed for ${s.id}:`, err);
     }
+  }
+
+  private reconcileAgent(s: Session, agent: HerdrAgent): void {
+    this.maybeReDriveRestoredAccount(s, agent);
     const status = mapState(agent.agentStatus);
     const idChanged = agent.terminalId !== s.herdrAgentId;
     if (idChanged || status !== s.status || agent.agentStatus !== s.lastState) {

--- a/src/service.ts
+++ b/src/service.ts
@@ -7,7 +7,7 @@ import type { RepoConfig, SessionStore } from "./store";
 import type { EventHub } from "./events";
 import type { WorktreeMgr } from "./worktree";
 import type { HerdrAgent, HerdrDriver } from "./herdr";
-import { matchAgents } from "./herdr";
+import { matchAgents, needsAccountRedrive } from "./herdr";
 import { config } from "./config";
 import type {
   AgentProvider,
@@ -1354,6 +1354,19 @@ export class SessionService {
   private readonly resumeInFlight = new Map<string, Promise<Session | null>>();
 
   /**
+   * Bounded-attempt bookkeeping for `reDriveAccount` (herdr-restart account-loss fix, task 4a).
+   * Keyed by session id; the `anchor` is the session's `spawnTerminalId` AT the time of the FIRST
+   * counted attempt for this husk — stable across unhealed/refused re-drives (persistSpawnIdentity
+   * preserves spawnTerminalId when the account doesn't come back), so it survives an unhealed
+   * re-drive's terminalId churn without resetting. Only a heal (spawnTerminalId advances) clears the
+   * entry. See `reDriveAccount` for the give-up logic.
+   */
+  private readonly redriveAttempts = new Map<string, { anchor: string | null; attempts: number }>();
+  /** After this many failed (refused/unhealed) re-drive attempts on the SAME anchor, give up
+   *  ("degraded") rather than re-firing every poller tick forever. */
+  private static readonly REDRIVE_CAP = 3;
+
+  /**
    * Merge-train completion tracker (issue #426). A train that lands ≥1 of its
    * queue PRs should offer a local-checkout fast-forward once, per repo. We track
    * each launched train so we can emit `mergetrain:landed` exactly when the run
@@ -2164,17 +2177,6 @@ export class SessionService {
 
     this.deps.store.update(session.id, { herdrAgentId: agent.terminalId });
     return this.deps.store.get(session.id);
-  }
-
-  /**
-   * A live pane that herdr re-created (its terminalId is NOT the one Shepherd last spawned on the
-   * owning account) for a session that HAS an owning plugin account. Such a pane is a bare
-   * `claude --resume` under the wrong CLAUDE_CONFIG_DIR — it must be re-driven through onSpawn, not
-   * adopted. Keys on spawnTerminalId (written only by the spawn-finish path, never by
-   * reconcile/poller) so their re-pointing of herdrAgentId cannot mask a herdr-restored husk.
-   */
-  private needsAccountRedrive(s: Session, agent: HerdrAgent): boolean {
-    return s.spawnAccountDir !== null && agent.terminalId !== s.spawnTerminalId;
   }
 
   private resumeRefusedByAutoGate(session: Session): boolean {
@@ -3123,7 +3125,7 @@ export class SessionService {
 
     const { session, provider } = target;
     const agent = this.liveAgentFor(id);
-    if (agent && !opts.force && !this.needsAccountRedrive(session, agent)) {
+    if (agent && !opts.force && !needsAccountRedrive(session, agent)) {
       // Already live (idle at the prompt, or restored by a herdr restart under a new terminalId)
       // AND either a default session or already on its owning account. Adopt; never spawn a second
       // claude.
@@ -3169,20 +3171,47 @@ export class SessionService {
 
   /**
    * Force-re-drive a herdr-restored account pane so onSpawn re-applies its CLAUDE_CONFIG_DIR.
-   * Serialized by resume()'s per-session guard. Returns:
-   *   "healed"   — re-spawned AND persistSpawnIdentity advanced spawnTerminalId (owning account restored)
-   *   "unhealed" — re-spawned but the account did NOT come back (folded null over a non-null prior;
-   *                persistSpawnIdentity preserved the marker) — plugin state loss / pool exhaustion
-   *   "refused"  — resume returned null (auto-gate refused BEFORE teardown, or spawn failed); husk preserved
-   * Later tasks use the verdict for bounded-attempt bookkeeping.
+   * Serialized by resume()'s per-session guard. Public: the poller (`index.ts` wiring) calls this
+   * as a fire-and-forget re-drive on a herdr-restored account pane. Returns:
+   *   "healed"    — re-spawned AND persistSpawnIdentity advanced spawnTerminalId (owning account restored)
+   *   "unhealed"  — re-spawned but the account did NOT come back (folded null over a non-null prior;
+   *                 persistSpawnIdentity preserved the marker) — plugin state loss / pool exhaustion
+   *   "refused"   — resume returned null (auto-gate refused BEFORE teardown, or spawn failed); husk preserved
+   *   "degraded"  — gave up after REDRIVE_CAP failed (unhealed/refused) attempts on the SAME
+   *                 spawnTerminalId anchor; no spawn attempted. Steering stays permitted on the
+   *                 current pane (no-worse-than-today; the steer-defer guard is a later task).
+   *
+   * Bounded: a persistently-failing account (e.g. usage-halted — the auto-gate refuses BEFORE
+   * teardown so spawnTerminalId never advances) would otherwise re-fire every poller tick forever.
+   * The counter is anchored on spawnTerminalId, NOT the husk/live terminalId: an unhealed re-drive
+   * (onSpawn returns `{}` → a fresh default-account pane) changes the live terminalId every attempt,
+   * so a husk-keyed counter would reset every time and never reach the cap. spawnTerminalId is
+   * stable across unhealed/refused attempts and only advances on a heal, so it is the correct
+   * give-up anchor.
    */
-  private async reDriveAccount(id: string): Promise<"healed" | "unhealed" | "refused"> {
+  async reDriveAccount(id: string): Promise<"healed" | "unhealed" | "refused" | "degraded"> {
     const before = this.deps.store.get(id);
     if (!before) return "refused";
-    const priorTerminalId = before.spawnTerminalId;
+    const anchor = before.spawnTerminalId; // stable until a heal advances it
+    const rec = this.redriveAttempts.get(id);
+    if (rec && rec.anchor === anchor && rec.attempts >= SessionService.REDRIVE_CAP) {
+      return "degraded"; // gave up on this husk; no spawn — steering stays as today (no-worse)
+    }
     const s = await this.resume(id, { force: true });
-    if (!s) return "refused";
-    return s.spawnTerminalId !== priorTerminalId ? "healed" : "unhealed";
+    const verdict = !s ? "refused" : s.spawnTerminalId !== anchor ? "healed" : "unhealed";
+    if (verdict === "healed") {
+      this.redriveAttempts.delete(id);
+    } else {
+      const attempts = rec && rec.anchor === anchor ? rec.attempts + 1 : 1;
+      this.redriveAttempts.set(id, { anchor, attempts });
+      if (attempts >= SessionService.REDRIVE_CAP) {
+        console.warn(
+          `[resume] account re-drive for ${id} gave up after ${attempts} failed attempts ` +
+            `(anchor ${anchor ?? "null"}): DEGRADED — steering permitted on the current pane`,
+        );
+      }
+    }
+    return verdict;
   }
 
   /**

--- a/src/service.ts
+++ b/src/service.ts
@@ -3215,6 +3215,24 @@ export class SessionService {
   }
 
   /**
+   * True when a steer/reply should be deferred because the session's live pane is a herdr-restored
+   * account husk not yet re-driven (and not yet exhausted). Autonomous steer paths consult this: true →
+   * route through resume() (Locus B re-drive) instead of steering the wrong-account husk. Goes false
+   * once healed (needsAccountRedrive clears) OR degraded (bounded re-drive hit CAP — steering resumes
+   * as today). Closes the race where a caller steers before the poller's proactive re-drive lands.
+   */
+  shouldDeferSteer(id: string): boolean {
+    const s = this.deps.store.get(id);
+    if (!s || s.spawnAccountDir === null) return false;
+    const agent = this.liveAgentFor(id);
+    if (!agent || !needsAccountRedrive(s, agent)) return false;
+    const rec = this.redriveAttempts.get(id);
+    const exhausted =
+      !!rec && rec.anchor === s.spawnTerminalId && rec.attempts >= SessionService.REDRIVE_CAP;
+    return !exhausted;
+  }
+
+  /**
    * Restore an archived session: re-create its worktree (if isolated), resume the Claude
    * conversation via `--resume`, and clear `archivedAt` so the session re-enters the Herd.
    *
@@ -3408,7 +3426,9 @@ export class SessionService {
       const s = this.deps.store.get(id);
       if (!s) continue;
       let succeeded = false;
-      if (live.has(s.herdrAgentId)) {
+      // A live herdr-restored account husk must be deferred to resume() (Locus B re-drive) rather
+      // than steered — else the retry lands on the wrong-account pane.
+      if (live.has(s.herdrAgentId) && !this.shouldDeferSteer(id)) {
         if (this.replyToLive(id, continueText, live)) {
           steered++;
           succeeded = true;

--- a/src/service.ts
+++ b/src/service.ts
@@ -1237,6 +1237,10 @@ type SpawnSuccess = {
   egressApplied: boolean;
   /** True when an interactive autonomous session ran FS-only because egress was unavailable. */
   egressDegraded: boolean;
+  /** The folded PLUGIN credentialDir (patchEnv.CLAUDE_CONFIG_DIR) this spawn used, or null — the
+   *  OWNED account for herdr-restore re-drive; excludes the api-key mirror, which shares
+   *  ~/.claude/projects/. */
+  spawnAccountDir: string | null;
 };
 type SpawnOutcome =
   SpawnSuccess | { ok: false; holdReason: string; abortCause?: PluginSpawnAborted };
@@ -1771,6 +1775,7 @@ export class SessionService {
       degraded,
       egressApplied: egressOn,
       egressDegraded,
+      spawnAccountDir: patchEnv.CLAUDE_CONFIG_DIR ?? null,
     };
   }
 
@@ -2193,7 +2198,47 @@ export class SessionService {
       egressApplied: outcome.egressApplied,
       egressDegraded: outcome.egressDegraded,
     });
+    this.persistSpawnIdentity(session, outcome);
     return this.deps.store.get(session.id);
+  }
+
+  /**
+   * The SINGLE writer of the poller/reconcile-immune spawn-identity markers
+   * (spawnTerminalId/spawnAccountDir) — herdr-restart account-loss detection.
+   * Applies a sticky, conditional rule so a failed/wrong re-derivation can never silently
+   * self-clear the owning account onto the default:
+   *
+   * | folded (outcome.spawnAccountDir) | prior session.spawnAccountDir | action                                        |
+   * | --------------------------------- | ------------------------------ | ---------------------------------------------- |
+   * | non-null                          | any                             | (re)confirmed owning account — advance terminal |
+   * | null                               | null                            | default session — advance terminal              |
+   * | null                               | non-null                        | preserve prior (do NOT advance, do NOT null)    |
+   *
+   * The last row leaves a later task's `needsAccountRedrive` armed (unadvanced spawnTerminalId
+   * vs. the live herdrAgentId), and warns loudly — plugin state loss / pool exhaustion.
+   */
+  private persistSpawnIdentity(
+    session: Session,
+    outcome: Extract<SpawnOutcome, { ok: true }>,
+  ): "healed" | "unhealed" {
+    const folded = outcome.spawnAccountDir;
+    if (folded !== null) {
+      this.deps.store.setSpawnIdentity(session.id, outcome.terminalId, folded);
+      return "healed";
+    }
+    if (session.spawnAccountDir === null) {
+      this.deps.store.setSpawnIdentity(session.id, outcome.terminalId, null);
+      return "healed";
+    }
+    // folded === null but a prior owning account was recorded: preserve it verbatim — do NOT
+    // advance the terminal, do NOT null the dir. Loud because this means the owning account
+    // was NOT restored on this spawn (plugin state loss / pool exhaustion).
+    console.warn(
+      `[spawn-identity] ${session.id}: owning account not restored this spawn ` +
+        `(prior spawnAccountDir=${session.spawnAccountDir}); preserving prior identity`,
+    );
+    this.deps.store.setSpawnIdentity(session.id, session.spawnTerminalId, session.spawnAccountDir);
+    return "unhealed";
   }
 
   /**
@@ -2421,6 +2466,10 @@ export class SessionService {
         research: spawnInput.research ?? false,
         mergeTrainPrs: spawnInput.mergeTrainPrs,
       });
+      // The row exists post-create; read it back so persistSpawnIdentity sees the persisted
+      // (null) prior spawn-identity fields rather than relying on the in-memory shape.
+      const created = this.deps.store.get(sessionId);
+      if (created) this.persistSpawnIdentity(created, outcome);
       // Attended sessions stay unapproved until a human clicks Approve in the UI.
       // Autopilot sessions are pre-approved so the agent can begin executing immediately
       // after authoring the queue without waiting for a human gate that will never come.
@@ -2698,6 +2747,8 @@ export class SessionService {
         egressApplied: outcome.egressApplied,
         egressDegraded: outcome.egressDegraded,
       });
+      const updated = this.deps.store.get(s.id);
+      if (updated) this.persistSpawnIdentity(updated, outcome);
     } catch (e) {
       try {
         this.deps.herdr.stop(outcome.terminalId);

--- a/src/service.ts
+++ b/src/service.ts
@@ -2166,6 +2166,17 @@ export class SessionService {
     return this.deps.store.get(session.id);
   }
 
+  /**
+   * A live pane that herdr re-created (its terminalId is NOT the one Shepherd last spawned on the
+   * owning account) for a session that HAS an owning plugin account. Such a pane is a bare
+   * `claude --resume` under the wrong CLAUDE_CONFIG_DIR — it must be re-driven through onSpawn, not
+   * adopted. Keys on spawnTerminalId (written only by the spawn-finish path, never by
+   * reconcile/poller) so their re-pointing of herdrAgentId cannot mask a herdr-restored husk.
+   */
+  private needsAccountRedrive(s: Session, agent: HerdrAgent): boolean {
+    return s.spawnAccountDir !== null && agent.terminalId !== s.spawnTerminalId;
+  }
+
   private resumeRefusedByAutoGate(session: Session): boolean {
     const hold = session.auto ? this.resumeAutoHold(session) : null;
     if (!hold) return false;
@@ -3112,11 +3123,16 @@ export class SessionService {
 
     const { session, provider } = target;
     const agent = this.liveAgentFor(id);
-    if (agent && !opts.force) {
-      // Already live (idle at the prompt, or restored by a herdr restart under a new
-      // terminalId). Adopt the fresh id if it drifted; never spawn a second claude.
+    if (agent && !opts.force && !this.needsAccountRedrive(session, agent)) {
+      // Already live (idle at the prompt, or restored by a herdr restart under a new terminalId)
+      // AND either a default session or already on its owning account. Adopt; never spawn a second
+      // claude.
       return this.adoptLiveResumeAgent(session, agent);
     }
+    // Fall through (force, OR a herdr-restored account pane — Locus B): a bare `claude --resume` under
+    // the wrong CLAUDE_CONFIG_DIR must be torn down and re-driven through onSpawn so the account is
+    // re-applied, BEFORE a human PTY attaches to it (raw keystrokes bypass the steer gate). The
+    // teardown + prepareResumeSpawn below does exactly that; persistSpawnIdentity records the heal.
 
     // Re-check the auto-gate BEFORE tearing down the existing husk — a refused resume
     // must not kill a live agent (mirrors drain's pre-check). So a mid-flight profile or

--- a/src/service.ts
+++ b/src/service.ts
@@ -3145,11 +3145,12 @@ export class SessionService {
     const trim = await this.trimFor(session.auto);
     // Forced respawn over a live agent: close the stale husk tab first so it doesn't
     // leak alongside the fresh one. (No-op when the agent is already gone.)
-    // PLUGIN NOTE (#1124): this teardown runs ONLY on a forced resume (a non-forced
-    // resume with a live agent returned early above; a non-forced resume with no live
-    // agent has no husk). So if a plugin onSpawn then hard-blocks via abortSpawn, the
-    // husk is already gone and the session is left stopped — intended: a forced resume
-    // is an explicit "replace the live agent" action, and aborting it (e.g. "don't run
+    // PLUGIN NOTE (#1124): this teardown runs on a forced resume OR a non-forced Locus-B
+    // re-drive of a herdr-restored account pane (needsAccountRedrive above) — the only two
+    // ways past the adopt early-return with a live agent. So if a plugin onSpawn then
+    // hard-blocks via abortSpawn, the husk is already gone and the session is left stopped —
+    // intended: replacing the live agent is deliberate (an explicit "bring agent back", or a
+    // restored wrong-account husk), and aborting it (e.g. "don't run
     // under the wrong account") is honored by NOT spawning a replacement.
     if (agent) this.deps.herdr.stop(agent.terminalId);
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -1344,6 +1344,16 @@ export class SessionService {
   constructor(private deps: ServiceDeps) {}
 
   /**
+   * Per-session resume() in-flight guard (herdr-restart account-loss fix, task 2).
+   * `resume()` has many entrypoints (HTTP "bring agent back", the autonomous resume
+   * deps, and a later poller re-drive) that can race on one session id, each tearing
+   * down + re-spawning a herdr agent — two racing calls would double-spawn (a leaked
+   * husk + last-write-wins spawnTerminalId). Keyed by session id so cross-session
+   * resumes are never serialized against each other.
+   */
+  private readonly resumeInFlight = new Map<string, Promise<Session | null>>();
+
+  /**
    * Merge-train completion tracker (issue #426). A train that lands ≥1 of its
    * queue PRs should offer a local-checkout fast-forward once, per repo. We track
    * each launched train so we can emit `mergetrain:landed` exactly when the run
@@ -3079,8 +3089,24 @@ export class SessionService {
    * lost, and the control is only surfaced/clicked when the user believes they're
    * stranded. Guaranteeing the husk case works (always respawn) beats preserving
    * scrollback in the rare misclick-on-live-claude case.
+   *
+   * Serialized per session id by the resumeInFlight guard below: a concurrent resume
+   * for the same id coalesces onto the SAME in-flight promise rather than starting a
+   * second spawn. The FIRST caller's `opts` win; a second caller racing in with e.g.
+   * `force: true` does not get its own spawn — this is the double-spawn-safe choice (a
+   * stricter "await then run mine" would still allow a second spawn). Cross-session
+   * resumes are unaffected — the guard is keyed by id.
    */
   async resume(id: string, opts: { force?: boolean } = {}): Promise<Session | null> {
+    const existing = this.resumeInFlight.get(id);
+    if (existing) return existing; // coalesce: a resume for this id is already running
+    const p = this.resumeInner(id, opts).finally(() => this.resumeInFlight.delete(id));
+    this.resumeInFlight.set(id, p);
+    return p;
+  }
+
+  /** resume() body; serialized per session by the public resume() guard. */
+  private async resumeInner(id: string, opts: { force?: boolean } = {}): Promise<Session | null> {
     const target = this.resumeTarget(id);
     if (!target) return null;
 
@@ -3122,6 +3148,24 @@ export class SessionService {
       return null;
     }
     return this.finishResumeSpawn(session, outcome);
+  }
+
+  /**
+   * Force-re-drive a herdr-restored account pane so onSpawn re-applies its CLAUDE_CONFIG_DIR.
+   * Serialized by resume()'s per-session guard. Returns:
+   *   "healed"   — re-spawned AND persistSpawnIdentity advanced spawnTerminalId (owning account restored)
+   *   "unhealed" — re-spawned but the account did NOT come back (folded null over a non-null prior;
+   *                persistSpawnIdentity preserved the marker) — plugin state loss / pool exhaustion
+   *   "refused"  — resume returned null (auto-gate refused BEFORE teardown, or spawn failed); husk preserved
+   * Later tasks use the verdict for bounded-attempt bookkeeping.
+   */
+  private async reDriveAccount(id: string): Promise<"healed" | "unhealed" | "refused"> {
+    const before = this.deps.store.get(id);
+    if (!before) return "refused";
+    const priorTerminalId = before.spawnTerminalId;
+    const s = await this.resume(id, { force: true });
+    if (!s) return "refused";
+    return s.spawnTerminalId !== priorTerminalId ? "healed" : "unhealed";
   }
 
   /**

--- a/src/service.ts
+++ b/src/service.ts
@@ -2237,21 +2237,23 @@ export class SessionService {
    * | null                               | null                            | default session — advance terminal              |
    * | null                               | non-null                        | preserve prior (do NOT advance, do NOT null)    |
    *
-   * The last row leaves a later task's `needsAccountRedrive` armed (unadvanced spawnTerminalId
-   * vs. the live herdrAgentId), and warns loudly — plugin state loss / pool exhaustion.
+   * The last row leaves `needsAccountRedrive` armed (unadvanced spawnTerminalId vs. the live
+   * herdrAgentId), and warns loudly — plugin state loss / pool exhaustion. Returns nothing: callers
+   * that need the healed/unhealed verdict (reDriveAccount) derive it from whether spawnTerminalId
+   * advanced, since this runs below resume()'s Session return and can't propagate a value up.
    */
   private persistSpawnIdentity(
     session: Session,
     outcome: Extract<SpawnOutcome, { ok: true }>,
-  ): "healed" | "unhealed" {
+  ): void {
     const folded = outcome.spawnAccountDir;
     if (folded !== null) {
       this.deps.store.setSpawnIdentity(session.id, outcome.terminalId, folded);
-      return "healed";
+      return;
     }
     if (session.spawnAccountDir === null) {
       this.deps.store.setSpawnIdentity(session.id, outcome.terminalId, null);
-      return "healed";
+      return;
     }
     // folded === null but a prior owning account was recorded: preserve it verbatim — do NOT
     // advance the terminal, do NOT null the dir. Loud because this means the owning account
@@ -2261,7 +2263,6 @@ export class SessionService {
         `(prior spawnAccountDir=${session.spawnAccountDir}); preserving prior identity`,
     );
     this.deps.store.setSpawnIdentity(session.id, session.spawnTerminalId, session.spawnAccountDir);
-    return "unhealed";
   }
 
   /**

--- a/src/store.ts
+++ b/src/store.ts
@@ -205,6 +205,8 @@ type NewSession = Omit<
   | "manualStepsAckedAt"
   | "experimentId"
   | "experimentRole"
+  | "spawnTerminalId"
+  | "spawnAccountDir"
 > & {
   id?: string;
   model?: string | null;
@@ -232,7 +234,8 @@ const COLS = `id, desig, name, prompt, repoPath, baseBranch, branch, worktreePat
   auto, issueNumber, sandboxApplied, sandboxDegraded, egressApplied, egressDegraded,
   research,
   createdAt, updatedAt, archivedAt, mergingSince, mergingTrainId, mergeTrainPrs, mergingPrNumber,
-  haltReason, haltedAt, manualStepsJson, manualStepsAckedAt, experimentId, experimentRole`;
+  haltReason, haltedAt, manualStepsJson, manualStepsAckedAt, experimentId, experimentRole,
+  spawnTerminalId, spawnAccountDir`;
 
 // ── SQLite row shapes ──────────────────────────────────────────────────────────
 
@@ -287,6 +290,8 @@ type SessionRow = {
   manualStepsAckedAt: number | null;
   experimentId: string | null;
   experimentRole: string | null;
+  spawnTerminalId: string | null;
+  spawnAccountDir: string | null;
 };
 
 /** SQLite row shape for the reviews table. */
@@ -1750,6 +1755,8 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       manualStepsAckedAt: null,
       experimentId: null,
       experimentRole: null,
+      spawnTerminalId: null, // stamped post-create by persistSpawnIdentity
+      spawnAccountDir: null,
     };
   }
 
@@ -1759,7 +1766,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       const seq = this.nextDesignationSeq();
       const s = this.buildSessionRow(input, seq, now);
       this.db.run(
-        `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+        `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
         [
           s.id,
           s.desig,
@@ -1810,6 +1817,8 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
           null, // manualStepsAckedAt — always null at create (P2)
           null, // experimentId — always null at create (stamped post-create by startVariant/startComparison)
           null, // experimentRole — always null at create
+          null, // spawnTerminalId — always null at create (stamped post-create by persistSpawnIdentity)
+          null, // spawnAccountDir — always null at create
         ],
       );
       return s;
@@ -2764,6 +2773,21 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     ]);
   }
 
+  /** Write the poller/reconcile-immune spawn-identity markers (herdr-restart account-loss
+   *  detection). The ONLY writer is {@link SessionService}'s `persistSpawnIdentity` helper,
+   *  which applies the sticky/conditional rule (never null-over-non-null); this setter itself
+   *  is an unconditional targeted UPDATE, mirroring {@link setHaltReason}. */
+  setSpawnIdentity(
+    id: string,
+    spawnTerminalId: string | null,
+    spawnAccountDir: string | null,
+  ): void {
+    this.db.run(
+      `UPDATE sessions SET spawnTerminalId=?, spawnAccountDir=?, updatedAt=? WHERE id=?`,
+      [spawnTerminalId, spawnAccountDir, Date.now(), id],
+    );
+  }
+
   /** Persist the manual operator steps detected in a session's PR body (#1059). Stored as a JSON
    *  array; an empty array clears any prior detection. Dedicated setter (the generic update()
    *  whitelist would silently drop it), mirroring {@link setHaltReason}'s direct-UPDATE style. */
@@ -3010,6 +3034,11 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     // rows default to null (not part of any experiment).
     add("experimentId", `experimentId TEXT`);
     add("experimentRole", `experimentRole TEXT`);
+    // Poller/reconcile-immune spawn-identity markers (herdr-restart account-loss detection):
+    // the terminalId of the pane Shepherd itself last spawned on the owning account, and that
+    // account's CLAUDE_CONFIG_DIR. Both nullable; written only via setSpawnIdentity.
+    add("spawnTerminalId", `spawnTerminalId TEXT`);
+    add("spawnAccountDir", `spawnAccountDir TEXT`);
   }
 
   // Migrate build_queue_steps from the legacy global `PRIMARY KEY (id)` to the composite
@@ -4296,6 +4325,8 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
         r.experimentRole === "variant" || r.experimentRole === "comparison"
           ? (r.experimentRole as ExperimentRole)
           : null,
+      spawnTerminalId: r.spawnTerminalId ?? null,
+      spawnAccountDir: r.spawnAccountDir ?? null,
     } as Session;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,15 @@ export interface Session {
   experimentId: string | null;
   /** This session's role within its experiment; null when not in one. */
   experimentRole: ExperimentRole | null;
+  /** terminalId of the pane Shepherd itself last spawned on the OWNING account (advances only
+   *  on a verified spawn — see persistSpawnIdentity); null for a session with no verified spawn
+   *  yet. Poller/reconcile-immune marker used to detect a herdr-restored pane. */
+  spawnTerminalId: string | null;
+  /** The owning account's CLAUDE_CONFIG_DIR (folded plugin credentialDir) as of the last verified
+   *  spawn; null for the default / no-plugin / api-key session. Sticky: never overwritten to null
+   *  once set (see persistSpawnIdentity) — a failed/wrong re-derivation can't silently self-clear
+   *  onto the default account. */
+  spawnAccountDir: string | null;
 }
 
 /**

--- a/test/automerge.test.ts
+++ b/test/automerge.test.ts
@@ -150,6 +150,39 @@ test("dead pane → resume attempted before steer; counter bumped once resumed",
   expect((setState as any).mock.calls[0]).toEqual(["s1", { rebaseCount: 1, rebaseHead: "h1" }]);
 });
 
+test("herdr-restored account husk (deferSteer true) → resume attempted before steer, even though paneAlive", async () => {
+  const reply = mock(() => true);
+  const resume = mock(() => true);
+  const setState = mock(() => {});
+  const d = deps({
+    worktree: { behindBase: async () => true } as any,
+    paneAlive: () => true, // pane IS live — only deferSteer forces the resume() detour
+    deferSteer: () => true,
+    service: { archive: mock(() => 1), reply, resume, resolveMerging: mock(() => {}) } as any,
+  });
+  d.store.setAutoMergeState = setState as any;
+  const svc = new AutoMergeService(d);
+  await svc.pump("/r");
+  expect(resume.mock.calls.length).toBe(1);
+  expect(reply.mock.calls.length).toBe(1);
+  expect((setState as any).mock.calls[0]).toEqual(["s1", { rebaseCount: 1, rebaseHead: "h1" }]);
+});
+
+test("deferSteer false + paneAlive true → replies directly, no resume (unchanged)", async () => {
+  const reply = mock(() => true);
+  const resume = mock(() => true);
+  const d = deps({
+    worktree: { behindBase: async () => true } as any,
+    paneAlive: () => true,
+    deferSteer: () => false,
+    service: { archive: mock(() => 1), reply, resume, resolveMerging: mock(() => {}) } as any,
+  });
+  const svc = new AutoMergeService(d);
+  await svc.pump("/r");
+  expect(resume.mock.calls.length).toBe(0);
+  expect(reply.mock.calls.length).toBe(1);
+});
+
 test("rebase steer fails to deliver → counter NOT bumped", async () => {
   const reply = mock(() => false);
   const setState = mock(() => {});

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -70,6 +70,8 @@ function sess(over: Partial<Session> = {}): Session {
     manualStepsAckedAt: null,
     experimentId: null,
     experimentRole: null,
+    spawnTerminalId: null,
+    spawnAccountDir: null,
     ...over,
   };
 }

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -88,6 +88,9 @@ function harness(opts: {
   repoMode?: "forge" | "lightweight";
   openPr?: boolean;
   paneAlive?: boolean;
+  /** Optional deferSteer dep (SessionService.shouldDeferSteer); omit to test the optional-dep
+   *  default (undefined → today's paneAlive-only behavior). */
+  deferSteer?: (id: string) => boolean;
   resumeOk?: boolean;
   steerOk?: boolean;
   fullAuto?: boolean;
@@ -166,6 +169,7 @@ function harness(opts: {
       return opts.resumeOk ?? true;
     },
     paneAlive: () => opts.paneAlive ?? true,
+    deferSteer: opts.deferSteer,
     readTail: () => ["finished, nothing else"],
     hasPr: () => opts.openPr ?? false,
     hasDiff: async () => opts.hasDiff ?? true,
@@ -448,6 +452,31 @@ test("finished + dead pane → resume then steer", async () => {
   });
   await h.svc.onDone("s1");
   expect(h.events).toContainEqual({ resume: true });
+  expect(h.events).toContainEqual({ steer: OPEN_PR_STEER_MAIN });
+});
+
+test("finished + live pane but deferSteer true (herdr-restored account husk) → resume then steer", async () => {
+  const h = harness({
+    session: sess({ status: "done" }),
+    verdict: { kind: "finished", summary: "done" },
+    paneAlive: true, // pane IS live — only deferSteer forces the resume() detour (Locus B re-drive)
+    deferSteer: () => true,
+    resumeOk: true,
+  });
+  await h.svc.onDone("s1");
+  expect(h.events).toContainEqual({ resume: true });
+  expect(h.events).toContainEqual({ steer: OPEN_PR_STEER_MAIN });
+});
+
+test("finished + live pane + deferSteer false → steers directly, no resume (unchanged)", async () => {
+  const h = harness({
+    session: sess({ status: "done" }),
+    verdict: { kind: "finished", summary: "done" },
+    paneAlive: true,
+    deferSteer: () => false,
+  });
+  await h.svc.onDone("s1");
+  expect(h.events).not.toContainEqual({ resume: true });
   expect(h.events).toContainEqual({ steer: OPEN_PR_STEER_MAIN });
 });
 

--- a/test/blocked.test.ts
+++ b/test/blocked.test.ts
@@ -164,6 +164,8 @@ function makeSession(planPhase: Session["planPhase"]): Session {
     manualStepsAckedAt: null,
     experimentId: null,
     experimentRole: null,
+    spawnTerminalId: null,
+    spawnAccountDir: null,
   };
 }
 

--- a/test/herd-digest.test.ts
+++ b/test/herd-digest.test.ts
@@ -65,6 +65,8 @@ function makeSession(over: Partial<Session> = {}): Session {
     manualStepsAckedAt: null,
     experimentId: null,
     experimentRole: null,
+    spawnTerminalId: null,
+    spawnAccountDir: null,
     ...over,
   };
 }

--- a/test/poller-redrive.test.ts
+++ b/test/poller-redrive.test.ts
@@ -1,0 +1,100 @@
+// Poller-side wiring for the herdr-restart account-loss fix (task 4a): tick() proactively
+// fires a re-drive for a herdr-restored account pane (spawnTerminalId no longer matches the live
+// agent's terminalId), via the injectable `poller.reDrive` field. Fire-and-forget — the actual
+// re-drive (SessionService.reDriveAccount) is exercised separately in
+// test/redrive-bounded.test.ts; here we only prove the poller detects the condition and calls
+// the hook with the right session id.
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+import { StatusPoller } from "../src/poller";
+import type { HerdrAgent } from "../src/herdr";
+
+const baseSession = {
+  name: "x",
+  prompt: "x",
+  repoPath: "/r",
+  baseBranch: "main",
+  branch: "shepherd/x",
+  worktreePath: "/wt",
+  isolated: true,
+  herdrSession: "default",
+  herdrAgentId: "T1",
+};
+
+function fakeAgent(terminalId: string): HerdrAgent {
+  return {
+    agent: "claude",
+    agentStatus: "working",
+    cwd: "/wt",
+    name: "",
+    paneId: "p",
+    tabId: "t",
+    terminalId,
+    workspaceId: "w",
+  };
+}
+
+test("poller fires reDrive for a herdr-restored account pane (spawnTerminalId != live terminalId)", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  store.setSpawnIdentity(s.id, "T1", "/acct"); // owning account, spawned on T1
+
+  // herdr restarted and re-created the pane under a NEW terminalId T2.
+  const agents: HerdrAgent[] = [fakeAgent("T2")];
+  const poller = new StatusPoller(
+    store,
+    { list: () => agents, read: () => "" } as never,
+    () => {},
+    () => {},
+  );
+
+  const redriveCalls: string[] = [];
+  poller.reDrive = (id) => redriveCalls.push(id);
+
+  poller.tick();
+
+  expect(redriveCalls).toEqual([s.id]);
+});
+
+test("poller does NOT fire reDrive for a default session (spawnAccountDir=null)", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  // spawnAccountDir defaults to null (no owning account) — a fresh terminalId here is just the
+  // ordinary herdr-restart-adopt case (Locus A path), not an account re-drive.
+  store.setSpawnIdentity(s.id, "T1", null);
+
+  const agents: HerdrAgent[] = [fakeAgent("T2")];
+  const poller = new StatusPoller(
+    store,
+    { list: () => agents, read: () => "" } as never,
+    () => {},
+    () => {},
+  );
+
+  const redriveCalls: string[] = [];
+  poller.reDrive = (id) => redriveCalls.push(id);
+
+  poller.tick();
+
+  expect(redriveCalls).toEqual([]);
+});
+
+test("poller tick() never throws even when reDrive itself throws (fire-and-forget dispatch)", () => {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  store.setSpawnIdentity(s.id, "T1", "/acct");
+
+  const agents: HerdrAgent[] = [fakeAgent("T2")];
+  const poller = new StatusPoller(
+    store,
+    { list: () => agents, read: () => "" } as never,
+    () => {},
+    () => {},
+  );
+
+  poller.reDrive = () => {
+    throw new Error("boom");
+  };
+
+  expect(() => poller.tick()).not.toThrow();
+});

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -83,6 +83,8 @@ function makeSession(over: Partial<Session> = {}): Session {
     manualStepsAckedAt: null,
     experimentId: null,
     experimentRole: null,
+    spawnTerminalId: null,
+    spawnAccountDir: null,
     ...over,
   };
 }

--- a/test/redrive-bounded.test.ts
+++ b/test/redrive-bounded.test.ts
@@ -1,0 +1,156 @@
+// Bounded-attempt bookkeeping for reDriveAccount (herdr-restart account-loss fix, task 4a).
+// A persistently-failing account re-drive (e.g. usage-halted: the auto-gate refuses BEFORE
+// teardown so spawnTerminalId never advances) must give up after REDRIVE_CAP attempts instead of
+// re-firing every poller tick forever. The counter is anchored on spawnTerminalId, NOT the
+// husk/live terminalId — an UNHEALED re-drive (onSpawn folds to `{}`) spawns a fresh pane (and
+// thus a fresh terminalId) on every attempt, so a husk-keyed counter would reset every time and
+// never reach the cap.
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+import { SessionService } from "../src/service";
+import { needsAccountRedrive } from "../src/herdr";
+import { PluginSpawnAborted, type SpawnDescriptor, type SpawnPatch } from "../src/plugins/types";
+
+type Hooks = (d: SpawnDescriptor) => Promise<SpawnPatch>;
+
+function makeService(hooks: { fn: Hooks }) {
+  const store = new SessionStore(":memory:");
+  let startCount = 0;
+  const service = new SessionService({
+    store,
+    namer: async () => "repo-x",
+    runSpawnHooks: (d) => hooks.fn(d),
+    worktree: {
+      ensureBaseRef: async () => {},
+      branchExists: () => false,
+      create: () => ({ worktreePath: "/wt/repo-x", branch: "shepherd/repo-x", isolated: true }),
+      remove: () => {},
+    } as never,
+    herdr: {
+      // Unique terminalId per call — needed so an unhealed re-drive's fresh pane (and thus
+      // fresh live terminalId) is distinguishable from the prior husk/anchor.
+      start: () => ({ terminalId: `term_${++startCount}` }) as never,
+      stop: () => {},
+      list: () => [],
+    } as never,
+  });
+  return { service, store, startCount: () => startCount };
+}
+
+async function makeResumableSession(service: SessionService, store: SessionStore) {
+  const s = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "go",
+    model: null,
+    images: [],
+  });
+  store.update(s.id, { status: "done" });
+  return s.id;
+}
+
+test("heal clears the counter + a subsequent needsAccountRedrive is false", async () => {
+  const hooks: { fn: Hooks } = { fn: async () => ({ credentialDir: "/acct" }) };
+  const { service, store } = makeService(hooks);
+  const id = await makeResumableSession(service, store);
+
+  const verdict = await service.reDriveAccount(id);
+  expect(verdict).toBe("healed");
+
+  const after = store.get(id);
+  expect(after).not.toBeNull();
+  // Anchor advanced -> the live agent at the fresh terminalId is no longer "needs redrive".
+  expect(needsAccountRedrive(after!, { terminalId: after!.spawnTerminalId! })).toBe(false);
+
+  // Calling reDriveAccount again after a heal is a FRESH count (not already-degraded): it
+  // re-drives again rather than short-circuiting to "degraded".
+  const again = await service.reDriveAccount(id);
+  expect(again).toBe("healed");
+});
+
+test("bounded -> degraded: refused variant, anchor-keyed counter reaches CAP", async () => {
+  const hooks: { fn: Hooks } = { fn: async () => ({ credentialDir: "/acct" }) };
+  const { service, store, startCount } = makeService(hooks);
+  const id = await makeResumableSession(service, store);
+  const before = store.get(id);
+  const anchor = before?.spawnTerminalId;
+
+  // Every re-drive attempt now fails BEFORE teardown (auto-gate style refusal): spawnTerminalId
+  // never advances, so needsAccountRedrive would stay true forever without the cap.
+  hooks.fn = async () => Promise.reject(new PluginSpawnAborted("no creds", "swap"));
+
+  const startsBefore = startCount();
+  // Attempts 1..CAP (3) return "refused" and never spawn (the refusal is pre-teardown).
+  expect(await service.reDriveAccount(id)).toBe("refused");
+  expect(await service.reDriveAccount(id)).toBe("refused");
+  expect(await service.reDriveAccount(id)).toBe("refused");
+  expect(store.get(id)?.spawnTerminalId).toBe(anchor); // never advanced
+
+  // The (CAP+1)-th call gives up WITHOUT calling herdr.start again.
+  const verdict = await service.reDriveAccount(id);
+  expect(verdict).toBe("degraded");
+  expect(startCount()).toBe(startsBefore); // no additional spawn attempted
+});
+
+test("bounded -> degraded: unhealed variant (the wedge test) — anchor-keyed, not husk-keyed", async () => {
+  const hooks: { fn: Hooks } = { fn: async () => ({ credentialDir: "/acct" }) };
+  const { service, store, startCount } = makeService(hooks);
+  const id = await makeResumableSession(service, store);
+  const before = store.get(id);
+  const anchor = before?.spawnTerminalId;
+  expect(anchor).toBeTruthy();
+
+  // Every re-drive re-spawns (a NEW live terminalId each time, per the unique-id harness) but
+  // onSpawn folds to {} -> the owning account never comes back -> "unhealed", and
+  // persistSpawnIdentity's sticky rule PRESERVES spawnTerminalId (does not advance it) so the
+  // anchor stays stable across attempts even though the live/husk terminalId changes every time.
+  hooks.fn = async () => ({});
+
+  const startsBefore = startCount();
+  expect(await service.reDriveAccount(id)).toBe("unhealed");
+  expect(await service.reDriveAccount(id)).toBe("unhealed");
+  expect(await service.reDriveAccount(id)).toBe("unhealed");
+  // Anchor (spawnTerminalId) never advanced across the 3 unhealed attempts — proves the counter
+  // is keyed on the STABLE anchor, not the churning live terminalId (which would never reach CAP).
+  expect(store.get(id)?.spawnTerminalId).toBe(anchor);
+  expect(startCount()).toBe(startsBefore + 3); // each attempt DID spawn a fresh (unhealed) pane
+
+  // The (CAP+1)-th call gives up WITHOUT spawning again.
+  const verdict = await service.reDriveAccount(id);
+  expect(verdict).toBe("degraded");
+  expect(startCount()).toBe(startsBefore + 3); // no additional spawn on the degraded call
+});
+
+test("new husk resets the counter: heal after degraded starts a fresh count at 1", async () => {
+  // Establish an owning account at create() so the session has a non-null spawnAccountDir —
+  // otherwise a folded-null outcome would read as "default session" (healed) rather than
+  // "unhealed", per persistSpawnIdentity's sticky rule.
+  const hooks: { fn: Hooks } = { fn: async () => ({ credentialDir: "/acct" }) };
+  const { service, store } = makeService(hooks);
+  const id = await makeResumableSession(service, store);
+
+  hooks.fn = async () => ({}); // now every re-drive fails to re-derive the account
+  // Drive to degraded (CAP unhealed attempts + 1 give-up call).
+  await service.reDriveAccount(id);
+  await service.reDriveAccount(id);
+  await service.reDriveAccount(id);
+  expect(await service.reDriveAccount(id)).toBe("degraded");
+
+  // Now simulate a fresh heal->re-break. Once degraded, reDriveAccount itself will keep
+  // short-circuiting to "degraded" forever for this SAME anchor (that's the give-up contract —
+  // the automatic re-drive path stops trying). The heal instead comes from outside that path: the
+  // session stays steerable as today (no steer-defer guard in this task), so an operator/explicit
+  // `resume({force: true})` — bypassing reDriveAccount's bounded map entirely — can still heal it.
+  hooks.fn = async () => ({ credentialDir: "/acct" });
+  const healed = await service.resume(id, { force: true });
+  expect(healed?.spawnAccountDir).toBe("/acct");
+  const healedAnchor = healed?.spawnTerminalId;
+  expect(healedAnchor).toBeTruthy();
+
+  // ...then the account breaks again (a subsequent failed re-drive). This must start a NEW
+  // count at 1, not resume the already-exhausted prior count (which would immediately degrade).
+  hooks.fn = async () => ({});
+  const verdict = await service.reDriveAccount(id);
+  expect(verdict).toBe("unhealed"); // NOT "degraded" — the new anchor gets a fresh budget
+  expect(store.get(id)?.spawnTerminalId).toBe(healedAnchor); // preserved (unhealed didn't advance)
+});

--- a/test/resume-account-redrive.test.ts
+++ b/test/resume-account-redrive.test.ts
@@ -1,0 +1,138 @@
+// Locus B of the herdr-restart account-loss fix (task 3): a non-forced resume() of a
+// herdr-restored ACCOUNT pane must re-drive through onSpawn instead of adopting the
+// wrong-account husk. Simulates the production sequence: session spawned on an owning
+// account (spawnAccountDir/spawnTerminalId stamped), herdr restarts, the poller re-points
+// herdrAgentId to the restored husk under a NEW terminalId — matchAgents/liveAgentFor now
+// resolves that husk as "live". needsAccountRedrive must catch this and fall through to
+// the existing teardown + prepareResumeSpawn path (never call reDriveAccount from here —
+// that would deadlock on the per-session resume() guard, see task-3-brief.md).
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+import { SessionService } from "../src/service";
+import type { HerdrAgent } from "../src/herdr";
+import type { SpawnDescriptor, SpawnPatch } from "../src/plugins/types";
+
+type Hooks = (d: SpawnDescriptor) => Promise<SpawnPatch>;
+
+function makeService(hooks: { fn: Hooks }) {
+  const store = new SessionStore(":memory:");
+  let startCount = 0;
+  const startCalls: { env: Record<string, string | undefined> }[] = [];
+  const stopCalls: string[] = [];
+  const liveAgent: { current: HerdrAgent | null } = { current: null };
+  const service = new SessionService({
+    store,
+    namer: async () => "repo-x",
+    runSpawnHooks: (d) => hooks.fn(d),
+    worktree: {
+      ensureBaseRef: async () => {},
+      branchExists: () => false,
+      create: () => ({ worktreePath: "/wt/repo-x", branch: "shepherd/repo-x", isolated: true }),
+      remove: () => {},
+    } as never,
+    herdr: {
+      // Unique terminalId per call, like Task 2's harness — needsAccountRedrive assertions
+      // depend on the fresh id differing from both the stale spawnTerminalId and the husk.
+      start: (
+        _name: string,
+        _cwd: string,
+        _argv: string[],
+        env: Record<string, string | undefined>,
+      ) => {
+        startCount++;
+        startCalls.push({ env });
+        return { terminalId: `term_${startCount}` };
+      },
+      stop: (terminalId: string) => {
+        stopCalls.push(terminalId);
+      },
+      list: () => (liveAgent.current ? [liveAgent.current] : []),
+    } as never,
+  });
+  return { service, store, startCount: () => startCount, startCalls, stopCalls, liveAgent };
+}
+
+async function makeResumableSession(service: SessionService, store: SessionStore) {
+  const s = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "go",
+    model: null,
+    images: [],
+  });
+  store.update(s.id, { status: "done" });
+  return s.id;
+}
+
+/** Fill in the HerdrAgent fields the tests don't otherwise care about. */
+function fakeAgent(terminalId: string, cwd: string): HerdrAgent {
+  return {
+    agent: "",
+    agentStatus: "done",
+    cwd,
+    name: "repo-x",
+    paneId: "pane-1",
+    tabId: "tab-1",
+    terminalId,
+    workspaceId: "ws-1",
+  };
+}
+
+test("Locus B: non-force resume() of a herdr-restored account pane re-drives, does not adopt", async () => {
+  const hooks: { fn: Hooks } = { fn: async () => ({ credentialDir: "/acct" }) };
+  const { service, store, stopCalls, startCalls, liveAgent } = makeService(hooks);
+  const id = await makeResumableSession(service, store);
+  const before = store.get(id);
+  expect(before?.spawnAccountDir).toBe("/acct");
+  const spawnTerminalId = before?.spawnTerminalId;
+  expect(spawnTerminalId).toBeTruthy();
+  const startsBefore = startCalls.length; // create() itself already spawned once
+
+  // Poller re-points herdrAgentId to the herdr-restored husk under a NEW terminalId.
+  store.update(id, { herdrAgentId: "T2" });
+  liveAgent.current = fakeAgent("T2", "/wt/repo-x");
+
+  const result = await service.resume(id);
+
+  expect(stopCalls).toContain("T2"); // husk torn down
+  expect(startCalls.length - startsBefore).toBe(1); // re-driven through onSpawn
+  expect(startCalls.at(-1)?.env.CLAUDE_CONFIG_DIR).toBe("/acct");
+  expect(result?.herdrAgentId).not.toBe("T2"); // did NOT adopt the husk
+});
+
+test("default session (no owning account) still adopts a herdr-restored pane", async () => {
+  const hooks: { fn: Hooks } = { fn: async () => ({}) }; // no credentialDir -> default session
+  const { service, store, stopCalls, startCalls, liveAgent } = makeService(hooks);
+  const id = await makeResumableSession(service, store);
+  const before = store.get(id);
+  expect(before?.spawnAccountDir).toBeNull();
+  const startsBefore = startCalls.length;
+
+  store.update(id, { herdrAgentId: "T2" });
+  liveAgent.current = fakeAgent("T2", "/wt/repo-x");
+
+  const result = await service.resume(id);
+
+  expect(stopCalls).toEqual([]); // no teardown
+  expect(startCalls.length - startsBefore).toBe(0); // no re-spawn
+  expect(result?.herdrAgentId).toBe("T2"); // adopted
+});
+
+test("genuinely-live account pane (terminalId unchanged) adopts, no re-drive", async () => {
+  const hooks: { fn: Hooks } = { fn: async () => ({ credentialDir: "/acct" }) };
+  const { service, store, stopCalls, startCalls, liveAgent } = makeService(hooks);
+  const id = await makeResumableSession(service, store);
+  const before = store.get(id);
+  const spawnTerminalId = before?.spawnTerminalId;
+  expect(spawnTerminalId).toBeTruthy();
+  const startsBefore = startCalls.length;
+
+  // herdrAgentId still points at the same terminal Shepherd last spawned — genuinely live.
+  liveAgent.current = fakeAgent(spawnTerminalId!, "/wt/repo-x");
+
+  const result = await service.resume(id);
+
+  expect(stopCalls).toEqual([]);
+  expect(startCalls.length - startsBefore).toBe(0);
+  expect(result?.herdrAgentId).toBe(spawnTerminalId!);
+});

--- a/test/resume-serialize.test.ts
+++ b/test/resume-serialize.test.ts
@@ -1,0 +1,134 @@
+// Per-session resume() serialization guard (herdr-restart account-loss fix, task 2):
+// proves concurrent resume() calls for the same session id coalesce onto a single spawn,
+// that the guard releases once settled, and the reDriveAccount() healed/unhealed/refused
+// verdicts built on top of it (task 1's persistSpawnIdentity sticky rule).
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+import { SessionService } from "../src/service";
+import { PluginSpawnAborted, type SpawnDescriptor, type SpawnPatch } from "../src/plugins/types";
+
+type Hooks = (d: SpawnDescriptor) => Promise<SpawnPatch>;
+
+function makeService(hooks: { fn: Hooks }) {
+  const store = new SessionStore(":memory:");
+  let startCount = 0;
+  const service = new SessionService({
+    store,
+    namer: async () => "repo-x",
+    runSpawnHooks: (d) => hooks.fn(d),
+    worktree: {
+      ensureBaseRef: async () => {},
+      branchExists: () => false,
+      create: () => ({ worktreePath: "/wt/repo-x", branch: "shepherd/repo-x", isolated: true }),
+      remove: () => {},
+    } as never,
+    herdr: {
+      // Unique terminalId per call — real herdr terminalIds are unique per spawn, and the
+      // reDriveAccount healed/unhealed inference depends on spawnTerminalId actually changing.
+      start: () => ({ terminalId: `term_${++startCount}` }) as never,
+      stop: () => {},
+      list: () => [],
+    } as never,
+  });
+  return { service, store, startCount: () => startCount };
+}
+
+const NOOP_HOOKS = { fn: async () => ({}) as SpawnPatch };
+
+async function makeResumableSession(service: SessionService, store: SessionStore) {
+  const s = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "go",
+    model: null,
+    images: [],
+  });
+  store.update(s.id, { status: "done" });
+  return s.id;
+}
+
+test("resume() coalesces concurrent calls for the same session id (no double-spawn)", async () => {
+  const { service, store, startCount } = makeService(NOOP_HOOKS);
+  const id = await makeResumableSession(service, store);
+  const before = startCount();
+
+  const [a, b] = await Promise.all([
+    service.resume(id, { force: true }),
+    service.resume(id, { force: true }),
+  ]);
+
+  expect(startCount() - before).toBe(1); // exactly one herdr.start for both callers
+  expect(a).not.toBeNull();
+  expect(a?.herdrAgentId).toBe(b?.herdrAgentId); // same resulting session
+});
+
+test("resume() guard releases after settling: a later resume spawns again", async () => {
+  const { service, store, startCount } = makeService(NOOP_HOOKS);
+  const id = await makeResumableSession(service, store);
+  const before = startCount();
+
+  await service.resume(id, { force: true });
+  expect(startCount() - before).toBe(1);
+
+  await service.resume(id, { force: true });
+  expect(startCount() - before).toBe(2); // guard cleared, spawns again
+});
+
+test("reDriveAccount: same credentialDir re-applied -> healed, spawnTerminalId advances", async () => {
+  const hooks: { fn: Hooks } = { fn: async () => ({ credentialDir: "/acct/1" }) };
+  const { service, store } = makeService(hooks);
+  const id = await makeResumableSession(service, store);
+  const before = store.get(id);
+  expect(before?.spawnAccountDir).toBe("/acct/1"); // established at create
+
+  const verdict = await (service as never as { reDriveAccount: (id: string) => Promise<string> })[
+    "reDriveAccount"
+  ](id);
+
+  expect(verdict).toBe("healed");
+  const after = store.get(id);
+  expect(after?.spawnAccountDir).toBe("/acct/1");
+  expect(after?.spawnTerminalId).not.toBe(before?.spawnTerminalId);
+});
+
+test("reDriveAccount: onSpawn folds null over a non-null prior -> unhealed, marker preserved", async () => {
+  const hooks: { fn: Hooks } = { fn: async () => ({ credentialDir: "/acct/1" }) };
+  const { service, store } = makeService(hooks);
+  const id = await makeResumableSession(service, store);
+  const before = store.get(id);
+
+  hooks.fn = async () => ({}); // this re-drive fails to re-derive the account
+  const verdict = await (service as never as { reDriveAccount: (id: string) => Promise<string> })[
+    "reDriveAccount"
+  ](id);
+
+  expect(verdict).toBe("unhealed");
+  const after = store.get(id);
+  expect(after?.spawnAccountDir).toBe("/acct/1"); // preserved, not nulled
+  expect(after?.spawnTerminalId).toBe(before?.spawnTerminalId); // NOT advanced
+});
+
+test("reDriveAccount: resume refused -> refused, husk/marker untouched", async () => {
+  const hooks: { fn: Hooks } = { fn: async () => ({ credentialDir: "/acct/1" }) };
+  const { service, store } = makeService(hooks);
+  const id = await makeResumableSession(service, store);
+  const before = store.get(id);
+
+  hooks.fn = async () => Promise.reject(new PluginSpawnAborted("no creds", "swap"));
+  const verdict = await (service as never as { reDriveAccount: (id: string) => Promise<string> })[
+    "reDriveAccount"
+  ](id);
+
+  expect(verdict).toBe("refused");
+  const after = store.get(id);
+  expect(after?.spawnTerminalId).toBe(before?.spawnTerminalId);
+  expect(after?.spawnAccountDir).toBe(before?.spawnAccountDir);
+});
+
+test("reDriveAccount: unknown session id -> refused", async () => {
+  const { service } = makeService(NOOP_HOOKS);
+  const verdict = await (service as never as { reDriveAccount: (id: string) => Promise<string> })[
+    "reDriveAccount"
+  ]("nonexistent");
+  expect(verdict).toBe("refused");
+});

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -96,6 +96,8 @@ function session(over: Partial<Session> = {}): Session {
     manualStepsAckedAt: null,
     experimentId: null,
     experimentRole: null,
+    spawnTerminalId: null,
+    spawnAccountDir: null,
     ...over,
   };
 }

--- a/test/rundown-core.test.ts
+++ b/test/rundown-core.test.ts
@@ -73,6 +73,8 @@ function session(over: Partial<Session> = {}): Session {
     manualStepsAckedAt: null,
     experimentId: null,
     experimentRole: null,
+    spawnTerminalId: null,
+    spawnAccountDir: null,
     ...over,
   };
 }

--- a/test/server-diff.test.ts
+++ b/test/server-diff.test.ts
@@ -54,6 +54,8 @@ const SESSION: Session = {
   manualStepsAckedAt: null,
   experimentId: null,
   experimentRole: null,
+  spawnTerminalId: null,
+  spawnAccountDir: null,
 };
 
 function makeDeps(session: Session | null, prCache?: AppDeps["prCache"]): AppDeps {

--- a/test/server-git.test.ts
+++ b/test/server-git.test.ts
@@ -59,6 +59,8 @@ const SESSION: Session = {
   manualStepsAckedAt: null,
   experimentId: null,
   experimentRole: null,
+  spawnTerminalId: null,
+  spawnAccountDir: null,
 };
 
 function fakeForge(

--- a/test/server-quota-endpoints.test.ts
+++ b/test/server-quota-endpoints.test.ts
@@ -60,6 +60,8 @@ const SESSION: Session = {
   manualStepsAckedAt: null,
   experimentId: null,
   experimentRole: null,
+  spawnTerminalId: null,
+  spawnAccountDir: null,
 };
 
 /** A ReviewVerdict that triggers the "rework" quota kind (addressRound >= addressCap, no pending). */

--- a/test/server-review-pr.test.ts
+++ b/test/server-review-pr.test.ts
@@ -60,6 +60,8 @@ const SESSION: Session = {
   manualStepsAckedAt: null,
   experimentId: null,
   experimentRole: null,
+  spawnTerminalId: null,
+  spawnAccountDir: null,
 };
 
 function fakeForge(over: Partial<GitForge> = {}): GitForge & { log: string[] } {

--- a/test/spawn-identity.test.ts
+++ b/test/spawn-identity.test.ts
@@ -1,0 +1,159 @@
+// Persist spawn identity (issue: "herdr restart loses a claude-swap session's account").
+// Covers the foundational persistence layer only: the two new session columns
+// (spawnTerminalId/spawnAccountDir), the setSpawnIdentity store setter, and the
+// persistSpawnIdentity service helper's sticky/conditional write table. No poller/resume
+// re-drive logic lives here — that's a later task.
+import { expect, spyOn, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { SessionStore } from "../src/store";
+import { SessionService } from "../src/service";
+import type { SpawnDescriptor, SpawnPatch } from "../src/plugins/types";
+
+const base = {
+  name: "spawn-identity-test",
+  prompt: "test session",
+  repoPath: "/r",
+  baseBranch: "main",
+  branch: "shepherd/spawn-identity-test",
+  worktreePath: "/r-wt",
+  isolated: true,
+  herdrSession: "default",
+  herdrAgentId: "term_1",
+};
+
+// ── store: column defaults + setSpawnIdentity ─────────────────────────────────
+
+test("freshly created session has spawnTerminalId=null, spawnAccountDir=null", () => {
+  const store = new SessionStore(":memory:");
+  const row = store.create(base);
+  expect(row.spawnTerminalId).toBeNull();
+  expect(row.spawnAccountDir).toBeNull();
+});
+
+test("setSpawnIdentity persists both fields", () => {
+  const store = new SessionStore(":memory:");
+  const row = store.create(base);
+  store.setSpawnIdentity(row.id, "term_9", "/acct");
+  const got = store.get(row.id);
+  expect(got?.spawnTerminalId).toBe("term_9");
+  expect(got?.spawnAccountDir).toBe("/acct");
+});
+
+test("setSpawnIdentity with nulls clears both fields", () => {
+  const store = new SessionStore(":memory:");
+  const row = store.create(base);
+  store.setSpawnIdentity(row.id, "term_9", "/acct");
+  store.setSpawnIdentity(row.id, null, null);
+  const got = store.get(row.id);
+  expect(got?.spawnTerminalId).toBeNull();
+  expect(got?.spawnAccountDir).toBeNull();
+});
+
+test("spawn identity fields persist across store reopen (migration + round-trip)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-spawn-identity-test-"));
+  const dbPath = join(dir, "test.db");
+  try {
+    const s1 = new SessionStore(dbPath);
+    const row = s1.create(base);
+    s1.setSpawnIdentity(row.id, "term_9", "/acct");
+
+    // reopen same DB — proves migrateSessionColumns() ADDs the columns onto a pre-existing DB.
+    const s2 = new SessionStore(dbPath);
+    const got = s2.get(row.id);
+    expect(got?.spawnTerminalId).toBe("term_9");
+    expect(got?.spawnAccountDir).toBe("/acct");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── service: persistSpawnIdentity via real spawns ─────────────────────────────
+
+type Hooks = (d: SpawnDescriptor) => Promise<SpawnPatch>;
+
+function makeService(hooks: { fn: Hooks }) {
+  const store = new SessionStore(":memory:");
+  let counter = 0;
+  const service = new SessionService({
+    store,
+    namer: async () => "repo-x",
+    runSpawnHooks: (d) => hooks.fn(d),
+    worktree: {
+      ensureBaseRef: async () => {},
+      branchExists: () => false,
+      create: () => ({ worktreePath: "/wt/repo-x", branch: "shepherd/repo-x", isolated: true }),
+      remove: () => {},
+    } as never,
+    herdr: {
+      start: () => ({ terminalId: `term_${++counter}` }) as never,
+      stop: () => {},
+      list: () => [],
+    } as never,
+  });
+  return { service, store };
+}
+
+const CREATE_INPUT = {
+  repoPath: "/repo",
+  baseBranch: "main",
+  prompt: "go",
+  model: null,
+  images: [],
+};
+
+test("1. onSpawn credentialDir folds into spawnAccountDir + advances spawnTerminalId", async () => {
+  const hooks = { fn: async () => ({ credentialDir: "/acct" }) as SpawnPatch };
+  const { service, store } = makeService(hooks);
+  const s = await service.create(CREATE_INPUT);
+  const row = store.get(s.id)!;
+  expect(row.spawnAccountDir).toBe("/acct");
+  expect(row.spawnTerminalId).toBe(row.herdrAgentId);
+});
+
+test("2. empty patch on a new session sets spawnAccountDir=null, spawnTerminalId set", async () => {
+  const hooks = { fn: async () => ({}) as SpawnPatch };
+  const { service, store } = makeService(hooks);
+  const s = await service.create(CREATE_INPUT);
+  const row = store.get(s.id)!;
+  expect(row.spawnAccountDir).toBeNull();
+  expect(row.spawnTerminalId).toBe(row.herdrAgentId);
+  expect(row.spawnTerminalId).not.toBeNull();
+});
+
+test("3. sticky/loud: resume with folded=null preserves prior owning-account identity + warns", async () => {
+  const hooks = { fn: async () => ({}) as SpawnPatch }; // folded account is always null
+  const { service, store } = makeService(hooks);
+  const s = await service.create(CREATE_INPUT);
+  // Simulate a prior verified owning-account spawn (e.g. from before a herdr restart).
+  store.setSpawnIdentity(s.id, "T1", "/acct");
+
+  const warnSpy = spyOn(console, "warn");
+  try {
+    const resumed = await service.resume(s.id);
+    expect(resumed).not.toBeNull();
+    expect(warnSpy).toHaveBeenCalled(); // loud: owning account not restored
+  } finally {
+    warnSpy.mockRestore();
+  }
+
+  const row = store.get(s.id)!;
+  expect(row.spawnAccountDir).toBe("/acct"); // NOT nulled
+  expect(row.spawnTerminalId).toBe("T1"); // NOT advanced
+});
+
+test("4. healed: resume with folded matching prior advances spawnTerminalId", async () => {
+  const hooks = { fn: async () => ({ credentialDir: "/acct" }) as SpawnPatch };
+  const { service, store } = makeService(hooks);
+  const s = await service.create(CREATE_INPUT);
+  store.setSpawnIdentity(s.id, "T1", "/acct");
+
+  const resumed = await service.resume(s.id);
+  expect(resumed).not.toBeNull();
+
+  const row = store.get(s.id)!;
+  expect(row.spawnAccountDir).toBe("/acct");
+  expect(row.spawnTerminalId).not.toBe("T1"); // advanced to the new spawn's terminalId
+  expect(row.spawnTerminalId).toBe(row.herdrAgentId);
+});

--- a/test/steer-defer.test.ts
+++ b/test/steer-defer.test.ts
@@ -1,0 +1,156 @@
+// Steer-defer guard (herdr-restart account-loss fix, task 4b): closes the residual race where an
+// autonomous caller (retryHalted/automerge/autopilot) fires in the brief window before the
+// poller's proactive re-drive (task 4a) lands, and steers a herdr-restored account husk instead of
+// the correct (re-driven) pane. SessionService.shouldDeferSteer(id) is the shared predicate;
+// retryHalted is the one autonomous caller that lives in service.ts, so its defer behavior is
+// exercised here too. automerge.doRebase / autopilot.sendSteer are covered in their own test files.
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+import { SessionService } from "../src/service";
+import type { HerdrAgent } from "../src/herdr";
+
+const REDRIVE_CAP = (SessionService as unknown as { REDRIVE_CAP: number }).REDRIVE_CAP;
+
+function fakeAgent(terminalId: string, cwd: string): HerdrAgent {
+  return {
+    agent: "claude",
+    agentStatus: "working",
+    cwd,
+    name: "",
+    paneId: "p",
+    tabId: "t",
+    terminalId,
+    workspaceId: "w",
+  };
+}
+
+/** Minimal service: only shouldDeferSteer + retryHalted are exercised, so the spawn-side deps
+ *  (namer/worktree) are never actually invoked — same shape as test/retry-halted.test.ts. */
+function makeHarness(agents: HerdrAgent[] = []) {
+  const store = new SessionStore(":memory:");
+  const resumed: string[] = [];
+  const sent: { target: string; text: string }[] = [];
+
+  const svc = new SessionService({
+    store,
+    namer: async () => "x",
+    worktree: {
+      create: () => ({}) as any,
+      ensureBaseRef: async () => {},
+      remove: () => {},
+      branchExists: () => false,
+    } as any,
+    herdr: {
+      start: () => ({}) as any,
+      list: () => agents,
+      stop: () => {},
+      send: (target: string, text: string) => sent.push({ target, text }),
+      relabel: () => {},
+    } as any,
+  });
+
+  // Patch resume so retryHalted's dead/deferred branch never actually spawns claude.
+  (svc as any).resume = async (id: string) => {
+    resumed.push(id);
+    return store.get(id);
+  };
+
+  const mk = (name: string, agentId: string) =>
+    store.create({
+      name,
+      prompt: "x",
+      repoPath: "/r",
+      baseBranch: "main",
+      branch: `shepherd/${name}`,
+      worktreePath: `/wt/${name}`,
+      isolated: true,
+      herdrSession: "default",
+      herdrAgentId: agentId,
+    });
+
+  return { store, svc, mk, resumed, sent };
+}
+
+test("shouldDeferSteer: restored account husk, not exhausted -> true", () => {
+  const { store, svc, mk } = makeHarness([fakeAgent("T2", "/wt/a")]);
+  const a = mk("a", "T2"); // herdrAgentId already re-pointed to the live husk
+  store.setSpawnIdentity(a.id, "T1", "/acct"); // spawned on T1 under an owning account
+
+  expect(svc.shouldDeferSteer(a.id)).toBe(true);
+});
+
+test("shouldDeferSteer: exhausted (degraded) -> false", () => {
+  const { store, svc, mk } = makeHarness([fakeAgent("T2", "/wt/a")]);
+  const a = mk("a", "T2");
+  store.setSpawnIdentity(a.id, "T1", "/acct");
+
+  // Seed the bounded re-drive counter to CAP on the matching anchor (T1) — same technique the
+  // brief allows in lieu of driving CAP real failures through reDriveAccount.
+  (svc as any).redriveAttempts.set(a.id, { anchor: "T1", attempts: REDRIVE_CAP });
+
+  expect(svc.shouldDeferSteer(a.id)).toBe(false);
+});
+
+test("shouldDeferSteer: default session (spawnAccountDir null) -> false", () => {
+  const { store, svc, mk } = makeHarness([fakeAgent("T2", "/wt/a")]);
+  const a = mk("a", "T2");
+  store.setSpawnIdentity(a.id, "T1", null);
+
+  expect(svc.shouldDeferSteer(a.id)).toBe(false);
+});
+
+test("shouldDeferSteer: healed (live terminalId === spawnTerminalId) -> false", () => {
+  const { store, svc, mk } = makeHarness([fakeAgent("T2", "/wt/a")]);
+  const a = mk("a", "T2");
+  store.setSpawnIdentity(a.id, "T2", "/acct"); // anchor now matches the live pane
+
+  expect(svc.shouldDeferSteer(a.id)).toBe(false);
+});
+
+test("shouldDeferSteer: no live agent -> false", () => {
+  const { store, svc, mk } = makeHarness([]); // herdr lists nothing
+  const a = mk("a", "T2");
+  store.setSpawnIdentity(a.id, "T1", "/acct");
+
+  expect(svc.shouldDeferSteer(a.id)).toBe(false);
+});
+
+test("retryHalted: restored account husk (live, deferred) -> resume(), not replyToLive", async () => {
+  const { store, svc, mk, resumed, sent } = makeHarness([fakeAgent("T2", "/wt/a")]);
+  const a = mk("a", "T2"); // in `live` per liveTerminalIds()
+  store.setSpawnIdentity(a.id, "T1", "/acct"); // restored husk: T2 live != T1 anchor
+  store.setHaltReason(a.id, "usage_limit", 1000);
+
+  const result = await svc.retryHalted([a.id], "please continue");
+
+  expect(result).toEqual({ resumed: 1, steered: 0, total: 1 });
+  expect(resumed).toEqual([a.id]);
+  expect(sent).toEqual([]); // never steered the wrong-account husk
+});
+
+test("retryHalted: healed account pane (live, not deferred) -> steers as today", async () => {
+  const { store, svc, mk, resumed, sent } = makeHarness([fakeAgent("T2", "/wt/a")]);
+  const a = mk("a", "T2");
+  store.setSpawnIdentity(a.id, "T2", "/acct"); // healed: anchor matches live terminalId
+  store.setHaltReason(a.id, "usage_limit", 1000);
+
+  const result = await svc.retryHalted([a.id], "please continue");
+
+  expect(result).toEqual({ resumed: 0, steered: 1, total: 1 });
+  expect(resumed).toEqual([]);
+  expect(sent.some((s) => s.target === "T2" && s.text.includes("please continue"))).toBe(true);
+});
+
+test("retryHalted: degraded account pane (live, exhausted) -> steers as today (no-worse)", async () => {
+  const { store, svc, mk, resumed, sent } = makeHarness([fakeAgent("T2", "/wt/a")]);
+  const a = mk("a", "T2");
+  store.setSpawnIdentity(a.id, "T1", "/acct"); // still an unhealed husk...
+  (svc as any).redriveAttempts.set(a.id, { anchor: "T1", attempts: REDRIVE_CAP }); // ...but exhausted
+  store.setHaltReason(a.id, "usage_limit", 1000);
+
+  const result = await svc.retryHalted([a.id], "please continue");
+
+  expect(result).toEqual({ resumed: 0, steered: 1, total: 1 });
+  expect(resumed).toEqual([]);
+  expect(sent.some((s) => s.target === "T2")).toBe(true);
+});


### PR DESCRIPTION
## Problem

After a herdr daemon restart/crash, herdr autonomously re-runs a bare `claude --resume <id>` with
clean env (its claude integration is detection-only — it strips `launch_argv`/env on restore). For a
session whose account identity is plugin-injected (the claude-swap plugin sets a per-account
`CLAUDE_CONFIG_DIR` via `onSpawn`), the restored pane lands on the **wrong config dir** → `claude`
prints **"No conversation found with session ID: …"**. The restored husk stays herdr-live, so Shepherd
adopts it and the autonomous drain machinery steers the wrong-account pane.

Account identity lives **only** in the plugin-injected `CLAUDE_CONFIG_DIR`; core persisted nothing to
detect or recover this. Empirically confirmed (Phase 0): herdr retains the restored/exited pane in
`agent list` (as a live or `unknown` agent), and neither `matchAgent`/`paneAlive` nor `liveTerminalIds`
filter by status — so the husk is observed live and steerable in every sub-case.

## Fix (plugin-agnostic, via the existing `onSpawn` re-drive)

Persist a **poller-immune spawn identity** and re-drive a herdr-restored account pane through
`onSpawn` so the account is re-applied:

- **Persist** two nullable session columns via a single writer `persistSpawnIdentity`:
  `spawnTerminalId` (the terminalId Shepherd itself spawned — written **only** by spawn-finish, never
  by reconcile/poller, so re-pointing `herdrAgentId` can't mask a restored husk) and `spawnAccountDir`
  (the folded **plugin** `patchEnv.CLAUDE_CONFIG_DIR`). Sticky/verified: a null/wrong re-derivation
  (plugin state lost) **preserves** the prior owning dir and does **not** advance `spawnTerminalId` —
  so a re-drive can never silently "heal" onto the default account.
- **Detect** with `needsAccountRedrive(s, agent) = spawnAccountDir != null && agent.terminalId != spawnTerminalId`.
- **Re-drive at three convergent loci:** the poller proactively (`reconcileAgent` → fire-and-forget
  `reDriveAccount`), the human parked-resume (`resumeInner` adopt branch falls through to teardown +
  re-drive), and the autonomous steer paths (autopilot / automerge / retryHalted / critic-address /
  plan-gate defer via `shouldDeferSteer` and route through `resume()` first).
- **Serialize + bound:** a per-session in-flight guard inside `resume()` coalesces every entrypoint
  (poller, human, "bring agent back" button, autonomous) so there is never a double `herdr.start`; a
  bounded counter anchored on `spawnTerminalId` gives up after 3 failed re-drives (→ DEGRADED, loudly
  logged, steering resumes as-today), so a usage-halted/degraded account can never wedge into an
  every-tick re-drive or a permanent steer-defer.

### Scope

- **Plugin/account sessions only.** api-key sessions are **excluded by construction**:
  `spawnAccountDir` folds only the plugin `patchEnv.CLAUDE_CONFIG_DIR`, not the api-key
  `apiKeyPassthrough` mirror — and that mirror symlinks `projects/` to the real `~/.claude`, so a bare
  resume still finds the conversation (no bug there).
- **No behavior change for default/no-plugin users**: empty patch → `spawnAccountDir` null →
  `needsAccountRedrive` false everywhere; the poller check short-circuits on the null before any
  `herdr.list()`.
- Server-internal fix — no UI, no user-facing strings.

## Why core, not herdr

The "fix at source" (herdr persist/restore the spawn env) is unavailable: herdr's claude integration
is detection-only and its restore strips env one-way, and an upstream-herdr fix + a PATH `claude` shim
were both explicitly rejected in favor of a core fix.

## Testing

- New TDD suites (red→green): `spawn-identity`, `resume-serialize`, `resume-account-redrive`,
  `poller-redrive`, `redrive-bounded`, `steer-defer` (+ automerge/autopilot deferSteer cases).
- `bun run lint`, `bun run typecheck`, `bun run test` (6008 pass / 0 fail), and `fallow audit` all
  green. Rebased onto latest `main`.
- Live herdr-restart repro deliberately not run (would disrupt the operator's other running sessions);
  verified via the TDD suite + a whole-branch review that traced the end-to-end flow + Phase-0
  live-state analysis.

[no-feature-entry] — server-internal fix, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
