### PR TITLE
feat: persist operator-language directive across resume + steer (both providers)

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -386,6 +386,11 @@ export function buildHooksFragment(input: {
  *    only: resume() re-passes no `--append-system-prompt` (pre-existing: house rules /
  *    directives don't ride resumes either), so a resumed trimmed session deliberately has
  *    skills off without the notice.
+ *    ONE narrow, deliberate exception (issue #1624): buildClaudeResumeArgv DOES re-pass a
+ *    single `--append-system-prompt` carrying ONLY the `<operator-language>` block (never the
+ *    full directive set) so a compacted/resumed session keeps addressing the operator in their
+ *    language instead of drifting back to English. Empirically verified honored on resume
+ *    (both `-p` and interactive PTY). "en" carries nothing → resume argv stays byte-identical.
  * Measured −6,349 tokens/turn combined in the issue-499 spike. Deliberately NOT
  * `--settings disableAllHooks` — that would kill the operator's global SessionStart hook
  * Shepherd's status pipeline depends on. Interactive spawns are untouched.
@@ -1051,6 +1056,27 @@ const PLAN_GO_STEER_BASE =
 /** Returns the plan-go steer, appending the draft-mode note when `draftMode` is true. */
 export function planGoSteer(draftMode: boolean): string {
   return draftMode ? `${PLAN_GO_STEER_BASE} ${DRAFT_PR_NOTE}` : PLAN_GO_STEER_BASE;
+}
+
+/**
+ * The operator-language directive re-carried as a suffix on an internal steer (#1624). Codex has no
+ * `--append-system-prompt` on resume (buildCodexResumeArgv carries no directive), so the
+ * `<operator-language>` block must re-ride each internal `reply()`-routed steer to persist past the
+ * opening turn — otherwise a compacted/steered Codex session drifts back to English. Claude gets the
+ * block on resume via buildClaudeResumeArgv's append, so its steers carry nothing (→ `""`, keeping
+ * Claude steer text byte-identical). `""` for "en" too (operatorLanguageBlock returns null). Applied
+ * centrally in replyToLive — the single funnel behind reply()/retryHalted — so every internal steer
+ * (autopilot, plan-review/critic, plan-answer, release, preview, retry, build-queue, auto-merge
+ * rebase) picks it up with one injection; operator free-text (operatorReply/broadcast) bypasses
+ * reply() via sendSteerTo and is deliberately excluded.
+ */
+export function operatorLanguageSteerSuffix(
+  provider: AgentProvider,
+  lang: OperatorLanguage,
+): string {
+  if (provider !== "codex") return "";
+  const block = operatorLanguageBlock(lang);
+  return block ? `\n\n${block}` : "";
 }
 
 /**
@@ -2286,6 +2312,12 @@ export class SessionService {
         hooks: { sessionId: s.id, baseUrl, token: config.token },
       }),
     ];
+    // Narrow #499 exception (#1624): re-pass ONLY the operator-language block on resume so a
+    // compacted/resumed session keeps addressing the operator in their language. `null` for "en"
+    // → nothing pushed, so the resume argv stays byte-identical for existing operators. Reads the
+    // live config value, exactly like composeDirectives on the spawn path.
+    const olBlock = operatorLanguageBlock(config.operatorLanguage);
+    if (olBlock) argv.push("--append-system-prompt", olBlock);
     this.pushModelFlag(argv, s.model);
     this.pushEffortFlag(argv, s.effort, "claude");
     return argv;
@@ -3905,7 +3937,14 @@ export class SessionService {
   ): Promise<boolean> {
     const s = this.deps.store.get(id);
     if (!s || !live.has(s.herdrAgentId)) return false; // unknown, or live-in-store / dead-pane
-    await this.sendSteerTo(s, text, signalPayload);
+    // Codex operator-language carrier (#1624): append the block to the delivered PTY text so the
+    // directive persists across steers (Codex has no --append-system-prompt on resume). "" for
+    // Claude/"en", so those steers stay byte-identical. Record the BASE steer text as the `reply`
+    // signal (block excluded, via signalPayload) so the learnings distiller never mines Shepherd's
+    // own directive — mirrors the #1405 epic-notice precedent.
+    const delivered =
+      text + operatorLanguageSteerSuffix(s.agentProvider ?? "claude", config.operatorLanguage);
+    await this.sendSteerTo(s, delivered, signalPayload);
     return true;
   }
 

--- a/test/operator-language-steer.test.ts
+++ b/test/operator-language-steer.test.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "bun:test";
+import { SessionService, operatorLanguageSteerSuffix } from "../src/service";
+import { operatorLanguageBlock } from "../src/operator-language";
+import { config } from "../src/config";
+import type { AgentProvider } from "../src/types";
+
+const BLOCK = operatorLanguageBlock("de")!;
+
+// ── (a) pure operatorLanguageSteerSuffix matrix ──────────────────────────────────────────────
+// Only codex+de carries the block; every other cell is byte-empty (Claude gets the block on resume
+// via --append-system-prompt, "en" has no directive at all).
+test("operatorLanguageSteerSuffix: only codex+de carries the block, else empty", () => {
+  expect(operatorLanguageSteerSuffix("codex", "de")).toBe(`\n\n${BLOCK}`);
+  expect(operatorLanguageSteerSuffix("codex", "en")).toBe("");
+  expect(operatorLanguageSteerSuffix("claude", "de")).toBe("");
+  expect(operatorLanguageSteerSuffix("claude", "en")).toBe("");
+});
+
+// ── (b) service-level: block-presence on the delivered steer text ────────────────────────────
+// The injection lives in replyToLive (below service.reply), so this is the authoritative test for
+// the WHOLE Codex steer channel: every internal reply()-routed steer — autopilot proceed/openPr/
+// CI-fix/rebase, plan-review/critic, plan-answer, releasePlanGate, preview START/SETUP, retry,
+// build-queue RECONCILE/APPROVE, and the auto-merge rebase steer — shares this one code path.
+
+const PASTE_START = "\x1b[200~";
+const PASTE_END = "\x1b[201~";
+
+/** Real SessionService over a stub store + capturing herdr, with a single live pane. */
+function harness(provider: AgentProvider) {
+  const sent: string[] = [];
+  const session = {
+    id: "s1",
+    herdrAgentId: "t1",
+    repoPath: "/r",
+    agentProvider: provider,
+  };
+  const store = {
+    get: () => session,
+    addSignal: () => {},
+  };
+  const svc = new SessionService({
+    store: store as any,
+    namer: async () => "x",
+    worktree: { create: () => ({}) as any, remove: () => {} } as any,
+    herdr: {
+      start: async () => ({}) as any,
+      list: () => [{ terminalId: "t1" }],
+      stop: async () => {},
+      send: async (_target: string, text: string) => {
+        sent.push(text);
+      },
+    } as any,
+  });
+  return { svc, sent };
+}
+
+/** The bracketed-paste chunk delivered to the PTY (the one carrying the steer text). */
+function pastePayload(sent: string[]): string {
+  const chunk = sent.find((c) => c.startsWith(PASTE_START));
+  expect(chunk).toBeDefined();
+  return chunk!.slice(PASTE_START.length, chunk!.length - PASTE_END.length);
+}
+
+// A representative internal steer — using the auto-merge rebase steer's shape to make explicit that
+// automerge.ts:372 (a distinct rebaseSteer from autopilot's) rides the same central injection.
+const STEER =
+  "You're in autopilot and your PR has passed review, but it can't merge as-is — rebase.";
+
+test("service.reply appends the operator-language block to a Codex steer when operatorLanguage=de", async () => {
+  const prev = config.operatorLanguage;
+  config.operatorLanguage = "de";
+  try {
+    const h = harness("codex");
+    expect(await h.svc.reply("s1", STEER)).toBe(true);
+    const delivered = pastePayload(h.sent);
+    expect(delivered).toBe(`${STEER}\n\n${BLOCK}`);
+    expect(delivered).toContain("<operator-language>");
+  } finally {
+    config.operatorLanguage = prev;
+  }
+});
+
+test("service.reply leaves a Codex steer byte-identical when operatorLanguage=en", async () => {
+  const prev = config.operatorLanguage;
+  config.operatorLanguage = "en";
+  try {
+    const h = harness("codex");
+    expect(await h.svc.reply("s1", STEER)).toBe(true);
+    expect(pastePayload(h.sent)).toBe(STEER);
+  } finally {
+    config.operatorLanguage = prev;
+  }
+});
+
+test("service.reply leaves a Claude steer byte-identical even at operatorLanguage=de (resume-append covers Claude)", async () => {
+  const prev = config.operatorLanguage;
+  config.operatorLanguage = "de";
+  try {
+    const h = harness("claude");
+    expect(await h.svc.reply("s1", STEER)).toBe(true);
+    expect(pastePayload(h.sent)).toBe(STEER);
+  } finally {
+    config.operatorLanguage = prev;
+  }
+});

--- a/test/service-release.test.ts
+++ b/test/service-release.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "bun:test";
 import { SessionService, DRAFT_PR_NOTE } from "../src/service";
+import { operatorLanguageBlock } from "../src/operator-language";
+import { config } from "../src/config";
 
 /** A full-enough Session row for the release-gate path (only the fields the method touches). */
 function sess(over: Record<string, unknown> = {}) {
@@ -103,4 +105,39 @@ test("releasePlanGate steers WITH draft note when draftMode=true", async () => {
   expect(await h.svc.releasePlanGate("s1")).toBe(true);
   const steerText = h.sent.map((s) => s.text).join("");
   expect(steerText).toContain(DRAFT_PR_NOTE);
+});
+
+// #1624: the plan-go steer is a reply()-routed internal steer, so a Codex session at
+// operatorLanguage=de re-carries the <operator-language> block on it; Codex+en and Claude do not.
+test("releasePlanGate re-carries the operator-language block on a Codex steer at de", async () => {
+  const prev = config.operatorLanguage;
+  config.operatorLanguage = "de";
+  try {
+    const h = harness({ session: sess({ agentProvider: "codex" }), gate: { approved: true } });
+    expect(await h.svc.releasePlanGate("s1")).toBe(true);
+    expect(h.sent.map((s) => s.text).join("")).toContain(operatorLanguageBlock("de")!);
+  } finally {
+    config.operatorLanguage = prev;
+  }
+});
+
+test("releasePlanGate carries NO operator-language block for Codex+en or Claude+de", async () => {
+  const prev = config.operatorLanguage;
+  const marker = "<operator-language>";
+  try {
+    config.operatorLanguage = "en";
+    const en = harness({ session: sess({ agentProvider: "codex" }), gate: { approved: true } });
+    expect(await en.svc.releasePlanGate("s1")).toBe(true);
+    expect(en.sent.map((s) => s.text).join("")).not.toContain(marker);
+
+    config.operatorLanguage = "de";
+    const claude = harness({
+      session: sess({ agentProvider: "claude" }),
+      gate: { approved: true },
+    });
+    expect(await claude.svc.releasePlanGate("s1")).toBe(true);
+    expect(claude.sent.map((s) => s.text).join("")).not.toContain(marker);
+  } finally {
+    config.operatorLanguage = prev;
+  }
 });

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -30,6 +30,7 @@ import {
   detectEpicIntent,
   UntrustedIssueAuthorError,
 } from "../src/service";
+import { operatorLanguageBlock } from "../src/operator-language";
 import { WorktreeRestoreError } from "../src/worktree";
 import { HOUSE_RULES_TAG } from "../src/house-rules";
 import { config, parseTrimAutoContext } from "../src/config";
@@ -2673,6 +2674,55 @@ test("resume omits --model when the session had none", async () => {
     "--settings",
     spawnSettingsOverlay(),
   ]);
+});
+
+// #1624: a "de" operator-language re-carries the <operator-language> block on the Claude resume
+// argv via --append-system-prompt (the one narrow #499 exception). "en" stays byte-identical
+// (asserted by the two byte-identity tests above, which run under the default "en" config).
+test("resume re-appends ONLY the operator-language block when operatorLanguage=de", async () => {
+  const prev = config.operatorLanguage;
+  config.operatorLanguage = "de";
+  try {
+    const store = new SessionStore(":memory:");
+    const calls: any = {};
+    const svc = new SessionService({
+      store,
+      namer: async () => "x",
+      worktree: {
+        create: () => ({}) as any,
+        ensureBaseRef: async () => {},
+        remove: () => {},
+        branchExists: () => false,
+      } as any,
+      herdr: {
+        start: async (_n: string, _c: string, argv: string[]) => {
+          calls.argv = argv;
+          return { terminalId: "term_new", agentStatus: "working" } as any;
+        },
+        list: () => [],
+        stop: async () => {},
+        send: () => {},
+      } as any,
+    });
+    const s = resumable(store, { model: null });
+    await svc.resume(s.id);
+    const block = operatorLanguageBlock("de")!;
+    expect(calls.argv).toEqual([
+      "claude",
+      "--dangerously-skip-permissions",
+      "--resume",
+      "abc-123",
+      "--settings",
+      spawnSettingsOverlay(),
+      "--append-system-prompt",
+      block,
+    ]);
+    // carries ONLY the operator-language block — none of the fresh-spawn directive blocks
+    expect(block).toContain("<operator-language>");
+    expect(block).not.toContain("<engineering-posture>");
+  } finally {
+    config.operatorLanguage = prev;
+  }
 });
 
 test("resume uses codex resume --last for codex sessions", async () => {


### PR DESCRIPTION
Part 1 of epic #1616 · closes #1624 · follow-up to #1586 / #1615.

## Problem

The `<operator-language>` directive only rode the two fresh-spawn argv builders (`composeSystemPrompt` → `composeDirectives`), so it evaporated after the opening turn:

- **Claude** — `buildClaudeResumeArgv` deliberately re-passes no `--append-system-prompt` (the #499 no-directives-on-resume rule). A compacting/resuming session drifted back to English.
- **Codex** — no `--append-system-prompt` at all; the directive rode inline on the opening prompt only, and no steer re-carried it.

This is #1586's motivating scenario: drift *after* plan reviews / critic feedback / steers.

## Change

- **Claude resume** — `buildClaudeResumeArgv` re-passes **only** the `<operator-language>` block via `--append-system-prompt` (a narrow, documented exception to the #499 rule, noted inline next to the existing #499 note). `null` for `"en"` → resume argv stays byte-identical.
- **Codex steers** — new `operatorLanguageSteerSuffix(provider, lang)` injected **centrally** in `replyToLive` (the sole funnel behind `reply()`/`retryHalted()`). Every internal `reply()`-routed steer picks it up with one edit: autopilot proceed/openPr/CI-fix/rebase, plan-review/critic (`planSteerText`), plan-answer (`planAnswerSteerText`), `releasePlanGate`, preview START + SETUP, retry, build-queue `RECONCILE_STEER`/`APPROVE_STEER`, and the auto-merge rebase steer. The recorded `reply` signal keeps the base steer text (block excluded, mirroring the #1405 epic-notice precedent).

`""` for Claude (resume-append covers it) and for `"en"` everywhere → byte-identical for existing operators; Claude steer text unchanged. `operatorReply`/`broadcast` (operator free-text, via `sendSteerTo`) are deliberately excluded.

## ## Phase-0 evidence — is `--append-system-prompt` honored on `--resume`?

**Verdict: HONORED** (both modes). Built the honored branch (resume-append).

Sentinel directive appended on resume: `End every reply with the exact token QZX9-SENTINEL ...`

### A) Headless `-p` (scriptable)
- Resume WITH block → reply ended with `QZX9-SENTINEL`.
- Resume WITHOUT block (baseline) → no sentinel.

### B) Interactive PTY (Shepherd's real resume path, bracketed-paste + CR)
- Resume WITH block → `SENTINEL_PRESENT: True`; reply "A compiler translates source code..." followed by `QZX9-SENTINEL`.

Mode-fidelity caveat resolved: both the headless and the interactive-PTY resume paths honor the appended block, so no mode mismatch.

## Tests

- Resume argv: `de` re-appends **only** the operator-language block; `en` byte-identical (existing byte-identity resume tests stay green).
- Service-level (real `SessionService` + `herdr.send` capture) driving `service.reply()` over the provider×lang matrix — the authoritative proof for the whole Codex steer channel, since every internal steer shares the one `replyToLive` injection.
- `releasePlanGate` carrier test (Codex+de present; Codex+en / Claude absent).
- Pure `operatorLanguageSteerSuffix` matrix.
- `automerge.test.ts` unchanged & green — it stubs `service.reply` (asserts call-count/setState, not steer text), so the injection never runs there.
- Full root suite: 6511 pass / 0 fail. `lint` + `typecheck` clean.

## Known residual gap (disclosed, not closed)

A resumed **Codex** process carries no operator-language directive from resume until its next `reply()`-routed steer (`buildCodexResumeArgv` has no system-prompt carrier; `codex resume` takes no such flag). Flagged for a possible epic follow-up.

[no-feature-entry] — server-only persistence fix; the operator-language feature (#1586) already has its catalog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)