### PR TITLE
fix(toasts): unify auto-dismiss — dead-end failures 12s, sticky is explicit

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -24,6 +24,7 @@
     "src/index.ts",
     "src/pty-attach.mjs",
     "scripts/**/*.ts",
+    "scripts/**/*.mjs",
     "test/**/*.ts",
     "test/**/*.mjs",
     "ui/src/routes/**/+*.ts",

--- a/docs/toast-inventory.md
+++ b/docs/toast-inventory.md
@@ -204,7 +204,7 @@ above as one of the 4 sticky / 2 promoted sites.
 | 942  | "Couldn't change the usage downgrade setting. Retry."    | duration:null, alert, key | persist(null) | 12s or sticky* |
 | 964  | "Couldn't change the usage downgrade threshold. Retry."  | duration:null, alert, key | persist(null) | 12s or sticky* |
 | 983  | "Couldn't change the downgrade model. Retry."            | duration:null, alert, key | persist(null) | 12s or sticky* |
-| 1015 | "Couldn't change session cleanup. Retry."                | —                         | 4s            | 4s             |
+| 1015 | "Couldn't change session cleanup. Retry."                | alert, key (added)        | 4s            | 12s (D)        |
 
 ### ui/src/lib/components/settings/SettingsDiagnosePanel.svelte
 

--- a/docs/toast-inventory.md
+++ b/docs/toast-inventory.md
@@ -27,8 +27,9 @@ screen forever.
 
 ## Reconciliation
 
-`grep -rn "toasts.info(" ui/src` → 182 hits; **167 excluding `*.test.*`** (+1 `toasts.undo`,
-out of scope). The classifier parses each call's own balanced argument list — a fixed
+`grep -rn "toasts.info(" ui/src` → 184 hits; **167 excluding `*.test.*`** (the rest are
+test-only call sites) (+1 `toasts.undo`, out of scope). The classifier parses each call's
+own balanced argument list — a fixed
 window bleeds flags between adjacent calls — and places all 167:
 
 | Bucket                                         | Count   |

--- a/docs/toast-inventory.md
+++ b/docs/toast-inventory.md
@@ -1,0 +1,345 @@
+# Toast inventory & lifetime policy
+
+Audit of every `toasts.info(` call site in the UI, and the unified auto-dismiss policy
+they follow. Regenerate/verify the site list with `node scripts/audit-toasts.mjs --list`
+(the same script gates CI: it fails if any product call still passes the removed
+`duration: null`).
+
+## Policy
+
+Toasts (`ui/src/lib/toasts.svelte.ts`, tone `info`) have three lifetimes, chosen by two
+explicit signals — `sticky` and `alert`:
+
+| Tier                 | Signal                               | Lifetime                                                | Countdown bar |
+| -------------------- | ------------------------------------ | ------------------------------------------------------- | ------------- |
+| **Must-persist**     | `sticky: true`                       | never auto-dismisses (until retried / closed / cleared) | no            |
+| **Failure**          | `alert: true` (no explicit duration) | **12 000 ms** (pause on hover/focus)                    | yes           |
+| **Success / notice** | neither                              | 4 000 ms                                                | yes           |
+| _(explicit)_         | `duration: <ms>`                     | as given                                                | yes           |
+
+`sticky` is the **only** way to persist — the former `duration: null` spelling was removed
+so persistence is a single explicit decision (and the compiler flags any stale site).
+Persist is reserved for: retry-failures the operator must act on, and tracked status
+toasts that a later event clears programmatically (e.g. draft-reconcile, cleared on
+success/archive). Everything else that fails is a plain `alert` (12s); dead-end failures
+the operator can only read (e.g. "branch merged — relaunch instead") no longer sit on
+screen forever.
+
+## Reconciliation
+
+`grep -rn "toasts.info(" ui/src` → 182 hits; **167 excluding `*.test.*`** (+1 `toasts.undo`,
+out of scope). The classifier parses each call's own balanced argument list — a fixed
+window bleeds flags between adjacent calls — and places all 167:
+
+| Bucket                                         | Count   |
+| ---------------------------------------------- | ------- |
+| PERSIST (`duration:null` today → `sticky`/12s) | 71      |
+| FAILURE-12s (`alert`, no duration)             | 8       |
+| EXPLICIT (`duration:<ms>`)                     | 2       |
+| SUCCESS/NOTICE (4s)                            | 86      |
+| **Total**                                      | **167** |
+
+Of the 71 PERSIST sites, **4 stay persistent** (`sticky: true`) — retry-failures
+`+page.svelte:2225` (halt), `PlanGateBadge.svelte:115`, `SteerBar.svelte:135`, and the
+tracked `store.svelte.ts:836` (draft-reconcile) — and **67 become plain 12s failures**
+(strip `duration:null`, keep `alert`). Two bare-4s retry-failures are promoted to
+`sticky` for consistency: `+page.svelte:2134` (decommission) and `:2303` (clear-merged).
+One outlier, `Settings.svelte:1015` (session-cleanup save failure), gains `alert`+`key` to
+match its 23 siblings (→ 12s).
+
+Two classifier caveats, hand-verified: `PuiActionButton.svelte:68` has no real `action`
+(the `action:` match is inside the key string `plugin-action:`) → dead-end; and
+`store.svelte.ts:836`'s `key` is shorthand (`{ key, … }`) → present.
+
+## Full site list
+
+Target column: **sticky (A)** = stays persistent; **12s** = failure default; **4s** =
+success/notice (unchanged). `*` on a `duration:null` row = becomes plain 12s unless listed
+above as one of the 4 sticky / 2 promoted sites.
+
+### ui/src/lib/components/BacklogView.svelte
+
+| Line | Message                                                     | Signals | Today | Target |
+| ---- | ----------------------------------------------------------- | ------- | ----- | ------ |
+| 137  | "Doc agent didn't start (already running or nothing to do)" | —       | 4s    | 4s     |
+| 139  | "Couldn't start the doc agent"                              | —       | 4s    | 4s     |
+
+### ui/src/lib/components/BroadcastDialog.svelte
+
+| Line | Message                                                                                    | Signals | Today | Target |
+| ---- | ------------------------------------------------------------------------------------------ | ------- | ----- | ------ |
+| 107  | "Broadcast steered {delivered} agents now."                                                | —       | 4s    | 4s     |
+| 109  | "Broadcast · {delivered} steered now, {queued} queued on busy agents (act after current tu | —       | 4s    | 4s     |
+
+### ui/src/lib/components/EpicHandsOffIntro.svelte
+
+| Line | Message                                                                                    | Signals                   | Today         | Target         |
+| ---- | ------------------------------------------------------------------------------------------ | ------------------------- | ------------- | -------------- |
+| 74   | "Couldn't apply hands-off defaults."                                                       | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 86   | "Applied the defaults, but couldn't switch the epic to auto mode — set Epic mode in the co | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 96   | "Hands-off defaults applied."                                                              | key                       | 4s            | 4s             |
+
+### ui/src/lib/components/EpicPanel.svelte
+
+| Line | Message                  | Signals                   | Today         | Target         |
+| ---- | ------------------------ | ------------------------- | ------------- | -------------- |
+| 31   | "Epic update failed"     | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 80   | "Import failed"          | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 129  | "Epic update failed"     | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 145  | "Epic update failed"     | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 165  | "Epic update failed"     | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 181  | "Couldn't stop the epic" | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 198  | "Approve failed"         | duration:null, alert, key | persist(null) | 12s or sticky* |
+
+### ui/src/lib/components/ExperimentPicker.svelte
+
+| Line | Message                                        | Signals | Today    | Target  |
+| ---- | ---------------------------------------------- | ------- | -------- | ------- |
+| 86   | "Could not start that run — please try again." | alert   | 4s+alert | 12s (C) |
+
+### ui/src/lib/components/GitRail.svelte
+
+| Line | Message                                                                        | Signals                   | Today         | Target         |
+| ---- | ------------------------------------------------------------------------------ | ------------------------- | ------------- | -------------- |
+| 314  | `text`                                                                         | —                         | 4s            | 4s             |
+| 318  | `text`                                                                         | duration:15, action, key  | 15ms          | 15ms           |
+| 513  | "Review not started — conditions changed or one's already running."            | —                         | 4s            | 4s             |
+| 515  | "Couldn't start the review. Try again."                                        | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 521  | "Couldn't start the review. Try again."                                        | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 538  | "Plan review not started: .shepherd-plan.md is missing, empty, or unreadable." | —                         | 4s            | 4s             |
+| 540  | "Couldn't start a plan review right now."                                      | —                         | 4s            | 4s             |
+| 542  | "Couldn't start the plan review. Try again."                                   | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 548  | "Couldn't start the plan review. Try again."                                   | duration:null, alert, key | persist(null) | 12s or sticky* |
+
+### ui/src/lib/components/NewTask.svelte
+
+| Line | Message                       | Signals | Today    | Target  |
+| ---- | ----------------------------- | ------- | -------- | ------- |
+| 290  | "Synced {name} with upstream" | —       | 4s       | 4s      |
+| 293  | `syncForkMsg(code)`           | alert   | 4s+alert | 12s (C) |
+
+### ui/src/lib/components/page/AppOverlays.svelte
+
+| Line | Message                                          | Signals | Today | Target |
+| ---- | ------------------------------------------------ | ------- | ----- | ------ |
+| 365  | "Distiller started for {repo}"                   | —       | 4s    | 4s     |
+| 370  | "Opened a CLAUDE.md PR for the rule"             | —       | 4s    | 4s     |
+| 373  | "Could not promote the rule; see the server log" | —       | 4s    | 4s     |
+| 376  | "Optimizing flagged rules…"                      | —       | 4s    | 4s     |
+| 377  | "Couldn’t start optimization"                    | —       | 4s    | 4s     |
+| 380  | "Optimizing flagged rules…"                      | —       | 4s    | 4s     |
+| 381  | "Couldn’t start optimization"                    | —       | 4s    | 4s     |
+| 385  | "Couldn't restore rule"                          | —       | 4s    | 4s     |
+| 389  | "Couldn't revert the trial — try again."         | key     | 4s    | 4s     |
+| 393  | "Couldn't update scope"                          | —       | 4s    | 4s     |
+| 401  | "Rules consolidated"                             | —       | 4s    | 4s     |
+| 404  | "Couldn't merge rules"                           | —       | 4s    | 4s     |
+| 412  | "Rule added to your global CLAUDE.md."           | —       | 4s    | 4s     |
+| 415  | "Couldn't write to your global CLAUDE.md."       | —       | 4s    | 4s     |
+| 418  | "Looking for rules to merge in {repo}…"          | —       | 4s    | 4s     |
+
+### ui/src/lib/components/PlanGateBadge.svelte
+
+| Line | Message                                                                        | Signals                           | Today         | Target         |
+| ---- | ------------------------------------------------------------------------------ | --------------------------------- | ------------- | -------------- |
+| 113  | "Plan changes sent to the agent."                                              | key                               | 4s            | 4s             |
+| 115  | "Couldn't send the plan changes to the agent."                                 | duration:null, alert, action, key | persist(null) | **sticky** (A) |
+| 131  | "Plan review started."                                                         | —                                 | 4s            | 4s             |
+| 133  | "Plan review not started: .shepherd-plan.md is missing, empty, or unreadable." | —                                 | 4s            | 4s             |
+| 135  | "Couldn't start a plan review right now."                                      | —                                 | 4s            | 4s             |
+| 137  | "Couldn't start the plan review. Try again."                                   | duration:null, alert, key         | persist(null) | 12s or sticky* |
+| 144  | "Couldn't start the plan review. Try again."                                   | duration:null, alert, key         | persist(null) | 12s or sticky* |
+
+### ui/src/lib/components/PrBadge.svelte
+
+| Line | Message                                                               | Signals                   | Today         | Target         |
+| ---- | --------------------------------------------------------------------- | ------------------------- | ------------- | -------------- |
+| 80   | "PR #{number} merged"                                                 | key                       | 4s            | 4s             |
+| 82   | "Merge failed: {reason}. Check the PR, then retry." / "unknown error" | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 100  | "PR marked as Draft" / "PR marked Ready for Review"                   | key                       | 4s            | 4s             |
+| 104  | "Couldn't change PR state: {reason}" / "unknown error"                | duration:null, alert, key | persist(null) | 12s or sticky* |
+
+### ui/src/lib/components/ReadinessPanel.svelte
+
+| Line | Message                                                                                  | Signals                   | Today         | Target         |
+| ---- | ---------------------------------------------------------------------------------------- | ------------------------- | ------------- | -------------- |
+| 162  | "Opened a PR adding .shepherd-* to .gitignore: {url}"                                    | action, key               | 4s            | 4s             |
+| 172  | ".shepherd-* is already in .gitignore."                                                  | key                       | 4s            | 4s             |
+| 176  | "No git forge configured; session artifacts are already hidden locally via git exclude." | key                       | 4s            | 4s             |
+| 180  | "No push access; session artifacts are already hidden locally via git exclude."          | key                       | 4s            | 4s             |
+| 188  | "Couldn't update .gitignore. Try again."                                                 | duration:null, alert, key | persist(null) | 12s or sticky* |
+
+### ui/src/lib/components/RetryDialog.svelte
+
+| Line | Message                                                        | Signals | Today | Target |
+| ---- | -------------------------------------------------------------- | ------- | ----- | ------ |
+| 67   | "Retry sent · {resumed} resumed · {steered} steered / {total}" | —       | 4s    | 4s     |
+
+### ui/src/lib/components/Settings.svelte
+
+| Line | Message                                                  | Signals                   | Today         | Target         |
+| ---- | -------------------------------------------------------- | ------------------------- | ------------- | -------------- |
+| 433  | "Couldn't change the role environment. Retry."           | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 453  | "Couldn't change the role environment. Retry."           | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 471  | "Couldn't change the role environment. Retry."           | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 553  | "Couldn't change PR review cycles. Retry."               | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 581  | "Couldn't change plan review cycles. Retry."             | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 602  | "Couldn't change default model. Retry."                  | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 621  | "Couldn't change default effort. Retry."                 | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 640  | "Couldn't save the operator language."                   | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 659  | "Couldn't change default coding CLI. Retry."             | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 685  | "Couldn't update authentication mode"                    | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 705  | "Couldn't save the API key"                              | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 753  | "Couldn't save the API key"                              | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 779  | "Couldn't change the extra-credit spend ceiling. Retry." | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 797  | "Couldn't change the Up Next picker setting. Retry."     | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 815  | "Couldn't change usage hold setting. Retry."             | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 833  | "Couldn't update Fable availability"                     | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 850  | "Couldn't change the fullscreen renderer setting."       | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 867  | "Couldn't change the mouse-capture setting."             | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 884  | "Couldn't save reduced notifications setting."           | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 902  | "Couldn't save the telemetry setting."                   | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 924  | "Couldn't change the usage hold threshold. Retry."       | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 942  | "Couldn't change the usage downgrade setting. Retry."    | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 964  | "Couldn't change the usage downgrade threshold. Retry."  | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 983  | "Couldn't change the downgrade model. Retry."            | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 1015 | "Couldn't change session cleanup. Retry."                | —                         | 4s            | 4s             |
+
+### ui/src/lib/components/settings/SettingsDiagnosePanel.svelte
+
+| Line | Message                                                                                    | Signals                   | Today         | Target         |
+| ---- | ------------------------------------------------------------------------------------------ | ------------------------- | ------------- | -------------- |
+| 48   | "Fixed — re-checked."                                                                      | duration:3000             | 3000ms        | 3000ms         |
+| 50   | "The command ran, but the check is still not OK — it may need a manual step or a restart." | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 57   | "Fix failed — the command did not complete. Try running it manually."                      | duration:null, alert, key | persist(null) | 12s or sticky* |
+
+### ui/src/lib/components/StarPrompt.svelte
+
+| Line | Message               | Signals | Today | Target |
+| ---- | --------------------- | ------- | ----- | ------ |
+| 28   | "Starred. Thank you!" | key     | 4s    | 4s     |
+
+### ui/src/lib/components/SteerBar.svelte
+
+| Line | Message       | Signals                           | Today         | Target         |
+| ---- | ------------- | --------------------------------- | ------------- | -------------- |
+| 135  | "send failed" | duration:null, alert, action, key | persist(null) | **sticky** (A) |
+
+### ui/src/lib/components/UnitRow.svelte
+
+| Line | Message                                                                        | Signals                   | Today         | Target         |
+| ---- | ------------------------------------------------------------------------------ | ------------------------- | ------------- | -------------- |
+| 372  | "Couldn't start execution. Try again."                                         | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 379  | "Couldn't start execution. Try again."                                         | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 394  | "Plan review started."                                                         | —                         | 4s            | 4s             |
+| 396  | "Plan review not started: .shepherd-plan.md is missing, empty, or unreadable." | —                         | 4s            | 4s             |
+| 398  | "Couldn't start a plan review right now."                                      | —                         | 4s            | 4s             |
+| 400  | "Couldn't start the plan review. Try again."                                   | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 406  | "Couldn't start the plan review. Try again."                                   | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 423  | "Couldn't resume the plan review. Try again."                                  | —                         | 4s            | 4s             |
+| 425  | "Couldn't resume the plan review. Try again."                                  | —                         | 4s            | 4s             |
+| 440  | "Re-running the failed CI jobs…"                                               | —                         | 4s            | 4s             |
+| 441  | "Retrying CI isn't available for this repo's forge."                           | —                         | 4s            | 4s             |
+| 442  | "No failed CI run found to retry."                                             | —                         | 4s            | 4s             |
+| 444  | "Couldn't retry CI. Try again."                                                | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 541  | "Couldn't resume {name}"                                                       | —                         | 4s            | 4s             |
+
+### ui/src/lib/components/UpNextPanel.svelte
+
+| Line | Message                                   | Signals                   | Today         | Target         |
+| ---- | ----------------------------------------- | ------------------------- | ------------- | -------------- |
+| 288  | "Started {count} session(s)"              | key                       | 4s            | 4s             |
+| 291  | "Held {count} task(s) until usage resets" | key                       | 4s            | 4s             |
+| 295  | "Couldn't start {count} item(s)"          | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 302  | "Couldn't start {count} item(s)"          | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 311  | "Couldn't start {count} item(s)"          | duration:null, alert, key | persist(null) | 12s or sticky* |
+
+### ui/src/lib/components/Viewport.svelte
+
+| Line | Message                                                                           | Signals                   | Today         | Target         |
+| ---- | --------------------------------------------------------------------------------- | ------------------------- | ------------- | -------------- |
+| 791  | "Couldn't change autopilot for this session. Try again."                          | —                         | 4s            | 4s             |
+| 1189 | "Couldn't stop the dev server; it may be ignoring the stop signal."               | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 1221 | "Stopped the dev server for {name}"                                               | —                         | 4s            | 4s             |
+| 1230 | "Couldn't stop the dev server; it may be ignoring the stop signal."               | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 1241 | "No running dev-server process was found to stop; the preview is still attached." | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 1251 | "Stopping dev server…"                                                            | —                         | 4s            | 4s             |
+| 1605 | "Copied to clipboard"                                                             | —                         | 4s            | 4s             |
+| 2760 | "Copied to clipboard"                                                             | —                         | 4s            | 4s             |
+| 2765 | "Couldn’t copy to clipboard"                                                      | alert                     | 4s+alert      | 12s (C)        |
+
+### ui/src/lib/components/viewport/ViewportTabBar.svelte
+
+| Line | Message                                                                                   | Signals                   | Today         | Target         |
+| ---- | ----------------------------------------------------------------------------------------- | ------------------------- | ------------- | -------------- |
+| 102  | "Couldn't start preview; check terminal for details"                                      | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 119  | "Preview is already live"                                                                 | —                         | 4s            | 4s             |
+| 124  | "Dev server is already running; opening preview"                                          | —                         | 4s            | 4s             |
+| 130  | "Preview setup sent to {name}; future starts will use the local repo script"              | —                         | 4s            | 4s             |
+| 136  | "Preview script started for {name} ({command})" / "Preview start sent to {name} (running: | —                         | 4s            | 4s             |
+
+### ui/src/lib/plugin-ui/PuiActionButton.svelte
+
+| Line | Message                | Signals                   | Today         | Target         |
+| ---- | ---------------------- | ------------------------- | ------------- | -------------- |
+| 66   | "Done"                 | —                         | 4s            | 4s             |
+| 68   | "Plugin action failed" | duration:null, alert, key | persist(null) | 12s or sticky* |
+
+### ui/src/lib/pull-offer.ts
+
+| Line | Message                                                                  | Signals                   | Today         | Target         |
+| ---- | ------------------------------------------------------------------------ | ------------------------- | ------------- | -------------- |
+| 11   | "Updated local {branch} to latest" / "Local {branch} already up to date" | —                         | 4s            | 4s             |
+| 23   | "Local checkout isn't on {branch}; left it untouched"                    | —                         | 4s            | 4s             |
+| 26   | "Local {branch} has uncommitted changes; left it untouched"              | —                         | 4s            | 4s             |
+| 29   | "Local {branch} has diverged; pull manually"                             | —                         | 4s            | 4s             |
+| 33   | "Couldn't update local checkout"                                         | duration:null, alert, key | persist(null) | 12s or sticky* |
+
+### ui/src/lib/store.svelte.ts
+
+| Line | Message                                                                                    | Signals                   | Today         | Target         |
+| ---- | ------------------------------------------------------------------------------------------ | ------------------------- | ------------- | -------------- |
+| 366  | "Renamed to {name}"                                                                        | —                         | 4s            | 4s             |
+| 492  | "Blocked egress to {host}"                                                                 | alert, key                | 4s+alert      | 12s (C)        |
+| 498  | "{count} attached file(s) expired and could not be restored. The session started without t | alert, key                | 4s+alert      | 12s (C)        |
+| 504  | "Heads up: issue content for a session tripped {count} prompt-injection check(s). It is fe | alert, key                | 4s+alert      | 12s (C)        |
+| 510  | "Auto-drain skipped issue #{issue}: its author is not a trusted repo member, so Shepherd w | alert, key                | 4s+alert      | 12s (C)        |
+| 647  | "{repo}: doc-update PR opened"                                                             | action, key               | 4s            | 4s             |
+| 659  | "{repo}: doc-agent observe run — no PR opened"                                             | —                         | 4s            | 4s             |
+| 661  | "{repo}: doc update aborted — prettier couldn't format the docs"                           | duration:null, alert, key | persist(null) | 12s or sticky* |
+| 667  | "{repo}: docs already current"                                                             | —                         | 4s            | 4s             |
+| 695  | "Epic #{number} landed — merged to the default branch"                                     | key                       | 4s            | 4s             |
+| 699  | "Epic #{number} complete — {count} sub-issues landed"                                      | key                       | 4s            | 4s             |
+| 801  | "Halted {count} agents"                                                                    | key                       | 4s            | 4s             |
+| 817  | "Merge train landed in {repo}"                                                             | key                       | 4s            | 4s             |
+| 836  | `text`                                                                                     | duration:null, alert, key | persist(null) | 12s or sticky* |
+
+### ui/src/routes/+page.svelte
+
+| Line | Message                                                                 | Signals                           | Today         | Target         |
+| ---- | ----------------------------------------------------------------------- | --------------------------------- | ------------- | -------------- |
+| 1028 | "No ready-to-merge PRs to run a merge train on"                         | —                                 | 4s            | 4s             |
+| 1051 | "Couldn't start the merge train"                                        | —                                 | 4s            | 4s             |
+| 1084 | "Couldn't start the merge train"                                        | —                                 | 4s            | 4s             |
+| 1901 | `(NEW_PROJECT_WARNINGS[entry.warning] ?? m.newproject_warning`          | —                                 | 4s            | 4s             |
+| 1958 | "Relaunched as {desig}"                                                 | —                                 | 4s            | 4s             |
+| 1961 | "Relaunched, but couldn't decommission the original; close it manually" | duration:null, alert, key         | persist(null) | 12s or sticky* |
+| 1996 | "Held task updated."                                                    | —                                 | 4s            | 4s             |
+| 2028 | "Task held — usage is high. It'll start when usage resets."             | —                                 | 4s            | 4s             |
+| 2059 | "Couldn't load the original's attachments. Re-attach them if needed."   | alert                             | 4s+alert      | 12s (C)        |
+| 2134 | "Couldn't decommission {name}"                                          | action                            | 4s            | —              |
+| 2153 | `text`                                                                  | duration:null, alert, key         | persist(null) | 12s or sticky* |
+| 2156 | "Relaunched as {desig}"                                                 | —                                 | 4s            | 4s             |
+| 2190 | `text`                                                                  | duration:null, alert, key         | persist(null) | 12s or sticky* |
+| 2194 | "Brought {desig} back to the herd"                                      | —                                 | 4s            | 4s             |
+| 2223 | "Halting {count} running agents…"                                       | key                               | 4s            | 4s             |
+| 2225 | "Halt failed: no agents interrupted. Retry."                            | duration:null, alert, action, key | persist(null) | **sticky** (A) |
+| 2256 | "Done"                                                                  | —                                 | 4s            | 4s             |
+| 2258 | "Plugin action failed"                                                  | duration:null, alert, key         | persist(null) | 12s or sticky* |
+| 2284 | "Couldn't decommission merged sessions"                                 | —                                 | 4s            | 4s             |
+| 2301 | "Decommissioned {count} merged sessions"                                | —                                 | 4s            | 4s             |
+| 2303 | "Couldn't decommission merged sessions"                                 | action                            | 4s            | —              |
+| 2327 | "Couldn't dismiss the epic — try again"                                 | duration:null, alert, key         | persist(null) | 12s or sticky* |
+| 2347 | "Couldn't acknowledge the migrations — try again"                       | duration:null, alert, key         | persist(null) | 12s or sticky* |
+| 2363 | "Couldn't acknowledge the manual steps — try again."                    | duration:null, alert, key         | persist(null) | 12s or sticky* |
+| 2415 | `msg`                                                                   | duration:null, alert, key         | persist(null) | 12s or sticky* |

--- a/scripts/audit-toasts.mjs
+++ b/scripts/audit-toasts.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// Toast inventory + lifetime-policy gate.
+//
+// Enumerates every `toasts.info(` call site in the UI (excluding tests) using a
+// balanced-paren scan of each call's own argument list — a fixed-window grep bleeds
+// option flags between adjacent calls, so this parses each call in isolation.
+//
+// For each site it reports the signal flags (sticky / alert / action / key / finite
+// duration) and the resulting lifetime bucket under the unified policy:
+//   - sticky:true          -> PERSIST (never auto-dismiss)
+//   - alert:true (no dur)  -> FAILURE (12s auto-dismiss)
+//   - explicit duration    -> that duration
+//   - otherwise            -> SUCCESS/NOTICE (4s)
+//
+// Gate mode (default): fails if any product `toasts.info(` still passes
+// `duration: null` (removed from the API in favor of `sticky: true`). Pass
+// `--list` to print the full inventory table instead.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOT = new URL("..", import.meta.url).pathname;
+const UI_SRC = join(ROOT, "ui/src");
+
+/** Recursively collect .svelte/.ts files under a dir, skipping test files. */
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) out.push(...walk(p));
+    else if (/\.(svelte|ts)$/.test(name) && !/\.test\./.test(name)) out.push(p);
+  }
+  return out;
+}
+
+/** Line number (1-based) of a byte offset in src. */
+function lineOf(src, pos) {
+  let n = 1;
+  for (let i = 0; i < pos; i++) if (src[i] === "\n") n++;
+  return n;
+}
+
+/** Extract the balanced `(...)` argument text starting at `openIdx` (the "("). */
+function balanced(src, openIdx) {
+  let depth = 0;
+  let inStr = null;
+  let prev = "";
+  for (let i = openIdx; i < src.length; i++) {
+    const c = src[i];
+    if (inStr) {
+      if (c === inStr && prev !== "\\") inStr = null;
+      prev = c;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      inStr = c;
+      prev = c;
+      continue;
+    }
+    if (c === "(") depth++;
+    else if (c === ")") {
+      depth--;
+      if (depth === 0) return src.slice(openIdx, i + 1);
+    }
+    prev = c;
+  }
+  return src.slice(openIdx);
+}
+
+const sites = [];
+for (const file of walk(UI_SRC)) {
+  const src = readFileSync(file, "utf8");
+  const re = /toasts\.info\(/g;
+  let m;
+  while ((m = re.exec(src))) {
+    const open = src.indexOf("(", m.index);
+    const call = balanced(src, open);
+    const flags = {
+      sticky: /\bsticky:\s*true/.test(call),
+      null: /duration:\s*null/.test(call),
+      durNum: /duration:\s*\d/.test(call),
+      alert: /\balert:\s*true/.test(call),
+      // action:/key: matches can appear inside a key STRING (e.g. `plugin-action:`);
+      // require the token at an option-key position (preceded by `{`, `,` or newline).
+      action: /[{,\n]\s*action:/.test(call),
+      key: /[{,\n]\s*key\b\s*[:,]/.test(call),
+    };
+    let bucket;
+    if (flags.sticky || flags.null) bucket = "PERSIST";
+    else if (flags.durNum) bucket = "EXPLICIT";
+    else if (flags.alert) bucket = "FAILURE-12s";
+    else bucket = "SUCCESS/NOTICE-4s";
+    sites.push({ file: relative(ROOT, file), line: lineOf(src, m.index), flags, bucket });
+  }
+}
+
+sites.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
+
+const list = process.argv.includes("--list");
+if (list) {
+  const fl = (f) =>
+    [
+      f.sticky && "sticky",
+      f.null && "duration:null",
+      f.durNum && "duration:N",
+      f.alert && "alert",
+      f.action && "action",
+      f.key && "key",
+    ]
+      .filter(Boolean)
+      .join(" ") || "(bare)";
+  for (const s of sites) console.log(`${s.file}:${s.line}\t${s.bucket}\t${fl(s.flags)}`);
+}
+
+const counts = sites.reduce((a, s) => ((a[s.bucket] = (a[s.bucket] ?? 0) + 1), a), {});
+console.error(`\ntoasts.info sites: ${sites.length}`);
+for (const [k, v] of Object.entries(counts)) console.error(`  ${k}: ${v}`);
+
+const legacy = sites.filter((s) => s.flags.null);
+if (legacy.length) {
+  console.error(
+    `\nERROR: ${legacy.length} site(s) still pass duration:null (use sticky:true for persistence):`,
+  );
+  for (const s of legacy) console.error(`  ${s.file}:${s.line}`);
+  process.exit(1);
+}

--- a/ui/src/lib/components/EpicHandsOffIntro.svelte
+++ b/ui/src/lib/components/EpicHandsOffIntro.svelte
@@ -72,7 +72,6 @@
         await repoConfig.applyHandsOffDefaults(repoPath);
       } catch {
         toasts.info(m.epic_handsoff_apply_failed(), {
-          duration: null,
           alert: true,
           key: "epic-handsoff-apply-fail",
         });
@@ -84,7 +83,6 @@
         } catch {
           // Partial success: repo defaults landed, only the auto-mode switch failed.
           toasts.info(m.epic_handsoff_mode_failed(), {
-            duration: null,
             alert: true,
             key: "epic-handsoff-mode-fail",
           });

--- a/ui/src/lib/components/EpicPanel.svelte
+++ b/ui/src/lib/components/EpicPanel.svelte
@@ -29,7 +29,6 @@
 
   function updateFailed() {
     toasts.info(m.epic_update_failed(), {
-      duration: null,
       alert: true,
       key: "epic-update-fail",
     });
@@ -78,7 +77,6 @@
         onclick={() =>
           importEpic(repoPath, parent).catch(() =>
             toasts.info(m.epic_import_failed(), {
-              duration: null,
               alert: true,
               key: "epic-import-fail",
             }),
@@ -127,7 +125,6 @@
         onclick={() =>
           updateEpic(repoPath, parent, { status: "paused" }).catch(() =>
             toasts.info(m.epic_update_failed(), {
-              duration: null,
               alert: true,
               key: "epic-update-fail",
             }),
@@ -143,7 +140,6 @@
         onclick={() =>
           updateEpic(repoPath, parent, { status: "running" }).catch(() =>
             toasts.info(m.epic_update_failed(), {
-              duration: null,
               alert: true,
               key: "epic-update-fail",
             }),
@@ -163,7 +159,6 @@
           mode: epic.run.mode === "auto" ? "attended" : "auto",
         }).catch(() =>
           toasts.info(m.epic_update_failed(), {
-            duration: null,
             alert: true,
             key: "epic-update-fail",
           }),
@@ -179,7 +174,6 @@
         onclick={() =>
           updateEpic(repoPath, parent, { status: "idle" }).catch(() =>
             toasts.info(m.epic_stop_failed(), {
-              duration: null,
               alert: true,
               key: "epic-stop-fail",
             }),
@@ -196,7 +190,6 @@
         onclick={() =>
           approveEpicNext(repoPath, parent).catch(() =>
             toasts.info(m.epic_approve_failed(), {
-              duration: null,
               alert: true,
               key: "epic-approve-fail",
             }),

--- a/ui/src/lib/components/GitRail.browser.test.ts
+++ b/ui/src/lib/components/GitRail.browser.test.ts
@@ -943,14 +943,13 @@ describe("GitRail — manual critic-review trigger", () => {
     expect(toastsInfo).toHaveBeenCalledWith(
       m.gitrail_review_failed(),
       expect.objectContaining({
-        duration: null,
         alert: true,
         key: `review-pr:${baseProps.sessionId}`,
       }),
     );
   });
 
-  it("a rejected reviewPr raises the persistent failure toast", async () => {
+  it("a rejected reviewPr raises the failure toast", async () => {
     reviewPrFn.mockRejectedValue(new Error("boom"));
     gitStateFn.mockResolvedValue(openPrState);
     await page.viewport(600, 900);
@@ -961,7 +960,7 @@ describe("GitRail — manual critic-review trigger", () => {
     await vi.waitFor(() => expect(toastsInfo).toHaveBeenCalledTimes(1));
     expect(toastsInfo).toHaveBeenCalledWith(
       m.gitrail_review_failed(),
-      expect.objectContaining({ duration: null, alert: true }),
+      expect.objectContaining({ alert: true }),
     );
   });
 
@@ -1204,14 +1203,13 @@ describe("GitRail — manual plan-review trigger", () => {
     expect(toastsInfo).toHaveBeenCalledWith(
       m.gitrail_review_plan_failed(),
       expect.objectContaining({
-        duration: null,
         alert: true,
         key: `review-plan:${baseProps.sessionId}`,
       }),
     );
   });
 
-  it("a rejected reviewPlan raises the persistent failure toast", async () => {
+  it("a rejected reviewPlan raises the failure toast", async () => {
     reviewPlanFn.mockRejectedValue(new Error("boom"));
     gitStateFn.mockResolvedValue(openPrState);
     await page.viewport(600, 900);
@@ -1226,7 +1224,6 @@ describe("GitRail — manual plan-review trigger", () => {
     expect(toastsInfo).toHaveBeenCalledWith(
       m.gitrail_review_plan_failed(),
       expect.objectContaining({
-        duration: null,
         alert: true,
         key: `review-plan:${baseProps.sessionId}`,
       }),

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -513,13 +513,11 @@
       if (status === "skipped") toasts.info(m.gitrail_review_skipped());
       else if (status !== "started")
         toasts.info(m.gitrail_review_failed(), {
-          duration: null,
           alert: true,
           key: `review-pr:${sessionId}`,
         });
     } catch {
       toasts.info(m.gitrail_review_failed(), {
-        duration: null,
         alert: true,
         key: `review-pr:${sessionId}`,
       });
@@ -532,7 +530,7 @@
     try {
       const status = await reviewPlan(sessionId);
       // "started" → bridge to the WS reviewing flag (silent; the indicator is the feedback).
-      // "skipped" while NOT already reviewing → transient note. "error" → persistent toast.
+      // "skipped" while NOT already reviewing → transient note. "error" → 12s failure toast.
       if (status === "started") awaitingPlanReview = true;
       else if (status === "plan-unavailable" && !planGates.isReviewing(sessionId))
         toasts.info(m.gitrail_review_plan_unavailable());
@@ -540,13 +538,11 @@
         toasts.info(m.gitrail_review_plan_skipped());
       else if (status === "error")
         toasts.info(m.gitrail_review_plan_failed(), {
-          duration: null,
           alert: true,
           key: `review-plan:${sessionId}`,
         });
     } catch {
       toasts.info(m.gitrail_review_plan_failed(), {
-        duration: null,
         alert: true,
         key: `review-plan:${sessionId}`,
       });

--- a/ui/src/lib/components/PlanGateBadge.svelte
+++ b/ui/src/lib/components/PlanGateBadge.svelte
@@ -113,7 +113,7 @@
       toasts.info(m.plangate_repair_sent(), { key: `plan-repair:${session.id}` });
     } catch {
       toasts.info(m.plangate_repair_send_failed(), {
-        duration: null,
+        sticky: true,
         alert: true,
         key: `plan-repair:${session.id}`,
         action: { label: m.common_retry(), run: () => sendChanges(draft) },
@@ -135,14 +135,12 @@
         toasts.info(m.plangate_review_skipped_stalled());
       else if (status === "error")
         toasts.info(m.gitrail_review_plan_failed(), {
-          duration: null,
           alert: true,
           key: `review-plan:${session.id}`,
         });
       if (status !== "error") closeMenu();
     } catch {
       toasts.info(m.gitrail_review_plan_failed(), {
-        duration: null,
         alert: true,
         key: `review-plan:${session.id}`,
       });

--- a/ui/src/lib/components/PrBadge.browser.test.ts
+++ b/ui/src/lib/components/PrBadge.browser.test.ts
@@ -178,7 +178,7 @@ describe("PrBadge", () => {
     await vi.waitFor(() =>
       expect(info).toHaveBeenCalledWith(
         m.prbadge_merge_failed({ reason: "boom" }),
-        expect.objectContaining({ alert: true, duration: null, key: "pr-merge:s1" }),
+        expect.objectContaining({ alert: true, key: "pr-merge:s1" }),
       ),
     );
   });

--- a/ui/src/lib/components/PrBadge.svelte
+++ b/ui/src/lib/components/PrBadge.svelte
@@ -83,7 +83,7 @@
         m.prbadge_merge_failed({
           reason: err instanceof Error ? err.message : m.prbadge_unknown_error(),
         }),
-        { alert: true, duration: null, key: `pr-merge:${sessionId}` },
+        { alert: true, key: `pr-merge:${sessionId}` },
       );
     } finally {
       busy = false;
@@ -105,7 +105,7 @@
         m.prbadge_draft_toggle_failed({
           reason: err instanceof Error ? err.message : m.prbadge_unknown_error(),
         }),
-        { alert: true, duration: null, key: `pr-draft:${sessionId}` },
+        { alert: true, key: `pr-draft:${sessionId}` },
       );
     } finally {
       busy = false;

--- a/ui/src/lib/components/ReadinessPanel.svelte
+++ b/ui/src/lib/components/ReadinessPanel.svelte
@@ -183,10 +183,9 @@
       }
     } catch {
       if (rp !== repoPath) return;
-      // Failure must not vanish: persistent (duration: null) + assertive, keyed
-      // per-tone so repeated failures collapse into one toast (house rule).
+      // Assertive failure (alert) → 12s auto-dismiss, keyed per-tone so repeated
+      // failures collapse into one toast instead of stacking.
       toasts.info(m.readiness_adopt_gitignore_error(), {
-        duration: null,
         alert: true,
         key: "adopt-gitignore-fail",
       });

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -385,8 +385,8 @@ describe("Settings diagnose one-click fix toast", () => {
     );
     // The critical assertion: no green "Fixed" toast on an unresolved check.
     expect(toasts.items.some((t) => t.text === m.diagnostics_fix_success())).toBe(false);
-    // And the unresolved toast is persistent (no auto-dismiss) — durationMs unset.
+    // And the unresolved toast is an assertive 12s failure — durationMs set.
     const t = toasts.items.find((x) => x.text === m.diagnostics_fix_unresolved())!;
-    expect(t.durationMs).toBeUndefined();
+    expect(t.durationMs).toBe(12000);
   });
 });

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -429,10 +429,9 @@
         await saveRoleEffort(role);
       }
     } catch {
-      roleCli[role] = roleCliSaved[role]; // revert; surface a persistent, deduped alert
+      roleCli[role] = roleCliSaved[role]; // revert; surface a 12s, deduped alert
       toasts.info(m.settings_role_model_save_failed(), {
         key: `role-cli-${role}`,
-        duration: null,
         alert: true,
       });
     } finally {
@@ -449,10 +448,9 @@
         roleModelSaved[role] = v;
       }
     } catch {
-      roleModelV[role] = roleModelSaved[role]; // revert; surface a persistent, deduped alert
+      roleModelV[role] = roleModelSaved[role]; // revert; surface a 12s, deduped alert
       toasts.info(m.settings_role_model_save_failed(), {
         key: `role-model-${role}`,
-        duration: null,
         alert: true,
       });
     }
@@ -467,10 +465,9 @@
         roleEffortSaved[role] = v;
       }
     } catch {
-      roleEffortV[role] = roleEffortSaved[role]; // revert; surface a persistent, deduped alert
+      roleEffortV[role] = roleEffortSaved[role]; // revert; surface a 12s, deduped alert
       toasts.info(m.settings_role_model_save_failed(), {
         key: `role-effort-${role}`,
-        duration: null,
         alert: true,
       });
     }
@@ -547,12 +544,11 @@
       prReviewCycles = r.prReviewCyclesCap;
       prReviewCyclesSaved = r.prReviewCyclesCap;
     } catch {
-      // revert to the last server-confirmed value; surface the failure as a persistent,
+      // revert to the last server-confirmed value; surface the failure as a 12s,
       // deduped alert so the no-op never looks like a save.
       prReviewCycles = prReviewCyclesSaved;
       toasts.info(m.settings_pr_review_cycles_save_failed(), {
         key: "pr-review-cycles-cap",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -575,12 +571,11 @@
       planReviewCycles = r.planReviewCyclesCap;
       planReviewCyclesSaved = r.planReviewCyclesCap;
     } catch {
-      // revert to the last server-confirmed value; surface the failure as a persistent,
+      // revert to the last server-confirmed value; surface the failure as a 12s,
       // deduped alert so the no-op never looks like a save.
       planReviewCycles = planReviewCyclesSaved;
       toasts.info(m.settings_plan_review_cycles_save_failed(), {
         key: "plan-review-cycles-cap",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -596,12 +591,11 @@
       defaultModel = r.defaultModel;
       defaultModelSaved = r.defaultModel;
     } catch {
-      // revert to the last server-confirmed value; surface the failure as a persistent,
+      // revert to the last server-confirmed value; surface the failure as a 12s,
       // deduped alert so the no-op never looks like a save.
       defaultModel = defaultModelSaved;
       toasts.info(m.settings_default_model_save_failed(), {
         key: "default-model",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -620,7 +614,6 @@
       defaultEffort = defaultEffortSaved;
       toasts.info(m.settings_default_effort_save_failed(), {
         key: "default-effort",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -639,7 +632,6 @@
       operatorLanguage = operatorLanguageSaved;
       toasts.info(m.settings_operator_language_save_failed(), {
         key: "operator-language",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -658,7 +650,6 @@
       defaultAgentProvider = defaultAgentProviderSaved;
       toasts.info(m.settings_default_agent_provider_save_failed(), {
         key: "default-agent-provider",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -680,11 +671,10 @@
         verifyMsg = "";
       }
     } catch {
-      // revert to the last server-confirmed value; surface the failure persistently.
+      // revert to the last server-confirmed value; surface the failure as a 12s alert.
       authMode = authModeSaved;
       toasts.info(m.settings_auth_mode_save_failed(), {
         key: "auth-mode",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -704,7 +694,6 @@
     } catch {
       toasts.info(m.settings_auth_key_save_failed(), {
         key: "auth-key",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -752,7 +741,6 @@
     } catch {
       toasts.info(m.settings_auth_key_save_failed(), {
         key: "auth-key",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -773,12 +761,11 @@
       extraCreditsCeiling = r.extraCreditsDrainCeiling;
       extraCreditsCeilingSaved = r.extraCreditsDrainCeiling;
     } catch {
-      // revert to the last server-confirmed value; surface the failure as a persistent,
+      // revert to the last server-confirmed value; surface the failure as a 12s,
       // deduped alert so the no-op never looks like a save.
       extraCreditsCeiling = extraCreditsCeilingSaved;
       toasts.info(m.settings_extra_credits_ceiling_save_failed(), {
         key: "extra-credits-ceiling",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -796,7 +783,6 @@
     } catch {
       toasts.info(m.settings_upnext_skip_cli_picker_save_failed(), {
         key: "upnext-skip-cli-picker",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -814,7 +800,6 @@
     } catch {
       toasts.info(m.settings_usage_hold_enabled_save_failed(), {
         key: "usage-hold-enabled",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -832,7 +817,6 @@
     } catch {
       toasts.info(m.settings_fable_available_save_failed(), {
         key: "fable-available",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -849,7 +833,6 @@
     } catch {
       toasts.info(m.settings_tui_fullscreen_save_failed(), {
         key: "tui-fullscreen",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -866,7 +849,6 @@
     } catch {
       toasts.info(m.settings_tui_disable_mouse_save_failed(), {
         key: "tui-disable-mouse",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -883,7 +865,6 @@
     } catch {
       toasts.info(m.settings_reduced_push_save_failed(), {
         key: "reduced-push-mode",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -901,7 +882,6 @@
     } catch {
       toasts.info(m.settings_telemetry_save_failed(), {
         key: "telemetry-consent",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -923,7 +903,6 @@
       usageHoldPct = usageHoldPctSaved;
       toasts.info(m.settings_usage_hold_pct_save_failed(), {
         key: "usage-hold-pct",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -941,7 +920,6 @@
     } catch {
       toasts.info(m.settings_usage_downgrade_enabled_save_failed(), {
         key: "usage-downgrade-enabled",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -963,7 +941,6 @@
       usageDowngradePct = usageDowngradePctSaved;
       toasts.info(m.settings_usage_downgrade_pct_save_failed(), {
         key: "usage-downgrade-pct",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -982,7 +959,6 @@
       usageDowngradeModel = usageDowngradeModelSaved;
       toasts.info(m.settings_usage_downgrade_model_save_failed(), {
         key: "usage-downgrade-model",
-        duration: null,
         alert: true,
       });
     } finally {
@@ -1012,7 +988,10 @@
     } catch {
       // the switch stays in its prior position (state only advances on success);
       // surface the failure so the no-op isn't silent.
-      toasts.info(m.settings_housekeeping_save_failed());
+      toasts.info(m.settings_housekeeping_save_failed(), {
+        alert: true,
+        key: "session-housekeeping",
+      });
     } finally {
       hkBusy = false;
     }

--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -124,8 +124,8 @@
   }
 
   // Steering is the product's core risky action: a failed send must not vanish.
-  // Route the failure through a persistent toast (duration: null, stays until
-  // retried or closed) with an inline Retry (retry re-runs send(), so a repeated
+  // Route the failure through a sticky toast (stays until retried or closed) with
+  // an inline Retry (retry re-runs send(), so a repeated
   // failure re-toasts), announced assertively (alert) so a screen-reader
   // operator hears it promptly. Keyed per focused agent so repeated failures
   // collapse into one toast (Retry targets the latest) instead of stacking.
@@ -133,7 +133,7 @@
   function send(text: string) {
     replySession(focusedId, text).catch(() => {
       toasts.info(m.steerbar_send_failed(), {
-        duration: null,
+        sticky: true,
         alert: true,
         key: `steer-fail:${focusedId}`,
         action: { label: m.common_retry(), run: () => send(text) },

--- a/ui/src/lib/components/Toasts.browser.test.ts
+++ b/ui/src/lib/components/Toasts.browser.test.ts
@@ -39,7 +39,7 @@ describe("Toasts mobile inset above the action bar (#810)", () => {
 
   it("insets the banner above the action bar when aboveActionBar is set", async () => {
     await page.viewport(400, 900); // ≤768px → mobile banner block
-    toasts.info("decommissioned", { duration: null });
+    toasts.info("decommissioned", { sticky: true });
     render(Toasts, { aboveActionBar: true });
     await tick();
     // --mobile-actionbar-h (44 + 10 + 2·1 = 56px) + max(--mobile-actionbar-pad 10px, 0) = 66px
@@ -50,7 +50,7 @@ describe("Toasts mobile inset above the action bar (#810)", () => {
 
   it("stays flush to the bottom edge (0px) when no action bar is present", async () => {
     await page.viewport(400, 900);
-    toasts.info("decommissioned", { duration: null });
+    toasts.info("decommissioned", { sticky: true });
     render(Toasts, { aboveActionBar: false });
     await tick();
     expect(toastsBottomPx()).toBe(0); // today's flush behavior; pre-fix value in both states

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -796,7 +796,7 @@ describe("UnitRow plan-gate hold CTA", () => {
       expect(toasts.items.some((t) => t.text === m.hold_cta_go_failed())).toBe(true),
     );
     const t = toasts.items.find((x) => x.text === m.hold_cta_go_failed())!;
-    expect(t.durationMs).toBeUndefined(); // persistent — no auto-dismiss
+    expect(t.durationMs).toBe(12000); // 12s failure — auto-dismisses
   });
 
   it("ci-red hold: Retry CI arms then reruns via retryCi(repoPath, pr) (#1629)", async () => {
@@ -843,7 +843,7 @@ describe("UnitRow plan-gate hold CTA", () => {
       expect(toasts.items.some((t) => t.text === m.hold_cta_retry_ci_failed())).toBe(true),
     );
     const t = toasts.items.find((x) => x.text === m.hold_cta_retry_ci_failed())!;
-    expect(t.durationMs).toBeUndefined(); // persistent — no auto-dismiss
+    expect(t.durationMs).toBe(12000); // 12s failure — auto-dismisses
   });
 
   it("busy: disables the CTA until the pending release settles", async () => {

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -370,14 +370,12 @@
       const ok = await releasePlanGate(session.id); // false on 409, no throw; rejects on network error
       if (!ok)
         toasts.info(m.hold_cta_go_failed(), {
-          duration: null,
           alert: true,
           key: `hold-cta:go:${session.id}`,
         });
       // No optimistic hide: the CTA disappears only when the WS gate/planPhase update arrives.
     } catch {
       toasts.info(m.hold_cta_go_failed(), {
-        duration: null,
         alert: true,
         key: `hold-cta:go:${session.id}`,
       });
@@ -398,13 +396,11 @@
         toasts.info(m.plangate_review_skipped_stalled());
       else if (status === "error")
         toasts.info(m.gitrail_review_plan_failed(), {
-          duration: null,
           alert: true,
           key: `hold-cta:review:${session.id}`,
         });
     } catch {
       toasts.info(m.gitrail_review_plan_failed(), {
-        duration: null,
         alert: true,
         key: `hold-cta:review:${session.id}`,
       });
@@ -430,7 +426,7 @@
 
   // Retry CI: the ci-red hold carries the PR number; the server resolves that PR head's latest
   // failed run and reruns its failed jobs. `unsupported` (non-GitHub forge) / `no-run` (nothing to
-  // retry) are expected outcomes → transient info; a genuine failure (throw) is a persistent alert.
+  // retry) are expected outcomes → transient info; a genuine failure (throw) is a 12s alert.
   async function doRetryCi() {
     const pr = hold?.params?.pr;
     if (ctaBusy || pr == null) return;
@@ -442,7 +438,6 @@
       else if (reason === "no-run") toasts.info(m.hold_cta_retry_ci_no_run());
     } catch {
       toasts.info(m.hold_cta_retry_ci_failed(), {
-        duration: null,
         alert: true,
         key: `hold-cta:retry-ci:${session.id}`,
       });

--- a/ui/src/lib/components/UpNextPanel.svelte
+++ b/ui/src/lib/components/UpNextPanel.svelte
@@ -291,18 +291,16 @@
         toasts.info(m.upnext_held({ count: res.held.length }), { key: "upnext-held" });
       }
       if (res.errors.length > 0) {
-        // Failure must stay until acknowledged — persistent + tone-namespaced dedupe key.
+        // Failure surfaced as a 12s alert — tone-namespaced dedupe key so repeats collapse.
         toasts.info(m.upnext_start_failed({ count: res.errors.length }), {
           key: "upnext-start-failed",
           alert: true,
-          duration: null,
         });
       }
       if (res.created.length === 0 && res.held.length === 0 && res.errors.length === 0) {
         toasts.info(m.upnext_start_failed({ count: items.length }), {
           key: "upnext-start-failed",
           alert: true,
-          duration: null,
         });
       }
       // Clear only the ones we just started; the WS snapshot refresh removes them shortly.
@@ -311,7 +309,6 @@
       toasts.info(m.upnext_start_failed({ count: items.length }), {
         key: "upnext-start-failed",
         alert: true,
-        duration: null,
       });
     } finally {
       starting = false;

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1187,7 +1187,6 @@
       }
       clearStopPending(id);
       toasts.info(m.viewport_preview_stop_failed(), {
-        duration: null,
         alert: true,
         key: `preview-stop-warn-${id}`,
       });
@@ -1228,7 +1227,6 @@
       res = await apiStopPreview(session.id);
     } catch {
       toasts.info(m.viewport_preview_stop_failed(), {
-        duration: null,
         alert: true,
         key: `preview-stop-fail-${unitId}`,
       });
@@ -1239,7 +1237,6 @@
 
     if (res.killed === 0) {
       toasts.info(m.viewport_preview_stop_nothing(), {
-        duration: null,
         alert: true,
         key: `preview-stop-warn-${unitId}`,
       });

--- a/ui/src/lib/components/settings/SettingsDiagnosePanel.svelte
+++ b/ui/src/lib/components/settings/SettingsDiagnosePanel.svelte
@@ -35,10 +35,10 @@
   }
 
   // One-click fix: run the check's remediation server-side, re-render from the
-  // re-probed snapshot. Fail closed on two levels: a non-2xx surfaces a persistent,
+  // re-probed snapshot. Fail closed on two levels: a non-2xx surfaces a 12s,
   // deduped failure toast (and rethrows so DiagnoseRows clears busy); a 2xx whose
   // re-probe shows the target check STILL not ok (the command exited 0 but didn't
-  // clear it) surfaces a persistent "unresolved" toast — never a green success.
+  // clear it) surfaces a 12s "unresolved" toast — never a green success.
   async function fixCheck(checkId: string) {
     try {
       const snap = await fixDiagnostic(checkId);
@@ -48,14 +48,12 @@
         toasts.info(m.diagnostics_fix_success(), { duration: 3000 });
       } else {
         toasts.info(m.diagnostics_fix_unresolved(), {
-          duration: null,
           alert: true,
           key: `diagnose-fix:${checkId}`,
         });
       }
     } catch {
       toasts.info(m.diagnostics_fix_failed(), {
-        duration: null,
         alert: true,
         key: `diagnose-fix:${checkId}`,
       });

--- a/ui/src/lib/components/viewport/ViewportTabBar.svelte
+++ b/ui/src/lib/components/viewport/ViewportTabBar.svelte
@@ -100,7 +100,6 @@
     } catch {
       clearPreviewPending(session.id);
       toasts.info(m.viewport_preview_start_failed(), {
-        duration: null,
         alert: true,
         key: `preview-start-fail-${session.id}`,
       });

--- a/ui/src/lib/plugin-ui/PuiActionButton.svelte
+++ b/ui/src/lib/plugin-ui/PuiActionButton.svelte
@@ -66,7 +66,6 @@
       toasts.info(text.length > 0 ? text : m.plugin_action_done());
     } catch {
       toasts.info(m.plugin_action_failed(), {
-        duration: null,
         alert: true,
         key: `plugin-action:${pluginId}:${path}`,
       });

--- a/ui/src/lib/pull-offer.test.ts
+++ b/ui/src/lib/pull-offer.test.ts
@@ -69,12 +69,14 @@ test("pullMainAndToast: diverged → benign info that auto-dismisses", async () 
   expect(toasts.items).toHaveLength(0);
 });
 
-test("pullMainAndToast: error → persistent alert toast keyed to repo", async () => {
+test("pullMainAndToast: error → 12s alert toast keyed to repo", async () => {
   vi.mocked(pullRepo).mockResolvedValue({ ok: false, reason: "error" });
   await pullMainAndToast("/repo/a");
   expect(toasts.items).toHaveLength(1);
   expect(toasts.items.find((t) => t.key === "update-main:/repo/a")).toBeDefined();
-  // Persistent: must survive far past any finite default duration
-  await vi.advanceTimersByTimeAsync(120_000);
+  // Assertive failure → 12s window: survives the 4s benign default, then auto-dismisses
+  await vi.advanceTimersByTimeAsync(4_100);
   expect(toasts.items).toHaveLength(1);
+  await vi.advanceTimersByTimeAsync(8_000);
+  expect(toasts.items).toHaveLength(0);
 });

--- a/ui/src/lib/pull-offer.ts
+++ b/ui/src/lib/pull-offer.ts
@@ -28,10 +28,9 @@ export async function pullMainAndToast(repoPath: string, branch?: string): Promi
     case "diverged":
       toasts.info(m.toast_update_main_diverged({ branch: b }));
       return;
-    // Genuine unexpected git/network failure: persistent + assertive.
+    // Genuine unexpected git/network failure: assertive 12s toast.
     case "error":
       toasts.info(m.toast_update_main_failed(), {
-        duration: null,
         alert: true,
         key: `update-main:${repoPath}`,
       });

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -1237,7 +1237,7 @@ test("doc-agent:done outcome=nochange fires keyed toast", () => {
   expect(toasts.items.some((x) => x.key === "doc-agent-done:/repos/da-nochange")).toBe(true);
 });
 
-test("doc-agent:done outcome=error fires a persistent assertive toast keyed doc-agent-error:", () => {
+test("doc-agent:done outcome=error fires a 12s assertive toast keyed doc-agent-error:", () => {
   toasts.items = [];
   const s = new HerdStore();
   s.docAgentEnabled = true;
@@ -1248,8 +1248,8 @@ test("doc-agent:done outcome=error fires a persistent assertive toast keyed doc-
   const t = toasts.items.find((x) => x.key === "doc-agent-error:/repos/da-error");
   expect(t).toBeDefined();
   expect(t?.alert).toBe(true);
-  // persistent: no durationMs set (duration: null → undefined in the store)
-  expect(t?.durationMs).toBeUndefined();
+  // dead-end failure → 12s auto-dismiss (durationMs drives the countdown bar)
+  expect(t?.durationMs).toBe(12000);
   expect(t?.text).toContain("da-error");
 });
 

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -660,7 +660,6 @@ export class HerdStore {
     } else if (ev.data.outcome === "error") {
       toasts.info(m.docagent_toast_error({ repo }), {
         key: `doc-agent-error:${ev.data.repoPath}`,
-        duration: null,
         alert: true,
       });
     } else {
@@ -833,7 +832,7 @@ export class HerdStore {
         state === "promote_error"
           ? m.draft_reconcile_promote_error({ desig: detail ?? "" })
           : m.draft_reconcile_enforce_error({ desig: detail ?? "" });
-      const id = toasts.info(text, { key, duration: null, alert: true });
+      const id = toasts.info(text, { key, sticky: true, alert: true });
       this.draftReconcileToastIds.set(sessionId, id);
     } else {
       // state === null: success — clear the alert if one is showing

--- a/ui/src/lib/toasts.svelte.test.ts
+++ b/ui/src/lib/toasts.svelte.test.ts
@@ -94,8 +94,8 @@ test("release() never goes below zero (stray release then hold still pauses)", a
   expect(toasts.items.some((t) => t.id === id)).toBe(true);
 });
 
-test("hold() no-ops on a persistent info toast", async () => {
-  const id = toasts.info("failed", { duration: null });
+test("hold() no-ops on a sticky info toast", async () => {
+  const id = toasts.info("failed", { sticky: true });
   toasts.hold(id);
   toasts.release(id);
 
@@ -123,9 +123,25 @@ test("a default-duration info toast carries durationMs", () => {
   expect(toasts.items.find((t) => t.id === id)?.durationMs).toBe(4000);
 });
 
-test("a persistent info toast has no durationMs (no bar)", () => {
-  const id = toasts.info("failed", { duration: null });
+test("a sticky info toast has no durationMs (no bar) and never auto-dismisses", async () => {
+  const id = toasts.info("failed", { sticky: true });
   expect(toasts.items.find((t) => t.id === id)?.durationMs).toBeUndefined();
+  await vi.advanceTimersByTimeAsync(60_000);
+  expect(toasts.items.some((t) => t.id === id)).toBe(true);
+});
+
+test("a failure info toast (alert) carries durationMs 12000 and auto-dismisses at 12s", async () => {
+  const id = toasts.info("failed", { alert: true });
+  expect(toasts.items.find((t) => t.id === id)?.durationMs).toBe(12000);
+  await vi.advanceTimersByTimeAsync(11_999);
+  expect(toasts.items.some((t) => t.id === id)).toBe(true); // still up just before the window
+  await vi.advanceTimersByTimeAsync(2);
+  expect(toasts.items.some((t) => t.id === id)).toBe(false); // gone after 12s
+});
+
+test("an explicit duration overrides the alert failure default", () => {
+  const id = toasts.info("failed", { alert: true, duration: 3000 });
+  expect(toasts.items.find((t) => t.id === id)?.durationMs).toBe(3000);
 });
 
 test("a keyed refresh bumps armSeq (restarts the bar animation)", () => {

--- a/ui/src/lib/toasts.svelte.ts
+++ b/ui/src/lib/toasts.svelte.ts
@@ -18,7 +18,7 @@ interface Toast {
   undoLabel?: string;
   /** Window length, fed to the depleting-bar animation. Set for any timed toast
    *  (undo, and info with a finite duration) — drives the depleting countdown
-   *  bar. Unset (undefined) for persistent info toasts, which draw no bar. */
+   *  bar. Unset (undefined) for sticky info toasts, which draw no bar. */
   durationMs?: number;
   /** True while hover/focus has paused an info toast's auto-dismiss; drives the
    *  bar's animation-play-state so it freezes instead of draining. (Info only.) */
@@ -36,14 +36,20 @@ interface Toast {
 }
 
 interface InfoOpts {
-  /** Auto-dismiss delay in ms (default 4000). Pass `null` to stay until the
-   *  operator retries or closes it (use for failures that must not vanish). */
-  duration?: number | null;
+  /** Explicit auto-dismiss delay in ms. Omit to use the severity default: a failure
+   *  (`alert: true`) lasts FAILURE_MS, a plain confirmation DEFAULT_MS. */
+  duration?: number;
   /** An inline action button (e.g. Retry on a failed operation). */
   action?: { label: string; run: () => void };
-  /** Announce assertively (role="alert") rather than politely. For failures
-   *  that must reach a screen-reader operator promptly. */
+  /** Announce assertively (role="alert") rather than politely. For failures that
+   *  must reach a screen-reader operator promptly; also lengthens the default
+   *  auto-dismiss to FAILURE_MS so a failure gets a longer read. */
   alert?: boolean;
+  /** Keep the toast until it is retried, closed, or programmatically dismissed —
+   *  it never auto-dismisses and draws no countdown bar. Reserved for retry-failures
+   *  the operator must act on and tracked status toasts a later event clears. This
+   *  is the ONLY way to persist a toast (a plain failure is `alert` → FAILURE_MS). */
+  sticky?: boolean;
   /** Dedupe key: a repeated info with the same key refreshes the existing toast
    *  instead of stacking another (e.g. repeated failures to one target). */
   key?: string;
@@ -59,6 +65,14 @@ interface UndoOpts {
   /** Dedupe: a new undo toast with the same key re-arms the existing one. */
   key?: string;
 }
+
+// Auto-dismiss lifetimes for info toasts, chosen by two explicit signals:
+//   sticky:true → never auto-dismisses; alert:true → FAILURE_MS; else → DEFAULT_MS.
+// See docs/toast-inventory.md for the policy and the full call-site inventory.
+/** Plain confirmation / notice. */
+const DEFAULT_MS = 4000;
+/** Assertive failure (`alert: true`) — a longer read window than a confirmation. */
+const FAILURE_MS = 12000;
 
 class ToastStore {
   items = $state<Toast[]>([]);
@@ -86,13 +100,23 @@ class ToastStore {
     return `${tone}:${key}`;
   }
 
-  /** Confirmation toast. Auto-dismisses after `duration` ms (default 4000);
-   *  pass `duration: null` for a persistent toast that stays until retried or
-   *  closed. `alert: true` announces it assertively (role="alert"). */
+  /** Confirmation / failure toast. Lifetime by severity: an assertive failure
+   *  (`alert: true`) auto-dismisses after FAILURE_MS, a plain confirmation after
+   *  DEFAULT_MS, an explicit `duration` after that many ms. `sticky: true` keeps it
+   *  until retried, closed, or programmatically dismissed. */
   info(text: string, opts: InfoOpts = {}): number {
-    // Finite duration drives the depleting countdown bar (--ms); persistent
-    // (`null`) toasts leave it undefined so no bar is drawn.
-    const durationMs = opts.duration === null ? undefined : (opts.duration ?? 4000);
+    // Effective lifetime (null ⇒ persistent). Sticky wins; else an explicit
+    // duration; else the severity default (FAILURE_MS failure / DEFAULT_MS confirm).
+    const effective: number | null = opts.sticky
+      ? null
+      : typeof opts.duration === "number"
+        ? opts.duration
+        : opts.alert
+          ? FAILURE_MS
+          : DEFAULT_MS;
+    // A finite lifetime drives the depleting countdown bar (--ms); sticky toasts
+    // leave it undefined so no bar is drawn.
+    const durationMs = effective ?? undefined;
     // Keyed dedupe: a repeated info with the same key refreshes the existing
     // toast (text / action / announcement / timer) instead of stacking another,
     // so e.g. repeated steer failures to one agent collapse to a single toast.
@@ -113,7 +137,7 @@ class ToastStore {
             }
           : t,
       );
-      this.#armInfo(prev, opts.duration);
+      this.#armInfo(prev, effective);
       return prev;
     }
     const id = ++this.#seq;
@@ -132,18 +156,17 @@ class ToastStore {
     ];
     if (opts.action) this.#actions.set(id, opts.action.run);
     if (opts.key !== undefined) this.#keyed.set(this.#kk("info", opts.key), id);
-    this.#armInfo(id, opts.duration);
+    this.#armInfo(id, effective);
     return id;
   }
 
-  /** Arm an info toast's auto-dismiss timer. `null` duration = persistent (stays
-   *  until the operator retries or closes it). */
-  #armInfo(id: number, duration: number | null | undefined) {
-    if (duration === null) {
-      this.#armed.delete(id); // a keyed refresh may turn a timed toast persistent
+  /** Arm an info toast's auto-dismiss timer. `null` = sticky (stays until the
+   *  operator retries/closes it, or it is programmatically dismissed). */
+  #armInfo(id: number, ms: number | null) {
+    if (ms === null) {
+      this.#armed.delete(id); // a keyed refresh may turn a timed toast sticky
       return;
     }
-    const ms = duration ?? 4000;
     this.#armed.set(id, { at: Date.now(), remaining: ms });
     // Keyed refresh landing while held (hovered/focused): don't start a timer
     // under the operator's pointer — release() arms the recorded duration.

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1957,9 +1957,8 @@
     resetCompose();
     if (result.archived) toasts.info(m.relaunch_done({ desig: result.session.desig }));
     else
-      // Same persistent + assertive failure toast onrelaunch uses (deduped per id).
+      // Same assertive 12s failure toast onrelaunch uses (deduped per id).
       toasts.info(m.relaunch_archive_failed(), {
-        duration: null,
         alert: true,
         key: `relaunch-fail:${id}`,
       });
@@ -2132,6 +2131,9 @@
           await archiveSession(id, reap);
         } catch {
           toasts.info(m.toast_decommission_failed({ name }), {
+            sticky: true,
+            alert: true,
+            key: `decommission-fail:${id}`,
             action: { label: m.common_retry(), run: () => onarchive(id, reap) },
           });
         }
@@ -2147,10 +2149,10 @@
   // is irreversible and an undo would have to also kill the fresh replacement).
   async function onrelaunch(id: string) {
     const fail = (text: string) =>
-      // Persistent + assertive, deduped per id under a relaunch-fail namespace: a
-      // failure toast must not vanish (unlike the transient success info), and repeated
-      // failures to one card collapse into a single toast rather than stacking.
-      toasts.info(text, { duration: null, alert: true, key: `relaunch-fail:${id}` });
+      // Assertive + deduped per id under a relaunch-fail namespace: the failure lingers
+      // 12s (longer than the transient 4s success info), and repeated failures to one
+      // card collapse into a single toast rather than stacking.
+      toasts.info(text, { alert: true, key: `relaunch-fail:${id}` });
     try {
       const { session, archived } = await relaunchSession(id);
       if (archived) toasts.info(m.relaunch_done({ desig: session.desig }));
@@ -2186,8 +2188,7 @@
   // has already confirmed. The live Herd row arrives via session:new — no manual
   // store mutation needed beyond dropping the row from the Done list on success.
   async function onBringBack(id: string) {
-    const fail = (text: string) =>
-      toasts.info(text, { duration: null, alert: true, key: `restore-fail:${id}` });
+    const fail = (text: string) => toasts.info(text, { alert: true, key: `restore-fail:${id}` });
     try {
       const s = await restoreSession(id);
       doneSessions.remove(id);
@@ -2224,7 +2225,7 @@
     apiHalt().catch(() => {
       toasts.info(m.halt_failed(), {
         alert: true,
-        duration: null, // stay until the operator retries/closes — a failed fleet-halt must not vanish
+        sticky: true, // stay until the operator retries/closes — a failed fleet-halt must not vanish
         key: "halt-done",
         action: { label: m.common_retry(), run: () => haltHerd() },
       });
@@ -2256,7 +2257,6 @@
         toasts.info(text.length > 0 ? text : m.plugin_gear_action_done());
       } catch {
         toasts.info(m.plugin_gear_action_failed(), {
-          duration: null,
           alert: true,
           key: `plugin-gear:${id}`,
         });
@@ -2301,6 +2301,9 @@
       toasts.info(m.toast_cleared_merged({ count: cleared.length }));
     } catch {
       toasts.info(m.toast_clear_merged_failed(), {
+        sticky: true,
+        alert: true,
+        key: "clear-merged-fail",
         action: { label: m.common_retry(), run: () => void runClearMerged(ids) },
       });
     }
@@ -2326,7 +2329,6 @@
       }
       toasts.info(m.integrated_epics_dismiss_failed(), {
         alert: true,
-        duration: null,
         key: `epic-dismiss-fail:${repoPath}#${parent}`,
       });
     }
@@ -2346,7 +2348,6 @@
       }
       toasts.info(m.integrated_epics_ack_migrations_failed(), {
         alert: true,
-        duration: null,
         key: `epic-ack-migrations-fail:${repoPath}#${parent}`,
       });
     }
@@ -2354,15 +2355,14 @@
 
   // Acknowledge a session's manual operator steps (#1060), clearing its auto-merge gate. The
   // server emits session:manual-steps with the fresh ackedAt on success, so the chip/CTA clear
-  // live via the WS handler — no optimistic mutation needed. On failure, a persistent, tone-
-  // namespaced keyed toast (shared store, not transient info) so a flapping failure can't stack.
+  // live via the WS handler — no optimistic mutation needed. On failure, a 12s, tone-
+  // namespaced keyed alert so a flapping failure can't stack.
   async function onAckManualSteps(id: string) {
     try {
       await ackManualSteps(id);
     } catch {
       toasts.info(m.unitrow_ack_manual_steps_failed(), {
         alert: true,
-        duration: null,
         key: `ack-manual-steps-fail:${id}`,
       });
     }
@@ -2414,7 +2414,6 @@
         err instanceof Error && err.message ? err.message : m.integrated_epics_land_failed();
       toasts.info(msg, {
         alert: true,
-        duration: null,
         key: `epic-land-fail:${repoPath}#${parent}`,
       });
     }


### PR DESCRIPTION
## What

Full audit of every toast we issue, then a unified auto-dismiss policy so failure toasts have consistent, predictable lifetimes. Fixes the reported bug: the restore **"Its branch was merged and removed — relaunch instead"** toast (and similar dead-end failures) used to sit on screen forever with only a manual ✕ to clear it.

## The policy (one place: `toasts.svelte.ts`)

Lifetime is chosen by two **explicit** signals:

| Tier | Signal | Lifetime |
|---|---|---|
| Success / notice | neither | 4s (unchanged) |
| Failure | `alert: true` (no explicit duration) | **12s**, pause-on-hover |
| Must-persist | `sticky: true` | never auto-dismisses |

`sticky: true` is now the **only** way to persist — the old `duration: null` spelling was removed from the API (`InfoOpts.duration` is `number | undefined`). This makes persistence a single explicit decision and lets the compiler flag every stale site.

## What changed across the 167 `toasts.info` sites

- **67 dead-end failures** (no inline retry) → **12s auto-dismiss** instead of forever: restore/relaunch failures, every Settings-save failure, epic/dev-server/plan-review/PR/preview failures, etc.
- **6 must-persist → `sticky: true`**: retry-failures the operator must act on (halt, steer, plan-changes, decommission, clear-merged) + the **tracked** draft-reconcile status toast (cleared programmatically on success/archive, so it must stay while unresolved).
- **Settings housekeeping-save** outlier (was a silent 4s no-key failure) brought in line with its 23 siblings.
- `alert`-marked failures with no explicit duration inherit the 12s default (a consistency win for the security/attachment warnings).

## Audit deliverable

- **`docs/toast-inventory.md`** — full line-by-line inventory of all 167 sites with message + lifetime.
- **`scripts/audit-toasts.mjs`** — balanced-paren classifier that regenerates/verifies the inventory and gates against any lingering `duration: null` (`node scripts/audit-toasts.mjs`). Registered as a fallow root (`.fallowrc.jsonc`), alongside the repo's other run-directly `scripts/*.mjs`.

## Verification

- `bun run check` (0 errors), `bun run test:node` (2176), `bun run test:browser` (1170), `check:i18n` (parity), root lint, prettier, and `fallow audit` all green. New store tests cover the full matrix (sticky persists; `alert` → 12s auto-dismiss; success → 4s; explicit duration respected).

```shepherd:manual-steps
- [ ] POST-MERGE: Update the out-of-repo Shepherd house-rule text that tells agents persistent failure toasts must pass `{ key, duration: null, alert: true }` — the spelling is now `sticky: true`, and most former dead-ends should be plain `alert` failures (12s), not persistent.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)