### PR TITLE
fix(ui): distinguish phone back control from queue pager

### DIFF
--- a/ui/src/lib/components/Viewport.browser.test.ts
+++ b/ui/src/lib/components/Viewport.browser.test.ts
@@ -900,3 +900,27 @@ describe("Viewport Activity tab A/B switch", () => {
     ).toBeNull();
   });
 });
+
+// ── Phone back control glyph (two-left-chevron regression) ────────────────────
+// On phone the .back control collapses from the desktop "‹ Herd" text to a bare
+// glyph. It must NOT be the left chevron "‹" — that made it visually identical to
+// the adjacent needs-you pager's prev button (also "‹"), yielding two ambiguous
+// left chevrons. It renders as the list glyph "☰" (back to the herd list), which
+// the pager never uses. The .back button only mounts when `onback` is supplied.
+describe("Viewport phone back glyph", () => {
+  it("phone back control renders the list glyph ☰, not the left chevron ‹", async () => {
+    const { container } = render(Viewport, {
+      session: session({ id: "back-glyph" }),
+      mobile: true,
+      onback: vi.fn(),
+      previewPort: null,
+      openPreviewTick: 0,
+    });
+
+    const back = container.querySelector(".back");
+    expect(back, ".back control should render on phone when onback is supplied").not.toBeNull();
+    const glyph = back!.textContent?.trim();
+    expect(glyph, "phone back glyph is the list glyph").toBe("☰");
+    expect(glyph, "phone back glyph must not be the left chevron").not.toBe("‹");
+  });
+});

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1889,7 +1889,7 @@
   >
     {#if onback}
       <button class="back" type="button" onclick={onback} aria-label={m.viewport_back_aria()}
-        >{mobile ? "‹" : m.viewport_back_button()}</button
+        >{mobile ? "☰" : m.viewport_back_button()}</button
       >
     {/if}
     {#if showQueueNav}
@@ -3221,7 +3221,8 @@
     min-height: 44px;
     padding: 5px 12px;
   }
-  /* phone: the back control is a bare chevron — size it up to read as an icon */
+  /* phone: the back control is a bare list glyph (☰, distinct from the ‹/› queue
+     pager) — size it up to read as an icon */
   .vp-head.phone .back {
     font-size: var(--fs-xl);
     line-height: 1;


### PR DESCRIPTION
## Problem

On the **phone** session-detail header, the back-to-herd button collapsed to a bare `‹`, identical to the adjacent needs-you pager's *previous* button (also `‹`) — two visually-identical left chevrons sitting next to the pager's `›`, i.e. `‹ ‹ ›`, doing different things (leave the session vs. page the queue). When the current session isn't in the needs-you queue the `n/total` label is hidden too, so nothing disambiguated them.

## Fix

Render the **phone** back control as the list glyph **`☰`** (back to the herd list), which the `‹ ›` pager never uses. Desktop/compact still show the text `‹ Herd`; the pager, swipe gestures, and all aria-labels are unchanged.

| | Back → herd | Queue prev | Queue next |
|---|---|---|---|
| Before (phone) | `‹` | `‹` | `›` |
| After (phone) | `☰` | `‹` | `›` |
| Desktop/compact | `‹ Herd` | `‹` | `›` |

### Glyph choice
`☰` (U+2630) over `⌂` (U+2302): `⌂` renders inconsistently (thin house / tofu) on some Android/system fonts, which no CI gate can catch; `☰` is a reliably-rendered list glyph that reads as "the herd list". The literal is a raw glyph like the existing `‹`/`›` — the translated meaning already lives in `aria-label` ("Back to herd" / "Zurück zum Herd"), so **no message-catalog change**.

## Tests
- Added a regression test in `Viewport.browser.test.ts`: the phone `.back` glyph is `☰` and **not** `‹`, guarding against silently reintroducing the collision.
- `bun run check`, `bun run check:i18n`, and `vitest --project browser Viewport.browser.test.ts` (26 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)