### PR TITLE
fix: auto-allow Tailscale Service-fronted HUD hosts too (#1645 Fix 2/3)

### DIFF
--- a/deploy/shepherd.service
+++ b/deploy/shepherd.service
@@ -24,8 +24,10 @@ Environment=SHEPHERD_PORT=7330
 Environment=SHEPHERD_HOST=127.0.0.1
 # localhost defaults only. A direct-served HUD (`tailscale serve` on this node) is trusted
 # automatically — Shepherd folds the node's own tailnet host into the allowlist at startup.
-# Only a Service-fronted / custom-DNS HUD (served under a different DNS name than this node)
-# needs its host added via SHEPHERD_ALLOWED_HOSTS in ~/.shepherd/env.
+# A Tailscale Service front (`tailscale serve` registered under `svc:<name>`) proxying to
+# this HUD's port is auto-trusted too, discovered the same way. Only a non-Tailscale reverse
+# proxy / custom-DNS front (a host that doesn't appear in `tailscale serve status`) needs its
+# host added via SHEPHERD_ALLOWED_HOSTS in ~/.shepherd/env.
 Environment=SHEPHERD_ALLOWED_HOSTS=localhost,127.0.0.1,::1,[::1]
 # optional overrides (token, repo root, etc.) — file may be absent
 EnvironmentFile=-%h/.shepherd/env

--- a/src/config.ts
+++ b/src/config.ts
@@ -126,54 +126,6 @@ export function clampCap(n: number, min: number, max: number, fallback: number):
 // previewPortCount is BOTH the range size and the max concurrent previews — a
 // single number, no secondary "max" constant anywhere else.
 
-/**
- * Pure parser: given the text of `tailscale serve status` and the HUD's local
- * listen port, return the public-facing HTTPS port that Tailscale fronts that
- * local port on. Returns null when no matching mapping is found.
- *
- * Example input lines:
- *   https://host.ts.net:5191 (tailnet only)
- *   |-- / proxy http://127.0.0.1:5190
- *
- * The HUD's default mapping has no port (=> 443):
- *   https://host.ts.net (tailnet only)
- *   |-- / proxy http://127.0.0.1:7330
- */
-export function parseServedPort(serveStatusText: string, localPort: number): number | null {
-  const lines = serveStatusText.split("\n");
-  let currentServedPort: number | null = null;
-  for (const line of lines) {
-    const t = line.trim();
-    const served = extractServedPort(t);
-    if (served !== null) {
-      currentServedPort = served;
-    } else if (currentServedPort !== null && isProxyTarget(t, localPort)) {
-      return currentServedPort;
-    }
-  }
-  return null;
-}
-
-/** Extract the public HTTPS port from a `https://...` serve-status header line.
- *  Returns 443 when no explicit port is present, null when the line isn't an
- *  https header.
- *  Note: IPv6 bracket hosts (`[::1]:…`) are intentionally not matched because
- *  Tailscale `serve` always emits `127.0.0.1` + ts.net hostnames. */
-function extractServedPort(line: string): number | null {
-  const m = line.match(/^https:\/\/[^:/]+(?::(\d+))?(?:\s|$)/);
-  if (!m) return null;
-  return m[1] ? Number(m[1]) : 443;
-}
-
-/** True when a `|-- / proxy ...` line targets 127.0.0.1:<localPort>.
- *  Note: `localhost` and IPv6 bracket targets (`[::1]:…`) are intentionally
- *  not matched because Tailscale `serve` always emits `127.0.0.1`. */
-function isProxyTarget(line: string, localPort: number): boolean {
-  if (!line.startsWith("|--")) return false;
-  const m = line.match(/proxy\s+(?:https?:\/\/)?127\.0\.0\.1:(\d+)/);
-  return m !== null && Number(m[1]) === localPort;
-}
-
 const LOOPBACK_RE = /^https?:\/\/(?:localhost|127\.0\.0\.1):(\d+)/;
 
 /** Plain (non-array) object guard — arrays are typeof "object" but malformed here. */
@@ -187,6 +139,14 @@ function publicPortFromKey(key: string): number {
   if (i === -1) return 443;
   const p = Number(key.slice(i + 1));
   return Number.isFinite(p) ? p : 443;
+}
+
+/** Public host from a "host:PORT" web-map key (bare-host keys have no ":PORT" —
+ *  the whole key IS the host); a trailing dot is stripped for parity with
+ *  resolveNodeHost's own hostname normalization. */
+function hostFromKey(key: string): string {
+  const i = key.lastIndexOf(":");
+  return (i === -1 ? key : key.slice(0, i)).replace(/\.$/, "");
 }
 
 /** Candidate web maps: top-level Web + each Services[svc].Web (arrays rejected, fail-closed). */
@@ -224,6 +184,20 @@ function servedPortInWebMap(webMap: Record<string, unknown>, localPort: number):
     }
   }
   return null;
+}
+
+/** Hosts of every web-map entry whose handler targets loopback:localPort. */
+function servedHostsInWebMap(webMap: Record<string, unknown>, localPort: number): string[] {
+  const hosts: string[] = [];
+  for (const [key, entry] of Object.entries(webMap)) {
+    if (!isPlainObject(entry)) continue;
+    const handlers = entry["Handlers"];
+    if (!isPlainObject(handlers)) continue;
+    if (Object.values(handlers).some((handler) => handlerTargetsPort(handler, localPort))) {
+      hosts.push(hostFromKey(key));
+    }
+  }
+  return hosts;
 }
 
 /**
@@ -269,6 +243,36 @@ export function findServedPort(serveStatusJson: string, localPort: number): numb
     if (served !== null) return served;
   }
   return null;
+}
+
+/**
+ * Companion to `findServedPort`: given the same `tailscale serve status --json`
+ * output and the HUD's local listen port, returns every public host name that
+ * fronts that local port — across the top-level `Web` map AND every
+ * `Services[svc].Web` map (a Tailscale Service front, e.g. `svc:shepherd` →
+ * `shepherd.ts.net:443` → `http://localhost:7330`). Reuses the same
+ * `collectWebMaps`/`handlerTargetsPort` matching as `findServedPort` — only a
+ * handler whose `.Proxy` targets loopback:localPort counts, so unrelated
+ * services are excluded.
+ *
+ * Deduped; parsing is fully defensive — any malformed, empty, or non-JSON
+ * input returns `[]` without throwing.
+ */
+export function findServedHosts(serveStatusJson: string, localPort: number): string[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(serveStatusJson);
+  } catch {
+    return [];
+  }
+  if (!isPlainObject(parsed)) return [];
+  const hosts: string[] = [];
+  for (const webMap of collectWebMaps(parsed)) {
+    for (const host of servedHostsInWebMap(webMap, localPort)) {
+      if (!hosts.includes(host)) hosts.push(host);
+    }
+  }
+  return hosts;
 }
 
 export interface PreviewPortRangeParams {
@@ -456,12 +460,31 @@ export function resolveAllowedOriginHosts(envValue: string | undefined): string[
  * the hostname is trusted: preview-port origins are still rejected by the origin
  * guard's preview-range check (it runs before the hostname check), so this does
  * not open preview-forged CSRF. A Service-fronted HUD is served under a DIFFERENT
- * DNS name, so it isn't covered here and still needs a manual allowlist entry.
+ * DNS name; that topology is covered separately by `addServedHostsToAllowlist`.
  * Issue #1645 Fix 2. Exported for tests.
  */
 export function addOwnHostToAllowlist(hosts: string[], host: string | null): void {
   const h = host?.trim();
   if (h && !hosts.includes(h)) hosts.push(h);
+}
+
+/**
+ * Fold every Tailscale-served host front (direct serve AND Service fronts) for
+ * the HUD's local port into an origin allowlist in place — the companion to
+ * `addOwnHostToAllowlist` for the topology that helper doesn't cover (a
+ * Service-fronted HUD served under a different DNS name than the node's own,
+ * e.g. `svc:shepherd` → `shepherd.ts.net`). Delegates host discovery to
+ * `findServedHosts` and dedup to `addOwnHostToAllowlist`. Issue #1645 Fix 2/3.
+ * Exported for tests.
+ */
+export function addServedHostsToAllowlist(
+  hosts: string[],
+  serveStatusJson: string,
+  localPort: number,
+): void {
+  for (const h of findServedHosts(serveStatusJson, localPort)) {
+    addOwnHostToAllowlist(hosts, h);
+  }
 }
 
 export const config = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,10 +14,11 @@ import {
   PLAN_REVIEW_CYCLES_MAX,
   DIAGNOSTICS_INTERVAL_MS,
   DIAGNOSTICS_RECHECK_INTERVAL_MS,
-  parseServedPort,
+  findServedPort,
   validatePreviewPortRange,
   validateAgentIngressPort,
   addOwnHostToAllowlist,
+  addServedHostsToAllowlist,
 } from "./config";
 import { SessionStore } from "./store";
 import type {
@@ -386,18 +387,22 @@ let credentialBanner: string | null = null;
 }
 
 // ── preview port range startup validation (hard-fail) ──────────────────────
-// Discover the public served port by parsing `tailscale serve status`; default
-// to 443 when tailscale is unavailable or the mapping isn't found. The parser
-// is pure and injected here so it's testable without tailscale.
+// Discover the public served port AND every served host front from a single
+// `tailscale serve status --json` call; default to 443 / no extra hosts when
+// tailscale is unavailable or no mapping is found. The parsers are pure and
+// injected here so they're testable without tailscale.
 // Also resolve this node's tailnet hostname for split-front preview URL construction.
 {
   let servedPort = 443;
+  let stdout = "";
   try {
-    const { stdout } = await execFileAsync("tailscale", ["serve", "status"], { timeout: 5000 });
-    const parsed = parseServedPort(stdout, config.port);
+    ({ stdout } = await execFileAsync("tailscale", ["serve", "status", "--json"], {
+      timeout: 5000,
+    }));
+    const parsed = findServedPort(stdout, config.port);
     if (parsed !== null) servedPort = parsed;
   } catch {
-    // tailscale not available or not set up — default to 443
+    // tailscale not available or not set up — default to 443, no served hosts
   }
   // Resolve the node's own tailnet hostname (null when tailscale is absent).
   config.previewHost = await resolveNodeHost();
@@ -405,9 +410,14 @@ let credentialBanner: string | null = null;
   // (direct `tailscale serve`, served front host == this node's DNSName) is trusted out of
   // the box — no manual SHEPHERD_ALLOWED_HOSTS. Preview-port origins stay rejected (the
   // guard's preview-range check runs first, independent of hostname) and foreign origins
-  // stay blocked. A Service-fronted HUD uses a different DNS name and still needs a manual
-  // allowlist entry (see deploy/shepherd.service). Issue #1645 Fix 2.
+  // stay blocked. Issue #1645 Fix 2.
   addOwnHostToAllowlist(config.allowedOriginHosts, config.previewHost);
+  // Fold every Tailscale-served host front for this HUD's port — including a Service
+  // front (e.g. `svc:shepherd` → `shepherd.ts.net`), served under a DIFFERENT DNS name
+  // than the node's own — into the allowlist too. Only a non-Tailscale reverse proxy /
+  // custom-DNS front still needs a manual SHEPHERD_ALLOWED_HOSTS entry (see
+  // deploy/shepherd.service). Issue #1645 Fix 2/3.
+  addServedHostsToAllowlist(config.allowedOriginHosts, stdout, config.port);
   validatePreviewPortRange({
     previewPortBase: config.previewPortBase,
     previewPortCount: config.previewPortCount,

--- a/test/config-origin.test.ts
+++ b/test/config-origin.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "bun:test";
 import {
   resolveAllowedOriginHosts,
   addOwnHostToAllowlist,
+  addServedHostsToAllowlist,
   SHEPHERD_CAPTURE_EXTENSION_ID,
   SHEPHERD_CAPTURE_UNPACKED_DEV_ID,
 } from "../src/config";
@@ -78,4 +79,47 @@ test("addOwnHostToAllowlist: trims surrounding whitespace", () => {
   const hosts: string[] = [];
   addOwnHostToAllowlist(hosts, "  agentnode.example.ts.net  ");
   expect(hosts).toEqual(["agentnode.example.ts.net"]);
+});
+
+// ── addServedHostsToAllowlist (issue #1645 Fix 2/3) ───────────────────────────
+
+// A Tailscale Service front (served under a different DNS name than the node's own) is folded
+// in — the topology addOwnHostToAllowlist alone doesn't cover.
+test("addServedHostsToAllowlist: folds a Service-fronted host in", () => {
+  const json = JSON.stringify({
+    Services: {
+      "svc:shepherd": {
+        Web: {
+          "shepherd.example.ts.net:443": {
+            Handlers: { "/": { Proxy: "http://localhost:7330" } },
+          },
+        },
+      },
+    },
+  });
+  const hosts = ["localhost", "127.0.0.1"];
+  addServedHostsToAllowlist(hosts, json, 7330);
+  expect(hosts).toEqual(["localhost", "127.0.0.1", "shepherd.example.ts.net"]);
+});
+
+// Dedup delegates to addOwnHostToAllowlist — an already-listed host is not doubled.
+test("addServedHostsToAllowlist: does not double an already-listed host", () => {
+  const json = JSON.stringify({
+    Web: {
+      "shepherd.example.ts.net:443": {
+        Handlers: { "/": { Proxy: "http://localhost:7330" } },
+      },
+    },
+  });
+  const hosts = ["shepherd.example.ts.net"];
+  addServedHostsToAllowlist(hosts, json, 7330);
+  expect(hosts).toEqual(["shepherd.example.ts.net"]);
+});
+
+// Malformed/empty JSON and non-matching serve status are no-ops.
+test("addServedHostsToAllowlist: malformed or empty JSON is a no-op", () => {
+  const hosts = ["localhost"];
+  addServedHostsToAllowlist(hosts, "not json", 7330);
+  addServedHostsToAllowlist(hosts, "", 7330);
+  expect(hosts).toEqual(["localhost"]);
 });

--- a/test/preview-config.test.ts
+++ b/test/preview-config.test.ts
@@ -1,75 +1,11 @@
 import { test, describe, expect } from "bun:test";
 import {
-  parseServedPort,
   findServedPort,
+  findServedHosts,
   validatePreviewPortRange,
   validateAgentIngressPort,
 } from "../src/config";
 import { originAllowed } from "../src/validate";
-
-// ── parseServedPort ───────────────────────────────────────────────────────────
-
-const SAMPLE_STATUS = `
-# Tailscale Serve Status
-
-https://agentnode.example.ts.net (tailnet only)
-|-- / proxy http://127.0.0.1:7330
-
-https://agentnode.example.ts.net:5191 (tailnet only)
-|-- / proxy http://127.0.0.1:5190
-
-https://agentnode.example.ts.net:5193 (tailnet only)
-|-- / proxy http://127.0.0.1:5192
-`;
-
-test("parseServedPort: finds the port whose target matches localPort", () => {
-  // 127.0.0.1:7330 is targeted by the https mapping on default 443
-  // (the mapping without an explicit port in the URL)
-  expect(parseServedPort(SAMPLE_STATUS, 7330)).toBe(443);
-});
-
-test("parseServedPort: finds explicit port mapping for a different local port", () => {
-  // 5190 → served at :5191
-  expect(parseServedPort(SAMPLE_STATUS, 5190)).toBe(5191);
-  // 5192 → served at :5193
-  expect(parseServedPort(SAMPLE_STATUS, 5192)).toBe(5193);
-});
-
-test("parseServedPort: returns null when no mapping targets the given local port", () => {
-  expect(parseServedPort(SAMPLE_STATUS, 9999)).toBeNull();
-});
-
-test("parseServedPort: handles multiple mappings and returns the correct one", () => {
-  const text = `
-https://host.ts.net:8443 (tailnet only)
-|-- / proxy http://127.0.0.1:8080
-
-https://host.ts.net:9000 (tailnet only)
-|-- / proxy http://127.0.0.1:3000
-`;
-  expect(parseServedPort(text, 8080)).toBe(8443);
-  expect(parseServedPort(text, 3000)).toBe(9000);
-});
-
-test("parseServedPort: returns null for empty text", () => {
-  expect(parseServedPort("", 7330)).toBeNull();
-});
-
-test("parseServedPort: handles missing port (443 implicit) in https URL", () => {
-  const text = `
-https://myhost.ts.net (tailnet only)
-|-- / proxy http://127.0.0.1:4000
-`;
-  expect(parseServedPort(text, 4000)).toBe(443);
-});
-
-test("parseServedPort: target without scheme (just 127.0.0.1:PORT) also matches", () => {
-  const text = `
-https://myhost.ts.net:7777 (tailnet only)
-|-- / proxy 127.0.0.1:5555
-`;
-  expect(parseServedPort(text, 5555)).toBe(7777);
-});
 
 // ── findServedPort ────────────────────────────────────────────────────────────
 
@@ -170,6 +106,101 @@ describe("findServedPort", () => {
     });
     expect(findServedPort(json, 3000)).toBe(8000);
     expect(findServedPort(json, 4000)).toBe(9000);
+  });
+});
+
+// ── findServedHosts ───────────────────────────────────────────────────────────
+
+describe("findServedHosts", () => {
+  test("Service front (Services svc:shepherd → localhost:mainPort) returns the service host", () => {
+    expect(findServedHosts(SERVE_STATUS_JSON_FULL, 7330)).toEqual(["shepherd.example.ts.net"]);
+  });
+
+  test("top-level Web direct-serve mapping (127.0.0.1:mainPort) returns the node host", () => {
+    expect(findServedHosts(SERVE_STATUS_JSON_FULL, 5190)).toEqual(["agentnode.example.ts.net"]);
+  });
+
+  test("negative: handler proxies a different port — excluded", () => {
+    const json = JSON.stringify({
+      Services: {
+        "svc:shepherd": {
+          Web: {
+            "shepherd.example.ts.net:443": {
+              Handlers: { "/": { Proxy: "http://localhost:9999" } },
+            },
+          },
+        },
+      },
+    });
+    expect(findServedHosts(json, 7330)).toEqual([]);
+  });
+
+  test("negative: handler proxies a non-loopback host — excluded (loopback-only matcher)", () => {
+    const json = JSON.stringify({
+      Web: {
+        "shepherd.example.ts.net:443": {
+          Handlers: { "/": { Proxy: "http://10.0.0.5:7330" } },
+        },
+      },
+    });
+    expect(findServedHosts(json, 7330)).toEqual([]);
+  });
+
+  test("bare-host key (no :PORT) matching main port returns the whole key as the host", () => {
+    const json = JSON.stringify({
+      Web: {
+        "shepherd.example.ts.net": {
+          Handlers: { "/": { Proxy: "http://127.0.0.1:7330" } },
+        },
+      },
+    });
+    expect(findServedHosts(json, 7330)).toEqual(["shepherd.example.ts.net"]);
+  });
+
+  test("trailing-dot key: the dot is stripped in the result", () => {
+    const json = JSON.stringify({
+      Web: {
+        "shepherd.example.ts.net.:443": {
+          Handlers: { "/": { Proxy: "http://localhost:7330" } },
+        },
+      },
+    });
+    expect(findServedHosts(json, 7330)).toEqual(["shepherd.example.ts.net"]);
+  });
+
+  test("same host across multiple web maps / handlers is deduped", () => {
+    const json = JSON.stringify({
+      Web: {
+        "shepherd.example.ts.net:443": {
+          Handlers: {
+            "/": { Proxy: "http://localhost:7330" },
+            "/api": { Proxy: "http://127.0.0.1:7330" },
+          },
+        },
+      },
+      Services: {
+        "svc:shepherd": {
+          Web: {
+            "shepherd.example.ts.net:443": {
+              Handlers: { "/": { Proxy: "http://localhost:7330" } },
+            },
+          },
+        },
+      },
+    });
+    expect(findServedHosts(json, 7330)).toEqual(["shepherd.example.ts.net"]);
+  });
+
+  test("negative: malformed JSON returns []", () => {
+    expect(findServedHosts("not json", 7330)).toEqual([]);
+  });
+
+  test("negative: empty string returns []", () => {
+    expect(findServedHosts("", 7330)).toEqual([]);
+  });
+
+  test("negative: missing Services and Web returns []", () => {
+    expect(findServedHosts("{}", 7330)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Problem

The auto-allow shipped in #1649 doesn't cover the topology it was filed for. It folds **only** the node's own `Self.DNSName` into the CSRF origin allowlist — but a HUD reached through a Tailscale **Service** front is served under a *different* DNS name, so its `Origin` never matches and every mutation still 403s until the operator sets `SHEPHERD_ALLOWED_HOSTS` by hand.

Verified live on an affected node:

| Host | Source | In allowlist? |
| --- | --- | --- |
| `<node>.<tailnet>.ts.net` | node `Self.DNSName` (what #1649 folds in) | yes |
| `shepherd.<tailnet>.ts.net` | `svc:shepherd` Service front → `http://localhost:7330` (the actual HUD Origin) | **no → 403** |

**Two layers:**
1. **Trigger** — #1646 (`46a9786f`) rightly scrubbed a maintainer's personal tailnet host from `deploy/shepherd.service`'s hardcoded `SHEPHERD_ALLOWED_HOSTS`. That removal is what made same-node operators suddenly need a manual entry.
2. **Gap** — #1649 was meant to compensate but only trusts `Self.DNSName`, and its own doc-comment conceded Service fronts "still need a manual allowlist entry" — which is exactly #1645's reported case (`shepherd.<tailnet>.ts.net`).

## Fix

Reuse the existing Services-aware JSON serve parser in `src/config.ts` (`collectWebMaps` + `handlerTargetsPort` + the `host:PORT` key split) rather than adding a new parser:

- **`findServedHosts(json, localPort)`** — every public host whose handler `.Proxy` targets loopback on the **main port**, across the top-level `Web` map and every `Services[svc].Web` map. Deduped, fully defensive (`[]` on any malformed/empty/missing input, never throws).
- **`addServedHostsToAllowlist(...)`** — folds those hosts in at boot, next to `addOwnHostToAllowlist`.
- **`src/index.ts`** — the boot call switches from text `tailscale serve status` to `serve status --json`, so a **single** exec yields both the served port (`findServedPort`) and the service host(s). This orphaned the text parser `parseServedPort` (+ `extractServedPort`, `isProxyTarget`), which are **removed** (`diagnostics.ts` already uses the JSON `findServedPort`).

The trust boundary is the shared loopback+main-port filter (`LOOPBACK_RE` = `localhost|127.0.0.1`, unchanged): only a service actually fronting Shepherd's port is trusted; unrelated hosted services and preview-port origins are excluded.

## Verification

- `bun run lint`, `bun run typecheck` clean; `bun test ./test` → 6544 pass / 0 fail. New `findServedHosts` / `addServedHostsToAllowlist` tests cover Service front, direct-serve, wrong-port and non-loopback exclusion, bare-host key, trailing-dot, cross-map dedup, and malformed input.
- **Empirical, on a live affected node:** the new `findServedHosts(<real `serve status --json`>, 7330)` returns `["shepherd.<tailnet>.ts.net"]` (the exact HUD front) and `[]` for a non-Shepherd port — so a fresh deploy trusts the Service-fronted HUD with **no** manual `SHEPHERD_ALLOWED_HOSTS`, while the boundary holds.

After this merges and the node restarts, operators who added a manual `SHEPHERD_ALLOWED_HOSTS` Service-host workaround can drop it (optional — it's harmless either way).

`[no-feature-entry]` — server-only, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)