### PR TITLE
fix(doc-agent): format docs with ignores off so PRs pass CI

### DIFF
--- a/src/doc-agent.ts
+++ b/src/doc-agent.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { devNull } from "node:os";
 import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
@@ -33,23 +34,60 @@ async function defaultGit(cwd: string, args: string[]): Promise<string> {
  *  plugins). Mirrors the pattern at egress.ts:94 and server.ts:127. */
 export const SERVER_INSTALL_ROOT = resolve(import.meta.dir, "..");
 
-/** Run the server's pinned prettier `--write` over `files`. No-op when the list is empty.
- *  `cwd` should be SERVER_INSTALL_ROOT: prettier 3 resolves the bare plugin specifiers in
- *  `configPath` (`prettier-plugin-svelte`/`-tailwindcss`) by importing from a synthetic module
- *  anchored at the CWD (verified on 3.8.4 — a wrong cwd fails with `imported from <cwd>/noop.js`),
- *  and those plugins are loaded for every parser, markdown included. SERVER_INSTALL_ROOT is the one
- *  directory guaranteed to have them (co-located with this pinned prettier); the managed worktree's
- *  own node_modules may be absent. Throws on prettier error — the caller catches for best-effort. */
-async function defaultPrettierWrite(args: {
+/** Run the server's pinned prettier `--check` over `files` with ALL ignore files disabled
+ *  (`--ignore-path devNull`) and reject if any file is not prettier-clean. Same `cwd`/`configPath`
+ *  as {@link defaultPrettierWrite}, so plugin resolution is identical (see that doc). No-op on an
+ *  empty list. Used as {@link defaultPrettierWrite}'s fail-closed verify; also exported so tests can
+ *  exercise the detection half on its own. */
+export async function assertPrettierClean(args: {
   cwd: string;
   configPath: string;
   files: string[];
 }): Promise<void> {
   if (args.files.length === 0) return;
   const binary = join(SERVER_INSTALL_ROOT, "node_modules", ".bin", "prettier");
-  await execFileP(binary, ["--write", "--config", args.configPath, "--", ...args.files], {
-    cwd: args.cwd,
-  });
+  await execFileP(
+    binary,
+    ["--check", "--ignore-path", devNull, "--config", args.configPath, "--", ...args.files],
+    { cwd: args.cwd },
+  );
+}
+
+/** Format `files` with the server's pinned prettier, then verify. No-op when the list is empty.
+ *  `cwd` should be SERVER_INSTALL_ROOT: prettier 3 resolves the bare plugin specifiers in
+ *  `configPath` (`prettier-plugin-svelte`/`-tailwindcss`) by importing from a synthetic module
+ *  anchored at the CWD (verified on 3.8.4 — a wrong cwd fails with `imported from <cwd>/noop.js`),
+ *  and those plugins are loaded for every parser, markdown included. SERVER_INSTALL_ROOT is the one
+ *  directory guaranteed to have them (co-located with this pinned prettier); the managed worktree's
+ *  own node_modules may be absent.
+ *
+ *  `--ignore-path devNull` disables ALL ignore files: the caller passes an already-whitelisted,
+ *  explicit file list (IN_SCOPE ∩ `docs/` ∩ existing), so prettier's ignore is redundant — and
+ *  harmful, because doc-agent worktrees live under `.shepherd-worktrees/` (worktree.ts), whose
+ *  component matches the `.shepherd-*` glob in the repo's own `.prettierignore`, silently making
+ *  `--write` a no-op on every doc file (the file is "ignored"). CI then checks the same file from a
+ *  clean checkout where nothing is ignored and fails `prettier --check`, so the doc PR is never
+ *  green and never auto-merges. Disabling ignores makes formatting independent of the worktree's
+ *  absolute location.
+ *
+ *  Fail-closed: after `--write`, {@link assertPrettierClean} runs `--check` with the SAME
+ *  cwd/config/ignore (only the mode flag differs) → prettier write→check is idempotent, so a valid
+ *  run never false-aborts, while a residual non-conformance (a future silent skip, config/version
+ *  drift, plugin load failure) throws here. Throws on prettier error — the caller catches to abort
+ *  the run (no commit/push/PR). */
+export async function defaultPrettierWrite(args: {
+  cwd: string;
+  configPath: string;
+  files: string[];
+}): Promise<void> {
+  if (args.files.length === 0) return;
+  const binary = join(SERVER_INSTALL_ROOT, "node_modules", ".bin", "prettier");
+  await execFileP(
+    binary,
+    ["--write", "--ignore-path", devNull, "--config", args.configPath, "--", ...args.files],
+    { cwd: args.cwd },
+  );
+  await assertPrettierClean(args);
 }
 
 /** Thrown by stageInScope when `prettier --write` fails, so finalize can fail-closed:
@@ -792,10 +830,12 @@ export class DocAgentService {
    * reference/cli/*, or a brand-new file is never staged → can't reach the PR.
    *
    * Before staging it formats the `docs/`-prefixed in-scope files (abs paths) with the server's
-   * pinned prettier so the PR passes CI's `prettier --check .` gate — docs-site/** is
+   * pinned prettier — then verifies (`--check`) — so the PR passes CI's `prettier --check .` gate;
+   * both run with ignores disabled so the worktree's `.shepherd-worktrees/` location can't make
+   * prettier silently skip the file (see {@link defaultPrettierWrite}). docs-site/** is
    * Astro/Starlight-governed and must NEVER be passed to root prettier. Prettier is fail-closed: a
-   * failure throws {@link PrettierFormatError}, which finalize catches to abort the run (no
-   * commit/push/PR) and record an `error` outcome. A skipped doc update beats a red un-mergeable PR.
+   * format OR verify failure throws {@link PrettierFormatError}, which finalize catches to abort the
+   * run (no commit/push/PR) and record an `error` outcome. A skipped doc update beats a red PR.
    */
   private async stageInScope(f: InFlight): Promise<string> {
     const inScope = IN_SCOPE_PATHS.filter((p) => this.fileExists(join(f.worktreePath, p)));

--- a/test/doc-agent.test.ts
+++ b/test/doc-agent.test.ts
@@ -1,9 +1,16 @@
 import { test, expect } from "bun:test";
+import { execFile } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
 import {
   DocAgentService,
   DOC_AGENT_LABEL,
   SERVER_INSTALL_ROOT,
   PrettierFormatError,
+  assertPrettierClean,
+  defaultPrettierWrite,
   isDocRelevantMerge,
   type DocAgentFinalize,
   type DocAgentDeps,
@@ -1099,6 +1106,111 @@ test("prettier regression: docs-site paths are never passed to prettier", async 
   const call = h.prettierCalls[0]!;
   for (const f of call.files) {
     expect(f).not.toContain("docs-site");
+  }
+});
+
+// ── real-prettier tests: the ignore-path fix + fail-closed --check guard ────────
+// These drive the REAL defaultPrettierWrite/assertPrettierClean (not the mocked seam), so they
+// prove the two halves the seam-based tests above cannot: (1) formatting is not silently skipped
+// when the worktree lives under a `.shepherd-*` path, and (2) the `--check` guard actually detects
+// a non-conformant file. They use SERVER_INSTALL_ROOT as cwd (real node_modules → prettier plugins
+// resolve) and the repo's real .prettierrc as the config, matching production.
+
+const execFileP = promisify(execFile);
+const REPO_PRETTIERRC = join(SERVER_INSTALL_ROOT, ".prettierrc");
+// A deliberately non-canonical Markdown table: prettier re-pads the first column to the width of
+// `attachmentNames`, so the input differs from prettier's output (the exact #1517 failure shape).
+const UNFORMATTED_MD = [
+  "# Doc",
+  "",
+  "| Field | Notes |",
+  "| --- | --- |",
+  "| `x` | short |",
+  "| `attachmentNames` | longer |",
+  "",
+].join("\n");
+
+/** Make a temp "worktree" whose path contains a `.shepherd-*` component (like the real
+ *  `.shepherd-worktrees/…`), holding a single unformatted `docs/<name>.md`. Returns the abs file
+ *  path + a cleanup thunk. */
+function mkShepherdWorktreeDoc(name = "foo.md"): { file: string; cleanup: () => void } {
+  // mkdtemp prefix `.shepherd-wt-` → the created dir matches the `.shepherd-*` glob in the repo's
+  // .prettierignore, reproducing the silent-skip that made doc PRs fail CI.
+  const wt = mkdtempSync(join(tmpdir(), ".shepherd-wt-"));
+  mkdirSync(join(wt, "docs"));
+  const file = join(wt, "docs", name);
+  writeFileSync(file, UNFORMATTED_MD);
+  return { file, cleanup: () => rmSync(wt, { recursive: true, force: true }) };
+}
+
+test("prettier fix (regression): defaultPrettierWrite formats a doc under a .shepherd-* worktree that the old path silently skipped", async () => {
+  const { file, cleanup } = mkShepherdWorktreeDoc();
+  try {
+    const binary = join(SERVER_INSTALL_ROOT, "node_modules", ".bin", "prettier");
+
+    // NEGATIVE CONTROL: the OLD invocation (no --ignore-path devNull) from cwd=SERVER_INSTALL_ROOT
+    // must leave the file BYTE-UNCHANGED — prettier treats it as ignored (path matches `.shepherd-*`
+    // in the repo .prettierignore). Without this, a mis-built temp layout would make the assertion
+    // below pass vacuously (the file would have formatted even without the fix).
+    await execFileP(binary, ["--write", "--config", REPO_PRETTIERRC, "--", file], {
+      cwd: SERVER_INSTALL_ROOT,
+    });
+    expect(readFileSync(file, "utf8")).toBe(UNFORMATTED_MD); // proven: layout reproduces the skip
+
+    // PATCHED: the real defaultPrettierWrite (adds --ignore-path devNull) MUST format it.
+    await defaultPrettierWrite({
+      cwd: SERVER_INSTALL_ROOT,
+      configPath: REPO_PRETTIERRC,
+      files: [file],
+    });
+    const formatted = readFileSync(file, "utf8");
+    expect(formatted).not.toBe(UNFORMATTED_MD);
+    // Alignment happened: prettier pads every table row to one width, so the short (`x`) row and the
+    // wide (`attachmentNames`) row now have identical length.
+    const rowX = formatted.split("\n").find((l) => l.includes("`x`"))!;
+    const rowLong = formatted.split("\n").find((l) => l.includes("`attachmentNames`"))!;
+    expect(rowX.length).toBe(rowLong.length);
+
+    // INDEPENDENT CONFIRMATION: the output passes `prettier --check` from a NON-nested path (a clean
+    // checkout equivalent, honoring default ignores) — i.e. it would go green in CI.
+    const plain = mkdtempSync(join(tmpdir(), "plain-doc-"));
+    try {
+      const plainFile = join(plain, "external-task-api.md");
+      writeFileSync(plainFile, formatted);
+      // exit 0 ⇒ resolves; a non-zero exit would reject and fail the test.
+      await execFileP(binary, ["--check", "--config", REPO_PRETTIERRC, "--", plainFile], {
+        cwd: SERVER_INSTALL_ROOT,
+      });
+    } finally {
+      rmSync(plain, { recursive: true, force: true });
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test("prettier guard: assertPrettierClean REJECTS an unformatted doc and RESOLVES a formatted one (detection half)", async () => {
+  const { file, cleanup } = mkShepherdWorktreeDoc();
+  try {
+    // Unformatted (and under a `.shepherd-*` path): --ignore-path devNull keeps --check non-vacuous,
+    // so the guard must detect the non-conformance and reject — this is the abort trigger.
+    await expect(
+      assertPrettierClean({ cwd: SERVER_INSTALL_ROOT, configPath: REPO_PRETTIERRC, files: [file] }),
+    ).rejects.toThrow();
+
+    // After formatting the SAME file, the guard must resolve (idempotency: no false-positive abort).
+    await defaultPrettierWrite({
+      cwd: SERVER_INSTALL_ROOT,
+      configPath: REPO_PRETTIERRC,
+      files: [file],
+    });
+    await assertPrettierClean({
+      cwd: SERVER_INSTALL_ROOT,
+      configPath: REPO_PRETTIERRC,
+      files: [file],
+    });
+  } finally {
+    cleanup();
   }
 });
 


### PR DESCRIPTION
## Problem

Doc-agent PRs (`docs: sync docs to recent source changes`, branch `shepherd/docs-update-*`) keep failing to auto-merge — e.g. #1517 sat red, and #1455/#1421 before it. The `doc-automerge.yml` workflow is **correct**; it rightly skips a PR whose checks aren't green. The real failure is upstream: the doc PRs themselves fail the CI `verify` job on a **Prettier** error, so they can never go green.

## Root cause (proven)

The doc agent already runs `prettier --write` before committing (`stageInScope`) and is fail-closed on prettier *errors* — but it runs prettier with `cwd = SERVER_INSTALL_ROOT`, so prettier reads that root's `.prettierignore`, which contains the glob `.shepherd-*`.

Doc-agent worktrees live at `dirname(repoPath)/.shepherd-worktrees/<name>` (`src/worktree.ts`). The absolute file path therefore contains the component `.shepherd-worktrees`, which matches `.shepherd-*` → prettier treats every doc file as **ignored and silently no-ops** (exit 0, no throw). The unformatted Markdown gets committed. CI checks the same file from a clean checkout (no `.shepherd-worktrees` ancestor → not ignored) and `prettier --check` fails → `verify` red → auto-merge skips forever, every sweep.

Concretely, #1517 added an `attachmentNames` table row wider than the column; Prettier re-aligns the whole table, so the raw agent output was non-conformant and the silently-skipped format pass never fixed it. Proof: `prettier --file-info` returns `{ "ignored": true }` on the worktree path vs `{ "ignored": false, "inferredParser": "markdown" }` at a plain path.

## Fix (`src/doc-agent.ts`, server-only)

1. **Root fix:** pass `--ignore-path <devNull>` on `prettier --write`. The file list is already the access-control boundary (`IN_SCOPE ∩ docs/ ∩ existing`), so prettier's ignore is redundant here — and, as shown, harmful: it skips based on *where the worktree lives*, not the file's identity. Disabling ignores makes formatting independent of the worktree's absolute location.
2. **Hardening (fail-closed on the whole silent-skip class):** extract `assertPrettierClean()` and run `prettier --check --ignore-path <devNull>` after the write, with **byte-identical** `cwd`/`--config`/`--ignore-path` (only the mode flag differs → identical plugin resolution → prettier idempotency, so a valid run never false-aborts). `--ignore-path <devNull>` keeps `--check` **non-vacuous** (a plain `--check` on an ignored file exits 0), so any residual non-conformance (future silent skip, config/version drift, plugin load failure) throws → `stageInScope` wraps it in `PrettierFormatError` → the run aborts (no commit/push/PR). A skipped doc update beats a red PR.

The `doc-automerge.yml` workflow is unchanged — it was already correct. No action taken on the currently-stuck #1517; once this lands, the next doc-agent sweep opens a correctly-formatted PR that supersedes it (as #1455/#1421 were superseded).

## Scope boundary

Only the three repo-root `docs/*.md` files reach root prettier (`stageInScope` filters `startsWith("docs/")`). In-scope `docs-site/src/content/docs/*.md` is Astro/Starlight-governed via the separate `docs-site` CI job — never root prettier — so a docs-site content failure is a distinct class, out of scope here.

## Tests (`test/doc-agent.test.ts`, real prettier)

- **Regression (write half) with an explicit negative control:** in a worktree nested under a `.shepherd-*` path, first assert the *unpatched* invocation leaves the file byte-unchanged (proving the layout genuinely reproduces the silent-skip, so the test can't pass vacuously); then assert the real `defaultPrettierWrite` formats it (table rows equal width); then assert the output passes `prettier --check` from a non-nested/clean path.
- **Guard-detection (check half):** `assertPrettierClean` rejects on an unformatted file (the real `--check` running) and resolves on a formatted one.

## Verification

- `bun run typecheck`, `bun run lint`, `bun test test/doc-agent.test.ts` (81 pass) — all green.
- Full `bun test`: my change adds +2 passing tests and introduces **zero** new failures (the pre-existing environment-dependent failures in browser-API suites are identical with and without this change).

[no-feature-entry] — server-only bug fix, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)