### PR TITLE
fix(ui): open top epic groups by default

### DIFF
--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -524,6 +524,49 @@ describe("Herd epic grouping", () => {
     expect(oncollapsetoggle).toHaveBeenCalledWith("/repo/a#100");
   });
 
+  it("reports the rendered epic group order after experiment grouping removes raw earlier epics", async () => {
+    const onrenderedepicgroups = vi.fn();
+    const renderedEpics = {
+      "/repo/a#100": epic([epicChild(11), epicChild(12)]),
+      "/repo/a#200": {
+        ...epic([epicChild(21)]),
+        parentIssueNumber: 200,
+        parentTitle: "Later epic",
+        run: { repoPath: "/repo/a", parentIssueNumber: 200, mode: "auto", status: "running" },
+      } satisfies Epic,
+    };
+    render(Herd, {
+      ...base,
+      sessions: [
+        session({
+          id: "a1",
+          name: "experiment original",
+          issueNumber: 11,
+          experimentId: "exp",
+          experimentRole: "variant",
+          createdAt: 1,
+        }),
+        session({
+          id: "a2",
+          name: "experiment variant",
+          issueNumber: 12,
+          experimentId: "exp",
+          experimentRole: "variant",
+          createdAt: 2,
+        }),
+        session({ id: "b1", name: "rendered epic child", issueNumber: 21 }),
+      ],
+      git: {},
+      epics: renderedEpics,
+      activeEpicKeys: new Set(["/repo/a#100", "/repo/a#200"]),
+      onrenderedepicgroups,
+    });
+
+    await expect.element(page.getByText("Later epic")).toBeInTheDocument();
+    await expect.poll(() => onrenderedepicgroups.mock.calls.at(-1)?.[0]).toEqual(["/repo/a#200"]);
+    expect(document.body.textContent).not.toContain("Big epic");
+  });
+
   it("keeps the merge-train action when the only ready PR session is an epic child", async () => {
     render(Herd, {
       ...base,

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -50,6 +50,7 @@
     activeEpicKeys = new Set(),
     collapsedKeys = new Set(),
     oncollapsetoggle = undefined,
+    onrenderedepicgroups = undefined,
     ondecommission,
     onrelaunch = undefined,
     onrelaunchElsewhere = undefined,
@@ -119,6 +120,9 @@
     collapsedKeys?: Set<string>;
     // toggles a group's collapse — the page owns the actual collapsedKeys mutation
     oncollapsetoggle?: (key: string) => void;
+    // reports the exact epic-group order this component renders; the page owns
+    // collapse-state normalization, but Herd owns the final filtered/grouped order.
+    onrenderedepicgroups?: (keys: string[]) => void;
     // when provided, rows gain left-swipe-to-decommission (mobile list)
     ondecommission?: (id: string) => void;
     // when provided, each row's CardMenu gains a Rename action
@@ -319,6 +323,14 @@
       ]),
     ),
   );
+  let lastRenderedEpicGroupSig = "";
+  $effect(() => {
+    const keys = grouped.groups.map((g) => g.key);
+    const sig = keys.join("\u0000");
+    if (sig === lastRenderedEpicGroupSig) return;
+    lastRenderedEpicGroupSig = sig;
+    onrenderedepicgroups?.(keys);
+  });
   // Per-group attention cues — reads the shared partition; the blocked count still scans
   // g.sessions directly via displayStatus (it's not a partition bucket).
   function cuesFor(g: { key: string; sessions: Session[] }): {

--- a/ui/src/lib/components/IssuesPanel.browser.test.ts
+++ b/ui/src/lib/components/IssuesPanel.browser.test.ts
@@ -35,6 +35,17 @@ beforeEach(() => {
   mockListIssues.mockReset();
   mockGetEpics.mockReset();
   mockEpic.mockReset();
+  mockEpic.mockImplementation((repoPath: string, parentIssueNumber: number) =>
+    Promise.resolve({
+      repoPath,
+      parentIssueNumber,
+      parentTitle: `Epic ${parentIssueNumber}`,
+      source: "native",
+      children: [],
+      warnings: [],
+      run: { repoPath, parentIssueNumber, mode: "auto", status: "idle" },
+    }),
+  );
 });
 
 afterEach(() => {
@@ -159,8 +170,37 @@ describe("IssuesPanel epic badge", () => {
     mockGetEpics.mockResolvedValue({ epics, subIssues });
   }
 
+  function liveEpic(
+    parentIssueNumber: number,
+    states: Epic["children"][number]["state"][],
+    source: Epic["source"] = "native",
+  ): Epic {
+    return {
+      repoPath: "/repo",
+      parentIssueNumber,
+      parentTitle: `Epic ${parentIssueNumber}`,
+      source,
+      children: states.map((state, i) => ({
+        number: 100 + i,
+        title: `Child ${100 + i}`,
+        url: `https://example.com/issues/${100 + i}`,
+        order: i,
+        body: "",
+        blockedBy: [],
+        state,
+        sessionId: null,
+        prNumber: null,
+        issueClosed: state === "merged",
+        claimed: false,
+      })),
+      warnings: [],
+      run: { repoPath: "/repo", parentIssueNumber, mode: "auto", status: "idle" },
+    };
+  }
+
   it("native source renders SUB-ISSUES merged/total badge", async () => {
     seed([issue(10, "Parent issue")], [epic(10, 1, 3, "native")]);
+    mockEpic.mockResolvedValue(liveEpic(10, ["merged", "running", "running"], "native"));
     render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
 
     // badge text is the accessible content — assert it directly
@@ -174,6 +214,9 @@ describe("IssuesPanel epic badge", () => {
 
   it("markdown source renders EPIC merged/total badge", async () => {
     seed([issue(20, "Epic parent")], [epic(20, 2, 4, "markdown")]);
+    mockEpic.mockResolvedValue(
+      liveEpic(20, ["merged", "merged", "running", "running"], "markdown"),
+    );
     render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
 
     const expectedText = m.epic_badge({ merged: 2, total: 4 });
@@ -368,7 +411,73 @@ describe("IssuesPanel expandEpic", () => {
     expect(document.querySelector(".epic-badge")?.getAttribute("aria-expanded")).toBe("false");
   });
 
-  it("does NOT auto-expand any epic when expandEpic is null", async () => {
+  it("auto-expands only the topmost epic when expandEpic is null", async () => {
+    mockIssues.mockResolvedValue({
+      slug: "acme/repo",
+      webUrl: null,
+      issues: [issue(400), issue(327)],
+      viewer: null,
+    });
+    mockEpics.mockResolvedValue({ epics: [summary(400), summary(327)], subIssues: [] });
+    mockEpic.mockResolvedValue(epic(400));
+
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop, expandEpic: null });
+
+    await expect.poll(() => document.querySelectorAll(".epic-badge").length).toBe(2);
+    const badges = [...document.querySelectorAll(".epic-badge")];
+    await expect.poll(() => badges[0]?.getAttribute("aria-expanded")).toBe("true");
+    expect(badges[1]?.getAttribute("aria-expanded")).toBe("false");
+    expect(mockEpic).toHaveBeenCalledWith("/repo", 400);
+  });
+
+  it("waits for listIssues when getEpics settles first before default-expanding the topmost epic", async () => {
+    let resolveIssues!: (r: Awaited<ReturnType<typeof listIssues>>) => void;
+    let resolveEpics!: (r: Awaited<ReturnType<typeof getEpics>>) => void;
+    mockIssues.mockReturnValue(new Promise((res) => (resolveIssues = res)));
+    mockEpics.mockReturnValue(new Promise((res) => (resolveEpics = res)));
+
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
+
+    resolveEpics({ epics: [summary(2), summary(1)], subIssues: [] });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(document.querySelector(".epic-badge")).toBeNull();
+    expect(mockEpic).not.toHaveBeenCalled();
+
+    resolveIssues({
+      slug: "acme/repo",
+      webUrl: null,
+      issues: [issue(2), issue(1)],
+      viewer: null,
+    });
+
+    await expect.poll(() => document.querySelectorAll(".epic-badge").length).toBe(2);
+    const badges = [...document.querySelectorAll(".epic-badge")];
+    await expect.poll(() => badges[0]?.getAttribute("aria-expanded")).toBe("true");
+    expect(badges[1]?.getAttribute("aria-expanded")).toBe("false");
+    expect(mockEpic).toHaveBeenCalledWith("/repo", 2);
+  });
+
+  it("expandEpic targeting a non-first epic suppresses default-opening the first epic", async () => {
+    mockIssues.mockResolvedValue({
+      slug: "acme/repo",
+      webUrl: null,
+      issues: [issue(1), issue(2)],
+      viewer: null,
+    });
+    mockEpics.mockResolvedValue({ epics: [summary(1), summary(2)], subIssues: [] });
+    mockEpic.mockResolvedValue(epic(2));
+
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop, expandEpic: 2 });
+
+    await expect.poll(() => document.querySelectorAll(".epic-badge").length).toBe(2);
+    const badges = [...document.querySelectorAll(".epic-badge")];
+    await expect.poll(() => badges[1]?.getAttribute("aria-expanded")).toBe("true");
+    expect(badges[0]?.getAttribute("aria-expanded")).toBe("false");
+    expect(mockEpic).toHaveBeenCalledTimes(1);
+    expect(mockEpic).toHaveBeenCalledWith("/repo", 2);
+  });
+
+  it("clicking an epic card toggles the same expansion state as the badge", async () => {
     mockIssues.mockResolvedValue({
       slug: "acme/repo",
       webUrl: null,
@@ -378,12 +487,56 @@ describe("IssuesPanel expandEpic", () => {
     mockEpics.mockResolvedValue({ epics: [summary(327)], subIssues: [] });
     mockEpic.mockResolvedValue(epic(327));
 
-    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop, expandEpic: null });
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
 
-    await expect.poll(() => document.querySelector(".epic-badge")).toBeTruthy();
-    // Badge stays collapsed; no targeted fetch.
-    expect(document.querySelector(".epic-badge")?.getAttribute("aria-expanded")).toBe("false");
-    expect(mockEpic).not.toHaveBeenCalled();
+    await expect
+      .poll(() => document.querySelector(".epic-badge")?.getAttribute("aria-expanded"))
+      .toBe("true");
+    const row = document.querySelector<HTMLElement>(".issue-row")!;
+    row.click();
+    await expect
+      .poll(() => document.querySelector(".epic-badge")?.getAttribute("aria-expanded"))
+      .toBe("false");
+    row.click();
+    await expect
+      .poll(() => document.querySelector(".epic-badge")?.getAttribute("aria-expanded"))
+      .toBe("true");
+  });
+
+  it("clicking inside the expanded EpicPanel subtree does not toggle the row", async () => {
+    mockIssues.mockResolvedValue({
+      slug: "acme/repo",
+      webUrl: null,
+      issues: [issue(327)],
+      viewer: null,
+    });
+    mockEpics.mockResolvedValue({ epics: [summary(327)], subIssues: [] });
+    mockEpic.mockResolvedValue({
+      ...epic(327),
+      children: [
+        {
+          number: 500,
+          title: "Child row",
+          url: "https://example.com/i/500",
+          order: 0,
+          body: "",
+          blockedBy: [],
+          state: "running",
+          sessionId: null,
+          prNumber: null,
+          issueClosed: false,
+          claimed: false,
+        },
+      ],
+    });
+
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
+
+    await expect.element(page.getByText("Child row")).toBeInTheDocument();
+    expect(document.querySelector(".epic-badge")?.getAttribute("aria-expanded")).toBe("true");
+    document.querySelector<HTMLElement>("[data-epic-panel]")!.click();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(document.querySelector(".epic-badge")?.getAttribute("aria-expanded")).toBe("true");
   });
 
   it("waits for getEpics to settle before scrolling, then lands on the sorted-first row", async () => {
@@ -1089,8 +1242,7 @@ describe("IssuesPanel soft refresh (backlogRefresh)", () => {
     await expect.poll(() => document.querySelector(".epic-badge")).toBeTruthy();
 
     const badge = () => document.querySelector(".epic-badge") as HTMLButtonElement;
-    badge().click(); // expand → backfill fetch #1 (held pending)
-    await expect.poll(() => mockEpic.mock.calls.length).toBe(1);
+    await expect.poll(() => mockEpic.mock.calls.length).toBe(1); // default expand → fetch #1
     badge().click(); // collapse while the fetch is still in flight
 
     // The late settle must NOT re-seed the cache for the collapsed panel…

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -134,6 +134,7 @@
   );
   // Set of expanded epic issue numbers (SvelteSet for fine-grained reactivity).
   const expanded = new SvelteSet<number>();
+  let defaultEpicSeeded = $state(false);
   // One-shot fetch cache: issue number → fetched Epic (avoids re-fetching on re-render).
   const fetched = new SvelteMap<number, Epic>();
 
@@ -152,6 +153,7 @@
     loadError = false;
     filter = "";
     expanded.clear();
+    defaultEpicSeeded = false;
     epicByNumber = new Map();
     nativeSubIssues = new Set();
     epicsLoaded = false;
@@ -364,6 +366,19 @@
       expandEpicRow(number);
     }
   }
+
+  $effect(() => {
+    if (defaultEpicSeeded) return;
+    if (expandEpic != null) {
+      defaultEpicSeeded = true;
+      return;
+    }
+    if (!epicsSettled || visibleIssues.length === 0 || epicByNumber.size === 0) return;
+    const firstEpic = visibleIssues.find((issue) => epicByNumber.has(issue.number));
+    if (!firstEpic) return;
+    defaultEpicSeeded = true;
+    expandEpicRow(firstEpic.number);
+  });
 
   // Targeted expand+scroll driven by the `expandEpic` prop (e.g. EPIC badge click).
   // The expand fires as soon as a target is set; the scroll waits until the issue

--- a/ui/src/lib/components/herd-epic-collapse.test.ts
+++ b/ui/src/lib/components/herd-epic-collapse.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { normalizeEpicCollapse } from "./herd-epic-collapse";
+
+describe("normalizeEpicCollapse", () => {
+  it("opens the first rendered group and collapses non-first groups by default", () => {
+    const next = normalizeEpicCollapse(["a", "b", "c"], new Set(), new Set());
+
+    expect([...next.collapsed].sort()).toEqual(["b", "c"]);
+    expect([...next.touched]).toEqual([]);
+  });
+
+  it("prunes stale collapsed and touched keys", () => {
+    const next = normalizeEpicCollapse(
+      ["a"],
+      new Set(["gone-collapsed", "a"]),
+      new Set(["gone-touched"]),
+    );
+
+    expect([...next.collapsed]).toEqual([]);
+    expect([...next.touched]).toEqual([]);
+  });
+
+  it("collapses a previously auto-open group when a new group appears above it", () => {
+    const first = normalizeEpicCollapse(["b"], new Set(), new Set());
+    expect([...first.collapsed]).toEqual([]);
+
+    const second = normalizeEpicCollapse(["a", "b"], first.collapsed, first.touched);
+
+    expect([...second.collapsed]).toEqual(["b"]);
+  });
+
+  it("preserves a user-opened non-first group across later normalization", () => {
+    const next = normalizeEpicCollapse(["a", "b", "c"], new Set(["c"]), new Set(["b"]));
+
+    expect([...next.collapsed].sort()).toEqual(["c"]);
+    expect([...next.touched]).toEqual(["b"]);
+  });
+
+  it("preserves a user-collapsed first group across later normalization", () => {
+    const next = normalizeEpicCollapse(["a", "b"], new Set(["a"]), new Set(["a"]));
+
+    expect([...next.collapsed].sort()).toEqual(["a", "b"]);
+    expect([...next.touched]).toEqual(["a"]);
+  });
+
+  it("preserves an explicitly expanded needs-you group from default re-collapse", () => {
+    const next = normalizeEpicCollapse(["a", "b"], new Set(), new Set(["b"]));
+
+    expect([...next.collapsed]).toEqual([]);
+    expect([...next.touched]).toEqual(["b"]);
+  });
+});

--- a/ui/src/lib/components/herd-epic-collapse.ts
+++ b/ui/src/lib/components/herd-epic-collapse.ts
@@ -1,0 +1,17 @@
+export function normalizeEpicCollapse(
+  orderedKeys: readonly string[],
+  collapsed: ReadonlySet<string>,
+  touched: ReadonlySet<string>,
+): { collapsed: Set<string>; touched: Set<string> } {
+  const live = new Set(orderedKeys);
+  const nextTouched = new Set([...touched].filter((key) => live.has(key)));
+  const nextCollapsed = new Set([...collapsed].filter((key) => live.has(key)));
+
+  orderedKeys.forEach((key, index) => {
+    if (nextTouched.has(key)) return;
+    if (index === 0) nextCollapsed.delete(key);
+    else nextCollapsed.add(key);
+  });
+
+  return { collapsed: nextCollapsed, touched: nextTouched };
+}

--- a/ui/src/lib/components/issues-panel/IssueRow.svelte
+++ b/ui/src/lib/components/issues-panel/IssueRow.svelte
@@ -59,9 +59,45 @@
         ? { merged: epicSummary.merged, total: epicSummary.total }
         : { merged: 0, total: 0 },
   );
+
+  const interactiveSelector = [
+    "a",
+    "button",
+    "input",
+    "select",
+    "textarea",
+    "summary",
+    "[role='button']",
+    "[role='link']",
+    "[tabindex]:not([tabindex='-1'])",
+  ].join(",");
+
+  function onRowClick(event: MouseEvent) {
+    if (!isEpicParent) return;
+    const target = event.target instanceof Element ? event.target : null;
+    if (!target) return;
+    if (target.closest("[data-epic-panel]")) return;
+    if (target.closest(interactiveSelector)) return;
+    ontoggleepic(issue.number);
+  }
+
+  function epicRowClick(node: HTMLElement) {
+    const click = (event: MouseEvent) => onRowClick(event);
+    node.addEventListener("click", click);
+    return {
+      destroy() {
+        node.removeEventListener("click", click);
+      },
+    };
+  }
 </script>
 
-<div class="issue-row" class:is-epic={isEpicParent} id={`epic-issue-row-${issue.number}`}>
+<div
+  class="issue-row"
+  class:is-epic={isEpicParent}
+  id={`epic-issue-row-${issue.number}`}
+  use:epicRowClick
+>
   <div class="issue-top">
     <!-- eslint-disable svelte/no-navigation-without-resolve -- external GitHub URL, not an app route -->
     <a
@@ -159,11 +195,13 @@
     >
   </div>
   {#if epicSummary && isExpanded}
-    {#if epic}
-      <EpicPanel {repoPath} parent={issue.number} {epic} />
-    {:else}
-      <div class="muted">{m.common_loading()}</div>
-    {/if}
+    <div data-epic-panel>
+      {#if epic}
+        <EpicPanel {repoPath} parent={issue.number} {epic} />
+      {:else}
+        <div class="muted">{m.common_loading()}</div>
+      {/if}
+    </div>
   {/if}
 </div>
 

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -90,6 +90,7 @@
     altComboKey,
   } from "$lib/components/herd-keynav";
   import { groupSessionsByEpic } from "$lib/components/epic-grouping";
+  import { normalizeEpicCollapse } from "$lib/components/herd-epic-collapse";
   import { isReworkRunning as isReworkRunningSession } from "$lib/components/rework-running";
   import { buildCommands } from "$lib/command-registry";
   import type { HerdFilter } from "$lib/components/herd-partition";
@@ -438,9 +439,34 @@
   // are reactive (a plain Set is not in Svelte 5); passed to both <Herd> (render) and
   // railOrder (nav) so the two read ONE source and can't drift.
   const collapsedEpics = new SvelteSet<string>();
+  const touchedEpicCollapseKeys = new SvelteSet<string>();
+  function replaceSet(target: SvelteSet<string>, next: ReadonlySet<string>) {
+    for (const key of [...target]) {
+      if (!next.has(key)) target.delete(key);
+    }
+    for (const key of next) {
+      if (!target.has(key)) target.add(key);
+    }
+  }
+  function normalizeRenderedEpicCollapse(keys: string[]) {
+    const next = normalizeEpicCollapse(keys, collapsedEpics, touchedEpicCollapseKeys);
+    replaceSet(collapsedEpics, next.collapsed);
+    replaceSet(touchedEpicCollapseKeys, next.touched);
+  }
+  function markEpicCollapseTouched(key: string) {
+    touchedEpicCollapseKeys.add(key);
+  }
+  function expandEpicGroup(key: string) {
+    markEpicCollapseTouched(key);
+    collapsedEpics.delete(key);
+  }
+  function collapseEpicGroup(key: string) {
+    markEpicCollapseTouched(key);
+    collapsedEpics.add(key);
+  }
   function toggleEpicCollapse(key: string) {
-    if (collapsedEpics.has(key)) collapsedEpics.delete(key);
-    else collapsedEpics.add(key);
+    if (collapsedEpics.has(key)) expandEpicGroup(key);
+    else collapseEpicGroup(key);
   }
   // Seed store.epics for any active epic we don't have the full Epic for yet (header
   // needs title + X/Y + backlog link). Reactive on activeEpicKeys, deduped per key.
@@ -1495,7 +1521,7 @@
       collapsedEpics,
     );
     if (expand) {
-      collapsedEpics.delete(expand);
+      expandEpicGroup(expand);
       await tick(); // let the now-expanded group's rows mount so keyNavSelect can scroll to the target
     }
     keyNavSelect(id, focusTerm);
@@ -2489,6 +2515,7 @@
             {activeEpicKeys}
             collapsedKeys={collapsedEpics}
             oncollapsetoggle={toggleEpicCollapse}
+            onrenderedepicgroups={normalizeRenderedEpicCollapse}
             ondecommission={onarchive}
             {onrelaunch}
             {onrelaunchElsewhere}
@@ -2668,6 +2695,7 @@
             {activeEpicKeys}
             collapsedKeys={collapsedEpics}
             oncollapsetoggle={toggleEpicCollapse}
+            onrenderedepicgroups={normalizeRenderedEpicCollapse}
             ondecommission={onarchive}
             {onrelaunch}
             {onrelaunchElsewhere}


### PR DESCRIPTION
## Summary
- default-open the top visible epic in the Backlog issues list while preserving targeted epic navigation
- make epic issue cards toggle their inline epic panel without stealing clicks from controls or panel content
- normalize Herd epic group collapse state from the rendered group order, preserving user and NEEDS-YOU expansions

## Tests
- cd ui && bun run test:node src/lib/components/herd-epic-collapse.test.ts
- cd ui && bun run test:browser src/lib/components/Herd.browser.test.ts src/lib/components/IssuesPanel.browser.test.ts
- cd ui && bun run check