### PR TITLE
fix(herd): drop moot ack button on terminal cards, verb-label merged manual-steps chip (#1478)

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2080,6 +2080,7 @@
   "feat_manual_operator_steps_body": "Deklariere manuelle Schritte im shepherd:manual-steps-Block eines PR (Flag umlegen, Umgebungsvariable setzen, Backfill ausführen), und Shepherd zeigt sie als bernsteinfarbenen Chip in der Session-Zeile sowie als Checkliste im Done-Recap an – damit sie beim Mergen des PR nicht verloren gehen.",
   "unitrow_ack_manual_steps": "Schritte best.",
   "unitrow_ack_manual_steps_failed": "Manuelle Schritte konnten nicht bestätigt werden — bitte erneut versuchen.",
+  "unitrow_resolve_manual_steps": "{count} Schritt(e) erledigen",
   "hold_manual_steps": "{steps} manuelle(r) Schritt(e) vor dem Mergen — bestätigen zum Fortfahren.",
   "feat_manual_operator_steps_gate_title": "Manuelle Schritte blockieren Auto-Merge",
   "feat_manual_operator_steps_gate_body": "Ein PR mit einem unbestätigten manuellen Schritt (alles, was nicht als POST-MERGE markiert ist) wird jetzt vom Auto-Merge zurückgehalten, bis du handelst. Klicke in der Session-Zeile auf \"Schritte best.\", um die Sperre aufzuheben; du wirst per Push und im täglichen Rundown erinnert. Reine POST-MERGE-Schritte blockieren nie.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2080,6 +2080,7 @@
   "feat_manual_operator_steps_body": "Declare manual steps in a PR's shepherd:manual-steps block (flip a flag, set an env var, run a backfill) and Shepherd surfaces them as an amber chip on the session row and a checklist in the Done recap — so they aren't lost when the PR lands.",
   "unitrow_ack_manual_steps": "Ack steps",
   "unitrow_ack_manual_steps_failed": "Couldn't acknowledge the manual steps — try again.",
+  "unitrow_resolve_manual_steps": "Resolve {count} step(s)",
   "hold_manual_steps": "{steps} manual step(s) to do before merge — ack to proceed.",
   "feat_manual_operator_steps_gate_title": "Manual steps gate auto-merge",
   "feat_manual_operator_steps_gate_body": "A PR with an un-acknowledged manual step (anything not marked POST-MERGE) is now held out of auto-merge until you act. Click \"Ack steps\" on the session row to clear the gate; you're nudged via push and the daily rundown. POST-MERGE-only steps never block.",

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -934,6 +934,81 @@ describe("UnitRow manual-steps chip", () => {
     await expect.element(page.getByTitle(m.unitrow_manual_steps_link())).not.toBeInTheDocument();
     await expect.element(page.getByText(m.unitrow_manual_steps({ count: 1 }))).toBeInTheDocument();
   });
+
+  // #1478: on a merged/closed card the auto-merge gate the Ack CTA used to clear no longer
+  // exists, so it must not render there; the count chip becomes the actual resolution route
+  // and gets a verb label on merged cards to read as the action.
+  it("open card: shows the Ack CTA and the neutral count-chip label", async () => {
+    let acked: string | null = null;
+    let shown: string | null = null;
+    render(UnitRow, {
+      session: session({
+        id: "ms3",
+        manualSteps: [{ id: "m1", text: "do a thing", postMerge: false }],
+        manualStepsAckedAt: null,
+      }),
+      git: { state: "open" } as never,
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+      onackmanualsteps: (id: string) => (acked = id),
+      onshowowed: (id: string) => (shown = id),
+    });
+    const ackBtn = page.getByTitle(m.unitrow_ack_manual_steps());
+    await expect.element(ackBtn).toBeInTheDocument();
+    await ackBtn.click();
+    expect(acked).toBe("ms3");
+    await expect.element(page.getByText(m.unitrow_manual_steps({ count: 1 }))).toBeInTheDocument();
+    expect(shown).toBe(null);
+  });
+
+  it("merged card: hides the Ack CTA and verb-labels the count chip → onshowowed", async () => {
+    let acked: string | null = null;
+    let shown: string | null = null;
+    render(UnitRow, {
+      session: session({
+        id: "ms4",
+        manualSteps: [{ id: "m1", text: "do a thing", postMerge: false }],
+        manualStepsAckedAt: null,
+      }),
+      git: { state: "merged" } as never,
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+      onackmanualsteps: (id: string) => (acked = id),
+      onshowowed: (id: string) => (shown = id),
+    });
+    await expect.element(page.getByTitle(m.unitrow_ack_manual_steps())).not.toBeInTheDocument();
+    const chip = page.getByText(m.unitrow_resolve_manual_steps({ count: 1 }));
+    await expect.element(chip).toBeInTheDocument();
+    await chip.click();
+    expect(shown).toBe("ms4");
+    expect(acked).toBe(null);
+  });
+
+  it("closed card: hides the Ack CTA and keeps the neutral count-chip label → onshowowed", async () => {
+    let acked: string | null = null;
+    let shown: string | null = null;
+    render(UnitRow, {
+      session: session({
+        id: "ms5",
+        manualSteps: [{ id: "m1", text: "do a thing", postMerge: false }],
+        manualStepsAckedAt: null,
+      }),
+      git: { state: "closed" } as never,
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+      onackmanualsteps: (id: string) => (acked = id),
+      onshowowed: (id: string) => (shown = id),
+    });
+    await expect.element(page.getByTitle(m.unitrow_ack_manual_steps())).not.toBeInTheDocument();
+    const chip = page.getByText(m.unitrow_manual_steps({ count: 1 }));
+    await expect.element(chip).toBeInTheDocument();
+    await chip.click();
+    expect(shown).toBe("ms5");
+    expect(acked).toBe(null);
+  });
 });
 
 describe("UnitRow stepper bar", () => {

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -146,6 +146,19 @@
   const hasBlockingManualSteps = $derived(
     session.manualStepsAckedAt == null && session.manualSteps.some((s) => !s.postMerge),
   );
+  // Terminal (merged/closed) cards no longer have an auto-merge gate to clear, so the
+  // Ack CTA is moot there (#1478). Merged additionally gets a verb label on the count
+  // chip since it's now the actual resolution route (→ Owed lens).
+  const isMerged = $derived(git?.state === "merged");
+  const isTerminal = $derived(git?.state === "merged" || git?.state === "closed");
+  // Verb label on merged cards (the count chip is the resolution route → Owed); neutral count
+  // elsewhere. Extracted from the template to keep it under the complexity bar.
+  const manualStepsChipLabel = $derived(
+    isMerged
+      ? m.unitrow_resolve_manual_steps({ count: session.manualSteps.length })
+      : m.unitrow_manual_steps({ count: session.manualSteps.length }),
+  );
+  const showAckCta = $derived(hasBlockingManualSteps && !isTerminal && !!onackmanualsteps);
   const repoIcon = $derived(projectIcons.iconFor(session.repoPath));
   const repoFiltered = $derived(repoFilter?.has(session.repoPath) ?? false);
   function toggleRepoFilter() {
@@ -769,7 +782,7 @@
               onshowowed?.(session.id);
             }}
           >
-            {m.unitrow_manual_steps({ count: session.manualSteps.length })}
+            {manualStepsChipLabel}
           </button>
         {:else}
           <span
@@ -779,7 +792,7 @@
             {m.unitrow_manual_steps({ count: session.manualSteps.length })}
           </span>
         {/if}
-        {#if hasBlockingManualSteps && onackmanualsteps}
+        {#if showAckCta}
           <button
             type="button"
             class="manual-steps-ack"
@@ -1377,8 +1390,12 @@
     outline: none;
     box-shadow: inset 0 0 0 1px var(--color-amber);
   }
-  /* "Ack" CTA beside the manual-steps chip — warn-toned, micro, clears the auto-merge gate (#1060) */
+  /* "Ack" CTA beside the manual-steps chip — warn-toned, micro, clears the auto-merge gate (#1060).
+     Raised above the .unit-hit overlay (same pattern as .chip-manual-steps--link above) so it's
+     actually clickable — without this it silently sits under the row's full-card click target. */
   .manual-steps-ack {
+    position: relative;
+    z-index: 1;
     flex: none;
     font-family: var(--font-mono);
     font-size: var(--fs-micro);

--- a/ui/src/lib/demo/router.test.ts
+++ b/ui/src/lib/demo/router.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { handleApi } from "./router";
 import { demoState } from "./state";
+import { bus } from "./bus";
 
 const REPO = "/demo/acme/storefront";
 const u = (path: string) => new URL(path, "http://localhost");
@@ -67,17 +68,26 @@ describe("polished GET handlers return the shape api.ts consumes", () => {
     expect(one.body.parentIssueNumber).toBe(100);
   });
 
-  it("GET /api/sessions/clear-merged returns the merged, non-archived ids (deps)", async () => {
+  it("GET /api/sessions/clear-merged returns the merged, non-archived ids (deps + envflag)", async () => {
     const { status, body } = await get("/api/sessions/clear-merged");
     expect(status).toBe(200);
-    expect(body).toEqual({ ids: ["deps"], leftovers: 0 });
+    expect(body).toEqual({ ids: ["deps", "envflag"], leftovers: 0 });
   });
 
-  it("the rich scenario seeds seven sessions across two repos", async () => {
+  it("the rich scenario seeds eight sessions across two repos", async () => {
     const { body } = await get("/api/sessions");
-    expect(body).toHaveLength(7);
+    expect(body).toHaveLength(8);
     expect(body.map((s: { id: string }) => s.id).sort()).toEqual(
-      ["authstore", "checkout-child", "coupon", "deps", "neon", "ogimg", "rounding"].sort(),
+      [
+        "authstore",
+        "checkout-child",
+        "coupon",
+        "deps",
+        "envflag",
+        "neon",
+        "ogimg",
+        "rounding",
+      ].sort(),
     );
     expect(new Set(body.map((s: { repoPath: string }) => s.repoPath))).toEqual(
       new Set(["/demo/acme/storefront", "/demo/acme/api"]),
@@ -133,8 +143,11 @@ describe("mutation handlers call the mutator and return the caller's shape", () 
     expect(r.status).toBe(200);
     expect(await r.json()).toEqual({ cleared: ["deps"], leftovers: 0 });
     expect(demoState.sessions().find((s) => s.id === "deps")).toBeUndefined();
-    // re-querying the clearable set now returns none — deps is gone, not re-offered.
-    expect((await get("/api/sessions/clear-merged")).body).toEqual({ ids: [], leftovers: 0 });
+    // re-querying the clearable set now returns envflag only — deps is gone, not re-offered.
+    expect((await get("/api/sessions/clear-merged")).body).toEqual({
+      ids: ["envflag"],
+      leftovers: 0,
+    });
   });
 
   it("POST /api/sessions/clear-merged ignores an id that isn't actually merged", async () => {
@@ -282,14 +295,21 @@ describe("session-detail tab GETs never fall back to {}", () => {
 // `ensure_array_like` falls back to `Array.from`, which is `[]` for a plain `{}`), so this
 // gap never THREW — it just left a showcased lens (deps' one real owed step) empty.
 describe("GET /api/manual-steps/outstanding (Owed lens) is populated, never silently empty", () => {
-  it("returns deps' seeded owed step", async () => {
+  it("returns deps' + envflag's seeded owed steps", async () => {
     const { status, body } = await get("/api/manual-steps/outstanding");
     expect(status).toBe(200);
     expect(Array.isArray(body)).toBe(true);
-    expect(body).toHaveLength(1);
-    expect(body[0].sessionId).toBe("deps");
-    expect(body[0].steps).toHaveLength(1);
-    expect(body[0].steps[0].doneAt).toBeNull();
+    expect(body).toHaveLength(2);
+    const byId = new Map(
+      (body as { sessionId: string; steps: { doneAt: number | null }[] }[]).map((r) => [
+        r.sessionId,
+        r,
+      ]),
+    );
+    expect(byId.get("deps")!.steps).toHaveLength(1);
+    expect(byId.get("deps")!.steps[0].doneAt).toBeNull();
+    expect(byId.get("envflag")!.steps).toHaveLength(1);
+    expect(byId.get("envflag")!.steps[0].doneAt).toBeNull();
   });
 
   it("POST .../steps/:stepId ticks the step; dismiss clears the whole record", async () => {
@@ -302,6 +322,33 @@ describe("GET /api/manual-steps/outstanding (Owed lens) is populated, never sile
 
     const dismissRes = await handleApi("POST", u("/api/manual-steps/deps/dismiss"), {});
     expect(dismissRes.status).toBe(200);
-    expect((await get("/api/manual-steps/outstanding")).body).toEqual([]);
+    // deps is cleared; envflag's owed record is untouched and still outstanding.
+    const remaining = (await get("/api/manual-steps/outstanding")).body as { sessionId: string }[];
+    expect(remaining.map((r) => r.sessionId)).toEqual(["envflag"]);
+  });
+});
+
+// #1478 Part 2: the demo router previously had no ack-manual-steps route, so the
+// pre-merge "Ack steps" CTA was a silent no-op in the demo build.
+describe("POST /api/sessions/:id/ack-manual-steps (mirrors the real server handler)", () => {
+  it("stamps manualStepsAckedAt and returns {ok:true}", async () => {
+    expect(demoState.sessions().find((s) => s.id === "envflag")?.manualStepsAckedAt).toBeNull();
+    const r = await handleApi("POST", u("/api/sessions/envflag/ack-manual-steps"), undefined);
+    expect(r.status).toBe(200);
+    expect(await r.json()).toEqual({ ok: true });
+    expect(demoState.sessions().find((s) => s.id === "envflag")?.manualStepsAckedAt).not.toBeNull();
+  });
+
+  it("emits session:manual-steps with a non-null manualStepsAckedAt", async () => {
+    const frames: { event: string; data: unknown }[] = [];
+    const unsub = bus.subscribe((ev) => frames.push(ev));
+    try {
+      await handleApi("POST", u("/api/sessions/envflag/ack-manual-steps"), undefined);
+    } finally {
+      unsub();
+    }
+    const ev = frames.find((f) => f.event === "session:manual-steps");
+    expect(ev).toBeDefined();
+    expect((ev!.data as { manualStepsAckedAt: number | null }).manualStepsAckedAt).not.toBeNull();
   });
 });

--- a/ui/src/lib/demo/router.ts
+++ b/ui/src/lib/demo/router.ts
@@ -230,6 +230,15 @@ const sessionIdMutationRoutes: ReadonlyArray<{
     },
   },
   {
+    // POST /api/sessions/:id/ack-manual-steps
+    method: "POST",
+    pattern: /^\/api\/sessions\/[^/]+\/ack-manual-steps$/,
+    handle: (path) => {
+      demoState.ackManualSteps(seg(path, 3));
+      return json({ ok: true });
+    },
+  },
+  {
     // DELETE /api/sessions/:id  (archive)
     method: "DELETE",
     pattern: /^\/api\/sessions\/[^/]+$/,

--- a/ui/src/lib/demo/seed.ts
+++ b/ui/src/lib/demo/seed.ts
@@ -6,13 +6,14 @@
 // The scenario — the fictional herd the marketing demo shows off:
 //   Two repos: `acme/storefront` (SvelteKit storefront) + `acme/api` (bun API).
 //   One active epic "Checkout v2" on storefront, mid-drain.
-//   Seven sessions spanning states so every lens / badge / panel has a real subject:
+//   Eight sessions spanning states so every lens / badge / panel has a real subject:
 //     coupon         WORKING (hero)   live activity, subagents, growing diff, no PR yet
 //     rounding       READY            PR open, CI green, ready-to-merge
 //     authstore      PLAN GATE        plan-gate verdict awaiting the operator's Go
 //     neon           BLOCKED          autopilot question awaiting an answer
 //     ogimg          MERGING          in the merge train
-//     deps           DONE             recap + merged PR + one owed manual step
+//     deps           DONE             recap + merged PR + one owed (post-merge) manual step
+//     envflag        DONE             merged PR + one un-acked PRE-merge step (#1478 showcase)
 //     checkout-child WORKING (auto)   epic child, drain-spawned
 // Session ids are STABLE + semantic — replay transcripts (Task 5) and the director
 // (Task 6) key off them.
@@ -236,6 +237,33 @@ function buildSessions(): Session[] {
       ],
       manualStepsAckedAt: null,
     }),
+    // ── done: merged, but an un-acked PRE-merge manual step slipped through — the
+    // merged-card "Resolve N step(s)" showcase (#1478). Unlike deps' post-merge step,
+    // this one is `postMerge: false`, so `hasBlockingManualSteps` in UnitRow is true
+    // right up until Ack/Resolve — but the terminal (merged) card hides the moot Ack
+    // CTA and verb-labels the chip instead, routing to the matching Owed record below.
+    mkSession({
+      id: "envflag",
+      desig: "TASK-50",
+      name: "feature-x-rollout",
+      repoPath: STOREFRONT,
+      branch: "shepherd/feature-x-rollout",
+      prompt: "Roll out the new checkout speed test behind a FEATURE_X flag",
+      model: "sonnet",
+      status: "done",
+      issueNumber: 150,
+      lastState: "done",
+      createdAt: NOW - 8 * HOUR,
+      updatedAt: NOW - 70 * MIN,
+      manualSteps: [
+        {
+          id: "envflag-ms-1",
+          text: "Set the FEATURE_X env var in production",
+          postMerge: false,
+        },
+      ],
+      manualStepsAckedAt: null,
+    }),
     // ── working (autopilot): epic child spawned by the drain ────────────────
     mkSession({
       id: "checkout-child",
@@ -381,6 +409,21 @@ function buildGitStates(): Record<string, GitState> {
       deployConfigured: true,
       headSha: "c7d8e9f",
       issueUrl: `${gh(STOREFRONT)}/issues/137`,
+    },
+    // done — merged, but a pre-merge manual step is still un-acked (#1478 showcase).
+    envflag: {
+      kind: "github",
+      state: "merged",
+      number: 520,
+      url: `${gh(STOREFRONT)}/pull/520`,
+      title: "TASK-50: roll out feature X behind env flag",
+      createdAt: NOW - 8 * HOUR,
+      mergeable: true,
+      checks: "success",
+      mergeStateStatus: "clean",
+      deployConfigured: true,
+      headSha: "f1a2b3c",
+      issueUrl: `${gh(STOREFRONT)}/issues/150`,
     },
     // epic child — building; no PR yet.
     "checkout-child": { kind: "github", state: "none", checks: "none", deployConfigured: true },
@@ -1471,10 +1514,13 @@ function buildTodo(): Record<string, { exists: boolean; content: string }> {
 }
 
 /** GET /api/manual-steps/outstanding (Owed lens) — durable post-merge step records.
- *  One row: `deps`'s single owed step (mirrors its `holdStates` entry + `manualSteps`
- *  above). Svelte's `{#each}` silently no-ops on the permissive `{}` fallback
+ *  Two rows: `deps`'s single owed (post-merge) step (mirrors its `holdStates` entry +
+ *  `manualSteps` above), and `envflag`'s un-acked PRE-merge step (#1478 merged-card
+ *  showcase — its `manualSteps`/`gitStates` entries above are the same session/step
+ *  id so the Owed lens shows a real, workable checklist for the "Resolve" chip).
+ *  Svelte's `{#each}` silently no-ops on the permissive `{}` fallback
  *  (`Array.from({})` → `[]`), so this gap never threw — it just left a showcased lens
- *  silently empty instead of showing the one owed step the seed already promises. */
+ *  silently empty instead of showing the owed steps the seed already promises. */
 function buildPostMergeSteps(): PostMergeSteps[] {
   return [
     {
@@ -1495,6 +1541,26 @@ function buildPostMergeSteps(): PostMergeSteps[] {
       trackingIssueNumber: null,
       createdAt: NOW - 45 * MIN,
       updatedAt: NOW - 45 * MIN,
+      clearedAt: null,
+    },
+    {
+      sessionId: "envflag",
+      desig: "TASK-50",
+      repoPath: STOREFRONT,
+      prNumber: 520,
+      prTitle: "TASK-50: roll out feature X behind env flag",
+      steps: [
+        {
+          id: "envflag-ms-1",
+          text: "Set the FEATURE_X env var in production",
+          postMerge: false,
+          doneAt: null,
+        },
+      ],
+      trackingIssueUrl: null,
+      trackingIssueNumber: null,
+      createdAt: NOW - 70 * MIN,
+      updatedAt: NOW - 70 * MIN,
       clearedAt: null,
     },
   ];

--- a/ui/src/lib/demo/state.test.ts
+++ b/ui/src/lib/demo/state.test.ts
@@ -68,11 +68,20 @@ describe("demoState.reset() → bootstrap getters", () => {
   });
 });
 
-describe("the rich 7-session scenario is seeded coherently", () => {
-  it("all seven stable session ids are present with the expected states", () => {
+describe("the rich 8-session scenario is seeded coherently", () => {
+  it("all eight stable session ids are present with the expected states", () => {
     const byId = new Map(demoState.sessions().map((s) => [s.id, s]));
     expect([...byId.keys()].sort()).toEqual(
-      ["authstore", "checkout-child", "coupon", "deps", "neon", "ogimg", "rounding"].sort(),
+      [
+        "authstore",
+        "checkout-child",
+        "coupon",
+        "deps",
+        "envflag",
+        "neon",
+        "ogimg",
+        "rounding",
+      ].sort(),
     );
     expect(byId.get("coupon")!.status).toBe("running");
     expect(byId.get("coupon")!.lastState).toBe("working");
@@ -85,6 +94,10 @@ describe("the rich 7-session scenario is seeded coherently", () => {
     expect(byId.get("ogimg")!.mergingSince).not.toBeNull();
     expect(byId.get("deps")!.status).toBe("done");
     expect(byId.get("deps")!.manualSteps.length).toBeGreaterThan(0);
+    expect(byId.get("envflag")!.status).toBe("done");
+    expect(byId.get("envflag")!.manualSteps.length).toBeGreaterThan(0);
+    expect(byId.get("envflag")!.manualSteps[0].postMerge).toBe(false);
+    expect(byId.get("envflag")!.manualStepsAckedAt).toBeNull();
     expect(byId.get("checkout-child")!.autopilotEnabled).toBe(true);
   });
 
@@ -111,6 +124,7 @@ describe("the rich 7-session scenario is seeded coherently", () => {
     expect(git.rounding.checks).toBe("success");
     expect(git.ogimg.state).toBe("open"); // in merge train
     expect(git.deps.state).toBe("merged"); // done
+    expect(git.envflag.state).toBe("merged"); // done, un-acked pre-merge step (#1478)
   });
 
   it("holds cover the blocked question and the owed manual step", () => {
@@ -263,8 +277,8 @@ describe("demoState mutators emit the correct WsEvent frames", () => {
     expect(demoState.sessions().find((s) => s.id === "coupon")).toBeUndefined();
   });
 
-  it("mergedClearable returns the merged, non-archived deps session", () => {
-    expect(demoState.mergedClearable()).toEqual({ ids: ["deps"], leftovers: 0 });
+  it("mergedClearable returns the merged, non-archived deps + envflag sessions", () => {
+    expect(demoState.mergedClearable()).toEqual({ ids: ["deps", "envflag"], leftovers: 0 });
   });
 
   it("clearMerged archives the merged ids, emits session:archived, and deps disappears", () => {
@@ -273,7 +287,8 @@ describe("demoState mutators emit the correct WsEvent frames", () => {
     expect(events(frames)).toEqual(["session:archived"]);
     expect(result).toEqual({ cleared: ["deps"], leftovers: 0 });
     expect(demoState.sessions().find((s) => s.id === "deps")).toBeUndefined();
-    expect(demoState.mergedClearable()).toEqual({ ids: [], leftovers: 0 });
+    // envflag is still merged + un-archived, so it's still offered.
+    expect(demoState.mergedClearable()).toEqual({ ids: ["envflag"], leftovers: 0 });
   });
 
   it("clearMerged skips ids that aren't actually merged", () => {

--- a/ui/src/lib/demo/state.ts
+++ b/ui/src/lib/demo/state.ts
@@ -453,6 +453,18 @@ export const demoState = {
     return rec;
   },
 
+  /** Acknowledge a session's manual operator steps (#1060) — stamp manualStepsAckedAt
+   *  idempotently and emit session:manual-steps so the CTA clears (mirrors the server). */
+  ackManualSteps(id: string): void {
+    const s = find(id);
+    if (!s) return;
+    s.manualStepsAckedAt ??= Date.now(); // COALESCE — keep the first ack time
+    emit({
+      event: "session:manual-steps",
+      data: { id, manualSteps: s.manualSteps, manualStepsAckedAt: s.manualStepsAckedAt },
+    });
+  },
+
   /** Archive every given id that's still merged (the server re-validates, same as
    *  the real API) — clears the herd's "Merged" group. Matches `clearMerged()`'s
    *  `{cleared, leftovers}` in api.ts; each archive emits its own `session:archived`. */

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -2385,6 +2385,9 @@
       owedFocusNonce += 1; // bump so re-clicking the same session re-fires
     }
     herdFilter = "owed";
+    // Force an on-demand refresh so a click on the chip never shows a client-stale
+    // frozen set (#1478) — the loaded-guarded loads above only fire once.
+    void postMergeStepsStore.load();
   }
 
   // Reports the panel's resolution of a focus click (live scroll+flash, frozen fallback, or a


### PR DESCRIPTION
## Problem

On a **merged (GEMERGT)** card, clicking **"Schritte best."** (the #1060 *Ack steps* button) produced no visible effect — the manual steps couldn't be worked off from the HUD (#1478).

## Root cause (two things, one confirmed here)

1. **The ack button was literally unclickable.** `.manual-steps-ack` was missing `position: relative; z-index: 1`, so it sat *under* the row's full-bleed `.unit-hit` click overlay (its sibling `.chip-manual-steps--link` already has this exact recipe). A click landed on the overlay, not the button — no ack POST, no toast, "nothing happens." This surfaced as a real Playwright click-timeout while writing the open-card test, and is the concrete, confirmed explanation for the reported symptom on a healthy build.
2. **On a terminal card the ack button is moot anyway.** Post-merge/close there is no auto-merge gate left to clear, and acking never resolves the durable Owed record. The actual resolution route — the count chip that links to the Owed lens — was passive (a neutral count) and got bypassed for the verb-shaped button.

## Change

**UI (`fix(herd)`)**
- Add `isMerged` / `isTerminal` deriveds (`isTerminal = merged || closed`, matching the existing `stepperTerminal`).
- **Drop the moot ack button on terminal (merged/closed) cards** (`!isTerminal` gate); open-PR behavior unchanged (it still clears the real auto-merge gate).
- **Give merged cards a verb affordance:** relabel the count chip to `Resolve N step(s)` → the Owed lens (per-step checklist + dismiss), so the resolution route reads as the action the operator reaches for.
- **Fix the unclickable ack button** (`position: relative; z-index: 1`), repairing the still-live pre-merge ack CTA too.
- `onShowOwed` now force-refreshes the outstanding set (`postMergeStepsStore.load()`) so a client that missed a `post-merge-steps:changed` frame lands on the live workable record, not the read-only frozen fallback. (Owed tick/dismiss are POST-response-driven, so resolution works regardless of WS delivery.)
- New i18n key `unitrow_resolve_manual_steps` (EN + DE).

**Demo (`chore(demo)`)**
- Add the missing `POST /api/sessions/:id/ack-manual-steps` route + `demoState.ackManualSteps` (mirrors the server: idempotent stamp + `session:manual-steps` emit) so the pre-merge ack CTA is faithful in demo.
- A merged `envflag` showcase card (session + merged git state + outstanding owed record) exercising the new merged-card verb chip.

## Design notes / trade-offs

- **Merged card with declared steps but no outstanding record** (resolved/dismissed): the verb chip → Owed lens shows the accurate `owed_frozen_cleared_note` ("no longer owed"). Intentional; the note is only misleading in the narrow *never-materialized* case (see below).
- I deliberately kept this **minimal** — no `owedRecord` threading / record-gating / mobile eager-GET, which an earlier draft explored but which regressed the resolved-state signal and didn't earn its keep (the frozen card is informative, not a hard dead-end).

## Closing criterion (why `Refs`, not `Fixes`)

Refs #1478. The described "click does nothing" symptom is resolved here (the button is now clickable and, on merged cards, replaced by a working verb affordance). One case this UI change cannot resolve on its own: if the reporter's session has **no materialized Owed record** (server-side non-materialization), the Owed lens shows the read-only frozen card and the steps still can't be ticked/dismissed — that closer is a separate **#1061** materialization-reliability fix. Please confirm on the affected instance that its record materializes (`GET /api/manual-steps/outstanding` includes the session / the Owed lens is workable) before closing #1478; if it doesn't, hand off to #1061.

## Verification

- `cd ui && bun run check` (svelte-check 0/0 + `check:i18n` parity) ✓
- UnitRow browser tests 55/55 (open = ack present + neutral label; merged = ack absent + verb label + click→onshowowed; closed = ack absent + neutral label) ✓
- Demo router/state tests (ack route → 200 + `session:manual-steps` with non-null `ackedAt`; seed invariants) ✓
- Full suites green (UI browser 1176, node 2180); pre-push gate (branch-hygiene, feature-catalog, glossary, fallow audit — complexity 0) ✓

[no-feature-entry] — a bug fix; the demo changes ship no new user-facing product UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
