### PR TITLE
feat: add provider-aware skill picking

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -276,6 +276,14 @@
         "reason": "Codex provider routing plus the empty-repo repair path keep the task composer above the Tier-1 Svelte template bar; keep capped until NewTask is split further (#855)."
       },
       {
+        "files": ["ui/src/lib/components/PromptSources.svelte"],
+        "functions": ["<template>"],
+        "maxCyclomatic": 40,
+        "maxCognitive": 70,
+        "maxCrap": 20000,
+        "reason": "PromptSources combines source tabs, issue filters and provider-aware command rows; provider badges push the existing template just above the Tier-1 cognitive bar. Keep capped until the source panes split into child components (#855)."
+      },
+      {
         "files": ["ui/src/lib/components/Settings.svelte"],
         "functions": ["<template>"],
         "maxCyclomatic": 50,

--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { listCommands } from "./commands";
+
+const roots: string[] = [];
+
+function tmpRoot(): string {
+  const root = join(tmpdir(), `shepherd-commands-${crypto.randomUUID()}`);
+  mkdirSync(root, { recursive: true });
+  roots.push(root);
+  return root;
+}
+
+function skill(root: string, rel: string, frontmatterName: string, description = "desc") {
+  const dir = join(root, rel);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "SKILL.md"),
+    `---\nname: ${frontmatterName}\ndescription: ${description}\n---\nBody\n`,
+  );
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("listCommands Codex direct skills", () => {
+  it("discovers direct repo Codex skills using frontmatter name as the invocation", () => {
+    const root = tmpRoot();
+    const repo = join(root, "repo");
+    const claude = join(root, ".claude");
+    const home = join(root, "home");
+    const codexHome = join(root, ".codex");
+    skill(repo, ".agents/skills/folder-name", "frontmatter-name", "Codex repo skill");
+
+    const rows = listCommands(repo, claude, { userHome: home, codexHome });
+    const row = rows.find((c) => c.id === "codex:repo:frontmatter-name");
+
+    expect(row).toMatchObject({
+      name: "frontmatter-name",
+      displayName: "frontmatter-name",
+      kind: "skill",
+      invocationName: "frontmatter-name",
+      sourceNamespace: "codex:repo",
+      providers: ["codex"],
+      invocations: { codex: "$frontmatter-name" },
+      description: "Codex repo skill",
+    });
+  });
+
+  it("honors Codex config disabled direct skills and leaves plugin caches undiscovered", () => {
+    const root = tmpRoot();
+    const repo = join(root, "repo");
+    const claude = join(root, ".claude");
+    const home = join(root, "home");
+    const codexHome = join(root, ".codex");
+    const disabledDir = join(home, ".agents/skills/disabled-skill");
+    skill(home, ".agents/skills/enabled-skill", "enabled-skill");
+    skill(home, ".agents/skills/disabled-skill", "disabled-skill");
+    skill(
+      codexHome,
+      "plugins/cache/openai-curated-remote/github/0.1.0/skills/gh-fix-ci",
+      "gh-fix-ci",
+    );
+    mkdirSync(codexHome, { recursive: true });
+    writeFileSync(
+      join(codexHome, "config.toml"),
+      `[[skills.config]]\npath = "${disabledDir.replaceAll("\\", "\\\\")}"\nenabled = false\n`,
+    );
+
+    const names = listCommands(repo, claude, { userHome: home, codexHome }).map((c) => c.name);
+
+    expect(names).toContain("enabled-skill");
+    expect(names).not.toContain("disabled-skill");
+    expect(names).not.toContain("gh-fix-ci");
+  });
+
+  it("does not merge unrelated same-name Claude and Codex skills into Both", () => {
+    const root = tmpRoot();
+    const repo = join(root, "repo");
+    const claude = join(root, ".claude");
+    const home = join(root, "home");
+    const codexHome = join(root, ".codex");
+    skill(claude, "skills/shared", "shared", "Claude skill");
+    skill(repo, ".agents/skills/shared", "shared", "Codex skill");
+
+    const rows = listCommands(repo, claude, { userHome: home, codexHome }).filter(
+      (c) => c.name === "shared",
+    );
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.providers).sort()).toEqual([["claude"], ["codex"]]);
+  });
+});

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,5 +1,8 @@
 import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { createHash } from "node:crypto";
+import type { AgentProvider } from "./types";
 
 /** Where a discovered slash command came from — drives the row badge and dedupe
  *  precedence (project > user > plugin > builtin). Skills are folded into
@@ -11,9 +14,17 @@ export type SlashCommandScope = "project" | "user" | "plugin" | "builtin";
  *  file (`.claude/commands/<name>.md`), an installed plugin command/skill, or a
  *  built-in — invokable from the prompt as `/<name>`. */
 export interface SlashCommand {
+  id: string;
   name: string;
+  displayName: string;
   description: string;
   scope: SlashCommandScope;
+  kind: "skill" | "command";
+  invocationName: string;
+  sourceNamespace: string;
+  sourcePath?: string;
+  providers: AgentProvider[];
+  invocations: Partial<Record<AgentProvider, string>>;
   /** Front-matter `argument-hint` (e.g. "<ticket>"), shown dimmed after the name. */
   argumentHint?: string;
 }
@@ -74,6 +85,7 @@ function readCommand(
   fallbackName: string,
   scope: SlashCommand["scope"],
   prefix = "",
+  kind: SlashCommand["kind"] = "command",
 ): SlashCommand | null {
   let text: string;
   try {
@@ -88,7 +100,21 @@ function readCommand(
   if (description.length > MAX_DESC)
     description = description.slice(0, MAX_DESC - 1).trimEnd() + "…";
   const argumentHint = fm["argument-hint"]?.trim() || undefined;
-  return { name: prefix + bare, description, scope, argumentHint };
+  const name = prefix + bare;
+  return {
+    id: `claude:${scope}:${name}`,
+    name,
+    displayName: name,
+    description,
+    scope,
+    kind,
+    invocationName: name,
+    sourceNamespace: `claude:${scope}`,
+    sourcePath: path,
+    providers: ["claude"],
+    invocations: { claude: `/${name}` },
+    argumentHint,
+  };
 }
 
 function safeReaddir(dir: string): string[] {
@@ -112,7 +138,7 @@ function collect(
   for (const entry of safeReaddir(skillsDir)) {
     const md = join(skillsDir, entry, "SKILL.md");
     if (!existsSync(md)) continue;
-    const cmd = readCommand(md, entry, scope, prefix);
+    const cmd = readCommand(md, entry, scope, prefix, "skill");
     if (cmd) out.set(cmd.name, cmd);
   }
   const cmdsDir = join(claudeDir, "commands");
@@ -143,6 +169,119 @@ const BUILTINS: ReadonlyArray<{ name: string; description: string }> = [
   },
   { name: "pr-comments", description: "Get comments from a GitHub pull request" },
 ];
+
+type CodexConfig = { skills?: { config?: Array<{ path?: unknown; enabled?: unknown }> } };
+
+function commandContentHash(path: string): string | undefined {
+  try {
+    return createHash("sha256")
+      .update(readFileSync(path, "utf8").replace(/\r\n/g, "\n"))
+      .digest("hex");
+  } catch {
+    return undefined;
+  }
+}
+
+function codexHomeDefault(): string {
+  return process.env.CODEX_HOME || join(homedir(), ".codex");
+}
+
+function disabledSkillPaths(codexHome: string): Set<string> {
+  let parsed: CodexConfig;
+  try {
+    parsed = Bun.TOML.parse(readFileSync(join(codexHome, "config.toml"), "utf8")) as CodexConfig;
+  } catch {
+    return new Set();
+  }
+  const out = new Set<string>();
+  for (const entry of parsed.skills?.config ?? []) {
+    if (typeof entry.path !== "string" || entry.enabled !== false) continue;
+    out.add(resolve(entry.path));
+    out.add(resolve(entry.path, "SKILL.md"));
+  }
+  return out;
+}
+
+function isDisabledSkill(path: string, disabled: Set<string>): boolean {
+  const skillPath = resolve(path);
+  return disabled.has(skillPath) || disabled.has(resolve(skillPath, ".."));
+}
+
+function readCodexSkill(
+  path: string,
+  sourceNamespace: string,
+  disabled: Set<string>,
+): SlashCommand | null {
+  if (isDisabledSkill(path, disabled)) return null;
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+  const { fm } = parseFrontmatter(text);
+  const name = fm.name?.trim();
+  if (!name) return null;
+  let description = fm.description?.trim() || "";
+  if (description.length > MAX_DESC)
+    description = description.slice(0, MAX_DESC - 1).trimEnd() + "…";
+  return {
+    id: `${sourceNamespace}:${name}`,
+    name,
+    displayName: name,
+    description,
+    scope: sourceNamespace.startsWith("codex:repo") ? "project" : "user",
+    kind: "skill",
+    invocationName: name,
+    sourceNamespace,
+    sourcePath: path,
+    providers: ["codex"],
+    invocations: { codex: `$${name}` },
+  };
+}
+
+function collectCodexSkillRoot(
+  root: string,
+  sourceNamespace: string,
+  disabled: Set<string>,
+  out: SlashCommand[],
+) {
+  for (const entry of safeReaddir(root)) {
+    const md = join(root, entry, "SKILL.md");
+    if (!existsSync(md)) continue;
+    const cmd = readCodexSkill(md, sourceNamespace, disabled);
+    if (cmd) out.push(cmd);
+  }
+}
+
+function mergeEquivalentRows(rows: SlashCommand[]): SlashCommand[] {
+  const out: SlashCommand[] = [];
+  for (const row of rows) {
+    if (row.providers.length !== 1) {
+      out.push(row);
+      continue;
+    }
+    const hash = row.sourcePath ? commandContentHash(row.sourcePath) : undefined;
+    const match =
+      hash &&
+      out.find(
+        (existing) =>
+          existing.kind === row.kind &&
+          existing.name === row.name &&
+          existing.sourcePath &&
+          commandContentHash(existing.sourcePath) === hash,
+      );
+    if (!match || match.providers.includes(row.providers[0]!)) {
+      out.push(row);
+      continue;
+    }
+    match.providers = [...match.providers, row.providers[0]!].sort();
+    match.invocations = { ...match.invocations, ...row.invocations };
+    match.id = `both:${match.kind}:${match.name}:${hash.slice(0, 12)}`;
+    match.sourceNamespace = `${match.sourceNamespace}+${row.sourceNamespace}`;
+  }
+  return out;
+}
 
 /** Re-root an absolute installPath under the local `~/.claude`. installPath is
  *  stored verbatim and may carry another machine's `$HOME` (settings sync across
@@ -191,12 +330,36 @@ function collectPlugins(
  *  autocomplete. Built in precedence order (lowest first, each later source
  *  shadowing earlier on a name clash): builtin → plugin → user → project. Sorted
  *  by name. `repoDir` null → no project layer. */
-export function listCommands(repoDir: string | null, userClaudeDir: string): SlashCommand[] {
+export function listCommands(
+  repoDir: string | null,
+  userClaudeDir: string,
+  opts: { userHome?: string; codexHome?: string } = {},
+): SlashCommand[] {
   const out = new Map<string, SlashCommand>();
   for (const b of BUILTINS)
-    out.set(b.name, { name: b.name, description: b.description, scope: "builtin" });
+    out.set(b.name, {
+      id: `claude:builtin:${b.name}`,
+      name: b.name,
+      displayName: b.name,
+      description: b.description,
+      scope: "builtin",
+      kind: "command",
+      invocationName: b.name,
+      sourceNamespace: "claude:builtin",
+      providers: ["claude"],
+      invocations: { claude: `/${b.name}` },
+    });
   collectPlugins(userClaudeDir, repoDir, out);
   collect(userClaudeDir, "user", out);
   if (repoDir) collect(join(repoDir, ".claude"), "project", out);
-  return [...out.values()].sort((a, b) => a.name.localeCompare(b.name));
+  const rows = [...out.values()];
+  const codexHome = opts.codexHome ?? codexHomeDefault();
+  const userHome = opts.userHome ?? homedir();
+  const disabled = disabledSkillPaths(codexHome);
+  if (repoDir)
+    collectCodexSkillRoot(join(repoDir, ".agents", "skills"), "codex:repo", disabled, rows);
+  collectCodexSkillRoot(join(userHome, ".agents", "skills"), "codex:user", disabled, rows);
+  collectCodexSkillRoot(join(codexHome, "skills", ".system"), "codex:system", disabled, rows);
+  collectCodexSkillRoot("/etc/codex/skills", "codex:admin", disabled, rows);
+  return mergeEquivalentRows(rows).sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -338,6 +338,8 @@ export interface Steer {
   /** Allowlist of repo NAMES this steer is bound to (the dir name listRepos enumerates
    *  under repoRoot). Empty/absent = universal (shows on every repo). */
   repos?: string[];
+  /** Optional provider allowlist. Empty/absent = universal. */
+  agentProviders?: AgentProvider[];
 }
 
 // ── git diff review panel ──────────────────────────────────────────────────

--- a/src/validate-steers.test.ts
+++ b/src/validate-steers.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { validateSteers } from "./validate";
+
+const base = {
+  id: "s1",
+  label: "Run",
+  text: "Do it",
+  inSteerBar: true,
+  onIssues: false,
+};
+
+describe("validateSteers provider constraints", () => {
+  it("keeps single-provider constraints", () => {
+    expect(validateSteers([{ ...base, agentProviders: ["codex"] }])).toEqual([
+      { ...base, agentProviders: ["codex"] },
+    ]);
+  });
+
+  it("normalizes both providers and missing providers to universal", () => {
+    expect(validateSteers([{ ...base, agentProviders: ["claude", "codex"] }])).toEqual([base]);
+    expect(validateSteers([base])).toEqual([base]);
+  });
+
+  it("rejects unknown providers", () => {
+    expect(validateSteers([{ ...base, agentProviders: ["other"] }])).toBeNull();
+  });
+});

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -999,6 +999,18 @@ function validateSteerRepos(v: unknown): string[] | undefined | null {
   return seen.size === 0 ? undefined : [...seen];
 }
 
+function validateSteerAgentProviders(v: unknown): AgentProvider[] | undefined | null {
+  if (v === undefined || v === null) return undefined;
+  if (!Array.isArray(v)) return null;
+  const out: AgentProvider[] = [];
+  for (const p of v) {
+    if (!(AGENT_PROVIDERS as readonly unknown[]).includes(p)) return null;
+    if (!out.includes(p as AgentProvider)) out.push(p as AgentProvider);
+  }
+  if (out.length === 0 || out.length === AGENT_PROVIDERS.length) return undefined;
+  return out;
+}
+
 /** Validate a steer's required label + text strings. Returns null on any violation. */
 function validateSteerLabelText(
   o: Record<string, unknown>,
@@ -1033,7 +1045,8 @@ function validateSteerItem(it: unknown): Steer | null {
   if (labelText === null || surfaces === null) return null;
   const emoji = validateSteerEmoji(o.emoji);
   const repos = validateSteerRepos(o.repos);
-  if (emoji === null || repos === null) return null;
+  const agentProviders = validateSteerAgentProviders(o.agentProviders);
+  if (emoji === null || repos === null || agentProviders === null) return null;
   const id = typeof o.id === "string" && o.id.length > 0 ? o.id : randomUUID();
   return {
     id,
@@ -1043,6 +1056,7 @@ function validateSteerItem(it: unknown): Steer | null {
     inSteerBar: surfaces.inSteerBar,
     onIssues: surfaces.onIssues,
     ...(repos !== undefined ? { repos } : {}),
+    ...(agentProviders !== undefined ? { agentProviders } : {}),
   };
 }
 

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -6,6 +6,8 @@ import { listCommands } from "../src/commands";
 
 let userClaude: string;
 let repo: string;
+let userHome: string;
+let codexHome: string;
 
 function skill(claudeDir: string, name: string, body: string) {
   mkdirSync(join(claudeDir, "skills", name), { recursive: true });
@@ -20,6 +22,8 @@ function command(claudeDir: string, file: string, body: string) {
 beforeEach(() => {
   userClaude = mkdtempSync(join(tmpdir(), "shepherd-cmds-user-"));
   repo = mkdtempSync(join(tmpdir(), "shepherd-cmds-repo-"));
+  userHome = mkdtempSync(join(tmpdir(), "shepherd-cmds-home-"));
+  codexHome = mkdtempSync(join(tmpdir(), "shepherd-cmds-codex-"));
 
   // user-scope skills
   skill(userClaude, "alpha", "---\nname: alpha-skill\ndescription: Alpha does things\n---\nbody");
@@ -41,12 +45,18 @@ beforeEach(() => {
 afterEach(() => {
   rmSync(userClaude, { recursive: true, force: true });
   rmSync(repo, { recursive: true, force: true });
+  rmSync(userHome, { recursive: true, force: true });
+  rmSync(codexHome, { recursive: true, force: true });
 });
+
+function commands(repoDir: string | null, claude: string) {
+  return listCommands(repoDir, claude, { userHome, codexHome });
+}
 
 /** Names contributed by skills/commands/plugins, with the always-present builtins
  *  filtered out — keeps the file-scan assertions stable as builtins evolve. */
 function nonBuiltin(repoDir: string | null, claude: string) {
-  return listCommands(repoDir, claude)
+  return commands(repoDir, claude)
     .filter((c) => c.scope !== "builtin")
     .map((c) => c.name);
 }
@@ -62,32 +72,40 @@ test("merges user + project commands, sorted by name", () => {
 });
 
 test("skill name comes from front-matter, scope is user", () => {
-  const alpha = listCommands(repo, userClaude).find((c) => c.name === "alpha-skill");
-  expect(alpha).toEqual({ name: "alpha-skill", description: "Alpha does things", scope: "user" });
+  const alpha = commands(repo, userClaude).find((c) => c.name === "alpha-skill");
+  expect(alpha).toMatchObject({
+    name: "alpha-skill",
+    description: "Alpha does things",
+    scope: "user",
+  });
 });
 
 test("skill name falls back to directory, description to first body line", () => {
-  const noname = listCommands(repo, userClaude).find((c) => c.name === "noname");
-  expect(noname).toEqual({ name: "noname", description: "No Front Matter", scope: "user" });
+  const noname = commands(repo, userClaude).find((c) => c.name === "noname");
+  expect(noname).toMatchObject({
+    name: "noname",
+    description: "No Front Matter",
+    scope: "user",
+  });
 });
 
 test("command description falls back to first body line", () => {
-  const bar = listCommands(repo, userClaude).find((c) => c.name === "bar");
-  expect(bar).toEqual({ name: "bar", description: "Do the bar thing", scope: "user" });
+  const bar = commands(repo, userClaude).find((c) => c.name === "bar");
+  expect(bar).toMatchObject({ name: "bar", description: "Do the bar thing", scope: "user" });
 });
 
 test("project shadows user on a name clash", () => {
-  const foo = listCommands(repo, userClaude).find((c) => c.name === "foo");
-  expect(foo).toEqual({ name: "foo", description: "project foo", scope: "project" });
+  const foo = commands(repo, userClaude).find((c) => c.name === "foo");
+  expect(foo).toMatchObject({ name: "foo", description: "project foo", scope: "project" });
 });
 
 test("merge-train is project-scoped", () => {
-  const mt = listCommands(repo, userClaude).find((c) => c.name === "merge-train");
+  const mt = commands(repo, userClaude).find((c) => c.name === "merge-train");
   expect(mt?.scope).toBe("project");
 });
 
 test("non-.md files in commands are ignored", () => {
-  expect(listCommands(repo, userClaude).some((c) => c.name === "ignore")).toBe(false);
+  expect(commands(repo, userClaude).some((c) => c.name === "ignore")).toBe(false);
 });
 
 test("null repoDir → user scope only (no project commands)", () => {
@@ -98,7 +116,7 @@ test("null repoDir → user scope only (no project commands)", () => {
 
 test("missing dirs → builtins only, no throw", () => {
   const missing = join(userClaude, "does-not-exist");
-  const cmds = listCommands(null, missing);
+  const cmds = commands(null, missing);
   expect(cmds.every((c) => c.scope === "builtin")).toBe(true);
   expect(cmds.length).toBeGreaterThan(0);
 });
@@ -106,7 +124,7 @@ test("missing dirs → builtins only, no throw", () => {
 // ── builtins, argument-hint, plugins (the enrichment over #147) ────────────────
 
 test("curated builtins are always present and scoped builtin", () => {
-  const cmds = listCommands(repo, userClaude);
+  const cmds = commands(repo, userClaude);
   const review = cmds.find((c) => c.name === "review");
   expect(review?.scope).toBe("builtin");
   expect(cmds.some((c) => c.name === "security-review" && c.scope === "builtin")).toBe(true);
@@ -118,7 +136,7 @@ test("front-matter argument-hint is surfaced", () => {
     "ticketed.md",
     "---\ndescription: needs a ticket\nargument-hint: <ticket>\n---\n",
   );
-  const cmd = listCommands(null, userClaude).find((c) => c.name === "ticketed");
+  const cmd = commands(null, userClaude).find((c) => c.name === "ticketed");
   expect(cmd?.argumentHint).toBe("<ticket>");
 });
 
@@ -137,7 +155,7 @@ test("installed plugins are scanned, namespaced, and re-rooted from a foreign in
       },
     }),
   );
-  const cmds = listCommands(null, userClaude);
+  const cmds = commands(null, userClaude);
   expect(cmds.find((c) => c.name === "myplugin:deploy")?.scope).toBe("plugin");
   expect(cmds.find((c) => c.name === "myplugin:scan")?.scope).toBe("plugin");
 });
@@ -146,7 +164,7 @@ test("over-long description is truncated with an ellipsis", () => {
   const long = mkdtempSync(join(tmpdir(), "shepherd-cmds-long-"));
   try {
     command(long, "big.md", `---\ndescription: ${"x".repeat(400)}\n---\n`);
-    const big = listCommands(null, long).find((c) => c.name === "big");
+    const big = commands(null, long).find((c) => c.name === "big");
     expect(big!.description.length).toBeLessThanOrEqual(280);
     expect(big!.description.endsWith("…")).toBe(true);
   } finally {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3014,5 +3014,12 @@
   "newtask_init_commit_running": "Wird erstellt…",
   "feat_initial_commit_repair_title": "Leere Repos in Neue Aufgabe reparieren",
   "feat_initial_commit_repair_body": "Wenn das ausgewählte Repo noch keinen initialen Commit hat, blockiert Neue Aufgabe jetzt den aussichtslosen Start und bietet an, direkt den ersten leeren Commit zu erstellen, damit die Aufgabe von einer echten Basis starten kann.",
-  "newtask_init_commit_unknown_reason": "Unbekannter Fehler"
+  "newtask_init_commit_unknown_reason": "Unbekannter Fehler",
+  "provider_badge_claude": "Claude",
+  "provider_badge_codex": "Codex",
+  "provider_badge_both": "Beide",
+  "newtask_provider_constraint_note": "{command} benötigt {provider}.",
+  "newtask_provider_constraint_error": "{command} benötigt {provider}. Entferne den Token oder wechsle die CLI.",
+  "feat_provider_aware_skills_title": "Provider-bewusste Skills",
+  "feat_provider_aware_skills_body": "Die Picker in Neuer Task und Compose verstehen jetzt Claude-Slash-Commands und direkte Codex-Skills. Nutze / für Claude, $ für Codex oder ein einzelnes @ als Codex-Picker-Alias; Zeilen zeigen, ob sie in Claude, Codex oder beiden laufen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3014,5 +3014,12 @@
   "newtask_init_commit_running": "Creating…",
   "feat_initial_commit_repair_title": "Repair empty repos from New Task",
   "feat_initial_commit_repair_body": "When a selected repo has no initial commit yet, New Task now blocks the doomed launch and offers to create the first empty commit in place so the task can start from a real base.",
-  "newtask_init_commit_unknown_reason": "Unknown error"
+  "newtask_init_commit_unknown_reason": "Unknown error",
+  "provider_badge_claude": "Claude",
+  "provider_badge_codex": "Codex",
+  "provider_badge_both": "Both",
+  "newtask_provider_constraint_note": "{command} requires {provider}.",
+  "newtask_provider_constraint_error": "{command} requires {provider}. Remove the token or switch CLI.",
+  "feat_provider_aware_skills_title": "Provider-aware skills",
+  "feat_provider_aware_skills_body": "The New Task and compose pickers now understand Claude slash commands and direct Codex skills. Use / for Claude, $ for Codex, or bare @ as a Codex picker alias; rows show whether they run in Claude, Codex, or both."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1133,18 +1133,18 @@ export async function cancelWorkflowRun(repoPath: string, runId: number): Promis
 }
 
 /** Installed slash commands (skills + command files) for the New Task picker. */
-export type CommandDiscoveryContext =
+type CommandDiscoveryContext =
   | { kind: "new-task"; repoPath: string; baseBranch?: string | null; agentProvider?: string }
   | { kind: "session"; sessionId: string }
   | { kind: "held"; heldTaskId: string }
   | { kind: "replace"; sessionId: string; handoffMode: "default" | "summarize" };
 
-export interface CommandDiscoveryRequest {
+interface CommandDiscoveryRequest {
   repoPath?: string;
   context?: CommandDiscoveryContext;
 }
 
-export async function fetchCommands(
+async function fetchCommands(
   request: CommandDiscoveryRequest,
 ): Promise<{ commands: SlashCommand[] }> {
   const params = new URLSearchParams();

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1133,10 +1133,31 @@ export async function cancelWorkflowRun(repoPath: string, runId: number): Promis
 }
 
 /** Installed slash commands (skills + command files) for the New Task picker. */
-export async function getCommands(repoPath: string): Promise<{ commands: SlashCommand[] }> {
-  const r = await fetch(`/api/commands?repo=${encodeURIComponent(repoPath)}`);
+export type CommandDiscoveryContext =
+  | { kind: "new-task"; repoPath: string; baseBranch?: string | null; agentProvider?: string }
+  | { kind: "session"; sessionId: string }
+  | { kind: "held"; heldTaskId: string }
+  | { kind: "replace"; sessionId: string; handoffMode: "default" | "summarize" };
+
+export interface CommandDiscoveryRequest {
+  repoPath?: string;
+  context?: CommandDiscoveryContext;
+}
+
+export async function fetchCommands(
+  request: CommandDiscoveryRequest,
+): Promise<{ commands: SlashCommand[] }> {
+  const params = new URLSearchParams();
+  if (request.repoPath) params.set("repo", request.repoPath);
+  if (request.context) params.set("context", JSON.stringify(request.context));
+  const qs = params.toString();
+  const r = await fetch(`/api/commands${qs ? `?${qs}` : ""}`);
   if (!r.ok) throw await failed(r, "commands");
   return r.json();
+}
+
+export async function getCommands(repoPath: string): Promise<{ commands: SlashCommand[] }> {
+  return fetchCommands({ repoPath });
 }
 
 const JSON_POST = (body?: unknown): RequestInit => ({

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1133,31 +1133,13 @@ export async function cancelWorkflowRun(repoPath: string, runId: number): Promis
 }
 
 /** Installed slash commands (skills + command files) for the New Task picker. */
-type CommandDiscoveryContext =
-  | { kind: "new-task"; repoPath: string; baseBranch?: string | null; agentProvider?: string }
-  | { kind: "session"; sessionId: string }
-  | { kind: "held"; heldTaskId: string }
-  | { kind: "replace"; sessionId: string; handoffMode: "default" | "summarize" };
-
-interface CommandDiscoveryRequest {
-  repoPath?: string;
-  context?: CommandDiscoveryContext;
-}
-
-async function fetchCommands(
-  request: CommandDiscoveryRequest,
-): Promise<{ commands: SlashCommand[] }> {
+export async function getCommands(repoPath: string): Promise<{ commands: SlashCommand[] }> {
   const params = new URLSearchParams();
-  if (request.repoPath) params.set("repo", request.repoPath);
-  if (request.context) params.set("context", JSON.stringify(request.context));
+  if (repoPath) params.set("repo", repoPath);
   const qs = params.toString();
   const r = await fetch(`/api/commands${qs ? `?${qs}` : ""}`);
   if (!r.ok) throw await failed(r, "commands");
   return r.json();
-}
-
-export async function getCommands(repoPath: string): Promise<{ commands: SlashCommand[] }> {
-  return fetchCommands({ repoPath });
 }
 
 const JSON_POST = (body?: unknown): RequestInit => ({

--- a/ui/src/lib/components/BroadcastDialog.svelte
+++ b/ui/src/lib/components/BroadcastDialog.svelte
@@ -39,7 +39,9 @@
         s.inSteerBar &&
         (!s.repos?.length ||
           (selectedSessions.length > 0 &&
-            selectedSessions.every((sess) => steerAppliesToRepo(s, repos.nameFor(sess.repoPath))))),
+            selectedSessions.every((sess) =>
+              steerAppliesToRepo(s, repos.nameFor(sess.repoPath), sess.agentProvider ?? "claude"),
+            ))),
     ),
   );
 

--- a/ui/src/lib/components/ComposeBar.browser.test.ts
+++ b/ui/src/lib/components/ComposeBar.browser.test.ts
@@ -4,6 +4,7 @@ import { page } from "vitest/browser";
 import "../../app.css";
 import { getCommands, getVoiceStatus, transcribeAudio } from "$lib/api";
 import { m } from "$lib/paraglide/messages";
+import type { SlashCommand } from "$lib/types";
 
 // Mock the API so the compose sheet renders deterministically with no network. Mocking
 // getVoiceStatus/transcribeAudio also lets the tests prove that a discarded recording is
@@ -101,6 +102,24 @@ const base = (extra: Record<string, unknown> = {}) => ({
   ...extra,
 });
 
+function slashCommand(name: string, providers: SlashCommand["providers"]): SlashCommand {
+  return {
+    id: `test:${name}`,
+    name,
+    displayName: name,
+    description: `${name} description`,
+    scope: "project",
+    kind: "skill",
+    invocationName: name,
+    sourceNamespace: providers?.includes("codex") ? "codex:repo" : "claude:repo",
+    providers,
+    invocations: {
+      ...(providers?.includes("claude") ? { claude: `/${name}` } : {}),
+      ...(providers?.includes("codex") ? { codex: `$${name}` } : {}),
+    },
+  };
+}
+
 const micBtn = () => page.getByRole("button", { name: m.composebar_dictate_aria() });
 const stopBtn = () => page.getByRole("button", { name: m.composebar_dictate_stop_aria() });
 const field = () => page.getByRole("textbox", { name: m.composebar_input_aria() });
@@ -174,5 +193,21 @@ describe("ComposeBar dictation (shared controller wiring)", () => {
     expect(rec.stopped).toBeGreaterThan(0);
     expect(onclose).toHaveBeenCalled();
     expect(mockTranscribeAudio).not.toHaveBeenCalled();
+  });
+});
+
+describe("ComposeBar provider-aware command picker", () => {
+  it("filters to Codex commands and inserts a dollar mention in place", async () => {
+    mockGetCommands.mockResolvedValue({
+      commands: [slashCommand("claude-only", ["claude"]), slashCommand("codex-only", ["codex"])],
+    });
+    render(ComposeBar, base({ agentProvider: "codex" }));
+
+    await field().fill("use $cod");
+    await expect.element(page.getByText("$codex-only")).toBeVisible();
+    expect(page.getByText("/claude-only").query()).toBeNull();
+    await page.getByText("$codex-only").click();
+
+    await expect.element(field()).toHaveValue("use $codex-only ");
   });
 });

--- a/ui/src/lib/components/ComposeBar.svelte
+++ b/ui/src/lib/components/ComposeBar.svelte
@@ -4,8 +4,14 @@
   import { insertNewlineAt } from "$lib/compose";
   import { getCommands } from "$lib/api";
   import { createDictation } from "$lib/dictation.svelte";
-  import { matchSlashTrigger, filterCommands, applyCommandPick } from "$lib/slash";
-  import type { SlashCommand } from "$lib/types";
+  import {
+    matchSlashTrigger,
+    filterCommands,
+    applyCommandPick,
+    applyMentionPick,
+    commandInvocationName,
+  } from "$lib/slash";
+  import type { AgentProvider, SlashCommand } from "$lib/types";
   import SlashCommandMenu from "./SlashCommandMenu.svelte";
   import { dialog } from "$lib/a11yDialog";
   import { steers } from "$lib/steers.svelte";
@@ -26,11 +32,13 @@
     onsend,
     onclose,
     repoPath,
+    agentProvider = "claude",
     startDictation = false,
   }: {
     onsend: (text: string) => void;
     onclose: () => void;
     repoPath: string;
+    agentProvider?: AgentProvider;
     // open the overlay already listening (mic entry); typing-only entries pass
     // false so the keyboard comes up without recording
     startDictation?: boolean;
@@ -44,14 +52,17 @@
   let allCommands = $state<SlashCommand[]>([]);
   let slashOpen = $state(false);
   let slashQuery = $state("");
+  let slashTrigger = $state<"/" | "$" | "@">("/");
   let slashIndex = $state(0);
-  const slashMatches = $derived(slashOpen ? filterCommands(allCommands, slashQuery) : []);
+  const slashMatches = $derived(
+    slashOpen ? filterCommands(allCommands, slashQuery, agentProvider) : [],
+  );
 
   // Steer chips ignore inSteerBar by design (every steer shows here), but still
   // gate on repo binding — universal steers always show, bound ones only for a
   // matching repo.
   const availableSteers = $derived(
-    steers.list.filter((s) => steerAppliesToRepo(s, repos.nameFor(repoPath))),
+    steers.list.filter((s) => steerAppliesToRepo(s, repos.nameFor(repoPath), agentProvider)),
   );
 
   // Load the slash-command list for this session's repo (its own
@@ -79,6 +90,7 @@
     if (trigger) {
       slashOpen = true;
       slashQuery = trigger.query;
+      slashTrigger = trigger.trigger;
       slashIndex = 0;
     } else {
       slashOpen = false;
@@ -92,7 +104,10 @@
   function pickCommand(cmd: SlashCommand) {
     const caret = ta?.selectionStart ?? value.length;
     const start = matchSlashTrigger(value, caret)?.start ?? 0;
-    const next = applyCommandPick(value, start, caret, cmd.name);
+    const next =
+      agentProvider === "codex"
+        ? applyMentionPick(value, start, caret, commandInvocationName(cmd))
+        : applyCommandPick(value, start, caret, commandInvocationName(cmd));
     value = next.value;
     slashOpen = false;
     queueMicrotask(() => {
@@ -327,6 +342,7 @@
         <SlashCommandMenu
           commands={slashMatches}
           activeIndex={slashIndex}
+          provider={agentProvider === "codex" || slashTrigger !== "/" ? "codex" : "claude"}
           placement="up"
           onpick={pickCommand}
           onhover={(i) => (slashIndex = i)}

--- a/ui/src/lib/components/GitRail.browser.test.ts
+++ b/ui/src/lib/components/GitRail.browser.test.ts
@@ -75,7 +75,9 @@ const { planGates, reviews, repoConfig } = await import("$lib/reviews.svelte");
 const { pullMainAndToast } = await import("$lib/pull-offer");
 
 const mounted: Array<{ unmount: () => void | Promise<void> }> = [];
-async function render(...args: Parameters<typeof rawRender>): ReturnType<typeof rawRender> {
+async function render(
+  ...args: Parameters<typeof rawRender>
+): Promise<Awaited<ReturnType<typeof rawRender>>> {
   const result = await rawRender(...args);
   mounted.push(result);
   return result;

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -276,6 +276,27 @@ describe("NewTask provider-aware command picker", () => {
     expect(document.querySelector<HTMLSelectElement>("#nt-agent-provider")!.value).toBe("codex");
     await expect.element(page.getByText("codex-skill requires Codex.")).toBeVisible();
   });
+
+  it("selecting a both-provider skill does not lock or explain the provider", async () => {
+    mockGetCommands.mockResolvedValue({
+      commands: [slashCommand("shared-skill", ["claude", "codex"])],
+    });
+    render(NewTask, { props: base({ initialRepoPath: "/repo/shared-skill" }) });
+
+    const promptField = document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;
+    promptField.value = "$shared";
+    promptField.dispatchEvent(new Event("input", { bubbles: true }));
+    await expect.element(page.getByText("$shared-skill")).toBeVisible();
+    await page.getByText("$shared-skill").click();
+
+    await expect.poll(() => promptField.value).toBe("$shared-skill ");
+    expect(document.querySelector<HTMLSelectElement>("#nt-agent-provider")!.value).toBe("codex");
+    expect(page.getByText("shared-skill requires Codex.").query()).toBeNull();
+    const options = Array.from(
+      document.querySelectorAll<HTMLOptionElement>("#nt-agent-provider option"),
+    );
+    expect(options.every((option) => !option.disabled)).toBe(true);
+  });
 });
 
 describe("NewTask task attachments", () => {

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -3,7 +3,7 @@ import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
 import { overwriteGetLocale } from "$lib/paraglide/runtime";
-import type { Issue, RepoConfig, RepoEntry, Steer } from "$lib/types";
+import type { Issue, RepoConfig, RepoEntry, SlashCommand, Steer } from "$lib/types";
 import type { UsageLimits } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
 import { steers } from "$lib/steers.svelte";
@@ -201,6 +201,24 @@ function capacityLimits(
   } satisfies UsageLimits;
 }
 
+function slashCommand(name: string, providers: SlashCommand["providers"]): SlashCommand {
+  return {
+    id: `test:${name}`,
+    name,
+    displayName: name,
+    description: `${name} description`,
+    scope: "project",
+    kind: "skill",
+    invocationName: name,
+    sourceNamespace: providers?.includes("codex") ? "codex:repo" : "claude:repo",
+    providers,
+    invocations: {
+      ...(providers?.includes("claude") ? { claude: `/${name}` } : {}),
+      ...(providers?.includes("codex") ? { codex: `$${name}` } : {}),
+    },
+  };
+}
+
 describe("NewTask initialImages seed", () => {
   it("renders a removable chip per seeded attachment", async () => {
     render(NewTask, {
@@ -238,6 +256,25 @@ describe("NewTask initialImages seed", () => {
 
     expect(page.getByText("a.png").query()).toBeNull();
     await expect.element(page.getByText("b.png")).toBeInTheDocument();
+  });
+});
+
+describe("NewTask provider-aware command picker", () => {
+  it("selecting a Codex skill from $ inserts a mention and switches CLI", async () => {
+    mockGetCommands.mockResolvedValue({
+      commands: [slashCommand("codex-skill", ["codex"])],
+    });
+    render(NewTask, { props: base({ initialRepoPath: "/repo/codex-skill" }) });
+
+    const promptField = document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;
+    promptField.value = "$cod";
+    promptField.dispatchEvent(new Event("input", { bubbles: true }));
+    await expect.element(page.getByText("$codex-skill")).toBeVisible();
+    await page.getByText("$codex-skill").click();
+
+    await expect.poll(() => promptField.value).toBe("$codex-skill ");
+    expect(document.querySelector<HTMLSelectElement>("#nt-agent-provider")!.value).toBe("codex");
+    await expect.element(page.getByText("codex-skill requires Codex.")).toBeVisible();
   });
 });
 

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -19,13 +19,22 @@
     type Issue,
     type IssueRef,
     type AgentProvider,
+    type ProviderTokenConstraint,
     type RepoEntry,
     type SandboxProfile,
     type SlashCommand,
     type Steer,
   } from "$lib/types";
   import { promoDefaultModel } from "$lib/fable-promo";
-  import { matchSlashTrigger, filterCommands, applyCommandPick } from "$lib/slash";
+  import {
+    matchSlashTrigger,
+    filterCommands,
+    applyCommandPick,
+    applyMentionPick,
+    commandInvocation,
+    commandInvocationName,
+    commandProviders,
+  } from "$lib/slash";
   import RepoSelect from "./RepoSelect.svelte";
   import PromptSources from "./PromptSources.svelte";
   import SlashCommandMenu from "./SlashCommandMenu.svelte";
@@ -269,8 +278,11 @@
   let allCommands = $state<SlashCommand[]>([]);
   let slashOpen = $state(false);
   let slashQuery = $state("");
+  let slashTrigger = $state<"/" | "$" | "@">("/");
   let slashIndex = $state(0);
   const slashMatches = $derived(slashOpen ? filterCommands(allCommands, slashQuery) : []);
+  let providerTokenConstraints = $state<ProviderTokenConstraint[]>([]);
+  const activeProviderConstraint = $derived(providerTokenConstraints[0] ?? null);
 
   /** Default to the most-recently-used repo; fall back to the first in the list. */
   function defaultRepoPath(list: RepoEntry[]): string {
@@ -581,6 +593,7 @@
     if (trigger) {
       slashOpen = true;
       slashQuery = trigger.query;
+      slashTrigger = trigger.trigger;
       slashIndex = 0;
     } else {
       slashOpen = false;
@@ -589,7 +602,19 @@
 
   function onPromptInput() {
     autogrow();
+    pruneProviderConstraints(prompt);
     refreshSlash();
+  }
+
+  function pruneProviderConstraints(text: string) {
+    providerTokenConstraints = providerTokenConstraints.filter((c) => text.includes(c.token));
+  }
+
+  function providerForPick(cmd: SlashCommand, trigger: "/" | "$" | "@"): AgentProvider {
+    const providers = commandProviders(cmd);
+    if ((trigger === "$" || trigger === "@") && providers.includes("codex")) return "codex";
+    if (trigger === "/" && providers.includes("claude")) return "claude";
+    return providers[0] ?? agentProvider;
   }
 
   // Replace the typed `/query` token with the chosen command and hoist it to the
@@ -598,14 +623,54 @@
   // argument. Caret lands past `/name ` so the user can type arguments straight away.
   function pickCommand(cmd: SlashCommand) {
     const caret = promptInput?.selectionStart ?? prompt.length;
-    const start = matchSlashTrigger(prompt, caret)?.start ?? 0;
-    const next = applyCommandPick(prompt, start, caret, cmd.name);
+    const trigger = matchSlashTrigger(prompt, caret);
+    const start = trigger?.start ?? 0;
+    const pickedProvider = providerForPick(cmd, trigger?.trigger ?? "/");
+    agentProvider = pickedProvider;
+    const token = commandInvocation(cmd, pickedProvider);
+    const next =
+      pickedProvider === "codex"
+        ? applyMentionPick(prompt, start, caret, commandInvocationName(cmd))
+        : applyCommandPick(prompt, start, caret, commandInvocationName(cmd));
     prompt = next.value;
+    providerTokenConstraints = [
+      {
+        id: cmd.id ?? `${pickedProvider}:${cmd.name}`,
+        commandId: cmd.id,
+        token,
+        providers: commandProviders(cmd),
+        label: cmd.displayName ?? cmd.name,
+      },
+    ];
     slashOpen = false;
     queueMicrotask(() => {
       autogrow();
       promptInput?.focus();
       promptInput?.setSelectionRange(next.caret, next.caret);
+    });
+  }
+
+  function pickCommandFromSource(cmd: SlashCommand) {
+    const providers = commandProviders(cmd);
+    const provider = providers.includes(agentProvider)
+      ? agentProvider
+      : (providers[0] ?? agentProvider);
+    agentProvider = provider;
+    const token = commandInvocation(cmd, provider);
+    prompt = provider === "codex" ? `${token} ` : `${token} `;
+    providerTokenConstraints = [
+      {
+        id: cmd.id ?? `${provider}:${cmd.name}`,
+        commandId: cmd.id,
+        token,
+        providers,
+        label: cmd.displayName ?? cmd.name,
+      },
+    ];
+    queueMicrotask(() => {
+      autogrow();
+      promptInput?.focus();
+      promptInput?.setSelectionRange(prompt.length, prompt.length);
     });
   }
 
@@ -707,11 +772,27 @@
     submitting = true;
     error = null;
     retry = null;
+    const finalPrompt = prompt.trim();
+    pruneProviderConstraints(finalPrompt);
+    const incompatible = providerTokenConstraints.find(
+      (c) => finalPrompt.includes(c.token) && !c.providers.includes(agentProvider),
+    );
+    if (incompatible) {
+      submitting = false;
+      error = m.newtask_provider_constraint_error({
+        command: incompatible.label,
+        provider:
+          incompatible.providers[0] === "codex"
+            ? m.agent_provider_codex()
+            : m.agent_provider_claude(),
+      });
+      return;
+    }
     try {
       await onsubmit({
         repoPath: repoPath.trim(),
         baseBranch: baseBranch.trim() || "main",
-        prompt: prompt.trim(),
+        prompt: finalPrompt,
         agentProvider,
         model: model !== "default" ? model : null,
         effort: effort !== "default" ? effort : null,
@@ -970,6 +1051,7 @@
           <SlashCommandMenu
             commands={slashMatches}
             activeIndex={slashIndex}
+            provider={slashTrigger === "/" ? agentProvider : "codex"}
             onpick={pickCommand}
             onhover={(i) => (slashIndex = i)}
           />
@@ -1053,6 +1135,7 @@
               promptInput?.setSelectionRange(prompt.length, prompt.length);
             });
           }}
+          onpickcommand={pickCommandFromSource}
           onpickissue={pickIssue}
           onpicksteer={injectSteer}
         />
@@ -1107,6 +1190,7 @@
         {usageLimits}
         {relaunch}
         {fableAvailable}
+        providerConstraint={activeProviderConstraint}
       />
 
       {#if error}

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -625,6 +625,7 @@
     const caret = promptInput?.selectionStart ?? prompt.length;
     const trigger = matchSlashTrigger(prompt, caret);
     const start = trigger?.start ?? 0;
+    const providers = commandProviders(cmd);
     const pickedProvider = providerForPick(cmd, trigger?.trigger ?? "/");
     agentProvider = pickedProvider;
     const token = commandInvocation(cmd, pickedProvider);
@@ -633,15 +634,18 @@
         ? applyMentionPick(prompt, start, caret, commandInvocationName(cmd))
         : applyCommandPick(prompt, start, caret, commandInvocationName(cmd));
     prompt = next.value;
-    providerTokenConstraints = [
-      {
-        id: cmd.id ?? `${pickedProvider}:${cmd.name}`,
-        commandId: cmd.id,
-        token,
-        providers: commandProviders(cmd),
-        label: cmd.displayName ?? cmd.name,
-      },
-    ];
+    providerTokenConstraints =
+      providers.length === 1
+        ? [
+            {
+              id: cmd.id ?? `${pickedProvider}:${cmd.name}`,
+              commandId: cmd.id,
+              token,
+              providers,
+              label: cmd.displayName ?? cmd.name,
+            },
+          ]
+        : [];
     slashOpen = false;
     queueMicrotask(() => {
       autogrow();
@@ -657,16 +661,19 @@
       : (providers[0] ?? agentProvider);
     agentProvider = provider;
     const token = commandInvocation(cmd, provider);
-    prompt = provider === "codex" ? `${token} ` : `${token} `;
-    providerTokenConstraints = [
-      {
-        id: cmd.id ?? `${provider}:${cmd.name}`,
-        commandId: cmd.id,
-        token,
-        providers,
-        label: cmd.displayName ?? cmd.name,
-      },
-    ];
+    prompt = `${token} `;
+    providerTokenConstraints =
+      providers.length === 1
+        ? [
+            {
+              id: cmd.id ?? `${provider}:${cmd.name}`,
+              commandId: cmd.id,
+              token,
+              providers,
+              label: cmd.displayName ?? cmd.name,
+            },
+          ]
+        : [];
     queueMicrotask(() => {
       autogrow();
       promptInput?.focus();

--- a/ui/src/lib/components/PromptSources.browser.test.ts
+++ b/ui/src/lib/components/PromptSources.browser.test.ts
@@ -50,8 +50,18 @@ function issue(n: number): Issue {
   };
 }
 
-function command(n: number): SlashCommand {
-  return { name: `command-${n}`, description: `Description for command ${n}`, scope: "project" };
+function command(n: number, providers?: SlashCommand["providers"]): SlashCommand {
+  return {
+    name: `command-${n}`,
+    description: `Description for command ${n}`,
+    scope: "project",
+    providers,
+    invocations: providers
+      ? (Object.fromEntries(
+          providers.map((p) => [p, p === "codex" ? `$command-${n}` : `/command-${n}`]),
+        ) as SlashCommand["invocations"])
+      : undefined,
+  };
 }
 
 // Asserts the sticky .ps-filter-bar cleanly covers the rows scrolling behind it:
@@ -188,6 +198,32 @@ describe("PromptSources filter bar (popover + sticky coverage)", () => {
     expect(document.querySelector(".ps-body .ps-filter-bar .cmd-filter")).not.toBeNull();
 
     assertStickyCovers();
+  });
+
+  it("Commands tab: fallback picker uses a Codex invocation for Codex-only commands", async () => {
+    mockListIssues.mockResolvedValue({
+      slug: "owner/repo",
+      webUrl: null,
+      issues: [],
+      viewer: null,
+    });
+    mockGetCommands.mockResolvedValue({
+      commands: [command(1, ["codex"])],
+    });
+    const onpick = vi.fn();
+
+    render(PromptSources, { repoPath: "/repo", onpick, onpickissue: noop });
+
+    const commandsTab = [...document.querySelectorAll<HTMLButtonElement>(".tabs .tab")].find(
+      (b) => b.textContent?.trim() === m.promptsources_commands_tab(),
+    );
+    expect(commandsTab).toBeTruthy();
+    commandsTab!.click();
+
+    await expect.poll(() => document.querySelector(".ps-body .row")).not.toBeNull();
+    (document.querySelector(".ps-body .row") as HTMLButtonElement).click();
+
+    expect(onpick).toHaveBeenCalledWith("$command-1 ");
   });
 });
 

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -5,7 +5,7 @@
   import type { Issue, SlashCommand, Steer } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { labelChipStyle } from "$lib/label-color";
-  import { commandInvocation, commandProviders } from "$lib/slash";
+  import { commandInvocation, commandInvocationProvider, commandProviders } from "$lib/slash";
   import {
     hideOthers,
     hideActive,
@@ -380,7 +380,9 @@
             class="row"
             type="button"
             onclick={() =>
-              onpickcommand ? onpickcommand(c) : onpick(commandInvocation(c, "claude") + " ")}
+              onpickcommand
+                ? onpickcommand(c)
+                : onpick(commandInvocation(c, commandInvocationProvider(c)) + " ")}
           >
             <span class="row-marker">{marker(c)}</span>
             <span class="cmd-name">{c.name}</span>

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -5,6 +5,7 @@
   import type { Issue, SlashCommand, Steer } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { labelChipStyle } from "$lib/label-color";
+  import { commandInvocation, commandProviders } from "$lib/slash";
   import {
     hideOthers,
     hideActive,
@@ -28,6 +29,7 @@
   let {
     repoPath,
     onpick,
+    onpickcommand,
     onpickissue,
     onpicksteer = undefined,
     allowIssues = true,
@@ -37,6 +39,7 @@
   }: {
     repoPath: string;
     onpick: (prompt: string) => void;
+    onpickcommand?: (cmd: SlashCommand) => void;
     onpickissue: (issue: Issue) => void;
     /** Inject an issue-scoped steer into the composer (append + attach the issue),
      *  from the row's right-click / long-press context menu. Never spawns. */
@@ -297,6 +300,16 @@
     if (selectedLabels.has(label)) selectedLabels.delete(label);
     else selectedLabels.add(label);
   }
+
+  function providerBadge(cmd: SlashCommand): string {
+    const providers = commandProviders(cmd);
+    if (providers.length > 1) return m.provider_badge_both();
+    return providers[0] === "codex" ? m.provider_badge_codex() : m.provider_badge_claude();
+  }
+
+  function marker(cmd: SlashCommand): string {
+    return commandProviders(cmd).includes("claude") ? "/" : "$";
+  }
 </script>
 
 <div class="ps-wrap">
@@ -362,11 +375,17 @@
       {#if filteredCommands.length === 0}
         <div class="muted">{m.promptsources_no_commands()}</div>
       {:else}
-        {#each filteredCommands as c (c.scope + ":" + c.name)}
-          <button class="row" type="button" onclick={() => onpick("/" + c.name + " ")}>
-            <span class="row-marker">/</span>
+        {#each filteredCommands as c (c.id ?? c.scope + ":" + c.name)}
+          <button
+            class="row"
+            type="button"
+            onclick={() =>
+              onpickcommand ? onpickcommand(c) : onpick(commandInvocation(c, "claude") + " ")}
+          >
+            <span class="row-marker">{marker(c)}</span>
             <span class="cmd-name">{c.name}</span>
             <span class="row-text cmd-desc">{c.description}</span>
+            <span class="chip">{providerBadge(c)}</span>
             {#if c.scope === "user"}<span class="chip">user</span>{/if}
           </button>
         {/each}

--- a/ui/src/lib/components/SlashCommandMenu.browser.test.ts
+++ b/ui/src/lib/components/SlashCommandMenu.browser.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import "../../app.css";
+import type { SlashCommand } from "$lib/types";
+
+const { default: SlashCommandMenu } = await import("./SlashCommandMenu.svelte");
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+function command(name: string, providers: NonNullable<SlashCommand["providers"]>): SlashCommand {
+  return {
+    id: `test:${providers.join("+")}:${name}`,
+    name,
+    displayName: name,
+    description: "",
+    scope: "user",
+    kind: "skill",
+    invocationName: name,
+    sourceNamespace: "test",
+    providers,
+    invocations: Object.fromEntries(
+      providers.map((p) => [p, p === "codex" ? `$${name}` : `/${name}`]),
+    ) as SlashCommand["invocations"],
+  };
+}
+
+describe("SlashCommandMenu", () => {
+  it("shows a Codex invocation for a Codex-only row even under a Claude-preferred menu", () => {
+    render(SlashCommandMenu, {
+      commands: [command("codex-only", ["codex"])],
+      activeIndex: 0,
+      provider: "claude",
+      onpick: () => {},
+      onhover: () => {},
+    });
+
+    expect(document.querySelector(".sc-name")?.textContent).toBe("$codex-only");
+  });
+
+  it("keeps the preferred provider display for rows available in both providers", () => {
+    render(SlashCommandMenu, {
+      commands: [command("shared", ["claude", "codex"])],
+      activeIndex: 0,
+      provider: "claude",
+      onpick: () => {},
+      onhover: () => {},
+    });
+
+    expect(document.querySelector(".sc-name")?.textContent).toBe("/shared");
+  });
+});

--- a/ui/src/lib/components/SlashCommandMenu.svelte
+++ b/ui/src/lib/components/SlashCommandMenu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { SlashCommand } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
+  import { commandInvocation, commandProviders } from "$lib/slash";
 
   let {
     commands,
@@ -8,6 +9,7 @@
     onpick,
     onhover,
     placement = "down",
+    provider = "claude",
   }: {
     commands: SlashCommand[];
     activeIndex: number;
@@ -16,6 +18,7 @@
     // "down" anchors below the field (New Task modal); "up" anchors above it,
     // for the compose bar pinned to the bottom of the viewport.
     placement?: "up" | "down";
+    provider?: "claude" | "codex";
   } = $props();
 
   // Keep the highlighted row in view as the user arrows through the list.
@@ -24,6 +27,12 @@
     const row = listEl?.children[activeIndex] as HTMLElement | undefined;
     row?.scrollIntoView({ block: "nearest" });
   });
+
+  function providerBadge(cmd: SlashCommand): string {
+    const providers = commandProviders(cmd);
+    if (providers.length > 1) return m.provider_badge_both();
+    return providers[0] === "codex" ? m.provider_badge_codex() : m.provider_badge_claude();
+  }
 </script>
 
 <div class="sc-panel" class:up={placement === "up"} role="presentation">
@@ -31,7 +40,7 @@
     <div class="sc-empty">{m.slash_menu_empty()}</div>
   {:else}
     <ul class="sc-list" bind:this={listEl} role="listbox" aria-label={m.slash_menu_label()}>
-      {#each commands as cmd, i (cmd.scope + ":" + cmd.name)}
+      {#each commands as cmd, i (cmd.id ?? cmd.scope + ":" + cmd.name)}
         <li
           class="sc-row"
           class:active={i === activeIndex}
@@ -45,10 +54,11 @@
           onmousemove={() => onhover(i)}
         >
           <div class="sc-line">
-            <span class="sc-name">/{cmd.name}</span>
+            <span class="sc-name">{commandInvocation(cmd, provider)}</span>
             {#if cmd.argumentHint}<span class="sc-hint">{cmd.argumentHint}</span>{/if}
             <!-- raw source tag, matching the Commands-tab chip convention -->
             {#if cmd.scope !== "project"}<span class="sc-scope">{cmd.scope}</span>{/if}
+            <span class="sc-provider">{providerBadge(cmd)}</span>
           </div>
           {#if cmd.description}<div class="sc-desc">{cmd.description}</div>{/if}
         </li>
@@ -123,6 +133,14 @@
     text-transform: uppercase;
     color: var(--color-slate);
     border: 1px solid var(--color-faint);
+    border-radius: 2px;
+    padding: 0 4px;
+  }
+  .sc-provider {
+    flex-shrink: 0;
+    font-size: var(--fs-micro);
+    color: var(--color-muted);
+    border: 1px solid var(--color-line-bright);
     border-radius: 2px;
     padding: 0 4px;
   }

--- a/ui/src/lib/components/SlashCommandMenu.svelte
+++ b/ui/src/lib/components/SlashCommandMenu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { SlashCommand } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
-  import { commandInvocation, commandProviders } from "$lib/slash";
+  import { commandInvocation, commandInvocationProvider, commandProviders } from "$lib/slash";
 
   let {
     commands,
@@ -54,7 +54,9 @@
           onmousemove={() => onhover(i)}
         >
           <div class="sc-line">
-            <span class="sc-name">{commandInvocation(cmd, provider)}</span>
+            <span class="sc-name"
+              >{commandInvocation(cmd, commandInvocationProvider(cmd, provider))}</span
+            >
             {#if cmd.argumentHint}<span class="sc-hint">{cmd.argumentHint}</span>{/if}
             <!-- raw source tag, matching the Commands-tab chip convention -->
             {#if cmd.scope !== "project"}<span class="sc-scope">{cmd.scope}</span>{/if}

--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -8,11 +8,13 @@
   import { m } from "$lib/paraglide/messages";
   import SteerMenu from "$lib/components/SteerMenu.svelte";
   import ControlBar from "$lib/components/ControlBar.svelte";
-  import type { Steer } from "$lib/types";
+  import type { AgentProvider, Steer } from "$lib/types";
 
   let {
     focusedId,
     repoPath,
+    agentProvider = "claude",
+    onbroadcast,
     onretry,
     retryHaltedCount = 0,
     retryReady = false,
@@ -25,6 +27,8 @@
   }: {
     focusedId: string;
     repoPath: string;
+    agentProvider?: AgentProvider;
+    onbroadcast?: () => void;
     onretry?: () => void;
     retryHaltedCount?: number;
     retryReady?: boolean;
@@ -39,7 +43,9 @@
   // Only steer-bar-scoped entries render here; issue-scoped ones live on backlog rows.
   // Also gated to steers bound to this session's repo (or universal ones).
   const chips = $derived(
-    steers.list.filter((s) => s.inSteerBar && steerAppliesToRepo(s, repos.nameFor(repoPath))),
+    steers.list.filter(
+      (s) => s.inSteerBar && steerAppliesToRepo(s, repos.nameFor(repoPath), agentProvider),
+    ),
   );
 
   // One-time coachmark: the steer chips are tap-to-send — not obvious on first sight.
@@ -187,6 +193,19 @@
     aria-label={m.steerbar_toolbar_aria()}
     use:fitLabels
   >
+    {#if onbroadcast}
+      <button
+        type="button"
+        class="chip bc"
+        onpointerdown={down}
+        onpointermove={move}
+        onpointercancel={cancel}
+        onpointerup={(e) => tap(e, onbroadcast)}
+        title={m.steerbar_broadcast_aria()}
+        aria-label={m.steerbar_broadcast_aria()}
+        >⌁<span class="bc-label">{m.steerbar_broadcast()}</span></button
+      >
+    {/if}
     {#if retryReady && retryHaltedCount > 0}
       <button
         type="button"

--- a/ui/src/lib/components/SteerBar.svelte
+++ b/ui/src/lib/components/SteerBar.svelte
@@ -14,7 +14,6 @@
     focusedId,
     repoPath,
     agentProvider = "claude",
-    onbroadcast,
     onretry,
     retryHaltedCount = 0,
     retryReady = false,
@@ -28,7 +27,6 @@
     focusedId: string;
     repoPath: string;
     agentProvider?: AgentProvider;
-    onbroadcast?: () => void;
     onretry?: () => void;
     retryHaltedCount?: number;
     retryReady?: boolean;
@@ -193,19 +191,6 @@
     aria-label={m.steerbar_toolbar_aria()}
     use:fitLabels
   >
-    {#if onbroadcast}
-      <button
-        type="button"
-        class="chip bc"
-        onpointerdown={down}
-        onpointermove={move}
-        onpointercancel={cancel}
-        onpointerup={(e) => tap(e, onbroadcast)}
-        title={m.steerbar_broadcast_aria()}
-        aria-label={m.steerbar_broadcast_aria()}
-        >⌁<span class="bc-label">{m.steerbar_broadcast()}</span></button
-      >
-    {/if}
     {#if retryReady && retryHaltedCount > 0}
       <button
         type="button"

--- a/ui/src/lib/components/SteersEditor.svelte
+++ b/ui/src/lib/components/SteersEditor.svelte
@@ -9,7 +9,14 @@
   import EmojiPicker from "$lib/components/EmojiPicker.svelte";
   import SlashCommandMenu from "$lib/components/SlashCommandMenu.svelte";
   import { getCommands } from "$lib/api";
-  import { matchSlashTrigger, filterCommands, applyCommandPick } from "$lib/slash";
+  import {
+    matchSlashTrigger,
+    filterCommands,
+    applyCommandPick,
+    applyMentionPick,
+    commandInvocationName,
+    commandProviders,
+  } from "$lib/slash";
   import type { Steer, SlashCommand } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
 
@@ -45,6 +52,7 @@
   // at a time, so a single set of menu state covers the whole list).
   let slashFor = $state<string | null>(null);
   let slashQuery = $state("");
+  let slashTrigger = $state<"/" | "$" | "@">("/");
   let slashIndex = $state(0);
   // the textarea currently driving the menu, for caret reads + post-pick refocus
   let activeTa: HTMLTextAreaElement | null = null;
@@ -105,6 +113,7 @@
     if (trigger) {
       slashFor = s.id;
       slashQuery = trigger.query;
+      slashTrigger = trigger.trigger;
       slashIndex = 0;
     } else if (slashFor === s.id) {
       slashFor = null;
@@ -138,9 +147,21 @@
   function pickCommand(s: Steer, cmd: SlashCommand) {
     const ta = activeTa;
     const caret = ta?.selectionStart ?? s.text.length;
-    const start = matchSlashTrigger(s.text, caret)?.start ?? 0;
-    const next = applyCommandPick(s.text, start, caret, cmd.name);
+    const trigger = matchSlashTrigger(s.text, caret);
+    const start = trigger?.start ?? 0;
+    const providers = commandProviders(cmd);
+    const provider =
+      (trigger?.trigger === "$" || trigger?.trigger === "@") && providers.includes("codex")
+        ? "codex"
+        : providers.includes("claude")
+          ? "claude"
+          : providers[0]!;
+    const next =
+      provider === "codex"
+        ? applyMentionPick(s.text, start, caret, commandInvocationName(cmd))
+        : applyCommandPick(s.text, start, caret, commandInvocationName(cmd));
     s.text = next.value;
+    s.agentProviders = providers.length === 1 ? providers : undefined;
     slashFor = null;
     saved = false;
     queueMicrotask(() => {
@@ -307,6 +328,7 @@
             <SlashCommandMenu
               commands={slashMatches}
               activeIndex={slashIndex}
+              provider={slashTrigger === "/" ? "claude" : "codex"}
               placement="down"
               onpick={(cmd) => pickCommand(s, cmd)}
               onhover={(i) => (slashIndex = i)}

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -2957,7 +2957,6 @@
       focusedId={session.id}
       repoPath={session.repoPath}
       agentProvider={effectiveAgentProvider}
-      onbroadcast={() => onbroadcast?.()}
       onretry={() => onretry?.()}
       {retryHaltedCount}
       {retryReady}

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -448,6 +448,12 @@
   // bare shell with no affordance (the in-terminal overlay only shows once the PTY
   // closes for good). A verifiably-alive claude (server /proc sweep) hides it.
   const resumable = $derived(canResume(session, claudeAlive));
+  const effectiveAgentProvider = $derived(
+    session.agentProvider ??
+      (session as Session & { launch?: { agent?: { provider?: Session["agentProvider"] } } }).launch
+        ?.agent?.provider ??
+      "claude",
+  );
   // a11y: the fold button's aria-controls points at the tab switcher — the always-
   // mounted primary region it collapses (the git rail + build queue come and go with
   // the fold, so they can't carry a stable controlled-region id). Per-session id so
@@ -2950,6 +2956,8 @@
     <SteerBar
       focusedId={session.id}
       repoPath={session.repoPath}
+      agentProvider={effectiveAgentProvider}
+      onbroadcast={() => onbroadcast?.()}
       onretry={() => onretry?.()}
       {retryHaltedCount}
       {retryReady}
@@ -2987,6 +2995,7 @@
       onsend={sendComposed}
       onclose={() => (composeOpen = false)}
       repoPath={session.repoPath}
+      agentProvider={effectiveAgentProvider}
       startDictation={composeDictate}
     />
   {/if}

--- a/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
+++ b/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
@@ -10,6 +10,7 @@
     AGENT_PROVIDERS,
     CODEX_MODELS,
     type AgentProvider,
+    type ProviderTokenConstraint,
     type SandboxProfile,
     type UsageLimits,
   } from "$lib/types";
@@ -37,6 +38,7 @@
     relaunch,
     holdLikely,
     fableAvailable,
+    providerConstraint = null,
   }: {
     planGate: boolean;
     research: boolean;
@@ -60,6 +62,7 @@
     relaunch: boolean;
     holdLikely: boolean;
     fableAvailable: boolean;
+    providerConstraint?: ProviderTokenConstraint | null;
   } = $props();
 
   const provModels = $derived(providerModels(agentProvider));
@@ -69,6 +72,9 @@
   const modeLocked = $derived(research || epicAuthoring);
 
   function agentProviderChanged() {
+    if (providerConstraint && !providerConstraint.providers.includes(agentProvider)) {
+      agentProvider = providerConstraint.providers[0] ?? "claude";
+    }
     if (!modelAvailableForProvider(agentProvider, model, fableAvailable)) {
       model = agentProvider === "codex" ? CODEX_MODELS[0] : "default";
     }
@@ -227,12 +233,26 @@
       <label class="micro" for="nt-agent-provider">{m.newtask_agent_provider_label()}</label>
       <select id="nt-agent-provider" bind:value={agentProvider} onchange={agentProviderChanged}>
         {#each AGENT_PROVIDERS as provider (provider)}
-          <option value={provider}>
+          <option
+            value={provider}
+            disabled={!!providerConstraint && !providerConstraint.providers.includes(provider)}
+          >
             {provider === "claude" ? m.agent_provider_claude() : m.agent_provider_codex_alpha()}
           </option>
         {/each}
       </select>
       <ProviderCapacityGauge limits={usageLimits} />
+      {#if providerConstraint}
+        <p class="pg-hint">
+          {m.newtask_provider_constraint_note({
+            command: providerConstraint.label,
+            provider:
+              providerConstraint.providers[0] === "codex"
+                ? m.agent_provider_codex()
+                : m.agent_provider_claude(),
+          })}
+        </p>
+      {/if}
     </div>
 
     <div class="model-field" use:coachTarget={"model-1m-context"}>

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-provider-aware-skills.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-provider-aware-skills.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "provider-aware-skills",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_provider_aware_skills_title",
+  bodyKey: "feat_provider_aware_skills_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/slash.test.ts
+++ b/ui/src/lib/slash.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { matchSlashTrigger, filterCommands, applyCommandPick, applyMentionPick } from "./slash";
+import {
+  matchSlashTrigger,
+  filterCommands,
+  applyCommandPick,
+  applyMentionPick,
+  commandInvocationProvider,
+} from "./slash";
 import type { SlashCommand } from "./types";
 
 const cmd = (name: string, providers: SlashCommand["providers"] = ["claude"]): SlashCommand => ({
@@ -145,5 +151,16 @@ describe("filterCommands", () => {
   it("filters to the requested provider", () => {
     const rows = [cmd("claude-only", ["claude"]), cmd("codex-only", ["codex"])];
     expect(filterCommands(rows, "", "codex").map((c) => c.name)).toEqual(["codex-only"]);
+  });
+});
+
+describe("commandInvocationProvider", () => {
+  it("keeps a preferred provider when the row supports it", () => {
+    expect(commandInvocationProvider(cmd("shared", ["claude", "codex"]), "codex")).toBe("codex");
+    expect(commandInvocationProvider(cmd("shared", ["claude", "codex"]), "claude")).toBe("claude");
+  });
+
+  it("falls back to the row's actual provider when the preferred provider is incompatible", () => {
+    expect(commandInvocationProvider(cmd("codex-only", ["codex"]), "claude")).toBe("codex");
   });
 });

--- a/ui/src/lib/slash.test.ts
+++ b/ui/src/lib/slash.test.ts
@@ -1,24 +1,37 @@
 import { describe, it, expect } from "vitest";
-import { matchSlashTrigger, filterCommands, applyCommandPick } from "./slash";
+import { matchSlashTrigger, filterCommands, applyCommandPick, applyMentionPick } from "./slash";
 import type { SlashCommand } from "./types";
 
-const cmd = (name: string): SlashCommand => ({ name, description: "", scope: "user" });
+const cmd = (name: string, providers: SlashCommand["providers"] = ["claude"]): SlashCommand => ({
+  id: `test:${providers.join("+")}:${name}`,
+  name,
+  displayName: name,
+  description: "",
+  scope: "user",
+  kind: "skill",
+  invocationName: name,
+  sourceNamespace: `test:${providers.join("+")}`,
+  providers,
+  invocations: Object.fromEntries(
+    providers.map((p) => [p, p === "codex" ? `$${name}` : `/${name}`]),
+  ) as SlashCommand["invocations"],
+});
 
 describe("matchSlashTrigger", () => {
   it("triggers on a leading slash at the caret", () => {
-    expect(matchSlashTrigger("/cre", 4)).toEqual({ query: "cre", start: 0 });
+    expect(matchSlashTrigger("/cre", 4)).toEqual({ query: "cre", start: 0, trigger: "/" });
   });
 
   it("triggers with an empty query right after the slash", () => {
-    expect(matchSlashTrigger("/", 1)).toEqual({ query: "", start: 0 });
+    expect(matchSlashTrigger("/", 1)).toEqual({ query: "", start: 0, trigger: "/" });
   });
 
   it("triggers when the slash starts a token after a space (mid-text)", () => {
-    expect(matchSlashTrigger("fix /foo", 8)).toEqual({ query: "foo", start: 4 });
+    expect(matchSlashTrigger("fix /foo", 8)).toEqual({ query: "foo", start: 4, trigger: "/" });
   });
 
   it("triggers when the slash starts a token after a newline", () => {
-    expect(matchSlashTrigger("ctx\n/sha", 8)).toEqual({ query: "sha", start: 4 });
+    expect(matchSlashTrigger("ctx\n/sha", 8)).toEqual({ query: "sha", start: 4, trigger: "/" });
   });
 
   it("does not trigger once a space ends the command token", () => {
@@ -32,11 +45,34 @@ describe("matchSlashTrigger", () => {
 
   it("uses the text before the caret, not the whole string", () => {
     // caret sits inside the slash token even though more text follows
-    expect(matchSlashTrigger("/foobar", 4)).toEqual({ query: "foo", start: 0 });
+    expect(matchSlashTrigger("/foobar", 4)).toEqual({ query: "foo", start: 0, trigger: "/" });
   });
 
   it("does not trigger on empty input", () => {
     expect(matchSlashTrigger("", 0)).toBeNull();
+  });
+
+  it("triggers Codex skill mentions from dollar tokens", () => {
+    expect(matchSlashTrigger("use $front", 10)).toEqual({
+      query: "front",
+      start: 4,
+      trigger: "$",
+    });
+  });
+
+  it("triggers the Codex alias only for a bare at sign", () => {
+    expect(matchSlashTrigger("use @", 5)).toEqual({ query: "", start: 4, trigger: "@" });
+    expect(matchSlashTrigger("use @file", 9)).toBeNull();
+    expect(matchSlashTrigger("use @file.txt", 13)).toBeNull();
+    expect(matchSlashTrigger("use @dir/file", 13)).toBeNull();
+    expect(matchSlashTrigger("use @foo", 8)).toBeNull();
+  });
+
+  it("suppresses shell variable dollar tokens", () => {
+    expect(matchSlashTrigger("echo $HOME", 10)).toBeNull();
+    expect(matchSlashTrigger("echo ${HOME}", 12)).toBeNull();
+    expect(matchSlashTrigger("echo $1", 7)).toBeNull();
+    expect(matchSlashTrigger("echo $?", 7)).toBeNull();
   });
 });
 
@@ -68,6 +104,22 @@ describe("applyCommandPick", () => {
   });
 });
 
+describe("applyMentionPick", () => {
+  it("replaces a dollar query in place with the exact Codex mention", () => {
+    expect(applyMentionPick("use $fro please", 4, 8, "frontmatter-name")).toEqual({
+      value: "use $frontmatter-name please",
+      caret: 22,
+    });
+  });
+
+  it("replaces a bare at alias in place with a dollar mention", () => {
+    expect(applyMentionPick("use @", 4, 5, "frontmatter-name")).toEqual({
+      value: "use $frontmatter-name ",
+      caret: 22,
+    });
+  });
+});
+
 describe("filterCommands", () => {
   const list = [cmd("deploy"), cmd("create_plan"), cmd("git:commit"), cmd("review")];
 
@@ -88,5 +140,10 @@ describe("filterCommands", () => {
 
   it("drops non-matches", () => {
     expect(filterCommands(list, "zzz")).toEqual([]);
+  });
+
+  it("filters to the requested provider", () => {
+    const rows = [cmd("claude-only", ["claude"]), cmd("codex-only", ["codex"])];
+    expect(filterCommands(rows, "", "codex").map((c) => c.name)).toEqual(["codex-only"]);
   });
 });

--- a/ui/src/lib/slash.ts
+++ b/ui/src/lib/slash.ts
@@ -1,11 +1,28 @@
 import type { SlashCommand } from "./types";
 
+export type CommandTrigger = "/" | "$" | "@";
+
+export function commandProviders(command: SlashCommand): Array<"claude" | "codex"> {
+  return command.providers && command.providers.length > 0 ? command.providers : ["claude"];
+}
+
+export function commandInvocation(command: SlashCommand, provider: "claude" | "codex"): string {
+  return (
+    command.invocations?.[provider] ??
+    (provider === "codex" ? `$${command.name}` : `/${command.name}`)
+  );
+}
+
+export function commandInvocationName(command: SlashCommand): string {
+  return command.invocationName ?? command.name;
+}
+
 /**
- * Detect a slash-command trigger from the text up to the caret. A `/` triggers the
+ * Detect a command/skill trigger from the text up to the caret. `/` and `$` trigger the
  * picker when it begins a new token — at the very start of the prompt, or right after
  * whitespace/newline — followed by zero or more non-space chars up to the caret.
- * Returns the typed query (without the slash) and the index of the `/`, or null when
- * no trigger is active.
+ * Bare `@` opens Shepherd's Codex alias picker, but any non-empty `@...` token is
+ * left untouched for Codex native mentions.
  *
  * The `/` must start a token: `a/foo` (a path, a mid-word slash) does not trigger.
  * Claude only *runs* a slash command when it leads the prompt, so a command typed
@@ -22,11 +39,22 @@ import type { SlashCommand } from "./types";
 export function matchSlashTrigger(
   text: string,
   caret: number,
-): { query: string; start: number } | null {
+): { query: string; start: number; trigger: CommandTrigger } | null {
   const before = text.slice(0, Math.max(0, caret));
-  const m = /(^|\s)\/(\S*)$/.exec(before);
+  const m = /(^|\s)([/$@])(\S*)$/.exec(before);
   if (!m) return null;
-  return { query: m[2]!, start: m.index + m[1]!.length };
+  const trigger = m[2] as CommandTrigger;
+  const query = m[3]!;
+  if (trigger === "@" && query !== "") return null;
+  if (trigger === "$" && isShellVariableToken(query)) return null;
+  return { query, start: m.index + m[1]!.length, trigger };
+}
+
+function isShellVariableToken(query: string): boolean {
+  if (query === "") return false;
+  if (query.startsWith("{")) return true;
+  if (/^[0-9?@$*#!-]/.test(query)) return true;
+  return /^[A-Z_][A-Z0-9_]*/.test(query);
 }
 
 /**
@@ -50,17 +78,37 @@ export function applyCommandPick(
   return { value: lead + rest, caret: lead.length };
 }
 
+/** Replace a `$query` or bare `@` trigger token in place with a Codex `$name` mention. */
+export function applyMentionPick(
+  text: string,
+  start: number,
+  caret: number,
+  name: string,
+): { value: string; caret: number } {
+  const lead = text.slice(0, start);
+  const tail = text.slice(caret);
+  const token = `$${name} `;
+  return { value: lead + token + tail.replace(/^\s+/, ""), caret: lead.length + token.length };
+}
+
 /**
  * Filter commands by the typed query (case-insensitive). Empty query → all.
  * Prefix matches rank above mid-name substring matches; ties keep input order
  * (the list arrives already sorted by name).
  */
-export function filterCommands(commands: SlashCommand[], query: string): SlashCommand[] {
+export function filterCommands(
+  commands: SlashCommand[],
+  query: string,
+  provider?: "claude" | "codex",
+): SlashCommand[] {
   const q = query.toLowerCase();
-  if (!q) return commands;
+  const filtered = provider
+    ? commands.filter((c) => commandProviders(c).includes(provider))
+    : commands;
+  if (!q) return filtered;
   const prefix: SlashCommand[] = [];
   const substr: SlashCommand[] = [];
-  for (const c of commands) {
+  for (const c of filtered) {
     const name = c.name.toLowerCase();
     if (name.startsWith(q)) prefix.push(c);
     else if (name.includes(q)) substr.push(c);

--- a/ui/src/lib/slash.ts
+++ b/ui/src/lib/slash.ts
@@ -13,6 +13,15 @@ export function commandInvocation(command: SlashCommand, provider: "claude" | "c
   );
 }
 
+export function commandInvocationProvider(
+  command: SlashCommand,
+  preferred?: "claude" | "codex",
+): "claude" | "codex" {
+  const providers = commandProviders(command);
+  if (preferred && providers.includes(preferred)) return preferred;
+  return providers[0] ?? "claude";
+}
+
 export function commandInvocationName(command: SlashCommand): string {
   return command.invocationName ?? command.name;
 }

--- a/ui/src/lib/steer-scope.test.ts
+++ b/ui/src/lib/steer-scope.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { steerAppliesToRepo } from "./steer-scope";
 import type { Steer } from "./types";
 
-function makeSteer(repos?: string[]): Steer {
+function makeSteer(repos?: string[], agentProviders?: Steer["agentProviders"]): Steer {
   return {
     id: "s1",
     label: "test",
@@ -10,6 +10,7 @@ function makeSteer(repos?: string[]): Steer {
     inSteerBar: true,
     onIssues: false,
     ...(repos !== undefined ? { repos } : {}),
+    ...(agentProviders !== undefined ? { agentProviders } : {}),
   };
 }
 
@@ -34,5 +35,17 @@ describe("steerAppliesToRepo", () => {
 
   it("hidden (not universal) when repoName is null and allowlist is non-empty", () => {
     expect(steerAppliesToRepo(makeSteer(["alpha"]), null)).toBe(false);
+  });
+
+  it("matches provider-specific steers only for that provider", () => {
+    expect(steerAppliesToRepo(makeSteer(undefined, ["codex"]), "alpha", "codex")).toBe(true);
+    expect(steerAppliesToRepo(makeSteer(undefined, ["codex"]), "alpha", "claude")).toBe(false);
+  });
+
+  it("combines repo and provider constraints", () => {
+    const steer = makeSteer(["alpha"], ["claude"]);
+    expect(steerAppliesToRepo(steer, "alpha", "claude")).toBe(true);
+    expect(steerAppliesToRepo(steer, "alpha", "codex")).toBe(false);
+    expect(steerAppliesToRepo(steer, "beta", "claude")).toBe(false);
   });
 });

--- a/ui/src/lib/steer-scope.ts
+++ b/ui/src/lib/steer-scope.ts
@@ -4,7 +4,7 @@ import type { AgentProvider } from "./types";
 /** Does this steer apply to a repo, given the repo's resolved NAME (null when the
  *  repo can't be resolved / not loaded)? Empty/absent allowlist = universal. A
  *  non-empty allowlist with a null or non-member name = hidden (NOT universal). */
-export function steerApplies(
+function steerApplies(
   steer: Steer,
   { repoName, provider }: { repoName: string | null; provider?: AgentProvider },
 ): boolean {

--- a/ui/src/lib/steer-scope.ts
+++ b/ui/src/lib/steer-scope.ts
@@ -1,9 +1,26 @@
 import type { Steer } from "./types";
+import type { AgentProvider } from "./types";
 
 /** Does this steer apply to a repo, given the repo's resolved NAME (null when the
  *  repo can't be resolved / not loaded)? Empty/absent allowlist = universal. A
  *  non-empty allowlist with a null or non-member name = hidden (NOT universal). */
-export function steerAppliesToRepo(steer: Steer, repoName: string | null): boolean {
-  if (!steer.repos || steer.repos.length === 0) return true;
-  return repoName != null && steer.repos.includes(repoName);
+export function steerApplies(
+  steer: Steer,
+  { repoName, provider }: { repoName: string | null; provider?: AgentProvider },
+): boolean {
+  const repoOk =
+    !steer.repos ||
+    steer.repos.length === 0 ||
+    (repoName != null && steer.repos.includes(repoName));
+  if (!repoOk) return false;
+  if (!provider || !steer.agentProviders || steer.agentProviders.length === 0) return true;
+  return steer.agentProviders.includes(provider);
+}
+
+export function steerAppliesToRepo(
+  steer: Steer,
+  repoName: string | null,
+  provider?: AgentProvider,
+): boolean {
+  return steerApplies(steer, { repoName, provider });
 }

--- a/ui/src/lib/steers.svelte.ts
+++ b/ui/src/lib/steers.svelte.ts
@@ -6,7 +6,14 @@ import { getSteers, putSteers } from "./api";
  *  bar chip instead of vanishing from every surface. Mirrors the server normalize();
  *  emoji stays optional (server-side migration assigns legacy defaults). */
 function normalize(s: Steer & { inSteerBar?: boolean; onIssues?: boolean }): Steer {
-  return { ...s, inSteerBar: s.inSteerBar ?? true, onIssues: s.onIssues ?? false };
+  const agentProviders =
+    s.agentProviders && s.agentProviders.length === 1 ? s.agentProviders : undefined;
+  return {
+    ...s,
+    inSteerBar: s.inSteerBar ?? true,
+    onIssues: s.onIssues ?? false,
+    ...(agentProviders ? { agentProviders } : { agentProviders: undefined }),
+  };
 }
 
 // Client cache of the saved canned steers. Loaded once on app start; every

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -249,11 +249,27 @@ export interface IssueRef {
  *  "Commands" tab; picking one seeds the prompt with `/<name> `. */
 export type SlashCommandScope = "project" | "user" | "plugin" | "builtin";
 export interface SlashCommand {
+  id?: string;
   name: string;
+  displayName?: string;
   description: string;
   scope: SlashCommandScope;
+  kind?: "skill" | "command";
+  invocationName?: string;
+  sourceNamespace?: string;
+  sourcePath?: string;
+  providers?: AgentProvider[];
+  invocations?: Partial<Record<AgentProvider, string>>;
   /** Front-matter `argument-hint` (e.g. "<ticket>"), shown dimmed after the name. */
   argumentHint?: string;
+}
+
+export interface ProviderTokenConstraint {
+  id: string;
+  commandId?: string;
+  token: string;
+  providers: AgentProvider[];
+  label: string;
 }
 
 export type BlockShape = "menu" | "yes-no" | "awaiting-input" | "stall" | "quota";
@@ -1862,6 +1878,8 @@ export interface Steer {
   /** Allowlist of repo NAMES this steer is bound to (the dir name listRepos enumerates
    *  under repoRoot). Empty/absent = universal (shows on every repo). */
   repos?: string[];
+  /** Optional provider allowlist. Empty/absent = universal. */
+  agentProviders?: AgentProvider[];
 }
 
 // ── git diff review panel ──────────────────────────────────────────────────

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -997,6 +997,7 @@
         repoPath,
         baseBranch,
         prompt: cmd,
+        agentProvider: action.agentProviders?.length === 1 ? action.agentProviders[0] : undefined,
         model: null,
         force: true,
         issueRef: {


### PR DESCRIPTION
## Summary
- Adds provider-aware command/skill discovery and picker rows for Claude slash commands and direct Codex skills, including Codex config disables.
- Supports `/`, `$`, and bare `@` picker triggers, with Codex selections inserted as `$skill` and provider/model visibility in New Task.
- Filters command/steer choices across running-session surfaces and persists provider-aware saved steers.

## Tests
- `cd ui && bun run check:i18n && bun run check`
- `cd ui && bun run test`
- `bun run typecheck && bun run lint && bun run test && bun test src/commands.test.ts src/validate-steers.test.ts`
- `bun run check:announcement-versions`
- `bash scripts/check-feature-catalog.sh`
- `bash scripts/check-branch-hygiene.sh`

## Notes
- Codex plugin-distributed skill discovery and server-canonical provider/token guards remain out of this first user-visible slice; direct Codex skill roots are covered.
