### PR TITLE
fix: codex reviewer 'agent host is busy' — confirm exec spawns by tab existence

### DIFF
--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -245,6 +245,18 @@ export function parseAgents(result: unknown): HerdrAgent[] {
   }));
 }
 
+/** Maps a `tab list` reply to `HerdrTab[]`. Shared by the sync `tabs()` and async
+ *  `tabsAsync()` so both parse the `result.tabs[]` shape identically. */
+export function parseTabs(parsed: unknown): HerdrTab[] {
+  const tabs = (parsed as { result?: { tabs?: Record<string, string>[] } })?.result?.tabs ?? [];
+  return tabs.map((t) => ({
+    tabId: t.tab_id ?? "",
+    label: t.label ?? "",
+    agentStatus: (t.agent_status ?? "unknown") as HerdrState,
+    workspaceId: t.workspace_id ?? "",
+  }));
+}
+
 /**
  * Maps a single herdr `AgentInfo` object (the `result.agent` of an `agent.start`
  * `agent_started` reply) to one `HerdrAgent`, using the SAME field mapping as
@@ -409,14 +421,14 @@ export class HerdrDriver implements IHerdrDriver {
 
   /** Every tab in the workspace — including husks with no live agent (`tab list`). */
   tabs(): HerdrTab[] {
-    const parsed = JSON.parse(this.runner(["tab", "list"]));
-    const tabs = parsed?.result?.tabs ?? [];
-    return tabs.map((t: Record<string, string>) => ({
-      tabId: t.tab_id,
-      label: t.label ?? "",
-      agentStatus: (t.agent_status ?? "unknown") as HerdrState,
-      workspaceId: t.workspace_id ?? "",
-    }));
+    return parseTabs(JSON.parse(this.runner(["tab", "list"])));
+  }
+
+  /** Async sibling of `tabs()` — same shape via `asyncRunner` so it never blocks the loop.
+   *  Used by resolveStartedAgent to tell a genuine spawn failure (tab gone) from a role
+   *  `exec` that already exited or a lagging registration (tab husk still present). */
+  async tabsAsync(): Promise<HerdrTab[]> {
+    return parseTabs(JSON.parse(await this.asyncRunner(["tab", "list"])));
   }
 
   /** Every pane across all tabs (`pane list`). Includes idle shell panes left behind by exited agents. */
@@ -544,21 +556,45 @@ export class HerdrDriver implements IHerdrDriver {
   /** Resolve the just-started agent from `agent list`, matching the unique tab we created
    *  for it (`tabId`) — deterministic, unlike the old cwd match (two sessions sharing a cwd
    *  could alias). The CLI `agent start` output exposes no terminal id, so a list read is the
-   *  only handle. An empty match means the agent isn't registered YET (a propagation lag, not
-   *  a slow list), so poll a bounded number of times. On exhaustion, warn distinctly — a
-   *  bounded retry masks transient staleness but not herdr-health decay (orphan accumulation
-   *  that eventually starves registration), so the signal must stay visible. The socket driver
-   *  reads terminal_id straight from the `agent.start` reply and needs none of this. */
+   *  only handle for a LIVE agent. Poll a bounded number of times for a registration lag.
+   *
+   *  A miss is NOT automatically a failure. `agent start` returning without throwing means the
+   *  spawn happened; a non-interactive role spawn (`codex exec`) runs to completion and EXITS,
+   *  which drops it from `agent list` while its tab husk lingers (`tab list`), and under load a
+   *  live agent's registration can lag past the poll window. Either way the review already ran
+   *  (or is running) and may have written its verdict — treating that as `error-spawn` would
+   *  wrongly delete its worktree. So on exhaustion decide by TAB existence, not agent liveness:
+   *    - tab still present ⇒ started; return a handle with an EMPTY terminal id (a completed
+   *      exec has no live terminal; `herdr.stop("")` is a safe no-op and callers re-derive a
+   *      live terminal by cwd where needed; the husk is reaped by the hourly orphan-tab sweep).
+   *      Do NOT close the tab here — a running-but-unregistered agent would be killed.
+   *    - tab gone ⇒ genuine failure (herdr never kept the tab) ⇒ throw.
+   *  The socket driver reads terminal_id straight from the `agent.start` reply and needs none of this. */
   private async resolveStartedAgent(tabId: string, cwd: string): Promise<HerdrAgent> {
     for (let attempt = 0; attempt < this.resolveAttempts; attempt++) {
       const match = (await this.listAsync()).find((a) => a.tabId === tabId);
       if (match) return match;
       if (attempt < this.resolveAttempts - 1) await sleep(this.resolveDelayMs);
     }
+    if ((await this.tabsAsync()).some((t) => t.tabId === tabId)) {
+      console.warn(
+        `[herdr] agent not in list but tab ${tabId} present — treating exec spawn as started (cwd ${cwd})`,
+      );
+      return {
+        agent: "",
+        agentStatus: "done",
+        cwd,
+        name: "",
+        paneId: "",
+        tabId,
+        terminalId: "",
+        workspaceId: "",
+      };
+    }
     console.warn(
-      `[herdr] agent resolve exhausted after ${this.resolveAttempts} attempts for tab ${tabId} (cwd ${cwd})`,
+      `[herdr] agent resolve exhausted and tab ${tabId} gone after ${this.resolveAttempts} attempts (cwd ${cwd})`,
     );
-    throw new Error(`herdr: started agent not found for tab ${tabId} (cwd ${cwd})`);
+    throw new Error(`herdr: started agent not found and tab gone for tab ${tabId} (cwd ${cwd})`);
   }
 
   private async startImpl(

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -246,8 +246,9 @@ export function parseAgents(result: unknown): HerdrAgent[] {
 }
 
 /** Maps a `tab list` reply to `HerdrTab[]`. Shared by the sync `tabs()` and async
- *  `tabsAsync()` so both parse the `result.tabs[]` shape identically. */
-export function parseTabs(parsed: unknown): HerdrTab[] {
+ *  `tabsAsync()` so both parse the `result.tabs[]` shape identically. Internal — not
+ *  exported (fallow flags an unused export; the parsers used cross-module are exported). */
+function parseTabs(parsed: unknown): HerdrTab[] {
   const tabs = (parsed as { result?: { tabs?: Record<string, string>[] } })?.result?.tabs ?? [];
   return tabs.map((t) => ({
     tabId: t.tab_id ?? "",

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -132,6 +132,24 @@ export function reviewerArgv(
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_CAP = 5;
 
+/** Zeroed usage for a completed reviewer whose transcript yields no totals — notably a Codex
+ *  role spawn (`codex exec` writes no Claude JSONL) or a half-written transcript. Recording
+ *  completion with zeros rather than skipping it keeps `reviewer_spawns.completedAt` honest: the
+ *  review DID finish and apply a verdict; only per-run token attribution is unavailable. Mirrors
+ *  review.ts's zeroedUsage. */
+const ZEROED_USAGE: SessionUsage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  total: 0,
+  messageCount: 0,
+  lastActivity: null,
+  byModel: {},
+  fullRecaches: 0,
+  sidechainCount: 0,
+};
+
 /** The reviewer's verdict JSON, as written to PLAN_VERDICT_FILE — untyped fields are coerced
  *  in finalize() (Task 6). Mirrors review.ts's RawVerdict. */
 export interface RawPlanVerdict {
@@ -601,7 +619,13 @@ export class PlanGateService {
     void this.deps.herdr.stop(terminalId).catch(() => {});
     try {
       const usage = await this.readUsage(sp.worktreePath, sp.reviewerSessionId);
-      if (usage) this.deps.store.completeReviewerSpawn(sp.reviewerSessionId, usage, this.now());
+      // Always complete the row (zeros when no transcript, e.g. a Codex exec) so it isn't
+      // re-listed as an orphan every boot and its completion is recorded.
+      this.deps.store.completeReviewerSpawn(
+        sp.reviewerSessionId,
+        usage ?? ZEROED_USAGE,
+        this.now(),
+      );
     } catch (err) {
       console.warn(`[plan-gate] orphan usage capture failed for ${sp.reviewerSessionId}:`, err);
     }
@@ -675,12 +699,19 @@ export class PlanGateService {
       else if (gate.decision === "changes_requested") await this.applyChangesRequested(f, gate);
       else this.applyError(f, gate); // timeout / unparseable verdict
       // Persist the reviewer's token total for exact cost attribution (issue #502). Best-effort:
-      // a missing/half-written transcript leaves the spawn row's totals null rather than
-      // stranding finalize. Safe to read before the `finally`'s worktree removal: the transcript
+      // a missing/half-written transcript (or a Codex exec, which writes none) completes the row
+      // with zeroed totals rather than stranding finalize or leaving `completedAt` null. Safe to
+      // read before the `finally`'s worktree removal: the transcript
       // lives under ~/.claude/projects (keyed by worktree path), not inside the worktree itself.
       try {
         const usage = await this.readUsage(f.worktreePath, f.reviewerSessionId);
-        if (usage) this.deps.store.completeReviewerSpawn(f.reviewerSessionId, usage, this.now());
+        // Complete the row even when usage is null (Codex exec writes no transcript) so
+        // `completedAt` reflects that the review finished — not a silent 0/N gap.
+        this.deps.store.completeReviewerSpawn(
+          f.reviewerSessionId,
+          usage ?? ZEROED_USAGE,
+          this.now(),
+        );
       } catch (err) {
         console.warn(`[plan-gate] usage capture failed for ${f.sessionId}:`, err);
       }

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -215,6 +215,10 @@ test("start rolls back its orphan tab when agent start fails", async () => {
 // ── read-back resolve: registration staleness, tab-keying, exhaustion (reviewer-spawn race) ──
 
 const EMPTY_LIST = JSON.stringify({ result: { type: "agent_list", agents: [] } });
+const EMPTY_TABS = JSON.stringify({ result: { type: "tab_list", tabs: [] } });
+const TAB_LIST_WITH_NEW = JSON.stringify({
+  result: { type: "tab_list", tabs: [{ tab_id: "t_new", label: "flatten", workspace_id: "w1" }] },
+});
 
 test("start: resolve retries until the agent registers (registration staleness)", async () => {
   // `agent start` can return before the agent shows up in `agent list` — the read-back must
@@ -280,7 +284,9 @@ test("start: resolve is keyed by the created tab, not cwd (no cwd-collision alia
   expect(agent.terminalId).toBe("term_ours"); // the created tab, not the stale sibling
 });
 
-test("start: resolve exhaustion warns distinctly and rolls back the orphan tab", async () => {
+test("start: resolve exhaustion AND tab gone warns distinctly and rolls back the orphan tab", async () => {
+  // The agent never registers AND its tab is gone → a genuine spawn failure (herdr never kept
+  // the tab). Only then does resolveStartedAgent throw and start() roll the orphan tab back.
   const calls: string[][] = [];
   const runner = (args: string[]): string => {
     calls.push(args);
@@ -288,6 +294,7 @@ test("start: resolve exhaustion warns distinctly and rolls back the orphan tab",
     if (args[0] === "tab" && args[1] === "create") return TAB_CREATE;
     if (args[0] === "agent" && args[1] === "start") return "{}";
     if (args[0] === "agent" && args[1] === "list") return EMPTY_LIST; // never registers
+    if (args[0] === "tab" && args[1] === "list") return EMPTY_TABS; // tab is gone too
     return "{}";
   };
   const warnings: string[] = [];
@@ -298,16 +305,39 @@ test("start: resolve exhaustion warns distinctly and rolls back the orphan tab",
   try {
     const d = new HerdrDriver(runner, async (a) => runner(a), 3, 0);
     await expect(d.start("flatten", "/wt/a", ["claude", "go"])).rejects.toThrow(
-      /started agent not found for tab t_new/,
+      /started agent not found and tab gone for tab t_new/,
     );
   } finally {
     console.warn = origWarn;
   }
   // distinct exhaustion signal (herdr-health), not a silent first-try success
   expect(
-    warnings.some((w) => w.includes("agent resolve exhausted after 3 attempts for tab t_new")),
+    warnings.some((w) => w.includes("agent resolve exhausted and tab t_new gone after 3 attempts")),
   ).toBe(true);
   expect(calls).toContainEqual(["tab", "close", "t_new"]); // orphan tab rolled back
+});
+
+test("start: agent never registers but its tab persists (exec spawn exited) → returns started, no rollback", async () => {
+  // A non-interactive `codex exec` runs to completion and EXITS, dropping it from `agent list`
+  // while its tab husk lingers. That is a successful spawn that already ran (and may have written
+  // its verdict), NOT a failure — throwing error-spawn here would wrongly delete its worktree.
+  // resolveStartedAgent must return a started handle (empty terminal id) and NOT roll back the
+  // tab (a running-but-unregistered agent would be killed by the close).
+  const calls: string[][] = [];
+  const runner = (args: string[]): string => {
+    calls.push(args);
+    if (args[0] === "workspace" && args[1] === "list") return WORKSPACE_LIST;
+    if (args[0] === "tab" && args[1] === "create") return TAB_CREATE;
+    if (args[0] === "agent" && args[1] === "start") return "{}";
+    if (args[0] === "agent" && args[1] === "list") return EMPTY_LIST; // never in the live list
+    if (args[0] === "tab" && args[1] === "list") return TAB_LIST_WITH_NEW; // but the tab husk persists
+    return "{}";
+  };
+  const d = new HerdrDriver(runner, async (a) => runner(a), 3, 0);
+  const agent = await d.start("flatten", "/wt/a", ["codex", "exec", "go"]);
+  expect(agent.tabId).toBe("t_new");
+  expect(agent.terminalId).toBe(""); // completed exec has no live terminal; herdr.stop("") is a no-op
+  expect(calls).not.toContainEqual(["tab", "close", "t_new"]); // NOT rolled back
 });
 
 test("start: the read-back runs OUTSIDE the serializer — a slow resolve doesn't block the next start", async () => {

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -737,6 +737,20 @@ test("completes the reviewer spawn's token total on finalize", async () => {
   expect(h.completedSpawns[0].u.total).toBe(10);
   expect(h.completedSpawns[0].id).toBe(h.recordedSpawns[0].reviewerSessionId);
 });
+test("completes the reviewer spawn even with no usage (Codex exec has no transcript) → zeroed totals", async () => {
+  // A Codex `exec` reviewer writes no Claude JSONL, so readUsage yields null. The row must still
+  // be completed with zeroed totals so `completedAt` reflects the finished review rather than
+  // leaving a silent 0/N gap in reviewer_spawns.
+  const h = harness({
+    readVerdict: () => ({ decision: "approve", summary: "ok", body: "B", findings: [] }),
+    readUsage: async () => null,
+  });
+  await h.svc.consider(planningSession() as any);
+  await h.svc.tick();
+  expect(h.completedSpawns.length).toBe(1);
+  expect(h.completedSpawns[0].u.total).toBe(0);
+  expect(h.completedSpawns[0].id).toBe(h.recordedSpawns[0].reviewerSessionId);
+});
 test("timeout with no verdict → error gate, reaped, not released", async () => {
   let t = 1000;
   const h = harness({ readVerdict: () => null, now: () => t });


### PR DESCRIPTION
## Problem — "Couldn't start the reviewer — the agent host is busy"

With the reviewer role CLIs set to **codex**, clicking **Review** (plan review / PR critic) frequently — and under load, constantly — fails with *"Couldn't start the reviewer — the agent host is busy"* (`error-spawn`).

**Root cause (verified on the live box):** codex roles run as headless `codex exec`, a **non-interactive process that runs to completion and exits**. Shepherd's CLI herdr driver confirms a spawn by polling `agent list` for the freshly-created tab. But herdr drops an agent from `agent list` the instant its process exits (proven), and under load a live agent's registration lags past the ~0.5 s poll window. So `resolveStartedAgent` threw `started agent not found`, surfaced as the toast — **and the failure path then deleted the reviewer's disposable worktree, discarding a verdict the reviewer may already have written.** (Claude reviewers are long-lived/interactive, so they're always found — this is codex-specific.)

Two secondary facts confirmed the diagnosis: codex reviews *do* land verdicts when the read-back happens to win, and the alarming `reviewer_spawns` "codex 0/N completed" is a **metrics artifact** (codex has no Claude transcript → `completeReviewerSpawn` was skipped), not a real failure.

## Solution

**1. Confirm exec-style spawns by tab existence, not agent liveness** (`src/herdr.ts`)
On read-back exhaustion, `resolveStartedAgent` now decides by `tab list` instead of `agent list`:
- **tab still present** ⇒ the spawn ran (running-late or already exited) ⇒ return a started handle with an empty terminal id (a completed exec has no live terminal; `herdr.stop("")` is a safe no-op; the tab husk is reaped by the existing hourly orphan-tab sweep). It does **not** close the tab here — a running-but-unregistered agent would be killed.
- **tab gone** ⇒ genuine failure ⇒ throw.

This stops the false `error-spawn` and, critically, stops the failure path from deleting a review worktree whose reviewer already produced a verdict.

**2. Record reviewer completion even without a transcript** (`src/plan-gate.ts`)
`finalize()` and the orphan-reap helper now call `completeReviewerSpawn(usage ?? ZEROED_USAGE)` instead of gating on `if (usage)` — mirroring the existing `review.ts` pattern — so codex reviewer completions set `completedAt` (per-run token attribution stays null for codex, which has none). No more misleading `0/N`.

## Technical details

- The happy path is unchanged: interactive/claude agents register immediately and are found in the first poll attempts; only the previously-throwing read-back **miss** path changes.
- Added `HerdrDriver.tabsAsync()` (async sibling of the existing `tabs()`) and a shared `parseTabs()` helper.
- The socket driver is unaffected — it reads `terminal_id` straight from the `agent.start` reply and never needed the read-back.
- **Tests:** updated the exhaustion case (now "tab gone → throws + rolls back"), added "agent never registers but tab persists (exec exited) → returns started, no rollback", and a plan-gate "null usage (codex) still completes with zeroed totals" case. `bun test ./test/herdr.test.ts ./test/plan-gate-service.test.ts` + related herdr/plan-gate suites green; `bun run lint` clean.

### Interim mitigation (no code)
Immediate relief before merge: set the reviewer role CLIs back to **claude** in Settings (claude reviewers are interactive and confirm reliably). Task sessions can stay on codex.
