### PR TITLE
feat(new-task): preview image attachments

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3092,5 +3092,8 @@
   "newtask_provider_constraint_title": "CLI-Verfügbarkeit",
   "newtask_provider_constraint_body": "Shepherd hat {provider} ausgewählt und inkompatible CLIs deaktiviert, solange dieser Token im Prompt steht.",
   "feat_provider_availability_card_title": "Hinweise für Single-CLI-Skills",
-  "feat_provider_availability_card_body": "Neue Aufgabe zeigt jetzt eine blaue CLI-Verfügbarkeitskarte, wenn ein gewählter Command-, Skill- oder Plugin-Token nur in einer Coding-CLI läuft, damit die erzwungene Provider-Wahl vor dem Start sichtbar ist."
+  "feat_provider_availability_card_body": "Neue Aufgabe zeigt jetzt eine blaue CLI-Verfügbarkeitskarte, wenn ein gewählter Command-, Skill- oder Plugin-Token nur in einer Coding-CLI läuft, damit die erzwungene Provider-Wahl vor dem Start sichtbar ist.",
+  "newtask_preview_image_aria": "Vorschau des angehängten Bildes {name}",
+  "feat_newtask_image_preview_title": "Bilder vor dem Task-Start prüfen",
+  "feat_newtask_image_preview_body": "Fahre mit der Maus über den Dateinamen eines Bildanhangs oder fokussiere ihn, um das Bild vor dem Start zu prüfen. Tippe auf Mobilgeräten auf den Dateinamen, um die Vorschau ein- oder auszublenden."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3092,5 +3092,8 @@
   "newtask_provider_constraint_title": "CLI availability",
   "newtask_provider_constraint_body": "Shepherd selected {provider} and disabled incompatible CLIs while this token is in the prompt.",
   "feat_provider_availability_card_title": "Single-CLI skill notices",
-  "feat_provider_availability_card_body": "New Task now shows a blue CLI-availability card when a picked command, skill, or plugin token only runs in one coding CLI, so the forced provider choice is visible before launch."
+  "feat_provider_availability_card_body": "New Task now shows a blue CLI-availability card when a picked command, skill, or plugin token only runs in one coding CLI, so the forced provider choice is visible before launch.",
+  "newtask_preview_image_aria": "Preview attached image {name}",
+  "feat_newtask_image_preview_title": "Preview images before starting a task",
+  "feat_newtask_image_preview_body": "Hover or focus an image attachment's filename to check it before launch. On mobile, tap the filename to toggle the preview."
 }

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -509,7 +509,9 @@ describe("NewTask task attachments", () => {
       new PointerEvent("pointerenter", { bubbles: true, pointerType: "mouse" }),
     );
 
-    await expect.poll(() => document.querySelector(".attachment-preview:popover-open")).not.toBeNull();
+    await expect
+      .poll(() => document.querySelector(".attachment-preview:popover-open"))
+      .not.toBeNull();
     expect(document.querySelector<HTMLImageElement>(".attachment-preview img")?.src).toContain(
       "blob:attachment-preview-1",
     );
@@ -520,7 +522,9 @@ describe("NewTask task attachments", () => {
     await expect.poll(() => document.querySelector(".attachment-preview:popover-open")).toBeNull();
 
     triggerEl.focus();
-    await expect.poll(() => document.querySelector(".attachment-preview:popover-open")).not.toBeNull();
+    await expect
+      .poll(() => document.querySelector(".attachment-preview:popover-open"))
+      .not.toBeNull();
     triggerEl.blur();
     await expect.poll(() => document.querySelector(".attachment-preview:popover-open")).toBeNull();
   });
@@ -535,7 +539,9 @@ describe("NewTask task attachments", () => {
       name: m.newtask_preview_image_aria({ name: "mobile.png" }),
     });
     await trigger.click();
-    await expect.poll(() => document.querySelector(".attachment-preview:popover-open")).not.toBeNull();
+    await expect
+      .poll(() => document.querySelector(".attachment-preview:popover-open"))
+      .not.toBeNull();
     await trigger.click();
     await expect.poll(() => document.querySelector(".attachment-preview:popover-open")).toBeNull();
 

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -127,6 +127,8 @@ beforeEach(() => {
 });
 
 let matchMediaSpy: ReturnType<typeof vi.spyOn> | undefined;
+let createObjectUrlSpy: ReturnType<typeof vi.spyOn> | undefined;
+let revokeObjectUrlSpy: ReturnType<typeof vi.spyOn> | undefined;
 function mockPointer(coarse: boolean) {
   const real = window.matchMedia.bind(window);
   matchMediaSpy = vi.spyOn(window, "matchMedia").mockImplementation((query: string) => {
@@ -149,6 +151,10 @@ function mockPointer(coarse: boolean) {
 afterEach(async () => {
   matchMediaSpy?.mockRestore();
   matchMediaSpy = undefined;
+  createObjectUrlSpy?.mockRestore();
+  createObjectUrlSpy = undefined;
+  revokeObjectUrlSpy?.mockRestore();
+  revokeObjectUrlSpy = undefined;
   overwriteGetLocale(() => "en");
   await page.viewport(1280, 900);
   document.body.innerHTML = "";
@@ -235,6 +241,9 @@ describe("NewTask initialImages seed", () => {
     // Each seeded chip carries its own remove control.
     const removers = page.getByRole("button", { name: m.newtask_remove_image_aria() }).all();
     expect(removers.length).toBe(2);
+    expect(
+      page.getByRole("button", { name: m.newtask_preview_image_aria({ name: "a.png" }) }).query(),
+    ).toBeNull();
   });
 
   it("renders no chips when initialImages is omitted", async () => {
@@ -313,6 +322,21 @@ describe("NewTask provider-aware command picker", () => {
 });
 
 describe("NewTask task attachments", () => {
+  async function upload(files: File[]) {
+    const input = document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    Object.defineProperty(input, "files", { value: files, configurable: true });
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+    await expect.poll(() => mockUploadFile.mock.calls.length).toBe(files.length);
+  }
+
+  function mockObjectUrls() {
+    let next = 0;
+    createObjectUrlSpy = vi
+      .spyOn(URL, "createObjectURL")
+      .mockImplementation(() => `blob:attachment-preview-${++next}`);
+    revokeObjectUrlSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+  }
+
   it("shows file/image attach copy and the keyboard paste-image hint", async () => {
     mockPointer(false);
     render(NewTask, { props: base({ initialRepoPath: "/repo/attachments" }) });
@@ -431,6 +455,136 @@ describe("NewTask task attachments", () => {
     await expect.element(page.getByText("drop.pdf")).toBeInTheDocument();
     await expect.element(page.getByText("drop.txt")).toBeInTheDocument();
     await expect.element(page.getByText("drop.md")).toBeInTheDocument();
+  });
+
+  it("previews only fresh image files and preserves the mixed attachment payload", async () => {
+    mockObjectUrls();
+    mockPointer(false);
+    const onsubmit = vi.fn().mockResolvedValue(undefined);
+    render(NewTask, { props: base({ onsubmit, initialRepoPath: "/repo/attachments" }) });
+
+    await upload([
+      new File(["png"], "shot.png", { type: "image/png" }),
+      new File(["notes"], "notes.txt", { type: "text/plain" }),
+    ]);
+
+    await expect
+      .element(
+        page.getByRole("button", { name: m.newtask_preview_image_aria({ name: "shot.png" }) }),
+      )
+      .toBeVisible();
+    expect(
+      page
+        .getByRole("button", { name: m.newtask_preview_image_aria({ name: "notes.txt" }) })
+        .query(),
+    ).toBeNull();
+    expect(page.getByText("notes.txt").element().closest("button")).toBeNull();
+
+    const promptField = document.querySelector<HTMLTextAreaElement>("#nt-prompt")!;
+    promptField.value = "use both attachments";
+    promptField.dispatchEvent(new Event("input", { bubbles: true }));
+    const run = document.querySelector<HTMLButtonElement>("button.run")!;
+    await expect.poll(() => run.disabled).toBe(false);
+    run.click();
+
+    await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
+    expect(onsubmit.mock.calls[0]![0]).toMatchObject({
+      images: ["/staged/shot.png", "/staged/notes.txt"],
+      attachmentNames: ["shot.png", "notes.txt"],
+    });
+  });
+
+  it("opens an image preview on desktop hover and keyboard focus", async () => {
+    mockObjectUrls();
+    mockPointer(false);
+    render(NewTask, { props: base({ initialRepoPath: "/repo/attachments" }) });
+    await upload([new File(["png"], "shot.png", { type: "image/png" })]);
+
+    const trigger = page.getByRole("button", {
+      name: m.newtask_preview_image_aria({ name: "shot.png" }),
+    });
+    await expect.element(trigger).toBeVisible();
+    const triggerEl = trigger.element() as HTMLButtonElement;
+    triggerEl.dispatchEvent(
+      new PointerEvent("pointerenter", { bubbles: true, pointerType: "mouse" }),
+    );
+
+    await expect.poll(() => document.querySelector(".attachment-preview:popover-open")).not.toBeNull();
+    expect(document.querySelector<HTMLImageElement>(".attachment-preview img")?.src).toContain(
+      "blob:attachment-preview-1",
+    );
+
+    triggerEl.dispatchEvent(
+      new PointerEvent("pointerleave", { bubbles: true, pointerType: "mouse" }),
+    );
+    await expect.poll(() => document.querySelector(".attachment-preview:popover-open")).toBeNull();
+
+    triggerEl.focus();
+    await expect.poll(() => document.querySelector(".attachment-preview:popover-open")).not.toBeNull();
+    triggerEl.blur();
+    await expect.poll(() => document.querySelector(".attachment-preview:popover-open")).toBeNull();
+  });
+
+  it("toggles an image preview on touch and dismisses it outside", async () => {
+    mockObjectUrls();
+    mockPointer(true);
+    render(NewTask, { props: base({ initialRepoPath: "/repo/attachments" }) });
+    await upload([new File(["png"], "mobile.png", { type: "image/png" })]);
+
+    const trigger = page.getByRole("button", {
+      name: m.newtask_preview_image_aria({ name: "mobile.png" }),
+    });
+    await trigger.click();
+    await expect.poll(() => document.querySelector(".attachment-preview:popover-open")).not.toBeNull();
+    await trigger.click();
+    await expect.poll(() => document.querySelector(".attachment-preview:popover-open")).toBeNull();
+
+    await trigger.click();
+    document.body.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    await expect.poll(() => document.querySelector(".attachment-preview:popover-open")).toBeNull();
+  });
+
+  it("dismisses an image preview on Escape, scroll, and resize", async () => {
+    mockObjectUrls();
+    mockPointer(true);
+    render(NewTask, { props: base({ initialRepoPath: "/repo/attachments" }) });
+    await upload([new File(["png"], "dismiss.png", { type: "image/png" })]);
+
+    const trigger = page.getByRole("button", {
+      name: m.newtask_preview_image_aria({ name: "dismiss.png" }),
+    });
+    const isOpen = () => document.querySelector(".attachment-preview:popover-open");
+
+    await trigger.click();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await expect.poll(isOpen).toBeNull();
+
+    await trigger.click();
+    window.dispatchEvent(new Event("scroll"));
+    await expect.poll(isOpen).toBeNull();
+
+    await trigger.click();
+    window.dispatchEvent(new Event("resize"));
+    await expect.poll(isOpen).toBeNull();
+  });
+
+  it("revokes image preview URLs on attachment removal and dialog teardown", async () => {
+    mockObjectUrls();
+    const screen = await render(NewTask, {
+      props: base({ initialRepoPath: "/repo/attachments" }),
+    });
+    await upload([
+      new File(["a"], "a.png", { type: "image/png" }),
+      new File(["b"], "b.png", { type: "image/png" }),
+    ]);
+    await expect.poll(() => createObjectUrlSpy?.mock.calls.length).toBe(2);
+
+    await page.getByRole("button", { name: m.newtask_remove_image_aria() }).first().click();
+    await expect.poll(() => revokeObjectUrlSpy?.mock.calls.length).toBe(1);
+    expect(revokeObjectUrlSpy).toHaveBeenCalledWith("blob:attachment-preview-1");
+
+    await screen.unmount();
+    expect(revokeObjectUrlSpy).toHaveBeenCalledWith("blob:attachment-preview-2");
   });
 });
 

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -40,6 +40,7 @@
   import SlashCommandMenu from "./SlashCommandMenu.svelte";
   import MicButton from "./MicButton.svelte";
   import BaseRepairNotice from "./new-task/BaseRepairNotice.svelte";
+  import AttachmentChip from "./new-task/AttachmentChip.svelte";
   import NewTaskRunSettings from "./new-task/NewTaskRunSettings.svelte";
   import FirstTaskAutomationConfirm from "./FirstTaskAutomationConfirm.svelte";
   import { dialog } from "$lib/a11yDialog";
@@ -48,6 +49,12 @@
   import { m } from "$lib/paraglide/messages";
   import { recentRepos } from "$lib/recentRepos";
   import type { UsageLimits } from "$lib/types";
+
+  type TaskAttachment = {
+    path: string;
+    name: string;
+    previewFile?: File;
+  };
 
   let {
     onsubmit,
@@ -262,7 +269,7 @@
   );
   // intentional one-time seed; NewTask remounts per open
   // svelte-ignore state_referenced_locally
-  let images = $state<{ path: string; name: string }[]>(initialImages ? [...initialImages] : []);
+  let images = $state<TaskAttachment[]>(initialImages ? [...initialImages] : []);
   let dragging = $state(false);
   let uploading = $state(false);
   let fileInput = $state<HTMLInputElement>();
@@ -526,7 +533,11 @@
     try {
       for (const f of uploads) {
         const path = await uploadFile(f);
-        images.push({ path, name: f.name });
+        images.push({
+          path,
+          name: f.name,
+          ...(f.type.startsWith("image/") ? { previewFile: f } : {}),
+        });
       }
     } catch (err) {
       if (isPreviewBlocked(err)) {
@@ -1102,15 +1113,12 @@
       {#if images.length > 0}
         <div class="chips">
           {#each images as img (img.path)}
-            <span class="chip">
-              <span class="chip-name">{img.name}</span>
-              <button
-                type="button"
-                class="chip-x"
-                onclick={() => removeUpload(img.path)}
-                aria-label={m.newtask_remove_image_aria()}>✕</button
-              >
-            </span>
+            <AttachmentChip
+              name={img.name}
+              previewFile={img.previewFile}
+              coarse={coarse.current}
+              onremove={() => removeUpload(img.path)}
+            />
           {/each}
         </div>
       {/if}
@@ -1621,32 +1629,6 @@
     flex-wrap: wrap;
     gap: 6px;
     margin-top: 6px;
-  }
-  .chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    max-width: 100%;
-    background: var(--color-inset);
-    border: 1px solid var(--color-line);
-    border-radius: 2px;
-    padding: 3px 7px;
-    font-size: var(--fs-meta);
-    color: var(--color-ink);
-  }
-  .chip-name {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    max-width: 22ch;
-  }
-  .chip-x {
-    background: transparent;
-    border: 0;
-    color: var(--color-muted);
-    cursor: pointer;
-    font: inherit;
-    line-height: 1;
   }
   .relaunch-note {
     display: flex;

--- a/ui/src/lib/components/new-task/AttachmentChip.svelte
+++ b/ui/src/lib/components/new-task/AttachmentChip.svelte
@@ -88,16 +88,13 @@
         if (!coarse) return;
         e.preventDefault();
         open = !open;
-      }}
-    >{name}</button>
+      }}>{name}</button
+    >
   {:else}
     <span class="chip-name">{name}</span>
   {/if}
-  <button
-    type="button"
-    class="chip-x"
-    onclick={onremove}
-    aria-label={m.newtask_remove_image_aria()}>✕</button
+  <button type="button" class="chip-x" onclick={onremove} aria-label={m.newtask_remove_image_aria()}
+    >✕</button
   >
 </span>
 

--- a/ui/src/lib/components/new-task/AttachmentChip.svelte
+++ b/ui/src/lib/components/new-task/AttachmentChip.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { anchorPopover } from "$lib/floating-anchor";
+  import { m } from "$lib/paraglide/messages";
+
+  let {
+    name,
+    previewFile,
+    coarse,
+    onremove,
+  }: {
+    name: string;
+    previewFile?: File;
+    coarse: boolean;
+    onremove: () => void;
+  } = $props();
+
+  const previewId = $props.id();
+  let previewUrl = $state<string | null>(null);
+  let open = $state(false);
+  let triggerEl = $state<HTMLButtonElement | null>(null);
+  let popoverEl = $state<HTMLElement | null>(null);
+
+  onMount(() => {
+    if (!previewFile) return;
+    const url = URL.createObjectURL(previewFile);
+    previewUrl = url;
+    return () => URL.revokeObjectURL(url);
+  });
+
+  $effect(() => {
+    if (!open || !triggerEl || !popoverEl) return;
+    try {
+      popoverEl.showPopover();
+    } catch {
+      return;
+    }
+    return anchorPopover(triggerEl, popoverEl, 6, "top");
+  });
+
+  $effect(() => {
+    if (!open) return;
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key === "Escape") open = false;
+    }
+    function onPointerdown(e: PointerEvent) {
+      const target = e.target as Node;
+      if (!triggerEl?.contains(target) && !popoverEl?.contains(target)) open = false;
+    }
+    function onScrollOrResize() {
+      open = false;
+    }
+    window.addEventListener("keydown", onKeydown);
+    window.addEventListener("pointerdown", onPointerdown);
+    window.addEventListener("scroll", onScrollOrResize, { capture: true, passive: true });
+    window.addEventListener("resize", onScrollOrResize, { passive: true });
+    return () => {
+      window.removeEventListener("keydown", onKeydown);
+      window.removeEventListener("pointerdown", onPointerdown);
+      window.removeEventListener("scroll", onScrollOrResize, { capture: true });
+      window.removeEventListener("resize", onScrollOrResize);
+    };
+  });
+</script>
+
+<span class="chip">
+  {#if previewFile}
+    <button
+      bind:this={triggerEl}
+      type="button"
+      class="chip-name preview-trigger"
+      aria-label={m.newtask_preview_image_aria({ name })}
+      aria-controls={previewId}
+      aria-expanded={coarse ? open : undefined}
+      onpointerenter={(e) => {
+        if (!coarse && e.pointerType !== "touch") open = true;
+      }}
+      onpointerleave={(e) => {
+        if (!coarse && e.pointerType !== "touch") open = false;
+      }}
+      onfocus={() => {
+        if (!coarse) open = true;
+      }}
+      onblur={() => {
+        if (!coarse) open = false;
+      }}
+      onclick={(e) => {
+        if (!coarse) return;
+        e.preventDefault();
+        open = !open;
+      }}
+    >{name}</button>
+  {:else}
+    <span class="chip-name">{name}</span>
+  {/if}
+  <button
+    type="button"
+    class="chip-x"
+    onclick={onremove}
+    aria-label={m.newtask_remove_image_aria()}>✕</button
+  >
+</span>
+
+{#if previewUrl}
+  <span
+    id={previewId}
+    bind:this={popoverEl}
+    class="attachment-preview"
+    role="tooltip"
+    aria-label={m.newtask_preview_image_aria({ name })}
+    popover="manual"
+  >
+    <img src={previewUrl} alt="" />
+  </span>
+{/if}
+
+<style>
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    max-width: 100%;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    padding: 3px 7px;
+    font-size: var(--fs-meta);
+    color: var(--color-ink);
+  }
+  .chip-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 22ch;
+  }
+  .preview-trigger {
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    cursor: zoom-in;
+  }
+  .preview-trigger:hover {
+    color: var(--color-ink-bright);
+  }
+  .preview-trigger:focus-visible {
+    outline: 2px solid var(--color-line-bright);
+    outline-offset: 2px;
+  }
+  .chip-x {
+    background: transparent;
+    border: 0;
+    color: var(--color-muted);
+    cursor: pointer;
+    font: inherit;
+    line-height: 1;
+  }
+  [popover].attachment-preview {
+    position: fixed;
+    inset: auto;
+    margin: 0;
+    padding: 4px;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
+    box-shadow: var(--shadow-popover);
+  }
+  .attachment-preview img {
+    display: block;
+    max-width: min(280px, 80vw);
+    max-height: min(200px, 35vh);
+    object-fit: contain;
+  }
+</style>

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-newtask-image-preview.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-newtask-image-preview.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "newtask-image-preview",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_newtask_image_preview_title",
+  bodyKey: "feat_newtask_image_preview_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## Problem / goal

Image attachments in the New Task dialog are represented only by filenames, so operators cannot confirm that the correct screenshot or picture was attached before launching a task. This is especially awkward when several similarly named captures are attached.

## Solution / added

- Adds a compact image preview anchored to fresh image-attachment filenames.
- Opens on hover or keyboard focus on desktop.
- Toggles on filename tap on mobile, with outside tap, Escape, scroll, and resize dismissal.
- Keeps non-image and carried relaunch/held attachments unchanged.
- Revokes browser object URLs when an attachment is removed or the dialog closes.
- Adds EN/DE accessible copy and a What is New entry for v1.44.0.

## Technical details

- Uses the native HTML Popover API and the existing `anchorPopover`/Floating UI helper to escape clipping and stay within viewport bounds.
- Keeps preview data browser-local from the original `File`; no server file-serving endpoint or staged-path exposure was added.
- Uses Shepherd semantic tokens and the existing popover shadow.
- Tests cover fresh-image eligibility, mixed payload preservation, desktop/mobile interaction, all dismissal paths, seeded-image exclusion, and URL cleanup.

## Validation

- `cd ui && bun run check:i18n`
- `cd ui && bun run check`
- `cd ui && bun run test:browser -- NewTask.browser.test.ts` (86 tests)
- `cd ui && bun run test` (3617 tests)
- Feature catalog, announcement version, glossary, and branch hygiene gates