### PR TITLE
fix(recap): handle Codex archive empty diffs

### DIFF
--- a/src/automerge.ts
+++ b/src/automerge.ts
@@ -75,6 +75,11 @@ export interface AutoMergeDeps {
   emitStatus: (s: AutoMergeStatus) => void;
   emitArchived: (id: string) => void;
   dropPrCache: (id: string) => void;
+  noteMergedForRecap?: (input: {
+    sessionId: string;
+    prNumber: number;
+    headSha: string | null;
+  }) => void;
   /** Mark a session so the drain's onArchived keeps its claim (close failed). */
   retainClaim: (id: string) => void;
   rebaseCap: number;
@@ -305,6 +310,7 @@ export class AutoMergeService {
       return false;
     }
     this.mergeFail.delete(sessionId); // success clears any backoff
+    this.deps.noteMergedForRecap?.({ sessionId, prNumber, headSha });
     // Clear the behind-cache so sibling sessions get a fresh read now that main has moved.
     this.behindCache.clear();
     // Autonomous merge emits no session:git event, so clear the merge-train mark and

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,7 @@ import { normalizeAgentProvider } from "./agent-provider";
 import { normalizeAuthModeSetting } from "./auth-mode";
 import { EgressWatcher } from "./egress-watch";
 import { detectEgressHostLoopback } from "./egress";
-import { RecapService } from "./recap";
+import { RecapService, type LandedWorkEvidence } from "./recap";
 import { PostMergeStepsService } from "./post-merge-steps";
 import { BuildQueueReminderService } from "./build-queue-reminder";
 import { HerdDigestService } from "./herd-digest";
@@ -452,6 +452,24 @@ const recapService: RecapService = new RecapService({
   // Resolve the PR's real base so the recap diff matches the PR. prPoller + resolveForge are
   // declared below; this closure only runs at recap time (well after init), like refreshPr above.
   resolveBase: (s) => resolveDiffBase(s, prPoller, resolveForge),
+  landedWorkEvidence: (s, head): LandedWorkEvidence | null => {
+    const git = prPoller.snapshot()[s.id];
+    if (git?.state === "merged" && (git.headSha == null || git.headSha === head)) {
+      return {
+        kind: "merged_pr",
+        summary: `merged PR${git.number ? ` #${git.number}` : ""}`,
+      };
+    }
+    const review = store.getReview(s.id);
+    if (review?.headSha === head) {
+      return { kind: "review", summary: "PR review recorded for this head" };
+    }
+    const recap = store.getRecap(s.id);
+    if (recap?.headSha === head && recap.changedFiles.length > 0) {
+      return { kind: "existing_recap", summary: "existing recap recorded changed files" };
+    }
+    return null;
+  },
 });
 
 // Lazy holder for the restricted agent-ingress listener's ephemeral port. The listener is started

--- a/src/index.ts
+++ b/src/index.ts
@@ -436,6 +436,8 @@ const egressWatcher = new EgressWatcher({
   emit: (event, data) => events.emit(event, data),
 });
 
+const autoMergedRecapEvidence = new Map<string, { prNumber: number; headSha: string | null }>();
+
 // Session recap (#XXX): generates a plain-language summary of each settled-idle session
 // so the operator can skim what happened without reading the transcript. Mirrors planGate's
 // deps/onChange wiring; model defaults to "sonnet" inside the service. Constructed BEFORE
@@ -453,6 +455,13 @@ const recapService: RecapService = new RecapService({
   // declared below; this closure only runs at recap time (well after init), like refreshPr above.
   resolveBase: (s) => resolveDiffBase(s, prPoller, resolveForge),
   landedWorkEvidence: (s, head): LandedWorkEvidence | null => {
+    const autoMerged = autoMergedRecapEvidence.get(s.id);
+    if (autoMerged && (autoMerged.headSha == null || autoMerged.headSha === head)) {
+      return {
+        kind: "merged_pr",
+        summary: `automerge merged PR #${autoMerged.prNumber}`,
+      };
+    }
     const git = prPoller.snapshot()[s.id];
     if (git?.state === "merged" && (git.headSha == null || git.headSha === head)) {
       return {
@@ -1397,6 +1406,7 @@ events.subscribe((event, data) => {
     reviewService.forget(id);
     planGate.forget(id);
     recapService.onArchived(id);
+    autoMergedRecapEvidence.delete(id);
     buildQueueReminder.forget(id);
     docAgent.onArchived(id);
   }
@@ -1663,6 +1673,9 @@ const autoMerge = new AutoMergeService({
   emitStatus: (status) => events.emit("automerge:status", status),
   emitArchived: (id) => events.emit("session:archived", { id }),
   dropPrCache: (id) => prPoller.drop(id),
+  noteMergedForRecap: ({ sessionId, prNumber, headSha }) => {
+    autoMergedRecapEvidence.set(sessionId, { prNumber, headSha });
+  },
   retainClaim: (id) => drain.retainClaim(id),
   rebaseCap: config.autoMergeRebaseCap,
 });

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -55,7 +55,21 @@ const PLAN_FILE = ".shepherd-plan.md";
 const DEFAULT_TIMEOUT_MS = 5 * 60_000;
 const DEFAULT_IDLE_THRESHOLD_MS = 120_000;
 
+type AncestryResult = "contained" | "not-contained" | "unknown";
+
+export interface LandedWorkEvidence {
+  kind: "merged_pr" | "review" | "existing_recap";
+  summary: string;
+}
+
+type EmptyDiffAction =
+  { kind: "continue"; landedContext: string } | { kind: "done"; result: "empty" | "error" };
+
 // ── defaults ──────────────────────────────────────────────────────────────────
+
+function optional<T>(value: T | undefined, fallback: T): T {
+  return value === undefined ? fallback : value;
+}
 
 async function defaultHeadSha(worktreePath: string): Promise<string> {
   const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
@@ -63,6 +77,33 @@ async function defaultHeadSha(worktreePath: string): Promise<string> {
     encoding: "utf8",
   });
   return stdout.trim();
+}
+
+async function defaultCurrentBranch(worktreePath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["symbolic-ref", "--quiet", "--short", "HEAD"], {
+      cwd: worktreePath,
+      encoding: "utf8",
+    });
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function defaultHeadContainedInBase(
+  worktreePath: string,
+  baseRef: string,
+): Promise<AncestryResult> {
+  try {
+    await execFileAsync("git", ["merge-base", "--is-ancestor", "HEAD", baseRef], {
+      cwd: worktreePath,
+      encoding: "utf8",
+    });
+    return "contained";
+  } catch (err) {
+    return (err as { code?: unknown }).code === 1 ? "not-contained" : "unknown";
+  }
 }
 
 function defaultReadTranscript(
@@ -156,6 +197,7 @@ export interface RecapServiceDeps {
     | "getReview"
     | "recordReviewerSpawn"
     | "completeReviewerSpawn"
+    | "listReviewerSpawns"
     | "list"
     | "setRecapPendingDiff"
   >;
@@ -180,6 +222,12 @@ export interface RecapServiceDeps {
   readPlan?: (worktreePath: string) => string;
   readVerdict?: (cwd: string) => VerdictRead<unknown>;
   readUsage?: (cwd: string, spawnSessionId: string) => Promise<SessionUsage | null>;
+  currentBranch?: (worktreePath: string) => Promise<string | null>;
+  headContainedInBase?: (worktreePath: string, baseRef: string) => Promise<AncestryResult>;
+  landedWorkEvidence?: (
+    session: Session,
+    headSha: string,
+  ) => Promise<LandedWorkEvidence | null> | LandedWorkEvidence | null;
   makeTmpDir?: () => string;
   cleanup?: (cwd: string) => void;
 }
@@ -214,6 +262,12 @@ export class RecapService {
   private _readPlan: (worktreePath: string) => string;
   private _readVerdict: (cwd: string) => VerdictRead<unknown>;
   private _readUsage: (cwd: string, spawnSessionId: string) => Promise<SessionUsage | null>;
+  private _currentBranch: (worktreePath: string) => Promise<string | null>;
+  private _headContainedInBase: (worktreePath: string, baseRef: string) => Promise<AncestryResult>;
+  private _landedWorkEvidence: (
+    session: Session,
+    headSha: string,
+  ) => Promise<LandedWorkEvidence | null> | LandedWorkEvidence | null;
   private _makeTmpDir: () => string;
   private _cleanup: (cwd: string) => void;
 
@@ -227,22 +281,26 @@ export class RecapService {
   private inFlight = new Set<string>();
 
   constructor(private deps: RecapServiceDeps) {
-    this.now = deps.now ?? Date.now;
-    this.timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-    this.idleThresholdMs = deps.idleThresholdMs ?? DEFAULT_IDLE_THRESHOLD_MS;
+    this.now = optional(deps.now, Date.now);
+    this.timeoutMs = optional(deps.timeoutMs, DEFAULT_TIMEOUT_MS);
+    this.idleThresholdMs = optional(deps.idleThresholdMs, DEFAULT_IDLE_THRESHOLD_MS);
     // No service-internal model default — the sonnet default now lives in config.recapModel seeding
     // (config.recapCli="claude"), resolved by roleEnv at the call site in index.ts.
-    this.env = deps.env ?? (() => ({ provider: "claude", model: null }));
-    this._resolveBase =
-      deps.resolveBase ?? ((s) => Promise.resolve({ base: s.baseBranch, resolved: false }));
-    this._computeDiff = deps.computeDiff ?? computeDiff;
-    this._headSha = deps.headSha ?? defaultHeadSha;
-    this._readTranscript = deps.readTranscript ?? defaultReadTranscript;
-    this._readPlan = deps.readPlan ?? defaultReadPlan;
-    this._readVerdict = deps.readVerdict ?? defaultReadVerdict;
-    this._readUsage = deps.readUsage ?? readSessionUsage;
-    this._makeTmpDir = deps.makeTmpDir ?? defaultMakeTmpDir;
-    this._cleanup = deps.cleanup ?? defaultCleanup;
+    this.env = optional(deps.env, () => ({ provider: "claude", model: null }));
+    this._resolveBase = optional(deps.resolveBase, (s) =>
+      Promise.resolve({ base: s.baseBranch, resolved: false }),
+    );
+    this._computeDiff = optional(deps.computeDiff, computeDiff);
+    this._headSha = optional(deps.headSha, defaultHeadSha);
+    this._readTranscript = optional(deps.readTranscript, defaultReadTranscript);
+    this._readPlan = optional(deps.readPlan, defaultReadPlan);
+    this._readVerdict = optional(deps.readVerdict, defaultReadVerdict);
+    this._readUsage = optional(deps.readUsage, readSessionUsage);
+    this._currentBranch = optional(deps.currentBranch, defaultCurrentBranch);
+    this._headContainedInBase = optional(deps.headContainedInBase, defaultHeadContainedInBase);
+    this._landedWorkEvidence = optional(deps.landedWorkEvidence, () => null);
+    this._makeTmpDir = optional(deps.makeTmpDir, defaultMakeTmpDir);
+    this._cleanup = optional(deps.cleanup, defaultCleanup);
   }
 
   // ── resolveTerminal ──────────────────────────────────────────────────────────
@@ -250,6 +308,114 @@ export class RecapService {
   /** Find a recap spawn's live terminal by its tmpdir cwd. "" when gone; herdr.stop("") is a no-op. */
   private resolveTerminal(cwd: string): string {
     return this.deps.herdr.list().find((a) => a.cwd === cwd)?.terminalId ?? "";
+  }
+
+  private putTerminalRecap(
+    session: Session,
+    input: {
+      state: "empty" | "failed";
+      headSha: string;
+      base: string;
+      headline?: string;
+      body?: string;
+    },
+  ): void {
+    const t = this.now();
+    const env = this.env();
+    const row: Recap = {
+      sessionId: session.id,
+      state: input.state,
+      headSha: input.headSha,
+      base: input.base,
+      verdict: null,
+      headline: input.headline ?? "",
+      body: input.body ?? "",
+      openItems: [],
+      changedFiles: [],
+      blocks: [],
+      spawnSessionId: "",
+      cwd: "",
+      model: env.model,
+      spawnedAt: t,
+      generatedAt: t,
+      updatedAt: t,
+    };
+    this.deps.store.putRecap(row);
+    this.deps.onChange(session.id, input.state === "empty" ? null : row);
+  }
+
+  private async classifyEmptyDiff(
+    session: Session,
+    head: string,
+    diff: DiffResult,
+  ): Promise<
+    | { kind: "empty" }
+    | { kind: "landed"; evidence: LandedWorkEvidence }
+    | { kind: "failed"; headline: string; body: string }
+  > {
+    if (!session.isolated || !session.branch) return { kind: "empty" };
+
+    const current = await this._currentBranch(session.worktreePath);
+    if (current && current !== session.branch) {
+      return {
+        kind: "failed",
+        headline: "Recap skipped: session metadata mismatch",
+        body: `The session row points at branch \`${session.branch}\`, but the archived worktree was on \`${current}\`. Shepherd did not trust the empty diff.`,
+      };
+    }
+
+    const evidence = await this._landedWorkEvidence(session, head);
+    if (!evidence) return { kind: "empty" };
+
+    if (diff.fetchFailed) {
+      return {
+        kind: "failed",
+        headline: "Recap skipped: base refresh failed",
+        body: `Shepherd found landed-work evidence (${evidence.summary}), but refreshing the base ref failed, so the empty diff could not be trusted.`,
+      };
+    }
+
+    const ancestry = await this._headContainedInBase(session.worktreePath, diff.baseRef);
+    if (ancestry === "contained") return { kind: "landed", evidence };
+    if (ancestry === "unknown") {
+      return {
+        kind: "failed",
+        headline: "Recap skipped: ancestry check failed",
+        body: `Shepherd found landed-work evidence (${evidence.summary}), but could not verify whether HEAD is already contained in \`${diff.baseRef}\`.`,
+      };
+    }
+    return {
+      kind: "failed",
+      headline: "Recap skipped: empty diff contradicted landed-work evidence",
+      body: `Shepherd found landed-work evidence (${evidence.summary}), but HEAD was not contained in \`${diff.baseRef}\` even though the diff was empty.`,
+    };
+  }
+
+  private async handleEmptyDiff(
+    session: Session,
+    head: string,
+    base: string,
+    diff: DiffResult,
+  ): Promise<EmptyDiffAction> {
+    const classified = await this.classifyEmptyDiff(session, head, diff);
+    if (classified.kind === "empty") {
+      this.putTerminalRecap(session, { state: "empty", headSha: head, base });
+      return { kind: "done", result: "empty" };
+    }
+    if (classified.kind === "failed") {
+      this.putTerminalRecap(session, {
+        state: "failed",
+        headSha: head,
+        base,
+        headline: classified.headline,
+        body: classified.body,
+      });
+      return { kind: "done", result: "error" };
+    }
+    return {
+      kind: "continue",
+      landedContext: `The code diff is empty because this session's HEAD is already contained in the resolved base. Landed-work evidence: ${classified.evidence.summary}. Summarize the completed work from the task, plan, review/PR context, and transcript digest; do not invent changed files.`,
+    };
   }
 
   // ── reapGenerating ───────────────────────────────────────────────────────────
@@ -427,27 +593,11 @@ export class RecapService {
         return "error";
       }
 
+      let landedContext = "";
       if (diff.files.length === 0) {
-        const t = this.now();
-        this.deps.store.putRecap({
-          sessionId: id,
-          state: "empty",
-          headSha: head,
-          base,
-          verdict: null,
-          headline: "",
-          body: "",
-          openItems: [],
-          changedFiles: [],
-          spawnSessionId: "",
-          cwd: "",
-          model: this.env().model,
-          spawnedAt: t,
-          generatedAt: t,
-          updatedAt: t,
-        });
-        this.deps.onChange(id, null);
-        return "empty";
+        const action = await this.handleEmptyDiff(session, head, base, diff);
+        if (action.kind === "done") return action.result;
+        landedContext = action.landedContext;
       }
 
       // Build prompt inputs.
@@ -460,6 +610,7 @@ export class RecapService {
       const contextParts: string[] = [];
       const review = this.deps.store.getReview(id);
       if (review?.summary) contextParts.push(`Critic verdict: ${review.summary}`);
+      if (landedContext) contextParts.push(landedContext);
       if (session.readyToMerge) contextParts.push("Operator marked ready to merge.");
       if (session.planPhase) contextParts.push(`Plan phase: ${session.planPhase}`);
       // #1059: hint the prose about detected manual operator steps (the authoritative copy is the
@@ -503,7 +654,9 @@ export class RecapService {
         taskSessionId: id,
         kind: "recap",
         worktreePath: cwd,
+        reviewerProvider: env.provider,
         model: env.model,
+        reviewerEffort: env.effort ?? null,
         spawnedAt,
       });
 
@@ -547,6 +700,7 @@ export class RecapService {
       let action: VerdictAction;
       let read: VerdictRead<unknown>;
       let elapsed: number;
+      let finished: boolean;
       try {
         elapsed = this.now() - r.spawnedAt;
         read = this._readVerdict(r.cwd);
@@ -554,7 +708,7 @@ export class RecapService {
         // Ground-truth liveness via paneForegroundProcs (same signal as tab-reaper): a live-but-idle
         // recap spawn between API turns reads "idle" in agentStatus but still has non-shell procs.
         // isSpawnAlive never throws; herdr errors → fail-closed alive.
-        const finished = !(await isSpawnAlive(this.deps.herdr, r.cwd));
+        finished = !(await isSpawnAlive(this.deps.herdr, r.cwd));
         action = decideVerdictAction(read, finished, timedOut, elapsed > STARTUP_GRACE_MS);
       } catch (err) {
         // _readVerdict or decideVerdictAction threw; isSpawnAlive itself never throws.
@@ -570,7 +724,7 @@ export class RecapService {
       }
       // finalize-value carries the parsed verdict; finalize-null (timeout / fail-fast) → `failed`.
       const raw = action === "finalize-value" && read.status === "parsed" ? read.value : null;
-      if (action === "finalize-null") this.logUnproducedVerdict(r, read, elapsed);
+      if (action === "finalize-null") this.logUnproducedVerdict(r, read, elapsed, finished);
 
       // finalizing flag stays set; always delete in finally so entry doesn't wedge after a throw.
       try {
@@ -584,14 +738,27 @@ export class RecapService {
   /** Observability for a finalize-null recap (timeout / fail-fast): a `failed` recap used to be a
    *  black hole (no log, raw discarded), so an intermittent malformed write was undiagnosable —
    *  surface WHY before finalizing. Extracted from tick() to keep its cognitive complexity in bound. */
-  private logUnproducedVerdict(r: Recap, read: VerdictRead<unknown>, elapsed: number): void {
+  private logUnproducedVerdict(
+    r: Recap,
+    read: VerdictRead<unknown>,
+    elapsed: number,
+    finished: boolean,
+  ): void {
+    const spawn = this.deps.store
+      .listReviewerSpawns()
+      .find((s) => s.reviewerSessionId === r.spawnSessionId);
+    const ctx =
+      `spawn=${r.spawnSessionId || "<none>"} cwd=${r.cwd || "<none>"} model=${r.model ?? "<default>"} ` +
+      `provider=${spawn?.reviewerProvider ?? "<unknown>"} effort=${spawn?.reviewerEffort ?? "<default>"} ` +
+      `elapsed=${Math.round(elapsed / 1000)}s pane=${this.resolveTerminal(r.cwd) ? "present" : "absent"} ` +
+      `finished=${finished}`;
     if (read.status === "unparseable") {
       console.warn(
-        `[recap] ${r.sessionId}: verdict file present but unparseable even after jsonrepair — failing. snippet: ${recapSnippet(read.raw)}`,
+        `[recap] ${r.sessionId}: verdict file present but unparseable even after jsonrepair — failing. ${ctx} snippet: ${recapSnippet(read.raw)}`,
       );
     } else {
       console.warn(
-        `[recap] ${r.sessionId}: no verdict file after ${Math.round(elapsed / 1000)}s (spawn exited or hard timeout) — agent produced nothing.`,
+        `[recap] ${r.sessionId}: no verdict file (spawn exited or hard timeout) — agent produced nothing. ${ctx}`,
       );
     }
   }

--- a/src/transient-agent-argv.ts
+++ b/src/transient-agent-argv.ts
@@ -126,6 +126,12 @@ const PRESETS: Record<TransientAgentKind, KindPreset> = {
   "writer-only": { allowedTools: ["Write"], mcpIsolated: false },
 };
 
+/** child_process.spawn rejects any argv arg containing a NUL. Keep one shared prompt sanitizer so
+ *  Claude and Codex transient roles have the same contract. */
+function sanitizePromptArg(prompt: string): string {
+  return prompt.replaceAll("\0", "\\0");
+}
+
 /**
  * Build the argv (and the forced session id) for a transient `claude` agent of the given kind.
  * Returns the pinned `--session-id` so callers can locate the spawn's transcript. Pure: no I/O,
@@ -143,7 +149,10 @@ export function buildTransientAgentArgv(
   // --allowedTools) have a Codex equivalent; the sandbox shape is enforced by
   // `--sandbox workspace-write`. sessionId is returned for shape but unused (no Claude transcript).
   if (opts.provider === "codex")
-    return { argv: codexRoleArgv(opts.model, opts.prompt, opts.effort ?? null), sessionId };
+    return {
+      argv: codexRoleArgv(opts.model, sanitizePromptArg(opts.prompt), opts.effort ?? null),
+      sessionId,
+    };
 
   const settings: Record<string, unknown> = { disableAllHooks: true };
   if (preset.mcpIsolated) settings.enableAllProjectMcpServers = true;
@@ -172,7 +181,7 @@ export function buildTransientAgentArgv(
   // transient spawn site (issue #1235). Replace each NUL with its visible 2-char escape `\0` rather
   // than stripping it, so the surrounding text's meaning survives for the reading agent. NUL is the
   // only spawn-illegal char; other control chars are legal in argv and left untouched.
-  argv.push(opts.prompt.replaceAll("\0", "\\0"));
+  argv.push(sanitizePromptArg(opts.prompt));
 
   return { argv, sessionId };
 }

--- a/test/automerge.test.ts
+++ b/test/automerge.test.ts
@@ -72,16 +72,32 @@ test("ready PR → forge.merge called with squash + delete-branch, then archived
   const merge = mock(async () => {});
   const archive = mock(() => 1);
   const resolveMerging = mock(() => {});
+  const noted: Array<{ sessionId: string; prNumber: number; headSha: string | null }> = [];
+  const order: string[] = [];
   const d = deps({
     resolveForge: () =>
       ({ kind: "github", mergeMethod: "squash", merge, closeIssue: mock(async () => {}) }) as any,
-    service: { archive, reply: mock(() => true), resume: mock(() => true), resolveMerging } as any,
+    service: {
+      archive: mock(() => {
+        order.push("archive");
+        return archive();
+      }),
+      reply: mock(() => true),
+      resume: mock(() => true),
+      resolveMerging,
+    } as any,
+    noteMergedForRecap: (input) => {
+      order.push("note");
+      noted.push(input);
+    },
   });
   const svc = new AutoMergeService(d);
   await svc.pump("/r");
   expect((merge as any).mock.calls[0]).toEqual([7, { method: "squash", deleteBranch: true }]);
   expect(archive.mock.calls.length).toBe(1);
   expect((resolveMerging as any).mock.calls).toEqual([["s1", true]]);
+  expect(noted).toEqual([{ sessionId: "s1", prNumber: 7, headSha: "h1" }]);
+  expect(order).toEqual(["note", "archive"]);
 });
 
 test("behind → steers a rebase + bumps the counter, does NOT merge", async () => {

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, beforeEach, afterEach } from "bun:test";
 import { RecapService } from "../src/recap";
 import type { VerdictRead } from "../src/json-tolerant";
-import type { Recap, Session } from "../src/types";
+import type { DiffResult, Recap, Session } from "../src/types";
 import type { ActivityEntry } from "../src/activity";
 import { config } from "../src/config";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
@@ -132,6 +132,7 @@ type FakeStore = {
   getReview: (id: string) => null;
   recordReviewerSpawn: (r: any) => void;
   completeReviewerSpawn: (id: string, u: any, at: number) => void;
+  listReviewerSpawns: () => any[];
   list: (opts?: { activeOnly?: boolean }) => Session[];
   setRecapPendingDiff: (sessionId: string, files: any[]) => void;
   get: (id: string) => Session | undefined;
@@ -167,6 +168,7 @@ function makeStore(sessions: Session[] = [], recaps: Recap[] = []): FakeStore {
     recordReviewerSpawn: (r: any) => store.reviewerSpawns.push(r),
     completeReviewerSpawn: (id: string, u: any, at: number) =>
       store.completedSpawns.push({ id, u, at }),
+    listReviewerSpawns: () => store.reviewerSpawns,
     list: () => store.sessions,
     setRecapPendingDiff: (sessionId, files) => {
       store.pendingDiffs[sessionId] = files;
@@ -217,7 +219,7 @@ function makeHerdr(livePanes: FakePaneEntry[] = [], defaultProcs: string[] = ["z
   return h;
 }
 
-const NON_EMPTY_DIFF = {
+const NON_EMPTY_DIFF: DiffResult = {
   base: "main",
   baseRef: "origin/main",
   head: "shepherd/x",
@@ -235,7 +237,7 @@ const NON_EMPTY_DIFF = {
   ],
 };
 
-const EMPTY_DIFF = {
+const EMPTY_DIFF: DiffResult = {
   base: "main",
   baseRef: "origin/main",
   head: "shepherd/x",
@@ -269,6 +271,12 @@ function buildSvc(opts: {
   readUsage?: () => Promise<any>;
   resolveBase?: (s: Session) => Promise<{ base: string; resolved: boolean }>;
   computeDiff?: (worktreePath: string, base: string, branch: string | null) => Promise<any>;
+  currentBranch?: (worktreePath: string) => Promise<string | null>;
+  headContainedInBase?: (
+    worktreePath: string,
+    baseRef: string,
+  ) => Promise<"contained" | "not-contained" | "unknown">;
+  landedWorkEvidence?: () => any;
 }): RecapService {
   let tmpIdx = 0;
   return new RecapService({
@@ -292,6 +300,9 @@ function buildSvc(opts: {
             ? { status: "parsed", value: opts.verdictJson, repaired: false }
             : { status: "absent" }),
     readUsage: opts.readUsage ?? (async () => null),
+    currentBranch: opts.currentBranch,
+    headContainedInBase: opts.headContainedInBase,
+    landedWorkEvidence: opts.landedWorkEvidence,
     makeTmpDir: opts.makeTmpDir ?? (() => `/tmp/recap-test-${++tmpIdx}`),
     cleanup: opts.cleanup ?? (() => {}),
   });
@@ -591,6 +602,53 @@ test("tick timeout: generating row, no verdict, past timeout → state 'failed',
   expect(cleaned).toContain("/tmp/recap-timeout");
 });
 
+test("tick no verdict logs Codex recap spawn context without prompt text", async () => {
+  const rec = makeRecap({
+    state: "generating",
+    cwd: "/tmp/recap-codex-timeout",
+    spawnSessionId: "sp-codex",
+    model: "gpt-5.3-codex",
+    spawnedAt: 1_000,
+  });
+  const store = makeStore([], [rec]);
+  store.reviewerSpawns.push({
+    reviewerSessionId: "sp-codex",
+    taskSessionId: "s1",
+    kind: "recap",
+    worktreePath: "/tmp/recap-codex-timeout",
+    reviewerProvider: "codex",
+    model: "gpt-5.3-codex",
+    reviewerEffort: "high",
+    spawnedAt: 1_000,
+  });
+  const herdr = makeHerdr([{ cwd: "/tmp/recap-codex-timeout", terminalId: "t-codex" }]);
+  const warnings: string[] = [];
+  const prevWarn = console.warn;
+  console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
+  try {
+    const svc = buildSvc({
+      store,
+      herdr,
+      nowFn: () => 400_000,
+      timeoutMs: 300_000,
+      verdictRead: { status: "absent" },
+    });
+
+    await svc.tick();
+  } finally {
+    console.warn = prevWarn;
+  }
+
+  const msg = warnings.join("\n");
+  expect(msg).toContain("spawn=sp-codex");
+  expect(msg).toContain("cwd=/tmp/recap-codex-timeout");
+  expect(msg).toContain("model=gpt-5.3-codex");
+  expect(msg).toContain("provider=codex");
+  expect(msg).toContain("effort=high");
+  expect(msg).toContain("pane=present");
+  expect(msg).not.toContain("do the thing");
+});
+
 test("tick unparseable: garbage verdict → state 'failed'", async () => {
   const rec = makeRecap({ state: "generating", cwd: "/tmp/recap-garbage", spawnedAt: 100_000 });
   const store = makeStore([], [rec]);
@@ -853,12 +911,13 @@ test("generate: subscription mode — --settings unchanged + no env 4th arg", as
 test("generate: codex provider spawns headless `codex exec` (no claude flags)", async () => {
   const s = makeSession({ status: "idle" });
   const herdr = makeHerdr();
+  const store = makeStore([s]);
   const svc = buildSvc({
-    store: makeStore([s]),
+    store,
     herdr,
     nowFn: () => 1,
     makeTmpDir: () => "/tmp/r",
-    env: () => ({ provider: "codex", model: "gpt-5.5" }),
+    env: () => ({ provider: "codex", model: "gpt-5.5", effort: "high" }),
   });
   await svc.regenerate(s);
   const argv = herdr.started[0]!.argv;
@@ -871,6 +930,14 @@ test("generate: codex provider spawns headless `codex exec` (no claude flags)", 
     "gpt-5.5",
   ]);
   expect(argv).not.toContain("--settings");
+  expect(argv).not.toContain("--allowedTools");
+  expect(argv).not.toContain("--permission-mode");
+  expect(argv[argv.length - 1]).toContain("`.shepherd-recap.json`");
+  expect(store.reviewerSpawns[0]).toMatchObject({
+    kind: "recap",
+    reviewerProvider: "codex",
+    reviewerEffort: "high",
+  });
 });
 
 test("generate: threads env.effort into the recap argv (issue #1418)", async () => {
@@ -1112,6 +1179,252 @@ test("generate: empty diff → empty row has changedFiles = []", async () => {
   const r = store.getRecap("s1");
   expect(r?.state).toBe("empty");
   expect(r?.changedFiles).toEqual([]);
+});
+
+test("generate: empty diff + contained head without landed evidence stays empty", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    diff: EMPTY_DIFF,
+    currentBranch: async () => "shepherd/x",
+    headContainedInBase: async () => "contained",
+  });
+
+  await expect(svc.generate(s)).resolves.toBe("empty");
+  expect(herdr.started.length).toBe(0);
+  expect(store.getRecap("s1")?.state).toBe("empty");
+});
+
+test("generate: empty diff + contained head with landed evidence starts visible recap", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    diff: EMPTY_DIFF,
+    currentBranch: async () => "shepherd/x",
+    headContainedInBase: async () => "contained",
+    landedWorkEvidence: () => ({ kind: "merged_pr", summary: "merged PR #12" }),
+  });
+
+  await expect(svc.generate(s)).resolves.toBe("started");
+  expect(herdr.started.length).toBe(1);
+  expect(herdr.started[0]!.argv.at(-1)).toContain("already contained in the resolved base");
+  expect(herdr.started[0]!.argv.at(-1)).toContain("merged PR #12");
+  expect(store.getRecap("s1")?.state).toBe("generating");
+});
+
+test("generate: empty diff + landed evidence + fetch failure becomes visible failed diagnostic", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    diff: { ...EMPTY_DIFF, fetchFailed: true },
+    currentBranch: async () => "shepherd/x",
+    headContainedInBase: async () => "contained",
+    landedWorkEvidence: () => ({ kind: "merged_pr", summary: "merged PR #12" }),
+  });
+
+  await expect(svc.generate(s)).resolves.toBe("error");
+  expect(herdr.started.length).toBe(0);
+  const r = store.getRecap("s1");
+  expect(r?.state).toBe("failed");
+  expect(r?.body).toContain("refreshing the base ref failed");
+});
+
+test("generate: empty diff + fetch failure without landed evidence stays empty", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    diff: { ...EMPTY_DIFF, fetchFailed: true },
+    currentBranch: async () => "shepherd/x",
+    headContainedInBase: async () => "contained",
+  });
+
+  await expect(svc.generate(s)).resolves.toBe("empty");
+  expect(herdr.started.length).toBe(0);
+  expect(store.getRecap("s1")?.state).toBe("empty");
+});
+
+test("generate: empty diff + branch mismatch becomes visible metadata failure", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    diff: EMPTY_DIFF,
+    currentBranch: async () => "shepherd/other",
+    landedWorkEvidence: () => ({ kind: "merged_pr", summary: "merged PR #12" }),
+  });
+
+  await expect(svc.generate(s)).resolves.toBe("error");
+  expect(herdr.started.length).toBe(0);
+  const r = store.getRecap("s1");
+  expect(r?.state).toBe("failed");
+  expect(r?.body).toContain("worktree was on `shepherd/other`");
+});
+
+test("generate: empty diff + not-contained ancestry without evidence stays empty", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    diff: EMPTY_DIFF,
+    currentBranch: async () => "shepherd/x",
+    headContainedInBase: async () => "not-contained",
+  });
+
+  await expect(svc.generate(s)).resolves.toBe("empty");
+  expect(herdr.started.length).toBe(0);
+  expect(store.getRecap("s1")?.state).toBe("empty");
+});
+
+test("generate: empty diff + unknown ancestry with landed evidence becomes visible failed diagnostic", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    diff: EMPTY_DIFF,
+    currentBranch: async () => "shepherd/x",
+    headContainedInBase: async () => "unknown",
+    landedWorkEvidence: () => ({ kind: "merged_pr", summary: "merged PR #12" }),
+  });
+
+  await expect(svc.generate(s)).resolves.toBe("error");
+  expect(herdr.started.length).toBe(0);
+  const r = store.getRecap("s1");
+  expect(r?.state).toBe("failed");
+  expect(r?.body).toContain("could not verify whether HEAD is already contained");
+});
+
+test("generate: empty diff + unknown ancestry without evidence stays empty", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    diff: EMPTY_DIFF,
+    currentBranch: async () => "shepherd/x",
+    headContainedInBase: async () => "unknown",
+  });
+
+  await expect(svc.generate(s)).resolves.toBe("empty");
+  expect(herdr.started.length).toBe(0);
+  expect(store.getRecap("s1")?.state).toBe("empty");
+});
+
+test("generate: empty diff + null current branch without evidence stays empty", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    diff: EMPTY_DIFF,
+    currentBranch: async () => null,
+    headContainedInBase: async () => "contained",
+  });
+
+  await expect(svc.generate(s)).resolves.toBe("empty");
+  expect(herdr.started.length).toBe(0);
+  expect(store.getRecap("s1")?.state).toBe("empty");
+});
+
+test("generate: empty diff + null current branch with landed evidence can start recap", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    diff: EMPTY_DIFF,
+    currentBranch: async () => null,
+    headContainedInBase: async () => "contained",
+    landedWorkEvidence: () => ({ kind: "merged_pr", summary: "merged PR #12" }),
+  });
+
+  await expect(svc.generate(s)).resolves.toBe("started");
+  expect(herdr.started.length).toBe(1);
+  expect(store.getRecap("s1")?.state).toBe("generating");
+});
+
+test("generate: empty diff + null current branch + landed evidence + fetch failure fails as stale base", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    diff: { ...EMPTY_DIFF, fetchFailed: true },
+    currentBranch: async () => null,
+    headContainedInBase: async () => "contained",
+    landedWorkEvidence: () => ({ kind: "merged_pr", summary: "merged PR #12" }),
+  });
+
+  await expect(svc.generate(s)).resolves.toBe("error");
+  expect(herdr.started.length).toBe(0);
+  const r = store.getRecap("s1");
+  expect(r?.state).toBe("failed");
+  expect(r?.body).toContain("refreshing the base ref failed");
+});
+
+test("generate: empty diff + null current branch + landed evidence + unknown ancestry fails as uncertain", async () => {
+  const s = makeSession({ status: "idle" });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => 200_000,
+    diff: EMPTY_DIFF,
+    currentBranch: async () => null,
+    headContainedInBase: async () => "unknown",
+    landedWorkEvidence: () => ({ kind: "merged_pr", summary: "merged PR #12" }),
+  });
+
+  await expect(svc.generate(s)).resolves.toBe("error");
+  expect(herdr.started.length).toBe(0);
+  const r = store.getRecap("s1");
+  expect(r?.state).toBe("failed");
+  expect(r?.body).toContain("could not verify whether HEAD is already contained");
 });
 
 // ── considerForArchive tests ──────────────────────────────────────────────────────

--- a/test/transient-agent-argv.test.ts
+++ b/test/transient-agent-argv.test.ts
@@ -136,6 +136,17 @@ test("multiple NULs are each escaped", () => {
   for (const arg of argv) expect(arg.includes("\0")).toBe(false);
 });
 
+test("Codex prompts escape NULs with the same argv contract as Claude", () => {
+  const { argv } = buildTransientAgentArgv("writer-only", {
+    provider: "codex",
+    model: "gpt-5.3-codex",
+    prompt: "a\0b",
+  });
+  expect(argv.slice(0, 4)).toEqual(["codex", "exec", "--sandbox", "workspace-write"]);
+  expect(argv[argv.length - 1]).toBe("a\\0b");
+  for (const arg of argv) expect(arg.includes("\0")).toBe(false);
+});
+
 test("NUL-free prompts pass through byte-for-byte unchanged (no spurious escaping)", () => {
   const prompt = "review the plan; key is `${slug}\\0${fork}` (already a literal escape)";
   const { argv } = buildTransientAgentArgv("reviewer", { model: null, prompt });

--- a/ui/src/lib/components/DoneRecapPanel.browser.test.ts
+++ b/ui/src/lib/components/DoneRecapPanel.browser.test.ts
@@ -280,10 +280,33 @@ describe("DoneRecapPanel bring-back button", () => {
 
 describe("DoneRecapPanel fail-closed", () => {
   it("failed recap → names the failure (never a blank success card)", async () => {
-    recaps.map = { f1: recap({ sessionId: "f1", state: "failed" }) };
+    recaps.map = { f1: recap({ sessionId: "f1", state: "failed", headline: "", body: "" }) };
     render(DoneRecapPanel, { session: session({ id: "f1" }) });
     await expect.element(page.getByText("Recap generation failed.")).toBeInTheDocument();
     expect(page.getByText("Shipped the feature").elements().length, "no headline").toBe(0);
+  });
+
+  it("failed recap with diagnostics → shows the persisted reason", async () => {
+    recaps.map = {
+      f2: recap({
+        sessionId: "f2",
+        state: "failed",
+        headline: "Recap skipped: session metadata mismatch",
+        body: "The session row points at branch `a`, but the archived worktree was on `b`.",
+      }),
+    };
+    render(DoneRecapPanel, { session: session({ id: "f2" }) });
+    await expect.element(page.getByText("Recap generation failed.")).toBeInTheDocument();
+    await expect
+      .element(page.getByText("Recap skipped: session metadata mismatch"))
+      .toBeInTheDocument();
+    await expect
+      .element(
+        page.getByText(
+          "The session row points at branch `a`, but the archived worktree was on `b`.",
+        ),
+      )
+      .toBeInTheDocument();
   });
 
   it("missing recap row on a recent session → generic unavailable", async () => {

--- a/ui/src/lib/components/DoneRecapPanel.svelte
+++ b/ui/src/lib/components/DoneRecapPanel.svelte
@@ -156,6 +156,12 @@
     {:else if recap?.state === "failed"}
       <!-- generation ran but couldn't produce a recap — say so, don't imply it was never tried. -->
       <p class="dr-muted">{m.recap_failed()}</p>
+      {#if recap.headline}
+        <p class="dr-failure-headline">{recap.headline}</p>
+      {/if}
+      {#if recap.body}
+        <p class="dr-failure-body">{recap.body}</p>
+      {/if}
     {:else if predatesRecapFeature}
       <!-- finished before durable recaps existed: name the reason instead of a bare "unavailable". -->
       <p class="dr-muted">{m.recap_predates_feature()}</p>
@@ -326,5 +332,19 @@
     margin: 0;
     font-size: var(--fs-meta);
     color: var(--color-muted);
+  }
+
+  .dr-failure-headline {
+    margin: 0;
+    font-size: var(--fs-base);
+    color: var(--color-ink-bright);
+  }
+
+  .dr-failure-body {
+    margin: 0;
+    font-size: var(--fs-meta);
+    line-height: 1.5;
+    color: var(--color-ink);
+    white-space: pre-wrap;
   }
 </style>


### PR DESCRIPTION
## Summary

Fixes missing Done recaps for Codex-backed sessions by making archive-time empty diffs deterministic and improving Codex recap spawn observability.

## Root cause

Codex recap helpers could fail without enough persisted/logged provider context, and archive-time empty diffs were always persisted as hidden `empty` recaps even when the session had landed work or stale metadata.

## Changes

- Sanitize Codex transient prompt argv the same way as Claude so NUL bytes cannot break spawn construction.
- Persist `reviewerProvider` and `reviewerEffort` for recap helper spawns and include bounded no-verdict logging context.
- Classify empty archive diffs as true no-op, visible metadata/base/ancestry failure, or proven merge-before-archive recap.
- Wire production landed-work evidence from merged PR state, matching review rows, or existing recaps with changed files.
- Add Codex-specific argv/startup/output-contract tests and empty-diff policy coverage.

## Validation

- `bun test test/transient-agent-argv.test.ts test/recap.test.ts`
- `bun test test/pull.test.ts`
- `bun run typecheck`
- `bun run lint`
- pre-push hook: prettier, eslint, gates, tsc, ext, root-tests, ui, fallow audit

Closes #1496