### PR TITLE
fix(herdr): gate socket terminal behind opt-in flag so scrolling works

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -551,6 +551,14 @@ export const config = {
   // preview-unstable (see HERDR_SOCKET_SUPPORTED_PROTOCOLS above), so this stays reversible
   // until the socket driver has soaked.
   herdrSocket: process.env.SHEPHERD_HERDR_SOCKET === "1",
+  // Sub-flag gating ONLY the interactive terminal onto herdr's socket `terminal session control`
+  // stream. Default-OFF interim gate: that stream is a screen-diff/redraw protocol, so xterm builds
+  // no scrollback and never sees the app's mouse mode — which kills mobile swipe + desktop wheel
+  // scrolling (the socket terminal renders, but can't be scrolled). Until socket-native scroll is
+  // built and proven for Claude+Codex (Phase B follow-up), keep the terminal on node-pty even when
+  // `herdrSocket` is on; the socket driver still drives send/steer/browser/usage. Flip on to soak
+  // socket-scroll once it lands.
+  herdrSocketTerminal: process.env.SHEPHERD_HERDR_SOCKET_TERMINAL === "1",
   // Push-based agent-info ingestion via Claude Code hooks (issue #704), additive on top
   // of polling, staged behind two default-off flags so each phase is independently reversible.
   // Phase 0: inject PostToolUse/PostToolUseFailure/Notification HTTP hooks into spawned

--- a/src/server.ts
+++ b/src/server.ts
@@ -6831,14 +6831,22 @@ export function pruneSocketTerminalFailures(
   for (const [id, t] of m) if (now - t >= ttl) m.delete(id);
 }
 
-/** Picks the socket bridge only when the driver is active, a pane target resolved, and this
- *  terminal hasn't recently failed over the socket path. */
+/** Picks the socket bridge only when the terminal sub-flag is on (interim gate — see
+ *  `config.herdrSocketTerminal`), the driver is active, a pane target resolved, and this terminal
+ *  hasn't recently failed over the socket path. With the sub-flag off the terminal stays on
+ *  node-pty (scrollable) even while the socket driver runs everything else. */
 export function pickTerminalBridgeKind(opts: {
+  herdrSocketTerminal?: boolean;
   herdrSocketActive?: boolean;
   paneTarget?: string;
   recentlyFailed: boolean;
 }): "socket" | "node-pty" {
-  return opts.herdrSocketActive && opts.paneTarget && !opts.recentlyFailed ? "socket" : "node-pty";
+  return opts.herdrSocketTerminal &&
+    opts.herdrSocketActive &&
+    opts.paneTarget &&
+    !opts.recentlyFailed
+    ? "socket"
+    : "node-pty";
 }
 
 /** The /usage refresh handler drives a multi-second ephemeral `claude` scrape and needs a longer
@@ -6952,6 +6960,7 @@ export function serve(deps: AppDeps, port: number) {
           if (prev && prev !== ws) prev.close(PTY_SUPERSEDED_CODE, "superseded");
           const sock = { send: (d: string | Uint8Array) => ws.send(d), close: () => ws.close() };
           const kind = pickTerminalBridgeKind({
+            herdrSocketTerminal: config.herdrSocketTerminal,
             herdrSocketActive: deps.herdrSocketActive,
             paneTarget: attach.paneTarget,
             recentlyFailed: recentlyFailed(socketTerminalFailures, tid, Date.now()),

--- a/test/socket-terminal-wiring.test.ts
+++ b/test/socket-terminal-wiring.test.ts
@@ -127,15 +127,34 @@ test("livePtyAttach: herdr.list() throws → stored id, no paneTarget (hiccup fa
 
 // ── pickTerminalBridgeKind ───────────────────────────────────────────────────
 
-test("pickTerminalBridgeKind: socket only when all three conditions hold", () => {
+test("pickTerminalBridgeKind: socket only when all conditions hold", () => {
   expect(
-    pickTerminalBridgeKind({ herdrSocketActive: true, paneTarget: "w1:p1", recentlyFailed: false }),
+    pickTerminalBridgeKind({
+      herdrSocketTerminal: true,
+      herdrSocketActive: true,
+      paneTarget: "w1:p1",
+      recentlyFailed: false,
+    }),
   ).toBe("socket");
 });
 
-test("pickTerminalBridgeKind: node-pty when flag is off", () => {
+test("pickTerminalBridgeKind: node-pty when the terminal sub-flag is off (interim gate)", () => {
+  // The default: socket driver active, pane resolved, no recent failure — but the interim
+  // SHEPHERD_HERDR_SOCKET_TERMINAL gate is off, so the terminal stays on scrollable node-pty.
   expect(
     pickTerminalBridgeKind({
+      herdrSocketTerminal: false,
+      herdrSocketActive: true,
+      paneTarget: "w1:p1",
+      recentlyFailed: false,
+    }),
+  ).toBe("node-pty");
+});
+
+test("pickTerminalBridgeKind: node-pty when driver is off", () => {
+  expect(
+    pickTerminalBridgeKind({
+      herdrSocketTerminal: true,
       herdrSocketActive: false,
       paneTarget: "w1:p1",
       recentlyFailed: false,
@@ -146,6 +165,7 @@ test("pickTerminalBridgeKind: node-pty when flag is off", () => {
 test("pickTerminalBridgeKind: node-pty when no paneTarget", () => {
   expect(
     pickTerminalBridgeKind({
+      herdrSocketTerminal: true,
       herdrSocketActive: true,
       paneTarget: undefined,
       recentlyFailed: false,
@@ -155,7 +175,12 @@ test("pickTerminalBridgeKind: node-pty when no paneTarget", () => {
 
 test("pickTerminalBridgeKind: node-pty when recently failed", () => {
   expect(
-    pickTerminalBridgeKind({ herdrSocketActive: true, paneTarget: "w1:p1", recentlyFailed: true }),
+    pickTerminalBridgeKind({
+      herdrSocketTerminal: true,
+      herdrSocketActive: true,
+      paneTarget: "w1:p1",
+      recentlyFailed: true,
+    }),
   ).toBe("node-pty");
 });
 


### PR DESCRIPTION
## Problem

Enabling `SHEPHERD_HERDR_SOCKET=1` (#1529/#1620) routed the interactive terminal onto herdr's `terminal session control` stream — and **killed scrolling in the terminal on mobile** (and desktop wheel).

**Root cause (evidence-backed):** that stream is a screen-diff/**redraw** protocol, not the append-only PTY byte stream xterm.js needs. Decoding live frames from a running Claude pane on the reporting instance, every `full:true` frame is `\x1b[2J` (clear) + absolute cursor-positioned repaint of every cell — **zero newlines** (nothing scrolls off the top, so xterm's scrollback never grows), **no alternate-buffer switch** (`?1049` absent), and **the app's mouse-tracking modes are stripped** (`?1000h`/`?1006h` absent). So in `Viewport.svelte`, `agentOwnsScroll(term)` (`buffer.type==='alternate' || mouseTrackingMode!=='none'`) is false and swipes/wheel route into xterm's empty scrollback, reaching nothing. node-pty streams raw PTY bytes → xterm builds scrollback + sees mouse modes → scroll works.

## Fix (regression-first, Phase A)

Add a **default-OFF** `SHEPHERD_HERDR_SOCKET_TERMINAL` sub-flag that gates **only** the interactive terminal onto the socket. With it off (the default), a `SHEPHERD_HERDR_SOCKET=1` instance keeps the terminal on **node-pty** — restoring native-granularity swipe + wheel scroll immediately — while the socket driver still drives send/steer/browser/usage.

- `src/config.ts` — new `herdrSocketTerminal` flag (default OFF), documented.
- `src/server.ts` — `pickTerminalBridgeKind` now requires the sub-flag; threaded through at the call site. The existing `SocketPtyBridge`/`onFallback` machinery is untouched, just not selected.
- `test/socket-terminal-wiring.test.ts` — covers the new gate condition.

**Blast radius:** none for non-opt-in operators (`SHEPHERD_HERDR_SOCKET` is itself default-OFF). Opt-in operators get the terminal on a proven, already-shipping transport and keep the socket driver everywhere else. Reversible by config.

## Why a gate, not a socket-side fix, in this PR

herdr 0.7.3 has no raw/scrollback-capable terminal transport (`terminal attach` needs a TTY and panics on a pipe), so socket-native scroll requires new work with an unproven lever for the target apps. Rather than leave the reported regression unfixed behind that uncertainty, this PR stops the bleeding now; **socket-native scroll is the follow-up (#1639)**, after which the flag flips on and node-pty can be removed (part of #1529/#1622).

## Verification

- `bun run lint`, `bun run typecheck`, `bun test ./test` (6509 pass, 0 fail) — all green.
- Empirical root-cause + a diagnostic spike proving the socket transport forwards PageUp/PageDown and re-renders scroll (for `less`) informed the follow-up; Claude/Codex transcript-scroll over the socket remains the open risk tracked in #1639.

🤖 Generated with [Claude Code](https://claude.com/claude-code)