### PR TITLE
fix(ui): reflow terminal above review/CI banner instead of covering the prompt

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2241,9 +2241,11 @@
       {reattach}
       {resumeSession}
     />
-    <!-- Non-blocking review-in-flight banner: bottom strip over the terminal,
-         above the steer bar. Stays mounted across tab switches (state survives);
-         it suppresses its own render off the term tab. (issue #1022) -->
+    <!-- Non-blocking review-in-flight banner: reserved bottom strip. The terminal
+         (.term-mount) shrinks by this banner's height (--review-banner-h) so the
+         strip sits BELOW the live prompt, not over it. Stays mounted across tab
+         switches (state survives); it suppresses its own render off the term tab.
+         (issue #1022) -->
     <ReviewInFlightBanner
       {session}
       keystrokes={opKeystrokes}
@@ -3027,7 +3029,18 @@
 
   .term-mount {
     width: 100%;
-    height: 100%;
+    /* Reserve the review/CI banner's bottom strip so xterm reflows ABOVE it instead
+       of being overlaid — the live prompt stays visible while a review runs.
+       --review-banner-h is published on .vp-body (0px when no banner shows).
+       Changing this height trips the ResizeObserver on this element → refit() → PTY
+       resize, which is the intended reflow. The min-height floor equals .vp-body's
+       own min-height (4rem) and must NOT exceed it: a larger floor would force the
+       mount taller than a squeezed body and clip the bottom prompt row via
+       .vp-body's overflow:hidden even with no banner. At the floor (squeezed-recap
+       takeover) the mount == body, so the banner overlaps its bottom again — prior
+       behavior — rather than resizing the PTY toward xterm's clamped 1-row minimum. */
+    height: calc(100% - var(--review-banner-h, 0px));
+    min-height: 4rem;
     overflow: hidden;
     /* we drive vertical scroll via touch handlers; keep the browser out of it */
     touch-action: none;

--- a/ui/src/lib/components/viewport/CiRunningBanner.svelte
+++ b/ui/src/lib/components/viewport/CiRunningBanner.svelte
@@ -85,9 +85,11 @@
 {/if}
 
 <style>
-  /* Bottom overlay strip pinned to the terminal body, directly above the steer
-     bar — mirrors ReviewInFlightBanner. Absolutely positioned so it never triggers
-     an xterm refit. Non-blocking: no scrim/blur (it does not seize interaction). */
+  /* Bottom strip pinned to the terminal body, directly above the steer bar —
+     mirrors ReviewInFlightBanner. The terminal reserves this height (.term-mount
+     shrinks by --review-banner-h) so the strip sits BELOW the live prompt, not over
+     it; appearing/resizing it intentionally triggers an xterm refit. Non-blocking:
+     no scrim/blur (it does not seize interaction). */
   .ci-banner {
     --accent: var(
       --color-amber

--- a/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
+++ b/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
@@ -228,9 +228,12 @@
 {/if}
 
 <style>
-  /* Bottom overlay strip pinned to the terminal body, directly above the steer
-     bar. Absolutely positioned so it never triggers an xterm refit. Non-blocking:
-     no scrim/blur — it does not seize interaction. */
+  /* Bottom strip pinned to the terminal body, directly above the steer bar. The
+     terminal reserves this height — .term-mount shrinks by --review-banner-h — so the
+     strip sits BELOW the live prompt, not over it; the operator can still see and use
+     the prompt while a review runs. Appearing/resizing it therefore intentionally
+     triggers an xterm refit. Non-blocking: no scrim/blur — it does not seize
+     interaction. */
   .review-banner {
     position: absolute;
     bottom: 0;


### PR DESCRIPTION
## Problem

The review-in-flight banner (and its CI-running twin) rendered as `position: absolute; bottom: 0` strips **over** the bottom of the xterm terminal — exactly where the live prompt/cursor sits. So while a review was in flight you couldn't see or use the prompt, even though you may well want to type/steer.

They were made absolute *specifically to avoid an xterm refit* — which is precisely why they covered the prompt.

## Fix — reserve space, don't overlay

Make `.term-mount` give up the strip:

```css
height: calc(100% - var(--review-banner-h, 0px));
min-height: 4rem;
```

`--review-banner-h` is **already** published on `.vp-body` (each banner measures its own `offsetHeight`; today only the floating scroll-jump button reads it). Shrinking the mount trips its existing `ResizeObserver` → `refit()`, so xterm reflows and the live prompt lands right above the banner — visible and typeable. One CSS change covers **both** banners (shared var, mutually exclusive) and **all** tiers (calm / escalated / every conclusion tone / CI-running), since each tier's real height flows through the same var.

### Short-terminal guard (`min-height: 4rem`)

The floor equals `.vp-body`'s own `min-height` and must **not** exceed it. When `.vp-body` is squeezed to its 4rem floor (the expanded-SessionRecap takeover), an unfloored mount would drop to ~1 row and SIGWINCH the running Claude Code TUI to a 1-row terminal. At the 4rem floor the mount equals the body (~3-4 rows), so the PTY is never driven to xterm's clamped 1-row minimum and the banner gracefully falls back to overlaying — today's behavior. A larger floor would force the mount taller than the body and clip the prompt via `overflow:hidden` **even with no banner**, so 4rem is the cap.

## Tradeoff (accepted with operator)

Reflow means the strip appearing / changing tier / disappearing drives a real PTY resize (up to ~3 real TUI redraws per review cycle — there's no client-side de-dup; only the kernel `TIOCSWINSZ` ignores same-dimension writes). The zero-refit alternative (pinning the strip to the **top** of the terminal) was weighed and held as the fallback — it removes the resize on the typing axis but floats over old scrollback and detaches the warning from the input. Operator chose bottom-reflow; if mid-review typing ever proves hostile to the resize, top-pin is the ready fallback.

## Verification

- `cd ui && bun run check` → 0 errors (2 pre-existing warnings in unrelated files).
- `cd ui && bun run test` → **2851 passed** (209 files).
- prettier + eslint (lint-staged) clean on the 3 changed files.

**Not exercised headlessly:** the live "type continuously while a review starts and finishes" gate needs a running herdr + a real in-flight review, which this environment can't stand up. The change is low-risk by construction — keystrokes flow through `term.onData` → WS independently of resize frames, so a SIGWINCH doesn't drop queued input — and the top-pin fallback above is ready if the operator observes any input drop/corruption during a real in-flight review.

_No new user-facing strings, glossary terms, or capabilities — a layout fix, so no i18n / feature-catalog changes. Context: issue #1022._
