### PR TITLE
feat: inject operator-language into rundown/herd-digest + prompt-recommend

### DIFF
--- a/src/herd-digest.ts
+++ b/src/herd-digest.ts
@@ -24,6 +24,7 @@ import type { GitState } from "./forge/types";
 import type { SessionUsage } from "./usage";
 import { readSessionUsage } from "./usage";
 import { isApiKeyMode, isApiKeyConfigured, apiKeyPassthroughEnv } from "./spawn-auth";
+import type { OperatorLanguage } from "./operator-language";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
 import {
   assembleHerdState,
@@ -140,6 +141,8 @@ export interface HerdDigestServiceDeps {
    *  authoritative not-ready→no-spawn decision lives in generate(). Optional — absent → false. */
   hasOpenLandingEpics?: () => boolean;
   model?: string | null;
+  /** Live operator-language setting, read per spawn (#1586). Absent → "en" (no directive). */
+  operatorLanguage?: () => OperatorLanguage;
   now?: () => number;
   timeoutMs?: number;
   topN?: number;
@@ -159,6 +162,7 @@ export class HerdDigestService {
   private timeoutMs: number;
   private topN: number;
   private model: string | null;
+  private operatorLanguage: () => OperatorLanguage;
 
   private _readVerdict: (cwd: string) => string | null;
   private _readUsage: (cwd: string, spawnSessionId: string) => Promise<SessionUsage | null>;
@@ -175,6 +179,7 @@ export class HerdDigestService {
     this.timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.topN = deps.topN ?? RUNDOWN_DEFAULT_TOPN;
     this.model = deps.model ?? "sonnet";
+    this.operatorLanguage = deps.operatorLanguage ?? (() => "en");
     this._readVerdict = deps.readVerdict ?? defaultReadVerdict;
     this._readUsage = deps.readUsage ?? readSessionUsage;
     this._makeTmpDir = deps.makeTmpDir ?? defaultMakeTmpDir;
@@ -339,7 +344,7 @@ export class HerdDigestService {
         })),
       );
 
-      const prompt = buildRundownPrompt(assembled);
+      const prompt = buildRundownPrompt(assembled, this.operatorLanguage());
       const { argv, sessionId: spawnSessionId } = rundownArgv(this.model, prompt);
 
       const cwd = this._makeTmpDir();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1860,6 +1860,8 @@ const landingReadyEpics = async (): Promise<RundownEpicItem[]> => {
 const herdDigestService = new HerdDigestService({
   store,
   herdr,
+  // Live operator-language setting, read per spawn (#1586).
+  operatorLanguage: () => config.operatorLanguage,
   isActive: () => presence.isActive(),
   landingReadyEpics,
   hasOpenLandingEpics: () => store.listEpicCompleted().some((r) => r.landingState === "open"),
@@ -2539,7 +2541,15 @@ const appDeps: AppDeps = {
       return { error: "no-history" as const };
     }
     return recommendPrompt(
-      { tail, taskPrompt: s.prompt, provider, model, label: `recommend ${s.desig}` },
+      {
+        tail,
+        taskPrompt: s.prompt,
+        provider,
+        model,
+        label: `recommend ${s.desig}`,
+        // Live per-call read at the composition root (#1586).
+        operatorLanguage: config.operatorLanguage,
+      },
       { herdr },
     );
   },

--- a/src/prompt-recommend.ts
+++ b/src/prompt-recommend.ts
@@ -11,6 +11,7 @@ import {
   apiKeyPassthroughEnv,
 } from "./spawn-auth";
 import { fenceUntrusted } from "./untrusted";
+import type { OperatorLanguage } from "./operator-language";
 
 /** The file the recommender agent writes its suggestion JSON to, in its temp cwd. */
 export const RECOMMEND_FILE = ".shepherd-recommend.json";
@@ -41,6 +42,9 @@ export interface RecommendArgs {
   model: string;
   /** herdr terminal label for the transient agent. */
   label: string;
+  /** Live operator-language setting (#1586). Optional — absent → "en" (no directive, byte-identical).
+   *  Kept optional so the shared test `args()` helper + existing call sites need no change. */
+  operatorLanguage?: OperatorLanguage;
 }
 
 interface RawSuggestion {
@@ -60,10 +64,14 @@ interface RawSuggestion {
  * initiated on the operator's own session history, same trust boundary as the codex sessions
  * Shepherd already spawns; revisit if codex gains a scoped-permission mode.
  */
-export function recommenderPrompt(tail: string[], taskPrompt: string): string {
+export function recommenderPrompt(
+  tail: string[],
+  taskPrompt: string,
+  operatorLanguage: OperatorLanguage = "en",
+): string {
   const clippedTask = taskPrompt.slice(0, 2000);
   const clippedTail = tail.slice(-120).join("\n").slice(0, 12000);
-  return [
+  const lines = [
     "You are an expert coding-agent supervisor. Another coding agent is working on a task in a",
     "terminal. Read its original task and the recent history of its terminal, then write the SINGLE",
     "most useful next prompt a human operator could send to that agent to move the work forward —",
@@ -81,7 +89,18 @@ export function recommenderPrompt(tail: string[], taskPrompt: string): string {
     '{"prompt": "<the next prompt to send, addressed directly to the agent, ready to paste>"}',
     "The prompt must be concrete, actionable, and specific to this session — not generic advice.",
     "Do not read or modify any other file.",
-  ].join("\n");
+  ];
+
+  if (operatorLanguage === "de") {
+    lines.push(
+      "",
+      "Write the recommended prompt (the `prompt` value) in German — the operator reads it. Keep any " +
+        "code, commands, file paths, identifiers, and quoted agent/tool output embedded in it " +
+        "verbatim; never translate those. The `prompt` JSON key stays literal.",
+    );
+  }
+
+  return lines.join("\n");
 }
 
 const realSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
@@ -206,7 +225,7 @@ export async function recommendPrompt(
   let terminalId: string | null = null;
   try {
     cwd = makeTmpDir();
-    const prompt = recommenderPrompt(args.tail, args.taskPrompt);
+    const prompt = recommenderPrompt(args.tail, args.taskPrompt, args.operatorLanguage ?? "en");
     const argv =
       args.provider === "codex"
         ? codexRecommenderArgv(args.model, prompt)

--- a/src/rundown-core.ts
+++ b/src/rundown-core.ts
@@ -19,6 +19,7 @@ import type { GitState } from "./forge/types";
 import type { BlockReason } from "./blocked";
 import { blockReasonToHoldCode, renderHold } from "./hold";
 import { fenceUntrusted } from "./untrusted";
+import type { OperatorLanguage } from "./operator-language";
 import { planStallStatus } from "./plan-status";
 import { addressStallStatus } from "./review-status";
 
@@ -518,7 +519,10 @@ export function assembleHerdState(input: AssembleInput): AssembledHerdState {
 // ── prompt ───────────────────────────────────────────────────────────────────
 /** The instruction prompt for the rundown spawn. Encodes the triage contract and tells
  *  the agent to Write `.shepherd-rundown.json` as its final action, then stop. */
-export function buildRundownPrompt(assembled: AssembledHerdState): string {
+export function buildRundownPrompt(
+  assembled: AssembledHerdState,
+  operatorLanguage: OperatorLanguage = "en",
+): string {
   const lines = [
     "You are triaging an autonomous-agent fleet for a SINGLE human operator. Your job is to",
     'answer one question: "what needs a human right now?" — across the whole live herd.',
@@ -627,7 +631,7 @@ export function buildRundownPrompt(assembled: AssembledHerdState): string {
           ...assembledForDump,
           sessions: assembled.sessions.map((s) => {
             const { hold, ...rest } = s;
-            if (hold) return { ...rest, why: renderHold(hold, "en") };
+            if (hold) return { ...rest, why: renderHold(hold, operatorLanguage) };
             return rest;
           }),
         },
@@ -636,6 +640,17 @@ export function buildRundownPrompt(assembled: AssembledHerdState): string {
       ),
     ),
   );
+
+  if (operatorLanguage === "de") {
+    lines.push(
+      "",
+      "Write the operator-facing prose fields `overnight`, `train`, and every `label` in " +
+        "`decisions[]`/`ciRework[]`/`focusNext[]` in German. Keep machine-read fields verbatim — " +
+        "never translate `sessionId` (an opaque id) or `pr` (a number). Reproduce any quoted PR/" +
+        "issue title from the herd state in its original language (GitHub text); write only the " +
+        "surrounding synthesis in German.",
+    );
+  }
 
   return lines.join("\n");
 }

--- a/test/prompt-recommend.test.ts
+++ b/test/prompt-recommend.test.ts
@@ -178,3 +178,26 @@ test("recommendPrompt: codex is exempt from the claude api-key guard", async () 
   expect(result).toEqual({ prompt: "go" });
   expect(calls.started).not.toBeNull();
 });
+
+// ─── operator-language injection (issue #1625) ──────────────────────────────
+
+// fenceUntrusted() mints a random per-call nonce; normalize it out before byte-identity.
+const normalizeUntrustedNonce = (s: string): string =>
+  s.replace(/⟦(\/?)UNTRUSTED:([\w ]+):[0-9a-f]+⟧/g, "⟦$1UNTRUSTED:$2:NONCE⟧");
+
+test("en is byte-identical: recommenderPrompt with/without explicit operatorLanguage:'en'", () => {
+  const tail = ["agent: I'm blocked on the failing test"];
+  const task = "Build a login page";
+  const withoutLang = normalizeUntrustedNonce(recommenderPrompt(tail, task));
+  const withEnLang = normalizeUntrustedNonce(recommenderPrompt(tail, task, "en"));
+  expect(withEnLang).toBe(withoutLang);
+  expect(withoutLang).not.toContain("German");
+  expect(withEnLang).not.toContain("German");
+});
+
+test("de: recommenderPrompt appends the German directive, keeps embedded code verbatim", () => {
+  const p = recommenderPrompt(["agent: stuck"], "Build a login page", "de");
+  expect(p).toContain("German");
+  expect(p).toContain("`prompt`");
+  expect(p).toContain("verbatim");
+});

--- a/test/rundown-core.test.ts
+++ b/test/rundown-core.test.ts
@@ -1054,3 +1054,46 @@ test("buildRundownPrompt: mixed paused + ready epics both rendered in dedicated 
   expect(prompt).toContain("#7");
   expect(prompt).toContain("#8");
 });
+
+// ─── operator-language injection (issue #1625) ──────────────────────────────
+
+// fenceUntrusted() mints a random per-call nonce, so two independent buildRundownPrompt calls
+// never come out byte-identical purely because of it. Normalize it out before comparing.
+const normalizeUntrustedNonce = (s: string): string =>
+  s.replace(/⟦(\/?)UNTRUSTED:([\w ]+):[0-9a-f]+⟧/g, "⟦$1UNTRUSTED:$2:NONCE⟧");
+
+// A herd with a halted-error session so an assembled `hold` is present — this exercises the
+// renderHold(hold, operatorLanguage) branch (else the byte-identity test would pass vacuously).
+const holdAssembled = () =>
+  assembleHerdState({
+    sessions: [session({ haltReason: "error" })],
+    overnightDelta: { mergedPrs: [], archivedSessions: [] },
+    generatedFor: "2026-07-11",
+    now: NOW,
+  });
+
+test("en is byte-identical: buildRundownPrompt with/without explicit operatorLanguage:'en'", () => {
+  const out = holdAssembled();
+  const withoutLang = normalizeUntrustedNonce(buildRundownPrompt(out));
+  const withEnLang = normalizeUntrustedNonce(buildRundownPrompt(out, "en"));
+  expect(withEnLang).toBe(withoutLang);
+  expect(withoutLang).not.toContain("German");
+  expect(withEnLang).not.toContain("German");
+  // Proves the fixture carries a hold so the renderHold branch is actually reached (non-vacuous).
+  expect(withoutLang).toContain("Halted on an error");
+});
+
+test("de: buildRundownPrompt appends the directive and renders the hold `why` line in German", () => {
+  const p = buildRundownPrompt(holdAssembled(), "de");
+  expect(p).toContain("German");
+  // operator-facing prose fields named
+  expect(p).toContain("overnight");
+  expect(p).toContain("train");
+  expect(p).toContain("`label`");
+  // machine-read fields called out as verbatim
+  expect(p).toContain("`sessionId`");
+  expect(p).toContain("`pr`");
+  // the threaded renderHold(hold, "de") produced the German copy in the herd-state dump
+  expect(p).toContain("Auf einem Fehler gestoppt");
+  expect(p).not.toContain("Halted on an error");
+});


### PR DESCRIPTION
Part 3 of epic #1616 (closes #1625). Extends PR #1615's operator-language injection to the remaining qualifying LLM prompt surfaces. Follows the established pattern (`operator-language.ts`; wiring precedent `recap-core.ts:190-199`): a defaulted `operatorLanguage: OperatorLanguage = "en"` param where `"en"` injects **nothing** (byte-identical to today) and `"de"` appends the directive. Live config is read **only at the composition root** (thunk / per-call), never in the leaf module.

`[no-feature-entry]` — server-only, no user-facing UI surface.

## Surfaces

**1. `buildRundownPrompt` (`src/rundown-core.ts`) — inject**
The real rundown prompt (herd-digest delegates to it). Emits operator-facing prose: `overnight`, `train`, and every `label` in `decisions[]`/`ciRework[]`/`focusNext[]`.
- New 2nd positional param `operatorLanguage = "en"`.
- Threads the previously-hardcoded `renderHold(hold, "en")` → `renderHold(hold, operatorLanguage)`, so the `why` context line renders in German under `"de"` (the `hold.ts` `DE` copy map already exists). Default `"en"` is unchanged.
- `"de"` directive: translate the prose fields; keep `sessionId`/`pr` verbatim; reproduce quoted PR/issue titles (GitHub text) in their original language.

**2. `HerdDigestService` (`src/herd-digest.ts`) — thread the thunk**
Long-lived service ⇒ reads the value per spawn via an `operatorLanguage?: () => OperatorLanguage` dep (recap/plan-gate precedent), passed into `buildRundownPrompt`.

**3. `recommenderPrompt` (`src/prompt-recommend.ts`) — inject (gate decision)**
The issue flagged this as a genuine design decision. Its framing calls `{prompt}` agent-facing *input*, which is true of its PTY destination — but its **first consumer is the operator**, who reads/edits/decides in the UI before it is ever sent (not auto-injected). That surface is operator-facing, so it should track operator language; a German-preference operator reading an English suggestion in a German UI is inconsistent. Once pasted, the downstream agent is already German-addressed via the session-level `<operator-language>` block (#1624), so function is preserved either way — and the verbatim carve-outs (embedded code/commands/paths/identifiers/quoted output) keep the prompt usable. Language never touches the parse guard (`normalize` only type-checks + trims).
- New defaulted param on `recommenderPrompt`; **optional** `RecommendArgs.operatorLanguage` (kept optional so the shared test `args()` helper + existing call sites need no change), defaulted at the call site with `?? "en"`.

**Wiring (`src/index.ts`):** herd-digest → `operatorLanguage: () => config.operatorLanguage`; recommend handler → `operatorLanguage: config.operatorLanguage` (per-call live read).

## Tests
Per surface: an `en` byte-identity test (`withEnLang).toBe(withoutLang)` + `not.toContain("German")`, normalizing the untrusted nonce) and a `de` injection test, following `test/recap-core.test.ts:703`. The rundown byte-identity fixture assembles a `halted-error` session so it carries a `hold` — the `renderHold` branch is exercised, not vacuous; the `de` test asserts the German copy ("Auf einem Fehler gestoppt") reaches the herd-state dump.

## Verification
`bun run typecheck`, `bun run lint`, and full `bun test ./test` (6523 pass, 0 fail) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)