### PR TITLE
feat(ui): toggle build queue from progress badge

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3097,5 +3097,7 @@
   "feat_newtask_image_preview_title": "Bilder vor dem Task-Start prüfen",
   "feat_newtask_image_preview_body": "Fahre mit der Maus über den Dateinamen eines Bildanhangs oder fokussiere ihn, um das Bild vor dem Start zu prüfen. Tippe auf Mobilgeräten auf den Dateinamen, um die Vorschau ein- oder auszublenden.",
   "feat_automerge_session_jump_title": "Aus Voll-Auto-Merge springen",
-  "feat_automerge_session_jump_body": "Klicke auf einen aktiven Voll-Auto-Merge-Eintrag, um direkt zu seinem Task und Terminal zu springen. Shepherd entfernt Filter, die ihn verbergen würden, und folgt dem Task ins richtige Repository."
+  "feat_automerge_session_jump_body": "Klicke auf einen aktiven Voll-Auto-Merge-Eintrag, um direkt zu seinem Task und Terminal zu springen. Shepherd entfernt Filter, die ihn verbergen würden, und folgt dem Task ins richtige Repository.",
+  "feat_build_queue_progress_toggle_title": "Build-Queue direkt öffnen",
+  "feat_build_queue_progress_toggle_body": "Klicke auf das Fortschritts-Badge einer Session, um sie auszuwählen und ihre Build-Queue über dem Terminal zu öffnen. Klicke erneut auf das Badge der ausgewählten Session, um die Queue ein- oder auszuklappen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3097,5 +3097,7 @@
   "feat_newtask_image_preview_title": "Preview images before starting a task",
   "feat_newtask_image_preview_body": "Hover or focus an image attachment's filename to check it before launch. On mobile, tap the filename to toggle the preview.",
   "feat_automerge_session_jump_title": "Jump from Full-auto merge",
-  "feat_automerge_session_jump_body": "Click any active Full-auto merge entry to jump straight to its task and terminal. Shepherd clears filters that would hide it and follows the task into the right repository."
+  "feat_automerge_session_jump_body": "Click any active Full-auto merge entry to jump straight to its task and terminal. Shepherd clears filters that would hide it and follows the task into the right repository.",
+  "feat_build_queue_progress_toggle_title": "Open the build queue from progress",
+  "feat_build_queue_progress_toggle_body": "Click a session's progress badge to select it and open its build queue above the terminal. Click the selected session's badge again to collapse or expand the queue."
 }

--- a/ui/src/lib/actions/statusTip.svelte.ts
+++ b/ui/src/lib/actions/statusTip.svelte.ts
@@ -4,6 +4,8 @@ import { anchorPopover } from "$lib/floating-anchor";
 export interface StatusTipParams {
   /** The explanation text shown in the tooltip and exposed to AT via aria-describedby. */
   text: string;
+  /** Set false for actionable controls whose delegated click handler must run. */
+  stopClickPropagation?: boolean;
 }
 
 // Module-scoped counter for unique popover ids. Client-only (actions never run on
@@ -21,6 +23,8 @@ let uid = 0;
  *    hover) — dismissed by outside-click / Esc / scroll.
  *  - every open path is idempotent and `click` never toggles, so a touch tap's
  *    `focus`→`click` sequence can't flash it shut.
+ * Click propagation is stopped by default so read-only chips never select their
+ * row; actionable controls can opt out while retaining the same explanation.
  *
  * The explanation is exposed to assistive tech via `aria-description` (a string —
  * always valid, no dangling IDREF, present from mount), so screen readers announce
@@ -34,6 +38,7 @@ export const statusTip: Action<HTMLElement, StatusTipParams | null | undefined> 
 ) => {
   let pop: HTMLDivElement | null = null;
   let text = "";
+  let stopClickPropagation = true;
   let open = false;
   let pinned = false;
   let stopAnchor: (() => void) | null = null;
@@ -106,7 +111,7 @@ export const statusTip: Action<HTMLElement, StatusTipParams | null | undefined> 
     hide();
   }
   function onClick(e: MouseEvent) {
-    e.stopPropagation(); // reveal the explanation, never select the row
+    if (stopClickPropagation) e.stopPropagation(); // read-only chips never select the row
     show();
     if (e.detail > 0) pinned = true; // genuine pointer click pins; keyboard (detail 0) does not
   }
@@ -114,8 +119,9 @@ export const statusTip: Action<HTMLElement, StatusTipParams | null | undefined> 
     if (e.key === "Escape") hide();
   }
 
-  function enable(nextText: string) {
-    text = nextText;
+  function enable(next: StatusTipParams) {
+    text = next.text;
+    stopClickPropagation = next.stopClickPropagation ?? true;
     if (pop) pop.textContent = text;
     // Expose the explanation to assistive tech directly (no referenced element).
     node.setAttribute("aria-description", text);
@@ -156,11 +162,11 @@ export const statusTip: Action<HTMLElement, StatusTipParams | null | undefined> 
     node.style.zIndex = "";
   }
 
-  if (params?.text) enable(params.text);
+  if (params?.text) enable(params);
 
   return {
     update(next: StatusTipParams | null | undefined) {
-      if (next?.text) enable(next.text);
+      if (next?.text) enable(next);
       else teardown();
     },
     destroy() {

--- a/ui/src/lib/components/BuildQueueBadge.browser.test.ts
+++ b/ui/src/lib/components/BuildQueueBadge.browser.test.ts
@@ -1,11 +1,30 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
-import type { BuildQueue, BuildStep, BuildStepStatus, GitState } from "$lib/types";
+import type { BuildQueue, BuildStep, BuildStepStatus, GitState, Session } from "$lib/types";
+import { m } from "$lib/paraglide/messages";
 
 const { default: BuildQueueBadge } = await import("./BuildQueueBadge.svelte");
 const { buildQueues } = await import("$lib/buildQueues.svelte");
+const { buildQueueCollapse } = await import("$lib/build-queue-collapse.svelte");
+
+type BadgeProps = {
+  sessionId: string;
+  planPhase: Session["planPhase"];
+  git?: GitState;
+  tip?: boolean;
+  selected?: boolean;
+  onselect?: (id: string) => void;
+};
+
+function renderBadge(props: BadgeProps) {
+  return render(BuildQueueBadge, {
+    selected: true,
+    onselect: () => {},
+    ...props,
+  });
+}
 
 const step = (status: BuildStepStatus, id: string): BuildStep => ({
   id,
@@ -31,6 +50,7 @@ const git = (state: GitState["state"]): GitState => ({
 
 beforeEach(() => {
   buildQueues.map = {};
+  buildQueueCollapse.set(false);
 });
 
 afterEach(() => {
@@ -42,12 +62,12 @@ describe("BuildQueueBadge", () => {
     buildQueues.map = {
       s1: queue(false, [step("done", "1"), step("pending", "2")]),
     };
-    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
+    renderBadge({ sessionId: "s1", planPhase: "executing" });
     expect(document.querySelector(".queue-badge")).toBeNull();
   });
 
   it("renders nothing when there is no queue for the session", async () => {
-    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
+    renderBadge({ sessionId: "s1", planPhase: "executing" });
     expect(document.querySelector(".queue-badge")).toBeNull();
   });
 
@@ -55,7 +75,7 @@ describe("BuildQueueBadge", () => {
     buildQueues.map = {
       s1: queue(true, []),
     };
-    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
+    renderBadge({ sessionId: "s1", planPhase: "executing" });
     expect(document.querySelector(".queue-badge")).toBeNull();
   });
 
@@ -70,7 +90,7 @@ describe("BuildQueueBadge", () => {
         step("pending", "5"),
       ]),
     };
-    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
+    renderBadge({ sessionId: "s1", planPhase: "executing" });
     await expect.element(page.getByText("4/5")).toBeInTheDocument();
   });
 
@@ -85,7 +105,7 @@ describe("BuildQueueBadge", () => {
         step("pending", "5"),
       ]),
     };
-    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
+    renderBadge({ sessionId: "s1", planPhase: "executing" });
     const badge = document.querySelector(".queue-badge") as HTMLElement;
     expect(badge).not.toBeNull();
     expect(badge.style.getPropertyValue("--queue-pct")).toBe("80%");
@@ -101,7 +121,7 @@ describe("BuildQueueBadge", () => {
         step("done", "5"),
       ]),
     };
-    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
+    renderBadge({ sessionId: "s1", planPhase: "executing" });
     await expect.element(page.getByText("5/5")).toBeInTheDocument();
     const badge = document.querySelector(".queue-badge") as HTMLElement;
     expect(badge.style.getPropertyValue("--queue-pct")).toBe("100%");
@@ -117,8 +137,58 @@ describe("BuildQueueBadge", () => {
         step("done", "5"),
       ]),
     };
-    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
+    renderBadge({ sessionId: "s1", planPhase: "executing" });
     await expect.element(page.getByText("5/5")).toBeInTheDocument();
+  });
+
+  it("selected badge toggles the queue while the styled tooltip is enabled", async () => {
+    buildQueues.map = {
+      s1: queue(true, [step("done", "1"), step("pending", "2")]),
+    };
+    const onselect = vi.fn();
+    const toggle = vi.spyOn(buildQueueCollapse, "toggle");
+    renderBadge({
+      sessionId: "s1",
+      planPhase: "executing",
+      selected: true,
+      onselect,
+      tip: true,
+    });
+
+    const progressAria = m.queuebadge_aria({ resolved: 1, total: 2 });
+    const collapseName = `${m.buildqueue_collapse_aria()}. ${progressAria}`;
+    const expandName = `${m.buildqueue_expand_aria()}. ${progressAria}`;
+
+    const expandedButton = page.getByRole("button", { name: collapseName });
+    await expect.element(expandedButton).toHaveAttribute("aria-expanded", "true");
+    await expect.element(expandedButton).toHaveAttribute("aria-controls", "bqp-content-s1");
+    await expandedButton.click();
+    expect(toggle).toHaveBeenCalledOnce();
+    expect(buildQueueCollapse.collapsed).toBe(true);
+
+    const collapsedButton = page.getByRole("button", { name: expandName });
+    await expect.element(collapsedButton).toHaveAttribute("aria-expanded", "false");
+    await collapsedButton.click();
+    expect(buildQueueCollapse.collapsed).toBe(false);
+    expect(onselect).not.toHaveBeenCalled();
+  });
+
+  it("unselected badge selects its session and forces the queue open", async () => {
+    buildQueues.map = {
+      s1: queue(true, [step("done", "1"), step("pending", "2")]),
+    };
+    buildQueueCollapse.set(true);
+    const onselect = vi.fn();
+    renderBadge({ sessionId: "s1", planPhase: "executing", selected: false, onselect });
+
+    const name = `${m.buildqueue_expand_aria()}. ${m.queuebadge_aria({ resolved: 1, total: 2 })}`;
+    const button = page.getByRole("button", { name });
+    await expect.element(button).not.toHaveAttribute("aria-controls");
+    await button.click();
+
+    expect(onselect).toHaveBeenCalledOnce();
+    expect(onselect).toHaveBeenCalledWith("s1");
+    expect(buildQueueCollapse.collapsed).toBe(false);
   });
 });
 
@@ -137,43 +207,53 @@ describe("BuildQueueBadge — drifted (working but unreported)", () => {
 
   it("executing + no git + all pending → drifted (git not consulted)", async () => {
     buildQueues.map = { s1: queue(true, allPending) };
-    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
+    renderBadge({ sessionId: "s1", planPhase: "executing" });
     await expectDrifted();
+  });
+
+  it("drifted badge uses the same toggle interaction", async () => {
+    buildQueues.map = { s1: queue(true, allPending) };
+    renderBadge({ sessionId: "s1", planPhase: "executing", selected: true });
+
+    const name = `${m.buildqueue_collapse_aria()}. ${m.queuebadge_stale_aria({ total: 3 })}`;
+    await page.getByRole("button", { name }).click();
+
+    expect(buildQueueCollapse.collapsed).toBe(true);
   });
 
   it("planPhase null (gate off) + no git + all pending → drifted", async () => {
     buildQueues.map = { s1: queue(true, allPending) };
-    render(BuildQueueBadge, { sessionId: "s1", planPhase: null });
+    renderBadge({ sessionId: "s1", planPhase: null });
     await expectDrifted();
   });
 
   it("planning + open PR + all pending → drifted", async () => {
     buildQueues.map = { s1: queue(true, allPending) };
-    render(BuildQueueBadge, { sessionId: "s1", planPhase: "planning", git: git("open") });
+    renderBadge({ sessionId: "s1", planPhase: "planning", git: git("open") });
     await expectDrifted();
   });
 
   it("planning + merged PR + all pending → NOT drifted (resolved PR)", async () => {
     buildQueues.map = { s1: queue(true, allPending) };
-    render(BuildQueueBadge, { sessionId: "s1", planPhase: "planning", git: git("merged") });
+    renderBadge({ sessionId: "s1", planPhase: "planning", git: git("merged") });
     await expectNotDrifted();
   });
 
   it("planning + closed PR + all pending → NOT drifted", async () => {
     buildQueues.map = { s1: queue(true, allPending) };
-    render(BuildQueueBadge, { sessionId: "s1", planPhase: "planning", git: git("closed") });
+    renderBadge({ sessionId: "s1", planPhase: "planning", git: git("closed") });
     await expectNotDrifted();
   });
 
   it("planning + no git + all pending → NOT drifted (degrade closed)", async () => {
     buildQueues.map = { s1: queue(true, allPending) };
-    render(BuildQueueBadge, { sessionId: "s1", planPhase: "planning" });
+    renderBadge({ sessionId: "s1", planPhase: "planning" });
     await expectNotDrifted();
   });
 
   it('planning + git state "none" + all pending → NOT drifted', async () => {
     buildQueues.map = { s1: queue(true, allPending) };
-    render(BuildQueueBadge, { sessionId: "s1", planPhase: "planning", git: git("none") });
+    renderBadge({ sessionId: "s1", planPhase: "planning", git: git("none") });
     await expectNotDrifted();
   });
 
@@ -181,7 +261,7 @@ describe("BuildQueueBadge — drifted (working but unreported)", () => {
     buildQueues.map = {
       s1: queue(true, [step("active", "1"), step("pending", "2"), step("pending", "3")]),
     };
-    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
+    renderBadge({ sessionId: "s1", planPhase: "executing" });
     await expectNotDrifted();
   });
 
@@ -189,14 +269,14 @@ describe("BuildQueueBadge — drifted (working but unreported)", () => {
     buildQueues.map = {
       s1: queue(true, [step("done", "1"), step("pending", "2"), step("pending", "3")]),
     };
-    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
+    renderBadge({ sessionId: "s1", planPhase: "executing" });
     await expectNotDrifted();
     await expect.element(page.getByText("1/3")).toBeInTheDocument();
   });
 
   it("clears automatically once a step becomes active", async () => {
     buildQueues.map = { s1: queue(true, allPending) };
-    render(BuildQueueBadge, { sessionId: "s1", planPhase: "executing" });
+    renderBadge({ sessionId: "s1", planPhase: "executing" });
     await expectDrifted();
 
     buildQueues.map = {

--- a/ui/src/lib/components/BuildQueueBadge.svelte
+++ b/ui/src/lib/components/BuildQueueBadge.svelte
@@ -3,6 +3,7 @@
   import { m } from "$lib/paraglide/messages";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
   import { statusTip } from "$lib/actions/statusTip.svelte";
+  import { buildQueueCollapse } from "$lib/build-queue-collapse.svelte";
   import type { Session, GitState } from "$lib/types";
 
   // `tip` (Herd card only): swap the native title for the styled statusTip tooltip.
@@ -10,11 +11,15 @@
     sessionId,
     planPhase,
     git,
+    selected,
+    onselect,
     tip = false,
   }: {
     sessionId: string;
     planPhase: Session["planPhase"];
     git?: GitState;
+    selected: boolean;
+    onselect: (id: string) => void;
     tip?: boolean;
   } = $props();
 
@@ -40,32 +45,57 @@
       (queue?.steps.every((s) => s.status === "pending") ?? false) &&
       working,
   );
+  const expanded = $derived(selected && !buildQueueCollapse.collapsed);
+  const actionLabel = $derived(
+    expanded ? m.buildqueue_collapse_aria() : m.buildqueue_expand_aria(),
+  );
+  const contentId = $derived(`bqp-content-${sessionId}`);
+
+  function activate(e: MouseEvent) {
+    e.stopPropagation();
+    if (selected) {
+      buildQueueCollapse.toggle();
+      return;
+    }
+    onselect(sessionId);
+    buildQueueCollapse.set(false);
+  }
 </script>
 
 {#if queue?.approved && total > 0}
   {#if drifted}
-    <span
+    <button
+      type="button"
       class="queue-badge queue-badge--stale"
-      role="img"
+      onclick={activate}
       title={tip ? undefined : m.queuebadge_stale_title({ total })}
-      aria-label={m.queuebadge_stale_aria({ total })}
+      aria-expanded={expanded}
+      aria-controls={selected ? contentId : undefined}
+      aria-label={`${actionLabel}. ${m.queuebadge_stale_aria({ total })}`}
       use:coachTarget={"build-queue-progress"}
-      use:statusTip={tip ? { text: m.queuebadge_stale_title({ total }) } : null}
+      use:statusTip={tip
+        ? { text: m.queuebadge_stale_title({ total }), stopClickPropagation: false }
+        : null}
     >
       <span class="queue-label">⚠ {total}</span>
-    </span>
+    </button>
   {:else}
-    <span
+    <button
+      type="button"
       class="queue-badge"
-      role="img"
       style="--queue-pct: {pct}%"
+      onclick={activate}
       title={tip ? undefined : m.queuebadge_title({ resolved, total })}
-      aria-label={m.queuebadge_aria({ resolved, total })}
+      aria-expanded={expanded}
+      aria-controls={selected ? contentId : undefined}
+      aria-label={`${actionLabel}. ${m.queuebadge_aria({ resolved, total })}`}
       use:coachTarget={"build-queue-progress"}
-      use:statusTip={tip ? { text: m.queuebadge_title({ resolved, total }) } : null}
+      use:statusTip={tip
+        ? { text: m.queuebadge_title({ resolved, total }), stopClickPropagation: false }
+        : null}
     >
       <span class="queue-label">{m.queuebadge_label({ resolved, total })}</span>
-    </span>
+    </button>
   {/if}
 {/if}
 
@@ -82,17 +112,25 @@
     letter-spacing: 0.12em;
     text-transform: uppercase;
     font-weight: 600;
+    font-family: inherit;
+    margin: 0;
     padding: 1px 6px;
     border: 1px solid var(--color-amber);
     border-radius: 2px;
     color: var(--color-amber);
     white-space: nowrap;
     overflow: hidden;
+    cursor: pointer;
     background: linear-gradient(
       to right,
       color-mix(in srgb, var(--color-amber) 22%, transparent) var(--queue-pct),
       transparent var(--queue-pct)
     );
+  }
+
+  .queue-badge:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
   }
 
   /* STALE (drifted): agent is working but hasn't posted step status, so every

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -766,6 +766,8 @@
 
     <UnitRowRight
       {session}
+      {selected}
+      {onselect}
       {git}
       {nowMs}
       {ondecommission}

--- a/ui/src/lib/components/unit-row/UnitRowRight.svelte
+++ b/ui/src/lib/components/unit-row/UnitRowRight.svelte
@@ -15,6 +15,8 @@
 
   let {
     session,
+    selected,
+    onselect,
     git,
     nowMs,
     ondecommission,
@@ -33,6 +35,8 @@
     elapsedEl = $bindable(),
   }: {
     session: Session;
+    selected: boolean;
+    onselect: (id: string) => void;
     git?: GitState;
     nowMs: number;
     ondecommission?: (id: string) => void;
@@ -160,7 +164,14 @@
   <ResearchBadge {session} tip />
   {#if !stepperTerminal}<PrBadge {git} sessionId={session.id} />{/if}
   <CriticBadge sessionId={session.id} tip prUrl={git?.url} />
-  <BuildQueueBadge sessionId={session.id} planPhase={session.planPhase} {git} tip />
+  <BuildQueueBadge
+    sessionId={session.id}
+    planPhase={session.planPhase}
+    {git}
+    {selected}
+    {onselect}
+    tip
+  />
   <PlanGateBadge
     {session}
     allowView={false}

--- a/ui/src/lib/feature-announcements/entries/v1.34.0-build-queue-progress.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.34.0-build-queue-progress.ts
@@ -1,7 +1,7 @@
 import type { FeatureAnnouncement } from "../../feature-announcements";
 
 const entry = {
-  // coachTarget "build-queue-progress" is on the BuildQueueBadge span itself
+  // coachTarget "build-queue-progress" is on the BuildQueueBadge control itself
   // (conditionally rendered when approved + steps > 0). 1.33.0 is the latest
   // released tag, so this ships in 1.34.0.
   id: "build-queue-progress",

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-build-queue-progress-toggle.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-build-queue-progress-toggle.ts
@@ -1,0 +1,11 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "build-queue-progress-toggle",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_build_queue_progress_toggle_title",
+  bodyKey: "feat_build_queue_progress_toggle_body",
+  targetId: "build-queue-progress",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## Goal

Make the build-queue progress badge a direct, predictable control for the queue above the terminal. Previously the badge reported progress but could not open or close the queue, forcing users to find a separate control.

## Solution

- Clicking the selected session's progress badge now collapses or expands its build queue.
- Clicking another session's progress badge selects that session and opens its queue.
- The same interaction works for normal and stale progress badges.
- The badge is now a keyboard-accessible button with localized action labels and expanded-state semantics.

## Technical details

- Reuses the existing shared build-queue collapse state instead of introducing a second visibility path.
- Threads the selected session state and selection callback through the existing unit-row components.
- Lets actionable status-tip controls opt out of the tooltip action's default click interception while preserving existing read-only badge behavior.
- Adds browser regression coverage for selected, unselected, tooltip-enabled, and stale badge interactions.
- Adds the EN/DE feature-announcement copy for release `1.44.0`.

## Validation

- `bun run lint`
- `cd ui && bun run check`
- `cd ui && bun run test:node` — 2,341 tests passed
- `cd ui && bun run test:browser -- --maxWorkers=1` — 1,284 tests passed
- `cd ui && bun run check:i18n`
- `bun run check:glossary`
- `bun run check:announcement-versions`
- `bash scripts/check-feature-catalog.sh`
- `bash scripts/check-branch-hygiene.sh`
