### PR TITLE
fix(site): add OpenAI footer trademark attribution

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -55,8 +55,8 @@ const HERDR_AUTHOR_URL = "https://github.com/ogulcancelik";
     </p>
 
     <p class="disclaimer">
-      Not affiliated with Anthropic. Claude and Anthropic are trademarks of
-      Anthropic, PBC.
+      Not affiliated with Anthropic or OpenAI. Claude and Anthropic are
+      trademarks of Anthropic, PBC. OpenAI and Codex are trademarks of OpenAI.
     </p>
   </div>
 </footer>


### PR DESCRIPTION
## Summary
- update the public site footer disclaimer to cover both Anthropic and OpenAI
- attribute Claude/Anthropic to Anthropic, PBC and OpenAI/Codex to OpenAI

## Tests
- `cd site && bun run check`
- `rg -n "Not affiliated with Anthropic|OpenAI and Codex|trademarks of OpenAI" site docs-site ui README.md`

Closes #1477