### PR TITLE
feat(ui): show issue author and filter issues by author and label

### DIFF
--- a/src/forge/gitea.ts
+++ b/src/forge/gitea.ts
@@ -129,6 +129,7 @@ export class GiteaForge implements GitForge {
       labels?: Array<{ name: string }>;
       created_at?: string;
       assignees?: Array<{ login?: string }> | null;
+      user?: { login?: string } | null;
     }>;
     return (raw ?? []).map((i) => {
       const ts = Date.parse(i.created_at ?? "");
@@ -142,6 +143,9 @@ export class GiteaForge implements GitForge {
         // Gitea serializes a user's canonical name as `login` (matches the PR-author
         // mapping above); drop any null/unnamed assignee defensively.
         assignees: (i.assignees ?? []).map((a) => a.login).filter((l): l is string => !!l),
+        // The issue's author (`user.login`) — surfaced in the UI's "by {login}" row text and
+        // author filter, mirroring GitHub's listIssues author mapping.
+        author: i.user?.login || undefined,
       };
     });
   }

--- a/test/forge/gitea.test.ts
+++ b/test/forge/gitea.test.ts
@@ -297,6 +297,7 @@ test("GiteaForge.listIssues: maps gitea issues, filters out PRs via type=issues"
           labels: [{ name: "bug" }, { name: "p1" }],
           created_at: GITEA_ISSUE_CREATED_AT,
           assignees: [{ login: "alice" }, { login: "bob" }],
+          user: { login: "carol" },
         },
         {
           number: 4,
@@ -321,6 +322,7 @@ test("GiteaForge.listIssues: maps gitea issues, filters out PRs via type=issues"
       labels: ["bug", "p1"],
       createdAt: Date.parse(GITEA_ISSUE_CREATED_AT),
       assignees: ["alice", "bob"],
+      author: "carol",
     },
     {
       number: 4,

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2764,5 +2764,12 @@
   "feat_preview_open_mode_body": "Pro Repository können Vorschau-Chips jetzt inline, in einem neuen Browser-Tab oder mit Nachfrage geöffnet werden.",
   "preview_open_mode_ask": "Immer nachfragen",
   "preview_open_mode_inline": "Inline-Vorschau",
-  "preview_open_mode_tab": "Neuer Browser-Tab"
+  "preview_open_mode_tab": "Neuer Browser-Tab",
+  "issues_filter_author_heading": "Autor",
+  "issues_filter_author_all": "Alle Autoren",
+  "issues_filter_labels_heading": "Labels",
+  "issues_filter_no_match": "keine Issues entsprechen den aktiven Filtern",
+  "issuerow_author_by": "von {login}",
+  "feat_issue_author_label_filter_title": "Issues nach Autor und Label filtern",
+  "feat_issue_author_label_filter_body": "Issue-Listen zeigen jetzt den Autor jedes Issues, und das Filter-Menü kann den Backlog nach Autor und Label eingrenzen — wähle einen Autor oder schalte ein oder mehrere Labels an, um die Liste zu fokussieren."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2764,5 +2764,12 @@
   "feat_preview_open_mode_body": "Each repo can now open Preview chips inline, in a new browser tab, or ask each time.",
   "preview_open_mode_ask": "Always ask",
   "preview_open_mode_inline": "Inline preview",
-  "preview_open_mode_tab": "New browser tab"
+  "preview_open_mode_tab": "New browser tab",
+  "issues_filter_author_heading": "Author",
+  "issues_filter_author_all": "All authors",
+  "issues_filter_labels_heading": "Labels",
+  "issues_filter_no_match": "no issues match the active filters",
+  "issuerow_author_by": "by {login}",
+  "feat_issue_author_label_filter_title": "Filter issues by author and label",
+  "feat_issue_author_label_filter_body": "Issue lists now show each issue's author, and the Filters menu can narrow the backlog by author and by label — pick an author or toggle one or more labels to focus the list."
 }

--- a/ui/src/lib/components/IssueFilterPopover.browser.test.ts
+++ b/ui/src/lib/components/IssueFilterPopover.browser.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render } from "vitest-browser-svelte";
 import "../../app.css";
 import { m } from "$lib/paraglide/messages";
@@ -225,5 +225,120 @@ describe("IssueFilterPopover", () => {
 
     // Focus must be restored to the trigger button.
     expect(document.activeElement).toBe(triggerBtn());
+  });
+});
+
+// ── Author + label filter sections ─────────────────────────────────────────────
+// Helpers scoped to the picker sections.
+const authorSection = () =>
+  popoverPanel()?.querySelector("[role='radiogroup']") as HTMLElement | null;
+const authorRadioFor = (login: string) =>
+  [...(authorSection()?.querySelectorAll(".author-row") ?? [])]
+    .find((row) => row.querySelector(".row-label")?.textContent?.trim() === login)
+    ?.querySelector<HTMLInputElement>("input[type=radio]") ?? null;
+const labelToggles = () =>
+  [...(popoverPanel()?.querySelectorAll(".label-toggle") ?? [])] as HTMLButtonElement[];
+const labelToggleFor = (label: string) =>
+  labelToggles().find((b) => b.textContent?.trim() === label) ?? null;
+
+async function open(props: Record<string, unknown>) {
+  render(IssueFilterPopover, props);
+  await expect.poll(() => triggerBtn()).toBeTruthy();
+  triggerBtn()!.click();
+  await expect.poll(() => isOpen()).toBe(true);
+}
+
+describe("IssueFilterPopover — author + label pickers", () => {
+  it("defaults: neither the author nor the label section renders when no options are passed", async () => {
+    await open({ showMine: true });
+    expect(authorSection()).toBeNull();
+    expect(labelToggles().length).toBe(0);
+  });
+
+  it("author section: renders 'All authors' + one radio per author when >=2 authors", async () => {
+    await open({ showMine: true, authors: ["kai", "scoop"] });
+    expect(authorSection()).toBeTruthy();
+    const radios = authorSection()!.querySelectorAll("input[type=radio]");
+    // All authors + kai + scoop.
+    expect(radios.length).toBe(3);
+    expect(authorRadioFor(m.issues_filter_author_all())).toBeTruthy();
+    expect(authorRadioFor("kai")).toBeTruthy();
+    expect(authorRadioFor("scoop")).toBeTruthy();
+  });
+
+  it("author section is hidden below two authors when nothing is selected", async () => {
+    await open({ showMine: true, authors: ["kai"], selectedAuthor: null });
+    expect(authorSection()).toBeNull();
+  });
+
+  it("author: the selected author's radio is checked; 'All authors' is checked when none selected", async () => {
+    await open({ showMine: true, authors: ["kai", "scoop"], selectedAuthor: "scoop" });
+    expect(authorRadioFor("scoop")!.checked).toBe(true);
+    expect(authorRadioFor(m.issues_filter_author_all())!.checked).toBe(false);
+  });
+
+  it("author callbacks: picking an author fires onauthor(login); 'All authors' fires onauthor(null)", async () => {
+    const onauthor = vi.fn();
+    await open({ showMine: true, authors: ["kai", "scoop"], selectedAuthor: "kai", onauthor });
+
+    authorRadioFor("scoop")!.click();
+    await expect.poll(() => onauthor).toHaveBeenCalledWith("scoop");
+
+    authorRadioFor(m.issues_filter_author_all())!.click();
+    await expect.poll(() => onauthor).toHaveBeenCalledWith(null);
+  });
+
+  it("refresh regression: a still-selected author keeps its clearable section when the option set shrinks to one", async () => {
+    // A same-repo refresh removed the other author but kept 'kai', so availableAuthors is
+    // now just ["kai"] — below the >=2 threshold. Because selectedAuthor stays set, the
+    // section must remain rendered and clearable via 'All authors'.
+    const onauthor = vi.fn();
+    await open({ showMine: true, authors: ["kai"], selectedAuthor: "kai", onauthor });
+
+    expect(authorSection()).toBeTruthy();
+    expect(authorRadioFor("kai")!.checked).toBe(true);
+
+    authorRadioFor(m.issues_filter_author_all())!.click();
+    await expect.poll(() => onauthor).toHaveBeenCalledWith(null);
+  });
+
+  it("label section: chips render with aria-pressed reflecting selectedLabels", async () => {
+    await open({ showMine: true, labels: ["BUG", "DOCS"], selectedLabels: ["BUG"] });
+    expect(labelToggles().length).toBe(2);
+    expect(labelToggleFor("BUG")!.getAttribute("aria-pressed")).toBe("true");
+    expect(labelToggleFor("DOCS")!.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("label callback: clicking a chip fires ontogglelabel(label)", async () => {
+    const ontogglelabel = vi.fn();
+    await open({ showMine: true, labels: ["BUG", "DOCS"], selectedLabels: [], ontogglelabel });
+
+    labelToggleFor("DOCS")!.click();
+    await expect.poll(() => ontogglelabel).toHaveBeenCalledWith("DOCS");
+  });
+
+  it("active count includes the selected author and every selected label", async () => {
+    // Default store (mine + subs) = 2, + author (1) + labels (2) = 5.
+    await open({
+      showMine: true,
+      authors: ["kai", "scoop"],
+      selectedAuthor: "kai",
+      labels: ["BUG", "DOCS"],
+      selectedLabels: ["BUG", "DOCS"],
+    });
+    expect(badgeText()).toBe("5");
+  });
+
+  it("focus on open still lands on the first boolean checkbox, not a radio, with sections present", async () => {
+    await open({
+      showMine: true,
+      authors: ["kai", "scoop"],
+      selectedAuthor: "kai",
+      labels: ["BUG"],
+      selectedLabels: ["BUG"],
+    });
+    // Let the focus-on-open setTimeout(0) settle.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(document.activeElement).toBe(checkboxes()[0]);
   });
 });

--- a/ui/src/lib/components/IssueFilterPopover.svelte
+++ b/ui/src/lib/components/IssueFilterPopover.svelte
@@ -6,7 +6,38 @@
 
   // showMine: when false the "mine & unassigned" row is NOT rendered (viewer unknown).
   // coachTargets: when true, the trigger carries use:coachTarget={"issue-filters"}.
-  let { showMine, coachTargets = false }: { showMine: boolean; coachTargets?: boolean } = $props();
+  // authors/labels: distinct option sets for the repo-scoped author + label filters
+  //   (computed by the parent from the raw issue list). selectedAuthor/selectedLabels are
+  //   the current selection; the parent owns the state and mutates it via the callbacks.
+  //   All optional — omitted (empty) → neither section renders, so existing callers are
+  //   unaffected.
+  let {
+    showMine,
+    coachTargets = false,
+    authors = [],
+    labels = [],
+    selectedAuthor = null,
+    selectedLabels = [],
+    onauthor = undefined,
+    ontogglelabel = undefined,
+  }: {
+    showMine: boolean;
+    coachTargets?: boolean;
+    authors?: string[];
+    labels?: string[];
+    selectedAuthor?: string | null;
+    selectedLabels?: string[];
+    onauthor?: (author: string | null) => void;
+    ontogglelabel?: (label: string) => void;
+  } = $props();
+
+  // Show the Author section at >=2 authors OR whenever a selection is set — the OR-guard
+  // keeps a still-valid author selection clearable when a refresh shrinks the option set to
+  // one (an absent selection is pruned upstream, so a non-null selectedAuthor is always in
+  // `authors`). The Labels section needs no such guard: its >=1 threshold can't hide a
+  // still-present selected label (an absent one is pruned upstream).
+  const showAuthorSection = $derived(authors.length >= 2 || selectedAuthor != null);
+  const showLabelSection = $derived(labels.length >= 1);
 
   // SSR-stable per-instance id for aria-controls wiring.
   const popoverId = $props.id();
@@ -17,11 +48,14 @@
   let popEl = $state<HTMLDivElement | null>(null);
 
   // Active count — gates mine toggle on showMine so a persisted hideOthers=true
-  // doesn't inflate the badge when the mine row isn't shown.
+  // doesn't inflate the badge when the mine row isn't shown. The author + label filters
+  // add one each per active selection (author = 0/1, labels = count).
   const activeCount = $derived(
     (showMine && issuesFilter.hideOthers ? 1 : 0) +
       (issuesFilter.hideActive ? 1 : 0) +
-      (issuesFilter.hideSubIssues ? 1 : 0),
+      (issuesFilter.hideSubIssues ? 1 : 0) +
+      (selectedAuthor != null ? 1 : 0) +
+      selectedLabels.length,
   );
 
   // Position the popover below the trigger whenever open + both elements exist.
@@ -149,6 +183,53 @@
       <span class="row-desc">{m.issues_filter_subissues_title()}</span>
     </span>
   </label>
+
+  {#if showAuthorSection}
+    <div class="section-divider" role="separator"></div>
+    <div class="section" role="radiogroup" aria-label={m.issues_filter_author_heading()}>
+      <div class="section-heading">{m.issues_filter_author_heading()}</div>
+      <label class="filter-row author-row">
+        <input
+          type="radio"
+          name="issue-author-filter-{popoverId}"
+          checked={selectedAuthor == null}
+          onchange={() => onauthor?.(null)}
+        />
+        <span class="row-label">{m.issues_filter_author_all()}</span>
+      </label>
+      {#each authors as author (author)}
+        <label class="filter-row author-row">
+          <input
+            type="radio"
+            name="issue-author-filter-{popoverId}"
+            checked={selectedAuthor === author}
+            onchange={() => onauthor?.(author)}
+          />
+          <span class="row-label author-login">{author}</span>
+        </label>
+      {/each}
+    </div>
+  {/if}
+
+  {#if showLabelSection}
+    <div class="section-divider" role="separator"></div>
+    <div class="section">
+      <div class="section-heading" id="issue-label-heading-{popoverId}">
+        {m.issues_filter_labels_heading()}
+      </div>
+      <div class="label-chips" role="group" aria-labelledby="issue-label-heading-{popoverId}">
+        {#each labels as label (label)}
+          {@const on = selectedLabels.includes(label)}
+          <button
+            type="button"
+            class={["label-toggle", { on }]}
+            aria-pressed={on}
+            onclick={() => ontogglelabel?.(label)}>{label}</button
+          >
+        {/each}
+      </div>
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -217,6 +298,10 @@
     margin: 0;
     min-width: 240px;
     max-width: min(320px, 90vw);
+    /* Cap the height so a label-/author-heavy repo scrolls the picker instead of
+       overflowing the viewport. */
+    max-height: min(70vh, 460px);
+    overflow-y: auto;
     padding: 8px 0;
     background: var(--color-inset);
     border: 1px solid var(--color-line);
@@ -279,5 +364,91 @@
     color: var(--color-muted);
     font-size: var(--fs-micro);
     line-height: 1.4;
+  }
+
+  /* Author + label filter sections, separated from the boolean toggles by a hairline. */
+  .section-divider {
+    height: 1px;
+    margin: 6px 12px;
+    background: var(--color-line);
+  }
+
+  .section {
+    padding: 0 12px;
+  }
+
+  .section-heading {
+    font-family: var(--font-mono);
+    font-size: var(--fs-micro);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--color-faint);
+    padding: 2px 0 4px;
+  }
+
+  /* Single-line radio rows for the author picker — tighter than the two-line boolean
+     rows above; overrides .filter-row's flex-start/padding. */
+  .author-row {
+    align-items: center;
+    gap: 8px;
+    padding: 3px 0;
+    margin: 0 -12px; /* full-width hover, re-inset by padding below */
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+
+  .author-row input[type="radio"] {
+    flex-shrink: 0;
+    cursor: pointer;
+  }
+
+  /* Logins are mixed-case — keep them verbatim (no uppercasing). */
+  .author-login {
+    font-family: var(--font-mono);
+  }
+
+  .label-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding: 2px 0 4px;
+  }
+
+  .label-toggle {
+    font-family: var(--font-mono);
+    font-size: var(--fs-micro);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    padding: 1px 6px;
+    cursor: pointer;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    transition:
+      color 0.12s,
+      border-color 0.12s,
+      background 0.12s;
+  }
+
+  .label-toggle:hover {
+    color: var(--color-ink);
+    border-color: var(--color-line-bright);
+  }
+
+  /* Selected label — amber accent matches the other "active filter" affordances. */
+  .label-toggle.on {
+    color: var(--color-amber);
+    border-color: var(--color-amber);
+    background: color-mix(in srgb, var(--color-amber) 14%, transparent);
+  }
+
+  .label-toggle:focus-visible {
+    outline: 2px solid var(--color-line-bright);
+    outline-offset: 1px;
   }
 </style>

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -11,6 +11,10 @@
     hideActive,
     hideSubIssues,
     sortEpicsFirst,
+    filterByAuthor,
+    filterByLabels,
+    distinctAuthors,
+    distinctLabels,
   } from "./issues-panel";
   import { issuesFilter } from "$lib/issues-filter.svelte";
   import { backlogRefresh } from "$lib/backlog-refresh.svelte";
@@ -64,6 +68,14 @@
   // PromptSources — distinguishes "couldn't load" from "no open issues".
   let loadError = $state(false);
   let filter = $state("");
+  // Repo-scoped author + label filters. Selection is local (not the global issuesFilter
+  // store) because the option sets are repo-specific; reset on repo change and pruned on
+  // refresh (see the reconcile effect below). Options are derived from the RAW `issues`
+  // list so picking one value doesn't drop the others from the picker.
+  let selectedAuthor = $state<string | null>(null);
+  const selectedLabels = new SvelteSet<string>();
+  let availableAuthors = $derived(distinctAuthors(issues));
+  let availableLabels = $derived(distinctLabels(issues));
   // Epic summaries for this repo: number → EpicSummary.
   let epicByNumber = $state<Map<number, EpicSummary>>(new Map());
   let nativeSubIssues = $state<Set<number>>(new Set());
@@ -95,6 +107,30 @@
       epicParentNums,
     ),
   );
+  // Author + label filters (repo-scoped), applied AFTER the toggle filters and BEFORE the
+  // text search. Kept as a named intermediate so the empty-state block can attribute a miss
+  // to the structured filters (this being empty) vs. the text search (this non-empty but
+  // visibleIssues empty).
+  let authorLabelFiltered = $derived(
+    filterByLabels(filterByAuthor(subFiltered, selectedAuthor), selectedLabels),
+  );
+
+  // Prune any selected author/label that a refresh removed from the current issue set.
+  // Without this, an absent-but-selected value keeps filtering while its picker entry is
+  // gone (the popover only renders present options), stranding the list unclearable. Keyed
+  // on the derived option sets (which depend on `issues`, not on the selection), so it can't
+  // loop; writes are untracked. A still-present selection that merely drops the author list
+  // below the popover's >=2 threshold is handled there (the section stays rendered).
+  $effect(() => {
+    const authors = availableAuthors;
+    const labels = availableLabels;
+    untrack(() => {
+      if (selectedAuthor != null && !authors.includes(selectedAuthor)) selectedAuthor = null;
+      for (const label of [...selectedLabels]) {
+        if (!labels.includes(label)) selectedLabels.delete(label);
+      }
+    });
+  });
   // Epic parents float to the top of the backlog (stable within each group), so
   // epics are the first thing the operator sees. Applied after text filtering.
   //
@@ -106,9 +142,9 @@
   // "" from the repo-change reset); sortEpicsFirst then pins it to the top once epics settle.
   let visibleIssues = $derived.by(() => {
     const base =
-      expandEpic != null && !subFiltered.some((i) => i.number === expandEpic)
-        ? [...issues.filter((i) => i.number === expandEpic), ...subFiltered]
-        : subFiltered;
+      expandEpic != null && !authorLabelFiltered.some((i) => i.number === expandEpic)
+        ? [...issues.filter((i) => i.number === expandEpic), ...authorLabelFiltered]
+        : authorLabelFiltered;
     return sortEpicsFirst(filterIssues(base, filter), epicParentNums);
   });
   // True when there ARE open issues but the assignee filter hid them all — drives
@@ -152,6 +188,8 @@
     loading = true;
     loadError = false;
     filter = "";
+    selectedAuthor = null;
+    selectedLabels.clear();
     expanded.clear();
     defaultEpicSeeded = false;
     epicByNumber = new Map();
@@ -354,6 +392,17 @@
     }
   });
 
+  /** Author filter: null clears it (radio "All authors"). */
+  function pickAuthor(author: string | null) {
+    selectedAuthor = author;
+  }
+
+  /** Label filter: toggle a label in/out of the AND-set. */
+  function toggleLabel(label: string) {
+    if (selectedLabels.has(label)) selectedLabels.delete(label);
+    else selectedLabels.add(label);
+  }
+
   /** Expand an epic's panel; the backfill effect above fetches it if needed. */
   function expandEpicRow(number: number) {
     expanded.add(number);
@@ -438,7 +487,16 @@
           placeholder={m.issuespanel_filter_placeholder()}
           aria-label={m.issuespanel_filter_placeholder()}
         />
-        <IssueFilterPopover showMine={viewer != null} coachTargets />
+        <IssueFilterPopover
+          showMine={viewer != null}
+          coachTargets
+          authors={availableAuthors}
+          labels={availableLabels}
+          {selectedAuthor}
+          selectedLabels={[...selectedLabels]}
+          onauthor={pickAuthor}
+          ontogglelabel={toggleLabel}
+        />
       </div>
       <!-- Only surface an empty-state reason when the rendered list is truly empty: a
            force-included navigated-to epic (Fix B) keeps visibleIssues non-empty, so a
@@ -450,6 +508,10 @@
           <div class="muted">{m.issues_filter_all_in_progress()}</div>
         {:else if allHiddenBySubIssues}
           <div class="muted">{m.issues_filter_all_sub_issues()}</div>
+        {:else if authorLabelFiltered.length === 0}
+          <!-- Structured author/label filters emptied it (even if a search term is also
+               present) — a generic filter miss, not the search-specific copy. -->
+          <div class="muted">{m.issues_filter_no_match()}</div>
         {:else}
           <div class="muted">{m.issuespanel_no_match()}</div>
         {/if}

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -1,9 +1,19 @@
 <script lang="ts">
   import { untrack } from "svelte";
+  import { SvelteSet } from "svelte/reactivity";
   import { getTodo, listIssues, getCommands } from "$lib/api";
   import type { Issue, SlashCommand } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
-  import { hideOthers, hideActive, hideSubIssues, ACTIVE_LABEL } from "./issues-panel";
+  import {
+    hideOthers,
+    hideActive,
+    hideSubIssues,
+    filterByAuthor,
+    filterByLabels,
+    distinctAuthors,
+    distinctLabels,
+    ACTIVE_LABEL,
+  } from "./issues-panel";
   import { issuesFilter } from "$lib/issues-filter.svelte";
   import IssueFilterPopover from "./IssueFilterPopover.svelte";
 
@@ -40,15 +50,28 @@
   // with the viewer-agnostic "hide in progress" filter; the explicit
   // assigneeFiltered intermediate lets each empty state be attributed to the
   // filter that caused it.
+  // Repo-scoped author + label filters (shared UI recipe with IssuesPanel). Selection is
+  // local, reset on repo change and pruned on refresh (see the effects below); options are
+  // derived from the RAW `issues` list so picking one value doesn't drop the others.
+  let selectedAuthor = $state<string | null>(null);
+  const selectedLabels = new SvelteSet<string>();
+  let availableAuthors = $derived(distinctAuthors(issues));
+  let availableLabels = $derived(distinctLabels(issues));
   let assigneeFiltered = $derived(hideOthers(issues, viewer, issuesFilter.hideOthers));
   let activeFiltered = $derived(hideActive(assigneeFiltered, issuesFilter.hideActive));
-  let visibleIssues = $derived(
+  // Toggle-filtered set (mine → active → sub-issue), BEFORE the author/label filters.
+  // allHiddenBySubIssues keys off this intermediate so its attribution isn't stolen by an
+  // author/label miss downstream.
+  let subFiltered = $derived(
     hideSubIssues(
       activeFiltered,
       issuesFilter.hideSubIssues && epicsLoaded,
       nativeSubIssues,
       epicParents,
     ),
+  );
+  let visibleIssues = $derived(
+    filterByLabels(filterByAuthor(subFiltered, selectedAuthor), selectedLabels),
   );
   let allHiddenByAssignee = $derived(
     issues.length > 0 && assigneeFiltered.length === 0 && viewer != null && issuesFilter.hideOthers,
@@ -64,7 +87,7 @@
     !allHiddenByAssignee &&
       !allHiddenByActive &&
       activeFiltered.length > 0 &&
-      visibleIssues.length === 0 &&
+      subFiltered.length === 0 &&
       issuesFilter.hideSubIssues &&
       epicsLoaded,
   );
@@ -90,6 +113,11 @@
     const rp = repoPath;
     hasTodo = null;
     todos = [];
+    // Repo-scoped author/label selection resets on repo change (its option sets are
+    // repo-specific). Keyed on repoPath here (not the tab/issues fetch), so switching tabs
+    // never clears an active filter.
+    selectedAuthor = null;
+    selectedLabels.clear();
     if (!rp) return;
     getTodo(rp)
       .then((r) => {
@@ -166,6 +194,31 @@
   $effect(() => {
     if (tab === "commands" && !loading) filterInput?.focus();
   });
+
+  // Prune any selected author/label a refresh removed from the current set (mirrors
+  // IssuesPanel), so an absent-but-selected value can't keep filtering while its picker
+  // entry is gone. Keyed on the option sets (which depend on `issues`, not the selection).
+  $effect(() => {
+    const authors = availableAuthors;
+    const labels = availableLabels;
+    untrack(() => {
+      if (selectedAuthor != null && !authors.includes(selectedAuthor)) selectedAuthor = null;
+      for (const label of [...selectedLabels]) {
+        if (!labels.includes(label)) selectedLabels.delete(label);
+      }
+    });
+  });
+
+  /** Author filter: null clears it (radio "All authors"). */
+  function pickAuthor(author: string | null) {
+    selectedAuthor = author;
+  }
+
+  /** Label filter: toggle a label in/out of the AND-set. */
+  function toggleLabel(label: string) {
+    if (selectedLabels.has(label)) selectedLabels.delete(label);
+    else selectedLabels.add(label);
+  }
 </script>
 
 <div class="ps-wrap">
@@ -252,7 +305,15 @@
         <div class="muted">{m.common_no_open_issues()}</div>
       {:else}
         <div class="ps-filter-bar">
-          <IssueFilterPopover showMine={viewer != null} />
+          <IssueFilterPopover
+            showMine={viewer != null}
+            authors={availableAuthors}
+            labels={availableLabels}
+            {selectedAuthor}
+            selectedLabels={[...selectedLabels]}
+            onauthor={pickAuthor}
+            ontogglelabel={toggleLabel}
+          />
         </div>
         {#if allHiddenByAssignee}
           <div class="muted">{m.issues_filter_all_assigned_to_others()}</div>
@@ -260,6 +321,9 @@
           <div class="muted">{m.issues_filter_all_in_progress()}</div>
         {:else if allHiddenBySubIssues}
           <div class="muted">{m.issues_filter_all_sub_issues()}</div>
+        {:else if visibleIssues.length === 0}
+          <!-- Author/label filters emptied the list (no text search on this tab). -->
+          <div class="muted">{m.issues_filter_no_match()}</div>
         {/if}
         {#each visibleIssues as i (i.number)}
           {@const ordered = orderedLabels(i.labels)}
@@ -270,6 +334,7 @@
             <div class="row row-epic" aria-disabled="true" title={m.promptsources_epic_hint()}>
               <span class="issue-num">#{i.number}</span>
               <span class="row-text">{i.title}</span>
+              {@render issueAuthor(i.author)}
               <span class="chips">
                 <span class="chip chip-epic">{m.promptsources_epic_tag()}</span>
                 {@render labelChips(ordered)}
@@ -279,6 +344,7 @@
             <button class="row" type="button" onclick={() => onpickissue(i)}>
               <span class="issue-num">#{i.number}</span>
               <span class="row-text">{i.title}</span>
+              {@render issueAuthor(i.author)}
               {#if ordered.length > 0}
                 <span class="chips">{@render labelChips(ordered)}</span>
               {/if}
@@ -289,6 +355,12 @@
     {/if}
   </div>
 </div>
+
+{#snippet issueAuthor(login: string | undefined)}
+  {#if login}
+    <span class="issue-author">{m.issuerow_author_by({ login })}</span>
+  {/if}
+{/snippet}
 
 {#snippet labelChips(ordered: string[])}
   {#each ordered.slice(0, 1) as lbl (lbl)}
@@ -437,6 +509,18 @@
     color: var(--color-muted);
     flex-shrink: 0;
     font-size: var(--fs-meta);
+  }
+
+  /* Subtle "by {login}" author metadata — dimmed, sits between the title and the label
+     chips; shrinks/ellipsates before the title's min-width floor so it never crushes it. */
+  .issue-author {
+    flex-shrink: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--color-faint);
+    font-size: var(--fs-micro);
   }
 
   /* Search input fills the sticky .ps-filter-bar wrapper (which provides the

--- a/ui/src/lib/components/issues-panel.test.ts
+++ b/ui/src/lib/components/issues-panel.test.ts
@@ -12,6 +12,10 @@ import {
   hideActive,
   hideSubIssues,
   sortEpicsFirst,
+  distinctAuthors,
+  distinctLabels,
+  filterByAuthor,
+  filterByLabels,
   ACTIVE_LABEL,
 } from "./issues-panel";
 import type { Issue } from "$lib/types";
@@ -22,6 +26,7 @@ function issue(
   body = "",
   labels: string[] = [],
   assignees: string[] = [],
+  author?: string,
 ): Issue {
   return {
     number,
@@ -31,6 +36,7 @@ function issue(
     labels,
     createdAt: 0,
     assignees,
+    author,
   };
 }
 
@@ -191,6 +197,108 @@ describe("hideSubIssues", () => {
     const subs = new Set<number>([]);
     const parents = new Set<number>([2]);
     expect(hideSubIssues(all, true, subs, parents)).toEqual(all);
+  });
+});
+
+describe("distinctAuthors", () => {
+  it("returns unique author logins sorted case-insensitively", () => {
+    const list = [
+      issue(1, "A", "", [], [], "scoop"),
+      issue(2, "B", "", [], [], "Kai"),
+      issue(3, "C", "", [], [], "scoop"),
+    ];
+    expect(distinctAuthors(list)).toEqual(["Kai", "scoop"]);
+  });
+
+  it("ignores issues without an author", () => {
+    const list = [issue(1, "A", "", [], [], "kai"), issue(2, "B")];
+    expect(distinctAuthors(list)).toEqual(["kai"]);
+  });
+
+  it("returns an empty array when no issue has an author", () => {
+    expect(distinctAuthors([issue(1, "A"), issue(2, "B")])).toEqual([]);
+  });
+});
+
+describe("distinctLabels", () => {
+  it("returns unique labels sorted case-insensitively, excluding shepherd:active", () => {
+    const list = [
+      issue(1, "A", "", ["enhancement", ACTIVE_LABEL]),
+      issue(2, "B", "", ["Bug", "enhancement"]),
+    ];
+    expect(distinctLabels(list)).toEqual(["Bug", "enhancement"]);
+  });
+
+  it("returns an empty array when the only label is shepherd:active", () => {
+    expect(distinctLabels([issue(1, "A", "", [ACTIVE_LABEL])])).toEqual([]);
+  });
+
+  it("does not throw on a stale payload missing labels", () => {
+    const stale = {
+      number: 1,
+      title: "No labels field",
+      body: "",
+      url: "https://example.test/1",
+      createdAt: 0,
+      assignees: [],
+    } as unknown as Issue;
+    expect(() => distinctLabels([stale])).not.toThrow();
+    expect(distinctLabels([stale])).toEqual([]);
+  });
+});
+
+describe("filterByAuthor", () => {
+  const mine = issue(1, "Mine", "", [], [], "kai");
+  const theirs = issue(2, "Theirs", "", [], [], "scoop");
+  const authorless = issue(3, "Authorless");
+  const all = [mine, theirs, authorless];
+
+  it("keeps only issues by the selected author", () => {
+    expect(filterByAuthor(all, "kai")).toEqual([mine]);
+  });
+
+  it("drops authorless issues when a specific author is selected", () => {
+    expect(filterByAuthor(all, "scoop")).toEqual([theirs]);
+  });
+
+  it("is an identity filter when author is null", () => {
+    const result = filterByAuthor(all, null);
+    expect(result).toEqual(all);
+    expect(result).not.toBe(all); // new array, input not mutated
+  });
+});
+
+describe("filterByLabels", () => {
+  const bug = issue(1, "Bug", "", ["bug"]);
+  const bugAndDocs = issue(2, "Bug+Docs", "", ["bug", "docs"]);
+  const docs = issue(3, "Docs", "", ["docs"]);
+  const all = [bug, bugAndDocs, docs];
+
+  it("keeps issues carrying the single selected label", () => {
+    expect(filterByLabels(all, new Set(["bug"]))).toEqual([bug, bugAndDocs]);
+  });
+
+  it("requires ALL selected labels (AND semantics)", () => {
+    expect(filterByLabels(all, new Set(["bug", "docs"]))).toEqual([bugAndDocs]);
+  });
+
+  it("is an identity filter when the selection is empty", () => {
+    const result = filterByLabels(all, new Set());
+    expect(result).toEqual(all);
+    expect(result).not.toBe(all);
+  });
+
+  it("does not throw on a stale payload missing labels", () => {
+    const stale = {
+      number: 4,
+      title: "No labels field",
+      body: "",
+      url: "https://example.test/4",
+      createdAt: 0,
+      assignees: [],
+    } as unknown as Issue;
+    expect(() => filterByLabels([stale], new Set(["bug"]))).not.toThrow();
+    expect(filterByLabels([stale], new Set(["bug"]))).toEqual([]);
   });
 });
 

--- a/ui/src/lib/components/issues-panel.ts
+++ b/ui/src/lib/components/issues-panel.ts
@@ -30,6 +30,64 @@ export function filterIssues(issues: readonly Issue[], query: string): Issue[] {
 }
 
 /**
+ * Distinct author logins present in an issue list, sorted case-insensitively.
+ * Issues without an author (forges/paths that don't supply one) contribute nothing.
+ * Source for the author filter's radio options — computed from the RAW list so
+ * picking one author doesn't make the others vanish from the picker.
+ */
+export function distinctAuthors(issues: readonly Issue[]): string[] {
+  const seen = new Set<string>();
+  for (const issue of issues) {
+    if (issue.author) seen.add(issue.author);
+  }
+  return [...seen].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+}
+
+/**
+ * Distinct label names present in an issue list, sorted case-insensitively, EXCLUDING
+ * the `shepherd:active` system label (the dedicated "hide in progress" toggle already
+ * governs it, so it doesn't belong in the categorization picker). Source for the label
+ * filter's toggle chips — computed from the RAW list for the same reason as
+ * {@link distinctAuthors}.
+ */
+export function distinctLabels(issues: readonly Issue[]): string[] {
+  const seen = new Set<string>();
+  for (const issue of issues) {
+    for (const label of issue.labels ?? []) {
+      if (label !== ACTIVE_LABEL) seen.add(label);
+    }
+  }
+  return [...seen].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+}
+
+/**
+ * Narrow an issue list to a single author. Keeps issues whose `author` equals the
+ * selected login; a `null` selection is an identity filter (no author chosen). An issue
+ * with no author is dropped when a specific author is selected — correct, since it can't
+ * match. The `?? []`-free comparison is safe: `author` is a scalar, absent → undefined.
+ */
+export function filterByAuthor(issues: readonly Issue[], author: string | null): Issue[] {
+  if (author == null) return [...issues];
+  return issues.filter((issue) => issue.author === author);
+}
+
+/**
+ * Narrow an issue list to those carrying ALL selected labels (AND semantics, mirroring
+ * GitHub's multi-label filtering). An empty selection is an identity filter. The `?? []`
+ * guard tolerates a stale payload predating the `labels` field.
+ */
+export function filterByLabels(issues: readonly Issue[], selected: ReadonlySet<string>): Issue[] {
+  if (selected.size === 0) return [...issues];
+  return issues.filter((issue) => {
+    const labels = issue.labels ?? [];
+    for (const want of selected) {
+      if (!labels.includes(want)) return false;
+    }
+    return true;
+  });
+}
+
+/**
  * Narrow an issue list to "mine & unassigned" (#824): keep an issue when it has
  * no assignees OR the viewer is one of its assignees; drop issues assigned only
  * to other people.

--- a/ui/src/lib/components/issues-panel/IssueRow.svelte
+++ b/ui/src/lib/components/issues-panel/IssueRow.svelte
@@ -139,7 +139,7 @@
   {#if bodyPreview && issue.body}
     <div class="body-preview">{issue.body}</div>
   {/if}
-  {#if issue.labels.length > 0 || age || (showAssignees && issue.assignees.length > 0)}
+  {#if issue.labels.length > 0 || age || issue.author || (showAssignees && issue.assignees.length > 0)}
     <div class="label-row">
       {#if showAssignees}
         {#each issue.assignees as login (login)}
@@ -156,6 +156,9 @@
           >{label}</span
         >
       {/each}
+      {#if issue.author}
+        <span class="issue-author">{m.issuerow_author_by({ login: issue.author })}</span>
+      {/if}
       {#if age}
         <span class="age-chip">{relativeAge(issue.createdAt, clock.current)}</span>
       {/if}
@@ -316,6 +319,15 @@
     letter-spacing: 0.1em;
     color: var(--color-faint);
     padding: 1px 0;
+  }
+
+  /* Subtle "by {login}" author text — dimmed, no chip border, so it reads as metadata
+     alongside the age and distinct from the 👤 assignee chip. Logins are verbatim. */
+  .issue-author {
+    font-size: var(--fs-micro);
+    color: var(--color-faint);
+    padding: 1px 0;
+    white-space: nowrap;
   }
 
   .issue-actions {

--- a/ui/src/lib/feature-announcements/entries/v1.43.0-issue-author-label-filter.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.43.0-issue-author-label-filter.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "issue-author-label-filter",
+  sinceVersion: "1.43.0",
+  titleKey: "feat_issue_author_label_filter_title",
+  bodyKey: "feat_issue_author_label_filter_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -187,6 +187,10 @@ export interface Issue {
   /** GitHub/Gitea logins assigned to the issue (empty when unassigned). Drives the
    *  "mine & unassigned" filter (#824). */
   assignees: string[];
+  /** Login of the issue's author, when the forge supplies it (GitHub always; Gitea via
+   *  `user.login`). Absent on hosts/paths that don't fetch it. Surfaced as the "by {login}"
+   *  row text and drives the author filter. */
+  author?: string;
 }
 
 /** Subset of an Issue attached to a task by reference (body rides out-of-band). */


### PR DESCRIPTION
## Was

Zeigt bei jedem Issue den **Autor** an und ermöglicht **Filtern nach Autor und Label** — auf beiden Issue-Oberflächen: dem Backlog-**Issues**-Panel und dem **Neue-Aufgabe**-Picker.

> Labels waren bereits sichtbar (die `ENHANCEMENT`/`BOT-TRIAGED`-Chips) und die Suche matchte schon auf Labels. Neu sind daher die **Autor-Anzeige** und die **strukturierten Filter**.

## Änderungen

- **Autor-Anzeige:** dezenter „by {login}"-Text pro Issue (im Backlog-Row und im New-Task-Row), klar unterscheidbar vom 👤-Assignee-Chip.
- **Filter im „Filters"-Popover:**
  - **Autor** — Einfachauswahl (Radio: „All authors" + je Autor)
  - **Labels** — Mehrfachauswahl (Toggle-Chips, **UND**-Semantik)
  - beides fließt in den Aktiv-Zähler-Badge ein; Popover ist höhenbegrenzt + scrollbar.
- **Server:** GitHub liefert den Autor bereits; Gitea `listIssues` mappt nun `user.login` mit.
- **Volle Label-Sichtbarkeit** bleibt Sache des Backlog-`IssueRow` (alle Chips); der kompakte New-Task-Picker bleibt bewusst bei „erstes Label + `+N`" (alle Labels via `+N`-Tooltip und Label-Filter erreichbar).

## Robustheit (aus dem Plan-Review)

- Auswahl ist **panel-lokal**, Reset bei Repo-Wechsel; Optionen aus der **rohen** Issue-Liste.
- **Immer abwählbar nach Refresh:** eine *entfernte* Auswahl wird geprunt; eine *überlebende* Auswahl, deren Optionsmenge unter die `>= 2`-Schwelle der Autor-Sektion fällt, hält die Sektion sichtbar (`|| selectedAuthor != null`).
- **Empty-State nach Ursache:** ein Autor/Label-Miss zeigt generisches „no issues match the active filters" — auch wenn zugleich ein Suchbegriff gesetzt ist; nur ein reiner Text-Such-Miss zeigt die suchspezifische Copy.

## Tests / Checks

- Neue Unit-Tests für `distinctAuthors/Labels`, `filterByAuthor/Labels`.
- Neue `IssueFilterPopover`-Browser-Tests: Controls, Callbacks, Aktiv-Zähler, Defaults/Schwellen, Fokus **und die Refresh-Regression** (Auswahl bleibt abwählbar bei Schrumpfen auf einen Autor).
- Gitea-`listIssues`-Test um Autor-Mapping erweitert.
- Grün: root `bun run lint` + Forge/Server-Issues-Tests; UI `bun run check` (0 Fehler), `check:i18n` (EN+DE-Parität), voller UI-Test-Lauf (3150), `fallow audit`.

i18n (EN+DE) und ein What's-New-Eintrag (v1.43.0) sind enthalten.

## Hinweis

Der New-Task-`<template>` überschritt durch die Autor-Anzeige knapp die fallow-Kognitiv-Schwelle (60); die Autor-Ausgabe wurde daher in ein Snippet ausgelagert (wieder unter der Schwelle), ohne Verhaltensänderung.
