### PR TITLE
feat(prompt): worktree git-stash safety notice (#1632)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,14 @@ Every PR branch must be cut from the **latest `main`** and kept **linear**:
 
 A branch that merges other branches drags their commits + a bloated diff into the PR. The gate `scripts/check-branch-hygiene.sh` fails any branch with merge commits relative to main; it runs in the **PR hygiene** CI workflow and the pre-push hook. To fix a polluted branch, re-create it off main with just your change (`git checkout -b <branch> origin/main` then cherry-pick / `rebase --onto origin/main`).
 
+## Never `git stash` in a worktree (shared `refs/stash`)
+
+`refs/stash` is a **single stack shared across every worktree of the repo** — there is no per-worktree isolation. A bare `git stash` / `git stash pop` in one session can grab or discard another concurrent session's entry, and `stash@{n}` indices race. So never run bare `git stash` / `git stash pop` (this is also injected into every agent's system prompt as `<worktree-stash-notice>`, so subagents get it too):
+
+- **To inspect or diff base state** without mutating the working tree, use read-only commands: `git show <ref>:<path>`, `git diff <ref>`, or a throwaway `git worktree add`. This is the primary safe path.
+- **If you must shelve local changes**, use `git stash create` (it prints a commit SHA **without** writing the shared `refs/stash` stack, and captures **tracked changes only** — untracked files are not saved), record that SHA yourself, and later restore with `git stash apply <sha>`.
+- **Never `git stash store`** — it writes into the same shared `refs/stash` stack and reproduces the exact collision `git stash create` avoids.
+
 ## Design system (REQUIRED for any UI work)
 
 The UI has a **semantic token layer** (`ui/src/app.css` — `--color-*` surfaces/text/accents, the `--fs-*` type scale, `--status-*`/`--wash-*`) and a live reference page that documents it plus the canonical component recipes: **`/design-system`** (`ui/src/routes/design-system/+page.svelte`). It exists to stop **design drift** — every session re-inventing buttons, spacing and colors. Before authoring any UI:

--- a/src/service.ts
+++ b/src/service.ts
@@ -419,6 +419,27 @@ const BRANCH_RENAME_NOTICE =
   "commits, and checked-out HEAD are unaffected — never treat a changed branch name as an error.";
 
 /**
+ * Appended to every spawned session's system prompt. `refs/stash` is a single stack shared
+ * across every worktree of a repo (there is no per-worktree isolation), so a bare `git stash`
+ * / `stash pop` in one Shepherd session can grab or discard another concurrent session's entry
+ * — a latent data-loss footgun (issue #1632). A global git-mechanism invariant, not per-repo
+ * learned guidance, so it lives in source and rides every spawn as its own block rather than in
+ * the `<shepherd-house-rules>` block. `git stash store` is deliberately NOT recommended: it
+ * writes into the same shared `refs/stash` stack and reproduces the collision. Not user-facing
+ * chrome (an instruction to the agent), so fixed English — same precedent as BRANCH_RENAME_NOTICE.
+ */
+const WORKTREE_STASH_NOTICE =
+  "Never run bare `git stash` / `git stash pop` in a Shepherd checkout — `refs/stash` is a " +
+  "single stack shared across every worktree of the repo, so concurrent sessions collide (a pop " +
+  "or drop can grab or discard another session's entry). To inspect or diff base state, use " +
+  "read-only commands that don't touch the working tree: `git show <ref>:<path>`, `git diff " +
+  "<ref>`, or a throwaway `git worktree add`. If you must shelve local changes, use `git stash " +
+  "create` (it prints a commit SHA without writing the shared `refs/stash` stack, and captures " +
+  "tracked changes only — untracked files are not saved), record that SHA yourself, and later " +
+  "restore with `git stash apply <sha>` — never `git stash store` (it writes the shared stack " +
+  "and reproduces the collision) and never bare `git stash` / `git stash pop`.";
+
+/**
  * Injected only into trimmed auto (drain) spawns — sessions launched with
  * `--disable-slash-commands` + an `enabledPlugins:false` settings overlay (issue #499,
  * see trimDecision). Without it, CLAUDE.md / memory instructions like "use the superpowers
@@ -1146,6 +1167,12 @@ export function composeSystemPrompt(
   const blocks = houseRules
     ? [posture, untrustedBoundary, research, houseRules, branchNotice]
     : [posture, untrustedBoundary, research, branchNotice];
+  // Worktree git-stash safety (issue #1632): a global git-mechanism invariant (`refs/stash` is
+  // shared across all worktrees of a repo, so concurrent sessions collide), so it rides EVERY
+  // spawn unconditionally — including research and non-isolated sessions, whose shared-checkout
+  // `git stash` writes the same shared stack. Sibling of branchNotice, not part of the per-repo
+  // house-rules block.
+  blocks.push(`<worktree-stash-notice>\n${WORKTREE_STASH_NOTICE}\n</worktree-stash-notice>`);
   // One-session-one-PR invariant (issue #839): rides every code spawn, suppressed only for a
   // research session — which already caps at exactly one report-PR / issue, so the block is
   // redundant there and would muddy that deliverable.

--- a/test/service-plan-gate.test.ts
+++ b/test/service-plan-gate.test.ts
@@ -204,3 +204,35 @@ test("de plan sidecar instructions carry the field-discipline verbatim-fields li
     expect(t).toContain(field);
   }
 });
+
+// Worktree git-stash safety notice (#1632) — a global git-mechanism invariant that must ride
+// EVERY spawn, regardless of learnings / research / plan-gate / autopilot state.
+test("worktree-stash-notice rides every spawn variant", () => {
+  const variants = [
+    composeSystemPrompt(null, false), // plain code spawn, no learnings
+    composeSystemPrompt("<shepherd-house-rules>\n- x\n</shepherd-house-rules>", false), // with house rules
+    composeSystemPrompt(null, true), // autopilot
+    composeSystemPrompt(null, false, { research: true }), // research
+    composeSystemPrompt(null, true, { planGate: "interactive" }), // plan gate
+  ];
+  for (const p of variants) {
+    expect(p).toContain("<worktree-stash-notice>");
+    expect(p).toContain("refs/stash");
+  }
+});
+
+test("worktree-stash-notice recommends read-only + create/apply, never store or bare stash", () => {
+  const p = composeSystemPrompt(null, false);
+  // Read-only inspection is the primary safe path.
+  expect(p).toContain("git show <ref>:<path>");
+  expect(p).toContain("git diff <ref>");
+  expect(p).toContain("git worktree add");
+  // Safe shelve = create (tracked-only, prints a SHA) + apply <sha>.
+  expect(p).toContain("git stash create");
+  expect(p).toContain("git stash apply <sha>");
+  // `git stash store` writes the shared stack — only ever named as the thing NOT to do.
+  expect(p).toContain("never `git stash store`");
+  expect(p).not.toContain("use `git stash store`");
+  // Bare stash/pop explicitly prohibited.
+  expect(p).toContain("never bare `git stash`");
+});

--- a/ui/src/lib/docs-manifest.ts
+++ b/ui/src/lib/docs-manifest.ts
@@ -81,7 +81,7 @@ export const DOCS_PAGES: readonly DocsPage[] = [
     title: "Project house rules",
     path: "/reference/house-rules/",
     keywords:
-      "shepherd's in-repo contributor & agent house rules (claude.md), rendered verbatim. running checks in a fresh worktree branch hygiene (one feature, linear off main) design system (required for any ui work) internationalization (required for any ui work) feature discovery (required for user-facing features) glossary (required when marking ui terms)",
+      "shepherd's in-repo contributor & agent house rules (claude.md), rendered verbatim. running checks in a fresh worktree branch hygiene (one feature, linear off main) never git stash in a worktree (shared refs/stash) design system (required for any ui work) internationalization (required for any ui work) feature discovery (required for user-facing features) glossary (required when marking ui terms)",
   },
   {
     title: "Keyboard shortcuts",


### PR DESCRIPTION
## What

Adds a source-shipped `<worktree-stash-notice>` directive block, injected into **every** Shepherd spawn's system prompt (any repo, any instance), steering agents off bare `git stash` inside a worktree.

`refs/stash` is a **single stack shared across every worktree of a repo** — no per-worktree isolation. A bare `git stash` / `git stash pop` in one session can grab or discard another concurrent session's entry, and `stash@{n}` indices race. A recurring, latent data-loss footgun (issue #1632).

## Approach

A **standalone directive block**, a sibling of `BRANCH_RENAME_NOTICE` / `SINGLE_PR_INVARIANT`, pushed unconditionally in `composeSystemPrompt` — **not** grafted into the `<shepherd-house-rules>` block. Rationale (per plan review):

- It's a **global git-mechanism invariant**, not per-repo learned guidance, so framing it as "standing guidance for this repo" (the `HOUSE_RULES_INTRO`) would misdescribe it.
- Keeps the learnings system untouched — no fork of `renderHouseRulesBlock`, no change to `recordInjectedHouseRules`'s null contract, no budget-meter/drawer impact.
- Rides every spawn (incl. research + non-isolated sessions — the shared main checkout writes the same `refs/stash`), immune to ranking/budget and independent of `learningsEnabled`.

## Safe alternatives the notice recommends

- **Primary (read-only):** `git show <ref>:<path>`, `git diff <ref>`, or a throwaway `git worktree add`.
- **Shelving:** `git stash create` (prints a SHA **without** writing `refs/stash`; tracked changes only) → record the SHA → `git stash apply <sha>`.
- **Never `git stash store`** — it writes the shared stack and reproduces the collision. Never bare `git stash` / `pop`.

## Files

- `src/service.ts` — `WORKTREE_STASH_NOTICE` constant + block push in `composeSystemPrompt`.
- `test/service-plan-gate.test.ts` — asserts the block rides every spawn variant and recommends read-only + create/apply, never `store` or bare stash/pop.
- `CLAUDE.md` — worktree-safety section documenting the safe alternatives.
- `ui/src/lib/docs-manifest.ts` — regenerated (the CLAUDE.md docs page keywords picked up the new heading).

## Divergence from issue Acceptance (operator-confirmed)

Issue #1632's literal Acceptance asks for a **Learning** "marked Always + proven", visible in the learnings drawer. Learnings are per-repo runtime SQLite rows (distiller-created) that can't ship to other instances via a PR, and a global invariant doesn't belong in the per-repo, budget-limited, age-out-able house-rules system. The operator explicitly accepted shipping this as a standalone source constant instead — invisible in the drawer, not a Learning row, but reaching every session/instance and immune to ranking/budget. The structural git-level guard (isolated per-worktree stash ref namespace / hook wrapper) remains a separate follow-up noted in the issue.

`[no-feature-entry]` — agent-prompt plumbing, ships no user-facing UX.

Closes #1632

🤖 Generated with [Claude Code](https://claude.com/claude-code)