### PR TITLE
fix(git): cache the git-rail's live PR fetch so the session card shows it

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -130,7 +130,7 @@ import { buildIssueUrl } from "./forge";
 import type { GithubRateLimitPayload } from "./forge/github-rate-limit";
 import { BaseCheckoutBusyError, MergeConflictError } from "./forge/local";
 import { recordEpicIntegrationIfChild, settleMergedSession } from "./merge-teardown";
-import { type PrCache, guardStaleTerminal, trustsTerminal } from "./pr-poller";
+import { type PrCache, gitStateChanged, guardStaleTerminal, trustsTerminal } from "./pr-poller";
 import {
   readRepoRoles,
   writeRepoRoles,
@@ -3519,21 +3519,40 @@ async function resolveGitState(
   deps: AppDeps,
 ): Promise<GitState> {
   const me = (await forge.currentUser?.()) ?? null;
-  const git: GitState = annotateHandoff(
-    { kind: forge.kind, ...(await forge.prStatus(session.branch ?? "")) },
-    session.repoPath,
-    me,
-  );
   const prev = deps.prCache?.get(session.id);
-  const trusted = trustsTerminal(
-    prev,
-    git,
-    session.mergingSince != null,
-    session.mergingPrNumber ?? null,
+  const marked = session.mergingSince != null;
+  const markedNumber = session.mergingPrNumber ?? null;
+  // The same trust guard the poller applies to every status result: keep a genuinely
+  // merged/closed PR when merge-train-flagged or already-owned, else drop a reused
+  // branch-name collision to "none".
+  const guard = (raw: GitState): GitState =>
+    trustsTerminal(prev, raw, marked, markedNumber)
+      ? raw
+      : guardStaleTerminal(raw, (headSha) => deps.ownsPr?.(session, headSha) ?? null);
+
+  let result = guard(
+    annotateHandoff(
+      { kind: forge.kind, ...(await forge.prStatus(session.branch ?? "")) },
+      session.repoPath,
+      me,
+    ),
   );
-  const result = trusted
-    ? git
-    : guardStaleTerminal(git, (headSha) => deps.ownsPr?.(session, headSha) ?? null);
+  // No PR for the stored branch: the agent may have renamed the worktree branch out
+  // from under us. Adopt the live branch and retry against it — mirrors the poller's
+  // statusPerSession so GitRail recognizes a renamed-branch PR the same way, and so a
+  // resolved "none" is authoritative (the caller can safely clear a stale cached PR).
+  if (result.state === "none") {
+    const live = deps.service.syncWorktreeBranch?.(session.id) ?? null;
+    if (live && live !== session.branch) {
+      result = guard(
+        annotateHandoff(
+          { kind: forge.kind, ...(await forge.prStatus(live)) },
+          session.repoPath,
+          me,
+        ),
+      );
+    }
+  }
   const issueUrl = buildIssueUrl(forge.webUrl, session.issueNumber);
   if (issueUrl) result.issueUrl = issueUrl;
   return result;
@@ -3550,7 +3569,22 @@ async function forgeGitStateResponse(
   session: Session,
   deps: AppDeps,
 ): Promise<Response> {
-  return json(await resolveGitState(forge, session, deps));
+  const result = await resolveGitState(forge, session, deps);
+  // Write-through: the git-rail's live GET is otherwise a read-only side channel the
+  // session card's cache (`prCache` + `session:git`) never sees, so a PR the poller
+  // hasn't cached stays invisible on the card while the detail view shows it. Feed the
+  // freshly-resolved state back into the shared cache and broadcast it — bounded to a
+  // genuine change (the poller's own gate), and "meaningful" so we surface a PR or clear
+  // one that was really there, but never emit a no-PR `none` for a session that never had
+  // one. `resolveGitState` reconciles a renamed branch first, so a `none` here is
+  // authoritative enough to clear a stale cached PR.
+  const prev = deps.prCache?.get(session.id);
+  const meaningful = result.state !== "none" || (prev != null && prev.state !== "none");
+  if (deps.prCache && meaningful && gitStateChanged(prev, result)) {
+    deps.prCache.set(session.id, result);
+    deps.events.emit("session:git", { id: session.id, git: result });
+  }
+  return json(result);
 }
 
 async function handleSessionGit(ctx: Ctx): Promise<Response | null> {

--- a/test/server-git.test.ts
+++ b/test/server-git.test.ts
@@ -99,8 +99,20 @@ function fakeForge(
 function makeDeps(
   forge: GitForge | null,
   session: Session | null = SESSION,
-  opts: { draftMode?: boolean; signoffAuthority?: "human" | "critic" | "either" } = {},
-): AppDeps & { emitted: { event: string; data: unknown }[]; cacheWrites: string[] } {
+  opts: {
+    draftMode?: boolean;
+    signoffAuthority?: "human" | "critic" | "either";
+    /** Injected worktree-branch reconcile: `resolveGitState` calls it on a "none" result
+     *  to adopt a renamed branch and retry. Absent (default) → reconcile is a no-op. */
+    syncBranch?: (id: string) => string | null;
+  } = {},
+): AppDeps & {
+  emitted: { event: string; data: unknown }[];
+  cacheWrites: string[];
+  /** The live cache map, exposed so a test can pre-seed a prior state (e.g. an already
+   *  cached open PR) and assert observable mutation after a GET write-through. */
+  snap: Record<string, GitState>;
+} {
   const store: Partial<SessionStore> = {
     get: (id) => (session && id === session.id ? session : null),
     getRepoConfig: () =>
@@ -113,16 +125,24 @@ function makeDeps(
   const emitted: { event: string; data: unknown }[] = [];
   const cacheWrites: string[] = [];
   const snap: Record<string, GitState> = {};
+  // Observable store (not just a write-log): `set` mutates `snap` so a later `get`
+  // reflects it — lets a second GET see the first's write-through and stay silent.
   const prCache: PrCache = {
     snapshot: () => snap,
     get: (id: string) => snap[id],
-    set: (id: string) => cacheWrites.push(id),
-    drop: (id: string) => cacheWrites.push(`drop:${id}`),
+    set: (id: string, git: GitState) => {
+      snap[id] = git;
+      cacheWrites.push(id);
+    },
+    drop: (id: string) => {
+      delete snap[id];
+      cacheWrites.push(`drop:${id}`);
+    },
   };
   return Object.assign(
     {
       store: store as SessionStore,
-      service: {} as SessionService,
+      service: { syncWorktreeBranch: opts.syncBranch } as unknown as SessionService,
       events: {
         emit: (event: string, data: unknown) => emitted.push({ event, data }),
       } as unknown as EventHub,
@@ -130,7 +150,7 @@ function makeDeps(
       resolveForge: () => forge,
       prCache,
     },
-    { emitted, cacheWrites },
+    { emitted, cacheWrites, snap },
   );
 }
 
@@ -173,6 +193,9 @@ test("GET git drops a merged PR whose head isn't on the session's branch (name c
   const body = await res.json();
   expect(body.state).toBe("none");
   expect(body.number).toBeUndefined();
+  // The guarded-to-none collision is a no-PR result for an uncached session → no write-through.
+  expect(deps.cacheWrites).toEqual([]);
+  expect(deps.emitted.filter((e) => e.event === "session:git")).toHaveLength(0);
 });
 
 test("GET git keeps a merged PR owned by the session's branch", async () => {
@@ -191,6 +214,80 @@ test("GET git keeps a merged PR owned by the session's branch", async () => {
   const body = await res.json();
   expect(body.state).toBe("merged");
   expect(body.number).toBe(5);
+});
+
+// ── GET write-through: the live git-rail fetch feeds the card's cache (issue: card shows
+//    no PR while the detail view does). resolveGitState now caches + emits session:git on a
+//    meaningful change, and reconciles a renamed branch first. ───────────────────────────
+const gitEvents = (deps: { emitted: { event: string; data: unknown }[] }) =>
+  deps.emitted.filter((e) => e.event === "session:git");
+
+test("GET git write-through surfaces an open PR into the cache and emits session:git", async () => {
+  const deps = makeDeps(fakeForge()); // default prStatus → open #5
+  const app = makeApp(deps);
+  const res = await app.fetch(new Request("http://localhost/api/sessions/s1/git"));
+  expect((await res.json()).state).toBe("open");
+  expect(deps.cacheWrites).toEqual(["s1"]);
+  expect(deps.snap.s1?.state).toBe("open");
+  expect(gitEvents(deps)).toHaveLength(1);
+  expect(gitEvents(deps)[0]!.data).toMatchObject({ id: "s1", git: { state: "open", number: 5 } });
+});
+
+test("GET git write-through: an unchanged repoll neither re-writes nor re-emits", async () => {
+  const deps = makeDeps(fakeForge());
+  const app = makeApp(deps);
+  await app.fetch(new Request("http://localhost/api/sessions/s1/git"));
+  await app.fetch(new Request("http://localhost/api/sessions/s1/git"));
+  expect(deps.cacheWrites).toEqual(["s1"]); // only the first GET wrote
+  expect(gitEvents(deps)).toHaveLength(1); // and only the first emitted
+});
+
+test("GET git write-through: a no-PR none for an uncached session stays silent", async () => {
+  const f = fakeForge({
+    prStatus: async () => ({ state: "none", checks: "none", deployConfigured: true }),
+  });
+  const deps = makeDeps(f);
+  const app = makeApp(deps);
+  const res = await app.fetch(new Request("http://localhost/api/sessions/s1/git"));
+  expect((await res.json()).state).toBe("none");
+  expect(deps.cacheWrites).toEqual([]);
+  expect(gitEvents(deps)).toHaveLength(0);
+});
+
+test("GET git write-through: clears a stale cached PR once the PR is genuinely gone", async () => {
+  const f = fakeForge({
+    prStatus: async () => ({ state: "none", checks: "none", deployConfigured: true }),
+  });
+  const deps = makeDeps(f);
+  deps.snap.s1 = { kind: "gitea", state: "open", number: 5, checks: "success" } as GitState;
+  const app = makeApp(deps);
+  const res = await app.fetch(new Request("http://localhost/api/sessions/s1/git"));
+  expect((await res.json()).state).toBe("none");
+  expect(deps.snap.s1?.state).toBe("none");
+  expect(gitEvents(deps)).toHaveLength(1);
+  expect(gitEvents(deps)[0]!.data).toMatchObject({ id: "s1", git: { state: "none" } });
+});
+
+test("GET git write-through: reconciles a renamed branch and surfaces its PR", async () => {
+  const heads: string[] = [];
+  const f = fakeForge({
+    prStatus: async (head: string) => {
+      heads.push(head);
+      return head === "shepherd/renamed"
+        ? { state: "open", number: 7, checks: "pending", deployConfigured: true }
+        : { state: "none", checks: "none", deployConfigured: true };
+    },
+  });
+  const deps = makeDeps(f, SESSION, { syncBranch: () => "shepherd/renamed" });
+  const app = makeApp(deps);
+  const res = await app.fetch(new Request("http://localhost/api/sessions/s1/git"));
+  const body = await res.json();
+  expect(body.state).toBe("open");
+  expect(body.number).toBe(7);
+  // stored branch tried first, then the reconciled live branch.
+  expect(heads).toEqual(["shepherd/add-feature", "shepherd/renamed"]);
+  expect(deps.snap.s1?.number).toBe(7);
+  expect(gitEvents(deps)).toHaveLength(1);
 });
 
 test("GET git → 404 when no forge for repo", async () => {


### PR DESCRIPTION
## Problem

A session's **card** in the herd list showed **no PR badge**, even though the same session's **detail view showed the PR** (reported with a card blank while the terminal read `PR #1534`).

## Root cause

PR state isn't on the `Session` object — it lives in a separate `GitState`, and the two surfaces read it from **different sources**:

| Surface | Source | Writes `prCache`? |
| --- | --- | --- |
| Session card | `store.git[id]` — `GET /api/git` snapshot of `prCache` + `session:git` WS pushes (filled **only** by the background `PrPoller`) | reader |
| Detail git-rail | its own live `GET /api/sessions/:id/git` → `resolveGitState`, polled ~15s | **NO — the bug** |

`resolveGitState` ran a fresh, trust-guarded `gh` lookup on every call but **never wrote back to `prCache` nor emitted `session:git`** — a read-only side channel the card's cache never saw. It also (unlike the poller's `statusPerSession`) never reconciled a **renamed** worktree branch, so it could itself return `none` for a session whose PR is real but under a branch the stored `session.branch` no longer names.

## Fix (server-side; no UI change)

1. **`resolveGitState` now reconciles a renamed branch** — on a `none` result it adopts the live worktree branch via `service.syncWorktreeBranch(id)` and retries under the same trust guard, mirroring the poller. This makes a resolved `none` **authoritative**.
2. **`forgeGitStateResponse` writes through + emits** — after resolving, it `prCache.set` + emits `session:git` when the result is *meaningful* (`state !== "none"`, **or** it clears a PR that was really cached) **and** actually changed (`gitStateChanged`, the poller's own gate). So it **surfaces** a PR the poller missed and **clears** one that's genuinely gone, but never emits a no-PR `none` for a session that never had one.

The card updates reactively through the existing `session:git` store handler — no UI change.

### Bounded emits / non-UI subscribers
`session:git` also drives `sessionRouter.onGit` (critic), `autoMerge.onGit`, `draftReconcile.onGit`, and `holdService.recompute`. Because the emit is gated on a genuine `gitStateChanged` over the **shared** `prCache`, whichever of the GET path / poller writes first flips the gate and the other stays silent → at most one emit per real change; repeated 15s git-rail polls of an unchanged PR are quiet.

### Known residual (documented, self-healing)
If `worktree.currentBranch` transiently fails during a GET reconcile while the poller holds a correct open PR, the GET could resolve `none` and briefly clear the card — re-surfaced within ≤15s by the poller's fast tick. Eliminating it fully would require changing `syncWorktreeBranch`'s contract (unchanged vs. unknown); out of scope.

## Verification
The live `/api/sessions/:id/git` endpoint sits behind the authenticated port, so rather than manufacture the exact transient state against the running instance, both sub-paths are verified reproducibly through the GET handler in `test/server-git.test.ts`:

- **Direct hit:** open PR + empty cache → cached + one `session:git` emit.
- **Reconcile:** stored branch `none`, live branch has the PR → adopted + surfaced.

## Testing
- `test/server-git.test.ts` — 6 write-through cases (surface, idempotent repoll, silent `none`, clear stale PR, renamed-branch reconcile, collision-guard regression). 36 pass.
- Regression across `resolveGitState`/`session:git` consumers: `server-review-pr`, `server-actions`, `pr-poller`, `cross-consumer-snapshot`, `automerge`, `resume-serialize`, `draft-reconcile`, `hold-service` — all green.
- `bun run typecheck` and `bun run lint` clean.