### PR TITLE
fix(ui): restore session rename affordances

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -675,6 +675,7 @@
   "redrawmenu_resume_hint": "Startet den Agenten mit dem Resume-Befehl des Providers neu und rendert die komplette Historie in aktueller Breite. Bricht einen laufenden Turn ab!",
   "cardmenu_label": "Sitzungs-Aktionen",
   "cardmenu_resume": "Sitzung fortsetzen",
+  "cardmenu_rename": "Umbenennen",
   "cardmenu_relaunch": "Neu starten",
   "cardmenu_relaunch_confirm": "Verwerfen & neu starten?",
   "cardmenu_relaunch_elsewhere": "In anderem Repo neu starten…",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -675,6 +675,7 @@
   "redrawmenu_resume_hint": "Respawns the agent with its provider's resume command and re-renders the full history at the current width. Aborts a running turn!",
   "cardmenu_label": "Session actions",
   "cardmenu_resume": "Resume session",
+  "cardmenu_rename": "Rename",
   "cardmenu_relaunch": "Relaunch",
   "cardmenu_relaunch_confirm": "Discard & relaunch?",
   "cardmenu_relaunch_elsewhere": "Relaunch in another repo…",

--- a/ui/src/lib/components/CardMenu.svelte
+++ b/ui/src/lib/components/CardMenu.svelte
@@ -12,6 +12,7 @@
     resumable,
     opener,
     onresume,
+    onrename,
     onrelaunch,
     onrelaunchElsewhere,
     onvariant,
@@ -27,6 +28,7 @@
     // the element that opened the menu (the card hit-target) — focus returns here on close
     opener?: HTMLElement;
     onresume?: () => void;
+    onrename?: () => void;
     // when provided, a two-step armed Relaunch item appears between Resume and
     // Decommission (the parent closes over the session id, like onresume/ondecommission)
     onrelaunch?: () => void;
@@ -145,6 +147,11 @@
   {#if resumable && onresume}
     <button class="cm-item" type="button" role="menuitem" tabindex="-1" onclick={onresume}>
       <span class="cm-icon" aria-hidden="true">↻</span>{m.cardmenu_resume()}
+    </button>
+  {/if}
+  {#if onrename}
+    <button class="cm-item" type="button" role="menuitem" tabindex="-1" onclick={onrename}>
+      <span class="cm-icon" aria-hidden="true">✎</span>{m.cardmenu_rename()}
     </button>
   {/if}
   {#if onrelaunch}

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -64,6 +64,7 @@
     filteredRepo = null,
     repoFilter = EMPTY_REPO_FILTER,
     onrepofilter = undefined,
+    onrename = undefined,
     filter = $bindable("all"),
     statusFilter = null,
     onstatusfilter = undefined,
@@ -120,6 +121,8 @@
     oncollapsetoggle?: (key: string) => void;
     // when provided, rows gain left-swipe-to-decommission (mobile list)
     ondecommission?: (id: string) => void;
+    // when provided, each row's CardMenu gains a Rename action
+    onrename?: (id: string) => void;
     // when provided, each row's CardMenu gains a two-step armed Relaunch action
     onrelaunch?: (id: string) => void;
     // when provided, each row's CardMenu gains a one-click "Relaunch elsewhere" item
@@ -365,6 +368,7 @@
     previewServe,
     onpreview,
     ondecommission,
+    onrename,
     onrelaunch,
     onrelaunchElsewhere,
     onvariant,

--- a/ui/src/lib/components/HerdGrid.svelte
+++ b/ui/src/lib/components/HerdGrid.svelte
@@ -16,6 +16,7 @@
     onsettings = undefined,
     filteredRepo = null,
     statusFilter = null,
+    onrename = undefined,
     onrelaunch = undefined,
     onrelaunchElsewhere = undefined,
     onvariant = undefined,
@@ -30,6 +31,8 @@
     git: Record<string, GitState>;
     // per-session live activity (heartbeat) — threaded into the tiles' TimePopover
     activity?: Record<string, SessionActivity>;
+    // when provided, each tile's CardMenu gains a Rename action
+    onrename?: (id: string) => void;
     // when provided, each tile's CardMenu gains a two-step armed Relaunch action
     onrelaunch?: (id: string) => void;
     // when provided, each tile's CardMenu gains a one-click "Relaunch elsewhere" item
@@ -81,6 +84,7 @@
         {onselect}
         git={git[session.id]}
         activity={activity[session.id]}
+        {onrename}
         {onrelaunch}
         {onrelaunchElsewhere}
         {onvariant}

--- a/ui/src/lib/components/RenameAllViewHarness.browser.test.ts
+++ b/ui/src/lib/components/RenameAllViewHarness.browser.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import type { Session } from "$lib/types";
+import { m } from "$lib/paraglide/messages";
+
+vi.mock("$lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/api")>();
+  return { ...actual, getReviews: vi.fn(async () => ({})), getReviewingIds: vi.fn(async () => []) };
+});
+
+const { default: RenameAllViewHarness } = await import("./RenameAllViewHarness.svelte");
+const { reviews } = await import("$lib/reviews.svelte");
+
+function session(partial: Partial<Session> & { id: string }): Session {
+  return {
+    desig: "TASK-01",
+    name: "task one",
+    prompt: "p",
+    repoPath: "/repo/a",
+    baseBranch: "main",
+    branch: "feat/x",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "h",
+    herdrAgentId: "ha",
+    claudeSessionId: "cs",
+    model: null,
+    status: "idle",
+    readyToMerge: false,
+    mergingSince: null,
+    mergingTrainId: null,
+    mergeTrainPrs: null,
+    autopilotEnabled: null,
+    autopilotStepCount: 0,
+    autopilotPaused: false,
+    autopilotComplete: false,
+    autopilotQuestion: null,
+    planGateEnabled: null,
+    planPhase: null,
+    autoMergeEnabled: null,
+    autoMergeRebaseCount: 0,
+    auto: false,
+    sandboxApplied: null,
+    sandboxDegraded: false,
+    egressApplied: false,
+    egressDegraded: false,
+    research: false,
+    issueNumber: null,
+    lastState: "",
+    createdAt: 0,
+    updatedAt: 0,
+    archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
+    experimentId: null,
+    experimentRole: null,
+    ...partial,
+  };
+}
+
+beforeEach(() => {
+  reviews.reviewing = {};
+  reviews.map = {};
+});
+
+describe("all-view tile Rename handoff", () => {
+  it("switches from grid tile menu into the selected Viewport rename editor", async () => {
+    render(RenameAllViewHarness, {
+      sessions: [session({ id: "tile-rename", name: "tile rename target" })],
+      nowMs: Date.now(),
+    });
+
+    const tile = page.getByRole("button", {
+      name: m.unit_open_aria({ name: "tile rename target" }),
+    });
+    tile.element().dispatchEvent(
+      new MouseEvent("contextmenu", { button: 2, clientX: 60, clientY: 60, bubbles: true }),
+    );
+    await page.getByRole("menuitem", { name: m.cardmenu_rename() }).click();
+
+    const input = page.getByRole("textbox", { name: m.viewport_rename_aria() });
+    await expect.element(input).toBeInTheDocument();
+    expect((input.element() as HTMLInputElement).value).toBe("tile rename target");
+  });
+});

--- a/ui/src/lib/components/RenameAllViewHarness.browser.test.ts
+++ b/ui/src/lib/components/RenameAllViewHarness.browser.test.ts
@@ -77,9 +77,11 @@ describe("all-view tile Rename handoff", () => {
     const tile = page.getByRole("button", {
       name: m.unit_open_aria({ name: "tile rename target" }),
     });
-    tile.element().dispatchEvent(
-      new MouseEvent("contextmenu", { button: 2, clientX: 60, clientY: 60, bubbles: true }),
-    );
+    tile
+      .element()
+      .dispatchEvent(
+        new MouseEvent("contextmenu", { button: 2, clientX: 60, clientY: 60, bubbles: true }),
+      );
     await page.getByRole("menuitem", { name: m.cardmenu_rename() }).click();
 
     const input = page.getByRole("textbox", { name: m.viewport_rename_aria() });

--- a/ui/src/lib/components/RenameAllViewHarness.svelte
+++ b/ui/src/lib/components/RenameAllViewHarness.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import type { GitState, Session } from "$lib/types";
+  import HerdGrid from "./HerdGrid.svelte";
+  import Viewport from "./Viewport.svelte";
+
+  let {
+    sessions,
+    nowMs = Date.now(),
+    git = {},
+  }: {
+    sessions: Session[];
+    nowMs?: number;
+    git?: Record<string, GitState>;
+  } = $props();
+
+  let viewMode = $state<"all" | "focus">("all");
+  let selectedId = $state<string | null>(null);
+  let renameRequest = $state<{ id: string; tick: number } | null>(null);
+  let renameSeq = 0;
+  const selected = $derived(sessions.find((s) => s.id === selectedId) ?? null);
+
+  function openRename(id: string) {
+    selectedId = id;
+    viewMode = "focus";
+    renameRequest = { id, tick: ++renameSeq };
+  }
+</script>
+
+{#if viewMode === "all"}
+  <HerdGrid
+    {sessions}
+    {selectedId}
+    {nowMs}
+    {git}
+    onselect={(id) => {
+      selectedId = id;
+      viewMode = "focus";
+    }}
+    onrename={openRename}
+    onnew={() => {}}
+  />
+{:else if selected}
+  <Viewport
+    session={selected}
+    git={git[selected.id] ?? null}
+    {renameRequest}
+    openPreviewTick={0}
+    consumeAutoFocusTerm={() => false}
+  />
+{/if}

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -157,6 +157,28 @@ describe("UnitRow preview badge", () => {
   });
 });
 
+describe("UnitRow context menu", () => {
+  it("offers Rename and calls the row rename handler", async () => {
+    const onrename = vi.fn();
+    render(UnitRow, {
+      session: session({ id: "rename-row", name: "rename row" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+      onrename,
+    });
+
+    const hit = page.getByRole("button", { name: m.unit_open_aria({ name: "rename row" }) });
+    hit.element().dispatchEvent(
+      new MouseEvent("contextmenu", { button: 2, clientX: 40, clientY: 40, bubbles: true }),
+    );
+
+    await page.getByRole("menuitem", { name: m.cardmenu_rename() }).click();
+
+    expect(onrename).toHaveBeenCalledWith("rename-row");
+  });
+});
+
 describe("UnitRow inline repo emoji filter", () => {
   // The emoji's title carries the repo name (hover reveal); match it precisely.
   it("clicking the emoji scopes the filter to this repo (non-additive) without selecting the row", async () => {

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -169,9 +169,11 @@ describe("UnitRow context menu", () => {
     });
 
     const hit = page.getByRole("button", { name: m.unit_open_aria({ name: "rename row" }) });
-    hit.element().dispatchEvent(
-      new MouseEvent("contextmenu", { button: 2, clientX: 40, clientY: 40, bubbles: true }),
-    );
+    hit
+      .element()
+      .dispatchEvent(
+        new MouseEvent("contextmenu", { button: 2, clientX: 40, clientY: 40, bubbles: true }),
+      );
 
     await page.getByRole("menuitem", { name: m.cardmenu_rename() }).click();
 

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -55,6 +55,7 @@
     previewServeFailed = false,
     onpreview,
     ondecommission,
+    onrename,
     onrelaunch,
     onrelaunchElsewhere,
     onvariant,
@@ -84,6 +85,8 @@
     // the left-swipe gesture, fine pointers a hover-revealed ✕ button, and the
     // right-click / long-press CardMenu offers it on both
     ondecommission?: (id: string) => void;
+    // when provided, the right-click / long-press CardMenu gains a Rename action
+    onrename?: (id: string) => void;
     // when provided, the right-click / long-press CardMenu gains a two-step armed
     // Relaunch action (spawns a fresh replacement + decommissions this session)
     onrelaunch?: (id: string) => void;
@@ -249,6 +252,7 @@
   const hasMenu = $derived(
     resumable ||
       !!ondecommission ||
+      !!onrename ||
       relaunchable ||
       relaunchElsewhereAble ||
       variantable ||
@@ -276,6 +280,10 @@
   function decommissionFromMenu() {
     menu = null;
     ondecommission?.(session.id);
+  }
+  function renameFromMenu() {
+    menu = null;
+    onrename?.(session.id);
   }
   function relaunchFromMenu() {
     menu = null;
@@ -556,6 +564,7 @@
     {resumable}
     opener={menu.opener}
     onresume={resumeFromMenu}
+    onrename={onrename ? renameFromMenu : undefined}
     onrelaunch={relaunchable ? relaunchFromMenu : undefined}
     onrelaunchElsewhere={relaunchElsewhereAble ? relaunchElsewhereFromMenu : undefined}
     onvariant={variantable ? variantFromMenu : undefined}

--- a/ui/src/lib/components/UnitTile.svelte
+++ b/ui/src/lib/components/UnitTile.svelte
@@ -38,6 +38,7 @@
     onselect,
     git,
     activity,
+    onrename,
     onrelaunch,
     onrelaunchElsewhere,
     onvariant,
@@ -51,6 +52,8 @@
     git?: GitState;
     // live per-session signal (heartbeat ts); feeds the TimePopover's last-activity line
     activity?: SessionActivity;
+    // when provided, the CardMenu gains a Rename action
+    onrename?: (id: string) => void;
     // when provided, the right-click / long-press CardMenu gains a two-step armed
     // Relaunch action (spawns a fresh replacement + decommissions this session)
     onrelaunch?: (id: string) => void;
@@ -206,7 +209,7 @@
   let elapsedEl = $state<HTMLSpanElement>();
   let menu = $state<{ x: number; y: number; opener: HTMLElement } | null>(null);
   const hasMenu = $derived(
-    resumable || relaunchable || relaunchElsewhereAble || variantable || replaceable,
+    resumable || !!onrename || relaunchable || relaunchElsewhereAble || variantable || replaceable,
   );
   function openMenuAt(x: number, y: number): boolean {
     if (menu || !hasMenu) return false;
@@ -226,6 +229,10 @@
     } catch {
       toasts.info(m.cardmenu_resume_failed({ name: session.name }));
     }
+  }
+  function renameFromMenu() {
+    menu = null;
+    onrename?.(session.id);
   }
   function relaunchFromMenu() {
     menu = null;
@@ -362,6 +369,7 @@
     {resumable}
     opener={menu.opener}
     onresume={resumeFromMenu}
+    onrename={onrename ? renameFromMenu : undefined}
     onrelaunch={relaunchable ? relaunchFromMenu : undefined}
     onrelaunchElsewhere={relaunchElsewhereAble ? relaunchElsewhereFromMenu : undefined}
     onvariant={variantable ? variantFromMenu : undefined}

--- a/ui/src/lib/components/Viewport.browser.test.ts
+++ b/ui/src/lib/components/Viewport.browser.test.ts
@@ -228,6 +228,51 @@ describe("Viewport preview tab", () => {
   });
 });
 
+describe("Viewport rename affordances", () => {
+  it("renders the session name in the normal desktop header and double-click opens rename", async () => {
+    const { container } = render(Viewport, {
+      session: session({ id: "rename-head", name: "visible session title" }),
+      previewPort: null,
+      openPreviewTick: 0,
+    });
+
+    const title = container.querySelector<HTMLElement>(".vp-head:not(.mobile) .vp-name");
+    expect(title, "normal desktop header title").not.toBeNull();
+    expect(title!.textContent).toBe("visible session title");
+
+    title!.click();
+    title!.click();
+
+    const input = page.getByRole("textbox", { name: m.viewport_rename_aria() });
+    await expect.element(input).toBeInTheDocument();
+    expect((input.element() as HTMLInputElement).value).toBe("visible session title");
+  });
+
+  it("opens rename only for matching targeted requests", async () => {
+    const { rerender } = render(Viewport, {
+      session: session({ id: "rename-target", name: "target title" }),
+      previewPort: null,
+      openPreviewTick: 0,
+      renameRequest: { id: "other", tick: 1 },
+    });
+
+    await expect
+      .element(page.getByRole("textbox", { name: m.viewport_rename_aria() }))
+      .not.toBeInTheDocument();
+
+    await rerender({
+      session: session({ id: "rename-target", name: "target title" }),
+      previewPort: null,
+      openPreviewTick: 0,
+      renameRequest: { id: "rename-target", tick: 2 },
+    });
+
+    const input = page.getByRole("textbox", { name: m.viewport_rename_aria() });
+    await expect.element(input).toBeInTheDocument();
+    expect((input.element() as HTMLInputElement).value).toBe("target title");
+  });
+});
+
 // ── Start-preview re-entrancy guard ──────────────────────────────────────────
 // Regression: the original code used $state<Set<string>> which Svelte 5 does
 // NOT proxy, so .add()/.delete() never triggered reactivity and the disabled

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -99,6 +99,7 @@
     previewServeFailed = false,
     previewMap = {},
     openPreviewTick = 0,
+    renameRequest = null,
     buildQueue = null,
     onSeedBuildQueue,
     previewHost = null,
@@ -151,6 +152,8 @@
     previewMap?: Record<string, number | null>;
     /** Monotonic tick bumped by a row's Preview-badge click → switch to the Preview tab. */
     openPreviewTick?: number;
+    /** Targeted request from a card context-menu Rename action. */
+    renameRequest?: { id: string; tick: number } | null;
     /** Current build queue for this session; updated live by WS queue:update events. */
     buildQueue?: BuildQueue | null;
     /** Called when the panel bootstrap-GETs or mutates a queue, to seed the store. */
@@ -693,6 +696,17 @@
     await tick();
     renameInput?.select();
   }
+  let lastRenameRequestTick = -1;
+  $effect(() => {
+    if (
+      renameRequest &&
+      renameRequest.id === session.id &&
+      renameRequest.tick !== lastRenameRequestTick
+    ) {
+      lastRenameRequestTick = renameRequest.tick;
+      void startRename();
+    }
+  });
   function cancelRename() {
     renaming = false;
     renameError = null;
@@ -735,7 +749,7 @@
   // identically (iOS Safari fires dblclick unreliably) — the first tap keeps
   // its existing job (meta popover via focus), the second one renames.
   // The timestamp is deliberately shared across the title elements (desig +
-  // vp-name co-render on compact desktops): both carry the same session
+  // vp-name): both carry the same session
   // identity side by side, so a double-tap straddling them still reads as
   // "double-tap the title" and should rename.
   let lastTitleTap = 0;
@@ -1958,8 +1972,9 @@
           {@render metaPop()}
         {/if}
       </span>
-      {#if compact && !renaming}
-        <!-- foldable/touch desktop only: surfaces the full name the desig can't carry.
+      {#if !renaming}
+        <!-- visible task title: on normal desktop this restores the name beside the
+             designator; on compact/touch desktop it keeps the previous name target.
              Pointer-only rename target — the adjacent desig owns the keyboard/AT path
              (a button role here would announce a second, redundant control for the
              same identity), so no role/tabindex/keydown by design. Hidden while
@@ -2593,8 +2608,7 @@
     font-variant-numeric: tabular-nums;
   }
 
-  /* full task name — surfaced in compact headers where the session list is
-     hidden, so the desig number alone can't identify the session */
+  /* full task name — the visible rename target beside the task designator */
   .vp-name {
     color: var(--color-ink);
     font-size: var(--fs-base);

--- a/ui/src/lib/components/herd/HerdGroup.svelte
+++ b/ui/src/lib/components/herd/HerdGroup.svelte
@@ -12,6 +12,7 @@
     previewServe: Record<string, "ok" | "failed">;
     onpreview?: (id: string) => void;
     ondecommission?: (id: string) => void;
+    onrename?: (id: string) => void;
     onrelaunch?: (id: string) => void;
     onrelaunchElsewhere?: (id: string) => void;
     onvariant?: (id: string, anchor: { x: number; y: number }) => void;
@@ -82,6 +83,7 @@
     previewServeFailed={withPreview ? ctx.previewServe[session.id] === "failed" : false}
     onpreview={withPreview ? ctx.onpreview : undefined}
     ondecommission={ctx.ondecommission}
+    onrename={ctx.onrename}
     onrelaunch={ctx.onrelaunch}
     onrelaunchElsewhere={ctx.onrelaunchElsewhere}
     onvariant={ctx.onvariant}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -216,8 +216,9 @@
     openPreviewTick++;
   }
   function openRename(id: string) {
-    selectUnit(id, false);
-    if (!mobile.current && viewMode === "all") viewMode = "focus";
+    selectUnit(id, false, true);
+    if (mobile.current) mobileScreen = "detail";
+    else if (viewMode === "all") viewMode = "focus";
     renameRequest = { id, tick: ++renameRequestSeq };
   }
   let showNew = $state(false);

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -191,6 +191,8 @@
   // Viewport so it switches to its Preview tab. A counter (not a boolean) so a
   // repeat click on the already-selected session still re-triggers the open.
   let openPreviewTick = $state(0);
+  let renameRequest = $state<{ id: string; tick: number } | null>(null);
+  let renameRequestSeq = 0;
   // Flatten the /api/preview snapshot ({ id: { previewPort, serve? } }) into the
   // store's flat sessionId → port|null map (unchanged shape; serve is separate).
   function flattenPreview(
@@ -212,6 +214,11 @@
   function openPreview(id: string) {
     selectUnit(id);
     openPreviewTick++;
+  }
+  function openRename(id: string) {
+    selectUnit(id, false);
+    if (!mobile.current && viewMode === "all") viewMode = "focus";
+    renameRequest = { id, tick: ++renameRequestSeq };
   }
   let showNew = $state(false);
   let showSettings = $state(false);
@@ -2446,6 +2453,7 @@
             preview={store.preview}
             previewServe={store.previewServe}
             onpreview={openPreview}
+            onrename={openRename}
             epics={store.epics}
             onepic={openEpicInBacklog}
             {activeEpicKeys}
@@ -2547,6 +2555,7 @@
             previewHost={settings?.previewHost ?? null}
             previewServeFailed={store.previewServe[selected.id] === "failed"}
             {openPreviewTick}
+            {renameRequest}
             buildQueue={store.buildQueues[selected.id] ?? null}
             onSeedBuildQueue={(q) => store.setBuildQueue(q)}
             queue={blockedEntries.map((e) => e.session.id)}
@@ -2581,6 +2590,7 @@
           {onrelaunchElsewhere}
           {onvariant}
           {onreplace}
+          onrename={openRename}
           onselect={(id) => {
             selectedId = id;
             viewMode = "focus";
@@ -2622,6 +2632,7 @@
             preview={store.preview}
             previewServe={store.previewServe}
             onpreview={openPreview}
+            onrename={openRename}
             epics={store.epics}
             onepic={openEpicInBacklog}
             {activeEpicKeys}
@@ -2711,6 +2722,7 @@
             previewHost={settings?.previewHost ?? null}
             previewServeFailed={store.previewServe[selected.id] === "failed"}
             {openPreviewTick}
+            {renameRequest}
             buildQueue={store.buildQueues[selected.id] ?? null}
             onSeedBuildQueue={(q) => store.setBuildQueue(q)}
             queue={blockedEntries.map((e) => e.session.id)}


### PR DESCRIPTION
## Summary

- add Rename to the session-card context menu and pass it through row/tile/all-view paths
- restore the visible session name in the desktop session header as the double-click rename target
- use a targeted `{ id, tick }` rename request so all-view tiles switch to focus and the mounted Viewport consumes the request once

Refs #1450 for the existing rename-affordance gap; the broader free-form branch-decoupled title proposal remains a separate product decision.

## Tests

- `cd ui && bun run check:i18n`
- `cd ui && bun run test:browser -- src/lib/components/Viewport.browser.test.ts src/lib/components/UnitRow.browser.test.ts src/lib/components/RenameAllViewHarness.browser.test.ts`
- `cd ui && bun run check`
- `cd ui && bun run test`
- `git diff --check`
