### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs/sandbox-security.md
+++ b/docs/sandbox-security.md
@@ -51,7 +51,7 @@ secrets out of the membrane entirely.
 
 Egress confinement is keyed to the autonomous **profile**, not to whether a human
 is watching (`willEgressConfine`, `src/sandbox.ts:565-570`; applied at
-`src/service.ts:1882`): the wrap applies iff the autonomous profile resolves
+`src/service.ts:1873`): the wrap applies iff the autonomous profile resolves
 **and** the fs + egress backends are present, independent of `ctx.auto`.
 Consequences:
 
@@ -108,7 +108,7 @@ Write --permission-mode dontAsk` (`src/transient-agent-argv.ts`,
   `buildTransientAgentArgv("reviewer", …)`).
 - **Research is the deliberately egress-UNCONFINED surface.** A research session
   that would resolve to `autonomous` is **downgraded to `standard`**
-  (`src/service.ts` `researchSafeProfileOverride`, ~L2591-2610, warns once),
+  (`src/service.ts` `researchSafeProfileOverride`, ~L2697, warns once),
   because research needs **open** web egress (search/fetch + sub-agents) that the
   autonomous firewall would block. The same downgrade applies to an
   **epic-authoring** session (`input.epicAuthoring`, #1507), which likewise needs
@@ -117,14 +117,14 @@ Write --permission-mode dontAsk` (`src/transient-agent-argv.ts`,
   route materializes the draft. It is operator-_created_ (cannot be
   auto-drained — `standard` refuses auto-spawn) but **autopilot-steerable, so it
   runs unattended in practice** (`RESEARCH_PROCEED_STEER`,
-  `src/autopilot.ts:24-29`, dispatched at L323). It ingests **untrusted web**
+  `src/autopilot.ts:42-47`, dispatched at L335). It ingests **untrusted web**
   content on `trusted`/`standard` with the **network open**, and can
   `gh pr create` / open issues via the bound gh token — so a hijacked research
   agent has **both** readable tokens **and** open egress.
 
   **Compensating factors:** the downgrade is explicit and warns once; research
   delivers a **report PR or GitHub issue only, never a code PR**
-  (`src/autopilot.ts:326-330`). The residual is **accepted**.
+  (`src/autopilot.ts:40-45`). The residual is **accepted**.
 
 ## See also
 


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc update summary

Reviewed source changes since the last docs sync (`21caec44`, docs sync #1672) through `HEAD`.
Most in-scope docs were already current — the recent range is largely UI work, and the two
source-level config additions (the `SHEPHERD_HOOKS_INGEST` default-on flip in `f7430c15` and the
runaway-orphan reaper env vars `SHEPHERD_REAP_RUNAWAY*` in `76b5642a`) already carried their own
`reference/configuration.md` updates. The only staleness found was drifted source line-number
references in `docs/sandbox-security.md`.

## Changes

- **`docs/sandbox-security.md`** — corrected four `src/`-line references that drifted when
  `6751ede1` inserted a new export block above `RESEARCH_PROCEED_STEER` in `src/autopilot.ts` and
  `6e91bc91` grew `src/service.ts`:
  - `RESEARCH_PROCEED_STEER` `src/autopilot.ts:24-29`, dispatched at L323 → **`:42-47`, dispatched
    at L335** (verified: def at `src/autopilot.ts:42`, dispatch at `:335`).
  - "report PR or GitHub issue only, never a code PR" `src/autopilot.ts:326-330` → **`:40-45`**
    (verified: the JSDoc + steer text now at `src/autopilot.ts:40-45`).
  - `researchSafeProfileOverride` `~L2591-2610` → **`~L2697`** (verified at `src/service.ts:2697`).
  - `willEgressConfine` applied at `src/service.ts:1882` → **`:1873`** (verified at
    `src/service.ts:1873`).

  The prose and semantics on this page were re-verified as still accurate (egress allowlist in
  `src/egress.ts`, reviewer argv in `src/transient-agent-argv.ts`, `egressApplies`/`willEgressConfine`
  in `src/sandbox.ts`) — only the line anchors changed.

## Uncertain / needs human judgment

- **Glossary — human-review-block concept.** `800f5845` ("surface human review blocks") added an
  operator-facing "human review block" concept (repo-roles / forge). It may warrant a glossary
  entry, but that's a *new* term, not a contradiction of existing prose, so I left `glossary.md`
  unchanged per the conservative-only rule.
- **"Claude Code agents" framing vs Codex.** Several commits in range add Codex/GPT model support
  (`870083eb`, `6e91bc91`, `95f0bac1`, plus Codex skill discovery `f6a51341`). The docs' taglines
  still say "fleets of Claude Code agents" (index.md, getting-started.md). This is marketing framing
  rather than a demonstrable factual claim, and reworking provider-neutrality across pages is a
  judgment call, so I did not change it.