### PR TITLE
fix(learnings): retype distiller/optimizer DI seams to => Promise<void> (#1597)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -420,11 +420,7 @@ export interface AppDeps {
    *  Optional so environments/tests that don't wire it still type-check; the route
    *  no-ops the trigger when absent. Wired to the real DistillerService in index.ts. */
   distiller?: {
-    // TODO(#1567 follow-up): mistyped. DistillerService.distillNow is `async … : Promise<void>`,
-    // so this `=> void` hides the promise from `tsc` and from the lint gate. The trigger route
-    // below no longer LEAKS (it wraps in `Promise.resolve(...).catch`), but the seam still lies.
-    // Retyping forces ~16 test doubles async — pre-existing, so it gets its own PR, not this one.
-    distillNow: (repoPath: string) => void;
+    distillNow: (repoPath: string) => Promise<void>;
     health?: () => {
       ok: boolean;
       consecutiveFailures: number;
@@ -435,12 +431,8 @@ export interface AppDeps {
    *  rules. Optional so tests that don't wire it still type-check; routes no-op when absent.
    *  Wired to the real OptimizerService in index.ts. */
   optimizer?: {
-    // TODO(#1567 follow-up): mistyped — OptimizerService.optimizeOne is `async`. Same as
-    // `distillNow` above; retype alongside its siblings so a marker-driven sweep can't miss it.
-    optimizeOne: (id: string) => void;
-    // TODO(#1567 follow-up): mistyped — OptimizerService.optimizeAllFlagged is `async`. Same
-    // reason for deferring the fix as `distillNow` above.
-    optimizeAllFlagged: (repoPath: string) => void;
+    optimizeOne: (id: string) => Promise<void>;
+    optimizeAllFlagged: (repoPath: string) => Promise<void>;
     health?: () => {
       ok: boolean;
       consecutiveFailures: number;
@@ -1631,20 +1623,16 @@ function handleRepoScopedLearningPost(parts: string[], url: URL, deps: AppDeps):
     return null;
   const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
   if (!dir) return json({ error: "invalid repo" }, 400);
-  // All three are async fire-and-forget whose service chains (enqueueOrBegin → begin) never catch,
-  // so a bare `void` leaks an unhandled rejection — and `no-floating-promises` defaults to
-  // `ignoreVoid: true`, so the gate this PR lands cannot see it. `distillNow`/`optimizeAllFlagged`
-  // are still mistyped `=> void` (see the TODOs on their DI declarations), but the leak needs no
-  // retype to close: `Promise.resolve` normalizes the declared-void/actually-promise value so the
-  // `.catch` attaches at runtime regardless of what the seam claims.
+  // Async fire-and-forget whose service chains (enqueueOrBegin → begin) never catch internally, so
+  // the `.catch` here is what stops an unhandled rejection; `void` satisfies no-floating-promises.
   if (parts[2] === "distill")
-    void Promise.resolve(deps.distiller?.distillNow(dir)).catch((err) =>
-      console.warn("[distill] distillNow failed:", err),
-    );
+    void deps.distiller
+      ?.distillNow(dir)
+      .catch((err) => console.warn("[distill] distillNow failed:", err));
   else if (parts[2] === "optimize")
-    void Promise.resolve(deps.optimizer?.optimizeAllFlagged(dir)).catch((err) =>
-      console.warn("[optimize] optimizeAllFlagged failed:", err),
-    );
+    void deps.optimizer
+      ?.optimizeAllFlagged(dir)
+      .catch((err) => console.warn("[optimize] optimizeAllFlagged failed:", err));
   else if (parts[2] === "merge-suggest")
     void deps.mergeSuggest
       ?.mergeNow(dir)
@@ -1748,11 +1736,11 @@ async function handleLearningIdAction(ctx: Ctx): Promise<Response | null> {
 
   // POST /api/learnings/:id/optimize — optimize a single flagged rule
   if (parts[3] === "optimize") {
-    // Same shape as the distill/optimize triggers above: async under a `=> void` seam, so the
-    // rejection is invisible to both `tsc` and the lint gate. Normalize, then catch.
-    void Promise.resolve(deps.optimizer?.optimizeOne(parts[2])).catch((err) =>
-      console.warn("[optimize] optimizeOne failed:", err),
-    );
+    // Async fire-and-forget (same shape as the distill/optimize triggers above): catch the rejection,
+    // `void` for no-floating-promises.
+    void deps.optimizer
+      ?.optimizeOne(parts[2])
+      .catch((err) => console.warn("[optimize] optimizeOne failed:", err));
     return json({ ok: true });
   }
 

--- a/test/agent-ingress.test.ts
+++ b/test/agent-ingress.test.ts
@@ -91,7 +91,7 @@ function makeDeps(): AppDeps {
     }),
     projections: () => [],
   };
-  return { store, service, events, usageLimits, distiller: { distillNow: () => {} } };
+  return { store, service, events, usageLimits, distiller: { distillNow: async () => {} } };
 }
 
 test("makeAgentIngressApp: a DENIED route 404s AT THE GATE (never reaches a handler)", async () => {

--- a/test/automation-confirm.test.ts
+++ b/test/automation-confirm.test.ts
@@ -211,7 +211,7 @@ function makeDeps(): AppDeps {
     }),
     projections: () => [],
   };
-  const distiller = { distillNow: () => {} };
+  const distiller = { distillNow: async () => {} };
   return { store, service, events, usageLimits, distiller };
 }
 

--- a/test/server-auth.test.ts
+++ b/test/server-auth.test.ts
@@ -41,7 +41,7 @@ function makeDeps(): AppDeps {
     }),
     projections: () => [],
   };
-  return { store, service, events, usageLimits, distiller: { distillNow: () => {} } };
+  return { store, service, events, usageLimits, distiller: { distillNow: async () => {} } };
 }
 
 const cookieHeader = (value: string) => ({ Cookie: `${SESSION_COOKIE}=${value}` });

--- a/test/server-fork.test.ts
+++ b/test/server-fork.test.ts
@@ -52,7 +52,7 @@ function makeDeps(ghRunner?: GhRunner): AppDeps {
     }),
     projections: () => [],
   };
-  const distiller = { distillNow: () => {} };
+  const distiller = { distillNow: async () => {} };
   return { store, service, events, usageLimits, distiller, newProjectGhRunner: ghRunner };
 }
 

--- a/test/server-learnings.test.ts
+++ b/test/server-learnings.test.ts
@@ -253,10 +253,10 @@ function makeOptimizerDeps(optimizer?: AppDeps["optimizer"]): AppDeps {
 test("POST /api/learnings/optimize?repo= valid → 200 {ok:true} and calls optimizeAllFlagged", async () => {
   const called: string[] = [];
   const optimizer: AppDeps["optimizer"] = {
-    optimizeAllFlagged: (dir) => {
+    optimizeAllFlagged: async (dir) => {
       called.push(dir);
     },
-    optimizeOne: () => {},
+    optimizeOne: async () => {},
   };
   const app = makeApp(makeOptimizerDeps(optimizer));
 
@@ -272,8 +272,8 @@ test("POST /api/learnings/optimize?repo= valid → 200 {ok:true} and calls optim
 
 test("POST /api/learnings/optimize?repo= missing → 400", async () => {
   const optimizer: AppDeps["optimizer"] = {
-    optimizeAllFlagged: () => {},
-    optimizeOne: () => {},
+    optimizeAllFlagged: async () => {},
+    optimizeOne: async () => {},
   };
   const app = makeApp(makeOptimizerDeps(optimizer));
 
@@ -287,8 +287,8 @@ test("POST /api/learnings/optimize?repo= missing → 400", async () => {
 test("POST /api/learnings/:id/optimize → 200 {ok:true} and calls optimizeOne", async () => {
   const called: string[] = [];
   const optimizer: AppDeps["optimizer"] = {
-    optimizeAllFlagged: () => {},
-    optimizeOne: (id) => {
+    optimizeAllFlagged: async () => {},
+    optimizeOne: async (id) => {
       called.push(id);
     },
   };
@@ -318,10 +318,10 @@ test("GET /api/learnings/health preserves top-level distiller fields and adds op
     service: {} as any,
     events,
     usageLimits: { limits: () => ({}) } as any,
-    distiller: { distillNow: () => {}, health: () => distillerHealth },
+    distiller: { distillNow: async () => {}, health: () => distillerHealth },
     optimizer: {
-      optimizeAllFlagged: () => {},
-      optimizeOne: () => {},
+      optimizeAllFlagged: async () => {},
+      optimizeOne: async () => {},
       health: () => optimizerHealth,
     },
   };
@@ -881,13 +881,10 @@ async function warningsDuring(fn: () => Promise<void>): Promise<string[]> {
 }
 
 test("POST /api/learnings/optimize: a REJECTING optimizeAllFlagged is caught, not left floating", async () => {
-  // The DI seam is typed `=> void` while the impl is async, so `tsc` and the lint gate are both
-  // blind here — `Promise.resolve(...)` in the route is what lets the `.catch` attach at runtime.
+  // The route fire-and-forgets this async seam; its `.catch` is what stops the rejection floating.
   const optimizer: AppDeps["optimizer"] = {
-    optimizeAllFlagged: (() => Promise.reject(new Error("boom-all"))) as unknown as (
-      d: string,
-    ) => void,
-    optimizeOne: () => {},
+    optimizeAllFlagged: () => Promise.reject(new Error("boom-all")),
+    optimizeOne: async () => {},
   };
   const app = makeApp(makeOptimizerDeps(optimizer));
 
@@ -907,8 +904,8 @@ test("POST /api/learnings/optimize: a REJECTING optimizeAllFlagged is caught, no
 
 test("POST /api/learnings/:id/optimize: a REJECTING optimizeOne is caught, not left floating", async () => {
   const optimizer: AppDeps["optimizer"] = {
-    optimizeAllFlagged: () => {},
-    optimizeOne: (() => Promise.reject(new Error("boom-one"))) as unknown as (id: string) => void,
+    optimizeAllFlagged: async () => {},
+    optimizeOne: () => Promise.reject(new Error("boom-one")),
   };
   const app = makeApp(makeOptimizerDeps(optimizer));
 

--- a/test/server-ping.test.ts
+++ b/test/server-ping.test.ts
@@ -31,7 +31,7 @@ function makeDeps(): AppDeps {
     }),
     projections: () => [],
   };
-  return { store, service, events, usageLimits, distiller: { distillNow: () => {} } };
+  return { store, service, events, usageLimits, distiller: { distillNow: async () => {} } };
 }
 
 const harness = () => makeApp(makeDeps());

--- a/test/server-projects.test.ts
+++ b/test/server-projects.test.ts
@@ -60,7 +60,7 @@ function makeDeps(): AppDeps {
     }),
     projections: () => [],
   };
-  const distiller = { distillNow: () => {} };
+  const distiller = { distillNow: async () => {} };
   return { store, service, events, usageLimits, distiller };
 }
 

--- a/test/server-sync-fork.test.ts
+++ b/test/server-sync-fork.test.ts
@@ -72,7 +72,7 @@ function makeDeps(resolveForge?: (dir: string) => GitForge | null): AppDeps {
     }),
     projections: () => [],
   };
-  const distiller = { distillNow: () => {} };
+  const distiller = { distillNow: async () => {} };
   return { store, service, events, usageLimits, distiller, resolveForge } as AppDeps;
 }
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -66,7 +66,7 @@ function makeDeps(liveTerminals: string[] = []): AppDeps {
     }),
     projections: () => [],
   };
-  const distiller = { distillNow: () => {} };
+  const distiller = { distillNow: async () => {} };
   return { store, service, events, usageLimits, distiller };
 }
 
@@ -358,7 +358,13 @@ function harnessWithReaper(reaper: { detect: any; reap: any; stopListenersOnPort
     }),
     projections: () => [],
   };
-  const app = makeApp({ store, service, events, usageLimits, distiller: { distillNow: () => {} } });
+  const app = makeApp({
+    store,
+    service,
+    events,
+    usageLimits,
+    distiller: { distillNow: async () => {} },
+  });
   return { app, store };
 }
 
@@ -1356,7 +1362,7 @@ test("GET /api/learnings/health returns distiller health when health() present",
     consecutiveFailures: 3,
     lastFailure: { reason: "spawn", at: 1, repoPath: "/r" },
   };
-  deps.distiller = { distillNow: () => {}, health: () => unhealthy };
+  deps.distiller = { distillNow: async () => {}, health: () => unhealthy };
   const app = makeApp(deps);
   const res = await app.fetch(new Request("http://x/api/learnings/health"));
   expect(res.status).toBe(200);
@@ -1367,7 +1373,7 @@ test("GET /api/learnings/health returns distiller health when health() present",
 });
 
 test("GET /api/learnings/health returns safe default when distiller lacks health()", async () => {
-  const deps = makeDeps(); // distiller = { distillNow: () => {} } — no health
+  const deps = makeDeps(); // distiller = { distillNow: async () => {} } — no health
   const app = makeApp(deps);
   const res = await app.fetch(new Request("http://x/api/learnings/health"));
   expect(res.status).toBe(200);
@@ -2018,7 +2024,13 @@ function harnessWithPreviewStop({
     }),
     projections: () => [],
   };
-  const app = makeApp({ store, service, events, usageLimits, distiller: { distillNow: () => {} } });
+  const app = makeApp({
+    store,
+    service,
+    events,
+    usageLimits,
+    distiller: { distillNow: async () => {} },
+  });
   return { app, store };
 }
 


### PR DESCRIPTION
## What

Three `AppDeps` DI seams (`src/server.ts`) were typed `=> void` while their real impls are `async … : Promise<void>` — so both `tsc` and the `no-floating-promises` gate (#1567) were blind to them.

| Seam | Impl |
|---|---|
| `distillNow: (repoPath) => void` → `=> Promise<void>` | `DistillerService.distillNow` (async) |
| `optimizeOne: (id) => void` → `=> Promise<void>` | `OptimizerService.optimizeOne` (async) |
| `optimizeAllFlagged: (repoPath) => void` → `=> Promise<void>` | `OptimizerService.optimizeAllFlagged` (async) |

## Changes

- Retype the three seams to `=> Promise<void>`; drop the `TODO(#1567 follow-up)` mistyping comments.
- Collapse the three call-site `void Promise.resolve(...).catch(...)` mitigation wrappers (added in #1575) back to the plain `void deps.x?.foo(arg).catch(...)` pattern the adjacent `mergeSuggest` sibling already uses (optional chaining short-circuits `.catch` safely).
- Make the ~13 cascading sync test doubles `async` across 9 test files; remove two now-redundant `as unknown as (...) => void` casts on the rejecting-double tests.

## Why now

Deliberately deferred out of #1567 / PR #1575: correcting the type cascades to the test doubles (root `tsconfig.json` type-checks `test/`), a wide mechanical change unrelated to the `send` port. This PR is that follow-up.

## Verification

- `bun run typecheck` ✓, `bun run lint` ✓
- `bun test ./test` ✓ (the 8 `service.test.ts` spawn failures reproduce on `main` too — a local Shepherd-session env leak, `SHEPHERD_HOOKS_INGEST=1`; CI is green without it. Pre-push passed with those vars scrubbed.)
- `grep "TODO(#1567 follow-up)" src` → empty; no `Promise.resolve(...)` wrapper or optimizer cast remains.

Closes #1597. Server-only type-correctness, no user-facing UX → `[no-feature-entry]`.