### PR TITLE
feat(drain): surface + auto-rerun CI-failing epic landing PRs

### DIFF
--- a/src/completed-epic.ts
+++ b/src/completed-epic.ts
@@ -43,6 +43,8 @@ export interface CompletedEpic {
   landingReady?: boolean;
   /** True when an open+ready landing has sat unlanded past EPIC_LANDING_STRANDED_MS (Rec D escalation). */
   landingStranded?: boolean;
+  /** Live, non-persisted: the landing PR's CI is terminally failing (not behind/conflicting). */
+  landingCiFailing?: boolean;
 }
 
 /** Rec D threshold: surface the "stranded" escalation when an open+ready landing PR has sat
@@ -101,7 +103,7 @@ export interface EnrichLandingDeps {
 }
 
 /** Enrich each OPEN-landing completed epic in `rows` with live landing-PR gate signals
- *  (`landingChecks`/`landingMergeable`/`landingReady`/`landingStranded`), mutating in place.
+ *  (`landingChecks`/`landingMergeable`/`landingReady`/`landingStranded`/`landingCiFailing`), mutating in place.
  *  Best-effort + fail-safe per row: a missing branch/forge or a forge error simply leaves that
  *  row's live fields undefined — never throws. Shared by GET /api/epics/completed and the rundown's
  *  landing-ready accessor so both compute readiness identically. */
@@ -128,6 +130,10 @@ export async function enrichLandingEpics(
           completedAt: row.completedAt,
           now: deps.now,
         });
+        // A terminally-failing landing PR that is NOT behind/conflicting (those are owned by the
+        // rebase pass's landingRebasePauseReason). Surfaced as a distinct Tier-1 item (index.ts).
+        row.landingCiFailing =
+          pr.checks === "failure" && pr.mergeStateStatus !== "behind" && pr.mergeable !== false;
       } catch {
         // leave live fields undefined — callers always serve/return the base DB rows
       }

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -70,6 +70,10 @@ const EPIC_RECONCILE_TTL_MS = 5 * 60_000;
  *  forge calls. Bounds the cost of a permanently-broken landing (no perpetual retry). */
 const MAX_LANDING_ATTEMPTS = 5;
 
+/** Per-head-SHA budget of automatic failed-CI reruns for a red epic landing PR before we stop and
+ *  leave it to the operator-facing `landingCiFailing` surfacing. A new head resets the budget. */
+const LANDING_RERUN_CAP = 2;
+
 /** Auto-land merge-error guardrails (#1044) — mirror AutoMergeService's per-head cap + backoff.
  *  After this many consecutive merge failures on the SAME landing-PR head, back the epic off so it
  *  stops re-firing forge.merge each tick; one retry per backoff window thereafter. In-memory only
@@ -231,6 +235,8 @@ export class DrainService {
   // same landingAttempts → lose an increment. This set makes the second invocation a
   // no-op; it'll be retried next tick anyway.
   private landingInFlight = new Set<string>();
+  /** repoPath#parent#headSha → count of automatic landing-CI reruns spent on that head (C). */
+  private landingRerunCount = new Map<string, number>();
   // Auto-land (#1044) per-epic merge-error backoff, keyed `${repoPath}#${parentIssueNumber}`:
   // consecutive merge failures on the current landing-PR head + when the epic is blocked until.
   // A new head or a success clears the entry. In-memory (ephemeral); mirrors AutoMergeService.
@@ -1320,6 +1326,88 @@ export class DrainService {
   }
 
   /**
+   * C: auto-rerun the failed CI on a red epic landing PR (flake absorption). Runs each tick between
+   * rebaseStuckLandingPrsForRepo (owns behind/conflict) and autoLandLandingPrsForRepo (lands green).
+   * GitHub-only (rerun API is GitHub-specific), engaged-gated, capped per head, fail-closed, and
+   * `landingInFlight`-serialized (shared key namespace with the other landing passes).
+   * NEVER merges — a rerun that greens is landed by tryAutoLandEpic / the manual CTA; a red one that
+   * exhausts its budget is surfaced by `landingCiFailing` (index.ts).
+   */
+  private async rerunRedLandingCiForRepo(repoPath: string): Promise<void> {
+    const cfg = this.deps.store.getRepoConfig(repoPath);
+    const er = this.deps.store.getEpicRun(repoPath);
+    const engaged =
+      !cfg.draftMode && (cfg.autoMergeEnabled || cfg.autoDrainEnabled || er?.status === "running");
+    if (!engaged) return;
+    const forge = this.deps.resolveForge(repoPath);
+    if (!forge || forge.kind !== "github") return;
+    // Capability gate (both are optional on GitForge — GitHub-only). Capture locals so TS keeps the
+    // non-undefined narrowing across the awaits below.
+    const latestFailedRunForPr = forge.latestFailedRunForPr;
+    const rerunWorkflowRun = forge.rerunWorkflowRun;
+    if (!latestFailedRunForPr || !rerunWorkflowRun) return;
+
+    const open = this.deps.store
+      .listEpicCompleted(repoPath)
+      .filter((r) => r.landingState === "open" && r.landingPrNumber != null);
+    if (open.length === 0) return;
+
+    for (const row of open) {
+      const parent = row.parentIssueNumber;
+      const key = `${repoPath}#${parent}`;
+      if (this.landingInFlight.has(key)) continue;
+      this.landingInFlight.add(key);
+      try {
+        await this.processRedLandingRerun(
+          repoPath,
+          forge,
+          parent,
+          row.landingPrNumber!,
+          latestFailedRunForPr,
+          rerunWorkflowRun,
+        );
+      } catch (err) {
+        console.warn(`[drain] rerunRedLandingCiForRepo failed for ${key}:`, err);
+      } finally {
+        this.landingInFlight.delete(key);
+      }
+    }
+  }
+
+  /** Process one open landing row: rerun its failed CI iff terminally red, mergeable, not behind,
+   *  not draft, and under the per-head budget. Serialized by the caller via landingInFlight. */
+  private async processRedLandingRerun(
+    repoPath: string,
+    forge: GitForge,
+    parent: number,
+    prNumber: number,
+    latestFailedRunForPr: (prNumber: number) => Promise<number | null>,
+    rerunWorkflowRun: (runId: number, o: { failedOnly: boolean }) => Promise<void>,
+  ): Promise<void> {
+    const branch = this.deps.store.getEpicIntegrationBranch(repoPath, parent);
+    if (branch === null) return;
+    const pr = await forge.prStatus(branch);
+    if (pr.state !== "open" || pr.isDraft) return;
+    // Only a TERMINAL failure on an otherwise-mergeable, not-behind PR. behind/conflicting → the rebase
+    // pass; pending/none/success → nothing to rerun.
+    if (pr.checks !== "failure" || pr.mergeStateStatus === "behind" || pr.mergeable === false)
+      return;
+
+    const head = pr.headSha ?? "";
+    const cntKey = `${repoPath}#${parent}#${head}`;
+    const used = this.landingRerunCount.get(cntKey) ?? 0;
+    if (used >= LANDING_RERUN_CAP) return; // budget spent on this head → leave to landingCiFailing
+
+    const runId = await latestFailedRunForPr(prNumber);
+    if (runId == null) return; // fork-origin PR / no failed run resolvable
+    await rerunWorkflowRun(runId, { failedOnly: true });
+    this.landingRerunCount.set(cntKey, used + 1);
+    console.warn(
+      `[drain] rerunning failed landing CI for ${repoPath}#${parent} (run ${runId}, ${used + 1}/${LANDING_RERUN_CAP})`,
+    );
+  }
+
+  /**
    * AUTO-LAND (#1044): opt-in autonomous merge of a completed epic's aggregate landing PR. Runs in
    * {@link tick} alongside {@link ensureLandingPrsForRepo} — the session-less landing PR has no
    * managed session, so it can't ride the session-owned `AutoMergeService`; the drain (which
@@ -2164,6 +2252,9 @@ export class DrainService {
       // internally (automation-engaged check + GitHub-only + DB-gate → zero forge calls in
       // steady state). UNGATED by drain, like its neighbors.
       await this.rebaseStuckLandingPrsForRepo(repoPath);
+      // C: auto-rerun a red (flaky) landing PR's failed CI before the auto-land pass sees it —
+      // GitHub-only, capped per head, never merges. UNGATED like the passes around it.
+      await this.rerunRedLandingCiForRepo(repoPath);
       // #1044: opt-in auto-land of open landing PRs (gated internally on the repo's auto-merge
       // opt-in → zero forge calls when off). UNGATED by drain, like ensureLandingPrsForRepo.
       await this.autoLandLandingPrsForRepo(repoPath);

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -235,8 +235,10 @@ export class DrainService {
   // same landingAttempts → lose an increment. This set makes the second invocation a
   // no-op; it'll be retried next tick anyway.
   private landingInFlight = new Set<string>();
-  /** repoPath#parent#headSha → count of automatic landing-CI reruns spent on that head (C). */
-  private landingRerunCount = new Map<string, number>();
+  /** Automatic landing-CI reruns (C), keyed `${repoPath}#${parentIssueNumber}` → the current head +
+   *  reruns spent on it. A new head replaces the entry (reset), and a successful/terminal land deletes
+   *  it — so the map stays bounded to live epics, mirroring `landMergeFail`. In-memory (ephemeral). */
+  private landingRerunCount = new Map<string, { head: string; count: number }>();
   // Auto-land (#1044) per-epic merge-error backoff, keyed `${repoPath}#${parentIssueNumber}`:
   // consecutive merge failures on the current landing-PR head + when the epic is blocked until.
   // A new head or a success clears the entry. In-memory (ephemeral); mirrors AutoMergeService.
@@ -1394,14 +1396,16 @@ export class DrainService {
       return;
 
     const head = pr.headSha ?? "";
-    const cntKey = `${repoPath}#${parent}#${head}`;
-    const used = this.landingRerunCount.get(cntKey) ?? 0;
+    const key = `${repoPath}#${parent}`;
+    // A new head resets the budget (new commits = a fresh failure to absorb); same head accumulates.
+    const prior = this.landingRerunCount.get(key);
+    const used = prior && prior.head === head ? prior.count : 0;
     if (used >= LANDING_RERUN_CAP) return; // budget spent on this head → leave to landingCiFailing
 
     const runId = await latestFailedRunForPr(prNumber);
     if (runId == null) return; // fork-origin PR / no failed run resolvable
     await rerunWorkflowRun(runId, { failedOnly: true });
-    this.landingRerunCount.set(cntKey, used + 1);
+    this.landingRerunCount.set(key, { head, count: used + 1 });
     console.warn(
       `[drain] rerunning failed landing CI for ${repoPath}#${parent} (run ${runId}, ${used + 1}/${LANDING_RERUN_CAP})`,
     );
@@ -1507,6 +1511,7 @@ export class DrainService {
       return;
     }
     this.landMergeFail.delete(key); // success clears any backoff
+    this.landingRerunCount.delete(key); // landed → drop the rerun budget entry
     this.reconcileAutoLand(repoPath, parentIssueNumber, "merged", pr);
   }
 
@@ -1535,11 +1540,13 @@ export class DrainService {
     }
     if (live && live.state === "merged") {
       this.landMergeFail.delete(key);
+      this.landingRerunCount.delete(key); // terminal → drop the rerun budget entry
       this.reconcileAutoLand(repoPath, parentIssueNumber, "merged", live);
       return;
     }
     if (live && (live.state === "closed" || live.state === "none")) {
       this.landMergeFail.delete(key);
+      this.landingRerunCount.delete(key); // terminal → drop the rerun budget entry
       this.reconcileAutoLand(repoPath, parentIssueNumber, "none", live);
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1841,6 +1841,7 @@ const landingReadyEpics = async (): Promise<RundownEpicItem[]> => {
       title: r.parentTitle,
       landingPr: r.landingPrNumber,
       stranded: false, // paused items are not "stranded" (different escalation path)
+      ciFailing: false,
       pausedReason: r.landingRebasePauseReason as "cap" | "conflict" | "driver",
     }));
 
@@ -1876,6 +1877,7 @@ const landingReadyEpics = async (): Promise<RundownEpicItem[]> => {
       title: e.parentTitle,
       landingPr: e.landingPrNumber,
       stranded: e.landingStranded === true,
+      ciFailing: false,
     }));
 
   // CI-failing rows (terminal red, not behind/conflicting): surface as a distinct Tier-1 item. `epics`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1878,7 +1878,21 @@ const landingReadyEpics = async (): Promise<RundownEpicItem[]> => {
       stranded: e.landingStranded === true,
     }));
 
-  const val: RundownEpicItem[] = [...pausedItems, ...readyItems];
+  // CI-failing rows (terminal red, not behind/conflicting): surface as a distinct Tier-1 item. `epics`
+  // already excludes paused rows; a red row has landingReady=false so it is not in readyItems either —
+  // so each open row lands under exactly one heading.
+  const ciFailingItems: RundownEpicItem[] = epics
+    .filter((e) => e.landingState === "open" && e.landingCiFailing === true)
+    .map((e) => ({
+      repo: e.repoPath,
+      parent: e.parentIssueNumber,
+      title: e.parentTitle,
+      landingPr: e.landingPrNumber,
+      stranded: false,
+      ciFailing: true,
+    }));
+
+  const val: RundownEpicItem[] = [...pausedItems, ...readyItems, ...ciFailingItems];
   epicReadyCache = { key, ts: now, val };
   return val;
 };

--- a/src/rundown-core.ts
+++ b/src/rundown-core.ts
@@ -568,7 +568,8 @@ export function buildRundownPrompt(
 
   if (assembled.epics.length > 0) {
     const pausedEpics = assembled.epics.filter((e) => e.pausedReason != null);
-    const readyEpics = assembled.epics.filter((e) => e.pausedReason == null);
+    const readyEpics = assembled.epics.filter((e) => e.pausedReason == null && !e.ciFailing);
+    const ciFailingEpics = assembled.epics.filter((e) => e.ciFailing === true);
     const pauseReasonLabel = (r: "cap" | "conflict" | "driver"): string => {
       if (r === "cap") return "rebase cap exhausted — needs manual rebase/push";
       if (r === "conflict") return "genuine merge conflict — needs operator resolution";
@@ -604,6 +605,17 @@ export function buildRundownPrompt(
             `    - ${e.repo} #${e.parent} "${e.title}"` +
             (e.landingPr != null ? ` (landing PR #${e.landingPr})` : "") +
             (e.stranded ? " [STRANDED — unlanded well past threshold]" : ""),
+        ),
+      );
+    }
+    if (ciFailingEpics.length > 0) {
+      lines.push("  CI failing (landing PR red — needs attention):");
+      lines.push(
+        ...ciFailingEpics.map(
+          (e) =>
+            `    - ${e.repo} #${e.parent} "${e.title}"` +
+            (e.landingPr != null ? ` (landing PR #${e.landingPr})` : "") +
+            " [CI FAILING — needs attention]",
         ),
       );
     }

--- a/src/store.ts
+++ b/src/store.ts
@@ -2821,6 +2821,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
         title: typeof o.title === "string" ? o.title : "",
         landingPr: typeof o.landingPr === "number" ? o.landingPr : null,
         stranded: o.stranded === true,
+        ciFailing: o.ciFailing === true,
       });
     }
     return out;

--- a/src/types.ts
+++ b/src/types.ts
@@ -639,6 +639,10 @@ export interface RundownEpicItem {
   stranded: boolean;
   /** Present when the auto-rebase pass is paused and operator action is needed (#1071). */
   pausedReason?: "cap" | "conflict" | "driver";
+  /** When true, the landing PR's CI is failing (terminal `checks:"failure"`, and NOT
+   *  behind/conflicting — those are the rebase pass's `pausedReason`). A distinct Tier-1 attention
+   *  item: not "ready", not "paused". */
+  ciFailing?: boolean;
 }
 
 /** The LLM-authored verdict the rundown spawn writes to `.shepherd-rundown.json`. */

--- a/test/completed-epic-cifailing.test.ts
+++ b/test/completed-epic-cifailing.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+import { enrichLandingEpics } from "../src/completed-epic";
+import type { CompletedEpic } from "../src/completed-epic";
+import type { PrStatus } from "../src/forge/types";
+
+// ── enrichLandingEpics: landingCiFailing ─────────────────────────────────────
+
+describe("enrichLandingEpics — landingCiFailing", () => {
+  const baseEpic = (over: Partial<CompletedEpic> = {}): CompletedEpic => ({
+    repoPath: "/repo/a",
+    parentIssueNumber: 7,
+    parentTitle: "Epic A",
+    completedAt: 1_000,
+    children: [],
+    landingPrNumber: 42,
+    landingPrUrl: "http://x/42",
+    landingState: "open",
+    migrationPaths: [],
+    migrationsAckedAt: null,
+    landingRebasePauseReason: null,
+    ...over,
+  });
+
+  const prStatus = (over: Partial<PrStatus> = {}): PrStatus =>
+    ({ state: "open", checks: "success", mergeable: true, ...over }) as PrStatus;
+
+  it("checks:failure + mergeable:true + mergeStateStatus:clean → landingCiFailing true", async () => {
+    const rows = [baseEpic()];
+    await enrichLandingEpics(rows, {
+      getEpicIntegrationBranch: () => "epic/7",
+      resolveForge: () => ({
+        kind: "local",
+        prStatus: async () =>
+          prStatus({ checks: "failure", mergeable: true, mergeStateStatus: "clean" }),
+      }),
+      now: 0,
+    });
+    expect(rows[0]?.landingCiFailing).toBe(true);
+  });
+
+  it("checks:failure + mergeStateStatus:behind → landingCiFailing false (rebase-owned)", async () => {
+    const rows = [baseEpic()];
+    await enrichLandingEpics(rows, {
+      getEpicIntegrationBranch: () => "epic/7",
+      resolveForge: () => ({
+        kind: "local",
+        prStatus: async () =>
+          prStatus({ checks: "failure", mergeable: true, mergeStateStatus: "behind" }),
+      }),
+      now: 0,
+    });
+    expect(rows[0]?.landingCiFailing).toBe(false);
+  });
+
+  it("checks:failure + mergeable:false → landingCiFailing false (conflict-owned)", async () => {
+    const rows = [baseEpic()];
+    await enrichLandingEpics(rows, {
+      getEpicIntegrationBranch: () => "epic/7",
+      resolveForge: () => ({
+        kind: "local",
+        prStatus: async () =>
+          prStatus({ checks: "failure", mergeable: false, mergeStateStatus: "clean" }),
+      }),
+      now: 0,
+    });
+    expect(rows[0]?.landingCiFailing).toBe(false);
+  });
+
+  it("checks:success → landingCiFailing false", async () => {
+    const rows = [baseEpic()];
+    await enrichLandingEpics(rows, {
+      getEpicIntegrationBranch: () => "epic/7",
+      resolveForge: () => ({
+        kind: "local",
+        prStatus: async () =>
+          prStatus({ checks: "success", mergeable: true, mergeStateStatus: "clean" }),
+      }),
+      now: 0,
+    });
+    expect(rows[0]?.landingCiFailing).toBe(false);
+  });
+});

--- a/test/drain-epic-landing-rerun.test.ts
+++ b/test/drain-epic-landing-rerun.test.ts
@@ -387,6 +387,28 @@ describe("rerunRedLandingCiForRepo (C)", () => {
     expect(h.spy.rerunCalls).toHaveLength(CAP + 1);
   });
 
+  test("bounded map: successive heads on one landing keep a SINGLE per-parent entry (not one per head)", async () => {
+    let head = "h1";
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => redPr({ headSha: head }),
+      latestFailedRunForPr: async () => 42,
+    });
+    seedOpenLanding(h);
+
+    for (const nextHead of ["h1", "h2", "h3"]) {
+      head = nextHead;
+      await callRerunPass(h);
+    }
+
+    // The old per-head-SHA keying grew one entry per head (would be 3 here) and never evicted; the
+    // per-`repoPath#parent` keying self-replaces on each new head, so the map stays bounded to live
+    // epics. This is the regression guard for the unbounded-growth finding.
+    const map = (h.drain as unknown as { landingRerunCount: Map<string, unknown> })
+      .landingRerunCount;
+    expect(map.size).toBe(1);
+  });
+
   // ── skip cases (no rerun) ────────────────────────────────────────────────────
 
   test("skips: mergeStateStatus=behind (rebase pass's territory)", async () => {

--- a/test/drain-epic-landing-rerun.test.ts
+++ b/test/drain-epic-landing-rerun.test.ts
@@ -1,0 +1,483 @@
+/**
+ * Tests for the (C) drain-tick pass — `rerunRedLandingCiForRepo` in drain.ts.
+ *
+ * Auto-reruns the failed CI on a red epic landing PR (flake absorption), capped per head SHA.
+ * GitHub-only; never merges. Runs between rebaseStuckLandingPrsForRepo and autoLandLandingPrsForRepo.
+ */
+import { test, expect, describe } from "bun:test";
+import { DrainService } from "../src/drain";
+import { SessionStore } from "../src/store";
+import type { GitForge, Issue, PrStatus, SubIssueRef } from "../src/forge/types";
+import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
+import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
+import type { CompletedEpic } from "../src/completed-epic";
+import { epicIntegrationBranch } from "../src/epic-branch";
+
+const REPO = "/repo";
+const PARENT = 327;
+const PARENT_TITLE = "EFI cluster";
+const INTEGRATION_BRANCH = epicIntegrationBranch(PARENT, PARENT_TITLE); // epic/327-efi-cluster
+const LANDING_PR = 555;
+
+const NO_USAGE: UsageLimitsType = {
+  session5h: null,
+  week: null,
+  perModelWeek: [],
+  credits: null,
+  stale: false,
+  calibratedAt: null,
+  subscriptionOnly: false,
+};
+
+/** A red (terminally failed CI), otherwise-landable PR — the target of this pass. */
+function redPr(over: Partial<PrStatus> = {}): PrStatus {
+  return {
+    state: "open",
+    number: LANDING_PR,
+    url: `https://github.com/o/r/pull/${LANDING_PR}`,
+    checks: "failure",
+    mergeable: true,
+    mergeStateStatus: "clean",
+    headSha: "h1",
+    isDraft: false,
+    deployConfigured: false,
+    ...over,
+  };
+}
+
+interface RerunCall {
+  runId: number;
+  failedOnly: boolean;
+}
+
+interface ForgeSpy {
+  forge: GitForge;
+  prStatusCalls: string[];
+  rerunCalls: RerunCall[];
+  latestFailedRunCalls: number[];
+}
+
+function fakeForge(opts: {
+  kind?: "github" | "gitea" | "local";
+  prStatus?: (branch: string) => Promise<PrStatus>;
+  latestFailedRunForPr?: (prNumber: number) => Promise<number | null>;
+  /** When false, omit rerunWorkflowRun/latestFailedRunForPr entirely (capability-missing case). */
+  hasRerunCapability?: boolean;
+}): ForgeSpy {
+  const prStatusCalls: string[] = [];
+  const rerunCalls: RerunCall[] = [];
+  const latestFailedRunCalls: number[] = [];
+  const hasCap = opts.hasRerunCapability ?? true;
+
+  const forge: GitForge = {
+    kind: opts.kind ?? "github",
+    slug: "o/r",
+    mergeMethod: "squash",
+    deployWorkflow: null,
+    listIssues: async () => [],
+    listPullRequests: async () => [],
+    listBacklogCounts: async () => EMPTY_BACKLOG_COUNTS,
+    prStatus: async (branch: string) => {
+      prStatusCalls.push(branch);
+      return (
+        (await opts.prStatus?.(branch)) ??
+        ({ state: "none", checks: "none", deployConfigured: false } as PrStatus)
+      );
+    },
+    openPr: async () => ({ state: "open", checks: "none", deployConfigured: false }) as PrStatus,
+    defaultBranch: async () => "main",
+    merge: async () => {
+      throw new Error("merge should never be called by the rerun pass");
+    },
+    redeploy: async () => {},
+    postReview: async () => ({}),
+    closeIssue: async () => {},
+    ensureIssueLink: async () => {},
+    addIssueLabel: async () => {},
+    removeIssueLabel: async () => {},
+    getIssue: async (): Promise<Issue | null> => null,
+    listSubIssues: async (): Promise<SubIssueRef[]> => [],
+    listBlockedBy: async () => [],
+    ...(hasCap
+      ? {
+          latestFailedRunForPr: async (prNumber: number) => {
+            latestFailedRunCalls.push(prNumber);
+            return (await opts.latestFailedRunForPr?.(prNumber)) ?? null;
+          },
+          rerunWorkflowRun: async (runId: number, o: { failedOnly: boolean }) => {
+            rerunCalls.push({ runId, failedOnly: o.failedOnly });
+          },
+        }
+      : {}),
+  };
+  return { forge, prStatusCalls, rerunCalls, latestFailedRunCalls };
+}
+
+interface Harness {
+  store: SessionStore;
+  drain: DrainService;
+  completedEmits: CompletedEpic[];
+  spy: ForgeSpy;
+}
+
+function makeHarness(opts: {
+  autoMergeEnabled?: boolean;
+  autoDrainEnabled?: boolean;
+  epicRunning?: boolean;
+  draftMode?: boolean;
+  prStatus?: (branch: string) => Promise<PrStatus>;
+  latestFailedRunForPr?: (prNumber: number) => Promise<number | null>;
+  /** When false, use a gitea forge (non-github). */
+  github?: boolean;
+  hasRerunCapability?: boolean;
+}): Harness {
+  const store = new SessionStore(":memory:");
+  store.setRepoConfig(REPO, {
+    criticEnabled: false,
+    criticAllPrs: false,
+    autoAddressEnabled: false,
+    learningsEnabled: false,
+    autopilotEnabled: false,
+    planGateEnabled: false,
+    autoDrainEnabled: opts.autoDrainEnabled ?? false,
+    autoMergeEnabled: opts.autoMergeEnabled ?? false,
+    buildQueueEnabled: false,
+    draftMode: opts.draftMode ?? false,
+    signoffAuthority: "human",
+    maxAuto: 2,
+    autoLabel: "shepherd:auto",
+    usageCeilingPct: 80,
+    sandboxProfile: "trusted",
+    defaultModel: "inherit",
+    defaultEffort: "inherit",
+    previewOpenMode: "ask",
+    egressExtraHosts: [],
+    repoMode: "forge",
+    autoOptimizeFlagged: false,
+    manualStepsIssueEnabled: false,
+    hidden: false,
+  });
+
+  if (opts.epicRunning) {
+    store.setEpicRun({
+      repoPath: REPO,
+      parentIssueNumber: PARENT,
+      mode: "auto",
+      status: "running",
+    });
+  }
+
+  const spy = fakeForge({
+    kind: opts.github === false ? "gitea" : "github",
+    prStatus: opts.prStatus,
+    latestFailedRunForPr: opts.latestFailedRunForPr,
+    hasRerunCapability: opts.hasRerunCapability,
+  });
+  const completedEmits: CompletedEpic[] = [];
+
+  const drain = new DrainService({
+    store,
+    service: {
+      create: async () => {
+        throw new Error("not used");
+      },
+      archive: () => 1,
+    } as never,
+    resolveForge: () => spy.forge,
+    prCache: { snapshot: () => ({}) },
+    usage: { limits: (): UsageLimitsType => NO_USAGE },
+    repos: () => [REPO],
+    emitStatus: () => {},
+    emitArchived: () => {},
+    dropPrCache: () => {},
+    emitEpic: () => {},
+    emitEpicCompleted: (e) => completedEmits.push(e),
+    rebaseCap: 5,
+    rebaseLandingBranch: async () => ({ kind: "current" }),
+  });
+
+  return { store, drain, completedEmits, spy };
+}
+
+/** Seed an `epic_completed` row with landingState='open' and a pinned integration branch. */
+function seedOpenLanding(h: Harness): void {
+  h.store.recordEpicIntegrated(REPO, PARENT, 320, {
+    number: 9320,
+    url: "https://github.com/o/r/pull/9320",
+  });
+  h.store.recordEpicCompleted({
+    repoPath: REPO,
+    parentIssueNumber: PARENT,
+    parentTitle: PARENT_TITLE,
+    completedAt: 1,
+    childrenJson: JSON.stringify([
+      {
+        number: 320,
+        title: "child 320",
+        url: "https://x/320",
+        prNumber: 9320,
+        prUrl: "https://github.com/o/r/pull/9320",
+        mergedAt: 1,
+        integrated: true,
+      },
+    ]),
+  });
+  h.store.getOrInitEpicIntegrationBranch(REPO, PARENT, INTEGRATION_BRANCH);
+  h.store.setEpicLandingPr(REPO, PARENT, {
+    state: "open",
+    prNumber: LANDING_PR,
+    prUrl: `https://github.com/o/r/pull/${LANDING_PR}`,
+    attempts: 0,
+  });
+}
+
+/** Invoke the private rerun pass directly so prStatus/rerun call counts are isolated to it
+ *  (tick() also runs rebaseStuckLandingPrsForRepo and autoLandLandingPrsForRepo, which read prStatus). */
+function callRerunPass(h: Harness): Promise<void> {
+  return (
+    h.drain as unknown as { rerunRedLandingCiForRepo: (repoPath: string) => Promise<void> }
+  ).rerunRedLandingCiForRepo(REPO);
+}
+
+describe("rerunRedLandingCiForRepo (C)", () => {
+  // ── gate tests ──────────────────────────────────────────────────────────────
+
+  test("gate-off: draftMode ON → rerunWorkflowRun NOT called", async () => {
+    const h = makeHarness({
+      draftMode: true,
+      autoMergeEnabled: true,
+      prStatus: async () => redPr(),
+      latestFailedRunForPr: async () => 42,
+    });
+    seedOpenLanding(h);
+
+    await callRerunPass(h);
+
+    expect(h.spy.rerunCalls).toHaveLength(0);
+    expect(h.spy.prStatusCalls).toHaveLength(0);
+  });
+
+  test("gate-off: autoMerge+autoDrain off, no running epic → rerunWorkflowRun NOT called", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: false,
+      autoDrainEnabled: false,
+      prStatus: async () => redPr(),
+      latestFailedRunForPr: async () => 42,
+    });
+    seedOpenLanding(h);
+
+    await callRerunPass(h);
+
+    expect(h.spy.rerunCalls).toHaveLength(0);
+    expect(h.spy.prStatusCalls).toHaveLength(0);
+  });
+
+  test("gate: autoMergeEnabled ON (autoDrain off, no epic) → pass runs", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      autoDrainEnabled: false,
+      prStatus: async () => redPr(),
+      latestFailedRunForPr: async () => 42,
+    });
+    seedOpenLanding(h);
+
+    await callRerunPass(h);
+
+    expect(h.spy.rerunCalls).toHaveLength(1);
+  });
+
+  test("gate: autoDrainEnabled ON (autoMerge off, no epic) → pass runs", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: false,
+      autoDrainEnabled: true,
+      prStatus: async () => redPr(),
+      latestFailedRunForPr: async () => 42,
+    });
+    seedOpenLanding(h);
+
+    await callRerunPass(h);
+
+    expect(h.spy.rerunCalls).toHaveLength(1);
+  });
+
+  test("epic-running engages: autoMerge+autoDrain off but epic status=running → pass runs", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: false,
+      autoDrainEnabled: false,
+      epicRunning: true,
+      prStatus: async () => redPr(),
+      latestFailedRunForPr: async () => 42,
+    });
+    seedOpenLanding(h);
+
+    await callRerunPass(h);
+
+    expect(h.spy.rerunCalls).toHaveLength(1);
+  });
+
+  test("non-github forge (gitea) → NOT called, zero prStatus calls", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      github: false,
+      prStatus: async () => redPr(),
+      latestFailedRunForPr: async () => 42,
+    });
+    seedOpenLanding(h);
+
+    await callRerunPass(h);
+
+    expect(h.spy.rerunCalls).toHaveLength(0);
+    expect(h.spy.prStatusCalls).toHaveLength(0);
+  });
+
+  test("forge missing rerunWorkflowRun/latestFailedRunForPr capability → NOT called", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      hasRerunCapability: false,
+      prStatus: async () => redPr(),
+    });
+    seedOpenLanding(h);
+
+    await callRerunPass(h);
+
+    expect(h.spy.rerunCalls).toHaveLength(0);
+    expect(h.spy.prStatusCalls).toHaveLength(0);
+  });
+
+  // ── core behavior ─────────────────────────────────────────────────────────
+
+  test("reruns a flaky red: terminal failure + mergeable + clean → rerunWorkflowRun(runId, {failedOnly:true})", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => redPr(),
+      latestFailedRunForPr: async () => 42,
+    });
+    seedOpenLanding(h);
+
+    await callRerunPass(h);
+
+    expect(h.spy.latestFailedRunCalls).toEqual([LANDING_PR]);
+    expect(h.spy.rerunCalls).toEqual([{ runId: 42, failedOnly: true }]);
+  });
+
+  // ── per-head cap ────────────────────────────────────────────────────────────
+
+  test("per-head cap: after LANDING_RERUN_CAP reruns on head h1, further passes stop; a NEW head resets", async () => {
+    const CAP = 2;
+    let head = "h1";
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => redPr({ headSha: head }),
+      latestFailedRunForPr: async () => 42,
+    });
+    seedOpenLanding(h);
+
+    for (let i = 0; i < CAP; i++) {
+      await callRerunPass(h);
+    }
+    expect(h.spy.rerunCalls).toHaveLength(CAP);
+
+    // Still h1, budget spent → no rerun.
+    await callRerunPass(h);
+    expect(h.spy.rerunCalls).toHaveLength(CAP);
+
+    // Head advances (new push) → budget resets.
+    head = "h2";
+    await callRerunPass(h);
+    expect(h.spy.rerunCalls).toHaveLength(CAP + 1);
+  });
+
+  // ── skip cases (no rerun) ────────────────────────────────────────────────────
+
+  test("skips: mergeStateStatus=behind (rebase pass's territory)", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => redPr({ mergeStateStatus: "behind" }),
+      latestFailedRunForPr: async () => 42,
+    });
+    seedOpenLanding(h);
+
+    await callRerunPass(h);
+
+    expect(h.spy.rerunCalls).toHaveLength(0);
+  });
+
+  test("skips: mergeable=false (conflict, rebase pass's territory)", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => redPr({ mergeable: false }),
+      latestFailedRunForPr: async () => 42,
+    });
+    seedOpenLanding(h);
+
+    await callRerunPass(h);
+
+    expect(h.spy.rerunCalls).toHaveLength(0);
+  });
+
+  test("skips: isDraft=true", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => redPr({ isDraft: true }),
+      latestFailedRunForPr: async () => 42,
+    });
+    seedOpenLanding(h);
+
+    await callRerunPass(h);
+
+    expect(h.spy.rerunCalls).toHaveLength(0);
+  });
+
+  test("skips: checks=success (nothing to rerun)", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => redPr({ checks: "success" }),
+      latestFailedRunForPr: async () => 42,
+    });
+    seedOpenLanding(h);
+
+    await callRerunPass(h);
+
+    expect(h.spy.rerunCalls).toHaveLength(0);
+  });
+
+  test("skips: checks=pending (nothing to rerun)", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => redPr({ checks: "pending" }),
+      latestFailedRunForPr: async () => 42,
+    });
+    seedOpenLanding(h);
+
+    await callRerunPass(h);
+
+    expect(h.spy.rerunCalls).toHaveLength(0);
+  });
+
+  test("skips: latestFailedRunForPr resolves null (fork-origin PR / no resolvable run)", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => redPr(),
+      latestFailedRunForPr: async () => null,
+    });
+    seedOpenLanding(h);
+
+    await callRerunPass(h);
+
+    expect(h.spy.rerunCalls).toHaveLength(0);
+  });
+
+  // ── never-merges ─────────────────────────────────────────────────────────────
+
+  test("never merges: forge.merge is never invoked by this pass", async () => {
+    const h = makeHarness({
+      autoMergeEnabled: true,
+      prStatus: async () => redPr(),
+      latestFailedRunForPr: async () => 42,
+    });
+    seedOpenLanding(h);
+
+    // merge() throws in the fake forge if ever called — a clean pass proves it wasn't.
+    await expect(callRerunPass(h)).resolves.toBeUndefined();
+  });
+});

--- a/test/herd-digest.test.ts
+++ b/test/herd-digest.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, beforeEach, afterEach } from "bun:test";
 import { HerdDigestService, dayKeyFor } from "../src/herd-digest";
 import type { HerdSnapshots, MergeTrainState } from "../src/herd-digest";
+import { SessionStore } from "../src/store";
 import type { HerdDigest, RundownEpicItem, Session } from "../src/types";
 import { RUNDOWN_EPICS_CAP } from "../src/rundown-core";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
@@ -824,6 +825,69 @@ test("reconcileEpics: unchanged set → no-op (no emit)", async () => {
     landingReadyEpics: async () => [sampleEpic()], // identical
   });
   await svc.reconcileEpics();
+  expect(changes.length).toBe(0);
+});
+
+// Mirrors the exact object literal src/index.ts's landingReadyEpics() emits for a plain ready
+// (non-stranded, non-CI-failing) epic in its `readyItems` .map() — keep in sync with that map.
+const READY_LIVE_SHAPE: RundownEpicItem = {
+  repo: "/repo/a",
+  parent: 7,
+  title: "Epic A",
+  landingPr: 99,
+  stranded: false,
+  ciFailing: false,
+};
+
+test("reconcileEpics: real store round-trip is idempotent for a ready epic (regression)", async () => {
+  // Uses the REAL SessionStore (not the in-memory FakeStore) so the digest's epicsToLand goes
+  // through the actual JSON column + hydrateEpics() round-trip on read — that round-trip is where
+  // the regression lived: hydrateEpics() unconditionally forces a `ciFailing` boolean onto every
+  // hydrated item, so a stored/hydrated ready epic must already carry `ciFailing: false` or every
+  // tick's JSON.stringify comparison against the live (un-hydrated) landingReadyEpics() output
+  // mismatches and reconcileEpics() fires a spurious putHerdDigest + onChange broadcast.
+  const dayKey = dayKeyFor(DAY1);
+  const store = new SessionStore(":memory:");
+  store.putHerdDigest({
+    dayKey,
+    state: "ready",
+    overnight: "",
+    decisions: [],
+    ciRework: [],
+    train: "",
+    focusNext: [],
+    // The exact shape frozen into epicsToLand at spawn time (landingReadyEpics() output).
+    epicsToLand: [READY_LIVE_SHAPE],
+    attentionFingerprint: {},
+    spawnSessionId: "spawn-1",
+    cwd: "/tmp/x",
+    model: "sonnet",
+    spawnedAt: DAY1 - 1000,
+    generatedAt: DAY1 - 1000,
+    updatedAt: DAY1 - 1000,
+  });
+
+  const changes: HerdDigest[] = [];
+  const svc = new HerdDigestService({
+    store,
+    herdr: makeHerdr() as any,
+    isActive: () => true,
+    onChange: (d) => changes.push(d),
+    snapshots: () => EMPTY_SNAPSHOTS,
+    model: "sonnet",
+    now: () => DAY1,
+    timeoutMs: 300_000,
+    readVerdict: () => null,
+    readUsage: async () => null,
+    makeTmpDir: () => "/tmp/rundown-test-regression",
+    cleanup: () => {},
+    // Nothing changed since spawn: the epic is still open + ready, same shape landingReadyEpics()
+    // emits live on this tick (NOT hydrated — exactly like the real index.ts wiring).
+    landingReadyEpics: async () => [READY_LIVE_SHAPE],
+  });
+
+  await svc.reconcileEpics();
+  // Nothing actually changed → must be a no-op: no rewrite, no WS broadcast.
   expect(changes.length).toBe(0);
 });
 

--- a/test/store-herd-digests.test.ts
+++ b/test/store-herd-digests.test.ts
@@ -45,7 +45,14 @@ test("herd_digests: put→get round-trip (incl. JSON columns)", () => {
   expect(got?.ciRework).toEqual([{ label: "ci red", pr: 42 }]);
   expect(got?.focusNext).toEqual([{ label: "review migration" }]);
   expect(got?.epicsToLand).toEqual([
-    { repo: "/repo/a", parent: 7, title: "Epic A", landingPr: 99, stranded: true },
+    {
+      repo: "/repo/a",
+      parent: 7,
+      title: "Epic A",
+      landingPr: 99,
+      stranded: true,
+      ciFailing: false,
+    },
   ]);
   expect(got?.attentionFingerprint).toEqual({ s1: ["ci-red", "in-flight"] });
   expect(got?.model).toBe("claude-opus-4-8");


### PR DESCRIPTION
## Why

When an epic drain lands its aggregate PR (`epic/<#>-<slug> → main`) it often ends with a **CI failure** — and today that red landing PR is surfaced **nowhere**: `computeLandingStranded` requires `landingReady === true` (cleared checks), so a failing-CI landing is neither "ready" nor "paused", and it silently stalls until the 6 h stranded threshold (which also can't fire for it).

Root cause: the landing PR is the epic's **first main-relative CI run**. Children target `epic/<#>` and are never rebased forward (the `AutoMergeService` rebase-steer is gated on `isFullAuto`, which excludes `epic/**`); and although #1635 runs CI + hygiene on `epic/**` child PRs, those measure against the **epic branch**. So main-relative Fallow/hygiene and the main-only `pr-title` first bite at landing.

This is the verified, self-standing slice (**B + C**) of the plan. The two heavier/speculative pieces are deferred to follow-up issues.

## What this PR does

**B — make a CI-failing landing visible.** New live `CompletedEpic.landingCiFailing` (computed in `enrichLandingEpics` as terminal `checks==="failure"` **and not** behind/conflicting — those are the rebase pass's `pausedReason`), surfaced as a distinct Tier-1 rundown item (`landingReadyEpics` → `RundownEpicItem.ciFailing` → `[CI FAILING — needs attention]` in `rundown-core`). Each open row is surfaced under exactly one heading (paused / ready / ci-failing).

**C — auto-rerun a flaky red landing.** New `rerunRedLandingCiForRepo` drain-tick pass (between `rebaseStuckLandingPrsForRepo` and `autoLandLandingPrsForRepo`) that re-runs only the failed jobs (`gh run rerun --failed`) on a terminally-red, mergeable, not-behind landing PR — GitHub-only, engaged-gated, `landingInFlight`-serialized, fail-closed, **capped per head SHA** (`LANDING_RERUN_CAP`), never merges. Absorbs the flaky-infra failure mode automatically; a persistent red is left to B's surfacing.

**Reconcile-idempotency fix** (caught by the whole-branch review): `landingReadyEpics` now always emits `ciFailing` as a boolean on ready/paused items too, so `reconcileEpics`'s deep-equality against the hydrated digest still no-ops for a ready landing epic (otherwise it wrote + WS-broadcast every tick). Guarded by a real-store regression test that fails pre-fix / passes post-fix.

Server-only; no UI/i18n/glossary/feature-catalog changes (`[no-feature-entry]`).

## Deferred (follow-up issues, not this PR)

- **#1664** — A: pre-warm landing CI via an early **draft** landing PR (behind a default-off toggle). Its honest benefit is pre-warming only, and it's always-on-cost, so it was deferred rather than shipped.
- **#1665** — D: an **agent repair session** to fix a genuinely-red landing (needs a new `pushToBase` session flag + autopilot suppression + a durable rebase fence; mechanism unverified).
- **#1666** — pre-existing bug found in review: `hydrateEpics` drops `pausedReason`, so **paused** landing epics churn the reconcile every tick (same class as the fix above, but predates this branch — left out of scope).

## Testing

`bun run lint`, `bun run typecheck`, `bunx prettier --check` (touched files) — clean. `bun test ./test` → **6685 pass / 8 skip / 0 fail**. New: `test/completed-epic-cifailing.test.ts` (compute: true + the three false cases), `test/drain-epic-landing-rerun.test.ts` (16 cases: rerun, per-head cap + reset, every skip, gate-off, never-merges), plus a reconcile-idempotency regression test in `test/herd-digest.test.ts`. `bunx fallow@2.100.0 audit --base origin/main` → exit 0 (dead code 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
