### PR TITLE
chore: scrub personal tailnet/node identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,8 +489,8 @@ for p in $(seq 8001 8016); do tailscale serve --bg --https=$p 127.0.0.1:$p; done
 **Split-front / `previewHost`:** the preview iframe URL is built from the **agent node's own
 tailnet hostname** (server-reported `previewHost`), not the operator's connection host. This means
 the preview works when the HUD is fronted under a different Tailscale identity than the agent node
-— e.g. a Tailscale Service `svc:shepherd` at `:443` while agents run on `backontop`. The slot is
-served at the node, so the iframe correctly targets `https://backontop.<tailnet>.ts.net:<port>`
+— e.g. a Tailscale Service `svc:shepherd` at `:443` while agents run on `agentnode`. The slot is
+served at the node, so the iframe correctly targets `https://agentnode.<tailnet>.ts.net:<port>`
 rather than the Service address. On localhost dev and single-host tailnets behavior is unchanged.
 
 **Scope / precondition:** the operator's browser must be on the tailnet, and tailnet ACLs must

--- a/deploy/shepherd.service
+++ b/deploy/shepherd.service
@@ -22,7 +22,8 @@ RestartPreventExitStatus=78
 Environment=PATH=%h/.bun/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin
 Environment=SHEPHERD_PORT=7330
 Environment=SHEPHERD_HOST=127.0.0.1
-Environment=SHEPHERD_ALLOWED_HOSTS=localhost,127.0.0.1,::1,[::1],shepherd.chicken-beardie.ts.net
+# localhost defaults only; add your own tailnet hostname via SHEPHERD_ALLOWED_HOSTS in ~/.shepherd/env
+Environment=SHEPHERD_ALLOWED_HOSTS=localhost,127.0.0.1,::1,[::1]
 # optional overrides (token, repo root, etc.) — file may be absent
 EnvironmentFile=-%h/.shepherd/env
 

--- a/src/tailscale.ts
+++ b/src/tailscale.ts
@@ -18,7 +18,7 @@ const defaultRun: TailscaleRunner = (args) =>
 // ── resolveNodeHost ───────────────────────────────────────────────────────────
 
 /**
- * Returns this node's own Tailscale hostname (e.g. `"backontop.chicken-beardie.ts.net"`)
+ * Returns this node's own Tailscale hostname (e.g. `"agentnode.example.ts.net"`)
  * by parsing `tailscale status --json`.
  *
  * WHY: when Shepherd's HUD is fronted by a Tailscale Service identity (a different
@@ -45,7 +45,7 @@ export async function resolveNodeHost(run: TailscaleRunner = defaultRun): Promis
     ) {
       return null;
     }
-    // Strip trailing dot: "backontop.chicken-beardie.ts.net." → "backontop.chicken-beardie.ts.net"
+    // Strip trailing dot: "agentnode.example.ts.net." → "agentnode.example.ts.net"
     return parsed.Self.DNSName.replace(/\.$/, "");
   } catch {
     return null;

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -390,7 +390,7 @@ describe("DiagnosticsService probes", () => {
             "svc:shepherd": {
               TCP: { "443": { HTTPS: true } },
               Web: {
-                "shepherd.chicken-beardie.ts.net:443": {
+                "shepherd.example.ts.net:443": {
                   Handlers: { "/": { Proxy: "http://localhost:7330" } },
                 },
               },

--- a/test/egress-runner.test.ts
+++ b/test/egress-runner.test.ts
@@ -6,7 +6,7 @@
  * nft/dnsmasq) and tear it down with SIGKILL, so they are GATED. The suite SKIPS
  * when (a) the host can't do rootless user+net namespaces / lacks the tools, (b)
  * running under CI (no real slirp teardown in any CI job), or (c) a rootless
- * docker daemon's socket is present — because on a host (e.g. `backontop`) whose
+ * docker daemon's socket is present — because on a host (e.g. `agentnode`) whose
  * rootless docker serves the CI runners, churning the real slirp machinery can
  * take out that daemon's shared `slirp4netns` and knock all runners offline
  * (2026-06-12 incident; issue #591). The skip decision lives in

--- a/test/preview-config.test.ts
+++ b/test/preview-config.test.ts
@@ -12,13 +12,13 @@ import { originAllowed } from "../src/validate";
 const SAMPLE_STATUS = `
 # Tailscale Serve Status
 
-https://backontop.chicken-beardie.ts.net (tailnet only)
+https://agentnode.example.ts.net (tailnet only)
 |-- / proxy http://127.0.0.1:7330
 
-https://backontop.chicken-beardie.ts.net:5191 (tailnet only)
+https://agentnode.example.ts.net:5191 (tailnet only)
 |-- / proxy http://127.0.0.1:5190
 
-https://backontop.chicken-beardie.ts.net:5193 (tailnet only)
+https://agentnode.example.ts.net:5193 (tailnet only)
 |-- / proxy http://127.0.0.1:5192
 `;
 
@@ -77,7 +77,7 @@ https://myhost.ts.net:7777 (tailnet only)
 const SERVE_STATUS_JSON_FULL = JSON.stringify({
   TCP: { "5191": { HTTPS: true } },
   Web: {
-    "backontop.chicken-beardie.ts.net:5191": {
+    "agentnode.example.ts.net:5191": {
       Handlers: { "/": { Proxy: "http://127.0.0.1:5190" } },
     },
   },
@@ -85,7 +85,7 @@ const SERVE_STATUS_JSON_FULL = JSON.stringify({
     "svc:shepherd": {
       TCP: { "443": { HTTPS: true } },
       Web: {
-        "shepherd.chicken-beardie.ts.net:443": {
+        "shepherd.example.ts.net:443": {
           Handlers: { "/": { Proxy: "http://localhost:7330" } },
         },
       },

--- a/test/tailscale.test.ts
+++ b/test/tailscale.test.ts
@@ -10,14 +10,14 @@ import {
 
 const REALISTIC_STATUS = JSON.stringify({
   Self: {
-    HostName: "backontop",
-    DNSName: "backontop.chicken-beardie.ts.net.",
+    HostName: "agentnode",
+    DNSName: "agentnode.example.ts.net.",
     OS: "linux",
     TailscaleIPs: ["100.64.0.1"],
     Online: true,
   },
   Peers: {},
-  MagicDNSSuffix: "chicken-beardie.ts.net",
+  MagicDNSSuffix: "example.ts.net",
   CurrentTailnet: {},
 });
 
@@ -25,7 +25,7 @@ describe("resolveNodeHost", () => {
   test("parses Self.DNSName and strips trailing dot", async () => {
     const run = async () => ({ stdout: REALISTIC_STATUS });
     const result = await resolveNodeHost(run);
-    expect(result).toBe("backontop.chicken-beardie.ts.net");
+    expect(result).toBe("agentnode.example.ts.net");
   });
 
   test("returns null when runner rejects (tailscale absent / not running)", async () => {
@@ -50,7 +50,7 @@ describe("resolveNodeHost", () => {
 
   test("returns null when Self.DNSName is missing", async () => {
     const run = async () => ({
-      stdout: JSON.stringify({ Self: { HostName: "backontop" } }),
+      stdout: JSON.stringify({ Self: { HostName: "agentnode" } }),
     });
     const result = await resolveNodeHost(run);
     expect(result).toBeNull();

--- a/ui/src/lib/previewUrl.test.ts
+++ b/ui/src/lib/previewUrl.test.ts
@@ -32,7 +32,7 @@ describe("buildPreviewUrl — loopback branch", () => {
     // Dev must stay on localhost; previewHost must be ignored.
     expect(
       buildPreviewUrl(
-        "backontop.chicken-beardie.ts.net",
+        "agentnode.example.ts.net",
         { protocol: "http:", hostname: "localhost" },
         PORT,
       ),
@@ -44,11 +44,11 @@ describe("buildPreviewUrl — previewHost branch (split-front fix)", () => {
   it("non-loopback + previewHost → https://previewHost:port/", () => {
     expect(
       buildPreviewUrl(
-        "backontop.chicken-beardie.ts.net",
-        { protocol: "https:", hostname: "shepherd.chicken-beardie.ts.net" },
+        "agentnode.example.ts.net",
+        { protocol: "https:", hostname: "shepherd.example.ts.net" },
         PORT,
       ),
-    ).toBe("https://backontop.chicken-beardie.ts.net:8001/");
+    ).toBe("https://agentnode.example.ts.net:8001/");
   });
 
   it("forces https on the previewHost branch even when loc.protocol is http", () => {
@@ -56,42 +56,38 @@ describe("buildPreviewUrl — previewHost branch (split-front fix)", () => {
     // tailscale serve --https (HTTPS-only) → the preview URL must still be https.
     expect(
       buildPreviewUrl(
-        "backontop.chicken-beardie.ts.net",
-        { protocol: "http:", hostname: "shepherd.chicken-beardie.ts.net" },
+        "agentnode.example.ts.net",
+        { protocol: "http:", hostname: "shepherd.example.ts.net" },
         PORT,
       ),
-    ).toBe("https://backontop.chicken-beardie.ts.net:8001/");
+    ).toBe("https://agentnode.example.ts.net:8001/");
   });
 
   it("port is interpolated correctly", () => {
     expect(
       buildPreviewUrl(
-        "backontop.chicken-beardie.ts.net",
-        { protocol: "https:", hostname: "shepherd.chicken-beardie.ts.net" },
+        "agentnode.example.ts.net",
+        { protocol: "https:", hostname: "shepherd.example.ts.net" },
         9999,
       ),
-    ).toBe("https://backontop.chicken-beardie.ts.net:9999/");
+    ).toBe("https://agentnode.example.ts.net:9999/");
   });
 });
 
 describe("buildPreviewUrl — fallback branch", () => {
   it("non-loopback + previewHost null → loc.protocol//loc.hostname:port/", () => {
     expect(
-      buildPreviewUrl(
-        null,
-        { protocol: "https:", hostname: "backontop.chicken-beardie.ts.net" },
-        PORT,
-      ),
-    ).toBe("https://backontop.chicken-beardie.ts.net:8001/");
+      buildPreviewUrl(null, { protocol: "https:", hostname: "agentnode.example.ts.net" }, PORT),
+    ).toBe("https://agentnode.example.ts.net:8001/");
   });
 
   it("non-loopback + previewHost empty string → fallback (NOT https://:8001/)", () => {
     const url = buildPreviewUrl(
       "",
-      { protocol: "https:", hostname: "backontop.chicken-beardie.ts.net" },
+      { protocol: "https:", hostname: "agentnode.example.ts.net" },
       PORT,
     );
-    expect(url).toBe("https://backontop.chicken-beardie.ts.net:8001/");
+    expect(url).toBe("https://agentnode.example.ts.net:8001/");
     // Explicit guard: empty previewHost must never produce `https://:port/`
     expect(url).not.toContain("https://:");
   });

--- a/ui/src/lib/previewUrl.ts
+++ b/ui/src/lib/previewUrl.ts
@@ -13,7 +13,7 @@
  *    `tailscale serve --https` is HTTPS-only — there is no HTTP listener on
  *    the slot port. This is the split-front fix: when the HUD is fronted by a
  *    different Tailscale identity (e.g. a Service `svc:shepherd`) than the
- *    agent node (`backontop`), the iframe must target the agent node's OWN
+ *    agent node (`agentnode`), the iframe must target the agent node's OWN
  *    tailnet hostname, not the operator's connection host. Using loc.hostname
  *    in that case would hit a port that serves nothing → ERR_SSL_PROTOCOL_ERROR.
  *


### PR DESCRIPTION
## What

Removes traces of a personal Tailscale identity that were committed into the repo:

- **Tailnet** `chicken-beardie` → `example`
- **Node** `backontop` → `agentnode`

## Why

`deploy/shepherd.service` hardcoded a real tailnet host (`shepherd.chicken-beardie.ts.net`) in `SHEPHERD_ALLOWED_HOSTS`, and the same identity leaked into doc-comment examples and test fixtures. A committed unit template shouldn't carry one operator's private hostname.

## Changes

- `deploy/shepherd.service`: drop the hardcoded host; leave localhost-only defaults + a comment pointing operators to add their own tailnet host via `~/.shepherd/env` (matches the README contract).
- `README.md`, `src/tailscale.ts`, `ui/src/lib/previewUrl.ts`: genericize example hostnames in comments.
- Test fixtures (`test/tailscale.test.ts`, `test/preview-config.test.ts`, `test/diagnostics.test.ts`, `test/egress-runner.test.ts`, `ui/src/lib/previewUrl.test.ts`): renamed to the neutral placeholders.

Pure rename/removal — no behavior change. `git grep` for the old identifiers now returns nothing.

## Verification

- Root: `bun test ./test/tailscale.test.ts ./test/preview-config.test.ts ./test/diagnostics.test.ts ./test/egress-runner.test.ts` → pass
- UI: `bun test src/lib/previewUrl.test.ts` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)