### PR TITLE
fix(drain): don't treat a stale critic verdict as "needs changes"

### DIFF
--- a/src/drain-core.ts
+++ b/src/drain-core.ts
@@ -2,6 +2,7 @@ import type { Issue, GitState } from "./forge/types";
 import type { AgentProvider, SessionStatus, ReviewDecision } from "./types";
 import { signedOff, type SignoffAuthority, type SignoffView } from "./signoff";
 import { checksCleared } from "./checks-gate";
+import { verdictStale } from "./verdict-freshness";
 
 /** Issues carrying this label jump to the head of the drain queue. Fixed (the
  *  per-repo `autoLabel` is configurable, but the priority marker is a constant
@@ -214,9 +215,16 @@ function retireDecision(state: DrainRepoState): DrainDecision | null {
 function troubleHold(state: DrainRepoState): HoldReason | null {
   const blocked = state.autoSessions.find((s) => s.status === "blocked");
   if (blocked) return { code: "blocked", detail: blocked.desig };
-  const cr = state.autoSessions.find((s) => s.reviewDecision === "changes_requested");
+  // A verdict for an OLDER head (rework pushed, PR open at a newer head, re-review pending) is
+  // NOT trouble — the same SHA staleness `readyToRetire` already respects. Suppress it here so a
+  // superseded changes_requested/error doesn't falsely pause the drain (banner "needs changes").
+  const cr = state.autoSessions.find(
+    (s) => s.reviewDecision === "changes_requested" && !verdictStale(s.reviewHeadSha, s.git),
+  );
   if (cr) return { code: "changes_requested", detail: cr.desig };
-  const err = state.autoSessions.find((s) => s.reviewDecision === "error");
+  const err = state.autoSessions.find(
+    (s) => s.reviewDecision === "error" && !verdictStale(s.reviewHeadSha, s.git),
+  );
   return err ? { code: "error", detail: err.desig } : null;
 }
 

--- a/src/rundown-core.ts
+++ b/src/rundown-core.ts
@@ -18,6 +18,7 @@ import type {
 import type { GitState } from "./forge/types";
 import type { BlockReason } from "./blocked";
 import { blockReasonToHoldCode, renderHold } from "./hold";
+import { verdictStale } from "./verdict-freshness";
 import { fenceUntrusted } from "./untrusted";
 import type { OperatorLanguage } from "./operator-language";
 import { addressStallStatus } from "./review-status";
@@ -141,11 +142,19 @@ function planReworkActive(s: Session, gate: PlanGate | undefined): boolean {
   );
 }
 
-/** Critic-side twin of planReworkActive (no planPhase gate — critic rework runs post-PR). */
-function criticReworkActive(s: Session, review: ReviewVerdict | undefined, now: number): boolean {
+/** Critic-side twin of planReworkActive (no planPhase gate — critic rework runs post-PR).
+ *  A verdict for an OLDER head (rework pushed, PR open at a newer head) is stale — the agent
+ *  already delivered, a re-review is pending — so it is not active rework (matches troubleHold). */
+function criticReworkActive(
+  s: Session,
+  review: ReviewVerdict | undefined,
+  git: GitState | undefined,
+  now: number,
+): boolean {
   return (
     review?.decision === "changes_requested" &&
     !review.dismissed &&
+    !verdictStale(review.headSha, git) &&
     !(s.status === "running" && addressStallStatus(review, now) === "stalled")
   );
 }
@@ -168,7 +177,7 @@ const ATTENTION_RULES: Array<{
       Boolean(c.block),
   },
   { signal: "plan-rework", when: (s, c) => planReworkActive(s, c.gate) },
-  { signal: "critic-rework", when: (s, c, now) => criticReworkActive(s, c.review, now) },
+  { signal: "critic-rework", when: (s, c, now) => criticReworkActive(s, c.review, c.git, now) },
   { signal: "ci-red", when: (_s, c) => c.git?.checks === "failure" },
   // manual-steps: a PR declares un-acked, non-POST-MERGE manual operator steps that gate its
   // auto-merge (#1060). Last in the Tier-1 block so a genuinely-more-urgent co-signal stays the

--- a/src/verdict-freshness.ts
+++ b/src/verdict-freshness.ts
@@ -1,0 +1,34 @@
+// DRIFT: keep in sync with ui/src/lib/verdict-freshness.ts — the two are locked together by
+// test/fixtures/verdict-stale-parity.json (read by both suites), like MERGE_MARK_BACKSTOP_MS.
+
+/** The minimal git shape verdict-freshness reasons over (a subset of GitState / the UI twin). */
+export interface VerdictGit {
+  state: "none" | "open" | "merged" | "closed";
+  /** Head commit SHA of the PR branch; undefined when there is no PR. */
+  headSha?: string | null;
+}
+
+/**
+ * Whether a critic verdict is provably STALE — reviewed an older head than the PR's current one,
+ * so it must NOT be treated as a live blocking verdict (the agent already pushed rework; a
+ * re-review is pending).
+ *
+ * Asymmetric by design: the APPROVAL side (readyToRetire / isReviewOk) requires proof of
+ * FRESHNESS (`verdictHead === currentHead`); the BLOCKING side is cleared only on proof of
+ * STALENESS. So this returns true ONLY when a strictly-newer OPEN head is proven:
+ *   git present ∧ state === "open" ∧ verdictHead present ∧ currentHead present ∧ verdictHead ≠ currentHead
+ * Unknown git / absent-or-empty SHA / non-open PR ⇒ not proven stale ⇒ "don't advance on
+ * uncertainty" (an empty-string head is UNKNOWN, not an older SHA).
+ */
+export function verdictStale(
+  verdictHeadSha: string | null | undefined,
+  git: VerdictGit | null | undefined,
+): boolean {
+  return (
+    !!git &&
+    git.state === "open" &&
+    !!verdictHeadSha &&
+    !!git.headSha &&
+    verdictHeadSha !== git.headSha
+  );
+}

--- a/test/drain-core.test.ts
+++ b/test/drain-core.test.ts
@@ -243,6 +243,93 @@ describe("computeNext", () => {
     expect(d).toEqual({ kind: "hold", reason: { code: "error", detail: "TASK-09" } });
   });
 
+  // A verdict for an OLDER head (rework pushed, PR open at a newer head, CI/re-review pending) is
+  // stale — not trouble. It must NOT pause the drain; suppression advances computeNext past the
+  // trouble gate so the fleet resumes draining (throughput change, intended).
+  const STALE_GIT: GitState = {
+    kind: "github",
+    state: "open",
+    number: 7,
+    checks: "pending", // CI running on the new head
+    headSha: "newsha",
+    mergeable: null,
+    deployConfigured: false,
+  };
+
+  test("stale changes_requested (rework pushed, CI on newer head) → NOT trouble; drain spawns", () => {
+    const i2 = issue(2);
+    const d = computeNext(
+      state({
+        maxAuto: 2,
+        autoSessions: [
+          autoSession({
+            desig: "TASK-09",
+            reviewDecision: "changes_requested",
+            reviewHeadSha: "oldsha",
+            git: STALE_GIT,
+          }),
+        ],
+        candidates: [i2],
+      }),
+    );
+    expect(d).toEqual({ kind: "spawn", issue: i2 });
+  });
+
+  test("stale error verdict → NOT trouble; drain spawns", () => {
+    const i2 = issue(2);
+    const d = computeNext(
+      state({
+        maxAuto: 2,
+        autoSessions: [
+          autoSession({
+            desig: "TASK-09",
+            reviewDecision: "error",
+            reviewHeadSha: "oldsha",
+            git: STALE_GIT,
+          }),
+        ],
+        candidates: [i2],
+      }),
+    );
+    expect(d).toEqual({ kind: "spawn", issue: i2 });
+  });
+
+  test("stale changes_requested at cap (maxAuto=1) → holds as cap, not changes_requested", () => {
+    const d = computeNext(
+      state({
+        maxAuto: 1,
+        autoSessions: [
+          autoSession({
+            desig: "TASK-09",
+            reviewDecision: "changes_requested",
+            reviewHeadSha: "oldsha",
+            git: STALE_GIT,
+          }),
+        ],
+        candidates: [issue(2)],
+      }),
+    );
+    expect(d).toEqual({ kind: "hold", reason: { code: "cap", detail: "1" } });
+  });
+
+  test("changes_requested at the CURRENT head → still holds (not stale)", () => {
+    const liveGit: GitState = { ...STALE_GIT, headSha: "samesha" };
+    const d = computeNext(
+      state({
+        autoSessions: [
+          autoSession({
+            desig: "TASK-09",
+            reviewDecision: "changes_requested",
+            reviewHeadSha: "samesha",
+            git: liveGit,
+          }),
+        ],
+        candidates: [issue(2)],
+      }),
+    );
+    expect(d).toEqual({ kind: "hold", reason: { code: "changes_requested", detail: "TASK-09" } });
+  });
+
   test("dedupe: skips candidates already mapped to a session", () => {
     const i3 = issue(3);
     const d = computeNext(

--- a/test/fixtures/verdict-stale-parity.json
+++ b/test/fixtures/verdict-stale-parity.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "no git (PR not polled) → not stale",
+    "verdictHeadSha": "aaa",
+    "git": null,
+    "expected": false
+  },
+  {
+    "name": "git open, verdict head absent → not stale",
+    "verdictHeadSha": null,
+    "git": { "state": "open", "headSha": "bbb" },
+    "expected": false
+  },
+  {
+    "name": "git open, current head absent (wire) → not stale",
+    "verdictHeadSha": "aaa",
+    "git": { "state": "open" },
+    "expected": false
+  },
+  {
+    "name": "git open, verdict head empty string (unknown) → not stale",
+    "verdictHeadSha": "",
+    "git": { "state": "open", "headSha": "bbb" },
+    "expected": false
+  },
+  {
+    "name": "git open, current head empty string (unknown) → not stale",
+    "verdictHeadSha": "aaa",
+    "git": { "state": "open", "headSha": "" },
+    "expected": false
+  },
+  {
+    "name": "git open, heads match → not stale (live verdict)",
+    "verdictHeadSha": "aaa",
+    "git": { "state": "open", "headSha": "aaa" },
+    "expected": false
+  },
+  {
+    "name": "git open, verdict head older than current → STALE",
+    "verdictHeadSha": "aaa",
+    "git": { "state": "open", "headSha": "bbb" },
+    "expected": true
+  },
+  {
+    "name": "git merged, heads differ → not stale (not open)",
+    "verdictHeadSha": "aaa",
+    "git": { "state": "merged", "headSha": "bbb" },
+    "expected": false
+  },
+  {
+    "name": "git closed, heads differ → not stale (not open)",
+    "verdictHeadSha": "aaa",
+    "git": { "state": "closed", "headSha": "bbb" },
+    "expected": false
+  },
+  {
+    "name": "git none, heads differ → not stale (not open)",
+    "verdictHeadSha": "aaa",
+    "git": { "state": "none", "headSha": "bbb" },
+    "expected": false
+  }
+]

--- a/test/rundown-core.test.ts
+++ b/test/rundown-core.test.ts
@@ -593,6 +593,37 @@ test("critic-rework: running + stalled suppresses; dismissed suppresses; idle st
   ).not.toContain("critic-rework");
 });
 
+test("critic-rework: verdict for an OLDER head (rework pushed, PR open at newer head) is suppressed", () => {
+  const review = {
+    decision: "changes_requested",
+    findings: ["f"],
+    headSha: "oldsha",
+    addressRound: 1,
+    addressCap: 3,
+    finalRoundPending: false,
+    updatedAt: NOW,
+  } as any;
+  const staleGit = {
+    kind: "github",
+    state: "open",
+    checks: "pending",
+    headSha: "newsha",
+    deployConfigured: false,
+  } as GitState;
+  // stale: verdict head ≠ the PR's current open head → not active rework
+  expect(
+    classifyAttention(session({ status: "idle" }), { review, git: staleGit }, NOW).signals,
+  ).not.toContain("critic-rework");
+  // live: verdict head === current head → still active rework
+  expect(
+    classifyAttention(
+      session({ status: "idle" }),
+      { review, git: { ...staleGit, headSha: "oldsha" } },
+      NOW,
+    ).signals,
+  ).toContain("critic-rework");
+});
+
 test("classifyAttention + assemble: planning session with same at-cap gate still gets plan-rework + planRound (guard not over-suppressing)", () => {
   // Contrast: planPhase:"planning" with the same gate must still produce plan-rework and planRound.
   const planningSession = session({ planPhase: "planning", status: "idle" });

--- a/test/verdict-freshness.test.ts
+++ b/test/verdict-freshness.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "bun:test";
+import { verdictStale, type VerdictGit } from "../src/verdict-freshness";
+
+type ParityCase = {
+  name: string;
+  verdictHeadSha: string | null;
+  git: VerdictGit | null;
+  expected: boolean;
+};
+
+const cases = JSON.parse(
+  readFileSync(new URL("./fixtures/verdict-stale-parity.json", import.meta.url), "utf8"),
+) as ParityCase[];
+
+describe("verdictStale (server) — shared parity fixture (server ↔ UI drift lock)", () => {
+  // The SAME fixture is asserted by ui/src/lib/verdict-freshness.test.ts against the mirrored
+  // UI helper; any drift between the two implementations fails one suite. Mirrors the
+  // MERGE_MARK_BACKSTOP_MS / plan-question-parity.json lock.
+  for (const c of cases) {
+    test(c.name, () => {
+      expect(verdictStale(c.verdictHeadSha, c.git)).toBe(c.expected);
+    });
+  }
+});

--- a/ui/src/lib/components/stage.test.ts
+++ b/ui/src/lib/components/stage.test.ts
@@ -266,6 +266,52 @@ describe("deriveStage — review tint", () => {
     });
     expect(s.review).toBe("none");
   });
+
+  it("verdict changes_requested on a STALE head (open PR at a newer head) → NOT 'changes'", () => {
+    // Rework pushed, PR now at "new"; the verdict reviewed "old" → superseded, don't paint red.
+    const s = deriveStage({
+      git: git({ state: "open", headSha: "new" }),
+      verdict: { ...verdict, decision: "changes_requested", headSha: "old" },
+      reviewing: false,
+      readyToMerge: false,
+    });
+    expect(s.review).toBe("none");
+  });
+
+  it("verdict error on a STALE head → NOT 'error'", () => {
+    const s = deriveStage({
+      git: git({ state: "open", headSha: "new" }),
+      verdict: { ...verdict, decision: "error", headSha: "old" },
+      reviewing: false,
+      readyToMerge: false,
+    });
+    expect(s.review).toBe("none");
+  });
+
+  it("verdict changes_requested at the CURRENT head → still 'changes'", () => {
+    const s = deriveStage({
+      git: git({ state: "open", headSha: "same" }),
+      verdict: { ...verdict, decision: "changes_requested", headSha: "same" },
+      reviewing: false,
+      readyToMerge: false,
+    });
+    expect(s.review).toBe("changes");
+  });
+
+  it("human latestReview changes_requested still tints 'changes' even on a stale critic head", () => {
+    // The forge fact (human requested changes) is independent of critic-verdict staleness.
+    const s = deriveStage({
+      git: git({
+        state: "open",
+        headSha: "new",
+        latestReview: { state: "changes_requested", author: "x", submittedAt: 0 },
+      }),
+      verdict: { ...verdict, decision: "changes_requested", headSha: "old" },
+      reviewing: false,
+      readyToMerge: false,
+    });
+    expect(s.review).toBe("changes");
+  });
 });
 
 describe("deriveStage — derived-ready predicate", () => {

--- a/ui/src/lib/components/stage.ts
+++ b/ui/src/lib/components/stage.ts
@@ -1,4 +1,5 @@
 import type { GitState, ReviewVerdict, ChecksState } from "$lib/types";
+import { verdictStale } from "$lib/verdict-freshness";
 
 /** Pipeline stages, low→high. The agent's furthest-reached stage drives the stepper. */
 export const STAGE_ORDER = ["planning", "implementing", "pr", "review", "ready"] as const;
@@ -57,10 +58,16 @@ function reviewTint(
   git: GitState | undefined,
 ): StageInfo["review"] {
   if (reviewing) return "reviewing";
-  if (verdict?.decision === "changes_requested" || git?.latestReview?.state === "changes_requested")
+  // A critic verdict for an OLDER head (rework pushed, PR open at a newer head, re-review pending)
+  // is stale — don't paint it red. The human forge review (git.latestReview) is a separate fact.
+  const criticStale = verdictStale(verdict?.headSha, git);
+  if (
+    (verdict?.decision === "changes_requested" && !criticStale) ||
+    git?.latestReview?.state === "changes_requested"
+  )
     return "changes";
   if (reviewOk) return "approved";
-  if (verdict?.decision === "error") return "error";
+  if (verdict?.decision === "error" && !criticStale) return "error";
   return "none";
 }
 

--- a/ui/src/lib/verdict-freshness.test.ts
+++ b/ui/src/lib/verdict-freshness.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "vitest";
+import { verdictStale, type VerdictGit } from "./verdict-freshness";
+
+type ParityCase = {
+  name: string;
+  verdictHeadSha: string | null;
+  git: VerdictGit | null;
+  expected: boolean;
+};
+
+describe("verdictStale (UI) — shared parity fixture (server ↔ UI drift lock)", () => {
+  // The SAME fixture is asserted by test/verdict-freshness.test.ts against the server helper;
+  // any drift between the two implementations fails one suite. Mirrors the
+  // MERGE_MARK_BACKSTOP_MS / plan-question-parity.json lock.
+  const cases = JSON.parse(
+    readFileSync(
+      new URL("../../../test/fixtures/verdict-stale-parity.json", import.meta.url),
+      "utf8",
+    ),
+  ) as ParityCase[];
+  for (const c of cases) {
+    test(c.name, () => {
+      expect(verdictStale(c.verdictHeadSha, c.git)).toBe(c.expected);
+    });
+  }
+});

--- a/ui/src/lib/verdict-freshness.ts
+++ b/ui/src/lib/verdict-freshness.ts
@@ -1,0 +1,34 @@
+// DRIFT: keep in sync with src/verdict-freshness.ts — the two are locked together by
+// test/fixtures/verdict-stale-parity.json (read by both suites), like MERGE_MARK_BACKSTOP_MS.
+
+/** The minimal git shape verdict-freshness reasons over (a subset of GitState / the server twin). */
+export interface VerdictGit {
+  state: "none" | "open" | "merged" | "closed";
+  /** Head commit SHA of the PR branch; undefined when there is no PR. */
+  headSha?: string | null;
+}
+
+/**
+ * Whether a critic verdict is provably STALE — reviewed an older head than the PR's current one,
+ * so it must NOT be treated as a live blocking verdict (the agent already pushed rework; a
+ * re-review is pending).
+ *
+ * Asymmetric by design: the APPROVAL side (isReviewOk / readyToRetire) requires proof of
+ * FRESHNESS (`verdictHead === currentHead`); the BLOCKING side is cleared only on proof of
+ * STALENESS. So this returns true ONLY when a strictly-newer OPEN head is proven:
+ *   git present ∧ state === "open" ∧ verdictHead present ∧ currentHead present ∧ verdictHead ≠ currentHead
+ * Unknown git / absent-or-empty SHA / non-open PR ⇒ not proven stale ⇒ "don't advance on
+ * uncertainty" (an empty-string head is UNKNOWN, not an older SHA).
+ */
+export function verdictStale(
+  verdictHeadSha: string | null | undefined,
+  git: VerdictGit | null | undefined,
+): boolean {
+  return (
+    !!git &&
+    git.state === "open" &&
+    !!verdictHeadSha &&
+    !!git.headSha &&
+    verdictHeadSha !== git.headSha
+  );
+}


### PR DESCRIPTION
## Problem

A task with **CI running and nothing actually requested** showed **"Paused: TASK-1541 needs changes"** at the top of FleetView, plus a red **"REVIEW 1/3 · Critic requested changes (2 open)"** card.

Root cause: a critic verdict carries the head SHA it reviewed. The **approval** paths already gate on `verdictHead === currentHead` (`drain-core.readyToRetire`, `stage.isReviewOk`), but the **blocking** paths keyed purely on `decision` and ignored the SHA. So once the agent pushed rework (head advances) and CI reran, the *superseded* `changes_requested`/`error` verdict kept blocking until re-review landed — a false alarm.

## Fix

New `verdictStale()` helper — **server** (`src/verdict-freshness.ts`) mirrored by **UI** (`ui/src/lib/verdict-freshness.ts`), drift-locked by a shared `test/fixtures/verdict-stale-parity.json` read in both suites (the repo's `MERGE_MARK_BACKSTOP_MS` / `plan-question-parity.json` convention).

Gated the three blocking consumers:
1. `drain-core.ts` `troubleHold` — the top banner (`changes_requested` **and** `error`)
2. `stage.ts` `reviewTint` — the card's red review-segment tint (`changes_requested` **and** `error`)
3. `rundown-core.ts` `criticReworkActive` — the "Critic requested changes (N open)" line

**Asymmetric by design:** approval requires proof of *freshness*; the blocking side is cleared only on proof of *staleness* — a strictly-newer **open** head. Unknown git / absent-or-empty SHA / non-open PR / matching head all keep prior behavior ("don't advance on uncertainty"). A verdict genuinely live at the current head is never suppressed, so this cannot hide a real changes-requested — only a superseded one.

**Throughput note:** suppressing a stale trouble-hold lets `computeNext` advance past the trouble gate, so the drain resumes spawning up to `maxAuto` — intended, since a stale verdict is not "trouble". Covered by an explicit drain-core test (spawns under headroom; still holds as `cap` at `maxAuto = 1`).

## Scope notes

- `isReworkRunning` (the Herd's *reassuring* "agent working" group) was **deliberately left out** — it's gated on `displayStatus === "running"`, isn't the alarm, and gating it would demote a running session into a worse bucket (`ciRunning` / a "your turn to merge" handoff).
- The `dismissed` axis (operator take-over) is a **pre-existing, orthogonal** gap in sites 1/2 (they lack a `dismissed` field) — unchanged here; candidate follow-up.
- `automerge-core.ts` already SHA-gates correctly and is untouched; `readyToRetire` unchanged, so a stale-verdict session still waits for re-review rather than retiring.

## Tests
- Shared parity fixture asserted by both server + UI suites (drift lock).
- `drain-core`: stale `changes_requested`/`error` → not trouble (spawns / holds as `cap`); matching-head & unknown-git still hold.
- `rundown-core`: `criticReworkActive` false when stale, true when live.
- `stage`: stale verdict → not `changes`/`error`; matching head → `changes`; human forge review still tints independently.
- Green: root `bun run lint` + `bun test ./test` (0 fail), `cd ui && bun run check` + full node project + Stepper/UnitRow browser specs.

Fallow's duplication warning on the two `verdict-freshness.ts` files is the intentional, drift-locked mirror pair (warn, non-blocking).