### PR TITLE
feat: surface human review blocks

### DIFF
--- a/src/automerge-core.ts
+++ b/src/automerge-core.ts
@@ -1,4 +1,4 @@
-import type { ChecksState, PrStatus } from "./forge/types";
+import type { ChecksState, MergeStateStatus, PrStatus } from "./forge/types";
 import type { ReviewDecision } from "./types";
 import type { ManualStep } from "./manual-steps";
 import { signedOff, type SignoffAuthority } from "./signoff";
@@ -29,6 +29,8 @@ export interface MergeSessionView {
   noCi: boolean;
   /** null = host still computing; treat as not-yet-mergeable. */
   mergeable: boolean | null;
+  /** GitHub branch-protection merge state; absent on forges that do not supply it. */
+  mergeStateStatus?: MergeStateStatus;
   number: number | null;
   headSha: string | null;
   /** false = up-to-date; true = behind main (rebase); null = unknown (never merge). */
@@ -107,6 +109,7 @@ function readyExceptManualSteps(
   if (s.mergeBlocked) return false; // backed off after repeated merge failures → skip, try siblings
   if (s.state !== "open" || !checksCleared(s.checks, s.noCi) || s.mergeable !== true || !s.number)
     return false;
+  if (s.mergeStateStatus === "blocked") return false;
   if (s.behind !== false) return false; // true=stale, null=unknown → not now
   if (draftMode && !signedOff(authority, signoffView(s))) return false; // backstop: never merge an unsigned draft
   if (s.reviewDecision === "changes_requested" || s.reviewDecision === "error") return false;

--- a/src/automerge.ts
+++ b/src/automerge.ts
@@ -147,6 +147,7 @@ export class AutoMergeService {
       checks: git?.checks ?? ("none" as const),
       noCi: git?.noCi ?? false,
       mergeable: git?.mergeable ?? null,
+      mergeStateStatus: git?.mergeStateStatus,
       number: git?.number ?? null,
       headSha: git?.headSha ?? null,
       humanApproved: git?.latestReview?.state === "approved",

--- a/src/forge/github.ts
+++ b/src/forge/github.ts
@@ -33,6 +33,7 @@ import type {
   OpenPrSnapshot,
   PostReviewInput,
   PrComment,
+  PrReviewerState,
   PrReviewMeta,
   PrStatus,
   PullRequest,
@@ -215,7 +216,7 @@ const defaultRunner: GhRunner = (args) =>
     }
   });
 
-interface GhReview {
+export interface GhReview {
   author?: { login?: string } | null;
   state?: string | null; // APPROVED | CHANGES_REQUESTED | COMMENTED | PENDING | DISMISSED
   body?: string | null;
@@ -226,6 +227,13 @@ const REVIEW_STATE: Record<string, "approved" | "changes_requested" | "commented
   APPROVED: "approved",
   CHANGES_REQUESTED: "changes_requested",
   COMMENTED: "commented",
+};
+
+const REVIEWER_REPLAY_STATE: Record<string, PrReviewerState["state"] | "dismissed"> = {
+  APPROVED: "approved",
+  CHANGES_REQUESTED: "changes_requested",
+  COMMENTED: "commented",
+  DISMISSED: "dismissed",
 };
 
 /** Newest human review (critic-marked + non-terminal states excluded). */
@@ -242,6 +250,36 @@ function latestHumanReview(reviews: GhReview[] | undefined): PrStatus["latestRev
     best = { state, author: r.author?.login ?? "", submittedAt: ts };
   }
   return best;
+}
+
+/** Latest terminal human review state per reviewer. Unlike latestHumanReview(),
+ *  this replay treats DISMISSED as a clearing event and keeps COMMENTED neutral. */
+export function reviewerStatesFromReviews(
+  reviews: GhReview[] | undefined,
+): PrStatus["reviewerStates"] {
+  if (!reviews) return undefined;
+  const states: NonNullable<PrStatus["reviewerStates"]> = {};
+  const ordered = [...reviews]
+    .map((r) => ({ review: r, ts: Date.parse(r.submittedAt ?? "") }))
+    .filter(({ review, ts }) => {
+      if (!Number.isFinite(ts)) return false;
+      if ((review.body ?? "").includes(CRITIC_REVIEW_MARKER)) return false;
+      return !!REVIEWER_REPLAY_STATE[review.state ?? ""];
+    })
+    .sort((a, b) => a.ts - b.ts);
+  for (const { review, ts } of ordered) {
+    const author = review.author?.login ?? "";
+    if (!author) continue;
+    const state = REVIEWER_REPLAY_STATE[review.state ?? ""];
+    if (!state) continue;
+    if (state === "dismissed") {
+      delete states[author];
+      continue;
+    }
+    if (state === "commented" && states[author]?.state === "changes_requested") continue;
+    states[author] = { state, latestAt: ts };
+  }
+  return states;
 }
 
 interface GhPr {
@@ -1059,6 +1097,7 @@ export class GithubForge implements GitForge {
       headSha: pr.headRefOid,
       baseRefName: pr.baseRefName,
       latestReview: latestHumanReview(pr.reviews),
+      reviewerStates: reviewerStatesFromReviews(pr.reviews),
       requestedReviewers: (pr.reviewRequests ?? [])
         .map((r) => r.login)
         .filter((l): l is string => !!l),

--- a/src/forge/types.ts
+++ b/src/forge/types.ts
@@ -143,6 +143,17 @@ export interface PrReview {
   submittedAt: number; // epoch ms
 }
 
+export interface PrReviewerState {
+  state: "approved" | "changes_requested" | "commented";
+  latestAt: number | null; // epoch ms when the terminal state was submitted
+}
+
+export interface PrReviewBlock {
+  reviewer: string;
+  state: "changes_requested";
+  latestAt: number | null;
+}
+
 /** An open PR surfaced in the backlog PRs tab. Lighter than PrStatus: it is a
  *  list row across all forge repos, not one session's live git state. */
 export interface PullRequest {
@@ -203,6 +214,9 @@ export interface PrStatus {
   headSha?: string;
   /** Newest *human* PR review (critic-marked reviews excluded), or undefined. */
   latestReview?: PrReview;
+  /** Latest terminal human review state per reviewer, critic-marked reviews excluded.
+   *  Unscoped forge data; server role annotation turns this into `reviewBlock`. */
+  reviewerStates?: Record<string, PrReviewerState>;
   /** GitHub logins with a pending review request on the PR (teams/bots without a
    *  login are dropped). Drives merger auto-inference when the repo has no
    *  `.shepherd/roles.json`. Optional: a cached payload predating the field ⇒ treat as `[]`. */
@@ -240,6 +254,8 @@ export interface GitState extends PrStatus {
    *  `.shepherd/roles.json`); suppresses the outward issue-log comment, which
    *  stays opt-in to explicitly-configured roles. */
   handoffInferred?: boolean;
+  /** Role-scoped active requested-changes block for the configured reviewer. */
+  reviewBlock?: PrReviewBlock;
   /** Web URL of the backlog issue this session was spawned for (session.issueNumber),
    *  or absent when the session has no linked issue or the repo has no web forge
    *  (LocalForge). Lets GitRail surface an "open issue" link. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1673,7 +1673,12 @@ const autopilot = new AutopilotService({
         body: s.prompt,
       });
       const me = (await forge.currentUser?.()) ?? null;
-      const git: GitState = annotateHandoff({ kind: forge.kind, ...status }, s.repoPath, me);
+      const git: GitState = annotateHandoff(
+        { kind: forge.kind, ...status },
+        s.repoPath,
+        me,
+        prPoller.get(s.id),
+      );
       prPoller.set(s.id, git);
       events.emit("session:git", { id: s.id, git });
     } catch (err) {

--- a/src/issue-log.ts
+++ b/src/issue-log.ts
@@ -44,7 +44,14 @@ export function issueLogEntries(
   // the full condition so a stale/hand-rolled GitState can't comment early. An
   // auto-inferred handoff (no roles.json) is excluded — the outward comment is
   // opt-in to explicitly-configured roles (see module doc).
-  if (
+  if (git.state === "open" && checksCleared(git.checks, git.noCi ?? false) && git.reviewBlock) {
+    const key = `changes-requested:${git.number}`;
+    if (!alreadyLogged(key))
+      out.push({
+        key,
+        body: stamp(`⚠️ Changes requested on PR #${git.number} by @${git.reviewBlock.reviewer}.`),
+      });
+  } else if (
     git.state === "open" &&
     checksCleared(git.checks, git.noCi ?? false) &&
     git.handoff &&

--- a/src/pr-poller.ts
+++ b/src/pr-poller.ts
@@ -80,6 +80,17 @@ function sameSet(a: string[] | undefined, b: string[] | undefined): boolean {
   return as.every((v, i) => v === bs[i]);
 }
 
+function stableJson(v: unknown): string {
+  if (!v || typeof v !== "object") return JSON.stringify(v ?? null);
+  return JSON.stringify(
+    Object.fromEntries(
+      Object.entries(v as Record<string, unknown>).sort(([a], [b]) =>
+        a.toLowerCase().localeCompare(b.toLowerCase()),
+      ),
+    ),
+  );
+}
+
 /** True when a freshly polled PR state differs from the cached one in any field
  *  the UI renders (status, CI/merge-eligibility, review, handoff) — i.e. worth
  *  pushing a session:git update. Exported for unit testing. */
@@ -96,8 +107,10 @@ export function gitStateChanged(prev: GitState | undefined, git: GitState): bool
     prev.headSha !== git.headSha ||
     prev.baseRefName !== git.baseRefName ||
     prev.latestReview?.submittedAt !== git.latestReview?.submittedAt ||
+    stableJson(prev.reviewerStates) !== stableJson(git.reviewerStates) ||
     prev.handoff !== git.handoff ||
-    prev.handoffWho !== git.handoffWho
+    prev.handoffWho !== git.handoffWho ||
+    stableJson(prev.reviewBlock) !== stableJson(git.reviewBlock)
   );
 }
 
@@ -402,7 +415,7 @@ export class PrPoller implements PrCache {
 
     // Who's up (open+green): computed from .shepherd/roles.json + the operator's
     // login, so the herd can show "waiting on scoop" instead of "your turn".
-    const git = annotateHandoff(raw, s.repoPath, me);
+    const git = annotateHandoff(raw, s.repoPath, me, prev);
     this.trackTransient(s.id, git);
     if (gitStateChanged(prev, git)) {
       this.cache.set(s.id, git);

--- a/src/repo-roles.ts
+++ b/src/repo-roles.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "./instrument";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { rmSync } from "node:fs";
-import type { GitState, PrStatus } from "./forge/types";
+import type { GitState, PrReviewBlock, PrReviewerState, PrStatus } from "./forge/types";
 import { checksCleared, repoHasNoCiCached } from "./checks-gate";
 
 /** Per-repo responsibility config, committed to `.shepherd/roles.json` at the repo
@@ -56,20 +56,39 @@ export function computeHandoff(
   me: string | null,
   latestReview: PrStatus["latestReview"],
   requestedReviewers: string[] = [],
+  reviewBlock?: PrReviewBlock,
 ): { handoff: HandoffRole; handoffWho: string | null; inferred: boolean } {
   // GitHub logins are case-insensitive, so compare folded — else a free-text
   // entry whose casing differs from the operator's own login would mis-read as
   // "someone else" and show "waiting on yourself".
   const meLc = me?.toLowerCase() ?? null;
-  if (roles.reviewer || roles.merger) {
-    const reviewerIsOther = !!roles.reviewer && roles.reviewer.toLowerCase() !== meLc;
-    const mergerIsOther = !!roles.merger && roles.merger.toLowerCase() !== meLc;
-    const reviewApproved = latestReview?.state === "approved";
-    if (reviewerIsOther && !reviewApproved)
-      return { handoff: "reviewer", handoffWho: roles.reviewer, inferred: false };
-    if (mergerIsOther) return { handoff: "merger", handoffWho: roles.merger, inferred: false };
+  if (roles.reviewer || roles.merger)
+    return configuredHandoff(roles, meLc, latestReview, reviewBlock);
+  return inferredHandoff(meLc, latestReview, requestedReviewers);
+}
+
+function configuredHandoff(
+  roles: RepoRoles,
+  meLc: string | null,
+  latestReview: PrStatus["latestReview"],
+  reviewBlock?: PrReviewBlock,
+): { handoff: HandoffRole; handoffWho: string | null; inferred: false } {
+  const reviewerIsOther = !!roles.reviewer && roles.reviewer.toLowerCase() !== meLc;
+  const mergerIsOther = !!roles.merger && roles.merger.toLowerCase() !== meLc;
+  if (reviewerIsOther && reviewBlock?.state === "changes_requested")
     return { handoff: "self", handoffWho: null, inferred: false };
-  }
+  const reviewApproved = latestReview?.state === "approved";
+  if (reviewerIsOther && !reviewApproved)
+    return { handoff: "reviewer", handoffWho: roles.reviewer, inferred: false };
+  if (mergerIsOther) return { handoff: "merger", handoffWho: roles.merger, inferred: false };
+  return { handoff: "self", handoffWho: null, inferred: false };
+}
+
+function inferredHandoff(
+  meLc: string | null,
+  latestReview: PrStatus["latestReview"],
+  requestedReviewers: string[],
+): { handoff: HandoffRole; handoffWho: string | null; inferred: boolean } {
   // Fully unconfigured: infer a merger from the PR. Foreign = login != me (folded).
   const foreign = (login: string): boolean => login.toLowerCase() !== meLc;
   const lowestForeignRequestedReviewer =
@@ -141,27 +160,66 @@ function readRolesFromRef(repoPath: string): RepoRoles {
   return EMPTY;
 }
 
+function stateForReviewer(
+  reviewerStates: Record<string, PrReviewerState> | undefined,
+  reviewer: string | null,
+): { login: string; state: PrReviewerState } | null {
+  if (!reviewer || !reviewerStates) return null;
+  const reviewerLc = reviewer.toLowerCase();
+  for (const [login, state] of Object.entries(reviewerStates)) {
+    if (login.toLowerCase() === reviewerLc) return { login, state };
+  }
+  return null;
+}
+
 /** Annotate a GitState with `handoff`/`handoffWho` (+ `handoffInferred` when the
  *  handoff was auto-inferred from the PR's reviewers rather than configured roles).
  *  Always returns a clean state (any stale handoff is stripped first), so re-running
  *  it after a role change correctly clears a no-longer-applicable waiting state. Only
  *  an open + green PR carries a handoff (the only point the herd consults it);
  *  everything else is returned without one. */
-export function annotateHandoff(state: GitState, repoPath: string, me: string | null): GitState {
+export function annotateHandoff(
+  state: GitState,
+  repoPath: string,
+  me: string | null,
+  prev?: GitState,
+): GitState {
   // Stamp noCi on EVERY state (the poller + on-demand /git chokepoint) so all downstream gates can
   // read git.noCi without re-deriving it. A no-CI repo (GitHub + zero workflows) treats a terminal
   // checks:"none" as cleared — see checks-gate.ts.
   const noCi = repoHasNoCiCached(state.kind, repoPath);
-  const base: GitState = { ...state, noCi };
+  const preservedReviewerStates =
+    state.reviewerStates ??
+    (state.state === "open" && prev?.state === "open" && prev.number === state.number
+      ? prev.reviewerStates
+      : undefined);
+  const base: GitState = {
+    ...state,
+    reviewerStates: preservedReviewerStates,
+    noCi,
+  };
   delete base.handoff; // drop any stale handoff so a role change clears it
   delete base.handoffWho;
   delete base.handoffInferred;
+  delete base.reviewBlock;
+  const roles = readRepoRoles(repoPath);
+  const scoped = stateForReviewer(base.reviewerStates, roles.reviewer);
+  const reviewBlock =
+    scoped?.state.state === "changes_requested"
+      ? ({
+          reviewer: scoped.login,
+          state: "changes_requested",
+          latestAt: scoped.state.latestAt,
+        } as const)
+      : undefined;
+  if (reviewBlock) base.reviewBlock = reviewBlock;
   if (base.state !== "open" || !checksCleared(base.checks, noCi)) return base;
   const { handoff, handoffWho, inferred } = computeHandoff(
-    readRepoRoles(repoPath),
+    roles,
     me,
     base.latestReview,
     base.requestedReviewers,
+    reviewBlock,
   );
   if (handoff === "self") return base;
   const next = handoffWho ? { ...base, handoff, handoffWho } : { ...base, handoff };

--- a/src/server.ts
+++ b/src/server.ts
@@ -1552,11 +1552,12 @@ function repushHandoff(deps: AppDeps, dir: string, me: string | null): void {
     if (s.repoPath !== dir) continue;
     const prev = snap[s.id];
     if (!prev) continue;
-    const updated = annotateHandoff(prev, dir, me);
+    const updated = annotateHandoff(prev, dir, me, prev);
     if (
       updated.handoff !== prev.handoff ||
       updated.handoffWho !== prev.handoffWho ||
-      updated.handoffInferred !== prev.handoffInferred
+      updated.handoffInferred !== prev.handoffInferred ||
+      JSON.stringify(updated.reviewBlock ?? null) !== JSON.stringify(prev.reviewBlock ?? null)
     ) {
       deps.prCache.set(s.id, updated);
       deps.events.emit("session:git", { id: s.id, git: updated });
@@ -3559,7 +3560,13 @@ async function forgeOpenPr(
     throw err;
   }
   const me = (await forge.currentUser?.()) ?? null;
-  const git: GitState = annotateHandoff({ kind: forge.kind, ...status }, session.repoPath, me);
+  const prev = deps.prCache?.get(session.id);
+  const git: GitState = annotateHandoff(
+    { kind: forge.kind, ...status },
+    session.repoPath,
+    me,
+    prev,
+  );
   deps.prCache?.set(session.id, git);
   deps.events.emit("session:git", { id: session.id, git });
   return json(status);
@@ -3627,7 +3634,13 @@ async function forgeMerge(
   }
   const status = await forge.prStatus(head);
   const me = (await forge.currentUser?.()) ?? null;
-  const git: GitState = annotateHandoff({ kind: forge.kind, ...status }, session.repoPath, me);
+  const prev = deps.prCache?.get(session.id);
+  const git: GitState = annotateHandoff(
+    { kind: forge.kind, ...status },
+    session.repoPath,
+    me,
+    prev,
+  );
   deps.prCache?.set(session.id, git);
   deps.events.emit("session:git", { id: session.id, git });
   return json(status);
@@ -3647,10 +3660,12 @@ async function refreshSessionGit(
   deps: AppDeps,
 ): Promise<GitState> {
   const me = (await forge.currentUser?.()) ?? null;
+  const prev = deps.prCache?.get(session.id);
   const git: GitState = annotateHandoff(
     { kind: forge.kind, ...(await forge.prStatus(session.branch ?? "")) },
     session.repoPath,
     me,
+    prev,
   );
   deps.prCache?.set(session.id, git);
   deps.events.emit("session:git", { id: session.id, git });
@@ -3756,6 +3771,7 @@ async function resolveGitState(
       { kind: forge.kind, ...(await forge.prStatus(session.branch ?? "")) },
       session.repoPath,
       me,
+      prev,
     ),
   );
   // No PR for the stored branch: the agent may have renamed the worktree branch out
@@ -3770,6 +3786,7 @@ async function resolveGitState(
           { kind: forge.kind, ...(await forge.prStatus(live)) },
           session.repoPath,
           me,
+          prev,
         ),
       );
     }

--- a/test/automerge-core.test.ts
+++ b/test/automerge-core.test.ts
@@ -46,6 +46,11 @@ test("open+green+mergeable+current → merge (critic off)", () => {
   expect(d).toEqual({ kind: "merge", sessionId: "s1", prNumber: 7, headSha: "h1" });
 });
 
+test("open+green+mergeable but branch-protection blocked → hold", () => {
+  const d = computeMerge(state([sess({ mergeStateStatus: "blocked" })]));
+  expect(d).toEqual({ kind: "hold", reason: { code: "idle" } });
+});
+
 test("no-CI repo (noCi + checks:none) → merge", () => {
   // A GitHub repo with zero workflows reports checks:"none" forever; with noCi it's mergeable.
   const d = computeMerge(state([sess({ checks: "none", noCi: true })]));

--- a/test/automerge.test.ts
+++ b/test/automerge.test.ts
@@ -100,6 +100,29 @@ test("ready PR → forge.merge called with squash + delete-branch, then archived
   expect(order).toEqual(["note", "archive"]);
 });
 
+test("mergeStateStatus blocked from prCache prevents merge", async () => {
+  const merge = mock(async () => {});
+  const d = deps({
+    prCache: {
+      snapshot: () => ({
+        s1: {
+          state: "open",
+          checks: "success",
+          mergeable: true,
+          mergeStateStatus: "blocked",
+          number: 7,
+          headSha: "h1",
+        },
+      }),
+    } as any,
+    resolveForge: () =>
+      ({ kind: "github", mergeMethod: "squash", merge, closeIssue: mock(async () => {}) }) as any,
+  });
+  const svc = new AutoMergeService(d);
+  await svc.pump("/r");
+  expect(merge).not.toHaveBeenCalled();
+});
+
 test("behind → steers a rebase + bumps the counter, does NOT merge", async () => {
   const reply = mock(() => true);
   const setState = mock(() => {});

--- a/test/forge/github.test.ts
+++ b/test/forge/github.test.ts
@@ -1,8 +1,9 @@
 import { test, expect } from "bun:test";
-import { GithubForge } from "../../src/forge/github";
+import { GithubForge, reviewerStatesFromReviews } from "../../src/forge/github";
 import { graphRateLimit } from "../../src/forge/rate-limit";
-import { EmptyDiffError } from "../../src/forge/types";
-import type { PullRequest, PrStatus } from "../../src/forge/types";
+import { CRITIC_REVIEW_MARKER, EmptyDiffError } from "../../src/forge/types";
+import type { PullRequest, PrReviewerState, PrStatus } from "../../src/forge/types";
+import type { GhReview } from "../../src/forge/github";
 
 // A recording fake `gh` runner. Returns canned stdout keyed by the subcommand.
 function fakeRunner(responses: Record<string, string>) {
@@ -45,6 +46,64 @@ const ISSUES_JSON = JSON.stringify([
     // no assignees key → maps to []
   },
 ]);
+
+function review(author: string, state: string, submittedAt: string, body = ""): GhReview {
+  return { author: { login: author }, state, submittedAt, body };
+}
+
+test("reviewerStatesFromReviews: changes requested creates a per-reviewer state", () => {
+  expect(
+    reviewerStatesFromReviews([review("scoop", "CHANGES_REQUESTED", "2026-01-01T00:00:00Z")]),
+  ).toEqual({
+    scoop: { state: "changes_requested", latestAt: Date.parse("2026-01-01T00:00:00Z") },
+  });
+});
+
+test("reviewerStatesFromReviews: approval clears prior requested changes", () => {
+  expect(
+    reviewerStatesFromReviews([
+      review("scoop", "CHANGES_REQUESTED", "2026-01-01T00:00:00Z"),
+      review("scoop", "APPROVED", "2026-01-01T01:00:00Z"),
+    ]),
+  ).toEqual({ scoop: { state: "approved", latestAt: Date.parse("2026-01-01T01:00:00Z") } });
+});
+
+test("reviewerStatesFromReviews: later comment does not clear requested changes", () => {
+  expect(
+    reviewerStatesFromReviews([
+      review("scoop", "CHANGES_REQUESTED", "2026-01-01T00:00:00Z"),
+      review("scoop", "COMMENTED", "2026-01-01T01:00:00Z"),
+    ]),
+  ).toEqual({
+    scoop: { state: "changes_requested", latestAt: Date.parse("2026-01-01T00:00:00Z") },
+  });
+});
+
+test("reviewerStatesFromReviews: dismissed clears requested changes", () => {
+  expect(
+    reviewerStatesFromReviews([
+      review("scoop", "CHANGES_REQUESTED", "2026-01-01T00:00:00Z"),
+      review("scoop", "DISMISSED", "2026-01-01T01:00:00Z"),
+    ]),
+  ).toEqual({});
+});
+
+test("reviewerStatesFromReviews: replay is chronological, not payload-order dependent", () => {
+  expect(
+    reviewerStatesFromReviews([
+      review("scoop", "APPROVED", "2026-01-01T01:00:00Z"),
+      review("scoop", "CHANGES_REQUESTED", "2026-01-01T00:00:00Z"),
+    ]),
+  ).toEqual({ scoop: { state: "approved", latestAt: Date.parse("2026-01-01T01:00:00Z") } });
+});
+
+test("reviewerStatesFromReviews: critic reviews are ignored", () => {
+  expect(
+    reviewerStatesFromReviews([
+      review("scoop", "CHANGES_REQUESTED", "2026-01-01T00:00:00Z", CRITIC_REVIEW_MARKER),
+    ]),
+  ).toEqual({});
+});
 
 test("GithubForge.listBacklogCounts: parses counts, CI rollup and PR-kind split", async () => {
   const graphql = JSON.stringify({
@@ -2102,12 +2161,16 @@ const EXPECTED_STATUSES: Map<string, PrStatus> = new Map([
       mergeStateStatus: "clean",
       isDraft: false,
       checks: "success",
+      runningChecks: undefined,
       headSha: "aaa111",
       baseRefName: "main",
       latestReview: {
         state: "approved",
         author: "bob",
         submittedAt: Date.parse("2026-01-01T00:00:00Z"),
+      },
+      reviewerStates: {
+        bob: { state: "approved", latestAt: Date.parse("2026-01-01T00:00:00Z") },
       },
       requestedReviewers: ["carol"],
       deployConfigured: false,
@@ -2125,9 +2188,11 @@ const EXPECTED_STATUSES: Map<string, PrStatus> = new Map([
       mergeStateStatus: "dirty",
       isDraft: true,
       checks: "none",
+      runningChecks: undefined,
       headSha: "bbb222",
       baseRefName: "main",
       latestReview: undefined,
+      reviewerStates: {} as Record<string, PrReviewerState>,
       requestedReviewers: [],
       deployConfigured: false,
     },

--- a/test/issue-log.test.ts
+++ b/test/issue-log.test.ts
@@ -30,6 +30,23 @@ test("open+green+reviewer handoff → one waiting entry naming the reviewer", ()
   ]);
 });
 
+test("open+green+reviewBlock → one changes-requested entry, not passive waiting", () => {
+  const e = issueLogEntries(
+    open({
+      handoff: "reviewer",
+      handoffWho: "scoop",
+      reviewBlock: { reviewer: "scoop", state: "changes_requested", latestAt: 1 },
+    }),
+    never,
+  );
+  expect(e).toEqual([
+    {
+      key: "changes-requested:7",
+      body: stamped("⚠️ Changes requested on PR #7 by @scoop."),
+    },
+  ]);
+});
+
 test("open+green+merger handoff → one waiting entry naming the merger", () => {
   const e = issueLogEntries(open({ handoff: "merger", handoffWho: "scoop" }), never);
   expect(e).toEqual([{ key: "waiting:7", body: stamped("⏸️ Waiting on @scoop to merge PR #7.") }]);

--- a/test/pr-poller.test.ts
+++ b/test/pr-poller.test.ts
@@ -34,6 +34,32 @@ test("gitStateChanged: false when running-checks only reorders (set-equal)", () 
   ).toBe(false);
 });
 
+test("gitStateChanged: true when reviewerStates or reviewBlock changes", () => {
+  const prev = openGit({
+    checks: "success",
+    latestReview: { state: "changes_requested", author: "scoop", submittedAt: 1 },
+  });
+  expect(
+    gitStateChanged(prev, {
+      ...prev,
+      reviewerStates: { scoop: { state: "changes_requested", latestAt: 1 } },
+    }),
+  ).toBe(true);
+  expect(
+    gitStateChanged(
+      {
+        ...prev,
+        reviewerStates: { scoop: { state: "changes_requested", latestAt: 1 } },
+      },
+      {
+        ...prev,
+        reviewerStates: { scoop: { state: "changes_requested", latestAt: 1 } },
+        reviewBlock: { reviewer: "scoop", state: "changes_requested", latestAt: 1 },
+      },
+    ),
+  ).toBe(true);
+});
+
 const baseSession = {
   name: "x",
   prompt: "x",

--- a/test/repo-roles.test.ts
+++ b/test/repo-roles.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { execFileSync } from "node:child_process";
 import { annotateHandoff, computeHandoff, parseRoles, normalizeLogin } from "../src/repo-roles";
 import type { GitForge, GitState, PrStatus } from "../src/forge/types";
 import { makeApp, type AppDeps } from "../src/server";
@@ -37,6 +38,16 @@ test("foreign reviewer with no approval → waiting on the reviewer", () => {
   const r = computeHandoff({ reviewer: "scoop", merger: "scoop" }, "kai", undefined);
   expect(r.handoff).toBe("reviewer");
   expect(r.handoffWho).toBe("scoop");
+});
+
+test("foreign reviewer requested changes → self handoff, not passive waiting", () => {
+  const r = computeHandoff({ reviewer: "scoop", merger: "scoop" }, "kai", undefined, [], {
+    reviewer: "scoop",
+    state: "changes_requested",
+    latestAt: 1,
+  });
+  expect(r.handoff).toBe("self");
+  expect(r.handoffWho).toBeNull();
 });
 
 test("foreign reviewer once approved falls through to the merger", () => {
@@ -128,6 +139,80 @@ test("normalizeLogin trims, drops a leading @, empties to null", () => {
   expect(normalizeLogin("  @scoop ")).toBe("scoop");
   expect(normalizeLogin("")).toBeNull();
   expect(normalizeLogin(42)).toBeNull();
+});
+
+function repoWithRoles(roles: { reviewer: string | null; merger: string | null }): string {
+  const dir = mkdtempSync(join(config.repoRoot, "shepherd-roles-git-"));
+  execFileSync("git", ["-C", dir, "init", "-b", "main"], { stdio: "ignore" });
+  execFileSync("git", ["-C", dir, "config", "user.email", "test@example.com"], {
+    stdio: "ignore",
+  });
+  execFileSync("git", ["-C", dir, "config", "user.name", "Test"], { stdio: "ignore" });
+  mkdirSync(join(dir, ".shepherd"));
+  writeFileSync(join(dir, ".shepherd", "roles.json"), `${JSON.stringify(roles)}\n`);
+  execFileSync("git", ["-C", dir, "add", ".shepherd/roles.json"], { stdio: "ignore" });
+  execFileSync("git", ["-C", dir, "commit", "-m", "roles"], { stdio: "ignore" });
+  return dir;
+}
+
+test("annotateHandoff stamps reviewBlock only for the configured reviewer", () => {
+  const dir = repoWithRoles({ reviewer: "scoop", merger: "scoop" });
+  try {
+    const g = annotateHandoff(
+      gitState({
+        checks: "success",
+        reviewerStates: {
+          scoop: { state: "changes_requested", latestAt: 1 },
+          alice: { state: "changes_requested", latestAt: 2 },
+        },
+      }),
+      dir,
+      "kai",
+    );
+    expect(g.reviewBlock).toEqual({ reviewer: "scoop", state: "changes_requested", latestAt: 1 });
+    expect(g.handoff).toBeUndefined();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("annotateHandoff preserves previous reviewerStates when a fallback payload has none", () => {
+  const dir = repoWithRoles({ reviewer: "scoop", merger: "scoop" });
+  try {
+    const prev = gitState({
+      number: 7,
+      checks: "success",
+      reviewerStates: { scoop: { state: "changes_requested", latestAt: 1 } },
+      reviewBlock: { reviewer: "scoop", state: "changes_requested", latestAt: 1 },
+    });
+    const g = annotateHandoff(gitState({ number: 7, checks: "success" }), dir, "kai", prev);
+    expect(g.reviewerStates).toEqual(prev.reviewerStates);
+    expect(g.reviewBlock).toEqual(prev.reviewBlock);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("annotateHandoff clears previous reviewBlock when a fresh empty replay arrives", () => {
+  const dir = repoWithRoles({ reviewer: "scoop", merger: "scoop" });
+  try {
+    const prev = gitState({
+      number: 7,
+      checks: "success",
+      reviewerStates: { scoop: { state: "changes_requested", latestAt: 1 } },
+      reviewBlock: { reviewer: "scoop", state: "changes_requested", latestAt: 1 },
+    });
+    const g = annotateHandoff(
+      gitState({ number: 7, checks: "success", reviewerStates: {} }),
+      dir,
+      "kai",
+      prev,
+    );
+    expect(g.reviewBlock).toBeUndefined();
+    expect(g.handoff).toBe("reviewer");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("PUT /api/repo-roles: push failure → 502 generic pushError, raw error not leaked (CodeQL #14)", async () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3065,5 +3065,16 @@
   "plangate_tip_reviewing_env": "Planprüfung läuft · {env}",
   "planpanel_reviewing_env": "Prüfe Plan · {env}",
   "feat_plan_reviewer_env_title": "Sieh, wer deinen Plan prüft",
-  "feat_plan_reviewer_env_body": "Während eine Plan-Gate-Prüfung läuft, zeigt der Prüfen-Button jetzt an, welche Coding-CLI, welches Modell und welcher Aufwand die Prüfung durchführen — so weißt du genau, wer deinen Plan vor der Ausführung kontrolliert."
+  "feat_plan_reviewer_env_body": "Während eine Plan-Gate-Prüfung läuft, zeigt der Prüfen-Button jetzt an, welche Coding-CLI, welches Modell und welcher Aufwand die Prüfung durchführen — so weißt du genau, wer deinen Plan vor der Ausführung kontrolliert.",
+  "herd_changes_requested_group": "Änderungen angefordert ({count})",
+  "herd_merge_blocked_group": "Merge blockiert ({count})",
+  "unitrow_changes_requested": "Änderungen angefordert von {reviewer}",
+  "unitrow_changes_requested_title": "PR-Änderungen angefordert von {reviewer}",
+  "unitrow_merge_blocked": "Merge blockiert",
+  "unitrow_merge_blocked_title": "Branch Protection blockiert den Merge, nachdem die Checks grün sind",
+  "unitrow_unknown_reviewer": "unbekannter Reviewer",
+  "feat_review_block_cues_title": "Review-Blocker sind auf Session-Karten sichtbar",
+  "feat_review_block_cues_body": "Wenn der konfigurierte menschliche Reviewer Änderungen anfordert, zeigen Session-Karte und Herd-Gruppen jetzt Änderungen angefordert, statt still auf diesen Reviewer zu warten.",
+  "epic_group_cue_changes_requested": "{count} mit angeforderten Änderungen",
+  "epic_group_cue_merge_blocked": "{count} Merge blockiert"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3065,5 +3065,16 @@
   "plangate_tip_reviewing_env": "Plan review is running · {env}",
   "planpanel_reviewing_env": "Reviewing · {env}",
   "feat_plan_reviewer_env_title": "See who's reviewing your plan",
-  "feat_plan_reviewer_env_body": "When a Plan Gate review is running, the Reviewing button now shows which coding CLI, model, and effort are doing the review — so you know exactly who's checking your plan before execution."
+  "feat_plan_reviewer_env_body": "When a Plan Gate review is running, the Reviewing button now shows which coding CLI, model, and effort are doing the review — so you know exactly who's checking your plan before execution.",
+  "herd_changes_requested_group": "Changes requested ({count})",
+  "herd_merge_blocked_group": "Merge blocked ({count})",
+  "unitrow_changes_requested": "Changes requested by {reviewer}",
+  "unitrow_changes_requested_title": "PR changes requested by {reviewer}",
+  "unitrow_merge_blocked": "Merge blocked",
+  "unitrow_merge_blocked_title": "Branch protection is blocking merge after checks cleared",
+  "unitrow_unknown_reviewer": "unknown reviewer",
+  "feat_review_block_cues_title": "Review blocks are visible on session cards",
+  "feat_review_block_cues_body": "When the configured human reviewer requests changes, the session card and herd groups now show Changes requested instead of quietly waiting on that reviewer.",
+  "epic_group_cue_changes_requested": "{count} with requested changes",
+  "epic_group_cue_merge_blocked": "{count} merge blocked"
 }

--- a/ui/src/lib/components/EpicGroupHeader.browser.test.ts
+++ b/ui/src/lib/components/EpicGroupHeader.browser.test.ts
@@ -36,7 +36,7 @@ const epic = (children: EpicChild[], p: Partial<Epic> = {}): Epic => ({
   ...p,
 });
 
-const noCues = { ciFailed: 0, ready: 0, blocked: 0 };
+const noCues = { ciFailed: 0, needsRework: 0, branchProtectionBlocked: 0, ready: 0, blocked: 0 };
 
 afterEach(() => {
   document.body.innerHTML = "";
@@ -98,12 +98,14 @@ describe("EpicGroupHeader", () => {
     render(EpicGroupHeader, {
       epic: epic([child("running", 1)]),
       collapsed: true,
-      cues: { ciFailed: 2, ready: 3, blocked: 1 },
+      cues: { ciFailed: 2, needsRework: 4, branchProtectionBlocked: 5, ready: 3, blocked: 1 },
       ontoggle: () => {},
     });
     // each chip = leading aria-hidden glyph + count, so textContent ends with the count
     expect(document.querySelector(".cue-ci")?.textContent).toContain("2");
     expect(document.querySelector(".cue-ready")?.textContent).toContain("3");
+    expect(document.querySelector(".cue-needs-rework")?.textContent).toContain("4");
+    expect(document.querySelector(".cue-branch-blocked")?.textContent).toContain("5");
     expect(document.querySelector(".cue-blocked")?.textContent).toContain("1");
     expect(document.querySelector(".cue-blocked")?.getAttribute("title")).toContain("1");
   });
@@ -114,7 +116,7 @@ describe("EpicGroupHeader", () => {
     render(EpicGroupHeader, {
       epic: epic([child("running", 1)]),
       collapsed: true,
-      cues: { ciFailed: 1, ready: 0, blocked: 1 },
+      cues: { ciFailed: 1, needsRework: 0, branchProtectionBlocked: 0, ready: 0, blocked: 1 },
       ontoggle: () => {},
     });
     const ciGlyph = document.querySelector(".cue-ci .cue-glyph")?.textContent;
@@ -133,7 +135,7 @@ describe("EpicGroupHeader", () => {
     render(EpicGroupHeader, {
       epic: epic([child("running", 1)]),
       collapsed: false,
-      cues: { ciFailed: 0, ready: 2, blocked: 0 },
+      cues: { ciFailed: 0, needsRework: 0, branchProtectionBlocked: 0, ready: 2, blocked: 0 },
       ontoggle: () => {},
     });
     expect(document.querySelector(".cue-ci")).toBeNull();

--- a/ui/src/lib/components/EpicGroupHeader.svelte
+++ b/ui/src/lib/components/EpicGroupHeader.svelte
@@ -15,7 +15,13 @@
     collapsed: boolean;
     // per-stage tallies derived from the group's children; each chip renders
     // only when its count > 0, so a collapsed group still signals attention
-    cues: { ciFailed: number; ready: number; blocked: number };
+    cues: {
+      ciFailed: number;
+      needsRework: number;
+      branchProtectionBlocked: number;
+      ready: number;
+      blocked: number;
+    };
     ontoggle: () => void;
     // an epic badge was clicked → open the backlog on this repo, scrolled to the epic
     onepic?: (repoPath: string, issueNumber: number) => void;
@@ -65,6 +71,22 @@
         title={m.epic_group_cue_ready({ count: cues.ready })}
         aria-label={m.epic_group_cue_ready({ count: cues.ready })}
         ><span class="cue-glyph" aria-hidden="true">✓</span>{cues.ready}</span
+      >
+    {/if}
+    {#if cues.needsRework > 0}
+      <span
+        class="cue cue-needs-rework"
+        title={m.epic_group_cue_changes_requested({ count: cues.needsRework })}
+        aria-label={m.epic_group_cue_changes_requested({ count: cues.needsRework })}
+        ><span class="cue-glyph" aria-hidden="true">!</span>{cues.needsRework}</span
+      >
+    {/if}
+    {#if cues.branchProtectionBlocked > 0}
+      <span
+        class="cue cue-branch-blocked"
+        title={m.epic_group_cue_merge_blocked({ count: cues.branchProtectionBlocked })}
+        aria-label={m.epic_group_cue_merge_blocked({ count: cues.branchProtectionBlocked })}
+        ><span class="cue-glyph" aria-hidden="true">!</span>{cues.branchProtectionBlocked}</span
       >
     {/if}
     {#if cues.blocked > 0}
@@ -184,6 +206,10 @@
   /* Ready to merge — green (the reserved actionable-complete hue). */
   .cue-ready {
     color: var(--color-green);
+  }
+  .cue-needs-rework,
+  .cue-branch-blocked {
+    color: var(--color-amber);
   }
   /* Needs you / blocked — the canonical blocked status token (--status-blocked). */
   .cue-blocked {

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -335,12 +335,16 @@
   // g.sessions directly via displayStatus (it's not a partition bucket).
   function cuesFor(g: { key: string; sessions: Session[] }): {
     ciFailed: number;
+    needsRework: number;
+    branchProtectionBlocked: number;
     ready: number;
     blocked: number;
   } {
     const p = groupParts.get(g.key);
     return {
       ciFailed: p?.ciFailed.length ?? 0,
+      needsRework: p?.needsRework.length ?? 0,
+      branchProtectionBlocked: p?.branchProtectionBlocked.length ?? 0,
       ready: p?.ready.length ?? 0,
       blocked: g.sessions.filter((s) => displayStatus(s, workingBlocked) === "blocked").length,
     };
@@ -441,6 +445,22 @@
         sessions: partition.reworkRunning,
         headClass: "rework-head",
         countLabel: m.herd_rework_running_group({ count: partition.reworkRunning.length }),
+        withPreview: true,
+      },
+      partition.needsRework.length > 0 && {
+        key: "needs-rework",
+        sessions: partition.needsRework,
+        headClass: "needs-rework-head",
+        countLabel: m.herd_changes_requested_group({ count: partition.needsRework.length }),
+        withPreview: true,
+      },
+      partition.branchProtectionBlocked.length > 0 && {
+        key: "branch-protection-blocked",
+        sessions: partition.branchProtectionBlocked,
+        headClass: "branch-blocked-head",
+        countLabel: m.herd_merge_blocked_group({
+          count: partition.branchProtectionBlocked.length,
+        }),
         withPreview: true,
       },
       partition.waitingOnReviewer.length > 0 && {

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -4,7 +4,7 @@ import { page } from "vitest/browser";
 import "../../app.css";
 import UnitRow from "./UnitRow.svelte";
 import { projectIcons } from "$lib/projectIcons.svelte";
-import type { HoldReason, PlanGate, Session } from "$lib/types";
+import type { GitState, HoldReason, PlanGate, Session } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
 import type { ReviewVerdict } from "$lib/types";
 
@@ -109,6 +109,15 @@ const baseGate: PlanGate = {
   updatedAt: Date.now(),
 };
 
+const openGreenGit = (over: Partial<GitState> = {}): GitState => ({
+  kind: "github",
+  state: "open",
+  checks: "success",
+  number: 7,
+  deployConfigured: false,
+  ...over,
+});
+
 beforeEach(() => {
   reviews.reviewing = {};
   reviews.map = {};
@@ -157,6 +166,32 @@ describe("UnitRow merging badge", () => {
     });
     await expect.element(page.getByText("READY")).toBeInTheDocument();
     await expect.element(page.getByText("MERGING")).not.toBeInTheDocument();
+  });
+
+  it("shows Changes requested instead of READY for a ready review-blocked session", async () => {
+    render(UnitRow, {
+      session: session({ id: "c", readyToMerge: true, status: "idle" }),
+      git: openGreenGit({
+        reviewBlock: { reviewer: "scoop", state: "changes_requested", latestAt: 1 },
+      }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+    });
+    await expect.element(page.getByText("Changes requested by scoop")).toBeInTheDocument();
+    await expect.element(page.getByText("READY")).not.toBeInTheDocument();
+  });
+
+  it("shows Merge blocked instead of READY after checks clear", async () => {
+    render(UnitRow, {
+      session: session({ id: "d", readyToMerge: true, status: "idle" }),
+      git: openGreenGit({ mergeStateStatus: "blocked" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+    });
+    await expect.element(page.getByText("Merge blocked")).toBeInTheDocument();
+    await expect.element(page.getByText("READY")).not.toBeInTheDocument();
   });
 });
 

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -43,6 +43,7 @@
   import UnitRowRight from "./unit-row/UnitRowRight.svelte";
   import { rowHold } from "$lib/hold-row";
   import { holdAwaitsOperator } from "$lib/hold";
+  import { checksCleared } from "$lib/checks-cleared";
   import {
     REVEAL_PX,
     snapOffset,
@@ -317,6 +318,17 @@
   });
 
   const reviewing = $derived(reviews.isReviewing(session.id));
+  const idleOpenCleared = $derived(
+    git?.state === "open" &&
+      checksCleared(git.checks, git.noCi) &&
+      session.status !== "running" &&
+      session.status !== "blocked" &&
+      !reviewing,
+  );
+  const changesRequested = $derived(idleOpenCleared && !!git?.reviewBlock);
+  const branchProtectionBlocked = $derived(
+    idleOpenCleared && !git?.reviewBlock && git?.mergeStateStatus === "blocked",
+  );
 
   // plan-gate row state. NOTE: `reviewing` above is the CRITIC store (reviews.isReviewing) —
   // this is the PLAN-GATE reviewer flag, a DIFFERENT store. Do not reuse the name `reviewing`.
@@ -479,7 +491,12 @@
     [
       `u-repo-${session.id}`,
       `u-sub-${session.id}`,
-      isMerging(session, nowMs) || session.readyToMerge ? `u-status-${session.id}` : null,
+      changesRequested ||
+      branchProtectionBlocked ||
+      isMerging(session, nowMs) ||
+      session.readyToMerge
+        ? `u-status-${session.id}`
+        : null,
     ]
       .filter(Boolean)
       .join(" "),

--- a/ui/src/lib/components/epic-grouping.test.ts
+++ b/ui/src/lib/components/epic-grouping.test.ts
@@ -284,27 +284,42 @@ test("ordering: within a group, members come back in STAGE_ORDER lifecycle order
   expect(groups[0].sessions.map((s) => s.id)).toEqual(["a", "r", "m"]);
 });
 
-test("ordering: reworkRunning sits after reviewerRunning and before waiting-on-reviewer", () => {
-  const e = epic("/r", 100, [1, 2, 3]);
+test("ordering: review-blocked and branch-blocked sit before waiting-on-reviewer", () => {
+  const e = epic("/r", 100, [1, 2, 3, 4, 5]);
   const epics = { [key("/r", 100)]: e };
   const active = new Set([key("/r", 100)]);
 
   const wait = session("wait", "/r", 1, "idle");
   const rework = session("rework", "/r", 2, "running");
   const review = session("review", "/r", 3, "running");
+  const needs = session("needs", "/r", 4, "idle");
+  const branch = session("branch", "/r", 5, "idle");
 
   const { groups } = groupSessionsByEpic(
-    [wait, rework, review],
+    [wait, rework, review, needs, branch],
     epics,
     active,
-    { wait: { ...git("open", "success"), handoff: "reviewer", handoffWho: "scoop" } },
+    {
+      wait: { ...git("open", "success"), handoff: "reviewer", handoffWho: "scoop" },
+      needs: {
+        ...git("open", "success"),
+        reviewBlock: { reviewer: "scoop", state: "changes_requested", latestAt: 1 },
+      },
+      branch: { ...git("open", "success"), mergeStateStatus: "blocked" },
+    },
     (id) => id === "review",
     now,
     (s) => s.id === "rework",
   );
 
   expect(groups).toHaveLength(1);
-  expect(groups[0].sessions.map((s) => s.id)).toEqual(["review", "rework", "wait"]);
+  expect(groups[0].sessions.map((s) => s.id)).toEqual([
+    "review",
+    "rework",
+    "needs",
+    "branch",
+    "wait",
+  ]);
 });
 
 test("issueNumber == null never groups", () => {

--- a/ui/src/lib/components/herd-keynav.test.ts
+++ b/ui/src/lib/components/herd-keynav.test.ts
@@ -266,13 +266,22 @@ test("railOrder mirrors the template across ≥2 groups + rest over ≥2 stages"
 test("railOrder places reworkRunning after reviewerRunning and before waiting groups", () => {
   const list = [
     session("wait", false, "idle"),
+    session("branch", false, "idle"),
+    session("needs", false, "idle"),
     session("rework"),
     session("review"),
     session("active"),
   ];
   const order = railOrder(
     list,
-    { wait: { ...git("open", "success"), handoff: "reviewer", handoffWho: "scoop" } },
+    {
+      wait: { ...git("open", "success"), handoff: "reviewer", handoffWho: "scoop" },
+      needs: {
+        ...git("open", "success"),
+        reviewBlock: { reviewer: "scoop", state: "changes_requested", latestAt: 1 },
+      },
+      branch: { ...git("open", "success"), mergeStateStatus: "blocked" },
+    },
     (id) => id === "review",
     1000,
     "all",
@@ -283,7 +292,7 @@ test("railOrder places reworkRunning after reviewerRunning and before waiting gr
     (s) => s.id === "rework",
   );
 
-  expect(order).toEqual(["active", "review", "rework", "wait"]);
+  expect(order).toEqual(["active", "review", "rework", "needs", "branch", "wait"]);
 });
 
 test("cycleId steps down and up through the order", () => {

--- a/ui/src/lib/components/herd-partition.test.ts
+++ b/ui/src/lib/components/herd-partition.test.ts
@@ -198,6 +198,65 @@ test("operator-parked ready wins over green CI (awaitingMerge)", () => {
   expect(ready.map((s) => s.id)).toEqual(["r"]);
 });
 
+test("idle green PR with reviewBlock lands in needsRework", () => {
+  const list = [session("r", false, "idle")];
+  const p = partitionSessions(list, {
+    r: {
+      ...git("open", "success"),
+      reviewBlock: { reviewer: "scoop", state: "changes_requested", latestAt: 1 },
+    },
+  });
+  expect(p.needsRework.map((s) => s.id)).toEqual(["r"]);
+  expect(p.waitingOnReviewer).toHaveLength(0);
+});
+
+test("readyToMerge plus idle reviewBlock is shown as changes requested", () => {
+  const list = [session("r", true, "idle")];
+  const p = partitionSessions(list, {
+    r: {
+      ...git("open", "success"),
+      reviewBlock: { reviewer: "scoop", state: "changes_requested", latestAt: 1 },
+    },
+  });
+  expect(p.needsRework.map((s) => s.id)).toEqual(["r"]);
+  expect(p.ready).toHaveLength(0);
+});
+
+test("readyToMerge plus reviewBlock remains ready while a review is running", () => {
+  const list = [session("r", true, "idle")];
+  const p = partitionSessions(
+    list,
+    {
+      r: {
+        ...git("open", "success"),
+        reviewBlock: { reviewer: "scoop", state: "changes_requested", latestAt: 1 },
+      },
+    },
+    (id) => id === "r",
+  );
+  expect(p.ready.map((s) => s.id)).toEqual(["r"]);
+  expect(p.needsRework).toHaveLength(0);
+});
+
+test("cleared branch-protection block lands in branchProtectionBlocked", () => {
+  const list = [session("b", false, "idle")];
+  const p = partitionSessions(list, {
+    b: { ...git("open", "success"), mergeStateStatus: "blocked" },
+  });
+  expect(p.branchProtectionBlocked.map((s) => s.id)).toEqual(["b"]);
+});
+
+test("pending and failing checks outrank branch-protection blocked", () => {
+  const list = [session("pending", false, "idle"), session("failed", false, "idle")];
+  const p = partitionSessions(list, {
+    pending: { ...git("open", "pending"), mergeStateStatus: "blocked" },
+    failed: { ...git("open", "failure"), mergeStateStatus: "blocked" },
+  });
+  expect(p.ciRunning.map((s) => s.id)).toEqual(["pending"]);
+  expect(p.ciFailed.map((s) => s.id)).toEqual(["failed"]);
+  expect(p.branchProtectionBlocked).toHaveLength(0);
+});
+
 test("a session under review lands in the reviewerRunning group", () => {
   const list = [session("a"), session("rv"), session("b")];
   const { active, reviewerRunning } = partitionSessions(list, {}, (id) => id === "rv");
@@ -257,17 +316,33 @@ test("idle changes-requested with failed CI stays in ciFailed, not reworkRunning
 test("flattenByStage places reworkRunning after reviewerRunning and before waiting groups", () => {
   const list = [
     session("wait", false, "idle"),
+    session("branch", false, "idle"),
+    session("needs", false, "idle"),
     session("rework"),
     session("review"),
     session("active"),
   ];
   const p = partitionSessions(
     list,
-    { wait: gitHandoff("reviewer", "scoop") },
+    {
+      wait: gitHandoff("reviewer", "scoop"),
+      needs: {
+        ...git("open", "success"),
+        reviewBlock: { reviewer: "scoop", state: "changes_requested", latestAt: 1 },
+      },
+      branch: { ...git("open", "success"), mergeStateStatus: "blocked" },
+    },
     (id) => id === "review",
     (s) => s.id === "rework",
   );
-  expect(flattenByStage(p).map((s) => s.id)).toEqual(["active", "review", "rework", "wait"]);
+  expect(flattenByStage(p).map((s) => s.id)).toEqual([
+    "active",
+    "review",
+    "rework",
+    "needs",
+    "branch",
+    "wait",
+  ]);
 });
 
 test("reviewing wins over pending CI when both apply", () => {

--- a/ui/src/lib/components/herd-partition.ts
+++ b/ui/src/lib/components/herd-partition.ts
@@ -9,6 +9,8 @@ import { isMerging } from "./merge-train";
  *  - ciFailed: open PR whose CI checks failed (`open` + `failure`) — done, needs a look
  *  - reviewerRunning: a critic run is in flight for the session
  *  - reworkRunning: the task agent is actively addressing plan-gate or critic requested changes
+ *  - needsRework: the configured reviewer has active requested changes on an idle green PR.
+ *  - branchProtectionBlocked: the forge reports protected-branch merge blocked after checks clear.
  *  - draftAwaitingSignoff: open DRAFT PR, CI green (`open` + `success` + `isDraft`) AND
  *    the agent is not actively in the loop — parked, awaiting human sign-off before merge.
  *    Never reads as the green "Your turn" state; rendered in slate (parked, not actionable).
@@ -30,7 +32,7 @@ import { isMerging } from "./merge-train";
  *
  *  First-match precedence (terminal states win; reviewing/rework beat the CI/merge stages
  *  as the later in-flight stage):
- *    merged > merging > ready > reviewerRunning > reworkRunning > ciRunning > ciFailed >
+ *    merged > merging > needsRework > branchProtectionBlocked > ready > reviewerRunning > reworkRunning > ciRunning > ciFailed >
  *    draftAwaitingSignoff > (waitingOnReviewer | waitingOnMerger | awaitingMerge) > active.
  *  A draft outranks the handed-off groups: a green idle DRAFT is awaiting sign-off
  *  regardless of who the roles file names. An open PR with `none` checks (no CI reported
@@ -49,6 +51,8 @@ type Stage =
   | "ready"
   | "reviewerRunning"
   | "reworkRunning"
+  | "needsRework"
+  | "branchProtectionBlocked"
   | "ciRunning"
   | "ciFailed"
   | "draftAwaitingSignoff"
@@ -120,12 +124,32 @@ function terminalStage(
 ): Stage | null {
   if (g?.state === "merged") return "merged";
   if (isMerging(s, now)) return "merging";
+  const idleOpenCleared = isIdleOpenCleared(s, g, isReviewing, isReworkRunning);
+  if (idleOpenCleared && g.reviewBlock) return "needsRework";
+  if (idleOpenCleared && !g.reviewBlock && g.mergeStateStatus === "blocked")
+    return "branchProtectionBlocked";
   if (s.readyToMerge) return "ready";
   if (isReviewing(s.id)) return "reviewerRunning";
   if (isReworkRunning(s)) return "reworkRunning";
   if (g?.state === "open" && g.checks === "pending") return "ciRunning";
   if (g?.state === "open" && g.checks === "failure") return "ciFailed";
   return null;
+}
+
+function isIdleOpenCleared(
+  s: Session,
+  g: GitState | undefined,
+  isReviewing: (id: string) => boolean,
+  isReworkRunning: (session: Session) => boolean,
+): g is GitState & { state: "open" } {
+  return (
+    g?.state === "open" &&
+    checksCleared(g.checks, g.noCi) &&
+    s.status !== "running" &&
+    s.status !== "blocked" &&
+    !isReviewing(s.id) &&
+    !isReworkRunning(s)
+  );
 }
 
 /** Bucket a green, idle (handed-off) PR: a draft awaits sign-off; otherwise a foreign
@@ -171,6 +195,8 @@ const STAGE_ORDER = [
   "ciFailed",
   "reviewerRunning",
   "reworkRunning",
+  "needsRework",
+  "branchProtectionBlocked",
   "waitingOnReviewer",
   "waitingOnMerger",
   "draftAwaitingSignoff",
@@ -197,6 +223,8 @@ export function partitionSessions(
   ciFailed: Session[];
   reviewerRunning: Session[];
   reworkRunning: Session[];
+  needsRework: Session[];
+  branchProtectionBlocked: Session[];
   draftAwaitingSignoff: Session[];
   waitingOnReviewer: Session[];
   waitingOnMerger: Session[];
@@ -211,6 +239,8 @@ export function partitionSessions(
     ciFailed: [],
     reviewerRunning: [],
     reworkRunning: [],
+    needsRework: [],
+    branchProtectionBlocked: [],
     draftAwaitingSignoff: [],
     waitingOnReviewer: [],
     waitingOnMerger: [],

--- a/ui/src/lib/components/herd/HerdEpicGroups.svelte
+++ b/ui/src/lib/components/herd/HerdEpicGroups.svelte
@@ -22,6 +22,8 @@
     collapsedKeys: Set<string>;
     cuesFor: (g: { key: string; sessions: import("$lib/types").Session[] }) => {
       ciFailed: number;
+      needsRework: number;
+      branchProtectionBlocked: number;
       ready: number;
       blocked: number;
     };

--- a/ui/src/lib/components/herd/HerdGroup.svelte
+++ b/ui/src/lib/components/herd/HerdGroup.svelte
@@ -178,6 +178,16 @@
     border-top: 1px solid color-mix(in srgb, var(--color-slate) 30%, var(--color-line));
   }
 
+  .needs-rework-head,
+  .branch-blocked-head {
+    display: flex;
+    align-items: center;
+    padding: 10px 8px 6px;
+    margin-top: 6px;
+    color: var(--color-amber);
+    border-top: 1px solid color-mix(in srgb, var(--color-amber) 30%, var(--color-line));
+  }
+
   /* blue section header for the landed "merged PR" group */
   .merged-head {
     display: flex;

--- a/ui/src/lib/components/unit-row/UnitRowRight.svelte
+++ b/ui/src/lib/components/unit-row/UnitRowRight.svelte
@@ -11,6 +11,7 @@
   import AutopilotBadge from "../AutopilotBadge.svelte";
   import { repoConfig } from "$lib/reviews.svelte";
   import { statusTip } from "$lib/actions/statusTip.svelte";
+  import { checksCleared } from "$lib/checks-cleared";
 
   let {
     session,
@@ -87,6 +88,18 @@
         : quotaKind === "error"
           ? m.unitrow_quota_error()
           : m.unitrow_quota_plan(),
+  );
+
+  const idleOpenCleared = $derived(
+    git?.state === "open" &&
+      checksCleared(git.checks, git.noCi) &&
+      session.status !== "running" &&
+      session.status !== "blocked" &&
+      !reviewing,
+  );
+  const changesRequested = $derived(idleOpenCleared && !!git?.reviewBlock);
+  const branchProtectionBlocked = $derived(
+    idleOpenCleared && !git?.reviewBlock && git?.mergeStateStatus === "blocked",
   );
 </script>
 
@@ -214,7 +227,26 @@
       >{m.session_sandbox_unconfined_label()}</span
     >
   {/if}
-  {#if isMerging(session, nowMs)}
+  {#if changesRequested}
+    <span
+      class="badge attention"
+      id="u-status-{session.id}"
+      use:statusTip={{
+        text: m.unitrow_changes_requested_title({
+          reviewer: git?.reviewBlock?.reviewer ?? m.unitrow_unknown_reviewer(),
+        }),
+      }}
+      >{m.unitrow_changes_requested({
+        reviewer: git?.reviewBlock?.reviewer ?? m.unitrow_unknown_reviewer(),
+      })}</span
+    >
+  {:else if branchProtectionBlocked}
+    <span
+      class="badge attention"
+      id="u-status-{session.id}"
+      use:statusTip={{ text: m.unitrow_merge_blocked_title() }}>{m.unitrow_merge_blocked()}</span
+    >
+  {:else if isMerging(session, nowMs)}
     <span
       class="badge merging"
       id="u-status-{session.id}"
@@ -298,6 +330,9 @@
     text-transform: uppercase;
     color: var(--color-muted);
     white-space: nowrap;
+  }
+  .attention {
+    color: var(--color-amber);
   }
 
   /* PREVIEW: an actionable, navigational badge — opens the live app pane. Blue is

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-review-block-cues.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-review-block-cues.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "review-block-cues",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_review_block_cues_title",
+  bodyKey: "feat_review_block_cues_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -364,6 +364,11 @@ export interface PrStatus {
     author: string;
     submittedAt: number;
   };
+  /** Latest terminal human review state per reviewer, critic reviews excluded. */
+  reviewerStates?: Record<
+    string,
+    { state: "approved" | "changes_requested" | "commented"; latestAt: number | null }
+  >;
   /** true = PR is a draft / not ready-for-review. Absent ⇒ treat as false. */
   isDraft?: boolean;
 }
@@ -930,6 +935,12 @@ export interface GitState extends PrStatus {
   handoff?: "reviewer" | "merger";
   /** The login to display for {@link handoff} (e.g. "scoop"). */
   handoffWho?: string;
+  /** Role-scoped active requested-changes block for the configured reviewer. */
+  reviewBlock?: {
+    reviewer: string;
+    state: "changes_requested";
+    latestAt: number | null;
+  };
   /** Web URL of the backlog issue this session was spawned for, or absent when the
    *  session has no linked issue or the repo has no web forge (local mode). */
   issueUrl?: string;


### PR DESCRIPTION
## Summary

- Derive unscoped GitHub reviewer terminal states from fetched review history and scope the configured reviewer into a session `reviewBlock`.
- Surface idle, checks-cleared review blocks as Changes requested on session cards, herd sections, and collapsed epic cues instead of passive waiting/READY cues.
- Preserve prior reviewer state through review-less REST fallback snapshots and emit `session:git` on review-block transitions.
- Add a checked branch-protection blocked cue and prevent automerge from attempting `mergeStateStatus === "blocked"` PRs.

Follow-up for the deferred auto-steering half: #1708.

## Verification

- `bun run lint`
- `bun test test/forge/github.test.ts test/repo-roles.test.ts test/pr-poller.test.ts test/issue-log.test.ts test/automerge-core.test.ts test/automerge.test.ts`
- `cd ui && bun run check`
- `cd ui && bun run check:i18n`
- `cd ui && bun run test`

Note: `bun install` at the repo root reported a `node-pty` rebuild failure because the linker could not find `-lgcc_s`, but dependencies installed far enough for lint and targeted root tests to run. A full root `bun test`/`bun test src test` run hung after broad suites; the touched root suites listed above passed.