### PR TITLE
fix(ui): silence Svelte 5 non-reactive/local-state warnings

### DIFF
--- a/ui/src/lib/components/CommandBar.svelte
+++ b/ui/src/lib/components/CommandBar.svelte
@@ -14,6 +14,7 @@
   import { jumpDigitIndex } from "$lib/components/herd-keynav";
   import { sortBlocked, type BlockState } from "$lib/triage";
   import { m } from "$lib/paraglide/messages";
+  import { untrack } from "svelte";
 
   let {
     sessions,
@@ -80,7 +81,7 @@
     | { kind: "doc"; title: string; url: string };
   type OptRow = Row & { oid: number };
 
-  let filter = $state(initialFilter ?? "");
+  let filter = $state(untrack(() => initialFilter) ?? "");
   let activeIdx = $state(0);
   let inputEl = $state<HTMLInputElement | null>(null);
   let listEl = $state<HTMLUListElement | null>(null);

--- a/ui/src/lib/components/viewport/FilesPanel.svelte
+++ b/ui/src/lib/components/viewport/FilesPanel.svelte
@@ -32,7 +32,7 @@
   let nextUploadId = 0;
   let dragOver = $state(false);
 
-  let fileInput: HTMLInputElement;
+  let fileInput = $state<HTMLInputElement>();
 
   async function browse(path: string) {
     loading = true;
@@ -160,7 +160,7 @@
   }
 
   function openFilePicker() {
-    fileInput.click();
+    fileInput?.click();
   }
 </script>
 


### PR DESCRIPTION
## What

Clears two compile-time `vite-plugin-svelte` warnings surfaced during the build. Both were benign at runtime; this makes the intent explicit and quiets the noise.

- **`FilesPanel.svelte`** — the `fileInput` `bind:this` ref is now `$state<HTMLInputElement>()` (fixes `non_reactive_update`); its imperative `.click()` is guarded (`fileInput?.click()`) for the now-optional type.
- **`CommandBar.svelte`** — `filter` seeds via `untrack(() => initialFilter)`, documenting the deliberate one-time seed from the demo-only `initialFilter` prop and silencing `state_referenced_locally`. Added the `untrack` import.

No behavior change.

## Verification

`cd ui && bun run check` → 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)