### PR TITLE
fix(onboarding): stop racing the Arch image's own keyring init

### DIFF
--- a/ci/onboarding-harness/seed.ts
+++ b/ci/onboarding-harness/seed.ts
@@ -61,7 +61,9 @@ const PROFILES = ["default", "shep-onb"];
  *  function exists to close, degrading back to a flaky nightly. So we separate the one benign
  *  case from real failures: `systemctl list-unit-files` (0 present / 1 absent) gates the stop, an
  *  absent unit is skipped, and a present unit that will not stop fails this CHECKED baseline step
- *  loudly. `reset-failed` keeps its `|| true` — it is pure cosmetics.
+ *  loudly — and legibly: the stop keeps its stderr (only stdout is dropped), so systemd's own
+ *  reason rides along into the error seedInstance throws. `reset-failed` keeps its `|| true` — it
+ *  is pure cosmetics.
  *
  *  Guarded on `command -v pacman` so it's a clean no-op on apt/apk/dnf images (the 8 non-Arch
  *  scenarios). Runs as root — `driver.exec` → `incus exec` is root by default, which
@@ -85,8 +87,11 @@ function archKeyringRefresh(): string {
     '    systemctl list-unit-files "$u" >/dev/null 2>&1 || continue',
     // The unit exists, so a stop MUST succeed. Anything else — a 120s timeout (124), a bus
     // error — means a writer may still be live, and rebuilding the keyring under it would
-    // silently re-enter the #1738 race. Fail the (checked) baseline step instead.
-    '    timeout 120 systemctl stop "$u" >/dev/null 2>&1 || ' +
+    // silently re-enter the #1738 race. Fail the (checked) baseline step instead. stdout is
+    // dropped but stderr is NOT: systemd's own reason (job timed out / failed to connect to
+    // bus / …) is the diagnostic, and seedInstance propagates it into the thrown baseline
+    // error — so the failure is legible, not just loud.
+    '    timeout 120 systemctl stop "$u" >/dev/null || ' +
       '{ rc=$?; echo "FATAL: could not stop $u (exit $rc); refusing to rebuild the keyring ' +
       'while a writer may still be running" >&2; exit 1; }',
     "  done",

--- a/ci/onboarding-harness/seed.ts
+++ b/ci/onboarding-harness/seed.ts
@@ -8,25 +8,69 @@ const SHEPHERD_DIR = "/opt/shepherd";
 // replace default and leave the instance with no root device.
 const PROFILES = ["default", "shep-onb"];
 
-/** Arch's base-image `archlinux-keyring` drifts behind the mirror over time; once a
- *  mirror package is signed by a packager key newer than the image's keyring,
- *  `pacman -Sy <pkg>` fails "signature … is unknown trust / invalid or corrupted
- *  package (PGP signature)" and the checked baseline aborts (issue #1422 — herdr-missing
- *  on images:archlinux is the only Arch scenario). Refresh the keyring ONCE before any
- *  pacman install: init the gnupg dir, populate trust from the shipped keyring, then
- *  update archlinux-keyring from the mirror (its own signature verifies against the
- *  freshly-populated trust; its install hook re-populates the new packager keys).
- *  Populate-before-sync is required — `-Sy` first would fail verification before the
- *  keyring is refreshed. `--needed` skips a redundant reinstall when already current.
- *  Guarded on `command -v pacman` so it's a clean no-op on apt/apk/dnf images (the 8
- *  non-Arch scenarios). Runs as root — `driver.exec` → `incus exec` is root by default,
- *  which `pacman-key` requires. */
+/** Take sole ownership of Arch's pacman keyring, then refresh it from the mirror.
+ *
+ *  WHY refresh at all (#1422): the base image's `archlinux-keyring` drifts behind the
+ *  mirror; once a mirror package is signed by a packager key newer than the image's
+ *  keyring, `pacman -Sy <pkg>` fails "signature … is unknown trust / invalid or corrupted
+ *  package (PGP signature)" and the checked baseline aborts. So we rebuild trust and pull
+ *  a current `archlinux-keyring` BEFORE any pacman install. Populate-before-sync is
+ *  required — `-Sy` first would fail verification before the keyring is refreshed.
+ *
+ *  WHY stop units first (#1738): `images:archlinux` runs its OWN keyring init at boot —
+ *  `/etc/systemd/system/pacman-init.service` (`ExecStart=pacman-key --init` + `--populate`,
+ *  ordered `After=time-sync.target`). We only wait for DNS (waitForDns), which resolves
+ *  long before time-sync, so the pre-#1738 version of this function raced that unit: two gpg
+ *  processes writing /etc/pacman.d/gnupg, and the loser died with "can't open pubring.gpg /
+ *  no writable keyring found / could not be locally signed". Reproduced 3/3 by exec'ing as
+ *  soon as DNS resolved; 0/3 when run after the unit had settled. Since runScenario launches
+ *  a FRESH instance per scenario, BOTH Arch scenarios are exposed — which one loses on a
+ *  given night is jitter, which is exactly why the nightly looked flaky.
+ *
+ *  Enumerating `systemctl list-units --all '*keyring*' '*pacman*'` + `list-timers` on a
+ *  fresh instance, pacman-init is not the only writer of that homedir:
+ *   - `archlinux-keyring-wkd-sync.timer` (loaded, active, OnCalendar=weekly, Persistent=true)
+ *     refreshes keys in the SAME homedir. On a fresh instance it sits ~6 days out and does not
+ *     fire at boot — but Persistent=true means an aged image cache can fire a catch-up run
+ *     right inside our window, so we stop it (and its service) defensively.
+ *   - the socket-activated `gpg-agent@ / dirmngr@ / keyboxd@ etc-pacman.d-gnupg` daemons are
+ *     separate units that SURVIVE stopping pacman-init, so one can linger holding the homedir
+ *     we are about to delete; `gpgconf --kill all` releases them first.
+ *  Nothing else in that enumeration touches the homedir.
+ *
+ *  We then rebuild UNCONDITIONALLY (`rm -rf` + init + populate) rather than probe-and-heal:
+ *  after a race the unit finishes its own populate, so the homedir converges to healthy and a
+ *  `pacman-key --list-keys` probe would exit 0 and skip the heal; and pacman-init's
+ *  `ConditionPathIsDirectory=!/etc/pacman.d/gnupg` makes `systemctl start` a no-op once the dir
+ *  exists, so it cannot repair a broken-but-present homedir either. Destroying and rebuilding is
+ *  safe here — these are throw-away instances whose keyring we fully own. (For the same reason
+ *  this shape must NOT be ported to the in-app remediation that runs on real user machines.)
+ *
+ *  `set -e` is load-bearing: `driver.exec` runs this via `sh -c`, which returns only the LAST
+ *  command's status, and `pacman -Sy --needed archlinux-keyring` exits 0 ("nothing to do") when
+ *  the version already matches — so without it, a failed init/populate would be swallowed and the
+ *  step would report success on an EMPTY keyring, resurfacing later as a misleading `curl`/`unzip`
+ *  install error. It is placed after the guard so non-Arch images still exit 0.
+ *
+ *  `timeout 120` bounds the stop: it blocks on the unit's job, and incus.ts's RUNNER_TIMEOUT_MS
+ *  is 20min — unbounded, a wedged stop would turn a fast, legible failure into a hung run.
+ *
+ *  Guarded on `command -v pacman` so it's a clean no-op on apt/apk/dnf images (the 8 non-Arch
+ *  scenarios). Runs as root — `driver.exec` → `incus exec` is root by default, which
+ *  `pacman-key` and `systemctl` require. */
 function archKeyringRefresh(): string {
-  return (
-    "command -v pacman >/dev/null 2>&1 || exit 0; " +
-    "pacman-key --init && pacman-key --populate archlinux && " +
-    "pacman -Sy --needed --noconfirm archlinux-keyring"
-  );
+  return [
+    "command -v pacman >/dev/null 2>&1 || exit 0",
+    "set -e",
+    "timeout 120 systemctl stop pacman-init.service archlinux-keyring-wkd-sync.timer " +
+      "archlinux-keyring-wkd-sync.service >/dev/null 2>&1 || true",
+    "systemctl reset-failed pacman-init.service >/dev/null 2>&1 || true",
+    "gpgconf --homedir /etc/pacman.d/gnupg --kill all >/dev/null 2>&1 || true",
+    "rm -rf /etc/pacman.d/gnupg",
+    "pacman-key --init",
+    "pacman-key --populate archlinux",
+    "pacman -Sy --needed --noconfirm archlinux-keyring",
+  ].join("\n");
 }
 
 /** Cross-distro "ensure package `$1` is installed" one-liner (apt/apk/dnf/pacman). */
@@ -83,7 +127,8 @@ function herdrStub(): string {
  *  AFTER this so degraded Shepherd can still boot. */
 function baselineCommands(): string[] {
   return [
-    // Arch keyring rot (#1422) fails the first pacman install; refresh it before any
+    // Arch keyring rot (#1422) fails the first pacman install, and the image's own boot-time
+    // keyring init races ours (#1738) — take ownership of the keyring and refresh it before any
     // package op. No-op on non-Arch images. See archKeyringRefresh().
     archKeyringRefresh(),
     ensurePkg("curl"),

--- a/ci/onboarding-harness/seed.ts
+++ b/ci/onboarding-harness/seed.ts
@@ -55,6 +55,14 @@ const PROFILES = ["default", "shep-onb"];
  *  `timeout 120` bounds the stop: it blocks on the unit's job, and incus.ts's RUNNER_TIMEOUT_MS
  *  is 20min — unbounded, a wedged stop would turn a fast, legible failure into a hung run.
  *
+ *  The stop is NOT `|| true`-swallowed. Blanket-ignoring its status would hide a wedged stop
+ *  (timeout ⇒ 124) or an unreachable bus, and we would then `rm -rf` + re-init the keyring while
+ *  the writer we failed to stop is STILL RUNNING — silently re-entering the very race this
+ *  function exists to close, degrading back to a flaky nightly. So we separate the one benign
+ *  case from real failures: `systemctl list-unit-files` (0 present / 1 absent) gates the stop, an
+ *  absent unit is skipped, and a present unit that will not stop fails this CHECKED baseline step
+ *  loudly. `reset-failed` keeps its `|| true` — it is pure cosmetics.
+ *
  *  Guarded on `command -v pacman` so it's a clean no-op on apt/apk/dnf images (the 8 non-Arch
  *  scenarios). Runs as root — `driver.exec` → `incus exec` is root by default, which
  *  `pacman-key` and `systemctl` require. */
@@ -62,9 +70,28 @@ function archKeyringRefresh(): string {
   return [
     "command -v pacman >/dev/null 2>&1 || exit 0",
     "set -e",
-    "timeout 120 systemctl stop pacman-init.service archlinux-keyring-wkd-sync.timer " +
-      "archlinux-keyring-wkd-sync.service >/dev/null 2>&1 || true",
-    "systemctl reset-failed pacman-init.service >/dev/null 2>&1 || true",
+    // Only systemd can be running the writers. No systemd as PID 1 ⇒ pacman-init/wkd-sync
+    // never ran ⇒ nothing to race, so skip the block rather than fail on a missing bus.
+    'if [ "$(cat /proc/1/comm 2>/dev/null)" = systemd ]; then',
+    // systemd IS PID 1, so the bus must answer. If it doesn't we cannot know whether a
+    // writer is live — fail loudly instead of silently proceeding (see the `continue` below,
+    // which would otherwise read an unreachable bus as "unit absent").
+    "  systemctl list-unit-files --no-legend >/dev/null 2>&1 || " +
+      "{ echo 'FATAL: systemd is PID 1 but its bus is unreachable; cannot verify the keyring " +
+      "writers are stopped' >&2; exit 1; }",
+    "  for u in pacman-init.service archlinux-keyring-wkd-sync.timer " +
+      "archlinux-keyring-wkd-sync.service; do",
+    // Absent unit (exit 1) is the ONLY benign skip: there is nothing to stop.
+    '    systemctl list-unit-files "$u" >/dev/null 2>&1 || continue',
+    // The unit exists, so a stop MUST succeed. Anything else — a 120s timeout (124), a bus
+    // error — means a writer may still be live, and rebuilding the keyring under it would
+    // silently re-enter the #1738 race. Fail the (checked) baseline step instead.
+    '    timeout 120 systemctl stop "$u" >/dev/null 2>&1 || ' +
+      '{ rc=$?; echo "FATAL: could not stop $u (exit $rc); refusing to rebuild the keyring ' +
+      'while a writer may still be running" >&2; exit 1; }',
+    "  done",
+    "  systemctl reset-failed pacman-init.service >/dev/null 2>&1 || true",
+    "fi",
     "gpgconf --homedir /etc/pacman.d/gnupg --kill all >/dev/null 2>&1 || true",
     "rm -rf /etc/pacman.d/gnupg",
     "pacman-key --init",

--- a/test/onboarding-harness/seed.test.ts
+++ b/test/onboarding-harness/seed.test.ts
@@ -110,6 +110,12 @@ describe("seedInstance", () => {
     expect(/systemctl stop[^\n]*\|\|\s*true/.test(step)).toBe(false);
     expect(step).toContain('systemctl list-unit-files "$u"');
     expect(/systemctl stop[^\n]*\|\|[\s\S]*exit 1/.test(step)).toBe(true);
+
+    // …and LEGIBLE: the stop must keep its stderr (only stdout is dropped), or systemd's own
+    // reason (job timed out / failed to connect to bus / …) is lost and the FATAL says only
+    // "exit 124". seedInstance propagates stderr into the thrown baseline error, so that
+    // reason is what a human debugging a red nightly actually reads.
+    expect(/timeout 120 systemctl stop "\$u" >\/dev\/null(?! ?2>&1)/.test(step)).toBe(true);
   });
 
   it("the herdr stub is a CHECKED baseline step (a failure aborts the seed)", async () => {

--- a/test/onboarding-harness/seed.test.ts
+++ b/test/onboarding-harness/seed.test.ts
@@ -66,6 +66,43 @@ describe("seedInstance", () => {
     expect(flat.some((c) => c.includes("herdr.dev"))).toBe(false);
   });
 
+  it("the Arch keyring step owns the keyring and is fail-closed (#1738)", async () => {
+    const { calls, run } = recorder();
+    const d = new IncusDriver(run, "shep-onb-");
+    await seedInstance(d, scenario, "/tmp/shepherd.tar");
+
+    const flat = calls.map((c) => c.join(" "));
+    const step = flat.find((c) => c.includes("pacman-key --populate archlinux"))!;
+    expect(step).toBeDefined();
+
+    // Stays a clean no-op on the 8 non-Arch (apt/apk/dnf) scenarios.
+    expect(step).toContain("command -v pacman");
+
+    // FAIL-CLOSED. `driver.exec` runs this via `sh -c`, which returns only the LAST
+    // command's status — and `pacman -Sy --needed archlinux-keyring` exits 0 ("nothing to
+    // do") when the version already matches. Without `set -e` a failed init/populate would
+    // be swallowed and the step would report success on an EMPTY keyring. Either `set -e`
+    // or an unbroken `&&` chain from init through the sync satisfies the contract.
+    const failClosed =
+      /(^|\n)set -e(\s|$)/.test(step) ||
+      /pacman-key --init\s*&&[\s\S]*pacman -Sy[^\n]*archlinux-keyring/.test(step);
+    expect(failClosed).toBe(true);
+
+    // Stops the image's OWN boot-time keyring writers BEFORE touching pacman-key, or we
+    // race them (#1738): pacman-init.service (After=time-sync.target, so it can fire well
+    // after our DNS gate) and the wkd-sync timer (Persistent=true ⇒ boot catch-up run).
+    const stopIdx = step.indexOf("systemctl stop");
+    const keyIdx = step.indexOf("pacman-key");
+    expect(stopIdx).toBeGreaterThanOrEqual(0);
+    expect(stopIdx).toBeLessThan(keyIdx);
+    expect(step).toContain("pacman-init.service");
+    expect(step).toContain("archlinux-keyring-wkd-sync.timer");
+
+    // BOUNDED: `systemctl stop` blocks on the unit's job; unbounded it could hang to the
+    // 20min RUNNER_TIMEOUT_MS SIGKILL instead of failing fast.
+    expect(step).toContain("timeout 120 systemctl stop");
+  });
+
   it("the herdr stub is a CHECKED baseline step (a failure aborts the seed)", async () => {
     const calls: string[][] = [];
     const run = async (args: string[]): Promise<IncusExec> => {

--- a/test/onboarding-harness/seed.test.ts
+++ b/test/onboarding-harness/seed.test.ts
@@ -101,6 +101,15 @@ describe("seedInstance", () => {
     // BOUNDED: `systemctl stop` blocks on the unit's job; unbounded it could hang to the
     // 20min RUNNER_TIMEOUT_MS SIGKILL instead of failing fast.
     expect(step).toContain("timeout 120 systemctl stop");
+
+    // The stop must NOT be `|| true`-swallowed: that would hide a wedged stop (timeout ⇒ 124)
+    // or an unreachable bus, and we would then rm -rf + re-init the keyring while the writer
+    // we failed to stop is still running — silently back in the #1738 race. An ABSENT unit is
+    // the only benign skip (gated on `list-unit-files`); a present-but-unstoppable one must
+    // fail this checked baseline step loudly.
+    expect(/systemctl stop[^\n]*\|\|\s*true/.test(step)).toBe(false);
+    expect(step).toContain('systemctl list-unit-files "$u"');
+    expect(/systemctl stop[^\n]*\|\|[\s\S]*exit 1/.test(step)).toBe(true);
   });
 
   it("the herdr stub is a CHECKED baseline step (a failure aborts the seed)", async () => {


### PR DESCRIPTION
Fixes #1738 — the nightly's `herdr-missing` **BOOT CRASH**.

## Root cause: a race, not a broken command

`images:archlinux` ships its **own** boot-time keyring init:

```
# /etc/systemd/system/pacman-init.service   (from the Incus image)
ConditionPathIsDirectory=!/etc/pacman.d/gnupg
After=time-sync.target
ExecStart=/usr/bin/pacman-key --init
ExecStart=/usr/bin/pacman-key --populate
```

`seed.ts::archKeyringRefresh()` ran **those exact same commands** itself. The harness gates only on DNS (`waitForDns`), which resolves long before `time-sync.target` — so our `pacman-key --init` ran *concurrently with the image's*. Two gpg processes on one `/etc/pacman.d/gnupg`, and the loser dies with exactly the reported `can't open pubring.gpg` / `no writable keyring found` / `could not be locally signed`.

Since `runScenario` launches a **fresh instance per scenario**, *both* Arch scenarios are exposed — which one loses on a given night is jitter. That's why the nightly looked flaky and self-inconsistent, and why `herdr-outdated` passing was luck, not immunity.

## The fix

Take sole ownership of the keyring instead of racing for it:

- **Stop every writer first.** `pacman-init.service`, plus `archlinux-keyring-wkd-sync.timer`/`.service` — enumerating `systemctl list-units --all '*keyring*' '*pacman*'` showed wkd-sync is `Persistent=true`, so an aged image cache can fire a boot catch-up run into the same homedir. The socket-activated `gpg-agent@`/`dirmngr@`/`keyboxd@` units *survive* stopping pacman-init, so `gpgconf --kill all` releases the homedir before we delete it. Bounded by `timeout 120` — `RUNNER_TIMEOUT_MS` is 20 min, and an unbounded stop would wedge a run rather than fail fast.
- **Rebuild unconditionally** rather than probe-and-heal: after a race the unit finishes its own populate, so the homedir converges to healthy and a `pacman-key --list-keys` probe would exit 0 and skip the heal; and `ConditionPathIsDirectory` makes `systemctl start` a no-op once the dir exists. Safe here — throw-away instances whose keyring we fully own.
- **`set -e` restores fail-closed.** `driver.exec` runs the step via `sh -c`, which returns only the **last** command's status, and `pacman -Sy --needed archlinux-keyring` exits 0 on "nothing to do". Without it a failed init/populate is swallowed and the step reports success **on an empty keyring**, resurfacing later as a misleading `curl`/`unzip` error.

Still a clean no-op on the 8 non-Arch scenarios (`command -v pacman` guard retained, asserted in test).

## Verification

| Check | Result |
| --- | --- |
| Raced micro-repro, current command | **3/3 fail** — reproduces #1738, same fingerprint `D8AFDDA0…` |
| Raced micro-repro, this fix | **5/5 pass**, keyring intact after boot settles, signature-verified `pacman -S` succeeds |
| Fail-closed (break `--populate`) | Exits **1** (the pre-`set -e` shape exited **0**) |
| Negative test (pre-corrupt keyring) | Heals, signed install succeeds |
| `onboarding:test --scenario herdr-missing` | **5/5 green** (was BOOT CRASH) |
| `onboarding:test --scenario herdr-outdated` | **2/2**, no baseline failure |
| **Full `onboarding:test`** | **6/6 green** (was 5/6); other 9 scenarios unchanged |
| `bun run lint`, `bun test` | pass (6963 tests) |

## Follow-up (deliberately out of scope)

`src/remediations.ts` (`GIT_INSTALL`'s pacman branch) has a superficially similar `pacman-key --init && --populate` shape. No scenario exercises it (git-missing is Alpine) and it ships to user machines, so it is untouched here.

⚠️ **If that is ever revisited, the `rm -rf /etc/pacman.d/gnupg` self-heal must NOT be ported to it.** It is destructive on a real user's host, and the defect it defends against does not exist there — a long-installed Arch box has no `pacman-init.service` and no fresh-boot keyring init to race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)