### PR TITLE
fix(ui): add PR draft actions to the terminal rail

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1856,7 +1856,7 @@
   "feat_learnings_recur_body": "Wenn dieselbe Regel in mehreren Repos wiederkehrt, schlägt das Learnings-Panel jetzt vor, sie in deine benutzerglobale CLAUDE.md aufzunehmen – als Vorschlag, den du verwerfen kannst.",
   "gitrail_open_issue": "Issue ↗",
   "gitrail_issue_label": "Issue #{number}",
-  "gitrail_pr_link": "PR ↗",
+  "gitrail_pr_link": "PR",
   "gitrail_pr_plain": "PR",
   "feat_open_linked_issue_title": "Verknüpftes Issue öffnen",
   "feat_open_linked_issue_body": "GitRail zeigt jetzt einen \"Issue ↗\"-Link für Aufgaben, die aus einem Backlog-Issue gestartet wurden – direkt zum Issue auf GitHub oder Gitea springen.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1856,7 +1856,7 @@
   "feat_learnings_recur_body": "When the same rule recurs across several repos, the Learnings drawer now suggests promoting it to your user-global CLAUDE.md — kept as a suggestion you can dismiss.",
   "gitrail_open_issue": "Issue ↗",
   "gitrail_issue_label": "Issue #{number}",
-  "gitrail_pr_link": "PR ↗",
+  "gitrail_pr_link": "PR",
   "gitrail_pr_plain": "PR",
   "feat_open_linked_issue_title": "Open the linked issue",
   "feat_open_linked_issue_body": "GitRail now shows an \"Issue ↗\" link for tasks spawned from a backlog issue — jump straight to the issue on GitHub or Gitea.",

--- a/ui/src/lib/components/GitRail.browser.test.ts
+++ b/ui/src/lib/components/GitRail.browser.test.ts
@@ -24,6 +24,10 @@ const openPrState: GitState = {
 // gitStateFn is a vi.fn() whose implementation we swap per describe block so
 // each state suite gets its own mocked GitState without re-importing the module.
 const gitStateFn = vi.fn(async () => openPrState);
+const setPrDraftStateFn = vi.fn(async (_id: string, draft: boolean) => ({
+  ...openPrState,
+  isDraft: draft,
+}));
 
 // Preserve the real module (the wider graph — reviews store, AutomationPanel —
 // pulls other named exports like getRepoConfig/getReviews) and override only the
@@ -44,6 +48,7 @@ vi.mock("$lib/api", async (importOriginal) => {
   return {
     ...actual,
     gitState: gitStateFn,
+    setPrDraftState: setPrDraftStateFn,
     openPr: vi.fn(),
     mergePr: vi.fn(),
     redeploy: vi.fn(),
@@ -92,6 +97,11 @@ async function render(
 // line high (no vertical stacking) with no squished-to-zero controls.
 let fontStyle: HTMLStyleElement;
 beforeEach(() => {
+  setPrDraftStateFn.mockClear();
+  setPrDraftStateFn.mockImplementation(async (_id: string, draft: boolean) => ({
+    ...openPrState,
+    isDraft: draft,
+  }));
   fontStyle = document.createElement("style");
   fontStyle.textContent = `:root { --font-mono: ui-monospace, monospace; }
     *, *::before, *::after { box-sizing: border-box; }
@@ -196,22 +206,24 @@ const baseProps = {
 };
 
 describe("GitRail — shortened issue & PR labels", () => {
-  // The rail drops the #number from the visible label (Issue ↗ / PR ↗) to save
-  // horizontal space, keeping the external-link ↗ and stashing the full
-  // reference in the title + aria-label. These fail on the pre-change markup
-  // (no title attr; visible text still carried the number).
-  it("PR link: short visible text, ↗ kept, full ref in title + accessible name", async () => {
+  // The PR control now discloses an action menu, so only the explicit menu item
+  // keeps the external-link arrow. The issue control remains a direct link.
+  it("PR menu trigger: short visible text, no ↗, full ref in title + accessible name", async () => {
     gitStateFn.mockResolvedValue(openPrState);
     await page.viewport(600, 900);
     const h = host(600);
     const screen = await render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
-    // accessible name (aria-label) carries the full reference…
-    await expect.element(screen.getByRole("link", { name: "PR #12345" })).toBeVisible();
-    // …and so does the hover tooltip…
+    await expect
+      .element(
+        screen.getByRole("button", {
+          name: m.prbadge_button_title({ label: m.prbadge_open({ number: 12345 }) }),
+        }),
+      )
+      .toBeVisible();
     await expect.element(screen.getByTitle("PR #12345")).toBeVisible();
-    // …but the rail's VISIBLE text is the short form with the arrow, no number.
     const rail = h.querySelector<HTMLElement>(".rail")!;
-    expect(rail.textContent).toContain("PR ↗");
+    expect(rail.textContent).toContain("PR");
+    expect(rail.textContent).not.toContain("PR ↗");
     expect(rail.textContent).not.toContain("#12345");
   });
 
@@ -231,6 +243,95 @@ describe("GitRail — shortened issue & PR labels", () => {
     const rail = h.querySelector<HTMLElement>(".rail")!;
     expect(rail.textContent).toContain("Issue ↗");
     expect(rail.textContent).not.toContain("#855");
+  });
+});
+
+describe("GitRail — PR actions menu", () => {
+  beforeEach(() => {
+    toastsInfo.mockClear();
+  });
+
+  it("opens the PR URL only from the explicit menu action", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    const h = host(600);
+    const screen = await render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+
+    const trigger = screen.getByRole("button", {
+      name: m.prbadge_button_title({ label: m.prbadge_open({ number: 12345 }) }),
+    });
+    await trigger.click();
+    expect(open).not.toHaveBeenCalled();
+
+    await page.getByRole("menuitem", { name: m.prbadge_open_pr() }).click();
+    expect(open).toHaveBeenCalledWith(
+      openPrState.url,
+      "_blank",
+      "noopener,noreferrer",
+    );
+    open.mockRestore();
+  });
+
+  it("sets a draft PR Ready for Review and refreshes the next menu", async () => {
+    gitStateFn.mockResolvedValue({ ...openPrState, isDraft: true });
+    const h = host(600);
+    const screen = await render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    const trigger = screen.getByRole("button", {
+      name: m.prbadge_button_title({ label: m.prbadge_open({ number: 12345 }) }),
+    });
+
+    await trigger.click();
+    await page.getByRole("menuitem", { name: m.prbadge_mark_ready() }).click();
+    expect(setPrDraftStateFn).toHaveBeenCalledWith("sess-1", false);
+    expect(toastsInfo).toHaveBeenCalledWith(m.prbadge_marked_ready(), {
+      key: "pr-draft:sess-1",
+    });
+
+    await trigger.click();
+    await expect
+      .element(page.getByRole("menuitem", { name: m.prbadge_mark_draft() }))
+      .toBeVisible();
+  });
+
+  it("sets a ready PR back to Draft and refreshes the next menu", async () => {
+    gitStateFn.mockResolvedValue({ ...openPrState, isDraft: false });
+    const h = host(600);
+    const screen = await render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    const trigger = screen.getByRole("button", {
+      name: m.prbadge_button_title({ label: m.prbadge_open({ number: 12345 }) }),
+    });
+
+    await trigger.click();
+    await page.getByRole("menuitem", { name: m.prbadge_mark_draft() }).click();
+    expect(setPrDraftStateFn).toHaveBeenCalledWith("sess-1", true);
+    expect(toastsInfo).toHaveBeenCalledWith(m.prbadge_marked_draft(), {
+      key: "pr-draft:sess-1",
+    });
+
+    await trigger.click();
+    await expect
+      .element(page.getByRole("menuitem", { name: m.prbadge_mark_ready() }))
+      .toBeVisible();
+  });
+
+  it("keeps the menu open when changing Draft state fails", async () => {
+    gitStateFn.mockResolvedValue({ ...openPrState, isDraft: true });
+    setPrDraftStateFn.mockRejectedValueOnce(new Error("boom"));
+    const h = host(600);
+    const screen = await render(GitRail, { target: h, props: { ...baseProps, mobile: false } });
+    const trigger = screen.getByRole("button", {
+      name: m.prbadge_button_title({ label: m.prbadge_open({ number: 12345 }) }),
+    });
+
+    await trigger.click();
+    const markReady = page.getByRole("menuitem", { name: m.prbadge_mark_ready() });
+    await markReady.click();
+
+    await expect.element(markReady).toBeVisible();
+    expect(toastsInfo).toHaveBeenCalledWith(
+      m.prbadge_draft_toggle_failed({ reason: "boom" }),
+      { alert: true, key: "pr-draft:sess-1" },
+    );
   });
 });
 
@@ -630,9 +731,9 @@ describe("GitRail — forge-error fallback (no silent-empty rail)", () => {
     )!;
     retry.click();
     await vi.waitFor(() => {
-      const link = h.querySelector<HTMLAnchorElement>("a.status-chip.info");
-      expect(link, "PR link rendered after retry").not.toBeNull();
-      expect(link!.getAttribute("href")).toBe(openPrState.url);
+      const trigger = h.querySelector<HTMLButtonElement>("button.status-chip.info");
+      expect(trigger, "PR menu trigger rendered after retry").not.toBeNull();
+      expect(trigger!.getAttribute("aria-haspopup")).toBe("menu");
     });
     expect(h.querySelector(".err"), "error cleared after successful retry").toBeNull();
   });

--- a/ui/src/lib/components/GitRail.browser.test.ts
+++ b/ui/src/lib/components/GitRail.browser.test.ts
@@ -264,11 +264,7 @@ describe("GitRail — PR actions menu", () => {
     expect(open).not.toHaveBeenCalled();
 
     await page.getByRole("menuitem", { name: m.prbadge_open_pr() }).click();
-    expect(open).toHaveBeenCalledWith(
-      openPrState.url,
-      "_blank",
-      "noopener,noreferrer",
-    );
+    expect(open).toHaveBeenCalledWith(openPrState.url, "_blank", "noopener,noreferrer");
     open.mockRestore();
   });
 
@@ -328,10 +324,10 @@ describe("GitRail — PR actions menu", () => {
     await markReady.click();
 
     await expect.element(markReady).toBeVisible();
-    expect(toastsInfo).toHaveBeenCalledWith(
-      m.prbadge_draft_toggle_failed({ reason: "boom" }),
-      { alert: true, key: "pr-draft:sess-1" },
-    );
+    expect(toastsInfo).toHaveBeenCalledWith(m.prbadge_draft_toggle_failed({ reason: "boom" }), {
+      alert: true,
+      key: "pr-draft:sess-1",
+    });
   });
 });
 

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {
     gitState,
+    setPrDraftState,
     openPr,
     mergePr,
     redeploy,
@@ -374,6 +375,29 @@
     }
   }
 
+  async function doTogglePrDraft(draft: boolean): Promise<boolean> {
+    busy = true;
+    err = null;
+    retry = null;
+    try {
+      git = await setPrDraftState(sessionId, draft);
+      toasts.info(draft ? m.prbadge_marked_draft() : m.prbadge_marked_ready(), {
+        key: `pr-draft:${sessionId}`,
+      });
+      return true;
+    } catch (e) {
+      toasts.info(
+        m.prbadge_draft_toggle_failed({
+          reason: e instanceof Error ? e.message : m.prbadge_unknown_error(),
+        }),
+        { alert: true, key: `pr-draft:${sessionId}` },
+      );
+      return false;
+    } finally {
+      busy = false;
+    }
+  }
+
   const mergeBlocked = $derived(
     !git ||
       git.mergeable === false ||
@@ -650,6 +674,7 @@
         {planReviewLabel}
         {planReviewBlockedReason}
         {startPr}
+        togglePrDraft={doTogglePrDraft}
         {doMerge}
         {doRedeploy}
         {toggleReview}

--- a/ui/src/lib/components/git-rail/RailStatusActions.svelte
+++ b/ui/src/lib/components/git-rail/RailStatusActions.svelte
@@ -2,6 +2,7 @@
   import type { GitState, SessionStatus } from "$lib/types";
   import type { CriticChip } from "../critic-badge";
   import ReadyToggle from "../ReadyToggle.svelte";
+  import PrBadgeMenu from "../PrBadgeMenu.svelte";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
   import { m } from "$lib/paraglide/messages";
 
@@ -28,6 +29,7 @@
     planReviewLabel,
     planReviewBlockedReason,
     startPr,
+    togglePrDraft,
     doMerge,
     doRedeploy,
     toggleReview,
@@ -56,6 +58,7 @@
     planReviewLabel: string;
     planReviewBlockedReason: string | null;
     startPr: () => void;
+    togglePrDraft: (draft: boolean) => Promise<boolean>;
     doMerge: (skipArm?: boolean) => Promise<void>;
     doRedeploy: (skipArm?: boolean) => Promise<void>;
     toggleReview: (e?: Event) => void;
@@ -76,6 +79,30 @@
   // CI status → .status-chip accent modifier ("" = neutral for the "none" state).
   function ciMod(c: GitState["checks"]): string {
     return c === "success" ? "pass" : c === "pending" ? "pend" : c === "failure" ? "fail" : "";
+  }
+
+  const canToggleDraft = $derived(git.kind === "github" || git.kind === "gitea");
+  let prButton = $state<HTMLButtonElement>();
+  let prMenuAnchor = $state<DOMRect | null>(null);
+
+  function closePrMenu() {
+    prMenuAnchor = null;
+  }
+
+  function togglePrMenu(e: MouseEvent) {
+    e.stopPropagation();
+    if (prMenuAnchor) closePrMenu();
+    else if (prButton) prMenuAnchor = prButton.getBoundingClientRect();
+  }
+
+  function openPr() {
+    closePrMenu();
+    if (!git.url) return;
+    window.open(git.url, "_blank", "noopener,noreferrer");
+  }
+
+  async function toggleDraftState() {
+    if (await togglePrDraft(git.isDraft !== true)) closePrMenu();
   }
 </script>
 
@@ -110,17 +137,20 @@
       ><span class="dot" aria-hidden="true"></span>{m.gitrail_ready_to_merge()} #{git.number}</span
     >
   {:else if git.url}
-    <!-- eslint-disable svelte/no-navigation-without-resolve -- external git-host URL, not an app route -->
-    <a
+    <button
+      bind:this={prButton}
+      type="button"
       class="status-chip info"
-      href={git.url}
-      target="_blank"
-      rel="noopener"
+      class:open={!!prMenuAnchor}
       title={m.prbadge_open({ number: git.number ?? 0 })}
-      aria-label={m.prbadge_open({ number: git.number ?? 0 })}
-      ><span class="dot" aria-hidden="true"></span>{m.gitrail_pr_link()}</a
+      aria-label={m.prbadge_button_title({
+        label: m.prbadge_open({ number: git.number ?? 0 }),
+      })}
+      aria-haspopup="menu"
+      aria-expanded={!!prMenuAnchor}
+      onclick={togglePrMenu}
+      ><span class="dot" aria-hidden="true"></span>{m.gitrail_pr_link()}</button
     >
-    <!-- eslint-enable svelte/no-navigation-without-resolve -->
   {:else}
     <span class="status-chip info" title={m.prbadge_open({ number: git.number ?? 0 })}
       ><span class="dot" aria-hidden="true"></span>{m.gitrail_pr_plain()}</span
@@ -169,6 +199,20 @@
   <span class="status-chip parked"
     ><span class="dot" aria-hidden="true"></span>{m.gitrail_closed()}</span
   >
+{/if}
+
+{#if prMenuAnchor}
+  <PrBadgeMenu
+    anchor={prMenuAnchor}
+    opener={prButton}
+    isDraft={git.isDraft === true}
+    canOpen={!!git.url}
+    {canToggleDraft}
+    {busy}
+    onopen={openPr}
+    ontoggledraft={toggleDraftState}
+    onclose={closePrMenu}
+  />
 {/if}
 
 {#if showReady && (git.state === "open" || ready) && status !== "running" && status !== "blocked"}
@@ -289,8 +333,8 @@
   }
 
   /* Status Chip — component-scoped copy of the canonical recipe (DESIGN.json;
-     there is no shared class). Read-only functional-status readouts: PR / CI /
-     merged / closed / issue. Semantic hue on border + text + leading dot. */
+     there is no shared class). Functional-status readouts plus the PR menu
+     trigger. Semantic hue on border + text + leading dot. */
   .status-chip {
     display: inline-flex;
     align-items: center;
@@ -307,12 +351,24 @@
     white-space: nowrap;
     text-decoration: none;
   }
-  a.status-chip {
+  button.status-chip {
+    appearance: none;
+    margin: 0;
+    line-height: inherit;
+  }
+  a.status-chip,
+  button.status-chip {
     cursor: pointer;
     transition: background 0.12s;
   }
-  a.status-chip:hover {
+  a.status-chip:hover,
+  button.status-chip:hover,
+  button.status-chip.open {
     background: var(--color-hover);
+  }
+  button.status-chip:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
   }
   .status-chip .dot {
     width: 7px;


### PR DESCRIPTION
## Problem

In the terminal view, the PR status chip opened the pull request directly. For draft PRs this meant the existing action to mark the PR Ready for Review was missing, even though the same PR badge menu was already available in the Herd/Backlog view.

## Solution

The terminal PR chip now opens the shared PR action menu for every open remote PR. From there, operators can open the PR or switch it between Draft and Ready for Review without leaving Shepherd. The separate Merge action remains unchanged.

## Technical details

- Reuses `PrBadgeMenu` instead of introducing another popover.
- Keeps PR state mutation in `GitRail` and updates its local `GitState` from the confirmed API response.
- Retains localized success/error toasts and leaves the menu open on failed state changes.
- Changes the trigger label from `PR ↗` to `PR`; the external-link marker remains on the explicit “Open PR” action.
- Adds browser coverage for menu disclosure, safe external opening, both draft transitions, failure behavior, and the existing rail sizing/recovery paths.

## Validation

- `bun run test:browser -- GitRail.browser.test.ts` — 70 tests passed
- `bun run check:i18n` — EN/DE parity, 3096 keys each
- `bun run check` — 0 errors, 0 warnings
- `CI=true bun run test` — 3624 tests passed across 244 files
- `scripts/check-branch-hygiene.sh` — linear off `origin/main`
