### PR TITLE
fix(rework): stop stalled/dismissed rework showing as REWORK RUNNING

### DIFF
--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -563,6 +563,11 @@ export class PlanGateService {
     }
     // Round advances only when the steer actually lands; at/over the cap it holds.
     gate.round = priorRound >= this.cap ? priorRound : delivered ? priorRound + 1 : priorRound;
+    // The FINAL rework round is in flight only when THIS write is the cap-th delivered steer
+    // (priorRound === cap-1 → round === cap, delivered). The no-steer post-cap re-review
+    // (priorRound >= cap, delivered=false) and every sub-cap round leave it false, so
+    // planStallStatus can tell a genuine final round from a stall/takeover. See src/plan-status.ts.
+    gate.finalRoundPending = delivered && gate.round >= this.cap;
     if (gate.round >= this.cap) {
       // At/over the cap — a plan still unapproved after this many rounds can't progress on its own.
       // Fires on the crossing round and on any re-review that re-enters already at the cap.
@@ -677,7 +682,9 @@ export class PlanGateService {
   resume(session: Session): boolean {
     const gate = this.deps.store.getPlanGate(session.id);
     if (!gate || gate.decision !== "changes_requested") return false; // nothing to resume
-    const reset = { ...gate, round: 0 };
+    // Re-engaging active rework from a fresh round budget: clear dismissed + finalRoundPending so
+    // the re-steered agent classifies as REWORK RUNNING again (not stalled/taken-over).
+    const reset = { ...gate, round: 0, finalRoundPending: false, dismissed: false };
     this.deps.store.putPlanGate(reset);
     this.deps.onChange(session.id, reset);
     return this.deps.reply(session.id, planSteerText(gate.findings));
@@ -691,7 +698,9 @@ export class PlanGateService {
   dismiss(session: Session): void {
     const gate = this.deps.store.getPlanGate(session.id);
     if (!gate || gate.decision !== "changes_requested") return;
-    const reset = { ...gate, round: 0 };
+    // Operator took over: mark dismissed so the rework classification (REWORK RUNNING / banner /
+    // rundown) stops counting it as active rework, even after the round reset drops below the cap.
+    const reset = { ...gate, round: 0, finalRoundPending: false, dismissed: true };
     this.deps.store.putPlanGate(reset);
     this.deps.onChange(session.id, reset);
   }

--- a/src/plan-status.ts
+++ b/src/plan-status.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared plan-gate rework-status predicate.
+ * Mirror pair: ui/src/lib/plan-status.ts — keep both files byte-identical in logic.
+ *
+ * The structural twin of addressStallStatus (src/review-status.ts) for the pre-execution plan
+ * gate. The plan gate has no per-row finalRoundTimeoutMs column, so the timeout is this shared
+ * constant (matching the reviews table's 900_000 ms default).
+ */
+import type { PlanGate } from "./types";
+
+export type PlanStallStatus = "round" | "final" | "stalled";
+
+/** Abandonment window for a plan gate's final rework round (ms). Mirror-pinned constant. */
+export const PLAN_FINAL_ROUND_TIMEOUT_MS = 900_000;
+
+/**
+ * Pure tri-state decision for a plan-rework streak's current status.
+ *  - "round":   below the cap — the auto-loop is still steering findings back.
+ *  - "final":   at/over the cap, finalRoundPending=true, and not yet timed out — the final steer
+ *               landed and the agent is actively revising the plan.
+ *  - "stalled": at/over the cap with no pending final round (post-cap re-review / takeover), or the
+ *               pending final round has timed out.
+ *
+ * `now` is a ms timestamp (Date.now() or a reactive clock).
+ */
+export function planStallStatus(g: PlanGate, now: number): PlanStallStatus {
+  const cap = g.cap;
+  const round = Math.min(g.round, cap);
+  if (round < cap) return "round";
+  if (!g.finalRoundPending) return "stalled";
+  if (now - g.updatedAt > PLAN_FINAL_ROUND_TIMEOUT_MS) return "stalled";
+  return "final";
+}

--- a/src/push.ts
+++ b/src/push.ts
@@ -475,8 +475,14 @@ export class PushService {
 export function attachReviewPush(events: EventHub, store: SessionStore, push: PushService): void {
   events.subscribe((event, data) => {
     if (event !== "session:review") return;
-    const { id, review } = data as { id: string; review: { decision: string } | null };
+    const { id, review } = data as {
+      id: string;
+      review: { decision: string; dismissed?: boolean } | null;
+    };
     if (review?.decision !== "changes_requested" && review?.decision !== "commented") return;
+    // A dismissed verdict is the operator taking over a stalled rework — clearStallState re-emits
+    // session:review with the (unchanged) changes_requested decision, which must NOT re-notify.
+    if (review.dismissed) return;
     const name = store.get(id)?.name ?? id;
     void push.notify({
       kind: "review",

--- a/src/review.ts
+++ b/src/review.ts
@@ -437,6 +437,10 @@ export class ReviewService {
       streakReviews: 0,
       errorRound: 0,
       reviewedPatchIds: [],
+      // Operator took over: the rework classification (REWORK RUNNING / banner / rundown) stops
+      // counting this verdict as active rework even though decision stays changes_requested, and
+      // attachReviewPush skips the emit below so the takeover doesn't re-notify.
+      dismissed: true,
     };
     this.deps.store.putReview(reset);
     this.deps.onChange(session.id, reset);
@@ -475,6 +479,9 @@ export class ReviewService {
         reviewedPatchIds: [],
         addressRound: 0,
         finalRoundPending: false,
+        // Forcing a fresh review re-engages active rework — clear any prior dismiss so the
+        // re-reviewed verdict classifies normally.
+        dismissed: false,
       });
     }
     // 4. one code path:

--- a/src/rundown-core.ts
+++ b/src/rundown-core.ts
@@ -19,6 +19,8 @@ import type { GitState } from "./forge/types";
 import type { BlockReason } from "./blocked";
 import { blockReasonToHoldCode, renderHold } from "./hold";
 import { fenceUntrusted } from "./untrusted";
+import { planStallStatus } from "./plan-status";
+import { addressStallStatus } from "./review-status";
 
 export const RUNDOWN_VERDICT_FILE = ".shepherd-rundown.json";
 
@@ -122,6 +124,29 @@ export function planQuestionsUnanswered(gate: PlanGate | null | undefined): bool
   return false;
 }
 
+/** A session's plan gate surfaces as active plan-rework when changes were requested, the operator
+ *  hasn't dismissed/taken over, and — for a display-running / taken-over session only — the loop
+ *  hasn't stalled. An IDLE stalled rework still counts (it needs a human, and co-fires
+ *  blocked-decision via the quota block). Shared by the attention rule + the planRound copy so the
+ *  two never drift. See src/plan-status.ts. */
+function planReworkActive(s: Session, gate: PlanGate | undefined, now: number): boolean {
+  return (
+    s.planPhase === "planning" &&
+    gate?.decision === "changes_requested" &&
+    !gate.dismissed &&
+    !(s.status === "running" && planStallStatus(gate, now) === "stalled")
+  );
+}
+
+/** Critic-side twin of planReworkActive (no planPhase gate — critic rework runs post-PR). */
+function criticReworkActive(s: Session, review: ReviewVerdict | undefined, now: number): boolean {
+  return (
+    review?.decision === "changes_requested" &&
+    !review.dismissed &&
+    !(s.status === "running" && addressStallStatus(review, now) === "stalled")
+  );
+}
+
 /** Ordered (signal, predicate) rules. classifyAttention pushes each signal whose predicate
  *  holds, in this exact order — Tier-1 codes first, then Tier-2, then Tier-3 — so the emitted
  *  `signals` array order is stable. Splitting the predicates out of classifyAttention keeps
@@ -139,11 +164,8 @@ const ATTENTION_RULES: Array<{
       Boolean(s.autopilotPaused && s.autopilotQuestion) ||
       Boolean(c.block),
   },
-  {
-    signal: "plan-rework",
-    when: (s, c) => s.planPhase === "planning" && c.gate?.decision === "changes_requested",
-  },
-  { signal: "critic-rework", when: (_s, c) => c.review?.decision === "changes_requested" },
+  { signal: "plan-rework", when: (s, c, now) => planReworkActive(s, c.gate, now) },
+  { signal: "critic-rework", when: (s, c, now) => criticReworkActive(s, c.review, now) },
   { signal: "ci-red", when: (_s, c) => c.git?.checks === "failure" },
   // manual-steps: a PR declares un-acked, non-POST-MERGE manual operator steps that gate its
   // auto-merge (#1060). Last in the Tier-1 block so a genuinely-more-urgent co-signal stays the
@@ -433,8 +455,8 @@ function toAssembledSession(
   if (git?.number != null) item.prNumber = git.number;
   if (git?.url) item.prUrl = git.url;
   if (review?.findings?.length) item.findings = review.findings;
-  if (s.planPhase === "planning" && gate && gate.decision === "changes_requested")
-    item.planRound = gate.round;
+  // Same predicate as the plan-rework signal so the round copy tracks it.
+  if (gate && planReworkActive(s, gate, now)) item.planRound = gate.round;
   const hold = explainHold(s, caches, now);
   if (hold !== null) item.hold = hold;
   return item;

--- a/src/store.ts
+++ b/src/store.ts
@@ -326,6 +326,7 @@ type ReviewVerdictRow = {
   seenNoteIds: string;
   url: string | null;
   spawnAborted: number | null;
+  dismissed: number | null;
   updatedAt: number;
 };
 
@@ -347,6 +348,8 @@ type PlanGateRow = {
   reviewerProvider: string | null;
   reviewerModel: string | null;
   reviewerEffort: string | null;
+  finalRoundPending: number | null;
+  dismissed: number | null;
 };
 
 /** SQLite row shape for the recaps table. */
@@ -2234,6 +2237,8 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       url: r.url ?? undefined,
       // Optional flag: present only on a pre-spawn abort row; a normal verdict omits it entirely.
       spawnAborted: r.spawnAborted ? true : undefined,
+      // Optional flag: true only when the operator dismissed/took over this stalled rework.
+      dismissed: r.dismissed ? true : undefined,
     } as ReviewVerdict;
   }
 
@@ -2241,7 +2246,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     const r = this.db
       .query(
         `SELECT sessionId, headSha, patchId, decision, summary, body, findings, addressRound,
-                addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, spawnAborted, updatedAt
+                addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, spawnAborted, dismissed, updatedAt
               FROM reviews WHERE sessionId = ?`,
       )
       .get(sessionId) as ReviewVerdictRow | null;
@@ -2251,8 +2256,8 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
   putReview(v: ReviewVerdict): void {
     this.db.run(
       `INSERT INTO reviews (sessionId, headSha, patchId, decision, summary, body, findings, addressRound,
-         addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, spawnAborted, updatedAt)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+         addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, spawnAborted, dismissed, updatedAt)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
        ON CONFLICT(sessionId) DO UPDATE SET headSha=excluded.headSha, patchId=excluded.patchId,
          decision=excluded.decision,
          summary=excluded.summary, body=excluded.body, findings=excluded.findings,
@@ -2260,7 +2265,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
          streakReviews=excluded.streakReviews, reviewedPatchIds=excluded.reviewedPatchIds,
          errorRound=excluded.errorRound, finalRoundPending=excluded.finalRoundPending,
          finalRoundTimeoutMs=excluded.finalRoundTimeoutMs, seenNoteIds=excluded.seenNoteIds,
-         url=excluded.url, spawnAborted=excluded.spawnAborted, updatedAt=excluded.updatedAt`,
+         url=excluded.url, spawnAborted=excluded.spawnAborted, dismissed=excluded.dismissed, updatedAt=excluded.updatedAt`,
       [
         v.sessionId,
         v.headSha,
@@ -2279,6 +2284,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
         JSON.stringify(v.seenNoteIds ?? []),
         v.url ?? null,
         v.spawnAborted ? 1 : 0,
+        v.dismissed ? 1 : 0,
         v.updatedAt,
       ],
     );
@@ -2320,7 +2326,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     const rows = this.db
       .query(
         `SELECT sessionId, headSha, patchId, decision, summary, body, findings, addressRound,
-                addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, spawnAborted, updatedAt FROM reviews`,
+                addressCap, streakReviews, reviewedPatchIds, errorRound, finalRoundPending, finalRoundTimeoutMs, seenNoteIds, url, spawnAborted, dismissed, updatedAt FROM reviews`,
       )
       .all() as ReviewVerdictRow[];
     const out: Record<string, ReviewVerdict> = {};
@@ -2369,13 +2375,15 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       updatedAt: r.updatedAt,
       blocks,
       answeredQuestionKeys,
+      finalRoundPending: !!r.finalRoundPending,
+      dismissed: !!r.dismissed,
     } as PlanGate;
   }
 
   getPlanGate(sessionId: string): PlanGate | null {
     const r = this.db
       .query(
-        `SELECT sessionId, planHash, decision, summary, body, findings, round, cap, approved, plan, updatedAt, blocks, answeredQuestionKeys, reviewerProvider, reviewerModel, reviewerEffort
+        `SELECT sessionId, planHash, decision, summary, body, findings, round, cap, approved, plan, updatedAt, blocks, answeredQuestionKeys, reviewerProvider, reviewerModel, reviewerEffort, finalRoundPending, dismissed
               FROM plan_gates WHERE sessionId = ?`,
       )
       .get(sessionId) as PlanGateRow | null;
@@ -2384,15 +2392,16 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
 
   putPlanGate(g: PlanGate): void {
     this.db.run(
-      `INSERT INTO plan_gates (sessionId, planHash, decision, summary, body, findings, round, cap, approved, plan, updatedAt, blocks, answeredQuestionKeys, reviewerProvider, reviewerModel, reviewerEffort)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+      `INSERT INTO plan_gates (sessionId, planHash, decision, summary, body, findings, round, cap, approved, plan, updatedAt, blocks, answeredQuestionKeys, reviewerProvider, reviewerModel, reviewerEffort, finalRoundPending, dismissed)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
        ON CONFLICT(sessionId) DO UPDATE SET planHash=excluded.planHash, decision=excluded.decision,
          summary=excluded.summary, body=excluded.body, findings=excluded.findings,
          round=excluded.round, cap=excluded.cap, approved=excluded.approved,
          plan=excluded.plan, updatedAt=excluded.updatedAt, blocks=excluded.blocks,
          answeredQuestionKeys=excluded.answeredQuestionKeys,
          reviewerProvider=excluded.reviewerProvider, reviewerModel=excluded.reviewerModel,
-         reviewerEffort=excluded.reviewerEffort`,
+         reviewerEffort=excluded.reviewerEffort,
+         finalRoundPending=excluded.finalRoundPending, dismissed=excluded.dismissed`,
       [
         g.sessionId,
         g.planHash ?? "",
@@ -2410,6 +2419,8 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
         g.reviewerProvider ?? null,
         g.reviewerModel ?? null,
         g.reviewerEffort ?? null,
+        g.finalRoundPending ? 1 : 0,
+        g.dismissed ? 1 : 0,
       ],
     );
   }
@@ -2421,7 +2432,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
   snapshotPlanGates(): Record<string, PlanGate> {
     const rows = this.db
       .query(
-        `SELECT sessionId, planHash, decision, summary, body, findings, round, cap, approved, plan, updatedAt, blocks, answeredQuestionKeys, reviewerProvider, reviewerModel, reviewerEffort FROM plan_gates`,
+        `SELECT sessionId, planHash, decision, summary, body, findings, round, cap, approved, plan, updatedAt, blocks, answeredQuestionKeys, reviewerProvider, reviewerModel, reviewerEffort, finalRoundPending, dismissed FROM plan_gates`,
       )
       .all() as PlanGateRow[];
     const out: Record<string, PlanGate> = {};
@@ -3312,6 +3323,9 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     // spawnAborted (#1211): marks a row that records a pre-spawn onSpawn abort (critic never ran),
     // exempting it from the same-head re-review dedup. Pre-existing rows backfill to 0 (real reviews).
     add("spawnAborted", `spawnAborted INTEGER NOT NULL DEFAULT 0`);
+    // dismissed: operator took over this stalled critic rework; classification/attention consumers
+    // skip it. Pre-existing rows backfill to 0 (not dismissed).
+    add("dismissed", `dismissed INTEGER NOT NULL DEFAULT 0`);
   }
 
   private migratePlanGateColumns(): void {
@@ -3325,6 +3339,11 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     add("reviewerProvider", `reviewerProvider TEXT`);
     add("reviewerModel", `reviewerModel TEXT`);
     add("reviewerEffort", `reviewerEffort TEXT`);
+    // finalRoundPending: the cap-th plan-rework steer just landed and the agent is revising the
+    // FINAL round (planStallStatus reads it). dismissed: operator took over this stalled plan
+    // rework. Pre-existing rows backfill to 0 (not final / not dismissed).
+    add("finalRoundPending", `finalRoundPending INTEGER NOT NULL DEFAULT 0`);
+    add("dismissed", `dismissed INTEGER NOT NULL DEFAULT 0`);
   }
 
   private migrateReviewerSpawnColumns(): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -477,6 +477,14 @@ export interface PlanGate {
   // key is absent here is still pending (see planQuestionsUnanswered). Optional (like `blocks`):
   // absent ⇒ treated as [] by every consumer.
   answeredQuestionKeys?: string[];
+  // cap-th steer just delivered while at/over the cap → the FINAL plan-rework round is in flight
+  // (agent actively revising). Distinguishes the genuine final round from a post-cap re-review /
+  // takeover (both leave round === cap); planStallStatus reads it. Absent ⇒ false. See src/plan-status.ts.
+  finalRoundPending?: boolean;
+  // Operator dismissed / took over this stalled rework. Display + attention consumers stop counting
+  // this verdict as active rework (REWORK RUNNING / review banner / rundown rework signal). Reset to
+  // false on any new verdict (buildGate) and on resume(). Absent ⇒ false.
+  dismissed?: boolean;
   updatedAt: number;
 }
 
@@ -501,6 +509,10 @@ export interface ReviewVerdict {
   seenNoteIds: string[]; // ids of author notes already fed to the critic, so each is injected only once
   url?: string; // posted PR-review URL, when the host returns one
   spawnAborted?: boolean; // true ⇒ this row records a pre-spawn onSpawn abort (critic never ran — e.g. no usable account), surfaced for the badge but EXEMPT from the same-head dedup so the auto path re-attempts once the blocker clears. Cleared (omitted) on every real verdict.
+  // Operator dismissed / took over this stalled critic rework (clearStallState). Display + attention
+  // consumers stop counting it as active rework and attachReviewPush skips it. Reset to false on any
+  // new verdict (buildVerdict) and on forceReview. Absent ⇒ false.
+  dismissed?: boolean;
   updatedAt: number;
 }
 

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -1105,6 +1105,104 @@ test("resume no-op: gate decision is 'error' → returns false", () => {
   expect(h.svc.resume(planningSession() as any)).toBe(false);
 });
 
+// ── finalRoundPending + dismissed (rework-stall classification) ────────────────
+
+test("request-changes: final delivered round (round==cap) sets finalRoundPending", async () => {
+  const h = harness({
+    cap: 3,
+    readVerdict: () => ({ decision: "request-changes", summary: "no", body: "B", findings: ["f"] }),
+    reply: () => true,
+    store: {
+      getPlanGate: () => ({ planHash: "x", approved: false, round: 2, findings: ["f"] }),
+      get: () => ({ id: "s1", auto: false }),
+    },
+  });
+  await h.svc.consider(planningSession() as any);
+  await h.svc.tick();
+  expect(h.store.gate.round).toBe(3); // cap reached via the final delivered steer
+  expect(h.store.gate.finalRoundPending).toBe(true);
+});
+
+test("request-changes: sub-cap round leaves finalRoundPending false", async () => {
+  const h = harness({
+    cap: 3,
+    readVerdict: () => ({ decision: "request-changes", summary: "no", body: "B", findings: ["f"] }),
+    reply: () => true,
+  });
+  await h.svc.consider(planningSession() as any);
+  await h.svc.tick();
+  expect(h.store.gate.round).toBe(1);
+  expect(h.store.gate.finalRoundPending).toBeFalsy();
+});
+
+test("request-changes at cap (no steer) leaves finalRoundPending false → planStallStatus stalled", async () => {
+  const h = harness({
+    cap: 1,
+    readVerdict: () => ({ decision: "request-changes", summary: "no", body: "B", findings: ["f"] }),
+    reply: () => true,
+    store: {
+      getPlanGate: () => ({ planHash: "x", approved: false, round: 1, findings: ["f"] }),
+      addSignal() {},
+      get: () => ({ id: "s1", auto: false }),
+    },
+  });
+  await h.svc.consider(planningSession() as any);
+  await h.svc.tick();
+  expect(h.store.gate.finalRoundPending).toBeFalsy();
+});
+
+test("dismiss: marks dismissed=true, clears finalRoundPending, keeps changes_requested", () => {
+  const gate: any = {
+    sessionId: "s1",
+    planHash: "h1",
+    decision: "changes_requested",
+    summary: "x",
+    body: "b",
+    findings: ["f"],
+    round: 3,
+    cap: 3,
+    approved: false,
+    plan: "p",
+    finalRoundPending: true,
+    updatedAt: 1000,
+  };
+  const putCalls: any[] = [];
+  const h = harness({
+    store: { getPlanGate: () => gate, putPlanGate: (g: any) => putCalls.push(g) },
+  });
+  h.svc.dismiss(planningSession() as any);
+  expect(putCalls).toHaveLength(1);
+  expect(putCalls[0].dismissed).toBe(true);
+  expect(putCalls[0].finalRoundPending).toBe(false);
+  expect(putCalls[0].decision).toBe("changes_requested");
+  expect(putCalls[0].round).toBe(0);
+});
+
+test("resume: clears a prior dismissed flag", () => {
+  const gate: any = {
+    sessionId: "s1",
+    planHash: "h1",
+    decision: "changes_requested",
+    summary: "x",
+    body: "b",
+    findings: ["f"],
+    round: 3,
+    cap: 3,
+    approved: false,
+    plan: "p",
+    dismissed: true,
+    updatedAt: 1000,
+  };
+  const putCalls: any[] = [];
+  const h = harness({
+    store: { getPlanGate: () => gate, putPlanGate: (g: any) => putCalls.push(g) },
+    reply: () => true,
+  });
+  h.svc.resume(planningSession() as any);
+  expect(putCalls).toHaveLength(1);
+  expect(putCalls[0].dismissed).toBe(false);
+});
+
 // ── readPlanBlocks: blocks captured into the gate ──────────────────────────────
 
 const questionBlock = () => ({

--- a/test/plan-status.test.ts
+++ b/test/plan-status.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "bun:test";
+import { planStallStatus, PLAN_FINAL_ROUND_TIMEOUT_MS } from "../src/plan-status";
+import type { PlanGate } from "../src/types";
+
+/** Minimal PlanGate fixture; only the fields planStallStatus inspects. */
+function makeGate(overrides: Partial<PlanGate> = {}): PlanGate {
+  return {
+    sessionId: "s1",
+    planHash: "h1",
+    decision: "changes_requested",
+    summary: "test",
+    body: "body",
+    findings: ["finding 1"],
+    round: 1,
+    cap: 5,
+    approved: false,
+    plan: "plan text",
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+const NOW = 1_000_000_000_000;
+
+describe("planStallStatus", () => {
+  it('returns "round" when round < cap', () => {
+    expect(planStallStatus(makeGate({ round: 2, cap: 5, updatedAt: NOW }), NOW)).toBe("round");
+  });
+
+  it('returns "final" on the just-landed final round (round==cap, finalRoundPending, recent)', () => {
+    const g = makeGate({ round: 5, cap: 5, finalRoundPending: true, updatedAt: NOW - 60_000 });
+    expect(planStallStatus(g, NOW)).toBe("final");
+  });
+
+  it('returns "stalled" at cap with finalRoundPending=false (post-cap re-review / takeover)', () => {
+    const g = makeGate({ round: 5, cap: 5, finalRoundPending: false, updatedAt: NOW });
+    expect(planStallStatus(g, NOW)).toBe("stalled");
+  });
+
+  it('returns "stalled" when the pending final round has timed out', () => {
+    const g = makeGate({
+      round: 5,
+      cap: 5,
+      finalRoundPending: true,
+      updatedAt: NOW - PLAN_FINAL_ROUND_TIMEOUT_MS - 1,
+    });
+    expect(planStallStatus(g, NOW)).toBe("stalled");
+  });
+
+  it("treats round over cap like at cap", () => {
+    expect(planStallStatus(makeGate({ round: 9, cap: 5, updatedAt: NOW }), NOW)).toBe("stalled");
+  });
+});

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -439,6 +439,22 @@ test("attachReviewPush notifies on changes_requested and commented, ignores erro
   expect(calls[1]).toMatchObject({ kind: "review", sessionId: "r2", decision: "commented" });
 });
 
+test("attachReviewPush skips a dismissed verdict (operator took over → no re-notify)", async () => {
+  const calls: any[] = [];
+  const { store, push } = svc(async () => ({}));
+  (push as any).notify = async (p: any) => calls.push(p);
+  const events = new EventHub();
+  attachReviewPush(events, store, push);
+
+  // clearStallState re-emits session:review carrying the unchanged changes_requested decision.
+  events.emit("session:review", {
+    id: "r1",
+    review: { decision: "changes_requested", dismissed: true },
+  });
+  await Promise.resolve();
+  expect(calls.length).toBe(0);
+});
+
 function gitState(over: Partial<any> = {}) {
   return {
     kind: "github",

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -293,6 +293,45 @@ function makeDeps(
   };
 }
 
+function verdict(over: Partial<ReviewVerdict> = {}): ReviewVerdict {
+  return {
+    sessionId: "s1",
+    headSha: "abc",
+    patchId: "p",
+    decision: "changes_requested",
+    summary: "s",
+    body: "b",
+    findings: ["f"],
+    addressRound: 3,
+    addressCap: 3,
+    streakReviews: 1,
+    reviewedPatchIds: [],
+    errorRound: 0,
+    finalRoundPending: true,
+    finalRoundTimeoutMs: 900_000,
+    seenNoteIds: [],
+    updatedAt: 1000,
+    ...over,
+  };
+}
+
+test("clearStallState marks the verdict dismissed, keeps changes_requested", () => {
+  const { deps: d, reviews } = makeDeps({});
+  reviews["s1"] = verdict();
+  new ReviewService(d as any).clearStallState(session());
+  expect(reviews["s1"]!.dismissed).toBe(true);
+  expect(reviews["s1"]!.decision).toBe("changes_requested");
+  expect(reviews["s1"]!.addressRound).toBe(0);
+});
+
+test("forceReview pre-reset clears a prior dismissed flag", async () => {
+  const { deps: d, reviews } = makeDeps({});
+  reviews["s1"] = verdict({ dismissed: true });
+  await new ReviewService(d as any).forceReview(session(), OPEN_GREEN);
+  // forceReview writes the hygiene reset row (dismissed:false) before spawning the re-review.
+  expect(reviews["s1"]!.dismissed).toBeFalsy();
+});
+
 test("reviewPrompt embeds base + task and asks for the verdict file", () => {
   const p = reviewPrompt("main", "do the thing");
   expect(p).toContain("git diff main...HEAD");

--- a/test/rundown-core.test.ts
+++ b/test/rundown-core.test.ts
@@ -150,9 +150,20 @@ test("classifyAttention: each signal maps to the correct tier", () => {
     "blocked-decision",
   );
   expect(
-    c(session({ planPhase: "planning" }), { gate: { decision: "changes_requested" } as any }).tier,
+    c(session({ planPhase: "planning" }), {
+      gate: { decision: "changes_requested", round: 1, cap: 3 } as any,
+    }).tier,
   ).toBe(1);
-  expect(c(session(), { review: { decision: "changes_requested" } as any }).tier).toBe(1);
+  expect(
+    c(session(), {
+      review: {
+        decision: "changes_requested",
+        findings: ["f"],
+        addressRound: 1,
+        addressCap: 3,
+      } as any,
+    }).tier,
+  ).toBe(1);
   expect(c(session({ status: "idle" }), { git: git({ checks: "failure" }) }).tier).toBe(1);
 
   expect(c(session({ status: "idle" }), { git: git({ handoff: "merger" }) }).tier).toBe(2);
@@ -497,6 +508,64 @@ test("classifyAttention + assemble: executing session with retained gate has no 
   // The session must still appear (it has an in-flight signal from idle status + some tier).
   // planRound must be absent — the retained gate must not leak planRound into execution.
   expect(item?.planRound).toBeUndefined(); // L251 guard
+});
+
+test("plan-rework: running + stalled (takeover) suppresses the signal + planRound; idle keeps both", () => {
+  // round==cap, finalRoundPending absent → planStallStatus "stalled".
+  const gate = { ...retainedAtCapGate };
+  // RUNNING taken-over session: no plan-rework, no planRound (reads as active work).
+  const running = classifyAttention(
+    session({ planPhase: "planning", status: "running" }),
+    { gate },
+    NOW,
+  );
+  expect(running.signals).not.toContain("plan-rework");
+  const runOut = assembleHerdState({
+    sessions: [session({ planPhase: "planning", status: "running" })],
+    gates: { s1: gate },
+    overnightDelta: { mergedPrs: [], archivedSessions: [] },
+    generatedFor: "2026-06-19",
+    now: NOW,
+  });
+  expect(runOut.sessions.find((s) => s.sessionId === "s1")?.planRound).toBeUndefined();
+  // IDLE genuinely-stalled session: plan-rework + planRound preserved (needs a human).
+  const idle = classifyAttention(session({ planPhase: "planning", status: "idle" }), { gate }, NOW);
+  expect(idle.signals).toContain("plan-rework");
+  const idleOut = assembleHerdState({
+    sessions: [session({ planPhase: "planning", status: "idle" })],
+    gates: { s1: gate },
+    overnightDelta: { mergedPrs: [], archivedSessions: [] },
+    generatedFor: "2026-06-19",
+    now: NOW,
+  });
+  expect(idleOut.sessions.find((s) => s.sessionId === "s1")?.planRound).toBe(3);
+});
+
+test("plan-rework: a dismissed gate suppresses the signal even when idle", () => {
+  const gate: PlanGate = { ...retainedAtCapGate, round: 1, cap: 3, dismissed: true };
+  const idle = classifyAttention(session({ planPhase: "planning", status: "idle" }), { gate }, NOW);
+  expect(idle.signals).not.toContain("plan-rework");
+});
+
+test("critic-rework: running + stalled suppresses; dismissed suppresses; idle stall keeps it", () => {
+  const stalled = {
+    decision: "changes_requested",
+    findings: ["f"],
+    addressRound: 3,
+    addressCap: 3,
+    finalRoundPending: false,
+    updatedAt: NOW,
+  } as any;
+  expect(
+    classifyAttention(session({ status: "running" }), { review: stalled }, NOW).signals,
+  ).not.toContain("critic-rework");
+  expect(
+    classifyAttention(session({ status: "idle" }), { review: stalled }, NOW).signals,
+  ).toContain("critic-rework");
+  expect(
+    classifyAttention(session({ status: "idle" }), { review: { ...stalled, dismissed: true } }, NOW)
+      .signals,
+  ).not.toContain("critic-rework");
 });
 
 test("classifyAttention + assemble: planning session with same at-cap gate still gets plan-rework + planRound (guard not over-suppressing)", () => {

--- a/test/store-plan-gate.test.ts
+++ b/test/store-plan-gate.test.ts
@@ -42,6 +42,19 @@ test("plan_gate CRUD round-trips + snapshot", () => {
   expect(s.getPlanGate("s1")).toBeNull();
 });
 
+test("plan_gate round-trips finalRoundPending + dismissed (legacy rows default false)", () => {
+  const s = new SessionStore(":memory:");
+  // A fresh in-loop gate omits both → hydrate treats absent as falsy.
+  s.putPlanGate(g());
+  expect(s.getPlanGate("s1")?.finalRoundPending).toBeFalsy();
+  expect(s.getPlanGate("s1")?.dismissed).toBeFalsy();
+  // Set both and confirm they persist.
+  s.putPlanGate(g({ finalRoundPending: true, dismissed: true }));
+  expect(s.getPlanGate("s1")?.finalRoundPending).toBe(true);
+  expect(s.getPlanGate("s1")?.dismissed).toBe(true);
+  expect(s.snapshotPlanGates().s1!.dismissed).toBe(true);
+});
+
 test("repo_config carries planGateEnabled default + setter", () => {
   const s = new SessionStore(":memory:");
   expect(s.getRepoConfig("/r").planGateEnabled).toBe(false);

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -444,6 +444,33 @@ test("reviews: upsert + read by session, snapshot all", () => {
   expect(store.getReview("s1")).toBeNull();
 });
 
+test("reviews: dismissed round-trips; legacy rows default falsy", () => {
+  const store = new SessionStore(":memory:");
+  const v = {
+    sessionId: "s1",
+    headSha: "abc",
+    patchId: "pid",
+    decision: "changes_requested" as const,
+    summary: "",
+    body: "",
+    findings: ["f"],
+    addressRound: 3,
+    addressCap: 3,
+    streakReviews: 1,
+    reviewedPatchIds: [],
+    errorRound: 0,
+    finalRoundPending: false,
+    finalRoundTimeoutMs: 900_000,
+    seenNoteIds: [],
+    updatedAt: 1,
+  };
+  store.putReview(v);
+  expect(store.getReview("s1")?.dismissed).toBeFalsy();
+  store.putReview({ ...v, dismissed: true, updatedAt: 2 });
+  expect(store.getReview("s1")?.dismissed).toBe(true);
+  expect(store.snapshotReviews().s1!.dismissed).toBe(true);
+});
+
 test("reviews: findings/addressRound/addressCap/errorRound/seenNoteIds default when absent", () => {
   const store = new SessionStore(":memory:");
   // a verdict row written before the #247 columns existed (missing the new fields)

--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -720,6 +720,7 @@ describe("Herd rework-running group", () => {
           s,
           { planGate: planGates.map[s.id], review: reviews.map[s.id] },
           workingBlocked,
+          Date.now(),
         ),
       0,
       "all",

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -239,6 +239,7 @@
       session,
       { planGate: planGates.map[session.id], review: reviews.map[session.id] },
       workingBlocked,
+      nowMs,
     );
 
   // Derives the quota block kind for a session if its block has shape "quota"; null otherwise.

--- a/ui/src/lib/components/rework-running.test.ts
+++ b/ui/src/lib/components/rework-running.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "vitest";
 import { isReworkRunning } from "./rework-running";
-import type { Session, SessionStatus } from "$lib/types";
+import type { PlanGate, ReviewVerdict, Session } from "$lib/types";
+
+const NOW = 1_000_000_000_000;
 
 function session(
   id: string,
@@ -9,56 +11,129 @@ function session(
 ): Pick<Session, "id" | "status" | "planPhase"> {
   return { id, status, planPhase };
 }
+type SessionStatus = Session["status"];
 
-test("matches display-running plan-gate changes during planning", () => {
-  expect(
-    isReworkRunning(
-      session("s", "running", "planning"),
-      { planGate: { decision: "changes_requested" } },
-      {},
-    ),
-  ).toBe(true);
-});
+/** Plan gate mid-loop (round < cap) by default — planStallStatus "round". */
+function gate(over: Partial<PlanGate> = {}): PlanGate {
+  return {
+    sessionId: "s",
+    planHash: "h",
+    decision: "changes_requested",
+    summary: "",
+    body: "",
+    findings: ["f"],
+    round: 1,
+    cap: 5,
+    approved: false,
+    plan: "",
+    updatedAt: NOW,
+    ...over,
+  };
+}
 
-test("does not match plan-gate changes after execution starts", () => {
-  expect(
-    isReworkRunning(
-      session("s", "running", "executing"),
-      { planGate: { decision: "changes_requested" } },
-      {},
-    ),
-  ).toBe(false);
-});
+/** Critic verdict mid-loop (addressRound < addressCap) by default — addressStallStatus "round". */
+function review(over: Partial<ReviewVerdict> = {}): ReviewVerdict {
+  return {
+    sessionId: "s",
+    headSha: "abc",
+    decision: "changes_requested",
+    summary: "",
+    body: "",
+    findings: ["f"],
+    addressRound: 1,
+    addressCap: 5,
+    finalRoundPending: false,
+    finalRoundTimeoutMs: 900_000,
+    updatedAt: NOW,
+    ...over,
+  } as ReviewVerdict;
+}
 
-test("matches display-running critic changes", () => {
-  expect(isReworkRunning(session("s"), { review: { decision: "changes_requested" } }, {})).toBe(
+test("matches display-running plan-gate changes during planning (mid-loop)", () => {
+  expect(isReworkRunning(session("s", "running", "planning"), { planGate: gate() }, {}, NOW)).toBe(
     true,
   );
 });
 
-test("ignores non-changes decisions", () => {
-  expect(isReworkRunning(session("s"), { planGate: { decision: "approved" } }, {})).toBe(false);
-  expect(isReworkRunning(session("s"), { review: { decision: "commented" } }, {})).toBe(false);
-});
-
-test("requires display-running status", () => {
-  expect(
-    isReworkRunning(session("s", "idle"), { review: { decision: "changes_requested" } }, {}),
-  ).toBe(false);
-});
-
-test("includes working-while-blocked changes-requested rows", () => {
+test("keeps the genuine in-flight final round in the group", () => {
   expect(
     isReworkRunning(
-      session("s", "blocked"),
-      { review: { decision: "changes_requested" } },
-      { s: true },
+      session("s", "running", "planning"),
+      { planGate: gate({ round: 5, cap: 5, finalRoundPending: true, updatedAt: NOW }) },
+      {},
+      NOW,
     ),
   ).toBe(true);
 });
 
-test("keeps genuinely blocked changes-requested rows out of the running group", () => {
+test("drops a stalled plan gate (at cap, no pending final round → takeover)", () => {
   expect(
-    isReworkRunning(session("s", "blocked"), { review: { decision: "changes_requested" } }, {}),
+    isReworkRunning(
+      session("s", "running", "planning"),
+      { planGate: gate({ round: 5, cap: 5, finalRoundPending: false }) },
+      {},
+      NOW,
+    ),
   ).toBe(false);
+});
+
+test("drops a dismissed plan gate even mid-loop", () => {
+  expect(
+    isReworkRunning(
+      session("s", "running", "planning"),
+      { planGate: gate({ dismissed: true }) },
+      {},
+      NOW,
+    ),
+  ).toBe(false);
+});
+
+test("does not match plan-gate changes after execution starts", () => {
+  expect(isReworkRunning(session("s", "running", "executing"), { planGate: gate() }, {}, NOW)).toBe(
+    false,
+  );
+});
+
+test("matches display-running critic changes (mid-loop)", () => {
+  expect(isReworkRunning(session("s"), { review: review() }, {}, NOW)).toBe(true);
+});
+
+test("drops a stalled critic streak", () => {
+  expect(
+    isReworkRunning(
+      session("s"),
+      { review: review({ addressRound: 5, addressCap: 5, finalRoundPending: false }) },
+      {},
+      NOW,
+    ),
+  ).toBe(false);
+});
+
+test("drops a dismissed critic verdict", () => {
+  expect(isReworkRunning(session("s"), { review: review({ dismissed: true }) }, {}, NOW)).toBe(
+    false,
+  );
+});
+
+test("ignores non-changes decisions", () => {
+  expect(isReworkRunning(session("s"), { planGate: gate({ decision: "approved" }) }, {}, NOW)).toBe(
+    false,
+  );
+  expect(
+    isReworkRunning(session("s"), { review: review({ decision: "commented" }) }, {}, NOW),
+  ).toBe(false);
+});
+
+test("requires display-running status", () => {
+  expect(isReworkRunning(session("s", "idle"), { review: review() }, {}, NOW)).toBe(false);
+});
+
+test("includes working-while-blocked changes-requested rows", () => {
+  expect(isReworkRunning(session("s", "blocked"), { review: review() }, { s: true }, NOW)).toBe(
+    true,
+  );
+});
+
+test("keeps genuinely blocked changes-requested rows out of the running group", () => {
+  expect(isReworkRunning(session("s", "blocked"), { review: review() }, {}, NOW)).toBe(false);
 });

--- a/ui/src/lib/components/rework-running.ts
+++ b/ui/src/lib/components/rework-running.ts
@@ -1,19 +1,34 @@
 import type { PlanGate, ReviewVerdict, Session } from "$lib/types";
 import { displayStatus } from "$lib/display-status";
+import { planStallStatus } from "$lib/plan-status";
+import { addressStallStatus } from "$lib/review-status";
 
 export type ReworkRunningSignals = {
-  planGate?: Pick<PlanGate, "decision">;
-  review?: Pick<ReviewVerdict, "decision">;
+  planGate?: PlanGate;
+  review?: ReviewVerdict;
 };
 
+/** A display-running session counts as "actively reworking" only while its auto-rework loop is
+ *  live: the verdict is changes_requested, the operator has NOT dismissed/taken it over, and the
+ *  loop is not stalled (a taken-over / timed-out final round drops out, but the genuine in-flight
+ *  final round — planStallStatus/addressStallStatus "final" — stays). `now` drives the stall
+ *  timeout, so the caller threads a reactive clock. */
 export function isReworkRunning(
   session: Pick<Session, "id" | "status" | "planPhase">,
   signals: ReworkRunningSignals,
   workingBlocked: Record<string, boolean>,
+  now: number,
 ): boolean {
   if (displayStatus(session, workingBlocked) !== "running") return false;
-  return (
-    (session.planPhase === "planning" && signals.planGate?.decision === "changes_requested") ||
-    signals.review?.decision === "changes_requested"
-  );
+  const { planGate, review } = signals;
+  const planRework =
+    session.planPhase === "planning" &&
+    planGate?.decision === "changes_requested" &&
+    !planGate.dismissed &&
+    planStallStatus(planGate, now) !== "stalled";
+  const criticRework =
+    review?.decision === "changes_requested" &&
+    !review.dismissed &&
+    addressStallStatus(review, now) !== "stalled";
+  return planRework || criticRework;
 }

--- a/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
+++ b/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
@@ -10,6 +10,9 @@
     type BannerState,
     type ReviewKind,
   } from "$lib/review-banner";
+  import { planStallStatus } from "$lib/plan-status";
+  import { addressStallStatus } from "$lib/review-status";
+  import { clock } from "$lib/now.svelte";
 
   // Non-blocking signal that an in-flight PR-critic / plan-gate review may steer
   // this session when it concludes (issue #1022). Shown only when a paste could
@@ -150,8 +153,16 @@
       dStatus,
       planGate: planGates.map[session.id],
       planReviewing,
+      // A stalled/timed-out loop is no longer active rework (the genuine in-flight "final" round
+      // is not "stalled"); clock.current ticks so it flips when the timeout elapses.
+      planStalled: planGates.map[session.id]
+        ? planStallStatus(planGates.map[session.id]!, clock.current) === "stalled"
+        : false,
       review: reviews.map[session.id],
       criticReviewing,
+      criticStalled: reviews.map[session.id]
+        ? addressStallStatus(reviews.map[session.id]!, clock.current) === "stalled"
+        : false,
       activitySummary: activity?.summary,
     }),
   );

--- a/ui/src/lib/plan-status.test.ts
+++ b/ui/src/lib/plan-status.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "vitest";
+import { planStallStatus, PLAN_FINAL_ROUND_TIMEOUT_MS } from "./plan-status";
+import type { PlanGate } from "./types";
+
+const NOW = 1_000_000_000_000;
+
+function gate(over: Partial<PlanGate> = {}): PlanGate {
+  return {
+    sessionId: "s1",
+    planHash: "h1",
+    decision: "changes_requested",
+    summary: "",
+    body: "",
+    findings: ["f"],
+    round: 1,
+    cap: 5,
+    approved: false,
+    plan: "",
+    updatedAt: NOW,
+    ...over,
+  };
+}
+
+test('planStallStatus "round" below cap', () => {
+  expect(planStallStatus(gate({ round: 2, cap: 5 }), NOW)).toBe("round");
+});
+
+test('planStallStatus "final" on the just-landed final round', () => {
+  expect(
+    planStallStatus(
+      gate({ round: 5, cap: 5, finalRoundPending: true, updatedAt: NOW - 1000 }),
+      NOW,
+    ),
+  ).toBe("final");
+});
+
+test('planStallStatus "stalled" at cap without a pending final round', () => {
+  expect(planStallStatus(gate({ round: 5, cap: 5, finalRoundPending: false }), NOW)).toBe(
+    "stalled",
+  );
+});
+
+test('planStallStatus "stalled" once the pending final round times out', () => {
+  expect(
+    planStallStatus(
+      gate({
+        round: 5,
+        cap: 5,
+        finalRoundPending: true,
+        updatedAt: NOW - PLAN_FINAL_ROUND_TIMEOUT_MS - 1,
+      }),
+      NOW,
+    ),
+  ).toBe("stalled");
+});

--- a/ui/src/lib/plan-status.ts
+++ b/ui/src/lib/plan-status.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared plan-gate rework-status predicate.
+ * Mirror pair: src/plan-status.ts — keep both files byte-identical in logic.
+ *
+ * The structural twin of addressStallStatus (ui/src/lib/review-status.ts) for the pre-execution
+ * plan gate. The plan gate has no per-row finalRoundTimeoutMs column, so the timeout is this shared
+ * constant (matching the reviews table's 900_000 ms default).
+ */
+import type { PlanGate } from "./types";
+
+export type PlanStallStatus = "round" | "final" | "stalled";
+
+/** Abandonment window for a plan gate's final rework round (ms). Mirror-pinned constant. */
+export const PLAN_FINAL_ROUND_TIMEOUT_MS = 900_000;
+
+/**
+ * Pure tri-state decision for a plan-rework streak's current status.
+ *  - "round":   below the cap — the auto-loop is still steering findings back.
+ *  - "final":   at/over the cap, finalRoundPending=true, and not yet timed out — the final steer
+ *               landed and the agent is actively revising the plan.
+ *  - "stalled": at/over the cap with no pending final round (post-cap re-review / takeover), or the
+ *               pending final round has timed out.
+ *
+ * `now` is a ms timestamp (Date.now() or a reactive clock).
+ */
+export function planStallStatus(g: PlanGate, now: number): PlanStallStatus {
+  const cap = g.cap;
+  const round = Math.min(g.round, cap);
+  if (round < cap) return "round";
+  if (!g.finalRoundPending) return "stalled";
+  if (now - g.updatedAt > PLAN_FINAL_ROUND_TIMEOUT_MS) return "stalled";
+  return "final";
+}

--- a/ui/src/lib/review-banner.test.ts
+++ b/ui/src/lib/review-banner.test.ts
@@ -284,4 +284,35 @@ describe("activeReworkBannerState", () => {
       }),
     ).toEqual({ show: false });
   });
+
+  it("hides plan-gate rework when the operator dismissed it", () => {
+    expect(
+      activeReworkBannerState({
+        ...base,
+        planGate: { decision: "changes_requested", round: 1, cap: 5, dismissed: true },
+      }),
+    ).toEqual({ show: false });
+  });
+
+  it("hides plan-gate rework when the loop has stalled (takeover)", () => {
+    expect(activeReworkBannerState({ ...base, planStalled: true })).toEqual({ show: false });
+  });
+
+  it("hides critic rework when dismissed or stalled", () => {
+    const criticBase = {
+      ...base,
+      planPhase: "executing" as const,
+      planGate: undefined,
+      review: { decision: "changes_requested" as const, addressRound: 2, addressCap: 5 },
+    };
+    expect(
+      activeReworkBannerState({
+        ...criticBase,
+        review: { ...criticBase.review, dismissed: true },
+      }),
+    ).toEqual({ show: false });
+    expect(activeReworkBannerState({ ...criticBase, criticStalled: true })).toEqual({
+      show: false,
+    });
+  });
 });

--- a/ui/src/lib/review-banner.ts
+++ b/ui/src/lib/review-banner.ts
@@ -143,22 +143,31 @@ export interface ReviewBannerInput {
 export interface ActiveReworkBannerInput {
   planPhase: "planning" | "executing" | null;
   dStatus: SessionStatus;
-  planGate: Pick<PlanGate, "decision" | "round" | "cap"> | undefined;
+  planGate: Pick<PlanGate, "decision" | "round" | "cap" | "dismissed"> | undefined;
   planReviewing: boolean;
-  review: Pick<ReviewVerdict, "decision" | "addressRound" | "addressCap"> | undefined;
+  // planStallStatus(planGate, now) === "stalled" — the plan-rework loop has stalled/been taken over
+  // (the genuine in-flight "final" round is NOT stalled). Computed by the component (it holds the
+  // clock); absent ⇒ treated as not-stalled. Keeps this function pure + trivially testable.
+  planStalled?: boolean;
+  review: Pick<ReviewVerdict, "decision" | "addressRound" | "addressCap" | "dismissed"> | undefined;
   criticReviewing: boolean;
+  // addressStallStatus(review, now) === "stalled" — same idea for the critic auto-address loop.
+  criticStalled?: boolean;
   activitySummary: string | null | undefined;
 }
 
 /** Active task-agent rework telemetry for the same bottom strip as review/CI.
  *  Parked REWORK verdicts stay in the header/list chips; only a display-running
- *  session gets this strip. */
+ *  session gets this strip. A verdict the operator dismissed/took over, or whose rework loop
+ *  has stalled, is no longer "actively reworking" — the strip clears for it. */
 export function activeReworkBannerState(input: ActiveReworkBannerInput): BannerState {
   if (input.dStatus !== "running") return { show: false };
 
   if (
     input.planPhase === "planning" &&
     input.planGate?.decision === "changes_requested" &&
+    !input.planGate.dismissed &&
+    !input.planStalled &&
     !input.planReviewing
   ) {
     return {
@@ -176,6 +185,8 @@ export function activeReworkBannerState(input: ActiveReworkBannerInput): BannerS
   if (
     input.planPhase !== "planning" &&
     input.review?.decision === "changes_requested" &&
+    !input.review.dismissed &&
+    !input.criticStalled &&
     !input.criticReviewing
   ) {
     const hasRound = input.review.addressRound > 0 && input.review.addressCap > 0;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -392,6 +392,13 @@ export interface PlanGate {
   // server field; absent ⇒ treated as []. Drives the "unanswered plan question" amber tab
   // signal via planQuestionsUnanswered in tab-signal.svelte.ts.
   answeredQuestionKeys?: string[];
+  // The cap-th plan-rework steer just landed → the FINAL round is in flight (agent revising).
+  // planStallStatus (plan-status.ts) reads it to keep the genuine final round in REWORK RUNNING.
+  // Absent ⇒ false.
+  finalRoundPending?: boolean;
+  // Operator dismissed / took over this stalled rework; the rework classification skips it.
+  // Absent ⇒ false.
+  dismissed?: boolean;
   updatedAt: number;
 }
 
@@ -578,6 +585,9 @@ export interface ReviewVerdict {
   addressCap: number; // server's streak cap for this run — the badge reads it instead of mirroring
   finalRoundPending: boolean; // cap-th steer just delivered, no re-review yet → dimmed FINAL badge
   finalRoundTimeoutMs: number; // live abandonment timeout (ms); UI escalates FINAL→STALLED after this
+  // Operator dismissed / took over this stalled critic rework; the rework classification skips it.
+  // Absent ⇒ false.
+  dismissed?: boolean;
   url?: string;
   updatedAt: number;
 }

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -478,6 +478,7 @@
         session,
         { planGate: planGates.map[session.id], review: reviews.map[session.id] },
         store.workingBlocked,
+        nowMs,
       );
     const { groups } = groupSessionsByEpic(
       herdSessions,
@@ -1304,6 +1305,7 @@
           session,
           { planGate: planGates.map[session.id], review: reviews.map[session.id] },
           store.workingBlocked,
+          nowMs,
         ),
       nowMs,
       // a page-level status filter short-circuits the rail's all/ready filter in


### PR DESCRIPTION
## Problem

A plan-review (or critic) rework that **stalls** and then **gets working again** — via operator takeover in the live pane, or the working-while-blocked overlay — stayed stuck under **REWORK RUNNING** ("rework in progress"). The group is derived purely from `decision === "changes_requested"` + display-running, and:

- past the cap the reviewer **stops steering** (`plan-gate.ts` `applyChangesRequested`), so a session *running at 5/5* isn't the auto-loop — it's a takeover/overlay; and
- the quota block (hence its **Dismiss** button) only exists while **idle** (`blocked.ts:124`), so once the card flips to `running` there's **no affordance to clear the label**.

## Fix — key the classification on the *stall condition*, not an operator action

- **`planStallStatus` mirror** (`src/plan-status.ts` + `ui/src/lib/plan-status.ts`, byte-identical, twin of `addressStallStatus`), backed by a new persisted **`finalRoundPending`** on the plan gate — set only on the cap-th *delivered* steer. The genuine in-flight **final round stays "final"** (kept in the group); a taken-over / timed-out cap round is **"stalled"** and drops to plain active work.
- **Durable `dismissed` flag** on `PlanGate` + `ReviewVerdict`, set by dismiss / `clearStallState` (take-over), cleared by resume / `forceReview` and every fresh verdict. `attachReviewPush` skips a dismissed verdict so a critic take-over doesn't re-notify.
- `isReworkRunning`, the active-rework banner, and the rundown `plan-rework`/`critic-rework` attention rules honor both. The rundown **stall** guard is scoped to `status === "running"` so an **idle** genuine stall keeps its Tier-1 signal + `planRound` copy; the `dismissed` guard is status-independent.

Additive DB columns (legacy rows default false). **Merge-gating** (drain/automerge) and the read-only verdict **panel/badge** are untouched — *dismiss ≠ approve*.

## Behavior matrix

| Scenario | REWORK RUNNING? | Rundown rework signal? |
| --- | --- | --- |
| Plan mid-loop / genuine in-flight **final** round, running | yes | yes |
| Plan at cap, running (takeover/overlay) | no — active work | no |
| Plan at cap, **idle** (genuine stall) | n/a (not running) | **yes + planRound** |
| Plan/critic `resume` | yes | yes |
| Plan/critic **dismiss**, then working | no — durable | no (no push re-fired) |
| Critic streak `"stalled"`, running | no — active work | no |
| New `changes_requested` after real change | yes — re-enters | yes |

## Verification

`bun run lint` · `bun run typecheck` · `bun test ./test` (6224 pass) · `cd ui && bun run check` (0 errors) · `cd ui && bun run test` (3074 pass) · `fallow audit` gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)