### PR TITLE
feat(ui): right-click context menu on issue rows (open · details · inject steers)

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2948,5 +2948,13 @@
   "issues_filter_all_blocked": "Alle passenden Issues sind blockiert — zum Anzeigen ausschalten",
   "upnext_hide_blocked": "Blockierte Issues ausblenden",
   "feat_hide_blocked_toggle_title": "Blockierte Issues überall ausblenden",
-  "feat_hide_blocked_toggle_body": "Ein \"Blockierte Issues ausblenden\"-Schalter funktioniert jetzt einheitlich im Backlog, im Issue-Picker von Neue Aufgabe und in Als Nächstes — standardmäßig aktiv, blendet er jedes als blockiert markierte Issue aus."
+  "feat_hide_blocked_toggle_body": "Ein \"Blockierte Issues ausblenden\"-Schalter funktioniert jetzt einheitlich im Backlog, im Issue-Picker von Neue Aufgabe und in Als Nächstes — standardmäßig aktiv, blendet er jedes als blockiert markierte Issue aus.",
+  "issuemenu_aria": "Aktionen für Issue #{number}",
+  "issuemenu_open": "Issue öffnen",
+  "issuemenu_details": "Details anzeigen",
+  "issuemenu_inject_aria": "Steer einfügen: {label}",
+  "issuedetails_aria": "Details zu Issue #{number}",
+  "issuedetails_no_body": "Keine Beschreibung.",
+  "feat_issue_context_menu_title": "Rechtsklick auf ein Issue für Schnellaktionen",
+  "feat_issue_context_menu_body": "Rechtsklick (oder langes Drücken) auf ein Issue im New-Task-Dialog oder im Backlog öffnet es auf der Forge, zeigt eine Detailvorschau oder legt einen deiner Issue-Steers direkt in den Editor — vorausgefüllt und bereit zum Prüfen, nicht gestartet."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2948,5 +2948,13 @@
   "issues_filter_all_blocked": "All matching issues are blocked — toggle off to see them",
   "upnext_hide_blocked": "Hide blocked issues",
   "feat_hide_blocked_toggle_title": "Hide blocked issues, everywhere",
-  "feat_hide_blocked_toggle_body": "A \"Hide blocked issues\" toggle now works the same way across the backlog, New Task issue picker, and Up Next — on by default, it drops any issue labeled as blocked."
+  "feat_hide_blocked_toggle_body": "A \"Hide blocked issues\" toggle now works the same way across the backlog, New Task issue picker, and Up Next — on by default, it drops any issue labeled as blocked.",
+  "issuemenu_aria": "Actions for issue #{number}",
+  "issuemenu_open": "Open issue",
+  "issuemenu_details": "Show details",
+  "issuemenu_inject_aria": "Inject steer: {label}",
+  "issuedetails_aria": "Details for issue #{number}",
+  "issuedetails_no_body": "No description.",
+  "feat_issue_context_menu_title": "Right-click an issue for quick actions",
+  "feat_issue_context_menu_body": "Right-click (or long-press) an issue in the New Task dialog or the backlog to open it on the forge, preview its details, or drop one of your issue steers straight into the composer — pre-filled and ready to review, not launched."
 }

--- a/ui/src/lib/components/BacklogOverlay.svelte
+++ b/ui/src/lib/components/BacklogOverlay.svelte
@@ -9,6 +9,7 @@
     mobile,
     onissue,
     onquick = undefined,
+    oninject = undefined,
     onpr,
     onadopt,
     onlaunchtrain,
@@ -26,6 +27,7 @@
     mobile: boolean;
     onissue: (repoPath: string, issue: Issue) => void;
     onquick?: (repoPath: string, issue: Issue, action: Steer) => void;
+    oninject?: (repoPath: string, issue: Issue, steer: Steer) => void;
     onpr: (repoPath: string, pr: PullRequest) => void;
     onadopt: (repoPath: string, prompt: string) => void;
     onlaunchtrain: (repoPath: string, prs: PullRequest[]) => void;
@@ -77,6 +79,7 @@
         {mobile}
         {onissue}
         {onquick}
+        {oninject}
         {onpr}
         {onadopt}
         {onlaunchtrain}

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -26,6 +26,7 @@
     mobile,
     onissue,
     onquick = undefined,
+    oninject = undefined,
     onpr,
     onadopt,
     onlaunchtrain,
@@ -52,6 +53,9 @@
     /** Quick-launch an issue with the configured standard command, skipping the
      *  New Task dialog. Omitted → no quick button is shown on the issues. */
     onquick?: (repoPath: string, issue: Issue, action: Steer) => void;
+    /** Inject an issue steer: open the New Task dialog pre-seeded with the steer's
+     *  prompt + the issue attached (does NOT spawn). Omitted → no steer items. */
+    oninject?: (repoPath: string, issue: Issue, steer: Steer) => void;
     /** Open a review task seeded with a PR (PRs tab → New Task). */
     onpr: (repoPath: string, pr: PullRequest) => void;
     /** Seed a New Task with the AI-readiness install prescription (Readiness tab). */
@@ -366,6 +370,7 @@
             {selectedPath}
             {onissue}
             {onquick}
+            {oninject}
             {onpr}
             {onlaunchtrain}
             {onadopt}

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -433,6 +433,7 @@
               {selectedPath}
               {onissue}
               {onquick}
+              {oninject}
               {onpr}
               {onlaunchtrain}
               {onadopt}

--- a/ui/src/lib/components/IssueContextMenu.browser.test.ts
+++ b/ui/src/lib/components/IssueContextMenu.browser.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import type { Issue, Steer } from "$lib/types";
+import { m } from "$lib/paraglide/messages";
+import IssueContextMenu from "./IssueContextMenu.svelte";
+import IssueDetailsPopover from "./IssueDetailsPopover.svelte";
+
+// A real, connected opener: the menu/popover measure their rect for positioning and
+// restore focus to it on close.
+let opener: HTMLButtonElement;
+beforeEach(() => {
+  opener = document.createElement("button");
+  opener.textContent = "opener";
+  document.body.appendChild(opener);
+});
+afterEach(() => {
+  opener.remove();
+  document.body.innerHTML = "";
+});
+
+function steer(id: string, label: string): Steer {
+  return { id, label, text: `run ${label}`, inSteerBar: false, onIssues: true };
+}
+
+function issue(n: number): Issue {
+  return {
+    number: n,
+    title: `Issue ${n}`,
+    body: "The full issue body text.",
+    url: `https://example.com/issues/${n}`,
+    labels: ["bug", "p2"],
+    createdAt: 0,
+    assignees: [],
+    author: "alice",
+  };
+}
+
+const menuBase = (extra: Record<string, unknown> = {}) => ({
+  x: 10,
+  y: 10,
+  number: 42,
+  steers: [] as Steer[],
+  canSteer: true,
+  opener,
+  onopenissue: vi.fn(),
+  ondetails: vi.fn(),
+  onsteer: vi.fn(),
+  onclose: vi.fn(),
+  ...extra,
+});
+
+describe("IssueContextMenu", () => {
+  it("always renders Open issue + Show details, and fires their callbacks", async () => {
+    const onopenissue = vi.fn();
+    const ondetails = vi.fn();
+    render(IssueContextMenu, { props: menuBase({ onopenissue, ondetails }) });
+
+    await page.getByRole("menuitem", { name: m.issuemenu_open() }).click();
+    expect(onopenissue).toHaveBeenCalledTimes(1);
+
+    await page.getByRole("menuitem", { name: m.issuemenu_details() }).click();
+    expect(ondetails).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders one item per steer (canSteer) and fires onsteer with that steer", async () => {
+    const onsteer = vi.fn();
+    const s = steer("s1", "Fix");
+    render(IssueContextMenu, { props: menuBase({ steers: [s], canSteer: true, onsteer }) });
+
+    await page.getByRole("menuitem", { name: m.issuemenu_inject_aria({ label: "Fix" }) }).click();
+    expect(onsteer).toHaveBeenCalledExactlyOnceWith(s);
+  });
+
+  it("hides steer items when canSteer is false (epic-parent rows)", async () => {
+    render(IssueContextMenu, {
+      props: menuBase({ steers: [steer("s1", "Fix")], canSteer: false }),
+    });
+    // Open + Details still there, but no steer item.
+    expect(page.getByRole("menuitem", { name: m.issuemenu_open() }).query()).not.toBeNull();
+    expect(
+      page.getByRole("menuitem", { name: m.issuemenu_inject_aria({ label: "Fix" }) }).query(),
+    ).toBeNull();
+  });
+
+  it("Escape closes it AND preventDefaults, so a11yDialog (checks defaultPrevented) won't also close", async () => {
+    const onclose = vi.fn();
+    render(IssueContextMenu, { props: menuBase({ onclose }) });
+
+    const ev = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true });
+    window.dispatchEvent(ev);
+
+    expect(onclose).toHaveBeenCalledTimes(1);
+    // preventDefault ran: a11yDialog's Escape handler returns early on defaultPrevented,
+    // so the host New Task dialog / backlog overlay does NOT close.
+    expect(ev.defaultPrevented).toBe(true);
+  });
+});
+
+const popBase = (extra: Record<string, unknown> = {}) => ({
+  x: 10,
+  y: 10,
+  issue: issue(42),
+  opener,
+  onclose: vi.fn(),
+  ...extra,
+});
+
+describe("IssueDetailsPopover", () => {
+  it("renders number, author, title, labels and body", async () => {
+    render(IssueDetailsPopover, { props: popBase() });
+    const pop = document.querySelector(".issue-details")!;
+    expect(pop.textContent).toContain("#42");
+    expect(pop.textContent).toContain("Issue 42");
+    expect(pop.textContent).toContain("The full issue body text.");
+    expect(pop.querySelectorAll(".id-chip").length).toBe(2);
+  });
+
+  it("shows a no-description note when the body is empty", async () => {
+    render(IssueDetailsPopover, { props: popBase({ issue: { ...issue(7), body: "" } }) });
+    expect(document.querySelector(".issue-details")!.textContent).toContain(
+      m.issuedetails_no_body(),
+    );
+  });
+
+  it("Escape closes it AND preventDefaults (a11yDialog-safe)", async () => {
+    const onclose = vi.fn();
+    render(IssueDetailsPopover, { props: popBase({ onclose }) });
+    const ev = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true });
+    window.dispatchEvent(ev);
+    expect(onclose).toHaveBeenCalledTimes(1);
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it("scrolling its OWN body does not dismiss it; scrolling behind it does", async () => {
+    const onclose = vi.fn();
+    render(IssueDetailsPopover, { props: popBase({ onclose }) });
+    const body = document.querySelector(".issue-details .id-body")!;
+
+    // Scroll originating inside the popover body → guarded, stays open.
+    body.dispatchEvent(new Event("scroll", { bubbles: true }));
+    expect(onclose).not.toHaveBeenCalled();
+
+    // Scroll behind it (the list moving) → dismiss.
+    document.body.dispatchEvent(new Event("scroll", { bubbles: true }));
+    expect(onclose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/lib/components/IssueContextMenu.svelte
+++ b/ui/src/lib/components/IssueContextMenu.svelte
@@ -1,0 +1,204 @@
+<script lang="ts">
+  import type { Steer } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+
+  // Small anchored, non-blocking context menu for an issue row (desktop right-click
+  // or touch long-press, both via issueMenuTrigger). Per the design system's popover
+  // rule it gets NO scrim/blur — it dismisses on outside-click, Esc or scroll.
+  // Modelled on CardMenu/SteerMenu, with one critical difference: it renders INSIDE
+  // a11yDialog modals (NewTask, BacklogOverlay), so its Escape handler runs in
+  // CAPTURE phase and preventDefault()s — otherwise a11yDialog (which yields only on
+  // defaultPrevented, and listens on an ancestor node in the bubble phase) would also
+  // close the host dialog and lose the composed prompt.
+  let {
+    x,
+    y,
+    number,
+    steers,
+    canSteer,
+    opener,
+    onopenissue,
+    ondetails,
+    onsteer,
+    onclose,
+  }: {
+    // viewport coordinates of the right-click / long-press that opened the menu
+    x: number;
+    y: number;
+    // the issue number, woven into the menu's accessible name
+    number: number;
+    // issue-scoped steers to offer as inject actions
+    steers: Steer[];
+    // false for epic-parent rows → the steer items are omitted (launching an epic
+    // via a manual task collides with the Epic Runner)
+    canSteer: boolean;
+    // the row that opened the menu — focus returns here on close
+    opener?: HTMLElement;
+    onopenissue: () => void;
+    ondetails: () => void;
+    onsteer: (steer: Steer) => void;
+    onclose: () => void;
+  } = $props();
+
+  let el = $state<HTMLDivElement>();
+
+  // Clamp the menu inside the viewport so it never spills off the bottom/right edge.
+  // Measured after mount; until then the template falls back to the raw pointer (x/y).
+  let pos = $state<{ left: number; top: number } | null>(null);
+  $effect(() => {
+    const node = el;
+    if (!node) return;
+    const r = node.getBoundingClientRect();
+    const margin = 8;
+    const left = Math.min(x, window.innerWidth - r.width - margin);
+    const top = Math.min(y, window.innerHeight - r.height - margin);
+    pos = { left: Math.max(margin, left), top: Math.max(margin, top) };
+    items()[0]?.focus(); // open with the first item focused, per the menu pattern
+  });
+
+  function items(): HTMLButtonElement[] {
+    return el ? Array.from(el.querySelectorAll<HTMLButtonElement>(".im-item")) : [];
+  }
+  // Arrow / Home / End roving focus; Tab is trapped (cycled) so focus can't escape.
+  function onNav(e: KeyboardEvent) {
+    const list = items();
+    if (list.length === 0) return;
+    const i = list.indexOf(document.activeElement as HTMLButtonElement);
+    const fwd = (i + 1) % list.length;
+    const back = (i - 1 + list.length) % list.length;
+    let next: number;
+    if (e.key === "ArrowDown") next = fwd;
+    else if (e.key === "ArrowUp") next = back;
+    else if (e.key === "Home") next = 0;
+    else if (e.key === "End") next = list.length - 1;
+    else if (e.key === "Tab") next = e.shiftKey ? back : fwd;
+    else return;
+    e.preventDefault();
+    list[next]!.focus();
+  }
+
+  $effect(() => {
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      // Capture phase + preventDefault + stopPropagation: beat a11yDialog's ancestor
+      // (bubble-phase) Escape handler so Esc closes only this menu, not the host dialog.
+      e.preventDefault();
+      e.stopPropagation();
+      onclose();
+    }
+    function onPointer(e: Event) {
+      if (el && !el.contains(e.target as Node)) onclose();
+    }
+    window.addEventListener("keydown", onKeydown, { capture: true });
+    // capture so we beat the row's own handlers; scroll dismisses (the anchor moves)
+    window.addEventListener("pointerdown", onPointer, true);
+    window.addEventListener("scroll", onclose, true);
+    return () => {
+      window.removeEventListener("keydown", onKeydown, { capture: true });
+      window.removeEventListener("pointerdown", onPointer, true);
+      window.removeEventListener("scroll", onclose, true);
+      // Return focus to the opener once the menu unmounts, but only when focus fell to
+      // <body> — an action that moved focus elsewhere (into the details popover, into
+      // the prompt textarea) keeps it.
+      const target = opener;
+      queueMicrotask(() => {
+        if (target?.isConnected && document.activeElement === document.body) target.focus();
+      });
+    };
+  });
+</script>
+
+<div
+  bind:this={el}
+  class="issue-menu"
+  role="menu"
+  tabindex="-1"
+  aria-label={m.issuemenu_aria({ number })}
+  style="left:{pos?.left ?? x}px;top:{pos?.top ?? y}px"
+  onkeydown={onNav}
+>
+  <button class="im-item" type="button" role="menuitem" tabindex="-1" onclick={onopenissue}>
+    <span class="im-icon" aria-hidden="true">↗</span>{m.issuemenu_open()}
+  </button>
+  <button class="im-item" type="button" role="menuitem" tabindex="-1" onclick={ondetails}>
+    <span class="im-icon" aria-hidden="true">≡</span>{m.issuemenu_details()}
+  </button>
+  {#if canSteer && steers.length > 0}
+    <div class="im-sep" role="separator"></div>
+    {#each steers as s (s.id)}
+      <button
+        class="im-item"
+        type="button"
+        role="menuitem"
+        tabindex="-1"
+        title={s.text}
+        aria-label={m.issuemenu_inject_aria({ label: s.label })}
+        onclick={() => onsteer(s)}
+      >
+        <span class="im-icon" aria-hidden="true">{s.emoji ?? "▷"}</span><span class="im-label"
+          >{s.label}</span
+        >
+      </button>
+    {/each}
+  {/if}
+</div>
+
+<style>
+  .issue-menu {
+    position: fixed;
+    z-index: 60;
+    min-width: 180px;
+    max-width: calc(100vw - 16px);
+    padding: 4px;
+    background: var(--color-panel);
+    border: 1px solid var(--color-line-bright);
+    border-radius: 3px;
+    /* established popover shadow (matches CardMenu/SteerMenu) — no token exists */
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+  .issue-menu:focus {
+    outline: none;
+  }
+  .im-item {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    width: 100%;
+    padding: 8px 11px;
+    border: 0;
+    border-radius: 2px;
+    background: transparent;
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: var(--fs-base);
+    text-align: left;
+    cursor: pointer;
+  }
+  .im-item:hover,
+  .im-item:focus-visible {
+    background: var(--color-hover);
+    outline: none;
+  }
+  .im-icon {
+    font-size: var(--fs-meta);
+    width: 1em;
+    text-align: center;
+    flex-shrink: 0;
+  }
+  /* Steer label — the steer's text rides in the title/aria; cap a long label so the
+     menu keeps a sane width. */
+  .im-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+  .im-sep {
+    height: 1px;
+    margin: 3px 6px;
+    background: var(--color-line);
+  }
+</style>

--- a/ui/src/lib/components/IssueDetailsPopover.svelte
+++ b/ui/src/lib/components/IssueDetailsPopover.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+  import type { Issue } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+  import { relativeAge } from "$lib/format";
+  import { clock } from "$lib/now.svelte";
+
+  // Small anchored, non-blocking preview of an issue — a "little more" than the row
+  // shows: number · author · age, title, all labels, and the body (plain text,
+  // scrollable). Per the design system's popover rule it gets NO scrim/blur — it
+  // dismisses on outside-click, Esc or ANCESTOR scroll. Escape is intercepted in
+  // capture phase + preventDefault so a11yDialog (NewTask / BacklogOverlay) doesn't
+  // also close the host dialog.
+  let {
+    x,
+    y,
+    issue,
+    opener,
+    onclose,
+  }: {
+    x: number;
+    y: number;
+    issue: Issue;
+    // the row that opened the popover — focus returns here on close
+    opener?: HTMLElement;
+    onclose: () => void;
+  } = $props();
+
+  let el = $state<HTMLDivElement>();
+
+  let pos = $state<{ left: number; top: number } | null>(null);
+  $effect(() => {
+    const node = el;
+    if (!node) return;
+    const r = node.getBoundingClientRect();
+    const margin = 8;
+    const left = Math.min(x, window.innerWidth - r.width - margin);
+    const top = Math.min(y, window.innerHeight - r.height - margin);
+    pos = { left: Math.max(margin, left), top: Math.max(margin, top) };
+    node.focus(); // take focus so Esc is caught here and returns to the opener on close
+  });
+
+  $effect(() => {
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      e.stopPropagation();
+      onclose();
+    }
+    function onPointer(e: Event) {
+      if (el && !el.contains(e.target as Node)) onclose();
+    }
+    function onScroll(e: Event) {
+      // Ignore scrolls that originate INSIDE the popover — its own body scrolls when
+      // the issue body is long, and that must NOT dismiss it. Only ancestor/anchor
+      // scroll (the list behind it moving) closes it.
+      if (el?.contains(e.target as Node)) return;
+      onclose();
+    }
+    window.addEventListener("keydown", onKeydown, { capture: true });
+    window.addEventListener("pointerdown", onPointer, true);
+    window.addEventListener("scroll", onScroll, true);
+    return () => {
+      window.removeEventListener("keydown", onKeydown, { capture: true });
+      window.removeEventListener("pointerdown", onPointer, true);
+      window.removeEventListener("scroll", onScroll, true);
+      const target = opener;
+      queueMicrotask(() => {
+        if (target?.isConnected && document.activeElement === document.body) target.focus();
+      });
+    };
+  });
+</script>
+
+<div
+  bind:this={el}
+  class="issue-details"
+  role="dialog"
+  tabindex="-1"
+  aria-label={m.issuedetails_aria({ number: issue.number })}
+  style="left:{pos?.left ?? x}px;top:{pos?.top ?? y}px"
+>
+  <div class="id-head">
+    <span class="id-num">#{issue.number}</span>
+    {#if issue.author}
+      <span class="id-author">{m.issuerow_author_by({ login: issue.author })}</span>
+    {/if}
+    <span class="id-age">{relativeAge(issue.createdAt, clock.current)}</span>
+  </div>
+  <div class="id-title">{issue.title}</div>
+  {#if issue.labels.length > 0}
+    <div class="id-labels">
+      {#each issue.labels as label (label)}
+        <span class="id-chip">{label}</span>
+      {/each}
+    </div>
+  {/if}
+  <div class="id-body">
+    {#if issue.body?.trim()}
+      {issue.body}
+    {:else}
+      <span class="id-empty">{m.issuedetails_no_body()}</span>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .issue-details {
+    position: fixed;
+    z-index: 60;
+    width: min(360px, calc(100vw - 16px));
+    padding: 10px 12px;
+    background: var(--color-panel);
+    border: 1px solid var(--color-line-bright);
+    border-radius: 3px;
+    /* established popover shadow (matches CardMenu/SteerMenu) — no token exists */
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-family: var(--font-mono);
+  }
+  .issue-details:focus {
+    outline: none;
+  }
+  .id-head {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 8px;
+    font-size: var(--fs-micro);
+    color: var(--color-faint);
+  }
+  .id-num {
+    color: var(--color-muted);
+  }
+  .id-author {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 20ch;
+  }
+  .id-title {
+    font-size: var(--fs-base);
+    color: var(--color-ink-bright);
+    line-height: 1.4;
+    word-break: break-word;
+  }
+  .id-labels {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+  .id-chip {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    padding: 1px 5px;
+  }
+  .id-body {
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    line-height: 1.45;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 40vh;
+    overflow-y: auto;
+    border-top: 1px solid var(--color-line);
+    padding-top: 6px;
+  }
+  .id-body::-webkit-scrollbar {
+    width: 4px;
+  }
+  .id-body::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .id-body::-webkit-scrollbar-thumb {
+    background: var(--color-faint);
+    border-radius: 2px;
+  }
+  .id-empty {
+    color: var(--color-faint);
+    font-style: italic;
+  }
+</style>

--- a/ui/src/lib/components/IssueMenuLayer.svelte
+++ b/ui/src/lib/components/IssueMenuLayer.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import type { Issue, Steer } from "$lib/types";
+  import IssueContextMenu from "./IssueContextMenu.svelte";
+  import IssueDetailsPopover from "./IssueDetailsPopover.svelte";
+
+  // Renders an issue row's right-click context menu + details preview from the
+  // parent's menu/details state. Extracted from IssueRow and PromptSources so
+  // neither host template carries the two {#if} branches (which push their
+  // synthetic <template> over the fallow Tier-1 complexity bar) and the menu +
+  // popover wiring lives in one place instead of being duplicated per host.
+  let {
+    menu,
+    details,
+    steers,
+    onopenissue,
+    onshowdetails,
+    onsteer,
+    onclosemenu,
+    onclosedetails,
+  }: {
+    menu: { issue: Issue; x: number; y: number; opener: HTMLElement; canSteer: boolean } | null;
+    details: { issue: Issue; x: number; y: number; opener: HTMLElement } | null;
+    steers: Steer[];
+    onopenissue: () => void;
+    onshowdetails: () => void;
+    onsteer: (steer: Steer) => void;
+    onclosemenu: () => void;
+    onclosedetails: () => void;
+  } = $props();
+</script>
+
+{#if menu}
+  <IssueContextMenu
+    x={menu.x}
+    y={menu.y}
+    number={menu.issue.number}
+    {steers}
+    canSteer={menu.canSteer}
+    opener={menu.opener}
+    {onopenissue}
+    ondetails={onshowdetails}
+    {onsteer}
+    onclose={onclosemenu}
+  />
+{/if}
+{#if details}
+  <IssueDetailsPopover
+    x={details.x}
+    y={details.y}
+    issue={details.issue}
+    opener={details.opener}
+    onclose={onclosedetails}
+  />
+{/if}

--- a/ui/src/lib/components/IssuesPanel.browser.test.ts
+++ b/ui/src/lib/components/IssuesPanel.browser.test.ts
@@ -1320,3 +1320,82 @@ describe("IssuesPanel soft refresh (backlogRefresh)", () => {
       .toBeInTheDocument();
   });
 });
+
+describe("IssuesPanel issue context menu (inject steer, Surface B)", () => {
+  const issueSteer: Steer = {
+    id: "st1",
+    label: "Fix it",
+    text: "/fix please",
+    inSteerBar: false,
+    onIssues: true,
+  };
+  beforeEach(() => {
+    steers.list = [issueSteer];
+  });
+  afterEach(() => {
+    steers.list = [];
+  });
+
+  async function renderWithIssue(extra: Record<string, unknown>) {
+    mockListIssues.mockResolvedValue({
+      slug: "o/r",
+      webUrl: null,
+      viewer: null,
+      issues: [
+        {
+          number: 55,
+          title: "Add widget",
+          body: "the widget body",
+          url: "https://gh/o/r/issues/55",
+          labels: [],
+          createdAt: 0,
+          assignees: [],
+          author: "bob",
+        },
+      ],
+    });
+    mockGetEpics.mockResolvedValue({ epics: [], subIssues: [] });
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop, ...extra });
+    await expect.poll(() => document.querySelector(".issue-row")).not.toBeNull();
+  }
+
+  // A mouse pointerdown pins lastPointerType away from "touch" so the contextmenu opens.
+  function rightClickRow() {
+    const row = document.querySelector<HTMLElement>(".issue-row")!;
+    window.dispatchEvent(new PointerEvent("pointerdown", { pointerType: "mouse" }));
+    row.dispatchEvent(
+      new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 20, clientY: 20 }),
+    );
+  }
+
+  it("picking a steer calls oninject(issue, steer) once — opens the dialog pre-seeded, no spawn", async () => {
+    const oninject = vi.fn();
+    const onquick = vi.fn();
+    const onnewtask = vi.fn();
+    await renderWithIssue({ oninject, onquick, onnewtask });
+
+    rightClickRow();
+    await expect.poll(() => document.querySelector(".issue-menu")).not.toBeNull();
+    await page
+      .getByRole("menuitem", { name: m.issuemenu_inject_aria({ label: "Fix it" }) })
+      .click();
+
+    // The page handler seeds composeIssue/composePrompt + showNew from exactly these args.
+    expect(oninject).toHaveBeenCalledTimes(1);
+    expect(oninject).toHaveBeenCalledWith(expect.objectContaining({ number: 55 }), issueSteer);
+    // Inject != execute: neither the quick-launch (spawn) nor the +Task path fired.
+    expect(onquick).not.toHaveBeenCalled();
+    expect(onnewtask).not.toHaveBeenCalled();
+  });
+
+  it("omits steer items when oninject is not provided (Open + Details still shown)", async () => {
+    await renderWithIssue({}); // no oninject
+    rightClickRow();
+    await expect.poll(() => document.querySelector(".issue-menu")).not.toBeNull();
+
+    expect(page.getByRole("menuitem", { name: m.issuemenu_open() }).query()).not.toBeNull();
+    expect(
+      page.getByRole("menuitem", { name: m.issuemenu_inject_aria({ label: "Fix it" }) }).query(),
+    ).toBeNull();
+  });
+});

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -34,6 +34,7 @@
     repoPath,
     onnewtask,
     onquick = undefined,
+    oninject = undefined,
     bodyPreview = false,
     age = false,
     epics = undefined,
@@ -45,6 +46,9 @@
     /** Quick-launch: spawn a session with the picked issue action's prompt + this
      *  issue, skipping the New Task dialog. Omitted → no action buttons are shown. */
     onquick?: (issue: Issue, action: Steer) => void;
+    /** Inject an issue steer into the New Task dialog (pre-seed prompt + attach issue,
+     *  no spawn), from the row's right-click / long-press menu. Omitted → no steer items. */
+    oninject?: (issue: Issue, steer: Steer) => void;
     bodyPreview?: boolean;
     age?: boolean;
     /** Live epic record from the store, keyed `${repoPath}#${parentIssueNumber}`.
@@ -555,6 +559,7 @@
           {issueActions}
           {onnewtask}
           {onquick}
+          {oninject}
           ontoggleepic={toggleEpic}
         />
       {/each}

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -3,9 +3,10 @@ import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
 import { overwriteGetLocale } from "$lib/paraglide/runtime";
-import type { Issue, RepoConfig, RepoEntry } from "$lib/types";
+import type { Issue, RepoConfig, RepoEntry, Steer } from "$lib/types";
 import type { UsageLimits } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
+import { steers } from "$lib/steers.svelte";
 import {
   listIssues,
   getEpics,
@@ -1883,5 +1884,113 @@ describe("NewTask — hidden repos excluded from keyboard selection paths", () =
     // Backward enters at the LAST visible repo.
     altChord("BracketLeft");
     await expect.poll(() => selectedRepo()).toBe("vis2");
+  });
+});
+
+describe("NewTask issue steer inject (context menu)", () => {
+  const issueSteer: Steer = {
+    id: "st1",
+    label: "Fix it",
+    text: "/fix please",
+    inSteerBar: false,
+    onIssues: true,
+  };
+
+  beforeEach(() => {
+    steers.list = [issueSteer];
+    mockListIssues.mockResolvedValue({
+      slug: "o/r",
+      webUrl: "https://gh/o/r",
+      viewer: null,
+      issues: [
+        {
+          number: 55,
+          title: "Add widget",
+          body: "the widget body",
+          url: "https://gh/o/r/issues/55",
+          labels: [],
+          createdAt: 0,
+          assignees: [],
+          author: "bob",
+        },
+      ],
+    });
+  });
+  afterEach(() => {
+    steers.list = [];
+  });
+
+  // Right-click the (only) issue row and wait for the context menu to open. A mouse
+  // pointerdown first pins lastPointerType away from "touch" so the contextmenu opens.
+  async function openIssueMenu() {
+    await page.getByRole("button", { name: m.promptsources_issues_tab(), exact: true }).click();
+    await expect.poll(() => document.querySelectorAll(".ps-body .row").length).toBe(1);
+    const row = document.querySelector<HTMLElement>(".ps-body .row")!;
+    window.dispatchEvent(new PointerEvent("pointerdown", { pointerType: "mouse" }));
+    row.dispatchEvent(
+      new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 20, clientY: 20 }),
+    );
+    await expect.poll(() => document.querySelector(".issue-menu")).not.toBeNull();
+  }
+
+  it("picking a steer injects its text into an EMPTY prompt (no #N template) and does NOT spawn", async () => {
+    const onsubmit = vi.fn();
+    render(NewTask, { props: { onsubmit, initialRepoPath: "/repo" } });
+    await openIssueMenu();
+
+    await page
+      .getByRole("menuitem", { name: m.issuemenu_inject_aria({ label: "Fix it" }) })
+      .click();
+
+    const prompt = document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;
+    await expect.poll(() => prompt.value).toBe("/fix please");
+    // Injected, not launched.
+    expect(onsubmit).not.toHaveBeenCalled();
+    // The issue got attached as a reference (rides out-of-band, not dumped in the prompt).
+    await expect
+      .poll(() => document.querySelector(".issue-ref-link")?.textContent?.trim())
+      .toBe("#55 Add widget");
+  });
+
+  it("picking a steer APPENDS its text to a non-empty prompt", async () => {
+    render(NewTask, {
+      props: { onsubmit: vi.fn(), initialRepoPath: "/repo", initialPrompt: "draft" },
+    });
+    await openIssueMenu();
+
+    await page
+      .getByRole("menuitem", { name: m.issuemenu_inject_aria({ label: "Fix it" }) })
+      .click();
+
+    const prompt = document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;
+    await expect.poll(() => prompt.value).toBe("draft\n/fix please");
+  });
+
+  it("Show details closes the menu and opens the details popover with the issue body", async () => {
+    render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo" } });
+    await openIssueMenu();
+
+    await page.getByRole("menuitem", { name: m.issuemenu_details() }).click();
+
+    await expect.poll(() => document.querySelector(".issue-menu")).toBeNull();
+    const pop = await vi.waitFor(() => {
+      const el = document.querySelector(".issue-details");
+      if (!el) throw new Error("popover not yet open");
+      return el;
+    });
+    expect(pop.textContent).toContain("the widget body");
+  });
+
+  it("Open issue opens the forge URL in a new tab (no spawn)", async () => {
+    const onsubmit = vi.fn();
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    render(NewTask, { props: { onsubmit, initialRepoPath: "/repo" } });
+    await openIssueMenu();
+
+    await page.getByRole("menuitem", { name: m.issuemenu_open() }).click();
+
+    expect(openSpy).toHaveBeenCalledWith("https://gh/o/r/issues/55", "_blank", "noopener");
+    expect(onsubmit).not.toHaveBeenCalled();
+    openSpy.mockRestore();
   });
 });

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -21,6 +21,7 @@
     type RepoEntry,
     type SandboxProfile,
     type SlashCommand,
+    type Steer,
   } from "$lib/types";
   import { promoDefaultModel } from "$lib/fable-promo";
   import { matchSlashTrigger, filterCommands, applyCommandPick } from "$lib/slash";
@@ -529,6 +530,23 @@
     }
   }
 
+  // Inject an issue-scoped steer from PromptSources' per-row context menu: attach the
+  // issue and APPEND the steer's text to the prompt. This matches the backlog
+  // quick-launch payload but does NOT spawn — the dialog stays open for review/edit.
+  // On an empty prompt we set it to the steer text alone (no `#N title` template,
+  // unlike pickIssue): the steer text IS the intended prompt and the issue rides
+  // out-of-band via issueRef, so a title line would be redundant.
+  function injectSteer(issue: Issue, steer: Steer) {
+    issueRef = issue;
+    const t = steer.text;
+    prompt = prompt.trim() ? `${prompt}\n${t}` : t;
+    queueMicrotask(() => {
+      autogrow();
+      promptInput?.focus();
+      promptInput?.setSelectionRange(prompt.length, prompt.length);
+    });
+  }
+
   // Grow the prompt with its content (capped by CSS max-height, then it scrolls).
   // iOS Safari has no usable resize handle, so auto-grow is how the field gets bigger.
   function autogrow() {
@@ -990,6 +1008,7 @@
             });
           }}
           onpickissue={pickIssue}
+          onpicksteer={injectSteer}
         />
       {/if}
 

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -2,7 +2,7 @@
   import { untrack } from "svelte";
   import { SvelteSet } from "svelte/reactivity";
   import { getTodo, listIssues, getCommands } from "$lib/api";
-  import type { Issue, SlashCommand } from "$lib/types";
+  import type { Issue, SlashCommand, Steer } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { labelChipStyle } from "$lib/label-color";
   import {
@@ -19,11 +19,18 @@
   } from "./issues-panel";
   import { issuesFilter } from "$lib/issues-filter.svelte";
   import IssueFilterPopover from "./IssueFilterPopover.svelte";
+  import IssueContextMenu from "./IssueContextMenu.svelte";
+  import IssueDetailsPopover from "./IssueDetailsPopover.svelte";
+  import { issueMenuTrigger } from "./issue-menu-trigger";
+  import { steers } from "$lib/steers.svelte";
+  import { repos } from "$lib/repos.svelte";
+  import { steerAppliesToRepo } from "$lib/steer-scope";
 
   let {
     repoPath,
     onpick,
     onpickissue,
+    onpicksteer = undefined,
     allowIssues = true,
     epicParents = new Set(),
     nativeSubIssues = new Set(),
@@ -32,11 +39,54 @@
     repoPath: string;
     onpick: (prompt: string) => void;
     onpickissue: (issue: Issue) => void;
+    /** Inject an issue-scoped steer into the composer (append + attach the issue),
+     *  from the row's right-click / long-press context menu. Never spawns. */
+    onpicksteer?: (issue: Issue, steer: Steer) => void;
     allowIssues?: boolean;
     epicParents?: Set<number>;
     nativeSubIssues?: Set<number>;
     epicsLoaded?: boolean;
   } = $props();
+
+  // Issue-scoped steers (same set the backlog shows as quick buttons), gated to the
+  // steers bound to this repo (or universal ones). Offered as inject actions in the
+  // per-row context menu.
+  const issueActions = $derived(
+    steers.list.filter((s) => s.onIssues && steerAppliesToRepo(s, repos.nameFor(repoPath))),
+  );
+
+  // Right-click / long-press context menu + details preview state. Only one of each is
+  // open at a time (opening a second requires a pointerdown that dismisses the first).
+  let menu = $state<{
+    issue: Issue;
+    x: number;
+    y: number;
+    opener: HTMLElement;
+    canSteer: boolean;
+  } | null>(null);
+  let details = $state<{ issue: Issue; x: number; y: number; opener: HTMLElement } | null>(null);
+
+  function openMenu(issue: Issue, canSteer: boolean, x: number, y: number, node: HTMLElement) {
+    menu = { issue, x, y, opener: node, canSteer };
+  }
+  // "Show details" is a menu item (inside the menu), so the outside-pointerdown
+  // dismiss won't close the menu — close it explicitly and carry the ROW as the
+  // popover's opener so focus returns to the row when the popover closes.
+  function showDetails() {
+    const d = menu;
+    menu = null;
+    if (d) details = { issue: d.issue, x: d.x, y: d.y, opener: d.opener };
+  }
+  function openIssue() {
+    const i = menu?.issue;
+    menu = null;
+    if (i) window.open(i.url, "_blank", "noopener");
+  }
+  function pickSteer(steer: Steer) {
+    const i = menu?.issue;
+    menu = null;
+    if (i) onpicksteer?.(i, steer);
+  }
 
   let tab = $state<"todo" | "issues" | "commands">("todo");
   let todos = $state<string[]>([]);
@@ -357,7 +407,12 @@
             <!-- Epic-parent tracking issue: not pickable as a manual task (it would
                  collide with the Epic Runner). Shown disabled with an EPIC tag + hint;
                  epics launch via the epic panel's Start control. -->
-            <div class="row row-epic" aria-disabled="true" title={m.promptsources_epic_hint()}>
+            <div
+              class="row row-epic"
+              aria-disabled="true"
+              title={m.promptsources_epic_hint()}
+              use:issueMenuTrigger={{ onopen: (x, y, node) => openMenu(i, false, x, y, node) }}
+            >
               <span class="issue-num">#{i.number}</span>
               <span class="row-text">{i.title}</span>
               {@render issueAuthor(i.author)}
@@ -367,7 +422,14 @@
               </span>
             </div>
           {:else}
-            <button class="row" type="button" onclick={() => onpickissue(i)}>
+            <button
+              class="row"
+              type="button"
+              onclick={() => onpickissue(i)}
+              use:issueMenuTrigger={{
+                onopen: (x, y, node) => openMenu(i, onpicksteer != null, x, y, node),
+              }}
+            >
               <span class="issue-num">#{i.number}</span>
               <span class="row-text">{i.title}</span>
               {@render issueAuthor(i.author)}
@@ -381,6 +443,30 @@
     {/if}
   </div>
 </div>
+
+{#if menu}
+  <IssueContextMenu
+    x={menu.x}
+    y={menu.y}
+    number={menu.issue.number}
+    steers={issueActions}
+    canSteer={menu.canSteer}
+    opener={menu.opener}
+    onopenissue={openIssue}
+    ondetails={showDetails}
+    onsteer={pickSteer}
+    onclose={() => (menu = null)}
+  />
+{/if}
+{#if details}
+  <IssueDetailsPopover
+    x={details.x}
+    y={details.y}
+    issue={details.issue}
+    opener={details.opener}
+    onclose={() => (details = null)}
+  />
+{/if}
 
 {#snippet issueAuthor(login: string | undefined)}
   {#if login}

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -19,8 +19,7 @@
   } from "./issues-panel";
   import { issuesFilter } from "$lib/issues-filter.svelte";
   import IssueFilterPopover from "./IssueFilterPopover.svelte";
-  import IssueContextMenu from "./IssueContextMenu.svelte";
-  import IssueDetailsPopover from "./IssueDetailsPopover.svelte";
+  import IssueMenuLayer from "./IssueMenuLayer.svelte";
   import { issueMenuTrigger } from "./issue-menu-trigger";
   import { steers } from "$lib/steers.svelte";
   import { repos } from "$lib/repos.svelte";
@@ -86,6 +85,12 @@
     const i = menu?.issue;
     menu = null;
     if (i) onpicksteer?.(i, steer);
+  }
+  function closeMenu() {
+    menu = null;
+  }
+  function closeDetails() {
+    details = null;
   }
 
   let tab = $state<"todo" | "issues" | "commands">("todo");
@@ -444,29 +449,16 @@
   </div>
 </div>
 
-{#if menu}
-  <IssueContextMenu
-    x={menu.x}
-    y={menu.y}
-    number={menu.issue.number}
-    steers={issueActions}
-    canSteer={menu.canSteer}
-    opener={menu.opener}
-    onopenissue={openIssue}
-    ondetails={showDetails}
-    onsteer={pickSteer}
-    onclose={() => (menu = null)}
-  />
-{/if}
-{#if details}
-  <IssueDetailsPopover
-    x={details.x}
-    y={details.y}
-    issue={details.issue}
-    opener={details.opener}
-    onclose={() => (details = null)}
-  />
-{/if}
+<IssueMenuLayer
+  {menu}
+  {details}
+  steers={issueActions}
+  onopenissue={openIssue}
+  onshowdetails={showDetails}
+  onsteer={pickSteer}
+  onclosemenu={closeMenu}
+  onclosedetails={closeDetails}
+/>
 
 {#snippet issueAuthor(login: string | undefined)}
   {#if login}

--- a/ui/src/lib/components/backlog-view/BacklogTabContent.svelte
+++ b/ui/src/lib/components/backlog-view/BacklogTabContent.svelte
@@ -16,6 +16,7 @@
     selectedPath,
     onissue,
     onquick = undefined,
+    oninject = undefined,
     onpr,
     onlaunchtrain,
     onadopt,
@@ -28,6 +29,7 @@
     selectedPath: string;
     onissue: (repoPath: string, issue: Issue) => void;
     onquick?: (repoPath: string, issue: Issue, action: Steer) => void;
+    oninject?: (repoPath: string, issue: Issue, steer: Steer) => void;
     onpr: (repoPath: string, pr: PullRequest) => void;
     onlaunchtrain: (repoPath: string, prs: PullRequest[]) => void;
     onadopt: (repoPath: string, prompt: string) => void;
@@ -45,6 +47,7 @@
       onissue(selectedPath, issue);
     }}
     onquick={onquick ? (issue, action) => onquick(selectedPath, issue, action) : undefined}
+    oninject={oninject ? (issue, steer) => oninject(selectedPath, issue, steer) : undefined}
     bodyPreview
     age
     {epics}

--- a/ui/src/lib/components/issue-menu-trigger.ts
+++ b/ui/src/lib/components/issue-menu-trigger.ts
@@ -1,0 +1,76 @@
+import { longPress } from "./longpress";
+
+// Svelte action: open an issue-row context menu on desktop right-click OR touch
+// long-press. Modelled on Viewport.svelte's longPress + lastPointerType recipe —
+// NOT CardMenu, which leans on the native `contextmenu` that longpress.ts documents
+// as unreliable on touch.
+//
+// Dedup: Android Chrome fires BOTH a native `contextmenu` and the 500ms longPress
+// on a touch long-press. We let longPress own the open on touch and bail out of the
+// `contextmenu` handler — still preventing its default so the native menu never
+// shows and the touchcancel it would otherwise trigger can't kill the longPress
+// timer. The touch-vs-mouse decision keys off the pointer type of the LAST
+// pointerdown, never device capability, so a real mouse right-click on a touchscreen
+// laptop still opens the menu.
+
+// One window listener shared by every trigger instance; ref-counted so it installs
+// on the first mount and tears down when the last row unmounts. Capture phase so it
+// records the type before any target handler runs.
+let lastPointerType = "";
+let refCount = 0;
+function onWinPointerDown(e: PointerEvent) {
+  lastPointerType = e.pointerType;
+}
+function onWinKeyDown() {
+  lastPointerType = ""; // keyboard Menu key must not be read as a pointer type
+}
+function acquire() {
+  if (refCount++ === 0) {
+    window.addEventListener("pointerdown", onWinPointerDown, { capture: true });
+    window.addEventListener("keydown", onWinKeyDown, { capture: true });
+  }
+}
+function release() {
+  if (--refCount === 0) {
+    window.removeEventListener("pointerdown", onWinPointerDown, { capture: true });
+    window.removeEventListener("keydown", onWinKeyDown, { capture: true });
+  }
+}
+
+export type IssueMenuTriggerOpts = {
+  /** Open the menu at viewport coords, with `node` as the focus-return opener. */
+  onopen: (x: number, y: number, node: HTMLElement) => void;
+};
+
+export function issueMenuTrigger(node: HTMLElement, opts: IssueMenuTriggerOpts) {
+  let o = opts;
+  acquire();
+
+  function onContextMenu(e: MouseEvent) {
+    // Never surface the browser's native menu over an issue row.
+    e.preventDefault();
+    // Touch long-press: longPress owns the open, so bail here — this keeps Android's
+    // simultaneous native contextmenu from opening a second menu.
+    if (lastPointerType === "touch") return;
+    o.onopen(e.clientX, e.clientY, node);
+  }
+  node.addEventListener("contextmenu", onContextMenu);
+
+  const trigger = (x: number, y: number) => {
+    o.onopen(x, y, node);
+    return true; // suppress the trailing synthetic click so the row's own click can't also fire
+  };
+  const lp = longPress(node, { onTrigger: trigger });
+
+  return {
+    update(next: IssueMenuTriggerOpts) {
+      o = next;
+      lp.update({ onTrigger: trigger });
+    },
+    destroy() {
+      node.removeEventListener("contextmenu", onContextMenu);
+      lp.destroy();
+      release();
+    },
+  };
+}

--- a/ui/src/lib/components/issues-panel/IssueRow.svelte
+++ b/ui/src/lib/components/issues-panel/IssueRow.svelte
@@ -8,6 +8,9 @@
   import { ACTIVE_LABEL } from "../issues-panel";
   import { progress } from "../epic-panel";
   import EpicPanel from "../EpicPanel.svelte";
+  import IssueContextMenu from "../IssueContextMenu.svelte";
+  import IssueDetailsPopover from "../IssueDetailsPopover.svelte";
+  import { issueMenuTrigger } from "../issue-menu-trigger";
 
   // One backlog issue row, extracted from IssuesPanel so the panel template clears the
   // Tier-1 <template> complexity bar (#855). The row owns all its nested conditionals
@@ -25,6 +28,7 @@
     issueActions,
     onnewtask,
     onquick = undefined,
+    oninject = undefined,
     ontoggleepic,
   }: {
     issue: Issue;
@@ -46,8 +50,32 @@
     issueActions: Steer[];
     onnewtask: (issue: Issue) => void;
     onquick?: (issue: Issue, action: Steer) => void;
+    /** Inject an issue-scoped steer: open the New Task dialog pre-seeded with the
+     *  steer's prompt + this issue attached (does NOT spawn). From the row's
+     *  right-click / long-press context menu. Omitted → no steer items in the menu. */
+    oninject?: (issue: Issue, steer: Steer) => void;
     ontoggleepic: (number: number) => void;
   } = $props();
+
+  // Right-click / long-press context menu + details preview state (this row's issue).
+  let menu = $state<{ x: number; y: number; opener: HTMLElement } | null>(null);
+  let details = $state<{ x: number; y: number; opener: HTMLElement } | null>(null);
+
+  // "Show details" lives inside the menu, so the outside-pointerdown dismiss won't
+  // close it — close explicitly and carry the ROW as the popover's opener.
+  function showDetails() {
+    const d = menu;
+    menu = null;
+    if (d) details = d;
+  }
+  function openIssue() {
+    menu = null;
+    window.open(issue.url, "_blank", "noopener");
+  }
+  function pickSteer(steer: Steer) {
+    menu = null;
+    oninject?.(issue, steer);
+  }
 
   // Epic-parent rows disable quick-launch + Task: an epic is launched via the epic
   // panel's Start, not by spawning a manual session against the parent tracking issue.
@@ -102,6 +130,7 @@
   class:is-epic={isEpicParent}
   id={`epic-issue-row-${issue.number}`}
   use:epicRowClick
+  use:issueMenuTrigger={{ onopen: (x, y, node) => (menu = { x, y, opener: node }) }}
 >
   <div class="issue-top">
     <!-- eslint-disable svelte/no-navigation-without-resolve -- external GitHub URL, not an app route -->
@@ -221,6 +250,30 @@
     </div>
   {/if}
 </div>
+
+{#if menu}
+  <IssueContextMenu
+    x={menu.x}
+    y={menu.y}
+    number={issue.number}
+    steers={issueActions}
+    canSteer={!isEpicParent && oninject != null}
+    opener={menu.opener}
+    onopenissue={openIssue}
+    ondetails={showDetails}
+    onsteer={pickSteer}
+    onclose={() => (menu = null)}
+  />
+{/if}
+{#if details}
+  <IssueDetailsPopover
+    x={details.x}
+    y={details.y}
+    {issue}
+    opener={details.opener}
+    onclose={() => (details = null)}
+  />
+{/if}
 
 <style>
   .issue-row {

--- a/ui/src/lib/components/issues-panel/IssueRow.svelte
+++ b/ui/src/lib/components/issues-panel/IssueRow.svelte
@@ -8,8 +8,7 @@
   import { ACTIVE_LABEL } from "../issues-panel";
   import { progress } from "../epic-panel";
   import EpicPanel from "../EpicPanel.svelte";
-  import IssueContextMenu from "../IssueContextMenu.svelte";
-  import IssueDetailsPopover from "../IssueDetailsPopover.svelte";
+  import IssueMenuLayer from "../IssueMenuLayer.svelte";
   import { issueMenuTrigger } from "../issue-menu-trigger";
 
   // One backlog issue row, extracted from IssuesPanel so the panel template clears the
@@ -57,16 +56,24 @@
     ontoggleepic: (number: number) => void;
   } = $props();
 
-  // Right-click / long-press context menu + details preview state (this row's issue).
-  let menu = $state<{ x: number; y: number; opener: HTMLElement } | null>(null);
-  let details = $state<{ x: number; y: number; opener: HTMLElement } | null>(null);
+  // Right-click / long-press context menu + details preview state. Both carry the
+  // issue so <IssueMenuLayer> stays host-agnostic (shared with PromptSources).
+  type MenuState = { issue: Issue; x: number; y: number; opener: HTMLElement; canSteer: boolean };
+  type DetailsState = { issue: Issue; x: number; y: number; opener: HTMLElement };
+  let menu = $state<MenuState | null>(null);
+  let details = $state<DetailsState | null>(null);
 
+  // Trigger opener (mouse right-click / touch long-press). Epic-parent rows omit the
+  // steer items (canSteer), same footgun guard as the disabled quick-launch/+Task.
+  function openMenu(x: number, y: number, node: HTMLElement) {
+    menu = { issue, x, y, opener: node, canSteer: !isEpicParent && oninject != null };
+  }
   // "Show details" lives inside the menu, so the outside-pointerdown dismiss won't
   // close it — close explicitly and carry the ROW as the popover's opener.
   function showDetails() {
     const d = menu;
     menu = null;
-    if (d) details = d;
+    if (d) details = { issue: d.issue, x: d.x, y: d.y, opener: d.opener };
   }
   function openIssue() {
     menu = null;
@@ -75,6 +82,12 @@
   function pickSteer(steer: Steer) {
     menu = null;
     oninject?.(issue, steer);
+  }
+  function closeMenu() {
+    menu = null;
+  }
+  function closeDetails() {
+    details = null;
   }
 
   // Epic-parent rows disable quick-launch + Task: an epic is launched via the epic
@@ -130,7 +143,7 @@
   class:is-epic={isEpicParent}
   id={`epic-issue-row-${issue.number}`}
   use:epicRowClick
-  use:issueMenuTrigger={{ onopen: (x, y, node) => (menu = { x, y, opener: node }) }}
+  use:issueMenuTrigger={{ onopen: openMenu }}
 >
   <div class="issue-top">
     <!-- eslint-disable svelte/no-navigation-without-resolve -- external GitHub URL, not an app route -->
@@ -251,29 +264,16 @@
   {/if}
 </div>
 
-{#if menu}
-  <IssueContextMenu
-    x={menu.x}
-    y={menu.y}
-    number={issue.number}
-    steers={issueActions}
-    canSteer={!isEpicParent && oninject != null}
-    opener={menu.opener}
-    onopenissue={openIssue}
-    ondetails={showDetails}
-    onsteer={pickSteer}
-    onclose={() => (menu = null)}
-  />
-{/if}
-{#if details}
-  <IssueDetailsPopover
-    x={details.x}
-    y={details.y}
-    {issue}
-    opener={details.opener}
-    onclose={() => (details = null)}
-  />
-{/if}
+<IssueMenuLayer
+  {menu}
+  {details}
+  steers={issueActions}
+  onopenissue={openIssue}
+  onshowdetails={showDetails}
+  onsteer={pickSteer}
+  onclosemenu={closeMenu}
+  onclosedetails={closeDetails}
+/>
 
 <style>
   .issue-row {

--- a/ui/src/lib/components/page/AppOverlays.browser.test.ts
+++ b/ui/src/lib/components/page/AppOverlays.browser.test.ts
@@ -122,6 +122,7 @@ function baseProps(): Props {
     inTrainPrs: new Set<string>(),
     onissue: vi.fn(),
     onquick: vi.fn(),
+    oninject: vi.fn(),
     onpr: vi.fn(),
     onadopt: vi.fn(),
     onlaunchtrain: vi.fn(),

--- a/ui/src/lib/components/page/AppOverlays.svelte
+++ b/ui/src/lib/components/page/AppOverlays.svelte
@@ -183,6 +183,7 @@
     inTrainPrs,
     onissue,
     onquick,
+    oninject,
     onpr,
     onadopt,
     onlaunchtrain,
@@ -314,6 +315,7 @@
     inTrainPrs: Set<string>;
     onissue: (repoPath: string, issue: Issue) => void;
     onquick: (repoPath: string, issue: Issue, action: Steer) => void;
+    oninject: (repoPath: string, issue: Issue, steer: Steer) => void;
     onpr: (repoPath: string, pr: PullRequest) => void;
     onadopt: (repoPath: string, prompt: string) => void;
     onlaunchtrain: (repoPath: string, prs: PullRequest[]) => void;
@@ -623,6 +625,7 @@
     {mobile}
     {onissue}
     {onquick}
+    {oninject}
     {onpr}
     {onadopt}
     {onlaunchtrain}

--- a/ui/src/lib/feature-announcements/entries/v1.43.0-issue-context-menu.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.43.0-issue-context-menu.ts
@@ -1,0 +1,16 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // Right-click / long-press an issue row (New Task dialog or backlog) opens a context
+  // menu: open on the forge, preview details, or inject an issue steer into the composer
+  // (pre-filled, not launched). No targetId — the menu is anchored to a transient
+  // right-click, so there's no always-present element to point a coachmark at; surface
+  // via the What's-New drawer only. 1.42.x is the latest released line, so this ships in
+  // 1.43.0 (bun run next-version).
+  id: "issue-context-menu",
+  sinceVersion: "1.43.0",
+  titleKey: "feat_issue_context_menu_title",
+  bodyKey: "feat_issue_context_menu_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-issue-context-menu.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-issue-context-menu.ts
@@ -5,10 +5,10 @@ const entry = {
   // menu: open on the forge, preview details, or inject an issue steer into the composer
   // (pre-filled, not launched). No targetId — the menu is anchored to a transient
   // right-click, so there's no always-present element to point a coachmark at; surface
-  // via the What's-New drawer only. 1.42.x is the latest released line, so this ships in
-  // 1.43.0 (bun run next-version).
+  // via the What's-New drawer only. 1.43.0 is the latest released line, so this ships in
+  // 1.44.0 (bun run next-version).
   id: "issue-context-menu",
-  sinceVersion: "1.43.0",
+  sinceVersion: "1.44.0",
   titleKey: "feat_issue_context_menu_title",
   bodyKey: "feat_issue_context_menu_body",
 } satisfies FeatureAnnouncement;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1016,6 +1016,18 @@
     }
   }
 
+  // Inject an issue steer from a backlog row's right-click / long-press menu: open the
+  // New Task dialog pre-seeded with the steer's prompt + the issue attached. Unlike
+  // onquickissue this does NOT spawn — the operator reviews and hits Run. Mirrors the
+  // PR-review seed path (composePrompt + open the dialog).
+  function oninjectissue(repoPath: string, issue: Issue, steer: Steer) {
+    composeRepoPath = repoPath;
+    composeIssue = issue;
+    composePrompt = steer.text;
+    showBacklog = false;
+    showNew = true;
+  }
+
   // Merge-train shortcut (Ready-to-merge group header): spawn a new session that
   // works through the PRs of every ready-to-merge session, suggesting a merge
   // order. A merge train is per-repo, so when ready PRs span repos we scope to
@@ -2648,6 +2660,7 @@
               mobile={true}
               {onissue}
               onquick={onquickissue}
+              oninject={oninjectissue}
               {onpr}
               {onadopt}
               {onlaunchtrain}
@@ -2834,6 +2847,7 @@
             mobile={false}
             {onissue}
             onquick={onquickissue}
+            oninject={oninjectissue}
             {onpr}
             {onadopt}
             {onlaunchtrain}
@@ -3142,6 +3156,7 @@
   {inTrainPrs}
   {onissue}
   onquick={onquickissue}
+  oninject={oninjectissue}
   {onpr}
   {onadopt}
   {onlaunchtrain}


### PR DESCRIPTION
## What

Right-click (or long-press) an **issue row** to open a small context menu with three actions:

- **Open issue** — open the issue on the forge in a new tab.
- **Show details** — an anchored preview popover: number · author · age, title, all labels, and the issue body (scrollable).
- **Steer actions** — one item per issue-scoped steer (the `onIssues` steers). Picking one **injects** the steer into the New Task dialog rather than spawning.

The menu lives on **two surfaces**:

| Surface | Steer pick behavior |
| --- | --- |
| **New Task dialog** (`PromptSources` → Issues tab) | Appends the steer's text to the composer prompt and attaches the issue — in place, dialog stays open. |
| **Standalone backlog** (`IssueRow`) | Opens the New Task dialog **pre-seeded** with the steer's prompt + the issue attached. |

Either way it's **inject, not execute** — the operator reviews and hits Run. The backlog's existing quick-launch buttons (which *do* spawn) are unchanged; the right-click menu is the additive, review-first path.

## How

- **`IssueContextMenu.svelte`** + **`IssueDetailsPopover.svelte`** — anchored, non-blocking popovers modelled on `CardMenu`/`SteerMenu` (design-system popover recipe, no scrim, viewport-clamped, roving focus).
- **`issue-menu-trigger.ts`** — shared Svelte action for the right-click + long-press trigger, modelled on `Viewport.svelte` (the real `longPress` user). Dedups Android Chrome's simultaneous native `contextmenu` + longPress (opens once) and keys touch-vs-mouse off `lastPointerType`, so a mouse right-click on a touchscreen laptop still opens.
- Both popovers render **inside** `a11yDialog` modals (New Task dialog, backlog overlay), so they intercept **Escape in capture phase + `preventDefault`** — otherwise `a11yDialog` (which yields only on `defaultPrevented`) would also close the host dialog and lose the composed prompt. The details popover ignores its own body's scroll so reading a long issue doesn't dismiss it.
- Backlog inject threads a new `oninject` callback `IssueRow → IssuesPanel → BacklogTabContent → BacklogView → BacklogOverlay → AppOverlays → +page.oninjectissue`, mirroring the existing `onquick` plumbing.
- Epic-parent rows show Open + Details but no steer items (same footgun guard as the disabled quick-launch/+Task).

## Commits

1. **Surface A** — New Task dialog (shared components + `PromptSources`/`NewTask` + feature-announcement entry). Independently shippable.
2. **Surface B** — standalone backlog (`IssueRow` menu + `oninject` threading).

## Tests

- `IssueContextMenu.browser.test.ts` — menu items + `canSteer` gating; details popover content, empty-body note, Escape capture+`preventDefault`, and self-scroll guard.
- `NewTask.browser.test.ts` — inject into empty prompt (`= steer.text`, no `#N` template), append into a non-empty prompt, menu→details transition, open-issue, and **no spawn**.
- `IssuesPanel.browser.test.ts` — backlog steer-pick fires `oninject(issue, steer)` once with **no spawn**; steer items omitted when `oninject` isn't provided.

`bun run check`, `bun run check:i18n`, and the full `bun run test` suite (3352 tests) pass; PR-hygiene gates (branch-hygiene, i18n parity, feature-catalog, announcement-version) pass. EN + DE message keys added for all new chrome.
