### PR TITLE
test: isolate suite from ambient operator SHEPHERD_* env

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,6 @@
+# Root `bun test` config. The preload strips the operator's ambient SHEPHERD_* runtime config
+# before any test imports src/config.ts, so the suite is deterministic regardless of whether it
+# runs in CI, a plain shell, or inside a live Shepherd session (dogfooding). See the header of
+# test/setup-test-env.ts for the full rationale.
+[test]
+preload = ["./test/setup-test-env.ts"]

--- a/test/setup-test-env.ts
+++ b/test/setup-test-env.ts
@@ -1,0 +1,33 @@
+// Preloaded before any test module (bunfig.toml → [test] preload), which means it runs
+// BEFORE `src/config.ts` is first imported. That ordering is the whole point: `config` is a
+// single object literal that snapshots ~100 `SHEPHERD_*` env vars at import and never re-reads
+// them. When `bun test` runs inside a live Shepherd session (dogfooding), the operator's runtime
+// toggles — `SHEPHERD_HOOKS_INGEST=1`, `SHEPHERD_DOC_AGENT=1`, `SHEPHERD_PASSWORD=…`, etc. — are
+// inherited by the spawned agent's env and leak into that snapshot, flipping config away from the
+// defaults the suite assumes. Concretely, `spawnSettingsOverlay()` starts emitting a `hooks` blob
+// and 8 spawn/resume snapshot tests fail. CI stays green only because it happens to run with none
+// of these set — so the failure is invisible until you run the suite (or `git push`, via the
+// pre-push hook's test lane) from inside Shepherd.
+//
+// Fix the class, not the instances: strip the operator's entire ambient Shepherd config so every
+// `bun test` invocation sees CI-equivalent defaults regardless of who launched it. Any FUTURE
+// feature flag is neutralised automatically — no per-flag maintenance. We keep only the short
+// allowlist of resource/harness vars that tests and the pre-push lane deliberately provide;
+// deleting those would be actively harmful (e.g. `SHEPHERD_DB` unset falls back to the real
+// `~/.shepherd/shepherd.db`, and the pre-push lane sets `SHEPHERD_REPO_ROOT` to a temp dir for
+// repo-discovery isolation).
+const KEEP = new Set([
+  "SHEPHERD_DB", // resource path — never let tests fall back to the real user DB
+  "SHEPHERD_FORGES", // resource path (derived from the DB dir)
+  "SHEPHERD_PLUGINS_DIR", // resource path (derived from the DB dir)
+  "SHEPHERD_REPO_ROOT", // pre-push lane sets a temp root for repo-discovery isolation
+  "SHEPHERD_TMP_SWEEP_DIR", // scratchpad*.test.ts set + restore this per-test
+  "SHEPHERD_PROFILE_LOOP", // instrument.test.ts sets + restores this
+  "SHEPHERD_NODE_COMPILE_CACHE", // herdr.test.ts sets this sentinel
+  "SHEPHERD_PREPUSH_LANES", // consumed by scripts/pre-push.ts
+  "SHEPHERD_PREPUSH_LANE_TIMEOUT_MS", // consumed by scripts/pre-push.ts
+]);
+
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith("SHEPHERD_") && !KEEP.has(key)) delete process.env[key];
+}


### PR DESCRIPTION
## Problem

`config` (src/config.ts) is a single object literal that snapshots ~100 `SHEPHERD_*` env vars **at import** and never re-reads them. Running `bun test` — or `git push` via the pre-push test lane — **inside a live Shepherd session** (dogfooding) inherits the operator's runtime toggles (`SHEPHERD_HOOKS_INGEST=1`, `SHEPHERD_DOC_AGENT=1`, `SHEPHERD_PASSWORD=…`, …) into that snapshot, flipping config away from the defaults the suite assumes.

Concretely, `spawnSettingsOverlay()` starts emitting a `hooks` blob and **8 spawn/resume snapshot tests fail** (`test/service.test.ts`). CI stays green only because it happens to run with none of these set — so the failure is invisible until you run the suite from inside Shepherd, and it blocks pushes there.

This is a latent landmine, not just 8 tests: every default-off feature flag and operator preference is a trap for whichever tests assume its default.

## Fix

Add a Bun test preload (`bunfig.toml` → `[test] preload`) that strips **all** `SHEPHERD_*` from `process.env` before `config` loads, keeping a short allowlist of the resource/harness vars tests and the pre-push lane deliberately provide (`SHEPHERD_DB`, `SHEPHERD_REPO_ROOT`, `SHEPHERD_TMP_SWEEP_DIR`, …).

Fixes the **class**: any future flag is neutralised automatically — no per-flag maintenance.

## Verification

- Full root suite **inside a Shepherd session** (with `SHEPHERD_HOOKS_INGEST=1` set): was **8 fail** → now **6359 pass / 0 fail**.
- `git push` from inside a session now passes the pre-push `root-tests` lane **without** any manual env scrubbing (previously required `env -u SHEPHERD_HOOKS_INGEST …`).
- `bun run lint` clean; `prettier --check .` clean (bunfig.toml is skipped under the glob, matching CI).

No production code changed; no user-facing surface. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)