### PR TITLE
fix(test): add preWarmEpicLandingCi to landing-repair RepoConfig literal

### DIFF
--- a/test/drain-landing-repair.test.ts
+++ b/test/drain-landing-repair.test.ts
@@ -156,6 +156,7 @@ function makeHarness(opts: {
     repoMode: "forge",
     autoOptimizeFlagged: false,
     manualStepsIssueEnabled: false,
+    preWarmEpicLandingCi: false,
     hidden: false,
   });
 


### PR DESCRIPTION
Unbreaks `main`, which is red at **Typecheck (root tsc)**.

## The failure

```
test/drain-landing-repair.test.ts(136,29): error TS2345:
  Property 'preWarmEpicLandingCi' is missing ... but required in type 'RepoConfig'
```

A semantic merge conflict — each branch was green on its own:

- **#1670** made `preWarmEpicLandingCi: boolean` a **required** field of `RepoConfig` (`src/store.ts:182`) and added `preWarmEpicLandingCi: false` to the ~10 test files that then built a full `RepoConfig` literal.
- **#1671** landed in the same window with a **new** test file, `test/drain-landing-repair.test.ts`, whose literal predates the field.

Neither branch saw the other, so both passed CI and `main` broke on the merge.

## The fix

One line: add `preWarmEpicLandingCi: false` to the `makeHarness` literal, matching the store default (`src/store.ts:686`) and the ~10 sibling tests.

## Verification

- `bunx tsc --noEmit` on this branch: **exit 0**.
- Full root suite (`bun run test`): **6754 pass, 8 skip, 0 fail**. Run in full rather than just the one file — #1670 and #1671 both touch the epic landing path in `drain.ts`, so this confirms the type error was not masking a behavioral conflict between pre-warm and landing-repair.

## Heads-up for other open PRs

Open PRs cut before this fix stay red at **Typecheck** until they rebase onto it — same `TS2345`, already diagnosed here: #1510, #1497, #1491, #1386, #1102, #1088. No need to re-diagnose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)