### PR TITLE
feat(viewport): single-tap title toggles git rail

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2239,6 +2239,8 @@
   "feat_upnext_body": "Eine neue oberste Ansicht reiht noch nicht begonnene GitHub-Issues über all deine Repos in eine flache Warteschlange — Priorität zuerst. Sieh das Lohnenswerteste zum Starten und starte eine Session dafür — oder mehrere — mit einem Klick.",
   "feat_up_next_sort_title": "Als Nächstes frei sortieren",
   "feat_up_next_sort_body": "Als Nächstes kann jetzt zwischen Empfehlung, neueste, älteste und Titel A-Z/Z-A wechseln. Priorisierte Arbeit bleibt zuerst gruppiert, und deine Sortierung wird gemerkt.",
+  "feat_git_rail_title_tap_title": "Titel antippen öffnet die PR-Aktionen",
+  "feat_git_rail_title_tap_body": "Auf dem Desktop öffnet oder schließt ein einfacher Klick auf den Sitzungstitel jetzt die PR-, Merge- und Kritik-Aktionen. Ein Doppelklick benennt die Sitzung weiterhin um, und der Umschalter sitzt jetzt direkt neben dem Titel als größeres, leichter treffbares Ziel.",
   "feat_upnext_skip_cli_picker_title": "Coding-CLI-Auswahl in „Als Nächstes“ überspringen",
   "feat_upnext_skip_cli_picker_body": "Eine neue Opt-in-Einstellung (Einstellungen → Coding CLI) startet den Schnellstart in „Als Nächstes“ sofort mit deiner Standard-Coding-CLI, statt jedes Mal nachzufragen, welche CLI verwendet werden soll.",
   "feat_add_repo_title": "Repo aus dem Backlog hinzufügen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2239,6 +2239,8 @@
   "feat_upnext_body": "A new top-level lens ranks un-started GitHub issues across all your repos into one flat queue, priority-first. See the single most worthwhile thing to start next and spawn a session on it — or several — in one click.",
   "feat_up_next_sort_title": "Sort Up Next your way",
   "feat_up_next_sort_body": "Up Next now lets you switch between recommended ranking, newest, oldest, and title A-Z/Z-A order. Priority work stays grouped first, and your sort choice is remembered.",
+  "feat_git_rail_title_tap_title": "Tap the title to open PR actions",
+  "feat_git_rail_title_tap_body": "On desktop, a single tap on the session title now opens or closes the PR, merge & critic actions. Double-tap still renames the session, and the toggle now sits right beside the title as a larger, easier target.",
   "feat_upnext_skip_cli_picker_title": "Skip the coding-CLI picker in Up Next",
   "feat_upnext_skip_cli_picker_body": "A new opt-in setting (Settings → Coding CLI) launches Up Next quick-start with your default coding CLI immediately, instead of asking which CLI to use each time.",
   "feat_add_repo_title": "Add a repo from the Backlog",

--- a/ui/src/lib/components/Viewport.browser.test.ts
+++ b/ui/src/lib/components/Viewport.browser.test.ts
@@ -385,6 +385,76 @@ describe("Viewport rename affordances", () => {
     expect(header!.querySelector<HTMLElement>(".branch")?.textContent).toBe("feature/actual-work");
   });
 
+  it("desktop single-tap on the title toggles the git rail instantly", async () => {
+    const { container } = render(Viewport, {
+      session: session({ id: "toggle-head", name: "toggle title" }),
+      previewPort: null,
+      openPreviewTick: 0,
+    });
+
+    const header = container.querySelector<HTMLElement>(".vp-head:not(.mobile)");
+    expect(header, "normal desktop header").not.toBeNull();
+    // rail closed at rest on desktop
+    expect(container.querySelector(".vp-git-strip")).toBeNull();
+
+    header!.querySelector<HTMLElement>(".vp-name")!.click();
+    await expect.poll(() => container.querySelector(".vp-git-strip")).not.toBeNull();
+  });
+
+  it("double-tap renames and restores the rail to its pre-rename state", async () => {
+    const { container } = render(Viewport, {
+      session: session({ id: "toggle-rename", name: "toggle rename title" }),
+      previewPort: null,
+      openPreviewTick: 0,
+    });
+
+    const header = container.querySelector<HTMLElement>(".vp-head:not(.mobile)");
+    const title = header!.querySelector<HTMLElement>(".vp-name");
+    // two taps inside the double-tap window: tap 1 opens the rail, tap 2 undoes
+    // that and opens rename → the rail returns to closed, no lingering toggle
+    title!.click();
+    title!.click();
+
+    const input = page.getByRole("textbox", { name: m.viewport_rename_aria() });
+    await expect.element(input).toBeInTheDocument();
+    expect(container.querySelector(".vp-git-strip")).toBeNull();
+  });
+
+  it("clicking the relocated git-toggle chip toggles the rail with aria-expanded", async () => {
+    const { container } = render(Viewport, {
+      session: session({ id: "toggle-chip", name: "chip title" }),
+      previewPort: null,
+      openPreviewTick: 0,
+    });
+
+    const header = container.querySelector<HTMLElement>(".vp-head:not(.mobile)");
+    const toggle = header!.querySelector<HTMLElement>(".git-toggle");
+    expect(toggle, "git-toggle chip").not.toBeNull();
+    expect(toggle!.getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector(".vp-git-strip")).toBeNull();
+
+    toggle!.click();
+    await expect.poll(() => container.querySelector(".vp-git-strip")).not.toBeNull();
+    expect(toggle!.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("mobile double-tap on the title still renames (no rail toggle path)", async () => {
+    const { container } = render(Viewport, {
+      session: session({ id: "toggle-mobile", name: "mobile title" }),
+      mobile: true,
+      previewPort: null,
+      openPreviewTick: 0,
+    });
+
+    const trigger = container.querySelector<HTMLElement>(".vp-head.mobile .ctx-trigger");
+    expect(trigger, "mobile ctx-trigger").not.toBeNull();
+    trigger!.click();
+    trigger!.click();
+
+    const input = page.getByRole("textbox", { name: m.viewport_rename_aria() });
+    await expect.element(input).toBeInTheDocument();
+  });
+
   it("opens rename only for matching targeted requests", async () => {
     const { rerender } = render(Viewport, {
       session: session({ id: "rename-target", name: "target title" }),

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -875,23 +875,35 @@
       cancelRename();
     }
   }
-  // Double-tap / double-click on the session title also opens the editor.
-  // Hand-rolled click timing instead of ondblclick so touch and mouse behave
-  // identically (iOS Safari fires dblclick unreliably) — the first tap keeps
-  // its existing job (meta popover via focus), the second one renames.
-  // The timestamp is deliberately shared across the title elements (desig +
-  // vp-name): both carry the same session
-  // identity side by side, so a double-tap straddling them still reads as
-  // "double-tap the title" and should rename.
+  // Double-tap / double-click on the session title opens the rename editor; a
+  // lone tap toggles the git rail (desktop only). Hand-rolled click timing
+  // instead of ondblclick so touch and mouse behave identically (iOS Safari
+  // fires dblclick unreliably). The timestamp is deliberately shared across the
+  // title elements (desig + vp-name): both carry the same session identity side
+  // by side, so a double-tap straddling them still reads as "double-tap the
+  // title" and should rename.
+  //
+  // Timing: the single-tap toggle fires instantly so the common action stays
+  // snappy; the double-tap that renames undoes the first tap's toggle, so the
+  // rail returns to its pre-rename state and the only flash is on the rare
+  // rename path. Synchronous — no timer, so nothing fires after the user moves
+  // on. The toggle is desktop-only (gitOpen doesn't exist on compact, where the
+  // rail lives in the header fold instead), so the mobile .ctx-trigger keeps its
+  // first-tap-focus / double-tap-rename behavior unchanged.
+  // 500ms matches the common OS double-click default (400 dropped slow double-clicks).
+  const DOUBLE_TAP_MS = 500;
   let lastTitleTap = 0;
   function onTitleTap() {
     const now = Date.now();
-    // 500ms matches the common OS double-click default (400 dropped slow double-clicks)
-    if (now - lastTitleTap < 500) {
+    if (now - lastTitleTap < DOUBLE_TAP_MS) {
       lastTitleTap = 0;
+      // undo the toggle the first tap performed → rail back to its original state
+      if (!compact) gitOpen = !gitOpen;
       void startRename();
     } else {
       lastTitleTap = now;
+      // desktop: a lone tap toggles the git rail immediately
+      if (!compact) gitOpen = !gitOpen;
     }
   }
   function onTitleKey(e: KeyboardEvent) {
@@ -2213,6 +2225,31 @@
       <!-- transient post-rename note (e.g. "branch kept"); the rename input itself
            takes the title's slot in place when active -->
       {@render renameNoteEl()}
+      <!-- git-rail disclosure, welded to the title: the full rail (PR / CI /
+           merge / critic / ready / verdict) plus the autopilot toggle live one
+           tap away, revealed as a second header row (.vp-git-strip). Sitting it
+           beside the title enlarges the tap target and pairs it with the
+           single-tap-toggle on the title itself (onTitleTap). A direct tap here
+           toggles instantly and is the keyboard/AT path (aria-expanded). -->
+      <button
+        class="git-toggle"
+        class:open={gitOpen}
+        class:attention={prAttention || planAttention}
+        class:clear={prClear}
+        type="button"
+        aria-expanded={gitOpen}
+        onclick={() => (gitOpen = !gitOpen)}
+        title={gitToggleState
+          ? m.viewport_git_actions_title_state({ state: gitToggleState })
+          : m.viewport_git_actions_title()}
+        aria-label={gitToggleState
+          ? m.viewport_git_actions_aria_state({ state: gitToggleState })
+          : m.viewport_git_actions_aria()}
+      >
+        <span class="gt-dot" aria-hidden="true"></span>
+        <span class="gt-label">{m.viewport_git_actions()}</span>
+        <span class="gt-caret" aria-hidden="true">{gitOpen ? "▴" : "▾"}</span>
+      </button>
     {/if}
     <div class="spacer"></div>
     <ViewportTabBar
@@ -2277,30 +2314,6 @@
          executing read-only chip — it is its home. -->
     <PlanGateBadge {session} />
     {#if !compact}
-      <!-- desktop: the full git rail (PR / CI / merge / critic / ready / verdict)
-           plus the autopilot toggle live one disclosure away — this toggle reveals
-           them as a second header row (.vp-git-strip), keeping the primary line
-           down to identity + tabs + status. Decommission is NOT in here on
-           desktop: it sits inline in the actions cluster (quiet ✕ / green nudge). -->
-      <button
-        class="git-toggle"
-        class:open={gitOpen}
-        class:attention={prAttention || planAttention}
-        class:clear={prClear}
-        type="button"
-        aria-expanded={gitOpen}
-        onclick={() => (gitOpen = !gitOpen)}
-        title={gitToggleState
-          ? m.viewport_git_actions_title_state({ state: gitToggleState })
-          : m.viewport_git_actions_title()}
-        aria-label={gitToggleState
-          ? m.viewport_git_actions_aria_state({ state: gitToggleState })
-          : m.viewport_git_actions_aria()}
-      >
-        <span class="gt-dot" aria-hidden="true"></span>
-        <span class="gt-label">{m.viewport_git_actions()}</span>
-        <span class="gt-caret" aria-hidden="true">{gitOpen ? "▴" : "▾"}</span>
-      </button>
       <!-- passive at-rest pip: the READY control lives in the git strip; its ON
            state stays glance-able here. Autopilot's ON state is surfaced solely
            by the Automation pill in GitRail; paused/complete states still appear

--- a/ui/src/lib/feature-announcements/entries/v1.43.0-git-rail-title-tap.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.43.0-git-rail-title-tap.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "git-rail-title-tap",
+  sinceVersion: "1.43.0",
+  titleKey: "feat_git_rail_title_tap_title",
+  bodyKey: "feat_git_rail_title_tap_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## What

On the focused-session header (desktop), a **single tap on the session title now collapses/expands the Git rail**, and the tiny toggle chip moves from the far-right actions cluster to sit **beside the title** — enlarging the tap target and pairing it with the title. **Double-tap still renames.**

Addresses the ask: the standalone toggle button was tiny and easy to miss; it's now welded to the title and the title itself is part of the tap target.

## Interaction model

- **Single tap** on the title → toggles the rail **instantly** (the common action stays snappy; no delay).
- **Double-tap** → renames, and *undoes* the first tap's toggle so the rail returns to its pre-rename state. A brief flash can only appear on the rare rename path, never on the common toggle.
- Synchronous — **no timer**, so nothing fires after the user moves on.
- The relocated chip stays an instant, `aria-expanded` button (the keyboard/AT toggle path); `.desig` keeps Enter/Space → rename.
- **Desktop only.** `gitOpen` and the chip are already desktop-only; the toggle branch in `onTitleTap` is `!compact`-guarded, so mobile/compact keeps its existing first-tap-focus / double-tap-rename and header-fold behavior unchanged.

## Why not a delay

An earlier draft used a 500 ms delayed toggle to avoid any flash, but "no flash" was never a requirement and a half-second lag on the primary toggle is a real regression. Instant-toggle-with-undo keeps toggling immediate and confines the only flash to renames.

## Tests

Added to `Viewport.browser.test.ts`: single-tap toggles the rail instantly; double-tap renames **and** restores the rail to closed; the relocated chip toggles with `aria-expanded`; mobile `.ctx-trigger` double-tap still renames. Full `Viewport.browser.test.ts` suite green (31/31); `bun run check` clean; `check:i18n` in parity.

## Feature discovery

Adds `v1.43.0-git-rail-title-tap` announcement entry + EN/DE keys.

## Follow-up

Restyling the rail *contents* as compact pill chips is tracked separately in #1520 (out of scope here — this PR only relocates the toggle and rewires the title tap).