### PR TITLE
fix(build-queue): flag working-but-unreported queues on the badge

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1631,6 +1631,8 @@
   "queuebadge_label": "{resolved}/{total}",
   "queuebadge_title": "Build-Queue: {resolved} von {total} Schritten erledigt",
   "queuebadge_aria": "Build-Queue: {resolved} von {total} Schritten erledigt",
+  "queuebadge_stale_title": "Build-Queue: {total} Schritte, Fortschritt nicht gemeldet – Agent arbeitet, hat aber den Schrittstatus nicht aktualisiert",
+  "queuebadge_stale_aria": "Build-Queue-Fortschritt nicht gemeldet: {total} Schritte, Agent arbeitet, aber Status nicht aktualisiert",
   "feat_build_queue_progress_title": "Build-Queue-Fortschritt auf einen Blick",
   "feat_build_queue_progress_body": "Session-Karten zeigen jetzt ein kleines bernsteinfarbenes Badge mit Fortschrittsbalken, wenn eine genehmigte Build-Queue aktiv ist — erledigte / Gesamtschritte ohne Öffnen des Panels einsehbar.",
   "learnings_optimize": "Optimieren",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1631,6 +1631,8 @@
   "queuebadge_label": "{resolved}/{total}",
   "queuebadge_title": "Build queue: {resolved} of {total} steps done",
   "queuebadge_aria": "Build queue: {resolved} of {total} steps done",
+  "queuebadge_stale_title": "Build queue: {total} steps, progress unreported — agent working but hasn't updated step status",
+  "queuebadge_stale_aria": "Build queue progress unreported: {total} steps, agent working but status not updated",
   "feat_build_queue_progress_title": "Build queue progress at a glance",
   "feat_build_queue_progress_body": "Session cards now show a small amber badge with a progress meter when an approved build queue is active — see resolved / total steps without opening the panel.",
   "learnings_optimize": "Optimize",

--- a/ui/src/lib/components/BuildQueueBadge.browser.test.ts
+++ b/ui/src/lib/components/BuildQueueBadge.browser.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
-import type { BuildQueue, BuildStep, BuildStepStatus } from "$lib/types";
+import type { BuildQueue, BuildStep, BuildStepStatus, GitState } from "$lib/types";
 
 const { default: BuildQueueBadge } = await import("./BuildQueueBadge.svelte");
 const { buildQueues } = await import("$lib/buildQueues.svelte");
@@ -20,6 +20,15 @@ const queue = (approved: boolean, steps: BuildStep[], sessionId = "s1"): BuildQu
   steps,
 });
 
+// Minimal GitState literal — only `state` matters for the drift predicate;
+// the rest are required fields filled with harmless placeholders.
+const git = (state: GitState["state"]): GitState => ({
+  kind: "github",
+  state,
+  checks: "none",
+  deployConfigured: false,
+});
+
 beforeEach(() => {
   buildQueues.map = {};
 });
@@ -33,12 +42,12 @@ describe("BuildQueueBadge", () => {
     buildQueues.map = {
       s1: queue(false, [step("done", "1"), step("pending", "2")]),
     };
-    render(BuildQueueBadge, { sessionId: "s1" });
+    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
     expect(document.querySelector(".queue-badge")).toBeNull();
   });
 
   it("renders nothing when there is no queue for the session", async () => {
-    render(BuildQueueBadge, { sessionId: "s1" });
+    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
     expect(document.querySelector(".queue-badge")).toBeNull();
   });
 
@@ -46,7 +55,7 @@ describe("BuildQueueBadge", () => {
     buildQueues.map = {
       s1: queue(true, []),
     };
-    render(BuildQueueBadge, { sessionId: "s1" });
+    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
     expect(document.querySelector(".queue-badge")).toBeNull();
   });
 
@@ -61,7 +70,7 @@ describe("BuildQueueBadge", () => {
         step("pending", "5"),
       ]),
     };
-    render(BuildQueueBadge, { sessionId: "s1" });
+    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
     await expect.element(page.getByText("4/5")).toBeInTheDocument();
   });
 
@@ -76,7 +85,7 @@ describe("BuildQueueBadge", () => {
         step("pending", "5"),
       ]),
     };
-    render(BuildQueueBadge, { sessionId: "s1" });
+    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
     const badge = document.querySelector(".queue-badge") as HTMLElement;
     expect(badge).not.toBeNull();
     expect(badge.style.getPropertyValue("--queue-pct")).toBe("80%");
@@ -92,7 +101,7 @@ describe("BuildQueueBadge", () => {
         step("done", "5"),
       ]),
     };
-    render(BuildQueueBadge, { sessionId: "s1" });
+    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
     await expect.element(page.getByText("5/5")).toBeInTheDocument();
     const badge = document.querySelector(".queue-badge") as HTMLElement;
     expect(badge.style.getPropertyValue("--queue-pct")).toBe("100%");
@@ -108,7 +117,94 @@ describe("BuildQueueBadge", () => {
         step("done", "5"),
       ]),
     };
-    render(BuildQueueBadge, { sessionId: "s1" });
+    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
     await expect.element(page.getByText("5/5")).toBeInTheDocument();
+  });
+});
+
+describe("BuildQueueBadge — drifted (working but unreported)", () => {
+  const allPending = [step("pending", "1"), step("pending", "2"), step("pending", "3")];
+
+  const expectDrifted = async () => {
+    await expect.element(page.getByText("⚠ 3")).toBeInTheDocument();
+    expect(document.querySelector(".queue-badge--stale")).not.toBeNull();
+  };
+
+  const expectNotDrifted = async () => {
+    expect(document.querySelector(".queue-badge--stale")).toBeNull();
+    expect(document.querySelector(".queue-badge")).not.toBeNull();
+  };
+
+  it("executing + no git + all pending → drifted (git not consulted)", async () => {
+    buildQueues.map = { s1: queue(true, allPending) };
+    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
+    await expectDrifted();
+  });
+
+  it("planPhase null (gate off) + no git + all pending → drifted", async () => {
+    buildQueues.map = { s1: queue(true, allPending) };
+    render(BuildQueueBadge, { sessionId: "s1", planPhase: null });
+    await expectDrifted();
+  });
+
+  it("planning + open PR + all pending → drifted", async () => {
+    buildQueues.map = { s1: queue(true, allPending) };
+    render(BuildQueueBadge, { sessionId: "s1", planPhase: "planning", git: git("open") });
+    await expectDrifted();
+  });
+
+  it("planning + merged PR + all pending → NOT drifted (resolved PR)", async () => {
+    buildQueues.map = { s1: queue(true, allPending) };
+    render(BuildQueueBadge, { sessionId: "s1", planPhase: "planning", git: git("merged") });
+    await expectNotDrifted();
+  });
+
+  it("planning + closed PR + all pending → NOT drifted", async () => {
+    buildQueues.map = { s1: queue(true, allPending) };
+    render(BuildQueueBadge, { sessionId: "s1", planPhase: "planning", git: git("closed") });
+    await expectNotDrifted();
+  });
+
+  it("planning + no git + all pending → NOT drifted (degrade closed)", async () => {
+    buildQueues.map = { s1: queue(true, allPending) };
+    render(BuildQueueBadge, { sessionId: "s1", planPhase: "planning" });
+    await expectNotDrifted();
+  });
+
+  it('planning + git state "none" + all pending → NOT drifted', async () => {
+    buildQueues.map = { s1: queue(true, allPending) };
+    render(BuildQueueBadge, { sessionId: "s1", planPhase: "planning", git: git("none") });
+    await expectNotDrifted();
+  });
+
+  it("executing + no git + one active, rest pending → NOT drifted (has active)", async () => {
+    buildQueues.map = {
+      s1: queue(true, [step("active", "1"), step("pending", "2"), step("pending", "3")]),
+    };
+    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
+    await expectNotDrifted();
+  });
+
+  it("executing + no git + one done, rest pending → NOT drifted (normal progress)", async () => {
+    buildQueues.map = {
+      s1: queue(true, [step("done", "1"), step("pending", "2"), step("pending", "3")]),
+    };
+    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
+    await expectNotDrifted();
+    await expect.element(page.getByText("1/3")).toBeInTheDocument();
+  });
+
+  it("clears automatically once a step becomes active", async () => {
+    buildQueues.map = { s1: queue(true, allPending) };
+    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
+    await expectDrifted();
+
+    buildQueues.map = {
+      s1: queue(true, [step("active", "1"), step("pending", "2"), step("pending", "3")]),
+    };
+    // Reactivity is async (Svelte flushes on a microtask) — poll for the
+    // resolved/total label rather than asserting synchronously.
+    await expect.element(page.getByText("0/3")).toBeInTheDocument();
+    expect(document.querySelector(".queue-badge--stale")).toBeNull();
   });
 });

--- a/ui/src/lib/components/BuildQueueBadge.svelte
+++ b/ui/src/lib/components/BuildQueueBadge.svelte
@@ -2,8 +2,13 @@
   import { buildQueues } from "$lib/buildQueues.svelte";
   import { m } from "$lib/paraglide/messages";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
+  import type { Session, GitState } from "$lib/types";
 
-  let { sessionId }: { sessionId: string } = $props();
+  let {
+    sessionId,
+    planPhase,
+    git,
+  }: { sessionId: string; planPhase: Session["planPhase"]; git?: GitState } = $props();
 
   const queue = $derived(buildQueues.map[sessionId] ?? null);
   const total = $derived(queue?.steps.length ?? 0);
@@ -11,19 +16,47 @@
     queue?.steps.filter((s) => s.status === "done" || s.status === "skipped").length ?? 0,
   );
   const pct = $derived(total > 0 ? (resolved / total) * 100 : 0);
+
+  // "Working but unreported": the agent is past planning (or has an open PR
+  // already up, which only happens mid/post-implementation) yet EVERY step
+  // still sits at `pending` — none active, none done/skipped — so the agent
+  // isn't posting step status at all. Note this requires *all* steps pending,
+  // not merely "some": a queue with real (partial) resolved/total progress
+  // (e.g. 4/5) is normal progress, not a stale/unreported queue, even though
+  // one step remains pending.
+  const prPresent = $derived(git?.state === "open");
+  const working = $derived(planPhase !== "planning" || prPresent);
+  const drifted = $derived(
+    (queue?.approved ?? false) &&
+      total > 0 &&
+      (queue?.steps.every((s) => s.status === "pending") ?? false) &&
+      working,
+  );
 </script>
 
 {#if queue?.approved && total > 0}
-  <span
-    class="queue-badge"
-    role="img"
-    style="--queue-pct: {pct}%"
-    title={m.queuebadge_title({ resolved, total })}
-    aria-label={m.queuebadge_aria({ resolved, total })}
-    use:coachTarget={"build-queue-progress"}
-  >
-    <span class="queue-label">{m.queuebadge_label({ resolved, total })}</span>
-  </span>
+  {#if drifted}
+    <span
+      class="queue-badge queue-badge--stale"
+      role="img"
+      title={m.queuebadge_stale_title({ total })}
+      aria-label={m.queuebadge_stale_aria({ total })}
+      use:coachTarget={"build-queue-progress"}
+    >
+      <span class="queue-label">⚠ {total}</span>
+    </span>
+  {:else}
+    <span
+      class="queue-badge"
+      role="img"
+      style="--queue-pct: {pct}%"
+      title={m.queuebadge_title({ resolved, total })}
+      aria-label={m.queuebadge_aria({ resolved, total })}
+      use:coachTarget={"build-queue-progress"}
+    >
+      <span class="queue-label">{m.queuebadge_label({ resolved, total })}</span>
+    </span>
+  {/if}
 {/if}
 
 <style>
@@ -50,5 +83,31 @@
       color-mix(in srgb, var(--color-amber) 22%, transparent) var(--queue-pct),
       transparent var(--queue-pct)
     );
+  }
+
+  /* STALE (drifted): agent is working but hasn't posted step status, so every
+     step still reads `pending`. A left-fill wash at 0% would look identical to
+     "nothing started" — actively misleading — so this state drops --queue-pct
+     entirely in favor of a moving diagonal stripe: same amber hue (still
+     "attention", never red/green), but a texture that reads as "unknown/in
+     motion" rather than a measured 0%. */
+  .queue-badge--stale {
+    background: repeating-linear-gradient(
+      -45deg,
+      color-mix(in srgb, var(--color-amber) 22%, transparent) 0,
+      color-mix(in srgb, var(--color-amber) 22%, transparent) 4px,
+      transparent 4px,
+      transparent 8px
+    );
+    animation: queue-badge-stale-scroll 1.2s linear infinite;
+  }
+
+  @keyframes queue-badge-stale-scroll {
+    from {
+      background-position: 0 0;
+    }
+    to {
+      background-position: 16px 0;
+    }
   }
 </style>

--- a/ui/src/lib/components/unit-row/UnitRowRight.svelte
+++ b/ui/src/lib/components/unit-row/UnitRowRight.svelte
@@ -123,7 +123,7 @@
   <ResearchBadge {session} />
   {#if !stepperTerminal}<PrBadge {git} sessionId={session.id} />{/if}
   <CriticBadge sessionId={session.id} />
-  <BuildQueueBadge sessionId={session.id} />
+  <BuildQueueBadge sessionId={session.id} planPhase={session.planPhase} {git} />
   <PlanGateBadge
     {session}
     allowView={false}


### PR DESCRIPTION
## Why

Operators saw build-queue badges stuck at `0/N` on sessions that were clearly deep into implementation. Root cause (diagnosed from the DB + four sessions' transcripts): those agents **authored** a queue but never **POSTed** step status, so every step stays `pending` → the badge honestly shows `0/N`. The flat `0/N` reads as "nothing happened" even when the agent is mid-implementation — that's the confusion this PR removes.

## What this does

Adds a client-side **"working but unreported"** state to `BuildQueueBadge`. When a session is past planning (or has an open PR) but its approved queue is still entirely `pending`, the badge drops the misleading flat `0/N` for an indeterminate ⚠ state (striped amber wash, `⚠ {total}`) with a tooltip/aria explaining the agent is working but hasn't updated step status. It clears automatically the moment any step goes `active`/`done`.

Gate (client-side, no server changes):
```
prPresent = git?.state === "open"                       // open PR only; merged/closed = resolved
working   = planPhase !== "planning" || prPresent       // null (gate off) treated like executing,
                                                        //   matching the server backstop
drifted   = approved && steps.every(pending) && working  // truly untouched = the "0/N" case
```
`every(pending)` (not the server's `some(pending) && !some(active)`) is deliberate: the badge has no idle/settle gating, so the looser predicate would flash the warning every time a *compliant* agent is briefly between steps. `git` rides `session:git` (separate from `session:status`), so absent/stale `git` degrades closed — never a false flag.

## Scope — this surfaces the symptom, it does not fix progression

This is the operator-facing half. The **actual reliability gap** — the reconcile backstop never firing for these sessions despite settled-idle windows — is tracked separately in **#1617** (it needs live sweep instrumentation to pin down before a fix; the hypothesis space is already reduced there). This PR does **not** attempt that fix.

## Testing

- `cd ui && bun run check` — 0 errors / 0 warnings
- `cd ui && bun run check:i18n` — locale parity (EN + DE keys added)
- `bun run test:browser -- src/lib/components/BuildQueueBadge.browser.test.ts` — 17/17 (full drifted matrix: executing / gate-off-null / planning×{open,merged,closed,none,undefined} / has-active / has-done / clears-on-active)

Relates to #1617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
