### PR TITLE
feat: exclude dependency-blocked issues from Up Next, flag them in the Backlog

### DIFF
--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -1994,14 +1994,17 @@ export class GithubForge implements GitForge {
         const args = [
           "api",
           "graphql",
-          "-F",
+          "-f",
           `owner=${owner}`,
-          "-F",
+          "-f",
           `name=${name}`,
           "-f",
           `query=${query}`,
         ];
-        if (after !== null) args.push("-F", `after=${after}`);
+        // Thread cursor as a raw string (-f): the opaque base64 cursor must not be type-coerced
+        // by gh. Page 1 omits it so $after defaults to null in GraphQL. Matches the sibling
+        // paginators (listSubIssueSummaries / listOpenPrClosingIssues).
+        if (after !== null) args.push("-f", `after=${after}`);
         const pageInfo = collectBlockedByOpenPage(await this.run(args), result);
         if (!pageInfo.hasNextPage) break;
         after = pageInfo.endCursor;

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -1986,7 +1986,7 @@ export class GithubForge implements GitForge {
     // failure (rate limit, malformed JSON) yields an empty Map — degraded to no exclusion.
     const [owner, name] = this.slug.split("/");
     const query =
-      "query($owner:String!,$name:String!,$after:String){repository(owner:$owner,name:$name){issues(states:OPEN, first:100, after:$after){pageInfo{ hasNextPage endCursor }nodes{ number blockedBy(first:20){ nodes{ number state } } }}}}";
+      "query($owner:String!,$name:String!,$after:String){repository(owner:$owner,name:$name){issues(states:OPEN, first:100, after:$after, orderBy:{field:CREATED_AT,direction:DESC}){pageInfo{ hasNextPage endCursor }nodes{ number blockedBy(first:20){ nodes{ number state } } }}}}";
     const result = new Map<number, number[]>();
     try {
       let after: string | null = null;

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -136,6 +136,42 @@ function collectClosingIssuesPage(
   };
 }
 
+/** Parse one page of the batched issue-dependency GraphQL response: for every OPEN issue node
+ *  with >=1 still-OPEN blocker, record its open-blocker numbers into `into` (keyed by the
+ *  blocked issue's number); issues with no open blockers are skipped, keeping the map small.
+ *  Returns the page's cursor info. */
+function collectBlockedByOpenPage(
+  out: string,
+  into: Map<number, number[]>,
+): { hasNextPage: boolean; endCursor: string | null } {
+  const json = JSON.parse(out || "{}") as {
+    data?: {
+      repository?: {
+        issues?: {
+          pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+          nodes?: Array<{
+            number: number;
+            blockedBy?: { nodes?: Array<{ number?: number; state?: string }> };
+          } | null>;
+        };
+      };
+    };
+  };
+  const issues = json.data?.repository?.issues;
+  for (const node of issues?.nodes ?? []) {
+    if (!node) continue;
+    const openBlockers = (node.blockedBy?.nodes ?? [])
+      .filter((b): b is { number: number; state?: string } => typeof b.number === "number")
+      .filter((b) => b.state === "OPEN")
+      .map((b) => b.number);
+    if (openBlockers.length > 0) into.set(node.number, openBlockers);
+  }
+  return {
+    hasNextPage: issues?.pageInfo?.hasNextPage ?? false,
+    endCursor: issues?.pageInfo?.endCursor ?? null,
+  };
+}
+
 /** Runs `gh` with the given args and returns stdout. Injected in tests. */
 export type GhRunner = (args: string[]) => Promise<string>;
 
@@ -1939,5 +1975,40 @@ export class GithubForge implements GitForge {
       return [];
     }
     return [...closed];
+  }
+
+  async listBlockedByOpen(): Promise<Map<number, number[]>> {
+    if (graphRateLimit.blocked()) return new Map();
+    // One batched GraphQL query for every open issue's still-open blockers, so Up Next can
+    // hide dependency-blocked issues without an N+1 fan-out. Paginated like
+    // listSubIssueSummaries/listOpenPrClosingIssues; capped to ~200 open issues (matches
+    // listIssues' REST_LIST_CAP). Fail open: no REST fallback exists for this data, so any
+    // failure (rate limit, malformed JSON) yields an empty Map — degraded to no exclusion.
+    const [owner, name] = this.slug.split("/");
+    const query =
+      "query($owner:String!,$name:String!,$after:String){repository(owner:$owner,name:$name){issues(states:OPEN, first:100, after:$after){pageInfo{ hasNextPage endCursor }nodes{ number blockedBy(first:20){ nodes{ number state } } }}}}";
+    const result = new Map<number, number[]>();
+    try {
+      let after: string | null = null;
+      for (let page = 0; page < MAX_SUMMARY_PAGES; page++) {
+        const args = [
+          "api",
+          "graphql",
+          "-F",
+          `owner=${owner}`,
+          "-F",
+          `name=${name}`,
+          "-f",
+          `query=${query}`,
+        ];
+        if (after !== null) args.push("-F", `after=${after}`);
+        const pageInfo = collectBlockedByOpenPage(await this.run(args), result);
+        if (!pageInfo.hasNextPage) break;
+        after = pageInfo.endCursor;
+      }
+    } catch {
+      return new Map();
+    }
+    return result;
   }
 }

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -32,6 +32,10 @@ export interface Issue {
    *  getIssue path; absent elsewhere (Gitea has no equivalent). Drives the autonomous-spawn author
    *  trust gate — an absent value fails closed. */
   authorAssociation?: string;
+  /** Numbers of the issue's still-OPEN blockers (GitHub issue dependencies). Populated only by
+   *  consumers that attach it (Up Next, /api/issues) via listBlockedByOpen — absent/empty means
+   *  not blocked. NOT fetched by listIssues (which has no dependency data). */
+  blockedBy?: number[];
 }
 
 export type ForgeKind = "github" | "gitea" | "local";
@@ -494,6 +498,11 @@ export interface GitForge {
   issueId?(issueNumber: number): Promise<number | null>;
   addSubIssue?(parentNumber: number, childNumber: number): Promise<void>;
   addBlockedBy?(issueNumber: number, blockerNumber: number): Promise<void>;
+  /** Batched: one call returning every open issue that has >=1 OPEN blocker, mapped to its
+   *  open-blocker numbers. Distinct from the per-issue listBlockedBy(n) (which returns ALL
+   *  blockers for one issue and is used by the epic pipeline). Optional — hosts without issue
+   *  dependencies (Gitea) omit it; callers must fail open when it's absent. */
+  listBlockedByOpen?(): Promise<Map<number, number[]>>;
   /** Cheap per-parent native sub-issue counts for the backlog epic-badge discovery
    *  (GitHub only; absent → no native-epic discovery, markdown fallback only). Map keyed
    *  by parent issue number; only entries with total > 0 are included. Also returns the

--- a/src/server.ts
+++ b/src/server.ts
@@ -131,7 +131,7 @@ import {
   recordSocketAttach,
   recordFallback,
 } from "./terminal-transport-metrics";
-import type { GitForge, GitState, MergeMethod, PrStatus, WorkflowRun } from "./forge/types";
+import type { GitForge, GitState, Issue, MergeMethod, PrStatus, WorkflowRun } from "./forge/types";
 import { DEPENDABOT_REBASE_COMMAND, EmptyDiffError } from "./forge/types";
 import { buildIssueUrl } from "./forge";
 import type { GithubRateLimitPayload } from "./forge/github-rate-limit";
@@ -4961,6 +4961,23 @@ async function handleBranchStatus({ req, parts, url }: Ctx): Promise<Response | 
   return null;
 }
 
+/** Fetch a repo's open issues and, best-effort, attach each one's still-open blockers
+ *  (GitHub issue dependencies) as `blockedBy`. The blocked-map fetch fails open — a missing
+ *  method (Gitea/local) or a forge error yields no annotations, never a failed request. */
+async function listIssuesWithBlockers(forge: GitForge): Promise<Issue[]> {
+  const [issues, blockedByOpen] = await Promise.all([
+    forge.listIssues(),
+    Promise.resolve(forge.listBlockedByOpen?.())
+      .catch(() => null)
+      .then((m) => m ?? new Map<number, number[]>()),
+  ]);
+  for (const i of issues) {
+    const b = blockedByOpen.get(i.number);
+    if (b && b.length > 0) i.blockedBy = b;
+  }
+  return issues;
+}
+
 async function handleIssues({ req, parts, url, deps }: Ctx): Promise<Response | null> {
   if (req.method === "GET" && parts[0] === "api" && parts[1] === "issues" && !parts[2]) {
     const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
@@ -4968,10 +4985,11 @@ async function handleIssues({ req, parts, url, deps }: Ctx): Promise<Response | 
     const forge = deps.resolveForge?.(dir) ?? null;
     if (!forge) return json({ slug: null, webUrl: null, issues: [], viewer: null });
     try {
+      const issues = await listIssuesWithBlockers(forge);
       return json({
         slug: forge.slug,
         webUrl: forge.webUrl ?? null,
-        issues: await forge.listIssues(),
+        issues,
         // The operator's own login, so the UI's "mine & unassigned" filter (#824)
         // knows who "me" is. Cached in the forge, so no per-request gh cost after
         // the first call. null when the host can't resolve it (fail open → show all).

--- a/src/up-next-core.ts
+++ b/src/up-next-core.ts
@@ -71,6 +71,9 @@ export interface EpicUnitInput {
   memberNumbers: number[];
   /** selectEpicCandidates()[0], or null when no child is actionable (suppress the unit). */
   candidate: Issue | null;
+  /** The epic parent's own still-open blockers (GitHub issue dependencies). Non-empty ⇒ the whole
+   *  epic unit is suppressed from Up Next, mirroring the standalone blocked-issue rule. */
+  parentBlockedBy?: number[];
 }
 
 export interface RepoInput {
@@ -140,6 +143,7 @@ function isExcludedIssue(issue: Issue, labelSet: Set<string>): boolean {
   if (hasLabel(labelSet, ACTIVE_LABEL)) return true;
   if (intersects(labelSet, EXCLUDE_LABELS)) return true;
   if (isBotAuthored(issue)) return true;
+  if (issue.blockedBy && issue.blockedBy.length > 0) return true; // dependency-blocked (#1622)
   return false;
 }
 
@@ -172,6 +176,7 @@ function epicItem(repo: RepoInput, e: EpicUnitInput, linkedSet: Set<number>): Up
   if (hasLabel(parentLabelSet, ACTIVE_LABEL)) return null;
   if (intersects(parentLabelSet, EXCLUDE_LABELS)) return null;
   if (isAssignedToOthers(e.parentAssignees, repo.viewer)) return null; // #824 (keyed on parent)
+  if (e.parentBlockedBy && e.parentBlockedBy.length > 0) return null; // epic parent dependency-blocked
   if (linkedSet.has(c.number)) return null; // the child already has a PR in flight
   return {
     repoPath: repo.repoPath,

--- a/src/up-next.ts
+++ b/src/up-next.ts
@@ -233,7 +233,18 @@ export class UpNextService {
       subIssueNumbers: [],
     };
     const linkedIssueNumbers = (await forge.listOpenPrClosingIssues?.().catch(() => null)) ?? [];
-    const epics = await this.resolveEpics(r.repoPath, openIssues, summaries.summaries);
+    const blockedByOpen =
+      (await forge.listBlockedByOpen?.().catch(() => null)) ?? new Map<number, number[]>();
+    for (const issue of openIssues) {
+      const blockers = blockedByOpen.get(issue.number);
+      if (blockers && blockers.length > 0) issue.blockedBy = blockers;
+    }
+    const epics = await this.resolveEpics(
+      r.repoPath,
+      openIssues,
+      summaries.summaries,
+      blockedByOpen,
+    );
 
     return {
       repoPath: r.repoPath,
@@ -255,6 +266,7 @@ export class UpNextService {
     repoPath: string,
     openIssues: Awaited<ReturnType<GitForge["listIssues"]>>,
     nativeSummaries: Map<number, { total: number; completed: number }>,
+    blockedByOpen: Map<number, number[]>,
   ): Promise<EpicUnitInput[]> {
     const openByNum = new Map(openIssues.map((i) => [i.number, i]));
     const epicParents = new Set<number>();
@@ -276,6 +288,7 @@ export class UpNextService {
         parentAssignees: parent.assignees,
         memberNumbers: epic.children.map((c) => c.number),
         candidate: selectEpicCandidates(epic.children)[0] ?? null,
+        parentBlockedBy: blockedByOpen.get(pn) ?? [],
       });
     }
     return units;

--- a/test/forge/github-epic.test.ts
+++ b/test/forge/github-epic.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, describe } from "bun:test";
 import { GithubForge } from "../../src/forge/github";
 import type { GhRunner } from "../../src/forge/github";
+import { graphRateLimit } from "../../src/forge/rate-limit";
 
 function fakeRunner(responses: Record<string, string>) {
   const run = async (args: string[]): Promise<string> => {
@@ -220,5 +221,125 @@ describe("GithubForge listSubIssueSummaries", () => {
     expect(result.subIssueNumbers).toEqual([42]);
     expect(result.summaries.get(42)).toEqual({ total: 3, completed: 1 });
     expect(result.summaries.size).toBe(1);
+  });
+});
+
+describe("GithubForge listBlockedByOpen", () => {
+  test("real payload: maps blocked issues to open-blocker numbers; unblocked/closed-blocker issues omitted", async () => {
+    // Verified-live fixture shape (see task brief): #1600 has no blockers, #1601's only
+    // blocker is CLOSED — neither should appear in the result Map.
+    const page = JSON.stringify({
+      data: {
+        repository: {
+          issues: {
+            pageInfo: { hasNextPage: false, endCursor: "y" },
+            nodes: [
+              { number: 1622, blockedBy: { nodes: [{ number: 1642, state: "OPEN" }] } },
+              { number: 1506, blockedBy: { nodes: [{ number: 1505, state: "OPEN" }] } },
+              { number: 1507, blockedBy: { nodes: [{ number: 1505, state: "OPEN" }] } },
+              { number: 1627, blockedBy: { nodes: [{ number: 1626, state: "OPEN" }] } },
+              { number: 1600, blockedBy: { nodes: [] } },
+              { number: 1601, blockedBy: { nodes: [{ number: 1500, state: "CLOSED" }] } },
+            ],
+          },
+        },
+      },
+    });
+    const { run, calls } = sequenceRunner([page]);
+    const result = await new GithubForge("o/r", {} as never, run).listBlockedByOpen!();
+    expect(result).toEqual(
+      new Map([
+        [1622, [1642]],
+        [1506, [1505]],
+        [1507, [1505]],
+        [1627, [1626]],
+      ]),
+    );
+    expect(result.has(1600)).toBe(false);
+    expect(result.has(1601)).toBe(false);
+    expect(calls.length).toBe(1);
+  });
+
+  test("runner throws rate-limit error → returns empty Map (no rethrow)", async () => {
+    const run: GhRunner = async () => {
+      throw { stderr: "API rate limit exceeded for graphql resource" };
+    };
+    const result = await new GithubForge("o/r", {} as never, run).listBlockedByOpen!();
+    expect(result).toBeInstanceOf(Map);
+    expect(result.size).toBe(0);
+  });
+
+  test("malformed JSON response → returns empty Map (no throw)", async () => {
+    const run: GhRunner = async () => "not json";
+    const result = await new GithubForge("o/r", {} as never, run).listBlockedByOpen!();
+    expect(result.size).toBe(0);
+  });
+
+  test("graphRateLimit.blocked(): short-circuits to empty Map without calling the runner", async () => {
+    graphRateLimit.noteLimitError(60);
+    try {
+      const calls: string[][] = [];
+      const run: GhRunner = async (args) => {
+        calls.push(args);
+        return "{}";
+      };
+      const result = await new GithubForge("o/r", {} as never, run).listBlockedByOpen!();
+      expect(result.size).toBe(0);
+      expect(calls.length).toBe(0);
+    } finally {
+      graphRateLimit.note({ remaining: 1000, resetAt: Date.now() + 60_000 });
+    }
+  });
+
+  test("two-page cursor: collects both pages into one Map, 2 runner calls, second passes after= from first", async () => {
+    const page1 = JSON.stringify({
+      data: {
+        repository: {
+          issues: {
+            pageInfo: { hasNextPage: true, endCursor: "cursor-abc" },
+            nodes: [{ number: 10, blockedBy: { nodes: [{ number: 9, state: "OPEN" }] } }],
+          },
+        },
+      },
+    });
+    const page2 = JSON.stringify({
+      data: {
+        repository: {
+          issues: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ number: 20, blockedBy: { nodes: [{ number: 19, state: "OPEN" }] } }],
+          },
+        },
+      },
+    });
+    const { run, calls } = sequenceRunner([page1, page2]);
+    const result = await new GithubForge("o/r", {} as never, run).listBlockedByOpen!();
+    expect(calls.length).toBe(2);
+    expect(result).toEqual(
+      new Map([
+        [10, [9]],
+        [20, [19]],
+      ]),
+    );
+    const firstCallArgs = calls[0]!.join(" ");
+    const secondCallArgs = calls[1]!.join(" ");
+    expect(firstCallArgs).not.toContain("cursor-abc");
+    expect(secondCallArgs).toContain("cursor-abc");
+  });
+
+  test("cap: runner always returns hasNextPage:true → called at most MAX_SUMMARY_PAGES (2) times", async () => {
+    const infinitePage = JSON.stringify({
+      data: {
+        repository: {
+          issues: {
+            pageInfo: { hasNextPage: true, endCursor: "cursor-loop" },
+            nodes: [{ number: 99, blockedBy: { nodes: [{ number: 98, state: "OPEN" }] } }],
+          },
+        },
+      },
+    });
+    const { run, calls } = infiniteRunner(infinitePage);
+    await new GithubForge("o/r", {} as never, run).listBlockedByOpen!();
+    expect(calls.length).toBe(2);
   });
 });

--- a/test/server-issues.test.ts
+++ b/test/server-issues.test.ts
@@ -128,6 +128,58 @@ test("GET /api/issues?repo outside root → 400", async () => {
   expect(res.status).toBe(400);
 });
 
+// ── blockedBy merge (listBlockedByOpen) ───────────────────────────────────
+
+test("GET /api/issues merges blockedBy onto matching issues", async () => {
+  const app = makeApp(
+    makeDeps(() =>
+      fakeForge({
+        listBlockedByOpen: async () => new Map([[1, [42, 43]]]),
+      }),
+    ),
+  );
+  const res = await app.fetch(req(repoDir));
+  const body = await res.json();
+  expect(body.issues).toEqual([{ ...ISSUE, blockedBy: [42, 43] }]);
+});
+
+test("GET /api/issues leaves blockedBy unset for issues absent from the blocked map", async () => {
+  const app = makeApp(
+    makeDeps(() =>
+      fakeForge({
+        listBlockedByOpen: async () => new Map([[999, [1]]]),
+      }),
+    ),
+  );
+  const res = await app.fetch(req(repoDir));
+  const body = await res.json();
+  expect(body.issues).toEqual([ISSUE]);
+});
+
+test("GET /api/issues without listBlockedByOpen (optional) → issues returned unmodified", async () => {
+  const app = makeApp(makeDeps(() => fakeForge())); // fakeForge has no listBlockedByOpen
+  const res = await app.fetch(req(repoDir));
+  const body = await res.json();
+  expect(body.issues).toEqual([ISSUE]);
+});
+
+test("GET /api/issues: a failing listBlockedByOpen fails open — issues still return", async () => {
+  const app = makeApp(
+    makeDeps(() =>
+      fakeForge({
+        listBlockedByOpen: async () => {
+          throw new Error("dependency query failed");
+        },
+      }),
+    ),
+  );
+  const res = await app.fetch(req(repoDir));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.issues).toEqual([ISSUE]);
+  expect(body.error).toBeUndefined();
+});
+
 // ── POST /api/issues (handleIssueCreate) ─────────────────────────────────────
 
 function postIssue(

--- a/test/up-next-core.test.ts
+++ b/test/up-next-core.test.ts
@@ -109,6 +109,23 @@ describe("exclusions", () => {
     const r = [repo({ openIssues: [issue(1), issue(2)], linkedIssueNumbers: [1] })];
     expect(repoSection(r, "/r/a")!.items.map((i) => i.number)).toEqual([2]);
   });
+  test("standalone issue with an open blocker excluded; empty/undefined blockedBy included (#1622)", () => {
+    const r = [
+      repo({
+        openIssues: [
+          issue(1, { blockedBy: [1642] }),
+          issue(2, { blockedBy: [] }),
+          issue(3), // blockedBy undefined
+        ],
+      }),
+    ];
+    expect(repoSection(r, "/r/a")!.items.map((i) => i.number)).toEqual([2, 3]);
+  });
+  test("blocked-by exclusion is independent of the `blocked` LABEL path", () => {
+    // #1 has an open blocker but no `blocked` label — must still be excluded via blockedBy alone.
+    const r = [repo({ openIssues: [issue(1, { blockedBy: [99], labels: [] }), issue(2)] })];
+    expect(repoSection(r, "/r/a")!.items.map((i) => i.number)).toEqual([2]);
+  });
   test("fully-excluded repo emits no section", () => {
     const r = [repo({ openIssues: [issue(1, { labels: ["shepherd:active"] })] })];
     expect(repoSection(r, "/r/a")).toBeUndefined();
@@ -245,6 +262,20 @@ describe("epics as one unit", () => {
       }),
     ];
     expect(repoSection(r, "/r/a")).toBeUndefined();
+  });
+  test("epic unit suppressed when its parent has an open blocker; not when empty (#1622)", () => {
+    const blocked = [
+      repo({
+        epics: [epic({ memberNumbers: [2], candidate: issue(2), parentBlockedBy: [99] })],
+      }),
+    ];
+    expect(repoSection(blocked, "/r/a")).toBeUndefined();
+    const notBlocked = [
+      repo({
+        epics: [epic({ memberNumbers: [2], candidate: issue(2), parentBlockedBy: [] })],
+      }),
+    ];
+    expect(repoSection(notBlocked, "/r/a")!.items.filter((i) => i.kind === "epic")).toHaveLength(1);
   });
 });
 

--- a/test/up-next.test.ts
+++ b/test/up-next.test.ts
@@ -176,6 +176,68 @@ describe("UpNextService.refresh", () => {
     expect(items.map((i) => i.number)).toEqual([1, 2]);
   });
 
+  test("listBlockedByOpen attaches blockedBy → standalone issue with an open blocker excluded (#1622)", async () => {
+    const s = svc({
+      resolveForge: () =>
+        fakeForge({
+          issues: [issue(1), issue(2)],
+          listBlockedByOpen: async () => new Map([[1, [42]]]),
+        }),
+    });
+    const snap = await s.refresh();
+    const items = snap.sections.find((x) => x.kind === "repo")!.items;
+    expect(items.map((i) => i.number)).toEqual([2]);
+  });
+
+  test("forge without listBlockedByOpen (absent) fails open — excludes nothing", async () => {
+    const s = svc({
+      resolveForge: () => fakeForge({ issues: [issue(1), issue(2)] }), // no listBlockedByOpen
+    });
+    const snap = await s.refresh();
+    const items = snap.sections.find((x) => x.kind === "repo")!.items;
+    expect(items.map((i) => i.number)).toEqual([1, 2]);
+  });
+
+  test("listBlockedByOpen suppresses an epic unit whose parent has an open blocker (#1622)", async () => {
+    const epic: Epic = {
+      repoPath: "/r/a",
+      parentIssueNumber: 100,
+      parentTitle: "epic",
+      source: "native",
+      run: { repoPath: "/r/a", parentIssueNumber: 100, mode: "auto", status: "idle" } as EpicRun,
+      warnings: [],
+      children: [
+        {
+          number: 2,
+          title: "child-2",
+          url: "https://x/2",
+          order: 0,
+          body: "b2",
+          blockedBy: [],
+          state: "ready",
+          sessionId: null,
+          prNumber: null,
+          issueClosed: false,
+          integrationMerged: false,
+          claimed: false,
+        },
+      ],
+    };
+    const s = svc({
+      resolveForge: () =>
+        fakeForge({
+          issues: [issue(1), issue(2), issue(100, { body: "```epic-dag\n#2\n```" })],
+          listBlockedByOpen: async () => new Map([[100, [7]]]),
+        }),
+      buildEpic: async () => epic,
+    });
+    const snap = await s.refresh();
+    const items = snap.sections.find((x) => x.kind === "repo")!.items;
+    // Parent #100 has an open blocker → epic unit suppressed; only standalone #1 remains.
+    expect(items.filter((i) => i.kind === "epic")).toHaveLength(0);
+    expect(items.map((i) => i.number)).toEqual([1]);
+  });
+
   test("threads epic parent assignees → hides epic unit whose parent is assigned to others (#824)", async () => {
     const epic: Epic = {
       repoPath: "/r/a",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2848,5 +2848,8 @@
   "recap_skip_evidence_merged_pr": "PR #{pr} gemergt",
   "recap_skip_evidence_merged_pr_no_number": "PR gemergt",
   "recap_skip_evidence_review": "PR-Review für diesen Head erfasst",
-  "recap_skip_evidence_existing_recap": "vorhandene Zusammenfassung erfasste geänderte Dateien"
+  "recap_skip_evidence_existing_recap": "vorhandene Zusammenfassung erfasste geänderte Dateien",
+  "issuerow_blocked_on": "blockiert durch {deps}",
+  "feat_blocked_issues_title": "Blockierte Issues bleiben dir aus dem Weg",
+  "feat_blocked_issues_body": "Up Next schlägt keine Issues mehr vor, die durch eine offene Abhängigkeit blockiert sind, und das Backlog kennzeichnet sie jetzt mit einem \"blockiert durch #N\"-Badge, damit du siehst, worauf sie warten."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2848,5 +2848,8 @@
   "recap_skip_evidence_merged_pr": "merged PR #{pr}",
   "recap_skip_evidence_merged_pr_no_number": "merged PR",
   "recap_skip_evidence_review": "PR review recorded for this head",
-  "recap_skip_evidence_existing_recap": "existing recap recorded changed files"
+  "recap_skip_evidence_existing_recap": "existing recap recorded changed files",
+  "issuerow_blocked_on": "blocked on {deps}",
+  "feat_blocked_issues_title": "Blocked issues stay out of your way",
+  "feat_blocked_issues_body": "Up Next no longer suggests issues that are blocked by an open dependency, and the backlog now flags them with a \"blocked on #N\" badge so you can see what they're waiting on."
 }

--- a/ui/src/lib/components/IssuesPanel.browser.test.ts
+++ b/ui/src/lib/components/IssuesPanel.browser.test.ts
@@ -323,6 +323,69 @@ describe("IssuesPanel epic badge", () => {
   });
 });
 
+describe("IssuesPanel blocked badge", () => {
+  function issue(number: number, title: string, blockedBy?: number[]): Issue {
+    return {
+      number,
+      title,
+      url: `https://example.com/issues/${number}`,
+      labels: [],
+      body: "",
+      createdAt: 0,
+      assignees: [],
+      ...(blockedBy ? { blockedBy } : {}),
+    };
+  }
+
+  function epic(
+    parentIssueNumber: number,
+    merged: number,
+    total: number,
+    source: EpicSummary["source"],
+  ): EpicSummary {
+    return {
+      parentIssueNumber,
+      parentTitle: `Epic ${parentIssueNumber}`,
+      merged,
+      total,
+      status: "idle",
+      source,
+    };
+  }
+
+  function seed(issues: Issue[], epics: EpicSummary[] = []) {
+    mockListIssues.mockResolvedValue({ slug: "owner/repo", webUrl: null, issues, viewer: null });
+    mockGetEpics.mockResolvedValue({ epics, subIssues: [] });
+  }
+
+  it("renders a blocked-on badge when the issue has open blockers", async () => {
+    seed([issue(70, "Blocked issue", [1642])]);
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
+
+    const expectedText = m.issuerow_blocked_on({ deps: "#1642" });
+    await expect.element(page.getByText(expectedText)).toBeInTheDocument();
+    const chip = document.querySelector(".blocked-chip");
+    expect(chip).not.toBeNull();
+    expect(chip!.textContent?.trim()).toBe(expectedText);
+  });
+
+  it("renders no blocked chip when the issue has no blockers", async () => {
+    seed([issue(71, "Unblocked issue")]);
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
+
+    await expect.poll(() => document.querySelector(".issue-title")).toBeTruthy();
+    expect(document.querySelector(".blocked-chip")).toBeNull();
+  });
+
+  it("does not render the standalone blocked chip on an epic-parent row", async () => {
+    seed([issue(72, "Epic parent", [1642])], [epic(72, 1, 3, "markdown")]);
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
+
+    await expect.poll(() => document.querySelector(".epic-badge")).toBeTruthy();
+    expect(document.querySelector(".blocked-chip")).toBeNull();
+  });
+});
+
 describe("IssuesPanel expandEpic", () => {
   function issue(number: number, title = `Issue ${number}`): Issue {
     return {

--- a/ui/src/lib/components/issues-panel/IssueRow.svelte
+++ b/ui/src/lib/components/issues-panel/IssueRow.svelte
@@ -143,8 +143,13 @@
   {#if bodyPreview && issue.body}
     <div class="body-preview">{issue.body}</div>
   {/if}
-  {#if issue.labels.length > 0 || age || issue.author || (showAssignees && issue.assignees.length > 0)}
+  {#if issue.labels.length > 0 || age || issue.author || (showAssignees && issue.assignees.length > 0) || (!isEpicParent && issue.blockedBy?.length)}
     <div class="label-row">
+      {#if !isEpicParent && issue.blockedBy?.length}
+        <span class="blocked-chip"
+          >{m.issuerow_blocked_on({ deps: issue.blockedBy.map((n) => `#${n}`).join(", ") })}</span
+        >
+      {/if}
       {#if showAssignees}
         {#each issue.assignees as login (login)}
           <span class="label-chip assignee" title={m.issuerow_assignee_title({ login })}
@@ -281,6 +286,20 @@
     border: 1px solid var(--color-line);
     border-radius: 2px;
     padding: 1px 5px;
+  }
+
+  /* "blocked on #N" — standalone (non-epic-parent) issues held back by an open dependency.
+     Uses the semantic blocked token (red); never green, never a raw hex. Mirrors EpicPanel's
+     .deps chip but as its own class since it lives in the label-row, not the epic child list. */
+  .blocked-chip {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--status-blocked);
+    border: 1px solid var(--status-blocked);
+    border-radius: 2px;
+    padding: 1px 5px;
+    background: color-mix(in srgb, var(--status-blocked) 14%, transparent);
   }
 
   /* Assignee chip — reuses the label-chip recipe but keeps the login verbatim (logins are

--- a/ui/src/lib/feature-announcements/entries/v1.43.0-blocked-issue-awareness.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.43.0-blocked-issue-awareness.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "blocked-issue-awareness",
+  sinceVersion: "1.43.0",
+  titleKey: "feat_blocked_issues_title",
+  bodyKey: "feat_blocked_issues_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -194,6 +194,9 @@ export interface Issue {
    *  `user.login`). Absent on hosts/paths that don't fetch it. Surfaced as the "by {login}"
    *  row text and drives the author filter. */
   author?: string;
+  /** Numbers of the issue's still-OPEN blockers (GitHub issue dependencies), attached by
+   *  /api/issues. Absent/empty ⇒ not blocked. Drives the "blocked on #N" badge. */
+  blockedBy?: number[];
 }
 
 /** Subset of an Issue attached to a task by reference (body rides out-of-band). */


### PR DESCRIPTION
## Why

"Up Next" was surfacing issues that are natively **`blocked_by`** an open issue (GitHub issue
dependencies), even though they aren't startable. Its standalone exclusion path only dropped the
literal `blocked` **label** — it never read dependencies. `blocked_by` was honored only for epic
children.

Verified live: **#1622** (OPEN, no `blocked` label, not an epic child) is `blocked_by` open
**#1642**, and appeared in Up Next regardless.

## What changed

- **`feat(forge)`** — new batched `GitForge.listBlockedByOpen(): Promise<Map<number, number[]>>`,
  one GraphQL call per repo returning each open issue's **still-open** blockers (filters
  `state === "OPEN"`, so a closed blocker no longer blocks). Fails open: rate-limit / error /
  malformed → empty Map, never throws. Optional on the interface (Gitea/local omit it).
- **`feat(up-next)`** — hides standalone issues with an open blocker, **and** suppresses an epic
  unit whose **parent** issue has an open blocker (mirrors the standalone rule). Epic children stay
  owned by the existing epic pipeline.
- **`feat(backlog)`** — `/api/issues` attaches `blockedBy`, and the Backlog issue row shows a
  `blocked on #N` badge (visible, **not** hidden — unlike Up Next). Uses the semantic
  `--status-blocked` token. Ships the i18n keys (EN + DE) and the `v1.43.0` feature-announcement
  entry.

## Verification

- Root `bun test` (6544 pass), UI `bun run check` / `check:i18n` / vitest (3340 pass), lint clean.
- PR-hygiene gates green — branch-hygiene, **feature-catalog (actively validating, not skipped)**,
  announcement-version, glossary, i18n parity, and `fallow audit` (no issues in changed files).
- **Live e2e against the real repo:** `listBlockedByOpen()` → `#1622: [1642]` (not a silent no-op),
  `/api/issues` merges `blockedBy:[1642]`, and the Up Next snapshot **excludes #1622** while still
  surfacing 38 unblocked items.

Motivating example: #1622 (stays open — it's genuinely blocked by #1642; this PR just stops it from
being suggested as startable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
