### PR TITLE
fix(diagnostics): probe herdr server liveness, not just the binary (#1559)

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -74,10 +74,11 @@ export interface DiagnosticsDeps {
   /** Probe herdr **server liveness** (not just binary presence): run `herdr agent
    *  list`, resolving on a zero exit (daemon reachable), rejecting on
    *  connection-refused / timeout (daemon offline). Exit code only — the agent
-   *  listing is discarded, so nothing but a state crosses into the snapshot. This is
-   *  the same reachability signal `herdr-update` relies on. Default
-   *  `execFileAsync(config.herdrBin, ["agent","list"])` with the shared probe
-   *  timeout. Injected in tests (resolve = live, reject = offline). */
+   *  listing is discarded (routed to /dev/null, never buffered), so nothing but a
+   *  state crosses into the snapshot. This is the same reachability signal
+   *  `herdr-update` relies on. Default `spawn(config.herdrBin, ["agent","list"], {
+   *  stdio:"ignore" })` with the shared probe timeout. Injected in tests (resolve =
+   *  live, reject = offline). */
   runHerdrLiveness?: () => Promise<void>;
   /** Run `gh auth status`; resolves on a zero exit, rejects on non-zero / timeout.
    *  Its stdout is intentionally discarded (it carries account identity). On rejection
@@ -172,6 +173,37 @@ export function defaultRunRemediation(
   });
 }
 
+/** Default `runHerdrLiveness`: spawn `herdr agent list` with stdout/stderr routed to
+ *  /dev/null (`stdio: "ignore"`) — the exit code is the only signal, so a large agent
+ *  listing on a busy server is never buffered and can never exceed a buffer cap and
+ *  falsely read as offline (unlike `execFile`, whose 1 MiB `maxBuffer` would reject).
+ *  Resolves on exit 0 (daemon reachable); rejects on non-zero exit, spawn error
+ *  (ENOENT / ECONNREFUSED), or timeout (daemon offline). */
+function defaultHerdrLiveness(bin: string, timeoutMs: number): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn(bin, ["agent", "list"], { stdio: "ignore" });
+    let settled = false;
+    const timer = setTimeout(() => {
+      settled = true;
+      child.kill("SIGKILL");
+      reject(new Error("herdr liveness timed out"));
+    }, timeoutMs);
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (code === 0) resolve();
+      else reject(new Error(`herdr agent list exited ${String(code)}`));
+    });
+  });
+}
+
 /**
  * Server-side environment-readiness diagnostics (issue #623). Fans dependency
  * probes with `Promise.all` behind a TTL cache. Mirrors HerdrUpdateService:
@@ -212,15 +244,7 @@ export class DiagnosticsService {
       });
     this.runHerdrLiveness =
       deps.runHerdrLiveness ??
-      (async () => {
-        // Exit code only — the agent listing is discarded. A zero exit means the
-        // daemon answered (reachable); a reject (ECONNREFUSED/ENOENT/timeout) means
-        // it's offline. `agent list` is the same reachability check `herdr-update` uses.
-        await execFileAsync(config.herdrBin, ["agent", "list"], {
-          encoding: "utf8",
-          timeout: DIAGNOSTICS_PROBE_TIMEOUT_MS,
-        });
-      });
+      (() => defaultHerdrLiveness(config.herdrBin, DIAGNOSTICS_PROBE_TIMEOUT_MS));
     this.runGhAuth =
       deps.runGhAuth ??
       (async () => {

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -71,6 +71,14 @@ export interface DiagnosticsDeps {
   /** Run `<bin> <args...>` and return stdout. Used for every `--version` probe
    *  plus the `which`/presence checks. Reject (incl. timeout) ⇒ binary absent. */
   runVersion?: (bin: string, args: string[]) => Promise<string>;
+  /** Probe herdr **server liveness** (not just binary presence): run `herdr agent
+   *  list`, resolving on a zero exit (daemon reachable), rejecting on
+   *  connection-refused / timeout (daemon offline). Exit code only — the agent
+   *  listing is discarded, so nothing but a state crosses into the snapshot. This is
+   *  the same reachability signal `herdr-update` relies on. Default
+   *  `execFileAsync(config.herdrBin, ["agent","list"])` with the shared probe
+   *  timeout. Injected in tests (resolve = live, reject = offline). */
+  runHerdrLiveness?: () => Promise<void>;
   /** Run `gh auth status`; resolves on a zero exit, rejects on non-zero / timeout.
    *  Its stdout is intentionally discarded (it carries account identity). On rejection
    *  the error's `code` / `killed` / `signal` classify the failure (see `ghProbe`):
@@ -180,6 +188,7 @@ export function defaultRunRemediation(
  */
 export class DiagnosticsService {
   private runVersion: (bin: string, args: string[]) => Promise<string>;
+  private runHerdrLiveness: () => Promise<void>;
   private runGhAuth: () => Promise<void>;
   private ghProbeAttempts: number;
   private ghProbeRetryDelayMs: number;
@@ -200,6 +209,17 @@ export class DiagnosticsService {
           timeout: DIAGNOSTICS_PROBE_TIMEOUT_MS,
         });
         return stdout.toString();
+      });
+    this.runHerdrLiveness =
+      deps.runHerdrLiveness ??
+      (async () => {
+        // Exit code only — the agent listing is discarded. A zero exit means the
+        // daemon answered (reachable); a reject (ECONNREFUSED/ENOENT/timeout) means
+        // it's offline. `agent list` is the same reachability check `herdr-update` uses.
+        await execFileAsync(config.herdrBin, ["agent", "list"], {
+          encoding: "utf8",
+          timeout: DIAGNOSTICS_PROBE_TIMEOUT_MS,
+        });
       });
     this.runGhAuth =
       deps.runGhAuth ??
@@ -238,16 +258,30 @@ export class DiagnosticsService {
   }
 
   /** Shared tri-state version probe (herdr / bun / node): missing ⇒ error,
-   *  below-floor ⇒ warning, else ok. Floors are advisory — never an error. */
+   *  below-floor ⇒ warning, else ok. Floors are advisory — never an error.
+   *
+   *  herdr additionally passes a `liveness` probe + an `offline` key: once the binary
+   *  is confirmed present, a daemon that doesn't answer is `error` (offline). Offline
+   *  outranks an outdated-version warning — a dead server is unusable now, a
+   *  live-but-old one merely wants updating. bun / node pass neither and keep the
+   *  binary-only tri-state. */
   private async versionProbe(
     id: string,
     bin: string,
     floor: string,
-    keys: { ok: string; outdated: string; missing: string },
+    keys: { ok: string; outdated: string; missing: string; offline?: string },
+    liveness?: () => Promise<void>,
   ): Promise<DiagnosticCheck> {
     const out = await this.runVersion(bin, ["--version"]);
     const version = this.parseVersion(out);
     if (!version) return { id, state: "error", hintKey: keys.missing };
+    if (liveness && keys.offline) {
+      try {
+        await liveness();
+      } catch {
+        return { id, state: "error", hintKey: keys.offline };
+      }
+    }
     if (compareSemver(version, floor) < 0) {
       return { id, state: "warning", hintKey: keys.outdated };
     }
@@ -255,11 +289,18 @@ export class DiagnosticsService {
   }
 
   private herdrProbe = (): Promise<DiagnosticCheck> =>
-    this.versionProbe("herdr", config.herdrBin, HERDR_MIN_VERSION, {
-      ok: "diagnostics_hint_herdr_ok",
-      outdated: "diagnostics_hint_herdr_outdated",
-      missing: "diagnostics_hint_herdr_missing",
-    });
+    this.versionProbe(
+      "herdr",
+      config.herdrBin,
+      HERDR_MIN_VERSION,
+      {
+        ok: "diagnostics_hint_herdr_ok",
+        outdated: "diagnostics_hint_herdr_outdated",
+        missing: "diagnostics_hint_herdr_missing",
+        offline: "diagnostics_hint_herdr_offline",
+      },
+      this.runHerdrLiveness,
+    );
 
   private bunProbe = (): Promise<DiagnosticCheck> =>
     this.versionProbe("bun", "bun", BUN_MIN_VERSION, {

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -38,6 +38,10 @@ const HEALTHY_VERSIONS: Record<string, string> = {
 function healthyDeps(): DiagnosticsDeps {
   return {
     runVersion: versionRunner({ ...HEALTHY_VERSIONS }),
+    // herdr daemon reachable (agent list exits 0). Override with a rejecting fn to
+    // model an offline server. Without this default, the real `execFileAsync` probe
+    // would shell out to an absent daemon and redden every herdr/overall-ok assertion.
+    runHerdrLiveness: async () => {},
     runGhAuth: async () => {},
     // gh probe now retries transient failures; zero delay keeps the failure-path tests
     // (which reject synchronously) from accruing real wall-time.
@@ -153,6 +157,61 @@ describe("DiagnosticsService probes", () => {
       expect(c.hintKey).toBe(missKey);
     });
   }
+
+  // ── herdr: server liveness (issue #1559) ─────────────────────────────────────
+  // A parseable `--version` proves only that the BINARY is present; the daemon must
+  // also answer. A reachable binary with a dead server is `error` (offline), not `ok`.
+  describe("herdr server liveness", () => {
+    const offline = () => Promise.reject(new Error("connect ECONNREFUSED"));
+
+    it("error/offline when the binary is present but the daemon is unreachable", async () => {
+      const svc = new DiagnosticsService({ ...healthyDeps(), runHerdrLiveness: offline });
+      const c = byId((await svc.check(0)).checks, "herdr");
+      expect(c.state).toBe("error");
+      expect(c.hintKey).toBe("diagnostics_hint_herdr_offline");
+      assertPure(c);
+    });
+
+    it("ok when the binary is current AND the daemon answers", async () => {
+      const svc = new DiagnosticsService({ ...healthyDeps(), runHerdrLiveness: async () => {} });
+      const c = byId((await svc.check(0)).checks, "herdr");
+      expect(c.state).toBe("ok");
+      expect(c.hintKey).toBe("diagnostics_hint_herdr_ok");
+    });
+
+    it("offline outranks an outdated-version warning", async () => {
+      const svc = new DiagnosticsService({
+        ...healthyDeps(),
+        runVersion: versionRunner({ ...HEALTHY_VERSIONS, herdr: "herdr 0.5.0" }),
+        runHerdrLiveness: offline,
+      });
+      const c = byId((await svc.check(0)).checks, "herdr");
+      expect(c.state).toBe("error");
+      expect(c.hintKey).toBe("diagnostics_hint_herdr_offline");
+    });
+
+    it("skips the liveness probe when the binary is missing (stays _missing)", async () => {
+      let pinged = false;
+      const svc = new DiagnosticsService({
+        ...healthyDeps(),
+        runVersion: versionRunner({ ...HEALTHY_VERSIONS, herdr: new Error("ENOENT") }),
+        runHerdrLiveness: async () => {
+          pinged = true;
+        },
+      });
+      const c = byId((await svc.check(0)).checks, "herdr");
+      expect(c.state).toBe("error");
+      expect(c.hintKey).toBe("diagnostics_hint_herdr_missing");
+      expect(pinged).toBe(false);
+    });
+
+    it("an offline daemon drives the overall snapshot to error", async () => {
+      const svc = new DiagnosticsService({ ...healthyDeps(), runHerdrLiveness: offline });
+      const snap = await svc.check(0);
+      expect(byId(snap.checks, "herdr").state).toBe("error");
+      expect(snap.overall).toBe("error");
+    });
+  });
 
   // ── git: presence-only ───────────────────────────────────────────────────────
   it("git: ok when present", async () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1268,6 +1268,7 @@
   "diagnostics_hint_herdr_ok": "herdr ist aktuell.",
   "diagnostics_hint_herdr_outdated": "Deine herdr-Version liegt unter dem unterstützten Minimum — aktualisiere herdr.",
   "diagnostics_hint_herdr_missing": "herdr-Binary nicht im PATH gefunden — installiere es, um Agent-Sessions zu starten.",
+  "diagnostics_hint_herdr_offline": "herdr ist installiert, aber sein Server ist offline — Agent-Sessions können nicht laufen. Starte ihn mit `herdr server` und führe die Diagnose erneut aus.",
   "diagnostics_hint_tailscale_ok": "Tailscale ist verbunden.",
   "diagnostics_hint_tailscale_not_serving": "Tailscale läuft, stellt Shepherd aber nicht bereit — richte tailscale serve oder einen Tailscale-Service für den Remote-Zugriff ein.",
   "diagnostics_hint_tailscale_missing": "Tailscale nicht installiert oder nicht angemeldet — installiere es und führe tailscale up aus.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1268,6 +1268,7 @@
   "diagnostics_hint_herdr_ok": "herdr is up to date.",
   "diagnostics_hint_herdr_outdated": "Your herdr version is below the supported floor — update herdr.",
   "diagnostics_hint_herdr_missing": "herdr binary not found in PATH — install it to run agent sessions.",
+  "diagnostics_hint_herdr_offline": "herdr is installed but its server is offline — agent sessions can't run. Start it by running `herdr server`, then re-run Diagnose.",
   "diagnostics_hint_tailscale_ok": "Tailscale is connected.",
   "diagnostics_hint_tailscale_not_serving": "Tailscale is running but isn't fronting Shepherd — set up tailscale serve or a Tailscale Service for remote access.",
   "diagnostics_hint_tailscale_missing": "Tailscale not installed or not logged in — install it and run tailscale up.",

--- a/ui/src/lib/diagnostics-docs.ts
+++ b/ui/src/lib/diagnostics-docs.ts
@@ -4,6 +4,7 @@ import type { PwaRowState } from "$lib/pwa";
  *  get no auto-Fix button (the fix needs a human secret). Pure presentational
  *  chrome — kept UI-side, NOT in the /api/diagnostics payload. */
 export const DOC_LINKS: Record<string, string> = {
+  diagnostics_hint_herdr_offline: "https://herdr.dev",
   diagnostics_hint_gh_missing: "https://github.com/cli/cli#installation",
   diagnostics_hint_gh_not_authenticated: "https://cli.github.com/manual/gh_auth_login",
   diagnostics_hint_tailscale_missing: "https://tailscale.com/kb/1347/installation",


### PR DESCRIPTION
## Problem

Fixes #1559. The DIAGNOSE panel's herdr check ran only `herdr --version` — proving the **binary** is present, never that the **daemon** answers. A dead herdr server still read green **"ok"** while the system was unusable.

## Fix

Separate "installed" from "usable" for herdr:

- After confirming the binary/version, the herdr check now runs a **liveness probe** — `herdr agent list` (exit 0 = daemon reachable, connection-refused/timeout = offline). This is the same reachability signal `herdr-update` already relies on, and works regardless of the default-off socket driver.
- An offline daemon surfaces as a red **`error`** with a new `diagnostics_hint_herdr_offline` hint that names the concrete start command (`herdr server`), plus a guidance doc-link (parity with the tailscale/gh guidance rows).
- Precedence inside the check: **missing > offline > outdated > ok** — a live-but-old daemon stays a warning; a dead one is an error. Liveness is probed only when the binary is present.
- **Guidance-only** (no auto-run Fix button): there is no existing fix-map "start herdr server" primitive, and auto-starting a dead daemon is version/platform-dependent.

## Scope / non-goals

- **Boot preflight (`preflight.ts`) is deliberately untouched** — `restart.ts` documents that a down daemon must not trip the exit-78 fail-fast (Shepherd may be what starts it). This change is scoped to the re-runnable DIAGNOSE panel.
- Known transient: a Diagnose run *during* a `herdr update`/live-handoff can briefly read `offline`. Accepted — DIAGNOSE is a manual, re-runnable snapshot, not a poll/alert.

## Tests

Adds functional liveness cases to `test/diagnostics.test.ts` (the test the issue asks for): offline→`error`/`_offline` (+payload purity), live→`ok`, binary-missing→`_missing` with the liveness probe **not** invoked, offline-outranks-outdated, and offline driving `overall` to `error`. Also injects a resolving `runHerdrLiveness` into the `healthyDeps()` helper so existing "ok" assertions don't probe a real absent daemon.

Verified locally: `bun run lint`, `bun run typecheck`, `bun test test/diagnostics.test.ts` (67 pass), `cd ui && bun run check` + `check:i18n` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)