### PR TITLE
feat: make the manual plan re-review actually re-review (force seam)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2400,7 +2400,7 @@ const appDeps: AppDeps = {
     reviewing: () => planGate.reviewingIds(),
   },
   planGate: {
-    consider: (s) => planGate.consider(s),
+    consider: (s, opts) => planGate.consider(s, opts),
     resume: (s) => planGate.resume(s),
     dismiss: (s) => planGate.dismiss(s),
   },

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -22,10 +22,11 @@ import { effectiveAutopilot } from "./effective-autopilot";
 import { resolveAuxSpawn, type MembraneSeams } from "./spawn-membrane";
 import { fenceUntrusted } from "./untrusted";
 
-/** Outcome of an on-demand `consider()`: a reviewer actually spawned, the request was a no-op
- *  (plan unchanged / already approved / nothing to review), the plan artifact is unavailable, or
- *  a spawn attempt failed. The review-plan route relays this so the UI can distinguish a silent
- *  dedupe from a real error or an unusable `.shepherd-plan.md`. */
+/** Outcome of an on-demand `consider()`: a reviewer actually spawned (`"started"`); the request
+ *  was a no-op (`"skipped"` — not planning, a review already in flight/starting, a tombstone or
+ *  plugin-abort during spawn, or an unchanged plan on the auto-path); the plan artifact is
+ *  unavailable (`"plan-unavailable"`); or a spawn attempt failed (`"error"`). The review-plan route
+ *  relays this so the UI can distinguish a no-op from a real error or an unusable `.shepherd-plan.md`. */
 export type PlanReviewTrigger = "started" | "skipped" | "plan-unavailable" | "error";
 
 /** The plan the planning agent writes in its LIVE session worktree; the reviewer reads its text. */
@@ -187,6 +188,7 @@ interface PlanInFlight {
   reviewerModel: string | null;
   reviewerEffort: string | null;
   priorRound: number; // adversarial rounds already spent on this plan streak
+  forced: boolean; // this run is an operator's manual re-review (consider's opts.force) — governs the F3 hold + stall-signal guards
   startedAt: number;
   finalizing?: boolean;
 }
@@ -243,21 +245,32 @@ export class PlanGateService {
     this.readUsage = deps.readUsage ?? readSessionUsage;
   }
 
-  /** sha256 of the plan text — dedups re-reviews of an unchanged plan. */
+  /** sha256 of the plan text — dedups re-reviews of an unchanged plan on the auto-path. The manual
+   *  `force` path (consider's `opts.force`) deliberately bypasses this dedupe so an operator's
+   *  re-review always runs even when the plan text is byte-identical. */
   static async hashPlan(plan: string): Promise<string> {
     return createHash("sha256").update(plan).digest("hex");
   }
 
   /** Decide whether `session`'s current plan warrants a fresh adversarial review, and start one.
-   *  Returns `"started"` iff a reviewer actually spawned, `"skipped"` for a no-op (not planning,
-   *  in flight, no/unchanged plan, already approved), or `"error"` if a spawn was attempted but
-   *  failed. The on-demand "Review plan now" route relays this so the UI can tell a real review
-   *  from a silent dedupe — and a genuine failure from either — instead of just blinking the button. */
-  async consider(session: Session): Promise<PlanReviewTrigger> {
+   *  Returns `"started"` iff a reviewer actually spawned; `"skipped"` for a no-op — not planning,
+   *  a review already in flight/starting, an already-`approved` gate, an unchanged plan on the
+   *  auto-path, a `forget()` tombstone abort mid-fetch, or a plugin `onSpawn` refusal;
+   *  `"plan-unavailable"` when the plan artifact is missing/unreadable/empty; or `"error"` if a
+   *  spawn was attempted but failed. The on-demand "Review plan now" route relays this so the UI
+   *  can tell a real review from a no-op — and a genuine failure from either.
+   *
+   *  `opts.force` (the manual re-review path) bypasses ONLY the unchanged-plan hash dedupe, so an
+   *  operator's click always re-reviews the same plan text rather than silently no-opping on it —
+   *  a click is therefore no longer a silent dedupe. It bypasses no hard precondition: a non-
+   *  planning phase, an in-flight/starting review, an already-`approved` gate, and a missing plan
+   *  each still short-circuit exactly as on the auto-path. */
+  async consider(session: Session, opts?: { force?: boolean }): Promise<PlanReviewTrigger> {
+    const force = opts?.force === true;
     if (session.planPhase !== "planning") return "skipped"; // only gate before execution
     if (this.inflight.has(session.id) || this.starting.has(session.id)) return "skipped"; // in flight / mid-spawn
     const prior = this.deps.store.getPlanGate(session.id);
-    if (prior?.approved) return "skipped"; // already cleared → execution allowed, don't re-review
+    if (prior?.approved) return "skipped"; // already cleared → execution allowed, don't re-review (force does NOT bypass this)
     const plan = (this.readPlan(session.worktreePath) ?? "").trim();
     if (!plan) return "plan-unavailable"; // missing / unreadable / empty → nothing usable to review
     // Claim the slot SYNCHRONOUSLY, before any await — hashPlan is async, so two concurrent
@@ -266,11 +279,12 @@ export class PlanGateService {
     this.starting.add(session.id);
     try {
       const planHash = await PlanGateService.hashPlan(plan);
-      // Dedupe an unchanged plan — but NEVER skip past an `error` verdict. A timeout/unparseable
-      // run produced no real verdict, so re-running it (e.g. via the "Review plan now" button) must
-      // retry rather than no-op on the stale error. Mirrors review.ts rebaseSkip's error carve-out.
-      if (prior?.planHash === planHash && prior.decision !== "error") return "skipped";
-      return await this.begin(session, plan, planHash, prior);
+      // Dedupe an unchanged plan on the auto-path — but NEVER when `force` (the manual re-review
+      // path) is set, and NEVER skip past an `error` verdict. `force` makes a click re-review the
+      // same plan text instead of no-opping; a timeout/unparseable run produced no real verdict, so
+      // re-running it must retry rather than no-op on the stale error. Mirrors review.ts rebaseSkip.
+      if (!force && prior?.planHash === planHash && prior.decision !== "error") return "skipped";
+      return await this.begin(session, plan, planHash, prior, force);
     } finally {
       this.starting.delete(session.id);
     }
@@ -281,6 +295,7 @@ export class PlanGateService {
     plan: string,
     planHash: string,
     prior: PlanGate | null,
+    forced: boolean,
   ): Promise<PlanReviewTrigger> {
     // Resolve the base SHA so the reviewer inspects a CLEAN copy of the codebase at the base
     // branch — never the live worktree (the planning agent is still editing it). baseSha's
@@ -404,6 +419,7 @@ export class PlanGateService {
       reviewerModel: reviewerEnv.model,
       reviewerEffort,
       priorRound: prior?.round ?? 0,
+      forced,
       startedAt: this.now(),
     });
     // Persist the spawn row now (totals NULL until finalize) so plan-review burn is attributable
@@ -449,6 +465,18 @@ export class PlanGateService {
       // Reaped worktree ⇒ the review finalized (finalize removes it); nothing to re-adopt.
       if (!this.worktreeExists(sp.worktreePath)) continue;
       const prior = this.deps.store.getPlanGate(id);
+      // Uphold `approved ⇒ no reviewer in flight`. This method is the SECOND maintainer of that
+      // invariant (the first is consider()'s `prior?.approved` short-circuit): a crash between
+      // applyApproved's putPlanGate and finalize's worktree.remove leaves an approved gate whose
+      // orphan spawn still satisfies the adoption predicate. Re-adopting it would resurrect exactly
+      // the state the invariant forbids and let finalize() steer into an executing agent. Reap it
+      // properly instead — a bare `continue` would strand the reviewer terminal + a NULL-totals
+      // spawn row (gcStaleReviewWorktrees only reaps the worktree; reapReviewer only acts on
+      // entries already in `inflight`, which this is not). See reapOrphanSpawn.
+      if (prior?.approved) {
+        await this.reapOrphanSpawn(sp);
+        continue;
+      }
       const plan = (this.readPlan(s.worktreePath) ?? "").trim();
       this.inflight.set(id, {
         sessionId: id,
@@ -463,10 +491,38 @@ export class PlanGateService {
         reviewerModel: sp.model,
         reviewerEffort: sp.reviewerEffort ?? s.effort ?? null,
         priorRound: prior?.round ?? 0,
+        // The `reviewer_spawns` row has no `forced` column, so a restart mid-forced-review
+        // resurrects the entry as `forced: false`. The divergence is deliberate: adding a column +
+        // migration to suppress one at-cap stall row isn't worth it, and it fails SAFE — after a
+        // crash "needs a human" is arguably true, and no operator is known to be present. Bounded at
+        // one stall row per restart per session, unreachable by clicking, so it can't walk the
+        // distiller toward its learnings-signal threshold. See applyChangesRequested's guards.
+        forced: false,
         startedAt: sp.spawnedAt, // keep the original start so a verdict-less orphan times out
       });
       this.deps.onReviewing?.(id, true);
     }
+  }
+
+  /** Targeted reap of an orphaned plan-review spawn whose gate already landed `approved` — mirrors
+   *  finalize()'s cleanup (terminal stop + best-effort usage capture + worktree remove) WITHOUT
+   *  re-adopting it into `inflight`. Keeps `approved ⇒ no reviewer in flight` while still closing the
+   *  reviewer terminal and completing the #502 cost-attribution row (its totals would otherwise stay
+   *  NULL forever). Best-effort throughout: a missing transcript leaves totals null rather than
+   *  throwing, exactly as finalize() does. */
+  private async reapOrphanSpawn(sp: {
+    worktreePath: string;
+    reviewerSessionId: string;
+  }): Promise<void> {
+    const terminalId = this.resolveTerminal(sp.worktreePath);
+    void this.deps.herdr.stop(terminalId).catch(() => {});
+    try {
+      const usage = await this.readUsage(sp.worktreePath, sp.reviewerSessionId);
+      if (usage) this.deps.store.completeReviewerSpawn(sp.reviewerSessionId, usage, this.now());
+    } catch (err) {
+      console.warn(`[plan-gate] orphan usage capture failed for ${sp.reviewerSessionId}:`, err);
+    }
+    this.deps.worktree.remove(sp.worktreePath);
   }
 
   /** Reap stale plan-review worktrees left on disk by a prior run — e.g. the older of two
@@ -577,6 +633,23 @@ export class PlanGateService {
   /** Steer the findings back to the LIVE planning agent while under the cap; at/over the cap stop
    *  steering and escalate to the operator. Execution stays gated until the plan is approved. */
   private async applyChangesRequested(f: PlanInFlight, gate: PlanGate): Promise<void> {
+    // Read the LIVE (prior) gate — buildGate hasn't persisted this verdict yet, so this still
+    // returns the pre-review row (with its round / finalRoundPending / planHash).
+    const prior = this.deps.store.getPlanGate(f.sessionId);
+    // F3 — a forced re-review of an UNCHANGED plan is inert on the streak. The findings are
+    // identical to what the planning agent already holds, so re-injecting them is noise. Hold
+    // `round`, leave `finalRoundPending` as it was, deliver NO steer, and write NO signal — neither
+    // the at-cap crossing nor the sub-cap unreachable-pane escalation, since no delivery was
+    // attempted so "unreachable" is meaningless. The fresh verdict (summary/body/findings) is still
+    // persisted + surfaced; only the streak-advancing and signal side effects are suppressed. A
+    // forced review of a CHANGED plan (hash differs) is a real revision and falls through below.
+    if (f.forced && prior && prior.planHash === f.planHash) {
+      gate.round = f.priorRound;
+      gate.finalRoundPending = prior.finalRoundPending;
+      this.deps.store.putPlanGate(gate);
+      this.deps.onChange(f.sessionId, gate);
+      return;
+    }
     const priorRound = f.priorRound;
     let delivered = false;
     if (priorRound < this.cap) {
@@ -595,27 +668,36 @@ export class PlanGateService {
     gate.finalRoundPending = delivered && gate.round >= this.cap;
     if (gate.round >= this.cap) {
       // At/over the cap — a plan still unapproved after this many rounds can't progress on its own.
-      // Fires on the crossing round and on any re-review that re-enters already at the cap.
-      this.deps.store.addSignal({
-        repoPath: f.repoPath,
-        sessionId: f.sessionId,
-        kind: "stall",
-        payload: `plan reviewer requested changes ${gate.round} rounds running and the plan still isn't approved — needs a human`,
-      });
+      // Fires on the crossing round and on any re-review that re-enters already at the cap. Suppress
+      // ONLY a forced at-cap RE-ENTRY (`f.priorRound >= cap`): a repeat-clickable button must not
+      // spam the learnings distiller. NOT `!f.forced` — a forced CROSSING (priorRound === cap-1
+      // whose steer lands) still signals exactly once, as a crossing happens at most once per streak.
+      if (!(f.forced && f.priorRound >= this.cap)) {
+        this.deps.store.addSignal({
+          repoPath: f.repoPath,
+          sessionId: f.sessionId,
+          kind: "stall",
+          payload: `plan reviewer requested changes ${gate.round} rounds running and the plan still isn't approved — needs a human`,
+        });
+      }
     } else if (!delivered) {
       // Sub-cap but the steer didn't land (dead/unreachable pane): the findings never reached the
       // planning agent and the round didn't advance, so it's stranded just like a cap stall rather
-      // than mid-revision. Escalate so it surfaces instead of silently going quiet.
+      // than mid-revision. Escalate so it surfaces instead of silently going quiet — but suppress the
+      // learnings signal on a forced run (newly reachable per click and unbounded); the console.warn
+      // and the rendered verdict still surface it to the operator.
       console.warn(
         `[plan-gate] changes-requested steer did not land for ${f.sessionId}; escalating`,
       );
-      this.deps.store.addSignal({
-        repoPath: f.repoPath,
-        sessionId: f.sessionId,
-        kind: "stall",
-        payload:
-          "plan reviewer requested changes but the planning agent's pane was unreachable — needs a human",
-      });
+      if (!f.forced) {
+        this.deps.store.addSignal({
+          repoPath: f.repoPath,
+          sessionId: f.sessionId,
+          kind: "stall",
+          payload:
+            "plan reviewer requested changes but the planning agent's pane was unreachable — needs a human",
+        });
+      }
     }
     this.deps.store.putPlanGate(gate);
     this.deps.onChange(f.sessionId, gate);
@@ -653,6 +735,10 @@ export class PlanGateService {
   }
 
   private buildGate(f: PlanInFlight, raw: RawPlanVerdict | null): PlanGate {
+    // Read the LIVE gate — buildGate runs in finalize() BEFORE this verdict is persisted, so this
+    // still returns the pre-review row, INCLUDING any answered keys the answer route merged into it
+    // while the review ran. Carry them forward when the plan text is unchanged (same planHash).
+    const live = this.deps.store.getPlanGate(f.sessionId);
     const decision = normalizeDecision(raw?.decision);
     const resolved: PlanDecision = raw && decision ? decision : "error";
     const summary = resolveSummary(resolved, raw);
@@ -675,10 +761,14 @@ export class PlanGateService {
       reviewerModel: f.reviewerModel,
       reviewerEffort: f.reviewerEffort,
       blocks: f.blocks,
-      // Fresh gate for this planHash — no questions answered yet. buildGate runs once per
-      // planHash (consider() dedups identical plans), so a revised plan resets the pending
-      // signal; the answer route appends resolved keys onto the persisted gate (#1332).
-      answeredQuestionKeys: [],
+      // Answered question-form keys belong to the plan TEXT, not to a single review run. A same-
+      // planHash re-run is reachable via `force` (the manual re-review path), so we can no longer
+      // assume buildGate runs once per planHash: carry the answers forward across a re-review of the
+      // SAME text and reset them only when the text changes. The read is of the LIVE gate above (not
+      // a begin()-time snapshot), so answers the answer route merged DURING the review survive; a
+      // changed plan → [] so planQuestionsUnanswered re-fires against the new question set (#1332).
+      answeredQuestionKeys:
+        live && live.planHash === f.planHash ? [...(live.answeredQuestionKeys ?? [])] : [],
       updatedAt: this.now(),
     };
   }

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -477,31 +477,41 @@ export class PlanGateService {
         await this.reapOrphanSpawn(sp);
         continue;
       }
-      const plan = (this.readPlan(s.worktreePath) ?? "").trim();
-      this.inflight.set(id, {
-        sessionId: id,
-        repoPath: s.repoPath,
-        worktreePath: sp.worktreePath,
-        terminalId: this.resolveTerminal(sp.worktreePath),
-        reviewerSessionId: sp.reviewerSessionId,
-        planHash: await PlanGateService.hashPlan(plan),
-        plan,
-        blocks: this.readPlanBlocks(s.worktreePath),
-        reviewerProvider: reviewerProviderFromSpawn(sp.reviewerProvider, sp.model),
-        reviewerModel: sp.model,
-        reviewerEffort: sp.reviewerEffort ?? s.effort ?? null,
-        priorRound: prior?.round ?? 0,
-        // The `reviewer_spawns` row has no `forced` column, so a restart mid-forced-review
-        // resurrects the entry as `forced: false`. The divergence is deliberate: adding a column +
-        // migration to suppress one at-cap stall row isn't worth it, and it fails SAFE — after a
-        // crash "needs a human" is arguably true, and no operator is known to be present. Bounded at
-        // one stall row per restart per session, unreachable by clicking, so it can't walk the
-        // distiller toward its learnings-signal threshold. See applyChangesRequested's guards.
-        forced: false,
-        startedAt: sp.spawnedAt, // keep the original start so a verdict-less orphan times out
-      });
+      this.inflight.set(id, await this.buildAdoptedInflight(sp, s, prior));
       this.deps.onReviewing?.(id, true);
     }
+  }
+
+  /** Rebuild an in-flight entry for a restart-orphaned plan review from its persisted spawn row.
+   *  Split out of adoptOrphans to keep that loop's cognitive complexity within the health bar. */
+  private async buildAdoptedInflight(
+    sp: ReturnType<SessionStore["listReviewerSpawns"]>[number],
+    s: Session,
+    prior: PlanGate | null,
+  ): Promise<PlanInFlight> {
+    const plan = (this.readPlan(s.worktreePath) ?? "").trim();
+    return {
+      sessionId: s.id,
+      repoPath: s.repoPath,
+      worktreePath: sp.worktreePath,
+      terminalId: this.resolveTerminal(sp.worktreePath),
+      reviewerSessionId: sp.reviewerSessionId,
+      planHash: await PlanGateService.hashPlan(plan),
+      plan,
+      blocks: this.readPlanBlocks(s.worktreePath),
+      reviewerProvider: reviewerProviderFromSpawn(sp.reviewerProvider, sp.model),
+      reviewerModel: sp.model,
+      reviewerEffort: sp.reviewerEffort ?? s.effort ?? null,
+      priorRound: prior?.round ?? 0,
+      // The `reviewer_spawns` row has no `forced` column, so a restart mid-forced-review resurrects
+      // the entry as `forced: false`. The divergence is deliberate: adding a column + migration to
+      // suppress one at-cap stall row isn't worth it, and it fails SAFE — after a crash "needs a
+      // human" is arguably true, and no operator is known to be present. Bounded at one stall row per
+      // restart per session, unreachable by clicking, so it can't walk the distiller toward its
+      // learnings-signal threshold. See applyChangesRequested's guards.
+      forced: false,
+      startedAt: sp.spawnedAt, // keep the original start so a verdict-less orphan times out
+    };
   }
 
   /** Targeted reap of an orphaned plan-review spawn whose gate already landed `approved` — mirrors
@@ -666,12 +676,21 @@ export class PlanGateService {
     // (priorRound >= cap, delivered=false) and every sub-cap round leave it false, so
     // planStallStatus can tell a genuine final round from a stall/takeover. See src/plan-status.ts.
     gate.finalRoundPending = delivered && gate.round >= this.cap;
+    this.escalateStallIfNeeded(f, gate, delivered);
+    this.deps.store.putPlanGate(gate);
+    this.deps.onChange(f.sessionId, gate);
+  }
+
+  /** Emit the learnings `stall` signal when a changes-requested round can't progress on its own —
+   *  at/over the cap, or sub-cap with an undelivered steer (dead pane). A forced re-review suppresses
+   *  the signal so a repeat-clickable button can't spam the distiller: an at-cap RE-ENTRY
+   *  (`priorRound >= cap`) is fully suppressed, but a forced CROSSING (`priorRound === cap-1` whose
+   *  steer lands) still signals exactly once. Split out of applyChangesRequested to keep its
+   *  cognitive complexity within the health bar. */
+  private escalateStallIfNeeded(f: PlanInFlight, gate: PlanGate, delivered: boolean): void {
     if (gate.round >= this.cap) {
-      // At/over the cap — a plan still unapproved after this many rounds can't progress on its own.
-      // Fires on the crossing round and on any re-review that re-enters already at the cap. Suppress
-      // ONLY a forced at-cap RE-ENTRY (`f.priorRound >= cap`): a repeat-clickable button must not
-      // spam the learnings distiller. NOT `!f.forced` — a forced CROSSING (priorRound === cap-1
-      // whose steer lands) still signals exactly once, as a crossing happens at most once per streak.
+      // Fires on the crossing round and on any re-review that re-enters already at the cap. NOT
+      // `!f.forced` — a forced crossing still signals once; only a forced at-cap re-entry is suppressed.
       if (!(f.forced && f.priorRound >= this.cap)) {
         this.deps.store.addSignal({
           repoPath: f.repoPath,
@@ -680,12 +699,12 @@ export class PlanGateService {
           payload: `plan reviewer requested changes ${gate.round} rounds running and the plan still isn't approved — needs a human`,
         });
       }
-    } else if (!delivered) {
-      // Sub-cap but the steer didn't land (dead/unreachable pane): the findings never reached the
-      // planning agent and the round didn't advance, so it's stranded just like a cap stall rather
-      // than mid-revision. Escalate so it surfaces instead of silently going quiet — but suppress the
-      // learnings signal on a forced run (newly reachable per click and unbounded); the console.warn
-      // and the rendered verdict still surface it to the operator.
+      return;
+    }
+    if (!delivered) {
+      // Sub-cap but the steer didn't land (dead/unreachable pane): stranded like a cap stall rather
+      // than mid-revision. Escalate so it surfaces — but suppress the learnings signal on a forced run
+      // (newly reachable per click and unbounded); the console.warn + rendered verdict still surface it.
       console.warn(
         `[plan-gate] changes-requested steer did not land for ${f.sessionId}; escalating`,
       );
@@ -699,8 +718,6 @@ export class PlanGateService {
         });
       }
     }
-    this.deps.store.putPlanGate(gate);
-    this.deps.onChange(f.sessionId, gate);
   }
 
   /** Persist the error gate + escalate, but don't steer (no real findings) and don't release. */

--- a/src/server.ts
+++ b/src/server.ts
@@ -355,7 +355,7 @@ export interface AppDeps {
   /** Trigger an adversarial plan review for a session on demand (the /review-plan route).
    *  Wired to PlanGateService.consider in index.ts; absent in tests that don't exercise it. */
   planGate?: {
-    consider(session: Session): Promise<import("./plan-gate").PlanReviewTrigger>;
+    consider: import("./plan-gate").PlanGateService["consider"];
     /** Reset the plan-gate round so the quota block clears, re-delivering findings to the agent.
      *  Async since #1567 — resolves true when the re-delivered steer reached the live pane. */
     resume?(session: Session): Promise<boolean>;
@@ -2548,17 +2548,20 @@ function handlePreviewStop({ req, parts, deps }: Ctx): Response | null {
   return json({ killed });
 }
 
-// POST /api/sessions/:id/review-plan — trigger an on-demand adversarial plan review.
-// 404 for an unknown id; 202 once the review is kicked off (consider() is fire-and-go).
-// `status` tells the caller whether a reviewer actually spawned ("started"), the plan was a
-// silent no-op ("skipped" — unchanged / already approved), the plan artifact is unavailable
-// ("plan-unavailable"), or a spawn attempt failed ("error"), so the UI can explain why nothing
-// changed without mislabelling a failure as an unchanged plan.
+// POST /api/sessions/:id/review-plan — operator-initiated (re)start of the adversarial plan
+// review. 404 for an unknown id; 202 once the review is kicked off (consider() is fire-and-go).
+// Mirrors /review-pr → reviewTrigger.force: this is a manual click, so it passes `force: true`
+// to bypass the unchanged-plan dedupe (an operator re-clicking on an identical plan should still
+// re-review). `status` tells the caller what happened: a reviewer actually spawned ("started"),
+// the plan artifact is unavailable ("plan-unavailable"), a spawn attempt failed ("error"), or
+// nothing happened ("skipped" — a review is already in flight, the gate is already approved, or
+// the session has left the plan phase; the route can't distinguish which), so the UI can explain
+// the outcome without mislabelling a failure as a no-op.
 async function handleSessionReviewPlan({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (!(req.method === "POST" && parts[2] && parts[3] === "review-plan")) return null;
   const s = deps.store.get(parts[2]);
   if (!s) return json({ error: "not found" }, 404);
-  const status = (await deps.planGate?.consider(s)) ?? "skipped";
+  const status = (await deps.planGate?.consider(s, { force: true })) ?? "skipped";
   return json({ ok: true, status }, 202);
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -455,7 +455,7 @@ export type PlanDecision = "approved" | "changes_requested" | "error";
 
 export interface PlanGate {
   sessionId: string;
-  planHash: string; // sha256 of the reviewed plan text; dedups re-reviews of an unchanged plan
+  planHash: string; // sha256 of the reviewed plan text; dedups re-reviews of an unchanged plan on the auto-path (the manual force path bypasses that dedupe)
   decision: PlanDecision;
   summary: string; // <=100 char one-liner for the badge tooltip
   body: string; // full markdown reviewer write-up

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -1298,3 +1298,309 @@ test("onActivity does not fire on the tick that finalizes the verdict", async ()
   await h.svc.tick();
   expect(acts).toEqual([]);
 });
+
+// ── force: the manual re-review seam (#don-offer-re-review) ────────────────────
+
+test("force bypasses the unchanged-plan hash dedupe → a reviewer spawns", async () => {
+  const hash = await PlanGateService.hashPlan("PLAN TEXT");
+  const h = harness({ store: { getPlanGate: () => ({ planHash: hash, approved: false }) } });
+  const status = await h.svc.consider(planningSession() as any, { force: true });
+  expect(status).toBe("started"); // no silent dedupe — the click re-reviews the same text
+  expect(h.started.length).toBe(1);
+});
+
+test("unforced consider still dedupes an unchanged plan (regression: force defaults false)", async () => {
+  const hash = await PlanGateService.hashPlan("PLAN TEXT");
+  const h = harness({ store: { getPlanGate: () => ({ planHash: hash, approved: false }) } });
+  expect(await h.svc.consider(planningSession() as any)).toBe("skipped");
+  expect(await h.svc.consider(planningSession() as any, { force: false })).toBe("skipped");
+  expect(h.started.length).toBe(0); // the auto-path is bit-identical to today
+});
+
+test("force does NOT bypass an approved gate → skipped, no spawn", async () => {
+  const hash = await PlanGateService.hashPlan("PLAN TEXT");
+  const h = harness({ store: { getPlanGate: () => ({ planHash: hash, approved: true }) } });
+  const status = await h.svc.consider(planningSession() as any, { force: true });
+  expect(status).toBe("skipped"); // approved is a hard precondition force does not lift
+  expect(h.started.length).toBe(0);
+});
+
+test("force does NOT bypass a non-planning phase", async () => {
+  const h = harness();
+  const status = await h.svc.consider({ ...planningSession(), planPhase: "executing" } as any, {
+    force: true,
+  });
+  expect(status).toBe("skipped");
+  expect(h.started.length).toBe(0);
+});
+
+test("force does NOT bypass a starting review", async () => {
+  const h = harness();
+  (h.svc as any).starting.add("s1");
+  const status = await h.svc.consider(planningSession() as any, { force: true });
+  expect(status).toBe("skipped");
+  expect(h.started.length).toBe(0);
+});
+
+test("force does NOT bypass an in-flight review", async () => {
+  const h = harness();
+  expect(await h.svc.consider(planningSession() as any)).toBe("started");
+  const status = await h.svc.consider(planningSession() as any, { force: true });
+  expect(status).toBe("skipped");
+  expect(h.started.length).toBe(1);
+});
+
+test("force does NOT bypass an empty/unusable plan", async () => {
+  const h = harness({ readPlan: () => "  \n\t " });
+  const status = await h.svc.consider(planningSession() as any, { force: true });
+  expect(status).toBe("plan-unavailable");
+  expect(h.started.length).toBe(0);
+});
+
+// ── force + answeredQuestionKeys carry-forward (#1332) ─────────────────────────
+
+test("forced re-review of an unchanged plan preserves answeredQuestionKeys merged mid-review", async () => {
+  const hash = await PlanGateService.hashPlan("PLAN TEXT");
+  // The live gate starts with no answers; the answer route merges keys into it AFTER begin() and
+  // BEFORE finalize(). buildGate reads the LIVE gate (not a begin()-time snapshot), so the merge
+  // must survive. `live` is mutable so we can simulate that mid-review merge.
+  let live: any = { planHash: hash, approved: false, answeredQuestionKeys: [] };
+  const h = harness({
+    store: {
+      getPlanGate: () => live,
+      get: () => ({ id: "s1", auto: false }),
+    },
+    readVerdict: () => ({ decision: "approve", summary: "ok", body: "B", findings: [] }),
+  });
+  expect(await h.svc.consider(planningSession() as any, { force: true })).toBe("started");
+  live = { planHash: hash, approved: false, answeredQuestionKeys: ["q1 q1a"] }; // merged mid-review
+  await h.svc.tick();
+  expect(h.store.gate.answeredQuestionKeys).toEqual(["q1 q1a"]); // survived the re-review
+});
+
+test("a review of a CHANGED plan resets answeredQuestionKeys", async () => {
+  const oldHash = await PlanGateService.hashPlan("OLD PLAN");
+  const h = harness({
+    readPlan: () => "NEW PLAN", // different text ⇒ different hash ⇒ not deduped
+    store: {
+      getPlanGate: () => ({
+        planHash: oldHash,
+        approved: false,
+        answeredQuestionKeys: ["q1 q1a"],
+      }),
+      get: () => ({ id: "s1", auto: false }),
+    },
+    readVerdict: () => ({ decision: "approve", summary: "ok", body: "B", findings: [] }),
+  });
+  await h.svc.consider(planningSession() as any);
+  await h.svc.tick();
+  expect(h.store.gate.answeredQuestionKeys).toEqual([]); // new question set ⇒ reset
+});
+
+// ── F3: a sub-cap forced re-review must not spend a rework round ───────────────
+
+test("F3: sub-cap forced re-review of an unchanged plan holds round + finalRoundPending, no steer, no stall", async () => {
+  const hash = await PlanGateService.hashPlan("PLAN TEXT");
+  const steers: string[] = [];
+  const signals: any[] = [];
+  const h = harness({
+    cap: 3,
+    readVerdict: () => ({
+      decision: "request-changes",
+      summary: "no",
+      body: "B",
+      findings: ["fix A"],
+    }),
+    reply: (_id: string, t: string) => {
+      steers.push(t);
+      return true;
+    },
+    store: {
+      getPlanGate: () => ({
+        planHash: hash,
+        approved: false,
+        round: 1,
+        finalRoundPending: false,
+        findings: ["fix A"],
+      }),
+      addSignal: (s: any) => signals.push(s),
+      get: () => ({ id: "s1", auto: false }),
+    },
+  });
+  expect(await h.svc.consider(planningSession() as any, { force: true })).toBe("started");
+  await h.svc.tick();
+  expect(steers.length).toBe(0); // no re-steer of findings the agent already holds
+  expect(h.store.gate.round).toBe(1); // held at priorRound — no advance
+  expect(h.store.gate.finalRoundPending).toBe(false); // unchanged
+  expect(signals.length).toBe(0); // no stall row
+  expect(h.store.gate.decision).toBe("changes_requested"); // fresh verdict still persisted
+});
+
+test("F3: sub-cap forced review of a CHANGED plan advances the round and steers", async () => {
+  const oldHash = await PlanGateService.hashPlan("OLD PLAN");
+  const steers: string[] = [];
+  const h = harness({
+    cap: 3,
+    readPlan: () => "NEW PLAN",
+    readVerdict: () => ({
+      decision: "request-changes",
+      summary: "no",
+      body: "B",
+      findings: ["fix A"],
+    }),
+    reply: (_id: string, t: string) => {
+      steers.push(t);
+      return true;
+    },
+    store: {
+      getPlanGate: () => ({ planHash: oldHash, approved: false, round: 1, findings: ["fix A"] }),
+      get: () => ({ id: "s1", auto: false }),
+    },
+  });
+  expect(await h.svc.consider(planningSession() as any, { force: true })).toBe("started");
+  await h.svc.tick();
+  expect(steers.length).toBe(1); // a real revision steers
+  expect(h.store.gate.round).toBe(2); // priorRound(1) advanced
+});
+
+// ── force: stall-signal guards (learnings-corpus protection) ──────────────────
+
+test("forced at-cap re-entry of an unchanged plan writes no stall row (F3 preempts)", async () => {
+  const hash = await PlanGateService.hashPlan("PLAN TEXT");
+  const steers: string[] = [];
+  const signals: any[] = [];
+  const h = harness({
+    cap: 1,
+    readVerdict: () => ({
+      decision: "request-changes",
+      summary: "no",
+      body: "B",
+      findings: ["again"],
+    }),
+    reply: (_id: string, t: string) => {
+      steers.push(t);
+      return true;
+    },
+    store: {
+      getPlanGate: () => ({ planHash: hash, approved: false, round: 1, findings: ["again"] }),
+      addSignal: (s: any) => signals.push(s),
+      get: () => ({ id: "s1", auto: false }),
+    },
+  });
+  await h.svc.consider(planningSession() as any, { force: true });
+  await h.svc.tick();
+  expect(signals.length).toBe(0); // repeat-clickable at the cap must not spam the distiller
+  expect(steers.length).toBe(0);
+  expect(h.store.gate.round).toBe(1);
+});
+
+test("forced CHANGED-plan crossing the cap writes exactly one stall row", async () => {
+  const oldHash = await PlanGateService.hashPlan("OLD PLAN");
+  const signals: any[] = [];
+  const h = harness({
+    cap: 3,
+    readPlan: () => "NEW PLAN",
+    readVerdict: () => ({
+      decision: "request-changes",
+      summary: "no",
+      body: "B",
+      findings: ["fix"],
+    }),
+    reply: () => true,
+    store: {
+      getPlanGate: () => ({ planHash: oldHash, approved: false, round: 2, findings: ["fix"] }),
+      addSignal: (s: any) => signals.push(s),
+      get: () => ({ id: "s1", auto: false }),
+    },
+  });
+  await h.svc.consider(planningSession() as any, { force: true });
+  await h.svc.tick();
+  expect(signals.filter((s) => s.kind === "stall").length).toBe(1); // crossing signals once
+  expect(h.store.gate.round).toBe(3); // priorRound(2) crossed the cap
+});
+
+test("forced CHANGED-plan re-entry already at the cap suppresses the stall row (guard #1)", async () => {
+  const oldHash = await PlanGateService.hashPlan("OLD PLAN");
+  const signals: any[] = [];
+  const h = harness({
+    cap: 2,
+    readPlan: () => "NEW PLAN",
+    readVerdict: () => ({
+      decision: "request-changes",
+      summary: "no",
+      body: "B",
+      findings: ["fix"],
+    }),
+    reply: () => true,
+    store: {
+      getPlanGate: () => ({ planHash: oldHash, approved: false, round: 3, findings: ["fix"] }),
+      addSignal: (s: any) => signals.push(s),
+      get: () => ({ id: "s1", auto: false }),
+    },
+  });
+  await h.svc.consider(planningSession() as any, { force: true });
+  await h.svc.tick();
+  expect(signals.length).toBe(0); // forced re-entry already at the cap → suppressed
+});
+
+test("forced sub-cap review whose steer doesn't land writes no stall row but records the verdict", async () => {
+  const oldHash = await PlanGateService.hashPlan("OLD PLAN");
+  const signals: any[] = [];
+  const h = harness({
+    cap: 3,
+    readPlan: () => "NEW PLAN",
+    readVerdict: () => ({
+      decision: "request-changes",
+      summary: "no",
+      body: "B",
+      findings: ["fix"],
+    }),
+    reply: () => false, // dead / unreachable pane
+    store: {
+      getPlanGate: () => ({ planHash: oldHash, approved: false, round: 0, findings: ["fix"] }),
+      addSignal: (s: any) => signals.push(s),
+      get: () => ({ id: "s1", auto: false }),
+    },
+  });
+  await h.svc.consider(planningSession() as any, { force: true });
+  await h.svc.tick();
+  expect(signals.length).toBe(0); // guard #2 suppresses the learnings row on a forced run
+  expect(h.store.gate.decision).toBe("changes_requested"); // operator not stranded — verdict recorded
+  expect(h.store.gate.round).toBe(0); // nothing delivered → no advance
+});
+
+// ── adoptOrphans: reap (not re-adopt) an approved orphan (invariant maintainer #2) ──
+
+test("adoptOrphans reaps an approved orphan: stops terminal, completes spawn, removes worktree, no inflight", async () => {
+  const stopped: string[] = [];
+  const usage = {
+    input: 1,
+    output: 2,
+    cacheRead: 3,
+    cacheWrite: 4,
+    total: 10,
+    messageCount: 1,
+    lastActivity: 0,
+    byModel: {},
+  };
+  const h = harness({
+    worktreeExists: () => true,
+    store: {
+      get: () => ({ id: "s1", repoPath: "/r", worktreePath: "/wt", planPhase: "planning" }),
+      getPlanGate: () => ({ planHash: "h", approved: true }),
+      listReviewerSpawns: () => [orphanSpawn()],
+    },
+    herdr: {
+      start: async () => ({ terminalId: "t1" }),
+      stop: async (id: string) => stopped.push(id),
+      list: () => [{ cwd: "/wt-detached", terminalId: "rev-term-approved" }],
+    },
+    readUsage: async () => usage,
+  });
+  await h.svc.adoptOrphans();
+  expect(h.svc.reviewingIds()).toEqual([]); // NOT re-adopted — approved ⇒ no reviewer in flight
+  expect(stopped).toContain("rev-term-approved"); // reviewer terminal stopped
+  expect(h.completedSpawns.length).toBe(1); // #502 spawn row completed (no NULL-totals leak)
+  expect(h.completedSpawns[0].u.total).toBe(10);
+  expect(h.removed).toContain("/wt-detached"); // disposable worktree removed
+});

--- a/test/server-plan-gate.test.ts
+++ b/test/server-plan-gate.test.ts
@@ -142,6 +142,39 @@ test("POST /api/sessions/:id/review-plan → 202, calls consider, relays status:
   expect(considered[0]!.id).toBe(id);
 });
 
+test("POST /api/sessions/:id/review-plan → forwards { force: true } to consider (operator click bypasses dedupe)", async () => {
+  const calls: Array<[Session, { force?: boolean } | undefined]> = [];
+  const { app, store } = harness({
+    planGate: {
+      consider: async (s: Session, opts?: { force?: boolean }) => {
+        calls.push([s, opts]);
+        return "started" as const;
+      },
+    },
+  });
+  const seeded = store.create({
+    name: "force",
+    prompt: "go",
+    repoPath: repoDir,
+    baseBranch: "main",
+    branch: "shepherd/force",
+    worktreePath: join(repoDir, "wt-force"),
+    isolated: true,
+    herdrSession: "sess-force",
+    herdrAgentId: "term_force",
+    claudeSessionId: "claude-force",
+    model: null,
+  });
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${seeded.id}/review-plan`, { method: "POST" }),
+  );
+  expect(res.status).toBe(202);
+  expect(await res.json()).toEqual({ ok: true, status: "started" });
+  expect(calls.length).toBe(1);
+  expect(calls[0]![0]!.id).toBe(seeded.id);
+  expect(calls[0]![1]).toEqual({ force: true });
+});
+
 test("POST /api/sessions/:id/review-plan → status:skipped when consider deduped", async () => {
   const { app, store } = harness({
     planGate: {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2269,6 +2269,8 @@
   "feat_up_next_sort_body": "Als Nächstes kann jetzt zwischen Empfehlung, neueste, älteste und Titel A-Z/Z-A wechseln. Priorisierte Arbeit bleibt zuerst gruppiert, und deine Sortierung wird gemerkt.",
   "feat_herd_resizable_title": "Herd-Seitenleiste anpassen",
   "feat_herd_resizable_body": "Zieh den Trenner zwischen der Herd-Seitenleiste und dem Terminal, um die Breite der Sitzungsleiste zu wählen. Deine Breite bleibt über Neuladen hinweg erhalten; ein Doppelklick auf den Trenner setzt sie auf den Standard zurück.",
+  "feat_manual_plan_rereview_title": "Plan auf Anfrage erneut prüfen",
+  "feat_manual_plan_rereview_body": "Die Aktion „Plan erneut prüfen“ startet jetzt immer eine frische Prüfung – auch wenn sich der Plan seit der letzten Runde nicht geändert hat –, sodass du ein neues Urteil für einen Plan erhältst, der an der Prüfungsgrenze feststeckt. Löse sie über das Planmenü, die Git-Leiste oder das Plan-Panel aus. Ist ein Plan bereits genehmigt, wird das Steuerelement jetzt mit einer Begründung als nicht verfügbar angezeigt, statt nichts zu tun.",
   "feat_title_tap_toggle_title": "Titel antippen zum Umschalten",
   "feat_title_tap_toggle_body": "Ein einfacher Tipp auf den Sitzungstitel öffnet oder schließt jetzt die danebenliegende Ansicht: Auf dem Desktop sind das die PR-, Merge- und Kritik-Aktionen, auf Telefon/Touch klappt er den Header ein oder aus, um Platz für das Terminal zu schaffen. Ein Doppel-Tipp benennt die Sitzung weiterhin um.",
   "feat_upnext_skip_cli_picker_title": "Coding-CLI-Auswahl in „Als Nächstes“ überspringen",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -638,7 +638,6 @@
   "planpanel_go": "Los: Ausführung starten",
   "planpanel_review_now": "Plan jetzt prüfen",
   "planpanel_reviewing": "Prüfe Plan…",
-  "planpanel_review_unchanged": "Plan seit der letzten Prüfung unverändert; keine erneute Prüfung nötig.",
   "planpanel_review_already_approved": "Plan bereits freigegeben; bereit zum Start.",
   "planpanel_review_plan_unavailable": "Prüfung nicht gestartet, weil .shepherd-plan.md fehlt, leer oder nicht lesbar ist.",
   "planpanel_review_nothing_to_review": "Planprüfung konnte gerade nicht gestartet werden.",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -619,7 +619,7 @@
   "plangate_repair_sent": "Plan-Änderungen an den Agenten gesendet.",
   "plangate_repair_send_failed": "Plan-Änderungen konnten nicht an den Agenten gesendet werden.",
   "plangate_review_started": "Plan-Prüfung gestartet.",
-  "plangate_review_skipped_stalled": "Plan-Prüfung nicht gestartet, weil der Plan unverändert ist. Lass den Agenten .shepherd-plan.md aktualisieren und prüfe dann erneut.",
+  "plangate_review_skipped_stalled": "Planprüfung konnte gerade nicht gestartet werden.",
   "feat_plan_stall_menu_title": "Gestoppte Pläne direkt am Chip reparieren",
   "feat_plan_stall_menu_body": "Wenn eine Plan-Prüfung ihr Rundenlimit erreicht, öffnet der Plan-Chip jetzt ein Aktionsmenü: Plan öffnen, einen vorbereiteten Steuertext mit Review-Befunden bearbeiten oder nach Änderung von .shepherd-plan.md erneut prüfen.",
   "plangate_tip_planning": "Planprüfung vor der Ausführung erforderlich.",
@@ -640,9 +640,8 @@
   "planpanel_reviewing": "Prüfe Plan…",
   "planpanel_review_unchanged": "Plan seit der letzten Prüfung unverändert; keine erneute Prüfung nötig.",
   "planpanel_review_already_approved": "Plan bereits freigegeben; bereit zum Start.",
-  "planpanel_review_changes_pending": "Plan unverändert. Angeforderte Änderungen brauchen vor der Ausführung weiter eine Freigabe.",
   "planpanel_review_plan_unavailable": "Prüfung nicht gestartet, weil .shepherd-plan.md fehlt, leer oder nicht lesbar ist.",
-  "planpanel_review_nothing_to_review": "Aktuell gibt es nichts zu prüfen.",
+  "planpanel_review_nothing_to_review": "Planprüfung konnte gerade nicht gestartet werden.",
   "planpanel_review_failed": "Prüfung konnte nicht gestartet werden. Bitte erneut versuchen.",
   "planpanel_status_ready": "Plan freigegeben. Starte die Ausführung, wenn bereit.",
   "planpanel_status_changes": "Prüfung hat Änderungen angefordert. Los wird erst nach Überarbeitung und Freigabe aktiv.",
@@ -1594,7 +1593,7 @@
   "gitrail_review_plan": "Plan prüfen",
   "gitrail_rereview_plan": "Plan erneut prüfen",
   "gitrail_reviewing_plan": "Prüfe Plan…",
-  "gitrail_review_plan_skipped": "Plan-Prüfung nicht gestartet – unverändert, bereits freigegeben oder läuft bereits.",
+  "gitrail_review_plan_skipped": "Planprüfung konnte gerade nicht gestartet werden.",
   "gitrail_review_plan_unavailable": "Plan-Prüfung nicht gestartet: .shepherd-plan.md fehlt, ist leer oder nicht lesbar.",
   "gitrail_review_plan_failed": "Plan-Prüfung konnte nicht gestartet werden. Erneut versuchen.",
   "feat_manual_critic_review_title": "Kritiker-Review neu starten",
@@ -2779,5 +2778,6 @@
   "feat_issue_author_label_filter_body": "Issue-Listen zeigen jetzt den Autor jedes Issues, und das Filter-Menü kann den Backlog nach Autor und Label eingrenzen — wähle einen Autor oder schalte ein oder mehrere Labels an, um die Liste zu fokussieren.",
   "reviewbanner_preview_waiting": "Überprüfung startet…",
   "feat_review_live_preview_title": "Live-Vorschau der Überprüfung + gedimmtes Terminal",
-  "feat_review_live_preview_body": "Während eine PR-Critic- oder Plan-Gate-Überprüfung im Hintergrund läuft, zeigt der amber Balken jetzt einen Live-Auszug dessen, was der Prüfer gerade tut — seine letzten Aktionen — und das Terminal wird gedimmt, um zu signalisieren, dass Shepherd arbeitet und du nichts eingeben musst. Das Dimmen ist rein visuell; dein Prompt bleibt nutzbar."
+  "feat_review_live_preview_body": "Während eine PR-Critic- oder Plan-Gate-Überprüfung im Hintergrund läuft, zeigt der amber Balken jetzt einen Live-Auszug dessen, was der Prüfer gerade tut — seine letzten Aktionen — und das Terminal wird gedimmt, um zu signalisieren, dass Shepherd arbeitet und du nichts eingeben musst. Das Dimmen ist rein visuell; dein Prompt bleibt nutzbar.",
+  "gitrail_review_plan_approved": "Plan bereits freigegeben – nichts erneut zu prüfen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -638,7 +638,6 @@
   "planpanel_go": "Go: start execution",
   "planpanel_review_now": "Review plan now",
   "planpanel_reviewing": "Reviewing…",
-  "planpanel_review_unchanged": "Plan unchanged since the last review; nothing to re-check.",
   "planpanel_review_already_approved": "Plan already approved; ready to start.",
   "planpanel_review_plan_unavailable": "Review did not start because .shepherd-plan.md is missing, empty, or unreadable.",
   "planpanel_review_nothing_to_review": "Couldn't start a plan review right now.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2269,6 +2269,8 @@
   "feat_up_next_sort_body": "Up Next now lets you switch between recommended ranking, newest, oldest, and title A-Z/Z-A order. Priority work stays grouped first, and your sort choice is remembered.",
   "feat_herd_resizable_title": "Resize the Herd sidebar",
   "feat_herd_resizable_body": "Drag the splitter between the Herd sidebar and the terminal to choose how wide the session rail sits. Your width is remembered across refreshes; double-click the splitter to snap back to the default.",
+  "feat_manual_plan_rereview_title": "Re-review a plan on demand",
+  "feat_manual_plan_rereview_body": "The Re-review plan action now always starts a fresh review — even when the plan hasn't changed since the last round — so you can get a new verdict on a plan that stalled at the review cap. Trigger it from the plan menu, the git rail, or the plan panel. When a plan is already approved, the control now shows as unavailable with a reason instead of doing nothing.",
   "feat_title_tap_toggle_title": "Tap the title to toggle",
   "feat_title_tap_toggle_body": "A single tap on the session title now opens or closes the disclosure beside it: on desktop that's the PR, merge & critic actions, and on phone/touch it folds or unfolds the header to reclaim space for the terminal. Double-tap still renames the session.",
   "feat_upnext_skip_cli_picker_title": "Skip the coding-CLI picker in Up Next",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -619,7 +619,7 @@
   "plangate_repair_sent": "Plan changes sent to the agent.",
   "plangate_repair_send_failed": "Couldn't send the plan changes to the agent.",
   "plangate_review_started": "Plan review started.",
-  "plangate_review_skipped_stalled": "Plan review did not start because the plan is unchanged. Have the agent update .shepherd-plan.md, then re-review.",
+  "plangate_review_skipped_stalled": "Couldn't start a plan review right now.",
   "feat_plan_stall_menu_title": "Repair stalled plans from the chip",
   "feat_plan_stall_menu_body": "When a plan review hits its round limit, the plan chip now opens an action menu: open the plan, edit a prepared steer with the review findings, or re-run review after .shepherd-plan.md changes.",
   "plangate_tip_planning": "Plan review required before execution.",
@@ -640,9 +640,8 @@
   "planpanel_reviewing": "Reviewing…",
   "planpanel_review_unchanged": "Plan unchanged since the last review; nothing to re-check.",
   "planpanel_review_already_approved": "Plan already approved; ready to start.",
-  "planpanel_review_changes_pending": "Plan unchanged. Requested changes still need approval before execution.",
   "planpanel_review_plan_unavailable": "Review did not start because .shepherd-plan.md is missing, empty, or unreadable.",
-  "planpanel_review_nothing_to_review": "Nothing to review right now.",
+  "planpanel_review_nothing_to_review": "Couldn't start a plan review right now.",
   "planpanel_review_failed": "Couldn't start the review. Please try again.",
   "planpanel_status_ready": "Plan approved. Start execution when ready.",
   "planpanel_status_changes": "Review requested changes. Go unlocks after the plan is revised and approved.",
@@ -1594,7 +1593,7 @@
   "gitrail_review_plan": "Review plan",
   "gitrail_rereview_plan": "Re-review plan",
   "gitrail_reviewing_plan": "Reviewing…",
-  "gitrail_review_plan_skipped": "Plan review not started — unchanged, already approved, or one's already running.",
+  "gitrail_review_plan_skipped": "Couldn't start a plan review right now.",
   "gitrail_review_plan_unavailable": "Plan review not started: .shepherd-plan.md is missing, empty, or unreadable.",
   "gitrail_review_plan_failed": "Couldn't start the plan review. Try again.",
   "feat_manual_critic_review_title": "Restart a critic review",
@@ -2779,5 +2778,6 @@
   "feat_issue_author_label_filter_body": "Issue lists now show each issue's author, and the Filters menu can narrow the backlog by author and by label — pick an author or toggle one or more labels to focus the list.",
   "reviewbanner_preview_waiting": "Starting review…",
   "feat_review_live_preview_title": "Live review preview + dimmed terminal",
-  "feat_review_live_preview_body": "While a PR-critic or plan-gate review runs off-screen, the amber banner now shows a live tail of what the reviewer is doing — its last few actions — and the terminal dims to signal that Shepherd is working and there's no need to type. The dim is visual only; your prompt stays usable."
+  "feat_review_live_preview_body": "While a PR-critic or plan-gate review runs off-screen, the amber banner now shows a live tail of what the reviewer is doing — its last few actions — and the terminal dims to signal that Shepherd is working and there's no need to type. The dim is visual only; your prompt stays usable.",
+  "gitrail_review_plan_approved": "Plan already approved — nothing to re-review."
 }

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -14,6 +14,7 @@
   import { reviews, repoConfig, planGates } from "$lib/reviews.svelte";
   import { checksCleared } from "$lib/checks-cleared";
   import { criticChip, criticBadgeLabel } from "./critic-badge";
+  import { canTriggerPlanReview } from "./plan-gate-badge";
   import RailStatusActions from "./git-rail/RailStatusActions.svelte";
   import AutomationPanel from "./AutomationPanel.svelte";
   import { automationCount, AUTOMATION_TOTAL } from "./git-rail-automation";
@@ -430,6 +431,21 @@
   // (planPhase === "planning"), matching PlanPanel's canReviewNow.
   const canReviewPlan = $derived(planPhase === "planning");
   const planReviewing = $derived(planGates.isReviewing(sessionId) || awaitingPlanReview);
+  // Only `approved` is a genuine block: `force` re-reviews an unchanged/at-cap plan, but the
+  // server never bypasses `approved`, so a click there would dead no-op. Pass GitRail's own
+  // `planReviewing` (store flag ∪ the 3 s optimistic bridge) so the block can't re-enable mid-bridge.
+  // (The "reviewing" case is already covered by the button's `disabled={planReviewing}` busy state.)
+  const planReviewBlock = $derived(
+    canTriggerPlanReview({ planPhase }, planGates.map[sessionId], planReviewing),
+  );
+  const planReviewBlockedReason = $derived(
+    planReviewBlock === "approved" ? m.gitrail_review_plan_approved() : null,
+  );
+  // If the control becomes blocked while its 3 s confirm latch is armed, drop the latch so it
+  // can't linger on an inert button.
+  $effect(() => {
+    if (planReviewBlockedReason && armed === "review-plan") armed = null;
+  });
   const planReviewLabel = $derived(
     armed === "review-plan"
       ? m.gitrail_confirm_review()
@@ -635,6 +651,7 @@
         {canReviewPlan}
         {planReviewing}
         {planReviewLabel}
+        {planReviewBlockedReason}
         {startPr}
         {doMerge}
         {doRedeploy}

--- a/ui/src/lib/components/PlanGateBadge.browser.test.ts
+++ b/ui/src/lib/components/PlanGateBadge.browser.test.ts
@@ -10,7 +10,9 @@ import { toasts } from "$lib/toasts.svelte";
 
 const api = vi.hoisted(() => ({
   replySession: vi.fn(async () => {}),
-  reviewPlan: vi.fn(async () => "skipped" as const),
+  reviewPlan: vi.fn(
+    async (): Promise<"started" | "skipped" | "plan-unavailable" | "error"> => "skipped",
+  ),
   releasePlanGate: vi.fn(async () => true),
 }));
 
@@ -141,7 +143,7 @@ describe("PlanGateBadge stalled menu", () => {
     expect(toasts.items.some((t) => t.text === m.plangate_repair_sent())).toBe(true);
   });
 
-  it("explains an unchanged plan when re-review is skipped", async () => {
+  it("toasts when a re-review can't start (skipped)", async () => {
     const id = "s-review";
     planGates.map = { [id]: gate(id) };
 
@@ -152,5 +154,19 @@ describe("PlanGateBadge stalled menu", () => {
 
     await vi.waitFor(() => expect(api.reviewPlan).toHaveBeenCalledWith(id));
     expect(toasts.items.some((t) => t.text === m.plangate_review_skipped_stalled())).toBe(true);
+  });
+
+  it("starts a real re-review from the stalled menu (force bypasses the dedupe)", async () => {
+    const id = "s-review-started";
+    api.reviewPlan.mockResolvedValue("started");
+    planGates.map = { [id]: gate(id) };
+
+    render(PlanGateBadge, { props: { session: session({ id }) } });
+
+    await page.getByRole("button", { name: m.plangate_changes({ round: 3, cap: 3 }) }).click();
+    await page.getByRole("menuitem", { name: m.plangate_menu_rereview() }).click();
+
+    await vi.waitFor(() => expect(api.reviewPlan).toHaveBeenCalledWith(id));
+    expect(toasts.items.some((t) => t.text === m.plangate_review_started())).toBe(true);
   });
 });

--- a/ui/src/lib/components/PlanPanel.browser.test.ts
+++ b/ui/src/lib/components/PlanPanel.browser.test.ts
@@ -93,6 +93,7 @@ afterEach(() => {
   // Clean up any seeded plan gate entries.
   planGates.map = {};
   planGates.reviewing = {};
+  vi.mocked(reviewPlan).mockReset();
   vi.mocked(reviewPlan).mockResolvedValue("skipped");
   vi.unstubAllGlobals();
 });
@@ -424,23 +425,32 @@ describe("PlanPanel release state", () => {
     await expect.element(page.getByRole("button", { name: m.planpanel_go() })).not.toBeDisabled();
   });
 
-  it("shows approved skipped-review feedback without blocked copy", async () => {
-    const id = "s-approved-skip";
+  it("renders the review control inert for an approved gate and does not trigger a review", async () => {
+    const id = "s-approved-inert";
     planGates.map = { [id]: gate(id) };
 
     render(PlanPanel, {
       props: { session: session({ id }), onclose: vi.fn() },
     });
 
-    await page.getByRole("button", { name: m.planpanel_review_now() }).click();
+    // The approved reason is shown persistently beside the control.
     await expect.element(page.getByText(m.planpanel_review_already_approved())).toBeVisible();
-    await expect
-      .element(page.getByText(m.planpanel_review_changes_pending()))
-      .not.toBeInTheDocument();
+
+    const reviewBtn = page.getByRole("button", {
+      name: `${m.planpanel_review_now()} — ${m.planpanel_review_already_approved()}`,
+    });
+    await expect.element(reviewBtn).toHaveAttribute("aria-disabled", "true");
+
+    // Clicking the inert control is a guarded no-op — no review is triggered. `force` bypasses
+    // Playwright's actionability wait (it treats aria-disabled as not-enabled), so the click still
+    // dispatches and we assert the component's own onclick guard swallows it.
+    await reviewBtn.click({ force: true });
+    expect(vi.mocked(reviewPlan)).not.toHaveBeenCalled();
   });
 
-  it("shows pending-changes skipped-review feedback for unchanged unapproved plans", async () => {
-    const id = "s-changes-skip";
+  it("starts a real review for an unchanged unapproved (changes-requested) plan", async () => {
+    const id = "s-changes-review";
+    vi.mocked(reviewPlan).mockResolvedValue("started");
     planGates.map = {
       [id]: gate(id, {
         decision: "changes_requested",
@@ -455,7 +465,9 @@ describe("PlanPanel release state", () => {
     });
 
     await page.getByRole("button", { name: m.planpanel_review_now() }).click();
-    await expect.element(page.getByText(m.planpanel_review_changes_pending())).toBeVisible();
+    expect(vi.mocked(reviewPlan)).toHaveBeenCalledWith(id);
+    // The in-flight indicator appears (the "started" bridge to the WS reviewing flag).
+    await expect.element(page.getByText(m.planpanel_reviewing())).toBeVisible();
   });
 
   it("explains the required plan artifact in the planning/no-gate empty state", async () => {

--- a/ui/src/lib/components/PlanPanel.svelte
+++ b/ui/src/lib/components/PlanPanel.svelte
@@ -2,7 +2,12 @@
   import type { AgentProvider, Session } from "$lib/types";
   import { planGates } from "$lib/reviews.svelte";
   import { dismissQuota, releasePlanGate, resumeQuota, reviewPlan } from "$lib/api";
-  import { canRelease, canShowPlanStallActions, planGateChip } from "./plan-gate-badge";
+  import {
+    canRelease,
+    canShowPlanStallActions,
+    canTriggerPlanReview,
+    planGateChip,
+  } from "./plan-gate-badge";
   import { dialog } from "$lib/a11yDialog";
   import { portal } from "$lib/portal";
   import { m } from "$lib/paraglide/messages";
@@ -38,6 +43,9 @@
     canReviewNow ? { sessionId: session.id, locked: reviewing } : undefined,
   );
   const planStalled = $derived(canShowPlanStallActions(session, gate, reviewing));
+  // Only `approved` renders the Review control inert: `force` re-reviews an unchanged plan, but the
+  // server never bypasses `approved`. (The `reviewing` case is handled by the in-flight spinner path.)
+  const planReviewBlock = $derived(canTriggerPlanReview(session, gate, reviewing));
   let envOpen = $state(false);
 
   function providerLabel(provider: AgentProvider): string {
@@ -106,9 +114,10 @@
   // until `reviewing` is observed, with a backstop timeout so a lost event can't wedge the spinner.
   let awaitingReview = $state(false);
   // Outcome of the last manual review trigger that produced no live run, so the panel can explain
-  // why nothing changed. Auto-dismissed so it can't go stale between clicks.
-  // null = no note (fresh page, or a real review is/was in flight).
-  let outcome = $state<"approved" | "changes" | "idle" | "error" | null>(null);
+  // that it couldn't start. Auto-dismissed so it can't go stale between clicks.
+  // null = no note (fresh page, or a real review is/was in flight). The cause is not guessed from the
+  // cached gate — `force` makes any "unchanged/approved" claim false, and a plugin abort is unknowable.
+  let outcome = $state<"skipped" | "error" | null>(null);
   // Persistent while the current planning state has no usable `.shepherd-plan.md` artifact.
   // Unlike `outcome`, this must not auto-dismiss: it explains why Review cannot start.
   let planUnavailable = $state(false);
@@ -166,11 +175,11 @@
     try {
       const status = await reviewPlan(session.id);
       // "started" → bridge to the WS reviewing flag so the spinner doesn't blink back.
-      // "skipped" → unchanged/already-approved/not-reviewable; branch on the cached gate so
-      // approved plans do not read as blocked and requested-change plans do not read as cleared.
+      // "skipped" → the review couldn't start (a race, an approval landing, a planPhase flip, or a
+      // plugin abort). The cause is unknowable from here, so the note stays causally silent.
       if (status === "started") awaitingReview = true;
       else if (status === "plan-unavailable" && !reviewing) planUnavailable = true;
-      else if (status === "skipped" && !reviewing) outcome = skippedOutcome(gate);
+      else if (status === "skipped" && !reviewing) outcome = "skipped";
       else if (status === "error") outcome = "error";
     } catch {
       // The trigger request itself failed (network / non-2xx) — surface it like a spawn failure.
@@ -220,13 +229,6 @@
     } finally {
       quotaBusy = null;
     }
-  }
-
-  function skippedOutcome(currentGate: typeof gate): typeof outcome {
-    if (currentGate?.approved) return "approved";
-    if (currentGate?.decision === "changes_requested") return "changes";
-    if (currentGate?.decision === "error") return "error";
-    return "idle";
   }
 
   const statusNoteId = $derived(`plan-status-${session.id}`);
@@ -390,11 +392,7 @@
 
       {#if planUnavailable}
         <p class="note" role="status">{m.planpanel_review_plan_unavailable()}</p>
-      {:else if outcome === "approved"}
-        <p class="note" role="status">{m.planpanel_review_already_approved()}</p>
-      {:else if outcome === "changes"}
-        <p class="note" role="status">{m.planpanel_review_changes_pending()}</p>
-      {:else if outcome === "idle"}
+      {:else if outcome === "skipped"}
         <p class="note" role="status">{m.planpanel_review_nothing_to_review()}</p>
       {:else if outcome === "error"}
         <p class="note err" role="alert">{m.planpanel_review_failed()}</p>
@@ -440,8 +438,15 @@
             <button
               type="button"
               class="review"
-              onclick={review}
               disabled={inFlight || !!quotaBusy}
+              aria-disabled={planReviewBlock === "approved" ? "true" : undefined}
+              aria-label={planReviewBlock === "approved"
+                ? `${m.planpanel_review_now()} — ${m.planpanel_review_already_approved()}`
+                : undefined}
+              onclick={() => {
+                if (planReviewBlock === "approved") return;
+                review();
+              }}
             >
               {#if inFlight}
                 <span class="rev-dot" aria-hidden="true"></span>{m.planpanel_reviewing()}
@@ -460,6 +465,9 @@
             {m.planpanel_go()}
           </button>
         </div>
+        {#if planReviewBlock === "approved"}
+          <p class="note" role="status">{m.planpanel_review_already_approved()}</p>
+        {/if}
       {/if}
     </div>
   </div>
@@ -824,7 +832,10 @@
   }
   .review:disabled,
   .go:disabled,
-  .quota-btn:disabled {
+  .quota-btn:disabled,
+  /* Inert (approved) — kept focusable so its aria-label reason is keyboard-reachable,
+     unlike bare `disabled`. */
+  .review[aria-disabled="true"] {
     opacity: 0.5;
     cursor: not-allowed;
     color: var(--color-faint);

--- a/ui/src/lib/components/git-rail/RailStatusActions.svelte
+++ b/ui/src/lib/components/git-rail/RailStatusActions.svelte
@@ -26,6 +26,7 @@
     canReviewPlan,
     planReviewing,
     planReviewLabel,
+    planReviewBlockedReason,
     startPr,
     doMerge,
     doRedeploy,
@@ -53,6 +54,7 @@
     canReviewPlan: boolean;
     planReviewing: boolean;
     planReviewLabel: string;
+    planReviewBlockedReason: string | null;
     startPr: () => void;
     doMerge: (skipArm?: boolean) => Promise<void>;
     doRedeploy: (skipArm?: boolean) => Promise<void>;
@@ -219,10 +221,18 @@
 {#if canReviewPlan}
   <button
     class="gbtn"
-    class:armed={armed === "review-plan"}
+    class:armed={armed === "review-plan" && !planReviewBlockedReason}
     type="button"
     disabled={planReviewing}
-    onclick={() => doReviewPlan()}
+    aria-disabled={planReviewBlockedReason ? "true" : undefined}
+    title={planReviewBlockedReason ?? undefined}
+    aria-label={planReviewBlockedReason
+      ? `${planReviewLabel} — ${planReviewBlockedReason}`
+      : undefined}
+    onclick={() => {
+      if (planReviewBlockedReason) return;
+      doReviewPlan();
+    }}
   >
     {planReviewLabel}
   </button>
@@ -255,6 +265,17 @@
   .gbtn:disabled {
     opacity: 0.4;
     cursor: not-allowed;
+  }
+  /* Inert (not busy) — kept focusable so the reason in `title`/aria-label is reachable
+     by keyboard, unlike bare `disabled`. */
+  .gbtn[aria-disabled="true"] {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+  .gbtn[aria-disabled="true"]:hover {
+    border-color: var(--color-line);
+    color: var(--color-muted);
+    background: transparent;
   }
   .gbtn.armed {
     border-color: var(--color-amber);

--- a/ui/src/lib/components/plan-gate-badge.test.ts
+++ b/ui/src/lib/components/plan-gate-badge.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { canTriggerPlanReview } from "./plan-gate-badge";
+import type { PlanGate, Session } from "$lib/types";
+
+const baseGate: PlanGate = {
+  sessionId: "s1",
+  planHash: "hash",
+  decision: "changes_requested",
+  summary: "",
+  body: "",
+  findings: [],
+  round: 3,
+  cap: 3,
+  approved: false,
+  plan: "",
+  updatedAt: 1_000_000,
+};
+const gate = (p: Partial<PlanGate>): PlanGate => ({ ...baseGate, ...p });
+const session = (planPhase: Session["planPhase"]): Pick<Session, "planPhase"> => ({ planPhase });
+
+describe("canTriggerPlanReview", () => {
+  it("reviewing wins over an approved gate", () => {
+    expect(canTriggerPlanReview(session("planning"), gate({ approved: true }), true)).toBe(
+      "reviewing",
+    );
+  });
+  it("an approved gate blocks when not reviewing", () => {
+    expect(canTriggerPlanReview(session("planning"), gate({ approved: true }), false)).toBe(
+      "approved",
+    );
+  });
+  it("a startable gate (e.g. changes_requested at cap) is not blocked", () => {
+    expect(
+      canTriggerPlanReview(
+        session("planning"),
+        gate({ decision: "changes_requested", round: 3, cap: 3, approved: false }),
+        false,
+      ),
+    ).toBeNull();
+  });
+  it("off the plan phase is never blocked, regardless of gate/reviewing", () => {
+    expect(canTriggerPlanReview(session("executing"), gate({ approved: true }), true)).toBeNull();
+  });
+  it("no gate at all, not reviewing, is startable", () => {
+    expect(canTriggerPlanReview(session("planning"), undefined, false)).toBeNull();
+  });
+});

--- a/ui/src/lib/components/plan-gate-badge.ts
+++ b/ui/src/lib/components/plan-gate-badge.ts
@@ -80,6 +80,24 @@ export function canShowPlanStallActions(
   );
 }
 
+/** Reason a manual plan re-review is BLOCKED on GitRail / PlanPanel, or null when it can start.
+ *  `reviewing` (one already in flight) is checked BEFORE `approved` — matching planGateChip() — so a
+ *  review landing on a just-approved gate reads as in-flight, not "already approved". After the
+ *  `force` seam an unchanged/at-cap plan is no longer a block (force re-reviews it); only these two
+ *  states remain genuinely un-startable. The caller still gates visibility on planPhase==="planning". */
+export type PlanReviewBlockReason = "reviewing" | "approved";
+
+export function canTriggerPlanReview(
+  session: Pick<Session, "planPhase">,
+  gate: PlanGate | undefined,
+  reviewing: boolean,
+): PlanReviewBlockReason | null {
+  if (session.planPhase !== "planning") return null; // control isn't offered off the plan phase
+  if (reviewing) return "reviewing";
+  if (gate?.approved) return "approved";
+  return null;
+}
+
 export type PlanGateTooltipCopy = {
   fallback: string;
   planning: string;

--- a/ui/src/lib/feature-announcements/entries/v1.43.0-manual-plan-rereview.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.43.0-manual-plan-rereview.ts
@@ -1,0 +1,13 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+// No targetId/coachmark: the plan-review control only mounts while a session is in the planning
+// phase (a transient state), so an anchored coachmark could not reliably fire. Surfaced through
+// the What's-New drawer only.
+const entry = {
+  id: "manual-plan-rereview",
+  sinceVersion: "1.43.0",
+  titleKey: "feat_manual_plan_rereview_title",
+  bodyKey: "feat_manual_plan_rereview_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## Problem

The operator's **Re-review plan** control (stalled plan-gate menu, GitRail, PlanPanel) was a guaranteed no-op. `PlanGateService.consider()` dedupes on `sha256(.shepherd-plan.md)`, and at the adversarial-review round cap the planning agent is never re-steered — so the on-disk plan is byte-identical to the one already reviewed. Every click round-tripped `POST /review-plan`, got `"skipped"`, and produced a toast saying the review didn't start. The control was dead by construction.

## Fix

Give the plan gate the **`force` seam the PR critic already has** (`ReviewService.consider(…, { force })`). `POST /review-plan` is operator-initiated, so it now passes `{ force: true }`, which bypasses **only** the plan-hash dedupe. Every hard precondition still gates.

`approved` stays a **hard precondition** — `force` does *not* bypass it. `gate.approved` is a release latch on a one-way transition, and `releasePlanGate` / `#enterExecution` / `finalize()` rely on the invariant `approved ⇒ no reviewer in flight`. That invariant is maintained by two sites: `consider()`'s approved guard **and** `adoptOrphans()` reaping (not re-adopting) an approved orphan. So the one state where a manual review is offered but genuinely cannot start is an **approved** gate — and GitRail + PlanPanel render that control inert (`aria-disabled`, keyboard-reachable, announced reason) instead of firing a dead click.

### Behaviour details
- **F3** — a forced re-review of an *unchanged* plan holds the round, holds `finalRoundPending`, delivers no steer, and writes no stall signal (re-injecting identical findings is noise). A forced review of a *changed* plan advances normally.
- **Stall signals bounded** — a forced at-cap *re-entry* writes no `stall` row (a human just clicked; the signal means "needs a human"), but a forced review that *crosses* the cap still writes exactly one. Prevents repeat clicks from walking a session toward the learnings-distiller threshold.
- **Answer preservation** — `answeredQuestionKeys` now carry forward from the **live** gate at finalize time, so a forced re-review of an unchanged plan no longer wipes the operator's recorded question-form answers (including answers merged mid-review).
- **Honest copy** — deleted `PlanPanel.skippedOutcome()` (which guessed a cause from the cached gate) and neutralized three strings that asserted "the plan is unchanged" — false once `force` re-reviews it. The skipped toasts remain as the fail-safe for the render→click race, with causally-silent copy.

### Deferred (follow-ups, intentionally not in this PR)
- `releasePlanGate` `isReviewing` guard + a `planPhase` re-check in `finalize()` — only reachable *if* a future change lets `force` bypass `approved`; unreachable today, so writing them now would be dead code. A test pins `consider(session, { force: true })` declining an approved gate as the guard.
- A plugin `onSpawn` abort returns `"skipped"` deterministically; giving it its own trigger value (rather than sharing `"skipped"`) would let the UI explain a plugin-refusing repo. Out of scope here.

## Regression protection (accurate)

The route→adapter→service path carrying `{ force: true }` is protected by the **forwarding adapter** in `index.ts` (`(s, opts) => planGate.consider(s, opts)`) plus a **route test** asserting `consider` receives `{ force: true }`. Note: typing the dep `PlanGateService["consider"]` is a DRY win but is **not** a compile-time guard against a dropped param — TypeScript allows a fewer-parameter function to satisfy a wider function type. The runtime test is the real guard.

## Tests
- `test/plan-gate-service.test.ts` (+16 cases): force bypasses the dedupe only; does *not* bypass `approved`/`planPhase`/in-flight/empty-plan; unforced auto-path bit-identical; answer carry-forward (incl. mid-review merge) vs reset; F3 sub-cap hold; at-cap re-entry vs crossing vs dead-pane signal arms; `adoptOrphans` reaps an approved orphan without re-adopting.
- `test/server-plan-gate.test.ts`: route forwards `{ force: true }`.
- UI: `canTriggerPlanReview` unit test; PlanPanel/PlanGateBadge browser tests (approved control is `aria-disabled` + no POST; a `changes_requested` click starts a real review; the menu issues the POST and surfaces `plangate_review_started`).

Server suite 108/108, UI suite 3135/3135, `check` + `check:i18n` (EN/DE parity) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
