### PR TITLE
fix(recap): guard ChatGPT-account-incompatible Codex role models

### DIFF
--- a/src/codex-auth.ts
+++ b/src/codex-auth.ts
@@ -1,0 +1,55 @@
+/**
+ * Codex CLI auth-mode detection. Some Codex models return HTTP 400
+ * ("… not supported when using Codex with a ChatGPT account") under a ChatGPT-account login but
+ * work with an API key, so role/main spawn resolution must know the auth mode to avoid pinning a
+ * doomed model (see `clampCodexModelForAuth` in ./default-model).
+ *
+ * Detection is STRUCTURAL, not by any single field: a real `~/.codex/auth.json` may omit an
+ * explicit `auth_mode`, so relying on it alone would silently mis-detect a ChatGPT operator as
+ * `unknown` and never clamp. Precedence: a real API key wins; else a present OAuth access token
+ * means a ChatGPT-account login; else an explicit `auth_mode` corroborates; else `unknown`.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { codexHome } from "./codex-usage";
+import type { CodexAuthMode } from "./default-model";
+
+function nonEmptyString(v: unknown): v is string {
+  return typeof v === "string" && v.trim() !== "";
+}
+
+/**
+ * Classify a parsed `auth.json` object into a {@link CodexAuthMode}. Pure — no I/O.
+ * Order matters: an API key is authoritative (it overrides a stale tokens block); a present
+ * `tokens.access_token` is the affirmative ChatGPT-account signal; `auth_mode` is only a
+ * last-resort corroborator so a file lacking tokens still resolves when it names its mode.
+ */
+export function parseCodexAuthMode(raw: unknown): CodexAuthMode {
+  if (typeof raw !== "object" || raw === null) return "unknown";
+  const obj = raw as Record<string, unknown>;
+
+  if (nonEmptyString(obj.OPENAI_API_KEY)) return "apikey";
+
+  const tokens = obj.tokens;
+  if (typeof tokens === "object" && tokens !== null) {
+    if (nonEmptyString((tokens as Record<string, unknown>).access_token)) return "chatgpt";
+  }
+
+  if (obj.auth_mode === "chatgpt") return "chatgpt";
+  if (obj.auth_mode === "apikey") return "apikey";
+
+  return "unknown";
+}
+
+/**
+ * Read `<dir>/auth.json` and detect the Codex auth mode. Fail-open: any error — missing file,
+ * unreadable, invalid JSON, non-Codex host — resolves to `unknown` so a spawn is never blocked on
+ * a false positive. Read on demand (auth mode can change at runtime); no caching.
+ */
+export function readCodexAuthMode(dir = codexHome()): CodexAuthMode {
+  try {
+    return parseCodexAuthMode(JSON.parse(readFileSync(join(dir, "auth.json"), "utf8")));
+  } catch {
+    return "unknown";
+  }
+}

--- a/src/default-model.ts
+++ b/src/default-model.ts
@@ -131,6 +131,39 @@ export function resolveDefaultModelSetting(
   return globalSetting;
 }
 
+/** How the operator's Codex CLI is authenticated. Some Codex models are rejected (HTTP 400) under
+ *  a ChatGPT-account login but work with an API key, so a role/main spawn resolution must know the
+ *  auth mode to avoid pinning a doomed model. `unknown` = undetermined (missing/unreadable
+ *  `~/.codex/auth.json`, or a non-Codex host) → fail-open, never clamp. Detected structurally in
+ *  `src/codex-auth.ts` (tokens present + no API key ⇒ chatgpt), not by any single JSON field. */
+export type CodexAuthMode = "chatgpt" | "apikey" | "unknown";
+
+/** Codex models known to be rejected (HTTP 400 "… not supported when using Codex with a ChatGPT
+ *  account") under a ChatGPT-account login. Deliberately a BLOCKLIST of empirically-confirmed bad
+ *  models, not an allowlist: fail-open, so a new/unknown model is never wrongly blocked. Extend as
+ *  more are confirmed; `src/codex-auth.ts`'s pane-tail capture makes a not-yet-listed one
+ *  diagnosable rather than silent. */
+export const CHATGPT_INCOMPATIBLE_CODEX_MODELS = new Set<string>(["gpt-5.3-codex"]);
+
+/** Auth-aware model clamp, orthogonal to {@link modelCompatibleWithProvider} (which stays a pure
+ *  model↔provider check). Returns `null` — "drop the --model flag, use the provider's own default"
+ *  — only for a Codex model that a ChatGPT-account login is known to reject; otherwise the model is
+ *  returned unchanged. `unknown`/`apikey` never clamp (fail-open). Pure. */
+export function clampCodexModelForAuth(
+  model: string | null,
+  provider: AgentProvider,
+  authMode: CodexAuthMode,
+): string | null {
+  if (
+    provider === "codex" &&
+    authMode === "chatgpt" &&
+    model !== null &&
+    CHATGPT_INCOMPATIBLE_CODEX_MODELS.has(model)
+  )
+    return null;
+  return model;
+}
+
 /** A resolved per-role spawn environment: which CLI to launch, which model flag (null = the
  *  provider's own default, no --model), and which effort flag (null/undefined = no --effort).
  *  `effort` is OPTIONAL — several call sites fall back to a `{ provider, model }` literal without
@@ -181,13 +214,16 @@ export function resolveRoleEnvironment(
   globalModelSetting: string,
   fableAvailable: boolean,
   roleEffort: string | null | undefined,
+  codexAuthMode: CodexAuthMode = "unknown",
 ): RoleEnvironment {
   const effort = normalizeEffort(roleEffort);
   const cli = normalizeRoleCli(roleCli);
   if (cli === null || cli === "inherit") {
+    // Clamp the global default too — a codex global default can itself be chatgpt-incompatible.
+    const model = spawnModelForAvailability(drainSpawnModel(globalModelSetting), fableAvailable);
     return {
       provider: globalProvider,
-      model: spawnModelForAvailability(drainSpawnModel(globalModelSetting), fableAvailable),
+      model: clampCodexModelForAuth(model, globalProvider, codexAuthMode),
       effort,
     };
   }
@@ -195,5 +231,35 @@ export function resolveRoleEnvironment(
   if (token === "default") return { provider: cli, model: null, effort };
   // Clamp: the stored model must belong to the chosen provider, else fall back to its default.
   if (!modelCompatibleWithProvider(token, cli)) return { provider: cli, model: null, effort };
-  return { provider: cli, model: spawnModelForAvailability(token, fableAvailable), effort };
+  const model = spawnModelForAvailability(token, fableAvailable);
+  // Auth-aware clamp: a codex model rejected by a ChatGPT-account login falls back to its default.
+  return { provider: cli, model: clampCodexModelForAuth(model, cli, codexAuthMode), effort };
+}
+
+/** Args for {@link resolveRoleEnvWithAuth} — the per-role setting triple plus the global fallback. */
+export interface RoleEnvArgs {
+  roleCli: string | null | undefined;
+  roleModel: string | null | undefined;
+  globalProvider: AgentProvider;
+  globalModelSetting: string;
+  fableAvailable: boolean;
+  roleEffort: string | null | undefined;
+}
+
+/** Testable role-env seam: reads the Codex auth mode via the INJECTED `readAuth` thunk and feeds it
+ *  into {@link resolveRoleEnvironment}. This is the unit the wiring in `src/index.ts` delegates to,
+ *  so the auth-read → resolve → clamp path is coverable without booting the server. */
+export function resolveRoleEnvWithAuth(
+  args: RoleEnvArgs,
+  readAuth: () => CodexAuthMode,
+): RoleEnvironment {
+  return resolveRoleEnvironment(
+    args.roleCli,
+    args.roleModel,
+    args.globalProvider,
+    args.globalModelSetting,
+    args.fableAvailable,
+    args.roleEffort,
+    readAuth(),
+  );
 }

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -17,6 +17,12 @@ import { parseGitVersion, gitVersionAtLeast, MIN_GIT_MAJOR, MIN_GIT_MINOR } from
 import { compareSemver } from "./herdr-update";
 import { autoFixCommandFor } from "./remediations";
 import { resolveNodeHost } from "./tailscale";
+import { readCodexAuthMode } from "./codex-auth";
+import {
+  resolveRoleEnvironment,
+  CHATGPT_INCOMPATIBLE_CODEX_MODELS,
+  type CodexAuthMode,
+} from "./default-model";
 import type { DiagnosticCheck, DiagnosticsSnapshot, DiagnosticState } from "./types";
 
 const execFileAsync = promisify(execFile);
@@ -109,6 +115,9 @@ export interface DiagnosticsDeps {
   /** Returns true when at least one configured repo has repoMode "lightweight".
    *  Default `() => false` (no extra git capability warning unless opted in). */
   anyLightweightRepo?: () => boolean;
+  /** Detect the Codex CLI auth mode (chatgpt / apikey / unknown). Default reads
+   *  `~/.codex/auth.json`. Injected in tests to exercise the codex_model_auth check. */
+  readCodexAuthMode?: () => CodexAuthMode;
 }
 
 /** A single probe: an async fn returning ONLY `{ id, state, hintKey }`. */
@@ -248,6 +257,7 @@ export class DiagnosticsService {
   private runRemediation: (cmd: string) => Promise<void>;
   private anyForgeRepo: () => boolean;
   private anyLightweightRepo: () => boolean;
+  private detectCodexAuthMode: () => CodexAuthMode;
   private last: DiagnosticsSnapshot | null = null;
   private lastAt = 0;
 
@@ -292,6 +302,50 @@ export class DiagnosticsService {
     this.runRemediation = deps.runRemediation ?? defaultRunRemediation;
     this.anyForgeRepo = deps.anyForgeRepo ?? (() => true);
     this.anyLightweightRepo = deps.anyLightweightRepo ?? (() => false);
+    this.detectCodexAuthMode = deps.readCodexAuthMode ?? readCodexAuthMode;
+  }
+
+  /**
+   * Warn when a live-configured Codex role/global model would be rejected by the operator's
+   * ChatGPT-account Codex login (the class behind silent recap failures). Returns the warning
+   * check, or null when it does not apply (not chatgpt auth, or no configured model is
+   * blocklisted) — so the check only surfaces as a real advisory, never as `ok` noise. Enumerates
+   * the live per-role cli/model pairs + the global default; each is resolved UNCLAMPED
+   * (authMode "unknown") to see the model that WOULD be spawned without the guard.
+   */
+  private codexModelAuthCheck(): DiagnosticCheck | null {
+    if (this.detectCodexAuthMode() !== "chatgpt") return null;
+    const pairs: Array<[string, string]> = [
+      [config.recapCli, config.recapModel],
+      [config.namerCli, config.namerModel],
+      [config.autopilotCli, config.autopilotModel],
+      [config.criticCli, config.criticModel],
+      [config.docAgentCli, config.docAgentModel],
+      ["inherit", "default"], // the global default (defaultAgentProvider/defaultModel)
+    ];
+    const hit = pairs.some(([cli, model]) => {
+      const env = resolveRoleEnvironment(
+        cli,
+        model,
+        config.defaultAgentProvider,
+        config.defaultModel,
+        config.fableAvailable,
+        "default",
+        "unknown",
+      );
+      return (
+        env.provider === "codex" &&
+        env.model !== null &&
+        CHATGPT_INCOMPATIBLE_CODEX_MODELS.has(env.model)
+      );
+    });
+    return hit
+      ? {
+          id: "codex_model_auth",
+          state: "warning",
+          hintKey: "diagnostics_hint_codex_model_chatgpt_incompatible",
+        }
+      : null;
   }
 
   /** Parse a (major.minor.patch) out of arbitrary `--version` output; null if none. */
@@ -536,6 +590,10 @@ export class DiagnosticsService {
         },
       });
     }
+    // Codex model↔auth advisory: only added when a configured codex model is chatgpt-incompatible,
+    // so it never surfaces as `ok` noise. Synchronous + local, so run resolves the precomputed check.
+    const codexAuth = this.codexModelAuthCheck();
+    if (codexAuth) list.push({ run: async () => codexAuth, onTimeout: codexAuth });
     return list;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,10 +144,12 @@ import {
   normalizeFableAvailable,
   normalizeRoleCli,
   normalizeRoleModelToken,
-  resolveRoleEnvironment,
+  resolveRoleEnvWithAuth,
   spawnModelForAvailability,
+  CHATGPT_INCOMPATIBLE_CODEX_MODELS,
   type RoleEnvironment,
 } from "./default-model";
+import { readCodexAuthMode } from "./codex-auth";
 import { normalizeDefaultEffortSetting } from "./default-effort";
 import { shouldDowngrade } from "./usage-downgrade";
 import { normalizeAgentProvider } from "./agent-provider";
@@ -591,14 +593,28 @@ function usageDowngradeModel(): string | null {
 // in the usage-downgrade so role agents are covered too (they bypass service.create/pushModelFlag).
 // The downgrade target is a Claude model setting, so it only overrides a Claude-resolved role.
 function roleEnv(cli: string, model: string, effort: string): RoleEnvironment {
-  const env = resolveRoleEnvironment(
-    cli,
-    model,
-    config.defaultAgentProvider,
-    config.defaultModel,
-    config.fableAvailable,
-    effort,
+  // resolveRoleEnvWithAuth reads the live Codex auth mode per spawn (auth can change at runtime) and
+  // clamps a ChatGPT-account-incompatible codex model to the account default before it can be spawned.
+  const env = resolveRoleEnvWithAuth(
+    {
+      roleCli: cli,
+      roleModel: model,
+      globalProvider: config.defaultAgentProvider,
+      globalModelSetting: config.defaultModel,
+      fableAvailable: config.fableAvailable,
+      roleEffort: effort,
+    },
+    readCodexAuthMode,
   );
+  // Observability: the clamp is otherwise silent. Warn exactly when it dropped a pinned codex model.
+  if (
+    env.provider === "codex" &&
+    env.model === null &&
+    CHATGPT_INCOMPATIBLE_CODEX_MODELS.has(model)
+  )
+    console.warn(
+      `[role-env] codex model "${model}" unsupported by ChatGPT-account auth — using account default`,
+    );
   const dg = usageDowngradeModel();
   if (dg !== null && env.provider === "claude")
     return { provider: "claude", model: dg, effort: env.effort };

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -217,7 +217,7 @@ export interface RecapServiceDeps {
     | "list"
     | "setRecapPendingDiff"
   >;
-  herdr: Pick<HerdrDriver, "start" | "stop" | "list" | "paneForegroundProcs">;
+  herdr: Pick<HerdrDriver, "start" | "stop" | "list" | "paneForegroundProcs" | "readAsync">;
   onChange: (id: string, recap: Recap | null) => void;
   // optional environment thunk (CLI + model, read per spawn → live settings)
   env?: () => RoleEnvironment;
@@ -755,7 +755,7 @@ export class RecapService {
       }
       // finalize-value carries the parsed verdict; finalize-null (timeout / fail-fast) → `failed`.
       const raw = action === "finalize-value" && read.status === "parsed" ? read.value : null;
-      if (action === "finalize-null") this.logUnproducedVerdict(r, read, elapsed, finished);
+      if (action === "finalize-null") await this.logUnproducedVerdict(r, read, elapsed, finished);
 
       // finalizing flag stays set; always delete in finally so entry doesn't wedge after a throw.
       try {
@@ -769,28 +769,48 @@ export class RecapService {
   /** Observability for a finalize-null recap (timeout / fail-fast): a `failed` recap used to be a
    *  black hole (no log, raw discarded), so an intermittent malformed write was undiagnosable —
    *  surface WHY before finalizing. Extracted from tick() to keep its cognitive complexity in bound. */
-  private logUnproducedVerdict(
+  private async logUnproducedVerdict(
     r: Recap,
     read: VerdictRead<unknown>,
     elapsed: number,
     finished: boolean,
-  ): void {
+  ): Promise<void> {
     const spawn = this.deps.store
       .listReviewerSpawns()
       .find((s) => s.reviewerSessionId === r.spawnSessionId);
+    const paneId = this.resolveTerminal(r.cwd);
     const ctx =
       `spawn=${r.spawnSessionId || "<none>"} cwd=${r.cwd || "<none>"} model=${r.model ?? "<default>"} ` +
       `provider=${spawn?.reviewerProvider ?? "<unknown>"} effort=${spawn?.reviewerEffort ?? "<default>"} ` +
-      `elapsed=${Math.round(elapsed / 1000)}s pane=${this.resolveTerminal(r.cwd) ? "present" : "absent"} ` +
+      `elapsed=${Math.round(elapsed / 1000)}s pane=${paneId ? "present" : "absent"} ` +
       `finished=${finished}`;
     if (read.status === "unparseable") {
       console.warn(
         `[recap] ${r.sessionId}: verdict file present but unparseable even after jsonrepair — failing. ${ctx} snippet: ${recapSnippet(read.raw)}`,
       );
-    } else {
-      console.warn(
-        `[recap] ${r.sessionId}: no verdict file (spawn exited or hard timeout) — agent produced nothing. ${ctx}`,
-      );
+      return;
+    }
+    // No verdict file — capture the spawn's terminal tail (best-effort) so the reason is diagnosable
+    // instead of a black hole: a chatgpt-account-incompatible codex model prints its 400
+    // ("… not supported when using Codex with a ChatGPT account") here before exiting. The pane may
+    // already be reaped (husk gone) → empty tail, unchanged behaviour.
+    const tail = paneId ? await this.readPaneTail(paneId) : "";
+    console.warn(
+      `[recap] ${r.sessionId}: no verdict file (spawn exited or hard timeout) — agent produced nothing. ${ctx}${
+        tail ? ` pane-tail: ${tail}` : ""
+      }`,
+    );
+  }
+
+  /** Best-effort, bounded tail of a spawn's terminal buffer for diagnostics. Takes the LAST ~300
+   *  chars (a CLI error appears at the end, unlike recapSnippet's head slice). Never throws. */
+  private async readPaneTail(paneId: string): Promise<string> {
+    try {
+      const buf = await this.deps.herdr.readAsync(paneId, "recent", 20);
+      const oneLine = buf.replace(/\s+/g, " ").trim();
+      return oneLine.length > 300 ? `…${oneLine.slice(-300)}` : oneLine;
+    } catch {
+      return "";
     }
   }
 

--- a/test/codex-auth.test.ts
+++ b/test/codex-auth.test.ts
@@ -1,0 +1,74 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import { parseCodexAuthMode, readCodexAuthMode } from "../src/codex-auth";
+
+let dirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of dirs) rmSync(dir, { recursive: true, force: true });
+  dirs = [];
+});
+
+function tempDirWithAuth(auth: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), "codex-auth-"));
+  dirs.push(dir);
+  writeFileSync(join(dir, "auth.json"), JSON.stringify(auth));
+  return dir;
+}
+
+describe("parseCodexAuthMode", () => {
+  test("tokens.access_token present + no OPENAI_API_KEY ⇒ chatgpt (even with NO auth_mode field)", () => {
+    // The load-bearing case: a real ChatGPT-account auth.json may omit auth_mode; structural
+    // detection must still resolve chatgpt, else the clamp silently no-ops for its target operator.
+    expect(parseCodexAuthMode({ tokens: { access_token: "abc" }, OPENAI_API_KEY: null })).toBe(
+      "chatgpt",
+    );
+  });
+
+  test("non-empty OPENAI_API_KEY ⇒ apikey (takes precedence over tokens)", () => {
+    expect(parseCodexAuthMode({ OPENAI_API_KEY: "sk-xxx", tokens: { access_token: "abc" } })).toBe(
+      "apikey",
+    );
+  });
+
+  test("explicit auth_mode corroborates when no key and no tokens", () => {
+    expect(parseCodexAuthMode({ auth_mode: "chatgpt" })).toBe("chatgpt");
+    expect(parseCodexAuthMode({ auth_mode: "apikey" })).toBe("apikey");
+  });
+
+  test("empty-string OPENAI_API_KEY is not apikey", () => {
+    expect(parseCodexAuthMode({ OPENAI_API_KEY: "   ", tokens: { access_token: "abc" } })).toBe(
+      "chatgpt",
+    );
+  });
+
+  test("garbage / missing signals ⇒ unknown", () => {
+    expect(parseCodexAuthMode(null)).toBe("unknown");
+    expect(parseCodexAuthMode("nope")).toBe("unknown");
+    expect(parseCodexAuthMode({})).toBe("unknown");
+    expect(parseCodexAuthMode({ tokens: {} })).toBe("unknown");
+    expect(parseCodexAuthMode({ auth_mode: "weird" })).toBe("unknown");
+  });
+});
+
+describe("readCodexAuthMode", () => {
+  test("reads and structurally detects chatgpt from a fixture dir", () => {
+    const dir = tempDirWithAuth({ tokens: { access_token: "abc" }, OPENAI_API_KEY: null });
+    expect(readCodexAuthMode(dir)).toBe("chatgpt");
+  });
+
+  test("missing auth.json ⇒ unknown (fail-open)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "codex-auth-empty-"));
+    dirs.push(dir);
+    expect(readCodexAuthMode(dir)).toBe("unknown");
+  });
+
+  test("unreadable / invalid JSON ⇒ unknown (fail-open)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "codex-auth-bad-"));
+    dirs.push(dir);
+    writeFileSync(join(dir, "auth.json"), "{ not json");
+    expect(readCodexAuthMode(dir)).toBe("unknown");
+  });
+});

--- a/test/default-model.test.ts
+++ b/test/default-model.test.ts
@@ -1,9 +1,15 @@
-import { test, expect, describe } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, test, expect, describe } from "bun:test";
 import {
   normalizeDefaultModelSetting,
   normalizeRepoDefaultModelSetting,
   resolveDefaultModelSetting,
   resolveRoleEnvironment,
+  resolveRoleEnvWithAuth,
+  clampCodexModelForAuth,
+  CHATGPT_INCOMPATIBLE_CODEX_MODELS,
   normalizeRoleCli,
   normalizeRoleModelToken,
   drainSpawnModel,
@@ -12,6 +18,7 @@ import {
   modelCompatibleWithProvider,
   modelForProviderOrDefault,
 } from "../src/default-model";
+import { readCodexAuthMode } from "../src/codex-auth";
 import { MODELS } from "../src/types";
 
 describe("normalizeDefaultModelSetting", () => {
@@ -343,4 +350,105 @@ describe("normalizeFableAvailable", () => {
   test('"nonsense" → null', () => expect(normalizeFableAvailable("nonsense")).toBeNull());
   test("undefined → null", () => expect(normalizeFableAvailable(undefined)).toBeNull());
   test("42 → null", () => expect(normalizeFableAvailable(42)).toBeNull());
+});
+
+describe("clampCodexModelForAuth", () => {
+  const blocked = [...CHATGPT_INCOMPATIBLE_CODEX_MODELS][0]!;
+
+  test("codex + chatgpt + blocklisted model → null (use account default)", () => {
+    expect(clampCodexModelForAuth(blocked, "codex", "chatgpt")).toBeNull();
+  });
+  test("codex + chatgpt + non-blocklisted model → unchanged", () => {
+    expect(clampCodexModelForAuth("gpt-5.5", "codex", "chatgpt")).toBe("gpt-5.5");
+  });
+  test("codex + apikey → unchanged even for a blocklisted model", () => {
+    expect(clampCodexModelForAuth(blocked, "codex", "apikey")).toBe(blocked);
+  });
+  test("codex + unknown → unchanged (fail-open)", () => {
+    expect(clampCodexModelForAuth(blocked, "codex", "unknown")).toBe(blocked);
+  });
+  test("claude provider is never clamped", () => {
+    expect(clampCodexModelForAuth(blocked, "claude", "chatgpt")).toBe(blocked);
+  });
+  test("null model stays null", () => {
+    expect(clampCodexModelForAuth(null, "codex", "chatgpt")).toBeNull();
+  });
+});
+
+describe("resolveRoleEnvironment codexAuthMode clamp", () => {
+  const blocked = [...CHATGPT_INCOMPATIBLE_CODEX_MODELS][0]!;
+
+  test("explicit codex role + blocklisted model under chatgpt → model null", () => {
+    expect(
+      resolveRoleEnvironment("codex", blocked, "claude", "opus", true, "default", "chatgpt"),
+    ).toEqual({ provider: "codex", model: null, effort: null });
+  });
+  test("same config under apikey → model unchanged", () => {
+    expect(
+      resolveRoleEnvironment("codex", blocked, "claude", "opus", true, "default", "apikey"),
+    ).toEqual({ provider: "codex", model: blocked, effort: null });
+  });
+  test("inherit/global branch also clamps a codex global default", () => {
+    expect(
+      resolveRoleEnvironment("inherit", "default", "codex", blocked, true, "default", "chatgpt"),
+    ).toEqual({ provider: "codex", model: null, effort: null });
+  });
+  test("omitted authMode defaults to unknown → no clamp (backward-compatible)", () => {
+    expect(resolveRoleEnvironment("codex", blocked, "claude", "opus", true, "default")).toEqual({
+      provider: "codex",
+      model: blocked,
+      effort: null,
+    });
+  });
+});
+
+describe("resolveRoleEnvWithAuth (real reader→resolver seam)", () => {
+  const blocked = [...CHATGPT_INCOMPATIBLE_CODEX_MODELS][0]!;
+  let dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs) rmSync(d, { recursive: true, force: true });
+    dirs = [];
+  });
+  function chatgptAuthDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "roleenv-auth-"));
+    dirs.push(dir);
+    writeFileSync(
+      join(dir, "auth.json"),
+      JSON.stringify({ tokens: { access_token: "abc" }, OPENAI_API_KEY: null }),
+    );
+    return dir;
+  }
+
+  test("a recap-shaped codex role resolves to model null when the injected reader detects chatgpt", () => {
+    const dir = chatgptAuthDir();
+    expect(
+      resolveRoleEnvWithAuth(
+        {
+          roleCli: "codex",
+          roleModel: blocked,
+          globalProvider: "claude",
+          globalModelSetting: "opus",
+          fableAvailable: true,
+          roleEffort: "low",
+        },
+        () => readCodexAuthMode(dir),
+      ),
+    ).toEqual({ provider: "codex", model: null, effort: "low" });
+  });
+
+  test("with an injected apikey reader the same role keeps its pinned model", () => {
+    expect(
+      resolveRoleEnvWithAuth(
+        {
+          roleCli: "codex",
+          roleModel: blocked,
+          globalProvider: "claude",
+          globalModelSetting: "opus",
+          fableAvailable: true,
+          roleEffort: "low",
+        },
+        () => "apikey",
+      ),
+    ).toEqual({ provider: "codex", model: blocked, effort: "low" });
+  });
 });

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -10,6 +10,7 @@ import {
   DIAGNOSTICS_INTERVAL_MS,
   DIAGNOSTICS_RECHECK_INTERVAL_MS,
   GH_PROBE_ATTEMPTS,
+  config,
 } from "../src/config";
 import type { DiagnosticState } from "../src/types";
 import { REMEDIATIONS } from "../src/remediations";
@@ -63,6 +64,9 @@ function healthyDeps(): DiagnosticsDeps {
           },
         },
       }),
+    // Pin the Codex auth mode so the codex_model_auth advisory is deterministically absent here
+    // (it must not depend on the test host's real ~/.codex/auth.json).
+    readCodexAuthMode: () => "unknown",
   };
 }
 
@@ -1003,5 +1007,58 @@ describe("nextDiagnosticsDelay", () => {
     const ok = nextDiagnosticsDelay("ok", DIAGNOSTICS_INTERVAL_MS, DIAGNOSTICS_RECHECK_INTERVAL_MS);
     expect(err).toBeLessThan(warn);
     expect(warn).toBe(ok);
+  });
+});
+
+describe("codex_model_auth advisory", () => {
+  // Save/restore the live role config the check enumerates (see hold-gate/drain test precedent).
+  function withRecap(
+    cli: typeof config.recapCli,
+    model: typeof config.recapModel,
+    fn: () => Promise<void>,
+  ): Promise<void> {
+    const savedCli = config.recapCli;
+    const savedModel = config.recapModel;
+    config.recapCli = cli;
+    config.recapModel = model;
+    return fn().finally(() => {
+      config.recapCli = savedCli;
+      config.recapModel = savedModel;
+    });
+  }
+
+  it("warns when a blocklisted codex model is configured under chatgpt auth", async () => {
+    await withRecap("codex", "gpt-5.3-codex", async () => {
+      const svc = new DiagnosticsService({
+        ...healthyDeps(),
+        readCodexAuthMode: () => "chatgpt",
+      });
+      const c = byId((await svc.check(0)).checks, "codex_model_auth");
+      expect(c.state).toBe("warning");
+      expect(c.hintKey).toBe("diagnostics_hint_codex_model_chatgpt_incompatible");
+      assertPure(c);
+    });
+  });
+
+  it("does NOT warn under apikey auth (the model is supported there)", async () => {
+    await withRecap("codex", "gpt-5.3-codex", async () => {
+      const svc = new DiagnosticsService({
+        ...healthyDeps(),
+        readCodexAuthMode: () => "apikey",
+      });
+      const checks = (await svc.check(0)).checks;
+      expect(checks.find((c) => c.id === "codex_model_auth")).toBeUndefined();
+    });
+  });
+
+  it("does NOT warn for a compatible codex model under chatgpt auth", async () => {
+    await withRecap("codex", "gpt-5.5", async () => {
+      const svc = new DiagnosticsService({
+        ...healthyDeps(),
+        readCodexAuthMode: () => "chatgpt",
+      });
+      const checks = (await svc.check(0)).checks;
+      expect(checks.find((c) => c.id === "codex_model_auth")).toBeUndefined();
+    });
   });
 });

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -190,6 +190,8 @@ type FakeHerdr = {
   procsOverride: Map<string, string[]>;
   /** Default procs for any pane not in procsOverride (default ['zsh'] = shell-only husk). */
   defaultProcs: string[];
+  /** Terminal-buffer text returned by readAsync (the finalize-null pane-tail capture). */
+  readBuffer: string;
   start: (
     label: string,
     cwd: string,
@@ -199,6 +201,7 @@ type FakeHerdr = {
   stop: (id: string) => Promise<void>;
   list: () => FakePaneEntry[];
   paneForegroundProcs: (paneId: string) => Promise<string[]>;
+  readAsync: (paneId: string, source?: "visible" | "recent", lines?: number) => Promise<string>;
 };
 
 function makeHerdr(livePanes: FakePaneEntry[] = [], defaultProcs: string[] = ["zsh"]): FakeHerdr {
@@ -208,6 +211,7 @@ function makeHerdr(livePanes: FakePaneEntry[] = [], defaultProcs: string[] = ["z
     livePanes,
     procsOverride: new Map(),
     defaultProcs,
+    readBuffer: "",
     start: async (label, cwd, argv, env) => {
       const tid = `tid-${h.started.length + 1}`;
       h.started.push({ label, cwd, argv, env });
@@ -217,6 +221,7 @@ function makeHerdr(livePanes: FakePaneEntry[] = [], defaultProcs: string[] = ["z
     stop: async (id) => void h.stopped.push(id),
     list: () => h.livePanes,
     paneForegroundProcs: async (paneId: string) => h.procsOverride.get(paneId) ?? h.defaultProcs,
+    readAsync: async () => h.readBuffer,
   };
   return h;
 }
@@ -649,6 +654,40 @@ test("tick no verdict logs Codex recap spawn context without prompt text", async
   expect(msg).toContain("effort=high");
   expect(msg).toContain("pane=present");
   expect(msg).not.toContain("do the thing");
+});
+
+test("tick no verdict captures the codex pane tail (400) so the failure is diagnosable", async () => {
+  const rec = makeRecap({
+    state: "generating",
+    cwd: "/tmp/recap-codex-400",
+    spawnSessionId: "sp-400",
+    model: "gpt-5.3-codex",
+    spawnedAt: 1_000,
+  });
+  const store = makeStore([], [rec]);
+  const herdr = makeHerdr([{ cwd: "/tmp/recap-codex-400", terminalId: "t-400" }]);
+  herdr.readBuffer =
+    'codex\nERROR: {"status":400,"message":"The \'gpt-5.3-codex\' model is not supported when using Codex with a ChatGPT account."}\n';
+  const warnings: string[] = [];
+  const prevWarn = console.warn;
+  console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
+  try {
+    const svc = buildSvc({
+      store,
+      herdr,
+      nowFn: () => 400_000,
+      timeoutMs: 300_000,
+      verdictRead: { status: "absent" },
+    });
+    await svc.tick();
+  } finally {
+    console.warn = prevWarn;
+  }
+
+  const msg = warnings.join("\n");
+  expect(msg).toContain("pane-tail:");
+  expect(msg).toContain("not supported when using Codex with a ChatGPT account");
+  expect(store.getRecap("s1")?.state).toBe("failed");
 });
 
 test("tick unparseable: garbage verdict → state 'failed'", async () => {
@@ -1119,6 +1158,7 @@ test("generate/regenerate: herdr.start throws → returns 'error', no row, tmpdi
     livePanes: [],
     procsOverride: new Map(),
     defaultProcs: ["zsh"],
+    readBuffer: "",
     start: async () => {
       throw new Error("herdr start failed");
     },
@@ -1126,6 +1166,7 @@ test("generate/regenerate: herdr.start throws → returns 'error', no row, tmpdi
     list: () => herdr.livePanes,
     paneForegroundProcs: async (paneId: string) =>
       herdr.procsOverride.get(paneId) ?? herdr.defaultProcs,
+    readAsync: async () => herdr.readBuffer,
   };
 
   const svc = buildSvc({

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2171,6 +2171,7 @@
   "diagnostics_hint_codex_ok": "Codex CLI ist verfügbar.",
   "diagnostics_hint_codex_missing": "Codex CLI nicht im PATH gefunden. Installiere Codex oder Claude Code, um Agent-Sessions zu starten.",
   "diagnostics_hint_codex_optional": "Codex CLI ist optional, weil Claude Code verfügbar ist. Installiere es, wenn beide Agent-Runtimes funktionieren sollen.",
+  "diagnostics_hint_codex_model_chatgpt_incompatible": "Ein konfiguriertes Codex-Modell wird von deinem ChatGPT-Account-Login für Codex nicht unterstützt und durch den Account-Standard ersetzt. Wähle ein unterstütztes Modell oder melde dich bei Codex mit einem API-Key an.",
   "taskid_button_title": "Aktionen für {desig} — ID kopieren oder Promptempfehlung holen",
   "taskid_menu_label": "Task-ID-Aktionen",
   "taskid_copy": "ID kopieren",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2171,6 +2171,7 @@
   "diagnostics_hint_codex_ok": "Codex CLI is available.",
   "diagnostics_hint_codex_missing": "Codex CLI not found in PATH. Install Codex or Claude Code to run agent sessions.",
   "diagnostics_hint_codex_optional": "Codex CLI is optional because Claude Code is available. Install it if you want both agent runtimes.",
+  "diagnostics_hint_codex_model_chatgpt_incompatible": "A configured Codex model isn't supported by your ChatGPT-account Codex login and is being replaced with the account default. Pick a supported model, or sign in to Codex with an API key.",
   "taskid_button_title": "Actions for {desig} — copy ID or get a prompt recommendation",
   "taskid_menu_label": "Task ID actions",
   "taskid_copy": "Copy ID",


### PR DESCRIPTION
## Why "Recap generation failed."

The recap role was pinned to Codex **`gpt-5.3-codex`**, which the operator's **ChatGPT-account**
Codex login rejects with `HTTP 400` ("… not supported when using Codex with a ChatGPT account.").
The spawn exits after ~74 s (well under the 300 s timeout) writing no `.shepherd-recap.json`, so
`RecapService.finalize()` fails closed → the UI's "Recap generation failed."

Root-caused from the live DB + logs: **`gpt-5.3-codex` → 133 `failed` / 0 `ready`** vs **`sonnet`
→ 39 `ready`**; reproduced directly with `codex exec -m gpt-5.3-codex …`. The gap: the shared role
resolver (`resolveRoleEnvironment`) only clamps model↔**provider**, never the **auth mode**, and no
code read `~/.codex/auth.json`.

## The fix (role-spawn path)

Covers every background role resolved through the shared resolver — **recap, namer, autopilot,
critic, doc-agent** — in three complementary moves:

1. **Preventive** — `src/codex-auth.ts` detects the Codex auth mode **structurally** (a present
   `tokens.access_token` + no `OPENAI_API_KEY` ⇒ `chatgpt`, even when `auth_mode` is absent;
   fail-open on any error). `clampCodexModelForAuth` (`src/default-model.ts`) drops a
   blocklisted-under-chatgpt Codex model to the account default (`model → null`, i.e. no `--model`).
   `resolveRoleEnvironment` gains a `codexAuthMode` param (clamps both the inherit/global and
   explicit-role branches); `resolveRoleEnvWithAuth` is the testable reader→resolver seam that
   `roleEnv` (index.ts) delegates to, reading the live auth mode per spawn.
2. **Diagnostic** — on a finalize-null recap, `src/recap.ts` now captures the codex pane tail via
   `herdr.readAsync` and logs it, so a **not-yet-blocklisted** incompatible model is diagnosable
   instead of a silent black hole (the very gap that made this bug hard to find).
3. **Visible** — a `codex_model_auth` diagnostics **warning** (`src/diagnostics.ts`) across the live
   role/global model config under chatgpt auth, surfacing the override to the operator.

## Scope & honesty

- Clamping to the account default **cannot guarantee** a `ready` recap end-to-end — Shepherd does
  not read `~/.codex/config.toml`, so if that default is itself incompatible the recap still fails
  (now diagnosably, via move 2). The blocklist is a pragmatic first cut for confirmed-bad models;
  fail-open never wrongly blocks an unknown one.
- **Main-task / drain Codex path** is deliberately **out of scope** (its failures are loud — the
  operator sees the 400 live) and tracked in #1680.

## Tests & verification

- New: `test/codex-auth.test.ts` (incl. the no-`auth_mode` chatgpt case); real reader→resolver seam
  test + clamp tests in `test/default-model.test.ts`; pane-tail capture in `test/recap.test.ts`;
  `codex_model_auth` warn/omit in `test/diagnostics.test.ts`.
- `tsc --noEmit` clean · `bun run lint` clean · `check:i18n` parity (en+de) · branch-hygiene /
  feature-catalog / glossary / announcement-version gates green.
- Full root suite: 6817 pass / 1 fail — the single failure (`pty-bridge`) reproduces on clean
  `origin/main` and is environment-specific (unrelated to this change).

Closes the recap failure reported for TASK-641.