### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs-site/src/content/docs/operating.md
+++ b/docs-site/src/content/docs/operating.md
@@ -76,6 +76,34 @@ web-push alert. macOS / core-only hosts have no backup timer and stay silent. Fu
 details are in the
 [backups runbook](https://github.com/erwins-enkel/shepherd/blob/main/docs/backups.md).
 
+## herdr server lifecycle & "Update Herd"
+
+Shepherd drives herdr but **does not own the herdr server's lifecycle** — the
+daemon is normally auto-spawned on demand by any `herdr` CLI call. **"Update
+Herd"** swaps the herdr binary (`herdr update --handoff`), which stops the running
+server for the swap. Afterwards Shepherd makes a best-effort attempt to bring it
+back: it runs `herdr agent list` (which auto-spawns the daemon) with a short
+grace+retry, and only if that still fails does it relaunch a detached server so
+orphaned panes reattach.
+
+If you run the herdr **server** under your own systemd unit, use
+**`Restart=always`**, not `Restart=on-failure`. The stop during an update is a
+_clean_ exit (status 0), which `Restart=on-failure` does **not** treat as a restart
+trigger — so the server would stay down after "Update Herd", leaving a stale
+`~/.config/herdr/herdr.sock` and clients looping on `ConnectionRefused`.
+`Restart=always` survives that clean stop and is the durable fix; Shepherd's
+post-update recovery above is a subordinate best-effort belt (its relaunched server
+is a child of Shepherd's cgroup and is not durable across a `systemctl restart
+shepherd`).
+
+Every "Update Herd" run appends one delimited block to `~/.shepherd/herdr-update.log`
+— written by the update child itself, so the record survives even if Shepherd dies
+mid-update:
+
+```bash
+grep '>>> herdr-update' ~/.shepherd/herdr-update.log   # each step marker + the exit code
+```
+
 ## Host tuning — tmpfs inodes
 
 Shepherd keeps spawned agents' Node compile cache **off** the `/tmp` tmpfs and runs

--- a/docs/sandbox-security.md
+++ b/docs/sandbox-security.md
@@ -25,6 +25,18 @@ The membrane keeps two token surfaces readable to any in-membrane tool call:
 - `~/.config/gh` — bound **RO** (the gh token, needed to `git push` /
   `gh pr create`) at `src/sandbox.ts:413`.
 
+**Under api-key auth the OAuth surface shifts rather than disappears.** In
+subscription mode (the default) both binds above apply verbatim. In api-key mode
+(`SHEPHERD_AUTH_MODE=api-key`) `apiKeyMembraneFields` sets `maskCredentials`
+(`src/spawn-auth.ts:73-79`), and the membrane then binds `~/.claude` per-child RO
+**omitting `.credentials.json` entirely** — no bind of any kind
+(`src/sandbox.ts:308-317`) — so the OAuth token is genuinely absent inside the
+membrane. In its place the `apiKeyHelper` script is `--ro-bind`ed at the same path
+(`src/sandbox.ts:419-421`) so `--settings` resolves it, and that script is what an
+in-membrane tool call can read/run to obtain the API key. The residual is the same
+shape — a readable credential surface the session legitimately needs — with a
+different file behind it. (`~/.config/gh` is bound RO in both modes.)
+
 `--clearenv` (`src/sandbox.ts:438`) strips **all** inherited env
 (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `GH_TOKEN`, `SHEPHERD_TOKEN`,
 …), re-setting only HOME/PATH/TERM + non-secret locale vars — so these two
@@ -51,7 +63,7 @@ secrets out of the membrane entirely.
 
 Egress confinement is keyed to the autonomous **profile**, not to whether a human
 is watching (`willEgressConfine`, `src/sandbox.ts:565-570`; applied at
-`src/service.ts:1409`): the wrap applies iff the autonomous profile resolves
+`src/service.ts:1812`): the wrap applies iff the autonomous profile resolves
 **and** the fs + egress backends are present, independent of `ctx.auto`.
 Consequences:
 
@@ -108,19 +120,20 @@ Write --permission-mode dontAsk` (`src/transient-agent-argv.ts`,
   `buildTransientAgentArgv("reviewer", …)`).
 - **Research is the deliberately egress-UNCONFINED surface.** A research session
   that would resolve to `autonomous` is **downgraded to `standard`**
-  (`src/service.ts` `researchSafeProfileOverride`, ~L1796-1814, warns once),
+  (`src/service.ts` `researchSafeProfileOverride`, ~L2402-2418, warns once),
   because research needs **open** web egress (search/fetch + sub-agents) that the
   autonomous firewall would block. It is operator-_created_ (cannot be
   auto-drained — `standard` refuses auto-spawn) but **autopilot-steerable, so it
   runs unattended in practice** (`RESEARCH_PROCEED_STEER`,
-  `src/autopilot.ts:24-29`, dispatched at L307). It ingests **untrusted web**
+  `src/autopilot.ts:25-30`, dispatched at L323). It ingests **untrusted web**
   content on `trusted`/`standard` with the **network open**, and can
   `gh pr create` / open issues via the bound gh token — so a hijacked research
   agent has **both** readable tokens **and** open egress.
 
   **Compensating factors:** the downgrade is explicit and warns once; research
   delivers a **report PR or GitHub issue only, never a code PR**
-  (`src/autopilot.ts:309-313`). The residual is **accepted**.
+  (`src/autopilot.ts:327-331` — a finished research session is marked complete
+  instead of being steered to open one). The residual is **accepted**.
 
 ## See also
 


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc sync — stale prose vs. current source

Two files changed. The rest of the in-scope set was checked against source and is current.

## Changes

- **`docs-site/src/content/docs/operating.md`** — added a new **"herdr server lifecycle & 'Update Herd'"**
  section between _Deploy a code change_ and _Host tuning_. Grounded in commit `5f580aa1`
  ("fix(herdr): recover herdr server after Update Herd (#1558)"), which added exactly this guidance to
  `README.md` but never mirrored it to the docs site. The prose tracks `src/herdr-update.ts:85-142`:
  `herdr update --handoff` stops the server; recovery is an unconditional `herdr agent list`
  (auto-spawns the daemon) under a 3× grace+retry loop, with a detached `setsid herdr server` only as a
  last-resort fallback. The `Restart=always` (not `Restart=on-failure`) advice for a self-managed herdr
  systemd unit comes from the same commit and the code comment at `src/herdr-update.ts:100-118` — the
  update's stop is a clean exit(0), which `on-failure` will not restart. Also documents the durable
  audit log at `~/.shepherd/herdr-update.log` (`src/config.ts:19-24`, `UPDATE_LOG_PREFIX` at
  `src/herdr-update.ts:27`).

- **`docs/sandbox-security.md`** — two kinds of fix:
  1. **R3 was only true for subscription auth.** The section asserted the membrane keeps
     `~/.claude/.credentials.json` bound RW, full stop. Under api-key auth
     (`config.authMode === "api-key"`, `src/config.ts:685`), `apiKeyMembraneFields`
     (`src/spawn-auth.ts:73-79`) sets `maskCredentials`, and `buildMembraneFlags`
     (`src/sandbox.ts:308-317`) then binds `~/.claude` per-child RO **omitting `.credentials.json`
     entirely** — the OAuth token is genuinely absent. The `apiKeyHelper` script is `--ro-bind`ed in its
     place (`src/sandbox.ts:419-421`). Added a paragraph describing that the readable-credential
     residual keeps its shape but changes file; `~/.config/gh` is unchanged in both modes.
  2. **Stale source line citations** (the surrounding claims all still verify; only the anchors drifted):
     - `willEgressConfine` applied at `src/service.ts:1409` → **`:1812`** (only call site in the spawn path).
     - `researchSafeProfileOverride, ~L1796-1814` → **`~L2402-2418`**.
     - `RESEARCH_PROCEED_STEER, src/autopilot.ts:24-29` → **`:25-30`**; "dispatched at L307" → **L323**.
     - "report PR or GitHub issue only, never a code PR (`src/autopilot.ts:309-313`)" →
       **`:327-331`** (the `case "finished"` research branch that calls `markComplete` instead of
       steering `gh pr create`).

     The `src/sandbox.ts` anchors (`308-310`, `315-317`, `413`, `438`, `~501-502`, `~554`, `565-570`)
     were re-verified and are still correct — left as-is.

## Uncertain / needs human judgment

- **`docs/token-usage-analysis.md` — deliberately not touched.** It is a dated, point-in-time report
  that explicitly says its levers are "proposals — not done here". Since then, lever #1
  (trim per-turn context) shipped as `config.trimAutoContext` / `SHEPHERD_TRIM_AUTO_CONTEXT`, lever #3's
  "per-task cap on auto-address rounds" shipped as `config.prReviewCyclesCap` /
  `SHEPHERD_REVIEW_CYCLES_CAP`, and the meta-lever (persist reviewer ids + totals at spawn) shipped as
  `reviewer_spawns` (#502). Annotating a historical analysis with "this has since shipped" is an
  editorial call — it would rewrite a record the doc frames as a snapshot. **Recommend a human decide**
  whether to add a dated "status since publication" note or leave it as an archive.

- **`docs/external-task-api.md` — request-schema table lists 8 of the 16 `ALLOWED_KEYS`.**
  `src/validate.ts:40-57` also accepts `attachmentNames`, `issueRef`, `launchUiState`, `planGateEnabled`,
  `autopilotEnabled`, `sandboxProfile`, `research`, and `mergeTrainPrs`. All eight predate the doc's last
  two sync passes, which repeatedly left them out — so this reads as **deliberate scoping** (UI-only /
  internal fields) rather than drift, and I could not ground the intended external-caller semantics of
  `launchUiState` or `mergeTrainPrs` from source alone. Left alone. `planGateEnabled`, `autopilotEnabled`,
  `sandboxProfile`, and `research` do look genuinely useful to an external submitter — worth a human call.

- **`docs-site/src/content/docs/reference/configuration.md` says "Every environment variable"** but the
  tables omit a number of real ones read in `src/config.ts` — e.g. `SHEPHERD_AUTH_MODE`, `CODEX_BIN`,
  `SHEPHERD_NODE_BIN`, `SHEPHERD_HERDR_UPDATE_LOG`, `SHEPHERD_CODEX_UPDATE_LOG`,
  `SHEPHERD_SANDBOX_EXTRA_HOSTS`, the per-role `*_CLI` / `*_MODEL` / `*_EFFORT` matrix,
  `SHEPHERD_REVIEW_CYCLES_CAP`, `SHEPHERD_VAPID_*`, `SHEPHERD_REDUCED_PUSH_MODE`,
  `SHEPHERD_HOOKS_INGEST` / `_SIGNALS`. This is a long-standing gap, **not** a regression from any recent
  commit, and closing it is a larger editorial task (which vars are operator-facing vs. internal?). I
  deliberately did **not** expand the table, and for that reason dropped a `SHEPHERD_HERDR_UPDATE_LOG`
  mention from my new operating.md section rather than reference an undocumented var.

- **`docs/sandbox-security.md` reviewer-argv excerpt** shows `--safe-mode --disable-slash-commands
  --allowedTools …`. Actual emission order (`src/transient-agent-argv.ts:166-176`) is
  `--disable-slash-commands`, then `--safe-mode`, then `--allowedTools`, and the excerpt also omits
  `--session-id` / `--settings` / `--model` / `--effort`. The tool allowlist itself matches
  `READONLY_GIT + "Write"` exactly. Since the doc presents an abbreviated excerpt rather than a literal
  argv, I left the ordering alone — flagging in case it should be made literal.

- **Repo preview "open mode"** (`423a8abb`, #1534, `ui/src/lib/previewOpen.ts`) is a new per-repo setting
  with no environment variable and no home in the in-scope pages (none of them document per-repo
  settings). Not added; may warrant a page that is out of scope here.

### Verified current — no change needed

`docs-site/src/content/docs/index.md`, `getting-started.md`, and `reference/glossary.md` (all 13 term ids
in `ui/src/lib/glossary.ts` are present and match), plus `reference/configuration.md`'s herdr-socket rows,
which `f4f34cc1` already updated for the `start`/`stop`/`relabel`/`closeTab` socket port (`send` still
CLI-backed, per `src/herdr-socket-driver.ts`).