### PR TITLE
fix(ui): scope done lens to repo filter

### DIFF
--- a/ui/src/lib/done-filter.test.ts
+++ b/ui/src/lib/done-filter.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+import type { Session } from "./types";
+import {
+  doneRailIds,
+  doneSessionsForRepoFilter,
+  nextDoneSelectedId,
+  resolveDoneSelected,
+} from "./done-filter";
+
+function session(id: string, repoPath: string): Session {
+  return { id, repoPath } as Session;
+}
+
+const done = [
+  session("shep-1", "/repo/shepherd"),
+  session("shopify-1", "/repo/epamano-shopify"),
+  session("theme-1", "/repo/epamano-shopifytheme"),
+  session("shep-2", "/repo/shepherd"),
+];
+
+describe("doneSessionsForRepoFilter", () => {
+  test("empty repo filter keeps every recent done session", () => {
+    expect(doneSessionsForRepoFilter(done, new Set()).map((s) => s.id)).toEqual([
+      "shep-1",
+      "shopify-1",
+      "theme-1",
+      "shep-2",
+    ]);
+  });
+
+  test("single repo filter keeps only matching repoPath sessions", () => {
+    expect(doneSessionsForRepoFilter(done, new Set(["/repo/shepherd"])).map((s) => s.id)).toEqual([
+      "shep-1",
+      "shep-2",
+    ]);
+  });
+
+  test("multi repo filter keeps sessions from any selected repo", () => {
+    expect(
+      doneSessionsForRepoFilter(
+        done,
+        new Set(["/repo/epamano-shopify", "/repo/epamano-shopifytheme"]),
+      ).map((s) => s.id),
+    ).toEqual(["shopify-1", "theme-1"]);
+  });
+});
+
+describe("Done selection and keynav lists", () => {
+  test("resolveDoneSelected cannot resolve a session hidden by the filtered list", () => {
+    const filtered = doneSessionsForRepoFilter(done, new Set(["/repo/shepherd"]));
+    expect(resolveDoneSelected(filtered, "shopify-1")).toBeNull();
+    expect(resolveDoneSelected(filtered, "shep-2")?.id).toBe("shep-2");
+  });
+
+  test("nextDoneSelectedId preserves a visible selection", () => {
+    const filtered = doneSessionsForRepoFilter(done, new Set(["/repo/shepherd"]));
+    expect(nextDoneSelectedId(filtered, "shep-2")).toBe("shep-2");
+  });
+
+  test("nextDoneSelectedId moves to the first visible row when current selection is filtered out", () => {
+    const filtered = doneSessionsForRepoFilter(done, new Set(["/repo/shepherd"]));
+    expect(nextDoneSelectedId(filtered, "shopify-1")).toBe("shep-1");
+  });
+
+  test("nextDoneSelectedId clears when the active repo filter has no done rows", () => {
+    const filtered = doneSessionsForRepoFilter(done, new Set(["/repo/missing"]));
+    expect(nextDoneSelectedId(filtered, "shep-1")).toBeNull();
+  });
+
+  test("doneRailIds returns only filtered ids for Done keyboard navigation", () => {
+    const filtered = doneSessionsForRepoFilter(done, new Set(["/repo/shepherd"]));
+    expect(doneRailIds(filtered)).toEqual(["shep-1", "shep-2"]);
+  });
+});

--- a/ui/src/lib/done-filter.ts
+++ b/ui/src/lib/done-filter.ts
@@ -1,0 +1,26 @@
+import type { Session } from "./types";
+
+export function doneSessionsForRepoFilter(
+  sessions: Session[],
+  repoFilter: ReadonlySet<string>,
+): Session[] {
+  if (repoFilter.size === 0) return sessions;
+  return sessions.filter((s) => repoFilter.has(s.repoPath));
+}
+
+export function resolveDoneSelected(
+  sessions: Session[],
+  selectedId: string | null,
+): Session | null {
+  return sessions.find((s) => s.id === selectedId) ?? null;
+}
+
+export function nextDoneSelectedId(sessions: Session[], selectedId: string | null): string | null {
+  if (sessions.length === 0) return null;
+  if (sessions.some((s) => s.id === selectedId)) return selectedId;
+  return sessions[0].id;
+}
+
+export function doneRailIds(sessions: Session[]): string[] {
+  return sessions.map((s) => s.id);
+}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -86,6 +86,12 @@
   import { upNext } from "$lib/up-next.svelte";
   import { claudeUsageHoldLikely } from "$lib/provider-capacity";
   import { doneSessions } from "$lib/done.svelte";
+  import {
+    doneRailIds,
+    doneSessionsForRepoFilter,
+    nextDoneSelectedId,
+    resolveDoneSelected,
+  } from "$lib/done-filter";
   import { postMergeSteps as postMergeStepsStore } from "$lib/post-merge-steps.svelte";
   import { learnings } from "$lib/learnings.svelte";
   import TopBar from "$lib/components/TopBar.svelte";
@@ -1403,8 +1409,9 @@
   // (the live list), which has EVICTED archived sessions — so reusing it for a done
   // (archived) id would break. doneSelectedId tracks the picked done row instead.
   let doneSelectedId = $state<string | null>(null);
-  // The currently-selected done session (resolved against the lazy doneSessions list).
-  const doneSelected = $derived(doneSessions.sessions.find((s) => s.id === doneSelectedId) ?? null);
+  const shownDoneSessions = $derived(doneSessionsForRepoFilter(doneSessions.sessions, repoFilter));
+  // The currently-selected done session (resolved against the filtered lazy done list).
+  const doneSelected = $derived(resolveDoneSelected(shownDoneSessions, doneSelectedId));
   // Entering the Done lens lazy-loads the archived session list + repopulates the
   // shared recaps store (archived recaps persist server-side; live events dropped the
   // session's recap, /api/recaps returns it). Both are best-effort / self-handling.
@@ -1435,12 +1442,7 @@
   });
   $effect(() => {
     if (herdFilter !== "done") return;
-    const list = doneSessions.sessions;
-    if (list.length === 0) {
-      doneSelectedId = null;
-    } else if (!list.some((s) => s.id === doneSelectedId)) {
-      doneSelectedId = list[0].id;
-    }
+    doneSelectedId = nextDoneSelectedId(shownDoneSessions, doneSelectedId);
   });
 
   // The herd rail's visible session order (same shown set + partition + group
@@ -1451,7 +1453,7 @@
     // The Done lens is its own navigation space (archived rows, not live `sessions`),
     // so j/k/1-9 walk the done list and select via doneSelectedId — never the hidden
     // live partition.
-    if (herdFilter === "done") return doneSessions.sessions.map((s) => s.id);
+    if (herdFilter === "done") return doneRailIds(shownDoneSessions);
     return railOrder(
       herdSessions,
       store.git,
@@ -2772,7 +2774,7 @@
             completedEpics={completedEpicsShown}
             ondismissepic={onDismissEpic}
             onlandepic={onLandEpic}
-            doneList={doneSessions.sessions}
+            doneList={shownDoneSessions}
             {doneSelectedId}
             ondoneselect={(id) => {
               doneSelectedId = id;
@@ -2938,7 +2940,7 @@
               completedEpics={completedEpicsShown}
               ondismissepic={onDismissEpic}
               onlandepic={onLandEpic}
-              doneList={doneSessions.sessions}
+              doneList={shownDoneSessions}
               {doneSelectedId}
               ondoneselect={(id) => (doneSelectedId = id)}
               onrundownitem={selectRundownItem}


### PR DESCRIPTION
## Summary

- Scope the Done lens session list to the active repo filter in `+page.svelte`.
- Share that filtered Done list across Done recap selection, auto-selection, and keyboard navigation ids.
- Add focused helper coverage for empty, single, and multi-repo filters plus Done selection/keynav behavior.

Closes #

## Verification

- `cd ui && bun run test -- done-filter.test.ts`
- `cd ui && bun run check` (passes with two unrelated existing Svelte warnings in `CommandBar.svelte` and `FilesPanel.svelte`)
- `cd ui && bun run test` (218 files, 3007 tests passed)
- `git push` pre-push hook passed: prettier, eslint, gates, tsc, ext, root-tests, ui, fallow audit. Fallow reported inherited duplication warnings and no issues in the 3 changed files.

## Checklist

- [x] Conventional-commit PR title (`fix(ui): scope done lens to repo filter`).
- [x] Branch is cut from latest `main` and kept linear.
- [x] Relevant UI checks/tests pass.
- [x] No new user-facing text.
- [x] No feature announcement needed; this is a bug fix, not a new feature.
- [x] No docs needed; no public API, config, or CLI behavior changed.