### PR TITLE
fix(herdr): recover herdr server after Update Herd (#1558)

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,24 @@ single-operator password and stores browser access in a signed session cookie. S
 `SHEPHERD_PASSWORD` in `~/.shepherd/env`, or use the first-boot generated password from the server
 log; machine clients can use `SHEPHERD_TOKEN` as a bearer alternative.
 
+### herdr server lifecycle & "Update Herd"
+
+Shepherd drives herdr but **does not own the herdr server's lifecycle** — the daemon is
+normally auto-spawned on demand by any `herdr` CLI call. **"Update Herd"** swaps the herdr
+binary (`herdr update --handoff`), which stops the running server for the swap. Afterwards
+Shepherd makes a best-effort attempt to bring it back: it runs `herdr agent list` (which
+auto-spawns the daemon) with a short grace+retry, and only if that still fails does it
+relaunch a detached server so orphaned panes reattach.
+
+If you run the herdr **server** under your own systemd unit, use **`Restart=always`**, not
+`Restart=on-failure`. The stop during an update is a _clean_ exit (status 0), which
+`Restart=on-failure` does **not** treat as a restart trigger — so the server would stay down
+after "Update Herd", leaving a stale `~/.config/herdr/herdr.sock` and clients looping on
+`ConnectionRefused`. `Restart=always` survives that clean stop and is the durable fix;
+Shepherd's post-update recovery above is a subordinate best-effort belt (its relaunched
+server is a child of Shepherd's cgroup and is not durable across a `systemctl restart
+shepherd`).
+
 ### Host tuning — tmpfs inodes
 
 Shepherd keeps spawned agents' Node compile cache **off** the `/tmp` tmpfs (it points

--- a/src/herdr-update.ts
+++ b/src/herdr-update.ts
@@ -86,12 +86,16 @@ export function buildUpdateScript(
   // so gating recovery on `rc != 0` (as we used to) skipped the exact bug — a
   // successful swap that never brought the server back, leaving a stale socket and
   // clients looping on ConnectionRefused. So we ALWAYS run `herdr agent list` after
-  // the update, regardless of rc. That CLI call is itself the recovery: a herdr CLI
-  // call is documented to auto-spawn the daemon (herdr.ts:44-46; the "herdr update
-  // without a shepherd restart" design doc, item 4 body). It runs the real herdr
-  // binary directly, so it bypasses shepherd's in-process maintenance guard (which
-  // only gates shepherd's own Runner) and can resurrect the server before the poller
-  // even resumes — driver-independent (it does not depend on SHEPHERD_HERDR_SOCKET).
+  // the update, regardless of rc. That CLI call is itself the recovery: any herdr
+  // CLI call auto-spawns the daemon (stated in the "herdr update without a shepherd
+  // restart" design doc, item 4 body — docs/superpowers/specs/
+  // 2026-06-04-herdr-update-without-restart-design.md). Shepherd's own maintenance
+  // guard (`HerdrUnavailableError`, herdr.ts:44-46) corroborates it: that guard
+  // exists specifically to STOP shepherd's Runner from spawning mid-update, which
+  // only matters because a normal CLI call would. Our `agent list` here runs the
+  // real herdr binary directly, bypassing that in-process guard (which only gates
+  // shepherd's own Runner), so it can resurrect the server before the poller even
+  // resumes — driver-independent (it does not depend on SHEPHERD_HERDR_SOCKET).
   //
   // Grace + retry: a still-binding server — an in-flight `--handoff`, or a self-
   // managed systemd unit with `Restart=always` coming up — must not be mistaken for

--- a/src/herdr-update.ts
+++ b/src/herdr-update.ts
@@ -82,18 +82,36 @@ export function buildUpdateScript(
   // pane. Not stopping means a failed update usually leaves the live server +
   // panes untouched.
   //
-  // Recovery (only when the update fails): because the agent targets outlive a
-  // dead server, if the server is actually gone we relaunch one and the orphaned
-  // panes reattach — the app's Reconnect / `viewport_herdr_unreachable` path, the
-  // "live agent returns once herdr is back" invariant from #413. We gate the
-  // relaunch on `agent list`, the SAME throw-on-unreachable signal broadcast()
-  // catches in service.ts, and relaunch ONLY when it fails — an unconditional
-  // restart while the server is still up is the #241/#314 hazard. `setsid ...
-  // server` detaches the foreground `herdr server` into its own session. Caveat:
-  // this recovery server is a child of shepherd's cgroup, so it is not durable
-  // across a later `systemctl restart shepherd` — at which point the still-alive
-  // targets simply re-orphan and recover again (never lost). A cgroup-durable
-  // server would need systemd-run, which this script deliberately avoids.
+  // Recovery (#1558): `herdr update` exits 0 even when it leaves NO running server,
+  // so gating recovery on `rc != 0` (as we used to) skipped the exact bug — a
+  // successful swap that never brought the server back, leaving a stale socket and
+  // clients looping on ConnectionRefused. So we ALWAYS run `herdr agent list` after
+  // the update, regardless of rc. That CLI call is itself the recovery: a herdr CLI
+  // call is documented to auto-spawn the daemon (herdr.ts:44-46; the "herdr update
+  // without a shepherd restart" design doc, item 4 body). It runs the real herdr
+  // binary directly, so it bypasses shepherd's in-process maintenance guard (which
+  // only gates shepherd's own Runner) and can resurrect the server before the poller
+  // even resumes — driver-independent (it does not depend on SHEPHERD_HERDR_SOCKET).
+  //
+  // Grace + retry: a still-binding server — an in-flight `--handoff`, or a self-
+  // managed systemd unit with `Restart=always` coming up — must not be mistaken for
+  // "down". The retry loop lets it bind first, so a systemd-managed server wins and
+  // the fallback below is never entered (auto-spawn no-ops against a bound socket).
+  //
+  // Last-resort fallback: ONLY after the retries still report unreachable do we
+  // relaunch a detached server, so orphaned targets reattach — the app's Reconnect /
+  // `viewport_herdr_unreachable` path, the "live agent returns once herdr is back"
+  // invariant from #413. Kept (not deleted) because the auto-spawn premise above is
+  // from the herdr 0.6.x era and this bug is 0.7.x — if 0.7.x no longer auto-spawns
+  // on `agent list`, this explicit relaunch is the only thing that recovers the host;
+  // removing it would regress vs. today's rc!=0 path. `setsid ... server` detaches
+  // the foreground `herdr server` into its own session so it outlives this script
+  // (and the `timeout … agent list` wrapper). Caveat: this recovery server is a child
+  // of shepherd's cgroup, so it is not durable across a later `systemctl restart
+  // shepherd` — at which point the still-alive targets simply re-orphan and recover
+  // again (never lost). A cgroup-durable server would need systemd-run, which this
+  // script deliberately avoids; `Restart=always` on a self-managed unit is the
+  // durable operator-side fix (see README).
   return [
     `LOG=${q}`,
     'mkdir -p "$(dirname "$LOG")"',
@@ -102,13 +120,19 @@ export function buildUpdateScript(
     `  echo '${UPDATE_LOG_PREFIX} running herdr update --handoff'`,
     `  ${h} update --handoff; rc=$?`,
     `  echo "${UPDATE_LOG_PREFIX} herdr update exited rc=$rc"`,
-    '  if [ "$rc" -ne 0 ]; then',
-    `    if timeout 10 ${h} agent list >/dev/null 2>&1; then`,
-    `      echo '${UPDATE_LOG_PREFIX} update failed — herdr server still reachable (agent list ok); live sessions untouched'`,
-    "    else",
-    `      echo '${UPDATE_LOG_PREFIX} update failed, herdr server unreachable — relaunching a detached server so orphaned sessions reattach'`,
-    `      setsid ${h} server </dev/null >/dev/null 2>&1 &`,
-    "    fi",
+    // Unconditional (NOT gated on rc): the CLI call auto-spawns the daemon, so this
+    // both verifies AND recovers the server. Grace+retry lets an in-flight --handoff
+    // or a systemd `Restart=always` unit bind first before we conclude "unreachable".
+    "  ok=0",
+    "  for attempt in 1 2 3; do",
+    `    if timeout 10 ${h} agent list >/dev/null 2>&1; then ok=1; break; fi`,
+    "    sleep 2",
+    "  done",
+    '  if [ "$ok" -eq 1 ]; then',
+    `    echo '${UPDATE_LOG_PREFIX} herdr server reachable after update'`,
+    "  else",
+    `    echo '${UPDATE_LOG_PREFIX} herdr server unreachable after retries — relaunching a detached server so orphaned sessions reattach'`,
+    `    setsid ${h} server </dev/null >/dev/null 2>&1 &`,
     "  fi",
     '} 2>&1 | tee -a "$LOG"',
   ].join("\n");

--- a/test/herdr-update.test.ts
+++ b/test/herdr-update.test.ts
@@ -21,16 +21,32 @@ test("buildUpdateScript: runs `herdr update --handoff`, no destructive pre-stop"
   expect(s).not.toContain("herdr server stop");
 });
 
-test("buildUpdateScript: on failure, relaunches herdr ONLY when it is unreachable", () => {
+test("buildUpdateScript: runs `agent list` UNCONDITIONALLY after update, not gated on rc (#1558)", () => {
   const s = buildUpdateScript(LOG, "0.6.5", "0.6.6");
-  // the whole recovery is gated on the update having failed
-  expect(s).toContain('if [ "$rc" -ne 0 ]; then');
-  // probe is the repo's own unreachable signal: `agent list` exits non-zero when
-  // herdr is unreachable — the exact throw broadcast() catches in service.ts.
+  // #1558: `herdr update` exits 0 even when it left no running server, so gating
+  // recovery on the exit code skipped the exact bug. Recovery must NOT be wrapped
+  // in an rc check any more.
+  expect(s).not.toContain('if [ "$rc" -ne 0 ]');
+  // `agent list` is the recovery: a herdr CLI call auto-spawns the daemon, so this
+  // both verifies AND resurrects the server, driver-independently.
   expect(s).toContain("agent list");
-  // relaunch a DETACHED server (bare `herdr server` is foreground) on the
-  // unreachable branch so the orphaned targets (which outlive the dead server) reattach.
+  // grace + retry so an in-flight --handoff / a systemd `Restart=always` unit can
+  // bind first before we conclude the server is unreachable.
+  expect(s).toContain("for attempt in 1 2 3");
+  expect(s).toContain("sleep 2");
+  expect(s).toContain("ok=1");
+});
+
+test("buildUpdateScript: relaunches a detached server ONLY as a post-retry fallback", () => {
+  const s = buildUpdateScript(LOG, "0.6.5", "0.6.6");
+  // the explicit relaunch is RETAINED (hedge against a weaker 0.7.x auto-spawn) but
+  // fires only in the `else` branch, i.e. after the grace+retry loop still failed.
   expect(s).toMatch(/setsid\b.*\bserver\b.*&/);
+  expect(s).toMatch(/else\s*\n\s*echo '[^']*unreachable after retries/);
+  // NEVER unlink the socket: herdr clears/rebinds its own stale socket on spawn, and
+  // an external `rm` could destroy a concurrently-recovering server's socket (#1558).
+  expect(s).not.toMatch(/\brm\b/);
+  expect(s).not.toContain("herdr.sock");
   // the nonexistent verb is gone; no stop/handoff (both need a live server) and no systemd.
   expect(s).not.toContain("herdr server start");
   expect(s).not.toContain("live-handoff");
@@ -39,8 +55,9 @@ test("buildUpdateScript: on failure, relaunches herdr ONLY when it is unreachabl
 
 test("buildUpdateScript: threads a custom HERDR_BIN through every herdr call", () => {
   const s = buildUpdateScript(LOG, "0.6.5", "0.6.6", "/opt/herdr/bin/herdr");
-  // the configured binary drives the update, the unreachable probe, and the
-  // relaunch — each shell-quoted so a path with spaces/quotes can't break the script.
+  // the configured binary drives the update, the auto-spawning `agent list` probe,
+  // and the fallback relaunch — each shell-quoted so a path with spaces/quotes can't
+  // break the script.
   expect(s).toContain("'/opt/herdr/bin/herdr' update --handoff");
   expect(s).toContain("'/opt/herdr/bin/herdr' agent list");
   expect(s).toContain("'/opt/herdr/bin/herdr' server");
@@ -56,8 +73,8 @@ test("buildUpdateScript: never restarts shepherd or shells systemd", () => {
 test("buildUpdateScript: echoes a greppable marker for each step", () => {
   const s = buildUpdateScript(LOG, "0.6.5", "0.6.6");
   const markers = s.split("\n").filter((l) => l.includes(UPDATE_LOG_PREFIX));
-  // running / exited rc / reachable-branch / unreachable-branch = 4 markers
-  // (the two failure branches are mutually exclusive at runtime, both present in text)
+  // running / exited rc / reachable-after-update / unreachable-after-retries = 4 markers
+  // (the reachable + unreachable branches are mutually exclusive at runtime, both in text)
   expect(markers.length).toBe(4);
   expect(s).toContain(`${UPDATE_LOG_PREFIX} herdr update exited rc=$rc`);
 });


### PR DESCRIPTION
## Problem

Fixes #1558. After **"Update Herd"** the herdr **server** did not come back up: the HUD dropped to the "herdr offline / reconnect" screen with a repeating `ConnectionRefused` loop, and a stale `~/.config/herdr/herdr.sock` was left with no listener.

## Root cause

`buildUpdateScript()` in `src/herdr-update.ts` gated its post-update recovery behind `if [ "$rc" -ne 0 ]`. But `herdr update` exits **0** even when the swap left no running server, so on the common *successful-update-but-server-down* path the script made **no** herdr call at all — neither the auto-spawning `agent list` nor the fallback relaunch fired. On a self-managed herdr systemd unit with `Restart=on-failure`, the clean stop (exit 0) during the swap doesn't trigger a restart either, so nothing on any layer brought the server back.

## Fix

- Run `herdr agent list` **unconditionally** after the update (not gated on `rc`). A herdr CLI call auto-spawns the daemon (`src/herdr.ts:44-46`), so this both verifies **and** recovers the server — and it runs the real `herdr` binary directly, so it's independent of the socket-vs-CLI driver.
- Wrap it in a **bounded grace + retry** so an in-flight `--handoff` (rc==0 bind window) or a systemd `Restart=always` unit binds first and is never mistaken for "down".
- **Retain** the detached `setsid herdr server` relaunch as a **last-resort fallback**, fired only after the retries still report unreachable — a hedge in case herdr 0.7.x no longer auto-spawns on `agent list` (the auto-spawn evidence is from the 0.6.x-era design doc). Removing it outright would regress vs. today's `rc!=0` path.
- **No socket `rm`**: herdr clears/rebinds its own stale socket on spawn, and an external `rm` could destroy a concurrently-recovering server's socket.

## Docs

README gains a **"herdr server lifecycle & Update Herd"** subsection recommending **`Restart=always`** (not `on-failure`) for a self-managed herdr-server systemd unit — the durable operator-side fix. Shepherd's post-update recovery is documented as a subordinate best-effort belt (its relaunched server is a cgroup child, not durable across `systemctl restart shepherd`).

## Not done here (noted in the issue as the "broader gap")

- Deeper socket-driver reliability gap (`herdr-socket-driver` connects but never respawns a dead server at *any* time).
- Full lifecycle ownership: shipping + enabling a `herdr-server.service` from `deploy/install.sh`.

## Testing

- `test/herdr-update.test.ts` updated: `agent list` runs regardless of `rc`; grace+retry present; `setsid ... server &` only in the post-retry `else` branch; **no** `rm`/socket removal; `HERDR_BIN` still threaded through every call; marker count.
- Generated script verified with `bash -n`.
- Root `bun run lint` clean; `bun run test` — **6270 pass / 0 fail**.

Verified end-to-end against a live herdr is not possible in CI (herdr is absent from the runner image); the `buildUpdateScript` string tests are the established proxy for this file, and the change is deliberately minimal + non-destructive because of that limit.

[no-feature-entry] — server-side lifecycle fix, no user-facing UX surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)