### PR TITLE
fix: don't report a slow-but-successful epic approve as a failure

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -7335,10 +7335,24 @@ export function pickTerminalBridgeKind(opts: {
     : "node-pty";
 }
 
-/** The /usage refresh handler drives a multi-second ephemeral `claude` scrape and needs a longer
- *  idle window than Bun's 10s default (see the fetch handler). */
-const isSlowScrapeRequest = (req: Request, url: URL): boolean =>
-  req.method === "POST" && url.pathname === "/api/usage/refresh";
+/** Per-route idle budget (seconds) for the handful of routes that legitimately outrun Bun's 10s
+ *  default; `null` leaves a route on that default. Applied per-request via `server.timeout` in the
+ *  fetch handler — deliberately NOT a global `idleTimeout`, which would make every route hold a
+ *  stalled socket for the same window (and would cap /usage/refresh below its own budget).
+ *
+ *  - /usage/refresh drives an ephemeral `claude` scrape (~24s worst case: boot + week wait + credits
+ *    grace); a reset connection there shows a false "Retry" on the gauge.
+ *  - epic-draft/approve materializes the epic into GitHub: one createIssue per child + the parent +
+ *    one native sub-issue link each + buildEpic — ~25 sequential round-trips for a 12-child epic,
+ *    which blows past 10s. Bun then severs the socket while the handler keeps running to completion,
+ *    so the operator saw a bogus failure for an approve that had actually succeeded. 255 is Bun's
+ *    ceiling for both `idleTimeout` and `server.timeout`. */
+export const slowRequestTimeoutSec = (req: Request, url: URL): number | null => {
+  if (req.method !== "POST") return null;
+  if (url.pathname === "/api/usage/refresh") return 60;
+  if (/^\/api\/sessions\/[^/]+\/epic-draft\/approve$/.test(url.pathname)) return 255;
+  return null;
+};
 
 export function serve(deps: AppDeps, port: number) {
   const app = makeApp(deps);
@@ -7402,10 +7416,10 @@ export function serve(deps: AppDeps, port: number) {
           ? undefined
           : new Response("upgrade failed", { status: 500 });
       }
-      // /usage refresh drives an ephemeral claude scrape (~24s worst case: boot + week wait +
-      // credits grace); lift Bun's 10s idle timeout for just this request so a slow scrape can't
-      // reset the connection into a false "Retry" on the gauge. Insurance — other endpoints unchanged.
-      if (isSlowScrapeRequest(req, url)) server.timeout(req, 60);
+      // Lift Bun's 10s idle timeout for the known-slow routes (see slowRequestTimeoutSec) so a long
+      // handler can't have its connection reset out from under it. Other endpoints unchanged.
+      const slowSec = slowRequestTimeoutSec(req, url);
+      if (slowSec !== null) server.timeout(req, slowSec);
       return app.fetch(req);
     },
     websocket: {

--- a/test/epic-draft-api.test.ts
+++ b/test/epic-draft-api.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { makeApp, type AppDeps } from "../src/server";
+import { makeApp, slowRequestTimeoutSec, type AppDeps } from "../src/server";
 import { SessionStore } from "../src/store";
 import { EventHub } from "../src/events";
 import { config } from "../src/config";
@@ -200,4 +200,22 @@ test("a failed materialize reverts the draft to 'draft' so a retry can resume", 
   const res = await approve(app, s.id);
   expect(res.status).toBe(500);
   expect(store.getEpicDraft(s.id)?.status).toBe("draft"); // reverted, not stuck at materializing
+});
+
+// The approve request itself outruns Bun's 10s default idle timeout (~25 sequential GitHub calls for
+// a 12-child epic), so `serve()` lifts it per-request. Guard the route matching: a rename here would
+// silently sever the socket mid-materialize again, and the operator would see a bogus failure for an
+// approve that actually succeeded.
+test("slowRequestTimeoutSec budgets the known-slow routes and leaves others on the default", () => {
+  const sec = (method: string, path: string) =>
+    slowRequestTimeoutSec(new Request(`http://x${path}`, { method }), new URL(`http://x${path}`));
+
+  expect(sec("POST", "/api/sessions/abc-123/epic-draft/approve")).toBe(255); // Bun's ceiling
+  expect(sec("POST", "/api/usage/refresh")).toBe(60); // pre-existing budget, unchanged
+
+  // Everything else keeps the 10s default — including the draft's other verbs and near-miss paths.
+  expect(sec("GET", "/api/sessions/abc-123/epic-draft/approve")).toBeNull();
+  expect(sec("POST", "/api/sessions/abc-123/epic-draft")).toBeNull();
+  expect(sec("POST", "/api/sessions/abc-123/epic-draft/approve/extra")).toBeNull();
+  expect(sec("POST", "/api/sessions")).toBeNull();
 });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3124,5 +3124,6 @@
   "feat_mobile_herd_accordion_title": "Lebenszyklus-Gruppen mobil einklappen",
   "feat_mobile_herd_accordion_body": "Die Herd-Liste auf dem Smartphone hält jetzt höchstens eine benannte Lebenszyklus-Gruppe offen. „Du bist dran“ ist standardmäßig geöffnet; tippe auf eine größere Gruppenzeile, um den Bereich zu wechseln oder zu schließen, während aktive Sessions sichtbar bleiben.",
   "feat_review_job_model_title": "Sieh, welches Modell prüft",
-  "feat_review_job_model_body": "Das Review-Banner im Terminal zeigt jetzt Coding-CLI, Modell und Aufwand von Plan-Gate- und PR-Critic-Jobs, damit ihre Umgebung klar von der Task-Session unterscheidbar ist."
+  "feat_review_job_model_body": "Das Review-Banner im Terminal zeigt jetzt Coding-CLI, Modell und Aufwand von Plan-Gate- und PR-Critic-Jobs, damit ihre Umgebung klar von der Task-Session unterscheidbar ist.",
+  "epicdraft_approve_in_progress": "Epic wird noch erstellt — das dauert etwas. Es erscheint hier, sobald es fertig ist."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3124,5 +3124,6 @@
   "feat_mobile_herd_accordion_title": "Fold lifecycle groups on mobile",
   "feat_mobile_herd_accordion_body": "The phone herd now keeps only one named lifecycle group open at a time. Your turn opens by default; tap any larger group header to switch or close it while active sessions stay visible.",
   "feat_review_job_model_title": "See which model is reviewing",
-  "feat_review_job_model_body": "The terminal review banner now shows the coding CLI, model and effort used by both Plan Gate and PR critic jobs, so their environment is distinct from the task session."
+  "feat_review_job_model_body": "The terminal review banner now shows the coding CLI, model and effort used by both Plan Gate and PR critic jobs, so their environment is distinct from the task session.",
+  "epicdraft_approve_in_progress": "Still creating the epic — this is taking a while. It'll appear here when it lands."
 }

--- a/ui/src/lib/api.previewBlocked.test.ts
+++ b/ui/src/lib/api.previewBlocked.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { createSession, isPreviewBlocked } from "./api";
+import {
+  ApiError,
+  createSession,
+  isPreviewBlocked,
+  relaunchSession,
+  restoreSession,
+  uploadScratchpadFile,
+} from "./api";
 import type { CreateInput } from "./types";
 
 function mockFetch(status: number, body: unknown): typeof fetch {
@@ -53,5 +60,64 @@ describe("preview-origin blocked detection", () => {
     // Remapped to a translated sentence — not the raw server string.
     expect(err!.message.length).toBeGreaterThan(0);
     expect(err!.message).not.toBe("forbidden: origin host not allowed");
+  });
+});
+
+// The re-wrap sites (upload / relaunch / restore) rebuild an ApiError to attach a `code`. Each must
+// first re-throw a PreviewBlockedError untouched — re-wrapping it as a plain ApiError silently
+// strips the class, and every isPreviewBlocked() caller then misclassifies the 403 as a real failure.
+describe("re-wrap sites preserve PreviewBlockedError", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it.each([
+    ["restoreSession", () => restoreSession("s1")],
+    ["relaunchSession", () => relaunchSession("s1", {} as never)],
+    ["uploadScratchpadFile", () => uploadScratchpadFile("s1", new File(["x"], "x.txt"))],
+  ])("%s keeps the preview-origin 403 a PreviewBlockedError", async (_label, call) => {
+    globalThis.fetch = mockFetch(403, { error: "forbidden: origin not allowed" });
+    const err = await call().then(
+      () => null,
+      (e) => e as Error,
+    );
+    expect(isPreviewBlocked(err)).toBe(true);
+  });
+});
+
+// `serverAuthored` gates whether a caller may show `message` to a human, so its definition has to
+// hold at every construction site: a body-less response must NOT masquerade as a server message.
+describe("ApiError.serverAuthored provenance", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  const restoreErr = async (status: number, body: unknown) => {
+    globalThis.fetch = mockFetch(status, body);
+    return (await restoreSession("s1").then(
+      () => null,
+      (e) => e,
+    )) as ApiError;
+  };
+
+  it("is true for a real server message", async () => {
+    const err = await restoreErr(400, { error: "no active workspace" });
+    expect(err.serverAuthored).toBe(true);
+    expect(err.message).toBe("no active workspace");
+  });
+
+  it("is false for a body-less response — the fallback is a plumbing string", async () => {
+    const err = await restoreErr(502, null);
+    expect(err.serverAuthored).toBe(false);
+    expect(err.message).toBe("restore failed: 502");
+  });
+
+  // An empty message is no message: honouring it would render a blank toast.
+  it("is false for an empty server message, and falls back", async () => {
+    const err = await restoreErr(500, { error: "" });
+    expect(err.serverAuthored).toBe(false);
+    expect(err.message).toBe("restore failed: 500");
   });
 });

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -114,7 +114,19 @@ export function isPreviewBlocked(e: unknown): boolean {
 
 /** Build an Error from a failed response body. A `403` carrying the server's
  *  preview-origin rejection becomes a translated {@link PreviewBlockedError}; every
- *  other failure becomes a plain Error preferring the server `{error}` over `fallback`. */
+ *  other failure becomes an {@link ApiError} preferring the server `{error}` over `fallback`.
+ *
+ *  `serverAuthored` records the PROVENANCE of the message: true when it came from the response
+ *  body (or is one of the translated 403s), false when `fallback` — the bare
+ *  `"<label> failed: <status>"` plumbing string — was used because the response carried no body.
+ *  A caller that surfaces `e.message` to a human MUST gate on it: a proxy 502/504 (or any severed
+ *  upstream) yields a bodyless response, and rendering that fallback verbatim shows the operator
+ *  "epic-draft approve failed: 502" instead of a real cause. Status alone can't stand in for this —
+ *  a 500 from a handler that catches and reports (`{error: e.message}`) is genuinely informative.
+ *
+ *  An EMPTY `{error: ""}` counts as no message, not as an empty server-authored one: a handler that
+ *  forwards `e.message` verbatim (e.g. approve's 500, src/server.ts) can emit one, and honouring it
+ *  would render a BLANK toast instead of the generic failure. Hence the truthiness check. */
 function apiError(
   status: number,
   body: { error?: string } | null | undefined,
@@ -125,9 +137,9 @@ function apiError(
     return new PreviewBlockedError(m.error_preview_readonly());
   }
   if (status === 403 && body?.error === ORIGIN_HOST_BLOCK) {
-    return new Error(m.error_origin_host_not_allowed());
+    return new ApiError(status, m.error_origin_host_not_allowed(), undefined, true);
   }
-  return new Error(body?.error ?? fallback);
+  return new ApiError(status, body?.error || fallback, undefined, !!body?.error);
 }
 
 /** A failed API call that carries the HTTP `status` and the server's stable `code`
@@ -136,12 +148,22 @@ function apiError(
 export class ApiError extends Error {
   status: number;
   code?: string;
-  constructor(status: number, message: string, code?: string) {
+  /** Whether `message` came from the server (a `{error}` body) rather than the bare
+   *  `"<label> failed: <status>"` fallback. Gate on this before showing `message` to a human —
+   *  see {@link apiError}. */
+  serverAuthored: boolean;
+  constructor(status: number, message: string, code?: string, serverAuthored = false) {
     super(message);
     this.status = status;
     this.code = code;
+    this.serverAuthored = serverAuthored;
   }
 }
+
+/** Provenance of an error built by {@link apiError}, for the re-wrap sites that rebuild an
+ *  {@link ApiError} to attach a `code`. Read it off the built error rather than re-deriving it from
+ *  the body, so "server authored" has exactly one definition and cannot drift between call sites. */
+const serverAuthored = (e: Error): boolean => e instanceof ApiError && e.serverAuthored;
 
 /** Build an Error from a failed response, preferring the server's `{error}` body
  *  (e.g. "no active workspace") over the bare status code so the UI shows the real
@@ -688,7 +710,9 @@ export async function uploadScratchpadFile(
   const r = await fetch(`/api/sessions/${id}/scratchpad/upload${q}`, { method: "POST", body: fd });
   if (!r.ok) {
     const body = (await r.json().catch(() => null)) as { error?: string } | null;
-    throw new ApiError(r.status, body?.error ?? `upload failed: ${r.status}`);
+    // No `code` to attach here, so `base` (already an ApiError, or a PreviewBlockedError) is exactly
+    // what a re-wrap would produce.
+    throw apiError(r.status, body, `upload failed: ${r.status}`);
   }
   return (await r.json()).path as string;
 }
@@ -899,7 +923,7 @@ export async function relaunchSession(
   // the rest of the API; for every other failure carry status + code to the caller.
   const base = apiError(r.status, body, `relaunch failed: ${r.status}`);
   if (isPreviewBlocked(base)) throw base;
-  throw new ApiError(r.status, base.message, body?.code);
+  throw new ApiError(r.status, base.message, body?.code, serverAuthored(base));
 }
 
 export type HandoffMode = "resume" | "summarize";
@@ -962,7 +986,8 @@ export async function restoreSession(id: string): Promise<Session> {
   if (r.ok) return r.json();
   const body = (await r.json().catch(() => null)) as { error?: string; code?: string } | null;
   const base = apiError(r.status, body, `restore failed: ${r.status}`);
-  throw new ApiError(r.status, base.message, body?.code);
+  if (isPreviewBlocked(base)) throw base; // else the 403 loses its PreviewBlockedError class
+  throw new ApiError(r.status, base.message, body?.code, serverAuthored(base));
 }
 
 /**

--- a/ui/src/lib/components/EpicDraftModal.svelte
+++ b/ui/src/lib/components/EpicDraftModal.svelte
@@ -2,7 +2,8 @@
   import type { EpicDraftChild } from "$lib/types";
   import { dialog } from "$lib/a11yDialog";
   import { epicDrafts } from "$lib/epic-draft.svelte";
-  import { approveEpicDraft, replySession, archiveSession } from "$lib/api";
+  import { replySession, archiveSession } from "$lib/api";
+  import { approveEpic } from "$lib/epic-approve";
   import { toasts } from "$lib/toasts.svelte";
   import { m } from "$lib/paraglide/messages";
   import EpicDraftChildRow from "$lib/components/EpicDraftChildRow.svelte";
@@ -37,16 +38,13 @@
 
   async function approve() {
     if (approving) return;
+    // Capture the session: this dialog can close (and Viewport closes it on a session switch) long
+    // before a ~25s materialize returns. approveEpic owns the outcome from here — it lives outside
+    // the component tree precisely so the result is still reported if this modal is gone.
+    const sid = sessionId;
     approving = true;
     try {
-      const r = await approveEpicDraft(sessionId);
-      toasts.info(m.epicdraft_approve_success({ n: r.parentNumber }));
-    } catch (e) {
-      toasts.info(e instanceof Error ? e.message : m.epicdraft_approve_failed(), {
-        key: `epicdraft-approve-${sessionId}`,
-        sticky: true,
-        alert: true,
-      });
+      await approveEpic(sid);
     } finally {
       approving = false;
     }

--- a/ui/src/lib/epic-approve.test.ts
+++ b/ui/src/lib/epic-approve.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { EpicDraft } from "./types";
+import { epicDrafts } from "./epic-draft.svelte";
+import { toasts } from "./toasts.svelte";
+import { m } from "./paraglide/messages";
+import * as api from "./api";
+import { approveEpic, __resetAwaiting } from "./epic-approve";
+
+// Mock only the network boundaries; ApiError + isPreviewBlocked stay REAL — the reconcile
+// discriminates on them, so stubbing them would test the mock instead of the code.
+vi.mock("./api", async (importOriginal) => ({
+  ...(await importOriginal<typeof api>()),
+  approveEpicDraft: vi.fn(),
+  getEpicDraft: vi.fn(),
+}));
+
+function draft(sessionId: string, status: EpicDraft["status"]): EpicDraft {
+  return {
+    sessionId,
+    parent: { title: "t", body: "b", acceptanceCriteria: [], nonGoals: [] },
+    children: [{ key: "c1", title: "Child", body: "b", acceptanceCriteria: [], blockedBy: [] }],
+    status,
+    materializedChildren: {},
+    parentNumber: status === "approved" ? 13 : null,
+    parentUrl: status === "approved" ? "https://example.test/13" : null,
+  };
+}
+
+/** The bodyless-response fallback `apiError` builds when a proxy 502s a severed socket. A plain
+ *  Error — NOT a TypeError — which is exactly why "not a TypeError" cannot gate the message. */
+const proxy502 = () => new Error("epic-draft approve failed: 502");
+const networkDrop = () => new TypeError("Failed to fetch");
+
+const text = () => toasts.items.map((t) => t.text);
+const last = () => toasts.items[toasts.items.length - 1]?.text;
+
+// A fresh session id per test. The toast store's keyed-dedupe map OUTLIVES a test (only `items` is
+// reset), so reusing an id would make a toast dedupe against the previous test's entry — refreshing
+// a row that is no longer in `items` — and silently emit nothing at all.
+let n = 0;
+const nextSid = () => `s-${++n}`;
+
+describe("approveEpic", () => {
+  beforeEach(() => {
+    toasts.items = [];
+    epicDrafts.map = {};
+    __resetAwaiting();
+    vi.mocked(api.approveEpicDraft).mockReset();
+    vi.mocked(api.getEpicDraft).mockReset();
+  });
+
+  it("toasts success on the happy path", async () => {
+    const s1 = nextSid();
+    vi.mocked(api.approveEpicDraft).mockResolvedValue({
+      parentNumber: 13,
+      parentUrl: "u",
+      childNumbers: {},
+    } as never);
+
+    await approveEpic(s1);
+    expect(last()).toBe(m.epicdraft_approve_success({ n: 13 }));
+  });
+
+  // A throw does NOT mean failure: the request can lose its connection while the handler runs on and
+  // commits the epic. The two shapes — bodyless proxy 502 (dev) and fetch TypeError (prod) — must both
+  // reconcile against the SERVER's state, not the throw.
+  it.each([
+    ["bodyless 502", proxy502],
+    ["network TypeError", networkDrop],
+  ])("reports success when %s hid an approve that actually landed", async (_l, thrown) => {
+    const s1 = nextSid();
+    vi.mocked(api.approveEpicDraft).mockRejectedValue(thrown());
+    vi.mocked(api.getEpicDraft).mockResolvedValue(draft(s1, "approved"));
+
+    await approveEpic(s1);
+    expect(last()).toBe(m.epicdraft_approve_success({ n: 13 }));
+  });
+
+  // THE REGRESSION GUARD. Server killed mid-materialize → the orphan-reset row is back at `draft`, and
+  // the thrown proxy 502 is a plain Error. A discriminator of "show e.message unless it's a TypeError"
+  // renders "epic-draft approve failed: 502" straight to the operator — the very string this fix
+  // exists to kill. Only message PROVENANCE (ApiError.serverAuthored) rejects it.
+  it.each([
+    ["bodyless 502", proxy502, "epic-draft approve failed: 502"],
+    ["network TypeError", networkDrop, "Failed to fetch"],
+  ])("shows the generic failure — never the raw %s string", async (_l, thrown, raw) => {
+    const s1 = nextSid();
+    vi.mocked(api.approveEpicDraft).mockRejectedValue(thrown());
+    vi.mocked(api.getEpicDraft).mockResolvedValue(draft(s1, "draft"));
+
+    await approveEpic(s1);
+    expect(last()).toBe(m.epicdraft_approve_failed());
+    expect(last()).not.toContain(raw);
+  });
+
+  // The 500 case guards a status-range rule (`status < 500`) from creeping back in: the handler's 500
+  // carries `{error: e.message}` and is the most informative failure this flow can produce.
+  it.each([
+    [400, "no forge for this repo"],
+    [409, "epic materialize already in progress"],
+    [500, "epic materialize failed: GitHub rate limit exceeded"],
+  ])("surfaces the server-authored %s message", async (status, msg) => {
+    const s1 = nextSid();
+    vi.mocked(api.approveEpicDraft).mockRejectedValue(
+      new api.ApiError(status as number, msg as string, undefined, true),
+    );
+    vi.mocked(api.getEpicDraft).mockResolvedValue(draft(s1, "draft"));
+
+    await approveEpic(s1);
+    expect(last()).toBe(msg);
+  });
+
+  // An empty `{error: ""}` is NOT a server message — honouring it would render a blank toast.
+  it("shows the generic failure for an empty server message, not a blank toast", async () => {
+    const s1 = nextSid();
+    vi.mocked(api.approveEpicDraft).mockRejectedValue(new api.ApiError(500, "", undefined, false));
+    vi.mocked(api.getEpicDraft).mockResolvedValue(draft(s1, "draft"));
+
+    await approveEpic(s1);
+    expect(last()).toBe(m.epicdraft_approve_failed());
+  });
+
+  it.each([
+    ["the refetch throws", () => vi.mocked(api.getEpicDraft).mockRejectedValue(new Error("x"))],
+    ["the session has no draft", () => vi.mocked(api.getEpicDraft).mockResolvedValue(null)],
+  ])("falls back to the generic failure when %s", async (_l, arrange) => {
+    const s1 = nextSid();
+    vi.mocked(api.approveEpicDraft).mockRejectedValue(proxy502());
+    (arrange as () => void)();
+
+    await approveEpic(s1);
+    expect(last()).toBe(m.epicdraft_approve_failed());
+    expect(last()).not.toContain("failed: ");
+  });
+
+  // Every outcome shares one key per session. The failure toast is sticky — it never auto-dismisses —
+  // so without the key a retry's success toast appears BESIDE a pinned "Couldn't create the epic.",
+  // telling the operator two contradictory things at once.
+  it("supersedes a pinned failure toast when the retry succeeds", async () => {
+    const s1 = nextSid();
+    vi.mocked(api.approveEpicDraft).mockRejectedValue(proxy502());
+    vi.mocked(api.getEpicDraft).mockResolvedValue(draft(s1, "draft"));
+    await approveEpic(s1);
+    expect(last()).toBe(m.epicdraft_approve_failed());
+
+    vi.mocked(api.approveEpicDraft).mockResolvedValue({
+      parentNumber: 13,
+      parentUrl: "u",
+      childNumbers: {},
+    } as never);
+    await approveEpic(s1);
+
+    expect(toasts.items).toHaveLength(1); // superseded in place, not stacked
+    expect(last()).toBe(m.epicdraft_approve_success({ n: 13 }));
+  });
+
+  // The response died and the handler is STILL materializing. Its terminal state arrives later over
+  // WS. Without the watcher a subsequent failure would be entirely silent — in the exact scenario this
+  // whole change exists for. The watcher lives outside the component tree, so it keeps working after
+  // the modal that started the approve is closed and the operator has moved to another session.
+  describe("a materialize whose response was lost", () => {
+    let pendingSid = "";
+    beforeEach(() => {
+      pendingSid = nextSid();
+      vi.mocked(api.approveEpicDraft).mockRejectedValue(proxy502());
+      vi.mocked(api.getEpicDraft).mockResolvedValue(draft(pendingSid, "materializing"));
+    });
+
+    it.each([
+      ["failure", "draft" as const, () => m.epicdraft_approve_failed()],
+      ["success", "approved" as const, () => m.epicdraft_approve_success({ n: 13 })],
+    ])("resolves into a %s toast when the WS event lands", async (_l, terminal, expected) => {
+      const s1 = pendingSid;
+      await approveEpic(s1);
+      expect(last()).toBe(m.epicdraft_approve_in_progress());
+
+      epicDrafts.upsert(draft(s1, terminal)); // the WS `session:epic-draft` event
+
+      expect(toasts.items).toHaveLength(1); // superseded its own in-progress toast
+      expect(last()).toBe(expected());
+    });
+
+    // The outcome belongs to the session that started the approve — never to whatever is on screen.
+    it("keys the outcome to the approving session, not another one", async () => {
+      const s1 = pendingSid;
+      epicDrafts.upsert(draft(nextSid(), "draft")); // an unrelated session sitting in `draft`
+      await approveEpic(s1);
+
+      // s2 must not be told its (never-attempted) approve failed.
+      expect(text()).not.toContain(m.epicdraft_approve_failed());
+      expect(toasts.items).toHaveLength(1);
+      expect(toasts.items[0]!.key).toBe(`epicdraft-approve-${s1}`);
+
+      epicDrafts.upsert(draft(s1, "approved"));
+
+      expect(last()).toBe(m.epicdraft_approve_success({ n: 13 }));
+    });
+  });
+});

--- a/ui/src/lib/epic-approve.ts
+++ b/ui/src/lib/epic-approve.ts
@@ -1,0 +1,105 @@
+import { ApiError, approveEpicDraft, isPreviewBlocked } from "./api";
+import { epicDrafts } from "./epic-draft.svelte";
+import { toasts } from "./toasts.svelte";
+import { m } from "./paraglide/messages";
+
+/**
+ * Approving an epic draft, and reporting what it actually did.
+ *
+ * This lives OUTSIDE the component tree on purpose. Materializing an epic runs ~25 sequential GitHub
+ * calls, so the request routinely outlives the UI that started it: EpicDraftModal is mounted under an
+ * `{#if}` and Viewport closes it on a session switch, so any state held there dies exactly when the
+ * outcome finally lands. A module-level singleton outlives the modal, the panel, and the session
+ * selection — so an approve is always reported to the operator, wherever they happen to be looking.
+ *
+ * Every path is keyed by an explicitly-passed session id, never a reactive prop read after an await.
+ */
+
+/** One toast key per session, so each outcome supersedes the last IN PLACE. Without it the failure
+ *  toast — which is sticky, so it never auto-dismisses — stays pinned beside the success toast of the
+ *  retry that fixed it. */
+const toastKey = (sessionId: string) => `epicdraft-approve-${sessionId}`;
+
+const succeeded = (sessionId: string, n: number) =>
+  toasts.info(m.epicdraft_approve_success({ n }), { key: toastKey(sessionId) });
+
+const failed = (sessionId: string, message?: string) =>
+  toasts.info(message ?? m.epicdraft_approve_failed(), {
+    key: toastKey(sessionId),
+    sticky: true,
+    alert: true,
+  });
+
+/** Sessions whose approve is materializing server-side with its response lost — see {@link watch}. */
+const awaiting = new Set<string>();
+
+/** Resolve an approve whose response we never got. The handler keeps running, and its terminal state
+ *  arrives over WS (`session:epic-draft`): `approved`, or `draft` again — the server reverts a failed
+ *  materialize rather than leaving it stuck. The store only upserts that event, so without this a
+ *  failure AFTER the reconcile would be entirely silent: the operator would be left with a pinned
+ *  "still creating…" and no word of what went wrong — the exact hole this reconcile exists to close.
+ *
+ *  A plain store observer, deliberately not an `$effect`: this must keep watching after the modal
+ *  that started the approve has closed and the operator has moved to another session, so it cannot be
+ *  owned by any component's lifecycle. */
+let unsubscribe: (() => void) | null = null;
+function watch(sessionId: string) {
+  awaiting.add(sessionId);
+  unsubscribe ??= epicDrafts.onUpsert((draft) => {
+    const sid = draft.sessionId;
+    if (!awaiting.has(sid)) return;
+
+    if (draft.status === "approved" && draft.parentNumber != null) {
+      succeeded(sid, draft.parentNumber);
+      awaiting.delete(sid);
+    } else if (draft.status === "draft") {
+      // Reverted ⇒ the materialize failed. The response that carried the server's reason died with
+      // the connection, so the generic message is all we honestly have.
+      failed(sid);
+      awaiting.delete(sid);
+    }
+  });
+}
+
+/** A thrown approve does NOT mean the approve failed — the request can lose its connection (a severed
+ *  socket surfaces as a bodyless proxy 502 in dev, a `fetch` TypeError in prod) while the handler runs
+ *  on and commits the whole epic. Re-GET the draft and report what the SERVER did, not what the throw
+ *  implied. */
+async function reconcile(sessionId: string, e: unknown) {
+  const fresh = await epicDrafts.refresh(sessionId).catch(() => undefined);
+
+  if (fresh?.status === "approved" && fresh.parentNumber != null) {
+    succeeded(sessionId, fresh.parentNumber); // it landed after all
+    return;
+  }
+  if (fresh?.status === "materializing") {
+    // Still running. Sticky, because the outcome is still unknown — a self-dismissing toast would
+    // leave the operator believing all is well if it then fails. The watcher replaces it once the WS
+    // event reports how it ended.
+    toasts.info(m.epicdraft_approve_in_progress(), { key: toastKey(sessionId), sticky: true });
+    watch(sessionId);
+    return;
+  }
+
+  // A genuine failure (or we couldn't find out). Surface the thrown message ONLY when the server
+  // authored it — a bodyless response leaves `apiError` holding its "<label> failed: <status>"
+  // fallback, and a network drop throws a TypeError; neither is fit for a human to read.
+  const authored =
+    e instanceof Error && (isPreviewBlocked(e) || (e instanceof ApiError && e.serverAuthored));
+  failed(sessionId, authored ? e.message : undefined);
+}
+
+/** Approve a session's epic draft and toast the outcome. Never throws. */
+export async function approveEpic(sessionId: string): Promise<void> {
+  try {
+    const r = await approveEpicDraft(sessionId);
+    succeeded(sessionId, r.parentNumber);
+  } catch (e) {
+    await reconcile(sessionId, e);
+  }
+}
+
+/** Test seam: forget any pending materialize watch. */
+export function __resetAwaiting() {
+  awaiting.clear();
+}

--- a/ui/src/lib/epic-draft.svelte.test.ts
+++ b/ui/src/lib/epic-draft.svelte.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { EpicDraft } from "./types";
+import { epicDrafts } from "./epic-draft.svelte";
+import * as api from "./api";
+
+vi.mock("./api", async (importOriginal) => ({
+  ...(await importOriginal<typeof api>()),
+  getEpicDraft: vi.fn(),
+}));
+
+function draft(sessionId: string, status: EpicDraft["status"]): EpicDraft {
+  return {
+    sessionId,
+    parent: { title: "t", body: "b", acceptanceCriteria: [], nonGoals: [] },
+    children: [{ key: "c1", title: "Child", body: "b", acceptanceCriteria: [], blockedBy: [] }],
+    status,
+    materializedChildren: {},
+    parentNumber: status === "approved" ? 13 : null,
+    parentUrl: status === "approved" ? "https://example.test/13" : null,
+  };
+}
+
+describe("EpicDraftsStore.refresh", () => {
+  beforeEach(() => {
+    epicDrafts.map = {};
+    vi.mocked(api.getEpicDraft).mockReset();
+  });
+
+  it("upserts the server's row and returns it", async () => {
+    vi.mocked(api.getEpicDraft).mockResolvedValue(draft("s1", "materializing"));
+
+    expect((await epicDrafts.refresh("s1"))?.status).toBe("materializing");
+    expect(epicDrafts.get("s1")?.status).toBe("materializing");
+  });
+
+  it("evicts the cached row when the server reports no draft", async () => {
+    epicDrafts.upsert(draft("s1", "draft"));
+    vi.mocked(api.getEpicDraft).mockResolvedValue(null);
+
+    expect(await epicDrafts.refresh("s1")).toBeNull();
+    expect(epicDrafts.get("s1")).toBeUndefined();
+  });
+
+  // The reconcile's GET can lose a race: if the handler finishes while it is in flight, the WS event
+  // carrying the TERMINAL state lands first. Writing the older `materializing` response over it would
+  // pin the panel on "materializing" forever — no further event is coming — with a sticky in-progress
+  // toast, until a reload. A write that landed during the GET must win.
+  it.each([
+    ["approved", "approved" as const],
+    ["reverted to draft", "draft" as const],
+  ])("does not clobber a WS event that landed mid-flight (%s)", async (_label, terminal) => {
+    epicDrafts.upsert(draft("s1", "draft"));
+
+    vi.mocked(api.getEpicDraft).mockImplementation(async () => {
+      // The handler finishes while the GET is in flight: the WS event upserts the terminal row...
+      epicDrafts.upsert(draft("s1", terminal));
+      // ...and only then does this (now stale) response resolve.
+      return draft("s1", "materializing");
+    });
+
+    const returned = await epicDrafts.refresh("s1");
+
+    expect(epicDrafts.get("s1")?.status).toBe(terminal); // the newer event survives
+    expect(returned?.status).toBe(terminal); // and the caller sees the truth, not the stale row
+  });
+
+  // ...but the guard must be scoped to THIS session. Every write replaces `map` wholesale, so a
+  // global write counter would also trip on an unrelated session's event — discarding a perfectly
+  // good response and reporting the stale `draft` row as a failure for an approve that is still
+  // materializing and about to succeed.
+  it("is not tripped by an unrelated session's write during the GET", async () => {
+    epicDrafts.upsert(draft("s1", "draft"));
+
+    vi.mocked(api.getEpicDraft).mockImplementation(async () => {
+      epicDrafts.upsert(draft("other-session", "approved")); // noise from another panel/WS event
+      return draft("s1", "materializing");
+    });
+
+    const returned = await epicDrafts.refresh("s1");
+
+    expect(returned?.status).toBe("materializing"); // the fresh response is kept, not discarded
+    expect(epicDrafts.get("s1")?.status).toBe("materializing");
+  });
+});

--- a/ui/src/lib/epic-draft.svelte.ts
+++ b/ui/src/lib/epic-draft.svelte.ts
@@ -10,13 +10,68 @@ class EpicDraftsStore {
   map = $state<Record<string, EpicDraft>>({});
   /** sessionIds with a load() in flight — avoids duplicate fetches while one is pending. */
   private loading = new Set<string>();
-
   get(sessionId: string): EpicDraft | undefined {
     return this.map[sessionId];
   }
 
+  /** Plain observers, notified on every upsert. Rendering reads `map` reactively; this is for logic
+   *  that must react to a draft's state OUTSIDE the component tree and outlive it — see
+   *  `epic-approve.ts`, which reports the outcome of an approve whose response was lost long after
+   *  the modal that started it has closed. */
+  private listeners = new Set<(d: EpicDraft) => void>();
+
+  /** Observe every upserted draft (WS event or GET). Returns an unsubscribe. */
+  onUpsert(fn: (d: EpicDraft) => void): () => void {
+    this.listeners.add(fn);
+    return () => this.listeners.delete(fn);
+  }
+
   upsert(d: EpicDraft) {
     this.map = { ...this.map, [d.sessionId]: d };
+    for (const fn of this.listeners) fn(d);
+  }
+
+  /** Force a re-GET of a session's draft and upsert it, returning the authoritative row (`null` when
+   *  the session has none). Unlike {@link load} this never short-circuits on the cache — the caller
+   *  needs the SERVER's current state, not what the store happens to hold.
+   *
+   *  Used to reconcile a failed-looking approve: the request's connection can die (a severed socket,
+   *  a proxy 502) while the handler runs on to completion, so a "failure" in the client may be a
+   *  success on the server. The local store can't answer that — the WS `session:epic-draft` event
+   *  only fires when the handler FINISHES, strictly after the connection died, and the
+   *  draft→materializing transition emits no event at all — so at reconcile time the store still
+   *  holds the stale pre-approve row. Only a fresh GET knows.
+   *
+   *  The GET can still LOSE a race, though: if the handler finishes while it is in flight, the WS
+   *  event carrying the terminal state (`approved` / reverted `draft`) may be applied first, and
+   *  writing this older response over it would pin the panel on `materializing` forever — no further
+   *  event is coming. So a write to THIS session that landed during the GET wins, and we return what
+   *  the store now holds.
+   *
+   *  The guard compares this session's ROW IDENTITY, not a global write counter: every write replaces
+   *  `map` wholesale, so a counter (or a `map` reference check) would also trip on an unrelated
+   *  session's event — discarding a perfectly good response and reporting a stale `draft` row as a
+   *  failure for an approve that is still materializing and about to succeed. */
+  async refresh(sessionId: string): Promise<EpicDraft | null> {
+    const before = this.map[sessionId];
+    const d = await getEpicDraft(sessionId);
+    // Overtaken by a newer write to this session (WS event / eviction) — don't clobber it.
+    if (this.map[sessionId] !== before) return this.map[sessionId] ?? null;
+
+    if (d) this.upsert(d);
+    // `null` is authoritative too: the server says this session has no draft. Drop the cached row —
+    // keeping it would leave the panel rendering a stale draft (approve button and all) next to the
+    // failure toast explaining that it's gone.
+    else this.remove(sessionId);
+    return d;
+  }
+
+  /** Forget a session's cached draft. */
+  remove(sessionId: string) {
+    if (!(sessionId in this.map)) return;
+    const next = { ...this.map };
+    delete next[sessionId];
+    this.map = next;
   }
 
   /** Fetch a session's draft once and cache it. No-op if already loaded or a load is in flight;


### PR DESCRIPTION
## The bug

Approving an epic draft showed the operator a red **`epic-draft approve failed: 502`** — with no real error text. The approve had **fully succeeded**: the parent issue, all 12 children, every native sub-issue link, and the registered epic run were all created. Only the *response* failed to get back to the browser.

## Root cause

Materializing an epic runs ~25 sequential GitHub calls (a `createIssue` per child + the parent + a native sub-issue link each + `buildEpic`), which outruns **Bun's 10s default idle timeout**. Bun severs the socket — but the handler keeps running and commits the whole epic. Reproduced:

```
[Bun.serve]: request timed out after 10 seconds. Pass `idleTimeout` to configure.
CLIENT ERROR after 12.0s: The socket connection was closed unexpectedly
HANDLER COMPLETED (side effects would have landed)
```

The dev proxy turns the dead socket into a **bodyless 502**, so `failed()` has no `{error}` to read and falls back to the bare `"<label> failed: <status>"` plumbing string. (In production there is no proxy — `fetch` rejects with a `TypeError` instead. Same event, two different thrown shapes.)

## The fix

**Server — a per-route idle budget, not a global one.** `serve()` already solved this per-request for `/usage/refresh` (`server.timeout(req, 60)`), with a comment deliberately choosing *"other endpoints unchanged"*. Rather than reverse that, `isSlowScrapeRequest` is generalized into `slowRequestTimeoutSec`:

| Route | Budget |
| --- | --- |
| `POST /api/sessions/:id/epic-draft/approve` | **255s** (Bun's ceiling) |
| `POST /api/usage/refresh` | 60s (unchanged) |
| everything else | 10s default (unchanged) |

A global `idleTimeout: 255` was rejected: it would make *every* route hold stalled sockets for 255s, and would cap `/usage/refresh` below its own explicit budget.

**Client — reconcile, don't guess.** A throw no longer means failure. `approve()` re-GETs the draft and reports what the server *actually* did: `approved` → success toast, `materializing` → in-progress toast, `draft`/`null`/refetch-failed → the real error.

The forced GET (`epicDrafts.refresh()`) is load-bearing: the WS `session:epic-draft` event only fires when the handler **finishes**, strictly *after* the connection died, and the draft→materializing transition emits no event at all — so the local store is stale-by-construction exactly when the reconcile runs.

**Message provenance.** `apiError` now returns `ApiError` carrying `serverAuthored` — true only when the message came from a response body. This is what stops the leak: a bodyless 502 is a plain `Error`, **not** a `TypeError`, so class alone can't gate it, and a status range can't either (the handler's 500 carries a genuinely informative `{error}` body — a GitHub rate-limit or permissions failure — worth showing).

## Verification

- **End-to-end probe on the real `serve()` listener**: a 13.0s approve now returns `HTTP 200` with its real body (`parent=#112`, draft `approved`), where the 10s default severed it.
- **Regression guard in the suite**: bodyless-502 reconciling to `draft` must show the generic toast, never `e.message`. The previously-planned suite would have *passed* with the bug present — it only paired the 502 shape with `approved`/`materializing`, neither of which reaches the message path.
- Root `bun run lint` + 6944 tests pass; UI `bun run check` (0 errors), `check:i18n` (parity), 3684 tests pass. The shared `apiError` return-type change broke no existing consumer.

## Note

No feature-announcement entry: this is a `fix:`, not a `feat:`. The already-created epic needs no repair — it was complete all along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)