### PR TITLE
fix(ui): show build queue chip before approval

### DIFF
--- a/ui/src/lib/components/BuildQueueBadge.browser.test.ts
+++ b/ui/src/lib/components/BuildQueueBadge.browser.test.ts
@@ -58,12 +58,12 @@ afterEach(() => {
 });
 
 describe("BuildQueueBadge", () => {
-  it("renders nothing when queue is unapproved (approved=false) even with steps", async () => {
+  it("renders progress when queue is unapproved (approved=false) with pending steps", async () => {
     buildQueues.map = {
-      s1: queue(false, [step("done", "1"), step("pending", "2")]),
+      s1: queue(false, [step("pending", "1"), step("pending", "2")]),
     };
     renderBadge({ sessionId: "s1", planPhase: "executing" });
-    expect(document.querySelector(".queue-badge")).toBeNull();
+    await expect.element(page.getByText("0/2")).toBeInTheDocument();
   });
 
   it("renders nothing when there is no queue for the session", async () => {

--- a/ui/src/lib/components/BuildQueueBadge.svelte
+++ b/ui/src/lib/components/BuildQueueBadge.svelte
@@ -62,7 +62,7 @@
   }
 </script>
 
-{#if queue?.approved && total > 0}
+{#if total > 0}
   {#if drifted}
     <button
       type="button"


### PR DESCRIPTION
## Problem

Wenn ein Agent seine Build Queue erstellt hat, aber noch auf die Freigabe wartet, war die Queue im Terminal bereits sichtbar. Der zugehörige Fortschritts-Chip auf der Session-Karte im Side Pane blieb jedoch verborgen, weil er zusätzlich eine bereits erteilte Freigabe verlangte.

## Lösung

Der Chip wird nun angezeigt, sobald die Queue mindestens einen Schritt enthält. Eine noch nicht freigegebene Queue mit ausschließlich ausstehenden Schritten erscheint damit als `0/N`; der Detailbereich bleibt weiterhin die eindeutige Stelle für den Status „Awaiting your approval“.

## Technische Details

- Die Render-Bedingung von `BuildQueueBadge` prüft nur noch auf vorhandene Schritte, nicht mehr auf `approved`.
- Ein Browser-Regressionstest deckt den unfreigegebenen `0/2`-Fall ab.
- Keine Änderungen an API, WebSocket-Events, Queue-Store oder Übersetzungen.

## Validierung

- `cd ui && bun run test:browser -- BuildQueueBadge.browser.test.ts` — 20 Tests bestanden
- `cd ui && bun run check` — 0 Fehler, 0 Warnungen