### PR TITLE
fix: settings gear attention dot

### DIFF
--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -1121,6 +1121,74 @@ describe("TopBar — working-while-blocked counts in the working tally, not bloc
   });
 });
 
+describe("TopBar — gear attention dot is settings-owned", () => {
+  it("desktop: running or blocked sessions do not put a pip on the gear", async () => {
+    await page.viewport(1280, 900);
+    document.body.style.width = "1280px";
+    const list = [
+      { id: "r1", status: "running" },
+      { id: "b1", status: "blocked" },
+    ] as unknown as Session[];
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.desktop,
+      sessions: list,
+    });
+
+    expect(document.querySelector(".halt-pip")).toBeNull();
+    await page.getByRole("button", { name: m.topbar_menu_aria() }).click();
+    await expect
+      .element(page.getByRole("menuitem", { name: m.halt_all_aria({ count: 1 }) }))
+      .toBeInTheDocument();
+  });
+
+  it("mobile: running, blocked, update and what's-new signals do not put a pip on the gear", async () => {
+    await page.viewport(390, 800);
+    document.body.style.width = "390px";
+    const list = [
+      { id: "r1", status: "running" },
+      { id: "b1", status: "blocked" },
+    ] as unknown as Session[];
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.mobile,
+      sessions: list,
+      update: { behind: 2 } as UpdateStatus,
+      herdrUpdate: { updateAvailable: true } as HerdrUpdateStatus,
+      whatsNew: true,
+      diagnosticsOverall: "ok",
+    });
+
+    expect(document.querySelector(".gear-pip")).toBeNull();
+  });
+
+  it("mobile: diagnostics warning/error put the settings-attention pip on the gear", async () => {
+    await page.viewport(390, 800);
+    document.body.style.width = "390px";
+    const { rerender } = render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.mobile,
+      sessions: [],
+      diagnosticsOverall: "error",
+    });
+
+    expect(document.querySelector(".gear-pip")?.getAttribute("data-tier")).toBe("red");
+
+    await rerender({
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.mobile,
+      sessions: [],
+      diagnosticsOverall: "warning",
+    });
+
+    expect(document.querySelector(".gear-pip")?.getAttribute("data-tier")).toBe("yellow");
+  });
+});
+
 describe("TopBar — idle gear opens Settings directly", () => {
   it("desktop: an idle herd's gear opens Settings without a menu", async () => {
     await page.viewport(1280, 900);

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -542,22 +542,18 @@
   // once the bar has crowded down to icons.
   // Plugin items also force menu mode: their actions live in the menu, not the gear click.
   const gearOpensMenu = $derived(mobile || haltable > 0 || compactBadges || pluginItems.length > 0);
-  // Mobile only: every gear-area signal collapses into ONE dot, colored by the
-  // most serious active tier (red > orange > yellow > blue). Desktop keeps its
-  // halt-pip + dedicated badges, so this stays null off-mobile.
-  type GearPipTier = "red" | "orange" | "yellow" | "blue" | null;
+  // Mobile only: settings-owned diagnostics attention collapses into one dot on
+  // the gear, because the Diagnose row lives inside the gear sheet on phones.
+  // Herd/session state stays on the tallies and rows instead of duplicating here.
+  type GearPipTier = "red" | "yellow" | null;
   const gearPipTier = $derived<GearPipTier>(
     !mobile
       ? null
-      : blocked > 0 || diagnosticsOverall === "error"
+      : diagnosticsOverall === "error"
         ? "red"
-        : haltable > 0 || updateAvailable
-          ? "orange"
-          : diagnosticsOverall === "warning"
-            ? "yellow"
-            : herdrUpdateAvailable || codexUpdateAvailable || whatsNew || learningsPresent
-              ? "blue"
-              : null,
+        : diagnosticsOverall === "warning"
+          ? "yellow"
+          : null,
   );
   function clickGear() {
     if (!gearOpensMenu) {
@@ -767,19 +763,12 @@
     {/if}
     <!-- The gear adapts to state: idle herd → a click opens Settings directly;
          when something is haltable it becomes a menu button opening the e-stop above
-         the Settings entry. The pip differs by platform:
-         • Desktop keeps the dedicated halt-pip — the only at-rest cue that there's a
-           herd to halt: amber while agents simply work (matches the working colour),
-           escalating to red only when something is blocked. Other signals (update,
-           health, what's-new) live in their own labelled badges.
-         • Mobile folds those badges into the gear's bottom sheet, so the gear carries
-           a SINGLE collapsed dot (gearPipTier) coloured by the most serious active
-           signal — red > orange > yellow > blue. Red still means "needs you",
-           consistent with the rest of the bar. -->
+         the Settings entry. The gear's dot is settings-owned attention only:
+         diagnostics have a standalone desktop pip, and fold into the gear on mobile
+         because the Diagnose row lives in that sheet. -->
     <TopBarGear
       {mobile}
       {haltable}
-      {blocked}
       {gearPipTier}
       {gearOpensMenu}
       {armed}
@@ -898,14 +887,14 @@
   }
   /* learnings-btn, learn-glyph, learn-n, gear-wrap, gear-menu moved to top-bar/TopBarBadges.svelte / TopBarGear.svelte (#855) */
   /* quick, theme-seg, t-opt, contrast-toggle, gear-sheet-portal, menu-scrim, gear-sheet, sheet-* moved to top-bar/TopBarMobileSheet.svelte (#855) */
-  /* menu-item, menu-icon, menu-glyph, menu-label, halt-item, halt-pip, menu-sep moved to top-bar/TopBarGear.svelte (#855) */
+  /* menu-item, menu-icon, menu-glyph, menu-label, halt-item, menu-sep moved to top-bar/TopBarGear.svelte (#855) */
   .rightside {
     margin-left: auto;
     display: flex;
     align-items: center;
     gap: 16px;
   }
-  /* gear, gear-pip, halt-pip, health-pip, health-dot moved to top-bar/TopBarGear.svelte / TopBarBadges.svelte (#855) */
+  /* gear, gear-pip, health-pip, health-dot moved to top-bar/TopBarGear.svelte / TopBarBadges.svelte (#855) */
   /* whatsnew-badge, whatsnew-dot-btn, wn-pip, health-pip, health-dot, update-badge, learnings-btn moved to top-bar/TopBarBadges.svelte (#855) */
   /* usage-sub-only, gauges-wrap, gauges, gauge, g-label, gauge-wrap, gauge-btn, gauge-pop,
      gauge-pop-desk, gp-window, gp-head, credit-amount moved to top-bar/TopBarUsage.svelte (#855) */

--- a/ui/src/lib/components/top-bar/TopBarBadges.svelte
+++ b/ui/src/lib/components/top-bar/TopBarBadges.svelte
@@ -152,10 +152,10 @@
 {/if}
 <!-- Health pip: visible ONLY when diagnosticsOverall !== "ok" AND not mobile
      (on mobile it moves into the gear bottom sheet).
-     Own slot left of the gear-wrap so it never overlaps the halt-pip (gear top-right).
+     Own slot left of the gear-wrap so it never overlaps the settings gear.
      Color: slate ring with state-colored core —
-     warn for warning, red for error — distinct from both the halt-pip identity
-     and the herdr blue. Token choice: --status-warn / --color-red for the core,
+     warn for warning, red for error — distinct from the herdr blue.
+     Token choice: --status-warn / --color-red for the core,
      --color-line-bright for the ring. Never --color-green (hidden when ok anyway). -->
 {#if diagnosticsOverall !== "ok"}
   <button
@@ -280,7 +280,7 @@
   /* Health pip: a standalone button placed left of the gear-wrap in .rightside.
      Visible only when diagnosticsOverall !== "ok" (hidden-when-OK via {#if}).
      Ring: --color-line-bright (neutral slate) — a quiet outline that doesn't
-     read as the halt-pip or the herdr dot.
+     read as the herdr dot.
      Core: --status-warn (warning) or --color-red (error, .alert). */
   .health-pip {
     position: relative;

--- a/ui/src/lib/components/top-bar/TopBarGear.svelte
+++ b/ui/src/lib/components/top-bar/TopBarGear.svelte
@@ -4,12 +4,11 @@
   import type { FeedbackKind } from "$lib/feedback-link";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
 
-  type GearPipTier = "red" | "orange" | "yellow" | "blue" | null;
+  type GearPipTier = "red" | "yellow" | null;
 
   let {
     mobile,
     haltable,
-    blocked,
     gearPipTier,
     gearOpensMenu,
     armed,
@@ -28,7 +27,6 @@
   }: {
     mobile: boolean;
     haltable: number;
-    blocked: number;
     gearPipTier: GearPipTier;
     gearOpensMenu: boolean;
     armed: boolean;
@@ -58,14 +56,7 @@
     aria-haspopup={gearOpensMenu ? (mobile ? "dialog" : "menu") : undefined}
     aria-expanded={gearOpensMenu ? menuOpen : undefined}
     aria-label={gearOpensMenu ? m.topbar_menu_aria() : m.topbar_settings_aria()}
-    >⚙{#if !mobile && haltable > 0}<span
-        class="halt-pip"
-        class:alert={blocked > 0}
-        aria-hidden="true"
-      ></span>{/if}{#if mobile && gearPipTier}<span
-        class="gear-pip"
-        data-tier={gearPipTier}
-        aria-hidden="true"
+    >⚙{#if mobile && gearPipTier}<span class="gear-pip" data-tier={gearPipTier} aria-hidden="true"
       ></span>{/if}</button
   >
   {#if menuOpen && !mobile}
@@ -273,24 +264,8 @@
   .gear:hover {
     color: var(--color-amber);
   }
-  /* Pip on the gear: the only at-rest cue that there's a herd to halt. Amber while
-     agents merely work; red (.alert) only when something is blocked, so red stays
-     reserved for "needs you" rather than the normal running state. */
-  .halt-pip {
-    position: absolute;
-    top: 2px;
-    right: 2px;
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    background: var(--color-amber);
-    box-shadow: 0 0 0 2px var(--color-panel);
-  }
-  .halt-pip.alert {
-    background: var(--color-red);
-  }
-  /* Mobile only: single severity dot on the gear — red > orange > yellow > blue.
-     One dot replaces the old three-pip "measles" layout on mobile. */
+  /* Mobile only: single settings-attention dot for diagnostics surfaced inside
+     the gear sheet. Session state has its own stronger affordances elsewhere. */
   .gear-pip {
     position: absolute;
     top: 2px;
@@ -303,14 +278,8 @@
   .gear-pip[data-tier="red"] {
     background: var(--color-red);
   }
-  .gear-pip[data-tier="orange"] {
-    background: var(--color-warn);
-  }
   .gear-pip[data-tier="yellow"] {
     background: var(--color-amber);
-  }
-  .gear-pip[data-tier="blue"] {
-    background: var(--color-blue);
   }
   /* Mobile: finger-sized tap targets (≥44px) — the desktop sizes are tuned for a
      cursor and are too small to hit reliably on a phone. These rules (.gear.mobile)


### PR DESCRIPTION
## Summary

- Stop using the settings gear bubble for running or blocked session state.
- Keep the mobile gear dot only for settings-owned diagnostics attention: red for errors, yellow for warnings.
- Preserve the existing running-session gear menu behavior so the halt action remains reachable.

## Why

The gear bubble implied something inside Settings needed attention, but it was also reflecting herd/session state that already has stronger, clearer affordances elsewhere in the top bar and session list.

## Validation

- `cd ui && bun run check` (0 errors, 2 pre-existing warnings)
- `cd ui && bun run test:browser -- src/lib/components/TopBar.browser.test.ts` (72 passed)
