### PR TITLE
fix(ui): explain epic start controls on hover

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2742,5 +2742,11 @@
   "planpanel_quota_dismissing": "Verwerfe…",
   "planpanel_quota_unreachable": "Der Planungsbereich war nicht erreichbar. Der Plan wurde nicht fortgesetzt.",
   "planpanel_quota_not_stalled": "Dieser Plan ist nicht mehr blockiert. Aktualisiere oder prüfe erneut, falls der Status veraltet wirkt.",
-  "planpanel_quota_failed": "Der blockierte Plan konnte nicht aktualisiert werden. Bitte erneut versuchen."
+  "planpanel_quota_failed": "Der blockierte Plan konnte nicht aktualisiert werden. Bitte erneut versuchen.",
+  "epic_start_title": "Klicken, um diesen Epic zu starten. Shepherd startet das nächste geeignete Kind-Issue und fährt im gewählten Modus fort.",
+  "epic_pause_title": "Klicken, um diesen Epic-Runner zu pausieren. Laufende Sessions und Fortschritt bleiben erhalten.",
+  "epic_mode_auto_title": "Klicken, um in den begleiteten Modus zu wechseln. Shepherd wartet dann darauf, dass du jedes nächste Kind-Issue freigibst.",
+  "epic_mode_auto_aria": "Automatisch: Epic in begleiteten Modus wechseln",
+  "epic_mode_attended_title": "Klicken, um in den automatischen Modus zu wechseln. Shepherd startet geeignete Kind-Issues dann ohne einzelne Freigabe.",
+  "epic_mode_attended_aria": "Begleitet: Epic in automatischen Modus wechseln"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2742,5 +2742,11 @@
   "planpanel_quota_dismissing": "Dismissing…",
   "planpanel_quota_unreachable": "Couldn't reach the planning pane. The plan was not resumed.",
   "planpanel_quota_not_stalled": "This plan is no longer stalled. Refresh or review again if the state looks stale.",
-  "planpanel_quota_failed": "Couldn't update the stalled plan. Please try again."
+  "planpanel_quota_failed": "Couldn't update the stalled plan. Please try again.",
+  "epic_start_title": "Click to start this epic. Shepherd launches the next eligible child issue and continues according to the selected mode.",
+  "epic_pause_title": "Click to pause this epic runner. Existing sessions and progress stay intact.",
+  "epic_mode_auto_title": "Click to switch to attended mode. Shepherd will wait for you to approve each next child issue.",
+  "epic_mode_auto_aria": "Auto: switch epic to attended mode",
+  "epic_mode_attended_title": "Click to switch to auto mode. Shepherd will launch eligible child issues without asking for each approval.",
+  "epic_mode_attended_aria": "Attended: switch epic to auto mode"
 }

--- a/ui/src/lib/components/EpicPanel.svelte
+++ b/ui/src/lib/components/EpicPanel.svelte
@@ -105,6 +105,7 @@
       <button
         class="gbtn"
         type="button"
+        title={m.epic_pause_title()}
         onclick={() =>
           updateEpic(repoPath, parent, { status: "paused" }).catch(() =>
             toasts.info(m.epic_update_failed(), {
@@ -120,6 +121,7 @@
       <button
         class="gbtn"
         type="button"
+        title={m.epic_start_title()}
         onclick={() =>
           updateEpic(repoPath, parent, { status: "running" }).catch(() =>
             toasts.info(m.epic_update_failed(), {
@@ -136,6 +138,8 @@
     <button
       class="gbtn"
       type="button"
+      title={epic.run.mode === "auto" ? m.epic_mode_auto_title() : m.epic_mode_attended_title()}
+      aria-label={epic.run.mode === "auto" ? m.epic_mode_auto_aria() : m.epic_mode_attended_aria()}
       onclick={() =>
         updateEpic(repoPath, parent, {
           mode: epic.run.mode === "auto" ? "attended" : "auto",


### PR DESCRIPTION
## Summary
- Add hover tooltip copy for the Epic Start/Pause control.
- Add hover tooltip copy for the Epic Auto/Attended mode toggle, explicitly describing the click result.
- Keep mode-toggle accessible names short and action-oriented.

## Checks
- cd ui && bun run check:i18n
- cd ui && bun run check