### PR TITLE
fix(ui): avoid duplicate desktop session title

### DIFF
--- a/ui/src/lib/components/Viewport.browser.test.ts
+++ b/ui/src/lib/components/Viewport.browser.test.ts
@@ -229,16 +229,41 @@ describe("Viewport preview tab", () => {
 });
 
 describe("Viewport rename affordances", () => {
-  it("renders the session name in the normal desktop header and double-click opens rename", async () => {
+  const headerNameSlug = (value: string) =>
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+
+  it("renders a renamed session name once and double-click opens rename", async () => {
     const { container } = render(Viewport, {
-      session: session({ id: "rename-head", name: "visible session title" }),
+      session: session({
+        id: "rename-head",
+        name: "visible session title",
+        branch: "shepherd/visible-session-title",
+      }),
       previewPort: null,
       openPreviewTick: 0,
     });
 
-    const title = container.querySelector<HTMLElement>(".vp-head:not(.mobile) .vp-name");
+    const header = container.querySelector<HTMLElement>(".vp-head:not(.mobile)");
+    expect(header, "normal desktop header").not.toBeNull();
+    const title = header!.querySelector<HTMLElement>(".vp-name");
     expect(title, "normal desktop header title").not.toBeNull();
     expect(title!.textContent).toBe("visible session title");
+    expect(header!.querySelector(".vp-name + .sep")).toBeNull();
+
+    const visibleIdentityNodes = Array.from(
+      header!.querySelectorAll<HTMLElement>(".vp-name, .branch"),
+    );
+    expect(
+      visibleIdentityNodes.filter(
+        (node) => headerNameSlug(node.textContent ?? "") === "visible-session-title",
+      ),
+    ).toHaveLength(1);
+    expect(header!.querySelector<HTMLElement>(".branch")?.textContent).not.toBe(
+      "visible-session-title",
+    );
 
     title!.click();
     title!.click();
@@ -246,6 +271,26 @@ describe("Viewport rename affordances", () => {
     const input = page.getByRole("textbox", { name: m.viewport_rename_aria() });
     await expect.element(input).toBeInTheDocument();
     expect((input.element() as HTMLInputElement).value).toBe("visible session title");
+  });
+
+  it("keeps a distinct normal desktop branch label visible", () => {
+    const { container } = render(Viewport, {
+      session: session({
+        id: "rename-branch",
+        name: "visible session title",
+        branch: "feature/actual-work",
+      }),
+      previewPort: null,
+      openPreviewTick: 0,
+    });
+
+    const header = container.querySelector<HTMLElement>(".vp-head:not(.mobile)");
+    expect(header, "normal desktop header").not.toBeNull();
+    expect(header!.querySelector<HTMLElement>(".vp-name")?.textContent).toBe(
+      "visible session title",
+    );
+    expect(header!.querySelector<HTMLElement>(".vp-name + .sep")).not.toBeNull();
+    expect(header!.querySelector<HTMLElement>(".branch")?.textContent).toBe("feature/actual-work");
   });
 
   it("opens rename only for matching targeted requests", async () => {

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -186,11 +186,22 @@
   // Display-side status for every header/status render below (see display-status.ts).
   const dStatus = $derived(displayStatus(session, workingBlocked));
 
+  const headerNameSlug = (value: string) =>
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+
   // Branch label for the header: every session branch is cut as `shepherd/<name>`,
   // so the prefix is pure noise that only eats the truncation budget — strip it and
   // surface the descriptive tail (the part the user actually distinguishes by).
   const branchLabel = $derived(
     (session.branch ?? session.worktreePath)?.replace(/^shepherd\//, ""),
+  );
+  const branchRepeatsSessionName = $derived(
+    !!session.branch &&
+      !!branchLabel &&
+      headerNameSlug(branchLabel) === headerNameSlug(session.name),
   );
 
   const activityRecap = $derived(recaps.map[session.id]);
@@ -1984,7 +1995,7 @@
       {/if}
     {/if}
     {#if !compact}
-      {#if !renaming}
+      {#if !renaming && branchLabel && !branchRepeatsSessionName}
         <!-- hidden while the rename editor is open — the editor claims the full
              row width, so the branch label would only fight it for space -->
         <span class="sep">·</span>


### PR DESCRIPTION
## Summary
- Hide the desktop branch label when it is only the slugified form of the visible session name.
- Keep the existing desktop `.desig` / `.vp-name` markup and rename affordances unchanged.
- Add Viewport browser regressions for renamed-style duplicate branches and distinct branch labels.

## Testing
- `cd ui && bun run check` (passes; existing warnings in `CommandBar.svelte` and `FilesPanel.svelte`)
- `cd ui && bun run test:browser src/lib/components/Viewport.browser.test.ts` (passes, 25 tests)
- `cd ui && bun test` (fails/hangs in existing unrelated Bun test-runner harness issues, e.g. `$state is not defined`, `document is not defined`, `importOriginal is not a function`; terminated the hung process after failures were reported)
- `git diff --check`
