### PR TITLE
test(usage): de-flake midnight-straddle timeline heatmap test that reddens doc-PR CI

### DIFF
--- a/ui/src/lib/components/Usage.browser.test.ts
+++ b/ui/src/lib/components/Usage.browser.test.ts
@@ -49,12 +49,22 @@ const inlineProjections: UsageProjection[] = [
   { window: "WK", projectedPct: 41, resetAt: BASE + 58 * H, burnRatePerHour: 31_000 },
 ];
 
+// Pin the timeline buckets to a fixed mid-day point of "today" so both hours always fall on the
+// SAME local calendar day → one 24-cell heatmap row, at every wall-clock time. A Date.now()-relative
+// fixture flakes during the 01:00 local hour (one bucket lands on the previous day → 2 rows /
+// 48 cells), which kept the doc-PR `verify` CI red whenever it ran in that nightly window.
+const TODAY_NOON = (() => {
+  const d = new Date(BASE);
+  d.setHours(12, 0, 0, 0);
+  return d.getTime();
+})();
+
 const inlineTimeline: UsageTimeline = {
   range: "7d",
   generatedAt: BASE,
   hours: [
-    { hourStart: BASE - 2 * H - (BASE % H), units: 12 },
-    { hourStart: BASE - H - (BASE % H), units: 40 },
+    { hourStart: TODAY_NOON - 2 * H, units: 12 },
+    { hourStart: TODAY_NOON - H, units: 40 },
   ],
   totalUnits: 52,
   peakHourUnits: 40,


### PR DESCRIPTION
## Why "auto docs commits keep failing CI"

The failing job ([run 28761279077](https://github.com/erwins-enkel/shepherd/actions/runs/28761279077/job/85277117591)) is **not a docs problem** — it's a wall-clock-dependent flaky UI test.

`ui/src/lib/components/Usage.browser.test.ts` built its two timeline hour-buckets relative to `Date.now()` (`now-2h`, `now-1h`) and asserted the heatmap renders exactly **one** 24-cell day row. `TimelineLens.svelte` correctly groups usage hours into **contiguous local-calendar-day rows** — so during the **01:00–01:59 UTC** hour, `now-2h` = 23:00 *yesterday* and `now-1h` = 00:00 *today* straddle midnight → **2 rows → 48 cells** → `expected 48 to be 24`. The failing run was at **01:06 UTC**.

Doc PRs run the full `verify` suite (not just the doc diff), so any doc-PR whose CI lands in that ~1-hour nightly window goes red — hence the recurring failures.

## Fix

Anchor both buckets to a fixed mid-day point of "today" so they always share one local calendar day, at every wall-clock time. Mirrors the deterministic fixed-date pattern the sibling `usage/TimelineLens.browser.test.ts` already uses. **Test-only — component behavior unchanged.**

## Verification

A/B under a spoofed clock in the failing window (`TZ=Etc/GMT+5`, local 01:41):
- **Before:** Timeline test fails `expected 48 to be 24` — reproduces the CI failure exactly.
- **After:** all 10 tests pass.

Also green: `Usage.browser.test.ts` (normal clock), `ui bun run check` (0 errors), prettier + eslint on the changed file.

Scope-checked: this is the only test in the repo with the day-straddle bug (`TimelineLens.browser.test.ts` uses fixed dates; `GitRail`/`DocAgentControl` use `Date.now()` only for relative timestamps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)