### PR TITLE
fix: auto-allow node's own tailnet host + accurate origin-block copy (#1645 Fix 2+3)

### DIFF
--- a/deploy/shepherd.service
+++ b/deploy/shepherd.service
@@ -22,7 +22,10 @@ RestartPreventExitStatus=78
 Environment=PATH=%h/.bun/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin
 Environment=SHEPHERD_PORT=7330
 Environment=SHEPHERD_HOST=127.0.0.1
-# localhost defaults only; add your own tailnet hostname via SHEPHERD_ALLOWED_HOSTS in ~/.shepherd/env
+# localhost defaults only. A direct-served HUD (`tailscale serve` on this node) is trusted
+# automatically — Shepherd folds the node's own tailnet host into the allowlist at startup.
+# Only a Service-fronted / custom-DNS HUD (served under a different DNS name than this node)
+# needs its host added via SHEPHERD_ALLOWED_HOSTS in ~/.shepherd/env.
 Environment=SHEPHERD_ALLOWED_HOSTS=localhost,127.0.0.1,::1,[::1]
 # optional overrides (token, repo root, etc.) — file may be absent
 EnvironmentFile=-%h/.shepherd/env

--- a/src/config.ts
+++ b/src/config.ts
@@ -448,6 +448,22 @@ export function resolveAllowedOriginHosts(envValue: string | undefined): string[
   return hosts;
 }
 
+/**
+ * Fold the node's own resolved host into an origin allowlist in place (deduped;
+ * null/blank ignored). Called at boot once `config.previewHost` resolves so a
+ * same-node HUD — direct `tailscale serve`, where the served front host IS the
+ * node's own DNSName — is trusted without a manual SHEPHERD_ALLOWED_HOSTS. Only
+ * the hostname is trusted: preview-port origins are still rejected by the origin
+ * guard's preview-range check (it runs before the hostname check), so this does
+ * not open preview-forged CSRF. A Service-fronted HUD is served under a DIFFERENT
+ * DNS name, so it isn't covered here and still needs a manual allowlist entry.
+ * Issue #1645 Fix 2. Exported for tests.
+ */
+export function addOwnHostToAllowlist(hosts: string[], host: string | null): void {
+  const h = host?.trim();
+  if (h && !hosts.includes(h)) hosts.push(h);
+}
+
 export const config = {
   port: mainPort,
   // bind to loopback only; the Tailscale-serve proxy reaches it via 127.0.0.1.

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
   parseServedPort,
   validatePreviewPortRange,
   validateAgentIngressPort,
+  addOwnHostToAllowlist,
 } from "./config";
 import { SessionStore } from "./store";
 import type {
@@ -400,6 +401,13 @@ let credentialBanner: string | null = null;
   }
   // Resolve the node's own tailnet hostname (null when tailscale is absent).
   config.previewHost = await resolveNodeHost();
+  // Fold the node's own tailnet host into the CSRF origin allowlist so a same-node HUD
+  // (direct `tailscale serve`, served front host == this node's DNSName) is trusted out of
+  // the box — no manual SHEPHERD_ALLOWED_HOSTS. Preview-port origins stay rejected (the
+  // guard's preview-range check runs first, independent of hostname) and foreign origins
+  // stay blocked. A Service-fronted HUD uses a different DNS name and still needs a manual
+  // allowlist entry (see deploy/shepherd.service). Issue #1645 Fix 2.
+  addOwnHostToAllowlist(config.allowedOriginHosts, config.previewHost);
   validatePreviewPortRange({
     previewPortBase: config.previewPortBase,
     previewPortCount: config.previewPortCount,

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,6 +34,7 @@ import {
   validateNewProject,
   isAuthorized,
   originAllowed,
+  classifyOrigin,
   safeRepoDir,
   parseTermDims,
   validateSteers,
@@ -628,9 +629,17 @@ function checkOrigin(req: Request): Response | null {
   const method = req.method;
   if (method !== "POST" && method !== "DELETE" && method !== "PUT") return null;
   const previewRange = { base: config.previewPortBase, count: config.previewPortCount };
-  if (!originAllowed(req.headers.get("Origin"), config.allowedOriginHosts, previewRange)) {
-    return json({ error: "forbidden: origin not allowed" }, 403);
-  }
+  const verdict = classifyOrigin(
+    req.headers.get("Origin"),
+    config.allowedOriginHosts,
+    previewRange,
+  );
+  // Distinct bodies so the client can show accurate copy (issue #1645 Fix 3): a preview-port
+  // origin genuinely IS read-only; an un-allowlisted host should be pointed at
+  // SHEPHERD_ALLOWED_HOSTS, not told to "open Shepherd directly" (it already is).
+  if (verdict === "preview-port") return json({ error: "forbidden: origin not allowed" }, 403);
+  if (verdict === "host-not-allowed")
+    return json({ error: "forbidden: origin host not allowed" }, 403);
   return null;
 }
 

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -867,26 +867,35 @@ export function safeRepoDir(repoPathRaw: string, repoRoot: string): string | nul
   }
 }
 
+/** Verdict for an incoming CSRF origin check: allowed, rejected because it's a
+ *  preview-port origin, or rejected because its host isn't allowlisted. The two
+ *  rejection reasons let the caller surface distinct copy (issue #1645 Fix 3): a
+ *  genuine preview app is "read-only", while an un-allowlisted HUD host should
+ *  point the operator at SHEPHERD_ALLOWED_HOSTS instead of blaming the preview. */
+export type OriginVerdict = "allow" | "preview-port" | "host-not-allowed";
+
 /**
- * Returns true when the request should be allowed through the CSRF origin check.
+ * Classify an incoming Origin for the CSRF guard (see {@link originAllowed} for the
+ * boolean shorthand). Preserves the historical edges: an absent/empty Origin
+ * (curl/CLI, no browser) is `"allow"`; a malformed Origin is `"host-not-allowed"`.
  *
  * When `previewRange` is supplied, any Origin whose port falls in
- * [base, base + count) is **rejected** even if its hostname is allowlisted —
- * a preview app running on that port shares the HUD's hostname and could
- * otherwise forge `/api` mutations (CSRF via blind cross-origin POST).
- * CLI / curl clients (no Origin header) are always allowed through.
+ * [base, base + count) is `"preview-port"` even if its hostname is allowlisted —
+ * a preview app running on that port shares the HUD's hostname and could otherwise
+ * forge `/api` mutations (CSRF via blind cross-origin POST). This check runs BEFORE
+ * the hostname check so a previewed app can never be reclassified as an allowed host.
  */
-export function originAllowed(
+export function classifyOrigin(
   originHeader: string | null | undefined,
   allowedHosts: string[],
   previewRange?: { base: number; count: number },
-): boolean {
-  if (!originHeader) return true; // no-browser client (curl, CLI)
+): OriginVerdict {
+  if (!originHeader) return "allow"; // no-browser client (curl, CLI)
   let parsed: URL;
   try {
     parsed = new URL(originHeader);
   } catch {
-    return false; // malformed origin
+    return "host-not-allowed"; // malformed origin
   }
 
   // Reject preview-port origins before the hostname check so a previewed app
@@ -900,12 +909,25 @@ export function originAllowed(
     if (parsed.port !== "") {
       const port = Number(parsed.port);
       if (port >= base && port < base + count) {
-        return false; // preview-port origin → reject
+        return "preview-port"; // preview-port origin → reject
       }
     }
   }
 
-  return allowedHosts.includes(parsed.hostname);
+  return allowedHosts.includes(parsed.hostname) ? "allow" : "host-not-allowed";
+}
+
+/**
+ * Returns true when the request should be allowed through the CSRF origin check.
+ * Thin boolean wrapper over {@link classifyOrigin}; CLI / curl clients (no Origin
+ * header) are always allowed through.
+ */
+export function originAllowed(
+  originHeader: string | null | undefined,
+  allowedHosts: string[],
+  previewRange?: { base: number; count: number },
+): boolean {
+  return classifyOrigin(originHeader, allowedHosts, previewRange) === "allow";
 }
 
 const STEER_LABEL_MAX = 60;

--- a/test/config-origin.test.ts
+++ b/test/config-origin.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "bun:test";
 import {
   resolveAllowedOriginHosts,
+  addOwnHostToAllowlist,
   SHEPHERD_CAPTURE_EXTENSION_ID,
   SHEPHERD_CAPTURE_UNPACKED_DEV_ID,
 } from "../src/config";
@@ -46,4 +47,35 @@ test("resolveAllowedOriginHosts: trims whitespace, drops empties, preserves [::1
     SHEPHERD_CAPTURE_EXTENSION_ID,
     SHEPHERD_CAPTURE_UNPACKED_DEV_ID,
   ]);
+});
+
+// ── addOwnHostToAllowlist (issue #1645 Fix 2) ─────────────────────────────────
+
+// The node's own resolved tailnet host is folded in so a same-node HUD is trusted.
+test("addOwnHostToAllowlist: appends the node's own host", () => {
+  const hosts = ["localhost", "127.0.0.1"];
+  addOwnHostToAllowlist(hosts, "agentnode.example.ts.net");
+  expect(hosts).toEqual(["localhost", "127.0.0.1", "agentnode.example.ts.net"]);
+});
+
+// Dedup: an already-listed host must not be doubled (e.g. operator set it manually too).
+test("addOwnHostToAllowlist: does not double an already-listed host", () => {
+  const hosts = ["localhost", "agentnode.example.ts.net"];
+  addOwnHostToAllowlist(hosts, "agentnode.example.ts.net");
+  expect(hosts).toEqual(["localhost", "agentnode.example.ts.net"]);
+});
+
+// Null/blank host (tailscale absent, or resolveNodeHost returned null) is a no-op.
+test("addOwnHostToAllowlist: null or blank host is a no-op", () => {
+  const hosts = ["localhost"];
+  addOwnHostToAllowlist(hosts, null);
+  addOwnHostToAllowlist(hosts, "   ");
+  expect(hosts).toEqual(["localhost"]);
+});
+
+// A host with stray whitespace is trimmed before it lands in the allowlist.
+test("addOwnHostToAllowlist: trims surrounding whitespace", () => {
+  const hosts: string[] = [];
+  addOwnHostToAllowlist(hosts, "  agentnode.example.ts.net  ");
+  expect(hosts).toEqual(["agentnode.example.ts.net"]);
 });

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -9,6 +9,7 @@ import {
   validateNewProject,
   isAuthorized,
   originAllowed,
+  classifyOrigin,
   isValidTerminalId,
   expandHome,
   parseTermDims,
@@ -539,6 +540,58 @@ test("originAllowed: chrome-extension origin passes when its ID is allowlisted",
   const id = "bflahkibnmcbijbhelmpjbohpfhlbaig";
   expect(originAllowed(`chrome-extension://${id}`, [...allowedHosts, id])).toBe(true);
   expect(originAllowed(`chrome-extension://${id}`, allowedHosts)).toBe(false);
+});
+
+// ── classifyOrigin (issue #1645 Fix 3) ────────────────────────────────────────
+// originAllowed is now a thin wrapper over classifyOrigin(...) === "allow"; these assert
+// the two rejection reasons stay distinct so the client can show accurate copy.
+
+const previewRange = { base: 8001, count: 16 };
+
+// Absent/empty Origin must classify as "allow" — preserves the curl/CLI bypass
+// (originAllowed's `if (!originHeader) return true`).
+test("classifyOrigin: absent/empty Origin is allow (curl/cli)", () => {
+  expect(classifyOrigin(null, allowedHosts, previewRange)).toBe("allow");
+  expect(classifyOrigin(undefined, allowedHosts, previewRange)).toBe("allow");
+  expect(classifyOrigin("", allowedHosts, previewRange)).toBe("allow");
+});
+
+test("classifyOrigin: allowlisted host is allow", () => {
+  expect(classifyOrigin("http://localhost:7330", allowedHosts, previewRange)).toBe("allow");
+});
+
+// The auto-allowed node's own tailnet host (Fix 2) classifies as allow.
+test("classifyOrigin: folded-in node host is allow", () => {
+  const hosts = [...allowedHosts, "agentnode.example.ts.net"];
+  expect(classifyOrigin("https://agentnode.example.ts.net", hosts, previewRange)).toBe("allow");
+});
+
+// The un-allowlisted-host reason drives the new SHEPHERD_ALLOWED_HOSTS hint copy.
+test("classifyOrigin: non-allowlisted host is host-not-allowed", () => {
+  expect(classifyOrigin("https://other.example.ts.net", allowedHosts, previewRange)).toBe(
+    "host-not-allowed",
+  );
+});
+
+// Preview-port precedence: a preview app on an ALLOWLISTED host is still preview-port,
+// never allow — this is the CSRF invariant that Fix 2 must not weaken.
+test("classifyOrigin: preview-port on an allowlisted host is preview-port (not allow)", () => {
+  const hosts = [...allowedHosts, "agentnode.example.ts.net"];
+  expect(classifyOrigin("https://agentnode.example.ts.net:8001", hosts, previewRange)).toBe(
+    "preview-port",
+  );
+  expect(classifyOrigin("http://localhost:8005", hosts, previewRange)).toBe("preview-port");
+});
+
+// A port just outside the range on a non-allowlisted host is host-not-allowed, not preview-port.
+test("classifyOrigin: out-of-range port on non-allowlisted host is host-not-allowed", () => {
+  expect(classifyOrigin("https://other.example.ts.net:8017", allowedHosts, previewRange)).toBe(
+    "host-not-allowed",
+  );
+});
+
+test("classifyOrigin: malformed Origin is host-not-allowed", () => {
+  expect(classifyOrigin("not-a-url", allowedHosts, previewRange)).toBe("host-not-allowed");
 });
 
 // ── isValidTerminalId ─────────────────────────────────────────────────────────

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -41,6 +41,7 @@
   "emptyherd_extension_prompt": "Du arbeitest im Browser? Erfasse jede Seite mit der Shepherd-Capture-Erweiterung als Aufgabe.",
   "emptyherd_extension_link": "Im Chrome Web Store holen",
   "error_preview_readonly": "Die Vorschau ist schreibgeschützt. Öffne Shepherd direkt (nicht über die Live-Vorschau), um Änderungen vorzunehmen.",
+  "error_origin_host_not_allowed": "Dieser Host darf keine Änderungen vornehmen. Füge ihn zu SHEPHERD_ALLOWED_HOSTS hinzu (in ~/.shepherd/env) und starte Shepherd neu.",
   "status_working": "AKTIV",
   "status_idle": "INAKTIV",
   "status_blocked": "BLOCKIERT",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -41,6 +41,7 @@
   "emptyherd_extension_prompt": "Working in the browser? Capture any page into a task with the Shepherd Capture extension.",
   "emptyherd_extension_link": "Get it on the Chrome Web Store",
   "error_preview_readonly": "Preview is read-only. Open Shepherd directly (not through the live preview) to make changes.",
+  "error_origin_host_not_allowed": "This host isn't allowed to make changes. Add it to SHEPHERD_ALLOWED_HOSTS (in ~/.shepherd/env) and restart Shepherd.",
   "status_working": "BUSY",
   "status_idle": "IDLE",
   "status_blocked": "BLOCKED",

--- a/ui/src/lib/api.previewBlocked.test.ts
+++ b/ui/src/lib/api.previewBlocked.test.ts
@@ -38,4 +38,20 @@ describe("preview-origin blocked detection", () => {
     expect(isPreviewBlocked(err)).toBe(false);
     expect(err!.message).toBe("nope");
   });
+
+  // A host-not-allowlisted 403 (real HUD on an un-allowed host, #1645 Fix 3) is NOT a preview
+  // block — it becomes a plain Error carrying the translated SHEPHERD_ALLOWED_HOSTS hint, so the
+  // UI stops misdirecting the operator to "the live preview".
+  it("maps a 403 host-block body to a plain (non-preview) error with hint copy", async () => {
+    globalThis.fetch = mockFetch(403, { error: "forbidden: origin host not allowed" });
+    const err = await createSession({ repo: "r", prompt: "p" } as unknown as CreateInput).then(
+      () => null,
+      (e) => e as Error,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect(isPreviewBlocked(err)).toBe(false);
+    // Remapped to a translated sentence — not the raw server string.
+    expect(err!.message.length).toBeGreaterThan(0);
+    expect(err!.message).not.toBe("forbidden: origin host not allowed");
+  });
 });

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -88,10 +88,16 @@ function flagIfUnauthorized(status: number): boolean {
 }
 
 /** Server's CSRF preview-origin rejection string. The HUD origin guard
- *  (`src/validate.ts` `originAllowed` → `src/server.ts:214` `checkOrigin`) returns
+ *  (`src/validate.ts` `classifyOrigin` → `checkOrigin`) returns
  *  `403 {error:"forbidden: origin not allowed"}` for any mutation from the live-preview
  *  port range — kept in sync here so the matched string stays discoverable. */
 const ORIGIN_BLOCK = "forbidden: origin not allowed";
+
+/** Server's CSRF host-not-allowlisted rejection string. `checkOrigin` returns
+ *  `403 {error:"forbidden: origin host not allowed"}` when the HUD is reached on a host
+ *  absent from `SHEPHERD_ALLOWED_HOSTS` (NOT a preview port). Distinct from {@link ORIGIN_BLOCK}
+ *  so the copy can point the operator at the allowlist instead of blaming the preview (#1645). */
+const ORIGIN_HOST_BLOCK = "forbidden: origin host not allowed";
 
 /** Thrown when a mutation is rejected because it originated from the read-only live
  *  preview (CSRF origin guard). Detect via `isPreviewBlocked`/`instanceof`. */
@@ -113,6 +119,9 @@ function apiError(
   flagIfUnauthorized(status);
   if (status === 403 && body?.error === ORIGIN_BLOCK) {
     return new PreviewBlockedError(m.error_preview_readonly());
+  }
+  if (status === 403 && body?.error === ORIGIN_HOST_BLOCK) {
+    return new Error(m.error_origin_host_not_allowed());
   }
   return new Error(body?.error ?? fallback);
 }


### PR DESCRIPTION
Closes the two behavioral fixes left open on #1645 after #1646 shipped the deploy-template scrub (Fix 1 + Fix 4). Both live on the CSRF origin-guard surface, so they ship together.

## Fix 2 — auto-allow the node's own host (the real functional fix)

The node's own tailnet hostname was resolved at startup into `config.previewHost` but **never** folded into `config.allowedOriginHosts` — so a fresh deploy 403'd every mutation until the operator manually set `SHEPHERD_ALLOWED_HOSTS`.

- New `addOwnHostToAllowlist` (`src/config.ts`), called at boot right after `previewHost` resolves (`src/index.ts`).
- **Security invariant preserved:** only the *hostname* is trusted. Preview-port origins (`previewHost:8001–8016`) stay rejected because the guard's preview-range check runs *first*, independent of hostname — so this grants same-host HUD mutations, not preview-forged CSRF. Foreign origins stay blocked.
- **Scope:** covers the documented direct-serve path (served front host == the node's `Self.DNSName`). A **Tailscale Service / custom-DNS** HUD is fronted under a *different* DNS name, so it still needs a manual `SHEPHERD_ALLOWED_HOSTS` entry — reworded the `deploy/shepherd.service:25` comment to say exactly that (direct-serve is now automatic).

## Fix 3 — accurate error copy (self-diagnosable failure)

A non-preview-port 403 (real HUD reached on a host absent from `SHEPHERD_ALLOWED_HOSTS`) surfaced as *"Preview is read-only. Open Shepherd directly…"*, misdirecting operators already on the real HUD.

- New `classifyOrigin` (`src/validate.ts`) → `allow | preview-port | host-not-allowed`; `originAllowed` becomes a thin `=== "allow"` wrapper (behavior unchanged, incl. curl/CLI no-Origin bypass and malformed→reject).
- `checkOrigin` returns a distinct body for the host case (`forbidden: origin host not allowed`); the client maps it to a plain error pointing at `SHEPHERD_ALLOWED_HOSTS` (`error_origin_host_not_allowed`, EN+DE). A genuine preview-port 403 keeps the "Preview is read-only" copy.
- Verified the new message surfaces: `applyUpdate` throws `apiError(...)` directly and `UpdateModal` renders `e.message` verbatim; the `isPreviewBlocked` rethrow (`api.ts:863`) is `relaunchSession`-only and special-cases `PreviewBlockedError`, so a plain host error isn't swallowed.

## Tests / verification

- `test/config-origin.test.ts` — `addOwnHostToAllowlist` (append, dedup, null/blank no-op, trim).
- `test/validate.test.ts` — `classifyOrigin` cases incl. **null/empty → allow** and **preview-port on an allowlisted host stays preview-port** (the CSRF invariant Fix 2 must not weaken).
- `ui/src/lib/api.previewBlocked.test.ts` — host-block 403 → plain (non-preview) error with hint copy.
- Green locally: root `bun run lint` + `bun test` (6538 pass / 0 fail), `ui` `bun run check` (0 errors) + `vitest` + `check:i18n` (parity).

No feature-catalog entry (both are `fix:`; Fix 3 is error copy, not a new capability), no glossary entry (`SHEPHERD_ALLOWED_HOSTS` is an env var), no manual operator steps (a restart/deploy — inherent to any change — fully applies it).