### PR TITLE
fix(ui): keep Up Next header on one line (no sort ⇅ wrap)

### DIFF
--- a/ui/src/lib/components/UpNextPanel.browser.test.ts
+++ b/ui/src/lib/components/UpNextPanel.browser.test.ts
@@ -480,6 +480,43 @@ describe("UpNextPanel provider picker", () => {
   });
 });
 
+describe("UpNextPanel header layout", () => {
+  const headEl = () => document.querySelector<HTMLElement>(".un-head")!;
+  const panelEl = () => document.querySelector<HTMLElement>(".upnext")!;
+  // Force a reflow at a given panel width so offsetHeight reflects the new layout.
+  const setWidth = (w: number) => {
+    panelEl().style.width = `${w}px`;
+    void headEl().offsetHeight;
+  };
+
+  // Font-agnostic guards: the header must never wrap a control to a second line.
+  // We assert the mechanism (flex-wrap: nowrap) directly, then prove behaviorally that
+  // the header keeps a single row's height even when the panel is forced narrower than
+  // its content — a wrap would add a row and grow the height. No px thresholds or
+  // monospace-metric assumptions, so it trips on the wrap regardless of the CI font.
+  it("keeps the header on a single row when the panel is narrow (with a snapshot)", async () => {
+    render(UpNextPanel, {});
+    await expect.element(page.getByText(m.upnext_title())).toBeInTheDocument();
+    expect(getComputedStyle(headEl()).flexWrap).toBe("nowrap");
+    setWidth(600);
+    const wide = headEl().offsetHeight;
+    setWidth(140);
+    expect(headEl().offsetHeight).toBe(wide);
+  });
+
+  it("keeps the header single-row in the loading state (no updated-time span)", async () => {
+    upNext.snapshot = null;
+    render(UpNextPanel, {});
+    await expect.element(page.getByText(m.common_loading())).toBeInTheDocument();
+    // The shrink valve must still exist without .un-updated present.
+    expect(document.querySelector(".un-updated")).toBeNull();
+    setWidth(600);
+    const wide = headEl().offsetHeight;
+    setWidth(140);
+    expect(headEl().offsetHeight).toBe(wide);
+  });
+});
+
 describe("UpNextPanel load failure", () => {
   it("surfaces a load error when every repo's issue fetch failed (empty queue, failures > 0)", async () => {
     upNext.snapshot = {

--- a/ui/src/lib/components/UpNextPanel.svelte
+++ b/ui/src/lib/components/UpNextPanel.svelte
@@ -544,15 +544,24 @@
     flex: 1;
   }
 
+  /* Single-line by design: the header never wraps a control to a second line
+     (issue: sort ⇅ dropped below the row at narrow mobile widths in the wider
+     monospace fallback). nowrap + fixed-size icons; the text spans are the
+     shrink valve (min-width:0 + ellipsis), so a too-narrow panel truncates the
+     text rather than wrapping a button. Both spans shrink so a valve exists even
+     in the loading state, where .un-updated is absent. */
   .un-head {
     display: flex;
     align-items: center;
     gap: 10px;
     padding: 12px 16px;
     border-bottom: 1px solid var(--color-line);
-    flex-wrap: wrap;
   }
   .un-title-h {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     font-size: var(--fs-meta);
     letter-spacing: 0.18em;
     text-transform: uppercase;
@@ -560,6 +569,10 @@
     font-weight: 600;
   }
   .un-updated {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     font-size: var(--fs-meta);
     color: var(--color-muted);
   }
@@ -567,11 +580,13 @@
      time. Both are compact ~30px controls matching the panel's dense chrome
      (deliberate sub-44px tap targets — waiver noted in the PR). */
   .un-sortwrap {
+    flex: none;
     margin-left: auto;
     display: inline-flex;
   }
   .un-refresh,
   .un-sortbtn {
+    flex: none;
     display: inline-flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## Problem

On the Up Next lens header, the sort ⇅ button wrapped to its own second line at mobile widths (reported on **Vivaldi Android** — see screenshot in the issue). Line 1 showed `UP NEXT · updated 0s ago · ⟳`; the sort control dropped below, right-aligned.

## Root cause (empirically confirmed)

`.un-head` used `flex-wrap: wrap` with `margin-left: auto` on the sort control. The whole app renders in `--font-mono`; on Android "Berkeley Mono"/"JetBrains Mono" aren't installed, so text falls back to the wider system **monospace**. Under Pixel-5 emulation with monospace, the header's single-line threshold is ~282px (EN) / ~342px (DE) — a thin margin at a ~360px mobile panel, crossed by device font width / the DE locale / a longer "updated Nm ago" string. Once content exceeds the width, the auto-margin item (sort) wraps rather than the text shrinking. (A sans-font repro never wraps — the fix targets the wrap *mechanism*, not just width.)

Note: the header has no "filter" control; the issue's "filter/refresh" wording refers to the sort ⇅ menu.

## Fix

Scoped CSS in `UpNextPanel.svelte`, no markup/logic change:

- `.un-head`: drop `flex-wrap: wrap` (→ `nowrap`).
- `.un-title-h` **and** `.un-updated`: `min-width: 0` + `overflow/ellipsis/nowrap` — the text is the shrink valve, so a too-narrow panel truncates text instead of wrapping a button. Both spans shrink so a valve exists even in the loading state (where `.un-updated` is absent).
- `.un-refresh` / `.un-sortbtn` / `.un-sortwrap`: `flex: none` — icons never shrink/grow; `margin-left: auto` still pins sort to the right edge on the single line.

## Verification

Font-agnostic regression test added to `UpNextPanel.browser.test.ts` (real Blink harness), red before the fix, green after:

- asserts computed `flex-wrap === 'nowrap'` (mechanism guard);
- A/B header height at a wide panel (600px) vs a forced-narrow one (140px) — equal = single row, no wrap-induced growth. No px/font-metric assumptions;
- covers both the snapshot **and** loading states.

`bun run check` (0 errors), `check:i18n` (parity), full `UpNextPanel` browser suite (25/25), root `bun run lint`, prettier, and the pre-push hygiene/fallow gates all pass.

## Accessibility

The refresh/sort icons remain the panel's pre-existing compact ~30px controls (deliberate sub-44px tap targets in this dense chrome — unchanged by this PR). Flagging for reviewer confirmation of the existing waiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)