### PR TITLE
fix(herdr): reset-failed before restart in herdr_offline Fix path

### DIFF
--- a/src/remediations.ts
+++ b/src/remediations.ts
@@ -34,12 +34,19 @@ export const HERDR_INSTALL = "curl -fsSL https://herdr.dev/install.sh | bash";
  *   - `agent list || { start }` — IDEMPOTENT: a live daemon short-circuits, so this never
  *     races a second server against a bound socket (a second `herdr server` against a bound
  *     socket exits 1 with "herdr server is already running" — verified, #1574).
- *   - `systemctl --user restart herdr` WHEN THE UNIT EXISTS — on a provisioned host,
- *     `herdr: offline` means `herdr.service` itself cannot bind. Spawning a detached daemon
- *     there would put an unsupervised process on the socket, so the unit's ExecStart exits 1
- *     forever (`StartLimitIntervalSec=0` means it never even parks in `failed`) while the check
- *     reads `ok` because the orphan answers — exactly the green-check/thrashing-unit state this
- *     whole change exists to eliminate. Drive the unit; never race it.
+ *   - `systemctl --user reset-failed herdr` THEN `restart herdr` WHEN THE UNIT EXISTS — on a
+ *     provisioned host, `herdr: offline` means `herdr.service` itself cannot bind. Spawning a
+ *     detached daemon there would put an unsupervised process on the socket, so the unit's
+ *     ExecStart exits 1 forever (`StartLimitIntervalSec=0` means it never even parks in `failed`)
+ *     while the check reads `ok` because the orphan answers — exactly the green-check/thrashing-unit
+ *     state this whole change exists to eliminate. Drive the unit; never race it. The leading
+ *     `reset-failed` mirrors provision's `HERDR_ADOPT_SOCKET`: on a host provisioned by the current
+ *     `deploy/` the unit carries `StartLimitIntervalSec=0` and so NEVER parks in `failed` from the
+ *     start-limiter, making `reset-failed` a strict no-op there — its only value is a LEGACY or
+ *     hand-edited unit lacking that setting, which a crash-loop against a held socket can park in
+ *     `failed` with the limiter tripped, whereupon a bare `restart` is refused ("start request
+ *     repeated too quickly") until the failed state is cleared. `;`-sequenced, not `&&`: a non-zero
+ *     `reset-failed` (nothing to clear) must NOT block the restart.
  *   - `setsid … || nohup …` — the FALLBACK, for hosts with no unit (macOS, `buildOnly`'s
  *     SHEPHERD_NO_SERVICE path, hand-rolled installs). Detach so the daemon outlives the shell
  *     (an `incus exec` session, or the in-app Fix endpoint's child). macOS has NO `setsid`, so
@@ -55,6 +62,7 @@ export const HERDR_SERVE =
   '"$H" agent list >/dev/null 2>&1 || ' +
   "{ if command -v systemctl >/dev/null 2>&1 && " +
   "systemctl --user cat herdr >/dev/null 2>&1; then " +
+  "systemctl --user reset-failed herdr >/dev/null 2>&1; " +
   "systemctl --user restart herdr >/dev/null 2>&1; " +
   "elif command -v setsid >/dev/null 2>&1; then " +
   'setsid "$H" server </dev/null >/dev/null 2>&1 & ' +

--- a/test/remediations.test.ts
+++ b/test/remediations.test.ts
@@ -107,7 +107,16 @@ describe("herdr offline remediation (#1574)", () => {
       const r = runInSandbox(HERDR_SERVE, dir);
 
       expect(r.status).toBe(0);
-      expect(readFileSync(sysLog, "utf8")).toContain("restart herdr");
+      const sys = readFileSync(sysLog, "utf8");
+      expect(sys).toContain("restart herdr");
+      // `reset-failed` clears a legacy/hand-edited unit the start-limiter parked in `failed`
+      // BEFORE the restart (mirrors provision's HERDR_ADOPT_SOCKET). The stub `exit 1`s on the
+      // unmatched `reset-failed` arg, so this exercises the real failing-reset-failed→restart
+      // path: ordering proves reset-failed runs first, and status 0 proves the non-zero
+      // reset-failed did NOT abort the sequence — a `;`→`&&` regression would flip status to 1
+      // and never reach restart.
+      expect(sys.indexOf("reset-failed herdr")).toBeGreaterThanOrEqual(0);
+      expect(sys.indexOf("reset-failed herdr")).toBeLessThan(sys.indexOf("restart herdr"));
       // The daemon was NEVER spawned directly — no orphan on the socket.
       expect(readFileSync(herdrLog, "utf8")).not.toContain("server");
     } finally {


### PR DESCRIPTION
Closes #1579.

## Context

Most of #1579 already shipped when #1574 actually merged (commit `a91ce9e4`, "#1580"), filed after the issue was deferred: `HERDR_SERVE` already prefers the systemd unit (`restart herdr`) over a detached child, provision's `HERDR_ADOPT_SOCKET` already does socket-adopt + `reset-failed` before `enable --now herdr`, and `herdr.service` already carries `StartLimitIntervalSec=0`. The issue's "related hazard" (process-group SIGKILL on the 120s timeout) is explicitly informational and currently unreachable.

## The remaining delta

The in-app Fix remediation `HERDR_SERVE` ran `systemctl --user restart herdr` with **no** preceding `reset-failed`. On a **legacy or hand-edited** unit lacking `StartLimitIntervalSec=0` that crash-looped against a held socket, the start-limiter parks it in `failed` and a bare `restart` is then refused ("start request repeated too quickly") until the failed state is cleared. This adds `systemctl --user reset-failed herdr` before the restart, mirroring provision's `HERDR_ADOPT_SOCKET`.

- `;`-sequenced (not `&&`): a non-zero `reset-failed` (nothing to clear) must not block the restart.
- On a host provisioned by the **current** `deploy/` the unit never parks in `failed` from the limiter, so `reset-failed` is a **strict no-op** there — the comment says so, to stop a future reader over-reading the line. Its only value is legacy/hand-edited units.

## Test

Extended the existing "drives the systemd unit" behavioral test rather than adding a source-substring check. The systemctl stub `exit 1`s on the unmatched `reset-failed` arg, so once the line is inserted the test exercises the real failing-`reset-failed`→`restart` path: it asserts `sysLog` shows `reset-failed herdr` before `restart herdr` **and** `r.status === 0` — a `;`→`&&` regression would flip status to 1 and never reach restart.

## Verification

- `bun run lint` clean
- `bun test ./test/remediations.test.ts ./test/provision.test.ts ./test/diagnostics.test.ts ./test/onboarding-harness/remediations.test.ts` green (140 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)