### PR TITLE
fix(diagnostics): retry gh auth probe, stop false "not logged in"

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -63,6 +63,16 @@ export const DIAGNOSTICS_TTL_MS = 60_000;
 // Per-probe exec timeout: a timed-out probe RESOLVES to its defined non-OK state
 // (never rejects the Promise.all), so one hung binary can't stall the batch.
 export const DIAGNOSTICS_PROBE_TIMEOUT_MS = 5_000;
+// gh auth probe hardening (#623 follow-up): `gh auth status` reads the token from the OS
+// keyring, so a locked keyring / D-Bus stall / cold `gh` under load can transiently blow
+// the probe budget and — pre-fix — masquerade as "not logged in". The probe now RETRIES a
+// timed-out attempt and only reports a hard-auth error when gh actually exits with a
+// verdict. A dedicated, SHORTER per-attempt timeout keeps the bounded retry loop from
+// stalling the batch: GH_PROBE_ATTEMPTS × GH_PROBE_TIMEOUT_MS (+ delays) ≈ 6.25s worst case,
+// vs. 3×5s if it reused DIAGNOSTICS_PROBE_TIMEOUT_MS. Healthy gh answers in ~0.25s.
+export const GH_PROBE_ATTEMPTS = 2;
+export const GH_PROBE_TIMEOUT_MS = 3_000;
+export const GH_PROBE_RETRY_DELAY_MS = 250;
 // Time budget for an in-app remediation command (POST /api/diagnostics/fix). Far
 // larger than a probe — these are real `curl | bash` installs. On timeout the whole
 // process GROUP is SIGKILLed (see diagnostics.ts runRemediation) so no reparented

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -4,6 +4,9 @@ import {
   BUN_MIN_VERSION,
   DIAGNOSTICS_PROBE_TIMEOUT_MS,
   DIAGNOSTICS_TTL_MS,
+  GH_PROBE_ATTEMPTS,
+  GH_PROBE_RETRY_DELAY_MS,
+  GH_PROBE_TIMEOUT_MS,
   HERDR_MIN_VERSION,
   NODE_MIN_VERSION,
   REMEDIATION_TIMEOUT_MS,
@@ -22,6 +25,42 @@ const execFileAsync = promisify(execFile);
  *  capture. Kept local so the regex's lastIndex state is never shared. */
 const SEMVER_RE = /(\d+\.\d+\.\d+)/;
 
+/** Resolve after `ms` — used to space out the gh probe's bounded retries. */
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** True when a rejected probe was KILLED (timeout → SIGTERM) rather than having exited
+ *  with its own status. execFile's timeout path sets `killed:true` + a `signal`; a normal
+ *  non-zero exit sets neither. This is how `ghProbe` tells a transient stall (retry, then
+ *  "couldn't verify") apart from a real auth verdict (error) — no stdout/stderr parsing. */
+function isTransientProbeFailure(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const e = err as NodeJS.ErrnoException & { killed?: boolean; signal?: string };
+  return e.killed === true || (typeof e.signal === "string" && e.signal.length > 0);
+}
+
+/** A spawn that failed because the binary isn't on PATH. */
+function isEnoent(err: unknown): boolean {
+  return !!err && typeof err === "object" && (err as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+/** Map a non-ok gh outcome: the given (state, hintKey) when a forge-mode repo needs gh,
+ *  else a soft `not_required` warning (gh is optional when all repos are lightweight). */
+function ghFailure(forge: boolean, state: DiagnosticState, hintKey: string): DiagnosticCheck {
+  return forge
+    ? { id: "gh", state, hintKey }
+    : { id: "gh", state: "warning", hintKey: "diagnostics_hint_gh_not_required" };
+}
+
+/** Log a timed-out gh probe using ONLY its disposition — never stderr/stdout/message,
+ *  which can carry the logged-in account identity. */
+function logGhUnverified(err: unknown, attempts: number): void {
+  const e = (err ?? {}) as NodeJS.ErrnoException & { killed?: boolean; signal?: string };
+  console.warn(
+    `[diagnostics] gh auth status could not be verified after ${attempts} attempts` +
+      ` (timed out; code=${String(e.code)} killed=${String(e.killed)} signal=${String(e.signal)})`,
+  );
+}
+
 /**
  * Injectable child-process runners. Each defaults to an async `execFile` with a
  * per-probe timeout (`DIAGNOSTICS_PROBE_TIMEOUT_MS`) — **never** `execFileSync`,
@@ -33,8 +72,17 @@ export interface DiagnosticsDeps {
    *  plus the `which`/presence checks. Reject (incl. timeout) ⇒ binary absent. */
   runVersion?: (bin: string, args: string[]) => Promise<string>;
   /** Run `gh auth status`; resolves on a zero exit, rejects on non-zero / timeout.
-   *  Its stdout is intentionally discarded (it carries account identity). */
+   *  Its stdout is intentionally discarded (it carries account identity). On rejection
+   *  the error's `code` / `killed` / `signal` classify the failure (see `ghProbe`):
+   *  a killed/signalled reject = a transient timeout, a plain non-zero exit = a real
+   *  auth verdict. */
   runGhAuth?: () => Promise<void>;
+  /** Attempts for the gh probe's bounded retry loop (default `GH_PROBE_ATTEMPTS`).
+   *  Injected so tests exercise the retry/exhaustion paths deterministically. */
+  ghProbeAttempts?: number;
+  /** Delay between gh probe retries in ms (default `GH_PROBE_RETRY_DELAY_MS`). Tests
+   *  pass 0 so a retried-failure case adds no real wall-time. */
+  ghProbeRetryDelayMs?: number;
   /** This node's tailnet hostname, or null when tailscale is absent / not logged
    *  in. Defaults to the shared `resolveNodeHost`. */
   resolveHost?: () => Promise<string | null>;
@@ -133,6 +181,8 @@ export function defaultRunRemediation(
 export class DiagnosticsService {
   private runVersion: (bin: string, args: string[]) => Promise<string>;
   private runGhAuth: () => Promise<void>;
+  private ghProbeAttempts: number;
+  private ghProbeRetryDelayMs: number;
   private resolveHost: () => Promise<string | null>;
   private runServeStatus: () => Promise<string>;
   private runRemediation: (cmd: string) => Promise<void>;
@@ -155,11 +205,17 @@ export class DiagnosticsService {
       deps.runGhAuth ??
       (async () => {
         // exit code only — stdout (which carries the logged-in account) is dropped.
+        // A dedicated, shorter timeout than the generic probe budget keeps the retry
+        // loop bounded (see config `GH_PROBE_*`). On timeout execFile SIGTERMs the child,
+        // so the reject carries `killed:true` / `signal` — `ghProbe` reads that to tell a
+        // transient stall apart from a real non-zero auth verdict.
         await execFileAsync("gh", ["auth", "status"], {
           encoding: "utf8",
-          timeout: DIAGNOSTICS_PROBE_TIMEOUT_MS,
+          timeout: GH_PROBE_TIMEOUT_MS,
         });
       });
+    this.ghProbeAttempts = deps.ghProbeAttempts ?? GH_PROBE_ATTEMPTS;
+    this.ghProbeRetryDelayMs = deps.ghProbeRetryDelayMs ?? GH_PROBE_RETRY_DELAY_MS;
     this.resolveHost = deps.resolveHost ?? (() => resolveNodeHost());
     this.runServeStatus =
       deps.runServeStatus ??
@@ -227,28 +283,48 @@ export class DiagnosticsService {
       : { id: "git", state: "error", hintKey: "diagnostics_hint_git_missing" };
   };
 
-  /** gh: presence + `gh auth status` exit code (NEVER its stdout). ENOENT ⇒
-   *  binary missing; non-zero exit ⇒ not authenticated. Timeout propagates to the
-   *  `probes()` catch which resolves to `diagnostics_hint_gh_not_authenticated`.
-   *  When no forge-mode repos are configured, failures downgrade to warnings — gh
-   *  is optional when all repos are lightweight. */
+  /** gh: presence + `gh auth status` disposition (NEVER its stdout). The probe is the
+   *  reported false-alarm surface — `gh auth status` reads the token from the OS keyring,
+   *  so a locked keyring / D-Bus stall / cold `gh` under load can transiently time out and
+   *  used to render as a hard "not logged in". So it now RETRIES (bounded) and classifies
+   *  by HOW the last attempt failed rather than what it printed:
+   *    • success on any attempt ⇒ ok;
+   *    • ENOENT ⇒ binary missing (deterministic, no retry);
+   *    • timed-out / killed on every attempt (`killed`/`signal` set — gh never rendered a
+   *      verdict) ⇒ a soft, honest `gh_unverified` warning + a server-side log of the
+   *      disposition only (never stderr/stdout/identity);
+   *    • otherwise (gh exited with a non-zero verdict: logged-out / invalid token / bad
+   *      scopes) ⇒ the actionable `gh_not_authenticated` error.
+   *  When no forge-mode repos are configured, every non-ok outcome downgrades to a
+   *  `not_required` warning — gh is optional when all repos are lightweight. */
   private ghProbe = async (): Promise<DiagnosticCheck> => {
-    try {
-      await this.runGhAuth();
-      return { id: "gh", state: "ok", hintKey: "diagnostics_hint_gh_ok" };
-    } catch (err) {
-      const forgeRequired = this.anyForgeRepo();
-      if (err && typeof err === "object" && (err as NodeJS.ErrnoException).code === "ENOENT") {
-        if (!forgeRequired) {
-          return { id: "gh", state: "warning", hintKey: "diagnostics_hint_gh_not_required" };
-        }
-        return { id: "gh", state: "error", hintKey: "diagnostics_hint_gh_missing" };
+    const forge = this.anyForgeRepo();
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= this.ghProbeAttempts; attempt++) {
+      try {
+        await this.runGhAuth();
+        return { id: "gh", state: "ok", hintKey: "diagnostics_hint_gh_ok" };
+      } catch (err) {
+        lastErr = err;
+        // Binary missing is deterministic — no point retrying.
+        if (isEnoent(err)) return ghFailure(forge, "error", "diagnostics_hint_gh_missing");
+        // Only a killed/timed-out failure is worth retrying; a non-zero EXIT is gh's
+        // deterministic auth verdict, so probing it again would just delay the same answer.
+        if (!isTransientProbeFailure(err)) break;
+        if (attempt < this.ghProbeAttempts) await delay(this.ghProbeRetryDelayMs);
       }
-      if (!forgeRequired) {
-        return { id: "gh", state: "warning", hintKey: "diagnostics_hint_gh_not_required" };
-      }
-      return { id: "gh", state: "error", hintKey: "diagnostics_hint_gh_not_authenticated" };
     }
+    // A killed/signalled reject means gh never finished (transient timeout) — report the
+    // soft "couldn't verify" state, not a false "not logged in". Otherwise gh exited with a
+    // real non-zero verdict ⇒ actionable auth failure.
+    if (isTransientProbeFailure(lastErr)) {
+      // Log only when the warning actually surfaces (a forge repo needs gh); a
+      // lightweight-only host downgrades to a benign not_required and shouldn't emit a
+      // "could not be verified" line for a state the user never sees.
+      if (forge) logGhUnverified(lastErr, this.ghProbeAttempts);
+      return ghFailure(forge, "warning", "diagnostics_hint_gh_unverified");
+    }
+    return ghFailure(forge, "error", "diagnostics_hint_gh_not_authenticated");
   };
 
   /** git capability check for lightweight mode: requires git ≥ 2.38 for
@@ -348,10 +424,13 @@ export class DiagnosticsService {
       },
       {
         run: this.ghProbe,
+        // Defense-in-depth: ghProbe owns its own retry/timeout and no longer throws, but
+        // an unexpected throw must still land on the soft "couldn't verify" state — never
+        // a false "not logged in".
         onTimeout: {
           id: "gh",
-          state: "error",
-          hintKey: "diagnostics_hint_gh_not_authenticated",
+          state: "warning",
+          hintKey: "diagnostics_hint_gh_unverified",
         },
       },
       {

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import {
   DiagnosticsService,
   defaultRunRemediation,
   type DiagnosticsDeps,
 } from "../src/diagnostics";
-import { DIAGNOSTICS_TTL_MS } from "../src/config";
+import { DIAGNOSTICS_TTL_MS, GH_PROBE_ATTEMPTS } from "../src/config";
 import { REMEDIATIONS } from "../src/remediations";
 import type { DiagnosticCheck } from "../src/types";
 import { SessionStore } from "../src/store";
@@ -39,6 +39,9 @@ function healthyDeps(): DiagnosticsDeps {
   return {
     runVersion: versionRunner({ ...HEALTHY_VERSIONS }),
     runGhAuth: async () => {},
+    // gh probe now retries transient failures; zero delay keeps the failure-path tests
+    // (which reject synchronously) from accruing real wall-time.
+    ghProbeRetryDelayMs: 0,
     resolveHost: async () => "node.example.ts.net",
     // served-status JSON (tailscale serve status --json) that maps config.port (default 7330) → port 443.
     runServeStatus: async () =>
@@ -394,6 +397,113 @@ describe("DiagnosticsService gh probe repo-mode awareness", () => {
     expect(c.state).toBe("error");
     expect(c.hintKey).toBe("diagnostics_hint_gh_not_authenticated");
     assertPure(c);
+  });
+});
+
+// ── gh probe: bounded retry + disposition-based classification (#623 follow-up) ──
+// The reported bug: a transiently slow `gh auth status` (keyring/D-Bus stall, cold gh)
+// timed out and was rendered as a hard "not logged in". These lock in that a KILLED
+// (timed-out) probe retries and, if still stalling, reports the soft `gh_unverified`
+// warning — while a real non-zero EXIT (logout / invalid token) still errors.
+describe("DiagnosticsService gh probe retry + classification", () => {
+  const timeoutErr = () =>
+    Object.assign(new Error("gh auth status timed out"), { killed: true, signal: "SIGTERM" });
+
+  it("timeout (killed) on every attempt → warning + gh_unverified (no false auth error)", async () => {
+    let calls = 0;
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      runGhAuth: async () => {
+        calls++;
+        throw timeoutErr();
+      },
+    });
+    const c = byId((await svc.check(0)).checks, "gh");
+    expect(c.state).toBe("warning");
+    expect(c.hintKey).toBe("diagnostics_hint_gh_unverified");
+    expect(calls).toBe(GH_PROBE_ATTEMPTS); // retried the full budget before giving up
+    assertPure(c);
+  });
+
+  it("retries a transient timeout and recovers → ok", async () => {
+    let calls = 0;
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      runGhAuth: async () => {
+        calls++;
+        if (calls === 1) throw timeoutErr();
+        // second attempt succeeds
+      },
+    });
+    const c = byId((await svc.check(0)).checks, "gh");
+    expect(c.state).toBe("ok");
+    expect(c.hintKey).toBe("diagnostics_hint_gh_ok");
+    expect(calls).toBe(2);
+  });
+
+  it("persistent non-zero EXIT (gh rendered a verdict) → error + gh_not_authenticated, not retried", async () => {
+    let calls = 0;
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      runGhAuth: async () => {
+        // a real logged-out / invalid-token `gh auth status` exits non-zero with NO kill
+        // signal — the disposition that marks a genuine, actionable auth failure.
+        calls++;
+        throw Object.assign(new Error("exit 1"), { code: 1 });
+      },
+    });
+    const c = byId((await svc.check(0)).checks, "gh");
+    expect(c.state).toBe("error");
+    expect(c.hintKey).toBe("diagnostics_hint_gh_not_authenticated");
+    expect(calls).toBe(1); // deterministic verdict — probed once, no wasted retry
+    assertPure(c);
+  });
+
+  it("timeout + anyForgeRepo=false → warning + not_required, no unverified log", async () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const svc = new DiagnosticsService({
+        ...healthyDeps(),
+        runGhAuth: async () => {
+          throw timeoutErr();
+        },
+        anyForgeRepo: () => false,
+      });
+      const c = byId((await svc.check(0)).checks, "gh");
+      expect(c.state).toBe("warning");
+      expect(c.hintKey).toBe("diagnostics_hint_gh_not_required");
+      // the warning never surfaces on a lightweight-only host → no scary log either.
+      const logged = warn.mock.calls.flat().map(String).join(" ");
+      expect(logged).not.toContain("could not be verified");
+      assertPure(c);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("unverified path logs only the disposition — never stderr / account identity", async () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const svc = new DiagnosticsService({
+        ...healthyDeps(),
+        runGhAuth: async () => {
+          // pack identity-looking text into message + stderr; it must NOT reach the log.
+          throw Object.assign(new Error("Logged in to github.com account secret-user"), {
+            killed: true,
+            signal: "SIGTERM",
+            stderr: "Token: gho_secrettoken00000 account secret-user",
+          });
+        },
+      });
+      const c = byId((await svc.check(0)).checks, "gh");
+      expect(c.hintKey).toBe("diagnostics_hint_gh_unverified");
+      const logged = warn.mock.calls.flat().map(String).join(" ");
+      expect(logged).toContain("could not be verified");
+      expect(logged).not.toContain("secret-user");
+      expect(logged).not.toContain("gho_secrettoken");
+    } finally {
+      warn.mockRestore();
+    }
   });
 });
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1225,6 +1225,7 @@
   "diagnostics_hint_git_missing": "git nicht im PATH gefunden — installiere es, bevor du Aufgaben startest.",
   "diagnostics_hint_gh_ok": "GitHub CLI ist authentifiziert.",
   "diagnostics_hint_gh_not_authenticated": "GitHub CLI fehlt oder ist nicht angemeldet — führe gh auth login aus.",
+  "diagnostics_hint_gh_unverified": "GitHub-CLI-Authentifizierung konnte nicht geprüft werden — die Prüfung hat das Zeitlimit überschritten. Shepherd prüft in Kürze erneut.",
   "diagnostics_hint_claude_ok": "Claude Code CLI ist verfügbar.",
   "diagnostics_hint_claude_missing": "Claude Code CLI nicht im PATH gefunden. Installiere Claude Code oder Codex, um Agent-Sessions zu starten.",
   "diagnostics_hint_bun_ok": "bun ist aktuell.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1225,6 +1225,7 @@
   "diagnostics_hint_git_missing": "git not found in PATH — install it before running tasks.",
   "diagnostics_hint_gh_ok": "GitHub CLI is authenticated.",
   "diagnostics_hint_gh_not_authenticated": "GitHub CLI missing or not logged in — run gh auth login.",
+  "diagnostics_hint_gh_unverified": "Couldn't verify GitHub CLI auth — the check timed out. Shepherd will re-check shortly.",
   "diagnostics_hint_claude_ok": "Claude Code CLI is available.",
   "diagnostics_hint_claude_missing": "Claude Code CLI not found in PATH. Install Claude Code or Codex to run agent sessions.",
   "diagnostics_hint_bun_ok": "bun is up to date.",


### PR DESCRIPTION
## Problem

The **Diagnostics** panel intermittently showed **gh → Problem: "GitHub CLI missing or not logged in — run gh auth login."** on hosts where `gh` is installed and authenticated. Re-running cleared it; it returned after a while.

**Root cause:** `ghProbe` ran `gh auth status` once with a 5s timeout and collapsed **every** failure — a timeout, a transient keyring/D-Bus stall, or a cold `gh` under load — into the single hard verdict `error` + `diagnostics_hint_gh_not_authenticated`. The 4s boot kick + 6h `setInterval` re-check pushed that to all clients and the 60s TTL re-probed, so an authenticated host flickered red and cleared on a fast manual re-run. The real error was swallowed (no logging), so the exact transient trigger was invisible.

`gh auth status` reads the token from the OS keyring (no network), which is the transient surface.

## Fix

Rewrite `ghProbe` as a **bounded retry loop** that classifies the final failure by **process disposition** — not by parsing gh's output (a real logout and an invalid/expired token print different text, and success identity lands on stdout):

| gh failure (forge repo) | Before | After |
|---|---|---|
| binary missing (`ENOENT`) | error · `gh_missing` | unchanged |
| logged out / invalid token / bad scopes (gh **exits** non-zero) | error · run gh auth login | unchanged (still actionable) |
| timeout / transient stall (probe **kills** gh) | error · run gh auth login | retry → **warning · `gh_unverified`** ("couldn't verify — timed out") |

- Success on any attempt ⇒ `ok`; a transient blip that clears on retry resolves cleanly.
- Killed/timed-out on every attempt ⇒ soft `gh_unverified` warning + a **disposition-only** server log (`code`/`killed`/`signal` — never stderr/stdout, so no account identity leaks).
- A dedicated shorter per-attempt timeout (`GH_PROBE_TIMEOUT_MS = 3s` × `GH_PROBE_ATTEMPTS = 2`) caps the probe at ≈6.25s instead of a possible 3×5s stall.
- New `diagnostics_hint_gh_unverified` message (EN + DE); deliberately **no** `DOC_LINKS`/remediation mapping, so the warning row shows guidance-free text (no misleading "How to fix" / "Fix" button).

Overall system health also softens from error-red to a warning when gh merely can't be verified, instead of marking the whole host broken.

## Tests

`test/diagnostics.test.ts`: timeout → `gh_unverified` (regression guard), retry-recovery → `ok`, retry-exhaustion call-count, persistent non-zero exit → `gh_not_authenticated`, forge-downgrade, and log-purity (no identity/stderr in the log). Existing gh tests keep their assertions (plain-`Error` → exited-verdict branch); only `healthyDeps` gains `ghProbeRetryDelayMs: 0`.

## Verification

`bun run typecheck`, `bun run lint`, `bun test ./test/diagnostics.test.ts` (62 pass), `cd ui && bun run check:i18n`, `check:glossary`, `check:announcement-versions`, and `fallow audit` all clean. The full `bun test` failure count is identical with/without this change (pre-existing headless DOM/browser-env tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)