### PR TITLE
fix(diagnostics): self-heal false herdr "offline" verdict

### DIFF
--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -88,6 +88,30 @@ if command -v systemctl >/dev/null 2>&1 && systemctl --user show-environment >/d
   systemctl --user daemon-reload
   systemctl --user enable --now shepherd-logrotate.timer
 
+  # ── sync the core shepherd.service unit ──────────────────────────────────────
+  # Same self-heal rationale as the timers + herdr unit: provision.ts installs shepherd.service
+  # only on a FRESH box, so an already-provisioned host never picks up later changes to the unit
+  # — most consequentially the `After=herdr.service` ordering. Without it, at boot Shepherd can
+  # start BEFORE the sibling herdr daemon, and the diagnostics probe (4s after Shepherd boot,
+  # src/index.ts) races herdr's startup and latches a false `herdr: offline`.
+  #
+  # TEMPLATED like the backup service above (templateUnit in provision.ts): rewrite only the
+  # WorkingDirectory line to THIS checkout so a custom SHEPHERD_DIR install runs against the right
+  # dir. Write only when the rendered unit differs (`cmp -s`, which also treats a missing installed
+  # unit as changed) so a byte-identical unit skips even a redundant daemon-reload. No restart in
+  # this block: the `systemctl --user restart shepherd` below applies the reloaded unit, and the
+  # `After=` ordering only takes effect at the next boot anyway.
+  SHEP_UNIT_TMP="$(mktemp)"
+  sed "s|^WorkingDirectory=.*|WorkingDirectory=${REPO}|" \
+    "$REPO/deploy/shepherd.service" >"$SHEP_UNIT_TMP"
+  if ! cmp -s "$SHEP_UNIT_TMP" "$UNIT_DIR/shepherd.service"; then
+    note "syncing shepherd.service unit"
+    mv "$SHEP_UNIT_TMP" "$UNIT_DIR/shepherd.service"
+    systemctl --user daemon-reload
+  else
+    rm -f "$SHEP_UNIT_TMP"
+  fi
+
   # ── sync the herdr daemon unit (#1574) ───────────────────────────────────────
   # Same self-heal rationale as the timers above: provision.ts installs herdr.service only on a
   # FRESH box, so without this every already-provisioned host would keep running an unsupervised

--- a/src/config.ts
+++ b/src/config.ts
@@ -78,6 +78,16 @@ export const HERDR_SOCKET_SUPPORTED_PROTOCOLS = new Set([16]);
 // TTL backing DiagnosticsService.current() — a request without ?refresh=1 reads
 // this cache. Matches the existing CountsService/backlog 60s TTL.
 export const DIAGNOSTICS_TTL_MS = 60_000;
+// Background diagnostics re-check cadence (src/index.ts). ADAPTIVE: the steady-state
+// interval is used while the last snapshot's `overall` is ok/warning; on an `error`
+// snapshot the scheduler switches to the much shorter recheck interval so a transient
+// hard error (canonically herdr `offline`) self-corrects within ~one recheck instead of
+// staying pinned on the client — which seeds diagnostics once and thereafter only takes
+// the `diagnostics:status` push (never re-GETs). Only `error` accelerates: a `warning`
+// is steady-state by design (advisory version floors, gh-not-required on lightweight
+// hosts) and must NOT drive a permanent fast poll.
+export const DIAGNOSTICS_INTERVAL_MS = 6 * 60 * 60 * 1000;
+export const DIAGNOSTICS_RECHECK_INTERVAL_MS = 60_000;
 // Per-probe exec timeout: a timed-out probe RESOLVES to its defined non-OK state
 // (never rejects the Promise.all), so one hung binary can't stall the batch.
 export const DIAGNOSTICS_PROBE_TIMEOUT_MS = 5_000;

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -125,6 +125,25 @@ function worstOf(checks: DiagnosticCheck[]): DiagnosticState {
   return worst;
 }
 
+/**
+ * Adaptive delay until the next background diagnostics re-check, chosen from the snapshot
+ * just produced. ONLY an `error` accelerates to `recheckMs`: a hard error (canonically
+ * herdr `offline`) is expected to be transient/recoverable, and the client only learns it
+ * cleared from the next `diagnostics:status` push — so re-checking every `recheckMs` while
+ * `error` persists lets a healthy-again host self-correct within ~one recheck instead of
+ * staying pinned until the next `intervalMs`. `warning` deliberately stays on `intervalMs`:
+ * it is steady-state by design (advisory version floors, gh-not-required on lightweight
+ * hosts, `worstOf` never surfaces `optional` — it ranks 0, same as `ok`), so accelerating on
+ * it would fast-poll forever with no path back to the steady cadence.
+ */
+export function nextDiagnosticsDelay(
+  overall: DiagnosticState,
+  intervalMs: number,
+  recheckMs: number,
+): number {
+  return overall === "error" ? recheckMs : intervalMs;
+}
+
 /** Cap on drained child output: just enough to keep a noisy `curl | bash` install
  *  from blocking on a full pipe, then dropped. NEVER surfaced to the client. */
 const REMEDIATION_DRAIN_CAP = 1 << 20; // 1 MiB

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ import {
   PR_REVIEW_CYCLES_MAX,
   PLAN_REVIEW_CYCLES_MIN,
   PLAN_REVIEW_CYCLES_MAX,
+  DIAGNOSTICS_INTERVAL_MS,
+  DIAGNOSTICS_RECHECK_INTERVAL_MS,
   parseServedPort,
   validatePreviewPortRange,
   validateAgentIngressPort,
@@ -60,7 +62,7 @@ import { HerdrUpdateService } from "./herdr-update";
 import { CodexUpdateService } from "./codex-update";
 import { PluginUpdateService } from "./plugin-update";
 import { RestartService } from "./restart";
-import { DiagnosticsService } from "./diagnostics";
+import { DiagnosticsService, nextDiagnosticsDelay } from "./diagnostics";
 import { TelemetryService } from "./telemetry";
 import { normalizeTelemetryConsent } from "./telemetry-consent";
 import { wirePrOpenedTelemetry } from "./pr-opened-telemetry";
@@ -2260,10 +2262,33 @@ const diagnostics = new DiagnosticsService({
   anyLightweightRepo: () =>
     listRepos(config.repoRoot).some((r) => store.getRepoConfig(r.path).repoMode === "lightweight"),
 });
-const checkDiagnostics = async () =>
-  events.emit("diagnostics:status", await diagnostics.check(Date.now()));
-setTimeout(timerTask("diagnostics", checkDiagnostics), 4_000);
-setInterval(timerTask("diagnostics", checkDiagnostics), 6 * 60 * 60 * 1000);
+// Adaptive background re-check (NOT a fixed setInterval): each tick probes, pushes the
+// snapshot, then re-arms itself with a delay chosen from that snapshot — 60s while the
+// verdict is a hard `error` (so a transient herdr `offline` self-corrects within ~one
+// recheck instead of staying pinned on the client, which only takes the push), else the
+// 6h steady cadence. Bespoke wiring, not `timerTask`: that helper is fire-and-forget and
+// discards the snapshot the delay depends on. CRITICAL: the next tick is armed in `finally`
+// (on settle), never only on the success path — a thrown `check()` must not kill the loop
+// and freeze diagnostics until restart. `check()` is designed never to reject (each probe
+// resolves to its non-ok state), so the catch is defensive; on the off chance it throws we
+// re-arm at the recheck cadence to retry soon rather than wait 6h.
+const diagnosticsTick = async (): Promise<void> => {
+  let delay = DIAGNOSTICS_RECHECK_INTERVAL_MS;
+  try {
+    const snapshot = await diagnostics.check(Date.now());
+    events.emit("diagnostics:status", snapshot);
+    delay = nextDiagnosticsDelay(
+      snapshot.overall,
+      DIAGNOSTICS_INTERVAL_MS,
+      DIAGNOSTICS_RECHECK_INTERVAL_MS,
+    );
+  } catch (err) {
+    console.warn("[diagnostics] tick failed:", err);
+  } finally {
+    setTimeout(() => void diagnosticsTick(), delay);
+  }
+};
+setTimeout(() => void diagnosticsTick(), 4_000);
 
 // forge resolution: detect a repo's GitHub/Gitea host from its `origin` remote.
 // Per-host config (tokens, gitea base URLs) loads from config.forges (SHEPHERD_FORGES);

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -2,9 +2,16 @@ import { describe, expect, it, spyOn } from "bun:test";
 import {
   DiagnosticsService,
   defaultRunRemediation,
+  nextDiagnosticsDelay,
   type DiagnosticsDeps,
 } from "../src/diagnostics";
-import { DIAGNOSTICS_TTL_MS, GH_PROBE_ATTEMPTS } from "../src/config";
+import {
+  DIAGNOSTICS_TTL_MS,
+  DIAGNOSTICS_INTERVAL_MS,
+  DIAGNOSTICS_RECHECK_INTERVAL_MS,
+  GH_PROBE_ATTEMPTS,
+} from "../src/config";
+import type { DiagnosticState } from "../src/types";
 import { REMEDIATIONS } from "../src/remediations";
 import type { DiagnosticCheck } from "../src/types";
 import { SessionStore } from "../src/store";
@@ -917,5 +924,44 @@ describe("DiagnosticsService gh probe — real anyForgeRepo closure (bare repo d
     expect(c.state).toBe("warning");
     expect(c.hintKey).toBe("diagnostics_hint_gh_not_required");
     assertPure(c);
+  });
+});
+
+// ── adaptive background re-check cadence (nextDiagnosticsDelay) ──────────────────
+// The scheduler in src/index.ts re-arms itself with this delay after every snapshot.
+// ONLY an `error` accelerates to the recheck interval so a transient hard error (herdr
+// `offline`) self-corrects fast; `warning` must stay on the steady interval or a
+// persistent-by-design warning (advisory version floors, gh-not-required) would fast-poll
+// forever. The input domain is exactly {ok, warning, error}: `overall` is worstOf(checks),
+// and worstOf ranks `optional` at 0 (== ok) upgrading only on a strict increase, so it can
+// never surface `optional` — hence it is intentionally not part of the cases below.
+describe("nextDiagnosticsDelay", () => {
+  const cases: Array<[DiagnosticState, number]> = [
+    ["error", DIAGNOSTICS_RECHECK_INTERVAL_MS],
+    ["warning", DIAGNOSTICS_INTERVAL_MS],
+    ["ok", DIAGNOSTICS_INTERVAL_MS],
+  ];
+  for (const [overall, expected] of cases) {
+    it(`overall=${overall} → ${expected === DIAGNOSTICS_RECHECK_INTERVAL_MS ? "recheck" : "steady"} interval`, () => {
+      expect(
+        nextDiagnosticsDelay(overall, DIAGNOSTICS_INTERVAL_MS, DIAGNOSTICS_RECHECK_INTERVAL_MS),
+      ).toBe(expected);
+    });
+  }
+
+  it("only error accelerates: warning/ok are ≥ error's delay (no permanent fast poll)", () => {
+    const err = nextDiagnosticsDelay(
+      "error",
+      DIAGNOSTICS_INTERVAL_MS,
+      DIAGNOSTICS_RECHECK_INTERVAL_MS,
+    );
+    const warn = nextDiagnosticsDelay(
+      "warning",
+      DIAGNOSTICS_INTERVAL_MS,
+      DIAGNOSTICS_RECHECK_INTERVAL_MS,
+    );
+    const ok = nextDiagnosticsDelay("ok", DIAGNOSTICS_INTERVAL_MS, DIAGNOSTICS_RECHECK_INTERVAL_MS);
+    expect(err).toBeLessThan(warn);
+    expect(warn).toBe(ok);
   });
 });

--- a/test/update-sh-macos.test.ts
+++ b/test/update-sh-macos.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "bun:test";
 import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 
 // deploy/update.sh runs under `set -e`. On macOS / core-only there is no systemd
 // user manager, so a bare `systemctl --user restart` aborts the whole deploy after
@@ -16,4 +17,41 @@ test("update.sh gates the restart on a systemctl-presence probe with a manual-st
   expect(src).toContain("command -v systemctl");
   expect(src).toMatch(/no systemd user manager[\s\S]*not restarting/);
   expect(src).toContain("bun run start");
+});
+
+// provision.ts installs shepherd.service only on a fresh box, so an existing host would never
+// pick up later unit changes — most consequentially the `After=herdr.service` boot-ordering that
+// keeps the diagnostics probe from racing herdr's startup. update.sh must self-heal it, mirroring
+// its herdr.service / timer syncs. Presence assertions (the existing text-grep pattern):
+test("update.sh self-heals shepherd.service into the user unit dir with WorkingDirectory templated", () => {
+  // writes the rendered unit to the user unit dir
+  expect(src).toMatch(/"\$UNIT_DIR\/shepherd\.service"/);
+  // templates WorkingDirectory to the checkout via the same rewrite templateUnit uses
+  expect(src).toMatch(/s\|\^WorkingDirectory=\.\*\|WorkingDirectory=\$\{REPO\}\|/);
+  // reloads so the restart below picks up the new unit
+  expect(src).toContain("systemctl --user daemon-reload");
+});
+
+// Behavioral, not just grep: run the SAME WorkingDirectory rewrite update.sh uses against the
+// real deploy/shepherd.service and assert the rendered unit is well-formed — a malformed sed that
+// dropped the ordering or mangled WorkingDirectory would pass a text-grep but fail here.
+// Coverage limit: this replicates the sed expression rather than extracting it from update.sh; the
+// grep assertion above (that the script uses this exact ^WorkingDirectory= rewrite) is the bridge.
+test("the shepherd.service WorkingDirectory rewrite renders a well-formed, correctly-ordered unit", () => {
+  const unitPath = new URL("../deploy/shepherd.service", import.meta.url).pathname;
+  const repo = "/tmp/some/checkout";
+  const rendered = spawnSync(
+    "sed",
+    [`s|^WorkingDirectory=.*|WorkingDirectory=${repo}|`, unitPath],
+    {
+      encoding: "utf8",
+    },
+  );
+  expect(rendered.status).toBe(0);
+  const out = rendered.stdout;
+  // WorkingDirectory rewritten to the given checkout, exactly once
+  expect(out.match(/^WorkingDirectory=.*$/gm)).toEqual([`WorkingDirectory=${repo}`]);
+  // boot ordering + Wants intact — this is the whole point of syncing the unit
+  expect(out).toMatch(/^After=network-online\.target herdr\.service$/m);
+  expect(out).toMatch(/^Wants=herdr\.service$/m);
 });


### PR DESCRIPTION
## Problem

A **healthy** herdr server was diagnosed `offline` and stayed that way for hours (the persistent "Problem" card with a **Fix** button), even though `herdr status server` → running and `herdr agent list` exits 0.

## Root cause — a trigger and an amplifier

- **Amplifier (the reason it's visible for hours):** the pushed `diagnostics:status` verdict only re-ran on a **6-hour interval** (`src/index.ts`), and the client seed-fetches diagnostics once (`+page.svelte`) then updates **only** from that push (`store.svelte.ts`) — no periodic re-GET. So **any** transient hard `error` (herdr `offline`, a forge host's failed `gh auth`) stays pinned for up to 6h. herdr goes transiently offline on more than boot: its own `Restart=always` bounce, and the #1578 `update --handoff` socket bounce.
- **Trigger (boot race):** the *installed* `~/.config/systemd/user/shepherd.service` was missing `After=herdr.service` (only `After=network-online.target`), so at boot Shepherd started ~7s before herdr; the diagnostics probe (4s after Shepherd boot) raced herdr's startup and latched `offline`. The repo's `deploy/shepherd.service` already carries the ordering fix, but `update.sh` self-heals the timers + `herdr.service` (#1574) and **never re-synced `shepherd.service`** — so existing hosts kept the pre-fix unit.

## Fix (two complementary parts)

**A — adaptive re-check (fixes the amplifier at its source).** Replace the fixed 6h `setInterval` with a self-rescheduling tick: `60s` while `overall === "error"`, else the `6h` steady cadence, so a transient error self-corrects within ~60s of recovery.
- Keys on **`error` only** — a `warning` is steady-state by design (advisory version floors, gh-not-required on lightweight hosts), so fast-polling it would never revert to 6h.
- Bespoke wiring (not `timerTask`, which discards the snapshot): the next tick is armed in `finally`, so a thrown `check()` can't kill the loop and freeze diagnostics.
- `DiagnosticsService.check()/current()/fix()` untouched; the policy is a pure, unit-tested `nextDiagnosticsDelay` helper.

**B — trigger reduction.** `update.sh` now self-heals `shepherd.service` (WorkingDirectory templated, `cmp -s`-gated) exactly like it already does for `herdr.service` + the timers, so the `After=herdr.service` ordering reaches already-provisioned hosts on the next `bun run update`. (`Type=simple` means this orders behind herdr's fork, not its socket-ready state — a probability reduction; Part A is the recovery guarantee.)

## Testing

- `nextDiagnosticsDelay` over its full input domain `{ok, warning, error}` (with a note on why `overall` is never `optional`).
- `update.sh`: presence assertions + a **behavioral** test that runs the real `sed` rewrite against `deploy/shepherd.service` and asserts a well-formed unit with `After=/Wants=herdr.service` intact (catches a malformed rewrite a grep would miss).
- Full root suite (`bun test ./test`), `bun run lint`, `bun run typecheck` — all green.

## Residual (honest)

Recovery is invisible for at most one 60s tick; no fixed-attempt exhaustion window. Warnings intentionally stay on the 6h cadence. A genuinely dead herdr correctly keeps showing `offline` (re-checked each 60s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)