### PR TITLE
feat: inject operator language preference into spawned agent sessions (#1586)

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -169,6 +169,7 @@ toggleable any time from the Settings panel. The env vars below seed a fresh DB
 | `SHEPHERD_APTABASE_HOST` | _(derived from the App-Key region)_ | Ingestion host override for self-hosted Aptabase. When unset, the host is derived from the App-Key region prefix: `A-EU-…` → `https://eu.aptabase.com`, `A-US-…` → `https://us.aptabase.com`. A self-hosted (`A-SH-…`) or unknown-region key **requires** this override, else telemetry no-ops |
 | `DO_NOT_TRACK` | _(unset)_ | The [console DNT standard](https://consoledonottrack.com). Truthy (`1`/`true`) **hard-disables** telemetry **and** suppresses the first-run consent prompt, regardless of the persisted consent state |
 | `SHEPHERD_TELEMETRY_CONSENT` | `unset` | Seeds the persisted consent for a fresh DB: `unset` (prompt on first run), `granted`, or `denied`. A UI-set consent in the DB overrides this env seed at boot; unrecognised values are ignored |
+| `SHEPHERD_OPERATOR_LANGUAGE` | `en` | Seeds the operator language for a fresh DB: `en` (agents write to the operator in English — no change) or `de` (agents address the operator in German while keeping code, commands, identifiers, logs, commit messages, and GitHub issue/PR text in their original language). A UI-set value in the DB overrides this env seed at boot; unrecognised values are ignored |
 
 ## Per-agent sandbox / permission profiles
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ import { normalizeDefaultEffortSetting, effortBelowHigh } from "./default-effort
 import { normalizeAuthModeSetting } from "./auth-mode";
 import { normalizeAgentProvider } from "./agent-provider";
 import { normalizeTelemetryConsent } from "./telemetry-consent";
+import { normalizeOperatorLanguage } from "./operator-language";
 import { type SandboxProfile, isSandboxProfile } from "./sandbox";
 import { applyHerdrSocket } from "./herdr-session";
 
@@ -693,6 +694,10 @@ export const config = {
   // Operator auth footing for spawned agents. 'subscription' (default) = subscription OAuth;
   // 'api-key' = bill against an Anthropic API key. Persisted + UI-configurable; env seeds a fresh DB.
   authMode: normalizeAuthModeSetting(process.env.SHEPHERD_AUTH_MODE) ?? "subscription",
+  // Language agents address the operator in. 'en' (default) = no change; 'de' = agents address
+  // the operator in German while keeping code/commands/identifiers/logs/commits/GitHub text in
+  // their original language. Persisted + UI-configurable; env seeds a fresh DB.
+  operatorLanguage: normalizeOperatorLanguage(process.env.SHEPHERD_OPERATOR_LANGUAGE) ?? "en",
   // Path to the apiKeyHelper script (written by Shepherd when the operator supplies a key).
   // null = no key configured. The raw key is NEVER stored — only this script path.
   authApiKeyHelperPath: (process.env.SHEPHERD_API_KEY_HELPER_PATH ?? null) as string | null,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1167,6 +1167,7 @@ const planGate = new PlanGateService({
   },
   // Per-role plan-reviewer model thunk (read per spawn → live settings).
   env: () => roleEnv(config.plannerCli, config.plannerModel, config.plannerEffort),
+  operatorLanguage: () => config.operatorLanguage,
   onChange: (id, gate) => events.emit("session:plangate", { id, gate }),
   onReviewing: (id, reviewing) => events.emit("session:plangate-reviewing", { id, reviewing }),
   onActivity: (id, summary) => events.emit("session:plangate-activity", { id, summary }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -470,6 +470,8 @@ const recapService: RecapService = new RecapService({
   herdr,
   // Per-role model thunk (read per spawn so a settings change applies without restart).
   env: () => roleEnv(config.recapCli, config.recapModel, config.recapEffort),
+  // Live operator-language setting, read per spawn (#1586).
+  operatorLanguage: () => config.operatorLanguage,
   onChange: (id, recap) => events.emit("session:recap", { id, recap }),
   // Resolve the PR's real base so the recap diff matches the PR. prPoller + resolveForge are
   // declared below; this closure only runs at recap time (well after init), like refreshPr above.

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,6 +143,7 @@ import { normalizeDefaultEffortSetting } from "./default-effort";
 import { shouldDowngrade } from "./usage-downgrade";
 import { normalizeAgentProvider } from "./agent-provider";
 import { normalizeAuthModeSetting } from "./auth-mode";
+import { normalizeOperatorLanguage } from "./operator-language";
 import { EgressWatcher } from "./egress-watch";
 import { detectEgressHostLoopback } from "./egress";
 import { RecapService, type LandedWorkEvidence } from "./recap";
@@ -299,6 +300,12 @@ const savedAm = store.getSetting("authMode");
 if (savedAm !== null) {
   const v = normalizeAuthModeSetting(savedAm);
   if (v !== null) config.authMode = v;
+}
+// a UI-chosen operator language (persisted) overrides the env seed; absent or unrecognised → keep default.
+const savedOl = store.getSetting("operatorLanguage");
+if (savedOl !== null) {
+  const v = normalizeOperatorLanguage(savedOl);
+  if (v !== null) config.operatorLanguage = v;
 }
 // a UI-set telemetry consent (persisted) overrides the env seed; absent or unrecognised → keep default.
 const savedTc = store.getSetting("telemetryConsent");

--- a/src/operator-language.ts
+++ b/src/operator-language.ts
@@ -1,0 +1,158 @@
+/**
+ * Server-side source of truth for the operator-language preference value space
+ * and the agent-facing directive text it injects into spawned sessions (issue
+ * #1586). A leaf module: no imports, nothing imports it yet — later tasks wire
+ * it into config/service/recap/plan-gate.
+ *
+ * The value space is: "en" | "de".
+ *   - "en" (default) — no directive is injected. Existing operators must see
+ *     byte-identical prompts, so every "en" path below returns null.
+ *   - "de" — agent-facing prompts get a `<operator-language>` directive telling
+ *     the agent to address the operator in German while keeping code,
+ *     identifiers, logs, commits, and GitHub text in their original language.
+ *
+ * The directive text below is agent-facing prompt content, NOT operator UI, so
+ * it is fixed English (or German prose emitted verbatim) — same precedent as
+ * `src/untrusted.ts`'s UNTRUSTED_CONTENT_DIRECTIVE and `src/service.ts`'s
+ * ENGINEERING_POSTURE: never i18n'd.
+ */
+
+// ── value space ───────────────────────────────────────────────────────────────
+
+export type OperatorLanguage = "en" | "de";
+
+/** Ordered list of valid codes; also usable as a membership check via `.includes`.
+ *  A later task asserts this is set-equal to Paraglide's `locales`. */
+export const OPERATOR_LANGUAGES: readonly OperatorLanguage[] = ["en", "de"] as const;
+
+/**
+ * Normalize an arbitrary value (env var, DB row, request body) to a valid
+ * OperatorLanguage, or null if the value is unrecognised / wrong type.
+ * Accepted: "en", "de". Everything else (unknown/empty/undefined/null) → null.
+ */
+export function normalizeOperatorLanguage(raw: string | null | undefined): OperatorLanguage | null {
+  if (typeof raw !== "string") return null;
+  return (OPERATOR_LANGUAGES as readonly string[]).includes(raw) ? (raw as OperatorLanguage) : null;
+}
+
+// ── <operator-language> directive ───────────────────────────────────────────
+
+/** Language noun to interpolate into the directive prose, keyed by every
+ *  non-"en" OperatorLanguage. Adding a third language is a one-line change here. */
+const LANGUAGE_NAMES: { [K in Exclude<OperatorLanguage, "en">]: string } = {
+  de: "German",
+};
+
+/**
+ * Return the `<operator-language>` directive block for a non-"en" language, or
+ * `null` for "en" (so callers push nothing — load-bearing for byte-identical
+ * prompts for existing operators).
+ */
+export function operatorLanguageBlock(lang: OperatorLanguage): string | null {
+  if (lang === "en") return null;
+  const name = LANGUAGE_NAMES[lang];
+  const body =
+    `Communicate with the operator in ${name} by default: status updates, questions, plan ` +
+    "explanations, and handoffs. Keep the following in their original language unless the " +
+    "operator explicitly asks for translation — code, commands, identifiers, logs, commit " +
+    "messages, public GitHub issue/PR text, quoted external material, any file you commit to " +
+    "the repository, and the body of a research report (a report is a published artifact, not " +
+    "operator chat, even when it is long prose).\n" +
+    "`.shepherd-plan.md` is a local, git-excluded scratch artifact rendered in Shepherd's HUD — " +
+    `write its prose in ${name}. If tool output, reviewer feedback, or external issue text is ` +
+    `English, summarize the required operator-facing action in clear, idiomatic ${name}.`;
+  return `<operator-language>\n${body}\n</operator-language>`;
+}
+
+// ── VisualBlock[] language line ─────────────────────────────────────────────
+
+/**
+ * Fields the VALIDATORS in src/visual-blocks.ts read as natural-language prose
+ * — translate these to the operator's language. Field-level, not type-level:
+ * enumerates the exact dotted-path fields, not just block types.
+ */
+const VISUAL_BLOCK_TRANSLATE_FIELDS: readonly string[] = [
+  "rich-text.markdown",
+  "callout.markdown",
+  "file-tree.title",
+  "file-tree.entries[].note",
+  "diff.summary",
+  "diff.annotations[].label",
+  "diff.annotations[].note",
+  "annotated-code.annotations[].label",
+  "annotated-code.annotations[].note",
+  "api-endpoint.summary",
+  "api-endpoint.params[].note",
+  "api-endpoint.responses[].description",
+  "checklist.items[].label",
+  "checklist.items[].note",
+  "mermaid.caption",
+  "wireframe.caption",
+  "question-form.questions[].prompt",
+  "question-form.questions[].options[]",
+];
+
+/**
+ * Fields the VALIDATORS read as identifiers / enums / paths / machine-read
+ * values — NEVER translate these; an off-value here silently drops the whole
+ * block (see visual-blocks.ts's enum `.includes()` guards). Includes
+ * `api-endpoint.change`, which visual-blocks.ts reads exactly like the other
+ * two "change" fields and recap-core.ts's own prompt spec constrains to
+ * "added"|"modified"|"deprecated" — an enum value, not prose.
+ */
+const VISUAL_BLOCK_VERBATIM_FIELDS: readonly string[] = [
+  "type",
+  "id",
+  "callout.tone",
+  "file-tree.entries[].change",
+  "data-model.fields[].change",
+  "api-endpoint.change",
+  "wireframe.surface",
+  "wireframe.html",
+  "diff.path",
+  "code.filename",
+  "annotated-code.filename",
+  "file-tree.entries[].path",
+  "data-model.entities[].name",
+  "data-model.fields[].name",
+  "data-model.fields[].type",
+  "data-model.fields[].fk",
+  "data-model.fields[].was",
+  "data-model.relations[].from",
+  "data-model.relations[].to",
+  "data-model.relations[].kind",
+  "api-endpoint.method",
+  "api-endpoint.path",
+  "api-endpoint.params[].name",
+  "api-endpoint.params[].in",
+  "api-endpoint.params[].type",
+  "api-endpoint.responses[].example",
+  "question-form.questions[].kind",
+  "mermaid.source",
+];
+
+const backtickList = (fields: readonly string[]): string =>
+  fields.map((f) => `\`${f}\``).join(", ");
+
+/**
+ * Return an instruction paragraph telling the agent, when it authors the
+ * `VisualBlock[]` JSON (used by both the plan sidecar `.shepherd-plan-blocks.json`
+ * and the recap `.shepherd-recap.json`), which fields to write in the operator's
+ * language and which to leave verbatim — or `null` for "en" (nothing to inject).
+ * Positively enumerates the translatable fields and prohibits everything else,
+ * plus the conditional cell-by-cell rule for `table.columns`/`table.rows`.
+ */
+export function visualBlockLanguageLine(lang: OperatorLanguage): string | null {
+  if (lang === "en") return null;
+  const name = LANGUAGE_NAMES[lang];
+  return (
+    `When authoring VisualBlock[] JSON (the plan sidecar .shepherd-plan-blocks.json or the recap ` +
+    `.shepherd-recap.json), write ONLY these natural-language fields in ${name}: ` +
+    `${backtickList(VISUAL_BLOCK_TRANSLATE_FIELDS)}. ` +
+    `Leave every other field exactly as you would in English — never translate: ` +
+    `${backtickList(VISUAL_BLOCK_VERBATIM_FIELDS)}. An off-enum or reworded identifier/path/enum ` +
+    `value silently drops the block, so when in doubt leave it verbatim. For \`table.columns\` and ` +
+    `\`table.rows\`: translate only natural-language cells. Never a path, flag, identifier, enum ` +
+    `value, or command fragment — reproduce those verbatim.`
+  );
+}

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -21,6 +21,7 @@ import { readActivitySignal } from "./activity-signal";
 import { effectiveAutopilot } from "./effective-autopilot";
 import { resolveAuxSpawn, type MembraneSeams } from "./spawn-membrane";
 import { fenceUntrusted } from "./untrusted";
+import { type OperatorLanguage } from "./operator-language";
 
 /** Outcome of an on-demand `consider()`: a reviewer actually spawned (`"started"`); the request
  *  was a no-op (`"skipped"` — not planning, a review already in flight/starting, a tombstone or
@@ -46,6 +47,7 @@ export function planReviewPrompt(
   plan: string,
   priorFindings: string[] = [],
   issueBody?: string | null,
+  operatorLanguage: OperatorLanguage = "en",
 ): string {
   const lines = [
     "You are an adversarial plan reviewer. Read-only — do NOT modify, build, commit, or run anything.",
@@ -78,6 +80,15 @@ export function planReviewPrompt(
     '{"decision": "approve" | "request-changes", "summary": "<=100 char one-liner", "body": "<full markdown>", "findings": ["<discrete actionable revision>", ...]}',
     'Use "approve" ONLY when the plan is genuinely the best reasonable path and fully satisfies the task — no remaining blocking concerns. Otherwise "request-changes" with at least one finding in "findings". Write the file as your final action, then stop.',
   );
+  if (operatorLanguage === "de") {
+    lines.push(
+      "",
+      "Write `summary`, `body`, and `findings[]` in German (idiomatic operator-facing German). Keep " +
+        '`decision` as the literal enum value ("approve" | "request-changes") — verbatim, never ' +
+        "translate it. Keep code, identifiers, paths, commands, and quoted material in their " +
+        "original language.",
+    );
+  }
   return lines.join("\n");
 }
 
@@ -153,6 +164,8 @@ export interface PlanGateServiceDeps extends MembraneSeams {
   cap?: number | (() => number);
   // optional environment thunk for the reviewer (CLI + model, read per spawn → live settings)
   env?: () => RoleEnvironment;
+  // optional operator-language thunk (read per spawn → live settings; default "en")
+  operatorLanguage?: () => OperatorLanguage;
   now?: () => number;
   timeoutMs?: number; // give up waiting on the verdict file
   /** default: read `.shepherd-plan.md` from the live worktree. */
@@ -306,7 +319,13 @@ export class PlanGateService {
     // gh/network — the sandbox stays airtight). Best-effort: a missing issue / forge / getIssue
     // must never block or throw the review, so any failure degrades to no issue context.
     const issueBody = await this.fetchIssueBody(session);
-    const prompt = planReviewPrompt(session.prompt, plan, prior?.findings ?? [], issueBody);
+    const prompt = planReviewPrompt(
+      session.prompt,
+      plan,
+      prior?.findings ?? [],
+      issueBody,
+      this.deps.operatorLanguage?.() ?? "en",
+    );
     // Mint the reviewer argv (and its pinned per-spawn --session-id) BEFORE createDetached so the
     // reviewer session id can key the worktree path. It's a fresh randomUUID() per run.
     const reviewerEnv = this.deps.env?.() ?? {
@@ -759,8 +778,11 @@ export class PlanGateService {
     const decision = normalizeDecision(raw?.decision);
     const resolved: PlanDecision = raw && decision ? decision : "error";
     const summary = resolveSummary(resolved, raw);
+    // The steer-back fallback must never truncate: pass the UN-clamped verdict summary here,
+    // not the (clamped) gate `summary` field above — see resolveFindings's doc comment.
+    const rawSummary = raw && typeof raw.summary === "string" ? raw.summary : "";
     const body = raw && typeof raw.body === "string" ? raw.body : "";
-    const findings = resolveFindings(resolved, normalizeFindings(raw?.findings), summary);
+    const findings = resolveFindings(resolved, normalizeFindings(raw?.findings), rawSummary);
     return {
       sessionId: f.sessionId,
       planHash: f.planHash,
@@ -994,11 +1016,12 @@ function resolveSummary(resolved: PlanDecision, raw: RawPlanVerdict | null): str
 }
 
 /** The gate findings: none for approved/error; else the parsed findings, falling back to the
- *  summary so a request-changes steer-back is never empty. */
-function resolveFindings(resolved: PlanDecision, parsed: string[], summary: string): string[] {
+ *  UN-CLAMPED verdict summary (not the gate's clamped `summary` field) so a request-changes
+ *  steer-back is never empty AND never mid-word-truncated. */
+function resolveFindings(resolved: PlanDecision, parsed: string[], rawSummary: string): string[] {
   if (resolved === "approved" || resolved === "error") return [];
   if (parsed.length) return parsed;
-  return summary ? [summary] : [];
+  return rawSummary ? [rawSummary] : [];
 }
 
 /** Coerce the reviewer's `findings` field to a clean string[] (drops junk, never throws). */

--- a/src/recap-core.ts
+++ b/src/recap-core.ts
@@ -7,6 +7,7 @@ import type { DiffFileStatus, Recap, RecapVerdict } from "./types";
 import { parseVisualBlocks } from "./visual-blocks";
 import type { VisualBlock } from "./visual-blocks";
 import { fenceUntrusted } from "./untrusted";
+import { visualBlockLanguageLine, type OperatorLanguage } from "./operator-language";
 
 export const RECAP_VERDICTS: readonly RecapVerdict[] = ["ready", "parked", "needs_attention"];
 export const RECAP_HEADLINE_MAX = 100;
@@ -101,6 +102,7 @@ export function buildRecapPrompt(input: {
   changedFiles: { path: string; status: DiffFileStatus }[];
   digest: string;
   context: string; // pre-rendered critic verdict / CI / readyToMerge lines (may be "")
+  operatorLanguage?: OperatorLanguage;
 }): string {
   const lines = [
     "You are summarizing a COMPLETED coding session for an operator who will decide whether to merge the work.",
@@ -184,6 +186,17 @@ export function buildRecapPrompt(input: {
     `{"verdict": "ready" | "parked" | "needs_attention", "headline": "<string>", "body": "<markdown>", "openItems": ["<string>", ...], "blocks": [ ... ]}`,
     "Write the file as your final action, then stop.",
   );
+
+  if (input.operatorLanguage === "de") {
+    lines.push(
+      "",
+      "Write the recap prose fields `headline`, `body`, and `openItems[]` in German. Keep " +
+        '`verdict` as the literal enum value ("ready" | "parked" | "needs_attention") — the ' +
+        "operator UI switches on it, never translate it.",
+    );
+    const blockLine = visualBlockLanguageLine("de");
+    if (blockLine) lines.push(blockLine);
+  }
 
   return lines.join("\n");
 }

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -21,6 +21,7 @@ import type { HerdrDriver } from "./herdr";
 import type { Session, Recap, AgentProvider } from "./types";
 import type { DiffResult } from "./types";
 import type { RoleEnvironment } from "./default-model";
+import type { OperatorLanguage } from "./operator-language";
 import type { ActivityEntry } from "./activity";
 import type { SessionUsage } from "./usage";
 import { readSessionUsage } from "./usage";
@@ -205,6 +206,8 @@ export interface RecapServiceDeps {
   onChange: (id: string, recap: Recap | null) => void;
   // optional environment thunk (CLI + model, read per spawn → live settings)
   env?: () => RoleEnvironment;
+  // optional operator-language thunk (read per spawn → live settings; default "en")
+  operatorLanguage?: () => OperatorLanguage;
   now?: () => number;
   timeoutMs?: number;
   idleThresholdMs?: number;
@@ -246,6 +249,7 @@ export class RecapService {
   private timeoutMs: number;
   private idleThresholdMs: number;
   private env: () => RoleEnvironment;
+  private operatorLanguage: () => OperatorLanguage;
 
   private _resolveBase: (session: Session) => Promise<{ base: string; resolved: boolean }>;
   private _computeDiff: (
@@ -287,6 +291,7 @@ export class RecapService {
     // No service-internal model default — the sonnet default now lives in config.recapModel seeding
     // (config.recapCli="claude"), resolved by roleEnv at the call site in index.ts.
     this.env = optional(deps.env, () => ({ provider: "claude", model: null }));
+    this.operatorLanguage = optional(deps.operatorLanguage, () => "en");
     this._resolveBase = optional(deps.resolveBase, (s) =>
       Promise.resolve({ base: s.baseBranch, resolved: false }),
     );
@@ -629,6 +634,7 @@ export class RecapService {
         changedFiles: changedFilesWithStatus,
         digest,
         context,
+        operatorLanguage: this.operatorLanguage(),
       });
       const env = this.env();
       const { argv, sessionId: spawnSessionId } = recapArgv(

--- a/src/server.ts
+++ b/src/server.ts
@@ -183,6 +183,7 @@ import { excludeHiddenSections } from "./up-next-core";
 import type { UpNextSnapshot } from "./up-next-core";
 import { normalizeAgentProvider } from "./agent-provider";
 import { normalizeAuthModeSetting, writeApiKeyHelper, clearApiKeyHelper } from "./auth-mode";
+import { normalizeOperatorLanguage } from "./operator-language";
 import {
   type SandboxProfile,
   SANDBOX_PROFILES,
@@ -4280,6 +4281,8 @@ async function handleSettings({ req, parts, deps }: Ctx): Promise<Response | nul
       extraCreditsDrainCeiling: config.extraCreditsDrainCeiling,
       // auth footing for spawned agents; "subscription" (default) or "api-key".
       authMode: config.authMode,
+      // language agents address the operator in; "en" (default) or "de".
+      operatorLanguage: config.operatorLanguage,
       // whether an apiKeyHelper script is configured; NEVER expose the key or path.
       hasApiKey: config.authApiKeyHelperPath !== null,
       // usage-aware task holding
@@ -4353,6 +4356,7 @@ const SETTING_PATCHES: [string, (value: unknown, deps: Ctx["deps"]) => Response]
   ["upnextSkipCliPicker", putUpnextSkipCliPicker],
   ["extraCreditsDrainCeiling", putExtraCreditsDrainCeiling],
   ["authMode", putAuthMode],
+  ["operatorLanguage", putOperatorLanguage],
   ["anthropicApiKey", putAnthropicApiKey],
   ["usageHoldEnabled", putUsageHoldEnabled],
   ["usageHoldPct", putUsageHoldPct],
@@ -4510,6 +4514,15 @@ function putAuthMode(value: unknown, deps: Ctx["deps"]): Response {
   config.authMode = v; // live: next spawn picks it up
   deps.store.setSetting("authMode", v); // persist across restarts
   return json({ authMode: config.authMode, hasApiKey: config.authApiKeyHelperPath !== null });
+}
+
+// Language agents address the operator in; "en" (default, no-op) or "de".
+function putOperatorLanguage(value: unknown, deps: Ctx["deps"]): Response {
+  const v = normalizeOperatorLanguage(typeof value === "string" ? value : undefined);
+  if (v === null) return json({ error: "operatorLanguage must be 'en' or 'de'" }, 400);
+  config.operatorLanguage = v; // live: next spawn picks it up
+  deps.store.setSetting("operatorLanguage", v); // persist across restarts
+  return json({ operatorLanguage: config.operatorLanguage });
 }
 
 // Consent is the only persisted telemetry state. Granting for the first time emits

--- a/src/service.ts
+++ b/src/service.ts
@@ -1192,10 +1192,8 @@ export function composeSystemPrompt(
   }
   // Operator-language directive rides LAST. operatorLanguageBlock returns the already-wrapped
   // <operator-language>...</operator-language> string (unlike the blocks above, do NOT re-wrap it),
-  // or null for "en" — so nothing is pushed and existing "en" callers stay byte-identical.
-  const opLang = operatorLanguageBlock(operatorLanguage);
-  if (opLang) blocks.push(opLang);
-  return blocks.join("\n\n");
+  // or null for "en" — filtered out below so existing "en" callers stay byte-identical.
+  return [...blocks, operatorLanguageBlock(operatorLanguage)].filter(Boolean).join("\n\n");
 }
 
 /**

--- a/src/service.ts
+++ b/src/service.ts
@@ -9,6 +9,11 @@ import type { WorktreeMgr } from "./worktree";
 import type { HerdrAgent, HerdrDriver } from "./herdr";
 import { createSerializer, matchAgents, needsAccountRedrive } from "./herdr";
 import { config } from "./config";
+import {
+  operatorLanguageBlock,
+  visualBlockLanguageLine,
+  type OperatorLanguage,
+} from "./operator-language";
 import { findCodexSessionId } from "./codex-session-id";
 import type {
   AgentProvider,
@@ -827,6 +832,7 @@ export function buildQueueDirective(args: {
 export function planBlockInstructions(opts: {
   allowQuestionForm: boolean;
   agentProvider?: AgentProvider;
+  operatorLanguage?: OperatorLanguage;
 }): string {
   const lines: string[] = [
     "## Optional visual-plan sidecar",
@@ -885,6 +891,11 @@ export function planBlockInstructions(opts: {
     "- Redact secrets (API keys, tokens, passwords) in any summary/markdown/annotation — use placeholders like `sk-•••` / `<redacted>`.",
   );
 
+  if (opts.operatorLanguage === "de") {
+    const languageLine = visualBlockLanguageLine(opts.operatorLanguage);
+    if (languageLine) lines.push("", "**Operator language:**", languageLine);
+  }
+
   return lines.join("\n");
 }
 
@@ -897,7 +908,10 @@ export function planBlockInstructions(opts: {
  * `planGateDirectiveInteractive("claude")` is byte-identical to the prior
  * `PLAN_GATE_DIRECTIVE_INTERACTIVE` constant — keep it that way (Claude regression).
  */
-function planGateDirectiveInteractive(agentProvider: AgentProvider): string {
+function planGateDirectiveInteractive(
+  agentProvider: AgentProvider,
+  operatorLanguage: OperatorLanguage = "en",
+): string {
   const stopClause =
     agentProvider === "codex"
       ? "Do NOT write or modify ANY code this turn. Your ONLY deliverable right now is the plan file " +
@@ -922,7 +936,7 @@ function planGateDirectiveInteractive(agentProvider: AgentProvider): string {
     "assumptions and resolved decisions.\n" +
     "An adversarial reviewer will critique the plan; address its findings by revising `.shepherd-plan.md`. " +
     "Begin implementing ONLY after the plan is approved and you are told to execute.\n\n" +
-    planBlockInstructions({ allowQuestionForm: false, agentProvider })
+    planBlockInstructions({ allowQuestionForm: false, agentProvider, operatorLanguage })
   );
 }
 const PLAN_GATE_DIRECTIVE_INTERACTIVE = planGateDirectiveInteractive("claude");
@@ -933,7 +947,10 @@ const PLAN_GATE_DIRECTIVE_INTERACTIVE = planGateDirectiveInteractive("claude");
  * `planGateDirectiveAuto("claude")` is byte-identical to the prior `PLAN_GATE_DIRECTIVE_AUTO`
  * constant — keep it that way (Claude regression).
  */
-function planGateDirectiveAuto(agentProvider: AgentProvider): string {
+function planGateDirectiveAuto(
+  agentProvider: AgentProvider,
+  operatorLanguage: OperatorLanguage = "en",
+): string {
   const stopClause =
     agentProvider === "codex"
       ? "Do NOT write or modify ANY code this turn. Your ONLY deliverable right now is the plan file " +
@@ -946,7 +963,7 @@ function planGateDirectiveAuto(agentProvider: AgentProvider): string {
     "at the repo root (goal, approach, files, steps, risks, success criteria). An adversarial reviewer " +
     "will critique it; revise `.shepherd-plan.md` to address findings. Begin implementing ONLY after you " +
     "are told the plan is approved.\n\n" +
-    planBlockInstructions({ allowQuestionForm: true, agentProvider })
+    planBlockInstructions({ allowQuestionForm: true, agentProvider, operatorLanguage })
   );
 }
 const PLAN_GATE_DIRECTIVE_AUTO = planGateDirectiveAuto("claude");
@@ -1076,16 +1093,21 @@ export function planGoSteer(draftMode: boolean): string {
 function primaryDirectiveBlock(
   agentProvider: AgentProvider,
   autopilotActive: boolean,
-  opts: { research?: boolean; planGate?: "interactive" | "auto" },
+  opts: {
+    research?: boolean;
+    planGate?: "interactive" | "auto";
+    operatorLanguage?: OperatorLanguage;
+  },
 ): string | null {
   if (opts.research) {
     return `<research-directive>\n${researchDirective(agentProvider)}\n</research-directive>`;
   }
   if (opts.planGate) {
+    const operatorLanguage: OperatorLanguage = opts.operatorLanguage ?? "en";
     const variant =
       opts.planGate === "auto"
-        ? planGateDirectiveAuto(agentProvider)
-        : planGateDirectiveInteractive(agentProvider);
+        ? planGateDirectiveAuto(agentProvider, operatorLanguage)
+        : planGateDirectiveInteractive(agentProvider, operatorLanguage);
     return `<plan-gate-directive>\n${variant}\n</plan-gate-directive>`;
   }
   if (autopilotActive) {
@@ -1106,12 +1128,17 @@ export function composeSystemPrompt(
     trimmed?: boolean;
     epicIntent?: boolean;
     agentProvider?: AgentProvider;
+    operatorLanguage?: OperatorLanguage;
   } = {},
 ): string {
   // Provider-adjust only the two blocks that name a Claude-only tool/capability (research's
   // "sub-agents", the interactive plan-gate's "AskUserQuestion"). Absent → "claude", so every
   // existing Claude caller is byte-identical.
   const agentProvider = opts.agentProvider ?? "claude";
+  // Absent/"en" → byte-identical to today (operatorLanguageBlock/visualBlockLanguageLine both
+  // return null for "en"). The live value only ever arrives via composeDirectives passing
+  // config.operatorLanguage in opts — never defaulted from config here.
+  const operatorLanguage: OperatorLanguage = opts.operatorLanguage ?? "en";
   const posture = `<engineering-posture>\n${ENGINEERING_POSTURE}\n</engineering-posture>`;
   const untrustedBoundary = `<untrusted-content-boundary>\n${UNTRUSTED_CONTENT_DIRECTIVE}\n</untrusted-content-boundary>`;
   const research = `<research-first-notice>\n${RESEARCH_FIRST_NOTICE}\n</research-first-notice>`;
@@ -1143,7 +1170,10 @@ export function composeSystemPrompt(
   }
   // Research is the highest-priority directive: it replaces BOTH the plan-gate and the autopilot
   // directive (none of those fit a report-PR/issue deliverable). See primaryDirectiveBlock.
-  const primary = primaryDirectiveBlock(agentProvider, autopilotActive, opts);
+  const primary = primaryDirectiveBlock(agentProvider, autopilotActive, {
+    ...opts,
+    operatorLanguage,
+  });
   if (primary) blocks.push(primary);
   // Build queue rides independently of the plan-gate/autopilot directive (orthogonal repo config),
   // but a research session authors no queue — suppress it there too.
@@ -1160,6 +1190,11 @@ export function composeSystemPrompt(
   if (opts.trimmed) {
     blocks.push(`<context-trim-notice>\n${CONTEXT_TRIM_NOTICE}\n</context-trim-notice>`);
   }
+  // Operator-language directive rides LAST. operatorLanguageBlock returns the already-wrapped
+  // <operator-language>...</operator-language> string (unlike the blocks above, do NOT re-wrap it),
+  // or null for "en" — so nothing is pushed and existing "en" callers stay byte-identical.
+  const opLang = operatorLanguageBlock(operatorLanguage);
+  if (opLang) blocks.push(opLang);
   return blocks.join("\n\n");
 }
 
@@ -2124,6 +2159,10 @@ export class SessionService {
       // operator epic ask, so nothing is lost.
       epicIntent: !input.auto && detectEpicIntent(input.prompt),
       agentProvider: args.agentProvider,
+      // The ONE place the live config value enters — never defaulted at any module-level
+      // constant (see PLAN_GATE_DIRECTIVE_INTERACTIVE/_AUTO, computed at import time with the
+      // literal "en" default).
+      operatorLanguage: config.operatorLanguage,
     });
   }
 

--- a/src/visual-blocks.ts
+++ b/src/visual-blocks.ts
@@ -584,14 +584,14 @@ function parseBlock(item: unknown): VisualBlock | null {
  *  This is the trust boundary — be defensive, drop on any doubt. */
 export function parseVisualBlocks(raw: unknown): VisualBlock[] {
   // (A) warn if blocks field is present but non-array (mangled shape)
-  if (raw !== undefined && !Array.isArray(raw)) {
-    console.warn(
-      `[visual-blocks] blocks field is present but not an array (received ${typeof raw})`,
-    );
+  if (!Array.isArray(raw)) {
+    if (raw !== undefined) {
+      console.warn(
+        `[visual-blocks] blocks field is present but not an array (received ${typeof raw})`,
+      );
+    }
     return [];
   }
-
-  if (!Array.isArray(raw)) return [];
 
   const result: VisualBlock[] = [];
   const seenIds = new Set<string>();
@@ -600,14 +600,13 @@ export function parseVisualBlocks(raw: unknown): VisualBlock[] {
     const block = parseBlock(item);
     // (B) warn when parseBlock rejects — log type/id defensively from raw item
     if (!block) {
-      if (item && typeof item === "object" && !Array.isArray(item)) {
-        const itemObj = item as Record<string, unknown>;
-        const type = sanitizeForLog(itemObj.type);
-        const id = sanitizeForLog(itemObj.id);
-        console.warn(`[visual-blocks] dropped block: type="${type}" id="${id}"`);
-      } else {
-        console.warn(`[visual-blocks] dropped malformed block (not an object): ${typeof item}`);
-      }
+      const itemObj =
+        item && typeof item === "object" && !Array.isArray(item)
+          ? (item as Record<string, unknown>)
+          : undefined;
+      const type = sanitizeForLog(itemObj?.type);
+      const id = sanitizeForLog(itemObj?.id);
+      console.warn(`[visual-blocks] dropped block: type="${type}" id="${id}"`);
       continue;
     }
 

--- a/src/visual-blocks.ts
+++ b/src/visual-blocks.ts
@@ -139,6 +139,17 @@ export const QUESTION_KINDS: readonly QuestionKind[] = ["single", "multi", "free
 
 // ── parseVisualBlocks ─────────────────────────────────────────────────────────
 
+/** Sanitize a value for logging: coerce to string, clamp length, strip control characters.
+ *  Returns "<none>" for absent/non-string values. Used to prevent LLM-authored strings
+ *  from forging or smearing log lines. */
+function sanitizeForLog(v: unknown): string {
+  if (typeof v !== "string" || v === "") return "<none>";
+  // Clamp to 80 chars and strip C0/C1 control characters (including newlines, ANSI escapes, etc)
+  const clamped = v.substring(0, 80);
+  // eslint-disable-next-line no-control-regex
+  return clamped.replace(/[\x00-\x1f\x7f-\x9f]/g, "");
+}
+
 function validateRichText(r: Record<string, unknown>, id: string): VisualBlock | null {
   if (typeof r.markdown !== "string") return null;
   return { type: "rich-text", id, markdown: r.markdown };
@@ -572,6 +583,14 @@ function parseBlock(item: unknown): VisualBlock | null {
  *  `{#each}` by `block.id`, so a duplicate id would break the keyed-each.
  *  This is the trust boundary — be defensive, drop on any doubt. */
 export function parseVisualBlocks(raw: unknown): VisualBlock[] {
+  // (A) warn if blocks field is present but non-array (mangled shape)
+  if (raw !== undefined && !Array.isArray(raw)) {
+    console.warn(
+      `[visual-blocks] blocks field is present but not an array (received ${typeof raw})`,
+    );
+    return [];
+  }
+
   if (!Array.isArray(raw)) return [];
 
   const result: VisualBlock[] = [];
@@ -579,8 +598,26 @@ export function parseVisualBlocks(raw: unknown): VisualBlock[] {
 
   for (const item of raw) {
     const block = parseBlock(item);
-    if (!block) continue;
-    if (seenIds.has(block.id)) continue; // duplicate id → drop (keyed-each requires unique ids)
+    // (B) warn when parseBlock rejects — log type/id defensively from raw item
+    if (!block) {
+      if (item && typeof item === "object" && !Array.isArray(item)) {
+        const itemObj = item as Record<string, unknown>;
+        const type = sanitizeForLog(itemObj.type);
+        const id = sanitizeForLog(itemObj.id);
+        console.warn(`[visual-blocks] dropped block: type="${type}" id="${id}"`);
+      } else {
+        console.warn(`[visual-blocks] dropped malformed block (not an object): ${typeof item}`);
+      }
+      continue;
+    }
+
+    // (C) warn when duplicate id is detected
+    if (seenIds.has(block.id)) {
+      const type = sanitizeForLog(block.type);
+      const id = sanitizeForLog(block.id);
+      console.warn(`[visual-blocks] dropped duplicate id: type="${type}" id="${id}"`);
+      continue; // duplicate id → drop (keyed-each requires unique ids)
+    }
     seenIds.add(block.id);
     result.push(block);
   }

--- a/test/operator-language.test.ts
+++ b/test/operator-language.test.ts
@@ -194,6 +194,16 @@ describe("visualBlockLanguageLine — field inventory integrity (guards the guar
     expect(matches.length).toBe(2);
   });
 
+  // KNOWN LIMITATION: these count-regexes match `typeof r.field === "string"` and
+  // `ENUM.includes(r.field as Type)` directly, but NOT the indirect
+  // `const x = r.field; if (typeof x === "string")` idiom — the one `parseBlock`
+  // itself uses for `type` and `id` (src/visual-blocks.ts:570-574: `const id = r.id;
+  // if (typeof id !== "string") ...`). A future field added to a validator via that
+  // same indirect assign-then-typeof idiom will NOT increment either count above, so
+  // it can slip past this backstop silently. It must be added to TRANSLATE_FIELDS /
+  // VERBATIM_FIELDS by hand — this backstop only catches the two idioms it greps
+  // for; review must catch the rest.
+
   test("every VALIDATORS block type is represented in the field inventory", () => {
     const validatorsBlock = VISUAL_BLOCKS_SRC.slice(VISUAL_BLOCKS_SRC.indexOf("const VALIDATORS"));
     const blockTypes = [
@@ -261,5 +271,30 @@ describe("visualBlockLanguageLine", () => {
     expect(line).toContain("`api-endpoint.responses[].example`");
     expect(line).toContain("`api-endpoint.change`");
     expect(line).toContain("`question-form.questions[].kind`");
+  });
+});
+
+// ── No new `./config` import in recap.ts / plan-gate.ts ──────────────────────
+//
+// The point of this test: `deps.operatorLanguage` in recap.ts and plan-gate.ts
+// defaults to the literal () => "en" precisely so neither module needs a
+// `./config` import — the live value is wired at the composition root
+// (src/index.ts) instead. A module-level `./config` import in either file would
+// risk the config value getting read (and frozen) at import time rather than
+// per-spawn — see the plan's "import-time freeze" note for
+// PLAN_GATE_DIRECTIVE_INTERACTIVE / PLAN_GATE_DIRECTIVE_AUTO. This is a
+// source-level regression guard for that constraint, not a behavioral test.
+
+describe("no new ./config import (import-time-freeze guard)", () => {
+  const RECAP_SRC = readFileSync(join(import.meta.dir, "../src/recap.ts"), "utf8");
+  const PLAN_GATE_SRC = readFileSync(join(import.meta.dir, "../src/plan-gate.ts"), "utf8");
+  const CONFIG_IMPORT_RE = /from\s+["']\.\/config["']/;
+
+  test("src/recap.ts does not import from ./config", () => {
+    expect(CONFIG_IMPORT_RE.test(RECAP_SRC)).toBe(false);
+  });
+
+  test("src/plan-gate.ts does not import from ./config", () => {
+    expect(CONFIG_IMPORT_RE.test(PLAN_GATE_SRC)).toBe(false);
   });
 });

--- a/test/operator-language.test.ts
+++ b/test/operator-language.test.ts
@@ -1,0 +1,265 @@
+import { test, expect, describe } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  OPERATOR_LANGUAGES,
+  normalizeOperatorLanguage,
+  operatorLanguageBlock,
+  visualBlockLanguageLine,
+} from "../src/operator-language";
+
+// ── OPERATOR_LANGUAGES ────────────────────────────────────────────────────────
+
+describe("OPERATOR_LANGUAGES", () => {
+  test("is the ordered ['en', 'de'] list", () => {
+    expect(OPERATOR_LANGUAGES).toEqual(["en", "de"]);
+  });
+
+  test("is usable as a membership check", () => {
+    expect((OPERATOR_LANGUAGES as readonly string[]).includes("en")).toBe(true);
+    expect((OPERATOR_LANGUAGES as readonly string[]).includes("de")).toBe(true);
+    expect((OPERATOR_LANGUAGES as readonly string[]).includes("fr")).toBe(false);
+  });
+});
+
+// ── normalizeOperatorLanguage ─────────────────────────────────────────────────
+
+describe("normalizeOperatorLanguage", () => {
+  test("accepts 'en'", () => {
+    expect(normalizeOperatorLanguage("en")).toBe("en");
+  });
+
+  test("accepts 'de'", () => {
+    expect(normalizeOperatorLanguage("de")).toBe("de");
+  });
+
+  test("returns null for unknown string", () => {
+    expect(normalizeOperatorLanguage("fr")).toBeNull();
+  });
+
+  test("returns null for empty string", () => {
+    expect(normalizeOperatorLanguage("")).toBeNull();
+  });
+
+  test("returns null for undefined", () => {
+    expect(normalizeOperatorLanguage(undefined)).toBeNull();
+  });
+
+  test("returns null for null", () => {
+    expect(normalizeOperatorLanguage(null)).toBeNull();
+  });
+
+  test("is case-sensitive — 'EN'/'DE' are not accepted", () => {
+    expect(normalizeOperatorLanguage("EN")).toBeNull();
+    expect(normalizeOperatorLanguage("DE")).toBeNull();
+  });
+});
+
+// ── operatorLanguageBlock ─────────────────────────────────────────────────────
+
+describe("operatorLanguageBlock", () => {
+  test("returns null for 'en' (byte-identical prompts for existing operators)", () => {
+    expect(operatorLanguageBlock("en")).toBeNull();
+  });
+
+  test("returns a <operator-language> wrapped block for 'de'", () => {
+    const block = operatorLanguageBlock("de");
+    expect(block).not.toBeNull();
+    expect(block as string).toMatch(/^<operator-language>\n/);
+    expect(block as string).toMatch(/\n<\/operator-language>$/);
+  });
+
+  test("'de' block names German and covers the key carve-outs", () => {
+    const block = operatorLanguageBlock("de") as string;
+    expect(block).toContain("German");
+    expect(block).toContain(".shepherd-plan.md");
+    expect(block).toContain("code");
+    expect(block).toContain("commit messages");
+    expect(block).toContain("research report");
+  });
+});
+
+// ── visualBlockLanguageLine — field-level drift guard ─────────────────────────
+//
+// The point of this test: every string-valued field each VALIDATORS entry in
+// src/visual-blocks.ts reads must be named by visualBlockLanguageLine("de") in
+// exactly one of the translate / verbatim classifications — never both, never
+// neither. A type-level check (every VALIDATORS key + every enum member) is NOT
+// sufficient: it would pass even if a specific string field (e.g.
+// `data-model.fields[].change`) went unruled. So this test enumerates FIELDS,
+// not just block types.
+
+const VISUAL_BLOCKS_SRC = readFileSync(join(import.meta.dir, "../src/visual-blocks.ts"), "utf8");
+
+// Fields that must read as natural-language prose and get translated to German.
+// Copied verbatim from the approved field lists (task-1-brief.md).
+const TRANSLATE_FIELDS = [
+  "rich-text.markdown",
+  "callout.markdown",
+  "file-tree.title",
+  "file-tree.entries[].note",
+  "diff.summary",
+  "diff.annotations[].label",
+  "diff.annotations[].note",
+  "annotated-code.annotations[].label",
+  "annotated-code.annotations[].note",
+  "api-endpoint.summary",
+  "api-endpoint.params[].note",
+  "api-endpoint.responses[].description",
+  "checklist.items[].label",
+  "checklist.items[].note",
+  "mermaid.caption",
+  "wireframe.caption",
+  "question-form.questions[].prompt",
+  "question-form.questions[].options[]",
+] as const;
+
+// Fields that are identifiers / enums / paths / machine-read and must NEVER be
+// translated. Copied verbatim from the approved field lists, PLUS one field the
+// brief's authoritative list omitted: `api-endpoint.change`. visual-blocks.ts
+// reads it exactly like the other two "change" enums (`typeof r.change ===
+// "string"`, line ~366) and recap-core.ts's own prompt spec constrains it to
+// `"added"|"modified"|"deprecated"` (src/recap-core.ts:161) — an enum value, not
+// prose. Left unruled it would be silently untranslated-or-mistranslated by an
+// agent with no explicit instruction either way; this is exactly the kind of gap
+// the field-level guard below exists to catch.
+const VERBATIM_FIELDS = [
+  "type",
+  "id",
+  "callout.tone",
+  "file-tree.entries[].change",
+  "data-model.fields[].change",
+  "api-endpoint.change",
+  "wireframe.surface",
+  "wireframe.html",
+  "diff.path",
+  "code.filename",
+  "annotated-code.filename",
+  "file-tree.entries[].path",
+  "data-model.entities[].name",
+  "data-model.fields[].name",
+  "data-model.fields[].type",
+  "data-model.fields[].fk",
+  "data-model.fields[].was",
+  "data-model.relations[].from",
+  "data-model.relations[].to",
+  "data-model.relations[].kind",
+  "api-endpoint.method",
+  "api-endpoint.path",
+  "api-endpoint.params[].name",
+  "api-endpoint.params[].in",
+  "api-endpoint.params[].type",
+  "api-endpoint.responses[].example",
+  "question-form.questions[].kind",
+  "mermaid.source",
+] as const;
+
+// table.columns / table.rows are conditional — translated cell by cell, never a
+// path/flag/identifier/enum/command fragment. Named in their own rule, not in
+// either list above.
+const TABLE_CONDITIONAL_FIELDS = ["table.columns", "table.rows"] as const;
+
+const ALL_FIELD_TOKENS = [...TRANSLATE_FIELDS, ...VERBATIM_FIELDS, ...TABLE_CONDITIONAL_FIELDS];
+
+describe("visualBlockLanguageLine — field inventory integrity (guards the guard)", () => {
+  test("no field token is listed more than once across translate/verbatim/table", () => {
+    const seen = new Set<string>();
+    for (const token of ALL_FIELD_TOKENS) {
+      expect(seen.has(token)).toBe(false);
+      seen.add(token);
+    }
+  });
+
+  // Cross-check the hardcoded field inventory above against the actual validator
+  // source, so a new string field added to visual-blocks.ts can't silently ship
+  // without an explicit translate/verbatim rule. Every `typeof x.field === "string"`
+  // / `typeof x.field !== "string"` guard and every `SOME_ENUM.includes(x.field as
+  // Type)` enum guard in the VALIDATORS bodies is a string-valued field read; the
+  // counts below are the current, hand-verified totals. If a future validator adds
+  // a new field via either idiom, these counts drift and this test fails — forcing
+  // the new field to be added to TRANSLATE_FIELDS or VERBATIM_FIELDS (and to
+  // visualBlockLanguageLine's prose) before it can ship.
+  test("typeof-string field-read idiom count matches the hand-verified total", () => {
+    const matches = VISUAL_BLOCKS_SRC.match(/typeof [a-zA-Z]+\.[a-zA-Z]+ *[!=]== *"string"/g) ?? [];
+    expect(matches.length).toBe(39);
+  });
+
+  test("ENUM.includes(x.field as Type) field-read idiom count matches the hand-verified total", () => {
+    const matches = VISUAL_BLOCKS_SRC.match(/[A-Z_]+\.includes\([a-zA-Z]+\.[a-zA-Z]+ as/g) ?? [];
+    expect(matches.length).toBe(5);
+  });
+
+  test("'is string =>' array-filter idiom count matches the hand-verified total (table.columns, question-form options)", () => {
+    const matches = VISUAL_BLOCKS_SRC.match(/\([a-zA-Z]+\): [a-zA-Z]+ is string =>/g) ?? [];
+    expect(matches.length).toBe(2);
+  });
+
+  test("every VALIDATORS block type is represented in the field inventory", () => {
+    const validatorsBlock = VISUAL_BLOCKS_SRC.slice(VISUAL_BLOCKS_SRC.indexOf("const VALIDATORS"));
+    const blockTypes = [
+      ...validatorsBlock.matchAll(/^\s*(?:"([\w-]+)"|([\w-]+)):\s*validate/gm),
+    ].map((m) => m[1] ?? m[2]);
+    expect(blockTypes.length).toBeGreaterThan(0);
+    for (const type of blockTypes) {
+      const hasField = ALL_FIELD_TOKENS.some((f) => f === type || f.startsWith(`${type}.`));
+      expect(hasField).toBe(true);
+    }
+  });
+});
+
+describe("visualBlockLanguageLine", () => {
+  test("returns null for 'en'", () => {
+    expect(visualBlockLanguageLine("en")).toBeNull();
+  });
+
+  test("returns non-null prose for 'de'", () => {
+    const line = visualBlockLanguageLine("de");
+    expect(line).not.toBeNull();
+    expect(typeof line).toBe("string");
+  });
+
+  test("every translate field is named exactly once, and not in the verbatim section", () => {
+    const line = visualBlockLanguageLine("de") as string;
+    for (const token of TRANSLATE_FIELDS) {
+      const re = new RegExp("`" + token.replace(/[.[\]]/g, "\\$&") + "`", "g");
+      expect(line.match(re)?.length ?? 0).toBe(1);
+    }
+  });
+
+  test("every verbatim field is named exactly once, and not in the translate section", () => {
+    const line = visualBlockLanguageLine("de") as string;
+    for (const token of VERBATIM_FIELDS) {
+      const re = new RegExp("`" + token.replace(/[.[\]]/g, "\\$&") + "`", "g");
+      expect(line.match(re)?.length ?? 0).toBe(1);
+    }
+  });
+
+  test("every field token in the emitted text is accounted for exactly once total (never both, never neither)", () => {
+    const line = visualBlockLanguageLine("de") as string;
+    for (const token of ALL_FIELD_TOKENS) {
+      const re = new RegExp("`" + token.replace(/[.[\]]/g, "\\$&") + "`", "g");
+      expect(line.match(re)?.length ?? 0).toBe(1);
+    }
+  });
+
+  test("includes the conditional table cell-by-cell rule", () => {
+    const line = visualBlockLanguageLine("de") as string;
+    expect(line).toContain("`table.columns`");
+    expect(line).toContain("`table.rows`");
+    expect(line.toLowerCase()).toContain("never a path, flag, identifier, enum value, or command");
+  });
+
+  // The specific fields review called out as easily missed by a type-level (not
+  // field-level) guard — assert them explicitly, in addition to the loop above.
+  test("names the previously-easy-to-miss fields explicitly", () => {
+    const line = visualBlockLanguageLine("de") as string;
+    expect(line).toContain("`data-model.fields[].change`");
+    expect(line).toContain("`data-model.relations[].from`");
+    expect(line).toContain("`data-model.relations[].to`");
+    expect(line).toContain("`data-model.fields[].fk`");
+    expect(line).toContain("`data-model.fields[].was`");
+    expect(line).toContain("`api-endpoint.responses[].example`");
+    expect(line).toContain("`api-endpoint.change`");
+    expect(line).toContain("`question-form.questions[].kind`");
+  });
+});

--- a/test/operator-language.test.ts
+++ b/test/operator-language.test.ts
@@ -231,24 +231,33 @@ describe("visualBlockLanguageLine", () => {
   test("every translate field is named exactly once, and not in the verbatim section", () => {
     const line = visualBlockLanguageLine("de") as string;
     for (const token of TRANSLATE_FIELDS) {
-      const re = new RegExp("`" + token.replace(/[.[\]]/g, "\\$&") + "`", "g");
-      expect(line.match(re)?.length ?? 0).toBe(1);
+      // Count literal `` `token` `` occurrences via split — no regex, so no metacharacter
+      // escaping to get wrong (the tokens contain `.`/`[`/`]`, and CodeQL rightly flags a
+      // hand-rolled escape that misses backslashes).
+      const needle = "`" + token + "`";
+      expect(line.split(needle).length - 1).toBe(1);
     }
   });
 
   test("every verbatim field is named exactly once, and not in the translate section", () => {
     const line = visualBlockLanguageLine("de") as string;
     for (const token of VERBATIM_FIELDS) {
-      const re = new RegExp("`" + token.replace(/[.[\]]/g, "\\$&") + "`", "g");
-      expect(line.match(re)?.length ?? 0).toBe(1);
+      // Count literal `` `token` `` occurrences via split — no regex, so no metacharacter
+      // escaping to get wrong (the tokens contain `.`/`[`/`]`, and CodeQL rightly flags a
+      // hand-rolled escape that misses backslashes).
+      const needle = "`" + token + "`";
+      expect(line.split(needle).length - 1).toBe(1);
     }
   });
 
   test("every field token in the emitted text is accounted for exactly once total (never both, never neither)", () => {
     const line = visualBlockLanguageLine("de") as string;
     for (const token of ALL_FIELD_TOKENS) {
-      const re = new RegExp("`" + token.replace(/[.[\]]/g, "\\$&") + "`", "g");
-      expect(line.match(re)?.length ?? 0).toBe(1);
+      // Count literal `` `token` `` occurrences via split — no regex, so no metacharacter
+      // escaping to get wrong (the tokens contain `.`/`[`/`]`, and CodeQL rightly flags a
+      // hand-rolled escape that misses backslashes).
+      const needle = "`" + token + "`";
+      expect(line.split(needle).length - 1).toBe(1);
     }
   });
 

--- a/test/plan-gate-prompt.test.ts
+++ b/test/plan-gate-prompt.test.ts
@@ -54,3 +54,23 @@ test("reviewerArgv inserts --model when given", () => {
   expect(a[mi + 1]).toBe("opus");
   expect(a[a.length - 1]).toBe("PROMPT"); // prompt still trailing
 });
+
+// ─── operator-language: `de` line for the plan reviewer (Task 6, issue #1586) ────────────────
+
+test("en is byte-identical: planReviewPrompt with/without explicit operatorLanguage:'en'", () => {
+  const withoutLang = planReviewPrompt("task", "plan");
+  const withEnLang = planReviewPrompt("task", "plan", [], null, "en");
+  expect(withEnLang).toBe(withoutLang);
+  expect(withoutLang).not.toContain("German");
+  expect(withEnLang).not.toContain("German");
+});
+
+test("de: planReviewPrompt names summary/body/findings as German-prose fields, keeps decision literal", () => {
+  const p = planReviewPrompt("task", "plan", [], null, "de");
+  expect(p).toContain("German");
+  expect(p).toContain("summary");
+  expect(p).toContain("body");
+  expect(p).toContain("findings");
+  expect(p).toContain("decision");
+  expect(p).toContain('"approve" | "request-changes"');
+});

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -1604,3 +1604,69 @@ test("adoptOrphans reaps an approved orphan: stops terminal, completes spawn, re
   expect(h.completedSpawns[0].u.total).toBe(10);
   expect(h.removed).toContain("/wt-detached"); // disposable worktree removed
 });
+
+// ─── resolveFindings un-clamped steer-back guard (Task 6, issue #1586) ───────────────────────
+// resolveSummary clamps the gate's HUD `summary` field to 100 chars; the empty-findings
+// fallback used to steer that SAME clamped (possibly mid-word-truncated) value back into the
+// coding agent. buildGate now feeds resolveFindings the un-clamped verdict summary instead —
+// language-independent, fixes en and de alike.
+
+test("code guard: request-changes + empty findings steers back the FULL un-clamped summary, while the gate's HUD summary stays clamped to 100", async () => {
+  const longSummary = "S".repeat(180); // >100 chars — would previously arrive truncated
+  const h = harness({
+    readVerdict: () => ({
+      decision: "request-changes",
+      summary: longSummary,
+      body: "B",
+      findings: [],
+    }),
+  });
+  await h.svc.consider(planningSession() as any);
+  await h.svc.tick();
+  expect(h.store.gate.summary).toBe(longSummary.slice(0, 100));
+  expect(h.store.gate.summary.length).toBe(100); // HUD one-liner stays clamped
+  expect(h.store.gate.findings).toEqual([longSummary]); // steer-back is the FULL, untruncated summary
+  expect(h.store.gate.findings[0].length).toBeGreaterThan(100);
+});
+
+test("code guard: a normal (<=100 char) summary fallback is unaffected", async () => {
+  const h = harness({
+    readVerdict: () => ({
+      decision: "request-changes",
+      summary: "short one-liner",
+      body: "B",
+      findings: [],
+    }),
+  });
+  await h.svc.consider(planningSession() as any);
+  await h.svc.tick();
+  expect(h.store.gate.summary).toBe("short one-liner");
+  expect(h.store.gate.findings).toEqual(["short one-liner"]);
+});
+
+// ─── operator-language: per-spawn read, not frozen at construction (Task 6, issue #1586) ─────
+
+test("operator-language: reviewer prompt reads operatorLanguage per spawn, not cached at construction", async () => {
+  let lang: "en" | "de" = "en";
+  let calls = 0;
+  const h = harness({
+    operatorLanguage: () => {
+      calls++;
+      return lang;
+    },
+  });
+  const s1 = await h.svc.consider(planningSession() as any);
+  expect(s1).toBe("started");
+  expect(calls).toBe(1);
+  expect(h.started[0].argv.at(-1)).not.toContain("German");
+
+  // Free the inflight slot (mirrors the createDetached-slug test above) so a second begin() can
+  // run on the SAME service instance, then flip the live setting and drive another spawn — a
+  // construction-frozen value would never see this change.
+  h.svc.forget("s1");
+  lang = "de";
+  const s2 = await h.svc.consider(planningSession() as any);
+  expect(s2).toBe("started");
+  expect(calls).toBe(2);
+  expect(h.started[1].argv.at(-1)).toContain("German");
+});

--- a/test/recap-core.test.ts
+++ b/test/recap-core.test.ts
@@ -691,3 +691,64 @@ test("buildRecapPrompt: data-model/api-endpoint doc mentions redaction", () => {
   });
   expect(p).toContain("redact");
 });
+
+// ─── operator-language injection (Task 5, issue #1586) ──────────────────────
+
+// fenceUntrusted() mints a random per-call nonce (see src/untrusted.ts), so two independent
+// buildRecapPrompt calls never come out byte-identical purely because of that nonce even when
+// nothing else differs. Normalize it out before the byte-identity comparison below.
+const normalizeUntrustedNonce = (s: string): string =>
+  s.replace(/⟦(\/?)UNTRUSTED:(\w+):[0-9a-f]+⟧/g, "⟦$1UNTRUSTED:$2:NONCE⟧");
+
+test("en is byte-identical: buildRecapPrompt with/without explicit operatorLanguage:'en'", () => {
+  const representativeInput = {
+    taskPrompt: "Implement recap",
+    plan: "Step 1: do x",
+    changedFiles: [
+      { path: "src/new.ts", status: "added" as const },
+      { path: "src/old.ts", status: "modified" as const },
+    ],
+    digest: "[Edit] edited server.ts",
+    context: "Critic verdict: looks good",
+  };
+  const withoutLang = normalizeUntrustedNonce(buildRecapPrompt(representativeInput));
+  const withEnLang = normalizeUntrustedNonce(
+    buildRecapPrompt({ ...representativeInput, operatorLanguage: "en" }),
+  );
+  expect(withEnLang).toBe(withoutLang);
+  expect(withoutLang).not.toContain("German");
+  expect(withEnLang).not.toContain("German");
+  expect(withoutLang).not.toContain("write ONLY these natural-language fields");
+  expect(withEnLang).not.toContain("write ONLY these natural-language fields");
+});
+
+test("de: buildRecapPrompt names headline/body/openItems as German-prose fields, keeps verdict literal", () => {
+  const p = buildRecapPrompt({
+    taskPrompt: "t",
+    plan: "",
+    changedFiles: [],
+    digest: "",
+    context: "",
+    operatorLanguage: "de",
+  });
+  expect(p).toContain("headline");
+  expect(p).toContain("body");
+  expect(p).toContain("openItems");
+  expect(p).toContain("German");
+  expect(p).toContain('"ready" | "parked" | "needs_attention"');
+});
+
+test("de: buildRecapPrompt carries the VisualBlock verbatim-fields rule (visualBlockLanguageLine appended)", () => {
+  const p = buildRecapPrompt({
+    taskPrompt: "t",
+    plan: "",
+    changedFiles: [],
+    digest: "",
+    context: "",
+    operatorLanguage: "de",
+  });
+  expect(p).toContain("write ONLY these natural-language fields");
+  for (const field of ["type", "tone", "mermaid.source"]) {
+    expect(p).toContain(field);
+  }
+});

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -988,6 +988,51 @@ test("generate: api-key mode — apiKeyHelper in --settings + CLAUDE_CONFIG_DIR 
   });
 });
 
+// ─── operator-language: per-spawn read, not frozen at construction (Task 5, issue #1586) ────
+
+test("generate: reads operatorLanguage per spawn, not cached at construction", async () => {
+  const s = makeSession({ status: "idle" });
+  const herdr = makeHerdr();
+  const store = makeStore([s]);
+  let lang: "en" | "de" = "en";
+  let callCount = 0;
+
+  const svc = new RecapService({
+    store: store as any,
+    herdr: herdr as any,
+    onChange: () => {},
+    env: () => ({ provider: "claude", model: "sonnet" }),
+    operatorLanguage: () => {
+      callCount++;
+      return lang;
+    },
+    now: () => 1,
+    timeoutMs: 300_000,
+    headSha: async () => "sha-head",
+    computeDiff: async () => NON_EMPTY_DIFF as any,
+    readTranscript: (): ActivityEntry[] => [],
+    readPlan: () => "",
+    readVerdict: (): VerdictRead<unknown> => ({ status: "absent" }),
+    makeTmpDir: () => "/tmp/r1",
+    cleanup: () => {},
+  });
+
+  // First generation, still "en": getter invoked, prompt carries no German marker.
+  await svc.regenerate(s);
+  expect(callCount).toBe(1);
+  const firstPrompt = herdr.started[0]!.argv.at(-1)!;
+  expect(firstPrompt).not.toContain("German");
+
+  // Flip the live setting, then drive a second generation on the SAME service instance —
+  // a construction-frozen value would never see this change.
+  lang = "de";
+  const svc2 = svc; // same instance, reused deliberately
+  await svc2.regenerate(s);
+  expect(callCount).toBe(2);
+  const secondPrompt = herdr.started[1]!.argv.at(-1)!;
+  expect(secondPrompt).toContain("German");
+});
+
 test("generate: api-key without a configured key fails closed → 'error', no spawn", async () => {
   await withAuth("api-key", null, async () => {
     const s = makeSession({ status: "idle" });

--- a/test/server-settings.test.ts
+++ b/test/server-settings.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, rmSync, realpathSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, realpathSync, existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SessionStore } from "../src/store";
@@ -8,6 +8,7 @@ import { makeApp, type AppDeps } from "../src/server";
 import { config, clampCap, PR_REVIEW_CYCLES_MIN, PR_REVIEW_CYCLES_MAX } from "../src/config";
 import type { AuthMode } from "../src/auth-mode";
 import { EFFORTS } from "../src/types";
+import { OPERATOR_LANGUAGES, normalizeOperatorLanguage } from "../src/operator-language";
 
 let tmp: string;
 let savedRoot: string;
@@ -23,6 +24,7 @@ let savedRoleEnvs: Record<string, string>;
 let savedDefaultAgentProvider: typeof config.defaultAgentProvider;
 let savedExtraCredits: number;
 let savedAuthMode: AuthMode;
+let savedOperatorLanguage: typeof config.operatorLanguage;
 let savedAuthApiKeyHelperPath: string | null;
 let savedHome: string | undefined;
 let savedTuiFullscreen: boolean;
@@ -55,6 +57,7 @@ beforeEach(() => {
   savedDefaultAgentProvider = config.defaultAgentProvider;
   savedExtraCredits = config.extraCreditsDrainCeiling;
   savedAuthMode = config.authMode;
+  savedOperatorLanguage = config.operatorLanguage;
   savedAuthApiKeyHelperPath = config.authApiKeyHelperPath;
   savedTuiFullscreen = config.tuiFullscreen;
   savedTuiDisableMouse = config.tuiDisableMouse;
@@ -89,6 +92,7 @@ afterEach(() => {
   config.defaultAgentProvider = savedDefaultAgentProvider;
   config.extraCreditsDrainCeiling = savedExtraCredits;
   config.authMode = savedAuthMode;
+  config.operatorLanguage = savedOperatorLanguage;
   config.authApiKeyHelperPath = savedAuthApiKeyHelperPath;
   config.tuiFullscreen = savedTuiFullscreen;
   config.tuiDisableMouse = savedTuiDisableMouse;
@@ -901,4 +905,63 @@ test("PUT /api/settings rejects a non-boolean tuiDisableMouse", async () => {
   const { app } = harness();
   const res = await put(app, { tuiDisableMouse: "yes" });
   expect(res.status).toBe(400);
+});
+
+// ── operatorLanguage ─────────────────────────────────────────────────────────
+
+test("GET /api/settings includes operatorLanguage", async () => {
+  config.operatorLanguage = "en";
+  const { app } = harness();
+  const res = await app.fetch(new Request("http://x/api/settings"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.operatorLanguage).toBe("en");
+});
+
+test("PUT /api/settings sets operatorLanguage to 'de', persists, live-updates, reflected by GET", async () => {
+  config.operatorLanguage = "en";
+  const { app, store } = harness();
+  const res = await put(app, { operatorLanguage: "de" });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.operatorLanguage).toBe("de");
+  expect(config.operatorLanguage as string).toBe("de"); // live
+  expect(store.getSetting("operatorLanguage")).toBe("de"); // persisted
+  const got = await (await app.fetch(new Request("http://x/api/settings"))).json();
+  expect(got.operatorLanguage).toBe("de"); // reflected by a subsequent GET
+});
+
+test("PUT /api/settings rejects an unrecognised operatorLanguage value → 400", async () => {
+  config.operatorLanguage = "en";
+  const { app } = harness();
+  for (const bad of ["fr", "", 42, null, true]) {
+    const res = await put(app, { operatorLanguage: bad });
+    expect(res.status).toBe(400);
+  }
+  expect(config.operatorLanguage).toBe("en"); // unchanged on failure
+});
+
+test("a persisted operatorLanguage row overrides the env seed at boot hydration", () => {
+  // Mirrors the hydration snippet in src/index.ts: a UI-set row wins over whatever
+  // the env seed produced.
+  const store = new SessionStore(":memory:");
+  store.setSetting("operatorLanguage", "de");
+  config.operatorLanguage = "en"; // simulate the env-seeded default having booted first
+  const savedOl = store.getSetting("operatorLanguage");
+  expect(savedOl).not.toBeNull();
+  if (savedOl !== null) {
+    const v = normalizeOperatorLanguage(savedOl);
+    if (v !== null) config.operatorLanguage = v;
+  }
+  expect(config.operatorLanguage).toBe("de"); // the persisted row won
+});
+
+test("OPERATOR_LANGUAGES is set-equal to the UI's Paraglide locales", () => {
+  const settingsPath = join(import.meta.dir, "..", "ui", "project.inlang", "settings.json");
+  const parsed = JSON.parse(readFileSync(settingsPath, "utf8")) as { locales: string[] };
+  const locales = new Set(parsed.locales);
+  const opLangs = new Set(OPERATOR_LANGUAGES as readonly string[]);
+  expect(locales.size).toBe(opLangs.size);
+  for (const l of locales) expect(opLangs.has(l)).toBe(true);
+  for (const l of opLangs) expect(locales.has(l)).toBe(true);
 });

--- a/test/service-plan-gate.test.ts
+++ b/test/service-plan-gate.test.ts
@@ -137,3 +137,70 @@ test("planBlockInstructions(INTERACTIVE) drops AskUserQuestion for codex, keeps 
     "AskUserQuestion",
   );
 });
+
+// ─── operator-language injection (Task 4, issue #1586) ──────────────────────
+
+test("en is byte-identical: composeSystemPrompt with/without explicit operatorLanguage:'en'", () => {
+  const representativeOpts = [
+    { planGate: "interactive" as const },
+    { planGate: "auto" as const },
+    {},
+    { agentProvider: "codex" as const },
+    { planGate: "interactive" as const, agentProvider: "codex" as const },
+  ];
+  for (const opts of representativeOpts) {
+    const withoutLang = composeSystemPrompt(null, false, opts);
+    const withEnLang = composeSystemPrompt(null, false, { ...opts, operatorLanguage: "en" });
+    expect(withEnLang).toBe(withoutLang);
+    expect(withoutLang).not.toContain("operator-language");
+    expect(withEnLang).not.toContain("operator-language");
+  }
+});
+
+test("en is byte-identical: planBlockInstructions with/without explicit operatorLanguage:'en'", () => {
+  for (const allowQuestionForm of [true, false]) {
+    const withoutLang = planBlockInstructions({ allowQuestionForm });
+    const withEnLang = planBlockInstructions({ allowQuestionForm, operatorLanguage: "en" });
+    expect(withEnLang).toBe(withoutLang);
+  }
+});
+
+test("import-time PLAN_GATE_DIRECTIVE constants render as 'en' regardless of env (import-time-constant trap)", () => {
+  // These are computed at module-import time with the literal "en" default — never config.operatorLanguage.
+  // This documents the contract: they must never carry the German directive or field-discipline text,
+  // even when SHEPHERD_OPERATOR_LANGUAGE=de is set in the environment.
+  for (const d of [PLAN_GATE_DIRECTIVE_INTERACTIVE, PLAN_GATE_DIRECTIVE_AUTO]) {
+    expect(d).not.toContain("operator-language");
+    // visualBlockLanguageLine("de")'s distinctive marker — must never appear in the "en"-rendered constant.
+    expect(d).not.toContain("write ONLY these natural-language fields");
+  }
+});
+
+test("de injects <operator-language> naming German, for both claude and codex", () => {
+  const claude = composeSystemPrompt(null, false, { operatorLanguage: "de" });
+  const codex = composeSystemPrompt(null, false, {
+    operatorLanguage: "de",
+    agentProvider: "codex",
+  });
+  for (const p of [claude, codex]) {
+    expect(p).toContain("<operator-language>");
+    expect(p).toContain("German");
+  }
+});
+
+test("de plan sidecar instructions carry the field-discipline verbatim-fields line", () => {
+  const t = planBlockInstructions({ allowQuestionForm: true, operatorLanguage: "de" });
+  for (const field of [
+    "type",
+    "id",
+    "tone",
+    "change",
+    "path",
+    "mermaid.source",
+    "method",
+    "surface",
+    "kind",
+  ]) {
+    expect(t).toContain(field);
+  }
+});

--- a/test/visual-blocks.test.ts
+++ b/test/visual-blocks.test.ts
@@ -2442,4 +2442,92 @@ describe("groundPlanBlocks", () => {
     expect(blk.type).toBe("rich-text");
     expect((blk as unknown as Record<string, unknown>).inferred).toBeUndefined();
   });
+
+  // ── German operator-language plan sidecar round-trip (Task 4, issue #1586) ──
+  // Proves visualBlockLanguageLine's field rules keep a real German sidecar parseable:
+  // translatable fields carry German prose, machine fields (type/id/tone/change/kind/surface/path)
+  // stay verbatim, and nothing gets silently dropped by parseVisualBlocks or groundPlanBlocks.
+  it("a German plan-blocks fixture round-trips through parseVisualBlocks + groundPlanBlocks with zero drops", () => {
+    const raw = [
+      { type: "rich-text", id: "r1", markdown: "Diese Änderung fügt die Sprachpräferenz hinzu." },
+      {
+        type: "callout",
+        id: "c1",
+        tone: "info",
+        markdown: "Hinweis: die Konfiguration wird pro Betreiber gespeichert.",
+      },
+      {
+        type: "file-tree",
+        id: "ft1",
+        title: "Geplante Dateien",
+        entries: [
+          {
+            path: "src/operator-language.ts",
+            change: "added",
+            note: "Neues Modul für die Sprachdirektive.",
+          },
+          {
+            path: "src/service.ts",
+            change: "modified",
+            note: "Direktive wird hier eingefügt.",
+          },
+        ],
+      },
+      {
+        type: "mermaid",
+        id: "m1",
+        source: "flowchart TD\n  A[Config] --> B[Service]",
+        caption: "Ablauf der Sprachdirektive durch den Service.",
+      },
+      {
+        type: "table",
+        id: "t1",
+        columns: ["Feld", "Beschreibung"],
+        rows: [["operatorLanguage", "Bevorzugte Sprache des Betreibers"]],
+      },
+      {
+        type: "wireframe",
+        id: "w1",
+        surface: "browser",
+        html: "<div>Einstellungen</div>",
+        caption: "Mockup der Spracheinstellung.",
+      },
+      {
+        type: "question-form",
+        id: "qf1",
+        questions: [
+          {
+            id: "q1",
+            prompt: "Welche Sprache soll der Agent standardmäßig verwenden?",
+            kind: "single",
+            options: ["Englisch", "Deutsch"],
+          },
+        ],
+      },
+    ];
+
+    const parsed = parseVisualBlocks(raw);
+    expect(parsed).toHaveLength(raw.length); // zero blocks dropped by the validator stage
+
+    const grounded = groundPlanBlocks(parsed);
+    expect(grounded).toHaveLength(raw.length); // zero blocks dropped by the plan-grounding stage
+
+    // type/id uniqueness + verbatim machine fields survive intact
+    const byId = new Map(grounded.map((b) => [b.id, b]));
+    expect(byId.size).toBe(raw.length); // ids stayed unique
+
+    const callout = asBlock(byId.get("c1"), "callout");
+    expect(callout.tone).toBe("info");
+    expect(callout.markdown).toContain("Betreiber");
+
+    const fileTree = asBlock(byId.get("ft1"), "file-tree");
+    expect(fileTree.entries.map((e) => e.change)).toEqual(["added", "modified"]);
+
+    const questionForm = asBlock(byId.get("qf1"), "question-form");
+    expect(questionForm.questions[0]!.kind).toBe("single");
+    expect(questionForm.questions[0]!.prompt).toContain("Sprache");
+
+    const wireframe = asBlock(byId.get("w1"), "wireframe");
+    expect(wireframe.surface).toBe("browser");
+  });
 });

--- a/test/visual-blocks.test.ts
+++ b/test/visual-blocks.test.ts
@@ -832,6 +832,117 @@ describe("groundBlocks", () => {
   });
 });
 
+// ── groundBlocks: a translated path/filename is silently dropped, verbatim survives (Task 5,
+// issue #1586) — this is WHY `path`/`filename` are on the VisualBlock verbatim field list in
+// operator-language.ts: if the agent ever "translated" one of these instead of copying it
+// verbatim, grounding can no longer match it back to the real diff and drops it (or the whole
+// block).
+describe("groundBlocks: translated path/filename is dropped", () => {
+  const fooFile: DiffFile = {
+    path: "src/foo.ts",
+    status: "modified",
+    additions: 5,
+    deletions: 2,
+    binary: false,
+    hunks: [],
+  };
+  const barFile: DiffFile = {
+    path: "src/bar.ts",
+    status: "added",
+    additions: 10,
+    deletions: 0,
+    binary: false,
+    hunks: [],
+  };
+  const addedFile = makeAddedFile("src/new.ts", ["const x = 1;"]);
+
+  describe("carrier present (pendingDiff non-empty)", () => {
+    it("file-tree: one entry with a translated (non-matching) path is dropped, verbatim path survives", () => {
+      const blocks = parseVisualBlocks([
+        {
+          type: "file-tree",
+          id: "ft1",
+          entries: [
+            { path: "src/foo.ts", change: "modified" }, // verbatim — survives
+            { path: "src/foo-übersetzt.ts", change: "modified" }, // "translated" — dropped
+          ],
+        },
+      ]);
+      const result = groundBlocks(blocks, [fooFile], ["src/foo.ts"]);
+      expect(result).toHaveLength(1);
+      const blk = asBlock(result[0], "file-tree");
+      expect(blk.entries).toHaveLength(1);
+      expect(blk.entries[0]!.path).toBe("src/foo.ts");
+    });
+
+    it("file-tree: EVERY entry's path is translated (non-matching) → whole block dropped", () => {
+      const blocks = parseVisualBlocks([
+        {
+          type: "file-tree",
+          id: "ft1",
+          entries: [{ path: "src/foo-übersetzt.ts", change: "modified" }],
+        },
+      ]);
+      const result = groundBlocks(blocks, [fooFile], ["src/foo.ts"]);
+      expect(result).toEqual([]);
+    });
+
+    it("diff: a translated (non-matching) path is dropped by joinDiffBlocks; verbatim path survives", () => {
+      const blocks = parseVisualBlocks([
+        { type: "diff", id: "d1", path: "src/foo.ts", summary: "verbatim — kept" },
+        { type: "diff", id: "d2", path: "src/foo-übersetzt.ts", summary: "translated — dropped" },
+      ]);
+      const result = groundBlocks(blocks, [fooFile, barFile], ["src/foo.ts", "src/bar.ts"]);
+      expect(result).toHaveLength(1);
+      const blk = asBlock(result[0], "diff");
+      expect(blk.id).toBe("d1");
+      expect(blk.file).toBe(fooFile);
+    });
+
+    it("code: a translated (non-matching) filename is dropped by joinCodeBlocks", () => {
+      const blocks = parseVisualBlocks([
+        { type: "code", id: "c1", filename: "src/neu.ts" }, // translated filename — never matches
+      ]);
+      const result = groundBlocks(blocks, [addedFile], ["src/new.ts"]);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("carrier miss (pendingDiff empty — fallback path)", () => {
+    it("file-tree: entries are filtered against changedFiles; a translated path is dropped, verbatim survives", () => {
+      const blocks = parseVisualBlocks([
+        {
+          type: "file-tree",
+          id: "ft1",
+          entries: [
+            { path: "src/foo.ts", change: "modified" }, // verbatim — matches changedFiles
+            { path: "src/foo-übersetzt.ts", change: "modified" }, // translated — dropped
+          ],
+        },
+      ]);
+      const result = groundBlocks(blocks, [], ["src/foo.ts"]);
+      expect(result).toHaveLength(1);
+      const blk = asBlock(result[0], "file-tree");
+      expect(blk.entries).toHaveLength(1);
+      expect(blk.entries[0]!.path).toBe("src/foo.ts");
+    });
+
+    it("diff: dropped unconditionally, even with a verbatim path (no real hunks to ground against)", () => {
+      const blocks = parseVisualBlocks([
+        { type: "diff", id: "d1", path: "src/foo.ts", summary: "x" },
+      ]);
+      const result = groundBlocks(blocks, [], ["src/foo.ts"]);
+      expect(result).toEqual([]);
+    });
+
+    it("code: dropped unconditionally, even with a verbatim filename (no real hunks to ground against)", () => {
+      const blocks = parseVisualBlocks([{ type: "code", id: "c1", filename: "src/new.ts" }]);
+      const result = groundBlocks(blocks, [], ["src/new.ts"]);
+      expect(result).toEqual([]);
+    });
+  });
+});
+
 // ── constant arrays ────────────────────────────────────────────────────────────
 
 describe("constant arrays", () => {

--- a/test/visual-blocks.test.ts
+++ b/test/visual-blocks.test.ts
@@ -116,6 +116,13 @@ describe("parseVisualBlocks", () => {
       const result = parseVisualBlocks(["string-item", 5, null]);
       expect(result).toEqual([]);
       expect(warn.mock.calls.length).toBeGreaterThan(0);
+      // non-object items have no type/id to read — the standard warn shape must still
+      // report a type=/id= pair, using "<none>" for both rather than a distinct message.
+      for (const call of warn.mock.calls) {
+        const msg = call[0] as string;
+        expect(msg).toContain('type="<none>"');
+        expect(msg).toContain('id="<none>"');
+      }
     } finally {
       warn.mockRestore();
     }
@@ -141,20 +148,42 @@ describe("parseVisualBlocks", () => {
     }
   });
 
-  it("(hygiene) sanitizes type and id containing control characters", () => {
+  it("(hygiene) (B)-path: sanitizes type and id containing control characters on a dropped block", () => {
     const warn = spyOn(console, "warn");
     try {
+      // "rich-text\n\r" is not a known type (VALIDATORS lookup is exact-match), so this
+      // block is rejected at (B) — its id is never reserved.
       const result = parseVisualBlocks([
-        { type: "rich-text\n\r", id: "id\x1b[31m", markdown: "first" },
-        { type: "callout", id: "id\x1b[31m", tone: "info", markdown: "second" },
+        { type: "rich-text\n\r", id: "id\x1b[31m", markdown: "x" },
+      ]);
+      expect(result).toEqual([]);
+      expect(warn).toHaveBeenCalledTimes(1);
+      const msg = warn.mock.calls[0]?.[0] as string;
+      expect(msg).not.toContain("\n");
+      expect(msg).not.toContain("\r");
+      expect(msg).not.toContain("\x1b");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("(hygiene) (C)-path: sanitizes duplicate id containing control characters on a real dedup collision", () => {
+    const warn = spyOn(console, "warn");
+    try {
+      // Both blocks validate successfully and share the same (control-character-laden) id —
+      // this is a genuine dedup collision, unlike feeding an already-rejected first block.
+      const result = parseVisualBlocks([
+        { type: "rich-text", id: "id\x1b[31m\n\r", markdown: "first" },
+        { type: "callout", id: "id\x1b[31m\n\r", tone: "info", markdown: "second" },
       ]);
       expect(result).toHaveLength(1);
-      for (const call of warn.mock.calls) {
-        const msg = call[0] as string;
-        expect(msg).not.toContain("\n");
-        expect(msg).not.toContain("\r");
-        expect(msg).not.toContain("\x1b");
-      }
+      expect(result[0]!.type).toBe("rich-text"); // first kept, second (duplicate) dropped
+      expect(warn).toHaveBeenCalledTimes(1);
+      const msg = warn.mock.calls[0]?.[0] as string;
+      expect(msg).toContain("duplicate");
+      expect(msg).not.toContain("\n");
+      expect(msg).not.toContain("\r");
+      expect(msg).not.toContain("\x1b");
     } finally {
       warn.mockRestore();
     }

--- a/test/visual-blocks.test.ts
+++ b/test/visual-blocks.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import type { DiffFile, DiffHunk } from "../src/types";
 import type { VisualBlock } from "../src/visual-blocks";
 
@@ -36,6 +36,147 @@ describe("parseVisualBlocks", () => {
     expect(parseVisualBlocks("string")).toEqual([]);
     expect(parseVisualBlocks(42)).toEqual([]);
     expect(parseVisualBlocks({ type: "rich-text", id: "1", markdown: "x" })).toEqual([]);
+  });
+
+  it("(A) warns when blocks is present but non-array (mangled blocks field)", () => {
+    const warn = spyOn(console, "warn");
+    try {
+      expect(parseVisualBlocks("nope")).toEqual([]);
+      expect(warn).toHaveBeenCalledTimes(1);
+      const msg = warn.mock.calls[0]?.[0] as string;
+      expect(msg).toContain("[visual-blocks]");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("(A) warns for non-array object", () => {
+    const warn = spyOn(console, "warn");
+    try {
+      expect(parseVisualBlocks({})).toEqual([]);
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("(A) warns for number as blocks", () => {
+    const warn = spyOn(console, "warn");
+    try {
+      expect(parseVisualBlocks(42)).toEqual([]);
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("(A) stays silent when blocks is undefined (legitimate)", () => {
+    const warn = spyOn(console, "warn");
+    try {
+      expect(parseVisualBlocks(undefined)).toEqual([]);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("(B) warns when parseBlock rejects with unknown type", () => {
+    const warn = spyOn(console, "warn");
+    try {
+      const result = parseVisualBlocks([{ type: "fancy-thing", id: "block1", markdown: "x" }]);
+      expect(result).toEqual([]);
+      expect(warn).toHaveBeenCalledTimes(1);
+      const msg = warn.mock.calls[0]?.[0] as string;
+      expect(msg).toContain("fancy-thing");
+      expect(msg).toContain("block1");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("(B) warns when parseBlock rejects with invalid enum", () => {
+    const warn = spyOn(console, "warn");
+    try {
+      const result = parseVisualBlocks([
+        { type: "callout", id: "c1", tone: "invalid-tone", markdown: "x" },
+      ]);
+      expect(result).toEqual([]);
+      expect(warn).toHaveBeenCalledTimes(1);
+      const msg = warn.mock.calls[0]?.[0] as string;
+      expect(msg).toContain("callout");
+      expect(msg).toContain("c1");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("(B) defensive read: warns for non-object item in array without throwing", () => {
+    const warn = spyOn(console, "warn");
+    try {
+      const result = parseVisualBlocks(["string-item", 5, null]);
+      expect(result).toEqual([]);
+      expect(warn.mock.calls.length).toBeGreaterThan(0);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("(C) warns for duplicate id", () => {
+    const warn = spyOn(console, "warn");
+    try {
+      const result = parseVisualBlocks([
+        { type: "rich-text", id: "dup", markdown: "first" },
+        { type: "callout", id: "dup", tone: "info", markdown: "second" },
+      ]);
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe("dup");
+      expect(result[0]!.type).toBe("rich-text");
+      expect(warn).toHaveBeenCalledTimes(1);
+      const msg = warn.mock.calls[0]?.[0] as string;
+      expect(msg).toContain("duplicate");
+      expect(msg).toContain("dup");
+      expect(msg).toContain("callout");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("(hygiene) sanitizes type and id containing control characters", () => {
+    const warn = spyOn(console, "warn");
+    try {
+      const result = parseVisualBlocks([
+        { type: "rich-text\n\r", id: "id\x1b[31m", markdown: "first" },
+        { type: "callout", id: "id\x1b[31m", tone: "info", markdown: "second" },
+      ]);
+      expect(result).toHaveLength(1);
+      for (const call of warn.mock.calls) {
+        const msg = call[0] as string;
+        expect(msg).not.toContain("\n");
+        expect(msg).not.toContain("\r");
+        expect(msg).not.toContain("\x1b");
+      }
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("(hygiene) clamps very long type/id strings", () => {
+    const warn = spyOn(console, "warn");
+    try {
+      const longType = "a".repeat(200);
+      const longId = "b".repeat(200);
+      const result = parseVisualBlocks([
+        { type: longType, id: longId, markdown: "x" },
+        { type: "callout", id: longId, tone: "info", markdown: "y" },
+      ]);
+      expect(result).toHaveLength(1);
+      for (const call of warn.mock.calls) {
+        const msg = call[0] as string;
+        expect(msg.length).toBeLessThan(300);
+      }
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("drops blocks with missing id", () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2804,5 +2804,7 @@
   "hold_cta_resume_failed": "Plan-Review konnte nicht fortgesetzt werden. Erneut versuchen.",
   "settings_operator_language_title": "Betreibersprache",
   "settings_operator_language_hint": "Die Sprache, in der Shepherds Agenten mit dir sprechen — Status, Rückfragen, Pläne, Übergaben. Unabhängig von der Sprache dieser Oberfläche. Code, Befehle, Logs und GitHub-Texte bleiben in ihrer Originalsprache.",
-  "settings_operator_language_save_failed": "Betreibersprache konnte nicht gespeichert werden."
+  "settings_operator_language_save_failed": "Betreibersprache konnte nicht gespeichert werden.",
+  "feat_operator_language_title": "Agenten sprechen deine Sprache",
+  "feat_operator_language_body": "Lege in den Einstellungen eine Betreibersprache fest, und Shepherds gestartete Agenten verfassen ihre Statusupdates, Rückfragen, Planerklärungen und Übergaben in dieser Sprache. Code, Befehle, Logs, Commit-Nachrichten und GitHub-Issue-/PR-Texte bleiben in ihrer Originalsprache."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2801,5 +2801,8 @@
   "feat_hold_cta_title": "Blockierte Sessions direkt in der Zeile bearbeiten",
   "feat_hold_cta_body": "Eine im Plan-Gate blockierte Session erklärt jetzt direkt in ihrer Zeile, worauf sie wartet — wartet auf erneute Prüfung, Plan freigegeben oder Review festgefahren — und bietet die passende Ein-Klick-Aktion (Erneut prüfen, Los, Fortsetzen oder Antworten), ohne die Session zu öffnen.",
   "hold_cta_go_failed": "Ausführung konnte nicht gestartet werden. Erneut versuchen.",
-  "hold_cta_resume_failed": "Plan-Review konnte nicht fortgesetzt werden. Erneut versuchen."
+  "hold_cta_resume_failed": "Plan-Review konnte nicht fortgesetzt werden. Erneut versuchen.",
+  "settings_operator_language_title": "Betreibersprache",
+  "settings_operator_language_hint": "Die Sprache, in der Shepherds Agenten mit dir sprechen — Status, Rückfragen, Pläne, Übergaben. Unabhängig von der Sprache dieser Oberfläche. Code, Befehle, Logs und GitHub-Texte bleiben in ihrer Originalsprache.",
+  "settings_operator_language_save_failed": "Betreibersprache konnte nicht gespeichert werden."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2804,5 +2804,7 @@
   "hold_cta_resume_failed": "Couldn't resume the plan review. Try again.",
   "settings_operator_language_title": "Operator language",
   "settings_operator_language_hint": "The language Shepherd's agents use to talk to you — status, questions, plans, handoffs. Independent of this interface's language. Code, commands, logs, and GitHub text stay in their original language.",
-  "settings_operator_language_save_failed": "Couldn't save the operator language."
+  "settings_operator_language_save_failed": "Couldn't save the operator language.",
+  "feat_operator_language_title": "Agents can speak your language",
+  "feat_operator_language_body": "Set an operator language in Settings and Shepherd's spawned agents write their status updates, questions, plan explanations, and handoffs in that language. Code, commands, logs, commit messages, and GitHub issue/PR text stay in their original language."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2801,5 +2801,8 @@
   "feat_hold_cta_title": "Act on parked sessions from the row",
   "feat_hold_cta_body": "A parked plan-gate session now explains why it's waiting right on its row — awaiting re-review, plan approved, or review stuck — and offers the matching one-click action (Re-review, Go, Resume, or Answer) without opening the session.",
   "hold_cta_go_failed": "Couldn't start execution. Try again.",
-  "hold_cta_resume_failed": "Couldn't resume the plan review. Try again."
+  "hold_cta_resume_failed": "Couldn't resume the plan review. Try again.",
+  "settings_operator_language_title": "Operator language",
+  "settings_operator_language_hint": "The language Shepherd's agents use to talk to you — status, questions, plans, handoffs. Independent of this interface's language. Code, commands, logs, and GitHub text stay in their original language.",
+  "settings_operator_language_save_failed": "Couldn't save the operator language."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -564,6 +564,10 @@ export const putDefaultModel = (model: string): Promise<{ defaultModel: string }
 export const putDefaultEffort = (effort: string): Promise<{ defaultEffort: string }> =>
   patchSettings<{ defaultEffort: string }>({ defaultEffort: effort });
 
+// Persist the language spawned agents use to talk to the operator ("en" | "de").
+export const putOperatorLanguage = (lang: string): Promise<{ operatorLanguage: string }> =>
+  patchSettings<{ operatorLanguage: string }>({ operatorLanguage: lang });
+
 export const putDefaultAgentProvider = (
   provider: AgentProvider,
 ): Promise<{ defaultAgentProvider: AgentProvider }> =>

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -56,6 +56,7 @@ function settings(over: Partial<SettingsPayload> = {}): SettingsPayload {
     sessionHousekeepingEnabled: true,
     defaultModel: "auto",
     defaultEffort: "default",
+    operatorLanguage: "en",
     criticCli: "inherit",
     criticModel: "default",
     criticEffort: "high",

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -1018,6 +1018,17 @@
     }
   }
 
+  // Apply the model / effort / operator-language preference trio from a loaded settings payload.
+  // Extracted from onMount so each added preference doesn't grow that handler's branch count.
+  function applyModelPrefs(s: Awaited<ReturnType<typeof getSettings>>) {
+    defaultModel = s.defaultModel ?? "auto";
+    defaultModelSaved = defaultModel;
+    defaultEffort = s.defaultEffort ?? "default";
+    defaultEffortSaved = defaultEffort;
+    operatorLanguage = s.operatorLanguage ?? "en";
+    operatorLanguageSaved = operatorLanguage;
+  }
+
   onMount(async () => {
     try {
       const s = await getSettings();
@@ -1033,12 +1044,7 @@
       planReviewCyclesMax = s.planReviewCyclesMax;
       planReviewCycles = s.planReviewCyclesCap;
       planReviewCyclesSaved = s.planReviewCyclesCap;
-      defaultModel = s.defaultModel ?? "auto";
-      defaultModelSaved = defaultModel;
-      defaultEffort = s.defaultEffort ?? "default";
-      defaultEffortSaved = defaultEffort;
-      operatorLanguage = s.operatorLanguage ?? "en";
-      operatorLanguageSaved = operatorLanguage;
+      applyModelPrefs(s);
       // Fall back to the seed default per role when a field is absent (e.g. an older backend that
       // predates per-role environments) so the pickers never render blank — a sensible default is
       // always shown.

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -8,6 +8,7 @@
     putPlanReviewCyclesCap,
     putDefaultModel,
     putDefaultEffort,
+    putOperatorLanguage,
     putRoleModel,
     putRoleEffort,
     putRoleCli,
@@ -260,6 +261,9 @@
   let defaultEffort = $state("default"); // raw default-effort setting ("default"|<tier>)
   let defaultEffortSaved = "default"; // last server-confirmed value, for revert on failure
   let defaultEffortBusy = $state(false);
+  let operatorLanguage = $state("en"); // language spawned agents use to talk to the operator
+  let operatorLanguageSaved = "en"; // last server-confirmed, for revert on failure
+  let operatorLanguageBusy = $state(false);
   let defaultAgentProvider = $state<AgentProvider>("claude");
   let defaultAgentProviderSaved: AgentProvider = "claude";
   let defaultAgentProviderBusy = $state(false);
@@ -621,6 +625,25 @@
       });
     } finally {
       defaultEffortBusy = false;
+    }
+  }
+
+  async function saveOperatorLanguage() {
+    if (operatorLanguageBusy) return;
+    operatorLanguageBusy = true;
+    try {
+      const r = await putOperatorLanguage(operatorLanguage);
+      operatorLanguage = r.operatorLanguage;
+      operatorLanguageSaved = r.operatorLanguage;
+    } catch {
+      operatorLanguage = operatorLanguageSaved;
+      toasts.info(m.settings_operator_language_save_failed(), {
+        key: "operator-language",
+        duration: null,
+        alert: true,
+      });
+    } finally {
+      operatorLanguageBusy = false;
     }
   }
 
@@ -1014,6 +1037,8 @@
       defaultModelSaved = defaultModel;
       defaultEffort = s.defaultEffort ?? "default";
       defaultEffortSaved = defaultEffort;
+      operatorLanguage = s.operatorLanguage ?? "en";
+      operatorLanguageSaved = operatorLanguage;
       // Fall back to the seed default per role when a field is absent (e.g. an older backend that
       // predates per-role environments) so the pickers never render blank — a sensible default is
       // always shown.
@@ -1235,6 +1260,20 @@
             {#each EFFORTS as tier (tier)}
               <option value={tier}>{effortLabel(tier)}</option>
             {/each}
+          </select>
+        </div>
+        <div class="rc">
+          <span class="micro">{m.settings_operator_language_title()}</span>
+          <p class="hint">{m.settings_operator_language_hint()}</p>
+          <select
+            class="model-select"
+            bind:value={operatorLanguage}
+            disabled={operatorLanguageBusy}
+            aria-label={m.settings_operator_language_title()}
+            onchange={saveOperatorLanguage}
+          >
+            <option value="en">{m.lang_english()}</option>
+            <option value="de">{m.lang_german()}</option>
           </select>
         </div>
         <div class="rc">

--- a/ui/src/lib/demo/seed.ts
+++ b/ui/src/lib/demo/seed.ts
@@ -962,6 +962,7 @@ function buildSettings(): Settings {
     sessionHousekeepingEnabled: true,
     defaultModel: "auto",
     defaultEffort: "default",
+    operatorLanguage: "en",
     criticCli: "inherit",
     criticModel: "default",
     criticEffort: "high",

--- a/ui/src/lib/feature-announcements/entries/v1.43.0-operator-language.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.43.0-operator-language.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "operator-language",
+  sinceVersion: "1.43.0",
+  titleKey: "feat_operator_language_title",
+  bodyKey: "feat_operator_language_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -59,6 +59,9 @@ export interface Settings {
   defaultModel: string;
   /** Global default-effort setting ("default"|<tier>); "default" emits no effort flag. */
   defaultEffort: string;
+  /** Language spawned agents use to talk to the operator ("en" | "de"). Independent of the
+   *  interface language — set only from the Settings page. */
+  operatorLanguage: string;
   /** Per-role ENVIRONMENT settings for the helper agents Shepherd spawns: a CLI pair per role.
    *  `<role>Cli` ∈ "inherit" | "claude" | "codex" ("inherit" follows `defaultAgentProvider` +
    *  `defaultModel`); `<role>Model` ∈ "default" | <alias for that CLI>. The Settings UI shows each


### PR DESCRIPTION
Closes #1586.

## What

Lets an operator choose the language Shepherd-spawned agents use to talk to them. When the operator sets **German** (Settings → Operator language, or the `SHEPHERD_OPERATOR_LANGUAGE` env seed), agent-facing prompts get an `<operator-language>` directive so agents write **status updates, questions, plan explanations and handoffs in German**, while **code, commands, identifiers, logs, commit messages, and public GitHub issue/PR text stay in their original language**.

**English (`en`, the default) injects nothing** — spawn prompts are byte-identical to before, verified by regression tests across every mutated prompt surface.

## Surfaces covered (the inclusion rule: ship iff `de` correctness is provable with deterministic tests)

- **Coding-session directive** (`composeSystemPrompt`) — Claude (`--append-system-prompt`) and Codex (inline).
- **Plan sidecar** (`planBlockInstructions`) — the `.shepherd-plan-blocks.json` field discipline.
- **Recap** (`buildRecapPrompt`) — the `.shepherd-recap.json` HUD card.
- **Plan reviewer** (`planReviewPrompt`) — `summary`/`body`/`findings` in German, `decision` verbatim.

Structured-output fields are enumerated exactly: prose is translated, every machine-read field (block `type`, `id`, enums like `tone`/`change`/`kind`, `path`/`filename`, `mermaid.source`, `decision`, `verdict`) is kept verbatim — a translated enum/type would otherwise silently drop a block. A **field-level drift guard** asserts every string field the `VisualBlock` validators read is ruled exactly once, so a new block type can't ship unruled.

## Also included

- **Bug fix (language-independent):** the plan-review empty-`findings` fallback now steers back the **un-clamped** summary instead of the 100-char HUD-clamped one, so a long summary is never truncated mid-word into the agent's only instruction. Fixes `en` and `de` alike.
- **Observability:** `parseVisualBlocks` now warns (sanitized) on dropped/duplicate/non-array blocks, so a field regression is diagnosable instead of a silent empty panel.
- Persisted setting (`SHEPHERD_OPERATOR_LANGUAGE` env seed → DB row override), `PUT /api/settings` handler (400s off-enum), Settings UI control, and a What's-New feature-announcement entry.

## Design guarantees

- **`en` byte-identity** across all four surfaces (null-returns + literal-`"en"` defaults; the `<operator-language>` block rides last).
- **Import-time-constant safety:** `PLAN_GATE_DIRECTIVE_*` module constants never read `config` — the live value enters only at the composition roots / per-spawn getters.
- **Per-spawn reads:** recap/plan-gate read a `() => OperatorLanguage` getter at prompt-build time (a settings change reaches the next spawn); neither imports `./config` (guarded by a source-level test).
- Server-persisted setting is the single source of truth; the LanguageSwitcher is untouched (agent language ≠ device UI locale).

## Explicit deferrals (documented, not silent — see #1586 follow-up)

- **Mid-session drift, both providers:** the directive rides `--append-system-prompt` (dropped on Claude compaction/resume, #499) and Codex's opening prompt only — so a long session can still drift back to English. Threading it onto the resume/steer paths is a follow-up.
- **Autopilot classifier:** its output qualifies but classification quality can't be verified without a live-model eval harness this repo lacks.
- **Server-authored HUD strings** (recap-skipped headlines, the no-verdict line) and **other LLM surfaces** (herd-digest, rundown, up-next, prompt-recommend) — each needs its own analysis.

## Verification

Delivered as 8 subagent-reviewed tasks + a final whole-branch review. Every touched file passes its test suite in isolation; `bun run lint`, UI `bun run check`, `check:i18n`, branch-hygiene, feature-catalog, announcement-version, and the fallow complexity gate all pass. (The full `bun test` shows the repo's usual infra-dependent integration failures — the same count at base — none in touched files.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)