### PR TITLE
fix(ui): compact Up Next sort into icon menu, inline refresh

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2210,6 +2210,7 @@
   "upnext_priority_section": "Priorität",
   "upnext_normal_section": "Warteschlange",
   "upnext_sort_aria": "Als Nächstes sortieren",
+  "upnext_sort_by": "Sortieren nach {mode}",
   "upnext_sort_recommended": "Empfohlen",
   "upnext_sort_newest": "Neueste",
   "upnext_sort_oldest": "Älteste",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2210,6 +2210,7 @@
   "upnext_priority_section": "Priority",
   "upnext_normal_section": "Queued",
   "upnext_sort_aria": "Sort Up Next",
+  "upnext_sort_by": "Sort by {mode}",
   "upnext_sort_recommended": "Recommended",
   "upnext_sort_newest": "Newest",
   "upnext_sort_oldest": "Oldest",

--- a/ui/src/lib/components/UpNextPanel.browser.test.ts
+++ b/ui/src/lib/components/UpNextPanel.browser.test.ts
@@ -159,6 +159,11 @@ const providerSelect = () => document.querySelector<HTMLSelectElement>("#mcp-pro
 const pickerConfirm = () => document.querySelector<HTMLButtonElement>(".mcp-actions .primary")!;
 const rowNumbers = () =>
   Array.from(document.querySelectorAll(".un-row .un-num")).map((el) => el.textContent ?? "");
+// Sort now lives behind a ⇅ icon that opens a listbox menu; open it, then pick the mode.
+const pickSort = async (name: string) => {
+  document.querySelector<HTMLButtonElement>(".un-sortbtn")!.click();
+  await page.getByRole("option", { name }).click();
+};
 
 let fontStyle: HTMLStyleElement;
 beforeEach(() => {
@@ -262,18 +267,18 @@ describe("UpNextPanel sorting", () => {
   it("keeps the server-ranked sections available as Recommended", async () => {
     upNext.snapshot = sortSnapshot();
     render(UpNextPanel, {});
-    await page.getByRole("button", { name: m.upnext_sort_recommended() }).click();
+    await pickSort(m.upnext_sort_recommended());
     await expect.poll(rowNumbers).toEqual(["#10", "#11", "#20", "#21", "#30", "#31"]);
   });
 
   it("sorts oldest and title modes within the priority and normal tiers", async () => {
     upNext.snapshot = sortSnapshot();
     render(UpNextPanel, {});
-    await page.getByRole("button", { name: m.upnext_sort_oldest() }).click();
+    await pickSort(m.upnext_sort_oldest());
     await expect.poll(rowNumbers).toEqual(["#10", "#11", "#30", "#20", "#21", "#31"]);
-    await page.getByRole("button", { name: m.upnext_sort_title_asc() }).click();
+    await pickSort(m.upnext_sort_title_asc());
     await expect.poll(rowNumbers).toEqual(["#11", "#10", "#21", "#20", "#31", "#30"]);
-    await page.getByRole("button", { name: m.upnext_sort_title_desc() }).click();
+    await pickSort(m.upnext_sort_title_desc());
     await expect.poll(rowNumbers).toEqual(["#10", "#11", "#30", "#31", "#20", "#21"]);
   });
 
@@ -317,7 +322,7 @@ describe("UpNextPanel sorting", () => {
     upNext.snapshot = snapshot;
     render(UpNextPanel, {});
     await page.getByRole("button", { name: m.upnext_show_all({ count: 6 }) }).click();
-    await page.getByRole("button", { name: m.upnext_sort_oldest() }).click();
+    await pickSort(m.upnext_sort_oldest());
     await expect.element(page.getByText(m.upnext_show_less())).toBeInTheDocument();
   });
 
@@ -326,7 +331,7 @@ describe("UpNextPanel sorting", () => {
     upNext.snapshot = snapshot;
     const original = snapshot.sections.map((s) => s.items.map((it) => it.number));
     render(UpNextPanel, {});
-    await page.getByRole("button", { name: m.upnext_sort_title_desc() }).click();
+    await pickSort(m.upnext_sort_title_desc());
     await expect.poll(rowNumbers).toEqual(["#10", "#11", "#30", "#31", "#20", "#21"]);
     expect(snapshot.sections.map((s) => s.items.map((it) => it.number))).toEqual(original);
   });

--- a/ui/src/lib/components/UpNextPanel.svelte
+++ b/ui/src/lib/components/UpNextPanel.svelte
@@ -11,6 +11,7 @@
   import { EMPTY_REPO_FILTER } from "./queue-strip";
   import { onMount } from "svelte";
   import ModelCliPicker from "./new-task/ModelCliPicker.svelte";
+  import UpNextSortMenu from "./UpNextSortMenu.svelte";
   import {
     capacitySuggestedProvider,
     claudeUsageHoldLikely,
@@ -97,6 +98,28 @@
     } catch {
       /* storage may be blocked */
     }
+  }
+
+  // Sort is a compact icon button opening an anchored listbox menu (see
+  // UpNextSortMenu). Rect is captured on open so the portaled menu can position
+  // itself under the trigger; the menu handles Esc/outside-click/scroll dismiss.
+  let sortBtn = $state<HTMLButtonElement>();
+  let sortMenuOpen = $state(false);
+  let sortAnchor = $state<DOMRect | null>(null);
+  const sortOptions = $derived(
+    SORT_MODES.map((mode) => ({ value: mode, label: SORT_LABELS[mode]() })),
+  );
+  function toggleSortMenu() {
+    if (sortMenuOpen) {
+      sortMenuOpen = false;
+      return;
+    }
+    if (sortBtn) sortAnchor = sortBtn.getBoundingClientRect();
+    sortMenuOpen = true;
+  }
+  function selectSort(value: string) {
+    setSortMode(validSortMode(value));
+    sortMenuOpen = false;
   }
 
   const snap = $derived(upNext.snapshot);
@@ -390,17 +413,6 @@
     {#if updatedAgo}
       <span class="un-updated">{m.upnext_updated_ago({ ago: updatedAgo })}</span>
     {/if}
-    <div class="un-sort" role="group" aria-label={m.upnext_sort_aria()}>
-      {#each SORT_MODES as mode (mode)}
-        <button
-          type="button"
-          class="un-sort-btn"
-          class:seg-active={sortMode === mode}
-          aria-pressed={sortMode === mode}
-          onclick={() => setSortMode(mode)}>{SORT_LABELS[mode]()}</button
-        >
-      {/each}
-    </div>
     <button
       type="button"
       class="un-refresh"
@@ -410,6 +422,18 @@
       aria-label={m.upnext_refresh()}
       onclick={refresh}>⟳</button
     >
+    <div class="un-sortwrap">
+      <button
+        bind:this={sortBtn}
+        type="button"
+        class="un-sortbtn"
+        aria-haspopup="listbox"
+        aria-expanded={sortMenuOpen}
+        title={m.upnext_sort_by({ mode: SORT_LABELS[sortMode]() })}
+        aria-label={m.upnext_sort_by({ mode: SORT_LABELS[sortMode]() })}
+        onclick={toggleSortMenu}>⇅</button
+      >
+    </div>
   </header>
 
   {#if selectedCount > 0}
@@ -479,6 +503,18 @@
   </div>
 </section>
 
+{#if sortMenuOpen && sortAnchor}
+  <UpNextSortMenu
+    anchor={sortAnchor}
+    opener={sortBtn}
+    current={sortMode}
+    options={sortOptions}
+    label={m.upnext_sort_aria()}
+    onselect={selectSort}
+    onclose={() => (sortMenuOpen = false)}
+  />
+{/if}
+
 {#if picker}
   <ModelCliPicker
     x={picker.x}
@@ -527,47 +563,21 @@
     font-size: var(--fs-meta);
     color: var(--color-muted);
   }
-  .un-sort {
-    display: flex;
-    border: 1px solid var(--color-line);
-    border-radius: 2px;
-    overflow: hidden;
-    min-width: min(100%, 320px);
-  }
-  .un-sort-btn {
-    flex: 1;
-    min-width: 0;
-    min-height: 32px;
-    border: 0;
-    border-right: 1px solid var(--color-line);
-    background: none;
-    font-family: inherit;
-    font-size: var(--fs-micro);
-    cursor: pointer;
-    padding: 0 6px;
-    color: var(--color-muted);
-    text-align: center;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .un-sort-btn:last-child {
-    border-right: 0;
-  }
-  .un-sort-btn:hover {
-    color: var(--color-ink);
-  }
-  .un-sort-btn:focus-visible {
-    outline: none;
-    box-shadow: inset 0 0 0 1px var(--color-amber);
-  }
-  .un-sort-btn.seg-active {
-    color: var(--color-amber);
-    background: var(--color-inset);
-    box-shadow: inset 0 -2px 0 var(--color-amber);
-  }
-  .un-refresh {
+  /* Sort ⇅ trigger sits at the header's right edge; refresh ⟳ stays beside the
+     time. Both are compact ~30px controls matching the panel's dense chrome
+     (deliberate sub-44px tap targets — waiver noted in the PR). */
+  .un-sortwrap {
     margin-left: auto;
+    display: inline-flex;
+  }
+  .un-refresh,
+  .un-sortbtn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 30px;
+    min-width: 30px;
+    padding: 0 7px;
     background: transparent;
     border: 1px solid var(--color-line-bright);
     border-radius: 2px;
@@ -575,15 +585,18 @@
     font: inherit;
     font-size: var(--fs-lg);
     line-height: 1;
-    padding: 2px 7px;
     cursor: pointer;
-    transition: color 0.12s ease;
+    transition:
+      color 0.12s ease,
+      border-color 0.12s ease;
   }
-  .un-refresh:hover:not(:disabled) {
+  .un-refresh:hover:not(:disabled),
+  .un-sortbtn:hover {
     color: var(--color-amber);
     border-color: var(--color-amber);
   }
-  .un-refresh:focus-visible {
+  .un-refresh:focus-visible,
+  .un-sortbtn:focus-visible {
     outline: none;
     box-shadow: inset 0 0 0 1px var(--color-amber);
   }

--- a/ui/src/lib/components/UpNextSortMenu.svelte
+++ b/ui/src/lib/components/UpNextSortMenu.svelte
@@ -1,0 +1,173 @@
+<script lang="ts">
+  import { portal } from "$lib/portal";
+
+  // Small anchored, non-blocking single-select picker opened by the Up Next sort
+  // button. Positioning + dismiss mechanics mirror TaskIdMenu (portal so the
+  // panel's overflow:auto can't clip it, JS-anchored under the trigger with a
+  // flip-up when there's no room below, dismiss on Esc / outside-click / scroll,
+  // focus-restore to the trigger). Semantics mirror LanguageSwitcher — a
+  // role="listbox" with role="option" + a ✓ on the active mode. No scrim, per the
+  // design system's anchored-popover rule. The parent owns open/close state.
+  let {
+    anchor,
+    opener,
+    current,
+    options,
+    label,
+    onselect,
+    onclose,
+  }: {
+    anchor: DOMRect;
+    opener?: HTMLElement;
+    current: string;
+    options: ReadonlyArray<{ value: string; label: string }>;
+    label: string;
+    onselect: (value: string) => void;
+    onclose: () => void;
+  } = $props();
+
+  let el = $state<HTMLDivElement>();
+
+  // Clamp inside the viewport: anchor below-left by default, flip above when the
+  // menu would overflow the bottom. Measured after mount; until then a sensible
+  // fallback (just under the anchor) keeps the first paint roughly placed.
+  let pos = $state<{ left: number; top: number } | null>(null);
+  $effect(() => {
+    const node = el;
+    if (!node) return;
+    const r = node.getBoundingClientRect();
+    const margin = 8;
+    const below = anchor.bottom + 4;
+    const above = anchor.top - r.height - 4;
+    const top = below + r.height + margin > window.innerHeight && above > margin ? above : below;
+    // Right-align to the trigger (it lives at the header's right edge), then clamp.
+    const left = Math.min(anchor.right - r.width, window.innerWidth - r.width - margin);
+    pos = { left: Math.max(margin, left), top: Math.max(margin, top) };
+    // Open with the active option focused (falling back to the first), per the menu pattern.
+    (opts().find((b) => b.dataset.value === current) ?? opts()[0])?.focus();
+  });
+
+  function opts(): HTMLButtonElement[] {
+    return el ? Array.from(el.querySelectorAll<HTMLButtonElement>(".usm-item")) : [];
+  }
+  // Arrow / Home / End roving focus; Tab is trapped (cycled) so focus can't escape
+  // the open menu — Esc, a selection, or an outside click are the only ways out.
+  function onNav(e: KeyboardEvent) {
+    const list = opts();
+    if (list.length === 0) return;
+    const i = list.indexOf(document.activeElement as HTMLButtonElement);
+    const fwd = (i + 1) % list.length;
+    const back = (i - 1 + list.length) % list.length;
+    let next: number;
+    if (e.key === "ArrowDown") next = fwd;
+    else if (e.key === "ArrowUp") next = back;
+    else if (e.key === "Home") next = 0;
+    else if (e.key === "End") next = list.length - 1;
+    else if (e.key === "Tab") next = e.shiftKey ? back : fwd;
+    else return;
+    e.preventDefault();
+    list[next]!.focus();
+  }
+
+  $effect(() => {
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key === "Escape") onclose();
+    }
+    function onPointer(e: Event) {
+      const t = e.target as Node;
+      // Exclude the opener: a pointerdown on the sort button must NOT dismiss here,
+      // or the button's own click would just toggle the menu back open.
+      if (el && !el.contains(t) && !opener?.contains(t)) onclose();
+    }
+    window.addEventListener("keydown", onKeydown);
+    // capture so we beat the trigger's own click; scroll dismisses (the anchor moves)
+    window.addEventListener("pointerdown", onPointer, true);
+    window.addEventListener("scroll", onclose, true);
+    return () => {
+      window.removeEventListener("keydown", onKeydown);
+      window.removeEventListener("pointerdown", onPointer, true);
+      window.removeEventListener("scroll", onclose, true);
+      // Restore focus to the trigger on close, but only when focus fell to <body>.
+      const target = opener;
+      queueMicrotask(() => {
+        if (target?.isConnected && document.activeElement === document.body) target.focus();
+      });
+    };
+  });
+</script>
+
+<div
+  bind:this={el}
+  use:portal
+  class="un-sortmenu"
+  role="listbox"
+  tabindex="-1"
+  aria-label={label}
+  style="left:{pos?.left ?? anchor.left}px;top:{pos?.top ?? anchor.bottom + 4}px"
+  onkeydown={onNav}
+>
+  {#each options as opt (opt.value)}
+    <button
+      class="usm-item"
+      type="button"
+      role="option"
+      tabindex="-1"
+      data-value={opt.value}
+      aria-selected={opt.value === current}
+      class:active={opt.value === current}
+      onclick={() => onselect(opt.value)}
+    >
+      <span class="usm-check" aria-hidden="true">{opt.value === current ? "✓" : ""}</span>
+      {opt.label}
+    </button>
+  {/each}
+</div>
+
+<style>
+  .un-sortmenu {
+    position: fixed;
+    z-index: 60;
+    min-width: 180px;
+    max-width: calc(100vw - 16px);
+    padding: 4px;
+    background: var(--color-panel);
+    border: 1px solid var(--color-line-bright);
+    border-radius: 3px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+  .un-sortmenu:focus {
+    outline: none;
+  }
+  .usm-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 8px 11px;
+    border: 0;
+    border-radius: 2px;
+    background: transparent;
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: var(--fs-base);
+    text-align: left;
+    cursor: pointer;
+  }
+  .usm-item:hover,
+  .usm-item:focus-visible {
+    background: var(--color-hover);
+    outline: none;
+  }
+  .usm-item.active {
+    color: var(--color-amber);
+  }
+  .usm-check {
+    width: 1em;
+    flex-shrink: 0;
+    text-align: center;
+    color: var(--color-amber);
+  }
+</style>


### PR DESCRIPTION
## Why

The Up Next sort control was a five-segment strip (`Recommended / Newest / Oldest / Title A-Z / Title Z-A`) forced to a 320px minimum. At the real ~360px dock width it **wrapped onto its own line and the labels ellipsized** — it "looked like crap." The refresh `⟳` was stranded at the far right.

## What

- **Sort → `⇅` icon + anchored menu.** New `UpNextSortMenu.svelte`: a single-select `role="listbox"` (`✓` on the active mode) that mirrors the repo's existing `TaskIdMenu` mechanics — `use:portal` + JS anchoring under the trigger (so the panel's `overflow:auto` can't clip it), flip-up when there's no room, roving arrow-key nav, focus-restore, and dismiss on **Esc / outside-click / scroll**. No scrim (design-system anchored-popover exemption).
- **Refresh → inline** beside the "updated … ago" time; the sort trigger is right-anchored (`.un-sortwrap { margin-left:auto }`). The header now fits on one line at 360px.
- Trigger `aria-label`/`title` read "Sort by {current}", so the active sort stays discoverable despite the icon.
- All sort logic (`SORT_MODES`, `SORT_LABELS`, `setSortMode` + its `localStorage` persistence) is reused unchanged.

## ⚠️ Reviewer-confirmable waiver — tap-target size

The sort `⇅` and refresh `⟳` buttons are **~30px, below the 44×44px tap-target floor**. This is deliberate: every other control in the Up Next panel (rows, start buttons, expand) is compact at this density, and raising only these two to 44px would look inconsistent and bloat the header. Please confirm this waiver is acceptable.

## Notes

- Fallow flags the menu's dismiss/nav block as duplicated — this is intentional: it matches the existing `TaskIdMenu`/`CardMenu`/`SteerMenu`/`PrBadgeMenu` family, the accepted pattern I cloned. Warn-level, non-blocking.
- Not a new capability (a refinement of an existing control) → committed as `fix`, no feature-announcement entry.

## Verification

- `bun run check` (svelte-check) — 0 errors
- `bun run check:i18n` — locales in parity (added `upnext_sort_by` EN+DE)
- eslint + prettier clean
- `UpNextPanel.browser.test.ts` — 23/23 pass (updated to open the menu before picking a sort mode; exercises all modes in a real browser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)