### PR TITLE
fix(onboarding): refresh Arch keyring before pacman installs

### DIFF
--- a/ci/onboarding-harness/seed.ts
+++ b/ci/onboarding-harness/seed.ts
@@ -8,6 +8,27 @@ const SHEPHERD_DIR = "/opt/shepherd";
 // replace default and leave the instance with no root device.
 const PROFILES = ["default", "shep-onb"];
 
+/** Arch's base-image `archlinux-keyring` drifts behind the mirror over time; once a
+ *  mirror package is signed by a packager key newer than the image's keyring,
+ *  `pacman -Sy <pkg>` fails "signature … is unknown trust / invalid or corrupted
+ *  package (PGP signature)" and the checked baseline aborts (issue #1422 — herdr-missing
+ *  on images:archlinux is the only Arch scenario). Refresh the keyring ONCE before any
+ *  pacman install: init the gnupg dir, populate trust from the shipped keyring, then
+ *  update archlinux-keyring from the mirror (its own signature verifies against the
+ *  freshly-populated trust; its install hook re-populates the new packager keys).
+ *  Populate-before-sync is required — `-Sy` first would fail verification before the
+ *  keyring is refreshed. `--needed` skips a redundant reinstall when already current.
+ *  Guarded on `command -v pacman` so it's a clean no-op on apt/apk/dnf images (the 8
+ *  non-Arch scenarios). Runs as root — `driver.exec` → `incus exec` is root by default,
+ *  which `pacman-key` requires. */
+function archKeyringRefresh(): string {
+  return (
+    "command -v pacman >/dev/null 2>&1 || exit 0; " +
+    "pacman-key --init && pacman-key --populate archlinux && " +
+    "pacman -Sy --needed --noconfirm archlinux-keyring"
+  );
+}
+
 /** Cross-distro "ensure package `$1` is installed" one-liner (apt/apk/dnf/pacman). */
 function ensurePkg(pkg: string): string {
   return (
@@ -62,6 +83,9 @@ function herdrStub(): string {
  *  AFTER this so degraded Shepherd can still boot. */
 function baselineCommands(): string[] {
   return [
+    // Arch keyring rot (#1422) fails the first pacman install; refresh it before any
+    // package op. No-op on non-Arch images. See archKeyringRefresh().
+    archKeyringRefresh(),
     ensurePkg("curl"),
     // busybox/minimal images (alpine) ship no `bash`; the bun installer pipes
     // to `bash` explicitly, so it must be present before the curl step runs.

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -113,10 +113,30 @@ install_os_prereqs() {
   # gzip — both baseline) — no external `logrotate` package to install here anymore.
 }
 
+# arch_keyring_refresh: on Arch only, refresh the drifted `archlinux-keyring` ONCE so the
+# pacman branch below doesn't fail "unknown trust / invalid or corrupted package (PGP
+# signature)" on a fresh image (#1422). Mirrors seed.ts archKeyringRefresh(). LAZY —
+# callers invoke it only after their `command -v` early-return, i.e. only when an install
+# is genuinely pending, so an all-prereqs-present Arch host never runs it. Memoized via
+# `_arch_keyring_done` (set in this parent shell; only the privileged sync is a `$sp sh -c`
+# subshell) so N missing prereqs trigger ONE sync, not N. No-op (returns 0) off pacman.
+_arch_keyring_done=0
+arch_keyring_refresh() {
+  command -v pacman >/dev/null 2>&1 || return 0
+  [ "$_arch_keyring_done" = 1 ] && return 0
+  local sp
+  sp="$(sudo_prefix "archlinux-keyring")"
+  note "refreshing Arch package-signing keyring (archlinux-keyring)"
+  $sp sh -c "pacman-key --init && pacman-key --populate archlinux && pacman -Sy --needed --noconfirm archlinux-keyring" \
+    || die "failed to refresh the Arch keyring (pacman-key/archlinux-keyring)"
+  _arch_keyring_done=1
+}
+
 # ensure_pkg <bin> <pkg>: install <pkg> via apt/apk/dnf/pacman if <bin> is absent.
 ensure_pkg() {
   local bin="$1" pkg="$2" sp
   command -v "$bin" >/dev/null 2>&1 && return 0
+  arch_keyring_refresh
   sp="$(sudo_prefix "$pkg")"
   note "installing $pkg (provides '$bin')"
   $sp sh -c "(apt-get update && apt-get install -y $pkg) || apk add --no-cache $pkg || dnf install -y $pkg || pacman -Sy --noconfirm $pkg" \
@@ -127,6 +147,7 @@ ensure_pkg() {
 ensure_toolchain() {
   local sp
   command -v cc >/dev/null 2>&1 && command -v make >/dev/null 2>&1 && return 0
+  arch_keyring_refresh
   sp="$(sudo_prefix "build-essential/base-devel + python3")"
   note "installing C/C++ build toolchain + python3 (node-pty native build)"
   $sp sh -c "(apt-get update && apt-get install -y build-essential python3) || apk add --no-cache build-base python3 || dnf install -y gcc-c++ make python3 || pacman -Sy --noconfirm base-devel python3" \

--- a/src/remediations.ts
+++ b/src/remediations.ts
@@ -29,8 +29,9 @@ const CODEX_INSTALL =
 // GUIDANCE_ONLY below), so this string is only ever executed with privilege.
 // The pacman branch refreshes Arch's drifted archlinux-keyring first (#1422) — a fresh
 // Arch host otherwise fails "unknown trust / invalid or corrupted package (PGP
-// signature)". The refresh is reached only after apt/apk/dnf all miss (= an Arch host)
-// and installs a single package, so it's inherently lazy + one-shot; guarded on
+// signature)". The refresh is reached only after apt/apk/dnf all miss (= an Arch host),
+// and this whole string runs once per apply (not looped), so it's inherently lazy and
+// needs no run-once memo — the keyring is refreshed at most once here; guarded on
 // `command -v pacman` so it can't run on a non-Arch box.
 const GIT_INSTALL =
   "command -v git >/dev/null 2>&1 || " +

--- a/src/remediations.ts
+++ b/src/remediations.ts
@@ -27,10 +27,18 @@ const CODEX_INSTALL =
 // uses) covers ubuntu/debian/alpine/arch/fedora. NO `sudo`: the harness runs as root
 // (and busybox alpine has no sudo); the in-app surface never auto-runs it (git is
 // GUIDANCE_ONLY below), so this string is only ever executed with privilege.
+// The pacman branch refreshes Arch's drifted archlinux-keyring first (#1422) — a fresh
+// Arch host otherwise fails "unknown trust / invalid or corrupted package (PGP
+// signature)". The refresh is reached only after apt/apk/dnf all miss (= an Arch host)
+// and installs a single package, so it's inherently lazy + one-shot; guarded on
+// `command -v pacman` so it can't run on a non-Arch box.
 const GIT_INSTALL =
   "command -v git >/dev/null 2>&1 || " +
   "(apt-get update && apt-get install -y git) || apk add --no-cache git || " +
-  "dnf install -y git || pacman -Sy --noconfirm git";
+  "dnf install -y git || " +
+  "((command -v pacman >/dev/null 2>&1 && " +
+  "pacman-key --init && pacman-key --populate archlinux && " +
+  "pacman -Sy --needed --noconfirm archlinux-keyring); pacman -Sy --noconfirm git)";
 
 export const REMEDIATIONS: Record<string, string> = {
   diagnostics_hint_bun_missing: "curl -fsSL https://bun.sh/install | bash",

--- a/test/onboarding-harness/remediations.test.ts
+++ b/test/onboarding-harness/remediations.test.ts
@@ -53,6 +53,12 @@ describe("remediations catalog", () => {
     expect(cmd).toContain("apk add --no-cache git");
     expect(cmd).toContain("dnf install -y git");
     expect(cmd).toContain("pacman -Sy --noconfirm git");
+    // the pacman branch refreshes Arch's drifted keyring first (#1422), else a fresh
+    // Arch host fails "unknown trust"; guarded on `command -v pacman` so it can't run
+    // on a non-Arch box, and reached only after apt/apk/dnf all miss.
+    expect(cmd).toContain("command -v pacman");
+    expect(cmd).toContain("pacman-key --populate archlinux");
+    expect(cmd).toContain("archlinux-keyring");
     expect(cmd).not.toContain("sudo"); // harness runs as root; busybox alpine has no sudo
     // privileged system install ⇒ guidance-only in-app (the root harness still applies it)
     expect(GUIDANCE_ONLY.has("diagnostics_hint_git_missing")).toBe(true);

--- a/test/onboarding-harness/seed.test.ts
+++ b/test/onboarding-harness/seed.test.ts
@@ -46,6 +46,17 @@ describe("seedInstance", () => {
     expect(flat.some((c) => c.includes("unzip"))).toBe(true);
     expect(flat.some((c) => c.includes("build-essential"))).toBe(true);
 
+    // Arch keyring refresh (#1422) runs BEFORE the first pacman install so a fresh
+    // archlinux image doesn't fail unzip on a drifted keyring; guarded on `command -v
+    // pacman` so it's a no-op on non-Arch scenarios.
+    const keyringIdx = flat.findIndex(
+      (c) => c.includes("pacman-key --populate archlinux") && c.includes("archlinux-keyring"),
+    );
+    expect(keyringIdx).toBeGreaterThanOrEqual(0);
+    expect(flat[keyringIdx]).toContain("command -v pacman");
+    const unzipIdx = flat.findIndex((c) => c.includes("unzip"));
+    expect(keyringIdx).toBeLessThan(unzipIdx);
+
     // baseline writes the network-free herdr STUB (satisfies the #1313 preflight
     // with zero network) before the scenario seed — NOT a herdr.dev fetch.
     const stubIdx = flat.findIndex((c) => c.includes(".local/bin/herdr") && c.includes("chmod +x"));


### PR DESCRIPTION
## What & why

The nightly onboarding harness regressed: **herdr-missing** (the only scenario on `images:archlinux`) crashed at its baseline (#1422). Root cause is **Arch keyring rot**, not a code change — a fresh archlinux image ships an `archlinux-keyring` that drifts behind the mirror. Once a mirror package is signed by a packager key newer than that keyring, the first `pacman -Sy <pkg>` fails:

```
error: unzip: signature from "Lukas Fleischer <lfleischer@lfos.de>" is unknown trust
error: failed to commit transaction (invalid or corrupted package (PGP signature))
```

`ensurePkg("unzip")` is a **checked** baseline step, so it aborts the seed → reported as a BOOT CRASH. It surfaces as a "nightly regression" simply because the cached image ages until the keyring tips over.

## Fix

Refresh the keyring once before any pacman install — populate trust from the shipped keyring, then pull the current one:

```
pacman-key --init && pacman-key --populate archlinux && pacman -Sy --needed --noconfirm archlinux-keyring
```

Populate-before-sync is required (`-Sy` first would fail verification before the keyring is refreshed); `--needed` skips a redundant reinstall. Applied at **all three** copies of the failing `pacman -Sy --noconfirm` branch so they don't drift:

| Site | Placement | Lazy | Run-once |
| --- | --- | --- | --- |
| `ci/onboarding-harness/seed.ts` | dedicated first baseline step, `command -v pacman`-guarded | fresh instance always installs → never wasted; no-op on the 8 non-Arch scenarios | single step |
| `deploy/install.sh` | inside `ensure_pkg`/`ensure_toolchain`, **after** the `command -v` early-return | only when a prereq is genuinely missing; all-present Arch host no-ops | `_arch_keyring_done` memo → N missing prereqs = 1 sync |
| `src/remediations.ts` (`GIT_INSTALL`) | folded into the pacman branch only | reached only after apt/apk/dnf all miss (= an Arch host) | single package |

Runs as root at every site (`pacman-key` requires it): harness via `incus exec` (root); installer via `sudo_prefix`; `GIT_INSTALL` is `GUIDANCE_ONLY` in-app so its keyring branch only ever runs under the root harness apply.

## Verification

- `bun test ./test` — 6033 pass, 0 fail; `bun run typecheck` clean; `bun run lint` clean; `shellcheck deploy/install.sh` clean (only a pre-existing info-level SC1091).
- New assertions: `seed.test.ts` (keyring step present, `command -v pacman`-guarded, ordered before unzip); `remediations.test.ts` (`GIT_INSTALL` gains the keyring refresh, keeps the `pacman -Sy --noconfirm git` substring).
- **Unit tests only assert the string's presence/order — they cannot validate the `pacman-key` incantation** (the harness needs Incus and cannot run in CI). The real proof is the **next nightly run**: herdr-missing clears the baseline and reaches green.

Fixes #1422

🤖 Generated with [Claude Code](https://claude.com/claude-code)