### PR TITLE
fix: guard incompatible Codex main models

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -118,6 +118,8 @@ export interface DiagnosticsDeps {
   /** Detect the Codex CLI auth mode (chatgpt / apikey / unknown). Default reads
    *  `~/.codex/auth.json`. Injected in tests to exercise the codex_model_auth check. */
   readCodexAuthMode?: () => CodexAuthMode;
+  /** Additional live Codex models configured outside role/global settings (repo defaults, epics). */
+  configuredCodexModels?: () => readonly (string | null)[];
 }
 
 /** A single probe: an async fn returning ONLY `{ id, state, hintKey }`. */
@@ -258,6 +260,7 @@ export class DiagnosticsService {
   private anyForgeRepo: () => boolean;
   private anyLightweightRepo: () => boolean;
   private detectCodexAuthMode: () => CodexAuthMode;
+  private configuredCodexModels: () => readonly (string | null)[];
   private last: DiagnosticsSnapshot | null = null;
   private lastAt = 0;
 
@@ -303,6 +306,7 @@ export class DiagnosticsService {
     this.anyForgeRepo = deps.anyForgeRepo ?? (() => true);
     this.anyLightweightRepo = deps.anyLightweightRepo ?? (() => false);
     this.detectCodexAuthMode = deps.readCodexAuthMode ?? readCodexAuthMode;
+    this.configuredCodexModels = deps.configuredCodexModels ?? (() => []);
   }
 
   /**
@@ -310,8 +314,9 @@ export class DiagnosticsService {
    * ChatGPT-account Codex login (the class behind silent recap failures). Returns the warning
    * check, or null when it does not apply (not chatgpt auth, or no configured model is
    * blocklisted) — so the check only surfaces as a real advisory, never as `ok` noise. Enumerates
-   * the live per-role cli/model pairs + the global default; each is resolved UNCLAMPED
-   * (authMode "unknown") to see the model that WOULD be spawned without the guard.
+   * the live per-role cli/model pairs + global default, then the injected repo/epic settings.
+   * Role/global pairs are resolved UNCLAMPED (authMode "unknown") to see the model that WOULD be
+   * spawned without the guard.
    */
   private codexModelAuthCheck(): DiagnosticCheck | null {
     if (this.detectCodexAuthMode() !== "chatgpt") return null;
@@ -323,7 +328,7 @@ export class DiagnosticsService {
       [config.docAgentCli, config.docAgentModel],
       ["inherit", "default"], // the global default (defaultAgentProvider/defaultModel)
     ];
-    const hit = pairs.some(([cli, model]) => {
+    const roleOrGlobalHit = pairs.some(([cli, model]) => {
       const env = resolveRoleEnvironment(
         cli,
         model,
@@ -339,6 +344,10 @@ export class DiagnosticsService {
         CHATGPT_INCOMPATIBLE_CODEX_MODELS.has(env.model)
       );
     });
+    const configuredHit = this.configuredCodexModels().some(
+      (model) => model !== null && CHATGPT_INCOMPATIBLE_CODEX_MODELS.has(model),
+    );
+    const hit = roleOrGlobalHit || configuredHit;
     return hit
       ? {
           id: "codex_model_auth",

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -344,6 +344,18 @@ export class DrainService {
     );
   }
 
+  private resolvedSpawnModel(
+    decision: Extract<DrainDecision, { kind: "spawn" }>,
+    repoDefaultModel: string,
+  ): string | null {
+    const settings = decision.epicProviderSettings;
+    const provider = settings?.agentProvider ?? config.defaultAgentProvider;
+    const model = settings
+      ? modelForProviderOrDefault(settings.model, settings.agentProvider)
+      : drainSpawnModel(resolveDefaultModelSetting(repoDefaultModel, config.defaultModel));
+    return this.clampCodexModel(model, provider);
+  }
+
   /** Fetch and cache the epic's structure (parent issue + sub-issues + blocked-by maps). */
   private async epicStructure(repoPath: string, run: EpicRun): Promise<EpicStructure | null> {
     const key = `${repoPath}:${run.parentIssueNumber}`;
@@ -2349,16 +2361,12 @@ export class DrainService {
       // wins over the global default; when both are unset ("inherit"/"auto") they
       // fall back to no --model flag (Claude's own default). The Fable promo is a
       // client-only UI concern and is NEVER applied to autonomous spawns.
-      const provider = epicSettings?.agentProvider ?? config.defaultAgentProvider;
-      const selectedModel = epicSettings
-        ? modelForProviderOrDefault(epicSettings.model, epicSettings.agentProvider)
-        : drainSpawnModel(resolveDefaultModelSetting(rc.defaultModel, config.defaultModel));
       session = await this.deps.service.create({
         repoPath,
         baseBranch: base,
         prompt,
         ...(epicSettings ? { agentProvider: epicSettings.agentProvider } : {}),
-        model: this.clampCodexModel(selectedModel, provider),
+        model: this.resolvedSpawnModel(decision, rc.defaultModel),
         effort: epicSettings
           ? epicSettings.effort
           : drainSpawnEffort(resolveDefaultEffortSetting(rc.defaultEffort, config.defaultEffort)),

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -96,10 +96,13 @@ const LANDING_REPAIR_CAP = 1;
 const LAND_MERGE_ERROR_CAP = 3;
 const LAND_MERGE_BACKOFF_MS = 300_000;
 import {
+  clampCodexModelForAuth,
   drainSpawnModel,
   modelForProviderOrDefault,
   resolveDefaultModelSetting,
+  type CodexAuthMode,
 } from "./default-model";
+import { readCodexAuthMode } from "./codex-auth";
 import { drainSpawnEffort, resolveDefaultEffortSetting } from "./default-effort";
 import {
   resolveProfile,
@@ -214,6 +217,8 @@ export interface DrainDeps {
    *  with an FS backend, so a drain-spawned autonomous session is refused-loud when egress
    *  is unavailable. */
   detectEgressBackend?: () => EgressBackend;
+  /** Live Codex auth mode; read per model resolution because login mode can change at runtime. */
+  readCodexAuthMode?: () => CodexAuthMode;
   /** #1071: maximum genuine rebase attempts (cap budget). Wired from config.autoMergeRebaseCap
    *  in index.ts; injected directly so tests can set a small cap without touching global config. */
   rebaseCap: number;
@@ -329,6 +334,14 @@ export class DrainService {
    *  (not `?? real()`) since the seam legitimately returns null. */
   private detectEgressBackend(): EgressBackend {
     return this.deps.detectEgressBackend ? this.deps.detectEgressBackend() : detectEgressBackend();
+  }
+
+  private clampCodexModel(model: string | null, provider: "claude" | "codex"): string | null {
+    return clampCodexModelForAuth(
+      model,
+      provider,
+      this.deps.readCodexAuthMode?.() ?? readCodexAuthMode(),
+    );
   }
 
   /** Fetch and cache the epic's structure (parent issue + sub-issues + blocked-by maps). */
@@ -1725,8 +1738,9 @@ export class DrainService {
     const lastFail = this.repairSpawnCooldown.get(key);
     if (lastFail !== undefined && this.now() - lastFail < SPAWN_FAIL_COOLDOWN_MS) return; // recent refusal
     const head = pr.headSha ?? "";
-    const cfgModel = drainSpawnModel(
-      resolveDefaultModelSetting(cfg.defaultModel, config.defaultModel),
+    const cfgModel = this.clampCodexModel(
+      drainSpawnModel(resolveDefaultModelSetting(cfg.defaultModel, config.defaultModel)),
+      config.defaultAgentProvider,
     );
     const cfgEffort = drainSpawnEffort(
       resolveDefaultEffortSetting(cfg.defaultEffort, config.defaultEffort),
@@ -2335,14 +2349,16 @@ export class DrainService {
       // wins over the global default; when both are unset ("inherit"/"auto") they
       // fall back to no --model flag (Claude's own default). The Fable promo is a
       // client-only UI concern and is NEVER applied to autonomous spawns.
+      const provider = epicSettings?.agentProvider ?? config.defaultAgentProvider;
+      const selectedModel = epicSettings
+        ? modelForProviderOrDefault(epicSettings.model, epicSettings.agentProvider)
+        : drainSpawnModel(resolveDefaultModelSetting(rc.defaultModel, config.defaultModel));
       session = await this.deps.service.create({
         repoPath,
         baseBranch: base,
         prompt,
         ...(epicSettings ? { agentProvider: epicSettings.agentProvider } : {}),
-        model: epicSettings
-          ? modelForProviderOrDefault(epicSettings.model, epicSettings.agentProvider)
-          : drainSpawnModel(resolveDefaultModelSetting(rc.defaultModel, config.defaultModel)),
+        model: this.clampCodexModel(selectedModel, provider),
         effort: epicSettings
           ? epicSettings.effort
           : drainSpawnEffort(resolveDefaultEffortSetting(rc.defaultEffort, config.defaultEffort)),

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,7 @@ import { preflightHerdr } from "./preflight";
 import { resolveNodeHost, TailscaleServeService } from "./tailscale";
 import {
   drainSpawnModel,
+  modelForProviderOrDefault,
   normalizeDefaultModelSetting,
   normalizeFableAvailable,
   normalizeRoleCli,
@@ -631,6 +632,7 @@ const telemetry = new TelemetryService({
 
 const service = new SessionService({
   store,
+  readCodexAuthMode,
   worktree,
   herdr,
   resolveForge,
@@ -1757,6 +1759,7 @@ events.subscribe((event, data) => {
 // core (computeNext) with side effects here; driven off the same poller events.
 const drain = new DrainService({
   store,
+  readCodexAuthMode,
   service,
   resolveForge,
   prCache: prPoller, // has snapshot()
@@ -2465,6 +2468,18 @@ const diagnostics = new DiagnosticsService({
     listRepos(config.repoRoot).some((r) => store.getRepoConfig(r.path).repoMode === "forge"),
   anyLightweightRepo: () =>
     listRepos(config.repoRoot).some((r) => store.getRepoConfig(r.path).repoMode === "lightweight"),
+  configuredCodexModels: () => [
+    ...(config.defaultAgentProvider === "codex"
+      ? listRepos(config.repoRoot).map((r) => {
+          const setting = store.getRepoConfig(r.path).defaultModel;
+          return drainSpawnModel(setting === "inherit" ? config.defaultModel : setting);
+        })
+      : []),
+    ...store
+      .listEpicRuns()
+      .filter((run) => run.agentProvider === "codex")
+      .map((run) => modelForProviderOrDefault(run.model ?? null, "codex")),
+  ],
 });
 // Adaptive background re-check (NOT a fixed setInterval): each tick probes, pushes the
 // snapshot, then re-arms itself with a delay chosen from that snapshot — 60s while the
@@ -2587,6 +2602,7 @@ deferredStarts.push(() => {
 const appDeps: AppDeps = {
   store,
   service,
+  readCodexAuthMode,
   telemetry,
   learnings: learningsSvc,
   repoConfig: repoConfigSvc,

--- a/src/server.ts
+++ b/src/server.ts
@@ -190,8 +190,11 @@ import {
   resolveDefaultModelSetting,
   normalizeRoleCli,
   normalizeRoleModelToken,
+  clampCodexModelForAuth,
   modelCompatibleWithProvider,
+  type CodexAuthMode,
 } from "./default-model";
+import { readCodexAuthMode } from "./codex-auth";
 import {
   normalizeDefaultEffortSetting,
   normalizeRepoDefaultEffortSetting,
@@ -249,6 +252,8 @@ export interface AppDeps {
   store: SessionStore;
   service: SessionService;
   events: EventHub;
+  /** Live Codex auth mode; optional for tests and read on demand in production. */
+  readCodexAuthMode?: () => CodexAuthMode;
   /** Anonymous product telemetry (Aptabase). `event()` itself no-ops unless consent is
    *  granted (config.telemetryConsent === "granted") and DO_NOT_TRACK isn't set. Optional
    *  so the many test `makeDeps()` builders need no change; wired to the real
@@ -6473,6 +6478,23 @@ async function handleEpicPut({ req, parts, url, deps }: Ctx): Promise<Response |
     storedForPut && storedForPut.parentIssueNumber === parentNumber
       ? storedForPut
       : defaultEpicRun(dir, parentNumber);
+  const effectiveProvider = mergedEpicRunAgentProvider(base, patch);
+  if (
+    patchHas(patch, "model") &&
+    typeof patch.model === "string" &&
+    effectiveProvider === "codex" &&
+    clampCodexModelForAuth(
+      patch.model,
+      effectiveProvider,
+      deps.readCodexAuthMode?.() ?? readCodexAuthMode(),
+    ) === null
+  )
+    return json(
+      {
+        error: `model "${patch.model}" is not supported when using Codex with a ChatGPT account`,
+      },
+      400,
+    );
   const merged = mergeEpicRunPatch(base, patch);
   if (merged === null) return json({ error: "invalid epic run patch" }, 400);
   deps.store.setEpicRun(merged);

--- a/src/server.ts
+++ b/src/server.ts
@@ -6030,6 +6030,18 @@ function mergedEpicRunAgentProvider(base: EpicRun, patch: EpicRunPatch): AgentPr
     : (base.agentProvider ?? null);
 }
 
+function incompatibleEpicModelForAuth(
+  base: EpicRun,
+  patch: EpicRunPatch,
+  authMode: CodexAuthMode,
+): string | null {
+  if (!patchHas(patch, "model") || typeof patch.model !== "string") return null;
+  const provider = mergedEpicRunAgentProvider(base, patch);
+  return provider === "codex" && clampCodexModelForAuth(patch.model, provider, authMode) === null
+    ? patch.model
+    : null;
+}
+
 function inheritedEpicProviderSettings(
   patch: EpicRunPatch,
 ): Pick<EpicRun, "agentProvider" | "model" | "effort"> | null {
@@ -6458,10 +6470,13 @@ function kickDrainOnEpicStart(
   void drain.tick().catch((err) => console.warn("[epic] start tick:", err));
 }
 
+function isEpicPutRequest(req: Request, parts: string[]): boolean {
+  return req.method === "PUT" && parts[0] === "api" && parts[1] === "epic" && !parts[2];
+}
+
 // PUT /api/epic?repo=&parent= — patch the EpicRun settings, re-assemble, emit.
 async function handleEpicPut({ req, parts, url, deps }: Ctx): Promise<Response | null> {
-  if (!(req.method === "PUT" && parts[0] === "api" && parts[1] === "epic" && !parts[2]))
-    return null;
+  if (!isEpicPutRequest(req, parts)) return null;
   const dir = safeRepoDir(url.searchParams.get("repo") ?? "", config.repoRoot);
   if (!dir) return json({ error: "invalid repo" }, 400);
   const parentRaw = url.searchParams.get("parent");
@@ -6478,20 +6493,15 @@ async function handleEpicPut({ req, parts, url, deps }: Ctx): Promise<Response |
     storedForPut && storedForPut.parentIssueNumber === parentNumber
       ? storedForPut
       : defaultEpicRun(dir, parentNumber);
-  const effectiveProvider = mergedEpicRunAgentProvider(base, patch);
-  if (
-    patchHas(patch, "model") &&
-    typeof patch.model === "string" &&
-    effectiveProvider === "codex" &&
-    clampCodexModelForAuth(
-      patch.model,
-      effectiveProvider,
-      deps.readCodexAuthMode?.() ?? readCodexAuthMode(),
-    ) === null
-  )
+  const incompatibleModel = incompatibleEpicModelForAuth(
+    base,
+    patch,
+    deps.readCodexAuthMode?.() ?? readCodexAuthMode(),
+  );
+  if (incompatibleModel)
     return json(
       {
-        error: `model "${patch.model}" is not supported when using Codex with a ChatGPT account`,
+        error: `model "${incompatibleModel}" is not supported when using Codex with a ChatGPT account`,
       },
       400,
     );

--- a/src/service.ts
+++ b/src/service.ts
@@ -2834,7 +2834,8 @@ export class SessionService {
       );
     }
     const spawnModel = clampCodexModelForAuth(model, agentProvider, this.codexAuthMode());
-    const spawnInput = spawnModel === model ? resolvedInput : { ...resolvedInput, model: spawnModel };
+    const spawnInput =
+      spawnModel === model ? resolvedInput : { ...resolvedInput, model: spawnModel };
     if (model !== null && spawnModel === null)
       console.warn(
         `[spawn] codex model "${model}" unsupported by ChatGPT-account auth — using account default`,
@@ -2874,7 +2875,15 @@ export class SessionService {
             trim,
             baseUrl,
           );
-    return { agentProvider, resolvedInput, spawnInput, repoConfig, planGateOn, profileOverride, argv };
+    return {
+      agentProvider,
+      resolvedInput,
+      spawnInput,
+      repoConfig,
+      planGateOn,
+      profileOverride,
+      argv,
+    };
   }
 
   /** Fail-closed author-trust gate for AUTONOMOUS issue spawns. No-op for operator-initiated

--- a/src/service.ts
+++ b/src/service.ts
@@ -36,10 +36,13 @@ import {
 } from "./uploads";
 import { slugifyManual, isHeuristicNameStrong, NAMER_LABEL } from "./namer";
 import {
+  clampCodexModelForAuth,
   modelCompatibleWithProvider,
   modelForProviderOrDefault,
   spawnModelForAvailability,
+  type CodexAuthMode,
 } from "./default-model";
+import { readCodexAuthMode } from "./codex-auth";
 import { effortForSpawn } from "./default-effort";
 import {
   isApiKeyMode,
@@ -213,6 +216,8 @@ export interface ServiceDeps {
    *  Codex main sessions bypass pushModelFlag, so they are not downgraded. Wired from src/index.ts
    *  off usageLimits + config; absent in tests → no downgrade. Consumed by pushModelFlag. */
   usageDowngrade?: () => string | null;
+  /** Live Codex auth mode. Read per resolution/spawn because login mode can change at runtime. */
+  readCodexAuthMode?: () => CodexAuthMode;
   /** Per-session DNS-drop watcher; absent in tests that don't care → no-op. */
   egressWatcher?: Pick<EgressWatcher, "start" | "stop">;
   /** Best-effort pre-teardown hook (recap generation) — runs while the worktree still
@@ -1427,12 +1432,26 @@ function reconcileRelaunchModel(
   overrideModel: string | null | undefined,
   originalModel: string | null,
   provider: AgentProvider,
+  authMode: CodexAuthMode,
+  authPolicy: "error" | "clamp" = "error",
 ): string | null {
   const model = pickOverride(overrideModel, originalModel);
-  if (modelCompatibleWithProvider(model, provider)) return model;
-  if (overrideModel != null && overrideModel !== "default")
-    throw new Error(`model "${overrideModel}" is not valid for provider ${provider}`);
-  return null;
+  if (!modelCompatibleWithProvider(model, provider)) {
+    if (overrideModel != null && overrideModel !== "default")
+      throw new Error(`model "${overrideModel}" is not valid for provider ${provider}`);
+    return null;
+  }
+  if (
+    model !== null &&
+    clampCodexModelForAuth(model, provider, authMode) === null &&
+    overrideModel != null &&
+    overrideModel !== "default" &&
+    authPolicy === "error"
+  )
+    throw new Error(
+      `model "${overrideModel}" is not supported when using Codex with a ChatGPT account`,
+    );
+  return model;
 }
 
 /** Renderer env for the MAIN session spawn. Default: pin the classic renderer. The
@@ -2282,6 +2301,10 @@ export class SessionService {
     if (spawnModel) argv.push("--model", spawnModel);
   }
 
+  private codexAuthMode(): CodexAuthMode {
+    return this.deps.readCodexAuthMode?.() ?? readCodexAuthMode();
+  }
+
   /**
    * Push the reasoning-effort flag for `provider`, or nothing when effort is unset/unsupported.
    * The value is clamped/translated by `effortForSpawn` (Codex: no xhigh/max → high; Claude:
@@ -2435,7 +2458,8 @@ export class SessionService {
     const { input, sessionId, promptArg, planGateOn, isolated, baseUrl } = args;
     const repoConfig = this.deps.store.getRepoConfig(input.repoPath);
     const argv = ["codex", "--no-alt-screen", "--dangerously-bypass-approvals-and-sandbox"];
-    if (input.model) argv.push("--model", input.model);
+    const model = clampCodexModelForAuth(input.model, "codex", this.codexAuthMode());
+    if (model) argv.push("--model", model);
     this.pushEffortFlag(argv, input.effort, "codex");
     // Codex divergence (preserved from the prior call-site gating): the autopilot directive stands
     // down on a non-isolated session, and the per-session toggle counts. Research/plan-gate precedence
@@ -2482,7 +2506,12 @@ export class SessionService {
       "--no-alt-screen",
       "--dangerously-bypass-approvals-and-sandbox",
     ];
-    if (model) argv.push("--model", model);
+    const spawnModel = clampCodexModelForAuth(model, "codex", this.codexAuthMode());
+    if (model !== null && spawnModel === null)
+      console.warn(
+        `[resume] codex model "${model}" unsupported by ChatGPT-account auth — using account default`,
+      );
+    if (spawnModel) argv.push("--model", spawnModel);
     this.pushEffortFlag(argv, effort, "codex");
     return argv;
   }
@@ -2789,6 +2818,7 @@ export class SessionService {
     opts: { planGateOn?: boolean } = {},
   ): Promise<{
     agentProvider: AgentProvider;
+    resolvedInput: CreateSessionInput;
     spawnInput: CreateSessionInput;
     repoConfig: RepoConfig;
     planGateOn: boolean;
@@ -2797,12 +2827,18 @@ export class SessionService {
   }> {
     const agentProvider = input.agentProvider ?? config.defaultAgentProvider;
     const model = modelForProviderOrDefault(input.model, agentProvider);
-    const spawnInput = model === input.model ? input : { ...input, model };
+    const resolvedInput = model === input.model ? input : { ...input, model };
     if (input.model && model === null) {
       console.warn(
         `[spawn] dropping model "${input.model}" because it is not valid for ${agentProvider}; using provider default`,
       );
     }
+    const spawnModel = clampCodexModelForAuth(model, agentProvider, this.codexAuthMode());
+    const spawnInput = spawnModel === model ? resolvedInput : { ...resolvedInput, model: spawnModel };
+    if (model !== null && spawnModel === null)
+      console.warn(
+        `[spawn] codex model "${model}" unsupported by ChatGPT-account auth — using account default`,
+      );
 
     const repoConfig = this.deps.store.getRepoConfig(spawnInput.repoPath);
     // Plan gate (#348): provider-agnostic (TASK-413) — Codex now enters the gate too; its directive
@@ -2838,7 +2874,7 @@ export class SessionService {
             trim,
             baseUrl,
           );
-    return { agentProvider, spawnInput, repoConfig, planGateOn, profileOverride, argv };
+    return { agentProvider, resolvedInput, spawnInput, repoConfig, planGateOn, profileOverride, argv };
   }
 
   /** Fail-closed author-trust gate for AUTONOMOUS issue spawns. No-op for operator-initiated
@@ -2908,8 +2944,15 @@ export class SessionService {
         injectionHits,
         attachments,
       } = await this.composePromptArg(input, wt.worktreePath);
-      const { agentProvider, spawnInput, repoConfig, planGateOn, profileOverride, argv } =
-        await this.resolveCreateLaunch(input, wt, promptArg, sessionId, claudeSessionId);
+      const {
+        agentProvider,
+        resolvedInput,
+        spawnInput,
+        repoConfig,
+        planGateOn,
+        profileOverride,
+        argv,
+      } = await this.resolveCreateLaunch(input, wt, promptArg, sessionId, claudeSessionId);
       // Auto-refuse surfaces as a throw so the create() caller (route 4xx / drain catch) sees it.
       const outcome = await this.prepareSpawnOrThrow(argv, {
         sessionId,
@@ -2939,7 +2982,7 @@ export class SessionService {
         egressDegraded: outcome.egressDegraded,
         claudeSessionId: agentProvider === "claude" ? claudeSessionId : "",
         agentProvider,
-        model: spawnInput.model,
+        model: resolvedInput.model,
         effort: spawnInput.effort ?? null,
         auto: spawnInput.auto ?? false,
         issueNumber: spawnInput.issueRef?.number ?? null,
@@ -2953,7 +2996,7 @@ export class SessionService {
         mergeTrainPrs: spawnInput.mergeTrainPrs,
         launchMetadata: this.buildLaunchMetadata({
           input,
-          spawnInput,
+          spawnInput: resolvedInput,
           attachments,
           branch: wt.branch,
           agentProvider,
@@ -3087,6 +3130,7 @@ export class SessionService {
     originalId: string,
     issueRef?: IssueRef,
     overrides?: RelaunchOverrides,
+    authPolicy: "error" | "clamp" = "error",
   ): Promise<Session> {
     const s = this.deps.store.get(originalId);
     if (!s || s.status === "archived")
@@ -3106,7 +3150,13 @@ export class SessionService {
     // Provider/model coupling: resolve the EFFECTIVE provider and reconcile the carried model
     // against it (see reconcileRelaunchModel) so a provider switch never drags an incompatible model.
     const effectiveProvider = overrides?.agentProvider ?? s.agentProvider ?? "claude";
-    const model = reconcileRelaunchModel(overrides?.model, s.model, effectiveProvider);
+    const model = reconcileRelaunchModel(
+      overrides?.model,
+      s.model,
+      effectiveProvider,
+      this.codexAuthMode(),
+      authPolicy,
+    );
 
     // Apply overrides over the original: an ABSENT field keeps the original's value;
     // a PRESENT one (including explicit `null` for model/planGateEnabled) replaces it.
@@ -3240,7 +3290,7 @@ export class SessionService {
         // poller re-captures the new session's id (restore derives fresh regardless).
         providerSessionId: "",
         agentProvider,
-        model: launch.spawnInput.model,
+        model: launch.resolvedInput.model,
         // Mirror the create path (#1418): persist the effort actually spawned with, so a later
         // resume of this same row (post-crash) re-emits the effort the operator chose here rather
         // than reverting to whatever was stored before the replace.
@@ -3372,11 +3422,16 @@ export class SessionService {
 
     // Spawn the sibling WITHOUT an issue link; passing no `images` key makes relaunch auto-carry
     // the original's uploads so the variant runs the same task with the same attachments.
-    const variant = await this.relaunch(originalId, undefined, {
-      agentProvider: opts.agentProvider,
-      model: opts.model,
-      effort: opts.effort,
-    });
+    const variant = await this.relaunch(
+      originalId,
+      undefined,
+      {
+        agentProvider: opts.agentProvider,
+        model: opts.model,
+        effort: opts.effort,
+      },
+      "clamp",
+    );
     // Force auto-merge OFF on the variant (relaunch carries the original's setting). Autopilot
     // stays as carried so the variant still runs the task hands-off — but auto-merge must not land
     // its PR into base before the read-only comparison reads it, which would make

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -1061,4 +1061,25 @@ describe("codex_model_auth advisory", () => {
       expect(checks.find((c) => c.id === "codex_model_auth")).toBeUndefined();
     });
   });
+
+  it("warns for a blocklisted per-repo or epic Codex model under chatgpt auth", async () => {
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      readCodexAuthMode: () => "chatgpt",
+      configuredCodexModels: () => ["gpt-5.3-codex"],
+    });
+    const c = byId((await svc.check(0)).checks, "codex_model_auth");
+    expect(c.state).toBe("warning");
+    expect(c.hintKey).toBe("diagnostics_hint_codex_model_chatgpt_incompatible");
+  });
+
+  it("does NOT warn for configured Codex models under apikey auth", async () => {
+    const svc = new DiagnosticsService({
+      ...healthyDeps(),
+      readCodexAuthMode: () => "apikey",
+      configuredCodexModels: () => ["gpt-5.3-codex"],
+    });
+    const checks = (await svc.check(0)).checks;
+    expect(checks.find((c) => c.id === "codex_model_auth")).toBeUndefined();
+  });
 });

--- a/test/drain-epic-spawn-base.test.ts
+++ b/test/drain-epic-spawn-base.test.ts
@@ -109,6 +109,7 @@ function makeHarness(
     listSubIssuesImpl?: (parentNumber: number) => Promise<SubIssueRef[]>;
     listBlockedByImpl?: (issueNumber: number) => Promise<number[]>;
     noEnsureBranch?: boolean;
+    authMode?: "chatgpt" | "apikey" | "unknown";
   } = {},
 ): Harness {
   const store = new SessionStore(":memory:");
@@ -195,6 +196,7 @@ function makeHarness(
     emitArchived: () => {},
     dropPrCache: () => {},
     emitEpic: (epic) => epics.push(epic),
+    readCodexAuthMode: () => opts.authMode ?? "unknown",
     rebaseCap: 5,
   });
 
@@ -284,6 +286,43 @@ describe("epic-child spawns base on the integration branch", () => {
       effort: "high",
       issueRef: { number: CHILD },
     });
+  });
+
+  test("ChatGPT auth clamps a blocked Codex epic model before child create", async () => {
+    const subIssues: SubIssueRef[] = [
+      { number: CHILD, title: "EFI", url: "u320", body: "spec 320", closed: false, labels: [] },
+    ];
+    const h = makeHarness({
+      authMode: "chatgpt",
+      listIssuesImpl: async () => [],
+      getIssueImpl: async (n) =>
+        n === PARENT
+          ? ({
+              number: PARENT,
+              title: "EFI cluster",
+              body: "epic body",
+              url: "u327",
+              labels: [],
+              createdAt: 0,
+              assignees: [],
+            } as Issue)
+          : null,
+      listSubIssuesImpl: async () => subIssues,
+      listBlockedByImpl: async () => [],
+    });
+    h.store.setEpicRun({
+      repoPath: REPO,
+      parentIssueNumber: PARENT,
+      mode: "auto",
+      status: "running",
+      agentProvider: "codex",
+      model: "gpt-5.3-codex",
+      effort: "high",
+    });
+
+    await h.drain.pump(REPO);
+
+    expect(h.creates[0]).toMatchObject({ agentProvider: "codex", model: null });
   });
 
   test("running epic on a forge WITHOUT ensureBranch: falls back to main, never the epic branch", async () => {

--- a/test/drain-landing-repair.test.ts
+++ b/test/drain-landing-repair.test.ts
@@ -14,6 +14,7 @@ import { EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
 import type { CreateSessionInput } from "../src/types";
 import { epicIntegrationBranch } from "../src/epic-branch";
+import { config } from "../src/config";
 
 const REPO = "/repo";
 const PARENT = 327;
@@ -131,6 +132,8 @@ function makeHarness(opts: {
   autoMergeEnabled?: boolean;
   prStatus?: (branch: string) => Promise<PrStatus>;
   createThrows?: boolean;
+  repoDefaultModel?: string;
+  authMode?: "chatgpt" | "apikey" | "unknown";
 }): Harness {
   const store = new SessionStore(":memory:");
   store.setRepoConfig(REPO, {
@@ -149,7 +152,7 @@ function makeHarness(opts: {
     autoLabel: "shepherd:auto",
     usageCeilingPct: 80,
     sandboxProfile: "trusted",
-    defaultModel: "inherit",
+    defaultModel: opts.repoDefaultModel ?? "inherit",
     defaultEffort: "inherit",
     previewOpenMode: "ask",
     egressExtraHosts: [],
@@ -159,7 +162,6 @@ function makeHarness(opts: {
     preWarmEpicLandingCi: false,
     hidden: false,
   });
-
   const spy = fakeForge({ prStatus: opts.prStatus });
   const createCalls: CreateCall[] = [];
   const repairCountCalls: RepairCountCall[] = [];
@@ -202,6 +204,7 @@ function makeHarness(opts: {
     dropPrCache: () => {},
     emitEpic: () => {},
     emitEpicCompleted: () => {},
+    readCodexAuthMode: () => opts.authMode ?? "unknown",
     rebaseCap: 5,
     rebaseLandingBranch: async () => {
       harness.rebaseSeamCalls += 1;
@@ -359,6 +362,30 @@ describe("landing-repair: dispatch", () => {
     expect(input.issueRef).toBeUndefined(); // never stamp the closed epic issue
     // Durable count incremented ONLY on a successful spawn, recording the PR head.
     expect(h.repairCountCalls).toEqual([{ count: 1, head: "h1" }]);
+  });
+
+  test("ChatGPT auth clamps a blocked Codex repo default for landing repair", async () => {
+    const prior = config.defaultAgentProvider;
+    const priorModel = config.defaultModel;
+    config.defaultAgentProvider = "codex";
+    config.defaultModel = "gpt-5.3-codex";
+    try {
+      const h = makeHarness({
+        autoDrainEnabled: true,
+        prStatus: async () => redPr(),
+        repoDefaultModel: "gpt-5.3-codex",
+        authMode: "chatgpt",
+      });
+      seedOpenLanding(h);
+      spendRerunBudget(h);
+
+      await callRerunPass(h);
+
+      expect(h.createCalls[0]?.input.model).toBeNull();
+    } finally {
+      config.defaultAgentProvider = prior;
+      config.defaultModel = priorModel;
+    }
   });
 
   test("cap exhausted: landingRepairCount already 1 → no service.create", async () => {

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -158,6 +158,8 @@ function makeHarness(
     omitCloseIssue?: boolean;
     omitGetIssue?: boolean;
     createImpl?: () => Promise<void>;
+    repoDefaultModel?: string;
+    authMode?: "chatgpt" | "apikey" | "unknown";
     // Epic support
     listSubIssuesImpl?: (parentNumber: number) => Promise<SubIssueRef[]>;
     listBlockedByImpl?: (issueNumber: number) => Promise<number[]>;
@@ -180,7 +182,7 @@ function makeHarness(
     autoLabel: "shepherd:auto",
     usageCeilingPct: opts.usageCeilingPct ?? 80,
     sandboxProfile: "trusted",
-    defaultModel: "inherit",
+    defaultModel: opts.repoDefaultModel ?? "inherit",
     defaultEffort: "inherit",
     previewOpenMode: "ask",
     egressExtraHosts: [],
@@ -190,7 +192,6 @@ function makeHarness(
     preWarmEpicLandingCi: false,
     hidden: false,
   });
-
   const forgeRec: ForgeRec = {
     merges: [],
     links: [],
@@ -294,6 +295,7 @@ function makeHarness(
     dropPrCache: (id) => dropped.push(id),
     emitEpic: (epic) => epics.push(epic),
     emitSessionNew: (s) => sessionNews.push(s),
+    readCodexAuthMode: () => opts.authMode ?? "unknown",
     rebaseCap: 5,
   });
   harness.drain = drain;
@@ -333,6 +335,26 @@ test("spawn fills to cap: 3 labeled issues, maxAuto 2 → creates exactly 2 auto
   }
   // last status holds on cap
   expect(h.statuses.at(-1)?.inFlight).toBe(2);
+});
+
+test("ChatGPT auth clamps a blocked Codex repo default before drain create", async () => {
+  const prior = config.defaultAgentProvider;
+  const priorModel = config.defaultModel;
+  config.defaultAgentProvider = "codex";
+  config.defaultModel = "gpt-5.3-codex";
+  try {
+    const h = makeHarness({
+      issues: [issue(1)],
+      maxAuto: 1,
+      repoDefaultModel: "gpt-5.3-codex",
+      authMode: "chatgpt",
+    });
+    await h.drain.pump(REPO);
+    expect(h.creates[0]?.model).toBeNull();
+  } finally {
+    config.defaultAgentProvider = prior;
+    config.defaultModel = priorModel;
+  }
 });
 
 test("spawn emits session:new for the created session (UI session list is push-only)", async () => {

--- a/test/epic-server.test.ts
+++ b/test/epic-server.test.ts
@@ -131,6 +131,7 @@ type FakeDrain = NonNullable<AppDeps["drain"]>;
 function harness(opts?: {
   drainOverrides?: Partial<FakeDrain>;
   resolveForge?: AppDeps["resolveForge"];
+  authMode?: "chatgpt" | "apikey" | "unknown";
 }): { app: ReturnType<typeof makeApp>; store: SessionStore; emitted: unknown[] } {
   const store = new SessionStore(":memory:");
   const emitted: unknown[] = [];
@@ -158,6 +159,7 @@ function harness(opts?: {
     usageLimits: { limits: () => ({}) } as any,
     drain,
     resolveForge: opts?.resolveForge,
+    readCodexAuthMode: () => opts?.authMode ?? "unknown",
   };
   return { app: makeApp(deps), store, emitted };
 }
@@ -256,6 +258,44 @@ describe("PUT /api/epic", () => {
       model: "gpt-5.5",
       effort: "high",
     });
+  });
+
+  test("explicit blocked Codex model is rejected under ChatGPT auth", async () => {
+    const { app, store } = harness({ authMode: "chatgpt" });
+    const res = await app.fetch(
+      new Request(`http://x/api/epic?repo=${encRepo(repoDir)}&parent=327`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ agentProvider: "codex", model: "gpt-5.3-codex" }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: 'model "gpt-5.3-codex" is not supported when using Codex with a ChatGPT account',
+    });
+    expect(store.getEpicRun(repoDir)).toBeNull();
+  });
+
+  test("an existing blocked epic model remains stored across unrelated patches", async () => {
+    const { app, store } = harness({ authMode: "chatgpt" });
+    store.setEpicRun({
+      repoPath: repoDir,
+      parentIssueNumber: 327,
+      mode: "auto",
+      status: "idle",
+      agentProvider: "codex",
+      model: "gpt-5.3-codex",
+      effort: null,
+    });
+    const res = await app.fetch(
+      new Request(`http://x/api/epic?repo=${encRepo(repoDir)}&parent=327`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ mode: "attended" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(store.getEpicRun(repoDir)?.model).toBe("gpt-5.3-codex");
   });
 
   test("explicit agentProvider null clears model and effort to inherit", async () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { test, expect, spyOn } from "bun:test";
 import {
   mkdtempSync,
   mkdirSync,
@@ -252,7 +252,10 @@ test("createSession: session_created props map each to its own source (distinct-
 
 // Build a SessionService whose worktree.create yields the given `isolated`, capturing the
 // spawned argv. Used by the codex-autopilot directive tests below.
-function codexHarness(isolated: boolean) {
+function codexHarness(
+  isolated: boolean,
+  authMode: "chatgpt" | "apikey" | "unknown" = "unknown",
+) {
   const store = new SessionStore(":memory:");
   const calls: any = {};
   const service = new SessionService({
@@ -283,6 +286,7 @@ function codexHarness(isolated: boolean) {
       },
       list: () => [],
     } as any,
+    readCodexAuthMode: () => authMode,
   });
   return { store, service, calls };
 }
@@ -358,6 +362,44 @@ test("createSession: codex provider starts interactive codex; spawn argv carries
   expect(s.claudeSessionId).toBe("");
   expect(store.get(s.id)?.agentProvider).toBe("codex");
   expect(store.get(s.id)?.model).toBe("gpt-5.5");
+});
+
+test("createSession: ChatGPT auth omits a blocked Codex model but preserves model intent", async () => {
+  const { store, service, calls } = codexHarness(true, "chatgpt");
+  const warn = spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    const s = await service.create({
+      repoPath: "/repo",
+      baseBranch: "main",
+      prompt: "flatten it",
+      agentProvider: "codex",
+      model: "gpt-5.3-codex",
+      images: [],
+    });
+
+    expect(calls.start.argv).not.toContain("--model");
+    expect(s.model).toBe("gpt-5.3-codex");
+    expect(store.get(s.id)?.model).toBe("gpt-5.3-codex");
+    expect(warn).toHaveBeenCalledWith(
+      '[spawn] codex model "gpt-5.3-codex" unsupported by ChatGPT-account auth — using account default',
+    );
+  } finally {
+    warn.mockRestore();
+  }
+});
+
+test("createSession: API-key auth preserves a blocklisted Codex model", async () => {
+  const { service, calls } = codexHarness(true, "apikey");
+  const s = await service.create({
+    repoPath: "/repo",
+    baseBranch: "main",
+    prompt: "flatten it",
+    agentProvider: "codex",
+    model: "gpt-5.3-codex",
+    images: [],
+  });
+  expect(calls.start.argv).toContain("gpt-5.3-codex");
+  expect(s.model).toBe("gpt-5.3-codex");
 });
 
 test("createSession: codex spawn emits -c model_reasoning_effort, clamping max → high (#1417)", async () => {
@@ -2778,6 +2820,37 @@ test("resume uses codex resume --last for codex sessions", async () => {
   ]);
 });
 
+test("resume: ChatGPT auth omits a blocked legacy Codex model without changing stored intent", async () => {
+  const store = new SessionStore(":memory:");
+  const calls: any = {};
+  const svc = makeRestoreSvc(store, calls, { authMode: "chatgpt" });
+  const s = resumable(store, {
+    agentProvider: "codex",
+    claudeSessionId: "",
+    model: "gpt-5.3-codex",
+  });
+
+  await svc.resume(s.id);
+
+  expect(calls.start).not.toContain("--model");
+  expect(store.get(s.id)?.model).toBe("gpt-5.3-codex");
+});
+
+test("resume: API-key auth re-emits a blocklisted stored Codex model", async () => {
+  const store = new SessionStore(":memory:");
+  const calls: any = {};
+  const svc = makeRestoreSvc(store, calls, { authMode: "apikey" });
+  const s = resumable(store, {
+    agentProvider: "codex",
+    claudeSessionId: "",
+    model: "gpt-5.3-codex",
+  });
+
+  await svc.resume(s.id);
+
+  expect(calls.start).toContain("gpt-5.3-codex");
+});
+
 // ── reasoning effort persists across resume (issue #1417) ────────────────────────────────────
 test("resume re-emits the persisted --effort for a Claude session", async () => {
   const store = new SessionStore(":memory:");
@@ -3006,7 +3079,11 @@ function archivedWithSession(
 function makeRestoreSvc(
   store: SessionStore,
   calls: Record<string, unknown>,
-  opts: { startFails?: boolean; restoreExistingThrows?: unknown } = {},
+  opts: {
+    startFails?: boolean;
+    restoreExistingThrows?: unknown;
+    authMode?: "chatgpt" | "apikey" | "unknown";
+  } = {},
 ) {
   return new SessionService({
     store,
@@ -3032,6 +3109,7 @@ function makeRestoreSvc(
       stop: async () => {},
       send: () => {},
     } as any,
+    readCodexAuthMode: () => opts.authMode ?? "unknown",
   });
 }
 
@@ -5877,7 +5955,10 @@ test("resume of an auto session re-applies the trim: flag + plugin-off overlay",
 /** A relaunch-service harness: real store, mocked worktree/herdr/reaper.
  *  `create` makes a worktree at /wt/<name>; `archive` removes it + stops the agent.
  *  Returns the service plus a record of started/stopped/removed for assertions. */
-function relaunchHarness(store: SessionStore) {
+function relaunchHarness(
+  store: SessionStore,
+  authMode: "chatgpt" | "apikey" | "unknown" = "unknown",
+) {
   const calls: {
     started: { name: string; cwd: string; argv: string[] }[];
     stopped: string[];
@@ -5925,6 +6006,7 @@ function relaunchHarness(store: SessionStore) {
         src: i,
         copiedPath: `${worktreePath}/.shepherd-uploads/${i.split("/").pop()}`,
       })),
+    readCodexAuthMode: () => authMode,
   });
   return { service, calls, breakOverride, breakStart };
 }
@@ -6122,6 +6204,34 @@ test("relaunch does NOT archive the original", async () => {
   expect(calls.removed).not.toContain("/wt/orig"); // original worktree left in place
 });
 
+test("relaunch: ChatGPT auth clamps a carried Codex model but preserves it on the new session", async () => {
+  const store = new SessionStore(":memory:");
+  const { service, calls } = relaunchHarness(store, "chatgpt");
+  const orig = originalSession(store, {
+    agentProvider: "codex",
+    claudeSessionId: "",
+    model: "gpt-5.3-codex",
+  });
+
+  const fresh = await service.relaunch(orig.id);
+
+  expect(calls.started[0]!.argv).not.toContain("--model");
+  expect(fresh.model).toBe("gpt-5.3-codex");
+});
+
+test("relaunch: explicit blocked Codex override is a clear error under ChatGPT auth", async () => {
+  const store = new SessionStore(":memory:");
+  const { service, calls } = relaunchHarness(store, "chatgpt");
+  const orig = originalSession(store, { agentProvider: "codex", claudeSessionId: "" });
+
+  await expect(
+    service.relaunch(orig.id, undefined, { model: "gpt-5.3-codex" }),
+  ).rejects.toThrow(
+    'model "gpt-5.3-codex" is not supported when using Codex with a ChatGPT account',
+  );
+  expect(calls.started).toHaveLength(0);
+});
+
 test("replaceAgent swaps provider in the same session and worktree", async () => {
   const store = new SessionStore(":memory:");
   const { service, calls } = relaunchHarness(store);
@@ -6168,6 +6278,26 @@ test("replaceAgent swaps provider in the same session and worktree", async () =>
   expect(calls.removed).toEqual([]);
 });
 
+test("replaceAgent: ChatGPT auth clamps and warns while preserving the Codex model choice", async () => {
+  const store = new SessionStore(":memory:");
+  const { service, calls } = relaunchHarness(store, "chatgpt");
+  const orig = originalSession(store, { agentProvider: "claude" });
+  const warn = spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    const replaced = await service.replaceAgent(orig.id, {
+      agentProvider: "codex",
+      model: "gpt-5.3-codex",
+    });
+    expect(calls.started[0]!.argv).not.toContain("--model");
+    expect(replaced.model).toBe("gpt-5.3-codex");
+    expect(warn).toHaveBeenCalledWith(
+      '[spawn] codex model "gpt-5.3-codex" unsupported by ChatGPT-account auth — using account default',
+    );
+  } finally {
+    warn.mockRestore();
+  }
+});
+
 test("replaceAgent threads effort onto the spawned Claude argv (#1418)", async () => {
   const store = new SessionStore(":memory:");
   const { service, calls } = relaunchHarness(store);
@@ -6201,7 +6331,21 @@ test("startVariant threads effort onto the relaunched spawn (#1418)", async () =
   expect(argv[argv.indexOf("--effort") + 1]).toBe("high");
 });
 
-test("startComparison threads effort into the created CreateSessionInput (#1418)", async () => {
+test("startVariant: ChatGPT auth clamps and preserves an explicit blocked Codex model", async () => {
+  const store = new SessionStore(":memory:");
+  const { service, calls } = relaunchHarness(store, "chatgpt");
+  const orig = originalSession(store, { agentProvider: "claude" });
+
+  const { variant } = await service.startVariant(orig.id, {
+    agentProvider: "codex",
+    model: "gpt-5.3-codex",
+  });
+
+  expect(calls.started[0]!.argv).not.toContain("--model");
+  expect(variant.model).toBe("gpt-5.3-codex");
+});
+
+test("startComparison clamps a blocked Codex model while preserving intent and effort", async () => {
   const store = new SessionStore(":memory:");
   const calls: { start?: { name: string; cwd: string; argv: string[] } } = {};
   const service = new SessionService({
@@ -6224,6 +6368,7 @@ test("startComparison threads effort into the created CreateSessionInput (#1418)
       },
       list: () => [],
     } as any,
+    readCodexAuthMode: () => "chatgpt",
   });
 
   const v1 = store.create({
@@ -6251,12 +6396,18 @@ test("startComparison threads effort into the created CreateSessionInput (#1418)
   });
   store.setExperiment(v2.id, { experimentId: "exp-1", role: "variant" });
 
-  const created = await service.startComparison("exp-1", { model: "opus", effort: "high" });
+  const created = await service.startComparison("exp-1", {
+    agentProvider: "codex",
+    model: "gpt-5.3-codex",
+    effort: "high",
+  });
 
   expect(created.effort).toBe("high");
+  expect(created.model).toBe("gpt-5.3-codex");
   const argv = calls.start!.argv;
-  expect(argv).toContain("--effort");
-  expect(argv[argv.indexOf("--effort") + 1]).toBe("high");
+  expect(argv).not.toContain("--model");
+  expect(argv).toContain("-c");
+  expect(argv[argv.indexOf("-c") + 1]).toBe("model_reasoning_effort=high");
 });
 
 test("replaceAgent preserves an executing plan phase instead of resurrecting Codex plan-gate", async () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -252,10 +252,7 @@ test("createSession: session_created props map each to its own source (distinct-
 
 // Build a SessionService whose worktree.create yields the given `isolated`, capturing the
 // spawned argv. Used by the codex-autopilot directive tests below.
-function codexHarness(
-  isolated: boolean,
-  authMode: "chatgpt" | "apikey" | "unknown" = "unknown",
-) {
+function codexHarness(isolated: boolean, authMode: "chatgpt" | "apikey" | "unknown" = "unknown") {
   const store = new SessionStore(":memory:");
   const calls: any = {};
   const service = new SessionService({
@@ -6224,9 +6221,7 @@ test("relaunch: explicit blocked Codex override is a clear error under ChatGPT a
   const { service, calls } = relaunchHarness(store, "chatgpt");
   const orig = originalSession(store, { agentProvider: "codex", claudeSessionId: "" });
 
-  await expect(
-    service.relaunch(orig.id, undefined, { model: "gpt-5.3-codex" }),
-  ).rejects.toThrow(
+  await expect(service.relaunch(orig.id, undefined, { model: "gpt-5.3-codex" })).rejects.toThrow(
     'model "gpt-5.3-codex" is not supported when using Codex with a ChatGPT account',
   );
   expect(calls.started).toHaveLength(0);


### PR DESCRIPTION
## Summary
- clamp ChatGPT-account-incompatible Codex models at foreground create, resume, relaunch, comparison, and drain spawn boundaries while preserving stored operator intent
- reject explicit incompatible epic-run model updates with a clear 400 and extend codex_model_auth diagnostics to repo and epic settings
- add coverage for main spawns, explicit foreground entry points, epic runs, drain children, landing repair, and diagnostics

## Verification
- bun test test/service.test.ts test/epic-server.test.ts test/drain.test.ts test/drain-epic-spawn-base.test.ts test/drain-landing-repair.test.ts test/diagnostics.test.ts (508 passed)
- bun run typecheck
- bun run lint
- scripts/check-branch-hygiene.sh

Closes #1680