### PR TITLE
feat(ui): open GitHub repo from chip

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -5080,6 +5080,19 @@ async function handleBranchStatus({ req, parts, url }: Ctx): Promise<Response | 
   return null;
 }
 
+async function handleRepoWeb({ req, parts, url, deps }: Ctx): Promise<Response | null> {
+  if (req.method !== "GET" || parts[0] !== "api" || parts[1] !== "repo-web" || parts[2])
+    return null;
+  const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
+  if (!dir) return json({ error: "invalid repo" }, 400);
+  const forge = deps.resolveForge?.(dir) ?? null;
+  return json({
+    slug: forge?.slug ?? null,
+    webUrl: forge?.webUrl ?? null,
+    kind: forge?.kind ?? null,
+  });
+}
+
 /** Fetch a repo's open issues and, best-effort, attach each one's still-open blockers
  *  (GitHub issue dependencies) as `blockedBy`. The blocked-map fetch fails open — a missing
  *  method (Gitea/local) or a forge error yields no annotations, never a failed request. */
@@ -6845,6 +6858,7 @@ const ROUTE_HANDLERS = [
   handleFsDirs,
   handleBranches,
   handleBranchStatus,
+  handleRepoWeb,
   handleIssues,
   handleIssueCreate,
   handlePrsList,

--- a/test/server-issues.test.ts
+++ b/test/server-issues.test.ts
@@ -62,6 +62,31 @@ function req(repo: string): Request {
   return new Request(`http://localhost/api/issues?repo=${encodeURIComponent(repo)}`);
 }
 
+function repoWebReq(repo: string): Request {
+  return new Request(`http://localhost/api/repo-web?repo=${encodeURIComponent(repo)}`);
+}
+
+test("GET /api/repo-web resolves lightweight forge link metadata", async () => {
+  const app = makeApp(
+    makeDeps(() =>
+      fakeForge({ kind: "github", webUrl: "https://github.com/team/proj" } as Partial<GitForge>),
+    ),
+  );
+  const res = await app.fetch(repoWebReq(repoDir));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({
+    slug: "team/proj",
+    webUrl: "https://github.com/team/proj",
+    kind: "github",
+  });
+});
+
+test("GET /api/repo-web?repo outside root → 400", async () => {
+  const app = makeApp(makeDeps(() => fakeForge()));
+  const res = await app.fetch(repoWebReq("/etc"));
+  expect(res.status).toBe(400);
+});
+
 test("GET /api/issues resolves via the forge → {slug, issues}", async () => {
   const app = makeApp(makeDeps(() => fakeForge()));
   const res = await app.fetch(req(repoDir));

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2986,5 +2986,8 @@
   "diff_view_split": "Geteilt",
   "diff_view_unified": "Vereinheitlicht",
   "feat_diff_review_title": "Ein schärferer Diff-Tab",
-  "feat_diff_review_body": "Der Diff-Tab der Sitzung nutzt jetzt eine neue Engine: Wechsle zwischen Nebeneinander- und vereinheitlichter Ansicht — mit wortgenauer Hervorhebung innerhalb der Zeile, einer Datei-Seitenleiste zur schnellen Navigation und einklappbarem unverändertem Kontext."
+  "feat_diff_review_body": "Der Diff-Tab der Sitzung nutzt jetzt eine neue Engine: Wechsle zwischen Nebeneinander- und vereinheitlichter Ansicht — mit wortgenauer Hervorhebung innerhalb der Zeile, einer Datei-Seitenleiste zur schnellen Navigation und einklappbarem unverändertem Kontext.",
+  "repo_chip_open_github": "GitHub-Repo-Webseite öffnen",
+  "feat_repo_chip_github_link_title": "GitHub über einen Repo-Chip öffnen",
+  "feat_repo_chip_github_link_body": "Rechtsklicke oder halte einen GitHub-Repo-Chip gedrückt, um die Repository-Seite direkt aus dem Herdenkopf zu öffnen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2986,5 +2986,8 @@
   "diff_view_split": "Split",
   "diff_view_unified": "Unified",
   "feat_diff_review_title": "A sharper Diff tab",
-  "feat_diff_review_body": "The session Diff tab now renders through a new engine: switch between side-by-side and unified views, with word-level intra-line highlighting, a file sidebar for quick navigation, and collapsible unchanged context."
+  "feat_diff_review_body": "The session Diff tab now renders through a new engine: switch between side-by-side and unified views, with word-level intra-line highlighting, a file sidebar for quick navigation, and collapsible unchanged context.",
+  "repo_chip_open_github": "Open GitHub Repo-Webpage",
+  "feat_repo_chip_github_link_title": "Open GitHub from a repo chip",
+  "feat_repo_chip_github_link_body": "Right-click or hold a GitHub-backed repo chip and open the repository page directly from the herd header."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -983,6 +983,16 @@ export async function listIssues(repoPath: string): Promise<{
   return r.json();
 }
 
+export async function getRepoWeb(repoPath: string): Promise<{
+  slug: string | null;
+  webUrl: string | null;
+  kind: ForgeKind | null;
+}> {
+  const r = await fetch(`/api/repo-web?repo=${encodeURIComponent(repoPath)}`);
+  if (!r.ok) throw await failed(r, "repo web");
+  return r.json();
+}
+
 export async function listPullRequests(
   repoPath: string,
 ): Promise<{ slug: string | null; webUrl: string | null; prs: PullRequest[] }> {

--- a/ui/src/lib/components/RepoSwitcher.browser.test.ts
+++ b/ui/src/lib/components/RepoSwitcher.browser.test.ts
@@ -3,22 +3,32 @@ import { tick } from "svelte";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
-import type { DrainStatus, QueuedItem } from "$lib/types";
+import type { DrainStatus, ForgeKind, QueuedItem } from "$lib/types";
 import type { RepoChip } from "./queue-strip";
 import { m } from "$lib/paraglide/messages";
 
 // getDrainQueue is only exercised by the inline-expand interaction; stub it so no
 // network call fires. Preserve the rest of $lib/api so the import graph resolves.
 const getDrainQueueFn = vi.fn(async (): Promise<QueuedItem[]> => []);
+const getRepoWebFn = vi.fn(
+  async (): Promise<{ slug: string | null; webUrl: string | null; kind: ForgeKind | null }> => ({
+    slug: null,
+    webUrl: null,
+    kind: null,
+  }),
+);
 vi.mock("$lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("$lib/api")>();
-  return { ...actual, getDrainQueue: getDrainQueueFn };
+  return { ...actual, getDrainQueue: getDrainQueueFn, getRepoWeb: getRepoWebFn };
 });
 
 const { default: RepoSwitcher } = await import("./RepoSwitcher.svelte");
 
 afterEach(() => {
   vi.useRealTimers();
+  getDrainQueueFn.mockClear();
+  getRepoWebFn.mockClear();
+  getRepoWebFn.mockResolvedValue({ slug: null, webUrl: null, kind: null });
 });
 
 function drain(partial: Partial<DrainStatus> & { repoPath: string }): DrainStatus {
@@ -307,7 +317,12 @@ describe("RepoSwitcher — filter rail", () => {
     ).toContain(m.repo_chip_remove_filter());
   });
 
-  it("arrow / home / end keys rove focus between the two menu items", async () => {
+  it("shows a GitHub repo webpage link when the lazy repo lookup resolves to GitHub", async () => {
+    getRepoWebFn.mockResolvedValueOnce({
+      slug: "owner/alpha",
+      webUrl: "https://github.com/owner/alpha",
+      kind: "github",
+    });
     render(RepoSwitcher, {
       chips: [chip({ repoPath: "/repo/alpha" }), chip({ repoPath: "/repo/beta" })],
       repoFilter: new Set<string>(),
@@ -317,21 +332,89 @@ describe("RepoSwitcher — filter rail", () => {
     alpha.dispatchEvent(
       new MouseEvent("contextmenu", { button: 2, clientX: 40, clientY: 40, bubbles: true }),
     );
+
+    await vi.waitFor(() => {
+      const link = page.getByRole("menuitem", { name: m.repo_chip_open_github() }).element();
+      expect(link).toBeTruthy();
+    });
+
+    const link = page
+      .getByRole("menuitem", { name: m.repo_chip_open_github() })
+      .element() as HTMLAnchorElement;
+    expect(getRepoWebFn).toHaveBeenCalledWith("/repo/alpha");
+    expect(link.href).toBe("https://github.com/owner/alpha");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener");
+
+    const allowed = link.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    expect(allowed).toBe(true);
     await tick();
+    expect(document.querySelector(".rs-menu"), "menu closes after opening GitHub").toBeNull();
+  });
+
+  it("omits the repo webpage link for non-GitHub or missing-url forge metadata", async () => {
+    for (const result of [
+      { slug: "owner/alpha", webUrl: "https://gitea.example/owner/alpha", kind: "gitea" as const },
+      { slug: null, webUrl: null, kind: "local" as const },
+      { slug: "owner/alpha", webUrl: null, kind: "github" as const },
+    ]) {
+      getRepoWebFn.mockResolvedValueOnce(result);
+      const { unmount } = await render(RepoSwitcher, {
+        chips: [chip({ repoPath: "/repo/alpha" }), chip({ repoPath: "/repo/beta" })],
+        repoFilter: new Set<string>(),
+        onrepofilter: () => {},
+      });
+      const alpha = document.querySelector(".rs-chip") as HTMLElement;
+      alpha.dispatchEvent(
+        new MouseEvent("contextmenu", { button: 2, clientX: 40, clientY: 40, bubbles: true }),
+      );
+      await tick();
+      await tick();
+
+      expect(page.getByRole("menuitem", { name: m.repo_chip_open_github() }).query()).toBeNull();
+      unmount();
+      document.body.innerHTML = "";
+    }
+  });
+
+  it("arrow / home / end keys rove focus between all menu items", async () => {
+    getRepoWebFn.mockResolvedValueOnce({
+      slug: "owner/alpha",
+      webUrl: "https://github.com/owner/alpha",
+      kind: "github",
+    });
+    render(RepoSwitcher, {
+      chips: [chip({ repoPath: "/repo/alpha" }), chip({ repoPath: "/repo/beta" })],
+      repoFilter: new Set<string>(),
+      onrepofilter: () => {},
+    });
+    const alpha = document.querySelector(".rs-chip") as HTMLElement;
+    alpha.dispatchEvent(
+      new MouseEvent("contextmenu", { button: 2, clientX: 40, clientY: 40, bubbles: true }),
+    );
+    await vi.waitFor(() =>
+      expect(
+        page.getByRole("menuitem", { name: m.repo_chip_open_github() }).query(),
+      ).not.toBeNull(),
+    );
 
     const items = [...document.querySelectorAll<HTMLElement>(".rs-menu-item")];
-    expect(items.length).toBe(2);
+    expect(items.length).toBe(3);
     // The open effect focuses the first item.
     expect(document.activeElement).toBe(items[0]);
 
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
     expect(document.activeElement).toBe(items[1]);
-    window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
-    expect(document.activeElement).toBe(items[0]);
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    expect(document.activeElement).toBe(items[2]);
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
-    expect(document.activeElement).toBe(items[1]);
+    expect(document.activeElement).toBe(items[2]);
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true }));
     expect(document.activeElement).toBe(items[0]);
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
+    expect(document.activeElement).toBe(items[2]);
 
     // Escape still closes.
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));

--- a/ui/src/lib/components/RepoSwitcher.svelte
+++ b/ui/src/lib/components/RepoSwitcher.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { tick } from "svelte";
   import type { RepoChip } from "./queue-strip";
+  import { getRepoWeb } from "$lib/api";
+  import type { ForgeKind } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { basename } from "./learnings-drawer";
   import { projectIcons } from "$lib/projectIcons.svelte";
@@ -127,6 +129,12 @@
   // Pinning is a secondary action: click keeps filtering, while right-click,
   // touch long-press, or mouse/stylus hold opens this anchored menu.
   let menu = $state<{ chip: RepoChip; x: number; y: number; opener: HTMLElement } | null>(null);
+  let menuRepoWeb = $state<{
+    repoPath: string;
+    slug: string | null;
+    webUrl: string | null;
+    kind: ForgeKind | null;
+  } | null>(null);
   let menuEl = $state<HTMLDivElement | null>(null);
   let menuPos = $state<{ left: number; top: number } | null>(null);
 
@@ -155,7 +163,17 @@
 
   function openPinMenu(chip: RepoChip, x: number, y: number, opener: HTMLElement): boolean {
     menu = { chip, x, y, opener };
+    menuRepoWeb = { repoPath: chip.repoPath, slug: null, webUrl: null, kind: null };
     menuPos = null;
+    getRepoWeb(chip.repoPath)
+      .then((r) => {
+        if (menu?.chip.repoPath !== chip.repoPath) return;
+        menuRepoWeb = { repoPath: chip.repoPath, ...r };
+      })
+      .catch(() => {
+        if (menu?.chip.repoPath !== chip.repoPath) return;
+        menuRepoWeb = { repoPath: chip.repoPath, slug: null, webUrl: null, kind: null };
+      });
     return true;
   }
 
@@ -219,6 +237,7 @@
 
   function closeMenu() {
     menu = null;
+    menuRepoWeb = null;
     menuPos = null;
     holdFired = false;
   }
@@ -251,7 +270,7 @@
     const left = Math.min(current.x, window.innerWidth - r.width - margin);
     const top = Math.min(current.y, window.innerHeight - r.height - margin);
     menuPos = { left: Math.max(margin, left), top: Math.max(margin, top) };
-    node.querySelector<HTMLButtonElement>(".rs-menu-item")?.focus();
+    node.querySelector<HTMLElement>(".rs-menu-item")?.focus();
   });
 
   $effect(() => {
@@ -265,9 +284,9 @@
       // Roving focus across the menu items (they are tabindex="-1", so Arrow/Home/End — not Tab —
       // move between them). preventDefault so these keys don't scroll the page instead.
       if (!menuEl) return;
-      const items = [...menuEl.querySelectorAll<HTMLButtonElement>(".rs-menu-item")];
+      const items = [...menuEl.querySelectorAll<HTMLElement>(".rs-menu-item")];
       if (items.length === 0) return;
-      const idx = items.indexOf(document.activeElement as HTMLButtonElement);
+      const idx = items.indexOf(document.activeElement as HTMLElement);
       let next = -1;
       if (e.key === "ArrowDown") next = idx < 0 ? 0 : (idx + 1) % items.length;
       else if (e.key === "ArrowUp")
@@ -391,6 +410,20 @@
         ? m.repo_chip_unpin()
         : m.repo_chip_pin()}
     </button>
+    {#if menuRepoWeb?.repoPath === menu.chip.repoPath && menuRepoWeb.kind === "github" && menuRepoWeb.webUrl}
+      <!-- eslint-disable svelte/no-navigation-without-resolve -- external GitHub URL, not an app route -->
+      <a
+        class="rs-menu-item"
+        role="menuitem"
+        tabindex="-1"
+        href={menuRepoWeb.webUrl}
+        target="_blank"
+        rel="noopener"
+        onclick={() => closeMenu()}
+      >
+        <span class="rs-menu-icon" aria-hidden="true">↗</span>{m.repo_chip_open_github()}
+      </a>
+    {/if}
     <button class="rs-menu-item" type="button" role="menuitem" tabindex="-1" onclick={commitFilter}>
       <span class="rs-menu-icon" aria-hidden="true">{menuFiltered ? "⊖" : "⊕"}</span>{menuFiltered
         ? m.repo_chip_remove_filter()
@@ -577,6 +610,7 @@
     font: inherit;
     font-size: var(--fs-base);
     text-align: left;
+    text-decoration: none;
     cursor: pointer;
   }
   .rs-menu-item:hover,

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-repo-chip-github-link.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-repo-chip-github-link.ts
@@ -1,0 +1,12 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // No targetId: the action is inside a context menu that only mounts after
+  // right-click or long-press, so surface it through What's-New only.
+  id: "repo-chip-github-link",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_repo_chip_github_link_title",
+  bodyKey: "feat_repo_chip_github_link_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## Summary

- add a lazy `/api/repo-web` endpoint for lightweight forge link metadata
- add a GitHub-only repo webpage action to the repo chip context menu
- add localized copy, feature announcement, and server/UI coverage

## Validation

- `bun run test:browser -- RepoSwitcher.browser.test.ts` (in `ui/`)
- `bun run check` (in `ui/`)
- `bun run check:i18n` (in `ui/`)
- `bun test test/server-issues.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run check:announcement-versions`
- `scripts/check-feature-catalog.sh`
- `scripts/check-branch-hygiene.sh`
