### PR TITLE
fix(viewport): cap review-in-flight banner so it can't bury the prompt

### DIFF
--- a/ui/src/lib/components/Viewport.browser.test.ts
+++ b/ui/src/lib/components/Viewport.browser.test.ts
@@ -770,19 +770,23 @@ describe("Viewport review banner — reflow guarantee (no prompt overlap)", () =
     planGates.applyReviewing(id, true);
     planGates.setActivity(id, "read .shepherd-plan.md");
 
-    const { container } = render(Viewport, {
+    render(Viewport, {
       session: session({ id, status: "running", planPhase: "planning" }),
+      activity: activity("read .shepherd-plan.md"),
       previewPort: null,
       openPreviewTick: 0,
     });
-    // Force a SHORT terminal (well above .vp-body's 4rem floor) so the cap has to engage.
-    (container as HTMLElement).style.height = "320px";
-
-    const banner = () => container.querySelector<HTMLElement>(".review-banner");
+    const banner = () => document.querySelector<HTMLElement>(".review-banner");
     await vi.waitFor(() => expect(banner()).not.toBeNull());
-    const mount = container.querySelector<HTMLElement>(".term-mount")!;
+    // Force a SHORT terminal (well above .vp-body's 4rem floor) so the cap has to engage.
+    // Resize the Viewport's mount div (its height:100% root fills it); read it off the DOM
+    // because render()'s typed result varies by version.
+    const host = document.querySelector<HTMLElement>(".viewport")!.parentElement as HTMLElement;
+    host.style.height = "320px";
+
+    const mount = document.querySelector<HTMLElement>(".term-mount")!;
     expect(mount, ".term-mount should render").not.toBeNull();
-    const vpBody = container.querySelector<HTMLElement>(".vp-body")!;
+    const vpBody = document.querySelector<HTMLElement>(".vp-body")!;
     const fourRem = 4 * parseFloat(getComputedStyle(document.documentElement).fontSize);
 
     await vi.waitFor(() => {

--- a/ui/src/lib/components/Viewport.browser.test.ts
+++ b/ui/src/lib/components/Viewport.browser.test.ts
@@ -747,6 +747,58 @@ describe("Viewport autopilot badge vs in-flight review", () => {
   });
 });
 
+describe("Viewport review banner — reflow guarantee (no prompt overlap)", () => {
+  function clearReviewState() {
+    reviews.map = {};
+    reviews.reviewing = {};
+    reviews.activity = {};
+    planGates.map = {};
+    planGates.reviewing = {};
+    planGates.activity = {};
+  }
+  beforeEach(clearReviewState);
+  afterEach(clearReviewState);
+
+  // The literal reported bug: in a short terminal the tall banner overlaid the CLI prompt.
+  // The banner caps its height (max-height: min(50%, 100% - 4rem)) so it leaves ≥ 4rem for
+  // the terminal; .term-mount (= 100% - --review-banner-h, floored at 4rem) then reflows fully
+  // ABOVE it — keeping its 4rem floor and never extending under the banner. Rendered at a short
+  // terminal height where the banner's natural (uncapped) height would otherwise force the
+  // reserve under its floor and overlap the prompt.
+  it("caps the in-flight banner so .term-mount keeps its 4rem floor and never overlaps it", async () => {
+    const id = "vr-overlap";
+    planGates.applyReviewing(id, true);
+    planGates.setActivity(id, "read .shepherd-plan.md");
+
+    const { container } = render(Viewport, {
+      session: session({ id, status: "running", planPhase: "planning" }),
+      previewPort: null,
+      openPreviewTick: 0,
+    });
+    // Force a SHORT terminal (well above .vp-body's 4rem floor) so the cap has to engage.
+    (container as HTMLElement).style.height = "320px";
+
+    const banner = () => container.querySelector<HTMLElement>(".review-banner");
+    await vi.waitFor(() => expect(banner()).not.toBeNull());
+    const mount = container.querySelector<HTMLElement>(".term-mount")!;
+    expect(mount, ".term-mount should render").not.toBeNull();
+    const vpBody = container.querySelector<HTMLElement>(".vp-body")!;
+    const fourRem = 4 * parseFloat(getComputedStyle(document.documentElement).fontSize);
+
+    await vi.waitFor(() => {
+      const vpH = vpBody.getBoundingClientRect().height;
+      const b = banner()!.getBoundingClientRect();
+      const m = mount.getBoundingClientRect();
+      // Reflow guarantee: the banner leaves at least a 4rem terminal (banner ≤ vp-body - 4rem).
+      expect(b.height).toBeLessThanOrEqual(vpH - fourRem + 0.5);
+      // → .term-mount keeps its 4rem floor …
+      expect(m.height).toBeGreaterThanOrEqual(fourRem - 0.5);
+      // … and never extends under the banner (the prompt is never overlaid).
+      expect(m.bottom).toBeLessThanOrEqual(b.top + 0.5);
+    });
+  });
+});
+
 describe("Viewport active REWORK terminal strip", () => {
   function clearReviewState() {
     reviews.map = {};

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -3642,9 +3642,15 @@
        resize, which is the intended reflow. The min-height floor equals .vp-body's
        own min-height (4rem) and must NOT exceed it: a larger floor would force the
        mount taller than a squeezed body and clip the bottom prompt row via
-       .vp-body's overflow:hidden even with no banner. At the floor (squeezed-recap
-       takeover) the mount == body, so the banner overlaps its bottom again — prior
-       behavior — rather than resizing the PTY toward xterm's clamped 1-row minimum. */
+       .vp-body's overflow:hidden even with no banner. The review banner caps its own
+       height at min(50%, 100% - 4rem) (see ReviewInFlightBanner) and shrinks its live
+       preview to fit, so for any usably-sized terminal --review-banner-h stays ≤ 100% -
+       4rem ⇒ this mount keeps its 4rem floor and the floor never overrides the reserve
+       into an overlap. The banner can't shrink below its headline row (~1 line,
+       flex-shrink:0), so only in the extreme squeezed-recap takeover — .vp-body pinned at
+       its own 4rem floor, where nothing fits both a prompt and a banner — a small residual
+       overlap of at most that headline row remains, still far less than the full-banner
+       burial before the cap. */
     height: calc(100% - var(--review-banner-h, 0px));
     min-height: 4rem;
     overflow: hidden;

--- a/ui/src/lib/components/viewport/ReviewInFlightBanner.browser.test.ts
+++ b/ui/src/lib/components/viewport/ReviewInFlightBanner.browser.test.ts
@@ -93,11 +93,11 @@ describe("ReviewInFlightBanner preview — in-flight tier", () => {
     await expect.poll(feedLines).toEqual(["read .shepherd-plan.md"]);
   });
 
-  it("caps the preview at 4 lines, dropping the oldest (newest at the bottom)", async () => {
+  it("caps the preview at 2 lines, dropping the oldest (newest at the bottom)", async () => {
     planGates.applyReviewing(ID, true);
     for (const l of ["act-1", "act-2", "act-3", "act-4", "act-5"]) planGates.setActivity(ID, l);
     render(ReviewInFlightBanner, props() as never);
-    await expect.poll(feedLines).toEqual(["act-2", "act-3", "act-4", "act-5"]);
+    await expect.poll(feedLines).toEqual(["act-4", "act-5"]);
   });
 
   it("shows the waiting placeholder (no feed lines) before the first activity arrives", async () => {
@@ -109,17 +109,40 @@ describe("ReviewInFlightBanner preview — in-flight tier", () => {
     expect(feedLines()).toEqual([]);
   });
 
-  it("keeps a stable banner height as the feed fills from 0 to 4 lines", async () => {
+  it("keeps a stable banner height as the feed fills from 0 to 2 lines", async () => {
     planGates.applyReviewing(ID, true);
     render(ReviewInFlightBanner, props() as never);
     await expect
       .poll(() => document.querySelector(".rb-pv-wait")?.textContent)
       .toBe(m.reviewbanner_preview_waiting());
     const emptyH = banner()!.getBoundingClientRect().height;
-    for (const l of ["act-1", "act-2", "act-3", "act-4"]) planGates.setActivity(ID, l);
-    await expect.poll(() => feedLines().length).toBe(4);
+    for (const l of ["act-1", "act-2"]) planGates.setActivity(ID, l);
+    await expect.poll(() => feedLines().length).toBe(2);
     const fullH = banner()!.getBoundingClientRect().height;
-    expect(fullH).toBe(emptyH); // fixed 4-row preview area → one xterm refit, not per-line churn
+    expect(fullH).toBe(emptyH); // reserved 2-row preview area → one xterm refit, not per-line churn
+  });
+
+  // The reflow guarantee: in a short pane the banner caps its own height so the terminal
+  // (.term-mount = 100% - --review-banner-h, floored at 4rem) can always reflow ABOVE it —
+  // i.e. banner ≤ containerHeight - 4rem, so .term-mount never drops under its floor and the
+  // prompt is never overlaid. See ReviewInFlightBanner's .review-banner max-height.
+  it("caps its height in a short pane so the terminal keeps its 4rem reflow floor", async () => {
+    planGates.applyReviewing(ID, true);
+    for (const l of ["act-1", "act-2"]) planGates.setActivity(ID, l);
+    const { container } = render(ReviewInFlightBanner, props() as never);
+    // The banner is position:absolute; give it a positioned, definite short containing block —
+    // otherwise the % cap resolves against the viewport and the cap is never exercised.
+    const host = container as HTMLElement;
+    host.style.position = "relative";
+    host.style.height = "120px";
+    await expect.poll(() => banner()).not.toBeNull();
+    await expect.poll(() => feedLines().length).toBe(2);
+    const remPx = parseFloat(getComputedStyle(document.documentElement).fontSize);
+    const containerH = host.getBoundingClientRect().height;
+    const bannerH = banner()!.getBoundingClientRect().height;
+    expect(bannerH).toBeLessThanOrEqual(containerH - 4 * remPx + 0.5); // +0.5px rounding tolerance
+    expect(bannerH).toBeGreaterThan(0); // clamped, not collapsed — headline still shows at 120px
+    expect(document.querySelector(".rb-text")?.textContent?.trim()).toBeTruthy(); // headline present (ellipsized)
   });
 });
 

--- a/ui/src/lib/components/viewport/ReviewInFlightBanner.browser.test.ts
+++ b/ui/src/lib/components/viewport/ReviewInFlightBanner.browser.test.ts
@@ -129,13 +129,14 @@ describe("ReviewInFlightBanner preview — in-flight tier", () => {
   it("caps its height in a short pane so the terminal keeps its 4rem reflow floor", async () => {
     planGates.applyReviewing(ID, true);
     for (const l of ["act-1", "act-2"]) planGates.setActivity(ID, l);
-    const { container } = render(ReviewInFlightBanner, props() as never);
-    // The banner is position:absolute; give it a positioned, definite short containing block —
-    // otherwise the % cap resolves against the viewport and the cap is never exercised.
-    const host = container as HTMLElement;
+    render(ReviewInFlightBanner, props() as never);
+    await expect.poll(() => banner()).not.toBeNull();
+    // The banner is position:absolute; make its mount div a positioned, definite short
+    // containing block — otherwise the % cap resolves against the viewport and is never
+    // exercised. (Read the host off the DOM: render()'s typed result varies by version.)
+    const host = banner()!.parentElement as HTMLElement;
     host.style.position = "relative";
     host.style.height = "120px";
-    await expect.poll(() => banner()).not.toBeNull();
     await expect.poll(() => feedLines().length).toBe(2);
     const remPx = parseFloat(getComputedStyle(document.documentElement).fontSize);
     const containerH = host.getBoundingClientRect().height;

--- a/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
+++ b/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
@@ -291,10 +291,11 @@
       <span class="rb-text">{bannerText(view)}</span>
     </div>
     {#if view.show && view.phase === "in-flight"}
-      <!-- Live "tail -f" of the off-screen reviewer's actions. Fixed height for MAX_ACTIVITY_LINES
-           rows so the banner keeps a stable height across the whole in-flight phase (lines fill
-           progressively) → one xterm refit on enter/exit, not one per line. aria-hidden: the
-           polite headline is the announcement; a fast-updating feed would spam a screen reader. -->
+      <!-- Live "tail -f" of the off-screen reviewer's actions. Reserves MAX_ACTIVITY_LINES rows
+           (a fixed flex-basis) so the banner keeps a stable height across the whole in-flight phase
+           as lines fill progressively → one xterm refit on enter/exit, not one per line; it only
+           gives way when the banner's height cap bites in a short pane. aria-hidden: the polite
+           headline is the announcement; a fast-updating feed would spam a screen reader. -->
       <div class="rb-preview" style:--rb-pv-rows={MAX_ACTIVITY_LINES} aria-hidden="true">
         {#if feed.length === 0}
           <span class="rb-pv-wait">{m.reviewbanner_preview_waiting()}</span>
@@ -314,7 +315,21 @@
      strip sits BELOW the live prompt, not over it; the operator can still see and use
      the prompt while a review runs. Appearing/resizing it therefore intentionally
      triggers an xterm refit. Non-blocking: no scrim/blur — it does not seize
-     interaction. */
+     interaction.
+
+     Height is CAPPED (max-height below) so it can never bury the prompt:
+     - min(50%, …): never eats more than half the terminal body.
+     - calc(100% - 4rem): the reflow guarantee. Banner ≤ 100% - 4rem ⇒
+       .term-mount (= 100% - --review-banner-h) stays ≥ its own 4rem floor, so the floor
+       can never override the reserve and force an overlap. The live preview shrinks to fit
+       (flex-shrink below); the banner bottoms out at its headline row (.rb-head is
+       flex-shrink:0), so the guarantee holds for any usably-sized terminal. Only at the
+       .vp-body 4rem floor (expanded-recap takeover), where nothing fits both a prompt and a
+       banner, does a residual overlap of at most that one headline row remain.
+     - box-sizing:border-box so the padding + 1px border fold INTO the cap (else the
+       rendered box overshoots it and re-opens the overlap).
+     - overflow:hidden so offsetHeight (→ --review-banner-h) equals the rendered box; any
+       oversized content is clipped inside the cap instead of spilling below un-measured. */
   .review-banner {
     position: absolute;
     bottom: 0;
@@ -323,6 +338,9 @@
     z-index: 2;
     display: flex;
     flex-direction: column;
+    box-sizing: border-box;
+    max-height: min(50%, calc(100% - 4rem));
+    overflow: hidden;
     padding: 5px 10px;
     font-size: var(--fs-meta);
     color: var(--accent);
@@ -338,11 +356,15 @@
     padding: 9px 12px;
     font-size: var(--fs-base);
   }
-  /* Headline row (icon + message) — the former single-row flex layout. */
+  /* Headline row (icon + message) — the former single-row flex layout. flex-shrink:0
+     keeps it over a shrinking preview when the banner is capped; min-width:0 lets its
+     .rb-text child actually ellipsize rather than force the head past the cap. */
   .rb-head {
     display: flex;
     align-items: center;
     gap: 8px;
+    flex-shrink: 0;
+    min-width: 0;
   }
   /* Live activity tail under the in-flight headline. Newest line pins to the bottom
      (justify-content:flex-end); the reserved height is MAX_ACTIVITY_LINES rows (--rb-pv-rows) so
@@ -354,7 +376,12 @@
     flex-direction: column;
     justify-content: flex-end;
     margin-top: 6px;
-    height: calc(var(--fs-meta) * 1.5 * var(--rb-pv-rows, 4));
+    /* Reserve --rb-pv-rows rows as a fixed flex-basis (stable height → one xterm refit),
+       but flex-shrink:1 + min-height:0 let it give way FIRST when the banner's max-height
+       cap bites in a short pane; flex-end + overflow:hidden then keep the newest line
+       pinned at the bottom and clip the oldest off the top. */
+    flex: 0 1 calc(var(--fs-meta) * 1.5 * var(--rb-pv-rows, 2));
+    min-height: 0;
     overflow: hidden;
     font-family: var(--font-mono);
     font-size: var(--fs-meta);
@@ -401,7 +428,14 @@
       animation: icon-btn-spin 6s linear infinite !important;
     }
   }
+  /* One deterministic-height line (min-width:0 so it can shrink inside .rb-head): it
+     ellipsizes in a narrow pane rather than wrapping and pushing the head past the cap.
+     The full text still reaches assistive tech via the banner's aria-live region. */
   .rb-text {
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     color: var(--color-ink-bright);
   }
   /* Tone → accent token. Calm = amber (matches the REVIEWING dot); escalated =

--- a/ui/src/lib/reviews.svelte.test.ts
+++ b/ui/src/lib/reviews.svelte.test.ts
@@ -189,10 +189,10 @@ test("setActivity ignores an unchanged value (no reactive churn)", () => {
 // Guaranteed by three reset points, verified below for BOTH stores: start (OFF→ON), end
 // (ON→OFF), and bootstrap/resync.
 
-test("reviews activityFeed accumulates distinct lines newest-last, capped at 4", () => {
+test("reviews activityFeed accumulates distinct lines newest-last, capped at 2", () => {
   reviews.setReviewing("s1", true);
   for (const l of ["a", "b", "c", "d", "e"]) reviews.setActivity("s1", l);
-  expect(reviews.activityFeed("s1")).toEqual(["b", "c", "d", "e"]); // oldest ("a") dropped
+  expect(reviews.activityFeed("s1")).toEqual(["d", "e"]); // older lines dropped (cap MAX_ACTIVITY_LINES)
   expect(reviews.activityFor("s1")).toBe("e"); // badge tooltip = newest line
 });
 

--- a/ui/src/lib/reviews.svelte.ts
+++ b/ui/src/lib/reviews.svelte.ts
@@ -12,8 +12,10 @@ import {
 } from "./api";
 
 /** Max lines kept in a review's rolling live-activity feed (the terminal preview shows these,
- *  newest at the bottom). Bounded so the ephemeral tail can't grow without limit. */
-export const MAX_ACTIVITY_LINES = 4;
+ *  newest at the bottom). Bounded so the ephemeral tail can't grow without limit. Also the
+ *  banner's reserved preview-row count (--rb-pv-rows) — kept small (2) so the in-flight banner
+ *  stays short and can't bury the terminal prompt in a short pane (see ReviewInFlightBanner). */
+export const MAX_ACTIVITY_LINES = 2;
 
 /** Append `summary` to a bounded rolling feed, deduping against the last line (the server
  *  re-emits the same summary every tick → no churn). Returns the SAME array reference when


### PR DESCRIPTION
## Problem

The review-in-flight terminal banner became **unbelievably tall and blocked all access to the CLI prompt** in a short terminal pane.

Regression from #1593, which added an always-reserved **4-row** live-activity preview under the headline. The banner grew from ~40px to ~108px. `Viewport.svelte` reserves the strip via `.term-mount { height: calc(100% - var(--review-banner-h)); min-height: 4rem }`; in a short pane `100% − 108px` falls under the `4rem` floor, so the terminal stops shrinking and the tall banner overlays the bottom xterm rows — the input line.

## Fix

Two coordinated changes:

1. **Shrink in every pane** — `MAX_ACTIVITY_LINES` 4 → 2. Banner ~108px → ~75px; shows the 2 newest reviewer-activity lines. Stable-height / one-refit property preserved (a smaller *fixed* reservation costs no refits).
2. **Cap + guarantee reflow** — `.review-banner { max-height: min(50%, calc(100% - 4rem)); box-sizing: border-box; overflow: hidden }`. `50%` bounds it to a fraction of the terminal; `100% − 4rem` guarantees `.term-mount` keeps its `4rem` floor so it always reflows fully above the banner. The preview is now a shrinkable `flex-basis` (gives way first under the cap); the headline is `flex-shrink:0` + `nowrap`/ellipsis so it can't wrap past the cap. Each declaration is load-bearing — drop `border-box` and padding overshoots the cap; drop `overflow:hidden` and `offsetHeight` (→ `--review-banner-h`) under-reports.

### Empirical note (found during implementation)

`.rb-head` is `flex-shrink:0`, so `max-height` can't shrink the banner below its **one headline row (~19px)** — verified in-browser (`max-height:8px` still renders 19px; `40%`→24px clamps fine). Consequences, probed on the real `Viewport`:

- Any usably-sized terminal (`.vp-body ≳ 71px`): cap engages, banner leaves ≥ 4rem, **no overlap** (measured: vp-body 100px → banner 48px, term 52px, 0 overlap).
- Only at the absolute `.vp-body` 4rem floor (expanded-recap takeover — where nothing fits both a prompt and a banner) does a residual overlap of **at most one headline row** remain — still far less than the pre-cap ~108px burial. The stale `Viewport.svelte` / banner comments were rewritten to state this real invariant.

## Verification

- `cd ui && bun run check` → 0 errors; `check:i18n` → parity (no new strings); eslint + prettier clean on touched files.
- `cd ui && bun test` → **3229 passed**.
- Retargeted the feed-cap tests 4→2; added a **short-pane cap** test (`ReviewInFlightBanner`) asserting `banner ≤ container − 4rem`, and a **Viewport-level no-overlap / reflow-guarantee** test (`.term-mount` stays ≥ 4rem and never extends under the banner).

`[no-feature-entry]` — this is a bug fix to existing UI, no new user-facing capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)