### PR TITLE
feat: add Codex skill discovery

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -19,7 +19,7 @@ export interface SlashCommand {
   displayName: string;
   description: string;
   scope: SlashCommandScope;
-  kind: "skill" | "command";
+  kind: "skill" | "command" | "plugin";
   invocationName: string;
   sourceNamespace: string;
   sourcePath?: string;
@@ -211,6 +211,7 @@ function readCodexSkill(
   path: string,
   sourceNamespace: string,
   disabled: Set<string>,
+  prefix = "",
 ): SlashCommand | null {
   if (isDisabledSkill(path, disabled)) return null;
   let text: string;
@@ -220,8 +221,9 @@ function readCodexSkill(
     return null;
   }
   const { fm } = parseFrontmatter(text);
-  const name = fm.name?.trim();
-  if (!name) return null;
+  const bare = fm.name?.trim();
+  if (!bare) return null;
+  const name = prefix + bare;
   let description = fm.description?.trim() || "";
   if (description.length > MAX_DESC)
     description = description.slice(0, MAX_DESC - 1).trimEnd() + "…";
@@ -230,7 +232,11 @@ function readCodexSkill(
     name,
     displayName: name,
     description,
-    scope: sourceNamespace.startsWith("codex:repo") ? "project" : "user",
+    scope: sourceNamespace.startsWith("codex:repo")
+      ? "project"
+      : sourceNamespace.startsWith("codex:plugin")
+        ? "plugin"
+        : "user",
     kind: "skill",
     invocationName: name,
     sourceNamespace,
@@ -245,12 +251,116 @@ function collectCodexSkillRoot(
   sourceNamespace: string,
   disabled: Set<string>,
   out: SlashCommand[],
+  prefix = "",
 ) {
   for (const entry of safeReaddir(root)) {
     const md = join(root, entry, "SKILL.md");
     if (!existsSync(md)) continue;
-    const cmd = readCodexSkill(md, sourceNamespace, disabled);
+    const cmd = readCodexSkill(md, sourceNamespace, disabled, prefix);
     if (cmd) out.push(cmd);
+  }
+}
+
+interface CodexPluginManifest {
+  name?: string;
+  version?: string;
+  description?: string;
+  skills?: string;
+  interface?: {
+    displayName?: string;
+    shortDescription?: string;
+  };
+}
+
+function readJson(path: string): unknown | null {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function pluginVersionRoot(pluginRoot: string): string | null {
+  const versions = safeReaddir(pluginRoot)
+    .map((entry) => join(pluginRoot, entry))
+    .filter((dir) => {
+      try {
+        return statSync(dir).isDirectory() && existsSync(join(dir, ".codex-plugin", "plugin.json"));
+      } catch {
+        return false;
+      }
+    })
+    .sort((a, b) => a.localeCompare(b));
+  return versions.at(-1) ?? null;
+}
+
+function codexPluginDescription(manifest: CodexPluginManifest | null, fallback: string): string {
+  const description =
+    manifest?.interface?.shortDescription?.trim() || manifest?.description?.trim() || fallback;
+  return description.length > MAX_DESC
+    ? description.slice(0, MAX_DESC - 1).trimEnd() + "…"
+    : description;
+}
+
+function codexPluginSkillsDir(
+  versionRoot: string,
+  manifest: CodexPluginManifest | null,
+): string | null {
+  if (typeof manifest?.skills !== "string") return null;
+  return join(versionRoot, manifest.skills.replace(/^\.\//, ""));
+}
+
+function collectCodexPlugin(
+  pluginRoot: string,
+  pluginEntry: string,
+  marketplace: string,
+  disabled: Set<string>,
+  out: SlashCommand[],
+) {
+  if (!existsSync(join(pluginRoot, ".codex-remote-plugin-install.json"))) return;
+  const versionRoot = pluginVersionRoot(pluginRoot);
+  if (!versionRoot) return;
+  const manifest = readJson(
+    join(versionRoot, ".codex-plugin", "plugin.json"),
+  ) as CodexPluginManifest | null;
+  const pluginName = manifest?.name?.trim() || pluginEntry;
+  out.push({
+    id: `codex:plugin:${marketplace}:${pluginName}`,
+    name: pluginName,
+    displayName: pluginName,
+    description: codexPluginDescription(manifest, pluginName),
+    scope: "plugin",
+    kind: "plugin",
+    invocationName: pluginName,
+    sourceNamespace: `codex:plugin:${marketplace}:${pluginName}`,
+    sourcePath: versionRoot,
+    providers: ["codex"],
+    invocations: {},
+  });
+  const skillsDir = codexPluginSkillsDir(versionRoot, manifest);
+  if (!skillsDir) return;
+  collectCodexSkillRoot(
+    skillsDir,
+    `codex:plugin:${marketplace}:${pluginName}`,
+    disabled,
+    out,
+    `${pluginName}:`,
+  );
+}
+
+function collectCodexPlugins(codexHome: string, disabled: Set<string>, out: SlashCommand[]) {
+  const cacheDir = join(codexHome, "plugins", "cache");
+  for (const marketplace of safeReaddir(cacheDir)) {
+    const marketplaceDir = join(cacheDir, marketplace);
+    for (const pluginEntry of safeReaddir(marketplaceDir)) {
+      collectCodexPlugin(
+        join(marketplaceDir, pluginEntry),
+        pluginEntry,
+        marketplace,
+        disabled,
+        out,
+      );
+    }
   }
 }
 
@@ -333,33 +443,38 @@ function collectPlugins(
 export function listCommands(
   repoDir: string | null,
   userClaudeDir: string,
-  opts: { userHome?: string; codexHome?: string } = {},
+  opts: { userHome?: string; codexHome?: string; provider?: AgentProvider } = {},
 ): SlashCommand[] {
   const out = new Map<string, SlashCommand>();
-  for (const b of BUILTINS)
-    out.set(b.name, {
-      id: `claude:builtin:${b.name}`,
-      name: b.name,
-      displayName: b.name,
-      description: b.description,
-      scope: "builtin",
-      kind: "command",
-      invocationName: b.name,
-      sourceNamespace: "claude:builtin",
-      providers: ["claude"],
-      invocations: { claude: `/${b.name}` },
-    });
-  collectPlugins(userClaudeDir, repoDir, out);
-  collect(userClaudeDir, "user", out);
-  if (repoDir) collect(join(repoDir, ".claude"), "project", out);
+  if (opts.provider !== "codex") {
+    for (const b of BUILTINS)
+      out.set(b.name, {
+        id: `claude:builtin:${b.name}`,
+        name: b.name,
+        displayName: b.name,
+        description: b.description,
+        scope: "builtin",
+        kind: "command",
+        invocationName: b.name,
+        sourceNamespace: "claude:builtin",
+        providers: ["claude"],
+        invocations: { claude: `/${b.name}` },
+      });
+    collectPlugins(userClaudeDir, repoDir, out);
+    collect(userClaudeDir, "user", out);
+    if (repoDir) collect(join(repoDir, ".claude"), "project", out);
+  }
   const rows = [...out.values()];
-  const codexHome = opts.codexHome ?? codexHomeDefault();
-  const userHome = opts.userHome ?? homedir();
-  const disabled = disabledSkillPaths(codexHome);
-  if (repoDir)
-    collectCodexSkillRoot(join(repoDir, ".agents", "skills"), "codex:repo", disabled, rows);
-  collectCodexSkillRoot(join(userHome, ".agents", "skills"), "codex:user", disabled, rows);
-  collectCodexSkillRoot(join(codexHome, "skills", ".system"), "codex:system", disabled, rows);
-  collectCodexSkillRoot("/etc/codex/skills", "codex:admin", disabled, rows);
+  if (opts.provider !== "claude") {
+    const codexHome = opts.codexHome ?? codexHomeDefault();
+    const userHome = opts.userHome ?? homedir();
+    const disabled = disabledSkillPaths(codexHome);
+    if (repoDir)
+      collectCodexSkillRoot(join(repoDir, ".agents", "skills"), "codex:repo", disabled, rows);
+    collectCodexSkillRoot(join(userHome, ".agents", "skills"), "codex:user", disabled, rows);
+    collectCodexSkillRoot(join(codexHome, "skills", ".system"), "codex:system", disabled, rows);
+    collectCodexSkillRoot("/etc/codex/skills", "codex:admin", disabled, rows);
+    collectCodexPlugins(codexHome, disabled, rows);
+  }
   return mergeEquivalentRows(rows).sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -77,6 +77,7 @@ import {
 import { resolveDefaultBranch, fastForwardDefaultBranch } from "./pull";
 import { analyzeReadiness } from "./readiness";
 import { listCommands } from "./commands";
+import { codexHome } from "./codex-usage";
 import { listDirs, validateRoot, collapseHome } from "./dirs";
 import { scratchpadHasFiles } from "./tmp-sweep";
 import {
@@ -5880,7 +5881,16 @@ function handleCommands({ req, parts, url }: Ctx): Response | null {
   if (req.method === "GET" && parts[0] === "api" && parts[1] === "commands" && !parts[2]) {
     // invalid/absent repo → null dir → user-scope commands only (still useful)
     const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
-    return json({ commands: listCommands(dir, join(homedir(), ".claude")) });
+    const provider = url.searchParams.get("provider") ?? "claude";
+    if (provider === "claude" || provider === "codex")
+      return json({
+        commands: listCommands(dir, join(homedir(), ".claude"), {
+          provider,
+          userHome: homedir(),
+          codexHome: codexHome(),
+        }),
+      });
+    return json({ error: "invalid provider" }, 400);
   }
   return null;
 }

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -19,6 +19,14 @@ function command(claudeDir: string, file: string, body: string) {
   writeFileSync(join(claudeDir, "commands", file), body);
 }
 
+function codexSkill(skillsDir: string, dir: string, name: string, description: string) {
+  mkdirSync(join(skillsDir, dir), { recursive: true });
+  writeFileSync(
+    join(skillsDir, dir, "SKILL.md"),
+    `---\nname: ${name}\ndescription: ${description}\n---\nbody`,
+  );
+}
+
 beforeEach(() => {
   userClaude = mkdtempSync(join(tmpdir(), "shepherd-cmds-user-"));
   repo = mkdtempSync(join(tmpdir(), "shepherd-cmds-repo-"));
@@ -158,6 +166,54 @@ test("installed plugins are scanned, namespaced, and re-rooted from a foreign in
   const cmds = commands(null, userClaude);
   expect(cmds.find((c) => c.name === "myplugin:deploy")?.scope).toBe("plugin");
   expect(cmds.find((c) => c.name === "myplugin:scan")?.scope).toBe("plugin");
+});
+
+test("provider option scans only Codex skill roots", () => {
+  codexSkill(join(userHome, ".agents", "skills"), "shared", "shared", "home shared");
+  codexSkill(join(repo, ".agents", "skills"), "repo", "repo-only", "repo skill");
+
+  const cmds = listCommands(repo, userClaude, { userHome, codexHome, provider: "codex" });
+
+  expect(cmds.map((c) => c.name)).toEqual(["repo-only", "shared"]);
+  expect(cmds.every((c) => c.providers.includes("codex"))).toBe(true);
+  expect(cmds.find((c) => c.name === "repo-only")).toMatchObject({
+    scope: "project",
+    kind: "skill",
+    invocations: { codex: "$repo-only" },
+  });
+});
+
+test("Codex installed plugin cache exposes browsing inventory and namespaced skills", () => {
+  const pluginRoot = join(codexHome, "plugins", "cache", "mkt", "github");
+  const versionRoot = join(pluginRoot, "1.0.0");
+  mkdirSync(join(versionRoot, ".codex-plugin"), { recursive: true });
+  writeFileSync(join(pluginRoot, ".codex-remote-plugin-install.json"), '{"schema_version":1}');
+  writeFileSync(
+    join(versionRoot, ".codex-plugin", "plugin.json"),
+    JSON.stringify({
+      name: "github",
+      description: "GitHub plugin",
+      skills: "./skills/",
+      interface: { shortDescription: "GitHub workflows" },
+    }),
+  );
+  codexSkill(join(versionRoot, "skills"), "yeet", "yeet", "Publish changes");
+
+  const cmds = listCommands(null, userClaude, { userHome, codexHome, provider: "codex" });
+
+  expect(cmds.find((c) => c.name === "github")).toMatchObject({
+    description: "GitHub workflows",
+    scope: "plugin",
+    kind: "plugin",
+    providers: ["codex"],
+    invocations: {},
+  });
+  expect(cmds.find((c) => c.name === "github:yeet")).toMatchObject({
+    description: "Publish changes",
+    scope: "plugin",
+    kind: "skill",
+    invocations: { codex: "$github:yeet" },
+  });
 });
 
 test("over-long description is truncated with an ellipsis", () => {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -93,6 +93,14 @@ test("GET /api/usage/limits returns limits + projections", async () => {
   });
 });
 
+test("GET /api/commands rejects invalid provider", async () => {
+  const res = await harness().fetch(
+    new Request(`http://x/api/commands?repo=${encodeURIComponent(validRepo)}&provider=mixed`),
+  );
+  expect(res.status).toBe(400);
+  expect(await res.json()).toEqual({ error: "invalid provider" });
+});
+
 test("POST /api/usage/refresh calls refreshUsage and returns its fresh limits", async () => {
   const fresh = {
     session5h: { pct: 80, resetAt: 123 },

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3076,5 +3076,16 @@
   "feat_review_block_cues_title": "Review-Blocker sind auf Session-Karten sichtbar",
   "feat_review_block_cues_body": "Wenn der konfigurierte menschliche Reviewer Änderungen anfordert, zeigen Session-Karte und Herd-Gruppen jetzt Änderungen angefordert, statt still auf diesen Reviewer zu warten.",
   "epic_group_cue_changes_requested": "{count} mit angeforderten Änderungen",
-  "epic_group_cue_merge_blocked": "{count} Merge blockiert"
+  "epic_group_cue_merge_blocked": "{count} Merge blockiert",
+  "command_kind_command": "Befehl",
+  "command_kind_skill": "Skill",
+  "command_kind_plugin": "Plugin",
+  "command_scope_project": "Projekt",
+  "command_scope_user": "User",
+  "command_scope_plugin": "Plugin",
+  "command_scope_builtin": "Eingebaut",
+  "command_source_codex_home": "Codex-Home",
+  "command_source_system": "System",
+  "feat_codex_discovery_title": "Codex-Skills in der Command-Discovery",
+  "feat_codex_discovery_body": "Der Prompt-Picker versteht jetzt Codex-Skills, einschließlich installierter Plugin-Skills wie $github:yeet, während installierte Codex-Plugins als Browsing-Inventar erscheinen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3076,5 +3076,16 @@
   "feat_review_block_cues_title": "Review blocks are visible on session cards",
   "feat_review_block_cues_body": "When the configured human reviewer requests changes, the session card and herd groups now show Changes requested instead of quietly waiting on that reviewer.",
   "epic_group_cue_changes_requested": "{count} with requested changes",
-  "epic_group_cue_merge_blocked": "{count} merge blocked"
+  "epic_group_cue_merge_blocked": "{count} merge blocked",
+  "command_kind_command": "Command",
+  "command_kind_skill": "Skill",
+  "command_kind_plugin": "Plugin",
+  "command_scope_project": "Project",
+  "command_scope_user": "User",
+  "command_scope_plugin": "Plugin",
+  "command_scope_builtin": "Built-in",
+  "command_source_codex_home": "Codex home",
+  "command_source_system": "System",
+  "feat_codex_discovery_title": "Codex skills in command discovery",
+  "feat_codex_discovery_body": "The prompt picker now understands Codex skills, including installed plugin skills such as $github:yeet, while installed Codex plugins appear as a browsing-only inventory."
 }

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getCommands } from "./api";
+
+vi.mock("$lib/auth.svelte", () => ({
+  auth: { unauthenticated: false, checked: false },
+}));
+
+describe("getCommands", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("serializes repo and optional provider", async () => {
+    const fetchMock = vi.fn(async () => Response.json({ commands: [] }));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await getCommands("/repo path", { provider: "codex" });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/commands?repo=%2Frepo+path&provider=codex");
+  });
+
+  it("preserves the legacy no-provider command URL", async () => {
+    const fetchMock = vi.fn(async () => Response.json({ commands: [] }));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await getCommands("/repo path");
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/commands?repo=%2Frepo+path");
+  });
+});

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1144,9 +1144,13 @@ export async function cancelWorkflowRun(repoPath: string, runId: number): Promis
 }
 
 /** Installed slash commands (skills + command files) for the New Task picker. */
-export async function getCommands(repoPath: string): Promise<{ commands: SlashCommand[] }> {
+export async function getCommands(
+  repoPath: string,
+  opts: { provider?: AgentProvider } = {},
+): Promise<{ commands: SlashCommand[] }> {
   const params = new URLSearchParams();
   if (repoPath) params.set("repo", repoPath);
+  if (opts.provider) params.set("provider", opts.provider);
   const qs = params.toString();
   const r = await fetch(`/api/commands${qs ? `?${qs}` : ""}`);
   if (!r.ok) throw await failed(r, "commands");

--- a/ui/src/lib/components/ComposeBar.svelte
+++ b/ui/src/lib/components/ComposeBar.svelte
@@ -54,8 +54,11 @@
   let slashQuery = $state("");
   let slashTrigger = $state<"/" | "$" | "@">("/");
   let slashIndex = $state(0);
+  const commandProvider = $derived(
+    slashOpen ? (slashTrigger === "/" ? "claude" : "codex") : agentProvider,
+  );
   const slashMatches = $derived(
-    slashOpen ? filterCommands(allCommands, slashQuery, agentProvider) : [],
+    slashOpen ? filterCommands(allCommands, slashQuery, commandProvider) : [],
   );
 
   // Steer chips ignore inSteerBar by design (every steer shows here), but still
@@ -69,16 +72,17 @@
   // .claude/commands + .claude/skills layer on top of the global/user ones).
   $effect(() => {
     const rp = repoPath;
+    const provider = commandProvider;
     if (!rp) {
       allCommands = [];
       return;
     }
-    getCommands(rp)
+    getCommands(rp, { provider })
       .then((r) => {
-        if (rp === repoPath) allCommands = r.commands;
+        if (rp === repoPath && provider === commandProvider) allCommands = r.commands;
       })
       .catch(() => {
-        if (rp === repoPath) allCommands = [];
+        if (rp === repoPath && provider === commandProvider) allCommands = [];
       });
   });
 
@@ -342,7 +346,7 @@
         <SlashCommandMenu
           commands={slashMatches}
           activeIndex={slashIndex}
-          provider={agentProvider === "codex" || slashTrigger !== "/" ? "codex" : "claude"}
+          provider={commandProvider}
           placement="up"
           onpick={pickCommand}
           onhover={(i) => (slashIndex = i)}

--- a/ui/src/lib/components/NewProject.svelte
+++ b/ui/src/lib/components/NewProject.svelte
@@ -3,6 +3,7 @@
   import type { RepoEntry } from "$lib/types";
   import { dialog } from "$lib/a11yDialog";
   import { m } from "$lib/paraglide/messages";
+  import { commandInsertable, commandProviders } from "$lib/slash";
   import { onMount } from "svelte";
 
   // Slug rule mirrors src/validate.ts PROJECT_SLUG_RE exactly.
@@ -77,8 +78,9 @@
 
   onMount(async () => {
     try {
-      const { commands } = await getCommands("");
+      const { commands } = await getCommands("", { provider: "claude" });
       kickoffCommands = commands
+        .filter((c) => commandProviders(c).includes("claude") && commandInsertable(c, "claude"))
         .map((c) => c.name.split(":").pop() ?? c.name)
         .filter((n) => KICKOFF_COMMANDS.has(n));
     } catch {

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -1369,6 +1369,17 @@ describe("NewTask Codex model picker", () => {
     expect(modelSelect().disabled).toBe(false);
   });
 
+  it("loads commands with the active codex provider", async () => {
+    const repoPath = "/repo/codex-commands";
+    render(NewTask, {
+      props: base({ initialRepoPath: repoPath, defaultAgentProvider: "codex" }),
+    });
+
+    await expect
+      .poll(() => mockGetCommands.mock.calls.some((call) => call[1]?.provider === "codex"))
+      .toBe(true);
+  });
+
   it("submits the selected codex model", async () => {
     const repoPath = "/repo/codex-model";
     mockGetRepoConfig.mockResolvedValue(confirmedRepoConfig());

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -280,7 +280,12 @@
   let slashQuery = $state("");
   let slashTrigger = $state<"/" | "$" | "@">("/");
   let slashIndex = $state(0);
-  const slashMatches = $derived(slashOpen ? filterCommands(allCommands, slashQuery) : []);
+  const commandProvider = $derived(
+    slashOpen ? (slashTrigger === "/" ? "claude" : "codex") : agentProvider,
+  );
+  const slashMatches = $derived(
+    slashOpen ? filterCommands(allCommands, slashQuery, commandProvider) : [],
+  );
   let providerTokenConstraints = $state<ProviderTokenConstraint[]>([]);
   const activeProviderConstraint = $derived(providerTokenConstraints[0] ?? null);
 
@@ -469,16 +474,17 @@
   // .claude/commands + .claude/skills layer on top of the global/user/plugin ones.
   $effect(() => {
     const rp = repoPath;
+    const provider = commandProvider;
     if (!rp) {
       allCommands = [];
       return;
     }
-    getCommands(rp)
+    getCommands(rp, { provider })
       .then((r) => {
-        if (rp === repoPath) allCommands = r.commands;
+        if (rp === repoPath && provider === commandProvider) allCommands = r.commands;
       })
       .catch(() => {
-        if (rp === repoPath) allCommands = [];
+        if (rp === repoPath && provider === commandProvider) allCommands = [];
       });
   });
 
@@ -1058,7 +1064,7 @@
           <SlashCommandMenu
             commands={slashMatches}
             activeIndex={slashIndex}
-            provider={slashTrigger === "/" ? agentProvider : "codex"}
+            provider={commandProvider}
             onpick={pickCommand}
             onhover={(i) => (slashIndex = i)}
           />
@@ -1131,6 +1137,7 @@
           {epicParents}
           {nativeSubIssues}
           {epicsLoaded}
+          {agentProvider}
           allowIssues={!relaunch}
           onpick={(p) => {
             prompt = p;

--- a/ui/src/lib/components/PromptSources.browser.test.ts
+++ b/ui/src/lib/components/PromptSources.browser.test.ts
@@ -225,6 +225,47 @@ describe("PromptSources filter bar (popover + sticky coverage)", () => {
 
     expect(onpick).toHaveBeenCalledWith("$command-1 ");
   });
+
+  it("Commands tab: browsing-only Codex plugin rows are disabled", async () => {
+    mockListIssues.mockResolvedValue({
+      slug: "owner/repo",
+      webUrl: null,
+      issues: [],
+      viewer: null,
+    });
+    mockGetCommands.mockResolvedValue({
+      commands: [
+        {
+          name: "github",
+          description: "GitHub workflows",
+          scope: "plugin",
+          kind: "plugin",
+          providers: ["codex"],
+          invocations: {},
+        },
+      ],
+    });
+    const onpick = vi.fn();
+
+    render(PromptSources, {
+      repoPath: "/repo",
+      agentProvider: "codex",
+      onpick,
+      onpickissue: noop,
+    });
+
+    const commandsTab = [...document.querySelectorAll<HTMLButtonElement>(".tabs .tab")].find(
+      (b) => b.textContent?.trim() === m.promptsources_commands_tab(),
+    );
+    expect(commandsTab).toBeTruthy();
+    commandsTab!.click();
+
+    await expect.poll(() => document.querySelector(".ps-body .row.disabled")).not.toBeNull();
+    const row = document.querySelector<HTMLButtonElement>(".ps-body .row.disabled");
+    expect(row?.disabled).toBe(true);
+    row!.click();
+    expect(onpick).not.toHaveBeenCalled();
+  });
 });
 
 describe("PromptSources label chips (responsive 1↔2 cap)", () => {

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -5,7 +5,12 @@
   import type { Issue, SlashCommand, Steer } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { labelChipStyle } from "$lib/label-color";
-  import { commandInvocation, commandInvocationProvider, commandProviders } from "$lib/slash";
+  import {
+    commandInsertable,
+    commandInvocation,
+    commandInvocationProvider,
+    commandProviders,
+  } from "$lib/slash";
   import {
     hideOthers,
     hideActive,
@@ -33,6 +38,7 @@
     onpickissue,
     onpicksteer = undefined,
     allowIssues = true,
+    agentProvider = "claude",
     epicParents = new Set(),
     nativeSubIssues = new Set(),
     epicsLoaded = false,
@@ -45,6 +51,7 @@
      *  from the row's right-click / long-press context menu. Never spawns. */
     onpicksteer?: (issue: Issue, steer: Steer) => void;
     allowIssues?: boolean;
+    agentProvider?: "claude" | "codex";
     epicParents?: Set<number>;
     nativeSubIssues?: Set<number>;
     epicsLoaded?: boolean;
@@ -223,18 +230,19 @@
 
   $effect(() => {
     const rp = repoPath;
+    const provider = agentProvider;
     const t = tab;
     if (!rp || t === "todo") return; // todo is loaded eagerly above
     loading = true;
     if (t === "commands") {
-      getCommands(rp)
+      getCommands(rp, { provider })
         .then((r) => {
-          if (rp !== repoPath || t !== tab) return;
+          if (rp !== repoPath || provider !== agentProvider || t !== tab) return;
           commands = r.commands;
           loading = false;
         })
         .catch(() => {
-          if (rp !== repoPath || t !== tab) return;
+          if (rp !== repoPath || provider !== agentProvider || t !== tab) return;
           commands = [];
           loading = false;
         });
@@ -308,7 +316,21 @@
   }
 
   function marker(cmd: SlashCommand): string {
-    return commandProviders(cmd).includes("claude") ? "/" : "$";
+    const provider = commandInvocationProvider(cmd, agentProvider);
+    if (!commandInsertable(cmd, provider)) return "@";
+    return provider === "claude" ? "/" : "$";
+  }
+
+  function commandRowClass(cmd: SlashCommand): string {
+    const provider = commandInvocationProvider(cmd, agentProvider);
+    return commandInsertable(cmd, provider) ? "row" : "row disabled";
+  }
+
+  function pickCommand(cmd: SlashCommand) {
+    const provider = commandInvocationProvider(cmd, agentProvider);
+    if (!commandInsertable(cmd, provider)) return;
+    if (onpickcommand) onpickcommand(cmd);
+    else onpick(commandInvocation(cmd, provider) + " ");
   }
 </script>
 
@@ -377,12 +399,10 @@
       {:else}
         {#each filteredCommands as c (c.id ?? c.scope + ":" + c.name)}
           <button
-            class="row"
+            class={commandRowClass(c)}
             type="button"
-            onclick={() =>
-              onpickcommand
-                ? onpickcommand(c)
-                : onpick(commandInvocation(c, commandInvocationProvider(c)) + " ")}
+            disabled={!commandInsertable(c, commandInvocationProvider(c, agentProvider))}
+            onclick={() => pickCommand(c)}
           >
             <span class="row-marker">{marker(c)}</span>
             <span class="cmd-name">{c.name}</span>
@@ -630,6 +650,16 @@
   .row:hover {
     background: var(--color-panel);
     color: var(--color-ink-bright);
+  }
+
+  .row.disabled {
+    color: var(--color-faint);
+    cursor: default;
+  }
+
+  .row.disabled:hover {
+    background: transparent;
+    color: var(--color-faint);
   }
 
   /* Epic-parent rows are listed but not selectable — muted, no hover affordance. */

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -1608,7 +1608,7 @@
           return;
         }
         const { text, colAt } = lineTextWithColumns(line, linkCell);
-        const found = findCommandLinks(text, knownCommands);
+        const found = findCommandLinks(text, knownCommands, effectiveAgentProvider);
         if (found.length === 0) {
           callback(undefined);
           return;

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -352,17 +352,19 @@
   let knownCommands = $state<Set<string>>(new Set());
   $effect(() => {
     const rp = session.repoPath;
+    const provider = effectiveAgentProvider;
     if (!rp) {
       knownCommands = new Set();
       return;
     }
-    getCommands(rp)
+    getCommands(rp, { provider })
       .then((r) => {
-        if (rp === session.repoPath)
+        if (rp === session.repoPath && provider === effectiveAgentProvider)
           knownCommands = new Set(r.commands.map((c) => c.name.toLowerCase()));
       })
       .catch(() => {
-        if (rp === session.repoPath) knownCommands = new Set();
+        if (rp === session.repoPath && provider === effectiveAgentProvider)
+          knownCommands = new Set();
       });
   });
 

--- a/ui/src/lib/demo/router.test.ts
+++ b/ui/src/lib/demo/router.test.ts
@@ -293,6 +293,15 @@ describe("session-detail tab GETs never fall back to {}", () => {
     const cmds = await get(`/api/commands?repo=${repo}`);
     expect(Array.isArray(cmds.body.commands)).toBe(true);
     expect(cmds.body.commands.length).toBeGreaterThan(0);
+    expect(
+      cmds.body.commands.every((c: { providers?: string[] }) =>
+        (c.providers ?? ["claude"]).includes("claude"),
+      ),
+    ).toBe(true);
+    const codexCmds = await get(`/api/commands?repo=${repo}&provider=codex`);
+    expect(codexCmds.body.commands.some((c: { name: string }) => c.name === "github:yeet")).toBe(
+      true,
+    );
     const todo = await get(`/api/todo?repo=${repo}`);
     expect(todo.body).toEqual({ exists: false, content: "" });
   });

--- a/ui/src/lib/demo/router.ts
+++ b/ui/src/lib/demo/router.ts
@@ -49,7 +49,12 @@ const bootstrapGetRoutes: Record<string, GetHandler> = {
   // Done lens (#Task 8): archived sessions, distinct from the live `sessions` list.
   "/api/sessions/done": () => json(demoState.doneSessions()),
   "/api/repo-config": (url) => json(demoState.repoConfig(repoParam(url))),
-  "/api/commands": (url) => json(demoState.commands(repoParam(url))),
+  "/api/commands": (url) => {
+    const provider = url.searchParams.get("provider");
+    if (provider && provider !== "claude" && provider !== "codex")
+      return json({ error: "invalid provider" }, 400);
+    return json(demoState.commands(repoParam(url), provider === "codex" ? "codex" : "claude"));
+  },
   "/api/todo": (url) => json(demoState.todo(repoParam(url))),
   // Owed lens (#Task 8): durable post-merge step records — outstanding only. Svelte's
   // `{#each}` silently no-ops on the old `{}` fallback, so this gap never threw; it

--- a/ui/src/lib/demo/seed.ts
+++ b/ui/src/lib/demo/seed.ts
@@ -1562,8 +1562,46 @@ function buildRepoConfig(): Record<string, DemoRepoConfig> {
  *  small, plausible set for both demo repos. */
 function buildSlashCommands(): Record<string, SlashCommand[]> {
   const commands: SlashCommand[] = [
-    { name: "test", description: "Run the test suite", scope: "project" },
-    { name: "lint", description: "Run lint + typecheck", scope: "project" },
+    {
+      name: "test",
+      description: "Run the test suite",
+      scope: "project",
+      kind: "command",
+      providers: ["claude"],
+      invocations: { claude: "/test" },
+    },
+    {
+      name: "lint",
+      description: "Run lint + typecheck",
+      scope: "project",
+      kind: "command",
+      providers: ["claude"],
+      invocations: { claude: "/lint" },
+    },
+    {
+      name: "domain-modeling",
+      description: "Build and sharpen the project domain model",
+      scope: "user",
+      kind: "skill",
+      providers: ["codex"],
+      invocations: { codex: "$domain-modeling" },
+    },
+    {
+      name: "github:yeet",
+      description: "Publish local changes through the GitHub plugin",
+      scope: "plugin",
+      kind: "skill",
+      providers: ["codex"],
+      invocations: { codex: "$github:yeet" },
+    },
+    {
+      name: "github",
+      description: "GitHub workflows plugin",
+      scope: "plugin",
+      kind: "plugin",
+      providers: ["codex"],
+      invocations: {},
+    },
   ];
   return { [STOREFRONT]: commands, [API]: commands };
 }

--- a/ui/src/lib/demo/state.ts
+++ b/ui/src/lib/demo/state.ts
@@ -138,8 +138,13 @@ export const demoState = {
   repoConfig: (repoPath: string): DemoRepoConfig | Record<string, never> =>
     world.repoConfig[repoPath] ?? {},
   /** GET /api/commands?repo= — installed slash commands, [] for an unrecognized repoPath. */
-  commands: (repoPath: string): { commands: SlashCommand[] } => ({
-    commands: world.slashCommands[repoPath] ?? [],
+  commands: (
+    repoPath: string,
+    provider: "claude" | "codex" = "claude",
+  ): { commands: SlashCommand[] } => ({
+    commands: (world.slashCommands[repoPath] ?? []).filter((c) =>
+      (c.providers ?? ["claude"]).includes(provider),
+    ),
   }),
   /** GET /api/todo?repo= — {exists:false} for an unrecognized repoPath. */
   todo: (repoPath: string): { exists: boolean; content: string } =>

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-codex-discovery.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-codex-discovery.ts
@@ -1,0 +1,8 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+export default {
+  id: "codex-discovery",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_codex_discovery_title",
+  bodyKey: "feat_codex_discovery_body",
+} satisfies FeatureAnnouncement;

--- a/ui/src/lib/slash.test.ts
+++ b/ui/src/lib/slash.test.ts
@@ -152,6 +152,14 @@ describe("filterCommands", () => {
     const rows = [cmd("claude-only", ["claude"]), cmd("codex-only", ["codex"])];
     expect(filterCommands(rows, "", "codex").map((c) => c.name)).toEqual(["codex-only"]);
   });
+
+  it("excludes provider rows that do not expose an invocation", () => {
+    const rows = [
+      cmd("codex-skill", ["codex"]),
+      { ...cmd("codex-plugin", ["codex"]), kind: "plugin" as const, invocations: {} },
+    ];
+    expect(filterCommands(rows, "", "codex").map((c) => c.name)).toEqual(["codex-skill"]);
+  });
 });
 
 describe("commandInvocationProvider", () => {

--- a/ui/src/lib/slash.ts
+++ b/ui/src/lib/slash.ts
@@ -13,6 +13,11 @@ export function commandInvocation(command: SlashCommand, provider: "claude" | "c
   );
 }
 
+export function commandInsertable(command: SlashCommand, provider: "claude" | "codex"): boolean {
+  if (command.invocations) return Boolean(command.invocations[provider]);
+  return commandProviders(command).includes(provider);
+}
+
 export function commandInvocationProvider(
   command: SlashCommand,
   preferred?: "claude" | "codex",
@@ -112,7 +117,9 @@ export function filterCommands(
 ): SlashCommand[] {
   const q = query.toLowerCase();
   const filtered = provider
-    ? commands.filter((c) => commandProviders(c).includes(provider))
+    ? commands.filter(
+        (c) => commandProviders(c).includes(provider) && commandInsertable(c, provider),
+      )
     : commands;
   if (!q) return filtered;
   const prefix: SlashCommand[] = [];

--- a/ui/src/lib/slashLinks.test.ts
+++ b/ui/src/lib/slashLinks.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { findCommandLinks } from "./slashLinks";
 
-const names = (line: string, known: Set<string> = new Set()) =>
-  findCommandLinks(line, known).map((l) => l.name);
+const names = (
+  line: string,
+  known: Set<string> = new Set(),
+  provider: "claude" | "codex" = "claude",
+) => findCommandLinks(line, known, provider).map((l) => l.name);
 
 describe("findCommandLinks", () => {
   describe("hits — boundary chars", () => {
@@ -94,6 +97,16 @@ describe("findCommandLinks", () => {
   describe("known command overrides path-prefix denylist", () => {
     it('"/dev" linkifies when it is an installed command', () => {
       expect(names("/dev", new Set(["dev"]))).toEqual(["dev"]);
+    });
+  });
+
+  describe("codex provider", () => {
+    it("does not speculatively link arbitrary slash names", () => {
+      expect(names("try /review", new Set(), "codex")).toEqual([]);
+    });
+
+    it("does not make slash paste targets for known codex skills", () => {
+      expect(names("use /github:yeet", new Set(["github:yeet"]), "codex")).toEqual([]);
     });
   });
 });

--- a/ui/src/lib/slashLinks.ts
+++ b/ui/src/lib/slashLinks.ts
@@ -78,7 +78,12 @@ function nameOk(name: string, known: Set<string>): boolean {
  *   findCommandLinks("/home/moe/x", new Set())     → []   (followed by "/": path)
  *   findCommandLinks("/My_Skill", set(["my_skill"]))→ [{ ... name: "My_Skill" }] (A)
  */
-export function findCommandLinks(line: string, known: Set<string>): CommandLink[] {
+export function findCommandLinks(
+  line: string,
+  known: Set<string>,
+  provider: "claude" | "codex" = "claude",
+): CommandLink[] {
+  if (provider === "codex") return [];
   const out: CommandLink[] = [];
   for (const m of line.matchAll(TOKEN)) {
     const slash = m.index;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -254,7 +254,7 @@ export interface SlashCommand {
   displayName?: string;
   description: string;
   scope: SlashCommandScope;
-  kind?: "skill" | "command";
+  kind?: "skill" | "command" | "plugin";
   invocationName?: string;
   sourceNamespace?: string;
   sourcePath?: string;


### PR DESCRIPTION
## Summary
- Add Codex command discovery alongside the existing Claude command endpoint contract, preserving omitted/Claude-only behavior and adding explicit `provider=codex` filtering.
- Discover Codex skills from repo/user/CODEX_HOME/system roots plus plugin-bundled skills from the installed plugin cache; expose installed plugin rows as non-insertable browsing inventory.
- Thread the active agent provider through New Task, prompt sources, ComposeBar, and terminal linkification so Codex uses `$skill` insertions and avoids Claude-style `/name` links.
- Add demo state, i18n strings, feature announcement, and server/UI tests for provider filtering, trigger behavior, plugin skills, disabled skills, and stale provider loading.

## Verification
- `bun run lint`
- `bun run test` (full root suite passed before final Fallow adjustment; focused `bun test test/commands.test.ts test/server.test.ts` passed after final adjustment)
- `cd ui && bun run check`
- `cd ui && bun run check:i18n`
- `cd ui && bun run test:node`
- `cd ui && bun run test:browser -- src/lib/components/PromptSources.browser.test.ts src/lib/components/NewTask.browser.test.ts --testNamePattern 'browsing-only inventory|loads commands with the active codex provider'`
- `cd extension && bun run check`
- `bunx fallow@2.100.0 audit --base origin/main --fail-on-issues`
- `git push` pre-push hook passed all lanes (`prettier`, `eslint`, `gates`, `tsc`, `ext`, `root-tests`, `ui`, Fallow)
