### PR TITLE
feat(service): inject epic-authoring notice on operator steer-time reply (#1405)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2141,11 +2141,11 @@ async function handleSessionReply({ req, parts, deps }: Ctx): Promise<Response |
   if (!body || typeof (body as { text?: unknown }).text !== "string") {
     return json({ error: "body must be {text: string}" }, 400);
   }
-  // reply() returns false for an unknown id, a dead pane, OR a transient herdr-unreachable
-  // (it can't confirm liveness, so it can't deliver) — all collapse to 404 here. The last
-  // case is rare and "couldn't deliver" is honest; differentiating would need a richer
-  // return than the boolean that broadcast()/auto-address also rely on.
-  const ok = deps.service.reply(parts[2], (body as { text: string }).text);
+  // operatorReply() is the human free-text boundary: same false semantics as reply() (unknown id,
+  // dead pane, or transient herdr-unreachable → 404 here), but it also injects the epic-authoring
+  // notice once per session when the message signals epic intent (#1405). Internal steers keep
+  // calling service.reply() directly, so they never trip that path.
+  const ok = deps.service.operatorReply(parts[2], (body as { text: string }).text);
   return ok ? json({ ok: true }) : json({ error: "not found" }, 404);
 }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -615,6 +615,21 @@ export function detectEpicIntent(prompt: string): boolean {
 }
 
 /**
+ * Compose the steer payload for a mid-session (steer-time) operator reply (#1405). When the
+ * operator's message signals epic intent, append the epic-authoring notice so the epic-shape
+ * contract rides at steer-time too: spawn-time detectEpicIntent (composeDirectives) only fires on
+ * the SPAWN prompt, and the `.claude/skills/shepherd-epic-authoring` skill is Claude-only AND
+ * model-invoked — Codex never reads `.claude/skills/`, and even Claude may not auto-pick the skill
+ * on a bare epic reply. The injected block is the PTY-text channel that reaches BOTH providers
+ * deterministically, wrapped exactly like the spawn-time block. Returns null when the message shows
+ * no epic intent (the caller then delivers it verbatim). Exported for tests.
+ */
+export function composeEpicSteer(text: string): string | null {
+  if (!detectEpicIntent(text)) return null;
+  return `${text}\n\n<epic-authoring-notice>\n${EPIC_AUTHORING_NOTICE}\n</epic-authoring-notice>`;
+}
+
+/**
  * Agent-facing notice (#1257) that tells a PR-authoring agent to DECLARE manual operator steps in the
  * PR body via the carriers `parseManualSteps()` (src/manual-steps.ts) understands, so the #1061
  * post-merge pipeline + the Owed lens get a live data source. Claude gets it via composeSystemPrompt
@@ -1414,6 +1429,11 @@ export class SessionService {
   /** (repoPath#issue) keys already signaled as untrusted-author, so a stuck issue's periodic
    *  drain retries emit the untrusted_author signal ONCE rather than growing the store unbounded. */
   #untrustedAuthorSignaled = new Set<string>();
+
+  /** Session ids that have already had the epic-authoring notice steered in via operatorReply
+   *  (#1405). Ephemeral/in-memory — a first mid-session epic ask injects the notice once; later
+   *  epic replies deliver verbatim. Re-arming after a server restart is harmless. */
+  #epicNoticeSteered = new Set<string>();
 
   /**
    * Build the human-turn prompt: the user's text plus any attached images, the issue
@@ -3367,6 +3387,30 @@ export class SessionService {
   }
 
   /**
+   * The operator's free-text mid-session reply boundary (`POST /api/sessions/:id/reply`), as opposed
+   * to the internal steers (autopilot, plan-gate, critic, preview, retry-halted, approve) that call
+   * reply() directly. Same non-throwing boolean contract as reply().
+   *
+   * When the operator's message signals epic intent (composeEpicSteer), the epic-authoring notice is
+   * appended ONCE per session so the epic-shape contract reaches the agent mid-session too. This is
+   * the agnostic complement to the spawn-time #1391 notice, which only fires on the spawn prompt: the
+   * `.claude/skills/shepherd-epic-authoring` skill is Claude-only (Codex never reads `.claude/skills/`)
+   * AND model-invoked (even Claude may not auto-pick it), so operator-facing guidance that must reach
+   * both providers belongs in an injected steer block, not a skill. See #1405.
+   *
+   * The notice rides the PTY only — the recorded `reply` signal stores just the raw operator text
+   * (signalPayload) so the learnings distiller never mines Shepherd's own notice. The session is
+   * marked only on SUCCESSFUL delivery, so a reply to a dead pane doesn't burn the one-shot.
+   */
+  operatorReply(id: string, text: string): boolean {
+    const combined = this.#epicNoticeSteered.has(id) ? null : composeEpicSteer(text);
+    if (!combined) return this.reply(id, text);
+    const ok = this.replyToLive(id, combined, this.liveTerminalIds(), /* signalPayload */ text);
+    if (ok) this.#epicNoticeSteered.add(id);
+    return ok;
+  }
+
+  /**
    * Steer the agent for session `id` to start its dev server with `command` running
    * in the background. The agent's PTY is a live CLI session — we can't spawn processes
    * ourselves, so we deliver a directive asking the agent to do it. Returns false for
@@ -3540,24 +3584,37 @@ export class SessionService {
     }
   }
 
-  /** Steer one session against a pre-fetched live set. False on unknown id or dead pane. */
-  private replyToLive(id: string, text: string, live: Set<string>): boolean {
+  /** Steer one session against a pre-fetched live set. False on unknown id or dead pane.
+   *  `signalPayload` (default = `text`) is threaded to sendSteerTo so operatorReply can deliver the
+   *  combined text while recording only the raw operator words (#1405). */
+  private replyToLive(
+    id: string,
+    text: string,
+    live: Set<string>,
+    signalPayload: string = text,
+  ): boolean {
     const s = this.deps.store.get(id);
     if (!s || !live.has(s.herdrAgentId)) return false; // unknown, or live-in-store / dead-pane
-    this.sendSteerTo(s, text);
+    this.sendSteerTo(s, text, signalPayload);
     return true;
   }
 
   /** Deliver a human-style steer to an already-resolved, live session: record the reply
    *  signal, then bracket-paste the text and submit with a CR. Single source for the send
    *  used by replyToLive (reply/retry) and broadcast (which resolves the session itself so
-   *  it can classify the outcome without a second store lookup). */
-  private sendSteerTo(s: Session, text: string): void {
+   *  it can classify the outcome without a second store lookup).
+   *
+   *  `signalPayload` defaults to the delivered `text`, so every existing caller is unchanged.
+   *  operatorReply (#1405) passes the RAW operator text here while `text` carries the
+   *  operator text PLUS the injected epic-authoring notice — the notice reaches the PTY but the
+   *  recorded `reply` signal stays the operator's words alone, so the learnings distiller never
+   *  mines Shepherd's own notice (`reply` is a mined signal kind). */
+  private sendSteerTo(s: Session, text: string, signalPayload: string = text): void {
     this.deps.store.addSignal({
       repoPath: s.repoPath,
       sessionId: s.id,
       kind: "reply",
-      payload: text,
+      payload: signalPayload,
     });
     const PASTE_START = "\x1b[200~";
     const PASTE_END = "\x1b[201~";

--- a/src/service.ts
+++ b/src/service.ts
@@ -3399,15 +3399,16 @@ export class SessionService {
    * both providers belongs in an injected steer block, not a skill. See #1405.
    *
    * The notice rides the PTY only — the recorded `reply` signal stores just the raw operator text
-   * (signalPayload) so the learnings distiller never mines Shepherd's own notice. The session is
-   * marked only on SUCCESSFUL delivery, so a reply to a dead pane doesn't burn the one-shot.
+   * so the learnings distiller never mines Shepherd's own notice. The session is marked only on
+   * SUCCESSFUL delivery, so a reply to a dead pane doesn't burn the one-shot. The injection itself
+   * lives in steerWithEpicNotice, shared with broadcast() so both operator free-text channels behave
+   * identically.
    */
   operatorReply(id: string, text: string): boolean {
-    const combined = this.#epicNoticeSteered.has(id) ? null : composeEpicSteer(text);
-    if (!combined) return this.reply(id, text);
-    const ok = this.replyToLive(id, combined, this.liveTerminalIds(), /* signalPayload */ text);
-    if (ok) this.#epicNoticeSteered.add(id);
-    return ok;
+    const s = this.deps.store.get(id);
+    if (!s || !this.liveTerminalIds().has(s.herdrAgentId)) return false; // unknown or dead pane
+    this.steerWithEpicNotice(s, text);
+    return true;
   }
 
   /**
@@ -3528,7 +3529,10 @@ export class SessionService {
         offline++; // unknown id or dead pane — the steer can't land
         continue;
       }
-      this.sendSteerTo(s, text);
+      // Like operatorReply, an epic-intent broadcast injects the epic-authoring notice once per
+      // session (#1405). Delivery classification below is unchanged — the notice only alters the
+      // PTY text, not whether/how the steer lands, and the recorded signal stays the raw text.
+      this.steerWithEpicNotice(s, text);
       if (statusByTerminal.get(s.herdrAgentId) === "working") queued++;
       else delivered++;
     }
@@ -3605,7 +3609,7 @@ export class SessionService {
    *  it can classify the outcome without a second store lookup).
    *
    *  `signalPayload` defaults to the delivered `text`, so every existing caller is unchanged.
-   *  operatorReply (#1405) passes the RAW operator text here while `text` carries the
+   *  steerWithEpicNotice (#1405) passes the RAW operator text here while `text` carries the
    *  operator text PLUS the injected epic-authoring notice — the notice reaches the PTY but the
    *  recorded `reply` signal stays the operator's words alone, so the learnings distiller never
    *  mines Shepherd's own notice (`reply` is a mined signal kind). */
@@ -3621,6 +3625,23 @@ export class SessionService {
     const safe = text.replaceAll(PASTE_START, "").replaceAll(PASTE_END, "");
     this.deps.herdr.send(s.herdrAgentId, `${PASTE_START}${safe}${PASTE_END}`);
     this.deps.herdr.send(s.herdrAgentId, "\r");
+  }
+
+  /** Deliver an operator-authored steer to an already-resolved, LIVE session, injecting the
+   *  epic-authoring notice ONCE per session when the text signals epic intent (#1405). The notice
+   *  rides the PTY only; the recorded `reply` signal keeps the raw operator text either way. Shared
+   *  by operatorReply (single session) and broadcast (fan-out) so both operator free-text channels
+   *  behave identically — a broadcast that says "make these epics" gets the same guidance a single
+   *  reply would. Callers have already confirmed the pane is live, so injecting == delivering and
+   *  marking here can't burn the one-shot on a non-delivery. */
+  private steerWithEpicNotice(s: Session, text: string): void {
+    const combined = this.#epicNoticeSteered.has(s.id) ? null : composeEpicSteer(text);
+    if (combined) {
+      this.sendSteerTo(s, combined, /* signalPayload */ text);
+      this.#epicNoticeSteered.add(s.id);
+    } else {
+      this.sendSteerTo(s, text);
+    }
   }
 
   /**

--- a/test/epic-steer.test.ts
+++ b/test/epic-steer.test.ts
@@ -1,0 +1,137 @@
+import { test, expect, describe } from "bun:test";
+import { SessionService, composeEpicSteer } from "../src/service";
+import { SessionStore } from "../src/store";
+import { EventHub } from "../src/events";
+import { makeApp, type AppDeps } from "../src/server";
+
+const EPIC_MSG = "promote #12 to an epic with sub-issues";
+const PLAIN_MSG = "fix the login bug";
+const NOTICE_MARK = "<epic-authoring-notice>";
+
+// ── the pure helper ──
+
+describe("composeEpicSteer", () => {
+  test("returns null when the message shows no epic intent", () => {
+    expect(composeEpicSteer(PLAIN_MSG)).toBeNull();
+  });
+
+  test("appends the wrapped notice (with the epic-dag grammar) when intent matches", () => {
+    const out = composeEpicSteer(EPIC_MSG);
+    expect(out).not.toBeNull();
+    expect(out!).toContain(EPIC_MSG); // the operator's own words ride first
+    expect(out!).toContain(NOTICE_MARK);
+    expect(out!).toContain("</epic-authoring-notice>");
+    expect(out!).toContain("```epic-dag"); // the recognition contract is carried
+  });
+});
+
+// ── operatorReply: stateful behavior ──
+
+/** Service harness modeled on test/signal-capture.test.ts, with a mutable live-terminal set and a
+ *  capture of everything pasted into the pane. */
+function makeSvc(live: string[] = ["t1"]) {
+  const sent: string[] = [];
+  const liveIds = { current: live };
+  const store = new SessionStore(":memory:");
+  const svc = new SessionService({
+    store,
+    worktree: {},
+    herdr: {
+      send: (_id: string, text: string) => {
+        sent.push(text);
+      },
+      list: () => liveIds.current.map((terminalId) => ({ terminalId })),
+    },
+    namer: (p: string) => p,
+  } as any);
+  const s = store.create({
+    name: "n",
+    prompt: "p",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "b",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "t1",
+  });
+  const pasted = () => sent.join("");
+  return { svc, store, sent, pasted, liveIds, id: s.id };
+}
+
+describe("operatorReply", () => {
+  test("injects the notice into the PTY on the first epic reply", () => {
+    const { svc, pasted, id } = makeSvc();
+    expect(svc.operatorReply(id, EPIC_MSG)).toBe(true);
+    expect(pasted()).toContain(NOTICE_MARK);
+    expect(pasted()).toContain(EPIC_MSG);
+  });
+
+  test("records only the raw operator text in the reply signal — never the notice", () => {
+    const { svc, store, id } = makeSvc();
+    svc.operatorReply(id, EPIC_MSG);
+    const sigs = store.listSignals("/r");
+    expect(sigs.length).toBe(1);
+    expect(sigs[0]!.kind).toBe("reply");
+    expect(sigs[0]!.payload).toBe(EPIC_MSG); // raw words, so the distiller never mines the notice
+    expect(sigs[0]!.payload).not.toContain(NOTICE_MARK);
+  });
+
+  test("injects at most once per session (dedup)", () => {
+    const { svc, sent, id } = makeSvc();
+    svc.operatorReply(id, EPIC_MSG);
+    sent.length = 0; // drop the first delivery's captures
+    expect(svc.operatorReply(id, "also split #20 into sub-issues")).toBe(true);
+    const second = sent.join("");
+    expect(second).not.toContain(NOTICE_MARK); // second epic reply is delivered verbatim
+    expect(second).toContain("also split #20 into sub-issues");
+  });
+
+  test("marks only on successful delivery — a dead pane keeps the one-shot armed", () => {
+    const { svc, pasted, liveIds, id } = makeSvc([]); // no live terminals → delivery fails
+    expect(svc.operatorReply(id, EPIC_MSG)).toBe(false);
+    expect(pasted()).toBe(""); // nothing delivered, nothing recorded
+    liveIds.current = ["t1"]; // pane comes back
+    expect(svc.operatorReply(id, EPIC_MSG)).toBe(true);
+    expect(pasted()).toContain(NOTICE_MARK); // the notice still rides on the retry
+  });
+
+  test("a non-epic reply is delivered verbatim (unchanged reply behavior)", () => {
+    const { svc, store, pasted, id } = makeSvc();
+    expect(svc.operatorReply(id, PLAIN_MSG)).toBe(true);
+    expect(pasted()).toContain(PLAIN_MSG);
+    expect(pasted()).not.toContain(NOTICE_MARK);
+    expect(store.listSignals("/r")[0]!.payload).toBe(PLAIN_MSG);
+  });
+});
+
+// ── route wiring: the reply endpoint goes through operatorReply, not reply ──
+
+describe("POST /api/sessions/:id/reply", () => {
+  test("routes through service.operatorReply", async () => {
+    const calls: Array<[string, string]> = [];
+    const store = new SessionStore(":memory:");
+    const deps: AppDeps = {
+      store,
+      events: new EventHub(),
+      service: {
+        // Only operatorReply is provided: if the handler still called reply() it would throw.
+        operatorReply: (id: string, text: string) => {
+          calls.push([id, text]);
+          return true;
+        },
+      } as any,
+      usageLimits: { limits: () => ({}) } as any,
+    };
+    const app = makeApp(deps);
+    const res = await app.fetch(
+      new Request("http://x/api/sessions/abc/reply", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ text: EPIC_MSG }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(calls).toEqual([["abc", EPIC_MSG]]);
+  });
+});

--- a/test/epic-steer.test.ts
+++ b/test/epic-steer.test.ts
@@ -40,7 +40,7 @@ function makeSvc(live: string[] = ["t1"]) {
       send: (_id: string, text: string) => {
         sent.push(text);
       },
-      list: () => liveIds.current.map((terminalId) => ({ terminalId })),
+      list: () => liveIds.current.map((terminalId) => ({ terminalId, agentStatus: "idle" })),
     },
     namer: (p: string) => p,
   } as any);
@@ -102,6 +102,34 @@ describe("operatorReply", () => {
     expect(pasted()).toContain(PLAIN_MSG);
     expect(pasted()).not.toContain(NOTICE_MARK);
     expect(store.listSignals("/r")[0]!.payload).toBe(PLAIN_MSG);
+  });
+});
+
+// ── broadcast: the other operator free-text channel shares the same notice logic ──
+
+describe("broadcast", () => {
+  test("injects the notice on an epic-intent broadcast while preserving accounting + raw signal", () => {
+    const { svc, store, pasted, id } = makeSvc();
+    const res = svc.broadcast([id], EPIC_MSG);
+    expect(res).toEqual({ delivered: 1, queued: 0, offline: 0, total: 1 });
+    expect(pasted()).toContain(NOTICE_MARK); // the notice rides the PTY
+    expect(store.listSignals("/r")[0]!.payload).toBe(EPIC_MSG); // ...but the signal stays raw
+  });
+
+  test("shares the once-per-session dedup with operatorReply", () => {
+    const { svc, sent, id } = makeSvc();
+    svc.operatorReply(id, EPIC_MSG); // marks the session
+    sent.length = 0;
+    const res = svc.broadcast([id], "promote #30 to an epic");
+    expect(res.delivered).toBe(1); // still delivered...
+    expect(sent.join("")).not.toContain(NOTICE_MARK); // ...but the notice is not re-injected
+  });
+
+  test("a non-epic broadcast is delivered verbatim", () => {
+    const { svc, pasted, id } = makeSvc();
+    svc.broadcast([id], PLAIN_MSG);
+    expect(pasted()).toContain(PLAIN_MSG);
+    expect(pasted()).not.toContain(NOTICE_MARK);
   });
 });
 


### PR DESCRIPTION
## The direct answer first

**No — a307d6a2 does not work agnostically.** It adds a `.claude/skills/shepherd-epic-authoring` skill, which is **Claude Code only**: Codex never reads `.claude/skills/`, so it can't surface or invoke that skill at all. The **agnostic** epic-shape mechanism is the **spawn-time #1391 notice** (`composeSystemPrompt`, no provider gate) — but `detectEpicIntent` fires **only on the spawn prompt**, so a **mid-session** ("make this an epic") reply fell through: on Codex it got no epic guidance, and on Claude only *maybe* (the skill is model-invoked, not force-injected). **This PR closes that steer-time gap** for both providers.

## What changed

Route the operator's free-text reply boundary (`POST /api/sessions/:id/reply` → `handleSessionReply`) through a new `SessionService.operatorReply()`:

- When the operator's mid-session message signals epic intent (`composeEpicSteer` → `detectEpicIntent`), it appends the existing `EPIC_AUTHORING_NOTICE` **once per session**, delivered via the PTY-text channel — the only steer-time channel, identical for Claude and Codex, so the fix is **provider-agnostic by construction** (no provider branch).
- **Internal steers** (autopilot, plan-gate, critic, preview, retry-halted, approve) keep calling `reply()` directly, so they never trip this path.
- The one-shot is marked **only on successful delivery**, so a reply to a dead pane doesn't burn it.

### No self-feedback into the learnings corpus

`reply` is a **mined** signal kind (`NON_LEARNING_SIGNAL_KINDS` excludes it). Delivering the combined text unchanged would feed Shepherd's own notice back into rule distillation — an asymmetry spawn-time injection lacks. So an optional `signalPayload` is threaded through `sendSteerTo`/`replyToLive` (default = the delivered text, every existing caller byte-identical): the **combined** text reaches the PTY, but the recorded `reply` signal stores **only the raw operator words**.

## Both operator free-text channels share the logic

Per critic feedback, the epic-once-per-session injection is factored into a shared `steerWithEpicNotice(s, text)` helper, used by **both** `operatorReply()` (single session) and `broadcast()` (fan-out). A broadcast that says "make these epics" now gets the same guidance a single reply would, with **broadcast's delivered/queued/offline accounting unchanged** (the notice only alters the PTY text) and the recorded signal still the raw operator words. The `#epicNoticeSteered` dedup is shared across both channels, so a session already steered via one isn't re-injected by the other.

## Scope notes

- **Server-only / agent-facing** prompt plumbing — no UI, no user-facing strings → no i18n and no feature-announcement entry (exempt).

## Testing

`test/epic-steer.test.ts` (new, 11 tests):

- `composeEpicSteer` — null on no-intent; wrapped notice carrying the `epic-dag` grammar on intent.
- `operatorReply` — injects on first epic reply; **once-per-session** dedup; **records only the raw operator text** (never the notice); **marks only on successful delivery** (dead pane keeps the one-shot armed); non-epic reply delivered verbatim.
- `broadcast` — epic-intent broadcast injects the notice while preserving delivered/queued/offline accounting and the raw signal; **shares the dedup** with `operatorReply`; non-epic broadcast delivered verbatim.
- Route wiring — `POST /api/sessions/:id/reply` goes through `operatorReply` (not `reply`).

Verified locally: `bun test ./test/epic-steer.test.ts` (11 pass) + related suites (`signal-capture`, `server-steers`, `retry-halted`, `epic-parse` — all pass), `bun run lint` clean, `bun run typecheck` clean. Branch rebased onto latest `main` (linear).

Closes #1405.
