### PR TITLE
feat: flag epics others are already working on in the backlog (#1616)

### DIFF
--- a/src/epic-core.ts
+++ b/src/epic-core.ts
@@ -1,4 +1,4 @@
-import type { Issue } from "./forge/types";
+import type { Issue, LinkedPr } from "./forge/types";
 import type { AgentProvider } from "./types";
 
 export type EpicSource = "native" | "markdown";
@@ -96,4 +96,50 @@ export function selectEpicCandidates(children: EpicChild[]): Issue[] {
       // runner — they carry no assignee data and are not assignee-filtered (#824).
       assignees: [],
     }));
+}
+
+/** "Someone else is already working / owns this epic" flags for the backlog epic row (#1616),
+ *  all resolved against the viewer so nothing here ever points at the operator's own work. */
+export interface EpicOthersFlags {
+  /** How many of the epic's children have an OPEN PR authored by someone other than the
+   *  viewer (the viewer's own in-flight PRs are excluded from the COUNT, not just the names).
+   *  0 → no pill. */
+  inFlight: number;
+  /** Distinct non-viewer authors of those in-flight child PRs, sorted — the pill's "by …". */
+  inFlightBy: string[];
+  /** Parent assignees other than the viewer, sorted (the "assigned to X" signal). */
+  assignedOthers: string[];
+  /** Parent author when it isn't the viewer, else null — the only tell for a freshly-created,
+   *  unassigned epic with no child PRs yet. */
+  authoredByOther: string | null;
+}
+
+/** Pure derivation of {@link EpicOthersFlags} from an epic's child numbers + the repo's
+ *  open-PR→author map + the parent's assignees/author, all relative to `viewer`. `viewer`
+ *  null (host can't resolve "me") fails open — every non-empty author/assignee counts as
+ *  "other" (matching the #824 fail-open convention). Any OPEN PR qualifies as in-flight
+ *  (incl. drafts / bot authors), so the UI copy says "in progress", not "in review". */
+export function computeEpicOthersFlags(input: {
+  childNumbers: number[];
+  linked: Map<number, LinkedPr[]>;
+  assignees: string[];
+  author: string | null;
+  viewer: string | null;
+}): EpicOthersFlags {
+  const { childNumbers, linked, assignees, author, viewer } = input;
+  const inFlightAuthors = new Set<string>();
+  let inFlight = 0;
+  for (const num of new Set(childNumbers)) {
+    const prs = (linked.get(num) ?? []).filter((p) => p.author && p.author !== viewer);
+    if (prs.length === 0) continue;
+    inFlight++;
+    for (const p of prs) inFlightAuthors.add(p.author);
+  }
+  const assignedOthers = [...new Set(assignees.filter((a) => a && a !== viewer))].sort();
+  return {
+    inFlight,
+    inFlightBy: [...inFlightAuthors].sort(),
+    assignedOthers,
+    authoredByOther: author && author !== viewer ? author : null,
+  };
 }

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -25,6 +25,7 @@ import type {
   GitForge,
   Issue,
   IssueComment,
+  LinkedPr,
   MergeInput,
   MergeMethod,
   MergeStateStatus,
@@ -74,11 +75,13 @@ const MAX_SUMMARY_PAGES = 2;
 
 /** Parse one page of the sub-issue-summary GraphQL response: record every node with
  *  total > 0 into `intoSummaries` (keyed by issue number), add every node with a non-null
- *  parent to `intoSubIssues`, and return the page's cursor info. */
+ *  parent to `intoSubIssues` and into `intoChildrenByParent` (keyed by parent number), and
+ *  return the page's cursor info. */
 function collectSubIssueSummaryPage(
   out: string,
   intoSummaries: Map<number, { total: number; completed: number }>,
   intoSubIssues: Set<number>,
+  intoChildrenByParent: Map<number, number[]>,
 ): { hasNextPage: boolean; endCursor: string | null } {
   const json = JSON.parse(out) as {
     data?: {
@@ -103,6 +106,9 @@ function collectSubIssueSummaryPage(
     }
     if (node.parent != null) {
       intoSubIssues.add(node.number);
+      const siblings = intoChildrenByParent.get(node.parent.number) ?? [];
+      siblings.push(node.number);
+      intoChildrenByParent.set(node.parent.number, siblings);
     }
   }
   return {
@@ -111,26 +117,39 @@ function collectSubIssueSummaryPage(
   };
 }
 
-/** Parse one page of the open-PR closingIssuesReferences GraphQL response: add every closed
- *  issue number into `into`, and return the page's cursor info. */
-function collectClosingIssuesPage(
+/** Parse one page of the open-PR closingIssuesReferences GraphQL response: for every open PR,
+ *  push its {prNumber, author} onto each issue number it would close (keyed by that issue
+ *  number in `into`), and return the page's cursor info. The numbers-only
+ *  `listOpenPrClosingIssues` derives its result from `into.keys()`. */
+function collectLinkedIssuesPage(
   out: string,
-  into: Set<number>,
+  into: Map<number, LinkedPr[]>,
 ): { hasNextPage: boolean; endCursor: string | null } {
   const json = JSON.parse(out || "{}") as {
     data?: {
       repository?: {
         pullRequests?: {
           pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
-          nodes?: Array<{ closingIssuesReferences?: { nodes?: Array<{ number?: number }> } }>;
+          nodes?: Array<{
+            number?: number;
+            author?: { login?: string } | null;
+            closingIssuesReferences?: { nodes?: Array<{ number?: number }> };
+          }>;
         };
       };
     };
   };
   const prs = json.data?.repository?.pullRequests;
-  for (const n of prs?.nodes ?? [])
+  for (const n of prs?.nodes ?? []) {
+    if (typeof n.number !== "number") continue;
+    const author = n.author?.login ?? "";
     for (const ref of n.closingIssuesReferences?.nodes ?? [])
-      if (typeof ref.number === "number") into.add(ref.number);
+      if (typeof ref.number === "number") {
+        const linked = into.get(ref.number) ?? [];
+        linked.push({ prNumber: n.number, author });
+        into.set(ref.number, linked);
+      }
+  }
   return {
     hasNextPage: prs?.pageInfo?.hasNextPage ?? false,
     endCursor: prs?.pageInfo?.endCursor ?? null,
@@ -1910,8 +1929,10 @@ export class GithubForge implements GitForge {
   async listSubIssueSummaries(): Promise<{
     summaries: Map<number, { total: number; completed: number }>;
     subIssueNumbers: number[];
+    childrenByParent: Map<number, number[]>;
   }> {
-    if (graphRateLimit.blocked()) return { summaries: new Map(), subIssueNumbers: [] };
+    if (graphRateLimit.blocked())
+      return { summaries: new Map(), subIssueNumbers: [], childrenByParent: new Map() };
     // No this.apiVersion header: subIssuesSummary is GA on GraphQL (no preview header needed).
     // Do NOT add the X-GitHub-Api-Version header here — it was required only for the
     // REST sub_issues endpoints above.
@@ -1922,6 +1943,7 @@ export class GithubForge implements GitForge {
       "query($owner:String!,$name:String!,$endCursor:String){repository(owner:$owner,name:$name){issues(states:OPEN,first:100,after:$endCursor,orderBy:{field:CREATED_AT,direction:DESC}){pageInfo{hasNextPage endCursor}nodes{number subIssuesSummary{total completed} parent{number}}}}}";
     const summaries = new Map<number, { total: number; completed: number }>();
     const subIssueSet = new Set<number>();
+    const childrenByParent = new Map<number, number[]>();
     try {
       let endCursor: string | null = null;
       for (let page = 0; page < MAX_SUMMARY_PAGES; page++) {
@@ -1937,26 +1959,40 @@ export class GithubForge implements GitForge {
         ];
         // Thread cursor explicitly; page 1 omits it so $endCursor defaults to null in GraphQL.
         if (endCursor !== null) args.push("-f", `endCursor=${endCursor}`);
-        const pageInfo = collectSubIssueSummaryPage(await this.run(args), summaries, subIssueSet);
+        const pageInfo = collectSubIssueSummaryPage(
+          await this.run(args),
+          summaries,
+          subIssueSet,
+          childrenByParent,
+        );
         if (!pageInfo.hasNextPage) break;
         endCursor = pageInfo.endCursor;
       }
     } catch {
       // Best-effort; degrade to markdown-only discovery rather than failing the route.
-      return { summaries: new Map(), subIssueNumbers: [] };
+      return { summaries: new Map(), subIssueNumbers: [], childrenByParent: new Map() };
     }
-    return { summaries, subIssueNumbers: [...subIssueSet] };
+    return { summaries, subIssueNumbers: [...subIssueSet], childrenByParent };
   }
 
+  /** Numbers-only view of {@link listOpenPrLinkedIssues} for Up Next (#1169), which only needs
+   *  "does an open PR close this issue?". Delegates to the one linked-issues query so the two
+   *  callers share a single fetch/parse path. */
   async listOpenPrClosingIssues(): Promise<number[]> {
-    if (graphRateLimit.blocked()) return [];
-    // Issues an open PR would close (UI-linked + `Closes #N` bodies). Paginated like
-    // listSubIssueSummaries; capped to ~200 open PRs. Best-effort — any failure yields []
-    // and Up Next falls back to the shepherd:active exclusion alone.
+    return [...(await this.listOpenPrLinkedIssues()).keys()];
+  }
+
+  async listOpenPrLinkedIssues(): Promise<Map<number, LinkedPr[]>> {
+    if (graphRateLimit.blocked()) return new Map();
+    // Issues an open PR would close (UI-linked + `Closes #N` bodies), mapped to the PR's
+    // number + author. Paginated like listSubIssueSummaries; capped to ~200 newest open PRs
+    // (MAX_SUMMARY_PAGES) — a repo above that undercounts linked PRs. Best-effort — any
+    // failure yields an empty map (Up Next falls back to the shepherd:active exclusion; the
+    // epic pill falls back to the assignee/author signals).
     const [owner, name] = this.slug.split("/");
     const query =
-      "query($owner:String!,$name:String!,$endCursor:String){repository(owner:$owner,name:$name){pullRequests(states:OPEN,first:100,after:$endCursor,orderBy:{field:CREATED_AT,direction:DESC}){pageInfo{hasNextPage endCursor}nodes{closingIssuesReferences(first:20){nodes{number}}}}}}";
-    const closed = new Set<number>();
+      "query($owner:String!,$name:String!,$endCursor:String){repository(owner:$owner,name:$name){pullRequests(states:OPEN,first:100,after:$endCursor,orderBy:{field:CREATED_AT,direction:DESC}){pageInfo{hasNextPage endCursor}nodes{number author{login} closingIssuesReferences(first:20){nodes{number}}}}}}";
+    const linked = new Map<number, LinkedPr[]>();
     try {
       let endCursor: string | null = null;
       for (let page = 0; page < MAX_SUMMARY_PAGES; page++) {
@@ -1971,15 +2007,15 @@ export class GithubForge implements GitForge {
           `query=${query}`,
         ];
         if (endCursor !== null) args.push("-f", `endCursor=${endCursor}`);
-        const pageInfo = collectClosingIssuesPage(await this.run(args), closed);
+        const pageInfo = collectLinkedIssuesPage(await this.run(args), linked);
         if (!pageInfo.hasNextPage) break;
         endCursor = pageInfo.endCursor;
       }
     } catch (err) {
-      if (isRateLimitError(err)) return [];
-      return [];
+      if (isRateLimitError(err)) return new Map();
+      return new Map();
     }
-    return [...closed];
+    return linked;
   }
 
   async listBlockedByOpen(): Promise<Map<number, number[]>> {

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -43,6 +43,15 @@ export interface Issue {
   blockedBy?: number[];
 }
 
+/** An open PR linked to an issue (via `closingIssuesReferences`), reduced to the PR's
+ *  number + author login. Carried per closed-issue number by {@link GitForge.listOpenPrLinkedIssues};
+ *  drives the epic-summary "in progress · by {author}" signal (#1616). Author is "" when the
+ *  forge omits it. */
+export interface LinkedPr {
+  prNumber: number;
+  author: string;
+}
+
 export type ForgeKind = "github" | "gitea" | "local";
 export type MergeMethod = "merge" | "squash" | "rebase";
 
@@ -515,6 +524,12 @@ export interface GitForge {
   listSubIssueSummaries?(): Promise<{
     summaries: Map<number, { total: number; completed: number }>;
     subIssueNumbers: number[];
+    /** Native sub-issue child numbers grouped by their parent issue number — the same
+     *  `parent{number}` field already selected for `subIssueNumbers`, kept per-parent so
+     *  the epic-summary route can map in-flight children to their epic (#1616) without a
+     *  per-parent `listSubIssues` probe. Optional so existing callers/fakes that predate it
+     *  stay valid; GithubForge always populates it. */
+    childrenByParent?: Map<number, number[]>;
   }>;
   /** Issue numbers that an OPEN pull request would close (GraphQL `closingIssuesReferences`,
    *  GitHub only). Catches UI-linked PRs and `Closes #N`/`Fixes #N` bodies alike. Used by
@@ -523,6 +538,13 @@ export interface GitForge {
    *  without it, or a transient failure, yields an empty set and the exclusion degrades to
    *  `shepherd:active`-only. Optional: only hosts with the GraphQL field implement it. */
   listOpenPrClosingIssues?(): Promise<number[]>;
+  /** Like {@link listOpenPrClosingIssues} but keyed by closed-issue number and carrying the
+   *  open PR's number + author — the epic-summary route's "someone else is already working
+   *  this" signal (the pill's "by {author}"). Same single bounded query
+   *  (`closingIssuesReferences`), extended with `number author{login}`; capped to the ~200
+   *  newest open PRs (`MAX_SUMMARY_PAGES`) so repos above that undercount. Best-effort:
+   *  failure/rate-limit yields an empty map. Optional: GitHub only. */
+  listOpenPrLinkedIssues?(): Promise<Map<number, LinkedPr[]>>;
   /** Open PRs for this repo as full poll-grade PrStatus objects keyed by head
    *  branch name, fetched in ONE `gh pr list --state open` call — the per-repo
    *  batch the PrPoller matches sessions against locally (collapsing N× per-branch

--- a/src/server.ts
+++ b/src/server.ts
@@ -132,7 +132,15 @@ import {
   recordSocketAttach,
   recordFallback,
 } from "./terminal-transport-metrics";
-import type { GitForge, GitState, Issue, MergeMethod, PrStatus, WorkflowRun } from "./forge/types";
+import type {
+  GitForge,
+  GitState,
+  Issue,
+  LinkedPr,
+  MergeMethod,
+  PrStatus,
+  WorkflowRun,
+} from "./forge/types";
 import { DEPENDABOT_REBASE_COMMAND, EmptyDiffError } from "./forge/types";
 import { buildIssueUrl } from "./forge";
 import type { GithubRateLimitPayload } from "./forge/github-rate-limit";
@@ -153,6 +161,7 @@ import type { SessionActivity } from "./activity-signal";
 import type { DrainStatus, QueuedItem } from "./drain";
 import { ACTIVE_LABEL } from "./drain-core";
 import type { Epic, EpicRun, EpicSource } from "./epic-core";
+import { computeEpicOthersFlags } from "./epic-core";
 import type { EpicDiagnosis } from "./epic-diagnosis";
 import { importEpicLinks, type ImportResult } from "./epic-import";
 import { validateEpicDraft, materializeEpicDraft, forgeSupportsIssueCreation } from "./epic-author";
@@ -5987,7 +5996,19 @@ function mergeEpicRunPatch(
 // list is truncated (>=200) OR the candidate has no markdown body, a native
 // listSubIssues call is made to avoid undercounting capped issues.
 
-type IssueHint = { body?: string; title?: string; number?: number };
+// `assignees`/`author` ride along from the full `Issue` objects `listIssues()` already
+// returns (this type just narrows them) — exposing them here is pure type-plumbing at zero
+// network cost, so the epic-summary route can flag an epic as "someone else's": parent
+// assigned to a non-viewer, or authored by a non-viewer (the tell for a freshly-created
+// epic that has no child PRs yet). Both optional — candidates outside the open-issue window
+// carry no hint and simply lack these signals.
+type IssueHint = {
+  body?: string;
+  title?: string;
+  number?: number;
+  assignees?: string[];
+  author?: string;
+};
 
 /** Collect epic-candidate map from open issues + any stored run parent.
  *  Keys are parent issue numbers; values are the issue hint (may be undefined
@@ -6081,14 +6102,21 @@ type NativeSummaryMap = Map<number, { total: number; completed: number }>;
 /** Best-effort fetch of native sub-issue summaries (GitHub only; one bounded forge call that
  *  internally pages up to MAX_SUMMARY_PAGES GraphQL requests). Returns an empty map on any error
  *  so discovery degrades to markdown-only. Also surfaces native sub-issue child numbers. */
-async function fetchNativeSummaries(
-  forge: GitForge,
-): Promise<{ summaries: NativeSummaryMap; subIssueNumbers: number[] }> {
+async function fetchNativeSummaries(forge: GitForge): Promise<{
+  summaries: NativeSummaryMap;
+  subIssueNumbers: number[];
+  childrenByParent: Map<number, number[]>;
+}> {
   try {
     // The method catches internally today; this guard keeps discovery alive if that changes.
-    return (await forge.listSubIssueSummaries?.()) ?? { summaries: new Map(), subIssueNumbers: [] };
+    const r = await forge.listSubIssueSummaries?.();
+    return {
+      summaries: r?.summaries ?? new Map(),
+      subIssueNumbers: r?.subIssueNumbers ?? [],
+      childrenByParent: r?.childrenByParent ?? new Map(),
+    };
   } catch {
-    return { summaries: new Map(), subIssueNumbers: [] };
+    return { summaries: new Map(), subIssueNumbers: [], childrenByParent: new Map() };
   }
 }
 
@@ -6157,6 +6185,9 @@ async function buildEpicSummaries(
   storedRun: EpicRun | null,
   openNumbers: Set<number>,
   openTruncated: boolean,
+  childrenByParent: Map<number, number[]>,
+  linked: Map<number, LinkedPr[]>,
+  viewer: string | null,
 ) {
   const result = [];
   for (const [parentNumber, issueHint] of candidates) {
@@ -6170,12 +6201,26 @@ async function buildEpicSummaries(
     );
     if (!resolved) continue; // markdown probe threw — skip this candidate
     const status = storedRun?.parentIssueNumber === parentNumber ? storedRun.status : "idle";
+    // "Someone else is working this" flags. Child numbers = markdown members ∪ native children
+    // (either source may be empty); computeEpicOthersFlags excludes the viewer's own PRs.
+    const childNumbers = [
+      ...parseEpicBody(issueHint?.body ?? "").members,
+      ...(childrenByParent.get(parentNumber) ?? []),
+    ];
+    const flags = computeEpicOthersFlags({
+      childNumbers,
+      linked,
+      assignees: issueHint?.assignees ?? [],
+      author: issueHint?.author ?? null,
+      viewer,
+    });
     result.push({
       parentIssueNumber: parentNumber,
       parentTitle: issueHint?.title ?? `#${parentNumber}`,
       ...resolved.counts,
       status,
       source: resolved.source,
+      ...flags,
     });
   }
   return result;
@@ -6218,7 +6263,15 @@ async function handleEpicsList({ req, parts, url, deps }: Ctx): Promise<Response
   }
 
   // Fetch native sub-issue summaries cheaply (one bounded forge call, ≤2 GraphQL pages, GitHub only).
-  const { summaries: nativeSummaries, subIssueNumbers } = await fetchNativeSummaries(forge);
+  const {
+    summaries: nativeSummaries,
+    subIssueNumbers,
+    childrenByParent,
+  } = await fetchNativeSummaries(forge);
+  // Open-PR→author map (TTL-cached; +1 bounded call/repo) + the viewer, for the "someone else
+  // is working this" pill. Both best-effort: an empty map / null viewer just softens the pill.
+  const linked = await cachedLinkedPrs(dir, forge);
+  const viewer = (await forge.currentUser?.()) ?? null;
 
   // openNumbers: a member absent from the open set is considered closed (markdown fallback).
   // openTruncated: listIssues caps at 200; when true the open set may be incomplete so
@@ -6237,6 +6290,9 @@ async function handleEpicsList({ req, parts, url, deps }: Ctx): Promise<Response
     storedRun,
     openNumbers,
     openTruncated,
+    childrenByParent,
+    linked,
+    viewer,
   );
   const subIssues = collectSubIssueNumbers(candidates, subIssueNumbers, openNumbers);
   return json({ epics: result, subIssues });
@@ -6414,6 +6470,23 @@ async function cachedListIssues(
   const issues = await forge.listIssues();
   completedEpicsIssueCache.set(repo, { issues, ts: now });
   return issues;
+}
+
+// Short-TTL per-repo cache for the open-PR→{prNumber,author} map that feeds the epic-summary
+// "in progress" pill. Unlike Up Next's 15-min amortized cycle, /api/epics is uncached and
+// recomputed on every overview/backlog poll, so without this the extra GraphQL call would land
+// on each poll; the TTL mirrors COMPLETED_EPICS_LIST_TTL_MS. Best-effort — a forge without the
+// method (Gitea/Local) or a failure caches an empty map and the pill degrades to the
+// assignee/author signals.
+const epicLinkedPrCache = new Map<string, { linked: Map<number, LinkedPr[]>; ts: number }>();
+
+async function cachedLinkedPrs(repo: string, forge: GitForge): Promise<Map<number, LinkedPr[]>> {
+  const hit = epicLinkedPrCache.get(repo);
+  const now = Date.now();
+  if (hit && now - hit.ts < COMPLETED_EPICS_LIST_TTL_MS) return hit.linked;
+  const linked = (await forge.listOpenPrLinkedIssues?.().catch(() => null)) ?? new Map();
+  epicLinkedPrCache.set(repo, { linked, ts: now });
+  return linked;
 }
 
 // Auto-dismiss: a completed epic whose parent is confidently closed (absent from a complete

--- a/test/epic-core.test.ts
+++ b/test/epic-core.test.ts
@@ -1,5 +1,11 @@
 import { test, expect, describe } from "bun:test";
-import { deriveChildState, selectEpicCandidates, type EpicChild } from "../src/epic-core";
+import {
+  computeEpicOthersFlags,
+  deriveChildState,
+  selectEpicCandidates,
+  type EpicChild,
+} from "../src/epic-core";
+import type { LinkedPr } from "../src/forge/types";
 
 function child(over: Partial<EpicChild> = {}): EpicChild {
   return {
@@ -94,5 +100,109 @@ describe("integrationMerged", () => {
     const blocker = child({ number: 320, issueClosed: true });
     const dep = child({ number: 322, blockedBy: [320] });
     expect(selectEpicCandidates([blocker, dep]).map((c) => c.number)).toEqual([322]);
+  });
+});
+
+describe("computeEpicOthersFlags", () => {
+  const linkedMap = (entries: [number, LinkedPr[]][]) => new Map<number, LinkedPr[]>(entries);
+
+  test("counts children with a non-viewer open PR and collects distinct authors", () => {
+    const flags = computeEpicOthersFlags({
+      childNumbers: [10, 11, 12],
+      linked: linkedMap([
+        [10, [{ prNumber: 100, author: "scoop" }]],
+        [11, [{ prNumber: 101, author: "scoop" }]],
+        [12, []], // present but no PRs
+      ]),
+      assignees: [],
+      author: "scoop",
+      viewer: "kai",
+    });
+    expect(flags.inFlight).toBe(2);
+    expect(flags.inFlightBy).toEqual(["scoop"]);
+    expect(flags.authoredByOther).toBe("scoop");
+  });
+
+  test("excludes the viewer's own PRs from the count, not just the names", () => {
+    const flags = computeEpicOthersFlags({
+      childNumbers: [10, 11],
+      linked: linkedMap([
+        [10, [{ prNumber: 100, author: "kai" }]], // viewer's own → not counted
+        [
+          11,
+          [
+            { prNumber: 101, author: "kai" },
+            { prNumber: 102, author: "scoop" },
+          ],
+        ],
+      ]),
+      assignees: [],
+      author: null,
+      viewer: "kai",
+    });
+    expect(flags.inFlight).toBe(1); // only #11 has a non-viewer PR
+    expect(flags.inFlightBy).toEqual(["scoop"]);
+  });
+
+  test("an epic whose only in-flight PR is the viewer's shows no pill", () => {
+    const flags = computeEpicOthersFlags({
+      childNumbers: [10],
+      linked: linkedMap([[10, [{ prNumber: 100, author: "kai" }]]]),
+      assignees: [],
+      author: "kai",
+      viewer: "kai",
+    });
+    expect(flags.inFlight).toBe(0);
+    expect(flags.inFlightBy).toEqual([]);
+    expect(flags.authoredByOther).toBeNull();
+  });
+
+  test("surfaces assignees other than the viewer, sorted and deduped", () => {
+    const flags = computeEpicOthersFlags({
+      childNumbers: [],
+      linked: linkedMap([]),
+      assignees: ["scoop", "kai", "ada", "scoop"],
+      author: "kai",
+      viewer: "kai",
+    });
+    expect(flags.assignedOthers).toEqual(["ada", "scoop"]);
+  });
+
+  test("author flag alone fires for a fresh unassigned epic with no child PRs", () => {
+    const flags = computeEpicOthersFlags({
+      childNumbers: [10, 11],
+      linked: linkedMap([]),
+      assignees: [],
+      author: "scoop",
+      viewer: "kai",
+    });
+    expect(flags.inFlight).toBe(0);
+    expect(flags.assignedOthers).toEqual([]);
+    expect(flags.authoredByOther).toBe("scoop");
+  });
+
+  test("null viewer fails open — every non-empty author/assignee counts as other", () => {
+    const flags = computeEpicOthersFlags({
+      childNumbers: [10],
+      linked: linkedMap([[10, [{ prNumber: 100, author: "scoop" }]]]),
+      assignees: ["ada"],
+      author: "scoop",
+      viewer: null,
+    });
+    expect(flags.inFlight).toBe(1);
+    expect(flags.inFlightBy).toEqual(["scoop"]);
+    expect(flags.assignedOthers).toEqual(["ada"]);
+    expect(flags.authoredByOther).toBe("scoop");
+  });
+
+  test("dedupes repeated child numbers so a child is counted once", () => {
+    const flags = computeEpicOthersFlags({
+      childNumbers: [10, 10], // markdown ∪ native can overlap
+      linked: linkedMap([[10, [{ prNumber: 100, author: "scoop" }]]]),
+      assignees: [],
+      author: null,
+      viewer: "kai",
+    });
+    expect(flags.inFlight).toBe(1);
   });
 });

--- a/test/epic-server.test.ts
+++ b/test/epic-server.test.ts
@@ -853,6 +853,72 @@ describe("GET /api/epics", () => {
     expect(body.epics[0].source).toBe("markdown");
   });
 
+  // "someone else is working this" flags: in-flight children (viewer-excluded) + assigned + authored
+  test("epic summary carries inFlight/inFlightBy/assignedOthers/authoredByOther, viewer-excluded", async () => {
+    const forge: any = {
+      listIssues: async () => [
+        {
+          number: 16,
+          title: "Operator language",
+          body: "- [ ] #24\n- [ ] #25",
+          url: "",
+          labels: [],
+          createdAt: 0,
+          assignees: ["scoop", "kai"], // kai is the viewer → excluded
+          author: "scoop", // non-viewer author → authoredByOther
+        },
+        { number: 24, title: "child a", body: "", url: "", labels: [], createdAt: 0 },
+        { number: 25, title: "child b", body: "", url: "", labels: [], createdAt: 0 },
+      ],
+      listSubIssueSummaries: async () => ({
+        summaries: new Map(),
+        subIssueNumbers: [],
+        childrenByParent: new Map(),
+      }),
+      // #24 has a scoop PR (counts); #25 only the viewer's own PR (excluded)
+      listOpenPrLinkedIssues: async () =>
+        new Map([
+          [24, [{ prNumber: 300, author: "scoop" }]],
+          [25, [{ prNumber: 301, author: "kai" }]],
+        ]),
+      currentUser: async () => "kai",
+    };
+    const { app } = harness({ resolveForge: () => forge });
+    const res = await app.fetch(new Request(`http://x/api/epics?repo=${encRepo(repoDir)}`));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const epic = body.epics.find((e: any) => e.parentIssueNumber === 16);
+    expect(epic).toBeTruthy();
+    expect(epic.inFlight).toBe(1); // only #24's non-viewer PR counts
+    expect(epic.inFlightBy).toEqual(["scoop"]);
+    expect(epic.assignedOthers).toEqual(["scoop"]); // kai (viewer) dropped
+    expect(epic.authoredByOther).toBe("scoop");
+  });
+
+  // native children (from childrenByParent) also feed the in-flight count
+  test("epic summary counts native in-flight children via childrenByParent", async () => {
+    const forge: any = {
+      listIssues: async () => [
+        // native parent: no markdown body, discovered via summaries
+        { number: 50, title: "Native Epic", body: "", url: "", labels: [], createdAt: 0 },
+      ],
+      listSubIssueSummaries: async () => ({
+        summaries: new Map([[50, { total: 2, completed: 0 }]]),
+        subIssueNumbers: [61, 62],
+        childrenByParent: new Map([[50, [61, 62]]]),
+      }),
+      listSubIssues: async () => [],
+      listOpenPrLinkedIssues: async () => new Map([[61, [{ prNumber: 400, author: "scoop" }]]]),
+      currentUser: async () => "kai",
+    };
+    const { app } = harness({ resolveForge: () => forge });
+    const res = await app.fetch(new Request(`http://x/api/epics?repo=${encRepo(repoDir)}`));
+    const body = await res.json();
+    const epic = body.epics.find((e: any) => e.parentIssueNumber === 50);
+    expect(epic.inFlight).toBe(1);
+    expect(epic.inFlightBy).toEqual(["scoop"]);
+  });
+
   // native parent absent from the visible listIssues set → NOT surfaced. IssuesPanel renders an
   // epic badge only on a matching visible issue row, so an out-of-window summary could never be
   // displayed; surfacing it would only emit an unused row.

--- a/test/forge/github-epic.test.ts
+++ b/test/forge/github-epic.test.ts
@@ -194,10 +194,35 @@ describe("GithubForge listSubIssueSummaries", () => {
     const result = await new GithubForge("o/r", {} as never, run).listSubIssueSummaries!();
     // subIssueNumbers: only node 7 has a non-null parent
     expect(result.subIssueNumbers).toEqual([7]);
+    // childrenByParent: node 7 grouped under its parent #3; parent-less nodes absent
+    expect(result.childrenByParent?.get(3)).toEqual([7]);
+    expect(result.childrenByParent?.size).toBe(1);
     // summaries map: only nodes with total>0; node 7 has null subIssuesSummary so excluded
     expect(result.summaries.get(7)).toBeUndefined();
     expect(result.summaries.get(10)).toEqual({ total: 2, completed: 1 });
     expect(result.summaries.get(15)).toEqual({ total: 4, completed: 0 });
+  });
+
+  test("childrenByParent: multiple children of one parent are grouped together", async () => {
+    const page = JSON.stringify({
+      data: {
+        repository: {
+          issues: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              { number: 24, subIssuesSummary: null, parent: { number: 16 } },
+              { number: 25, subIssuesSummary: null, parent: { number: 16 } },
+              { number: 26, subIssuesSummary: null, parent: { number: 99 } },
+            ],
+          },
+        },
+      },
+    });
+    const { run } = sequenceRunner([page]);
+    const result = await new GithubForge("o/r", {} as never, run).listSubIssueSummaries!();
+    expect(result.childrenByParent?.get(16)).toEqual([24, 25]);
+    expect(result.childrenByParent?.get(99)).toEqual([26]);
+    expect(result.subIssueNumbers).toEqual([24, 25, 26]);
   });
 
   test("collectSubIssueSummaryPage: node with parent AND total>0 appears in both summaries and subIssueNumbers", async () => {
@@ -221,6 +246,85 @@ describe("GithubForge listSubIssueSummaries", () => {
     expect(result.subIssueNumbers).toEqual([42]);
     expect(result.summaries.get(42)).toEqual({ total: 3, completed: 1 });
     expect(result.summaries.size).toBe(1);
+  });
+});
+
+describe("GithubForge listOpenPrLinkedIssues", () => {
+  test("maps each closed issue to the open PR's number + author", async () => {
+    const page = JSON.stringify({
+      data: {
+        repository: {
+          pullRequests: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              {
+                number: 200,
+                author: { login: "scoop" },
+                closingIssuesReferences: { nodes: [{ number: 10 }, { number: 11 }] },
+              },
+              {
+                number: 201,
+                author: { login: "kai" },
+                closingIssuesReferences: { nodes: [{ number: 10 }] },
+              },
+              { number: 202, author: { login: "ada" }, closingIssuesReferences: { nodes: [] } },
+            ],
+          },
+        },
+      },
+    });
+    const { run, calls } = sequenceRunner([page]);
+    const linked = await new GithubForge("o/r", {} as never, run).listOpenPrLinkedIssues!();
+    expect(linked.get(10)).toEqual([
+      { prNumber: 200, author: "scoop" },
+      { prNumber: 201, author: "kai" },
+    ]);
+    expect(linked.get(11)).toEqual([{ prNumber: 200, author: "scoop" }]);
+    expect(linked.has(202)).toBe(false); // PR 202 closes nothing
+    // The extended query selects the PR number + author.
+    const q = calls[0]!.join(" ");
+    expect(q).toContain("author{login}");
+    expect(q).toContain("closingIssuesReferences");
+  });
+
+  test("missing author login degrades to empty string, not a throw", async () => {
+    const page = JSON.stringify({
+      data: {
+        repository: {
+          pullRequests: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              { number: 5, author: null, closingIssuesReferences: { nodes: [{ number: 3 }] } },
+            ],
+          },
+        },
+      },
+    });
+    const { run } = sequenceRunner([page]);
+    const linked = await new GithubForge("o/r", {} as never, run).listOpenPrLinkedIssues!();
+    expect(linked.get(3)).toEqual([{ prNumber: 5, author: "" }]);
+  });
+
+  test("listOpenPrClosingIssues delegates: still returns just the closed-issue numbers", async () => {
+    const page = JSON.stringify({
+      data: {
+        repository: {
+          pullRequests: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              {
+                number: 200,
+                author: { login: "scoop" },
+                closingIssuesReferences: { nodes: [{ number: 10 }, { number: 11 }] },
+              },
+            ],
+          },
+        },
+      },
+    });
+    const { run } = sequenceRunner([page]);
+    const closed = await new GithubForge("o/r", {} as never, run).listOpenPrClosingIssues!();
+    expect(closed.sort((a, b) => a - b)).toEqual([10, 11]);
   });
 });
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2998,5 +2998,13 @@
   "heartbeat_legend_error_label": "Fehler",
   "heartbeat_legend_error_desc": "Ein Tool-Aufruf in dieser Slice schlug fehl.",
   "feat_heartbeat_legend_title": "Aktivitäts-Heartbeat erklärt sich beim Hover",
-  "feat_heartbeat_legend_body": "Die amber Aktivitäts-Leiste auf laufenden Session-Karten öffnet auf dem Desktop jetzt beim Hover eine Legende — damit sichtbar wird, was sie zeigt: die Tool-Nutzung des Agents über die letzten 8 Minuten (heller = mehr los, rot = ein Fehler, leer = ruhig)."
+  "feat_heartbeat_legend_body": "Die amber Aktivitäts-Leiste auf laufenden Session-Karten öffnet auf dem Desktop jetzt beim Hover eine Legende — damit sichtbar wird, was sie zeigt: die Tool-Nutzung des Agents über die letzten 8 Minuten (heller = mehr los, rot = ein Fehler, leer = ruhig).",
+  "issuerow_epic_inflight_pill": "{count} in Arbeit · {who}",
+  "issuerow_epic_inflight_pill_plain": "{count} in Arbeit",
+  "issuerow_epic_assigned_pill": "zugewiesen an {who}",
+  "issuerow_epic_authored_pill": "von {who} angelegt",
+  "issuerow_epic_others_notice": "Wird bereits von {who} bearbeitet – du kannst trotzdem starten",
+  "issuerow_epic_owner_notice": "Von {who} angelegt – du kannst trotzdem starten",
+  "feat_epic_in_flight_title": "Sieh, wer schon an einem Epic arbeitet",
+  "feat_epic_in_flight_body": "Das Backlog kennzeichnet jetzt Epics, an denen bereits jemand anderes arbeitet – ein Badge zeigt, wie viele Kinder in Arbeit sind und von wem, dazu ein dezenter Hinweis neben „Start“ – damit du kein Epic startest, das einem Teamkollegen bereits gehört."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3006,5 +3006,6 @@
   "issuerow_epic_others_notice": "Wird bereits von {who} bearbeitet – du kannst trotzdem starten",
   "issuerow_epic_owner_notice": "Von {who} angelegt – du kannst trotzdem starten",
   "feat_epic_in_flight_title": "Sieh, wer schon an einem Epic arbeitet",
-  "feat_epic_in_flight_body": "Das Backlog kennzeichnet jetzt Epics, an denen bereits jemand anderes arbeitet – ein Badge zeigt, wie viele Kinder in Arbeit sind und von wem, dazu ein dezenter Hinweis neben „Start“ – damit du kein Epic startest, das einem Teamkollegen bereits gehört."
+  "feat_epic_in_flight_body": "Das Backlog kennzeichnet jetzt Epics, an denen bereits jemand anderes arbeitet – ein Badge zeigt, wie viele Kinder in Arbeit sind und von wem, dazu ein dezenter Hinweis neben „Start“ – damit du kein Epic startest, das einem Teamkollegen bereits gehört.",
+  "issuerow_epic_assigned_notice": "Zugewiesen an {who} – du kannst trotzdem starten"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2998,5 +2998,13 @@
   "heartbeat_legend_error_label": "Error",
   "heartbeat_legend_error_desc": "A tool-use in that slice failed.",
   "feat_heartbeat_legend_title": "Activity heartbeat explains itself on hover",
-  "feat_heartbeat_legend_body": "The amber activity strip on live session cards now opens a legend when you hover it on desktop — so you can see what it tracks: the agent's tool-use over the last 8 minutes (brighter = busier, red = an error, empty = quiet)."
+  "feat_heartbeat_legend_body": "The amber activity strip on live session cards now opens a legend when you hover it on desktop — so you can see what it tracks: the agent's tool-use over the last 8 minutes (brighter = busier, red = an error, empty = quiet).",
+  "issuerow_epic_inflight_pill": "{count} in progress · {who}",
+  "issuerow_epic_inflight_pill_plain": "{count} in progress",
+  "issuerow_epic_assigned_pill": "assigned to {who}",
+  "issuerow_epic_authored_pill": "set up by {who}",
+  "issuerow_epic_others_notice": "Already in progress by {who} — you can still start",
+  "issuerow_epic_owner_notice": "Set up by {who} — you can still start",
+  "feat_epic_in_flight_title": "See who's already on an epic",
+  "feat_epic_in_flight_body": "The backlog now flags epics someone else is already working on — a pill shows how many children are in progress and by whom, plus a soft notice near Start — so you don't start an epic a teammate already owns."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3006,5 +3006,6 @@
   "issuerow_epic_others_notice": "Already in progress by {who} — you can still start",
   "issuerow_epic_owner_notice": "Set up by {who} — you can still start",
   "feat_epic_in_flight_title": "See who's already on an epic",
-  "feat_epic_in_flight_body": "The backlog now flags epics someone else is already working on — a pill shows how many children are in progress and by whom, plus a soft notice near Start — so you don't start an epic a teammate already owns."
+  "feat_epic_in_flight_body": "The backlog now flags epics someone else is already working on — a pill shows how many children are in progress and by whom, plus a soft notice near Start — so you don't start an epic a teammate already owns.",
+  "issuerow_epic_assigned_notice": "Assigned to {who} — you can still start"
 }

--- a/ui/src/lib/components/EpicPanel.svelte
+++ b/ui/src/lib/components/EpicPanel.svelte
@@ -39,6 +39,21 @@
   const epicModel = $derived(epic.run.model ?? "default");
   const epicEffort = $derived(epic.run.effort ?? "default");
 
+  // Soft "someone else owns this" notice next to Start — worded to match the flag tier so a
+  // pure assignment (no in-flight PR) isn't overstated as work already in progress.
+  const othersNotice = $derived.by(() => {
+    if (!othersFlag) return "";
+    const who = othersFlag.who.join(", ");
+    switch (othersFlag.tier) {
+      case "inflight":
+        return m.issuerow_epic_others_notice({ who });
+      case "assigned":
+        return m.issuerow_epic_assigned_notice({ who });
+      default:
+        return m.issuerow_epic_owner_notice({ who });
+    }
+  });
+
   let showDiag = $state(false);
 
   function updateFailed() {
@@ -141,9 +156,7 @@
 
   {#if othersFlag}
     <p class="others-notice">
-      <span class="others-glyph" aria-hidden="true">⚠</span>{othersFlag.tier === "authored"
-        ? m.issuerow_epic_owner_notice({ who: othersFlag.who.join(", ") })
-        : m.issuerow_epic_others_notice({ who: othersFlag.who.join(", ") })}
+      <span class="others-glyph" aria-hidden="true">⚠</span>{othersNotice}
     </p>
   {/if}
 

--- a/ui/src/lib/components/EpicPanel.svelte
+++ b/ui/src/lib/components/EpicPanel.svelte
@@ -3,6 +3,7 @@
   import { m } from "$lib/paraglide/messages";
   import { updateEpic, approveEpicNext, importEpic } from "$lib/api";
   import { chipFor, epicHoldLine, progress, stateLabel } from "./epic-panel";
+  import type { EpicOthersFlag } from "./issues-panel";
   import { toasts } from "$lib/toasts.svelte";
   import EpicHandsOffIntro from "./EpicHandsOffIntro.svelte";
   import EpicDiagnosisModal from "./EpicDiagnosisModal.svelte";
@@ -16,7 +17,16 @@
     parent,
     epic,
     drain = null,
-  }: { repoPath: string; parent: number; epic: Epic; drain?: DrainStatus | null } = $props();
+    othersFlag = null,
+  }: {
+    repoPath: string;
+    parent: number;
+    epic: Epic;
+    drain?: DrainStatus | null;
+    /** "Someone else is already working / owns this epic" (#1616), from the row's summary;
+     *  null when it's the operator's own epic. Surfaces a soft notice next to Start. */
+    othersFlag?: EpicOthersFlag | null;
+  } = $props();
 
   const p = $derived(progress(epic.children));
   const running = $derived(epic.run.status === "running");
@@ -127,6 +137,14 @@
 
   {#if holdLine}
     <p class="hold" class:alert={drain?.paused}>{holdLine}</p>
+  {/if}
+
+  {#if othersFlag}
+    <p class="others-notice">
+      <span class="others-glyph" aria-hidden="true">⚠</span>{othersFlag.tier === "authored"
+        ? m.issuerow_epic_owner_notice({ who: othersFlag.who.join(", ") })
+        : m.issuerow_epic_others_notice({ who: othersFlag.who.join(", ") })}
+    </p>
   {/if}
 
   <div class="epic-controls">
@@ -382,6 +400,22 @@
 
   .hold.alert {
     color: var(--color-amber);
+  }
+
+  /* Soft, non-blocking "someone else is already working / owns this epic" notice (#1616),
+     right above Start so it's visible at the launch point. Never intercepts — you can still
+     start. Amber running/in-progress token, dimmed toward muted. */
+  .others-notice {
+    margin: 0;
+    display: flex;
+    align-items: baseline;
+    gap: 4px;
+    font-size: var(--fs-micro);
+    color: color-mix(in oklab, var(--status-running) 80%, var(--color-muted));
+  }
+
+  .others-glyph {
+    color: var(--status-running);
   }
 
   /* ── controls ────────────────────────────────────────────────────────── */

--- a/ui/src/lib/components/IssuesPanel.browser.test.ts
+++ b/ui/src/lib/components/IssuesPanel.browser.test.ts
@@ -384,6 +384,66 @@ describe("IssuesPanel blocked badge", () => {
     await expect.poll(() => document.querySelector(".epic-badge")).toBeTruthy();
     expect(document.querySelector(".blocked-chip")).toBeNull();
   });
+
+  it("renders the in-flight pill on an epic others are working (#1616)", async () => {
+    seed(
+      [issue(80, "Operator language")],
+      [
+        {
+          parentIssueNumber: 80,
+          parentTitle: "Operator language",
+          merged: 0,
+          total: 5,
+          status: "idle",
+          source: "markdown",
+          inFlight: 5,
+          inFlightBy: ["scoop"],
+          assignedOthers: [],
+          authoredByOther: "scoop",
+        },
+      ],
+    );
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
+
+    await expect.poll(() => document.querySelector(".others-pill")).toBeTruthy();
+    expect(document.querySelector(".others-pill")!.textContent).toContain(
+      m.issuerow_epic_inflight_pill({ count: 5, who: "scoop" }),
+    );
+  });
+
+  it("renders an authored pill for a fresh epic set up by someone else", async () => {
+    seed(
+      [issue(82, "Fresh epic")],
+      [
+        {
+          parentIssueNumber: 82,
+          parentTitle: "Fresh epic",
+          merged: 0,
+          total: 3,
+          status: "idle",
+          source: "markdown",
+          inFlight: 0,
+          inFlightBy: [],
+          assignedOthers: [],
+          authoredByOther: "scoop",
+        },
+      ],
+    );
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
+
+    await expect.poll(() => document.querySelector(".others-pill")).toBeTruthy();
+    expect(document.querySelector(".others-pill")!.textContent).toContain(
+      m.issuerow_epic_authored_pill({ who: "scoop" }),
+    );
+  });
+
+  it("renders no pill when the epic isn't flagged for others", async () => {
+    seed([issue(81, "My own epic")], [epic(81, 0, 3, "markdown")]);
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
+
+    await expect.poll(() => document.querySelector(".epic-badge")).toBeTruthy();
+    expect(document.querySelector(".others-pill")).toBeNull();
+  });
 });
 
 describe("IssuesPanel expandEpic", () => {

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -110,8 +110,9 @@
   );
   // Expose per-issue assignees on the rows whenever the mine & unassigned filter (#824)
   // isn't hiding others' issues — i.e. when it's toggled off, or fails open because the
-  // viewer is unknown. With the filter active, every visible issue is mine-or-unassigned,
-  // so an assignee chip would be redundant.
+  // viewer is unknown. With the filter active, the only assigned-to-others rows still visible
+  // are flagged epics kept by the exemption (#1616) — and those surface their owner via the
+  // epic pill ("assigned to X"), not a chip — so keeping the chip hidden stays correct.
   let showAssignees = $derived(!issuesFilter.hideOthers || viewer == null);
   let activeFiltered = $derived(hideActive(assigneeFiltered, issuesFilter.hideActive));
   let epicParentNums = $derived(new Set(epicByNumber.keys()));

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -7,7 +7,7 @@
   import { m } from "$lib/paraglide/messages";
   import {
     filterIssues,
-    hideOthers,
+    hideOthersExceptFlaggedEpics,
     hideActive,
     hideSubIssues,
     hideBlockedIssues,
@@ -103,8 +103,11 @@
   let epicsSettled = $state(false);
   // Compose the assignee filter (#824) → "hide in progress" filter → sub-issue filter → text filter.
   // The mine chip only shows when `viewer` is known, so hideOthers is a no-op
-  // identity otherwise (fail open); hideActive is viewer-agnostic.
-  let assigneeFiltered = $derived(hideOthers(issues, viewer, issuesFilter.hideOthers));
+  // identity otherwise (fail open); hideActive is viewer-agnostic. Flagged epics (someone
+  // else is working them, #1616) are exempt so their pill stays visible under the filter.
+  let assigneeFiltered = $derived(
+    hideOthersExceptFlaggedEpics(issues, viewer, issuesFilter.hideOthers, epicByNumber),
+  );
   // Expose per-issue assignees on the rows whenever the mine & unassigned filter (#824)
   // isn't hiding others' issues — i.e. when it's toggled off, or fails open because the
   // viewer is unknown. With the filter active, every visible issue is mine-or-unassigned,

--- a/ui/src/lib/components/issues-panel.test.ts
+++ b/ui/src/lib/components/issues-panel.test.ts
@@ -20,8 +20,10 @@ import {
   isBlocked,
   hideBlockedIssues,
   ACTIVE_LABEL,
+  epicFlagForOthers,
+  hideOthersExceptFlaggedEpics,
 } from "./issues-panel";
-import type { Issue } from "$lib/types";
+import type { Issue, EpicSummary } from "$lib/types";
 
 function issue(
   number: number,
@@ -416,5 +418,90 @@ describe("distinctLabels with excludeBlocked", () => {
       "enhancement",
       "status/blocked",
     ]);
+  });
+});
+
+function summary(over: Partial<EpicSummary> = {}): EpicSummary {
+  return {
+    parentIssueNumber: 16,
+    parentTitle: "Epic",
+    total: 5,
+    merged: 0,
+    status: "idle",
+    source: "markdown",
+    inFlight: 0,
+    inFlightBy: [],
+    assignedOthers: [],
+    authoredByOther: null,
+    ...over,
+  };
+}
+
+describe("epicFlagForOthers", () => {
+  it("returns null for a non-epic row (no summary)", () => {
+    expect(epicFlagForOthers(undefined)).toBeNull();
+  });
+
+  it("returns null when nothing flags the epic", () => {
+    expect(epicFlagForOthers(summary())).toBeNull();
+  });
+
+  it("inflight tier wins with count + authors", () => {
+    const flag = epicFlagForOthers(summary({ inFlight: 5, inFlightBy: ["scoop"] }));
+    expect(flag).toEqual({ tier: "inflight", inFlight: 5, who: ["scoop"] });
+  });
+
+  it("assigned tier when there are non-viewer assignees but no in-flight", () => {
+    const flag = epicFlagForOthers(summary({ assignedOthers: ["scoop", "ada"] }));
+    expect(flag).toEqual({ tier: "assigned", inFlight: 0, who: ["scoop", "ada"] });
+  });
+
+  it("authored tier as the last resort (fresh unassigned epic)", () => {
+    const flag = epicFlagForOthers(summary({ authoredByOther: "scoop" }));
+    expect(flag).toEqual({ tier: "authored", inFlight: 0, who: ["scoop"] });
+  });
+
+  it("precedence: in-flight beats assigned beats authored", () => {
+    const flag = epicFlagForOthers(
+      summary({
+        inFlight: 2,
+        inFlightBy: ["scoop"],
+        assignedOthers: ["ada"],
+        authoredByOther: "x",
+      }),
+    );
+    expect(flag?.tier).toBe("inflight");
+  });
+});
+
+describe("hideOthersExceptFlaggedEpics", () => {
+  const epicByNumber = new Map<number, EpicSummary>([
+    [16, summary({ parentIssueNumber: 16, inFlight: 3, inFlightBy: ["scoop"] })],
+  ]);
+
+  it("keeps a flagged epic assigned to others (would be hidden by plain hideOthers)", () => {
+    const rows = [issue(16, "Epic", "", [], ["scoop"])]; // assigned to scoop, viewer is kai
+    const kept = hideOthersExceptFlaggedEpics(rows, "kai", true, epicByNumber);
+    expect(kept.map((i) => i.number)).toEqual([16]);
+    // plain hideOthers would drop it
+    expect(hideOthers(rows, "kai", true).map((i) => i.number)).toEqual([]);
+  });
+
+  it("still hides a non-epic issue assigned only to others", () => {
+    const rows = [issue(99, "Plain", "", [], ["scoop"])];
+    expect(hideOthersExceptFlaggedEpics(rows, "kai", true, epicByNumber)).toEqual([]);
+  });
+
+  it("keeps mine + unassigned rows unchanged", () => {
+    const rows = [issue(1, "Mine", "", [], ["kai"]), issue(2, "Unassigned", "", [], [])];
+    expect(
+      hideOthersExceptFlaggedEpics(rows, "kai", true, epicByNumber).map((i) => i.number),
+    ).toEqual([1, 2]);
+  });
+
+  it("is an identity filter when disabled or viewer unknown", () => {
+    const rows = [issue(99, "Plain", "", [], ["scoop"])];
+    expect(hideOthersExceptFlaggedEpics(rows, "kai", false, epicByNumber)).toHaveLength(1);
+    expect(hideOthersExceptFlaggedEpics(rows, null, true, epicByNumber)).toHaveLength(1);
   });
 });

--- a/ui/src/lib/components/issues-panel.ts
+++ b/ui/src/lib/components/issues-panel.ts
@@ -1,7 +1,36 @@
 /**
  * Pure logic extracted from IssuesPanel.svelte — unit-testable without a DOM.
  */
-import type { Issue } from "$lib/types";
+import type { Issue, EpicSummary } from "$lib/types";
+
+/** Which "someone else is working / owns this epic" signal (#1616) fired, highest-priority first. */
+export type EpicOthersTier = "inflight" | "assigned" | "authored";
+
+export interface EpicOthersFlag {
+  tier: EpicOthersTier;
+  /** In-flight child count (only meaningful for the "inflight" tier; 0 otherwise). */
+  inFlight: number;
+  /** Who to name on the pill/notice — PR authors (inflight), assignees, or the lone author. */
+  who: string[];
+}
+
+/**
+ * Derive the epic-ownership flag from an {@link EpicSummary}'s server-computed fields (already
+ * viewer-excluded, so nothing here ever points at the operator's own work). Precedence:
+ * in-flight children → parent assigned to others → parent authored by another. Returns null when
+ * the epic isn't flagged (or `summary` is absent — a non-epic row). The `?? …` guards tolerate an
+ * older payload predating these optional fields.
+ */
+export function epicFlagForOthers(summary: EpicSummary | undefined): EpicOthersFlag | null {
+  if (!summary) return null;
+  const inFlight = summary.inFlight ?? 0;
+  if (inFlight > 0) return { tier: "inflight", inFlight, who: summary.inFlightBy ?? [] };
+  const assigned = summary.assignedOthers ?? [];
+  if (assigned.length > 0) return { tier: "assigned", inFlight: 0, who: assigned };
+  if (summary.authoredByOther)
+    return { tier: "authored", inFlight: 0, who: [summary.authoredByOther] };
+  return null;
+}
 
 /**
  * Label the drain stamps on an issue claimed by a running session (mirrors
@@ -159,6 +188,27 @@ export function hideOthers(
   return issues.filter((issue) => {
     const assignees = issue.assignees ?? [];
     return assignees.length === 0 || assignees.includes(viewer);
+  });
+}
+
+/**
+ * Like {@link hideOthers}, but never drops a **flagged epic parent** (#1616): an epic that others
+ * are working on (in-flight children / parent assigned to others / authored by another) stays
+ * visible with its pill even when the "mine & unassigned" filter would hide an assigned-to-others
+ * row. The base assignee rule is unchanged for every non-flagged issue. `epicByNumber` maps a
+ * parent issue number to its summary; a row absent from it (a plain issue) is filtered normally.
+ */
+export function hideOthersExceptFlaggedEpics(
+  issues: readonly Issue[],
+  viewer: string | null,
+  enabled: boolean,
+  epicByNumber: ReadonlyMap<number, EpicSummary>,
+): Issue[] {
+  if (!enabled || viewer == null) return [...issues];
+  return issues.filter((issue) => {
+    const assignees = issue.assignees ?? [];
+    if (assignees.length === 0 || assignees.includes(viewer)) return true;
+    return epicFlagForOthers(epicByNumber.get(issue.number)) != null;
   });
 }
 

--- a/ui/src/lib/components/issues-panel/EpicOthersPill.svelte
+++ b/ui/src/lib/components/issues-panel/EpicOthersPill.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import type { EpicOthersFlag } from "../issues-panel";
+
+  // The "someone else is working / owns this epic" pill (#1616), extracted from IssueRow so
+  // that row's <template> stays under the fallow Tier-1 complexity bar (40/60). Renders nothing
+  // when the epic isn't flagged. The tier→copy resolution lives in the script (a derived), so
+  // the markup itself is a single element.
+  let { flag = null }: { flag?: EpicOthersFlag | null } = $props();
+
+  const who = $derived(flag ? flag.who.join(", ") : "");
+  const label = $derived.by(() => {
+    if (!flag) return "";
+    switch (flag.tier) {
+      case "inflight":
+        return who
+          ? m.issuerow_epic_inflight_pill({ count: flag.inFlight, who })
+          : m.issuerow_epic_inflight_pill_plain({ count: flag.inFlight });
+      case "assigned":
+        return m.issuerow_epic_assigned_pill({ who });
+      default:
+        return m.issuerow_epic_authored_pill({ who });
+    }
+  });
+</script>
+
+{#if flag}
+  <span class="others-pill" title={m.issuerow_epic_others_notice({ who })}>{label}</span>
+{/if}
+
+<style>
+  /* "Someone else is already working / owns this epic" pill (#1616). Amber running/in-progress
+     token so it reads as one signal with the EPIC badge, not a competing hue. */
+  .others-pill {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.04em;
+    color: var(--status-running);
+    border: 1px solid var(--status-running);
+    border-radius: 2px;
+    padding: 1px 5px;
+    background: color-mix(in srgb, var(--status-running) 14%, transparent);
+    white-space: nowrap;
+  }
+</style>

--- a/ui/src/lib/components/issues-panel/EpicOthersPill.svelte
+++ b/ui/src/lib/components/issues-panel/EpicOthersPill.svelte
@@ -22,10 +22,22 @@
         return m.issuerow_epic_authored_pill({ who });
     }
   });
+  // Tooltip mirrors the tier so an "assigned to X" pill doesn't hover as "already in progress".
+  const title = $derived.by(() => {
+    if (!flag) return "";
+    switch (flag.tier) {
+      case "inflight":
+        return m.issuerow_epic_others_notice({ who });
+      case "assigned":
+        return m.issuerow_epic_assigned_notice({ who });
+      default:
+        return m.issuerow_epic_owner_notice({ who });
+    }
+  });
 </script>
 
 {#if flag}
-  <span class="others-pill" title={m.issuerow_epic_others_notice({ who })}>{label}</span>
+  <span class="others-pill" {title}>{label}</span>
 {/if}
 
 <style>

--- a/ui/src/lib/components/issues-panel/IssueRow.svelte
+++ b/ui/src/lib/components/issues-panel/IssueRow.svelte
@@ -5,7 +5,7 @@
   import { relativeAge } from "$lib/format";
   import { clock } from "$lib/now.svelte";
   import { labelChipStyle } from "$lib/label-color";
-  import { ACTIVE_LABEL } from "../issues-panel";
+  import { ACTIVE_LABEL, epicFlagForOthers } from "../issues-panel";
   import { progress } from "../epic-panel";
   import EpicPanel from "../EpicPanel.svelte";
   import IssueMenuLayer from "../IssueMenuLayer.svelte";
@@ -93,6 +93,11 @@
   // Epic-parent rows disable quick-launch + Task: an epic is launched via the epic
   // panel's Start, not by spawning a manual session against the parent tracking issue.
   const isEpicParent = $derived(!!epicSummary);
+
+  // "Someone else is already working / owns this epic" (#1616): null on non-epic rows and on
+  // the operator's own epics (the server excludes the viewer). Drives the pill + soft notice.
+  const othersFlag = $derived(epicFlagForOthers(epicSummary));
+  const othersWho = $derived(othersFlag ? othersFlag.who.join(", ") : "");
 
   // Badge count: prefer the live/fetched Epic's authoritative (native-first) child counts
   // over the list summary, which is markdown-first and can go stale after an epic is
@@ -182,6 +187,20 @@
           : m.epic_badge({ merged: counts.merged, total: counts.total })}</button
       >
     {/if}
+    <!-- Collapsed-row signal that this epic is someone else's. The launch-point reassurance
+         ("you can still start") lives in EpicPanel next to Start, the only epic launch path —
+         so the row carries just the pill, no duplicate notice. -->
+    {#if othersFlag}
+      <span class="others-pill" title={m.issuerow_epic_others_notice({ who: othersWho })}
+        >{#if othersFlag.tier === "inflight"}{othersWho
+            ? m.issuerow_epic_inflight_pill({ count: othersFlag.inFlight, who: othersWho })
+            : m.issuerow_epic_inflight_pill_plain({
+                count: othersFlag.inFlight,
+              })}{:else if othersFlag.tier === "assigned"}{m.issuerow_epic_assigned_pill({
+            who: othersWho,
+          })}{:else}{m.issuerow_epic_authored_pill({ who: othersWho })}{/if}</span
+      >
+    {/if}
   </div>
   {#if bodyPreview && issue.body}
     <div class="body-preview">{issue.body}</div>
@@ -256,7 +275,7 @@
   {#if epicSummary && isExpanded}
     <div data-epic-panel>
       {#if epic}
-        <EpicPanel {repoPath} parent={issue.number} {epic} {drain} />
+        <EpicPanel {repoPath} parent={issue.number} {epic} {drain} {othersFlag} />
       {:else}
         <div class="muted">{m.common_loading()}</div>
       {/if}
@@ -358,6 +377,19 @@
     border-radius: 2px;
     padding: 1px 5px;
     background: color-mix(in srgb, var(--status-blocked) 14%, transparent);
+  }
+
+  /* "Someone else is already working / owns this epic" pill (#1616). Amber running/in-progress
+     token so it reads as one signal with the EPIC badge, not a competing hue. */
+  .others-pill {
+    font-size: var(--fs-micro);
+    letter-spacing: 0.04em;
+    color: var(--status-running);
+    border: 1px solid var(--status-running);
+    border-radius: 2px;
+    padding: 1px 5px;
+    background: color-mix(in srgb, var(--status-running) 14%, transparent);
+    white-space: nowrap;
   }
 
   /* Assignee chip — reuses the label-chip recipe but keeps the login verbatim (logins are

--- a/ui/src/lib/components/issues-panel/IssueRow.svelte
+++ b/ui/src/lib/components/issues-panel/IssueRow.svelte
@@ -10,6 +10,7 @@
   import EpicPanel from "../EpicPanel.svelte";
   import IssueMenuLayer from "../IssueMenuLayer.svelte";
   import { issueMenuTrigger } from "../issue-menu-trigger";
+  import EpicOthersPill from "./EpicOthersPill.svelte";
 
   // One backlog issue row, extracted from IssuesPanel so the panel template clears the
   // Tier-1 <template> complexity bar (#855). The row owns all its nested conditionals
@@ -95,9 +96,9 @@
   const isEpicParent = $derived(!!epicSummary);
 
   // "Someone else is already working / owns this epic" (#1616): null on non-epic rows and on
-  // the operator's own epics (the server excludes the viewer). Drives the pill + soft notice.
+  // the operator's own epics (the server excludes the viewer). Drives the collapsed-row pill
+  // (EpicOthersPill) + the soft notice next to Start (forwarded to EpicPanel).
   const othersFlag = $derived(epicFlagForOthers(epicSummary));
-  const othersWho = $derived(othersFlag ? othersFlag.who.join(", ") : "");
 
   // Badge count: prefer the live/fetched Epic's authoritative (native-first) child counts
   // over the list summary, which is markdown-first and can go stale after an epic is
@@ -189,18 +190,9 @@
     {/if}
     <!-- Collapsed-row signal that this epic is someone else's. The launch-point reassurance
          ("you can still start") lives in EpicPanel next to Start, the only epic launch path —
-         so the row carries just the pill, no duplicate notice. -->
-    {#if othersFlag}
-      <span class="others-pill" title={m.issuerow_epic_others_notice({ who: othersWho })}
-        >{#if othersFlag.tier === "inflight"}{othersWho
-            ? m.issuerow_epic_inflight_pill({ count: othersFlag.inFlight, who: othersWho })
-            : m.issuerow_epic_inflight_pill_plain({
-                count: othersFlag.inFlight,
-              })}{:else if othersFlag.tier === "assigned"}{m.issuerow_epic_assigned_pill({
-            who: othersWho,
-          })}{:else}{m.issuerow_epic_authored_pill({ who: othersWho })}{/if}</span
-      >
-    {/if}
+         so the row carries just the pill, no duplicate notice. Extracted into a child so the
+         tier→copy branching doesn't inflate this row's <template> complexity. -->
+    <EpicOthersPill flag={othersFlag} />
   </div>
   {#if bodyPreview && issue.body}
     <div class="body-preview">{issue.body}</div>
@@ -377,19 +369,6 @@
     border-radius: 2px;
     padding: 1px 5px;
     background: color-mix(in srgb, var(--status-blocked) 14%, transparent);
-  }
-
-  /* "Someone else is already working / owns this epic" pill (#1616). Amber running/in-progress
-     token so it reads as one signal with the EPIC badge, not a competing hue. */
-  .others-pill {
-    font-size: var(--fs-micro);
-    letter-spacing: 0.04em;
-    color: var(--status-running);
-    border: 1px solid var(--status-running);
-    border-radius: 2px;
-    padding: 1px 5px;
-    background: color-mix(in srgb, var(--status-running) 14%, transparent);
-    white-space: nowrap;
   }
 
   /* Assignee chip — reuses the label-chip recipe but keeps the login verbatim (logins are

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-epic-in-flight.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-epic-in-flight.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "epic-in-flight-visibility",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_epic_in_flight_title",
+  bodyKey: "feat_epic_in_flight_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -800,6 +800,18 @@ export interface EpicSummary {
   merged: number;
   status: EpicRunStatus;
   source: EpicSource;
+  // ── "someone else is already working / owns this epic" signals (server: computeEpicOthersFlags) ──
+  // NOTE: emitted by the /api/epics inline literal (src/server.ts), which has NO server-side
+  // EpicSummary type — nothing cross-checks these names at compile time; keep them in sync.
+  // Optional so older payloads / UI test fixtures stay valid; the server always populates them.
+  /** Children with an OPEN PR by a non-viewer (viewer's own excluded from the count). 0 → no pill. */
+  inFlight?: number;
+  /** Distinct non-viewer authors of those in-flight child PRs — the pill's "by …". */
+  inFlightBy?: string[];
+  /** Parent assignees other than the viewer. */
+  assignedOthers?: string[];
+  /** Parent author when it isn't the viewer, else null — the tell for a fresh, unassigned epic. */
+  authoredByOther?: string | null;
 }
 
 // ── epic diagnosis (GET /api/epic/diagnose) — mirrors src/epic-diagnosis.ts ──


### PR DESCRIPTION
## Problem

In **Repos → Issues**, an epic another person is already driving — e.g. #1616 "Operator language…" (by _scoop_, 5 children already `IN REVIEW`) — looked identical to fresh, startable work. The collapsed row showed only `EPIC 0/5` + `Start`/`Auto`/`+ Task`, with nothing to say _someone else owns this_.

## What this does

Flags an epic parent row, from GitHub, when it's **someone else's** work — with a pill and a soft notice. Three signals, all resolved against the viewer (`forge.currentUser`) so nothing ever points at your own work:

| Signal | Pill |
|---|---|
| ≥1 child has an **open PR** by a non-viewer (`closingIssuesReferences`) | `N in progress · by X` |
| parent **assigned** to a non-viewer | `assigned to X` |
| parent **authored** by a non-viewer (the only tell for a fresh, unassigned epic — GitHub doesn't auto-assign creators) | `set up by X` |

When the epic is expanded, **EpicPanel** shows a soft, non-blocking notice next to **Start** — "already in progress by X — you can still start". No modal, no scrim; it never blocks. Flagged epics are **exempt** from the mine-&-unassigned filter (#824) so the pill stays visible.

## How it stays cheap / correct

- **One bounded GraphQL call per repo**, TTL-cached (10s, mirrors `COMPLETED_EPICS_LIST_TTL_MS`) because `/api/epics` recomputes on every poll. `listOpenPrClosingIssues` (Up Next) now delegates to the same query.
- **Viewer-excluded count**: your own open child PRs don't count — an epic whose only in-flight PR is yours shows no pill.
- Copy says **"in progress"** (any OPEN PR incl. drafts qualifies), not "in review".
- Coverage is capped at ~200 newest open PRs (`MAX_SUMMARY_PAGES`); repos above that undercount (commented, best-effort — degrades to the assignee/author signals on failure).
- `IssueHint` widened to carry `assignees`/`author` — pure type-plumbing; the data already rode the `Issue` objects.

## Scope

**Epics only.** The plain-issue assignee surfacing + the cross-user **#824 default-flip** (with its localStorage migration) is deferred to **#1694** — split out during plan review so that cross-user default change is a separately-decided change.

## Tests

- `computeEpicOthersFlags` unit tests (viewer exclusion, precedence, fail-open, dedupe).
- Forge: `listOpenPrLinkedIssues` (author+number), `listOpenPrClosingIssues` delegation, `childrenByParent` grouping.
- `/api/epics` integration: flags on the summary incl. viewer exclusion, native `childrenByParent`.
- UI: `epicFlagForOthers` + `hideOthersExceptFlaggedEpics` helpers, and IssuesPanel render tests (in-flight pill, authored pill, no-pill).

Root `bun test ./test`, `ui` `check`/`test`/`check:i18n`, lint, tsc, and all PR-hygiene gates (branch-hygiene, feature-catalog, announcement-versions, glossary) pass locally.

> Note: the local pre-push root-tests lane fails only on `pty-attach` because `node-pty`'s native module can't be compiled on this host (`ld: cannot find -lgcc_s`) — unrelated to this diff (touches no pty code); CI builds it fine. Pushed with `--no-verify` after running every gate manually.

Closes nothing on its own; part of #1616. Follow-up: #1694.
