### PR TITLE
style(viewport): move PR foldout into right-hand control cluster

### DIFF
--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2243,12 +2243,30 @@
       <!-- transient post-rename note (e.g. "branch kept"); the rename input itself
            takes the title's slot in place when active -->
       {@render renameNoteEl()}
-      <!-- git-rail disclosure, welded to the title: the full rail (PR / CI /
-           merge / critic / ready / verdict) plus the autopilot toggle live one
-           tap away, revealed as a second header row (.vp-git-strip). Sitting it
-           beside the title enlarges the tap target and pairs it with the
-           single-tap-toggle on the title itself (onTitleTap). A direct tap here
-           toggles instantly and is the keyboard/AT path (aria-expanded). -->
+    {/if}
+    <div class="spacer"></div>
+    <ViewportTabBar
+      bind:tab
+      {session}
+      {previewPort}
+      todoExists={!!todoExists}
+      {hasFiles}
+      {hasPreview}
+      {compact}
+      {headerFolded}
+      {vpBodyId}
+      {tabId}
+      {foldRegionId}
+    />
+    {#if !compact}
+      <span class="sep">·</span>
+      <!-- git-rail disclosure — grouped with the work-state chips (status ·
+           PLANNING) it shares meaning with, anchored in the right cluster so a
+           short task name no longer strands it mid-bar. Reveals the full rail
+           (PR / CI / merge / critic / ready / verdict) plus the autopilot toggle
+           as a second header row (.vp-git-strip). A direct tap toggles instantly
+           and is the keyboard/AT path (aria-expanded); tapping the task title
+           (onTitleTap) toggles the same strip. -->
       <button
         class="git-toggle"
         class:open={gitOpen}
@@ -2268,23 +2286,6 @@
         <span class="gt-label">{m.viewport_git_actions()}</span>
         <span class="gt-caret" aria-hidden="true">{gitOpen ? "▴" : "▾"}</span>
       </button>
-    {/if}
-    <div class="spacer"></div>
-    <ViewportTabBar
-      bind:tab
-      {session}
-      {previewPort}
-      todoExists={!!todoExists}
-      {hasFiles}
-      {hasPreview}
-      {compact}
-      {headerFolded}
-      {vpBodyId}
-      {tabId}
-      {foldRegionId}
-    />
-    {#if !compact}
-      <span class="sep">·</span>
     {/if}
     {#if mobile}
       <!-- connection state, alert-by-exception: a lone red dot only when dropped -->


### PR DESCRIPTION
## Why

The PR disclosure control (`.git-toggle`, **● PR ▾**) sat in the **left** cluster of the viewport header, welded after the task name. A flex `.spacer` then pushes every other control to the right edge — so on a **short** task name the left cluster is tiny and the PR chip is left stranded in the middle of a wide empty gap, anchored to nothing. It "feels lost".

## What

Relocate the chip into the **right-hand work-state group**, between the post-tabs separator and the status mark:

```
before:  TASK-1442  warnings  [● PR ▾] ·············· Terminal Activity Diff Files Preview · ◆ PLANNING ⚙ ✕
after:   TASK-1442  warnings ························· Terminal Activity Diff Files Preview · [● PR ▾] ◆ PLANNING ⚙ ✕
```

Now it's anchored to the right cluster at **every** task-name length, and reads with the kin it shares meaning with (session status, plan phase), while staying clear of the window controls (gear / ✕).

## Scope

- **Markup move only** in `Viewport.svelte` — the button reads the same component-scope state (`gitOpen`, `prAttention`, `planAttention`, `prClear`, `gitToggleState`) at the new position. No behavior, CSS, i18n, glossary, or design-system change.
- **Desktop-only**, unchanged: the chip is `{#if !compact}`-gated and never rendered on compact/mobile (which shows the git strip unconditionally with no toggle).
- Tapping the task title (`onTitleTap`) still toggles the same strip — that affordance is untouched; the now-stale "welded to the title" comment was corrected.
- Not a feature — reposition only, so no feature-announcement entry (`style` commit; the catalog gate arms only on `feat`).

## Testing

- `cd ui && bun run check` → 0 errors.
- `cd ui && bun run test` → **3095 tests / 220 files pass**, including the real-browser `Viewport.browser.test.ts` (nothing asserted the old chip position).
- Layout matches the mockup approved during planning (short + long task names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)