### PR TITLE
fix(automation): full-screen touch sheet + close button for repo automation panel

### DIFF
--- a/ui/src/lib/components/AutomationPanel.svelte
+++ b/ui/src/lib/components/AutomationPanel.svelte
@@ -8,6 +8,7 @@
     sessionId,
     planPhase = null,
     drain = null,
+    onClose,
   }: {
     repoPath: string;
     sessionId: string;
@@ -15,6 +16,11 @@
     /** Live drain status for this repo; passed from GitRail via the store.
      *  When drain.epicParent is set, label-drain is suspended by the active epic. */
     drain?: DrainStatus | null;
+    /** Closes the panel (flips GitRail's showAutomation flag). Desktop still
+     *  dismisses via click-outside/Escape, like every other non-modal popover
+     *  here; the touch full-screen sheet has no "outside" left to tap, so it
+     *  needs this explicit close button wired to the same state. */
+    onClose: () => void;
   } = $props();
 
   // The popover is anchored to its trigger (top: 100% on the rail wrapper), so a
@@ -33,7 +39,7 @@
     const el = popEl;
     if (!el) return;
     const clamp = () => {
-      // Touch layouts render the panel as a centered fixed modal sheet (see the
+      // Touch layouts render the panel as a full-screen fixed sheet (see the
       // pointer:coarse block in the stylesheet), where the anchor-relative height math
       // below is meaningless and the inline max-height would override the CSS.
       // Hand max-height back to the stylesheet and never flip on touch.
@@ -79,7 +85,7 @@
     };
   });
 
-  // On touch the panel becomes a centered fixed modal sheet over a dimming scrim
+  // On touch the panel becomes a full-screen fixed sheet over a dimming scrim
   // (see the pointer:coarse block in the stylesheet). Give it the same dialog
   // semantics as the sibling findings sheet (.review-pop) so keyboard/AT users get
   // parity: aria-modal, initial focus, a Tab focus-trap, and focus restoration.
@@ -141,7 +147,17 @@
   bind:this={popEl}
   onkeydown={trapTab}
 >
-  <AutomationSettings {repoPath} {sessionId} {planPhase} {drain} armCoachmarks={true} />
+  <!-- Close affordance: only visible in the touch full-screen sheet (CSS-gated
+       below) — the desktop popover has no room/need for it, since it dismisses
+       via click-outside/Escape. -->
+  <div class="auto-pop-head">
+    <button type="button" class="auto-close" onclick={onClose} aria-label={m.common_close()}>
+      ✕
+    </button>
+  </div>
+  <div class="auto-pop-body">
+    <AutomationSettings {repoPath} {sessionId} {planPhase} {drain} armCoachmarks={true} />
+  </div>
 </div>
 
 <style>
@@ -169,6 +185,12 @@
        actually available below the anchored top edge. */
     max-height: 85vh;
     overflow-y: auto;
+    /* overflow-y alone leaves overflow-x computed as "auto" too (per the CSS
+       overflow spec, visible + non-visible on the other axis isn't renderable),
+       so a row a hair wider than the box — a fixed-width select, a long
+       nowrap label — made the ENTIRE panel horizontally pannable instead of
+       just clipping. Pin it shut; .auto-pop-body takes over scrolling on touch. */
+    overflow-x: hidden;
   }
   /* anchor too close to the viewport bottom → open upward instead */
   .auto-pop.flip-up {
@@ -177,25 +199,67 @@
     margin-top: 0;
     margin-bottom: 4px;
   }
+  /* Hidden on desktop: the anchored popover dismisses via click-outside/Escape,
+     like every other non-modal popover here, so it doesn't need its own head.
+     Shown only in the touch full-screen sheet below, where there's no
+     "outside" left to tap once the sheet covers the viewport. */
+  .auto-pop-head {
+    display: none;
+    align-items: center;
+    justify-content: flex-end;
+    flex-shrink: 0;
+  }
+  .auto-close {
+    min-width: 40px;
+    min-height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: 0;
+    color: var(--color-muted);
+    font-size: var(--fs-base);
+    cursor: pointer;
+  }
+  .auto-close:hover {
+    color: var(--color-amber);
+  }
   /* Touch layouts (phones + unfolded folds): the strip goes position:static, so
      this absolute popover hangs below the 44px strip and — anchored right:8px and
-     narrower than the page — could be panned partly off-screen. Override into a
-     centered fixed modal sheet over the .auto-scrim backdrop (rendered by GitRail),
-     wider than the desktop popover and impossible to pan. Mirrors .review-pop.
-     The JS height-clamp bails on coarse pointers, leaving max-height to this rule. */
+     narrower than the page — could be panned partly off-screen. A centered card
+     still left the rest of the app visible around its edges with no way to
+     dismiss it short of guessing where "outside" was, so go fully edge-to-edge
+     instead — matching every other mobile modal in the app (Settings, WhatsNew)
+     — with an explicit close button since there's no backdrop sliver left to
+     tap. .auto-scrim (rendered by GitRail) still dims what's behind while this
+     mounts. The JS height-clamp bails on coarse pointers, so height is CSS-only
+     here. */
   @media (pointer: coarse) {
     .auto-pop {
       position: fixed;
-      top: 50%;
-      left: 50%;
-      right: auto;
-      bottom: auto;
-      transform: translate(-50%, -50%);
+      inset: 0;
       margin: 0;
-      width: min(480px, 92vw);
+      width: auto;
       max-width: none;
-      max-height: 85vh;
+      height: 100dvh;
+      max-height: none;
+      border: 0;
+      border-radius: 0;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
       z-index: 51;
+    }
+    .auto-pop-head {
+      display: flex;
+      padding: max(8px, env(safe-area-inset-top)) max(8px, env(safe-area-inset-right)) 0 8px;
+    }
+    .auto-pop-body {
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow-y: auto;
+      overflow-x: hidden;
+      padding-bottom: env(safe-area-inset-bottom);
     }
   }
 </style>

--- a/ui/src/lib/components/GitRail.browser.test.ts
+++ b/ui/src/lib/components/GitRail.browser.test.ts
@@ -1620,3 +1620,100 @@ describe("GitRail — post-merge decommission offer", () => {
     expect(ondecommission, "ondecommission never invoked").not.toHaveBeenCalled();
   });
 });
+
+describe("GitRail — automation panel close affordance + overflow fix", () => {
+  // AutomationPanel additionally gates a full-screen-sheet layout on the REAL
+  // `@media (pointer: coarse)` query, which this headless mouse-driven runner has
+  // no way to force true (mocking `window.matchMedia` only fools JS reads of it —
+  // the browser's own CSS engine still resolves the stylesheet's `@media` block
+  // against the actual hardware pointer). So this suite covers what's verifiable
+  // here: the `.auto-close` button's JS wiring (mocking matchMedia to flip the
+  // component's `touch` state, which drives aria-modal/focus-trap/dialog
+  // semantics), and the pointer-independent overflow-x fix. The `@media
+  // (pointer: coarse)` visual layout itself mirrors `.review-pop`'s already-shipped
+  // touch sheet in this same file, verified only by manual/device testing.
+  let matchMediaSpy: ReturnType<typeof vi.spyOn> | undefined;
+  function mockPointer(coarse: boolean) {
+    const real = window.matchMedia.bind(window);
+    matchMediaSpy = vi.spyOn(window, "matchMedia").mockImplementation((query: string) => {
+      if (query === "(pointer: coarse)") {
+        return {
+          matches: coarse,
+          media: query,
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          addListener: () => {},
+          removeListener: () => {},
+          dispatchEvent: () => false,
+          onchange: null,
+        } as unknown as MediaQueryList;
+      }
+      return real(query);
+    });
+  }
+  afterEach(() => {
+    matchMediaSpy?.mockRestore();
+  });
+
+  async function openAutomation(h: HTMLElement) {
+    const pill = h.querySelector<HTMLButtonElement>("button.auto-pill");
+    expect(pill, "auto-pill present").not.toBeNull();
+    pill!.click();
+    const dialog = await vi.waitFor(() => {
+      const d = h.querySelector<HTMLElement>(".auto-pop");
+      expect(d, "automation panel opened").not.toBeNull();
+      return d!;
+    });
+    return { pill: pill!, dialog };
+  }
+
+  it("clips horizontal overflow instead of letting the whole panel be dragged sideways", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(600, 900);
+    const h = host(600);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await expect.element(screen.getByTitle("PR #12345")).toBeVisible();
+
+    const { dialog } = await openAutomation(h);
+    // Regression: `overflow-y: auto` alone left `overflow-x` computed as "auto"
+    // too (per the CSS overflow spec — visible on one axis + non-visible on the
+    // other isn't renderable), so a row a hair wider than the box made the WHOLE
+    // panel horizontally pannable instead of just clipping.
+    expect(getComputedStyle(dialog).overflowX, "overflow-x pinned to hidden").toBe("hidden");
+  });
+
+  it("close button's click handler dismisses the panel (touch dialog semantics)", async () => {
+    mockPointer(true);
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(390, 844);
+    const h = host(390);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: true } });
+    await expect.element(screen.getByTitle("PR #12345")).toBeVisible();
+
+    const { dialog } = await openAutomation(h);
+    expect(dialog.getAttribute("aria-modal"), "touch dialog is modal").toBe("true");
+    const closeBtn = dialog.querySelector<HTMLButtonElement>(
+      `button[aria-label="${m.common_close()}"]`,
+    );
+    expect(closeBtn, "close button present").not.toBeNull();
+    closeBtn!.click();
+    await vi.waitFor(() => {
+      expect(h.querySelector(".auto-pop"), "panel closed").toBeNull();
+    });
+  });
+
+  it("desktop (fine pointer) keeps the non-modal anchored popover, close head hidden", async () => {
+    mockPointer(false);
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(1024, 800);
+    const h = host(600);
+    const screen = render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    await expect.element(screen.getByTitle("PR #12345")).toBeVisible();
+
+    const { dialog } = await openAutomation(h);
+    expect(dialog.getAttribute("aria-modal"), "desktop popover stays non-modal").toBeNull();
+    const head = dialog.querySelector<HTMLElement>(".auto-pop-head");
+    expect(head, "head element present in DOM").not.toBeNull();
+    expect(getComputedStyle(head!).display, "close-button head hidden on desktop").toBe("none");
+  });
+});

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -711,7 +711,13 @@
     {/if}
 
     {#if showAutomation}
-      <AutomationPanel {repoPath} {sessionId} {planPhase} {drain} />
+      <AutomationPanel
+        {repoPath}
+        {sessionId}
+        {planPhase}
+        {drain}
+        onClose={() => (showAutomation = false)}
+      />
     {/if}
 
     {#if armedEntry}


### PR DESCRIPTION
## Summary

On iPhone the repo-automation popover (⚙ pill on the git rail) felt broken: it rendered as a small floating card over the app instead of a real dialog, you could drag it left/right (dragging the whole panel, not just scrolling), and there was no close (✕) button anywhere — the only way out was tapping blindly outside it.

Root causes:
- `AutomationPanel.svelte`'s `.auto-pop` set `overflow-y: auto` without `overflow-x`. Per the CSS overflow spec, that makes the browser compute `overflow-x` as `auto` too — so any row a hair wider than the box (a fixed-width `<select>`, a `white-space: nowrap` label) made the *entire panel* horizontally pannable instead of just clipping.
- The touch/mobile variant was a centered floating card with no header and no close control — unlike every other mobile modal in the app (Settings, WhatsNew, `.review-pop` in the same file), which all use a pinned header + ✕ button and go edge-to-edge on small screens.

## Changes

- `AutomationPanel.svelte`: pin `overflow-x: hidden` on `.auto-pop` (fixes the drag bug on both desktop and touch). On touch (`pointer: coarse`), the panel now renders as a true full-screen sheet (`inset: 0`, safe-area-aware padding) with a pinned header containing a ✕ close button, mirroring `.review-pop`'s established pattern. Desktop keeps the existing small anchored, non-modal popover unchanged (no scrim, dismiss via click-outside/Escape, per the design-system exemption for non-blocking popovers).
- `GitRail.svelte`: wires the new `onClose` prop to `showAutomation = false`.
- `GitRail.browser.test.ts`: adds a regression test proving `overflow-x` computes to `hidden` (verified it reproduces `"auto"` without the fix), a close-button dismiss test, and a test confirming the desktop popover stays non-modal with the new head hidden.

## Test plan

- [x] `cd ui && bun run check` — 0 errors
- [x] `cd ui && bun run test:node` — 1938 passed
- [x] `cd ui && bun run test:browser -- --run src/lib/components/GitRail.browser.test.ts` — 64 passed (incl. 3 new tests)
- [x] Manually reverted the `overflow-x: hidden` fix and confirmed the new regression test fails (`overflow-x` resolves to `auto`), then restored it