### PR TITLE
fix(buildqueue): make the awaiting-approval state unmistakable

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -950,6 +950,8 @@
   "feat_automerge_body": "Aktiviere Voll-Auto-Merge, damit Shepherd fertige PRs für dich mergt: vor jedem Merge wird auf main rebased und erneut geprüft, damit parallele Aufgaben sicher bleiben.",
   "buildqueue_panel_title": "Build-Queue",
   "buildqueue_empty": "Noch keine Schritte. Der Agent erstellt eine Queue, wenn er startet.",
+  "buildqueue_awaiting_chip": "Wartet auf deine Freigabe",
+  "buildqueue_awaiting_hint": "Der Agent pausiert hier. Prüfe die Schritte und gib sie mit Freigeben & ausführen frei.",
   "buildqueue_status_pending": "ausstehend",
   "buildqueue_status_active": "aktiv",
   "buildqueue_status_done": "erledigt",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -950,6 +950,8 @@
   "feat_automerge_body": "Turn on Full-auto merge to let Shepherd land ready PRs for you: it rebases onto main and re-verifies before every merge, so parallel tasks stay safe.",
   "buildqueue_panel_title": "Build queue",
   "buildqueue_empty": "No steps yet. The agent will author a queue when it starts.",
+  "buildqueue_awaiting_chip": "Awaiting your approval",
+  "buildqueue_awaiting_hint": "The agent paused here. Review the steps, then Approve & run to let it start.",
   "buildqueue_status_pending": "pending",
   "buildqueue_status_active": "active",
   "buildqueue_status_done": "done",

--- a/ui/src/lib/components/BuildQueuePanel.browser.test.ts
+++ b/ui/src/lib/components/BuildQueuePanel.browser.test.ts
@@ -38,6 +38,7 @@ beforeEach(() => {
   fontStyle = document.createElement("style");
   fontStyle.textContent = `:root {
     --font-mono: ui-monospace, monospace;
+    --color-bg: #0a0d0c;
     --color-panel: #1a1a1a;
     --color-line: #333;
     --color-inset: #111;
@@ -141,6 +142,110 @@ describe("BuildQueuePanel — curation state (unapproved, with steps)", () => {
       onbootstrap: noop,
     });
     await expect.element(page.getByRole("button", { name: m.buildqueue_add_step() })).toBeVisible();
+  });
+});
+
+describe("BuildQueuePanel — awaiting-approval affordances (unapproved + steps)", () => {
+  const curationQueue: BuildQueue = {
+    sessionId: "s1",
+    approved: false,
+    steps: [
+      { id: "a", title: "Install deps", status: "pending", position: 0 },
+      { id: "b", title: "Run tests", status: "pending", position: 1 },
+    ],
+  };
+
+  it("shows the awaiting chip + explanatory hint and marks the panel is-awaiting", async () => {
+    render(BuildQueuePanel, {
+      sessionId: "s1",
+      enabled: true,
+      queue: curationQueue,
+      onbootstrap: noop,
+    });
+    await expect.element(page.getByText(m.buildqueue_awaiting_chip())).toBeVisible();
+    await expect.element(page.getByText(m.buildqueue_awaiting_hint())).toBeVisible();
+    expect(document.querySelector(".bqp.is-awaiting"), "panel carries is-awaiting").not.toBeNull();
+  });
+
+  it("announces the awaiting status to assistive tech even when collapsed (aria-describedby → header chip)", async () => {
+    render(BuildQueuePanel, {
+      sessionId: "s1",
+      enabled: true,
+      queue: curationQueue,
+      onbootstrap: noop,
+    });
+    const toggle = document.querySelector<HTMLButtonElement>("button.bqp-collapse-toggle")!;
+    const describedby = toggle.getAttribute("aria-describedby");
+    expect(describedby, "toggle describes the awaiting chip").toBeTruthy();
+    const chip = document.getElementById(describedby!);
+    expect(chip?.textContent).toContain(m.buildqueue_awaiting_chip());
+
+    // Collapse: the chip lives in the always-rendered header, so its description
+    // must still resolve and stay visible while the content is hidden.
+    buildQueueCollapse.set(true);
+    await expect
+      .poll(() => document.querySelector<HTMLElement>(".bqp-content.collapsed"))
+      .toBeTruthy();
+
+    expect(toggle.getAttribute("aria-describedby"), "describedby unchanged when collapsed").toBe(
+      describedby,
+    );
+    const chipAfter = document.getElementById(describedby!);
+    expect(chipAfter, "chip still in DOM when collapsed").not.toBeNull();
+    expect(chipAfter!.offsetParent, "chip still visible (header not collapsed)").not.toBeNull();
+  });
+
+  it("applies the amber tint, emphasized CTA, and amber chip in the browser (computed styles)", async () => {
+    render(BuildQueuePanel, {
+      sessionId: "s1",
+      enabled: true,
+      queue: curationQueue,
+      onbootstrap: noop,
+    });
+    // 6% amber wash shifts the panel off the plain --color-panel (#1a1a1a).
+    const panel = document.querySelector<HTMLElement>(".bqp.is-awaiting")!;
+    expect(getComputedStyle(panel).backgroundColor, "tint applied").not.toBe("rgb(26, 26, 26)");
+
+    // Emphasized CTA: amber text + a non-empty inner-glow box-shadow (no solid fill).
+    const approve = document.querySelector<HTMLElement>("button.bqp-approve")!;
+    const approveStyle = getComputedStyle(approve);
+    expect(approveStyle.color, "CTA text is amber").toBe("rgb(245, 166, 35)");
+    expect(approveStyle.boxShadow, "CTA carries the inner-glow emphasis").not.toBe("none");
+
+    const chip = document.querySelector<HTMLElement>(".bqp-awaiting-chip")!;
+    expect(getComputedStyle(chip).color, "chip is amber").toBe("rgb(245, 166, 35)");
+  });
+});
+
+describe("BuildQueuePanel — awaiting affordances gated off other states", () => {
+  it("does not show awaiting affordances for an approved queue with steps", async () => {
+    const approvedQueue: BuildQueue = {
+      sessionId: "s1",
+      approved: true,
+      steps: [{ id: "a", title: "Install deps", status: "active", position: 0 }],
+    };
+    render(BuildQueuePanel, {
+      sessionId: "s1",
+      enabled: true,
+      queue: approvedQueue,
+      onbootstrap: noop,
+    });
+    expect(document.querySelector(".bqp.is-awaiting"), "no is-awaiting when approved").toBeNull();
+    expect(document.querySelector(".bqp-awaiting-chip"), "no chip when approved").toBeNull();
+    expect(document.querySelector(".bqp-hint"), "no hint when approved").toBeNull();
+  });
+
+  it("does not show awaiting affordances for an empty (unapproved, 0-step) queue", async () => {
+    render(BuildQueuePanel, {
+      sessionId: "s1",
+      enabled: true,
+      queue: { sessionId: "s1", steps: [], approved: false },
+      onbootstrap: noop,
+    });
+    expect(document.querySelector(".bqp.is-awaiting"), "no is-awaiting when empty").toBeNull();
+    expect(document.querySelector(".bqp-awaiting-chip"), "no chip when empty").toBeNull();
+    expect(document.querySelector(".bqp-hint"), "no hint when empty").toBeNull();
+    await expect.element(page.getByText(m.buildqueue_empty())).toBeInTheDocument();
   });
 });
 

--- a/ui/src/lib/components/BuildQueuePanel.svelte
+++ b/ui/src/lib/components/BuildQueuePanel.svelte
@@ -43,6 +43,12 @@
   const approved = $derived(queue?.approved ?? false);
 
   const contentId = $derived(`bqp-content-${sessionId}`);
+  const awaitingId = $derived(`bqp-awaiting-${sessionId}`);
+
+  // Curation state: the agent has authored steps and paused for the operator to
+  // review + approve. This is a needs-you moment (Design Principle 2), so it gets
+  // a distinct amber treatment the calm default states never carry.
+  const awaiting = $derived(!approved && steps.length > 0);
 
   // ------------- edit helpers -------------
 
@@ -159,7 +165,12 @@
 </script>
 
 {#if visible}
-  <div class="bqp" role="region" aria-label={m.buildqueue_panel_title()}>
+  <div
+    class="bqp"
+    class:is-awaiting={awaiting}
+    role="region"
+    aria-label={m.buildqueue_panel_title()}
+  >
     <button
       type="button"
       class="bqp-head bqp-collapse-toggle"
@@ -169,6 +180,7 @@
       aria-label={buildQueueCollapse.collapsed
         ? m.buildqueue_expand_aria()
         : m.buildqueue_collapse_aria()}
+      aria-describedby={awaiting ? awaitingId : undefined}
       title={buildQueueCollapse.collapsed
         ? m.buildqueue_expand_aria()
         : m.buildqueue_collapse_aria()}
@@ -177,6 +189,13 @@
       <span class="bqp-title">{m.buildqueue_panel_title()}</span>
       {#if approved && steps.length > 0}
         <span class={["bqp-approved", `bqp-run-${runState}`]}>{approvalLabel} · {runLabel}</span>
+      {:else if awaiting}
+        <!-- Needs-you chip: mirrors the approved chip's slot so the header always
+             narrates queue status. Lives in the always-rendered header, so the
+             signal (and its aria-describedby target) survives collapse. -->
+        <span class="bqp-awaiting-chip" id={awaitingId}>
+          <span class="bqp-awaiting-dot" aria-hidden="true"></span>{m.buildqueue_awaiting_chip()}
+        </span>
       {/if}
       <span class="bqp-collapse-glyph" aria-hidden="true"
         >{buildQueueCollapse.collapsed ? "▴" : "▾"}</span
@@ -188,6 +207,7 @@
         <p class="bqp-empty">{m.buildqueue_empty()}</p>
       {:else if !approved}
         <!-- Curation mode: editable list -->
+        <p class="bqp-hint">{m.buildqueue_awaiting_hint()}</p>
         <ol class="bqp-list" aria-label={m.buildqueue_panel_title()}>
           {#each steps as step, i (step.id)}
             <li class="bqp-row">
@@ -267,7 +287,7 @@
             {m.buildqueue_add_step()}
           </button>
           <button type="button" class="bqp-btn bqp-approve" onclick={approve}>
-            {m.buildqueue_approve()}
+            <span class="bqp-approve-glyph" aria-hidden="true">▸</span>{m.buildqueue_approve()}
           </button>
         </div>
       {:else}
@@ -305,6 +325,12 @@
     font-size: var(--fs-meta);
   }
 
+  /* Awaiting operator approval: a faint amber wash so the paused panel reads as
+     distinct from calm sibling panels without shouting (Design Principle 2). */
+  .is-awaiting {
+    background: color-mix(in oklab, var(--color-amber) 6%, var(--color-panel));
+  }
+
   /* The whole header is the collapse toggle (mirrors IntegratedEpicRow's
      .row-head), so a click anywhere on the bar expands/collapses — not just
      the ▴/▾ glyph. Button reset; the glyph keeps its boxed look below. */
@@ -338,6 +364,27 @@
     letter-spacing: 0.08em;
     text-transform: uppercase;
     /* Color lives on the run-state modifier classes below. */
+  }
+
+  /* Needs-you chip: amber (Shepherd's attention hue), sits in the same header
+     slot as .bqp-approved. The words carry the meaning; the dot is decoration,
+     so the signal never relies on hue alone. */
+  .bqp-awaiting-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: var(--fs-micro);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-amber);
+  }
+
+  .bqp-awaiting-dot {
+    flex: none;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--color-amber);
   }
 
   /* Run-state modifier colors (design-system rule 4 — tokens only, never literals).
@@ -387,6 +434,19 @@
     margin: 0;
     color: var(--color-faint);
     font-size: var(--fs-micro);
+  }
+
+  /* Explains the paused state and what to do. Full-surface amber wash + full
+     border (never a side-stripe); ink-bright text keeps the copy legible. */
+  .bqp-hint {
+    margin: 0;
+    padding: 5px 8px;
+    border: 1px solid color-mix(in oklab, var(--color-amber) 30%, transparent);
+    border-radius: 3px;
+    background: color-mix(in oklab, var(--color-amber) 10%, transparent);
+    color: var(--color-ink-bright);
+    font-size: var(--fs-micro);
+    line-height: 1.45;
   }
 
   .bqp-list {
@@ -531,15 +591,34 @@
     padding-top: 2px;
   }
 
+  /* Emphasized primary: the design system's loudest-action recipe
+     (.chip-action.primary) — amber text + amber border + an inner amber glow.
+     Deliberately NOT a solid fill: --color-amber flips light↔dark across themes,
+     so on-amber text would drop below AA in light theme. Amber text on the panel
+     stays contrast-safe in both themes and both high-contrast variants. */
   .bqp-approve {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
     color: var(--color-amber);
     border-color: var(--color-amber);
-    font-weight: 500;
+    font-weight: 600;
+    box-shadow: inset 0 0 18px -10px var(--color-amber);
   }
 
-  .bqp-approve:hover,
-  .bqp-approve:focus-visible {
-    background: color-mix(in oklab, var(--color-amber) 12%, transparent);
+  /* :not(:disabled) keeps specificity on par with the base .bqp-btn hover so this
+     later rule wins and the CTA stays amber (never the ink hover). */
+  .bqp-approve:hover:not(:disabled),
+  .bqp-approve:focus-visible:not(:disabled) {
     color: var(--color-amber);
+    border-color: var(--color-amber);
+    box-shadow:
+      inset 0 0 0 1px var(--color-amber),
+      inset 0 0 22px -8px var(--color-amber);
+  }
+
+  .bqp-approve-glyph {
+    font-size: var(--fs-micro);
+    line-height: 1;
   }
 </style>


### PR DESCRIPTION
## Why

When the agent authors a build queue and pauses for the operator, the panel gave no signal that it needs review + approval: muted header, faint `PENDING` badges, a modestly-outlined `Approve & run`. Nothing said *the agent stopped and is waiting for you*. That conflicts with Design Principle 2 (the needs-you state must be unmistakable).

## What

Only for **unapproved queues that have steps** (the curation state):

- **Amber "awaiting your approval" header chip**, in the same slot as the approved chip, so the header always narrates queue status and the signal **survives collapse**.
- **`aria-describedby`** wires the collapse toggle to that chip, so assistive tech hears the awaiting status even when the content is collapsed. The chip's words carry the meaning (the dot is `aria-hidden`), so the signal never relies on hue alone.
- **Explanatory hint line** telling the operator what the pause means and what to do.
- **Emphasized `Approve & run` CTA** using the design-system loudest-action recipe (amber text + border + inner glow), **not a solid fill**: `--color-amber` flips light↔dark across themes, so on-amber text would drop below WCAG AA in light theme. Amber text stays contrast-safe in dark, light, and both high-contrast variants.
- **Subtle amber panel tint** distinguishing the paused panel from calm siblings.

Approved, running, and empty states are unchanged. Tokens only, no literals; no banned patterns (no side-stripe, gradient text, glass, or modal).

## Verification

- `bun run check` (svelte-check): 0 errors · `bun run check:i18n`: EN/DE parity · full UI suite green (3134 tests).
- New browser tests assert: chip + hint render; `aria-describedby` resolves to the visible chip **after collapse**; the awaiting hooks are **absent** for approved-with-steps and empty queues and **present** only for unapproved-with-steps; and computed-style checks (real Chromium) confirm the tint applies, the CTA is amber with a non-empty inner-glow shadow, and the chip is amber.
- Manually eyeballed the rendered awaiting state in **dark and light** themes with the real design tokens; both read clearly and the CTA stays legible.

Classified as a clarity fix to an existing feature (ships as `fix`), so no feature-announcement entry. No new glossary terms.