### PR TITLE
feat(ui): mic button on the New Task prompt (#1433)

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2573,5 +2573,14 @@
   "restart_err_already": "Ein Neustart läuft bereits.",
   "restart_err_generic": "Der Neustart konnte nicht gestartet werden. Starte bei anhaltenden Problemen manuell neu:",
   "feat_restart_shepherd_title": "Shepherd direkt aus der UI neu starten",
-  "feat_restart_shepherd_body": "Einstellungen → Session hat jetzt eine „Shepherd neu starten“-Aktion, und die Plugin-Restart-Banner haben einen „Jetzt neu starten“-Button — kein Kopieren des systemctl-Befehls mehr. Optional startet auch der herdr-Daemon neu, und zwar sanft: Live-Panes werden per Handoff übergeben und überleben."
+  "feat_restart_shepherd_body": "Einstellungen → Session hat jetzt eine „Shepherd neu starten“-Aktion, und die Plugin-Restart-Banner haben einen „Jetzt neu starten“-Button — kein Kopieren des systemctl-Befehls mehr. Optional startet auch der herdr-Daemon neu, und zwar sanft: Live-Panes werden per Handoff übergeben und überleben.",
+  "micbtn_dictate": "◉",
+  "micbtn_dictate_aria": "Diktieren",
+  "micbtn_dictate_stop_aria": "Diktat beenden",
+  "micbtn_transcribing": "Wird transkribiert…",
+  "micbtn_transcribe_failed": "Transkription fehlgeschlagen – bitte erneut versuchen.",
+  "micbtn_origin_local": "🎙️ Lokales Whisper",
+  "micbtn_origin_web": "Browser/Gerät",
+  "feat_newtask_prompt_mic_title": "Den New-Task-Prompt diktieren",
+  "feat_newtask_prompt_mic_body": "Das Prompt-Feld im New-Task-Dialog hat jetzt ein Mikrofon — mit denselben Engines wie die Compose-Leiste: der Diktierfunktion des Browsers oder lokalem Whisper über das voice-whisper-Plugin (das einzige Mikrofon in einer iOS-Homescreen-PWA). Während du sprichst, erscheint eine Live-Vorschau im Feld; beim Stoppen ersetzt das genaue Transkript des vollständigen Clips die Vorschau."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2573,5 +2573,14 @@
   "restart_err_already": "A restart is already in progress.",
   "restart_err_generic": "Could not start the restart. Restart manually if the problem persists:",
   "feat_restart_shepherd_title": "Restart Shepherd from the UI",
-  "feat_restart_shepherd_body": "Settings → Session now has a Restart Shepherd action, and the plugin restart banners gained a Restart-now button — no more copy-pasting the systemctl command. Optionally the herdr daemon restarts too, gracefully: live panes are handed off and survive."
+  "feat_restart_shepherd_body": "Settings → Session now has a Restart Shepherd action, and the plugin restart banners gained a Restart-now button — no more copy-pasting the systemctl command. Optionally the herdr daemon restarts too, gracefully: live panes are handed off and survive.",
+  "micbtn_dictate": "◉",
+  "micbtn_dictate_aria": "Dictate",
+  "micbtn_dictate_stop_aria": "Stop dictation",
+  "micbtn_transcribing": "Transcribing…",
+  "micbtn_transcribe_failed": "Couldn't transcribe that — try again.",
+  "micbtn_origin_local": "🎙️ Local Whisper",
+  "micbtn_origin_web": "Browser / device",
+  "feat_newtask_prompt_mic_title": "Dictate the New Task prompt",
+  "feat_newtask_prompt_mic_body": "The New Task prompt field now has a mic — same engines as the compose bar: the browser's dictation, or local Whisper via the voice-whisper plugin (the only mic in an iOS home-screen PWA). While you speak, a live preview renders in the field; on stop the accurate full-clip transcript replaces it."
 }

--- a/ui/src/lib/api.transcribeAudio.test.ts
+++ b/ui/src/lib/api.transcribeAudio.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { transcribeAudio } from "./api";
+
+function captureFetch(status: number, body: unknown): { forms: FormData[] } {
+  const forms: FormData[] = [];
+  globalThis.fetch = vi.fn(async (_url: unknown, init?: { body?: FormData }) => {
+    if (init?.body instanceof FormData) forms.push(init.body);
+    return new Response(JSON.stringify(body), { status });
+  }) as unknown as typeof fetch;
+  return { forms };
+}
+
+const clip = new Blob(["riff"], { type: "audio/wav" });
+
+describe("transcribeAudio", () => {
+  it("appends mode=partial for interim preview requests", async () => {
+    const { forms } = captureFetch(200, { text: "hello" });
+    await expect(transcribeAudio(clip, "en", { mode: "partial" })).resolves.toBe("hello");
+    expect(forms[0]!.get("mode")).toBe("partial");
+    expect(forms[0]!.get("lang")).toBe("en");
+  });
+
+  it("sends NO mode field for the final clip — the plugin treats absent mode as final", async () => {
+    const { forms } = captureFetch(200, { text: "final text" });
+    await expect(transcribeAudio(clip, "de")).resolves.toBe("final text");
+    expect(forms[0]!.get("mode")).toBeNull();
+    expect(forms[0]!.get("lang")).toBe("de");
+  });
+
+  it("omits lang when not supplied", async () => {
+    const { forms } = captureFetch(200, { text: "x" });
+    await transcribeAudio(clip);
+    expect(forms[0]!.get("lang")).toBeNull();
+    expect(forms[0]!.get("mode")).toBeNull();
+  });
+
+  it("throws on a non-ok response (e.g. a 429 shed)", async () => {
+    captureFetch(429, { error: "busy" });
+    await expect(transcribeAudio(clip, "en", { mode: "partial" })).rejects.toThrow();
+  });
+});

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -333,11 +333,19 @@ export function getVoiceStatus(): Promise<VoiceStatus> {
 }
 
 /** Transcribe a recorded audio clip via the voice-whisper plugin; returns the text. `lang`
- *  (`"de"`/`"en"`) pins the transcription language when the plugin isn't configured to force one. */
-export async function transcribeAudio(blob: Blob, lang?: string): Promise<string> {
+ *  (`"de"`/`"en"`) pins the transcription language when the plugin isn't configured to force one.
+ *  `opts.mode: "partial"` marks a disposable live-preview request — the plugin reserves a
+ *  concurrency slot for non-partial (final) clips so previews can never 429-starve the one
+ *  transcription the user actually keeps. The final clip must send no `mode` at all. */
+export async function transcribeAudio(
+  blob: Blob,
+  lang?: string,
+  opts?: { mode?: "partial" },
+): Promise<string> {
   const fd = new FormData();
   fd.append("file", blob, "clip.webm");
   if (lang) fd.append("lang", lang);
+  if (opts?.mode) fd.append("mode", opts.mode);
   // no content-type header: the browser sets the multipart boundary
   const r = await fetch("/api/plugins/voice-whisper/transcribe", { method: "POST", body: fd });
   if (!r.ok) throw await failed(r, "transcribe");

--- a/ui/src/lib/components/ComposeBar.browser.test.ts
+++ b/ui/src/lib/components/ComposeBar.browser.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import { getCommands, getVoiceStatus, transcribeAudio } from "$lib/api";
+import { m } from "$lib/paraglide/messages";
+
+// Mock the API so the compose sheet renders deterministically with no network. Mocking
+// getVoiceStatus/transcribeAudio also lets the tests prove that a discarded recording is
+// NEVER uploaded (the teardown guarantee).
+vi.mock("$lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/api")>();
+  return {
+    ...actual,
+    getCommands: vi.fn(),
+    getVoiceStatus: vi.fn(),
+    transcribeAudio: vi.fn(),
+  };
+});
+
+const { default: ComposeBar } = await import("./ComposeBar.svelte");
+
+const mockGetCommands = vi.mocked(getCommands);
+const mockGetVoiceStatus = vi.mocked(getVoiceStatus);
+const mockTranscribeAudio = vi.mocked(transcribeAudio);
+
+// Deterministic Web Speech stand-in. The dictation controller looks up
+// window.SpeechRecognition ?? window.webkitSpeechRecognition at creation time, so installing
+// this on window.SpeechRecognition before render() makes it the engine (it wins the ??
+// even though Chromium ships webkitSpeechRecognition).
+interface FakeResultChunk {
+  transcript: string;
+  isFinal: boolean;
+}
+class FakeRecognition {
+  static instances: FakeRecognition[] = [];
+  lang = "";
+  interimResults = false;
+  continuous = false;
+  onresult: ((e: unknown) => void) | null = null;
+  onend: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  started = 0;
+  stopped = 0;
+  constructor() {
+    FakeRecognition.instances.push(this);
+  }
+  start() {
+    this.started++;
+  }
+  stop() {
+    this.stopped++;
+    this.onend?.();
+  }
+  /** Fire onresult with the shape the controller consumes: results[i][0].transcript + isFinal. */
+  emit(chunks: FakeResultChunk[]) {
+    this.onresult?.({
+      resultIndex: 0,
+      results: chunks.map((c) =>
+        Object.assign([{ transcript: c.transcript }], { isFinal: c.isFinal }),
+      ),
+    });
+  }
+}
+
+type SpeechWindow = Window & { SpeechRecognition?: unknown; webkitSpeechRecognition?: unknown };
+const w = window as SpeechWindow;
+const originalWebkitSpeech = w.webkitSpeechRecognition;
+
+const voiceAbsent = {
+  available: false,
+  engine: null,
+  model: null,
+  ffmpeg: false,
+  language: "auto",
+  preferLocal: false,
+  hint: "",
+};
+
+beforeEach(() => {
+  FakeRecognition.instances = [];
+  w.SpeechRecognition = FakeRecognition;
+  mockGetCommands.mockReset();
+  mockGetVoiceStatus.mockReset();
+  mockTranscribeAudio.mockReset();
+  mockGetCommands.mockResolvedValue({ commands: [] });
+  mockGetVoiceStatus.mockResolvedValue(voiceAbsent);
+  mockTranscribeAudio.mockResolvedValue("never used");
+});
+
+afterEach(() => {
+  delete w.SpeechRecognition;
+  w.webkitSpeechRecognition = originalWebkitSpeech;
+  document.body.innerHTML = "";
+});
+
+const base = (extra: Record<string, unknown> = {}) => ({
+  onsend: vi.fn(),
+  onclose: vi.fn(),
+  repoPath: "/repo",
+  ...extra,
+});
+
+const micBtn = () => page.getByRole("button", { name: m.composebar_dictate_aria() });
+const stopBtn = () => page.getByRole("button", { name: m.composebar_dictate_stop_aria() });
+const field = () => page.getByRole("textbox", { name: m.composebar_input_aria() });
+
+describe("ComposeBar dictation (shared controller wiring)", () => {
+  it("shows the mic when Web Speech is available; a tap starts recognition", async () => {
+    render(ComposeBar, base());
+    await expect.element(micBtn()).toBeVisible();
+    await micBtn().click();
+    expect(FakeRecognition.instances).toHaveLength(1);
+    expect(FakeRecognition.instances[0]!.started).toBe(1);
+    // While listening the button reads as the stop control and is pressed.
+    await expect.element(stopBtn()).toBeVisible();
+    await expect.element(stopBtn()).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("renders no mic when neither engine is available", async () => {
+    delete w.SpeechRecognition;
+    delete w.webkitSpeechRecognition;
+    render(ComposeBar, base());
+    // Send is always there; once it is visible the sheet has settled without a mic.
+    await expect
+      .element(page.getByRole("button", { name: m.composebar_send_aria() }))
+      .toBeVisible();
+    expect(micBtn().query()).toBeNull();
+  });
+
+  it("writes interim and final results into the field with the join rule", async () => {
+    render(ComposeBar, base());
+    await field().fill("typed first");
+    await micBtn().click();
+    const rec = FakeRecognition.instances[0]!;
+    rec.emit([{ transcript: " hello world", isFinal: false }]);
+    // interim renders after the pre-typed base…
+    await expect.element(field()).toHaveValue("typed first hello world");
+    // …and a final chunk replaces the interim with the settled text.
+    rec.emit([{ transcript: " hello world.", isFinal: true }]);
+    await expect.element(field()).toHaveValue("typed first hello world.");
+  });
+
+  it("startDictation auto-starts the web engine on mount", async () => {
+    render(ComposeBar, base({ startDictation: true }));
+    await expect.element(stopBtn()).toBeVisible();
+    expect(FakeRecognition.instances).toHaveLength(1);
+    expect(FakeRecognition.instances[0]!.started).toBe(1);
+  });
+
+  it("Send mid-recording stops recognition, sends the field text, uploads nothing", async () => {
+    const onsend = vi.fn();
+    render(ComposeBar, base({ onsend }));
+    await micBtn().click();
+    const rec = FakeRecognition.instances[0]!;
+    rec.emit([{ transcript: "take this", isFinal: false }]);
+    await expect.element(field()).toHaveValue("take this");
+    await page.getByRole("button", { name: m.composebar_send_aria() }).click();
+    expect(rec.stopped).toBeGreaterThan(0);
+    expect(onsend).toHaveBeenCalledWith("take this");
+    expect(mockTranscribeAudio).not.toHaveBeenCalled();
+  });
+
+  it("cancel (✕) mid-recording stops recognition and uploads nothing", async () => {
+    const onclose = vi.fn();
+    render(ComposeBar, base({ onclose }));
+    await micBtn().click();
+    const rec = FakeRecognition.instances[0]!;
+    // The ✕ acts on pointerdown (so it never blurs the soft keyboard); Playwright's click
+    // refuses it because the autogrown textarea's hit-area overlaps — dispatch the event
+    // the handler actually listens for.
+    const closeEl = page.getByRole("button", { name: m.common_close() }).query()!;
+    closeEl.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, cancelable: true }));
+    expect(rec.stopped).toBeGreaterThan(0);
+    expect(onclose).toHaveBeenCalled();
+    expect(mockTranscribeAudio).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/lib/components/ComposeBar.svelte
+++ b/ui/src/lib/components/ComposeBar.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
   import { onDestroy, onMount } from "svelte";
   import { m } from "$lib/paraglide/messages";
-  import { getLocale } from "$lib/i18n";
   import { insertNewlineAt } from "$lib/compose";
-  import { getCommands, getVoiceStatus, transcribeAudio } from "$lib/api";
-  import { pcmChunksToWavBlob } from "$lib/wav";
+  import { getCommands } from "$lib/api";
+  import { createDictation } from "$lib/dictation.svelte";
   import { matchSlashTrigger, filterCommands, applyCommandPick } from "$lib/slash";
   import type { SlashCommand } from "$lib/types";
   import SlashCommandMenu from "./SlashCommandMenu.svelte";
@@ -146,369 +145,14 @@
     applySteer(text);
   }
 
-  // In-browser dictation via the Web Speech API (Chrome/Android, Safari/iOS).
-  // This is NOT the iOS keyboard's native dictation mic — no web API can summon
-  // that — but it's the standards-based equivalent: transcribes straight into
-  // this field. Known gap: WebKit doesn't expose it inside an iOS home-screen
-  // PWA (standalone display mode), only in the Safari browser tab. When
-  // unsupported the in-overlay mic toggle hides itself and the overlay is a
-  // plain type-and-send sheet — so the entry point never becomes a dead end.
-
-  // Minimal SpeechRecognition interface — the W3C Web Speech API types are not
-  // yet in TypeScript's built-in lib.dom.d.ts (only the event/result sub-types
-  // are), so we declare the constructor/instance shape we actually consume.
-  interface SpeechRecognitionInstance {
-    lang: string;
-    interimResults: boolean;
-    continuous: boolean;
-    onresult: ((e: SpeechRecognitionEvent) => void) | null;
-    onend: (() => void) | null;
-    onerror: (() => void) | null;
-    start(): void;
-    stop(): void;
-  }
-  interface SpeechRecognitionConstructor {
-    new (): SpeechRecognitionInstance;
-  }
-  interface SpeechWindow extends Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
-
-  const SpeechRec: SpeechRecognitionConstructor | undefined =
-    typeof window !== "undefined"
-      ? ((window as SpeechWindow).SpeechRecognition ??
-        (window as SpeechWindow).webkitSpeechRecognition)
-      : undefined;
-  let speechSupported = $state(!!SpeechRec);
-  let listening = $state(false);
-  let recog: SpeechRecognitionInstance | null = null;
-
-  // ── local Whisper voice input (the optional voice-whisper plugin) ──────────────────
-  // Server-side transcription: record with MediaRecorder, POST the clip to the plugin, insert
-  // the returned text. This is the ONLY mic in an iOS home-screen PWA (no Web Speech there).
-  // Detection is memoized once per page load; absent (404) → we keep Web Speech / hide the mic
-  // exactly as before. The backend is the optional voice-whisper plugin (issue #76):
-  // https://github.com/erwins-enkel/shepherd-plugin-voice-whisper — install it into ~/.shepherd/plugins/.
-  let localVoiceAvailable = $state(false);
-  let preferLocal = $state(false);
-  let transcribing = $state(false);
-  let voiceError = $state(false);
-  let voiceErrorTimer: ReturnType<typeof setTimeout> | null = null;
-
-  // The client must actually be able to record — MediaRecorder + getUserMedia. Without them a
-  // server-available plugin still can't be used from this browser, so treat local as unusable.
-  const recorderSupported =
-    typeof window !== "undefined" &&
-    typeof MediaRecorder !== "undefined" &&
-    !!navigator.mediaDevices?.getUserMedia;
-  const localUsable = $derived(localVoiceAvailable && recorderSupported);
-
-  // The mic shows whenever *either* engine can run; `useLocal` picks which engine a NEW tap
-  // starts — local when Web Speech is absent (iOS PWA) or the plugin asks to be preferred,
-  // else the browser's live dictation. It can flip mid-session (getVoiceStatus() resolving
-  // after an auto-started dictation), so it must NOT decide how to STOP an in-flight session.
-  const micVisible = $derived(speechSupported || localUsable);
-  const useLocal = $derived(localUsable && (!speechSupported || preferLocal));
-
-  // Which engine actually owns the live recording, fixed when it starts. tapMic stops THIS one
-  // rather than re-reading `useLocal`, so a mid-session flip never strands the active recorder.
-  let activeEngine = $state<"web" | "local" | null>(null);
-
-  // Which engine to name on the origin label: the engine that owns the live recording, or "local"
-  // during the post-recording batch transcription. `transcribing` is set on the local path only
-  // (Web Speech transcribes live and never sets it), so it unambiguously means local — this keeps
-  // the label up across BOTH the recording and the transcription phase, then clears once both are
-  // done. It names the origin of THIS recording only — never plugin health/availability.
-  const originEngine = $derived(activeEngine ?? (transcribing ? "local" : null));
-
-  let mediaRecorder: MediaRecorder | null = null;
-  let mediaStream: MediaStream | null = null;
-  let chunks: Blob[] = [];
-  let recordTimer: ReturnType<typeof setTimeout> | null = null;
-  const MAX_RECORD_MS = 60_000; // cap a single clip so a forgotten mic can't record forever
-
-  // ── live interim transcription (progressive read-along) ────────────────────────────
-  // While MediaRecorder captures the authoritative clip, we ALSO tap the SAME mic stream via
-  // Web Audio, accumulate raw PCM, and every INTERIM_MS post the growing clip — encoded as a WAV,
-  // which is valid at every prefix — to the plugin, showing the returned text live in the field.
-  // On stop the accurate full-clip transcription replaces it. This is the ONLY way to get
-  // read-along on an iOS home-screen PWA: there is no Web Speech, and an iOS MediaRecorder mp4
-  // writes its `moov` atom only on stop so it can't be transcribed mid-recording. Everything stays
-  // local (the whisper plugin runs on the host), so — unlike a Web-Speech hybrid — nothing leaves
-  // the machine. The final MediaRecorder path is untouched, so a browser without Web Audio simply
-  // gets no interim and the same batch result as before.
-  interface AudioWindow extends Window {
-    webkitAudioContext?: typeof AudioContext;
-  }
-  const AudioCtx: typeof AudioContext | undefined =
-    typeof window !== "undefined"
-      ? (window.AudioContext ?? (window as AudioWindow).webkitAudioContext)
-      : undefined;
-  const INTERIM_MS = 2500; // how often to re-transcribe the growing clip for the live preview
-  let audioCtx: AudioContext | null = null;
-  let audioSource: MediaStreamAudioSourceNode | null = null;
-  let audioProc: ScriptProcessorNode | null = null;
-  let audioSink: GainNode | null = null;
-  let pcmChunks: Float32Array[] = [];
-  let pcmRate = 0;
-  let interimTimer: ReturnType<typeof setInterval> | null = null;
-  let interimBusy = false; // one interim request in flight at a time — never stack transcriptions
-  let interimSeq = 0; // bumped to discard a stale/late interim response (incl. after stop)
-  let dictationBase = ""; // field text when recording started; interim/final render after it
-
-  function pickMimeType(): string | undefined {
-    if (typeof MediaRecorder === "undefined") return undefined;
-    for (const c of ["audio/webm;codecs=opus", "audio/webm", "audio/mp4", "audio/ogg"])
-      if (MediaRecorder.isTypeSupported(c)) return c;
-    return undefined; // let the browser choose its default container
-  }
-
-  function flashVoiceError() {
-    voiceError = true;
-    if (voiceErrorTimer) clearTimeout(voiceErrorTimer);
-    voiceErrorTimer = setTimeout(() => (voiceError = false), 4000);
-  }
-
-  // Tap the live mic stream with Web Audio and start the interim-transcription loop. Best-effort:
-  // if Web Audio is unavailable or setup throws, we bail quietly and the final clip still runs.
-  function startInterimCapture(stream: MediaStream) {
-    if (!AudioCtx) return;
-    try {
-      // Ask for 16 kHz directly so the browser resamples for us; fall back to the device rate.
-      try {
-        audioCtx = new AudioCtx({ sampleRate: 16000 });
-      } catch {
-        audioCtx = new AudioCtx();
-      }
-      void audioCtx.resume?.().catch(() => {});
-      pcmRate = audioCtx.sampleRate;
-      pcmChunks = [];
-      audioSource = audioCtx.createMediaStreamSource(stream);
-      // ScriptProcessor is deprecated in favour of AudioWorklet, but the worklet needs a separately
-      // bundled module; ScriptProcessor is the simplest path that also works in an iOS PWA. A 60 s
-      // dictation on the main thread is well within its budget.
-      audioProc = audioCtx.createScriptProcessor(4096, 1, 1);
-      audioProc.onaudioprocess = (e) => {
-        pcmChunks.push(new Float32Array(e.inputBuffer.getChannelData(0)));
-      };
-      // Route through a muted gain into the destination so the processor actually runs, without
-      // echoing the mic back to the speakers.
-      audioSink = audioCtx.createGain();
-      audioSink.gain.value = 0;
-      audioSource.connect(audioProc);
-      audioProc.connect(audioSink);
-      audioSink.connect(audioCtx.destination);
-      interimTimer = setInterval(() => void runInterim(), INTERIM_MS);
-    } catch {
-      stopInterimCapture();
-    }
-  }
-
-  // One interim tick: transcribe the clip captured so far and show it live. Guarded so only one
-  // request is ever in flight, and a stale/late response (a newer tick, or one arriving after we
-  // stopped) is discarded via the sequence number.
-  async function runInterim() {
-    if (interimBusy || transcribing || !listening) return;
-    if (pcmChunks.length === 0 || pcmRate === 0) return;
-    const blob = pcmChunksToWavBlob(pcmChunks, pcmRate);
-    interimBusy = true;
-    const seq = ++interimSeq;
-    try {
-      const text = await transcribeAudio(blob, getLocale() === "de" ? "de" : "en");
-      if (seq === interimSeq && listening && text)
-        value = dictationBase.trim() ? dictationBase.trimEnd() + " " + text.trim() : text.trim();
-      queueMicrotask(autogrow);
-    } catch {
-      // interim is best-effort — a failed/blocked tick is silently skipped; the final clip still runs
-    } finally {
-      interimBusy = false;
-    }
-  }
-
-  function stopInterimCapture() {
-    if (interimTimer) {
-      clearInterval(interimTimer);
-      interimTimer = null;
-    }
-    interimSeq++; // invalidate any in-flight interim response
-    interimBusy = false;
-    if (audioProc) audioProc.onaudioprocess = null;
-    try {
-      audioProc?.disconnect();
-      audioSource?.disconnect();
-      audioSink?.disconnect();
-    } catch {
-      /* nodes already torn down */
-    }
-    audioProc = null;
-    audioSource = null;
-    audioSink = null;
-    if (audioCtx) {
-      void audioCtx.close().catch(() => {});
-      audioCtx = null;
-    }
-    pcmChunks = [];
-    pcmRate = 0;
-  }
-
-  // Start recording. Reached two ways, both within the getUserMedia activation window: an
-  // in-sheet mic tap, or the ◉ dictate entry (startDictation) auto-starting on mount when local
-  // is the engine — getVoiceStatus is memoized/pre-resolved by then, so the auto-start runs in
-  // the same turn as the chip tap. `acquiring` guards the getUserMedia await so an auto-start
-  // and a fast manual tap can't both open a stream.
-  let acquiring = false;
-  async function startLocalRecording() {
-    if (listening || transcribing || acquiring) return;
-    if (!recorderSupported) {
-      flashVoiceError();
-      return;
-    }
-    acquiring = true;
-    voiceError = false;
-    try {
-      try {
-        mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      } catch {
-        flashVoiceError();
-        return;
-      }
-      const mimeType = pickMimeType();
-      chunks = [];
-      // MediaRecorder construction or start() can throw (unsupported mimeType, hardware in use);
-      // release the just-acquired mic stream so it isn't left open on failure.
-      try {
-        mediaRecorder = new MediaRecorder(mediaStream, mimeType ? { mimeType } : undefined);
-        mediaRecorder.ondataavailable = (e) => {
-          if (e.data.size) chunks.push(e.data);
-        };
-        mediaRecorder.onstop = () => void finishLocalRecording();
-        mediaRecorder.start();
-      } catch {
-        mediaRecorder = null;
-        releaseStream();
-        flashVoiceError();
-        return;
-      }
-      listening = true;
-      activeEngine = "local";
-      recordTimer = setTimeout(() => stopLocalRecording(), MAX_RECORD_MS);
-      // Start the live read-along preview off the same stream (best-effort; the final clip above
-      // is authoritative and runs regardless of whether interim capture succeeds).
-      dictationBase = value;
-      if (mediaStream) startInterimCapture(mediaStream);
-    } finally {
-      acquiring = false;
-    }
-  }
-
-  // User-initiated stop → let onstop fire finishLocalRecording (which uploads + inserts).
-  function stopLocalRecording() {
-    if (recordTimer) {
-      clearTimeout(recordTimer);
-      recordTimer = null;
-    }
-    if (mediaRecorder && mediaRecorder.state !== "inactive") mediaRecorder.stop();
-    listening = false;
-  }
-
-  async function finishLocalRecording() {
-    const type = mediaRecorder?.mimeType || "audio/webm";
-    stopInterimCapture();
-    releaseStream();
-    mediaRecorder = null;
-    activeEngine = null;
-    if (chunks.length === 0) return;
-    const blob = new Blob(chunks, { type });
-    chunks = [];
-    transcribing = true;
-    try {
-      const text = await transcribeAudio(blob, getLocale() === "de" ? "de" : "en");
-      // The accurate full-clip result replaces whatever the live preview last showed. On error we
-      // keep the last interim text rather than discarding what the user just dictated.
-      value = dictationBase;
-      if (text) appendTranscript(text);
-    } catch {
-      flashVoiceError();
-    } finally {
-      transcribing = false;
-    }
-  }
-
-  function releaseStream() {
-    mediaStream?.getTracks().forEach((t) => t.stop());
-    mediaStream = null;
-  }
-
-  // Tear down an in-progress recording WITHOUT uploading (dismiss/submit/destroy): drop the
-  // onstop handler first so stopping never triggers a transcription of a discarded clip.
-  function teardownRecording() {
-    if (recordTimer) {
-      clearTimeout(recordTimer);
-      recordTimer = null;
-    }
-    if (mediaRecorder) {
-      mediaRecorder.ondataavailable = null;
-      mediaRecorder.onstop = null;
-      if (mediaRecorder.state !== "inactive") {
-        try {
-          mediaRecorder.stop();
-        } catch {
-          /* already stopped */
-        }
-      }
-      mediaRecorder = null;
-    }
-    stopInterimCapture();
-    releaseStream();
-    chunks = [];
-    listening = false;
-    activeEngine = null;
-  }
-
-  // Append transcribed text after whatever is already in the field (same join rule dictation uses).
-  function appendTranscript(text: string) {
-    const t = text.trim();
-    if (!t) return;
-    value = value.trim() ? value.trimEnd() + " " + t : t;
-    queueMicrotask(autogrow);
-  }
-
-  function toggleDictation() {
-    if (!SpeechRec) return;
-    if (listening) {
-      recog?.stop();
-      return;
-    }
-    recog = new SpeechRec();
-    recog.lang = getLocale() === "de" ? "de-DE" : "en-US";
-    recog.interimResults = true;
-    recog.continuous = true;
-    let base = value; // text already typed before dictation started
-    recog.onresult = (e: SpeechRecognitionEvent) => {
-      let finalChunk = "";
-      let interim = "";
-      for (let i = e.resultIndex; i < e.results.length; i++) {
-        const t = e.results[i][0].transcript;
-        if (e.results[i].isFinal) finalChunk += t;
-        else interim += t;
-      }
-      if (finalChunk) base = (base ? base.trimEnd() + " " : "") + finalChunk.trim();
-      value = interim ? (base ? base.trimEnd() + " " : "") + interim.trim() : base;
-      queueMicrotask(autogrow);
-    };
-    recog.onend = () => {
-      listening = false;
-      activeEngine = null;
-    };
-    recog.onerror = () => {
-      listening = false;
-      activeEngine = null;
-    };
-    recog.start();
-    listening = true;
-    activeEngine = "web";
-  }
+  // Dictation (Web Speech / the local-Whisper voice plugin) lives in the shared controller —
+  // $lib/dictation.svelte.ts owns the engine pick, recording, live interim preview and
+  // teardown; this sheet just renders its state on the ◉ button and the lines below the field.
+  const dict = createDictation({
+    getText: () => value,
+    setText: (t) => (value = t),
+    onTextRendered: autogrow,
+  });
 
   // Keep the sheet centered in the *visible* viewport — i.e. the area above the
   // soft keyboard — so the field and Send button never hide behind it. The
@@ -530,29 +174,16 @@
     // still edit the transcript inline
     ta?.focus();
     autogrow();
-    // Probe for the local-Whisper plugin (memoized once per page load, so this resolves in the
-    // same turn as the tap that opened the sheet). When the ◉ dictate entry opened us and local
-    // is the engine (e.g. iOS PWA, no Web Speech), start recording now — otherwise a local-only
-    // dictate chip would open an idle sheet. The status is pre-resolved by the time the chip is
-    // tappable, so getUserMedia is still inside the tap's activation window; a denial just flashes
-    // an error and leaves the in-sheet mic. Guarded against double-starting Web Speech below.
-    getVoiceStatus()
-      .then((s) => {
-        localVoiceAvailable = s.available;
-        preferLocal = s.preferLocal;
-        if (startDictation && useLocal && !listening && !transcribing) void startLocalRecording();
-      })
-      .catch(() => {});
-    // Web Speech "open already listening" — fires synchronously so it's never delayed by the
-    // probe. On a local-only client (no Web Speech) this is a no-op and the branch above starts
-    // local instead.
-    if (startDictation && speechSupported) toggleDictation();
+    // The ◉ dictate entry opens the sheet already listening — otherwise a local-only dictate
+    // chip would open an idle sheet. The controller owns the engine pick and the probe/ready
+    // sequencing (Web Speech synchronously; local once its pre-resolved status applies, still
+    // inside the chip tap's getUserMedia activation window — a denial just flashes an error
+    // and leaves the in-sheet mic).
+    if (startDictation) dict.autoStart();
   });
 
   onDestroy(() => {
-    recog?.stop();
-    teardownRecording();
-    if (voiceErrorTimer) clearTimeout(voiceErrorTimer);
+    dict.teardown();
     window.visualViewport?.removeEventListener("resize", syncViewport);
     window.visualViewport?.removeEventListener("scroll", syncViewport);
   });
@@ -565,8 +196,7 @@
   }
 
   function submit() {
-    recog?.stop();
-    teardownRecording();
+    dict.teardown();
     slashOpen = false;
     onsend(value);
     value = "";
@@ -574,8 +204,7 @@
   }
 
   function cancel() {
-    recog?.stop();
-    teardownRecording();
+    dict.teardown();
     onclose();
   }
 
@@ -637,18 +266,9 @@
   // (which would dismiss the mobile soft keyboard), matching ControlBar.
   function tapMic(e: PointerEvent) {
     e.preventDefault();
-    if (transcribing) return;
-    // A live session is stopped by the engine that STARTED it (not the current `useLocal`,
-    // which may have flipped mid-session) — otherwise the active recorder is never stopped.
-    if (activeEngine === "local") {
-      stopLocalRecording();
-    } else if (activeEngine === "web") {
-      recog?.stop();
-    } else if (useLocal) {
-      void startLocalRecording();
-    } else {
-      toggleDictation();
-    }
+    // The controller stops a live session via the engine that STARTED it (not the current
+    // `useLocal`, which may have flipped mid-session), else starts the engine picked now.
+    dict.toggle();
   }
   function tapSend(e: PointerEvent) {
     e.preventDefault();
@@ -728,28 +348,28 @@
         {/each}
       </div>
     {/if}
-    {#if voiceError}
+    {#if dict.voiceError}
       <div class="voice-hint" role="alert">{m.composebar_transcribe_failed()}</div>
     {/if}
-    {#if originEngine}
+    {#if dict.originEngine}
       <div class="voice-origin">
-        {originEngine === "local" ? m.composebar_origin_local() : m.composebar_origin_web()}
+        {dict.originEngine === "local" ? m.composebar_origin_local() : m.composebar_origin_web()}
       </div>
     {/if}
     <div class="actions">
-      {#if micVisible}
+      {#if dict.micVisible}
         <button
           type="button"
           class="btn mic"
-          class:listening
-          class:transcribing
-          disabled={transcribing}
-          aria-label={transcribing
+          class:listening={dict.listening}
+          class:transcribing={dict.transcribing}
+          disabled={dict.transcribing}
+          aria-label={dict.transcribing
             ? m.composebar_transcribing()
-            : listening
+            : dict.listening
               ? m.composebar_dictate_stop_aria()
               : m.composebar_dictate_aria()}
-          aria-pressed={listening}
+          aria-pressed={dict.listening}
           onpointerdown={tapMic}>{m.composebar_dictate()}</button
         >
       {/if}

--- a/ui/src/lib/components/MicButton.browser.test.ts
+++ b/ui/src/lib/components/MicButton.browser.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import { getVoiceStatus, transcribeAudio } from "$lib/api";
+import { m } from "$lib/paraglide/messages";
+
+// Mock the API so engine detection is deterministic and so the tests can prove a discarded
+// recording is never uploaded.
+vi.mock("$lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/api")>();
+  return {
+    ...actual,
+    getVoiceStatus: vi.fn(),
+    transcribeAudio: vi.fn(),
+  };
+});
+
+const { default: MicButton } = await import("./MicButton.svelte");
+
+const mockGetVoiceStatus = vi.mocked(getVoiceStatus);
+const mockTranscribeAudio = vi.mocked(transcribeAudio);
+
+// Deterministic Web Speech stand-in — installed on window.SpeechRecognition so it wins the
+// controller's `SpeechRecognition ?? webkitSpeechRecognition` lookup (done at creation time).
+interface FakeResultChunk {
+  transcript: string;
+  isFinal: boolean;
+}
+class FakeRecognition {
+  static instances: FakeRecognition[] = [];
+  lang = "";
+  interimResults = false;
+  continuous = false;
+  onresult: ((e: unknown) => void) | null = null;
+  onend: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  started = 0;
+  stopped = 0;
+  constructor() {
+    FakeRecognition.instances.push(this);
+  }
+  start() {
+    this.started++;
+  }
+  stop() {
+    this.stopped++;
+    this.onend?.();
+  }
+  emit(chunks: FakeResultChunk[]) {
+    this.onresult?.({
+      resultIndex: 0,
+      results: chunks.map((c) =>
+        Object.assign([{ transcript: c.transcript }], { isFinal: c.isFinal }),
+      ),
+    });
+  }
+}
+
+type SpeechWindow = Window & { SpeechRecognition?: unknown; webkitSpeechRecognition?: unknown };
+const w = window as SpeechWindow;
+const originalWebkitSpeech = w.webkitSpeechRecognition;
+
+const voiceAbsent = {
+  available: false,
+  engine: null,
+  model: null,
+  ffmpeg: false,
+  language: "auto",
+  preferLocal: false,
+  hint: "",
+};
+
+beforeEach(() => {
+  FakeRecognition.instances = [];
+  w.SpeechRecognition = FakeRecognition;
+  // The button positions itself UPWARD from its zero-height anchor (in real usage a text
+  // field sits above it); standalone the anchor is at y=0, which would put the button above
+  // the viewport where Playwright refuses to click. Give the body headroom instead.
+  document.body.style.paddingTop = "120px";
+  mockGetVoiceStatus.mockReset();
+  mockTranscribeAudio.mockReset();
+  mockGetVoiceStatus.mockResolvedValue(voiceAbsent);
+  mockTranscribeAudio.mockResolvedValue("never used");
+});
+
+afterEach(() => {
+  delete w.SpeechRecognition;
+  w.webkitSpeechRecognition = originalWebkitSpeech;
+  document.body.style.paddingTop = "";
+  document.body.innerHTML = "";
+});
+
+function makeHost() {
+  const host = { value: "", rendered: 0 };
+  return {
+    host,
+    props: {
+      getText: () => host.value,
+      setText: (t: string) => (host.value = t),
+      onTextRendered: () => host.rendered++,
+    },
+  };
+}
+
+const micBtn = () => page.getByRole("button", { name: m.micbtn_dictate_aria() });
+const stopBtn = () => page.getByRole("button", { name: m.micbtn_dictate_stop_aria() });
+
+describe("MicButton", () => {
+  it("renders the mic when Web Speech is available; tap toggles a session", async () => {
+    const { props } = makeHost();
+    render(MicButton, props);
+    await expect.element(micBtn()).toBeVisible();
+    await micBtn().click();
+    const rec = FakeRecognition.instances[0]!;
+    expect(rec.started).toBe(1);
+    await expect.element(stopBtn()).toHaveAttribute("aria-pressed", "true");
+    // second tap stops the session that was started
+    await stopBtn().click();
+    expect(rec.stopped).toBeGreaterThan(0);
+    await expect.element(micBtn()).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("renders nothing when neither engine is available", async () => {
+    delete w.SpeechRecognition;
+    delete w.webkitSpeechRecognition;
+    const { props } = makeHost();
+    render(MicButton, props);
+    // getVoiceStatus resolved unavailable → micVisible stays false; give the probe a tick
+    await mockGetVoiceStatus.mock.results[0]?.value;
+    expect(micBtn().query()).toBeNull();
+    expect(document.querySelector(".micbtn-anchor")).toBeNull();
+  });
+
+  it("appears via the plugin engine when Web Speech is absent but the plugin is ready", async () => {
+    delete w.SpeechRecognition;
+    delete w.webkitSpeechRecognition;
+    mockGetVoiceStatus.mockResolvedValue({
+      ...voiceAbsent,
+      available: true,
+      engine: "whisper.cpp",
+      model: "ggml-small.bin",
+    });
+    const { props } = makeHost();
+    render(MicButton, props);
+    // Chromium has MediaRecorder + getUserMedia, so localUsable flips true once the
+    // (controller-owned) probe applies — the mic must appear without any tap.
+    await expect.element(micBtn()).toBeVisible();
+  });
+
+  it("writes results through setText with the join rule and defers onTextRendered", async () => {
+    const { host, props } = makeHost();
+    host.value = "typed base";
+    render(MicButton, props);
+    await micBtn().click();
+    const rec = FakeRecognition.instances[0]!;
+    const renderedBefore = host.rendered;
+    rec.emit([{ transcript: " hello", isFinal: false }]);
+    // setText is synchronous, the render callback is deferred (queueMicrotask) so an
+    // autogrow handler measures the post-flush layout.
+    expect(host.value).toBe("typed base hello");
+    expect(host.rendered).toBe(renderedBefore);
+    await Promise.resolve();
+    expect(host.rendered).toBe(renderedBefore + 1);
+    rec.emit([{ transcript: " hello there.", isFinal: true }]);
+    expect(host.value).toBe("typed base hello there.");
+  });
+
+  it("unmount mid-recording stops recognition and uploads nothing", async () => {
+    const { props } = makeHost();
+    const screen = render(MicButton, props);
+    await micBtn().click();
+    const rec = FakeRecognition.instances[0]!;
+    expect(rec.started).toBe(1);
+    screen.unmount();
+    expect(rec.stopped).toBeGreaterThan(0);
+    expect(mockTranscribeAudio).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/lib/components/MicButton.browser.test.ts
+++ b/ui/src/lib/components/MicButton.browser.test.ts
@@ -166,6 +166,50 @@ describe("MicButton", () => {
     expect(host.value).toBe("typed base hello there.");
   });
 
+  it("releases a stream that resolves after teardown and never starts recording", async () => {
+    // Local-engine path: unmount while the getUserMedia permission prompt is still pending,
+    // then let it resolve — the orphaned stream must be released, and no MediaRecorder may
+    // ever start (it would otherwise keep the mic open and upload a discarded clip).
+    delete w.SpeechRecognition;
+    delete w.webkitSpeechRecognition;
+    mockGetVoiceStatus.mockResolvedValue({
+      ...voiceAbsent,
+      available: true,
+      engine: "whisper.cpp",
+      model: "ggml-small.bin",
+    });
+    const mediaDevices = navigator.mediaDevices as { getUserMedia: unknown };
+    const originalGetUserMedia = mediaDevices.getUserMedia;
+    const originalMediaRecorder = window.MediaRecorder;
+    let resolveAcquisition!: (stream: unknown) => void;
+    const stopTrack = vi.fn();
+    const recorderCtor = vi.fn();
+    mediaDevices.getUserMedia = () => new Promise((r) => (resolveAcquisition = r));
+    window.MediaRecorder = class {
+      constructor() {
+        recorderCtor();
+      }
+      static isTypeSupported() {
+        return false;
+      }
+    } as unknown as typeof MediaRecorder;
+    try {
+      const { props } = makeHost();
+      const screen = render(MicButton, props);
+      await expect.element(micBtn()).toBeVisible();
+      await micBtn().click(); // startLocal() now awaits the pending permission prompt
+      screen.unmount(); // teardown while acquiring
+      resolveAcquisition({ getTracks: () => [{ stop: stopTrack }] });
+      await new Promise((r) => setTimeout(r, 0));
+      expect(stopTrack).toHaveBeenCalled();
+      expect(recorderCtor).not.toHaveBeenCalled();
+      expect(mockTranscribeAudio).not.toHaveBeenCalled();
+    } finally {
+      mediaDevices.getUserMedia = originalGetUserMedia;
+      window.MediaRecorder = originalMediaRecorder;
+    }
+  });
+
   it("unmount mid-recording stops recognition and uploads nothing", async () => {
     const { props } = makeHost();
     const screen = render(MicButton, props);

--- a/ui/src/lib/components/MicButton.svelte
+++ b/ui/src/lib/components/MicButton.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import { m } from "$lib/paraglide/messages";
+  import { createDictation } from "$lib/dictation.svelte";
+
+  // Reusable dictation mic for any text field — mount it directly AFTER the field inside any
+  // block container; no position:relative needed on the host. A zero-height in-flow anchor
+  // hugs the field's bottom edge and the ◉ button is absolutely positioned against it, so it
+  // floats inside the field's bottom-right corner and tracks the field's autogrow. The origin
+  // and error lines render after the anchor in normal flow (below the field), OUTSIDE the
+  // button's positioning context — they can never displace the button. The host should pad
+  // the field's right edge while the mic is rendered so typed text never runs under it, e.g.
+  //   .wrap:has(:global(.micbtn-anchor)) textarea { padding-right: 54px; }
+  // Renders nothing when neither engine (Web Speech / voice-whisper plugin) is available.
+  let {
+    getText,
+    setText,
+    onTextRendered,
+  }: {
+    /** Current field text (dictation appends after it). */
+    getText: () => string;
+    /** Replace the field text (live preview + final transcript). */
+    setText: (text: string) => void;
+    /** Fires deferred after every setText — wire the field's autogrow here. */
+    onTextRendered?: () => void;
+  } = $props();
+
+  // Closures (not the bare props) so the controller always calls the CURRENT prop value —
+  // also silences state_referenced_locally, which flags capturing props at init time.
+  const dict = createDictation({
+    getText: () => getText(),
+    setText: (t) => setText(t),
+    onTextRendered: () => onTextRendered?.(),
+  });
+
+  /** Discard an in-flight recording WITHOUT uploading — hosts call this on submit;
+   *  unmount (dialog close) does the same via onDestroy. */
+  export function teardown() {
+    dict.teardown();
+  }
+
+  onDestroy(() => dict.teardown());
+
+  // pointerdown + preventDefault: fire instantly and never blur the field (which would
+  // dismiss the mobile soft keyboard) — same rule as the compose sheet's mic.
+  function tapMic(e: PointerEvent) {
+    e.preventDefault();
+    dict.toggle();
+  }
+</script>
+
+{#if dict.micVisible}
+  <div class="micbtn-anchor">
+    <button
+      type="button"
+      class="micbtn"
+      class:listening={dict.listening}
+      class:transcribing={dict.transcribing}
+      class:error={dict.voiceError}
+      disabled={dict.transcribing}
+      aria-label={dict.transcribing
+        ? m.micbtn_transcribing()
+        : dict.listening
+          ? m.micbtn_dictate_stop_aria()
+          : m.micbtn_dictate_aria()}
+      aria-pressed={dict.listening}
+      onpointerdown={tapMic}>{m.micbtn_dictate()}</button
+    >
+  </div>
+  {#if dict.voiceError}
+    <div class="mic-hint" role="alert">{m.micbtn_transcribe_failed()}</div>
+  {/if}
+  {#if dict.originEngine}
+    <div class="mic-origin">
+      {dict.originEngine === "local" ? m.micbtn_origin_local() : m.micbtn_origin_web()}
+    </div>
+  {/if}
+{/if}
+
+<style>
+  /* Zero-height anchor: sits in flow directly under the field, so `bottom` on the absolutely
+     positioned button lands INSIDE the field's bottom-right corner and follows the field as
+     it autogrows. Anything rendered after the anchor is outside this positioning context. */
+  .micbtn-anchor {
+    position: relative;
+    height: 0;
+  }
+
+  .micbtn {
+    position: absolute;
+    right: 6px;
+    bottom: 6px;
+    width: 44px;
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line-bright);
+    border-radius: 2px;
+    color: var(--color-ink);
+    font-family: var(--font-mono);
+    font-size: var(--fs-lg);
+    line-height: 1;
+    cursor: pointer;
+    touch-action: manipulation;
+    user-select: none;
+    transition:
+      background 0.08s,
+      border-color 0.08s;
+  }
+  .micbtn:active {
+    background: var(--color-line-bright);
+    border-color: var(--color-ink);
+  }
+  .micbtn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+  /* while listening/transcribing: highlighted + a soft pulse so it reads as "working" */
+  .micbtn.listening,
+  .micbtn.transcribing {
+    background: var(--color-line-bright);
+    border-color: var(--color-ink);
+    animation: micPulse 1s ease-in-out infinite;
+  }
+  .micbtn.error {
+    border-color: var(--color-red);
+    color: var(--color-red);
+  }
+  .micbtn:disabled {
+    cursor: default;
+    opacity: 0.7;
+  }
+  @keyframes micPulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.5;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .micbtn.listening,
+    .micbtn.transcribing {
+      animation: none;
+    }
+  }
+
+  /* transient error line below the field when a transcription fails */
+  .mic-hint {
+    color: var(--color-red);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    padding: 4px 2px 0;
+  }
+
+  /* subtle origin label below the field — names which engine is capturing/transcribing this
+     dictation (local Whisper vs the browser engine). Faint + neutral so it never reads as an
+     error; it is provenance, NOT a plugin health badge. */
+  .mic-origin {
+    color: var(--color-faint);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    padding: 4px 2px 0;
+  }
+</style>

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -27,6 +27,7 @@
   import RepoSelect from "./RepoSelect.svelte";
   import PromptSources from "./PromptSources.svelte";
   import SlashCommandMenu from "./SlashCommandMenu.svelte";
+  import MicButton from "./MicButton.svelte";
   import NewTaskRunSettings from "./new-task/NewTaskRunSettings.svelte";
   import FirstTaskAutomationConfirm from "./FirstTaskAutomationConfirm.svelte";
   import { dialog } from "$lib/a11yDialog";
@@ -234,6 +235,7 @@
   let fileInput = $state<HTMLInputElement>();
   let promptInput = $state<HTMLTextAreaElement>();
   let repoSelect: RepoSelect | undefined = $state();
+  let mic: MicButton | undefined = $state();
   let isMac = $state(false);
   // Coarse pointer = touch-primary device with no hardware Ctrl/⌘/⌥ keys: hide
   // keyboard-combo hints it can't fulfil (submit shortcut badge + repo shortcuts).
@@ -702,6 +704,10 @@
   async function submit(e: Event, force = false) {
     e.preventDefault();
     if (!prompt.trim() || !repoPath.trim() || submitting) return;
+    // A mid-recording submit sends the prompt as it stands: stop the mic and discard the
+    // clip so nothing is uploaded while (or after) the task spawns. Closing the dialog is
+    // covered by MicButton's own unmount teardown.
+    mic?.teardown();
     const repo = repoPath.trim();
     // Settle the repo config BEFORE reading confirm/rowExists — an in-flight fetch reads both falsy,
     // which would spuriously show the step for a confirmed repo AND fail the !rowExists seed guard,
@@ -863,6 +869,15 @@
           onkeydown={onPromptKeydown}
           onblur={() => (slashOpen = false)}
           required></textarea>
+        <!-- Dictation mic (Web Speech / voice-whisper plugin): floats in the textarea's
+             bottom-right corner via its own zero-height anchor, writes the live preview and
+             final transcript into `prompt`. Hidden when neither engine is available. -->
+        <MicButton
+          bind:this={mic}
+          getText={() => prompt}
+          setText={(t) => (prompt = t)}
+          onTextRendered={autogrow}
+        />
         {#if slashOpen}
           <SlashCommandMenu
             commands={slashMatches}
@@ -1152,6 +1167,11 @@
   }
   .prompt-wrap {
     position: relative;
+  }
+  /* Reserve the mic's corner only while it is rendered (no engine → no dead padding),
+     so typed text never runs under the floating ◉ button. */
+  .prompt-wrap:has(:global(.micbtn-anchor)) textarea {
+    padding-right: 58px;
   }
   textarea,
   input,

--- a/ui/src/lib/dictation.svelte.ts
+++ b/ui/src/lib/dictation.svelte.ts
@@ -1,0 +1,487 @@
+import { getVoiceStatus, transcribeAudio } from "$lib/api";
+import { getLocale } from "$lib/i18n";
+import { pcmChunksToWavBlob } from "$lib/wav";
+
+// Reusable dictation controller — the engine behind every mic in the app, extracted from
+// ComposeBar so further fields cost one MicButton each instead of ~250 inlined lines.
+//
+// Two engines, picked per session:
+//  • Web Speech (Chrome/Android, Safari browser tab): the browser transcribes live. This is
+//    NOT the iOS keyboard's native dictation mic — no web API can summon that — and WebKit
+//    doesn't expose it inside an iOS home-screen PWA at all.
+//  • Local Whisper (the optional voice-whisper plugin, issue #76): record with MediaRecorder,
+//    POST the clip to the plugin, insert the returned text. The ONLY mic in an iOS PWA.
+//    While recording, a Web-Audio tap on the same stream feeds a live read-along preview:
+//    the PCM captured so far is encoded as a WAV (valid at every prefix — unlike an iOS
+//    MediaRecorder mp4, whose `moov` atom is written only on stop) and re-transcribed every
+//    INTERIM_MS with `mode=partial`, so the plugin's load gate keeps a slot free for the
+//    final full-clip transcription that replaces the preview on stop.
+//
+// The host owns the text field; the controller only reads/writes through the DictationHost
+// callbacks and never touches the DOM. One controller per field.
+
+export interface DictationHost {
+  /** Current field text (dictation appends after it). */
+  getText(): string;
+  /** Replace the field text (live preview + final transcript). */
+  setText(text: string): void;
+  /** Called DEFERRED (queueMicrotask) after every setText, once the reactive write has
+   *  flushed — so an autogrow handler measures the fresh scrollHeight, never a stale one. */
+  onTextRendered?(): void;
+}
+
+// Minimal SpeechRecognition interface — the W3C Web Speech API types are not yet in
+// TypeScript's built-in lib.dom.d.ts (only the event/result sub-types are), so we declare
+// the constructor/instance shape we actually consume.
+interface SpeechRecognitionInstance {
+  lang: string;
+  interimResults: boolean;
+  continuous: boolean;
+  onresult: ((e: SpeechRecognitionEvent) => void) | null;
+  onend: (() => void) | null;
+  onerror: (() => void) | null;
+  start(): void;
+  stop(): void;
+}
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+interface SpeechWindow extends Window {
+  SpeechRecognition?: SpeechRecognitionConstructor;
+  webkitSpeechRecognition?: SpeechRecognitionConstructor;
+}
+interface AudioWindow extends Window {
+  webkitAudioContext?: typeof AudioContext;
+}
+
+const MAX_RECORD_MS = 60_000; // cap a single clip so a forgotten mic can't record forever
+const INTERIM_MS = 2500; // how often to re-transcribe the growing clip for the live preview
+
+/** One dictation engine bound to one text field. Engine/browser capabilities are probed at
+ *  creation time (not module load), so tests can stub the globals before mounting a host. */
+export function createDictation(host: DictationHost) {
+  const SpeechRec: SpeechRecognitionConstructor | undefined =
+    typeof window !== "undefined"
+      ? ((window as SpeechWindow).SpeechRecognition ??
+        (window as SpeechWindow).webkitSpeechRecognition)
+      : undefined;
+  const AudioCtx: typeof AudioContext | undefined =
+    typeof window !== "undefined"
+      ? (window.AudioContext ?? (window as AudioWindow).webkitAudioContext)
+      : undefined;
+  const speechSupported = !!SpeechRec;
+
+  // The client must actually be able to record — MediaRecorder + getUserMedia. Without them a
+  // server-available plugin still can't be used from this browser, so treat local as unusable.
+  const recorderSupported =
+    typeof window !== "undefined" &&
+    typeof MediaRecorder !== "undefined" &&
+    !!navigator.mediaDevices?.getUserMedia;
+
+  let localVoiceAvailable = $state(false);
+  let preferLocal = $state(false);
+  let listening = $state(false);
+  let transcribing = $state(false);
+  let voiceError = $state(false);
+  let voiceErrorTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const localUsable = $derived(localVoiceAvailable && recorderSupported);
+  // The mic shows whenever *either* engine can run; `useLocal` picks which engine a NEW tap
+  // starts — local when Web Speech is absent (iOS PWA) or the plugin asks to be preferred,
+  // else the browser's live dictation. It can flip mid-session (the status probe resolving
+  // after an auto-started dictation), so it must NOT decide how to STOP an in-flight session.
+  const micVisible = $derived(speechSupported || localUsable);
+  const useLocal = $derived(localUsable && (!speechSupported || preferLocal));
+
+  // Which engine actually owns the live recording, fixed when it starts. toggle() stops THIS
+  // one rather than re-reading `useLocal`, so a mid-session flip never strands the recorder.
+  let activeEngine = $state<"web" | "local" | null>(null);
+
+  // Which engine to name on the origin label: the engine that owns the live recording, or
+  // "local" during the post-recording batch transcription. `transcribing` is set on the local
+  // path only (Web Speech transcribes live and never sets it), so it unambiguously means local
+  // — this keeps the label up across BOTH the recording and the transcription phase, then
+  // clears once both are done. It names the origin of THIS recording only — never plugin
+  // health/availability.
+  const originEngine = $derived(activeEngine ?? (transcribing ? "local" : null));
+
+  // The controller is the single owner of the plugin-status probe (memoized in api.ts).
+  // `ready` IS the promise that applies the result, so anything chained on it is guaranteed
+  // to observe localVoiceAvailable/preferLocal/useLocal already applied — hosts must never
+  // register their own getVoiceStatus().then and race this one.
+  const ready: Promise<void> = getVoiceStatus()
+    .then((s) => {
+      localVoiceAvailable = s.available;
+      preferLocal = s.preferLocal;
+    })
+    .catch(() => {});
+
+  let recog: SpeechRecognitionInstance | null = null;
+  let mediaRecorder: MediaRecorder | null = null;
+  let mediaStream: MediaStream | null = null;
+  let chunks: Blob[] = [];
+  let recordTimer: ReturnType<typeof setTimeout> | null = null;
+
+  let audioCtx: AudioContext | null = null;
+  let audioSource: MediaStreamAudioSourceNode | null = null;
+  let audioProc: ScriptProcessorNode | null = null;
+  let audioSink: GainNode | null = null;
+  let pcmChunks: Float32Array[] = [];
+  let pcmRate = 0;
+  let interimTimer: ReturnType<typeof setInterval> | null = null;
+  let interimBusy = false; // one interim request in flight at a time — never stack transcriptions
+  let interimSeq = 0; // bumped to discard a stale/late interim response (incl. after stop)
+  let dictationBase = ""; // field text when recording started; interim/final render after it
+
+  // Every text write goes through here: set, then notify the host DEFERRED so its
+  // autogrow-style handler measures the post-flush layout (the queueMicrotask(autogrow)
+  // pattern the pre-extraction ComposeBar used).
+  function render(text: string) {
+    host.setText(text);
+    queueMicrotask(() => host.onTextRendered?.());
+  }
+
+  function pickMimeType(): string | undefined {
+    if (typeof MediaRecorder === "undefined") return undefined;
+    for (const c of ["audio/webm;codecs=opus", "audio/webm", "audio/mp4", "audio/ogg"])
+      if (MediaRecorder.isTypeSupported(c)) return c;
+    return undefined; // let the browser choose its default container
+  }
+
+  function flashVoiceError() {
+    voiceError = true;
+    if (voiceErrorTimer) clearTimeout(voiceErrorTimer);
+    voiceErrorTimer = setTimeout(() => (voiceError = false), 4000);
+  }
+
+  // Tap the live mic stream with Web Audio and start the interim-transcription loop.
+  // Best-effort: if Web Audio is unavailable or setup throws, we bail quietly and the final
+  // clip still runs.
+  function startInterimCapture(stream: MediaStream) {
+    if (!AudioCtx) return;
+    try {
+      // Ask for 16 kHz directly so the browser resamples for us; fall back to the device rate.
+      try {
+        audioCtx = new AudioCtx({ sampleRate: 16000 });
+      } catch {
+        audioCtx = new AudioCtx();
+      }
+      void audioCtx.resume?.().catch(() => {});
+      pcmRate = audioCtx.sampleRate;
+      pcmChunks = [];
+      audioSource = audioCtx.createMediaStreamSource(stream);
+      // ScriptProcessor is deprecated in favour of AudioWorklet, but the worklet needs a
+      // separately bundled module; ScriptProcessor is the simplest path that also works in an
+      // iOS PWA. A 60 s dictation on the main thread is well within its budget.
+      audioProc = audioCtx.createScriptProcessor(4096, 1, 1);
+      audioProc.onaudioprocess = (e) => {
+        pcmChunks.push(new Float32Array(e.inputBuffer.getChannelData(0)));
+      };
+      // Route through a muted gain into the destination so the processor actually runs,
+      // without echoing the mic back to the speakers.
+      audioSink = audioCtx.createGain();
+      audioSink.gain.value = 0;
+      audioSource.connect(audioProc);
+      audioProc.connect(audioSink);
+      audioSink.connect(audioCtx.destination);
+      interimTimer = setInterval(() => void runInterim(), INTERIM_MS);
+    } catch {
+      stopInterimCapture();
+    }
+  }
+
+  // One interim tick: transcribe the clip captured so far and show it live. Guarded so only
+  // one request is ever in flight, and a stale/late response (a newer tick, or one arriving
+  // after we stopped) is discarded via the sequence number. `mode: "partial"` marks the
+  // request disposable so the plugin's load gate keeps a slot free for the final clip.
+  async function runInterim() {
+    if (interimBusy || transcribing || !listening) return;
+    if (pcmChunks.length === 0 || pcmRate === 0) return;
+    const blob = pcmChunksToWavBlob(pcmChunks, pcmRate);
+    interimBusy = true;
+    const seq = ++interimSeq;
+    try {
+      const text = await transcribeAudio(blob, getLocale() === "de" ? "de" : "en", {
+        mode: "partial",
+      });
+      if (seq === interimSeq && listening && text)
+        render(dictationBase.trim() ? dictationBase.trimEnd() + " " + text.trim() : text.trim());
+    } catch {
+      // interim is best-effort — a failed/shed tick is silently skipped; the final clip still runs
+    } finally {
+      interimBusy = false;
+    }
+  }
+
+  function stopInterimCapture() {
+    if (interimTimer) {
+      clearInterval(interimTimer);
+      interimTimer = null;
+    }
+    interimSeq++; // invalidate any in-flight interim response
+    interimBusy = false;
+    if (audioProc) audioProc.onaudioprocess = null;
+    try {
+      audioProc?.disconnect();
+      audioSource?.disconnect();
+      audioSink?.disconnect();
+    } catch {
+      /* nodes already torn down */
+    }
+    audioProc = null;
+    audioSource = null;
+    audioSink = null;
+    if (audioCtx) {
+      void audioCtx.close().catch(() => {});
+      audioCtx = null;
+    }
+    pcmChunks = [];
+    pcmRate = 0;
+  }
+
+  // Start recording via the local plugin. Must be reached within the getUserMedia
+  // user-activation window (a mic tap, or autoStart() with the status probe pre-resolved).
+  // `acquiring` guards the getUserMedia await so an auto-start and a fast manual tap can't
+  // both open a stream.
+  let acquiring = false;
+  async function startLocal() {
+    if (listening || transcribing || acquiring) return;
+    if (!recorderSupported) {
+      flashVoiceError();
+      return;
+    }
+    acquiring = true;
+    voiceError = false;
+    try {
+      try {
+        mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      } catch {
+        flashVoiceError();
+        return;
+      }
+      const mimeType = pickMimeType();
+      chunks = [];
+      // MediaRecorder construction or start() can throw (unsupported mimeType, hardware in
+      // use); release the just-acquired mic stream so it isn't left open on failure.
+      try {
+        mediaRecorder = new MediaRecorder(mediaStream, mimeType ? { mimeType } : undefined);
+        mediaRecorder.ondataavailable = (e) => {
+          if (e.data.size) chunks.push(e.data);
+        };
+        mediaRecorder.onstop = () => void finishLocalRecording();
+        mediaRecorder.start();
+      } catch {
+        mediaRecorder = null;
+        releaseStream();
+        flashVoiceError();
+        return;
+      }
+      listening = true;
+      activeEngine = "local";
+      recordTimer = setTimeout(() => stopLocal(), MAX_RECORD_MS);
+      // Start the live read-along preview off the same stream (best-effort; the final clip
+      // above is authoritative and runs regardless of whether interim capture succeeds).
+      dictationBase = host.getText();
+      if (mediaStream) startInterimCapture(mediaStream);
+    } finally {
+      acquiring = false;
+    }
+  }
+
+  // User-initiated stop → let onstop fire finishLocalRecording (which uploads + inserts).
+  function stopLocal() {
+    if (recordTimer) {
+      clearTimeout(recordTimer);
+      recordTimer = null;
+    }
+    if (mediaRecorder && mediaRecorder.state !== "inactive") mediaRecorder.stop();
+    listening = false;
+  }
+
+  async function finishLocalRecording() {
+    const type = mediaRecorder?.mimeType || "audio/webm";
+    stopInterimCapture();
+    releaseStream();
+    mediaRecorder = null;
+    activeEngine = null;
+    if (chunks.length === 0) return;
+    const blob = new Blob(chunks, { type });
+    chunks = [];
+    transcribing = true;
+    try {
+      // The final clip sends NO mode — the plugin treats absent mode as the one
+      // transcription its load gate reserves a slot for.
+      const text = await transcribeAudio(blob, getLocale() === "de" ? "de" : "en");
+      // The accurate full-clip result replaces whatever the live preview last showed. On
+      // error we keep the last interim text rather than discarding what the user dictated.
+      render(dictationBase);
+      if (text) appendTranscript(text);
+    } catch {
+      flashVoiceError();
+    } finally {
+      transcribing = false;
+    }
+  }
+
+  function releaseStream() {
+    mediaStream?.getTracks().forEach((t) => t.stop());
+    mediaStream = null;
+  }
+
+  // Tear down an in-progress recording WITHOUT uploading (dismiss/submit/destroy): drop the
+  // onstop handler first so stopping never triggers a transcription of a discarded clip.
+  function teardownRecording() {
+    if (recordTimer) {
+      clearTimeout(recordTimer);
+      recordTimer = null;
+    }
+    if (mediaRecorder) {
+      mediaRecorder.ondataavailable = null;
+      mediaRecorder.onstop = null;
+      if (mediaRecorder.state !== "inactive") {
+        try {
+          mediaRecorder.stop();
+        } catch {
+          /* already stopped */
+        }
+      }
+      mediaRecorder = null;
+    }
+    stopInterimCapture();
+    releaseStream();
+    chunks = [];
+    listening = false;
+    activeEngine = null;
+  }
+
+  // Append transcribed text after whatever is already in the field (the join rule both the
+  // interim preview and Web Speech use).
+  function appendTranscript(text: string) {
+    const t = text.trim();
+    if (!t) return;
+    const cur = host.getText();
+    render(cur.trim() ? cur.trimEnd() + " " + t : t);
+  }
+
+  // Start a Web Speech session — the browser transcribes live straight into the field.
+  function startWeb() {
+    if (!SpeechRec || listening || transcribing) return;
+    recog = new SpeechRec();
+    recog.lang = getLocale() === "de" ? "de-DE" : "en-US";
+    recog.interimResults = true;
+    recog.continuous = true;
+    let base = host.getText(); // text already typed before dictation started
+    recog.onresult = (e: SpeechRecognitionEvent) => {
+      let finalChunk = "";
+      let interim = "";
+      for (let i = e.resultIndex; i < e.results.length; i++) {
+        const t = e.results[i][0].transcript;
+        if (e.results[i].isFinal) finalChunk += t;
+        else interim += t;
+      }
+      if (finalChunk) base = (base ? base.trimEnd() + " " : "") + finalChunk.trim();
+      render(interim ? (base ? base.trimEnd() + " " : "") + interim.trim() : base);
+    };
+    recog.onend = () => {
+      listening = false;
+      activeEngine = null;
+    };
+    recog.onerror = () => {
+      listening = false;
+      activeEngine = null;
+    };
+    recog.start();
+    listening = true;
+    activeEngine = "web";
+  }
+
+  function stopWeb() {
+    recog?.stop();
+  }
+
+  // One mic tap. A live session is stopped by the engine that STARTED it (not the current
+  // `useLocal`, which may have flipped mid-session) — otherwise the active recorder is never
+  // stopped. A fresh tap starts whichever engine `useLocal` picks now.
+  function toggle() {
+    if (transcribing) return;
+    if (activeEngine === "local") {
+      stopLocal();
+    } else if (activeEngine === "web") {
+      stopWeb();
+    } else if (useLocal) {
+      void startLocal();
+    } else {
+      startWeb();
+    }
+  }
+
+  // "Open already listening" (ComposeBar's ◉ dictate entry). Reproduces the pre-extraction
+  // mount order with no .then-registration race: Web Speech starts synchronously (never
+  // delayed by the probe); the local branch chains on `ready` — the controller's OWN status
+  // application — so its guard always reads applied state, and is skipped when the web engine
+  // is already listening. The probe is memoized and pre-resolved by the host's entry point
+  // (ViewportTermControls), so `ready` settles in the same turn and getUserMedia stays inside
+  // the tap's user-activation window; a denial just flashes an error.
+  function autoStart() {
+    if (speechSupported) startWeb();
+    void ready.then(() => {
+      if (useLocal && !listening && !transcribing) void startLocal();
+    });
+  }
+
+  // Full stop for dismiss/submit/destroy: discard any in-flight recording WITHOUT uploading,
+  // silence late Web Speech results, and reset every one-shot guard (incl. the error flash).
+  function teardown() {
+    if (recog) {
+      recog.onresult = null;
+      recog.onend = null;
+      recog.onerror = null;
+      try {
+        recog.stop();
+      } catch {
+        /* already stopped */
+      }
+      recog = null;
+    }
+    teardownRecording();
+    if (voiceErrorTimer) {
+      clearTimeout(voiceErrorTimer);
+      voiceErrorTimer = null;
+    }
+    voiceError = false;
+  }
+
+  return {
+    /** Either engine can run — render the mic. */
+    get micVisible() {
+      return micVisible;
+    },
+    get listening() {
+      return listening;
+    },
+    /** Local batch transcription in flight (recording already stopped). */
+    get transcribing() {
+      return transcribing;
+    },
+    get voiceError() {
+      return voiceError;
+    },
+    /** Engine that owns the CURRENT recording/transcription — provenance, not health. */
+    get originEngine() {
+      return originEngine;
+    },
+    get useLocal() {
+      return useLocal;
+    },
+    get speechSupported() {
+      return speechSupported;
+    },
+    /** Resolves once the plugin-status probe has been APPLIED to controller state. */
+    ready,
+    toggle,
+    autoStart,
+    startLocal,
+    startWeb,
+    teardown,
+  };
+}

--- a/ui/src/lib/dictation.svelte.ts
+++ b/ui/src/lib/dictation.svelte.ts
@@ -242,8 +242,12 @@ export function createDictation(host: DictationHost) {
   // Start recording via the local plugin. Must be reached within the getUserMedia
   // user-activation window (a mic tap, or autoStart() with the status probe pre-resolved).
   // `acquiring` guards the getUserMedia await so an auto-start and a fast manual tap can't
-  // both open a stream.
+  // both open a stream. `session` is bumped by teardown(): if teardown runs while the
+  // permission prompt is still pending (dialog closed / submitted), the resolved stream is
+  // stale — release it and never start recording, else the mic would stay open and the 60 s
+  // cap would eventually stop-and-UPLOAD a clip nobody kept.
   let acquiring = false;
+  let session = 0;
   async function startLocal() {
     if (listening || transcribing || acquiring) return;
     if (!recorderSupported) {
@@ -252,13 +256,21 @@ export function createDictation(host: DictationHost) {
     }
     acquiring = true;
     voiceError = false;
+    const mySession = session;
     try {
+      let stream: MediaStream;
       try {
-        mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       } catch {
-        flashVoiceError();
+        if (session === mySession) flashVoiceError();
         return;
       }
+      if (session !== mySession) {
+        // torn down while permission was pending — the acquisition is orphaned
+        stream.getTracks().forEach((t) => t.stop());
+        return;
+      }
+      mediaStream = stream;
       const mimeType = pickMimeType();
       chunks = [];
       // MediaRecorder construction or start() can throw (unsupported mimeType, hardware in
@@ -431,7 +443,10 @@ export function createDictation(host: DictationHost) {
 
   // Full stop for dismiss/submit/destroy: discard any in-flight recording WITHOUT uploading,
   // silence late Web Speech results, and reset every one-shot guard (incl. the error flash).
+  // Bumping `session` also orphans a getUserMedia acquisition that is still awaiting the
+  // permission prompt — startLocal releases the stream instead of recording (see above).
   function teardown() {
+    session++;
     if (recog) {
       recog.onresult = null;
       recog.onend = null;

--- a/ui/src/lib/feature-announcements/entries/v1.42.0-newtask-prompt-mic.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.42.0-newtask-prompt-mic.ts
@@ -1,0 +1,13 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "newtask-prompt-mic",
+  sinceVersion: "1.42.0",
+  titleKey: "feat_newtask_prompt_mic_title",
+  bodyKey: "feat_newtask_prompt_mic_body",
+  // No targetId: the mic lives inside the New Task dialog (closed by default) AND only
+  // renders when a dictation engine is available, so a coachmark could never reliably
+  // find its anchor — What's-New drawer only.
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
Closes #1433

## What

A mic on the New Task prompt with full parity to the compose-bar mic — engine pick (Web Speech / local Whisper via the voice-whisper plugin), live read-along preview while speaking, final full-clip replacement on stop, visible engine-origin line — built as a reusable component so further fields cost one line each.

Three atomic commits:

1. **`fix(voice): send mode=partial on interim transcriptions`** — `transcribeAudio(blob, lang?, opts?: { mode?: "partial" })`. Interim previews now mark themselves disposable, so the plugin's load gate (`RESERVED_FOR_FINAL = 1`, verified against the installed plugin source: field name `mode`, absent-mode-is-final, identical `{ text }` response for both modes) can never let previews 429-starve the final clip. The final clip sends no `mode` field.
2. **`refactor(voice): extract ComposeBar dictation into a runes controller`** — the ~250 inlined lines move verbatim into `createDictation()` (`ui/src/lib/dictation.svelte.ts`). The controller is the single owner of the `getVoiceStatus` probe with an explicit `ready` application-promise and a guarded `autoStart()`, so the iOS user-activation-window auto-start no longer depends on `.then` registration order. Host contract: `getText`/`setText` + a **deferred** `onTextRendered` (queueMicrotask) so autogrow measures post-flush layout. Behaviour-identical apart from `mode=partial`.
3. **`feat(ui): mic button on the New Task prompt`** — new `MicButton.svelte`: a zero-height in-flow anchor floats the ◉ toggle inside the field's bottom-right corner (tracks autogrow; the in-flow origin/error lines render outside its positioning context so they can never displace it). Mounted in NewTask's `.prompt-wrap`; the textarea gets right padding only while the mic is rendered (`:has()`); submit/close mid-recording releases the mic stream and uploads nothing. Feature-announcement entry `v1.42.0-newtask-prompt-mic` (drawer-only, no targetId — anchor lives in a closed-by-default dialog) + EN/DE keys.

## Verified

- `bun run check` — 0 errors; `check:i18n` — 2 locales in parity; `bun run lint` — clean; full UI suite **2903 tests / 215 files green** (includes new `ComposeBar.browser.test.ts`, `MicButton.browser.test.ts`, `api.transcribeAudio.test.ts`).
- New CI coverage for the highest-risk refactor: ComposeBar web-speech path (mic tap, `startDictation` auto-start, interim/final join rule, **no `transcribeAudio` call on submit/cancel mid-recording**).
- Pre-push hygiene gates green: branch hygiene, feature catalog, announcement versions, glossary, fallow audit.

## Manual regression (on-device, hardware-bound paths)

- [ ] Compose bar: mic tap start/stop; ◉ dictate chip auto-start; cancel/submit mid-recording; engine flip while recording (plugin status resolving mid-session)
- [ ] iOS home-screen PWA + voice-whisper plugin: New Task mic records, live preview renders, final transcript replaces it; interim POSTs carry `mode=partial`, final does not (plugin logs/network tab)
- [ ] Desktop Chrome without plugin: New Task mic appears via Web Speech; no plugin → no engine → no mic

## Follow-ups (filed)

- #1452 — mic on further fields (NewProject, FeedbackDialog, SteersEditor, …), one mount each now that MicButton exists
- #1453 — plugin-agnostic transcription capability contract, replacing the deliberate voice-whisper seam in `api.ts` that this PR knowingly keeps