### PR TITLE
feat: live review preview + dimmed terminal during in-flight reviews

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1153,6 +1153,7 @@ const planGate = new PlanGateService({
   env: () => roleEnv(config.plannerCli, config.plannerModel, config.plannerEffort),
   onChange: (id, gate) => events.emit("session:plangate", { id, gate }),
   onReviewing: (id, reviewing) => events.emit("session:plangate-reviewing", { id, reviewing }),
+  onActivity: (id, summary) => events.emit("session:plangate-activity", { id, summary }),
   cap: () => config.planReviewCyclesCap,
 });
 // Grace window for a recent uncompleted reviewer_spawns row: spares a recently-spawned reviewer

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -16,7 +16,8 @@ import {
 } from "./visual-blocks";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
 import { apiKeyFailClosed } from "./spawn-auth";
-import { readSessionUsage, type SessionUsage } from "./usage";
+import { jsonlPathFor, readSessionUsage, type SessionUsage } from "./usage";
+import { readActivitySignal } from "./activity-signal";
 import { effectiveAutopilot } from "./effective-autopilot";
 import { resolveAuxSpawn, type MembraneSeams } from "./spawn-membrane";
 import { fenceUntrusted } from "./untrusted";
@@ -134,6 +135,14 @@ export interface PlanGateServiceDeps extends MembraneSeams {
   /** Fired when a plan review starts (true) and when it ends (false) for a session. */
   onReviewing?: (id: string, reviewing: boolean) => void;
   /**
+   * Fired each tick a plan reviewer is still running, with its latest *meaningful* tool-use
+   * summary (e.g. "$ git diff", "read plan"). Surfaced live in the UI review-in-flight banner
+   * preview so the operator can see what the reviewer is doing, not just that it's busy. Only
+   * fired when a summary is available; the run-ended (onReviewing false) signal clears it
+   * client-side. Mirrors ReviewService's onActivity.
+   */
+  onActivity?: (id: string, summary: string) => void;
+  /**
    * Max adversarial rounds before escalating to the human (default 5). Pass a thunk to read a
    * live, UI-configurable value per-use — resolved on every read so a settings change takes
    * effect on the next run without a restart.
@@ -155,6 +164,9 @@ export interface PlanGateServiceDeps extends MembraneSeams {
   readVerdict?: (worktreePath: string) => RawPlanVerdict | null;
   /** default: `git rev-parse origin/<base>` (fallback `<base>`) in the repo. */
   baseSha?: (repoPath: string, base: string) => string;
+  /** Injectable reader for the plan reviewer's latest tool-use summary (default: parse its JSONL
+   *  transcript via readActivitySignal). null = no parseable activity yet. */
+  readActivity?: (worktreePath: string, reviewerSessionId: string) => string | null;
   /** Injectable reader of a finished reviewer's token totals from its transcript
    *  (default: readSessionUsage). null = transcript missing/unreadable → totals stay null. */
   readUsage?: (worktreePath: string, reviewerSessionId: string) => Promise<SessionUsage | null>;
@@ -208,6 +220,7 @@ export class PlanGateService {
   private readVerdict: (worktreePath: string) => RawPlanVerdict | null;
   private worktreeExists: (worktreePath: string) => boolean;
   private baseSha: (repoPath: string, base: string) => string;
+  private readActivity: (worktreePath: string, reviewerSessionId: string) => string | null;
   private readUsage: (
     worktreePath: string,
     reviewerSessionId: string,
@@ -224,6 +237,7 @@ export class PlanGateService {
     this.readVerdict = deps.readVerdict ?? defaultReadVerdict;
     this.worktreeExists = deps.worktreeExists ?? existsSync;
     this.baseSha = deps.baseSha ?? defaultBaseSha;
+    this.readActivity = deps.readActivity ?? defaultReadActivity;
     this.readUsage = deps.readUsage ?? readSessionUsage;
   }
 
@@ -491,7 +505,14 @@ export class PlanGateService {
       if (f.finalizing) continue; // already being finalized by an overlapping tick
       const raw = this.readVerdict(f.worktreePath);
       const timedOut = this.now() - f.startedAt > this.timeoutMs;
-      if (!raw && !timedOut) continue;
+      if (!raw && !timedOut) {
+        // still running — surface what the reviewer is doing right now. Emit every tick (not
+        // only on change) so a reloaded client repopulates within one tick; the client dedups
+        // identical summaries. Mirrors ReviewService.tick's critic-activity signal.
+        const summary = this.readActivity(f.worktreePath, f.reviewerSessionId);
+        if (summary) this.deps.onActivity?.(f.sessionId, summary);
+        continue;
+      }
       f.finalizing = true; // stay claimed in `inflight` so consider() won't re-spawn mid-finalize
       // Always drop the entry, even if finalize throws — otherwise it stays
       // `finalizing=true` and every later tick `continue`s past it, wedging the
@@ -902,6 +923,13 @@ function defaultReadPlan(worktreePath: string): string | null {
   } catch {
     return null;
   }
+}
+
+/** Latest meaningful tool-use summary from the plan reviewer's JSONL transcript (its claude
+ *  session id forces a predictable path under the disposable worktree). null when the transcript
+ *  is missing or has no parseable activity yet. Mirrors review.ts's defaultReadActivity. */
+function defaultReadActivity(worktreePath: string, reviewerSessionId: string): string | null {
+  return readActivitySignal(jsonlPathFor(worktreePath, reviewerSessionId))?.summary ?? null;
 }
 
 /** Read the reviewer's verdict JSON from its disposable worktree. Null until written / on a

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -1261,3 +1261,40 @@ test("changes_requested verdict also carries blocks from readPlanBlocks", async 
   expect(h.store.gate.blocks).toHaveLength(1);
   expect(h.store.gate.blocks[0].type).toBe("question-form");
 });
+
+test("onActivity surfaces the running plan reviewer's latest tool-use while no verdict yet", async () => {
+  const acts: { id: string; summary: string }[] = [];
+  const h = harness({
+    readVerdict: () => null, // still running — no verdict file yet
+    readActivity: () => "read .shepherd-plan.md",
+    onActivity: (id: string, summary: string) => acts.push({ id, summary }),
+  });
+  await h.svc.consider(planningSession() as any);
+  await h.svc.tick();
+  expect(acts).toEqual([{ id: "s1", summary: "read .shepherd-plan.md" }]);
+});
+
+test("onActivity stays silent when the plan reviewer has no parseable activity yet", async () => {
+  const acts: unknown[] = [];
+  const h = harness({
+    readVerdict: () => null,
+    readActivity: () => null, // transcript missing / nothing parseable
+    onActivity: (id: string, summary: string) => acts.push({ id, summary }),
+  });
+  await h.svc.consider(planningSession() as any);
+  await h.svc.tick();
+  expect(acts).toEqual([]);
+});
+
+test("onActivity does not fire on the tick that finalizes the verdict", async () => {
+  const acts: unknown[] = [];
+  const h = harness({
+    // verdict present → this tick finalizes rather than reporting activity
+    readVerdict: () => ({ decision: "approve", summary: "ok", body: "B", findings: [] }),
+    readActivity: () => "read .shepherd-plan.md",
+    onActivity: (id: string, summary: string) => acts.push({ id, summary }),
+  });
+  await h.svc.consider(planningSession() as any);
+  await h.svc.tick();
+  expect(acts).toEqual([]);
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2773,5 +2773,8 @@
   "issues_filter_no_match": "keine Issues entsprechen den aktiven Filtern",
   "issuerow_author_by": "von {login}",
   "feat_issue_author_label_filter_title": "Issues nach Autor und Label filtern",
-  "feat_issue_author_label_filter_body": "Issue-Listen zeigen jetzt den Autor jedes Issues, und das Filter-Menü kann den Backlog nach Autor und Label eingrenzen — wähle einen Autor oder schalte ein oder mehrere Labels an, um die Liste zu fokussieren."
+  "feat_issue_author_label_filter_body": "Issue-Listen zeigen jetzt den Autor jedes Issues, und das Filter-Menü kann den Backlog nach Autor und Label eingrenzen — wähle einen Autor oder schalte ein oder mehrere Labels an, um die Liste zu fokussieren.",
+  "reviewbanner_preview_waiting": "Überprüfung startet…",
+  "feat_review_live_preview_title": "Live-Vorschau der Überprüfung + gedimmtes Terminal",
+  "feat_review_live_preview_body": "Während eine PR-Critic- oder Plan-Gate-Überprüfung im Hintergrund läuft, zeigt der amber Balken jetzt einen Live-Auszug dessen, was der Prüfer gerade tut — seine letzten Aktionen — und das Terminal wird gedimmt, um zu signalisieren, dass Shepherd arbeitet und du nichts eingeben musst. Das Dimmen ist rein visuell; dein Prompt bleibt nutzbar."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2773,5 +2773,8 @@
   "issues_filter_no_match": "no issues match the active filters",
   "issuerow_author_by": "by {login}",
   "feat_issue_author_label_filter_title": "Filter issues by author and label",
-  "feat_issue_author_label_filter_body": "Issue lists now show each issue's author, and the Filters menu can narrow the backlog by author and by label — pick an author or toggle one or more labels to focus the list."
+  "feat_issue_author_label_filter_body": "Issue lists now show each issue's author, and the Filters menu can narrow the backlog by author and by label — pick an author or toggle one or more labels to focus the list.",
+  "reviewbanner_preview_waiting": "Starting review…",
+  "feat_review_live_preview_title": "Live review preview + dimmed terminal",
+  "feat_review_live_preview_body": "While a PR-critic or plan-gate review runs off-screen, the amber banner now shows a live tail of what the reviewer is doing — its last few actions — and the terminal dims to signal that Shepherd is working and there's no need to type. The dim is visual only; your prompt stays usable."
 }

--- a/ui/src/lib/components/Viewport.browser.test.ts
+++ b/ui/src/lib/components/Viewport.browser.test.ts
@@ -20,7 +20,7 @@ vi.mock("$lib/api", async (importOriginal) => {
 const { default: Viewport } = await import("./Viewport.svelte");
 // Dynamic import AFTER the $lib/api mock: reviews.svelte imports $lib/api, so a static
 // (hoisted) import would pull the real module in before the mock registers and break it.
-const { reviews, planGates } = await import("$lib/reviews.svelte");
+const { reviews, planGates, repoConfig } = await import("$lib/reviews.svelte");
 // Dynamic import for same reason: recaps.svelte imports $lib/api via getRecaps.
 const { recaps } = await import("$lib/recaps.svelte");
 import { toasts } from "$lib/toasts.svelte";
@@ -1169,6 +1169,108 @@ describe("Viewport Activity tab A/B switch", () => {
 // the adjacent needs-you pager's prev button (also "‹"), yielding two ambiguous
 // left chevrons. It renders as the list glyph "☰" (back to the herd list), which
 // the pager never uses. The .back button only mounts when `onback` is supplied.
+// ── Terminal dim while a review runs off-screen (in-flight tier only) ─────────
+// The ReviewInFlightBanner binds out an `inflight` signal that is true ONLY on its in-flight
+// tier (a review runs in a separate worktree/PTY; this session's PTY is idle). Viewport uses it
+// to dim .term-mount (visual-only "hands off"). It must NOT dim during addressing (agent works
+// in THIS PTY), conclusion (review done), or when the critic banner is suppressed (auto-address
+// off). Verified for both Plan-Gate and Critic.
+describe("Viewport terminal dim on in-flight review", () => {
+  function clearReviewState() {
+    reviews.map = {};
+    reviews.reviewing = {};
+    reviews.activity = {};
+    planGates.map = {};
+    planGates.reviewing = {};
+    planGates.activity = {};
+    repoConfig.autoAddress = {};
+  }
+  beforeEach(clearReviewState);
+  afterEach(clearReviewState);
+
+  const termDimmed = (container: HTMLElement) =>
+    container.querySelector(".term-mount")?.classList.contains("reviewing");
+
+  it("plan-gate in-flight: dims the terminal", async () => {
+    const id = "dim-plan";
+    planGates.applyReviewing(id, true);
+    const { container } = render(Viewport, {
+      session: session({ id, status: "running", planPhase: "planning" }),
+      previewPort: null,
+      openPreviewTick: 0,
+    });
+    await expect.element(page.getByText(m.reviewbanner_calm())).toBeInTheDocument();
+    await expect.poll(() => termDimmed(container)).toBe(true);
+  });
+
+  it("critic in-flight (auto-address on): dims the terminal", async () => {
+    const id = "dim-critic";
+    repoConfig.autoAddress = { "/repo/a": true };
+    reviews.setReviewing(id, true);
+    const { container } = render(Viewport, {
+      session: session({ id, status: "running", planPhase: "executing" }),
+      previewPort: null,
+      openPreviewTick: 0,
+    });
+    await expect.element(page.getByText(m.reviewbanner_calm())).toBeInTheDocument();
+    await expect.poll(() => termDimmed(container)).toBe(true);
+  });
+
+  it("addressing phase: does NOT dim (agent works in this PTY)", async () => {
+    const id = "dim-addressing";
+    planGates.map = { [id]: planGate({ sessionId: id, round: 1, cap: 5 }) };
+    const { container } = render(Viewport, {
+      session: session({ id, status: "running", planPhase: "planning" }),
+      activity: activity("edited .shepherd-plan.md"),
+      previewPort: null,
+      openPreviewTick: 0,
+    });
+    await expect
+      .element(page.getByText("REWORK · 1/5 · edited .shepherd-plan.md"))
+      .toBeInTheDocument();
+    expect(termDimmed(container)).toBe(false);
+  });
+
+  it("critic in-flight with auto-address OFF: banner suppressed, so NO dim", async () => {
+    const id = "dim-critic-off";
+    repoConfig.autoAddress = { "/repo/a": false };
+    reviews.setReviewing(id, true);
+    const { container } = render(Viewport, {
+      session: session({ id, status: "idle", planPhase: "executing" }),
+      previewPort: null,
+      openPreviewTick: 0,
+    });
+    await expect.poll(() => container.querySelector(".review-banner")).toBeNull();
+    expect(termDimmed(container)).toBe(false);
+  });
+
+  it("conclusion phase: does NOT dim once the verdict lands", async () => {
+    const id = "dim-conclusion";
+    planGates.applyReviewing(id, true);
+    const { container } = render(Viewport, {
+      session: session({ id, status: "running", planPhase: "planning" }),
+      previewPort: null,
+      openPreviewTick: 0,
+    });
+    await expect.poll(() => termDimmed(container)).toBe(true); // in-flight → dimmed
+    // land an approved verdict and end the review → the brief conclusion tier
+    planGates.map = {
+      [id]: planGate({
+        sessionId: id,
+        decision: "approved",
+        approved: true,
+        round: 0,
+        findings: [],
+      }),
+    };
+    planGates.applyReviewing(id, false);
+    await expect
+      .poll(() => container.querySelector(".review-banner")?.getAttribute("data-phase"))
+      .toBe("conclusion");
+    expect(termDimmed(container)).toBe(false);
+  });
+});
+
 describe("Viewport phone back glyph", () => {
   it("phone back control renders the list glyph ☰, not the left chevron ‹", async () => {
     const { container } = render(Viewport, {

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -292,6 +292,11 @@
   // jump-to-latest button lifts by `reviewBannerH || ciBannerH` (no max() needed).
   let ciBannerH = $state(0);
   let reviewActive = $state(false);
+  // In-flight-review dim signal, bound out of ReviewInFlightBanner: true ONLY while a review runs
+  // off-screen (its PTY is separate, this session's PTY is idle). Drives the .term-mount dim so
+  // the operator reads "Shepherd is working — hands off". False during addressing (agent works in
+  // THIS PTY) and conclusion, so the terminal never dims while its own output is live.
+  let reviewInFlight = $state(false);
   // Text stashed from an OSC 52 clipboard write that the browser refused (async writes need
   // a user gesture); the ClipboardPill offers a one-click retry that runs inside a real click.
   let pendingCopy = $state<string | null>(null);
@@ -2508,6 +2513,7 @@
     <div
       class="term-mount"
       class:dragging
+      class:reviewing={reviewInFlight}
       role="region"
       aria-label={m.viewport_terminal_tab()}
       bind:this={el}
@@ -2565,6 +2571,7 @@
       {tab}
       bind:height={reviewBannerH}
       bind:active={reviewActive}
+      bind:inflight={reviewInFlight}
     />
     <!-- Non-blocking "CI is running" banner: same bottom strip, shown only when no
          review banner claims it (reviewActive) so the two never overlap. -->
@@ -3384,6 +3391,15 @@
     overflow: hidden;
     /* we drive vertical scroll via touch handlers; keep the browser out of it */
     touch-action: none;
+  }
+
+  /* Visual-only dim while a review runs off-screen (bound from ReviewInFlightBanner's in-flight
+     tier): the operator reads "Shepherd is working — hands off". NOT a modal scrim/blur — this is
+     a non-blocking state and the live prompt stays usable; only the idle terminal recedes. The
+     review banner + its live preview are siblings in .vp-body, so they stay fully lit. */
+  .term-mount.reviewing {
+    opacity: 0.5;
+    transition: opacity 0.18s ease;
   }
 
   /* let xterm fill the mount */

--- a/ui/src/lib/components/viewport/ReviewInFlightBanner.browser.test.ts
+++ b/ui/src/lib/components/viewport/ReviewInFlightBanner.browser.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import "../../../app.css";
+import { m } from "$lib/paraglide/messages";
+import { reviews, planGates, repoConfig } from "$lib/reviews.svelte";
+import type { PlanGate, ReviewVerdict } from "$lib/types";
+
+const { default: ReviewInFlightBanner } = await import("./ReviewInFlightBanner.svelte");
+
+const REPO = "/r";
+const ID = "s1";
+
+// Minimal session; the banner only reads id/repoPath/planPhase/auto/autopilotEnabled.
+const sess = (over: Record<string, unknown> = {}) => ({
+  id: ID,
+  repoPath: REPO,
+  planPhase: null,
+  auto: false,
+  autopilotEnabled: false,
+  ...over,
+});
+
+// Props typed loosely — the banner's Session prop is a large type we don't need in full here.
+const props = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+  session: sess(),
+  dStatus: "idle",
+  activity: undefined,
+  keystrokes: 0,
+  tab: "term",
+  ...over,
+});
+
+const changesRequested = (): ReviewVerdict => ({
+  sessionId: ID,
+  headSha: "abc",
+  decision: "changes_requested",
+  summary: "needs work",
+  body: "B",
+  findings: ["fix X"],
+  addressRound: 1, // < cap → addressStallStatus === "round" (never "stalled"): clock-independent
+  addressCap: 3,
+  finalRoundPending: false,
+  finalRoundTimeoutMs: 900_000,
+  updatedAt: 0,
+});
+
+const approvedGate = (): PlanGate => ({
+  sessionId: ID,
+  planHash: "abc",
+  decision: "approved",
+  summary: "ok",
+  body: "B",
+  findings: [],
+  round: 0,
+  cap: 5,
+  approved: true,
+  plan: "PLAN",
+  updatedAt: 0,
+});
+
+const feedLines = () => [...document.querySelectorAll(".rb-pv-line")].map((e) => e.textContent);
+const banner = () => document.querySelector(".review-banner");
+
+beforeEach(() => {
+  reviews.map = {};
+  reviews.reviewing = {};
+  reviews.activity = {};
+  planGates.map = {};
+  planGates.reviewing = {};
+  planGates.activity = {};
+  repoConfig.autoAddress = {};
+  repoConfig.autopilot = {};
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("ReviewInFlightBanner preview — in-flight tier", () => {
+  it("critic in-flight (auto-address on): renders the rolling activity feed, oldest→newest", async () => {
+    repoConfig.autoAddress = { [REPO]: true };
+    reviews.setReviewing(ID, true);
+    reviews.setActivity(ID, "read review.ts");
+    reviews.setActivity(ID, "$ git diff main...HEAD");
+    render(ReviewInFlightBanner, props() as never);
+    await expect.poll(feedLines).toEqual(["read review.ts", "$ git diff main...HEAD"]); // newest line sits at the bottom
+  });
+
+  it("plan-gate in-flight: renders the reviewer's activity feed", async () => {
+    planGates.applyReviewing(ID, true);
+    planGates.setActivity(ID, "read .shepherd-plan.md");
+    render(ReviewInFlightBanner, props() as never);
+    await expect.poll(feedLines).toEqual(["read .shepherd-plan.md"]);
+  });
+
+  it("caps the preview at 4 lines, dropping the oldest (newest at the bottom)", async () => {
+    planGates.applyReviewing(ID, true);
+    for (const l of ["act-1", "act-2", "act-3", "act-4", "act-5"]) planGates.setActivity(ID, l);
+    render(ReviewInFlightBanner, props() as never);
+    await expect.poll(feedLines).toEqual(["act-2", "act-3", "act-4", "act-5"]);
+  });
+
+  it("shows the waiting placeholder (no feed lines) before the first activity arrives", async () => {
+    planGates.applyReviewing(ID, true);
+    render(ReviewInFlightBanner, props() as never);
+    await expect
+      .poll(() => document.querySelector(".rb-pv-wait")?.textContent)
+      .toBe(m.reviewbanner_preview_waiting());
+    expect(feedLines()).toEqual([]);
+  });
+
+  it("keeps a stable banner height as the feed fills from 0 to 4 lines", async () => {
+    planGates.applyReviewing(ID, true);
+    render(ReviewInFlightBanner, props() as never);
+    await expect
+      .poll(() => document.querySelector(".rb-pv-wait")?.textContent)
+      .toBe(m.reviewbanner_preview_waiting());
+    const emptyH = banner()!.getBoundingClientRect().height;
+    for (const l of ["act-1", "act-2", "act-3", "act-4"]) planGates.setActivity(ID, l);
+    await expect.poll(() => feedLines().length).toBe(4);
+    const fullH = banner()!.getBoundingClientRect().height;
+    expect(fullH).toBe(emptyH); // fixed 4-row preview area → one xterm refit, not per-line churn
+  });
+});
+
+describe("ReviewInFlightBanner preview — negative cases (no preview / no dim)", () => {
+  it("critic in-flight with auto-address OFF: banner hidden entirely, so no preview", async () => {
+    repoConfig.autoAddress = { [REPO]: false };
+    reviews.setReviewing(ID, true);
+    render(ReviewInFlightBanner, props() as never);
+    // criticInFlightShows is false → the whole banner suppresses; nothing to dim behind.
+    await expect.poll(() => banner()).toBeNull();
+    expect(document.querySelector(".rb-preview")).toBeNull();
+  });
+
+  it("addressing phase (agent reworks in the PTY): banner shows, but no preview", async () => {
+    reviews.map = { [ID]: changesRequested() }; // not reviewing; running; executing → addressing
+    render(
+      ReviewInFlightBanner,
+      props({ session: sess({ planPhase: "executing" }), dStatus: "running" }) as never,
+    );
+    await expect.poll(() => banner()?.getAttribute("data-phase")).toBe("addressing");
+    expect(document.querySelector(".rb-preview")).toBeNull();
+  });
+
+  it("conclusion phase (verdict just landed): banner shows, but no preview", async () => {
+    planGates.applyReviewing(ID, true);
+    render(ReviewInFlightBanner, props() as never);
+    await expect
+      .poll(() => document.querySelector(".rb-pv-wait")?.textContent)
+      .toBe(m.reviewbanner_preview_waiting());
+    // land an approved verdict and end the review → the brief conclusion tier
+    planGates.map = { [ID]: approvedGate() };
+    planGates.applyReviewing(ID, false);
+    await expect.poll(() => banner()?.getAttribute("data-phase")).toBe("conclusion");
+    expect(document.querySelector(".rb-preview")).toBeNull();
+  });
+});

--- a/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
+++ b/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Session, SessionActivity, SessionStatus } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
-  import { reviews, planGates, repoConfig } from "$lib/reviews.svelte";
+  import { reviews, planGates, repoConfig, MAX_ACTIVITY_LINES } from "$lib/reviews.svelte";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
   import {
     activeReworkBannerState,
@@ -27,6 +27,7 @@
     tab,
     height = $bindable(0),
     active = $bindable(false),
+    inflight = $bindable(false),
   }: {
     session: Session;
     dStatus: SessionStatus;
@@ -38,6 +39,10 @@
      *  condition below). Bound out so a sibling status banner (CiRunningBanner)
      *  can suppress itself synchronously — no offsetHeight/paint race. */
     active?: boolean;
+    /** True iff the banner is showing its in-flight tier (a review runs off-screen,
+     *  the session PTY is idle). Bound out so the Viewport can dim the terminal only
+     *  in that phase — not during addressing (agent works in the PTY) or conclusion. */
+    inflight?: boolean;
   } = $props();
 
   // Live in-flight flags (mutually exclusive: plan-gate = planning phase, critic =
@@ -46,6 +51,18 @@
   const planReviewing = $derived(planGates.isReviewing(session.id));
   const liveKind = $derived<ReviewKind | null>(
     criticReviewing ? "critic" : planReviewing ? "plangate" : null,
+  );
+
+  // Live rolling activity feed of whichever reviewer is in flight (oldest→newest, ≤
+  // MAX_ACTIVITY_LINES). Rendered as the tail preview under the in-flight headline: the reviewer
+  // runs off-screen in its own worktree, so this is the operator's only window into what it's
+  // doing. Verbatim tool-use lines (e.g. "$ git diff", "read poller.ts") — NOT translated.
+  const feed = $derived<string[]>(
+    liveKind === "critic"
+      ? reviews.activityFeed(session.id)
+      : liveKind === "plangate"
+        ? planGates.activityFeed(session.id)
+        : [],
   );
 
   // Session's effective autopilot (mirrors src/effective-autopilot.ts): per-session
@@ -225,6 +242,10 @@
   $effect(() => {
     const shown = view.show && tab === "term";
     if (active !== shown) active = shown; // logical occupancy signal for a sibling status banner (pre-paint)
+    // Terminal-dim signal: only the in-flight tier (review runs off-screen, PTY idle). Narrowed
+    // off `view` directly so TS sees the discriminant; NOT during addressing/conclusion.
+    const preview = view.show && view.phase === "in-flight" && tab === "term";
+    if (inflight !== preview) inflight = preview;
     if (!shown) {
       height = 0; // hidden branch: reset (the only place height is zeroed)
       return;
@@ -244,29 +265,46 @@
     bind:offsetHeight={height}
     use:coachTarget={"review-inflight"}
   >
-    {#if spinning}
-      <!-- Rotating cog: an inline SVG (not the ⚙ glyph, which renders as a color
-           emoji ignoring currentColor and rotates off-center) so it tints to the
-           tone accent and turns cleanly about its center. -->
-      <svg
-        class="rb-cog"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        aria-hidden="true"
-      >
-        <circle cx="12" cy="12" r="3" />
-        <path
-          d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
-        />
-      </svg>
-    {:else}
-      <span class="rb-icon" aria-hidden="true">{icon}</span>
+    <div class="rb-head">
+      {#if spinning}
+        <!-- Rotating cog: an inline SVG (not the ⚙ glyph, which renders as a color
+             emoji ignoring currentColor and rotates off-center) so it tints to the
+             tone accent and turns cleanly about its center. -->
+        <svg
+          class="rb-cog"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="3" />
+          <path
+            d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
+          />
+        </svg>
+      {:else}
+        <span class="rb-icon" aria-hidden="true">{icon}</span>
+      {/if}
+      <span class="rb-text">{bannerText(view)}</span>
+    </div>
+    {#if view.show && view.phase === "in-flight"}
+      <!-- Live "tail -f" of the off-screen reviewer's actions. Fixed height for MAX_ACTIVITY_LINES
+           rows so the banner keeps a stable height across the whole in-flight phase (lines fill
+           progressively) → one xterm refit on enter/exit, not one per line. aria-hidden: the
+           polite headline is the announcement; a fast-updating feed would spam a screen reader. -->
+      <div class="rb-preview" style:--rb-pv-rows={MAX_ACTIVITY_LINES} aria-hidden="true">
+        {#if feed.length === 0}
+          <span class="rb-pv-wait">{m.reviewbanner_preview_waiting()}</span>
+        {:else}
+          {#each feed as line, i (i)}
+            <span class="rb-pv-line">{line}</span>
+          {/each}
+        {/if}
+      </div>
     {/if}
-    <span class="rb-text">{bannerText(view)}</span>
   </div>
 {/if}
 
@@ -284,8 +322,7 @@
     right: 0;
     z-index: 2;
     display: flex;
-    align-items: center;
-    gap: 8px;
+    flex-direction: column;
     padding: 5px 10px;
     font-size: var(--fs-meta);
     color: var(--accent);
@@ -300,6 +337,43 @@
   .review-banner[data-phase="addressing"] {
     padding: 9px 12px;
     font-size: var(--fs-base);
+  }
+  /* Headline row (icon + message) — the former single-row flex layout. */
+  .rb-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  /* Live activity tail under the in-flight headline. Newest line pins to the bottom
+     (justify-content:flex-end); the reserved height is MAX_ACTIVITY_LINES rows (--rb-pv-rows) so
+     the banner keeps a STABLE height across the whole in-flight phase as lines fill in — one
+     xterm refit on enter/exit, not one per line. Monospace + quiet ink so it reads as terminal
+     echo of the off-screen reviewer, not app chrome. */
+  .rb-preview {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    margin-top: 6px;
+    height: calc(var(--fs-meta) * 1.5 * var(--rb-pv-rows, 4));
+    overflow: hidden;
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    color: var(--color-ink);
+  }
+  .rb-pv-line {
+    line-height: 1.5;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  /* Older lines recede so the newest (bottom) reads as "happening now". */
+  .rb-pv-line:not(:last-child) {
+    color: var(--color-faint);
+  }
+  .rb-pv-wait {
+    line-height: 1.5;
+    color: var(--color-faint);
+    font-style: italic;
   }
   .rb-icon {
     font-size: var(--fs-base);

--- a/ui/src/lib/feature-announcements/entries/v1.43.0-review-live-preview.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.43.0-review-live-preview.ts
@@ -1,0 +1,14 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // Live "tail -f" preview of what an off-screen review (PR-critic / plan-gate) is doing, shown
+  // under the amber review-in-flight banner, plus a visual dim of the idle terminal. targetId
+  // points the coachmark at the banner (use:coachTarget={"review-inflight"}).
+  id: "review-live-preview",
+  sinceVersion: "1.43.0",
+  titleKey: "feat_review_live_preview_title",
+  bodyKey: "feat_review_live_preview_body",
+  targetId: "review-inflight",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/feature-announcements/entries/v1.43.0-review-live-preview.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.43.0-review-live-preview.ts
@@ -1,14 +1,13 @@
 import type { FeatureAnnouncement } from "../../feature-announcements";
 
 const entry = {
-  // Live "tail -f" preview of what an off-screen review (PR-critic / plan-gate) is doing, shown
-  // under the amber review-in-flight banner, plus a visual dim of the idle terminal. targetId
-  // points the coachmark at the banner (use:coachTarget={"review-inflight"}).
+  // No targetId: the only <Coachmark> host (GitRail) arms exclusively from PILL_FEATURE_IDS
+  // (critic / auto-address / learnings), so an anchor on the review-in-flight banner would never
+  // fire — it would be a dead coachmark target. This feature surfaces via the What's-New drawer.
   id: "review-live-preview",
   sinceVersion: "1.43.0",
   titleKey: "feat_review_live_preview_title",
   bodyKey: "feat_review_live_preview_body",
-  targetId: "review-inflight",
 } satisfies FeatureAnnouncement;
 
 export default entry;

--- a/ui/src/lib/reviews.svelte.test.ts
+++ b/ui/src/lib/reviews.svelte.test.ts
@@ -1,15 +1,24 @@
 import { test, expect, vi, beforeEach } from "vitest";
-import type { ReviewVerdict, RepoConfig } from "./types";
+import type { ReviewVerdict, PlanGate, RepoConfig } from "./types";
 
 vi.mock("./api", () => ({
   getReviews: vi.fn(),
   getReviewingIds: vi.fn(),
+  getPlanGates: vi.fn(),
+  getPlanGatesInflight: vi.fn(),
   getRepoConfig: vi.fn(),
   putRepoConfig: vi.fn(),
 }));
 
-import { reviews, repoConfig } from "./reviews.svelte";
-import { getReviews, getReviewingIds, getRepoConfig, putRepoConfig } from "./api";
+import { reviews, planGates, repoConfig } from "./reviews.svelte";
+import {
+  getReviews,
+  getReviewingIds,
+  getPlanGates,
+  getPlanGatesInflight,
+  getRepoConfig,
+  putRepoConfig,
+} from "./api";
 
 /** Build a minimal RepoConfig with all required fields; override as needed. */
 const rc = (overrides: Partial<RepoConfig> = {}): RepoConfig => ({
@@ -54,10 +63,27 @@ const verdict = (id: string): ReviewVerdict => ({
   updatedAt: 0,
 });
 
+const planGate = (id: string): PlanGate => ({
+  sessionId: id,
+  planHash: "abc123",
+  decision: "approved",
+  summary: "ok",
+  body: "body",
+  findings: [],
+  round: 0,
+  cap: 5,
+  approved: true,
+  plan: "PLAN",
+  updatedAt: 0,
+});
+
 beforeEach(() => {
   reviews.map = {};
   reviews.reviewing = {};
   reviews.activity = {};
+  planGates.map = {};
+  planGates.reviewing = {};
+  planGates.activity = {};
   repoConfig.enabled = {};
   repoConfig.autoAddress = {};
   repoConfig.learnings = {};
@@ -156,6 +182,96 @@ test("setActivity ignores an unchanged value (no reactive churn)", () => {
   const before = reviews.activity;
   reviews.setActivity("s1", "$ git log"); // identical → same object reference kept
   expect(reviews.activity).toBe(before);
+});
+
+// ── review activity feed: rolling window + staleness invariant ──────────────
+// No line from a prior run or from before a reconnect may leak into a later in-flight preview.
+// Guaranteed by three reset points, verified below for BOTH stores: start (OFF→ON), end
+// (ON→OFF), and bootstrap/resync.
+
+test("reviews activityFeed accumulates distinct lines newest-last, capped at 4", () => {
+  reviews.setReviewing("s1", true);
+  for (const l of ["a", "b", "c", "d", "e"]) reviews.setActivity("s1", l);
+  expect(reviews.activityFeed("s1")).toEqual(["b", "c", "d", "e"]); // oldest ("a") dropped
+  expect(reviews.activityFor("s1")).toBe("e"); // badge tooltip = newest line
+});
+
+test("reviews activityFeed dedups a repeated last line", () => {
+  reviews.setActivity("s1", "a");
+  reviews.setActivity("s1", "a");
+  reviews.setActivity("s1", "b");
+  expect(reviews.activityFeed("s1")).toEqual(["a", "b"]);
+});
+
+test("reviews activityFeed returns [] for an unknown id", () => {
+  expect(reviews.activityFeed("nope")).toEqual([]);
+});
+
+test("reviews: starting a review resets a leftover feed (defensive against a missed end-clear)", () => {
+  // straggler feed present while NOT reviewing (a missed end-clear from a prior run)
+  reviews.setActivity("s1", "stale-from-prior-run");
+  expect(reviews.activityFeed("s1")).toEqual(["stale-from-prior-run"]);
+  reviews.setReviewing("s1", true); // OFF→ON must wipe it — a new run starts empty
+  expect(reviews.activityFeed("s1")).toEqual([]);
+});
+
+test("reviews: drop clears the live activity feed", () => {
+  reviews.setReviewing("s1", true);
+  reviews.setActivity("s1", "read x");
+  reviews.drop("s1");
+  expect(reviews.activityFeed("s1")).toEqual([]);
+});
+
+test("reviews.load wipes any stale feed, even for a still-in-flight id", async () => {
+  reviews.setReviewing("s7", true);
+  reviews.setActivity("s7", "line from before the resync");
+  vi.mocked(getReviews).mockResolvedValue({});
+  vi.mocked(getReviewingIds).mockResolvedValue(["s7"]); // snapshot: s7 still in flight
+  await reviews.load();
+  expect(reviews.isReviewing("s7")).toBe(true); // still in flight…
+  expect(reviews.activityFeed("s7")).toEqual([]); // …but feed wiped; rebuilds from live events
+});
+
+// ── plan-gate activity feed: mirrors ReviewsStore ──────────────────────────
+
+test("planGates activityFeed accumulates, dedups, and resets on the ON→OFF transition", () => {
+  planGates.applyReviewing("p1", true);
+  planGates.setActivity("p1", "read plan");
+  planGates.setActivity("p1", "read plan"); // dedup
+  planGates.setActivity("p1", "$ git diff");
+  expect(planGates.activityFeed("p1")).toEqual(["read plan", "$ git diff"]);
+  planGates.applyReviewing("p1", false); // end → clear
+  expect(planGates.activityFeed("p1")).toEqual([]);
+});
+
+test("planGates: a leftover feed is wiped when a new review starts", () => {
+  planGates.setActivity("p1", "stale"); // straggler while not reviewing
+  planGates.applyReviewing("p1", true); // OFF→ON must wipe it
+  expect(planGates.activityFeed("p1")).toEqual([]);
+});
+
+test("planGates: applying a verdict clears the feed", () => {
+  planGates.applyReviewing("p1", true);
+  planGates.setActivity("p1", "read plan");
+  planGates.apply("p1", planGate("p1"));
+  expect(planGates.activityFeed("p1")).toEqual([]);
+});
+
+test("planGates: drop clears the feed", () => {
+  planGates.applyReviewing("p1", true);
+  planGates.setActivity("p1", "read plan");
+  planGates.drop("p1");
+  expect(planGates.activityFeed("p1")).toEqual([]);
+});
+
+test("planGates.load wipes any stale feed, even for a still-in-flight id", async () => {
+  planGates.applyReviewing("p9", true);
+  planGates.setActivity("p9", "line before resync");
+  vi.mocked(getPlanGates).mockResolvedValue({});
+  vi.mocked(getPlanGatesInflight).mockResolvedValue(["p9"]);
+  await planGates.load();
+  expect(planGates.isReviewing("p9")).toBe(true);
+  expect(planGates.activityFeed("p9")).toEqual([]);
 });
 
 test("repoConfig.isEnabled returns true for unknown repo (default-on)", () => {

--- a/ui/src/lib/reviews.svelte.ts
+++ b/ui/src/lib/reviews.svelte.ts
@@ -11,15 +11,31 @@ import {
   putRepoConfig,
 } from "./api";
 
+/** Max lines kept in a review's rolling live-activity feed (the terminal preview shows these,
+ *  newest at the bottom). Bounded so the ephemeral tail can't grow without limit. */
+export const MAX_ACTIVITY_LINES = 4;
+
+/** Append `summary` to a bounded rolling feed, deduping against the last line (the server
+ *  re-emits the same summary every tick → no churn). Returns the SAME array reference when
+ *  nothing changed so callers can skip a reactive write. */
+function pushActivity(cur: string[] | undefined, summary: string): string[] {
+  const feed = cur ?? [];
+  if (feed[feed.length - 1] === summary) return feed; // unchanged → signal no-op to caller
+  return [...feed, summary].slice(-MAX_ACTIVITY_LINES);
+}
+
 /** Client cache of critic verdicts keyed by session id. Loaded once on app start;
  *  live updates arrive via the `session:review` WS event (see store.svelte.ts). */
 class ReviewsStore {
   map = $state<Record<string, ReviewVerdict>>({});
   // session ids with a critic run currently in flight; driven by `session:reviewing`
   reviewing = $state<Record<string, boolean>>({});
-  // latest tool-use summary of the in-flight critic, keyed by session id; driven by
-  // `session:critic-activity`. Surfaced in the badge tooltip; cleared when the run ends.
-  activity = $state<Record<string, string>>({});
+  // rolling live-activity feed (last MAX_ACTIVITY_LINES tool-use summaries) of the in-flight
+  // critic, keyed by session id; driven by `session:critic-activity`. Surfaced in the badge
+  // tooltip (latest line) and the review-in-flight banner preview (full feed). RESET on both
+  // ends of a reviewing transition (start + end) and wiped on bootstrap — see the staleness
+  // invariant: no line from a prior run or from before a reconnect may leak into a later preview.
+  activity = $state<Record<string, string[]>>({});
 
   async load() {
     try {
@@ -30,6 +46,9 @@ class ReviewsStore {
     try {
       // bootstrap in-flight runs so a reload mid-review still shows the indicator
       this.reviewing = Object.fromEntries((await getReviewingIds()).map((id) => [id, true]));
+      // Snapshot carries no historical activity → any pre-existing feed is stale after a resync.
+      // Wipe it; the live feed rebuilds from `session:critic-activity` within ~1 tick.
+      this.activity = {};
     } catch {
       /* best-effort; `session:reviewing` events still populate it */
     }
@@ -48,20 +67,27 @@ class ReviewsStore {
 
   setReviewing(id: string, on: boolean) {
     if (!!this.reviewing[id] === on) return;
+    // Any genuine transition resets the feed: on START a new run must begin empty (defensive
+    // against a missed end-clear), on END the finished run's live tail is stale. Guarded by the
+    // early return above so a repeated same-state call doesn't clear.
+    this.clearActivity(id);
     if (on) this.reviewing = { ...this.reviewing, [id]: true };
     else {
       const copy = { ...this.reviewing };
       delete copy[id];
       this.reviewing = copy;
-      this.clearActivity(id); // run ended → its live activity is stale
     }
   }
 
-  /** Record the in-flight critic's latest tool-use summary; ignores an unchanged value
-   *  so the server re-emitting the same line every tick causes no reactive churn. */
+  /** Append the in-flight critic's latest tool-use summary to its bounded rolling feed
+   *  (last MAX_ACTIVITY_LINES). Dedups against the last line so the server re-emitting the
+   *  same line every tick causes no reactive churn. No `reviewing` gate needed: the preview
+   *  only renders in-flight and every run starts empty, so a straggler tick after the end can
+   *  never surface (see staleness invariant). */
   setActivity(id: string, summary: string) {
-    if (this.activity[id] === summary) return;
-    this.activity = { ...this.activity, [id]: summary };
+    const next = pushActivity(this.activity[id], summary);
+    if (next === this.activity[id]) return; // unchanged reference → no churn
+    this.activity = { ...this.activity, [id]: next };
   }
 
   private clearActivity(id: string) {
@@ -71,8 +97,15 @@ class ReviewsStore {
     this.activity = copy;
   }
 
+  /** Latest feed line (for the badge tooltip); null when the feed is empty/absent. */
   activityFor(id: string): string | null {
-    return this.activity[id] ?? null;
+    const feed = this.activity[id];
+    return feed && feed.length ? feed[feed.length - 1]! : null;
+  }
+
+  /** The full rolling feed (oldest→newest) for the banner preview; [] when absent. */
+  activityFeed(id: string): string[] {
+    return this.activity[id] ?? [];
   }
 
   isReviewing(id: string): boolean {
@@ -97,12 +130,20 @@ export class PlanGateStore {
   map = $state<Record<string, PlanGate>>({});
   // session ids whose plan reviewer is currently in flight; driven by `session:plangate-reviewing`
   reviewing = $state<Record<string, boolean>>({});
+  // rolling live-activity feed (last MAX_ACTIVITY_LINES) of the in-flight plan reviewer; driven
+  // by `session:plangate-activity`, surfaced in the review-in-flight banner preview. Same
+  // staleness invariant as ReviewsStore: reset on both ends of a reviewing transition and wiped
+  // on bootstrap so no line from a prior run or from before a reconnect leaks into a later preview.
+  activity = $state<Record<string, string[]>>({});
 
   /** Bootstrap from a GET /api/plan-gates snapshot + GET /api/plan-gates/inflight ids,
    *  so a reload mid-review still shows verdicts and the in-flight indicator. */
   bootstrap(map: Record<string, PlanGate>, inflightIds: string[]) {
     this.map = map;
     this.reviewing = Object.fromEntries(inflightIds.map((id) => [id, true]));
+    // Snapshot carries no historical activity → wipe any stale feed; it rebuilds from
+    // `session:plangate-activity` within ~1 tick. Covers load() (which calls through here).
+    this.activity = {};
   }
 
   /** Re-fetch the snapshot + in-flight ids from the server (best-effort). */
@@ -130,12 +171,34 @@ export class PlanGateStore {
 
   applyReviewing(id: string, on: boolean) {
     if (!!this.reviewing[id] === on) return;
+    // Reset the feed on both ends of a transition (start = fresh empty run, end = stale tail).
+    this.clearActivity(id);
     if (on) this.reviewing = { ...this.reviewing, [id]: true };
     else {
       const copy = { ...this.reviewing };
       delete copy[id];
       this.reviewing = copy;
     }
+  }
+
+  /** Append the in-flight plan reviewer's latest tool-use summary to its bounded rolling feed
+   *  (last MAX_ACTIVITY_LINES), deduping against the last line. Mirrors ReviewsStore.setActivity. */
+  setActivity(id: string, summary: string) {
+    const next = pushActivity(this.activity[id], summary);
+    if (next === this.activity[id]) return; // unchanged reference → no churn
+    this.activity = { ...this.activity, [id]: next };
+  }
+
+  private clearActivity(id: string) {
+    if (!(id in this.activity)) return;
+    const copy = { ...this.activity };
+    delete copy[id];
+    this.activity = copy;
+  }
+
+  /** The full rolling feed (oldest→newest) for the banner preview; [] when absent. */
+  activityFeed(id: string): string[] {
+    return this.activity[id] ?? [];
   }
 
   isReviewing(id: string): boolean {

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -642,6 +642,39 @@ test("session:critic-activity routes to the reviews store", async () => {
   expect(reviews.activityFor("s1")).toBe("$ git diff");
 });
 
+test("session:plangate-activity routes to the plan-gates store feed", async () => {
+  const { planGates } = await import("./reviews.svelte");
+  planGates.activity = {};
+  planGates.reviewing = {};
+  const s = new HerdStore();
+  s.apply({ event: "session:plangate-activity", data: { id: "s1", summary: "read plan" } });
+  expect(planGates.activityFeed("s1")).toEqual(["read plan"]);
+});
+
+test("session:plangate-reviewing false clears the plan-gate activity feed", async () => {
+  const { planGates } = await import("./reviews.svelte");
+  planGates.activity = {};
+  planGates.reviewing = {};
+  const s = new HerdStore();
+  s.apply({ event: "session:plangate-reviewing", data: { id: "s1", reviewing: true } });
+  s.apply({ event: "session:plangate-activity", data: { id: "s1", summary: "read plan" } });
+  expect(planGates.activityFeed("s1")).toEqual(["read plan"]);
+  s.apply({ event: "session:plangate-reviewing", data: { id: "s1", reviewing: false } });
+  expect(planGates.activityFeed("s1")).toEqual([]);
+});
+
+test("session:reviewing false clears the critic activity feed", async () => {
+  const { reviews } = await import("./reviews.svelte");
+  reviews.activity = {};
+  reviews.reviewing = {};
+  const s = new HerdStore();
+  s.apply({ event: "session:reviewing", data: { id: "s1", reviewing: true } });
+  s.apply({ event: "session:critic-activity", data: { id: "s1", summary: "$ git diff" } });
+  expect(reviews.activityFeed("s1")).toEqual(["$ git diff"]);
+  s.apply({ event: "session:reviewing", data: { id: "s1", reviewing: false } });
+  expect(reviews.activityFeed("s1")).toEqual([]);
+});
+
 // ── session:subagents ──────────────────────────────────────────────────────
 
 const SUBAGENTS: SubagentEntry[] = [{ agentId: "a1", agentType: "Explore", startedAt: 1000 }];

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -580,6 +580,9 @@ export class HerdStore {
       case "session:plangate-reviewing":
         planGates.applyReviewing(ev.data.id, ev.data.reviewing);
         return true;
+      case "session:plangate-activity":
+        planGates.setActivity(ev.data.id, ev.data.summary);
+        return true;
       default:
         return false;
     }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1557,6 +1557,7 @@ export type WsEvent =
       data: { id: string; gate?: PlanGate; planPhase?: "planning" | "executing" };
     }
   | { event: "session:plangate-reviewing"; data: { id: string; reviewing: boolean } }
+  | { event: "session:plangate-activity"; data: { id: string; summary: string } }
   | { event: "learnings:update"; data: { pending: number } }
   | {
       event: "plugin:status";


### PR DESCRIPTION
## Was & Warum

Wenn der amber **„A review is running"**-Balken zeigt, dass ein Review (PR-Critic oder Plan-Gate) läuft, geschieht das **off-screen** in einem separaten Worktree/PTY — das Session-Terminal ist dabei still und der Operator hat keine Sicht darauf, *was* der Review gerade tut. Diese PR macht das sichtbar:

- **Live-Preview (max. 4 Zeilen, „tail -f"-artig)** direkt unter dem Balken: der semantische Aktivitäts-Feed des Reviewers (`read review.ts`, `$ git diff`, …), neueste Zeile unten.
- **Terminal rein visuell gedimmt** (opacity 0.5, kein Blur), solange der Review läuft — „Shepherd arbeitet, keine Terminaleingaben nötig". Der Prompt bleibt nutzbar (nicht-blockierend, kein Modal-Scrim).

Gilt für **beide** Reviews. Der PR-Critic hatte das Live-Signal schon (im Badge-Tooltip); der **Plan-Gate** bekommt es hier serverseitig nachgerüstet.

## Umsetzung

- **Server** (`src/plan-gate.ts`, `src/index.ts`): neues WS-Event `session:plangate-activity`, aus dem Reviewer-Transkript pro Tick gelesen (`readActivity`/`onActivity`, spiegelt exakt `ReviewService`).
- **UI-Transport** (`types.ts`, `store.svelte.ts`): Event-Union + Dispatch.
- **Stores** (`reviews.svelte.ts`): rollender Feed (letzte 4 Zeilen, dedupt) in **beiden** Stores.
- **Banner** (`ReviewInFlightBanner.svelte`): feste 4-Zeilen-Preview, **nur** in der In-Flight-Phase (nicht addressing/conclusion), `aria-hidden`, Leerzustand; bindet ein `inflight`-Signal aus.
- **Terminal** (`Viewport.svelte`): dimmt `.term-mount` genau bei diesem `inflight`-Signal.
- **i18n** (en/de) + **Feature-Katalog-Eintrag** `v1.43.0-review-live-preview.ts`.

### Zwei Design-Entscheidungen (verankert)

1. **Kopplung an die In-Flight-*Phase*, nicht an rohes `isReviewing`.** In-Flight läuft der Reviewer separat → Terminal still → Dimmen/Preview sinnvoll. In *addressing* arbeitet der Agent **im** Terminal (kein Dimmen); der Critic-Balken hängt zudem an Auto-Address=ON, sonst steuert das Verdict die Session nicht → dann **kein** Dimmen ohne sichtbaren Grund.
2. **Staleness-Invariante:** In einer Preview erscheint nie eine Zeile eines früheren Laufs oder von vor einem Reconnect — garantiert durch drei symmetrische Reset-Punkte (Start / Ende / Bootstrap) in beiden Stores.

## Tests / Verifikation

- Neu: `ReviewInFlightBanner.browser.test.ts` (4-Zeilen-Cap, newest-bottom, Leerzustand, stabile Höhe, In-Flight-only inkl. Negativfälle addressing/conclusion/auto-address-off) und Dim-Tests in `Viewport.browser.test.ts` (beide Reviews + Negativfälle). Store-Lifecycle-Tests (Start/Ende/Bootstrap) für beide Stores; Server-Tests für die Tick-Emission.
- Grün: UI `check` (0 Fehler) · `check:i18n` (Parität) · `bun run test` (3154) · Root `lint` · `tsc` · `bun test ./test` (6301, im /tmp-Worktree wegen des bekannten Session-Worktree-Hangs).

_Keine manuellen Schritte nötig — die Änderung ist selbstenthaltend (Server emittiert ein neues WS-Event, UI konsumiert es)._