### PR TITLE
fix(ui): group running rework sessions

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2611,5 +2611,6 @@
   "planpanel_env_help_aria": "Wo sich die Coding-Umgebungen für Plan und Prüfung ändern lassen",
   "planpanel_env_popover_title": "Coding-Umgebung",
   "planpanel_env_popover_body": "Plan zeigt Coding-CLI, Modell und Reasoning Effort der Task-Session. Prüfung zeigt den Plan-Gate-Reviewer, der diesen Plan geprüft hat. Task-Defaults änderst du in Neuer Task, in Repo-Defaults oder globalen Defaults; den Reviewer unter Einstellungen -> CLIs -> Planer (Plan-Reviewer).",
-  "planpanel_env_docs_link": "Konfigurationsdoku öffnen"
+  "planpanel_env_docs_link": "Konfigurationsdoku öffnen",
+  "herd_rework_running_group": "REWORK läuft ({count})"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2611,5 +2611,6 @@
   "planpanel_env_help_aria": "Where to change plan and review coding environments",
   "planpanel_env_popover_title": "Coding environment",
   "planpanel_env_popover_body": "Plan shows the task session's coding CLI, model and reasoning effort. Review shows the Plan Gate reviewer that checked this plan. Change task defaults in New Task, repo defaults or global defaults; change the reviewer under Settings -> CLIs -> Planner (plan reviewer).",
-  "planpanel_env_docs_link": "Open configuration docs"
+  "planpanel_env_docs_link": "Open configuration docs",
+  "herd_rework_running_group": "Rework running ({count})"
 }

--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -3,9 +3,11 @@ import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
 import Herd from "./Herd.svelte";
+import { railOrder } from "./herd-keynav";
+import { isReworkRunning } from "./rework-running";
 import { reviews, planGates } from "$lib/reviews.svelte";
 import { postMergeSteps } from "$lib/post-merge-steps.svelte";
-import type { Session, GitState, Epic, EpicChild, PostMergeSteps } from "$lib/types";
+import type { Session, GitState, Epic, EpicChild, PostMergeSteps, ReviewVerdict } from "$lib/types";
 
 function session(partial: Partial<Session> & { id: string }): Session {
   return {
@@ -74,6 +76,22 @@ const base = {
   onnew: () => {},
   activity: {},
 };
+
+function changesReview(sessionId: string): ReviewVerdict {
+  return {
+    sessionId,
+    headSha: "abc",
+    decision: "changes_requested",
+    summary: "changes",
+    body: "body",
+    findings: ["fix it"],
+    addressRound: 1,
+    addressCap: 3,
+    finalRoundPending: false,
+    finalRoundTimeoutMs: 0,
+    updatedAt: 0,
+  };
+}
 
 describe("Herd merging group", () => {
   it("renders a Merging group for in-train sessions", async () => {
@@ -639,5 +657,76 @@ describe("Herd reviewer-running preview badge", () => {
     });
     // The .preview-badge span renders the text "Preview" when previewPort is non-null
     await expect.element(page.getByText("Preview")).toBeInTheDocument();
+  });
+});
+
+describe("Herd rework-running group", () => {
+  afterEach(() => {
+    reviews.setReviewing("review", false);
+    reviews.drop("rework");
+  });
+
+  it("renders in the same order as railOrder, including working-while-blocked REWORK", async () => {
+    const sessions = [
+      session({ id: "wait", name: "waiting reviewer", status: "idle" }),
+      session({ id: "rework", name: "rework active", status: "blocked" }),
+      session({ id: "review", name: "review active", status: "running" }),
+      session({ id: "ci", name: "ci active", status: "running" }),
+      session({ id: "active", name: "plain active", status: "running" }),
+    ];
+    const git = {
+      wait: {
+        kind: "github",
+        state: "open",
+        checks: "success",
+        deployConfigured: false,
+        handoff: "reviewer",
+        handoffWho: "scoop",
+      },
+      ci: {
+        kind: "github",
+        state: "open",
+        checks: "pending",
+        deployConfigured: false,
+      },
+      rework: {
+        kind: "github",
+        state: "open",
+        checks: "failure",
+        deployConfigured: false,
+      },
+    } satisfies Record<string, GitState>;
+    const workingBlocked = { rework: true };
+    reviews.setReviewing("review", true);
+    reviews.apply({ id: "rework", review: changesReview("rework") });
+
+    render(Herd, {
+      ...base,
+      sessions,
+      git,
+      workingBlocked,
+    });
+
+    await expect.element(page.getByText(/Rework running \(1\)/i)).toBeInTheDocument();
+    const rendered = [...document.querySelectorAll<HTMLElement>("[data-unit-id]")].map(
+      (el) => el.dataset.unitId,
+    );
+    const ordered = railOrder(
+      sessions,
+      git,
+      (id) => reviews.isReviewing(id) || planGates.isReviewing(id),
+      (s) =>
+        isReworkRunning(
+          s,
+          { planGate: planGates.map[s.id], review: reviews.map[s.id] },
+          workingBlocked,
+        ),
+      0,
+      "all",
+      workingBlocked,
+    );
+
+    expect(rendered).toEqual(ordered);
+    expect(rendered).toEqual(["active", "ci", "review", "rework", "wait"]);
   });
 });

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -26,6 +26,7 @@
   import { groupSessionsByExperiment } from "./experiment-grouping";
   import { collectReadyPrs } from "./merge-train";
   import { displayStatus } from "$lib/display-status";
+  import { isReworkRunning as isReworkRunningSession } from "./rework-running";
   import { reviews, planGates } from "$lib/reviews.svelte";
   import { m } from "$lib/paraglide/messages";
   import { postMergeSteps, owedRecordsForRepo } from "$lib/post-merge-steps.svelte";
@@ -216,6 +217,12 @@
   // a critic post-PR review or a pre-execution plan-gate review currently in flight —
   // the reviewer is actively working the session, so it is NOT awaiting the operator.
   const inReview = (id: string) => reviews.isReviewing(id) || planGates.isReviewing(id);
+  const isReworkRunning = (session: Session) =>
+    isReworkRunningSession(
+      session,
+      { planGate: planGates.map[session.id], review: reviews.map[session.id] },
+      workingBlocked,
+    );
 
   // Derives the quota block kind for a session if its block has shape "quota"; null otherwise.
   const quotaKindFor = (id: string) => {
@@ -263,9 +270,19 @@
   // form a group). Epic grouping then runs over the remainder; a session is never double-grouped.
   const experimentGrouped = $derived(groupSessionsByExperiment(shown));
   const grouped = $derived(
-    groupSessionsByEpic(experimentGrouped.rest, epics, activeEpicKeys, git, inReview, nowMs),
+    groupSessionsByEpic(
+      experimentGrouped.rest,
+      epics,
+      activeEpicKeys,
+      git,
+      inReview,
+      isReworkRunning,
+      nowMs,
+    ),
   );
-  const partition = $derived(partitionSessions(grouped.rest, git, inReview, nowMs));
+  const partition = $derived(
+    partitionSessions(grouped.rest, git, inReview, isReworkRunning, nowMs),
+  );
   // ready-to-merge sessions that actually have an open PR — the merge-train link
   // only surfaces when there's something to run (fail-closed: no PR → no link).
   // In-review sessions are excluded so the link's count matches the launch action.
@@ -278,7 +295,10 @@
   // partition depends on (grouped, git, inReview, nowMs).
   const groupParts = $derived(
     new Map(
-      grouped.groups.map((g) => [g.key, partitionSessions(g.sessions, git, inReview, nowMs)]),
+      grouped.groups.map((g) => [
+        g.key,
+        partitionSessions(g.sessions, git, inReview, isReworkRunning, nowMs),
+      ]),
     ),
   );
   // Per-group attention cues — reads the shared partition; the blocked count still scans
@@ -383,6 +403,13 @@
         sessions: partition.reviewerRunning,
         headClass: "reviewing-head",
         countLabel: m.herd_reviewer_running_group({ count: partition.reviewerRunning.length }),
+        withPreview: true,
+      },
+      partition.reworkRunning.length > 0 && {
+        key: "rework-running",
+        sessions: partition.reworkRunning,
+        headClass: "rework-head",
+        countLabel: m.herd_rework_running_group({ count: partition.reworkRunning.length }),
         withPreview: true,
       },
       partition.waitingOnReviewer.length > 0 && {

--- a/ui/src/lib/components/epic-grouping.test.ts
+++ b/ui/src/lib/components/epic-grouping.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "vitest";
-import { groupSessionsByEpic } from "./epic-grouping";
+import { groupSessionsByEpic as groupSessionsByEpicRaw } from "./epic-grouping";
 import type { Session, GitState, Epic, EpicChild, SessionStatus } from "$lib/types";
 
 function session(
@@ -92,6 +92,26 @@ function git(state: GitState["state"], checks: GitState["checks"] = "none"): Git
 }
 
 const now = 1000;
+
+function groupSessionsByEpic(
+  sessions: Session[],
+  epics: Record<string, Epic>,
+  activeEpicKeys: Set<string>,
+  git: Record<string, GitState>,
+  isReviewing: (id: string) => boolean,
+  at: number,
+  isReworkRunning: (session: Session) => boolean = () => false,
+) {
+  return groupSessionsByEpicRaw(
+    sessions,
+    epics,
+    activeEpicKeys,
+    git,
+    isReviewing,
+    isReworkRunning,
+    at,
+  );
+}
 
 test("key-alignment: child issue number groups; parent issue number does NOT", () => {
   const e = epic("/r", 100, [101, 102]);
@@ -261,6 +281,29 @@ test("ordering: within a group, members come back in STAGE_ORDER lifecycle order
 
   expect(groups).toHaveLength(1);
   expect(groups[0].sessions.map((s) => s.id)).toEqual(["a", "r", "m"]);
+});
+
+test("ordering: reworkRunning sits after reviewerRunning and before waiting-on-reviewer", () => {
+  const e = epic("/r", 100, [1, 2, 3]);
+  const epics = { [key("/r", 100)]: e };
+  const active = new Set([key("/r", 100)]);
+
+  const wait = session("wait", "/r", 1, "idle");
+  const rework = session("rework", "/r", 2, "running");
+  const review = session("review", "/r", 3, "running");
+
+  const { groups } = groupSessionsByEpic(
+    [wait, rework, review],
+    epics,
+    active,
+    { wait: { ...git("open", "success"), handoff: "reviewer", handoffWho: "scoop" } },
+    (id) => id === "review",
+    now,
+    (s) => s.id === "rework",
+  );
+
+  expect(groups).toHaveLength(1);
+  expect(groups[0].sessions.map((s) => s.id)).toEqual(["review", "rework", "wait"]);
 });
 
 test("issueNumber == null never groups", () => {

--- a/ui/src/lib/components/epic-grouping.ts
+++ b/ui/src/lib/components/epic-grouping.ts
@@ -23,6 +23,7 @@ export function groupSessionsByEpic(
   activeEpicKeys: Set<string>,
   git: Record<string, GitState>,
   isReviewing: (id: string) => boolean,
+  isReworkRunning: (session: Session) => boolean,
   now: number,
 ): { groups: Array<{ key: string; epic: Epic; sessions: Session[] }>; rest: Session[] } {
   // Build a child→epicKey index from the ACTIVE epics only.
@@ -58,7 +59,9 @@ export function groupSessionsByEpic(
       key,
       // key came from childIndex, which is built only from epics present above → defined.
       epic: epics[key],
-      sessions: flattenByStage(partitionSessions(memberSessions, git, isReviewing, now)),
+      sessions: flattenByStage(
+        partitionSessions(memberSessions, git, isReviewing, isReworkRunning, now),
+      ),
     }))
     .sort((a, b) => {
       const byRepo = basename(a.epic.repoPath).localeCompare(basename(b.epic.repoPath));

--- a/ui/src/lib/components/herd-keynav.test.ts
+++ b/ui/src/lib/components/herd-keynav.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "vitest";
 import {
-  railOrder,
+  railOrder as railOrderRaw,
   cycleId,
   nthId,
   nextNeedsYou,
@@ -8,6 +8,7 @@ import {
   altComboKey,
   jumpDigitIndex,
 } from "./herd-keynav";
+import type { HerdFilter } from "./herd-partition";
 import type { Session, GitState, Epic, EpicChild, SessionStatus } from "$lib/types";
 
 function session(
@@ -98,6 +99,34 @@ function epic(repoPath: string, parentIssueNumber: number, childNumbers: number[
 }
 
 const epicKey = (repoPath: string, parent: number) => `${repoPath}#${parent}`;
+const noReview = () => false;
+const noRework = () => false;
+
+function railOrder(
+  sessions: Session[],
+  git: Record<string, GitState>,
+  isReviewing: (id: string) => boolean = noReview,
+  now: number = Date.now(),
+  filter: HerdFilter = "all",
+  workingBlocked: Record<string, boolean> = {},
+  epics: Record<string, Epic> = {},
+  activeEpicKeys: Set<string> = new Set(),
+  collapsedKeys: Set<string> = new Set(),
+  isReworkRunning: (session: Session) => boolean = noRework,
+) {
+  return railOrderRaw(
+    sessions,
+    git,
+    isReviewing,
+    isReworkRunning,
+    now,
+    filter,
+    workingBlocked,
+    epics,
+    activeEpicKeys,
+    collapsedKeys,
+  );
+}
 
 test("railOrder flattens the partition in the rail's render order", () => {
   // input order interleaves stages; the rail renders active → ciRunning →
@@ -231,6 +260,29 @@ test("railOrder mirrors the template across ≥2 groups + rest over ≥2 stages"
   // groups top in basename/parent order (A then B), each lifecycle-flattened;
   // then rest by STAGE_ORDER (ciRunning before merged)
   expect(order).toEqual(["a-active", "a-ready", "b-member", "rest-ci", "rest-merged"]);
+});
+
+test("railOrder places reworkRunning after reviewerRunning and before waiting groups", () => {
+  const list = [
+    session("wait", false, "idle"),
+    session("rework"),
+    session("review"),
+    session("active"),
+  ];
+  const order = railOrder(
+    list,
+    { wait: { ...git("open", "success"), handoff: "reviewer", handoffWho: "scoop" } },
+    (id) => id === "review",
+    1000,
+    "all",
+    {},
+    {},
+    new Set(),
+    new Set(),
+    (s) => s.id === "rework",
+  );
+
+  expect(order).toEqual(["active", "review", "rework", "wait"]);
 });
 
 test("cycleId steps down and up through the order", () => {

--- a/ui/src/lib/components/herd-keynav.ts
+++ b/ui/src/lib/components/herd-keynav.ts
@@ -25,7 +25,8 @@ import { groupSessionsByEpic } from "./epic-grouping";
 export function railOrder(
   sessions: Session[],
   git: Record<string, GitState>,
-  isReviewing: (id: string) => boolean = () => false,
+  isReviewing: (id: string) => boolean,
+  isReworkRunning: (session: Session) => boolean,
   now: number = Date.now(),
   filter: HerdFilter = "all",
   workingBlocked: Record<string, boolean> = {},
@@ -34,13 +35,21 @@ export function railOrder(
   collapsedKeys: Set<string> = new Set(),
 ): string[] {
   const shown = shownSessions(sessions, filter, isReviewing, workingBlocked, git, now);
-  const grouped = groupSessionsByEpic(shown, epics, activeEpicKeys, git, isReviewing, now);
+  const grouped = groupSessionsByEpic(
+    shown,
+    epics,
+    activeEpicKeys,
+    git,
+    isReviewing,
+    isReworkRunning,
+    now,
+  );
   const groupIds = grouped.groups.flatMap((g) =>
     collapsedKeys.has(g.key) ? [] : g.sessions.map((s) => s.id),
   );
-  const restIds = flattenByStage(partitionSessions(grouped.rest, git, isReviewing, now)).map(
-    (s) => s.id,
-  );
+  const restIds = flattenByStage(
+    partitionSessions(grouped.rest, git, isReviewing, isReworkRunning, now),
+  ).map((s) => s.id);
   return [...groupIds, ...restIds];
 }
 

--- a/ui/src/lib/components/herd-partition.test.ts
+++ b/ui/src/lib/components/herd-partition.test.ts
@@ -1,5 +1,9 @@
 import { test, expect } from "vitest";
-import { partitionSessions, shownSessions } from "./herd-partition";
+import {
+  partitionSessions as partitionSessionsRaw,
+  shownSessions,
+  flattenByStage,
+} from "./herd-partition";
 import type { Session, GitState, SessionStatus } from "$lib/types";
 
 function session(id: string, readyToMerge = false, status: SessionStatus = "running"): Session {
@@ -53,6 +57,22 @@ function session(id: string, readyToMerge = false, status: SessionStatus = "runn
 
 function git(state: GitState["state"], checks: GitState["checks"] = "none"): GitState {
   return { kind: "github", state, checks, deployConfigured: false };
+}
+
+const notReviewing = () => false;
+const notReworking = () => false;
+
+function partitionSessions(
+  sessions: Session[],
+  git: Record<string, GitState>,
+  isReviewing: (id: string) => boolean = notReviewing,
+  isReworkRunningOrNow: ((session: Session) => boolean) | number = notReworking,
+  now: number = Date.now(),
+) {
+  const isReworkRunning =
+    typeof isReworkRunningOrNow === "number" ? notReworking : isReworkRunningOrNow;
+  const at = typeof isReworkRunningOrNow === "number" ? isReworkRunningOrNow : now;
+  return partitionSessionsRaw(sessions, git, isReviewing, isReworkRunning, at);
 }
 
 test("ready sessions land in the ready group, active stay on top", () => {
@@ -182,6 +202,71 @@ test("a session under review lands in the reviewerRunning group", () => {
   const { active, reviewerRunning } = partitionSessions(list, {}, (id) => id === "rv");
   expect(active.map((s) => s.id)).toEqual(["a", "b"]);
   expect(reviewerRunning.map((s) => s.id)).toEqual(["rv"]);
+});
+
+test("display-running plan-gate REWORK lands in the reworkRunning group", () => {
+  const plan = { ...session("plan"), planPhase: "planning" as const };
+  const { active, reworkRunning } = partitionSessions(
+    [session("a"), plan, session("b")],
+    {},
+    notReviewing,
+    (s) => s.id === "plan",
+  );
+  expect(active.map((s) => s.id)).toEqual(["a", "b"]);
+  expect(reworkRunning.map((s) => s.id)).toEqual(["plan"]);
+});
+
+test("display-running critic REWORK lands in the reworkRunning group", () => {
+  const list = [session("a"), session("crit"), session("b")];
+  const { active, reworkRunning } = partitionSessions(
+    list,
+    {},
+    notReviewing,
+    (s) => s.id === "crit",
+  );
+  expect(active.map((s) => s.id)).toEqual(["a", "b"]);
+  expect(reworkRunning.map((s) => s.id)).toEqual(["crit"]);
+});
+
+test("display-running REWORK beats pending and failing CI", () => {
+  const list = [session("pending"), session("failed")];
+  const { ciRunning, ciFailed, reworkRunning } = partitionSessions(
+    list,
+    { pending: git("open", "pending"), failed: git("open", "failure") },
+    notReviewing,
+    () => true,
+  );
+  expect(ciRunning).toHaveLength(0);
+  expect(ciFailed).toHaveLength(0);
+  expect(reworkRunning.map((s) => s.id)).toEqual(["pending", "failed"]);
+});
+
+test("idle changes-requested with failed CI stays in ciFailed, not reworkRunning", () => {
+  const idle = session("idle", false, "idle");
+  const { ciFailed, reworkRunning } = partitionSessions(
+    [idle],
+    { idle: git("open", "failure") },
+    notReviewing,
+    notReworking,
+  );
+  expect(reworkRunning).toHaveLength(0);
+  expect(ciFailed.map((s) => s.id)).toEqual(["idle"]);
+});
+
+test("flattenByStage places reworkRunning after reviewerRunning and before waiting groups", () => {
+  const list = [
+    session("wait", false, "idle"),
+    session("rework"),
+    session("review"),
+    session("active"),
+  ];
+  const p = partitionSessions(
+    list,
+    { wait: gitHandoff("reviewer", "scoop") },
+    (id) => id === "review",
+    (s) => s.id === "rework",
+  );
+  expect(flattenByStage(p).map((s) => s.id)).toEqual(["active", "review", "rework", "wait"]);
 });
 
 test("reviewing wins over pending CI when both apply", () => {

--- a/ui/src/lib/components/herd-partition.ts
+++ b/ui/src/lib/components/herd-partition.ts
@@ -8,6 +8,7 @@ import { isMerging } from "./merge-train";
  *  - ciRunning: open PR with CI checks in flight (`open` + `pending`)
  *  - ciFailed: open PR whose CI checks failed (`open` + `failure`) — done, needs a look
  *  - reviewerRunning: a critic run is in flight for the session
+ *  - reworkRunning: the task agent is actively addressing plan-gate or critic requested changes
  *  - draftAwaitingSignoff: open DRAFT PR, CI green (`open` + `success` + `isDraft`) AND
  *    the agent is not actively in the loop — parked, awaiting human sign-off before merge.
  *    Never reads as the green "Your turn" state; rendered in slate (parked, not actionable).
@@ -27,9 +28,9 @@ import { isMerging } from "./merge-train";
  *  - ready: operator-parked "ready to merge"
  *  - merged: PR already landed
  *
- *  First-match precedence (terminal states win; reviewing beats the CI/merge stages
+ *  First-match precedence (terminal states win; reviewing/rework beat the CI/merge stages
  *  as the later in-flight stage):
- *    merged > merging > ready > reviewerRunning > ciRunning > ciFailed >
+ *    merged > merging > ready > reviewerRunning > reworkRunning > ciRunning > ciFailed >
  *    draftAwaitingSignoff > (waitingOnReviewer | waitingOnMerger | awaitingMerge) > active.
  *  A draft outranks the handed-off groups: a green idle DRAFT is awaiting sign-off
  *  regardless of who the roles file names. An open PR with `none` checks (no CI reported
@@ -46,6 +47,7 @@ type Stage =
   | "merging"
   | "ready"
   | "reviewerRunning"
+  | "reworkRunning"
   | "ciRunning"
   | "ciFailed"
   | "draftAwaitingSignoff"
@@ -98,7 +100,7 @@ export function shownSessions(
       (s) =>
         displayStatus(s, workingBlocked) !== "running" &&
         !inReview(s.id) &&
-        !NOT_YOUR_TURN.has(stageOf(s, git[s.id], inReview, now)),
+        !NOT_YOUR_TURN.has(stageOf(s, git[s.id], inReview, () => false, now)),
     );
   // Rundown + Owed + Up Next are panel-only lenses (a dedicated panel, no session list).
   if (filter === "rundown" || filter === "owed" || filter === "next") return [];
@@ -112,12 +114,14 @@ function terminalStage(
   s: Session,
   g: GitState | undefined,
   isReviewing: (id: string) => boolean,
+  isReworkRunning: (session: Session) => boolean,
   now: number,
 ): Stage | null {
   if (g?.state === "merged") return "merged";
   if (isMerging(s, now)) return "merging";
   if (s.readyToMerge) return "ready";
   if (isReviewing(s.id)) return "reviewerRunning";
+  if (isReworkRunning(s)) return "reworkRunning";
   if (g?.state === "open" && g.checks === "pending") return "ciRunning";
   if (g?.state === "open" && g.checks === "failure") return "ciFailed";
   return null;
@@ -139,9 +143,10 @@ function stageOf(
   s: Session,
   g: GitState | undefined,
   isReviewing: (id: string) => boolean,
+  isReworkRunning: (session: Session) => boolean,
   now: number,
 ): Stage {
-  const terminal = terminalStage(s, g, isReviewing, now);
+  const terminal = terminalStage(s, g, isReviewing, isReworkRunning, now);
   if (terminal) return terminal;
   // Raw status by design: a working-while-blocked session (display "running") is raw
   // "blocked" — both are excluded from greenIdle, so the display flag can't change
@@ -164,6 +169,7 @@ const STAGE_ORDER = [
   "ciRunning",
   "ciFailed",
   "reviewerRunning",
+  "reworkRunning",
   "waitingOnReviewer",
   "waitingOnMerger",
   "draftAwaitingSignoff",
@@ -181,13 +187,15 @@ export function flattenByStage(p: ReturnType<typeof partitionSessions>): Session
 export function partitionSessions(
   sessions: Session[],
   git: Record<string, GitState>,
-  isReviewing: (id: string) => boolean = () => false,
+  isReviewing: (id: string) => boolean,
+  isReworkRunning: (session: Session) => boolean,
   now: number = Date.now(),
 ): {
   active: Session[];
   ciRunning: Session[];
   ciFailed: Session[];
   reviewerRunning: Session[];
+  reworkRunning: Session[];
   draftAwaitingSignoff: Session[];
   waitingOnReviewer: Session[];
   waitingOnMerger: Session[];
@@ -201,6 +209,7 @@ export function partitionSessions(
     ciRunning: [],
     ciFailed: [],
     reviewerRunning: [],
+    reworkRunning: [],
     draftAwaitingSignoff: [],
     waitingOnReviewer: [],
     waitingOnMerger: [],
@@ -210,7 +219,7 @@ export function partitionSessions(
     merged: [],
   };
   for (const s of sessions) {
-    groups[stageOf(s, git[s.id], isReviewing, now)].push(s);
+    groups[stageOf(s, git[s.id], isReviewing, isReworkRunning, now)].push(s);
   }
   return groups;
 }

--- a/ui/src/lib/components/herd-partition.ts
+++ b/ui/src/lib/components/herd-partition.ts
@@ -38,10 +38,11 @@ import { isMerging } from "./merge-train";
  *  as pending — UNLESS the repo has no CI at all (`g.noCi`, GitHub + zero workflows), where
  *  `none` is terminal and the PR is handed off like a green one. The groups render top→bottom as
  *  active → ciRunning → ciFailed →
- *  reviewerRunning → waitingOnReviewer → waitingOnMerger → draftAwaitingSignoff →
- *  awaitingMerge → ready → merging → merged (Herd.svelte's template order, mirrored
- *  by herd-keynav's railOrder via flattenByStage), tracking the session lifecycle. `isReviewing`
- *  is injected so this stays a pure function (the caller wires it to the reviews store). */
+ *  reviewerRunning → reworkRunning → waitingOnReviewer → waitingOnMerger →
+ *  draftAwaitingSignoff → awaitingMerge → ready → merging → merged (Herd.svelte's template
+ *  order, mirrored by herd-keynav's railOrder via flattenByStage), tracking the session
+ *  lifecycle. `isReviewing` is injected so this stays a pure function (the caller wires it to
+ *  the reviews store). */
 type Stage =
   | "merged"
   | "merging"

--- a/ui/src/lib/components/herd/HerdGroup.svelte
+++ b/ui/src/lib/components/herd/HerdGroup.svelte
@@ -108,6 +108,7 @@
      reviewing) — amber mirrors the CI-pending dot and the critic badge */
   .ci-head,
   .reviewing-head,
+  .rework-head,
   .merging-head {
     display: flex;
     align-items: center;

--- a/ui/src/lib/components/rework-running.test.ts
+++ b/ui/src/lib/components/rework-running.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "vitest";
+import { isReworkRunning } from "./rework-running";
+import type { Session, SessionStatus } from "$lib/types";
+
+function session(
+  id: string,
+  status: SessionStatus = "running",
+  planPhase: Session["planPhase"] = null,
+): Pick<Session, "id" | "status" | "planPhase"> {
+  return { id, status, planPhase };
+}
+
+test("matches display-running plan-gate changes during planning", () => {
+  expect(
+    isReworkRunning(
+      session("s", "running", "planning"),
+      { planGate: { decision: "changes_requested" } },
+      {},
+    ),
+  ).toBe(true);
+});
+
+test("does not match plan-gate changes after execution starts", () => {
+  expect(
+    isReworkRunning(
+      session("s", "running", "executing"),
+      { planGate: { decision: "changes_requested" } },
+      {},
+    ),
+  ).toBe(false);
+});
+
+test("matches display-running critic changes", () => {
+  expect(isReworkRunning(session("s"), { review: { decision: "changes_requested" } }, {})).toBe(
+    true,
+  );
+});
+
+test("ignores non-changes decisions", () => {
+  expect(isReworkRunning(session("s"), { planGate: { decision: "approved" } }, {})).toBe(false);
+  expect(isReworkRunning(session("s"), { review: { decision: "commented" } }, {})).toBe(false);
+});
+
+test("requires display-running status", () => {
+  expect(
+    isReworkRunning(session("s", "idle"), { review: { decision: "changes_requested" } }, {}),
+  ).toBe(false);
+});
+
+test("includes working-while-blocked changes-requested rows", () => {
+  expect(
+    isReworkRunning(
+      session("s", "blocked"),
+      { review: { decision: "changes_requested" } },
+      { s: true },
+    ),
+  ).toBe(true);
+});
+
+test("keeps genuinely blocked changes-requested rows out of the running group", () => {
+  expect(
+    isReworkRunning(session("s", "blocked"), { review: { decision: "changes_requested" } }, {}),
+  ).toBe(false);
+});

--- a/ui/src/lib/components/rework-running.ts
+++ b/ui/src/lib/components/rework-running.ts
@@ -1,0 +1,19 @@
+import type { PlanGate, ReviewVerdict, Session } from "$lib/types";
+import { displayStatus } from "$lib/display-status";
+
+export type ReworkRunningSignals = {
+  planGate?: Pick<PlanGate, "decision">;
+  review?: Pick<ReviewVerdict, "decision">;
+};
+
+export function isReworkRunning(
+  session: Pick<Session, "id" | "status" | "planPhase">,
+  signals: ReworkRunningSignals,
+  workingBlocked: Record<string, boolean>,
+): boolean {
+  if (displayStatus(session, workingBlocked) !== "running") return false;
+  return (
+    (session.planPhase === "planning" && signals.planGate?.decision === "changes_requested") ||
+    signals.review?.decision === "changes_requested"
+  );
+}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -90,6 +90,7 @@
     altComboKey,
   } from "$lib/components/herd-keynav";
   import { groupSessionsByEpic } from "$lib/components/epic-grouping";
+  import { isReworkRunning as isReworkRunningSession } from "$lib/components/rework-running";
   import { buildCommands } from "$lib/command-registry";
   import type { HerdFilter } from "$lib/components/herd-partition";
   import {
@@ -464,12 +465,19 @@
   // for ordering — so the filter asymmetry with render/rail is intentional and harmless.
   const epicGroupOf = $derived.by(() => {
     const isReviewing = (id: string) => reviews.isReviewing(id) || planGates.isReviewing(id);
+    const isReworkRunning = (session: Session) =>
+      isReworkRunningSession(
+        session,
+        { planGate: planGates.map[session.id], review: reviews.map[session.id] },
+        store.workingBlocked,
+      );
     const { groups } = groupSessionsByEpic(
       herdSessions,
       store.epics,
       activeEpicKeys,
       store.git,
       isReviewing,
+      isReworkRunning,
       nowMs,
     );
     // Build from an entries array (not .set in a loop) so it's a plain non-reactive
@@ -1274,6 +1282,12 @@
       herdSessions,
       store.git,
       (id) => reviews.isReviewing(id) || planGates.isReviewing(id),
+      (session) =>
+        isReworkRunningSession(
+          session,
+          { planGate: planGates.map[session.id], review: reviews.map[session.id] },
+          store.workingBlocked,
+        ),
       nowMs,
       // a page-level status filter short-circuits the rail's all/ready filter in
       // Herd's shown set (one filter at a time) — mirror that here so keynav walks


### PR DESCRIPTION
## Summary
- add a shared store-backed rework-running predicate for plan-gate and critic changes-requested sessions
- add a REWORK RUNNING herd section in the same lifecycle/order path used by render, epic grouping, and keynav
- cover working-while-blocked rework, CI precedence, epic ordering, and render-vs-rail order

## Tests
- cd ui && bun run check:i18n
- cd ui && bun run check
- cd ui && bun run test:node ./src/lib/components/rework-running.test.ts ./src/lib/components/herd-partition.test.ts ./src/lib/components/herd-keynav.test.ts ./src/lib/components/epic-grouping.test.ts
- cd ui && bun run test:browser ./src/lib/components/Herd.browser.test.ts
- cd ui && bun run test:node
- cd ui && bun run test:browser
- bun run lint
- git push --force-with-lease (pre-push: prettier, eslint, gates, tsc, ext, root-tests, ui)