### PR TITLE
feat(ui): compare coding cli capacity

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2690,5 +2690,12 @@
   "tasktip_inherit": "Geerbt",
   "tasktip_egress_applied": "Egress-Allowlist",
   "feat_session_tooltip_title": "Vollständige Startdetails",
-  "feat_session_tooltip_body": "Bewege den Mauszeiger über die Task-ID oberhalb des Terminals, um Prompt, Issue, angehängte Dateinamen, Branch, Start-Checkboxen, Coding-CLI, Modell, Aufwand und Sandbox-Status zu sehen."
+  "feat_session_tooltip_body": "Bewege den Mauszeiger über die Task-ID oberhalb des Terminals, um Prompt, Issue, angehängte Dateinamen, Branch, Start-Checkboxen, Coding-CLI, Modell, Aufwand und Sandbox-Status zu sehen.",
+  "newtask_provider_capacity_aria": "Kapazitätsvergleich der Coding-CLI",
+  "newtask_provider_capacity_title": "Verbleibender Spielraum",
+  "newtask_provider_capacity_meter_aria": "{provider} hat {free}% frei",
+  "newtask_provider_capacity_free": "{pct}% frei",
+  "newtask_provider_capacity_unavailable": "Keine Nutzungsfenster-Daten",
+  "feat_provider_capacity_gauge_title": "Vergleiche die Coding-CLI-Kapazität vor der Auswahl",
+  "feat_provider_capacity_gauge_body": "Das Neue-Aufgabe-Formular zeigt Claude Code und Codex jetzt nebeneinander mit ihrem verbleibenden Spielraum unter dem Coding-CLI-Auswahlfeld, damit du vor dem Starten eines Laufs den Provider mit der größten Reserve wählen kannst."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2690,5 +2690,12 @@
   "tasktip_inherit": "Inherited",
   "tasktip_egress_applied": "Egress allowlist",
   "feat_session_tooltip_title": "Full task launch details",
-  "feat_session_tooltip_body": "Hover the task id above the terminal to see the prompt, issue, attached file names, branch, launch checkboxes, coding CLI, model, effort, and sandbox state."
+  "feat_session_tooltip_body": "Hover the task id above the terminal to see the prompt, issue, attached file names, branch, launch checkboxes, coding CLI, model, effort, and sandbox state.",
+  "newtask_provider_capacity_aria": "Coding CLI capacity comparison",
+  "newtask_provider_capacity_title": "Remaining room",
+  "newtask_provider_capacity_meter_aria": "{provider} has {free}% free",
+  "newtask_provider_capacity_free": "{pct}% free",
+  "newtask_provider_capacity_unavailable": "No usage-window data",
+  "feat_provider_capacity_gauge_title": "Compare Coding CLI capacity before you pick",
+  "feat_provider_capacity_gauge_body": "The New Task form now shows Claude Code and Codex side by side with their remaining usage room below the Coding CLI selector, so you can choose the provider with the most headroom before you start a run."
 }

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -4,6 +4,7 @@ import { page } from "vitest/browser";
 import "../../app.css";
 import { overwriteGetLocale } from "$lib/paraglide/runtime";
 import type { Issue, RepoConfig, RepoEntry } from "$lib/types";
+import type { UsageLimits } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
 import {
   listIssues,
@@ -149,6 +150,43 @@ const base = (extra: Record<string, unknown> = {}) => ({
   onsubmit: vi.fn(),
   ...extra,
 });
+
+function capacityLimits(codexWindows: { session5h?: boolean; week?: boolean } = {}) {
+  const codex = {
+    provider: "codex" as const,
+    kind: "tokens" as const,
+    totalTokens: 12_000,
+    session5hTokens: 1_000,
+    weekTokens: 9_000,
+    updatedAt: 123,
+    stale: false,
+    session5h: codexWindows.session5h === false ? null : { pct: 20, resetAt: 0 },
+    week: codexWindows.week === false ? null : { pct: 80, resetAt: 0 },
+  };
+  return {
+    session5h: { pct: 30, resetAt: 0 },
+    week: { pct: 60, resetAt: 0 },
+    perModelWeek: [],
+    credits: null,
+    stale: false,
+    calibratedAt: null,
+    subscriptionOnly: false,
+    providers: [
+      {
+        provider: "claude" as const,
+        kind: "limits" as const,
+        session5h: { pct: 30, resetAt: 0 },
+        week: { pct: 60, resetAt: 0 },
+        perModelWeek: [],
+        credits: null,
+        stale: false,
+        calibratedAt: null,
+        subscriptionOnly: false,
+      },
+      codex,
+    ],
+  } satisfies UsageLimits;
+}
 
 describe("NewTask initialImages seed", () => {
   it("renders a removable chip per seeded attachment", async () => {
@@ -311,6 +349,39 @@ describe("NewTask task attachments", () => {
     await expect.element(page.getByText("drop.md")).toBeInTheDocument();
   });
 });
+
+describe("NewTask provider capacity gauge", () => {
+  it("renders both providers with remaining room below the Coding CLI selector", async () => {
+    render(NewTask, {
+      props: base({
+        initialRepoPath: "/repo",
+        usageLimits: capacityLimits(),
+      }),
+    });
+
+    await expect.element(page.getByText(m.newtask_provider_capacity_title())).toBeInTheDocument();
+    await expect.poll(() => document.querySelectorAll(".pcap-row").length).toBe(2);
+
+    const rows = Array.from(document.querySelectorAll<HTMLElement>(".pcap-row"));
+    expect(rows[0]?.textContent).toContain(m.newtask_provider_capacity_free({ pct: 40 }));
+    expect(rows[1]?.textContent).toContain(m.newtask_provider_capacity_free({ pct: 20 }));
+  });
+
+  it("shows Codex as unavailable when rollout limits are missing", async () => {
+    render(NewTask, {
+      props: base({
+        initialRepoPath: "/repo",
+        usageLimits: capacityLimits({ session5h: false, week: false }),
+      }),
+    });
+
+    await expect.poll(() => document.querySelectorAll(".pcap-row").length).toBe(2);
+    const rows = Array.from(document.querySelectorAll<HTMLElement>(".pcap-row"));
+    expect(rows[1]?.textContent).toContain(m.newtask_provider_capacity_unavailable());
+    expect(rows[1]?.textContent).not.toContain("100%");
+  });
+});
+
 describe("NewTask issue picker epic-parent rows", () => {
   function issue(number: number, title: string, labels: string[] = []): Issue {
     return {

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -380,6 +380,23 @@ describe("NewTask provider capacity gauge", () => {
     expect(rows[1]?.textContent).toContain(m.newtask_provider_capacity_unavailable());
     expect(rows[1]?.textContent).not.toContain("100%");
   });
+
+  it("wraps the gauge rows on narrow widths instead of overflowing the field", async () => {
+    await page.viewport(390, 800);
+    render(NewTask, {
+      props: base({
+        initialRepoPath: "/repo",
+        usageLimits: capacityLimits(),
+      }),
+    });
+
+    await expect.poll(() => document.querySelectorAll(".pcap-row").length).toBe(2);
+
+    const rows = Array.from(document.querySelectorAll<HTMLElement>(".pcap-row"));
+    for (const row of rows) {
+      expect(row.scrollWidth).toBeLessThanOrEqual(row.clientWidth);
+    }
+  });
 });
 
 describe("NewTask issue picker epic-parent rows", () => {

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -35,6 +35,7 @@
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
   import { m } from "$lib/paraglide/messages";
   import { recentRepos } from "$lib/recentRepos";
+  import type { UsageLimits } from "$lib/types";
 
   let {
     onsubmit,
@@ -60,6 +61,7 @@
     initialAutopilot,
     initialSandboxProfile,
     initialResearch = false,
+    usageLimits = null,
     holdLikely = false,
     fableAvailable = true,
   }: {
@@ -108,6 +110,7 @@
     initialAutopilot?: boolean | null;
     initialSandboxProfile?: SandboxProfile | null;
     initialResearch?: boolean;
+    usageLimits?: UsageLimits | null;
     holdLikely?: boolean;
     fableAvailable?: boolean;
   } = $props();
@@ -1024,6 +1027,7 @@
         {autopilotLoading}
         {autopilotDefault}
         {repoPath}
+        {usageLimits}
         {relaunch}
         {fableAvailable}
       />

--- a/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
+++ b/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
@@ -5,11 +5,13 @@
   import { modelOptionLabel } from "$lib/model-guidance";
   import ModelGuidance from "$lib/components/ModelGuidance.svelte";
   import GlossaryText from "$lib/components/GlossaryText.svelte";
+  import ProviderCapacityGauge from "./ProviderCapacityGauge.svelte";
   import {
     AGENT_PROVIDERS,
     CODEX_MODELS,
     type AgentProvider,
     type SandboxProfile,
+    type UsageLimits,
   } from "$lib/types";
   import { providerModels, modelAvailableForProvider } from "$lib/provider-models";
   import { providerEfforts, effortLabel, effortAvailableForProvider } from "$lib/effort-guidance";
@@ -30,6 +32,7 @@
     autopilotLoading,
     autopilotDefault,
     repoPath,
+    usageLimits = null,
     relaunch,
     holdLikely,
     fableAvailable,
@@ -51,6 +54,7 @@
     autopilotLoading: boolean;
     autopilotDefault: boolean;
     repoPath: string;
+    usageLimits?: UsageLimits | null;
     relaunch: boolean;
     holdLikely: boolean;
     fableAvailable: boolean;
@@ -190,6 +194,7 @@
           </option>
         {/each}
       </select>
+      <ProviderCapacityGauge limits={usageLimits} />
     </div>
 
     <div class="model-field" use:coachTarget={"model-1m-context"}>

--- a/ui/src/lib/components/new-task/ProviderCapacityGauge.svelte
+++ b/ui/src/lib/components/new-task/ProviderCapacityGauge.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import { gaugeColor, providerCapacityRows } from "$lib/components/usage-gauges";
+  import type { UsageLimits } from "$lib/types";
+
+  let { limits = null }: { limits?: UsageLimits | null } = $props();
+
+  const rows = $derived(providerCapacityRows(limits));
+</script>
+
+<div class="pcap" aria-label={m.newtask_provider_capacity_aria()}>
+  <div class="pcap-head micro">{m.newtask_provider_capacity_title()}</div>
+  <div class="pcap-list">
+    {#each rows as row (row.provider)}
+      <div class="pcap-row" class:stale={row.stale}>
+        <span class="pcap-label">
+          {row.provider === "claude" ? m.agent_provider_claude() : m.agent_provider_codex()}
+        </span>
+        {#if row.available && row.remainingPct != null && row.usedPct != null}
+          <span
+            class="pcap-bar"
+            role="meter"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={row.remainingPct}
+            aria-valuetext={m.newtask_provider_capacity_meter_aria({
+              provider:
+                row.provider === "claude" ? m.agent_provider_claude() : m.agent_provider_codex(),
+              free: row.remainingPct,
+            })}
+          >
+            <span
+              class="pcap-fill"
+              style="width:{row.remainingPct}%;background:{gaugeColor(row.usedPct)}"
+            ></span>
+          </span>
+          <span class="pcap-value"
+            >{m.newtask_provider_capacity_free({ pct: row.remainingPct })}</span
+          >
+        {:else}
+          <span class="pcap-miss">{m.newtask_provider_capacity_unavailable()}</span>
+        {/if}
+      </div>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .pcap {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .pcap-head {
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .pcap-list {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .pcap-row {
+    display: grid;
+    grid-template-columns: minmax(5.5rem, 7rem) minmax(0, 1fr) auto;
+    gap: 8px;
+    align-items: center;
+    min-width: 0;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .pcap-row.stale {
+    opacity: 0.55;
+  }
+
+  .pcap-label,
+  .pcap-value,
+  .pcap-miss {
+    font-size: var(--fs-meta);
+    min-width: 0;
+  }
+
+  .pcap-label {
+    color: var(--color-ink-bright);
+  }
+
+  .pcap-value {
+    color: var(--color-muted);
+    white-space: nowrap;
+  }
+
+  .pcap-miss {
+    color: var(--color-faint);
+    white-space: nowrap;
+  }
+
+  .pcap-bar {
+    display: block;
+    width: 100%;
+    height: 6px;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line-bright);
+    overflow: hidden;
+  }
+
+  .pcap-fill {
+    display: block;
+    height: 100%;
+    transition: width 0.2s ease;
+  }
+</style>

--- a/ui/src/lib/components/new-task/ProviderCapacityGauge.svelte
+++ b/ui/src/lib/components/new-task/ProviderCapacityGauge.svelte
@@ -47,6 +47,7 @@
 
 <style>
   .pcap {
+    container-type: inline-size;
     display: flex;
     flex-direction: column;
     gap: 6px;
@@ -113,5 +114,18 @@
     display: block;
     height: 100%;
     transition: width 0.2s ease;
+  }
+
+  @container (max-width: 16rem) {
+    .pcap-row {
+      grid-template-columns: minmax(0, 1fr);
+      gap: 4px;
+      align-items: start;
+    }
+
+    .pcap-value,
+    .pcap-miss {
+      white-space: normal;
+    }
   }
 </style>

--- a/ui/src/lib/components/page/AppOverlays.svelte
+++ b/ui/src/lib/components/page/AppOverlays.svelte
@@ -36,6 +36,7 @@
     Settings as Settings_,
     StarPromptStatus,
     Steer,
+    UsageLimits,
   } from "$lib/types";
   import type { FeatureAnnouncement } from "$lib/feature-announcements";
   import LearningsDrawer from "$lib/components/LearningsDrawer.svelte";
@@ -128,6 +129,7 @@
     composeAutopilot,
     composeSandbox,
     composeResearch,
+    usageLimits = null,
     holdLikely,
     onnewclose,
     onnewclone,
@@ -248,6 +250,7 @@
     composeAutopilot: boolean | null;
     composeSandbox: SandboxProfile | null;
     composeResearch: boolean;
+    usageLimits?: UsageLimits | null;
     holdLikely: boolean;
     onnewclose: () => void;
     onnewclone: () => void;
@@ -504,6 +507,7 @@
     initialAutopilot={composeAutopilot}
     initialSandboxProfile={composeSandbox}
     initialResearch={composeResearch}
+    {usageLimits}
     defaultAgentProvider={newTaskDefaultAgentProvider}
     defaultModel={settings?.defaultModel}
     defaultEffort={newTaskDefaultEffort}

--- a/ui/src/lib/components/usage-gauges.test.ts
+++ b/ui/src/lib/components/usage-gauges.test.ts
@@ -7,6 +7,7 @@ import {
   overspending,
   providerSnapshots,
   gaugeColor,
+  providerCapacityRows,
 } from "./usage-gauges";
 import type { UsageLimits, LimitWindow, CreditWindow } from "../types";
 
@@ -281,5 +282,93 @@ describe("overspending", () => {
   it("is false when credits is null or limits is null", () => {
     expect(overspending(limits({ credits: null }))).toBe(false);
     expect(overspending(null)).toBe(false);
+  });
+});
+
+describe("providerCapacityRows", () => {
+  it("derives remaining room from the hottest available provider windows", () => {
+    const l = limits({
+      session5h: w(30),
+      week: w(60),
+      providers: [
+        {
+          provider: "claude",
+          kind: "limits",
+          session5h: w(30),
+          week: w(60),
+          perModelWeek: [],
+          credits: null,
+          stale: false,
+          calibratedAt: null,
+          subscriptionOnly: false,
+        },
+        {
+          provider: "codex",
+          kind: "tokens",
+          totalTokens: 12_000,
+          session5hTokens: 1_000,
+          weekTokens: 9_000,
+          updatedAt: 123,
+          stale: false,
+          session5h: w(20),
+          week: w(80),
+        },
+      ],
+    });
+
+    expect(providerCapacityRows(l)).toEqual([
+      {
+        provider: "claude",
+        usedPct: 60,
+        remainingPct: 40,
+        available: true,
+        stale: false,
+      },
+      {
+        provider: "codex",
+        usedPct: 80,
+        remainingPct: 20,
+        available: true,
+        stale: false,
+      },
+    ]);
+  });
+
+  it("marks Codex unavailable when no rollout limit windows exist", () => {
+    const l = limits({
+      session5h: w(30),
+      week: w(60),
+      providers: [
+        {
+          provider: "claude",
+          kind: "limits",
+          session5h: w(30),
+          week: w(60),
+          perModelWeek: [],
+          credits: null,
+          stale: false,
+          calibratedAt: null,
+          subscriptionOnly: false,
+        },
+        {
+          provider: "codex",
+          kind: "tokens",
+          totalTokens: 12_000,
+          session5hTokens: 1_000,
+          weekTokens: 9_000,
+          updatedAt: 123,
+          stale: false,
+          session5h: null,
+          week: null,
+        },
+      ],
+    });
+
+    expect(providerCapacityRows(l)[1]).toMatchObject({
+      provider: "codex",
+      available: false,
+      usedPct: null,
+      remainingPct: null,
+    });
   });
 });

--- a/ui/src/lib/components/usage-gauges.ts
+++ b/ui/src/lib/components/usage-gauges.ts
@@ -5,6 +5,7 @@ import type {
   UsageProviderSnapshot,
   CreditWindow,
 } from "../types";
+import type { AgentProvider } from "../types";
 
 export type GaugeKey = "5H" | "WK";
 
@@ -217,4 +218,51 @@ export function gaugeColor(pct: number): string {
 export function overspending(limits: UsageLimits | null): boolean {
   const c = limits?.credits;
   return !!c && !c.stale && c.spent > 0;
+}
+
+export interface ProviderCapacityRow {
+  provider: AgentProvider;
+  usedPct: number | null;
+  remainingPct: number | null;
+  available: boolean;
+  stale: boolean;
+}
+
+function capPct(v: number): number {
+  return Math.min(Math.max(v, 0), 100);
+}
+
+function remainingFromUsed(usedPct: number | null): number | null {
+  return usedPct == null ? null : Math.max(0, 100 - usedPct);
+}
+
+function hottestUsedPct(windows: Gauge[]): number | null {
+  if (!windows.length) return null;
+  return Math.max(...windows.map((g) => capPct(g.w.pct)));
+}
+
+export function providerCapacityRows(limits: UsageLimits | null): ProviderCapacityRow[] {
+  const claudeWindows = gaugeList(limits);
+  const codexUsage = codexTokenUsage(limits);
+  const codexWindows = codexGaugeList(codexUsage);
+
+  const claudeUsedPct = hottestUsedPct(claudeWindows);
+  const codexUsedPct = hottestUsedPct(codexWindows);
+
+  return [
+    {
+      provider: "claude",
+      usedPct: claudeUsedPct,
+      remainingPct: remainingFromUsed(claudeUsedPct),
+      available: claudeUsedPct != null,
+      stale: limits?.stale ?? false,
+    },
+    {
+      provider: "codex",
+      usedPct: codexUsedPct,
+      remainingPct: remainingFromUsed(codexUsedPct),
+      available: codexUsedPct != null,
+      stale: codexUsage?.stale ?? false,
+    },
+  ];
 }

--- a/ui/src/lib/feature-announcements/entries/v1.43.0-provider-capacity-gauge.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.43.0-provider-capacity-gauge.ts
@@ -1,0 +1,12 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // The New Task form now compares Claude Code and Codex capacity side by side so operators can
+  // pick the provider with the most remaining room before starting a run.
+  id: "provider-capacity-gauge",
+  sinceVersion: "1.43.0",
+  titleKey: "feat_provider_capacity_gauge_title",
+  bodyKey: "feat_provider_capacity_gauge_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -2876,6 +2876,7 @@
   {composeAutopilot}
   {composeSandbox}
   {composeResearch}
+  usageLimits={store.usageLimits}
   holdLikely={composeHoldLikely}
   onnewclose={() => {
     showNew = false;


### PR DESCRIPTION
## Summary\n- Adds a compact remaining-room gauge under New Task's Coding CLI selector\n- Compares Claude Code and Codex side by side using existing usage snapshots\n- Threads live usage limits into the New Task overlay stack and adds i18n, tests, and a feature-announcement entry\n\n## Verification\n- cd ui && bun run check:i18n\n- cd ui && bun run check\n- cd ui && bun run test:browser src/lib/components/NewTask.browser.test.ts