### PR TITLE
fix(build-queue): arm reconcile gate on 1Hz running events, not the 15s sweep (#1617)

### DIFF
--- a/src/build-queue-reminder.ts
+++ b/src/build-queue-reminder.ts
@@ -53,7 +53,9 @@ interface DebounceEntry {
   idleSince: number | null;
   /** true once a reminder fired in the current idle episode (reset when it re-activates). */
   firedThisEpisode: boolean;
-  /** true once we've observed the session actually running since we began tracking it. */
+  /** true once we've observed the session actually running since we began tracking it — set
+   *  either by the 15s sweep sampling `running`, or (reliably) by `markRan`, fed from the poller's
+   *  1 Hz `session:status` running transitions so a sub-15s burst can't slip the gate (#1617). */
   sawRunning: boolean;
   /** lifetime reminders sent to this session (runaway guard). */
   nudgeCount: number;
@@ -73,6 +75,9 @@ export class BuildQueueReminderService {
   private idleThresholdMs: number;
   private maxNudges: number;
   private debounce = new Map<string, DebounceEntry>();
+  /** Per-session last-logged diagnostic tuple, so the #1617 sweep log dedupes on discrete-state
+   *  transitions instead of spamming every 15s tick. Pruned alongside the debounce entry. */
+  private lastDiag = new Map<string, string>();
   /** True while a sweep is in flight. Guards re-entrancy now that `sweep` awaits its steer
    *  (#1567) — see the drop-the-tick rationale on `sweep`. */
   private sweeping = false;
@@ -86,6 +91,21 @@ export class BuildQueueReminderService {
   /** Drop a session's debounce state (call on archive). */
   forget(id: string): void {
     this.debounce.delete(id);
+    this.lastDiag.delete(id);
+  }
+
+  /**
+   * Arm the evidence gate from an observed `running` transition — the RELIABLE arming path, fed by
+   * the poller's 1 Hz `session:status` events (wired in index.ts). The sweep's own 15s sample can
+   * miss a herdr-`working` burst that starts and finishes between ticks — `status` is a
+   * point-in-time level, not a "recently-active" latch (#1617) — so a bursty agent would never set
+   * `sawRunning` via the sweep alone. The caller gates this to a `running` event on an approved,
+   * non-empty queue outside the plan gate (mirroring the sweep's own guards), so here we just record
+   * the evidence. Arming ONLY on observed-running preserves the worked-vs-never-started
+   * discriminator: a never-started session emits no `running` event, so it is never nudged.
+   */
+  markRan(id: string): void {
+    this.entry(id).sawRunning = true;
   }
 
   private entry(id: string): DebounceEntry {
@@ -133,6 +153,9 @@ export class BuildQueueReminderService {
       for (const id of [...this.debounce.keys()]) {
         if (!live.has(id)) this.debounce.delete(id);
       }
+      for (const id of [...this.lastDiag.keys()]) {
+        if (!live.has(id)) this.lastDiag.delete(id);
+      }
     } finally {
       this.sweeping = false; // a thrown store error / rejected steer must not wedge the sweep off
     }
@@ -149,6 +172,7 @@ export class BuildQueueReminderService {
     // No approved queue yet (or none authored) → nothing to reconcile; drop any state.
     if (!q.approved || q.steps.length === 0) {
       this.debounce.delete(id);
+      this.lastDiag.delete(id);
       return;
     }
     const e = this.entry(id);
@@ -157,14 +181,18 @@ export class BuildQueueReminderService {
     // all-pending — no execution step has begun, so all-pending is correct, not drift. Return
     // BEFORE the status switch so planning-phase running never sets sawRunning (readyToNudge
     // ANDs on sawRunning, so this alone suppresses the nudge) and idle time can't accrue toward
-    // a post-gate nudge. NOTE: execution CAN occur while still "planning" (operator manually
-    // steers instead of clicking Go); we suppress there too by design — the PR-open flip to
-    // "executing" (service.advanceToExecutionOnPr) is the deliberate re-arm point, after which
-    // a fresh execution-running tick sets sawRunning and genuine drift nudges normally.
+    // a post-gate nudge. The same guard is mirrored on the markRan arming path (index.ts skips
+    // running events while planning). NOTE: execution CAN occur while still "planning" (operator
+    // manually steers instead of clicking Go); we suppress there too by design — the PR-open flip
+    // to "executing" (service.advanceToExecutionOnPr) is the deliberate re-arm point, after which
+    // a fresh execution-running transition (via markRan or the sweep) sets sawRunning and genuine
+    // drift nudges normally.
     if (planPhase === "planning") {
       this.resetEpisode(e);
       return;
     }
+
+    this.logDiag(id, status, planPhase, e, q, now);
 
     // Only `idle` is eligible. `running` records work-seen; everything else (done/blocked/
     // archived) is skipped without steering. All non-idle states reset the idle episode.
@@ -186,6 +214,33 @@ export class BuildQueueReminderService {
       e.firedThisEpisode = true;
       e.nudgeCount++;
     }
+  }
+
+  /**
+   * Read-only diagnostic (#1617): for an executing, drifted queue, log the gate inputs so the NEXT
+   * live occurrence resolves hypothesis (a) — sawRunning never armed while the agent worked — vs
+   * (e) — status never `idle`. Deduped on the discrete-state tuple so a session parked for hours
+   * logs transitions, not thousands of identical ticks. Purely observational: no control flow
+   * depends on it.
+   */
+  private logDiag(
+    id: string,
+    status: SessionStatus,
+    planPhase: Session["planPhase"],
+    e: DebounceEntry,
+    q: BuildQueue,
+    now: number,
+  ): void {
+    if (planPhase !== "executing" || !isQueueDrifted(q)) return;
+    const ready = this.readyToNudge(e, q, now);
+    const key = `${status}|${e.sawRunning}|${e.idleSince !== null}|${ready}`;
+    if (this.lastDiag.get(id) === key) return;
+    this.lastDiag.set(id, key);
+    const idleMs = e.idleSince === null ? "-" : String(now - e.idleSince);
+    console.log(
+      `[build-queue] reconcile-sweep id=${id} status=${status} planPhase=${planPhase} ` +
+        `sawRunning=${e.sawRunning} idleSinceMs=${idleMs} readyToNudge=${ready}`,
+    );
   }
 
   /** Whether a settled-idle session is eligible for a reconcile nudge this episode. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -955,6 +955,23 @@ events.subscribe((event, data) => {
   if (status !== "running") prPoller.pollSession(id);
 });
 
+// Build-queue reconcile backstop (#1617): arm the reminder's evidence gate from the poller's 1 Hz
+// `running` transitions, not the reminder's own coarse 15s sweep. A herdr-`working` burst that
+// starts and finishes between two sweeps would otherwise never set `sawRunning` (status is a
+// point-in-time level, not a "recently-active" latch), so a bursty agent's drift would never nudge.
+// Gate to a running transition on an approved, non-empty queue OUTSIDE the plan gate — mirroring the
+// sweep's own guards; arming only on observed-running keeps the worked-vs-never-started discriminator.
+events.subscribe((event, data) => {
+  if (event !== "session:status") return;
+  const { id, status } = data as { id: string; status: string };
+  if (status !== "running") return;
+  const s = store.get(id);
+  if (!s || s.planPhase === "planning") return;
+  const q = store.getBuildQueue(id);
+  if (!q.approved || q.steps.length === 0) return;
+  buildQueueReminder.markRan(id);
+});
+
 // Manual operator steps (#1059): when a session's PR body is (re)fetched, parse any
 // shepherd:manual-steps carrier + `Manual-Step:` trailers and persist them on the session, so the
 // backlog chip + Done recap surface them. Throttled on head SHA so we don't re-`gh pr view` on

--- a/test/build-queue-reminder.test.ts
+++ b/test/build-queue-reminder.test.ts
@@ -179,6 +179,60 @@ test("plan gate: planning suppresses, then executing nudges once after a post-fl
   expect(h.steers).toEqual([RECONCILE_STEER]);
 });
 
+// ── sweep: #1617 event-driven arming (burst race, boundary, discriminator) ──
+
+test("burst missed by the 15s sweep: markRan (poller 1Hz event) arms where the sweep alone can't", async () => {
+  const h = harness("idle", queue(true, ["pending", "pending", "pending"]));
+  h.state.planPhase = "executing";
+
+  // The agent's herdr-`working` burst falls entirely between two 15s sweeps, so the sweep NEVER
+  // samples "running". This is the pre-fix behavior: sawRunning never arms → a drifted, settled-idle
+  // executing session gets ZERO steers (the #1617 bug).
+  await h.svc.sweep(); // first idle tick → idleSince
+  h.state.t += THRESHOLD + 1;
+  await h.svc.sweep(); // settled, but sawRunning false → no steer
+  expect(h.steers).toHaveLength(0);
+
+  // The fix: the poller caught the same burst at 1 Hz and emitted session:status "running" →
+  // markRan. Now the settled-idle drifted session nudges exactly once.
+  h.svc.markRan("S");
+  h.state.t += THRESHOLD + 1;
+  await h.svc.sweep();
+  expect(h.steers).toEqual([RECONCILE_STEER]);
+});
+
+test("boundary: armed via markRan but flapping into blocked resets the settle → no steer", async () => {
+  const h = harness("idle", queue(true, ["pending", "pending"]));
+  h.state.planPhase = "executing";
+  h.svc.markRan("S"); // agent ran earlier → armed
+
+  // Its windows are non-idle: every time idle starts to accrue, a `blocked` tick resets it, so the
+  // 120s settle never completes. Arming is real, but the fix must NOT rescue a non-idle session.
+  await h.svc.sweep(); // idle tick → idleSince set
+  h.state.status = "blocked";
+  await h.svc.sweep(); // blocked → resetEpisode wipes idleSince
+  h.state.status = "idle";
+  await h.svc.sweep(); // idle again → settle restarts from now
+  h.state.t += THRESHOLD - 1; // not yet past threshold since the restart
+  await h.svc.sweep();
+  expect(h.steers).toHaveLength(0);
+});
+
+test("never-started discriminator: executing + drifted but never observed running → no steer, no RECONCILE_STEER", async () => {
+  const h = harness("idle", queue(true, ["pending", "pending"]));
+  h.state.planPhase = "executing";
+
+  // No markRan, no running sweep — the agent never worked. sawRunning stays false, so the session is
+  // never nudged and RECONCILE_STEER (whose text assumes work happened) is never sent to it.
+  await h.svc.sweep();
+  h.state.t += THRESHOLD + 1;
+  await h.svc.sweep();
+  h.state.t += THRESHOLD + 1;
+  await h.svc.sweep();
+  expect(h.steers).toHaveLength(0);
+  expect(h.steers).not.toContain(RECONCILE_STEER);
+});
+
 // ── sweep: episode reset + lifetime cap + retry ─────────────────────────────
 
 test("episode reset: re-running between idle episodes allows another steer", async () => {


### PR DESCRIPTION
Fixes #1617.

## Problem

The build-queue **reconcile backstop** never fired for some Go-released `executing` sessions with an approved, all-pending queue — they drifted to `0/N` and never got the settled-idle nudge.

**Provable defect (hypothesis a):** the `sawRunning` evidence gate armed *only* when the reminder's own **15 s** sweep sampled `status === "running"`. But `status` is `mapState(herdr.agent_status)` — a **point-in-time level** polled at 1 Hz with no "recently-active" latch. A herdr-`working` burst that starts and finishes *between two 15 s sweeps* is never sampled, so `sawRunning` never arms and a bursty drifted queue never nudges.

## Honest diagnosis (read the issue's A/B house rule)

Read-only forensic on the four reported sessions (live DB + server log): all were `executing`, `haltReason=NULL` (no quota/error halt), all ran real work (492–918 tool-activity lines), all ended `lastState=done`. **The per-window `idle`/`blocked`/`done` split is unrecoverable** — worktrees + transcripts were removed at archival and the DB keeps no status history.

So:
- Hypothesis **(a)** is a real *latent* defect but **not grounded** as the cause for these four.
- It is **implausible for TASK-1472** (~90 min executing activity would have been sampled running); its ~11 h tail was likely `done` (hypothesis **e**), which the `status!=="idle"` guard **correctly** suppresses.
- **This fix may be a no-op for the reported population if their windows were non-idle (e).** It closes the (a) race for whichever sessions it bit; it deliberately does not (and must not) wake a `done`/`blocked` session.

## Fix

Arm on **observed-running** (preserving the worked-vs-never-started discriminator), but sample it at the poller's real **1 Hz** cadence instead of the reminder's coarse 15 s sweep:

- Subscribe to `session:status` in `index.ts`; on a `running` event for an approved, non-empty queue **outside the plan gate**, call the new `BuildQueueReminderService.markRan(id)`.
- The existing 15 s sweep arming stays as a harmless fallback for sustained running.

A never-started session emits no `running` event → never armed → never nudged, so `RECONCILE_STEER` (whose text assumes work happened) is never mis-sent. **No message change.**

## Forward instrumentation (production falsifiability)

A read-only, **deduped** sweep diagnostic for executing+drifted sessions:

```
[build-queue] reconcile-sweep id=… status=idle planPhase=executing sawRunning=false idleSinceMs=1001 readyToNudge=false
```

On the next live drift this resolves **(a)** (`sawRunning=false` while working) vs **(e)** (`status` never `idle`) and confirms the nudge lands — the surviving trace for the four could not. Purely observational; no control flow depends on it.

## Tests / verification (service-level A/B)

`test/build-queue-reminder.test.ts` (18 pass, 0 fail):
- **Burst-missed-by-sweep A/B:** sweep-only (pre-fix path) → **0** steers; then `markRan` (poller 1 Hz event) → **exactly 1** `RECONCILE_STEER`.
- **Boundary:** armed but flapping into `blocked` (resets `idleSince`) → **0** (honest scope).
- **Never-started discriminator:** executing+drifted, never observed running → **0**, and `RECONCILE_STEER` never emitted.

Full root suite `bun test ./test`: **6507 pass / 0 fail**. `bun run lint`, `bun run typecheck`, `fallow audit`: clean.

## Scope

In scope: `idle` executing drifted sessions **observed running** → one nudge/episode. Out of scope by design: `blocked` (resumable — own subsystems), `done` (badge PR's job), never-observed-running, and non-gated (`planPhase=null`, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
