### PR TITLE
fix: preserve plan reviewer launches

### DIFF
--- a/src/herdr-socket-driver.ts
+++ b/src/herdr-socket-driver.ts
@@ -95,7 +95,7 @@ export class SocketHerdrDriver implements IHerdrDriver {
   /**
    * Spawn an agent over the socket, mirroring `HerdrDriver.start`'s orchestration:
    * ensure a workspace → create a dedicated tab → `agent.start` (with collision-retry) →
-   * close the leftover shell pane → resolve the `HerdrAgent`. Unlike the CLI path, the
+   * close the leftover shell pane → resolve the `HerdrAgent`. As on the CLI path, the
    * `agent.start` reply carries the started agent's full `AgentInfo` (terminal_id/tab_id/…),
    * so no post-start re-list is needed. Serialized to preserve start atomicity.
    */

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -8,8 +8,6 @@ import type { HerdrState, SessionStatus } from "./types";
 
 const execFileAsync = promisify(execFile);
 
-const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
-
 export interface HerdrAgent {
   agent: string;
   agentStatus: HerdrState;
@@ -245,9 +243,8 @@ export function parseAgents(result: unknown): HerdrAgent[] {
   }));
 }
 
-/** Maps a `tab list` reply to `HerdrTab[]`. Shared by the sync `tabs()` and async
- *  `tabsAsync()` so both parse the `result.tabs[]` shape identically. Internal — not
- *  exported (fallow flags an unused export; the parsers used cross-module are exported). */
+/** Maps a `tab list` reply to `HerdrTab[]`. Internal — not exported (fallow flags an
+ *  unused export; the parsers used cross-module are exported). */
 function parseTabs(parsed: unknown): HerdrTab[] {
   const tabs = (parsed as { result?: { tabs?: Record<string, string>[] } })?.result?.tabs ?? [];
   return tabs.map((t) => ({
@@ -261,10 +258,9 @@ function parseTabs(parsed: unknown): HerdrTab[] {
 /**
  * Maps a single herdr `AgentInfo` object (the `result.agent` of an `agent.start`
  * `agent_started` reply) to one `HerdrAgent`, using the SAME field mapping as
- * `parseAgents`' per-item map. The socket `start` (issue #1553) resolves its started
- * agent straight from this reply — `agent_started.agent` carries `terminal_id`/`tab_id`/…
- * directly (confirmed against live herdr 0.7.3), so it needs no post-start re-list, unlike
- * the CLI path whose `agent start` output exposes no terminal id.
+ * `parseAgents`' per-item map. Both start transports resolve their started agent straight
+ * from this reply — `agent_started.agent` carries `terminal_id`/`tab_id`/… directly
+ * (confirmed against live herdr 0.7.3), so no post-start re-list is needed.
  */
 export function parseAgentInfo(agent: unknown): HerdrAgent {
   const a = (agent ?? {}) as Record<string, string>;
@@ -400,11 +396,6 @@ export class HerdrDriver implements IHerdrDriver {
   constructor(
     private runner: Runner = defaultRunner,
     private asyncRunner: AsyncRunner = defaultAsyncRunner,
-    // Read-back retry knobs (issue: reviewer-spawn resolve race). `agent start` returning
-    // does not guarantee the agent is in `agent list` yet — a short registration lag. Poll
-    // a few times before giving up; injectable so tests run without real delay.
-    private resolveAttempts = 5,
-    private resolveDelayMs = 100,
   ) {}
 
   list(): HerdrAgent[] {
@@ -423,13 +414,6 @@ export class HerdrDriver implements IHerdrDriver {
   /** Every tab in the workspace — including husks with no live agent (`tab list`). */
   tabs(): HerdrTab[] {
     return parseTabs(JSON.parse(this.runner(["tab", "list"])));
-  }
-
-  /** Async sibling of `tabs()` — same shape via `asyncRunner` so it never blocks the loop.
-   *  Used by resolveStartedAgent to tell a genuine spawn failure (tab gone) from a role
-   *  `exec` that already exited or a lagging registration (tab husk still present). */
-  async tabsAsync(): Promise<HerdrTab[]> {
-    return parseTabs(JSON.parse(await this.asyncRunner(["tab", "list"])));
   }
 
   /** Every pane across all tabs (`pane list`). Includes idle shell panes left behind by exited agents. */
@@ -499,7 +483,7 @@ export class HerdrDriver implements IHerdrDriver {
     tabId: string,
     cwd: string,
     wrapped: string[],
-  ): Promise<void> {
+  ): Promise<HerdrAgent> {
     const agentStartArgs = [
       "agent",
       "start",
@@ -515,8 +499,12 @@ export class HerdrDriver implements IHerdrDriver {
     const MAX_ATTEMPTS = 3;
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
       try {
-        await this.asyncRunner(agentStartArgs);
-        return;
+        const parsed = JSON.parse(await this.asyncRunner(agentStartArgs));
+        const agent = parseAgentInfo(parsed?.result?.agent);
+        if (!agent.terminalId || agent.tabId !== tabId) {
+          throw new Error(`herdr: agent start returned an invalid agent for tab ${tabId}`);
+        }
+        return agent;
       } catch (err) {
         if (!isNameTakenError(err) || attempt === MAX_ATTEMPTS - 1) {
           // Non-name-taken error → propagate immediately; or attempts exhausted → propagate
@@ -527,6 +515,7 @@ export class HerdrDriver implements IHerdrDriver {
         for (const sq of squatters) await this.closeTab(sq.tabId);
       }
     }
+    throw new Error(`herdr: agent start exhausted retries for ${name}`);
   }
 
   /**
@@ -540,62 +529,7 @@ export class HerdrDriver implements IHerdrDriver {
     argv: string[],
     env?: Record<string, string>,
   ): Promise<HerdrAgent> {
-    // The workspace/tab orchestration is serialized (concurrent spawns must not race it);
-    // it returns the freshly-created tab id. The read-back that resolves the started agent
-    // is a pure `agent list` read, so it runs OUTSIDE the serializer — a retry there must
-    // not hold the start mutex, or it would stall every other queued spawn. Roll back the
-    // orphan tab if the agent never registers.
-    const tabId = await this.serializeStart(() => this.startImpl(name, cwd, argv, env));
-    try {
-      return await this.resolveStartedAgent(tabId, cwd);
-    } catch (err) {
-      await this.closeTab(tabId);
-      throw err;
-    }
-  }
-
-  /** Resolve the just-started agent from `agent list`, matching the unique tab we created
-   *  for it (`tabId`) — deterministic, unlike the old cwd match (two sessions sharing a cwd
-   *  could alias). The CLI `agent start` output exposes no terminal id, so a list read is the
-   *  only handle for a LIVE agent. Poll a bounded number of times for a registration lag.
-   *
-   *  A miss is NOT automatically a failure. `agent start` returning without throwing means the
-   *  spawn happened; a non-interactive role spawn (`codex exec`) runs to completion and EXITS,
-   *  which drops it from `agent list` while its tab husk lingers (`tab list`), and under load a
-   *  live agent's registration can lag past the poll window. Either way the review already ran
-   *  (or is running) and may have written its verdict — treating that as `error-spawn` would
-   *  wrongly delete its worktree. So on exhaustion decide by TAB existence, not agent liveness:
-   *    - tab still present ⇒ started; return a handle with an EMPTY terminal id (a completed
-   *      exec has no live terminal; `herdr.stop("")` is a safe no-op and callers re-derive a
-   *      live terminal by cwd where needed; the husk is reaped by the hourly orphan-tab sweep).
-   *      Do NOT close the tab here — a running-but-unregistered agent would be killed.
-   *    - tab gone ⇒ genuine failure (herdr never kept the tab) ⇒ throw.
-   *  The socket driver reads terminal_id straight from the `agent.start` reply and needs none of this. */
-  private async resolveStartedAgent(tabId: string, cwd: string): Promise<HerdrAgent> {
-    for (let attempt = 0; attempt < this.resolveAttempts; attempt++) {
-      const match = (await this.listAsync()).find((a) => a.tabId === tabId);
-      if (match) return match;
-      if (attempt < this.resolveAttempts - 1) await sleep(this.resolveDelayMs);
-    }
-    if ((await this.tabsAsync()).some((t) => t.tabId === tabId)) {
-      console.warn(
-        `[herdr] agent not in list but tab ${tabId} present — treating exec spawn as started (cwd ${cwd})`,
-      );
-      return {
-        agent: "",
-        agentStatus: "done",
-        cwd,
-        name: "",
-        paneId: "",
-        tabId,
-        terminalId: "",
-        workspaceId: "",
-      };
-    }
-    console.warn(
-      `[herdr] agent resolve exhausted and tab ${tabId} gone after ${this.resolveAttempts} attempts (cwd ${cwd})`,
-    );
-    throw new Error(`herdr: started agent not found and tab gone for tab ${tabId} (cwd ${cwd})`);
+    return this.serializeStart(() => this.startImpl(name, cwd, argv, env));
   }
 
   private async startImpl(
@@ -603,7 +537,7 @@ export class HerdrDriver implements IHerdrDriver {
     cwd: string,
     argv: string[],
     env?: Record<string, string>,
-  ): Promise<string> {
+  ): Promise<HerdrAgent> {
     // herdr needs an active workspace before any tab can be created — guarantee one.
     await this.ensureWorkspace(cwd);
     // Give each agent its OWN tab so its pane spans the full herdr window width.
@@ -623,8 +557,7 @@ export class HerdrDriver implements IHerdrDriver {
 
     // `agent start` can fail (e.g. name-taken exhaustion). The tab already exists, so on
     // failure we must close it — otherwise it lingers forever as an empty husk with no
-    // claude in it. The read-back that resolves the agent runs in start() (outside the
-    // serializer); its own rollback lives there.
+    // claude in it.
     try {
       // Byte-identical spawn to the socket path — see `buildWrappedArgv`.
       const wrapped = buildWrappedArgv(argv, env);
@@ -633,7 +566,9 @@ export class HerdrDriver implements IHerdrDriver {
       // was running), resolve the squatter(s) by name from `list()`, close their tabs
       // (which both kills the orphan via --die-with-parent and synchronously releases the
       // name), then retry. Bounded at 3 total attempts.
-      await this.startAgentWithCollisionRetry(name, tabId, cwd, wrapped);
+      // Capture the authoritative handle before root-pane cleanup: a fast role can already be
+      // absent from agent.list, and closing the remaining shell pane can remove the whole tab.
+      const agent = await this.startAgentWithCollisionRetry(name, tabId, cwd, wrapped);
 
       if (rootPaneId) {
         try {
@@ -643,7 +578,7 @@ export class HerdrDriver implements IHerdrDriver {
         }
       }
 
-      return tabId;
+      return agent;
     } catch (err) {
       await this.closeTab(tabId); // roll back the orphan tab before propagating
       throw err;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1345,11 +1345,10 @@ const planGate = new PlanGateService({
   onActivity: (id, summary) => events.emit("session:plangate-activity", { id, summary }),
   cap: () => config.planReviewCyclesCap,
 });
-// Grace window for a recent uncompleted reviewer_spawns row: spares a recently-spawned reviewer
-// whose path is not currently in `inflight` (e.g. a restart-orphan before re-adoption). It does
-// NOT cover the pre-`inflight` begin() window — recordReviewerSpawn runs AFTER inflight.set — so
-// that window is covered instead by the directory-age guard in reapStaleReviewWorktrees, which
-// reuses this same value as the dir-age threshold.
+// Grace window for a recent uncompleted reviewer_spawns row: spares a plan-gate reviewer during
+// its durable pre-launch/pre-inflight window and any recent restart-orphan before re-adoption.
+// The directory-age guard in reapStaleReviewWorktrees reuses this threshold as an independent
+// safety net for reviewer services that have not persisted a row yet.
 const REVIEW_WORKTREE_GRACE_MS = 15 * 60 * 1000;
 
 // Disk-driven stale reviewer-worktree sweep (#721): reaps `*-review-*` checkouts under each

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -457,6 +457,25 @@ export class PlanGateService {
       this.deps.worktree.remove(wt.worktreePath);
       return "skipped";
     }
+    const spawnedAt = this.now();
+    // Persist ownership before launch so a server restart during Herdr orchestration can adopt
+    // this run and preserve the worktree that receives its verdict.
+    try {
+      this.deps.store.recordReviewerSpawn({
+        reviewerSessionId,
+        taskSessionId: session.id,
+        kind: "plan_gate",
+        worktreePath: wt.worktreePath,
+        reviewerProvider: reviewerEnv.provider,
+        model: reviewerEnv.model,
+        reviewerEffort,
+        spawnedAt,
+      });
+    } catch (err) {
+      console.warn(`[plan-gate] ownership persistence failed for ${session.id}:`, err);
+      this.deps.worktree.remove(wt.worktreePath);
+      return "error-spawn";
+    }
     let terminalId: string;
     try {
       terminalId = (
@@ -469,6 +488,11 @@ export class PlanGateService {
       ).terminalId;
     } catch (err) {
       console.warn(`[plan-gate] spawn failed for ${session.id}:`, err);
+      try {
+        this.deps.store.completeReviewerSpawn(reviewerSessionId, ZEROED_USAGE, this.now());
+      } catch (completeErr) {
+        console.warn(`[plan-gate] spawn failure accounting failed for ${session.id}:`, completeErr);
+      }
       this.deps.worktree.remove(wt.worktreePath);
       return "error-spawn";
     }
@@ -493,19 +517,7 @@ export class PlanGateService {
       reviewerEffort,
       priorRound: prior?.round ?? 0,
       forced,
-      startedAt: this.now(),
-    });
-    // Persist the spawn row now (totals NULL until finalize) so plan-review burn is attributable
-    // even if the run crashes/times out before producing a verdict (issue #502).
-    this.deps.store.recordReviewerSpawn({
-      reviewerSessionId,
-      taskSessionId: session.id,
-      kind: "plan_gate",
-      worktreePath: wt.worktreePath,
-      reviewerProvider: reviewerEnv.provider,
-      model: reviewerEnv.model,
-      reviewerEffort,
-      spawnedAt: this.now(),
+      startedAt: spawnedAt,
     });
     this.deps.onReviewing?.(session.id, true, {
       provider: reviewerEnv.provider,
@@ -632,11 +644,9 @@ export class PlanGateService {
    *   (a) it MUST run once at boot AFTER adoptOrphans() has repopulated `inflight`, so every
    *       genuinely-live orphan is already adopted (its worktree is in the inflight set below) and
    *       only the truly ownerless duplicates remain to reap;
-   *   (b) the load-bearing invariant that begin() calls recordReviewerSpawn AFTER inflight.set —
-   *       so any persisted not-yet-finalized plan_gate row implies its run is already in `inflight`
-   *       (or it finalized, and finalize already removed the worktree). A future reorder putting
-   *       recordReviewerSpawn BEFORE inflight.set would let this GC reap a live spawning run, so
-   *       that ordering must not be changed. */
+   *   (b) begin() persists ownership before launch, so a restart can adopt the row before this GC
+   *       runs. During a live launch this boot-only method cannot run concurrently; after restart,
+   *       (a) ensures adoption has already rebuilt `inflight`. */
   gcStaleReviewWorktrees(): void {
     const live = new Set([...this.inflight.values()].map((f) => f.worktreePath));
     for (const sp of this.deps.store.listReviewerSpawns()) {

--- a/src/tab-reaper.ts
+++ b/src/tab-reaper.ts
@@ -188,13 +188,12 @@ export async function reapOrphanTabs(
  *
  * **Full spare/reap coverage matrix** (an unowned candidate is reaped only if it survives
  * every spare below):
- *  - **pre-`inflight` begin() window** — each reviewer service's `begin()` does
- *    `createDetached` (mints the `-review-<tag>` dir on disk) and only LATER `inflight.set`
- *    then `recordReviewerSpawn`. In that window the dir exists, matches the tag shape, is
- *    NOT in `protectedPaths`, has NO `reviewer_spawns` row, and hosts no live `claude` yet —
- *    a mid-begin checkout. Covered by the **directory-age guard**: a candidate whose dir is
- *    younger than `graceMs` (or that can't be stat'd → fail-closed) is spared. Checked
- *    BEFORE the `scanAlive` probe so a not-yet-running spawn is held by age alone.
+ *  - **pre-`inflight` begin() window** — a reviewer worktree may exist before in-memory ownership.
+ *    Plan-gate persists its `reviewer_spawns` row before launch, so the recent-row grace covers
+ *    that starting window; other reviewer services can still have no row yet. The independent
+ *    **directory-age guard** therefore remains required: a candidate younger than `graceMs` (or
+ *    that can't be stat'd → fail-closed) is spared. Checked BEFORE the `scanAlive` probe so a
+ *    not-yet-running spawn is held by age alone.
  *  - **owned in memory (`protectedPaths`)** — paths a reviewer service currently holds.
  *    Spared REGARDLESS of age or `/proc` liveness. This is the #631 regression guard: a
  *    re-adopted plan-gate orphan has a DEAD reviewer `claude` AND an OLD uncompleted
@@ -206,12 +205,10 @@ export async function reapOrphanTabs(
  *  - **live `claude` under the dir (`scanAlive`)** — one cheap `/proc` pass; a candidate
  *    hosting a live `claude` is spared (`sparedLive`).
  *  - **recent uncompleted spawn (the `graceMs` grace)** — a `reviewer_spawns` row with
- *    `completedAt == null` whose `spawnedAt` is within `graceMs`. INVARIANT:
- *    `recordReviewerSpawn` runs AFTER `inflight.set`, so a row NEVER precedes in-memory
- *    tracking — the grace therefore does NOT cover the pre-`inflight` window (the age guard
- *    does). It spares a recently-spawned reviewer whose path is not (yet/any longer) in
- *    `inflight`, e.g. across a restart before re-adoption, or a review/critic spawn that
- *    isn't re-adopted.
+ *    `completedAt == null` whose `spawnedAt` is within `graceMs`. It covers plan-gate's durable
+ *    pre-launch ownership window and also spares a recently-spawned reviewer whose path is not
+ *    (yet/any longer) in `inflight`, e.g. across a restart before re-adoption, or a review/critic
+ *    spawn that isn't re-adopted.
  *  - **old + ownerless** — survives every spare above → reaped.
  *
  * Too-young/unstattable and live-session spares are counted under `sparedOwned`.

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -63,6 +63,23 @@ const TAB_CREATE = JSON.stringify({
   },
 });
 
+const AGENT_STARTED = JSON.stringify({
+  result: {
+    type: "agent_started",
+    agent: {
+      agent: "codex",
+      agent_status: "working",
+      cwd: "/wt/a",
+      name: "flatten",
+      pane_id: "p_started",
+      tab_id: "t_new",
+      terminal_id: "term_started",
+      workspace_id: "w1",
+    },
+    argv: ["codex", "exec", "go"],
+  },
+});
+
 test("list surfaces the agent name (empty when herdr omits it)", async () => {
   const d = mkDriver(() => FIXTURE);
   const a = d.list();
@@ -83,6 +100,7 @@ const WORKSPACE_LIST_EMPTY = JSON.stringify({
 function reply(args: string[], workspaceList: string): string {
   if (args[0] === "workspace" && args[1] === "list") return workspaceList;
   if (args[0] === "tab" && args[1] === "create") return TAB_CREATE;
+  if (args[0] === "agent" && args[1] === "start") return AGENT_STARTED;
   return FIXTURE;
 }
 
@@ -97,7 +115,7 @@ test("start gives each agent its own full-width tab, not a shared split pane", a
     "--dangerously-skip-permissions",
     "go",
   ]);
-  expect(agent.terminalId).toBe("term_a");
+  expect(agent.terminalId).toBe("term_started");
   // 0) a workspace already exists, so we only check for one — no create
   expect(calls[0]).toEqual(["workspace", "list"]);
   expect(calls.some((c) => c[0] === "workspace" && c[1] === "create")).toBe(false);
@@ -212,7 +230,23 @@ test("start rolls back its orphan tab when agent start fails", async () => {
   expect(calls).toContainEqual(["tab", "close", "t_new"]);
 });
 
-// ── read-back resolve: registration staleness, tab-keying, exhaustion (reviewer-spawn race) ──
+test("start rejects an invalid agent-start handle and rolls back its tab", async () => {
+  const calls: string[][] = [];
+  const d = mkDriver((args) => {
+    calls.push(args);
+    if (args[0] === "agent" && args[1] === "start") {
+      return JSON.stringify({
+        result: { agent: { terminal_id: "term_wrong", tab_id: "t_wrong" } },
+      });
+    }
+    return reply(args, WORKSPACE_LIST);
+  });
+
+  await expect(d.start("flatten", "/wt/a", ["codex", "exec", "go"])).rejects.toThrow(
+    "herdr: agent start returned an invalid agent for tab t_new",
+  );
+  expect(calls).toContainEqual(["tab", "close", "t_new"]);
+});
 
 const EMPTY_LIST = JSON.stringify({ result: { type: "agent_list", agents: [] } });
 const EMPTY_TABS = JSON.stringify({ result: { type: "tab_list", tabs: [] } });
@@ -220,190 +254,35 @@ const TAB_LIST_WITH_NEW = JSON.stringify({
   result: { type: "tab_list", tabs: [{ tab_id: "t_new", label: "flatten", workspace_id: "w1" }] },
 });
 
-test("start: resolve retries until the agent registers (registration staleness)", async () => {
-  // `agent start` can return before the agent shows up in `agent list` — the read-back must
-  // poll, not fail on the first empty read. Delay 0 keeps the test instant.
-  let listCalls = 0;
+test("start: captures agent start reply before root-pane close can remove the tab", async () => {
+  const calls: string[][] = [];
+  let tabPresent = false;
   const runner = (args: string[]): string => {
+    calls.push(args);
     if (args[0] === "workspace" && args[1] === "list") return WORKSPACE_LIST;
-    if (args[0] === "tab" && args[1] === "create") return TAB_CREATE;
-    if (args[0] === "agent" && args[1] === "start") return "{}";
-    if (args[0] === "agent" && args[1] === "list") {
-      listCalls++;
-      return listCalls < 3 ? EMPTY_LIST : FIXTURE; // empty twice, then the agent (tab t_new)
+    if (args[0] === "tab" && args[1] === "create") {
+      tabPresent = true;
+      return TAB_CREATE;
+    }
+    if (args[0] === "agent" && args[1] === "start") return AGENT_STARTED;
+    if (args[0] === "pane" && args[1] === "close") {
+      tabPresent = false; // the fast role pane is gone, so closing root removes the whole tab
+      return "{}";
+    }
+    if (args[0] === "agent" && args[1] === "list") return EMPTY_LIST;
+    if (args[0] === "tab" && args[1] === "list") {
+      return tabPresent ? TAB_LIST_WITH_NEW : EMPTY_TABS;
     }
     return "{}";
   };
-  const d = new HerdrDriver(runner, async (a) => runner(a), 5, 0);
-  const agent = await d.start("flatten", "/wt/a", ["claude", "go"]);
-  expect(agent.terminalId).toBe("term_a");
-  expect(listCalls).toBeGreaterThanOrEqual(3); // it polled past the empty reads
-});
+  const d = new HerdrDriver(runner, async (a) => runner(a));
 
-test("start: resolve is keyed by the created tab, not cwd (no cwd-collision aliasing)", async () => {
-  // Two agents share cwd /wt/a; only the one in the tab we created (t_new) is ours. The old
-  // cwd `.at(-1)` match could return the wrong (stale) sibling; the tab match cannot.
-  const TWO_AT_SAME_CWD = JSON.stringify({
-    result: {
-      type: "agent_list",
-      agents: [
-        // ours — in the tab we just created
-        {
-          agent: "claude",
-          agent_status: "working",
-          cwd: "/wt/a",
-          name: "flatten",
-          pane_id: "p1",
-          tab_id: "t_new",
-          terminal_id: "term_ours",
-          workspace_id: "w1",
-        },
-        // a stale sibling at the same cwd, listed LAST (so `.at(-1)` would have picked it)
-        {
-          agent: "claude",
-          agent_status: "done",
-          cwd: "/wt/a",
-          name: "stale",
-          pane_id: "p9",
-          tab_id: "t_old",
-          terminal_id: "term_stale",
-          workspace_id: "w1",
-        },
-      ],
-    },
-  });
-  const runner = (args: string[]): string => {
-    if (args[0] === "workspace" && args[1] === "list") return WORKSPACE_LIST;
-    if (args[0] === "tab" && args[1] === "create") return TAB_CREATE;
-    if (args[0] === "agent" && args[1] === "start") return "{}";
-    if (args[0] === "agent" && args[1] === "list") return TWO_AT_SAME_CWD;
-    return "{}";
-  };
-  const d = new HerdrDriver(runner, async (a) => runner(a), 5, 0);
-  const agent = await d.start("flatten", "/wt/a", ["claude", "go"]);
-  expect(agent.terminalId).toBe("term_ours"); // the created tab, not the stale sibling
-});
-
-test("start: resolve exhaustion AND tab gone warns distinctly and rolls back the orphan tab", async () => {
-  // The agent never registers AND its tab is gone → a genuine spawn failure (herdr never kept
-  // the tab). Only then does resolveStartedAgent throw and start() roll the orphan tab back.
-  const calls: string[][] = [];
-  const runner = (args: string[]): string => {
-    calls.push(args);
-    if (args[0] === "workspace" && args[1] === "list") return WORKSPACE_LIST;
-    if (args[0] === "tab" && args[1] === "create") return TAB_CREATE;
-    if (args[0] === "agent" && args[1] === "start") return "{}";
-    if (args[0] === "agent" && args[1] === "list") return EMPTY_LIST; // never registers
-    if (args[0] === "tab" && args[1] === "list") return EMPTY_TABS; // tab is gone too
-    return "{}";
-  };
-  const warnings: string[] = [];
-  const origWarn = console.warn;
-  console.warn = (...a: unknown[]) => {
-    warnings.push(a.map(String).join(" "));
-  };
-  try {
-    const d = new HerdrDriver(runner, async (a) => runner(a), 3, 0);
-    await expect(d.start("flatten", "/wt/a", ["claude", "go"])).rejects.toThrow(
-      /started agent not found and tab gone for tab t_new/,
-    );
-  } finally {
-    console.warn = origWarn;
-  }
-  // distinct exhaustion signal (herdr-health), not a silent first-try success
-  expect(
-    warnings.some((w) => w.includes("agent resolve exhausted and tab t_new gone after 3 attempts")),
-  ).toBe(true);
-  expect(calls).toContainEqual(["tab", "close", "t_new"]); // orphan tab rolled back
-});
-
-test("start: agent never registers but its tab persists (exec spawn exited) → returns started, no rollback", async () => {
-  // A non-interactive `codex exec` runs to completion and EXITS, dropping it from `agent list`
-  // while its tab husk lingers. That is a successful spawn that already ran (and may have written
-  // its verdict), NOT a failure — throwing error-spawn here would wrongly delete its worktree.
-  // resolveStartedAgent must return a started handle (empty terminal id) and NOT roll back the
-  // tab (a running-but-unregistered agent would be killed by the close).
-  const calls: string[][] = [];
-  const runner = (args: string[]): string => {
-    calls.push(args);
-    if (args[0] === "workspace" && args[1] === "list") return WORKSPACE_LIST;
-    if (args[0] === "tab" && args[1] === "create") return TAB_CREATE;
-    if (args[0] === "agent" && args[1] === "start") return "{}";
-    if (args[0] === "agent" && args[1] === "list") return EMPTY_LIST; // never in the live list
-    if (args[0] === "tab" && args[1] === "list") return TAB_LIST_WITH_NEW; // but the tab husk persists
-    return "{}";
-  };
-  const d = new HerdrDriver(runner, async (a) => runner(a), 3, 0);
   const agent = await d.start("flatten", "/wt/a", ["codex", "exec", "go"]);
-  expect(agent.tabId).toBe("t_new");
-  expect(agent.terminalId).toBe(""); // completed exec has no live terminal; herdr.stop("") is a no-op
-  expect(calls).not.toContainEqual(["tab", "close", "t_new"]); // NOT rolled back
-});
 
-test("start: the read-back runs OUTSIDE the serializer — a slow resolve doesn't block the next start", async () => {
-  // If the resolve were inside serializeStart, start #2's orchestration could not begin until
-  // start #1's retry finished. Here #1's agent registers only AFTER #2 completes, yet #2 still
-  // finishes first — proving the read-back holds no start mutex. (Old in-mutex code deadlocks.)
-  let tabSeq = 0;
-  let p2done = false;
-  const makeTabCreate = (): string => {
-    const id = `t_new${++tabSeq}`;
-    return JSON.stringify({
-      result: {
-        type: "tab_created",
-        tab: { tab_id: id, workspace_id: "w1" },
-        root_pane: { pane_id: `pr${tabSeq}`, tab_id: id },
-      },
-    });
-  };
-  const listReply = (): string => {
-    const agents: Record<string, string>[] = [
-      {
-        agent: "claude",
-        agent_status: "working",
-        cwd: "/wt/b",
-        name: "two",
-        pane_id: "p2",
-        tab_id: "t_new2",
-        terminal_id: "term_2",
-        workspace_id: "w1",
-      },
-    ];
-    if (p2done)
-      agents.unshift({
-        agent: "claude",
-        agent_status: "working",
-        cwd: "/wt/a",
-        name: "one",
-        pane_id: "p1",
-        tab_id: "t_new1",
-        terminal_id: "term_1",
-        workspace_id: "w1",
-      });
-    return JSON.stringify({ result: { type: "agent_list", agents } });
-  };
-  const runner = (args: string[]): string => {
-    if (args[0] === "workspace" && args[1] === "list") return WORKSPACE_LIST;
-    if (args[0] === "tab" && args[1] === "create") return makeTabCreate();
-    if (args[0] === "agent" && args[1] === "start") return "{}";
-    if (args[0] === "agent" && args[1] === "list") return listReply();
-    return "{}";
-  };
-  const d = new HerdrDriver(runner, async (a) => runner(a), 20, 20); // #1 keeps polling ~for a while
-  const order: string[] = [];
-  const p1 = d.start("one", "/wt/a", ["claude", "go"]).then((a) => {
-    order.push("p1");
-    return a;
-  });
-  const p2 = d.start("two", "/wt/b", ["claude", "go"]).then((a) => {
-    p2done = true; // #1's agent becomes resolvable only now
-    order.push("p2");
-    return a;
-  });
-  const [a1, a2] = await Promise.all([p1, p2]);
-  expect(a2.terminalId).toBe("term_2");
-  expect(a1.terminalId).toBe("term_1");
-  expect(order[0]).toBe("p2"); // #2 finished before #1's retry — resolve is not serialized
+  expect(agent).toMatchObject({ terminalId: "term_started", tabId: "t_new" });
+  expect(tabPresent).toBe(false);
+  expect(calls.some((c) => c[0] === "agent" && c[1] === "list")).toBe(false);
+  expect(calls.some((c) => c[0] === "tab" && c[1] === "list")).toBe(false);
 });
 
 const TAB_LIST = JSON.stringify({
@@ -940,25 +819,6 @@ const SQUATTER_LIST = JSON.stringify({
   },
 });
 
-// Agent list after the squatter is evicted: the freshly started agent appears at /wt/a
-const POST_EVICT_LIST = JSON.stringify({
-  result: {
-    type: "agent_list",
-    agents: [
-      {
-        agent: "claude",
-        agent_status: "working",
-        cwd: "/wt/a",
-        name: "review TASK-504",
-        pane_id: "p_new",
-        tab_id: "t_new",
-        terminal_id: "term_started",
-        workspace_id: "w1",
-      },
-    ],
-  },
-});
-
 function makeNameTakenError(): Error {
   return Object.assign(new Error("herdr CLI error"), { stderr: NAME_TAKEN_JSON });
 }
@@ -966,9 +826,6 @@ function makeNameTakenError(): Error {
 test("start: single collision then success — squatter tab closed, agent returned", async () => {
   const calls: string[][] = [];
   let agentStartAttempts = 0;
-  // list() returns squatter on first call (during eviction), then the fresh agent
-  let listCallCount = 0;
-
   const runner = (args: string[]) => {
     calls.push(args);
     if (args[0] === "workspace" && args[1] === "list") return WORKSPACE_LIST;
@@ -976,12 +833,10 @@ test("start: single collision then success — squatter tab closed, agent return
     if (args[0] === "agent" && args[1] === "start") {
       agentStartAttempts++;
       if (agentStartAttempts === 1) throw makeNameTakenError();
-      return "{}";
+      return AGENT_STARTED;
     }
     if (args[0] === "agent" && args[1] === "list") {
-      listCallCount++;
-      // first list() call is during eviction (resolves squatter), second is the final resolve
-      return listCallCount === 1 ? SQUATTER_LIST : POST_EVICT_LIST;
+      return SQUATTER_LIST;
     }
     if (args[0] === "tab" && args[1] === "close") return "{}";
     if (args[0] === "pane" && args[1] === "close") return "{}";
@@ -1002,8 +857,6 @@ test("start: single collision then success — squatter tab closed, agent return
 test("start: two collisions then success — bounded retry recovers, squatter evicted each time", async () => {
   const calls: string[][] = [];
   let agentStartAttempts = 0;
-  let listCallCount = 0;
-
   const runner = (args: string[]) => {
     calls.push(args);
     if (args[0] === "workspace" && args[1] === "list") return WORKSPACE_LIST;
@@ -1011,12 +864,10 @@ test("start: two collisions then success — bounded retry recovers, squatter ev
     if (args[0] === "agent" && args[1] === "start") {
       agentStartAttempts++;
       if (agentStartAttempts < 3) throw makeNameTakenError();
-      return "{}";
+      return AGENT_STARTED;
     }
     if (args[0] === "agent" && args[1] === "list") {
-      listCallCount++;
-      // first two list() calls are squatter evictions; third is final resolve
-      return listCallCount < 3 ? SQUATTER_LIST : POST_EVICT_LIST;
+      return SQUATTER_LIST;
     }
     if (args[0] === "tab" && args[1] === "close") return "{}";
     if (args[0] === "pane" && args[1] === "close") return "{}";

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -282,6 +282,35 @@ test("consider re-reviews an error verdict even when the plan hash is unchanged"
   expect(status).toBe("started");
   expect(h.started.length).toBe(1); // an error verdict is retried, not deduped away
 });
+test("consider persists reviewer ownership before asking Herdr to start it", async () => {
+  const events: string[] = [];
+  const rows: any[] = [];
+  const h = harness({
+    store: {
+      recordReviewerSpawn: (row: any) => {
+        rows.push(row);
+        events.push("record");
+      },
+    },
+    herdr: {
+      start: async () => {
+        events.push("start");
+        return { terminalId: "t1" };
+      },
+      async stop() {},
+      list: () => [],
+    },
+  });
+
+  expect(await h.svc.consider(planningSession() as any)).toBe("started");
+  expect(events).toEqual(["record", "start"]);
+  expect(rows[0]).toMatchObject({
+    taskSessionId: "s1",
+    kind: "plan_gate",
+    worktreePath: "/wt-detached",
+    spawnedAt: 1000,
+  });
+});
 test("consider reports 'error-spawn' (not a dedupe) when the reviewer fails to spawn", async () => {
   const h = harness({
     herdr: {
@@ -294,6 +323,10 @@ test("consider reports 'error-spawn' (not a dedupe) when the reviewer fails to s
   const status = await h.svc.consider(planningSession() as any);
   expect(status).toBe("error-spawn"); // UI shows a failure note, not "plan unchanged"
   expect(h.started.length).toBe(0);
+  expect(h.recordedSpawns.length).toBe(1); // ownership exists before the launch attempt
+  expect(h.completedSpawns).toHaveLength(1); // confirmed launch failure closes the row
+  expect(h.completedSpawns[0].id).toBe(h.recordedSpawns[0].reviewerSessionId);
+  expect(h.completedSpawns[0].u.total).toBe(0);
   expect(h.removed).toEqual(["/wt-detached"]); // the detached worktree is reaped on failure
 });
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -646,7 +646,7 @@
   "planpanel_review_plan_unavailable": "Prüfung nicht gestartet, weil .shepherd-plan.md fehlt, leer oder nicht lesbar ist.",
   "planpanel_review_nothing_to_review": "Planprüfung konnte gerade nicht gestartet werden.",
   "planpanel_review_failed": "Prüfung konnte nicht gestartet werden. Bitte erneut versuchen.",
-  "planpanel_review_failed_spawn": "Prüfer konnte nicht gestartet werden – der Agent-Host ist ausgelastet. Bitte gleich erneut versuchen.",
+  "planpanel_review_failed_spawn": "Start des Prüfers fehlgeschlagen. Bitte erneut versuchen; falls das Problem bleibt, prüfe die Shepherd-Logs.",
   "planpanel_review_failed_worktree": "Prüf-Workspace konnte nicht erstellt werden. Speicherplatz und Git prüfen, dann erneut versuchen.",
   "planpanel_review_failed_auth": "Für die Prüfung wird ein API-Schlüssel benötigt, es ist aber keiner konfiguriert.",
   "planpanel_status_ready": "Plan freigegeben. Starte die Ausführung, wenn bereit.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -646,7 +646,7 @@
   "planpanel_review_plan_unavailable": "Review did not start because .shepherd-plan.md is missing, empty, or unreadable.",
   "planpanel_review_nothing_to_review": "Couldn't start a plan review right now.",
   "planpanel_review_failed": "Couldn't start the review. Please try again.",
-  "planpanel_review_failed_spawn": "Couldn't start the reviewer — the agent host is busy. Try again in a moment.",
+  "planpanel_review_failed_spawn": "Reviewer launch failed. Try again; if the problem continues, check Shepherd's logs.",
   "planpanel_review_failed_worktree": "Couldn't create the review workspace. Check disk space and git, then retry.",
   "planpanel_review_failed_auth": "Review needs an API key, but none is configured.",
   "planpanel_status_ready": "Plan approved. Start execution when ready.",

--- a/ui/src/lib/components/PlanPanel.browser.test.ts
+++ b/ui/src/lib/components/PlanPanel.browser.test.ts
@@ -523,12 +523,13 @@ describe("PlanPanel release state", () => {
     await expect.element(page.getByText(m.planpanel_review_plan_unavailable())).toBeVisible();
   });
 
-  it("names a busy agent host when the reviewer spawn fails", async () => {
+  it("reports reviewer launch failure without claiming host saturation", async () => {
     const id = "s-review-error-spawn";
     vi.mocked(reviewPlan).mockResolvedValue("error-spawn");
     render(PlanPanel, { props: { session: session({ id }), onclose: vi.fn() } });
     await page.getByRole("button", { name: m.planpanel_review_now() }).click();
     await expect.element(page.getByText(m.planpanel_review_failed_spawn())).toBeVisible();
+    expect(m.planpanel_review_failed_spawn().toLowerCase()).not.toContain("busy");
   });
 
   it("names the review workspace when worktree creation fails", async () => {


### PR DESCRIPTION
## Problem

A successful plan-reviewer launch could be reported as `error-spawn` when a fast Codex role disappeared from `agent list` before Shepherd finished startup orchestration. Shepherd discarded the authoritative `herdr agent start` response, closed the root pane, and then tried to rediscover the reviewer. If closing the root pane removed the tab, the launch was forgotten, its detached worktree was deleted, and the UI incorrectly claimed that the agent host was busy.

## Solution

- Keep and validate `result.agent` from the successful CLI `agent start` response before root-pane cleanup.
- Remove the eventually-consistent post-start `agent list` / `tab list` lookup as the source of launch truth.
- Persist the `reviewer_spawns` ownership row before asking Herdr to launch, so restart adoption can recover the run.
- Complete failed launch records explicitly and only remove the worktree after a confirmed launch failure.
- Replace the host-saturation claim with an accurate reviewer-launch failure message in English and German.

## Technical details

The CLI-backed Herdr driver now matches the socket-backed path: both parse the returned `AgentInfo` into the existing `HerdrAgent` type. The lifecycle regression test models tab creation, a successful agent response, root-pane closure removing the tab, and absent list entries; it verifies that no rediscovery call can turn that success into a failure.

Plan-gate persistence now records the reviewer session ID, worktree, provider, model, effort, and timestamp before launch. A thrown launch closes that same row with zero usage and cleans the worktree; a server restart can adopt an uncompleted row before stale-worktree GC runs. Reaper documentation and tests pin the revised ownership invariant.

## Verification

- Pre-push hook: all 7 lanes passed (Root tests, UI tests, Extension check, TypeScript, ESLint, formatting, repository gates)
- Focused Herdr / plan-gate / reaper suite: 226 passed
- PlanPanel browser suite: 29 passed
- i18n parity: English and German catalogs aligned
- Branch hygiene: linear and rebased on current `origin/main`

Closes #1740
