### PR TITLE
feat(ui): show reviewer model in review banner

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1252,7 +1252,7 @@ const reviewService = new ReviewService({
   // Per-role critic environment thunk (read per spawn so a settings change applies without restart).
   env: () => roleEnv(config.criticCli, config.criticModel, config.criticEffort),
   onChange: (id, verdict) => events.emit("session:review", { id, review: verdict }),
-  onReviewing: (id, reviewing) => events.emit("session:reviewing", { id, reviewing }),
+  onReviewing: (id, reviewing, env) => events.emit("session:reviewing", { id, reviewing, env }),
   onActivity: (id, summary) => events.emit("session:critic-activity", { id, summary }),
   // auto-address: steer critic findings straight into the task agent's PTY (same path
   // as a human "send review to agent"). Gated per-repo by autoAddressEnabled; the
@@ -2670,7 +2670,7 @@ const appDeps: AppDeps = {
   hooks: hookIngest,
   reviewCache: {
     snapshot: () => reviewService.snapshot(),
-    reviewing: () => reviewService.reviewingIds(),
+    reviewing: () => reviewService.reviewingInflight(),
   },
   planGateCache: {
     snapshot: () => planGate.snapshot(),

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "./instrument";
 import type { SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
 import type { WorktreeMgr } from "./worktree";
-import type { Session, PlanGate, PlanDecision, AgentProvider } from "./types";
+import type { Session, PlanGate, PlanDecision, AgentProvider, ReviewerEnv } from "./types";
 import { modelCompatibleWithProvider, type RoleEnvironment } from "./default-model";
 import type { GitForge } from "./forge/types";
 import {
@@ -201,7 +201,7 @@ export interface PlanGateServiceDeps extends MembraneSeams {
    *  *which* coding CLI/model is doing the review before a verdict — and thus the gate's
    *  `reviewer*` fields — exists (notably the FIRST review, where no gate is present). Absent on
    *  the end (`false`) signal. */
-  onReviewing?: (id: string, reviewing: boolean, env?: ReviewerEnvSignal) => void;
+  onReviewing?: (id: string, reviewing: boolean, env?: ReviewerEnv) => void;
   /**
    * Fired each tick a plan reviewer is still running, with its latest *meaningful* tool-use
    * summary (e.g. "$ git diff", "read plan"). Surfaced live in the UI review-in-flight banner
@@ -241,15 +241,6 @@ export interface PlanGateServiceDeps extends MembraneSeams {
    *  (default: readSessionUsage). null = transcript missing/unreadable → totals stay null. */
   readUsage?: (worktreePath: string, reviewerSessionId: string) => Promise<SessionUsage | null>;
 }
-
-/** The reviewer's resolved CLI + model + effort for the currently in-flight run — carried on the
- *  reviewing=true signal (and the inflight bootstrap snapshot) so the UI can surface which coding
- *  CLI/model is doing the review even before a gate exists. */
-export type ReviewerEnvSignal = {
-  provider: AgentProvider | null;
-  model: string | null;
-  effort: string | null;
-};
 
 interface PlanInFlight {
   sessionId: string;
@@ -932,7 +923,7 @@ export class PlanGateService {
   /** In-flight plan reviews with their reviewer env — the client bootstrap snapshot so a reload
    *  mid-review restores which CLI/model is doing the review, not just that one is running. Distinct
    *  from `reviewingIds()`, which stays a bare `string[]` for the herd/upnext consumer. */
-  reviewingInflight(): Array<{ id: string } & ReviewerEnvSignal> {
+  reviewingInflight(): Array<{ id: string } & ReviewerEnv> {
     return [...this.inflight.values()].map((f) => ({
       id: f.sessionId,
       provider: f.reviewerProvider,

--- a/src/review.ts
+++ b/src/review.ts
@@ -344,11 +344,7 @@ export class ReviewService {
     // Fail closed: api-key mode without a configured key must NOT bill the subscription.
     // Checked AFTER the worktree allocation + the post-await re-check so the worktree cleanup
     // here has wt.worktreePath — but BEFORE membrane/backend construction so we skip that work.
-    const reviewerEnv = this.deps.env?.() ?? {
-      provider: "claude" as const,
-      model: null,
-      effort: null,
-    };
+    const reviewerEnv = this.reviewerEnv();
     if (apiKeyFailClosed(reviewerEnv.provider)) {
       console.warn(
         "[review] api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)",
@@ -604,6 +600,10 @@ export class ReviewService {
       effort: env.effort,
       prompt: reviewPrompt(diffBase, session.prompt, priorFindings, authorNotes, issueBody),
     });
+  }
+
+  private reviewerEnv(): RoleEnvironment {
+    return this.deps.env?.() ?? { provider: "claude", model: null, effort: null };
   }
 
   /** Best-effort fetch of the originating issue's body for UNTRUSTED reviewer context.

--- a/src/review.ts
+++ b/src/review.ts
@@ -4,7 +4,7 @@ import type { HerdrDriver, HerdrAgent } from "./herdr";
 import type { WorktreeMgr } from "./worktree";
 import type { GitForge, GitState, PrStatus } from "./forge/types";
 import { CRITIC_REVIEW_MARKER, AUTHOR_RESPONSE_MARKER } from "./forge/types";
-import type { ReviewVerdict, Session, ReviewerSpawnRow } from "./types";
+import type { ReviewVerdict, ReviewerEnv, Session, ReviewerSpawnRow } from "./types";
 import type { RoleEnvironment } from "./default-model";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
 import { apiKeyFailClosed } from "./spawn-auth";
@@ -71,6 +71,9 @@ interface InFlight {
   worktreePath: string;
   terminalId: string;
   criticSessionId: string; // the critic's claude session id → locates its transcript for live activity
+  reviewerProvider: ReviewerEnv["provider"];
+  reviewerModel: string | null;
+  reviewerEffort: string | null;
   startedAt: number;
   priorRound: number; // auto-address steers already spent on this findings streak
   priorErrorRound: number; // consecutive critic error/timeout verdicts before this run
@@ -121,8 +124,9 @@ export interface ReviewServiceDeps extends MembraneSeams {
   worktree: Pick<WorktreeMgr, "createDetached" | "remove" | "gitCommonDir">;
   resolveForge: (repoPath: string) => GitForge | null;
   onChange: (id: string, verdict: ReviewVerdict) => void;
-  /** Fired when a critic run starts (true) and when it ends (false) for a session. */
-  onReviewing?: (id: string, reviewing: boolean) => void;
+  /** Fired when a critic run starts (true) and when it ends (false) for a session. The start
+   *  transition carries the exact environment captured for that spawn; end omits it. */
+  onReviewing?: (id: string, reviewing: boolean, env?: ReviewerEnv) => void;
   /**
    * Fired each tick a critic is still running, with its latest *meaningful* tool-use
    * summary (e.g. "$ git diff", "read review.ts") — surfaced live in the UI badge
@@ -340,7 +344,12 @@ export class ReviewService {
     // Fail closed: api-key mode without a configured key must NOT bill the subscription.
     // Checked AFTER the worktree allocation + the post-await re-check so the worktree cleanup
     // here has wt.worktreePath — but BEFORE membrane/backend construction so we skip that work.
-    if (apiKeyFailClosed(this.deps.env?.().provider ?? "claude")) {
+    const reviewerEnv = this.deps.env?.() ?? {
+      provider: "claude" as const,
+      model: null,
+      effort: null,
+    };
+    if (apiKeyFailClosed(reviewerEnv.provider)) {
       console.warn(
         "[review] api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)",
       );
@@ -353,6 +362,7 @@ export class ReviewService {
       prior?.findings ?? [],
       authorNotes,
       issueBody,
+      reviewerEnv,
     );
     // Fire plugin onSpawn hooks for this reviewer-style spawn (issue #1205) and bind any patched
     // env THROUGH the membrane (apiKeyPassthroughEnv handled inside). A hook that calls abortSpawn
@@ -367,7 +377,7 @@ export class ReviewService {
         sessionId: criticSessionId,
         kind: "review",
         parentSessionId: session.id,
-        model: this.deps.env?.().model ?? null,
+        model: reviewerEnv.model,
       },
     });
     if ("aborted" in aux) {
@@ -407,6 +417,9 @@ export class ReviewService {
       worktreePath: wt.worktreePath,
       terminalId,
       criticSessionId,
+      reviewerProvider: reviewerEnv.provider,
+      reviewerModel: reviewerEnv.model,
+      reviewerEffort: reviewerEnv.effort ?? null,
       startedAt: this.now(),
       ...priorStreakState(prior),
       seenNoteIds,
@@ -418,10 +431,16 @@ export class ReviewService {
       taskSessionId: session.id,
       kind: "review",
       worktreePath: wt.worktreePath,
-      model: this.deps.env?.().model ?? null,
+      reviewerProvider: reviewerEnv.provider,
+      model: reviewerEnv.model,
+      reviewerEffort: reviewerEnv.effort ?? null,
       spawnedAt: this.now(),
     });
-    this.deps.onReviewing?.(session.id, true);
+    this.deps.onReviewing?.(session.id, true, {
+      provider: reviewerEnv.provider,
+      model: reviewerEnv.model,
+      effort: reviewerEnv.effort ?? null,
+    });
   }
 
   /**
@@ -572,13 +591,13 @@ export class ReviewService {
     priorFindings: string[],
     authorNotes: string[],
     issueBody: string | null,
+    env: RoleEnvironment,
   ): { argv: string[]; sessionId: string } {
     // Shared with the plan reviewer: same read-only injection-contained sandbox (the PR diff is
     // UNTRUSTED). The prompt is the only critic-specific part. `diffBase` is the resolved base
     // commit (SHA) threaded from rebaseSkip, NOT session.baseBranch — so the review diffs the
     // identical fresh base the fingerprint used (no stale-local-main fold-in). `issueBody` is the
     // originating issue's body, fetched in begin() and injected as UNTRUSTED context.
-    const env = this.deps.env?.() ?? { provider: "claude" as const, model: null };
     return buildTransientAgentArgv("reviewer", {
       provider: env.provider,
       model: env.model,
@@ -1142,6 +1161,16 @@ export class ReviewService {
   /** Session ids with a critic run currently in flight (for client bootstrap). */
   reviewingIds(): string[] {
     return [...this.inflight.keys()];
+  }
+
+  /** In-flight critic reviews with the exact environment captured for each spawn. */
+  reviewingInflight(): Array<{ id: string } & ReviewerEnv> {
+    return [...this.inflight.values()].map((f) => ({
+      id: f.sessionId,
+      provider: f.reviewerProvider,
+      model: f.reviewerModel,
+      effort: f.reviewerEffort,
+    }));
   }
 
   /** Worktree paths of critic runs currently owned in-memory — the GC sweep must spare

--- a/src/server.ts
+++ b/src/server.ts
@@ -375,7 +375,7 @@ export interface AppDeps {
   /** Snapshot of critic verdicts keyed by session id (+ in-flight run ids); absent in tests that skip it. */
   reviewCache?: {
     snapshot(): Record<string, import("./types").ReviewVerdict>;
-    reviewing?(): string[];
+    reviewing?(): Array<{ id: string } & import("./types").ReviewerEnv>;
   };
   /** Snapshot of plan-gate verdicts keyed by session id (+ in-flight reviewer ids); absent in
    *  tests that skip it. The parallel of reviewCache for the pre-execution plan gate. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -487,6 +487,14 @@ export type PlanDecision = "approved" | "changes_requested" | "error";
  *  other summary is the reviewer's own operator-language text, passed through verbatim. */
 export type PlanSummaryCode = "no-verdict";
 
+/** Resolved coding environment for one in-flight reviewer job. `provider` can be null only for
+ *  legacy/restart-adopted runs whose durable spawn row predates provider persistence. */
+export interface ReviewerEnv {
+  provider: AgentProvider | null;
+  model: string | null;
+  effort: string | null;
+}
+
 export interface PlanGate {
   sessionId: string;
   planHash: string; // sha256 of the reviewed plan text; dedups re-reviews of an unchanged plan on the auto-path (the manual force path bypasses that dedupe)

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -431,6 +431,25 @@ test("onReviewing fires true on spawn and false on finalize", async () => {
   ]);
 });
 
+test("onReviewing start + inflight snapshot carry the critic's exact reviewer env", async () => {
+  const events: unknown[][] = [];
+  const env = { provider: "codex" as const, model: "gpt-5.5", effort: "high" };
+  const { deps: d } = makeDeps({
+    env: () => env,
+    onReviewing: (id: string, reviewing: boolean, reviewerEnv?: unknown) =>
+      events.push([id, reviewing, reviewerEnv]),
+  });
+  const svc = new ReviewService(d as any);
+
+  await svc.consider(session(), OPEN_GREEN);
+
+  expect(events).toContainEqual(["s1", true, env]);
+  expect(svc.reviewingInflight()).toEqual([{ id: "s1", ...env }]);
+  await svc.tick();
+  expect(svc.reviewingInflight()).toEqual([]);
+  expect(events.at(-1)).toEqual(["s1", false, undefined]);
+});
+
 test("onReviewing fires false when an in-flight critic is forgotten", async () => {
   const events: { id: string; reviewing: boolean }[] = [];
   const { deps: d } = makeDeps({

--- a/test/server-reviews.test.ts
+++ b/test/server-reviews.test.ts
@@ -67,11 +67,15 @@ test("GET /api/reviews returns {} when reviewCache is absent", async () => {
   expect(await res.json()).toEqual({});
 });
 
-test("GET /api/reviews/inflight returns in-flight session ids", async () => {
-  const { app } = harness({ snapshot: () => ({}), reviewing: () => ["sess-1", "sess-2"] });
+test("GET /api/reviews/inflight returns in-flight reviews with their reviewer env", async () => {
+  const inflight = [
+    { id: "sess-1", provider: "codex" as const, model: "gpt-5.5", effort: "high" },
+    { id: "sess-2", provider: null, model: null, effort: null },
+  ];
+  const { app } = harness({ snapshot: () => ({}), reviewing: () => inflight });
   const res = await app.fetch(new Request("http://x/api/reviews/inflight"));
   expect(res.status).toBe(200);
-  expect(await res.json()).toEqual(["sess-1", "sess-2"]);
+  expect(await res.json()).toEqual(inflight);
 });
 
 test("GET /api/reviews/inflight returns [] when reviewCache is absent", async () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3117,5 +3117,7 @@
   "feat_default_coding_environment_title": "Standard-CLI und -Modell wählen",
   "feat_default_coding_environment_body": "Die Einstellungen merken sich jetzt getrennte Standardmodelle für Claude Code und Codex. Neue Aufgaben und unbeaufsichtigte Starts verwenden das zur ausgewählten Coding-CLI gehörende Modell.",
   "feat_mobile_herd_accordion_title": "Lebenszyklus-Gruppen mobil einklappen",
-  "feat_mobile_herd_accordion_body": "Die Herd-Liste auf dem Smartphone hält jetzt höchstens eine benannte Lebenszyklus-Gruppe offen. „Du bist dran“ ist standardmäßig geöffnet; tippe auf eine größere Gruppenzeile, um den Bereich zu wechseln oder zu schließen, während aktive Sessions sichtbar bleiben."
+  "feat_mobile_herd_accordion_body": "Die Herd-Liste auf dem Smartphone hält jetzt höchstens eine benannte Lebenszyklus-Gruppe offen. „Du bist dran“ ist standardmäßig geöffnet; tippe auf eine größere Gruppenzeile, um den Bereich zu wechseln oder zu schließen, während aktive Sessions sichtbar bleiben.",
+  "feat_review_job_model_title": "Sieh, welches Modell prüft",
+  "feat_review_job_model_body": "Das Review-Banner im Terminal zeigt jetzt Coding-CLI, Modell und Aufwand von Plan-Gate- und PR-Critic-Jobs, damit ihre Umgebung klar von der Task-Session unterscheidbar ist."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3117,5 +3117,7 @@
   "feat_default_coding_environment_title": "Choose a default CLI and model",
   "feat_default_coding_environment_body": "Settings now remembers separate default models for Claude Code and Codex. New tasks and unattended starts use the model paired with the selected coding CLI.",
   "feat_mobile_herd_accordion_title": "Fold lifecycle groups on mobile",
-  "feat_mobile_herd_accordion_body": "The phone herd now keeps only one named lifecycle group open at a time. Your turn opens by default; tap any larger group header to switch or close it while active sessions stay visible."
+  "feat_mobile_herd_accordion_body": "The phone herd now keeps only one named lifecycle group open at a time. Your turn opens by default; tap any larger group header to switch or close it while active sessions stay visible.",
+  "feat_review_job_model_title": "See which model is reviewing",
+  "feat_review_job_model_body": "The terminal review banner now shows the coding CLI, model and effort used by both Plan Gate and PR critic jobs, so their environment is distinct from the task session."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1628,8 +1628,8 @@ export async function getReviews(): Promise<Record<string, ReviewVerdict>> {
   return getJson("/api/reviews", "reviews");
 }
 
-/** Session ids with a critic run currently in flight (bootstrap for the reviewing indicator). */
-export async function getReviewingIds(): Promise<string[]> {
+/** In-flight critic reviews with the environment used by each reviewer job. */
+export async function getReviewingIds(): Promise<Array<{ id: string } & ReviewerEnv>> {
   return getJson("/api/reviews/inflight", "reviewing");
 }
 

--- a/ui/src/lib/components/viewport/ReviewInFlightBanner.browser.test.ts
+++ b/ui/src/lib/components/viewport/ReviewInFlightBanner.browser.test.ts
@@ -64,9 +64,11 @@ const banner = () => document.querySelector(".review-banner");
 beforeEach(() => {
   reviews.map = {};
   reviews.reviewing = {};
+  reviews.reviewerEnv = {};
   reviews.activity = {};
   planGates.map = {};
   planGates.reviewing = {};
+  planGates.reviewerEnv = {};
   planGates.activity = {};
   repoConfig.autoAddress = {};
   repoConfig.autopilot = {};
@@ -77,6 +79,41 @@ afterEach(() => {
 });
 
 describe("ReviewInFlightBanner preview — in-flight tier", () => {
+  it("shows the Plan Gate reviewer's CLI, model, and effort below the headline", async () => {
+    planGates.applyReviewing(ID, true, {
+      provider: "codex",
+      model: "gpt-5.5",
+      effort: "high",
+    });
+    render(ReviewInFlightBanner, props() as never);
+
+    await expect
+      .poll(() => document.querySelector(".rb-env")?.textContent?.trim())
+      .toBe("Codex · gpt-5.5 · High");
+  });
+
+  it("shows the critic reviewer's environment when auto-address makes the banner visible", async () => {
+    repoConfig.autoAddress = { [REPO]: true };
+    reviews.setReviewing(ID, true, {
+      provider: "claude",
+      model: "opus",
+      effort: "high",
+    });
+    render(ReviewInFlightBanner, props() as never);
+
+    await expect
+      .poll(() => document.querySelector(".rb-env")?.textContent?.trim())
+      .toBe("Claude Code · opus · High");
+  });
+
+  it("keeps the current banner unchanged when the reviewer provider is unavailable", async () => {
+    planGates.applyReviewing(ID, true, { provider: null, model: "opus", effort: "high" });
+    render(ReviewInFlightBanner, props() as never);
+
+    await expect.poll(() => banner()).not.toBeNull();
+    expect(document.querySelector(".rb-env")).toBeNull();
+  });
+
   it("critic in-flight (auto-address on): renders the rolling activity feed, oldest→newest", async () => {
     repoConfig.autoAddress = { [REPO]: true };
     reviews.setReviewing(ID, true);
@@ -127,7 +164,11 @@ describe("ReviewInFlightBanner preview — in-flight tier", () => {
   // i.e. banner ≤ containerHeight - 4rem, so .term-mount never drops under its floor and the
   // prompt is never overlaid. See ReviewInFlightBanner's .review-banner max-height.
   it("caps its height in a short pane so the terminal keeps its 4rem reflow floor", async () => {
-    planGates.applyReviewing(ID, true);
+    planGates.applyReviewing(ID, true, {
+      provider: "codex",
+      model: "gpt-5.5",
+      effort: "high",
+    });
     for (const l of ["act-1", "act-2"]) planGates.setActivity(ID, l);
     render(ReviewInFlightBanner, props() as never);
     await expect.poll(() => banner()).not.toBeNull();
@@ -144,6 +185,7 @@ describe("ReviewInFlightBanner preview — in-flight tier", () => {
     expect(bannerH).toBeLessThanOrEqual(containerH - 4 * remPx + 0.5); // +0.5px rounding tolerance
     expect(bannerH).toBeGreaterThan(0); // clamped, not collapsed — headline still shows at 120px
     expect(document.querySelector(".rb-text")?.textContent?.trim()).toBeTruthy(); // headline present (ellipsized)
+    expect(document.querySelector(".rb-env")?.textContent?.trim()).toBe("Codex · gpt-5.5 · High");
   });
 });
 

--- a/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
+++ b/ui/src/lib/components/viewport/ReviewInFlightBanner.svelte
@@ -13,6 +13,7 @@
   import { planStallStatus } from "$lib/plan-status";
   import { addressStallStatus } from "$lib/review-status";
   import { clock } from "$lib/now.svelte";
+  import { environmentLabel } from "$lib/reviewer-env";
 
   // Non-blocking signal that an in-flight PR-critic / plan-gate review may steer
   // this session when it concludes (issue #1022). Shown only when a paste could
@@ -63,6 +64,22 @@
       : liveKind === "plangate"
         ? planGates.activityFeed(session.id)
         : [],
+  );
+
+  // The reviewer is a separate job from the task session shown above the terminal. Read the
+  // environment captured for whichever review kind is live so the banner identifies that job,
+  // not the task agent. A legacy run with no resolved provider stays visually unchanged.
+  const reviewerEnv = $derived(
+    liveKind === "critic"
+      ? reviews.reviewerEnvFor(session.id)
+      : liveKind === "plangate"
+        ? planGates.reviewerEnvFor(session.id)
+        : null,
+  );
+  const reviewerIdentity = $derived(
+    reviewerEnv?.provider
+      ? environmentLabel(reviewerEnv.provider, reviewerEnv.model, reviewerEnv.effort)
+      : null,
   );
 
   // Session's effective autopilot (mirrors src/effective-autopilot.ts): per-session
@@ -288,7 +305,12 @@
       {:else}
         <span class="rb-icon" aria-hidden="true">{icon}</span>
       {/if}
-      <span class="rb-text">{bannerText(view)}</span>
+      <span class="rb-copy">
+        <span class="rb-text">{bannerText(view)}</span>
+        {#if view.phase === "in-flight" && reviewerIdentity}
+          <span class="rb-env">{reviewerIdentity}</span>
+        {/if}
+      </span>
     </div>
     {#if view.show && view.phase === "in-flight"}
       <!-- Live "tail -f" of the off-screen reviewer's actions. Reserves MAX_ACTIVITY_LINES rows
@@ -366,6 +388,18 @@
     flex-shrink: 0;
     min-width: 0;
   }
+  .rb-copy {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+  .rb-env {
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    line-height: 1.3;
+    overflow-wrap: anywhere;
+  }
   /* Live activity tail under the in-flight headline. Newest line pins to the bottom
      (justify-content:flex-end); the reserved height is MAX_ACTIVITY_LINES rows (--rb-pv-rows) so
      the banner keeps a STABLE height across the whole in-flight phase as lines fill in — one
@@ -432,6 +466,7 @@
      ellipsizes in a narrow pane rather than wrapping and pushing the head past the cap.
      The full text still reaches assistive tech via the banner's aria-live region. */
   .rb-text {
+    display: block;
     min-width: 0;
     white-space: nowrap;
     overflow: hidden;

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-review-job-model.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-review-job-model.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "review-job-model",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_review_job_model_title",
+  bodyKey: "feat_review_job_model_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/reviews.svelte.test.ts
+++ b/ui/src/lib/reviews.svelte.test.ts
@@ -81,9 +81,11 @@ const planGate = (id: string): PlanGate => ({
 beforeEach(() => {
   reviews.map = {};
   reviews.reviewing = {};
+  reviews.reviewerEnv = {};
   reviews.activity = {};
   planGates.map = {};
   planGates.reviewing = {};
+  planGates.reviewerEnv = {};
   planGates.activity = {};
   repoConfig.enabled = {};
   repoConfig.autoAddress = {};
@@ -227,10 +229,38 @@ test("reviews.load wipes any stale feed, even for a still-in-flight id", async (
   reviews.setReviewing("s7", true);
   reviews.setActivity("s7", "line from before the resync");
   vi.mocked(getReviews).mockResolvedValue({});
-  vi.mocked(getReviewingIds).mockResolvedValue(["s7"]); // snapshot: s7 still in flight
+  vi.mocked(getReviewingIds).mockResolvedValue([
+    { id: "s7", provider: "codex", model: "gpt-5.5", effort: "high" },
+  ]); // snapshot: s7 still in flight
   await reviews.load();
   expect(reviews.isReviewing("s7")).toBe(true); // still in flight…
+  expect(reviews.reviewerEnvFor("s7")).toEqual({
+    provider: "codex",
+    model: "gpt-5.5",
+    effort: "high",
+  });
   expect(reviews.activityFeed("s7")).toEqual([]); // …but feed wiped; rebuilds from live events
+});
+
+test("reviews.setReviewing caches, refreshes, and clears the critic reviewer env", () => {
+  reviews.setReviewing("ce", true, { provider: "claude", model: "opus", effort: "high" });
+  reviews.setActivity("ce", "read review.ts");
+  expect(reviews.reviewerEnvFor("ce")).toEqual({
+    provider: "claude",
+    model: "opus",
+    effort: "high",
+  });
+
+  reviews.setReviewing("ce", true, { provider: "codex", model: "gpt-5.5", effort: "low" });
+
+  expect(reviews.reviewerEnvFor("ce")).toEqual({
+    provider: "codex",
+    model: "gpt-5.5",
+    effort: "low",
+  });
+  expect(reviews.activityFeed("ce")).toEqual(["read review.ts"]);
+  reviews.setReviewing("ce", false);
+  expect(reviews.reviewerEnvFor("ce")).toBeNull();
 });
 
 // ── plan-gate activity feed: mirrors ReviewsStore ──────────────────────────
@@ -322,10 +352,17 @@ test("repoConfig.toggle defaults to false when state unknown (default-on)", asyn
 test("reviews.load populates map and in-flight ids from api", async () => {
   const v = verdict("s2");
   vi.mocked(getReviews).mockResolvedValue({ s2: v });
-  vi.mocked(getReviewingIds).mockResolvedValue(["s3"]);
+  vi.mocked(getReviewingIds).mockResolvedValue([
+    { id: "s3", provider: "claude", model: "opus", effort: "high" },
+  ]);
   await reviews.load();
   expect(reviews.map["s2"]).toEqual(v);
   expect(reviews.isReviewing("s3")).toBe(true);
+  expect(reviews.reviewerEnvFor("s3")).toEqual({
+    provider: "claude",
+    model: "opus",
+    effort: "high",
+  });
 });
 
 test("repoConfig.ensure fetches and caches", async () => {

--- a/ui/src/lib/reviews.svelte.ts
+++ b/ui/src/lib/reviews.svelte.ts
@@ -32,6 +32,8 @@ class ReviewsStore {
   map = $state<Record<string, ReviewVerdict>>({});
   // session ids with a critic run currently in flight; driven by `session:reviewing`
   reviewing = $state<Record<string, boolean>>({});
+  // Exact reviewer environment for the current critic run, keyed by task session id.
+  reviewerEnv = $state<Record<string, ReviewerEnv>>({});
   // rolling live-activity feed (last MAX_ACTIVITY_LINES tool-use summaries) of the in-flight
   // critic, keyed by session id; driven by `session:critic-activity`. Surfaced in the badge
   // tooltip (latest line) and the review-in-flight banner preview (full feed). RESET on both
@@ -46,8 +48,12 @@ class ReviewsStore {
       /* best-effort; live events still populate it */
     }
     try {
-      // bootstrap in-flight runs so a reload mid-review still shows the indicator
-      this.reviewing = Object.fromEntries((await getReviewingIds()).map((id) => [id, true]));
+      // Bootstrap both the in-flight indicator and reviewer identity after a reload.
+      const inflight = await getReviewingIds();
+      this.reviewing = Object.fromEntries(inflight.map(({ id }) => [id, true]));
+      this.reviewerEnv = Object.fromEntries(
+        inflight.map(({ id, provider, model, effort }) => [id, { provider, model, effort }]),
+      );
       // Snapshot carries no historical activity → any pre-existing feed is stale after a resync.
       // Wipe it; the live feed rebuilds from `session:critic-activity` within ~1 tick.
       this.activity = {};
@@ -67,7 +73,14 @@ class ReviewsStore {
     this.setReviewing(d.id, false);
   }
 
-  setReviewing(id: string, on: boolean) {
+  setReviewing(id: string, on: boolean, env?: ReviewerEnv) {
+    if (on) {
+      if (env) this.reviewerEnv = { ...this.reviewerEnv, [id]: env };
+    } else if (id in this.reviewerEnv) {
+      const copy = { ...this.reviewerEnv };
+      delete copy[id];
+      this.reviewerEnv = copy;
+    }
     if (!!this.reviewing[id] === on) return;
     // Any genuine transition resets the feed: on START a new run must begin empty (defensive
     // against a missed end-clear), on END the finished run's live tail is stale. Guarded by the
@@ -108,6 +121,10 @@ class ReviewsStore {
   /** The full rolling feed (oldest→newest) for the banner preview; [] when absent. */
   activityFeed(id: string): string[] {
     return this.activity[id] ?? [];
+  }
+
+  reviewerEnvFor(id: string): ReviewerEnv | null {
+    return this.reviewerEnv[id] ?? null;
   }
 
   isReviewing(id: string): boolean {

--- a/ui/src/lib/store.svelte.test.ts
+++ b/ui/src/lib/store.svelte.test.ts
@@ -668,12 +668,26 @@ test("session:reviewing false clears the critic activity feed", async () => {
   const { reviews } = await import("./reviews.svelte");
   reviews.activity = {};
   reviews.reviewing = {};
+  reviews.reviewerEnv = {};
   const s = new HerdStore();
-  s.apply({ event: "session:reviewing", data: { id: "s1", reviewing: true } });
+  s.apply({
+    event: "session:reviewing",
+    data: {
+      id: "s1",
+      reviewing: true,
+      env: { provider: "codex", model: "gpt-5.5", effort: "high" },
+    },
+  });
+  expect(reviews.reviewerEnvFor("s1")).toEqual({
+    provider: "codex",
+    model: "gpt-5.5",
+    effort: "high",
+  });
   s.apply({ event: "session:critic-activity", data: { id: "s1", summary: "$ git diff" } });
   expect(reviews.activityFeed("s1")).toEqual(["$ git diff"]);
   s.apply({ event: "session:reviewing", data: { id: "s1", reviewing: false } });
   expect(reviews.activityFeed("s1")).toEqual([]);
+  expect(reviews.reviewerEnvFor("s1")).toBeNull();
 });
 
 // ── session:subagents ──────────────────────────────────────────────────────

--- a/ui/src/lib/store.svelte.ts
+++ b/ui/src/lib/store.svelte.ts
@@ -568,7 +568,7 @@ export class HerdStore {
         reviews.apply(ev.data);
         return true;
       case "session:reviewing":
-        reviews.setReviewing(ev.data.id, ev.data.reviewing);
+        reviews.setReviewing(ev.data.id, ev.data.reviewing, ev.data.env);
         return true;
       case "session:critic-activity":
         reviews.setActivity(ev.data.id, ev.data.summary);

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -480,11 +480,9 @@ export interface PlanGate {
   updatedAt: number;
 }
 
-/** The plan reviewer's resolved CLI + model + effort for the currently in-flight run. Carried on
- *  the `session:plangate-reviewing` start signal (and the `/api/plan-gates/inflight` bootstrap) so
- *  the UI can show which coding CLI/model is doing the review before a gate — and thus its
- *  `reviewer*` fields — exists (notably the first review). `provider: null` for legacy /
- *  restart-adopted reviews whose CLI couldn't be resolved. */
+/** A reviewer's resolved CLI + model + effort for the currently in-flight run. Carried on the
+ *  review start signal and `/inflight` bootstrap so the UI can identify Plan Gate and critic jobs
+ *  before a verdict exists. `provider: null` for legacy/restart-adopted runs. */
 export type ReviewerEnv = {
   provider: AgentProvider | null;
   model: string | null;
@@ -1717,7 +1715,10 @@ export type WsEvent =
   | { event: "herd:digest"; data: { digest: HerdDigest } }
   | { event: "upnext:snapshot"; data: { snapshot: UpNextSnapshot } }
   | { event: "session:review"; data: { id: string; review: ReviewVerdict | null } }
-  | { event: "session:reviewing"; data: { id: string; reviewing: boolean } }
+  | {
+      event: "session:reviewing";
+      data: { id: string; reviewing: boolean; env?: ReviewerEnv };
+    }
   | { event: "session:critic-activity"; data: { id: string; summary: string } }
   | {
       event: "session:plangate";


### PR DESCRIPTION
## What changed

- carry the exact coding CLI, model, and reasoning effort for in-flight PR critic jobs through the bootstrap API and WebSocket event
- show the active Plan Gate or PR critic reviewer environment as quiet metadata in the terminal review banner
- clear or replace reviewer identity across review lifecycle transitions and reloads
- add EN/DE discovery copy and a v1.44.0 feature announcement

## Why

The review job runs separately from the task session, but the existing banner did not identify which model was performing the review. Users can now distinguish the reviewer environment from the task agent at a glance.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun test test/review.test.ts test/server-reviews.test.ts`
- `cd ui && bun run check`
- `cd ui && bun run check:i18n`
- focused UI node and banner browser tests
- announcement-version, glossary, feature-catalog, and branch-hygiene gates
