### PR TITLE
docs: add "Authoring an epic" operator guide (#1505)

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -113,6 +113,7 @@ export default defineConfig({
           items: [
             { label: "Getting started", slug: "getting-started" },
             { label: "Operating Shepherd", slug: "operating" },
+            { label: "Authoring an epic", slug: "authoring-epics" },
             { label: "Hands-off epics", slug: "hands-off-epics" },
             { label: "Capture extension", slug: "capture-extension" },
           ],

--- a/docs-site/src/content/docs/authoring-epics.md
+++ b/docs-site/src/content/docs/authoring-epics.md
@@ -1,0 +1,165 @@
+---
+title: Authoring an epic
+description: Step-by-step guide to structuring a GitHub epic that Shepherd recognizes and can drain — native sub-issues, the epic-dag fence, and the checklist fallback.
+---
+
+An **epic** is a tracking issue whose children are wired by dependency edges: Shepherd spawns a
+session per ready child, collects their PRs on a shared integration branch, and lands everything as
+one final PR. See [Concepts & glossary](/reference/glossary/) for the model, and
+[Hands-off epics](/hands-off-epics/) for running one once it exists.
+
+This page is the other half — how to **author** an epic Shepherd will recognize. Recognition is
+**purely structural**: Shepherd reads the parent issue's structure, never a label or a title. Get
+the structure right and the epic shows up in Shepherd, ready to drain; get it wrong and the parent
+stays a plain issue Shepherd never sees.
+
+## What "recognized" means
+
+Shepherd treats a parent issue as an epic when **either** is true:
+
+- The parent has **native GitHub sub-issues**, or
+- The parent **body references child issue numbers** — an `epic-dag` fence or a `- [ ] #123`
+  checklist.
+
+Everything hinges on **real child issue numbers**. That drives the ordering of the whole process:
+create the children first, capture their numbers, then mark the parent with those numbers. A marker
+written before the children exist has nothing valid to point at.
+
+:::caution[What Shepherd does NOT recognize]
+None of these make an issue an epic — each is silently ignored, leaving a plain issue:
+
+- An **`epic` label**.
+- An **`[EPIC]` title prefix**.
+- A **prose checklist** with no `#<number>` references (e.g. `- [ ] Build the API`).
+- **Placeholder lines** like `#<n>` or `#child` — the parser needs literal digits.
+- **YAML front matter** or **HTML markers/comments**.
+
+There is no label, title, or front-matter convention anywhere in Shepherd. If your epic isn't
+showing up, it's almost always one of these.
+:::
+
+## Step 1 — New epic, or promote an existing issue?
+
+Two starting points, same finish line (a parent whose body/links reference real children):
+
+- **New epic** — you have an idea and no issue yet. You'll create the children and a fresh parent.
+- **Promote an existing issue `#N`** — you already have an issue that's really several PRs of work.
+  You keep `#N` as the parent and **edit its body** (or attach sub-issues) to add the marker.
+  Creating children while leaving `#N`'s body unmarked leaves `#N` unrecognized — the parent edit
+  **is** the promotion.
+
+## Step 2 — Split the work into child issues
+
+Break the work into children where **one child = one PR = one Shepherd session**. Each child should
+be a thin, end-to-end slice with an observable result, small enough to land in a single PR. A child
+too big for one PR is itself an epic — split it further.
+
+Give each child a crisp title and a body stating the goal and a checkable acceptance criterion. The
+child's body is forwarded verbatim as the spawn brief, so write it for the agent that will pick it
+up.
+
+## Step 3 — Create the children first and capture their numbers
+
+Create the child issues **before** marking the parent, and record each issue number — the marker
+must reference the real numbers.
+
+```bash
+url=$(gh issue create --title "Add the widget API endpoint" --body "Goal: ... Acceptance: ...")
+num=${url##*/}          # gh prints the new issue URL; the trailing segment is the number, e.g. 142
+echo "$num"
+```
+
+Repeat per child, keeping the numbers. (In the GitHub web UI, the number is the `#142` shown on the
+created issue.)
+
+## Step 4 — Mark the parent (choose one shape)
+
+Pick **one** of the three recognized shapes. Native sub-issues are preferred; the two markdown
+shapes are fallbacks.
+
+### Native sub-issues (preferred)
+
+Attach each child to the parent as a GitHub **sub-issue** (on the parent issue, use **Create
+sub-issue → Add existing issue** and reference each child number). Ordering and dependencies come
+from issue **`blocked_by`** relationships (GitHub's issue *dependencies*).
+
+This is the safest shape for gating: Shepherd reads each child's open/closed state and its
+dependency edges directly from GitHub, with no reliance on scanning the repo's issue list. Prefer it
+— especially in large repos (see [Why native links matter](#step-6--import-a-markdown-epic-into-native-links)).
+
+### `epic-dag` fence (markdown)
+
+Add exactly **one** fenced block to the parent body. One `#<number>` line per child; add
+`<- #<blocker>` to declare a dependency (multiple blockers comma-separated):
+
+````markdown
+```epic-dag
+#12
+#13 <- #12
+#14 <- #12, #13
+```
+````
+
+That reads: `#12` is a root; `#13` is blocked by `#12`; `#14` is blocked by both `#12` and `#13`.
+Lines must use **literal digits** — a `#<n>` placeholder is unparseable. Only the **first**
+`epic-dag` fence in the body is read, so keep exactly one.
+
+### Checklist (markdown, no dependencies)
+
+When the children have **no** ordering between them, a task-list works. One `- [ ] #<number>` line
+per child:
+
+```markdown
+- [ ] #12
+- [ ] #13
+- [ ] #14
+```
+
+A checklist carries **members only, no dependency edges** — every child is a root and they all drain
+in parallel. The checkbox state (`[ ]` vs `[x]`) is ignored for recognition; done-ness comes from
+the issue being closed or merged, not the box.
+
+:::note[Which shape wins if you mix them]
+Precedence is deterministic: **native sub-issues win over the markdown body**; within the body an
+**`epic-dag` fence wins over a checklist**; and only the **first** fence is read. Don't rely on
+mixing — pick one shape and keep the parent tidy.
+:::
+
+## Step 5 — Add dependency edges
+
+If some children must land before others, express the ordering:
+
+- **Native:** add a **`blocked_by`** relationship on the dependent child (issue dependencies).
+- **`epic-dag`:** add `<- #<blocker>` on the child's line — `#13 <- #12` means "#13 is blocked by
+  #12"; comma-separate multiple blockers.
+- **Checklist:** no edges are possible — every child drains in parallel. If you need ordering, use
+  the fence or native links instead.
+
+Children with no blockers are the **DAG roots** — Shepherd starts those first, then drains the rest
+as their blockers complete.
+
+## Step 6 — Import a markdown epic into native links
+
+If you authored the epic in markdown (fence or checklist), Shepherd's Epic panel shows an **Import
+structure** button (it appears only for markdown-source epics). Clicking it wires each member as a
+native GitHub sub-issue and each dependency as a `blocked_by` relationship — converting your markdown
+epic into the native shape. Once imported, the epic resolves natively and the button disappears.
+
+**Why import (or author native from the start):** the markdown path resolves each child against the
+repo's open-issue list, which Shepherd reads **capped at 200 issues**. In a large repo, a child
+beyond that cap can be misread as closed and spawned prematurely. Native sub-issue links carry each
+child's state and edges directly, so gating stays exact regardless of repo size. In small repos
+markdown is fine; in large ones, prefer native — import is the one-click path to get there.
+
+## Step 7 — Verify in Shepherd before draining
+
+Before you start the drain, open the parent issue's **Epic panel** in Shepherd and confirm:
+
+- Every child you expect is listed, with the right **state** chips.
+- Dependency edges look right — blocked children show what they're **blocked on**.
+- Any **warnings** on the panel are understood and clear (for example, the markdown 200-cap warning
+  is a prompt to import into native links).
+
+When the tree looks right, follow [Hands-off epics → Starting the epic](/hands-off-epics/#starting-the-epic)
+to drain it. Shepherd spawns the first ready child, then drains the rest as their dependencies
+complete, landing one aggregate PR at the end.

--- a/docs-site/src/content/docs/hands-off-epics.md
+++ b/docs-site/src/content/docs/hands-off-epics.md
@@ -11,6 +11,9 @@ intervention** — it only stops on a genuine blocker.
 This page documents the best-practice **automation-pane** settings for that, and what will still
 stop the epic (so hands-off never means unsafe).
 
+> Don't have an epic yet? See [Authoring an epic](/authoring-epics/) to structure one Shepherd
+> recognizes, then come back here to drain it.
+
 > The automation pane holds **repo-wide** defaults — "Repo automation", not this task alone.
 > The "Apply hands-off defaults" button on the Epic panel writes these same repo-wide defaults, so
 > they apply to every task in the repo, not only the epic you launched it from.
@@ -86,8 +89,9 @@ in-flight work running and resumes on its own — and only a few are **terminal*
 
 ## Starting the epic
 
-1. Make sure the epic exists (a parent issue with sub-issues or an `epic-dag` body). See
-   [Concepts & glossary](/reference/glossary/) for the epic model.
+1. Make sure the epic exists (a parent issue with sub-issues or an `epic-dag` body) — see
+   [Authoring an epic](/authoring-epics/) to create one, and [Concepts & glossary](/reference/glossary/)
+   for the epic model.
 2. Open the epic's panel from its issue row.
 3. If it's your first epic, the **Run this epic hands-off** panel offers **Apply hands-off
    defaults** — or set the pane manually per the table above.

--- a/ui/src/lib/docs-manifest.ts
+++ b/ui/src/lib/docs-manifest.ts
@@ -6,6 +6,12 @@ export type DocsPage = { title: string; path: string; keywords: string };
 
 export const DOCS_PAGES: readonly DocsPage[] = [
   {
+    title: "Authoring an epic",
+    path: "/authoring-epics/",
+    keywords:
+      'step-by-step guide to structuring a github epic that shepherd recognizes and can drain — native sub-issues, the epic-dag fence, and the checklist fallback. what "recognized" means step 1 — new epic, or promote an existing issue? step 2 — split the work into child issues step 3 — create the children first and capture their numbers step 4 — mark the parent (choose one shape) native sub-issues (preferred) epic-dag fence (markdown) checklist (markdown, no dependencies) step 5 — add dependency edges step 6 — import a markdown epic into native links step 7 — verify in shepherd before draining',
+  },
+  {
     title: "Shepherd Capture (browser extension)",
     path: "/capture-extension/",
     keywords:


### PR DESCRIPTION
Closes #1505.

Adds an operator-facing **Authoring an epic** guide to the hosted docs (docs.shepherd.run), walking a human from an idea or an existing issue to an epic Shepherd recognizes and can drain. Docs-only — no runtime code.

## What it documents

The **structural** recognition contract, verified against `src/epic-parse.ts`, `src/epic-model.ts`, `src/epic-import.ts`, and `src/service.ts` (`EPIC_SHAPE_CONTRACT`):

- **All three recognized shapes**, with literal-number examples:
  - **Native GitHub sub-issues** (preferred; ordering via `blocked_by`)
  - **`epic-dag` fence** (`#12` / `#13 <- #12`, one fence, literal digits)
  - **Checklist** (`- [ ] #123`, members only, all drain in parallel)
- **Precedence:** native > markdown; fence > checklist; only the first fence is read.
- **What Shepherd does NOT recognize** (`epic` label, `[EPIC]` title prefix, prose checklist without `#N`, `#<n>` placeholders, front matter, HTML markers).
- **When & why to import** a markdown epic into native links — the markdown path resolves children against a 200-issue-capped list, so large repos risk premature spawns; the Epic panel's **Import structure** button wires native sub-issue + `blocked_by` links for exact gating.
- A **verify-before-drain** step, handing off to Hands-off epics → Starting the epic.

## Wiring

- New Guides page (`docs-site/src/content/docs/authoring-epics.md`), slug `/authoring-epics/`, placed before **Hands-off epics** in the sidebar.
- `hands-off-epics.md` links to it from the intro and the "Starting the epic" step (satisfying the "link before the Starting-the-epic steps" acceptance criterion).
- Regenerated the command-bar docs manifest (`ui/src/lib/docs-manifest.ts`).

## Validation

- `docs-site` Astro/Starlight build passes; `/authoring-epics/` renders; both cross-link anchors resolve (incl. `/hands-off-epics/#starting-the-epic`).
- `check:docs-manifest` clean (new page staged before regen, so `git ls-files` picks it up).
- Prettier + ESLint clean; pre-push gates (ext, root-tests, ui, fallow audit) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)