### PR TITLE
fix(store): hydrate pausedReason so paused landing epics stop churning reconcile

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -118,6 +118,11 @@ function strOrEmpty(v: string | null | undefined): string {
   return v ?? "";
 }
 
+/** Coerce a persisted RundownEpicItem.pausedReason to its union, or undefined for anything else. */
+function coercePauseReason(v: unknown): RundownEpicItem["pausedReason"] {
+  return v === "cap" || v === "conflict" || v === "driver" ? v : undefined;
+}
+
 /** Designation prefix for task sessions, e.g. "TASK-07". Single source for the prefix + its SUBSTR offset. */
 const DESIG_PREFIX = "TASK-";
 
@@ -2822,6 +2827,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
         landingPr: typeof o.landingPr === "number" ? o.landingPr : null,
         stranded: o.stranded === true,
         ciFailing: o.ciFailing === true,
+        pausedReason: coercePauseReason(o.pausedReason),
       });
     }
     return out;

--- a/test/herd-digest.test.ts
+++ b/test/herd-digest.test.ts
@@ -891,6 +891,67 @@ test("reconcileEpics: real store round-trip is idempotent for a ready epic (regr
   expect(changes.length).toBe(0);
 });
 
+// Mirrors the exact object literal src/index.ts's landingReadyEpics() emits for a paused epic in
+// its `pausedItems` .map() — keep in sync with that map.
+const PAUSED_LIVE_SHAPE: RundownEpicItem = {
+  repo: "/repo/a",
+  parent: 7,
+  title: "Epic A",
+  landingPr: 99,
+  stranded: false,
+  ciFailing: false,
+  pausedReason: "cap",
+};
+
+test("reconcileEpics: real store round-trip is idempotent for a paused epic (regression)", async () => {
+  // Same class as the ready-epic regression above, but for the PAUSED case (#1666): hydrateEpics()
+  // never read `pausedReason`, so a stored/hydrated paused epic dropped it and every tick's
+  // JSON.stringify comparison against the live (un-hydrated) landingReadyEpics() output mismatched —
+  // firing a spurious putHerdDigest + onChange broadcast for as long as any paused landing PR sat.
+  const dayKey = dayKeyFor(DAY1);
+  const store = new SessionStore(":memory:");
+  store.putHerdDigest({
+    dayKey,
+    state: "ready",
+    overnight: "",
+    decisions: [],
+    ciRework: [],
+    train: "",
+    focusNext: [],
+    // The exact shape frozen into epicsToLand at spawn time (landingReadyEpics() output).
+    epicsToLand: [PAUSED_LIVE_SHAPE],
+    attentionFingerprint: {},
+    spawnSessionId: "spawn-1",
+    cwd: "/tmp/x",
+    model: "sonnet",
+    spawnedAt: DAY1 - 1000,
+    generatedAt: DAY1 - 1000,
+    updatedAt: DAY1 - 1000,
+  });
+
+  const changes: HerdDigest[] = [];
+  const svc = new HerdDigestService({
+    store,
+    herdr: makeHerdr() as any,
+    isActive: () => true,
+    onChange: (d) => changes.push(d),
+    snapshots: () => EMPTY_SNAPSHOTS,
+    model: "sonnet",
+    now: () => DAY1,
+    timeoutMs: 300_000,
+    readVerdict: () => null,
+    readUsage: async () => null,
+    makeTmpDir: () => "/tmp/rundown-test-paused-regression",
+    cleanup: () => {},
+    // Still paused with the same reason, same shape landingReadyEpics() emits live (NOT hydrated).
+    landingReadyEpics: async () => [PAUSED_LIVE_SHAPE],
+  });
+
+  await svc.reconcileEpics();
+  // Nothing actually changed → must be a no-op: no rewrite, no WS broadcast.
+  expect(changes.length).toBe(0);
+});
+
 test("reconcileEpics: landed/lost readiness shrinks the set", async () => {
   const dayKey = dayKeyFor(DAY1);
   const ready: HerdDigest = {


### PR DESCRIPTION
Fixes #1666.

## Problem

`SessionStore.hydrateEpics` (`src/store.ts`) round-trips `RundownEpicItem` but never read `pausedReason` — it was silently dropped on every persist/hydrate cycle. Meanwhile `landingReadyEpics()` (`src/index.ts`) emits `pausedReason` on paused items. So `reconcileEpics` (`src/herd-digest.ts`), which gates its write on `JSON.stringify(latest.epicsToLand) === JSON.stringify(current)`, compared a live paused item (`{…, pausedReason:"cap"}`) against its hydrated form (no `pausedReason`) — **never equal** — and fired `putHerdDigest` + an `onChange` WS broadcast on **every tick** for as long as any epic landing PR sat paused (rebase cap / conflict / driver).

Same class as the reconcile-churn bug the landing-CI-failing PR fixed for the *ready* case via `ciFailing`; this predated that branch for the *paused* case.

## Fix

- Restore `pausedReason` on hydration via a small module-level `coercePauseReason` helper (matches the existing `coerceSummaryCode` / `nullableBool` coercion-helper pattern, and keeps `hydrateEpics` cognitive complexity under the fallow gate). Whitelisted to the `"cap" | "conflict" | "driver"` union; any other stored value → `undefined`.
- `JSON.stringify` omits `undefined`-valued keys, so ready items (which carry no `pausedReason` live) stay byte-identical after hydration — the existing ready-epic idempotency test still passes.

## Test

Added `reconcileEpics: real store round-trip is idempotent for a paused epic (regression)` — mirrors the existing ready-epic regression test, using the real `SessionStore(":memory:")` so `epicsToLand` round-trips through the JSON column + `hydrateEpics()`. Verified it **fails** against pre-fix `hydrateEpics` (spurious broadcast → `changes.length` 1) and **passes** with the fix.

## Verification

- `bun run lint` — clean
- `bun test test/herd-digest.test.ts` — 32 pass
- `bunx fallow@2.100.0 audit` — ✓ no issues in changed files

## Impact

Eliminates wasted DB writes + WS broadcasts every tick while any paused landing epic exists. No schema change, no user-facing UX (server-internal plumbing → `[no-feature-entry]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)