### PR TITLE
fix(ui): inline epic run-settings labels

### DIFF
--- a/ui/src/lib/components/EpicPanel.svelte
+++ b/ui/src/lib/components/EpicPanel.svelte
@@ -442,19 +442,23 @@
 
   .run-settings {
     display: flex;
-    align-items: end;
+    align-items: center;
     gap: 6px;
     flex-wrap: wrap;
   }
 
+  /* Caption reads as an inline prefix on the control's own line — baseline, not
+     centre, so it sits on the select's text rather than mid-box. */
   .mini-field {
     display: flex;
-    flex-direction: column;
-    gap: 2px;
-    min-width: 96px;
+    flex-direction: row;
+    align-items: baseline;
+    gap: 4px;
   }
 
   .micro {
+    flex: none;
+    white-space: nowrap;
     color: var(--color-faint);
     font-size: var(--fs-micro);
     letter-spacing: 0.08em;
@@ -463,6 +467,7 @@
 
   select {
     min-height: 24px;
+    min-width: 96px;
     max-width: 180px;
     background: var(--color-inset);
     border: 1px solid var(--color-line);
@@ -530,6 +535,12 @@
     .gbtn {
       min-height: 40px;
       padding: 2px 14px;
+    }
+
+    /* Matches .gbtn above — the fields sit inline with the buttons, so an
+       unraised 24px select would read as a short control beside a tall one. */
+    select {
+      min-height: 40px;
     }
   }
 </style>

--- a/ui/src/lib/components/EpicPanel.svelte
+++ b/ui/src/lib/components/EpicPanel.svelte
@@ -535,15 +535,15 @@
      landscape is short-wide, so a width-only query would leave these controls
      desktop-sized while app.css had already bumped their font to 16px. */
   @media (max-width: 768px), (max-height: 600px) {
+    /* 44px is the tap-target floor — buttons and the inline selects beside them
+       move together, else the taller control breaks the shared control line. */
     .gbtn {
-      min-height: 40px;
+      min-height: 44px;
       padding: 2px 14px;
     }
 
-    /* Matches .gbtn above — the fields sit inline with the buttons, so an
-       unraised 24px select would read as a short control beside a tall one. */
     select {
-      min-height: 40px;
+      min-height: 44px;
     }
   }
 </style>

--- a/ui/src/lib/components/EpicPanel.svelte
+++ b/ui/src/lib/components/EpicPanel.svelte
@@ -531,7 +531,10 @@
     color: var(--color-amber);
   }
 
-  @media (max-width: 768px) {
+  /* Condition mirrors the global mobile control branch in app.css — phone
+     landscape is short-wide, so a width-only query would leave these controls
+     desktop-sized while app.css had already bumped their font to 16px. */
+  @media (max-width: 768px), (max-height: 600px) {
     .gbtn {
       min-height: 40px;
       padding: 2px 14px;


### PR DESCRIPTION
The `CLI` dropdown in the EPIC drain panel sat visibly below the `Pause` / `Auto` / `Stop epic` buttons. Cause: `.mini-field` was a column flex, so the uppercase caption stacked *above* its `<select>` — the field ran two lines tall against one-line buttons, and `.run-settings` then bottom-aligned (`align-items: end`) the taller field, dropping the select off the control row.

Each run-settings field is now a single-line chip — the caption is an inline prefix, `CLI [inherit ▾]`.

## Changes (CSS only, scoped to `EpicPanel.svelte`)

- `.mini-field` → `row` + `align-items: baseline`. Baseline, not centre: the caption belongs *on the select's text line*, not centred against a 24px (40px mobile) box.
- `.run-settings` → `align-items: center`. Outer axis centres whole controls against the buttons; inner axis aligns text. Deliberately different.
- The `min-width: 96px` floor moves off `.mini-field` onto `select`, and `.micro` gets `flex: none; white-space: nowrap` — so a tight row **wraps** (both containers already declare `flex-wrap: wrap`) instead of crushing the control.
- Phone-width `select` → `min-height: 40px`, in the same `@media (max-width: 768px)` block that already raises `.gbtn`. Without it, flattening the field leaves short selects beside tall buttons.

Applies to all three fields (`CLI`, `Model`, `Effort`) — the latter two appear once a provider is picked, so inlining only `CLI` would leave a mixed-height row.

## Deliberately unchanged

`new-task/NewTaskRunSettings.svelte` and `new-task/ModelCliPicker.svelte` keep their caption-above-control layout. They are **form** fields (label over input is correct there); EpicPanel's are **chips in a horizontal control row** beside buttons. The divergence is intentional — not an oversight to harmonize later.

## Touch targets

Phone-width `.gbtn` **and** the inline `select`s are both `min-height: 44px`, meeting the house tap-target floor. They move together — raising only the select would make it taller than the buttons beside it and reintroduce the misalignment this PR fixes. (An earlier revision shipped 40px, matching the old `.gbtn` precedent; that waiver is now cleared.) The media condition mirrors the global mobile control branch in `app.css` — `(max-width: 768px), (max-height: 600px)` — so phone landscape, which is short-*wide*, gets the same heights instead of 16px text in desktop-height controls.

## Verification

- `cd ui && bun run check` — 0 errors.
- `cd ui && bun run test` — 3675 passed. `EpicPanel.browser.test.ts` resolves the selects via `getByLabelText`, so it's the automated proof the `<label>`→`<select>` association survived the layout change.
- Rendered the panel in real Chromium at four states and inspected each: default, provider-selected (Model + Effort visible), narrow/wrapped, and phone width — buttons and selects share one line and one height; the narrow row wraps cleanly with no crushed control.

No new strings (no i18n change) and no feature-catalog entry — this is a `fix`, not a `feat`. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
