### PR TITLE
fix(ui): redo update-flock ASCII art (consistent sheep + real dog)

### DIFF
--- a/ui/src/lib/components/AsciiFlockOverlay.svelte
+++ b/ui/src/lib/components/AsciiFlockOverlay.svelte
@@ -9,15 +9,21 @@
     reducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
   });
 
+  // Front-facing fluffy sheep (direction-neutral) + a side-profile herding dog
+  // that faces right, so the whole flock drifts left→right (the dog trots
+  // forward rather than moon-walking). One sheep silhouette, reused + size-scaled.
+  const SHEEP = " (@@@)\n (o.o)\n (   )\n || ||";
+  const DOG = " ___\n(___()'`;\n/,    /`\n\\\"--\\\\";
+
   const actors = [
     {
       id: "sheep-1",
       type: "sheep",
       kind: "light small",
-      art: "  __\n (oo)\\\n /||\\",
-      lane: 18,
-      start: 108,
-      distance: -136,
+      art: SHEEP,
+      lane: 20,
+      start: -12,
+      distance: 140,
       delay: "-1s",
       duration: "11s",
     },
@@ -25,10 +31,10 @@
       id: "sheep-2",
       type: "sheep",
       kind: "dark small",
-      art: " ,_,\n(oo)-.\n /|\\\\",
-      lane: 72,
-      start: 93,
-      distance: -124,
+      art: SHEEP,
+      lane: 70,
+      start: -20,
+      distance: 132,
       delay: "-6s",
       duration: "13s",
     },
@@ -36,10 +42,10 @@
       id: "sheep-3",
       type: "sheep",
       kind: "light big",
-      art: "  .-''''-.\n /  (oo)  \\\n(__(____)__)\n   ||  ||",
-      lane: 108,
-      start: 116,
-      distance: -150,
+      art: SHEEP,
+      lane: 120,
+      start: -8,
+      distance: 150,
       delay: "-4s",
       duration: "16s",
     },
@@ -47,21 +53,21 @@
       id: "sheep-4",
       type: "sheep",
       kind: "dark big",
-      art: "   .-oooo-.\n  (  (oo) )\n   )  --  (\n  /__|  |__\\",
-      lane: 30,
-      start: 70,
-      distance: -100,
+      art: SHEEP,
+      lane: 40,
+      start: -28,
+      distance: 140,
       delay: "-11s",
       duration: "18s",
     },
     {
       id: "sheep-5",
       type: "sheep",
-      kind: "light tiny reverse",
-      art: " _.\n(o)\n/|\\",
-      lane: 150,
-      start: -18,
-      distance: 118,
+      kind: "light tiny",
+      art: SHEEP,
+      lane: 100,
+      start: -16,
+      distance: 140,
       delay: "-9s",
       duration: "12s",
     },
@@ -69,10 +75,10 @@
       id: "sheep-6",
       type: "sheep",
       kind: "light small",
-      art: "  __\n (oo)\n/|  |\\",
-      lane: 86,
-      start: 42,
-      distance: -74,
+      art: SHEEP,
+      lane: 145,
+      start: 18,
+      distance: 96,
       delay: "-7s",
       duration: "10s",
     },
@@ -80,10 +86,10 @@
       id: "sheep-7",
       type: "sheep",
       kind: "dark small",
-      art: " .-.\n(oo)___\n || ||",
-      lane: 166,
-      start: 118,
-      distance: -148,
+      art: SHEEP,
+      lane: 60,
+      start: -18,
+      distance: 150,
       delay: "-14s",
       duration: "15s",
     },
@@ -91,10 +97,10 @@
       id: "dog",
       type: "dog",
       kind: "dog",
-      art: " /^..^\\\n/  _  \\\n  / \\_",
-      lane: 10,
-      start: 122,
-      distance: -150,
+      art: DOG,
+      lane: 8,
+      start: -24,
+      distance: 150,
       delay: "-4s",
       duration: "8s",
     },
@@ -162,6 +168,9 @@
   .actor.tiny {
     font-size: var(--fs-micro);
     opacity: 0.58;
+    animation:
+      flock-cross var(--duration) linear var(--delay) infinite,
+      flock-wiggle-tiny 0.58s ease-in-out var(--delay) infinite alternate;
   }
   .actor.dark {
     color: var(--color-slate);
@@ -182,25 +191,25 @@
     transform: translate3d(10vw, 0, 0);
   }
   .flock.reduced .actor:nth-child(2) {
-    transform: translate3d(24vw, 0, 0);
+    transform: translate3d(26vw, 0, 0);
   }
   .flock.reduced .actor:nth-child(3) {
-    transform: translate3d(42vw, 0, 0);
+    transform: translate3d(44vw, 0, 0);
   }
   .flock.reduced .actor:nth-child(4) {
-    transform: translate3d(62vw, 0, 0);
+    transform: translate3d(64vw, 0, 0);
   }
   .flock.reduced .actor:nth-child(5) {
-    transform: translate3d(76vw, 0, 0);
+    transform: translate3d(78vw, 0, 0);
   }
   .flock.reduced .actor:nth-child(6) {
-    transform: translate3d(33vw, 0, 0);
+    transform: translate3d(34vw, 0, 0);
   }
   .flock.reduced .actor:nth-child(7) {
-    transform: translate3d(88vw, 0, 0);
+    transform: translate3d(90vw, 0, 0);
   }
   .flock.reduced .actor:nth-child(8) {
-    transform: translate3d(54vw, 0, 0);
+    transform: translate3d(52vw, 0, 0);
   }
 
   @keyframes flock-cross {
@@ -219,6 +228,14 @@
     to {
       translate: 0 4px;
       rotate: 2deg;
+    }
+  }
+  @keyframes flock-wiggle-tiny {
+    from {
+      translate: 0 -3px;
+    }
+    to {
+      translate: 0 4px;
     }
   }
   @keyframes dog-loop {

--- a/ui/src/lib/components/UpdateModal.browser.test.ts
+++ b/ui/src/lib/components/UpdateModal.browser.test.ts
@@ -117,8 +117,8 @@ describe("UpdateModal", () => {
     expect(dog).not.toBeNull();
     expect(flock!.querySelector("svg")).toBeNull();
     expect(sheep!.tagName).toBe("PRE");
-    expect(sheep!.textContent).toContain("(oo)");
-    expect(dog!.textContent).toContain("^..^");
+    expect(sheep!.textContent).toContain("(o.o)");
+    expect(dog!.textContent).toContain("(___()");
     expect(card).not.toBeNull();
     await expect.element(run).toBeVisible();
 
@@ -181,7 +181,7 @@ describe("UpdateModal", () => {
     expect(sheet!.querySelectorAll('[data-flock-actor="sheep"]').length).toBeGreaterThan(1);
     expect(sheet!.querySelector('[data-flock-actor="dog"]')).not.toBeNull();
     expect(sheet!.querySelector("svg")).toBeNull();
-    expect(sheet!.textContent).toContain("(oo)");
+    expect(sheet!.textContent).toContain("(o.o)");
   });
 
   it("uses a testable static flock state when reduced motion is requested", async () => {
@@ -203,6 +203,6 @@ describe("UpdateModal", () => {
     await vi.waitFor(() => expect(flock!.dataset.reduced).toBe("true"));
     expect(getComputedStyle(actor!).animationName).toBe("none");
     expect(flock!.querySelectorAll('[data-flock-actor="sheep"]').length).toBeGreaterThan(1);
-    expect(flock!.textContent).toContain("(oo)");
+    expect(flock!.textContent).toContain("(o.o)");
   });
 });


### PR DESCRIPTION
## Why

The update-flock overlay behind the busy `UpdateModal` (added in #1513) was drawn with **seven inconsistent, arbitrary sheep shapes** and a **"dog" (`/^..^\`) that read as a cat** — it looked awful. The concept (a herd + a herding dog drifting past while an update applies) is charming and on-brand for a monospace terminal UI, so this keeps the concept and the well-tested machinery, and **redoes only the art**.

## What

- **One canonical sheep glyph, reused for all seven sheep**, size-scaled via the existing `small`/`big`/`tiny` classes — a front-facing fluffy sheep (`(@@@)` woolly crown, `(o.o)` face, body, `|| ||` four legs) that reads clearly even at 10–13px and low opacity.
- **A proper dog** — the classic side-profile `(___()'\`;` sheepdog — replacing the cat face.
- **Whole flock drifts left→right** so the right-facing dog trots forward instead of moon-walking; front-facing sheep are direction-neutral. (Dropped the one inert `reverse` actor.)
- **Retuned lanes + reduced-motion static positions** for the now-uniform 4-line sprite height (no top-clipping on short viewports).
- **Tiny sprite gets a translate-only wiggle** (no rotation) so it stays crisp at `--fs-micro`.
- Updated the four pinned glyph assertions in `UpdateModal.browser.test.ts` (`(o.o)` for sheep, `(___()` for dog — each a single-line signature unique to its actor).

## Verification

- `bun run check` → 0 errors (2 pre-existing warnings in unrelated files).
- `bun run test:browser` → `UpdateModal.browser.test.ts` 5/5 pass (still asserts PRE-not-SVG, placement, reduced-motion, counts).
- Rendered the busy modal at desktop + mobile and enlarged the static (reduced-motion) layout via throwaway screenshot specs — confirmed the sheep read as sheep and the dog as a dog — then removed the scaffolding.

## Notes

- Stays ASCII (`<pre>`), never SVG (a test enforces this; the earlier SVG detour in #1513 was reverted).
- Art is `aria-hidden` decorative, not user-facing text → exempt from i18n / feature-catalog / glossary, hence `[no-feature-entry]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
