### PR TITLE
ci: add awaiting-response stale sweep (3d ping, 3d close)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,81 @@
+name: Awaiting-response sweep
+
+# Chases down issues that are blocked on the reporter. When a maintainer asks a question and
+# labels the issue `awaiting-response`, this workflow pings after 3 days of silence and closes 3
+# days after that (6 days total) — so a question we can't answer without the reporter doesn't
+# linger open forever. It ONLY ever touches issues carrying `awaiting-response`; everything else is
+# invisible to it (`only-labels`). PRs are excluded entirely (both PR knobs are -1).
+#
+# The moment the person we're waiting on replies, the `clear-on-reply` job strips the label, which
+# both stops the countdown and removes any `stale` marker — so a real answer never trips the sweep.
+# A maintainer's own comment does NOT clear it (we're waiting on the reporter, not on us): the job
+# fires only when the comment author IS the issue author.
+
+on:
+  schedule:
+    - cron: "23 7 * * *" # once-daily sweep; 3-day thresholds give day-resolution, which is plenty
+  workflow_dispatch:
+  issue_comment:
+    types: [created]
+
+# Least privilege: label + comment + close issues. Nothing else.
+permissions:
+  issues: write
+  contents: read
+
+# Never run two sweeps at once; let an in-flight sweep finish rather than cancelling it.
+concurrency:
+  group: awaiting-response-sweep
+  cancel-in-progress: false
+
+jobs:
+  # ── periodic sweep: ping stale awaiting-response issues, then close them ──────────────────────
+  sweep:
+    if: github.event_name != 'issue_comment'
+    name: ping + close stale awaiting-response issues
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          # Only issues we're explicitly waiting on the reporter for.
+          only-labels: "awaiting-response"
+          # 3 days idle → ping (adds `stale`); 3 more days idle → close. Any update resets the clock
+          # and, via remove-stale-when-updated, drops the `stale` marker.
+          days-before-stale: 3
+          days-before-close: 3
+          remove-stale-when-updated: true
+          stale-issue-label: "stale"
+          stale-issue-message: >
+            No reply from the reporter for 3 days on our question above. If this is still relevant,
+            just leave a comment — otherwise this issue will be closed automatically in 3 days.
+          close-issue-message: >
+            Closing automatically: no reply for 6 days after we asked for more information. This
+            isn't a "wontfix" — if it's still needed, comment and we'll reopen and pick it back up.
+          # This sweep is issues-only; never let it act on pull requests.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+
+  # ── reporter replied → clear the waiting state so the sweep stops chasing it ──────────────────
+  clear-on-reply:
+    if: >
+      github.event_name == 'issue_comment' &&
+      !github.event.issue.pull_request &&
+      github.event.comment.user.login == github.event.issue.user.login
+    name: clear awaiting-response when the reporter replies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove awaiting-response (and any stale marker)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          # Idempotent per-label DELETE: the REST endpoint 404s when the label isn't on the issue,
+          # which is fine here (the reporter may comment on an issue that was never labeled) — so we
+          # tolerate a miss rather than pre-reading the label set.
+          for label in awaiting-response stale; do
+            gh api -X DELETE "repos/$GH_REPO/issues/$ISSUE/labels/$label" >/dev/null 2>&1 \
+              && echo "removed '$label' from #$ISSUE" \
+              || echo "'$label' not present on #$ISSUE — nothing to remove"
+          done

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,15 +1,24 @@
 name: Awaiting-response sweep
 
 # Chases down issues that are blocked on the reporter. When a maintainer asks a question and
-# labels the issue `awaiting-response`, this workflow pings after 3 days of silence and closes 3
+# labels the issue `awaiting-response`, this workflow pings after 3 days of INACTIVITY and closes 3
 # days after that (6 days total) — so a question we can't answer without the reporter doesn't
 # linger open forever. It ONLY ever touches issues carrying `awaiting-response`; everything else is
 # invisible to it (`only-labels`). PRs are excluded entirely (both PR knobs are -1).
 #
-# The moment the person we're waiting on replies, the `clear-on-reply` job strips the label, which
-# both stops the countdown and removes any `stale` marker — so a real answer never trips the sweep.
-# A maintainer's own comment does NOT clear it (we're waiting on the reporter, not on us): the job
-# fires only when the comment author IS the issue author.
+# TWO distinct mechanisms, don't conflate them:
+#
+#   1. The stale TIMER is activity-based, not reporter-specific. `days-before-stale: 3` counts days
+#      since the last update of ANY kind, and `remove-stale-when-updated: true` drops the `stale`
+#      marker + restarts the countdown on ANY update — INCLUDING a maintainer's own comment. So a
+#      maintainer follow-up (e.g. re-asking, adding detail) legitimately hands the reporter a fresh
+#      3-day window rather than closing out from under an active thread. That's the intended trade;
+#      actions/stale tracks inactivity, and we accept "any activity" as the reset signal.
+#
+#   2. The `awaiting-response` LABEL is cleared reporter-only. The `clear-on-reply` job strips it
+#      (and any `stale` marker) the moment the ISSUE AUTHOR comments — taking the issue out of scope
+#      entirely so the sweep never chases it again. A maintainer's comment resets the timer (per #1)
+#      but does NOT clear the label: we're still waiting on the reporter, so the issue stays tracked.
 
 on:
   schedule:


### PR DESCRIPTION
## What

Adds `.github/workflows/stale.yml` — an issue-triage sweep scoped to a new **`awaiting-response`** label.

When a maintainer asks a question and labels an issue `awaiting-response`:
- **After 3 days** of no reply → the bot posts a ping and adds `stale`.
- **After 3 more days** (6 total) of continued silence → the issue is closed with a friendly "not a wontfix, comment to reopen" message.
- **The reporter replying clears it**: a separate `clear-on-reply` job strips `awaiting-response` (and any `stale` marker) the moment the *issue author* comments — stopping the countdown. A maintainer's own comment does **not** clear it (we're waiting on the reporter, not on us).

Issues-only: both PR knobs are `-1`, so pull requests are never touched.

## Why

There was no label for "waiting on the reporter" and no automation to chase or retire stalled questions — so a question we can't answer without the reporter would linger open indefinitely. This closes that gap with tight, easily-tuned thresholds.

## Notes for the reviewer

- **`awaiting-response` label already created live** in the repo (color `#D4C5F9`, "Waiting on the reporter to answer a question before we can proceed") and already applied to #1450 — so the workflow is functional the moment this merges. It's not part of the diff because labels aren't files.
- `actions/stale@v10` pinned to the major tag, matching the repo convention for first-party `actions/*` (e.g. `actions/checkout@v7`). All 9 inputs verified against the v10 `action.yml`.
- No untrusted free-text (issue/comment bodies) reaches any `run:` — only the numeric `issue.number` and `github.repository`, via `env:` vars. The reporter-vs-maintainer check is a pure `if:` expression.
- **Timing is trivial to tune**: `days-before-stale` / `days-before-close` in the `sweep` job.

## Context

Spun out of triage on #1450 (which is now the first issue wearing `awaiting-response`, pending its reporter's reply). This PR does **not** implement or close #1450.