### PR TITLE
fix(onboarding): failing optional remediation must not abort the apply (#1577)

### DIFF
--- a/ci/onboarding-harness/apply.ts
+++ b/ci/onboarding-harness/apply.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { IncusDriver } from "./incus";
-import { remediationsFor } from "../../src/remediations";
+import { remediationEntriesFor } from "../../src/remediations";
 import type { DiagnosticsSnapshot } from "../../src/types";
 
 export interface CoachingLine {
@@ -64,16 +64,66 @@ function shellQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`;
 }
 
-/** Run each harness-catalog remediation (keyed by Shepherd's emitted hintKeys)
- *  verbatim inside the instance. Returns false if any command exits non-zero. */
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/** Run one remediation inside the instance with a bounded retry, so a single transient
+ *  network/mirror flake in a download-and-install command doesn't fail the apply (#1577).
+ *  Returns the final exit code (0 ⇒ it eventually succeeded within `attempts`). */
+async function runWithRetry(
+  driver: IncusDriver,
+  name: string,
+  cmd: string,
+  attempts: number,
+  delayMs: number,
+): Promise<number> {
+  let code = 0;
+  for (let i = 1; i <= attempts; i++) {
+    const r = await driver.exec(name, ["sh", "-c", cmd]);
+    code = r.code;
+    if (code === 0) return 0;
+    if (i < attempts) await sleep(delayMs);
+  }
+  return code;
+}
+
+/** Options for {@link applyVerbatim}. `attempts`/`delayMs` bound the per-remediation
+ *  transient-flake retry; tests pass `delayMs: 0` to stay instant. */
+export interface ApplyVerbatimOpts {
+  attempts?: number;
+  delayMs?: number;
+}
+
+/** Run each harness-catalog remediation (keyed by Shepherd's emitted hintKeys) verbatim
+ *  inside the instance, each with a bounded retry. Returns false when a REQUIRED
+ *  (non-optional) remediation still fails after its retries — that's a real regression and
+ *  must gate. A failing OPTIONAL-state remediation (an equivalent alternative is already
+ *  healthy — e.g. a broken third-party `codex` installer while `claude` is present) is
+ *  logged and skipped, never fatal: it must not red the release gate for an unrelated
+ *  defect (#1577). */
 export async function applyVerbatim(
   driver: IncusDriver,
   name: string,
   snapshot: DiagnosticsSnapshot,
+  opts: ApplyVerbatimOpts = {},
 ): Promise<boolean> {
-  for (const cmd of remediationsFor(snapshot)) {
-    const r = await driver.exec(name, ["sh", "-c", cmd]);
-    if (r.code !== 0) return false;
+  const attempts = opts.attempts ?? 2;
+  const delayMs = opts.delayMs ?? 3000;
+  for (const { id, cmd, optional } of remediationEntriesFor(snapshot)) {
+    // Retry guards a REQUIRED remediation against a transient flake that would red the
+    // gate. An optional remediation's failure is non-fatal anyway, so retrying a
+    // structurally-broken optional installer (e.g. codex) only burns a needless attempt +
+    // sleep every run — attempt it once, then skip. (#1577)
+    const code = await runWithRetry(driver, name, cmd, optional ? 1 : attempts, delayMs);
+    if (code !== 0) {
+      if (optional) {
+        console.log(
+          `[${name}] optional remediation for ${id} failed (exit ${code}); ` +
+            `continuing — not fatal to the apply`,
+        );
+        continue;
+      }
+      return false;
+    }
   }
   return true;
 }

--- a/src/remediations.ts
+++ b/src/remediations.ts
@@ -128,11 +128,31 @@ export const GUIDANCE_ONLY: ReadonlySet<string> = new Set([
   "diagnostics_hint_git_missing",
 ]);
 
-/** Verbatim commands for every non-ok check whose emitted hintKey has a known fix. */
-export function remediationsFor(snapshot: DiagnosticsSnapshot): string[] {
+/** One verbatim remediation resolved for a non-ok check. `optional` mirrors the
+ *  check's `optional` state (an equivalent alternative is already healthy — e.g.
+ *  `codex` when `claude` is present). The harness apply loop treats a failing
+ *  optional remediation as NON-fatal (a broken third-party/optional installer must
+ *  not red the release gate for an unrelated defect — #1577). */
+export interface Remediation {
+  id: string;
+  cmd: string;
+  optional: boolean;
+}
+
+/** Verbatim remediation entries for every non-ok check whose emitted hintKey has a
+ *  known fix, each tagged with whether its check is in the (non-fatal) `optional` state. */
+export function remediationEntriesFor(snapshot: DiagnosticsSnapshot): Remediation[] {
   return snapshot.checks
     .filter((c) => c.state !== "ok" && REMEDIATIONS[c.hintKey])
-    .map((c) => REMEDIATIONS[c.hintKey]!);
+    .map((c) => ({ id: c.id, cmd: REMEDIATIONS[c.hintKey]!, optional: c.state === "optional" }));
+}
+
+/** Verbatim commands for every non-ok check whose emitted hintKey has a known fix.
+ *  Thin projection of {@link remediationEntriesFor} — its `string[]` contract (and every
+ *  caller/gate that reads `.length`) is unchanged. The optional-vs-required distinction that
+ *  decides fatality lives in the consumer (`applyVerbatim`), which uses the richer entries. */
+export function remediationsFor(snapshot: DiagnosticsSnapshot): string[] {
+  return remediationEntriesFor(snapshot).map((r) => r.cmd);
 }
 
 /** The auto-fix gate for product surfaces (in-app Fix endpoint): the command for a

--- a/test/onboarding-harness/apply.test.ts
+++ b/test/onboarding-harness/apply.test.ts
@@ -56,4 +56,66 @@ describe("applyVerbatim", () => {
     expect(ok).toBe(true);
     expect(calls[0]!.join(" ")).toContain("bun.sh/install");
   });
+
+  it("treats a failing optional remediation as non-fatal and still runs later required ones", async () => {
+    // Mirrors node-too-old: codex is `optional` (claude present) and its install fails,
+    // but it sorts before node — the node fix must still run and the apply must succeed.
+    const calls: string[][] = [];
+    const run = async (args: string[]) => {
+      calls.push(args);
+      const joined = args.join(" ");
+      const code = joined.includes("chatgpt.com/codex") ? 1 : 0; // codex installer broken
+      return { stdout: "", stderr: "", code };
+    };
+    const d = new IncusDriver(run, "shep-onb-");
+    const snap = {
+      checks: [
+        { id: "codex", state: "optional" as const, hintKey: "diagnostics_hint_codex_optional" },
+        { id: "node", state: "warning" as const, hintKey: "diagnostics_hint_node_outdated" },
+      ],
+      generatedAt: 1,
+      overall: "warning" as const,
+    };
+    const ok = await applyVerbatim(d, "node-too-old", snap, { attempts: 2, delayMs: 0 });
+    expect(ok).toBe(true);
+    const codexCalls = calls.filter((c) => c.join(" ").includes("chatgpt.com/codex"));
+    expect(codexCalls.length).toBe(1); // attempted once, NOT retried (optional ⇒ non-fatal)
+    expect(calls.some((c) => c.join(" ").includes("fnm.vercel.app"))).toBe(true); // node still ran
+  });
+
+  it("still fails the apply when a required (non-optional) remediation fails", async () => {
+    const run = async (args: string[]) => ({
+      stdout: "",
+      stderr: "",
+      code: args.join(" ").includes("bun.sh/install") ? 1 : 0,
+    });
+    const d = new IncusDriver(run, "shep-onb-");
+    const snap = {
+      checks: [{ id: "bun", state: "error" as const, hintKey: "diagnostics_hint_bun_missing" }],
+      generatedAt: 1,
+      overall: "error" as const,
+    };
+    const ok = await applyVerbatim(d, "bun-missing", snap, { delayMs: 0 });
+    expect(ok).toBe(false);
+  });
+
+  it("retries a transient failure and succeeds within the bounded attempts", async () => {
+    let bunCalls = 0;
+    const run = async (args: string[]) => {
+      if (args.join(" ").includes("bun.sh/install")) {
+        bunCalls += 1;
+        return { stdout: "", stderr: "", code: bunCalls === 1 ? 1 : 0 }; // flake once, then ok
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+    const d = new IncusDriver(run, "shep-onb-");
+    const snap = {
+      checks: [{ id: "bun", state: "error" as const, hintKey: "diagnostics_hint_bun_missing" }],
+      generatedAt: 1,
+      overall: "error" as const,
+    };
+    const ok = await applyVerbatim(d, "bun-missing", snap, { attempts: 2, delayMs: 0 });
+    expect(ok).toBe(true);
+    expect(bunCalls).toBe(2);
+  });
 });

--- a/test/onboarding-harness/remediations.test.ts
+++ b/test/onboarding-harness/remediations.test.ts
@@ -3,6 +3,7 @@ import {
   autoFixCommandFor,
   GUIDANCE_ONLY,
   REMEDIATIONS,
+  remediationEntriesFor,
   remediationsFor,
 } from "../../src/remediations";
 import type { DiagnosticsSnapshot } from "../../src/types";
@@ -63,6 +64,26 @@ describe("remediations catalog", () => {
     // privileged system install ⇒ guidance-only in-app (the root harness still applies it)
     expect(GUIDANCE_ONLY.has("diagnostics_hint_git_missing")).toBe(true);
     expect(autoFixCommandFor("diagnostics_hint_git_missing")).toBeUndefined();
+  });
+
+  it("remediationEntriesFor tags each entry's optional state (optional ⇒ non-fatal in the apply)", () => {
+    const snap: DiagnosticsSnapshot = {
+      checks: [
+        { id: "codex", state: "optional", hintKey: "diagnostics_hint_codex_optional" },
+        { id: "node", state: "warning", hintKey: "diagnostics_hint_node_outdated" },
+        { id: "bun", state: "error", hintKey: "diagnostics_hint_bun_missing" },
+        { id: "git", state: "ok", hintKey: "diagnostics_hint_git_ok" }, // ok → skipped
+      ],
+      generatedAt: 1,
+      overall: "error",
+    };
+    expect(remediationEntriesFor(snap)).toEqual([
+      { id: "codex", cmd: REMEDIATIONS.diagnostics_hint_codex_optional!, optional: true },
+      { id: "node", cmd: REMEDIATIONS.diagnostics_hint_node_outdated!, optional: false },
+      { id: "bun", cmd: REMEDIATIONS.diagnostics_hint_bun_missing!, optional: false },
+    ]);
+    // The string projection is unchanged (run.ts's path-selection `.length` is preserved).
+    expect(remediationsFor(snap)).toEqual(remediationEntriesFor(snap).map((r) => r.cmd));
   });
 
   it("remediationsFor includes the git install for a git-error snapshot (harness applies it as root)", () => {


### PR DESCRIPTION
Closes #1577.

## Problem

A broken **third-party, optional** installer red the **release gate** for an unrelated scenario. `scripts/onboarding-gate.sh` exited 1 on `node-too-old` (node stayed `warning`) because:

- `applyVerbatim` (`ci/onboarding-harness/apply.ts`) bailed on the **first** non-zero exit.
- `remediationsFor` includes every non-ok check with a fix — including `codex` in state **`optional`** (`diagnostics_hint_codex_optional`, which codex reports whenever `claude` is present). `codex` sorts **before** `node`, so the upstream-broken codex install failed, the loop returned early, and `node`'s remediation never ran.

Blast radius is contained to the harness: `remediationsFor` is consumed only by `apply.ts` + `run.ts`. The in-app Fix endpoint and cold-start installer use `autoFixCommandFor` per-check and are unaffected.

## Fix

1. **Optional failures are non-fatal.** New `remediationEntriesFor` returns `{ id, cmd, optional }` (tagging the check's `optional` state); `remediationsFor` is now a thin `.map(r => r.cmd)` projection so its `string[]` contract — and `run.ts`'s verbatim-vs-agent `.length` gate — are byte-for-byte unchanged. `applyVerbatim` still attempts the optional remediation best-effort, but a non-zero exit is logged and skipped; **required** (`error`/`warning`) failures still gate (fail-closed).
2. **Bounded retry** (default 2 attempts, ~3s delay; injectable so tests stay instant) around each remediation, so one transient network/mirror flake can't red the gate.

## Scope note

The `node-pty` tarball extraction flake mentioned in the issue was in the **`install.sh`** path (installE2E scenarios), which this `applyVerbatim` retry does **not** cover — deliberately out of scope, called out so it isn't mistaken for fixed.

## Tests

Added to `test/onboarding-harness/`: optional-failure-non-fatal (node still runs, apply succeeds), required-failure-still-fatal, transient-retry-succeeds, and `remediationEntriesFor` optional-flag tagging.

- `bun run lint` ✓
- `bun test ./test` ✓ (6347 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)