### PR TITLE
style(viewport): remove terminal scan-line effect

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -296,14 +296,6 @@ body {
     opacity: 0;
   }
 }
-@keyframes scan {
-  0% {
-    transform: translateY(-70px);
-  }
-  100% {
-    transform: translateY(100%);
-  }
-}
 /* in-flight MERGING text pulse — dims and restores amber opacity; clip-proof
    (no box-shadow halo), so it never bleeds into adjacent badges. */
 @keyframes merge-pulse {

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2460,7 +2460,7 @@
     />
   {/if}
 
-  <!-- scan overlay + terminal (terminal stays mounted across tab switches) -->
+  <!-- terminal (stays mounted across tab switches) -->
   <div
     class="vp-body"
     data-swipe-page
@@ -2469,7 +2469,6 @@
     aria-labelledby={tabId(tab)}
     style:--review-banner-h={`${reviewBannerH || ciBannerH}px`}
   >
-    <div class="scan" class:running={tab === "term"} aria-hidden="true"></div>
     <div
       class="term-mount"
       class:dragging
@@ -3288,33 +3287,6 @@
        terminal/diff/todo/preview always remains. Only bites under the
        expanded-recap takeover; normal body content is far taller. */
     min-height: 4rem;
-  }
-
-  /* faint amber scan line: full-height layer with a 70px amber band at its top,
-     swept top→bottom via translateY (compositor-only) instead of animating top.
-     Animation + will-change only when the terminal tab is active — no wasted
-     compositor layer or GPU work on idle dashboard tabs. */
-  .scan {
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 0;
-    height: 100%;
-    background-image: linear-gradient(
-      to bottom,
-      transparent,
-      color-mix(in srgb, var(--color-amber) 4%, transparent),
-      transparent
-    );
-    background-repeat: no-repeat;
-    background-size: 100% 70px;
-    background-position: 0 0;
-    pointer-events: none;
-    z-index: 1;
-  }
-  .scan.running {
-    will-change: transform;
-    animation: scan 8s linear infinite;
   }
 
   .term-mount {


### PR DESCRIPTION
## What

Removes the faint amber **scan-line effect** that swept top→bottom over the terminal tab in the Viewport. It was a purely decorative CRT-style overlay (`aria-hidden`, `pointer-events: none`) — nothing depended on it.

## Changes

- **`ui/src/lib/components/Viewport.svelte`** — remove the `.scan` overlay `<div>`, its adjacent comment, and the `.scan` / `.scan.running` CSS rules.
- **`ui/src/app.css`** — remove the now-dead `@keyframes scan` (was referenced only by `.scan.running`).

## Verification

- `cd ui && bun run check` → 0 errors (2 pre-existing warnings in unrelated files).
- `prettier --check` clean; pre-push + lint-staged (prettier/eslint) passed.
- `grep` confirms no orphaned `scan` effect references remain.

No i18n / feature-catalog / glossary impact — a purely visual removal adds no user-facing text and warrants no What's-New entry. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)