### PR TITLE
fix(codex): back off codex session-id capture + correct rollout comments (#1175)

### DIFF
--- a/src/codex-session-id.ts
+++ b/src/codex-session-id.ts
@@ -8,10 +8,10 @@
  *   {"type":"session_meta","payload":{"session_id":"<uuid>","id":"<uuid>","cwd":"<abs>","source":"cli",…}}
  *
  * Two constraints make this reliable for an ISOLATED worktree (unique cwd):
- *  - The cwd match is a RAW string compare against `worktreePath`, which is already canonical
- *    (Shepherd's `safeRepoDir` realpath-resolves repoPath and the worktree joins from it) and which
- *    Codex records canonically. No `realpath` is performed on the candidate cwd — this runs BEFORE
- *    the worktree is re-created at restore time, so the path may not exist on disk.
+ *  - The cwd match is a lexical `normalize()` compare against `worktreePath`, which is already
+ *    canonical (Shepherd's `safeRepoDir` realpath-resolves repoPath and the worktree joins from it)
+ *    and which Codex records canonically. No `realpath` is performed on the candidate cwd — this runs
+ *    BEFORE the worktree is re-created at restore time, so the path may not exist on disk.
  *  - `source === "cli"` excludes headless `codex exec` ROLE spawns (recap/critic/reviewer) that can
  *    share a worktree cwd; resuming one of those instead of the interactive session would be wrong.
  */
@@ -37,9 +37,10 @@ export function findCodexSessionId(
   home = codexHome(),
 ): string | null {
   const target = normalize(worktreePath);
-  // listRolloutFiles is newest-first, so the first cwd+cli match is the newest one.
+  // listRolloutFiles is newest-first by mtime, so the first cwd+cli match is the newest one — and the
+  // first file older than the window means every remaining file is too: stop rather than scan the tail.
   for (const { path, mtimeMs } of listRolloutFiles(home)) {
-    if (mtimeMs < notBeforeMs) continue;
+    if (mtimeMs < notBeforeMs) break;
     const meta = readSessionMeta(path);
     if (!meta || meta.source !== "cli" || !meta.id) continue;
     if (normalize(meta.cwd) === target) return meta.id;

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -52,6 +52,12 @@ const BLOCK_NOTIFICATION_TYPES = new Set(["permission_prompt"]);
  *  done-flip more than this apart are treated as unrelated turns and never paired. */
 const STOP_WINDOW_MAX_MS = 30_000;
 
+/** Codex session-id capture back-off: after a missed rescan, wait `BASE << misses` (capped) before the
+ *  next scan. A rollout normally appears within seconds of spawn, so early retries stay quick; a
+ *  never-matching session widens to one scan per ~2 min instead of every 1 s tick. */
+const CODEX_CAPTURE_BACKOFF_BASE_MS = 2_000;
+const CODEX_CAPTURE_BACKOFF_MAX_MS = 120_000;
+
 /**
  * Injectable preview wiring: service + throttle cadence + scan/pick overrides.
  * Defaults to the real implementations; tests inject fakes to avoid /proc + network.
@@ -136,8 +142,9 @@ export class StatusPoller {
 
   /** Fire-and-forget best-effort seed of a running Codex session's provider-native id (wired to
    *  service.captureCodexSessionId in index.ts). No-op for non-Codex / non-isolated / already-seeded
-   *  sessions. Left undefined in tests that don't exercise it. */
-  captureCodexSessionId?: (s: Session) => void;
+   *  sessions. Returns `true` when it was an applicable attempt that still missed (used to back off the
+   *  per-session rescan cadence below). Left undefined in tests that don't exercise it. */
+  captureCodexSessionId?: (s: Session) => boolean;
 
   /**
    * Resting-session (done/idle) MCP-auth detection seams, public + assignable (mirrors `reDrive`)
@@ -176,6 +183,10 @@ export class StatusPoller {
   private lastAuthPtyAt = new Map<string, number>();
   private lastAuthUrlEmitted = new Map<string, string>();
   private lastProbeAt = new Map<string, number>();
+  /** Per-session Codex session-id capture back-off: earliest next-attempt time + consecutive misses.
+   *  Bounds a never-matching running session (rollout GC'd / no `source=cli` header) to a widening
+   *  rescan of `$CODEX_HOME/sessions` instead of a full scan every tick. Dropped on seed/prune. */
+  private codexCaptureBackoff = new Map<string, { nextAt: number; misses: number }>();
   private lastActivitySig = new Map<string, string>();
   private lastActivity = new Map<string, SessionActivity>();
   /** Per-session liveness state machine (transcript-vs-interim routing, both
@@ -432,13 +443,11 @@ export class StatusPoller {
       if (!agent) this.reapGone(s);
       else this.reconcileAgent(s, agent);
       // Best-effort seed of a live Codex session's provider-native id (no-op unless it's an isolated
-      // Codex session that hasn't been seeded yet). tick() runs on a bare setInterval — never throw.
+      // Codex session that hasn't been seeded yet). Rescanning $CODEX_HOME every tick for a session
+      // that never matches is wasteful, so an applicable miss backs off exponentially (see below).
+      // tick() runs on a bare setInterval — never throw.
       if (agent && this.captureCodexSessionId) {
-        try {
-          this.captureCodexSessionId(s);
-        } catch (err) {
-          console.warn("[poller] codex session-id capture failed:", err);
-        }
+        this.maybeCaptureCodexSessionId(s);
       }
     }
     this.pruneInactive(activeIds);
@@ -449,6 +458,35 @@ export class StatusPoller {
     this.maybeRunPreviewSweep(sessions);
     // claude-liveness sweep: throttled; synchronous (one cheap /proc pass)
     this.maybeRunLivenessSweep(sessions);
+  }
+
+  /**
+   * Back-off wrapper around the injected `captureCodexSessionId`: skip the (tree-scanning) attempt while
+   * a prior miss's cooldown is unelapsed, and widen the cooldown exponentially per consecutive miss so a
+   * never-matching running Codex session can't rescan `$CODEX_HOME` every tick. A hit / non-applicable
+   * session clears the entry (subsequent ticks are cheap no-ops guarded by `providerSessionId`).
+   */
+  private maybeCaptureCodexSessionId(s: Session): void {
+    const bo = this.codexCaptureBackoff.get(s.id);
+    const t = this.now();
+    if (bo && t < bo.nextAt) return;
+    let missed: boolean;
+    try {
+      missed = this.captureCodexSessionId!(s);
+    } catch (err) {
+      console.warn("[poller] codex session-id capture failed:", err);
+      return;
+    }
+    if (missed) {
+      const misses = (bo?.misses ?? 0) + 1;
+      const delay = Math.min(
+        CODEX_CAPTURE_BACKOFF_BASE_MS * 2 ** (misses - 1),
+        CODEX_CAPTURE_BACKOFF_MAX_MS,
+      );
+      this.codexCaptureBackoff.set(s.id, { nextAt: t + delay, misses });
+    } else {
+      this.codexCaptureBackoff.delete(s.id);
+    }
   }
 
   /**
@@ -689,6 +727,7 @@ export class StatusPoller {
       ...this.lastAuthPtyAt.keys(),
       ...this.lastAuthUrlEmitted.keys(),
       ...this.lastProbeAt.keys(),
+      ...this.codexCaptureBackoff.keys(),
       ...this.lastActivitySig.keys(),
       ...this.lastActivity.keys(),
       ...this.liveness.keys(),
@@ -713,6 +752,7 @@ export class StatusPoller {
         this.lastAuthUrlEmitted.delete(id);
         this.lastBlockReason.delete(id);
         this.lastProbeAt.delete(id);
+        this.codexCaptureBackoff.delete(id);
         this.lastActivitySig.delete(id);
         this.lastActivity.delete(id);
         this.liveness.delete(id);

--- a/src/service.ts
+++ b/src/service.ts
@@ -2196,11 +2196,21 @@ export class SessionService {
    * when already set) and never writes an empty string — a `null` derive is a no-op, so a transient
    * miss can't clobber a good id. `restore` does NOT trust this cached value (it re-derives), so this
    * is purely the best-effort provider-neutral seed for #1087/#1160. Never throws.
+   *
+   * Returns `true` only when this was an APPLICABLE attempt that still missed (isolated Codex, unseeded,
+   * no matching rollout yet) — the signal the poller uses to back off its per-session rescan cadence so
+   * a never-matching running session doesn't scan the whole `$CODEX_HOME/sessions` tree every tick.
+   * Returns `false` for a non-applicable session (not Codex / non-isolated / already seeded) or a hit.
    */
-  captureCodexSessionId(s: Session): void {
-    if ((s.agentProvider ?? "claude") !== "codex" || !s.isolated || s.providerSessionId) return;
+  captureCodexSessionId(s: Session): boolean {
+    if ((s.agentProvider ?? "claude") !== "codex" || !s.isolated || s.providerSessionId)
+      return false;
     const id = findCodexSessionId(s.worktreePath, s.createdAt - CODEX_ID_SKEW_MS);
-    if (id) this.deps.store.setProviderSessionId(s.id, id);
+    if (id) {
+      this.deps.store.setProviderSessionId(s.id, id);
+      return false;
+    }
+    return true;
   }
 
   private resumeTarget(id: string): { session: Session; provider: AgentProvider } | null {

--- a/test/poller-codex-capture.test.ts
+++ b/test/poller-codex-capture.test.ts
@@ -1,0 +1,121 @@
+// Poller-side back-off for the Codex provider-session-id seed (issue #1175). tick() invokes the
+// injectable `poller.captureCodexSessionId` for a live isolated Codex session, but that call scans the
+// whole `$CODEX_HOME/sessions` tree. A session that never matches (rollout GC'd / no `source=cli`
+// header) must not rescan every 1s tick — an applicable miss (the hook returns `true`) backs off
+// exponentially; a hit / non-applicable session (returns `false`) clears the back-off. The actual
+// discovery is exercised in test/codex-session-id.test.ts + service.test.ts; here we prove the cadence.
+import { test, expect } from "bun:test";
+import { SessionStore } from "../src/store";
+import { StatusPoller } from "../src/poller";
+import type { HerdrAgent } from "../src/herdr";
+
+const codexSession = {
+  name: "x",
+  prompt: "x",
+  repoPath: "/r",
+  baseBranch: "main",
+  branch: "shepherd/x",
+  worktreePath: "/wt",
+  isolated: true,
+  herdrSession: "default",
+  herdrAgentId: "T1",
+  agentProvider: "codex" as const,
+};
+
+function liveAgent(): HerdrAgent {
+  return {
+    agent: "codex",
+    agentStatus: "working",
+    cwd: "/wt",
+    name: "",
+    paneId: "p",
+    tabId: "t",
+    terminalId: "T1",
+    workspaceId: "w",
+  };
+}
+
+function makePoller(store: SessionStore, agents: HerdrAgent[], now: () => number) {
+  return new StatusPoller(
+    store,
+    { list: () => agents, read: () => "", readAsync: async () => "" } as never,
+    () => {},
+    () => {},
+    1000,
+    3000,
+    (() => null) as never,
+    now,
+  );
+}
+
+test("a never-matching capture backs off exponentially instead of scanning every tick", () => {
+  const store = new SessionStore(":memory:");
+  store.create(codexSession);
+  let clock = 1_000_000;
+  const poller = makePoller(store, [liveAgent()], () => clock);
+
+  let calls = 0;
+  poller.captureCodexSessionId = () => {
+    calls++;
+    return true; // always an applicable miss
+  };
+
+  poller.tick(); // attempt #1 → miss, next allowed at +2000ms
+  expect(calls).toBe(1);
+
+  poller.tick(); // no clock advance → still cooling down
+  expect(calls).toBe(1);
+
+  clock += 1999; // just before the 2000ms window
+  poller.tick();
+  expect(calls).toBe(1);
+
+  clock += 1; // window elapsed
+  poller.tick(); // attempt #2 → miss, next allowed at +4000ms
+  expect(calls).toBe(2);
+
+  clock += 2000; // 2000ms < the widened 4000ms window
+  poller.tick();
+  expect(calls).toBe(2);
+
+  clock += 2000; // 4000ms total → window elapsed
+  poller.tick(); // attempt #3
+  expect(calls).toBe(3);
+});
+
+test("a hit / non-applicable capture clears the back-off (next tick attempts immediately)", () => {
+  const store = new SessionStore(":memory:");
+  store.create(codexSession);
+  let clock = 1_000_000;
+  const poller = makePoller(store, [liveAgent()], () => clock);
+
+  let calls = 0;
+  let miss = true;
+  poller.captureCodexSessionId = () => {
+    calls++;
+    return miss;
+  };
+
+  poller.tick(); // miss → back-off set
+  expect(calls).toBe(1);
+
+  miss = false; // now reports non-applicable / seeded
+  clock += 2000;
+  poller.tick(); // window elapsed → attempts, returns false → clears entry
+  expect(calls).toBe(2);
+
+  poller.tick(); // no back-off entry → attempts again immediately (no clock advance)
+  expect(calls).toBe(3);
+});
+
+test("tick() never throws when the capture hook throws (fire-and-forget)", () => {
+  const store = new SessionStore(":memory:");
+  store.create(codexSession);
+  const poller = makePoller(store, [liveAgent()], () => 1_000_000);
+
+  poller.captureCodexSessionId = () => {
+    throw new Error("boom");
+  };
+
+  expect(() => poller.tick()).not.toThrow();
+});


### PR DESCRIPTION
Follow-up to #1475 (merged before its PR-critic review could be addressed on the branch). Applies the three critic findings against the now-merged Codex bring-back code. `[no-feature-entry]` — no user-facing UX.

## What

Addresses the PR-critic review of #1475:

1. **poller: negative-cache / exponential back-off for the session-id seed.** `captureCodexSessionId` scans the whole `$CODEX_HOME/sessions` tree; it ran every 1s tick for any live isolated Codex session that isn't yet seeded — including one that can *never* match (rollout GC'd, no `source=cli` header). Now `service.captureCodexSessionId` returns whether it was an applicable-but-missed attempt, and `StatusPoller.maybeCaptureCodexSessionId` widens the per-session rescan interval exponentially (2s → … → 120s cap) on consecutive misses. A hit / non-applicable session clears the entry; the map is pruned in `pruneInactive`.

2. **codex-session-id: `break`, not `continue`.** `listRolloutFiles` is newest-first by mtime, so the first file older than the window means every remaining file is too — `break` skips the older tail instead of scanning it.

3. **codex-session-id: comment fix.** The header said the cwd match is a "RAW string compare" but the code `normalize()`s both sides — corrected to "lexical `normalize()` compare".

## Testing

- New `test/poller-codex-capture.test.ts`: exponential back-off cadence, hit/non-applicable clears the back-off, tick() never throws when the hook throws.
- Root suite green (6130 pass), root lint clean, PR-hygiene gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)