### PR TITLE
ci: run CI + PR hygiene on epic/** base PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    # Also run on PRs targeting an epic integration branch (epic/**) so epic-child
+    # PRs get CI — the adversarial reviewer gates on green CI, which the epic drain
+    # needs. The Fallow audit already diffs against origin/${{ github.base_ref }},
+    # so it scopes to the epic base automatically (no other job is base-relative).
+    branches: [main, "epic/**"]
   push:
     branches: [main]
 

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -5,7 +5,11 @@ name: PR hygiene
 # branches drags their commits + a bloated diff into the PR).
 on:
   pull_request:
-    branches: [main]
+    # Include epic integration branches so epic-child PRs are gated too (the epic
+    # drain needs green CI). The hygiene scripts below are scoped to the PR's real
+    # base via BASE_REF, so they compare against the epic branch — not main — and
+    # don't false-fail on the epic branch's own accumulated commits.
+    branches: [main, "epic/**"]
 
 # Least privilege: these jobs only read git + run local check scripts. Without an
 # explicit block the token inherits the repo/org default (write-all unless the repo
@@ -26,6 +30,15 @@ jobs:
     if: ${{ !(startsWith(github.head_ref, 'release-please--') && (github.event.pull_request.user.login == 'shepherd-release-please[bot]' || github.event.pull_request.user.login == 'github-actions[bot]')) }}
     # Pinned to GitHub-hosted — public repo, no CI_RUNNER toggle (see ci.yml).
     runs-on: ubuntu-latest
+    # Scope the range-based checks (branch-hygiene, feature-catalog, announcement-
+    # versions — all honour $BASE_REF, default origin/main) to the PR's ACTUAL base.
+    # For a PR targeting main this is origin/main (unchanged). For an epic-child PR
+    # it's the epic integration branch, so the checks measure only the child's own
+    # commits instead of dragging in the epic branch's accumulated history off main.
+    # checkout below is fetch-depth:0, so origin/<base_ref> resolves (as ci.yml's
+    # Fallow audit already relies on).
+    env:
+      BASE_REF: origin/${{ github.base_ref }}
     steps:
       - name: Checkout PR head (the real branch tip, not the merge ref)
         uses: actions/checkout@v7


### PR DESCRIPTION
## Problem

Epic-child PRs target the epic integration branch (`epic/**`), but both `pull_request` workflows filter on `branches: [main]`. GitHub's `branches:` filter matches the PR's **base**, so epic-child PRs get **no CI checks at all**. The adversarial reviewer gates on green CI, so with no checks the epic never drains.

(Concretely: PR #1634, base `epic/1616-…`, shows "no checks reported.")

## Change

- Add `epic/**` to the `pull_request` base-branch filter on **ci.yml** and **pr-hygiene.yml** (glob filter-patterns are supported; the filter matches the base branch).
- Thread `BASE_REF=origin/${{ github.base_ref }}` into pr-hygiene's range-scoped checks (`check-branch-hygiene.sh`, `check-feature-catalog.sh`, `check-announcement-versions.mjs` — all already honour `$BASE_REF`, defaulting to `origin/main`). Without this, an epic-child PR would be measured against `main` and **false-fail** branch-hygiene on the epic branch's own accumulated commits (red CI wouldn't unblock the critic either). ci.yml's Fallow audit already uses `origin/${{ github.base_ref }}`, so it needs only the trigger widening.

Main-targeted PRs are unchanged (`base_ref=main` → `origin/main`; same behaviour as today). checkout is already `fetch-depth: 0`, so `origin/<base_ref>` resolves.

Scope is intentionally the two **required** gates (CI + PR hygiene) — the minimum for the critic to run. `pr-title.yml` / `onboarding-release-gate.yml` were left as-is.

## Side-effect to be aware of

`doc-automerge.yml` triggers on `workflow_run: workflows: ["CI","PR hygiene"] completed`. Once those run on epic-child PRs, their completions will fire doc-automerge for epic children too. Its own merge guards (signoff / checks) still apply, but worth confirming it behaves as intended for epic-child PRs.

## Manual step

Because `pull_request` evaluates the workflow from the base branch, an **already-open** epic child (e.g. #1634) only picks up the new triggers once the epic branch carries these workflow files.

```shepherd:manual-steps
- [ ] POST-MERGE: Rebase the open epic integration branch(es) (e.g. epic/1616-…) onto updated main so their child PRs inherit the epic/** triggers, then re-push (or reopen) an epic-child PR to trigger CI. Future epic branches cut from main inherit it automatically.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)