### PR TITLE
docs(design): permit 6px semantically-accented status chips (#1537)

### DIFF
--- a/DESIGN.json
+++ b/DESIGN.json
@@ -198,6 +198,14 @@
       "css": ".ds-pip { width: 9px; height: 9px; border-radius: 50%; display: inline-block; margin-right: 10px; vertical-align: middle; } .ds-pip-working { background: var(--color-amber); animation: ds-pip-pulse 1.5s ease-out infinite; } .ds-pip-blocked { background: var(--color-red); } .ds-pip-ready { color: var(--color-green); font-size: 10px; font-weight: 700; line-height: 1; } @keyframes ds-pip-pulse { 0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-amber) 70%, transparent); } 70% { box-shadow: 0 0 0 7px transparent; } 100% { box-shadow: 0 0 0 0 transparent; } } @media (prefers-reduced-motion: reduce) { .ds-pip-working { animation: none; } }"
     },
     {
+      "name": "Status Chip",
+      "kind": "custom",
+      "refersTo": "status-chip",
+      "description": "Compact read-only functional-status chip (git / CI / PR / ready). 6px radius — softer than a 2px button, still not the forbidden 999px pill. Carries its semantic hue on border + text + optional leading dot; a failure red is subordinate (no halo, pulse, or wash), so a blocked agent's pip stays the loudest red on screen.",
+      "html": "<div class=\"ds-status-chips\"><span class=\"ds-status-chip info\"><span class=\"ds-status-dot\"></span>PR #42</span><span class=\"ds-status-chip ready\"><span class=\"ds-status-dot\"></span>CI passing</span><span class=\"ds-status-chip fail\"><span class=\"ds-status-dot\"></span>CI failed</span></div>",
+      "css": ".ds-status-chips { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; } .ds-status-chip { display: inline-flex; align-items: center; gap: 6px; background: var(--color-panel-2); color: var(--color-muted); border: 1px solid var(--color-line); border-radius: 6px; padding: 3px 9px; font-family: var(--font-mono, ui-monospace, monospace); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; white-space: nowrap; } .ds-status-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--color-muted); flex: none; } .ds-status-chip.info { color: var(--color-blue); border-color: var(--color-blue); } .ds-status-chip.info .ds-status-dot { background: var(--color-blue); } .ds-status-chip.ready { color: var(--color-green); border-color: var(--color-green); } .ds-status-chip.ready .ds-status-dot { background: var(--color-green); } .ds-status-chip.fail { color: var(--color-red); border-color: var(--color-red); } .ds-status-chip.fail .ds-status-dot { background: var(--color-red); }"
+    },
+    {
       "name": "Toolbar Panel",
       "kind": "card",
       "refersTo": "panel",
@@ -235,7 +243,7 @@
     "rules": [
       {
         "name": "The Four-Light Rule",
-        "body": "Status speaks in exactly four colors: amber (working), green (done/ready), red (blocked), slate (idle). These hues are reserved for state; no decorative element may borrow a status color. Narrow exception: the usage-limit gauge may go red when pct > 90 as a bar-fill/text-only signal (no halo, no status pip), so a blocked agent's red pip remains the loudest red on screen.",
+        "body": "Status speaks in exactly four colors: amber (working), green (done/ready), red (blocked), slate (idle). These hues are reserved for state — never decoration. State includes functional machine status: a functional-status chip (git / CI / PR / ready) may carry the matching hue (blue stays informational, not a status light). Red is rationed by loudness: the loudest red — a pulsing haloed pip or the oxblood header wash — stays reserved for blocked agent state, while subordinate red (a CI-failure chip's text/border/dot, or the usage-limit gauge above pct > 90 as a bar-fill/text-only signal) carries no halo, pulse, or wash, so a blocked agent's red pip remains the loudest red on screen.",
         "section": "colors"
       },
       {
@@ -266,11 +274,11 @@
     ],
     "dos": [
       "Do keep everything in Berkeley Mono. Build hierarchy from size, weight, case, and ink brightness (Faint Moss -> Muted Sage -> Phosphor Ink -> Bright Phosphor).",
-      "Do reserve the four status colors (amber / green / red / slate) strictly for agent state. Exception: the usage-limit gauge may show red when pct > 90 as a bar-fill/text-only signal (see Four-Light Rule).",
+      "Do reserve the four status colors (amber / green / red / slate) for state — agent state and functional machine status (git / CI / PR / ready) alike — never decoration. Red is rationed by loudness: subordinate red (a CI-failure chip's text/border/dot, or the usage-limit gauge above pct > 90 as bar-fill/text-only) is permitted, but the loudest red — pulsing haloed pip or oxblood wash — stays reserved for blocked agent state (see Four-Light Rule).",
       "Do build depth with tonal layering and 1px hairlines (inset < panel-2 < panel < head).",
-      "Do keep structural panels square (0 radius) and reserve the 2px radius for buttons and chips; 12px is only for rising bottom sheets.",
+      "Do keep structural panels square (0 radius), use the 2px radius for buttons and controls and the 6px chip radius for status chips, and reserve 12px for rising bottom sheets; the full pill (999px) stays forbidden.",
       "Do use tabular figures for any number that updates in place.",
-      "Do keep the screen calm at rest and make the blocked (red) state the loudest thing on it. The usage-gauge red (bar-fill/text-only, no halo/pip) is subordinate — a blocked pip stays the loudest red on screen.",
+      "Do keep the screen calm at rest and make the blocked (red) state the loudest thing on it. Subordinate reds — the usage-gauge fill and a CI-failure chip (text/border/dot, no halo/pulse/wash) — stay below it; a blocked pip stays the loudest red on screen.",
       "Do pair every status color with a non-color cue (position, pulse, check glyph, or label), and keep touch targets thumb-reachable; phone steering is first-class."
     ],
     "donts": [

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -92,6 +92,7 @@ components:
     backgroundColor: "{colors.panel-2}"
     textColor: "{colors.muted}"
     typography: "{typography.label}"
+    letterSpacing: "0.08em"
     rounded: "{rounded.chip}"
     padding: "3px 9px"
   compose-sheet:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -50,6 +50,7 @@ typography:
 rounded:
   sm: "2px"
   md: "3px"
+  chip: "6px"
   lg: "12px"
 spacing:
   xs: "4px"
@@ -87,6 +88,12 @@ components:
     backgroundColor: "{colors.amber}"
     size: "9px"
     rounded: "50%"
+  status-chip:
+    backgroundColor: "{colors.panel-2}"
+    textColor: "{colors.muted}"
+    typography: "{typography.label}"
+    rounded: "{rounded.chip}"
+    padding: "3px 9px"
   compose-sheet:
     backgroundColor: "{colors.head}"
     textColor: "{colors.ink}"
@@ -141,7 +148,9 @@ A desaturated, green-tinted monochrome ground with four reserved status accents.
 
 ### Named Rules
 
-**The Four-Light Rule.** Status speaks in exactly four colors: amber (working), green (ready / actionable-complete), red (blocked), slate (idle / parked, including a WAITING agent awaiting its next steer). These hues are reserved for state. No decorative element may borrow a status color, or it dilutes the only signal that must never be missed. Green is spent only on a ready-to-ship session, never on a merely finished turn — so a parked agent reads quiet, not "done, ignore me." **Narrow exception — usage gauge:** the usage-limit bar may go red when `pct > 90` (approaching cap) as a bar-fill/text-only signal; it carries no halo or status pip, so a blocked agent's red pip remains the loudest red on screen. Red stays fully reserved for blocked agent state in all other UI elements.
+**The Four-Light Rule.** Status speaks in exactly four colors: amber (working), green (ready / actionable-complete), red (blocked), slate (idle / parked, including a WAITING agent awaiting its next steer). These hues are reserved for **state — never decoration**. State is not only _agent_ state: a **functional-status chip** reporting genuine machine state (git / CI / PR / ready) is status too, and may carry the matching semantic hue (blue stays informational, not a status light). What the rule forbids is a _decorative_ element borrowing a status color, which would dilute the only signal that must never be missed. Green is spent only on a ready-to-ship session, never on a merely finished turn — so a parked agent reads quiet, not "done, ignore me."
+
+**Red is rationed by loudness, not banned outright.** The _loudest_ red — a pulsing, haloed status pip, or the oxblood header wash (`--wash-blocked`) — stays fully reserved for blocked agent state, so it is never out-competed. Quieter, _subordinate_ red is permitted for non-agent failure: a CI-failure chip may go red on its text, border and dot, and the usage-limit bar may go red when `pct > 90` (approaching cap) as a bar-fill/text-only signal. Neither carries a halo, pulse, or wash, so a blocked agent's red pip remains the loudest red on screen.
 
 **The Quiet Ground Rule.** The surface is desaturated green-black; visible chroma stays at or below ~10% of any screen, spent on status lights and the one amber action. If the screen looks colorful at rest, color has leaked out of its lane.
 
@@ -197,10 +206,17 @@ Shadows are permitted in exactly one situation: a summoned overlay. Bottom sheet
 
 ### Buttons
 
-- **Shape:** Gently squared (2px radius). Square enough to read as instrument hardware, never pill-shaped.
+- **Shape:** Gently squared (2px radius). Square enough to read as instrument hardware, never pill-shaped. Buttons are interactive controls; a read-only _status chip_ steps to the softer 6px chip radius (see Status Chip below), which is still not the forbidden full pill (999px).
 - **Default:** Outline ghost. Transparent fill, 1px Bright Hairline border, Phosphor Ink text, uppercase 11px label at +0.12em, padding 7px 14px.
 - **Primary / Active:** Same ghost geometry, but border and text switch to Signal Amber with an inset amber glow (`inset 0 0 18px -10px`). The amber primary is never a solid amber fill; the glow does the emphasis.
 - **Hover:** Background lifts to `hover` (#0c1110); border brightens. No motion beyond the tonal shift.
+
+### Status Chip
+
+- **When:** A compact, read-only **functional-status** readout in a chip row — git / CI / PR / critic / ready state. It is a distinct control class: not a **Button** (interactive → 2px ghost), not a structural **Panel** (square, 0 radius), and not the inline **Badge** (the smallest 2px micro-label embedded in running text or a table cell). Reach for a chip when a row of machine-state values must read at a glance and stay thumb-reachable.
+- **Shape:** The 6px chip radius (`rounded.chip`) — the one softer step in the system, between the 2px control and the forbidden 999px pill. Padding ~3px 9px, uppercase 11px label (`--fs-meta`) at +0.08em, 1px Hairline border, `panel-2` fill.
+- **Semantic accent:** A chip may carry its status hue on **border + text + an optional leading dot**, chosen by meaning (blue = informational / PR, green = passing / ready, amber = in progress, slate = idle / parked). The hue is not decoration — it _is_ the status. Always pair it with a non-color cue: the label carries the meaning, the dot reinforces it; hue never stands alone.
+- **Subordinate red:** A functional failure (e.g. CI failed) may go red on text + border + dot, but never takes a halo, pulse, or wash — that loudest red stays reserved for the blocked agent pip (see the Four-Light Rule).
 
 ### Inputs / Fields
 
@@ -233,11 +249,11 @@ Shadows are permitted in exactly one situation: a summoned overlay. Bottom sheet
 ### Do:
 
 - **Do** keep everything in Berkeley Mono. Build hierarchy from size, weight, case, and ink brightness (Faint Moss -> Muted Sage -> Phosphor Ink -> Bright Phosphor).
-- **Do** reserve the four status colors (amber / green / red / slate) strictly for agent state. The Four-Light Rule is the most important rule in the system. Exception: the usage-limit gauge may show red when `pct > 90` as a bar-fill/text-only signal (see Four-Light Rule above).
+- **Do** reserve the four status colors (amber / green / red / slate) for _state_ — agent state and functional machine status (git / CI / PR / ready) alike — never for decoration. The Four-Light Rule is the most important rule in the system. Red is rationed by loudness: subordinate red (a CI-failure chip's text/border/dot, or the usage-limit gauge above `pct > 90` as bar-fill/text-only) is permitted, but the loudest red — pulsing haloed pip or oxblood wash — stays reserved for blocked agent state (see Four-Light Rule above).
 - **Do** build depth with tonal layering and 1px hairlines (inset < panel-2 < panel < head). If a panel needs separation, step the value or brighten the hairline.
-- **Do** keep structural panels square (0 radius) and reserve the 2px radius for buttons and chips; 12px is only for rising bottom sheets.
+- **Do** keep structural panels square (0 radius), use the 2px radius for buttons and controls and the 6px chip radius for status chips, and reserve 12px for rising bottom sheets. The full pill (999px) stays forbidden.
 - **Do** use tabular figures for any number that updates in place.
-- **Do** keep the screen calm at rest and make the blocked (red) state the loudest thing on it. The usage-gauge red (bar-fill/text-only, no halo/pip) is subordinate to this — a blocked pip remains the loudest red on screen. Spend attention only on what is actionable.
+- **Do** keep the screen calm at rest and make the blocked (red) state the loudest thing on it. Subordinate reds — the usage-gauge fill and a CI-failure chip (text/border/dot, no halo/pulse/wash) — stay below it; a blocked pip remains the loudest red on screen. Spend attention only on what is actionable.
 - **Do** pair every status color with a non-color cue (position, pulse, check glyph, or label), and keep touch targets thumb-reachable; phone steering is first-class.
 
 ### Don't:

--- a/ui/src/routes/design-system/+page.svelte
+++ b/ui/src/routes/design-system/+page.svelte
@@ -136,6 +136,34 @@ input, select, textarea {
 }
 /* state colors come from the accent/status tokens, applied to color + border */`;
 
+  const statusChipMarkup = `<span class="status-chip info"><span class="dot"></span>PR #42</span>
+<span class="status-chip ready"><span class="dot"></span>CI passing</span>
+<span class="status-chip fail"><span class="dot"></span>CI failed</span>
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--fs-meta);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 3px 9px;
+  border: 1px solid var(--color-line);
+  border-radius: 6px;          /* softer chip rung — not a 2px control, not a 999px pill */
+  background: var(--color-panel-2);
+  color: var(--color-muted);
+}
+.status-chip .dot {
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  background: currentColor;    /* dot follows the chip's hue */
+}
+/* semantic accent on border + text + dot, chosen by meaning */
+.status-chip.info  { color: var(--color-blue);  border-color: var(--color-blue); }
+.status-chip.ready { color: var(--color-green); border-color: var(--color-green); }
+/* subordinate red — failure only; never a halo/pulse/wash (Four-Light Rule) */
+.status-chip.fail  { color: var(--color-red);   border-color: var(--color-red); }`;
+
   const meterMarkup = `<!-- PuiMeter — plugin UI primitive (issue #1185); rendered via PluginUIRenderer -->
 <div class="pui-meter">
   <div class="pui-meter-header">
@@ -704,12 +732,19 @@ input, select, textarea {
   </section>
 
   <section class="panel">
-    <h2>Badges &amp; pills</h2>
+    <h2>Badges &amp; chips</h2>
     <p class="when">
-      <strong>When:</strong> a compact, read-only status label (PR state, CI, critic verdict). Color
-      comes from the accent/status tokens. <strong>When not:</strong> if it's clickable it's a button,
-      not a badge.
+      Two read-only status primitives, split by size and context.
+      <strong>Badge</strong> — the smallest inline micro-label (2px radius, 10px, no dot) embedded
+      in running text, a table cell, or beside a title for a single state token.
+      <strong>Status chip</strong> — the 6px chip-row control (11px, optional leading dot,
+      thumb-reachable) for a row of functional-status values (git / CI / PR / ready). Both may carry
+      a semantic hue on border + text; only the chip adds the dot and the softer radius.
+      <strong>When not:</strong> if it's clickable it's a button, not a badge or chip; hue is reserved
+      for genuine state, never decoration.
     </p>
+
+    <p class="when"><strong>Badge</strong> — inline micro-label:</p>
     <div class="demo">
       <span class="badge">OPEN</span>
       <span class="badge" style="color: var(--color-green); border-color: var(--color-green)"
@@ -720,6 +755,20 @@ input, select, textarea {
       >
     </div>
     <pre><code>{badgeMarkup}</code></pre>
+
+    <p class="when"><strong>Status chip</strong> — functional-status row (radius 6px):</p>
+    <div class="demo">
+      <span class="status-chip"><span class="dot"></span>PR #42</span>
+      <span class="status-chip info"><span class="dot"></span>PR #42</span>
+      <span class="status-chip ready"><span class="dot"></span>CI passing</span>
+      <span class="status-chip ready"><span class="dot"></span>READY</span>
+      <span class="status-chip fail"><span class="dot"></span>CI failed</span>
+    </div>
+    <p class="when">
+      The <code>fail</code> chip's red is <strong>subordinate</strong> — text + border + dot only, never
+      a halo, pulse, or wash — so the blocked-agent pip stays the loudest red on screen (Four-Light Rule).
+    </p>
+    <pre><code>{statusChipMarkup}</code></pre>
   </section>
 
   <section class="panel">
@@ -1140,6 +1189,39 @@ input, select, textarea {
     border: 1px solid var(--color-line);
     border-radius: 2px;
     color: var(--color-muted);
+  }
+  /* Status chip — 6px chip-row control; distinct from the 2px .chip color swatch above */
+  .status-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: var(--fs-meta);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 3px 9px;
+    border: 1px solid var(--color-line);
+    border-radius: 6px;
+    background: var(--color-panel-2);
+    color: var(--color-muted);
+  }
+  .status-chip .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: currentColor;
+  }
+  .status-chip.info {
+    color: var(--color-blue);
+    border-color: var(--color-blue);
+  }
+  .status-chip.ready {
+    color: var(--color-green);
+    border-color: var(--color-green);
+  }
+  /* subordinate red — failure only; never a halo/pulse/wash (Four-Light Rule) */
+  .status-chip.fail {
+    color: var(--color-red);
+    border-color: var(--color-red);
   }
   /* PuiMeter demo styles (mirrors PuiMeter.svelte) */
   .pui-meter-demo {


### PR DESCRIPTION
Closes #1537. Design-rules pass that defines the shared **functional-status chip** language, so the downstream restyles **#1520 (GitRail)** and **#1533 (top-bar)** implement against a settled rule instead of re-litigating the constitution per PR.

## Decisions (settled against a live token-accurate mockup, attended review)

| # | Decision | Choice |
|---|---|---|
| 1 | Chip radius | **6px** rung — between 2px controls and the still-forbidden 999px pill; panels stay square (0) |
| 2 | Accent depth | **border + text + dot** carry the semantic hue |
| 3 | Red usage | **subordinate**: CI-fail chips may go red on text/border/dot, never halo/pulse/wash |
| 4 | Rule scope | **general** functional-status rule (not a GitRail carve-out) |

## What changed

- **Four-Light Rule reconciled** — status hue is reserved for *state incl. functional machine status* (git/CI/PR/ready), never decoration. Red is rationed by *loudness*: the loudest red (pulsing haloed pip + oxblood wash) stays reserved for blocked-agent state; subordinate static red is sanctioned for functional failure — the same carve-out granted the usage-limit gauge in #788.
- **Shape reconciled** — added a 6px `chip` rung; clarified the Buttons "never pill-shaped" line and the Do's radius/red lines so nothing contradicts.
- **Status Chip recipe** added to all three sources of truth: `DESIGN.md` §5, `DESIGN.json` `components`, and `/design-system`.
- **`DESIGN.md` + `DESIGN.json` edited in lockstep** (per #788 precedent) — CI does not cross-validate the mirror, so both moved together and a two-file grep sweep confirmed no residual contradiction.
- **/design-system** — "Badges & pills" → "Badges & chips": new `.status-chip` recipe (named `.status-chip`, **not** `.chip`, which is already the color-swatch class) plus a crisp badge-vs-chip split so the reference isn't left with two rival status primitives.

## Scope

Docs/governance only — `DESIGN.md`, `DESIGN.json`, `ui/src/routes/design-system/+page.svelte`. No component code, no `app.css` tokens, no i18n (the /design-system page is i18n-exempt), no feature-announcement entry. GitRail/top-bar implementation lands in #1520/#1533.

## Verification

- `cd ui && bun run check` → 0 errors (2 pre-existing warnings in untouched files).
- `DESIGN.json` valid JSON; Status Chip recipe present.
- Two-file grep sweep (`2px`/`pill`/`chip`/`Four-Light`/`red`) clean; every `pill` mention frames 999px as forbidden; `.chip` swatch selector untouched.
- `/design-system` route renders 200 with the new section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)