### PR TITLE
fix(reaper): reap runaway orphans by env provenance, not cwd (#1144)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -408,6 +408,22 @@ export function parseHour(raw: string | undefined, def: number): number {
   return Number.isInteger(n) && n >= 0 && n <= 23 ? n : def;
 }
 
+/** Mode for the runaway-orphan reaper (issue #1144). Mirrors `ReapMarkedOptions["mode"]`. */
+type ReapRunawayMode = "armed" | "observe" | "off";
+
+/**
+ * `SHEPHERD_REAP_RUNAWAY`: `0`/`off` disables the sweep entirely; `observe` runs every gate but
+ * never signals (log-only). Anything else — including unset — is `armed`, the default: the sweep
+ * is safe to arm because a candidate must carry an agent-spawned env marker AND belong to an
+ * archived session before it can be touched.
+ */
+function normalizeReapRunaway(raw: string | undefined): ReapRunawayMode {
+  const v = raw?.trim().toLowerCase();
+  if (v === "0" || v === "off") return "off";
+  if (v === "observe") return "observe";
+  return "armed";
+}
+
 // The HUD's main listen port. Extracted so the agent-ingress port can default
 // relative to it (mainPort + 1) — a custom SHEPHERD_PORT shifts both in lockstep.
 const mainPort = Number(process.env.SHEPHERD_PORT ?? 7330);
@@ -656,6 +672,19 @@ export const config = {
   // on, with this flag as the kill switch. UI-configurable + persisted; set
   // SHEPHERD_SESSION_HOUSEKEEPING=0 to seed it off on a fresh DB.
   sessionHousekeepingEnabled: process.env.SHEPHERD_SESSION_HOUSEKEEPING !== "0",
+  // Runaway-orphan reaper (issue #1144). SIGKILLs a process that (a) carries this session's
+  // SHEPHERD_SESSION_ID in its /proc/<pid>/environ (provenance — an agent spawned it) AND (b) whose
+  // session row is present and `archived` (terminality — the agent is definitively done), once it has
+  // burned `reapRunawayMinCpu` of a core over `reapRunawayMinAgeS`. Safety comes from provenance ∧
+  // terminality; the CPU/age pair is a PERFORMANCE prefilter that keeps the sweep's /proc/<pid>/environ
+  // reads (which take the target's mmap lock) near zero — NOT a safety floor.
+  //   armed (default) → SIGKILL · observe → log-only · off → the sweep never runs.
+  reapRunaway: normalizeReapRunaway(process.env.SHEPHERD_REAP_RUNAWAY),
+  // Fraction of ONE core, averaged over the process's whole lifetime (incl. reaped children).
+  reapRunawayMinCpu: Number(process.env.SHEPHERD_REAP_RUNAWAY_MIN_CPU ?? 0.8),
+  // Minimum process age before it can be reaped. Also what makes the benign `restore()` race
+  // (agent respawned before the row flips off `archived`) unreachable — keep it comfortably > 0.
+  reapRunawayMinAgeS: Number(process.env.SHEPHERD_REAP_RUNAWAY_MIN_AGE_S ?? 300),
   // LLM session naming: after a session is created with the instant heuristic name,
   // a transient haiku agent comprehends the prompt and renames it in the background.
   // Default on; set SHEPHERD_LLM_NAMING=0 to keep the pure-heuristic name.

--- a/src/config.ts
+++ b/src/config.ts
@@ -118,6 +118,13 @@ export function clampCap(n: number, min: number, max: number, fallback: number):
   return Math.min(max, Math.max(min, Math.round(n)));
 }
 
+// As clampCap, but WITHOUT the integer rounding — for ratio knobs (e.g. a CPU fraction, where
+// clampCap would round 0.8 to 1). Same forgiving contract: non-finite falls back, else snap.
+export function clampFraction(n: number, min: number, max: number, fallback: number): number {
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(max, Math.max(min, n));
+}
+
 // ── preview-port range ─────────────────────────────────────────────────────
 // Single source of truth for the preview-port range; consumed by both the slot
 // allocator (future PreviewService) and checkOrigin (origin hardening). The range
@@ -681,10 +688,25 @@ export const config = {
   //   armed (default) → SIGKILL · observe → log-only · off → the sweep never runs.
   reapRunaway: normalizeReapRunaway(process.env.SHEPHERD_REAP_RUNAWAY),
   // Fraction of ONE core, averaged over the process's whole lifetime (incl. reaped children).
-  reapRunawayMinCpu: Number(process.env.SHEPHERD_REAP_RUNAWAY_MIN_CPU ?? 0.8),
-  // Minimum process age before it can be reaped. Also what makes the benign `restore()` race
-  // (agent respawned before the row flips off `archived`) unreachable — keep it comfortably > 0.
-  reapRunawayMinAgeS: Number(process.env.SHEPHERD_REAP_RUNAWAY_MIN_AGE_S ?? 300),
+  // CLAMPED, not just defaulted: `Number("")` is 0, so an env var that is merely SET-BUT-EMPTY
+  // would otherwise silently drop the gate to "any marked process of an archived session".
+  reapRunawayMinCpu: clampFraction(
+    Number(process.env.SHEPHERD_REAP_RUNAWAY_MIN_CPU ?? 0.8),
+    0.05,
+    1,
+    0.8,
+  ),
+  // Minimum process age before it can be reaped. This floor is what makes the benign `restore()`
+  // race unreachable — restore SPAWNS the agent before `store.unarchive` flips the row off
+  // `archived`, so a live agent's row briefly reads archived. Clamped to a hard >= 60s minimum:
+  // `Number("")` is 0, and a 0 floor would open exactly that window (and reap the freshly
+  // respawned agent's own children). A comment cannot enforce this; the clamp does.
+  reapRunawayMinAgeS: clampCap(
+    Number(process.env.SHEPHERD_REAP_RUNAWAY_MIN_AGE_S ?? 300),
+    60,
+    24 * 60 * 60,
+    300,
+  ),
   // LLM session naming: after a session is created with the instant heuristic name,
   // a transient haiku agent comprehends the prompt and renames it in the background.
   // Default on; set SHEPHERD_LLM_NAMING=0 to keep the pure-heuristic name.

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ import { CountsService } from "./backlog";
 import { OpenPrSnapshotService } from "./open-pr-snapshot";
 import { BacklogPoller } from "./backlog-poller";
 import { UpNextService, buildUpNextRepos } from "./up-next";
-import { ProcessReaper, reapDeletedWorktreeOrphans } from "./process-reaper";
+import { ProcessReaper, reapDeletedWorktreeOrphans, reapMarkedOrphans } from "./process-reaper";
 import {
   sweepClaudeTmp,
   compileCacheDir,
@@ -625,6 +625,8 @@ const service = new SessionService({
     : undefined,
   events,
   reaper: new ProcessReaper(),
+  // #1144: reap what the agent left burning, for the ids just archived. Defined below.
+  reapRunaway: (ids) => sweepRunawayOrphans(ids),
   preview: previewService,
   // Fast-poll a queue member to surface its merge promptly when the train session
   // archives before the 120s PR sweep credits it (the merge-train completion race).
@@ -732,6 +734,55 @@ const fireTmpSweep = (phase: "boot" | "daily") => {
 
 deferredStarts.push(() => {
   fireTmpSweep("boot");
+});
+
+/**
+ * #1144: SIGKILL processes an agent left burning a core after its session was archived.
+ *
+ * Attribution is by ENV MARKER, not cwd: every agent spawn carries SHEPHERD_SESSION_ID, every
+ * descendant inherits it, and /proc/<pid>/environ survives `cd`, backgrounding, PID-1 reparenting
+ * and worktree deletion. So this catches the two leaks #1143's cwd sweeps structurally cannot —
+ * an orphan that chdir'd out of the worktree, and a NON-isolated session's orphan (whose "worktree"
+ * IS the shared repo root, which we must never sweep by cwd). An operator's own hot processes never
+ * carry the marker, so they can never be candidates.
+ *
+ * Runs at teardown (via SessionService.reapRunaway), on boot, and hourly as the safety net for a
+ * leak that was still under the age floor when its session was archived.
+ */
+const sweepRunawayOrphans = (ids?: Set<string>) => {
+  if (maintenance.active) return; // a sync /proc sweep must not run mid-update
+  try {
+    const { reaped, observed } = reapMarkedOrphans({
+      ids,
+      mode: config.reapRunaway,
+      minCpu: config.reapRunawayMinCpu,
+      minAgeS: config.reapRunawayMinAgeS,
+      // MUST throw rather than report "absent" if the store is ever unreadable: "absent" is a
+      // positive claim that no such session exists HERE (which is how a second Shepherd instance's
+      // live sessions are spared), so a failed read must never be mistaken for one.
+      sessionStatus: (id) => {
+        const s = store.get(id);
+        if (!s) return "absent";
+        return s.status === "archived" ? "archived" : "live";
+      },
+    });
+    for (const c of observed) {
+      const pct = Math.round(c.cpuFraction * 100);
+      const mins = Math.round(c.ageSeconds / 60);
+      console.warn(
+        `[reap-runaway] ${config.reapRunaway === "armed" ? "killed" : "would kill"} pid ${c.pid} ` +
+          `(${c.comm}) session=${c.sessionId} cpu=${pct}% age=${mins}m ppid=${c.ppid} cwd=${c.cwd}`,
+      );
+    }
+    if (reaped > 0) console.warn(`[reap-runaway] reaped ${reaped} runaway orphan(s)`);
+  } catch (err) {
+    console.warn("[reap-runaway] sweep failed:", err);
+  }
+};
+
+deferredStarts.push(() => {
+  sweepRunawayOrphans();
+  setInterval(() => sweepRunawayOrphans(), 60 * 60 * 1000);
 });
 
 // Reap orphaned helper tabs (usage-probe / review husks no live agent backs). The

--- a/src/index.ts
+++ b/src/index.ts
@@ -808,7 +808,14 @@ const sweepRunawayOrphans = (ids?: Set<string>) => {
 };
 
 deferredStarts.push(() => {
-  sweepRunawayOrphans();
+  // Deferred off the synchronous boot path (same as the #1133 orphan reap above): the sweep is a
+  // host-wide /proc enumeration — a readdir plus a comm + stat read per pid, and an fd-table walk
+  // for every hot, old survivor — and it runs on Bun's single loop. Nothing about it is urgent at
+  // boot (it is the safety net; teardown already swept these), so it must not sit inline ahead of
+  // the server accepting connections.
+  void Promise.resolve()
+    .then(() => sweepRunawayOrphans())
+    .catch((err) => console.warn("[reap-runaway] boot sweep failed:", err));
   setInterval(() => sweepRunawayOrphans(), 60 * 60 * 1000);
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,12 @@ import { CountsService } from "./backlog";
 import { OpenPrSnapshotService } from "./open-pr-snapshot";
 import { BacklogPoller } from "./backlog-poller";
 import { UpNextService, buildUpNextRepos } from "./up-next";
-import { ProcessReaper, reapDeletedWorktreeOrphans, reapMarkedOrphans } from "./process-reaper";
+import {
+  ProcessReaper,
+  reapDeletedWorktreeOrphans,
+  reapMarkedOrphans,
+  SESSION_MARKER_ENV,
+} from "./process-reaper";
 import {
   sweepClaudeTmp,
   compileCacheDir,
@@ -172,6 +177,18 @@ import {
 import { fetchGithubRateLimit } from "./forge/github-rate-limit";
 
 const execFileAsync = promisify(execFile);
+
+// Scrub any INHERITED session marker before anything can spawn (issue #1144).
+//
+// The marker means "an agent of session <id> spawned this process". If Shepherd itself is launched
+// from inside an agent session (an agent restarting the server, a dev run from a session shell), it
+// inherits that id in its own process.env — and hands it, by plain env inheritance, to every child
+// it spawns. The aux/satellite agents (critic, distiller, doc-agent, plan-gate) pass no marker of
+// their own precisely so that they stay unmarked and are ALWAYS spared; a stale inherited one would
+// silently mark them with a real session id, and once that session archived the reaper would treat
+// a live critic's background work as a runaway. Delete it once, here, at the top of boot: the
+// server is not an agent's child in any sense the reaper should honour.
+delete process.env[SESSION_MARKER_ENV];
 
 startLoopLagSampler(); // no-op unless SHEPHERD_PROFILE_LOOP=1
 logRemainingOnLoopBlockers(); // one-time operator map of intentionally-sync calls
@@ -752,7 +769,7 @@ deferredStarts.push(() => {
 const sweepRunawayOrphans = (ids?: Set<string>) => {
   if (maintenance.active) return; // a sync /proc sweep must not run mid-update
   try {
-    const { reaped, observed } = reapMarkedOrphans({
+    const { reaped, observed, killed } = reapMarkedOrphans({
       ids,
       mode: config.reapRunaway,
       minCpu: config.reapRunawayMinCpu,
@@ -766,12 +783,22 @@ const sweepRunawayOrphans = (ids?: Set<string>) => {
         return s.status === "archived" ? "archived" : "live";
       },
     });
+    // Log per candidate from what ACTUALLY happened, never from `observed` alone: an armed sweep
+    // can still skip a kill (pid recycled between scan and kill, or the process already exited),
+    // and claiming "killed" for those would contradict the `reaped` total below.
+    const killedPids = new Set(killed.map((c) => c.pid));
     for (const c of observed) {
+      const verb =
+        config.reapRunaway !== "armed"
+          ? "would kill"
+          : killedPids.has(c.pid)
+            ? "killed"
+            : "skipped";
       const pct = Math.round(c.cpuFraction * 100);
       const mins = Math.round(c.ageSeconds / 60);
       console.warn(
-        `[reap-runaway] ${config.reapRunaway === "armed" ? "killed" : "would kill"} pid ${c.pid} ` +
-          `(${c.comm}) session=${c.sessionId} cpu=${pct}% age=${mins}m ppid=${c.ppid} cwd=${c.cwd}`,
+        `[reap-runaway] ${verb} pid ${c.pid} (${c.comm}) session=${c.sessionId} ` +
+          `cpu=${pct}% age=${mins}m ppid=${c.ppid} cwd=${c.cwd}`,
       );
     }
     if (reaped > 0) console.warn(`[reap-runaway] reaped ${reaped} runaway orphan(s)`);

--- a/src/process-reaper.ts
+++ b/src/process-reaper.ts
@@ -680,10 +680,25 @@ export interface ReapMarkedOptions {
  * PPID != 1), and requiring it would make this a no-op in a container where Shepherd is PID 1 and
  * every process reads as PPID-1. It is recorded on the candidate for the log only.
  *
- * LOAD-BEARING INVARIANT: no code path may hard-delete a `sessions` row without archiving it first.
- * Because absent ⇒ spare, a hard-deleted session's marked orphans become permanently unreapable.
- * This holds today — the only `DELETE FROM sessions` (store.ts, pruneArchivedSessions) is scoped to
- * `status = 'archived'`.
+ * LOAD-BEARING TIMING CONSTRAINT — an orphan must be SWEPT BEFORE ITS SESSION ROW IS PRUNED.
+ *
+ * `archived` is the only status that authorises a kill, and `absent` spares. So a marked orphan is
+ * reapable only during the window between its session being archived and its row being deleted.
+ * `pruneArchivedSessions` (store.ts) hard-deletes archived rows — the very rows this sweep depends
+ * on — so once it runs, that session's surviving orphans are unreapable FOREVER. (An earlier
+ * version of this note claimed the invariant was "never hard-delete a row without archiving it
+ * first", and cited the prune as satisfying it. That was backwards: the prune deletes only archived
+ * rows, so it satisfies that phrasing exactly while causing the failure the note meant to exclude.)
+ *
+ * What actually guarantees the ordering is CADENCE, not a rule about deletion:
+ *   - the sweep runs at teardown (SessionService.archive, synchronously after store.archive), then
+ *     hourly;
+ *   - the prune runs at most DAILY (runDailySweep) and only past a retention window
+ *     (SESSION_RETENTION_DAYS = 30, SESSION_RETENTION_KEEP = 250).
+ * So an orphan gets a teardown sweep plus ~24 hourly sweeps before its row is even eligible to be
+ * pruned. The margin is enormous, but it is a MARGIN, not a proof — anything that shortens
+ * retention toward the sweep interval, or lengthens the sweep interval toward retention, erodes it.
+ * Keep the sweep strictly more frequent than the prune.
  *
  * Fails closed throughout: any missing probe, an unreadable environ/stat, or a throwing
  * `sessionStatus` reaps nothing.

--- a/src/process-reaper.ts
+++ b/src/process-reaper.ts
@@ -767,10 +767,17 @@ function scanPid(pid: number, ctx: SweepContext): Scanned | null {
 
 export function reapMarkedOrphans(opts: ReapMarkedOptions): {
   reaped: number;
+  /** Everything that cleared every gate — in `observe` mode, what WOULD have been killed. */
   observed: RunawayCandidate[];
+  /**
+   * The subset actually SIGKILLed. Strictly ⊆ `observed`, and smaller whenever the pid-recycle
+   * guard fired or `killPid` threw — so callers must log from THIS, not from `observed`, or their
+   * per-candidate lines will claim kills that never happened and contradict `reaped`.
+   */
+  killed: RunawayCandidate[];
 } {
   const { sessionStatus, ids, mode, minCpu, minAgeS, probes = defaultProbes } = opts;
-  const none = { reaped: 0, observed: [] as RunawayCandidate[] };
+  const none = { reaped: 0, observed: [] as RunawayCandidate[], killed: [] as RunawayCandidate[] };
   if (mode === "off") return none;
 
   // Fail closed: without every probe the gates can't be established, so reap nothing.
@@ -798,7 +805,7 @@ export function reapMarkedOrphans(opts: ReapMarkedOptions): {
   };
 
   const observed: RunawayCandidate[] = [];
-  let reaped = 0;
+  const killed: RunawayCandidate[] = [];
 
   for (const pid of listPids()) {
     const hit = scanPid(pid, ctx);
@@ -813,13 +820,13 @@ export function reapMarkedOrphans(opts: ReapMarkedOptions): {
 
     try {
       probes.killPid(pid, "SIGKILL");
-      reaped++;
+      killed.push(hit.candidate);
     } catch {
       /* best-effort: the process may have exited between the re-check and here */
     }
   }
 
-  return { reaped, observed };
+  return { reaped: killed.length, observed, killed };
 }
 
 // ── batched port scan ─────────────────────────────────────────────────────────

--- a/src/process-reaper.ts
+++ b/src/process-reaper.ts
@@ -67,10 +67,82 @@ export interface ReaperProbes {
    * the hot scanProcs() pollers never pay for it.
    */
   ppidForPid?(pid: number): number | null;
+  /**
+   * Every pid on the host, straight from /proc's numeric dirents. Deliberately NOT `scanProcs`:
+   * that one silently `continue`s past any pid whose /proc/<pid>/cwd readlink fails, and the
+   * runaway sweep must not depend on a readable cwd (it attributes by environ, not by directory).
+   * Optional + fail-closed: absent ⇒ the sweep reaps nothing.
+   */
+  listPids?(): number[];
+  /** A single process's comm (name), or "" when unreadable. */
+  commForPid?(pid: number): string;
+  /**
+   * A single process's environment, parsed from the NUL-separated /proc/<pid>/environ, or null when
+   * unreadable (process gone, or not ours). Read LAST in the sweep: unlike comm/stat this goes
+   * through access_remote_vm and takes the TARGET's mmap lock, so it can block on a stalled process.
+   */
+  environForPid?(pid: number): Record<string, string> | null;
+  /**
+   * CPU accounting + start time from /proc/<pid>/stat, in USER_HZ ticks. Null when unreadable.
+   * `cutime`/`cstime` are the CPU of already-REAPED children — load-bearing, see cpuBusyFraction.
+   */
+  cpuStatForPid?(pid: number): CpuStat | null;
+  /** System uptime in seconds (/proc/uptime), or null when unreadable. */
+  uptimeSeconds?(): number | null;
+  /** A process's cwd, for the log line only — never a gate. Null when unreadable. */
+  cwdForPid?(pid: number): string | null;
 }
+
+/** Raw CPU accounting for one process, in USER_HZ ticks (see {@link USER_HZ}). */
+export interface CpuStat {
+  utime: number;
+  stime: number;
+  /** CPU of reaped children — what makes a `wait()`-blocked supervisor shell visible. */
+  cutime: number;
+  cstime: number;
+  /** Ticks since boot at which the process started. Doubles as a pid-recycle fingerprint. */
+  starttime: number;
+}
+
+/**
+ * The `sysconf(_SC_CLK_TCK)` unit that /proc/<pid>/stat reports its times in — NOT the kernel's
+ * internal `HZ`. Universally 100 on Linux, and Node/Bun expose no `sysconf`, so it is hardcoded.
+ */
+export const USER_HZ = 100;
+
+/**
+ * Env var stamped on every agent spawn (issue #1144), inherited by every process the agent ever
+ * spawns. `/proc/<pid>/environ` is fixed at exec, so the marker survives `cd`, backgrounding,
+ * PID-1 reparenting and worktree deletion — which is what lets `reapMarkedOrphans` attribute an
+ * orphan to a session EXACTLY, rather than guessing from its cwd.
+ *
+ * ID DOMAIN — load-bearing: the value MUST be a `sessions`-table id, because the reaper resolves it
+ * against the store to decide whether the owning session is archived. The aux/satellite spawns
+ * (review.ts, plan-gate.ts, doc-agent.ts, standalone-critic.ts — all via `resolveAuxSpawn`) pass a
+ * critic/doc-agent id that is NOT a sessions row, so they are deliberately NOT marked: their leaks
+ * stay unmarked and are therefore always spared. If they are ever marked, they must use
+ * `descriptor.parentSessionId`, never their own id.
+ */
+export const SESSION_MARKER_ENV = "SHEPHERD_SESSION_ID";
 
 // The agent itself runs `claude` with cwd == worktree; never offer to kill it.
 const AGENT_COMMS = new Set(["claude", "codex"]);
+
+/**
+ * git spares. An agent's `git fetch` triggers a detached `git gc --auto` (gc.autoDetach defaults on)
+ * which INHERITS the session marker, is non-listening, and runs at ~100% CPU from birth on a large
+ * repo — it clears every other gate. SIGKILLing it strands a stale `gc.pid` lock, and the repo is
+ * then never gc'd again.
+ *
+ * `/proc/<pid>/comm` is kernel-truncated to TASK_COMM_LEN-1 = 15 chars, so `git-pack-objects` (16)
+ * surfaces as `git-pack-object` and can never match an exact entry — the `git-` PREFIX rule below is
+ * what actually covers it. The exact set is kept for the names that do fit.
+ */
+const GIT_COMMS = new Set(["git", "git-gc", "git-repack", "git-maintenance"]);
+
+function isGitComm(comm: string): boolean {
+  return GIT_COMMS.has(comm) || comm.startsWith("git-");
+}
 
 // Path segment every shepherd session/review worktree lives under. The orphan
 // sweeps refuse to act on any path lacking it, so a mistaken caller passing a repo
@@ -176,6 +248,75 @@ function readPpid(pid: number): number | null {
   return m ? Number(m[1]) : null;
 }
 
+/** Every numeric dirent under /proc — i.e. every pid on the host. */
+function readPids(): number[] {
+  try {
+    return readdirSync("/proc")
+      .filter((e) => /^\d+$/.test(e))
+      .map(Number);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Parse /proc/<pid>/stat.
+ *
+ * The comm field (2) is wrapped in parens AND may itself contain spaces and parens — e.g. a process
+ * named `foo (bar)`. So the only safe split point is the LAST ')': everything after it is field 3
+ * onward, whitespace-separated. Fields (1-indexed): 14 utime, 15 stime, 16 cutime, 17 cstime,
+ * 22 starttime — which land at offsets 11, 12, 13, 14 and 19 of that remainder.
+ */
+function readCpuStat(pid: number): CpuStat | null {
+  let text: string;
+  try {
+    text = readFileSync(`/proc/${pid}/stat`, "utf8");
+  } catch {
+    return null; // process gone, or not ours to inspect
+  }
+  const close = text.lastIndexOf(")");
+  if (close === -1) return null;
+  const f = text
+    .slice(close + 1)
+    .trim()
+    .split(/\s+/);
+  const at = (i: number) => Number(f[i]);
+  const stat = {
+    utime: at(11),
+    stime: at(12),
+    cutime: at(13),
+    cstime: at(14),
+    starttime: at(19),
+  };
+  return Object.values(stat).every(Number.isFinite) ? stat : null;
+}
+
+/** Parse the NUL-separated /proc/<pid>/environ into a map. */
+function readEnviron(pid: number): Record<string, string> | null {
+  let raw: string;
+  try {
+    raw = readFileSync(`/proc/${pid}/environ`, "utf8");
+  } catch {
+    return null; // process gone, or not ours to inspect
+  }
+  const env: Record<string, string> = {};
+  for (const entry of raw.split("\0")) {
+    const eq = entry.indexOf("=");
+    if (eq > 0) env[entry.slice(0, eq)] = entry.slice(eq + 1);
+  }
+  return env;
+}
+
+/** System uptime in seconds — the first field of /proc/uptime. */
+function readUptimeSeconds(): number | null {
+  try {
+    const n = Number(readFileSync("/proc/uptime", "utf8").trim().split(/\s+/)[0]);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Read the socket inodes held open by a single process from /proc/<pid>/fd. */
 function readSocketInodes(pid: number): number[] {
   let fds: string[];
@@ -244,6 +385,32 @@ const defaultProbes: ReaperProbes = {
   },
   ppidForPid(pid) {
     return readPpid(pid);
+  },
+  listPids() {
+    return readPids();
+  },
+  commForPid(pid) {
+    try {
+      return readFileSync(`/proc/${pid}/comm`, "utf8").trim();
+    } catch {
+      return "";
+    }
+  },
+  environForPid(pid) {
+    return readEnviron(pid);
+  },
+  cpuStatForPid(pid) {
+    return readCpuStat(pid);
+  },
+  uptimeSeconds() {
+    return readUptimeSeconds();
+  },
+  cwdForPid(pid) {
+    try {
+      return readlinkSync(`/proc/${pid}/cwd`);
+    } catch {
+      return null;
+    }
   },
   readTranscript(path) {
     try {
@@ -437,6 +604,222 @@ export function reapDeletedWorktreeOrphans(probes: ReaperProbes = defaultProbes)
     }
   }
   return { reaped };
+}
+
+// ── #1144: resource-gated reaper for MARKED orphans ──────────────────────────
+
+/** What the store knows about the session a marked process claims to belong to. */
+export type SessionTerminality =
+  /** row present, `status === 'archived'` — the agent is definitively done. */
+  | "archived"
+  /** row present, any other status (running/idle/blocked/done, husk, mid-respawn). */
+  | "live"
+  /** no such row in THIS instance's store. */
+  | "absent";
+
+/** A process that cleared every gate (or, in `observe` mode, would have). */
+export interface RunawayCandidate {
+  pid: number;
+  comm: string;
+  sessionId: string;
+  cwd: string | null;
+  /** Lifetime-average fraction of ONE core, incl. reaped children. */
+  cpuFraction: number;
+  ageSeconds: number;
+  /** Recorded for the log only — see the note on PPID below. */
+  ppid: number | null;
+}
+
+export interface ReapMarkedOptions {
+  /**
+   * Resolve a marker's session id against the store. MUST THROW (not return "absent") when the
+   * store is unavailable — "absent" is a positive claim that no such session exists here, and the
+   * sweep treats an unavailable store as a reason to reap NOTHING.
+   */
+  sessionStatus(id: string): SessionTerminality;
+  /**
+   * When given, only reap marked processes whose session id is in this set (the teardown call
+   * scopes to the just-archived ids). Omitted ⇒ any archived session qualifies (boot/hourly).
+   */
+  ids?: ReadonlySet<string>;
+  mode: "armed" | "observe" | "off";
+  /** Lifetime-average fraction of one core (config.reapRunawayMinCpu). */
+  minCpu: number;
+  /** Minimum process age in seconds (config.reapRunawayMinAgeS). */
+  minAgeS: number;
+  probes?: ReaperProbes;
+}
+
+/**
+ * SIGKILL processes an agent left burning a core after its session was archived (issue #1144).
+ *
+ * WHAT MAKES THIS SAFE is the conjunction of two gates, and ONLY those two:
+ *
+ *  - PROVENANCE — the process carries {@link SESSION_MARKER_ENV} in its environ, so an *agent*
+ *    spawned it. Attribution is exact, not a guess from its cwd: the marker is inherited by every
+ *    descendant and survives `cd`, backgrounding, PID-1 reparenting and worktree deletion. An
+ *    operator's own `nohup cargo bench &`, their editor's `rust-analyzer`, a stray `ffmpeg` — none
+ *    of them carry it, so none of them can EVER be a candidate. Unmarked ⇒ spared. Unreadable ⇒ spared.
+ *  - TERMINALITY — the session that owns the marker is PRESENT in the store and `archived`, so its
+ *    agent is definitively finished. This is what spares an agent's in-flight `cargo build &`: a
+ *    one-shot Bash tool call reparents its background job to PID 1 the moment the call's shell exits,
+ *    while the agent is still working. PPID-1 means signal-unmanageable, NOT abandoned.
+ *    "absent" ⇒ SPARED: SHEPHERD_DB/SHEPHERD_PORT make a second Shepherd on one host a supported
+ *    setup, and reaping on absent would let instance A SIGKILL instance B's LIVE session's work.
+ *
+ * The CPU + age pair is NOT a safety floor — it is a PERFORMANCE PREFILTER. Reading environ goes
+ * through access_remote_vm and takes the target's mmap lock; without a cheap gate in front, an
+ * hourly host-wide sweep would take that lock hundreds of times on the event loop, any one of which
+ * can block on a stalled process. So the gates run cheapest-first and environ is read LAST, for the
+ * handful of hot, old, non-agent, non-git, non-listening survivors. Semantics are unaffected (every
+ * gate is conjunctive); only the cost is. It does mean the threshold silently costs coverage (a
+ * late-onset spin, or a leak at 60% of a core, is missed) — an accepted trade, see #1144.
+ *
+ * PPID is deliberately NOT a gate. It is redundant here (an archived session's agent is dead, so a
+ * survivor IS an orphan), it would cost coverage (a marked child of a still-live marked wrapper has
+ * PPID != 1), and requiring it would make this a no-op in a container where Shepherd is PID 1 and
+ * every process reads as PPID-1. It is recorded on the candidate for the log only.
+ *
+ * LOAD-BEARING INVARIANT: no code path may hard-delete a `sessions` row without archiving it first.
+ * Because absent ⇒ spare, a hard-deleted session's marked orphans become permanently unreapable.
+ * This holds today — the only `DELETE FROM sessions` (store.ts, pruneArchivedSessions) is scoped to
+ * `status = 'archived'`.
+ *
+ * Fails closed throughout: any missing probe, an unreadable environ/stat, or a throwing
+ * `sessionStatus` reaps nothing.
+ */
+/** Everything the per-pid gate chain needs, resolved once per sweep. */
+interface SweepContext extends Required<
+  Pick<ReapMarkedOptions, "sessionStatus" | "minCpu" | "minAgeS">
+> {
+  ids: ReadonlySet<string> | undefined;
+  probes: ReaperProbes;
+  /** System uptime (s), for deriving each process's age from its starttime. */
+  uptime: number;
+  /** True when the pid holds any listening socket. Builds its inode→port map at most once. */
+  isListening(pid: number): boolean;
+}
+
+/** A candidate plus the `starttime` that fingerprints it, for the pre-kill recycle check. */
+interface Scanned {
+  candidate: RunawayCandidate;
+  starttime: number;
+}
+
+/**
+ * The gate chain for ONE pid, cheapest-first — see {@link reapMarkedOrphans} for why the order
+ * matters and why provenance + terminality (and NOT the CPU gate, and NOT PPID) are what make this
+ * safe. Returns null the moment any gate rejects, so the expensive reads are never reached for the
+ * overwhelming majority of pids.
+ */
+function scanPid(pid: number, ctx: SweepContext): Scanned | null {
+  const { probes, uptime, minAgeS, minCpu, ids } = ctx;
+  if (pid === process.pid) return null; // never reap the server itself
+
+  // ── cheap gates first: one comm read, one stat read ────────────────────────
+  const comm = probes.commForPid!(pid);
+  if (AGENT_COMMS.has(comm) || isGitComm(comm)) return null;
+
+  const stat = probes.cpuStatForPid!(pid);
+  if (!stat) return null;
+
+  const ageSeconds = uptime - stat.starttime / USER_HZ;
+  if (!(ageSeconds >= minAgeS)) return null; // NaN-safe
+
+  // cutime/cstime (the CPU of already-REAPED children) are load-bearing: a
+  // `while true; do <work>; done &` supervisor sits blocked in wait() with its own utime/stime at
+  // ~0, while each child burns a core and dies under the age floor. Without these columns the
+  // shell falls below the threshold, every child is too young, and the leak is never reaped.
+  const cpuSeconds = (stat.utime + stat.stime + stat.cutime + stat.cstime) / USER_HZ;
+  const cpuFraction = cpuSeconds / ageSeconds;
+  if (!(cpuFraction >= minCpu)) return null;
+
+  // A busy-loop listens on nothing (#1133), so this costs zero coverage on the target class while
+  // sparing a marked dev server an agent started (`bun run dev &`).
+  if (ctx.isListening(pid)) return null;
+
+  // ── expensive gates last: reading environ takes the TARGET's mmap lock ─────
+  const sessionId = probes.environForPid!(pid)?.[SESSION_MARKER_ENV];
+  if (!sessionId) return null; // unmarked, or unreadable ⇒ not ours ⇒ spared
+  if (ids && !ids.has(sessionId)) return null;
+
+  let terminality: SessionTerminality;
+  try {
+    terminality = ctx.sessionStatus(sessionId);
+  } catch {
+    return null; // store unavailable ⇒ terminality unprovable ⇒ spare
+  }
+  if (terminality !== "archived") return null;
+
+  return {
+    starttime: stat.starttime,
+    candidate: {
+      pid,
+      comm,
+      sessionId,
+      cwd: probes.cwdForPid?.(pid) ?? null,
+      cpuFraction,
+      ageSeconds,
+      ppid: probes.ppidForPid?.(pid) ?? null,
+    },
+  };
+}
+
+export function reapMarkedOrphans(opts: ReapMarkedOptions): {
+  reaped: number;
+  observed: RunawayCandidate[];
+} {
+  const { sessionStatus, ids, mode, minCpu, minAgeS, probes = defaultProbes } = opts;
+  const none = { reaped: 0, observed: [] as RunawayCandidate[] };
+  if (mode === "off") return none;
+
+  // Fail closed: without every probe the gates can't be established, so reap nothing.
+  const { listPids, commForPid, environForPid, cpuStatForPid, uptimeSeconds } = probes;
+  if (!listPids || !commForPid || !environForPid || !cpuStatForPid || !uptimeSeconds) return none;
+  const uptime = uptimeSeconds();
+  if (uptime === null) return none;
+
+  // Built at most once per sweep, and only if some pid actually reaches the listening gate.
+  let inodeMap: Map<number, number> | null = null;
+  const batched =
+    typeof probes.inodeToPortMap === "function" && typeof probes.socketInodesForPid === "function";
+  const ctx: SweepContext = {
+    sessionStatus,
+    ids,
+    minCpu,
+    minAgeS,
+    probes,
+    uptime,
+    isListening: (pid) => {
+      if (!batched) return probes.portsForPid(pid).length > 0;
+      inodeMap ??= probes.inodeToPortMap!();
+      return probes.socketInodesForPid!(pid).some((inode) => inodeMap!.has(inode));
+    },
+  };
+
+  const observed: RunawayCandidate[] = [];
+  let reaped = 0;
+
+  for (const pid of listPids()) {
+    const hit = scanPid(pid, ctx);
+    if (!hit) continue;
+    observed.push(hit.candidate);
+    if (mode !== "armed") continue;
+
+    // Pid-recycle guard: between the scan above and the kill below, the pid may have been recycled
+    // onto an unrelated process. starttime is the kernel's own fingerprint for "still the same one".
+    const recheck = cpuStatForPid(pid);
+    if (!recheck || recheck.starttime !== hit.starttime) continue;
+
+    try {
+      probes.killPid(pid, "SIGKILL");
+      reaped++;
+    } catch {
+      /* best-effort: the process may have exited between the re-check and here */
+    }
+  }
+
+  return { reaped, observed };
 }
 
 // ── batched port scan ─────────────────────────────────────────────────────────

--- a/src/service.ts
+++ b/src/service.ts
@@ -4624,15 +4624,23 @@ export class SessionService {
     removeEgressTmp(id);
     this.attributeLearningReward(s);
     this.deps.store.archive(id);
-    // AFTER store.archive, so the reaper's terminality gate sees `archived`. Suppressed under
-    // archiveMany, which sweeps ONCE for the whole batch — a per-id call there would mean N
-    // host-wide /proc enumerations on the event loop.
-    if (!this.bulkArchiving) this.deps.reapRunaway?.(new Set([id]));
+    // AFTER store.archive, so the reaper's terminality gate sees `archived`. While a batch is
+    // draining we DEFER rather than skip: `archive` awaits (herdr.stop, the 15s beforeArchive
+    // window), so a timer-driven archive (automerge / drain / merge-teardown) can interleave with
+    // archiveMany's loop. A boolean "suppress" would drop that id's sweep entirely — it is not in
+    // `cleared`, so the post-batch sweep would miss it too. Collecting the id instead means every
+    // archived session is swept exactly once, in one host-wide /proc enumeration.
+    if (this.pendingRunawayIds) this.pendingRunawayIds.add(id);
+    else this.deps.reapRunaway?.(new Set([id]));
     return reaped;
   }
 
-  /** Set only while `archiveMany` is draining its loop — see the sweep call in `archive`. */
-  private bulkArchiving = false;
+  /**
+   * Non-null only while `archiveMany` is draining. Every id archived in that window — the batch's
+   * own, and any that interleaves from a concurrent caller — lands here and is swept once at the
+   * end. See the deferral in `archive`.
+   */
+  private pendingRunawayIds: Set<string> | null = null;
 
   /**
    * Startup reconcile: remove any orphaned `shepherd-egress/<id>` temp dir whose id is
@@ -4662,8 +4670,11 @@ export class SessionService {
     const cleared: string[] = [];
     let leftovers = 0;
     // The runaway sweep enumerates every pid on the host, so it must run ONCE for the batch, not
-    // once per id — hence the suppress-then-sweep-once dance (see `archive`).
-    this.bulkArchiving = true;
+    // once per id — hence the defer-then-sweep-once dance (see `archive`). Nesting is possible in
+    // principle, so an already-open collector is reused rather than clobbered.
+    const outer = this.pendingRunawayIds;
+    const pending = outer ?? new Set<string>();
+    this.pendingRunawayIds = pending;
     try {
       for (const id of ids) {
         const s = this.deps.store.get(id);
@@ -4677,9 +4688,12 @@ export class SessionService {
         }
       }
     } finally {
-      this.bulkArchiving = false;
+      // Only the OUTERMOST archiveMany closes the collector and sweeps.
+      if (!outer) this.pendingRunawayIds = null;
     }
-    if (cleared.length > 0) this.deps.reapRunaway?.(new Set(cleared));
+    // Sweeps every id archived during the window — the batch's own AND any concurrent archive that
+    // interleaved with our awaits (those are not in `cleared`, so they'd otherwise be missed).
+    if (!outer && pending.size > 0) this.deps.reapRunaway?.(pending);
     return { cleared, leftovers };
   }
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -49,6 +49,7 @@ import {
   apiKeyPassthroughEnv,
 } from "./spawn-auth";
 import type { Leftover, ProcessReaper } from "./process-reaper";
+import { SESSION_MARKER_ENV } from "./process-reaper";
 import type { PreviewService } from "./preview";
 import type { TelemetryService } from "./telemetry";
 import { extractTargetPaths, planHouseRulesInjection, renderHouseRulesBlock } from "./house-rules";
@@ -165,6 +166,14 @@ export interface ServiceDeps {
   copyUploads?: (uploads: string[], worktreePath: string) => UploadCopyResult[];
   /** Detects/terminates leftover subprocesses at close; absent in tests that skip it. */
   reaper?: Pick<ProcessReaper, "detect" | "reap" | "stopListenersOnPort">;
+  /**
+   * Reap runaway orphans the agent left behind, for the sessions just archived (issue #1144).
+   * Called at the END of teardown, after `store.archive`, so the reaper's terminality gate sees
+   * `archived`. This is the ONLY teardown reap a NON-isolated session gets: `reapOrphansUnder`
+   * hangs off `worktree.remove()`, which teardown calls only `if (s.isolated)` — that hole IS the
+   * bug #1144 tracks. Absent in tests that skip it.
+   */
+  reapRunaway?: (ids: Set<string>) => void;
   /** Live preview service; provides devPortFor for stopPreview. Absent → stopPreview returns not_found. */
   preview?: Pick<PreviewService, "devPortFor">;
   /** Fast-poll one session's PR (= prPoller.pollSession), to nudge merge detection
@@ -2069,7 +2078,14 @@ export class SessionService {
           home: homedir(),
           nodeBinReal,
           term: process.env.TERM,
-          extraEnv: { ...passthroughEnv, ...rendererEnv, ...patchEnv },
+          // SESSION_MARKER_ENV rides the membrane's --setenv loop so it survives bwrap's
+          // --clearenv (see sandbox.ts). Last, so nothing above can shadow it.
+          extraEnv: {
+            ...passthroughEnv,
+            ...rendererEnv,
+            ...patchEnv,
+            [SESSION_MARKER_ENV]: ctx.sessionId,
+          },
           // api-key mode: bind the helper RO + mask the OAuth credential in place
           // (the operator's ~/.claude customizations stay bound). Subscription: null/false.
           ...apiKeyAuth.membraneFields,
@@ -2091,7 +2107,18 @@ export class SessionService {
     // credential-less mirror dir. The membrane case masks creds in place (keeping
     // the operator's real ~/.claude customizations), so it needs no env override.
     // The egress branch is always willWrap, so this is undefined there. patchEnv LAST.
-    const spawnEnv = { ...apiKeyPassthrough, ...rendererEnv, ...patchEnv };
+    //
+    // SESSION_MARKER_ENV (issue #1144) stamps the session id on the agent and — by inheritance —
+    // on every process it ever spawns. /proc/<pid>/environ is fixed at exec, so the marker survives
+    // `cd`, backgrounding, PID-1 reparenting and worktree deletion: it is what lets the runaway
+    // reaper attribute an orphan to a session without guessing from its cwd. Stamped on BOTH paths
+    // (here for trusted, and on membrane.extraEnv above for sandboxed) so they stay uniform.
+    const spawnEnv = {
+      ...apiKeyPassthrough,
+      ...rendererEnv,
+      ...patchEnv,
+      [SESSION_MARKER_ENV]: ctx.sessionId,
+    };
     const agent = await this.deps.herdr.start(ctx.name, ctx.worktreePath, wrapped, spawnEnv);
     // Start the egress drop-watcher AFTER herdr.start (the agent is now running).
     if (egressOn && egressAllowlist && egressDnsLog) {
@@ -4597,8 +4624,15 @@ export class SessionService {
     removeEgressTmp(id);
     this.attributeLearningReward(s);
     this.deps.store.archive(id);
+    // AFTER store.archive, so the reaper's terminality gate sees `archived`. Suppressed under
+    // archiveMany, which sweeps ONCE for the whole batch — a per-id call there would mean N
+    // host-wide /proc enumerations on the event loop.
+    if (!this.bulkArchiving) this.deps.reapRunaway?.(new Set([id]));
     return reaped;
   }
+
+  /** Set only while `archiveMany` is draining its loop — see the sweep call in `archive`. */
+  private bulkArchiving = false;
 
   /**
    * Startup reconcile: remove any orphaned `shepherd-egress/<id>` temp dir whose id is
@@ -4627,17 +4661,25 @@ export class SessionService {
   async archiveMany(ids: string[]): Promise<{ cleared: string[]; leftovers: number }> {
     const cleared: string[] = [];
     let leftovers = 0;
-    for (const id of ids) {
-      const s = this.deps.store.get(id);
-      if (!s) continue;
-      const keys = this.deps.reaper?.detect(s).map((l) => l.key) ?? [];
-      try {
-        leftovers += await this.archive(id, keys); // count what was reaped, not what was detected
-        cleared.push(id);
-      } catch {
-        // skip this one; its row stays active and gets no archived event
+    // The runaway sweep enumerates every pid on the host, so it must run ONCE for the batch, not
+    // once per id — hence the suppress-then-sweep-once dance (see `archive`).
+    this.bulkArchiving = true;
+    try {
+      for (const id of ids) {
+        const s = this.deps.store.get(id);
+        if (!s) continue;
+        const keys = this.deps.reaper?.detect(s).map((l) => l.key) ?? [];
+        try {
+          leftovers += await this.archive(id, keys); // count what was reaped, not what was detected
+          cleared.push(id);
+        } catch {
+          // skip this one; its row stays active and gets no archived event
+        }
       }
+    } finally {
+      this.bulkArchiving = false;
     }
+    if (cleared.length > 0) this.deps.reapRunaway?.(new Set(cleared));
     return { cleared, leftovers };
   }
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -4689,11 +4689,28 @@ export class SessionService {
       }
     } finally {
       // Only the OUTERMOST archiveMany closes the collector and sweeps.
-      if (!outer) this.pendingRunawayIds = null;
+      //
+      // The sweep MUST run in the `finally`, not after the try/finally. `store.get` and
+      // `reaper.detect` above sit outside the inner try/catch, so a throw from either escapes the
+      // loop — and every id already archived earlier in this batch has DEFERRED its own teardown
+      // sweep into `pending` rather than running it. Sweeping after the try/finally would clear the
+      // collector and then never reach the call, silently downgrading those sessions to the hourly
+      // net (up to an hour of a leaked core). Deferring a sweep only makes sense if the deferred
+      // sweep is guaranteed to happen.
+      if (!outer) {
+        this.pendingRunawayIds = null;
+        // Never let the sweep mask the original exception on the throwing path.
+        if (pending.size > 0) {
+          try {
+            // Covers every id archived during the window — the batch's own AND any concurrent
+            // archive that interleaved with our awaits (those are not in `cleared`).
+            this.deps.reapRunaway?.(pending);
+          } catch (err) {
+            console.warn("[reap-runaway] batch sweep failed:", err);
+          }
+        }
+      }
     }
-    // Sweeps every id archived during the window — the batch's own AND any concurrent archive that
-    // interleaved with our awaits (those are not in `cleared`, so they'd otherwise be missed).
-    if (!outer && pending.size > 0) this.deps.reapRunaway?.(pending);
     return { cleared, leftovers };
   }
 }

--- a/test/process-reaper.test.ts
+++ b/test/process-reaper.test.ts
@@ -4,7 +4,11 @@ import {
   leftoverKey,
   scanClaudeAliveByWorktree,
   reapDeletedWorktreeOrphans,
+  reapMarkedOrphans,
+  USER_HZ,
+  type CpuStat,
   type ReaperProbes,
+  type ReapMarkedOptions,
 } from "../src/process-reaper";
 import { jsonlPathFor } from "../src/usage";
 
@@ -494,4 +498,316 @@ test("reapDeletedWorktreeOrphans: spares a deleted cwd that isn't a shepherd wor
   );
   expect(reaped).toBe(0);
   expect(k.killed).toEqual([]);
+});
+
+// ── #1144: resource-gated reaper for MARKED orphans ──────────────────────────
+//
+// Safety here is provenance ∧ terminality. The regressions below are the ones that bit during
+// design review: an agent's in-flight `cargo build &` is PPID-1 but NOT abandoned; a second
+// Shepherd instance's live session must not be reaped; a `while true` supervisor hides its burn in
+// cutime/cstime. Each has a named test.
+
+const MARKED = "sess-archived";
+const HZ = USER_HZ;
+
+/** A /proc/<pid>/stat sample: `cpu` = fraction of one core burned over `ageS`, split as asked. */
+function cpuStat(
+  over: {
+    ageS?: number;
+    cpu?: number;
+    childCpu?: number;
+    starttime?: number;
+    uptime?: number;
+  } = {},
+): CpuStat {
+  const ageS = over.ageS ?? 600; // 10 min — comfortably past the 5-min floor
+  const uptime = over.uptime ?? 100_000;
+  const own = (over.cpu ?? 1) * ageS * HZ; // ticks of own CPU
+  const child = (over.childCpu ?? 0) * ageS * HZ; // ticks accrued from reaped children
+  return {
+    utime: own,
+    stime: 0,
+    cutime: child,
+    cstime: 0,
+    starttime: over.starttime ?? (uptime - ageS) * HZ,
+  };
+}
+
+/** Probes for a single hot, marked, non-listening orphan at ORPHAN_PID. Override as needed. */
+function markedProbes(over: Partial<ReaperProbes> = {}): ReaperProbes {
+  return makeProbes({
+    listPids: () => [ORPHAN_PID],
+    commForPid: () => "yes",
+    environForPid: () => ({ SHEPHERD_SESSION_ID: MARKED }),
+    cpuStatForPid: () => cpuStat(),
+    uptimeSeconds: () => 100_000,
+    ppidForPid: () => 1,
+    portsForPid: () => [],
+    ...over,
+  });
+}
+
+const reapOpts = (over: Partial<ReapMarkedOptions> = {}): ReapMarkedOptions => ({
+  sessionStatus: () => "archived",
+  mode: "armed",
+  minCpu: 0.8,
+  minAgeS: 300,
+  ...over,
+});
+
+test("#1144 gap 2: a marked orphan of an ARCHIVED session is SIGKILLed", () => {
+  const k = killSpy();
+  const r = reapMarkedOrphans(reapOpts({ probes: markedProbes({ killPid: k.killPid }) }));
+  expect(r.reaped).toBe(1);
+  expect(k.killed).toEqual([{ pid: ORPHAN_PID, signal: "SIGKILL" }]);
+  expect(r.observed[0]!.sessionId).toBe(MARKED);
+});
+
+test("#1144 gap 1: cwd is irrelevant — an orphan that chdir'd out to $HOME is still reaped", () => {
+  // The whole point of provenance: the marker survives `cd`. A cwd-based sweep could never see this.
+  const k = killSpy();
+  const r = reapMarkedOrphans(
+    reapOpts({
+      probes: markedProbes({ cwdForPid: () => "/home/u", killPid: k.killPid }),
+    }),
+  );
+  expect(r.reaped).toBe(1);
+  expect(r.observed[0]!.cwd).toBe("/home/u");
+});
+
+test("#1144: an UNMARKED hot process (operator's rust-analyzer / nohup bench) is NEVER a candidate", () => {
+  const k = killSpy();
+  const r = reapMarkedOrphans(
+    reapOpts({
+      probes: markedProbes({
+        commForPid: () => "rust-analyzer",
+        environForPid: () => ({ PATH: "/usr/bin" }), // no marker
+        killPid: k.killPid,
+      }),
+    }),
+  );
+  expect(r.reaped).toBe(0);
+  expect(r.observed).toEqual([]);
+  expect(k.killed).toEqual([]);
+});
+
+test("#1144: an unreadable environ is spared (fail closed)", () => {
+  const k = killSpy();
+  const r = reapMarkedOrphans(
+    reapOpts({ probes: markedProbes({ environForPid: () => null, killPid: k.killPid }) }),
+  );
+  expect(r.reaped).toBe(0);
+  expect(k.killed).toEqual([]);
+});
+
+// ── terminality: the in-flight-build regressions ─────────────────────────────
+
+test("#1144 REGRESSION: an agent's in-flight `cargo build &` (live session) is SPARED", () => {
+  // PPID-1 but NOT abandoned: a one-shot Bash tool call reparents its background job to PID 1 the
+  // moment that call's shell exits, while the agent is still working and tailing the log.
+  const k = killSpy();
+  const r = reapMarkedOrphans(
+    reapOpts({
+      sessionStatus: () => "live",
+      probes: markedProbes({ commForPid: () => "cargo", killPid: k.killPid }),
+    }),
+  );
+  expect(r.reaped).toBe(0);
+  expect(k.killed).toEqual([]);
+});
+
+test("#1144 REGRESSION: a second instance's session (row ABSENT here) is SPARED", () => {
+  // SHEPHERD_DB/SHEPHERD_PORT make two Shepherds on one host supported. Reaping on "absent" would
+  // let instance A SIGKILL instance B's LIVE session's work.
+  const k = killSpy();
+  const r = reapMarkedOrphans(
+    reapOpts({ sessionStatus: () => "absent", probes: markedProbes({ killPid: k.killPid }) }),
+  );
+  expect(r.reaped).toBe(0);
+  expect(k.killed).toEqual([]);
+});
+
+test("#1144: a throwing sessionStatus (store unavailable) kills nothing", () => {
+  const k = killSpy();
+  const r = reapMarkedOrphans(
+    reapOpts({
+      sessionStatus: () => {
+        throw new Error("store closed");
+      },
+      probes: markedProbes({ killPid: k.killPid }),
+    }),
+  );
+  expect(r.reaped).toBe(0);
+  expect(k.killed).toEqual([]);
+});
+
+test("#1144: `ids` scopes the sweep — a marked orphan outside the set is spared", () => {
+  const k = killSpy();
+  const inSet = reapMarkedOrphans(
+    reapOpts({ ids: new Set([MARKED]), probes: markedProbes({ killPid: k.killPid }) }),
+  );
+  expect(inSet.reaped).toBe(1);
+  const outOfSet = reapMarkedOrphans(
+    reapOpts({ ids: new Set(["other"]), probes: markedProbes({ killPid: k.killPid }) }),
+  );
+  expect(outOfSet.reaped).toBe(0);
+});
+
+// ── the supervisor busy-loop (cutime/cstime) ─────────────────────────────────
+
+test("#1144 REGRESSION: a `while true` supervisor shell is reaped via cutime/cstime", () => {
+  // The shell sits blocked in wait(): its OWN utime/stime are ~0 while each short-lived child burns
+  // a core and dies under the age floor. Only the reaped-children columns reveal the burn.
+  const k = killSpy();
+  const r = reapMarkedOrphans(
+    reapOpts({
+      probes: markedProbes({
+        commForPid: () => "bash",
+        cpuStatForPid: () => cpuStat({ cpu: 0.01, childCpu: 0.99 }),
+        killPid: k.killPid,
+      }),
+    }),
+  );
+  expect(r.reaped).toBe(1);
+  expect(k.killed).toEqual([{ pid: ORPHAN_PID, signal: "SIGKILL" }]);
+});
+
+test("#1144: that same supervisor would be MISSED if cutime/cstime were dropped (guards the fix)", () => {
+  // Same process, but with the children's CPU erased — proving the columns are load-bearing and a
+  // future "simplification" that drops them silently reintroduces the leak.
+  const r = reapMarkedOrphans(
+    reapOpts({
+      probes: markedProbes({
+        commForPid: () => "bash",
+        cpuStatForPid: () => ({ ...cpuStat({ cpu: 0.01, childCpu: 0.99 }), cutime: 0, cstime: 0 }),
+      }),
+    }),
+  );
+  expect(r.reaped).toBe(0);
+});
+
+// ── spares ───────────────────────────────────────────────────────────────────
+
+test("#1144: git-family comms are spared, incl. the 15-char-truncated `git-pack-object`", () => {
+  // /proc/<pid>/comm truncates at TASK_COMM_LEN-1 = 15, so `git-pack-objects` (16) can never match
+  // an exact entry — the `git-` prefix rule is what covers it. `git gc --auto` is detached by
+  // gc.autoDetach, INHERITS the marker, is non-listening and pegs a core from birth; SIGKILLing it
+  // strands a stale gc.pid lock and the repo is then never gc'd.
+  for (const comm of ["git", "git-gc", "git-repack", "git-maintenance", "git-pack-object"]) {
+    const k = killSpy();
+    const r = reapMarkedOrphans(
+      reapOpts({ probes: markedProbes({ commForPid: () => comm, killPid: k.killPid }) }),
+    );
+    expect({ comm, reaped: r.reaped }).toEqual({ comm, reaped: 0 });
+    expect(k.killed).toEqual([]);
+  }
+});
+
+test("#1144: a LISTENING marked process (an agent-started dev server) is spared", () => {
+  const k = killSpy();
+  const r = reapMarkedOrphans(
+    reapOpts({
+      probes: markedProbes({
+        commForPid: () => "vite",
+        portsForPid: () => [5174],
+        killPid: k.killPid,
+      }),
+    }),
+  );
+  expect(r.reaped).toBe(0);
+  expect(k.killed).toEqual([]);
+});
+
+test("#1144: below the CPU threshold, and under the age floor even at 100%, are spared", () => {
+  const quiet = reapMarkedOrphans(
+    reapOpts({ probes: markedProbes({ cpuStatForPid: () => cpuStat({ cpu: 0.2 }) }) }),
+  );
+  expect(quiet.reaped).toBe(0);
+  const young = reapMarkedOrphans(
+    reapOpts({ probes: markedProbes({ cpuStatForPid: () => cpuStat({ ageS: 60, cpu: 1 }) }) }),
+  );
+  expect(young.reaped).toBe(0);
+});
+
+test("#1144: the agent itself, and the shepherd server's own pid, are spared", () => {
+  for (const comm of ["claude", "codex"]) {
+    const r = reapMarkedOrphans(reapOpts({ probes: markedProbes({ commForPid: () => comm }) }));
+    expect(r.reaped).toBe(0);
+  }
+  const self = reapMarkedOrphans(
+    reapOpts({ probes: markedProbes({ listPids: () => [process.pid] }) }),
+  );
+  expect(self.reaped).toBe(0);
+});
+
+test("#1144: a missing probe reaps nothing (fail closed)", () => {
+  // makeProbes() omits every #1144 probe.
+  const r = reapMarkedOrphans(reapOpts({ probes: makeProbes() }));
+  expect(r.reaped).toBe(0);
+});
+
+test("#1144: mode `observe` logs the candidate but never kills; `off` does nothing at all", () => {
+  const k = killSpy();
+  const obs = reapMarkedOrphans(
+    reapOpts({ mode: "observe", probes: markedProbes({ killPid: k.killPid }) }),
+  );
+  expect(obs.reaped).toBe(0);
+  expect(obs.observed).toHaveLength(1); // still surfaced for the log
+  expect(k.killed).toEqual([]);
+
+  const off = reapMarkedOrphans(
+    reapOpts({ mode: "off", probes: markedProbes({ killPid: k.killPid }) }),
+  );
+  expect(off.observed).toEqual([]);
+  expect(k.killed).toEqual([]);
+});
+
+test("#1144: a pid recycled between scan and kill is NOT killed (starttime fingerprint)", () => {
+  const k = killSpy();
+  let call = 0;
+  const r = reapMarkedOrphans(
+    reapOpts({
+      probes: markedProbes({
+        // 1st read: the candidate. 2nd (pre-kill re-check): a different process on the same pid.
+        cpuStatForPid: () => (++call === 1 ? cpuStat() : cpuStat({ starttime: 999 })),
+        killPid: k.killPid,
+      }),
+    }),
+  );
+  expect(r.reaped).toBe(0);
+  expect(k.killed).toEqual([]);
+});
+
+// ── enumeration + gate ordering ──────────────────────────────────────────────
+
+test("#1144: a candidate whose cwd is UNREADABLE is still found (no cwd dependency)", () => {
+  // scanProcs() silently drops such pids; this sweep enumerates /proc directly, so it must not.
+  const k = killSpy();
+  const r = reapMarkedOrphans(
+    reapOpts({ probes: markedProbes({ cwdForPid: () => null, killPid: k.killPid }) }),
+  );
+  expect(r.reaped).toBe(1);
+  expect(r.observed[0]!.cwd).toBeNull();
+});
+
+test("#1144: environ is read LAST — an idle process never has its mmap lock taken", () => {
+  // Reading environ goes through access_remote_vm and takes the TARGET's mmap lock, so it can block
+  // on a stalled process. On a host of mostly-idle pids it must never be reached.
+  const environReads: number[] = [];
+  const IDLE = ORPHAN_PID + 1;
+  const r = reapMarkedOrphans(
+    reapOpts({
+      probes: markedProbes({
+        listPids: () => [ORPHAN_PID, IDLE],
+        commForPid: (pid) => (pid === IDLE ? "chrome" : "yes"),
+        cpuStatForPid: (pid) => (pid === IDLE ? cpuStat({ cpu: 0 }) : cpuStat()),
+        environForPid: (pid) => {
+          environReads.push(pid);
+          return { SHEPHERD_SESSION_ID: MARKED };
+        },
+      }),
+    }),
+  );
+  expect(r.reaped).toBe(1);
+  expect(environReads).toEqual([ORPHAN_PID]); // the idle chrome was never touched
 });

--- a/test/process-reaper.test.ts
+++ b/test/process-reaper.test.ts
@@ -776,6 +776,25 @@ test("#1144: a pid recycled between scan and kill is NOT killed (starttime finge
   );
   expect(r.reaped).toBe(0);
   expect(k.killed).toEqual([]);
+  // It WAS a candidate — it just wasn't killed. Callers must log from `killed`, not `observed`,
+  // or the per-candidate lines would claim a kill that never happened and contradict `reaped`.
+  expect(r.observed).toHaveLength(1);
+  expect(r.killed).toEqual([]);
+});
+
+test("#1144: `killed` excludes a candidate whose killPid throws (it must not be logged as killed)", () => {
+  const r = reapMarkedOrphans(
+    reapOpts({
+      probes: markedProbes({
+        killPid: () => {
+          throw new Error("ESRCH"); // already exited between the re-check and the kill
+        },
+      }),
+    }),
+  );
+  expect(r.observed).toHaveLength(1);
+  expect(r.killed).toEqual([]);
+  expect(r.reaped).toBe(0);
 });
 
 // ── enumeration + gate ordering ──────────────────────────────────────────────

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -924,3 +924,21 @@ describe("parseSandboxProfile (config helper)", () => {
     expect(parseSandboxProfile("nonsense")).toBe("trusted");
   });
 });
+
+describe("#1144 session marker survives the membrane", () => {
+  test("SHEPHERD_SESSION_ID rides --setenv into the bwrap argv (past --clearenv)", () => {
+    // House rule: env set OUTSIDE the sandbox is stripped by --clearenv. The runaway reaper
+    // (#1144) attributes an orphan by reading SHEPHERD_SESSION_ID from its /proc/<pid>/environ,
+    // so if the marker did not survive into the sandbox, EVERY membrane-spawned agent's leaks
+    // would be unattributable and silently unreapable. Assert it is actually in the argv.
+    const f = buildMembraneFlags(
+      fakeMembrane({ extraEnv: { SHEPHERD_SESSION_ID: "sess-abc" } }),
+      detDeps,
+    );
+    expect(f).toContain("--clearenv");
+    const i = f.indexOf("SHEPHERD_SESSION_ID");
+    expect(i).toBeGreaterThanOrEqual(0);
+    expect(f[i - 1]).toBe("--setenv");
+    expect(f[i + 1]).toBe("sess-abc");
+  });
+});

--- a/test/server-settings.test.ts
+++ b/test/server-settings.test.ts
@@ -5,7 +5,13 @@ import { join } from "node:path";
 import { SessionStore } from "../src/store";
 import { EventHub } from "../src/events";
 import { makeApp, type AppDeps } from "../src/server";
-import { config, clampCap, PR_REVIEW_CYCLES_MIN, PR_REVIEW_CYCLES_MAX } from "../src/config";
+import {
+  config,
+  clampCap,
+  clampFraction,
+  PR_REVIEW_CYCLES_MIN,
+  PR_REVIEW_CYCLES_MAX,
+} from "../src/config";
 import type { AuthMode } from "../src/auth-mode";
 import { EFFORTS } from "../src/types";
 import { OPERATOR_LANGUAGES, normalizeOperatorLanguage } from "../src/operator-language";
@@ -964,4 +970,29 @@ test("OPERATOR_LANGUAGES is set-equal to the UI's Paraglide locales", () => {
   expect(locales.size).toBe(opLangs.size);
   for (const l of locales) expect(opLangs.has(l)).toBe(true);
   for (const l of opLangs) expect(locales.has(l)).toBe(true);
+});
+
+// ── #1144: runaway-reaper knob clamping ──────────────────────────────────────
+
+/** Exactly how config.ts reads these knobs: `Number(process.env.X ?? <default>)`. */
+const asEnv = (raw: string | undefined, def: number) => Number(raw ?? def);
+
+test("#1144: an empty SHEPHERD_REAP_RUNAWAY_MIN_AGE_S cannot disarm the age floor", () => {
+  // `Number("")` is 0 — a SET-BUT-EMPTY env var slips past `??`, which only catches undefined. A 0
+  // age floor would open the benign restore() race (restore SPAWNS the agent before store.unarchive
+  // flips the row off `archived`), letting the sweep reap a freshly-respawned agent's own children.
+  // The clamp, not a comment, is what prevents it.
+  expect(asEnv("", 300)).toBe(0); // the trap itself
+  expect(clampCap(asEnv("", 300), 60, 24 * 60 * 60, 300)).toBe(60); // …snapped to the floor
+  expect(clampCap(asEnv(undefined, 300), 60, 24 * 60 * 60, 300)).toBe(300);
+  expect(clampCap(asEnv("nonsense", 300), 60, 24 * 60 * 60, 300)).toBe(300); // NaN ⇒ fallback
+  expect(clampCap(asEnv("99999999", 300), 60, 24 * 60 * 60, 300)).toBe(24 * 60 * 60);
+});
+
+test("#1144: the CPU fraction clamps WITHOUT rounding (clampCap would round 0.8 → 1)", () => {
+  expect(clampFraction(asEnv("", 0.8), 0.05, 1, 0.8)).toBe(0.05); // empty ⇒ floor, not 0
+  expect(clampFraction(asEnv(undefined, 0.8), 0.05, 1, 0.8)).toBe(0.8); // default survives intact
+  expect(clampCap(asEnv(undefined, 0.8), 0.05, 1, 0.8)).toBe(1); // …which clampCap would ROUND away
+  expect(clampFraction(asEnv("nonsense", 0.8), 0.05, 1, 0.8)).toBe(0.8);
+  expect(clampFraction(asEnv("5", 0.8), 0.05, 1, 0.8)).toBe(1);
 });

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -7497,11 +7497,12 @@ test("learnings: disabled repo records nothing and archive is a reward no-op", a
 // ── #1144: runaway-orphan reap at teardown ───────────────────────────────────
 
 /** Minimal SessionService wired for archive(); records reapRunaway calls. */
-function archiveHarness(isolated: boolean) {
+function archiveHarness(isolated: boolean, beforeArchive?: () => Promise<void>) {
   const store = new SessionStore(":memory:");
   const sweeps: Set<string>[] = [];
   const removed: string[] = [];
   const service = new SessionService({
+    beforeArchive,
     store,
     namer: async () => "n",
     worktree: {
@@ -7579,4 +7580,40 @@ test("#1144: archiveMany sweeps ONCE for the batch, not once per session", async
   expect(cleared).toHaveLength(3);
   expect(sweeps).toHaveLength(1);
   expect(sweeps[0]).toEqual(new Set([a.id, b.id, c.id]));
+});
+
+test("#1144: an archive() that interleaves with archiveMany's awaits is still swept", async () => {
+  // archive() awaits (herdr.stop, the 15s beforeArchive window), so a timer-driven archive
+  // (automerge / drain / merge-teardown) can land mid-batch. A boolean "suppress while bulk"
+  // would drop that id's sweep entirely — it is not in `cleared`, so the post-batch sweep would
+  // miss it too, and the session's runaway would survive until the hourly tick (or forever, if
+  // its row were later pruned). The deferred-id set must catch it.
+  let interloper: string | null = null;
+  let fired = false;
+  const h = archiveHarness(true, async () => {
+    // Runs inside archiveMany's first archive(), i.e. mid-batch.
+    if (fired) return;
+    fired = true;
+    await h.service.archive(interloper!);
+  });
+  const a = await h.service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "a",
+    model: null,
+    images: [],
+  } as any);
+  const x = await h.service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "x",
+    model: null,
+    images: [],
+  } as any);
+  interloper = x.id;
+
+  const { cleared } = await h.service.archiveMany([a.id]);
+  expect(cleared).toEqual([a.id]); // the interloper is NOT in `cleared`…
+  expect(h.sweeps).toHaveLength(1); // …still exactly one host-wide sweep…
+  expect(h.sweeps[0]).toEqual(new Set([a.id, x.id])); // …and it covers BOTH ids.
 });

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -7617,3 +7617,39 @@ test("#1144: an archive() that interleaves with archiveMany's awaits is still sw
   expect(h.sweeps).toHaveLength(1); // …still exactly one host-wide sweep…
   expect(h.sweeps[0]).toEqual(new Set([a.id, x.id])); // …and it covers BOTH ids.
 });
+
+test("#1144: a mid-batch throw still sweeps the ids already archived in that batch", async () => {
+  // `store.get` / `reaper.detect` sit OUTSIDE archiveMany's inner try/catch, so a throw from
+  // either escapes the loop. Every id archived earlier in the batch has deferred its teardown
+  // sweep into the collector rather than running it — so if the sweep didn't run on the throwing
+  // path, those sessions would silently fall back to the hourly net (up to an hour of a leaked
+  // core). Deferring a sweep is only safe if the deferred sweep is guaranteed to happen.
+  const { service, sweeps, store } = archiveHarness(true);
+  const a = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "a",
+    model: null,
+    images: [],
+  } as any);
+  const b = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "b",
+    model: null,
+    images: [],
+  } as any);
+
+  // archiveMany calls store.get(id) at the TOP of its loop, OUTSIDE the inner try/catch — so this
+  // throws from there, escaping the loop. (Throwing from inside archive() instead would just be
+  // swallowed by the inner catch and the id skipped, which is the already-handled path.)
+  const realGet = store.get.bind(store);
+  (store as any).get = (id: string) => {
+    if (id === b.id) throw new Error("boom");
+    return realGet(id);
+  };
+
+  await expect(service.archiveMany([a.id, b.id])).rejects.toThrow("boom");
+  // `a` was already archived and its sweep deferred — it must still be swept.
+  expect(sweeps).toEqual([new Set([a.id])]);
+});

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -7493,3 +7493,90 @@ test("learnings: disabled repo records nothing and archive is a reward no-op", a
   expect(store.getLearning(a.id)!.injectedCount).toBe(0);
   expect(store.getLearning(a.id)!.helpfulCount).toBe(0);
 });
+
+// ── #1144: runaway-orphan reap at teardown ───────────────────────────────────
+
+/** Minimal SessionService wired for archive(); records reapRunaway calls. */
+function archiveHarness(isolated: boolean) {
+  const store = new SessionStore(":memory:");
+  const sweeps: Set<string>[] = [];
+  const removed: string[] = [];
+  const service = new SessionService({
+    store,
+    namer: async () => "n",
+    worktree: {
+      ensureBaseRef: async () => {},
+      branchExists: () => false,
+      create: () => ({
+        worktreePath: isolated ? "/wt/n" : "/repo",
+        branch: isolated ? "shepherd/n" : null,
+        isolated,
+      }),
+      remove: (p: string) => removed.push(p),
+    } as any,
+    herdr: {
+      start: async () => ({
+        terminalId: "t1",
+        cwd: "/",
+        agent: "claude",
+        agentStatus: "working",
+        paneId: "p",
+        tabId: "t",
+        workspaceId: "w",
+      }),
+      stop: async () => {},
+      list: () => [],
+    } as any,
+    reapRunaway: (ids: Set<string>) => sweeps.push(ids),
+  } as any);
+  return { store, service, sweeps, removed };
+}
+
+test("#1144: archive() reaps runaways for a NON-isolated session — its only teardown reap", async () => {
+  // The bug this closes: `reapOrphansUnder` hangs off worktree.remove(), which teardown calls only
+  // `if (s.isolated)`. A non-isolated session's worktreePath IS the shared repo root, so it got NO
+  // teardown reap at all. The marker-based sweep is cwd-blind, so it can safely serve both.
+  const { store, service, sweeps, removed } = archiveHarness(false);
+  const s = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "p",
+    model: null,
+    images: [],
+  } as any);
+  await service.archive(s.id);
+  expect(removed).toEqual([]); // non-isolated ⇒ worktree.remove() never runs, as before
+  expect(sweeps).toEqual([new Set([s.id])]);
+  expect(store.get(s.id)!.status).toBe("archived"); // swept AFTER archive ⇒ terminality sees it
+});
+
+test("#1144: archiveMany sweeps ONCE for the batch, not once per session", async () => {
+  // The sweep enumerates every pid on the host. N sessions must not mean N host-wide /proc walks
+  // on the event loop.
+  const { service, sweeps } = archiveHarness(true);
+  const a = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "a",
+    model: null,
+    images: [],
+  } as any);
+  const b = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "b",
+    model: null,
+    images: [],
+  } as any);
+  const c = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "c",
+    model: null,
+    images: [],
+  } as any);
+  const { cleared } = await service.archiveMany([a.id, b.id, c.id]);
+  expect(cleared).toHaveLength(3);
+  expect(sweeps).toHaveLength(1);
+  expect(sweeps[0]).toEqual(new Set([a.id, b.id, c.id]));
+});


### PR DESCRIPTION
Closes #1144.

## The problem with cwd

#1143 reaps PPID-1 orphans by **cwd**. That structurally cannot see the two gaps #1144 tracks:

- **chdir-out orphans** — a background job that `cd`s out of the worktree has a cwd that is neither under it nor a deleted `.shepherd-worktrees/*` path.
- **non-isolated sessions** — their `worktreePath` **is** the shared repo root, which we must never cwd-sweep: it hosts the server and the operator's own processes. `reapOrphansUnder` hangs off `WorktreeManager.remove()`, which teardown calls only `if (s.isolated)` — so that path gets **no teardown reap at all**.

Both are symptoms of one thing: **cwd is a guess.** Attributing a runaway process by which directory it happens to sit in can't be made both safe and complete.

## Attribute by provenance instead

Every agent spawn now carries `SHEPHERD_SESSION_ID`. Every descendant inherits it, and `/proc/<pid>/environ` is fixed at `exec` — so the marker survives `cd`, backgrounding, PID-1 reparenting, and worktree deletion. Attribution becomes **exact**:

- An operator's `rust-analyzer`, `nohup cargo bench &`, or `ffmpeg` **never carries the marker**, so it can never be a candidate. The false-positive surface isn't small — it's structurally empty.
- Both gaps close, and the sweep is safe to ship **armed**.

This deletes the roots, `.git`/depth/`$HOME` fences, and birth windows that a cwd-based design needs.

## Safety is `provenance ∧ terminality`

A process is reaped only if it carries the marker **and** its session row is **present and `archived`**.

Terminality is what spares an agent's **in-flight `cargo build &`**: a one-shot Bash tool call reparents its background job to PID 1 the moment that call's shell exits — while the agent is still working. **PPID-1 means signal-unmanageable, not abandoned.**

"Row **absent** ⇒ **spare**", because `SHEPHERD_DB`/`SHEPHERD_PORT` make a second Shepherd on one host supported — reaping on absent would let instance A SIGKILL instance B's *live* session's work.

## Notable gates

- **`cutime`/`cstime` in the CPU numerator.** A `while true; do <work>; done &` supervisor sits blocked in `wait()` with its own utime/stime ≈ 0 while each child dies *under* the age floor. Without the reaped-children columns, the commonest shape of this leak is never caught. A test asserts it's missed if they're dropped.
- **git spares.** An agent's `git fetch` triggers a detached `git gc --auto` that **inherits the marker**, is non-listening, and pegs a core from birth — it clears every other gate. SIGKILLing it strands a stale `gc.pid` lock and the repo is then never gc'd. (`comm` truncates at 15 chars, so the `git-` **prefix** rule is what actually covers `git-pack-objects`.)
- **`environ` is read LAST.** It goes through `access_remote_vm` and takes the *target's* mmap lock, so it can block on a stalled process. Gates run cheapest-first; on a host of idle pids the mmap lock is never taken.
- **PPID is logged, not gated.** Requiring it costs coverage (a marked child of a live marked wrapper has PPID ≠ 1) and would make this a **no-op in a container** where Shepherd is PID 1.

## Where it runs

At **teardown** via `archive()` — the only teardown reap a non-isolated session has ever had — plus boot + hourly. `archiveMany` sweeps **once** for the batch, not once per id (the sweep enumerates every pid on the host).

Armed by default; `SHEPHERD_REAP_RUNAWAY=0` disables, `=observe` logs only.

## Verification

`bun run lint`, `bun run typecheck`, `bun run test` (6781 pass), and `fallow audit` all green. Beyond the unit tests (which use injected probes), the **real `/proc` probes were exercised end-to-end** against a live marked busy-loop: read back at `cpuFraction: 1`, and the armed sweep actually SIGKILLed it. Notably its `ppid` was **not** 1 — confirming the PPID demotion is load-bearing.

## Known bounds (deliberate)

- **Reaps only once a session is `archived`.** A runaway in a session parked in `done`/`idle`/`blocked` is spared — still the shape of #817's undetected burn. Terminality is what makes the sweep safe *and* what bounds it.
- **The CPU/age gate is a performance prefilter, not a safety floor** — it's what keeps the mmap-lock reads near zero. It silently costs coverage (late-onset spin, anything under 80%).
- **The marker is evadable** (`env -u SHEPHERD_SESSION_ID`) since `buildWrappedArgv` renders env as argv tokens. Fail-closed — evasion *spares*. This is a safety net against accident, not a sandbox against intent.

**The real fix for all three** is exact attribution via **cgroup-per-session (`systemd-run --user --scope`) or `PR_SET_CHILD_SUBREAPER`** — it would retire the marker, the CPU gate, and this whole sweep, and would also cover the #1135/#1136 husks. It's out of proportion to a priority:low follow-up (systemd-user dependency / `prctl(2)` via FFI, rewriting every spawn path), so it's recommended as its own issue. **This PR is the interim measure.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)