### PR TITLE
fix(ui): hide Codex usage in CLI picker when Codex absent

### DIFF
--- a/ui/src/lib/components/new-task/ModelCliPicker.svelte
+++ b/ui/src/lib/components/new-task/ModelCliPicker.svelte
@@ -181,32 +181,32 @@
           <span class="mcp-unavailable">{m.upnext_usage_unavailable()}</span>
         {/if}
       </div>
-      <div class="mcp-provider-usage">
-        <span class="micro">{m.agent_provider_codex()}</span>
-        {#if codexGauges.length > 0}
-          {#each codexGauges as g (g.label)}
-            <div class="mcp-gauge">
-              <span>{g.label}</span>
-              <span class="mcp-bar">
-                <span
-                  class="mcp-fill"
-                  style="transform:scaleX({gaugeFill(g.w.pct)});background:{gaugeColor(g.w.pct)}"
-                ></span>
-              </span>
-              <span style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
-              <small>{formatResetIn(g.w.resetAt, nowMs)}</small>
-            </div>
-          {/each}
-        {:else}
-          <span class="mcp-unavailable">{m.topbar_codex_limits_unavailable()}</span>
-        {/if}
-        {#if codexUsage}
+      {#if codexUsage}
+        <div class="mcp-provider-usage">
+          <span class="micro">{m.agent_provider_codex()}</span>
+          {#if codexGauges.length > 0}
+            {#each codexGauges as g (g.label)}
+              <div class="mcp-gauge">
+                <span>{g.label}</span>
+                <span class="mcp-bar">
+                  <span
+                    class="mcp-fill"
+                    style="transform:scaleX({gaugeFill(g.w.pct)});background:{gaugeColor(g.w.pct)}"
+                  ></span>
+                </span>
+                <span style="color:{gaugeColor(g.w.pct)}">{g.w.pct}%</span>
+                <small>{formatResetIn(g.w.resetAt, nowMs)}</small>
+              </div>
+            {/each}
+          {:else}
+            <span class="mcp-unavailable">{m.topbar_codex_limits_unavailable()}</span>
+          {/if}
           <div class="mcp-token">
             <span>{m.topbar_tokens_total()}</span>
             <span>{formatTokenLabel(codexUsage.totalTokens)}</span>
           </div>
-        {/if}
-      </div>
+        </div>
+      {/if}
     </div>
   {/if}
 


### PR DESCRIPTION
## Problem

The **Choose coding CLI** popover (`ModelCliPicker`) rendered a **CODEX** section reading *"Codex limits not found; showing token usage."* even when no Codex was found on the machine — with no token row beneath it, since `codexUsage` was `null`. It promised token usage that didn't exist.

<!-- screenshot in the originating issue -->

## Cause

The Codex block rendered whenever `codexGauges` was empty, which is true in **two** cases:
1. Codex present but logged no rate-limit windows (legitimate token-usage fallback).
2. Codex **absent** entirely (`codexUsage === null`) — no data at all.

Only the token *row* was guarded by `{#if codexUsage}`; the label + "limits not found" message were not.

## Fix

Wrap the entire Codex `.mcp-provider-usage` block in `{#if codexUsage}`:

| Codex state | Before | After |
| --- | --- | --- |
| Absent (no snapshot) | "limits not found; showing token usage." (no token row) | nothing rendered |
| Present, has rate limits | 5H / WK gauges | unchanged |
| Present, no rate limits | message + TOTAL row | unchanged |

This mirrors how the other three consumers already gate on `codexUsage` (`TopBarMobileSheet`, `LimitsLens`, `CodexTokenDetail`) — so they need no change. The token-usage fallback is intentionally preserved when Codex *is* present.

## Verification

- `cd ui && bun run check` — 0 errors
- `bunx eslint` + `bunx prettier --check` on the touched file — clean

No message keys added/removed; `topbar_codex_limits_unavailable` still used by the present-but-no-limits path. Display-correctness fix, no user-facing feature → no announcement entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)