### PR TITLE
fix(ui): align mobile git rail button heights

### DIFF
--- a/ui/src/lib/components/GitRail.browser.test.ts
+++ b/ui/src/lib/components/GitRail.browser.test.ts
@@ -143,6 +143,21 @@ function assertControlsWithin(cell: HTMLElement) {
     // overflow, so nothing paints left of the cell's origin.
     const cellRect = cell.getBoundingClientRect();
     expect(getComputedStyle(rail!).overflowX, "mobile rail scrolls horizontally").toBe("auto");
+    const expectedTouchHeight = Number.parseFloat(
+      getComputedStyle(document.documentElement).getPropertyValue("--mobile-actionbar-hit"),
+    );
+    const touchButtons = rail!.querySelectorAll<HTMLElement>(
+      "button.gbtn, button.verdict-chip, button.ready-toggle",
+    );
+    expect(expectedTouchHeight, "mobile actionbar height token").toBeGreaterThan(0);
+    expect(touchButtons.length, "mobile rail has touch buttons").toBeGreaterThan(0);
+    for (const button of touchButtons) {
+      const label =
+        button.getAttribute("aria-label") || button.textContent?.trim() || button.className;
+      expect(button.getBoundingClientRect().height, `${label} uses mobile touch height`).toBe(
+        expectedTouchHeight,
+      );
+    }
     const tallest = Math.max(...[...controls].map((c) => c.getBoundingClientRect().height));
     const railH = rail!.getBoundingClientRect().height;
     expect(railH, "rail stays a single row (no vertical stacking)").toBeLessThanOrEqual(
@@ -233,6 +248,41 @@ describe("GitRail — controls stay within the cell", () => {
     const screen = await render(GitRail, { target: h, props: { ...baseProps, mobile: true } });
     await expect.element(screen.getByTitle("PR #12345")).toBeVisible();
     assertControlsWithin(h);
+  });
+
+  it("mobile rail buttons share the actionbar touch height with a verdict present", async () => {
+    const sessionId = "touch-height";
+    const verdict: ReviewVerdict = {
+      sessionId,
+      headSha: "deadbeef",
+      decision: "commented",
+      summary: "Ready to merge.",
+      body: "No findings.",
+      findings: [],
+      addressRound: 0,
+      addressCap: 2,
+      finalRoundPending: false,
+      finalRoundTimeoutMs: 900000,
+      updatedAt: Date.now(),
+    };
+    reviews.apply({ id: sessionId, review: verdict });
+
+    try {
+      gitStateFn.mockResolvedValue(openPrState);
+      await page.viewport(400, 900);
+      const h = host(360);
+      const screen = await render(GitRail, {
+        target: h,
+        props: { ...baseProps, sessionId, mobile: true },
+      });
+      await expect.element(screen.getByTitle("PR #12345")).toBeVisible();
+      await vi.waitFor(() =>
+        expect(h.querySelector("button.verdict-chip"), "verdict button present").not.toBeNull(),
+      );
+      assertControlsWithin(h);
+    } finally {
+      reviews.drop(sessionId);
+    }
   });
 
   // ── none state ────────────────────────────────────────────────────────────

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -1004,7 +1004,7 @@
     margin-left: auto;
   }
   .rail.mobile :global(.gbtn) {
-    min-height: 40px;
+    min-height: var(--mobile-actionbar-hit);
     padding: 6px 9px;
     font-size: var(--fs-base);
   }
@@ -1013,12 +1013,12 @@
      rendered at ~half height (23px) in muted text, indistinguishable from the
      passive list badge. On touch (no hover affordance) the happy "✓ REVIEWED"
      chip then read as a status label, not a button, so findings were effectively
-     unreachable on mobile/fold. Match it to the sibling controls: a real ≥40px
+     unreachable on mobile/fold. Match it to the sibling controls: a full-height
      tap target that obviously invites a tap. Scoped to button.verdict-chip so the
      non-interactive reviewing <span> (no prior findings) isn't blown up into a
-     40px button-looking element that does nothing on tap. */
+     full-height button-looking element that does nothing on tap. */
   .rail.mobile :global(button.verdict-chip) {
-    min-height: 40px;
+    min-height: var(--mobile-actionbar-hit);
     padding: 6px 9px;
     font-size: var(--fs-base);
     display: inline-flex;

--- a/ui/src/lib/components/ReadyToggle.svelte
+++ b/ui/src/lib/components/ReadyToggle.svelte
@@ -14,7 +14,7 @@
   }: {
     sessionId: string;
     ready?: boolean;
-    // touch layout: enlargement so the toggle matches the ≥40px
+    // touch layout: enlarge to --mobile-actionbar-hit so the toggle matches its
     // .gbtn / .verdict-chip siblings instead of rendering half-height next to them.
     mobile?: boolean;
   } = $props();
@@ -53,12 +53,12 @@
     border-color: var(--color-amber);
     color: var(--color-amber);
   }
-  /* touch rail: match the ≥40px .gbtn / button.verdict-chip siblings so the
+  /* touch rail: match the full-height .gbtn / button.verdict-chip siblings so the
      toggle isn't a half-height odd-one-out beside the Reviewed chip */
   .ready-toggle.mobile {
     display: inline-flex;
     align-items: center;
-    min-height: 40px;
+    min-height: var(--mobile-actionbar-hit);
     padding: 6px 14px;
     font-size: var(--fs-base);
   }

--- a/ui/src/lib/components/Viewport.browser.test.ts
+++ b/ui/src/lib/components/Viewport.browser.test.ts
@@ -1048,6 +1048,18 @@ describe("Viewport mobile page-swipe scoping", () => {
     }
   });
 
+  it("uses the shared actionbar touch height for the autopilot toggle", async () => {
+    const { container } = await renderMobile(vi.fn());
+    const toggle = container.querySelector<HTMLElement>(".strip-controls .ap-toggle");
+    expect(toggle, "autopilot toggle should render").not.toBeNull();
+    const expectedTouchHeight = getComputedStyle(document.documentElement)
+      .getPropertyValue("--mobile-actionbar-hit")
+      .trim();
+
+    expect(expectedTouchHeight, "mobile actionbar height token").not.toBe("");
+    expect(getComputedStyle(toggle!).minHeight).toBe(expectedTouchHeight);
+  });
+
   it("does NOT page when a drag starts on a [data-swipe-ignore] surface inside the body", async () => {
     const onnavigate = vi.fn();
     const { container } = await renderMobile(onnavigate);

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -3815,10 +3815,10 @@
     padding-left: 8px;
     border-left: 1px solid var(--color-line);
   }
-  /* the strip's GitRail always renders its ≥44px touch variant — match it so the
+  /* the strip's GitRail uses the shared actionbar touch height — match it so the
      cluster doesn't sit half-height beside the rail buttons */
   .strip-controls .ap-toggle {
-    min-height: 44px;
+    min-height: var(--mobile-actionbar-hit);
     padding: 6px 9px;
   }
 


### PR DESCRIPTION
## Summary

- use the shared `--mobile-actionbar-hit` token for compact GitRail action buttons, verdict buttons, Ready, and Autopilot
- keep passive and linked PR/issue status chips compact
- add browser regressions for the verdict-present rail and AP-to-rail token parity

## Root cause

The compact GitRail buttons and Ready toggle used a 40px minimum height, while the adjacent Autopilot toggle already rendered at the design system's 44px mobile actionbar height. That produced the uneven action row shown on touch layouts.

## Validation

- `cd ui && bun run check` (0 errors, 0 warnings)
- `cd ui && bun run test` (238 files, 3506 tests passed)
- `cd ui && bun run test:browser src/lib/components/GitRail.browser.test.ts src/lib/components/Viewport.browser.test.ts` (127 tests passed before rebase; included in the full post-rebase suite)
- `scripts/check-branch-hygiene.sh`

The repository table's raw `cd ui && bun test` command was also attempted. Bun's native runner loads `*.browser.test.ts` without a browser environment and fails on pre-existing `document`/`$state` references; the package-defined Vitest suite above is green.
