### PR TITLE
fix(usage-probe): pre-seed claude folder-trust to stop /usage wedge (#1075)

### DIFF
--- a/src/claude-trust.ts
+++ b/src/claude-trust.ts
@@ -1,0 +1,78 @@
+/**
+ * Read/seed Claude Code's per-folder trust flag (`hasTrustDialogAccepted`) in the
+ * `.claude.json` config file, so an ephemeral spawn (the /usage probe) doesn't wedge
+ * on the "Do you trust the files in this folder?" dialog. `--dangerously-skip-permissions`
+ * does NOT suppress that dialog, and no flag/env skips it — pre-seeding the flag is the
+ * only unattended path (#1075).
+ *
+ * Pure + injectable: every function takes explicit paths so the caller resolves the
+ * config-dir target once and tests never touch a real `$HOME`.
+ */
+
+import { readFile, writeFile, rename } from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * The `.claude.json` file Claude Code actually reads, mirroring the sandbox.ts:404 rule:
+ *  - DEFAULT config dir (`${home}/.claude`) → `$HOME/.claude.json` (a SIBLING of `~/.claude`).
+ *  - CUSTOM `CLAUDE_CONFIG_DIR` (anything else) → `${claudeDir}/.claude.json` (INSIDE it).
+ *
+ * Hardcoding `$HOME/.claude.json` would target the wrong file on a custom-config-dir
+ * install: the seed would miss (dialog still fires) and the read would always report
+ * untrusted (spurious rewrite every run). Pass `config.claudeDir` here.
+ */
+export function claudeConfigPath(home: string, claudeDir: string): string {
+  return claudeDir === `${home}/.claude`
+    ? join(home, ".claude.json")
+    : join(claudeDir, ".claude.json");
+}
+
+/**
+ * True iff `configPath`'s JSON records `projects[dir].hasTrustDialogAccepted === true`.
+ * Any failure (missing file, malformed JSON, unreadable) → `false` — treat "can't
+ * confirm trusted" as untrusted so the caller seeds it.
+ */
+export async function readRepoRootTrusted(configPath: string, dir: string): Promise<boolean> {
+  try {
+    const j = JSON.parse(await readFile(configPath, "utf8"));
+    return j?.projects?.[dir]?.hasTrustDialogAccepted === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Seed `projects[dir].hasTrustDialogAccepted = true` in `configPath`, PRESERVING every
+ * other field. Writes unconditionally — the caller gates on {@link readRepoRootTrusted}
+ * so this only runs when actually untrusted (one write per dir, ever).
+ *
+ * Whole-file read-modify-write via a temp file + atomic rename: the file is never left
+ * torn, but Claude writes this file frequently (onboarding/project state), so a stale
+ * read + our rename can CLOBBER concurrent Claude state written between them
+ * (last-writer-wins). Accepted given the read-gate's rarity and the sub-ms window.
+ *
+ * Emits COMPACT JSON (no pretty-print) to match Claude's on-disk format and avoid
+ * reflowing a possibly-large file.
+ */
+export async function trustRepoRoot(configPath: string, dir: string): Promise<void> {
+  let j: Record<string, unknown> = {};
+  try {
+    const parsed = JSON.parse(await readFile(configPath, "utf8"));
+    if (parsed && typeof parsed === "object") j = parsed as Record<string, unknown>;
+  } catch {
+    // Missing or malformed → start from an empty config; Claude tolerates a minimal file.
+    j = {};
+  }
+  const projects = (j.projects && typeof j.projects === "object" ? j.projects : {}) as Record<
+    string,
+    Record<string, unknown>
+  >;
+  const entry = projects[dir] && typeof projects[dir] === "object" ? projects[dir] : {};
+  entry.hasTrustDialogAccepted = true;
+  projects[dir] = entry;
+  j.projects = projects;
+
+  const tmp = `${configPath}.tmp.${process.pid}`;
+  await writeFile(tmp, JSON.stringify(j), "utf8");
+  await rename(tmp, configPath);
+}

--- a/src/usage-probe.ts
+++ b/src/usage-probe.ts
@@ -3,6 +3,7 @@ import { parseUsageFrame, type UsageProbe } from "./usage-limits";
 import { config } from "./config";
 import { compileCacheDir } from "./tmp-sweep";
 import { isApiKeyMode } from "./spawn-auth";
+import { claudeConfigPath, readRepoRootTrusted, trustRepoRoot } from "./claude-trust";
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 const decoder = new TextDecoder();
@@ -61,11 +62,24 @@ export async function awaitUsageFrame(
  * `/usage` makes no model call (zero token cost).
  */
 export class HerdrUsageProbe implements UsageProbe {
+  private readTrusted: () => Promise<boolean>;
+  private trust: () => Promise<void>;
+
   constructor(
     private herdr: Pick<HerdrDriver, "start" | "stop" | "list">,
     private cwd: string = config.repoRoot,
     private helperPath = new URL("./pty-attach.mjs", import.meta.url).pathname,
-  ) {}
+    // Trust pre-seed, injectable for tests. Defaults resolve the SAME `.claude.json`
+    // Claude reads (config-dir-aware, see claude-trust.ts) and target this probe's cwd.
+    deps: {
+      readTrusted?: () => Promise<boolean>;
+      trust?: () => Promise<void>;
+    } = {},
+  ) {
+    const configPath = claudeConfigPath(process.env.HOME ?? "", config.claudeDir);
+    this.readTrusted = deps.readTrusted ?? (() => readRepoRootTrusted(configPath, this.cwd));
+    this.trust = deps.trust ?? (() => trustRepoRoot(configPath, this.cwd));
+  }
 
   /**
    * Close every lingering probe agent (and its herdr tab/pane). Probes run under the reserved
@@ -93,6 +107,19 @@ export class HerdrUsageProbe implements UsageProbe {
     // Reap leftovers from any prior run that didn't clean up after itself, so probe tabs can't
     // accumulate in herdr over time.
     await this.sweep();
+
+    // Pre-seed folder trust so claude boots straight to the REPL. An untrusted cwd makes claude
+    // open the "Do you trust the files in this folder?" dialog (NOT suppressed by
+    // --dangerously-skip-permissions), which eats our /usage keystrokes → null scrape (#1075).
+    // Read-gated so we write at most once per cwd. Best-effort: a trust read/write failure
+    // (EACCES/ENOSPC, malformed config, race) must NEVER reject scrape() — calibrate()
+    // (usage-limits.ts) awaits it unguarded, so a rejection would surface as a refresh-route 500.
+    // On failure we fall through to the spawn; an untrusted folder then just yields the usual null.
+    try {
+      if (!(await this.readTrusted())) await this.trust();
+    } catch (err) {
+      console.warn("[usage-probe] trust pre-seed failed; continuing", err);
+    }
 
     let terminalId: string;
     try {

--- a/test/claude-trust.test.ts
+++ b/test/claude-trust.test.ts
@@ -1,0 +1,101 @@
+import { test, expect } from "bun:test";
+import { mkdtemp, readFile, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { claudeConfigPath, readRepoRootTrusted, trustRepoRoot } from "../src/claude-trust";
+
+async function withTmp<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "claude-trust-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+// ── path selection: config-dir-aware target (#1075 blocking) ─────────────────
+// Mirrors sandbox.ts:404 — the seed/read MUST hit the same file Claude uses, else a
+// custom-config-dir install seeds the wrong file (wedge persists) and reads the wrong
+// file (read-gate never trips → spurious rewrite every run).
+test("claudeConfigPath targets $HOME/.claude.json for the default config dir", () => {
+  const home = "/home/alice";
+  expect(claudeConfigPath(home, `${home}/.claude`)).toBe("/home/alice/.claude.json");
+});
+
+test("claudeConfigPath targets ${CLAUDE_CONFIG_DIR}/.claude.json for a custom config dir", () => {
+  const home = "/home/alice";
+  expect(claudeConfigPath(home, "/custom/cfg")).toBe("/custom/cfg/.claude.json");
+});
+
+// ── round-trip ───────────────────────────────────────────────────────────────
+test("untrusted → trust → trusted", async () => {
+  await withTmp(async (dir) => {
+    const cfg = join(dir, ".claude.json");
+    await writeFile(
+      cfg,
+      JSON.stringify({ projects: { "/repo": { hasTrustDialogAccepted: false } } }),
+    );
+
+    expect(await readRepoRootTrusted(cfg, "/repo")).toBe(false);
+    await trustRepoRoot(cfg, "/repo");
+    expect(await readRepoRootTrusted(cfg, "/repo")).toBe(true);
+  });
+});
+
+test("trust preserves sibling project fields and other top-level keys", async () => {
+  await withTmp(async (dir) => {
+    const cfg = join(dir, ".claude.json");
+    await writeFile(
+      cfg,
+      JSON.stringify({
+        oauthAccount: { email: "a@b.c" },
+        projects: {
+          "/repo": { history: [1, 2, 3], hasTrustDialogAccepted: false },
+          "/other": { hasTrustDialogAccepted: true },
+        },
+      }),
+    );
+
+    await trustRepoRoot(cfg, "/repo");
+    const j = JSON.parse(await readFile(cfg, "utf8"));
+
+    expect(j.projects["/repo"].hasTrustDialogAccepted).toBe(true);
+    expect(j.projects["/repo"].history).toEqual([1, 2, 3]); // sibling field intact
+    expect(j.projects["/other"].hasTrustDialogAccepted).toBe(true); // other project intact
+    expect(j.oauthAccount).toEqual({ email: "a@b.c" }); // other top-level key intact
+  });
+});
+
+test("readRepoRootTrusted → false for a missing file; trust creates it", async () => {
+  await withTmp(async (dir) => {
+    const cfg = join(dir, ".claude.json"); // does not exist yet
+    expect(await readRepoRootTrusted(cfg, "/repo")).toBe(false);
+
+    await trustRepoRoot(cfg, "/repo");
+    const j = JSON.parse(await readFile(cfg, "utf8"));
+    expect(j.projects["/repo"].hasTrustDialogAccepted).toBe(true);
+  });
+});
+
+test("malformed JSON → readRepoRootTrusted false; trust rewrites a clean file", async () => {
+  await withTmp(async (dir) => {
+    const cfg = join(dir, ".claude.json");
+    await writeFile(cfg, "{ not valid json ");
+
+    expect(await readRepoRootTrusted(cfg, "/repo")).toBe(false);
+    await trustRepoRoot(cfg, "/repo");
+    expect(await readRepoRootTrusted(cfg, "/repo")).toBe(true);
+  });
+});
+
+test("trust writes compact JSON (no pretty-print reflow)", async () => {
+  await withTmp(async (dir) => {
+    const cfg = join(dir, ".claude.json");
+    await writeFile(cfg, JSON.stringify({ projects: {} }));
+
+    await trustRepoRoot(cfg, "/repo");
+    const raw = await readFile(cfg, "utf8");
+    expect(raw).not.toContain("\n"); // compact — single line
+    expect(JSON.parse(raw).projects["/repo"].hasTrustDialogAccepted).toBe(true);
+  });
+});

--- a/test/usage-probe.test.ts
+++ b/test/usage-probe.test.ts
@@ -65,7 +65,10 @@ test("scrape reaps leftover probe tabs and never touches real sessions", async (
     },
   };
 
-  const res = await new HerdrUsageProbe(herdr, "/repo").scrape();
+  // Inject trust deps so the pre-seed never touches the developer's real ~/.claude.json.
+  const res = await new HerdrUsageProbe(herdr, "/repo", undefined, {
+    readTrusted: async () => true,
+  }).scrape();
 
   expect(res).toBeNull();
   // both leftover probes reaped…
@@ -74,6 +77,87 @@ test("scrape reaps leftover probe tabs and never touches real sessions", async (
   // …real sessions are left alone — the plain one and the "usage-probe"-slugged user session.
   expect(stopped).not.toContain("keep");
   expect(stopped).not.toContain("user");
+});
+
+// ── trust pre-seed (#1075) ───────────────────────────────────────────────────
+// An untrusted cwd makes claude boot into the folder-trust dialog, eating the probe's
+// /usage keystrokes → null scrape. scrape() now pre-seeds trust (read-gated) before
+// spawning. herdr.start is made to throw so each case returns null right after the
+// pre-seed, letting us assert whether trust() ran — without a real PTY.
+
+function throwingHerdr() {
+  return {
+    list: () => [] as HerdrAgent[],
+    start: async () => {
+      throw new Error("start stubbed — return null after pre-seed");
+    },
+    stop: async () => {},
+  };
+}
+
+test("scrape seeds trust once when the cwd is untrusted", async () => {
+  let trustCalls = 0;
+  const res = await new HerdrUsageProbe(throwingHerdr(), "/repo", undefined, {
+    readTrusted: async () => false,
+    trust: async () => {
+      trustCalls++;
+    },
+  }).scrape();
+
+  expect(res).toBeNull();
+  expect(trustCalls).toBe(1); // pre-seed ran before start
+});
+
+test("scrape does not write when the cwd is already trusted", async () => {
+  let trustCalls = 0;
+  await new HerdrUsageProbe(throwingHerdr(), "/repo", undefined, {
+    readTrusted: async () => true,
+    trust: async () => {
+      trustCalls++;
+    },
+  }).scrape();
+
+  expect(trustCalls).toBe(0); // read-gated: no write when already trusted
+});
+
+test("scrape never touches trust in api-key mode", async () => {
+  const prior = config.authMode;
+  try {
+    config.authMode = "api-key";
+    let touched = false;
+    const res = await new HerdrUsageProbe(throwingHerdr(), "/repo", undefined, {
+      readTrusted: async () => {
+        touched = true;
+        return false;
+      },
+      trust: async () => {
+        touched = true;
+      },
+    }).scrape();
+    expect(res).toBeNull();
+    expect(touched).toBe(false); // api-key short-circuit fires before the pre-seed
+  } finally {
+    config.authMode = prior;
+  }
+});
+
+test("scrape returns null (never throws) when the trust read throws", async () => {
+  const res = await new HerdrUsageProbe(throwingHerdr(), "/repo", undefined, {
+    readTrusted: async () => {
+      throw new Error("EACCES");
+    },
+  }).scrape();
+  expect(res).toBeNull(); // best-effort: a trust failure must not reject scrape()
+});
+
+test("scrape returns null (never throws) when the trust write throws", async () => {
+  const res = await new HerdrUsageProbe(throwingHerdr(), "/repo", undefined, {
+    readTrusted: async () => false,
+    trust: async () => {
+      throw new Error("ENOSPC");
+    },
+  }).scrape();
+  expect(res).toBeNull();
 });
 
 // ── awaitUsageFrame: the credits-grace gate ──────────────────────────────────


### PR DESCRIPTION
Fixes #1075.

## Problem
The `/usage` probe spawns `claude --dangerously-skip-permissions` in `config.repoRoot`. When that folder is **not yet trusted** (`~/.claude.json` → `projects[<dir>].hasTrustDialogAccepted !== true`), claude boots into the **"Do you trust the files in this folder?"** dialog — which `--dangerously-skip-permissions` does **not** suppress. The probe's `/usage`+Enter keystrokes land in that dialog instead of the REPL, so `scrape()` returns `null` and every usage meter (week + 5h + credits) stays stale until the folder happens to get trusted by some other claude invocation.

## Fix
Before spawning claude, `scrape()` reads whether its cwd is trusted and, if not, seeds `hasTrustDialogAccepted: true` **once** — so claude boots straight to the REPL and `/usage` lands. Properties:

- **Deterministic** — no dialog to detect/dismiss, no boot-timer race, no added latency on the trusted path.
- **Read-gated / idempotent** — `trust()` runs only when `readTrusted()` is false → one write per cwd, ever (the write-race window against claude's own writes shrinks to a single write).
- **Subscription-only for free** — sits after the existing `isApiKeyMode()` short-circuit; never runs in api-key mode (where an untrusted cwd wedges nothing).
- **Best-effort** — a trust read/write failure (EACCES/ENOSPC, malformed config, race) is **logged and swallowed**, falling through to the spawn. `calibrate()` (`usage-limits.ts`) awaits `scrape()` **unguarded**, so a rejection would surface as a refresh-route 500; the guard preserves the null-on-every-failure contract.
- **Config-dir-aware** (`src/claude-trust.ts`, mirroring `sandbox.ts:404`) — targets `$HOME/.claude.json` for the default config dir, else `${CLAUDE_CONFIG_DIR}/.claude.json`, so a custom-config-dir install seeds the file claude actually reads.

## Scope
Server-only reliability fix. The broader user-facing surfacing (a `claude_trust` Diagnose check + one-click fix, and whether unattended autopilot **worktree-path** spawns wedge on the same dialog) is deferred to **#1683**.

## Tests
- `test/claude-trust.test.ts` — config-dir-aware path selection (`$HOME` vs `CLAUDE_CONFIG_DIR`), round-trip, field preservation, missing/malformed file, compact JSON output.
- `test/usage-probe.test.ts` — pre-seed once when untrusted; never when trusted; never in api-key mode; `scrape()` resolves to `null` (never throws) when the trust read/write throws.

Local: `bun run lint`, `bun run typecheck`, `bun test ./test` (6808 pass) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)