### PR TITLE
fix(codex): restore weekly usage gauge

### DIFF
--- a/src/codex-usage.ts
+++ b/src/codex-usage.ts
@@ -230,6 +230,38 @@ function toLimitWindow(w: RolloutLimitWindow | null | undefined, now: number): L
   return { pct: Math.max(0, Math.min(100, Math.round(w.used_percent))), resetAt };
 }
 
+type WindowBucket = "session5h" | "week";
+
+const UNKNOWN_WINDOW_DURATIONS_WARNED = new Set<number>();
+
+function bucketForWindow(
+  w: RolloutLimitWindow,
+  positionalFallback: WindowBucket,
+): WindowBucket | null {
+  if (typeof w.window_minutes !== "number") return positionalFallback;
+  if (Math.abs(w.window_minutes - 300) <= 1) return "session5h";
+  if (Math.abs(w.window_minutes - 10080) <= 1) return "week";
+  if (!UNKNOWN_WINDOW_DURATIONS_WARNED.has(w.window_minutes)) {
+    UNKNOWN_WINDOW_DURATIONS_WARNED.add(w.window_minutes);
+    console.warn(`[codex-usage] ignoring unrecognized rate-limit window: ${w.window_minutes}m`);
+  }
+  return null;
+}
+
+function assignLimitWindow(
+  out: { session5h: LimitWindow | null; week: LimitWindow | null },
+  w: RolloutLimitWindow | null | undefined,
+  positionalFallback: WindowBucket,
+  now: number,
+): void {
+  if (!w) return;
+  const bucket = bucketForWindow(w, positionalFallback);
+  if (!bucket) return;
+  const limit = toLimitWindow(w, now);
+  if (!limit) return;
+  out[bucket] = limit;
+}
+
 function readFileTail(path: string, maxBytes: number): string {
   const st = statSync(path);
   const start = Math.max(0, st.size - maxBytes);
@@ -263,8 +295,13 @@ function rateLimitsFromEvent(obj: RolloutTokenCountEvent, now: number): CodexRat
   if (obj.type !== "event_msg" || obj.payload?.type !== "token_count") return null;
   const rl = obj.payload.rate_limits;
   if (!rl) return null;
-  const session5h = toLimitWindow(rl.primary, now);
-  const week = toLimitWindow(rl.secondary, now);
+  const windows: { session5h: LimitWindow | null; week: LimitWindow | null } = {
+    session5h: null,
+    week: null,
+  };
+  assignLimitWindow(windows, rl.primary, "session5h", now);
+  assignLimitWindow(windows, rl.secondary, "week", now);
+  const { session5h, week } = windows;
   if (!session5h && !week) return null;
   return {
     session5h,
@@ -279,7 +316,9 @@ function rateLimitsFromEvent(obj: RolloutTokenCountEvent, now: number): CodexRat
 /**
  * Extract the most recent rate-limit windows from one rollout JSONL file's content. Codex appends a
  * `{type:"event_msg", payload:{type:"token_count", rate_limits:{primary,secondary}}}` line on each
- * turn; `primary` is the 5h window, `secondary` the weekly. The last such line is the current state.
+ * turn. Codex has emitted both positional primary=5h/secondary=weekly and duration-labelled
+ * primary=weekly shapes; prefer `window_minutes` when present and fall back to position only for
+ * older duration-less rollouts. The last such line is the current state.
  *
  * This is a line-based scan, which assumes the JSONL invariant of one complete JSON object per line
  * (Codex writes exactly that) — a pretty-printed, multi-line object would not parse. The pre-filter

--- a/test/codex-usage.test.ts
+++ b/test/codex-usage.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
@@ -131,6 +131,80 @@ test("parseCodexRateLimits reads the latest primary/secondary windows", () => {
     checkedAt: NOW,
     filesScanned: 0,
     latestEventAt: Date.parse("2026-06-25T15:59:00.000Z"),
+  });
+});
+
+test("parseCodexRateLimits classifies a real weekly-only primary window as weekly", () => {
+  const content = readFileSync(
+    join(import.meta.dir, "fixtures", "codex-usage", "weekly-primary-rollout.jsonl"),
+    "utf8",
+  );
+
+  expect(parseCodexRateLimits(content, NOW)).toMatchObject({
+    session5h: null,
+    week: { pct: 3, resetAt: 1784487529 * 1000 },
+  });
+});
+
+test("parseCodexRateLimits handles reordered weekly-primary and 5h-secondary windows", () => {
+  const resetSec = Math.floor(NOW / 1000) + 3600;
+  const content = JSON.stringify({
+    type: "event_msg",
+    payload: {
+      type: "token_count",
+      rate_limits: {
+        primary: { used_percent: 17, window_minutes: 10080, resets_at: resetSec + 600 },
+        secondary: { used_percent: 41, window_minutes: 300, resets_at: resetSec },
+      },
+    },
+  });
+
+  expect(parseCodexRateLimits(content, NOW)).toMatchObject({
+    session5h: { pct: 41, resetAt: resetSec * 1000 },
+    week: { pct: 17, resetAt: (resetSec + 600) * 1000 },
+  });
+});
+
+test("parseCodexRateLimits ignores unknown present durations", () => {
+  const resetSec = Math.floor(NOW / 1000) + 3600;
+  const content = JSON.stringify({
+    type: "event_msg",
+    payload: {
+      type: "token_count",
+      rate_limits: {
+        primary: { used_percent: 17, window_minutes: 60, resets_at: resetSec },
+        secondary: null,
+      },
+    },
+  });
+
+  const originalWarn = console.warn;
+  const warnings: string[] = [];
+  console.warn = (msg) => warnings.push(String(msg));
+  try {
+    expect(parseCodexRateLimits(content, NOW)).toBeNull();
+  } finally {
+    console.warn = originalWarn;
+  }
+  expect(warnings).toEqual(["[codex-usage] ignoring unrecognized rate-limit window: 60m"]);
+});
+
+test("parseCodexRateLimits lets the later same-bucket known duration win", () => {
+  const resetSec = Math.floor(NOW / 1000) + 3600;
+  const content = JSON.stringify({
+    type: "event_msg",
+    payload: {
+      type: "token_count",
+      rate_limits: {
+        primary: { used_percent: 17, window_minutes: 10080, resets_at: resetSec },
+        secondary: { used_percent: 23, window_minutes: 10079, resets_at: resetSec + 600 },
+      },
+    },
+  });
+
+  expect(parseCodexRateLimits(content, NOW)).toMatchObject({
+    session5h: null,
+    week: { pct: 23, resetAt: (resetSec + 600) * 1000 },
   });
 });
 

--- a/test/fixtures/codex-usage/weekly-primary-rollout.jsonl
+++ b/test/fixtures/codex-usage/weekly-primary-rollout.jsonl
@@ -1,0 +1,1 @@
+{"type":"event_msg","payload":{"type":"token_count","rate_limits":{"limit_id":"codex","limit_name":null,"primary":{"used_percent":3,"window_minutes":10080,"resets_at":1784487529},"secondary":null,"credits":null,"individual_limit":null,"plan_type":"pro","rate_limit_reached_type":null}}}


### PR DESCRIPTION
## Summary
- classify Codex rollout rate-limit windows by `window_minutes` when present, so a weekly window emitted as `primary` is shown as WK instead of 5H
- keep positional fallback for older duration-less rollout lines and ignore unknown durations with a one-time warning
- add a minimal fixture from a current rollout shape plus regression coverage for weekly-only, reordered windows, unknown durations, and same-bucket collision handling

## Validation
- `bun test test/codex-usage.test.ts`
- `bun run lint`
- `cd ui && bun test src/lib/components/usage-gauges.test.ts`
- `cd ui && bun run check`
- `cd extension && bun run check`
- `git push` pre-push hook: prettier, eslint, gates, tsc, ext, root-tests, ui, fallow audit
