### PR TITLE
feat(ui): make mobile lifecycle groups collapsible

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3115,5 +3115,7 @@
   "settings_default_environment_title": "Standard-Coding-Umgebung",
   "settings_default_environment_hint": "Wähle CLI und Modell für neue Aufgaben und unbeaufsichtigte Arbeit. Shepherd merkt sich je ein Modell für Claude Code und Codex.",
   "feat_default_coding_environment_title": "Standard-CLI und -Modell wählen",
-  "feat_default_coding_environment_body": "Die Einstellungen merken sich jetzt getrennte Standardmodelle für Claude Code und Codex. Neue Aufgaben und unbeaufsichtigte Starts verwenden das zur ausgewählten Coding-CLI gehörende Modell."
+  "feat_default_coding_environment_body": "Die Einstellungen merken sich jetzt getrennte Standardmodelle für Claude Code und Codex. Neue Aufgaben und unbeaufsichtigte Starts verwenden das zur ausgewählten Coding-CLI gehörende Modell.",
+  "feat_mobile_herd_accordion_title": "Lebenszyklus-Gruppen mobil einklappen",
+  "feat_mobile_herd_accordion_body": "Die Herd-Liste auf dem Smartphone hält jetzt höchstens eine benannte Lebenszyklus-Gruppe offen. „Du bist dran“ ist standardmäßig geöffnet; tippe auf eine größere Gruppenzeile, um den Bereich zu wechseln oder zu schließen, während aktive Sessions sichtbar bleiben."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3115,5 +3115,7 @@
   "settings_default_environment_title": "Default coding environment",
   "settings_default_environment_hint": "Choose the CLI and its model for new tasks and unattended work. Shepherd remembers a separate model for Claude Code and Codex.",
   "feat_default_coding_environment_title": "Choose a default CLI and model",
-  "feat_default_coding_environment_body": "Settings now remembers separate default models for Claude Code and Codex. New tasks and unattended starts use the model paired with the selected coding CLI."
+  "feat_default_coding_environment_body": "Settings now remembers separate default models for Claude Code and Codex. New tasks and unattended starts use the model paired with the selected coding CLI.",
+  "feat_mobile_herd_accordion_title": "Fold lifecycle groups on mobile",
+  "feat_mobile_herd_accordion_body": "The phone herd now keeps only one named lifecycle group open at a time. Your turn opens by default; tap any larger group header to switch or close it while active sessions stay visible."
 }

--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -193,6 +193,97 @@ describe("Herd merge-train link", () => {
   });
 });
 
+describe("Herd mobile lifecycle accordion", () => {
+  afterEach(() => {
+    reviews.setReviewing("mobile-review", false);
+  });
+
+  it("opens Your turn by default and keeps ungrouped active sessions visible", async () => {
+    reviews.setReviewing("mobile-review", true);
+    render(Herd, {
+      ...base,
+      sessions: [
+        session({ id: "active", name: "active session", status: "running" }),
+        session({ id: "mobile-review", name: "review session" }),
+        session({ id: "your-turn", name: "your turn session" }),
+      ],
+      git: { "your-turn": openPr },
+      flow: true,
+    });
+
+    const yourTurn = page.getByRole("button", { name: /Your turn \(1\)/i });
+    const reviewing = page.getByRole("button", { name: /Reviewing \(1\)/i });
+    await expect.element(yourTurn).toHaveAttribute("aria-expanded", "true");
+    await expect.element(reviewing).toHaveAttribute("aria-expanded", "false");
+    await expect.element(page.getByText("active session")).toBeInTheDocument();
+    await expect.element(page.getByText("your turn session")).toBeInTheDocument();
+    await expect.element(page.getByText("review session")).not.toBeInTheDocument();
+
+    const reviewToggleHeight = (reviewing.element() as HTMLElement).getBoundingClientRect().height;
+    expect(reviewToggleHeight).toBeGreaterThanOrEqual(44);
+  });
+
+  it("opens only the tapped group and lets a second tap close it", async () => {
+    reviews.setReviewing("mobile-review", true);
+    render(Herd, {
+      ...base,
+      sessions: [
+        session({ id: "mobile-review", name: "review session" }),
+        session({ id: "your-turn", name: "your turn session" }),
+      ],
+      git: { "your-turn": openPr },
+      flow: true,
+    });
+
+    const yourTurn = page.getByRole("button", { name: /Your turn \(1\)/i });
+    const reviewing = page.getByRole("button", { name: /Reviewing \(1\)/i });
+    await reviewing.click();
+    await expect.element(reviewing).toHaveAttribute("aria-expanded", "true");
+    await expect.element(yourTurn).toHaveAttribute("aria-expanded", "false");
+    await expect.element(page.getByText("review session")).toBeInTheDocument();
+    await expect.element(page.getByText("your turn session")).not.toBeInTheDocument();
+
+    await reviewing.click();
+    await expect.element(reviewing).toHaveAttribute("aria-expanded", "false");
+    await expect.element(page.getByText("review session")).not.toBeInTheDocument();
+  });
+
+  it("keeps a group action separate from the disclosure toggle", async () => {
+    const onmergetrain = vi.fn();
+    render(Herd, {
+      ...base,
+      sessions: [session({ id: "ready", name: "ready session", readyToMerge: true })],
+      git: { ready: openPr },
+      flow: true,
+      onmergetrain,
+    });
+
+    const ready = page.getByRole("button", { name: /Ready to merge \(1\)/i });
+    await expect.element(ready).toHaveAttribute("aria-expanded", "false");
+    await page.getByRole("button", { name: "Merge train" }).click();
+    expect(onmergetrain).toHaveBeenCalledOnce();
+    await expect.element(ready).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("leaves lifecycle groups expanded and non-interactive on desktop", async () => {
+    reviews.setReviewing("mobile-review", true);
+    render(Herd, {
+      ...base,
+      sessions: [
+        session({ id: "mobile-review", name: "review session" }),
+        session({ id: "your-turn", name: "your turn session" }),
+      ],
+      git: { "your-turn": openPr },
+    });
+
+    await expect.element(page.getByText("review session")).toBeInTheDocument();
+    await expect.element(page.getByText("your turn session")).toBeInTheDocument();
+    await expect
+      .element(page.getByRole("button", { name: /Your turn \(1\)/i }))
+      .not.toBeInTheDocument();
+  });
+});
+
 describe("Herd Ready filter", () => {
   // reviews/planGates are module singletons — clear any state set per test so it
   // doesn't bleed into the next one.

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -357,6 +357,14 @@
   // global merged count (rest + grouped) — drives clear-merged enablement
   const mergedCount = $derived(partition.merged.length + mergedAbove);
 
+  // Phone-only lifecycle accordion. The stable key makes "Your turn" the default
+  // without coupling the open state to the groups' live ordering. null closes all
+  // named lifecycle groups; unheaded active rows remain visible.
+  let mobileOpenPartitionKey = $state<string | null>("awaiting-merge");
+  function toggleMobilePartitionGroup(key: string) {
+    mobileOpenPartitionKey = mobileOpenPartitionKey === key ? null : key;
+  }
+
   // The waiting-on-* group headers name the responsible person when the whole
   // group shares one (the common case: one repo, one merger). The herd can span
   // repos, so a mixed group falls back to a name-less header.
@@ -682,7 +690,14 @@
       />
       <HerdExperimentGroups groups={experimentGrouped.groups} {oncompare} ctx={rowCtx} />
       {#each partitionGroups as grp (grp.key)}
-        <HerdGroup ctx={rowCtx} {...grp} help={groupHelp[grp.key] ?? null} />
+        <HerdGroup
+          ctx={rowCtx}
+          {...grp}
+          help={groupHelp[grp.key] ?? null}
+          collapsible={flow && !!grp.headClass && grp.sessions.length > 0}
+          expanded={!flow || mobileOpenPartitionKey === grp.key}
+          ontoggle={() => toggleMobilePartitionGroup(grp.key)}
+        />
       {/each}
     {/if}
     {#if filter !== "done" && filter !== "rundown" && filter !== "owed"}

--- a/ui/src/lib/components/herd/HerdGroup.svelte
+++ b/ui/src/lib/components/herd/HerdGroup.svelte
@@ -47,6 +47,9 @@
     // Optional stage explainer: a right-aligned "i" that opens a tooltip describing what
     // this lifecycle stage means, what Shepherd does automatically, and what happens next.
     help?: { text: string; label: string } | null;
+    collapsible?: boolean;
+    expanded?: boolean;
+    ontoggle?: () => void;
     ctx: HerdRowCtx;
   };
 
@@ -58,14 +61,25 @@
     action = null,
     withPreview = false,
     help = null,
+    collapsible = false,
+    expanded = true,
+    ontoggle = undefined,
     ctx,
   }: HerdGroupProps = $props();
 </script>
 
 {#if headClass}
-  <div class="{headClass} micro">
-    {#if countLabel}{countLabel}{/if}
-    {#if aboveLabel}<span class="above">{aboveLabel}</span>{/if}
+  <div class="{headClass} micro" class:collapsible>
+    {#if collapsible}
+      <button class="group-toggle" type="button" aria-expanded={expanded} onclick={ontoggle}>
+        <span class="chev" class:collapsed={!expanded} aria-hidden="true">▾</span>
+        {#if countLabel}<span>{countLabel}</span>{/if}
+        {#if aboveLabel}<span class="above">{aboveLabel}</span>{/if}
+      </button>
+    {:else}
+      {#if countLabel}{countLabel}{/if}
+      {#if aboveLabel}<span class="above">{aboveLabel}</span>{/if}
+    {/if}
     {#if action || help}
       <!-- right-aligned cluster: the optional bulk action, then the stage-explainer "i"
            (kept rightmost for a consistent target across every header). -->
@@ -85,32 +99,34 @@
     {/if}
   </div>
 {/if}
-{#each sessions as session (session.id)}
-  <UnitRow
-    {session}
-    selected={session.id === ctx.selectedId}
-    nowMs={ctx.nowMs}
-    onselect={ctx.onselect}
-    git={ctx.git[session.id]}
-    activity={ctx.activity[session.id]}
-    previewPort={withPreview ? (ctx.preview[session.id] ?? null) : null}
-    previewServeFailed={withPreview ? ctx.previewServe[session.id] === "failed" : false}
-    onpreview={withPreview ? ctx.onpreview : undefined}
-    ondecommission={ctx.ondecommission}
-    onrename={ctx.onrename}
-    onrelaunch={ctx.onrelaunch}
-    onrelaunchElsewhere={ctx.onrelaunchElsewhere}
-    onvariant={ctx.onvariant}
-    onreplace={ctx.onreplace}
-    repoFilter={ctx.repoFilter}
-    onrepofilter={ctx.onrepofilter}
-    workingBlocked={ctx.workingBlocked}
-    quotaKind={ctx.quotaKindFor(session.id)}
-    hold={ctx.holdFor(session.id)}
-    onackmanualsteps={ctx.onackmanualsteps}
-    onshowowed={ctx.onshowowed}
-  />
-{/each}
+{#if !collapsible || expanded}
+  {#each sessions as session (session.id)}
+    <UnitRow
+      {session}
+      selected={session.id === ctx.selectedId}
+      nowMs={ctx.nowMs}
+      onselect={ctx.onselect}
+      git={ctx.git[session.id]}
+      activity={ctx.activity[session.id]}
+      previewPort={withPreview ? (ctx.preview[session.id] ?? null) : null}
+      previewServeFailed={withPreview ? ctx.previewServe[session.id] === "failed" : false}
+      onpreview={withPreview ? ctx.onpreview : undefined}
+      ondecommission={ctx.ondecommission}
+      onrename={ctx.onrename}
+      onrelaunch={ctx.onrelaunch}
+      onrelaunchElsewhere={ctx.onrelaunchElsewhere}
+      onvariant={ctx.onvariant}
+      onreplace={ctx.onreplace}
+      repoFilter={ctx.repoFilter}
+      onrepofilter={ctx.onrepofilter}
+      workingBlocked={ctx.workingBlocked}
+      quotaKind={ctx.quotaKindFor(session.id)}
+      hold={ctx.holdFor(session.id)}
+      onackmanualsteps={ctx.onackmanualsteps}
+      onshowowed={ctx.onshowowed}
+    />
+  {/each}
+{/if}
 
 <style>
   .micro {
@@ -118,6 +134,42 @@
     letter-spacing: 0.18em;
     text-transform: uppercase;
     color: var(--color-muted);
+  }
+
+  .micro.collapsible {
+    min-height: 44px;
+    padding-block: 0;
+  }
+
+  .group-toggle {
+    display: flex;
+    align-items: center;
+    align-self: stretch;
+    gap: 7px;
+    flex: 1;
+    min-width: 0;
+    min-height: 44px;
+    padding: 0;
+    border: 0;
+    background: none;
+    color: inherit;
+    font: inherit;
+    letter-spacing: inherit;
+    text-transform: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+  .group-toggle:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+
+  .chev {
+    flex: none;
+    transition: transform 0.12s ease;
+  }
+  .chev.collapsed {
+    transform: rotate(-90deg);
   }
 
   /* amber section headers for the in-flight stages (PR CI running, critic
@@ -223,6 +275,13 @@
   .merge-train:focus-visible {
     outline: none;
     box-shadow: inset 0 0 0 1px var(--color-amber);
+  }
+
+  .collapsible .merge-train,
+  .collapsible .clear-merged {
+    align-self: stretch;
+    min-height: 44px;
+    padding-inline: 8px;
   }
 
   /* right-aligned bulk action in the merged group header */

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-mobile-herd-accordion.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-mobile-herd-accordion.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "mobile-herd-accordion",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_mobile_herd_accordion_title",
+  bodyKey: "feat_mobile_herd_accordion_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## Problem / goal

The mobile Herd can contain many lifecycle sections such as **Your turn**, **Reviewing**, **Rework running**, and **Waiting on review**. Showing every session in every section at once creates a long, difficult-to-scan phone view, while the existing section headers are too small to act as comfortable touch controls.

The goal is to keep the operator-focused **Your turn** section visible by default and make the remaining lifecycle groups easy to reach without changing the desktop workflow.

## Solution / added

- Turn named lifecycle sections into a phone-only accordion.
- Open **Your turn** by default and collapse the other named sections.
- Keep at most one named section open; tapping the open section closes it.
- Keep ungrouped active sessions visible above the accordion.
- Give disclosure headers a 44 px minimum touch target, a directional chevron, keyboard focus treatment, and `aria-expanded` state.
- Preserve separate header actions and stage help controls without nested interactive elements.
- Leave desktop, epic groups, and experiment groups unchanged.
- Add EN/DE What's New copy for the mobile behavior.

## Technical details

- `Herd.svelte` owns one ephemeral open lifecycle-group key, initialized to `awaiting-merge` (the internal key for **Your turn**).
- `HerdGroup.svelte` renders a semantic disclosure button only when the existing mobile `flow` mode is active.
- Group identity uses stable partition keys, so live status reordering cannot open the wrong section.
- Accordion state is intentionally not persisted and resets on reload.
- Existing stage explainer tooltips from current `main` remain in the right-side header cluster after the rebase.

## Verification

- `cd ui && bun run check` - passed, 0 errors and 0 warnings
- `cd ui && bun run check:i18n` - passed, EN/DE catalogs in parity
- `cd ui && bun run test:browser -- src/lib/components/Herd.browser.test.ts` - passed, 35 tests
- Branch hygiene, feature catalog, announcement version, and glossary gates - passed
- The full UI browser matrix was attempted after rebasing but was stopped after host-wide Playwright load caused repeated browser-server connection timeouts. The focused affected suite is green; CI will run the isolated full matrix.
