### PR TITLE
feat: operator-language + input-robustness for the stop-classifier (eval-gated)

### DIFF
--- a/.github/workflows/eval-stop-classifier.yml
+++ b/.github/workflows/eval-stop-classifier.yml
@@ -26,6 +26,10 @@ on:
         description: "Model id (default claude-haiku-4-5 — the CLI 'haiku' snapshot)"
         required: false
         default: "claude-haiku-4-5"
+      operator_language_off:
+        description: "#1627 A/B: 'true' forces operator-language OFF everywhere (the *before* leg ≡ #1626 baseline); default 'false' runs the *after* leg (German directive live for de fixtures)"
+        required: false
+        default: "false"
 
 permissions:
   contents: read
@@ -53,7 +57,7 @@ jobs:
       - name: Run eval (report)
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: bun run eval:stop-classifier --trials "${{ github.event.inputs.trials }}" --model "${{ github.event.inputs.model }}"
+        run: bun run eval:stop-classifier --trials "${{ github.event.inputs.trials }}" --model "${{ github.event.inputs.model }}" ${{ github.event.inputs.operator_language_off == 'true' && '--operator-language-off' || '' }}
 
       # Machine-readable JSON (per-fixture kind distributions + no-tool/parse-fail counts) —
       # this is what you copy into docs/eval-stop-classifier.md. `if: always()` so the JSON is
@@ -64,4 +68,4 @@ jobs:
         if: always()
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: bun run eval:stop-classifier --trials "${{ github.event.inputs.trials }}" --model "${{ github.event.inputs.model }}" --json || true
+        run: bun run eval:stop-classifier --trials "${{ github.event.inputs.trials }}" --model "${{ github.event.inputs.model }}" ${{ github.event.inputs.operator_language_off == 'true' && '--operator-language-off' || '' }} --json || true

--- a/docs/eval-stop-classifier.md
+++ b/docs/eval-stop-classifier.md
@@ -5,7 +5,11 @@ quality** of the autopilot stop-classifier (`classifierPrompt` / `normalize`, no
 module `src/autopilot-classify-core.ts`) against a labelled fixture set, so the operator-language
 follow-up (#1627) has a real **before/after** baseline before it touches the prompt.
 
-This issue is the **harness + baseline only** — it makes **no change to `classifierPrompt` prose**.
+Issue #1626 was the **harness + baseline only** — it made **no change to `classifierPrompt` prose**.
+Issue **#1627** (this follow-up) is the first change to touch the prompt: it adds an
+`operatorLanguage` parameter to `classifierPrompt` (German `summary` + input-robustness line, with
+`kind` pinned to the exact English enum) and turns the German fixtures into the load-bearing gate for
+that change. See **[Operator-language A/B (#1627)](#operator-language-ab-1627)** below.
 
 ## What it does
 
@@ -32,10 +36,25 @@ ANTHROPIC_API_KEY=… bun run eval:stop-classifier            # human-readable r
 ANTHROPIC_API_KEY=… bun run eval:stop-classifier --json     # machine-readable (for this doc)
 
 # Flags: --trials N  --model <id>  --temperature <t>  --threshold <0..1>  --filter <substr>  --json
+#        --operator-language-off   (#1627 A/B: force operator-language OFF for every fixture — the
+#                                   *before* leg ≡ #1626 baseline; omit it for the *after* leg)
+```
+
+The two A/B legs (#1627) — run on the same branch/commit for a clean before/after:
+
+```bash
+ANTHROPIC_API_KEY=… bun run eval:stop-classifier --trials 9 --operator-language-off --json   # before
+ANTHROPIC_API_KEY=… bun run eval:stop-classifier --trials 9 --json                            # after
 ```
 
 Or dispatch **`.github/workflows/eval-stop-classifier.yml`** (workflow_dispatch-only, `ubuntu-latest`,
-uses the repo's existing `ANTHROPIC_API_KEY` secret) and read the numbers from its run log.
+uses the repo's existing `ANTHROPIC_API_KEY` secret) and read the numbers from its run log. It takes
+an `operator_language_off` input (`"true"`/`"false"`, default `"false"`) that maps to the
+`--operator-language-off` flag, so both A/B legs are reproducible from CI. **Note:** because
+`workflow_dispatch` inputs are validated against the workflow file on the **default branch**, the
+`operator_language_off` input only becomes dispatchable once this PR merges; before merge, capture the
+_after_ leg by dispatch (default inputs) and use the recorded #1626 German baseline as the _before_,
+or run both legs locally with a key.
 
 The harness's **pure logic** (parse/aggregate/decide + fixture invariants) is unit-tested in
 `test/eval-stop-classifier.test.ts` and runs for free in the normal gated `bun test ./test` — no
@@ -43,14 +62,14 @@ network, no key.
 
 ## Encoded decisions
 
-| Decision         | Value                                                                                       | Rationale                                                                   |
-| ---------------- | ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| Model            | `claude-haiku-4-5` (default)                                                                | The API snapshot for the CLI `haiku` alias that `classifyStop` defaults to. |
-| Temperature      | `1.0` (default)                                                                             | Approximates production nondeterminism (see caveat B).                      |
-| Trials `T`       | `5` default; **`9`** for `ambiguous-unknown`                                                | Odd → majority-decidable; thicker for the most-eroded bucket.               |
-| Per-fixture pass | majority-correct (`> T/2` trials `== expectedKind`)                                         | Tolerates nondeterminism.                                                   |
-| Overall pass     | every **gating** fixture majority-correct **AND** gating accuracy `≥ GATING_ACCURACY_FLOOR` | Coarse catastrophe-catcher.                                                 |
-| German tails     | `gating:false` (baseline, reported not gated)                                               | Baseline mixed-language behavior for #1627's before/after.                  |
+| Decision         | Value                                                                                           | Rationale                                                                   |
+| ---------------- | ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Model            | `claude-haiku-4-5` (default)                                                                    | The API snapshot for the CLI `haiku` alias that `classifyStop` defaults to. |
+| Temperature      | `1.0` (default)                                                                                 | Approximates production nondeterminism (see caveat B).                      |
+| Trials `T`       | `5` default; **`9`** for `ambiguous-unknown`                                                    | Odd → majority-decidable; thicker for the most-eroded bucket.               |
+| Per-fixture pass | majority-correct (`> T/2` trials `== expectedKind`)                                             | Tolerates nondeterminism.                                                   |
+| Overall pass     | every **gating** fixture majority-correct **AND** gating accuracy `≥ GATING_ACCURACY_FLOOR`     | Coarse catastrophe-catcher.                                                 |
+| German tails     | **#1627:** gate/question/unknown buckets `gating:true` at `T=9`; spec-first + finished baseline | The de directive is load-bearing, so its buckets gate; see A/B section.     |
 
 ### The pinned threshold (`GATING_ACCURACY_FLOOR`)
 
@@ -68,18 +87,20 @@ kind-distribution baseline below — the overall floor only catches a catastroph
 
 ## Fixture set
 
-| id                       | kind     | gating | lang | T   | intent                                                      |
-| ------------------------ | -------- | ------ | ---- | --- | ----------------------------------------------------------- |
-| `gate-commit-now`        | gate     | ✔      | en   | 5   | "ready to commit?" — proceed-obvious                        |
-| `question-jwt-vs-cookie` | question | ✔      | en   | 5   | real product fork needing a human                           |
-| `finished-pr-pending`    | finished | ✔      | en   | 5   | code done, PR deliverable, not yet opened                   |
-| `complete-investigation` | complete | ✔      | en   | 5   | research/analysis, no PR to produce                         |
-| `complete-issue-created` | complete | ✔      | en   | 5   | filed a GitHub issue, nothing to PR                         |
-| `ambiguous-unknown`      | unknown  | ✔      | en   | 9   | genuinely ambiguous tail — MUST abstain to `unknown`        |
-| `gate-spec-first`        | gate     | —      | en   | 5   | prompt's own gate exemplar — **known gap** (leans question) |
-| `de-gate-spec`           | gate     | —      | de   | 5   | German tail — baseline mixed-language                       |
-| `de-question-approach`   | question | —      | de   | 5   | German tail — baseline mixed-language                       |
-| `de-finished-pr`         | finished | —      | de   | 5   | German tail — baseline mixed-language                       |
+| id                       | kind     | gating | lang | T   | intent                                                            |
+| ------------------------ | -------- | ------ | ---- | --- | ----------------------------------------------------------------- |
+| `gate-commit-now`        | gate     | ✔      | en   | 5   | "ready to commit?" — proceed-obvious                              |
+| `question-jwt-vs-cookie` | question | ✔      | en   | 5   | real product fork needing a human                                 |
+| `finished-pr-pending`    | finished | ✔      | en   | 5   | code done, PR deliverable, not yet opened                         |
+| `complete-investigation` | complete | ✔      | en   | 5   | research/analysis, no PR to produce                               |
+| `complete-issue-created` | complete | ✔      | en   | 5   | filed a GitHub issue, nothing to PR                               |
+| `ambiguous-unknown`      | unknown  | ✔      | en   | 9   | genuinely ambiguous tail — MUST abstain to `unknown`              |
+| `gate-spec-first`        | gate     | —      | en   | 5   | prompt's own gate exemplar — **known gap** (leans question)       |
+| `de-gate-commit`         | gate     | ✔      | de   | 9   | **#1627** German proceed-obvious gate (twin of `gate-commit-now`) |
+| `de-question-approach`   | question | ✔      | de   | 9   | **#1627** German product fork — promoted from baseline            |
+| `de-ambiguous-unknown`   | unknown  | ✔      | de   | 9   | **#1627** abstain bucket under German input — headline datum      |
+| `de-gate-spec`           | gate     | —      | de   | 5   | German twin of the known-gap spec-first — baseline only           |
+| `de-finished-pr`         | finished | —      | de   | 5   | German tail — baseline before/after datum                         |
 
 `gate-spec-first` started gating and was demoted to baseline per the contingency rule after the first
 run (see **Known gaps** below).
@@ -127,6 +148,59 @@ is a genuine verdict, not a masked miss. `gate-spec-first` is shown at the botto
 > The contingency rule (applied above): (1) revise a fixture only if genuinely under-specified/mislabeled;
 > (2) else demote to non-gating baseline + record here; (3) never silently lower the floor to paper over a
 > gap. `ambiguous-unknown` held majority at `T=9`, so no demotion was needed there.
+
+## Operator-language A/B (#1627)
+
+#1627 makes `classifierPrompt` operator-language-aware: for `operatorLanguage === "de"` it splices in
+two lines — render `summary` in German, and an **input-robustness** line so a German/mixed tail
+doesn't erode the `unknown` abstain bucket — while **pinning `kind` to the exact English enum** (a
+translated kind silently collapses to `unknown` via `normalize`'s `KINDS.includes`). The `"en"` path
+is **byte-identical** to the #1626 prompt (unit-tested).
+
+**The de path gates — it is not observational-only.** Three German fixtures are `gating:true` at
+`T=9`, one per abstain-critical bucket: `de-gate-commit` (new), `de-question-approach` (promoted),
+and `de-ambiguous-unknown` (new — the headline abstain-bucket datum). `de-gate-spec` (German twin of
+the known-gap spec-first exemplar) and `de-finished-pr` stay baseline.
+
+**A/B mechanism.** `--operator-language-off` forces `operatorLanguage="en"` for every fixture (the
+_before_ leg — byte-identical to #1626); omitting it runs the _after_ leg with the German directive
+live for `de` fixtures. English fixtures are `"en"` either way, so the English gating set is unchanged
+across legs (its `ambiguous-unknown` 9/9 abstain is preserved **by construction** — the prompt it
+sees is byte-identical).
+
+- **Before (German fixtures, operator-language OFF)** — the #1626 baseline already recorded it:
+  `de-gate` 4/5, `de-question` 5/5, `de-finished` 5/5 (English prompt against a German tail). Re-run
+  it exactly with `--operator-language-off`.
+- **After (German directive live)** — **PENDING capture.** Run both legs (locally with a key, or via
+  the workflow) and transcribe the `--json` here. The gate: every German gating fixture stays
+  majority-correct at `T=9`, gating accuracy ≥ floor, and `de-ambiguous-unknown` holds `unknown`
+  majority. This eval is **manual/nightly, never a per-PR gate** (paid, keyed, nondeterministic), so
+  the PR declares the after-run as a manual step and must not merge until it is green.
+
+### Noise band (react to signal, not model noise)
+
+At `temperature = 1.0` a single-run `T=5` majority can flip on one trial of sampling noise. So the
+German gating fixtures run at **`T=9`**, and a shift between legs counts as **signal** only when it
+**crosses the majority boundary** OR moves by **≥2 trials**, AND survives a **confirmation re-run**. A
+lone ±1-trial wobble is noise — never reword the directive in response to it.
+
+### Verification split — what the eval does and does NOT cover
+
+- **Input-robustness / abstain half — behaviorally gated.** The eval scores `kind`, and the German
+  gating fixtures exercise it end-to-end against the live model. A regression here fails the gate.
+- **German-`summary` output half — NOT behaviorally verified.** The eval scores `kind` only; it never
+  inspects `summary` language, and the unit tests assert the prompt _contains_ the German-summary
+  instruction, not that the model _obeys_ it. "Summary renders in German" rests on prompt content +
+  the shipped recap precedent (recap already ships the same directive shape for its `body`/`headline`),
+  **not** on measurement. **Do not read an eval PASS as evidence the summary output is correct.**
+
+### Contingency for a German non-hold
+
+If the after-run shows a promoted German fixture below majority (past the noise band), treat it as a
+**finding**, not a reason to silently un-gate: (1) iterate the directive wording and re-run; (2) demote
+to baseline **only** with an explicit justification recorded as a known gap — exactly the treatment
+`gate-spec-first` received. Re-pin `GATING_ACCURACY_FLOOR` only if the adjustment rule
+(`round_down(observed − 0.15)` to 0.05) requires, with a commit note.
 
 ## Fidelity caveats
 

--- a/scripts/eval-stop-classifier.ts
+++ b/scripts/eval-stop-classifier.ts
@@ -199,9 +199,27 @@ export const FIXTURES: Fixture[] = [
       "Soll ich zuerst die Spezifikation schreiben, bevor ich implementiere? (j/n)",
     ],
     expectedKind: "gate",
+    // Baseline (not gating): the German twin of `gate-spec-first`, the recorded known gap that
+    // leans `question` even in English — kept for the before/after comparison, never gated (gating
+    // it would just import that gap). The German gate BUCKET is gated via `de-gate-commit` below.
     gating: false,
     lang: "de",
-    note: "German tail, English prompt — baseline mixed-language behavior (#1627 before/after).",
+    note: "German twin of the known-gap spec-first exemplar — baseline before/after datum only.",
+  },
+  {
+    id: "de-gate-commit",
+    taskPrompt: "Add a rate limiter to the API middleware.",
+    tail: [
+      "Der Rate-Limiter ist implementiert und die Tests sind grün.",
+      "Soll ich jetzt committen? (j/n)",
+    ],
+    expectedKind: "gate",
+    // GATING (#1627): the German proceed-obvious gate — German twin of the SOLID `gate-commit-now`,
+    // not the known-gap spec-first exemplar. T=9 for a noise-tolerant German-input signal.
+    gating: true,
+    trials: 9,
+    lang: "de",
+    note: "German proceed-obvious gate — committing its own green work is clearly correct.",
   },
   {
     id: "de-question-approach",
@@ -212,9 +230,24 @@ export const FIXTURES: Fixture[] = [
       "Das hat sehr unterschiedliche Sicherheits- und Skalierungs-Konsequenzen.",
     ],
     expectedKind: "question",
-    gating: false,
+    // GATING (#1627): the German product-fork bucket (5/5 at the #1626 baseline). T=9.
+    gating: true,
+    trials: 9,
     lang: "de",
-    note: "German tail, English prompt — baseline mixed-language behavior (#1627 before/after).",
+    note: "German real product fork needing a human — the German `question` bucket under #1627.",
+  },
+  {
+    id: "de-ambiguous-unknown",
+    taskPrompt: "Refactor the report generator for readability.",
+    tail: ["Mit dem ersten Teil fertig. Ich mache weiter.", ""],
+    expectedKind: "unknown",
+    // GATING (#1627 HEADLINE): the abstain bucket under German input — the exact erosion the
+    // input-robustness line defends against. No prior fixture covered German→unknown. T=9, the
+    // thick-confidence count the English `ambiguous-unknown` also uses for the most-eroded bucket.
+    gating: true,
+    trials: 9,
+    lang: "de",
+    note: "Genuinely ambiguous German tail — the classifier MUST abstain to unknown, not guess.",
   },
   {
     id: "de-finished-pr",
@@ -224,9 +257,11 @@ export const FIXTURES: Fixture[] = [
       "hinzugefügt. Alle Tests grün. Ich habe den PR noch nicht geöffnet.",
     ],
     expectedKind: "finished",
+    // Baseline (not gating): kept as a before/after datum; the three gated German buckets above
+    // (gate/question/unknown) are the load-bearing #1627 signal.
     gating: false,
     lang: "de",
-    note: "German tail, English prompt — baseline mixed-language behavior (#1627 before/after).",
+    note: "German tail, English prompt — baseline mixed-language before/after datum.",
   },
 ];
 
@@ -398,9 +433,15 @@ export function formatReport(
   results: FixtureResult[],
   decision: Decision,
   modelId: string,
+  operatorLanguageOff = false,
 ): string {
   const lines: string[] = [];
   lines.push(`autopilot stop-classifier eval — model=${modelId}`);
+  lines.push(
+    operatorLanguageOff
+      ? "operator-language: OFF (before leg — forced en everywhere, ≡ #1626 baseline)"
+      : "operator-language: per-fixture lang (after leg — German directive live for `de` fixtures)",
+  );
   lines.push(
     `fixtures=${results.length} (gating=${results.filter((r) => r.fixture.gating).length}, ` +
       `baseline=${results.filter((r) => !r.fixture.gating).length}); ` +
@@ -455,6 +496,11 @@ interface RunOptions {
   temperature: number;
   trials: number;
   filter?: string;
+  /** #1627 A/B switch: when true, force `operatorLanguage="en"` for EVERY fixture (the *before* leg
+   *  — byte-identical to the #1626 baseline). Default false → each fixture uses its own `lang` (the
+   *  *after* leg, with the German directive live for `de` fixtures). English fixtures are unchanged
+   *  either way. One harness, both A/B legs, reproducibly on the same branch/commit. */
+  operatorLanguageOff: boolean;
 }
 
 function buildRequestBody(
@@ -500,6 +546,7 @@ function parseArgs(argv: string[]): {
   threshold: number;
   filter?: string;
   json: boolean;
+  operatorLanguageOff: boolean;
 } {
   const get = (flag: string): string | undefined => {
     const i = argv.indexOf(flag);
@@ -512,6 +559,7 @@ function parseArgs(argv: string[]): {
     threshold: Number(get("--threshold") ?? GATING_ACCURACY_FLOOR),
     filter: get("--filter"),
     json: argv.includes("--json"),
+    operatorLanguageOff: argv.includes("--operator-language-off"),
   };
 }
 
@@ -540,13 +588,17 @@ async function main(): Promise<void> {
     temperature: args.temperature,
     trials: args.trials,
     filter: args.filter,
+    operatorLanguageOff: args.operatorLanguageOff,
   };
 
   const results: FixtureResult[] = [];
   let firstCall = true;
   for (const fixture of fixtures) {
     const n = trialsFor(fixture, args.trials);
-    const prompt = classifierPrompt(fixture.tail, fixture.taskPrompt);
+    // #1627 A/B: `--operator-language-off` forces "en" everywhere (the *before* leg); otherwise each
+    // fixture uses its own `lang`, so `de` fixtures exercise the real German directive (*after*).
+    const operatorLanguage = opts.operatorLanguageOff ? "en" : fixture.lang;
+    const prompt = classifierPrompt(fixture.tail, fixture.taskPrompt, operatorLanguage);
     const outcomes: TrialOutcome[] = [];
     for (let t = 0; t < n; t++) {
       let response: AnthropicResponse;
@@ -582,6 +634,9 @@ async function main(): Promise<void> {
         {
           model: args.model,
           temperature: args.temperature,
+          // #1627 A/B leg: false = *after* (per-fixture lang, German directive live for `de`);
+          // true = *before* (operator-language forced off everywhere, ≡ #1626 baseline).
+          operatorLanguageOff: args.operatorLanguageOff,
           decision,
           results: results.map((r) => ({
             id: r.fixture.id,
@@ -602,7 +657,7 @@ async function main(): Promise<void> {
       ),
     );
   } else {
-    console.log(formatReport(results, decision, args.model));
+    console.log(formatReport(results, decision, args.model, args.operatorLanguageOff));
   }
 
   process.exit(decision.pass ? 0 : 1);

--- a/src/autopilot-classify-core.ts
+++ b/src/autopilot-classify-core.ts
@@ -1,11 +1,13 @@
 import type { AutopilotVerdict, AutopilotKind } from "./types";
 import { fenceUntrusted } from "./untrusted";
+import type { OperatorLanguage } from "./operator-language";
 
 /**
  * Pure classifier core for the autopilot stop-classifier — the prompt + verdict
  * interpretation, with NO import-time side effects. Deliberately a LEAF module: its only
- * imports are `./untrusted` (which imports just `node:crypto`) and `./types` (types-only),
- * so importing it never reads env or touches the filesystem. `src/autopilot-llm.ts`
+ * imports are `./untrusted` (which imports just `node:crypto`), `./types` (types-only), and
+ * `./operator-language` (a leaf with no imports and no side effects — issue #1627), so importing
+ * it never reads env or touches the filesystem. `src/autopilot-llm.ts`
  * re-exports these symbols (production behavior is unchanged); the live-model eval
  * (`scripts/eval-stop-classifier.ts`) and its hermetic unit test import them from HERE to
  * avoid pulling in `./config`/`./spawn-auth`, which read `process.env` and probe the
@@ -40,13 +42,48 @@ export function preClassify(tail: string[]): AutopilotVerdict | null {
 }
 
 /**
+ * The operator-language directive text for the classifier (issue #1627). Two lines, injected only
+ * when `operatorLanguage === "de"` — the "en" path adds nothing, keeping the prompt byte-identical
+ * for existing operators. Both are fixed agent-facing prose, never i18n'd (same precedent as the
+ * rest of this prompt and `src/operator-language.ts`); the "de"/"German" hardcode mirrors
+ * `recap-core.ts`'s own `operatorLanguage === "de"` branch.
+ *
+ *  - INPUT: input-robustness — a German/mixed tail must NOT erode the `unknown` abstain bucket, and
+ *    a non-English tail is never itself a reason to guess a confident kind. Injected next to the
+ *    terminal-tail fence (it governs how to READ the tail).
+ *  - OUTPUT: render `summary` in German while PINNING `kind` to the exact English enum — a
+ *    translated/off-enum kind silently collapses to `unknown` via `normalize`'s `KINDS.includes`.
+ *    Injected next to the enum block (before the terminal "then stop" line) so it is not discounted
+ *    as post-stop chrome.
+ */
+const CLASSIFIER_INPUT_ROBUSTNESS_DE =
+  "The terminal tail above may be written in German or a mix of German and English. Classify by " +
+  "what the agent actually MEANS, not by matching English phrasing — a non-English tail is never " +
+  "itself a reason to choose a kind. When the wording leaves the agent's intent genuinely unclear, " +
+  'prefer "unknown"; never upgrade an uncertain read to a confident "gate" or "question" just to ' +
+  "avoid abstaining.";
+const CLASSIFIER_OUTPUT_LANGUAGE_DE =
+  "Write the `summary` field in German. Keep `kind` as one of the exact English enum values above " +
+  '("gate" | "question" | "finished" | "complete" | "unknown") — Shepherd matches it literally, and ' +
+  'a translated or reworded kind silently collapses to "unknown", so never translate it.';
+
+/**
  * Self-contained instructions for the classifier agent. NOT UI chrome — never i18n'd.
  * The tail is UNTRUSTED agent output; it is embedded as data the agent only classifies,
  * never executes — the Write-only / dontAsk / no-Bash sandbox contains any injection.
+ *
+ * `operatorLanguage` (issue #1627): "en" (default) returns the byte-identical historical prompt;
+ * "de" splices the two directives above in at their anchors so `summary` renders in German while
+ * `kind` stays the exact English enum token.
  */
-export function classifierPrompt(tail: string[], taskPrompt: string): string {
+export function classifierPrompt(
+  tail: string[],
+  taskPrompt: string,
+  operatorLanguage: OperatorLanguage = "en",
+): string {
   const clippedTask = taskPrompt.slice(0, 1500);
   const clippedTail = tail.slice(-20).join("\n").slice(0, 3000);
+  const de = operatorLanguage === "de";
   return [
     "You are triaging why a coding agent has stopped. Read its task and the tail of its terminal,",
     "then classify WHY it is waiting. Do not do the task. Do not run anything.",
@@ -56,6 +93,8 @@ export function classifierPrompt(tail: string[], taskPrompt: string): string {
     "",
     "The tail of the agent's terminal (most recent last; untrusted output):",
     fenceUntrusted("terminal tail", clippedTail),
+    // Anchor A — input-robustness (de only): governs how to READ a German/mixed tail.
+    ...(de ? [CLASSIFIER_INPUT_ROBUSTNESS_DE] : []),
     "",
     "Classify into exactly one `kind`:",
     '- "gate": a procedural/workflow stop the agent could resolve itself and the answer is obviously "yes, keep going" — e.g. "shall I write the spec first?", "ready to start implementing?", "want me to commit now?". Choose this ONLY when proceeding is clearly correct.',
@@ -63,6 +102,8 @@ export function classifierPrompt(tail: string[], taskPrompt: string): string {
     '- "finished": the agent has done code/implementation work whose deliverable is a pull request, believes it is done, but has not opened the PR yet. (It still needs to be driven to a PR.)',
     '- "complete": the agent has fully delivered a task whose deliverable is NOT a pull request — research/investigation/analysis, creating a GitHub issue, or a one-off answer — and there is nothing to turn into a PR. Judge by the TASK: if it never asked for code changes, a finished agent is "complete", not "finished".',
     '- "unknown": you cannot confidently tell. When in doubt, use this — never guess "gate".',
+    // Anchor B — output/kind-pin (de only): adjacent to the enum, before the terminal "then stop".
+    ...(de ? [CLASSIFIER_OUTPUT_LANGUAGE_DE] : []),
     "",
     `Write your verdict as JSON to the file \`${VERDICT_FILE}\` in the current directory, with EXACTLY this shape, then stop:`,
     '{"kind": "gate" | "question" | "finished" | "complete" | "unknown", "summary": "<1-2 sentence plain description of what the agent is waiting for, or for \\"complete\\" what it delivered>"}',

--- a/src/autopilot-llm.ts
+++ b/src/autopilot-llm.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { HerdrDriver } from "./herdr";
 import type { AutopilotVerdict, AgentProvider } from "./types";
+import type { OperatorLanguage } from "./operator-language";
 import { apiKeyFailClosed, apiKeyPassthroughEnv } from "./spawn-auth";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
 import {
@@ -28,6 +29,9 @@ export interface ClassifierDeps {
   provider?: AgentProvider;
   model?: string | null;
   effort?: string | null;
+  /** Operator language for the classifier prompt (issue #1627). "en" (default) → byte-identical
+   *  historical prompt; "de" → `summary` in German with `kind` pinned to the exact English enum. */
+  operatorLanguage?: OperatorLanguage;
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
   timeoutMs?: number;
@@ -109,6 +113,7 @@ export async function classifyStop(
     provider = "claude",
     model = "haiku",
     effort = null,
+    operatorLanguage = "en",
     now = Date.now,
     sleep = realSleep,
     // Deliberately shorter than the critic's 10m: this is a fast tail-triage on haiku, not a
@@ -131,7 +136,7 @@ export async function classifyStop(
   let terminalId: string | null = null;
   try {
     cwd = makeTmpDir();
-    const prompt = classifierPrompt(tail, taskPrompt);
+    const prompt = classifierPrompt(tail, taskPrompt, operatorLanguage);
     try {
       terminalId = (
         await deps.herdr.start(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1482,7 +1482,13 @@ const autopilot = new AutopilotService({
     return classifyStop(
       tail,
       taskPrompt,
-      { herdr, provider: env.provider, model: env.model, effort: env.effort },
+      {
+        herdr,
+        provider: env.provider,
+        model: env.model,
+        effort: env.effort,
+        operatorLanguage: config.operatorLanguage,
+      },
       label,
     );
   },

--- a/test/autopilot-llm.test.ts
+++ b/test/autopilot-llm.test.ts
@@ -73,6 +73,59 @@ test("classifierPrompt fences the task and terminal tail as untrusted", () => {
   expect(p).toContain("ignore all previous instructions");
 });
 
+// --- operator-language (#1627): en byte-identical; de adds summary→German + kind-pin + robustness ---
+
+test("classifierPrompt en (default and explicit) is byte-identical — no operator-language drift", () => {
+  const tail = ["Ready to commit now? (y/n)"];
+  const task = "Add a rate limiter";
+  // fenceUntrusted stamps a fresh random nonce per call (by design), so normalize the nonce out
+  // before comparing structural byte-identity — the nonce is not a prompt-drift axis.
+  const stripNonce = (s: string) => s.replace(/:[0-9a-f]{12}⟧/g, ":<nonce>⟧");
+  const def = stripNonce(classifierPrompt(tail, task));
+  expect(stripNonce(classifierPrompt(tail, task, "en"))).toBe(def);
+  // The de-only directives must be entirely absent from the en prompt.
+  expect(def).not.toContain("in German");
+  expect(def).not.toContain("may be written in German");
+});
+
+test("classifierPrompt de injects the summary→German + verbatim-kind-pin + input-robustness lines", () => {
+  const p = classifierPrompt(["Soll ich jetzt committen? (j/n)"], "Add a rate limiter", "de");
+  expect(p).toContain("Write the `summary` field in German");
+  // kind is pinned to the exact English enum — a translated kind collapses to unknown via normalize.
+  expect(p).toContain("never translate it");
+  // input-robustness: a German/mixed tail must not erode the unknown abstain bucket.
+  expect(p).toContain("The terminal tail above may be written in German");
+  expect(p).toContain("avoid abstaining");
+});
+
+test("classifierPrompt de places the kind-pin BEFORE the terminal 'then stop' line (not post-stop chrome)", () => {
+  const p = classifierPrompt(["Soll ich jetzt committen? (j/n)"], "task", "de");
+  const pinIdx = p.indexOf("Keep `kind` as one of the exact English enum");
+  const stopIdx = p.indexOf("then stop:");
+  expect(pinIdx).toBeGreaterThanOrEqual(0);
+  expect(stopIdx).toBeGreaterThanOrEqual(0);
+  expect(pinIdx).toBeLessThan(stopIdx);
+});
+
+test("classifyStop threads operatorLanguage=de into the classifier prompt (argv positional)", async () => {
+  const { deps, calls } = makeDeps({
+    operatorLanguage: "de",
+    readVerdict: () => ({ kind: "gate", summary: "x" }) as any,
+  });
+  await classifyStop(["Soll ich jetzt committen? (j/n)"], "task", deps, "l");
+  const argvStr: string = calls.started.argv.join("\n");
+  expect(argvStr).toContain("Write the `summary` field in German");
+});
+
+test("classifyStop default (en) keeps the classifier prompt free of the de directive", async () => {
+  const { deps, calls } = makeDeps({
+    readVerdict: () => ({ kind: "gate", summary: "x" }) as any,
+  });
+  await classifyStop(["Ready to commit? (y/n)"], "task", deps, "l");
+  const argvStr: string = calls.started.argv.join("\n");
+  expect(argvStr).not.toContain("field in German");
+});
+
 test("classifyStop: parses a complete verdict (non-PR deliverable)", async () => {
   const { deps } = makeDeps({
     readVerdict: () => ({ kind: "complete", summary: "Created issue #345." }),

--- a/test/eval-stop-classifier.test.ts
+++ b/test/eval-stop-classifier.test.ts
@@ -229,17 +229,37 @@ test("fixture ids are unique", () => {
   expect(new Set(ids).size).toBe(ids.length);
 });
 
-test("the ambiguous→unknown fixture exists, is gating, and uses T≥9", () => {
-  const amb = FIXTURES.find((f) => f.expectedKind === "unknown");
-  expect(amb).toBeDefined();
-  expect(amb?.gating).toBe(true);
-  expect(amb?.trials ?? 0).toBeGreaterThanOrEqual(9);
+test("every gating ambiguous→unknown fixture uses T≥9 (thick abstain-bucket confidence)", () => {
+  const abstain = FIXTURES.filter((f) => f.expectedKind === "unknown" && f.gating);
+  // Both the English and German abstain fixtures gate (#1627).
+  expect(abstain.length).toBeGreaterThanOrEqual(2);
+  for (const f of abstain) expect(f.trials ?? 0).toBeGreaterThanOrEqual(9);
 });
 
-test("at least one German baseline fixture exists (non-gating), for the #1627 before/after", () => {
+test("German fixtures both gate (the #1627 de path) and keep baseline before/after data", () => {
   const de = FIXTURES.filter((f) => f.lang === "de");
   expect(de.length).toBeGreaterThan(0);
-  for (const f of de) expect(f.gating).toBe(false);
+  // #1627 makes the de path load-bearing: at least one German gating fixture per abstain-critical
+  // bucket, AND at least one German baseline fixture retained for the before/after comparison.
+  const deGating = de.filter((f) => f.gating);
+  const deBaseline = de.filter((f) => !f.gating);
+  expect(deGating.length).toBeGreaterThan(0);
+  expect(deBaseline.length).toBeGreaterThan(0);
+});
+
+test("the German gating fixtures cover gate, question, and the unknown abstain bucket", () => {
+  const deGatingKinds = new Set(
+    FIXTURES.filter((f) => f.gating && f.lang === "de").map((f) => f.expectedKind),
+  );
+  for (const k of ["gate", "question", "unknown"] as AutopilotKind[]) {
+    expect(deGatingKinds).toContain(k);
+  }
+});
+
+test("German gating fixtures run at T≥9 (temperature-1.0 noise band — no 1-trial flips)", () => {
+  for (const f of FIXTURES.filter((f) => f.gating && f.lang === "de")) {
+    expect(f.trials ?? 0).toBeGreaterThanOrEqual(9);
+  }
 });
 
 test("gating English fixtures cover gate, question, finished, complete, and unknown", () => {


### PR DESCRIPTION
Part 2b of epic #1616 (issue #1627). Follows #1626 (the eval harness/baseline). Base: `epic/1616-operator-language-mid-session-persistenc`.

## What

Makes the autopilot stop-classifier language-correct on both ends, gated by the #1626 live-model eval.

- **`classifierPrompt` gains an `operatorLanguage` param** (`src/autopilot-classify-core.ts`). For `"de"` it splices two lines into the prompt body:
  - **output:** render the `summary` field in German;
  - **input-robustness:** a German/mixed terminal tail must not erode the `unknown` abstain bucket, and a non-English tail is never itself a reason to guess a confident kind.
- **`kind` is pinned verbatim** to the exact English enum — `normalize()` hard-matches `KINDS.includes` (`autopilot-classify-core.ts:80`), so a translated/off-enum kind silently collapses to `unknown`. Same discipline as recap's `verdict` enum.
- **`en` stays byte-identical.** Both directives are `de`-gated; the `en` path returns the unchanged #1626 prompt (unit-tested by normalizing the fence nonce out and comparing). Because a German tail only appears once injection is active, `de`-gating both additions also scopes input-robustness to exactly when it's needed.
- **Threaded end-to-end:** `config.operatorLanguage` → `ClassifierDeps` → `classifyStop` (`autopilot-llm.ts`) → `classifierPrompt`, and the `index.ts` classify closure. Same source of truth recap/rundown use, kept live across resume+steer by #1634.

### Placement

The kind-pin is injected **adjacent to the enum block, before** the terminal `Write your verdict … then stop` line — not appended after it — so it isn't discounted as post-stop chrome. A unit test asserts the ordering.

## Eval (the gate)

- New `--operator-language-off` flag + `operator_language_off` workflow input give a one-harness A/B: `off` = *before* (byte-identical to #1626), on = *after* (German directive live for `de` fixtures).
- **Three German fixtures are now `gating:true` at `T=9`** so the `de` path is load-bearing, not observational: `de-gate-commit` (new, twin of the *solid* commit-now gate), `de-question-approach` (promoted), `de-ambiguous-unknown` (new — the abstain bucket under German input). `de-gate-spec` (German twin of the known-gap spec-first exemplar) and `de-finished-pr` stay baseline.
- **Noise band:** `T=9` + react to a shift only if it crosses the majority boundary or moves ≥2 trials AND survives a confirmation re-run — no reacting to 1-trial temperature-1.0 wobble.

### ⚠️ Verification split — read before trusting the eval

- The **input-robustness / abstain** half **is** behaviorally gated (the eval scores `kind` against live German fixtures).
- The **German-`summary` output** half has **no behavioral verification** — the eval scores `kind` only; unit tests assert prompt *content*, not model *obedience*. It rests on prompt content + the shipped recap precedent. **An eval PASS is not evidence the summary output is correct.**

## Verification done locally

- `bun run lint`, `bun run typecheck`, `bunx prettier --check`, and `bun test ./test` (6551 pass, 0 fail) all green.
- A/B lever verified at the prompt layer (no model call): `de` adds exactly the 2 directive lines; `en` is unchanged.

## Required before merge (manual — paid, keyed eval)

The live eval is manual/nightly, never a per-PR gate (paid, keyed, nondeterministic). The **after-run must be captured and confirmed at/above baseline before merge**:

```shepherd:manual-steps
- [ ] Run the #1627 eval A/B and confirm the gate is green at/above the #1626 baseline: dispatch `.github/workflows/eval-stop-classifier.yml` on this branch (default inputs = the *after* leg, T=9), or run locally `ANTHROPIC_API_KEY=… bun run eval:stop-classifier --trials 9 --json`. Confirm every gating fixture (incl. the 3 German ones) is majority-correct, gating accuracy ≥ floor, and English `ambiguous-unknown` stays 9/9. Transcribe the after-numbers into `docs/eval-stop-classifier.md`.
```

*before* leg = the recorded #1626 German baseline (`de-gate` 4/5, `de-question` 5/5, `de-finished` 5/5, English prompt vs German tail); the `--operator-language-off`/`operator_language_off` input reproduces it exactly once this PR reaches the default branch (dispatch inputs validate against the default-branch workflow file). If a promoted German fixture doesn't hold at `T=9`, the doc's contingency rule applies (iterate wording + re-run, or demote with a documented justification).

`[no-feature-entry]`: server-side prompt change, no new UI surface — the operator-language discovery entry belongs to the epic's UI PR.

Closes #1627.

🤖 Generated with [Claude Code](https://claude.com/claude-code)