### PR TITLE
fix(ui): add uninstall and restart plugin action

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1246,6 +1246,7 @@
   "plugins_confirm_uninstall_title": "Dieses Plugin deinstallieren?",
   "plugins_confirm_uninstall_body": "{name} entfernen? Dadurch wird sein Ordner gelöscht. Ein laufendes Plugin arbeitet weiter, bis du Shepherd neu startest.",
   "plugins_uninstall": "Deinstallieren",
+  "plugins_uninstall_restart_shepherd": "Deinstallieren + Shepherd neu starten",
   "plugins_activate": "Aktivieren",
   "plugins_activating": "Aktiviere…",
   "plugins_activate_needs_restart": "„{name}“ wurde mit einem Fehler geladen — installiere ggf. seine Abhängigkeiten (bun install) und starte Shepherd neu.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1246,6 +1246,7 @@
   "plugins_confirm_uninstall_title": "Uninstall this plugin?",
   "plugins_confirm_uninstall_body": "Remove {name}? This deletes its folder. A running plugin keeps working until you restart Shepherd.",
   "plugins_uninstall": "Uninstall",
+  "plugins_uninstall_restart_shepherd": "Uninstall + restart Shepherd",
   "plugins_activate": "Activate",
   "plugins_activating": "Activating…",
   "plugins_activate_needs_restart": "\"{name}\" loaded with an error — it may need its dependencies installed (bun install), then a restart of Shepherd.",

--- a/ui/src/lib/components/RestartShepherdDialog.svelte
+++ b/ui/src/lib/components/RestartShepherdDialog.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import { dialog } from "$lib/a11yDialog";
   import { m } from "$lib/paraglide/messages";
   import { triggerRestart } from "$lib/api";
 
-  let { onclose }: { onclose?: () => void } = $props();
+  let {
+    onclose,
+    shepherdOnly = false,
+    autoStart = false,
+  }: { onclose?: () => void; shepherdOnly?: boolean; autoStart?: boolean } = $props();
 
   const RESTART_CMD = "systemctl --user restart shepherd";
   /** give systemctl this long to take the old process down before assuming the
@@ -60,14 +65,21 @@
 
   async function confirm() {
     error = null;
-    const res = await triggerRestart({ herdr: alsoHerdr });
+    const res = await triggerRestart({ herdr: shepherdOnly ? false : alsoHerdr });
     if (!res.ok) {
       error = restartErr(res.error);
+      phase = "confirm";
       return;
     }
     phase = "restarting";
     void rideThrough();
   }
+
+  onMount(() => {
+    if (!autoStart) return;
+    phase = "restarting";
+    void confirm();
+  });
 
   // the dialog blocks dismissal mid-restart: there is nothing sensible to go
   // back to while the server is down
@@ -99,13 +111,15 @@
 
     {#if phase === "confirm"}
       <p class="body">{m.restart_confirm_body()}</p>
-      <label class="herdr">
-        <input type="checkbox" bind:checked={alsoHerdr} />
-        <span>
-          <span class="herdr-label">{m.restart_herdr_label()}</span>
-          <span class="herdr-note">{m.restart_herdr_note()}</span>
-        </span>
-      </label>
+      {#if !shepherdOnly}
+        <label class="herdr">
+          <input type="checkbox" bind:checked={alsoHerdr} />
+          <span>
+            <span class="herdr-label">{m.restart_herdr_label()}</span>
+            <span class="herdr-note">{m.restart_herdr_note()}</span>
+          </span>
+        </label>
+      {/if}
       {#if error}
         <div class="err" role="alert">
           {error}

--- a/ui/src/lib/components/settings/PluginConfirmDialog.svelte
+++ b/ui/src/lib/components/settings/PluginConfirmDialog.svelte
@@ -3,15 +3,18 @@
   import { dialog } from "$lib/a11yDialog";
 
   type Confirm =
-    { kind: "install"; url: string } | { kind: "uninstall"; folder: string; name: string };
+    | { kind: "install"; url: string }
+    | { kind: "uninstall"; folder: string; name: string; loaded: boolean };
 
   let {
     confirm,
     onconfirm,
+    onconfirmrestart,
     oncancel,
   }: {
     confirm: Confirm;
     onconfirm: (c: Confirm) => void;
+    onconfirmrestart: (c: Extract<Confirm, { kind: "uninstall" }>) => void;
     oncancel: () => void;
   } = $props();
 
@@ -49,6 +52,11 @@
 
     <div class="actions">
       <button type="button" class="ghost" onclick={oncancel}>{m.common_cancel()}</button>
+      {#if confirm.kind === "uninstall" && confirm.loaded}
+        <button type="button" class="run danger wide" onclick={() => onconfirmrestart(confirm)}>
+          {m.plugins_uninstall_restart_shepherd()}
+        </button>
+      {/if}
       <button
         type="button"
         class="run"
@@ -120,6 +128,7 @@
   .actions {
     display: flex;
     justify-content: flex-end;
+    flex-wrap: wrap;
     gap: 8px;
     margin-top: 2px;
   }
@@ -142,6 +151,11 @@
   .run.danger {
     border-color: var(--color-red);
     color: var(--color-red);
+  }
+  .run.wide {
+    max-width: 100%;
+    white-space: normal;
+    text-align: center;
   }
   @media (max-width: 768px) {
     .overlay {

--- a/ui/src/lib/components/settings/SettingsPluginsPanel.browser.test.ts
+++ b/ui/src/lib/components/settings/SettingsPluginsPanel.browser.test.ts
@@ -118,7 +118,39 @@ function stubApply(rows: InstalledPlugin[], apply: () => { payload: unknown; sta
   return calls;
 }
 
-afterEach(() => vi.unstubAllGlobals());
+function stubUninstallRestart(rows: InstalledPlugin[]) {
+  const calls: { url: string; method: string; body: string }[] = [];
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    calls.push({ url, method, body: init?.body ? String(init.body) : "" });
+    if (url.includes("/api/plugins/manage/installed/")) {
+      return new Response(null, { status: 204 });
+    }
+    if (url.includes("/api/restart")) {
+      return new Response(JSON.stringify({ started: true }), {
+        status: 202,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.includes("/api/health")) {
+      return new Response("ok", { status: 200 });
+    }
+    if (url.includes("/api/plugins/manage/installed")) {
+      return new Response(JSON.stringify({ installed: rows }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response("{}", { status: 404 });
+  });
+  return calls;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
 
 describe("SettingsPluginsPanel", () => {
   it("always shows the install-from-URL section", async () => {
@@ -228,6 +260,51 @@ describe("SettingsPluginsPanel", () => {
     render(SettingsPluginsPanel, { plugins: [plugin({ id: "gone", name: "Gone Plugin" })] });
     await expect.element(page.getByText(/restart to unload/i)).toBeVisible();
     await expect.element(page.getByText("systemctl --user restart shepherd")).toBeVisible();
+  });
+
+  it("a loaded plugin confirmation offers uninstall plus Shepherd-only restart", async () => {
+    const calls = stubUninstallRestart([inst({ loaded: true })]);
+    render(SettingsPluginsPanel, { plugins: [plugin()] });
+
+    await page.getByRole("button", { name: "Uninstall" }).click();
+    await expect
+      .element(page.getByRole("button", { name: "Uninstall + restart Shepherd" }))
+      .toBeVisible();
+
+    await page.getByRole("button", { name: "Uninstall + restart Shepherd" }).click();
+    await expect.element(page.getByText("Restarting Shepherd — waiting for it to come back…")).toBeVisible();
+
+    await vi.waitFor(() =>
+      expect(calls.some((c) => c.url.includes("/api/restart") && c.body === '{"herdr":false}')).toBe(
+        true,
+      ),
+    );
+    const uninstallIdx = calls.findIndex((c) => c.method === "DELETE");
+    const restartIdx = calls.findIndex((c) => c.url.includes("/api/restart"));
+    expect(uninstallIdx).toBeGreaterThanOrEqual(0);
+    expect(restartIdx).toBeGreaterThan(uninstallIdx);
+  });
+
+  it("not-loaded plugin confirmations do not offer uninstall plus restart", async () => {
+    stubScan([inst({ id: "fresh", name: "Fresh Plugin", folder: "fresh" })]);
+    render(SettingsPluginsPanel, { plugins: [] });
+
+    await page.getByRole("button", { name: "Uninstall" }).click();
+    await expect.element(page.getByText("Uninstall this plugin?")).toBeVisible();
+    expect(document.body.textContent).not.toContain("Uninstall + restart Shepherd");
+  });
+
+  it("plain uninstall does not restart Shepherd", async () => {
+    const calls = stubUninstallRestart([inst({ loaded: true })]);
+    render(SettingsPluginsPanel, { plugins: [plugin()] });
+
+    await page.getByRole("button", { name: "Uninstall" }).click();
+    await page
+      .getByRole("dialog", { name: "Uninstall this plugin?" })
+      .getByRole("button", { name: "Uninstall", exact: true })
+      .click();
+    await vi.waitFor(() => expect(calls.some((c) => c.method === "DELETE")).toBe(true));
+    expect(calls.some((c) => c.url.includes("/api/restart"))).toBe(false);
   });
 
   it("a pending plugin exposes an Activate button that posts + triggers a store refresh", async () => {

--- a/ui/src/lib/components/settings/SettingsPluginsPanel.browser.test.ts
+++ b/ui/src/lib/components/settings/SettingsPluginsPanel.browser.test.ts
@@ -272,12 +272,14 @@ describe("SettingsPluginsPanel", () => {
       .toBeVisible();
 
     await page.getByRole("button", { name: "Uninstall + restart Shepherd" }).click();
-    await expect.element(page.getByText("Restarting Shepherd — waiting for it to come back…")).toBeVisible();
+    await expect
+      .element(page.getByText("Restarting Shepherd — waiting for it to come back…"))
+      .toBeVisible();
 
     await vi.waitFor(() =>
-      expect(calls.some((c) => c.url.includes("/api/restart") && c.body === '{"herdr":false}')).toBe(
-        true,
-      ),
+      expect(
+        calls.some((c) => c.url.includes("/api/restart") && c.body === '{"herdr":false}'),
+      ).toBe(true),
     );
     const uninstallIdx = calls.findIndex((c) => c.method === "DELETE");
     const restartIdx = calls.findIndex((c) => c.url.includes("/api/restart"));

--- a/ui/src/lib/components/settings/SettingsPluginsPanel.svelte
+++ b/ui/src/lib/components/settings/SettingsPluginsPanel.svelte
@@ -58,9 +58,11 @@
 
   // Blocking confirm — trust warning before an install, plain confirm before an uninstall.
   type Confirm =
-    { kind: "install"; url: string } | { kind: "uninstall"; folder: string; name: string };
+    | { kind: "install"; url: string }
+    | { kind: "uninstall"; folder: string; name: string; loaded: boolean };
   let confirm = $state<Confirm | null>(null);
   let restartOpen = $state(false); // the one-click Restart-Shepherd dialog
+  let restartAutoStart = $state(false);
 
   const RESTART_CMD = "systemctl --user restart shepherd";
 
@@ -271,14 +273,19 @@
     confirm = { kind: "install", url: u };
   }
 
-  function askUninstall(folder: string, name: string) {
+  function askUninstall(folder: string, name: string, loaded = false) {
     actionError = null;
-    confirm = { kind: "uninstall", folder, name };
+    confirm = { kind: "uninstall", folder, name, loaded };
   }
 
   function onConfirm(c: Confirm) {
     if (c.kind === "install") runInstall(c.url);
     else runUninstall(c.folder);
+  }
+
+  function openRestart(autoStart: boolean) {
+    restartAutoStart = autoStart;
+    restartOpen = true;
   }
 
   async function runInstall(u: string) {
@@ -306,6 +313,22 @@
       const res = await uninstallPlugin(folder);
       if (res.ok) await loadInstalled();
       else actionError = errorMessage(res.error);
+    } finally {
+      busyFolder = null;
+    }
+  }
+
+  async function runUninstallAndRestart(folder: string) {
+    busyFolder = folder;
+    actionError = null;
+    confirm = null;
+    try {
+      const res = await uninstallPlugin(folder);
+      if (res.ok) {
+        openRestart(true);
+      } else {
+        actionError = errorMessage(res.error);
+      }
     } finally {
       busyFolder = null;
     }
@@ -429,7 +452,7 @@
         plugin={row.info}
         folder={row.folder}
         busy={busyFolder === row.folder}
-        onuninstall={askUninstall}
+        onuninstall={(folder, name) => askUninstall(folder, name, true)}
         update={cardUpdate(rowId)}
         onupdate={() => runUpdate(rowId)}
       />
@@ -475,7 +498,7 @@
           type="button"
           class="gbtn del"
           disabled={busyFolder === row.inst.folder}
-          onclick={() => askUninstall(row.inst.folder, row.inst.name)}
+          onclick={() => askUninstall(row.inst.folder, row.inst.name, false)}
         >
           {m.plugins_uninstall()}
         </button>
@@ -504,11 +527,23 @@
 </div>
 
 {#if confirm}
-  <PluginConfirmDialog {confirm} onconfirm={onConfirm} oncancel={() => (confirm = null)} />
+  <PluginConfirmDialog
+    {confirm}
+    onconfirm={onConfirm}
+    onconfirmrestart={(c) => runUninstallAndRestart(c.folder)}
+    oncancel={() => (confirm = null)}
+  />
 {/if}
 
 {#if restartOpen}
-  <RestartShepherdDialog onclose={() => (restartOpen = false)} />
+  <RestartShepherdDialog
+    shepherdOnly={restartAutoStart}
+    autoStart={restartAutoStart}
+    onclose={() => {
+      restartOpen = false;
+      restartAutoStart = false;
+    }}
+  />
 {/if}
 
 <style>

--- a/ui/src/lib/components/settings/SettingsPluginsPanel.svelte
+++ b/ui/src/lib/components/settings/SettingsPluginsPanel.svelte
@@ -325,6 +325,7 @@
     try {
       const res = await uninstallPlugin(folder);
       if (res.ok) {
+        await loadInstalled();
         openRestart(true);
       } else {
         actionError = errorMessage(res.error);


### PR DESCRIPTION
## Summary
- add a loaded-plugin-only `Uninstall + restart Shepherd` action to the plugin uninstall dialog
- reuse `RestartShepherdDialog` in Shepherd-only auto-start mode so herdr is never restarted from this path
- cover loaded, not-loaded, and plain-uninstall behavior in the plugins panel browser test

## Verification
- `cd ui && bun run check:i18n`
- `cd ui && bun run check` (passes with pre-existing warnings in `CommandBar.svelte` and `FilesPanel.svelte`)
- `cd ui && bun run test:browser -- SettingsPluginsPanel.browser.test.ts`

## Notes
- Attempted `cd ui && bun test`; it invokes Bun native test mode in this worktree and produced unrelated existing suite failures for Vitest/browser-mode tests, then did not terminate promptly. The process was stopped after the focused relevant test passed.