### PR TITLE
fix(ui): clarify new task attachment copy

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -255,9 +255,9 @@
   "issues_filter_all_assigned_to_others": "Alle offenen Issues sind anderen zugewiesen — zum Anzeigen ausschalten",
   "newtask_title": "Neue Aufgabe",
   "newtask_prompt_label": "Prompt",
-  "newtask_prompt_placeholder": "füge eine Funktion hinzu, die…",
+  "newtask_prompt_placeholder": "Beschreibe Feature, Fix oder Aufgabe…",
   "newtask_uploading": "Lädt hoch…",
-  "newtask_attach_image": "↥ Dateien anhängen",
+  "newtask_attach_image": "↥ Datei/Bild anhängen",
   "newtask_drop_hint": "oder Dateien hier ablegen",
   "newtask_remove_image_aria": "Anhang entfernen",
   "feat_task_attachments_title": "Dateien an neue Tasks anhängen",
@@ -2630,5 +2630,7 @@
   "feat_usage_gauge_provider_rotation_body": "Wenn Auslastungsdaten für Claude Code und Codex konfiguriert sind, wechselt die kompakte Anzeige in der Topbar jetzt alle zwei Minuten zwischen CC und CX. Codex zeigt Limit-Balken, sobald sie verfügbar sind, oder Token-Summen, bis die CLI Reset-Fenster meldet.",
   "plugins_repo": "REPO",
   "feat_codex_bring_back_title": "Codex-Sessions zurückholen",
-  "feat_codex_bring_back_body": "Zurückholen funktioniert jetzt auch für Codex-Sessions, nicht nur für Claude. Wähle eine abgeschlossene Codex-Session in der Fertig-Ansicht und klicke auf Zurückholen — Shepherd erstellt ihren Worktree neu und setzt das exakte Codex-Gespräch anhand seiner Session-ID fort. Nur isolierte Codex-Sessions können zurückgeholt werden; andere müssen weiterhin neu gestartet werden."
+  "feat_codex_bring_back_body": "Zurückholen funktioniert jetzt auch für Codex-Sessions, nicht nur für Claude. Wähle eine abgeschlossene Codex-Session in der Fertig-Ansicht und klicke auf Zurückholen — Shepherd erstellt ihren Worktree neu und setzt das exakte Codex-Gespräch anhand seiner Session-ID fort. Nur isolierte Codex-Sessions können zurückgeholt werden; andere müssen weiterhin neu gestartet werden.",
+  "newtask_drop_hint_keyboard": "oder Dateien hier ablegen oder ein Bild mit {shortcut} einfügen",
+  "newtask_upload_unknown_reason": "unbekannter Fehler"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -255,9 +255,9 @@
   "issues_filter_all_assigned_to_others": "All open issues are assigned to others — toggle off to see them",
   "newtask_title": "New Task",
   "newtask_prompt_label": "Prompt",
-  "newtask_prompt_placeholder": "add a feature that…",
+  "newtask_prompt_placeholder": "Describe the feature, fix, or task…",
   "newtask_uploading": "Uploading…",
-  "newtask_attach_image": "↥ Attach files",
+  "newtask_attach_image": "↥ Attach file/image",
   "newtask_drop_hint": "or drop files here",
   "newtask_remove_image_aria": "remove attachment",
   "feat_task_attachments_title": "Attach files to a new task",
@@ -2630,5 +2630,7 @@
   "feat_usage_gauge_provider_rotation_body": "When Claude Code and Codex usage data are both configured, the compact top-bar gauge now alternates every two minutes between CC and CX. Codex shows rate-limit bars when available, or token totals until the CLI reports reset windows.",
   "plugins_repo": "REPO",
   "feat_codex_bring_back_title": "Bring back Codex sessions",
-  "feat_codex_bring_back_body": "Bring back now works for Codex sessions too, not just Claude. Select a done Codex session in the Done lens and click Bring back — Shepherd re-creates its worktree and resumes the exact Codex conversation by its session id. Only isolated Codex sessions can be brought back; others still need a relaunch."
+  "feat_codex_bring_back_body": "Bring back now works for Codex sessions too, not just Claude. Select a done Codex session in the Done lens and click Bring back — Shepherd re-creates its worktree and resumes the exact Codex conversation by its session id. Only isolated Codex sessions can be brought back; others still need a relaunch.",
+  "newtask_drop_hint_keyboard": "or drop files here, or paste an image with {shortcut}",
+  "newtask_upload_unknown_reason": "unknown error"
 }

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
+import { overwriteGetLocale } from "$lib/paraglide/runtime";
 import type { Issue, RepoConfig, RepoEntry } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
 import {
@@ -116,7 +117,31 @@ beforeEach(() => {
   });
 });
 
-afterEach(() => {
+let matchMediaSpy: ReturnType<typeof vi.spyOn> | undefined;
+function mockPointer(coarse: boolean) {
+  const real = window.matchMedia.bind(window);
+  matchMediaSpy = vi.spyOn(window, "matchMedia").mockImplementation((query: string) => {
+    if (query === "(pointer: coarse)") {
+      return {
+        matches: coarse,
+        media: query,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+        onchange: null,
+      } as unknown as MediaQueryList;
+    }
+    return real(query);
+  });
+}
+
+afterEach(async () => {
+  matchMediaSpy?.mockRestore();
+  matchMediaSpy = undefined;
+  overwriteGetLocale(() => "en");
+  await page.viewport(1280, 900);
   document.body.innerHTML = "";
 });
 
@@ -166,6 +191,44 @@ describe("NewTask initialImages seed", () => {
 });
 
 describe("NewTask task attachments", () => {
+  it("shows file/image attach copy and the keyboard paste-image hint", async () => {
+    mockPointer(false);
+    render(NewTask, { props: base({ initialRepoPath: "/repo/attachments" }) });
+
+    await expect.element(page.getByPlaceholder(m.newtask_prompt_placeholder())).toBeInTheDocument();
+    await expect
+      .element(page.getByRole("button", { name: m.newtask_attach_image() }))
+      .toBeVisible();
+    await expect
+      .element(page.getByText(m.newtask_drop_hint_keyboard({ shortcut: "Ctrl+V" })))
+      .toBeVisible();
+  });
+
+  it("uses the short touch hint in coarse pointer contexts", async () => {
+    mockPointer(true);
+    render(NewTask, { props: base({ initialRepoPath: "/repo/attachments" }) });
+
+    await expect.element(page.getByText(m.newtask_drop_hint())).toBeVisible();
+    expect(page.getByText(m.newtask_drop_hint_keyboard({ shortcut: "Ctrl+V" })).query()).toBeNull();
+  });
+
+  it("keeps the longer German attachment row inside a mobile-width sheet", async () => {
+    await page.viewport(390, 800);
+    overwriteGetLocale(() => "de");
+    mockPointer(false);
+    render(NewTask, { props: base({ initialRepoPath: "/repo/attachments" }) });
+
+    await expect
+      .element(page.getByRole("button", { name: m.newtask_attach_image() }))
+      .toBeVisible();
+    await expect
+      .element(page.getByText(m.newtask_drop_hint_keyboard({ shortcut: "Ctrl+V" })))
+      .toBeVisible();
+
+    const row = document.querySelector<HTMLElement>(".attach-row")!;
+    expect(row.scrollWidth).toBeLessThanOrEqual(row.clientWidth);
+  });
+
   it("uploads a non-image file, renders a chip, and submits its staged path", async () => {
     mockUploadFile.mockResolvedValue("/staged/notes.md");
     const onsubmit = vi.fn().mockResolvedValue(undefined);

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -479,7 +479,7 @@
       if (isPreviewBlocked(err)) {
         error = (err as Error).message;
       } else {
-        error = m.newtask_upload_failed({ reason: reason(err, m.newtask_attach_image()) });
+        error = m.newtask_upload_failed({ reason: reason(err, m.newtask_upload_unknown_reason()) });
         retry = () => addFiles(uploads);
       }
     } finally {
@@ -896,7 +896,11 @@
         >
           {uploading ? m.newtask_uploading() : m.newtask_attach_image()}
         </button>
-        <span class="hint">{m.newtask_drop_hint()}</span>
+        <span class="hint">
+          {coarse.current
+            ? m.newtask_drop_hint()
+            : m.newtask_drop_hint_keyboard({ shortcut: isMac ? "⌘V" : "Ctrl+V" })}
+        </span>
       </div>
       {#if relaunch}
         <span class="hint attach-relaunch-note">{m.newtask_relaunch_image_note()}</span>
@@ -1379,6 +1383,7 @@
   .attach-row {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 8px;
     margin-top: 4px;
   }
@@ -1398,7 +1403,10 @@
     cursor: default;
   }
   .hint {
+    flex: 1 1 18ch;
+    min-width: 0;
     font-size: var(--fs-meta);
+    line-height: 1.35;
     color: var(--color-muted);
   }
   .repo-shortcuts-hint {

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -1403,11 +1403,13 @@
     cursor: default;
   }
   .hint {
-    flex: 1 1 18ch;
-    min-width: 0;
     font-size: var(--fs-meta);
     line-height: 1.35;
     color: var(--color-muted);
+  }
+  .attach-row .hint {
+    flex: 1 1 18ch;
+    min-width: 0;
   }
   .repo-shortcuts-hint {
     display: block;


### PR DESCRIPTION
## Summary
- Broaden the New Task prompt placeholder beyond future-feature wording
- Rename the attach button to file/image and surface paste-image support only on keyboard-capable contexts
- Decouple upload error fallback copy from the attach button and cover English/German/mobile layout in browser tests

## Tests
- cd ui && bun run check:i18n
- cd ui && bun run check
- cd ui && bun run test:browser -- NewTask.browser.test.ts
- cd ui && bun run test:node
- cd ui && bun run test:browser
- cd ui && bun run test