### PR TITLE
feat(ui): source per-line Diff-tab annotations (agent reasoning + critic findings) (#1699)

### DIFF
--- a/docs/external-task-api.md
+++ b/docs/external-task-api.md
@@ -129,7 +129,10 @@ Once a task exists, an external agent can also drive it:
 - `POST /api/broadcast` — send the same text to many sessions at once.
 - `DELETE /api/sessions/:id` — archive (end) the session.
 - `GET /api/sessions` — list active sessions; `GET /api/sessions/:id/diff`,
-  `/activity`, `/usage` for inspection.
+  `/activity`, `/usage` for inspection. `GET /api/sessions/:id/diff/annotations`
+  returns best-effort per-line Diff-tab annotations (agent reasoning anchored to
+  changed lines plus routed critic findings) as `{ "notes": [...] }`; it degrades
+  to an empty list on any error rather than failing.
 - `GET /api/sessions/:id/scratchpad[?path=]` — browse a live session's own
   scratchpad subtree; `GET /api/sessions/:id/scratchpad/download?path=`
   streams a single file. Paths are relative to the scratchpad root and

--- a/src/critic-core.ts
+++ b/src/critic-core.ts
@@ -340,7 +340,7 @@ function isPathShaped(token: string): boolean {
  * `files` set carried on InFlight, so it never touches the poll loop). For each finding, parse a
  * leading `<path>: ` token (stripping an optional `:<line>` suffix on the path) and DROP it iff:
  *   `files` is non-empty AND the leading token is path-shaped AND it does NOT correspond to any
- *   changed file (see `correspondsToChangedFile`: exact, trailing-segment, or basename match).
+ *   changed file (via `attributeFinding` → `matchChangedFile`: exact, trailing-segment, or basename match).
  * Findings with no parseable path prefix are KEPT (unattributed → never drop something we can't
  * attribute). Note this means a finding prefixed with an extensionless path (`Makefile: ...`,
  * `Dockerfile: ...`, `LICENSE: ...`) is NOT path-shaped per isPathShaped, so it is treated as

--- a/src/critic-core.ts
+++ b/src/critic-core.ts
@@ -356,35 +356,65 @@ export function scopeFindings(
   const kept: string[] = [];
   const dropped: string[] = [];
   for (const f of findings) {
-    // Leading token = everything up to the first ": ". No ": " → unattributed → keep.
-    const sep = f.indexOf(": ");
-    if (sep < 0) {
-      kept.push(f);
-      continue;
-    }
-    // Strip an optional `:<line>` (or `:<line>:<col>`) suffix so "src/a.ts:42: ..." → "src/a.ts".
-    const token = f.slice(0, sep).replace(/:\d+(?::\d+)?$/, "");
-    if (!isPathShaped(token)) {
-      kept.push(f); // prose prefix (e.g. "Note", "Nit") → not a path → keep
-      continue;
-    }
-    if (correspondsToChangedFile(token, files)) kept.push(f);
-    else dropped.push(f); // path-shaped + provably outside the diff → drop
+    // Reuse the shared classifier so the drop rule can never drift from the Diff-tab
+    // routing (#1699). DROP iff provably outside the diff; keep matched + unattributed —
+    // byte-identical to the pre-refactor per-finding logic.
+    if (attributeFinding(f, files).attribution === "out-of-diff") dropped.push(f);
+    else kept.push(f);
   }
   return { kept, dropped };
 }
 
-/** Does a path-shaped finding token correspond to a file actually changed in the diff? The critic
- *  is instructed to prefix the full repo-relative path, but it sometimes uses just the basename
+/** How a critic finding relates to the diff's changed-file set (`files`), used by BOTH the scope
+ *  backstop (`scopeFindings` drops `out-of-diff`) and the Diff tab's annotation routing (#1699,
+ *  which surfaces `out-of-diff` in the panel banner instead of dropping). Sharing one classifier
+ *  keeps the two consumers from drifting. */
+export type FindingAttribution = "matched" | "unattributed" | "out-of-diff";
+
+export interface AttributedFinding {
+  attribution: FindingAttribution;
+  /** `matched` → the corresponding `DiffFile.path` (NOT the raw token, so a basename/trailing
+   *  token keys the right file); `out-of-diff` → the raw path token; `unattributed` → "". */
+  path: string;
+  /** `matched`/`out-of-diff` → the finding with its `<path>: ` prefix stripped; `unattributed`
+   *  → the whole finding (there is no path prefix to strip). */
+  text: string;
+}
+
+/**
+ * Classify a single critic finding against the diff's changed-file set. Parses a leading
+ * `<path>: ` token (stripping an optional `:<line>[:<col>]` suffix). A finding with no `": "`
+ * separator, or whose leading token is not path-shaped (prose like "Note: "/"Nit: ", or an
+ * extensionless path like `Makefile: `), is `unattributed`. A path-shaped token that corresponds
+ * to a changed file (exact, trailing-segment, or basename match — see `matchChangedFile`) is
+ * `matched`; one that provably does not is `out-of-diff`. PURE. Callers with an empty `files` set
+ * should short-circuit before calling (an empty set would classify every path-shaped finding as
+ * `out-of-diff`).
+ */
+export function attributeFinding(finding: string, files: string[]): AttributedFinding {
+  const sep = finding.indexOf(": ");
+  if (sep < 0) return { attribution: "unattributed", path: "", text: finding };
+  // Strip an optional `:<line>` (or `:<line>:<col>`) suffix so "src/a.ts:42: ..." → "src/a.ts".
+  const token = finding.slice(0, sep).replace(/:\d+(?::\d+)?$/, "");
+  if (!isPathShaped(token)) return { attribution: "unattributed", path: "", text: finding };
+  const text = finding.slice(sep + 2); // everything after the "<path>: " prefix
+  const matched = matchChangedFile(token, files);
+  return matched
+    ? { attribution: "matched", path: matched, text }
+    : { attribution: "out-of-diff", path: token, text };
+}
+
+/** The changed file a path-shaped finding token corresponds to, or null. The critic is instructed
+ *  to prefix the full repo-relative path, but it sometimes uses just the basename
  *  (`Viewport.svelte:`) or a trailing slice (`components/Viewport.svelte:`). Match on any of:
  *  exact equality, the token being a trailing path-segment of a changed file, OR a bare basename
- *  match. Erring toward correspondence (KEEP) is the safe direction — a missed drop only wastes a
- *  round, whereas a false drop hides a real in-diff finding. The cost is that a basename shared by
- *  an unrelated changed file (`index.ts`) won't drop; acceptable given the prompt asks for full
- *  paths and this is only a fallback. */
-function correspondsToChangedFile(token: string, files: string[]): boolean {
+ *  match — returning the first such changed-file path. Erring toward correspondence (a match) is
+ *  the safe direction — a missed drop only wastes a round, whereas a false drop hides a real
+ *  in-diff finding. The cost is that a basename shared by an unrelated changed file (`index.ts`)
+ *  matches; acceptable given the prompt asks for full paths and this is only a fallback. */
+function matchChangedFile(token: string, files: string[]): string | null {
   const base = baseName(token);
-  return files.some((f) => f === token || f.endsWith("/" + token) || baseName(f) === base);
+  return files.find((f) => f === token || f.endsWith("/" + token) || baseName(f) === base) ?? null;
 }
 
 function baseName(p: string): string {

--- a/src/diff-annotations.ts
+++ b/src/diff-annotations.ts
@@ -1,0 +1,303 @@
+// Per-line Diff-tab annotations (#1699). Derives two read-only, EPHEMERAL sources from data
+// that already exists — no new storage:
+//
+//  1. Agent spans  — the agent's own reasoning, anchored to the changed line its edit produced.
+//     Sourced from the session transcript: Phase-0 (see .shepherd-plan.md) established that Claude
+//     Code writes each content block as its OWN assistant JSONL line (thinking / text / tool_use
+//     separate), sharing a `message.id` per turn, and that `thinking` is absent in practice — so
+//     reasoning is read from the turn's `text` blocks (grouped by `message.id`), and each edit is
+//     anchored by a UNIQUE multi-line content signature (ambiguity → DROP, never anchor wrong).
+//  2. Review findings — the session's Critic findings, routed via the shared critic-core
+//     `attributeFinding` classifier: a finding attributable to a diff file → per-file banner;
+//     unattributed OR out-of-diff → panel banner (NEVER dropped here — see the endpoint/client).
+//
+// This module is PURE + sync (except `readTranscriptTail`, itself sync fs) so the builder is unit
+// testable; the endpoint (server.ts) does the async IO (computeDiff / getReview) and calls in.
+
+import { attributeFinding } from "./critic-core";
+import { readTranscriptTail } from "./activity";
+import type { DiffFile } from "./types";
+
+/** One Diff-tab annotation on the wire. `kind:"agent"` carries a line anchor (`side`+`lineNumber`)
+ *  and the tool; `kind:"review"` is file-level (`path`) or panel-level (`path:""`), no anchor.
+ *  NOTE: named `DiffNote`, not `DiffAnnotation` — the UI already owns a `DiffAnnotation` type
+ *  (visual-block prose note). `text` is VERBATIM agent/critic content — never HTML (client renders
+ *  it as a text node only). */
+export interface DiffNote {
+  path: string;
+  kind: "agent" | "review";
+  text: string;
+  side?: "additions" | "deletions";
+  lineNumber?: number;
+  tool?: string;
+}
+
+// ── tuning knobs (all conservative; the design's honest limits live here) ──────────────────────
+const SIG_MAX_LINES = 3; // signature = up to N leading non-blank lines of the edit's new text
+const MIN_SINGLE_LINE_SIG = 20; // a 1-line signature must be at least this long (else too ambiguous)
+const MIN_REASON_LEN = 20; // reasoning shorter than this is treated as trivial → drop the note
+const REASON_MAX = 240; // clamp reasoning to ~this many chars (word boundary), then ellipsize
+const PER_FILE_AGENT_CAP = 8; // at most this many agent notes per file (avoid a wall on churny files)
+
+/** Normalize a line for signature comparison: trim outer whitespace (so indentation differences
+ *  between an edit's `new_string` and the diff's rendered content never block a match). */
+function norm(s: string): string {
+  return s.trim();
+}
+
+/** Up to `SIG_MAX_LINES` leading NON-BLANK lines of `text`, normalized — the anchoring signature. */
+function signatureLines(text: string): string[] {
+  const out: string[] = [];
+  for (const raw of text.split("\n")) {
+    const n = norm(raw);
+    if (n === "") continue;
+    out.push(n);
+    if (out.length >= SIG_MAX_LINES) break;
+  }
+  return out;
+}
+
+/** New-side view of a file's diff: every add/ctx line in document order, with its new-side line
+ *  number and whether it is an actual addition. `del` lines (no new-side number) are skipped. This
+ *  is the sequence an edit's `new_string` signature is matched against. */
+function newSideLines(file: DiffFile): { no: number; content: string; isAdd: boolean }[] {
+  const rows: { no: number; content: string; isAdd: boolean }[] = [];
+  for (const hunk of file.hunks ?? []) {
+    for (const line of hunk.lines) {
+      if (line.kind === "del") continue;
+      if (line.newNo === undefined) continue;
+      rows.push({ no: line.newNo, content: line.content, isAdd: line.kind === "add" });
+    }
+  }
+  return rows;
+}
+
+/**
+ * Anchor an edit's `newString` to a changed line, or return null (DROP). Requires a UNIQUE
+ * consecutive match of the signature against the file's new-side lines, AND that the match covers
+ * at least one real added line (so the anchor is genuinely in the diff, not pure context). Returns
+ * the new-side line number of the first added line within the matched run. A 1-line signature must
+ * clear `MIN_SINGLE_LINE_SIG` chars (a lone `}` / `return;` is too ambiguous to anchor).
+ */
+export function anchorEdit(
+  newString: string,
+  rows: { no: number; content: string; isAdd: boolean }[],
+): number | null {
+  const sig = signatureLines(newString);
+  if (sig.length === 0) return null;
+  if (sig.length === 1 && sig[0]!.length < MIN_SINGLE_LINE_SIG) return null;
+  const normed = rows.map((r) => norm(r.content));
+  const starts: number[] = [];
+  for (let i = 0; i + sig.length <= normed.length; i++) {
+    let ok = true;
+    for (let j = 0; j < sig.length; j++) {
+      if (normed[i + j] !== sig[j]) {
+        ok = false;
+        break;
+      }
+    }
+    if (ok) starts.push(i);
+  }
+  if (starts.length !== 1) return null; // 0 = no match, >1 = ambiguous → never anchor wrong
+  const s = starts[0]!;
+  for (let j = 0; j < sig.length; j++) {
+    if (rows[s + j]!.isAdd) return rows[s + j]!.no;
+  }
+  return null; // signature matched only context lines → not actually in the diff → drop
+}
+
+/** Clamp reasoning to `REASON_MAX` chars at a word boundary, ellipsizing when cut. */
+function clampReason(text: string): string {
+  const t = text.replace(/\s+/g, " ").trim();
+  if (t.length <= REASON_MAX) return t;
+  const cut = t.slice(0, REASON_MAX);
+  const sp = cut.lastIndexOf(" ");
+  return (sp > REASON_MAX * 0.6 ? cut.slice(0, sp) : cut).trimEnd() + "…";
+}
+
+/** One extracted edit operation: the file it targeted (repo-relative), the tool, the new text to
+ *  anchor, and the turn's reasoning. Exported for the extractor's test. */
+export interface TranscriptEdit {
+  path: string; // repo-relative (worktree prefix stripped)
+  tool: string; // "Edit" | "MultiEdit" | "Write"
+  newString: string;
+  reasoning: string;
+}
+
+const EDIT_TOOLS = new Set(["Edit", "MultiEdit", "Write"]);
+
+/** Repo-relative path for a transcript tool `file_path` (absolute), or null if outside the
+ *  worktree / missing. */
+function relPath(filePath: unknown, worktreePath: string): string | null {
+  if (typeof filePath !== "string" || filePath === "") return null;
+  const root = worktreePath.endsWith("/") ? worktreePath : worktreePath + "/";
+  if (filePath === worktreePath) return null;
+  if (!filePath.startsWith(root)) return null;
+  return filePath.slice(root.length);
+}
+
+type Turn = {
+  text: string[];
+  think: string[];
+  edits: { tool: string; input: Record<string, unknown> }[];
+};
+
+/** Parse one JSONL line as an assistant message with its turn id + content blocks, or null. */
+function parseAssistantLine(
+  line: string,
+): { id: string; content: Array<Record<string, unknown>> } | null {
+  const t = line.trim();
+  if (t === "") return null;
+  let o: unknown;
+  try {
+    o = JSON.parse(t);
+  } catch {
+    return null;
+  }
+  const rec = o as { type?: unknown; message?: { id?: unknown; content?: unknown } };
+  if (rec.type !== "assistant" || !Array.isArray(rec.message?.content)) return null;
+  const id = typeof rec.message?.id === "string" ? rec.message.id : "";
+  if (id === "") return null;
+  return { id, content: rec.message!.content as Array<Record<string, unknown>> };
+}
+
+/** Fold a message's content blocks into its turn: text / thinking → reasoning, edit tools → edits. */
+function addBlocksToTurn(turn: Turn, content: Array<Record<string, unknown>>): void {
+  for (const b of content) {
+    if (b.type === "text" && typeof b.text === "string" && b.text.trim())
+      turn.text.push(b.text.trim());
+    else if (b.type === "thinking" && typeof b.thinking === "string" && b.thinking.trim())
+      turn.think.push(b.thinking.trim());
+    else if (b.type === "tool_use" && typeof b.name === "string" && EDIT_TOOLS.has(b.name))
+      turn.edits.push({ tool: b.name, input: (b.input as Record<string, unknown>) ?? {} });
+  }
+}
+
+/** The non-empty new-text strings a single edit tool contributes: MultiEdit → each `edits[].new_string`,
+ *  Write → `content`, Edit → `new_string`. */
+function editNewStrings(tool: string, input: Record<string, unknown>): string[] {
+  const raw =
+    tool === "MultiEdit" && Array.isArray(input.edits)
+      ? (input.edits as Array<Record<string, unknown>>).map((e) => e?.new_string)
+      : [tool === "Write" ? input.content : input.new_string];
+  return raw.filter((s): s is string => typeof s === "string" && s.trim() !== "");
+}
+
+/** The edit ops a single turn contributes: each edit tool × each of its new-text strings, tagged
+ *  with the turn's reasoning (thinking preferred over text). Edits outside the worktree are skipped. */
+function turnEdits(turn: Turn, worktreePath: string): TranscriptEdit[] {
+  const reasoning = (turn.think.join(" ") || turn.text.join(" ")).trim();
+  const ops: TranscriptEdit[] = [];
+  for (const e of turn.edits) {
+    const path = relPath(e.input.file_path, worktreePath);
+    if (path === null) continue;
+    for (const newString of editNewStrings(e.tool, e.input))
+      ops.push({ path, tool: e.tool, newString, reasoning });
+  }
+  return ops;
+}
+
+/**
+ * Parse a transcript into edit operations with their turn reasoning. Groups assistant lines by
+ * `message.id` (each content block is its own JSONL line — Phase 0), so a turn's `text` blocks
+ * (preferring `thinking` when present, though it is absent in practice) supply the reasoning for
+ * every edit in that turn. Edit → one op; MultiEdit → one op per `edits[]`; Write → the `content`.
+ * PURE (operates on the passed text).
+ */
+export function parseTranscriptEdits(text: string, worktreePath: string): TranscriptEdit[] {
+  const turns = new Map<string, Turn>();
+  const order: string[] = [];
+  for (const line of text.split("\n")) {
+    const parsed = parseAssistantLine(line);
+    if (!parsed) continue;
+    let turn = turns.get(parsed.id);
+    if (!turn) {
+      turn = { text: [], think: [], edits: [] };
+      turns.set(parsed.id, turn);
+      order.push(parsed.id);
+    }
+    addBlocksToTurn(turn, parsed.content);
+  }
+  return order.flatMap((id) => turnEdits(turns.get(id)!, worktreePath));
+}
+
+/** Build the agent-span notes: anchor each extracted edit against its diff file's new-side lines,
+ *  dropping trivial reasoning, unanchorable edits, per-line/text duplicates, and anything beyond
+ *  the per-file cap. PURE. */
+export function buildAgentNotes(edits: TranscriptEdit[], files: DiffFile[]): DiffNote[] {
+  const byPath = new Map(files.map((f) => [f.path, f]));
+  const rowsCache = new Map<string, { no: number; content: string; isAdd: boolean }[]>();
+  const perFileCount = new Map<string, number>();
+  const seen = new Set<string>();
+  const notes: DiffNote[] = [];
+  for (const e of edits) {
+    const reason = clampReason(e.reasoning);
+    if (reason.length < MIN_REASON_LEN) continue; // trivial/empty → drop
+    const file = byPath.get(e.path);
+    if (!file || file.binary || file.truncated) continue; // no anchorable hunks
+    let rows = rowsCache.get(e.path);
+    if (!rows) {
+      rows = newSideLines(file);
+      rowsCache.set(e.path, rows);
+    }
+    const line = anchorEdit(e.newString, rows);
+    if (line === null) continue;
+    const dedupe = `${e.path} ${line} ${reason}`;
+    if (seen.has(dedupe)) continue;
+    const count = perFileCount.get(e.path) ?? 0;
+    if (count >= PER_FILE_AGENT_CAP) continue;
+    seen.add(dedupe);
+    perFileCount.set(e.path, count + 1);
+    notes.push({
+      path: e.path,
+      kind: "agent",
+      text: reason,
+      side: "additions",
+      lineNumber: line,
+      tool: e.tool,
+    });
+  }
+  return notes;
+}
+
+/** Build the review notes from already-scope-filtered critic findings. Routes via the shared
+ *  `attributeFinding` discriminant: `matched` → per-file (keyed to the DiffFile.path); BOTH
+ *  `unattributed` and `out-of-diff` → panel-level (`path:""`) — NEVER dropped here (the findings
+ *  already passed the critic's scope gate; a base skew must not hide one). PURE. */
+export function buildReviewNotes(findings: string[], filePaths: string[]): DiffNote[] {
+  const notes: DiffNote[] = [];
+  for (const f of findings) {
+    const { attribution, path, text } = attributeFinding(f, filePaths);
+    notes.push({
+      path: attribution === "matched" ? path : "",
+      kind: "review",
+      text: attribution === "matched" ? text : f,
+    });
+  }
+  return notes;
+}
+
+/** Full builder: agent notes (from the transcript) + review notes (from findings), against a
+ *  computed diff's files. `transcriptPath` may be "" (pre-feature session, no pinned id) → no
+ *  agent notes. PURE except the sync `readTranscriptTail`. */
+export function buildDiffNotes(input: {
+  files: DiffFile[];
+  worktreePath: string;
+  transcriptPath: string;
+  findings: string[];
+}): DiffNote[] {
+  const { files, worktreePath, transcriptPath, findings } = input;
+  const filePaths = files.map((f) => f.path);
+  let agent: DiffNote[] = [];
+  if (transcriptPath !== "") {
+    let transcript: string;
+    try {
+      transcript = readTranscriptTail(transcriptPath);
+    } catch {
+      transcript = ""; // missing/unreadable transcript → no agent notes (never an error)
+    }
+    if (transcript !== "")
+      agent = buildAgentNotes(parseTranscriptEdits(transcript, worktreePath), files);
+  }
+  return [...agent, ...buildReviewNotes(findings, filePaths)];
+}

--- a/src/diff-annotations.ts
+++ b/src/diff-annotations.ts
@@ -116,12 +116,14 @@ function clampReason(text: string): string {
 }
 
 /** One extracted edit operation: the file it targeted (repo-relative), the tool, the new text to
- *  anchor, and the turn's reasoning. Exported for the extractor's test. */
+ *  anchor, the turn's reasoning, and the id of the turn it came from (so `buildAgentNotes` can cap
+ *  a turn's reasoning to one note per file). Exported for the extractor's test. */
 export interface TranscriptEdit {
   path: string; // repo-relative (worktree prefix stripped)
   tool: string; // "Edit" | "MultiEdit" | "Write"
   newString: string;
   reasoning: string;
+  turnId: string; // the assistant message.id this edit's turn came from
 }
 
 const EDIT_TOOLS = new Set(["Edit", "MultiEdit", "Write"]);
@@ -184,15 +186,16 @@ function editNewStrings(tool: string, input: Record<string, unknown>): string[] 
 }
 
 /** The edit ops a single turn contributes: each edit tool × each of its new-text strings, tagged
- *  with the turn's reasoning (thinking preferred over text). Edits outside the worktree are skipped. */
-function turnEdits(turn: Turn, worktreePath: string): TranscriptEdit[] {
+ *  with the turn's reasoning (thinking preferred over text) and its `turnId`. Edits outside the
+ *  worktree are skipped. */
+function turnEdits(turn: Turn, worktreePath: string, turnId: string): TranscriptEdit[] {
   const reasoning = (turn.think.join(" ") || turn.text.join(" ")).trim();
   const ops: TranscriptEdit[] = [];
   for (const e of turn.edits) {
     const path = relPath(e.input.file_path, worktreePath);
     if (path === null) continue;
     for (const newString of editNewStrings(e.tool, e.input))
-      ops.push({ path, tool: e.tool, newString, reasoning });
+      ops.push({ path, tool: e.tool, newString, reasoning, turnId });
   }
   return ops;
 }
@@ -218,35 +221,54 @@ export function parseTranscriptEdits(text: string, worktreePath: string): Transc
     }
     addBlocksToTurn(turn, parsed.content);
   }
-  return order.flatMap((id) => turnEdits(turns.get(id)!, worktreePath));
+  return order.flatMap((id) => turnEdits(turns.get(id)!, worktreePath, id));
 }
 
 /** Build the agent-span notes: anchor each extracted edit against its diff file's new-side lines,
  *  dropping trivial reasoning, unanchorable edits, per-line/text duplicates, and anything beyond
  *  the per-file cap. PURE. */
+type RowsCache = Map<string, { no: number; content: string; isAdd: boolean }[]>;
+
+/** The changed line an edit anchors to in its diff file, or null (no renderable file, or an
+ *  ambiguous / out-of-diff signature). Caches each file's new-side rows across edits. */
+function anchorEditLine(
+  e: TranscriptEdit,
+  byPath: Map<string, DiffFile>,
+  cache: RowsCache,
+): number | null {
+  const file = byPath.get(e.path);
+  if (!file || file.binary || file.truncated) return null;
+  let rows = cache.get(e.path);
+  if (!rows) {
+    rows = newSideLines(file);
+    cache.set(e.path, rows);
+  }
+  return anchorEdit(e.newString, rows);
+}
+
 export function buildAgentNotes(edits: TranscriptEdit[], files: DiffFile[]): DiffNote[] {
   const byPath = new Map(files.map((f) => [f.path, f]));
-  const rowsCache = new Map<string, { no: number; content: string; isAdd: boolean }[]>();
+  const rowsCache: RowsCache = new Map();
   const perFileCount = new Map<string, number>();
   const seen = new Set<string>();
+  // One note per (turn, file): a turn's reasoning is turn-level, not per-edit — repeating the same
+  // paragraph on every line a turn touched duplicates text and over-claims per-line specificity, so
+  // a turn's reasoning is anchored to the FIRST line it successfully anchors on each file.
+  const turnFileAnnotated = new Set<string>();
   const notes: DiffNote[] = [];
   for (const e of edits) {
     const reason = clampReason(e.reasoning);
     if (reason.length < MIN_REASON_LEN) continue; // trivial/empty → drop
-    const file = byPath.get(e.path);
-    if (!file || file.binary || file.truncated) continue; // no anchorable hunks
-    let rows = rowsCache.get(e.path);
-    if (!rows) {
-      rows = newSideLines(file);
-      rowsCache.set(e.path, rows);
-    }
-    const line = anchorEdit(e.newString, rows);
+    const turnFile = `${e.turnId} ${e.path}`;
+    if (turnFileAnnotated.has(turnFile)) continue; // this turn already annotated this file
+    const line = anchorEditLine(e, byPath, rowsCache);
     if (line === null) continue;
     const dedupe = `${e.path} ${line} ${reason}`;
     if (seen.has(dedupe)) continue;
     const count = perFileCount.get(e.path) ?? 0;
     if (count >= PER_FILE_AGENT_CAP) continue;
     seen.add(dedupe);
+    turnFileAnnotated.add(turnFile);
     perFileCount.set(e.path, count + 1);
     notes.push({
       path: e.path,

--- a/src/server.ts
+++ b/src/server.ts
@@ -91,6 +91,7 @@ import { loadSteers, saveSteers } from "./steers";
 import { loadIcons, setIcon } from "./project-icons";
 import { listBranches } from "./branches";
 import { computeDiff, toSessionDiff } from "./diff";
+import { buildDiffNotes } from "./diff-annotations";
 import { resolveDiffBase } from "./diff-base";
 import { sessionTokens, jsonlPathFor, type SessionUsageRollup } from "./usage";
 import { buildUsageBreakdown } from "./usage-breakdown";
@@ -2076,6 +2077,33 @@ async function sessionDiffRead(id: string, deps: AppDeps): Promise<Response> {
   }
 }
 
+// Per-line Diff-tab annotations (#1699): agent reasoning anchored to changed lines (from the
+// transcript) + Critic findings routed to per-file / panel banners. Best-effort chrome — a
+// sibling of /diff so its heavier computation (transcript parse + anchoring) can never block or
+// break the diff itself. The client fetches it on diff-load + manual refresh, NOT on the 15s poll.
+// Uses the SAME base the tab renders; findings are already scope-filtered at critic time, so the
+// builder re-routes (never re-drops). Any failure degrades to an empty list, never a tab error.
+async function sessionDiffAnnotationsRead(id: string, deps: AppDeps): Promise<Response> {
+  const s = deps.store.get(id);
+  if (!s) return json({ error: "not found" }, 404);
+  try {
+    const { base } = await resolveDiffBase(s, deps.prCache, deps.resolveForge);
+    const diff = await computeDiff(s.worktreePath, base, s.branch); // structured hunks (not toSessionDiff)
+    const transcriptPath = s.claudeSessionId ? jsonlPathFor(s.worktreePath, s.claudeSessionId) : "";
+    const findings = deps.store.getReview(id)?.findings ?? [];
+    return json({
+      notes: buildDiffNotes({
+        files: diff.files,
+        worktreePath: s.worktreePath,
+        transcriptPath,
+        findings,
+      }),
+    });
+  } catch {
+    return json({ notes: [] });
+  }
+}
+
 async function sessionRead(id: string, deps: AppDeps): Promise<Response> {
   const s = deps.store.get(id);
   if (!s) return json({ error: "not found" }, 404);
@@ -2127,6 +2155,9 @@ async function handleSessionReads({ req, parts, deps }: Ctx): Promise<Response |
   if (parts[2] === "done" && !parts[3]) return json(doneSessionsWithIssueUrl(deps));
   if (parts[3] === "usage") return sessionUsageRead(parts[2], deps);
   if (parts[3] === "activity") return sessionActivityRead(parts[2], deps);
+  // annotations must precede the bare `diff` check (which matches parts[3]==="diff" regardless).
+  if (parts[3] === "diff" && parts[4] === "annotations")
+    return sessionDiffAnnotationsRead(parts[2], deps);
   if (parts[3] === "diff") return sessionDiffRead(parts[2], deps);
   // leftover subprocesses/proxies that would survive this session's close
   if (parts[3] === "leftovers") return json(deps.service.leftovers(parts[2]));

--- a/src/server.ts
+++ b/src/server.ts
@@ -2089,7 +2089,12 @@ async function sessionDiffAnnotationsRead(id: string, deps: AppDeps): Promise<Re
   try {
     const { base } = await resolveDiffBase(s, deps.prCache, deps.resolveForge);
     const diff = await computeDiff(s.worktreePath, base, s.branch); // structured hunks (not toSessionDiff)
-    const transcriptPath = s.claudeSessionId ? jsonlPathFor(s.worktreePath, s.claudeSessionId) : "";
+    // spawnAccountDir MUST be passed: a spawn-account session writes its JSONL under
+    // <account>/projects (see src/usage.ts) — omitting it resolves a nonexistent path and
+    // silently yields no agent notes. Matches poller/recap/reaper.
+    const transcriptPath = s.claudeSessionId
+      ? jsonlPathFor(s.worktreePath, s.claudeSessionId, s.spawnAccountDir)
+      : "";
     const findings = deps.store.getReview(id)?.findings ?? [];
     return json({
       notes: buildDiffNotes({

--- a/test/critic-core.test.ts
+++ b/test/critic-core.test.ts
@@ -6,6 +6,7 @@ import {
   scopeBackstop,
   shouldSkipForPatchId,
   scopeFindings,
+  attributeFinding,
   normalizeDecision,
   normalizeFindings,
   buildVerdictCore,
@@ -241,6 +242,53 @@ test("scopeFindings strips a :line suffix on the path token before matching", ()
   const { kept, dropped } = scopeFindings(["src/a.ts:42: out-of-line"], ["src/a.ts"]);
   expect(kept).toEqual(["src/a.ts:42: out-of-line"]);
   expect(dropped).toEqual([]);
+});
+
+// ── attributeFinding (pure, shared by scopeFindings + the Diff-tab #1699) ───
+
+test("attributeFinding classifies matched / unattributed / out-of-diff", () => {
+  const files = ["ui/src/lib/components/Viewport.svelte", "src/a.ts"];
+  // full path → matched, keyed to the DiffFile.path, prefix stripped
+  expect(attributeFinding("src/a.ts: real bug", files)).toEqual({
+    attribution: "matched",
+    path: "src/a.ts",
+    text: "real bug",
+  });
+  // basename prefix → matched on the right file (not a bespoke exact match)
+  expect(attributeFinding("Viewport.svelte: x", files)).toEqual({
+    attribution: "matched",
+    path: "ui/src/lib/components/Viewport.svelte",
+    text: "x",
+  });
+  // trailing-segment prefix → matched
+  expect(attributeFinding("lib/components/Viewport.svelte: y", files).attribution).toBe("matched");
+  // no ": " → unattributed, whole finding kept as text
+  expect(attributeFinding("does not satisfy the task", files)).toEqual({
+    attribution: "unattributed",
+    path: "",
+    text: "does not satisfy the task",
+  });
+  // prose prefix (not path-shaped) → unattributed
+  expect(attributeFinding("Note: something", files).attribution).toBe("unattributed");
+  // path-shaped but not in the diff → out-of-diff (scopeFindings drops; the Diff tab surfaces)
+  expect(attributeFinding("src/z.ts: gone", files)).toEqual({
+    attribution: "out-of-diff",
+    path: "src/z.ts",
+    text: "gone",
+  });
+  // :line suffix is stripped before matching
+  expect(attributeFinding("src/a.ts:42: at a line", files).attribution).toBe("matched");
+});
+
+test("scopeFindings drops exactly the out-of-diff attributions (parity with attributeFinding)", () => {
+  const files = ["src/a.ts", "src/b.ts"];
+  const findings = ["src/a.ts: in", "src/x.ts: out", "just a note", "Nit: prose"];
+  const { kept, dropped } = scopeFindings(findings, files);
+  // every dropped finding is out-of-diff; every kept one is not — the shared-classifier invariant
+  for (const f of dropped) expect(attributeFinding(f, files).attribution).toBe("out-of-diff");
+  for (const f of kept) expect(attributeFinding(f, files).attribution).not.toBe("out-of-diff");
+  expect(kept).toEqual(["src/a.ts: in", "just a note", "Nit: prose"]);
+  expect(dropped).toEqual(["src/x.ts: out"]);
 });
 
 // ── normalizeDecision / normalizeFindings (pure) ────────────────────────────

--- a/test/diff-annotations.test.ts
+++ b/test/diff-annotations.test.ts
@@ -135,8 +135,15 @@ test("buildAgentNotes anchors a note and drops trivial reasoning", () => {
       tool: "Edit",
       newString: "const distinctiveThing = 1;",
       reasoning: "This introduces the distinctive thing to fix the bug.",
+      turnId: "t1",
     },
-    { path: "src/a.ts", tool: "Edit", newString: "const distinctiveThing = 1;", reasoning: "ok" }, // trivial → drop
+    {
+      path: "src/a.ts",
+      tool: "Edit",
+      newString: "const distinctiveThing = 1;",
+      reasoning: "ok",
+      turnId: "t2",
+    }, // trivial → drop
   ];
   const notes = buildAgentNotes(edits, files);
   expect(notes).toHaveLength(1);
@@ -161,6 +168,7 @@ test("buildAgentNotes enforces the per-file cap", () => {
     tool: "Edit",
     newString: l.content,
     reasoning: `A sufficiently long reasoning string number ${i} for the gate.`,
+    turnId: `t${i}`, // distinct turns → the per-(turn,file) dedupe doesn't collapse them
   }));
   expect(buildAgentNotes(edits, files)).toHaveLength(8); // PER_FILE_AGENT_CAP
 });
@@ -175,9 +183,52 @@ test("buildAgentNotes skips binary/truncated files", () => {
       tool: "Write",
       newString: "whatever content long enough",
       reasoning: "A long enough reasoning string here.",
+      turnId: "t1",
     },
   ];
   expect(buildAgentNotes(edits, files)).toEqual([]);
+});
+
+test("buildAgentNotes emits ONE note per (turn, file) — no duplicated reasoning across a turn's anchors", () => {
+  const files = [
+    file("src/a.ts", [
+      { kind: "add", content: "firstDistinctiveEditLine();" },
+      { kind: "add", content: "secondDistinctiveEditLine();" },
+    ]),
+    file("src/b.ts", [{ kind: "add", content: "otherFileDistinctiveLine();" }]),
+  ];
+  const reasoning = "One turn-level paragraph that edited several unrelated spots at once.";
+  // A single turn (turnId "t1") edits two lines of a.ts + one line of b.ts.
+  const edits: TranscriptEdit[] = [
+    {
+      path: "src/a.ts",
+      tool: "Edit",
+      newString: "firstDistinctiveEditLine();",
+      reasoning,
+      turnId: "t1",
+    },
+    {
+      path: "src/a.ts",
+      tool: "Edit",
+      newString: "secondDistinctiveEditLine();",
+      reasoning,
+      turnId: "t1",
+    },
+    {
+      path: "src/b.ts",
+      tool: "Edit",
+      newString: "otherFileDistinctiveLine();",
+      reasoning,
+      turnId: "t1",
+    },
+  ];
+  const notes = buildAgentNotes(edits, files);
+  // One note per file the turn touched (a.ts anchored once at its FIRST line, b.ts once) — the
+  // reasoning is NOT repeated on a.ts's second edited line.
+  expect(notes.map((n) => [n.path, n.lineNumber])).toEqual([
+    ["src/a.ts", 1],
+    ["src/b.ts", 1],
+  ]);
 });
 
 // ── buildReviewNotes (pure) — routing, never re-drops ───────────────────────

--- a/test/diff-annotations.test.ts
+++ b/test/diff-annotations.test.ts
@@ -1,0 +1,204 @@
+import { test, expect } from "bun:test";
+import {
+  anchorEdit,
+  parseTranscriptEdits,
+  buildAgentNotes,
+  buildReviewNotes,
+  type TranscriptEdit,
+} from "../src/diff-annotations";
+import type { DiffFile } from "../src/types";
+
+// Build a modified DiffFile from a list of new-side lines (kind + content + newNo).
+function file(path: string, lines: { kind: "add" | "ctx"; content: string }[]): DiffFile {
+  let newNo = 1;
+  return {
+    path,
+    status: "modified",
+    additions: lines.filter((l) => l.kind === "add").length,
+    deletions: 0,
+    binary: false,
+    hunks: [{ header: "@@", lines: lines.map((l) => ({ ...l, newNo: newNo++ })) }],
+  };
+}
+
+// A transcript turn: message.id groups a text block + edit tool_use blocks (each its own line).
+function turn(id: string, text: string, edits: object[]): string {
+  const lines = [
+    JSON.stringify({
+      type: "assistant",
+      message: { id, role: "assistant", content: [{ type: "text", text }] },
+    }),
+    ...edits.map((input) =>
+      JSON.stringify({ type: "assistant", message: { id, role: "assistant", content: [input] } }),
+    ),
+  ];
+  return lines.join("\n");
+}
+const editUse = (name: string, input: object) => ({ type: "tool_use", name, input });
+
+// ── anchorEdit (pure) ───────────────────────────────────────────────────────
+
+test("anchorEdit anchors a unique multi-line signature to the first added line", () => {
+  const rows = [
+    { no: 10, content: "  ctx before", isAdd: false },
+    { no: 11, content: "const alpha = computeThing();", isAdd: true },
+    { no: 12, content: "return alpha + beta;", isAdd: true },
+  ];
+  expect(anchorEdit("const alpha = computeThing();\nreturn alpha + beta;", rows)).toBe(11);
+});
+
+test("anchorEdit drops an ambiguous (non-unique) signature — never anchors wrong", () => {
+  const rows = [
+    { no: 1, content: "return;", isAdd: true },
+    { no: 2, content: "return;", isAdd: true },
+  ];
+  expect(anchorEdit("return;", rows)).toBeNull();
+});
+
+test("anchorEdit drops a short single-line signature (too ambiguous)", () => {
+  const rows = [{ no: 1, content: "}", isAdd: true }];
+  expect(anchorEdit("}", rows)).toBeNull();
+});
+
+test("anchorEdit drops when the signature matches only context lines (not in the diff)", () => {
+  const rows = [
+    { no: 5, content: "unchanged distinctive context line here", isAdd: false },
+    { no: 6, content: "another unchanged distinctive context", isAdd: false },
+  ];
+  expect(
+    anchorEdit(
+      "unchanged distinctive context line here\nanother unchanged distinctive context",
+      rows,
+    ),
+  ).toBeNull();
+});
+
+test("anchorEdit matches despite indentation differences (trim-normalized)", () => {
+  const rows = [{ no: 3, content: "        deeplyIndentedDistinctiveCall();", isAdd: true }];
+  expect(anchorEdit("deeplyIndentedDistinctiveCall();", rows)).toBe(3);
+});
+
+// ── parseTranscriptEdits (pure) ─────────────────────────────────────────────
+
+const WT = "/home/u/wt";
+
+test("parseTranscriptEdits extracts Edit / MultiEdit / Write with turn reasoning", () => {
+  const text = [
+    turn("m1", "Reason for edit one that is sufficiently long.", [
+      editUse("Edit", { file_path: `${WT}/src/a.ts`, old_string: "x", new_string: "NEW A" }),
+    ]),
+    turn("m2", "Reason for the multi edit, also long enough here.", [
+      editUse("MultiEdit", {
+        file_path: `${WT}/src/b.ts`,
+        edits: [
+          { old_string: "o1", new_string: "M1" },
+          { old_string: "o2", new_string: "M2" },
+        ],
+      }),
+    ]),
+    turn("m3", "Reason for the write op, plenty long for the gate.", [
+      editUse("Write", { file_path: `${WT}/src/c.ts`, content: "WHOLE FILE" }),
+    ]),
+  ].join("\n");
+  const ops = parseTranscriptEdits(text, WT);
+  expect(ops.map((o) => [o.tool, o.path, o.newString])).toEqual([
+    ["Edit", "src/a.ts", "NEW A"],
+    ["MultiEdit", "src/b.ts", "M1"],
+    ["MultiEdit", "src/b.ts", "M2"],
+    ["Write", "src/c.ts", "WHOLE FILE"],
+  ]);
+  expect(ops[0]!.reasoning).toContain("Reason for edit one");
+});
+
+test("parseTranscriptEdits ignores edits outside the worktree and non-edit tools", () => {
+  const text = [
+    turn("m1", "long enough reasoning text goes here", [
+      editUse("Edit", { file_path: "/somewhere/else/x.ts", new_string: "OUT" }),
+      editUse("Bash", { command: "ls" }),
+    ]),
+  ].join("\n");
+  expect(parseTranscriptEdits(text, WT)).toEqual([]);
+});
+
+// ── buildAgentNotes (pure) ──────────────────────────────────────────────────
+
+test("buildAgentNotes anchors a note and drops trivial reasoning", () => {
+  const files = [
+    file("src/a.ts", [
+      { kind: "ctx", content: "// header" },
+      { kind: "add", content: "const distinctiveThing = 1;" },
+    ]),
+  ];
+  const edits: TranscriptEdit[] = [
+    {
+      path: "src/a.ts",
+      tool: "Edit",
+      newString: "const distinctiveThing = 1;",
+      reasoning: "This introduces the distinctive thing to fix the bug.",
+    },
+    { path: "src/a.ts", tool: "Edit", newString: "const distinctiveThing = 1;", reasoning: "ok" }, // trivial → drop
+  ];
+  const notes = buildAgentNotes(edits, files);
+  expect(notes).toHaveLength(1);
+  expect(notes[0]).toMatchObject({
+    path: "src/a.ts",
+    kind: "agent",
+    side: "additions",
+    lineNumber: 2,
+    tool: "Edit",
+  });
+  expect(notes[0]!.text).toContain("distinctive thing");
+});
+
+test("buildAgentNotes enforces the per-file cap", () => {
+  const lines = Array.from({ length: 12 }, (_, i) => ({
+    kind: "add" as const,
+    content: `uniqueLineNumber${i}();`,
+  }));
+  const files = [file("src/big.ts", lines)];
+  const edits: TranscriptEdit[] = lines.map((l, i) => ({
+    path: "src/big.ts",
+    tool: "Edit",
+    newString: l.content,
+    reasoning: `A sufficiently long reasoning string number ${i} for the gate.`,
+  }));
+  expect(buildAgentNotes(edits, files)).toHaveLength(8); // PER_FILE_AGENT_CAP
+});
+
+test("buildAgentNotes skips binary/truncated files", () => {
+  const files: DiffFile[] = [
+    { path: "img.png", status: "modified", additions: 0, deletions: 0, binary: true, hunks: [] },
+  ];
+  const edits: TranscriptEdit[] = [
+    {
+      path: "img.png",
+      tool: "Write",
+      newString: "whatever content long enough",
+      reasoning: "A long enough reasoning string here.",
+    },
+  ];
+  expect(buildAgentNotes(edits, files)).toEqual([]);
+});
+
+// ── buildReviewNotes (pure) — routing, never re-drops ───────────────────────
+
+test("buildReviewNotes routes matched→per-file, unattributed+out-of-diff→panel, never drops", () => {
+  const filePaths = ["ui/src/lib/components/Viewport.svelte", "src/a.ts"];
+  const findings = [
+    "src/a.ts: real per-file bug", // matched → per-file
+    "Viewport.svelte: basename bug", // matched via basename → per-file (right path)
+    "does not satisfy the task", // unattributed → panel
+    "src/gone.ts: stale finding", // out-of-diff → panel (NOT dropped)
+  ];
+  const notes = buildReviewNotes(findings, filePaths);
+  expect(notes).toHaveLength(4); // nothing dropped
+  expect(notes[0]).toEqual({ path: "src/a.ts", kind: "review", text: "real per-file bug" });
+  expect(notes[1]).toEqual({
+    path: "ui/src/lib/components/Viewport.svelte",
+    kind: "review",
+    text: "basename bug",
+  });
+  // unattributed + out-of-diff → panel (path ""), whole finding preserved as text
+  expect(notes[2]).toEqual({ path: "", kind: "review", text: "does not satisfy the task" });
+  expect(notes[3]).toEqual({ path: "", kind: "review", text: "src/gone.ts: stale finding" });
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3057,5 +3057,9 @@
   "herd_help_merging": "Der Merge-Train landet diese Pull Requests nacheinander für dich – kein manuelles Mergen. Sobald einer landet, wandert er zu „Gemergt“.",
   "herd_help_merged": "Diese Pull Requests sind auf deinem Main-Branch gelandet – fertig. Shepherd baut ihre Worktrees ab; übrige manuelle Schritte erscheinen in der Owed-Lens.",
   "feat_herd_stage_help_title": "Jede Board-Phase verstehen",
-  "feat_herd_stage_help_body": "Jede Phase in der Herd hat jetzt ein kleines „i“, das erklärt, was sie bedeutet, was Shepherd gerade für dich erledigt und was als Nächstes kommt – von „In Arbeit“ über „Review läuft“ bis „Gemergt“. Fahr mit der Maus drüber (oder tippe am Handy). Neu dabei? Das leere Board zeigt außerdem, wie die Arbeit von Anfang bis Ende fließt."
+  "feat_herd_stage_help_body": "Jede Phase in der Herd hat jetzt ein kleines „i“, das erklärt, was sie bedeutet, was Shepherd gerade für dich erledigt und was als Nächstes kommt – von „In Arbeit“ über „Review läuft“ bis „Gemergt“. Fahr mit der Maus drüber (oder tippe am Handy). Neu dabei? Das leere Board zeigt außerdem, wie die Arbeit von Anfang bis Ende fließt.",
+  "viewport_diff_annotation_agent": "Agent",
+  "viewport_diff_annotation_review": "Prüfung",
+  "feat_diff_annotations_title": "Agenten-Notizen im Diff-Tab",
+  "feat_diff_annotations_body": "Der Diff-Tab zeigt jetzt die Begründung des Agenten direkt inline — verankert an den Zeilen, die seine Änderungen erzeugt haben — sowie Code-Review-Befunde als Banner an den betroffenen Dateien. So steht das Warum direkt neben der Änderung."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3057,5 +3057,9 @@
   "herd_help_merging": "The Merge train is landing these pull requests for you, one after another — no manual merging. As each lands it moves to Merged.",
   "herd_help_merged": "These pull requests have landed on your main branch — done. Shepherd tears down their worktrees; any leftover manual steps show up on the Owed lens.",
   "feat_herd_stage_help_title": "Understand every board stage",
-  "feat_herd_stage_help_body": "Every stage on the Herd now has a small \"i\" that explains what it means, what Shepherd is doing for you, and what happens next — from Working through Reviewing to Merged. Hover it (or tap on mobile). New here? The empty board also shows how work flows end to end."
+  "feat_herd_stage_help_body": "Every stage on the Herd now has a small \"i\" that explains what it means, what Shepherd is doing for you, and what happens next — from Working through Reviewing to Merged. Hover it (or tap on mobile). New here? The empty board also shows how work flows end to end.",
+  "viewport_diff_annotation_agent": "Agent",
+  "viewport_diff_annotation_review": "Review",
+  "feat_diff_annotations_title": "Agent notes in the Diff tab",
+  "feat_diff_annotations_body": "The Diff tab now shows the agent's own reasoning inline, anchored to the lines its edits produced, plus any code-review findings as banners on the files they concern — so the why behind a change lives next to the change."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -31,6 +31,7 @@ import type {
   StarPromptStatus,
   Steer,
   DiffResult,
+  DiffAnnotationsResult,
   ProjectIcons,
   ReviewVerdict,
   PlanGate,
@@ -770,6 +771,15 @@ export async function getActivity(id: string): Promise<ActivityEntry[]> {
 export async function getDiff(id: string): Promise<DiffResult> {
   const r = await fetch(`/api/sessions/${id}/diff`);
   if (!r.ok) throw await failed(r, "diff");
+  return r.json();
+}
+
+/** Per-line Diff-tab annotations (#1699). Best-effort chrome — the caller fetches it on diff-load
+ *  + manual refresh (NOT on the 15s poll) and tolerates failure (renders the diff without notes).
+ *  The server already degrades to `{ notes: [] }` on any internal error. */
+export async function getDiffAnnotations(id: string): Promise<DiffAnnotationsResult> {
+  const r = await fetch(`/api/sessions/${id}/diff/annotations`);
+  if (!r.ok) throw await failed(r, "diff annotations");
   return r.json();
 }
 

--- a/ui/src/lib/components/DiffFileStack.browser.test.ts
+++ b/ui/src/lib/components/DiffFileStack.browser.test.ts
@@ -124,6 +124,52 @@ describe("DiffFileStack", () => {
     });
   });
 
+  it("shows a per-file review banner independent of lazy-mount + noteKind, escaping markup (#1699)", async () => {
+    vi.stubGlobal("IntersectionObserver", NoopIO);
+    const reviewFindings = new Map<string, string[]>([
+      [TEXT_PATH, ["a real per-file finding"]], // renderable file, NOT lazy-mounted (no scrollToPath)
+      ["logo.png", ["<img src=x onerror=alert(1)> binary finding"]], // binary note-card file
+    ]);
+    const { container } = await render(DiffFileStack, {
+      files,
+      diffStyle: "split" as "split" | "unified",
+      reviewFindings,
+    });
+
+    // Lazy-mount independence: no scrollToPath → no Pierre host, yet the banner still shows.
+    expect(host(), "no Pierre host mounted (lazy)").toBeNull();
+    const banners = container.querySelectorAll(".review-banner");
+    expect(banners.length, "one banner per file with findings").toBe(2);
+    expect(document.body.textContent).toContain("a real per-file finding");
+    expect(document.body.textContent).toContain(m.viewport_diff_annotation_review());
+
+    // noteKind independence: the banner shows on the binary note-card file too.
+    const binarySection = container.querySelector('[data-diff-path="logo.png"]');
+    expect(
+      binarySection?.querySelector(".review-banner"),
+      "banner on a binary note-card file",
+    ).toBeTruthy();
+
+    // XSS: finding markup renders as literal text, no element injected.
+    expect(document.body.textContent).toContain("<img src=x onerror=alert(1)> binary finding");
+    expect(
+      container.querySelector(".review-banner img"),
+      "no injected element from finding markup",
+    ).toBeNull();
+  });
+
+  it("renders no review banner when a file has no findings (#1699)", async () => {
+    vi.stubGlobal("IntersectionObserver", NoopIO);
+    const { container } = await render(DiffFileStack, {
+      files,
+      diffStyle: "split" as "split" | "unified",
+      reviewFindings: new Map<string, string[]>(),
+    });
+    expect(container.querySelectorAll(".review-banner").length, "no banners without findings").toBe(
+      0,
+    );
+  });
+
   it("renders an added-file (/dev/null) synthesized patch as a Pierre host, not a note card", async () => {
     vi.stubGlobal("IntersectionObserver", NoopIO);
     const addedFiles: DiffFile[] = [

--- a/ui/src/lib/components/DiffFileStack.svelte
+++ b/ui/src/lib/components/DiffFileStack.svelte
@@ -12,7 +12,7 @@
   // Pierre's async render settles to correct any estimate delta.
   import { tick } from "svelte";
   import { SvelteSet, SvelteMap } from "svelte/reactivity";
-  import type { DiffFile } from "$lib/types";
+  import type { DiffFile, DiffAgentAnnotation } from "$lib/types";
   import { fileSignature, estimateHeight } from "$lib/pierre-diff";
   import { m } from "$lib/paraglide/messages";
   import PierreDiff from "./PierreDiff.svelte";
@@ -20,10 +20,16 @@
   let {
     files,
     diffStyle,
+    agentAnnotations,
+    reviewFindings,
     onvisible,
   }: {
     files: DiffFile[];
     diffStyle: "split" | "unified";
+    // #1699: per-file agent annotations (→ Pierre) and review findings (→ per-file banner). Maps
+    // default to empty so the component renders exactly as before when no annotations are supplied.
+    agentAnnotations?: Map<string, DiffAgentAnnotation[]>;
+    reviewFindings?: Map<string, string[]>;
     onvisible?: (path: string) => void;
   } = $props();
 
@@ -171,6 +177,21 @@
         </span>
       </header>
 
+      <!-- Per-file review banner (#1699). Placed in the ALWAYS-rendered part of the section (before
+           the note/body branch), so it shows regardless of the IntersectionObserver lazy-mount
+           (rendered) or noteKind (binary/truncated/no-changes) — a finding on an off-screen or
+           note-card file still surfaces. Text is verbatim data via {text} (auto-escaped), no HTML. -->
+      {#if reviewFindings?.get(file.path)?.length}
+        <div class="review-banner" role="note">
+          <span class="review-chip">{m.viewport_diff_annotation_review()}</span>
+          <ul class="review-list">
+            {#each reviewFindings.get(file.path) ?? [] as finding (finding)}
+              <li>{finding}</li>
+            {/each}
+          </ul>
+        </div>
+      {/if}
+
       {#if note !== null}
         <p class="note">
           {#if note === "binary"}{m.diff_note_binary()}
@@ -179,7 +200,12 @@
         </p>
       {:else if rendered.has(file.path)}
         <div class="body" data-swipe-ignore>
-          <PierreDiff patch={file.patch ?? ""} signature={fileSignature(file)} {diffStyle} />
+          <PierreDiff
+            patch={file.patch ?? ""}
+            signature={fileSignature(file)}
+            {diffStyle}
+            lineAnnotations={agentAnnotations?.get(file.path) ?? []}
+          />
         </div>
       {/if}
     </section>
@@ -248,6 +274,36 @@
     padding: 8px 12px;
     color: var(--color-muted);
     font-size: var(--fs-meta);
+  }
+
+  /* Per-file review banner (#1699) — critic findings for this file. Amber (attention) accent per
+     the semantic-hue rule; verbatim finding text via {text} interpolation, never {@html}. */
+  .review-banner {
+    display: flex;
+    gap: 8px;
+    align-items: baseline;
+    padding: 6px 12px;
+    background: var(--color-inset);
+    border-bottom: 1px solid var(--color-line);
+    border-left: 2px solid var(--color-amber);
+    font-size: var(--fs-meta);
+    color: var(--color-ink);
+  }
+  .review-chip {
+    flex-shrink: 0;
+    font-family: var(--font-mono);
+    font-size: var(--fs-micro);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: var(--color-amber);
+  }
+  .review-list {
+    margin: 0;
+    padding-left: 1.1em;
+    list-style: disc;
+  }
+  .review-list li {
+    overflow-wrap: anywhere;
   }
   .body {
     padding: 4px 0;

--- a/ui/src/lib/components/DiffFileStack.svelte
+++ b/ui/src/lib/components/DiffFileStack.svelte
@@ -185,7 +185,7 @@
         <div class="review-banner" role="note">
           <span class="review-chip">{m.viewport_diff_annotation_review()}</span>
           <ul class="review-list">
-            {#each reviewFindings.get(file.path) ?? [] as finding (finding)}
+            {#each reviewFindings.get(file.path) ?? [] as finding, i (i)}
               <li>{finding}</li>
             {/each}
           </ul>

--- a/ui/src/lib/components/DiffPanel.svelte
+++ b/ui/src/lib/components/DiffPanel.svelte
@@ -166,7 +166,7 @@
       <div class="review-banner review-banner-panel" role="note">
         <span class="review-chip">{m.viewport_diff_annotation_review()}</span>
         <ul class="review-list">
-          {#each generalFindings as finding (finding)}
+          {#each generalFindings as finding, i (i)}
             <li>{finding}</li>
           {/each}
         </ul>

--- a/ui/src/lib/components/DiffPanel.svelte
+++ b/ui/src/lib/components/DiffPanel.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import { getDiff } from "$lib/api";
+  import { getDiff, getDiffAnnotations } from "$lib/api";
   import { pollWhileVisible } from "$lib/visibility";
   import { diffTotals } from "$lib/diff";
   import { diffView } from "$lib/diff-view.svelte";
-  import type { DiffResult } from "$lib/types";
+  import { SvelteMap } from "svelte/reactivity";
+  import type { DiffResult, DiffAgentAnnotation } from "$lib/types";
   import DiffFileSidebar from "$lib/components/DiffFileSidebar.svelte";
   import DiffFileStack from "$lib/components/DiffFileStack.svelte";
   import { m } from "$lib/paraglide/messages";
@@ -18,7 +19,16 @@
   // Stack instance handle — we only call its exported scrollToPath.
   let stackRef = $state<{ scrollToPath: (path: string) => Promise<void> }>();
 
+  // Per-line annotations (#1699), fetched SEPARATELY from the diff (see loadAnnotations) so the
+  // heavier transcript-parse/anchoring can never block or break the diff. Agent notes → per-file
+  // Pierre annotations; review findings → per-file banner (path) or panel banner (path "").
+  // Stable SvelteMaps (already reactive → no $state wrap); mutated in place, never reassigned.
+  const agentByPath = new SvelteMap<string, DiffAgentAnnotation[]>();
+  const reviewByPath = new SvelteMap<string, string[]>();
+  let generalFindings = $state<string[]>([]);
+
   let alive = true;
+  // Diff-only fetch — this is what the 15s poll and the initial load call.
   function load() {
     const id = sessionId; // the session this request is for
     getDiff(id)
@@ -35,6 +45,43 @@
       });
   }
 
+  // Annotations fetch — separate from the poll (best-effort chrome). Called on initial load and on
+  // manual refresh ONLY, never by the 15s poll. Failure degrades to no annotations (diff unaffected).
+  function loadAnnotations() {
+    const id = sessionId;
+    getDiffAnnotations(id)
+      .then(({ notes }) => {
+        if (!alive || id !== sessionId) return;
+        // Repopulate the stable reactive maps in place (clear + set) — never reassign the ref.
+        agentByPath.clear();
+        reviewByPath.clear();
+        const general: string[] = [];
+        for (const n of notes) {
+          if (n.kind === "agent" && n.lineNumber != null && n.side) {
+            (agentByPath.get(n.path) ?? agentByPath.set(n.path, []).get(n.path)!).push({
+              side: n.side,
+              lineNumber: n.lineNumber,
+              metadata: { text: n.text, tool: n.tool ?? "" },
+            });
+          } else if (n.kind === "review") {
+            if (n.path === "") general.push(n.text);
+            else
+              (reviewByPath.get(n.path) ?? reviewByPath.set(n.path, []).get(n.path)!).push(n.text);
+          }
+        }
+        generalFindings = general;
+      })
+      .catch(() => {
+        if (!alive || id !== sessionId) return; // keep the diff; just no annotations
+      });
+  }
+
+  // Diff + annotations together (initial load and manual refresh).
+  function refresh() {
+    load();
+    loadAnnotations();
+  }
+
   // fetch on session change + poll every 15s while this panel is mounted (tab active)
   $effect(() => {
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- reactive dep
@@ -43,9 +90,12 @@
     loaded = false;
     failed = false;
     activePath = undefined;
+    agentByPath.clear();
+    reviewByPath.clear();
+    generalFindings = [];
     alive = true;
-    load();
-    const stop = pollWhileVisible(load, 15000); // skip hidden-tab ticks; refresh on return
+    refresh();
+    const stop = pollWhileVisible(load, 15000); // diff only — annotations are not polled
     return () => {
       alive = false;
       stop();
@@ -101,7 +151,7 @@
         </button>
       </div>
     {/if}
-    <button class="refresh" type="button" onclick={load} aria-label={m.diff_refresh()}>↻</button>
+    <button class="refresh" type="button" onclick={refresh} aria-label={m.diff_refresh()}>↻</button>
   </div>
 
   {#if !loaded}
@@ -109,11 +159,26 @@
   {:else if failed}
     <p class="msg">{m.diff_error()}</p>
   {:else if result && result.files.length}
+    {#if generalFindings.length}
+      <!-- Panel-level review banner (#1699): non-file-specific critic findings (e.g. the headline
+           "does not satisfy the task" verdict) that can't attach to a file. Text is verbatim data
+           rendered via {text} interpolation (auto-escaped) — never {@html}. -->
+      <div class="review-banner review-banner-panel" role="note">
+        <span class="review-chip">{m.viewport_diff_annotation_review()}</span>
+        <ul class="review-list">
+          {#each generalFindings as finding (finding)}
+            <li>{finding}</li>
+          {/each}
+        </ul>
+      </div>
+    {/if}
     <div class="content">
       <DiffFileSidebar files={result.files} {activePath} onselect={handleSelect} />
       <DiffFileStack
         files={result.files}
         diffStyle={diffView.resolved}
+        agentAnnotations={agentByPath}
+        reviewFindings={reviewByPath}
         onvisible={(p) => (activePath = p)}
         bind:this={stackRef}
       />
@@ -256,5 +321,36 @@
     margin: 0;
     padding: 8px 10px;
     font-size: var(--fs-base);
+  }
+
+  /* Review banner (#1699) — critic findings. Amber (attention) accent per the semantic-hue rule.
+     The panel variant sits above the file stack for non-file-specific findings. */
+  .review-banner {
+    display: flex;
+    gap: 8px;
+    align-items: baseline;
+    padding: 6px 10px;
+    background: var(--color-inset);
+    border-bottom: 1px solid var(--color-line);
+    border-left: 2px solid var(--color-amber);
+    font-size: var(--fs-meta);
+    color: var(--color-ink);
+    flex-shrink: 0;
+  }
+  .review-chip {
+    flex-shrink: 0;
+    font-family: var(--font-mono);
+    font-size: var(--fs-micro);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: var(--color-amber);
+  }
+  .review-list {
+    margin: 0;
+    padding-left: 1.1em;
+    list-style: disc;
+  }
+  .review-list li {
+    overflow-wrap: anywhere;
   }
 </style>

--- a/ui/src/lib/components/DiffPanel.svelte
+++ b/ui/src/lib/components/DiffPanel.svelte
@@ -3,6 +3,7 @@
   import { pollWhileVisible } from "$lib/visibility";
   import { diffTotals } from "$lib/diff";
   import { diffView } from "$lib/diff-view.svelte";
+  import { fileSignature } from "$lib/pierre-diff";
   import { SvelteMap } from "svelte/reactivity";
   import type { DiffResult, DiffAgentAnnotation } from "$lib/types";
   import DiffFileSidebar from "$lib/components/DiffFileSidebar.svelte";
@@ -28,8 +29,16 @@
   let generalFindings = $state<string[]>([]);
 
   let alive = true;
-  // Diff-only fetch — this is what the 15s poll and the initial load call.
-  function load() {
+  // Content signature of the currently-shown diff (join of per-file signatures). When it changes
+  // across a poll the agent-anchored line numbers have shifted, so the persisted line annotations
+  // would mis-anchor — we clear them and re-fetch (see load()).
+  let lastDiffSig: string | undefined;
+
+  // Diff fetch — the 15s poll (forceAnnotations=false) and initial/manual load (true) all call this.
+  // When the diff CONTENT changes, agent notes anchored to the old line numbers are dropped
+  // immediately (prevent mis-anchoring) and re-fetched. `forceAnnotations` additionally re-fetches
+  // on an unchanged diff (manual refresh) so new critic findings surface without a content change.
+  function load(forceAnnotations = false) {
     const id = sessionId; // the session this request is for
     getDiff(id)
       .then((r) => {
@@ -37,6 +46,14 @@
         result = r;
         loaded = true;
         failed = false;
+        const sig = r.files.map(fileSignature).join(",");
+        if (sig !== lastDiffSig) {
+          lastDiffSig = sig;
+          agentByPath.clear(); // line numbers shifted → old anchors are stale; drop before re-fetch
+          loadAnnotations();
+        } else if (forceAnnotations) {
+          loadAnnotations();
+        }
       })
       .catch(() => {
         if (!alive || id !== sessionId) return;
@@ -76,10 +93,10 @@
       });
   }
 
-  // Diff + annotations together (initial load and manual refresh).
+  // Diff + annotations (initial load and manual refresh). `load(true)` re-fetches annotations even
+  // when the diff content is unchanged, so the button also refreshes critic findings.
   function refresh() {
-    load();
-    loadAnnotations();
+    load(true);
   }
 
   // fetch on session change + poll every 15s while this panel is mounted (tab active)
@@ -93,9 +110,11 @@
     agentByPath.clear();
     reviewByPath.clear();
     generalFindings = [];
+    lastDiffSig = undefined;
     alive = true;
     refresh();
-    const stop = pollWhileVisible(load, 15000); // diff only — annotations are not polled
+    // Poll the diff only; load() re-fetches annotations itself when the diff content changes.
+    const stop = pollWhileVisible(() => load(), 15000);
     return () => {
       alive = false;
       stop();

--- a/ui/src/lib/components/PierreDiff.browser.test.ts
+++ b/ui/src/lib/components/PierreDiff.browser.test.ts
@@ -149,3 +149,129 @@ describe("PierreDiff", () => {
     expect(appliedColorScheme(), "theme still light after toggle").toBe("light");
   });
 });
+
+// ── #1699 per-line annotations ──────────────────────────────────────────────
+// These read the REAL DOM Pierre produces and pin the @pierre/diffs API/behaviour the
+// metadata-generic + late-arrival + two-paths design bet on (treated as assumptions, gated here).
+
+type Anno = {
+  side: "additions" | "deletions";
+  lineNumber: number;
+  metadata: { text: string; tool: string };
+};
+// PATCH's only added line is new-side line 2 (`return \`hello ${name}\``).
+function anno(text: string, lineNumber = 2): Anno {
+  return { side: "additions", lineNumber, metadata: { text, tool: "Edit" } };
+}
+function annoCard(): Element | null {
+  return host()?.querySelector(".diff-anno") ?? null;
+}
+function annoWrapper(): HTMLElement | null {
+  return host()?.querySelector("[data-annotation-slot]") ?? null;
+}
+
+describe("PierreDiff annotations (#1699)", () => {
+  it("HARD GATE: setLineAnnotations/rerender are public and a late-set annotation renders + survives a re-render", async () => {
+    // The metadata-generic + late-arrival fixes bet on these APIs. Fail LOUDLY if a bump breaks them.
+    expect(typeof FileDiff.prototype.setLineAnnotations, "setLineAnnotations is public").toBe(
+      "function",
+    );
+    expect(typeof FileDiff.prototype.rerender, "rerender is public").toBe("function");
+
+    const screen = await render(PierreDiff, {
+      patch: PATCH,
+      signature: "sig-anno-1",
+      diffStyle: "split" as "split" | "unified",
+      lineAnnotations: [] as Anno[],
+    });
+    await vi.waitFor(() => expect(diffTypeMarker()).toBe("split"));
+    expect(annoCard(), "no annotation before one arrives").toBeNull();
+
+    // Late arrival: annotations set AFTER the first render must appear (setLineAnnotations+rerender).
+    await screen.rerender({
+      patch: PATCH,
+      signature: "sig-anno-1",
+      diffStyle: "split",
+      lineAnnotations: [anno("why this line changed")],
+    });
+    await vi.waitFor(() => {
+      const card = annoCard();
+      expect(card, "annotation card rendered").toBeTruthy();
+      expect(card!.textContent).toContain("why this line changed");
+      expect(
+        annoWrapper()?.assignedSlot ?? null,
+        "wrapper is slotted (line-anchored)",
+      ).not.toBeNull();
+    });
+
+    // A subsequent re-render (diffStyle toggle) must PRESERVE the annotation.
+    await screen.rerender({
+      patch: PATCH,
+      signature: "sig-anno-1",
+      diffStyle: "unified",
+      lineAnnotations: [anno("why this line changed")],
+    });
+    await vi.waitFor(() => expect(diffTypeMarker()).toBe("single"));
+    expect(annoCard()?.textContent, "annotation preserved across rerender").toContain(
+      "why this line changed",
+    );
+  });
+
+  it("LINE-0 OBSERVED: FileDiff DOES honor a file-level (lineNumber:0) slot — banner path kept regardless", async () => {
+    // Observed-behaviour guard (the plan's stated fallback). Planning ASSUMED FileDiff drops
+    // lineNumber:0; this test found it actually renders it (a slot `annotation-additions-0` above
+    // the first hunk). That does NOT change the architecture: review findings STILL route through
+    // the Svelte banner, not a line-0 Pierre annotation, because the banner also covers
+    // binary/truncated/no-changes files (which have NO Pierre host at all) and the panel-level
+    // general findings, and is token/i18n-native. This test documents the reality; it is not a gate
+    // on a redesign. If a future @pierre/diffs bump STOPS honouring line 0, this flips to a plain
+    // pass — the banner path is unaffected either way.
+    await render(PierreDiff, {
+      patch: PATCH,
+      signature: "sig-anno-0",
+      diffStyle: "split" as "split" | "unified",
+      lineAnnotations: [anno("file level note", 0)],
+    });
+    await vi.waitFor(() => expect(diffTypeMarker()).toBe("split"));
+    await vi.waitFor(() => {
+      expect(
+        annoWrapper()?.assignedSlot ?? null,
+        "line-0 annotation IS slotted (Pierre honors file-level)",
+      ).not.toBeNull();
+    });
+  });
+
+  it("XSS: verbatim annotation text with markup renders as literal text, not HTML", async () => {
+    const payload = `<img src=x onerror=alert(1)><script>bad()</script>`;
+    await render(PierreDiff, {
+      patch: PATCH,
+      signature: "sig-anno-xss",
+      diffStyle: "split" as "split" | "unified",
+      lineAnnotations: [anno(payload)],
+    });
+    await vi.waitFor(() => expect(annoCard(), "card rendered").toBeTruthy());
+    const card = annoCard()!;
+    expect(card.textContent, "raw markup preserved as text").toContain(payload);
+    expect(card.querySelector("img, script"), "no element injected from the payload").toBeNull();
+  });
+
+  it("does not re-render Pierre when annotations stay empty (no pre-render / no-op rerender)", async () => {
+    const rerenderSpy = vi.spyOn(FileDiff.prototype, "rerender");
+    const screen = await render(PierreDiff, {
+      patch: PATCH,
+      signature: "sig-anno-empty",
+      diffStyle: "split" as "split" | "unified",
+      lineAnnotations: [] as Anno[],
+    });
+    await vi.waitFor(() => expect(diffTypeMarker()).toBe("split"));
+    // A fresh empty array (as `?? []` yields on every annotations refresh) must NOT trigger rerender.
+    await screen.rerender({
+      patch: PATCH,
+      signature: "sig-anno-empty",
+      diffStyle: "split",
+      lineAnnotations: [],
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(rerenderSpy.mock.calls.length, "no rerender for unchanged-empty annotations").toBe(0);
+  });
+});

--- a/ui/src/lib/components/PierreDiff.svelte
+++ b/ui/src/lib/components/PierreDiff.svelte
@@ -27,21 +27,23 @@
   import type { DiffLineAnnotation, FileDiff, FileDiffOptions } from "@pierre/diffs";
   import { theme } from "$lib/theme.svelte";
   import { registerShepherdThemes, parseFilePatch } from "$lib/pierre-diff";
+  import { m } from "$lib/paraglide/messages";
 
-  type Annotation = DiffLineAnnotation;
+  // Metadata carried on each agent annotation (#1699). Threaded as Pierre's `LAnnotation` generic
+  // so `renderAnnotation` can read `a.metadata`; the wrapper hardcoded `<undefined>` before.
+  type Meta = { text: string; tool: string };
+  type Annotation = DiffLineAnnotation<Meta>;
 
   let {
     patch,
     signature,
     diffStyle,
     lineAnnotations = [],
-    renderAnnotation,
   }: {
     patch: string;
     signature: string;
     diffStyle: "split" | "unified";
     lineAnnotations?: Annotation[];
-    renderAnnotation?: (a: Annotation) => HTMLElement | undefined;
   } = $props();
 
   // Wrapper the `<diffs-container>` host is appended into (by Pierre).
@@ -49,8 +51,41 @@
 
   // Non-reactive instance state (deliberately plain `let`, not `$state`: these
   // drive the external Pierre lib, never the template).
-  let fd: FileDiff | undefined; // the FileDiff instance (fd.options is the live options source of truth)
+  let fd: FileDiff<Meta> | undefined; // the FileDiff instance (fd.options is the live options source of truth)
   let lastSignature: string | undefined; // content-gate: skip re-render when unchanged
+  // Whether the current `fd` has completed its first `render()`. Plain `let` (NOT $state): the
+  // late-arrival annotations effect reads it as a guard but must not re-run when it flips — it
+  // re-runs only when `lineAnnotations` changes. Guards against calling `rerender()` pre-render.
+  let hasRendered = false;
+  // Cheap content key of the annotations already applied to `fd`, so the late-arrival effect skips
+  // a redundant `setLineAnnotations`+`rerender` when the array reference changes but the CONTENT
+  // is identical (a fresh `[]` from `?? []` on every annotations refresh is the common case).
+  let lastAnnoKey: string | undefined;
+
+  // Stable content key: same annotations (side/line/text) → same string, regardless of reference.
+  function annoKey(annos: Annotation[]): string {
+    return annos.map((a) => `${a.side}:${a.lineNumber}:${a.metadata?.text ?? ""}`).join("|");
+  }
+
+  // Stable, in-component annotation renderer (#1699). Pierre captures `renderAnnotation` ONCE at
+  // FileDiff construction (not reactively), so it must be one stable reference present before the
+  // first render — hence a local const, not a per-file prop from DiffFileStack. Builds the agent
+  // card with TEXT NODES ONLY: `metadata.text` is verbatim, untrusted agent/transcript content, so
+  // innerHTML/template-string HTML would be a stored-XSS vector in the review surface.
+  function renderAnnotation(a: Annotation): HTMLElement | undefined {
+    if (!a.metadata) return undefined;
+    const card = document.createElement("div");
+    card.className = "diff-anno";
+    const chip = document.createElement("span");
+    chip.className = "diff-anno-chip";
+    chip.textContent = a.metadata.tool; // tool name (e.g. "Edit") — pass-through data, not translated
+    chip.title = m.viewport_diff_annotation_agent();
+    const body = document.createElement("span");
+    body.className = "diff-anno-text";
+    body.textContent = a.metadata.text; // VERBATIM — textContent only (never innerHTML)
+    card.append(chip, body);
+    return card;
+  }
   // Render-generation counter: every (re-)render bumps it and captures the value;
   // after each `await` a stale generation bails, so a rapid prop change or teardown
   // can never interleave two `render()` calls on the same host.
@@ -64,7 +99,7 @@
     const { FileDiff } = await import("@pierre/diffs");
     await registerShepherdThemes();
     if (fd) return; // another call won the race while we awaited
-    const options: FileDiffOptions<undefined> = {
+    const options: FileDiffOptions<Meta> = {
       theme: { dark: "shepherd-dark", light: "shepherd-light" },
       themeType: theme.resolved,
       diffStyle,
@@ -83,6 +118,7 @@
   // insert the `<diffs-container>` host itself on first render.
   async function renderContent(): Promise<void> {
     const myGen = ++gen;
+    hasRendered = false; // a fresh render is in flight — block the late-arrival effect until it lands
     await ensureInit();
     if (myGen !== gen || !fd || !root) return;
     const meta = await parseFilePatch(patch);
@@ -90,6 +126,8 @@
     if (meta == null) return; // empty/invalid patch — nothing to render
     fd.render({ fileDiff: meta, containerWrapper: root, lineAnnotations });
     lastSignature = signature;
+    lastAnnoKey = annoKey(lineAnnotations); // the render carried these; the effect diffs against it
+    hasRendered = true;
   }
 
   // Content reaction: (re-)render only when the signature actually changes.
@@ -105,6 +143,21 @@
   $effect(() => {
     const resolved = theme.resolved;
     fd?.setThemeType(resolved);
+  });
+
+  // Late-arrival annotations (#1699): the Diff-tab annotations are fetched separately from (and
+  // usually AFTER) the diff, so a file's first render often runs with `[]`. When `lineAnnotations`
+  // later changes, push it into the live instance WITHOUT a re-parse. GUARDED by `hasRendered` so
+  // `rerender()` is never called before the first `render()` (which is invalid) — before then, the
+  // current `lineAnnotations` is already carried into `renderContent`'s `fd.render(...)` call.
+  $effect(() => {
+    const annos = lineAnnotations; // reactive dep
+    const key = annoKey(annos);
+    if (!fd || !hasRendered) return; // pre-render: the initial render() already carries annos
+    if (key === lastAnnoKey) return; // unchanged content (e.g. a fresh empty array) → no-op
+    lastAnnoKey = key;
+    fd.setLineAnnotations(annos);
+    fd.rerender();
   });
 
   // View reaction: toggle split↔unified. `setOptions` replaces options wholesale,
@@ -127,6 +180,8 @@
   $effect(() => {
     return () => {
       gen++;
+      hasRendered = false;
+      lastAnnoKey = undefined;
       fd?.cleanUp();
       fd = undefined;
     };
@@ -140,5 +195,33 @@
      the shadow DOM (app tokens can't cascade in). The wrapper needs no chrome. */
   .pierre-diff {
     display: block;
+  }
+
+  /* Agent annotation card (#1699). `:global` because the node is built imperatively in
+     `renderAnnotation` (Svelte scoping only tags template elements). It's a LIGHT-DOM node Pierre
+     slots into its shadow host, so `:root` design tokens still inherit — no raw literals. */
+  :global(.diff-anno) {
+    display: flex;
+    gap: 8px;
+    align-items: baseline;
+    padding: 5px 12px;
+    margin: 2px 0;
+    background: var(--color-inset);
+    border-left: 2px solid var(--color-blue);
+    font-size: var(--fs-meta);
+    line-height: 1.5;
+    color: var(--color-ink);
+  }
+  :global(.diff-anno-chip) {
+    flex-shrink: 0;
+    font-family: var(--font-mono);
+    font-size: var(--fs-micro);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: var(--color-blue);
+  }
+  :global(.diff-anno-text) {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
   }
 </style>

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-diff-annotations.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-diff-annotations.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "diff-annotations",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_diff_annotations_title",
+  bodyKey: "feat_diff_annotations_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1920,6 +1920,32 @@ export interface DiffResult {
   files: DiffFile[];
 }
 
+/** One Diff-tab annotation (#1699). Mirrors the server `DiffNote`. `kind:"agent"` carries a line
+ *  anchor (`side`+`lineNumber`) + the tool; `kind:"review"` is file-level (`path`) or panel-level
+ *  (`path:""`), no anchor. `text` is VERBATIM agent/critic content — the client renders it as text
+ *  only (never HTML). (Named `DiffNote`, not `DiffAnnotation` — the latter is a visual-block type.) */
+export interface DiffNote {
+  path: string;
+  kind: "agent" | "review";
+  text: string;
+  side?: "additions" | "deletions";
+  lineNumber?: number;
+  tool?: string;
+}
+
+export interface DiffAnnotationsResult {
+  notes: DiffNote[];
+}
+
+/** An agent annotation in the shape `@pierre/diffs`' `DiffLineAnnotation<{text,tool}>` expects,
+ *  derived from a `DiffNote`. Kept as a structural match so the diff components need not import
+ *  Pierre's types (PierreDiff's `Annotation` type is assignable from this). */
+export interface DiffAgentAnnotation {
+  side: "additions" | "deletions";
+  lineNumber: number;
+  metadata: { text: string; tool: string };
+}
+
 export type LearningStatus = "proposed" | "active" | "promoted" | "dismissed" | "retired";
 
 /** What an evidence signal was captured from (mirrors server `SignalKind`):


### PR DESCRIPTION
Closes #1699. Follow-up to #1698/#1700 — feeds the already-proven `@pierre/diffs` annotation substrate (plumbed in #1700, fed `[]`) with real data.

## What

Two **read-only, ephemeral** annotation sources, both derived from data that already exists (no new storage/schema):

1. **Agent spans** — the agent's own reasoning, anchored to the changed line its edit produced. Turn-grouped transcript extraction (by `message.id`, reusing `readTranscriptTail`), rendered as **Pierre line annotations**.
2. **Review findings** — the session's Critic findings (`ReviewVerdict.findings`), rendered as **Svelte banners** (per-file + panel-level).

New sibling endpoint **`GET /api/sessions/:id/diff/annotations`** — best-effort chrome, fetched on diff-load + manual refresh (**not** the 15s poll), degrades to `[]` on any error so it can never block or break the diff.

## Design decisions (aligned with maintainer during plan gate)

- **Two rendering paths.** Agent spans → Pierre `lineAnnotations`; review findings → Svelte banner. The banner is required regardless of Pierre's line-0 support because binary/truncated/no-changes files have **no Pierre host at all**, and it uniformly carries the panel-level "not-file-specific" findings.
- **Strict-or-drop anchoring.** An edit anchors only on a **unique** multi-line content signature covering a real added line; ambiguous / out-of-diff / trivial-reasoning → **dropped** (never anchor wrong). Honest limits: ~40% of edits carry usable reasoning (Phase-0 measured), `thinking` blocks absent in practice, 512 KB transcript tail.
- **Shared classifier, no double-drop.** Review findings route via a new `attributeFinding` (3-way `matched | unattributed | out-of-diff`) extracted from `critic-core`'s `scopeFindings` logic (refactored onto it, byte-identical). Findings are already scope-filtered at critic time, so the tab **re-routes, never re-drops** — `matched` → per-file banner, `unattributed`/`out-of-diff` → panel banner.
- **XSS-safe.** All verbatim agent/critic text reaches the DOM as text nodes / `{text}` only — never `innerHTML`/`{@html}`.
- **Late-arrival.** Annotations fetched after first render appear via a `hasRendered`-guarded effect (`setLineAnnotations` + `rerender`, no re-parse), with a content-key gate so a fresh `[]` never triggers a redundant re-render.

## Empirical gates (this is a review-first surface — gates are loud-failing)

- **Phase 0 (HALTing):** verified on 3 real transcripts the agent-reasoning source is usable → PROCEED.
- **Browser gates** pin the `@pierre/diffs` API (generic `metadata`, public `setLineAnnotations`/`rerender`). The **line-0 gate found FileDiff DOES honor a file-level slot** (planning assumed it dropped) — the stated fallback was taken: the banner architecture is unchanged (see above).

## Tests

- `test/diff-annotations.test.ts` — anchoring (unique/ambiguous-drop/context-only-drop/short-drop), Edit/MultiEdit/Write extraction, trivial-drop, per-file cap, review routing.
- `test/critic-core.test.ts` — `attributeFinding` discriminant + `scopeFindings` byte-identical parity after the shared refactor.
- `PierreDiff.browser.test.ts` — hard API gate, line-0 observed behavior, XSS-as-text, late-arrival, no-op-empty rerender.
- `DiffFileStack.browser.test.ts` — per-file banner independent of lazy-mount + noteKind, markup escaped.

i18n EN+DE; feature-announcement entry `v1.44.0-diff-annotations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)