### PR TITLE
docs(readme): repo is public — retitle external-testers section, drop private-repo workarounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,15 +133,15 @@ before running it. Read the script first:
 | `SHEPHERD_SRC`        | _(none)_          | Install from a local tarball or directory instead of cloning (used by the onboarding harness) |
 | `SHEPHERD_NO_SERVICE` | _(none)_          | Skip the systemd unit step (set automatically on macOS)                                       |
 
-### Private repo & external testers
+### External testers
 
-Shepherd's GitHub repo is private, so the `curl|bash` one-liner above does **not** work for someone
-without repo access — both the raw `install.sh` URL and the `git clone` it performs need
-authentication. Three ways to get an external tester running:
+Shepherd's GitHub repo is public, so the `curl|bash` one-liner above works for an external tester
+directly — both the raw `install.sh` URL and the `git clone` it performs are anonymous, needing no
+token and no collaborator grant. Point testers at that one-liner; the rest of this section covers two
+special cases where it doesn't fit.
 
-**Air-gapped tarball (no GitHub access needed).** The installer can land the source from a local
-tarball via `SHEPHERD_SRC` instead of cloning — the fastest way to hand the code to a first tester
-with nothing to grant:
+**Air-gapped tarball (no GitHub access at all).** For a fully offline machine, the installer can land
+the source from a local tarball via `SHEPHERD_SRC` instead of cloning — nothing to reach GitHub for:
 
 ```bash
 # maintainer — build a source tarball from the current checkout:
@@ -156,43 +156,28 @@ SHEPHERD_SRC=~/shepherd.tar.gz bash deploy/install.sh
 `git archive` ships tracked files only; that's sufficient, since the installer runs `bun install`
 and builds from source. Trade-off: no in-place updates — each new build is a fresh tarball.
 
-**Release tarball (self-serve, versioned).** Every merge of the release-please PR cuts a tagged
-GitHub release, and GitHub auto-generates a source tarball for each tag — so there's nothing to
-`git archive` or upload. The tester downloads the tag they want and feeds it to `SHEPHERD_SRC`. This
-is a **private** repo, so the download needs a token — but a **fine-grained, read-only PAT scoped to
-just this repo** is enough (no collaborator membership; revocable):
+**Pinned version (self-serve, versioned).** Every merge of the release-please PR cuts a tagged
+GitHub release, and GitHub auto-generates a source tarball for each tag. Since the repo is public,
+the source archive downloads anonymously — no token — and the tester feeds it to `SHEPHERD_SRC`:
 
 ```bash
-# tester — with `gh auth login` done, fetch the source archive for a tag:
-gh release download v1.4.0 --archive=tar.gz -R erwins-enkel/shepherd   # → shepherd-1.4.0.tar.gz
+# tester — anonymous, no auth: fetch the source archive for a tag straight from codeload:
+curl -fL https://github.com/erwins-enkel/shepherd/archive/refs/tags/v1.41.0.tar.gz \
+  -o shepherd-1.41.0.tar.gz
 
-# …or with a bare PAT, straight from the API (302s to a signed codeload URL):
-curl -fL -H "Authorization: Bearer $GH_TOKEN" \
-  https://api.github.com/repos/erwins-enkel/shepherd/tarball/v1.4.0 -o shepherd-1.4.0.tar.gz
+# …or, if you already have `gh auth login` done, the gh CLI is a convenience:
+gh release download v1.41.0 --archive=tar.gz -R erwins-enkel/shepherd   # → shepherd-1.41.0.tar.gz
 
 # GitHub archives nest everything under a top-level dir — strip it and install from
 # the extracted directory (SHEPHERD_SRC accepts a directory as well as a tarball):
-mkdir -p ~/shepherd-src && tar -xzf shepherd-1.4.0.tar.gz --strip-components=1 -C ~/shepherd-src
+mkdir -p ~/shepherd-src && tar -xzf shepherd-1.41.0.tar.gz --strip-components=1 -C ~/shepherd-src
 SHEPHERD_SRC=~/shepherd-src bash ~/shepherd-src/deploy/install.sh
 ```
 
-Note there is **no anonymous URL** for private-repo archives or release assets — the token is
-unavoidable, but a scoped read-only PAT is far less than write access. Testers self-serve any
-tagged version and re-download to update.
-
-**Repo collaborator (sustainable, allows updates).** Grant read access, then the tester
-authenticates once and clones directly (the public one-liner still won't work — the raw URL is
-private), running the local script:
-
-```bash
-gh auth login                                      # or a read-only PAT in the git credential helper
-gh repo clone erwins-enkel/shepherd ~/.shepherd/app
-bash ~/.shepherd/app/deploy/install.sh
-```
-
-This keeps them on `main` with `update.sh` / `git pull` for ongoing updates. Either way, full
-support is Linux + systemd (see the [OS matrix](#os-matrix) above) — put testers on Linux to
-exercise the real sandbox membrane.
+Testers self-serve any tagged version and re-download to update. For ongoing updates on `main`
+instead, the anonymous `curl|bash` one-liner above installs a clone that `update.sh` / `git pull`
+keeps current. Either way, full support is Linux + systemd (see the [OS matrix](#os-matrix) above) —
+put testers on Linux to exercise the real sandbox membrane.
 
 ### Finish setup
 


### PR DESCRIPTION
## What

Shepherd's GitHub repo went public several days ago (`gh repo view` → `PUBLIC`; anonymous `archive/refs/heads/main.tar.gz` → HTTP 200), but the README's **"Private repo & external testers"** section still asserted the repo is private and routed testers through a token and a collaborator grant that are no longer needed.

## Changes (`README.md` only)

- **Retitle** `### Private repo & external testers` → `### External testers`.
- **New opening** states the anonymous `curl|bash` **Install** one-liner above now works for external testers directly (no token, no collaborator grant), and frames the rest of the section as two remaining special cases.
- **Kept** the two visibility-independent paths:
  - Air-gapped `SHEPHERD_SRC` tarball (unchanged — the offline / onboarding-harness path).
  - Pinned-version release download, **de-tokenized**: leads with the genuinely-anonymous codeload URL `…/archive/refs/tags/v1.41.0.tar.gz` (verified 200 unauthenticated); `gh release download` demoted to a convenience for testers who already have `gh auth login` (since `gh` needs an authenticated session even on a public repo). Stale example tag `v1.4.0` → `v1.41.0` (current latest).
- **Removed** the "Repo collaborator" subsection and the "no anonymous URL for private-repo archives" note — both existed only for the private-repo case; public clone + `update.sh`/`git pull` covers the update story.

**Left untouched (verified not stale):** L376 "never enter the public repo" (confirms public), the "source-available, not open source" license statement, and the unrelated "Fork a repo" contribution note.

## Verification

- `prettier --check README.md` → clean; lint-staged prettier ran on commit.
- No `#quick-start` link introduced in the tester install path (that anchor is the separate from-source dev flow); `#os-matrix` still resolves.
- No product code touched — no i18n / feature-catalog / glossary gates apply (`[no-feature-entry]`: docs-only).
- Pre-push passed (branch hygiene, i18n parity, feature catalog, fallow audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)