### PR TITLE
feat(ui): clickable banner for MCP OAuth auth URLs above the terminal

### DIFF
--- a/src/auth-url.test.ts
+++ b/src/auth-url.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "bun:test";
+import { detectAuthUrl } from "./auth-url";
+
+// Real-shape fixtures (synthetic client_id / code_challenge). Mirrors the Step-0 capture:
+// the authorize URL lands in an assistant `text` block AND/OR a `tool_result` block inside a
+// `role:"user"` message. `code_challenge` is a PKCE hash placeholder here.
+const AUTH_URL =
+  "https://mcp.notion.com/authorize?response_type=code&client_id=abc123&code_challenge=HOkFuV4sAW3&code_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost%3A3118%2Fcallback&resource=https%3A%2F%2Fmcp.notion.com%2Fmcp";
+
+const assistantText = (text: string) =>
+  JSON.stringify({
+    type: "assistant",
+    message: { role: "assistant", content: [{ type: "text", text }] },
+  });
+const toolResult = (content: string) =>
+  JSON.stringify({
+    type: "user",
+    message: { role: "user", content: [{ type: "tool_result", content }] },
+  });
+const opInputString = (text: string) =>
+  JSON.stringify({ type: "user", message: { role: "user", content: text } });
+const opInputText = (text: string) =>
+  JSON.stringify({ type: "user", message: { role: "user", content: [{ type: "text", text }] } });
+const toolUse = () =>
+  JSON.stringify({
+    type: "assistant",
+    message: { role: "assistant", content: [{ type: "tool_use", name: "notion" }] },
+  });
+
+describe("detectAuthUrl", () => {
+  it("detects the URL in an assistant text block", () => {
+    const jsonl = [
+      opInputString("read this notion page for me"),
+      assistantText(
+        `I need you to authorize the Notion connection.\n1. Open this URL in your browser:\n\n${AUTH_URL}\n\n2. Copy the callback URL back here.`,
+      ),
+    ].join("\n");
+    expect(detectAuthUrl(jsonl)).toBe(AUTH_URL);
+  });
+
+  it("detects the URL in a tool_result (role:user) — the assistant-only scan would miss it", () => {
+    const jsonl = [
+      opInputString("read this notion page"),
+      toolUse(),
+      toolResult(`Authorization required. Visit ${AUTH_URL} to authorize.`),
+    ].join("\n");
+    expect(detectAuthUrl(jsonl)).toBe(AUTH_URL);
+  });
+
+  it("detects a Vercel-style /oauth/authorize URL", () => {
+    const vercel =
+      "https://vercel.com/oauth/authorize?response_type=code&client_id=cl_Wbdt&code_challenge=x&code_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost%3A9999%2Fcallback";
+    expect(detectAuthUrl(assistantText(`Open ${vercel} then paste the callback.`))).toBe(vercel);
+  });
+
+  it("returns null for a plain non-auth URL", () => {
+    expect(
+      detectAuthUrl(assistantText("See the docs at https://example.com/guide/setup for details.")),
+    ).toBeNull();
+  });
+
+  it("does not match the localhost callback URL the operator pastes back", () => {
+    const callback = "http://localhost:3118/callback?code=xyz789&state=abc";
+    expect(detectAuthUrl(opInputString(`Here is the callback: ${callback}`))).toBeNull();
+    expect(detectAuthUrl(toolResult(`redirected to ${callback}`))).toBeNull();
+  });
+
+  it("clears a resolved URL once the operator has responded (no stale resurface)", () => {
+    const jsonl = [
+      assistantText(`Open ${AUTH_URL}`),
+      opInputString("http://localhost:3118/callback?code=done"), // operator pasted the callback
+      toolUse(),
+      assistantText("Thanks, I read the page. Anything else?"),
+    ].join("\n");
+    expect(detectAuthUrl(jsonl)).toBeNull();
+  });
+
+  it("clears when the operator answers via a typed text turn", () => {
+    const jsonl = [
+      toolResult(`authorize at ${AUTH_URL}`),
+      opInputText("skip it, read the page directly instead"),
+    ].join("\n");
+    expect(detectAuthUrl(jsonl)).toBeNull();
+  });
+
+  it("surfaces the current URL while still blocked (URL is the newest relevant content)", () => {
+    const jsonl = [
+      opInputString("original request"),
+      toolUse(),
+      toolResult(`auth required: ${AUTH_URL}`),
+      assistantText(`Please open ${AUTH_URL} and paste the callback.`),
+    ].join("\n");
+    expect(detectAuthUrl(jsonl)).toBe(AUTH_URL);
+  });
+
+  it("round-trips a long URL byte-exactly and skips malformed lines", () => {
+    const jsonl = ["not json", "", "{broken", assistantText(`link: ${AUTH_URL}`)].join("\n");
+    expect(detectAuthUrl(jsonl)).toBe(AUTH_URL);
+  });
+
+  it("returns null for an empty transcript", () => {
+    expect(detectAuthUrl("")).toBeNull();
+  });
+});

--- a/src/auth-url.ts
+++ b/src/auth-url.ts
@@ -1,0 +1,141 @@
+// Detect a *pending* OAuth authorization URL in a Claude Code session transcript.
+//
+// When an MCP server needs OAuth (e.g. Notion, Vercel), the agent prints a long
+// `…/authorize?response_type=code&client_id=…` URL and blocks, asking the operator to
+// open it in their browser and paste back the localhost callback. Claude's TUI word-wraps
+// that URL across several indented terminal lines, so it is un-clickable and un-copyable
+// in the PTY buffer — but it appears *verbatim, un-wrapped* in the JSONL transcript.
+//
+// Step-0 capture (real Vercel/Notion MCP flows) showed the URL lands in TWO record shapes
+// in the same flow — an assistant `text` block (Claude relaying it) AND a `tool_result`
+// block carried inside a `role:"user"` message (the raw MCP payload). So this scans BOTH;
+// scanning only assistant-side text (which excludes `role:"user"`) would miss the
+// tool_result delivery. Pure + transcript-only so it is unit-testable without the poller.
+
+import { eachJsonlObject } from "./jsonl";
+
+// URL token: http(s) up to the first whitespace/quote/bracket/backtick. Query chars
+// (& = % + . _ ~ : / ? #) are all inside this class, so a long authorize URL is captured
+// whole. Trailing sentence punctuation is stripped below.
+const URL_RE = /https?:\/\/[^\s"'`<>\\)\]}]+/g;
+
+/** Strip trailing sentence/markdown punctuation a URL token may have swallowed. */
+function trimUrl(u: string): string {
+  return u.replace(/[.,;:!?)\]}>"']+$/, "");
+}
+
+/**
+ * True when `u` is an OAuth *authorization* endpoint (not the localhost callback the
+ * operator pastes back). Match on the authorize path or the PKCE/response-type query, so
+ * a `/callback?code=…` return URL is correctly excluded.
+ */
+function isAuthUrl(u: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(u);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") return false;
+  if (/\/(oauth\/)?authorize\b/i.test(url.pathname)) return true;
+  if (url.searchParams.get("response_type") === "code") return true;
+  if (url.searchParams.has("code_challenge")) return true;
+  return false;
+}
+
+/** First authorization URL in a blob of text, or null. */
+function firstAuthUrl(text: string): string | null {
+  const matches = text.match(URL_RE);
+  if (!matches) return null;
+  for (const raw of matches) {
+    const u = trimUrl(raw);
+    if (isAuthUrl(u)) return u;
+  }
+  return null;
+}
+
+/** Text carried by a `tool_result` block, whose `content` is either a string or an
+ *  array of `{type:"text", text}` blocks (both shapes occur in real transcripts). */
+function toolResultText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((b) =>
+        b && typeof (b as { text?: unknown }).text === "string" ? (b as { text: string }).text : "",
+      )
+      .join(" ");
+  }
+  return "";
+}
+
+interface Rec {
+  role: string;
+  content: unknown;
+}
+
+/** Normalize a raw JSONL object to `{ role, content }`; null when it carries no message. */
+function toRec(o: unknown): Rec | null {
+  const rec = o as { message?: { role?: unknown; content?: unknown }; type?: unknown } | undefined;
+  const content = rec?.message?.content;
+  if (content === undefined) return null;
+  const role = typeof rec?.message?.role === "string" ? rec.message.role : String(rec?.type ?? "");
+  return { role, content };
+}
+
+/** Last authorize URL across an assistant record's `text` blocks, or null. */
+function assistantAuthUrl(content: unknown): string | null {
+  if (!Array.isArray(content)) return null;
+  let url: string | null = null;
+  for (const b of content) {
+    if ((b as { type?: unknown })?.type !== "text") continue;
+    const found = firstAuthUrl(String((b as { text?: unknown }).text ?? ""));
+    if (found) url = found;
+  }
+  return url;
+}
+
+/**
+ * A user record's effect on the pending URL. A user message with no tool_result is
+ * operator input → clears (`{ clear: true }`); otherwise the last authorize URL across its
+ * tool_result blocks (or null).
+ */
+function userAuthEffect(content: unknown): { clear: boolean; url: string | null } {
+  const toolResults = Array.isArray(content)
+    ? content.filter((b) => (b as { type?: unknown })?.type === "tool_result")
+    : [];
+  if (toolResults.length === 0) return { clear: true, url: null };
+  let url: string | null = null;
+  for (const b of toolResults) {
+    const found = firstAuthUrl(toolResultText((b as { content?: unknown }).content));
+    if (found) url = found;
+  }
+  return { clear: false, url };
+}
+
+/**
+ * Return the authorization URL the agent is *currently* waiting on the operator to open,
+ * or null. Walks the transcript oldest→newest and tracks the pending URL:
+ *
+ *  - an assistant `text` block or a `tool_result` block carrying an authorize URL SETS it;
+ *  - a plain operator input (a `role:"user"` message with no tool_result — a string or a
+ *    typed `text` turn) CLEARS it, because the operator has responded to the prompt.
+ *
+ * So a prior, already-answered auth URL still sitting in the tail is not resurfaced when the
+ * agent later blocks for an unrelated reason. Malformed/blank lines are skipped.
+ */
+export function detectAuthUrl(rawJsonl: string): string | null {
+  let pending: string | null = null;
+  for (const o of eachJsonlObject(rawJsonl)) {
+    const rec = toRec(o);
+    if (!rec) continue;
+    if (rec.role === "assistant") {
+      pending = assistantAuthUrl(rec.content) ?? pending;
+    } else if (rec.role === "user") {
+      const { clear, url } = userAuthEffect(rec.content);
+      if (clear) pending = null;
+      else pending = url ?? pending;
+    }
+    // system / other roles: ignored
+  }
+  return pending;
+}

--- a/src/blocked.ts
+++ b/src/blocked.ts
@@ -16,6 +16,10 @@ export interface BlockReason {
   tail: string[];
   /** Discriminator for quota blocks: which sub-kind of quota exhaustion triggered this. */
   quotaKind?: "rework" | "review" | "error" | "plan";
+  /** Full OAuth authorization URL an awaiting-input block is waiting on the operator to
+   *  open (MCP auth flows, e.g. Notion/Vercel). Absent unless the transcript held a
+   *  pending authorize URL. Sourced from the JSONL, not the word-wrapped PTY tail. */
+  authUrl?: string;
 }
 
 const TAIL_LINES = 15;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2268,6 +2268,7 @@ const appDeps: AppDeps = {
   prCache: prPoller,
   ownsPr,
   activity: { snapshot: () => poller.activitySnapshot() },
+  blocks: { snapshot: () => poller.blockSnapshot() },
   claudeAlive: { snapshot: () => poller.claudeAliveSnapshot() },
   workingBlocked: { snapshot: () => poller.workingBlockedSnapshot() },
   preview: { snapshot: () => previewService.snapshot() },

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -18,6 +18,7 @@ import { DEFAULT_STALL } from "./stall";
 import { jsonlPathFor } from "./usage";
 import { readTranscriptSignals, STRIP_WINDOW_MS, type SessionActivity } from "./activity-signal";
 import { readTranscriptTail } from "./activity";
+import { detectAuthUrl } from "./auth-url";
 import { classifyHalt, assistantSideText } from "./usage-halt";
 import type { UsageLimits } from "./usage-limits";
 import { maintenance } from "./maintenance";
@@ -87,6 +88,17 @@ export interface LivenessWiring {
   onChange: (id: string, alive: boolean) => void;
 }
 
+/** Bounded tail read + auth-URL detection for a session's transcript; the default
+ *  `detectAuth` wiring. Missing/unreadable transcript (or no claude session yet) ⇒ null. */
+function readAuthUrl(s: Session): string | null {
+  if (!s.claudeSessionId) return null;
+  try {
+    return detectAuthUrl(readTranscriptTail(jsonlPathFor(s.worktreePath, s.claudeSessionId)));
+  } catch {
+    return null;
+  }
+}
+
 export class StatusPoller {
   /** Fire-and-forget re-drive of a herdr-restored account pane (wired to service.reDriveAccount in
    *  index.ts). Left undefined in tests that don't exercise it. */
@@ -95,6 +107,10 @@ export class StatusPoller {
   private timer: ReturnType<typeof setInterval> | null = null;
   private lastReadAt = new Map<string, number>();
   private lastSig = new Map<string, string>();
+  /** Last-emitted block reason per session (parallel to `lastActivity`), for client
+   *  bootstrap via `blockSnapshot()`. Maintained by `emitBlock`; blocks are otherwise
+   *  edge-emitted and would be absent on a fresh page load / push-then-open. */
+  private lastBlockReason = new Map<string, BlockReason>();
   private lastProbeAt = new Map<string, number>();
   private lastActivitySig = new Map<string, string>();
   private lastActivity = new Map<string, SessionActivity>();
@@ -267,6 +283,13 @@ export class StatusPoller {
      * Optional (undefined ⇒ stub) so callers can skip it.
      */
     usageLimits?: { limits(now: number): UsageLimits },
+    /**
+     * Detects the pending OAuth authorization URL in a session's transcript, attached to
+     * an awaiting-input block so the UI can offer a clickable "open in browser" affordance
+     * (MCP auth flows print a URL Claude word-wraps un-clickably across terminal lines).
+     * Injectable for tests; defaults to a bounded tail read + `detectAuthUrl`.
+     */
+    private detectAuth: (s: Session) => string | null = readAuthUrl,
   ) {
     // Merge supplied overrides with real defaults. When preview is omitted entirely
     // we create a no-op wiring so tick() never throws on undefined access.
@@ -467,7 +490,7 @@ export class StatusPoller {
     // immediately wipe the just-emitted block. See tryHookAwaitingBlock.
     if (status !== "blocked" && this.tryHookAwaitingBlock(s)) return;
 
-    if (status === "blocked") this.maybeClassify(s.id, s.herdrAgentId);
+    if (status === "blocked") this.maybeClassify(s, s.herdrAgentId);
     else if (status === "running") this.maybeProbe(s);
     else this.maybeQuota(s, status);
   }
@@ -573,7 +596,7 @@ export class StatusPoller {
     if (!config.hooksSignals || !this.hookAwaitingInput.has(s.id)) return false;
     // Consume the marker only when the classify actually ran (throttle didn't skip);
     // a throttled tick keeps the marker so the next tick retries the surface.
-    if (this.maybeClassify(s.id, s.herdrAgentId)) this.hookAwaitingInput.delete(s.id);
+    if (this.maybeClassify(s, s.herdrAgentId)) this.hookAwaitingInput.delete(s.id);
     const sig = this.lastSig.get(s.id);
     return sig !== undefined && sig !== STALL_SIG;
   }
@@ -600,6 +623,7 @@ export class StatusPoller {
       if (!activeIds.has(id)) {
         this.lastReadAt.delete(id);
         this.lastSig.delete(id);
+        this.lastBlockReason.delete(id);
         this.lastProbeAt.delete(id);
         this.lastActivitySig.delete(id);
         this.lastActivity.delete(id);
@@ -866,6 +890,20 @@ export class StatusPoller {
     return at !== undefined && now - at < 2 * this.probeCheckMs;
   }
 
+  /** Single sink for block emissions: keep the `lastBlockReason` snapshot map in step
+   *  (set on a reason, delete on clear) and forward to the injected `onBlock`. All block
+   *  fire/clear paths route through here so a fresh client can bootstrap current blocks. */
+  private emitBlock(id: string, block: BlockReason | null): void {
+    if (block) this.lastBlockReason.set(id, block);
+    else this.lastBlockReason.delete(id);
+    this.onBlock(id, block);
+  }
+
+  /** Last-emitted block reason per session, for client bootstrap. */
+  blockSnapshot(): Record<string, BlockReason> {
+    return Object.fromEntries(this.lastBlockReason);
+  }
+
   /** Emit an activity signal, deduped by content so clients see only real changes. */
   private emitActivity(id: string, activity: SessionActivity): void {
     const sig = JSON.stringify(activity);
@@ -880,14 +918,14 @@ export class StatusPoller {
     if (this.lastSig.get(id) !== STALL_SIG) return;
     this.lastSig.delete(id);
     this.lastReadAt.delete(id);
-    this.onBlock(id, null);
+    this.emitBlock(id, null);
   }
 
   /** Emit a stall block once per episode (guarded by `lastSig === STALL_SIG`). */
   private fireStall(id: string, visible: string): void {
     if (this.lastSig.get(id) === STALL_SIG) return; // already announced this episode
     this.lastSig.set(id, STALL_SIG);
-    this.onBlock(id, { shape: "stall", options: [], tail: tailLines(visible) });
+    this.emitBlock(id, { shape: "stall", options: [], tail: tailLines(visible) });
   }
 
   /**
@@ -906,7 +944,8 @@ export class StatusPoller {
    * false)` fires first, then `onBlock`, in the same tick — clients see the flag drop
    * and the block land together.
    */
-  private maybeClassify(id: string, term: string): boolean {
+  private maybeClassify(s: Session, term: string): boolean {
+    const id = s.id;
     const t = this.now();
     // Throttled this tick → did NOT look (caller may keep an awaiting marker to retry).
     if (t - (this.lastReadAt.get(id) ?? 0) < this.reclassifyMs) return false;
@@ -938,13 +977,22 @@ export class StatusPoller {
       // drop the episode memory so the next spinner sighting gets a fresh grace.
       this.lastSuppressVisible.delete(id);
     }
+    // Awaiting-input blocks may be an MCP OAuth prompt: attach the full authorize URL from
+    // the transcript (Claude word-wraps it un-clickably in the PTY). Gated to awaiting-input
+    // so a menu/y-n block never triggers the read; the read is bounded + throttled by the
+    // reclassifyMs gate above. `authUrl` is part of `reason`, so it rides the lastSig dedup
+    // and the block snapshot for free; null ⇒ field omitted (not an auth prompt).
+    if (reason.shape === "awaiting-input") {
+      const authUrl = this.detectAuth(s);
+      if (authUrl) reason.authUrl = authUrl;
+    }
     const sig = JSON.stringify(reason);
     if (sig === this.lastSig.get(id)) return true; // looked this tick (dedup short-circuit)
     // Re-arm: a block is about to be emitted → end the suppression episode FIRST so
     // the flag-off and the block reach clients in the same tick, in that order.
     if (this.workingWhileBlocked.delete(id)) this.onWorkingBlocked(id, false);
     this.lastSig.set(id, sig);
-    this.onBlock(id, reason);
+    this.emitBlock(id, reason);
     return true; // looked + classified this tick
   }
 
@@ -965,7 +1013,7 @@ export class StatusPoller {
     if (prev !== undefined && prev === visible) return false; // frozen → re-arm
     if (this.lastSig.has(id)) {
       this.lastSig.delete(id);
-      this.onBlock(id, null);
+      this.emitBlock(id, null);
     }
     if (!this.workingWhileBlocked.has(id)) {
       this.workingWhileBlocked.add(id);
@@ -984,7 +1032,7 @@ export class StatusPoller {
    */
   acknowledgeStall(id: string): boolean {
     if (this.lastSig.get(id) !== STALL_SIG) return false;
-    this.onBlock(id, null);
+    this.emitBlock(id, null);
     return true;
   }
 
@@ -994,7 +1042,7 @@ export class StatusPoller {
     if (!this.lastSig.has(id)) return;
     this.lastSig.delete(id);
     this.lastReadAt.delete(id);
-    this.onBlock(id, null);
+    this.emitBlock(id, null);
   }
 
   /**
@@ -1015,7 +1063,7 @@ export class StatusPoller {
     if (reason) {
       if (this.lastSig.get(s.id) !== QUOTA_SIG) {
         this.lastSig.set(s.id, QUOTA_SIG);
-        this.onBlock(s.id, reason);
+        this.emitBlock(s.id, reason);
       }
     } else {
       this.clearBlock(s.id);

--- a/src/server.ts
+++ b/src/server.ts
@@ -187,7 +187,7 @@ import {
 } from "./sandbox";
 import { validateHookEvent, type HookEvent, type SubagentEntry } from "./hooks-ingest";
 import { fingerprintDiffCount } from "./rundown-core";
-import { quotaBlockReason } from "./blocked";
+import { quotaBlockReason, type BlockReason } from "./blocked";
 import { upstreamStatus } from "./upstream-status";
 import { shouldHold } from "./usage-hold";
 import { PluginSpawnAborted } from "./plugins/types";
@@ -292,6 +292,10 @@ export interface AppDeps {
    *  (working-while-blocked display flag), for client bootstrap; updates flow via
    *  the `session:working-blocked` event. Absent in tests that skip it. */
   workingBlocked?: { snapshot(): Record<string, boolean> };
+  /** Last-emitted block reason per session, for client bootstrap; updates flow via the
+   *  `session:block` event. Lets a fresh page load / push-then-open surface a live block
+   *  (incl. an MCP-auth `authUrl`) that was edge-emitted before the client connected. */
+  blocks?: { snapshot(): Record<string, BlockReason> };
   /** Live preview port per session, for client bootstrap; absent until PreviewService is wired (Task 2+).
    *  `session:preview` events are emitted via PreviewService.onChange in index.ts. */
   preview?: {
@@ -698,6 +702,13 @@ function handleClaudeAliveSnapshot({ req, parts, deps }: Ctx): Response | null {
 function handleWorkingBlockedSnapshot({ req, parts, deps }: Ctx): Response | null {
   if (req.method === "GET" && parts[0] === "api" && parts[1] === "working-blocked" && !parts[2]) {
     return json(deps.workingBlocked?.snapshot() ?? {});
+  }
+  return null;
+}
+
+function handleBlocksSnapshot({ req, parts, deps }: Ctx): Response | null {
+  if (req.method === "GET" && parts[0] === "api" && parts[1] === "blocks" && !parts[2]) {
+    return json(deps.blocks?.snapshot() ?? {});
   }
   return null;
 }
@@ -6207,6 +6218,7 @@ const ROUTE_HANDLERS = [
   handleActivitySnapshot,
   handleClaudeAliveSnapshot,
   handleWorkingBlockedSnapshot,
+  handleBlocksSnapshot,
   handleHoldsSnapshot,
   handleSubagentsSnapshot,
   handlePreviewSnapshot,

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -476,6 +476,35 @@ test("GET /api/working-blocked returns the snapshot; {} when unwired", async () 
   expect(await res.json()).toEqual({});
 });
 
+test("GET /api/blocks returns the block snapshot (incl. authUrl); {} when unwired", async () => {
+  const baseDeps = {
+    store: new SessionStore(":memory:"),
+    service: {} as any,
+    events: { subscribe: () => () => {}, emit: () => {} } as any,
+    usageLimits: {
+      limits: () => ({ session5h: null, week: null, stale: true, calibratedAt: null }),
+    },
+  };
+  const reason = {
+    shape: "awaiting-input",
+    options: [],
+    tail: ["paste callback"],
+    authUrl: AUTH_URL,
+  };
+  const wired = makeApp({
+    ...baseDeps,
+    blocks: { snapshot: () => ({ "session-1": reason }) },
+  } as any);
+  let res = await wired.fetch(new Request("http://localhost/api/blocks"));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ "session-1": reason });
+
+  const unwired = makeApp(baseDeps as any);
+  res = await unwired.fetch(new Request("http://localhost/api/blocks"));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({});
+});
+
 test("marks a session done and emits once when its herdr agent is gone", () => {
   const store = new SessionStore(":memory:");
   const s = store.create(baseSession);
@@ -2821,4 +2850,53 @@ test("fullscreen: an advancing spinner frame stays suppressed (live turn, not a 
   expect(h.blocks).toHaveLength(0);
   expect(h.working).toEqual([{ id: h.id, working: true }]); // only the initial flag-on
   expect(h.poller.workingBlockedSnapshot()).toEqual({ [h.id]: true });
+});
+
+// ── auth-URL detection on awaiting-input blocks (MCP OAuth banner source) ──────────
+const AUTH_URL =
+  "https://mcp.notion.com/authorize?response_type=code&client_id=abc&code_challenge=x&code_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost%3A3118%2Fcallback";
+
+test("awaiting-input block carries the detected auth URL + blockSnapshot exposes it", () => {
+  const h = spinnerHarness("Open the URL in your browser, then paste the callback here:");
+  (h.poller as any).detectAuth = () => AUTH_URL;
+  h.poller.tick();
+  expect(h.blocks).toHaveLength(1);
+  expect((h.blocks[0]!.block as any).shape).toBe("awaiting-input");
+  expect((h.blocks[0]!.block as any).authUrl).toBe(AUTH_URL);
+  // snapshot (client bootstrap) exposes the same reason incl. the URL
+  expect(h.poller.blockSnapshot()[h.id]?.authUrl).toBe(AUTH_URL);
+});
+
+test("awaiting-input block has no authUrl when none is detected", () => {
+  const h = spinnerHarness("Type your answer:");
+  (h.poller as any).detectAuth = () => null;
+  h.poller.tick();
+  expect((h.blocks[0]!.block as any).shape).toBe("awaiting-input");
+  expect((h.blocks[0]!.block as any).authUrl).toBeUndefined();
+});
+
+test("detectAuth is not consulted for a non-awaiting (menu) block", () => {
+  const h = spinnerHarness("❯ 1. Yes\n  2. No");
+  let calls = 0;
+  (h.poller as any).detectAuth = () => {
+    calls++;
+    return AUTH_URL;
+  };
+  h.poller.tick();
+  expect((h.blocks[0]!.block as any).shape).toBe("menu");
+  expect(calls).toBe(0);
+  expect((h.blocks[0]!.block as any).authUrl).toBeUndefined();
+});
+
+test("blockSnapshot drops the auth URL when the session resumes", async () => {
+  const h = spinnerHarness("Paste the callback URL:");
+  (h.poller as any).detectAuth = () => AUTH_URL;
+  h.poller.tick();
+  expect(h.poller.blockSnapshot()[h.id]?.authUrl).toBe(AUTH_URL);
+  // agent resumes → block clears → snapshot no longer carries it
+  h.setStatus("working");
+  h.advance(5000);
+  h.poller.tick();
+  await flush();
+  expect(h.poller.blockSnapshot()[h.id]).toBeUndefined();
 });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -634,6 +634,10 @@
   "viewport_keynav_hint": "j/k Session wechseln",
   "viewport_commandbar_hint": "{key} Befehle",
   "viewport_keynav_enter_hint": "↵ zurück zum Terminal",
+  "viewport_auth_title": "Zum Fortfahren im Browser autorisieren",
+  "viewport_auth_open": "Öffnen",
+  "viewport_auth_copy": "Kopieren",
+  "viewport_auth_copied": "Kopiert",
   "viewport_parked_title": "Auf anderem Gerät aktiv",
   "viewport_parked_sub": "Tippen zum Übernehmen",
   "viewport_session_ended": "── Sitzung beendet ──",
@@ -2538,6 +2542,8 @@
   "clipboard_copy_failed": "Kopieren in die Zwischenablage fehlgeschlagen",
   "clipboard_pill_prompt": "Terminal hat Text kopiert",
   "clipboard_pill_copy": "In Zwischenablage kopieren",
+  "feat_auth_url_banner_title": "Ein-Klick-Öffnen für MCP-Anmeldelinks",
+  "feat_auth_url_banner_body": "Wenn ein Agent dich bittet, eine MCP-Verbindung zu autorisieren (etwa Notion), brach der lange Anmelde-Link bisher über mehrere Terminalzeilen um, sodass du ihn weder anklicken noch kopieren konntest. Jetzt erscheint über dem Terminal ein Banner mit dem vollständigen Link und Ein-Klick-Schaltflächen zum Öffnen und Kopieren, während der Agent wartet.",
   "feat_clipboard_osc52_title": "Claudes „Kopieren“ landet jetzt in deiner Zwischenablage",
   "feat_clipboard_osc52_body": "Wenn Claude im Terminal Text kopiert (`c to copy`), landet er jetzt in deiner System-Zwischenablage. Blockiert der Browser das automatische Schreiben, erscheint eine kleine Copy-Pille über dem Terminal zum Kopieren per Klick."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -634,6 +634,10 @@
   "viewport_keynav_hint": "j/k switch session",
   "viewport_commandbar_hint": "{key} commands",
   "viewport_keynav_enter_hint": "↵ back to terminal",
+  "viewport_auth_title": "Authorize in your browser to continue",
+  "viewport_auth_open": "Open",
+  "viewport_auth_copy": "Copy",
+  "viewport_auth_copied": "Copied",
   "viewport_parked_title": "Active on another device",
   "viewport_parked_sub": "Tap to take over",
   "viewport_session_ended": "── session ended ──",
@@ -2538,6 +2542,8 @@
   "clipboard_copy_failed": "Couldn’t copy to clipboard",
   "clipboard_pill_prompt": "Terminal copied text",
   "clipboard_pill_copy": "Copy to clipboard",
+  "feat_auth_url_banner_title": "One-click open for MCP sign-in links",
+  "feat_auth_url_banner_body": "When an agent needs you to authorize an MCP connection (like Notion), the long sign-in URL used to wrap across terminal lines so you couldn't click or copy it. Now a banner appears above the terminal with the full link and one-click Open and Copy buttons while the agent waits.",
   "feat_clipboard_osc52_title": "Claude's \"copy\" now reaches your clipboard",
   "feat_clipboard_osc52_body": "When Claude copies text in the terminal (`c to copy`), it now lands in your system clipboard. If the browser blocks the automatic write, a small Copy pill appears over the terminal for a one-click copy."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -51,6 +51,7 @@ import type {
   WorkflowRun,
   WorkflowJob,
   SessionActivity,
+  BlockReason,
   SubagentEntry,
   BuildQueue,
   BuildStepStatus,
@@ -1120,6 +1121,15 @@ export async function claudeAliveStates(): Promise<Record<string, boolean>> {
 export async function workingBlockedStates(): Promise<Record<string, boolean>> {
   const r = await fetch("/api/working-blocked");
   if (!r.ok) throw await failed(r, "working-blocked states");
+  return r.json();
+}
+
+/** Snapshot of the last-emitted block reason per session, keyed by session id (client
+ *  bootstrap). Blocks are otherwise edge-emitted via `session:block`, so a fresh page load
+ *  / push-then-open needs this to surface a live block (incl. an MCP-auth `authUrl`). */
+export async function blockStates(): Promise<Record<string, BlockReason>> {
+  const r = await fetch("/api/blocks");
+  if (!r.ok) throw await failed(r, "block states");
   return r.json();
 }
 

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -101,6 +101,7 @@
     onSeedBuildQueue,
     previewHost = null,
     workingBlocked = {},
+    authUrl = null,
     consumeAutoFocusTerm = () => true,
     drain = null,
     subagents = {},
@@ -157,6 +158,10 @@
      *  the derived `dStatus`; behavioral reads (resume self-heal, preview confirm
      *  arm) stay on the raw `session.status`. */
     workingBlocked?: Record<string, boolean>;
+    /** Pending MCP OAuth authorization URL for this session's awaiting-input block (from
+     *  the block reason). Drives the "open in browser" banner above the terminal; null
+     *  when the agent isn't waiting on an auth URL. */
+    authUrl?: string | null;
     /** One-shot gate for the mount auto-focus: the page records whether the selection
      *  that remounted this terminal *wants* the keyboard (click / Alt-combo / Enter →
      *  yes; plain j/k chaining → no), and this consumes that intent — read it, reset
@@ -2235,6 +2240,7 @@
       {resuming}
       {resumeFailed}
       {resumable}
+      {authUrl}
       {scrollToTop}
       {scrollToBottom}
       {takeover}

--- a/ui/src/lib/components/viewport/ViewportTermBanners.browser.test.ts
+++ b/ui/src/lib/components/viewport/ViewportTermBanners.browser.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../../app.css";
+
+const { default: ViewportTermBanners } = await import("./ViewportTermBanners.svelte");
+
+const AUTH_URL =
+  "https://mcp.notion.com/authorize?response_type=code&client_id=abc&code_challenge=x&code_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost%3A3118%2Fcallback";
+
+const baseProps = {
+  tab: "term",
+  scrolledUp: false,
+  parked: false,
+  ended: false,
+  endReason: "gone" as const,
+  resuming: false,
+  resumeFailed: false,
+  resumable: false,
+  scrollToTop: vi.fn(),
+  scrollToBottom: vi.fn(),
+  takeover: vi.fn(),
+  reattach: vi.fn(),
+  resumeSession: vi.fn(),
+};
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("ViewportTermBanners auth banner", () => {
+  it("shows the full URL and Open/Copy when an authUrl is pending", async () => {
+    render(ViewportTermBanners, { ...baseProps, authUrl: AUTH_URL });
+    await expect.element(page.getByText(AUTH_URL)).toBeInTheDocument();
+    await expect.element(page.getByRole("button", { name: /open/i })).toBeInTheDocument();
+    await expect.element(page.getByRole("button", { name: /copy/i })).toBeInTheDocument();
+  });
+
+  it("Open opens the URL in a new tab with noopener", async () => {
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+    render(ViewportTermBanners, { ...baseProps, authUrl: AUTH_URL });
+    await page.getByRole("button", { name: /open/i }).click();
+    expect(open).toHaveBeenCalledWith(AUTH_URL, "_blank", "noopener,noreferrer");
+  });
+
+  it("Copy writes the URL to the clipboard and flips the label to Copied", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } });
+    render(ViewportTermBanners, { ...baseProps, authUrl: AUTH_URL });
+    await page.getByRole("button", { name: /copy/i }).click();
+    expect(writeText).toHaveBeenCalledWith(AUTH_URL);
+    await expect.element(page.getByRole("button", { name: /copied/i })).toBeInTheDocument();
+  });
+
+  it("renders nothing when there is no authUrl", async () => {
+    render(ViewportTermBanners, { ...baseProps, authUrl: null });
+    await expect.element(page.getByRole("button", { name: /open/i })).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/components/viewport/ViewportTermBanners.svelte
+++ b/ui/src/lib/components/viewport/ViewportTermBanners.svelte
@@ -10,6 +10,7 @@
     resuming,
     resumeFailed,
     resumable,
+    authUrl = null,
     scrollToTop,
     scrollToBottom,
     takeover,
@@ -24,12 +25,33 @@
     resuming: boolean;
     resumeFailed: boolean;
     resumable: boolean;
+    /** Pending MCP OAuth authorization URL for an awaiting-input block — the operator must
+     *  open it in their browser. null when the agent isn't waiting on an auth URL. */
+    authUrl?: string | null;
     scrollToTop: () => void;
     scrollToBottom: () => void;
     takeover: () => void;
     reattach: () => void;
     resumeSession: () => void;
   } = $props();
+
+  let copied = $state(false);
+  let copyTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function openAuth() {
+    if (authUrl) window.open(authUrl, "_blank", "noopener,noreferrer");
+  }
+  async function copyAuth() {
+    if (!authUrl) return;
+    try {
+      await navigator.clipboard?.writeText(authUrl);
+      copied = true;
+      clearTimeout(copyTimer);
+      copyTimer = setTimeout(() => (copied = false), 2000);
+    } catch {
+      /* clipboard denied (unfocused/insecure) — the URL stays visible to copy manually */
+    }
+  }
 </script>
 
 {#if tab === "term" && scrolledUp && !parked}
@@ -52,6 +74,27 @@
     >
       <span aria-hidden="true">↓</span>
     </button>
+  </div>
+{/if}
+{#if authUrl && tab === "term" && !parked}
+  <!-- Non-modal top strip: an MCP OAuth prompt (e.g. Notion/Vercel) whose URL Claude
+       word-wraps un-clickably in the terminal. Sourced from the JSONL, so the full URL
+       is intact. The prompt sits at the terminal's bottom, so a top strip never covers
+       it. Full URL shown (title=full) so the operator can vet the host before opening. -->
+  <div class="auth-banner" role="status">
+    <span class="auth-icon" aria-hidden="true">🔗</span>
+    <div class="auth-text">
+      <span class="auth-title">{m.viewport_auth_title()}</span>
+      <span class="auth-url" title={authUrl}>{authUrl}</span>
+    </div>
+    <div class="auth-actions">
+      <button class="auth-btn primary" type="button" onclick={openAuth}>
+        {m.viewport_auth_open()}
+      </button>
+      <button class="auth-btn" type="button" onclick={copyAuth}>
+        {copied ? m.viewport_auth_copied() : m.viewport_auth_copy()}
+      </button>
+    </div>
   </div>
 {/if}
 {#if parked && tab === "term"}
@@ -79,6 +122,88 @@
 {/if}
 
 <style>
+  /* auth-banner: non-modal top strip surfacing a pending MCP OAuth URL. Anchored at the
+     top so it never covers the prompt/input at the terminal's bottom. Amber accent — an
+     actionable "needs you" state, not a success. */
+  .auth-banner {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 3;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    background: color-mix(in srgb, var(--color-head) 96%, transparent);
+    backdrop-filter: blur(2px);
+    border-bottom: 1px solid color-mix(in srgb, var(--color-amber) 55%, var(--color-line-bright));
+    box-shadow: 0 3px 12px rgba(0, 0, 0, 0.35);
+  }
+  .auth-icon {
+    color: var(--color-amber);
+    font-size: var(--fs-xl);
+    line-height: 1;
+    flex: none;
+  }
+  .auth-text {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0; /* let the URL truncate instead of overflowing the row */
+    flex: 1 1 auto;
+  }
+  .auth-title {
+    color: var(--color-ink-bright);
+    font-size: var(--fs-lg); /* ≥16px body-text floor */
+    line-height: 1.2;
+  }
+  .auth-url {
+    color: var(--color-muted);
+    font-size: var(--fs-base);
+    font-family: var(--font-mono, monospace);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .auth-actions {
+    display: flex;
+    gap: 6px;
+    flex: none;
+  }
+  .auth-btn {
+    min-height: 32px;
+    padding: 0 12px;
+    border-radius: 6px;
+    border: 1px solid var(--color-line-bright);
+    background: var(--color-bg);
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: var(--fs-base);
+    cursor: pointer;
+    transition:
+      background 0.12s ease,
+      border-color 0.12s ease;
+  }
+  .auth-btn:hover {
+    background: var(--color-hover);
+  }
+  .auth-btn.primary {
+    border-color: color-mix(in srgb, var(--color-amber) 70%, var(--color-line-bright));
+    background: color-mix(in srgb, var(--color-amber) 18%, var(--color-bg));
+    color: var(--color-ink-bright);
+  }
+  .auth-btn.primary:hover {
+    background: color-mix(in srgb, var(--color-amber) 28%, var(--color-bg));
+  }
+  /* Coarse pointers (touch): 44px tap-target floor. */
+  @media (pointer: coarse) {
+    .auth-btn {
+      min-height: 44px;
+      padding: 0 16px;
+    }
+  }
+
   /* parked: this terminal is live on another device — tap to take it back */
   .parked {
     position: absolute;

--- a/ui/src/lib/components/viewport/ViewportTermBanners.svelte
+++ b/ui/src/lib/components/viewport/ViewportTermBanners.svelte
@@ -42,9 +42,9 @@
     if (authUrl) window.open(authUrl, "_blank", "noopener,noreferrer");
   }
   async function copyAuth() {
-    if (!authUrl) return;
+    if (!authUrl || !navigator.clipboard) return; // no clipboard (insecure context) → don't fake success
     try {
-      await navigator.clipboard?.writeText(authUrl);
+      await navigator.clipboard.writeText(authUrl);
       copied = true;
       clearTimeout(copyTimer);
       copyTimer = setTimeout(() => (copied = false), 2000);

--- a/ui/src/lib/feature-announcements/entries/v1.42.0-auth-url-banner.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.42.0-auth-url-banner.ts
@@ -1,0 +1,13 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // MCP OAuth prompts (Notion, Vercel, …) print an authorize URL Claude word-wraps
+  // un-clickably across terminal lines. A banner now surfaces the full URL (read from
+  // the transcript) with one-click Open / Copy while the agent waits.
+  id: "auth-url-banner",
+  sinceVersion: "1.42.0",
+  titleKey: "feat_auth_url_banner_title",
+  bodyKey: "feat_auth_url_banner_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -1234,3 +1234,31 @@ test("doc-agent:done dedupes repeated events for the same repo (same key)", () =
   });
   expect(toasts.items.filter((x) => x.key === "doc-agent-done:/repos/da-dedup")).toHaveLength(1);
 });
+
+test("setBlocks seeds the block map (incl. authUrl) for bootstrap", () => {
+  const s = new HerdStore();
+  const reason = {
+    shape: "awaiting-input" as const,
+    options: [],
+    tail: ["paste callback"],
+    authUrl: "https://mcp.notion.com/authorize?response_type=code&client_id=abc",
+  };
+  s.setBlocks({ s1: reason });
+  expect(s.blocks.s1?.reason.authUrl).toBe(reason.authUrl);
+  expect(s.blocks.s1?.reason.shape).toBe("awaiting-input");
+});
+
+test("session:block carries the authUrl through to the block map", () => {
+  const s = new HerdStore();
+  const reason = {
+    shape: "awaiting-input" as const,
+    options: [],
+    tail: [],
+    authUrl: "https://vercel.com/oauth/authorize?response_type=code&client_id=x",
+  };
+  s.apply({ event: "session:block", data: { id: "s1", block: reason } });
+  expect(s.blocks.s1?.reason.authUrl).toBe(reason.authUrl);
+  // clearing drops the entry
+  s.apply({ event: "session:block", data: { id: "s1", block: null } });
+  expect(s.blocks.s1).toBeUndefined();
+});

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -187,6 +187,17 @@ export class HerdStore {
   setWorkingBlocked(map: Record<string, boolean>) {
     this.workingBlocked = map;
   }
+  /** Seed the per-session block map after a bootstrap GET /api/blocks. Blocks are
+   *  edge-emitted via `session:block`, so a fresh load / push-then-open would otherwise
+   *  show no block (and no MCP-auth affordance) until the next re-classify. `since` is
+   *  best-effort (bootstrap can't recover the original block time). Live events keep the
+   *  earlier `since` via `setBlock`. */
+  setBlocks(map: Record<string, BlockReason>) {
+    const now = Date.now();
+    this.blocks = Object.fromEntries(
+      Object.entries(map).map(([id, reason]) => [id, { reason, since: now }]),
+    );
+  }
   /** Seed (or replace) the hold-reason map after a bootstrap GET. */
   setHolds(map: Record<string, HoldReason>): void {
     this.holds = map;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -215,6 +215,10 @@ export interface BlockReason {
   tail: string[];
   /** Discriminator for quota blocks: which sub-kind of quota exhaustion triggered this. */
   quotaKind?: "rework" | "review" | "error" | "plan";
+  /** Full OAuth authorization URL an awaiting-input block is waiting on the operator to
+   *  open (MCP auth flows, e.g. Notion/Vercel), sourced from the JSONL transcript rather
+   *  than the word-wrapped terminal. Drives the "open in browser" affordance. */
+  authUrl?: string;
 }
 
 export type HoldCode =

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -23,6 +23,7 @@
     activityStates,
     claudeAliveStates,
     workingBlockedStates,
+    blockStates,
     holdStates,
     subagentStates,
     previewStates,
@@ -644,6 +645,10 @@
   );
 
   const selected = $derived(store.sessions.find((s) => s.id === selectedId) ?? null);
+  // Pending MCP OAuth authorize URL for the selected session's awaiting-input block, if any.
+  const selectedAuthUrl = $derived(
+    selected ? (store.blocks[selected.id]?.reason.authUrl ?? null) : null,
+  );
 
   // Select a freshly-started session and follow the herd's repo filter onto its repo.
   // A new task lands in `repoPath`; if the active filter does NOT include that repo the
@@ -777,6 +782,9 @@
       .catch(() => {});
     workingBlockedStates()
       .then((m) => store.setWorkingBlocked(m))
+      .catch(() => {});
+    blockStates()
+      .then((m) => store.setBlocks(m))
       .catch(() => {});
     holdStates()
       .then((m) => store.setHolds(m))
@@ -1514,6 +1522,9 @@
       .catch(() => {});
     workingBlockedStates()
       .then((m) => store.setWorkingBlocked(m))
+      .catch(() => {});
+    blockStates()
+      .then((m) => store.setBlocks(m))
       .catch(() => {});
     holdStates()
       .then((m) => store.setHolds(m))
@@ -2520,6 +2531,7 @@
             {consumeAutoFocusTerm}
             {onarchive}
             workingBlocked={store.workingBlocked}
+            authUrl={selectedAuthUrl}
             onback={() => (mobileScreen = "list")}
             onbroadcast={() => (showBroadcast = true)}
             onretry={() => (showRetry = true)}
@@ -2681,6 +2693,7 @@
             {consumeAutoFocusTerm}
             {onarchive}
             workingBlocked={store.workingBlocked}
+            authUrl={selectedAuthUrl}
             onbroadcast={() => (showBroadcast = true)}
             onretry={() => (showRetry = true)}
             retryHaltedCount={haltedCount}


### PR DESCRIPTION
## Problem

When an agent hits an MCP OAuth flow (Notion, Vercel, …) it prints a long authorize URL and blocks, asking the operator to open it in their browser. Claude's TUI **word-wraps that URL across several indented terminal lines**, so in the xterm buffer it's fragmented — the existing `WebLinksAddon` never linkifies it, and there's **no OSC 52** to copy it (unlike the Claude *login* screen handled in #1427). The operator can neither click nor cleanly copy it.

This is the "clickable URL" piece deferred from the OSC 52 login work (#1427), generalized to MCP auth.

## Step 0 — empirical source gate (done before building)

The plan hinged on an unproven assumption: does the URL actually reach a source we can read un-wrapped? A screenshot only proves the *PTY buffer* (fragmented). Captured real MCP OAuth flows on disk (Vercel MCP, `claude-cowork-sales`) and confirmed:

- The full **380-char un-wrapped** authorize URL appears **verbatim in the JSONL transcript**, in **two** record shapes in the same flow:
  - an `assistant` `text` block (Claude relaying it — the screenshot's shape), and
  - a `tool_result` block carried inside a **`role:"user"`** message (the raw MCP payload).
- Because tool_results are `role:"user"`, an assistant-only scan (`assistantSideText`) would **miss** the tool_result delivery — so the detector scans both.
- A/B on the real transcript: the detector returns the URL at the blocked moment and `null` once the operator has answered (no stale resurface).

## Approach

- **`detectAuthUrl(transcript)`** (`src/auth-url.ts`, pure + unit-tested): walks the JSONL, tracks the *pending* authorize URL (set by an assistant-text or tool_result authorize URL; cleared by operator input), so a resolved URL isn't resurfaced on a later unrelated block. `http/https` + OAuth-authorize heuristic; the `localhost/callback` return URL is correctly excluded.
- **Carried on the existing block channel**, not a parallel pipeline: `BlockReason.authUrl?` is populated in the poller's `maybeClassify` for `awaiting-input` blocks (a bounded, throttled tail read, gated to that shape). It rides the existing `session:block` dedup + UI, and clears with the block. Detection lives in `maybeClassify`, reached by **both** the herdr-blocked branch and the hook-awaiting-input path — so it fires in the awaiting state even if herdr hasn't latched blocked.
- **`GET /api/blocks` snapshot** (mirrors `/api/activity`): blocks were edge-emitted only, so a push-then-open / fresh load showed no block on first paint. Now current blocks (incl. the auth URL) bootstrap — a small, general fix.
- **Banner** in `ViewportTermBanners` above the terminal (non-modal, so it never covers the bottom prompt): the full URL shown for host-vetting, **Open** (`window.open`, `noopener`) and **Copy**. Design tokens only, EN+DE, ≥16px title / 44px touch targets.

## Scope

Outbound URL only (the return-trip callback paste uses the existing compose flow). Task sessions only — the Claude account-login pane (no transcript) keeps its OSC 52 copy from #1427.

## Security

The URL originates from agent output (which may relay untrusted MCP/issue content). Mitigations: the banner **shows the full URL** for vetting, **http/https only**, **explicit operator click** (never automatic), `noopener,noreferrer`. No wider than the terminal's existing click-to-open links.

## Testing

- `src/auth-url.test.ts` — detector (assistant text, tool_result, Vercel `/oauth/authorize`, callback-URL exclusion, staleness-clear, malformed lines).
- `test/poller.test.ts` — awaiting-input block carries + snapshots the URL; not consulted for menu blocks; clears on resume; `GET /api/blocks`.
- `ui` store + `ViewportTermBanners.browser.test.ts` (render / Open / Copy / hidden-when-null).
- Full suites green: root lint + 6005 tests; UI `check` (0 errors) + `check:i18n` + 2859 tests; fallow audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)