### PR TITLE
fix(plan-gate): resume an exited (Codex) planner before steering findings

### DIFF
--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -7,6 +7,7 @@ import { effectiveAutopilot } from "./effective-autopilot";
 import { signedOff } from "./signoff";
 import { checksCleared } from "./checks-gate";
 import { DRAFT_PR_NOTE } from "./service";
+import { resumeThenSteer } from "./resume-then-steer";
 
 /**
  * Agent-facing steer templates. NOT UI chrome — never i18n'd (they are typed into the
@@ -315,16 +316,11 @@ export class AutopilotService {
     await this.driveSteer(s, EMPTY_COMPLETION_STEER);
   }
 
-  /** Send `text` into the session, resuming an exited pane first. Returns whether the steer
-   *  landed; does NOT bump the step (the caller decides whether the attempt counts). */
-  private async sendSteer(s: Session, text: string): Promise<boolean> {
-    if (!this.deps.paneAlive(s.id) || this.deps.deferSteer?.(s.id)) {
-      // Not live, OR a herdr-restored account husk to re-drive first (Locus B) so the steer lands on the
-      // re-driven pane, not the wrong-account husk. resume() resolves falsy when it can't (archived /
-      // no pinned session id) — then there's nothing to do.
-      if (!(await this.deps.resume(s.id))) return false;
-    }
-    return await this.deps.steer(s.id, text);
+  /** Send `text` into the session, resuming an exited pane first (shared with the plan gate via
+   *  resumeThenSteer). Returns whether the steer landed; does NOT bump the step (the caller decides
+   *  whether the attempt counts). */
+  private sendSteer(s: Session, text: string): Promise<boolean> {
+    return resumeThenSteer(s.id, text, this.deps);
   }
 
   /** Steer `text` into the session and bump the step on a landed steer. Best-effort —

--- a/src/index.ts
+++ b/src/index.ts
@@ -1300,10 +1300,28 @@ const planGate = new PlanGateService({
   resolveForge,
   // Plugin onSpawn hooks fire for reviewer-style aux spawns too (issue #1205); no-op until loadAll.
   runSpawnHooks: (d) => pluginRegistry.runSpawnHooks(d),
-  // Defer while a herdr-restored account pane still needs a re-drive: return false so the plan-gate
-  // round holds (retries next cycle) instead of steering findings into the wrong-account husk. The
-  // poller heals it within ~1 tick (Locus A); shouldDeferSteer clears once healed or degraded.
-  reply: async (id, text) => (service.shouldDeferSteer(id) ? false : await service.reply(id, text)),
+  // Raw steer, delivered THROUGH resumeThenSteer (paneAlive/resume/deferSteer below): findings now
+  // revive an exited planner before landing rather than holding the round on a dead pane. This is
+  // what makes a Codex planner (which exits after its turn) actually receive the findings and revise.
+  reply: (id, text) => service.reply(id, text),
+  // Whether the planning session is still a live agent (mirrors autopilot.paneAlive).
+  paneAlive: (id) => {
+    const s = store.get(id);
+    return !!s && matchAgent(s, herdr.list()) !== null;
+  },
+  // Resume an exited planning pane so the findings land — EXCEPT a NON-isolated Codex session:
+  // `codex resume --last` is cwd-scoped and would resume/steer a SIBLING codex session (the exact
+  // constraint autopilot enforces at eligibility). Returning null there makes resumeThenSteer report
+  // the steer undelivered, so applyChangesRequested escalates to the operator instead of corrupting
+  // a sibling. Claude / isolated Codex resume normally.
+  resume: (id) => {
+    const s = store.get(id);
+    if (s && (s.agentProvider ?? "claude") === "codex" && !s.isolated) return null;
+    return service.resume(id);
+  },
+  // Defer + re-drive a herdr-restored account pane first (Locus A) so the steer lands on the healed
+  // pane, not the wrong-account husk; resumeThenSteer resumes it rather than dropping the round.
+  deferSteer: (id) => service.shouldDeferSteer(id),
   // Discards releasePlanGate's boolean: the plan-gate DI contract is "release it", not "was it
   // releasable" — a no-op release (not planning / not approved) is not an error here.
   release: async (id) => {

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -22,6 +22,7 @@ import { effectiveAutopilot } from "./effective-autopilot";
 import { resolveAuxSpawn, type MembraneSeams } from "./spawn-membrane";
 import { fenceUntrusted } from "./untrusted";
 import { type OperatorLanguage } from "./operator-language";
+import { resumeThenSteer } from "./resume-then-steer";
 
 /** Outcome of an on-demand `consider()`: a reviewer actually spawned (`"started"`); the request
  *  was a no-op (`"skipped"` — not planning, a review already in flight/starting, a tombstone or
@@ -159,9 +160,20 @@ export interface PlanGateServiceDeps extends MembraneSeams {
   /** Resolve the forge for a repo so begin() can fetch the originating issue's body as UNTRUSTED
    *  reviewer context. Optional + optional-chained: absence ⇒ no issue context (never blocks). */
   resolveForge?: (repoPath: string) => GitForge | null;
-  /** Steer reviewer findings into the live planning agent's PTY (SessionService.reply).
-   *  Async since #1567 — resolves true only when the steer reached a live pane. */
+  /** Deliver reviewer findings into the planning agent's live PTY (SessionService.reply). Async
+   *  since #1567 — resolves true only when the steer reached a live pane. Called THROUGH
+   *  resumeThenSteer (paneAlive/resume/deferSteer below) so an exited Codex planner is revived first. */
   reply: (sessionId: string, text: string) => Promise<boolean>;
+  /** Whether the planning session's herdr pane is currently a live agent (matchAgent). A Codex
+   *  planner EXITS after its turn, so findings must resume it before steering; Claude idles live. */
+  paneAlive: (sessionId: string) => boolean;
+  /** Resume an exited planning session so findings can land (SessionService.resume; async — the
+   *  awaited result decides, truthy = resumed). The wiring refuses a NON-isolated Codex session
+   *  (returns falsy): `codex resume --last` is cwd-scoped and would resume a sibling, so such a
+   *  planner escalates to the operator instead of being auto-resumed. */
+  resume: (sessionId: string) => unknown;
+  /** Defer + re-drive first while a herdr-restored account pane needs it (SessionService.shouldDeferSteer). */
+  deferSteer?: (sessionId: string) => boolean;
   /** Release an APPROVED autonomous (auto/autopilot) session into execution (SessionService.releasePlanGate).
    *  Async since #1567: the release steers the agent, so it resolves once that steer has landed. */
   release: (sessionId: string) => Promise<void>;
@@ -679,6 +691,20 @@ export class PlanGateService {
     if (s.auto || autopilotReleases) await this.deps.release(f.sessionId);
   }
 
+  /** Deliver the reviewer's findings to the planning agent, RESUMING an exited pane first so the
+   *  steer actually lands. Claude idles live at its prompt (steers directly); Codex exits after its
+   *  turn, so without the resume-first the findings would vanish and the plan would never be revised
+   *  — the core "rework does nothing" cause. Mirrors autopilot.sendSteer via the shared helper.
+   *  Returns whether the steer reached the agent. */
+  private steerFindings(sessionId: string, findings: string[]): Promise<boolean> {
+    return resumeThenSteer(sessionId, planSteerText(findings), {
+      paneAlive: this.deps.paneAlive,
+      deferSteer: this.deps.deferSteer,
+      resume: this.deps.resume,
+      steer: this.deps.reply,
+    });
+  }
+
   /** Steer the findings back to the LIVE planning agent while under the cap; at/over the cap stop
    *  steering and escalate to the operator. Execution stays gated until the plan is approved. */
   private async applyChangesRequested(f: PlanInFlight, gate: PlanGate): Promise<void> {
@@ -693,17 +719,21 @@ export class PlanGateService {
     // persisted + surfaced; only the streak-advancing and signal side effects are suppressed. A
     // forced review of a CHANGED plan (hash differs) is a real revision and falls through below.
     if (f.forced && prior && prior.planHash === f.planHash) {
-      gate.round = f.priorRound;
+      gate.round = prior.round; // live round (not the begin-time snapshot) — an operator reset wins
       gate.finalRoundPending = prior.finalRoundPending;
       this.deps.store.putPlanGate(gate);
       this.deps.onChange(f.sessionId, gate);
       return;
     }
-    const priorRound = f.priorRound;
+    // Carry the LIVE gate's round, not the begin-time snapshot: an operator resume()/dismiss() that
+    // reset the round WHILE this review was in flight must win over this finalize, not be clobbered
+    // back to the pre-reset value (the reviewer captured f.priorRound before the reset).
+    const priorRound = prior?.round ?? f.priorRound;
     let delivered = false;
     if (priorRound < this.cap) {
       try {
-        delivered = await this.deps.reply(f.sessionId, planSteerText(gate.findings));
+        // resume-before-steer: revive an exited (Codex) planner so the findings actually land.
+        delivered = await this.steerFindings(f.sessionId, gate.findings);
       } catch (err) {
         console.warn(`[plan-gate] steer failed for ${f.sessionId}:`, err);
       }
@@ -814,9 +844,10 @@ export class PlanGateService {
       summaryCode,
       body,
       findings,
-      // approved resets the streak; changes_requested/error carry priorRound (finalize()
-      // overwrites it for changes_requested once the steer outcome is known).
-      round: resolved === "approved" ? 0 : f.priorRound,
+      // approved resets the streak; changes_requested/error carry the LIVE round (not the begin-time
+      // snapshot) so an operator resume()/dismiss() reset during the review isn't clobbered — the
+      // `error` path persists this directly; applyChangesRequested recomputes it for changes_requested.
+      round: resolved === "approved" ? 0 : (live?.round ?? f.priorRound),
       cap: this.cap, // surface the live cap so the UI badge need not mirror it
       approved: resolved === "approved",
       plan: f.plan,
@@ -865,7 +896,8 @@ export class PlanGateService {
     const reset = { ...gate, round: 0, finalRoundPending: false, dismissed: false };
     this.deps.store.putPlanGate(reset);
     this.deps.onChange(session.id, reset);
-    return await this.deps.reply(session.id, planSteerText(gate.findings));
+    // resume-before-steer: revive an exited (Codex) planner so the re-delivered findings land.
+    return await this.steerFindings(session.id, gate.findings);
   }
 
   /**

--- a/src/resume-then-steer.ts
+++ b/src/resume-then-steer.ts
@@ -1,0 +1,37 @@
+/** The seams `resumeThenSteer` needs — a structural subset of both AutopilotDeps and
+ *  PlanGateServiceDeps, so either can pass `this.deps` (or an adapter) straight through. */
+export interface ResumeThenSteerDeps {
+  /** Whether the session's herdr pane is currently a live agent. */
+  paneAlive: (id: string) => boolean;
+  /** Defer + re-drive first while a herdr-restored account pane still needs it (SessionService.shouldDeferSteer). */
+  deferSteer?: (id: string) => boolean;
+  /** Resume an exited session so it can be steered (SessionService.resume, async — the awaited
+   *  result decides). Truthy resolved value = resumed and steerable. */
+  resume: (id: string) => unknown;
+  /** Deliver text into the session's live PTY (SessionService.reply). false = didn't land. */
+  steer: (id: string, text: string) => Promise<boolean>;
+}
+
+/**
+ * Deliver `text` to a session, RESUMING an exited (or redrive-pending) pane FIRST so the steer
+ * lands on a live agent instead of vanishing. Returns whether the steer landed; a pane that cannot
+ * be resumed (resume() resolves falsy) yields false without steering.
+ *
+ * This is the shared body of autopilot.sendSteer, lifted so the plan gate can deliver reviewer
+ * findings the same way. It matters because Claude idles live at its prompt after a turn (a bare
+ * steer lands), but Codex EXITS after its turn — so without a resume-first the reviewer's findings
+ * would never reach the Codex planner and the plan would never get revised.
+ */
+export async function resumeThenSteer(
+  id: string,
+  text: string,
+  deps: ResumeThenSteerDeps,
+): Promise<boolean> {
+  if (!deps.paneAlive(id) || deps.deferSteer?.(id)) {
+    // Not live, OR a herdr-restored account husk to re-drive first (Locus B), so the steer lands on
+    // the re-driven pane rather than the wrong-account husk. resume() resolves falsy when it can't
+    // (archived / no resumable session / a caller-refused provider) — then there's nothing to do.
+    if (!(await deps.resume(id))) return false;
+  }
+  return await deps.steer(id, text);
+}

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -70,6 +70,11 @@ function harness(over: any = {}) {
     // no bwrap on test hosts: degrade to passthrough so existing argv assertions hold
     detectBackend: () => null,
     reply: async () => true,
+    // Default: pane live (Claude idles at its prompt) → resumeThenSteer skips resume and delivers
+    // via `reply`, preserving every pre-existing test's behavior. Codex-exit tests override paneAlive.
+    paneAlive: () => true,
+    resume: async () => ({}),
+    deferSteer: () => false,
     async release() {},
     onChange() {},
     onReviewing() {},
@@ -497,6 +502,109 @@ test("request-changes sub-cap but the steer can't land → stall signal, round h
   expect(signals.some((s) => s.kind === "stall")).toBe(true); // escalates instead of going silent
   expect(h.store.gate.round).toBe(0); // round did not advance (nothing delivered)
 });
+
+// ── resume-before-steer: findings must reach an EXITED (Codex) planner ─────────
+test("codex planner exited (pane dead) → resume THEN steer, findings land, round advances", async () => {
+  const resumed: string[] = [];
+  const steers: string[] = [];
+  let alive = false; // Codex exits after writing the plan → pane is not a live agent
+  const h = harness({
+    cap: 5,
+    readVerdict: () => ({
+      decision: "request-changes",
+      summary: "no",
+      body: "B",
+      findings: ["fix A"],
+    }),
+    paneAlive: () => alive,
+    resume: async (id: string) => {
+      resumed.push(id);
+      alive = true; // revived → now steerable
+      return {};
+    },
+    reply: (_id: string, t: string) => {
+      steers.push(t);
+      return true;
+    },
+  });
+  await h.svc.consider(planningSession() as any);
+  await h.svc.tick();
+  expect(resumed).toEqual(["s1"]); // the exited pane was resumed FIRST
+  expect(steers.length).toBe(1); // then the findings were steered into the revived agent
+  expect(steers[0]).toContain("fix A");
+  expect(h.store.gate.round).toBe(1); // delivered → round advanced (the plan can now be revised)
+});
+test("codex planner exited but resume refused (non-isolated) → no steer, round held, escalates", async () => {
+  const steers: string[] = [];
+  const signals: any[] = [];
+  const h = harness({
+    cap: 5,
+    readVerdict: () => ({
+      decision: "request-changes",
+      summary: "no",
+      body: "B",
+      findings: ["fix"],
+    }),
+    paneAlive: () => false, // pane exited
+    resume: async () => null, // the wiring refuses a non-isolated Codex resume (sibling-corruption guard)
+    reply: (_id: string, t: string) => {
+      steers.push(t);
+      return true;
+    },
+    store: { addSignal: (s: any) => signals.push(s) },
+  });
+  await h.svc.consider(planningSession() as any);
+  await h.svc.tick();
+  expect(steers.length).toBe(0); // resume refused → never steered into a dead pane
+  expect(signals.some((s) => s.kind === "stall")).toBe(true); // escalated to the operator
+  expect(h.store.gate.round).toBe(0); // round held
+});
+test("claude planner live at prompt → steer WITHOUT a needless resume", async () => {
+  const resumed: string[] = [];
+  const h = harness({
+    cap: 5,
+    readVerdict: () => ({
+      decision: "request-changes",
+      summary: "no",
+      body: "B",
+      findings: ["fix"],
+    }),
+    paneAlive: () => true, // Claude idles live at its prompt
+    resume: async (id: string) => {
+      resumed.push(id);
+      return {};
+    },
+    reply: () => true,
+  });
+  await h.svc.consider(planningSession() as any);
+  await h.svc.tick();
+  expect(resumed).toEqual([]); // live pane → never resumed (byte-identical to pre-change behavior)
+  expect(h.store.gate.round).toBe(1);
+});
+test("resume() reset during an in-flight review is not clobbered by finalize (live round wins)", async () => {
+  // Begin a review while the gate is AT the cap (round 5); the reviewer captures priorRound=5.
+  let liveGate: any = {
+    planHash: "OLD", // differs from hash("PLAN TEXT") so consider() does not dedupe
+    decision: "changes_requested",
+    approved: false,
+    round: 5,
+    findings: ["x"],
+  };
+  const h = harness({
+    cap: 5,
+    readVerdict: () => ({ decision: "request-changes", summary: "no", body: "B", findings: ["x"] }),
+    reply: () => true, // paneAlive default true → delivers directly
+    store: { getPlanGate: () => liveGate },
+  });
+  await h.svc.consider(planningSession() as any); // f.priorRound = 5 captured here
+  // Operator resume() mid-review resets the live round to 0.
+  liveGate = { ...liveGate, round: 0, finalRoundPending: false, dismissed: false };
+  await h.svc.tick(); // finalize
+  // With the fix, finalize reads the LIVE round (0) → delivered → 1; the stale priorRound (5, at cap)
+  // does not resurrect. Without the fix this would be 5 (held at cap → falsely stalled).
+  expect(h.store.gate.round).toBe(1);
+});
+
 const lastPrompt = (h: ReturnType<typeof harness>): string => {
   const argv = h.started[0].argv;
   return argv[argv.length - 1];


### PR DESCRIPTION
## Problem

Clicking **rework / re-review** on a plan (or waiting for the auto-loop) does nothing when the planner is **Codex**: a reviewer churns for a few minutes, then everything looks byte-identical. The plan is never revised.

## Root cause

The plan-gate revise loop delivered the reviewer's findings with a **bare steer that assumes a live pane** (`applyChangesRequested` → `service.reply`, which no-ops unless the session is still a live agent in `herdr agent list`).

- **Claude** idles live at its prompt after a turn (`transient-tab-reaper.ts:26`, `distiller.ts:287`) → the steer lands → it revises. ✅
- **Codex** *exits* after its turn — the whole autopilot codex path exists for this (`autopilot.sendSteer` resumes an exited pane before steering). So for a Codex planner the findings reached **no live agent**, it never revised, and re-review just re-confirmed the same text.

And the one component that resumes an exited pane before steering — `autopilot` — is **paused during the plan gate** (`autopilot.eligible()` returns null while `planPhase === "planning"`). So nothing revived the exited Codex planner.

## Fix

Give the plan gate the **same resume-before-steer** autopilot already has, via a shared helper (`src/resume-then-steer.ts`, lifted from `autopilot.sendSteer`):

- If the planning pane isn't a live agent (or needs an account re-drive), **`resume()` it first, then steer.** A revived Codex planner receives the findings, revises `.shepherd-plan.md`, and the existing settle-triggered auto re-review picks up the changed plan.
- For **Claude** the pane is already live → `resume()` is skipped → behavior is byte-identical to before.
- Auto-resume is **refused for a non-isolated Codex session** (`codex resume --last` is cwd-scoped and would resume/steer a *sibling* — the same constraint autopilot enforces). Such a planner escalates to the operator instead of corrupting a sibling.

**Session split is unchanged:** reviewer stays its own fresh throwaway session, planner stays the main session (same as Claude) — only the exited Codex planner is revived so findings land.

### Also (same subsystem)

`finalize()` now carries the **live** gate round, not the begin-time snapshot, so an operator `resume()`/`dismiss()` that resets the round *during* an in-flight review isn't clobbered back to the pre-reset value.

## Testing

- `test/plan-gate-service.test.ts` (+4): Codex-exited → resume-then-steer lands + round advances; non-isolated Codex → resume refused → escalates; Claude live → no needless resume; resume-reset race not clobbered by finalize.
- Full suite: **6889 pass, 0 fail** (the lone `pty-bridge` failure is a pre-existing node-pty native-module load error in worktrees, unrelated). `typecheck` clean, `lint` clean, `autopilot` (140) green.

Server-only; no user-facing UI. `[no-feature-entry]`