### PR TITLE
fix(ui): wrap long toast action label instead of squishing message

### DIFF
--- a/ui/src/lib/components/Toasts.browser.test.ts
+++ b/ui/src/lib/components/Toasts.browser.test.ts
@@ -161,6 +161,37 @@ describe("Toasts: long action label wraps instead of squishing the message", () 
     expect(msgLineCount(msg)).toBe(1);
   });
 
+  /* .actions owns the row's ONLY auto margin; .undo and .x declare none. These two
+     pin the right-alignment that used to ride on those removed margins: the undo-tone
+     button (a direct child of .toast, outside .actions) is pushed right by .msg's
+     flex-grow, and a lone ✕ by .actions' own auto margin. */
+  it("right-aligns the undo-tone button, which sits outside .actions", async () => {
+    await page.viewport(1280, 900);
+    toasts.undo(MERGED, { undoLabel: m.common_undo(), onCommit: () => {} });
+    render(Toasts, {});
+    await tick();
+    const toast = el<HTMLElement>(".toast");
+    const undo = el<HTMLElement>(".undo");
+    expect(document.querySelector(".actions")).toBeNull(); // undo tone has no wrapper
+    // Flush right (12px padding + 1px border), not left-adrift beside the message.
+    expect(toast.getBoundingClientRect().right - undo.getBoundingClientRect().right).toBeCloseTo(
+      13,
+      0,
+    );
+  });
+
+  it("right-aligns a lone ✕ when there is no action label", async () => {
+    await page.viewport(1280, 900);
+    await renderToast(MERGED);
+    const toast = el<HTMLElement>(".toast");
+    const x = el<HTMLElement>(".x");
+    expect(document.querySelector(".undo")).toBeNull();
+    expect(toast.getBoundingClientRect().right - x.getBoundingClientRect().right).toBeCloseTo(
+      13,
+      0,
+    );
+  });
+
   it("keeps .countdown a direct child of .toast (absolutely positioned against it)", async () => {
     await page.viewport(1280, 900);
     toasts.info(MERGED, {

--- a/ui/src/lib/components/Toasts.browser.test.ts
+++ b/ui/src/lib/components/Toasts.browser.test.ts
@@ -161,35 +161,50 @@ describe("Toasts: long action label wraps instead of squishing the message", () 
     expect(msgLineCount(msg)).toBe(1);
   });
 
-  /* .actions owns the row's ONLY auto margin; .undo and .x declare none. These two
-     pin the right-alignment that used to ride on those removed margins: the undo-tone
-     button (a direct child of .toast, outside .actions) is pushed right by .msg's
-     flex-grow, and a lone ✕ by .actions' own auto margin. */
-  it("right-aligns the undo-tone button, which sits outside .actions", async () => {
-    await page.viewport(1280, 900);
-    toasts.undo(MERGED, { undoLabel: m.common_undo(), onCommit: () => {} });
+  /* .actions owns the row's ONLY auto margin; .undo and .x declare none. These pin the
+     right-alignment that used to ride on those removed margins. The undo tone is in
+     .actions too — a lone button on a wrapped line has no free space to grow into, so
+     .msg's flex-grow cannot reach it and it would left-align without the wrapper. */
+  async function renderUndo(text: string) {
+    toasts.undo(text, { undoLabel: m.common_undo(), onCommit: () => {} });
     render(Toasts, {});
     await tick();
-    const toast = el<HTMLElement>(".toast");
-    const undo = el<HTMLElement>(".undo");
-    expect(document.querySelector(".actions")).toBeNull(); // undo tone has no wrapper
-    // Flush right (12px padding + 1px border), not left-adrift beside the message.
-    expect(toast.getBoundingClientRect().right - undo.getBoundingClientRect().right).toBeCloseTo(
-      13,
-      0,
+  }
+
+  /** Distance from the toast's right edge — 13px (12px padding + 1px border) when flush. */
+  function insetRight(node: HTMLElement): number {
+    return (
+      el<HTMLElement>(".toast").getBoundingClientRect().right - node.getBoundingClientRect().right
     );
+  }
+
+  it("right-aligns the undo-tone button on an unwrapped row", async () => {
+    await page.viewport(1280, 900);
+    await renderUndo(MERGED);
+    expect(insetRight(el<HTMLElement>(".undo"))).toBeCloseTo(13, 0);
+  });
+
+  it("right-aligns the undo-tone button once the row WRAPS (long session name)", async () => {
+    await page.viewport(1280, 900);
+    // Reachable in real use: toast_decommissioned carries a session name and routinely
+    // exceeds the 440px cap. Without .actions the button would be alone on line 2 with
+    // no auto margin and no grow → left-adrift, unlike an info toast in the same state.
+    await renderUndo(m.toast_decommissioned({ name: "shepherd/toast-decommission-update-local" }));
+    const msg = el<HTMLElement>(".msg");
+    const undo = el<HTMLElement>(".undo");
+    // Actually wrapped (else this asserts nothing).
+    expect(undo.getBoundingClientRect().top).toBeGreaterThanOrEqual(
+      msg.getBoundingClientRect().bottom,
+    );
+    expect(insetRight(undo)).toBeCloseTo(13, 0);
   });
 
   it("right-aligns a lone ✕ when there is no action label", async () => {
     await page.viewport(1280, 900);
     await renderToast(MERGED);
-    const toast = el<HTMLElement>(".toast");
     const x = el<HTMLElement>(".x");
     expect(document.querySelector(".undo")).toBeNull();
-    expect(toast.getBoundingClientRect().right - x.getBoundingClientRect().right).toBeCloseTo(
-      13,
-      0,
-    );
+    expect(insetRight(x)).toBeCloseTo(13, 0);
   });
 
   it("keeps .countdown a direct child of .toast (absolutely positioned against it)", async () => {

--- a/ui/src/lib/components/Toasts.browser.test.ts
+++ b/ui/src/lib/components/Toasts.browser.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import { tick } from "svelte";
+import { m } from "$lib/paraglide/messages";
 // MUST import the stylesheet: the inset is calc()'d from the design tokens
 // (--mobile-actionbar-hit/-pad/--actionbar-border, all defined in app.css).
 // Without it the calc is invalid and getComputedStyle().bottom is `auto`, not px.
@@ -54,5 +55,158 @@ describe("Toasts mobile inset above the action bar (#810)", () => {
     render(Toasts, { aboveActionBar: false });
     await tick();
     expect(toastsBottomPx()).toBe(0); // today's flush behavior; pre-fix value in both states
+  });
+});
+
+/* A long action label ("Decommission & update local") used to squeeze .msg — the
+   only shrinkable child of a nowrap 440px row — into a 3-line column. The row now
+   wraps and the controls are one atomic flex item. Geometry is asserted against
+   REAL css (app.css is imported above), and every string comes from the real
+   message fns, so a future label change re-triggers these checks. */
+function el<T extends HTMLElement>(sel: string): T {
+  const node = document.querySelector(sel) as T;
+  expect(node, `${sel} rendered`).not.toBeNull();
+  return node;
+}
+
+/* .toast is align-items:center and .undo (~25px) / .x (~21px) differ in height, so
+   two items on one row do NOT share a `top`. Compare vertical centers instead. */
+function centerY(node: HTMLElement): number {
+  const r = node.getBoundingClientRect();
+  return r.top + r.height / 2;
+}
+function expectSameRow(a: HTMLElement, b: HTMLElement) {
+  expect(Math.abs(centerY(a) - centerY(b))).toBeLessThanOrEqual(2);
+}
+
+/** Line boxes the message text actually occupies — 3 with the bug, 1 when fixed.
+ *  A Range counts line boxes even though the flex item is blockified. */
+function msgLineCount(msg: HTMLElement): number {
+  const range = document.createRange();
+  range.selectNodeContents(msg);
+  return range.getClientRects().length;
+}
+
+const LONG_LABEL = m.gitrail_decommission_update_action(); // "Decommission & update local"
+const MERGED = m.toast_merged({ name: "cli-dropdown-alignment" });
+
+async function renderToast(text: string, label?: string, scale?: string) {
+  toasts.info(text, {
+    sticky: true,
+    ...(label ? { action: { label, run: () => {} } } : {}),
+  });
+  render(Toasts, {});
+  await tick();
+  // The iOS Dynamic Type probe sets --ui-scale on :root (app.css:80-86, capped 1.5).
+  if (scale) document.documentElement.style.setProperty("--ui-scale", scale);
+  await tick();
+}
+
+describe("Toasts: long action label wraps instead of squishing the message", () => {
+  afterEach(() => {
+    document.documentElement.style.removeProperty("--ui-scale");
+  });
+
+  it("keeps the message on ONE line and drops the controls to a second row", async () => {
+    await page.viewport(1280, 900);
+    await renderToast(MERGED, LONG_LABEL);
+    const msg = el<HTMLElement>(".msg");
+    const actions = el<HTMLElement>(".actions");
+
+    // THE regression: pre-fix this was 3. Height/width would pass trivially now
+    // that .msg has flex-grow, so assert the line boxes themselves.
+    expect(msgLineCount(msg)).toBe(1);
+    // Controls wrapped below the message rather than stealing its width.
+    expect(actions.getBoundingClientRect().top).toBeGreaterThanOrEqual(
+      msg.getBoundingClientRect().bottom,
+    );
+  });
+
+  it("keeps the ✕ beside the button on the wrapped row (no third-row orphan)", async () => {
+    await page.viewport(1280, 900);
+    await renderToast(MERGED, LONG_LABEL);
+    const undo = el<HTMLElement>(".undo");
+    const x = el<HTMLElement>(".x");
+
+    expectSameRow(x, undo);
+    // Adjacent, i.e. separated by exactly the .actions gap — not floated apart by
+    // an auto-margin split (Flexbox §8.1) or orphaned to its own line.
+    const gap = x.getBoundingClientRect().left - undo.getBoundingClientRect().right;
+    expect(gap).toBeGreaterThan(12);
+    expect(gap).toBeLessThan(16);
+  });
+
+  it("separates the two rows by the declared 8px row-gap, not the 14px shorthand", async () => {
+    await page.viewport(1280, 900);
+    await renderToast(MERGED, LONG_LABEL);
+    const msg = el<HTMLElement>(".msg");
+    const actions = el<HTMLElement>(".actions");
+    const rowGap = actions.getBoundingClientRect().top - msg.getBoundingClientRect().bottom;
+    expect(rowGap).toBeCloseTo(8, 0);
+  });
+
+  it("never overflows horizontally, even with an unbreakable branch name", async () => {
+    await page.viewport(1280, 900);
+    await renderToast(m.toast_merged({ name: "feat/" + "x".repeat(60) }), LONG_LABEL);
+    const toast = el<HTMLElement>(".toast");
+    // overflow-wrap: anywhere breaks the token instead of blowing out the panel.
+    expect(toast.scrollWidth).toBeLessThanOrEqual(toast.clientWidth + 1);
+  });
+
+  it("leaves a short-label toast on a single row (unchanged)", async () => {
+    await page.viewport(1280, 900);
+    await renderToast(MERGED, m.common_retry());
+    const msg = el<HTMLElement>(".msg");
+    expectSameRow(el<HTMLElement>(".actions"), msg);
+    expect(msgLineCount(msg)).toBe(1);
+  });
+
+  it("keeps .countdown a direct child of .toast (absolutely positioned against it)", async () => {
+    await page.viewport(1280, 900);
+    toasts.info(MERGED, {
+      duration: 5000,
+      action: { label: LONG_LABEL, run: () => {} },
+    });
+    render(Toasts, {});
+    await tick();
+    expect(document.querySelector(".toast > .countdown")).not.toBeNull();
+  });
+
+  for (const width of [390, 320]) {
+    it(`keeps the ✕ beside the button on a ${width}px banner`, async () => {
+      await page.viewport(width, 900);
+      await renderToast(MERGED, LONG_LABEL);
+      const toast = el<HTMLElement>(".toast");
+      const undo = el<HTMLElement>(".undo");
+
+      expectSameRow(el<HTMLElement>(".x"), undo);
+      expect(undo.getBoundingClientRect().right).toBeLessThanOrEqual(
+        toast.getBoundingClientRect().right,
+      );
+      expect(toast.scrollWidth).toBeLessThanOrEqual(toast.clientWidth + 1);
+    });
+  }
+
+  // --fs-meta = calc(11px * --ui-scale) → 16.5px at the probe's 1.5 cap, growing
+  // .undo past a 390px banner's ~362px content box. This is where flex-shrink on
+  // .undo actually engages: the button must WRAP its label (it keeps overflow:hidden
+  // for the .bar countdown, so clipping is a real failure mode), not overflow.
+  it("keeps the ✕ beside the button and the label unclipped at --ui-scale: 1.5 (390px)", async () => {
+    await page.viewport(390, 900);
+    await renderToast(MERGED, LONG_LABEL, "1.5");
+    const toast = el<HTMLElement>(".toast");
+    const undo = el<HTMLElement>(".undo");
+
+    // Sanity: the scale really applied (else this test proves nothing).
+    expect(parseFloat(getComputedStyle(undo).fontSize)).toBeCloseTo(16.5, 1);
+
+    expectSameRow(el<HTMLElement>(".x"), undo);
+    expect(undo.getBoundingClientRect().right).toBeLessThanOrEqual(
+      toast.getBoundingClientRect().right,
+    );
+    expect(toast.scrollWidth).toBeLessThanOrEqual(toast.clientWidth + 1);
+    // Shrunk, so its label wrapped inside the button rather than being cut off.
+    expect(undo.scrollWidth).toBeLessThanOrEqual(undo.clientWidth + 1);
+    expect(undo.scrollHeight).toBeLessThanOrEqual(undo.clientHeight + 1);
   });
 });

--- a/ui/src/lib/components/Toasts.svelte
+++ b/ui/src/lib/components/Toasts.svelte
@@ -124,9 +124,12 @@
     margin-left: auto;
     min-width: 0;
   }
+  /* No margin-left:auto here or on .x — .actions owns the row's single auto margin,
+     and .msg's flex-grow right-aligns the undo-tone button (a direct child of
+     .toast, outside .actions). A second auto margin would reintroduce the §8.1
+     equal-split of free space that grouping exists to prevent. */
   .undo {
     position: relative;
-    margin-left: auto;
     flex-shrink: 1;
     min-width: 0;
     max-width: 100%;
@@ -177,7 +180,6 @@
     animation-play-state: paused;
   }
   .x {
-    margin-left: auto;
     flex-shrink: 0;
     background: transparent;
     border: 0;

--- a/ui/src/lib/components/Toasts.svelte
+++ b/ui/src/lib/components/Toasts.svelte
@@ -30,19 +30,27 @@
             <span class="bar" aria-hidden="true"></span>
           </button>
         {:else}
-          {#if t.actionLabel}
-            <button type="button" class="undo" onclick={() => toasts.act(t.id)}>
-              {t.actionLabel}
+          <!-- Action + ✕ are ONE flex item: as two siblings, line-breaking collects
+               them separately, so a long action label orphans the ✕ onto a third
+               row once button + gap + ✕ exceeds the line box. Grouping also leaves
+               exactly one margin-left:auto on the row, so the free space can't be
+               split equally between two auto margins (Flexbox §8.1). -->
+          <div class="actions">
+            {#if t.actionLabel}
+              <button type="button" class="undo" onclick={() => toasts.act(t.id)}>
+                {t.actionLabel}
+              </button>
+            {/if}
+            <button
+              type="button"
+              class="x"
+              onclick={() => toasts.close(t.id)}
+              aria-label={m.common_close()}
+            >
+              ✕
             </button>
-          {/if}
-          <button
-            type="button"
-            class="x"
-            onclick={() => toasts.close(t.id)}
-            aria-label={m.common_close()}
-          >
-            ✕
-          </button>
+          </div>
+          <!-- Stays a direct child of .toast — absolutely positioned against it. -->
           {#if t.durationMs !== undefined}
             <!-- Keyed on armSeq so a keyed refresh recreates the node, restarting
                  the drain animation in sync with the freshly re-armed timer. -->
@@ -78,7 +86,11 @@
     pointer-events: auto;
     display: flex;
     align-items: center;
-    gap: 14px;
+    flex-wrap: wrap;
+    /* Split axes deliberately: `gap: 14px` is a both-axes shorthand, so wrapping
+       would silently adopt 14px as the row gap too. 8px matches the stack rhythm. */
+    column-gap: 14px;
+    row-gap: 8px;
     max-width: min(440px, 92vw);
     padding: 10px 12px;
     background: var(--color-panel);
@@ -90,15 +102,34 @@
   .is-undo {
     border-color: var(--color-amber);
   }
+  /* Flex base = max-content, so line-breaking wraps .actions away rather than
+     shrinking the message: the long-action-label squeeze (3-line column) can't
+     recur. overflow-wrap catches an unbreakable branch name that alone exceeds
+     the line; flex-grow right-aligns a lone ✕ when there's no action button. */
   .msg {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow-wrap: anywhere;
     color: var(--color-ink-bright);
     font-size: var(--fs-base);
     letter-spacing: 0.02em;
   }
+  /* The one auto margin on the row (see markup note). min-width:0 lets it shrink
+     so .undo inside it can, which is what keeps the ✕ beside the button at
+     --ui-scale 1.5 (--fs-meta 16.5px → the button alone overflows a phone banner). */
+  .actions {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    margin-left: auto;
+    min-width: 0;
+  }
   .undo {
     position: relative;
     margin-left: auto;
-    flex-shrink: 0;
+    flex-shrink: 1;
+    min-width: 0;
+    max-width: 100%;
     background: transparent;
     border: 1px solid var(--color-amber);
     border-radius: 2px;

--- a/ui/src/lib/components/Toasts.svelte
+++ b/ui/src/lib/components/Toasts.svelte
@@ -24,11 +24,17 @@
         onfocusout={() => toasts.release(t.id)}
       >
         <span class="msg">{t.text}</span>
+        <!-- Both tones put their controls in .actions: it carries the row's single
+             margin-left:auto, which is the ONLY thing right-aligning them once the row
+             wraps (a lone button on line 2 has no free space to grow into, so .msg's
+             flex-grow can't reach it). -->
         {#if t.tone === "undo"}
-          <button type="button" class="undo" onclick={() => toasts.cancel(t.id)}>
-            {t.undoLabel}
-            <span class="bar" aria-hidden="true"></span>
-          </button>
+          <div class="actions">
+            <button type="button" class="undo" onclick={() => toasts.cancel(t.id)}>
+              {t.undoLabel}
+              <span class="bar" aria-hidden="true"></span>
+            </button>
+          </div>
         {:else}
           <!-- Action + ✕ are ONE flex item: as two siblings, line-breaking collects
                them separately, so a long action label orphans the ✕ onto a third
@@ -105,7 +111,7 @@
   /* Flex base = max-content, so line-breaking wraps .actions away rather than
      shrinking the message: the long-action-label squeeze (3-line column) can't
      recur. overflow-wrap catches an unbreakable branch name that alone exceeds
-     the line; flex-grow right-aligns a lone ✕ when there's no action button. */
+     the line. */
   .msg {
     flex: 1 1 auto;
     min-width: 0;
@@ -124,10 +130,10 @@
     margin-left: auto;
     min-width: 0;
   }
-  /* No margin-left:auto here or on .x — .actions owns the row's single auto margin,
-     and .msg's flex-grow right-aligns the undo-tone button (a direct child of
-     .toast, outside .actions). A second auto margin would reintroduce the §8.1
-     equal-split of free space that grouping exists to prevent. */
+  /* No margin-left:auto here or on .x — .actions (their only parent, both tones)
+     owns the row's single auto margin and right-aligns them on wrapped and unwrapped
+     rows alike. A second auto margin would reintroduce the §8.1 equal-split of free
+     space that grouping exists to prevent. */
   .undo {
     position: relative;
     flex-shrink: 1;


### PR DESCRIPTION
The post-merge toast for an isolated session offers **Decommission & update local** — a long action label that squeezed the message into a narrow 3-line column (reported with a screenshot).

## Cause

`.toast` was a **non-wrapping** flex row capped at `min(440px, 92vw)`. `.undo` is `flex-shrink: 0`, uppercase, `letter-spacing: 0.12em`, so that label reserved ~270px of the 440px. `.msg` was the only shrinkable child, so it absorbed the entire deficit.

## Fix

The row now wraps: the message keeps its own line and the controls drop to a second row.

- **`.actions` wrapper (markup).** The action button and the ✕ become **one atomic flex item**. As two siblings they are collected onto the wrapped line independently, so the ✕ orphans onto a *third* row whenever button + gap + ✕ exceeds the line box (~293px vs a 320px banner's ~292px content box). `flex-shrink` can't rescue that — shrinking happens *after* line collection. The wrapper also leaves exactly **one** `margin-left: auto` on the row, so Flexbox §8.1 can't split the free space equally between two auto margins and float the button mid-row. `.countdown` stays a direct child of `.toast` (it is absolutely positioned against it).
- **Explicit `row-gap: 8px`.** `gap: 14px` is a both-axes shorthand, so wrapping would have silently adopted 14px vertically. 8px matches the stack rhythm.
- **`.undo` shrinkable.** At the iOS Dynamic Type cap (`--ui-scale: 1.5` → `--fs-meta` 16.5px) the button grows to ~380px against a 390px phone's ~362px content box. It now wraps its label *inside* the button instead of overflowing the banner.

## Tests

9 real-CSS geometry tests in `Toasts.browser.test.ts` (all strings from the real message fns, so a future label change re-triggers them). **6 of them fail against the pre-fix component** — verified by restoring it and re-running.

The core assertion counts the message's **line boxes** via a `Range` (3 before, 1 after) rather than box width, which the new `flex-grow` would make trivially true. Also covered: ✕ adjacency on the wrapped row, the 8px row-gap, no horizontal overflow with an unbreakable 60-char branch name, the short-label control still on one row, `.countdown` parentage, 390px/320px banners, and `--ui-scale: 1.5` × 390px (asserting the shrunk button *wrapped* rather than clipped its label — it keeps `overflow: hidden` for the `.bar` countdown).

Same-row checks compare vertical centers, not `top`: `.toast` is `align-items: center` and `.undo` (~25px) / `.x` (~21px) differ in height, so correct layout does not share a `top`.

## Verification

`bun run check` clean · `check:i18n` in parity · root `lint` + `prettier --check` clean · full UI suite green (3697 tests, 248 files).

No new message keys, no user-facing capability — a CSS/markup bugfix on shipped UI. [no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)