### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs/sandbox-security.md
+++ b/docs/sandbox-security.md
@@ -51,7 +51,7 @@ secrets out of the membrane entirely.
 
 Egress confinement is keyed to the autonomous **profile**, not to whether a human
 is watching (`willEgressConfine`, `src/sandbox.ts:565-570`; applied at
-`src/service.ts:1409`): the wrap applies iff the autonomous profile resolves
+`src/service.ts:1882`): the wrap applies iff the autonomous profile resolves
 **and** the fs + egress backends are present, independent of `ctx.auto`.
 Consequences:
 
@@ -108,19 +108,19 @@ Write --permission-mode dontAsk` (`src/transient-agent-argv.ts`,
   `buildTransientAgentArgv("reviewer", …)`).
 - **Research is the deliberately egress-UNCONFINED surface.** A research session
   that would resolve to `autonomous` is **downgraded to `standard`**
-  (`src/service.ts` `researchSafeProfileOverride`, ~L1796-1814, warns once),
+  (`src/service.ts` `researchSafeProfileOverride`, ~L2474-2491, warns once),
   because research needs **open** web egress (search/fetch + sub-agents) that the
   autonomous firewall would block. It is operator-_created_ (cannot be
   auto-drained — `standard` refuses auto-spawn) but **autopilot-steerable, so it
   runs unattended in practice** (`RESEARCH_PROCEED_STEER`,
-  `src/autopilot.ts:24-29`, dispatched at L307). It ingests **untrusted web**
+  `src/autopilot.ts:24-29`, dispatched at L323). It ingests **untrusted web**
   content on `trusted`/`standard` with the **network open**, and can
   `gh pr create` / open issues via the bound gh token — so a hijacked research
   agent has **both** readable tokens **and** open egress.
 
   **Compensating factors:** the downgrade is explicit and warns once; research
   delivers a **report PR or GitHub issue only, never a code PR**
-  (`src/autopilot.ts:309-313`). The residual is **accepted**.
+  (`src/autopilot.ts:326-330`). The residual is **accepted**.
 
 ## See also
 


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc update — sync to recent source changes

## Changes

- **`docs/sandbox-security.md`** — corrected four source line-number citations that had
  drifted since the last docs sync (source moved by later commits, notably #1429 injection
  hardening, #1615 operator-language injection, and #1636 worktree-stash notice, which all
  grew `src/service.ts`):
  - `willEgressConfine` "applied at `src/service.ts:1409`" → `:1882` (current site of
    `const egressOn = willEgressConfine(...)` in `src/service.ts`).
  - `researchSafeProfileOverride`, `~L1796-1814` → `~L2474-2491` (the method now lives at
    `src/service.ts:2474`).
  - `RESEARCH_PROCEED_STEER` "dispatched at L307" → `L323` (`driveSteer(... RESEARCH_PROCEED_STEER)`
    in `Autopilot.dispatch`, `src/autopilot.ts:323`).
  - research "never a code PR (`src/autopilot.ts:309-313`)" → `:326-330` (the `finished`/research
    `markComplete` branch that skips opening a code PR).

  Other line references in the same file were re-verified against source and remain accurate
  (`src/sandbox.ts` 308-310, 314-317, 413, 438, 554, 565-570; `autoHoldReason` ~L501-502), so
  they were left unchanged.

## Uncertain / needs human judgment

- **`docs-site/src/content/docs/reference/configuration.md`** — verified current: every env var
  added to `src/config.ts` since the last docs sync (`75eef20f`) is already documented
  (`SHEPHERD_HERDR_SOCKET`, `HERDR_SOCKET_PATH`, `SHEPHERD_HERDR_IGNORE_SESSION`,
  `SHEPHERD_OPERATOR_LANGUAGE`). No change made. Note the page is titled "every environment
  variable" but has always omitted a number of operational/obscure vars (e.g.
  `SHEPHERD_STANDARD_COMMAND`, `SHEPHERD_SESSION_HOUSEKEEPING`, `SHEPHERD_LLM_NAMING`,
  the per-role `*_CLI/_MODEL/_EFFORT` vars, `SHEPHERD_AUTH_MODE`, `SHEPHERD_SANDBOX_EXTRA_HOSTS`,
  the herdr/codex update-log paths). This is a pre-existing curation choice, not fresh
  staleness, so I did not add them — a human should decide whether the "every" framing warrants
  filling these in.
- **`docs/external-task-api.md`, `docs/token-usage-analysis.md`, `operating.md`,
  `getting-started.md`, `index.md`, `glossary.md`** — reviewed against current source; found
  current. The egress-allowlist prose (`api.anthropic.com` + `statsig.anthropic.com` + GitHub
  hosts) still matches `src/egress.ts`. No changes made.