### PR TITLE
fix: explain missing base refs on task create

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import type { PluginRegistry } from "./plugins/loader";
 import type { PluginInfo } from "./plugins/types";
 import type { SessionService } from "./service";
 import { PREVIEW_SETUP_STEER, RestoreError } from "./service";
-import { WorktreeRestoreError } from "./worktree";
+import { WorktreeMissingBaseError, WorktreeRestoreError } from "./worktree";
 import { LearningsService } from "./learnings-service";
 import { RepoConfigService } from "./repo-config-service";
 import type { CreateSessionInput } from "./types";
@@ -1892,9 +1892,11 @@ export async function claimLinkedIssue(forge: GitForge | null, issueNumber: numb
 }
 
 /** Map a service.create() error to the appropriate Response.
- *  SandboxAutoRefused → 403; agent_name_taken → 409; anything else → 502. */
+ *  SandboxAutoRefused → 403; missing base ref → 422; agent_name_taken → 409;
+ *  anything else → 502. */
 function createErrorResponse(e: unknown): Response {
   if (e instanceof SandboxAutoRefused) return json({ error: e.holdReason }, 403);
+  if (e instanceof WorktreeMissingBaseError) return json({ error: e.message }, 422);
   const msg = e instanceof Error ? e.message : "create failed";
   const taken = /agent_name_taken/.test(msg);
   return json({ error: taken ? "task name already in use, retry" : msg }, taken ? 409 : 502);

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -53,6 +53,15 @@ export class WorktreeRestoreError extends Error {
   }
 }
 
+export class WorktreeMissingBaseError extends Error {
+  constructor(public readonly baseRef: string) {
+    super(
+      `base ref "${baseRef}" does not resolve to a commit; create an initial commit or choose an existing base branch`,
+    );
+    this.name = "WorktreeMissingBaseError";
+  }
+}
+
 export class WorktreeMgr {
   /** Injectable so tests can assert the teardown orphan sweep fires without real /proc. */
   constructor(private reaper: ProcessReaper = new ProcessReaper()) {}
@@ -73,6 +82,9 @@ export class WorktreeMgr {
     if (!this.isGit(repoPath)) {
       return { worktreePath: repoPath, branch: null, isolated: false };
     }
+    if (!this.baseRefResolvesToCommit(repoPath, baseBranch)) {
+      throw new WorktreeMissingBaseError(baseBranch);
+    }
     ensureShepherdExclude(repoPath);
     const branch = `shepherd/${name}`;
     const parent = join(dirname(repoPath), ".shepherd-worktrees");
@@ -87,6 +99,18 @@ export class WorktreeMgr {
       return { worktreePath, branch, isolated: true };
     } catch (err) {
       return this.recoverFromAddFailure(repoPath, baseBranch, branch, worktreePath, err);
+    }
+  }
+
+  private baseRefResolvesToCommit(repoPath: string, baseRef: string): boolean {
+    try {
+      execFileSync("git", ["rev-parse", "--verify", `${baseRef}^{commit}`], {
+        cwd: repoPath,
+        stdio: "pipe",
+      });
+      return true;
+    } catch {
+      return false;
     }
   }
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,11 +1,13 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, rmSync, existsSync, realpathSync } from "node:fs";
 import { join } from "node:path";
+import { execFileSync } from "node:child_process";
 import { stagingDir } from "../src/uploads";
 import { SessionStore } from "../src/store";
 import { SessionService } from "../src/service";
 import { EventHub } from "../src/events";
 import { makeApp, serve, PTY_GONE_CODE, claimLinkedIssue, type AppDeps } from "../src/server";
+import { WorktreeMgr } from "../src/worktree";
 import type { GitForge } from "../src/forge/types";
 import { config, USAGE_HISTORY_RETENTION_MS } from "../src/config";
 import { ACTIVE_LABEL } from "../src/drain-core";
@@ -259,6 +261,40 @@ test("POST /api/sessions surfaces a herdr failure with its real message (not a b
   expect(res.status).toBe(502); // herdr/git failure
   const body = await res.json();
   expect(body.error).toContain("no active workspace"); // real cause reaches the client
+});
+
+test("POST /api/sessions returns 422 when the selected base does not resolve to a commit", async () => {
+  const unbornRepo = join(tmpRoot, "unborn");
+  mkdirSync(unbornRepo);
+  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: unbornRepo });
+
+  const deps = makeDeps();
+  deps.service = new SessionService({
+    store: deps.store,
+    namer: async () => "x",
+    worktree: new WorktreeMgr(),
+    herdr: {
+      start: () => {
+        throw new Error("herdr should not start for a missing base ref");
+      },
+      list: () => [],
+      stop: () => {},
+      send: () => {},
+    } as any,
+    events: deps.events,
+  });
+
+  const res = await postSessions(makeApp(deps), {
+    repoPath: unbornRepo,
+    baseBranch: "main",
+    prompt: "go",
+  });
+
+  expect(res.status).toBe(422);
+  const body = await res.json();
+  expect(body.error).toContain('base ref "main" does not resolve to a commit');
+  expect(body.error).toContain("create an initial commit");
+  expect(body.error).toContain("choose an existing base branch");
 });
 
 test("an unhandled throw on any route becomes a JSON 500, not Bun's HTML error page", async () => {

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import { join, dirname, basename } from "node:path";
 import { execFileSync } from "node:child_process";
-import { WorktreeMgr, WorktreeRestoreError } from "../src/worktree";
+import { WorktreeMgr, WorktreeMissingBaseError, WorktreeRestoreError } from "../src/worktree";
 import { ProcessReaper } from "../src/process-reaper";
 
 let repo: string;
@@ -389,9 +389,12 @@ const gitEnvBasic = {
   GIT_COMMITTER_EMAIL: "t@t",
 };
 
-test("create: invalid base ref throws with stderr in message", () => {
+test("create: missing base ref throws typed error", () => {
   const wt = new WorktreeMgr();
-  expect(() => wt.create(repo, "no-such-base", "x")).toThrow(/invalid reference/i);
+  expect(() => wt.create(repo, "no-such-base", "x")).toThrow(WorktreeMissingBaseError);
+  expect(() => wt.create(repo, "no-such-base", "x")).toThrow(
+    /base ref "no-such-base" does not resolve to a commit/i,
+  );
 });
 
 test("create: non-git directory returns non-isolated, no throw", () => {


### PR DESCRIPTION
## Summary
- add a typed worktree error when the requested base ref does not resolve to a commit
- map that failure to HTTP 422 so New Task shows an actionable missing-base message
- cover the worktree error and POST /api/sessions unborn-repo path

## Tests
- bun run lint
- bun test test/worktree.test.ts test/server.test.ts
- cd extension && bun run check
- pre-push hook passed: gates, prettier, eslint, tsc, ext, root-tests, ui, fallow audit

Note: a broad ad hoc `bun test` run was not used as a pass signal because it invokes UI browser tests outside their configured browser harness; the pre-push root-tests lane and targeted backend tests passed.