### PR TITLE
fix(herdr-update): recover via gated relaunch, not nonexistent `server start` (#1410)

### DIFF
--- a/src/herdr-update.ts
+++ b/src/herdr-update.ts
@@ -57,12 +57,18 @@ export function buildUpdateScript(
   logPath: string,
   from?: string | null,
   to?: string | null,
+  herdrBin: string = config.herdrBin,
 ): string {
   const f = sanitizeVersion(from);
   const t = sanitizeVersion(to);
-  // single-quote the path for the shell; a literal `'` inside it (vanishingly
-  // unlikely in a home path) is escaped via the classic '\'' close-reopen trick.
-  const q = `'${logPath.replace(/'/g, "'\\''")}'`;
+  // single-quote for the shell; a literal `'` inside (vanishingly unlikely in a
+  // home path or binary path) is escaped via the classic '\'' close-reopen trick.
+  const shq = (s: string): string => `'${s.replace(/'/g, "'\\''")}'`;
+  const q = shq(logPath);
+  // The configured herdr binary (HERDR_BIN / config.herdrBin), shell-quoted so a
+  // custom install path can't break the script. Every herdr invocation below uses
+  // it — a bare `herdr` would miss on a custom-binary host (mirrors restart.ts).
+  const h = shq(herdrBin);
   // Shepherd stays up during the update (no restart), so it captures this
   // script's stdout live for the modal. The `tee -a` is kept anyway: it makes
   // `cat <logPath>` a durable post-mortem that survives even a shepherd crash.
@@ -71,23 +77,38 @@ export function buildUpdateScript(
   // proceed while targets are running: bare `herdr update` aborts with "one or
   // more herdr targets must restart". `--handoff` hands the running targets to
   // the new version instead of aborting. We deliberately do NOT `herdr server
-  // stop` first: that earlier mitigation never actually cleared the targets (they
-  // outlive the server) yet left the server dead, so a failed update orphaned
-  // every agent pane — clients then loop forever on `agent attach` against a gone
-  // socket. Not stopping means a failed update leaves the live server + panes
-  // untouched. As a belt-and-suspenders recovery, if the update still fails we
-  // bring the server back up so panes can reattach.
+  // stop` first: that earlier mitigation never cleared the targets (they OUTLIVE
+  // the server) yet left the server dead, so a failed update orphaned every agent
+  // pane. Not stopping means a failed update usually leaves the live server +
+  // panes untouched.
+  //
+  // Recovery (only when the update fails): because the agent targets outlive a
+  // dead server, if the server is actually gone we relaunch one and the orphaned
+  // panes reattach — the app's Reconnect / `viewport_herdr_unreachable` path, the
+  // "live agent returns once herdr is back" invariant from #413. We gate the
+  // relaunch on `agent list`, the SAME throw-on-unreachable signal broadcast()
+  // catches in service.ts, and relaunch ONLY when it fails — an unconditional
+  // restart while the server is still up is the #241/#314 hazard. `setsid ...
+  // server` detaches the foreground `herdr server` into its own session. Caveat:
+  // this recovery server is a child of shepherd's cgroup, so it is not durable
+  // across a later `systemctl restart shepherd` — at which point the still-alive
+  // targets simply re-orphan and recover again (never lost). A cgroup-durable
+  // server would need systemd-run, which this script deliberately avoids.
   return [
     `LOG=${q}`,
     'mkdir -p "$(dirname "$LOG")"',
     "{",
     `  echo "=== herdr-update $(date -u +%Y-%m-%dT%H:%M:%SZ) ${f} -> ${t} ==="`,
     `  echo '${UPDATE_LOG_PREFIX} running herdr update --handoff'`,
-    "  herdr update --handoff; rc=$?",
+    `  ${h} update --handoff; rc=$?`,
     `  echo "${UPDATE_LOG_PREFIX} herdr update exited rc=$rc"`,
     '  if [ "$rc" -ne 0 ]; then',
-    `    echo '${UPDATE_LOG_PREFIX} update failed — restarting herdr server so panes can reattach'`,
-    "    herdr server start || true",
+    `    if timeout 10 ${h} agent list >/dev/null 2>&1; then`,
+    `      echo '${UPDATE_LOG_PREFIX} update failed — herdr server still reachable (agent list ok); live sessions untouched'`,
+    "    else",
+    `      echo '${UPDATE_LOG_PREFIX} update failed, herdr server unreachable — relaunching a detached server so orphaned sessions reattach'`,
+    `      setsid ${h} server </dev/null >/dev/null 2>&1 &`,
+    "    fi",
     "  fi",
     '} 2>&1 | tee -a "$LOG"',
   ].join("\n");

--- a/test/herdr-update.test.ts
+++ b/test/herdr-update.test.ts
@@ -13,17 +13,37 @@ const LOG = "/home/op/.shepherd/herdr-update.log";
 test("buildUpdateScript: runs `herdr update --handoff`, no destructive pre-stop", () => {
   const s = buildUpdateScript(LOG, "0.6.5", "0.6.6");
   // --handoff lets a protocol-bumping update proceed while Shepherd's own herdr
-  // target is live ("one or more herdr targets must restart" otherwise).
-  expect(s).toContain("herdr update --handoff");
+  // target is live ("one or more herdr targets must restart" otherwise). The
+  // binary is shell-quoted (`'herdr' update …`), so assert the flag, not `herdr `.
+  expect(s).toContain("update --handoff");
   // the old pre-update `herdr server stop` killed the live server but never
   // cleared the targets, orphaning every pane on a failed update — gone for good.
   expect(s).not.toContain("herdr server stop");
 });
 
-test("buildUpdateScript: restarts the herdr server only when the update fails", () => {
+test("buildUpdateScript: on failure, relaunches herdr ONLY when it is unreachable", () => {
   const s = buildUpdateScript(LOG, "0.6.5", "0.6.6");
+  // the whole recovery is gated on the update having failed
   expect(s).toContain('if [ "$rc" -ne 0 ]; then');
-  expect(s).toContain("herdr server start || true");
+  // probe is the repo's own unreachable signal: `agent list` exits non-zero when
+  // herdr is unreachable — the exact throw broadcast() catches in service.ts.
+  expect(s).toContain("agent list");
+  // relaunch a DETACHED server (bare `herdr server` is foreground) on the
+  // unreachable branch so the orphaned targets (which outlive the dead server) reattach.
+  expect(s).toMatch(/setsid\b.*\bserver\b.*&/);
+  // the nonexistent verb is gone; no stop/handoff (both need a live server) and no systemd.
+  expect(s).not.toContain("herdr server start");
+  expect(s).not.toContain("live-handoff");
+  expect(s).not.toContain("status server");
+});
+
+test("buildUpdateScript: threads a custom HERDR_BIN through every herdr call", () => {
+  const s = buildUpdateScript(LOG, "0.6.5", "0.6.6", "/opt/herdr/bin/herdr");
+  // the configured binary drives the update, the unreachable probe, and the
+  // relaunch — each shell-quoted so a path with spaces/quotes can't break the script.
+  expect(s).toContain("'/opt/herdr/bin/herdr' update --handoff");
+  expect(s).toContain("'/opt/herdr/bin/herdr' agent list");
+  expect(s).toContain("'/opt/herdr/bin/herdr' server");
 });
 
 test("buildUpdateScript: never restarts shepherd or shells systemd", () => {
@@ -36,8 +56,9 @@ test("buildUpdateScript: never restarts shepherd or shells systemd", () => {
 test("buildUpdateScript: echoes a greppable marker for each step", () => {
   const s = buildUpdateScript(LOG, "0.6.5", "0.6.6");
   const markers = s.split("\n").filter((l) => l.includes(UPDATE_LOG_PREFIX));
-  // running / exited rc / restart-on-failure = 3 markers
-  expect(markers.length).toBe(3);
+  // running / exited rc / reachable-branch / unreachable-branch = 4 markers
+  // (the two failure branches are mutually exclusive at runtime, both present in text)
+  expect(markers.length).toBe(4);
   expect(s).toContain(`${UPDATE_LOG_PREFIX} herdr update exited rc=$rc`);
 });
 


### PR DESCRIPTION
Fixes #1410.

## The bug

The herdr-update failure-recovery path ran `herdr server start || true`. But
`herdr server start` is **not a real subcommand** (verified against herdr 0.7.1 —
the `herdr server` verbs are `stop`, `live-handoff`, `reload-config`, and the
`*-agent-manifests` commands; bare `herdr server` runs a headless foreground
server). `|| true` masked the unknown-command error, so the recovery step was a
**silent no-op**: after a failed update that left the server dead, panes stayed
orphaned until the operator manually relaunched herdr.

## The fix

Restore the auto-recovery commit #413 *intended* (the bug was only the wrong
verb), using a repo-corroborated, gated invocation:

- **Probe = `herdr agent list` exit status** — the exact throw-on-unreachable
  signal `broadcast()` already catches at `src/service.ts:3517-3520`. Proven both
  to exist and to fail-on-unreachable by shipping code; pure exit status, no
  output-format/JSON coupling.
- **Relaunch only when unreachable.** On a failed `herdr update --handoff`, if
  `agent list` reports the server down, `setsid herdr server </dev/null >/dev/null
  2>&1 &` relaunches a detached server so the orphaned agent targets — which
  **outlive a dead server** (#413) — reattach via the app's Reconnect /
  `viewport_herdr_unreachable` path. A **reachable** server is left untouched,
  avoiding the #241/#314 unconditional-restart hazard.
- **Threads the configured `HERDR_BIN`** (shell-quoted) through the update, probe,
  and relaunch, so a custom-binary host isn't missed (mirrors `restart.ts`).

```sh
if [ "$rc" -ne 0 ]; then
  if timeout 10 'herdr' agent list >/dev/null 2>&1; then
    echo '>>> herdr-update: update failed — herdr server still reachable (agent list ok); live sessions untouched'
  else
    echo '>>> herdr-update: update failed, herdr server unreachable — relaunching a detached server so orphaned sessions reattach'
    setsid 'herdr' server </dev/null >/dev/null 2>&1 &
  fi
fi
```

## Caveat (documented in-code, honestly out of scope)

The update script is a plain child of shepherd, so the `setsid herdr server` it
spawns lives in `shepherd.service`'s cgroup (no `KillMode` → default kills the
whole cgroup on `systemctl restart shepherd`). The recovery server restores
service immediately but isn't durable across a *later* shepherd restart — the
still-alive targets then re-orphan and recover again (**never lost**). A
cgroup-durable server would need `systemd-run`, which this script deliberately
avoids. This is strictly better than the status-quo no-op.

One behavior can't be verified end-to-end without an actual failed protocol-bump
update (a fresh `herdr server` re-adopting the previous server's orphaned
targets) — asserted by #413's design + the herdr socket model, and the change is
gated + fail-safe.

## Testing

- `bun run lint` ✓
- `bun test ./test/herdr-update.test.ts` ✓ (18 pass) — covers the gated
  probe/relaunch command forms, custom-`HERDR_BIN` threading, absence of the
  bogus `herdr server start`, and the marker count.
- Rendered script passes `bash -n` (incl. a custom binary path with spaces).

[no-feature-entry] — server-only internal plumbing; no user-facing UI surface.
