### PR TITLE
feat(settings): choose a default model for each coding CLI

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import { dirname, join } from "node:path";
 import { resolveNodeBin } from "./node-bin";
 import { loadForgeMap } from "./forge/load-config";
 import {
+  normalizeDefaultCodexModelSetting,
   normalizeDefaultModelSetting,
   normalizeFableAvailable,
   normalizeRoleCli,
@@ -786,6 +787,10 @@ export const config = {
   // value applies to both the New Task picker and drain/autopilot auto-spawns. Env seeds
   // a fresh DB; absent/invalid → "auto".
   defaultModel: normalizeDefaultModelSetting(process.env.SHEPHERD_DEFAULT_MODEL) ?? "auto",
+  // Provider-specific Codex default. Existing installs seed to the picker's historical first
+  // choice; "default" means no --model flag and lets Codex choose.
+  defaultCodexModel:
+    normalizeDefaultCodexModelSetting(process.env.SHEPHERD_DEFAULT_CODEX_MODEL) ?? "gpt-5.5",
   // Global default reasoning-effort setting ("default" | <tier>). "default" = emit no effort flag.
   // Applies to the New Task picker and drain/autopilot auto-spawns. Env seeds a fresh DB;
   // absent/invalid → "default". Persisted + UI-configurable. No "auto" tier (effort has no promo).

--- a/src/default-model.ts
+++ b/src/default-model.ts
@@ -24,6 +24,7 @@ import {
 import { normalizeEffort } from "./default-effort";
 
 const SETTING_VALUES = new Set<string>(["auto", "default", ...MODELS]);
+const CODEX_SETTING_VALUES = new Set<string>(["default", ...CODEX_MODELS]);
 const CLAUDE_MODEL_VALUES = new Set<string>(MODELS);
 const CODEX_MODEL_VALUES = new Set<string>(CODEX_MODELS);
 
@@ -39,6 +40,12 @@ const REPO_SETTING_VALUES = new Set<string>(["inherit", ...SETTING_VALUES]);
 export function normalizeDefaultModelSetting(value: unknown): string | null {
   if (typeof value !== "string") return null;
   return SETTING_VALUES.has(value) ? value : null;
+}
+
+/** Normalize the persisted Codex default-model setting. */
+export function normalizeDefaultCodexModelSetting(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  return CODEX_SETTING_VALUES.has(value) ? value : null;
 }
 
 /**
@@ -129,6 +136,20 @@ export function resolveDefaultModelSetting(
   )
     return repoSetting;
   return globalSetting;
+}
+
+/** Resolve the selected provider's saved default, honoring only compatible repo overrides. */
+export function resolveProviderDefaultModelSetting(
+  repoSetting: string | null | undefined,
+  provider: AgentProvider,
+  claudeSetting: string,
+  codexSetting: string,
+): string {
+  const globalSetting = provider === "codex" ? codexSetting : claudeSetting;
+  const resolved = resolveDefaultModelSetting(repoSetting, globalSetting);
+  return modelCompatibleWithProvider(drainSpawnModel(resolved), provider)
+    ? resolved
+    : globalSetting;
 }
 
 /** How the operator's Codex CLI is authenticated. Some Codex models are rejected (HTTP 400) under

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -366,14 +366,16 @@ export class DiagnosticsService {
       [config.autopilotCli, config.autopilotModel],
       [config.criticCli, config.criticModel],
       [config.docAgentCli, config.docAgentModel],
-      ["inherit", "default"], // the global default (defaultAgentProvider/defaultModel)
+      ["inherit", "default"], // the global default provider and its matching model
     ];
     const roleOrGlobalHit = pairs.some(([cli, model]) => {
+      const globalModelSetting =
+        config.defaultAgentProvider === "codex" ? config.defaultCodexModel : config.defaultModel;
       const env = resolveRoleEnvironment(
         cli,
         model,
         config.defaultAgentProvider,
-        config.defaultModel,
+        globalModelSetting,
         config.fableAvailable,
         "default",
         "unknown",

--- a/src/drain.ts
+++ b/src/drain.ts
@@ -99,7 +99,7 @@ import {
   clampCodexModelForAuth,
   drainSpawnModel,
   modelForProviderOrDefault,
-  resolveDefaultModelSetting,
+  resolveProviderDefaultModelSetting,
   type CodexAuthMode,
 } from "./default-model";
 import { readCodexAuthMode } from "./codex-auth";
@@ -352,7 +352,14 @@ export class DrainService {
     const provider = settings?.agentProvider ?? config.defaultAgentProvider;
     const model = settings
       ? modelForProviderOrDefault(settings.model, settings.agentProvider)
-      : drainSpawnModel(resolveDefaultModelSetting(repoDefaultModel, config.defaultModel));
+      : drainSpawnModel(
+          resolveProviderDefaultModelSetting(
+            repoDefaultModel,
+            provider,
+            config.defaultModel,
+            config.defaultCodexModel,
+          ),
+        );
     return this.clampCodexModel(model, provider);
   }
 
@@ -1751,7 +1758,14 @@ export class DrainService {
     if (lastFail !== undefined && this.now() - lastFail < SPAWN_FAIL_COOLDOWN_MS) return; // recent refusal
     const head = pr.headSha ?? "";
     const cfgModel = this.clampCodexModel(
-      drainSpawnModel(resolveDefaultModelSetting(cfg.defaultModel, config.defaultModel)),
+      drainSpawnModel(
+        resolveProviderDefaultModelSetting(
+          cfg.defaultModel,
+          config.defaultAgentProvider,
+          config.defaultModel,
+          config.defaultCodexModel,
+        ),
+      ),
       config.defaultAgentProvider,
     );
     const cfgEffort = drainSpawnEffort(

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,7 @@ import { resolveNodeHost, TailscaleServeService } from "./tailscale";
 import {
   drainSpawnModel,
   modelForProviderOrDefault,
+  normalizeDefaultCodexModelSetting,
   normalizeDefaultModelSetting,
   normalizeFableAvailable,
   normalizeRoleCli,
@@ -275,6 +276,10 @@ const savedDm = store.getSetting("defaultModel");
 if (savedDm !== null) {
   const v = normalizeDefaultModelSetting(savedDm);
   if (v !== null) config.defaultModel = v;
+}
+const savedDcm = store.getSetting("defaultCodexModel");
+if (savedDcm !== null) {
+  config.defaultCodexModel = normalizeDefaultCodexModelSetting(savedDcm) ?? "default";
 }
 const savedDe = store.getSetting("defaultEffort");
 if (savedDe !== null) {
@@ -594,6 +599,8 @@ function usageDowngradeModel(): string | null {
 // in the usage-downgrade so role agents are covered too (they bypass service.create/pushModelFlag).
 // The downgrade target is a Claude model setting, so it only overrides a Claude-resolved role.
 function roleEnv(cli: string, model: string, effort: string): RoleEnvironment {
+  const globalModelSetting =
+    config.defaultAgentProvider === "codex" ? config.defaultCodexModel : config.defaultModel;
   // resolveRoleEnvWithAuth reads the live Codex auth mode per spawn (auth can change at runtime) and
   // clamps a ChatGPT-account-incompatible codex model to the account default before it can be spawned.
   const env = resolveRoleEnvWithAuth(
@@ -601,7 +608,7 @@ function roleEnv(cli: string, model: string, effort: string): RoleEnvironment {
       roleCli: cli,
       roleModel: model,
       globalProvider: config.defaultAgentProvider,
-      globalModelSetting: config.defaultModel,
+      globalModelSetting,
       fableAvailable: config.fableAvailable,
       roleEffort: effort,
     },

--- a/src/server.ts
+++ b/src/server.ts
@@ -184,14 +184,15 @@ import type { ServerWebSocket } from "bun";
 import { execFileSync, markPtyEvent } from "./instrument";
 import { isOperatorKeystroke, stampOperatorKeystroke } from "./operator-activity";
 import {
+  normalizeDefaultCodexModelSetting,
+  clampCodexModelForAuth,
   normalizeDefaultModelSetting,
   normalizeFableAvailable,
   normalizeRepoDefaultModelSetting,
   drainSpawnModel,
-  resolveDefaultModelSetting,
+  resolveProviderDefaultModelSetting,
   normalizeRoleCli,
   normalizeRoleModelToken,
-  clampCodexModelForAuth,
   modelCompatibleWithProvider,
   type CodexAuthMode,
 } from "./default-model";
@@ -1084,6 +1085,7 @@ async function handleUpNextStart(req: Request, deps: AppDeps): Promise<Response>
       // orchestration stays the auto epic-runner's job (documented v1 scoping, #1169).
       const base = await forge.defaultBranch();
       const rc = deps.store.getRepoConfig(it.dir);
+      const provider = choice?.agentProvider ?? config.defaultAgentProvider;
       const input: CreateSessionInput = {
         repoPath: it.dir,
         baseBranch: base,
@@ -1094,7 +1096,14 @@ async function handleUpNextStart(req: Request, deps: AppDeps): Promise<Response>
         model:
           choice && "model" in choice
             ? (choice.model ?? null)
-            : drainSpawnModel(resolveDefaultModelSetting(rc.defaultModel, config.defaultModel)),
+            : drainSpawnModel(
+                resolveProviderDefaultModelSetting(
+                  rc.defaultModel,
+                  provider,
+                  config.defaultModel,
+                  config.defaultCodexModel,
+                ),
+              ),
         effort:
           choice && "effort" in choice
             ? choice.effort
@@ -4462,6 +4471,7 @@ async function handleSettings({ req, parts, deps }: Ctx): Promise<Response | nul
       previewHost: config.previewHost,
       // raw configured default model; "auto" = unset/seed; client resolves promo itself.
       defaultModel: config.defaultModel,
+      defaultCodexModel: resolvedCodexSetting(config.defaultCodexModel, deps),
       defaultEffort: config.defaultEffort,
       // per-role ENVIRONMENT SETTINGs, a pair per role: `<role>Cli` ("inherit" | "claude" | "codex";
       // "inherit" follows defaultAgentProvider + defaultModel) and `<role>Model` ("default" | <alias>
@@ -4545,6 +4555,7 @@ const SETTING_PATCHES: [string, (value: unknown, deps: Ctx["deps"]) => Response]
   ["prReviewCyclesCap", putPrReviewCyclesCap],
   ["planReviewCyclesCap", putPlanReviewCyclesCap],
   ["defaultModel", putDefaultModel],
+  ["defaultCodexModel", putDefaultCodexModel],
   ["defaultEffort", putDefaultEffort],
   ["criticCli", makeRoleCliPatch("critic")],
   ["criticModel", makeRoleModelPatch("critic")],
@@ -4641,6 +4652,21 @@ function putDefaultModel(value: unknown, deps: Ctx["deps"]): Response {
   config.defaultModel = v; // live: next drain spawn picks it up
   deps.store.setSetting("defaultModel", v); // persist across restarts
   return json({ defaultModel: config.defaultModel });
+}
+
+function putDefaultCodexModel(value: unknown, deps: Ctx["deps"]): Response {
+  const normalized = normalizeDefaultCodexModelSetting(value);
+  if (normalized === null) return json({ error: "unknown Codex model" }, 400);
+  const v = resolvedCodexSetting(normalized, deps);
+  config.defaultCodexModel = v;
+  deps.store.setSetting("defaultCodexModel", v);
+  return json({ defaultCodexModel: config.defaultCodexModel });
+}
+
+function resolvedCodexSetting(value: string, deps: Ctx["deps"]): string {
+  const model = value === "default" ? null : value;
+  const authMode = (deps.readCodexAuthMode ?? readCodexAuthMode)();
+  return clampCodexModelForAuth(model, "codex", authMode) ?? "default";
 }
 
 function putDefaultEffort(value: unknown, deps: Ctx["deps"]): Response {

--- a/test/default-model.test.ts
+++ b/test/default-model.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, test, expect, describe } from "bun:test";
 import {
+  normalizeDefaultCodexModelSetting,
   normalizeDefaultModelSetting,
   normalizeRepoDefaultModelSetting,
   resolveDefaultModelSetting,
@@ -17,9 +18,10 @@ import {
   normalizeFableAvailable,
   modelCompatibleWithProvider,
   modelForProviderOrDefault,
+  resolveProviderDefaultModelSetting,
 } from "../src/default-model";
 import { readCodexAuthMode } from "../src/codex-auth";
-import { MODELS } from "../src/types";
+import { CODEX_MODELS, MODELS } from "../src/types";
 
 describe("normalizeDefaultModelSetting", () => {
   test("accepts 'auto'", () => {
@@ -58,6 +60,44 @@ describe("normalizeDefaultModelSetting", () => {
 
   test("returns null for object", () => {
     expect(normalizeDefaultModelSetting({})).toBeNull();
+  });
+});
+
+describe("normalizeDefaultCodexModelSetting", () => {
+  test("accepts 'default' and each curated Codex model", () => {
+    expect(normalizeDefaultCodexModelSetting("default")).toBe("default");
+    for (const model of CODEX_MODELS) {
+      expect(normalizeDefaultCodexModelSetting(model)).toBe(model);
+    }
+  });
+
+  test("rejects Claude models, auto, unknown values, and wrong types", () => {
+    expect(normalizeDefaultCodexModelSetting("opus")).toBeNull();
+    expect(normalizeDefaultCodexModelSetting("auto")).toBeNull();
+    expect(normalizeDefaultCodexModelSetting("gpt-6-unknown")).toBeNull();
+    expect(normalizeDefaultCodexModelSetting(null)).toBeNull();
+  });
+});
+
+describe("resolveProviderDefaultModelSetting", () => {
+  test("inherits the selected provider's saved model", () => {
+    expect(resolveProviderDefaultModelSetting("inherit", "claude", "opus", "gpt-5.4")).toBe("opus");
+    expect(resolveProviderDefaultModelSetting("inherit", "codex", "opus", "gpt-5.4")).toBe(
+      "gpt-5.4",
+    );
+  });
+
+  test("uses a compatible repo override", () => {
+    expect(resolveProviderDefaultModelSetting("haiku", "claude", "opus", "gpt-5.4")).toBe("haiku");
+    expect(resolveProviderDefaultModelSetting("default", "codex", "opus", "gpt-5.4")).toBe(
+      "default",
+    );
+  });
+
+  test("falls back to the selected provider's saved model for an incompatible override", () => {
+    expect(resolveProviderDefaultModelSetting("opus", "codex", "sonnet", "gpt-5.4")).toBe(
+      "gpt-5.4",
+    );
   });
 });
 

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -1119,6 +1119,27 @@ describe("codex_model_auth advisory", () => {
     });
   });
 
+  it("checks the provider-specific global Codex default", async () => {
+    const savedProvider = config.defaultAgentProvider;
+    const savedClaudeModel = config.defaultModel;
+    const savedCodexModel = config.defaultCodexModel;
+    config.defaultAgentProvider = "codex";
+    config.defaultModel = "sonnet";
+    config.defaultCodexModel = "gpt-5.3-codex";
+    try {
+      const svc = new DiagnosticsService({
+        ...healthyDeps(),
+        readCodexAuthMode: () => "chatgpt",
+      });
+      const c = byId((await svc.check(0)).checks, "codex_model_auth");
+      expect(c.state).toBe("warning");
+    } finally {
+      config.defaultAgentProvider = savedProvider;
+      config.defaultModel = savedClaudeModel;
+      config.defaultCodexModel = savedCodexModel;
+    }
+  });
+
   it("does NOT warn under apikey auth (the model is supported there)", async () => {
     await withRecap("codex", "gpt-5.3-codex", async () => {
       const svc = new DiagnosticsService({

--- a/test/drain-landing-repair.test.ts
+++ b/test/drain-landing-repair.test.ts
@@ -364,16 +364,15 @@ describe("landing-repair: dispatch", () => {
     expect(h.repairCountCalls).toEqual([{ count: 1, head: "h1" }]);
   });
 
-  test("ChatGPT auth clamps a blocked Codex repo default for landing repair", async () => {
-    const prior = config.defaultAgentProvider;
-    const priorModel = config.defaultModel;
+  test("ChatGPT auth clamps a blocked Codex global default for landing repair", async () => {
+    const savedProvider = config.defaultAgentProvider;
+    const savedCodexModel = config.defaultCodexModel;
     config.defaultAgentProvider = "codex";
-    config.defaultModel = "gpt-5.3-codex";
+    config.defaultCodexModel = "gpt-5.3-codex";
     try {
       const h = makeHarness({
         autoDrainEnabled: true,
         prStatus: async () => redPr(),
-        repoDefaultModel: "gpt-5.3-codex",
         authMode: "chatgpt",
       });
       seedOpenLanding(h);
@@ -383,8 +382,30 @@ describe("landing-repair: dispatch", () => {
 
       expect(h.createCalls[0]?.input.model).toBeNull();
     } finally {
-      config.defaultAgentProvider = prior;
-      config.defaultModel = priorModel;
+      config.defaultAgentProvider = savedProvider;
+      config.defaultCodexModel = savedCodexModel;
+    }
+  });
+
+  test("inherits the selected provider's saved model", async () => {
+    const savedProvider = config.defaultAgentProvider;
+    const savedClaudeModel = config.defaultModel;
+    const savedCodexModel = config.defaultCodexModel;
+    config.defaultAgentProvider = "codex";
+    config.defaultModel = "sonnet";
+    config.defaultCodexModel = "gpt-5.4";
+    try {
+      const h = makeHarness({ autoDrainEnabled: true, prStatus: async () => redPr() });
+      seedOpenLanding(h);
+      spendRerunBudget(h);
+
+      await callRerunPass(h);
+
+      expect(h.createCalls[0]!.input.model).toBe("gpt-5.4");
+    } finally {
+      config.defaultAgentProvider = savedProvider;
+      config.defaultModel = savedClaudeModel;
+      config.defaultCodexModel = savedCodexModel;
     }
   });
 

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -337,23 +337,22 @@ test("spawn fills to cap: 3 labeled issues, maxAuto 2 → creates exactly 2 auto
   expect(h.statuses.at(-1)?.inFlight).toBe(2);
 });
 
-test("ChatGPT auth clamps a blocked Codex repo default before drain create", async () => {
-  const prior = config.defaultAgentProvider;
-  const priorModel = config.defaultModel;
+test("ChatGPT auth clamps a blocked Codex global default before drain create", async () => {
+  const savedProvider = config.defaultAgentProvider;
+  const savedCodexModel = config.defaultCodexModel;
   config.defaultAgentProvider = "codex";
-  config.defaultModel = "gpt-5.3-codex";
+  config.defaultCodexModel = "gpt-5.3-codex";
   try {
     const h = makeHarness({
       issues: [issue(1)],
       maxAuto: 1,
-      repoDefaultModel: "gpt-5.3-codex",
       authMode: "chatgpt",
     });
     await h.drain.pump(REPO);
     expect(h.creates[0]?.model).toBeNull();
   } finally {
-    config.defaultAgentProvider = prior;
-    config.defaultModel = priorModel;
+    config.defaultAgentProvider = savedProvider;
+    config.defaultCodexModel = savedCodexModel;
   }
 });
 
@@ -1495,7 +1494,11 @@ describe("drain epic mode", () => {
 
   test("running epic inheriting global Codex default spawns despite Claude usage ceiling", async () => {
     const saved = config.defaultAgentProvider;
+    const savedClaudeModel = config.defaultModel;
+    const savedCodexModel = config.defaultCodexModel;
     config.defaultAgentProvider = "codex";
+    config.defaultModel = "sonnet";
+    config.defaultCodexModel = "gpt-5.4";
     try {
       const h = epicHarness("running", "auto", {
         usagePct: 100,
@@ -1504,11 +1507,14 @@ describe("drain epic mode", () => {
       await h.drain.pump(REPO);
       expect(h.creates).toHaveLength(1);
       expect(h.creates[0]!.agentProvider).toBeUndefined();
+      expect(h.creates[0]!.model).toBe("gpt-5.4");
       const last = h.statuses.at(-1)!;
       expect(last.paused).toBe(false);
       expect(last.reason).not.toBe("usage");
     } finally {
       config.defaultAgentProvider = saved;
+      config.defaultModel = savedClaudeModel;
+      config.defaultCodexModel = savedCodexModel;
     }
   });
 

--- a/test/server-settings.test.ts
+++ b/test/server-settings.test.ts
@@ -25,6 +25,7 @@ let savedHk: boolean;
 let savedPrCap: number;
 let savedPlanCap: number;
 let savedDefaultModel: string;
+let savedDefaultCodexModel: string;
 const ROLE_BASES = ["critic", "planner", "recap", "docAgent", "namer", "autopilot"] as const;
 let savedRoleEnvs: Record<string, string>;
 let savedDefaultAgentProvider: typeof config.defaultAgentProvider;
@@ -53,6 +54,7 @@ beforeEach(() => {
   savedPrCap = config.prReviewCyclesCap;
   savedPlanCap = config.planReviewCyclesCap;
   savedDefaultModel = config.defaultModel;
+  savedDefaultCodexModel = config.defaultCodexModel;
   savedRoleEnvs = {};
   const cfg = config as unknown as Record<string, string>;
   for (const role of ROLE_BASES) {
@@ -89,6 +91,7 @@ afterEach(() => {
   config.prReviewCyclesCap = savedPrCap;
   config.planReviewCyclesCap = savedPlanCap;
   config.defaultModel = savedDefaultModel;
+  config.defaultCodexModel = savedDefaultCodexModel;
   const cfg = config as unknown as Record<string, string>;
   for (const role of ROLE_BASES) {
     cfg[`${role}Cli`] = savedRoleEnvs[`${role}Cli`]!;
@@ -110,13 +113,17 @@ afterEach(() => {
   rmSync(tmp, { recursive: true, force: true });
 });
 
-function harness(): { app: ReturnType<typeof makeApp>; store: SessionStore } {
+function harness(opts: { codexAuthMode?: "chatgpt" | "apikey" | "unknown" } = {}): {
+  app: ReturnType<typeof makeApp>;
+  store: SessionStore;
+} {
   const store = new SessionStore(":memory:");
   const deps: AppDeps = {
     store,
     events: new EventHub(),
     service: {} as any,
     usageLimits: { limits: () => ({}) } as any,
+    readCodexAuthMode: () => opts.codexAuthMode ?? "unknown",
   };
   return { app: makeApp(deps), store };
 }
@@ -391,6 +398,13 @@ test("GET /api/settings includes defaultModel (raw, unresolved)", async () => {
   expect(body.defaultModel).toBe("opus");
 });
 
+test("GET /api/settings includes the provider-specific Codex default model", async () => {
+  config.defaultCodexModel = "gpt-5.4";
+  const { app } = harness();
+  const body = await (await app.fetch(new Request("http://x/api/settings"))).json();
+  expect(body.defaultCodexModel).toBe("gpt-5.4");
+});
+
 test("GET /api/settings includes defaultAgentProvider", async () => {
   config.defaultAgentProvider = "codex";
   const { app } = harness();
@@ -430,6 +444,40 @@ test("PUT /api/settings rejects an unknown defaultModel value", async () => {
   const res = await put(app, { defaultModel: "gpt9" });
   expect(res.status).toBe(400);
   expect(config.defaultModel).toBe("auto"); // unchanged on failure
+});
+
+test("PUT /api/settings sets and persists defaultCodexModel", async () => {
+  const { app, store } = harness();
+  config.defaultCodexModel = "gpt-5.5";
+  const res = await put(app, { defaultCodexModel: "gpt-5.4" });
+  expect(res.status).toBe(200);
+  expect((await res.json()).defaultCodexModel).toBe("gpt-5.4");
+  expect(config.defaultCodexModel).toBe("gpt-5.4");
+  expect(store.getSetting("defaultCodexModel")).toBe("gpt-5.4");
+});
+
+test("PUT /api/settings accepts provider default and rejects invalid Codex models", async () => {
+  const { app } = harness();
+  config.defaultCodexModel = "gpt-5.5";
+  const accepted = await put(app, { defaultCodexModel: "default" });
+  expect(accepted.status).toBe(200);
+  expect(config.defaultCodexModel).toBe("default");
+  const rejected = await put(app, { defaultCodexModel: "opus" });
+  expect(rejected.status).toBe(400);
+  expect(config.defaultCodexModel).toBe("default");
+});
+
+test("GET and PUT resolve a ChatGPT-incompatible Codex model to provider default", async () => {
+  const { app, store } = harness({ codexAuthMode: "chatgpt" });
+  config.defaultCodexModel = "gpt-5.3-codex";
+  const got = await (await app.fetch(new Request("http://x/api/settings"))).json();
+  expect(got.defaultCodexModel).toBe("default");
+
+  const res = await put(app, { defaultCodexModel: "gpt-5.3-codex" });
+  expect(res.status).toBe(200);
+  expect((await res.json()).defaultCodexModel).toBe("default");
+  expect(config.defaultCodexModel).toBe("default");
+  expect(store.getSetting("defaultCodexModel")).toBe("default");
 });
 
 // ── per-role environment settings (cli + model) for the six roles ──

--- a/test/server-up-next.test.ts
+++ b/test/server-up-next.test.ts
@@ -13,6 +13,8 @@ let repoDir: string;
 const oldUsageHoldEnabled = config.usageHoldEnabled;
 const oldUsageHoldPct = config.usageHoldPct;
 const oldDefaultModel = config.defaultModel;
+const oldDefaultCodexModel = config.defaultCodexModel;
+const oldDefaultAgentProvider = config.defaultAgentProvider;
 const oldDefaultEffort = config.defaultEffort;
 
 beforeEach(() => {
@@ -22,12 +24,16 @@ beforeEach(() => {
   config.usageHoldEnabled = oldUsageHoldEnabled;
   config.usageHoldPct = oldUsageHoldPct;
   config.defaultModel = oldDefaultModel;
+  config.defaultCodexModel = oldDefaultCodexModel;
+  config.defaultAgentProvider = oldDefaultAgentProvider;
   config.defaultEffort = oldDefaultEffort;
 });
 afterEach(() => {
   config.usageHoldEnabled = oldUsageHoldEnabled;
   config.usageHoldPct = oldUsageHoldPct;
   config.defaultModel = oldDefaultModel;
+  config.defaultCodexModel = oldDefaultCodexModel;
+  config.defaultAgentProvider = oldDefaultAgentProvider;
   config.defaultEffort = oldDefaultEffort;
   rmSync(tmpRoot, { recursive: true, force: true });
 });
@@ -201,6 +207,33 @@ test("POST /api/up-next/start preserves default model and effort for provider-on
   expect(createCalls[0]!.agentProvider).toBe("claude");
   expect(createCalls[0]!.model).toBe("sonnet");
   expect(createCalls[0]!.effort).toBe("high");
+});
+
+test("POST /api/up-next/start uses the saved Codex model for a provider-only choice", async () => {
+  config.defaultModel = "sonnet";
+  config.defaultCodexModel = "gpt-5.4";
+  const { app, createCalls } = harness();
+  const res = await app.fetch(
+    startReq([{ repoPath: repoDir, issueRef: { number: 7, url: "u", title: "t", body: "b" } }], {
+      agentProvider: "codex",
+    }),
+  );
+  expect(res.status).toBe(201);
+  expect(createCalls[0]!.agentProvider).toBe("codex");
+  expect(createCalls[0]!.model).toBe("gpt-5.4");
+});
+
+test("POST /api/up-next/start uses the saved model for the global default provider", async () => {
+  config.defaultAgentProvider = "codex";
+  config.defaultModel = "sonnet";
+  config.defaultCodexModel = "default";
+  const { app, createCalls } = harness();
+  const res = await app.fetch(
+    startReq([{ repoPath: repoDir, issueRef: { number: 7, url: "u", title: "t", body: "b" } }]),
+  );
+  expect(res.status).toBe(201);
+  expect(createCalls[0]!.agentProvider).toBeUndefined();
+  expect(createCalls[0]!.model).toBeNull();
 });
 
 test("POST /api/up-next/start rejects invalid provider/model/effort choices", async () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2176,7 +2176,7 @@
   "settings_upnext_skip_cli_picker_hint": "Wenn aktiviert, startet der Schnellstart in „Als Nächstes“ sofort mit deiner Standard-Coding-CLI, ohne nachzufragen, welche CLI verwendet werden soll — auch wenn mehr als eine installiert ist.",
   "settings_upnext_skip_cli_picker_save_failed": "Einstellung für die „Als Nächstes“-Auswahl konnte nicht geändert werden. Erneut versuchen.",
   "settings_cli_claude_title": "Claude Code",
-  "settings_cli_claude_hint": "Claude-basierte Läufe verwenden diese Modell- und Authentifizierungseinstellungen.",
+  "settings_cli_claude_hint": "Claude-basierte Läufe verwenden diese Einstellungen für Aufwand, Sprache und Authentifizierung.",
   "settings_cli_codex_title": "Codex",
   "settings_cli_codex_hint": "Codex läuft über die lokale Codex-CLI in einer steuerbaren Terminal-Session. Alpha/MVP, wird gerade intensiv weiterentwickelt.",
   "settings_cli_codex_auth_title": "Authentifizierung",
@@ -3108,5 +3108,12 @@
   "feat_automerge_session_jump_title": "Aus Voll-Auto-Merge springen",
   "feat_automerge_session_jump_body": "Klicke auf einen aktiven Voll-Auto-Merge-Eintrag, um direkt zu seinem Task und Terminal zu springen. Shepherd entfernt Filter, die ihn verbergen würden, und folgt dem Task ins richtige Repository.",
   "feat_build_queue_progress_toggle_title": "Build-Queue direkt öffnen",
-  "feat_build_queue_progress_toggle_body": "Klicke auf das Fortschritts-Badge einer Session, um sie auszuwählen und ihre Build-Queue über dem Terminal zu öffnen. Klicke erneut auf das Badge der ausgewählten Session, um die Queue ein- oder auszuklappen."
+  "feat_build_queue_progress_toggle_body": "Klicke auf das Fortschritts-Badge einer Session, um sie auszuwählen und ihre Build-Queue über dem Terminal zu öffnen. Klicke erneut auf das Badge der ausgewählten Session, um die Queue ein- oder auszuklappen.",
+  "settings_default_codex_model_title": "Codex-Modell",
+  "settings_default_codex_model_hint": "Legt das Codex-Modell für neue Aufgaben und Codex-basierte autonome Starts fest. Standard lässt die lokale Codex-CLI ohne --model-Flag wählen.",
+  "settings_default_codex_model_save_failed": "Das Standard-Codex-Modell konnte nicht geändert werden. Erneut versuchen.",
+  "settings_default_environment_title": "Standard-Coding-Umgebung",
+  "settings_default_environment_hint": "Wähle CLI und Modell für neue Aufgaben und unbeaufsichtigte Arbeit. Shepherd merkt sich je ein Modell für Claude Code und Codex.",
+  "feat_default_coding_environment_title": "Standard-CLI und -Modell wählen",
+  "feat_default_coding_environment_body": "Die Einstellungen merken sich jetzt getrennte Standardmodelle für Claude Code und Codex. Neue Aufgaben und unbeaufsichtigte Starts verwenden das zur ausgewählten Coding-CLI gehörende Modell."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2176,7 +2176,7 @@
   "settings_upnext_skip_cli_picker_hint": "When enabled, Up Next quick-start launches with your default coding CLI immediately, without asking which CLI to use — even when more than one is installed.",
   "settings_upnext_skip_cli_picker_save_failed": "Couldn't change the Up Next picker setting. Retry.",
   "settings_cli_claude_title": "Claude Code",
-  "settings_cli_claude_hint": "Claude-backed runs use these model and authentication settings.",
+  "settings_cli_claude_hint": "Claude-backed runs use these effort, language, and authentication settings.",
   "settings_cli_codex_title": "Codex",
   "settings_cli_codex_hint": "Codex runs through the local Codex CLI in a steerable terminal session. Alpha/MVP, under heavy development.",
   "settings_cli_codex_auth_title": "Authentication",
@@ -3108,5 +3108,12 @@
   "feat_automerge_session_jump_title": "Jump from Full-auto merge",
   "feat_automerge_session_jump_body": "Click any active Full-auto merge entry to jump straight to its task and terminal. Shepherd clears filters that would hide it and follows the task into the right repository.",
   "feat_build_queue_progress_toggle_title": "Open the build queue from progress",
-  "feat_build_queue_progress_toggle_body": "Click a session's progress badge to select it and open its build queue above the terminal. Click the selected session's badge again to collapse or expand the queue."
+  "feat_build_queue_progress_toggle_body": "Click a session's progress badge to select it and open its build queue above the terminal. Click the selected session's badge again to collapse or expand the queue.",
+  "settings_default_codex_model_title": "Codex model",
+  "settings_default_codex_model_hint": "Sets the Codex model for new tasks and Codex-backed autonomous starts. Default lets the local Codex CLI choose without a --model flag.",
+  "settings_default_codex_model_save_failed": "Couldn't change the default Codex model. Retry.",
+  "settings_default_environment_title": "Default coding environment",
+  "settings_default_environment_hint": "Choose the CLI and its model for new tasks and unattended work. Shepherd remembers a separate model for Claude Code and Codex.",
+  "feat_default_coding_environment_title": "Choose a default CLI and model",
+  "feat_default_coding_environment_body": "Settings now remembers separate default models for Claude Code and Codex. New tasks and unattended starts use the model paired with the selected coding CLI."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -574,6 +574,9 @@ export const putPlanReviewCyclesCap = (cap: number): Promise<{ planReviewCyclesC
 export const putDefaultModel = (model: string): Promise<{ defaultModel: string }> =>
   patchSettings<{ defaultModel: string }>({ defaultModel: model });
 
+export const putDefaultCodexModel = (model: string): Promise<{ defaultCodexModel: string }> =>
+  patchSettings<{ defaultCodexModel: string }>({ defaultCodexModel: model });
+
 export const putDefaultEffort = (effort: string): Promise<{ defaultEffort: string }> =>
   patchSettings<{ defaultEffort: string }>({ defaultEffort: effort });
 

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -1521,13 +1521,17 @@ describe("NewTask Codex model picker", () => {
   const providerSelect = () => document.querySelector<HTMLSelectElement>("#nt-agent-provider")!;
   const modelSelect = () => document.querySelector<HTMLSelectElement>("#nt-model")!;
 
-  it("shows codex models and normalizes a claude model when Codex is selected", async () => {
+  it("shows codex models and uses the configured Codex default", async () => {
     render(NewTask, {
-      props: base({ defaultAgentProvider: "codex", defaultModel: "opus" }),
+      props: base({
+        defaultAgentProvider: "codex",
+        defaultModel: "opus",
+        defaultCodexModel: "gpt-5.4",
+      }),
     });
 
     await expect.poll(() => providerSelect().value).toBe("codex");
-    await expect.poll(() => modelSelect().value).toBe("gpt-5.5");
+    await expect.poll(() => modelSelect().value).toBe("gpt-5.4");
     const options = Array.from(modelSelect().options).map((o) => o.value);
     expect(options).toContain("gpt-5.5");
     expect(options.slice(0, 5)).toEqual([
@@ -1553,6 +1557,24 @@ describe("NewTask Codex model picker", () => {
       .toBe(true);
   });
 
+  it("switching CLI restores each configured default", async () => {
+    render(NewTask, {
+      props: base({
+        defaultAgentProvider: "claude",
+        defaultModel: "opus",
+        defaultCodexModel: "gpt-5.4",
+      }),
+    });
+
+    await expect.poll(() => modelSelect().value).toBe("opus");
+    providerSelect().value = "codex";
+    providerSelect().dispatchEvent(new Event("change", { bubbles: true }));
+    await expect.poll(() => modelSelect().value).toBe("gpt-5.4");
+    providerSelect().value = "claude";
+    providerSelect().dispatchEvent(new Event("change", { bubbles: true }));
+    await expect.poll(() => modelSelect().value).toBe("opus");
+  });
+
   it("submits the selected codex model", async () => {
     const repoPath = "/repo/codex-model";
     mockGetRepoConfig.mockResolvedValue(confirmedRepoConfig());
@@ -1567,6 +1589,30 @@ describe("NewTask Codex model picker", () => {
     modelSelect().value = "gpt-5.4";
     modelSelect().dispatchEvent(new Event("change", { bubbles: true }));
 
+    await fillPromptAndClickRun();
+
+    await expect.poll(() => onsubmit.mock.calls.length).toBe(1);
+    expect(onsubmit.mock.calls[0]?.[0]).toMatchObject({
+      agentProvider: "codex",
+      model: "gpt-5.4",
+    });
+  });
+
+  it("ignores an incompatible repo override and submits the configured Codex default", async () => {
+    const repoPath = "/repo/codex-repo-override";
+    mockGetRepoConfig.mockResolvedValue({ ...confirmedRepoConfig(), defaultModel: "opus" });
+    const onsubmit = vi.fn().mockResolvedValue(undefined);
+    render(NewTask, {
+      props: {
+        onsubmit,
+        initialRepoPath: repoPath,
+        defaultAgentProvider: "codex",
+        defaultModel: "sonnet",
+        defaultCodexModel: "gpt-5.4",
+      },
+    });
+
+    await expect.poll(() => modelSelect().value).toBe("gpt-5.4");
     await fillPromptAndClickRun();
 
     await expect.poll(() => onsubmit.mock.calls.length).toBe(1);

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -24,6 +24,7 @@
     type SandboxProfile,
     type SlashCommand,
     type Steer,
+    MODELS_BY_PROVIDER,
   } from "$lib/types";
   import { promoDefaultModel } from "$lib/fable-promo";
   import {
@@ -69,6 +70,7 @@
     initialEffort,
     defaultAgentProvider = "claude",
     defaultModel,
+    defaultCodexModel,
     defaultEffort,
     relaunch = false,
     editHeld = false,
@@ -119,6 +121,7 @@
     initialEffort?: string;
     defaultAgentProvider?: AgentProvider;
     defaultModel?: string;
+    defaultCodexModel?: string;
     defaultEffort?: string;
     relaunch?: boolean;
     editHeld?: boolean;
@@ -160,14 +163,25 @@
   // let the repo's current branch win on every subsequent load / repo switch.
   // svelte-ignore state_referenced_locally
   let seededBase = $state(initialBaseBranch != null);
+  // Seeds once from the overlay-resolved default CLI. The overlay may route a fresh
+  // task to a ready alternate provider when the configured default would hit a
+  // usage hold; explicit relaunch/edit-held seeds still win and preserve the task.
+  // svelte-ignore state_referenced_locally
+  let agentProvider = $state<AgentProvider>(initialAgentProvider ?? defaultAgentProvider);
+
   // Picker preselect precedence: explicit initialModel (e.g. the "Try Fable" CTA) wins;
   // else the selected repo's default-model override; else the operator's global default
   // if it's an explicit model; else the fresh client promo (configured "auto", or
   // settings not yet loaded). NewTask remounts per open, so the promo cutoff is honored
   // fresh each open. `modelTouched` pins a manual pick so switching repos / a late repo
   // config load doesn't clobber it.
-  function preselectModel(configured: string | undefined): string {
-    const pick = configured && configured !== "auto" ? configured : promoDefaultModel();
+  function preselectModel(configured: string | undefined, provider: AgentProvider): string {
+    const pick =
+      configured && configured !== "auto"
+        ? configured
+        : provider === "claude"
+          ? promoDefaultModel()
+          : "default";
     return pick === "fable" && !fableAvailable ? "default" : pick;
   }
   // reads initialModel/fableAvailable once to compute the picker's seed (see preselectModel
@@ -177,7 +191,13 @@
   // seeds the model picker once; the $effect below re-derives it from the repo/global default
   // until the user picks one (modelTouched) — initial-value capture is intended here
   // svelte-ignore state_referenced_locally
-  let model = $state(safeInitial ?? preselectModel(defaultModel));
+  let model = $state(
+    safeInitial ??
+      preselectModel(
+        agentProvider === "codex" ? (defaultCodexModel ?? "gpt-5.5") : defaultModel,
+        agentProvider,
+      ),
+  );
   let modelTouched = $state(false);
 
   // Effort picker preselect: a settings SETTING ("default" | <tier>) maps to a picker value; the
@@ -213,11 +233,6 @@
   let autopilot = $state(initialAutopilot ?? false);
   // svelte-ignore state_referenced_locally
   let autopilotTouched = $state(initialAutopilot != null);
-  // Seeds once from the overlay-resolved default CLI. The overlay may route a fresh
-  // task to a ready alternate provider when the configured default would hit a
-  // usage hold; explicit relaunch/edit-held seeds still win and preserve the task.
-  // svelte-ignore state_referenced_locally
-  let agentProvider = $state<AgentProvider>(initialAgentProvider ?? defaultAgentProvider);
   // Research task kind: web research → report PR or issue; mutually exclusive w/ plan-gate.
   // svelte-ignore state_referenced_locally
   let research = $state(initialResearch);
@@ -461,11 +476,20 @@
   // Re-seeds the picker when the repo config loads / the repo changes, unless an explicit
   // initialModel (CTA) pinned it or the user already picked a model by hand.
   const repoModelOverride = $derived(repoPath ? repoConfig.defaultModelFor(repoPath) : "inherit");
-  const effectiveModelSetting = $derived(
-    repoModelOverride !== "inherit" ? repoModelOverride : (defaultModel ?? "auto"),
+  const providerModelSetting = $derived(
+    agentProvider === "codex" ? (defaultCodexModel ?? "gpt-5.5") : (defaultModel ?? "auto"),
   );
+  const effectiveModelSetting = $derived(
+    repoModelOverride !== "inherit" &&
+      (repoModelOverride === "auto" ||
+        repoModelOverride === "default" ||
+        MODELS_BY_PROVIDER[agentProvider].includes(repoModelOverride))
+      ? repoModelOverride
+      : providerModelSetting,
+  );
+  const providerDefaultModel = $derived(preselectModel(effectiveModelSetting, agentProvider));
   $effect(() => {
-    if (initialModel == null && !modelTouched) model = preselectModel(effectiveModelSetting);
+    if (initialModel == null && !modelTouched) model = providerDefaultModel;
   });
 
   // Effort mirrors the model re-seed: repo override (unless "inherit") → global default effort.
@@ -1212,6 +1236,7 @@
         {usageLimits}
         {relaunch}
         {fableAvailable}
+        {providerDefaultModel}
         providerConstraint={activeProviderConstraint}
       />
 

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -4,7 +4,13 @@ import { page } from "vitest/browser";
 import "../../app.css";
 import type { Settings as SettingsPayload, DiagnosticCheck } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
-import { getSettings, verifyApiKey, putAnthropicApiKey, fixDiagnostic } from "$lib/api";
+import {
+  getSettings,
+  verifyApiKey,
+  putAnthropicApiKey,
+  putDefaultCodexModel,
+  fixDiagnostic,
+} from "$lib/api";
 import { toasts } from "$lib/toasts.svelte";
 
 // Mock the API so Settings never hits the network. The settings GET is seeded to
@@ -21,6 +27,9 @@ vi.mock("$lib/api", async (importOriginal) => {
     verifyApiKey: vi.fn(),
     putAnthropicApiKey: vi.fn(),
     putAuthMode: vi.fn(async () => ({ authMode: "api-key", hasApiKey: true })),
+    putDefaultAgentProvider: vi.fn(async (provider) => ({ defaultAgentProvider: provider })),
+    putDefaultModel: vi.fn(async (model) => ({ defaultModel: model })),
+    putDefaultCodexModel: vi.fn(async (model) => ({ defaultCodexModel: model })),
   };
 });
 
@@ -45,6 +54,7 @@ const { default: Settings } = await import("./Settings.svelte");
 const mockGetSettings = vi.mocked(getSettings);
 const mockVerify = vi.mocked(verifyApiKey);
 const mockPutKey = vi.mocked(putAnthropicApiKey);
+const mockPutCodexModel = vi.mocked(putDefaultCodexModel);
 const mockFix = vi.mocked(fixDiagnostic);
 
 function settings(over: Partial<SettingsPayload> = {}): SettingsPayload {
@@ -55,6 +65,7 @@ function settings(over: Partial<SettingsPayload> = {}): SettingsPayload {
     remoteControlAtStartup: false,
     sessionHousekeepingEnabled: true,
     defaultModel: "auto",
+    defaultCodexModel: "gpt-5.5",
     defaultEffort: "default",
     operatorLanguage: "en",
     criticCli: "inherit",
@@ -137,6 +148,8 @@ beforeEach(() => {
   mockGetSettings.mockReset();
   mockVerify.mockReset();
   mockPutKey.mockReset();
+  mockPutCodexModel.mockReset();
+  mockPutCodexModel.mockImplementation(async (model) => ({ defaultCodexModel: model }));
   // Default seed: api-key mode, key configured → Verify button renders.
   mockGetSettings.mockResolvedValue(settings());
 });
@@ -154,6 +167,70 @@ const keyInput = () => page.getByRole("textbox", { name: m.settings_auth_key_lab
 function mountCodingAgents() {
   render(Settings, { initialTab: "codingAgents", onclose: noop, onsaved: noop });
 }
+
+describe("Settings default coding environment", () => {
+  it("loads the saved model for the selected Codex CLI", async () => {
+    mockGetSettings.mockResolvedValue(
+      settings({ defaultAgentProvider: "codex", defaultCodexModel: "gpt-5.4" }),
+    );
+    mountCodingAgents();
+
+    const model = page.getByTestId("default-environment-model");
+    await expect.element(model).toHaveValue("gpt-5.4");
+  });
+
+  it("switching CLI restores each CLI's saved model", async () => {
+    mockGetSettings.mockResolvedValue(
+      settings({
+        defaultAgentProvider: "claude",
+        defaultModel: "opus",
+        defaultCodexModel: "gpt-5.4",
+      }),
+    );
+    mountCodingAgents();
+
+    const provider = page.getByRole("combobox", {
+      name: m.settings_default_agent_provider_title(),
+    });
+    const model = page.getByTestId("default-environment-model");
+    await expect.element(model).toHaveValue("opus");
+    await provider.selectOptions("codex");
+    await expect.element(model).toHaveValue("gpt-5.4");
+    await provider.selectOptions("claude");
+    await expect.element(model).toHaveValue("opus");
+  });
+
+  it("saves Codex model changes through the Codex preference endpoint", async () => {
+    mockGetSettings.mockResolvedValue(
+      settings({ defaultAgentProvider: "codex", defaultCodexModel: "gpt-5.4" }),
+    );
+    mountCodingAgents();
+
+    const model = page.getByTestId("default-environment-model");
+    await model.selectOptions("gpt-5.6-luna");
+
+    await vi.waitFor(() => expect(mockPutCodexModel).toHaveBeenCalledWith("gpt-5.6-luna"));
+  });
+
+  it("reverts a Codex model change when saving fails", async () => {
+    toasts.items = [];
+    mockGetSettings.mockResolvedValue(
+      settings({ defaultAgentProvider: "codex", defaultCodexModel: "gpt-5.4" }),
+    );
+    mockPutCodexModel.mockRejectedValue(new Error("save failed"));
+    mountCodingAgents();
+
+    const model = page.getByTestId("default-environment-model");
+    await model.selectOptions("gpt-5.6-luna");
+
+    await expect.element(model).toHaveValue("gpt-5.4");
+    await vi.waitFor(() =>
+      expect(
+        toasts.items.some((toast) => toast.text === m.settings_default_codex_model_save_failed()),
+      ).toBe(true),
+    );
+  });
+});
 
 describe("Settings api-key verify", () => {
   it("verify → OK renders the verified line", async () => {

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -7,6 +7,7 @@
     putPrReviewCyclesCap,
     putPlanReviewCyclesCap,
     putDefaultModel,
+    putDefaultCodexModel,
     putDefaultEffort,
     putOperatorLanguage,
     putRoleModel,
@@ -257,6 +258,9 @@
   let defaultModel = $state("auto"); // raw default-model setting (auto|default|<alias>)
   let defaultModelSaved = "auto"; // last server-confirmed value, for revert on failure
   let defaultModelBusy = $state(false);
+  let defaultCodexModel = $state("gpt-5.5");
+  let defaultCodexModelSaved = "gpt-5.5";
+  let defaultCodexModelBusy = $state(false);
 
   let defaultEffort = $state("default"); // raw default-effort setting ("default"|<tier>)
   let defaultEffortSaved = "default"; // last server-confirmed value, for revert on failure
@@ -379,7 +383,7 @@
       if (token !== "default" && !MODELS_BY_PROVIDER[cli].includes(token)) token = "default";
     } else {
       provider = defaultAgentProvider;
-      token = defaultModel; // "auto" | "default" | <alias>
+      token = provider === "codex" ? defaultCodexModel : defaultModel;
     }
     let model: string;
     let modelLbl: string;
@@ -600,6 +604,24 @@
       });
     } finally {
       defaultModelBusy = false;
+    }
+  }
+
+  async function saveDefaultCodexModel() {
+    if (defaultCodexModelBusy) return;
+    defaultCodexModelBusy = true;
+    try {
+      const r = await putDefaultCodexModel(defaultCodexModel);
+      defaultCodexModel = r.defaultCodexModel;
+      defaultCodexModelSaved = r.defaultCodexModel;
+    } catch {
+      defaultCodexModel = defaultCodexModelSaved;
+      toasts.info(m.settings_default_codex_model_save_failed(), {
+        key: "default-codex-model",
+        alert: true,
+      });
+    } finally {
+      defaultCodexModelBusy = false;
     }
   }
 
@@ -1002,6 +1024,8 @@
   function applyModelPrefs(s: Awaited<ReturnType<typeof getSettings>>) {
     defaultModel = s.defaultModel ?? "auto";
     defaultModelSaved = defaultModel;
+    defaultCodexModel = s.defaultCodexModel ?? "gpt-5.5";
+    defaultCodexModelSaved = defaultCodexModel;
     defaultEffort = s.defaultEffort ?? "default";
     defaultEffortSaved = defaultEffort;
     operatorLanguage = s.operatorLanguage ?? "en";
@@ -1163,21 +1187,83 @@
       hidden={tab !== "codingAgents"}
     >
       <div class="rc cli-default">
-        <span class="micro">{m.settings_default_agent_provider_title()}</span>
-        <p class="hint">{m.settings_default_agent_provider_hint()}</p>
-        <select
-          class="model-select"
-          bind:value={defaultAgentProvider}
-          disabled={defaultAgentProviderBusy}
-          aria-label={m.settings_default_agent_provider_title()}
-          onchange={saveDefaultAgentProvider}
-        >
-          {#each AGENT_PROVIDERS as provider (provider)}
-            <option value={provider}>
-              {provider === "claude" ? m.agent_provider_claude() : m.agent_provider_codex_alpha()}
-            </option>
-          {/each}
-        </select>
+        <span class="micro">{m.settings_default_environment_title()}</span>
+        <p class="hint">{m.settings_default_environment_hint()}</p>
+        <div class="cli-row default-env-row">
+          <label class="default-env-field">
+            <span>{m.settings_default_agent_provider_title()}</span>
+            <select
+              class="model-select"
+              bind:value={defaultAgentProvider}
+              disabled={defaultAgentProviderBusy}
+              aria-label={m.settings_default_agent_provider_title()}
+              onchange={saveDefaultAgentProvider}
+            >
+              {#each AGENT_PROVIDERS as provider (provider)}
+                <option value={provider}>
+                  {provider === "claude"
+                    ? m.agent_provider_claude()
+                    : m.agent_provider_codex_alpha()}
+                </option>
+              {/each}
+            </select>
+          </label>
+          <label class="default-env-field">
+            <span>
+              {defaultAgentProvider === "claude"
+                ? m.settings_default_model_title()
+                : m.settings_default_codex_model_title()}
+            </span>
+            {#if defaultAgentProvider === "claude"}
+              <select
+                class="model-select"
+                data-testid="default-environment-model"
+                bind:value={defaultModel}
+                disabled={defaultModelBusy}
+                aria-label={m.settings_default_model_title()}
+                onchange={saveDefaultModel}
+              >
+                <option value="auto">{m.settings_default_model_auto()}</option>
+                <option value="default">{m.newtask_model_default()}</option>
+                {#each MODELS as mdl (mdl)}
+                  <option value={mdl}>{modelOptionLabel("claude", mdl)}</option>
+                {/each}
+              </select>
+            {:else}
+              <select
+                class="model-select"
+                data-testid="default-environment-model"
+                bind:value={defaultCodexModel}
+                disabled={defaultCodexModelBusy}
+                aria-label={m.settings_default_codex_model_title()}
+                onchange={saveDefaultCodexModel}
+              >
+                <option value="default">{m.newtask_model_default()}</option>
+                {#each MODELS_BY_PROVIDER.codex as mdl (mdl)}
+                  <option value={mdl}>{modelOptionLabel("codex", mdl)}</option>
+                {/each}
+              </select>
+            {/if}
+          </label>
+        </div>
+        <p class="hint">
+          {defaultAgentProvider === "claude"
+            ? m.settings_default_model_hint()
+            : m.settings_default_codex_model_hint()}
+        </p>
+        <ModelGuidance
+          provider={defaultAgentProvider}
+          model={defaultAgentProvider === "claude"
+            ? modelGuidanceAlias(defaultModel, fableAvailable)
+            : defaultCodexModel}
+          context="default"
+        />
+        {#if defaultAgentProvider === "claude" && isPremiumModel}
+          <p class="premium-warn">{m.settings_default_model_premium_warning()}</p>
+        {/if}
+        {#if defaultAgentProvider === "claude" && is1mModel}
+          <p class="premium-warn">{m.settings_default_model_1m_note()}</p>
+        {/if}
       </div>
 
       <div class="rc">
@@ -1202,34 +1288,6 @@
         <div class="cli-head">
           <span class="micro">{m.settings_cli_claude_title()}</span>
           <p class="hint">{m.settings_cli_claude_hint()}</p>
-        </div>
-        <div class="rc">
-          <span class="micro">{m.settings_default_model_title()}</span>
-          <p class="hint">{m.settings_default_model_hint()}</p>
-          <select
-            class="model-select"
-            bind:value={defaultModel}
-            disabled={defaultModelBusy}
-            aria-label={m.settings_default_model_title()}
-            onchange={saveDefaultModel}
-          >
-            <option value="auto">{m.settings_default_model_auto()}</option>
-            <option value="default">{m.newtask_model_default()}</option>
-            {#each MODELS as mdl (mdl)}
-              <option value={mdl}>{modelOptionLabel("claude", mdl)}</option>
-            {/each}
-          </select>
-          <ModelGuidance
-            provider="claude"
-            model={modelGuidanceAlias(defaultModel, fableAvailable)}
-            context="default"
-          />
-          {#if isPremiumModel}
-            <p class="premium-warn">{m.settings_default_model_premium_warning()}</p>
-          {/if}
-          {#if is1mModel}
-            <p class="premium-warn">{m.settings_default_model_1m_note()}</p>
-          {/if}
         </div>
         <div class="rc">
           <span class="micro">{m.settings_default_effort_title()}</span>
@@ -1975,6 +2033,23 @@
   .cli-default {
     padding-bottom: 10px;
     border-bottom: 1px solid var(--color-line);
+  }
+  .default-env-row {
+    align-items: flex-start;
+  }
+  .default-env-field {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 12rem;
+    min-width: 0;
+    gap: 6px;
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+  }
+  .default-env-field .model-select {
+    width: 100%;
+    min-width: 0;
+    align-self: stretch;
   }
   .cli-section {
     display: flex;

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -45,7 +45,6 @@
     MODELS,
     EFFORTS,
     MODELS_BY_PROVIDER,
-    PREMIUM_MODELS,
     type AgentProvider,
     type HerdrUpdateStatus,
     type CodexUpdateStatus,
@@ -58,6 +57,7 @@
   import SettingsDevicePanel from "$lib/components/settings/SettingsDevicePanel.svelte";
   import SettingsDiagnosePanel from "$lib/components/settings/SettingsDiagnosePanel.svelte";
   import SettingsPluginsPanel from "$lib/components/settings/SettingsPluginsPanel.svelte";
+  import SettingsDefaultEnvironment from "$lib/components/settings/SettingsDefaultEnvironment.svelte";
   import RestartShepherdDialog from "$lib/components/RestartShepherdDialog.svelte";
   import ModelGuidance from "$lib/components/ModelGuidance.svelte";
   import { dialog } from "$lib/a11yDialog";
@@ -271,11 +271,6 @@
   let defaultAgentProvider = $state<AgentProvider>("claude");
   let defaultAgentProviderSaved: AgentProvider = "claude";
   let defaultAgentProviderBusy = $state(false);
-  const isPremiumModel = $derived(PREMIUM_MODELS.includes(defaultModel));
-  // 1M-context variants ("opus[1m]"/"sonnet[1m]") carry an extra per-turn cost the
-  // generic premium warning doesn't convey, so they surface an additional note.
-  const is1mModel = $derived(defaultModel.endsWith("[1m]"));
-
   // Per-role ENVIRONMENT overrides (plan reviewer, PR critic, recap, doc-agent, namer, autopilot).
   // Each role is a PAIR: a CLI (`<role>Cli` ∈ "inherit"|"claude"|"codex"; "inherit" follows the
   // global provider+model) and a model (`<role>Model` ∈ "default"|<alias for that CLI>). Seeds
@@ -1186,85 +1181,18 @@
       aria-label={m.settings_tab_coding_agents()}
       hidden={tab !== "codingAgents"}
     >
-      <div class="rc cli-default">
-        <span class="micro">{m.settings_default_environment_title()}</span>
-        <p class="hint">{m.settings_default_environment_hint()}</p>
-        <div class="cli-row default-env-row">
-          <label class="default-env-field">
-            <span>{m.settings_default_agent_provider_title()}</span>
-            <select
-              class="model-select"
-              bind:value={defaultAgentProvider}
-              disabled={defaultAgentProviderBusy}
-              aria-label={m.settings_default_agent_provider_title()}
-              onchange={saveDefaultAgentProvider}
-            >
-              {#each AGENT_PROVIDERS as provider (provider)}
-                <option value={provider}>
-                  {provider === "claude"
-                    ? m.agent_provider_claude()
-                    : m.agent_provider_codex_alpha()}
-                </option>
-              {/each}
-            </select>
-          </label>
-          <label class="default-env-field">
-            <span>
-              {defaultAgentProvider === "claude"
-                ? m.settings_default_model_title()
-                : m.settings_default_codex_model_title()}
-            </span>
-            {#if defaultAgentProvider === "claude"}
-              <select
-                class="model-select"
-                data-testid="default-environment-model"
-                bind:value={defaultModel}
-                disabled={defaultModelBusy}
-                aria-label={m.settings_default_model_title()}
-                onchange={saveDefaultModel}
-              >
-                <option value="auto">{m.settings_default_model_auto()}</option>
-                <option value="default">{m.newtask_model_default()}</option>
-                {#each MODELS as mdl (mdl)}
-                  <option value={mdl}>{modelOptionLabel("claude", mdl)}</option>
-                {/each}
-              </select>
-            {:else}
-              <select
-                class="model-select"
-                data-testid="default-environment-model"
-                bind:value={defaultCodexModel}
-                disabled={defaultCodexModelBusy}
-                aria-label={m.settings_default_codex_model_title()}
-                onchange={saveDefaultCodexModel}
-              >
-                <option value="default">{m.newtask_model_default()}</option>
-                {#each MODELS_BY_PROVIDER.codex as mdl (mdl)}
-                  <option value={mdl}>{modelOptionLabel("codex", mdl)}</option>
-                {/each}
-              </select>
-            {/if}
-          </label>
-        </div>
-        <p class="hint">
-          {defaultAgentProvider === "claude"
-            ? m.settings_default_model_hint()
-            : m.settings_default_codex_model_hint()}
-        </p>
-        <ModelGuidance
-          provider={defaultAgentProvider}
-          model={defaultAgentProvider === "claude"
-            ? modelGuidanceAlias(defaultModel, fableAvailable)
-            : defaultCodexModel}
-          context="default"
-        />
-        {#if defaultAgentProvider === "claude" && isPremiumModel}
-          <p class="premium-warn">{m.settings_default_model_premium_warning()}</p>
-        {/if}
-        {#if defaultAgentProvider === "claude" && is1mModel}
-          <p class="premium-warn">{m.settings_default_model_1m_note()}</p>
-        {/if}
-      </div>
+      <SettingsDefaultEnvironment
+        bind:defaultAgentProvider
+        bind:defaultModel
+        bind:defaultCodexModel
+        {defaultAgentProviderBusy}
+        {defaultModelBusy}
+        {defaultCodexModelBusy}
+        {fableAvailable}
+        onProviderChange={saveDefaultAgentProvider}
+        onClaudeModelChange={saveDefaultModel}
+        onCodexModelChange={saveDefaultCodexModel}
+      />
 
       <div class="rc">
         <span class="micro">{m.settings_upnext_skip_cli_picker_label()}</span>
@@ -2029,27 +1957,6 @@
     display: flex;
     flex-direction: column;
     gap: 6px;
-  }
-  .cli-default {
-    padding-bottom: 10px;
-    border-bottom: 1px solid var(--color-line);
-  }
-  .default-env-row {
-    align-items: flex-start;
-  }
-  .default-env-field {
-    display: flex;
-    flex-direction: column;
-    flex: 1 1 12rem;
-    min-width: 0;
-    gap: 6px;
-    color: var(--color-muted);
-    font-size: var(--fs-meta);
-  }
-  .default-env-field .model-select {
-    width: 100%;
-    min-width: 0;
-    align-self: stretch;
   }
   .cli-section {
     display: flex;

--- a/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
+++ b/ui/src/lib/components/new-task/NewTaskRunSettings.svelte
@@ -8,7 +8,6 @@
   import ProviderCapacityGauge from "./ProviderCapacityGauge.svelte";
   import {
     AGENT_PROVIDERS,
-    CODEX_MODELS,
     type AgentProvider,
     type ProviderTokenConstraint,
     type SandboxProfile,
@@ -38,6 +37,7 @@
     relaunch,
     holdLikely,
     fableAvailable,
+    providerDefaultModel,
     providerConstraint = null,
   }: {
     planGate: boolean;
@@ -62,6 +62,7 @@
     relaunch: boolean;
     holdLikely: boolean;
     fableAvailable: boolean;
+    providerDefaultModel: string;
     providerConstraint?: ProviderTokenConstraint | null;
   } = $props();
 
@@ -75,9 +76,9 @@
     if (providerConstraint && !providerConstraint.providers.includes(agentProvider)) {
       agentProvider = providerConstraint.providers[0] ?? "claude";
     }
-    if (!modelAvailableForProvider(agentProvider, model, fableAvailable)) {
-      model = agentProvider === "codex" ? CODEX_MODELS[0] : "default";
-    }
+    model = modelAvailableForProvider(agentProvider, providerDefaultModel, fableAvailable)
+      ? providerDefaultModel
+      : "default";
   }
 
   function providerLabel(provider: AgentProvider | undefined): string {
@@ -86,7 +87,9 @@
 
   $effect(() => {
     if (!modelAvailableForProvider(agentProvider, model, fableAvailable)) {
-      model = agentProvider === "codex" ? CODEX_MODELS[0] : "default";
+      model = modelAvailableForProvider(agentProvider, providerDefaultModel, fableAvailable)
+        ? providerDefaultModel
+        : "default";
     }
   });
 

--- a/ui/src/lib/components/page/AppOverlays.svelte
+++ b/ui/src/lib/components/page/AppOverlays.svelte
@@ -344,6 +344,7 @@
   const newTaskFableAvailable = $derived(settings?.fableAvailable ?? true);
   // Hoisted out of the template (branch-free markup): the global default-effort seed.
   const newTaskDefaultEffort = $derived(settings?.defaultEffort);
+  const newTaskDefaultCodexModel = $derived(settings?.defaultCodexModel);
   // Onboarding folder-picker inputs, hoisted out of the template so the markup stays branch-free.
   const onboardingRepoRoot = $derived(settings?.repoRoot ?? null);
   const onboardingRepoRootDisplay = $derived(settings?.repoRootDisplay ?? null);
@@ -523,7 +524,7 @@
     {usageLimits}
     defaultAgentProvider={newTaskDefaultAgentProvider}
     defaultModel={settings?.defaultModel}
-    defaultCodexModel={settings?.defaultCodexModel}
+    defaultCodexModel={newTaskDefaultCodexModel}
     defaultEffort={newTaskDefaultEffort}
     fableAvailable={newTaskFableAvailable}
     {holdLikely}

--- a/ui/src/lib/components/page/AppOverlays.svelte
+++ b/ui/src/lib/components/page/AppOverlays.svelte
@@ -523,6 +523,7 @@
     {usageLimits}
     defaultAgentProvider={newTaskDefaultAgentProvider}
     defaultModel={settings?.defaultModel}
+    defaultCodexModel={settings?.defaultCodexModel}
     defaultEffort={newTaskDefaultEffort}
     fableAvailable={newTaskFableAvailable}
     {holdLikely}

--- a/ui/src/lib/components/settings/SettingsDefaultEnvironment.svelte
+++ b/ui/src/lib/components/settings/SettingsDefaultEnvironment.svelte
@@ -1,0 +1,185 @@
+<script lang="ts">
+  import { modelGuidanceAlias, modelOptionLabel } from "$lib/model-guidance";
+  import ModelGuidance from "$lib/components/ModelGuidance.svelte";
+  import {
+    AGENT_PROVIDERS,
+    MODELS,
+    MODELS_BY_PROVIDER,
+    PREMIUM_MODELS,
+    type AgentProvider,
+  } from "$lib/types";
+  import { m } from "$lib/paraglide/messages";
+
+  let {
+    defaultAgentProvider = $bindable(),
+    defaultModel = $bindable(),
+    defaultCodexModel = $bindable(),
+    defaultAgentProviderBusy,
+    defaultModelBusy,
+    defaultCodexModelBusy,
+    fableAvailable,
+    onProviderChange,
+    onClaudeModelChange,
+    onCodexModelChange,
+  }: {
+    defaultAgentProvider: AgentProvider;
+    defaultModel: string;
+    defaultCodexModel: string;
+    defaultAgentProviderBusy: boolean;
+    defaultModelBusy: boolean;
+    defaultCodexModelBusy: boolean;
+    fableAvailable: boolean;
+    onProviderChange: () => void | Promise<void>;
+    onClaudeModelChange: () => void | Promise<void>;
+    onCodexModelChange: () => void | Promise<void>;
+  } = $props();
+
+  const isPremiumModel = $derived(PREMIUM_MODELS.includes(defaultModel));
+  const is1mModel = $derived(defaultModel.endsWith("[1m]"));
+</script>
+
+<div class="rc cli-default">
+  <span class="micro">{m.settings_default_environment_title()}</span>
+  <p class="hint">{m.settings_default_environment_hint()}</p>
+  <div class="cli-row default-env-row">
+    <label class="default-env-field">
+      <span>{m.settings_default_agent_provider_title()}</span>
+      <select
+        class="model-select"
+        bind:value={defaultAgentProvider}
+        disabled={defaultAgentProviderBusy}
+        aria-label={m.settings_default_agent_provider_title()}
+        onchange={onProviderChange}
+      >
+        {#each AGENT_PROVIDERS as provider (provider)}
+          <option value={provider}>
+            {provider === "claude" ? m.agent_provider_claude() : m.agent_provider_codex_alpha()}
+          </option>
+        {/each}
+      </select>
+    </label>
+    <label class="default-env-field">
+      <span>
+        {defaultAgentProvider === "claude"
+          ? m.settings_default_model_title()
+          : m.settings_default_codex_model_title()}
+      </span>
+      {#if defaultAgentProvider === "claude"}
+        <select
+          class="model-select"
+          data-testid="default-environment-model"
+          bind:value={defaultModel}
+          disabled={defaultModelBusy}
+          aria-label={m.settings_default_model_title()}
+          onchange={onClaudeModelChange}
+        >
+          <option value="auto">{m.settings_default_model_auto()}</option>
+          <option value="default">{m.newtask_model_default()}</option>
+          {#each MODELS as mdl (mdl)}
+            <option value={mdl}>{modelOptionLabel("claude", mdl)}</option>
+          {/each}
+        </select>
+      {:else}
+        <select
+          class="model-select"
+          data-testid="default-environment-model"
+          bind:value={defaultCodexModel}
+          disabled={defaultCodexModelBusy}
+          aria-label={m.settings_default_codex_model_title()}
+          onchange={onCodexModelChange}
+        >
+          <option value="default">{m.newtask_model_default()}</option>
+          {#each MODELS_BY_PROVIDER.codex as mdl (mdl)}
+            <option value={mdl}>{modelOptionLabel("codex", mdl)}</option>
+          {/each}
+        </select>
+      {/if}
+    </label>
+  </div>
+  <p class="hint">
+    {defaultAgentProvider === "claude"
+      ? m.settings_default_model_hint()
+      : m.settings_default_codex_model_hint()}
+  </p>
+  <ModelGuidance
+    provider={defaultAgentProvider}
+    model={defaultAgentProvider === "claude"
+      ? modelGuidanceAlias(defaultModel, fableAvailable)
+      : defaultCodexModel}
+    context="default"
+  />
+  {#if defaultAgentProvider === "claude" && isPremiumModel}
+    <p class="premium-warn">{m.settings_default_model_premium_warning()}</p>
+  {/if}
+  {#if defaultAgentProvider === "claude" && is1mModel}
+    <p class="premium-warn">{m.settings_default_model_1m_note()}</p>
+  {/if}
+</div>
+
+<style>
+  .rc {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .cli-default {
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--color-line);
+  }
+  .micro {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+  .hint {
+    color: var(--color-faint);
+    font-size: var(--fs-meta);
+    margin: 0;
+  }
+  .cli-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .default-env-row {
+    align-items: flex-start;
+  }
+  .default-env-field {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 12rem;
+    min-width: 0;
+    gap: 6px;
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+  }
+  .model-select {
+    width: 100%;
+    min-width: 0;
+    align-self: stretch;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line-bright);
+    color: var(--color-ink-bright);
+    font: inherit;
+    font-size: var(--fs-base);
+    padding: 8px 10px;
+    border-radius: 2px;
+    appearance: none;
+    cursor: pointer;
+  }
+  .model-select:focus {
+    outline: none;
+    border-color: var(--color-amber);
+  }
+  .model-select:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+  .premium-warn {
+    color: var(--color-amber);
+    font-size: var(--fs-meta);
+    margin: 0;
+    font-weight: 500;
+  }
+</style>

--- a/ui/src/lib/demo/seed.ts
+++ b/ui/src/lib/demo/seed.ts
@@ -1009,6 +1009,7 @@ function buildSettings(): Settings {
     remoteControlAtStartup: false,
     sessionHousekeepingEnabled: true,
     defaultModel: "auto",
+    defaultCodexModel: "gpt-5.5",
     defaultEffort: "default",
     operatorLanguage: "en",
     criticCli: "inherit",

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-default-coding-environment.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-default-coding-environment.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "default-coding-environment",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_default_coding_environment_title",
+  bodyKey: "feat_default_coding_environment_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -90,6 +90,8 @@ export interface Settings {
   /** Raw configured default-model setting (auto|default|<alias>); the New Task
    *  picker resolves `auto` via the client promo. */
   defaultModel: string;
+  /** Raw Codex default-model setting (default|<curated Codex alias>). */
+  defaultCodexModel: string;
   /** Global default-effort setting ("default"|<tier>); "default" emits no effort flag. */
   defaultEffort: string;
   /** Language spawned agents use to talk to the operator ("en" | "de"). Independent of the


### PR DESCRIPTION
## Problem / Goal

Choosing Codex as the default coding CLI always preselected `gpt-5.5`, even when the operator preferred another Codex model. Settings only exposed the Claude default model, so the CLI and model could not be configured as one reusable default environment.

The goal is to let operators choose a default coding CLI and remember the preferred model for each CLI, then apply that pair consistently to new and unattended work.

## Solution / Added

- Added a unified **Default coding environment** control in Settings with a Coding CLI selector and provider-specific model selector.
- Shepherd now remembers independent defaults for Claude Code and Codex, restoring the saved model when the CLI changes.
- New Task, Up Next, drain/autopilot work, landing repair, and inherited helper roles use the model paired with the effective coding CLI.
- Added EN and DE copy plus a What's New entry for the feature.

## Technical details

- Added persisted `defaultCodexModel` configuration and a typed Settings API field alongside the existing Claude `defaultModel` setting.
- Added a provider-aware resolver that accepts compatible repository overrides and otherwise falls back to the selected provider's saved global model.
- Preserved the existing provider/auth clamps: `default` emits no model flag, known ChatGPT-account-incompatible Codex models resolve to the provider default, and unknown auth remains fail-open.
- Threaded both model preferences through the Settings and New Task component trees without changing explicit per-task or epic model selections.
- Added server and browser regression coverage for persistence, CLI/model round trips, launch paths, repository compatibility, auth behavior, and failed-save rollback.

## Validation

- `bun run lint`
- `bun run typecheck`
- Complete root suite in exact-path shards: 342 files, 6,937 passed, 7 skipped, 0 failed
- Focused server suite: 618 passed, 0 failed
- `cd ui && bun run check`
- `cd ui && bun run check:i18n`
- Changed browser suites: 101 passed, 0 failed
- `cd extension && bun run check`
- Glossary, announcement-version, feature-catalog, branch-hygiene, formatting, and diff checks
