### PR TITLE
feat(ui): show reviewer CLI + model on the in-flight plan-review button

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1315,7 +1315,8 @@ const planGate = new PlanGateService({
   env: () => roleEnv(config.plannerCli, config.plannerModel, config.plannerEffort),
   operatorLanguage: () => config.operatorLanguage,
   onChange: (id, gate) => events.emit("session:plangate", { id, gate }),
-  onReviewing: (id, reviewing) => events.emit("session:plangate-reviewing", { id, reviewing }),
+  onReviewing: (id, reviewing, env) =>
+    events.emit("session:plangate-reviewing", { id, reviewing, env }),
   onActivity: (id, summary) => events.emit("session:plangate-activity", { id, summary }),
   cap: () => config.planReviewCyclesCap,
 });
@@ -2643,7 +2644,7 @@ const appDeps: AppDeps = {
   },
   planGateCache: {
     snapshot: () => planGate.snapshot(),
-    reviewing: () => planGate.reviewingIds(),
+    reviewing: () => planGate.reviewingInflight(),
   },
   planGate: {
     consider: (s, opts) => planGate.consider(s, opts),

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -166,8 +166,12 @@ export interface PlanGateServiceDeps extends MembraneSeams {
    *  Async since #1567: the release steers the agent, so it resolves once that steer has landed. */
   release: (sessionId: string) => Promise<void>;
   onChange: (id: string, gate: PlanGate) => void;
-  /** Fired when a plan review starts (true) and when it ends (false) for a session. */
-  onReviewing?: (id: string, reviewing: boolean) => void;
+  /** Fired when a plan review starts (true) and when it ends (false) for a session. On the
+   *  start (`true`) transition it carries the reviewer's CLI + model + effort so the UI can show
+   *  *which* coding CLI/model is doing the review before a verdict — and thus the gate's
+   *  `reviewer*` fields — exists (notably the FIRST review, where no gate is present). Absent on
+   *  the end (`false`) signal. */
+  onReviewing?: (id: string, reviewing: boolean, env?: ReviewerEnvSignal) => void;
   /**
    * Fired each tick a plan reviewer is still running, with its latest *meaningful* tool-use
    * summary (e.g. "$ git diff", "read plan"). Surfaced live in the UI review-in-flight banner
@@ -207,6 +211,15 @@ export interface PlanGateServiceDeps extends MembraneSeams {
    *  (default: readSessionUsage). null = transcript missing/unreadable → totals stay null. */
   readUsage?: (worktreePath: string, reviewerSessionId: string) => Promise<SessionUsage | null>;
 }
+
+/** The reviewer's resolved CLI + model + effort for the currently in-flight run — carried on the
+ *  reviewing=true signal (and the inflight bootstrap snapshot) so the UI can surface which coding
+ *  CLI/model is doing the review even before a gate exists. */
+export type ReviewerEnvSignal = {
+  provider: AgentProvider | null;
+  model: string | null;
+  effort: string | null;
+};
 
 interface PlanInFlight {
   sessionId: string;
@@ -473,7 +486,11 @@ export class PlanGateService {
       reviewerEffort,
       spawnedAt: this.now(),
     });
-    this.deps.onReviewing?.(session.id, true);
+    this.deps.onReviewing?.(session.id, true, {
+      provider: reviewerEnv.provider,
+      model: reviewerEnv.model,
+      effort: reviewerEffort,
+    });
     return "started";
   }
 
@@ -516,8 +533,13 @@ export class PlanGateService {
         await this.reapOrphanSpawn(sp);
         continue;
       }
-      this.inflight.set(id, await this.buildAdoptedInflight(sp, s, prior));
-      this.deps.onReviewing?.(id, true);
+      const adopted = await this.buildAdoptedInflight(sp, s, prior);
+      this.inflight.set(id, adopted);
+      this.deps.onReviewing?.(id, true, {
+        provider: adopted.reviewerProvider,
+        model: adopted.reviewerModel,
+        effort: adopted.reviewerEffort,
+      });
     }
   }
 
@@ -843,6 +865,18 @@ export class PlanGateService {
   /** Session ids with a plan review currently in flight (for client bootstrap). */
   reviewingIds(): string[] {
     return [...this.inflight.keys()];
+  }
+
+  /** In-flight plan reviews with their reviewer env — the client bootstrap snapshot so a reload
+   *  mid-review restores which CLI/model is doing the review, not just that one is running. Distinct
+   *  from `reviewingIds()`, which stays a bare `string[]` for the herd/upnext consumer. */
+  reviewingInflight(): Array<{ id: string } & ReviewerEnvSignal> {
+    return [...this.inflight.values()].map((f) => ({
+      id: f.sessionId,
+      provider: f.reviewerProvider,
+      model: f.reviewerModel,
+      effort: f.reviewerEffort,
+    }));
   }
 
   /** Worktree paths of plan reviews currently owned in-memory — the GC sweep must spare

--- a/src/server.ts
+++ b/src/server.ts
@@ -379,7 +379,14 @@ export interface AppDeps {
    *  tests that skip it. The parallel of reviewCache for the pre-execution plan gate. */
   planGateCache?: {
     snapshot(): Record<string, import("./types").PlanGate>;
-    reviewing?(): string[];
+    /** In-flight plan reviews with their reviewer env (CLI + model + effort), so a reload
+     *  mid-review restores which coding CLI/model is doing the review — not just that one runs. */
+    reviewing?(): Array<{
+      id: string;
+      provider: import("./types").AgentProvider | null;
+      model: string | null;
+      effort: string | null;
+    }>;
   };
   /** Trigger an adversarial plan review for a session on demand (the /review-plan route).
    *  Wired to PlanGateService.consider in index.ts; absent in tests that don't exercise it. */

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -111,6 +111,25 @@ test("consider spawns reviewer when a plan exists and is unreviewed", async () =
   expect(h.started[0].argv[h.started[0].argv.length - 1]).toContain("PLAN TEXT");
   expect(h.svc.reviewingIds()).toEqual(["s1"]);
 });
+test("begin carries the reviewer env on the reviewing:true signal + reviewingInflight()", async () => {
+  const reviewingEvents: any[] = [];
+  const h = harness({
+    env: () => ({ provider: "codex", model: "gpt-5.5", effort: null }),
+    onReviewing: (id: string, r: boolean, env?: unknown) => reviewingEvents.push([id, r, env]),
+  });
+  await h.svc.consider({ ...planningSession(), effort: "high" } as any);
+  // The start signal carries CLI + model + the resolved effort (env.effort null → session.effort).
+  expect(reviewingEvents).toContainEqual([
+    "s1",
+    true,
+    { provider: "codex", model: "gpt-5.5", effort: "high" },
+  ]);
+  // The inflight bootstrap snapshot exposes the same env for a mid-review reload.
+  expect(h.svc.reviewingInflight()).toEqual([
+    { id: "s1", provider: "codex", model: "gpt-5.5", effort: "high" },
+  ]);
+});
+
 test("consider: env.effort overrides session.effort (issue #1418)", async () => {
   const h = harness({ env: () => ({ provider: "claude", model: null, effort: "high" }) });
   await h.svc.consider({ ...planningSession(), effort: "low" } as any);

--- a/test/server-plan-gate.test.ts
+++ b/test/server-plan-gate.test.ts
@@ -63,13 +63,17 @@ test("GET /api/plan-gates returns {} when planGateCache is absent", async () => 
   expect(await res.json()).toEqual({});
 });
 
-test("GET /api/plan-gates/inflight returns in-flight session ids", async () => {
+test("GET /api/plan-gates/inflight returns in-flight reviews with their reviewer env", async () => {
+  const inflight = [
+    { id: "sess-1", provider: "claude" as const, model: "opus", effort: "high" },
+    { id: "sess-2", provider: null, model: null, effort: null },
+  ];
   const { app } = harness({
-    planGateCache: { snapshot: () => ({}), reviewing: () => ["sess-1", "sess-2"] },
+    planGateCache: { snapshot: () => ({}), reviewing: () => inflight },
   });
   const res = await app.fetch(new Request("http://x/api/plan-gates/inflight"));
   expect(res.status).toBe(200);
-  expect(await res.json()).toEqual(["sess-1", "sess-2"]);
+  expect(await res.json()).toEqual(inflight);
 });
 
 test("GET /api/plan-gates/inflight returns [] when planGateCache is absent", async () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3061,5 +3061,9 @@
   "viewport_diff_annotation_agent": "Agent",
   "viewport_diff_annotation_review": "Prüfung",
   "feat_diff_annotations_title": "Agenten-Notizen im Diff-Tab",
-  "feat_diff_annotations_body": "Der Diff-Tab zeigt jetzt die Begründung des Agenten direkt inline — verankert an den Zeilen, die seine Änderungen erzeugt haben — sowie Code-Review-Befunde als Banner an den betroffenen Dateien. So steht das Warum direkt neben der Änderung."
+  "feat_diff_annotations_body": "Der Diff-Tab zeigt jetzt die Begründung des Agenten direkt inline — verankert an den Zeilen, die seine Änderungen erzeugt haben — sowie Code-Review-Befunde als Banner an den betroffenen Dateien. So steht das Warum direkt neben der Änderung.",
+  "plangate_tip_reviewing_env": "Planprüfung läuft · {env}",
+  "planpanel_reviewing_env": "Prüfe Plan · {env}",
+  "feat_plan_reviewer_env_title": "Sieh, wer deinen Plan prüft",
+  "feat_plan_reviewer_env_body": "Während eine Plan-Gate-Prüfung läuft, zeigt der Prüfen-Button jetzt an, welche Coding-CLI, welches Modell und welcher Aufwand die Prüfung durchführen — so weißt du genau, wer deinen Plan vor der Ausführung kontrolliert."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3061,5 +3061,9 @@
   "viewport_diff_annotation_agent": "Agent",
   "viewport_diff_annotation_review": "Review",
   "feat_diff_annotations_title": "Agent notes in the Diff tab",
-  "feat_diff_annotations_body": "The Diff tab now shows the agent's own reasoning inline, anchored to the lines its edits produced, plus any code-review findings as banners on the files they concern — so the why behind a change lives next to the change."
+  "feat_diff_annotations_body": "The Diff tab now shows the agent's own reasoning inline, anchored to the lines its edits produced, plus any code-review findings as banners on the files they concern — so the why behind a change lives next to the change.",
+  "plangate_tip_reviewing_env": "Plan review is running · {env}",
+  "planpanel_reviewing_env": "Reviewing · {env}",
+  "feat_plan_reviewer_env_title": "See who's reviewing your plan",
+  "feat_plan_reviewer_env_body": "When a Plan Gate review is running, the Reviewing button now shows which coding CLI, model, and effort are doing the review — so you know exactly who's checking your plan before execution."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -35,6 +35,7 @@ import type {
   ProjectIcons,
   ReviewVerdict,
   PlanGate,
+  ReviewerEnv,
   RepoConfig,
   PostMergeSteps,
   RepoRoles,
@@ -1630,8 +1631,9 @@ export async function getPlanGates(): Promise<Record<string, PlanGate>> {
   return getJson("/api/plan-gates", "plan-gates");
 }
 
-/** Session ids with a plan review currently in flight (bootstrap for the reviewing indicator). */
-export async function getPlanGatesInflight(): Promise<string[]> {
+/** In-flight plan reviews with their reviewer env (bootstrap for the reviewing indicator + the
+ *  CLI/model identity shown on the in-flight button). */
+export async function getPlanGatesInflight(): Promise<Array<{ id: string } & ReviewerEnv>> {
   return getJson("/api/plan-gates/inflight", "plan-gates inflight");
 }
 

--- a/ui/src/lib/components/PlanGateBadge.svelte
+++ b/ui/src/lib/components/PlanGateBadge.svelte
@@ -5,6 +5,7 @@
   import PlanPanel from "./PlanPanel.svelte";
   import PlanGateMenu from "./PlanGateMenu.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { environmentLabel } from "$lib/reviewer-env";
   import { replySession, reviewPlan, isPlanReviewError } from "$lib/api";
   import { toasts } from "$lib/toasts.svelte";
   import { clock } from "$lib/now.svelte";
@@ -42,6 +43,20 @@
   const pulseClass = $derived(pulseReady && chip.kind === "ready" ? " pg-pulse-ready" : "");
   const stalled = $derived(planGateStalledNow(session, gate, reviewing, clock.current));
   const stalledActionsVisible = $derived(stalled);
+  // Reviewer identity (CLI · model · effort) for the in-flight run — carried on the reviewing signal
+  // (+ bootstrap); falls back to the persisted gate fields. Surfaced only in the tooltip here (the
+  // dense chip label stays short). Null when no real provider is resolved → plain reviewing tip.
+  const liveReviewEnv = $derived(planGates.reviewerEnvFor(session.id));
+  const reviewProvider = $derived(liveReviewEnv?.provider ?? gate?.reviewerProvider ?? null);
+  const reviewerIdentity = $derived(
+    reviewProvider
+      ? environmentLabel(
+          reviewProvider,
+          liveReviewEnv?.provider ? liveReviewEnv.model : gate?.reviewerModel,
+          liveReviewEnv?.provider ? liveReviewEnv.effort : gate?.reviewerEffort,
+        )
+      : null,
+  );
 
   let open = $state(false);
   let btnEl = $state<HTMLButtonElement>();
@@ -69,7 +84,9 @@
       {
         fallback: m.plangate_title(),
         planning: m.plangate_tip_planning(),
-        reviewing: m.plangate_tip_reviewing(),
+        reviewing: reviewerIdentity
+          ? m.plangate_tip_reviewing_env({ env: reviewerIdentity })
+          : m.plangate_tip_reviewing(),
         changes: m.plangate_tip_changes(),
         changesStalled: m.plangate_tip_changes_stalled(),
         ready: m.plangate_tip_ready(),

--- a/ui/src/lib/components/PlanPanel.browser.test.ts
+++ b/ui/src/lib/components/PlanPanel.browser.test.ts
@@ -94,6 +94,7 @@ afterEach(() => {
   // Clean up any seeded plan gate entries.
   planGates.map = {};
   planGates.reviewing = {};
+  planGates.reviewerEnv = {};
   vi.mocked(reviewPlan).mockReset();
   vi.mocked(reviewPlan).mockResolvedValue("skipped");
   vi.unstubAllGlobals();
@@ -469,6 +470,32 @@ describe("PlanPanel release state", () => {
     expect(vi.mocked(reviewPlan)).toHaveBeenCalledWith(id);
     // The in-flight indicator appears (the "started" bridge to the WS reviewing flag).
     await expect.element(page.getByText(m.planpanel_reviewing())).toBeVisible();
+  });
+
+  it("shows the reviewer CLI · model · effort on the in-flight button", async () => {
+    const id = "s-reviewing-env";
+    planGates.applyReviewing(id, true, { provider: "claude", model: "opus", effort: "high" });
+
+    render(PlanPanel, {
+      props: { session: session({ id }), onclose: vi.fn() },
+    });
+
+    await expect
+      .element(page.getByText(m.planpanel_reviewing_env({ env: "Claude Code · opus · High" })))
+      .toBeVisible();
+  });
+
+  it("falls back to plain Reviewing… when the in-flight reviewer provider is null", async () => {
+    const id = "s-reviewing-null-provider";
+    // An adopted-orphan run can carry a null provider; the button must never surface "unavailable".
+    planGates.applyReviewing(id, true, { provider: null, model: "opus", effort: "high" });
+
+    render(PlanPanel, {
+      props: { session: session({ id }), onclose: vi.fn() },
+    });
+
+    await expect.element(page.getByText(m.planpanel_reviewing())).toBeVisible();
+    expect(document.querySelector(".review")?.textContent).not.toContain("unavailable");
   });
 
   it("explains the required plan artifact in the planning/no-gate empty state", async () => {

--- a/ui/src/lib/components/PlanPanel.svelte
+++ b/ui/src/lib/components/PlanPanel.svelte
@@ -68,10 +68,14 @@
     liveReviewEnv?.provider ? liveReviewEnv.effort : gate?.reviewerEffort,
   );
   const reviewEnv = $derived(environmentLabel(reviewProvider, reviewModel, reviewEffort));
-  // In-flight button identity: rendered ONLY when a real (non-null) provider is known, so an
-  // adopted-orphan {provider:null,…} or the pre-first-verdict bridge window falls back to a plain
-  // "Reviewing…" rather than surfacing an ugly "unavailable · <model>" string.
-  const reviewingEnvLabel = $derived(reviewProvider ? reviewEnv : null);
+  // In-flight button identity: shows the reviewer triple ONLY when a real (non-null) provider is
+  // known, so an adopted-orphan {provider:null,…} or the pre-first-verdict bridge window falls back
+  // to a plain "Reviewing…" rather than surfacing an ugly "unavailable · <model>" string. Composed
+  // here (not inline in the template) so the branch lives in the script, keeping the <template>
+  // synthetic complexity under the Tier-1 Svelte bar (.fallowrc.jsonc).
+  const reviewingButtonLabel = $derived(
+    reviewProvider ? m.planpanel_reviewing_env({ env: reviewEnv }) : m.planpanel_reviewing(),
+  );
 
   // Render the plan + reviewer body as markdown, SANITIZED before @html. Both are
   // agent-authored — the planning agent and the reviewer ingest untrusted input (issue
@@ -452,9 +456,7 @@
             >
               {#if inFlight}
                 <span class="rev-dot" aria-hidden="true"></span><span class="rev-text"
-                  >{reviewingEnvLabel
-                    ? m.planpanel_reviewing_env({ env: reviewingEnvLabel })
-                    : m.planpanel_reviewing()}</span
+                  >{reviewingButtonLabel}</span
                 >
               {:else}
                 {m.planpanel_review_now()}

--- a/ui/src/lib/components/PlanPanel.svelte
+++ b/ui/src/lib/components/PlanPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { AgentProvider, Session } from "$lib/types";
+  import type { Session } from "$lib/types";
   import { planGates } from "$lib/reviews.svelte";
   import {
     dismissQuota,
@@ -18,8 +18,7 @@
   import { dialog } from "$lib/a11yDialog";
   import { portal } from "$lib/portal";
   import { m } from "$lib/paraglide/messages";
-  import { modelLabel } from "$lib/model-label";
-  import { effortLabel } from "$lib/effort-guidance";
+  import { environmentLabel } from "$lib/reviewer-env";
   import { DOCS_URL } from "$lib/build-info";
   import VisualReview from "./VisualReview.svelte";
 
@@ -55,32 +54,24 @@
   const planReviewBlock = $derived(canTriggerPlanReview(session, gate, reviewing));
   let envOpen = $state(false);
 
-  function providerLabel(provider: AgentProvider): string {
-    return provider === "codex" ? m.agent_provider_codex() : m.agent_provider_claude();
-  }
-
-  function environmentLabel(
-    provider: AgentProvider | null | undefined,
-    model: string | null | undefined,
-    effort: string | null | undefined,
-  ): string {
-    if (!provider) {
-      const parts: string[] = [m.planpanel_env_unavailable()];
-      if (model) parts.push(modelLabel(model));
-      if (effort) parts.push(effortLabel(effort));
-      return parts.join(" · ");
-    }
-    const modelText = model ? modelLabel(model) : m.newtask_model_default();
-    const effortText = effort ? effortLabel(effort) : m.effort_default();
-    return `${providerLabel(provider)} · ${modelText} · ${effortText}`;
-  }
-
   const planEnv = $derived(
     environmentLabel(session.agentProvider ?? "claude", session.model, session.effort),
   );
-  const reviewEnv = $derived(
-    environmentLabel(gate?.reviewerProvider, gate?.reviewerModel, gate?.reviewerEffort),
+  // Live reviewer env for the in-flight run — carried on the reviewing signal (+ bootstrap), so the
+  // CLI/model identity is known before a gate exists (notably the FIRST review). Prefer it when its
+  // provider resolved to a real CLI; else fall back to the persisted gate fields (a finished/prior
+  // round, or an adopted-orphan run whose CLI couldn't be resolved).
+  const liveReviewEnv = $derived(planGates.reviewerEnvFor(session.id));
+  const reviewProvider = $derived(liveReviewEnv?.provider ?? gate?.reviewerProvider ?? null);
+  const reviewModel = $derived(liveReviewEnv?.provider ? liveReviewEnv.model : gate?.reviewerModel);
+  const reviewEffort = $derived(
+    liveReviewEnv?.provider ? liveReviewEnv.effort : gate?.reviewerEffort,
   );
+  const reviewEnv = $derived(environmentLabel(reviewProvider, reviewModel, reviewEffort));
+  // In-flight button identity: rendered ONLY when a real (non-null) provider is known, so an
+  // adopted-orphan {provider:null,…} or the pre-first-verdict bridge window falls back to a plain
+  // "Reviewing…" rather than surfacing an ugly "unavailable · <model>" string.
+  const reviewingEnvLabel = $derived(reviewProvider ? reviewEnv : null);
 
   // Render the plan + reviewer body as markdown, SANITIZED before @html. Both are
   // agent-authored — the planning agent and the reviewer ingest untrusted input (issue
@@ -460,7 +451,11 @@
               }}
             >
               {#if inFlight}
-                <span class="rev-dot" aria-hidden="true"></span>{m.planpanel_reviewing()}
+                <span class="rev-dot" aria-hidden="true"></span><span class="rev-text"
+                  >{reviewingEnvLabel
+                    ? m.planpanel_reviewing_env({ env: reviewingEnvLabel })
+                    : m.planpanel_reviewing()}</span
+                >
               {:else}
                 {m.planpanel_review_now()}
               {/if}
@@ -762,6 +757,9 @@
     gap: 8px;
     justify-content: flex-end;
     margin-top: 2px;
+    /* Let the in-flight Review button (which now carries the CLI·model·effort triple) drop to its
+       own line instead of pushing the row past the sheet on a narrow (~320px) phone. */
+    flex-wrap: wrap;
   }
   .quota-actions {
     display: flex;
@@ -812,6 +810,16 @@
     display: inline-flex;
     align-items: center;
     gap: 6px;
+    /* When in-flight the label is the full CLI·model·effort triple. Cap it to the row and let the
+       text WRAP (not truncate) so the identity the operator asked to see stays fully legible at
+       ~320px; the dot stays pinned (flex-shrink:0 below). */
+    max-width: 100%;
+    min-width: 0;
+    flex-wrap: wrap;
+  }
+  .rev-text {
+    min-width: 0;
+    overflow-wrap: anywhere;
   }
   .quota-btn.primary {
     border-color: var(--color-amber);
@@ -824,6 +832,7 @@
     height: 6px;
     border-radius: 50%;
     background: var(--color-amber);
+    flex-shrink: 0;
     /* functional status motion — exempt from the reduced-motion blanket (app.css) */
     animation: pp-pulse 1.1s ease-in-out infinite !important;
   }

--- a/ui/src/lib/demo/state.test.ts
+++ b/ui/src/lib/demo/state.test.ts
@@ -199,6 +199,9 @@ describe("demoState mutators emit the correct WsEvent frames", () => {
     });
     expect(status).toBe("started");
     expect(events(frames)).toEqual(["session:plangate-reviewing"]);
+    // Carries a concrete non-null reviewer env so the preview shows the real CLI · model · effort.
+    const frame = frames[0];
+    expect(frame.event === "session:plangate-reviewing" && frame.data.env?.provider).toBeTruthy();
   });
 
   it("reviewPlan returns plan-unavailable without a reviewing latch when no plan gate exists", () => {

--- a/ui/src/lib/demo/state.ts
+++ b/ui/src/lib/demo/state.ts
@@ -242,7 +242,22 @@ export const demoState = {
   /** Trigger an on-demand plan review — seeded plan gates simulate a reviewer, no gate is unavailable. */
   reviewPlan(id: string): "started" | "plan-unavailable" {
     if (!world.planGates[id]) return "plan-unavailable";
-    emit({ event: "session:plangate-reviewing", data: { id, reviewing: true } });
+    // Carry a concrete non-null reviewer env so the in-flight "Reviewing…" button shows the real
+    // CLI · model · effort triple in the demo/preview (reflecting the session's own env), not the
+    // bare fallback — which is what makes the mobile-wrap behavior visible in the browser preview.
+    const s = find(id);
+    emit({
+      event: "session:plangate-reviewing",
+      data: {
+        id,
+        reviewing: true,
+        env: {
+          provider: s?.agentProvider ?? "claude",
+          model: s?.model ?? "opus",
+          effort: s?.effort ?? "high",
+        },
+      },
+    });
     return "started";
   },
 

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-plan-reviewer-env.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-plan-reviewer-env.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "plan-reviewer-env",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_plan_reviewer_env_title",
+  bodyKey: "feat_plan_reviewer_env_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/plan-gate.test.ts
+++ b/ui/src/lib/plan-gate.test.ts
@@ -27,13 +27,14 @@ describe("PlanGateStore", () => {
     expect(s.isReviewing("s1")).toBe(false);
   });
 
-  it("bootstraps from a snapshot + inflight list", () => {
+  it("bootstraps from a snapshot + inflight list, seeding reviewer env", () => {
     const s = new PlanGateStore();
     s.bootstrap({ s1: gate({ decision: "changes_requested", approved: false, findings: ["x"] }) }, [
-      "s2",
+      { id: "s2", provider: "claude", model: "opus", effort: "high" },
     ]);
     expect(s.map["s1"].findings).toEqual(["x"]);
     expect(s.isReviewing("s2")).toBe(true);
+    expect(s.reviewerEnvFor("s2")).toEqual({ provider: "claude", model: "opus", effort: "high" });
   });
 
   it("drop clears both the verdict and the reviewing flag", () => {

--- a/ui/src/lib/reviewer-env.ts
+++ b/ui/src/lib/reviewer-env.ts
@@ -3,8 +3,9 @@ import { modelLabel } from "$lib/model-label";
 import { effortLabel } from "$lib/effort-guidance";
 import type { AgentProvider } from "$lib/types";
 
-/** Localized CLI label for an agent provider (Claude Code / Codex). */
-export function providerLabel(provider: AgentProvider): string {
+/** Localized CLI label for an agent provider (Claude Code / Codex). Internal to this module —
+ *  callers compose the full env via {@link environmentLabel}. */
+function providerLabel(provider: AgentProvider): string {
   return provider === "codex" ? m.agent_provider_codex() : m.agent_provider_claude();
 }
 

--- a/ui/src/lib/reviewer-env.ts
+++ b/ui/src/lib/reviewer-env.ts
@@ -1,0 +1,29 @@
+import { m } from "$lib/paraglide/messages";
+import { modelLabel } from "$lib/model-label";
+import { effortLabel } from "$lib/effort-guidance";
+import type { AgentProvider } from "$lib/types";
+
+/** Localized CLI label for an agent provider (Claude Code / Codex). */
+export function providerLabel(provider: AgentProvider): string {
+  return provider === "codex" ? m.agent_provider_codex() : m.agent_provider_claude();
+}
+
+/** Compose a `CLI · model · effort` label for a plan/reviewer environment. A null/absent provider
+ *  degrades to a localized "unavailable" (optionally suffixed with whatever model/effort is known);
+ *  callers that must NOT surface that string (e.g. the in-flight reviewing button) should gate on a
+ *  non-null provider first. `model`/`effort` fall back to their localized "default" when absent. */
+export function environmentLabel(
+  provider: AgentProvider | null | undefined,
+  model: string | null | undefined,
+  effort: string | null | undefined,
+): string {
+  if (!provider) {
+    const parts: string[] = [m.planpanel_env_unavailable()];
+    if (model) parts.push(modelLabel(model));
+    if (effort) parts.push(effortLabel(effort));
+    return parts.join(" · ");
+  }
+  const modelText = model ? modelLabel(model) : m.newtask_model_default();
+  const effortText = effort ? effortLabel(effort) : m.effort_default();
+  return `${providerLabel(provider)} · ${modelText} · ${effortText}`;
+}

--- a/ui/src/lib/reviews.svelte.test.ts
+++ b/ui/src/lib/reviews.svelte.test.ts
@@ -269,10 +269,31 @@ test("planGates.load wipes any stale feed, even for a still-in-flight id", async
   planGates.applyReviewing("p9", true);
   planGates.setActivity("p9", "line before resync");
   vi.mocked(getPlanGates).mockResolvedValue({});
-  vi.mocked(getPlanGatesInflight).mockResolvedValue(["p9"]);
+  vi.mocked(getPlanGatesInflight).mockResolvedValue([
+    { id: "p9", provider: "claude", model: "opus", effort: "high" },
+  ]);
   await planGates.load();
   expect(planGates.isReviewing("p9")).toBe(true);
   expect(planGates.activityFeed("p9")).toEqual([]);
+});
+
+test("planGates.applyReviewing caches reviewer env and refreshes on a redundant true", () => {
+  planGates.applyReviewing("pe", true, { provider: "claude", model: "opus", effort: "high" });
+  expect(planGates.reviewerEnvFor("pe")).toEqual({
+    provider: "claude",
+    model: "opus",
+    effort: "high",
+  });
+  // A redundant `true` (no transition) must still refresh the identity.
+  planGates.applyReviewing("pe", true, { provider: "codex", model: "gpt-5.5", effort: "low" });
+  expect(planGates.reviewerEnvFor("pe")).toEqual({
+    provider: "codex",
+    model: "gpt-5.5",
+    effort: "low",
+  });
+  // End clears it.
+  planGates.applyReviewing("pe", false);
+  expect(planGates.reviewerEnvFor("pe")).toBeNull();
 });
 
 test("repoConfig.isEnabled returns true for unknown repo (default-on)", () => {

--- a/ui/src/lib/reviews.svelte.ts
+++ b/ui/src/lib/reviews.svelte.ts
@@ -1,4 +1,4 @@
-import type { ReviewVerdict, PlanGate, RepoConfig, SandboxProfile } from "./types";
+import type { ReviewVerdict, PlanGate, ReviewerEnv, RepoConfig, SandboxProfile } from "./types";
 import type { AutomationFlags } from "./components/git-rail-automation";
 import { handsOffPatch } from "./components/epic-handsoff";
 import type { RepoConfigResponse } from "./api";
@@ -132,17 +132,26 @@ export class PlanGateStore {
   map = $state<Record<string, PlanGate>>({});
   // session ids whose plan reviewer is currently in flight; driven by `session:plangate-reviewing`
   reviewing = $state<Record<string, boolean>>({});
+  // reviewer env (CLI + model + effort) of the in-flight plan reviewer, keyed by session id; carried
+  // on the `session:plangate-reviewing` start signal (+ bootstrap). Surfaced on the in-flight
+  // "Reviewing…" button so the operator sees which coding CLI/model is doing the review — even on
+  // the FIRST review, before a gate (and thus its reviewer* fields) exists.
+  reviewerEnv = $state<Record<string, ReviewerEnv>>({});
   // rolling live-activity feed (last MAX_ACTIVITY_LINES) of the in-flight plan reviewer; driven
   // by `session:plangate-activity`, surfaced in the review-in-flight banner preview. Same
   // staleness invariant as ReviewsStore: reset on both ends of a reviewing transition and wiped
   // on bootstrap so no line from a prior run or from before a reconnect leaks into a later preview.
   activity = $state<Record<string, string[]>>({});
 
-  /** Bootstrap from a GET /api/plan-gates snapshot + GET /api/plan-gates/inflight ids,
-   *  so a reload mid-review still shows verdicts and the in-flight indicator. */
-  bootstrap(map: Record<string, PlanGate>, inflightIds: string[]) {
+  /** Bootstrap from a GET /api/plan-gates snapshot + GET /api/plan-gates/inflight,
+   *  so a reload mid-review still shows verdicts, the in-flight indicator, AND which
+   *  CLI/model is doing each review. */
+  bootstrap(map: Record<string, PlanGate>, inflight: Array<{ id: string } & ReviewerEnv>) {
     this.map = map;
-    this.reviewing = Object.fromEntries(inflightIds.map((id) => [id, true]));
+    this.reviewing = Object.fromEntries(inflight.map(({ id }) => [id, true]));
+    this.reviewerEnv = Object.fromEntries(
+      inflight.map(({ id, provider, model, effort }) => [id, { provider, model, effort }]),
+    );
     // Snapshot carries no historical activity → wipe any stale feed; it rebuilds from
     // `session:plangate-activity` within ~1 tick. Covers load() (which calls through here).
     this.activity = {};
@@ -151,7 +160,7 @@ export class PlanGateStore {
   /** Re-fetch the snapshot + in-flight ids from the server (best-effort). */
   async load() {
     let map: Record<string, PlanGate> = {};
-    let inflight: string[] = [];
+    let inflight: Array<{ id: string } & ReviewerEnv> = [];
     try {
       map = await getPlanGates();
     } catch {
@@ -171,7 +180,17 @@ export class PlanGateStore {
     this.applyReviewing(id, false);
   }
 
-  applyReviewing(id: string, on: boolean) {
+  applyReviewing(id: string, on: boolean, env?: ReviewerEnv) {
+    // Env cache write runs BEFORE the transition guard below: a redundant `true` (bootstrap-then-WS
+    // interleave on reload, or a re-emitted signal) doesn't transition `reviewing`, but must still
+    // refresh the identity. On end (`false`) drop it so a stale env can't linger past the run.
+    if (on) {
+      if (env) this.reviewerEnv = { ...this.reviewerEnv, [id]: env };
+    } else if (id in this.reviewerEnv) {
+      const copy = { ...this.reviewerEnv };
+      delete copy[id];
+      this.reviewerEnv = copy;
+    }
     if (!!this.reviewing[id] === on) return;
     // Reset the feed on both ends of a transition (start = fresh empty run, end = stale tail).
     this.clearActivity(id);
@@ -181,6 +200,12 @@ export class PlanGateStore {
       delete copy[id];
       this.reviewing = copy;
     }
+  }
+
+  /** The in-flight reviewer's env (CLI + model + effort) for a session, or null when none is
+   *  known (no review running, or a run whose env hasn't arrived yet). */
+  reviewerEnvFor(id: string): ReviewerEnv | null {
+    return this.reviewerEnv[id] ?? null;
   }
 
   /** Append the in-flight plan reviewer's latest tool-use summary to its bounded rolling feed

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -579,7 +579,7 @@ export class HerdStore {
         if (ev.data.planPhase) this.patchSession(ev.data.id, { planPhase: ev.data.planPhase });
         return true;
       case "session:plangate-reviewing":
-        planGates.applyReviewing(ev.data.id, ev.data.reviewing);
+        planGates.applyReviewing(ev.data.id, ev.data.reviewing, ev.data.env);
         return true;
       case "session:plangate-activity":
         planGates.setActivity(ev.data.id, ev.data.summary);

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -473,6 +473,17 @@ export interface PlanGate {
   updatedAt: number;
 }
 
+/** The plan reviewer's resolved CLI + model + effort for the currently in-flight run. Carried on
+ *  the `session:plangate-reviewing` start signal (and the `/api/plan-gates/inflight` bootstrap) so
+ *  the UI can show which coding CLI/model is doing the review before a gate — and thus its
+ *  `reviewer*` fields — exists (notably the first review). `provider: null` for legacy /
+ *  restart-adopted reviews whose CLI couldn't be resolved. */
+export type ReviewerEnv = {
+  provider: AgentProvider | null;
+  model: string | null;
+  effort: string | null;
+};
+
 // ── visual recap blocks ──────────────────────────────────────────────────────
 // mirrors server VisualBlock union (Phase 1: rich-text + callout; file-tree + diff; Phase 2: code + more)
 export type CalloutTone = "info" | "decision" | "risk" | "warning" | "success";
@@ -1696,7 +1707,11 @@ export type WsEvent =
       // Emitted two ways: a fresh verdict carries `gate`; a phase flip carries `planPhase`.
       data: { id: string; gate?: PlanGate; planPhase?: "planning" | "executing" };
     }
-  | { event: "session:plangate-reviewing"; data: { id: string; reviewing: boolean } }
+  | {
+      event: "session:plangate-reviewing";
+      // `env` carries the reviewer CLI/model/effort on the start (reviewing:true) signal; absent on end.
+      data: { id: string; reviewing: boolean; env?: ReviewerEnv };
+    }
   | { event: "session:plangate-activity"; data: { id: string; summary: string } }
   | { event: "learnings:update"; data: { pending: number } }
   | {


### PR DESCRIPTION
## What

When a **Plan Gate** review is running, the panel's **Reviewing…** button now shows *which coding CLI, model, and effort* are doing the review — e.g. `● REVIEWING · CLAUDE CODE · OPUS 4.8 · HIGH` — instead of a bare `REVIEWING…`.

It also fixes the panel header's **Review** chip reading **"unavailable"** during the **first** review (when no gate — and thus no `reviewer*` fields — exists yet).

| Before | After |
| --- | --- |
| `● REVIEWING…` | `● REVIEWING · CLAUDE CODE · OPUS 4.8 · HIGH` |

## Why it needed plumbing (not UI-only)

The reviewer's CLI+model is chosen server-side at spawn (`plan-gate.ts` `begin()`), but the `session:plangate-reviewing` event only carried `{ id, reviewing }`, and the saved gate gets its `reviewer*` fields only *after* a verdict lands. So on the **first** review there was no client-visible source. The fix carries a small `ReviewerEnv` on the `reviewing=true` signal **and** the `/api/plan-gates/inflight` bootstrap, cached client-side keyed by session id.

## Changes

**Server**
- `plan-gate.ts`: `onReviewing` carries the reviewer env on the `true` transition (`begin` + `adoptOrphans`); new `reviewingInflight()` feeds the bootstrap snapshot. `reviewingIds()` stays `string[]` for the herd/upnext consumer.
- `index.ts` / `server.ts`: emit the env; widen the `planGateCache.reviewing` interface type.

**UI**
- `reviews.svelte.ts`: cache `reviewerEnv`; the env write runs **before** the `applyReviewing` transition guard, so a redundant `reviewing=true` (bootstrap-then-WS interleave on reload) still refreshes the identity.
- `PlanPanel.svelte` / `PlanGateBadge.svelte`: render the triple **only when the provider is non-null** — an adopted-orphan `{provider:null,…}` or the pre-first-verdict bridge window falls back to plain `Reviewing…` (never `"unavailable · <model>"`). The button label **wraps (not truncates)** and the actions row wraps, so it never overflows a ~320px phone. The badge tooltip threads the env through a localized reviewing-branch template.
- `reviewer-env.ts`: shared `environmentLabel`/`providerLabel` helper (extracted from PlanPanel).
- Demo emits a concrete env so the browser preview shows the real triple.
- Adds the `v1.44.0` feature-announcement entry + EN/DE message keys.

## Testing

- Root: `bun run typecheck`, `bun run lint`, `bun test ./test/plan-gate-service.test.ts ./test/server-plan-gate.test.ts` (116 pass) — incl. new coverage that `begin()` emits the env on the reviewing signal and `reviewingInflight()` exposes it.
- UI: `bun run check` (0 errors), `bun run check:i18n` (parity), full `bun run test` (3509 pass) — incl. new PlanPanel browser cases rendering the triple and asserting the null-provider fallback, and a store test for the redundant-`true` env refresh.
- PR-hygiene gates (branch-hygiene, feature-catalog, announcement-versions, glossary) all pass.
- Verified the ~320px wrap in the demo preview (the demo now emits a concrete env).