### PR TITLE
feat(ui): plan-gate row CTA follow-ups — idle self-heal, final-round badge, answer CTA (#1610)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -328,10 +328,10 @@
       {
         "files": ["ui/src/lib/hold-row.ts"],
         "functions": ["rowState"],
-        "maxCyclomatic": 22,
-        "maxCognitive": 19,
+        "maxCyclomatic": 24,
+        "maxCognitive": 22,
         "maxCrap": 1000,
-        "reason": "Single ordered first-match classifier for the plan-gate row (#1561): one branch per rule (R1-R12), deliberately kept as a flat, top-to-bottom precedence chain so the exhaustively-tested rule order stays auditable at a glance. Cyclomatic is rule-count-driven, not nested logic (cognitive 19). Collapsing it into a data-driven rule table would hide the precedence the whole design turns on. Same envelope as src/drain.ts doSpawn (22/19)."
+        "reason": "Single ordered first-match classifier for the plan-gate row (#1561; +R1a for the non-planning Answer CTA, #1610): one branch per rule (R1a, R1-R12), deliberately kept as a flat, top-to-bottom precedence chain so the exhaustively-tested rule order stays auditable at a glance. Cyclomatic is rule-count-driven, not nested logic. Collapsing it into a data-driven rule table would hide the precedence the whole design turns on."
       },
       {
         "files": ["ui/src/lib/components/UnitRow.svelte"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ import { Presence } from "./presence";
 import { ReviewService } from "./review";
 import { StandalonePrCriticService } from "./standalone-critic";
 import { createIssueLogger } from "./issue-log";
-import { PlanGateService } from "./plan-gate";
+import { PlanGateService, shouldConsiderOnSettle } from "./plan-gate";
 import { AutopilotService } from "./autopilot";
 import { DrainService } from "./drain";
 import { SessionRouter, type SessionConsumer } from "./session-router";
@@ -1646,9 +1646,12 @@ const sessionRouter = new SessionRouter(
     // planning-phase session that just settled likely finished writing .shepherd-plan.md → kick the
     // adversarial review. Fires BEFORE the awaited consumer chain so a slow/hanging drain pump can
     // never starve it (#1193); consider() is self-contained and claims its slot synchronously.
+    // Also re-fires on the idle settle edge for the revise loop (a session that reworks its plan
+    // after `changes_requested` settles to idle, not done) — see shouldConsiderOnSettle (#1610).
     onStatusIndependent: (change) => {
       const sess = change.snapshot.session;
-      if (change.status === "done" && sess.planPhase === "planning")
+      const priorDecision = store.getPlanGate(sess.id)?.decision;
+      if (shouldConsiderOnSettle(change.status, sess.planPhase, priorDecision))
         void planGate.consider(sess).catch((err) => console.warn("[plan-gate] consider:", err));
     },
   },

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -29,6 +29,23 @@ import { fenceUntrusted } from "./untrusted";
  *  relays this so the UI can distinguish a no-op from a real error or an unusable `.shepherd-plan.md`. */
 export type PlanReviewTrigger = "started" | "skipped" | "plan-unavailable" | "error";
 
+/** Whether a settle edge should re-drive `consider()`. `done` always re-considers (first
+ *  draft + any settle); `idle` re-considers ONLY when a prior gate already requested changes
+ *  — the revise loop. This excludes the pre-first-draft window (no gate ⇒ `undefined`) so
+ *  partial authoring idles can't exhaust the adversarial cap, and excludes `error` gates
+ *  (consider() never dedups those, so idle-firing would spam re-reviews). `approved` gates are
+ *  excluded too (consider() would skip them anyway). See issue #1610. */
+export function shouldConsiderOnSettle(
+  status: string,
+  planPhase: Session["planPhase"],
+  priorDecision: PlanDecision | undefined,
+): boolean {
+  if (planPhase !== "planning") return false;
+  if (status === "done") return true;
+  if (status === "idle") return priorDecision === "changes_requested";
+  return false;
+}
+
 /** The plan the planning agent writes in its LIVE session worktree; the reviewer reads its text. */
 const PLAN_FILE = ".shepherd-plan.md";
 

--- a/test/plan-gate-settle.test.ts
+++ b/test/plan-gate-settle.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test";
+import { shouldConsiderOnSettle } from "../src/plan-gate";
+import type { Session } from "../src/types";
+
+test("shouldConsiderOnSettle truth table", () => {
+  const planning: Session["planPhase"] = "planning";
+  const executing: Session["planPhase"] = "executing";
+
+  expect(shouldConsiderOnSettle("done", planning, undefined)).toBe(true);
+  expect(shouldConsiderOnSettle("done", planning, "changes_requested")).toBe(true);
+  expect(shouldConsiderOnSettle("idle", planning, "changes_requested")).toBe(true);
+  expect(shouldConsiderOnSettle("idle", planning, "error")).toBe(false);
+  expect(shouldConsiderOnSettle("idle", planning, "approved")).toBe(false);
+  expect(shouldConsiderOnSettle("idle", planning, undefined)).toBe(false);
+  expect(shouldConsiderOnSettle("running", planning, "changes_requested")).toBe(false);
+  expect(shouldConsiderOnSettle("blocked", planning, "changes_requested")).toBe(false);
+  expect(shouldConsiderOnSettle("done", executing, "changes_requested")).toBe(false);
+  expect(shouldConsiderOnSettle("idle", null, "changes_requested")).toBe(false);
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -623,6 +623,8 @@
   "plangate_review_skipped_stalled": "Planprüfung konnte gerade nicht gestartet werden.",
   "feat_plan_stall_menu_title": "Gestoppte Pläne direkt am Chip reparieren",
   "feat_plan_stall_menu_body": "Wenn eine Plan-Prüfung ihr Rundenlimit erreicht, öffnet der Plan-Chip jetzt ein Aktionsmenü: Plan öffnen, einen vorbereiteten Steuertext mit Review-Befunden bearbeiten oder nach Änderung von .shepherd-plan.md erneut prüfen.",
+  "feat_hold_row_answer_title": "Blockierte Sitzungen direkt aus der Zeile beantworten",
+  "feat_hold_row_answer_body": "Sitzungen, die auf eine Frage warten – Autopilot pausiert oder Warten auf eine Ja/Nein-Antwort – zeigen jetzt eine Schaltfläche „Antworten“ direkt in ihrer Zeile. Ein Klick öffnet die Sitzung zum Antworten.",
   "plangate_tip_planning": "Planprüfung vor der Ausführung erforderlich.",
   "plangate_tip_reviewing": "Planprüfung läuft.",
   "plangate_tip_changes": "Ausführung wartet auf eine freigegebene Überarbeitung.",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2798,6 +2798,7 @@
   "hold_cta_rereview_title": "Plan erneut zur Prüfung senden",
   "hold_cta_resume_title": "Festgefahrene Plan-Review fortsetzen",
   "hold_cta_answer_title": "Plan öffnen, um offene Fragen zu beantworten",
+  "hold_cta_answer_reply_title": "Sitzung öffnen, um zu antworten und fortzufahren",
   "feat_hold_cta_title": "Blockierte Sessions direkt in der Zeile bearbeiten",
   "feat_hold_cta_body": "Eine im Plan-Gate blockierte Session erklärt jetzt direkt in ihrer Zeile, worauf sie wartet — wartet auf erneute Prüfung, Plan freigegeben oder Review festgefahren — und bietet die passende Ein-Klick-Aktion (Erneut prüfen, Los, Fortsetzen oder Antworten), ohne die Session zu öffnen.",
   "hold_cta_go_failed": "Ausführung konnte nicht gestartet werden. Erneut versuchen.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -623,6 +623,8 @@
   "plangate_review_skipped_stalled": "Couldn't start a plan review right now.",
   "feat_plan_stall_menu_title": "Repair stalled plans from the chip",
   "feat_plan_stall_menu_body": "When a plan review hits its round limit, the plan chip now opens an action menu: open the plan, edit a prepared steer with the review findings, or re-run review after .shepherd-plan.md changes.",
+  "feat_hold_row_answer_title": "Answer blocked sessions from the row",
+  "feat_hold_row_answer_body": "Sessions paused on a question — autopilot paused, or waiting on a yes/no — now show an Answer button right on their row. Click it to jump into the session and reply.",
   "plangate_tip_planning": "Plan review required before execution.",
   "plangate_tip_reviewing": "Plan review is running.",
   "plangate_tip_changes": "Execution waits for an approved revision.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2798,6 +2798,7 @@
   "hold_cta_rereview_title": "Send the plan back for another review",
   "hold_cta_resume_title": "Resume the stalled plan review",
   "hold_cta_answer_title": "Open the plan to answer its open questions",
+  "hold_cta_answer_reply_title": "Open the session to answer and continue",
   "feat_hold_cta_title": "Act on parked sessions from the row",
   "feat_hold_cta_body": "A parked plan-gate session now explains why it's waiting right on its row — awaiting re-review, plan approved, or review stuck — and offers the matching one-click action (Re-review, Go, Resume, or Answer) without opening the session.",
   "hold_cta_go_failed": "Couldn't start execution. Try again.",

--- a/ui/src/lib/components/PlanGateBadge.svelte
+++ b/ui/src/lib/components/PlanGateBadge.svelte
@@ -1,17 +1,13 @@
 <script lang="ts">
   import type { Session } from "$lib/types";
   import { planGates } from "$lib/reviews.svelte";
-  import {
-    canShowPlanStallActions,
-    composePlanGateTooltip,
-    planGateChip,
-    planGateStalled,
-  } from "./plan-gate-badge";
+  import { composePlanGateTooltip, planGateChip, planGateStalledNow } from "./plan-gate-badge";
   import PlanPanel from "./PlanPanel.svelte";
   import PlanGateMenu from "./PlanGateMenu.svelte";
   import { m } from "$lib/paraglide/messages";
   import { replySession, reviewPlan } from "$lib/api";
   import { toasts } from "$lib/toasts.svelte";
+  import { clock } from "$lib/now.svelte";
 
   // allowView (default true): whether to surface the read-only "view"/PLAN chip during
   // execution. The dense session-list surface (UnitRow) passes false so this chip
@@ -38,9 +34,9 @@
   const gate = $derived(planGates.map[session.id]);
   const reviewing = $derived(planGates.isReviewing(session.id));
   const chip = $derived(planGateChip(session, gate, reviewing, { allowView }));
-  const stalledActionsVisible = $derived(canShowPlanStallActions(session, gate, reviewing));
   const pulseClass = $derived(pulseReady && chip.kind === "ready" ? " pg-pulse-ready" : "");
-  const stalled = $derived(planGateStalled(chip));
+  const stalled = $derived(planGateStalledNow(session, gate, reviewing, clock.current));
+  const stalledActionsVisible = $derived(stalled);
 
   let open = $state(false);
   let btnEl = $state<HTMLButtonElement>();

--- a/ui/src/lib/components/PlanGateBadge.test.ts
+++ b/ui/src/lib/components/PlanGateBadge.test.ts
@@ -4,6 +4,7 @@ import {
   canRelease,
   canShowPlanStallActions,
   composePlanGateTooltip,
+  planGateStalledNow,
   type PlanGateTooltipCopy,
 } from "./plan-gate-badge";
 import type { PlanGate, Session } from "$lib/types";
@@ -167,6 +168,73 @@ describe("canShowPlanStallActions", () => {
       false,
     );
     expect(canShowPlanStallActions(actionSess("planning"), stalledGate, true)).toBe(false);
+  });
+});
+
+describe("planGateStalledNow", () => {
+  it("fresh final round, idle → not stalled", () => {
+    expect(
+      planGateStalledNow(
+        actionSess("planning"),
+        gate({ round: 3, cap: 3, finalRoundPending: true, updatedAt: 1_000_000 }),
+        false,
+        1_000_000,
+      ),
+    ).toBe(false);
+  });
+
+  it("fresh final round, running → not stalled", () => {
+    expect(
+      planGateStalledNow(
+        actionSess("planning", "running"),
+        gate({ round: 3, cap: 3, finalRoundPending: true, updatedAt: 1_000_000 }),
+        false,
+        1_000_000,
+      ),
+    ).toBe(false);
+  });
+
+  it("genuine stall (no finalRoundPending), idle → stalled", () => {
+    expect(
+      planGateStalledNow(
+        actionSess("planning"),
+        gate({ round: 3, cap: 3, finalRoundPending: false }),
+        false,
+        1_000_000,
+      ),
+    ).toBe(true);
+  });
+
+  it("timed-out final round, idle → stalled", () => {
+    expect(
+      planGateStalledNow(
+        actionSess("planning"),
+        gate({ round: 3, cap: 3, finalRoundPending: true, updatedAt: 1_000_000 }),
+        false,
+        1_000_000 + 900_001,
+      ),
+    ).toBe(true);
+  });
+
+  it("running at-cap genuine stall → not stalled (agent running)", () => {
+    expect(
+      planGateStalledNow(
+        actionSess("planning", "running"),
+        gate({ round: 3, cap: 3, finalRoundPending: false }),
+        false,
+        1_000_000,
+      ),
+    ).toBe(false);
+  });
+
+  it("below cap → not stalled", () => {
+    expect(
+      planGateStalledNow(actionSess("planning"), gate({ round: 1, cap: 3 }), false, 1_000_000),
+    ).toBe(false);
+  });
+
+  it("no gate → not stalled", () => {
+    expect(planGateStalledNow(actionSess("planning"), undefined, false, 1_000_000)).toBe(false);
   });
 });
 

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -830,6 +830,23 @@ describe("UnitRow plan-gate hold CTA", () => {
   });
 });
 
+describe("UnitRow answer CTA (non-plan hold)", () => {
+  it("renders an Answer CTA for an autopilot-paused row and click calls onselect", async () => {
+    let selected: string | null = null;
+    render(UnitRow, {
+      session: session({ id: "ap1", planPhase: "executing", status: "idle" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: (id: string) => (selected = id),
+      hold: { code: "autopilot-paused" },
+    });
+    const btn = page.getByTitle(m.hold_cta_answer_reply_title());
+    await expect.element(btn).toBeInTheDocument();
+    await btn.click();
+    expect(selected).toBe("ap1");
+  });
+});
+
 describe("UnitRow manual-steps chip", () => {
   // The chip's text content (the count) bubbles into the accessible name too, so match it
   // precisely by its title attribute rather than the ambiguous role+name (same pattern as the

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -320,6 +320,7 @@
     } else if (a.kind === "rereview") void doReview();
     else if (a.kind === "resume") void doResume();
     else if (a.kind === "answer") openPlanPanel();
+    else if (a.kind === "reply") onselect(session.id);
   }
 
   async function doGo() {

--- a/ui/src/lib/components/plan-gate-badge.ts
+++ b/ui/src/lib/components/plan-gate-badge.ts
@@ -1,4 +1,5 @@
 import type { PlanGate, Session } from "../types";
+import { planStallStatus } from "../plan-status";
 
 /**
  * Which plan-gate chip a session card should show, or "none" to hide it.
@@ -30,10 +31,6 @@ export type PlanGateChip =
   | { kind: "ready" }
   | { kind: "error" }
   | { kind: "planning" };
-
-export function planGateStalled(chip: PlanGateChip): boolean {
-  return chip.kind === "changes" && chip.round >= chip.cap;
-}
 
 export function planGateChip(
   session: Pick<Session, "planPhase">,
@@ -77,6 +74,24 @@ export function canShowPlanStallActions(
     !reviewing &&
     gate?.decision === "changes_requested" &&
     gate.round >= gate.cap,
+  );
+}
+
+/** Whether the badge should read as *genuinely stalled* (amber toning + stall-recovery menu):
+ *  the operator can act now (`canShowPlanStallActions`) AND the rework streak is truly stuck
+ *  (`planStallStatus === "stalled"` — NOT a fresh `final` round the agent is still revising).
+ *  `now` is a ms clock (reactive `clock.current`). Supersedes the old chip-only heuristic that
+ *  toned every at-cap `changes` chip amber, including a live final round (issue #1610). */
+export function planGateStalledNow(
+  session: Pick<Session, "planPhase" | "status">,
+  gate: PlanGate | undefined,
+  reviewing: boolean,
+  now: number,
+): boolean {
+  return (
+    gate != null &&
+    canShowPlanStallActions(session, gate, reviewing) &&
+    planStallStatus(gate, now) === "stalled"
   );
 }
 

--- a/ui/src/lib/feature-announcements/entries/v1.43.0-hold-row-answer.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.43.0-hold-row-answer.ts
@@ -1,0 +1,12 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // Sessions paused on a question (autopilot paused, or waiting on a yes/no) now show an
+  // Answer button on their row — click it to open the session and reply.
+  id: "hold-row-answer",
+  sinceVersion: "1.43.0",
+  titleKey: "feat_hold_row_answer_title",
+  bodyKey: "feat_hold_row_answer_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/hold-row.test.ts
+++ b/ui/src/lib/hold-row.test.ts
@@ -220,6 +220,34 @@ describe("rowState / rowHold fixtures", () => {
     expect(r.line).toBe(holdLine(sh));
     expect(r.action).toBeNull();
   });
+
+  it("18. non-planning + autopilot-paused hold -> server-answer, server line + Answer CTA", () => {
+    const s = sess({ planPhase: "executing", status: "idle" });
+    const sh = hold("autopilot-paused");
+    expect(rowState(s, undefined, false, sh)).toBe("server-answer");
+    const r = rowHold(s, undefined, false, sh);
+    expect(r.line).toBe(holdLine(sh));
+    expect(r.action?.kind).toBe("reply");
+    expect(r.action?.label).toBe(m.hold_cta_answer());
+  });
+  it("19. non-planning + blocked-yes-no hold -> server-answer", () => {
+    const s = sess({ planPhase: null, status: "idle" });
+    const sh = hold("blocked-yes-no");
+    expect(rowState(s, undefined, false, sh)).toBe("server-answer");
+    expect(rowHold(s, undefined, false, sh).action?.kind).toBe("reply");
+  });
+  it("20. non-planning + a NON-answerable hold -> passthrough (unchanged)", () => {
+    const s = sess({ planPhase: "executing", status: "idle" });
+    const sh = hold("manual-steps");
+    expect(rowState(s, undefined, false, sh)).toBe("passthrough");
+  });
+  it("21. PLANNING + autopilot-paused hold -> NOT server-answer (planning arm unchanged)", () => {
+    // R1a lives only in the non-planning arm; a planning row with this hold still passes
+    // through R3 (autopilot-paused ∉ PLAN_DOMAIN) → passthrough.
+    const s = sess({ planPhase: "planning", status: "idle" });
+    const sh = hold("autopilot-paused");
+    expect(rowState(s, undefined, false, sh)).toBe("passthrough");
+  });
 });
 
 // One canonical (session, gate, planReviewing, serverHold) tuple per RowState — reused by
@@ -278,6 +306,15 @@ const CASES: Array<{ state: RowState; args: Args }> = [
     ],
   },
   { state: "none", args: [sess({ status: "idle" }), undefined, false, hold("plan-rework")] },
+  {
+    state: "server-answer",
+    args: [
+      sess({ planPhase: "executing", status: "idle" }),
+      undefined,
+      false,
+      hold("autopilot-paused"),
+    ],
+  },
 ];
 
 describe("properties", () => {
@@ -293,6 +330,7 @@ describe("properties", () => {
       "awaiting-rereview",
       "ready",
       "none",
+      "server-answer",
     ];
     expect(new Set(CASES.map((c) => c.state))).toEqual(new Set(allStates));
     for (const { state, args } of CASES) {
@@ -382,5 +420,12 @@ describe("properties", () => {
     );
     expect(withNothingPending.state).toBe("dismissed");
     expect(withNothingPending.action).toBeNull();
+  });
+
+  it("P6 reply only for server-answer", () => {
+    for (const { state, args } of CASES) {
+      const r = rowHold(...args);
+      expect(r.action?.kind === "reply").toBe(state === "server-answer");
+    }
   });
 });

--- a/ui/src/lib/hold-row.ts
+++ b/ui/src/lib/hold-row.ts
@@ -4,7 +4,7 @@ import { planGateChip, type PlanGateChip } from "$lib/components/plan-gate-badge
 import { planQuestionsUnanswered } from "$lib/tab-signal.svelte";
 import type { HoldReason, PlanGate, Session } from "$lib/types";
 
-/** The ten mutually-exclusive presentations a plan-gate row can take. One classifier
+/** The eleven mutually-exclusive presentations a plan-gate row can take. One classifier
  *  decides the state; LINE and ACTION are total maps over it, so the subline can never
  *  contradict the button beside it. */
 export type RowState =
@@ -17,10 +17,11 @@ export type RowState =
   | "question"
   | "awaiting-rereview"
   | "ready"
-  | "none";
+  | "none"
+  | "server-answer";
 
 export interface HoldAction {
-  kind: "go" | "rereview" | "resume" | "answer";
+  kind: "go" | "rereview" | "resume" | "answer" | "reply";
   label: string;
   title: string;
 }
@@ -34,6 +35,11 @@ export interface RowHold {
 /** Plan-domain hold codes — the ONLY server holds this module is allowed to reinterpret.
  *  Any other code passes through untouched (R3). */
 const PLAN_DOMAIN = new Set<HoldReason["code"]>(["plan-rework", "quota-plan", "plan-question"]);
+
+/** Non-plan server holds that get an inline "Answer" CTA (opens the session so the operator
+ *  can reply). These occur OUTSIDE the plan phase, so this is handled in R1's non-planning arm
+ *  — the plan-phase rules R2–R12 are unaffected. */
+const ANSWERABLE = new Set<HoldReason["code"]>(["autopilot-paused", "blocked-yes-no"]);
 
 /** One ordered classifier, first match wins. Reads only `session` (synchronous with the
  *  row) + `gate`/`serverHold` (both async — a missing `gate` degrades to passthrough/none,
@@ -51,7 +57,10 @@ export function rowState(
   const parked = session.status === "idle" || session.status === "done";
   const atCap = chip.kind === "changes" && chip.round >= chip.cap;
 
-  if (session.planPhase !== "planning") return "passthrough"; // R1
+  if (session.planPhase !== "planning") {
+    if (serverHold && ANSWERABLE.has(serverHold.code)) return "server-answer"; // R1a
+    return "passthrough"; // R1
+  }
   if (
     session.status === "blocked" ||
     session.haltReason != null ||
@@ -90,6 +99,7 @@ const LINE: Record<RowState, (ctx: Ctx) => string | null> = {
   passthrough: serverLine,
   dismissed: serverLine,
   none: serverLine,
+  "server-answer": serverLine,
   reviewing: ({ gate }) => {
     const n = gate?.findings?.length ?? 0;
     return n > 0 ? m.hold_reviewing_findings({ count: n }) : m.hold_reviewing_plain();
@@ -125,6 +135,11 @@ const answer = (): HoldAction => ({
   label: m.hold_cta_answer(),
   title: m.hold_cta_answer_title(),
 });
+const reply = (): HoldAction => ({
+  kind: "reply",
+  label: m.hold_cta_answer(),
+  title: m.hold_cta_answer_reply_title(),
+});
 
 const ACTION: Record<RowState, () => HoldAction | null> = {
   passthrough: () => null,
@@ -137,6 +152,7 @@ const ACTION: Record<RowState, () => HoldAction | null> = {
   question: answer,
   "awaiting-rereview": rereview,
   ready: go,
+  "server-answer": reply,
 };
 
 /** Classify the row, then read its line and action off the two total maps. */


### PR DESCRIPTION
Implements three of the four deferrals recorded in #1610 (plan-gate row CTA follow-ups). The fourth item and one half of another are moved to #1629.

## What's in this PR

### #1 — Durability: re-drive `consider()` on the idle settle edge (server)
`onStatusIndependent` fired `planGate.consider()` only on `status === "done"`, so a plan-gate session that revised its plan and settled to **idle** (herdr's default) parked indefinitely in `awaiting-rereview`. Now a new pure predicate `shouldConsiderOnSettle(status, planPhase, priorDecision)` also re-drives on the `idle` edge — but **only when the prior gate decision is `changes_requested`** (the revise loop). That scoping deliberately excludes:
- the **pre-first-draft** window (no gate ⇒ partial authoring idles can't spawn reviews and exhaust the adversarial cap — hash-dedup does *not* protect there, each partial hashes differently), and
- **`error`** gates (`consider()` never dedups those, so idle-firing would spam re-reviews + `stall` signals).

`done` still fires unconditionally in planning; `mapState` is untouched.

### #3 — Badge: don't tone `pg-stalled` during a genuine final round (UI)
`PlanGateBadge`'s `stalled` used a chip-only heuristic (`round >= cap`) that ignored `finalRoundPending`, so the badge showed amber "stalled" toning + the stall-recovery menu while the agent was *actively revising* the final round. Replaced with a pure `planGateStalledNow(session, gate, reviewing, now)` = `canShowPlanStallActions(...) && planStallStatus(gate, now) === "stalled"`, driven by the shared reactive clock; toning, menu, and tooltip now agree. Deliberate consequence: **running ⇒ not stalled** everywhere (consistent with `canShowPlanStallActions`).

### #4 (Answer half) — "Answer" CTA for autopilot-paused / blocked-yes-no rows (UI)
The row classifier was plan-gate-scoped (R1 sent every non-planning row to `passthrough`, no CTA). Added a strictly-additive `server-answer` branch in R1's **non-planning arm** for `autopilot-paused` / `blocked-yes-no` holds, with an **Answer** CTA (label reuses `hold_cta_answer`; internal `reply` kind) that opens the session (`onselect(id)`) so the operator can reply in the terminal. Every planning-phase rule (R2–R12) stays byte-identical.

## Scope boundary
#1's idle self-heal fixes only the **indefinite** park. It does **not** close the brief steer→running window where the row shows `Re-review` while the agent is already revising (that edge is `changes_requested → running`, no settle trigger, and would dedup on the unchanged pre-revision plan). The manual `Re-review` button stays useful and is not removed. A watcher/settle-debounce to close that window is out of scope.

## Deferred to #1629
- #1610 item **#2** — re-tier `plan-rework` by whose-turn-it-is (rundown + digest + push blast radius).
- #1610 item **#4 (Retry-CI half)** — a `Retry CI` CTA for `ci-red`; the row lacks the failed workflow `runId` (the hold carries only `{ pr }`), so it needs an extra run-resolution fetch outside plan-gate scope.

## Verification
- Root `bun test ./test`: 6393 pass. UI `bun run check`: 0 errors. UI node vitest: 2130 pass (new predicate + classifier + badge cases). `bun run check:i18n`: parity (2805 keys/locale). New `UnitRow.browser.test.ts` case is CI-verified (playwright).
- PR-hygiene gates green: branch-hygiene (linear off main), feature-catalog (What's-New entry `v1.43.0-hold-row-answer.ts`), glossary, announcement-versions, fallow audit.

Closes #1610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
