### PR TITLE
feat(issues): hide blocked-labeled issues across Up Next & backlog

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -59,6 +59,24 @@ lines), read by the systemd unit if present.
 
 See [Operating Shepherd](/operating/) for the host-level `/etc/fstab` belt.
 
+## Runaway-orphan reaper
+
+A background sweep ([#1144](https://github.com/erwins-enkel/shepherd/issues/1144))
+that `SIGKILL`s a process only when it both **(a)** carries the archived session's
+`SHEPHERD_SESSION_ID` in its `/proc/<pid>/environ` (provenance — an agent, or a
+descendant that inherited the marker, spawned it) **and (b)** belongs to a session
+whose row is present and `archived` (the agent is definitively done). Attribution is
+by env marker, not working directory, so it survives `cd`, backgrounding, and
+worktree deletion — and an operator's own processes (which never carry the marker)
+can never be candidates. The CPU/age pair below is a performance prefilter that keeps
+the sweep's `/proc/<pid>/environ` reads near zero, **not** a safety floor.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SHEPHERD_REAP_RUNAWAY` | `armed` | Reaper mode. `armed` (the default — any unset/unrecognised value) `SIGKILL`s qualifying orphans; `observe` runs every gate but only logs (never signals); `0`/`off` disables the sweep entirely |
+| `SHEPHERD_REAP_RUNAWAY_MIN_CPU` | `0.8` | CPU prefilter: fraction of one core, averaged over the process's whole lifetime, a candidate must have burned before it can be reaped. Clamped to `0.05`–`1` (a set-but-empty value clamps rather than dropping the gate) |
+| `SHEPHERD_REAP_RUNAWAY_MIN_AGE_S` | `300` | Minimum process age (seconds) before a candidate can be reaped — the floor that keeps a freshly restored session's briefly-archived row from being reaped. Clamped to a hard `60`s minimum (up to 24h) |
+
 ## Main agent terminal renderer (research preview)
 
 Every spawned `claude` runs on Claude Code's **classic** renderer by default —

--- a/src/up-next-core.ts
+++ b/src/up-next-core.ts
@@ -26,6 +26,9 @@ export interface UpNextItem {
   kind: UpNextKind;
   priority: boolean;
   createdAt: number;
+  /** The issue's labels (standalone) or the parent epic's labels (epic unit) — used by the
+   *  UI's client-side hide-blocked display filter (isBlocked in issues-panel.ts). */
+  labels: string[];
   /** Present iff this row represents an epic unit (the parent it rolls up). */
   epicParent?: { number: number; title: string };
   /** Payload for SessionService.create()'s issueRef on Start. */
@@ -163,6 +166,7 @@ function standaloneItem(repo: RepoInput, issue: Issue, linkedSet: Set<number>): 
     kind: classifyKind(labelSet),
     priority: hasLabel(labelSet, PRIORITY_LABEL),
     createdAt: issue.createdAt,
+    labels: issue.labels,
     issueRef: { number: issue.number, url: issue.url, title: issue.title, body: issue.body },
   };
 }
@@ -188,6 +192,7 @@ function epicItem(repo: RepoInput, e: EpicUnitInput, linkedSet: Set<number>): Up
     kind: "epic",
     priority: hasLabel(parentLabelSet, PRIORITY_LABEL),
     createdAt: e.parentCreatedAt,
+    labels: e.parentLabels,
     epicParent: { number: e.parentNumber, title: e.parentTitle },
     issueRef: { number: c.number, url: c.url, title: c.title, body: c.body },
   };

--- a/test/up-next-core.test.ts
+++ b/test/up-next-core.test.ts
@@ -74,6 +74,30 @@ describe("classification", () => {
   });
 });
 
+describe("labels", () => {
+  test("standalone item carries the issue's labels", () => {
+    const r = [repo({ openIssues: [issue(1, { labels: ["blocked-upstream", "bug"] })] })];
+    expect(repoSection(r, "/r/a")!.items[0]!.labels).toEqual(["blocked-upstream", "bug"]);
+  });
+  test("epic unit carries the PARENT's labels, not the candidate child's", () => {
+    const r = [
+      repo({
+        openIssues: [issue(1), issue(2)],
+        epics: [
+          epic({
+            parentNumber: 100,
+            memberNumbers: [2],
+            parentLabels: ["blocked-upstream", "epic"],
+            candidate: issue(2, { labels: ["unrelated-child-label"] }),
+          }),
+        ],
+      }),
+    ];
+    const epicRow = repoSection(r, "/r/a")!.items.find((i) => i.kind === "epic")!;
+    expect(epicRow.labels).toEqual(["blocked-upstream", "epic"]);
+  });
+});
+
 describe("exclusions", () => {
   test("shepherd:active is excluded", () => {
     const r = [repo({ openIssues: [issue(1, { labels: ["shepherd:active"] }), issue(2)] })];
@@ -374,6 +398,7 @@ function makeItem(repoPath: string, num: number): UpNextItem {
     kind: "feature",
     priority: false,
     createdAt: num,
+    labels: [],
     issueRef: { number: num, url: `https://x/${num}`, title: `t${num}`, body: "" },
   };
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2935,5 +2935,8 @@
   "feat_prewarm_epic_ci_title": "Epic-Landing-CI vorwärmen",
   "feat_prewarm_epic_ci_body": "Ist die Option aktiviert, öffnet sich der Landing-PR eines Epics jetzt frühzeitig als Entwurf, sodass seine CI schon während des Abarbeitens vorgewärmt läuft, statt beim Abschluss kalt zu starten. Pro Repo in den Automatisierungseinstellungen aktivierbar.",
   "feat_colored_issue_labels_title": "Issue-Labels in ihren echten Farben",
-  "feat_colored_issue_labels_body": "Label-Chips im Backlog, in den Filtern und bei den Prompt-Quellen zeigen jetzt die echte Farbe des Labels aus GitHub, angepasst für Lesbarkeit in hellem und dunklem Theme — statt einheitlichem Grau."
+  "feat_colored_issue_labels_body": "Label-Chips im Backlog, in den Filtern und bei den Prompt-Quellen zeigen jetzt die echte Farbe des Labels aus GitHub, angepasst für Lesbarkeit in hellem und dunklem Theme — statt einheitlichem Grau.",
+  "issues_filter_blocked_label": "blockierte ausblenden",
+  "issues_filter_blocked_title": "Issues mit einem blocked-Label ausblenden (z. B. blocked-upstream)",
+  "issues_filter_all_blocked": "Alle passenden Issues sind blockiert — zum Anzeigen ausschalten"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2938,5 +2938,8 @@
   "feat_colored_issue_labels_body": "Label-Chips im Backlog, in den Filtern und bei den Prompt-Quellen zeigen jetzt die echte Farbe des Labels aus GitHub, angepasst für Lesbarkeit in hellem und dunklem Theme — statt einheitlichem Grau.",
   "issues_filter_blocked_label": "blockierte ausblenden",
   "issues_filter_blocked_title": "Issues mit einem blocked-Label ausblenden (z. B. blocked-upstream)",
-  "issues_filter_all_blocked": "Alle passenden Issues sind blockiert — zum Anzeigen ausschalten"
+  "issues_filter_all_blocked": "Alle passenden Issues sind blockiert — zum Anzeigen ausschalten",
+  "upnext_hide_blocked": "Blockierte Issues ausblenden",
+  "feat_hide_blocked_toggle_title": "Blockierte Issues überall ausblenden",
+  "feat_hide_blocked_toggle_body": "Ein \"Blockierte Issues ausblenden\"-Schalter funktioniert jetzt einheitlich im Backlog, im Issue-Picker von Neue Aufgabe und in Als Nächstes — standardmäßig aktiv, blendet er jedes als blockiert markierte Issue aus."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2938,5 +2938,8 @@
   "feat_colored_issue_labels_body": "Label chips across the backlog, filters, and prompt sources now render each label's actual color from GitHub, normalized for legibility in both light and dark themes — instead of flat grey.",
   "issues_filter_blocked_label": "hide blocked",
   "issues_filter_blocked_title": "Hide issues with a blocked label (e.g. blocked-upstream)",
-  "issues_filter_all_blocked": "All matching issues are blocked — toggle off to see them"
+  "issues_filter_all_blocked": "All matching issues are blocked — toggle off to see them",
+  "upnext_hide_blocked": "Hide blocked issues",
+  "feat_hide_blocked_toggle_title": "Hide blocked issues, everywhere",
+  "feat_hide_blocked_toggle_body": "A \"Hide blocked issues\" toggle now works the same way across the backlog, New Task issue picker, and Up Next — on by default, it drops any issue labeled as blocked."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2935,5 +2935,8 @@
   "feat_prewarm_epic_ci_title": "Pre-warm epic landing CI",
   "feat_prewarm_epic_ci_body": "When enabled, an epic's landing PR now opens early as a draft so its CI runs warm while the epic still drains, instead of a cold first run at completion. Opt in per repo in Automation settings.",
   "feat_colored_issue_labels_title": "Issue labels in their real colors",
-  "feat_colored_issue_labels_body": "Label chips across the backlog, filters, and prompt sources now render each label's actual color from GitHub, normalized for legibility in both light and dark themes — instead of flat grey."
+  "feat_colored_issue_labels_body": "Label chips across the backlog, filters, and prompt sources now render each label's actual color from GitHub, normalized for legibility in both light and dark themes — instead of flat grey.",
+  "issues_filter_blocked_label": "hide blocked",
+  "issues_filter_blocked_title": "Hide issues with a blocked label (e.g. blocked-upstream)",
+  "issues_filter_all_blocked": "All matching issues are blocked — toggle off to see them"
 }

--- a/ui/src/lib/components/IssueFilterPopover.browser.test.ts
+++ b/ui/src/lib/components/IssueFilterPopover.browser.test.ts
@@ -61,7 +61,7 @@ describe("IssueFilterPopover", () => {
     expect(triggerBtn()!.getAttribute("aria-expanded")).toBe("false");
   });
 
-  it("click trigger opens popover; three rows render when showMine=true", async () => {
+  it("click trigger opens popover; four rows render when showMine=true", async () => {
     render(IssueFilterPopover, { showMine: true });
 
     await expect.poll(() => triggerBtn()).toBeTruthy();
@@ -71,38 +71,39 @@ describe("IssueFilterPopover", () => {
 
     triggerBtn()!.click();
 
-    // After click, aria-expanded should be true and three checkbox rows present.
+    // After click, aria-expanded should be true and four checkbox rows present
+    // (mine + active + subs + blocked).
     await expect.poll(() => isOpen()).toBe(true);
-    expect(checkboxes().length).toBe(3);
+    expect(checkboxes().length).toBe(4);
 
     expect(rowLabels()).toContain(m.issues_filter_mine_label());
     expect(rowLabels()).toContain(m.issues_filter_active_label());
     expect(rowLabels()).toContain(m.issues_filter_subissues_label());
   });
 
-  it("badge reads 2 with showMine=true, hideOthers=true, hideActive=false, hideSubIssues=true", async () => {
-    // Default store: hideOthers=true, hideActive=false, hideSubIssues=true
-    // activeCount = 1 (mine) + 0 (active) + 1 (subs) = 2
+  it("badge reads 3 with showMine=true, hideOthers=true, hideActive=false, hideSubIssues=true", async () => {
+    // Default store: hideOthers=true, hideActive=false, hideSubIssues=true, hideBlocked=true
+    // activeCount = 1 (mine) + 0 (active) + 1 (subs) + 1 (blocked) = 3
     render(IssueFilterPopover, { showMine: true });
 
     await expect.poll(() => triggerBtn()).toBeTruthy();
-    expect(badgeText()).toBe("2");
+    expect(badgeText()).toBe("3");
   });
 
-  it("badge reads 1 (not 2) when showMine=false even with hideOthers=true persisted; mine row absent", async () => {
+  it("badge reads 2 (not 3) when showMine=false even with hideOthers=true persisted; mine row absent", async () => {
     // hideOthers is true (default) but showMine=false → mine doesn't count.
-    // activeCount = 0 (mine excluded) + 0 (active) + 1 (subs) = 1
+    // activeCount = 0 (mine excluded) + 0 (active) + 1 (subs) + 1 (blocked) = 2
     render(IssueFilterPopover, { showMine: false });
 
     await expect.poll(() => triggerBtn()).toBeTruthy();
-    expect(badgeText()).toBe("1");
+    expect(badgeText()).toBe("2");
 
     // Open the popover to verify mine row is absent.
     triggerBtn()!.click();
     await expect.poll(() => isOpen()).toBe(true);
 
-    // Only 2 checkboxes: active + subs (no mine).
-    expect(checkboxes().length).toBe(2);
+    // Only 3 checkboxes: active + subs + blocked (no mine).
+    expect(checkboxes().length).toBe(3);
 
     expect(rowLabels()).not.toContain(m.issues_filter_mine_label());
     expect(rowLabels()).toContain(m.issues_filter_active_label());
@@ -119,7 +120,7 @@ describe("IssueFilterPopover", () => {
     triggerBtn()!.click();
     await expect.poll(() => isOpen()).toBe(true);
 
-    expect(checkboxes().length).toBe(3);
+    expect(checkboxes().length).toBe(4);
 
     // Find the active checkbox by its row label text, not by checked state.
     const activeLabel = [...(popoverPanel()?.querySelectorAll(".filter-row") ?? [])].find(
@@ -146,7 +147,7 @@ describe("IssueFilterPopover", () => {
     triggerBtn()!.click();
     await expect.poll(() => isOpen()).toBe(true);
 
-    expect(checkboxes().length).toBe(3);
+    expect(checkboxes().length).toBe(4);
 
     // Mine checkbox is first and checked by default (hideOthers=true).
     const mineCheckbox = checkboxes()[0];
@@ -318,7 +319,7 @@ describe("IssueFilterPopover — author + label pickers", () => {
   });
 
   it("active count includes the selected author and every selected label", async () => {
-    // Default store (mine + subs) = 2, + author (1) + labels (2) = 5.
+    // Default store (mine + subs + blocked) = 3, + author (1) + labels (2) = 6.
     await open({
       showMine: true,
       authors: ["kai", "scoop"],
@@ -326,7 +327,7 @@ describe("IssueFilterPopover — author + label pickers", () => {
       labels: ["BUG", "DOCS"],
       selectedLabels: ["BUG", "DOCS"],
     });
-    expect(badgeText()).toBe("5");
+    expect(badgeText()).toBe("6");
   });
 
   it("focus on open still lands on the first boolean checkbox, not a radio, with sections present", async () => {

--- a/ui/src/lib/components/IssueFilterPopover.svelte
+++ b/ui/src/lib/components/IssueFilterPopover.svelte
@@ -58,6 +58,7 @@
     (showMine && issuesFilter.hideOthers ? 1 : 0) +
       (issuesFilter.hideActive ? 1 : 0) +
       (issuesFilter.hideSubIssues ? 1 : 0) +
+      (issuesFilter.hideBlocked ? 1 : 0) +
       (selectedAuthor != null ? 1 : 0) +
       selectedLabels.length,
   );
@@ -185,6 +186,17 @@
     <span class="row-text">
       <span class="row-label">{m.issues_filter_subissues_label()}</span>
       <span class="row-desc">{m.issues_filter_subissues_title()}</span>
+    </span>
+  </label>
+  <label class="filter-row">
+    <input
+      type="checkbox"
+      checked={issuesFilter.hideBlocked}
+      onchange={() => issuesFilter.toggleBlocked()}
+    />
+    <span class="row-text">
+      <span class="row-label">{m.issues_filter_blocked_label()}</span>
+      <span class="row-desc">{m.issues_filter_blocked_title()}</span>
     </span>
   </label>
 

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -10,6 +10,7 @@
     hideOthers,
     hideActive,
     hideSubIssues,
+    hideBlockedIssues,
     sortEpicsFirst,
     filterByAuthor,
     filterByLabels,
@@ -80,7 +81,9 @@
   let selectedAuthor = $state<string | null>(null);
   const selectedLabels = new SvelteSet<string>();
   let availableAuthors = $derived(distinctAuthors(issues));
-  let availableLabels = $derived(distinctLabels(issues));
+  let availableLabels = $derived(
+    distinctLabels(issues, { excludeBlocked: issuesFilter.hideBlocked }),
+  );
   let labelColorsMap = $derived(labelColorMap(issues));
   // Epic summaries for this repo: number → EpicSummary.
   let epicByNumber = $state<Map<number, EpicSummary>>(new Map());
@@ -113,12 +116,15 @@
       epicParentNums,
     ),
   );
+  // "Hide blocked" filter, applied AFTER the sub-issue filter and BEFORE the author/label
+  // filters (see hideBlockedIssues in issues-panel.ts).
+  let blockedFiltered = $derived(hideBlockedIssues(subFiltered, issuesFilter.hideBlocked));
   // Author + label filters (repo-scoped), applied AFTER the toggle filters and BEFORE the
   // text search. Kept as a named intermediate so the empty-state block can attribute a miss
   // to the structured filters (this being empty) vs. the text search (this non-empty but
   // visibleIssues empty).
   let authorLabelFiltered = $derived(
-    filterByLabels(filterByAuthor(subFiltered, selectedAuthor), selectedLabels),
+    filterByLabels(filterByAuthor(blockedFiltered, selectedAuthor), selectedLabels),
   );
 
   // Prune any selected author/label that a refresh removed from the current issue set.
@@ -173,6 +179,15 @@
       subFiltered.length === 0 &&
       issuesFilter.hideSubIssues &&
       epicsLoaded,
+  );
+  // The blocked filter emptied the remainder the sub-issue filter left behind.
+  let allHiddenByBlocked = $derived(
+    !allHiddenByAssignee &&
+      !allHiddenByActive &&
+      !allHiddenBySubIssues &&
+      subFiltered.length > 0 &&
+      blockedFiltered.length === 0 &&
+      issuesFilter.hideBlocked,
   );
   // Set of expanded epic issue numbers (SvelteSet for fine-grained reactivity).
   const expanded = new SvelteSet<number>();
@@ -515,6 +530,8 @@
           <div class="muted">{m.issues_filter_all_in_progress()}</div>
         {:else if allHiddenBySubIssues}
           <div class="muted">{m.issues_filter_all_sub_issues()}</div>
+        {:else if allHiddenByBlocked}
+          <div class="muted">{m.issues_filter_all_blocked()}</div>
         {:else if authorLabelFiltered.length === 0}
           <!-- Structured author/label filters emptied it (even if a search term is also
                present) — a generic filter miss, not the search-specific copy. -->

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -9,6 +9,7 @@
     hideOthers,
     hideActive,
     hideSubIssues,
+    hideBlockedIssues,
     filterByAuthor,
     filterByLabels,
     distinctAuthors,
@@ -58,7 +59,9 @@
   let selectedAuthor = $state<string | null>(null);
   const selectedLabels = new SvelteSet<string>();
   let availableAuthors = $derived(distinctAuthors(issues));
-  let availableLabels = $derived(distinctLabels(issues));
+  let availableLabels = $derived(
+    distinctLabels(issues, { excludeBlocked: issuesFilter.hideBlocked }),
+  );
   let labelColorsMap = $derived(labelColorMap(issues));
   let assigneeFiltered = $derived(hideOthers(issues, viewer, issuesFilter.hideOthers));
   let activeFiltered = $derived(hideActive(assigneeFiltered, issuesFilter.hideActive));
@@ -73,8 +76,11 @@
       epicParents,
     ),
   );
+  // "Hide blocked" filter, applied AFTER the sub-issue filter and BEFORE the author/label
+  // filters (mirrors IssuesPanel; see hideBlockedIssues in issues-panel.ts).
+  let blockedFiltered = $derived(hideBlockedIssues(subFiltered, issuesFilter.hideBlocked));
   let visibleIssues = $derived(
-    filterByLabels(filterByAuthor(subFiltered, selectedAuthor), selectedLabels),
+    filterByLabels(filterByAuthor(blockedFiltered, selectedAuthor), selectedLabels),
   );
   let allHiddenByAssignee = $derived(
     issues.length > 0 && assigneeFiltered.length === 0 && viewer != null && issuesFilter.hideOthers,

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -100,6 +100,15 @@
       issuesFilter.hideSubIssues &&
       epicsLoaded,
   );
+  // The blocked filter emptied the remainder the sub-issue filter left behind.
+  let allHiddenByBlocked = $derived(
+    !allHiddenByAssignee &&
+      !allHiddenByActive &&
+      !allHiddenBySubIssues &&
+      subFiltered.length > 0 &&
+      blockedFiltered.length === 0 &&
+      issuesFilter.hideBlocked,
+  );
   let filter = $state("");
   let filterInput = $state<HTMLInputElement>();
   // null = TODO.md presence not yet resolved for this repo; hide the tab until known.
@@ -336,6 +345,8 @@
           <div class="muted">{m.issues_filter_all_in_progress()}</div>
         {:else if allHiddenBySubIssues}
           <div class="muted">{m.issues_filter_all_sub_issues()}</div>
+        {:else if allHiddenByBlocked}
+          <div class="muted">{m.issues_filter_all_blocked()}</div>
         {:else if visibleIssues.length === 0}
           <!-- Author/label filters emptied the list (no text search on this tab). -->
           <div class="muted">{m.issues_filter_no_match()}</div>

--- a/ui/src/lib/components/UpNextPanel.browser.test.ts
+++ b/ui/src/lib/components/UpNextPanel.browser.test.ts
@@ -644,4 +644,31 @@ describe("UpNextPanel hide-blocked filter", () => {
     await expect.element(page.getByText("#3")).toBeInTheDocument();
     expect(btn.getAttribute("aria-pressed")).toBe("false");
   });
+
+  it("shows the blocked-filter hint (not 'all caught up') when every queued item is blocked", async () => {
+    // Whole queue hidden by the default-on toggle must read as "hidden by filter", not empty.
+    upNext.snapshot = {
+      generatedAt: 1,
+      repoCount: 1,
+      fallback: null,
+      failedRepoCount: 0,
+      sections: [
+        {
+          kind: "repo",
+          repoPath: "~/projects/homeassistant",
+          repoSlug: null,
+          repoLabel: "homeassistant",
+          totalCount: 1,
+          items: [item("~/projects/homeassistant", 5, false, { labels: ["blocked-upstream"] })],
+        },
+      ],
+    };
+    render(UpNextPanel, {});
+    await expect.element(page.getByText(m.issues_filter_all_blocked())).toBeInTheDocument();
+    await expect.element(page.getByText(m.upnext_empty())).not.toBeInTheDocument();
+    // Toggling off reveals the item and clears the hint.
+    document.querySelector<HTMLButtonElement>(".un-blockedbtn")!.click();
+    await expect.element(page.getByText("#5")).toBeInTheDocument();
+    await expect.element(page.getByText(m.issues_filter_all_blocked())).not.toBeInTheDocument();
+  });
 });

--- a/ui/src/lib/components/UpNextPanel.browser.test.ts
+++ b/ui/src/lib/components/UpNextPanel.browser.test.ts
@@ -12,6 +12,7 @@ import type {
 import { m } from "$lib/paraglide/messages";
 import { upNext } from "$lib/up-next.svelte";
 import { getUpNext, startUpNext } from "$lib/api";
+import { issuesFilter } from "$lib/issues-filter.svelte";
 
 // Mock the API so mounting (which kicks upNext.load()) makes no real network call.
 vi.mock("$lib/api", async (importOriginal) => {
@@ -30,7 +31,7 @@ const item = (
   repoPath: string,
   number: number,
   priority = false,
-  opts: { title?: string; createdAt?: number } = {},
+  opts: { title?: string; createdAt?: number; labels?: string[] } = {},
 ): UpNextItem => ({
   repoPath,
   repoSlug: null,
@@ -41,6 +42,7 @@ const item = (
   kind: "feature",
   priority,
   createdAt: opts.createdAt ?? 0,
+  labels: opts.labels ?? [],
   issueRef: {
     number,
     url: `https://example.test/${number}`,
@@ -182,6 +184,7 @@ afterEach(() => {
   upNext.snapshot = null;
   upNext.loadError = false;
   localStorage.removeItem("shepherd.upnext.sort");
+  issuesFilter.setBlocked(true); // restore the default so it never bleeds into other tests
   vi.clearAllMocks();
   fontStyle.remove();
 });
@@ -566,5 +569,79 @@ describe("UpNextPanel load failure", () => {
     render(UpNextPanel, {});
     await expect.element(page.getByText("#2")).toBeInTheDocument();
     await expect.element(page.getByText(m.common_issues_load_failed())).not.toBeInTheDocument();
+  });
+});
+
+describe("UpNextPanel hide-blocked filter", () => {
+  // A blocked item in the cross-repo priority section AND one in a per-repo section, across
+  // two repos, so the repo-filtered branch (below) has something to prove independently of
+  // the unfiltered/early-return branch.
+  const blockedSnapshot = (): UpNextSnapshot => ({
+    generatedAt: 1,
+    repoCount: 2,
+    fallback: null,
+    failedRepoCount: 0,
+    sections: [
+      {
+        kind: "priority",
+        repoPath: null,
+        repoSlug: null,
+        repoLabel: null,
+        totalCount: 2,
+        items: [
+          item("~/projects/homeassistant", 1, true),
+          item("~/projects/homeassistant", 2, true, { labels: ["blocked-upstream"] }),
+        ],
+      },
+      {
+        kind: "repo",
+        repoPath: "~/projects/homeassistant",
+        repoSlug: null,
+        repoLabel: "homeassistant",
+        totalCount: 1,
+        items: [item("~/projects/homeassistant", 3, false, { labels: ["blocked"] })],
+      },
+      {
+        kind: "repo",
+        repoPath: "~/projects/car-gas-tracker",
+        repoSlug: null,
+        repoLabel: "car-gas-tracker",
+        totalCount: 1,
+        items: [item("~/projects/car-gas-tracker", 4)],
+      },
+    ],
+  });
+
+  it("hides blocked items by default in the unfiltered (early-return) path", async () => {
+    upNext.snapshot = blockedSnapshot();
+    render(UpNextPanel, {});
+    await expect.element(page.getByText("#1")).toBeInTheDocument();
+    await expect.element(page.getByText("#4")).toBeInTheDocument();
+    await expect.element(page.getByText("#2")).not.toBeInTheDocument();
+    await expect.element(page.getByText("#3")).not.toBeInTheDocument();
+  });
+
+  it("also hides blocked items when a repo filter is active (repo-filtered path)", async () => {
+    // Critical (review point): the blocked filter must apply on BOTH branches of the
+    // `sections` derived, not just the unfiltered early return.
+    upNext.snapshot = blockedSnapshot();
+    render(UpNextPanel, { repoFilter: new Set(["~/projects/homeassistant"]) });
+    await expect.element(page.getByText("#1")).toBeInTheDocument();
+    await expect.element(page.getByText("#2")).not.toBeInTheDocument();
+    await expect.element(page.getByText("#3")).not.toBeInTheDocument();
+    // The other repo is filtered out entirely, independent of blocked-ness.
+    await expect.element(page.getByText("#4")).not.toBeInTheDocument();
+  });
+
+  it("reveals blocked items when the header toggle is switched off", async () => {
+    upNext.snapshot = blockedSnapshot();
+    render(UpNextPanel, {});
+    await expect.element(page.getByText("#1")).toBeInTheDocument();
+    const btn = document.querySelector<HTMLButtonElement>(".un-blockedbtn")!;
+    expect(btn.getAttribute("aria-pressed")).toBe("true");
+    btn.click();
+    await expect.element(page.getByText("#2")).toBeInTheDocument();
+    await expect.element(page.getByText("#3")).toBeInTheDocument();
+    expect(btn.getAttribute("aria-pressed")).toBe("false");
   });
 });

--- a/ui/src/lib/components/UpNextPanel.svelte
+++ b/ui/src/lib/components/UpNextPanel.svelte
@@ -12,6 +12,9 @@
   import { onMount } from "svelte";
   import ModelCliPicker from "./new-task/ModelCliPicker.svelte";
   import UpNextSortMenu from "./UpNextSortMenu.svelte";
+  import { isBlocked } from "./issues-panel";
+  import { issuesFilter } from "$lib/issues-filter.svelte";
+  import { coachTarget } from "$lib/actions/coachTarget.svelte";
   import {
     capacitySuggestedProvider,
     claudeUsageHoldLikely,
@@ -122,20 +125,36 @@
     sortMenuOpen = false;
   }
 
+  // Drops "blocked" items (per isBlocked / the shared hide-blocked toggle) from a section
+  // list — re-counting totalCount and dropping sections that empty out, same shape as the
+  // repo-filter step below. Identity (no-op) when the toggle is off.
+  function applyBlocked(list: UpNextSection[]): UpNextSection[] {
+    if (!issuesFilter.hideBlocked) return list;
+    return list
+      .map((s): UpNextSection | null => {
+        const items = s.items.filter((it) => !isBlocked(it.labels));
+        return items.length > 0 ? { ...s, items, totalCount: items.length } : null;
+      })
+      .filter((s): s is UpNextSection => s !== null);
+  }
+
   const snap = $derived(upNext.snapshot);
   // The chip-rail repo filter scopes the queue to one repo, identical to the session lenses.
   // Repo sections drop unless they match; the cross-repo priority section keeps only its items
-  // from the active repo (re-counting totalCount so "show all N" stays honest).
+  // from the active repo (re-counting totalCount so "show all N" stays honest). The hide-blocked
+  // filter is applied on BOTH branches — the early return must not skip it, or blocked issues
+  // leak whenever no repo chip is active.
   const sections = $derived.by(() => {
     const all = snap?.sections ?? [];
-    if (repoFilter.size === 0) return all;
-    return all
+    if (repoFilter.size === 0) return applyBlocked(all);
+    const repoFiltered = all
       .map((s): UpNextSection | null => {
         if (s.kind === "repo") return s.repoPath != null && repoFilter.has(s.repoPath) ? s : null;
         const items = s.items.filter((it) => repoFilter.has(it.repoPath));
         return items.length > 0 ? { ...s, items, totalCount: items.length } : null;
       })
       .filter((s): s is UpNextSection => s !== null);
+    return applyBlocked(repoFiltered);
   });
   // Empty ("all caught up") only once the server has actually produced a snapshot; a null/
   // never-computed snapshot shows loading, not the all-clear.
@@ -419,6 +438,15 @@
       aria-label={m.upnext_refresh()}
       onclick={refresh}>⟳</button
     >
+    <button
+      type="button"
+      class="un-blockedbtn"
+      use:coachTarget={"un-blockedbtn"}
+      aria-pressed={issuesFilter.hideBlocked}
+      title={m.upnext_hide_blocked()}
+      aria-label={m.upnext_hide_blocked()}
+      onclick={() => issuesFilter.toggleBlocked()}>⊘</button
+    >
     <div class="un-sortwrap">
       <button
         bind:this={sortBtn}
@@ -582,7 +610,8 @@
     display: inline-flex;
   }
   .un-refresh,
-  .un-sortbtn {
+  .un-sortbtn,
+  .un-blockedbtn {
     flex: none;
     display: inline-flex;
     align-items: center;
@@ -603,18 +632,26 @@
       border-color 0.12s ease;
   }
   .un-refresh:hover:not(:disabled),
-  .un-sortbtn:hover {
+  .un-sortbtn:hover,
+  .un-blockedbtn:hover {
     color: var(--color-amber);
     border-color: var(--color-amber);
   }
   .un-refresh:focus-visible,
-  .un-sortbtn:focus-visible {
+  .un-sortbtn:focus-visible,
+  .un-blockedbtn:focus-visible {
     outline: none;
     box-shadow: inset 0 0 0 1px var(--color-amber);
   }
   .un-refresh:disabled {
     opacity: 0.4;
     cursor: not-allowed;
+  }
+  /* Active (hide-blocked ON) reads the same as hover — amber, matching the "needs
+     attention"/actionable hue used elsewhere in this panel (priority pill, section head). */
+  .un-blockedbtn[aria-pressed="true"] {
+    color: var(--color-amber);
+    border-color: var(--color-amber);
   }
 
   .un-batch {

--- a/ui/src/lib/components/UpNextPanel.svelte
+++ b/ui/src/lib/components/UpNextPanel.svelte
@@ -138,24 +138,28 @@
       .filter((s): s is UpNextSection => s !== null);
   }
 
-  const snap = $derived(upNext.snapshot);
   // The chip-rail repo filter scopes the queue to one repo, identical to the session lenses.
   // Repo sections drop unless they match; the cross-repo priority section keeps only its items
-  // from the active repo (re-counting totalCount so "show all N" stays honest). The hide-blocked
-  // filter is applied on BOTH branches — the early return must not skip it, or blocked issues
-  // leak whenever no repo chip is active.
-  const sections = $derived.by(() => {
-    const all = snap?.sections ?? [];
-    if (repoFilter.size === 0) return applyBlocked(all);
-    const repoFiltered = all
+  // from the active repo (re-counting totalCount so "show all N" stays honest). Identity when no
+  // repo chip is active.
+  function applyRepoFilter(list: UpNextSection[]): UpNextSection[] {
+    if (repoFilter.size === 0) return list;
+    return list
       .map((s): UpNextSection | null => {
         if (s.kind === "repo") return s.repoPath != null && repoFilter.has(s.repoPath) ? s : null;
         const items = s.items.filter((it) => repoFilter.has(it.repoPath));
         return items.length > 0 ? { ...s, items, totalCount: items.length } : null;
       })
       .filter((s): s is UpNextSection => s !== null);
-    return applyBlocked(repoFiltered);
-  });
+  }
+
+  const snap = $derived(upNext.snapshot);
+  // Repo-filtered but BEFORE the hide-blocked step, so the empty state can tell "nothing queued"
+  // apart from "everything queued is hidden by the blocked toggle".
+  const sectionsPreBlocked = $derived(applyRepoFilter(snap?.sections ?? []));
+  // The hide-blocked filter is applied on top and runs regardless of whether a repo chip is active,
+  // so blocked issues never leak in the unfiltered view.
+  const sections = $derived(applyBlocked(sectionsPreBlocked));
   // Empty ("all caught up") only once the server has actually produced a snapshot; a null/
   // never-computed snapshot shows loading, not the all-clear.
   const computed = $derived(snap?.generatedAt != null);
@@ -171,6 +175,12 @@
       (upNext.loadError && sections.length === 0),
   );
   const isEmpty = $derived(computed && !loadFailed && sections.length === 0);
+  // The queue is empty ONLY because the (default-on) hide-blocked toggle dropped everything —
+  // surface a "hidden by the blocked filter" hint (same message as IssuesPanel/PromptSources)
+  // instead of the misleading "all caught up".
+  const allHiddenByBlocked = $derived(
+    isEmpty && issuesFilter.hideBlocked && sectionsPreBlocked.length > 0,
+  );
   const updatedAgo = $derived(
     snap?.generatedAt != null ? formatAgo(clock.current - snap.generatedAt) : null,
   );
@@ -496,7 +506,13 @@
     {:else if isEmpty}
       <div class="un-empty">
         <p class="un-muted">
-          {filteredRepo ? m.upnext_repo_filter_empty({ repo: filteredRepo }) : m.upnext_empty()}
+          {#if allHiddenByBlocked}
+            {m.issues_filter_all_blocked()}
+          {:else if filteredRepo}
+            {m.upnext_repo_filter_empty({ repo: filteredRepo })}
+          {:else}
+            {m.upnext_empty()}
+          {/if}
         </p>
         {#if onbacklog}
           <button type="button" class="un-backlog-link" onclick={() => onbacklog?.()}

--- a/ui/src/lib/components/issues-panel.test.ts
+++ b/ui/src/lib/components/issues-panel.test.ts
@@ -17,6 +17,8 @@ import {
   labelColorMap,
   filterByAuthor,
   filterByLabels,
+  isBlocked,
+  hideBlockedIssues,
   ACTIVE_LABEL,
 } from "./issues-panel";
 import type { Issue } from "$lib/types";
@@ -352,5 +354,67 @@ describe("sortEpicsFirst", () => {
   it("returns all issues when every issue is an epic parent", () => {
     const parents = new Set<number>([122, 100, 117, 90]);
     expect(sortEpicsFirst(all, parents)).toEqual(all);
+  });
+});
+
+describe("isBlocked", () => {
+  it.each([
+    "blocked",
+    "blocked-upstream",
+    "blocked-by-net",
+    "Blocked-Upstream",
+    "status/blocked",
+    "S: blocked",
+    "kind:blocked",
+  ])("matches label %j", (label) => {
+    expect(isBlocked([label])).toBe(true);
+  });
+
+  it.each(["unblocked", "needs-unblock", "unblock-me"])("does not match label %j", (label) => {
+    expect(isBlocked([label])).toBe(false);
+  });
+
+  it("returns false when no label matches", () => {
+    expect(isBlocked(["enhancement", "bug"])).toBe(false);
+  });
+
+  it("returns false for an empty labels array", () => {
+    expect(isBlocked([])).toBe(false);
+  });
+});
+
+describe("hideBlockedIssues", () => {
+  const plain = issue(1, "Plain", "", ["bug"]);
+  const blocked = issue(2, "Blocked", "", ["blocked-upstream"]);
+  const all = [plain, blocked];
+
+  it("when on, drops blocked issues and keeps the rest", () => {
+    expect(hideBlockedIssues(all, true)).toEqual([plain]);
+  });
+
+  it("when off, is an identity filter — returns all issues", () => {
+    const result = hideBlockedIssues(all, false);
+    expect(result).toEqual(all);
+    expect(result).not.toBe(all);
+  });
+});
+
+describe("distinctLabels with excludeBlocked", () => {
+  const list = [
+    issue(1, "A", "", ["enhancement", "blocked-upstream", ACTIVE_LABEL]),
+    issue(2, "B", "", ["Bug", "status/blocked"]),
+  ];
+
+  it("omits blocked-word labels when excludeBlocked is true", () => {
+    expect(distinctLabels(list, { excludeBlocked: true })).toEqual(["Bug", "enhancement"]);
+  });
+
+  it("keeps blocked-word labels when excludeBlocked is absent (existing behaviour)", () => {
+    expect(distinctLabels(list)).toEqual([
+      "blocked-upstream",
+      "Bug",
+      "enhancement",
+      "status/blocked",
+    ]);
   });
 });

--- a/ui/src/lib/components/issues-panel.ts
+++ b/ui/src/lib/components/issues-panel.ts
@@ -16,7 +16,7 @@ export const ACTIVE_LABEL = "shepherd:active";
  * `unblocked`/`unblock-me` (no boundary before "blocked" there). No `g` flag: `.test()`
  * stays stateless, so the shared instance is safe to reuse across calls.
  */
-export const BLOCKED_LABEL_RE = /\bblocked/i;
+const BLOCKED_LABEL_RE = /\bblocked/i;
 
 /**
  * Whether an issue's labels mark it blocked (any label matching {@link BLOCKED_LABEL_RE}).

--- a/ui/src/lib/components/issues-panel.ts
+++ b/ui/src/lib/components/issues-panel.ts
@@ -11,6 +11,31 @@ import type { Issue } from "$lib/types";
 export const ACTIVE_LABEL = "shepherd:active";
 
 /**
+ * Matches a `blocked` word at a word boundary, case-insensitive — e.g. `blocked`,
+ * `blocked-upstream`, `status/blocked`, `S: blocked`, `kind:blocked`. Does NOT match
+ * `unblocked`/`unblock-me` (no boundary before "blocked" there). No `g` flag: `.test()`
+ * stays stateless, so the shared instance is safe to reuse across calls.
+ */
+export const BLOCKED_LABEL_RE = /\bblocked/i;
+
+/**
+ * Whether an issue's labels mark it blocked (any label matching {@link BLOCKED_LABEL_RE}).
+ * The `?? []` guard tolerates a stale payload that predates the `labels` field.
+ */
+export function isBlocked(labels: readonly string[]): boolean {
+  return (labels ?? []).some((l) => BLOCKED_LABEL_RE.test(l));
+}
+
+/**
+ * Narrow an issue list to hide "blocked" issues (labeled with a blocked-word label —
+ * see {@link isBlocked}). Fails open — returns every issue unchanged — when `on` is false.
+ */
+export function hideBlockedIssues(issues: readonly Issue[], on: boolean): Issue[] {
+  if (!on) return [...issues];
+  return issues.filter((issue) => !isBlocked(issue.labels));
+}
+
+/**
  * Narrow an issue list by a free-text query (the panel's search field).
  * Case-insensitive substring match against number (with or without a leading
  * `#`), title, body, and labels. A blank/whitespace query is an identity
@@ -49,12 +74,22 @@ export function distinctAuthors(issues: readonly Issue[]): string[] {
  * governs it, so it doesn't belong in the categorization picker). Source for the label
  * filter's toggle chips — computed from the RAW list for the same reason as
  * {@link distinctAuthors}.
+ *
+ * `opts.excludeBlocked` additionally skips any blocked-word label (per {@link isBlocked}) —
+ * the dedicated "hide blocked" toggle already governs those. Default false: unchanged
+ * behaviour for existing callers.
  */
-export function distinctLabels(issues: readonly Issue[]): string[] {
+export function distinctLabels(
+  issues: readonly Issue[],
+  opts?: { excludeBlocked?: boolean },
+): string[] {
+  const excludeBlocked = opts?.excludeBlocked ?? false;
   const seen = new Set<string>();
   for (const issue of issues) {
     for (const label of issue.labels ?? []) {
-      if (label !== ACTIVE_LABEL) seen.add(label);
+      if (label === ACTIVE_LABEL) continue;
+      if (excludeBlocked && isBlocked([label])) continue;
+      seen.add(label);
     }
   }
   return [...seen].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));

--- a/ui/src/lib/demo/seed.ts
+++ b/ui/src/lib/demo/seed.ts
@@ -822,6 +822,7 @@ function buildUpNext(): UpNextSnapshot {
     kind,
     priority: false,
     createdAt: NOW - 26 * HOUR,
+    labels: [],
     issueRef: { number, url: `${gh(STOREFRONT)}/issues/${number}`, title, body },
   });
   const apiItem = (number: number, title: string, body: string, kind: Kind): UpNextItem => ({
@@ -834,6 +835,7 @@ function buildUpNext(): UpNextSnapshot {
     kind,
     priority: false,
     createdAt: NOW - 30 * HOUR,
+    labels: [],
     issueRef: { number, url: `${gh(API)}/issues/${number}`, title, body },
   });
   return {

--- a/ui/src/lib/docs-manifest.ts
+++ b/ui/src/lib/docs-manifest.ts
@@ -69,7 +69,7 @@ export const DOCS_PAGES: readonly DocsPage[] = [
     title: "Configuration",
     path: "/reference/configuration/",
     keywords:
-      "every environment variable and the per-agent sandbox profiles. core live preview host tuning (tmpfs inodes) main agent terminal renderer (research preview) up next quick-start documentation automation (pr-gated doc agent) anonymous usage telemetry per-agent sandbox / permission profiles",
+      "every environment variable and the per-agent sandbox profiles. core live preview host tuning (tmpfs inodes) runaway-orphan reaper main agent terminal renderer (research preview) up next quick-start documentation automation (pr-gated doc agent) anonymous usage telemetry per-agent sandbox / permission profiles",
   },
   {
     title: "External Task API",

--- a/ui/src/lib/feature-announcements/entries/v1.43.0-hide-blocked-toggle.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.43.0-hide-blocked-toggle.ts
@@ -1,0 +1,11 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "hide-blocked-toggle",
+  sinceVersion: "1.43.0",
+  titleKey: "feat_hide_blocked_toggle_title",
+  bodyKey: "feat_hide_blocked_toggle_body",
+  targetId: "un-blockedbtn",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/issues-filter.svelte.ts
+++ b/ui/src/lib/issues-filter.svelte.ts
@@ -11,6 +11,9 @@ const KEY_ACTIVE = "shepherd:issues-hide-active";
 // "Hide sub-issues" filter: drop native sub-issues (children of an epic). Default ON —
 // absence of the key means "on", so "0" is the value we persist.
 const KEY_SUB = "shepherd:issues-hide-subissues";
+// "Hide blocked" filter: drop issues whose labels mark them blocked (see isBlocked in
+// issues-panel.ts). Default ON — absence of the key means "on", so "0" is the value we persist.
+const KEY_BLOCKED = "shepherd:issues-hide-blocked";
 
 function read(): boolean {
   try {
@@ -39,10 +42,20 @@ function readSub(): boolean {
   }
 }
 
+function readBlocked(): boolean {
+  try {
+    // Default true: only an explicit "0" turns it off.
+    return localStorage.getItem(KEY_BLOCKED) !== "0";
+  } catch {
+    return true;
+  }
+}
+
 class IssuesFilter {
   hideOthers = $state(read());
   hideActive = $state(readActive());
   hideSubIssues = $state(readSub());
+  hideBlocked = $state(readBlocked());
   toggle() {
     this.set(!this.hideOthers);
   }
@@ -75,6 +88,18 @@ class IssuesFilter {
     try {
       if (v) localStorage.removeItem(KEY_SUB);
       else localStorage.setItem(KEY_SUB, "0");
+    } catch {
+      /* private mode / SSR — preference just won't survive reload */
+    }
+  }
+  toggleBlocked() {
+    this.setBlocked(!this.hideBlocked);
+  }
+  setBlocked(v: boolean) {
+    this.hideBlocked = v;
+    try {
+      if (v) localStorage.removeItem(KEY_BLOCKED);
+      else localStorage.setItem(KEY_BLOCKED, "0");
     } catch {
       /* private mode / SSR — preference just won't survive reload */
     }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1571,6 +1571,9 @@ export interface UpNextItem {
   kind: UpNextKind;
   priority: boolean;
   createdAt: number;
+  /** The issue's labels (standalone) or the parent epic's labels (epic unit) — used by the
+   *  hide-blocked display filter (isBlocked in issues-panel.ts). */
+  labels: string[];
   epicParent?: { number: number; title: string };
   issueRef: { number: number; url: string; title: string; body: string };
 }


### PR DESCRIPTION
## What

A zero-config **"Hide blocked issues"** toggle that filters out issues whose labels mark them
blocked — like our `blocked-upstream` label — across three surfaces:

- **Up Next** lens (new compact header toggle `⊘`)
- **Repo pane** / Backlog `IssuesPanel` (new row in the Filters popover)
- **New-Task** issue picker `PromptSources` (shares the same popover)

The toggle is a single persisted, viewer-agnostic preference (localStorage), **on by default**, so
blocked work stays out of the way out of the box. Flip it off to bring blocked issues back.

## Match rule

"Blocked" = a `blocked` word at a **word boundary**, case-insensitive (`/\bblocked/i`):

- **Matches:** `blocked`, `blocked-upstream`, `blocked-by-net`, and namespaced forms `status/blocked`,
  `S: blocked`, `kind:blocked`.
- **Skips:** `unblocked`, `needs-unblock`, `unblock-me` — a word boundary, not a substring, so
  semantically-ready labels are never hidden. This precision is what makes default-ON safe.

One shared client helper (`isBlocked`) drives all three surfaces, so they can't diverge.

## Details

- **Repo pane:** the blocked filter sits between the sub-issue and author/label filters; a dedicated
  `allHiddenByBlocked` empty-state explains a fully-filtered list; and blocked-word labels drop out
  of the include-chip options while the toggle is ON (so an include-chip can't silently yield an
  empty list).
- **Up Next:** `UpNextItem` now carries `labels` (populated server-side — standalone issues from
  their own labels, epic rows from the parent's). The filter runs in both the unfiltered and
  repo-filtered paths of the sections derivation, recounts section totals, and drops emptied
  sections.
- **Server ranking unchanged:** Up Next's pre-existing `EXCLUDE_LABELS` (exact `blocked`/`wontfix`)
  is a separate *ranking* exclusion and is intentionally left as-is. Consequence: toggling OFF
  reveals `blocked-*` issues (e.g. `blocked-upstream`) everywhere; an exact-`blocked` issue reappears
  in the backlog/New-Task picker but stays out of the Up Next *startable* queue — matching Up Next's
  other startability exclusions.
- Ships a What's-New announcement entry (`v1.43.0-hide-blocked-toggle`), differentiated from the
  sibling dependency-blocked-awareness and author/label-filter cards. Full EN/DE i18n.

## Testing

- Root `bun test` (6760 pass) + `bun run lint` clean.
- UI `bun run check` (0 errors), `check:i18n` (EN/DE parity), `test:node` (2220 pass),
  `test:browser` (full suite green — incl. updated `IssueFilterPopover` browser expectations for the
  new row + default-ON badge count).
- PR-hygiene gates (branch-hygiene, feature-catalog, announcement-versions, glossary) and
  `fallow audit` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
