### PR TITLE
feat(ui): surface single-CLI skill constraints

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3027,7 +3027,7 @@
   "provider_badge_claude": "Claude",
   "provider_badge_codex": "Codex",
   "provider_badge_both": "Beide",
-  "newtask_provider_constraint_note": "{command} benötigt {provider}.",
+  "newtask_provider_constraint_note": "{command} ist nur in {provider} verfügbar.",
   "newtask_provider_constraint_error": "{command} benötigt {provider}. Entferne den Token oder wechsle die CLI.",
   "feat_provider_aware_skills_title": "Provider-bewusste Skills",
   "feat_provider_aware_skills_body": "Die Picker in Neuer Task und Compose verstehen jetzt Claude-Slash-Commands und direkte Codex-Skills. Nutze / für Claude, $ für Codex oder ein einzelnes @ als Codex-Picker-Alias; Zeilen zeigen, ob sie in Claude, Codex oder beiden laufen.",
@@ -3088,5 +3088,9 @@
   "command_source_system": "System",
   "feat_codex_discovery_title": "Codex-Skills in der Command-Discovery",
   "feat_codex_discovery_body": "Der Prompt-Picker versteht jetzt Codex-Skills, einschließlich installierter Plugin-Skills wie $github:yeet, während installierte Codex-Plugins als Browsing-Inventar erscheinen.",
-  "files_source_difference_tip": "Das Scratchpad enthält zusätzliche Dateien dieser Sitzung und bleibt vom Repository getrennt. Der Worktree ist der Projektordner des Agenten mit seinen Änderungen; hier kannst du ihn nur durchsuchen und Dateien daraus herunterladen."
+  "files_source_difference_tip": "Das Scratchpad enthält zusätzliche Dateien dieser Sitzung und bleibt vom Repository getrennt. Der Worktree ist der Projektordner des Agenten mit seinen Änderungen; hier kannst du ihn nur durchsuchen und Dateien daraus herunterladen.",
+  "newtask_provider_constraint_title": "CLI-Verfügbarkeit",
+  "newtask_provider_constraint_body": "Shepherd hat {provider} ausgewählt und inkompatible CLIs deaktiviert, solange dieser Token im Prompt steht.",
+  "feat_provider_availability_card_title": "Hinweise für Single-CLI-Skills",
+  "feat_provider_availability_card_body": "Neue Aufgabe zeigt jetzt eine blaue CLI-Verfügbarkeitskarte, wenn ein gewählter Command-, Skill- oder Plugin-Token nur in einer Coding-CLI läuft, damit die erzwungene Provider-Wahl vor dem Start sichtbar ist."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3027,7 +3027,7 @@
   "provider_badge_claude": "Claude",
   "provider_badge_codex": "Codex",
   "provider_badge_both": "Both",
-  "newtask_provider_constraint_note": "{command} requires {provider}.",
+  "newtask_provider_constraint_note": "{command} is only available in {provider}.",
   "newtask_provider_constraint_error": "{command} requires {provider}. Remove the token or switch CLI.",
   "feat_provider_aware_skills_title": "Provider-aware skills",
   "feat_provider_aware_skills_body": "The New Task and compose pickers now understand Claude slash commands and direct Codex skills. Use / for Claude, $ for Codex, or bare @ as a Codex picker alias; rows show whether they run in Claude, Codex, or both.",
@@ -3088,5 +3088,9 @@
   "command_source_system": "System",
   "feat_codex_discovery_title": "Codex skills in command discovery",
   "feat_codex_discovery_body": "The prompt picker now understands Codex skills, including installed plugin skills such as $github:yeet, while installed Codex plugins appear as a browsing-only inventory.",
-  "files_source_difference_tip": "Scratchpad contains supplementary files for this session and stays separate from the repository. Worktree is the agent's project directory and changes; you can only browse and download it here."
+  "files_source_difference_tip": "Scratchpad contains supplementary files for this session and stays separate from the repository. Worktree is the agent's project directory and changes; you can only browse and download it here.",
+  "newtask_provider_constraint_title": "CLI availability",
+  "newtask_provider_constraint_body": "Shepherd selected {provider} and disabled incompatible CLIs while this token is in the prompt.",
+  "feat_provider_availability_card_title": "Single-CLI skill notices",
+  "feat_provider_availability_card_body": "New Task now shows a blue CLI-availability card when a picked command, skill, or plugin token only runs in one coding CLI, so the forced provider choice is visible before launch."
 }

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -274,7 +274,19 @@ describe("NewTask provider-aware command picker", () => {
 
     await expect.poll(() => promptField.value).toBe("$codex-skill ");
     expect(document.querySelector<HTMLSelectElement>("#nt-agent-provider")!.value).toBe("codex");
-    await expect.element(page.getByText("codex-skill requires Codex.")).toBeVisible();
+    await expect.element(page.getByText(m.newtask_provider_constraint_title())).toBeVisible();
+    await expect.element(page.getByText("codex-skill is only available in Codex.")).toBeVisible();
+    await expect
+      .element(
+        page.getByText(
+          "Shepherd selected Codex and disabled incompatible CLIs while this token is in the prompt.",
+        ),
+      )
+      .toBeVisible();
+    const options = Array.from(
+      document.querySelectorAll<HTMLOptionElement>("#nt-agent-provider option"),
+    );
+    expect(options.find((option) => option.value === "claude")?.disabled).toBe(true);
   });
 
   it("selecting a both-provider skill does not lock or explain the provider", async () => {
@@ -291,7 +303,8 @@ describe("NewTask provider-aware command picker", () => {
 
     await expect.poll(() => promptField.value).toBe("$shared-skill ");
     expect(document.querySelector<HTMLSelectElement>("#nt-agent-provider")!.value).toBe("codex");
-    expect(page.getByText("shared-skill requires Codex.").query()).toBeNull();
+    expect(page.getByText(m.newtask_provider_constraint_title()).query()).toBeNull();
+    expect(page.getByText("shared-skill is only available in Codex.").query()).toBeNull();
     const options = Array.from(
       document.querySelectorAll<HTMLOptionElement>("#nt-agent-provider option"),
     );

--- a/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
+++ b/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
@@ -80,6 +80,10 @@
     }
   }
 
+  function providerLabel(provider: AgentProvider | undefined): string {
+    return provider === "codex" ? m.agent_provider_codex() : m.agent_provider_claude();
+  }
+
   $effect(() => {
     if (!modelAvailableForProvider(agentProvider, model, fableAvailable)) {
       model = agentProvider === "codex" ? CODEX_MODELS[0] : "default";
@@ -242,18 +246,27 @@
         {/each}
       </select>
       <ProviderCapacityGauge limits={usageLimits} />
-      {#if providerConstraint}
-        <p class="pg-hint">
+    </div>
+
+    {#if providerConstraint}
+      <div class="provider-constraint-callout" role="status">
+        <div class="provider-callout-head constraint-head">
+          <span>{m.newtask_provider_constraint_title()}</span>
+          <span class="constraint-badge">{providerLabel(providerConstraint.providers[0])}</span>
+        </div>
+        <p>
           {m.newtask_provider_constraint_note({
             command: providerConstraint.label,
-            provider:
-              providerConstraint.providers[0] === "codex"
-                ? m.agent_provider_codex()
-                : m.agent_provider_claude(),
+            provider: providerLabel(providerConstraint.providers[0]),
           })}
         </p>
-      {/if}
-    </div>
+        <p>
+          {m.newtask_provider_constraint_body({
+            provider: providerLabel(providerConstraint.providers[0]),
+          })}
+        </p>
+      </div>
+    {/if}
 
     <div class="model-field" use:coachTarget={"model-1m-context"}>
       <label class="micro" for="nt-model">{m.newtask_model_label()}</label>
@@ -355,6 +368,19 @@
     width: 100%;
     box-sizing: border-box;
   }
+  .provider-constraint-callout {
+    flex: 1 0 100%;
+    border: 1px solid color-mix(in srgb, var(--color-blue) 52%, var(--color-line));
+    background: color-mix(in srgb, var(--color-blue) 13%, transparent);
+    color: var(--color-ink-bright);
+    font-size: var(--fs-meta);
+    line-height: 1.35;
+    margin: 0;
+    padding: 10px 12px;
+    border-radius: 2px;
+    width: 100%;
+    box-sizing: border-box;
+  }
   .provider-callout-head {
     display: flex;
     align-items: center;
@@ -365,9 +391,20 @@
     letter-spacing: 0.12em;
     text-transform: uppercase;
   }
+  .constraint-head {
+    color: var(--color-blue);
+  }
   .alpha-badge {
     border: 1px solid color-mix(in srgb, var(--color-amber) 62%, var(--color-line));
     color: var(--color-amber);
+    padding: 1px 6px;
+    border-radius: 2px;
+    font-size: var(--fs-micro);
+    letter-spacing: 0.08em;
+  }
+  .constraint-badge {
+    border: 1px solid color-mix(in srgb, var(--color-blue) 62%, var(--color-line));
+    color: var(--color-blue);
     padding: 1px 6px;
     border-radius: 2px;
     font-size: var(--fs-micro);
@@ -377,7 +414,14 @@
     margin: 0;
     color: var(--color-ink);
   }
+  .provider-constraint-callout p {
+    margin: 0;
+    color: var(--color-ink);
+  }
   .provider-callout p + p {
+    margin-top: 5px;
+  }
+  .provider-constraint-callout p + p {
     margin-top: 5px;
   }
   .opts-row {

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-provider-availability-card.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-provider-availability-card.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "provider-availability-card",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_provider_availability_card_title",
+  bodyKey: "feat_provider_availability_card_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## Problem / Case / Feature / Goal

When an operator picks a command, skill, or plugin token that only works in one coding CLI, Shepherd already forces the compatible provider. That constraint was only shown as a small inline hint near the picker, so it was easy to miss why the CLI changed or why the other option became unavailable.

## Solution / Added

- Replace the low-visibility provider constraint hint with a blue CLI availability card in the New Task run settings.
- Show the required provider as a badge and explain that Shepherd selected it while the constrained token remains in the prompt.
- Keep shared-provider entries quiet: no card, no disabled CLI options.
- Add EN/DE message keys and a feature announcement fragment for discovery.

## Technical Details

- Reuses the existing `ProviderTokenConstraint` flow; no API or data model changes.
- Adds token-based blue styling in `NewTaskRunSettings.svelte` with `var(--color-blue)`, `var(--fs-*)`, and the existing callout structure.
- Updates `NewTask.browser.test.ts` to assert the Codex-only skill card, provider lock, and shared-provider no-card behavior.

## Verification

- `scripts/check-branch-hygiene.sh`
- `scripts/check-announcement-versions.mjs`
- `scripts/check-feature-catalog.sh`
- `cd ui && bun run check:i18n`
- `cd ui && bun run test:browser -- NewTask.browser.test.ts`
- `cd ui && bun run check`