### PR TITLE
fix(ui): surface stalled plan actions

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -616,7 +616,7 @@
   "plangate_tip_planning": "Planprüfung vor der Ausführung erforderlich.",
   "plangate_tip_reviewing": "Planprüfung läuft.",
   "plangate_tip_changes": "Ausführung wartet auf eine freigegebene Überarbeitung.",
-  "plangate_tip_changes_stalled": "Plan ist blockiert; siehe Session-Karte.",
+  "plangate_tip_changes_stalled": "Plan ist blockiert; öffne den Plan, um fortzusetzen oder zu verwerfen.",
   "plangate_tip_ready": "Plan freigegeben; Ausführung kann starten.",
   "plangate_tip_error": "Prüfung wurde nicht abgeschlossen; vor der Ausführung erneut starten.",
   "plangate_tip_view": "Ausführung hat begonnen; Plan ist schreibgeschützt.",
@@ -637,7 +637,7 @@
   "planpanel_review_failed": "Prüfung konnte nicht gestartet werden. Bitte erneut versuchen.",
   "planpanel_status_ready": "Plan freigegeben. Starte die Ausführung, wenn bereit.",
   "planpanel_status_changes": "Prüfung hat Änderungen angefordert. Los wird erst nach Überarbeitung und Freigabe aktiv.",
-  "planpanel_status_changes_stalled": "Prüfung hat Änderungen angefordert und Shepherd markiert diesen Plan als blockiert. Die Session-Karte zeigt, warum sie wartet; steuere den Agenten im Terminal weiter.",
+  "planpanel_status_changes_stalled": "Prüfung hat Änderungen angefordert und Shepherd markiert diesen Plan als blockiert. Setze den Planner mit den Befunden fort oder verwirf den Stall, um selbst zu übernehmen.",
   "planpanel_status_error": "Prüfung wurde nicht abgeschlossen. Vor der Ausführung erneut starten.",
   "planpanel_status_planning": "Prüfe den Plan, bevor die Ausführung starten kann.",
   "planpanel_status_reviewing": "Planprüfung läuft. Ausführung wartet auf Freigabe.",
@@ -2731,5 +2731,12 @@
   "newtask_provider_capacity_free": "{pct}% frei",
   "newtask_provider_capacity_unavailable": "Keine Nutzungsfenster-Daten",
   "feat_provider_capacity_gauge_title": "Vergleiche die Coding-CLI-Kapazität vor der Auswahl",
-  "feat_provider_capacity_gauge_body": "Das Neue-Aufgabe-Formular zeigt Claude Code und Codex jetzt nebeneinander mit ihrem verbleibenden Spielraum unter dem Coding-CLI-Auswahlfeld, damit du vor dem Starten eines Laufs den Provider mit der größten Reserve wählen kannst."
+  "feat_provider_capacity_gauge_body": "Das Neue-Aufgabe-Formular zeigt Claude Code und Codex jetzt nebeneinander mit ihrem verbleibenden Spielraum unter dem Coding-CLI-Auswahlfeld, damit du vor dem Starten eines Laufs den Provider mit der größten Reserve wählen kannst.",
+  "planpanel_quota_resume": "Mit Befunden fortsetzen",
+  "planpanel_quota_resuming": "Setze fort…",
+  "planpanel_quota_dismiss": "Stall verwerfen",
+  "planpanel_quota_dismissing": "Verwerfe…",
+  "planpanel_quota_unreachable": "Der Planungsbereich war nicht erreichbar. Der Plan wurde nicht fortgesetzt.",
+  "planpanel_quota_not_stalled": "Dieser Plan ist nicht mehr blockiert. Aktualisiere oder prüfe erneut, falls der Status veraltet wirkt.",
+  "planpanel_quota_failed": "Der blockierte Plan konnte nicht aktualisiert werden. Bitte erneut versuchen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -616,7 +616,7 @@
   "plangate_tip_planning": "Plan review required before execution.",
   "plangate_tip_reviewing": "Plan review is running.",
   "plangate_tip_changes": "Execution waits for an approved revision.",
-  "plangate_tip_changes_stalled": "Plan is stalled; check the session card.",
+  "plangate_tip_changes_stalled": "Plan is stalled; open the plan to resume or dismiss it.",
   "plangate_tip_ready": "Plan approved; execution can start.",
   "plangate_tip_error": "Review did not complete; re-run it before execution.",
   "plangate_tip_view": "Execution has started; plan is read-only.",
@@ -637,7 +637,7 @@
   "planpanel_review_failed": "Couldn't start the review. Please try again.",
   "planpanel_status_ready": "Plan approved. Start execution when ready.",
   "planpanel_status_changes": "Review requested changes. Go unlocks after the plan is revised and approved.",
-  "planpanel_status_changes_stalled": "Review requested changes and Shepherd marked this plan stalled. The session card shows why it is waiting; steer the agent from the terminal.",
+  "planpanel_status_changes_stalled": "Review requested changes and Shepherd marked this plan stalled. Resume the planner with the findings or dismiss the stall to take over.",
   "planpanel_status_error": "Review did not complete. Re-run it before execution.",
   "planpanel_status_planning": "Review the plan before execution can start.",
   "planpanel_status_reviewing": "Plan review is running. Execution waits for approval.",
@@ -2731,5 +2731,12 @@
   "newtask_provider_capacity_free": "{pct}% free",
   "newtask_provider_capacity_unavailable": "No usage-window data",
   "feat_provider_capacity_gauge_title": "Compare Coding CLI capacity before you pick",
-  "feat_provider_capacity_gauge_body": "The New Task form now shows Claude Code and Codex side by side with their remaining usage room below the Coding CLI selector, so you can choose the provider with the most headroom before you start a run."
+  "feat_provider_capacity_gauge_body": "The New Task form now shows Claude Code and Codex side by side with their remaining usage room below the Coding CLI selector, so you can choose the provider with the most headroom before you start a run.",
+  "planpanel_quota_resume": "Resume with findings",
+  "planpanel_quota_resuming": "Resuming…",
+  "planpanel_quota_dismiss": "Dismiss stall",
+  "planpanel_quota_dismissing": "Dismissing…",
+  "planpanel_quota_unreachable": "Couldn't reach the planning pane. The plan was not resumed.",
+  "planpanel_quota_not_stalled": "This plan is no longer stalled. Refresh or review again if the state looks stale.",
+  "planpanel_quota_failed": "Couldn't update the stalled plan. Please try again."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1649,6 +1649,25 @@ export async function reviewPlan(id: string): Promise<PlanReviewTrigger> {
   return body.status ?? "skipped";
 }
 
+export type PlanQuotaResumeStatus = "resumed" | "unreachable" | "not-stalled" | (string & {});
+export type PlanQuotaDismissStatus = "dismissed" | "not-stalled" | (string & {});
+
+/** Resume a quota-stalled plan gate. Status decides whether the PTY was reached. */
+export async function resumeQuota(id: string): Promise<{ status: PlanQuotaResumeStatus }> {
+  const r = await fetch(`/api/sessions/${id}/quota/resume`, JSON_POST());
+  if (!r.ok) throw await failed(r, "quota resume");
+  const body = (await r.json().catch(() => ({}))) as { status?: string };
+  return { status: body.status ?? "not-stalled" };
+}
+
+/** Dismiss a quota-stalled plan gate without steering the findings back to the agent. */
+export async function dismissQuota(id: string): Promise<{ status: PlanQuotaDismissStatus }> {
+  const r = await fetch(`/api/sessions/${id}/quota/dismiss`, JSON_POST());
+  if (!r.ok) throw await failed(r, "quota dismiss");
+  const body = (await r.json().catch(() => ({}))) as { status?: string };
+  return { status: body.status ?? "not-stalled" };
+}
+
 /** Submit operator answers to a plan's question-form (#803). The server resolves them against the
  *  gate's persisted questions, composes a steer, and delivers it to the live planning agent.
  *  Returns whether the steer reached the PTY (`delivered:false` ⇒ the planning pane is gone).

--- a/ui/src/lib/components/PlanGateBadge.svelte
+++ b/ui/src/lib/components/PlanGateBadge.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import type { Session } from "$lib/types";
   import { planGates } from "$lib/reviews.svelte";
-  import { composePlanGateTooltip, planGateChip, planGateStalled } from "./plan-gate-badge";
+  import {
+    canShowPlanStallActions,
+    composePlanGateTooltip,
+    planGateChip,
+    planGateStalled,
+  } from "./plan-gate-badge";
   import PlanPanel from "./PlanPanel.svelte";
   import PlanGateMenu from "./PlanGateMenu.svelte";
   import { m } from "$lib/paraglide/messages";
@@ -30,6 +35,7 @@
   const gate = $derived(planGates.map[session.id]);
   const reviewing = $derived(planGates.isReviewing(session.id));
   const chip = $derived(planGateChip(session, gate, reviewing, { allowView }));
+  const stalledActionsVisible = $derived(canShowPlanStallActions(session, gate, reviewing));
   const pulseClass = $derived(pulseReady && chip.kind === "ready" ? " pg-pulse-ready" : "");
   const stalled = $derived(planGateStalled(chip));
 
@@ -39,16 +45,21 @@
   let busy = $state<"send" | "review" | null>(null);
 
   const title = $derived(
-    composePlanGateTooltip(chip, gate, {
-      fallback: m.plangate_title(),
-      planning: m.plangate_tip_planning(),
-      reviewing: m.plangate_tip_reviewing(),
-      changes: m.plangate_tip_changes(),
-      changesStalled: m.plangate_tip_changes_stalled(),
-      ready: m.plangate_tip_ready(),
-      error: m.plangate_tip_error(),
-      view: m.plangate_tip_view(),
-    }),
+    composePlanGateTooltip(
+      chip,
+      gate,
+      {
+        fallback: m.plangate_title(),
+        planning: m.plangate_tip_planning(),
+        reviewing: m.plangate_tip_reviewing(),
+        changes: m.plangate_tip_changes(),
+        changesStalled: m.plangate_tip_changes_stalled(),
+        ready: m.plangate_tip_ready(),
+        error: m.plangate_tip_error(),
+        view: m.plangate_tip_view(),
+      },
+      { stalledActionsVisible },
+    ),
   );
 
   function closeMenu() {

--- a/ui/src/lib/components/PlanGateBadge.test.ts
+++ b/ui/src/lib/components/PlanGateBadge.test.ts
@@ -6,6 +6,7 @@ import {
   type PlanGateTooltipCopy,
 } from "./plan-gate-badge";
 import type { PlanGate, Session } from "$lib/types";
+import { m } from "$lib/paraglide/messages";
 
 const baseGate: PlanGate = {
   sessionId: "s1",
@@ -27,7 +28,7 @@ const tooltipCopy: PlanGateTooltipCopy = {
   planning: "Review before execution.",
   reviewing: "Review running.",
   changes: "Execution waits for approval.",
-  changesStalled: "Plan is stalled.",
+  changesStalled: m.plangate_tip_changes_stalled(),
   ready: "Plan approved.",
   error: "Review did not complete.",
   view: "Execution started.",
@@ -154,9 +155,9 @@ describe("composePlanGateTooltip", () => {
 
   it("uses stalled copy for changes at the round cap", () => {
     const chip = planGateChip(sess("planning"), gate({ round: 3, cap: 3 }), false);
-    expect(composePlanGateTooltip(chip, gate({ summary: "" }), tooltipCopy)).toBe(
-      "Plan is stalled.",
-    );
+    const tooltip = composePlanGateTooltip(chip, gate({ summary: "" }), tooltipCopy);
+    expect(tooltip).toBe(m.plangate_tip_changes_stalled());
+    expect(tooltip.toLowerCase()).not.toContain("stall banner");
   });
 
   it("covers ready, error, and view states without a summary", () => {

--- a/ui/src/lib/components/PlanGateBadge.test.ts
+++ b/ui/src/lib/components/PlanGateBadge.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   planGateChip,
   canRelease,
+  canShowPlanStallActions,
   composePlanGateTooltip,
   type PlanGateTooltipCopy,
 } from "./plan-gate-badge";
@@ -23,6 +24,10 @@ const baseGate: PlanGate = {
 };
 const gate = (p: Partial<PlanGate>): PlanGate => ({ ...baseGate, ...p });
 const sess = (planPhase: Session["planPhase"]): Pick<Session, "planPhase"> => ({ planPhase });
+const actionSess = (
+  planPhase: Session["planPhase"],
+  status: Session["status"] = "idle",
+): Pick<Session, "planPhase" | "status"> => ({ planPhase, status });
 const tooltipCopy: PlanGateTooltipCopy = {
   fallback: "Plan gate",
   planning: "Review before execution.",
@@ -145,6 +150,26 @@ describe("canRelease", () => {
   });
 });
 
+describe("canShowPlanStallActions", () => {
+  it("matches the actionable stalled plan state", () => {
+    expect(
+      canShowPlanStallActions(
+        actionSess("planning"),
+        gate({ decision: "changes_requested", round: 3, cap: 3 }),
+        false,
+      ),
+    ).toBe(true);
+  });
+
+  it("is false while the planning agent or reviewer is running", () => {
+    const stalledGate = gate({ decision: "changes_requested", round: 3, cap: 3 });
+    expect(canShowPlanStallActions(actionSess("planning", "running"), stalledGate, false)).toBe(
+      false,
+    );
+    expect(canShowPlanStallActions(actionSess("planning"), stalledGate, true)).toBe(false);
+  });
+});
+
 describe("composePlanGateTooltip", () => {
   it("preserves reviewer summary and appends the causal hint", () => {
     const chip = planGateChip(sess("planning"), gate({ summary: "tighten scope" }), false);
@@ -155,9 +180,18 @@ describe("composePlanGateTooltip", () => {
 
   it("uses stalled copy for changes at the round cap", () => {
     const chip = planGateChip(sess("planning"), gate({ round: 3, cap: 3 }), false);
-    const tooltip = composePlanGateTooltip(chip, gate({ summary: "" }), tooltipCopy);
+    const tooltip = composePlanGateTooltip(chip, gate({ summary: "" }), tooltipCopy, {
+      stalledActionsVisible: true,
+    });
     expect(tooltip).toBe(m.plangate_tip_changes_stalled());
     expect(tooltip.toLowerCase()).not.toContain("stall banner");
+  });
+
+  it("uses non-actionable changes copy at the round cap when stall actions are hidden", () => {
+    const chip = planGateChip(sess("planning"), gate({ round: 3, cap: 3 }), false);
+    expect(composePlanGateTooltip(chip, gate({ summary: "" }), tooltipCopy)).toBe(
+      "Execution waits for approval.",
+    );
   });
 
   it("covers ready, error, and view states without a summary", () => {

--- a/ui/src/lib/components/PlanPanel.browser.test.ts
+++ b/ui/src/lib/components/PlanPanel.browser.test.ts
@@ -262,6 +262,43 @@ describe("PlanPanel release state", () => {
     await expect.element(page.getByRole("dialog", { name: m.planpanel_title() })).toBeVisible();
   });
 
+  it("keeps unreachable feedback visible after the server resets the plan gate round", async () => {
+    const id = "s-unreachable-reset";
+    const onclose = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        planGates.apply(
+          id,
+          gate(id, {
+            decision: "changes_requested",
+            round: 0,
+            cap: 3,
+            approved: false,
+          }),
+        );
+        return new Response(JSON.stringify({ ok: true, status: "unreachable" }), { status: 202 });
+      }),
+    );
+    planGates.map = {
+      [id]: gate(id, {
+        decision: "changes_requested",
+        round: 3,
+        cap: 3,
+        approved: false,
+      }),
+    };
+
+    render(PlanPanel, {
+      props: { session: session({ id }), onclose },
+    });
+
+    await page.getByRole("button", { name: m.planpanel_quota_resume() }).click();
+    await expect.element(page.getByText(m.planpanel_status_changes())).toBeVisible();
+    await expect.element(page.getByText(m.planpanel_quota_unreachable())).toBeVisible();
+    expect(onclose).not.toHaveBeenCalled();
+  });
+
   it("keeps the panel open when the quota endpoint reports not-stalled", async () => {
     const id = "s-not-stalled";
     const onclose = vi.fn();

--- a/ui/src/lib/components/PlanPanel.browser.test.ts
+++ b/ui/src/lib/components/PlanPanel.browser.test.ts
@@ -92,7 +92,9 @@ afterEach(() => {
   document.querySelectorAll(".overlay").forEach((el) => el.remove());
   // Clean up any seeded plan gate entries.
   planGates.map = {};
+  planGates.reviewing = {};
   vi.mocked(reviewPlan).mockResolvedValue("skipped");
+  vi.unstubAllGlobals();
 });
 
 describe("PlanPanel portal", () => {
@@ -174,6 +176,194 @@ describe("PlanPanel release state", () => {
     });
 
     await expect.element(page.getByText(m.planpanel_status_changes_stalled())).toBeVisible();
+  });
+
+  it("resumes a stalled plan through the quota endpoint and closes on resumed", async () => {
+    const id = "s-resume";
+    const onclose = vi.fn();
+    const fetch = vi.fn(async () => {
+      return new Response(JSON.stringify({ ok: true, status: "resumed" }), { status: 202 });
+    });
+    vi.stubGlobal("fetch", fetch);
+    planGates.map = {
+      [id]: gate(id, {
+        decision: "changes_requested",
+        round: 3,
+        cap: 3,
+        approved: false,
+      }),
+    };
+
+    render(PlanPanel, {
+      props: { session: session({ id }), onclose },
+    });
+
+    await page.getByRole("button", { name: m.planpanel_quota_resume() }).click();
+    await vi.waitFor(() => expect(onclose).toHaveBeenCalledTimes(1));
+    expect(fetch).toHaveBeenCalledWith(
+      `/api/sessions/${id}/quota/resume`,
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("dismisses a stalled plan through the quota endpoint and closes on dismissed", async () => {
+    const id = "s-dismiss";
+    const onclose = vi.fn();
+    const fetch = vi.fn(async () => {
+      return new Response(JSON.stringify({ ok: true, status: "dismissed" }), { status: 202 });
+    });
+    vi.stubGlobal("fetch", fetch);
+    planGates.map = {
+      [id]: gate(id, {
+        decision: "changes_requested",
+        round: 3,
+        cap: 3,
+        approved: false,
+      }),
+    };
+
+    render(PlanPanel, {
+      props: { session: session({ id }), onclose },
+    });
+
+    await page.getByRole("button", { name: m.planpanel_quota_dismiss() }).click();
+    await vi.waitFor(() => expect(onclose).toHaveBeenCalledTimes(1));
+    expect(fetch).toHaveBeenCalledWith(
+      `/api/sessions/${id}/quota/dismiss`,
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("keeps the panel open when resume cannot reach the planning pane", async () => {
+    const id = "s-unreachable";
+    const onclose = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(JSON.stringify({ ok: true, status: "unreachable" }), { status: 202 });
+      }),
+    );
+    planGates.map = {
+      [id]: gate(id, {
+        decision: "changes_requested",
+        round: 3,
+        cap: 3,
+        approved: false,
+      }),
+    };
+
+    render(PlanPanel, {
+      props: { session: session({ id }), onclose },
+    });
+
+    await page.getByRole("button", { name: m.planpanel_quota_resume() }).click();
+    await expect.element(page.getByText(m.planpanel_quota_unreachable())).toBeVisible();
+    expect(onclose).not.toHaveBeenCalled();
+    await expect.element(page.getByRole("dialog", { name: m.planpanel_title() })).toBeVisible();
+  });
+
+  it("keeps the panel open when the quota endpoint reports not-stalled", async () => {
+    const id = "s-not-stalled";
+    const onclose = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(JSON.stringify({ ok: true, status: "not-stalled" }), { status: 202 });
+      }),
+    );
+    planGates.map = {
+      [id]: gate(id, {
+        decision: "changes_requested",
+        round: 3,
+        cap: 3,
+        approved: false,
+      }),
+    };
+
+    render(PlanPanel, {
+      props: { session: session({ id }), onclose },
+    });
+
+    await page.getByRole("button", { name: m.planpanel_quota_dismiss() }).click();
+    await expect.element(page.getByText(m.planpanel_quota_not_stalled())).toBeVisible();
+    expect(onclose).not.toHaveBeenCalled();
+    await expect.element(page.getByRole("dialog", { name: m.planpanel_title() })).toBeVisible();
+  });
+
+  it("keeps the panel open and shows failure copy when a quota action rejects", async () => {
+    const id = "s-quota-error";
+    const onclose = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(JSON.stringify({ error: "boom" }), { status: 500 });
+      }),
+    );
+    planGates.map = {
+      [id]: gate(id, {
+        decision: "changes_requested",
+        round: 3,
+        cap: 3,
+        approved: false,
+      }),
+    };
+
+    render(PlanPanel, {
+      props: { session: session({ id }), onclose },
+    });
+
+    await page.getByRole("button", { name: m.planpanel_quota_resume() }).click();
+    await expect.element(page.getByText(m.planpanel_quota_failed())).toBeVisible();
+    expect(onclose).not.toHaveBeenCalled();
+  });
+
+  it("does not render stalled quota actions while the planning agent is running", async () => {
+    const id = "s-running";
+    planGates.map = {
+      [id]: gate(id, {
+        decision: "changes_requested",
+        round: 3,
+        cap: 3,
+        approved: false,
+      }),
+    };
+
+    render(PlanPanel, {
+      props: { session: session({ id, status: "running" }), onclose: vi.fn() },
+    });
+
+    await expect.element(page.getByText(m.planpanel_status_changes_stalled())).toBeVisible();
+    await expect
+      .element(page.getByRole("button", { name: m.planpanel_quota_resume() }))
+      .not.toBeInTheDocument();
+    await expect
+      .element(page.getByRole("button", { name: m.planpanel_quota_dismiss() }))
+      .not.toBeInTheDocument();
+  });
+
+  it("does not render stalled quota actions while the plan reviewer is in flight", async () => {
+    const id = "s-reviewing";
+    planGates.map = {
+      [id]: gate(id, {
+        decision: "changes_requested",
+        round: 3,
+        cap: 3,
+        approved: false,
+      }),
+    };
+    planGates.applyReviewing(id, true);
+
+    render(PlanPanel, {
+      props: { session: session({ id }), onclose: vi.fn() },
+    });
+
+    await expect.element(page.getByText(m.planpanel_status_reviewing())).toBeVisible();
+    await expect
+      .element(page.getByRole("button", { name: m.planpanel_quota_resume() }))
+      .not.toBeInTheDocument();
+    await expect
+      .element(page.getByRole("button", { name: m.planpanel_quota_dismiss() }))
+      .not.toBeInTheDocument();
   });
 
   it("enables Go for an approved planning gate", async () => {

--- a/ui/src/lib/components/PlanPanel.browser.test.ts
+++ b/ui/src/lib/components/PlanPanel.browser.test.ts
@@ -176,6 +176,12 @@ describe("PlanPanel release state", () => {
     });
 
     await expect.element(page.getByText(m.planpanel_status_changes_stalled())).toBeVisible();
+    await expect
+      .element(page.getByRole("button", { name: m.planpanel_quota_resume() }))
+      .toBeVisible();
+    await expect
+      .element(page.getByRole("button", { name: m.planpanel_quota_dismiss() }))
+      .toBeVisible();
   });
 
   it("resumes a stalled plan through the quota endpoint and closes on resumed", async () => {
@@ -354,7 +360,7 @@ describe("PlanPanel release state", () => {
     expect(onclose).not.toHaveBeenCalled();
   });
 
-  it("does not render stalled quota actions while the planning agent is running", async () => {
+  it("does not render stalled action copy or quota actions while the planning agent is running", async () => {
     const id = "s-running";
     planGates.map = {
       [id]: gate(id, {
@@ -369,7 +375,10 @@ describe("PlanPanel release state", () => {
       props: { session: session({ id, status: "running" }), onclose: vi.fn() },
     });
 
-    await expect.element(page.getByText(m.planpanel_status_changes_stalled())).toBeVisible();
+    await expect.element(page.getByText(m.planpanel_status_changes())).toBeVisible();
+    await expect
+      .element(page.getByText(m.planpanel_status_changes_stalled()))
+      .not.toBeInTheDocument();
     await expect
       .element(page.getByRole("button", { name: m.planpanel_quota_resume() }))
       .not.toBeInTheDocument();

--- a/ui/src/lib/components/PlanPanel.svelte
+++ b/ui/src/lib/components/PlanPanel.svelte
@@ -236,15 +236,15 @@
   }
 
   const statusNoteId = $derived(`plan-status-${session.id}`);
-  const statusNote = $derived(planStatusNote(chip));
+  const statusNote = $derived(planStatusNote(chip, planStalled));
   const statusTone = $derived(planStatusTone(chip));
 
-  function planStatusNote(currentChip: typeof chip): string | null {
+  function planStatusNote(currentChip: typeof chip, stalledActionsVisible: boolean): string | null {
     switch (currentChip.kind) {
       case "ready":
         return m.planpanel_status_ready();
       case "changes":
-        return currentChip.round >= currentChip.cap
+        return stalledActionsVisible
           ? m.planpanel_status_changes_stalled()
           : m.planpanel_status_changes();
       case "error":

--- a/ui/src/lib/components/PlanPanel.svelte
+++ b/ui/src/lib/components/PlanPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { AgentProvider, Session } from "$lib/types";
   import { planGates } from "$lib/reviews.svelte";
-  import { releasePlanGate, reviewPlan } from "$lib/api";
+  import { dismissQuota, releasePlanGate, resumeQuota, reviewPlan } from "$lib/api";
   import { canRelease, planGateChip } from "./plan-gate-badge";
   import { dialog } from "$lib/a11yDialog";
   import { portal } from "$lib/portal";
@@ -36,6 +36,13 @@
   // its questions persist past approval), with submit locked while a review is in flight.
   const planAnswerCtx = $derived(
     canReviewNow ? { sessionId: session.id, locked: reviewing } : undefined,
+  );
+  const planStalled = $derived(
+    canReviewNow &&
+      session.status !== "running" &&
+      !reviewing &&
+      gate?.decision === "changes_requested" &&
+      gate.round >= gate.cap,
   );
   let envOpen = $state(false);
 
@@ -113,6 +120,8 @@
   let planUnavailable = $state(false);
   // A review is visibly in flight from the click until the WS reviewing flag clears.
   const inFlight = $derived(busy || reviewing || awaitingReview);
+  let quotaBusy = $state<"resume" | "dismiss" | null>(null);
+  let quotaOutcome = $state<"unreachable" | "not-stalled" | "error" | null>(null);
 
   // Once the WS `reviewing` flag takes over the in-flight indicator, drop the bridge and any
   // stale no-op/error note — a real run supersedes both.
@@ -126,6 +135,10 @@
 
   $effect(() => {
     if (gate || !canReviewNow) planUnavailable = false;
+  });
+
+  $effect(() => {
+    if (!planStalled) quotaOutcome = null;
   });
 
   // Backstop: if the `reviewing` event never arrives (lost/late), don't wedge the spinner.
@@ -173,6 +186,48 @@
       outcome = "error";
     } finally {
       busy = false;
+    }
+  }
+
+  async function resumeStalledPlan() {
+    if (!planStalled || quotaBusy) return;
+    quotaBusy = "resume";
+    quotaOutcome = null;
+    try {
+      const { status } = await resumeQuota(session.id);
+      if (status === "resumed") {
+        onclose();
+      } else if (status === "unreachable") {
+        quotaOutcome = "unreachable";
+      } else if (status === "not-stalled") {
+        quotaOutcome = "not-stalled";
+      } else {
+        quotaOutcome = "error";
+      }
+    } catch {
+      quotaOutcome = "error";
+    } finally {
+      quotaBusy = null;
+    }
+  }
+
+  async function dismissStalledPlan() {
+    if (!planStalled || quotaBusy) return;
+    quotaBusy = "dismiss";
+    quotaOutcome = null;
+    try {
+      const { status } = await dismissQuota(session.id);
+      if (status === "dismissed") {
+        onclose();
+      } else if (status === "not-stalled") {
+        quotaOutcome = "not-stalled";
+      } else {
+        quotaOutcome = "error";
+      }
+    } catch {
+      quotaOutcome = "error";
+    } finally {
+      quotaBusy = null;
     }
   }
 
@@ -360,10 +415,43 @@
         </p>
       {/if}
 
+      {#if planStalled}
+        <div class="quota-actions" aria-describedby={statusNote ? statusNoteId : undefined}>
+          <button
+            type="button"
+            class="quota-btn primary"
+            onclick={resumeStalledPlan}
+            disabled={quotaBusy !== null}
+          >
+            {quotaBusy === "resume" ? m.planpanel_quota_resuming() : m.planpanel_quota_resume()}
+          </button>
+          <button
+            type="button"
+            class="quota-btn"
+            onclick={dismissStalledPlan}
+            disabled={quotaBusy !== null}
+          >
+            {quotaBusy === "dismiss" ? m.planpanel_quota_dismissing() : m.planpanel_quota_dismiss()}
+          </button>
+        </div>
+        {#if quotaOutcome === "unreachable"}
+          <p class="note err" role="alert">{m.planpanel_quota_unreachable()}</p>
+        {:else if quotaOutcome === "not-stalled"}
+          <p class="note" role="status">{m.planpanel_quota_not_stalled()}</p>
+        {:else if quotaOutcome === "error"}
+          <p class="note err" role="alert">{m.planpanel_quota_failed()}</p>
+        {/if}
+      {/if}
+
       {#if !readonly}
         <div class="actions" aria-describedby={statusNote ? statusNoteId : undefined}>
           {#if canReviewNow}
-            <button type="button" class="review" onclick={review} disabled={inFlight}>
+            <button
+              type="button"
+              class="review"
+              onclick={review}
+              disabled={inFlight || !!quotaBusy}
+            >
               {#if inFlight}
                 <span class="rev-dot" aria-hidden="true"></span>{m.planpanel_reviewing()}
               {:else}
@@ -375,7 +463,7 @@
             type="button"
             class="go"
             onclick={go}
-            disabled={busy || !releasable}
+            disabled={busy || !!quotaBusy || !releasable}
             aria-describedby={statusNote ? statusNoteId : undefined}
           >
             {m.planpanel_go()}
@@ -665,6 +753,12 @@
     justify-content: flex-end;
     margin-top: 2px;
   }
+  .quota-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+  }
   .note {
     margin: 0;
     color: var(--color-muted);
@@ -691,7 +785,8 @@
     color: var(--color-red);
   }
   .review,
-  .go {
+  .go,
+  .quota-btn {
     border: 1px solid var(--color-line-bright);
     background: transparent;
     color: var(--color-ink);
@@ -707,6 +802,11 @@
     display: inline-flex;
     align-items: center;
     gap: 6px;
+  }
+  .quota-btn.primary {
+    border-color: var(--color-amber);
+    color: var(--color-amber);
+    box-shadow: inset 0 0 18px -10px var(--color-amber);
   }
   /* plan reviewer running now: amber pulsing dot (mirrors PlanGateBadge) */
   .rev-dot {
@@ -732,7 +832,8 @@
     box-shadow: inset 0 0 18px -10px var(--color-green);
   }
   .review:disabled,
-  .go:disabled {
+  .go:disabled,
+  .quota-btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
     color: var(--color-faint);

--- a/ui/src/lib/components/PlanPanel.svelte
+++ b/ui/src/lib/components/PlanPanel.svelte
@@ -130,15 +130,12 @@
       awaitingReview = false;
       outcome = null;
       planUnavailable = false;
+      quotaOutcome = null;
     }
   });
 
   $effect(() => {
     if (gate || !canReviewNow) planUnavailable = false;
-  });
-
-  $effect(() => {
-    if (!planStalled) quotaOutcome = null;
   });
 
   // Backstop: if the `reviewing` event never arrives (lost/late), don't wedge the spinner.
@@ -434,13 +431,13 @@
             {quotaBusy === "dismiss" ? m.planpanel_quota_dismissing() : m.planpanel_quota_dismiss()}
           </button>
         </div>
-        {#if quotaOutcome === "unreachable"}
-          <p class="note err" role="alert">{m.planpanel_quota_unreachable()}</p>
-        {:else if quotaOutcome === "not-stalled"}
-          <p class="note" role="status">{m.planpanel_quota_not_stalled()}</p>
-        {:else if quotaOutcome === "error"}
-          <p class="note err" role="alert">{m.planpanel_quota_failed()}</p>
-        {/if}
+      {/if}
+      {#if quotaOutcome === "unreachable"}
+        <p class="note err" role="alert">{m.planpanel_quota_unreachable()}</p>
+      {:else if quotaOutcome === "not-stalled"}
+        <p class="note" role="status">{m.planpanel_quota_not_stalled()}</p>
+      {:else if quotaOutcome === "error"}
+        <p class="note err" role="alert">{m.planpanel_quota_failed()}</p>
       {/if}
 
       {#if !readonly}

--- a/ui/src/lib/components/PlanPanel.svelte
+++ b/ui/src/lib/components/PlanPanel.svelte
@@ -2,7 +2,7 @@
   import type { AgentProvider, Session } from "$lib/types";
   import { planGates } from "$lib/reviews.svelte";
   import { dismissQuota, releasePlanGate, resumeQuota, reviewPlan } from "$lib/api";
-  import { canRelease, planGateChip } from "./plan-gate-badge";
+  import { canRelease, canShowPlanStallActions, planGateChip } from "./plan-gate-badge";
   import { dialog } from "$lib/a11yDialog";
   import { portal } from "$lib/portal";
   import { m } from "$lib/paraglide/messages";
@@ -37,13 +37,7 @@
   const planAnswerCtx = $derived(
     canReviewNow ? { sessionId: session.id, locked: reviewing } : undefined,
   );
-  const planStalled = $derived(
-    canReviewNow &&
-      session.status !== "running" &&
-      !reviewing &&
-      gate?.decision === "changes_requested" &&
-      gate.round >= gate.cap,
-  );
+  const planStalled = $derived(canShowPlanStallActions(session, gate, reviewing));
   let envOpen = $state(false);
 
   function providerLabel(provider: AgentProvider): string {

--- a/ui/src/lib/components/plan-gate-badge.ts
+++ b/ui/src/lib/components/plan-gate-badge.ts
@@ -66,6 +66,20 @@ export function canRelease(
   return Boolean(gate?.approved) && session.planPhase === "planning";
 }
 
+export function canShowPlanStallActions(
+  session: Pick<Session, "planPhase" | "status">,
+  gate: PlanGate | undefined,
+  reviewing: boolean,
+): boolean {
+  return Boolean(
+    session.planPhase === "planning" &&
+    session.status !== "running" &&
+    !reviewing &&
+    gate?.decision === "changes_requested" &&
+    gate.round >= gate.cap,
+  );
+}
+
 export type PlanGateTooltipCopy = {
   fallback: string;
   planning: string;
@@ -82,21 +96,28 @@ export function composePlanGateTooltip(
   chip: PlanGateChip,
   gate: Pick<PlanGate, "summary"> | undefined,
   copy: PlanGateTooltipCopy,
+  opts: { stalledActionsVisible?: boolean } = {},
 ): string {
   if (chip.kind === "none") return "";
-  const hint = planGateTooltipHint(chip, copy);
+  const hint = planGateTooltipHint(chip, copy, opts);
   const summary = gate?.summary?.trim();
   return summary ? `${summary}; ${hint}` : hint || copy.fallback;
 }
 
-function planGateTooltipHint(chip: PlanGateChip, copy: PlanGateTooltipCopy): string {
+function planGateTooltipHint(
+  chip: PlanGateChip,
+  copy: PlanGateTooltipCopy,
+  opts: { stalledActionsVisible?: boolean },
+): string {
   switch (chip.kind) {
     case "planning":
       return copy.planning;
     case "reviewing":
       return copy.reviewing;
     case "changes":
-      return chip.round >= chip.cap ? copy.changesStalled : copy.changes;
+      return chip.round >= chip.cap && opts.stalledActionsVisible
+        ? copy.changesStalled
+        : copy.changes;
     case "ready":
       return copy.ready;
     case "error":


### PR DESCRIPTION
## Summary
- Add Plan panel actions to resume a quota-stalled plan with reviewer findings or dismiss the stall/take over.
- Branch on quota endpoint statuses so unreachable/not-stalled responses keep the panel open and do not imply resume.
- Remove stale stall-banner copy from Plan panel and PlanGate badge tooltip, with EN/DE message parity and tests.

## Tests
- cd ui && bun run check:i18n
- cd ui && bun run test:node -- src/lib/components/PlanGateBadge.test.ts
- cd ui && bun run test:browser -- src/lib/components/PlanPanel.browser.test.ts
- cd ui && bun run check (passes with 2 existing warnings in CommandBar.svelte and FilesPanel.svelte)
- cd ui && bun test (attempted; global suite hit existing environment/harness failures unrelated to this diff, then hung and was killed after targeted tests passed)

Manual operator steps: none.