### PR TITLE
fix(onboarding): retry bun install on transient node-pty tarball flake (#1602)

### DIFF
--- a/deploy/provision.ts
+++ b/deploy/provision.ts
@@ -232,6 +232,41 @@ const defaultRunner: Runner = (cmd, args, opts) => {
   }
 };
 
+/** Synchronous sleep — provision runs a sequential, synchronous install flow, so the
+ *  between-attempt backoff in {@link runWithRetry} can't be a Promise. `ms <= 0` is a
+ *  no-op (tests pass 0 to stay instant). */
+function sleepSync(ms: number): void {
+  if (ms <= 0) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/** Bounded, fail-closed retry around a single `run` step. Bun's dependency fetch/extract
+ *  can hit a transient registry/mirror flake — observed as `error: Fail extracting tarball
+ *  for "node-pty"` (#1602) — that succeeds on a re-run. Wrapping the `bun install` steps
+ *  lets one such flake not fail a cold-start install (nor red the onboarding release gate,
+ *  whose installE2E/serviceLifecycle scenarios drive this path). Any non-zero exit retries
+ *  up to `attempts`; a deterministic failure just re-fails each attempt and the last error
+ *  propagates — so a real regression still gates. Mirrors the apply-time retry in #1599. */
+function runWithRetry(
+  run: Runner,
+  cmd: string,
+  args: string[],
+  opts: { env?: NodeJS.ProcessEnv } | undefined,
+  attempts: number,
+  delayMs: number,
+): void {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      run(cmd, args, opts);
+      return;
+    } catch (err) {
+      if (attempt >= attempts) throw err;
+      log(`  step failed (attempt ${attempt}/${attempts}) — retrying in ${delayMs}ms`);
+      sleepSync(delayMs);
+    }
+  }
+}
+
 /** Injectable file IO. Production reads/writes the real filesystem; tests inject a
  *  recorder so the templated unit can be asserted without touching disk. */
 export interface FileIO {
@@ -458,18 +493,40 @@ export function installService(
 /** No-service path (harness e2e + macOS): starts the herdr daemon directly (no systemd unit
  * on this path), then deps + UI install + UI build. Do NOT touch systemd. (The harness boots
  * Shepherd directly afterward.) */
-export function buildOnly(repo: string, run: Runner, buildEnv: NodeJS.ProcessEnv): void {
+export function buildOnly(
+  repo: string,
+  run: Runner,
+  buildEnv: NodeJS.ProcessEnv,
+  // Bounds the transient-flake retry on the `bun install` steps; tests pass `delayMs: 0`.
+  retry: { attempts: number; delayMs: number } = { attempts: 2, delayMs: 3000 },
+): void {
   // No systemd on this path (harness install-e2e + macOS), so start the daemon directly.
   // HERDR_SERVE is idempotent and polls until it answers, so this both starts and verifies.
   log("starting herdr server (no-service path)");
   run("bash", ["-c", HERDR_SERVE], { env: buildEnv });
   log("installing deps (root + ui)");
-  run("bash", ["-c", `cd "${repo}" && bun install`], { env: buildEnv });
+  // Retry only the network-bound install: a transient `node-pty` tarball-extract flake
+  // must not fail the install (#1602). fix-perms / build are local + deterministic.
+  runWithRetry(
+    run,
+    "bash",
+    ["-c", `cd "${repo}" && bun install`],
+    { env: buildEnv },
+    retry.attempts,
+    retry.delayMs,
+  );
   // node-pty ships spawn-helper without the exec bit and Bun preserves tarball perms,
   // so on macOS posix_spawn fails ("posix_spawnp failed.") and every pane stays black.
   // Re-set it right after the root install; a silent no-op off macOS. See the script.
   run("bash", ["-c", `cd "${repo}" && bun scripts/fix-node-pty-perms.mjs`], { env: buildEnv });
-  run("bash", ["-c", `cd "${repo}/ui" && bun install`], { env: buildEnv });
+  runWithRetry(
+    run,
+    "bash",
+    ["-c", `cd "${repo}/ui" && bun install`],
+    { env: buildEnv },
+    retry.attempts,
+    retry.delayMs,
+  );
   log("building UI");
   run("bash", ["-c", `cd "${repo}/ui" && bun run build`], { env: buildEnv });
 }

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -20,6 +20,25 @@ die() {
   exit 1
 }
 
+# retry <attempts> <cmd...>: run <cmd> until it succeeds, up to <attempts> times, with a
+# 3s backoff between tries. Bun's dependency fetch/extract can hit a transient registry/
+# mirror flake — observed as `error: Fail extracting tarball for "node-pty"` (#1602) — that
+# succeeds on a re-run, so we wrap the `bun install` steps below. Fail-closed: a deterministic
+# failure re-fails every attempt and the final non-zero exit propagates under `set -e`.
+retry() {
+  local attempts="$1"
+  shift
+  local i
+  for ((i = 1; i <= attempts; i++)); do
+    "$@" && return 0
+    [ "$i" -lt "$attempts" ] && {
+      warn "\`$*\` failed (attempt $i/$attempts) — retrying in 3s"
+      sleep 3
+    }
+  done
+  return 1
+}
+
 # ── guard: the working tree IS the deployment ────────────────────────────────
 branch="$(git rev-parse --abbrev-ref HEAD)"
 [[ "$branch" == "main" ]] || warn "on branch '$branch' (not main) — the service will run THIS code"
@@ -36,12 +55,14 @@ fi
 
 # ── build ────────────────────────────────────────────────────────────────────
 note "installing deps (root + ui)"
-bun install
+# Retry only the network-bound install (transient node-pty tarball-extract flake, #1602);
+# fix-perms + build below are local + deterministic.
+retry 2 bun install
 # node-pty ships spawn-helper without the exec bit + Bun keeps tarball perms, so on
 # macOS posix_spawn fails ("posix_spawnp failed.") and panes stay black. Re-set it
 # after install (a silent no-op on Linux, where the forkpty path uses no helper).
 bun scripts/fix-node-pty-perms.mjs
-(cd ui && bun install)
+(cd ui && retry 2 bun install)
 
 note "building UI"
 (cd ui && bun run build)

--- a/test/provision.test.ts
+++ b/test/provision.test.ts
@@ -450,6 +450,54 @@ describe("extracted helpers (direct)", () => {
     expect(calls.some((c) => c[0] === "systemctl")).toBe(false);
   });
 
+  it("buildOnly retries a transient `bun install` flake, then succeeds (#1602)", () => {
+    const calls: string[][] = [];
+    let rootInstall = 0;
+    const run: Runner = (cmd, args) => {
+      calls.push([cmd, ...args]);
+      if ([cmd, ...args].join(" ").includes('cd "/repo" && bun install')) {
+        // First attempt flakes (node-pty tarball extract), retry succeeds.
+        if (++rootInstall === 1) throw new Error('Fail extracting tarball for "node-pty"');
+      }
+    };
+    expect(() =>
+      buildOnly("/repo", run, { PATH: "/x" }, { attempts: 2, delayMs: 0 }),
+    ).not.toThrow();
+    expect(rootInstall).toBe(2); // failed once → retried → succeeded
+    // The retry didn't swallow the downstream steps.
+    const flat = calls.map((c) => c.join(" "));
+    expect(flat.some((c) => c.includes('cd "/repo/ui" && bun run build'))).toBe(true);
+  });
+
+  it("buildOnly propagates a `bun install` failure that persists past the retry bound (#1602)", () => {
+    let attempts = 0;
+    const run: Runner = (cmd, args) => {
+      if ([cmd, ...args].join(" ").includes('cd "/repo" && bun install')) {
+        attempts++;
+        throw new Error('Fail extracting tarball for "node-pty"');
+      }
+    };
+    // Fail-closed: a persistent failure still gates (throws) after exactly `attempts` tries.
+    expect(() => buildOnly("/repo", run, { PATH: "/x" }, { attempts: 2, delayMs: 0 })).toThrow(
+      /node-pty/,
+    );
+    expect(attempts).toBe(2);
+  });
+
+  it("buildOnly does not retry a non-install step — a UI build failure gates immediately", () => {
+    let buildAttempts = 0;
+    const run: Runner = (cmd, args) => {
+      if ([cmd, ...args].join(" ").includes("bun run build")) {
+        buildAttempts++;
+        throw new Error("build broke");
+      }
+    };
+    expect(() => buildOnly("/repo", run, { PATH: "/x" }, { attempts: 2, delayMs: 0 })).toThrow(
+      /build broke/,
+    );
+    expect(buildAttempts).toBe(1); // only the network install steps are retried
+  });
+
   it("the herdr prereq installs the binary ONLY — no daemon start (#1574)", () => {
     // The shipped `herdr_missing` remediation is `HERDR_INSTALL && (HERDR_SERVE)`. Running that
     // here would leave an unsupervised daemon on the socket, so `enable --now herdr` would hit a

--- a/test/update-sh-retry.test.ts
+++ b/test/update-sh-retry.test.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+
+// deploy/update.sh's `bun install` steps can hit a transient node-pty tarball-extract
+// flake (#1602) that passes on a re-run. They must stay wrapped in the bounded `retry`
+// helper so one flake can't fail the deploy — nor red the onboarding serviceLifecycle
+// release gate, which drives update.sh through provision's installService path.
+const src = readFileSync(new URL("../deploy/update.sh", import.meta.url), "utf8");
+
+test("update.sh defines a bounded retry helper for the transient install flake (#1602)", () => {
+  expect(src).toMatch(/^retry\(\)\s*\{/m);
+  expect(src).toContain("#1602");
+});
+
+test("update.sh wraps both bun install steps in retry — no bare `bun install` remains", () => {
+  expect(src).toContain("retry 2 bun install");
+  expect(src).toContain("(cd ui && retry 2 bun install)");
+  // No un-retried root `bun install` at line start (fix-perms is `bun scripts`, build is `bun run`).
+  const bareInstall = src.split("\n").filter((l) => /^\s*bun install\b/.test(l));
+  expect(bareInstall).toEqual([]);
+});


### PR DESCRIPTION
Closes #1602. Follow-up from #1577 / #1599.

## Problem

A transient `error: Fail extracting tarball for "node-pty"` during `bun install` passes on re-run, but had no retry — so a single flake redded the onboarding release gate (`installE2E` / `serviceLifecycle` scenarios) and could fail real cold-start installs. #1599's `applyVerbatim` retry deliberately excluded this path.

**Key detail:** the flaky `bun install` is **not** in `install.sh` itself — `install.sh` hands off to the two paths that actually run it:
- `provision.ts` → `buildOnly()` — the **installE2E** / no-service path
- `deploy/update.sh` — the **serviceLifecycle** path (via `installService`)

## Fix

Bounded, fail-closed retry around **only the network-bound `bun install` step** in both paths (any non-zero exit retries, mirroring #1599's precedent):

- **`deploy/provision.ts`** — new `runWithRetry` (+ synchronous `sleepSync` backoff) wraps the two `buildOnly` bun installs. 2 attempts, 3s backoff. A deterministic failure re-fails each attempt and still gates.
- **`deploy/update.sh`** — a bash `retry()` helper wraps both bun installs (`retry 2 bun install`, `(cd ui && retry 2 bun install)`).
- `fix-node-pty-perms` and the UI build stay un-retried (local + deterministic).

## Tests

- `test/provision.test.ts`: retries-then-succeeds, persists-past-bound-still-gates, non-install-step-not-retried.
- `test/update-sh-retry.test.ts`: source assertions — helper present, both installs wrapped, no bare `bun install`.

## Verification

lint ✓ · typecheck ✓ · targeted tests 57 pass / 0 fail · branch-hygiene ✓ · feature-catalog ✓ (fix, not feat).

Not a user-facing feature → no feature-announcement entry; no user-facing strings → no i18n. `[no-feature-entry]`

The full suite shows 8 pre-existing environmental flakes (session/herdr tests needing a live daemon the fresh worktree lacks — 10 fail on the clean base); none touch `provision.ts`/`update.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)