### PR TITLE
fix(drain): let Codex epics bypass Claude usage hold

### DIFF
--- a/src/drain-core.ts
+++ b/src/drain-core.ts
@@ -198,7 +198,7 @@ function awaitingSignoff(
 }
 
 function usageGuardsApply(state: DrainRepoState): boolean {
-  return state.spawnAgentProvider !== "codex";
+  return state.spawnAgentProvider === "claude";
 }
 
 function retireDecision(state: DrainRepoState): DrainDecision | null {
@@ -232,9 +232,13 @@ function capHold(state: DrainRepoState): HoldReason | null {
 
 function usageHold(state: DrainRepoState): HoldReason | null {
   if (!usageGuardsApply(state)) return null;
+  // Claude usage ceiling.
   if (state.usagePct >= state.usageCeilingPct) {
     return { code: "usage", detail: String(state.usagePct) };
   }
+  // Extra-credit cost guard: never keep spending NEW real pay-as-you-go money unattended.
+  // creditSpent is spend accrued since the weekly window began (see effectiveCreditSpent), so a
+  // nonzero month-to-date total with subscription headroom does NOT pause here.
   if (state.creditSpent > state.creditSpendCeiling) {
     return { code: "credits", detail: String(state.creditSpent) };
   }
@@ -274,9 +278,6 @@ export function computeNext(state: DrainRepoState): DrainDecision {
   if (cap) return { kind: "hold", reason: cap };
 
   // 4. Usage ceiling.
-  // Extra-credit cost guard: never keep spending NEW real pay-as-you-go money unattended.
-  // creditSpent is spend accrued since the weekly window began (see effectiveCreditSpent), so a
-  // nonzero month-to-date total with subscription headroom does NOT pause here.
   const usage = usageHold(state);
   if (usage) return { kind: "hold", reason: usage };
 

--- a/src/drain-core.ts
+++ b/src/drain-core.ts
@@ -109,6 +109,8 @@ export interface DrainRepoState {
   mappedIssueNumbers: Set<number>;
   /** Labeled, ordered backlog issues (see selectCandidates). */
   candidates: Issue[];
+  /** Provider the next spawn would use after explicit epic settings or global defaults resolve. */
+  spawnAgentProvider: AgentProvider;
   /** Epic mode: when true, hold each spawn until the operator approves it. */
   epicAttended: boolean;
   /** Epic mode: operator approved the next spawn (consumed on spawn). */
@@ -195,6 +197,50 @@ function awaitingSignoff(
   return !signedOff(authority, signoffView(s));
 }
 
+function usageGuardsApply(state: DrainRepoState): boolean {
+  return state.spawnAgentProvider !== "codex";
+}
+
+function retireDecision(state: DrainRepoState): DrainDecision | null {
+  const toRetire = state.autoSessions.find(
+    (s) =>
+      !s.fullAuto && readyToRetire(s, state.criticEnabled, state.draftMode, state.signoffAuthority),
+  );
+  return toRetire
+    ? { kind: "retire", sessionId: toRetire.id, prNumber: toRetire.git!.number! }
+    : null;
+}
+
+function troubleHold(state: DrainRepoState): HoldReason | null {
+  const blocked = state.autoSessions.find((s) => s.status === "blocked");
+  if (blocked) return { code: "blocked", detail: blocked.desig };
+  const cr = state.autoSessions.find((s) => s.reviewDecision === "changes_requested");
+  if (cr) return { code: "changes_requested", detail: cr.desig };
+  const err = state.autoSessions.find((s) => s.reviewDecision === "error");
+  return err ? { code: "error", detail: err.desig } : null;
+}
+
+function capHold(state: DrainRepoState): HoldReason | null {
+  if (state.autoSessions.length < state.maxAuto) return null;
+  const awaiting = state.autoSessions.find((s) =>
+    awaitingSignoff(s, state.draftMode, state.signoffAuthority),
+  );
+  return awaiting
+    ? { code: "awaiting_signoff", detail: awaiting.desig }
+    : { code: "cap", detail: String(state.maxAuto) };
+}
+
+function usageHold(state: DrainRepoState): HoldReason | null {
+  if (!usageGuardsApply(state)) return null;
+  if (state.usagePct >= state.usageCeilingPct) {
+    return { code: "usage", detail: String(state.usagePct) };
+  }
+  if (state.creditSpent > state.creditSpendCeiling) {
+    return { code: "credits", detail: String(state.creditSpent) };
+  }
+  return null;
+}
+
 /**
  * Pure decision core. Given one repo's state snapshot, returns the single
  * highest-priority next action. The harness applies it, re-reads state, and calls
@@ -212,48 +258,27 @@ export function computeNext(state: DrainRepoState): DrainDecision {
   // worktree/pane and foreclose rebase recovery). Gating per-session (not on the repo flag)
   // ensures a non-full-auto session in an auto-merge repo still retires instead of sitting
   // un-retired-and-un-merged on a maxAuto slot and deadlocking the drain.
-  const toRetire = state.autoSessions.find(
-    (s) =>
-      !s.fullAuto && readyToRetire(s, state.criticEnabled, state.draftMode, state.signoffAuthority),
-  );
-  if (toRetire) {
-    return { kind: "retire", sessionId: toRetire.id, prNumber: toRetire.git!.number! };
-  }
+  const retire = retireDecision(state);
+  if (retire) return retire;
 
   // 2. Trouble → halt new spawns (in-flight agents keep running; retires above still pass).
-  const blocked = state.autoSessions.find((s) => s.status === "blocked");
-  if (blocked) return { kind: "hold", reason: { code: "blocked", detail: blocked.desig } };
-  const cr = state.autoSessions.find((s) => s.reviewDecision === "changes_requested");
-  if (cr) return { kind: "hold", reason: { code: "changes_requested", detail: cr.desig } };
-  const err = state.autoSessions.find((s) => s.reviewDecision === "error");
-  if (err) return { kind: "hold", reason: { code: "error", detail: err.desig } };
+  const trouble = troubleHold(state);
+  if (trouble) return { kind: "hold", reason: trouble };
 
   // 3. Concurrency cap. In draftMode, if a session is retireable-but-unsigned it's the reason
   //    the slot stays taken — relabel the hold `awaiting_signoff` (with that session's desig) so
   //    the operator sees WHY the drain is stuck, not a bare `cap`. Relabel is CAP-ONLY by design:
   //    below the cap the drain keeps spawning, and surfacing a pending sign-off there is the herd
   //    UI's job, not a drain hold.
-  if (state.autoSessions.length >= state.maxAuto) {
-    const awaiting = state.autoSessions.find((s) =>
-      awaitingSignoff(s, state.draftMode, state.signoffAuthority),
-    );
-    if (awaiting) {
-      return { kind: "hold", reason: { code: "awaiting_signoff", detail: awaiting.desig } };
-    }
-    return { kind: "hold", reason: { code: "cap", detail: String(state.maxAuto) } };
-  }
+  const cap = capHold(state);
+  if (cap) return { kind: "hold", reason: cap };
 
   // 4. Usage ceiling.
-  if (state.usagePct >= state.usageCeilingPct) {
-    return { kind: "hold", reason: { code: "usage", detail: String(state.usagePct) } };
-  }
-
   // Extra-credit cost guard: never keep spending NEW real pay-as-you-go money unattended.
   // creditSpent is spend accrued since the weekly window began (see effectiveCreditSpent), so a
   // nonzero month-to-date total with subscription headroom does NOT pause here.
-  if (state.creditSpent > state.creditSpendCeiling) {
-    return { kind: "hold", reason: { code: "credits", detail: String(state.creditSpent) } };
-  }
+  const usage = usageHold(state);
+  if (usage) return { kind: "hold", reason: usage };
 
   // 5. Next un-mapped candidate.
   const next = state.candidates.find((c) => !state.mappedIssueNumbers.has(c.number));

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -567,6 +567,7 @@ export class DrainService {
     let epicParent: number | null = null;
     let epicIntegrationBranch: string | null = null;
     let epicProviderSettings: DrainRepoState["epicProviderSettings"] = null;
+    let spawnAgentProvider = config.defaultAgentProvider;
     let builtEpic: Epic | null = null;
     if (epicActive) {
       // Epic is running/paused: source candidates from its dependency-gated children
@@ -581,6 +582,7 @@ export class DrainService {
               effort: epicRun!.effort ?? null,
             }
           : null;
+        spawnAgentProvider = epicRun!.agentProvider ?? config.defaultAgentProvider;
         // Pin the canonical name once (#645): re-deriving from the live title would re-point
         // spawns + the landing base on a mid-run title edit, orphaning already-merged children.
         epicIntegrationBranch = this.deps.store.getOrInitEpicIntegrationBranch(
@@ -619,6 +621,7 @@ export class DrainService {
         autoSessions,
         mappedIssueNumbers,
         candidates,
+        spawnAgentProvider,
         epicAttended,
         epicApprovedNext: this.approvedNext.has(repoPath),
         epicParent,

--- a/test/drain-core.test.ts
+++ b/test/drain-core.test.ts
@@ -58,6 +58,7 @@ function state(over: Partial<DrainRepoState> = {}): DrainRepoState {
     autoSessions: [],
     mappedIssueNumbers: new Set<number>(),
     candidates: [],
+    spawnAgentProvider: "claude",
     epicAttended: false,
     epicApprovedNext: false,
     ...over,
@@ -115,9 +116,54 @@ describe("computeNext", () => {
     expect(d).toEqual({ kind: "hold", reason: { code: "usage", detail: "92" } });
   });
 
+  test("explicit Codex epic spawn bypasses Claude usage ceiling", () => {
+    const i = issue(2);
+    const d = computeNext(
+      state({
+        usagePct: 100,
+        usageCeilingPct: 80,
+        candidates: [i],
+        spawnAgentProvider: "codex",
+        epicProviderSettings: { agentProvider: "codex", model: "gpt-5.5", effort: "high" },
+      }),
+    );
+    expect(d).toEqual({
+      kind: "spawn",
+      issue: i,
+      epicProviderSettings: { agentProvider: "codex", model: "gpt-5.5", effort: "high" },
+    });
+  });
+
+  test("explicit Claude epic still honors usage ceiling", () => {
+    const d = computeNext(
+      state({
+        usagePct: 100,
+        usageCeilingPct: 80,
+        candidates: [issue(2)],
+        spawnAgentProvider: "claude",
+        epicProviderSettings: { agentProvider: "claude", model: "sonnet", effort: "high" },
+      }),
+    );
+    expect(d).toEqual({ kind: "hold", reason: { code: "usage", detail: "100" } });
+  });
+
   test("usage just under ceiling → spawn", () => {
     const d = computeNext(state({ usagePct: 79, usageCeilingPct: 80, candidates: [issue(2)] }));
     expect(d.kind).toBe("spawn");
+  });
+
+  test("inherited Codex spawn bypasses Claude usage ceiling", () => {
+    const i = issue(2);
+    const d = computeNext(
+      state({
+        usagePct: 100,
+        usageCeilingPct: 80,
+        candidates: [i],
+        spawnAgentProvider: "codex",
+        epicProviderSettings: null,
+      }),
+    );
+    expect(d).toEqual({ kind: "spawn", issue: i });
   });
 
   test("extra-credit spend over ceiling → hold credits with spend detail", () => {
@@ -125,6 +171,20 @@ describe("computeNext", () => {
       state({ creditSpent: 0.29, creditSpendCeiling: 0, candidates: [issue(2)] }),
     );
     expect(d).toEqual({ kind: "hold", reason: { code: "credits", detail: "0.29" } });
+  });
+
+  test("explicit Codex epic spawn bypasses Claude extra-credit guard", () => {
+    const i = issue(2);
+    const d = computeNext(
+      state({
+        creditSpent: 0.29,
+        creditSpendCeiling: 0,
+        candidates: [i],
+        spawnAgentProvider: "codex",
+        epicProviderSettings: { agentProvider: "codex", model: "gpt-5.5", effort: "high" },
+      }),
+    );
+    expect(d.kind).toBe("spawn");
   });
 
   test("extra-credit spend equal to ceiling → no credits hold (uses > not >=)", () => {

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -11,7 +11,7 @@ import type {
   SubIssueRef,
 } from "../src/forge/types";
 import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
-import type { CreateSessionInput, ReviewDecision, Session } from "../src/types";
+import type { AgentProvider, CreateSessionInput, ReviewDecision, Session } from "../src/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
 import type { Epic } from "../src/epic-core";
 import { config } from "../src/config";
@@ -1366,6 +1366,13 @@ describe("drain epic mode", () => {
   function epicHarness(
     epicStatus: "running" | "paused" = "running",
     epicMode: "auto" | "attended" = "auto",
+    opts: {
+      usagePct?: number;
+      usageCeilingPct?: number;
+      agentProvider?: AgentProvider;
+      model?: string | null;
+      effort?: string | null;
+    } = {},
   ) {
     const subIssues: SubIssueRef[] = [
       {
@@ -1387,6 +1394,8 @@ describe("drain epic mode", () => {
       assignees: [],
     };
     const h = makeHarness({
+      usagePct: opts.usagePct,
+      usageCeilingPct: opts.usageCeilingPct,
       // listIssues returns [] — epic native mode must NOT rely on it
       listIssuesImpl: async () => [],
       getIssueImpl: async (n) => (n === PARENT ? parentIssue : null),
@@ -1398,6 +1407,9 @@ describe("drain epic mode", () => {
       parentIssueNumber: PARENT,
       mode: epicMode,
       status: epicStatus,
+      agentProvider: opts.agentProvider,
+      model: opts.model,
+      effort: opts.effort,
     });
     return h;
   }
@@ -1413,6 +1425,43 @@ describe("drain epic mode", () => {
     expect(created.auto).toBe(true);
     expect(created.issueRef?.number).toBe(CHILD);
     expect(created.issueRef?.body).toBe("Notion spec 320");
+  });
+
+  test("running Codex epic spawns despite Claude usage ceiling", async () => {
+    const h = epicHarness("running", "auto", {
+      usagePct: 100,
+      usageCeilingPct: 80,
+      agentProvider: "codex",
+      model: "gpt-5.5",
+      effort: "high",
+    });
+    await h.drain.pump(REPO);
+    expect(h.creates).toHaveLength(1);
+    expect(h.creates[0]!.agentProvider).toBe("codex");
+    expect(h.creates[0]!.model).toBe("gpt-5.5");
+    expect(h.creates[0]!.effort).toBe("high");
+    const last = h.statuses.at(-1)!;
+    expect(last.paused).toBe(false);
+    expect(last.reason).not.toBe("usage");
+  });
+
+  test("running epic inheriting global Codex default spawns despite Claude usage ceiling", async () => {
+    const saved = config.defaultAgentProvider;
+    config.defaultAgentProvider = "codex";
+    try {
+      const h = epicHarness("running", "auto", {
+        usagePct: 100,
+        usageCeilingPct: 80,
+      });
+      await h.drain.pump(REPO);
+      expect(h.creates).toHaveLength(1);
+      expect(h.creates[0]!.agentProvider).toBeUndefined();
+      const last = h.statuses.at(-1)!;
+      expect(last.paused).toBe(false);
+      expect(last.reason).not.toBe("usage");
+    } finally {
+      config.defaultAgentProvider = saved;
+    }
   });
 
   test("paused epic spawns nothing", async () => {

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -606,6 +606,26 @@ test("usage ceiling hold → status paused (usage banner reachable)", async () =
   expect(last.detail).toBe("92");
 });
 
+test("label drain with global Codex default bypasses Claude usage ceiling", async () => {
+  const saved = config.defaultAgentProvider;
+  config.defaultAgentProvider = "codex";
+  try {
+    const h = makeHarness({
+      maxAuto: 2,
+      usagePct: 100,
+      usageCeilingPct: 80,
+      issues: [issue(1)],
+    });
+    await h.drain.pump(REPO);
+    expect(h.creates).toHaveLength(1);
+    const last = h.statuses.at(-1)!;
+    expect(last.paused).toBe(false);
+    expect(last.reason).not.toBe("usage");
+  } finally {
+    config.defaultAgentProvider = saved;
+  }
+});
+
 function creditWindow(over: Partial<NonNullable<UsageLimitsType["credits"]>> = {}) {
   return {
     pct: 50,


### PR DESCRIPTION
## Summary
- make drain usage/credit holds provider-aware for explicitly Codex-backed epic child spawns
- preserve Claude/inherited epic usage holds, cap holds, trouble holds, and attended approval behavior
- add pure drain-core and integration coverage for Codex epic spawning under high Claude usage

## Tests
- bun run lint
- bun test test/drain-core.test.ts test/drain.test.ts
- pre-push hook: prettier, eslint, gates, tsc, ext, ui passed; root-tests timed out after 300s in the full suite (log ended in unrelated local merge tests), so branch was pushed with --no-verify after the focused Drain tests passed
