### PR TITLE
fix(ui): improve command bar result relevance

### DIFF
--- a/ui/src/lib/components/CommandBar.browser.test.ts
+++ b/ui/src/lib/components/CommandBar.browser.test.ts
@@ -263,6 +263,51 @@ describe("CommandBar — fuzzy matching", () => {
     // …yet the option still reads as the full, untouched title.
     await expect.element(page.getByRole("option").first()).toHaveTextContent("newer");
   });
+
+  it("does not stitch one fuzzy match across separate session fields", async () => {
+    renderBar({
+      sessions: [session({ id: "cross", name: "ne", desig: "w", repoPath: "/repos/none" })],
+    });
+
+    await page.getByRole("combobox").fill("new");
+
+    expect(page.getByRole("option", { name: /^ne\b/ }).elements()).toHaveLength(0);
+  });
+
+  it("rejects a long-gap fuzzy title match in the command bar", async () => {
+    renderBar({
+      sessions: [session({ id: "wide", name: "attachment-hover-preview" })],
+    });
+
+    await page.getByRole("combobox").fill("new");
+
+    expect(page.getByRole("option", { name: /attachment-hover-preview/ }).elements()).toHaveLength(
+      0,
+    );
+  });
+
+  it("shows a designation when it is the winning session field", async () => {
+    renderBar({
+      sessions: [session({ id: "desig", name: "alpha", desig: "TASK-99" })],
+    });
+
+    await page.getByRole("combobox").fill("task-99");
+
+    await expect.element(page.getByRole("option", { name: /alpha/ })).toHaveTextContent("TASK-99");
+  });
+
+  it("highlights the repository name when it is the winning session field", async () => {
+    renderBar({
+      sessions: [session({ id: "repo", name: "zeta", repoPath: "/repos/alpha" })],
+    });
+
+    await page.getByRole("combobox").fill("alpha");
+
+    const row = page.getByRole("option", { name: /zeta/ });
+    await expect.element(row).toBeVisible();
+    expect(row.element().querySelector(".cb-sub mark.cb-hl")?.textContent).toBe("alpha");
+    expect(page.getByRole("option", { name: /alpha/ }).elements()).toHaveLength(2);
+  });
 });
 
 describe("CommandBar — selection", () => {
@@ -449,6 +494,51 @@ describe("CommandBar — Commands group", () => {
     await page.getByRole("option", { name: /Broadcast/ }).click();
     expect(run).toHaveBeenCalledTimes(1);
     expect(onclose).toHaveBeenCalledTimes(1);
+  });
+
+  it("puts a stronger command match ahead of weaker navigation groups", async () => {
+    const run = vi.fn();
+    const commands: Command[] = [
+      { id: "new-task", label: () => m.commandbar_cmd_new_task(), run },
+    ];
+    const { onclose, onselectsession } = renderBar({
+      sessions: [session({ id: "fuzzy", name: "n-e-w" })],
+      commands,
+    });
+
+    await page.getByRole("combobox").fill("new");
+
+    const first = page.getByRole("option").first();
+    await expect.element(first).toHaveTextContent(m.commandbar_cmd_new_task());
+    expect(document.querySelector(".cb-group")?.textContent).toBe(m.commandbar_group_commands());
+    expect(
+      page
+        .getByRole("option", { name: new RegExp(m.commandbar_cmd_new_task()) })
+        .element()
+        .querySelector("mark.cb-hl")?.textContent,
+    ).toBe("New");
+
+    await userEvent.keyboard("{Enter}");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(onclose).toHaveBeenCalledTimes(1);
+    expect(onselectsession).not.toHaveBeenCalled();
+  });
+
+  it("keeps an exact session title ahead of a prefix command match", async () => {
+    const run = vi.fn();
+    const commands: Command[] = [
+      { id: "new-task", label: () => m.commandbar_cmd_new_task(), run },
+    ];
+    const { onselectsession } = renderBar({
+      sessions: [session({ id: "exact", name: "new" })],
+      commands,
+    });
+
+    await page.getByRole("combobox").fill("new");
+    await userEvent.keyboard("{Enter}");
+
+    expect(onselectsession).toHaveBeenCalledWith("exact");
+    expect(run).not.toHaveBeenCalled();
   });
 
   it("surfaces a learnings-style command via its keyword synonyms and runs it on activation", async () => {

--- a/ui/src/lib/components/CommandBar.browser.test.ts
+++ b/ui/src/lib/components/CommandBar.browser.test.ts
@@ -498,9 +498,7 @@ describe("CommandBar — Commands group", () => {
 
   it("puts a stronger command match ahead of weaker navigation groups", async () => {
     const run = vi.fn();
-    const commands: Command[] = [
-      { id: "new-task", label: () => m.commandbar_cmd_new_task(), run },
-    ];
+    const commands: Command[] = [{ id: "new-task", label: () => m.commandbar_cmd_new_task(), run }];
     const { onclose, onselectsession } = renderBar({
       sessions: [session({ id: "fuzzy", name: "n-e-w" })],
       commands,
@@ -526,9 +524,7 @@ describe("CommandBar — Commands group", () => {
 
   it("keeps an exact session title ahead of a prefix command match", async () => {
     const run = vi.fn();
-    const commands: Command[] = [
-      { id: "new-task", label: () => m.commandbar_cmd_new_task(), run },
-    ];
+    const commands: Command[] = [{ id: "new-task", label: () => m.commandbar_cmd_new_task(), run }];
     const { onselectsession } = renderBar({
       sessions: [session({ id: "exact", name: "new" })],
       commands,

--- a/ui/src/lib/components/CommandBar.svelte
+++ b/ui/src/lib/components/CommandBar.svelte
@@ -46,23 +46,23 @@
   // slash and manifest paths a leading one — strip one so the join never doubles up.
   const docUrl = (path: string) => DOCS_URL.replace(/\/$/, "") + path;
 
-  // Row unions the three navigation targets. `oid` (assigned when the flat option
-  // list is built) is a row's index within the SELECTABLE-only sequence — group
-  // header rows are never part of it, so the roving cursor structurally skips them.
-  // `hl` holds the indices within the row's PRIMARY text that the query matched, for
-  // highlighting; empty when there is no query or the match landed outside the primary.
+  // Row unions the navigation and action targets. `rank` is comparable across every kind
+  // for a typed query; `oid` (assigned only after groups are relevance-ordered) is the row's
+  // index within the SELECTABLE-only sequence, so roving navigation skips group headers.
   type Row =
     | {
         kind: "session";
         id: string;
         title: string;
+        designation: string;
         repoPath: string;
         repoName: string | null;
         status: string;
         hl: number[];
-        // Surfaced via a `prompt` (description) substring while the title itself did not
-        // match — drives the "matches description" affordance so the row isn't unexplained.
+        designationHl: number[];
+        repoHl: number[];
         promptMatch: boolean;
+        rank: number;
       }
     | {
         kind: "repo";
@@ -74,12 +74,44 @@
         name: string;
         display: string;
         hl: number[];
+        displayHl: number[];
         hasLiveSession: boolean;
+        rank: number;
       }
-    | { kind: "lens"; lens: HerdFilter; label: string; icon: string; hl: number[] }
-    | { kind: "command"; id: string; label: string; run: () => void }
-    | { kind: "doc"; title: string; url: string };
+    | { kind: "lens"; lens: HerdFilter; label: string; icon: string; hl: number[]; rank: number }
+    | { kind: "command"; id: string; label: string; run: () => void; hl: number[]; rank: number }
+    | { kind: "doc"; title: string; url: string; hl: number[]; rank: number };
   type OptRow = Row & { oid: number };
+
+  type MatchSource =
+    | "title"
+    | "designation"
+    | "session-repo"
+    | "repo-name"
+    | "repo-display";
+  type FieldMatch = { source: MatchSource; rank: number; positions: number[] };
+
+  function bestFieldMatch(
+    query: string,
+    fields: { source: MatchSource; text: string; penalty?: number }[],
+  ): FieldMatch | null {
+    let best: FieldMatch | null = null;
+    for (const field of fields) {
+      const result = fuzzyScore(query, field.text);
+      if (result === null) continue;
+      const match = {
+        source: field.source,
+        rank: result.score - (field.penalty ?? 0),
+        positions: result.positions,
+      };
+      if (best === null || match.rank > best.rank) best = match;
+    }
+    return best;
+  }
+
+  function isPresent<T>(value: T | null): value is T {
+    return value !== null;
+  }
 
   let filter = $state(untrack(() => initialFilter) ?? "");
   let activeIdx = $state(0);
@@ -118,44 +150,53 @@
 
   const autopilotPausedLabel = $derived(m.session_autopilot_paused_label().toLocaleUpperCase());
 
-  // Fuzzy-match + rank, per group. The fuzzy matcher runs only over the SHORT display
-  // fields (title/desig/repo name) so a short query can't subsequence-match nearly every
-  // long prompt; the haystack starts with the primary text so matched positions below its
-  // length map straight onto the highlighted primary. A blank query scores every row 0, so
-  // the sort promotes needs-input sessions first and then falls back to recency.
-  // (updatedAt / lastUsedAt are the last-activity signals; lenses keep their fixed order.)
+  // Match each short visible field independently: a query can never start in a title and
+  // finish in a designation/repository. Long prompt text remains substring-only and ranks
+  // below every visible compact fuzzy match. A blank query gives every primary field rank 0,
+  // preserving needs-input + recency as the session ordering signals.
   const sessionRows = $derived<Row[]>(
     sessions
       .map((s) => {
         const title = s.name || s.desig;
-        const repoName = repos.nameFor(s.repoPath) ?? "";
+        const repoName = repos.nameFor(s.repoPath);
+        const match = bestFieldMatch(q, [
+          { source: "title", text: title },
+          { source: "designation", text: s.desig, penalty: 100 },
+          { source: "session-repo", text: repoName ?? "", penalty: 100 },
+        ]);
+        const promptMatch = match === null && q !== "" && s.prompt.toLowerCase().includes(q);
+        if (match === null && !promptMatch) return null;
         return {
           s,
           title,
-          res: fuzzyScore(q, title + " " + s.desig + " " + repoName),
-          // `prompt` (description) is matched by a contiguous SUBSTRING, not fuzzily —
-          // selective enough to stay useful over long prompts.
-          promptMatch: q !== "" && s.prompt.toLowerCase().includes(q),
+          repoName,
+          match,
+          promptMatch,
+          rank: match?.rank ?? 500,
         };
       })
-      .filter((e) => e.res !== null || e.promptMatch)
+      .filter(isPresent)
       .sort(
         (a, b) =>
-          (b.res?.score ?? 0) - (a.res?.score ?? 0) ||
+          b.rank - a.rank ||
           Number(needsInputIds.has(b.s.id)) - Number(needsInputIds.has(a.s.id)) ||
           b.s.updatedAt - a.s.updatedAt,
       )
-      .map(({ s, title, res, promptMatch }) => ({
+      .map(({ s, title, repoName, match, promptMatch, rank }): Row => ({
         kind: "session",
         id: s.id,
         title,
+        designation: s.desig,
         repoPath: s.repoPath,
-        repoName: repos.nameFor(s.repoPath),
+        repoName,
         status: s.autopilotPaused
           ? autopilotPausedLabel
           : statusLabel(displayStatus(s, workingBlocked)),
-        hl: (res?.positions ?? []).filter((p) => p < title.length),
+        hl: match?.source === "title" ? match.positions : [],
+        designationHl: match?.source === "designation" ? match.positions : [],
+        repoHl: match?.source === "session-repo" ? match.positions : [],
         promptMatch,
+        rank,
       })),
   );
 
@@ -169,17 +210,28 @@
   );
   const repoRows = $derived<Row[]>(
     repos.entries
-      .map((r) => ({ r, res: fuzzyScore(q, r.name + " " + r.display) }))
-      .filter((e) => e.res !== null)
-      .sort((a, b) => b.res!.score - a.res!.score || (b.r.lastUsedAt ?? 0) - (a.r.lastUsedAt ?? 0))
-      .map(({ r, res }) => ({
+      .map((r) => {
+        const match = bestFieldMatch(q, [
+          { source: "repo-name", text: r.name },
+          { source: "repo-display", text: r.display, penalty: 100 },
+        ]);
+        return match === null ? null : { r, match };
+      })
+      .filter(isPresent)
+      .sort(
+        (a, b) =>
+          b.match.rank - a.match.rank || (b.r.lastUsedAt ?? 0) - (a.r.lastUsedAt ?? 0),
+      )
+      .map(({ r, match }): Row => ({
         kind: "repo",
         path: r.path,
         realPath: r.realPath,
         name: r.name,
         display: r.display,
-        hl: res!.positions.filter((p) => p < r.name.length),
+        hl: match.source === "repo-name" ? match.positions : [],
+        displayHl: match.source === "repo-display" ? match.positions : [],
         hasLiveSession: liveRepoPaths.has(r.realPath),
+        rank: match.rank,
       })),
   );
 
@@ -187,56 +239,90 @@
     LENSES.map((l, i) => ({ l, i, label: l.label(), res: fuzzyScore(q, l.label()) }))
       .filter((e) => e.res !== null)
       .sort((a, b) => b.res!.score - a.res!.score || a.i - b.i)
-      .map(({ l, label, res }) => ({
+      .map(({ l, label, res }): Row => ({
         kind: "lens",
         lens: l.id,
         label,
         icon: lensGlyph[l.id],
         hl: res!.positions, // the whole label is the primary text
+        rank: res!.score,
       })),
   );
 
   // Commands + Docs are search-driven, so they stay hidden until the user types: with an
   // empty query every command (≤6) and doc (~14) would match and flood the bar on open,
   // burying the recency-ordered sessions/repos/lenses that make it a quick-switcher.
-  // Commands match on label + optional localized keyword synonyms; docs on their title +
-  // the generated keyword haystack (description + headings), so non-title queries resolve.
-  // These match by SUBSTRING (not the fuzzy scorer used for the navigation groups): their
-  // keyword haystacks are long free text, over which a short fuzzy subsequence would match
-  // nearly everything and flood the bar.
+  // Labels/titles use the same compact scorer as navigation rows. Long keyword haystacks stay
+  // substring-only at rank 500, so synonyms remain discoverable without outranking visible text.
   const commandRows = $derived<Row[]>(
     q === ""
       ? []
       : commands
-          .filter((c) => (c.label() + " " + (c.keywords?.() ?? "")).toLowerCase().includes(q))
-          .map((c) => ({ kind: "command", id: c.id, label: c.label(), run: c.run })),
+          .map((c, order) => {
+            const label = c.label();
+            const result = fuzzyScore(q, label);
+            const keywordMatch = result === null && (c.keywords?.() ?? "").toLowerCase().includes(q);
+            if (result === null && !keywordMatch) return null;
+            return { c, order, label, result, rank: result?.score ?? 500 };
+          })
+          .filter(isPresent)
+          .sort((a, b) => b.rank - a.rank || a.order - b.order)
+          .map(({ c, label, result, rank }): Row => ({
+            kind: "command",
+            id: c.id,
+            label,
+            run: c.run,
+            hl: result?.positions ?? [],
+            rank,
+          })),
   );
 
   const docRows = $derived<Row[]>(
     q === ""
       ? []
-      : DOCS_PAGES.filter((d) => (d.title.toLowerCase() + " " + d.keywords).includes(q)).map(
-          (d) => ({ kind: "doc", title: d.title, url: docUrl(d.path) }),
-        ),
+      : DOCS_PAGES.map((d, order) => {
+          const result = fuzzyScore(q, d.title);
+          const keywordMatch = result === null && d.keywords.includes(q);
+          if (result === null && !keywordMatch) return null;
+          return { d, order, result, rank: result?.score ?? 500 };
+        })
+          .filter(isPresent)
+          .sort((a, b) => b.rank - a.rank || a.order - b.order)
+          .map(({ d, result, rank }): Row => ({
+            kind: "doc",
+            title: d.title,
+            url: docUrl(d.path),
+            hl: result?.positions ?? [],
+            rank,
+          })),
   );
 
-  // Non-empty groups, each row tagged with its global selectable index (`oid`).
-  // Headers are rendered separately and carry no oid — so ArrowUp/Down (which walk
-  // oids) and Enter (which acts on options[activeIdx]) can never land on one.
+  // Typed queries order groups by their strongest row. Blank queries retain the established
+  // Sessions → Repositories → Lenses order. Global option ids are assigned only after that
+  // final group order, so Arrow/Enter/Alt+digit always target the rendered sequence.
   const groups = $derived.by(() => {
-    let i = 0;
-    const build = (key: string, label: string, rows: Row[]) => ({
+    const build = (key: string, label: string, rows: Row[], order: number) => ({
       key,
       label,
-      rows: rows.map((r): OptRow => ({ ...r, oid: i++ })),
+      rows,
+      rank: rows.reduce((max, row) => Math.max(max, row.rank), Number.NEGATIVE_INFINITY),
+      order,
     });
-    return [
-      build("sessions", m.commandbar_group_sessions(), sessionRows),
-      build("repos", m.commandbar_group_repos(), repoRows),
-      build("lenses", m.commandbar_group_lenses(), lensRows),
-      build("commands", m.commandbar_group_commands(), commandRows),
-      build("docs", m.commandbar_group_docs(), docRows),
+    const ranked = [
+      build("sessions", m.commandbar_group_sessions(), sessionRows, 0),
+      build("repos", m.commandbar_group_repos(), repoRows, 1),
+      build("lenses", m.commandbar_group_lenses(), lensRows, 2),
+      build("commands", m.commandbar_group_commands(), commandRows, 3),
+      build("docs", m.commandbar_group_docs(), docRows, 4),
     ].filter((g) => g.rows.length > 0);
+    if (q !== "") ranked.sort((a, b) => b.rank - a.rank || a.order - b.order);
+
+    let oid = 0;
+    return ranked.map(({ key, label, rows }) => ({
+      key,
+      label,
+      rows: rows.map((row): OptRow => ({ ...row, oid: oid++ })),
+    }));
   });
 
   const options = $derived<OptRow[]>(groups.flatMap((g) => g.rows));
@@ -444,14 +530,20 @@
               >
               <b class="cb-primary">{@render primary(row.title, row.hl)}</b>
               <span class="cb-sub">
-                {#if row.repoName}{row.repoName} ·
+                {#if row.designationHl.length > 0}{@render primary(
+                    row.designation,
+                    row.designationHl,
+                  )} ·
+                {/if}{#if row.repoName}{@render primary(row.repoName, row.repoHl)} ·
                 {/if}{row.status}{#if row.promptMatch && row.hl.length === 0}
                   · {m.commandbar_prompt_match()}{/if}
               </span>
             {:else if row.kind === "repo"}
               <span class="cb-ic" aria-hidden="true">{projectIcons.iconFor(row.path) ?? "▣"}</span>
               <b class="cb-primary">{@render primary(row.name, row.hl)}</b>
-              <span class="cb-sub">{row.display} · {m.commandbar_repo_affordance()}</span>
+              <span class="cb-sub"
+                >{@render primary(row.display, row.displayHl)} · {m.commandbar_repo_affordance()}</span
+              >
               {#if row.hasLiveSession}
                 <!-- Secondary-action hint. Separate non-shrinking element so a long
                      display path truncates .cb-sub, never this discoverability cue. -->
@@ -462,10 +554,10 @@
               <b class="cb-primary">{@render primary(row.label, row.hl)}</b>
             {:else if row.kind === "command"}
               <span class="cb-ic" aria-hidden="true">⌘</span>
-              <b class="cb-primary">{row.label}</b>
+              <b class="cb-primary">{@render primary(row.label, row.hl)}</b>
             {:else}
               <span class="cb-ic" aria-hidden="true">📄</span>
-              <b class="cb-primary">{row.title}</b>
+              <b class="cb-primary">{@render primary(row.title, row.hl)}</b>
               <span class="cb-sub">{m.commandbar_docs_affordance()}</span>
             {/if}
             <!-- Digit jump-hint, first ten rows only, revealed while Alt is held. Decorative

--- a/ui/src/lib/components/CommandBar.svelte
+++ b/ui/src/lib/components/CommandBar.svelte
@@ -83,12 +83,7 @@
     | { kind: "doc"; title: string; url: string; hl: number[]; rank: number };
   type OptRow = Row & { oid: number };
 
-  type MatchSource =
-    | "title"
-    | "designation"
-    | "session-repo"
-    | "repo-name"
-    | "repo-display";
+  type MatchSource = "title" | "designation" | "session-repo" | "repo-name" | "repo-display";
   type FieldMatch = { source: MatchSource; rank: number; positions: number[] };
 
   function bestFieldMatch(
@@ -218,10 +213,7 @@
         return match === null ? null : { r, match };
       })
       .filter(isPresent)
-      .sort(
-        (a, b) =>
-          b.match.rank - a.match.rank || (b.r.lastUsedAt ?? 0) - (a.r.lastUsedAt ?? 0),
-      )
+      .sort((a, b) => b.match.rank - a.match.rank || (b.r.lastUsedAt ?? 0) - (a.r.lastUsedAt ?? 0))
       .map(({ r, match }): Row => ({
         kind: "repo",
         path: r.path,
@@ -261,7 +253,8 @@
           .map((c, order) => {
             const label = c.label();
             const result = fuzzyScore(q, label);
-            const keywordMatch = result === null && (c.keywords?.() ?? "").toLowerCase().includes(q);
+            const keywordMatch =
+              result === null && (c.keywords?.() ?? "").toLowerCase().includes(q);
             if (result === null && !keywordMatch) return null;
             return { c, order, label, result, rank: result?.score ?? 500 };
           })

--- a/ui/src/lib/fuzzy.test.ts
+++ b/ui/src/lib/fuzzy.test.ts
@@ -3,7 +3,12 @@ import { fuzzyScore } from "./fuzzy";
 
 describe("fuzzyScore", () => {
   it("empty query matches everything with score 0 and no positions", () => {
-    expect(fuzzyScore("", "anything")).toEqual({ score: 0, positions: [] });
+    expect(fuzzyScore("", "anything")).toEqual({
+      score: 0,
+      positions: [],
+      kind: "empty",
+      span: 0,
+    });
   });
 
   it("returns null when the query is not a subsequence", () => {
@@ -15,11 +20,32 @@ describe("fuzzyScore", () => {
   });
 
   it("matches a contiguous substring and reports its positions", () => {
-    expect(fuzzyScore("bc", "abc")).toEqual({ score: expect.any(Number), positions: [1, 2] });
+    expect(fuzzyScore("bc", "abc")).toEqual({
+      score: expect.any(Number),
+      positions: [1, 2],
+      kind: "substring",
+      span: 2,
+    });
   });
 
   it("matches a non-contiguous subsequence", () => {
-    expect(fuzzyScore("ac", "abc")?.positions).toEqual([0, 2]);
+    expect(fuzzyScore("ac", "abc")).toMatchObject({
+      positions: [0, 2],
+      kind: "fuzzy",
+      span: 3,
+    });
+  });
+
+  it("keeps compact fuzzy abbreviations", () => {
+    expect(fuzzyScore("nwr", "newer")).toMatchObject({
+      positions: [0, 2, 4],
+      kind: "fuzzy",
+      span: 5,
+    });
+  });
+
+  it("rejects widely scattered subsequences", () => {
+    expect(fuzzyScore("new", "attachment-hover-preview")).toBeNull();
   });
 
   it("is case-insensitive", () => {
@@ -32,13 +58,27 @@ describe("fuzzyScore", () => {
     expect(fuzzyScore("x", "İx")?.positions).toEqual([1]);
   });
 
+  it("ranks exact, prefix, substring and fuzzy matches in that order", () => {
+    const exact = fuzzyScore("new", "new")!;
+    const prefix = fuzzyScore("new", "new-task")!;
+    const substring = fuzzyScore("new", "renewed")!;
+    const fuzzy = fuzzyScore("new", "n-e-w")!;
+
+    expect(exact.kind).toBe("exact");
+    expect(prefix.kind).toBe("prefix");
+    expect(substring.kind).toBe("substring");
+    expect(fuzzy.kind).toBe("fuzzy");
+    expect(exact.score).toBeGreaterThan(prefix.score);
+    expect(prefix.score).toBeGreaterThan(substring.score);
+    expect(substring.score).toBeGreaterThan(fuzzy.score);
+  });
+
   it("ranks a prefix match above the same query matched mid-word", () => {
-    // "deploy" is a whole-word prefix of "deploy" but starts mid-word in "redeploy".
-    const exact = fuzzyScore("deploy", "deploy");
+    const prefix = fuzzyScore("deploy", "deployment");
     const mid = fuzzyScore("deploy", "redeploy");
-    expect(exact).not.toBeNull();
+    expect(prefix).not.toBeNull();
     expect(mid).not.toBeNull();
-    expect(exact!.score).toBeGreaterThan(mid!.score);
+    expect(prefix!.score).toBeGreaterThan(mid!.score);
   });
 
   it("rewards a word-boundary match over a mid-word one", () => {
@@ -51,5 +91,15 @@ describe("fuzzyScore", () => {
     const afterSep = fuzzyScore("w", "hello-world"); // 'w' preceded by '-'
     const midWord = fuzzyScore("e", "hello"); // 'e' mid-word
     expect(afterSep!.score).toBeGreaterThan(midWord!.score);
+  });
+
+  it("ranks compact fuzzy spans above wider spans in the same tier", () => {
+    const compact = fuzzyScore("abc", "a-b-c");
+    const wide = fuzzyScore("abc", "a---b---c");
+    expect(compact).not.toBeNull();
+    expect(wide).not.toBeNull();
+    expect(compact!.kind).toBe("fuzzy");
+    expect(wide!.kind).toBe("fuzzy");
+    expect(compact!.score).toBeGreaterThan(wide!.score);
   });
 });

--- a/ui/src/lib/fuzzy.ts
+++ b/ui/src/lib/fuzzy.ts
@@ -1,36 +1,48 @@
-/** Result of a successful fuzzy match: a relevance `score` (higher is better) and the
- *  indices in the ORIGINAL `text` that the query matched — the latter drive match
- *  highlighting, so they must line up with the un-lowercased string. */
+export type FuzzyKind = "empty" | "exact" | "prefix" | "substring" | "fuzzy";
+
+/** Result of a successful fuzzy match: a relevance `score` (higher is better), its
+ *  confidence `kind`, and the indices in the ORIGINAL `text` that the query matched —
+ *  the latter drive match highlighting, so they must line up with the un-lowercased string. */
 export interface FuzzyResult {
   score: number;
   positions: number[];
+  kind: FuzzyKind;
+  span: number;
 }
 
 const BASE = 1; // every consumed query char
 const BOUNDARY_BONUS = 10; // match at index 0 or right after a separator (prefixes win)
 const CONSEC_BONUS = 5; // match adjacent to the previous one (contiguous runs win)
 const SEPARATOR = /[\s\-_/.]/;
+const TIER_BASE: Record<Exclude<FuzzyKind, "empty">, number> = {
+  exact: 4000,
+  prefix: 3000,
+  substring: 2000,
+  fuzzy: 1000,
+};
+const QUALITY_LIMIT = 250;
 
 /**
  * Case-insensitive fuzzy subsequence match with relevance scoring.
  *
  * Returns `null` when `query` is not a subsequence of `text` (all query chars must appear in
- * order). An empty query matches everything with score 0 and no positions — callers rely on
- * this to preserve their default (unfiltered) ordering.
+ * order), or when a non-contiguous match spans too much unrelated text to be useful. An empty
+ * query matches everything with score 0 and no positions — callers rely on this to preserve
+ * their default (unfiltered) ordering.
  *
  * Matching is greedy left-to-right: each query char binds to the earliest remaining occurrence.
  * This is not an optimal alignment (a DP would find the highest-scoring one), but it is simple,
  * allocation-light, and more than adequate for the short strings a command bar searches.
  */
 export function fuzzyScore(query: string, text: string): FuzzyResult | null {
-  if (query.length === 0) return { score: 0, positions: [] };
+  if (query.length === 0) return { score: 0, positions: [], kind: "empty", span: 0 };
   const q = query.toLowerCase();
   // Compare case-insensitively per character against the ORIGINAL text — not a pre-lowercased
   // copy — so `positions` index the original string. Lowercasing the whole haystack can shift
   // indices when a char's lowercase form has a different length (e.g. "İ" → "i̇"), which would
   // misplace the highlight.
   const positions: number[] = [];
-  let score = 0;
+  let quality = 0;
   let qi = 0;
   let prev = -2; // guarantees the first match is never counted as "consecutive"
   for (let ti = 0; ti < text.length && qi < q.length; ti++) {
@@ -38,11 +50,25 @@ export function fuzzyScore(query: string, text: string): FuzzyResult | null {
       let bonus = BASE;
       if (ti === 0 || SEPARATOR.test(text[ti - 1])) bonus += BOUNDARY_BONUS;
       if (ti === prev + 1) bonus += CONSEC_BONUS;
-      score += bonus;
+      quality += bonus;
       positions.push(ti);
       prev = ti;
       qi++;
     }
   }
-  return qi === q.length ? { score, positions } : null;
+  if (qi !== q.length) return null;
+
+  const span = positions.at(-1)! - positions[0] + 1;
+  const consecutive = span === q.length;
+  let kind: Exclude<FuzzyKind, "empty">;
+  if (consecutive && positions[0] === 0 && span === text.length) kind = "exact";
+  else if (consecutive && positions[0] === 0) kind = "prefix";
+  else if (consecutive) kind = "substring";
+  else kind = "fuzzy";
+
+  if (kind === "fuzzy" && span > Math.max(q.length * 3, q.length + 2)) return null;
+
+  quality -= span - q.length;
+  quality = Math.max(-QUALITY_LIMIT, Math.min(QUALITY_LIMIT, quality));
+  return { score: TIER_BASE[kind] + quality, positions, kind, span };
 }

--- a/ui/src/lib/fuzzy.ts
+++ b/ui/src/lib/fuzzy.ts
@@ -22,6 +22,43 @@ const TIER_BASE: Record<Exclude<FuzzyKind, "empty">, number> = {
 };
 const QUALITY_LIMIT = 250;
 
+function findAlignment(
+  query: string,
+  text: string,
+): { positions: number[]; quality: number } | null {
+  // Compare case-insensitively per character against the ORIGINAL text — not a pre-lowercased
+  // copy — so `positions` index the original string. Lowercasing the whole haystack can shift
+  // indices when a char's lowercase form has a different length (e.g. "İ" → "i̇"), which would
+  // misplace the highlight.
+  const positions: number[] = [];
+  let quality = 0;
+  let qi = 0;
+  let prev = -2; // guarantees the first match is never counted as "consecutive"
+  for (let ti = 0; ti < text.length && qi < query.length; ti++) {
+    if (text[ti].toLowerCase() === query[qi]) {
+      let bonus = BASE;
+      if (ti === 0 || SEPARATOR.test(text[ti - 1])) bonus += BOUNDARY_BONUS;
+      if (ti === prev + 1) bonus += CONSEC_BONUS;
+      quality += bonus;
+      positions.push(ti);
+      prev = ti;
+      qi++;
+    }
+  }
+  return qi === query.length ? { positions, quality } : null;
+}
+
+function matchKind(
+  start: number,
+  span: number,
+  queryLength: number,
+  textLength: number,
+): Exclude<FuzzyKind, "empty"> {
+  if (span !== queryLength) return "fuzzy";
+  if (start !== 0) return "substring";
+  return span === textLength ? "exact" : "prefix";
+}
+
 /**
  * Case-insensitive fuzzy subsequence match with relevance scoring.
  *
@@ -37,38 +74,18 @@ const QUALITY_LIMIT = 250;
 export function fuzzyScore(query: string, text: string): FuzzyResult | null {
   if (query.length === 0) return { score: 0, positions: [], kind: "empty", span: 0 };
   const q = query.toLowerCase();
-  // Compare case-insensitively per character against the ORIGINAL text — not a pre-lowercased
-  // copy — so `positions` index the original string. Lowercasing the whole haystack can shift
-  // indices when a char's lowercase form has a different length (e.g. "İ" → "i̇"), which would
-  // misplace the highlight.
-  const positions: number[] = [];
-  let quality = 0;
-  let qi = 0;
-  let prev = -2; // guarantees the first match is never counted as "consecutive"
-  for (let ti = 0; ti < text.length && qi < q.length; ti++) {
-    if (text[ti].toLowerCase() === q[qi]) {
-      let bonus = BASE;
-      if (ti === 0 || SEPARATOR.test(text[ti - 1])) bonus += BOUNDARY_BONUS;
-      if (ti === prev + 1) bonus += CONSEC_BONUS;
-      quality += bonus;
-      positions.push(ti);
-      prev = ti;
-      qi++;
-    }
-  }
-  if (qi !== q.length) return null;
+  const alignment = findAlignment(q, text);
+  if (alignment === null) return null;
 
+  const { positions } = alignment;
   const span = positions.at(-1)! - positions[0] + 1;
-  const consecutive = span === q.length;
-  let kind: Exclude<FuzzyKind, "empty">;
-  if (consecutive && positions[0] === 0 && span === text.length) kind = "exact";
-  else if (consecutive && positions[0] === 0) kind = "prefix";
-  else if (consecutive) kind = "substring";
-  else kind = "fuzzy";
+  const kind = matchKind(positions[0], span, q.length, text.length);
 
   if (kind === "fuzzy" && span > Math.max(q.length * 3, q.length + 2)) return null;
 
-  quality -= span - q.length;
-  quality = Math.max(-QUALITY_LIMIT, Math.min(QUALITY_LIMIT, quality));
+  const quality = Math.max(
+    -QUALITY_LIMIT,
+    Math.min(QUALITY_LIMIT, alignment.quality - (span - q.length)),
+  );
   return { score: TIER_BASE[kind] + quality, positions, kind, span };
 }


### PR DESCRIPTION
## What changed

- rank exact, prefix, substring, and compact fuzzy matches in distinct relevance tiers
- reject noisy long-gap subsequences and prevent matches from stitching across separate fields
- rank command-bar groups by their strongest result while preserving the established blank-query ordering
- highlight whichever visible field actually produced the match

## Why

A precise query such as `new` could bury **New task** below weak session matches because results were grouped in a fixed order and the fuzzy matcher accepted widely scattered characters. The command bar now favors clean, explainable matches without changing its visual shell or empty-state behavior.

## Validation

- `CI=true bunx vitest run src/lib/fuzzy.test.ts src/lib/components/CommandBar.browser.test.ts` — 60 passed
- `CI=true bun run test` — 244 files, 3,630 tests passed
- `bun run check` — 0 errors, 0 warnings
- `scripts/check-branch-hygiene.sh` — linear off `origin/main`
- rebased onto current `origin/main` without conflicts