### PR TITLE
feat(ui): rotate compact usage gauges by provider

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2620,5 +2620,9 @@
   "planpanel_env_popover_title": "Coding-Umgebung",
   "planpanel_env_popover_body": "Plan zeigt Coding-CLI, Modell und Reasoning Effort der Task-Session. Prüfung zeigt den Plan-Gate-Reviewer, der diesen Plan geprüft hat. Task-Defaults änderst du in Neuer Task, in Repo-Defaults oder globalen Defaults; den Reviewer unter Einstellungen -> CLIs -> Planer (Plan-Reviewer).",
   "planpanel_env_docs_link": "Konfigurationsdoku öffnen",
-  "herd_rework_running_group": "REWORK läuft ({count})"
+  "herd_rework_running_group": "REWORK läuft ({count})",
+  "topbar_usage_provider_short_claude": "CC",
+  "topbar_usage_provider_short_codex": "CX",
+  "feat_usage_gauge_provider_rotation_title": "Auslastungsanzeigen wechseln nach CLI",
+  "feat_usage_gauge_provider_rotation_body": "Wenn Auslastungsdaten für Claude Code und Codex konfiguriert sind, wechselt die kompakte Anzeige in der Topbar jetzt alle zwei Minuten zwischen CC und CX. Codex zeigt Limit-Balken, sobald sie verfügbar sind, oder Token-Summen, bis die CLI Reset-Fenster meldet."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2620,5 +2620,9 @@
   "planpanel_env_popover_title": "Coding environment",
   "planpanel_env_popover_body": "Plan shows the task session's coding CLI, model and reasoning effort. Review shows the Plan Gate reviewer that checked this plan. Change task defaults in New Task, repo defaults or global defaults; change the reviewer under Settings -> CLIs -> Planner (plan reviewer).",
   "planpanel_env_docs_link": "Open configuration docs",
-  "herd_rework_running_group": "Rework running ({count})"
+  "herd_rework_running_group": "Rework running ({count})",
+  "topbar_usage_provider_short_claude": "CC",
+  "topbar_usage_provider_short_codex": "CX",
+  "feat_usage_gauge_provider_rotation_title": "Usage gauges rotate by CLI",
+  "feat_usage_gauge_provider_rotation_body": "When Claude Code and Codex usage data are both configured, the compact top-bar gauge now alternates every two minutes between CC and CX. Codex shows rate-limit bars when available, or token totals until the CLI reports reset windows."
 }

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -1678,6 +1678,53 @@ describe("TopBar — CR extra-credit gauge", () => {
     expect(text, "full popover still has Codex").toContain(m.agent_provider_codex());
   });
 
+  it("does not restart compact usage rotation on live percentage updates", async () => {
+    vi.useFakeTimers();
+    await page.viewport(1436, 900);
+    document.body.style.width = "1436px";
+    const props = {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.desktop,
+      ...sessionsProp(0),
+    };
+    const { rerender } = render(TopBar, {
+      ...props,
+      limits: withCodex(fullLimits, { windows: true }),
+    });
+    const hud = document.querySelector<HTMLElement>(".hud");
+    expect(hud, "TopBar .hud mounted").not.toBeNull();
+    const toggle = hud!.querySelector<HTMLElement>(".gauges-toggle");
+    expect(toggle, "rotating toggle present").not.toBeNull();
+    expect(toggle!.textContent ?? "", "starts on Claude").toContain(
+      m.topbar_usage_provider_short_claude(),
+    );
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await rerender({
+      ...props,
+      limits: withCodex(
+        {
+          ...fullLimits,
+          session5h: { pct: 89, resetAt: 1_700_003_600_000 },
+          week: { pct: 65, resetAt: 1_700_600_000_000 },
+        },
+        { windows: true },
+      ),
+    });
+    await Promise.resolve();
+    expect(toggle!.textContent ?? "", "usage update does not immediately rotate").toContain(
+      m.topbar_usage_provider_short_claude(),
+    );
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await Promise.resolve();
+
+    expect(toggle!.textContent ?? "", "rotates at the original two-minute mark").toContain(
+      m.topbar_usage_provider_short_codex(),
+    );
+  });
+
   it("rotates desktop compact usage to Codex token fallback when Codex has no windows", async () => {
     vi.useFakeTimers();
     const hud = await renderDesktop(withCodex(fullLimits));

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -5,6 +5,7 @@ import "../../app.css";
 import type { Session, UsageLimits, UpdateStatus, HerdrUpdateStatus, HeldTask } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
 import { REPO_URL, DOCS_URL, version } from "$lib/build-info";
+import { formatTokenLabel } from "$lib/format";
 
 // Mock api so the manual /usage refresh path never fires a real network call —
 // individual tests stub refreshUsage's resolution/rejection per case.
@@ -34,6 +35,7 @@ beforeEach(() => {
   document.head.appendChild(fontStyle);
 });
 afterEach(() => {
+  vi.useRealTimers();
   fontStyle.remove();
   document.body.innerHTML = "";
   document.body.style.width = "";
@@ -1364,6 +1366,45 @@ describe("TopBar — CR extra-credit gauge", () => {
     };
   }
 
+  function withCodex(
+    base: UsageLimits,
+    {
+      stale = false,
+      windows = false,
+    }: {
+      stale?: boolean;
+      windows?: boolean;
+    } = {},
+  ): UsageLimits {
+    return {
+      ...base,
+      providers: [
+        {
+          provider: "claude",
+          kind: "limits",
+          session5h: base.session5h,
+          week: base.week,
+          perModelWeek: base.perModelWeek,
+          credits: base.credits,
+          stale: base.stale,
+          calibratedAt: base.calibratedAt,
+          subscriptionOnly: base.subscriptionOnly,
+        },
+        {
+          provider: "codex",
+          kind: "tokens",
+          totalTokens: 92_600_000,
+          session5hTokens: 404_000,
+          weekTokens: 92_600_000,
+          updatedAt: 1_700_000_000_000,
+          stale,
+          session5h: windows ? { pct: 9, resetAt: 1_700_014_400_000 } : null,
+          week: windows ? { pct: 1, resetAt: 1_700_600_000_000 } : null,
+        },
+      ],
+    };
+  }
+
   async function renderTouch(limits: UsageLimits | null) {
     await page.viewport(1000, 900);
     document.body.style.width = "1000px";
@@ -1594,7 +1635,10 @@ describe("TopBar — CR extra-credit gauge", () => {
     const toggle = hud.querySelector<HTMLElement>(".gauges-toggle");
     expect(toggle, "codex-only toggle present").not.toBeNull();
     expect(toggle!.textContent ?? "", "inline codex token count").toContain(
-      m.agent_provider_codex(),
+      formatTokenLabel(92_600_000),
+    );
+    expect(toggle!.textContent ?? "", "single provider is unprefixed").not.toContain(
+      m.topbar_usage_provider_short_codex(),
     );
 
     openDesktopPopover(hud);
@@ -1608,13 +1652,85 @@ describe("TopBar — CR extra-credit gauge", () => {
     expect(text, "weekly token row").toContain(m.topbar_tokens_window({ period: "WK" }));
   });
 
+  it("rotates desktop compact usage from Claude to Codex limit gauges", async () => {
+    vi.useFakeTimers();
+    const hud = await renderDesktop(withCodex(fullLimits, { windows: true }));
+    const toggle = hud.querySelector<HTMLElement>(".gauges-toggle");
+    expect(toggle, "rotating toggle present").not.toBeNull();
+    expect(toggle!.textContent ?? "", "starts on Claude").toContain(
+      m.topbar_usage_provider_short_claude(),
+    );
+    expect(toggle!.textContent ?? "", "Claude window visible").toContain("88%");
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    await Promise.resolve();
+
+    expect(toggle!.textContent ?? "", "rotates to Codex").toContain(
+      m.topbar_usage_provider_short_codex(),
+    );
+    expect(toggle!.textContent ?? "", "Codex window visible").toContain("9%");
+
+    openDesktopPopover(hud);
+    await Promise.resolve();
+    const pop = hud.querySelector<HTMLElement>(".gauge-pop-desk");
+    const text = pop!.textContent ?? "";
+    expect(text, "full popover still has Claude").toContain(m.agent_provider_claude());
+    expect(text, "full popover still has Codex").toContain(m.agent_provider_codex());
+  });
+
+  it("rotates desktop compact usage to Codex token fallback when Codex has no windows", async () => {
+    vi.useFakeTimers();
+    const hud = await renderDesktop(withCodex(fullLimits));
+    const toggle = hud.querySelector<HTMLElement>(".gauges-toggle");
+    expect(toggle, "rotating toggle present").not.toBeNull();
+    expect(toggle!.textContent ?? "", "starts on Claude").toContain(
+      m.topbar_usage_provider_short_claude(),
+    );
+    expect(toggle!.textContent ?? "", "Claude window visible").toContain("88%");
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    await Promise.resolve();
+
+    expect(toggle!.textContent ?? "", "rotates to Codex").toContain(
+      m.topbar_usage_provider_short_codex(),
+    );
+    expect(toggle!.textContent ?? "", "Codex token fallback visible").toContain(
+      formatTokenLabel(92_600_000),
+    );
+  });
+
+  it("rotates touch compact usage to Codex token fallback", async () => {
+    vi.useFakeTimers();
+    const hud = await renderTouch(withCodex(fullLimits));
+    const toggle = hud.querySelector<HTMLElement>(".gauge-btn");
+    expect(toggle, "rotating touch toggle present").not.toBeNull();
+    expect(toggle!.textContent ?? "", "starts on Claude").toContain(
+      m.topbar_usage_provider_short_claude(),
+    );
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    await Promise.resolve();
+
+    const rotated = hud.querySelector<HTMLElement>(".gauge-btn");
+    expect(rotated, "rotated touch toggle present").not.toBeNull();
+    expect(rotated!.textContent ?? "", "rotates to Codex").toContain(
+      m.topbar_usage_provider_short_codex(),
+    );
+    expect(rotated!.textContent ?? "", "Codex token fallback visible").toContain(
+      formatTokenLabel(92_600_000),
+    );
+  });
+
   it("codex-only touch toggle dims when the Codex snapshot is stale", async () => {
     const hud = await renderTouch(codexOnly({ stale: true }));
     const toggle = hud.querySelector<HTMLElement>(".gauge-btn");
 
     expect(toggle, "codex-only touch toggle present").not.toBeNull();
     expect(toggle!.textContent ?? "", "inline codex token count").toContain(
-      m.agent_provider_codex(),
+      formatTokenLabel(92_600_000),
+    );
+    expect(toggle!.textContent ?? "", "single provider is unprefixed").not.toContain(
+      m.topbar_usage_provider_short_codex(),
     );
     expect(toggle!.classList.contains("stale"), "stale codex-only toggle is dimmed").toBe(true);
   });

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -1699,6 +1699,37 @@ describe("TopBar — CR extra-credit gauge", () => {
     );
   });
 
+  it("rotates touch compact usage from Claude to Codex limit gauges with provider aria labels", async () => {
+    vi.useFakeTimers();
+    const hud = await renderTouch(withCodex(fullLimits, { windows: true }));
+    const toggle = hud.querySelector<HTMLElement>(".gauge-btn");
+    expect(toggle, "rotating touch toggle present").not.toBeNull();
+    expect(toggle!.textContent ?? "", "starts on Claude").toContain(
+      m.topbar_usage_provider_short_claude(),
+    );
+    expect(toggle!.getAttribute("aria-label") ?? "", "Claude provider in aria label").toContain(
+      m.agent_provider_claude(),
+    );
+    expect(toggle!.getAttribute("aria-label") ?? "", "Claude limit in aria label").toContain(
+      m.topbar_gauge_toggle_aria({ period: m.topbar_gauge_period_5h(), pct: 88 }),
+    );
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    await Promise.resolve();
+
+    const rotated = hud.querySelector<HTMLElement>(".gauge-btn");
+    expect(rotated, "rotated touch toggle present").not.toBeNull();
+    expect(rotated!.textContent ?? "", "rotates to Codex").toContain(
+      m.topbar_usage_provider_short_codex(),
+    );
+    expect(rotated!.getAttribute("aria-label") ?? "", "Codex provider in aria label").toContain(
+      m.agent_provider_codex(),
+    );
+    expect(rotated!.getAttribute("aria-label") ?? "", "Codex limit in aria label").toContain(
+      m.topbar_gauge_toggle_aria({ period: m.topbar_gauge_period_5h(), pct: 9 }),
+    );
+  });
+
   it("rotates touch compact usage to Codex token fallback", async () => {
     vi.useFakeTimers();
     const hud = await renderTouch(withCodex(fullLimits));

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -302,13 +302,12 @@
   const creditColor = $derived(
     credits?.stale ? "var(--color-muted)" : overspend ? "var(--color-amber)" : "var(--color-muted)",
   );
-  function compactUsageMeasureKey(view: CompactUsageView): string {
+  function compactUsageLayoutKey(view: CompactUsageView): string {
     const base = `${view.provider}:${view.mode}:${view.widthClass}`;
     if (view.mode === "limits") {
-      return `${base}:${view.gauges.map((g) => `${g.label}:${g.w.pct}`).join(",")}`;
+      return `${base}:${view.gauges.map((g) => g.label).join(",")}`;
     }
-    if (view.mode === "tokens") return `${base}:${view.totalTokens}`;
-    if (view.mode === "model") return `${base}:${view.model.model}:${view.model.pct}`;
+    if (view.mode === "model") return `${base}:${view.model.model}`;
     return base;
   }
   const compactUsageViews = $derived(
@@ -323,10 +322,11 @@
   const rotatingCompactUsageViews = $derived(
     compactUsageViews.filter((view) => view.rotationEligible),
   );
-  const compactUsageRotating = $derived(rotatingCompactUsageViews.length >= 2);
+  const rotatingCompactUsageCount = $derived(rotatingCompactUsageViews.length);
+  const compactUsageRotating = $derived(rotatingCompactUsageCount >= 2);
   const compactUsageSetSignature = $derived(
     `${compactUsageRotating ? "rot" : "single"}:${compactUsageViews
-      .map(compactUsageMeasureKey)
+      .map(compactUsageLayoutKey)
       .join("|")}`,
   );
   let activeCompactUsageIndex = $state(0);
@@ -340,7 +340,7 @@
 
   $effect(() => {
     const signature = compactUsageSetSignature;
-    const count = rotatingCompactUsageViews.length;
+    const count = rotatingCompactUsageCount;
     void signature;
     activeCompactUsageIndex = 0;
     if (count < 2) return;

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -302,7 +302,13 @@
     credits?.stale ? "var(--color-muted)" : overspend ? "var(--color-amber)" : "var(--color-muted)",
   );
   const compactUsageViews = $derived(
-    compactUsageViewList({ gauges, perModel, credits, codexUsage }),
+    compactUsageViewList({
+      gauges,
+      claudeStale: limits?.stale ?? false,
+      perModel,
+      credits,
+      codexUsage,
+    }),
   );
   const rotatingCompactUsageViews = $derived(
     compactUsageViews.filter((view) => view.rotationEligible),

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -9,6 +9,7 @@
   } from "$lib/types";
   import { displayStatus } from "$lib/display-status";
   import {
+    compactUsageViews as compactUsageViewList,
     codexTokenUsage,
     gaugeList,
     hotterGauge,
@@ -218,6 +219,11 @@
     // neither this effect nor the ResizeObserver would re-fire — the bar would stay
     // un-compacted and overflow until an unrelated resize/badge change self-healed it.
     void gauges.length;
+    // Compact provider rotation changes top-bar content without changing `gauges.length`.
+    // Remeasure when the provider set/rotation state changes, and when the active view moves
+    // between width classes (e.g. two bars ↔ token total), but not for same-width provider ticks.
+    void compactUsageSetSignature;
+    void activeCompactUsageWidthClass;
     if (mode === "mobile") {
       measuredCompact = false;
       fullWidth = 0; // mobile: clear the cache so re-entry re-measures fresh
@@ -295,6 +301,38 @@
   const creditColor = $derived(
     credits?.stale ? "var(--color-muted)" : overspend ? "var(--color-amber)" : "var(--color-muted)",
   );
+  const compactUsageViews = $derived(
+    compactUsageViewList({ gauges, perModel, credits, codexUsage }),
+  );
+  const rotatingCompactUsageViews = $derived(
+    compactUsageViews.filter((view) => view.rotationEligible),
+  );
+  const compactUsageRotating = $derived(rotatingCompactUsageViews.length >= 2);
+  const compactUsageSetSignature = $derived(
+    `${compactUsageRotating ? "rot" : "single"}:${compactUsageViews
+      .map((view) => `${view.provider}:${view.mode}:${view.widthClass}`)
+      .join("|")}`,
+  );
+  let activeCompactUsageIndex = $state(0);
+  const activeCompactUsageView = $derived(
+    compactUsageRotating
+      ? (rotatingCompactUsageViews[activeCompactUsageIndex % rotatingCompactUsageViews.length] ??
+          null)
+      : (compactUsageViews[0] ?? null),
+  );
+  const activeCompactUsageWidthClass = $derived(activeCompactUsageView?.widthClass ?? "none");
+
+  $effect(() => {
+    const signature = compactUsageSetSignature;
+    const count = rotatingCompactUsageViews.length;
+    void signature;
+    activeCompactUsageIndex = 0;
+    if (count < 2) return;
+    const rotate = setInterval(() => {
+      activeCompactUsageIndex = (activeCompactUsageIndex + 1) % count;
+    }, 120_000);
+    return () => clearInterval(rotate);
+  });
 
   // Refresh: POST /api/usage/refresh; the server's calibrate emit bridges back to the
   // client `ln` WS frame, so the gauge self-updates — we ignore the returned value.
@@ -724,11 +762,12 @@
         {subscriptionOnly}
         {touch}
         stale={limits?.stale ?? false}
-        {hotter}
         {gauges}
         {perModel}
         {credits}
         {codexUsage}
+        {activeCompactUsageView}
+        {compactUsageRotating}
         {overspend}
         {creditFill}
         {creditColor}

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -15,6 +15,7 @@
     hotterGauge,
     modelWeekList,
     overspending,
+    type CompactUsageView,
     type GaugeKey,
   } from "./usage-gauges";
   import {
@@ -301,6 +302,15 @@
   const creditColor = $derived(
     credits?.stale ? "var(--color-muted)" : overspend ? "var(--color-amber)" : "var(--color-muted)",
   );
+  function compactUsageMeasureKey(view: CompactUsageView): string {
+    const base = `${view.provider}:${view.mode}:${view.widthClass}`;
+    if (view.mode === "limits") {
+      return `${base}:${view.gauges.map((g) => `${g.label}:${g.w.pct}`).join(",")}`;
+    }
+    if (view.mode === "tokens") return `${base}:${view.totalTokens}`;
+    if (view.mode === "model") return `${base}:${view.model.model}:${view.model.pct}`;
+    return base;
+  }
   const compactUsageViews = $derived(
     compactUsageViewList({
       gauges,
@@ -316,7 +326,7 @@
   const compactUsageRotating = $derived(rotatingCompactUsageViews.length >= 2);
   const compactUsageSetSignature = $derived(
     `${compactUsageRotating ? "rot" : "single"}:${compactUsageViews
-      .map((view) => `${view.provider}:${view.mode}:${view.widthClass}`)
+      .map(compactUsageMeasureKey)
       .join("|")}`,
   );
   let activeCompactUsageIndex = $state(0);

--- a/ui/src/lib/components/top-bar/TopBarUsage.svelte
+++ b/ui/src/lib/components/top-bar/TopBarUsage.svelte
@@ -75,6 +75,17 @@
         ? m.agent_provider_codex()
         : "",
   );
+  const activeHotGaugeLabel = $derived(
+    activeHotGauge
+      ? m.topbar_gauge_toggle_aria({
+          period: periodLabel(activeHotGauge.label),
+          pct: activeHotGauge.w.pct,
+        })
+      : "",
+  );
+  const activeTouchLimitLabel = $derived(
+    compactUsageRotating ? `${activeProviderName} · ${activeHotGaugeLabel}` : activeHotGaugeLabel,
+  );
 </script>
 
 {#if subscriptionOnly && !codexUsage}
@@ -94,10 +105,7 @@
           type="button"
           aria-haspopup="dialog"
           aria-expanded={popoverOpen}
-          aria-label={m.topbar_gauge_toggle_aria({
-            period: periodLabel(activeHotGauge.label),
-            pct: activeHotGauge.w.pct,
-          })}
+          aria-label={activeTouchLimitLabel}
           onclick={() => (popoverOpen = !popoverOpen)}
         >
           {#if compactUsageRotating}<span class="g-provider micro">{activeProviderShort}</span>{/if}

--- a/ui/src/lib/components/top-bar/TopBarUsage.svelte
+++ b/ui/src/lib/components/top-bar/TopBarUsage.svelte
@@ -4,6 +4,7 @@
   import type { UsageProviderSnapshot } from "$lib/types";
   import { formatTokenLabel } from "$lib/format";
   import { gaugeColor, modelDisplayName, type GaugeKey } from "../usage-gauges";
+  import type { CompactUsageView } from "../usage-gauges";
   import type { Gauge } from "../usage-gauges";
   import CreditGauge from "./CreditGauge.svelte";
   import TopBarUsagePopover from "./TopBarUsagePopover.svelte";
@@ -12,11 +13,12 @@
     subscriptionOnly,
     touch,
     stale,
-    hotter,
     gauges,
     perModel,
     credits,
     codexUsage,
+    activeCompactUsageView,
+    compactUsageRotating,
     overspend,
     creditFill,
     creditColor,
@@ -33,11 +35,12 @@
     subscriptionOnly: boolean;
     touch: boolean;
     stale: boolean;
-    hotter: Gauge | null;
     gauges: Gauge[];
     perModel: ModelWeekWindow[];
     credits: CreditWindow | null;
     codexUsage: Extract<UsageProviderSnapshot, { provider: "codex"; kind: "tokens" }> | null;
+    activeCompactUsageView: CompactUsageView | null;
+    compactUsageRotating: boolean;
     overspend: boolean;
     creditFill: number;
     creditColor: string;
@@ -52,67 +55,82 @@
     gaugeWrap: HTMLElement | null;
   } = $props();
 
-  // Desktop compact rule: show 5H+WK percentages inline, but swap to the CR amount when a window
-  // is pinned at its cap (% is uninformative there and the live credit € is the actionable number)
-  // OR when there are no usage windows at all (credits-only state — otherwise the toggle is blank).
-  const capped = $derived(gauges.some((g) => g.w.pct >= 100));
-  const showCreditsInline = $derived((capped || gauges.length === 0) && !!credits);
-  // Per-model passthrough (e.g. Fable) as a collapse/inline fallback trigger: when it is the ONLY
-  // usage signal (no calibrated 5H/WK gauge, no credits/codex), the section would otherwise render
-  // no affordance and the Fable bar in the popover couldn't be opened.
-  const perModelHot = $derived(perModel.length ? perModel[0]! : null);
+  const activeHotGauge = $derived(
+    activeCompactUsageView?.mode === "limits"
+      ? activeCompactUsageView.gauges.reduce((hot, g) => (g.w.pct >= hot.w.pct ? g : hot))
+      : null,
+  );
+  const activeStale = $derived(activeCompactUsageView?.stale ?? false);
+  const activeProviderShort = $derived(
+    activeCompactUsageView?.provider === "claude"
+      ? m.topbar_usage_provider_short_claude()
+      : activeCompactUsageView?.provider === "codex"
+        ? m.topbar_usage_provider_short_codex()
+        : "",
+  );
+  const activeProviderName = $derived(
+    activeCompactUsageView?.provider === "claude"
+      ? m.agent_provider_claude()
+      : activeCompactUsageView?.provider === "codex"
+        ? m.agent_provider_codex()
+        : "",
+  );
 </script>
 
 {#if subscriptionOnly && !codexUsage}
   <span class="usage-sub-only micro">{m.usage_subscription_only()}</span>
 {:else if touch}
-  {#if hotter || credits || codexUsage || perModelHot}
+  {#if activeCompactUsageView}
     <!-- touch: collapse to the hotter window (or the CR gauge when credits are the
          only signal, or a per-model bar when Fable is the only signal); tap for the
          full breakdown. The collapsed button carries an alert state while extra
          credits are being spent. -->
     <div class="gauge-wrap" bind:this={gaugeWrap}>
-      {#if hotter}
+      {#if activeCompactUsageView.mode === "limits" && activeHotGauge}
         <button
           class="gauge gauge-btn"
-          class:stale
+          class:stale={activeStale}
           class:alert={overspend}
           type="button"
           aria-haspopup="dialog"
           aria-expanded={popoverOpen}
           aria-label={m.topbar_gauge_toggle_aria({
-            period: periodLabel(hotter.label),
-            pct: hotter.w.pct,
+            period: periodLabel(activeHotGauge.label),
+            pct: activeHotGauge.w.pct,
           })}
           onclick={() => (popoverOpen = !popoverOpen)}
         >
-          <span class="g-label micro">{hotter.label}</span>
+          {#if compactUsageRotating}<span class="g-provider micro">{activeProviderShort}</span>{/if}
+          <span class="g-label micro">{activeHotGauge.label}</span>
           <span class="g-bar"
             ><span
               class="g-fill"
-              style="transform:scaleX({Math.min(Math.max(hotter.w.pct, 0), 100) /
-                100});background:{gaugeColor(hotter.w.pct)}"
+              style="transform:scaleX({Math.min(Math.max(activeHotGauge.w.pct, 0), 100) /
+                100});background:{gaugeColor(activeHotGauge.w.pct)}"
             ></span></span
           >
-          <span class="g-pct" style="color:{gaugeColor(hotter.w.pct)}">{hotter.w.pct}%</span>
+          <span class="g-pct" style="color:{gaugeColor(activeHotGauge.w.pct)}"
+            >{activeHotGauge.w.pct}%</span
+          >
         </button>
-      {:else if credits || codexUsage}
-        <!-- credits-only or codex-only: no usage windows scraped, but another provider has data -->
+      {:else if activeCompactUsageView.mode === "credit" || activeCompactUsageView.mode === "tokens"}
+        <!-- credits-only or codex token-only: no normal compact limit window, but usage data exists -->
         <button
           class="gauge gauge-btn"
-          class:stale={credits ? credits.stale : codexUsage?.stale}
+          class:stale={activeStale}
           class:alert={overspend}
           type="button"
           aria-haspopup="dialog"
           aria-expanded={popoverOpen}
-          aria-label={credits
+          aria-label={activeCompactUsageView.mode === "credit"
             ? overspend
               ? m.topbar_credits_alert_aria({ amount: creditAmount })
               : `${m.topbar_credits_period()} · ${creditAmount}`
-            : `${m.agent_provider_codex()} · ${formatTokenLabel(codexUsage?.totalTokens ?? 0)}`}
+            : `${activeProviderName} · ${formatTokenLabel(activeCompactUsageView.totalTokens)}`}
           onclick={() => (popoverOpen = !popoverOpen)}
         >
-          {#if credits}
+          {#if compactUsageRotating}<span class="g-provider micro">{activeProviderShort}</span>{/if}
+          {#if activeCompactUsageView.mode === "credit"}
             <span class="g-label micro">CR</span>
             <span class="g-bar"
               ><span class="g-fill" style="transform:scaleX({creditFill});background:{creditColor}"
@@ -120,34 +138,39 @@
             >
             <span class="g-pct credit-amount" style="color:{creditColor}">{creditAmount}</span>
           {:else}
-            <span class="g-label micro">{m.agent_provider_codex()}</span>
-            <span class="g-pct credit-amount">{formatTokenLabel(codexUsage?.totalTokens ?? 0)}</span
+            <span class="g-pct credit-amount"
+              >{formatTokenLabel(activeCompactUsageView.totalTokens)}</span
             >
           {/if}
         </button>
-      {:else if perModelHot}
+      {:else if activeCompactUsageView.mode === "model"}
         <!-- per-model-only (e.g. Fable): the sole usage signal — collapse to its bar so the
              popover (with the full per-model breakdown) can be opened. -->
         <button
           class="gauge gauge-btn"
-          class:stale={perModelHot.stale}
+          class:stale={activeCompactUsageView.stale}
           type="button"
           aria-haspopup="dialog"
           aria-expanded={popoverOpen}
           aria-label={`${m.usage_limits_window_week_model({
-            model: modelDisplayName(perModelHot.model),
-          })} · ${perModelHot.pct}%`}
+            model: modelDisplayName(activeCompactUsageView.model.model),
+          })} · ${activeCompactUsageView.model.pct}%`}
           onclick={() => (popoverOpen = !popoverOpen)}
         >
-          <span class="g-label micro">{modelDisplayName(perModelHot.model)}</span>
+          {#if compactUsageRotating}<span class="g-provider micro">{activeProviderShort}</span>{/if}
+          <span class="g-label micro">{modelDisplayName(activeCompactUsageView.model.model)}</span>
           <span class="g-bar"
             ><span
               class="g-fill"
-              style="transform:scaleX({Math.min(Math.max(perModelHot.pct, 0), 100) /
-                100});background:{gaugeColor(perModelHot.pct)}"
+              style="transform:scaleX({Math.min(
+                Math.max(activeCompactUsageView.model.pct, 0),
+                100,
+              ) / 100});background:{gaugeColor(activeCompactUsageView.model.pct)}"
             ></span></span
           >
-          <span class="g-pct" style="color:{gaugeColor(perModelHot.pct)}">{perModelHot.pct}%</span>
+          <span class="g-pct" style="color:{gaugeColor(activeCompactUsageView.model.pct)}"
+            >{activeCompactUsageView.model.pct}%</span
+          >
         </button>
       {/if}
       {#if popoverOpen}
@@ -175,7 +198,7 @@
       {/if}
     </div>
   {/if}
-{:else if gauges.length || credits || codexUsage || perModelHot}
+{:else if activeCompactUsageView}
   <!-- Desktop: the inline cluster is a click toggle (not hover) so the popover stays open while
        you move into it to reach REFRESH. Dismiss on Esc / outside-click is shared with the touch
        path (popoverOpen + gaugeWrap, handled in TopBar.svelte). -->
@@ -191,16 +214,18 @@
            gauge cluster + each gauge are <span>s (display:flex via class, blockified
            as flex items). Compact rule: percentages inline, swapped to the CR amount
            when capped or credits-only (see showCreditsInline). -->
-      <span class="gauges" class:stale>
-        {#if showCreditsInline}
+      <span class="gauges" class:stale={activeStale}>
+        {#if compactUsageRotating}<span class="g-provider micro">{activeProviderShort}</span>{/if}
+        {#if activeCompactUsageView.mode === "credit"}
           <CreditGauge {credits} {overspend} {creditFill} {creditColor} {creditAmount} />
-        {:else if codexUsage && gauges.length === 0}
+        {:else if activeCompactUsageView.mode === "tokens"}
           <span class="gauge">
-            <span class="g-label micro">{m.agent_provider_codex()}</span>
-            <span class="g-pct credit-amount">{formatTokenLabel(codexUsage.totalTokens)}</span>
+            <span class="g-pct credit-amount"
+              >{formatTokenLabel(activeCompactUsageView.totalTokens)}</span
+            >
           </span>
-        {:else if gauges.length}
-          {#each gauges as g (g.label)}
+        {:else if activeCompactUsageView.mode === "limits"}
+          {#each activeCompactUsageView.gauges as g (g.label)}
             <span class="gauge">
               <span class="g-label micro">{g.label}</span>
               <span class="g-bar"
@@ -213,19 +238,23 @@
               <span class="g-pct" style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
             </span>
           {/each}
-        {:else if perModelHot}
+        {:else if activeCompactUsageView.mode === "model"}
           <!-- per-model-only (e.g. Fable): the sole usage signal — inline its bar so the toggle
                isn't blank and its popover breakdown can be opened. -->
           <span class="gauge">
-            <span class="g-label micro">{modelDisplayName(perModelHot.model)}</span>
+            <span class="g-label micro">{modelDisplayName(activeCompactUsageView.model.model)}</span
+            >
             <span class="g-bar"
               ><span
                 class="g-fill"
-                style="transform:scaleX({Math.min(Math.max(perModelHot.pct, 0), 100) /
-                  100});background:{gaugeColor(perModelHot.pct)}"
+                style="transform:scaleX({Math.min(
+                  Math.max(activeCompactUsageView.model.pct, 0),
+                  100,
+                ) / 100});background:{gaugeColor(activeCompactUsageView.model.pct)}"
               ></span></span
             >
-            <span class="g-pct" style="color:{gaugeColor(perModelHot.pct)}">{perModelHot.pct}%</span
+            <span class="g-pct" style="color:{gaugeColor(activeCompactUsageView.model.pct)}"
+              >{activeCompactUsageView.model.pct}%</span
             >
           </span>
         {/if}
@@ -310,6 +339,9 @@
   /* Shared base-class rules (also in parent for sibling regions) */
   .g-label {
     color: var(--color-muted);
+  }
+  .g-provider {
+    color: var(--color-faint);
   }
   .g-bar {
     width: 46px;

--- a/ui/src/lib/components/usage-gauges.test.ts
+++ b/ui/src/lib/components/usage-gauges.test.ts
@@ -108,6 +108,7 @@ describe("compactUsageViews", () => {
   it("returns a Claude limit view for Claude-only normal gauges", () => {
     const views = compactUsageViews({
       gauges: gaugeList(limits({ session5h: w(10), week: w(20) })),
+      claudeStale: false,
       perModel: [],
       credits: null,
       codexUsage: null,
@@ -118,9 +119,22 @@ describe("compactUsageViews", () => {
     ]);
   });
 
+  it("marks Claude limit compact views stale when the Claude snapshot is stale", () => {
+    const views = compactUsageViews({
+      gauges: gaugeList(limits({ session5h: w(10), week: w(20), stale: true })),
+      claudeStale: true,
+      perModel: [],
+      credits: null,
+      codexUsage: null,
+    });
+
+    expect(views).toMatchObject([{ provider: "claude", mode: "limits", stale: true }]);
+  });
+
   it("returns a Codex limit view when Codex-only has rate-limit windows", () => {
     const views = compactUsageViews({
       gauges: [],
+      claudeStale: false,
       perModel: [],
       credits: null,
       codexUsage: { ...codexTokens, session5h: w(7), week: w(9) },
@@ -134,6 +148,7 @@ describe("compactUsageViews", () => {
   it("returns a Codex token fallback when Codex-only has no rate-limit windows", () => {
     const views = compactUsageViews({
       gauges: [],
+      claudeStale: false,
       perModel: [],
       credits: null,
       codexUsage: codexTokens,
@@ -147,6 +162,7 @@ describe("compactUsageViews", () => {
   it("returns Claude plus Codex token fallback for both-provider token-only Codex", () => {
     const views = compactUsageViews({
       gauges: gaugeList(limits({ session5h: w(10), week: w(20) })),
+      claudeStale: false,
       perModel: [],
       credits: null,
       codexUsage: codexTokens,
@@ -162,6 +178,7 @@ describe("compactUsageViews", () => {
   it("returns Claude plus Codex limit views when both have rate-limit windows", () => {
     const views = compactUsageViews({
       gauges: gaugeList(limits({ session5h: w(10), week: w(20) })),
+      claudeStale: false,
       perModel: [],
       credits: null,
       codexUsage: { ...codexTokens, session5h: w(7), week: w(9) },
@@ -176,6 +193,7 @@ describe("compactUsageViews", () => {
   it("preserves the Claude credit compact view when a normal window is capped", () => {
     const views = compactUsageViews({
       gauges: gaugeList(limits({ session5h: w(100), week: w(20) })),
+      claudeStale: false,
       perModel: [],
       credits: credit({ spent: 0.29 }),
       codexUsage: null,
@@ -189,6 +207,7 @@ describe("compactUsageViews", () => {
   it("preserves the Claude per-model compact view when it is the only Claude signal", () => {
     const views = compactUsageViews({
       gauges: [],
+      claudeStale: false,
       perModel: [{ model: "fable", pct: 7, resetAt: null, scrapedAt: 0, stale: false }],
       credits: null,
       codexUsage: null,

--- a/ui/src/lib/components/usage-gauges.test.ts
+++ b/ui/src/lib/components/usage-gauges.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  compactUsageViews,
   codexTokenUsage,
   gaugeList,
   hotterGauge,
@@ -36,6 +37,18 @@ function credit(over: Partial<CreditWindow>): CreditWindow {
     ...over,
   };
 }
+
+const codexTokens = {
+  provider: "codex" as const,
+  kind: "tokens" as const,
+  totalTokens: 12_000,
+  session5hTokens: 1_000,
+  weekTokens: 9_000,
+  updatedAt: 123,
+  stale: false,
+  session5h: null,
+  week: null,
+};
 
 describe("gaugeList", () => {
   it("is empty when no limits are present", () => {
@@ -84,20 +97,106 @@ describe("providerSnapshots", () => {
           calibratedAt: null,
           subscriptionOnly: false,
         },
-        {
-          provider: "codex",
-          kind: "tokens",
-          totalTokens: 12_000,
-          session5hTokens: 1_000,
-          weekTokens: 9_000,
-          updatedAt: 123,
-          stale: false,
-          session5h: null,
-          week: null,
-        },
+        codexTokens,
       ],
     });
     expect(codexTokenUsage(l)?.totalTokens).toBe(12_000);
+  });
+});
+
+describe("compactUsageViews", () => {
+  it("returns a Claude limit view for Claude-only normal gauges", () => {
+    const views = compactUsageViews({
+      gauges: gaugeList(limits({ session5h: w(10), week: w(20) })),
+      perModel: [],
+      credits: null,
+      codexUsage: null,
+    });
+
+    expect(views.map((v) => `${v.provider}:${v.mode}:${v.widthClass}`)).toEqual([
+      "claude:limits:bars",
+    ]);
+  });
+
+  it("returns a Codex limit view when Codex-only has rate-limit windows", () => {
+    const views = compactUsageViews({
+      gauges: [],
+      perModel: [],
+      credits: null,
+      codexUsage: { ...codexTokens, session5h: w(7), week: w(9) },
+    });
+
+    expect(views.map((v) => `${v.provider}:${v.mode}:${v.widthClass}`)).toEqual([
+      "codex:limits:bars",
+    ]);
+  });
+
+  it("returns a Codex token fallback when Codex-only has no rate-limit windows", () => {
+    const views = compactUsageViews({
+      gauges: [],
+      perModel: [],
+      credits: null,
+      codexUsage: codexTokens,
+    });
+
+    expect(views).toMatchObject([
+      { provider: "codex", mode: "tokens", widthClass: "token", totalTokens: 12_000 },
+    ]);
+  });
+
+  it("returns Claude plus Codex token fallback for both-provider token-only Codex", () => {
+    const views = compactUsageViews({
+      gauges: gaugeList(limits({ session5h: w(10), week: w(20) })),
+      perModel: [],
+      credits: null,
+      codexUsage: codexTokens,
+    });
+
+    expect(views.map((v) => `${v.provider}:${v.mode}:${v.widthClass}`)).toEqual([
+      "claude:limits:bars",
+      "codex:tokens:token",
+    ]);
+    expect(views.every((v) => v.rotationEligible)).toBe(true);
+  });
+
+  it("returns Claude plus Codex limit views when both have rate-limit windows", () => {
+    const views = compactUsageViews({
+      gauges: gaugeList(limits({ session5h: w(10), week: w(20) })),
+      perModel: [],
+      credits: null,
+      codexUsage: { ...codexTokens, session5h: w(7), week: w(9) },
+    });
+
+    expect(views.map((v) => `${v.provider}:${v.mode}:${v.widthClass}`)).toEqual([
+      "claude:limits:bars",
+      "codex:limits:bars",
+    ]);
+  });
+
+  it("preserves the Claude credit compact view when a normal window is capped", () => {
+    const views = compactUsageViews({
+      gauges: gaugeList(limits({ session5h: w(100), week: w(20) })),
+      perModel: [],
+      credits: credit({ spent: 0.29 }),
+      codexUsage: null,
+    });
+
+    expect(views.map((v) => `${v.provider}:${v.mode}:${v.widthClass}`)).toEqual([
+      "claude:credit:credit",
+    ]);
+  });
+
+  it("preserves the Claude per-model compact view when it is the only Claude signal", () => {
+    const views = compactUsageViews({
+      gauges: [],
+      perModel: [{ model: "fable", pct: 7, resetAt: null, scrapedAt: 0, stale: false }],
+      credits: null,
+      codexUsage: null,
+    });
+
+    expect(views).toMatchObject([
+      { provider: "claude", mode: "model", widthClass: "model", model: { model: "fable" } },
+    ]);
   });
 });
 

--- a/ui/src/lib/components/usage-gauges.ts
+++ b/ui/src/lib/components/usage-gauges.ts
@@ -1,4 +1,10 @@
-import type { UsageLimits, LimitWindow, ModelWeekWindow, UsageProviderSnapshot } from "../types";
+import type {
+  UsageLimits,
+  LimitWindow,
+  ModelWeekWindow,
+  UsageProviderSnapshot,
+  CreditWindow,
+} from "../types";
 
 export type GaugeKey = "5H" | "WK";
 
@@ -17,6 +23,47 @@ export function gaugeList(limits: UsageLimits | null): Gauge[] {
 }
 
 type CodexTokenSnapshot = Extract<UsageProviderSnapshot, { provider: "codex"; kind: "tokens" }>;
+
+export type CompactUsageView =
+  | {
+      provider: "claude";
+      mode: "limits";
+      gauges: Gauge[];
+      stale: boolean;
+      rotationEligible: boolean;
+      widthClass: "bars";
+    }
+  | {
+      provider: "claude";
+      mode: "credit";
+      stale: boolean;
+      rotationEligible: boolean;
+      widthClass: "credit";
+    }
+  | {
+      provider: "claude";
+      mode: "model";
+      model: ModelWeekWindow;
+      stale: boolean;
+      rotationEligible: boolean;
+      widthClass: "model";
+    }
+  | {
+      provider: "codex";
+      mode: "limits";
+      gauges: Gauge[];
+      stale: boolean;
+      rotationEligible: boolean;
+      widthClass: "bars";
+    }
+  | {
+      provider: "codex";
+      mode: "tokens";
+      totalTokens: number;
+      stale: boolean;
+      rotationEligible: boolean;
+      widthClass: "token";
+    };
 
 /** Codex's 5H/WK rate-limit windows as gauges, in display order — the same shape `gaugeList`
  *  produces for Claude so both render identically. Empty until Codex logs a rate-limit event. */
@@ -70,6 +117,75 @@ export function codexTokenUsage(
         p.provider === "codex" && p.kind === "tokens",
     ) ?? null
   );
+}
+
+export function compactUsageViews({
+  gauges,
+  perModel,
+  credits,
+  codexUsage,
+}: {
+  gauges: Gauge[];
+  perModel: ModelWeekWindow[];
+  credits: CreditWindow | null;
+  codexUsage: CodexTokenSnapshot | null;
+}): CompactUsageView[] {
+  const views: CompactUsageView[] = [];
+  const capped = gauges.some((g) => g.w.pct >= 100);
+  const showCreditsInline = (capped || gauges.length === 0) && !!credits;
+
+  if (showCreditsInline) {
+    views.push({
+      provider: "claude",
+      mode: "credit",
+      stale: credits.stale,
+      rotationEligible: true,
+      widthClass: "credit",
+    });
+  } else if (gauges.length) {
+    views.push({
+      provider: "claude",
+      mode: "limits",
+      gauges,
+      stale: false,
+      rotationEligible: true,
+      widthClass: "bars",
+    });
+  } else if (perModel.length) {
+    views.push({
+      provider: "claude",
+      mode: "model",
+      model: perModel[0]!,
+      stale: perModel[0]!.stale,
+      rotationEligible: true,
+      widthClass: "model",
+    });
+  }
+
+  if (codexUsage) {
+    const codexGauges = codexGaugeList(codexUsage);
+    if (codexGauges.length) {
+      views.push({
+        provider: "codex",
+        mode: "limits",
+        gauges: codexGauges,
+        stale: codexUsage.stale,
+        rotationEligible: true,
+        widthClass: "bars",
+      });
+    } else {
+      views.push({
+        provider: "codex",
+        mode: "tokens",
+        totalTokens: codexUsage.totalTokens,
+        stale: codexUsage.stale,
+        rotationEligible: true,
+        widthClass: "token",
+      });
+    }
+  }
+
+  return views;
 }
 
 /**

--- a/ui/src/lib/components/usage-gauges.ts
+++ b/ui/src/lib/components/usage-gauges.ts
@@ -121,11 +121,13 @@ export function codexTokenUsage(
 
 export function compactUsageViews({
   gauges,
+  claudeStale,
   perModel,
   credits,
   codexUsage,
 }: {
   gauges: Gauge[];
+  claudeStale: boolean;
   perModel: ModelWeekWindow[];
   credits: CreditWindow | null;
   codexUsage: CodexTokenSnapshot | null;
@@ -147,7 +149,7 @@ export function compactUsageViews({
       provider: "claude",
       mode: "limits",
       gauges,
-      stale: false,
+      stale: claudeStale,
       rotationEligible: true,
       widthClass: "bars",
     });

--- a/ui/src/lib/feature-announcements/entries/v1.42.0-usage-gauge-provider-rotation.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.42.0-usage-gauge-provider-rotation.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "usage-gauge-provider-rotation",
+  sinceVersion: "1.42.0",
+  titleKey: "feat_usage_gauge_provider_rotation_title",
+  bodyKey: "feat_usage_gauge_provider_rotation_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## Summary
- Rotate the compact top-bar usage affordance between Claude Code (`CC`) and Codex (`CX`) every two minutes when both providers have displayable usage data.
- Keep single-provider compact gauges unprefixed, preserve Claude CR/per-model fallbacks, and show Codex token totals until Codex rate-limit windows are available.
- Add the 1.42.0 feature-announcement fragment plus EN/DE strings.

## Verification
- `cd ui && bun run check` (passes; existing warnings in `CommandBar.svelte` and `FilesPanel.svelte`)
- `cd ui && bun run check:i18n`
- `cd ui && bun test -- usage-gauges.test.ts`
- `cd ui && bun run test:browser -- TopBar.browser.test.ts`
- `scripts/check-feature-catalog.sh && scripts/check-announcement-versions.mjs`
- `scripts/check-branch-hygiene.sh`

## Notes
- Attempted full `cd ui && bun test`; the existing aggregate run failed on unrelated global runner issues (browser specs outside browser mode, `$state` unavailable in node tests, missing `prettier`) and then had to be killed after it did not exit promptly. Focused changed-area tests pass.
