### PR TITLE
feat(hooks): default hook ingestion on for fresh installs (#740)

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -101,6 +101,29 @@ Opt-in, default-off. Configurable from the Settings panel (persisted in the SQLi
 | --- | --- | --- |
 | `SHEPHERD_UPNEXT_SKIP_CLI_PICKER` | `0` (off) | Set `1` to make Up Next quick-start launch with the operator's default coding CLI instead of opening the "Choose coding CLI" picker, even when more than one CLI is ready. Default off preserves the picker behavior. |
 
+## Push-based hook ingestion
+
+Shepherd injects Claude Code lifecycle **hooks** into each spawned agent that POST to a restricted
+loopback ingress, giving the HUD push updates (tool activity, notifications, sub-agent roster,
+turn-`Stop` timing) **on top of** the 1 s poller — never instead of it. The path is **fail-open**:
+each hook is synchronous with a 5 s budget, so an unreachable or hung endpoint (e.g. an
+autonomous/egress agent whose netns route is down) simply times out and the poller stays
+authoritative.
+
+Two independent stages, each an env override on a code default:
+
+- **Ingest** (`SHEPHERD_HOOKS_INGEST`) — injection + ingest route + ring-buffer/logging + the
+  sub-agent roster fan-out. Observe-only: it never mutates session status. **Default on** as of the
+  post-soak flip; set `SHEPHERD_HOOKS_INGEST=0` to disable (the kill switch).
+- **Signals** (`SHEPHERD_HOOKS_SIGNALS`) — feed matched hook events into the poller's signal
+  pipeline. Still **opt-in**; meaningful only when ingest is also on (with ingest off, no events
+  arrive to feed, and Shepherd warns and treats signals as off).
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SHEPHERD_HOOKS_INGEST` | `1` (on) | Inject observe-only lifecycle hooks into spawned agents (ingest route, ring buffer/logging, sub-agent roster fan-out). No status consumption; additive + fail-open. Set `0` to disable entirely (kill switch) |
+| `SHEPHERD_HOOKS_SIGNALS` | `0` (off) | Set `1` to forward matched hook events into the poller's signal pipeline. Meaningful only when `SHEPHERD_HOOKS_INGEST` is also on |
+
 ## Documentation automation (PR-gated doc agent)
 
 Opt-in, default-off. When enabled, a manual trigger (`POST /api/doc-agent?repo=<path>`)

--- a/src/config.ts
+++ b/src/config.ts
@@ -406,6 +406,15 @@ export function parseSandboxProfile(v: string | undefined): SandboxProfile {
   return isSandboxProfile(v) ? v : "trusted";
 }
 
+/**
+ * Parse a kill-switch env var (issue #740): default ON when unset; only an explicit `"0"` turns it
+ * off. The inverse of the `=== "1"` opt-in form — for a capability that has soaked and now ships on
+ * by default, keeping `<VAR>=0` as the operator's code-free revert. Exported for tests.
+ */
+export function parseKillSwitch(raw: string | undefined): boolean {
+  return raw !== "0";
+}
+
 /** Parse an hour-of-day env (0–23 integer); empty/missing/out-of-range falls back to `def`. Exported
  *  for tests. Guards the empty string explicitly — `Number("")` is `0`, which would otherwise pass as
  *  a valid midnight hour. */
@@ -630,15 +639,17 @@ export const config = {
   // when `herdrSocket` is on; the socket driver still drives send/steer/browser/usage. Revisiting the
   // flip is blocked on a scrollback-preserving / raw-passthrough herdr terminal transport (#1642).
   herdrSocketTerminal: process.env.SHEPHERD_HERDR_SOCKET_TERMINAL === "1",
-  // Push-based agent-info ingestion via Claude Code hooks (issue #704), additive on top
-  // of polling, staged behind two default-off flags so each phase is independently reversible.
-  // Phase 0: inject PostToolUse/PostToolUseFailure/Notification HTTP hooks into spawned
-  // agents + ingest + observe (no signal wiring) — to verify reachability, latency, and
-  // session correlation (incl. under the sandboxed/egress profile) before trusting the path.
-  hooksIngest: process.env.SHEPHERD_HOOKS_INGEST === "1",
+  // Push-based agent-info ingestion via Claude Code hooks (issue #704), additive on top of polling.
+  // Phase 0: inject PostToolUse/PostToolUseFailure/Notification HTTP hooks into spawned agents +
+  // ingest + observe (no signal wiring) — reachability, latency, and session correlation (incl.
+  // under the sandboxed/egress profile). DEFAULT ON as of #740 (post-soak): fresh installs inherit
+  // observe-only ingestion; it's additive + fail-open (an unreachable/hung endpoint times out per
+  // the hook's 5s budget → polling). SHEPHERD_HOOKS_INGEST=0 is the kill switch.
+  hooksIngest: parseKillSwitch(process.env.SHEPHERD_HOOKS_INGEST),
   // Phase 1: feed received hook events into the poller (the single owner of signal state).
   // Meaningful only when `hooksIngest` is also on — with ingest off no events arrive to feed.
-  // Staged after Phase 0 has confirmed the live payload shape (see issue #704).
+  // Still OPT-IN (=== "1"): #740 flipped only ingest on. Promoting signals to default awaits
+  // confirmed soak of the #711 netns transport (autonomous/egress) it would consume events over.
   hooksSignals: process.env.SHEPHERD_HOOKS_SIGNALS === "1",
   // PR-gated AI doc agent (issue #882, epic #875 Phase 3). Opt-in soak flag, mirroring
   // SHEPHERD_HOOKS_INGEST→HOOKS_SIGNALS: default-off and reversible. This is now Phase-0

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -34,7 +34,7 @@ import {
 import { operatorLanguageBlock } from "../src/operator-language";
 import { WorktreeRestoreError } from "../src/worktree";
 import { HOUSE_RULES_TAG } from "../src/house-rules";
-import { config, parseTrimAutoContext } from "../src/config";
+import { config, parseKillSwitch, parseTrimAutoContext } from "../src/config";
 import { MAX_IMAGES } from "../src/validate";
 import { stubBaseRef } from "./helpers/base-ref";
 
@@ -5669,6 +5669,14 @@ test("parseTrimAutoContext: default on; false/0/off (case-insensitive) turn it o
   expect(parseTrimAutoContext("0")).toBe(false);
   expect(parseTrimAutoContext("off")).toBe(false);
   expect(parseTrimAutoContext("Off")).toBe(false);
+});
+
+test("parseKillSwitch: default on; only an explicit '0' turns it off (#740)", () => {
+  expect(parseKillSwitch(undefined)).toBe(true); // unset → on
+  expect(parseKillSwitch("")).toBe(true); // set-but-empty → on
+  expect(parseKillSwitch("1")).toBe(true);
+  expect(parseKillSwitch("true")).toBe(true);
+  expect(parseKillSwitch("0")).toBe(false); // the kill switch
 });
 
 test("spawnSettingsOverlay: disablePlugins ids map to false; absent/empty omits the key", () => {

--- a/test/setup-test-env.ts
+++ b/test/setup-test-env.ts
@@ -31,3 +31,12 @@ const KEEP = new Set([
 for (const key of Object.keys(process.env)) {
   if (key.startsWith("SHEPHERD_") && !KEEP.has(key)) delete process.env[key];
 }
+
+// #740 flipped SHEPHERD_HOOKS_INGEST to default-ON (kill-switch `!== "0"` form). The strip above
+// removes the ambient var, so config would otherwise read the *code* default (on) and
+// spawnSettingsOverlay would bake a `hooks` blob into every spawn/resume argv — breaking the
+// snapshot tests this preload exists to keep deterministic. Pin both hook flags OFF so the suite
+// keeps CI-equivalent, hooks-off isolation. The on-path stays covered by the tests that set
+// `config.hooksIngest` / `config.hooksSignals` directly (service.test.ts, poller*.test.ts).
+process.env.SHEPHERD_HOOKS_INGEST = "0";
+process.env.SHEPHERD_HOOKS_SIGNALS = "0";

--- a/ui/src/lib/docs-manifest.ts
+++ b/ui/src/lib/docs-manifest.ts
@@ -69,7 +69,7 @@ export const DOCS_PAGES: readonly DocsPage[] = [
     title: "Configuration",
     path: "/reference/configuration/",
     keywords:
-      "every environment variable and the per-agent sandbox profiles. core live preview host tuning (tmpfs inodes) runaway-orphan reaper main agent terminal renderer (research preview) up next quick-start documentation automation (pr-gated doc agent) anonymous usage telemetry per-agent sandbox / permission profiles",
+      "every environment variable and the per-agent sandbox profiles. core live preview host tuning (tmpfs inodes) runaway-orphan reaper main agent terminal renderer (research preview) up next quick-start push-based hook ingestion documentation automation (pr-gated doc agent) anonymous usage telemetry per-agent sandbox / permission profiles",
   },
   {
     title: "External Task API",


### PR DESCRIPTION
## What

Flips **`SHEPHERD_HOOKS_INGEST`** to default **on** so fresh installs inherit push-based hook ingestion, keeping `SHEPHERD_HOOKS_INGEST=0` as a code-free kill switch. This is the **intermediate** step from #740 — ingest only; **`SHEPHERD_HOOKS_SIGNALS` stays opt-in**.

## Why this scope (ingest-only)

Per #740's exit criteria:

- **Criterion (b) — #713 stop-window data — MET.** Hook `Stop` leads herdr `done` in 92.4% of pairings (p50 ~1,168 ms).
- **Criterion (a) — clean soak incl. autonomous netns.** Attended soak is well past the week-plus bar, but the #711 restricted-loopback (netns) transport had carried **zero** hook events as of the last recorded verdict (all sessions `trusted`/`egress=0`), and current netns coverage isn't confirmed.

Ingest is **additive, observe-only, and fail-open** (no status consumption; an unreachable/hung endpoint times out per the hook's 5s budget → polling stays authoritative), so it's safe to default on now. Promoting **signals** to default is deliberately deferred — it would make the poller *consume* events over the still-unproven netns transport. **#740 stays open** to track the signals flip once netns soak is confirmed.

## Changes

- `src/config.ts` — new exported `parseKillSwitch(v) => v !== "0"` helper (mirrors `parseTrimAutoContext`); applied to `hooksIngest`. `hooksSignals` unchanged (`=== "1"`). Comments updated.
- `test/setup-test-env.ts` — pin both hook flags off for the suite, so the flipped code default doesn't leak a `hooks` blob into spawn/resume snapshot argv (the on-path stays covered by tests that set `config.hooks*` directly).
- `test/service.test.ts` — unit test for `parseKillSwitch`.
- `docs-site/.../reference/configuration.md` — new "Push-based hook ingestion" section documenting both flags + the kill switch (+ regenerated `ui/src/lib/docs-manifest.ts`).

## Note for the operator box

No merge action required. On the operator box, `SHEPHERD_HOOKS_INGEST=1` in `~/.shepherd/env` is now redundant (harmless — still means on) and may be dropped. **Keep `SHEPHERD_HOOKS_SIGNALS=1`** — signals remain opt-in, so removing it would turn signals off.

## Verification

- `bun run lint` ✓ · `bun test ./test` → 6797 pass / 0 fail ✓
- pre-push (7 lanes incl. tsc, ui check, docs-manifest freshness, fallow audit) ✓

Refs #740. Announced via release notes (this `feat:` commit → CHANGELOG); no in-app UX surface.

[no-feature-entry]