### PR TITLE
feat(herd): highlight cards awaiting the operator with a subtle wash

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2808,5 +2808,7 @@
   "settings_operator_language_hint": "Die Sprache, in der Shepherds Agenten mit dir sprechen — Status, Rückfragen, Pläne, Übergaben. Unabhängig von der Sprache dieser Oberfläche. Code, Befehle, Logs und GitHub-Texte bleiben in ihrer Originalsprache.",
   "settings_operator_language_save_failed": "Betreibersprache konnte nicht gespeichert werden.",
   "feat_operator_language_title": "Agenten sprechen deine Sprache",
-  "feat_operator_language_body": "Lege in den Einstellungen eine Betreibersprache fest, und Shepherds gestartete Agenten verfassen ihre Statusupdates, Rückfragen, Planerklärungen und Übergaben in dieser Sprache. Code, Befehle, Logs, Commit-Nachrichten und GitHub-Issue-/PR-Texte bleiben in ihrer Originalsprache."
+  "feat_operator_language_body": "Lege in den Einstellungen eine Betreibersprache fest, und Shepherds gestartete Agenten verfassen ihre Statusupdates, Rückfragen, Planerklärungen und Übergaben in dieser Sprache. Code, Befehle, Logs, Commit-Nachrichten und GitHub-Issue-/PR-Texte bleiben in ihrer Originalsprache.",
+  "feat_attention_highlight_title": "Karten, die auf dich warten, heben sich ab",
+  "feat_attention_highlight_body": "Wenn ein Agent stoppt und deine Entscheidung braucht (eine Menüauswahl, eine Plan-Review-Entscheidung, ein Halt bei einem Fehler), trägt seine Karte im Herd jetzt einen leichten roten Schimmer. So erkennst du auf einen Blick, wer wartet."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2808,5 +2808,7 @@
   "settings_operator_language_hint": "The language Shepherd's agents use to talk to you — status, questions, plans, handoffs. Independent of this interface's language. Code, commands, logs, and GitHub text stay in their original language.",
   "settings_operator_language_save_failed": "Couldn't save the operator language.",
   "feat_operator_language_title": "Agents can speak your language",
-  "feat_operator_language_body": "Set an operator language in Settings and Shepherd's spawned agents write their status updates, questions, plan explanations, and handoffs in that language. Code, commands, logs, commit messages, and GitHub issue/PR text stay in their original language."
+  "feat_operator_language_body": "Set an operator language in Settings and Shepherd's spawned agents write their status updates, questions, plan explanations, and handoffs in that language. Code, commands, logs, commit messages, and GitHub issue/PR text stay in their original language.",
+  "feat_attention_highlight_title": "Cards awaiting you stand out",
+  "feat_attention_highlight_body": "When an agent stops and needs your call (a menu choice, a plan-review decision, a halt on an error), its card in the herd now carries a faint red wash, so you can spot who is waiting at a glance."
 }

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -142,6 +142,13 @@
      reads as alarm; the same recipe is re-tuned for light below. */
   --wash-blocked: color-mix(in srgb, var(--color-red) 24%, var(--color-head));
   --wash-done: color-mix(in srgb, var(--color-slate) 24%, var(--color-head));
+  /* Card-level attention wash for a session whose HOLD means the agent has
+     stopped and awaits the operator (see holdAwaitsOperator in lib/hold.ts).
+     Deliberately much lighter than --wash-blocked (a full card in a dense list,
+     not a header bezel) and mixed toward --color-panel (the card's own ground)
+     so it stays "nur ganz leicht" — a subordinate red that never out-competes
+     the blocked pip or the --wash-blocked header. */
+  --wash-attention: color-mix(in srgb, var(--color-red) 7%, var(--color-panel));
 
   /* Wireframe mockup tokens — themed off the semantic --color-* layer (read as computed
      values by WireframeBlock and injected into its sandboxed iframe, which can't inherit these). */
@@ -198,6 +205,10 @@
      (slate, near-neutral) blends cleanly enough to keep the srgb recipe. */
   --wash-blocked: oklch(0.86 0.065 23);
   --wash-done: color-mix(in srgb, var(--color-slate) 24%, var(--color-head));
+  /* sRGB-blending red toward near-white muddies into dusty pink (same reason as
+     --wash-blocked above); hand-tune a very light, low-chroma warm rose in OKLCH,
+     hue aligned to --red (~23) and lighter than the blocked wash. */
+  --wash-attention: oklch(0.965 0.016 23);
 }
 
 /* ── High contrast (WCAG / "Brillenträger") ──────────────────────────────────

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -4,7 +4,7 @@ import { page } from "vitest/browser";
 import "../../app.css";
 import UnitRow from "./UnitRow.svelte";
 import { projectIcons } from "$lib/projectIcons.svelte";
-import type { PlanGate, Session } from "$lib/types";
+import type { HoldReason, PlanGate, Session } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
 import type { ReviewVerdict } from "$lib/types";
 
@@ -946,5 +946,109 @@ describe("UnitRow stepper bar", () => {
     // Clicking the halo selects the row exactly once.
     halo.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(selected, "halo click forwards exactly one onselect").toEqual(["step-1"]);
+  });
+});
+
+describe("UnitRow awaits-operator attention wash", () => {
+  const unitEl = (id: string) => document.querySelector(`[data-unit-id="${id}"]`) as HTMLElement;
+
+  // Resolve a CSS color expression to its computed rgb() so the composition test can
+  // compare against the plain selected surface without pinning a literal value.
+  function resolvedBackgroundColor(cssValue: string): string {
+    const el = document.createElement("div");
+    el.style.background = cssValue;
+    document.body.appendChild(el);
+    const color = getComputedStyle(el).backgroundColor;
+    el.remove();
+    return color;
+  }
+
+  const renderHold = (id: string, hold: HoldReason | undefined, extra: Partial<Session> = {}) =>
+    render(UnitRow, {
+      session: session({ id, status: "idle", ...extra }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+      hold,
+    });
+
+  it("applies .awaits-operator for a parked plan-rework hold", () => {
+    renderHold("aw-plan", { code: "plan-rework", params: { round: 2, cap: 5 } });
+    expect(unitEl("aw-plan").classList.contains("awaits-operator")).toBe(true);
+  });
+
+  it("applies .awaits-operator for a blocked-menu hold", () => {
+    render(UnitRow, {
+      session: session({ id: "aw-menu", status: "blocked" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+      hold: { code: "blocked-menu" },
+    });
+    expect(unitEl("aw-menu").classList.contains("awaits-operator")).toBe(true);
+  });
+
+  it("does NOT apply for excluded holds (ci-red / critic-rework / merging)", () => {
+    for (const [id, code] of [
+      ["aw-ci", "ci-red"],
+      ["aw-critic", "critic-rework"],
+      ["aw-merging", "merging"],
+    ] as const) {
+      renderHold(id, { code });
+      expect(unitEl(id).classList.contains("awaits-operator"), code).toBe(false);
+    }
+  });
+
+  it("does NOT apply when there is no hold", () => {
+    renderHold("aw-none", undefined);
+    expect(unitEl("aw-none").classList.contains("awaits-operator")).toBe(false);
+  });
+
+  it("does NOT apply while running — the agent is the actor (e.g. active plan rework)", () => {
+    // The server emits plan-rework for a still-running planning session that is
+    // actively addressing changes; that is the agent's turn, not the operator's.
+    render(UnitRow, {
+      session: session({ id: "aw-running", status: "running", planPhase: "planning" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+      hold: { code: "plan-rework", params: { round: 2, cap: 5 } },
+    });
+    expect(unitEl("aw-running").classList.contains("awaits-operator")).toBe(false);
+  });
+
+  it("does NOT apply to a working-while-blocked session (display-running, mid-turn)", () => {
+    render(UnitRow, {
+      session: session({ id: "aw-wb", status: "blocked" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+      hold: { code: "blocked-menu" },
+      workingBlocked: { "aw-wb": true },
+    });
+    expect(unitEl("aw-wb").classList.contains("awaits-operator")).toBe(false);
+  });
+
+  it("does NOT apply to a readyToMerge card even under an otherwise-included hold (green ✓ guard)", () => {
+    renderHold("aw-ready", { code: "plan-rework" }, { readyToMerge: true });
+    expect(unitEl("aw-ready").classList.contains("awaits-operator")).toBe(false);
+  });
+
+  it("composes with selection: keeps both classes and a wash-tinted background", () => {
+    render(UnitRow, {
+      session: session({ id: "aw-sel", status: "idle" }),
+      selected: true,
+      nowMs: Date.now(),
+      onselect: () => {},
+      hold: { code: "plan-rework", params: { round: 2, cap: 5 } },
+    });
+    const unit = unitEl("aw-sel");
+    expect(unit.classList.contains("awaits-operator")).toBe(true);
+    expect(unit.classList.contains("sel")).toBe(true);
+    // the wash is composited INTO the selected background, so it differs from the
+    // plain selected surface (--color-sel) and is not transparent.
+    const bg = getComputedStyle(unit).backgroundColor;
+    expect(bg).not.toBe(resolvedBackgroundColor("var(--color-sel)"));
+    expect(bg).not.toBe("rgba(0, 0, 0, 0)");
   });
 });

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -35,6 +35,7 @@
   import { onDestroy } from "svelte";
   import UnitRowRight from "./unit-row/UnitRowRight.svelte";
   import { rowHold } from "$lib/hold-row";
+  import { holdAwaitsOperator } from "$lib/hold";
   import {
     REVEAL_PX,
     snapOffset,
@@ -119,6 +120,22 @@
   // working-while-blocked session gets the full working treatment. Behavioral
   // reads (canResume) stay on the raw status.
   const dStatus = $derived(displayStatus(session, workingBlocked));
+
+  // The agent has stopped and awaits a DIRECT operator action → a subordinate red
+  // card wash (--wash-attention). See holdAwaitsOperator for the (deliberately
+  // narrow, agency-based) hold set. Two gates keep the wash honest:
+  //  - dStatus !== "running": a mid-turn session is the ACTOR, not waiting on you.
+  //    The server emits some operator-waiting holds (notably plan-rework) for a
+  //    still-running planning session that is actively addressing the requested
+  //    changes — that is the agent's turn, so it must not read as "you're up".
+  //    Using dStatus (not raw status) also excludes a working-while-blocked session
+  //    (display-running, shows the amber working pip), keeping the wash in step with
+  //    the pip rather than fighting it.
+  //  - !readyToMerge: a green ✓ (actionable-complete) card never takes a red wash
+  //    under it (Four-Light Rule).
+  const awaitsOperator = $derived(
+    !session.readyToMerge && dStatus !== "running" && !!hold && holdAwaitsOperator(hold),
+  );
 
   // repo the unit works in — the last path segment of its repoPath (e.g. "community-map")
   const repoName = $derived(session.repoPath.split("/").filter(Boolean).at(-1) ?? session.repoPath);
@@ -568,6 +585,7 @@
     class="unit"
     class:sel={selected}
     class:has-activity={live}
+    class:awaits-operator={awaitsOperator}
     class:decommissioning
     data-unit-id={session.id}
     style="--rule:{session.readyToMerge ? 'var(--color-green)' : STATUS_COLOR[dStatus]}"
@@ -1023,6 +1041,28 @@
     border-left: 0;
     border-top: 0;
     pointer-events: none;
+  }
+
+  /* Card-level attention wash: the agent has stopped and awaits a direct operator
+     action (see awaitsOperator / holdAwaitsOperator). A subordinate red tint that
+     makes "you're the next actor" legible at a glance without out-competing the
+     blocked pip or the --wash-blocked header. Composed with hover + selection so a
+     waiting card keeps its identity in every state; the pip / hold line carry the
+     non-color cue (WCAG 1.4.1), this tint only reinforces it. */
+  .unit.awaits-operator {
+    background: var(--wash-attention);
+  }
+  .unit.awaits-operator:hover {
+    background: color-mix(in srgb, var(--color-hover) 55%, var(--wash-attention));
+  }
+  .unit.awaits-operator.sel {
+    background:
+      radial-gradient(
+        120% 140% at 0% 50%,
+        color-mix(in srgb, var(--rule) 12%, transparent),
+        transparent 70%
+      ),
+      color-mix(in srgb, var(--color-sel) 78%, var(--wash-attention));
   }
 
   .pip-col {

--- a/ui/src/lib/feature-announcements/entries/v1.43.0-attention-card-highlight.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.43.0-attention-card-highlight.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "attention-card-highlight",
+  sinceVersion: "1.43.0",
+  titleKey: "feat_attention_highlight_title",
+  bodyKey: "feat_attention_highlight_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/hold.test.ts
+++ b/ui/src/lib/hold.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { holdAwaitsOperator } from "./hold";
+import type { HoldCode } from "./types";
+
+// The INTENDED classification, declared independently of hold.ts's HOLD_AWAITS_OPERATOR
+// map so a divergent edit there is caught. Typed as Record<HoldCode, boolean> so a newly
+// added HoldCode fails to compile here until its expected value is stated — the test's
+// exhaustiveness guard mirrors the map's.
+const EXPECTED: Record<HoldCode, boolean> = {
+  // The agent has stopped and awaits a DIRECT operator action → wash.
+  "halted-error": true,
+  "autopilot-paused": true,
+  "blocked-menu": true,
+  "blocked-yes-no": true,
+  "blocked-awaiting-input": true,
+  "blocked-generic": true,
+  "plan-rework": true,
+  "plan-question": true,
+  "manual-steps": true,
+  // Failure / advisory / autonomous / auto-resuming / handed-off / green-complete → no wash.
+  "blocked-stall": false,
+  "quota-rework": false,
+  "quota-review": false,
+  "quota-error": false,
+  "quota-plan": false,
+  "critic-rework": false,
+  "ci-red": false,
+  "awaiting-merge": false,
+  "train-error": false,
+  stalled: false,
+  "recap-attention": false,
+  merging: false,
+  "merge-rebasing": false,
+  "ready-merge": false,
+  "halted-usage": false,
+};
+
+describe("holdAwaitsOperator", () => {
+  for (const [code, expected] of Object.entries(EXPECTED) as [HoldCode, boolean][]) {
+    it(`${code} → ${expected}`, () => {
+      expect(holdAwaitsOperator({ code })).toBe(expected);
+    });
+  }
+
+  it("washes exactly the nine agent-awaits-operator holds", () => {
+    const wash = Object.entries(EXPECTED)
+      .filter(([, v]) => v)
+      .map(([k]) => k)
+      .sort();
+    expect(wash).toEqual(
+      [
+        "autopilot-paused",
+        "blocked-awaiting-input",
+        "blocked-generic",
+        "blocked-menu",
+        "blocked-yes-no",
+        "halted-error",
+        "manual-steps",
+        "plan-question",
+        "plan-rework",
+      ].sort(),
+    );
+  });
+
+  it("never washes a failure / non-agent state (no-failure-wash rule)", () => {
+    for (const code of ["ci-red", "train-error", "halted-usage"] as HoldCode[]) {
+      expect(holdAwaitsOperator({ code })).toBe(false);
+    }
+  });
+});

--- a/ui/src/lib/hold.ts
+++ b/ui/src/lib/hold.ts
@@ -46,3 +46,59 @@ const HOLD_LINE: Record<HoldCode, (hold: HoldReason) => string> = {
 export function holdLine(hold: HoldReason): string {
   return HOLD_LINE[hold.code](hold);
 }
+
+/** Does this hold mean the agent has stopped and awaits a DIRECT operator action?
+ *  Drives the card-level attention wash (UnitRow `.awaits-operator` + --wash-attention).
+ *
+ *  This is a VISUAL, agency-based classification — deliberately its OWN set, NOT the
+ *  behavioral "needs you" the rest of the app already defines differently:
+ *    - nextNeedsYou / CommandBar / common_needs_you → only `status === "blocked"`
+ *    - tab-signal.svelte.ts                          → blocked · ci-red · ready-to-merge
+ *    - Ready lens (shownSessions "ready")            → idle · blocked · done
+ *  and NOT the server rundown's SIGNAL_TIER (src/rundown-core.ts), which ranks by
+ *  URGENCY (e.g. critic-rework Tier 1, ready-merge Tier 3), not agency. The wash is
+ *  "rein visuell" and must not drift into any of those behavioral paths.
+ *
+ *  Excluded on purpose:
+ *    - ci-red / train-error / halted-usage: non-agent FAILURE / external limit — the
+ *      design system reserves a wash for blocked-AGENT state; failures get a subordinate
+ *      red chip, never a wash (DESIGN.md "Neither carries a halo, pulse, or wash").
+ *    - blocked-stall / stalled / recap-attention: uncertain heuristic / advisory nudge,
+ *      not a proven operator block.
+ *    - quota-*: limit-exhaustion; still carries the loud red "!" pip on its own.
+ *    - critic-rework / merging / merge-rebasing / awaiting-merge: autonomous or handed off.
+ *    - ready-merge: a green ✓ actionable-complete state (also guarded by !readyToMerge at
+ *      the callsite) — a red wash under green would break the Four-Light Rule.
+ *
+ *  Exhaustive Record so a newly-added HoldCode fails to compile until it is classified. */
+const HOLD_AWAITS_OPERATOR: Record<HoldCode, boolean> = {
+  "halted-error": true,
+  "autopilot-paused": true,
+  "blocked-menu": true,
+  "blocked-yes-no": true,
+  "blocked-awaiting-input": true,
+  "blocked-generic": true,
+  "plan-rework": true,
+  "plan-question": true,
+  "manual-steps": true,
+  "blocked-stall": false,
+  "quota-rework": false,
+  "quota-review": false,
+  "quota-error": false,
+  "quota-plan": false,
+  "critic-rework": false,
+  "ci-red": false,
+  "awaiting-merge": false,
+  "train-error": false,
+  stalled: false,
+  "recap-attention": false,
+  merging: false,
+  "merge-rebasing": false,
+  "ready-merge": false,
+  "halted-usage": false,
+};
+
+/** See HOLD_AWAITS_OPERATOR — the card-attention-wash predicate. */
+export function holdAwaitsOperator(hold: HoldReason): boolean {
+  return HOLD_AWAITS_OPERATOR[hold.code];
+}


### PR DESCRIPTION
## Was

Im Herd-Seitenrail (Live-Side-Mode) heben sich Karten, bei denen **der Agent gestoppt hat und direkt auf den Anwender wartet**, jetzt mit einem **sehr leichten roten Wash** ab – nicht mehr nur über das rote `!`-Pip.

## Warum

Das rote `!`-Pip (`StatusPip`) feuert nur bei `status === "blocked"`. Eine **geparkte** Session mit `plan-rework` („Plan-Review fordert Änderungen") wartet genauso auf den Anwender, zeigt aber nur ein ruhiges Slate-Pip + eine graue Textzeile. Zwei Zustände, die man als eine Klasse liest, rendern auf ganz verschiedenen Lautstärken. Der Wash macht „du bist der nächste Handelnde" sichtbar, unabhängig von der Pip-Farbe (Design-Prinzip #2, „quiet until it needs you").

## Wie

- **`holdAwaitsOperator(hold)`** in `ui/src/lib/hold.ts` – ein **erschöpfendes** `Record<HoldCode, boolean>` (ein neuer HoldCode kompiliert nicht, bis er eingeordnet ist). Klassifiziert nach **Agentur** („bin ich der nächste Handelnde?"), bewusst getrennt von den drei bestehenden „needs you"-Pfaden und vom Server-`SIGNAL_TIER`.
- **`--wash-attention`** in `app.css` (dunkel ~7 % red→panel; hell hand-getunter OKLCH-Rosé, analog zum bestehenden `--wash-blocked`).
- **`UnitRow.svelte`**: `awaitsOperator = !readyToMerge && !!hold && holdAwaitsOperator(hold)` → `class:awaits-operator`; CSS komponiert mit Hover + Auswahl.

### Umfang (Wash ✅ / kein Wash ❌)

| Hold | Wash |
|---|---|
| `blocked-menu/yes-no/awaiting-input/generic`, `autopilot-paused`, `plan-rework`, `plan-question`, `halted-error`, `manual-steps` | ✅ |
| `ci-red`, `train-error`, `halted-usage` | ❌ **No-Failure-Wash-Regel** (DESIGN.md:154 – Fehler bekommen rotes Chip, nie einen Wash) |
| `quota-*`, `blocked-stall`, `stalled`, `recap-attention` | ❌ fehlernah / unsichere Heuristik / Advisory |
| `critic-rework`, `merging`, `merge-rebasing`, `awaiting-merge` | ❌ autonom / an anderen übergeben |
| `ready-merge` / jede `readyToMerge`-Karte | ❌ grünes ✓ (Four-Light-Rule; per `!readyToMerge`-Guard erzwungen) |

## Design-System-Konformität

- Semantischer Token statt Literal; theme-aware (dunkel + hell).
- Rot nach Lautstärke rationiert – Hierarchie bleibt: pulsierendes `!`-Pip > `--wash-blocked` (24 %) > `--wash-attention` (~7 %).
- Non-Color-Cue (Pip / Hold-Textzeile) trägt die Bedeutung; der Wash verstärkt nur (WCAG 1.4.1).
- **Rein visuell:** Zähler, ⌘K-„zur nächsten"-Navigation, Tab-Signal und Ready-Lens bleiben unverändert – daher der eigenständige Name `awaits-operator` (kein „needs-you"-Drift).

## Tests / Checks

- `hold.test.ts` – erschöpfende Klassifikation (24 Codes, 9 true / 15 false) + No-Failure-Wash-Guard.
- `UnitRow.browser.test.ts` – Klasse vorhanden für `plan-rework`/`blocked-menu`, abwesend für `ci-red`/`critic-rework`/`merging`/`readyToMerge`, plus Auswahl-Komposition.
- `bun run check` (0 Fehler), `check:i18n` (Parität), PR-Hygiene-Gates (branch-hygiene, feature-catalog, announcement-versions) grün.

## Hinweis

Die Wash-Werte sind bewusst konservativ gewählt („nur ganz leicht", dunkel kaum sichtbar / hell eine Spur präsenter) und lassen sich in der Live-Preview leicht nachjustieren.
