### PR TITLE
feat(newtask): widen the New Task pane (520→760) + show two seed-from labels

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2290,6 +2290,8 @@
   "feat_upnext_body": "Eine neue oberste Ansicht reiht noch nicht begonnene GitHub-Issues über all deine Repos in eine flache Warteschlange — Priorität zuerst. Sieh das Lohnenswerteste zum Starten und starte eine Session dafür — oder mehrere — mit einem Klick.",
   "feat_up_next_sort_title": "Als Nächstes frei sortieren",
   "feat_up_next_sort_body": "Als Nächstes kann jetzt zwischen Empfehlung, neueste, älteste und Titel A-Z/Z-A wechseln. Priorisierte Arbeit bleibt zuerst gruppiert, und deine Sortierung wird gemerkt.",
+  "feat_newtask_wider_title": "Geräumigerer Neue-Aufgabe-Editor",
+  "feat_newtask_wider_body": "Das Fenster „Neue Aufgabe“ ist jetzt breiter und gibt dem Prompt und der Liste „Übernehmen aus“ mehr Platz. Issue-Zeilen zeigen mehr vom Titel und bis zu zwei Labels auf einen Blick statt einem.",
   "feat_epic_stall_legibility_title": "Sehen, worauf ein Epic wartet",
   "feat_epic_stall_legibility_body": "Das Epic-Panel warnt jetzt, wenn ein Epic keine Reihenfolge hat (sodass alle Teilaufgaben parallel laufen), und nennt bei einem angehaltenen Zug den Grund — welche Teilaufgabe oder welches Gate neue Starts blockiert, statt nur eingefroren zu wirken.",
   "feat_herd_resizable_title": "Herd-Seitenleiste anpassen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2290,6 +2290,8 @@
   "feat_upnext_body": "A new top-level lens ranks un-started GitHub issues across all your repos into one flat queue, priority-first. See the single most worthwhile thing to start next and spawn a session on it — or several — in one click.",
   "feat_up_next_sort_title": "Sort Up Next your way",
   "feat_up_next_sort_body": "Up Next now lets you switch between recommended ranking, newest, oldest, and title A-Z/Z-A order. Priority work stays grouped first, and your sort choice is remembered.",
+  "feat_newtask_wider_title": "Roomier New Task composer",
+  "feat_newtask_wider_body": "The New Task pane is now wider, giving the prompt and the Seed From issues list more room. Issue rows show more of the title, and up to two labels at a glance instead of one.",
   "feat_epic_stall_legibility_title": "See why an epic is waiting",
   "feat_epic_stall_legibility_body": "The epic panel now warns when an epic has no dependency order (so every child drains in parallel) and, when a train holds, spells out why — which child or gate is blocking new starts instead of just looking frozen.",
   "feat_herd_resizable_title": "Resize the Herd sidebar",

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -1125,7 +1125,7 @@
   .card {
     position: relative;
     margin: auto;
-    width: min(520px, 92vw);
+    width: min(760px, 92vw);
     border: 1px solid var(--color-line-bright);
     background: var(--color-panel);
     padding: 16px;

--- a/ui/src/lib/components/PromptSources.browser.test.ts
+++ b/ui/src/lib/components/PromptSources.browser.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
 import "../../app.css";
 import type { Issue, SlashCommand } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
@@ -187,5 +188,71 @@ describe("PromptSources filter bar (popover + sticky coverage)", () => {
     expect(document.querySelector(".ps-body .ps-filter-bar .cmd-filter")).not.toBeNull();
 
     assertStickyCovers();
+  });
+});
+
+describe("PromptSources label chips (responsive 1↔2 cap)", () => {
+  // Issue with 3 labels → wide shows 2 chips + "+1", narrow shows 1 chip + "+2".
+  const threeLabelIssue = () => ({
+    ...issue(1),
+    title: "Three label issue",
+    labels: ["enhancement", "reliability", "perf"],
+  });
+
+  const shown = (el: Element | null) =>
+    !!el && getComputedStyle(el as HTMLElement).display !== "none";
+  // Real label chips (excludes the "+N" more-counters).
+  const visibleChips = () =>
+    [...document.querySelectorAll(".ps-body .row .chip:not(.chip-more)")].filter(shown);
+  const moreWide = () => document.querySelector<HTMLElement>(".ps-body .row .more-wide");
+  const moreNarrow = () => document.querySelector<HTMLElement>(".ps-body .row .more-narrow");
+
+  afterEach(async () => {
+    // Restore a wide viewport so a leaked narrow width can't perturb the layout
+    // assertions in the sticky-cover suite (which measures element rects).
+    await page.viewport(1024, 768);
+  });
+
+  it("wide pane (≥520px): 2 chips + '+1', narrow counter hidden", async () => {
+    await page.viewport(900, 800);
+    mockListIssues.mockResolvedValue({
+      slug: "owner/repo",
+      webUrl: null,
+      issues: [threeLabelIssue()],
+      viewer: null,
+    });
+
+    render(PromptSources, { repoPath: "/repo", onpick: noop, onpickissue: noop });
+    await expect.poll(() => document.querySelectorAll(".ps-body .row").length).toBeGreaterThan(0);
+
+    // Two visible label chips (default/wide regime).
+    await expect.poll(() => visibleChips().length).toBe(2);
+    // Wide "+N" counts the labels beyond the 2 shown (len - 2 = 1); narrow one hidden.
+    expect(shown(moreWide())).toBe(true);
+    expect(moreWide()!.textContent).toContain(m.promptsources_more_labels({ count: 1 }));
+    expect(shown(moreNarrow())).toBe(false);
+  });
+
+  it("narrow pane (<520px): 1 chip + '+2', 2nd chip + wide counter hidden", async () => {
+    await page.viewport(400, 800);
+    mockListIssues.mockResolvedValue({
+      slug: "owner/repo",
+      webUrl: null,
+      issues: [threeLabelIssue()],
+      viewer: null,
+    });
+
+    render(PromptSources, { repoPath: "/repo", onpick: noop, onpickissue: noop });
+    await expect.poll(() => document.querySelectorAll(".ps-body .row").length).toBeGreaterThan(0);
+
+    // The media-query fallback: only 1 chip visible; the 2nd chip is in the DOM but hidden.
+    await expect.poll(() => visibleChips().length).toBe(1);
+    const chip2 = document.querySelector(".ps-body .row .chip-2");
+    expect(chip2).not.toBeNull();
+    expect(shown(chip2)).toBe(false);
+    // Narrow "+N" counts labels beyond the 1 shown (len - 1 = 2); wide one hidden.
+    expect(shown(moreWide())).toBe(false);
+    expect(shown(moreNarrow())).toBe(true);
+    expect(moreNarrow()!.textContent).toContain(m.promptsources_more_labels({ count: 2 }));
   });
 });

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -618,9 +618,10 @@
     white-space: nowrap;
   }
 
-  /* Single label chip + a "+N" count (labelChips caps inline chips at 1). The group
-     is bounded so the title keeps the row instead of being crushed to a character:
-     it may shrink (min-width:0), the label chip ellipsates, and the count never clips.
+  /* Up to 2 label chips + a "+N" count (labelChips caps inline chips at 2 in the
+     wide pane, 1 below 520px — see the responsive rule below). The group is bounded
+     so the title keeps the row instead of being crushed to a character: it may
+     shrink (min-width:0), the label chips ellipsate, and the count never clips.
      Combined with .row-text's min-width floor, the title can't collapse to nothing. */
   .chips {
     display: flex;

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -389,18 +389,29 @@
 {/snippet}
 
 {#snippet labelChips(ordered: string[], colors: Record<string, string> | undefined)}
-  {#each ordered.slice(0, 1) as lbl (lbl)}
+  {#each ordered.slice(0, 2) as lbl, idx (lbl)}
     {@const style = chipStyle(lbl, colors)}
     <span
       class="chip"
+      class:chip-2={idx === 1}
       class:active={lbl === ACTIVE_LABEL}
       class:hued={style !== null}
       {style}
       title={lbl === ACTIVE_LABEL ? m.issuespanel_active_label_title() : undefined}>{lbl}</span
     >
   {/each}
+  <!-- Two "+N" counters, one per regime (toggled by the pane-width media query in
+       <style>): the wide regime shows 2 chips so it hides ordered[2..]; the narrow
+       regime shows 1 chip so it hides ordered[1..]. Each title lists ONLY the labels
+       it actually hides — the wide counter must start at slice(2), or it would
+       over-list ordered[1], which is itself a visible chip when wide. -->
+  {#if ordered.length > 2}
+    <span class="chip chip-more more-wide" title={ordered.slice(2).join(", ")}>
+      {m.promptsources_more_labels({ count: ordered.length - 2 })}
+    </span>
+  {/if}
   {#if ordered.length > 1}
-    <span class="chip chip-more" title={ordered.slice(1).join(", ")}>
+    <span class="chip chip-more more-narrow" title={ordered.slice(1).join(", ")}>
       {m.promptsources_more_labels({ count: ordered.length - 1 })}
     </span>
   {/if}
@@ -667,5 +678,26 @@
        never be the thing that gets clipped when the row is tight. */
     flex-shrink: 0;
     max-width: none;
+  }
+
+  /* Responsive label cap: show 2 chips by default (the pane is now 760px wide),
+     falling back to 1 chip + a "+N" count when the pane is narrower than 520px.
+     The pane width is min(760px, 92vw) on desktop and 100vw on the mobile
+     full-bleed sheet, so "pane < 520" is exactly "viewport < 520" — a viewport
+     media query is equivalent to a container query here WITHOUT establishing
+     inline-size containment on the NewTask card (which would make it a containing
+     block for any position:fixed/absolute descendant). If the card-width formula
+     or the 768px mobile breakpoint changes, revisit this 519.98px threshold. */
+  .more-narrow {
+    display: none;
+  }
+  @media (max-width: 519.98px) {
+    .chip-2,
+    .more-wide {
+      display: none;
+    }
+    .more-narrow {
+      display: inline-block;
+    }
   }
 </style>

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-newtask-wider.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-newtask-wider.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "newtask-wider-pane",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_newtask_wider_title",
+  bodyKey: "feat_newtask_wider_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-newtask-wider.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-newtask-wider.ts
@@ -1,7 +1,7 @@
 import type { FeatureAnnouncement } from "../../feature-announcements";
 
 const entry = {
-  id: "newtask-wider-pane",
+  id: "newtask-wider",
   sinceVersion: "1.44.0",
   titleKey: "feat_newtask_wider_title",
   bodyKey: "feat_newtask_wider_body",


### PR DESCRIPTION
## What

The New Task composer was a cramped **520px** modal. Now that the Seed-From-Issues
panel carries issue #, title, `by {author}`, and label chips, rows truncated hard.

Two surgical, independently-committed changes:

1. **Widen the pane 520 → 760px** (`NewTask.svelte`, `.card` width `min(760px, 92vw)`).
   Widens the whole card — prompt, repo picker, run settings, and the seed list all
   get room. Mobile full-bleed sheet unchanged.
2. **Show two seed-from labels** (`PromptSources.svelte`): raise the visible label-chip
   cap from 1 → 2, falling back to **1 chip + "+N"** when the pane is narrower than
   **520px**.

## How the responsive cap works (no container-type)

The pane width is `min(760px, 92vw)` on desktop and `100vw` on the mobile full-bleed
sheet, so **"pane < 520" is exactly "viewport < 520"**. That lets a plain
`@media (max-width: 519.98px)` stand in for a container query **without** establishing
`container-type: inline-size` on the card (which would make it a containing block for
any `position: fixed/absolute` descendant — a latent footgun). An inline comment
records the coupling: revisit the threshold if the card-width formula or the 768px
mobile breakpoint changes.

Each "+N" counter lists only the labels it actually hides — wide uses `slice(2)`
(it shows 2 chips), narrow keeps `slice(1)` — so the tooltip never over-lists a
label that's already a visible chip.

| Labels | Pane ≥ 520 | Pane < 520 |
|---|---|---|
| 1 | 1 chip | 1 chip |
| 2 | 2 chips | 1 chip + "+1" |
| 3+ | 2 chips + "+(n-2)" | 1 chip + "+(n-1)" |

## Verification

- **New browser test** (`PromptSources.browser.test.ts`) covers **both** regimes via
  `page.viewport`: wide → 2 chips + "+1" (`.more-narrow` hidden); narrow @400px →
  1 chip + "+2" (`.chip-2` / `.more-wide` hidden). Asserted via computed `display`.
- `cd ui && bun run check` (svelte-check, 0 errors) ✓, `bun run check:i18n` (parity) ✓
- `test:browser` NewTask + PromptSources: 77 pass ✓ · `test:node` feature: 578 pass ✓
- Branch-hygiene / feature-catalog / announcement-version gates ✓
- Scope: **PromptSources only** — IssuesPanel / Backlog + mobile full-bleed untouched.

Reviewer note: worth eyeballing the wider in-card rows in the live preview —
`RepoSelect` dropdown, `NewTaskRunSettings` (ProviderCapacityGauge), attach row —
to confirm nothing reads sparse at 760px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)