### PR TITLE
fix(poller): surface the Claude /login account-URL banner (PTY-only source)

### DIFF
--- a/src/auth-url.test.ts
+++ b/src/auth-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { detectAuthUrl, detectPendingAuthUrl } from "./auth-url";
+import { detectAuthUrl, detectPendingAuthUrl, detectLoginAuthUrl } from "./auth-url";
 
 // Real-shape fixtures (synthetic client_id / code_challenge). Mirrors the Step-0 capture:
 // the authorize URL lands in an assistant `text` block AND/OR a `tool_result` block inside a
@@ -152,5 +152,99 @@ describe("detectPendingAuthUrl (freshness-gated)", () => {
       opInputString("http://localhost:3118/callback?code=xyz"),
     ].join("\n");
     expect(detectPendingAuthUrl(jsonl)).toBeNull();
+  });
+});
+
+// Byte-faithful capture of a real `herdr.read(term,"visible")` of the Claude Code `/login`
+// (account re-login) panel — the pane hard-wrapped the flush-left URL at 63 cols, breaking it
+// mid-token with NO inserted spaces. This authorize URL is PTY-only (it never lands in the JSONL
+// transcript), so this fixture is the sole validation that the wrap-join reconstructs a REAL
+// hard-wrap. `client_id` is the public Claude Code OAuth client id; the single-use PKCE
+// `code_challenge`/`state` are long-expired nonces.
+const LOGIN_URL_LINES = [
+  "https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c25",
+  "0a-e61b-44d9-88ed-5944d1962f5e&response_type=code&redirect_uri=ht",
+  "tps%3A%2F%2Fplatform.claude.com%2Foauth%2Fcode%2Fcallback&scope=o",
+  "rg%3Acreate_api_key+user%3Aprofile+user%3Ainference+user%3Asessio",
+  "ns%3Aclaude_code+user%3Amcp_servers+user%3Afile_upload&code_chall",
+  "enge=7fZ4v-QWXM2nnE_04d3um7K5-KOOVAHtRcFmvlTBIfE&code_challenge_m",
+  "ethod=S256&state=t6_LEFskFrRPiy_pnzr_f9uKwJSArorv7PaSt4DuoKY",
+];
+const LOGIN_URL = LOGIN_URL_LINES.join("");
+const LOGIN_PANEL = [
+  "❯ /login",
+  "",
+  "─".repeat(62),
+  "  Login",
+  "",
+  "  Browser didn't open? Use the url below to sign in (c to copy)",
+  "",
+  ...LOGIN_URL_LINES,
+  "",
+  "",
+  "  Paste code here if prompted >",
+  "",
+  "  Esc to cancel",
+].join("\n");
+
+describe("detectLoginAuthUrl", () => {
+  it("reconstructs the wrapped URL from a byte-faithful /login panel capture", () => {
+    expect(detectLoginAuthUrl(LOGIN_PANEL)).toBe(LOGIN_URL);
+    // Sanity: the reconstruction really is a valid authorize URL.
+    expect(new URL(LOGIN_URL).pathname).toBe("/cai/oauth/authorize");
+  });
+
+  it("returns a single-line (unwrapped) authorize URL as-is", () => {
+    expect(detectLoginAuthUrl(`  Login\n\n${LOGIN_URL}\n\n  Esc to cancel`)).toBe(LOGIN_URL);
+  });
+
+  it("reconstructs a URL wrapped inside a box-drawing border", () => {
+    const bordered = [
+      "│  Login" + " ".repeat(10) + "│",
+      "│" + " ".repeat(20) + "│",
+      ...LOGIN_URL_LINES.map((l) => "│ " + l + " │"),
+      "│" + " ".repeat(20) + "│",
+    ].join("\n");
+    expect(detectLoginAuthUrl(bordered)).toBe(LOGIN_URL);
+  });
+
+  it("stops before appending a following text line with NO intervening blank line (plain)", () => {
+    // `Paste code here…` directly follows the last URL chunk with no blank line. Its leading
+    // `Paste` must NOT be appended (evaluate-STOP-before-APPEND) — else a broken-but-structurally
+    // -valid authorize URL passes both isAuthUrl and the stability gate.
+    const noBlank = [...LOGIN_URL_LINES, "  Paste code here if prompted >"].join("\n");
+    expect(detectLoginAuthUrl(noBlank)).toBe(LOGIN_URL);
+  });
+
+  it("stops before appending a following text line with NO blank line (box-bordered)", () => {
+    const noBlank = [
+      ...LOGIN_URL_LINES.map((l) => "│ " + l + " │"),
+      "│ Paste code here if prompted > │",
+    ].join("\n");
+    expect(detectLoginAuthUrl(noBlank)).toBe(LOGIN_URL);
+  });
+
+  it("anchors past a non-URL prefix on the URL's first line", () => {
+    const prefixed = ["url> " + LOGIN_URL_LINES[0], ...LOGIN_URL_LINES.slice(1)].join("\n");
+    expect(detectLoginAuthUrl(prefixed)).toBe(LOGIN_URL);
+  });
+
+  it("returns null when the visible buffer has no URL", () => {
+    expect(
+      detectLoginAuthUrl("  Login\n\n  Paste code here if prompted >\n\n  Esc to cancel"),
+    ).toBeNull();
+  });
+
+  it("returns null for a wrapped NON-auth URL (isAuthUrl gate)", () => {
+    const nonAuth = [
+      "https://example.com/very/long/path/that/wraps/here/aaaaaaaaa",
+      "bbbbbbbbbbbb/cccccc/dddddd",
+    ].join("\n");
+    expect(detectLoginAuthUrl(nonAuth)).toBeNull();
+  });
+
+  it("skips a leading non-auth URL and finds the auth URL later in the buffer", () => {
+    const buf = ["visit https://example.com/docs for help", "", ...LOGIN_URL_LINES].join("\n");
+    expect(detectLoginAuthUrl(buf)).toBe(LOGIN_URL);
   });
 });

--- a/src/auth-url.ts
+++ b/src/auth-url.ts
@@ -185,3 +185,52 @@ export function detectPendingAuthUrl(rawJsonl: string, maxSinceSet = 25): string
   }
   return pending && sinceSet > maxSinceSet ? null : pending;
 }
+
+// eslint-disable-next-line no-control-regex
+const ANSI_LINE_RE = /\x1b\[[0-9;]*[A-Za-z]/g;
+// Framing a TUI panel puts on a line: box-drawing glyphs (U+2500–U+257F: the `─` rule and the
+// `│`/`┃` verticals) or an ASCII `|`, plus surrounding whitespace/indent. These survive
+// ANSI-strip, so peel them off BOTH ends of a line before anchoring/joining a URL. A URL has
+// none of these characters, so stripping ends never eats URL content.
+const BORDER_ENDS_RE = /^[\s─-╿|]+|[\s─-╿|]+$/g;
+
+/** A terminal line's content with ANSI + framing borders/indent stripped from both ends. */
+function innerText(line: string): string {
+  return line.replace(ANSI_LINE_RE, "").replace(BORDER_ENDS_RE, "");
+}
+
+/**
+ * Reconstruct a word-wrapped OAuth *authorization* URL from a terminal VISIBLE buffer.
+ *
+ * The Claude Code `/login` (account re-login) flow prints its authorize URL only into the PTY —
+ * it never lands in the JSONL transcript, so the transcript detectors above cannot see it. The
+ * TUI hard-wraps the URL at terminal width with NO inserted spaces, breaking it mid-token across
+ * several flush-left lines. So: anchor on the first line that carries an `https?://` token, then
+ * join following lines that are ENTIRELY URL characters, and validate the result is an authorize
+ * URL (`isAuthUrl`) so an arbitrary printed link can't forge one.
+ *
+ * The join evaluates its STOP condition strictly BEFORE appending: a hard-wrapped continuation is,
+ * by construction, a whole line of URL characters with no internal whitespace, so a line that is
+ * empty or has ANY internal whitespace (a blank line, or `Paste code here if prompted >`, even
+ * with no intervening blank line) ends the URL and contributes NOTHING. Appending a leading run of
+ * such a line would yield a *structurally valid* authorize URL that passes both `isAuthUrl` and the
+ * poller's stability gate — a silently broken banner — so it must be prevented here at the join.
+ */
+export function detectLoginAuthUrl(visible: string): string | null {
+  const lines = visible.split("\n").map(innerText);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    const idx = line.search(/https?:\/\//);
+    if (idx < 0) continue;
+    // Head: from the scheme to the first whitespace on this line (the wrap's first URL chunk).
+    let joined = line.slice(idx).split(/\s/)[0]!;
+    for (let j = i + 1; j < lines.length; j++) {
+      const cont = lines[j]!;
+      if (cont === "" || /\s/.test(cont)) break; // STOP before APPEND — URL ended
+      joined += cont;
+    }
+    const u = trimUrl(joined);
+    if (isAuthUrl(u)) return u;
+  }
+  return null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,7 @@ import { BuildQueueReminderService } from "./build-queue-reminder";
 import { HerdDigestService } from "./herd-digest";
 import { readSnapshot, isStalled, DEFAULT_STALL } from "./stall";
 import { jsonlPathFor } from "./usage";
-import { detectPendingAuthUrl } from "./auth-url";
+import { detectPendingAuthUrl, detectLoginAuthUrl } from "./auth-url";
 import { readTranscriptTail } from "./activity";
 import { verifyApiKey } from "./verify-key";
 import { releaseHeldTasks } from "./held-release";
@@ -1380,6 +1380,19 @@ events.subscribe((event, data) => {
   }
 });
 
+/** A session's live PTY visible buffer via its matched herdr agent, or null (no session / no live
+ *  agent / herdr down). Shared by the `readTail` and `pendingAuthUrl` autopilot seams. */
+function readVisibleBuffer(id: string): string | null {
+  const s = store.get(id);
+  if (!s) return null;
+  try {
+    const live = matchAgent(s, herdr.list());
+    return live ? herdr.read(live.terminalId, "visible") : null;
+  } catch {
+    return null;
+  }
+}
+
 // Autopilot: the pre-PR twin of the critic's auto-address loop. When an autopilot-enabled
 // session (per-repo default + per-session override) stalls on a procedural gate with no PR
 // yet, a transient classifier decides gate (auto-proceed) / question (surface) / finished
@@ -1403,24 +1416,30 @@ const autopilot = new AutopilotService({
   },
   deferSteer: (id) => service.shouldDeferSteer(id),
   readTail: (id) => {
-    const s = store.get(id);
-    if (!s) return [];
-    const live = matchAgent(s, herdr.list());
-    return live ? tailLines(herdr.read(live.terminalId, "visible")) : [];
+    const v = readVisibleBuffer(id);
+    return v === null ? [] : tailLines(v);
   },
-  // Pending MCP OAuth authorize URL (freshness-gated, swap-account-aware transcript read). An
-  // OAuth flow is human-only, so autopilot stands down until the operator completes it. Fresh
-  // read (not off an event) so onDone/consider re-checks are deterministic. Guarded → null.
+  // Pending human-only OAuth authorize URL — autopilot stands down until the operator completes
+  // it. A fresh read (not off an event) so onDone/consider re-checks are deterministic. TWO
+  // independent sources, first hit wins: the swap-account-aware transcript (MCP OAuth,
+  // freshness-gated) and, failing that, a fresh PTY visible read reconstructing a `/login`
+  // account-re-login URL (PTY-only — never in the transcript). The `claudeSessionId` precondition
+  // gates ONLY the transcript branch, so a `/login` session still reaches the PTY fallback.
   pendingAuthUrl: (id) => {
     const s = store.get(id);
-    if (!s?.claudeSessionId) return null;
-    try {
-      return detectPendingAuthUrl(
-        readTranscriptTail(jsonlPathFor(s.worktreePath, s.claudeSessionId, s.spawnAccountDir)),
-      );
-    } catch {
-      return null;
+    if (!s) return null;
+    if (s.claudeSessionId) {
+      try {
+        const u = detectPendingAuthUrl(
+          readTranscriptTail(jsonlPathFor(s.worktreePath, s.claudeSessionId, s.spawnAccountDir)),
+        );
+        if (u) return u;
+      } catch {
+        // transcript missing/unreadable → fall through to the PTY source
+      }
     }
+    const v = readVisibleBuffer(id); // PTY-only `/login` URL (guarded → null when herdr is down)
+    return v === null ? null : detectLoginAuthUrl(v);
   },
   // Any PR (open/merged/closed) stands autopilot down — only a session with NO PR yet is its
   // territory. `state` is "none" when no PR exists; anything else means one does.

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -18,7 +18,7 @@ import { DEFAULT_STALL } from "./stall";
 import { jsonlPathFor } from "./usage";
 import { readTranscriptSignals, STRIP_WINDOW_MS, type SessionActivity } from "./activity-signal";
 import { readTranscriptTail } from "./activity";
-import { detectAuthUrl, detectPendingAuthUrl } from "./auth-url";
+import { detectAuthUrl, detectPendingAuthUrl, detectLoginAuthUrl } from "./auth-url";
 import { statSync } from "node:fs";
 import { classifyHalt, assistantSideText } from "./usage-halt";
 import type { UsageLimits } from "./usage-limits";
@@ -154,6 +154,22 @@ export class StatusPoller {
   /** Transcript mtime at the last resting-auth probe per session — gates `maybeAuthAtRest`'s
    *  bounded read to ticks where the transcript actually changed (see AUTH_SIG). */
   private lastAuthMtime = new Map<string, number | null>();
+  /** Resting-auth (done/idle) caches — see `maybeAuthAtRest`. Two independent sources feed one
+   *  AUTH_SIG banner; each keeps its own cost gate and neither cross-clears the other. All pruned
+   *  in `pruneInactive`; the detection caches are additionally dropped on the leave-resting edge.
+   *   - `restAuthTxn`: last transcript `{url,tail}` (MCP-at-rest), refreshed only on mtime change.
+   *   - `restAuthPtyObserved`: last resolved PTY reconstruction url — the stability comparand.
+   *   - `restAuthPtyConfirmed`: a PTY reconstruction confirmed by two consecutive equal reads
+   *     (absent ⇒ none). The `/login` URL is PTY-only; the two-read gate stops a still-painting
+   *     partial (that happens to pass isAuthUrl) from latching past the value-blind AUTH_SIG.
+   *   - `lastAuthPtyAt`: throttle stamp for the async PTY visible-buffer probe.
+   *   - `lastAuthUrlEmitted`: the authUrl currently shown, for value-aware AUTH re-emit (AUTH_SIG
+   *     itself is value-blind, so a corrected URL would otherwise be suppressed). */
+  private restAuthTxn = new Map<string, { url: string | null; tail: string[] }>();
+  private restAuthPtyObserved = new Map<string, string | null>();
+  private restAuthPtyConfirmed = new Map<string, { url: string; tail: string[] }>();
+  private lastAuthPtyAt = new Map<string, number>();
+  private lastAuthUrlEmitted = new Map<string, string>();
   private lastProbeAt = new Map<string, number>();
   private lastActivitySig = new Map<string, string>();
   private lastActivity = new Map<string, SessionActivity>();
@@ -527,6 +543,7 @@ export class StatusPoller {
       this.lastSuppressVisible.delete(s.id);
       if (this.workingWhileBlocked.delete(s.id)) this.onWorkingBlocked(s.id, false);
     }
+    this.onLeaveResting(s.id, s.status, status);
     // Phase-1 push block-trigger (issue #704): a Notification awaiting-input edge
     // can classify THIS tick even before herdr latches "blocked". When it handles the
     // session (announced a block), short-circuit so the normal routing below doesn't
@@ -652,6 +669,11 @@ export class StatusPoller {
       ...this.lastSig.keys(),
       ...this.lastReadAt.keys(),
       ...this.lastAuthMtime.keys(),
+      ...this.restAuthTxn.keys(),
+      ...this.restAuthPtyObserved.keys(),
+      ...this.restAuthPtyConfirmed.keys(),
+      ...this.lastAuthPtyAt.keys(),
+      ...this.lastAuthUrlEmitted.keys(),
       ...this.lastProbeAt.keys(),
       ...this.lastActivitySig.keys(),
       ...this.lastActivity.keys(),
@@ -670,6 +692,11 @@ export class StatusPoller {
         this.lastReadAt.delete(id);
         this.lastSig.delete(id);
         this.lastAuthMtime.delete(id);
+        this.restAuthTxn.delete(id);
+        this.restAuthPtyObserved.delete(id);
+        this.restAuthPtyConfirmed.delete(id);
+        this.lastAuthPtyAt.delete(id);
+        this.lastAuthUrlEmitted.delete(id);
         this.lastBlockReason.delete(id);
         this.lastProbeAt.delete(id);
         this.lastActivitySig.delete(id);
@@ -1030,7 +1057,17 @@ export class StatusPoller {
     // reclassifyMs gate above. `authUrl` is part of `reason`, so it rides the lastSig dedup
     // and the block snapshot for free; null ⇒ field omitted (not an auth prompt).
     if (reason.shape === "awaiting-input") {
-      const authUrl = this.detectAuth(s);
+      // Transcript first (MCP OAuth). If none, fall back to reconstructing a `/login` account URL
+      // from the visible buffer we already read — covers a login modal herdr happens to classify
+      // as `blocked`. Run it through the SAME two-read stability gate as the resting path
+      // (`confirmLoginUrl`) so a mid-paint truncated authorize URL never surfaces for a cadence.
+      // Cache the REAL tail (`reason.tail`, i.e. `tailLines(visible)`), not a placeholder: the
+      // confirmed cache is shared with the resting path, and a `blocked → idle` transition (not a
+      // leave-resting edge, so caches persist) inherits this entry — an empty tail would surface a
+      // context-less banner that the URL-keyed re-emit gate never corrects.
+      const authUrl =
+        this.detectAuth(s) ??
+        this.confirmLoginUrl(id, { url: detectLoginAuthUrl(visible), tail: reason.tail })?.url;
       if (authUrl) reason.authUrl = authUrl;
     }
     const sig = JSON.stringify(reason);
@@ -1086,6 +1123,9 @@ export class StatusPoller {
   private clearBlock(id: string): void {
     this.liveness.get(id)?.clearTranscriptBaseline(); // reset the stall liveness baseline regardless of block state
     this.lastSuppressVisible.delete(id); // and the spinner-suppression episode baseline
+    // The shown-auth-URL marker follows the block (not the detection caches, which the
+    // leave-resting edge owns) — drop it so the next auth block re-emits cleanly.
+    this.lastAuthUrlEmitted.delete(id);
     if (!this.lastSig.has(id)) return;
     this.lastSig.delete(id);
     this.lastReadAt.delete(id);
@@ -1135,17 +1175,129 @@ export class StatusPoller {
    */
   private maybeAuthAtRest(s: Session): boolean {
     const id = s.id;
-    const standing = this.lastSig.get(id) === AUTH_SIG;
-    const mtime = this.authMtime(s);
-    if (this.lastAuthMtime.has(id) && mtime === this.lastAuthMtime.get(id)) return standing;
-    this.lastAuthMtime.set(id, mtime);
-    const { url, tail } = this.detectRestingAuth(s);
-    if (!url) return false;
-    if (!standing) {
+    // Transcript source (MCP-at-rest) takes precedence; the PTY source (`/login`) is consulted
+    // only when the transcript has no URL. Each helper owns its own cost gate.
+    const txn = this.restingTxnAuth(s);
+    const src = txn.url ? txn : this.restingPtyAuth(id, s.herdrAgentId);
+    if (!src.url) return false; // neither source pending → caller (maybeQuota) clears the block
+
+    // Emit on first stand OR when the URL changed (AUTH_SIG is value-blind, so track the shown
+    // URL and re-emit on a correction). A standing, unchanged URL dedupes to a no-op.
+    if (this.lastSig.get(id) !== AUTH_SIG || this.lastAuthUrlEmitted.get(id) !== src.url) {
       this.lastSig.set(id, AUTH_SIG);
-      this.emitBlock(id, { shape: "awaiting-input", options: [], tail, authUrl: url });
+      this.lastAuthUrlEmitted.set(id, src.url);
+      this.emitBlock(id, {
+        shape: "awaiting-input",
+        options: [],
+        tail: src.tail,
+        authUrl: src.url,
+      });
     }
     return true;
+  }
+
+  /** Transcript (MCP-at-rest) auth source: re-read only on transcript-mtime change; cached. */
+  private restingTxnAuth(s: Session): { url: string | null; tail: string[] } {
+    const id = s.id;
+    const mtime = this.authMtime(s);
+    if (!this.lastAuthMtime.has(id) || mtime !== this.lastAuthMtime.get(id)) {
+      this.lastAuthMtime.set(id, mtime);
+      this.restAuthTxn.set(id, this.detectRestingAuth(s));
+    }
+    return this.restAuthTxn.get(id) ?? { url: null, tail: [] };
+  }
+
+  /**
+   * PTY (`/login`) auth source: the URL is PTY-only and never bumps the transcript mtime, so probe
+   * the visible buffer on its own throttle (`reclassifyMs`). The read is ASYNC (`readAsync` — the
+   * poll-loop convention; a sync read under the resting-session fan-out would freeze the live web
+   * terminal) and fire-and-forget: `probePtyAuth` resolves into the observed/confirmed caches, and
+   * this returns the currently CONFIRMED reconstruction (two equal reads) for the tick to consume.
+   */
+  private restingPtyAuth(id: string, term: string): { url: string | null; tail: string[] } {
+    // Cheap pre-guard: a `/login` modal requires a LIVE claude process, so skip the read (and drop
+    // any stale confirmation) for a husk session whose claude has exited — bounds the added
+    // per-cadence herdr reads to resting sessions that could actually be at a prompt. `undefined`
+    // (not yet swept) is treated as maybe-alive so detection isn't missed before the first sweep.
+    if (this.lastClaudeAlive.get(id) === false) {
+      this.restAuthPtyObserved.delete(id);
+      this.restAuthPtyConfirmed.delete(id);
+      return { url: null, tail: [] };
+    }
+    const t = this.now();
+    if (t - (this.lastAuthPtyAt.get(id) ?? 0) >= this.reclassifyMs) {
+      this.lastAuthPtyAt.set(id, t);
+      void this.probePtyAuth(id, term);
+    }
+    return this.restAuthPtyConfirmed.get(id) ?? { url: null, tail: [] };
+  }
+
+  /**
+   * Async PTY probe for `maybeAuthAtRest`'s login source: read the visible buffer, reconstruct a
+   * word-wrapped `/login` authorize URL, and run it through the shared stability gate. Fire-and-
+   * forget (mirrors `maybeProbe`'s interim `readAsync().then()`); `confirmLoginUrl` resolves it
+   * into the observed/confirmed caches the tick consumes.
+   */
+  private async probePtyAuth(id: string, term: string): Promise<void> {
+    try {
+      const v = await this.herdr.readAsync(term, "visible");
+      this.confirmLoginUrl(id, { url: detectLoginAuthUrl(v), tail: tailLines(v) });
+    } catch {
+      // best-effort; retry next cadence
+    }
+  }
+
+  /**
+   * Two-read stability gate for a reconstructed `/login` URL, shared by the resting (async) and
+   * blocked (sync) paths so NEITHER surfaces a still-painting partial. Records `recon` as the
+   * latest observation and returns/caches a confirmed URL only once it equals the immediately-
+   * preceding reconstruction (two consecutive equal reads — a first, still-painting URL that
+   * passes `isAuthUrl` while truncated never latches). A NULL reconstruction (panel gone) clears
+   * the confirmation IMMEDIATELY (no second read): the real completion path, since a finished
+   * `/login` commonly returns to idle/done without a running/blocked edge. While unstable it
+   * returns any PRIOR confirmation (value-aware correction still lands once the new URL confirms).
+   */
+  private confirmLoginUrl(
+    id: string,
+    recon: { url: string | null; tail: string[] },
+  ): { url: string; tail: string[] } | null {
+    const prev = this.restAuthPtyObserved.get(id);
+    this.restAuthPtyObserved.set(id, recon.url);
+    if (recon.url === null) {
+      this.restAuthPtyConfirmed.delete(id);
+      return null;
+    }
+    if (prev === recon.url) {
+      const confirmed = { url: recon.url, tail: recon.tail };
+      this.restAuthPtyConfirmed.set(id, confirmed);
+      return confirmed;
+    }
+    return this.restAuthPtyConfirmed.get(id) ?? null;
+  }
+
+  /**
+   * Leave-resting edge (idle/done → running/blocked): drop the resting-auth DETECTION caches so a
+   * resumed-then-re-rested session re-probes fresh and never re-emits a stale confirmed `/login`
+   * URL. Hygiene only — the banner CLEAR itself is driven by a null PTY read (a completed `/login`
+   * often returns to idle/done without ever flipping to running/blocked, so this edge would not
+   * fire for it). Kept OUT of `clearBlock` on purpose: `maybeQuota` calls `clearBlock` every
+   * resting tick with no auth, and resetting the throttle/stability there would defeat the
+   * two-read gate (see `maybeAuthAtRest`).
+   */
+  private onLeaveResting(id: string, prev: Session["status"], next: Session["status"]): void {
+    const leaving =
+      (next === "running" || next === "blocked") && (prev === "idle" || prev === "done");
+    if (leaving) this.clearRestingAuthState(id);
+  }
+
+  /** Drop the resting-auth DETECTION caches for a session (leave-resting edge + prune). Does NOT
+   *  touch the standing block or `lastAuthUrlEmitted` — those follow the block via `clearBlock`. */
+  private clearRestingAuthState(id: string): void {
+    this.restAuthTxn.delete(id);
+    this.restAuthPtyObserved.delete(id);
+    this.restAuthPtyConfirmed.delete(id);
+    this.lastAuthPtyAt.delete(id);
+    this.lastAuthMtime.delete(id);
   }
 
   /**

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -2993,3 +2993,219 @@ test("clears the auth block at rest when the URL is answered (mtime bump, no run
   expect(h.blocks[1]!.block).toBeNull();
   expect(h.poller.blockSnapshot()[h.id]).toBeUndefined();
 });
+
+// ── Resting-session (done/idle) `/login` account-URL detection (PTY-only source) ──────────
+// The Claude Code `/login` flow prints its authorize URL ONLY to the PTY (never the transcript),
+// so the transcript `detectRestingAuth` yields null and detection falls to a throttled async
+// visible-buffer read gated by a two-read stability check (a half-painted URL must never latch).
+const LOGIN_FULL =
+  "https://claude.com/cai/oauth/authorize?response_type=code&code_challenge=abc123&state=xyz789";
+// A still-painting prefix — truncated but still an isAuthUrl-valid `/…/authorize` URL.
+const LOGIN_PARTIAL = "https://claude.com/cai/oauth/authorize?response_type=cod";
+const loginPanel = (url: string) => `─────\n  Login\n\n${url}\n\n  Paste code here if prompted >`;
+
+function doneLoginHarness() {
+  const store = new SessionStore(":memory:");
+  const s = store.create(baseSession);
+  const blocks: { id: string; block: unknown }[] = [];
+  let visible = "";
+  let readCalls = 0;
+  let agentStatus = "done";
+  const herdr = {
+    list: (): HerdrAgent[] => [
+      {
+        agent: "claude",
+        agentStatus,
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        name: "",
+        terminalId: "term_a",
+        workspaceId: "w",
+      } as HerdrAgent,
+    ],
+    read: () => visible, // sync read drives the blocked path (maybeClassify)
+    readAsync: () => {
+      readCalls++;
+      return Promise.resolve(visible);
+    },
+  };
+  let clock = 100_000;
+  let alive = true; // a /login modal implies a live claude; the pre-guard skips husk sessions
+  const poller = new StatusPoller(
+    store,
+    herdr as any,
+    () => {},
+    (id, block) => blocks.push({ id, block }),
+    1000,
+    3000,
+    classifyBlocked,
+    () => clock,
+    undefined, // probe
+    undefined, // stallCfg
+    undefined, // probeCheckMs
+    undefined, // onReady
+    undefined, // onActivity
+    undefined, // preview
+    // liveness: reflect the mutable `alive` flag every tick (sweepMs 0) instead of scanning /proc
+    { scan: (wts) => new Map(wts.map((w) => [w, alive])), sweepMs: 0, onChange: () => {} },
+  );
+  poller.authMtime = () => 100; // stable transcript mtime
+  poller.detectRestingAuth = () => ({ url: null, tail: [] }); // no transcript URL → force PTY source
+  return {
+    store,
+    id: s.id,
+    blocks,
+    poller,
+    advance: (ms: number) => (clock += ms),
+    setVisible: (v: string) => (visible = v),
+    setStatus: (st: string) => (agentStatus = st),
+    setAlive: (a: boolean) => (alive = a),
+    readCalls: () => readCalls,
+  };
+}
+
+/** Drive N throttled probe cadences (advance past reclassifyMs each), resolving each async read. */
+async function settleLogin(h: ReturnType<typeof doneLoginHarness>, times = 4) {
+  for (let i = 0; i < times; i++) {
+    h.advance(3000);
+    h.poller.tick();
+    await flush();
+  }
+}
+
+test("surfaces a /login authorize URL from the PTY after two equal reads (stability gate)", async () => {
+  const h = doneLoginHarness();
+  h.setVisible(loginPanel(LOGIN_FULL));
+  await settleLogin(h);
+  const emitted = h.blocks.filter((b) => b.block !== null);
+  expect(emitted).toHaveLength(1);
+  expect((emitted[0]!.block as any).shape).toBe("awaiting-input");
+  expect((emitted[0]!.block as any).authUrl).toBe(LOGIN_FULL);
+  expect(h.poller.blockSnapshot()[h.id]?.authUrl).toBe(LOGIN_FULL);
+});
+
+test("never emits a still-painting partial URL (emits the full URL once it stabilizes)", async () => {
+  const h = doneLoginHarness();
+  h.setVisible(loginPanel(LOGIN_PARTIAL));
+  h.advance(3000);
+  h.poller.tick();
+  await flush(); // read #1 = PARTIAL (observed, unconfirmed)
+  h.setVisible(loginPanel(LOGIN_FULL)); // paint completed before the next read
+  await settleLogin(h);
+  const emitted = h.blocks.filter((b) => b.block !== null);
+  expect(emitted.length).toBeGreaterThanOrEqual(1);
+  expect(emitted.every((b) => (b.block as any).authUrl === LOGIN_FULL)).toBe(true);
+  // the truncated prefix must never have surfaced
+  expect(h.blocks.some((b) => (b.block as any)?.authUrl === LOGIN_PARTIAL)).toBe(false);
+});
+
+test("clears the /login banner on a no-URL read, with NO running/blocked transition", async () => {
+  const h = doneLoginHarness();
+  h.setVisible(loginPanel(LOGIN_FULL));
+  await settleLogin(h);
+  expect(h.blocks.filter((b) => b.block !== null)).toHaveLength(1); // banner up
+  // login completes → panel gone, but the session STAYS done (no running edge fires)
+  h.setVisible("  Some other screen\n  no url here");
+  await settleLogin(h);
+  expect(h.blocks[h.blocks.length - 1]!.block).toBeNull();
+  expect(h.poller.blockSnapshot()[h.id]).toBeUndefined();
+});
+
+test("does not read the PTY while a transcript (MCP) URL stands", () => {
+  const h = doneLoginHarness();
+  h.poller.detectRestingAuth = () => ({ url: AUTH_URL, tail: [] }); // transcript owns the banner
+  h.poller.tick();
+  expect(h.readCalls()).toBe(0); // PTY source never consulted
+  expect((h.blocks[0]!.block as any).authUrl).toBe(AUTH_URL);
+});
+
+test("throttles the PTY probe to one read per reclassify cadence", async () => {
+  const h = doneLoginHarness();
+  h.setVisible(loginPanel(LOGIN_FULL));
+  h.poller.tick();
+  await flush(); // read #1
+  h.poller.tick();
+  await flush(); // same clock → throttled, no read
+  h.poller.tick();
+  await flush();
+  expect(h.readCalls()).toBe(1);
+  h.advance(3000);
+  h.poller.tick();
+  await flush(); // cadence elapsed → read #2
+  expect(h.readCalls()).toBe(2);
+});
+
+test("drops the confirmed /login cache on the leave-resting edge (no phantom re-emit)", async () => {
+  const h = doneLoginHarness();
+  h.setVisible(loginPanel(LOGIN_FULL));
+  await settleLogin(h);
+  expect(h.blocks.filter((b) => b.block !== null)).toHaveLength(1); // banner up
+  // agent resumes → the leave-resting edge drops the detection caches
+  h.setStatus("working");
+  h.advance(3000);
+  h.poller.tick();
+  await flush();
+  // immediately re-rested: a single tick can only RE-OBSERVE (one read), never RE-CONFIRM, so the
+  // stale FULL URL must not instantly re-emit.
+  h.setStatus("done");
+  const mark = h.blocks.length;
+  h.advance(3000);
+  h.poller.tick();
+  await flush();
+  expect(h.blocks.slice(mark).some((b) => (b.block as any)?.authUrl === LOGIN_FULL)).toBe(false);
+});
+
+test("blocked path: reconstructs a /login URL from the visible buffer (after two reads, no partial)", () => {
+  const h = spinnerHarness(loginPanel(LOGIN_FULL));
+  (h.poller as any).detectAuth = () => null; // no transcript URL
+  h.poller.tick(); // read #1 → awaiting-input block, URL observed but NOT yet confirmed
+  expect((h.blocks[0]!.block as any).shape).toBe("awaiting-input");
+  expect((h.blocks[0]!.block as any).authUrl).toBeUndefined();
+  h.advance(3000);
+  h.poller.tick(); // read #2 → confirmed → authUrl attached (re-emits, sig now includes authUrl)
+  const last = h.blocks[h.blocks.length - 1]!.block as any;
+  expect(last.authUrl).toBe(LOGIN_FULL);
+  // never a truncated partial
+  expect(
+    h.blocks.every((b) => {
+      const u = (b.block as any)?.authUrl;
+      return u === undefined || u === LOGIN_FULL;
+    }),
+  ).toBe(true);
+});
+
+test("blocked→idle inheritance surfaces the AUTH banner with a real (non-empty) tail", async () => {
+  const h = doneLoginHarness();
+  h.setVisible(loginPanel(LOGIN_FULL));
+  (h.poller as any).detectAuth = () => null; // no transcript URL → PTY reconstruction
+  // Blocked: two reads confirm the /login URL (blocked path caches into the shared confirmed map).
+  h.setStatus("blocked");
+  h.poller.tick();
+  h.advance(3000);
+  h.poller.tick();
+  await flush();
+  // blocked → idle: NOT a leave-resting edge, so the confirmed cache persists and the resting
+  // path inherits it. The inherited banner must carry the real login-panel tail, not a placeholder.
+  h.setStatus("idle");
+  h.advance(3000);
+  h.poller.tick();
+  await flush();
+  const authBlocks = h.blocks.filter((b) => (b.block as any)?.authUrl === LOGIN_FULL);
+  expect(authBlocks.length).toBeGreaterThan(0);
+  expect((authBlocks[authBlocks.length - 1]!.block as any).tail.length).toBeGreaterThan(0);
+});
+
+test("stops probing the PTY once a resting session's claude is known dead (husk)", () => {
+  const h = doneLoginHarness();
+  h.setVisible(loginPanel(LOGIN_FULL));
+  h.setAlive(false); // no live claude → no /login modal possible
+  h.poller.tick(); // cold tick: the post-loop liveness sweep records claude-dead
+  const afterPrime = h.readCalls(); // the cold tick probes once before the sweep runs (undefined=maybe)
+  h.advance(3000);
+  h.poller.tick();
+  h.advance(3000);
+  h.poller.tick();
+  expect(h.readCalls()).toBe(afterPrime); // no further PTY reads once known dead
+  expect(h.blocks.filter((b) => b.block !== null)).toHaveLength(0); // never surfaced a banner
+});


### PR DESCRIPTION
## Problem

The Claude Code **`/login`** (account re-login) flow prints an OAuth authorize URL that Shepherd never surfaces in the auth banner — even though **MCP OAuth works** (fixed in #1441). Reported: "Claude login URL still not recognized and displayed in bar."

## Root cause (confirmed via live repro)

A session sitting at `/login` reports herdr `agent_status: "done"` → it routes through `maybeQuota` → `maybeAuthAtRest`, which reads the **JSONL transcript only**. But `/login` is a slash-command TUI modal: its authorize URL is emitted **only to the PTY** (hard-wrapped at terminal width, no inserted spaces), and **never** lands in the conversation transcript. So both transcript detectors (`maybeClassify`'s `detectAuth` and `maybeAuthAtRest`'s `detectRestingAuth`) can't see it. MCP OAuth works because those URLs *do* appear in the transcript.

The banner UI and autopilot's `onBlock`→`authPending` stand-down already exist and are source-agnostic — **the gap is purely detection.**

## Change

- **`detectLoginAuthUrl(visible)`** (`auth-url.ts`): reconstruct the word-wrapped URL from a terminal visible buffer. Anchors on the first `https` line, strips ANSI + box-drawing borders per line, and joins whole whitespace-free continuation lines — **evaluating STOP before APPEND** so a trailing panel line (`Paste code here…`, even with no blank line) can't graft onto an otherwise-valid authorize URL. Validated by the existing `isAuthUrl`.
- **Resting path** (`maybeAuthAtRest`): a second, PTY source independent of the mtime-gated transcript source — an **async `readAsync`** (the poll-loop convention; a sync read under the resting-session fan-out would freeze the web terminal), throttled to `reclassifyMs`, only when the transcript has no URL. A reconstruction is emitted **only after two consecutive equal reads** (a half-painted, `isAuthUrl`-valid partial must not latch past the value-blind `AUTH_SIG`), the emit is **value-aware** (re-emits on a correction), and a **null read clears immediately** — the real completion path, since a finished `/login` returns to idle/done without a running/blocked edge. Detection caches clear on the leave-resting edge (kept out of `clearBlock`, whose per-tick resting calls would defeat the throttle/stability gate).
- **Blocked path** (`maybeClassify`): the same fallback (visible buffer already in hand), for a login modal herdr happens to classify as `blocked`.
- **Autopilot** (`index.ts`): the deterministic `pendingAuthUrl` stand-down seam gains a fresh PTY fallback so `onDone`/`consider` stand down on `/login` without racing the throttled banner emit — restructured so the `claudeSessionId` guard gates **only** the transcript branch. Factored a shared `readVisibleBuffer` helper (also used by `readTail`).

No UI changes: the banner + copy ("Authorize in your browser to continue") and autopilot stand-down are reused unchanged.

## Tests

- `auth-url.test.ts`: byte-faithful capture of a real `herdr.read(visible)` `/login` panel → full URL; box-bordered wrap; leading prefix; **STOP-before-APPEND** (Paste line with no blank line, plain + bordered); unwrapped; non-auth URL; scrollback.
- `poller.test.ts`: PTY URL surfaces after two equal reads; **partial never emitted**; **null read clears with no running/blocked transition**; PTY skipped while a transcript URL stands; throttle respected; leave-resting cache clear; blocked-path fallback.

## Verification

`bun run typecheck`, `bun run lint`, `bun run test` (6051 pass / 0 fail), and `fallow audit` (no issues in changed files) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)