### PR TITLE
fix(ui): land on the epic reliably when its badge is clicked

### DIFF
--- a/ui/src/lib/components/IssuesPanel.browser.test.ts
+++ b/ui/src/lib/components/IssuesPanel.browser.test.ts
@@ -183,6 +183,41 @@ describe("IssuesPanel epic badge", () => {
     expect(badge!.textContent?.trim()).toBe(expectedText);
   });
 
+  it("prefers the live epic's authoritative count over a stale markdown summary", async () => {
+    // The list summary is markdown-first and goes stale after an epic is restructured
+    // (e.g. badge "0/6"); the live/native record is authoritative ("3/6"). When a live
+    // record exists, the collapsed badge must show ITS count, not the stale summary's.
+    seed([issue(60, "Epic parent")], [epic(60, 0, 6, "markdown")]); // stale summary → 0/6
+    const live: Epic = {
+      repoPath: "/repo",
+      parentIssueNumber: 60,
+      parentTitle: "Epic 60",
+      source: "native",
+      children: (["merged", "merged", "merged", "running", "running", "running"] as const).map(
+        (state, i) => ({
+          number: 200 + i,
+          title: `Child ${200 + i}`,
+          url: `https://example.com/i/${200 + i}`,
+          order: i,
+          body: "",
+          blockedBy: [],
+          state,
+          sessionId: null,
+          prNumber: null,
+          issueClosed: state === "merged",
+          claimed: false,
+        }),
+      ),
+      warnings: [],
+      run: { repoPath: "/repo", parentIssueNumber: 60, mode: "auto", status: "idle" },
+    };
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop, epics: { "/repo#60": live } });
+
+    // The badge shows the live 3/6, never the stale summary 0/6.
+    await expect.element(page.getByText(m.epic_badge({ merged: 3, total: 6 }))).toBeInTheDocument();
+    expect(document.body.textContent).not.toContain(m.epic_badge({ merged: 0, total: 6 }));
+  });
+
   it("disables the +Task button on an epic-parent row, enables it on a normal one", async () => {
     seed([issue(30, "Epic parent"), issue(31, "Plain issue")], [epic(30, 1, 2, "markdown")]);
     render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
@@ -349,6 +384,107 @@ describe("IssuesPanel expandEpic", () => {
     // Badge stays collapsed; no targeted fetch.
     expect(document.querySelector(".epic-badge")?.getAttribute("aria-expanded")).toBe("false");
     expect(mockEpic).not.toHaveBeenCalled();
+  });
+
+  it("waits for getEpics to settle before scrolling, then lands on the sorted-first row", async () => {
+    // Race guard: listIssues and getEpics resolve independently. The scroll must NOT fire
+    // on the raw issue list (target still un-pinned, mid-list) — it must wait until
+    // getEpics settles so sortEpicsFirst has floated the epic to visibleIssues[0], then
+    // scroll THERE. Pin the shared filter singleton (a prior test may have left it dirty)
+    // so both issues stay visible and 327 sorts first deterministically; viewer=null also
+    // makes hideOthers fail open.
+    const prev = {
+      others: issuesFilter.hideOthers,
+      active: issuesFilter.hideActive,
+      sub: issuesFilter.hideSubIssues,
+    };
+    issuesFilter.set(false);
+    issuesFilter.setActive(false);
+    issuesFilter.setSubIssues(false);
+
+    const scrollCalls: { id: string; firstRowId: string | undefined }[] = [];
+    const origScroll = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = function (this: Element) {
+      scrollCalls.push({ id: this.id, firstRowId: document.querySelector(".issue-row")?.id });
+    };
+
+    let resolveIssues!: (r: Awaited<ReturnType<typeof listIssues>>) => void;
+    let resolveEpics!: (r: Awaited<ReturnType<typeof getEpics>>) => void;
+    mockIssues.mockReturnValue(new Promise((res) => (resolveIssues = res)));
+    mockEpics.mockReturnValue(new Promise((res) => (resolveEpics = res)));
+    mockEpic.mockResolvedValue(epic(327));
+
+    try {
+      render(IssuesPanel, { repoPath: "/repo", onnewtask: noop, expandEpic: 327 });
+
+      // Issues arrive FIRST, target NOT at position 0, epics still pending.
+      resolveIssues({
+        slug: "acme/repo",
+        webUrl: null,
+        issues: [issue(400), issue(327)],
+        viewer: null,
+      });
+      await expect.poll(() => document.querySelectorAll(".issue-row").length).toBe(2);
+      // getEpics has not settled → epicsSettled false → NO scroll yet (the bug scrolled here).
+      expect(scrollCalls.length).toBe(0);
+
+      // Epics settle: sortEpicsFirst pins 327 to the top and the scroll is released.
+      resolveEpics({ epics: [summary(327)], subIssues: [] });
+      await expect.poll(() => scrollCalls.length).toBe(1);
+      // It scrolled the TARGET row, which is now the first row in the DOM (visibleIssues[0]).
+      expect(scrollCalls[0].id).toBe("epic-issue-row-327");
+      expect(scrollCalls[0].firstRowId).toBe("epic-issue-row-327");
+    } finally {
+      Element.prototype.scrollIntoView = origScroll;
+      issuesFilter.set(prev.others);
+      issuesFilter.setActive(prev.active);
+      issuesFilter.setSubIssues(prev.sub);
+    }
+  });
+
+  it("lands on a target epic even when the mine & unassigned filter would hide it", async () => {
+    // hideOthers ON + the epic assigned to someone else would drop its row — but an
+    // explicit EPIC-badge navigation must force it back in AND scroll to it.
+    const prev = {
+      others: issuesFilter.hideOthers,
+      active: issuesFilter.hideActive,
+      sub: issuesFilter.hideSubIssues,
+    };
+    issuesFilter.set(true); // hideOthers ON — the case under test
+    issuesFilter.setActive(false);
+    issuesFilter.setSubIssues(false);
+
+    const scrolled: string[] = [];
+    const origScroll = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = function (this: Element) {
+      scrolled.push(this.id);
+    };
+
+    // 327 (target) is assigned to another user → hideOthers would filter it out.
+    const target: Issue = { ...issue(327), assignees: ["someone-else"] };
+    const mine: Issue = { ...issue(400), assignees: ["me"] };
+    mockIssues.mockResolvedValue({
+      slug: "acme/repo",
+      webUrl: null,
+      issues: [mine, target],
+      viewer: "me",
+    });
+    mockEpics.mockResolvedValue({ epics: [summary(327)], subIssues: [] });
+    mockEpic.mockResolvedValue(epic(327));
+
+    try {
+      render(IssuesPanel, { repoPath: "/repo", onnewtask: noop, expandEpic: 327 });
+
+      // The filtered-out epic row is force-included…
+      await expect.poll(() => document.getElementById("epic-issue-row-327")).toBeTruthy();
+      // …and the scroll actually fires on it (not just that the row renders).
+      await expect.poll(() => scrolled).toContain("epic-issue-row-327");
+    } finally {
+      Element.prototype.scrollIntoView = origScroll;
+      issuesFilter.set(prev.others);
+      issuesFilter.setActive(prev.active);
+      issuesFilter.setSubIssues(prev.sub);
+    }
   });
 });
 

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -68,6 +68,14 @@
   let epicByNumber = $state<Map<number, EpicSummary>>(new Map());
   let nativeSubIssues = $state<Set<number>>(new Set());
   let epicsLoaded = $state(false);
+  // True once a getEpics attempt for this repo has SETTLED (success or failure), so the
+  // epic-first sort is final. Gates the targeted expand-scroll below: scrolling before
+  // the sort settles would center the epic at a provisional (un-pinned) position that the
+  // re-sort then yanks away, stranding the viewport among unrelated issues. Reset (→false)
+  // ONLY on repo change; set (→true) in EVERY getEpics settle (mount + softRefresh, then +
+  // catch, inside the rp/ticket guard) so a backlogRefresh bump that supersedes the mount
+  // fetch mid-navigation still flips it via the winning fetch — never latched false.
+  let epicsSettled = $state(false);
   // Compose the assignee filter (#824) → "hide in progress" filter → sub-issue filter → text filter.
   // The mine chip only shows when `viewer` is known, so hideOthers is a no-op
   // identity otherwise (fail open); hideActive is viewer-agnostic.
@@ -89,7 +97,20 @@
   );
   // Epic parents float to the top of the backlog (stable within each group), so
   // epics are the first thing the operator sees. Applied after text filtering.
-  let visibleIssues = $derived(sortEpicsFirst(filterIssues(subFiltered, filter), epicParentNums));
+  //
+  // Force-include the navigated-to epic (expandEpic): an explicit "go to this epic" must
+  // always land on it, even when a toggle filter (hideOthers / hideActive / hideSubIssues)
+  // would drop its parent row. Deduped — only re-added when it actually fell out of
+  // subFiltered — so the {#each} key and the epic-issue-row-<n> DOM id stay unique. Added
+  // BEFORE filterIssues so the TEXT search still applies (at navigation time `filter` is
+  // "" from the repo-change reset); sortEpicsFirst then pins it to the top once epics settle.
+  let visibleIssues = $derived.by(() => {
+    const base =
+      expandEpic != null && !subFiltered.some((i) => i.number === expandEpic)
+        ? [...issues.filter((i) => i.number === expandEpic), ...subFiltered]
+        : subFiltered;
+    return sortEpicsFirst(filterIssues(base, filter), epicParentNums);
+  });
   // True when there ARE open issues but the assignee filter hid them all — drives
   // the distinct "all assigned to others" empty state (vs the text no-match state).
   let allHiddenByAssignee = $derived(
@@ -134,6 +155,7 @@
     epicByNumber = new Map();
     nativeSubIssues = new Set();
     epicsLoaded = false;
+    epicsSettled = false;
     fetched.clear();
     epicFetchSeq.clear();
     epicFetchPending.clear();
@@ -163,9 +185,13 @@
         epicByNumber = new Map(r.epics.map((s) => [s.parentIssueNumber, s]));
         nativeSubIssues = new Set(r.subIssues);
         epicsLoaded = true;
+        epicsSettled = true;
       })
       .catch(() => {
-        /* leave empty — epics are an enhancement, not blocking */
+        // Epics are an enhancement, not blocking — but the sort is now final (empty),
+        // so mark settled (guarded like the success path) to release the epic-scroll.
+        if (rp !== repoPath || epicsTicket !== epicsSeq) return;
+        epicsSettled = true;
       });
   });
 
@@ -228,8 +254,15 @@
         epicByNumber = new Map(r.epics.map((s) => [s.parentIssueNumber, s]));
         nativeSubIssues = new Set(r.subIssues);
         epicsLoaded = true;
+        // Also flip epicsSettled here (never reset it in softRefresh): if a bump
+        // supersedes the still-in-flight mount getEpics during epic-badge navigation,
+        // THIS ticket-winning fetch is what releases the epic-scroll.
+        epicsSettled = true;
       })
-      .catch(() => {});
+      .catch(() => {
+        if (rp !== repoPath || epicsTicket !== epicsSeq) return;
+        epicsSettled = true;
+      });
     // One-shot epic cache: drop what's no longer on screen, then refresh every
     // EXPANDED panel the live store doesn't cover (store-backed panels are refreshed
     // by +page's resync re-pull; idle/pruned epics exist only in `fetched`). Iterating
@@ -351,8 +384,13 @@
       appliedExpand = target;
       if (!expanded.has(target)) expandEpicRow(target);
     }
-    // Scroll once the targeted row is actually rendered (its issue is loaded).
-    if (target !== scrolledTo && issues.some((i) => i.number === target)) {
+    // Scroll once the epic list has SETTLED into its final sorted order (epicsSettled)
+    // AND the targeted row is actually rendered. Keying off `visibleIssues` (the sorted,
+    // force-included, rendered list) — not raw `issues` — is what makes this land on the
+    // epic's final top position instead of a provisional pre-sort spot; gating on
+    // `epicsSettled` closes the listIssues-vs-getEpics race that would otherwise fire the
+    // one-shot scroll before sortEpicsFirst pins the epic to the top.
+    if (target !== scrolledTo && epicsSettled && visibleIssues.some((i) => i.number === target)) {
       scrolledTo = target;
       tick().then(() => {
         const el = document.getElementById(`epic-issue-row-${target}`);
@@ -387,14 +425,19 @@
         />
         <IssueFilterPopover showMine={viewer != null} coachTargets />
       </div>
-      {#if allHiddenByAssignee}
-        <div class="muted">{m.issues_filter_all_assigned_to_others()}</div>
-      {:else if allHiddenByActive}
-        <div class="muted">{m.issues_filter_all_in_progress()}</div>
-      {:else if allHiddenBySubIssues}
-        <div class="muted">{m.issues_filter_all_sub_issues()}</div>
-      {:else if visibleIssues.length === 0}
-        <div class="muted">{m.issuespanel_no_match()}</div>
+      <!-- Only surface an empty-state reason when the rendered list is truly empty: a
+           force-included navigated-to epic (Fix B) keeps visibleIssues non-empty, so a
+           "hidden by filter" message must not sit above the one epic row we deliberately show. -->
+      {#if visibleIssues.length === 0}
+        {#if allHiddenByAssignee}
+          <div class="muted">{m.issues_filter_all_assigned_to_others()}</div>
+        {:else if allHiddenByActive}
+          <div class="muted">{m.issues_filter_all_in_progress()}</div>
+        {:else if allHiddenBySubIssues}
+          <div class="muted">{m.issues_filter_all_sub_issues()}</div>
+        {:else}
+          <div class="muted">{m.issuespanel_no_match()}</div>
+        {/if}
       {/if}
       {#each visibleIssues as issue (issue.number)}
         {@const isExpanded = expanded.has(issue.number)}
@@ -402,7 +445,7 @@
           {issue}
           epicSummary={epicByNumber.get(issue.number)}
           {isExpanded}
-          epic={isExpanded ? epicFor(issue.number) : undefined}
+          epic={epicFor(issue.number)}
           {repoPath}
           {bodyPreview}
           {age}

--- a/ui/src/lib/components/issues-panel/IssueRow.svelte
+++ b/ui/src/lib/components/issues-panel/IssueRow.svelte
@@ -5,6 +5,7 @@
   import { relativeAge } from "$lib/format";
   import { clock } from "$lib/now.svelte";
   import { ACTIVE_LABEL } from "../issues-panel";
+  import { progress } from "../epic-panel";
   import EpicPanel from "../EpicPanel.svelte";
 
   // One backlog issue row, extracted from IssuesPanel so the panel template clears the
@@ -46,6 +47,18 @@
   // Epic-parent rows disable quick-launch + Task: an epic is launched via the epic
   // panel's Start, not by spawning a manual session against the parent tracking issue.
   const isEpicParent = $derived(!!epicSummary);
+
+  // Badge count: prefer the live/fetched Epic's authoritative (native-first) child counts
+  // over the list summary, which is markdown-first and can go stale after an epic is
+  // restructured (e.g. badge "0/6" while the real state is "3/6"). Mirrors EpicBadge.svelte.
+  // Falls back to the summary when no live record exists (idle epic), then to zero.
+  const counts = $derived(
+    epic
+      ? progress(epic.children)
+      : epicSummary
+        ? { merged: epicSummary.merged, total: epicSummary.total }
+        : { merged: 0, total: 0 },
+  );
 </script>
 
 <div class="issue-row" class:is-epic={isEpicParent} id={`epic-issue-row-${issue.number}`}>
@@ -82,8 +95,8 @@
             : m.epic_badge_expand_aria({ parent: issue.number })}
         onclick={() => ontoggleepic(issue.number)}
         >{isNative
-          ? m.subissues_badge({ merged: epicSummary.merged, total: epicSummary.total })
-          : m.epic_badge({ merged: epicSummary.merged, total: epicSummary.total })}</button
+          ? m.subissues_badge({ merged: counts.merged, total: counts.total })
+          : m.epic_badge({ merged: counts.merged, total: counts.total })}</button
       >
     {/if}
   </div>


### PR DESCRIPTION
## Problem

Clicking an **EPIC badge** (fleet-view group header, integrated-epics band, rundown) opens the backlog Issues tab, but the viewport frequently lands **among unrelated issues instead of on the epic** — intermittently, so it "sometimes works". On top of that, the collapsed EPIC badge in the issues list could show a **stale count** (e.g. `0/6`) while the expanded panel and the fleet badge showed the real `3/6`.

## Root cause

`IssuesPanel` loads issues (`listIssues`) and epic summaries (`getEpics`) as **two independent, racing fetches**. The one-shot scroll fired as soon as the raw `issues` list arrived — *before* `sortEpicsFirst` (driven by `getEpics`) floated the epic to the top. So it centered the epic at its provisional mid-list position; the re-sort then moved the epic to the top, but the latched scroll never re-corrected, stranding the viewport over other issues.

The stale count is the documented markdown-vs-native divergence: the list badge is markdown-first (`summarizeEpicCandidate`), which goes stale after an epic is restructured, while the panel/fleet badge use the native-first authoritative live record.

## Fix (all in `IssuesPanel` / `IssueRow`, one central `expandEpic` path)

- **Reliable landing** — gate the targeted scroll on a new `epicsSettled` flag and key it off the sorted, rendered `visibleIssues` (not raw `issues`), so it lands on the epic's final top position. `epicsSettled` is set in **every** `getEpics` settle (mount + `softRefresh`, `then` + `catch`, inside the `rp`/ticket guard) and reset only on repo change — so a `backlogRefresh` bump that supersedes the in-flight mount fetch mid-navigation still releases the scroll via the winning fetch.
- **Always land, even when a filter would hide the epic** — force-include the navigated-to epic in `visibleIssues` (deduped, so the `{#each}` key / DOM id stay unique) so an active toggle filter (mine & unassigned / hide in progress / hide sub-issues) can't hide the target. The text search is still respected. The "hidden by filter" empty-state message is suppressed when the epic row is force-shown.
- **Correct status count** — the issues-list badge now prefers the live/native epic's child counts over the markdown-first summary (mirrors `EpicBadge.svelte`), so a restructured epic shows its authoritative status.

`epicsSettled`-set and force-include (the first two bullets) are coupled and ship together: neither alone yields "always land, at the right place".

## Tests (`IssuesPanel.browser.test.ts`)

- **Race:** with deferred fetches resolving `listIssues` *before* `getEpics`, asserts `scrollIntoView` does **not** fire until `getEpics` settles, then fires once on `epic-issue-row-<target>` as the first `.issue-row` in the DOM (`visibleIssues[0]`).
- **Filter:** with `hideOthers` on and the epic assigned to someone else, asserts the row is force-rendered **and** the scroll actually fires on it.
- **Count:** with a stale summary `0/6` vs a live epic `3/6`, asserts the badge shows `3/6`.

Existing `expandEpic`/badge tests stay green. `cd ui && bun run check`, `bun run check:i18n`, and the full `bun run test` (209 files / 2854 tests) all pass. No new user-facing strings (bugfix; existing messages reused).
