### PR TITLE
fix(ui): sort clone-repo list alphabetically

### DIFF
--- a/ui/src/lib/components/CloneRepo.browser.test.ts
+++ b/ui/src/lib/components/CloneRepo.browser.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import CloneRepo from "./CloneRepo.svelte";
+import type { GithubRepo } from "$lib/api";
+
+const getGithubRepos =
+  vi.fn<() => Promise<{ repos: GithubRepo[]; login: string; available: true }>>();
+
+vi.mock("$lib/api", async (orig) => ({
+  ...((await orig()) as object),
+  getGithubRepos: () => getGithubRepos(),
+}));
+
+function repo(nameWithOwner: string): GithubRepo {
+  const [owner, name] = nameWithOwner.split("/");
+  return {
+    nameWithOwner,
+    owner,
+    name,
+    url: `https://github.com/${nameWithOwner}.git`,
+    isPrivate: false,
+    isFork: false,
+    isArchived: false,
+    pushedAt: null,
+    cloned: false,
+  };
+}
+
+describe("CloneRepo", () => {
+  it("lists each owner's repos alphabetically, not in the server's most-recently-pushed order", async () => {
+    // Server order is by push recency — deliberately un-alphabetical, and interleaved
+    // across owners so grouping and sorting are both exercised.
+    getGithubRepos.mockResolvedValue({
+      repos: [repo("me/zeta"), repo("acme/widget"), repo("me/alpha"), repo("acme/anvil")],
+      login: "me",
+      available: true,
+    });
+
+    render(CloneRepo, { props: { ondone: vi.fn() } });
+
+    await expect.element(page.getByRole("button", { name: "alpha" })).toBeVisible();
+
+    const rows = [...document.querySelectorAll(".repolist .repo .rname")].map((e) => e.textContent);
+    // Own account first (alphabetical within), then the org (alphabetical within).
+    expect(rows).toEqual(["alpha", "zeta", "anvil", "widget"]);
+  });
+});

--- a/ui/src/lib/components/CloneRepo.svelte
+++ b/ui/src/lib/components/CloneRepo.svelte
@@ -48,7 +48,9 @@
   });
 
   // Not-yet-cloned repos that match the filter, grouped by owner with the user's own
-  // account first, then the teams/orgs they belong to (alphabetical).
+  // account first, then the teams/orgs they belong to (alphabetical). Repos inside a
+  // group are alphabetical too — the server returns them most-recently-pushed first,
+  // which is unscannable in a long list.
   const groups = $derived.by(() => {
     const q = query.trim().toLowerCase();
     const visible = repos.filter(
@@ -70,7 +72,11 @@
       }
       return a.localeCompare(b);
     });
-    return owners.map((owner) => ({ owner, isSelf: owner === login, repos: byOwner[owner] }));
+    return owners.map((owner) => ({
+      owner,
+      isSelf: owner === login,
+      repos: byOwner[owner].sort((a, b) => a.name.localeCompare(b.name)),
+    }));
   });
 
   const hasVisible = $derived(groups.length > 0);


### PR DESCRIPTION
## What

The clone-repo picker rendered each owner's repos in the order the server returned them — `src/repos.ts` lists via `user/repos?...&sort=pushed`, i.e. most-recently-pushed first. Owners were already sorted (own account first, then orgs alphabetically), but the repos *inside* each group weren't, which makes a long list unscannable.

Now the repos within each owner group are sorted by name (`localeCompare`). The group arrays are built fresh inside the `$derived`, so the in-place sort doesn't mutate the `repos` state array.

## Test

New `ui/src/lib/components/CloneRepo.browser.test.ts` feeds a deliberately push-ordered, cross-owner list and asserts the rendered rows come out `alpha, zeta, anvil, widget`. Verified red before the fix (`expected [ 'zeta', 'alpha', 'widget', 'anvil' ]`) and green after.

`bun run check`, `bun run check:i18n`, and the new test all pass. No user-facing new capability, so no feature-catalog entry. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)