### PR TITLE
feat: enable bring-back (restore) for isolated Codex sessions (#1175)

### DIFF
--- a/docs/spikes/1175-codex-restore.md
+++ b/docs/spikes/1175-codex-restore.md
@@ -20,6 +20,26 @@ The id **cannot** be pinned at spawn, but it **can** be discovered deterministic
 design is robust regardless of whether `codex resume` appends to the same rollout or forks a new one.
 Non-isolated Codex (shared cwd) stays `cannot_restore` by design.
 
+## Non-isolated Codex — deliberately blocked (not an oversight)
+
+Restore stays `cannot_restore` for **non-isolated** Codex sessions **by design** — this was confirmed
+with the operator during planning ("non-isolated Codex … keep blocking"). It is a correctness limit,
+not missing wiring: the id is discovered by matching the rollout header's `cwd`, which is unique only
+for an isolated worktree. A non-isolated session shares the repo cwd with siblings, later sessions,
+relaunches, and the operator's own `codex` runs, so **neither** strategy can attribute a rollout to a
+specific Shepherd row:
+
+- **Derive-at-restore** (this PR): "newest `source=cli` rollout for the repo cwd" at restore time is
+  whatever ran most recently in that repo — routinely an unrelated conversation once the repo is reused.
+- **Persist-at-spawn**: the populate-once capture can just as easily grab a sibling's / the operator's
+  rollout, so the persisted id can be the wrong one.
+
+Codex exposes no `--session-id` to pin and no way to read back its self-generated id (Finding 1), so a
+shared cwd is fundamentally un-attributable. Per #1175's principle — _restoring the wrong conversation
+is worse than refusing_ — those rows keep the "relaunch instead" hint, matching the autopilot
+isolated-only guard for Codex. It becomes feasible only if Codex adds spawn-time id pinning; tracked
+as a follow-up in **#1476**.
+
 ## Environment
 
 |               |                                                                                              |

--- a/docs/spikes/1175-codex-restore.md
+++ b/docs/spikes/1175-codex-restore.md
@@ -1,0 +1,102 @@
+# Spike #1175 — Can Shepherd bring back (restore) a Codex session by id?
+
+**Phase-0 go/no-go.** Follow-up to #1174 (Claude-only restore MVP). Restore must re-attach the
+**exact** prior conversation of an archived session, never a sibling's. For Codex that means
+resuming by a specific session id rather than `codex resume --last` (which is cwd-scoped and can
+target a sibling in a shared cwd). This spike asks the load-bearing questions before the
+store/guard/poller work is built on them.
+
+> 1. Can the Codex session id be **pinned at spawn** (an analog to `claude --session-id`)?
+> 2. Can it be **discovered post-spawn** — reliably, and scoped to the _interactive_ main agent (not
+>    a headless `codex exec` role spawn that shares the worktree cwd)?
+> 3. Does `codex resume <uuid>` re-attach the exact conversation in a **re-created** worktree, and
+>    does the transcript survive worktree removal?
+
+## Decision: **GO** ✅ (isolated Codex only)
+
+The id **cannot** be pinned at spawn, but it **can** be discovered deterministically for an
+**isolated** worktree from the rollout header (`session_meta.cwd` + `session_meta.source == "cli"`
+→ `session_meta.session_id`). Restore derives it **fresh** at restore time (source of truth), so the
+design is robust regardless of whether `codex resume` appends to the same rollout or forks a new one.
+Non-isolated Codex (shared cwd) stays `cannot_restore` by design.
+
+## Environment
+
+|               |                                                                                              |
+| ------------- | -------------------------------------------------------------------------------------------- |
+| codex         | `codex-cli 0.142.5`                                                                          |
+| CODEX_HOME    | `~/.codex` (override: `$CODEX_HOME`)                                                         |
+| Rollout store | `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`                                  |
+| Main spawn    | `codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox …` (`buildCodexSpawnArgv`) |
+| Resume form   | `codex resume [SESSION_ID] [PROMPT]` — positional UUID or session name                       |
+
+## Findings (verified from the installed CLI + on-disk rollouts)
+
+### 1. No pin-at-spawn — VERIFIED
+
+`codex --help` exposes **no** `--session-id` / `--thread-id` flag (`grep -c -- --session-id` → `0`);
+`-c/--config` sets `config.toml` keys, not the session id. Codex self-generates a UUIDv7 per session.
+Upstream feature requests for a spawn-time id flag (openai/codex #15767, #13242, #15271, #8923) are
+unshipped. ⇒ The id must be **discovered** after spawn.
+
+### 2. Discovery is deterministic for an isolated worktree — VERIFIED
+
+`codex resume --help`: `[SESSION_ID]` is a positional "Session id (UUID) or session name"; `--last`
+and the picker are **cwd-filtered** (`--all` "disables cwd filtering") and interactive-only
+(`--include-non-interactive` opts exec sessions in) — i.e. `--last` cannot disambiguate concurrent
+sessions in one cwd, exactly the issue's failure mode.
+
+Rollout header (line 1) carries everything needed, e.g.:
+
+```json
+{"type":"session_meta","payload":{
+  "session_id":"019f364c-cb8f-74d2-8e4d-64864a1aecc9",
+  "id":"019f364c-cb8f-74d2-8e4d-64864a1aecc9",
+  "cwd":"/home/moe/projects/.shepherd-worktrees/shepherd-gauges-bar-usage-changed",
+  "source":"cli","originator":"codex-tui","cli_version":"0.142.5", …}}
+```
+
+**The `source == "cli"` filter is load-bearing — VERIFIED.** On this machine, Shepherd's interactive
+main agents and its headless `codex exec` role spawns (reviewers) both write rollouts in
+`.shepherd-worktrees/…` cwds, distinguished only by `source`:
+
+```
+019f3669-… | source=cli  | /…/.shepherd-worktrees/shepherd-start-don-ask-which        (main agent)
+019f364c-… | source=cli  | /…/.shepherd-worktrees/shepherd-gauges-bar-usage-changed    (main agent)
+019f36a8-… | source=exec | /…/.shepherd-worktrees/shepherd-review-929b9cce             (role spawn)
+```
+
+So filtering to `source == "cli"` correctly targets the main conversation and excludes role spawns
+that share a worktree cwd. Matching `cwd` as a **raw string** is safe: Shepherd's `worktreePath` is
+already canonical (`safeRepoDir` realpath-resolves `repoPath`; the worktree `join`s from it) and
+Codex records its canonical cwd — so no `realpath` is done on the (possibly-absent, at restore time)
+candidate. The state DB (`~/.codex/state_5.sqlite`, `threads(id, rollout_path, cwd, …)`) carries the
+same mapping but is a lag-prone cache with a version-drifting filename, so the rollout header is used
+as ground truth.
+
+### 3. Transcript survives worktree removal — VERIFIED (by construction)
+
+Rollouts live under `$CODEX_HOME`, **outside** the worktree, so Shepherd's archive (which removes the
+worktree) does not delete them. Shepherd's archive is unrelated to Codex's own `codex archive`
+(Shepherd never calls it), so the session stays resumable.
+
+## Implementation consequence (robust to resume semantics)
+
+Because the id is derived **fresh at restore** (newest `source=cli` rollout whose cwd matches the
+worktree), correctness does **not** depend on whether `codex resume` appends to the same rollout or
+forks a new id: after any restore→work→archive cycle, the newest cwd-matching interactive rollout is
+always the current conversation. Live resume (autopilot/automerge/manual) keeps `codex resume --last`
+(cwd-scoped, interactive-only → the current conversation for an isolated cwd), so a pane-death mid-
+restored-session re-attaches correctly without trusting a stored id.
+
+## Remaining live checks (operator confirmation)
+
+These runtime round-trips need an authenticated interactive Codex session and were **not** driven in
+this headless spike; the design above does not hinge on their outcome (only on the CLI's documented
+`codex resume [SESSION_ID]` contract + the verified discovery), but confirm during rollout:
+
+- [ ] Archive an isolated Codex session, **Bring back** → `codex resume <uuid>` re-attaches the exact
+      prior conversation in the re-created worktree.
+- [ ] Multi-restore (restore → add work → archive → restore again) resumes the **latest** conversation.
+- [ ] Pane-death during a restored session → live `resume()` (`--last`) re-attaches the restored
+      conversation, not the pre-restore one.

--- a/src/codex-session-id.ts
+++ b/src/codex-session-id.ts
@@ -1,0 +1,100 @@
+/**
+ * Discover the provider-native Codex session id (the rollout UUID resumed via `codex resume <id>`)
+ * for an isolated Shepherd worktree, by reading rollout `session_meta` headers under
+ * `$CODEX_HOME/sessions`.
+ *
+ * The rollout header is the ground truth for the id (the Codex `state_N.sqlite` cache lags and its
+ * filename drifts across versions). Codex writes it as line 1 of every rollout jsonl:
+ *   {"type":"session_meta","payload":{"session_id":"<uuid>","id":"<uuid>","cwd":"<abs>","source":"cli",…}}
+ *
+ * Two constraints make this reliable for an ISOLATED worktree (unique cwd):
+ *  - The cwd match is a RAW string compare against `worktreePath`, which is already canonical
+ *    (Shepherd's `safeRepoDir` realpath-resolves repoPath and the worktree joins from it) and which
+ *    Codex records canonically. No `realpath` is performed on the candidate cwd — this runs BEFORE
+ *    the worktree is re-created at restore time, so the path may not exist on disk.
+ *  - `source === "cli"` excludes headless `codex exec` ROLE spawns (recap/critic/reviewer) that can
+ *    share a worktree cwd; resuming one of those instead of the interactive session would be wrong.
+ */
+import { closeSync, openSync, readSync } from "node:fs";
+import { normalize } from "node:path";
+
+import { codexHome, listRolloutFiles } from "./codex-usage";
+
+interface SessionMetaHeader {
+  id: string | null;
+  cwd: string;
+  source: string | null;
+}
+
+/**
+ * The newest interactive (`source === "cli"`) rollout whose recorded cwd equals `worktreePath`,
+ * among rollouts modified at/after `notBeforeMs`; null if none. The scan is UNBOUNDED over that
+ * mtime window (callers must not cap it) so a busy machine can't push the target rollout out of view.
+ */
+export function findCodexSessionId(
+  worktreePath: string,
+  notBeforeMs: number,
+  home = codexHome(),
+): string | null {
+  const target = normalize(worktreePath);
+  // listRolloutFiles is newest-first, so the first cwd+cli match is the newest one.
+  for (const { path, mtimeMs } of listRolloutFiles(home)) {
+    if (mtimeMs < notBeforeMs) continue;
+    const meta = readSessionMeta(path);
+    if (!meta || meta.source !== "cli" || !meta.id) continue;
+    if (normalize(meta.cwd) === target) return meta.id;
+  }
+  return null;
+}
+
+/** Parse line 1 of a rollout jsonl (the `session_meta` record). Tolerant: null on any read/parse
+ *  failure or a non-`session_meta` / malformed header (legacy or partially-written file). */
+function readSessionMeta(path: string): SessionMetaHeader | null {
+  const line = readFirstLine(path);
+  if (!line) return null;
+  let obj: unknown;
+  try {
+    obj = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (!obj || typeof obj !== "object") return null;
+  const rec = obj as { type?: unknown; payload?: unknown };
+  if (rec.type !== "session_meta" || !rec.payload || typeof rec.payload !== "object") return null;
+  const p = rec.payload as { session_id?: unknown; id?: unknown; cwd?: unknown; source?: unknown };
+  const cwd = typeof p.cwd === "string" ? p.cwd : null;
+  if (!cwd) return null;
+  const id =
+    typeof p.session_id === "string" ? p.session_id : typeof p.id === "string" ? p.id : null;
+  const source = typeof p.source === "string" ? p.source : null;
+  return { id, cwd, source };
+}
+
+/** Read the first line of a file without loading the whole thing — a rollout grows to many MB, but
+ *  its `session_meta` header (line 1) carries the full Codex system prompt so it can still be tens
+ *  of KB. One bounded read (512 KiB) covers any realistic header; a header larger than that, or with
+ *  no newline in the buffer, yields a truncated string that simply fails to JSON-parse (→ skipped). */
+function readFirstLine(path: string): string | null {
+  let fd: number | null = null;
+  try {
+    fd = openSync(path, "r");
+    const buf = Buffer.alloc(512 * 1024);
+    const n = readSync(fd, buf, 0, buf.length, 0);
+    const text = buf.toString("utf8", 0, n);
+    const nl = text.indexOf("\n");
+    return nl === -1 ? text : text.slice(0, nl);
+  } catch {
+    return null;
+  } finally {
+    if (fd !== null) closeSyncQuiet(fd);
+  }
+}
+
+/** closeSync that never throws (fd may already be gone). */
+function closeSyncQuiet(fd: number): void {
+  try {
+    closeSync(fd);
+  } catch {
+    /* already closed */
+  }
+}

--- a/src/codex-usage.ts
+++ b/src/codex-usage.ts
@@ -49,13 +49,13 @@ export interface CodexRateLimits {
   latestEventAt: number | null;
 }
 
-interface RolloutCandidate {
+export interface RolloutCandidate {
   path: string;
   mtimeMs: number;
   size: number;
 }
 
-function codexHome(): string {
+export function codexHome(): string {
   return process.env.CODEX_HOME || join(homedir(), ".codex");
 }
 
@@ -79,7 +79,12 @@ function dedupeRolloutCandidates(paths: string[], extra: RolloutCandidate[]): Ro
   return [...byPath.values()].sort((a, b) => b.mtimeMs - a.mtimeMs).slice(0, ROLLOUT_SCAN_LIMIT);
 }
 
-export function recentCodexRolloutPaths(home = codexHome(), limit = ROLLOUT_SCAN_LIMIT): string[] {
+/**
+ * Every rollout file under `$CODEX_HOME/sessions`, newest-first by mtime, with NO count cap — the
+ * complete set. Callers that only want the freshest few must slice themselves. `findCodexSessionId`
+ * relies on the full list so a busy machine can't push a session's own rollout past a limit.
+ */
+export function listRolloutFiles(home = codexHome()): RolloutCandidate[] {
   const root = join(home, "sessions");
   const out: RolloutCandidate[] = [];
   function walk(dir: string): void {
@@ -101,8 +106,11 @@ export function recentCodexRolloutPaths(home = codexHome(), limit = ROLLOUT_SCAN
     }
   }
   walk(root);
-  return out
-    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+  return out.sort((a, b) => b.mtimeMs - a.mtimeMs);
+}
+
+export function recentCodexRolloutPaths(home = codexHome(), limit = ROLLOUT_SCAN_LIMIT): string[] {
+  return listRolloutFiles(home)
     .slice(0, limit)
     .map((c) => c.path);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -767,6 +767,10 @@ poller.reDrive = (id) =>
     console.warn(`[poller] account re-drive failed for ${id}:`, err);
   });
 
+// Best-effort: seed a running isolated Codex session's provider-native id from its rollout header, so
+// restore (and #1087/#1160) has the id available. Synchronous + internally guarded/never-throws.
+poller.captureCodexSessionId = (s) => service.captureCodexSessionId(s);
+
 // Phase-1 push-hook signal wiring (issue #704): feed received hook events into the
 // poller (the single owner of per-session signal dedup + state). Only when
 // `config.hooksSignals` is on AND ingest is too — with ingest off no events ever

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -134,6 +134,11 @@ export class StatusPoller {
    *  index.ts). Left undefined in tests that don't exercise it. */
   reDrive?: (id: string) => void;
 
+  /** Fire-and-forget best-effort seed of a running Codex session's provider-native id (wired to
+   *  service.captureCodexSessionId in index.ts). No-op for non-Codex / non-isolated / already-seeded
+   *  sessions. Left undefined in tests that don't exercise it. */
+  captureCodexSessionId?: (s: Session) => void;
+
   /**
    * Resting-session (done/idle) MCP-auth detection seams, public + assignable (mirrors `reDrive`)
    * so tests can drive the mtime/URL sequence deterministically without touching disk:
@@ -426,6 +431,15 @@ export class StatusPoller {
       const agent = matched.get(s.id) ?? null;
       if (!agent) this.reapGone(s);
       else this.reconcileAgent(s, agent);
+      // Best-effort seed of a live Codex session's provider-native id (no-op unless it's an isolated
+      // Codex session that hasn't been seeded yet). tick() runs on a bare setInterval — never throw.
+      if (agent && this.captureCodexSessionId) {
+        try {
+          this.captureCodexSessionId(s);
+        } catch (err) {
+          console.warn("[poller] codex session-id capture failed:", err);
+        }
+      }
     }
     this.pruneInactive(activeIds);
     // Observe-only Stop↔herdr-done window (issue #713): expire markers that never paired

--- a/src/service.ts
+++ b/src/service.ts
@@ -3312,7 +3312,11 @@ export class SessionService {
       this.deps.store.setProviderSessionId(s.id, id); // write-through refresh
       return id;
     }
-    throw new RestoreError("cannot_restore"); // codex non-isolated, or any other provider
+    // codex non-isolated, or any other provider. Non-isolated Codex shares the repo cwd with
+    // siblings/relaunches/operator runs, so no rollout can be reliably attributed to THIS row —
+    // restoring the wrong conversation is worse than refusing (#1175). Blocked pending Codex
+    // spawn-time id pinning; tracked in #1476.
+    throw new RestoreError("cannot_restore");
   }
 
   async restore(id: string): Promise<Session | null> {

--- a/src/service.ts
+++ b/src/service.ts
@@ -9,6 +9,7 @@ import type { WorktreeMgr } from "./worktree";
 import type { HerdrAgent, HerdrDriver } from "./herdr";
 import { matchAgents, needsAccountRedrive } from "./herdr";
 import { config } from "./config";
+import { findCodexSessionId } from "./codex-session-id";
 import type {
   AgentProvider,
   CreateSessionInput,
@@ -100,6 +101,11 @@ export class RestoreError extends Error {
     this.name = "RestoreError";
   }
 }
+
+/** Generous negative clock-skew allowance when filtering Codex rollout files by mtime against a
+ *  session's `createdAt` — a rollout is written just after spawn, so its mtime is >= createdAt on the
+ *  same machine; this only guards against tiny FS/clock jitter so a legit rollout is never excluded. */
+const CODEX_ID_SKEW_MS = 5 * 60_000;
 
 /** Thrown by create() when an AUTONOMOUS (auto) spawn is refused because the originating issue's
  *  author is untrusted or its trust cannot be established (fail-closed). The drain's spawn catch
@@ -2132,16 +2138,20 @@ export class SessionService {
     return argv;
   }
 
-  private buildCodexResumeArgv(model: string | null, effort: string | null): string[] {
-    // Codex has `codex resume [SESSION_ID]`, but Shepherd does not yet persist the
-    // Codex session id. `--last` is scoped by the Codex CLI's own resume selection
-    // rules, so concurrent/non-isolated Codex sessions sharing a cwd can target the
-    // most recent Codex session for that cwd rather than this exact Shepherd row.
-    // Keep this visible until Codex spawn/ingest records a provider-native id.
+  private buildCodexResumeArgv(
+    model: string | null,
+    effort: string | null,
+    sessionId: string | null = null,
+  ): string[] {
+    // Resume a SPECIFIC Codex session by its rollout UUID when we know it — `restore` derives it
+    // fresh from the rollout header. Otherwise fall back to `codex resume --last`, which is cwd-scoped
+    // and interactive-only, so it correctly targets the current conversation for an isolated worktree;
+    // the live resume paths (autopilot/automerge/manual) take this fallback. `[SESSION_ID]` is a
+    // positional arg and must precede the flags.
     const argv = [
       "codex",
       "resume",
-      "--last",
+      sessionId ?? "--last",
       "--no-alt-screen",
       "--dangerously-bypass-approvals-and-sandbox",
     ];
@@ -2169,10 +2179,28 @@ export class SessionService {
     return argv;
   }
 
-  private buildResumeArgv(s: Session, provider: AgentProvider, trim: TrimDecision): string[] {
+  private buildResumeArgv(
+    s: Session,
+    provider: AgentProvider,
+    trim: TrimDecision,
+    codexSessionId: string | null = null,
+  ): string[] {
     return provider === "codex"
-      ? this.buildCodexResumeArgv(s.model, s.effort)
+      ? this.buildCodexResumeArgv(s.model, s.effort, codexSessionId)
       : this.buildClaudeResumeArgv(s, trim);
+  }
+
+  /**
+   * Poller-invoked, fire-and-forget: seed `providerSessionId` for a running ISOLATED Codex session
+   * that lacks one, by discovering its rollout id (cwd + `source=cli` match). Populate-once (skips
+   * when already set) and never writes an empty string — a `null` derive is a no-op, so a transient
+   * miss can't clobber a good id. `restore` does NOT trust this cached value (it re-derives), so this
+   * is purely the best-effort provider-neutral seed for #1087/#1160. Never throws.
+   */
+  captureCodexSessionId(s: Session): void {
+    if ((s.agentProvider ?? "claude") !== "codex" || !s.isolated || s.providerSessionId) return;
+    const id = findCodexSessionId(s.worktreePath, s.createdAt - CODEX_ID_SKEW_MS);
+    if (id) this.deps.store.setProviderSessionId(s.id, id);
   }
 
   private resumeTarget(id: string): { session: Session; provider: AgentProvider } | null {
@@ -2767,6 +2795,9 @@ export class SessionService {
       this.deps.store.update(s.id, {
         herdrAgentId: outcome.terminalId,
         claudeSessionId: agentProvider === "claude" ? claudeSessionId : "",
+        // Relaunch spawns a fresh agent → a fresh rollout; clear any stale captured Codex id so the
+        // poller re-captures the new session's id (restore derives fresh regardless).
+        providerSessionId: "",
         agentProvider,
         model: launch.spawnInput.model,
         // Mirror the create path (#1418): persist the effort actually spawned with, so a later
@@ -3261,6 +3292,29 @@ export class SessionService {
    * a generic 409). Throws `RestoreError` for precondition violations, and propagates
    * `WorktreeRestoreError` from the worktree layer so the route can map specific codes to 409.
    */
+  /**
+   * Resolve the id to resume an archived session by, enforcing per-provider restorability.
+   * Claude: requires its pinned `claudeSessionId` (returns null — it resumes via `--resume`).
+   * Codex: isolated only; derives the id FRESH from the rollout header (source of truth — always the
+   * actual last conversation for this worktree, robust to Codex-resume append-vs-fork, honest when the
+   * rollout was GC'd), persists it write-through, and returns it. The scan never touches the
+   * (at restore time absent) worktree — it string-matches cwds under `$CODEX_HOME` — so a miss throws
+   * BEFORE any worktree side effect (no rollback). Throws `RestoreError("cannot_restore")` otherwise.
+   */
+  private resolveCodexRestoreId(s: Session, provider: AgentProvider): string | null {
+    if (provider === "claude") {
+      if (!s.claudeSessionId) throw new RestoreError("cannot_restore");
+      return null;
+    }
+    if (provider === "codex" && s.isolated) {
+      const id = findCodexSessionId(s.worktreePath, s.createdAt - CODEX_ID_SKEW_MS);
+      if (!id) throw new RestoreError("cannot_restore");
+      this.deps.store.setProviderSessionId(s.id, id); // write-through refresh
+      return id;
+    }
+    throw new RestoreError("cannot_restore"); // codex non-isolated, or any other provider
+  }
+
   async restore(id: string): Promise<Session | null> {
     const s = this.deps.store.get(id);
     if (!s) return null;
@@ -3268,7 +3322,9 @@ export class SessionService {
     if (s.status !== "archived") throw new RestoreError("not_archived");
 
     const provider = s.agentProvider ?? "claude";
-    if (provider !== "claude" || !s.claudeSessionId) throw new RestoreError("cannot_restore");
+    // Codex resumes by an explicit id; Claude by `--resume`. resolveCodexRestoreId enforces
+    // restorability (throws cannot_restore) and returns the Codex id (null for Claude).
+    const codexSessionId = this.resolveCodexRestoreId(s, provider);
 
     let worktreeCreated = false;
     if (s.isolated && s.branch) {
@@ -3279,7 +3335,10 @@ export class SessionService {
     }
 
     const trim = await this.trimFor(s.auto);
-    const outcome = await this.prepareResumeSpawn(s, this.buildResumeArgv(s, provider, trim));
+    const outcome = await this.prepareResumeSpawn(
+      s,
+      this.buildResumeArgv(s, provider, trim, codexSessionId),
+    );
     if (!outcome.ok) {
       console.warn(`[restore] spawn refused for ${s.id}: ${outcome.holdReason}`);
       if (worktreeCreated) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -69,6 +69,11 @@ function nullableBool(v: unknown): boolean | null {
   return v === null || v === undefined ? null : !!v;
 }
 
+/** Coalesce a nullable/absent TEXT value to "" (for NOT-NULL string columns). */
+function strOrEmpty(v: string | null | undefined): string {
+  return v ?? "";
+}
+
 /** Designation prefix for task sessions, e.g. "TASK-07". Single source for the prefix + its SUBSTR offset. */
 const DESIG_PREFIX = "TASK-";
 
@@ -176,6 +181,7 @@ type NewSession = Omit<
   | "model"
   | "effort"
   | "claudeSessionId"
+  | "providerSessionId"
   | "agentProvider"
   | "readyToMerge"
   | "mergingSince"
@@ -213,6 +219,7 @@ type NewSession = Omit<
   model?: string | null;
   effort?: string | null;
   claudeSessionId?: string;
+  providerSessionId?: string;
   agentProvider?: Session["agentProvider"];
   auto?: boolean;
   issueNumber?: number | null;
@@ -236,7 +243,7 @@ const COLS = `id, desig, name, prompt, repoPath, baseBranch, branch, worktreePat
   research,
   createdAt, updatedAt, archivedAt, mergingSince, mergingTrainId, mergeTrainPrs, mergingPrNumber,
   haltReason, haltedAt, manualStepsJson, manualStepsAckedAt, experimentId, experimentRole,
-  spawnTerminalId, spawnAccountDir`;
+  spawnTerminalId, spawnAccountDir, providerSessionId`;
 
 // ── SQLite row shapes ──────────────────────────────────────────────────────────
 
@@ -254,6 +261,7 @@ type SessionRow = {
   herdrSession: string;
   herdrAgentId: string;
   claudeSessionId: string | null;
+  providerSessionId: string | null;
   agentProvider: string | null;
   model: string | null;
   effort: string | null;
@@ -723,6 +731,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       worktreePath TEXT NOT NULL, isolated INTEGER NOT NULL,
       herdrSession TEXT NOT NULL, herdrAgentId TEXT NOT NULL,
       claudeSessionId TEXT NOT NULL DEFAULT '',
+      providerSessionId TEXT NOT NULL DEFAULT '',
       agentProvider TEXT NOT NULL DEFAULT 'claude',
       model TEXT, effort TEXT, status TEXT NOT NULL, lastState TEXT NOT NULL,
       auto INTEGER NOT NULL DEFAULT 0, issueNumber INTEGER,
@@ -1720,6 +1729,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       model: input.model ?? null,
       effort: input.effort ?? null,
       claudeSessionId: input.claudeSessionId ?? "",
+      providerSessionId: strOrEmpty(input.providerSessionId),
       agentProvider: input.agentProvider ?? "claude",
       id: input.id ?? randomUUID(),
       desig: `${DESIG_PREFIX}${String(seq).padStart(2, "0")}`,
@@ -1768,7 +1778,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       const seq = this.nextDesignationSeq();
       const s = this.buildSessionRow(input, seq, now);
       this.db.run(
-        `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+        `INSERT INTO sessions (${COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
         [
           s.id,
           s.desig,
@@ -1821,6 +1831,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
           null, // experimentRole — always null at create
           null, // spawnTerminalId — always null at create (stamped post-create by persistSpawnIdentity)
           null, // spawnAccountDir — always null at create
+          strOrEmpty(s.providerSessionId), // "" at create for both providers; Codex id captured post-spawn
         ],
       );
       return s;
@@ -1878,6 +1889,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
         | "branch"
         | "herdrAgentId"
         | "claudeSessionId"
+        | "providerSessionId"
         | "agentProvider"
         | "model"
         | "effort"
@@ -1894,7 +1906,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     if (!cur) return;
     const next = { ...cur, ...patch, updatedAt: Date.now() };
     this.db.run(
-      `UPDATE sessions SET name=?, status=?, lastState=?, branch=?, herdrAgentId=?, claudeSessionId=?, agentProvider=?, model=?, effort=?, readyToMerge=?, mergingSince=?, mergingTrainId=?, mergingPrNumber=?, planGateEnabled=?, planPhase=?, updatedAt=? WHERE id=?`,
+      `UPDATE sessions SET name=?, status=?, lastState=?, branch=?, herdrAgentId=?, claudeSessionId=?, providerSessionId=?, agentProvider=?, model=?, effort=?, readyToMerge=?, mergingSince=?, mergingTrainId=?, mergingPrNumber=?, planGateEnabled=?, planPhase=?, updatedAt=? WHERE id=?`,
       [
         next.name,
         next.status,
@@ -1902,6 +1914,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
         next.branch,
         next.herdrAgentId,
         next.claudeSessionId,
+        strOrEmpty(next.providerSessionId),
         next.agentProvider ?? "claude",
         next.model,
         next.effort,
@@ -2801,6 +2814,17 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     );
   }
 
+  /** Persist a provider-native session id (the Codex rollout UUID) discovered post-spawn. Dedicated
+   *  setter (the generic update() whitelist would work too, but this mirrors {@link setSpawnIdentity}'s
+   *  targeted-UPDATE style for a post-spawn-discovered marker). Callers only ever pass a non-empty id. */
+  setProviderSessionId(id: string, providerSessionId: string): void {
+    this.db.run(`UPDATE sessions SET providerSessionId = ?, updatedAt = ? WHERE id = ?`, [
+      providerSessionId,
+      Date.now(),
+      id,
+    ]);
+  }
+
   /** Persist the manual operator steps detected in a session's PR body (#1059). Stored as a JSON
    *  array; an empty array clears any prior detection. Dedicated setter (the generic update()
    *  whitelist would silently drop it), mirroring {@link setHaltReason}'s direct-UPDATE style. */
@@ -3017,6 +3041,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     add("model", `model TEXT`);
     add("effort", `effort TEXT`);
     add("claudeSessionId", `claudeSessionId TEXT NOT NULL DEFAULT ''`);
+    add("providerSessionId", `providerSessionId TEXT NOT NULL DEFAULT ''`);
     add("agentProvider", `agentProvider TEXT NOT NULL DEFAULT 'claude'`);
     add("readyToMerge", `readyToMerge INTEGER NOT NULL DEFAULT 0`);
     // nullable: NULL = inherit repo default, 0/1 = explicit per-session override
@@ -4340,6 +4365,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       isolated: !!r.isolated,
       readyToMerge: !!r.readyToMerge,
       claudeSessionId: r.claudeSessionId ?? "",
+      providerSessionId: strOrEmpty(r.providerSessionId),
       agentProvider: r.agentProvider === "codex" ? "codex" : "claude",
       autopilotEnabled: nullableBool(r.autopilotEnabled),
       autopilotStepCount: r.autopilotStepCount ?? 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,11 @@ export interface Session {
   herdrSession: string;
   herdrAgentId: string; // herdr terminal_id (attach target)
   claudeSessionId: string; // pinned via `claude --session-id`; "" for pre-feature sessions
+  /** Provider-native session id for non-Claude providers — the Codex rollout UUID resumed via
+   *  `codex resume <id>`. Best-effort cached (poller-seeded, refreshed on restore); "" / absent when
+   *  unknown / not a Codex session. Optional like `agentProvider` so pre-existing rows + fixtures
+   *  need no change. Provider-neutral field owned by #1175; #1087/#1160 consume it. */
+  providerSessionId?: string;
   agentProvider?: AgentProvider;
 
   model: string | null; // selected CLI --model alias; null = provider default (no flag)

--- a/test/codex-session-id.test.ts
+++ b/test/codex-session-id.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { findCodexSessionId } from "../src/codex-session-id";
+
+let home: string;
+let sessionsDir: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "codex-home-"));
+  sessionsDir = join(home, "sessions");
+  mkdirSync(sessionsDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+/** Write a rollout jsonl whose line 1 is a session_meta header, with an explicit mtime (seconds). */
+function writeRollout(
+  name: string,
+  header: { session_id?: string; id?: string; cwd?: string; source?: string } | string,
+  mtimeSec: number,
+  extraLines: string[] = [],
+): void {
+  const line1 =
+    typeof header === "string" ? header : JSON.stringify({ type: "session_meta", payload: header });
+  const path = join(sessionsDir, name);
+  writeFileSync(path, [line1, ...extraLines].join("\n") + "\n");
+  utimesSync(path, mtimeSec, mtimeSec);
+}
+
+const CWD = "/home/u/.shepherd-worktrees/repo-feature";
+
+test("returns the session id of an interactive (source=cli) rollout matching the cwd", () => {
+  writeRollout("rollout-1.jsonl", { session_id: "uuid-A", cwd: CWD, source: "cli" }, 1000);
+  expect(findCodexSessionId(CWD, 0, home)).toBe("uuid-A");
+});
+
+test("falls back to payload.id when session_id is absent (legacy header)", () => {
+  writeRollout("rollout-legacy.jsonl", { id: "uuid-legacy", cwd: CWD, source: "cli" }, 1000);
+  expect(findCodexSessionId(CWD, 0, home)).toBe("uuid-legacy");
+});
+
+test("newest matching rollout wins", () => {
+  writeRollout("rollout-old.jsonl", { session_id: "uuid-old", cwd: CWD, source: "cli" }, 1000);
+  writeRollout("rollout-new.jsonl", { session_id: "uuid-new", cwd: CWD, source: "cli" }, 2000);
+  expect(findCodexSessionId(CWD, 0, home)).toBe("uuid-new");
+});
+
+test("ignores source=exec (headless role) rollouts sharing the cwd", () => {
+  // exec rollout is NEWER but must be skipped; the older cli rollout is the interactive session.
+  writeRollout("rollout-exec.jsonl", { session_id: "uuid-exec", cwd: CWD, source: "exec" }, 3000);
+  writeRollout("rollout-cli.jsonl", { session_id: "uuid-cli", cwd: CWD, source: "cli" }, 2000);
+  expect(findCodexSessionId(CWD, 0, home)).toBe("uuid-cli");
+});
+
+test("skips rollouts older than notBeforeMs", () => {
+  // mtime is in seconds; findCodexSessionId compares mtimeMs against notBeforeMs (ms).
+  writeRollout("rollout-stale.jsonl", { session_id: "uuid-stale", cwd: CWD, source: "cli" }, 1000);
+  // notBeforeMs = 2000_000 ms → file mtime 1000s = 1_000_000 ms is older → excluded.
+  expect(findCodexSessionId(CWD, 2_000_000, home)).toBeNull();
+});
+
+test("matches on cwd, not other sessions in different worktrees", () => {
+  writeRollout(
+    "rollout-other.jsonl",
+    { session_id: "uuid-other", cwd: "/somewhere/else", source: "cli" },
+    3000,
+  );
+  writeRollout("rollout-mine.jsonl", { session_id: "uuid-mine", cwd: CWD, source: "cli" }, 2000);
+  expect(findCodexSessionId(CWD, 0, home)).toBe("uuid-mine");
+});
+
+test("target beyond the 24 globally-newest rollouts is still found (scan is unbounded)", () => {
+  // 30 newer, non-matching cli rollouts would push the target past any 24-item cap.
+  for (let i = 0; i < 30; i++) {
+    writeRollout(
+      `rollout-noise-${i}.jsonl`,
+      { session_id: `n${i}`, cwd: "/other/cwd", source: "cli" },
+      5000 + i,
+    );
+  }
+  writeRollout(
+    "rollout-target.jsonl",
+    { session_id: "uuid-target", cwd: CWD, source: "cli" },
+    4000,
+  );
+  expect(findCodexSessionId(CWD, 0, home)).toBe("uuid-target");
+});
+
+test("no matching rollout → null", () => {
+  writeRollout(
+    "rollout-other.jsonl",
+    { session_id: "uuid-other", cwd: "/nope", source: "cli" },
+    1000,
+  );
+  expect(findCodexSessionId(CWD, 0, home)).toBeNull();
+});
+
+test("tolerates a malformed / non-session_meta header (skips it)", () => {
+  writeRollout("rollout-garbage.jsonl", "}{ not json", 3000);
+  writeRollout("rollout-wrongtype.jsonl", JSON.stringify({ type: "event_msg", payload: {} }), 2500);
+  writeRollout("rollout-ok.jsonl", { session_id: "uuid-ok", cwd: CWD, source: "cli" }, 2000);
+  expect(findCodexSessionId(CWD, 0, home)).toBe("uuid-ok");
+});
+
+test("reads a large header (system prompt of hundreds of KB)", () => {
+  // base_instructions.text in a real header is tens of KB; ensure the first-line reader handles it.
+  const big = "x".repeat(200_000);
+  writeRollout(
+    "rollout-big.jsonl",
+    JSON.stringify({
+      type: "session_meta",
+      payload: { session_id: "uuid-big", cwd: CWD, source: "cli", base_instructions: big },
+    }),
+    2000,
+  );
+  expect(findCodexSessionId(CWD, 0, home)).toBe("uuid-big");
+});
+
+test("missing CODEX_HOME sessions dir → null (graceful)", () => {
+  const empty = mkdtempSync(join(tmpdir(), "codex-empty-"));
+  try {
+    expect(findCodexSessionId(CWD, 0, empty)).toBeNull();
+  } finally {
+    rmSync(empty, { recursive: true, force: true });
+  }
+});

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -2846,6 +2846,37 @@ test("resume returns null for unknown, archived, or pre-feature sessions", async
 
 // ── restore ──────────────────────────────────────────────────────────────────
 
+/** Build a temp $CODEX_HOME containing the given rollout headers (line-1 session_meta records). */
+function mkCodexHome(rollouts: Array<{ name: string; payload: Record<string, unknown> }>): string {
+  const home = mkdtempSync(join(tmpdir(), "codex-home-"));
+  const sessions = join(home, "sessions");
+  mkdirSync(sessions, { recursive: true });
+  for (const r of rollouts) {
+    writeFileSync(
+      join(sessions, r.name),
+      JSON.stringify({ type: "session_meta", payload: r.payload }) + "\n",
+    );
+  }
+  return home;
+}
+
+/** Run `fn` with $CODEX_HOME pointed at a temp dir seeded with `rollouts`, restoring env after. */
+async function withCodexHome(
+  rollouts: Array<{ name: string; payload: Record<string, unknown> }>,
+  fn: () => Promise<void> | void,
+): Promise<void> {
+  const home = mkCodexHome(rollouts);
+  const prev = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = home;
+  try {
+    await fn();
+  } finally {
+    if (prev === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prev;
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
 function archivedWithSession(
   store: SessionStore,
   over: Partial<Parameters<SessionStore["create"]>[0]> = {},
@@ -2952,10 +2983,62 @@ test("restore: not_archived error for non-archived row", async () => {
   expect((err as RestoreError).code).toBe("not_archived");
 });
 
-test("restore: cannot_restore for codex session", async () => {
+test("restore: isolated codex resumes by fresh-derived id and persists providerSessionId", async () => {
+  // The rollout's recorded cwd matches the archived session's worktreePath ("/wt/x"). The worktree
+  // itself is ABSENT on disk (makeRestoreSvc's restoreExisting is a stub) — mirroring the real
+  // pre-restoreExisting ordering: the id is derived from $CODEX_HOME, not the worktree.
+  await withCodexHome(
+    [
+      {
+        name: "rollout-x.jsonl",
+        payload: { session_id: "codex-uuid-1", cwd: "/wt/x", source: "cli" },
+      },
+    ],
+    async () => {
+      const store = new SessionStore(":memory:");
+      const calls: any = {};
+      const svc = makeRestoreSvc(store, calls);
+      const s = archivedWithSession(store, { agentProvider: "codex", claudeSessionId: "" });
+
+      const out = await svc.restore(s.id);
+      expect(out?.status).toBe("running");
+      // codex resume <id> — the positional id, not --last
+      expect(calls.start).toContain("resume");
+      expect(calls.start).toContain("codex-uuid-1");
+      expect(calls.start).not.toContain("--last");
+      // write-through persisted the freshly-derived id
+      expect(store.get(s.id)?.providerSessionId).toBe("codex-uuid-1");
+    },
+  );
+});
+
+test("restore: isolated codex with no matching rollout → cannot_restore", async () => {
+  await withCodexHome([], async () => {
+    const store = new SessionStore(":memory:");
+    const calls: any = {};
+    const svc = makeRestoreSvc(store, calls);
+    const s = archivedWithSession(store, { agentProvider: "codex", claudeSessionId: "" });
+    let err: unknown;
+    try {
+      await svc.restore(s.id);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RestoreError);
+    expect((err as RestoreError).code).toBe("cannot_restore");
+    // thrown before restoreExisting — no worktree side effect
+    expect(calls.restoreExisting).toBeUndefined();
+  });
+});
+
+test("restore: non-isolated codex → cannot_restore (shared cwd is ambiguous)", async () => {
   const store = new SessionStore(":memory:");
   const svc = makeRestoreSvc(store, {});
-  const s = archivedWithSession(store, { agentProvider: "codex", claudeSessionId: "" });
+  const s = archivedWithSession(store, {
+    agentProvider: "codex",
+    claudeSessionId: "",
+    isolated: false,
+  });
   let err: unknown;
   try {
     await svc.restore(s.id);
@@ -2964,6 +3047,154 @@ test("restore: cannot_restore for codex session", async () => {
   }
   expect(err).toBeInstanceOf(RestoreError);
   expect((err as RestoreError).code).toBe("cannot_restore");
+});
+
+test("captureCodexSessionId: seeds a running isolated codex session from its rollout", async () => {
+  await withCodexHome(
+    [
+      {
+        name: "rollout-cap.jsonl",
+        payload: { session_id: "cap-uuid", cwd: "/wt/cap", source: "cli" },
+      },
+    ],
+    () => {
+      const store = new SessionStore(":memory:");
+      const svc = makeRestoreSvc(store, {});
+      const s = store.create({
+        name: "x",
+        prompt: "x",
+        repoPath: "/r",
+        baseBranch: "main",
+        branch: "shepherd/cap",
+        worktreePath: "/wt/cap",
+        isolated: true,
+        herdrSession: "default",
+        herdrAgentId: "term_cap",
+        agentProvider: "codex",
+      });
+      svc.captureCodexSessionId(s);
+      expect(store.get(s.id)?.providerSessionId).toBe("cap-uuid");
+    },
+  );
+});
+
+test("captureCodexSessionId: no matching rollout leaves providerSessionId empty (no '' clobber)", async () => {
+  await withCodexHome([], () => {
+    const store = new SessionStore(":memory:");
+    const svc = makeRestoreSvc(store, {});
+    const s = store.create({
+      name: "x",
+      prompt: "x",
+      repoPath: "/r",
+      baseBranch: "main",
+      branch: "shepherd/cap",
+      worktreePath: "/wt/none",
+      isolated: true,
+      herdrSession: "default",
+      herdrAgentId: "term_cap",
+      agentProvider: "codex",
+    });
+    svc.captureCodexSessionId(s);
+    expect(store.get(s.id)?.providerSessionId).toBe("");
+  });
+});
+
+test("captureCodexSessionId: populate-once — does not overwrite an already-set id", async () => {
+  await withCodexHome(
+    [
+      {
+        name: "rollout-new.jsonl",
+        payload: { session_id: "fresh-uuid", cwd: "/wt/cap", source: "cli" },
+      },
+    ],
+    () => {
+      const store = new SessionStore(":memory:");
+      const svc = makeRestoreSvc(store, {});
+      const s = store.create({
+        name: "x",
+        prompt: "x",
+        repoPath: "/r",
+        baseBranch: "main",
+        branch: "shepherd/cap",
+        worktreePath: "/wt/cap",
+        isolated: true,
+        herdrSession: "default",
+        herdrAgentId: "term_cap",
+        agentProvider: "codex",
+        providerSessionId: "already-set",
+      });
+      svc.captureCodexSessionId(s);
+      expect(store.get(s.id)?.providerSessionId).toBe("already-set");
+    },
+  );
+});
+
+test("captureCodexSessionId: no-op for non-isolated or non-codex sessions", async () => {
+  await withCodexHome(
+    [
+      {
+        name: "rollout-cap.jsonl",
+        payload: { session_id: "cap-uuid", cwd: "/wt/cap", source: "cli" },
+      },
+    ],
+    () => {
+      const store = new SessionStore(":memory:");
+      const svc = makeRestoreSvc(store, {});
+      const nonIsolated = store.create({
+        name: "x",
+        prompt: "x",
+        repoPath: "/r",
+        baseBranch: "main",
+        branch: null,
+        worktreePath: "/wt/cap",
+        isolated: false,
+        herdrSession: "default",
+        herdrAgentId: "t1",
+        agentProvider: "codex",
+      });
+      const claude = store.create({
+        name: "y",
+        prompt: "y",
+        repoPath: "/r",
+        baseBranch: "main",
+        branch: "shepherd/y",
+        worktreePath: "/wt/cap",
+        isolated: true,
+        herdrSession: "default",
+        herdrAgentId: "t2",
+        agentProvider: "claude",
+      });
+      svc.captureCodexSessionId(nonIsolated);
+      svc.captureCodexSessionId(claude);
+      expect(store.get(nonIsolated.id)?.providerSessionId).toBe("");
+      expect(store.get(claude.id)?.providerSessionId).toBe("");
+    },
+  );
+});
+
+test("resume (live path) uses codex resume --last, ignoring any stored providerSessionId", async () => {
+  const store = new SessionStore(":memory:");
+  const calls: any = {};
+  const svc = makeRestoreSvc(store, calls);
+  // A running (non-archived) codex session with a stale cached id and no live agent → resume
+  // respawns via --last (the live path never trusts providerSessionId).
+  const s = store.create({
+    name: "x",
+    prompt: "x",
+    repoPath: "/r",
+    baseBranch: "main",
+    branch: "shepherd/x",
+    worktreePath: "/wt/x",
+    isolated: true,
+    herdrSession: "default",
+    herdrAgentId: "term_old",
+    agentProvider: "codex",
+    providerSessionId: "should-be-ignored",
+  });
+  const out = await svc.resume(s.id);
+  expect(out).not.toBeNull();
+  expect(calls.start).toContain("--last");
+  expect(calls.start).not.toContain("should-be-ignored");
 });
 
 test("restore: cannot_restore for claude with empty claudeSessionId", async () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -3031,22 +3031,36 @@ test("restore: isolated codex with no matching rollout → cannot_restore", asyn
   });
 });
 
-test("restore: non-isolated codex → cannot_restore (shared cwd is ambiguous)", async () => {
-  const store = new SessionStore(":memory:");
-  const svc = makeRestoreSvc(store, {});
-  const s = archivedWithSession(store, {
-    agentProvider: "codex",
-    claudeSessionId: "",
-    isolated: false,
-  });
-  let err: unknown;
-  try {
-    await svc.restore(s.id);
-  } catch (e) {
-    err = e;
-  }
-  expect(err).toBeInstanceOf(RestoreError);
-  expect((err as RestoreError).code).toBe("cannot_restore");
+test("restore: non-isolated codex → cannot_restore EVEN with a matching rollout present", async () => {
+  // Locks the DELIBERATE isolated-only guard (#1175 / #1476): a non-isolated session shares its cwd
+  // with siblings/relaunches/operator runs, so a discoverable rollout can't be attributed to THIS
+  // row — restore refuses even when findCodexSessionId WOULD return an id for the cwd. Proves the
+  // block is the intentional guard, not an incidental "no rollout found".
+  await withCodexHome(
+    [
+      {
+        name: "rollout-shared.jsonl",
+        payload: { session_id: "codex-uuid-shared", cwd: "/wt/x", source: "cli" },
+      },
+    ],
+    async () => {
+      const store = new SessionStore(":memory:");
+      const svc = makeRestoreSvc(store, {});
+      const s = archivedWithSession(store, {
+        agentProvider: "codex",
+        claudeSessionId: "",
+        isolated: false,
+      });
+      let err: unknown;
+      try {
+        await svc.restore(s.id);
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(RestoreError);
+      expect((err as RestoreError).code).toBe("cannot_restore");
+    },
+  );
 });
 
 test("captureCodexSessionId: seeds a running isolated codex session from its rollout", async () => {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -42,6 +42,62 @@ test("session agentProvider defaults to claude and round-trips codex", () => {
   expect(s.get(codex.id)?.agentProvider).toBe("codex");
 });
 
+test("session providerSessionId: defaults '', accepts create input, set via setProviderSessionId", () => {
+  const s = mk();
+  const a = s.create(base);
+  expect(a.providerSessionId).toBe("");
+  expect(s.get(a.id)?.providerSessionId).toBe("");
+
+  const b = s.create({ ...base, herdrAgentId: "t2", providerSessionId: "rollout-uuid" });
+  expect(b.providerSessionId).toBe("rollout-uuid");
+  expect(s.get(b.id)?.providerSessionId).toBe("rollout-uuid");
+
+  s.setProviderSessionId(a.id, "captured-uuid");
+  expect(s.get(a.id)?.providerSessionId).toBe("captured-uuid");
+});
+
+test("session providerSessionId: update() preserves it when absent from patch, resets when passed", () => {
+  const s = mk();
+  const a = s.create({ ...base, providerSessionId: "keep-me" });
+  // a patch that doesn't mention providerSessionId leaves it intact
+  s.update(a.id, { status: "archived", lastState: "done" });
+  expect(s.get(a.id)?.providerSessionId).toBe("keep-me");
+  // an explicit reset (relaunch path) clears it
+  s.update(a.id, { providerSessionId: "" });
+  expect(s.get(a.id)?.providerSessionId).toBe("");
+});
+
+test("session migration: an old sessions row without providerSessionId gains the '' default", () => {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-store-sess-migrate-"));
+  const dbPath = join(dir, "test.db");
+  try {
+    // Pre-create the sessions table as it was BEFORE the providerSessionId column.
+    const raw = new Database(dbPath);
+    raw.run(`CREATE TABLE sessions (
+      id TEXT PRIMARY KEY, desig TEXT NOT NULL, name TEXT NOT NULL, prompt TEXT NOT NULL,
+      repoPath TEXT NOT NULL, baseBranch TEXT NOT NULL, branch TEXT,
+      worktreePath TEXT NOT NULL, isolated INTEGER NOT NULL,
+      herdrSession TEXT NOT NULL, herdrAgentId TEXT NOT NULL,
+      claudeSessionId TEXT NOT NULL DEFAULT '',
+      agentProvider TEXT NOT NULL DEFAULT 'claude',
+      model TEXT, effort TEXT, status TEXT NOT NULL, lastState TEXT NOT NULL,
+      auto INTEGER NOT NULL DEFAULT 0, issueNumber INTEGER,
+      createdAt INTEGER NOT NULL, updatedAt INTEGER NOT NULL, archivedAt INTEGER)`);
+    raw.run(
+      `INSERT INTO sessions (id, desig, name, prompt, repoPath, baseBranch, branch, worktreePath,
+        isolated, herdrSession, herdrAgentId, status, lastState, createdAt, updatedAt)
+       VALUES ('old', 'TASK-01', 'n', 'p', '/r', 'main', 'shepherd/n', '/wt', 1, 'default', 't',
+        'running', 'idle', 1, 1)`,
+    );
+    raw.close();
+    // opening through the store runs migrateSessionColumns, adding providerSessionId with its default
+    const store = new SessionStore(dbPath);
+    expect(store.get("old")?.providerSessionId).toBe("");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("update can replace a session's agent identity without changing the row", () => {
   const s = mk();
   const orig = s.create({ ...base, claudeSessionId: "claude-old", model: "opus" });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2628,5 +2628,7 @@
   "topbar_usage_provider_short_codex": "CX",
   "feat_usage_gauge_provider_rotation_title": "Auslastungsanzeigen wechseln nach CLI",
   "feat_usage_gauge_provider_rotation_body": "Wenn Auslastungsdaten für Claude Code und Codex konfiguriert sind, wechselt die kompakte Anzeige in der Topbar jetzt alle zwei Minuten zwischen CC und CX. Codex zeigt Limit-Balken, sobald sie verfügbar sind, oder Token-Summen, bis die CLI Reset-Fenster meldet.",
-  "plugins_repo": "REPO"
+  "plugins_repo": "REPO",
+  "feat_codex_bring_back_title": "Codex-Sessions zurückholen",
+  "feat_codex_bring_back_body": "Zurückholen funktioniert jetzt auch für Codex-Sessions, nicht nur für Claude. Wähle eine abgeschlossene Codex-Session in der Fertig-Ansicht und klicke auf Zurückholen — Shepherd erstellt ihren Worktree neu und setzt das exakte Codex-Gespräch anhand seiner Session-ID fort. Nur isolierte Codex-Sessions können zurückgeholt werden; andere müssen weiterhin neu gestartet werden."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2628,5 +2628,7 @@
   "topbar_usage_provider_short_codex": "CX",
   "feat_usage_gauge_provider_rotation_title": "Usage gauges rotate by CLI",
   "feat_usage_gauge_provider_rotation_body": "When Claude Code and Codex usage data are both configured, the compact top-bar gauge now alternates every two minutes between CC and CX. Codex shows rate-limit bars when available, or token totals until the CLI reports reset windows.",
-  "plugins_repo": "REPO"
+  "plugins_repo": "REPO",
+  "feat_codex_bring_back_title": "Bring back Codex sessions",
+  "feat_codex_bring_back_body": "Bring back now works for Codex sessions too, not just Claude. Select a done Codex session in the Done lens and click Bring back — Shepherd re-creates its worktree and resumes the exact Codex conversation by its session id. Only isolated Codex sessions can be brought back; others still need a relaunch."
 }

--- a/ui/src/lib/feature-announcements/entries/v1.42.0-codex-bring-back.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.42.0-codex-bring-back.ts
@@ -1,0 +1,14 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // Bring back (restore) now works for isolated Codex sessions, not just Claude: restore re-creates
+  // the worktree and resumes the exact Codex conversation via `codex resume <session-id>` (the id is
+  // derived fresh from the rollout at restore time). 1.41.0 is the latest released tag, so this ships
+  // in 1.42.0. No targetId — the button only renders when a done session is selected in the Done lens.
+  id: "codex-bring-back",
+  sinceVersion: "1.42.0",
+  titleKey: "feat_codex_bring_back_title",
+  bodyKey: "feat_codex_bring_back_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
Closes #1175. Follow-up to the Claude-only restore MVP (#1174).

## What

Enables **Bring back** (restore) for **isolated Codex** done-sessions. Restore now resumes the exact prior conversation via `codex resume <SESSION_ID>` instead of the ambiguous `codex resume --last`.

## How

Codex self-generates its session UUID (there is **no `--session-id` flag** to pin it at spawn — confirmed against `codex-cli 0.142.5`; see `docs/spikes/1175-codex-restore.md`), so the id is **discovered** from the rollout header (`session_meta.session_id`, matched by `cwd` + `source == "cli"`, ground truth over the lag-prone state DB).

- **`restore()` derives the id fresh** at restore time (source of truth) — always the actual last conversation for the worktree, robust to Codex-resume append-vs-fork, and honest `cannot_restore` when the rollout was GC'd. Derived **before** re-creating the worktree (raw-string cwd match against the already-canonical `worktreePath`; no `realpath` on the absent candidate), so a miss throws with no rollback.
- **Provider-neutral `providerSessionId` column** (per the de-overlap ask in #1175 — this issue owns the field; #1087/#1160 consume it). `claudeSessionId` stays for Claude. Best-effort **poller seed** populates it while a session runs; restore write-through refreshes it. Never written empty.
- **Live resume (autopilot/automerge/manual) stays on `--last`** — cwd-scoped + interactive-only, so a pane-death mid-restored-session re-attaches the current conversation; the stored id is deliberately not trusted there.

## Scope boundary

**Isolated Codex only.** A non-isolated session shares its repo cwd with siblings, so its id can't be uniquely identified — those stay `cannot_restore` by design (the existing "relaunch instead" hint). Isolated is the case that matters in practice (autopilot/drain already require it for Codex). Non-isolated restore is a documented gap.

## Out of scope

Fresh-agent restore variant; `providerMetadata`/`provider` columns (deferred to #1087/#1160); relaxing the autopilot Codex isolated-only guard.

## Testing

- New `test/codex-session-id.test.ts`: cli-only filter, newest-wins, `source=exec` ignored, mtime window, target-beyond-24 (unbounded scan), malformed-header tolerance, large-header read.
- `test/service.test.ts`: isolated-codex restore by fresh id + write-through (worktree absent); no-rollout / non-isolated → `cannot_restore`; `captureCodexSessionId` populate / null-no-clobber / populate-once / non-isolated no-op; live `resume()` uses `--last` (ignores stored id).
- `test/store.test.ts`: `providerSessionId` create/get/update/setter round-trip + migration.
- Full root suite (6116 pass), root lint/typecheck, UI `check` + `check:i18n` + feature tests, and PR-hygiene + fallow gates all green.

## Verification note

The load-bearing facts (no pin-at-spawn; `source=cli` main-agent vs `source=exec` role spawns; transcript survives worktree removal) are verified from the installed CLI + on-disk rollouts in the spike doc. Three runtime round-trips (resume re-attach, multi-restore, pane-death) need an authenticated interactive Codex session and are listed as operator checks in `docs/spikes/1175-codex-restore.md`; the design does not hinge on their outcome.
