### PR TITLE
feat(ui): explain the activity heartbeat strip on hover

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2989,5 +2989,14 @@
   "feat_diff_review_body": "Der Diff-Tab der Sitzung nutzt jetzt eine neue Engine: Wechsle zwischen Nebeneinander- und vereinheitlichter Ansicht — mit wortgenauer Hervorhebung innerhalb der Zeile, einer Datei-Seitenleiste zur schnellen Navigation und einklappbarem unverändertem Kontext.",
   "repo_chip_open_github": "GitHub-Repo-Webseite öffnen",
   "feat_repo_chip_github_link_title": "GitHub über einen Repo-Chip öffnen",
-  "feat_repo_chip_github_link_body": "Rechtsklicke oder halte einen GitHub-Repo-Chip gedrückt, um die Repository-Seite direkt aus dem Herdenkopf zu öffnen."
+  "feat_repo_chip_github_link_body": "Rechtsklicke oder halte einen GitHub-Repo-Chip gedrückt, um die Repository-Seite direkt aus dem Herdenkopf zu öffnen.",
+  "heartbeat_pop_intro": "Die Tool-Nutzung des Agents über die letzten 8 Minuten (jede Zelle ≈ 20 s). Eine leere Leiste heißt, die Session ist verstummt.",
+  "heartbeat_legend_active_label": "Aktiv",
+  "heartbeat_legend_active_desc": "Tool-Nutzung in dieser ~20-s-Slice — heller heißt mehr los.",
+  "heartbeat_legend_idle_label": "Leise",
+  "heartbeat_legend_idle_desc": "Keine Aktivität in dieser Slice.",
+  "heartbeat_legend_error_label": "Fehler",
+  "heartbeat_legend_error_desc": "Ein Tool-Aufruf in dieser Slice schlug fehl.",
+  "feat_heartbeat_legend_title": "Aktivitäts-Heartbeat erklärt sich beim Hover",
+  "feat_heartbeat_legend_body": "Die amber Aktivitäts-Leiste auf laufenden Session-Karten öffnet auf dem Desktop jetzt beim Hover eine Legende — damit sichtbar wird, was sie zeigt: die Tool-Nutzung des Agents über die letzten 8 Minuten (heller = mehr los, rot = ein Fehler, leer = ruhig)."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2989,5 +2989,14 @@
   "feat_diff_review_body": "The session Diff tab now renders through a new engine: switch between side-by-side and unified views, with word-level intra-line highlighting, a file sidebar for quick navigation, and collapsible unchanged context.",
   "repo_chip_open_github": "Open GitHub Repo-Webpage",
   "feat_repo_chip_github_link_title": "Open GitHub from a repo chip",
-  "feat_repo_chip_github_link_body": "Right-click or hold a GitHub-backed repo chip and open the repository page directly from the herd header."
+  "feat_repo_chip_github_link_body": "Right-click or hold a GitHub-backed repo chip and open the repository page directly from the herd header.",
+  "heartbeat_pop_intro": "The agent's tool-use over the last 8 minutes (each cell ≈ 20 s). An empty strip means the session has gone quiet.",
+  "heartbeat_legend_active_label": "Active",
+  "heartbeat_legend_active_desc": "Tool-use in that ~20 s slice — brighter means busier.",
+  "heartbeat_legend_idle_label": "Idle",
+  "heartbeat_legend_idle_desc": "No activity in that slice.",
+  "heartbeat_legend_error_label": "Error",
+  "heartbeat_legend_error_desc": "A tool-use in that slice failed.",
+  "feat_heartbeat_legend_title": "Activity heartbeat explains itself on hover",
+  "feat_heartbeat_legend_body": "The amber activity strip on live session cards now opens a legend when you hover it on desktop — so you can see what it tracks: the agent's tool-use over the last 8 minutes (brighter = busier, red = an error, empty = quiet)."
 }

--- a/ui/src/lib/components/HeartbeatStrip.browser.test.ts
+++ b/ui/src/lib/components/HeartbeatStrip.browser.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import "../../app.css";
+import type { SessionActivity } from "$lib/types";
+import { m } from "$lib/paraglide/messages";
+import HeartbeatStrip from "./HeartbeatStrip.svelte";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+// Fixed clock + in-window events so bucketStrip is deterministic (8-min window).
+const NOW = 10_000_000;
+function activity(overrides: Partial<SessionActivity> = {}): SessionActivity {
+  return {
+    lastActivityTs: NOW - 1_000,
+    summary: "edited poller.ts",
+    recentTs: [NOW - 5_000, NOW - 1_000],
+    recentErrTs: [NOW - 5_000], // one slice errored → a red stub cell
+    ...overrides,
+  };
+}
+
+describe("HeartbeatStrip trigger", () => {
+  it("is an activatable button, not a role=img span", () => {
+    render(HeartbeatStrip, { activity: activity(), nowMs: NOW });
+    const strip = document.querySelector("button.strip");
+    expect(strip, "strip is a <button>").not.toBeNull();
+    expect(document.querySelector('[role="img"]'), "no leftover role=img").toBeNull();
+    expect((strip as HTMLButtonElement).disabled, "focusable (not disabled)").toBe(false);
+  });
+
+  it("accessible name discloses that activating opens the session (not only recency)", () => {
+    render(HeartbeatStrip, { activity: activity(), nowMs: NOW });
+    const strip = document.querySelector("button.strip") as HTMLButtonElement;
+    const name = strip.getAttribute("aria-label") ?? "";
+    // Reviewer point 3: mirror the Stepper — the open-session hint must be present so a
+    // keyboard/SR user knows the control opens the session, not just "active X ago".
+    expect(name).toContain(m.stepper_open_hint());
+  });
+
+  it("wires aria-describedby to the role=tooltip encoding legend", () => {
+    render(HeartbeatStrip, { activity: activity(), nowMs: NOW });
+    const strip = document.querySelector("button.strip") as HTMLButtonElement;
+    const describedBy = strip.getAttribute("aria-describedby");
+    expect(describedBy, "aria-describedby set").toBeTruthy();
+    const legend = document.getElementById(describedBy!);
+    expect(legend, "legend element present").not.toBeNull();
+    expect(legend!.getAttribute("role")).toBe("tooltip");
+    expect(legend!.hasAttribute("popover")).toBe(true);
+  });
+
+  it("legend lists the three encoding rows", () => {
+    render(HeartbeatStrip, { activity: activity(), nowMs: NOW });
+    const labels = [...document.querySelectorAll(".legend .lg-label")].map((n) =>
+      n.textContent?.trim(),
+    );
+    expect(labels).toContain(m.heartbeat_legend_active_label());
+    expect(labels).toContain(m.heartbeat_legend_idle_label());
+    expect(labels).toContain(m.heartbeat_legend_error_label());
+  });
+
+  it("still renders an errored slice as a red stub cell in the strip", () => {
+    render(HeartbeatStrip, { activity: activity(), nowMs: NOW });
+    // Scope to the strip so the legend's error swatch isn't what we're matching.
+    const errCell = document.querySelector("button.strip .cell.err");
+    expect(errCell, "strip has an .cell.err stub").not.toBeNull();
+  });
+});

--- a/ui/src/lib/components/HeartbeatStrip.svelte
+++ b/ui/src/lib/components/HeartbeatStrip.svelte
@@ -1,23 +1,122 @@
 <script lang="ts">
   import { formatAgo } from "$lib/format";
   import { bucketStrip } from "$lib/heartbeat";
+  import { anchorPopover } from "$lib/floating-anchor";
   import { m } from "$lib/paraglide/messages";
   import type { SessionActivity } from "$lib/types";
 
-  let { activity, nowMs }: { activity?: SessionActivity; nowMs: number } = $props();
+  let {
+    activity,
+    nowMs,
+    onactivate,
+  }: {
+    activity?: SessionActivity;
+    nowMs: number;
+    // Activating the strip (click / Enter / Space) selects the row — same action as
+    // the card's primary .unit-hit button. Raising the strip above .unit-hit to catch
+    // hover would otherwise leave a dead click zone; forwarding the click keeps
+    // "click anywhere on the card selects it" intact. Optional so the component stays
+    // usable standalone (tests / stories).
+    onactivate?: () => void;
+  } = $props();
 
   // Bucket against nowMs (not the server's push time) so the strip ages/drains live.
   const cells = $derived(bucketStrip(activity?.recentTs ?? [], activity?.recentErrTs ?? [], nowMs));
 
-  // Screen-reader text: reuse the existing recency phrasing; "starting" before the first beat.
+  // Recency phrasing; "starting" before the first beat. Reused as the tail of the
+  // accessible name (not shown in the legend — TimePopover already carries recency).
   const label = $derived(
     activity && activity.lastActivityTs > 0
       ? m.activity_active({ ago: formatAgo(nowMs - activity.lastActivityTs) })
       : m.activity_starting(),
   );
+  // The strip activates (selects the session), so its accessible name discloses that
+  // — mirrors the Stepper's openLabel so a keyboard/SR user isn't told only the
+  // recency and left guessing that the control opens the session.
+  const openLabel = $derived(`${m.stepper_open_hint()} · ${label}`);
+
+  // --- Encoding legend (native top-layer popover; desktop hover/focus only) ---
+  // Same recipe as the Stepper stage legend: native popover="manual" placed with
+  // Floating UI so it escapes the card's overflow clipping.
+  const popId = $props.id();
+  let open = $state(false);
+  let stripEl = $state<HTMLButtonElement | null>(null);
+  let popEl = $state<HTMLElement | null>(null);
+
+  const isCoarse = () =>
+    typeof window !== "undefined" && window.matchMedia("(pointer: coarse)").matches;
+
+  // Fine pointer: hover opens. Touch pointerenter is skipped so a tap just selects
+  // the row (no tap-toggle) rather than popping a desktop tooltip.
+  function onEnter(e: PointerEvent) {
+    if (e.pointerType !== "touch") open = true;
+  }
+  // Focus opens on fine pointers only (a touch tap also focuses the button).
+  function onOpen() {
+    if (!isCoarse()) open = true;
+  }
+  function onClose() {
+    open = false;
+  }
+
+  // Position the popover above the strip whenever open + both elements exist.
+  $effect(() => {
+    if (!open || !stripEl || !popEl) return;
+    try {
+      popEl.showPopover();
+    } catch {
+      return; // not connected this tick — effect re-runs once popEl mounts
+    }
+    return anchorPopover(stripEl, popEl, 6, "top");
+  });
+
+  // Dismiss on Esc, outside pointerdown, and scroll/resize (mirrors Stepper/InfoTip).
+  $effect(() => {
+    if (!open) return;
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key === "Escape") open = false;
+    }
+    function onPointerdown(e: PointerEvent) {
+      if (
+        popEl &&
+        !popEl.contains(e.target as Node) &&
+        stripEl &&
+        !stripEl.contains(e.target as Node)
+      ) {
+        open = false;
+      }
+    }
+    function onScrollOrResize() {
+      open = false;
+    }
+    window.addEventListener("keydown", onKeydown);
+    window.addEventListener("pointerdown", onPointerdown);
+    window.addEventListener("scroll", onScrollOrResize, { capture: true, passive: true });
+    window.addEventListener("resize", onScrollOrResize, { passive: true });
+    return () => {
+      window.removeEventListener("keydown", onKeydown);
+      window.removeEventListener("pointerdown", onPointerdown);
+      window.removeEventListener("scroll", onScrollOrResize, { capture: true });
+      window.removeEventListener("resize", onScrollOrResize);
+    };
+  });
 </script>
 
-<span class="strip" role="img" aria-label={label}>
+<!-- A real <button> (not a role=img span): hover/focus reveals the legend,
+     click/Enter/Space selects the row. Raised above the .unit-hit overlay so it
+     actually receives the pointer/focus. -->
+<button
+  type="button"
+  class="strip"
+  aria-label={openLabel}
+  aria-describedby={popId}
+  bind:this={stripEl}
+  onpointerenter={onEnter}
+  onpointerleave={onClose}
+  onfocus={onOpen}
+  onblur={onClose}
+  onclick={() => onactivate?.()}
+>
   {#each cells as cell, i (i)}
     <span
       class="cell"
@@ -27,14 +126,49 @@
       aria-hidden="true"
     ></span>
   {/each}
+</button>
+<!-- role=tooltip so aria-describedby surfaces the legend to screen readers.
+     popover=manual: native top-layer, escapes the card's overflow:hidden. A <span>
+     (phrasing) so it stays valid wherever the strip is embedded; every child is a span. -->
+<span id={popId} bind:this={popEl} class="legend" role="tooltip" popover="manual">
+  <span class="lg-intro">{m.heartbeat_pop_intro()}</span>
+  <span class="lg-row">
+    <span class="sw"><span class="cell" data-level="4" aria-hidden="true"></span></span>
+    <span class="lg-text">
+      <span class="lg-label">{m.heartbeat_legend_active_label()}</span>
+      <span class="lg-desc">{m.heartbeat_legend_active_desc()}</span>
+    </span>
+  </span>
+  <span class="lg-row">
+    <span class="sw idle"><span class="cell" data-level="0" aria-hidden="true"></span></span>
+    <span class="lg-text">
+      <span class="lg-label">{m.heartbeat_legend_idle_label()}</span>
+      <span class="lg-desc">{m.heartbeat_legend_idle_desc()}</span>
+    </span>
+  </span>
+  <span class="lg-row">
+    <span class="sw"><span class="cell err" aria-hidden="true"></span></span>
+    <span class="lg-text">
+      <span class="lg-label">{m.heartbeat_legend_error_label()}</span>
+      <span class="lg-desc">{m.heartbeat_legend_error_desc()}</span>
+    </span>
+  </span>
 </span>
 
 <style>
   /* 24 equal cells; amber (--status-running) for live/recent signal (level ≥ 2
      and .now); low-activity cells (level 0–1) render neutral faint ink so idle
      strips read grey, not orange — amber is reserved for genuine "alive" signal.
-     No motion — StatusPip already pulses (matches prior Heartbeat.svelte decision). */
+     No motion — StatusPip already pulses (matches prior Heartbeat.svelte decision).
+
+     Now a <button>: button reset (mirrors the Stepper's .stepper) plus the raise
+     above .unit-hit (z-index:1) so hover/focus land on the strip. Deliberately NO
+     ::before hit-halo: the strip is already a full-width, 12px-tall target, and it
+     sits one 3px-gap row below .hold-cta (downward halo) and above the Stepper
+     (upward halo) — a vertical bleed would poach their hit zones. */
   .strip {
+    position: relative;
+    z-index: 1;
     display: inline-flex;
     align-items: stretch;
     gap: 1px;
@@ -42,6 +176,18 @@
     max-width: 40vw;
     height: 12px;
     flex: none;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: none;
+    color: inherit;
+    font: inherit;
+    cursor: help;
+  }
+  .strip:focus-visible {
+    outline: 2px solid var(--color-line-bright);
+    outline-offset: 2px;
+    border-radius: 2px;
   }
   .cell {
     flex: 1 1 0;
@@ -86,5 +232,69 @@
     opacity: 0.85;
     align-self: flex-end;
     height: 55%;
+  }
+
+  /* Top-layer legend positioning: fixed + inset:auto + margin:0 lets Floating UI
+     drive left/top without fighting browser default centering. Mirrors the
+     Stepper stage-legend recipe. */
+  [popover].legend {
+    position: fixed;
+    inset: auto;
+    margin: 0;
+    z-index: 30;
+    width: min(300px, 92vw);
+    gap: 6px;
+    padding: 6px 8px;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    box-shadow: var(--shadow-popover);
+    font-size: var(--fs-meta);
+    line-height: 1.4;
+    text-align: left;
+  }
+  [popover].legend:popover-open {
+    display: flex;
+    flex-direction: column;
+  }
+  .lg-intro {
+    color: var(--color-muted);
+  }
+  .lg-row {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: start;
+    gap: 8px;
+  }
+  .lg-text {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  }
+  .lg-label {
+    color: var(--color-ink);
+  }
+  .lg-desc {
+    font-size: var(--fs-micro);
+    color: var(--color-faint);
+    line-height: 1.35;
+  }
+  /* Legend swatch: reconstruct the strip's flex/height context around a single
+     .cell so .cell.err (align-self:flex-end; height:55%) shows its stub and the
+     faint idle cell renders exactly as on the strip — no separate swatch styling
+     that could drift from the real encoding. Nudged down to align with the label. */
+  .sw {
+    display: inline-flex;
+    align-items: stretch;
+    height: 12px;
+    width: 14px;
+    margin-top: 2px;
+    flex: none;
+  }
+  /* The idle cell is intentionally near-invisible (opacity 0.12); give its swatch a
+     hairline track so "Idle" is still legible as an empty slot in the legend. */
+  .sw.idle {
+    box-shadow: inset 0 0 0 1px var(--color-line);
+    border-radius: 1px;
   }
 </style>

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -761,7 +761,7 @@
 
     {#if live}
       <div class="u-activity">
-        <HeartbeatStrip {activity} {nowMs} />
+        <HeartbeatStrip {activity} {nowMs} onactivate={() => onselect(session.id)} />
       </div>
     {/if}
 

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-heartbeat-legend.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-heartbeat-legend.ts
@@ -1,0 +1,13 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // No targetId: the heartbeat strip appears once per live session card in a dense
+  // list — many strips can be in the DOM at once, and coachTargets key one node per
+  // id, so a duplicated targetId anchor would be wrong. Surface via What's-New only.
+  id: "heartbeat-legend",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_heartbeat_legend_title",
+  bodyKey: "feat_heartbeat_legend_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## 🎯 Problem

A teammate looked at the **amber activity strip** on a live session card and asked in chat:

> *„Sagt ma… was genau zeigt diese fancy Leiste eigentlich an?"*

The strip carried only a screen-reader `aria-label`, so a sighted mouse user got **nothing** on hover and had to ask a human what it meant. **Goal:** let the strip answer that question in place — on hover.

## ✨ Solution

Hovering (or keyboard-focusing) the strip now opens a small **legend popover** that decodes it:

- **What it is** — the agent's tool-use over the last **8 minutes** (each cell ≈ 20 s); an empty strip means the session has gone quiet.
- **Colour key** — **Active** (amber, brighter = busier) · **Idle** (faint) · **Error** (red stub).

The swatches in the legend are rendered from the *same* cells as the bar, so the key can never drift from what it explains. On touch, a tap still just selects the row (the legend is a desktop hover/focus affordance); mobile users meet it through the What's-New drawer.

## 🔧 Technical details

- **Mirrors the shipped Stepper stage-legend** — native `popover="manual"` placed with Floating UI (`anchorPopover`), so it escapes the card's `overflow:hidden`.
- The strip becomes a real `<button>` raised above the `.unit-hit` overlay so it receives hover; **click forwards to row-select** (no dead click zone), and its accessible name now discloses that it opens the session.
- **No hit-halo** (unlike the Stepper's 3px lamps): the full-width 12px strip sits one 3px-gap row below `.hold-cta` (downward halo) and above the Stepper (upward halo), so a vertical bleed would poach their hit zones.
- Legend swatches reconstruct the strip's flex/height context so `.cell.err` shows its stub and the faint idle cell renders faithfully.
- Kept strictly to **cell encoding** — recency ("active X ago") stays with the existing clock `TimePopover`, so the two hover popovers on a running card don't overlap in content.

### Files
| File | Change |
|------|--------|
| `HeartbeatStrip.svelte` | button trigger + encoding-legend popover |
| `UnitRow.svelte` | pass `onactivate` → row select |
| `messages/en.json` · `de.json` | 7 `heartbeat_*` keys + 2 `feat_heartbeat_legend_*` keys |
| `feature-announcements/entries/v1.44.0-heartbeat-legend.ts` | What's-New entry |
| `HeartbeatStrip.browser.test.ts` | new — asserts the button/aria/legend/error contract |

### Testing
- `bun run check` — 0 errors / 0 warnings
- `bun run check:i18n` — 2 locales in parity (2996 keys)
- `HeartbeatStrip.browser.test.ts` 5/5 · `UnitRow.browser.test.ts` 55/55 (regression)
- branch-hygiene · feature-catalog · announcement-versions (1.44.0 > released 1.43.0) · glossary — all ✓