### PR TITLE
fix(ui): keep epic draft review actions reachable

### DIFF
--- a/ui/src/lib/components/EpicDraftPanel.browser.test.ts
+++ b/ui/src/lib/components/EpicDraftPanel.browser.test.ts
@@ -12,7 +12,8 @@ function longDraft(sessionId: string): EpicDraft {
       title: "Keep long epic drafts reviewable",
       body: Array.from(
         { length: 80 },
-        (_, i) => `Section ${i + 1}\nDetailed research finding that must remain readable before approval.`,
+        (_, i) =>
+          `Section ${i + 1}\nDetailed research finding that must remain readable before approval.`,
       ).join("\n\n"),
       acceptanceCriteria: ["The complete draft can be reviewed."],
       nonGoals: ["Collapsible sections"],

--- a/ui/src/lib/components/EpicDraftPanel.browser.test.ts
+++ b/ui/src/lib/components/EpicDraftPanel.browser.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-svelte";
+import "../../app.css";
+import type { EpicDraft } from "$lib/types";
+import { epicDrafts } from "$lib/epic-draft.svelte";
+import EpicDraftPanel from "./EpicDraftPanel.svelte";
+
+function longDraft(sessionId: string): EpicDraft {
+  return {
+    sessionId,
+    parent: {
+      title: "Keep long epic drafts reviewable",
+      body: Array.from(
+        { length: 80 },
+        (_, i) => `Section ${i + 1}\nDetailed research finding that must remain readable before approval.`,
+      ).join("\n\n"),
+      acceptanceCriteria: ["The complete draft can be reviewed."],
+      nonGoals: ["Collapsible sections"],
+    },
+    children: Array.from({ length: 6 }, (_, i) => ({
+      key: `child-${i + 1}`,
+      title: `Child issue ${i + 1}`,
+      body: "A concrete vertical slice with enough detail to wrap on a narrow screen.",
+      acceptanceCriteria: ["The slice is independently verifiable."],
+      blockedBy: i === 0 ? [] : [`child-${i}`],
+    })),
+    status: "draft",
+    materializedChildren: {},
+    parentNumber: null,
+    parentUrl: null,
+  };
+}
+
+describe.each([
+  ["desktop", 1000],
+  ["narrow", 390],
+])("EpicDraftPanel long-draft layout — %s", (label, width) => {
+  it("scrolls the draft content while keeping review actions visible", async () => {
+    const sessionId = `epic-draft-scroll-${label}`;
+    epicDrafts.upsert(longDraft(sessionId));
+
+    const { container, unmount } = await render(EpicDraftPanel, {
+      sessionId,
+      epicAuthoring: true,
+      sessionLive: true,
+    });
+    container.style.width = `${width}px`;
+
+    const panel = container.querySelector<HTMLElement>(".edp");
+    const scroller = container.querySelector<HTMLElement>(".edp-scroll");
+    const actions = container.querySelector<HTMLElement>(".edp-actions");
+    const childList = container.querySelector<HTMLElement>(".edp-list");
+
+    expect(panel, "draft panel should render").not.toBeNull();
+    expect(scroller, "draft content should own the vertical scroll").not.toBeNull();
+    expect(actions, "review actions should have a fixed region").not.toBeNull();
+    expect(childList, "child issue list should render").not.toBeNull();
+
+    if (!panel || !scroller || !actions || !childList) {
+      unmount();
+      return;
+    }
+
+    expect(getComputedStyle(scroller).overflowY).toBe("auto");
+    expect(scroller.scrollHeight).toBeGreaterThan(scroller.clientHeight);
+    expect(getComputedStyle(childList).overflowY).not.toBe("auto");
+
+    const panelRect = panel.getBoundingClientRect();
+    const actionsRect = actions.getBoundingClientRect();
+    expect(actionsRect.height).toBeGreaterThan(0);
+    expect(actionsRect.top).toBeGreaterThanOrEqual(panelRect.top);
+    expect(actionsRect.bottom).toBeLessThanOrEqual(panelRect.bottom + 1);
+    expect(panelRect.height).toBeLessThanOrEqual(window.innerHeight * 0.6 + 1);
+
+    unmount();
+  });
+});

--- a/ui/src/lib/components/EpicDraftPanel.svelte
+++ b/ui/src/lib/components/EpicDraftPanel.svelte
@@ -123,100 +123,104 @@
     {#if !draft || children.length === 0}
       <p class="edp-empty">{m.epicdraft_empty()}</p>
     {:else}
-      {#if awaiting}
-        <p class="edp-hint">{m.epicdraft_awaiting_hint()}</p>
-      {:else if status === "materializing"}
-        <p class="edp-note">{m.epicdraft_materializing_note()}</p>
-      {:else if status === "approved"}
-        <p class="edp-note edp-note-done">
-          {m.epicdraft_created()}
-          {#if draft.parentUrl && draft.parentNumber != null}
-            <span aria-hidden="true">·</span>
-            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
-            <a class="edp-link" href={draft.parentUrl} target="_blank" rel="noopener noreferrer"
-              >{m.epicdraft_view_parent({ n: draft.parentNumber })}</a
-            >
+      <div class="edp-scroll">
+        {#if awaiting}
+          <p class="edp-hint">{m.epicdraft_awaiting_hint()}</p>
+        {:else if status === "materializing"}
+          <p class="edp-note">{m.epicdraft_materializing_note()}</p>
+        {:else if status === "approved"}
+          <p class="edp-note edp-note-done">
+            {m.epicdraft_created()}
+            {#if draft.parentUrl && draft.parentNumber != null}
+              <span aria-hidden="true">·</span>
+              <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL -->
+              <a class="edp-link" href={draft.parentUrl} target="_blank" rel="noopener noreferrer"
+                >{m.epicdraft_view_parent({ n: draft.parentNumber })}</a
+              >
+            {/if}
+          </p>
+        {/if}
+
+        <!-- Parent -->
+        <section class="edp-parent">
+          <span class="edp-section-label">{m.epicdraft_parent_label()}</span>
+          <h4 class="edp-parent-title">{draft.parent.title}</h4>
+          {#if draft.parent.body}<p class="edp-body">{draft.parent.body}</p>{/if}
+          {#if draft.parent.acceptanceCriteria.length}
+            <span class="edp-sub-label">{m.epicdraft_acceptance_label()}</span>
+            <ul class="edp-crit">
+              {#each draft.parent.acceptanceCriteria as c, i (i)}<li>{c}</li>{/each}
+            </ul>
           {/if}
-        </p>
-      {/if}
+          {#if draft.parent.nonGoals.length}
+            <span class="edp-sub-label">{m.epicdraft_nongoals_label()}</span>
+            <ul class="edp-crit">
+              {#each draft.parent.nonGoals as g, i (i)}<li>{g}</li>{/each}
+            </ul>
+          {/if}
+        </section>
 
-      <!-- Parent -->
-      <section class="edp-parent">
-        <span class="edp-section-label">{m.epicdraft_parent_label()}</span>
-        <h4 class="edp-parent-title">{draft.parent.title}</h4>
-        {#if draft.parent.body}<p class="edp-body">{draft.parent.body}</p>{/if}
-        {#if draft.parent.acceptanceCriteria.length}
-          <span class="edp-sub-label">{m.epicdraft_acceptance_label()}</span>
-          <ul class="edp-crit">
-            {#each draft.parent.acceptanceCriteria as c, i (i)}<li>{c}</li>{/each}
-          </ul>
-        {/if}
-        {#if draft.parent.nonGoals.length}
-          <span class="edp-sub-label">{m.epicdraft_nongoals_label()}</span>
-          <ul class="edp-crit">
-            {#each draft.parent.nonGoals as g, i (i)}<li>{g}</li>{/each}
-          </ul>
-        {/if}
-      </section>
-
-      <!-- Children (dependency DAG rendered as an ordered list with blocked-by annotations) -->
-      <section class="edp-children">
-        <span class="edp-section-label"
-          >{m.epicdraft_children_label({ count: children.length })}</span
-        >
-        <ol class="edp-list">
-          {#each children as child, i (child.key)}
-            <EpicDraftChildRow
-              {child}
-              index={i}
-              materializedNumber={draft.materializedChildren[child.key] ?? null}
-              blockedLabel={blockedLabel(child)}
-            />
-          {/each}
-        </ol>
-      </section>
+        <!-- Children (dependency DAG rendered as an ordered list with blocked-by annotations) -->
+        <section class="edp-children">
+          <span class="edp-section-label"
+            >{m.epicdraft_children_label({ count: children.length })}</span
+          >
+          <ol class="edp-list">
+            {#each children as child, i (child.key)}
+              <EpicDraftChildRow
+                {child}
+                index={i}
+                materializedNumber={draft.materializedChildren[child.key] ?? null}
+                blockedLabel={blockedLabel(child)}
+              />
+            {/each}
+          </ol>
+        </section>
+      </div>
 
       {#if awaiting}
-        <div class="edp-amend">
-          <input
-            class="edp-amend-input"
-            type="text"
-            bind:value={amendText}
-            disabled={!sessionLive}
-            placeholder={sessionLive
-              ? m.epicdraft_amend_placeholder()
-              : m.epicdraft_amend_offline()}
-            aria-label={m.epicdraft_amend_placeholder()}
-            onkeydown={(e) => {
-              if (e.key === "Enter") void sendAmend();
-            }}
-          />
-          <button
-            type="button"
-            class="edp-btn"
-            disabled={!sessionLive || !amendText.trim()}
-            onclick={() => void sendAmend()}>{m.epicdraft_amend_send()}</button
-          >
-        </div>
-        <div class="edp-footer">
-          <button
-            type="button"
-            class="edp-btn edp-abort"
-            class:is-armed={abortArmed}
-            onclick={() => void abort()}
-            onmouseleave={() => (abortArmed = false)}
-            onblur={() => (abortArmed = false)}
-            >{abortArmed ? m.epicdraft_abort_confirm() : m.epicdraft_abort()}</button
-          >
-          <button
-            type="button"
-            class="edp-btn edp-approve"
-            disabled={approving}
-            onclick={() => void approve()}
-          >
-            <span class="edp-approve-glyph" aria-hidden="true">▸</span>
-            {approving ? m.epicdraft_approving() : m.epicdraft_approve()}
-          </button>
+        <div class="edp-actions">
+          <div class="edp-amend">
+            <input
+              class="edp-amend-input"
+              type="text"
+              bind:value={amendText}
+              disabled={!sessionLive}
+              placeholder={sessionLive
+                ? m.epicdraft_amend_placeholder()
+                : m.epicdraft_amend_offline()}
+              aria-label={m.epicdraft_amend_placeholder()}
+              onkeydown={(e) => {
+                if (e.key === "Enter") void sendAmend();
+              }}
+            />
+            <button
+              type="button"
+              class="edp-btn"
+              disabled={!sessionLive || !amendText.trim()}
+              onclick={() => void sendAmend()}>{m.epicdraft_amend_send()}</button
+            >
+          </div>
+          <div class="edp-footer">
+            <button
+              type="button"
+              class="edp-btn edp-abort"
+              class:is-armed={abortArmed}
+              onclick={() => void abort()}
+              onmouseleave={() => (abortArmed = false)}
+              onblur={() => (abortArmed = false)}
+              >{abortArmed ? m.epicdraft_abort_confirm() : m.epicdraft_abort()}</button
+            >
+            <button
+              type="button"
+              class="edp-btn edp-approve"
+              disabled={approving}
+              onclick={() => void approve()}
+            >
+              <span class="edp-approve-glyph" aria-hidden="true">▸</span>
+              {approving ? m.epicdraft_approving() : m.epicdraft_approve()}
+            </button>
+          </div>
         </div>
       {/if}
     {/if}
@@ -233,6 +237,9 @@
     border-top: 1px solid var(--color-line);
     font-family: var(--font-mono);
     font-size: var(--fs-meta);
+    max-height: 60dvh;
+    min-height: 0;
+    overflow: hidden;
   }
   .is-awaiting {
     background: color-mix(in oklab, var(--color-amber) 6%, var(--color-panel));
@@ -242,6 +249,7 @@
     display: flex;
     align-items: center;
     gap: 8px;
+    flex: none;
   }
   .edp-title {
     font-size: var(--fs-micro);
@@ -304,6 +312,16 @@
     flex-direction: column;
     gap: 3px;
   }
+  .edp-scroll {
+    display: flex;
+    flex: 1 1 auto;
+    min-height: 0;
+    flex-direction: column;
+    gap: 6px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    touch-action: pan-y;
+  }
   .edp-section-label,
   .edp-sub-label {
     font-size: var(--fs-micro);
@@ -342,10 +360,14 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
-    max-height: 40vh;
-    overflow-y: auto;
-    overscroll-behavior: contain;
-    touch-action: pan-y;
+  }
+  .edp-actions {
+    display: flex;
+    flex: none;
+    flex-direction: column;
+    gap: 6px;
+    padding-top: 6px;
+    border-top: 1px solid var(--color-line);
   }
   .edp-amend {
     display: flex;


### PR DESCRIPTION
## Problem

Long drafts created through **Create EPIC from research** can grow beyond the available session viewport. Only the child-issue list owned a scrollbar, while a long parent issue body expanded the whole panel. The surrounding viewport clips overflow, which made **Amend**, **Abort**, and **Approve & create** unreachable on desktop and mobile.

## Solution

- Bound the Epic Draft panel to 60% of the dynamic viewport height.
- Give parent content and child issues one shared vertical scroll area.
- Keep the draft header and review actions visible outside that scroll area.
- Remove the nested child-list scrollbar so touch and mouse users have one predictable scroll target.
- Preserve the existing empty, materializing, approved, amend, abort, and approve behavior.

## Technical details

The panel now uses three flex regions:

1. A non-shrinking header.
2. A flexible `.edp-scroll` content region with `min-height: 0`, native vertical scrolling, contained overscroll, and touch panning.
3. A non-shrinking `.edp-actions` region separated by the existing semantic hairline token.

A focused Vitest browser regression renders an oversized draft at desktop and 390 px widths. It verifies that the content overflows inside the shared scroller, the child list no longer creates a nested scrollbar, the action region remains inside the panel bounds, and the panel respects its dynamic-viewport cap.

## Validation

- `bun run test:browser`: 116 files, 1,283 tests passed
- `bun run test`: 245 files, 3,622 tests passed
- `bun run check`: 0 errors and 0 warnings
- `bun run check:i18n`: EN/DE parity, 3,096 keys per locale
- `git diff --check`: clean
