### PR TITLE
fix(poller): surface MCP OAuth auth-URL banner for done/idle sessions

### DIFF
--- a/src/auth-url.test.ts
+++ b/src/auth-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { detectAuthUrl } from "./auth-url";
+import { detectAuthUrl, detectPendingAuthUrl } from "./auth-url";
 
 // Real-shape fixtures (synthetic client_id / code_challenge). Mirrors the Step-0 capture:
 // the authorize URL lands in an assistant `text` block AND/OR a `tool_result` block inside a
@@ -100,5 +100,57 @@ describe("detectAuthUrl", () => {
 
   it("returns null for an empty transcript", () => {
     expect(detectAuthUrl("")).toBeNull();
+  });
+});
+
+// Attachment / system records — carry no `message`, so they are NOT meaningful records and must
+// not count toward the freshness gate's since-set distance.
+const attachment = () => JSON.stringify({ type: "attachment" });
+const system = () => JSON.stringify({ type: "system", content: "hook ran" });
+
+describe("detectPendingAuthUrl (freshness-gated)", () => {
+  it("returns the URL for the real captured check-sentry tail shape (0 meaningful records after)", () => {
+    // Mirrors the captured transcript tail: the authorize URL lands in a `tool_result` (raw MCP
+    // payload) AND the assistant relay, with only attachment/system records trailing — sinceSet=0.
+    const jsonl = [
+      opInputString("check sentry"),
+      toolUse(),
+      toolResult(`MCP server sentry requires authorization. Visit: ${AUTH_URL}`),
+      attachment(),
+      assistantText(
+        `The Sentry MCP server needs authorization.\n1. Open this URL:\n\n${AUTH_URL}\n\n2. Paste the callback URL here.`,
+      ),
+      attachment(),
+      system(),
+      system(),
+    ].join("\n");
+    expect(detectPendingAuthUrl(jsonl)).toBe(AUTH_URL);
+  });
+
+  it("surfaces a URL that is the last meaningful record", () => {
+    const jsonl = [opInputString("go"), assistantText(`Authorize: ${AUTH_URL}`)].join("\n");
+    expect(detectPendingAuthUrl(jsonl)).toBe(AUTH_URL);
+  });
+
+  it("suppresses a stale URL buried under more than K meaningful records (truncation phantom)", () => {
+    // A stale URL whose clearing operator message scrolled out of the MAX_TAIL_BYTES window,
+    // followed by many autonomous tool turns — must NOT re-surface as a phantom banner.
+    const trailing = Array.from({ length: 30 }, () => toolUse());
+    const jsonl = [assistantText(`old prompt: ${AUTH_URL}`), ...trailing].join("\n");
+    expect(detectPendingAuthUrl(jsonl)).toBeNull();
+  });
+
+  it("still surfaces a URL with a handful of trailing assistant messages (generous K)", () => {
+    const trailing = Array.from({ length: 5 }, () => assistantText("still waiting on you"));
+    const jsonl = [assistantText(`Authorize: ${AUTH_URL}`), ...trailing].join("\n");
+    expect(detectPendingAuthUrl(jsonl)).toBe(AUTH_URL);
+  });
+
+  it("returns null once the operator has responded (explicit clear)", () => {
+    const jsonl = [
+      assistantText(`Authorize: ${AUTH_URL}`),
+      opInputString("http://localhost:3118/callback?code=xyz"),
+    ].join("\n");
+    expect(detectPendingAuthUrl(jsonl)).toBeNull();
   });
 });

--- a/src/auth-url.ts
+++ b/src/auth-url.ts
@@ -123,19 +123,65 @@ function userAuthEffect(content: unknown): { clear: boolean; url: string | null 
  * So a prior, already-answered auth URL still sitting in the tail is not resurfaced when the
  * agent later blocks for an unrelated reason. Malformed/blank lines are skipped.
  */
+/** The pending-URL transition a single record implies: SET (assistant text / tool_result
+ *  carrying an authorize URL), CLEAR (plain operator input), or NONE (everything else). */
+type AuthEffect = { kind: "set"; url: string } | { kind: "clear" } | { kind: "none" };
+
+function recAuthEffect(rec: Rec): AuthEffect {
+  if (rec.role === "assistant") {
+    const url = assistantAuthUrl(rec.content);
+    return url ? { kind: "set", url } : { kind: "none" };
+  }
+  if (rec.role === "user") {
+    const { clear, url } = userAuthEffect(rec.content);
+    if (clear) return { kind: "clear" };
+    if (url) return { kind: "set", url };
+  }
+  return { kind: "none" }; // system / other roles: ignored
+}
+
 export function detectAuthUrl(rawJsonl: string): string | null {
   let pending: string | null = null;
   for (const o of eachJsonlObject(rawJsonl)) {
     const rec = toRec(o);
     if (!rec) continue;
-    if (rec.role === "assistant") {
-      pending = assistantAuthUrl(rec.content) ?? pending;
-    } else if (rec.role === "user") {
-      const { clear, url } = userAuthEffect(rec.content);
-      if (clear) pending = null;
-      else pending = url ?? pending;
-    }
-    // system / other roles: ignored
+    const eff = recAuthEffect(rec);
+    if (eff.kind === "set") pending = eff.url;
+    else if (eff.kind === "clear") pending = null;
   }
   return pending;
+}
+
+/**
+ * Freshness-gated variant of {@link detectAuthUrl} for the resting-session (done/idle) path,
+ * where the transcript tail may be a truncated `MAX_TAIL_BYTES` window: an operator CLEAR that
+ * would have retired an already-answered URL can scroll OUT of that window, leaving a stale
+ * authorize URL at the tail that would otherwise re-surface as a phantom banner (and stand
+ * autopilot down forever). So on top of the same SET/CLEAR walk, this counts the *meaningful*
+ * records (`toRec`-non-null — attachment/system don't count) that follow the record which last
+ * SET `pending`, and suppresses the URL only when that count exceeds `maxSinceSet`.
+ *
+ * The gate is deliberately GENEROUS (default 25) and biased toward SURFACING: a false-suppress
+ * reproduces the exact reported bug (banner never shows) and is unrecoverable, whereas a rare
+ * false-surface is bounded — autopilot clears its stand-down on resume/archive. A genuine
+ * end-of-turn prompt has 0 meaningful records after the URL (measured against the captured
+ * `check-sentry` transcript), so it surfaces with wide margin; the operator-input CLEAR remains
+ * the primary staleness signal and the count is only a coarse backstop against gross truncation.
+ */
+export function detectPendingAuthUrl(rawJsonl: string, maxSinceSet = 25): string | null {
+  let pending: string | null = null;
+  let sinceSet = 0; // meaningful records since `pending` was last SET
+  for (const o of eachJsonlObject(rawJsonl)) {
+    const rec = toRec(o);
+    if (!rec) continue; // attachment / system with no message: not a meaningful record
+    const eff = recAuthEffect(rec);
+    if (eff.kind === "set") {
+      pending = eff.url;
+      sinceSet = 0;
+    } else if (eff.kind === "clear") {
+      pending = null;
+      sinceSet = 0;
+    } else if (pending) sinceSet++; // a meaningful record that neither set nor cleared
+  }
+  return pending && sinceSet > maxSinceSet ? null : pending;
 }

--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -120,6 +120,11 @@ export interface AutopilotDeps {
   deferSteer?: (id: string) => boolean;
   /** Visible terminal tail for a session (herdr.read → tailLines). */
   readTail: (id: string) => string[];
+  /** The pending MCP OAuth authorize URL for a session (freshness-gated transcript read), or
+   *  null. An OAuth flow is human-only — autopilot cannot paste the callback — so a non-null
+   *  result stands autopilot down until the operator completes it (the poller surfaces the
+   *  banner). Reads fresh (not off an event) so `onDone` can short-circuit deterministically. */
+  pendingAuthUrl: (id: string) => string | null;
   /** Whether the session already has a PR in any state (open/merged/closed). True → autopilot
    *  stands down (open = critic territory; merged/closed = pre-PR mission over). */
   hasPr: (id: string) => boolean;
@@ -186,6 +191,10 @@ export class AutopilotService {
   // deliver (the poller emits no `session:git` without a state change) — is owned by tick().
   private openSeen = new Set<string>();
   private ciNudged = new Map<string, string>();
+  // Sessions sitting on a pending MCP OAuth prompt (human-only). Stands autopilot down across
+  // every steer path until the operator completes it: set from onBlock(authUrl) / a pendingAuthUrl
+  // re-check, cleared on a null block, on `running` (operator resumed), and on archive (forget).
+  private authPending = new Set<string>();
   private stepCap: number;
   private rebaseCap: number;
 
@@ -219,6 +228,7 @@ export class AutopilotService {
       );
       return null;
     }
+    if (this.authPending.has(id)) return null; // human-only MCP OAuth pending — never steer/complete
     if (s.autopilotPaused) return null; // already handed back; waits for operator
     if (s.autopilotComplete) return null; // terminal: task delivered (non-PR), nothing to drive
     // A PR exists → autopilot normally stands down (critic territory). EXCEPTION: a full-auto
@@ -357,6 +367,13 @@ export class AutopilotService {
     // during the classify await.
     const cur = this.eligible(id);
     if (!cur) return;
+    // A done-edge auth URL may have been unflushed when onDone read it; by now (post-classify)
+    // it has landed. Re-read fresh and stand down before applying any terminal verdict, so a
+    // mid-OAuth session is never markComplete'd — deterministic, not reliant on onBlock's timing.
+    if (this.deps.pendingAuthUrl(cur.id)) {
+      this.authPending.add(cur.id);
+      return;
+    }
     await this.dispatch(cur, v);
   }
 
@@ -376,8 +393,15 @@ export class AutopilotService {
     this.onGit(id, change.git); // sync; PR-open handoff + red-CI recovery
   }
 
-  /** session:block handler. Only steerable shapes are eligible; menu/stall surface as-is. */
+  /** session:block handler. Only steerable shapes are eligible; menu/stall surface as-is.
+   *  The auth set/clear runs BEFORE the shape guard so a null block from the poller's clearBlock
+   *  actually reaches `authPending.delete` (a null would otherwise early-return). */
   async onBlock(id: string, block: BlockReason | null): Promise<void> {
+    if (block?.authUrl) {
+      this.authPending.add(id); // human-only MCP OAuth prompt — stand down, never steer it
+      return;
+    }
+    this.authPending.delete(id); // null / non-auth block ⇒ no OAuth pending
     if (!block || !STEERABLE_SHAPES.has(block.shape)) return;
     await this.consider(id, block.tail, `autopilot ${id}`);
   }
@@ -385,6 +409,14 @@ export class AutopilotService {
   /** session:status "done" handler — agent exited / idled. Read its tail and classify;
    *  a `finished` verdict drives it to a PR (resuming the pane if needed). */
   async onDone(id: string): Promise<void> {
+    // Human-only MCP OAuth prompt: the agent relayed an authorize URL and idled. Stand down
+    // BEFORE classify so a mid-OAuth session is never filed complete/paused (the poller surfaces
+    // the banner). Cheap early-out; a done-edge read that misses an as-yet-unflushed URL is
+    // caught by consider()'s post-classify re-check.
+    if (this.deps.pendingAuthUrl(id)) {
+      this.authPending.add(id);
+      return;
+    }
     // Kick a PR refresh up front: an agent that just ran `gh pr create` then idled may not
     // be in the cached PR snapshot yet. Firing it here puts the poll in flight during the
     // (multi-second) classify spawn, so the post-classify eligible()/hasPr re-check in
@@ -419,6 +451,9 @@ export class AutopilotService {
    *  cases that matter; conflating the two would let the cap never bite. */
   onStatus(id: string, status: string): void {
     if (status !== "running") return;
+    // Clear an MCP-OAuth stand-down the moment the operator resumes — BEFORE the paused/complete
+    // guard below, since an authPending stand-down set neither flag and would otherwise never clear.
+    this.authPending.delete(id);
     const s = this.deps.store.get(id);
     if (!s || (!s.autopilotPaused && !s.autopilotComplete)) return;
     this.deps.store.setAutopilotState(id, {
@@ -430,6 +465,17 @@ export class AutopilotService {
     });
     this.deps.store.setAutoMergeState(id, { rebaseCount: 0, rebaseHead: null });
     this.deps.onState?.(id);
+  }
+
+  /** Drop all per-session tracking for a session that's gone (session:archived). Mirrors the
+   *  poller's pruneInactive so archived sessions don't leak map entries. `openSeen`/`ciNudged`
+   *  otherwise self-clean on PR-gone and `pending` is transient, but clearing them here too is
+   *  harmless and keeps the teardown in one place. */
+  forget(id: string): void {
+    this.authPending.delete(id);
+    this.openSeen.delete(id);
+    this.ciNudged.delete(id);
+    this.pending.delete(id);
   }
 
   /** The critic handoff: clear pause + complete + reset the step budget. Invoked once per PR-open
@@ -525,6 +571,7 @@ export class AutopilotService {
     const s = this.deps.store.get(id);
     if (!s || s.status === "archived") return false;
     if (s.mergingSince !== null) return true; // merge train owns this session: claim it so onDone short-circuits BEFORE classify, but don't steer/bump/pause — that state must not survive mark-clear
+    if (this.authPending.has(id)) return false; // human-only MCP OAuth pending — don't steer even an open+red PR
     if (!this.enabled(s)) return false;
     if (s.autopilotPaused) return false; // already handed back; waits for operator
     if (s.autopilotComplete) return false; // terminal
@@ -615,6 +662,7 @@ export class AutopilotService {
    *  each piece simple. */
   private rebaseCandidate(s: Session): GitState | null {
     if (s.mergingSince !== null) return null; // merge-train-marked → the train owns its rebase
+    if (this.authPending.has(s.id)) return null; // human-only MCP OAuth pending — don't steer a rebase
     if (!this.enabled(s)) return null;
     if (s.autopilotPaused || s.autopilotComplete) return null; // handed back / terminal
     if (this.pending.has(s.id)) return null; // a classify (onDone/onBlock) is mid-flight — don't race it

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,8 @@ import { BuildQueueReminderService } from "./build-queue-reminder";
 import { HerdDigestService } from "./herd-digest";
 import { readSnapshot, isStalled, DEFAULT_STALL } from "./stall";
 import { jsonlPathFor } from "./usage";
+import { detectPendingAuthUrl } from "./auth-url";
+import { readTranscriptTail } from "./activity";
 import { verifyApiKey } from "./verify-key";
 import { releaseHeldTasks } from "./held-release";
 import { snapshotSessionUsage } from "./usage-snapshot";
@@ -1406,6 +1408,20 @@ const autopilot = new AutopilotService({
     const live = matchAgent(s, herdr.list());
     return live ? tailLines(herdr.read(live.terminalId, "visible")) : [];
   },
+  // Pending MCP OAuth authorize URL (freshness-gated, swap-account-aware transcript read). An
+  // OAuth flow is human-only, so autopilot stands down until the operator completes it. Fresh
+  // read (not off an event) so onDone/consider re-checks are deterministic. Guarded → null.
+  pendingAuthUrl: (id) => {
+    const s = store.get(id);
+    if (!s?.claudeSessionId) return null;
+    try {
+      return detectPendingAuthUrl(
+        readTranscriptTail(jsonlPathFor(s.worktreePath, s.claudeSessionId, s.spawnAccountDir)),
+      );
+    } catch {
+      return null;
+    }
+  },
   // Any PR (open/merged/closed) stands autopilot down — only a session with NO PR yet is its
   // territory. `state` is "none" when no PR exists; anything else means one does.
   hasPr: (id) => {
@@ -1502,6 +1518,13 @@ events.subscribe((event, data) => {
   if (event !== "session:block") return;
   const { id, block } = data as { id: string; block: import("./blocked").BlockReason | null };
   void autopilot.onBlock(id, block).catch((err) => console.warn("[autopilot] onBlock:", err));
+});
+
+// Drop autopilot's per-session tracking (incl. the MCP-OAuth stand-down set) when a session is
+// archived, so its maps don't leak — mirrors the poller's pruneInactive.
+events.subscribe((event, data) => {
+  if (event !== "session:archived") return;
+  autopilot.forget((data as { id: string }).id);
 });
 
 // Self-draining work queue (#222): when an auto session's PR merges, archive it and

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -18,7 +18,8 @@ import { DEFAULT_STALL } from "./stall";
 import { jsonlPathFor } from "./usage";
 import { readTranscriptSignals, STRIP_WINDOW_MS, type SessionActivity } from "./activity-signal";
 import { readTranscriptTail } from "./activity";
-import { detectAuthUrl } from "./auth-url";
+import { detectAuthUrl, detectPendingAuthUrl } from "./auth-url";
+import { statSync } from "node:fs";
 import { classifyHalt, assistantSideText } from "./usage-halt";
 import type { UsageLimits } from "./usage-limits";
 import { maintenance } from "./maintenance";
@@ -28,6 +29,7 @@ import { config } from "./config";
 import { SessionLiveness, type LivenessOutcome, type TranscriptSignals } from "./session-liveness";
 
 const STALL_SIG = "stall"; // fixed signature → a stall fires once per episode
+const AUTH_SIG = "auth"; // fixed signature → a resting MCP-auth block fires once per episode
 const QUOTA_SIG = "quota"; // fixed signature → a quota block fires once per episode
 
 /**
@@ -101,10 +103,46 @@ function readAuthUrl(s: Session): string | null {
   }
 }
 
+/** Transcript mtime for the resting-auth probe (default `authMtime` seam). Missing/unreadable
+ *  transcript (or no claude session yet) ⇒ null. Used to gate the (bounded) resting read to
+ *  ticks where the transcript actually changed. */
+function readRestingAuthMtime(s: Session): number | null {
+  if (!s.claudeSessionId) return null;
+  try {
+    return statSync(jsonlPathFor(s.worktreePath, s.claudeSessionId, s.spawnAccountDir)).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+/** Single bounded tail read → freshness-gated auth URL + context tail (default `detectRestingAuth`
+ *  seam). One read serves both the URL and the block's tail lines. */
+function readRestingAuth(s: Session): { url: string | null; tail: string[] } {
+  if (!s.claudeSessionId) return { url: null, tail: [] };
+  try {
+    const raw = readTranscriptTail(
+      jsonlPathFor(s.worktreePath, s.claudeSessionId, s.spawnAccountDir),
+    );
+    return { url: detectPendingAuthUrl(raw), tail: tailLines(assistantSideText(raw)) };
+  } catch {
+    return { url: null, tail: [] };
+  }
+}
+
 export class StatusPoller {
   /** Fire-and-forget re-drive of a herdr-restored account pane (wired to service.reDriveAccount in
    *  index.ts). Left undefined in tests that don't exercise it. */
   reDrive?: (id: string) => void;
+
+  /**
+   * Resting-session (done/idle) MCP-auth detection seams, public + assignable (mirrors `reDrive`)
+   * so tests can drive the mtime/URL sequence deterministically without touching disk:
+   *  - `authMtime`: the transcript's current mtime — a change gates the bounded read below.
+   *  - `detectRestingAuth`: one bounded tail read → freshness-gated URL + context tail.
+   * Production leaves the real-file defaults.
+   */
+  authMtime: (s: Session) => number | null = readRestingAuthMtime;
+  detectRestingAuth: (s: Session) => { url: string | null; tail: string[] } = readRestingAuth;
 
   private timer: ReturnType<typeof setInterval> | null = null;
   private lastReadAt = new Map<string, number>();
@@ -113,6 +151,9 @@ export class StatusPoller {
    *  bootstrap via `blockSnapshot()`. Maintained by `emitBlock`; blocks are otherwise
    *  edge-emitted and would be absent on a fresh page load / push-then-open. */
   private lastBlockReason = new Map<string, BlockReason>();
+  /** Transcript mtime at the last resting-auth probe per session — gates `maybeAuthAtRest`'s
+   *  bounded read to ticks where the transcript actually changed (see AUTH_SIG). */
+  private lastAuthMtime = new Map<string, number | null>();
   private lastProbeAt = new Map<string, number>();
   private lastActivitySig = new Map<string, string>();
   private lastActivity = new Map<string, SessionActivity>();
@@ -610,6 +651,7 @@ export class StatusPoller {
     const tracked = new Set([
       ...this.lastSig.keys(),
       ...this.lastReadAt.keys(),
+      ...this.lastAuthMtime.keys(),
       ...this.lastProbeAt.keys(),
       ...this.lastActivitySig.keys(),
       ...this.lastActivity.keys(),
@@ -627,6 +669,7 @@ export class StatusPoller {
       if (!activeIds.has(id)) {
         this.lastReadAt.delete(id);
         this.lastSig.delete(id);
+        this.lastAuthMtime.delete(id);
         this.lastBlockReason.delete(id);
         this.lastProbeAt.delete(id);
         this.lastActivitySig.delete(id);
@@ -1069,9 +1112,40 @@ export class StatusPoller {
         this.lastSig.set(s.id, QUOTA_SIG);
         this.emitBlock(s.id, reason);
       }
-    } else {
+    } else if (!this.maybeAuthAtRest(s)) {
       this.clearBlock(s.id);
     }
+  }
+
+  /**
+   * A resting (done/idle) session can be sitting on an MCP OAuth prompt: the agent printed an
+   * `…/authorize?…` URL and ended its turn, so herdr reports `done`/`idle` (never `blocked`) and
+   * the normal `maybeClassify` auth-detection path never runs. Surface it as an `awaiting-input`
+   * block carrying `authUrl` so the banner + attention-lens row appear (feat #1436).
+   *
+   * Returns true when an auth block stands (freshly emitted or preserved) so `maybeQuota` skips
+   * its `clearBlock`. Bounded + throttled: the (512 KB) tail read fires only when the transcript
+   * mtime CHANGED since the last probe — a static parked transcript costs one `stat`, no read.
+   *
+   *  - transcript unchanged ⇒ preserve whatever stands (no read);
+   *  - a fresh read with a pending URL ⇒ emit once (AUTH_SIG) and hold;
+   *  - a fresh read with NO URL ⇒ return false so the caller clears (self-clears AT REST when the
+   *    operator's paste appends a record and bumps mtime — no `running` transition required);
+   *  - a first-tick miss (URL not flushed yet) does NOT latch: the next append re-probes.
+   */
+  private maybeAuthAtRest(s: Session): boolean {
+    const id = s.id;
+    const standing = this.lastSig.get(id) === AUTH_SIG;
+    const mtime = this.authMtime(s);
+    if (this.lastAuthMtime.has(id) && mtime === this.lastAuthMtime.get(id)) return standing;
+    this.lastAuthMtime.set(id, mtime);
+    const { url, tail } = this.detectRestingAuth(s);
+    if (!url) return false;
+    if (!standing) {
+      this.lastSig.set(id, AUTH_SIG);
+      this.emitBlock(id, { shape: "awaiting-input", options: [], tail, authUrl: url });
+    }
+    return true;
   }
 
   /**

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -88,6 +88,8 @@ function harness(opts: {
   repoMode?: "forge" | "lightweight";
   openPr?: boolean;
   paneAlive?: boolean;
+  /** Pending MCP OAuth authorize URL returned by the pendingAuthUrl dep (default null = none). */
+  pendingAuthUrl?: string | null;
   /** Optional deferSteer dep (SessionService.shouldDeferSteer); omit to test the optional-dep
    *  default (undefined → today's paneAlive-only behavior). */
   deferSteer?: (id: string) => boolean;
@@ -171,6 +173,7 @@ function harness(opts: {
     paneAlive: () => opts.paneAlive ?? true,
     deferSteer: opts.deferSteer,
     readTail: () => ["finished, nothing else"],
+    pendingAuthUrl: () => opts.pendingAuthUrl ?? null,
     hasPr: () => opts.openPr ?? false,
     hasDiff: async () => opts.hasDiff ?? true,
     openLocalPr: async (id) => {
@@ -609,6 +612,7 @@ test("re-entrant onBlock during an in-flight classify spawns + steers only once"
     resume: () => true,
     paneAlive: () => true,
     readTail: () => [],
+    pendingAuthUrl: () => null,
     hasPr: () => false,
     hasDiff: async () => true,
     openLocalPr: async () => {},
@@ -1447,4 +1451,71 @@ test("rebase: tick skips a running session (don't interrupt active work)", async
   });
   await h.svc.tick();
   expect(h.events.some((e) => e.steer === REBASE_STEER_MAIN)).toBe(false);
+});
+
+// ── MCP OAuth stand-down (human-only auth prompt) ───────────────────────────────────────
+// An awaiting-input block carrying an authUrl is a human-only OAuth flow autopilot cannot
+// complete, so it must stand down on every steer path and recover once the operator resumes.
+const AUTH_URL_SD = "https://mcp.sentry.dev/oauth/authorize?response_type=code&client_id=x";
+const authBlock = (): BlockReason => ({
+  shape: "awaiting-input",
+  options: [],
+  tail: ["Open this URL in your browser"],
+  authUrl: AUTH_URL_SD,
+});
+
+test("onBlock with an authUrl stands autopilot down — no steer, no classify", async () => {
+  const h = harness({ session: sess(), verdict: { kind: "gate", summary: "start?" } });
+  await h.svc.onBlock("s1", authBlock());
+  expect(h.events.some((e) => "steer" in e)).toBe(false);
+  expect(h.classifyCount()).toBe(0);
+});
+
+test("a later non-auth block clears the auth stand-down and steers normally", async () => {
+  const h = harness({ session: sess(), verdict: { kind: "gate", summary: "start?" } });
+  await h.svc.onBlock("s1", authBlock()); // stand down
+  expect(h.events.some((e) => "steer" in e)).toBe(false);
+  await h.svc.onBlock("s1", block()); // null authUrl → clears, considers → gate → steer
+  expect(h.events).toContainEqual({ steer: PROCEED_STEER });
+});
+
+test("onDone stands down on a pending auth URL — before classify, no complete/pause", async () => {
+  const h = harness({
+    session: sess({ status: "done" }),
+    verdict: { kind: "finished", summary: "done" },
+    pendingAuthUrl: AUTH_URL_SD,
+  });
+  await h.svc.onDone("s1");
+  expect(h.classifyCount()).toBe(0);
+  expect(h.events.some((e) => "steer" in e || "complete" in e || "pause" in e)).toBe(false);
+});
+
+test("post-classify re-check blocks a terminal verdict when the auth URL flushes during classify", async () => {
+  // The block has no authUrl (onBlock's pre-guard clears any stand-down) so consider() runs
+  // classify; the URL is present by the time it resolves (pendingAuthUrl set), so the
+  // post-classify re-check must stand down BEFORE dispatch — classify ran but nothing steered.
+  const h = harness({
+    session: sess(),
+    verdict: { kind: "finished", summary: "done" },
+    pendingAuthUrl: AUTH_URL_SD,
+  });
+  await h.svc.onBlock("s1", block());
+  expect(h.classifyCount()).toBe(1);
+  expect(h.events.some((e) => "steer" in e || "complete" in e)).toBe(false);
+});
+
+test("reEngageCi respects the auth stand-down; onStatus(running) clears it", () => {
+  const h = harness({
+    session: sess({ status: "done" }),
+    repoEnabled: true,
+    fullAuto: true,
+    prGit: git(), // open + failing CI
+    pendingAuthUrl: null, // set authPending via the authUrl block below, not the dep
+  });
+  void h.svc.onBlock("s1", authBlock()); // sets the stand-down (add is synchronous)
+  h.svc.tick();
+  expect(h.events.some((e) => "steer" in e)).toBe(false); // reEngageCi stood down
+  h.svc.onStatus("s1", "running"); // operator resumed → clears the stand-down
+  h.svc.tick();
+  expect(h.events).toContainEqual({ steer: CI_FIX_STEER });
 });

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -2900,3 +2900,96 @@ test("blockSnapshot drops the auth URL when the session resumes", async () => {
   await flush();
   expect(h.poller.blockSnapshot()[h.id]).toBeUndefined();
 });
+
+// ── Resting-session (done/idle) MCP-auth detection (feat #1436 gap fix) ──────────────────
+// An MCP OAuth prompt ends the agent's turn → herdr reports `done`, never `blocked`, so the
+// normal maybeClassify path never runs. maybeAuthAtRest surfaces it via the injectable
+// authMtime/detectRestingAuth seams (driven here without touching disk).
+function doneAuthHarness() {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  const blocks: { id: string; block: unknown }[] = [];
+  const herdr = {
+    list: (): HerdrAgent[] => [
+      {
+        agent: "claude",
+        agentStatus: "done",
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        name: "",
+        terminalId: "term_a",
+        workspaceId: "w",
+      },
+    ],
+    read: () => "",
+    readAsync: () => Promise.resolve(""),
+  };
+  let clock = 100_000;
+  const poller = new StatusPoller(
+    store,
+    herdr as any,
+    () => {},
+    (id, block) => blocks.push({ id, block }),
+    1000,
+    3000,
+    classifyBlocked,
+    () => clock,
+  );
+  return { store, id: s.id, blocks, poller, advance: (ms: number) => (clock += ms) };
+}
+
+test("emits an awaiting-input auth block for a done session with a fresh pending URL", () => {
+  const h = doneAuthHarness();
+  let authCalls = 0;
+  h.poller.authMtime = () => 100; // stable mtime
+  h.poller.detectRestingAuth = () => {
+    authCalls++;
+    return { url: AUTH_URL, tail: ["Open this URL in your browser"] };
+  };
+  h.poller.tick();
+  expect(h.blocks).toHaveLength(1);
+  expect((h.blocks[0]!.block as any).shape).toBe("awaiting-input");
+  expect((h.blocks[0]!.block as any).authUrl).toBe(AUTH_URL);
+  expect(h.poller.blockSnapshot()[h.id]?.authUrl).toBe(AUTH_URL);
+  expect(authCalls).toBe(1);
+  // unchanged mtime → no re-read, no re-emit (the standing block is preserved)
+  h.advance(5000);
+  h.poller.tick();
+  expect(authCalls).toBe(1);
+  expect(h.blocks).toHaveLength(1);
+});
+
+test("does not latch on a first-tick miss — re-probes when the transcript grows (flush race)", () => {
+  const h = doneAuthHarness();
+  let mtime = 100;
+  let url: string | null = null; // URL not flushed to the transcript yet
+  h.poller.authMtime = () => mtime;
+  h.poller.detectRestingAuth = () => ({ url, tail: [] });
+  h.poller.tick();
+  expect(h.blocks).toHaveLength(0); // nothing emitted, no suppression latched
+  mtime = 200; // transcript appended → mtime bumps
+  url = AUTH_URL; // the authorize URL is now present
+  h.advance(5000);
+  h.poller.tick();
+  expect(h.blocks).toHaveLength(1);
+  expect((h.blocks[0]!.block as any).authUrl).toBe(AUTH_URL);
+});
+
+test("clears the auth block at rest when the URL is answered (mtime bump, no running edge)", () => {
+  const h = doneAuthHarness();
+  let mtime = 100;
+  let url: string | null = AUTH_URL;
+  h.poller.authMtime = () => mtime;
+  h.poller.detectRestingAuth = () => ({ url, tail: [] });
+  h.poller.tick();
+  expect(h.blocks).toHaveLength(1);
+  // operator pastes the callback → transcript changes and detectPendingAuthUrl clears
+  mtime = 200;
+  url = null;
+  h.advance(5000);
+  h.poller.tick();
+  expect(h.blocks).toHaveLength(2);
+  expect(h.blocks[1]!.block).toBeNull();
+  expect(h.poller.blockSnapshot()[h.id]).toBeUndefined();
+});


### PR DESCRIPTION
## Problem

The clickable MCP OAuth auth-URL banner (#1436) never appeared for the reported case (screenshot: a `check-sentry` session relaying a Sentry `…/authorize?…` URL), even after #1438 fixed the swap-account transcript path.

**Root cause (verified end-to-end against the real session):** an MCP OAuth prompt *ends the agent's turn*, so herdr reports the session `done` (never `blocked`). But auth-URL detection (`detectAuth`) runs **only** on the `blocked`-classification path (`maybeClassify`). A `done`/`idle` session routes to `maybeQuota`, which never runs detection, so `authUrl` was never attached and no block/banner emitted. #1438 (transcript path) was necessary but not sufficient — detection was gated behind a path these turns never hit.

## Fix

Detect the pending auth URL for **resting** (done/idle) sessions too and route it through the existing block plumbing as an `awaiting-input` block carrying `authUrl` — surfacing both the banner and the attention-lens row. **No UI changes** (the banner already renders purely on `authUrl`).

- **`maybeAuthAtRest`** (poller): mtime-gated — one bounded, swap-account-aware transcript read per change, not per tick. Self-clears at rest when the operator responds (transcript append bumps mtime → re-probe → `detectPendingAuthUrl` returns null → `clearBlock`); a first-tick flush-race miss does **not** latch.
- **`detectPendingAuthUrl`**: a generous tail-position freshness gate that suppresses a stale URL buried past the 512 KB tail window while surfacing genuine prompts. Biased toward surfacing — a false-suppress *is* the reported bug (unrecoverable); a false-surface is bounded (autopilot clears on resume/archive).
- **Autopilot stands down** on a pending auth URL (an OAuth flow is human-only — it cannot paste the callback) across **every** steer path: `onBlock` (before the STEERABLE guard so a null block clears), `onDone` pre-check, a **post-classify re-check** (catches a URL unflushed at the done edge → never `markComplete`s a mid-OAuth session), `eligible()`, and inside `reEngageCi`/`rebaseCandidate` (which bypass `eligible()` and can fire on a session that already has an open PR). Recovers on `onStatus(running)` and `forget` (archive).

## Testing

- `detectPendingAuthUrl` returns the URL for the **real captured `check-sentry` tail** (regression fixture) + synthetic freshness cases (last-record ✓, `>K` records after ✗, operator-clear ✗).
- Poller (seam-driven, no disk via injectable `authMtime`/`detectRestingAuth`): resting emit, flush-race re-probe, clear-at-rest on mtime bump, no re-read when unchanged.
- Autopilot: no steer/classify on an authUrl block; `onDone` stands down before classify; post-classify re-check blocks a terminal verdict; `reEngageCi` respects the stand-down and `onStatus(running)` clears it.
- `bunx tsc --noEmit`, `bun run lint`, `bun test ./test` (6043 pass, 0 fail) all green. No UI changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)