### PR TITLE
fix(ui): show Codex gauges in usage limits

### DIFF
--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -289,8 +289,8 @@
       : "",
   );
   // Alert hue: amber is the design system's caution token (also used by the update
-  // badge). The usage gauges now go red >90 (see gaugeColor); amber is their 75–90
-  // warning tier. pct is 0 here so gaugeColor(pct) can't drive it — overspend keys
+  // badge). The usage gauges now go red >90 (see gaugeColor); amber is their warming
+  // tier above 50. pct is 0 here so gaugeColor(pct) can't drive it — overspend keys
   // off real spend instead. Stale → muted; idle → neutral.
   const creditColor = $derived(
     credits?.stale ? "var(--color-muted)" : overspend ? "var(--color-amber)" : "var(--color-muted)",

--- a/ui/src/lib/components/Usage.browser.test.ts
+++ b/ui/src/lib/components/Usage.browser.test.ts
@@ -38,8 +38,8 @@ const inlineLimits: UsageLimits = {
       weekTokens: 87_654_321,
       updatedAt: BASE - 60_000,
       stale: false,
-      session5h: null,
-      week: null,
+      session5h: { pct: 42, resetAt: BASE + H },
+      week: { pct: 7, resetAt: BASE + 6 * 24 * H },
     },
   ],
 };
@@ -134,8 +134,13 @@ describe("Usage modal component", () => {
 
     limitsBtn!.click();
 
-    // Wait for the Limits lens to appear (it has meter-track elements)
-    await expect.poll(() => document.querySelectorAll(".meter-track").length).toBe(2);
+    // Wait for the Limits lens to appear. Claude meters stay in their provider section, and
+    // Codex uses the reused top-menu LimitGaugeRow primitive rather than the lens meter markup.
+    await expect.poll(() => document.querySelectorAll(".provider-claude .meter-track").length).toBe(2);
+    await expect
+      .poll(() => document.querySelectorAll(".provider-codex .sheet-gauge-row").length)
+      .toBe(2);
+    expect(document.querySelector(".provider-strip"), "Codex strip suppressed on Limits tab").toBeNull();
 
     // Range selector must not be present on the Limits tab
     const rangeGroup = document.querySelector('[role="group"][aria-label]');

--- a/ui/src/lib/components/Usage.browser.test.ts
+++ b/ui/src/lib/components/Usage.browser.test.ts
@@ -136,11 +136,16 @@ describe("Usage modal component", () => {
 
     // Wait for the Limits lens to appear. Claude meters stay in their provider section, and
     // Codex uses the reused top-menu LimitGaugeRow primitive rather than the lens meter markup.
-    await expect.poll(() => document.querySelectorAll(".provider-claude .meter-track").length).toBe(2);
+    await expect
+      .poll(() => document.querySelectorAll(".provider-claude .meter-track").length)
+      .toBe(2);
     await expect
       .poll(() => document.querySelectorAll(".provider-codex .sheet-gauge-row").length)
       .toBe(2);
-    expect(document.querySelector(".provider-strip"), "Codex strip suppressed on Limits tab").toBeNull();
+    expect(
+      document.querySelector(".provider-strip"),
+      "Codex strip suppressed on Limits tab",
+    ).toBeNull();
 
     // Range selector must not be present on the Limits tab
     const rangeGroup = document.querySelector('[role="group"][aria-label]');

--- a/ui/src/lib/components/Usage.svelte
+++ b/ui/src/lib/components/Usage.svelte
@@ -247,7 +247,7 @@
       </div>
     {/if}
 
-    {#if codexUsage}
+    {#if codexUsage && tab !== "limits"}
       <div class="provider-strip" class:provider-stale={codexUsage.stale}>
         <span class="provider-name">{m.agent_provider_codex()}</span>
         <span class="provider-metric">
@@ -286,7 +286,7 @@
       {:else if tab === "timeline" && timeline}
         <TimelineLens {timeline} />
       {:else if tab === "limits" && limits}
-        <LimitsLens {limits} {projections} />
+        <LimitsLens {limits} {projections} {codexUsage} />
       {:else if tab === "github" && github}
         <GithubLens data={github} />
       {:else if bodyError}

--- a/ui/src/lib/components/usage-gauges.test.ts
+++ b/ui/src/lib/components/usage-gauges.test.ts
@@ -128,11 +128,14 @@ describe("gaugeColor", () => {
   it("0 → muted", () => {
     expect(gaugeColor(0)).toBe("var(--color-muted)");
   });
-  it("74 → muted", () => {
-    expect(gaugeColor(74)).toBe("var(--color-muted)");
+  it("50 → muted", () => {
+    expect(gaugeColor(50)).toBe("var(--color-muted)");
   });
-  it("75 → amber", () => {
-    expect(gaugeColor(75)).toBe("var(--color-amber)");
+  it("51 → amber", () => {
+    expect(gaugeColor(51)).toBe("var(--color-amber)");
+  });
+  it("80 → amber", () => {
+    expect(gaugeColor(80)).toBe("var(--color-amber)");
   });
   it("90 → amber", () => {
     expect(gaugeColor(90)).toBe("var(--color-amber)");

--- a/ui/src/lib/components/usage-gauges.ts
+++ b/ui/src/lib/components/usage-gauges.ts
@@ -82,14 +82,14 @@ export function hotterGauge(limits: UsageLimits | null): Gauge | null {
   return gauges.reduce((hot, g) => (g.w.pct >= hot.w.pct ? g : hot));
 }
 
-/** Usage-gauge fill/text color. Three-step ladder: muted at rest, amber as the window
- *  warms (75–90), red once it runs critically hot (>90). Red here is a deliberate,
+/** Usage-gauge fill/text color. Three-step ladder: muted through 50, amber as the window
+ *  warms above 50, red once it runs critically hot (>90). Red here is a deliberate,
  *  documented exception to the Four-Light Rule (DESIGN.md / DESIGN.json) — usage telemetry
  *  near cap is an operator-attention signal, but it stays a bar-fill/text hue only (no halo,
  *  no status pip) so a blocked agent's red pip remains the loudest red on screen. */
 export function gaugeColor(pct: number): string {
   if (pct > 90) return "var(--color-red)";
-  if (pct >= 75) return "var(--color-amber)";
+  if (pct > 50) return "var(--color-amber)";
   return "var(--color-muted)";
 }
 

--- a/ui/src/lib/components/usage/LimitsLens.browser.test.ts
+++ b/ui/src/lib/components/usage/LimitsLens.browser.test.ts
@@ -242,10 +242,14 @@ describe("LimitsLens", () => {
     render(LimitsLens, { limits, projections: projectionsFixture(), codexUsage });
 
     await expect
-      .element(page.getByText(m.topbar_usage_provider_title({ provider: m.agent_provider_claude() })))
+      .element(
+        page.getByText(m.topbar_usage_provider_title({ provider: m.agent_provider_claude() })),
+      )
       .toBeInTheDocument();
     await expect
-      .element(page.getByText(m.topbar_usage_provider_title({ provider: m.agent_provider_codex() })))
+      .element(
+        page.getByText(m.topbar_usage_provider_title({ provider: m.agent_provider_codex() })),
+      )
       .toBeInTheDocument();
 
     const claude = document.querySelector<HTMLElement>(".provider-claude");

--- a/ui/src/lib/components/usage/LimitsLens.browser.test.ts
+++ b/ui/src/lib/components/usage/LimitsLens.browser.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../../app.css";
-import type { UsageLimits, UsageProjection, UsageHistoryResponse } from "$lib/types";
+import type {
+  UsageLimits,
+  UsageProjection,
+  UsageHistoryResponse,
+  UsageProviderSnapshot,
+} from "$lib/types";
+import { m } from "$lib/paraglide/messages";
+import { formatTokenLabel } from "$lib/format";
 
 const BASE = Date.now();
 const H = 3_600_000;
@@ -24,6 +31,35 @@ function projectionsFixture(): UsageProjection[] {
     { window: "5H", projectedPct: 64, resetAt: BASE + 2.5 * H, burnRatePerHour: 48_000 },
     { window: "WK", projectedPct: 41, resetAt: BASE + 58 * H, burnRatePerHour: 31_000 },
   ];
+}
+
+function emptyLimitsFixture(): UsageLimits {
+  return {
+    session5h: null,
+    week: null,
+    perModelWeek: [],
+    credits: null,
+    stale: false,
+    calibratedAt: null,
+    subscriptionOnly: false,
+  };
+}
+
+function codexUsageFixture(
+  overrides: Partial<Extract<UsageProviderSnapshot, { provider: "codex"; kind: "tokens" }>> = {},
+): Extract<UsageProviderSnapshot, { provider: "codex"; kind: "tokens" }> {
+  return {
+    provider: "codex",
+    kind: "tokens",
+    totalTokens: 884_800_000,
+    session5hTokens: 229_700_000,
+    weekTokens: 689_900_000,
+    updatedAt: BASE - 60_000,
+    stale: false,
+    session5h: { pct: 42, resetAt: BASE + H },
+    week: { pct: 7, resetAt: BASE + 6 * 24 * H },
+    ...overrides,
+  };
 }
 
 function historyFixture(): UsageHistoryResponse {
@@ -75,7 +111,7 @@ describe("LimitsLens", () => {
     render(LimitsLens, { limits, projections });
 
     // Two window blocks — one per gauge (5H and WK)
-    const meterTracks = document.querySelectorAll(".meter-track");
+    const meterTracks = document.querySelectorAll(".provider-claude .meter-track");
     expect(meterTracks.length, "one meter per window").toBe(2);
   });
 
@@ -167,8 +203,8 @@ describe("LimitsLens", () => {
     const projections = projectionsFixture();
     render(LimitsLens, { limits, projections, history: null });
 
-    expect(document.querySelectorAll(".meter-track").length).toBe(2);
-    expect(document.querySelectorAll(".proj-tick").length).toBe(2);
+    expect(document.querySelectorAll(".provider-claude .meter-track").length).toBe(2);
+    expect(document.querySelectorAll(".provider-claude .proj-tick").length).toBe(2);
     // No recorded history ⇒ no toggle
     expect(document.querySelector("button[aria-expanded]"), "no toggle without history").toBeNull();
     // Inline sparkline still renders (single live "now" point)
@@ -183,7 +219,10 @@ describe("LimitsLens", () => {
     render(LimitsLens, { limits, projections: projectionsFixture() });
 
     // Its own block, NOT a 5H/WK meter-track (those stay at 2)
-    expect(document.querySelectorAll(".meter-track").length, "5H/WK meters unchanged").toBe(2);
+    expect(
+      document.querySelectorAll(".provider-claude .meter-track").length,
+      "5H/WK meters unchanged",
+    ).toBe(2);
     const mwBar = document.querySelector(".model-week-block .mw-bar");
     expect(mwBar, "Fable passthrough bar present").not.toBeNull();
     await expect.element(page.getByText("Weekly window (Fable)")).toBeInTheDocument();
@@ -191,17 +230,58 @@ describe("LimitsLens", () => {
   });
 
   it("renders 'no data' message when limits are empty", async () => {
-    const emptyLimits = {
-      session5h: null,
-      week: null,
-      perModelWeek: [],
-      credits: null,
-      stale: false,
-      calibratedAt: null,
-      subscriptionOnly: false,
-    };
+    const emptyLimits = emptyLimitsFixture();
     render(LimitsLens, { limits: emptyLimits, projections: [] });
 
     await expect.element(page.getByText(/no usage-window data/i)).toBeInTheDocument();
+  });
+
+  it("renders provider-scoped Claude and Codex sections without mixing stale state", async () => {
+    const limits = limitsFixture();
+    const codexUsage = codexUsageFixture({ stale: true });
+    render(LimitsLens, { limits, projections: projectionsFixture(), codexUsage });
+
+    await expect
+      .element(page.getByText(m.topbar_usage_provider_title({ provider: m.agent_provider_claude() })))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText(m.topbar_usage_provider_title({ provider: m.agent_provider_codex() })))
+      .toBeInTheDocument();
+
+    const claude = document.querySelector<HTMLElement>(".provider-claude");
+    const codex = document.querySelector<HTMLElement>(".provider-codex");
+    expect(claude, "Claude section present").not.toBeNull();
+    expect(codex, "Codex section present").not.toBeNull();
+    expect(claude!.classList.contains("stale"), "Claude does not inherit Codex stale").toBe(false);
+    expect(codex!.classList.contains("stale"), "Codex uses its own stale flag").toBe(true);
+    expect(claude!.querySelectorAll(".meter-track").length, "Claude meters").toBe(2);
+    expect(codex!.querySelectorAll(".sheet-gauge-row").length, "Codex top-menu gauge rows").toBe(2);
+  });
+
+  it("renders codex-only limit gauges without the generic no-data message", async () => {
+    const limits = emptyLimitsFixture();
+    const codexUsage = codexUsageFixture();
+    render(LimitsLens, { limits, projections: [], codexUsage });
+
+    expect(document.querySelector(".provider-claude"), "no empty Claude section").toBeNull();
+    const codex = document.querySelector<HTMLElement>(".provider-codex");
+    expect(codex, "Codex section present").not.toBeNull();
+    expect(codex!.querySelectorAll(".sheet-gauge-row").length, "Codex gauges").toBe(2);
+    expect(document.querySelector(".no-data"), "no generic no-data with Codex usage").toBeNull();
+    await expect.element(page.getByText("42%")).toBeInTheDocument();
+    await expect.element(page.getByText("7%")).toBeInTheDocument();
+  });
+
+  it("renders codex token-only fallback without fake gauges", async () => {
+    const limits = emptyLimitsFixture();
+    const codexUsage = codexUsageFixture({ session5h: null, week: null });
+    render(LimitsLens, { limits, projections: [], codexUsage });
+
+    const codex = document.querySelector<HTMLElement>(".provider-codex");
+    expect(codex, "Codex section present").not.toBeNull();
+    expect(codex!.querySelectorAll(".sheet-gauge-row").length, "no fake Codex gauges").toBe(0);
+    await expect.element(page.getByText(m.topbar_codex_limits_unavailable())).toBeInTheDocument();
+    await expect.element(page.getByText(formatTokenLabel(884_800_000))).toBeInTheDocument();
+    expect(document.querySelector(".no-data"), "no generic no-data with token fallback").toBeNull();
   });
 });

--- a/ui/src/lib/components/usage/LimitsLens.svelte
+++ b/ui/src/lib/components/usage/LimitsLens.svelte
@@ -200,6 +200,9 @@
   .provider-heading {
     padding-bottom: 0.25rem;
     border-bottom: 1px solid var(--color-line);
+    color: var(--color-ink-bright);
+    font-size: var(--fs-base);
+    font-weight: 600;
   }
 
   .no-data {
@@ -221,18 +224,30 @@
   }
 
   .window-label {
-    font-size: var(--fs-base);
-    font-weight: 600;
-    color: var(--color-ink-bright);
+    font-size: var(--fs-meta);
+    font-weight: 500;
+    color: var(--color-ink);
     flex: 1;
   }
 
   .window-pct {
-    font-size: var(--fs-lg);
+    font-size: var(--fs-meta);
     font-weight: 600;
     font-variant-numeric: tabular-nums;
     min-width: 3.5rem;
     text-align: right;
+  }
+
+  .provider-codex :global(.gp-period),
+  .provider-codex :global(.g-pct),
+  .provider-codex :global(.gauge-pop-reset),
+  .provider-codex :global(.token-row) {
+    font-size: var(--fs-meta);
+  }
+
+  .provider-codex :global(.gp-period) {
+    color: var(--color-ink);
+    font-weight: 500;
   }
 
   .meter-wrap {

--- a/ui/src/lib/components/usage/LimitsLens.svelte
+++ b/ui/src/lib/components/usage/LimitsLens.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import type { UsageLimits, UsageProjection, UsageHistoryResponse } from "$lib/types";
+  import type {
+    UsageLimits,
+    UsageProjection,
+    UsageHistoryResponse,
+    UsageProviderSnapshot,
+  } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { gaugeList, gaugeColor, modelWeekList } from "$lib/components/usage-gauges";
   import { formatResetIn } from "$lib/format";
@@ -7,14 +12,17 @@
   import Sparkline from "./Sparkline.svelte";
   import ModelWeekGauge from "./ModelWeekGauge.svelte";
   import UsageHistoryPanel from "./UsageHistoryPanel.svelte";
+  import CodexTokenDetail from "../top-bar/CodexTokenDetail.svelte";
 
   const {
     limits,
     projections,
+    codexUsage = null,
     history = null,
   }: {
     limits: UsageLimits;
     projections: UsageProjection[];
+    codexUsage?: Extract<UsageProviderSnapshot, { provider: "codex"; kind: "tokens" }> | null;
     history?: UsageHistoryResponse | null;
   } = $props();
 
@@ -26,6 +34,7 @@
   // Per-model weekly passthrough sub-limits (e.g. Fable) — rendered as their own bars below the
   // calibrated 5H/WK windows. Kept out of `gaugeList` (no cap-inversion, no projection/sparkline).
   const perModel = $derived(modelWeekList(limits));
+  const hasClaude = $derived(gauges.length > 0 || perModel.length > 0);
 
   let showHistory = $state(false);
 
@@ -64,93 +73,109 @@
 </script>
 
 <div class="limits-lens panel">
-  {#if gauges.length === 0 && perModel.length === 0}
+  {#if !hasClaude && !codexUsage}
     <p class="no-data">{m.usage_limits_no_data()}</p>
   {:else}
-    {#each gauges as gauge (gauge.label)}
-      {@const pct = Math.min(Math.max(gauge.w.pct, 0), 100)}
-      {@const color = gaugeColor(gauge.w.pct)}
-      {@const proj = findProjection(gauge.label)}
-      {@const projPct = proj ? Math.min(Math.max(proj.projectedPct, 0), 100) : null}
-      {@const willExceed = proj ? proj.projectedPct > 100 : false}
-
-      <div class="window-block">
-        <div class="window-header">
-          <span class="window-label">{windowLabel(gauge.label)}</span>
-          <span class="micro">{gauge.label}</span>
-          <span class="window-pct" style="color:{color}">{gauge.w.pct}%</span>
+    {#if hasClaude}
+      <div class="provider-section provider-claude">
+        <div class="provider-heading micro">
+          {m.topbar_usage_provider_title({ provider: m.agent_provider_claude() })}
         </div>
+        {#each gauges as gauge (gauge.label)}
+          {@const pct = Math.min(Math.max(gauge.w.pct, 0), 100)}
+          {@const color = gaugeColor(gauge.w.pct)}
+          {@const proj = findProjection(gauge.label)}
+          {@const projPct = proj ? Math.min(Math.max(proj.projectedPct, 0), 100) : null}
+          {@const willExceed = proj ? proj.projectedPct > 100 : false}
 
-        <div
-          class="meter-wrap"
-          role="meter"
-          aria-valuenow={gauge.w.pct}
-          aria-valuemin={0}
-          aria-valuemax={100}
-          aria-label={windowLabel(gauge.label)}
-        >
-          <div class="meter-track">
-            <!-- Current fill -->
-            <div class="meter-fill" style="width:{pct}%;background:{color}"></div>
-            <!-- Projection tick -->
-            {#if projPct !== null}
-              <div class="proj-tick" style="left:{projPct}%" aria-hidden="true"></div>
-            {/if}
-          </div>
-        </div>
+          <div class="window-block">
+            <div class="window-header">
+              <span class="window-label">{windowLabel(gauge.label)}</span>
+              <span class="micro">{gauge.label}</span>
+              <span class="window-pct" style="color:{color}">{gauge.w.pct}%</span>
+            </div>
 
-        <!-- Recorded current-cycle trend: scrape samples + a live "now" endpoint. -->
-        <div class="spark-row">
-          <Sparkline
-            points={inlinePoints(gauge.label, gauge.w.pct, gauge.w.resetAt)}
-            {color}
-            liveLast={true}
-            domain={{ min: 0, max: 100 }}
-            ariaLabel={m.usage_history_inline_label({ window: windowLabel(gauge.label) })}
-          />
-        </div>
-
-        <div class="window-meta">
-          <span class="reset-time"
-            >{m.usage_limits_resets_in({ time: formatResetIn(gauge.w.resetAt, nowMs) })}</span
-          >
-          {#if proj}
-            <span class="proj-info" class:will-exceed={willExceed}>
-              {m.usage_limits_projected({ pct: proj.projectedPct })}
-              {#if willExceed}
-                &nbsp;—&nbsp;<span class="exceed-label">{m.usage_limits_will_exceed()}</span>
-              {/if}
-            </span>
-            <span class="burn-rate"
-              >{m.usage_limits_burn_rate({ rate: formatUnits(proj.burnRatePerHour) })}</span
+            <div
+              class="meter-wrap"
+              role="meter"
+              aria-valuenow={gauge.w.pct}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={windowLabel(gauge.label)}
             >
-          {/if}
-        </div>
-      </div>
-    {/each}
+              <div class="meter-track">
+                <!-- Current fill -->
+                <div class="meter-fill" style="width:{pct}%;background:{color}"></div>
+                <!-- Projection tick -->
+                {#if projPct !== null}
+                  <div class="proj-tick" style="left:{projPct}%" aria-hidden="true"></div>
+                {/if}
+              </div>
+            </div>
 
-    {#if perModel.length > 0}
-      <div class="model-week-block">
-        {#each perModel as entry (entry.model)}
-          <ModelWeekGauge {entry} {nowMs} />
+            <!-- Recorded current-cycle trend: scrape samples + a live "now" endpoint. -->
+            <div class="spark-row">
+              <Sparkline
+                points={inlinePoints(gauge.label, gauge.w.pct, gauge.w.resetAt)}
+                {color}
+                liveLast={true}
+                domain={{ min: 0, max: 100 }}
+                ariaLabel={m.usage_history_inline_label({ window: windowLabel(gauge.label) })}
+              />
+            </div>
+
+            <div class="window-meta">
+              <span class="reset-time"
+                >{m.usage_limits_resets_in({ time: formatResetIn(gauge.w.resetAt, nowMs) })}</span
+              >
+              {#if proj}
+                <span class="proj-info" class:will-exceed={willExceed}>
+                  {m.usage_limits_projected({ pct: proj.projectedPct })}
+                  {#if willExceed}
+                    &nbsp;—&nbsp;<span class="exceed-label">{m.usage_limits_will_exceed()}</span>
+                  {/if}
+                </span>
+                <span class="burn-rate"
+                  >{m.usage_limits_burn_rate({ rate: formatUnits(proj.burnRatePerHour) })}</span
+                >
+              {/if}
+            </div>
+          </div>
         {/each}
+
+        {#if perModel.length > 0}
+          <div class="model-week-block">
+            {#each perModel as entry (entry.model)}
+              <ModelWeekGauge {entry} {nowMs} />
+            {/each}
+          </div>
+        {/if}
+
+        {#if hasHistory}
+          <div class="history-toggle-row">
+            <button
+              type="button"
+              class="gbtn"
+              aria-expanded={showHistory}
+              onclick={() => (showHistory = !showHistory)}
+            >
+              {showHistory ? m.usage_history_hide() : m.usage_history_view()}
+            </button>
+          </div>
+          {#if showHistory && history}
+            <UsageHistoryPanel {history} />
+          {/if}
+        {/if}
       </div>
     {/if}
 
-    {#if hasHistory}
-      <div class="history-toggle-row">
-        <button
-          type="button"
-          class="gbtn"
-          aria-expanded={showHistory}
-          onclick={() => (showHistory = !showHistory)}
-        >
-          {showHistory ? m.usage_history_hide() : m.usage_history_view()}
-        </button>
+    {#if codexUsage}
+      <div class="provider-section provider-codex" class:stale={codexUsage.stale}>
+        <div class="provider-heading micro">
+          {m.topbar_usage_provider_title({ provider: m.agent_provider_codex() })}
+        </div>
+        <CodexTokenDetail usage={codexUsage} {nowMs} periodLabel={windowLabel} />
       </div>
-      {#if showHistory && history}
-        <UsageHistoryPanel {history} />
-      {/if}
     {/if}
   {/if}
 </div>
@@ -160,6 +185,21 @@
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
+  }
+
+  .provider-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .provider-section.stale {
+    opacity: 0.5;
+  }
+
+  .provider-heading {
+    padding-bottom: 0.25rem;
+    border-bottom: 1px solid var(--color-line);
   }
 
   .no-data {


### PR DESCRIPTION
## Summary
- show Codex 5H/WK rate-limit gauges inside Token Usage > Limits using the existing top-menu Codex detail/gauge row path
- suppress the Codex provider strip on the Limits tab so token totals are not duplicated
- add provider-scoped tests for mixed, Codex-only, token-only fallback, and stale Codex states

## Feature discovery
[no-feature-entry] This repairs the existing Token Usage Limits surface rather than adding a new discoverable user-facing capability.

## Tests
- cd ui && bun run test:browser -- src/lib/components/usage/LimitsLens.browser.test.ts
- cd ui && bun run test:browser -- src/lib/components/Usage.browser.test.ts
- cd ui && bun run check
- cd ui && bun run test -- src/lib/components/usage/LimitsLens.browser.test.ts src/lib/components/Usage.browser.test.ts
