### PR TITLE
chore(herdr): conclude socket-scroll spike (Codex honors no lever) — don't flip

### DIFF
--- a/scripts/verify-herdr-terminal.ts
+++ b/scripts/verify-herdr-terminal.ts
@@ -10,6 +10,17 @@
  * This is the herdr-upgrade check — it is intentionally NOT part of `bun test`
  * (it needs a live herdr daemon + a scratch pane). Run it after bumping herdr:
  *   bun scripts/verify-herdr-terminal.ts
+ *
+ * `--scroll` (or SHEPHERD_VERIFY_SCROLL=1) runs a second, heavier, opt-in mode: the app-binding
+ * scroll matrix (issue #1639). It spins up throwaway `claude` + `codex` agents, fills each with a
+ * tall transcript, and records which keyboard levers scroll it over `terminal.input`. REPORT-ONLY —
+ * prints a per-agent matrix and exits 0 (a NOTICE flags divergence from the recorded baseline in
+ * test/fixtures/terminal-control/scroll-binding-notes.md). It needs live agent auth + spends model
+ * tokens, so it is opt-in and never wired into CI. Background: socket-mode scroll needs the *app* to
+ * repaint on a lever (no scrollback in the frame stream); Claude honors PageUp, Codex honors none —
+ * which is why SHEPHERD_HERDR_SOCKET_TERMINAL stays default-off. Re-run after a herdr/agent upgrade
+ * to see whether that changed:
+ *   bun scripts/verify-herdr-terminal.ts --scroll
  */
 export {}; // make this a module so top-level await is allowed under tsc
 
@@ -119,72 +130,325 @@ async function controlRoundTrip(
   return { frames, closed, exit };
 }
 
-let scratchTabId: string | null = null;
-try {
-  // 1. Create a throwaway scratch pane.
-  const created = cli<TabCreateResult>([
-    "tab",
-    "create",
+/** Default mode: the herdr `terminal session control` wire-contract drift check. */
+async function runDriftCheck(): Promise<void> {
+  let scratchTabId: string | null = null;
+  try {
+    // 1. Create a throwaway scratch pane.
+    const created = cli<TabCreateResult>([
+      "tab",
+      "create",
+      "--cwd",
+      "/tmp",
+      "--label",
+      SCRATCH_LABEL,
+      "--no-focus",
+    ]);
+    scratchTabId = created.result.tab.tab_id;
+    const paneId = created.result.root_pane.pane_id;
+    const workspaceId = created.result.root_pane.workspace_id;
+    const target = paneId.includes(":") ? paneId : `${workspaceId}:${paneId}`;
+
+    // 2. Happy-path round-trip.
+    const { frames, closed, exit } = await controlRoundTrip(target);
+    check(frames.length > 0, "no terminal.frame records received");
+    const f0 = frames[0];
+    if (f0) {
+      for (const key of ["bytes", "encoding", "full", "width", "height", "seq"] as const) {
+        check(key in f0, `terminal.frame missing field '${key}'`);
+      }
+      check(f0.full === true && f0.seq === 1, "first frame is not full:true seq:1");
+      check(
+        typeof f0.bytes === "string" && Buffer.from(f0.bytes, "base64").length > 0,
+        "frame bytes not decodable base64",
+      );
+    }
+    const echoed = frames.some((f) =>
+      stripAnsi(Buffer.from(f.bytes, "base64").toString("utf8")).includes("VERIFY_OK"),
+    );
+    check(echoed, "terminal.input did not reach the PTY (echo not observed)");
+    const resized = frames.some((f) => f.full === true && f.width === 100 && f.height === 30);
+    check(resized, "terminal.resize did not produce a 100x30 full redraw");
+    check(
+      (closed as ClosedRec | null)?.type === "terminal.closed",
+      "no terminal.closed after release",
+    );
+    check(exit === 0, `clean release exited ${exit}, expected 0`);
+
+    // 3. Gone-target failure mode: exit 0 + terminal.closed{not found}, no frames.
+    const bad = await controlRoundTrip(`${workspaceId}:pZZZZ`);
+    check(bad.frames.length === 0, "bad target unexpectedly produced frames");
+    check(
+      /not found/i.test(bad.closed?.reason ?? ""),
+      `bad target reason not 'not found': ${JSON.stringify(bad.closed)}`,
+    );
+  } catch (err) {
+    problems.push(`threw: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    if (scratchTabId) {
+      try {
+        cli(["tab", "close", scratchTabId]);
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
+  }
+
+  if (problems.length) {
+    console.error("herdr terminal contract DRIFT:\n  - " + problems.join("\n  - "));
+    process.exit(1);
+  }
+  console.log(
+    "herdr terminal session control contract OK (frame/input/resize/release/closed + gone-target).",
+  );
+}
+
+// ── App-binding scroll matrix (opt-in: --scroll / SHEPHERD_VERIFY_SCROLL=1) ─────────────────────
+// Issue #1639 Phase-0 gate. Drives a LIVE throwaway agent TUI and records which keyboard levers
+// scroll its transcript over `terminal session control` (terminal.input) — the same channel the
+// socket bridge would use. REPORT-ONLY: prints a per-agent lever matrix and exits 0; a NOTICE flags
+// divergence from the recorded baseline. NOT a CI gate (needs live herdr + agent auth + tokens).
+
+interface Lever {
+  name: string;
+  seq: string;
+  repeat: number;
+}
+// "Up" levers (reveal older transcript). Ctrl+End (below) is the recovery, not a probe.
+const UP_LEVERS: Lever[] = [
+  { name: "PageUp", seq: "\x1b[5~", repeat: 4 },
+  { name: "Shift+PageUp", seq: "\x1b[5;2~", repeat: 4 },
+  { name: "Ctrl+Home", seq: "\x1b[1;5H", repeat: 1 },
+  { name: "MouseWheelUp", seq: "\x1b[<64;40;12M", repeat: 6 },
+];
+const CTRL_END = "\x1b[1;5F"; // jump-to-bottom recovery (Claude honors it; no-op for non-scrollers)
+
+// Agents we can start here. Codex needs the effort/verbosity overrides or its local default config
+// trips a provider 400 (`text.verbosity='low'` unsupported for gpt-5.2-codex) → no transcript.
+const SCROLL_AGENTS: { provider: string; argv: string[] }[] = [
+  { provider: "claude", argv: ["claude"] },
+  {
+    provider: "codex",
+    argv: ["codex", "-c", 'model_reasoning_effort="medium"', "-c", 'model_verbosity="medium"'],
+  },
+];
+const GEN_PROMPT =
+  "Output the integers 1 through 150, each on its own line. Output ONLY the numbers, one per line — no prose, no code block, no tool use.";
+
+// Recorded baseline (herdr 0.7.3, 2026-07-11) — see scroll-binding-notes.md. The NOTICE compares
+// SEMANTICS, not exact cells: only two facts gate #1639 — "Claude still honors PageUp" (the lever a
+// socket-scroll would ride) and "Codex honors NO lever" (why the flip can't ship). The secondary
+// levers (Ctrl+Home, MouseWheelUp, Shift+PageUp) are timing-sensitive between runs, so they are
+// printed for information but not asserted — otherwise the diagnostic would flap.
+const BASELINE_CLAUDE_PAGEUP = true;
+const BASELINE_CODEX_ANY_LEVER = false;
+
+function scrollStart(provider: string, argv: string[]): { term: string; tab: string } {
+  const r = cli<{ result: { agent: { terminal_id: string; tab_id: string } } }>([
+    "agent",
+    "start",
+    `__verify_scroll_${provider}__`,
     "--cwd",
     "/tmp",
-    "--label",
-    SCRATCH_LABEL,
     "--no-focus",
+    "--",
+    ...argv,
   ]);
-  scratchTabId = created.result.tab.tab_id;
-  const paneId = created.result.root_pane.pane_id;
-  const workspaceId = created.result.root_pane.workspace_id;
-  const target = paneId.includes(":") ? paneId : `${workspaceId}:${paneId}`;
+  return { term: r.result.agent.terminal_id, tab: r.result.agent.tab_id };
+}
+function scrollStatus(target: string): string {
+  try {
+    return cli<{ result: { agent: { agent_status: string } } }>(["agent", "get", target]).result
+      .agent.agent_status;
+  } catch {
+    return "unknown";
+  }
+}
+function scrollVisible(target: string, rows: number): string {
+  try {
+    return cli<{ result: { read: { text: string } } }>([
+      "agent",
+      "read",
+      target,
+      "--source",
+      "visible",
+      "--lines",
+      String(rows),
+      "--format",
+      "text",
+    ]).result.read.text;
+  } catch {
+    return "";
+  }
+}
+// Standalone numeric lines only — the transcript is 1..150; agent chrome carries stray numbers we
+// must not count, so require a line that is JUST the number.
+const standaloneNums = (t: string): number[] =>
+  [...t.matchAll(/^\s*(\d{1,3})\s*$/gm)].map((m) => Number(m[1]));
 
-  // 2. Happy-path round-trip.
-  const { frames, closed, exit } = await controlRoundTrip(target);
-  check(frames.length > 0, "no terminal.frame records received");
-  const f0 = frames[0];
-  if (f0) {
-    for (const key of ["bytes", "encoding", "full", "width", "height", "seq"] as const) {
-      check(key in f0, `terminal.frame missing field '${key}'`);
+interface ProbeRow {
+  provider: string;
+  error?: string;
+  results: { lever: string; scrolled: boolean }[];
+}
+
+async function probeAgentScroll(provider: string, argv: string[]): Promise<ProbeRow> {
+  const COLS = 80,
+    ROWS = 24;
+  let tab: string | null = null;
+  const results: { lever: string; scrolled: boolean }[] = [];
+  try {
+    const started = scrollStart(provider, argv);
+    tab = started.tab;
+    const term = started.term;
+    for (let i = 0; i < 100 && scrollStatus(term) === "unknown"; i++) await Bun.sleep(150);
+
+    const ctrl = Bun.spawn(
+      [
+        herdrBin,
+        "terminal",
+        "session",
+        "control",
+        term,
+        "--takeover",
+        "--cols",
+        String(COLS),
+        "--rows",
+        String(ROWS),
+      ],
+      { stdin: "pipe", stdout: "pipe", stderr: "pipe" },
+    );
+    let sawFrame = false;
+    void (async () => {
+      const dec = new TextDecoder();
+      let buf = "";
+      for await (const chunk of ctrl.stdout as ReadableStream<Uint8Array>) {
+        buf += dec.decode(chunk, { stream: true });
+        let nl: number;
+        while ((nl = buf.indexOf("\n")) !== -1) {
+          const line = buf.slice(0, nl);
+          buf = buf.slice(nl + 1);
+          if (!line) continue;
+          try {
+            if ((JSON.parse(line) as { type?: string }).type === "terminal.frame") sawFrame = true;
+          } catch {
+            /* ignore non-JSON */
+          }
+        }
+      }
+    })();
+    const key = (text: string) => {
+      ctrl.stdin.write(JSON.stringify({ type: "terminal.input", text }) + "\n");
+      ctrl.stdin.flush();
+    };
+
+    try {
+      for (let i = 0; i < 100 && !sawFrame; i++) await Bun.sleep(30);
+      // accept a first-run trust/confirm prompt if present (codex shows one on an untrusted cwd)
+      if (/trust|Yes, continue|Press enter/i.test(scrollVisible(term, ROWS))) {
+        key("\r");
+        await Bun.sleep(1500);
+      }
+      // type + submit the generator prompt, then wait for a tall transcript
+      key(GEN_PROMPT);
+      await Bun.sleep(500);
+      key("\r");
+      for (let i = 0; i < 150; i++) {
+        if (
+          scrollStatus(term) === "idle" &&
+          standaloneNums(scrollVisible(term, ROWS)).includes(150)
+        )
+          break;
+        await Bun.sleep(1000);
+      }
+      await Bun.sleep(1200);
+
+      for (const lever of UP_LEVERS) {
+        key(CTRL_END); // restore to bottom (scrollers honor it; no-op for non-scrollers)
+        await Bun.sleep(700);
+        const before = standaloneNums(scrollVisible(term, ROWS));
+        for (let i = 0; i < lever.repeat; i++) {
+          key(lever.seq);
+          await Bun.sleep(180);
+        }
+        await Bun.sleep(900);
+        const after = standaloneNums(scrollVisible(term, ROWS));
+        const bMin = before.length ? Math.min(...before) : Infinity;
+        const aMin = after.length ? Math.min(...after) : Infinity;
+        // scrolled up ⇔ an EARLIER line became visible than was at the bottom baseline
+        results.push({ lever: lever.name, scrolled: aMin < bMin });
+      }
+      key(CTRL_END);
+      await Bun.sleep(300);
+    } finally {
+      ctrl.kill();
     }
-    check(f0.full === true && f0.seq === 1, "first frame is not full:true seq:1");
-    check(
-      typeof f0.bytes === "string" && Buffer.from(f0.bytes, "base64").length > 0,
-      "frame bytes not decodable base64",
+    return { provider, results };
+  } catch (err) {
+    return { provider, error: err instanceof Error ? err.message : String(err), results };
+  } finally {
+    if (tab) {
+      try {
+        cli(["tab", "close", tab]);
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
+  }
+}
+
+/** Opt-in mode: the app-binding scroll matrix. Report-only, always exits 0. */
+async function runScrollMatrix(): Promise<void> {
+  console.log("herdr app-binding scroll matrix (report-only; live agents; ~2-4 min)…\n");
+  const rows: ProbeRow[] = [];
+  for (const a of SCROLL_AGENTS) rows.push(await probeAgentScroll(a.provider, a.argv));
+
+  const leverNames = UP_LEVERS.map((l) => l.name);
+  const header = ["agent".padEnd(8), ...leverNames.map((n) => n.padEnd(14))].join(" ");
+  console.log(header);
+  console.log("-".repeat(header.length));
+  const matrix: Record<string, Record<string, boolean>> = {};
+  for (const r of rows) {
+    const row: Record<string, boolean> = {};
+    matrix[r.provider] = row;
+    const cells = leverNames.map((n) => {
+      const v = r.results.find((x) => x.lever === n)?.scrolled ?? false;
+      row[n] = v;
+      return (v ? "scroll" : "----").padEnd(14);
+    });
+    console.log([r.provider.padEnd(8), ...cells].join(" ") + (r.error ? `  ⚠ ${r.error}` : ""));
+  }
+
+  // Semantic divergence NOTICE vs the recorded baseline (see scroll-binding-notes.md).
+  const claudePageUp = matrix.claude?.PageUp ?? false;
+  const codexLevers = leverNames.filter((n) => matrix.codex?.[n]);
+  const codexAny = codexLevers.length > 0;
+  const notices: string[] = [];
+  if (claudePageUp !== BASELINE_CLAUDE_PAGEUP) {
+    notices.push(
+      `Claude PageUp changed: baseline=${BASELINE_CLAUDE_PAGEUP ? "scroll" : "----"} now=${claudePageUp ? "scroll" : "----"} — the lever a socket-scroll would ride is no longer as recorded.`,
     );
   }
-  const echoed = frames.some((f) =>
-    stripAnsi(Buffer.from(f.bytes, "base64").toString("utf8")).includes("VERIFY_OK"),
-  );
-  check(echoed, "terminal.input did not reach the PTY (echo not observed)");
-  const resized = frames.some((f) => f.full === true && f.width === 100 && f.height === 30);
-  check(resized, "terminal.resize did not produce a 100x30 full redraw");
-  check(
-    (closed as ClosedRec | null)?.type === "terminal.closed",
-    "no terminal.closed after release",
-  );
-  check(exit === 0, `clean release exited ${exit}, expected 0`);
-
-  // 3. Gone-target failure mode: exit 0 + terminal.closed{not found}, no frames.
-  const bad = await controlRoundTrip(`${workspaceId}:pZZZZ`);
-  check(bad.frames.length === 0, "bad target unexpectedly produced frames");
-  check(
-    /not found/i.test(bad.closed?.reason ?? ""),
-    `bad target reason not 'not found': ${JSON.stringify(bad.closed)}`,
-  );
-} catch (err) {
-  problems.push(`threw: ${err instanceof Error ? err.message : String(err)}`);
-} finally {
-  if (scratchTabId) {
-    try {
-      cli(["tab", "close", scratchTabId]);
-    } catch {
-      /* best-effort cleanup */
-    }
+  if (codexAny !== BASELINE_CODEX_ANY_LEVER) {
+    notices.push(
+      `Codex now honors a scroll lever (${codexLevers.join(", ")}) — the SHEPHERD_HERDR_SOCKET_TERMINAL flip may have become viable; revisit issue #1639.`,
+    );
   }
+  console.log();
+  if (notices.length) {
+    console.log("NOTICE — scroll behavior diverged from the recorded baseline:");
+    for (const d of notices) console.log("  - " + d);
+  } else {
+    console.log(
+      "Load-bearing facts match the recorded baseline: Claude honors PageUp, Codex honors none.",
+    );
+  }
+  console.log("\nReport-only: exit 0 regardless (a diagnostic, not a gate).");
 }
 
-if (problems.length) {
-  console.error("herdr terminal contract DRIFT:\n  - " + problems.join("\n  - "));
-  process.exit(1);
+const RUN_SCROLL = process.argv.includes("--scroll") || process.env.SHEPHERD_VERIFY_SCROLL === "1";
+if (RUN_SCROLL) {
+  await runScrollMatrix();
+} else {
+  await runDriftCheck();
 }
-console.log(
-  "herdr terminal session control contract OK (frame/input/resize/release/closed + gone-target).",
-);

--- a/src/config.ts
+++ b/src/config.ts
@@ -554,10 +554,19 @@ export const config = {
   // Sub-flag gating ONLY the interactive terminal onto herdr's socket `terminal session control`
   // stream. Default-OFF interim gate: that stream is a screen-diff/redraw protocol, so xterm builds
   // no scrollback and never sees the app's mouse mode — which kills mobile swipe + desktop wheel
-  // scrolling (the socket terminal renders, but can't be scrolled). Until socket-native scroll is
-  // built and proven for Claude+Codex (Phase B follow-up), keep the terminal on node-pty even when
-  // `herdrSocket` is on; the socket driver still drives send/steer/browser/usage. Flip on to soak
-  // socket-scroll once it lands.
+  // scrolling (the socket terminal renders, but can't be scrolled). In socket mode scroll can only
+  // work if the *app* repaints on a keyboard lever over `terminal.input`.
+  //
+  // Phase B (#1639) probed exactly that on live agents (herdr 0.7.3 — see the reproduced matrix in
+  // test/fixtures/terminal-control/scroll-binding-notes.md, re-run via
+  // `bun scripts/verify-herdr-terminal.ts --scroll`): Claude Code honors PageUp, but **Codex honors
+  // no lever at all** — its off-screen transcript is unreachable in socket mode. So flipping this on
+  // would REGRESS Codex scroll, and node-pty removal (#1622) can't complete while Codex needs it.
+  // The frame-stream transport is therefore not yet good enough to replace node-pty for the terminal.
+  //
+  // So this stays default-OFF: the terminal remains on node-pty (scrollable for BOTH providers) even
+  // when `herdrSocket` is on; the socket driver still drives send/steer/browser/usage. Revisiting the
+  // flip is blocked on a scrollback-preserving / raw-passthrough herdr terminal transport (#1642).
   herdrSocketTerminal: process.env.SHEPHERD_HERDR_SOCKET_TERMINAL === "1",
   // Push-based agent-info ingestion via Claude Code hooks (issue #704), additive on top
   // of polling, staged behind two default-off flags so each phase is independently reversible.

--- a/test/fixtures/terminal-control/scroll-binding-notes.md
+++ b/test/fixtures/terminal-control/scroll-binding-notes.md
@@ -1,0 +1,69 @@
+# herdr app-binding scroll — captured lever matrix (issue #1639, Phase B spike)
+
+Captured live against **herdr 0.7.3** on 2026-07-11 by driving throwaway `claude` + `codex` agents
+over `terminal session control` and observing the rendered pane. This is the evidence behind keeping
+`SHEPHERD_HERDR_SOCKET_TERMINAL` **default-off** (see `src/config.ts`). Re-run after a herdr/agent
+upgrade to see whether the picture changed:
+
+```
+bun scripts/verify-herdr-terminal.ts --scroll
+```
+
+## Why this spike exists
+
+The socket `terminal session control` stream is a screen-diff/redraw protocol with **no scrollback**
+(see `capture-notes.md`). So in socket mode the terminal emulator has nothing to scroll — scrolling
+can only happen if the **app itself** repaints a scrolled view in response to a keyboard lever
+delivered over `terminal.input`. Issue #1639 proposed translating mobile swipe/wheel gestures into
+`PageUp`/`PageDown` and flipping the terminal onto the socket stream, **gated on** proving the actual
+target apps (Claude Code and Codex) honor such a lever. This is that proof.
+
+## Method
+
+- `herdr agent start __verify_scroll_<provider>__ --cwd /tmp --no-focus -- <provider…>` — a throwaway
+  agent, NOT a Shepherd-managed session (`--takeover` on a live session fights Shepherd's own attach).
+- Fill the transcript: submit "output the integers 1 through 150, one per line" so 130+ lines sit
+  off-screen above a 80×24 viewport.
+- Drive levers over a persistent `terminal session control <term> --takeover --cols 80 --rows 24`
+  stream via `{"type":"terminal.input","text":"<seq>"}`.
+- Observe with `herdr agent read <term> --source visible` (the app's actual rendered pane). The
+  discriminator is **standalone numeric lines only** (`/^\s*\d{1,3}\s*$/`) — agent chrome (context %,
+  model name, token counts) carries stray numbers that must not be counted. A lever "scrolled" iff a
+  **smaller** line number became visible than the bottom baseline showed.
+- **Codex config**: start it with `-c model_reasoning_effort="medium" -c model_verbosity="medium"`.
+  Its local default tripped a provider 400 (`text.verbosity='low'` unsupported for `gpt-5.2-codex`),
+  which produced no transcript at all — a false "nothing to scroll", not a scroll result.
+
+## Result (reproduced, stable across runs)
+
+| agent  | PageUp `\x1b[5~` | Shift+PageUp `\x1b[5;2~` | Ctrl+Home `\x1b[1;5H` | MouseWheelUp (SGR) |
+| ------ | ---------------- | ------------------------ | --------------------- | ------------------ |
+| claude | **scroll**       | —                        | —                     | **scroll**         |
+| codex  | —                | —                        | —                     | —                  |
+
+- **Claude Code** honors `PageUp` (~7 lines/key; bottom 135–150 → 112–128) and SGR mouse-wheel-up, and
+  renders its own "Jump to bottom (ctrl+End) ↓" affordance; `Ctrl+End` (`\x1b[1;5F`) jumps to bottom.
+- **Codex** honors **none** of the levers over `terminal.input` — the view stays pinned at the bottom
+  and its 130+ off-screen lines are unreachable. The manual spike additionally checked Ctrl+End,
+  Ctrl+Up, Up, Ctrl+B, Ctrl+U, Home — also no movement (9 levers total, all inert).
+
+### Caveats on the secondary cells
+
+`Ctrl+Home` reads `—` here because the probe restores to the bottom before each lever, and Claude
+appears to honor `Ctrl+Home` only from an **already-scrolled** state (in a manual battery, run after a
+prior PageUp, it jumped to line 1). `MouseWheelUp` is real but moot for the product: the socket frame
+stream strips mouse modes, so a client can't ride it anyway. These secondary levers are timing- and
+state-sensitive between runs, so the diagnostic **prints them for information but asserts only the two
+load-bearing facts** (Claude honors PageUp; Codex honors no lever).
+
+## Conclusion — do not flip the gate
+
+Only `PageUp` is a usable, mode-independent lever, and only Claude honors it. Because **Codex honors
+nothing**, flipping `SHEPHERD_HERDR_SOCKET_TERMINAL` on would leave Codex sessions unable to scroll
+their transcript in socket mode — a regression versus today's node-pty terminal, which scrolls
+natively for both providers. And node-pty removal (#1622) cannot complete while Codex needs node-pty.
+So herdr's frame-stream transport is **not yet good enough** to replace the node-pty terminal:
+
+- `SHEPHERD_HERDR_SOCKET_TERMINAL` stays default-off (Phase A gate unchanged).
+- Follow-up **#1642** tracks a scrollback-preserving / raw-passthrough (PTY-forwarding) herdr terminal
+  transport — the prerequisite for revisiting the flip and for #1622.


### PR DESCRIPTION
## What this is — and isn't

Issue #1639 (Phase B) asked to **build** socket-native terminal scroll (swipe/wheel → PageUp/PageDown over `terminal.input`) and **flip `SHEPHERD_HERDR_SOCKET_TERMINAL` on**. It made that **explicitly contingent** on a HALTing spike proving the *actual target apps* (Claude Code **and** Codex) scroll their transcript on such a lever over herdr's frame stream.

I ran that spike live (herdr 0.7.3, throwaway `herdr agent start` agents). It came back **negative for Codex**, so per the issue's own gate the build + flip are **intentionally not shipped**. This PR delivers the issue's stated fallback: durable evidence + a guard + a follow-up.

## Spike result (A/B, live agents, reproduced & stable)

| agent | PageUp `\x1b[5~` | Shift+PageUp | Ctrl+Home | MouseWheelUp (SGR) |
| --- | --- | --- | --- | --- |
| **Claude Code** | **scroll** (~7 lines/key; 135–150 → 112–128, renders own "Jump to bottom" hint) | — | —¹ | scroll² |
| **Codex** | — | — | — | — |

¹ Claude honors Ctrl+Home only from an already-scrolled state (probe restores to bottom each lever). ² Real but moot — the frame stream strips mouse modes, so a client can't ride the wheel anyway.

**Codex honors none** of 9 levers tested (PageUp/PageDown, wheel-SGR, Shift+PageUp, Ctrl+Up, Up, Ctrl+B, Ctrl+U, Ctrl+Home, Home).

## Why this means "don't flip"

In socket mode the frame stream has **no scrollback** — scroll needs the *app* to repaint on a lever. Claude does; Codex doesn't. So flipping `SHEPHERD_HERDR_SOCKET_TERMINAL` on would leave Codex sessions **unable to scroll** their transcript — a regression vs today's node-pty terminal, which scrolls natively for both providers. And node-pty removal (#1622) can't complete while Codex needs node-pty. herdr's frame-stream transport is **not yet good enough** to replace the node-pty terminal.

## Changes (small; no client/Viewport/flag change)

- **`scripts/verify-herdr-terminal.ts`** — opt-in `--scroll` app-binding matrix: spins up throwaway claude+codex agents, drives levers over `terminal.input`, observes via `agent read`. **Report-only, exits 0**; a NOTICE fires only if the two load-bearing facts change (Claude stops honoring PageUp, or Codex gains a lever → flip may become viable). Default drift-check path unchanged; never in CI.
- **`test/fixtures/terminal-control/scroll-binding-notes.md`** — reproduced matrix + method + conclusion.
- **`src/config.ts`** — `herdrSocketTerminal` comment records the finding + points at the follow-up. Flag stays **default-off** (Phase A gate unchanged).

## Follow-up & disposition

- **#1642** (internal tracking) requests a scrollback-preserving / raw-passthrough herdr terminal transport — the prerequisite for revisiting the flip and for #1622.
- **#1639 stays open**, blocked-by #1642 (the place to revisit build+flip if herdr gains a scroll-capable transport) — hence `Refs`, not `Fixes`.

Refs #1639, #1642, #1622. `[no-feature-entry]` (no user-facing UX ships).

## Test

- `bun run lint` ✅ · `bun run typecheck` ✅ · `bun test ./test/socket-terminal-wiring.test.ts ./test/terminal-transport-metrics.test.ts` ✅ (31 pass)
- `bun scripts/verify-herdr-terminal.ts --scroll` → reproduces the matrix, "load-bearing facts match", exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
