### PR TITLE
feat(plugins): add repo link to settings

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -26,6 +26,7 @@ import {
   type SpawnHook,
   type SpawnPatch,
 } from "./types";
+import { browserRepositoryUrl } from "./repository";
 import { validatePluginGearItem, validatePluginUIView } from "./ui-validate";
 
 const DEFAULT_HOOK_TIMEOUT_MS = 5_000;
@@ -488,6 +489,7 @@ export class PluginRegistry {
       id: r.manifest.id,
       name: r.manifest.name,
       version: r.manifest.version,
+      repository: browserRepositoryUrl(r.manifest.repository),
       health: r.health,
       lastError: r.lastError,
       status: r.status,

--- a/src/plugins/manage.ts
+++ b/src/plugins/manage.ts
@@ -16,6 +16,7 @@ import { promisify } from "node:util";
 import { execFile } from "node:child_process";
 import { PLUGIN_API_VERSION, type InstalledPlugin, type PluginManifest } from "./types";
 import { validManifest } from "./loader";
+import { browserRepositoryUrl } from "./repository";
 import { classifyCloneError } from "../repos";
 
 const execFileAsync = promisify(execFile);
@@ -147,6 +148,7 @@ export async function scanInstalled(
       id: manifest.id,
       name: manifest.name,
       version: manifest.version,
+      repository: browserRepositoryUrl(manifest.repository),
       folder,
       loaded: loadedIds.has(manifest.id),
       disabled: manifest.enabled === false,

--- a/src/plugins/repository.ts
+++ b/src/plugins/repository.ts
@@ -1,0 +1,12 @@
+/** Browser-clickable repository URL from optional plugin manifest metadata. */
+export function browserRepositoryUrl(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const raw = value.trim();
+  if (raw === "") return undefined;
+  try {
+    const url = new URL(raw);
+    return url.protocol === "http:" || url.protocol === "https:" ? url.href : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -245,6 +245,8 @@ export interface InstalledPlugin {
   disabled: boolean;
   /** True when the folder has no valid `plugin.json` (missing/unparseable/invalid). */
   broken: boolean;
+  /** Browser-clickable manifest repository URL, when declared and valid. */
+  repository?: string;
 }
 
 /** Panel/list view of a loaded plugin — core-derived health is authoritative. */
@@ -252,6 +254,8 @@ export interface PluginInfo {
   id: string;
   name: string;
   version: string;
+  /** Browser-clickable manifest repository URL, when declared and valid. */
+  repository?: string;
   health: PluginHealth;
   /** Last error message (load or hook), or null. */
   lastError: string | null;

--- a/test/plugins-manage.test.ts
+++ b/test/plugins-manage.test.ts
@@ -108,6 +108,25 @@ test("scanInstalled on a missing dir returns an empty list", async () => {
   expect(await scanInstalled(join(tmp(), "nope"), new Set())).toEqual([]);
 });
 
+test("scanInstalled carries only browser-safe repository urls", async () => {
+  const dir = tmp();
+  writePlugin(join(dir, "valid"), {
+    ...validManifest("valid"),
+    repository: "https://github.com/owner/plugin",
+  });
+  writePlugin(join(dir, "ssh"), { ...validManifest("ssh"), repository: "git@github.com:o/p.git" });
+  writePlugin(join(dir, "relative"), { ...validManifest("relative"), repository: "not a url" });
+  writePlugin(join(dir, "number"), { ...validManifest("number"), repository: 42 });
+
+  const rows = await scanInstalled(dir, new Set());
+  const byFolder = Object.fromEntries(rows.map((r) => [r.folder, r]));
+
+  expect(byFolder.valid?.repository).toBe("https://github.com/owner/plugin");
+  expect(byFolder.ssh?.repository).toBeUndefined();
+  expect(byFolder.relative?.repository).toBeUndefined();
+  expect(byFolder.number?.repository).toBeUndefined();
+});
+
 // ── installPlugin ─────────────────────────────────────────────────────────────
 
 test("installPlugin clones a valid plugin and returns its manifest info", async () => {

--- a/test/plugins.test.ts
+++ b/test/plugins.test.ts
@@ -136,6 +136,39 @@ test("loadAll: enabled:false is skipped", async () => {
   rmSync(root, { recursive: true, force: true });
 });
 
+test("list: carries only browser-safe repository urls", async () => {
+  const root = tmpDir();
+  writePlugin(root, "repo-ok", {
+    manifest: {
+      id: "repo-ok",
+      name: "Repo OK",
+      version: "1.0.0",
+      apiVersion: 1,
+      repository: "https://github.com/owner/repo-ok",
+    },
+    index: "export function register(){}",
+  });
+  writePlugin(root, "repo-bad", {
+    manifest: {
+      id: "repo-bad",
+      name: "Repo Bad",
+      version: "1.0.0",
+      apiVersion: 1,
+      repository: "git@github.com:owner/repo-bad.git",
+    },
+    index: "export function register(){}",
+  });
+
+  const { registry } = makeRegistry(root);
+  await registry.loadAll();
+
+  expect(registry.list().find((p) => p.id === "repo-ok")!.repository).toBe(
+    "https://github.com/owner/repo-ok",
+  );
+  expect(registry.list().find((p) => p.id === "repo-bad")!.repository).toBeUndefined();
+  rmSync(root, { recursive: true, force: true });
+});
+
 // ── loader: symlinked plugin dirs (#1176) ────────────────────────────────────
 test("loadAll: a symlinked plugin dir loads identically to a copied one", async () => {
   // The plugin's real folder lives outside the plugins dir; only a symlink to it

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1300,6 +1300,8 @@
   "feat_plugin_install_body": "Einstellungen → Plugins installiert jetzt ein Plugin per GitHub-URL — Repo einfügen, bestätigen und dann aktivieren (kein Neustart nötig). Außerdem werden alle installierten Plugins aufgelistet und lassen sich deinstallieren.",
   "feat_plugin_activate_title": "Plugins ohne Neustart aktivieren",
   "feat_plugin_activate_body": "Ein frisch installiertes Plugin hat jetzt in Einstellungen → Plugins einen „Aktivieren“-Button — es wird in-process geladen, sodass seine Routen, Hooks und Gear/UI sofort live sind. Für den Normalfall kein Neustart nötig (ein Plugin mit eigenen Abhängigkeiten braucht weiterhin bun install + Neustart).",
+  "feat_plugin_repo_link_title": "Plugin-Repo-Links in den Einstellungen",
+  "feat_plugin_repo_link_body": "Installierte Plugins mit Repository-Metadaten zeigen jetzt in Einstellungen → Plugins neben Aktualisieren, Aktivieren und Deinstallieren einen REPO-Link, damit du den Quellcode ohne plugin-eigene UI prüfen kannst.",
   "feat_server_plugins_title": "Serverseitige Plugins",
   "feat_server_plugins_body": "Führe private Erweiterungen außerhalb des Repos auf deiner Instanz aus. Ein neuer Bereich Einstellungen → Plugins zeigt Zustand und veröffentlichten Status jedes geladenen Plugins.",
   "diagnostics_title": "System-Diagnose",
@@ -2624,5 +2626,6 @@
   "topbar_usage_provider_short_claude": "CC",
   "topbar_usage_provider_short_codex": "CX",
   "feat_usage_gauge_provider_rotation_title": "Auslastungsanzeigen wechseln nach CLI",
-  "feat_usage_gauge_provider_rotation_body": "Wenn Auslastungsdaten für Claude Code und Codex konfiguriert sind, wechselt die kompakte Anzeige in der Topbar jetzt alle zwei Minuten zwischen CC und CX. Codex zeigt Limit-Balken, sobald sie verfügbar sind, oder Token-Summen, bis die CLI Reset-Fenster meldet."
+  "feat_usage_gauge_provider_rotation_body": "Wenn Auslastungsdaten für Claude Code und Codex konfiguriert sind, wechselt die kompakte Anzeige in der Topbar jetzt alle zwei Minuten zwischen CC und CX. Codex zeigt Limit-Balken, sobald sie verfügbar sind, oder Token-Summen, bis die CLI Reset-Fenster meldet.",
+  "plugins_repo": "REPO"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1300,6 +1300,8 @@
   "feat_plugin_install_body": "Settings → Plugins now installs a plugin from a GitHub URL — paste the repo, confirm, then Activate it (no restart needed). It also lists every installed plugin and lets you uninstall.",
   "feat_plugin_activate_title": "Activate plugins without a restart",
   "feat_plugin_activate_body": "A freshly installed plugin now has an Activate button in Settings → Plugins — it loads in-process, so its routes, hooks and gear/UI go live immediately. No restart needed for the common case (a plugin shipping its own dependencies still needs bun install + a restart).",
+  "feat_plugin_repo_link_title": "Plugin repo links in Settings",
+  "feat_plugin_repo_link_body": "Installed plugins with repository metadata now show a REPO link in Settings → Plugins, beside Update, Activate and Uninstall, so you can inspect the source without plugin-authored UI.",
   "feat_server_plugins_title": "Server-side plugins",
   "feat_server_plugins_body": "Run private, out-of-repo extensions on your instance. A new Settings → Plugins panel shows each loaded plugin's health and published status.",
   "diagnostics_title": "System diagnostics",
@@ -2624,5 +2626,6 @@
   "topbar_usage_provider_short_claude": "CC",
   "topbar_usage_provider_short_codex": "CX",
   "feat_usage_gauge_provider_rotation_title": "Usage gauges rotate by CLI",
-  "feat_usage_gauge_provider_rotation_body": "When Claude Code and Codex usage data are both configured, the compact top-bar gauge now alternates every two minutes between CC and CX. Codex shows rate-limit bars when available, or token totals until the CLI reports reset windows."
+  "feat_usage_gauge_provider_rotation_body": "When Claude Code and Codex usage data are both configured, the compact top-bar gauge now alternates every two minutes between CC and CX. Codex shows rate-limit bars when available, or token totals until the CLI reports reset windows.",
+  "plugins_repo": "REPO"
 }

--- a/ui/src/lib/components/settings/PluginLoadedCard.svelte
+++ b/ui/src/lib/components/settings/PluginLoadedCard.svelte
@@ -79,6 +79,17 @@
         {update.applying ? m.pluginupdate_applying() : m.pluginupdate_apply()}
       </button>
     {/if}
+    {#if plugin.repository}
+      <a
+        class="plugin-repo-link"
+        href={plugin.repository}
+        target="_blank"
+        rel="external noreferrer noopener"
+      >
+        <span aria-hidden="true">↗</span>
+        <span>{m.plugins_repo()}</span>
+      </a>
+    {/if}
     {#if folder}
       {@const f = folder}
       <button

--- a/ui/src/lib/components/settings/SettingsPluginsPanel.browser.test.ts
+++ b/ui/src/lib/components/settings/SettingsPluginsPanel.browser.test.ts
@@ -340,6 +340,40 @@ describe("SettingsPluginsPanel", () => {
     expect(page.getByRole("button", { name: "Activate" }).elements()).toHaveLength(0);
   });
 
+  it("a loaded plugin with repository metadata shows a REPO external link", async () => {
+    const repository = "https://github.com/erwins-enkel/shepherd-plugin-voice-whisper";
+    stubScan([inst({ loaded: true })]);
+    render(SettingsPluginsPanel, {
+      plugins: [plugin({ repository })],
+    });
+
+    const link = page.getByRole("link", { name: /REPO/ });
+    await expect.element(link).toBeVisible();
+    await expect.element(link).toHaveAttribute("href", repository);
+    await expect.element(link).toHaveAttribute("target", "_blank");
+    await expect.element(link).toHaveAttribute("rel", "external noreferrer noopener");
+  });
+
+  it("a pending plugin with repository metadata shows a REPO external link", async () => {
+    const repository = "https://github.com/erwins-enkel/shepherd-plugin-voice-whisper";
+    stubScan([inst({ id: "fresh", name: "Fresh Plugin", folder: "fresh", repository })]);
+    render(SettingsPluginsPanel, { plugins: [] });
+
+    const link = page.getByRole("link", { name: /REPO/ });
+    await expect.element(link).toBeVisible();
+    await expect.element(link).toHaveAttribute("href", repository);
+    await expect.element(link).toHaveAttribute("target", "_blank");
+    await expect.element(link).toHaveAttribute("rel", "external noreferrer noopener");
+  });
+
+  it("does not show a REPO placeholder without repository metadata", async () => {
+    stubScan([inst({ loaded: true })]);
+    render(SettingsPluginsPanel, { plugins: [plugin()] });
+
+    await expect.element(page.getByText("Test Plugin")).toBeVisible();
+    expect(page.getByRole("link", { name: /REPO/ }).elements()).toHaveLength(0);
+  });
+
   it("a failed activation surfaces a mapped message, not a raw code, and keeps the row pending", async () => {
     stubActivate([inst({ id: "fresh", name: "Fresh Plugin", folder: "fresh" })], () => ({
       payload: { error: "id_collision" },

--- a/ui/src/lib/components/settings/SettingsPluginsPanel.svelte
+++ b/ui/src/lib/components/settings/SettingsPluginsPanel.svelte
@@ -495,6 +495,17 @@
             {busyFolder === row.inst.folder ? m.plugins_activating() : m.plugins_activate()}
           </button>
         {/if}
+        {#if row.inst.repository}
+          <a
+            class="plugin-repo-link"
+            href={row.inst.repository}
+            target="_blank"
+            rel="external noreferrer noopener"
+          >
+            <span aria-hidden="true">↗</span>
+            <span>{m.plugins_repo()}</span>
+          </a>
+        {/if}
         <button
           type="button"
           class="gbtn del"
@@ -620,6 +631,24 @@
   .gbtn:disabled {
     opacity: 0.4;
     cursor: not-allowed;
+  }
+  :global(.plugin-repo-link) {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex: none;
+    color: var(--color-muted);
+    font-size: var(--fs-micro);
+    letter-spacing: 0.06em;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+  :global(.plugin-repo-link:hover) {
+    color: var(--color-amber);
+  }
+  :global(.plugin-repo-link:focus-visible) {
+    outline: none;
+    box-shadow: inset 0 -1px 0 var(--color-amber);
   }
   .gbtn.primary {
     border-color: var(--color-amber);

--- a/ui/src/lib/feature-announcements/entries/v1.42.0-plugin-repo-link.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.42.0-plugin-repo-link.ts
@@ -1,0 +1,13 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // Settings -> Plugins now surfaces a manifest-declared repository URL as a host-owned
+  // external link beside the installed-plugin actions. This is distinct from plugin docs
+  // or plugin-authored status/UI.
+  id: "plugin-repo-link",
+  sinceVersion: "1.42.0",
+  titleKey: "feat_plugin_repo_link_title",
+  bodyKey: "feat_plugin_repo_link_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1398,6 +1398,8 @@ export interface PluginInfo {
   id: string;
   name: string;
   version: string;
+  /** Browser-clickable manifest repository URL, when declared and valid. */
+  repository?: string;
   health: "ok" | "errored" | "timed-out";
   lastError: string | null;
   status: unknown;
@@ -1414,6 +1416,8 @@ export interface InstalledPlugin {
   id: string;
   name: string;
   version: string;
+  /** Browser-clickable manifest repository URL, when declared and valid. */
+  repository?: string;
   /** Directory name under the plugins dir — the uninstall key. */
   folder: string;
   loaded: boolean;


### PR DESCRIPTION
## Summary

- Surface sanitized plugin manifest `repository` URLs through loaded and installed plugin metadata.
- Render a host-owned `↗ REPO` external link in Settings -> Plugins for loaded and pending/disabled plugin rows when a browser-safe repository URL exists.
- Add the What's-New feature catalog entry plus EN/DE announcement copy.
- Cover valid, invalid, missing, and loaded-plugin repository metadata in server and browser tests.

## Validation

- `bun run lint`
- `bun test test/plugins-manage.test.ts test/plugins.test.ts`
- `cd ui && bun run test:browser src/lib/components/settings/SettingsPluginsPanel.browser.test.ts`
- `cd ui && bun run check && bun run check:i18n`
- `scripts/check-feature-catalog.sh`
- `node scripts/check-announcement-versions.mjs`

`cd ui && bun test` was previously attempted, but the package-wide suite hit unrelated existing failures in other specs (`$state` unavailable, mocked `importOriginal` undefined) and then stopped making progress; the focused browser spec for this change passed.
