### PR TITLE
fix(poller): resolve transcripts under the session's spawn account

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1749,7 +1749,7 @@ const herdDigestService = new HerdDigestService({
     const stalled = new Set<string>();
     for (const s of store.list({ activeOnly: true })) {
       if (s.status !== "running" || !s.claudeSessionId) continue;
-      const snap = readSnapshot(jsonlPathFor(s.worktreePath, s.claudeSessionId));
+      const snap = readSnapshot(jsonlPathFor(s.worktreePath, s.claudeSessionId, s.spawnAccountDir));
       if (snap && isStalled(snap, now, DEFAULT_STALL)) stalled.add(s.id);
     }
     return stalled;

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -93,7 +93,9 @@ export interface LivenessWiring {
 function readAuthUrl(s: Session): string | null {
   if (!s.claudeSessionId) return null;
   try {
-    return detectAuthUrl(readTranscriptTail(jsonlPathFor(s.worktreePath, s.claudeSessionId)));
+    return detectAuthUrl(
+      readTranscriptTail(jsonlPathFor(s.worktreePath, s.claudeSessionId, s.spawnAccountDir)),
+    );
   } catch {
     return null;
   }
@@ -219,7 +221,7 @@ export class StatusPoller {
      */
     private probe: (s: Session) => TranscriptSignals = (s) =>
       s.claudeSessionId
-        ? readTranscriptSignals(jsonlPathFor(s.worktreePath, s.claudeSessionId))
+        ? readTranscriptSignals(jsonlPathFor(s.worktreePath, s.claudeSessionId, s.spawnAccountDir))
         : { snapshot: null, activity: null },
     private stallCfg = DEFAULT_STALL,
     private probeCheckMs = 7000,
@@ -552,7 +554,9 @@ export class StatusPoller {
   private detectUsageHalt(s: Session): void {
     if (s.haltReason) return; // already set; skip
     try {
-      const tail = readTranscriptTail(jsonlPathFor(s.worktreePath, s.claudeSessionId));
+      const tail = readTranscriptTail(
+        jsonlPathFor(s.worktreePath, s.claudeSessionId, s.spawnAccountDir),
+      );
       // Match only NON-user transcript content: a user prompt mentioning usage-limit
       // phrasing must never be read as Claude's own halt notice (false positive on the
       // uncalibrated degrade path, where the usage corroboration is bypassed).

--- a/src/process-reaper.ts
+++ b/src/process-reaper.ts
@@ -264,7 +264,12 @@ export class ProcessReaper {
   constructor(private probes: ReaperProbes = defaultProbes) {}
 
   /** Detect surviving leftovers for a session (classes 2 + 3). */
-  detect(s: { worktreePath: string; claudeSessionId: string; isolated: boolean }): Leftover[] {
+  detect(s: {
+    worktreePath: string;
+    claudeSessionId: string;
+    isolated: boolean;
+    spawnAccountDir?: string | null;
+  }): Leftover[] {
     // Non-isolated sessions never got a private worktree — their `worktreePath` IS
     // the shared repo root, where the shepherd server itself (and other unrelated
     // long-running servers) are rooted. A cwd scan there flags processes that merely
@@ -296,9 +301,15 @@ export class ProcessReaper {
   }
 
   /** Class 3 — system side-effects scraped from the transcript, port-verified. */
-  private scanSystemSideEffects(s: { worktreePath: string; claudeSessionId: string }): Leftover[] {
+  private scanSystemSideEffects(s: {
+    worktreePath: string;
+    claudeSessionId: string;
+    spawnAccountDir?: string | null;
+  }): Leftover[] {
     if (!s.claudeSessionId) return [];
-    const text = this.probes.readTranscript(jsonlPathFor(s.worktreePath, s.claudeSessionId));
+    const text = this.probes.readTranscript(
+      jsonlPathFor(s.worktreePath, s.claudeSessionId, s.spawnAccountDir),
+    );
     if (!text) return [];
     const listening = this.probes.listeningPorts();
     // drop any whose port no longer listens — already stopped by hand

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -65,8 +65,12 @@ async function defaultHeadSha(worktreePath: string): Promise<string> {
   return stdout.trim();
 }
 
-function defaultReadTranscript(worktreePath: string, claudeSessionId: string): ActivityEntry[] {
-  const path = jsonlPathFor(worktreePath, claudeSessionId);
+function defaultReadTranscript(
+  worktreePath: string,
+  claudeSessionId: string,
+  spawnAccountDir?: string | null,
+): ActivityEntry[] {
+  const path = jsonlPathFor(worktreePath, claudeSessionId, spawnAccountDir);
   try {
     const text = readTranscriptTail(path);
     return parseActivity(text, -1); // -1 = all entries
@@ -168,7 +172,11 @@ export interface RecapServiceDeps {
   resolveBase?: (session: Session) => Promise<{ base: string; resolved: boolean }>;
   computeDiff?: (worktreePath: string, base: string, branch: string | null) => Promise<DiffResult>;
   headSha?: (worktreePath: string) => Promise<string>;
-  readTranscript?: (worktreePath: string, claudeSessionId: string) => ActivityEntry[];
+  readTranscript?: (
+    worktreePath: string,
+    claudeSessionId: string,
+    spawnAccountDir?: string | null,
+  ) => ActivityEntry[];
   readPlan?: (worktreePath: string) => string;
   readVerdict?: (cwd: string) => VerdictRead<unknown>;
   readUsage?: (cwd: string, spawnSessionId: string) => Promise<SessionUsage | null>;
@@ -198,7 +206,11 @@ export class RecapService {
     branch: string | null,
   ) => Promise<DiffResult>;
   private _headSha: (worktreePath: string) => Promise<string>;
-  private _readTranscript: (worktreePath: string, claudeSessionId: string) => ActivityEntry[];
+  private _readTranscript: (
+    worktreePath: string,
+    claudeSessionId: string,
+    spawnAccountDir?: string | null,
+  ) => ActivityEntry[];
   private _readPlan: (worktreePath: string) => string;
   private _readVerdict: (cwd: string) => VerdictRead<unknown>;
   private _readUsage: (cwd: string, spawnSessionId: string) => Promise<SessionUsage | null>;
@@ -390,7 +402,7 @@ export class RecapService {
       );
       return "error";
     }
-    const { id, worktreePath, branch, claudeSessionId } = session;
+    const { id, worktreePath, branch, claudeSessionId, spawnAccountDir } = session;
 
     // Synchronous guard: if already mid-flight for this session, bail immediately.
     if (this.inFlight.has(id)) return "started";
@@ -439,7 +451,7 @@ export class RecapService {
       }
 
       // Build prompt inputs.
-      const transcript = this._readTranscript(worktreePath, claudeSessionId);
+      const transcript = this._readTranscript(worktreePath, claudeSessionId, spawnAccountDir);
       const digest = buildTranscriptDigest(transcript);
       const plan = this._readPlan(worktreePath);
       const changedFiles = diff.files.map((f) => f.path);

--- a/src/usage-breakdown.ts
+++ b/src/usage-breakdown.ts
@@ -108,7 +108,7 @@ async function liveSessionToAccum(
   if (!s.claudeSessionId) return null;
   if (isOperationalArchetype(s)) return null;
 
-  const path = jsonlPathFor(s.worktreePath, s.claudeSessionId);
+  const path = jsonlPathFor(s.worktreePath, s.claudeSessionId, s.spawnAccountDir);
   const file = Bun.file(path);
   if (!(await file.exists())) return null;
 
@@ -345,6 +345,7 @@ async function addLiveRollupTasks(
       id: s.id,
       worktreePath: s.worktreePath,
       claudeSessionId: s.claudeSessionId,
+      spawnAccountDir: s.spawnAccountDir,
     })),
     now,
   );

--- a/src/usage-snapshot.ts
+++ b/src/usage-snapshot.ts
@@ -49,7 +49,7 @@ export async function snapshotSessionUsage(
     if (isOperationalArchetype(s) || !s.claudeSessionId) return "skipped";
 
     // 2. Resolve and read the JSONL file; skip if absent.
-    const path = jsonlPathFor(s.worktreePath, s.claudeSessionId);
+    const path = jsonlPathFor(s.worktreePath, s.claudeSessionId, s.spawnAccountDir);
     const file = Bun.file(path);
     if (!(await file.exists())) return "skipped";
     const text = await file.text();

--- a/src/usage-timeline.ts
+++ b/src/usage-timeline.ts
@@ -34,6 +34,7 @@ async function foldLiveSessions(
       id: s.id,
       worktreePath: s.worktreePath,
       claudeSessionId: s.claudeSessionId,
+      spawnAccountDir: s.spawnAccountDir,
     })),
     now,
   );

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -9,9 +9,24 @@ export function dashify(cwd: string): string {
   return cwd.replace(/[/.]/g, "-");
 }
 
-/** Absolute path to a session's JSONL given its worktree cwd + pinned claude session id. */
-export function jsonlPathFor(worktreePath: string, claudeSessionId: string): string {
-  return join(config.claudeProjectsDir, dashify(worktreePath), `${claudeSessionId}.jsonl`);
+/** The claude projects dir a session's transcript lives under. When the agent was spawned
+ *  into a swap/pool account (`spawnAccountDir` set — claude-swap sets CLAUDE_CONFIG_DIR to it),
+ *  Claude Code writes the JSONL to `<account>/projects/…`, NOT the server's active projects
+ *  dir. So resolution MUST follow the account, else every transcript readback (usage, activity,
+ *  halt classification, MCP-auth URL) reads a nonexistent path and silently misses. Null/absent
+ *  ⇒ the active `config.claudeProjectsDir` (session ran under the server's own account). */
+function projectsDirFor(spawnAccountDir?: string | null): string {
+  return spawnAccountDir ? join(spawnAccountDir, "projects") : config.claudeProjectsDir;
+}
+
+/** Absolute path to a session's JSONL given its worktree cwd + pinned claude session id, rooted
+ *  under the session's spawn account when it was spawned into one (see `projectsDirFor`). */
+export function jsonlPathFor(
+  worktreePath: string,
+  claudeSessionId: string,
+  spawnAccountDir?: string | null,
+): string {
+  return join(projectsDirFor(spawnAccountDir), dashify(worktreePath), `${claudeSessionId}.jsonl`);
 }
 
 export interface ParsedRecord {
@@ -246,9 +261,13 @@ export function dominantModel(u: SessionUsage): string | null {
 export async function readSessionUsage(
   worktreePath: string,
   claudeSessionId: string,
+  spawnAccountDir?: string | null,
 ): Promise<SessionUsage | null> {
   try {
-    const text = await readFile(jsonlPathFor(worktreePath, claudeSessionId), "utf8");
+    const text = await readFile(
+      jsonlPathFor(worktreePath, claudeSessionId, spawnAccountDir),
+      "utf8",
+    );
     return accumulate(text.split("\n"));
   } catch {
     return null;
@@ -436,6 +455,9 @@ export interface RollupSession {
   id: string;
   worktreePath: string;
   claudeSessionId: string | null;
+  /** Swap/pool account the agent ran under, so the rollup reads the JSONL where it was
+   *  actually written (see `projectsDirFor`); null ⇒ the active projects dir. */
+  spawnAccountDir?: string | null;
 }
 
 interface PerRecord {
@@ -498,8 +520,12 @@ export class SessionUsageRollup {
   private inflight: Promise<void> | null = null;
 
   /** Resolve the JSONL path for a session. Overridable for tests. */
-  protected pathFor(worktreePath: string, claudeSessionId: string): string {
-    return jsonlPathFor(worktreePath, claudeSessionId);
+  protected pathFor(
+    worktreePath: string,
+    claudeSessionId: string,
+    spawnAccountDir?: string | null,
+  ): string {
+    return jsonlPathFor(worktreePath, claudeSessionId, spawnAccountDir);
   }
 
   /** Rescan sessions, ingesting newly-appended lines. Concurrent calls share one in-flight promise. */
@@ -530,7 +556,7 @@ export class SessionUsageRollup {
   /** Ingest one session file: stat, reset if truncated, appendChunk if grown, then prune. */
   private async ingestSession(sess: RollupSession, cutoff: number): Promise<void> {
     if (!sess.claudeSessionId) return;
-    const path = this.pathFor(sess.worktreePath, sess.claudeSessionId);
+    const path = this.pathFor(sess.worktreePath, sess.claudeSessionId, sess.spawnAccountDir);
 
     let size: number;
     try {

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -55,6 +55,21 @@ test("jsonlPathFor composes projects dir + dashified cwd + session id", () => {
   expect(p.endsWith("/-home-p-Work-r/abc-123.jsonl")).toBe(true);
 });
 
+test("jsonlPathFor roots under {spawnAccountDir}/projects when a swap/pool account is given", () => {
+  // A claude-swap agent runs with CLAUDE_CONFIG_DIR=<account>, so it writes its JSONL to
+  // <account>/projects/…, NOT the server's active config.claudeProjectsDir. Resolution must
+  // follow the account or every transcript readback (usage/activity/halt/auth-url) misses.
+  const acct = "/home/p/.local/share/claude-swap/sessions/acme";
+  const p = jsonlPathFor("/home/p/Work/r", "abc-123", acct);
+  expect(p).toBe(`${acct}/projects/-home-p-Work-r/abc-123.jsonl`);
+});
+
+test("jsonlPathFor falls back to the active projects dir when spawnAccountDir is null", () => {
+  expect(jsonlPathFor("/home/p/Work/r", "abc-123", null)).toBe(
+    jsonlPathFor("/home/p/Work/r", "abc-123"),
+  );
+});
+
 test("parseLine ignores non-assistant and usage-less records", () => {
   expect(parseLine(JSON.stringify({ type: "user", message: {} }))).toBeNull();
   expect(parseLine(JSON.stringify({ type: "assistant", message: {} }))).toBeNull();


### PR DESCRIPTION
## Problem

The MCP OAuth **auth-URL banner** (#1436) never appeared, even for the mid-conversation flow it targets. Root cause is upstream of that feature: shepherd resolved **every** session's JSONL under the server's own `config.claudeProjectsDir` (`~/.claude/projects`), ignoring the swap/pool account the agent actually ran under.

claude-swap runs agents with `CLAUDE_CONFIG_DIR=<account>`, so their transcript lands in `<account>/projects/…`. `jsonlPathFor` read a nonexistent path → the read was swallowed → no data. This silently degraded **all** transcript readback (usage tracking, activity signals, halt classification, recap, and the auth-URL banner) for every claude-swap (`sandboxApplied=trusted`, unconfined — no membrane bind) session. The banner was just the newest feature to surface the miss.

Confirmed general, not feature-specific — every swap-account session, including live ones:

```
TASK-1344  blocked   sbox=trusted   active_path=False   swap_path=True
TASK-1336  done      sbox=trusted   active_path=False   swap_path=True   ← reported
```

## Fix

Make transcript resolution **account-aware**:

- `jsonlPathFor` takes an optional `spawnAccountDir` (new module-local `projectsDirFor`): roots under `<account>/projects` when set, else the active `config.claudeProjectsDir`.
- Thread `s.spawnAccountDir` through every session-level call site: poller (auth-url, activity/stall, halt), stalled-session scan, process-reaper, usage snapshot/breakdown/timeline rollup, and recap's main-session transcript read.
- Reviewer/critic reads intentionally stay on the active dir — they're shepherd-spawned, never swapped.

## Verification

A/B under the server's real env (no `CLAUDE_CONFIG_DIR`) against the real reported transcript:

| | Resolved path | Exists | Banner `authUrl` |
|---|---|---|---|
| **Pre-fix** | `~/.claude/projects/…/0189bb52.jsonl` | ❌ | `null` (bug reproduced) |
| **Post-fix** | `…/claude-swap/…/projects/…/0189bb52.jsonl` | ✅ | `https://mcp.sentry.dev/oauth/authorize?…` ✅ |

- New unit tests lock account-aware resolution + null fallback (RED→GREEN)
- Full root suite: **6031 pass, 0 fail** · `tsc` clean · lint clean · fallow audit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)