### PR TITLE
fix(herdr): update+handoff the running daemon on `herdr_outdated` (#1578)

### DIFF
--- a/ci/onboarding-harness/scenarios.ts
+++ b/ci/onboarding-harness/scenarios.ts
@@ -22,10 +22,14 @@ import type { Scenario } from "./types";
  *    reported as DETECTION-ONLY. This is the honest "onboarding still needs the
  *    user here" finding the gap report exists to surface.
  *
- * NOTE: scenarios that require provisioning the harness doesn't yet implement
- * (a pinned outdated herdr build; a faked tailnet for the not-serving warning
- * state) are intentionally OMITTED rather than shipped as permanent gaps — see
- * the deferred follow-ups in docs/superpowers/specs/...-design.md.
+ * NOTE: the `herdr-outdated` scenario below covers DETECTION of a live-but-old herdr
+ * (warning), but its GREEN-ABLE remediation — `herdr update --handoff` (#1578) — stays
+ * deferred: install.sh can't pin an old build, so the harness can't stand up a real old
+ * live daemon to hand off from (the remediation's behavior is proved by
+ * test/remediations.test.ts + test/diagnostics.test.ts instead). Other scenarios that
+ * require provisioning the harness doesn't yet implement (a faked tailnet for the
+ * not-serving warning state) remain intentionally OMITTED rather than shipped as permanent
+ * gaps — see the deferred follow-ups in docs/superpowers/specs/...-design.md.
  */
 export const SCENARIOS: Scenario[] = [
   {
@@ -89,6 +93,29 @@ export const SCENARIOS: Scenario[] = [
     expect: [{ id: "herdr", state: "error" }],
     coaching: "structured",
     preflightFailFast: true,
+  },
+  {
+    // A live-but-OUTDATED herdr: `herdr --version` reports below HERDR_MIN_VERSION → `warning`,
+    // while the daemon still answers `agent list` (liveness ok) so it reads outdated, NOT
+    // offline. The baseline stub reports 99.99.99 (ok); this seed overwrites it to report an
+    // old version. Present-but-old passes the boot preflight (it fail-fasts only on a MISSING
+    // binary, src/preflight.ts), so the instance boots and self-diagnoses.
+    //
+    // DETECTION-ONLY: applies no remediation, so it exercises NONE of the #1578
+    // `herdr update --handoff` remediation and largely duplicates the outdated→warning unit
+    // coverage (test/diagnostics.test.ts); its only marginal value is the real boot+probe
+    // classification of a live-but-old herdr end-to-end. A green-able E2E stays deferred — see
+    // the header NOTE (no install.sh version pinning → no real old daemon to hand off from).
+    id: "herdr-outdated",
+    image: "images:archlinux",
+    seed: [
+      "mkdir -p ~/.local/bin",
+      "cat > ~/.local/bin/herdr <<'HERDR_STUB'\n#!/bin/sh\necho '{\"version\":\"0.6.5\"}'\nHERDR_STUB",
+      "chmod +x ~/.local/bin/herdr",
+    ],
+    expect: [{ id: "herdr", state: "warning" }],
+    coaching: "prose",
+    detectionOnly: true,
   },
   {
     // claudeProbe is PRESENCE-ONLY (a successful `claude --version` ⇒ ok; there is

--- a/src/remediations.ts
+++ b/src/remediations.ts
@@ -1,3 +1,5 @@
+import { config } from "./config";
+import { buildUpdateScript } from "./herdr-update";
 import type { DiagnosticsSnapshot } from "./types";
 
 /** hintKey → verbatim shell remediation, keyed by the advice identifier Shepherd
@@ -97,12 +99,21 @@ export const REMEDIATIONS: Record<string, string> = {
   // check, spawn and poll would all run even when the install failed. `( … )` makes the
   // whole block one compound command whose status is what `&&` gates on.
   diagnostics_hint_herdr_missing: `${HERDR_INSTALL} && (${HERDR_SERVE})`,
-  // Install ONLY, deliberately. The version probe reads the BINARY (`herdr --version`
-  // answers with no daemon running — verified), so reinstalling clears the `outdated`
-  // warning on the next probe without touching the running server. Restarting the daemon
-  // to adopt the new binary is a separate concern (panes outlive the server; herdr ships
-  // `update --handoff` for exactly that) — tracked in #1578, NOT bolted on here.
-  diagnostics_hint_herdr_outdated: HERDR_INSTALL,
+  // Update AND hand off the running daemon (#1578). Reinstalling the binary alone (the
+  // pre-#1578 behavior) cleared the outdated WARNING — the probe reads `herdr --version`,
+  // the on-disk binary — but left the RUNNING daemon serving the old version: a degraded
+  // split state. `herdr update --handoff` (reused verbatim from buildUpdateScript) updates
+  // the binary AND hands the live targets to the new server ATOMICALLY, so a successful
+  // update can't leave an old daemon behind; its 3× reachability retry + detached
+  // `setsid server` relaunch keep a failed handoff from stranding the host offline.
+  // Verification is the diagnostics RE-PROBE (DiagnosticsService.fix → check): a no-op
+  // update leaves the binary old (still `warning`); a handoff that killed the server reads
+  // `offline` (error). The running-server version is exposed only over the herdr socket
+  // (`ping`), not a CLI verb, so the shell string cannot probe it directly — update
+  // atomicity + the re-probe are the guarantee. Stays auto-fixable (not GUIDANCE_ONLY).
+  // Executes in-app on the shepherd host only (the harness herdr-outdated scenario is
+  // detection-only), so buildUpdateScript's baked `config.herdrBin` is always the right one.
+  diagnostics_hint_herdr_outdated: buildUpdateScript(config.herdrUpdateLogPath),
   diagnostics_hint_herdr_offline: HERDR_SERVE,
   diagnostics_hint_claude_missing: "curl -fsSL https://claude.ai/install.sh | bash",
   diagnostics_hint_claude_optional: "curl -fsSL https://claude.ai/install.sh | bash",

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -786,6 +786,46 @@ describe("DiagnosticsService.fix", () => {
     expect(bun.state).toBe("ok");
   });
 
+  // #1578: the outdated remediation runs `herdr update --handoff`. Success is NOT the shell's
+  // exit code (`herdr update` exits 0 even when it did nothing) — it is fix()'s RE-PROBE of
+  // `herdr --version`. These pin that the re-probe is the real verifier, since the running
+  // server's version is only exposed over the herdr socket, never a CLI verb the shell can read.
+  it("herdr outdated: a no-op update leaves the binary old → re-probe still `warning` (no false ok, #1578)", async () => {
+    const calls: string[] = [];
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      // Binary stays 0.5.0 across the fix (the remediation was a no-op / couldn't update).
+      runVersion: versionRunner({ ...HEALTHY_VERSIONS, herdr: "herdr 0.5.0" }),
+      runRemediation: async (cmd) => {
+        calls.push(cmd);
+      },
+    });
+    const snap = await svc.fix("herdr", 0);
+    expect(calls).toEqual([REMEDIATIONS.diagnostics_hint_herdr_outdated!]);
+    const herdr = byId(snap.checks, "herdr");
+    expect(herdr.state).toBe("warning");
+    expect(herdr.hintKey).toBe("diagnostics_hint_herdr_outdated");
+  });
+
+  it("herdr outdated: a successful update bumps the binary → re-probe `ok` (#1578)", async () => {
+    let updated = false;
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      // Old until the remediation "updates" it, then above the floor.
+      runVersion: async (bin, args) => {
+        if (bin === "herdr") return updated ? "herdr 0.7.5" : "herdr 0.5.0";
+        return versionRunner({ ...HEALTHY_VERSIONS })!(bin, args);
+      },
+      runRemediation: async () => {
+        updated = true;
+      },
+    });
+    const snap = await svc.fix("herdr", 0);
+    const herdr = byId(snap.checks, "herdr");
+    expect(herdr.state).toBe("ok");
+    expect(herdr.hintKey).toBe("diagnostics_hint_herdr_ok");
+  });
+
   it("throws for an unknown checkId (runner never called)", async () => {
     let called = false;
     const svc = new DiagnosticsService({

--- a/test/remediations.test.ts
+++ b/test/remediations.test.ts
@@ -4,6 +4,8 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { REMEDIATIONS, autoFixCommandFor, HERDR_SERVE, HERDR_INSTALL } from "../src/remediations";
+import { buildUpdateScript } from "../src/herdr-update";
+import { config } from "../src/config";
 
 /** Build an isolated $HOME (with `logPath`/`markerPath` already decided) and a `.local/bin`
  *  dir so HERDR_SERVE's own `export PATH="$HOME/.local/bin:$PATH"` resolves to whatever stub
@@ -220,4 +222,88 @@ describe("herdr_missing composition is behaviorally gated, not just shaped right
       rmSync(dir, { recursive: true, force: true });
     }
   });
+});
+
+describe("herdr_outdated: update + handoff, not a bare reinstall (#1578)", () => {
+  it("routes through the herdr update+handoff machinery (buildUpdateScript)", () => {
+    // The fix for #1578: reinstalling the binary alone cleared the WARNING (the probe reads
+    // `herdr --version`) but left the RUNNING daemon old — a split state. The remediation now
+    // IS the update+handoff+recovery script, so a successful fix updates the binary AND hands
+    // the live targets to the new server atomically.
+    expect(REMEDIATIONS.diagnostics_hint_herdr_outdated).toBe(
+      buildUpdateScript(config.herdrUpdateLogPath),
+    );
+  });
+
+  it("updates AND hands off with recovery — not the reverted install+live-handoff design", () => {
+    const cmd = REMEDIATIONS.diagnostics_hint_herdr_outdated!;
+    expect(cmd).toContain("update --handoff"); // atomic update + handoff
+    expect(cmd).toContain("setsid"); // detached-relaunch recovery so a failed handoff can't strand the host
+    // The first-cut design used `herdr server live-handoff` behind a reachability poll (the
+    // OLD daemon answers before AND after → false success). Guard against its return.
+    expect(cmd).not.toContain("live-handoff");
+    // No longer a bare reinstall (the pre-#1578 behavior that left the daemon old).
+    expect(cmd).not.toBe(HERDR_INSTALL);
+  });
+
+  it("stays auto-fixable in-app (not guidance-only)", () => {
+    expect(autoFixCommandFor("diagnostics_hint_herdr_outdated")).toBe(
+      REMEDIATIONS.diagnostics_hint_herdr_outdated,
+    );
+  });
+});
+
+describe("herdr_outdated is behaviorally recover-on-fail, not just shaped right (#1578)", () => {
+  // Execute the SAME generator the production entry uses (buildUpdateScript), with the audit
+  // log redirected into the sandbox so the test never writes the dev's ~/.shepherd. The
+  // structural test above pins that the entry IS buildUpdateScript(config.herdrUpdateLogPath);
+  // the log path doesn't affect the update/handoff/recovery control flow exercised here.
+  // herdr-update.test.ts asserts the STRING shape — these are the first tests that RUN it.
+  //
+  // Safety: NEVER runs the real network `herdr update` or the real herdr binary. The herdrBin
+  // is pinned to bare `herdr`, which runInSandbox's PATH resolves to the sandbox stub.
+  const scriptFor = (logPath: string) => buildUpdateScript(logPath, null, null, "herdr");
+
+  it("a reachable server after update settles WITHOUT relaunching (also the no-op case)", () => {
+    // A no-op `herdr update` whose OLD server still answers `agent list` exits 0 at the SHELL
+    // layer — the shell CANNOT distinguish it from a real update (false success). That is
+    // caught one layer up by DiagnosticsService.fix()'s re-probe of `herdr --version` (see
+    // test/diagnostics.test.ts). Here we only assert the shell reaches the reachable branch.
+    const { dir, logPath, writeStub } = makeSandbox();
+    writeStub(`#!/bin/sh\nexit 0\n`); // update: ok; agent list: ok (server answers)
+    try {
+      const r = runInSandbox(scriptFor(logPath), dir);
+      expect(r.status).toBe(0);
+      const log = readFileSync(logPath, "utf8");
+      expect(log).toContain("reachable after update");
+      expect(log).not.toContain("unreachable after retries");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("a handoff that leaves NO running server triggers the detached relaunch recovery", () => {
+    const { dir, logPath, writeStub } = makeSandbox();
+    // `herdr update` exits 0 even when it left no running server (#1558), but the server never
+    // answers — the grace+retry loop exhausts and the setsid fallback relaunch fires so the
+    // host is never stranded offline (review point 2). The relaunch marker is echoed to the
+    // durable log BEFORE the backgrounded setsid, so asserting on the log is race-free.
+    writeStub(
+      `#!/bin/sh\n` +
+        `case "$1" in\n` +
+        `  update) exit 0 ;;\n` +
+        `  agent) exit 1 ;;\n` + // never reachable → forces the fallback
+        `  server) exit 0 ;;\n` +
+        `esac\nexit 0\n`,
+    );
+    try {
+      runInSandbox(scriptFor(logPath), dir);
+      const log = readFileSync(logPath, "utf8");
+      expect(log).toContain("unreachable after retries");
+      expect(log).toContain("relaunching");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    // buildUpdateScript's grace loop sleeps 3×2s before the fallback — allow for it.
+  }, 15_000);
 });


### PR DESCRIPTION
## Problem (#1578)

`diagnostics_hint_herdr_outdated` reinstalled the herdr binary but left the **running** daemon on the old version. The `outdated` probe reads `herdr --version` (the on-disk binary), so a reinstall cleared the *warning* while the live daemon kept serving the old version — a degraded split state.

## Fix

Route the remediation through herdr's atomic `herdr update --handoff`, reused verbatim from `buildUpdateScript`:

- A successful update updates the binary **and** hands the live targets to the new server as one herdr operation, so no old daemon can survive (unlike a decoupled install + best-effort handoff).
- Its 3× reachability retry + detached `setsid server` relaunch recovery keeps a failed handoff from stranding the host **offline**.
- Verification is layered, because the running-server version is exposed only over the herdr socket (`ping`), not any CLI verb the shell can read:
  - `DiagnosticsService.fix()` **re-probes** after running the remediation — a no-op update leaves the binary old (still `warning`, no false `ok`); a handoff that killed the server reads `offline`.
  - the residual "binary bumped but old daemon silently kept alive" case is precluded by herdr's update+handoff atomicity (documented).

Stays auto-fixable in-app (not guidance-only).

### Why not the first-cut `HERDR_INSTALL && herdr server live-handoff`

That decoupled design was reverted: its reachability poll is answered by the OLD daemon both before and after (false success), and `live-handoff` was best-effort. `update --handoff` is atomic and reuses proven install+handoff+recovery machinery.

## Tests

- `test/remediations.test.ts` — wiring (`entry === buildUpdateScript(config.herdrUpdateLogPath)`, contains `update --handoff` + `setsid`, not `live-handoff`, auto-fixable) + the **first behavioral run** of the recovery path (herdr-update.test.ts only asserts string shape).
- `test/diagnostics.test.ts` — the authoritative false-success guard: `fix("herdr")` with a no-op update → still `warning`; with a real bump → `ok`.
- `ci/onboarding-harness/scenarios.ts` — detection-only `herdr-outdated` scenario (live stub `< 0.7.0` → `warning`). A green-able E2E stays deferred: `install.sh` can't pin an old build, so the harness can't stand up a real old live daemon to hand off from (stated in the header NOTE). This scenario exercises none of the remediation and largely duplicates the unit coverage — its value is the real boot+probe classification.

Server + harness + tests only; no `ui/**` changes. `bun run lint` clean; `bun test ./test` green (6350 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)