### PR TITLE
fix(ui): clarify Scratchpad and Worktree files

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3087,5 +3087,6 @@
   "command_source_codex_home": "Codex-Home",
   "command_source_system": "System",
   "feat_codex_discovery_title": "Codex-Skills in der Command-Discovery",
-  "feat_codex_discovery_body": "Der Prompt-Picker versteht jetzt Codex-Skills, einschließlich installierter Plugin-Skills wie $github:yeet, während installierte Codex-Plugins als Browsing-Inventar erscheinen."
+  "feat_codex_discovery_body": "Der Prompt-Picker versteht jetzt Codex-Skills, einschließlich installierter Plugin-Skills wie $github:yeet, während installierte Codex-Plugins als Browsing-Inventar erscheinen.",
+  "files_source_difference_tip": "Das Scratchpad enthält zusätzliche Dateien dieser Sitzung und bleibt vom Repository getrennt. Der Worktree ist der Projektordner des Agenten mit seinen Änderungen; hier kannst du ihn nur durchsuchen und Dateien daraus herunterladen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3087,5 +3087,6 @@
   "command_source_codex_home": "Codex home",
   "command_source_system": "System",
   "feat_codex_discovery_title": "Codex skills in command discovery",
-  "feat_codex_discovery_body": "The prompt picker now understands Codex skills, including installed plugin skills such as $github:yeet, while installed Codex plugins appear as a browsing-only inventory."
+  "feat_codex_discovery_body": "The prompt picker now understands Codex skills, including installed plugin skills such as $github:yeet, while installed Codex plugins appear as a browsing-only inventory.",
+  "files_source_difference_tip": "Scratchpad contains supplementary files for this session and stays separate from the repository. Worktree is the agent's project directory and changes; you can only browse and download it here."
 }

--- a/ui/src/lib/components/viewport/FilesPanel.browser.test.ts
+++ b/ui/src/lib/components/viewport/FilesPanel.browser.test.ts
@@ -176,6 +176,23 @@ async function clickWorktreeSegButton() {
 }
 
 describe("FilesPanel — source switch (scratchpad/worktree)", () => {
+  it("provides a shared explanation of the two file sources", async () => {
+    render(FilesPanel, { sessionId: "sess-source-info" });
+    await waitForPanel();
+
+    await expect
+      .element(
+        page.getByRole("button", {
+          name: m.newtask_info_aria({ topic: m.files_source_switch_aria() }),
+        }),
+      )
+      .toBeInTheDocument();
+    expect(document.querySelector(".info-tooltip")?.textContent?.trim()).toBe(
+      "Scratchpad contains supplementary files for this session and stays separate from the repository. Worktree is the agent's project directory and changes; you can only browse and download it here.",
+    );
+    expect(mockWorktreeListing).not.toHaveBeenCalled();
+  });
+
   it("defaults to scratchpad and fetches scratchpad listing", async () => {
     render(FilesPanel, { sessionId: "sess-6" });
     await waitForPanel();

--- a/ui/src/lib/components/viewport/FilesPanel.svelte
+++ b/ui/src/lib/components/viewport/FilesPanel.svelte
@@ -11,6 +11,7 @@
   import { m } from "$lib/paraglide/messages";
   import { relativeAge } from "$lib/format";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
+  import InfoTip from "$lib/components/InfoTip.svelte";
   import { untrack } from "svelte";
 
   // Read/upload browser of the session's scratchpad subtree (#1164, #1258). Click a directory to
@@ -238,21 +239,30 @@
   ondragleave={handleDragLeave}
   ondrop={handleDrop}
 >
-  <div class="seg-row" role="group" aria-label={m.files_source_switch_aria()}>
-    <button
-      type="button"
-      class="seg-btn"
-      class:seg-active={source === "scratchpad"}
-      aria-pressed={source === "scratchpad"}
-      onclick={() => switchSource("scratchpad")}>{m.files_source_scratchpad()}</button
-    >
-    <button
-      type="button"
-      class="seg-btn"
-      class:seg-active={source === "worktree"}
-      aria-pressed={source === "worktree"}
-      onclick={() => switchSource("worktree")}>{m.files_source_worktree()}</button
-    >
+  <div class="seg-row">
+    <div class="seg-tabs" role="group" aria-label={m.files_source_switch_aria()}>
+      <button
+        type="button"
+        class="seg-btn"
+        class:seg-active={source === "scratchpad"}
+        aria-pressed={source === "scratchpad"}
+        onclick={() => switchSource("scratchpad")}>{m.files_source_scratchpad()}</button
+      >
+      <button
+        type="button"
+        class="seg-btn"
+        class:seg-active={source === "worktree"}
+        aria-pressed={source === "worktree"}
+        onclick={() => switchSource("worktree")}>{m.files_source_worktree()}</button
+      >
+    </div>
+    <div class="seg-tip">
+      <InfoTip
+        text={m.files_source_difference_tip()}
+        label={m.newtask_info_aria({ topic: m.files_source_switch_aria() })}
+        prominent={true}
+      />
+    </div>
   </div>
   {#if dragOver}
     <!-- Whole-tab drop overlay; sits over (not inside) the scroll wrapper so it always covers the
@@ -422,8 +432,22 @@
   }
   .seg-row {
     display: flex;
+    align-items: stretch;
     border-bottom: 1px solid var(--color-line);
     flex-shrink: 0;
+  }
+  .seg-tabs {
+    display: flex;
+    flex: 1;
+    min-width: 0;
+  }
+  .seg-tip {
+    flex: 0 0 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-left: 1px solid var(--color-line);
+    background: var(--color-inset);
   }
   .seg-btn {
     flex: 1;


### PR DESCRIPTION
# Problem

The Files tab offers Scratchpad and Worktree, but does not explain what each source represents. Operators can reasonably mistake one for a view of the other.

# Solution

Add a persistent, accessible `(i)` beside the source switch. Its tooltip explains that Scratchpad holds session-specific supplemental material outside the repository, while Worktree is the agent's project directory and is browse-only here.

# Technical details

- Reuses the shared, non-modal `InfoTip` interaction for hover, keyboard, and touch access.
- Adds matching English and German copy.
- Keeps the existing source-switch behavior unchanged.
- Adds a browser regression test for the labeled explanation.

The follow-up for surfacing New Task attachments in Scratchpad is tracked in #1717.

# Validation

- `cd ui && bun run check:i18n`
- `cd ui && bun run check`
- `cd ui && bun run test:browser -- src/lib/components/viewport/FilesPanel.browser.test.ts`
- `cd ui && bun run test`