### PR TITLE
feat(ui): color issue label chips with their real forge colors

### DIFF
--- a/src/forge/gitea.ts
+++ b/src/forge/gitea.ts
@@ -60,6 +60,27 @@ function isGiteaNoChanges(text: string): boolean {
   );
 }
 
+/** Normalize a forge-supplied hex color (with or without a leading `#`) to `#rrggbb`
+ *  lowercase. Returns undefined for anything that isn't exactly 6 hex digits. */
+function normalizeHex(c: string): string | undefined {
+  const s = c.trim().replace(/^#/, "");
+  return /^[0-9a-fA-F]{6}$/.test(s) ? `#${s.toLowerCase()}` : undefined;
+}
+
+/** Build a name→`#rrggbb` map from a list of labels carrying an optional forge color,
+ *  skipping any label with a missing/invalid color. Returns undefined (not `{}`) when
+ *  no label contributed a color, so callers can omit the field entirely. */
+function labelColorsFrom(
+  labels: Array<{ name?: string | null; color?: string | null }>,
+): Record<string, string> | undefined {
+  const labelColors: Record<string, string> = {};
+  for (const l of labels) {
+    const c = l.color ? normalizeHex(l.color) : undefined;
+    if (l.name && c) labelColors[l.name] = c;
+  }
+  return Object.keys(labelColors).length ? labelColors : undefined;
+}
+
 /** Gitea/Forgejo forge driven through the /api/v1 REST API (API-compatible). */
 export class GiteaForge implements GitForge {
   readonly kind = "gitea" as const;
@@ -126,19 +147,21 @@ export class GiteaForge implements GitForge {
       title: string;
       body?: string;
       html_url: string;
-      labels?: Array<{ name: string }>;
+      labels?: Array<{ name: string; color?: string }>;
       created_at?: string;
       assignees?: Array<{ login?: string }> | null;
       user?: { login?: string } | null;
     }>;
     return (raw ?? []).map((i) => {
       const ts = Date.parse(i.created_at ?? "");
+      const labelColors = labelColorsFrom(i.labels ?? []);
       return {
         number: i.number,
         title: i.title,
         body: i.body ?? "",
         url: i.html_url,
         labels: (i.labels ?? []).map((l) => l.name),
+        ...(labelColors ? { labelColors } : {}),
         createdAt: Number.isFinite(ts) ? ts : Date.now(),
         // Gitea serializes a user's canonical name as `login` (matches the PR-author
         // mapping above); drop any null/unnamed assignee defensively.

--- a/src/forge/gitea.ts
+++ b/src/forge/gitea.ts
@@ -1,5 +1,6 @@
 import { mapGiteaActionStatus, mapStatusState } from "./checks";
 import { classifyPr } from "./pr-kind";
+import { labelColorsFrom } from "./labels";
 import { mapBounded } from "../map-bounded";
 import type {
   ChecksState,
@@ -58,27 +59,6 @@ function isGiteaNoChanges(text: string): boolean {
     text.includes("no commits between") ||
     text.includes("has no changes")
   );
-}
-
-/** Normalize a forge-supplied hex color (with or without a leading `#`) to `#rrggbb`
- *  lowercase. Returns undefined for anything that isn't exactly 6 hex digits. */
-function normalizeHex(c: string): string | undefined {
-  const s = c.trim().replace(/^#/, "");
-  return /^[0-9a-fA-F]{6}$/.test(s) ? `#${s.toLowerCase()}` : undefined;
-}
-
-/** Build a name→`#rrggbb` map from a list of labels carrying an optional forge color,
- *  skipping any label with a missing/invalid color. Returns undefined (not `{}`) when
- *  no label contributed a color, so callers can omit the field entirely. */
-function labelColorsFrom(
-  labels: Array<{ name?: string | null; color?: string | null }>,
-): Record<string, string> | undefined {
-  const labelColors: Record<string, string> = {};
-  for (const l of labels) {
-    const c = l.color ? normalizeHex(l.color) : undefined;
-    if (l.name && c) labelColors[l.name] = c;
-  }
-  return Object.keys(labelColors).length ? labelColors : undefined;
 }
 
 /** Gitea/Forgejo forge driven through the /api/v1 REST API (API-compatible). */

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -63,6 +63,27 @@ function isNoCommitsBetween(text: string): boolean {
   return text.toLowerCase().includes("no commits between");
 }
 
+/** Normalize a forge-supplied hex color (with or without a leading `#`) to `#rrggbb`
+ *  lowercase. Returns undefined for anything that isn't exactly 6 hex digits. */
+function normalizeHex(c: string): string | undefined {
+  const s = c.trim().replace(/^#/, "");
+  return /^[0-9a-fA-F]{6}$/.test(s) ? `#${s.toLowerCase()}` : undefined;
+}
+
+/** Build a name→`#rrggbb` map from a list of labels carrying an optional forge color,
+ *  skipping any label with a missing/invalid color. Returns undefined (not `{}`) when
+ *  no label contributed a color, so callers can omit the field entirely. */
+function labelColorsFrom(
+  labels: Array<{ name?: string | null; color?: string | null }>,
+): Record<string, string> | undefined {
+  const labelColors: Record<string, string> = {};
+  for (const l of labels) {
+    const c = l.color ? normalizeHex(l.color) : undefined;
+    if (l.name && c) labelColors[l.name] = c;
+  }
+  return Object.keys(labelColors).length ? labelColors : undefined;
+}
+
 function mapGraphqlPrReviewState(state: string | null | undefined): PrReviewMeta["state"] {
   return GRAPHQL_PR_REVIEW_STATES[(state ?? "").toUpperCase()] ?? "none";
 }
@@ -268,7 +289,7 @@ interface RestIssue {
   title?: string;
   body?: string | null;
   html_url?: string;
-  labels?: Array<{ name?: string | null }> | null;
+  labels?: Array<{ name?: string | null; color?: string | null }> | null;
   created_at?: string;
   author_association?: string | null;
   assignees?: Array<{ login?: string | null }> | null;
@@ -399,12 +420,14 @@ export class GithubForge implements GitForge {
 
   private mapRestIssue(i: RestIssue): Issue {
     const ts = Date.parse(i.created_at ?? "");
+    const labelColors = labelColorsFrom(i.labels ?? []);
     return {
       number: i.number,
       title: i.title ?? "",
       body: i.body ?? "",
       url: i.html_url ?? `https://github.com/${this.slug}/issues/${i.number}`,
       labels: (i.labels ?? []).map((l) => l.name).filter((n): n is string => !!n),
+      ...(labelColors ? { labelColors } : {}),
       createdAt: Number.isFinite(ts) ? ts : Date.now(),
       assignees: (i.assignees ?? [])
         .map((a) => a.login ?? undefined)
@@ -617,19 +640,21 @@ export class GithubForge implements GitForge {
       title: string;
       body?: string;
       url: string;
-      labels?: Array<{ name: string }>;
+      labels?: Array<{ name: string; color?: string }>;
       createdAt?: string;
       assignees?: Array<{ login: string }>;
       author?: { login?: string } | null;
     }>;
     return raw.map((i) => {
       const ts = Date.parse(i.createdAt ?? "");
+      const labelColors = labelColorsFrom(i.labels ?? []);
       return {
         number: i.number,
         title: i.title,
         body: i.body ?? "",
         url: i.url,
         labels: (i.labels ?? []).map((l) => l.name),
+        ...(labelColors ? { labelColors } : {}),
         createdAt: Number.isFinite(ts) ? ts : Date.now(),
         assignees: (i.assignees ?? []).map((a) => a.login),
         author: i.author?.login,

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -10,6 +10,7 @@ import {
   runningCheckNames,
 } from "./checks";
 import { classifyPr } from "./pr-kind";
+import { labelColorsFrom } from "./labels";
 import {
   graphRateLimit,
   isGraphqlBucketCall,
@@ -61,27 +62,6 @@ const GRAPHQL_PR_REVIEW_STATES: Record<string, PrReviewMeta["state"]> = {
  *  Match that case-insensitively to classify an openPr failure as an EmptyDiffError. */
 function isNoCommitsBetween(text: string): boolean {
   return text.toLowerCase().includes("no commits between");
-}
-
-/** Normalize a forge-supplied hex color (with or without a leading `#`) to `#rrggbb`
- *  lowercase. Returns undefined for anything that isn't exactly 6 hex digits. */
-function normalizeHex(c: string): string | undefined {
-  const s = c.trim().replace(/^#/, "");
-  return /^[0-9a-fA-F]{6}$/.test(s) ? `#${s.toLowerCase()}` : undefined;
-}
-
-/** Build a name→`#rrggbb` map from a list of labels carrying an optional forge color,
- *  skipping any label with a missing/invalid color. Returns undefined (not `{}`) when
- *  no label contributed a color, so callers can omit the field entirely. */
-function labelColorsFrom(
-  labels: Array<{ name?: string | null; color?: string | null }>,
-): Record<string, string> | undefined {
-  const labelColors: Record<string, string> = {};
-  for (const l of labels) {
-    const c = l.color ? normalizeHex(l.color) : undefined;
-    if (l.name && c) labelColors[l.name] = c;
-  }
-  return Object.keys(labelColors).length ? labelColors : undefined;
 }
 
 function mapGraphqlPrReviewState(state: string | null | undefined): PrReviewMeta["state"] {

--- a/src/forge/labels.ts
+++ b/src/forge/labels.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared issue-label color helpers. Hex normalization is forge-agnostic (a `#rrggbb`
+ * means the same on GitHub and Gitea), so — unlike the deliberately per-forge constants
+ * (e.g. MAX_WORKFLOWS) — the rule lives in ONE place and both backends import it.
+ */
+
+/** Normalize a forge-supplied hex color (with or without a leading `#`) to `#rrggbb`
+ *  lowercase. Returns undefined for anything that isn't exactly 6 hex digits. */
+export function normalizeHex(c: string): string | undefined {
+  const s = c.trim().replace(/^#/, "");
+  return /^[0-9a-fA-F]{6}$/.test(s) ? `#${s.toLowerCase()}` : undefined;
+}
+
+/** Build a name→`#rrggbb` map from a list of labels carrying an optional forge color,
+ *  skipping any label with a missing/invalid color. Returns undefined (not `{}`) when
+ *  no label contributed a color, so callers can omit the field entirely. */
+export function labelColorsFrom(
+  labels: Array<{ name?: string | null; color?: string | null }>,
+): Record<string, string> | undefined {
+  const labelColors: Record<string, string> = {};
+  for (const l of labels) {
+    const c = l.color ? normalizeHex(l.color) : undefined;
+    if (l.name && c) labelColors[l.name] = c;
+  }
+  return Object.keys(labelColors).length ? labelColors : undefined;
+}

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -18,6 +18,11 @@ export interface Issue {
   body: string;
   url: string;
   labels: string[];
+  /** Label name → hex color (`#rrggbb`) from the forge, when available. Additive/optional:
+   *  `labels` stays the authoritative membership list; this is presentational metadata keyed
+   *  by name (forge label names are unique per issue). Absent/partial ⇒ UI falls back to a
+   *  neutral chip. Populated by the issue-LIST display paths only. */
+  labelColors?: Record<string, string>;
   createdAt: number;
   /** GitHub/Gitea logins assigned to the issue (empty when unassigned). Drives the
    *  UI's "mine & unassigned" filter (#824); filtering is purely client-side. */

--- a/test/forge/gitea.test.ts
+++ b/test/forge/gitea.test.ts
@@ -337,6 +337,51 @@ test("GiteaForge.listIssues: maps gitea issues, filters out PRs via type=issues"
   expect(calls[0]!.headers.get("Authorization")).toBe("token secret");
 });
 
+test("GiteaForge.listIssues: threads labelColors, handling both #-prefixed and bare hex", async () => {
+  const { fn } = fakeFetch({
+    "GET /api/v1/repos/team/proj/issues?state=open&type=issues&limit=200": {
+      json: [
+        {
+          number: 3,
+          title: "Bug",
+          body: "desc",
+          html_url: "https://git.example.com/team/proj/issues/3",
+          labels: [
+            { name: "bug", color: "#d73a4a" },
+            { name: "p1", color: "00ff00" },
+            { name: "no-color" },
+          ],
+          created_at: GITEA_ISSUE_CREATED_AT,
+        },
+      ],
+    },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  const issues = await forge.listIssues();
+  expect(issues[0]!.labels).toEqual(["bug", "p1", "no-color"]);
+  expect(issues[0]!.labelColors).toEqual({ bug: "#d73a4a", p1: "#00ff00" });
+});
+
+test("GiteaForge.listIssues: no label carries a color → labelColors omitted", async () => {
+  const { fn } = fakeFetch({
+    "GET /api/v1/repos/team/proj/issues?state=open&type=issues&limit=200": {
+      json: [
+        {
+          number: 3,
+          title: "Bug",
+          body: "desc",
+          html_url: "https://git.example.com/team/proj/issues/3",
+          labels: [{ name: "bug" }],
+          created_at: GITEA_ISSUE_CREATED_AT,
+        },
+      ],
+    },
+  });
+  const forge = new GiteaForge("team/proj", CFG, fn);
+  const issues = await forge.listIssues();
+  expect(issues[0]!.labelColors).toBeUndefined();
+});
+
 test("GiteaForge.currentUser: returns the authenticated login (#824)", async () => {
   const { fn, calls } = fakeFetch({
     "GET /api/v1/user": { json: { login: "octogit" } },

--- a/test/forge/github.test.ts
+++ b/test/forge/github.test.ts
@@ -164,6 +164,67 @@ test("GithubForge.listIssues: parses gh issue list output (incl. assignee logins
   ]);
 });
 
+test("GithubForge.listIssues: maps label color into labelColors (name→#rrggbb); colorless labels contribute nothing", async () => {
+  const issuesJson = JSON.stringify([
+    {
+      number: 1,
+      title: "Fix crash",
+      body: "boom",
+      url: "u1",
+      labels: [{ name: "bug", color: "d73a4a" }, { name: "no-color" }],
+      createdAt: ISSUE_CREATED_AT,
+    },
+  ]);
+  const { run } = fakeRunner({ "issue list": issuesJson });
+  const forge = new GithubForge("o/r", {}, run);
+  const issues = await forge.listIssues();
+  expect(issues[0]!.labels).toEqual(["bug", "no-color"]);
+  expect(issues[0]!.labelColors).toEqual({ bug: "#d73a4a" });
+});
+
+test("GithubForge.listIssues: no label carries a color → labelColors omitted", async () => {
+  const issuesJson = JSON.stringify([
+    {
+      number: 1,
+      title: "T",
+      body: "",
+      url: "u1",
+      labels: [{ name: "bug" }],
+      createdAt: ISSUE_CREATED_AT,
+    },
+  ]);
+  const { run } = fakeRunner({ "issue list": issuesJson });
+  const forge = new GithubForge("o/r", {}, run);
+  const issues = await forge.listIssues();
+  expect(issues[0]!.labelColors).toBeUndefined();
+});
+
+test("GithubForge.listIssues: REST fallback maps label color into labelColors (name→#rrggbb)", async () => {
+  const run = async (args: string[]): Promise<string> => {
+    if (args.includes("repos/o/r/issues")) {
+      return JSON.stringify([
+        {
+          number: 1,
+          title: "Issue 1",
+          body: "body",
+          html_url: "https://github.com/o/r/issues/1",
+          labels: [{ name: "bug", color: "D73A4A" }, { name: "no-color" }],
+          created_at: ISSUE_CREATED_AT,
+        },
+      ]);
+    }
+    return "[]";
+  };
+  blockGraphql();
+  try {
+    const issues = await new GithubForge("o/r", {}, run).listIssues();
+    expect(issues[0]!.labels).toEqual(["bug", "no-color"]);
+    expect(issues[0]!.labelColors).toEqual({ bug: "#d73a4a" });
+  } finally {
+    unblockGraphql();
+  }
+});
+
 test("GithubForge.listIssues: requests the assignees field from gh (#824)", async () => {
   const { run, calls } = fakeRunner({ "issue list": ISSUES_JSON });
   const forge = new GithubForge("o/r", { deployWorkflow: "deploy.yml" }, run);

--- a/test/forge/labels.test.ts
+++ b/test/forge/labels.test.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "bun:test";
+import { normalizeHex, labelColorsFrom } from "../../src/forge/labels";
+
+test("normalizeHex accepts bare and #-prefixed 6-hex, lowercasing", () => {
+  expect(normalizeHex("00AABB")).toBe("#00aabb");
+  expect(normalizeHex("#00AaBb")).toBe("#00aabb");
+  expect(normalizeHex("  d73a4a  ")).toBe("#d73a4a");
+});
+
+test("normalizeHex rejects anything not exactly 6 hex digits", () => {
+  expect(normalizeHex("fff")).toBeUndefined();
+  expect(normalizeHex("#gggggg")).toBeUndefined();
+  expect(normalizeHex("1234567")).toBeUndefined();
+  expect(normalizeHex("")).toBeUndefined();
+});
+
+test("labelColorsFrom maps valid colors and skips missing/invalid ones", () => {
+  expect(
+    labelColorsFrom([
+      { name: "bug", color: "d73a4a" },
+      { name: "feature", color: "#5319e7" },
+      { name: "no-color", color: null },
+      { name: "bad", color: "zzz" },
+      { name: null, color: "abcdef" },
+    ]),
+  ).toEqual({ bug: "#d73a4a", feature: "#5319e7" });
+});
+
+test("labelColorsFrom returns undefined (not {}) when nothing contributes a color", () => {
+  expect(labelColorsFrom([])).toBeUndefined();
+  expect(labelColorsFrom([{ name: "x", color: null }])).toBeUndefined();
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2933,5 +2933,7 @@
   "feat_epic_research_flow_title": "EPIC aus Recherche erstellen",
   "feat_epic_research_flow_body": "Mach aus einer groben Produktidee ein strukturiertes Epic. Aktiviere „EPIC aus Recherche erstellen“ im Dialog „Neue Aufgabe“: Eine betreute Sitzung arbeitet die Aufgabe aus und schlägt einen prüfbaren Entwurf vor — übergeordnetes Issue, untergeordnete Issues und ihre Abhängigkeitsreihenfolge. Nichts wird auf GitHub geschrieben, bis du genehmigst; dann erstellt Shepherd die Issues und Verknüpfungen, bereit zum Abarbeiten.",
   "feat_prewarm_epic_ci_title": "Epic-Landing-CI vorwärmen",
-  "feat_prewarm_epic_ci_body": "Ist die Option aktiviert, öffnet sich der Landing-PR eines Epics jetzt frühzeitig als Entwurf, sodass seine CI schon während des Abarbeitens vorgewärmt läuft, statt beim Abschluss kalt zu starten. Pro Repo in den Automatisierungseinstellungen aktivierbar."
+  "feat_prewarm_epic_ci_body": "Ist die Option aktiviert, öffnet sich der Landing-PR eines Epics jetzt frühzeitig als Entwurf, sodass seine CI schon während des Abarbeitens vorgewärmt läuft, statt beim Abschluss kalt zu starten. Pro Repo in den Automatisierungseinstellungen aktivierbar.",
+  "feat_colored_issue_labels_title": "Issue-Labels in ihren echten Farben",
+  "feat_colored_issue_labels_body": "Label-Chips im Backlog, in den Filtern und bei den Prompt-Quellen zeigen jetzt die echte Farbe des Labels aus GitHub, angepasst für Lesbarkeit in hellem und dunklem Theme — statt einheitlichem Grau."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2933,5 +2933,7 @@
   "feat_epic_research_flow_title": "Create EPIC from research",
   "feat_epic_research_flow_body": "Turn a rough product idea into a structured epic. Check \"Create EPIC from research\" in New Task and an attended session shapes the work, then proposes a reviewable draft — parent issue, child issues and their dependency order. Nothing is written to GitHub until you approve; then Shepherd creates the issues and links, ready to drain.",
   "feat_prewarm_epic_ci_title": "Pre-warm epic landing CI",
-  "feat_prewarm_epic_ci_body": "When enabled, an epic's landing PR now opens early as a draft so its CI runs warm while the epic still drains, instead of a cold first run at completion. Opt in per repo in Automation settings."
+  "feat_prewarm_epic_ci_body": "When enabled, an epic's landing PR now opens early as a draft so its CI runs warm while the epic still drains, instead of a cold first run at completion. Opt in per repo in Automation settings.",
+  "feat_colored_issue_labels_title": "Issue labels in their real colors",
+  "feat_colored_issue_labels_body": "Label chips across the backlog, filters, and prompt sources now render each label's actual color from GitHub, normalized for legibility in both light and dark themes — instead of flat grey."
 }

--- a/ui/src/lib/components/IssueFilterPopover.svelte
+++ b/ui/src/lib/components/IssueFilterPopover.svelte
@@ -3,6 +3,7 @@
   import { issuesFilter } from "$lib/issues-filter.svelte";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { labelChipStyle } from "$lib/label-color";
 
   // showMine: when false the "mine & unassigned" row is NOT rendered (viewer unknown).
   // coachTargets: when true, the trigger carries use:coachTarget={"issue-filters"}.
@@ -10,12 +11,14 @@
   //   (computed by the parent from the raw issue list). selectedAuthor/selectedLabels are
   //   the current selection; the parent owns the state and mutates it via the callbacks.
   //   All optional — omitted (empty) → neither section renders, so existing callers are
-  //   unaffected.
+  //   unaffected. labelColors: name → forge hex (see label-color.ts), used to hue an
+  //   unselected toggle; omitted (empty) → toggles render neutral, as before.
   let {
     showMine,
     coachTargets = false,
     authors = [],
     labels = [],
+    labelColors = {},
     selectedAuthor = null,
     selectedLabels = [],
     onauthor = undefined,
@@ -25,6 +28,7 @@
     coachTargets?: boolean;
     authors?: string[];
     labels?: string[];
+    labelColors?: Record<string, string>;
     selectedAuthor?: string | null;
     selectedLabels?: string[];
     onauthor?: (author: string | null) => void;
@@ -220,9 +224,11 @@
       <div class="label-chips" role="group" aria-labelledby="issue-label-heading-{popoverId}">
         {#each labels as label (label)}
           {@const on = selectedLabels.includes(label)}
+          {@const style = !on ? labelChipStyle(labelColors[label] ?? "") : null}
           <button
             type="button"
-            class={["label-toggle", { on }]}
+            class={["label-toggle", { on, hued: style !== null }]}
+            {style}
             aria-pressed={on}
             onclick={() => ontogglelabel?.(label)}>{label}</button
           >
@@ -445,6 +451,28 @@
     color: var(--color-amber);
     border-color: var(--color-amber);
     background: color-mix(in srgb, var(--color-amber) 14%, transparent);
+  }
+
+  /* Real forge label color (issue: labels-almost-invisible) — sanctioned exception to
+     "accent hues are semantic, not decorative" (see /design-system). Only applied to
+     UNSELECTED toggles (the template only computes a style when !on), so .on's amber
+     "selected" semantic always wins where it applies. */
+  .label-toggle.hued {
+    color: var(--lc-text-d);
+    border-color: var(--lc-border-d);
+    background: var(--lc-fill-d);
+  }
+  :global([data-theme="light"]) .label-toggle.hued {
+    color: var(--lc-text-l);
+    border-color: var(--lc-border-l);
+    background: var(--lc-fill-l);
+  }
+
+  /* A hued toggle pins its own color/border, so the neutral .label-toggle:hover rule
+     (equal specificity, earlier in source) can't tint it — hover would be invisible.
+     Brighten instead: hue-agnostic, works in both themes, needs no extra vars. */
+  .label-toggle.hued:hover {
+    filter: brightness(1.18);
   }
 
   .label-toggle:focus-visible {

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -15,6 +15,7 @@
     filterByLabels,
     distinctAuthors,
     distinctLabels,
+    labelColorMap,
   } from "./issues-panel";
   import { issuesFilter } from "$lib/issues-filter.svelte";
   import { backlogRefresh } from "$lib/backlog-refresh.svelte";
@@ -80,6 +81,7 @@
   const selectedLabels = new SvelteSet<string>();
   let availableAuthors = $derived(distinctAuthors(issues));
   let availableLabels = $derived(distinctLabels(issues));
+  let labelColorsMap = $derived(labelColorMap(issues));
   // Epic summaries for this repo: number → EpicSummary.
   let epicByNumber = $state<Map<number, EpicSummary>>(new Map());
   let nativeSubIssues = $state<Set<number>>(new Set());
@@ -496,6 +498,7 @@
           coachTargets
           authors={availableAuthors}
           labels={availableLabels}
+          labelColors={labelColorsMap}
           {selectedAuthor}
           selectedLabels={[...selectedLabels]}
           onauthor={pickAuthor}

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -4,6 +4,7 @@
   import { getTodo, listIssues, getCommands } from "$lib/api";
   import type { Issue, SlashCommand } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
+  import { labelChipStyle } from "$lib/label-color";
   import {
     hideOthers,
     hideActive,
@@ -12,6 +13,7 @@
     filterByLabels,
     distinctAuthors,
     distinctLabels,
+    labelColorMap,
     ACTIVE_LABEL,
   } from "./issues-panel";
   import { issuesFilter } from "$lib/issues-filter.svelte";
@@ -57,6 +59,7 @@
   const selectedLabels = new SvelteSet<string>();
   let availableAuthors = $derived(distinctAuthors(issues));
   let availableLabels = $derived(distinctLabels(issues));
+  let labelColorsMap = $derived(labelColorMap(issues));
   let assigneeFiltered = $derived(hideOthers(issues, viewer, issuesFilter.hideOthers));
   let activeFiltered = $derived(hideActive(assigneeFiltered, issuesFilter.hideActive));
   // Toggle-filtered set (mine → active → sub-issue), BEFORE the author/label filters.
@@ -105,6 +108,11 @@
     labels.includes(ACTIVE_LABEL)
       ? [ACTIVE_LABEL, ...labels.filter((l) => l !== ACTIVE_LABEL)]
       : labels;
+
+  // Inline `--lc-*` style vars for a label chip's real forge color, or null for the
+  // system ACTIVE_LABEL (stays semantic amber) / a missing/invalid color (neutral chip).
+  const chipStyle = (lbl: string, colors: Record<string, string> | undefined): string | null =>
+    lbl === ACTIVE_LABEL ? null : labelChipStyle(colors?.[lbl] ?? "");
 
   // Resolve TODO.md eagerly per repo (independent of the active tab) so the To-Do
   // tab is hidden outright when the repo has no TODO.md, and the panel opens on
@@ -309,6 +317,7 @@
             showMine={viewer != null}
             authors={availableAuthors}
             labels={availableLabels}
+            labelColors={labelColorsMap}
             {selectedAuthor}
             selectedLabels={[...selectedLabels]}
             onauthor={pickAuthor}
@@ -337,7 +346,7 @@
               {@render issueAuthor(i.author)}
               <span class="chips">
                 <span class="chip chip-epic">{m.promptsources_epic_tag()}</span>
-                {@render labelChips(ordered)}
+                {@render labelChips(ordered, i.labelColors)}
               </span>
             </div>
           {:else}
@@ -346,7 +355,7 @@
               <span class="row-text">{i.title}</span>
               {@render issueAuthor(i.author)}
               {#if ordered.length > 0}
-                <span class="chips">{@render labelChips(ordered)}</span>
+                <span class="chips">{@render labelChips(ordered, i.labelColors)}</span>
               {/if}
             </button>
           {/if}
@@ -362,11 +371,14 @@
   {/if}
 {/snippet}
 
-{#snippet labelChips(ordered: string[])}
+{#snippet labelChips(ordered: string[], colors: Record<string, string> | undefined)}
   {#each ordered.slice(0, 1) as lbl (lbl)}
+    {@const style = chipStyle(lbl, colors)}
     <span
       class="chip"
       class:active={lbl === ACTIVE_LABEL}
+      class:hued={style !== null}
+      {style}
       title={lbl === ACTIVE_LABEL ? m.issuespanel_active_label_title() : undefined}>{lbl}</span
     >
   {/each}
@@ -613,6 +625,21 @@
     color: var(--status-running);
     border-color: var(--status-running);
     background: color-mix(in srgb, var(--status-running) 14%, transparent);
+  }
+
+  /* Real forge label color (issue: labels-almost-invisible) — sanctioned exception to
+     "accent hues are semantic, not decorative" (see /design-system). Never coexists with
+     .active: the snippet only computes a style for non-active labels, so the semantic
+     amber rule above always wins where it applies. */
+  .chip.hued {
+    color: var(--lc-text-d);
+    border-color: var(--lc-border-d);
+    background: var(--lc-fill-d);
+  }
+  :global([data-theme="light"]) .chip.hued {
+    color: var(--lc-text-l);
+    border-color: var(--lc-border-l);
+    background: var(--lc-fill-l);
   }
 
   .chip-more {

--- a/ui/src/lib/components/issues-panel.test.ts
+++ b/ui/src/lib/components/issues-panel.test.ts
@@ -14,6 +14,7 @@ import {
   sortEpicsFirst,
   distinctAuthors,
   distinctLabels,
+  labelColorMap,
   filterByAuthor,
   filterByLabels,
   ACTIVE_LABEL,
@@ -244,6 +245,27 @@ describe("distinctLabels", () => {
     } as unknown as Issue;
     expect(() => distinctLabels([stale])).not.toThrow();
     expect(distinctLabels([stale])).toEqual([]);
+  });
+});
+
+describe("labelColorMap", () => {
+  it("merges labelColors across issues, last-wins on a name clash", () => {
+    const a = { ...issue(1, "A", "", ["bug", "enhancement"]), labelColors: { bug: "#ff0000" } };
+    const b = {
+      ...issue(2, "B", "", ["enhancement"]),
+      labelColors: { enhancement: "#00ff00", bug: "#0000ff" },
+    };
+    expect(labelColorMap([a, b])).toEqual({ bug: "#0000ff", enhancement: "#00ff00" });
+  });
+
+  it("skips issues without labelColors", () => {
+    const withColors = { ...issue(1, "A", "", ["bug"]), labelColors: { bug: "#ff0000" } };
+    const withoutColors = issue(2, "B", "", ["enhancement"]);
+    expect(labelColorMap([withColors, withoutColors])).toEqual({ bug: "#ff0000" });
+  });
+
+  it("returns an empty object for issues with no labelColors at all", () => {
+    expect(labelColorMap([issue(1, "A"), issue(2, "B")])).toEqual({});
   });
 });
 

--- a/ui/src/lib/components/issues-panel.ts
+++ b/ui/src/lib/components/issues-panel.ts
@@ -61,6 +61,23 @@ export function distinctLabels(issues: readonly Issue[]): string[] {
 }
 
 /**
+ * Merge every issue's `labelColors` into one name → hex map, for the filter popover
+ * (which lists distinct label names across the whole backlog and wants a color per
+ * name, not per issue). Simple last-wins merge; issues without `labelColors` (forge
+ * didn't supply them, or a stale payload predating the field) contribute nothing.
+ */
+export function labelColorMap(issues: readonly Issue[]): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const issue of issues) {
+    if (!issue.labelColors) continue;
+    for (const [name, hex] of Object.entries(issue.labelColors)) {
+      map[name] = hex;
+    }
+  }
+  return map;
+}
+
+/**
  * Narrow an issue list to a single author. Keeps issues whose `author` equals the
  * selected login; a `null` selection is an identity filter (no author chosen). An issue
  * with no author is dropped when a specific author is selected — correct, since it can't

--- a/ui/src/lib/components/issues-panel/IssueRow.svelte
+++ b/ui/src/lib/components/issues-panel/IssueRow.svelte
@@ -4,6 +4,7 @@
   import { fitLabels } from "$lib/fit-labels";
   import { relativeAge } from "$lib/format";
   import { clock } from "$lib/now.svelte";
+  import { labelChipStyle } from "$lib/label-color";
   import { ACTIVE_LABEL } from "../issues-panel";
   import { progress } from "../epic-panel";
   import EpicPanel from "../EpicPanel.svelte";
@@ -158,9 +159,13 @@
         {/each}
       {/if}
       {#each issue.labels as label (label)}
+        {@const style =
+          label !== ACTIVE_LABEL ? labelChipStyle(issue.labelColors?.[label] ?? "") : null}
         <span
           class="label-chip"
           class:active={label === ACTIVE_LABEL}
+          class:hued={style !== null}
+          {style}
           title={label === ACTIVE_LABEL ? m.issuespanel_active_label_title() : undefined}
           >{label}</span
         >
@@ -323,6 +328,22 @@
     color: var(--status-running);
     border-color: var(--status-running);
     background: color-mix(in srgb, var(--status-running) 14%, transparent);
+  }
+
+  /* Real forge label color (issue: labels-almost-invisible) — sanctioned exception to
+     "accent hues are semantic, not decorative" (see /design-system). Never coexists with
+     .active: labelChipStyle is only computed for non-active labels, so the semantic amber
+     rule above always wins where it applies. Vars come from labelChipStyle(); dark is the
+     default, [data-theme="light"] overrides. */
+  .label-chip.hued {
+    color: var(--lc-text-d);
+    border-color: var(--lc-border-d);
+    background: var(--lc-fill-d);
+  }
+  :global([data-theme="light"]) .label-chip.hued {
+    color: var(--lc-text-l);
+    border-color: var(--lc-border-l);
+    background: var(--lc-fill-l);
   }
 
   .body-preview {

--- a/ui/src/lib/feature-announcements/entries/v1.43.0-colored-issue-labels.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.43.0-colored-issue-labels.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "colored-issue-labels",
+  sinceVersion: "1.43.0",
+  titleKey: "feat_colored_issue_labels_title",
+  bodyKey: "feat_colored_issue_labels_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/label-color.test.ts
+++ b/ui/src/lib/label-color.test.ts
@@ -27,7 +27,7 @@
  * The exact numbers are re-derived and asserted (and printed to the console) below.
  */
 import { describe, it, expect } from "vitest";
-import { labelChipColors, hexToOklchCH, LABEL_CHIP_THEME } from "./label-color";
+import { labelChipColors, labelChipStyle, hexToOklchCH, LABEL_CHIP_THEME } from "./label-color";
 
 // ── inverse OKLCH → linear sRGB + gamma-encoded sRGB (Ottosson), local to this test ─
 
@@ -193,6 +193,28 @@ describe("labelChipColors", () => {
   });
 });
 
+describe("labelChipStyle", () => {
+  it("returns null for an invalid hex", () => {
+    expect(labelChipStyle("not-a-color")).toBeNull();
+    expect(labelChipStyle("")).toBeNull();
+  });
+
+  it("emits all six --lc-* custom properties for a valid hex", () => {
+    const style = labelChipStyle("#1d76db");
+    expect(style).not.toBeNull();
+    for (const name of [
+      "--lc-text-d",
+      "--lc-border-d",
+      "--lc-fill-d",
+      "--lc-text-l",
+      "--lc-border-l",
+      "--lc-fill-l",
+    ]) {
+      expect(style).toContain(`${name}:`);
+    }
+  });
+});
+
 describe("hexToOklchCH (forward-transform golden matrix)", () => {
   // Expected C/H computed independently once (Ottosson sRGB→OKLab, 6-dp) and pinned
   // here so a regression in any matrix coefficient is caught. Tolerances are generous
@@ -215,7 +237,7 @@ describe("gamut-aware worst-case contrast (WCAG AA, 4.5:1)", () => {
   it(`dark theme: text clears ${WCAG_AA_TEXT}:1 vs --inset (#070a09) over all hues+chromas`, () => {
     const { textL } = LABEL_CHIP_THEME.dark;
     const worst = worstCaseContrast(textL, ROW_BG_DARK);
-     
+
     console.log(
       `[label-color] dark worst-case: ratio=${worst.ratio.toFixed(3)} @ (hue=${worst.hue}, chroma=${worst.chroma.toFixed(4)})`,
     );
@@ -229,7 +251,7 @@ describe("gamut-aware worst-case contrast (WCAG AA, 4.5:1)", () => {
   it(`light theme: text clears ${WCAG_AA_TEXT}:1 vs --inset (#f3f6f4) over all hues+chromas`, () => {
     const { textL } = LABEL_CHIP_THEME.light;
     const worst = worstCaseContrast(textL, ROW_BG_LIGHT);
-     
+
     console.log(
       `[label-color] light worst-case: ratio=${worst.ratio.toFixed(3)} @ (hue=${worst.hue}, chroma=${worst.chroma.toFixed(4)})`,
     );

--- a/ui/src/lib/label-color.test.ts
+++ b/ui/src/lib/label-color.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for label-color.ts (issue: labels-almost-invisible).
+ *
+ * The core acceptance gate is contrast: label chip TEXT must clear WCAG 4.5:1
+ * against the row background it sits on, for every hue AND chroma a forge label
+ * could plausibly resolve to on screen, in both themes.
+ *
+ * Gamut-aware check (this matters): the chip text is emitted as a plain `oklch(L C H)`
+ * literal at the pinned per-theme lightness, but real forge labels reach chroma well
+ * beyond what's displayable at that L (e.g. GitHub #7057ff ≈ C 0.24). A browser
+ * gamut-maps an out-of-gamut `oklch()` by REDUCING chroma while holding L and H (CSS
+ * Color 4) — so the set of colors that can actually paint at lightness L is exactly
+ * `{ oklch(L, c, H) : 0 ≤ c ≤ maxInGamutChroma(L, H) }`. We therefore, per hue,
+ * binary-search that max in-gamut chroma and sample the whole 0→maxC segment
+ * (including c=0, the neutral gray), inverting each `oklch(L C H)` back to sRGB (the
+ * reverse of label-color.ts's forward hex→OKLCH transform) to compute WCAG relative
+ * luminance / contrast per WCAG 2.x. The worst case over all hues+chromas is the real
+ * bound — sampling a single fixed (out-of-gamut) chroma would report an artifact.
+ *
+ * Backgrounds are `--inset` from src/app.css: dark `#070a09`, light `#f3f6f4`.
+ *
+ * Tuning record: the task's STARTING constants (dark textL 0.80, light textL 0.48)
+ * were run through the gamut-aware gate below and already clear 4.5:1 with margin, so
+ * no adjustment was needed. True worst cases:
+ *   dark:  ≈9.81:1 at (hue 330, chroma 0.187)   [neutral c=0 ≈10.64:1]
+ *   light: ≈5.63:1 at (hue 145, chroma 0.151)   [neutral c=0 ≈6.01:1]
+ * The exact numbers are re-derived and asserted (and printed to the console) below.
+ */
+import { describe, it, expect } from "vitest";
+import { labelChipColors, hexToOklchCH, LABEL_CHIP_THEME } from "./label-color";
+
+// ── inverse OKLCH → linear sRGB + gamma-encoded sRGB (Ottosson), local to this test ─
+
+function oklchToLinearRgb(l: number, c: number, hDeg: number): { r: number; g: number; b: number } {
+  const h = (hDeg * Math.PI) / 180;
+  const a = c * Math.cos(h);
+  const b = c * Math.sin(h);
+
+  const l_ = l + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = l - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = l - 0.0894841775 * a - 1.291485548 * b;
+
+  const ll = l_ ** 3;
+  const mm = m_ ** 3;
+  const ss = s_ ** 3;
+
+  return {
+    r: 4.0767416621 * ll - 3.3077115913 * mm + 0.2309699292 * ss,
+    g: -1.2684380046 * ll + 2.6097574011 * mm - 0.3413193965 * ss,
+    b: -0.0041960863 * ll - 0.7034186147 * mm + 1.707614701 * ss,
+  };
+}
+
+function gammaEncode(c: number): number {
+  const clamped = Math.min(1, Math.max(0, c));
+  return clamped <= 0.0031308 ? 12.92 * clamped : 1.055 * clamped ** (1 / 2.4) - 0.055;
+}
+
+function oklchToSrgb(l: number, c: number, hDeg: number): { r: number; g: number; b: number } {
+  const { r, g, b } = oklchToLinearRgb(l, c, hDeg);
+  return { r: gammaEncode(r), g: gammaEncode(g), b: gammaEncode(b) };
+}
+
+/** True iff `oklch(l c h)` is inside the sRGB gamut (all linear channels within
+ *  [0,1] before clamping; small epsilon tolerates float noise at the boundary). */
+function inGamut(l: number, c: number, hDeg: number, eps = 1e-4): boolean {
+  const { r, g, b } = oklchToLinearRgb(l, c, hDeg);
+  return r >= -eps && r <= 1 + eps && g >= -eps && g <= 1 + eps && b >= -eps && b <= 1 + eps;
+}
+
+/** Largest chroma such that `oklch(l c h)` stays in the sRGB gamut, by binary search.
+ *  Mirrors how a browser clamps an out-of-gamut label color: reduce C, hold L and H. */
+function maxInGamutChroma(l: number, hDeg: number): number {
+  let lo = 0;
+  let hi = 0.5; // beyond any sRGB chroma at these lightnesses
+  for (let i = 0; i < 40; i++) {
+    const mid = (lo + hi) / 2;
+    if (inGamut(l, mid, hDeg)) lo = mid;
+    else hi = mid;
+  }
+  return lo;
+}
+
+/** Parse a plain `oklch(L C H)` (optionally `/ A`, ignored here) literal, as emitted
+ *  by label-color.ts, into its numeric components. */
+function parseOklch(str: string): { l: number; c: number; h: number } {
+  const m = /oklch\(([-\d.]+) ([-\d.]+) ([-\d.]+)(?: \/ [-\d.]+)?\)/.exec(str);
+  if (!m) throw new Error(`not a plain oklch() literal: ${str}`);
+  return { l: Number(m[1]), c: Number(m[2]), h: Number(m[3]) };
+}
+
+// ── WCAG contrast ────────────────────────────────────────────────────────────────
+
+function srgbChannelToLinear(c: number): number {
+  return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+}
+
+function relativeLuminance(r: number, g: number, b: number): number {
+  return (
+    0.2126 * srgbChannelToLinear(r) +
+    0.7152 * srgbChannelToLinear(g) +
+    0.0722 * srgbChannelToLinear(b)
+  );
+}
+
+function hexToRgb01(hex: string): { r: number; g: number; b: number } {
+  const int = parseInt(hex.slice(1), 16);
+  return {
+    r: ((int >> 16) & 0xff) / 255,
+    g: ((int >> 8) & 0xff) / 255,
+    b: (int & 0xff) / 255,
+  };
+}
+
+function contrastRatio(
+  fg: { r: number; g: number; b: number },
+  bg: { r: number; g: number; b: number },
+): number {
+  const lFg = relativeLuminance(fg.r, fg.g, fg.b);
+  const lBg = relativeLuminance(bg.r, bg.g, bg.b);
+  const lighter = Math.max(lFg, lBg);
+  const darker = Math.min(lFg, lBg);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+// --inset from ui/src/app.css
+const ROW_BG_DARK = hexToRgb01("#070a09");
+const ROW_BG_LIGHT = hexToRgb01("#f3f6f4");
+
+const WCAG_AA_TEXT = 4.5;
+
+/** Global worst-case (minimum) text contrast at lightness `textL` over every hue
+ *  (5° steps) and, per hue, the full in-gamut chroma range (0 → maxC, 12 steps incl.
+ *  c=0), against `bg`. Returns the ratio and the (hue, chroma) where it occurs. */
+function worstCaseContrast(
+  textL: number,
+  bg: { r: number; g: number; b: number },
+): { ratio: number; hue: number; chroma: number } {
+  let worst = Infinity;
+  let worstHue = -1;
+  let worstChroma = -1;
+  for (let h = 0; h < 360; h += 5) {
+    const maxC = maxInGamutChroma(textL, h);
+    for (let k = 0; k <= 12; k++) {
+      const c = (maxC * k) / 12;
+      const ratio = contrastRatio(oklchToSrgb(textL, c, h), bg);
+      if (ratio < worst) {
+        worst = ratio;
+        worstHue = h;
+        worstChroma = c;
+      }
+    }
+  }
+  return { ratio: worst, hue: worstHue, chroma: worstChroma };
+}
+
+describe("labelChipColors", () => {
+  it("returns null for an invalid hex", () => {
+    expect(labelChipColors("not-a-color")).toBeNull();
+    expect(labelChipColors("#fff")).toBeNull(); // 3-digit shorthand unsupported
+    expect(labelChipColors("#gggggg")).toBeNull();
+    expect(labelChipColors("")).toBeNull();
+  });
+
+  it("returns non-null well-formed oklch() literals for a valid hex", () => {
+    const result = labelChipColors("#1d76db"); // GitHub's default blue label color
+    expect(result).not.toBeNull();
+    const oklchLiteral = /^oklch\([-\d.]+ [-\d.]+ [-\d.]+\)$/;
+    const oklchAlphaLiteral = /^oklch\([-\d.]+ [-\d.]+ [-\d.]+ \/ [-\d.]+\)$/;
+    expect(result!.textDark).toMatch(oklchLiteral);
+    expect(result!.borderDark).toMatch(oklchLiteral);
+    expect(result!.fillDark).toMatch(oklchAlphaLiteral);
+    expect(result!.textLight).toMatch(oklchLiteral);
+    expect(result!.borderLight).toMatch(oklchLiteral);
+    expect(result!.fillLight).toMatch(oklchAlphaLiteral);
+  });
+
+  it("preserves hue/chroma while swapping in the per-theme text lightness", () => {
+    const result = labelChipColors("#1d76db")!;
+    const dark = parseOklch(result.textDark);
+    const light = parseOklch(result.textLight);
+    expect(dark.l).toBeCloseTo(LABEL_CHIP_THEME.dark.textL, 4);
+    expect(light.l).toBeCloseTo(LABEL_CHIP_THEME.light.textL, 4);
+    // same source color -> same hue/chroma in both themes
+    expect(dark.h).toBeCloseTo(light.h, 1);
+    expect(dark.c).toBeCloseTo(light.c, 3);
+  });
+
+  it("round-trips a neutral achromatic hex to near-zero chroma", () => {
+    const result = labelChipColors("#888888")!;
+    const dark = parseOklch(result.textDark);
+    expect(dark.c).toBeLessThan(0.01);
+  });
+});
+
+describe("hexToOklchCH (forward-transform golden matrix)", () => {
+  // Expected C/H computed independently once (Ottosson sRGB→OKLab, 6-dp) and pinned
+  // here so a regression in any matrix coefficient is caught. Tolerances are generous
+  // vs the pinned value but far tighter than any coefficient typo would land within.
+  const cases: Array<{ hex: string; c: number; h: number }> = [
+    { hex: "#1d76db", c: 0.174084, h: 255.394105 }, // GitHub blue
+    { hex: "#d73a4a", c: 0.192675, h: 20.10446 }, // GitHub "bug" red
+    { hex: "#7057ff", c: 0.236968, h: 282.959304 }, // GitHub "good first issue" violet
+  ];
+  for (const { hex, c, h } of cases) {
+    it(`maps ${hex} to the known C/H`, () => {
+      const got = hexToOklchCH(hex);
+      expect(got.c).toBeCloseTo(c, 4);
+      expect(got.h).toBeCloseTo(h, 2);
+    });
+  }
+});
+
+describe("gamut-aware worst-case contrast (WCAG AA, 4.5:1)", () => {
+  it(`dark theme: text clears ${WCAG_AA_TEXT}:1 vs --inset (#070a09) over all hues+chromas`, () => {
+    const { textL } = LABEL_CHIP_THEME.dark;
+    const worst = worstCaseContrast(textL, ROW_BG_DARK);
+     
+    console.log(
+      `[label-color] dark worst-case: ratio=${worst.ratio.toFixed(3)} @ (hue=${worst.hue}, chroma=${worst.chroma.toFixed(4)})`,
+    );
+    expect(worst.ratio).toBeGreaterThanOrEqual(WCAG_AA_TEXT);
+    // explicit neutral (c=0) assertion — a grey label must also pass
+    expect(contrastRatio(oklchToSrgb(textL, 0, 0), ROW_BG_DARK)).toBeGreaterThanOrEqual(
+      WCAG_AA_TEXT,
+    );
+  });
+
+  it(`light theme: text clears ${WCAG_AA_TEXT}:1 vs --inset (#f3f6f4) over all hues+chromas`, () => {
+    const { textL } = LABEL_CHIP_THEME.light;
+    const worst = worstCaseContrast(textL, ROW_BG_LIGHT);
+     
+    console.log(
+      `[label-color] light worst-case: ratio=${worst.ratio.toFixed(3)} @ (hue=${worst.hue}, chroma=${worst.chroma.toFixed(4)})`,
+    );
+    expect(worst.ratio).toBeGreaterThanOrEqual(WCAG_AA_TEXT);
+    // explicit neutral (c=0) assertion — a grey label must also pass
+    expect(contrastRatio(oklchToSrgb(textL, 0, 0), ROW_BG_LIGHT)).toBeGreaterThanOrEqual(
+      WCAG_AA_TEXT,
+    );
+  });
+});

--- a/ui/src/lib/label-color.ts
+++ b/ui/src/lib/label-color.ts
@@ -1,0 +1,124 @@
+/**
+ * OKLCH-based label chip coloring (issue: labels-almost-invisible).
+ *
+ * Raw forge hex (e.g. GitHub label colors) used verbatim as chip text is often
+ * illegible against Shepherd's near-black dark rows or near-white light rows —
+ * some hues are naturally very light (yellow) or very dark (navy) at full
+ * saturation, so a fixed L per theme, but true hue/chroma preserved, keeps the
+ * text recognizably "that label's color" while pinning contrast: OKLCH's L
+ * channel is built to be perceptually uniform, so holding L constant across
+ * hues gives near-constant contrast against a fixed background regardless of
+ * which hue a given label happens to be.
+ *
+ * Dependency-free (no CSS parsing/color libraries) — this module is pure math
+ * translated directly from Björn Ottosson's OKLab/OKLCH reference formulas
+ * (https://bottosson.github.io/posts/oklab/), so it can run in tests (node)
+ * and components (browser) alike without any DOM/CSSOM access.
+ */
+
+/** Emitted `oklch()` literal strings for a single label's color, one set per theme.
+ *  Plain literals (`oklch(L C H)` / `oklch(L C H / A)`) — NOT `oklch(from …)` relative
+ *  syntax — so the value is portable to inline styles, not just CSS that resolves a
+ *  base color at parse time. */
+export interface LabelChipColors {
+  textDark: string;
+  borderDark: string;
+  fillDark: string;
+  textLight: string;
+  borderLight: string;
+  fillLight: string;
+}
+
+/**
+ * Per-theme lightness/alpha constants for label chips — the single source of truth,
+ * intended to be surfaced on the /design-system reference page (nothing reads it yet).
+ * Hue and chroma always come
+ * from the source label color; only L (and fill alpha) are pinned here, per theme,
+ * so text stays legible against Shepherd's near-black dark rows / near-white light
+ * rows regardless of which hue a given label happens to be.
+ *
+ * `textL`/`borderL` are shared for a theme (border reuses the text lightness target
+ * region rather than needing its own tuning — it only needs to read as "the label's
+ * color," not clear a text-contrast bar). `fillL`/`fillA` set a low-opacity tint wash
+ * behind the chip.
+ *
+ * `textL` was verified against a gamut-aware worst-case WCAG contrast check (see
+ * label-color.test.ts): for every hue, over the FULL in-gamut chroma range at the
+ * pinned lightness (0 → maxInGamutChroma, since the browser gamut-maps an
+ * out-of-gamut oklch() literal by reducing C while holding L/H), the minimum text
+ * contrast vs the theme row bg clears 4.5:1. The starting values below already pass
+ * with margin (dark ≈9.81:1, light ≈5.63:1), so no tuning was needed; see that
+ * file's header comment for the exact worst-case (hue, chroma) per theme.
+ */
+export const LABEL_CHIP_THEME = {
+  dark: { textL: 0.8, borderL: 0.55, fillL: 0.62, fillA: 0.15 },
+  light: { textL: 0.48, borderL: 0.55, fillL: 0.62, fillA: 0.16 },
+} as const;
+
+const HEX_RE = /^#([0-9a-fA-F]{6})$/;
+
+function linearize(c: number): number {
+  return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+}
+
+/** sRGB `#rrggbb` hex → OKLCH chroma (C) and hue (H, degrees, [0,360)). The source
+ *  lightness is intentionally discarded — callers substitute a per-theme constant.
+ *  Exported for the forward-transform golden test; throws on a non-`#rrggbb` hex. */
+export function hexToOklchCH(hex: string): { c: number; h: number } {
+  const m = HEX_RE.exec(hex);
+  if (!m) throw new Error(`invalid hex: ${hex}`);
+  const int = parseInt(m[1], 16);
+  const r = linearize(((int >> 16) & 0xff) / 255);
+  const g = linearize(((int >> 8) & 0xff) / 255);
+  const b = linearize((int & 0xff) / 255);
+
+  const l = 0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b;
+  const m_ = 0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b;
+  const s = 0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b;
+
+  const l_ = Math.cbrt(l);
+  const m_c = Math.cbrt(m_);
+  const s_ = Math.cbrt(s);
+
+  const A = 1.9779984951 * l_ - 2.428592205 * m_c + 0.4505937099 * s_;
+  const B = 0.0259040371 * l_ + 0.7827717662 * m_c - 0.808675766 * s_;
+
+  const c = Math.hypot(A, B);
+  const h = ((Math.atan2(B, A) * 180) / Math.PI + 360) % 360;
+  return { c, h };
+}
+
+function round(n: number, decimals: number): number {
+  const f = 10 ** decimals;
+  return Math.round(n * f) / f;
+}
+
+function oklch(l: number, c: number, h: number): string {
+  return `oklch(${round(l, 4)} ${round(c, 4)} ${round(h, 2)})`;
+}
+
+function oklchAlpha(l: number, c: number, h: number, a: number): string {
+  return `oklch(${round(l, 4)} ${round(c, 4)} ${round(h, 2)} / ${round(a, 4)})`;
+}
+
+/**
+ * Convert a forge label hex color to legible chip colors for both themes. Preserves
+ * the source hue and chroma; substitutes a fixed per-theme lightness (see
+ * {@link LABEL_CHIP_THEME}) so contrast stays roughly constant across all hues.
+ *
+ * Returns `null` for anything that isn't a strict `#rrggbb` hex — callers fall back
+ * to the neutral chip styling in that case.
+ */
+export function labelChipColors(hex: string): LabelChipColors | null {
+  if (!HEX_RE.test(hex)) return null;
+  const { c, h } = hexToOklchCH(hex);
+  const { dark, light } = LABEL_CHIP_THEME;
+  return {
+    textDark: oklch(dark.textL, c, h),
+    borderDark: oklch(dark.borderL, c, h),
+    fillDark: oklchAlpha(dark.fillL, c, h, dark.fillA),
+    textLight: oklch(light.textL, c, h),
+    borderLight: oklch(light.borderL, c, h),
+    fillLight: oklchAlpha(light.fillL, c, h, light.fillA),
+  };
+}

--- a/ui/src/lib/label-color.ts
+++ b/ui/src/lib/label-color.ts
@@ -122,3 +122,15 @@ export function labelChipColors(hex: string): LabelChipColors | null {
     fillLight: oklchAlpha(light.fillL, c, h, light.fillA),
   };
 }
+
+/** Inline `style=""` custom-property declarations for a hued label chip, or null for an
+ *  invalid hex. Components apply these vars; their CSS picks per theme. Keeps the `--lc-*`
+ *  var names in one place. */
+export function labelChipStyle(hex: string): string | null {
+  const c = labelChipColors(hex);
+  if (!c) return null;
+  return (
+    `--lc-text-d:${c.textDark};--lc-border-d:${c.borderDark};--lc-fill-d:${c.fillDark};` +
+    `--lc-text-l:${c.textLight};--lc-border-l:${c.borderLight};--lc-fill-l:${c.fillLight}`
+  );
+}

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -219,6 +219,9 @@ export interface Issue {
   body: string;
   url: string;
   labels: string[];
+  /** Label name → hex color (`#rrggbb`) from the forge, when available. Additive/optional;
+   *  `labels` stays authoritative. Absent/partial ⇒ neutral chip fallback. */
+  labelColors?: Record<string, string>;
   createdAt: number;
   /** GitHub/Gitea logins assigned to the issue (empty when unassigned). Drives the
    *  "mine & unassigned" filter (#824). */

--- a/ui/src/routes/design-system/+page.svelte
+++ b/ui/src/routes/design-system/+page.svelte
@@ -17,6 +17,7 @@
   import { theme } from "$lib/theme.svelte";
   import IssueFilterPopover from "$lib/components/IssueFilterPopover.svelte";
   import GlossaryText from "$lib/components/GlossaryText.svelte";
+  import { labelChipStyle } from "$lib/label-color";
   // Graphical plugin-UI widgets (issue #1189). Unlike the static meter demo, these
   // widgets compute SVG geometry from props — a static copy would drift. Import the
   // real components via PluginUIRenderer so the showcase exercises the actual dispatch path.
@@ -135,6 +136,29 @@ input, select, textarea {
   color: var(--color-muted);
 }
 /* state colors come from the accent/status tokens, applied to color + border */`;
+
+  // Real forge label colors (GitHub's default "bug"/"good first issue"/"enhancement"
+  // palette) run through the same labelChipStyle() every issue label chip uses — see
+  // the "Sanctioned exception" note below.
+  const demoLabelStyle = labelChipStyle("#d73a4a");
+  const demoLabelStyle2 = labelChipStyle("#7057ff");
+  const demoLabelStyle3 = labelChipStyle("#a2eeef");
+
+  const labelChipMarkup = `import { labelChipStyle } from "$lib/label-color";
+
+<span class="label-chip" class:hued={style !== null} style={style}>bug</span>
+
+/* dark default; light theme overrides via the ancestor selector */
+.label-chip.hued {
+  color: var(--lc-text-d);
+  border-color: var(--lc-border-d);
+  background: var(--lc-fill-d);
+}
+:global([data-theme="light"]) .label-chip.hued {
+  color: var(--lc-text-l);
+  border-color: var(--lc-border-l);
+  background: var(--lc-fill-l);
+}`;
 
   const statusChipMarkup = `<span class="status-chip info"><span class="dot"></span>PR #42</span>
 <span class="status-chip ready"><span class="dot"></span>CI passing</span>
@@ -846,6 +870,33 @@ input, select, textarea {
         so a lone 6px chip is never stranded between 2px siblings.
       </li>
     </ul>
+
+    <p class="when">
+      <strong>Sanctioned exception — issue label chips render the real forge color.</strong> Rule 4
+      above ("accent hues are semantic, not decorative") governs Shepherd's OWN chrome — states
+      Shepherd itself defines (READY, running, blocked). Issue labels are the opposite: they are
+      <em>data</em>, not chrome — a label's color is whatever the forge (GitHub, etc.) assigned it,
+      the same way an avatar's color is whoever the person is. This is the ONLY place raw
+      data-driven color is allowed into chip chrome; nowhere else may a hex/rgba literal stand in
+      for a semantic token.
+    </p>
+    <p class="when">
+      The raw forge hex is never used verbatim (a fully-saturated yellow or navy label is unreadable
+      against a near-black or near-white row). Instead it is normalized through OKLCH (<code
+        >label-color.ts</code
+      >): the source hue and chroma are preserved, but lightness is substituted for a fixed
+      per-theme constant (<code>LABEL_CHIP_THEME</code>), so every label — regardless of hue —
+      clears WCAG AA (4.5:1) text contrast in both themes (verified by a gamut-aware worst-case test
+      over every hue/chroma the browser can actually paint). The tunable knobs (text/border
+      lightness, fill lightness + alpha, per theme) live in that one constant, not scattered across
+      components.
+    </p>
+    <div class="demo">
+      <span class="label-chip-demo" style={demoLabelStyle}>bug</span>
+      <span class="label-chip-demo" style={demoLabelStyle2}>good first issue</span>
+      <span class="label-chip-demo" style={demoLabelStyle3}>enhancement</span>
+    </div>
+    <pre><code>{labelChipMarkup}</code></pre>
   </section>
 
   <section class="panel">
@@ -1266,6 +1317,25 @@ input, select, textarea {
     border: 1px solid var(--color-line);
     border-radius: 2px;
     color: var(--color-muted);
+  }
+  /* Issue label chip demo — mirrors IssueRow's .label-chip.hued recipe: --lc-* vars
+     (from labelChipStyle()) drive dark-default color/border/fill, overridden per theme
+     via the ancestor [data-theme="light"] selector. See the "Sanctioned exception" note
+     in the Badges & chips section above. */
+  .label-chip-demo {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    border-radius: 2px;
+    padding: 1px 5px;
+    color: var(--lc-text-d);
+    border: 1px solid var(--lc-border-d);
+    background: var(--lc-fill-d);
+  }
+  :global([data-theme="light"]) .label-chip-demo {
+    color: var(--lc-text-l);
+    border-color: var(--lc-border-l);
+    background: var(--lc-fill-l);
   }
   /* Status chip — 6px chip-row control; distinct from the 2px .chip color swatch above */
   .status-chip {


### PR DESCRIPTION
## Problem

In the Repos pane → Issues view, label chips (`ENHANCEMENT`, `FEEDBACK`, `BOT-TRIAGED`, …) all rendered the **same neutral grey** — labels were near-invisible and indistinguishable. Root cause: the forge layer fetched each label but **discarded its color**, keeping only the name (`Issue.labels: string[]`).

## What this does

Carries each label's **real GitHub/Gitea color** out to the UI and renders the chip in it, kept legible in both themes via OKLCH.

**1. Forge — carry color additively** (`feat(forge)`)
- Adds optional `labelColors?: Record<string, string>` (name → `#rrggbb`) to `Issue`. `labels: string[]` is **unchanged** — the ~15 name-based consumers (drain, epic, filters, `ACTIVE_LABEL` checks) are untouched.
- Threads color on every **display** path: GitHub `gh issue list` **and** the rate-limit REST fallback (`mapRestIssue`), plus Gitea `listIssues`. Colors normalized to `#rrggbb`; the field is omitted when empty. Claim-recheck `getIssue` paths stay names-only (not a display surface).

**2. Legible color math** (`feat(ui)` — `ui/src/lib/label-color.ts`)
- Pure hex→OKLCH conversion. `labelChipColors(hex)` keeps the label's true hue + chroma but **pins perceptual lightness per theme**, emitting plain `oklch()` literals (no `oklch(from …)` relative syntax → no browser feature gate; a missing/invalid color → neutral fallback).
- Because OKLCH `L` is perceptual, contrast holds across all hues. A **gamut-aware** test binary-searches the max in-gamut chroma per hue and asserts WCAG AA (≥4.5:1) against both row backgrounds — verified worst case **dark 9.81:1 / light 5.63:1**.

**3. Render** (`feat(ui)`)
- Colors chips on all four sites: the issues list (`IssueRow`), the New-Task label chip (`PromptSources`), and both `IssueFilterPopover` instances (Backlog + New-Task). The `hued` class is only applied when the chip is **not** in a semantic state, so it never collides with `shepherd:active`/selected/epic/blocked/assignee styling.
- `/design-system` documents the sanctioned data-driven-color exception (label colors are data, like avatar colors); all tunable L/alpha live in one `LABEL_CHIP_THEME` constant.

## Testing

- Root: `bun test ./test/forge` (270 pass) + full `bun test` green; `bun run lint` clean.
- UI: `bun run check` (0 errors, i18n EN/DE parity) + `bun run test:node` (2218 pass, incl. the contrast + golden-matrix gates).
- PR-hygiene gates (branch linearity, feature-catalog, announcement-versions, glossary) + `fallow audit` all pass.

## Notes

- Ships a v1.43.0 **What's-New** entry (`colored-issue-labels`) + EN/DE keys.
- Labels on forges/paths without a color gracefully fall back to the existing neutral chip.
