### PR TITLE
feat: show plan reviewer cli metadata

### DIFF
--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -168,6 +168,9 @@ interface PlanInFlight {
   planHash: string;
   plan: string;
   blocks: VisualBlock[]; // captured at begin, carried into the gate
+  reviewerProvider: AgentProvider | null;
+  reviewerModel: string | null;
+  reviewerEffort: string | null;
   priorRound: number; // adversarial rounds already spent on this plan streak
   startedAt: number;
   finalizing?: boolean;
@@ -263,12 +266,17 @@ export class PlanGateService {
     const prompt = planReviewPrompt(session.prompt, plan, prior?.findings ?? [], issueBody);
     // Mint the reviewer argv (and its pinned per-spawn --session-id) BEFORE createDetached so the
     // reviewer session id can key the worktree path. It's a fresh randomUUID() per run.
-    const env = this.deps.env?.() ?? { provider: "claude" as const, model: null };
+    const reviewerEnv = this.deps.env?.() ?? {
+      provider: "claude" as const,
+      model: null,
+      effort: null,
+    };
+    const reviewerEffort = reviewerEnv.effort ?? session.effort ?? null;
     const { argv, sessionId: reviewerSessionId } = reviewerArgv(
-      env.provider,
-      env.model,
+      reviewerEnv.provider,
+      reviewerEnv.model,
       prompt,
-      env.effort ?? session.effort,
+      reviewerEffort,
     );
 
     // Disposable detached worktree at the base: read-only codebase inspection that can't race
@@ -305,7 +313,7 @@ export class PlanGateService {
     // Fail closed: api-key mode without a configured key must NOT bill the subscription.
     // Checked AFTER the worktree allocation + the post-await re-check so the worktree cleanup
     // here has wt.worktreePath — but BEFORE membrane/backend construction so we skip that work.
-    if (apiKeyFailClosed(this.deps.env?.().provider ?? "claude")) {
+    if (apiKeyFailClosed(reviewerEnv.provider)) {
       console.warn(
         "[plan-gate] api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)",
       );
@@ -325,7 +333,7 @@ export class PlanGateService {
         sessionId: reviewerSessionId,
         kind: "plan-gate",
         parentSessionId: session.id,
-        model: this.deps.env?.().model ?? null,
+        model: reviewerEnv.model,
       },
     });
     if ("aborted" in aux) {
@@ -362,6 +370,9 @@ export class PlanGateService {
       planHash,
       plan,
       blocks,
+      reviewerProvider: reviewerEnv.provider,
+      reviewerModel: reviewerEnv.model,
+      reviewerEffort,
       priorRound: prior?.round ?? 0,
       startedAt: this.now(),
     });
@@ -372,7 +383,7 @@ export class PlanGateService {
       taskSessionId: session.id,
       kind: "plan_gate",
       worktreePath: wt.worktreePath,
-      model: this.deps.env?.().model ?? null,
+      model: reviewerEnv.model,
       spawnedAt: this.now(),
     });
     this.deps.onReviewing?.(session.id, true);
@@ -416,6 +427,9 @@ export class PlanGateService {
         planHash: await PlanGateService.hashPlan(plan),
         plan,
         blocks: this.readPlanBlocks(s.worktreePath),
+        reviewerProvider: null,
+        reviewerModel: sp.model,
+        reviewerEffort: null,
         priorRound: prior?.round ?? 0,
         startedAt: sp.spawnedAt, // keep the original start so a verdict-less orphan times out
       });
@@ -613,6 +627,9 @@ export class PlanGateService {
       cap: this.cap, // surface the live cap so the UI badge need not mirror it
       approved: resolved === "approved",
       plan: f.plan,
+      reviewerProvider: f.reviewerProvider,
+      reviewerModel: f.reviewerModel,
+      reviewerEffort: f.reviewerEffort,
       blocks: f.blocks,
       // Fresh gate for this planHash — no questions answered yet. buildGate runs once per
       // planHash (consider() dedups identical plans), so a revised plan resets the pending

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -176,6 +176,10 @@ interface PlanInFlight {
   finalizing?: boolean;
 }
 
+function reviewerProviderFromSpawn(provider: string | null | undefined): AgentProvider | null {
+  return provider === "claude" || provider === "codex" ? provider : null;
+}
+
 export class PlanGateService {
   private inflight = new Map<string, PlanInFlight>();
   // Session ids whose reviewer is mid-spawn but not yet in `inflight`. begin() awaits the
@@ -383,7 +387,9 @@ export class PlanGateService {
       taskSessionId: session.id,
       kind: "plan_gate",
       worktreePath: wt.worktreePath,
+      reviewerProvider: reviewerEnv.provider,
       model: reviewerEnv.model,
+      reviewerEffort,
       spawnedAt: this.now(),
     });
     this.deps.onReviewing?.(session.id, true);
@@ -427,9 +433,9 @@ export class PlanGateService {
         planHash: await PlanGateService.hashPlan(plan),
         plan,
         blocks: this.readPlanBlocks(s.worktreePath),
-        reviewerProvider: null,
+        reviewerProvider: reviewerProviderFromSpawn(sp.reviewerProvider),
         reviewerModel: sp.model,
-        reviewerEffort: null,
+        reviewerEffort: sp.reviewerEffort,
         priorRound: prior?.round ?? 0,
         startedAt: sp.spawnedAt, // keep the original start so a verdict-less orphan times out
       });

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -6,7 +6,7 @@ import type { SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
 import type { WorktreeMgr } from "./worktree";
 import type { Session, PlanGate, PlanDecision, AgentProvider } from "./types";
-import type { RoleEnvironment } from "./default-model";
+import { modelCompatibleWithProvider, type RoleEnvironment } from "./default-model";
 import type { GitForge } from "./forge/types";
 import {
   type VisualBlock,
@@ -176,8 +176,15 @@ interface PlanInFlight {
   finalizing?: boolean;
 }
 
-function reviewerProviderFromSpawn(provider: string | null | undefined): AgentProvider | null {
-  return provider === "claude" || provider === "codex" ? provider : null;
+function reviewerProviderFromSpawn(
+  provider: string | null | undefined,
+  model: string | null | undefined,
+): AgentProvider | null {
+  if (provider === "claude" || provider === "codex") return provider;
+  if (!model) return null;
+  if (modelCompatibleWithProvider(model, "claude")) return "claude";
+  if (modelCompatibleWithProvider(model, "codex")) return "codex";
+  return null;
 }
 
 export class PlanGateService {
@@ -433,9 +440,9 @@ export class PlanGateService {
         planHash: await PlanGateService.hashPlan(plan),
         plan,
         blocks: this.readPlanBlocks(s.worktreePath),
-        reviewerProvider: reviewerProviderFromSpawn(sp.reviewerProvider),
+        reviewerProvider: reviewerProviderFromSpawn(sp.reviewerProvider, sp.model),
         reviewerModel: sp.model,
-        reviewerEffort: sp.reviewerEffort,
+        reviewerEffort: sp.reviewerEffort ?? s.effort ?? null,
         priorRound: prior?.round ?? 0,
         startedAt: sp.spawnedAt, // keep the original start so a verdict-less orphan times out
       });

--- a/src/store.ts
+++ b/src/store.ts
@@ -331,6 +331,9 @@ type PlanGateRow = {
   updatedAt: number;
   blocks: string;
   answeredQuestionKeys: string | null;
+  reviewerProvider: string | null;
+  reviewerModel: string | null;
+  reviewerEffort: string | null;
 };
 
 /** SQLite row shape for the recaps table. */
@@ -821,16 +824,11 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       cap INTEGER NOT NULL DEFAULT 3, approved INTEGER NOT NULL DEFAULT 0,
       plan TEXT NOT NULL DEFAULT '', updatedAt INTEGER NOT NULL,
       blocks TEXT NOT NULL DEFAULT '[]',
-      answeredQuestionKeys TEXT NOT NULL DEFAULT '[]')`);
-    const planGateCols = this.db.query(`PRAGMA table_info(plan_gates)`).all() as { name: string }[];
-    if (!planGateCols.some((c) => c.name === "blocks")) {
-      this.db.run(`ALTER TABLE plan_gates ADD COLUMN blocks TEXT NOT NULL DEFAULT '[]'`);
-    }
-    if (!planGateCols.some((c) => c.name === "answeredQuestionKeys")) {
-      this.db.run(
-        `ALTER TABLE plan_gates ADD COLUMN answeredQuestionKeys TEXT NOT NULL DEFAULT '[]'`,
-      );
-    }
+      answeredQuestionKeys TEXT NOT NULL DEFAULT '[]',
+      reviewerProvider TEXT,
+      reviewerModel TEXT,
+      reviewerEffort TEXT)`);
+    this.migratePlanGateColumns();
     this.db.run(`CREATE TABLE IF NOT EXISTS recaps (
       sessionId TEXT PRIMARY KEY,
       state TEXT NOT NULL,
@@ -2296,6 +2294,12 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       cap: r.cap ?? 3,
       approved: !!r.approved,
       plan: r.plan ?? "",
+      reviewerProvider:
+        r.reviewerProvider === "claude" || r.reviewerProvider === "codex"
+          ? r.reviewerProvider
+          : null,
+      reviewerModel: r.reviewerModel ?? null,
+      reviewerEffort: r.reviewerEffort ?? null,
       updatedAt: r.updatedAt,
       blocks,
       answeredQuestionKeys,
@@ -2305,7 +2309,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
   getPlanGate(sessionId: string): PlanGate | null {
     const r = this.db
       .query(
-        `SELECT sessionId, planHash, decision, summary, body, findings, round, cap, approved, plan, updatedAt, blocks, answeredQuestionKeys
+        `SELECT sessionId, planHash, decision, summary, body, findings, round, cap, approved, plan, updatedAt, blocks, answeredQuestionKeys, reviewerProvider, reviewerModel, reviewerEffort
               FROM plan_gates WHERE sessionId = ?`,
       )
       .get(sessionId) as PlanGateRow | null;
@@ -2314,13 +2318,15 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
 
   putPlanGate(g: PlanGate): void {
     this.db.run(
-      `INSERT INTO plan_gates (sessionId, planHash, decision, summary, body, findings, round, cap, approved, plan, updatedAt, blocks, answeredQuestionKeys)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+      `INSERT INTO plan_gates (sessionId, planHash, decision, summary, body, findings, round, cap, approved, plan, updatedAt, blocks, answeredQuestionKeys, reviewerProvider, reviewerModel, reviewerEffort)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
        ON CONFLICT(sessionId) DO UPDATE SET planHash=excluded.planHash, decision=excluded.decision,
          summary=excluded.summary, body=excluded.body, findings=excluded.findings,
          round=excluded.round, cap=excluded.cap, approved=excluded.approved,
          plan=excluded.plan, updatedAt=excluded.updatedAt, blocks=excluded.blocks,
-         answeredQuestionKeys=excluded.answeredQuestionKeys`,
+         answeredQuestionKeys=excluded.answeredQuestionKeys,
+         reviewerProvider=excluded.reviewerProvider, reviewerModel=excluded.reviewerModel,
+         reviewerEffort=excluded.reviewerEffort`,
       [
         g.sessionId,
         g.planHash ?? "",
@@ -2335,6 +2341,9 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
         g.updatedAt,
         JSON.stringify(g.blocks ?? []),
         JSON.stringify(g.answeredQuestionKeys ?? []),
+        g.reviewerProvider ?? null,
+        g.reviewerModel ?? null,
+        g.reviewerEffort ?? null,
       ],
     );
   }
@@ -2346,7 +2355,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
   snapshotPlanGates(): Record<string, PlanGate> {
     const rows = this.db
       .query(
-        `SELECT sessionId, planHash, decision, summary, body, findings, round, cap, approved, plan, updatedAt, blocks, answeredQuestionKeys FROM plan_gates`,
+        `SELECT sessionId, planHash, decision, summary, body, findings, round, cap, approved, plan, updatedAt, blocks, answeredQuestionKeys, reviewerProvider, reviewerModel, reviewerEffort FROM plan_gates`,
       )
       .all() as PlanGateRow[];
     const out: Record<string, PlanGate> = {};
@@ -3213,6 +3222,19 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     // spawnAborted (#1211): marks a row that records a pre-spawn onSpawn abort (critic never ran),
     // exempting it from the same-head re-review dedup. Pre-existing rows backfill to 0 (real reviews).
     add("spawnAborted", `spawnAborted INTEGER NOT NULL DEFAULT 0`);
+  }
+
+  private migratePlanGateColumns(): void {
+    const cols = this.db.query(`PRAGMA table_info(plan_gates)`).all() as { name: string }[];
+    const add = (name: string, ddl: string) => {
+      if (!cols.some((c) => c.name === name))
+        this.db.run(`ALTER TABLE plan_gates ADD COLUMN ${ddl}`);
+    };
+    add("blocks", `blocks TEXT NOT NULL DEFAULT '[]'`);
+    add("answeredQuestionKeys", `answeredQuestionKeys TEXT NOT NULL DEFAULT '[]'`);
+    add("reviewerProvider", `reviewerProvider TEXT`);
+    add("reviewerModel", `reviewerModel TEXT`);
+    add("reviewerEffort", `reviewerEffort TEXT`);
   }
 
   // ── learnings ─────────────────────────────────────────────────────────────

--- a/src/store.ts
+++ b/src/store.ts
@@ -20,6 +20,7 @@ import type {
   BuildQueue,
   BuildStepInput,
   ReviewerSpawnRow,
+  AgentProvider,
   PrReview,
   HerdDigest,
   PostMergeStep,
@@ -919,7 +920,9 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       taskSessionId     TEXT NOT NULL,
       kind              TEXT NOT NULL,
       worktreePath      TEXT NOT NULL,
+      reviewerProvider  TEXT,
       model             TEXT,
+      reviewerEffort    TEXT,
       spawnedAt         INTEGER NOT NULL,
       completedAt       INTEGER,
       inputTokens       INTEGER,
@@ -927,6 +930,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       cacheReadTokens   INTEGER,
       cacheWriteTokens  INTEGER,
       totalTokens       INTEGER)`);
+    this.migrateReviewerSpawnColumns();
     this.db.run(
       `CREATE INDEX IF NOT EXISTS reviewer_spawns_task ON reviewer_spawns (taskSessionId)`,
     );
@@ -2829,14 +2833,25 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     taskSessionId: string;
     kind: "review" | "plan_gate" | "recap" | "rundown" | "doc_agent";
     worktreePath: string;
+    reviewerProvider?: AgentProvider | null;
     model: string | null;
+    reviewerEffort?: string | null;
     spawnedAt: number;
   }): void {
     this.db.run(
       `INSERT INTO reviewer_spawns
-         (reviewerSessionId, taskSessionId, kind, worktreePath, model, spawnedAt)
-       VALUES (?,?,?,?,?,?)`,
-      [r.reviewerSessionId, r.taskSessionId, r.kind, r.worktreePath, r.model, r.spawnedAt],
+         (reviewerSessionId, taskSessionId, kind, worktreePath, reviewerProvider, model, reviewerEffort, spawnedAt)
+       VALUES (?,?,?,?,?,?,?,?)`,
+      [
+        r.reviewerSessionId,
+        r.taskSessionId,
+        r.kind,
+        r.worktreePath,
+        r.reviewerProvider ?? null,
+        r.model,
+        r.reviewerEffort ?? null,
+        r.spawnedAt,
+      ],
     );
   }
 
@@ -3234,6 +3249,16 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     add("answeredQuestionKeys", `answeredQuestionKeys TEXT NOT NULL DEFAULT '[]'`);
     add("reviewerProvider", `reviewerProvider TEXT`);
     add("reviewerModel", `reviewerModel TEXT`);
+    add("reviewerEffort", `reviewerEffort TEXT`);
+  }
+
+  private migrateReviewerSpawnColumns(): void {
+    const cols = this.db.query(`PRAGMA table_info(reviewer_spawns)`).all() as { name: string }[];
+    const add = (name: string, ddl: string) => {
+      if (!cols.some((c) => c.name === name))
+        this.db.run(`ALTER TABLE reviewer_spawns ADD COLUMN ${ddl}`);
+    };
+    add("reviewerProvider", `reviewerProvider TEXT`);
     add("reviewerEffort", `reviewerEffort TEXT`);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -584,7 +584,9 @@ export interface ReviewerSpawnRow {
   taskSessionId: string;
   kind: "review" | "plan_gate" | "recap" | "rundown" | "doc_agent";
   worktreePath: string;
+  reviewerProvider: AgentProvider | null;
   model: string | null;
+  reviewerEffort: string | null;
   spawnedAt: number;
   completedAt: number | null;
   inputTokens: number | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -411,6 +411,12 @@ export interface PlanGate {
   cap: number; // the round cap this run used — surfaced so the UI badge need not mirror it
   approved: boolean; // load-bearing gate flag: execution allowed only when true
   plan: string; // snapshot of the reviewed plan text (surfaced in the UI panel)
+  /** Resolved Plan Gate reviewer environment for the run that produced this verdict.
+   *  Optional/null for legacy rows and restart-adopted reviews whose reviewer_spawns row predates
+   *  provider/effort persistence. */
+  reviewerProvider?: AgentProvider | null;
+  reviewerModel?: string | null;
+  reviewerEffort?: string | null;
   blocks?: VisualBlock[]; // optional typed visual plan blocks (model-authored, no diff-join); absent → flat markdown
   // Answered question-form questions, keyed `${blockId} ${questionId}` (#1332). Durable so the
   // "unanswered plan question" attention signal survives reconnect/restart. Reset to [] by

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -658,6 +658,32 @@ test("adoptOrphans restores durable reviewer environment metadata", async () => 
   });
 });
 
+test("adoptOrphans reconstructs legacy reviewer environment from durable model and session effort", async () => {
+  const h = harness({
+    now: () => 1000,
+    store: {
+      get: () => ({
+        id: "s1",
+        repoPath: "/r",
+        worktreePath: "/wt",
+        planPhase: "planning",
+        effort: "medium",
+      }),
+      listReviewerSpawns: () => [
+        orphanSpawn({ reviewerProvider: null, model: "opus", reviewerEffort: null }),
+      ],
+    },
+    readVerdict: () => ({ decision: "approve", summary: "ok", body: "B", findings: [] }),
+  });
+  await h.svc.adoptOrphans();
+  await h.svc.tick();
+  expect(h.store.gate).toMatchObject({
+    reviewerProvider: "claude",
+    reviewerModel: "opus",
+    reviewerEffort: "medium",
+  });
+});
+
 test("adoptOrphans skips a spawn whose worktree was already reaped (finalized)", async () => {
   const h = harness({
     worktreeExists: () => false,

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -139,7 +139,9 @@ test("approved gate records the reviewer provider, model, and resolved effort", 
     reviewerModel: "gpt-5.5",
     reviewerEffort: "high",
   });
+  expect(h.recordedSpawns[0].reviewerProvider).toBe("codex");
   expect(h.recordedSpawns[0].model).toBe("gpt-5.5");
+  expect(h.recordedSpawns[0].reviewerEffort).toBe("high");
 });
 
 test("plan-gate: subscription mode — no apiKeyHelper, no env 4th arg", async () => {
@@ -636,21 +638,23 @@ test("adoptOrphans re-adopts an orphaned review; next tick finalizes it from the
   expect(h.removed).toContain("/wt-detached"); // reviewer worktree reaped
 });
 
-test("adoptOrphans finalizes with only durable reviewer model metadata", async () => {
+test("adoptOrphans restores durable reviewer environment metadata", async () => {
   const h = harness({
     now: () => 1000,
     store: {
       get: () => ({ id: "s1", repoPath: "/r", worktreePath: "/wt", planPhase: "planning" }),
-      listReviewerSpawns: () => [orphanSpawn({ model: "opus" })],
+      listReviewerSpawns: () => [
+        orphanSpawn({ reviewerProvider: "codex", model: "gpt-5.5", reviewerEffort: "high" }),
+      ],
     },
     readVerdict: () => ({ decision: "approve", summary: "ok", body: "B", findings: [] }),
   });
   await h.svc.adoptOrphans();
   await h.svc.tick();
   expect(h.store.gate).toMatchObject({
-    reviewerProvider: null,
-    reviewerModel: "opus",
-    reviewerEffort: null,
+    reviewerProvider: "codex",
+    reviewerModel: "gpt-5.5",
+    reviewerEffort: "high",
   });
 });
 

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -127,6 +127,21 @@ test("consider: falls back to session.effort when env.effort is null/absent (iss
   expect(argv[argv.indexOf("--effort") + 1]).toBe("medium");
 });
 
+test("approved gate records the reviewer provider, model, and resolved effort", async () => {
+  const h = harness({
+    env: () => ({ provider: "codex", model: "gpt-5.5", effort: null }),
+    readVerdict: () => ({ decision: "approve", summary: "ok", body: "B", findings: [] }),
+  });
+  await h.svc.consider({ ...planningSession(), effort: "high" } as any);
+  await h.svc.tick();
+  expect(h.store.gate).toMatchObject({
+    reviewerProvider: "codex",
+    reviewerModel: "gpt-5.5",
+    reviewerEffort: "high",
+  });
+  expect(h.recordedSpawns[0].model).toBe("gpt-5.5");
+});
+
 test("plan-gate: subscription mode — no apiKeyHelper, no env 4th arg", async () => {
   await withAuth("subscription", "/ignored.sh", async () => {
     const h = harness();
@@ -619,6 +634,24 @@ test("adoptOrphans re-adopts an orphaned review; next tick finalizes it from the
   expect(h.store.gate.round).toBe(2); // priorRound (1) advanced once the steer landed
   expect(replied).toEqual(["s1"]); // findings steered back to the planning agent
   expect(h.removed).toContain("/wt-detached"); // reviewer worktree reaped
+});
+
+test("adoptOrphans finalizes with only durable reviewer model metadata", async () => {
+  const h = harness({
+    now: () => 1000,
+    store: {
+      get: () => ({ id: "s1", repoPath: "/r", worktreePath: "/wt", planPhase: "planning" }),
+      listReviewerSpawns: () => [orphanSpawn({ model: "opus" })],
+    },
+    readVerdict: () => ({ decision: "approve", summary: "ok", body: "B", findings: [] }),
+  });
+  await h.svc.adoptOrphans();
+  await h.svc.tick();
+  expect(h.store.gate).toMatchObject({
+    reviewerProvider: null,
+    reviewerModel: "opus",
+    reviewerEffort: null,
+  });
 });
 
 test("adoptOrphans skips a spawn whose worktree was already reaped (finalized)", async () => {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1036,7 +1036,9 @@ test("recordReviewerSpawn then listReviewerSpawns returns the row with NULL toke
     taskSessionId: "task-1",
     kind: "review",
     worktreePath: "/rev-wt",
+    reviewerProvider: null,
     model: null,
+    reviewerEffort: null,
     spawnedAt: 1000,
   });
   const rows = s.listReviewerSpawns();
@@ -1046,7 +1048,9 @@ test("recordReviewerSpawn then listReviewerSpawns returns the row with NULL toke
     taskSessionId: "task-1",
     kind: "review",
     worktreePath: "/rev-wt",
+    reviewerProvider: null,
     model: null,
+    reviewerEffort: null,
     spawnedAt: 1000,
     completedAt: null,
     inputTokens: null,
@@ -1054,6 +1058,25 @@ test("recordReviewerSpawn then listReviewerSpawns returns the row with NULL toke
     cacheReadTokens: null,
     cacheWriteTokens: null,
     totalTokens: null,
+  });
+});
+
+test("recordReviewerSpawn persists reviewer provider and effort", () => {
+  const s = mk();
+  s.recordReviewerSpawn({
+    reviewerSessionId: "rev-1",
+    taskSessionId: "task-1",
+    kind: "plan_gate",
+    worktreePath: "/rev-wt",
+    reviewerProvider: "codex",
+    model: "gpt-5.5",
+    reviewerEffort: "high",
+    spawnedAt: 1000,
+  });
+  expect(s.listReviewerSpawns()[0]).toMatchObject({
+    reviewerProvider: "codex",
+    model: "gpt-5.5",
+    reviewerEffort: "high",
   });
 });
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2600,5 +2600,15 @@
   "micbtn_origin_local": "🎙️ Lokales Whisper",
   "micbtn_origin_web": "Browser/Gerät",
   "feat_newtask_prompt_mic_title": "Den New-Task-Prompt diktieren",
-  "feat_newtask_prompt_mic_body": "Das Prompt-Feld im New-Task-Dialog hat jetzt ein Mikrofon — mit denselben Engines wie die Compose-Leiste: der Diktierfunktion des Browsers oder lokalem Whisper über das voice-whisper-Plugin (das einzige Mikrofon in einer iOS-Homescreen-PWA). Während du sprichst, erscheint eine Live-Vorschau im Feld; beim Stoppen ersetzt das genaue Transkript des vollständigen Clips die Vorschau."
+  "feat_newtask_prompt_mic_body": "Das Prompt-Feld im New-Task-Dialog hat jetzt ein Mikrofon — mit denselben Engines wie die Compose-Leiste: der Diktierfunktion des Browsers oder lokalem Whisper über das voice-whisper-Plugin (das einzige Mikrofon in einer iOS-Homescreen-PWA). Während du sprichst, erscheint eine Live-Vorschau im Feld; beim Stoppen ersetzt das genaue Transkript des vollständigen Clips die Vorschau.",
+  "feat_plan_reviewer_environment_title": "Sieh, welche CLI einen Plan geprüft hat",
+  "feat_plan_reviewer_environment_body": "Plan-Gate-Überschriften zeigen jetzt Coding-CLI, Modell und Aufwand der Task-Session und des Reviewers. Öffne das Info-Popover neben den Chips für den genauen Pfad in den Einstellungen und den Dokumentationslink.",
+  "planpanel_env_aria": "Coding-Umgebung für Plan und Prüfung",
+  "planpanel_env_plan": "Plan",
+  "planpanel_env_review": "Prüfung",
+  "planpanel_env_unavailable": "nicht verfügbar",
+  "planpanel_env_help_aria": "Wo sich die Coding-Umgebungen für Plan und Prüfung ändern lassen",
+  "planpanel_env_popover_title": "Coding-Umgebung",
+  "planpanel_env_popover_body": "Plan zeigt Coding-CLI, Modell und Reasoning Effort der Task-Session. Prüfung zeigt den Plan-Gate-Reviewer, der diesen Plan geprüft hat. Task-Defaults änderst du in Neuer Task, in Repo-Defaults oder globalen Defaults; den Reviewer unter Einstellungen -> CLIs -> Planer (Plan-Reviewer).",
+  "planpanel_env_docs_link": "Konfigurationsdoku öffnen"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2600,5 +2600,15 @@
   "micbtn_origin_local": "🎙️ Local Whisper",
   "micbtn_origin_web": "Browser / device",
   "feat_newtask_prompt_mic_title": "Dictate the New Task prompt",
-  "feat_newtask_prompt_mic_body": "The New Task prompt field now has a mic — same engines as the compose bar: the browser's dictation, or local Whisper via the voice-whisper plugin (the only mic in an iOS home-screen PWA). While you speak, a live preview renders in the field; on stop the accurate full-clip transcript replaces it."
+  "feat_newtask_prompt_mic_body": "The New Task prompt field now has a mic — same engines as the compose bar: the browser's dictation, or local Whisper via the voice-whisper plugin (the only mic in an iOS home-screen PWA). While you speak, a live preview renders in the field; on stop the accurate full-clip transcript replaces it.",
+  "feat_plan_reviewer_environment_title": "See which CLI reviewed a plan",
+  "feat_plan_reviewer_environment_body": "Plan Gate headings now show the task session and reviewer coding CLI, model and effort. Open the info popover beside the chips for the exact Settings path and documentation link.",
+  "planpanel_env_aria": "Plan and review coding environment",
+  "planpanel_env_plan": "Plan",
+  "planpanel_env_review": "Review",
+  "planpanel_env_unavailable": "unavailable",
+  "planpanel_env_help_aria": "Where to change plan and review coding environments",
+  "planpanel_env_popover_title": "Coding environment",
+  "planpanel_env_popover_body": "Plan shows the task session's coding CLI, model and reasoning effort. Review shows the Plan Gate reviewer that checked this plan. Change task defaults in New Task, repo defaults or global defaults; change the reviewer under Settings -> CLIs -> Planner (plan reviewer).",
+  "planpanel_env_docs_link": "Open configuration docs"
 }

--- a/ui/src/lib/components/PlanPanel.browser.test.ts
+++ b/ui/src/lib/components/PlanPanel.browser.test.ts
@@ -7,6 +7,7 @@ import type { PlanGate, Session } from "$lib/types";
 import { planGates } from "$lib/reviews.svelte";
 import { reviewPlan } from "$lib/api";
 import { m } from "$lib/paraglide/messages";
+import { DOCS_URL } from "$lib/build-info";
 
 // Mock api so the panel's release/review calls never hit the network, keeping the
 // rest of the module intact (the reviews store imports other api exports).
@@ -228,6 +229,109 @@ describe("PlanPanel release state", () => {
     });
 
     expect(document.querySelector(".status-note")).toBeNull();
+  });
+});
+
+describe("PlanPanel environment heading", () => {
+  it("shows plan and review coding environments in the heading", async () => {
+    const id = "s-env";
+    planGates.map = {
+      [id]: {
+        sessionId: id,
+        planHash: "env",
+        decision: "approved",
+        summary: "ok",
+        body: "",
+        findings: [],
+        round: 0,
+        cap: 3,
+        approved: true,
+        plan: "# Env plan",
+        reviewerProvider: "claude",
+        reviewerModel: "opus",
+        reviewerEffort: "high",
+        updatedAt: Date.now(),
+      },
+    };
+
+    render(PlanPanel, {
+      props: {
+        session: session({
+          id,
+          agentProvider: "codex",
+          model: "gpt-5.5",
+          effort: "medium",
+        }),
+        onclose: vi.fn(),
+      },
+    });
+
+    const envText = document.querySelector(".envline")?.textContent ?? "";
+    expect(envText).toContain("Plan");
+    expect(envText).toContain("Review");
+    await expect.element(page.getByText("Codex · gpt-5.5 · Medium")).toBeVisible();
+    await expect.element(page.getByText("Claude Code · opus · High")).toBeVisible();
+  });
+
+  it("shows partial reviewer metadata when provider is unavailable", async () => {
+    const id = "s-env-missing";
+    planGates.map = {
+      [id]: {
+        sessionId: id,
+        planHash: "env-missing",
+        decision: "approved",
+        summary: "ok",
+        body: "",
+        findings: [],
+        round: 0,
+        cap: 3,
+        approved: true,
+        plan: "# Env plan",
+        reviewerProvider: null,
+        reviewerModel: "opus",
+        reviewerEffort: null,
+        updatedAt: Date.now(),
+      },
+    };
+
+    render(PlanPanel, { props: { session: session({ id }), onclose: vi.fn() } });
+
+    const envText = document.querySelector(".envline")?.textContent ?? "";
+    expect(envText).toContain("Review");
+    await expect.element(page.getByText("unavailable · opus")).toBeVisible();
+  });
+
+  it("opens a persistent details popover with the settings path and docs link", async () => {
+    const id = "s-env-pop";
+    planGates.map = {
+      [id]: {
+        sessionId: id,
+        planHash: "env-pop",
+        decision: "approved",
+        summary: "ok",
+        body: "",
+        findings: [],
+        round: 0,
+        cap: 3,
+        approved: true,
+        plan: "# Env plan",
+        reviewerProvider: "claude",
+        reviewerModel: null,
+        reviewerEffort: null,
+        updatedAt: Date.now(),
+      },
+    };
+
+    render(PlanPanel, { props: { session: session({ id }), onclose: vi.fn() } });
+
+    await page.getByLabelText("Where to change plan and review coding environments").click();
+    await expect.element(page.getByText("Coding environment")).toBeVisible();
+    await expect
+      .element(page.getByText(/Settings -> CLIs -> Planner \(plan reviewer\)/))
+      .toBeVisible();
+    await expect
+      .element(page.getByRole("link", { name: "Open configuration docs" }))
+      .toHaveAttribute("href", `${DOCS_URL}reference/configuration/`);
   });
 });
 

--- a/ui/src/lib/components/PlanPanel.browser.test.ts
+++ b/ui/src/lib/components/PlanPanel.browser.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
-import { page } from "vitest/browser";
+import { page, userEvent } from "vitest/browser";
 import "../../app.css";
 import PlanPanel from "./PlanPanel.svelte";
 import type { PlanGate, Session } from "$lib/types";
@@ -332,6 +332,39 @@ describe("PlanPanel environment heading", () => {
     await expect
       .element(page.getByRole("link", { name: "Open configuration docs" }))
       .toHaveAttribute("href", `${DOCS_URL}reference/configuration/`);
+  });
+
+  it("closes the details popover with Escape while focus is inside it", async () => {
+    const id = "s-env-pop-escape";
+    planGates.map = {
+      [id]: {
+        sessionId: id,
+        planHash: "env-pop-escape",
+        decision: "approved",
+        summary: "ok",
+        body: "",
+        findings: [],
+        round: 0,
+        cap: 3,
+        approved: true,
+        plan: "# Env plan",
+        reviewerProvider: "claude",
+        reviewerModel: null,
+        reviewerEffort: null,
+        updatedAt: Date.now(),
+      },
+    };
+
+    render(PlanPanel, { props: { session: session({ id }), onclose: vi.fn() } });
+
+    await page.getByLabelText("Where to change plan and review coding environments").click();
+    const docsLink = document.querySelector<HTMLAnchorElement>(".env-pop a");
+    docsLink?.focus();
+    expect(document.activeElement).toBe(docsLink);
+    await userEvent.keyboard("{Escape}");
+
+    await expect.element(page.getByText("Coding environment")).not.toBeInTheDocument();
+    await expect.element(page.getByRole("dialog", { name: m.planpanel_title() })).toBeVisible();
   });
 });
 

--- a/ui/src/lib/components/PlanPanel.svelte
+++ b/ui/src/lib/components/PlanPanel.svelte
@@ -1,15 +1,19 @@
 <script lang="ts">
-  import type { Session } from "$lib/types";
+  import type { AgentProvider, Session } from "$lib/types";
   import { planGates } from "$lib/reviews.svelte";
   import { releasePlanGate, reviewPlan } from "$lib/api";
   import { canRelease, planGateChip } from "./plan-gate-badge";
   import { dialog } from "$lib/a11yDialog";
   import { portal } from "$lib/portal";
   import { m } from "$lib/paraglide/messages";
+  import { modelLabel } from "$lib/model-label";
+  import { effortLabel } from "$lib/effort-guidance";
+  import { DOCS_URL } from "$lib/build-info";
   import VisualReview from "./VisualReview.svelte";
 
   let { session, onclose }: { session: Session; onclose: () => void } = $props();
 
+  const docsHref = `${DOCS_URL}reference/configuration/`;
   const gate = $derived(planGates.map[session.id]);
   // Plan blocks are the planning agent's own proposed structures. The "inferred" badge
   // (and its glossary tooltip) is recap-specific: it warns that a recap card was
@@ -32,6 +36,29 @@
   // its questions persist past approval), with submit locked while a review is in flight.
   const planAnswerCtx = $derived(
     canReviewNow ? { sessionId: session.id, locked: reviewing } : undefined,
+  );
+  let envOpen = $state(false);
+
+  function providerLabel(provider: AgentProvider): string {
+    return provider === "codex" ? m.agent_provider_codex() : m.agent_provider_claude();
+  }
+
+  function environmentLabel(
+    provider: AgentProvider | null | undefined,
+    model: string | null | undefined,
+    effort: string | null | undefined,
+  ): string {
+    if (!provider) return m.planpanel_env_unavailable();
+    const modelText = model ? modelLabel(model) : m.newtask_model_default();
+    const effortText = effort ? effortLabel(effort) : m.effort_default();
+    return `${providerLabel(provider)} · ${modelText} · ${effortText}`;
+  }
+
+  const planEnv = $derived(
+    environmentLabel(session.agentProvider ?? "claude", session.model, session.effort),
+  );
+  const reviewEnv = $derived(
+    environmentLabel(gate?.reviewerProvider, gate?.reviewerModel, gate?.reviewerEffort),
   );
 
   // Render the plan + reviewer body as markdown, SANITIZED before @html. Both are
@@ -174,6 +201,15 @@
   }
 </script>
 
+<svelte:window
+  onclick={() => {
+    envOpen = false;
+  }}
+  onkeydown={(e) => {
+    if (e.key === "Escape") envOpen = false;
+  }}
+/>
+
 <div
   class="overlay"
   role="presentation"
@@ -199,6 +235,51 @@
       <div class="htitle">
         <span class="micro">{m.planpanel_title()}</span>
         <span class="sname" title={session.name}>{session.name}</span>
+        <div class="envline" aria-label={m.planpanel_env_aria()}>
+          <span class="env-chip" title={planEnv}>
+            <span class="env-label">{m.planpanel_env_plan()}</span>
+            <span class="env-value">{planEnv}</span>
+          </span>
+          <span class="env-chip" title={reviewEnv}>
+            <span class="env-label">{m.planpanel_env_review()}</span>
+            <span class="env-value">{reviewEnv}</span>
+          </span>
+          <span class="env-info">
+            <button
+              type="button"
+              class="env-help"
+              aria-label={m.planpanel_env_help_aria()}
+              aria-expanded={envOpen}
+              onclick={(e) => {
+                e.stopPropagation();
+                envOpen = !envOpen;
+              }}
+            >
+              i
+            </button>
+            {#if envOpen}
+              <div
+                class="env-pop"
+                role="dialog"
+                tabindex="-1"
+                aria-label={m.planpanel_env_popover_title()}
+                onclick={(e) => {
+                  e.stopPropagation();
+                }}
+                onkeydown={(e) => {
+                  e.stopPropagation();
+                }}
+              >
+                <strong>{m.planpanel_env_popover_title()}</strong>
+                <span>{m.planpanel_env_popover_body()}</span>
+                <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external docs URL -->
+                <a href={docsHref} target="_blank" rel="noopener noreferrer"
+                  >{m.planpanel_env_docs_link()}</a
+                >
+              </div>
+            {/if}
+          </span>
+        </div>
       </div>
     </header>
 
@@ -371,6 +452,7 @@
     flex-direction: column;
     gap: 1px;
     min-width: 0;
+    flex: 1;
   }
   .micro {
     font-size: var(--fs-meta);
@@ -385,6 +467,96 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+  .envline {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    min-width: 0;
+    flex-wrap: wrap;
+    margin-top: 3px;
+  }
+  .env-chip {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 5px;
+    min-width: 0;
+    max-width: min(42ch, 100%);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    padding: 2px 5px;
+    color: var(--color-muted);
+    font-size: var(--fs-micro);
+    line-height: 1.2;
+  }
+  .env-label {
+    color: var(--color-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    flex-shrink: 0;
+  }
+  .env-value {
+    color: var(--color-ink);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+  }
+  .env-info {
+    position: relative;
+    display: inline-flex;
+    flex-shrink: 0;
+  }
+  .env-help {
+    width: 19px;
+    height: 19px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    background: transparent;
+    color: var(--color-muted);
+    font: inherit;
+    font-size: var(--fs-micro);
+    line-height: 1;
+    cursor: pointer;
+  }
+  .env-help:hover,
+  .env-help[aria-expanded="true"] {
+    border-color: var(--color-line-bright);
+    color: var(--color-ink);
+    background: var(--color-hover);
+  }
+  .env-pop {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    z-index: 3;
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+    width: min(320px, 86vw);
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-bright);
+    background: var(--color-panel);
+    color: var(--color-ink);
+    font-size: var(--fs-meta);
+    line-height: 1.35;
+    letter-spacing: 0.02em;
+  }
+  .env-pop strong {
+    color: var(--color-ink-bright);
+    font-size: var(--fs-meta);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+  }
+  .env-pop a {
+    color: var(--color-blue);
+    text-decoration: none;
+  }
+  .env-pop a:hover {
+    text-decoration: underline;
   }
   .plan-blocks {
     display: flex;

--- a/ui/src/lib/components/PlanPanel.svelte
+++ b/ui/src/lib/components/PlanPanel.svelte
@@ -48,7 +48,12 @@
     model: string | null | undefined,
     effort: string | null | undefined,
   ): string {
-    if (!provider) return m.planpanel_env_unavailable();
+    if (!provider) {
+      const parts: string[] = [m.planpanel_env_unavailable()];
+      if (model) parts.push(modelLabel(model));
+      if (effort) parts.push(effortLabel(effort));
+      return parts.join(" · ");
+    }
     const modelText = model ? modelLabel(model) : m.newtask_model_default();
     const effortText = effort ? effortLabel(effort) : m.effort_default();
     return `${providerLabel(provider)} · ${modelText} · ${effortText}`;

--- a/ui/src/lib/components/PlanPanel.svelte
+++ b/ui/src/lib/components/PlanPanel.svelte
@@ -272,6 +272,7 @@
                   e.stopPropagation();
                 }}
                 onkeydown={(e) => {
+                  if (e.key === "Escape") envOpen = false;
                   e.stopPropagation();
                 }}
               >

--- a/ui/src/lib/feature-announcements/entries/v1.42.0-plan-reviewer-environment.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.42.0-plan-reviewer-environment.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "plan-reviewer-environment",
+  sinceVersion: "1.42.0",
+  titleKey: "feat_plan_reviewer_environment_title",
+  bodyKey: "feat_plan_reviewer_environment_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -379,6 +379,11 @@ export interface PlanGate {
   cap: number; // the round cap this run used — the badge reads it instead of mirroring
   approved: boolean; // load-bearing gate flag: execution allowed only when true
   plan: string; // snapshot of the reviewed plan text (surfaced in the UI panel)
+  /** Resolved Plan Gate reviewer environment. Null/absent when unavailable for legacy or
+   *  restart-adopted reviews. */
+  reviewerProvider?: AgentProvider | null;
+  reviewerModel?: string | null;
+  reviewerEffort?: string | null;
   blocks?: VisualBlock[]; // optional typed visual plan blocks (model-authored); absent → flat markdown
   // Answered question-form questions, keyed `${blockId} ${questionId}` (#1332). Mirrors the
   // server field; absent ⇒ treated as []. Drives the "unanswered plan question" amber tab


### PR DESCRIPTION
## Summary
- Persist Plan Gate reviewer provider, model, and resolved effort on the gate record, including model-only recovery for adopted orphan reviewer spawns.
- Show Plan and Review CLI/model/effort chips in the Plan Gate heading with a click-open popover and configuration docs link.
- Add server/UI regression tests plus a feature announcement entry.

## Validation
- `bun run lint`
- `bun run test`
- `cd ui && bun run check`
- `cd ui && bun run test`
- `cd ui && bun run check:i18n`
- `cd extension && bun run check`
- `SHEPHERD_PREPUSH_LANE_TIMEOUT_MS=600000 git push -u origin shepherd/reviewer-cli-metadata`
- Verified `https://docs.shepherd.run/reference/configuration/` returns HTTP 200.

No manual operator steps required.

## Note
- `cd extension && bun test` was also attempted after installing extension dependencies and still fails on existing `$state` fixture tests (`ReferenceError: $state is not defined`); this change does not touch extension code, and the pre-push extension check passes.