### PR TITLE
fix(ui): cap Diff file sidebar at 1/3, collapse paths keeping the filename

### DIFF
--- a/ui/src/lib/components/DiffFileSidebar.svelte
+++ b/ui/src/lib/components/DiffFileSidebar.svelte
@@ -4,6 +4,7 @@
   // horizontally-scrollable chip strip (CSS-only; one markup). Purely a
   // files -> rows mapping + selection callback — no business logic.
   import type { DiffFile } from "$lib/types";
+  import { pathParts } from "$lib/diff-path";
   import { m } from "$lib/paraglide/messages";
 
   let {
@@ -48,7 +49,12 @@
           <span class="glyph status-{file.status}" aria-hidden="true">
             {STATUS_GLYPH[file.status]}
           </span>
-          <span class="path">{label(file)}</span>
+          <span class="path"
+            >{#each pathParts(file) as part, i (i)}{#if i > 0}<span class="arrow" aria-hidden="true"
+                  >&nbsp;→&nbsp;</span
+                >{/if}<span class="dir">{part.dir}</span><span class="name">{part.name}</span
+              >{/each}</span
+          >
           <span class="counts">
             <span class="add">+{file.additions}</span>
             <span class="del">−{file.deletions}</span>
@@ -126,11 +132,30 @@
   .status-modified {
     color: var(--color-amber);
   }
+  /* Filename never shrinks (always fully visible); the muted directory prefix
+     ellipsis-collapses when the rail is tight. */
   .path {
     flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: baseline;
+    overflow: hidden;
+  }
+  .dir {
+    flex: 0 1 auto;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    color: var(--color-muted);
+  }
+  .name {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+  .arrow {
+    flex: 0 0 auto;
+    color: var(--color-faint);
   }
   .counts {
     flex-shrink: 0;

--- a/ui/src/lib/components/DiffPanel.svelte
+++ b/ui/src/lib/components/DiffPanel.svelte
@@ -228,8 +228,12 @@
   }
   /* Sidebar root is <nav class="sidebar">; stack root is <div class="stack">.
      Both stretch to the content height (default align-items). */
+  /* Proportional cap, no px floor: the panel lives in the desktop grid's 1fr
+     region (min ~469px at a 769px viewport, where the 768px chip-strip breakpoint
+     hasn't engaged), so a fixed floor would eat >1/3 there. 30% keeps the diff
+     stack at ≥70% (> 2/3); capped so wide panels don't waste rail width. */
   .content > :global(.sidebar) {
-    flex: 0 0 220px;
+    flex: 0 0 min(30%, 320px);
   }
   .content > :global(.stack) {
     flex: 1;

--- a/ui/src/lib/diff-path.test.ts
+++ b/ui/src/lib/diff-path.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { collapsePath, pathParts } from "./diff-path";
+
+describe("collapsePath", () => {
+  it("collapses a long, deep path to root + immediate parent, keeping the filename whole", () => {
+    expect(collapsePath("ui/src/lib/components/viewport/FilesPanel.svelte")).toEqual({
+      dir: "ui/…/viewport/",
+      name: "FilesPanel.svelte",
+    });
+    expect(
+      collapsePath("ui/src/lib/feature-announcements/entries/v1.44.0-files-created-column.ts"),
+    ).toEqual({ dir: "ui/…/entries/", name: "v1.44.0-files-created-column.ts" });
+  });
+
+  it("passes through a short path (single directory segment)", () => {
+    expect(collapsePath("src/fs-browse.ts")).toEqual({ dir: "src/", name: "fs-browse.ts" });
+  });
+
+  it("does not collapse a shallow path (two directory segments)", () => {
+    expect(collapsePath("ui/messages/de.json")).toEqual({ dir: "ui/messages/", name: "de.json" });
+  });
+
+  it("returns an empty dir for a top-level file (no slash)", () => {
+    expect(collapsePath("README.md")).toEqual({ dir: "", name: "README.md" });
+  });
+});
+
+describe("pathParts", () => {
+  it("returns a single collapsed part for a normal file", () => {
+    expect(pathParts({ path: "src/fs-browse.ts", status: "modified" })).toEqual([
+      { dir: "src/", name: "fs-browse.ts" },
+    ]);
+  });
+
+  it("returns two collapsed parts (old → new) for a rename, collapsing both sides", () => {
+    expect(
+      pathParts({
+        status: "renamed",
+        oldPath: "ui/src/lib/old/nested/Old.ts",
+        path: "ui/src/lib/new/Renamed.ts",
+      }),
+    ).toEqual([
+      { dir: "ui/…/nested/", name: "Old.ts" },
+      { dir: "ui/…/new/", name: "Renamed.ts" },
+    ]);
+  });
+
+  it("ignores oldPath when status is not renamed", () => {
+    expect(pathParts({ path: "a/b/c/d.ts", oldPath: "x/y.ts", status: "modified" })).toEqual([
+      { dir: "a/…/c/", name: "d.ts" },
+    ]);
+  });
+});

--- a/ui/src/lib/diff-path.ts
+++ b/ui/src/lib/diff-path.ts
@@ -1,0 +1,28 @@
+// Path collapsing for the Diff-tab file rail (DiffFileSidebar). Splits a
+// repo-relative path into a collapsed directory label + the full filename, so
+// the sidebar can render the filename in a non-shrinking span (never truncated)
+// beside a muted, ellipsis-able directory prefix. Purely structural — no width
+// or character-count heuristics.
+
+export type PathPart = { dir: string; name: string };
+
+/**
+ * Split a repo-relative path into a collapsed directory label + full filename.
+ * Keeps the top-level dir + the file's immediate parent (`root/…/parent/`) when
+ * there are more than two directory segments; shows the full directory prefix
+ * otherwise; empty dir for a top-level file. The filename is always whole.
+ */
+export function collapsePath(p: string): PathPart {
+  const segs = p.split("/");
+  const name = segs.pop() ?? p; // filename — always kept whole
+  if (segs.length === 0) return { dir: "", name };
+  if (segs.length <= 2) return { dir: segs.join("/") + "/", name };
+  return { dir: `${segs[0]}/…/${segs[segs.length - 1]}/`, name };
+}
+
+/** One part normally; two (old → new) for a rename, each collapsed independently. */
+export function pathParts(file: { path: string; oldPath?: string; status: string }): PathPart[] {
+  return file.status === "renamed" && file.oldPath
+    ? [collapsePath(file.oldPath), collapsePath(file.path)]
+    : [collapsePath(file.path)];
+}


### PR DESCRIPTION
## What

On the new `@pierre/diffs` Diff tab, the file-name sidebar could take too much room and long paths were end-ellipsized (`…v1.44.0-files-created-colu…`), hiding the filename. This guarantees the diff keeps **≥2/3** of the panel and makes the filename always fully visible.

## Changes

- **Proportional cap, no floor** (`DiffPanel.svelte`): sidebar `flex: 0 0 min(30%, 320px)`. The panel sits in the desktop grid's `1fr` region (`minmax(300px,360px) 1fr`) — at a 769px viewport it's only ~469px wide and the 768px chip-strip breakpoint hasn't engaged, so a fixed px floor would eat >1/3 there. 30% keeps the diff stack at **≥70% (> 2/3)** at every two-pane width; capped at 320px so wide panels don't waste rail width.
- **Filename never truncated** (`DiffFileSidebar.svelte`): the path renders as a shrinking, muted directory span (`text-overflow: ellipsis`) + a **non-shrinking filename span**. Width can only collapse the directory prefix, never the filename tail. Full path stays in the row `title`.
- **Structural path collapse** (`diff-path.ts`, new): `collapsePath`/`pathParts` keep the top-level dir + the file's **immediate parent** (`root/…/parent/`, e.g. `ui/…/viewport/FilesPanel.svelte`) — the parent is what disambiguates same-named files. No width/char-count heuristic.

## Tests

- New `diff-path.test.ts` (node vitest): long+deep, short pass-through, shallow (≤2 dir segs), top-level (no slash), renamed `old → new`.
- `bun run check` clean; `test:node` (2278) green; existing `DiffPanel.browser.test.ts` (6) unchanged — the two adjacent spans concatenate to the same text.
- No new i18n keys (path text is verbatim data). Labeled `fix` (refinement of the shipped Diff tab, not a new capability) so no feature-catalog entry is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)