### PR TITLE
chore(ui): switch update flock to SVG art

### DIFF
--- a/ui/src/lib/components/SvgFlockOverlay.svelte
+++ b/ui/src/lib/components/SvgFlockOverlay.svelte
@@ -14,8 +14,8 @@
       id: "sheep-1",
       type: "sheep",
       kind: "light small",
-      art: "  __\n (oo)\\\n /||\\",
       lane: 18,
+      width: 92,
       start: 108,
       distance: -136,
       delay: "-1s",
@@ -24,9 +24,9 @@
     {
       id: "sheep-2",
       type: "sheep",
-      kind: "dark small",
-      art: " ,_,\n(oo)-.\n /|\\\\",
+      kind: "dark small flip",
       lane: 72,
+      width: 94,
       start: 93,
       distance: -124,
       delay: "-6s",
@@ -36,8 +36,8 @@
       id: "sheep-3",
       type: "sheep",
       kind: "light big",
-      art: "  .-''''-.\n /  (oo)  \\\n(__(____)__)\n   ||  ||",
       lane: 108,
+      width: 150,
       start: 116,
       distance: -150,
       delay: "-4s",
@@ -46,9 +46,9 @@
     {
       id: "sheep-4",
       type: "sheep",
-      kind: "dark big",
-      art: "   .-oooo-.\n  (  (oo) )\n   )  --  (\n  /__|  |__\\",
+      kind: "dark big flip",
       lane: 30,
+      width: 144,
       start: 70,
       distance: -100,
       delay: "-11s",
@@ -58,8 +58,8 @@
       id: "sheep-5",
       type: "sheep",
       kind: "light tiny reverse",
-      art: " _.\n(o)\n/|\\",
       lane: 150,
+      width: 76,
       start: -18,
       distance: 118,
       delay: "-9s",
@@ -69,8 +69,8 @@
       id: "sheep-6",
       type: "sheep",
       kind: "light small",
-      art: "  __\n (oo)\n/|  |\\",
       lane: 86,
+      width: 90,
       start: 42,
       distance: -74,
       delay: "-7s",
@@ -80,8 +80,8 @@
       id: "sheep-7",
       type: "sheep",
       kind: "dark small",
-      art: " .-.\n(oo)___\n || ||",
       lane: 166,
+      width: 96,
       start: 118,
       distance: -148,
       delay: "-14s",
@@ -91,8 +91,8 @@
       id: "dog",
       type: "dog",
       kind: "dog",
-      art: " /^..^\\\n/  _  \\\n  / \\_",
       lane: 10,
+      width: 92,
       start: 122,
       distance: -150,
       delay: "-4s",
@@ -109,15 +109,70 @@
   aria-hidden="true"
 >
   {#each actors as actor (actor.id)}
-    <pre
+    <svg
       class="actor {actor.kind}"
       data-flock-actor={actor.type}
-      data-flock-art={actor.id}
+      viewBox={actor.type === "dog" ? "0 0 96 58" : "0 0 150 96"}
       style:--lane={`${actor.lane}px`}
       style:--start={`${actor.start}vw`}
       style:--distance={`${actor.distance}vw`}
       style:--delay={actor.delay}
-      style:--duration={actor.duration}>{actor.art}</pre>
+      style:--duration={actor.duration}
+      style:--actor-width={`${actor.width}px`}
+      role="img"
+    >
+      {#if actor.type === "dog"}
+        <g class="sprite dog-sprite">
+          <path
+            class="dog-line body"
+            data-dog-body
+            d="M19 37 C24 23 39 20 51 28 L70 26 C78 25 84 31 84 39"
+          />
+          <path class="dog-line head" d="M20 37 L11 27 L20 19 L33 29" />
+          <path class="dog-line ear" d="M17 24 L13 12 L27 21" />
+          <path class="dog-line tail" d="M81 31 C91 24 94 16 91 8" />
+          <path class="dog-line legs" d="M38 35 L32 50 M60 34 L65 50" />
+          <circle class="dog-eye" cx="22" cy="27" r="2.4" />
+        </g>
+      {:else}
+        <g class="sprite sheep-sprite">
+          <path
+            class="sheep-leg rear"
+            d="M42 61 L38 88 M64 63 L62 88 M92 62 L95 88 M110 60 L115 86"
+          />
+          <path
+            class="wool base"
+            data-sheep-body
+            d="M35 59
+               C20 58 14 45 22 34
+               C17 22 30 12 43 18
+               C50 4 71 6 77 20
+               C89 8 107 17 106 32
+               C121 30 130 43 124 56
+               C130 68 115 78 101 71
+               C91 83 72 80 68 68
+               C56 80 37 75 35 59Z"
+          />
+          <circle class="wool puff" cx="34" cy="39" r="16" />
+          <circle class="wool puff" cx="52" cy="24" r="18" />
+          <circle class="wool puff" cx="76" cy="25" r="20" />
+          <circle class="wool puff" cx="99" cy="37" r="18" />
+          <circle class="wool puff" cx="54" cy="58" r="20" />
+          <circle class="wool puff" cx="84" cy="60" r="19" />
+          <path
+            class="face"
+            d="M112 40
+               C128 35 141 45 140 60
+               C139 76 122 81 112 69
+               C105 61 104 46 112 40Z"
+          />
+          <path class="ear" d="M117 43 C116 30 130 28 132 40 C127 41 122 43 117 43Z" />
+          <path class="snout" d="M127 62 C131 64 135 63 137 60" />
+          <circle class="eye" cx="127" cy="53" r="3" />
+          <path class="tail" d="M22 48 C11 46 9 56 18 60" />
+        </g>
+      {/if}
+    </svg>
   {/each}
 </div>
 
@@ -141,39 +196,92 @@
     position: absolute;
     bottom: var(--lane);
     left: 0;
-    margin: 0;
+    width: var(--actor-width);
+    height: auto;
     color: var(--color-ink-bright);
-    font-family: inherit;
-    font-size: var(--fs-meta);
-    font-weight: 700;
-    line-height: 1;
-    letter-spacing: 0;
-    white-space: pre;
-    opacity: 0.64;
+    opacity: 0.62;
+    overflow: visible;
     transform: translate3d(var(--start), 0, 0);
     animation:
       flock-cross var(--duration) linear var(--delay) infinite,
       flock-wiggle 0.58s ease-in-out var(--delay) infinite alternate;
   }
   .actor.big {
-    font-size: var(--fs-base);
-    opacity: 0.58;
+    opacity: 0.56;
   }
   .actor.tiny {
-    font-size: var(--fs-micro);
-    opacity: 0.58;
+    opacity: 0.54;
   }
   .actor.dark {
     color: var(--color-slate);
-    opacity: 0.68;
+    opacity: 0.66;
   }
   .actor.dog {
     color: var(--color-amber);
-    font-size: var(--fs-base);
     opacity: 0.82;
     animation:
       flock-cross var(--duration) linear var(--delay) infinite,
       dog-loop 0.46s ease-in-out var(--delay) infinite alternate;
+  }
+  .sprite {
+    transform-origin: center;
+  }
+  .actor.flip .sprite {
+    transform: translateX(150px) scaleX(-1);
+  }
+  .actor.dog.flip .sprite {
+    transform: translateX(96px) scaleX(-1);
+  }
+  .wool {
+    fill: currentColor;
+    stroke: color-mix(in srgb, currentColor 64%, var(--color-bg));
+    stroke-width: 3;
+    stroke-linejoin: round;
+  }
+  .wool.base {
+    opacity: 0.82;
+  }
+  .wool.puff {
+    opacity: 0.96;
+  }
+  .face,
+  .ear {
+    fill: var(--color-bg);
+    stroke: currentColor;
+    stroke-width: 4;
+    stroke-linejoin: round;
+  }
+  .tail,
+  .snout,
+  .eye {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 3;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+  .eye {
+    fill: currentColor;
+    stroke: none;
+  }
+  .sheep-leg {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 5;
+    stroke-linecap: round;
+  }
+  .sheep-leg.rear {
+    opacity: 0.82;
+  }
+  .dog-line {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 4;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+  .dog-eye {
+    fill: currentColor;
   }
   .flock.reduced .actor {
     animation: none;
@@ -245,13 +353,13 @@
       z-index: 0;
     }
     .actor {
-      opacity: 0.3;
+      opacity: 0.26;
     }
     .actor.big {
-      opacity: 0.28;
+      opacity: 0.24;
     }
     .actor.dog {
-      opacity: 0.42;
+      opacity: 0.38;
     }
   }
 

--- a/ui/src/lib/components/UpdateModal.browser.test.ts
+++ b/ui/src/lib/components/UpdateModal.browser.test.ts
@@ -106,8 +106,8 @@ describe("UpdateModal", () => {
 
     const flock = document.querySelector<HTMLElement>('[data-flock="backdrop"]');
     const sheet = document.querySelector<HTMLElement>('[data-flock="sheet"]');
-    const sheep = flock?.querySelector<HTMLElement>('[data-flock-actor="sheep"]');
-    const dog = flock?.querySelector<HTMLElement>('[data-flock-actor="dog"]');
+    const sheep = flock?.querySelector<SVGElement>('[data-flock-actor="sheep"]');
+    const dog = flock?.querySelector<SVGElement>('[data-flock-actor="dog"]');
     const card = document.querySelector<HTMLElement>(".card");
     const run = page.getByRole("button", { name: /updating/i });
 
@@ -115,10 +115,10 @@ describe("UpdateModal", () => {
     expect(sheet).not.toBeNull();
     expect(sheep).not.toBeNull();
     expect(dog).not.toBeNull();
-    expect(flock!.querySelector("svg")).toBeNull();
-    expect(sheep!.tagName).toBe("PRE");
-    expect(sheep!.textContent).toContain("(oo)");
-    expect(dog!.textContent).toContain("^..^");
+    expect(flock!.querySelector("pre")).toBeNull();
+    expect(sheep!.tagName).toBe("svg");
+    expect(sheep!.querySelector("[data-sheep-body]")).not.toBeNull();
+    expect(dog!.querySelector("[data-dog-body]")).not.toBeNull();
     expect(card).not.toBeNull();
     await expect.element(run).toBeVisible();
 
@@ -180,8 +180,8 @@ describe("UpdateModal", () => {
     expect(after.top).toBeLessThan(window.innerHeight);
     expect(sheet!.querySelectorAll('[data-flock-actor="sheep"]').length).toBeGreaterThan(1);
     expect(sheet!.querySelector('[data-flock-actor="dog"]')).not.toBeNull();
-    expect(sheet!.querySelector("svg")).toBeNull();
-    expect(sheet!.textContent).toContain("(oo)");
+    expect(sheet!.querySelector("pre")).toBeNull();
+    expect(sheet!.querySelector("[data-sheep-body]")).not.toBeNull();
   });
 
   it("uses a testable static flock state when reduced motion is requested", async () => {
@@ -196,13 +196,13 @@ describe("UpdateModal", () => {
     });
 
     const flock = document.querySelector<HTMLElement>('[data-flock="backdrop"]');
-    const actor = flock?.querySelector<HTMLElement>(".actor");
+    const actor = flock?.querySelector<SVGElement>(".actor");
     expect(flock).not.toBeNull();
     expect(actor).not.toBeNull();
 
     await vi.waitFor(() => expect(flock!.dataset.reduced).toBe("true"));
     expect(getComputedStyle(actor!).animationName).toBe("none");
     expect(flock!.querySelectorAll('[data-flock-actor="sheep"]').length).toBeGreaterThan(1);
-    expect(flock!.textContent).toContain("(oo)");
+    expect(flock!.querySelector("[data-sheep-body]")).not.toBeNull();
   });
 });

--- a/ui/src/lib/components/UpdateModal.svelte
+++ b/ui/src/lib/components/UpdateModal.svelte
@@ -3,7 +3,7 @@
   import { applyUpdate } from "$lib/api";
   import { dialog } from "$lib/a11yDialog";
   import { m } from "$lib/paraglide/messages";
-  import AsciiFlockOverlay from "$lib/components/AsciiFlockOverlay.svelte";
+  import SvgFlockOverlay from "$lib/components/SvgFlockOverlay.svelte";
 
   let {
     update,
@@ -56,7 +56,7 @@
   }}
 >
   {#if busy}
-    <AsciiFlockOverlay placement="backdrop" />
+    <SvgFlockOverlay placement="backdrop" />
   {/if}
   <div
     class="card bracket"
@@ -66,7 +66,7 @@
     use:dialog={{ onclose: () => !busy && onclose?.() }}
   >
     {#if busy}
-      <AsciiFlockOverlay placement="sheet" />
+      <SvgFlockOverlay placement="sheet" />
     {/if}
     <div class="card-content">
       <div class="chead">


### PR DESCRIPTION
## Summary
- replace the update-modal ASCII flock overlay with inline SVG sheep and shepherd-dog art
- keep the existing bottom overlay layering, mobile sheet behavior, and reduced-motion static state
- update browser assertions for SVG actors

[no-feature-entry]

## Checks
- cd ui && bun run test:browser -- UpdateModal.browser.test.ts
- cd ui && bun run check
- pre-push hook