### PR TITLE
feat(ui): fancier Diff tab via @pierre/diffs (split/unified, word-diff, sidebar)

### DIFF
--- a/src/diff.ts
+++ b/src/diff.ts
@@ -111,14 +111,23 @@ interface ParseState {
   lineCount: number; // add/del/ctx lines accumulated for cur
   totalLines: number; // global tally across all files
   capped: boolean; // true once MAX_TOTAL_LINES is reached
+  rawBuf: string[]; // raw lines for cur, from its "diff --git" header on; feeds cur.patch
 }
 
-/** Seal cur into files, marking truncated when over per-file cap. */
+/**
+ * Seal cur into files, marking truncated when over per-file cap. Sets `patch` to the
+ * losslessly-buffered raw diff block, but only for files a client can actually use it
+ * for (not truncated, not binary, has at least one body line) — binary/truncated files
+ * skip Pierre rendering downstream, so there's no point shipping their raw bytes.
+ */
 function finishFile(state: ParseState): void {
   if (!state.cur) return;
   if (state.lineCount > MAX_FILE_LINES) {
     state.cur.truncated = true;
     state.cur.hunks = [];
+  }
+  if (!state.cur.truncated && !state.cur.binary && state.lineCount > 0) {
+    state.cur.patch = state.rawBuf.join("\n");
   }
   state.files.push(state.cur);
 }
@@ -134,9 +143,13 @@ function handleDiffLine(state: ParseState, raw: string): void {
     state.hunk = null;
     state.lineCount = 0;
     state.cur = startFile(raw);
+    state.rawBuf = [raw];
     return;
   }
   if (!state.cur) return;
+  // Buffer the raw line for cur.patch. Skipped once globally capped — those files are
+  // truncated anyway, so there's no point holding onto their (large) raw text.
+  if (!state.capped) state.rawBuf.push(raw);
   if (applyFileHeader(state.cur, raw)) return;
 
   if (raw.startsWith("@@")) {
@@ -193,10 +206,22 @@ export function parseUnifiedDiff(text: string): DiffFile[] {
     lineCount: 0,
     totalLines: 0,
     capped: false,
+    rawBuf: [],
   };
   for (const raw of text.split("\n")) handleDiffLine(state, raw);
   finishFile(state);
   return state.files;
+}
+
+/** Session-wire shape: send raw `patch`, drop the redundant structured `hunks`. */
+export function toSessionDiff(result: DiffResult): DiffResult {
+  return {
+    ...result,
+    files: result.files.map(({ hunks, ...f }) => {
+      void hunks; // intentionally dropped from the wire shape; see doc comment above
+      return f as DiffFile;
+    }),
+  };
 }
 
 const REMOTE = "origin";

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -19,7 +19,7 @@ import { promisify } from "node:util";
 import type { SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
 import type { Session, Recap, AgentProvider, RecapEvidenceKind, RecapSkip } from "./types";
-import type { DiffResult } from "./types";
+import type { DiffFile, DiffResult } from "./types";
 import type { RoleEnvironment } from "./default-model";
 import type { OperatorLanguage } from "./operator-language";
 import type { ActivityEntry } from "./activity";
@@ -165,6 +165,19 @@ export function defaultReadVerdict(cwd: string): VerdictRead<unknown> {
   return r.status === "ok"
     ? { status: "parsed", value: r.value, repaired: r.repaired }
     : { status: "unparseable", raw: text }; // carry bytes so tick() can log WHY it failed
+}
+
+/**
+ * Recap's diff visual block renders via `hunks`, never the raw `patch` text (that's the
+ * session-endpoint-only wire shape — see toSessionDiff in diff.ts). Strip it before the
+ * files land in the pendingDiff carrier so a stored/reconstructed recap block never ships
+ * both representations.
+ */
+export function stripPatchForRecap(files: DiffFile[]): DiffFile[] {
+  return files.map(({ patch, ...f }) => {
+    void patch; // intentionally dropped — recap keeps `hunks` only
+    return f as DiffFile;
+  });
 }
 
 /** Bounded, single-line snippet of a raw verdict for diagnostic logs (recap content is agent
@@ -710,7 +723,10 @@ export class RecapService {
       };
       this.deps.store.putRecap(row);
       this.deps.onChange(id, row);
-      this.deps.store.setRecapPendingDiff(id, diff.files);
+      // Recap renders diff blocks via `hunks`, never `patch` — strip it before it lands
+      // in the pendingDiff carrier so the stored/reconstructed block never carries both
+      // representations (the session endpoint is the only consumer of raw `patch`).
+      this.deps.store.setRecapPendingDiff(id, stripPatchForRecap(diff.files));
 
       return "started";
     } finally {

--- a/src/server.ts
+++ b/src/server.ts
@@ -90,7 +90,7 @@ import { listWorktree, resolveWorktreeFile } from "./worktree-files";
 import { loadSteers, saveSteers } from "./steers";
 import { loadIcons, setIcon } from "./project-icons";
 import { listBranches } from "./branches";
-import { computeDiff } from "./diff";
+import { computeDiff, toSessionDiff } from "./diff";
 import { resolveDiffBase } from "./diff-base";
 import { sessionTokens, jsonlPathFor, type SessionUsageRollup } from "./usage";
 import { buildUsageBreakdown } from "./usage-breakdown";
@@ -2061,7 +2061,7 @@ async function sessionDiffRead(id: string, deps: AppDeps): Promise<Response> {
     // Diff against the PR's actual base (so it matches the PR's "Files changed" even when
     // the PR targets a non-default branch), falling back to the session's stored baseBranch.
     const { base } = await resolveDiffBase(s, deps.prCache, deps.resolveForge);
-    return json(await computeDiff(s.worktreePath, base, s.branch));
+    return json(toSessionDiff(await computeDiff(s.worktreePath, base, s.branch)));
   } catch (e) {
     return json({ error: e instanceof Error ? e.message : "diff failed" }, 500);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -366,6 +366,7 @@ export interface DiffFile {
   binary: boolean;
   truncated?: boolean; // hunks dropped because the file exceeded the line cap
   hunks: DiffHunk[]; // empty when binary or truncated
+  patch?: string; // raw git patch block for this file; session-endpoint only, omitted for binary/truncated
 }
 
 export interface DiffResult {

--- a/test/server-diff.test.ts
+++ b/test/server-diff.test.ts
@@ -3,7 +3,9 @@ import { makeApp, type AppDeps } from "../src/server";
 import type { SessionStore } from "../src/store";
 import type { SessionService } from "../src/service";
 import type { EventHub } from "../src/events";
-import type { Session } from "../src/types";
+import type { Session, DiffResult } from "../src/types";
+import { parseUnifiedDiff, toSessionDiff } from "../src/diff";
+import { stripPatchForRecap } from "../src/recap";
 
 const SESSION: Session = {
   id: "s1",
@@ -105,4 +107,150 @@ test("GET /api/sessions/:id/diff → 404 when session unknown", async () => {
   const app = makeApp(makeDeps(null));
   const res = await app.fetch(new Request("http://localhost/api/sessions/nope/diff"));
   expect(res.status).toBe(404);
+});
+
+// ── DiffFile.patch: lossless raw-block capture ──────────────────────────────
+
+const MODIFIED_DIFF = `diff --git a/src/server.ts b/src/server.ts
+index 1111111..2222222 100644
+--- a/src/server.ts
++++ b/src/server.ts
+@@ -40,3 +40,4 @@ function makeApp() {
+   const url = new URL(req.url);
+-  // old handler
++  if (parts[3] === "diff") {
++    return json(computeDiff());
++  }
+`;
+
+const ADDED_DIFF = `diff --git a/new.ts b/new.ts
+new file mode 100644
+index 0000000..3333333
+--- /dev/null
++++ b/new.ts
+@@ -0,0 +1,2 @@
++export const a = 1;
++export const b = 2;
+`;
+
+const DELETED_DIFF = `diff --git a/gone.ts b/gone.ts
+deleted file mode 100644
+index 4444444..0000000
+--- a/gone.ts
++++ /dev/null
+@@ -1,1 +0,0 @@
+-export const gone = true;
+`;
+
+// Rename WITH a content change — a pure rename has no body lines, so it never gets a
+// `patch` (see the "pure rename" test below); this fixture exercises the lossless-block
+// requirement for the renamed case.
+const RENAMED_WITH_CHANGE_DIFF = `diff --git a/old/name.ts b/new/name.ts
+similarity index 90%
+rename from old/name.ts
+rename to new/name.ts
+index 5555555..6666666 100644
+--- a/old/name.ts
++++ b/new/name.ts
+@@ -1,1 +1,1 @@
+-export const old = true;
++export const renamed = true;
+`;
+
+const BINARY_DIFF = `diff --git a/logo.png b/logo.png
+index 5555555..6666666 100644
+Binary files a/logo.png and b/logo.png differ
+`;
+
+test.each([
+  ["modified", MODIFIED_DIFF],
+  ["added", ADDED_DIFF],
+  ["deleted", DELETED_DIFF],
+  ["renamed", RENAMED_WITH_CHANGE_DIFF],
+])("parseUnifiedDiff: captures a lossless raw patch block for a %s file", (_status, text) => {
+  const f = parseUnifiedDiff(text)[0]!;
+  expect(f.patch).toBeDefined();
+  expect(f.patch!.startsWith("diff --git")).toBe(true);
+  expect(f.patch).toContain("@@");
+  // every non-blank source line must survive verbatim in the captured block
+  for (const line of text.split("\n")) {
+    if (line === "") continue;
+    expect(f.patch).toContain(line);
+  }
+});
+
+test("parseUnifiedDiff: a pure rename (no body lines) gets no patch", () => {
+  const RENAMED = `diff --git a/old/name.ts b/new/name.ts
+similarity index 100%
+rename from old/name.ts
+rename to new/name.ts
+`;
+  const f = parseUnifiedDiff(RENAMED)[0]!;
+  expect(f.patch).toBeUndefined();
+});
+
+test("parseUnifiedDiff: patch is omitted for a binary file", () => {
+  const f = parseUnifiedDiff(BINARY_DIFF)[0]!;
+  expect(f.binary).toBe(true);
+  expect(f.patch).toBeUndefined();
+});
+
+test("parseUnifiedDiff: patch is omitted for a file truncated by the per-file line cap", () => {
+  const big = Array.from({ length: 2100 }, (_, i) => `+line ${i}`).join("\n");
+  const text = `diff --git a/big.ts b/big.ts
+--- /dev/null
++++ b/big.ts
+@@ -0,0 +1,2100 @@
+${big}
+`;
+  const f = parseUnifiedDiff(text)[0]!;
+  expect(f.truncated).toBe(true);
+  expect(f.patch).toBeUndefined();
+});
+
+// ── toSessionDiff: strips `hunks`, keeps `patch` ────────────────────────────
+
+test("toSessionDiff: strips hunks from every file, keeps patch, leaves the rest of DiffResult untouched", () => {
+  const files = parseUnifiedDiff(MODIFIED_DIFF + ADDED_DIFF + BINARY_DIFF);
+  const result: DiffResult = {
+    base: "main",
+    baseRef: "origin/main",
+    head: "feature",
+    fetchFailed: false,
+    truncated: false,
+    files,
+  };
+  const wire = toSessionDiff(result);
+  expect(wire.base).toBe("main");
+  expect(wire.baseRef).toBe("origin/main");
+  expect(wire.head).toBe("feature");
+  expect(wire.fetchFailed).toBe(false);
+  expect(wire.truncated).toBe(false);
+  expect(wire.files).toHaveLength(3);
+  for (const f of wire.files) {
+    expect((f as { hunks?: unknown }).hunks).toBeUndefined();
+  }
+  // patch survives for the files that had one; still absent for the binary file.
+  const modified = wire.files.find((f) => f.path === "src/server.ts")!;
+  const added = wire.files.find((f) => f.path === "new.ts")!;
+  const binary = wire.files.find((f) => f.path === "logo.png")!;
+  expect(modified.patch).toBeDefined();
+  expect(added.patch).toBeDefined();
+  expect(binary.patch).toBeUndefined();
+});
+
+// ── stripPatchForRecap: recap keeps hunks, drops patch ──────────────────────
+
+test("stripPatchForRecap: keeps hunks, drops patch", () => {
+  const files = parseUnifiedDiff(MODIFIED_DIFF + ADDED_DIFF);
+  // sanity: parseUnifiedDiff really did populate patch, so this test isn't vacuous
+  expect(files.every((f) => f.patch)).toBe(true);
+
+  const recapFiles = stripPatchForRecap(files);
+  expect(recapFiles).toHaveLength(2);
+  for (const f of recapFiles) {
+    expect(f.patch).toBeUndefined();
+    expect(f.hunks).toBeDefined();
+    expect(f.hunks.length).toBeGreaterThan(0);
+  }
 });

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -6,6 +6,7 @@
       "name": "ui",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",
+        "@pierre/diffs": "1.2.12",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.19.0",
@@ -142,6 +143,12 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
 
+    "@pierre/diffs": ["@pierre/diffs@1.2.12", "", { "dependencies": { "@pierre/theme": "1.1.0", "@pierre/theming": "0.0.2", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-pY/gmgWL03WnagqCyCnBi3QtRXUv4hCIY6FYqd5b1ZGaoI6a4Bsji8j+yRl2RfzPh/8Hf19rCl1GE80G6a1cLQ=="],
+
+    "@pierre/theme": ["@pierre/theme@1.1.0", "", {}, "sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ=="],
+
+    "@pierre/theming": ["@pierre/theming@0.0.2", "", { "peerDependencies": { "@pierre/theme": "^1.1.0", "@shikijs/themes": "^3.0.0 || ^4.0.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0", "shiki": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@pierre/theme", "@shikijs/themes", "react", "react-dom", "shiki"] }, "sha512-QM1M4stXfnzfaE8I8YbjXSApV8c+2dBsXJj8eYg9WTpBR/cTmCZIcfGnN4p13iRrYu2Br/R/OJfEL7uR8Qjctw=="],
+
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
@@ -187,6 +194,8 @@
     "@shikijs/primitive": ["@shikijs/primitive@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A=="],
 
     "@shikijs/themes": ["@shikijs/themes@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1" } }, "sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA=="],
+
+    "@shikijs/transformers": ["@shikijs/transformers@4.3.1", "", { "dependencies": { "@shikijs/core": "4.3.1", "@shikijs/types": "4.3.1" } }, "sha512-z6ir0bGDgWcF2FduktEfPgIsdOtIlDiLAjFBgBzE42Q9xHbkkIXZtORHzlLVB71iZP9elEcqKg6keajvOUwE2A=="],
 
     "@shikijs/types": ["@shikijs/types@4.3.1", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g=="],
 
@@ -480,6 +489,8 @@
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
+    "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
+
     "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
@@ -566,6 +577,8 @@
 
     "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
 
+    "lru_map": ["lru_map@0.4.1", "", {}, "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "marked": ["marked@18.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-MrV5puXBfuiy6wl6DLaq3BtIJQAJToAd5zt/ZKhRfGRAuFPALE7/4Y7jnxRQoEgK/pBgurGqLyAuRgZ2xOjr6w=="],
@@ -620,6 +633,10 @@
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
+    "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
@@ -639,6 +656,8 @@
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2967,5 +2967,9 @@
   "issuedetails_aria": "Details zu Issue #{number}",
   "issuedetails_no_body": "Keine Beschreibung.",
   "feat_issue_context_menu_title": "Rechtsklick auf ein Issue für Schnellaktionen",
-  "feat_issue_context_menu_body": "Rechtsklick (oder langes Drücken) auf ein Issue im New-Task-Dialog oder im Backlog öffnet es auf der Forge, zeigt eine Detailvorschau oder legt einen deiner Issue-Steers direkt in den Editor — vorausgefüllt und bereit zum Prüfen, nicht gestartet."
+  "feat_issue_context_menu_body": "Rechtsklick (oder langes Drücken) auf ein Issue im New-Task-Dialog oder im Backlog öffnet es auf der Forge, zeigt eine Detailvorschau oder legt einen deiner Issue-Steers direkt in den Editor — vorausgefüllt und bereit zum Prüfen, nicht gestartet.",
+  "diff_files_label": "Dateien",
+  "diff_note_binary": "Binärdatei",
+  "diff_note_truncated": "große Datei – im Terminal ansehen",
+  "diff_note_no_changes": "keine Textänderungen"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2971,5 +2971,8 @@
   "diff_files_label": "Dateien",
   "diff_note_binary": "Binärdatei",
   "diff_note_truncated": "große Datei – im Terminal ansehen",
-  "diff_note_no_changes": "keine Textänderungen"
+  "diff_note_no_changes": "keine Textänderungen",
+  "diff_view_label": "Diff-Ansicht",
+  "diff_view_split": "Geteilt",
+  "diff_view_unified": "Vereinheitlicht"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2974,5 +2974,7 @@
   "diff_note_no_changes": "keine Textänderungen",
   "diff_view_label": "Diff-Ansicht",
   "diff_view_split": "Geteilt",
-  "diff_view_unified": "Vereinheitlicht"
+  "diff_view_unified": "Vereinheitlicht",
+  "feat_diff_review_title": "Ein schärferer Diff-Tab",
+  "feat_diff_review_body": "Der Diff-Tab der Sitzung nutzt jetzt eine neue Engine: Wechsle zwischen Nebeneinander- und vereinheitlichter Ansicht — mit wortgenauer Hervorhebung innerhalb der Zeile, einer Datei-Seitenleiste zur schnellen Navigation und einklappbarem unverändertem Kontext."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2967,5 +2967,9 @@
   "issuedetails_aria": "Details for issue #{number}",
   "issuedetails_no_body": "No description.",
   "feat_issue_context_menu_title": "Right-click an issue for quick actions",
-  "feat_issue_context_menu_body": "Right-click (or long-press) an issue in the New Task dialog or the backlog to open it on the forge, preview its details, or drop one of your issue steers straight into the composer — pre-filled and ready to review, not launched."
+  "feat_issue_context_menu_body": "Right-click (or long-press) an issue in the New Task dialog or the backlog to open it on the forge, preview its details, or drop one of your issue steers straight into the composer — pre-filled and ready to review, not launched.",
+  "diff_files_label": "Files",
+  "diff_note_binary": "binary file",
+  "diff_note_truncated": "large file — view in terminal",
+  "diff_note_no_changes": "no textual changes"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2974,5 +2974,7 @@
   "diff_note_no_changes": "no textual changes",
   "diff_view_label": "Diff view",
   "diff_view_split": "Split",
-  "diff_view_unified": "Unified"
+  "diff_view_unified": "Unified",
+  "feat_diff_review_title": "A sharper Diff tab",
+  "feat_diff_review_body": "The session Diff tab now renders through a new engine: switch between side-by-side and unified views, with word-level intra-line highlighting, a file sidebar for quick navigation, and collapsible unchanged context."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2971,5 +2971,8 @@
   "diff_files_label": "Files",
   "diff_note_binary": "binary file",
   "diff_note_truncated": "large file — view in terminal",
-  "diff_note_no_changes": "no textual changes"
+  "diff_note_no_changes": "no textual changes",
+  "diff_view_label": "Diff view",
+  "diff_view_split": "Split",
+  "diff_view_unified": "Unified"
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.7.6",
+    "@pierre/diffs": "1.2.12",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",

--- a/ui/src/lib/components/DiffFileBlock.svelte
+++ b/ui/src/lib/components/DiffFileBlock.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { DiffFile } from "$lib/types";
   import { theme, type Resolved } from "$lib/theme.svelte";
+  import { m } from "$lib/paraglide/messages";
 
   let { file }: { file: DiffFile } = $props();
 
@@ -86,11 +87,11 @@
 
   {#if open}
     {#if file.binary}
-      <p class="note">binary file</p>
+      <p class="note">{m.diff_note_binary()}</p>
     {:else if file.truncated}
-      <p class="note">large file — view in terminal</p>
+      <p class="note">{m.diff_note_truncated()}</p>
     {:else if flatLines.length === 0}
-      <p class="note">no textual changes</p>
+      <p class="note">{m.diff_note_no_changes()}</p>
     {:else}
       <!-- long diff lines scroll horizontally (overflow-x); opt out of the mobile
            page-swipe so a sideways drag scrolls the code instead of paging agents -->

--- a/ui/src/lib/components/DiffFileBlock.svelte
+++ b/ui/src/lib/components/DiffFileBlock.svelte
@@ -18,7 +18,7 @@
     renamed: "R",
   };
 
-  const flatLines = $derived(file.hunks.flatMap((h) => h.lines));
+  const flatLines = $derived((file.hunks ?? []).flatMap((h) => h.lines));
 
   // lazily highlight the first time this file is expanded (one Shiki call per
   // file). The highlighter (and Shiki) is dynamically imported here so it stays
@@ -57,7 +57,7 @@
   // pair each line with its highlighted HTML by global index (null until highlighted)
   const hunksView = $derived.by(() => {
     let i = 0;
-    return file.hunks.map((h) => ({
+    return (file.hunks ?? []).map((h) => ({
       header: h.header,
       lines: h.lines.map((line) => {
         const lineHtml = html ? (html[i] ?? null) : null;

--- a/ui/src/lib/components/DiffFileSidebar.svelte
+++ b/ui/src/lib/components/DiffFileSidebar.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+  // File rail for the multi-file diff tab: one selectable row per changed file.
+  // Wide: a vertical list. Narrow (<=768px): the same rows collapse to a
+  // horizontally-scrollable chip strip (CSS-only; one markup). Purely a
+  // files -> rows mapping + selection callback — no business logic.
+  import type { DiffFile } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+
+  let {
+    files,
+    activePath,
+    onselect,
+  }: {
+    files: DiffFile[];
+    activePath?: string;
+    onselect: (path: string) => void;
+  } = $props();
+
+  // Status glyph + colour convention, copied from DiffFileBlock.svelte.
+  const STATUS_GLYPH: Record<DiffFile["status"], string> = {
+    added: "A",
+    modified: "M",
+    deleted: "D",
+    renamed: "R",
+  };
+
+  const label = (file: DiffFile) =>
+    file.oldPath && file.status === "renamed" ? `${file.oldPath} → ${file.path}` : file.path;
+</script>
+
+<nav class="sidebar" aria-label={m.diff_files_label()}>
+  <div class="head">
+    <span>{m.diff_files_label()}</span>
+    <span class="count">{files.length}</span>
+  </div>
+  <!-- horizontal chip strip on narrow: opt out of the mobile page-swipe -->
+  <ul class="rail" data-swipe-ignore>
+    {#each files as file (file.path)}
+      <li>
+        <button
+          type="button"
+          class="row"
+          class:active={file.path === activePath}
+          aria-current={file.path === activePath ? "true" : undefined}
+          title={label(file)}
+          onclick={() => onselect(file.path)}
+        >
+          <span class="glyph status-{file.status}" aria-hidden="true">
+            {STATUS_GLYPH[file.status]}
+          </span>
+          <span class="path">{label(file)}</span>
+          <span class="counts">
+            <span class="add">+{file.additions}</span>
+            <span class="del">−{file.deletions}</span>
+          </span>
+        </button>
+      </li>
+    {/each}
+  </ul>
+</nav>
+
+<style>
+  .sidebar {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    background: var(--color-panel);
+    border-right: 1px solid var(--color-line);
+  }
+  .head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 6px;
+    padding: 6px 10px;
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    border-bottom: 1px solid var(--color-line);
+  }
+  .count {
+    font-variant-numeric: tabular-nums;
+    color: var(--color-faint);
+  }
+  .rail {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    overflow-y: auto;
+    min-height: 0;
+  }
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 5px 10px;
+    background: transparent;
+    border: 0;
+    border-left: 2px solid transparent;
+    cursor: pointer;
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    color: var(--color-ink);
+    text-align: left;
+  }
+  .row:hover {
+    background: var(--color-hover);
+  }
+  .row.active {
+    background: var(--color-sel);
+    border-left-color: var(--color-blue);
+  }
+  .glyph {
+    flex-shrink: 0;
+    width: 1em;
+    text-align: center;
+    font-weight: 600;
+  }
+  .status-added {
+    color: var(--color-green);
+  }
+  .status-deleted {
+    color: var(--color-red);
+  }
+  .status-renamed,
+  .status-modified {
+    color: var(--color-amber);
+  }
+  .path {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .counts {
+    flex-shrink: 0;
+    font-variant-numeric: tabular-nums;
+  }
+  .counts .add {
+    color: var(--color-green);
+  }
+  .counts .del {
+    color: var(--color-red);
+    margin-left: 6px;
+  }
+
+  /* Narrow: collapse the vertical list to a horizontal chip strip. */
+  @media (max-width: 768px) {
+    .sidebar {
+      border-right: 0;
+      border-bottom: 1px solid var(--color-line);
+    }
+    .rail {
+      display: flex;
+      gap: 6px;
+      overflow-x: auto;
+      overflow-y: hidden;
+      padding: 6px 10px;
+    }
+    .row {
+      width: auto;
+      max-width: 60vw;
+      padding: 4px 8px;
+      border: 1px solid var(--color-line);
+      border-radius: 999px;
+    }
+    .row.active {
+      border-color: var(--color-blue);
+      border-left-color: var(--color-blue);
+    }
+    .counts {
+      display: none;
+    }
+  }
+</style>

--- a/ui/src/lib/components/DiffFileStack.browser.test.ts
+++ b/ui/src/lib/components/DiffFileStack.browser.test.ts
@@ -33,6 +33,20 @@ index 1111111..2222222 100644
 
 const TEXT_PATH = "src/greet.ts";
 
+// An added-file patch in the exact shape the demo fixtures synthesize (seed.ts
+// patchFromFile): `new file mode` + `--- /dev/null`. Guards that this format parses
+// and renders a Pierre host (the modified-file TEXT_PATCH covers the other branch).
+const ADDED_PATCH = `diff --git a/src/New.svelte b/src/New.svelte
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/src/New.svelte
+@@ -0,0 +1,2 @@
++<script lang="ts">
++</script>
+`;
+const ADDED_PATH = "src/New.svelte";
+
 const files: DiffFile[] = [
   {
     path: TEXT_PATH,
@@ -108,5 +122,32 @@ describe("DiffFileStack", () => {
     await vi.waitFor(() => {
       expect(host(), "Pierre host present after scrollToPath").toBeTruthy();
     });
+  });
+
+  it("renders an added-file (/dev/null) synthesized patch as a Pierre host, not a note card", async () => {
+    vi.stubGlobal("IntersectionObserver", NoopIO);
+    const addedFiles: DiffFile[] = [
+      {
+        path: ADDED_PATH,
+        status: "added",
+        additions: 2,
+        deletions: 0,
+        binary: false,
+        patch: ADDED_PATCH,
+      },
+    ];
+    const { component } = await render(DiffFileStack, {
+      files: addedFiles,
+      diffStyle: "unified" as "split" | "unified",
+    });
+
+    await (component as { scrollToPath: (p: string) => Promise<void> }).scrollToPath(ADDED_PATH);
+
+    // A parse failure would leave no host (the file would show no diff); assert the
+    // added-file patch format actually parsed and rendered.
+    await vi.waitFor(() => {
+      expect(host(), "Pierre host present for added-file patch").toBeTruthy();
+    });
+    expect(document.body.textContent).not.toContain(m.diff_note_no_changes());
   });
 });

--- a/ui/src/lib/components/DiffFileStack.browser.test.ts
+++ b/ui/src/lib/components/DiffFileStack.browser.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { m } from "$lib/paraglide/messages";
+import type { DiffFile } from "$lib/types";
+import DiffFileStack from "./DiffFileStack.svelte";
+
+// BROWSER project: DiffFileStack mounts real <PierreDiff> hosts, which need a DOM.
+//
+// We stub IntersectionObserver with a no-op so the observer never auto-renders in
+// the harness (the mounted stack is unconstrained in height, so a real observer
+// would flag every section visible at once). That makes the lazy path the sole
+// driver we assert here: `scrollToPath` force-renders. Real IO-driven lazy render
+// is a runtime behaviour not exercised by this harness (documented limitation).
+class NoopIO {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+
+const TEXT_PATCH = `diff --git a/src/greet.ts b/src/greet.ts
+index 1111111..2222222 100644
+--- a/src/greet.ts
++++ b/src/greet.ts
+@@ -1,3 +1,3 @@
+ export function greet(name: string): string {
+-  return "hello " + name;
++  return \`hello \${name}\`;
+ }
+`;
+
+const TEXT_PATH = "src/greet.ts";
+
+const files: DiffFile[] = [
+  {
+    path: TEXT_PATH,
+    status: "modified",
+    additions: 1,
+    deletions: 1,
+    binary: false,
+    patch: TEXT_PATCH,
+  },
+  { path: "logo.png", status: "added", additions: 0, deletions: 0, binary: true },
+  {
+    path: "huge.json",
+    status: "modified",
+    additions: 9000,
+    deletions: 10,
+    binary: false,
+    truncated: true,
+  },
+];
+
+function host(): Element | null {
+  return document.querySelector("diffs-container");
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.body.innerHTML = "";
+});
+
+describe("DiffFileStack", () => {
+  it("renders a section per file; binary/truncated show note cards, not Pierre hosts", async () => {
+    vi.stubGlobal("IntersectionObserver", NoopIO);
+    const { container } = await render(DiffFileStack, {
+      files,
+      diffStyle: "split" as "split" | "unified",
+    });
+
+    expect(container.querySelectorAll("[data-diff-path]").length, "one section per file").toBe(3);
+
+    // Non-renderable files render their localized note text immediately.
+    expect(document.body.textContent).toContain(m.diff_note_binary());
+    expect(document.body.textContent).toContain(m.diff_note_truncated());
+
+    // Nothing has been lazy-rendered yet (no-op observer, no scrollToPath call).
+    expect(host(), "no Pierre host before any render").toBeNull();
+  });
+
+  it("scrollToPath force-renders an off-screen file (its Pierre host appears)", async () => {
+    vi.stubGlobal("IntersectionObserver", NoopIO);
+    // Spy on the section scroll so we can prove the corrective re-scroll has fired
+    // by the time the awaited promise resolves (regression: the double-rAF must be
+    // awaited, not left dangling after resolve).
+    const scrollSpy = vi.spyOn(HTMLElement.prototype, "scrollIntoView");
+    const { component } = await render(DiffFileStack, {
+      files,
+      diffStyle: "split" as "split" | "unified",
+    });
+
+    expect(host(), "no host before scrollToPath").toBeNull();
+
+    await (component as { scrollToPath: (p: string) => Promise<void> }).scrollToPath(TEXT_PATH);
+
+    // The initial scroll + the corrective double-rAF scroll have BOTH run before the
+    // promise resolved — asserted synchronously (no waitFor), so a dangling rAF
+    // (resolving early) would fail here with only 1 call.
+    expect(
+      scrollSpy.mock.calls.length,
+      "initial + awaited corrective scroll both fired before resolve",
+    ).toBeGreaterThanOrEqual(2);
+
+    // Pierre appends its <diffs-container> host asynchronously after the dynamic
+    // import resolves — poll for it.
+    await vi.waitFor(() => {
+      expect(host(), "Pierre host present after scrollToPath").toBeTruthy();
+    });
+  });
+});

--- a/ui/src/lib/components/DiffFileStack.svelte
+++ b/ui/src/lib/components/DiffFileStack.svelte
@@ -1,0 +1,256 @@
+<script lang="ts">
+  // Lazy, scrollable stack of file diffs. Each file is a <section> anchor with a
+  // reserved min-height (from estimateHeight) so the total scroll height stays
+  // ~stable before Pierre hydrates. An IntersectionObserver mounts each file's
+  // <PierreDiff> as it nears the viewport; already-rendered files stay mounted
+  // (keeps scroll + Pierre state stable). Files with no usable patch (binary /
+  // truncated / no textual change) render a small note card instead.
+  //
+  // The stack scrolls inside its own container (not the page). `scrollToPath` is
+  // exported for the parent (DiffPanel) to call via `bind:this`; it is robust to
+  // lazy heights — it force-renders the target, scrolls, then re-scrolls after
+  // Pierre's async render settles to correct any estimate delta.
+  import { tick } from "svelte";
+  import { SvelteSet, SvelteMap } from "svelte/reactivity";
+  import type { DiffFile } from "$lib/types";
+  import { fileSignature, estimateHeight } from "$lib/pierre-diff";
+  import { m } from "$lib/paraglide/messages";
+  import PierreDiff from "./PierreDiff.svelte";
+
+  let {
+    files,
+    diffStyle,
+    onvisible,
+  }: {
+    files: DiffFile[];
+    diffStyle: "split" | "unified";
+    onvisible?: (path: string) => void;
+  } = $props();
+
+  const STATUS_GLYPH: Record<DiffFile["status"], string> = {
+    added: "A",
+    modified: "M",
+    deleted: "D",
+    renamed: "R",
+  };
+
+  type Note = "binary" | "truncated" | "no-changes";
+
+  // Which non-renderable note (if any) a file shows instead of a Pierre diff.
+  function noteKind(file: DiffFile): Note | null {
+    if (file.binary) return "binary";
+    if (file.truncated) return "truncated";
+    if (!file.patch || file.patch.trim() === "") return "no-changes";
+    return null;
+  }
+
+  // Stable, id-safe DOM id derived from the path (for anchoring/testing).
+  const sectionId = (path: string) => `df-${path.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+
+  const byPath = $derived(new Map(files.map((f) => [f.path, f])));
+
+  // Paths whose PierreDiff has been mounted. SvelteSet so mutations are reactive.
+  const rendered = new SvelteSet<string>();
+
+  // path -> section element, for scroll targeting + observation. (A plain lookup,
+  // never read reactively; SvelteMap satisfies the prefer-svelte-reactivity lint.)
+  const sections = new SvelteMap<string, HTMLElement>();
+
+  let scroller = $state<HTMLElement>();
+  let observer: IntersectionObserver | undefined;
+  let lastReported: string | undefined;
+
+  function markRendered(path: string) {
+    const file = byPath.get(path);
+    if (file && noteKind(file) === null) rendered.add(path);
+  }
+
+  // Report the top-most currently-visible file up (sidebar highlight). Walks
+  // files in order and picks the first whose bottom clears the scroller's top.
+  function reportVisible() {
+    if (!onvisible || !scroller) return;
+    const top = scroller.getBoundingClientRect().top;
+    for (const file of files) {
+      const el = sections.get(file.path);
+      if (!el) continue;
+      if (el.getBoundingClientRect().bottom > top + 1) {
+        if (file.path !== lastReported) {
+          lastReported = file.path;
+          onvisible(file.path);
+        }
+        return;
+      }
+    }
+  }
+
+  function onIntersect(entries: IntersectionObserverEntry[]) {
+    for (const entry of entries) {
+      if (!entry.isIntersecting) continue;
+      const path = (entry.target as HTMLElement).dataset.diffPath;
+      if (path) markRendered(path);
+    }
+    reportVisible();
+  }
+
+  // Svelte action: register a section element + observe it. Handles sections that
+  // mount after the observer exists (files prop change); sections that exist when
+  // the observer is (re)created are picked up by the effect below.
+  function registerSection(node: HTMLElement, path: string) {
+    sections.set(path, node);
+    observer?.observe(node);
+    return {
+      destroy() {
+        observer?.unobserve(node);
+        if (sections.get(path) === node) sections.delete(path);
+      },
+    };
+  }
+
+  // Own the IntersectionObserver; re-created if the scroller element changes.
+  // Cleaned up on destroy (no listener/observer leak).
+  $effect(() => {
+    if (typeof IntersectionObserver === "undefined" || !scroller) return;
+    const io = new IntersectionObserver(onIntersect, {
+      root: scroller,
+      rootMargin: "300px 0px",
+      threshold: 0,
+    });
+    observer = io;
+    for (const node of sections.values()) io.observe(node);
+    return () => {
+      io.disconnect();
+      if (observer === io) observer = undefined;
+    };
+  });
+
+  /** Scroll a file into view, force-rendering it first and correcting for the
+   *  lazy-height estimate once Pierre's async render settles. Callable via
+   *  `bind:this` from the parent (Svelte 5 instance-method export). */
+  export async function scrollToPath(path: string): Promise<void> {
+    markRendered(path); // force-render (no-op for note-card files)
+    await tick(); // let the PierreDiff mount into the section
+    sections.get(path)?.scrollIntoView({ block: "start" });
+    // Pierre renders asynchronously (dynamic import + parse), so the section grows
+    // past its estimate after mount — re-scroll on the next frames to correct.
+    // AWAIT the double-rAF so the returned promise doesn't resolve until the
+    // corrective scroll has fired (Task 5's DiffPanel awaits this for positioning).
+    await tick();
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          sections.get(path)?.scrollIntoView({ block: "start" });
+          resolve();
+        });
+      });
+    });
+  }
+</script>
+
+<div class="stack" bind:this={scroller} data-swipe-ignore>
+  {#each files as file (file.path)}
+    {@const note = noteKind(file)}
+    <section
+      id={sectionId(file.path)}
+      data-diff-path={file.path}
+      use:registerSection={file.path}
+      style={note === null && !rendered.has(file.path)
+        ? `min-height:${estimateHeight(file)}px`
+        : undefined}
+    >
+      <header class="fhead">
+        <span class="glyph status-{file.status}" aria-hidden="true">
+          {STATUS_GLYPH[file.status]}
+        </span>
+        <span class="path">
+          {#if file.oldPath && file.status === "renamed"}{file.oldPath} →
+          {/if}{file.path}
+        </span>
+        <span class="counts">
+          <span class="add">+{file.additions}</span>
+          <span class="del">−{file.deletions}</span>
+        </span>
+      </header>
+
+      {#if note !== null}
+        <p class="note">
+          {#if note === "binary"}{m.diff_note_binary()}
+          {:else if note === "truncated"}{m.diff_note_truncated()}
+          {:else}{m.diff_note_no_changes()}{/if}
+        </p>
+      {:else if rendered.has(file.path)}
+        <div class="body" data-swipe-ignore>
+          <PierreDiff patch={file.patch ?? ""} signature={fileSignature(file)} {diffStyle} />
+        </div>
+      {/if}
+    </section>
+  {/each}
+</div>
+
+<style>
+  .stack {
+    height: 100%;
+    overflow-y: auto;
+    min-height: 0;
+    background: var(--color-inset);
+  }
+  section {
+    border-bottom: 1px solid var(--color-line);
+  }
+  .fhead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 10px;
+    background: var(--color-head);
+    border-bottom: 1px solid var(--color-line);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    color: var(--color-ink);
+  }
+  .glyph {
+    flex-shrink: 0;
+    width: 1em;
+    text-align: center;
+    font-weight: 600;
+  }
+  .status-added {
+    color: var(--color-green);
+  }
+  .status-deleted {
+    color: var(--color-red);
+  }
+  .status-renamed,
+  .status-modified {
+    color: var(--color-amber);
+  }
+  .path {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .counts {
+    flex-shrink: 0;
+    font-variant-numeric: tabular-nums;
+  }
+  .counts .add {
+    color: var(--color-green);
+  }
+  .counts .del {
+    color: var(--color-red);
+    margin-left: 6px;
+  }
+  .note {
+    margin: 0;
+    padding: 8px 12px;
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+  }
+  .body {
+    padding: 4px 0;
+    overflow-x: auto;
+  }
+</style>

--- a/ui/src/lib/components/DiffPanel.browser.test.ts
+++ b/ui/src/lib/components/DiffPanel.browser.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import type { DiffFile, DiffResult } from "$lib/types";
+import { m } from "$lib/paraglide/messages";
+import { getDiff } from "$lib/api";
+import { diffView } from "$lib/diff-view.svelte";
+
+// Mock only the network: getDiff. Everything below the panel (sidebar, lazy
+// stack, the diffView store) is exercised for real.
+vi.mock("$lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/api")>();
+  return {
+    ...actual,
+    getDiff: vi.fn(),
+  };
+});
+
+// This suite exercises DiffPanel's ORCHESTRATION (sidebar + lazy stack + toggle +
+// states), not Pierre's diff rendering (which has its own PierreDiff.browser.test).
+// So the fixture files are note-card files (binary / no textual change) — the stack
+// renders their note anchors synchronously and never mounts PierreDiff, keeping the
+// panel test deterministic and free of Pierre's async-highlight teardown races.
+function multiFileDiff(): DiffResult {
+  const files: DiffFile[] = [
+    {
+      path: "assets/logo.png",
+      status: "added",
+      additions: 0,
+      deletions: 0,
+      binary: true,
+    },
+    {
+      path: "src/empty.ts",
+      status: "modified",
+      additions: 0,
+      deletions: 0,
+      binary: false,
+      patch: "",
+    },
+  ];
+  return {
+    base: "main",
+    baseRef: "origin/main",
+    head: "feat/x",
+    fetchFailed: false,
+    truncated: false,
+    files,
+  };
+}
+
+const mockedGetDiff = vi.mocked(getDiff);
+
+// Import after vi.mock so the panel binds to the mocked getDiff.
+const { default: DiffPanel } = await import("./DiffPanel.svelte");
+
+let fontStyle: HTMLStyleElement;
+beforeEach(async () => {
+  // Wide viewport so `diffView.narrow` is false and the split/unified toggle shows.
+  // The headless CI browser defaults to a narrow (<=768px) iframe, which would
+  // otherwise force unified and hide the toggle.
+  await page.viewport(1280, 800);
+  // Reset the persisted diff-view preference so toggle assertions are deterministic.
+  try {
+    localStorage.removeItem("shepherd:diff-view");
+  } catch {
+    /* ignore */
+  }
+  diffView.set("split");
+  mockedGetDiff.mockReset();
+  fontStyle = document.createElement("style");
+  fontStyle.textContent = `:root {
+    --font-mono: ui-monospace, monospace;
+    --color-bg: #0a0d0c;
+    --color-head: #141414;
+    --color-panel: #1a1a1a;
+    --color-inset: #111;
+    --color-line: #333;
+    --color-line-bright: #444;
+    --color-hover: #222;
+    --color-sel: #223;
+    --color-ink: #ccc;
+    --color-muted: #888;
+    --color-faint: #555;
+    --color-amber: #f5a623;
+    --color-green: #4caf50;
+    --color-red: #f44336;
+    --color-blue: #4a90e2;
+    --fs-meta: 12px;
+    --fs-base: 13px;
+  }
+  *, *::before, *::after { box-sizing: border-box; }
+  body { margin: 0; }`;
+  document.head.appendChild(fontStyle);
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  fontStyle.remove();
+  document.body.innerHTML = "";
+});
+
+describe("DiffPanel — multi-file diff", () => {
+  it("lists files in the sidebar and renders the stack", async () => {
+    mockedGetDiff.mockResolvedValue(multiFileDiff());
+    render(DiffPanel, { sessionId: "s1" });
+
+    // Summary bar
+    await expect.element(page.getByText("2 files")).toBeInTheDocument();
+
+    // Sidebar rail: one selectable row per file
+    await vi.waitFor(() => {
+      const rows = document.querySelectorAll(".sidebar .row");
+      expect(rows.length).toBe(2);
+    });
+    expect(document.querySelector(".sidebar")?.textContent).toContain("assets/logo.png");
+    expect(document.querySelector(".sidebar")?.textContent).toContain("src/empty.ts");
+
+    // Stack: one anchor section per file
+    await vi.waitFor(() => {
+      expect(document.querySelectorAll(".stack section").length).toBe(2);
+    });
+  });
+
+  it("shows the split/unified toggle (wide) and toggling updates the store", async () => {
+    mockedGetDiff.mockResolvedValue(multiFileDiff());
+    render(DiffPanel, { sessionId: "s1" });
+
+    // Wide viewport (set in beforeEach) → diffView resolves non-narrow and the
+    // toggle mounts. Wait for the store's mount-time init() + the group to render.
+    const group = await vi.waitFor(() => {
+      expect(diffView.narrow, "wide viewport → not narrow").toBe(false);
+      const g = document.querySelector(`[aria-label="${m.diff_view_label()}"]`);
+      expect(g).not.toBeNull();
+      return g as HTMLElement;
+    });
+    const buttons = group.querySelectorAll("button");
+    expect(buttons.length).toBe(2);
+
+    // Default pref is split → first button active.
+    expect(buttons[0].getAttribute("aria-pressed")).toBe("true");
+    expect(diffView.pref).toBe("split");
+
+    // Click "Unified" → store flips, resolved view follows.
+    (buttons[1] as HTMLButtonElement).click();
+    await vi.waitFor(() => {
+      expect(diffView.pref).toBe("unified");
+      expect(buttons[1].getAttribute("aria-pressed")).toBe("true");
+    });
+  });
+
+  it("scrolls the stack when a sidebar file is selected", async () => {
+    mockedGetDiff.mockResolvedValue(multiFileDiff());
+    const scrollSpy = vi.spyOn(Element.prototype, "scrollIntoView").mockImplementation(() => {});
+    render(DiffPanel, { sessionId: "s1" });
+
+    const rows = await vi.waitFor(() => {
+      const r = document.querySelectorAll<HTMLButtonElement>(".sidebar .row");
+      expect(r.length).toBe(2);
+      return r;
+    });
+
+    rows[1].click(); // select the second file
+
+    await vi.waitFor(() => {
+      // handleSelect highlights immediately …
+      expect(rows[1].getAttribute("aria-current")).toBe("true");
+      // … then scrolls the target into view via the stack's scrollToPath.
+      expect(scrollSpy).toHaveBeenCalled();
+    });
+  });
+});
+
+describe("DiffPanel — states", () => {
+  it("renders the loading message before the diff resolves", async () => {
+    mockedGetDiff.mockReturnValue(new Promise<DiffResult>(() => {})); // never resolves
+    render(DiffPanel, { sessionId: "s1" });
+    await expect.element(page.getByText(m.common_loading())).toBeInTheDocument();
+  });
+
+  it("renders the error message when the diff fails", async () => {
+    mockedGetDiff.mockRejectedValue(new Error("boom"));
+    render(DiffPanel, { sessionId: "s1" });
+    await expect.element(page.getByText(m.diff_error())).toBeInTheDocument();
+  });
+
+  it("renders the empty message when there are no changed files", async () => {
+    mockedGetDiff.mockResolvedValue({
+      base: "main",
+      baseRef: "origin/main",
+      head: null,
+      fetchFailed: false,
+      truncated: false,
+      files: [],
+    });
+    render(DiffPanel, { sessionId: "s1" });
+    await expect.element(page.getByText(m.diff_empty({ base: "origin/main" }))).toBeInTheDocument();
+    // No toggle when there are no files.
+    expect(document.querySelector(`[aria-label="${m.diff_view_label()}"]`)).toBeNull();
+  });
+});

--- a/ui/src/lib/components/DiffPanel.svelte
+++ b/ui/src/lib/components/DiffPanel.svelte
@@ -2,8 +2,10 @@
   import { getDiff } from "$lib/api";
   import { pollWhileVisible } from "$lib/visibility";
   import { diffTotals } from "$lib/diff";
+  import { diffView } from "$lib/diff-view.svelte";
   import type { DiffResult } from "$lib/types";
-  import DiffFileBlock from "$lib/components/DiffFileBlock.svelte";
+  import DiffFileSidebar from "$lib/components/DiffFileSidebar.svelte";
+  import DiffFileStack from "$lib/components/DiffFileStack.svelte";
   import { m } from "$lib/paraglide/messages";
 
   let { sessionId }: { sessionId: string } = $props();
@@ -11,6 +13,10 @@
   let result = $state<DiffResult | null>(null);
   let loaded = $state(false);
   let failed = $state(false);
+  // Currently-highlighted file (sidebar). Set on select + as the stack scrolls.
+  let activePath = $state<string | undefined>(undefined);
+  // Stack instance handle — we only call its exported scrollToPath.
+  let stackRef = $state<{ scrollToPath: (path: string) => Promise<void> }>();
 
   let alive = true;
   function load() {
@@ -36,6 +42,7 @@
     result = null;
     loaded = false;
     failed = false;
+    activePath = undefined;
     alive = true;
     load();
     const stop = pollWhileVisible(load, 15000); // skip hidden-tab ticks; refresh on return
@@ -45,9 +52,19 @@
     };
   });
 
+  // Track viewport width so `diffView.narrow`/`.resolved` stay live (forces unified
+  // on narrow). Construction only seeds the initial value; init() wires the listener.
+  $effect(() => diffView.init());
+
   const totals = $derived(
     result ? diffTotals(result.files) : { files: 0, additions: 0, deletions: 0 },
   );
+
+  // Highlight immediately (responsive), then scroll the target into view.
+  async function handleSelect(path: string) {
+    activePath = path;
+    await stackRef?.scrollToPath(path);
+  }
 </script>
 
 <div class="diff">
@@ -62,22 +79,48 @@
       {/if}
     {/if}
     <div class="spacer"></div>
+    {#if result && result.files.length && !diffView.narrow}
+      <div class="seg-row" role="group" aria-label={m.diff_view_label()}>
+        <button
+          type="button"
+          class="seg-btn"
+          class:seg-active={diffView.pref === "split"}
+          aria-pressed={diffView.pref === "split"}
+          onclick={() => diffView.set("split")}
+        >
+          {m.diff_view_split()}
+        </button>
+        <button
+          type="button"
+          class="seg-btn"
+          class:seg-active={diffView.pref === "unified"}
+          aria-pressed={diffView.pref === "unified"}
+          onclick={() => diffView.set("unified")}
+        >
+          {m.diff_view_unified()}
+        </button>
+      </div>
+    {/if}
     <button class="refresh" type="button" onclick={load} aria-label={m.diff_refresh()}>↻</button>
   </div>
 
-  <div class="body">
-    {#if !loaded}
-      <p class="msg">{m.common_loading()}</p>
-    {:else if failed}
-      <p class="msg">{m.diff_error()}</p>
-    {:else if result && result.files.length}
-      {#each result.files as file (file.path)}
-        <DiffFileBlock {file} />
-      {/each}
-    {:else}
-      <p class="msg">{m.diff_empty({ base: result?.baseRef ?? "" })}</p>
-    {/if}
-  </div>
+  {#if !loaded}
+    <p class="msg">{m.common_loading()}</p>
+  {:else if failed}
+    <p class="msg">{m.diff_error()}</p>
+  {:else if result && result.files.length}
+    <div class="content">
+      <DiffFileSidebar files={result.files} {activePath} onselect={handleSelect} />
+      <DiffFileStack
+        files={result.files}
+        diffStyle={diffView.resolved}
+        onvisible={(p) => (activePath = p)}
+        bind:this={stackRef}
+      />
+    </div>
+  {:else}
+    <p class="msg">{m.diff_empty({ base: result?.baseRef ?? "" })}</p>
+  {/if}
 </div>
 
 <style>
@@ -85,6 +128,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
+    min-height: 0;
   }
   .bar {
     display: flex;
@@ -113,6 +157,53 @@
   .spacer {
     flex: 1;
   }
+
+  /* Split/unified toggle — the segmented-control recipe (/design-system),
+     compact for the bar. Active = --color-amber + inset. */
+  .seg-row {
+    display: flex;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    overflow: hidden;
+    flex-shrink: 0;
+  }
+  .seg-btn {
+    min-height: 24px;
+    border: 0;
+    border-right: 1px solid var(--color-line);
+    background: none;
+    font-family: inherit;
+    font-size: var(--fs-meta);
+    cursor: pointer;
+    padding: 2px 10px;
+    color: var(--color-muted);
+    white-space: nowrap;
+  }
+  .seg-btn:last-child {
+    border-right: 0;
+  }
+  .seg-btn:hover {
+    color: var(--color-ink);
+  }
+  .seg-btn.seg-active {
+    color: var(--color-amber);
+    background: var(--color-inset);
+    box-shadow: inset 0 -2px 0 var(--color-amber);
+  }
+  .seg-btn:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+  /* Coarse pointers (touch): meet the 44px tap-target floor regardless of width —
+     the toggle is hidden by viewport width (narrow), not by pointer type, so a wide
+     touchscreen would otherwise render it at the compact desktop height. */
+  @media (pointer: coarse) {
+    .seg-btn {
+      min-height: 44px;
+      padding: 0 10px;
+    }
+  }
+
   .refresh {
     background: transparent;
     border: 1px solid var(--color-line-bright);
@@ -126,15 +217,40 @@
   .refresh:hover {
     background: var(--color-hover);
   }
-  .body {
+
+  /* Two-pane body: sidebar rail + scrollable stack. The stack (not the page) owns
+     scrolling — the content wrapper is height-constrained so the stack's own
+     overflow + IntersectionObserver lazy render work. */
+  .content {
+    display: flex;
     flex: 1;
-    overflow-y: auto;
-    padding: 8px 10px;
+    min-height: 0;
   }
+  /* Sidebar root is <nav class="sidebar">; stack root is <div class="stack">.
+     Both stretch to the content height (default align-items). */
+  .content > :global(.sidebar) {
+    flex: 0 0 220px;
+  }
+  .content > :global(.stack) {
+    flex: 1;
+    min-height: 0;
+  }
+
+  /* Narrow: stack the panes vertically — sidebar (its chip strip) above, stack
+     below, full width. */
+  @media (max-width: 768px) {
+    .content {
+      flex-direction: column;
+    }
+    .content > :global(.sidebar) {
+      flex: 0 0 auto;
+    }
+  }
+
   .msg {
     color: var(--color-muted);
     margin: 0;
-    padding: 4px 0;
+    padding: 8px 10px;
     font-size: var(--fs-base);
   }
 </style>

--- a/ui/src/lib/components/PierreDiff.browser.test.ts
+++ b/ui/src/lib/components/PierreDiff.browser.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { FileDiff } from "@pierre/diffs";
+import { theme } from "$lib/theme.svelte";
+import PierreDiff from "./PierreDiff.svelte";
+
+// BROWSER project: PierreDiff drives @pierre/diffs' vanilla FileDiff, which needs
+// a real DOM (custom-element registration, shadow root, layout stylesheet). These
+// assertions read the ACTUAL DOM Pierre produced — no mocks of Pierre itself.
+
+const PATCH = `diff --git a/src/greet.ts b/src/greet.ts
+index 1111111..2222222 100644
+--- a/src/greet.ts
++++ b/src/greet.ts
+@@ -1,3 +1,3 @@
+ export function greet(name: string): string {
+-  return "hello " + name;
++  return \`hello \${name}\`;
+ }
+`;
+
+// A second, materially different patch so a signature actually differs.
+const PATCH_2 = PATCH.replace("hello", "hey");
+
+function host(): Element | null {
+  return document.querySelector("diffs-container");
+}
+
+// The split marker Pierre stamps on the rendered <pre> inside the host's shadow
+// root: "split" for side-by-side, "single" for unified.
+function diffTypeMarker(): string | null | undefined {
+  return host()?.shadowRoot?.querySelector("pre[data-diff-type]")?.getAttribute("data-diff-type");
+}
+
+// Pierre writes the active theme into a `<style data-theme-css>` in the shadow
+// root as `:host { color-scheme: <dark|light>; … }`. Read it back to prove which
+// theme is currently applied to the diff.
+function appliedColorScheme(): "dark" | "light" | null {
+  const css = host()?.shadowRoot?.querySelector("style[data-theme-css]")?.textContent ?? "";
+  const m = css.match(/color-scheme:\s*(dark|light)/);
+  return (m?.[1] as "dark" | "light") ?? null;
+}
+
+const originalPref = theme.pref;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  theme.setPref(originalPref);
+  document.body.innerHTML = "";
+});
+
+describe("PierreDiff", () => {
+  it("registers <diffs-container> and renders the split layout", async () => {
+    await render(PierreDiff, { patch: PATCH, signature: "sig-1", diffStyle: "split" });
+
+    // Registration: importing FileDiff (via the wrapper) defines the custom element.
+    await vi.waitFor(() => {
+      expect(customElements.get("diffs-container"), "custom element defined").toBeTruthy();
+    });
+
+    // Host is appended asynchronously (after the dynamic import resolves), so
+    // poll for it: present in the DOM and upgraded (its shadow root exists).
+    await vi.waitFor(() => {
+      expect(host(), "host element in DOM").toBeTruthy();
+      expect(host()?.shadowRoot, "host upgraded with a shadow root").toBeTruthy();
+    });
+
+    // Split layout is active.
+    await vi.waitFor(() => {
+      expect(diffTypeMarker(), "split marker on rendered <pre>").toBe("split");
+    });
+  });
+
+  it("toggling diffStyle to unified re-lays-out via setOptions+rerender", async () => {
+    const screen = await render(PierreDiff, {
+      patch: PATCH,
+      signature: "sig-2",
+      diffStyle: "split" as "split" | "unified",
+    });
+
+    await vi.waitFor(() => {
+      expect(diffTypeMarker(), "starts split").toBe("split");
+    });
+
+    await screen.rerender({ patch: PATCH, signature: "sig-2", diffStyle: "unified" });
+
+    // Same signature: the content-gate skips a re-parse; the diffStyle reaction
+    // re-lays-out in place. Marker flips split -> single (Pierre's unified value).
+    await vi.waitFor(() => {
+      expect(diffTypeMarker(), "split marker gone / unified active").toBe("single");
+    });
+  });
+
+  it("does not re-render Pierre when the signature is unchanged (anti-flash gate)", async () => {
+    // Spy on the real FileDiff.render (same module the wrapper dynamic-imports —
+    // Vite dedupes the specifier) to count actual Pierre renders.
+    const renderSpy = vi.spyOn(FileDiff.prototype, "render");
+
+    const screen = await render(PierreDiff, {
+      patch: PATCH,
+      signature: "sig-3",
+      diffStyle: "split" as "split" | "unified",
+    });
+
+    await vi.waitFor(() => {
+      expect(diffTypeMarker(), "rendered once").toBe("split");
+    });
+    expect(renderSpy.mock.calls.length, "one render for the initial mount").toBe(1);
+
+    // A poll returning identical content (same signature) must NOT re-render.
+    await screen.rerender({ patch: PATCH, signature: "sig-3", diffStyle: "split" });
+    await new Promise((r) => setTimeout(r, 50)); // give any (unwanted) async render a chance
+    expect(renderSpy.mock.calls.length, "same signature -> no second render").toBe(1);
+
+    // A genuine content change (new signature) DOES re-render.
+    await screen.rerender({ patch: PATCH_2, signature: "sig-3-changed", diffStyle: "split" });
+    await vi.waitFor(() => {
+      expect(renderSpy.mock.calls.length, "changed signature -> re-render").toBe(2);
+    });
+  });
+
+  it("keeps the applied theme after a diffStyle toggle (no stale-options revert)", async () => {
+    // Regression: Pierre's setThemeType swaps in a NEW fd.options object, so a
+    // component-side options copy would freeze themeType at mount and the diffStyle
+    // toggle would silently revert the diff's theme. Drive: dark -> light -> toggle.
+    theme.setPref("dark");
+    const screen = await render(PierreDiff, {
+      patch: PATCH,
+      signature: "sig-4",
+      diffStyle: "split" as "split" | "unified",
+    });
+
+    await vi.waitFor(() => {
+      expect(appliedColorScheme(), "starts dark").toBe("dark");
+    });
+
+    // App theme -> light: the diff re-themes.
+    theme.setPref("light");
+    await vi.waitFor(() => {
+      expect(appliedColorScheme(), "re-themes to light").toBe("light");
+    });
+
+    // Toggle split -> unified: theme MUST stay light (would snap back to dark if
+    // the merge source were a stale component-side options copy).
+    await screen.rerender({ patch: PATCH, signature: "sig-4", diffStyle: "unified" });
+    await vi.waitFor(() => {
+      expect(diffTypeMarker(), "toggled to unified").toBe("single");
+    });
+    expect(appliedColorScheme(), "theme still light after toggle").toBe("light");
+  });
+});

--- a/ui/src/lib/components/PierreDiff.svelte
+++ b/ui/src/lib/components/PierreDiff.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+  // Thin Svelte 5 wrapper around @pierre/diffs' vanilla `FileDiff` API, rendering
+  // ONE file's diff. Everything Pierre-related is CLIENT-ONLY: all `@pierre/diffs`
+  // access is dynamic-imported inside `$effect` (which never runs during SSR), so
+  // this component is safe to render on the server (it emits just the empty host
+  // `<div>`).
+  //
+  // Custom-element registration: dynamic-importing `@pierre/diffs` transitively
+  // runs `dist/components/web-components.js` (a side-effect module FileDiff.js
+  // statically imports), which calls `customElements.define("diffs-container", …)`.
+  // So merely importing FileDiff upgrades the `<diffs-container>` host — no
+  // separate submodule import is needed. (package.json lists that file under
+  // `sideEffects`, so bundlers keep it.)
+  //
+  // The `<diffs-container>` host is created and appended by PIERRE (we pass
+  // `containerWrapper: root`, and `render()` builds + inserts the host into it) —
+  // not by us. That is deliberate: Pierre owns the host's light DOM (it slots
+  // annotation nodes into it) and removes it on `cleanUp()`, so it must not be a
+  // Svelte-managed template element. Svelte only owns the empty wrapper `<div>`.
+  //
+  // Split-vs-unified is driven via `setOptions(opts) + rerender()`. NOTE Pierre's
+  // `setOptions` REPLACES the options object wholesale (no merge) — and Pierre's
+  // own `setThemeType()` also swaps in a NEW `fd.options` object behind our back —
+  // so we spread `fd.options` (the single live source of truth) when toggling
+  // `diffStyle`, NOT a component-side copy that would drift (e.g. freeze themeType
+  // at mount and silently revert the theme on toggle).
+  import type { DiffLineAnnotation, FileDiff, FileDiffOptions } from "@pierre/diffs";
+  import { theme } from "$lib/theme.svelte";
+  import { registerShepherdThemes, parseFilePatch } from "$lib/pierre-diff";
+
+  type Annotation = DiffLineAnnotation;
+
+  let {
+    patch,
+    signature,
+    diffStyle,
+    lineAnnotations = [],
+    renderAnnotation,
+  }: {
+    patch: string;
+    signature: string;
+    diffStyle: "split" | "unified";
+    lineAnnotations?: Annotation[];
+    renderAnnotation?: (a: Annotation) => HTMLElement | undefined;
+  } = $props();
+
+  // Wrapper the `<diffs-container>` host is appended into (by Pierre).
+  let root = $state<HTMLDivElement>();
+
+  // Non-reactive instance state (deliberately plain `let`, not `$state`: these
+  // drive the external Pierre lib, never the template).
+  let fd: FileDiff | undefined; // the FileDiff instance (fd.options is the live options source of truth)
+  let lastSignature: string | undefined; // content-gate: skip re-render when unchanged
+  // Render-generation counter: every (re-)render bumps it and captures the value;
+  // after each `await` a stale generation bails, so a rapid prop change or teardown
+  // can never interleave two `render()` calls on the same host.
+  let gen = 0;
+
+  // Lazily import + instantiate Pierre once. Reads the CURRENT `diffStyle`/theme
+  // for the initial construction; subsequent changes are handled by the reaction
+  // effects below.
+  async function ensureInit(): Promise<void> {
+    if (fd) return;
+    const { FileDiff } = await import("@pierre/diffs");
+    await registerShepherdThemes();
+    if (fd) return; // another call won the race while we awaited
+    const options: FileDiffOptions<undefined> = {
+      theme: { dark: "shepherd-dark", light: "shepherd-light" },
+      themeType: theme.resolved,
+      diffStyle,
+      lineDiffType: "word",
+      diffIndicators: "bars",
+      // `overflow: "wrap"` is REQUIRED — otherwise side-by-side split silently
+      // collapses to stacked.
+      overflow: "wrap",
+      renderAnnotation,
+    };
+    fd = new FileDiff(options);
+  }
+
+  // Parse `patch` and (re-)render into the host. Guarded by `gen` so overlapping
+  // async calls can't interleave. `containerWrapper: root` lets Pierre create +
+  // insert the `<diffs-container>` host itself on first render.
+  async function renderContent(): Promise<void> {
+    const myGen = ++gen;
+    await ensureInit();
+    if (myGen !== gen || !fd || !root) return;
+    const meta = await parseFilePatch(patch);
+    if (myGen !== gen || !fd || !root) return;
+    if (meta == null) return; // empty/invalid patch — nothing to render
+    fd.render({ fileDiff: meta, containerWrapper: root, lineAnnotations });
+    lastSignature = signature;
+  }
+
+  // Content reaction: (re-)render only when the signature actually changes.
+  // `signature` is a hash of the patch content, so it is the sole gate — an
+  // unchanged file (e.g. a 15s poll returning identical content) has an identical
+  // signature and is skipped, preventing a flash/re-render.
+  $effect(() => {
+    if (signature === lastSignature) return;
+    void renderContent();
+  });
+
+  // Theme reaction: instant swap, no re-render (Pierre keeps both themes' CSS).
+  $effect(() => {
+    const resolved = theme.resolved;
+    fd?.setThemeType(resolved);
+  });
+
+  // View reaction: toggle split↔unified. `setOptions` replaces options wholesale,
+  // so spread `fd.options` (the live source of truth — Pierre mutates it via
+  // setThemeType, so any component-side copy would drift and revert the theme);
+  // `rerender()` re-lays-out from the stored fileDiff (a full re-parse is NOT
+  // needed — proven in PierreDiff.browser.test.ts).
+  $effect(() => {
+    const style = diffStyle;
+    if (!fd || fd.options.diffStyle === style) return;
+    fd.setOptions({ ...fd.options, diffStyle: style });
+    fd.rerender();
+  });
+
+  // Teardown: `cleanUp()` disposes Pierre's Resize/Interaction/ScrollSync managers
+  // and (since the container is Pierre-managed) removes the host node it created —
+  // so there is no manager-listener leak and Svelte's own removal of the empty
+  // wrapper never collides with a node it doesn't track. Bump `gen` first to
+  // cancel any in-flight async render.
+  $effect(() => {
+    return () => {
+      gen++;
+      fd?.cleanUp();
+      fd = undefined;
+    };
+  });
+</script>
+
+<div bind:this={root} class="pierre-diff"></div>
+
+<style>
+  /* Layout only — the diff BODY themes itself via injected Shiki themes inside
+     the shadow DOM (app tokens can't cascade in). The wrapper needs no chrome. */
+  .pierre-diff {
+    display: block;
+  }
+</style>

--- a/ui/src/lib/demo/router.test.ts
+++ b/ui/src/lib/demo/router.test.ts
@@ -234,6 +234,13 @@ describe("session-detail tab GETs never fall back to {}", () => {
     expect(status).toBe(200);
     expect(Array.isArray(body.files)).toBe(true);
     expect(body.files.length).toBeGreaterThan(0);
+    // Every file carries a synthesized `patch` — the Diff tab renders from it, so a
+    // missing patch would make the demo show "no textual changes" for every file.
+    for (const f of body.files) {
+      expect(typeof f.patch).toBe("string");
+      expect(f.patch.startsWith("diff --git ")).toBe(true);
+      expect(f.patch).toContain("@@ ");
+    }
     // an unseeded session still gets a valid DiffResult, not {} (files would be undefined)
     const empty = await get("/api/sessions/rounding/diff");
     expect(Array.isArray(empty.body.files)).toBe(true);

--- a/ui/src/lib/demo/seed.ts
+++ b/ui/src/lib/demo/seed.ts
@@ -50,6 +50,8 @@ import type {
   StarPromptStatus,
   ActivityEntry,
   DiffResult,
+  DiffFile,
+  DiffHunk,
   ScratchListing,
   SessionUsage,
   SlashCommand,
@@ -1304,11 +1306,52 @@ function buildActivityEntries(): Record<string, ActivityEntry[]> {
   };
 }
 
+const DIFF_PREFIX = { add: "+", del: "-", ctx: " " } as const;
+
+/** Synthesize one hunk's unified-diff text from its structured lines, recomputing
+ *  the `@@ -a,b +c,d @@` counts from the actual lines (the fixtures' authored headers
+ *  are illustrative and needn't match): old side = ctx+del, new side = ctx+add.
+ *  Preserves any trailing section label after the original header. */
+function hunkToPatch(h: DiffHunk): string {
+  const oldCount = h.lines.filter((l) => l.kind !== "add").length;
+  const newCount = h.lines.filter((l) => l.kind !== "del").length;
+  const oldStart = h.lines.find((l) => l.oldNo != null)?.oldNo ?? 0;
+  const newStart = h.lines.find((l) => l.newNo != null)?.newNo ?? 0;
+  const body = h.lines.map((l) => DIFF_PREFIX[l.kind] + l.content);
+  const section = h.header.replace(/^@@[^@]*@@/, "").trim();
+  const head = `@@ -${oldStart},${oldCount} +${newStart},${newCount} @@${section ? " " + section : ""}`;
+  return [head, ...body].join("\n");
+}
+
+/** Build a valid single-file unified patch from a demo DiffFile's structured hunks, so
+ *  the Diff tab (which renders from `patch`) has something to show. The real server
+ *  attaches `patch` in `toSessionDiff`; the demo mock serves fixtures directly, so we
+ *  synthesize it here (else every demo file reads as "no textual changes"). */
+function patchFromFile(f: DiffFile): string {
+  const path = f.path;
+  const old = f.oldPath ?? path;
+  const lines: string[] = [`diff --git a/${old} b/${path}`];
+  if (f.status === "added") {
+    lines.push("new file mode 100644", "index 0000000..1111111", "--- /dev/null", `+++ b/${path}`);
+  } else if (f.status === "deleted") {
+    lines.push(
+      "deleted file mode 100644",
+      "index 1111111..0000000",
+      `--- a/${old}`,
+      "+++ /dev/null",
+    );
+  } else {
+    lines.push("index 1111111..2222222 100644", `--- a/${old}`, `+++ b/${path}`);
+  }
+  for (const h of f.hunks ?? []) lines.push(hunkToPatch(h));
+  return lines.join("\n") + "\n";
+}
+
 /** GET /api/sessions/:id/diff — coupon's growing diff (hero, no PR yet) + a small one for
  *  its epic-child sibling. A session with no seeded entry falls back to a valid empty
  *  DiffResult in state.ts (base/head filled from the session, `files: []` — never `{}`). */
 function buildDiffs(): Record<string, DiffResult> {
-  return {
+  const diffs: Record<string, DiffResult> = {
     coupon: {
       base: "main",
       baseRef: "origin/main",
@@ -1393,6 +1436,12 @@ function buildDiffs(): Record<string, DiffResult> {
       ],
     },
   };
+  // Attach a synthesized `patch` per file (the Diff tab renders from it); the demo
+  // mock bypasses the server's toSessionDiff that normally supplies it.
+  for (const d of Object.values(diffs)) {
+    d.files = d.files.map((f) => ({ ...f, patch: patchFromFile(f) }));
+  }
+  return diffs;
 }
 
 /** GET /api/sessions/:id/scratchpad (root listing) — only sessions with

--- a/ui/src/lib/diff-view.svelte.test.ts
+++ b/ui/src/lib/diff-view.svelte.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+// Stub localStorage + matchMedia BEFORE importing the module: the singleton's
+// read() + narrow-seed run at construction (import) time, so the globals must be
+// in place first (mirrors build-queue-collapse.svelte.test.ts's localStorage stub).
+const store: Record<string, string> = {};
+const localStorageMock = {
+  getItem: (key: string) => store[key] ?? null,
+  setItem: (key: string, value: string) => {
+    store[key] = value;
+  },
+  removeItem: (key: string) => {
+    delete store[key];
+  },
+  clear: () => {
+    for (const k of Object.keys(store)) delete store[k];
+  },
+};
+// @ts-expect-error stubbing global
+globalThis.localStorage = localStorageMock;
+
+// Controllable matchMedia: `mqMatches` drives `.matches`; `fire()` invokes the
+// registered change listeners (simulating a viewport crossing 768px).
+let mqMatches = false;
+const listeners = new Set<() => void>();
+const mql = {
+  get matches() {
+    return mqMatches;
+  },
+  addEventListener: (_e: string, cb: () => void) => {
+    listeners.add(cb);
+  },
+  removeEventListener: (_e: string, cb: () => void) => {
+    listeners.delete(cb);
+  },
+};
+function fire() {
+  for (const cb of listeners) cb();
+}
+// @ts-expect-error stubbing global
+globalThis.matchMedia = () => mql;
+
+import { diffView, readDiffView } from "./diff-view.svelte";
+
+const KEY = "shepherd:diff-view";
+
+beforeEach(() => {
+  localStorageMock.clear();
+  mqMatches = false;
+  listeners.clear();
+  diffView.set("split");
+  diffView.narrow = false;
+  localStorageMock.clear(); // drop the write from the reset above
+});
+
+afterEach(() => {
+  listeners.clear();
+});
+
+describe("diffView store", () => {
+  it("defaults to split when localStorage is empty", () => {
+    expect(diffView.pref).toBe("split");
+  });
+
+  it("readDiffView() returns split for an absent key", () => {
+    expect(readDiffView()).toBe("split");
+  });
+
+  it("readDiffView() returns split for a garbage value", () => {
+    store[KEY] = "sideways";
+    expect(readDiffView()).toBe("split");
+  });
+
+  it("set('unified') persists and reads back", () => {
+    diffView.set("unified");
+    expect(store[KEY]).toBe("unified");
+    expect(diffView.pref).toBe("unified");
+    expect(readDiffView()).toBe("unified");
+  });
+
+  it("toggle() flips split -> unified -> split", () => {
+    expect(diffView.pref).toBe("split");
+    diffView.toggle();
+    expect(diffView.pref).toBe("unified");
+    diffView.toggle();
+    expect(diffView.pref).toBe("split");
+  });
+
+  it("resolved mirrors pref on a wide viewport", () => {
+    diffView.set("split");
+    expect(diffView.resolved).toBe("split");
+    diffView.set("unified");
+    expect(diffView.resolved).toBe("unified");
+  });
+
+  it("forces resolved to unified on a narrow viewport even if pref is split", () => {
+    diffView.set("split");
+    const dispose = diffView.init();
+    mqMatches = true;
+    fire();
+    expect(diffView.narrow).toBe(true);
+    expect(diffView.resolved).toBe("unified");
+    // stored pref is untouched — a split preference survives the narrow override
+    expect(diffView.pref).toBe("split");
+    dispose();
+  });
+
+  it("init() returns a disposer that unregisters the change listener", () => {
+    const dispose = diffView.init();
+    dispose();
+    mqMatches = true;
+    fire(); // listener gone -> narrow stays false
+    expect(diffView.narrow).toBe(false);
+  });
+});

--- a/ui/src/lib/diff-view.svelte.ts
+++ b/ui/src/lib/diff-view.svelte.ts
@@ -1,0 +1,68 @@
+// Persisted split/unified preference for the multi-file diff tab. The stored
+// `pref` is the operator's choice; the *resolved* value is what the panel keys
+// on — narrow viewports (phone/split-screen) force unified regardless of pref,
+// because side-by-side split can't fit. Mirrors the shape of
+// build-queue-collapse.svelte.ts (localStorage read/try-catch + `set`) and
+// theme.svelte.ts (matchMedia-tracked `$state` seeded at construction, updated
+// via an `init()`-registered change listener that returns a disposer).
+
+export type DiffViewPref = "split" | "unified";
+
+const KEY = "shepherd:diff-view";
+const NARROW_QUERY = "(max-width: 768px)";
+
+function read(): DiffViewPref {
+  try {
+    const v = localStorage.getItem(KEY);
+    if (v === "split" || v === "unified") return v;
+  } catch {
+    /* localStorage unavailable (SSR / privacy mode) */
+  }
+  return "split";
+}
+
+function narrowNow(): boolean {
+  return typeof matchMedia !== "undefined" ? matchMedia(NARROW_QUERY).matches : false;
+}
+
+class DiffViewPrefStore {
+  pref = $state<DiffViewPref>(read());
+  narrow = $state<boolean>(narrowNow());
+
+  /** Effective view: unified is forced on a narrow viewport; otherwise `pref`.
+   *  A getter (not `$derived`) so it recomputes on every read — reactive in a
+   *  component because it reads the `$state` fields, and stable in node tests. */
+  get resolved(): DiffViewPref {
+    return this.narrow ? "unified" : this.pref;
+  }
+
+  /** Persist + apply a new stored preference. */
+  set(v: DiffViewPref) {
+    this.pref = v;
+    try {
+      localStorage.setItem(KEY, v);
+    } catch {
+      /* private mode / SSR — preference just won't survive reload */
+    }
+  }
+
+  toggle() {
+    this.set(this.pref === "split" ? "unified" : "split");
+  }
+
+  /** Wire viewport-width changes. Call once on mount; returns a disposer.
+   *  SSR-guarded like theme.svelte.ts's dark-query listener. */
+  init(): () => void {
+    if (typeof matchMedia === "undefined") return () => {};
+    const mq = matchMedia(NARROW_QUERY);
+    this.narrow = mq.matches;
+    const onChange = () => {
+      this.narrow = mq.matches;
+    };
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }
+}
+
+export const diffView = new DiffViewPrefStore();
+export { read as readDiffView };

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-diff-review-view.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-diff-review-view.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "diff-review-view",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_diff_review_title",
+  bodyKey: "feat_diff_review_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/highlight.ts
+++ b/ui/src/lib/highlight.ts
@@ -9,7 +9,7 @@ import { langFromPath } from "./diff";
 // Hand-tuned themes matching the HUD palette (Shiki needs concrete hex, not
 // CSS vars). Each mirrors app.css --ink/--muted/--amber/--green/--blue/--red
 // for its [data-theme] block.
-const SHEPHERD_DARK = {
+export const SHEPHERD_DARK = {
   name: "shepherd-dark",
   type: "dark" as const,
   colors: { "editor.background": "#0f1413", "editor.foreground": "#c4d0cb" },
@@ -30,7 +30,7 @@ const SHEPHERD_DARK = {
 };
 
 // Light counterpart — mirrors app.css [data-theme="light"] tokens.
-const SHEPHERD_LIGHT = {
+export const SHEPHERD_LIGHT = {
   name: "shepherd-light",
   type: "light" as const,
   colors: { "editor.background": "#f7f9f8", "editor.foreground": "#2b3633" },

--- a/ui/src/lib/pierre-diff.browser.test.ts
+++ b/ui/src/lib/pierre-diff.browser.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { registerShepherdThemes, parseFilePatch } from "./pierre-diff";
+
+// BROWSER project: exercises the lazy `@pierre/diffs` runtime path, which
+// needs a real DOM (custom-element registration etc).
+
+const SAMPLE_PATCH = `diff --git a/src/greet.ts b/src/greet.ts
+new file mode 100644
+index 0000000..e69de29
+--- /dev/null
++++ b/src/greet.ts
+@@ -0,0 +1,2 @@
++export function greet(): string {
++  return "hello";
++}
+`;
+
+describe("registerShepherdThemes", () => {
+  it("resolves without throwing", async () => {
+    await expect(registerShepherdThemes()).resolves.toBeUndefined();
+  });
+
+  it("is idempotent (safe to call twice)", async () => {
+    await registerShepherdThemes();
+    await expect(registerShepherdThemes()).resolves.toBeUndefined();
+  });
+});
+
+describe("parseFilePatch", () => {
+  it("parses a small one-file unified diff into non-null metadata matching the patch's path", async () => {
+    const file = await parseFilePatch(SAMPLE_PATCH);
+    expect(file).not.toBeNull();
+    expect(file?.name).toBe("src/greet.ts");
+  });
+});

--- a/ui/src/lib/pierre-diff.test.ts
+++ b/ui/src/lib/pierre-diff.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { fileSignature, estimateHeight } from "./pierre-diff";
+import type { DiffFile } from "./types";
+
+// NODE project: pure helpers only. This file must NOT trigger any @pierre/diffs
+// runtime import (which needs a DOM) — see pierre-diff.browser.test.ts for that.
+
+function diffFile(overrides: Partial<DiffFile> = {}): DiffFile {
+  return {
+    path: "src/foo.ts",
+    status: "modified",
+    additions: 1,
+    deletions: 1,
+    binary: false,
+    ...overrides,
+  };
+}
+
+describe("fileSignature", () => {
+  it("identical files produce identical signatures", () => {
+    const a = diffFile({ patch: "@@ -1 +1 @@\n-a\n+b\n" });
+    const b = diffFile({ patch: "@@ -1 +1 @@\n-a\n+b\n" });
+    expect(fileSignature(a)).toBe(fileSignature(b));
+  });
+
+  it("a changed patch changes the signature", () => {
+    const a = diffFile({ patch: "@@ -1 +1 @@\n-a\n+b\n" });
+    const b = diffFile({ patch: "@@ -1 +1 @@\n-a\n+c\n" });
+    expect(fileSignature(a)).not.toBe(fileSignature(b));
+  });
+
+  it("changed additions/deletions on a binary (no-patch) file changes the signature", () => {
+    const a = diffFile({ binary: true, additions: 0, deletions: 0, patch: undefined });
+    const b = diffFile({ binary: true, additions: 3, deletions: 2, patch: undefined });
+    expect(fileSignature(a)).not.toBe(fileSignature(b));
+  });
+
+  it("is stable across repeated calls", () => {
+    const file = diffFile({ patch: "@@ -1 +1 @@\n-a\n+b\n" });
+    expect(fileSignature(file)).toBe(fileSignature(file));
+  });
+});
+
+describe("estimateHeight", () => {
+  it("returns a positive integer", () => {
+    const height = estimateHeight(diffFile({ patch: "@@ -1 +1 @@\n-a\n+b\n" }));
+    expect(Number.isInteger(height)).toBe(true);
+    expect(height).toBeGreaterThan(0);
+  });
+
+  it("a file with more patch lines estimates taller than one with fewer", () => {
+    const short = estimateHeight(diffFile({ patch: "@@ -1 +1 @@\n-a\n+b\n" }));
+    const long = estimateHeight(
+      diffFile({ patch: "@@ -1,5 +1,5 @@\n-a\n-b\n-c\n-d\n-e\n+a\n+b\n+c\n+d\n+f\n" }),
+    );
+    expect(long).toBeGreaterThan(short);
+  });
+
+  it("falls back to additions+deletions for a no-patch (binary) file", () => {
+    const height = estimateHeight(
+      diffFile({ binary: true, additions: 4, deletions: 6, patch: undefined }),
+    );
+    expect(Number.isInteger(height)).toBe(true);
+    expect(height).toBeGreaterThan(0);
+  });
+});

--- a/ui/src/lib/pierre-diff.ts
+++ b/ui/src/lib/pierre-diff.ts
@@ -1,0 +1,73 @@
+// Client-side substrate for the Pierre-powered diff renderer (Task 3/4 build on
+// this). All `@pierre/diffs` runtime imports are DYNAMIC so merely importing this
+// module (e.g. from a node test exercising the pure helpers below) never touches
+// Pierre's DOM-dependent runtime. `import type` is side-effect free and fine at
+// top level.
+import type { DiffFile } from "./types";
+import type { FileDiffMetadata } from "@pierre/diffs";
+
+let registered = false;
+
+/**
+ * Register the Shepherd Shiki themes with Pierre's theme resolver, so
+ * `FileDiff` can render with `theme: "shepherd-dark" | "shepherd-light"`.
+ * Idempotent — safe to call from multiple wrappers/mounts; only the first
+ * call does any work.
+ */
+export async function registerShepherdThemes(): Promise<void> {
+  if (registered) return;
+  registered = true;
+  const { registerCustomTheme } = await import("@pierre/diffs");
+  const { SHEPHERD_DARK, SHEPHERD_LIGHT } = await import("./highlight");
+  registerCustomTheme("shepherd-dark", async () => SHEPHERD_DARK);
+  registerCustomTheme("shepherd-light", async () => SHEPHERD_LIGHT);
+}
+
+/**
+ * Parse a single-file unified diff patch into Pierre's `FileDiffMetadata`
+ * (the shape `FileDiff.render({ fileDiff })` expects). Returns `null` when
+ * parsing yields no file (empty/invalid patch).
+ */
+export async function parseFilePatch(patch: string): Promise<FileDiffMetadata | null> {
+  const { parsePatchFiles } = await import("@pierre/diffs");
+  return parsePatchFiles(patch)[0]?.files[0] ?? null;
+}
+
+/**
+ * Cheap deterministic djb2 hash → base36 string. Not cryptographic — only used
+ * to detect whether a file's diff content changed between 15s polls.
+ */
+function hashString(s: string): string {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    h = (h * 33) ^ s.charCodeAt(i);
+  }
+  return (h >>> 0).toString(36);
+}
+
+/**
+ * A deterministic signature for a `DiffFile`, used to skip re-rendering a
+ * file whose content hasn't changed since the last poll. Hashes the exact
+ * patch text plus the summary fields (status/additions/deletions/binary/
+ * truncated), so binary/truncated files (no `patch`) still get a signature
+ * that changes when their summary changes.
+ */
+export function fileSignature(file: DiffFile): string {
+  const basis = `${file.patch ?? ""}|${file.status}|${file.additions}|${file.deletions}|${file.binary}|${file.truncated ?? false}`;
+  return hashString(basis);
+}
+
+const ROW_HEIGHT_PX = 20; // rough per-rendered-line height (font + line-height); estimate only
+const HEADER_PADDING_PX = 44; // file header row + top/bottom padding; estimate only
+
+/**
+ * Rough pixel height for a placeholder rendered before Pierre mounts the real
+ * `FileDiff`, so lazy-rendered files don't jump the scroll position. Estimates
+ * row count from the patch's line count when present, else falls back to
+ * additions + deletions (binary/truncated files).
+ */
+export function estimateHeight(file: DiffFile): number {
+  const rows =
+    file.patch !== undefined ? file.patch.split("\n").length : file.additions + file.deletions;
+  return rows * ROW_HEIGHT_PX + HEADER_PADDING_PX;
+}

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1874,7 +1874,8 @@ export interface DiffFile {
   deletions: number;
   binary: boolean;
   truncated?: boolean; // hunks dropped because the file exceeded the line cap
-  hunks: DiffHunk[]; // empty when binary or truncated
+  hunks?: DiffHunk[]; // empty when binary or truncated; omitted on the session wire (patch sent instead)
+  patch?: string; // raw git patch block for this file; session-endpoint only, omitted for binary/truncated
 }
 
 export interface DiffResult {


### PR DESCRIPTION
Replaces the session **Diff tab**'s hand-rolled renderer with **`@pierre/diffs`** (the diffs.com / hunk.dev engine), fed from the existing `GET /api/sessions/:id/diff` pipeline. Implements the de-risked integration from the research spike (PR #1691).

Closes #1698.

## What's in it
- **Split ↔ unified toggle** (segmented control, persisted per-browser via `localStorage`; **split-first on wide**, forced **unified on narrow ≤768px**).
- **Word-level intra-line diff** + **collapsed unchanged context** (free with Pierre).
- **File sidebar** built from our per-file `DiffResult` (A/M/D/R glyph + `±` stats), **click-to-scroll** with render-then-scroll correction; collapses to a compact picker on narrow.
- **Lazy per-file render** (IntersectionObserver) with reserved height estimates — keeps the DOM bounded under the server's 2000-line/file cap (no virtualization needed).
- **DARK + LIGHT parity**: our existing Shiki themes are injected into Pierre (`registerCustomTheme`); theme toggle is instant (`setThemeType`, no re-render).
- **15s poll is flash-free**: per-file content **signature** gates re-render, so unchanged files keep their DOM + scroll across ticks.

## Server change (no payload doubling)
The server now surfaces a **lossless per-file `patch`** (`parseUnifiedDiff` captures each file's raw git block) instead of the client reconstructing one. To avoid shipping the diff text twice: the **session endpoint sends `patch`, strips `hunks`**; the **recap keeps `hunks`, strips `patch`**. Server `DiffFile` keeps `hunks` required (so `visual-blocks.ts` is untouched); only the client type relaxes `hunks?`. Binary/truncated files carry neither and render an i18n note card.

## Annotations — deferred (plumbed, fed `[]`)
The review-first payoff (per-line agent notes) is the reason Pierre was chosen. The wrapper exposes typed `lineAnnotations`/`renderAnnotation`, but this PR feeds an **empty list** — no annotation UI ships. The **data-source decision** (tool-call spans / plan steps / review pass; read-only vs thread) is tracked in **#1699** (owner @plenz, target v1.45.0). Sourcing the data later reuses this exact substrate with no viewer rework.

## Gates
- i18n EN/DE parity (`check:i18n`, 2969 keys) — includes fixing the pre-existing hardcoded English in `DiffFileBlock.svelte` ("binary file" / "large file…" / "no textual changes").
- Feature-announcement entry added (`v1.44.0-diff-review-view.ts`); catalog + version gates green.
- Design tokens only (no raw hex); toggle meets the 44px coarse-pointer tap floor.
- Branch hygiene linear; `fallow audit` green (duplication is a warn — the deliberately-shared status-glyph/note convention between the new stack and the recap-only `DiffFileBlock`).
- Root `bun test` (6845) + `cd ui && bun run test` (3475, incl. new browser tests exercising real Pierre shadow-DOM split/theme/toggle/scroll) both green; UI production build confirms Pierre is code-split into a lazy chunk off first paint.

## Notes
- `DiffFileBlock.svelte` is **retained** — the recap still renders through it (the original issue's "retire it" assumption was incorrect); only the session tab's render path is replaced.
- `setOptions({diffStyle}) + rerender()` was validated as the split↔unified path (the plan's open assumption); Pierre `setOptions` replaces options wholesale, so the toggle spreads Pierre's live `fd.options`.
- Verification here relied on the automated browser suite (real Chromium, real Pierre rendering) + production build; driving a live session diff end-to-end is recommended as a final pre-merge smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
