### PR TITLE
feat(ui): jump to sessions from auto-merge entries

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3095,5 +3095,7 @@
   "feat_provider_availability_card_body": "Neue Aufgabe zeigt jetzt eine blaue CLI-Verfügbarkeitskarte, wenn ein gewählter Command-, Skill- oder Plugin-Token nur in einer Coding-CLI läuft, damit die erzwungene Provider-Wahl vor dem Start sichtbar ist.",
   "newtask_preview_image_aria": "Vorschau des angehängten Bildes {name}",
   "feat_newtask_image_preview_title": "Bilder vor dem Task-Start prüfen",
-  "feat_newtask_image_preview_body": "Fahre mit der Maus über den Dateinamen eines Bildanhangs oder fokussiere ihn, um das Bild vor dem Start zu prüfen. Tippe auf Mobilgeräten auf den Dateinamen, um die Vorschau ein- oder auszublenden."
+  "feat_newtask_image_preview_body": "Fahre mit der Maus über den Dateinamen eines Bildanhangs oder fokussiere ihn, um das Bild vor dem Start zu prüfen. Tippe auf Mobilgeräten auf den Dateinamen, um die Vorschau ein- oder auszublenden.",
+  "feat_automerge_session_jump_title": "Aus Voll-Auto-Merge springen",
+  "feat_automerge_session_jump_body": "Klicke auf einen aktiven Voll-Auto-Merge-Eintrag, um direkt zu seinem Task und Terminal zu springen. Shepherd entfernt Filter, die ihn verbergen würden, und folgt dem Task ins richtige Repository."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3095,5 +3095,7 @@
   "feat_provider_availability_card_body": "New Task now shows a blue CLI-availability card when a picked command, skill, or plugin token only runs in one coding CLI, so the forced provider choice is visible before launch.",
   "newtask_preview_image_aria": "Preview attached image {name}",
   "feat_newtask_image_preview_title": "Preview images before starting a task",
-  "feat_newtask_image_preview_body": "Hover or focus an image attachment's filename to check it before launch. On mobile, tap the filename to toggle the preview."
+  "feat_newtask_image_preview_body": "Hover or focus an image attachment's filename to check it before launch. On mobile, tap the filename to toggle the preview.",
+  "feat_automerge_session_jump_title": "Jump from Full-auto merge",
+  "feat_automerge_session_jump_body": "Click any active Full-auto merge entry to jump straight to its task and terminal. Shepherd clears filters that would hide it and follows the task into the right repository."
 }

--- a/ui/src/lib/components/QueueStrip.browser.test.ts
+++ b/ui/src/lib/components/QueueStrip.browser.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page, userEvent } from "vitest/browser";
+import type { AutoMergeStatus } from "$lib/types";
+import { m } from "$lib/paraglide/messages";
+import QueueStrip from "./QueueStrip.svelte";
+
+function status(over: Partial<AutoMergeStatus> = {}): AutoMergeStatus {
+  return {
+    repoPath: "/repos/shop",
+    enabled: true,
+    state: "merge_error",
+    detail: "TASK-42",
+    sessionId: "session-42",
+    ...over,
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("QueueStrip session jumps", () => {
+  it("selects the affected session when its row is clicked", async () => {
+    const onselect = vi.fn();
+    render(QueueStrip, { autoMerge: { shop: status() }, onselect });
+
+    const row = page.getByRole("button", { name: /shop.*TASK-42/i });
+    await userEvent.click(row);
+
+    expect(onselect).toHaveBeenCalledOnce();
+    expect(onselect).toHaveBeenCalledWith("session-42");
+  });
+
+  it("uses native button keyboard activation", async () => {
+    const onselect = vi.fn();
+    render(QueueStrip, { autoMerge: { shop: status() }, onselect });
+
+    const row = page.getByRole("button", { name: /shop.*TASK-42/i });
+    row.element().focus();
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard(" ");
+
+    expect(onselect).toHaveBeenCalledTimes(2);
+    expect(onselect).toHaveBeenNthCalledWith(1, "session-42");
+    expect(onselect).toHaveBeenNthCalledWith(2, "session-42");
+  });
+
+  it("keeps a status without a session id static", async () => {
+    render(QueueStrip, {
+      autoMerge: { shop: status({ sessionId: null, state: "rebasing", detail: "TASK-42" }) },
+    });
+
+    await expect.element(page.getByText(m.automerge_state_rebasing())).toBeInTheDocument();
+    expect(document.querySelector(".qs-row")).not.toBeNull();
+    expect(document.querySelector("button.qs-row")).toBeNull();
+  });
+});

--- a/ui/src/lib/components/QueueStrip.svelte
+++ b/ui/src/lib/components/QueueStrip.svelte
@@ -6,8 +6,10 @@
 
   let {
     autoMerge = {},
+    onselect,
   }: {
     autoMerge?: Record<string, AutoMergeStatus>;
+    onselect?: (id: string) => void;
   } = $props();
   const mergeRows = $derived(activeMergeTrain(autoMerge));
 </script>
@@ -19,11 +21,28 @@
       {#each mergeRows as s (s.repoPath)}
         {@const label = mergeTrainLabel(s.state)}
         {@const attention = mergeTrainIsAttention(s.state!)}
-        <li class="qs-row" class:paused={attention}>
-          <span class="qs-repo">{basename(s.repoPath)}</span>
-          <span class={["qs-mt-state", { "qs-pause": attention }]}
-            >{s.detail ? `${label} (${s.detail})` : label}</span
-          >
+        {@const sessionId = s.sessionId}
+        <li>
+          {#if sessionId}
+            <button
+              type="button"
+              class="qs-row qs-link"
+              class:paused={attention}
+              onclick={() => onselect?.(sessionId)}
+            >
+              <span class="qs-repo">{basename(s.repoPath)}</span>
+              <span class={["qs-mt-state", { "qs-pause": attention }]}
+                >{s.detail ? `${label} (${s.detail})` : label}</span
+              >
+            </button>
+          {:else}
+            <span class="qs-row" class:paused={attention}>
+              <span class="qs-repo">{basename(s.repoPath)}</span>
+              <span class={["qs-mt-state", { "qs-pause": attention }]}
+                >{s.detail ? `${label} (${s.detail})` : label}</span
+              >
+            </span>
+          {/if}
         </li>
       {/each}
     </ul>
@@ -78,6 +97,24 @@
     color: var(--color-muted);
     white-space: nowrap;
   }
+  .qs-link {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    border-radius: 2px;
+    background: transparent;
+    font-family: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+    cursor: pointer;
+  }
+  .qs-link:hover .qs-repo {
+    color: var(--color-amber);
+  }
+  .qs-link:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
   .qs-repo {
     color: var(--color-ink-bright);
     font-weight: 500;
@@ -112,6 +149,12 @@
       overflow: visible;
       text-overflow: clip;
       max-width: none;
+    }
+  }
+
+  @media (pointer: coarse) {
+    .qs-link {
+      min-height: 44px;
     }
   }
 </style>

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-automerge-session-jump.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-automerge-session-jump.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "automerge-session-jump",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_automerge_session_jump_title",
+  bodyKey: "feat_automerge_session_jump_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1300,6 +1300,17 @@
     if (toDetail && mobile.current) mobileScreen = "detail";
   }
 
+  // A global session jump must leave the target visible in the herd, even when a lens or
+  // repo/status filter currently hides it. Shared by the command bar and auto-merge strip.
+  function jumpToSession(id: string) {
+    showBacklog = false;
+    herdFilter = "all";
+    statusFilter = null;
+    const repoPath = store.sessions.find((s) => s.id === id)?.repoPath;
+    if (repoPath) followFilterToRepo(repoPath);
+    selectUnit(id);
+  }
+
   // Deep-link a Rundown item to its live session: leave the panel-only Rundown lens
   // (back to the full list so the session row is visible) and select it via the same
   // selectUnit a rail click uses.
@@ -2580,7 +2591,7 @@
         onrepofilter={applyRepoFilter}
         onpinrepo={setPinnedRepo}
       />
-      <QueueStrip autoMerge={store.autoMerge} />
+      <QueueStrip autoMerge={store.autoMerge} onselect={jumpToSession} />
     </header>
   {/if}
 
@@ -3101,16 +3112,7 @@
   oncommandbarsession={(id) => {
     showCommandBar = false;
     demoCommandFilter = "";
-    showBacklog = false;
-    // A ⌘K session jump must land the session VISIBLE + highlighted in the herd list, which
-    // narrows by both the lens filter AND the sticky repo/status filters. Reset both stickies
-    // (herdFilter → all, statusFilter → null) and follow the repo filter onto the session's
-    // repo so a filter on a different repo/status can't strand it out of the list.
-    herdFilter = "all";
-    statusFilter = null;
-    const repoPath = store.sessions.find((s) => s.id === id)?.repoPath;
-    if (repoPath) followFilterToRepo(repoPath);
-    selectUnit(id);
+    jumpToSession(id);
   }}
   oncommandbarrepo={(path) => {
     showCommandBar = false;


### PR DESCRIPTION
## Problem

The Full-auto merge strip shows which task is currently merging, rebasing, or needs attention, but its entries are static. Operators have to search for the matching task manually before they can inspect or steer its terminal. This is especially confusing when a repository or status filter currently hides that task.

## Solution

Make session-backed Full-auto merge entries clickable and keyboard-accessible. Selecting an entry now clears filters that would hide the task, follows it into the correct repository, and opens the existing task and terminal view directly. Statuses without a session ID remain static rather than guessing a destination.

## Technical details

- Render session-backed strip rows as native buttons with token-based hover and focus states.
- Reuse one shared session-jump path for the auto-merge strip and command bar.
- Preserve existing status colors, sorting, responsive wrapping, and the static fallback.
- Add EN and DE announcement copy plus the v1.44.0 feature-catalog fragment.
- Add browser coverage for pointer activation, Enter and Space activation, and missing-session fallback.

## Verification

- `bun run check`
- `bun run check:i18n`
- `bun run test:browser -- QueueStrip.browser.test.ts`
- `bun run test` (239 files, 3509 tests)
- Branch hygiene, feature catalog, announcement version, glossary, and diff checks