### PR TITLE
fix(triage): skip triage bot for repo-privileged authors

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -98,6 +98,54 @@ jobs:
           d="ghenv_$(openssl rand -hex 16)"
           { echo "ISSUE_BODY<<$d"; printf '%s\n' "$body"; echo "$d"; } >> "$GITHUB_ENV"
 
+      # Authoritative maintainer gate. The job-level `if` above uses the webhook's
+      # author_association, which GitHub reports as NONE/CONTRIBUTOR for members whose
+      # org membership is PRIVATE — so a private-membership maintainer slips the gate
+      # (see issue #1493). Re-derive the author's EFFECTIVE repo role via GITHUB_TOKEN's
+      # implicit Metadata:read (repo permission is not membership-visibility-gated, unlike
+      # author_association). Fail closed: only a provably unprivileged author (role
+      # read/none) proceeds to triage; anything else — including custom repository roles —
+      # is treated as a maintainer and skipped. Runs on manual dispatch too (log-only there:
+      # dispatch is forced dry-run and bypasses the skip via the classify `if`).
+      - name: Authoritative author check (repo permission)
+        id: maintainer
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          AUTHOR: ${{ steps.issue.outputs.author }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+        run: |
+          set -euo pipefail
+          emit() { echo "is_maintainer=$1" >> "$GITHUB_OUTPUT"; echo "$2"; exit 0; }
+          # Diagnostic: read author_association via GITHUB_TOKEN so the "installation token
+          # sees CONTRIBUTOR, not MEMBER, for a private member" premise is confirmed in-run,
+          # not assumed. Log-only — it never gates.
+          assoc=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '.author_association' 2>/dev/null || echo '?')
+          echo "diagnostic: author_association (via GITHUB_TOKEN) = ${assoc}"
+          # AUTHOR arrives via env (login charset [A-Za-z0-9-], <=39 — URL/JSON-safe). curl
+          # (no --fail) captures the HTTP status for any response; a network error trips 000.
+          code=$(curl -sS -o resp.json -w '%{http_code}' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${REPO}/collaborators/${AUTHOR}/permission" 2>/dev/null || echo 000)
+          role=$(jq -r '.role_name // .permission // "none"' resp.json 2>/dev/null || echo none)
+          case "$code" in
+            # Proceed ONLY for a provably unprivileged author; skip everything else so a
+            # custom repository role can never fall through to triage.
+            200)
+              case "$role" in
+                read | none) emit false "author ${AUTHOR} has repo role '${role}' — proceed" ;;
+                *) emit true "author ${AUTHOR} has repo role '${role}' — skip triage" ;;
+              esac
+              ;;
+            404) emit false "author ${AUTHOR} is not a collaborator (404) — proceed" ;;
+            # Fail closed: never auto-triage when a maintainer can't be ruled out. A
+            # PERSISTENT 403 means GITHUB_TOKEN can't read this endpoint — verify via a
+            # manual dispatch before relying on this gate.
+            *) emit true "permission lookup inconclusive (HTTP ${code}) — skipping (fail-closed)" ;;
+          esac
+
       # Authoritative idempotency + best-effort abuse guard, both UNPAID. The
       # event payload's labels are frozen at open time and never carry the marker,
       # so we query the issue's CURRENT labels here to gate re-runs. (A manual
@@ -153,6 +201,7 @@ jobs:
           || (
             steps.preflight.outputs.already_triaged != 'true'
             && steps.preflight.outputs.author_burst != 'true'
+            && steps.maintainer.outputs.is_maintainer != 'true'
           )
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -169,6 +218,7 @@ jobs:
         if: >-
           github.event_name != 'workflow_dispatch'
           && steps.preflight.outputs.already_triaged != 'true'
+          && steps.maintainer.outputs.is_maintainer != 'true'
           && steps.app-token.outputs.token != ''
           && vars.ISSUE_BOT_DRY_RUN == 'false'
           && steps.triage.outputs.decision != ''


### PR DESCRIPTION
## Problem

The issue-triage bot triaged **#1493** — authored by a repo **admin** (Kai) — spending a paid Haiku call, adding `bot-triaged`/`enhancement` labels, and posting a public disclosed comment. Maintainers must never be auto-triaged.

**Root cause:** the `triage` job gate trusts the webhook field `github.event.issue.author_association`, which GitHub reports as `NONE`/`CONTRIBUTOR` for members whose org membership is **private** (a documented quirk). Kai's membership is private, so the payload said non-member and the gate passed (run `28790053486` ran Classify **and** Apply).

## Fix

Add an authoritative **repo-permission** check (`collaborators/{author}/permission`) read with `GITHUB_TOKEN`'s implicit `Metadata: read`. Repo permission is **not** membership-visibility-gated (unlike `author_association`), so it is truthful for a private member. **Fail closed:** only a provably unprivileged author (role `read`/`none`) proceeds to triage; `admin`/`write`/`maintain`/`triage` **and any custom repository role** are treated as a maintainer and skipped. The gate wraps both the paid classify step and the live label/comment step. The check also logs the `author_association` value read via `GITHUB_TOKEN` as an in-run diagnostic.

Why this route over re-reading `author_association` via REST: that value is itself visibility-gated — verified live, the same issue returns `MEMBER` to an org-member token but **`CONTRIBUTOR` unauthenticated** (the visibility class of the non-member `GITHUB_TOKEN`), so it would silently reproduce the bug. Repo permission is not, and its only failure mode (a 403 if the token can't read the endpoint) is **loud** and fail-closed.

## Scope / trade-off

Skips by *repo permission*, so a **read-only org member with private membership** is not skipped (public ones remain covered by the existing payload fast-path). Deliberate: read-only members aren't maintainers, and this avoids any org-scoped credential, grant, owner-approval, or interim pause. No manual operator steps.

## Verification

- `actionlint` clean; gate case-logic unit-exercised (privileged/custom/error → skip; read/none/404 → proceed).
- **Linchpin (installation-token access):** a `workflow_dispatch` on #1493 from this branch confirms `GITHUB_TOKEN` can read the endpoint (expects `role 'admin' — skip triage`) and logs the `author_association` diagnostic (expects `CONTRIBUTOR`, confirming the rationale). Result posted as a comment on this PR.

### Before merge
Confirm the `workflow_dispatch` verification above logged `role 'admin'` (not `HTTP 403`). A persistent 403 would mean `GITHUB_TOKEN` is blocked from the endpoint — escalate rather than merge.

Fixes #1493.

[no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)