### PR TITLE
fix(ui): only escalate the review banner on real operator input

### DIFF
--- a/src/operator-activity.ts
+++ b/src/operator-activity.ts
@@ -12,11 +12,48 @@
  *  URL-bar toggles. It is NOT operator typing, so it must not stamp the seam. */
 const RESIZE_PREFIX = "\x00resize:";
 
-/** True iff `frame` is genuine operator keystroke input (i.e. not a resize
- *  control frame). The only non-keystroke frame this WS carries is the resize
- *  frame above; everything else is real input. */
+/**
+ * Frames this WS carries that nobody typed. The browser forwards everything xterm
+ * emits, and with mouse tracking on (Claude Code runs that way) that includes a
+ * report for every mouse move / click / drag / wheel, plus focus reports and the
+ * terminal's replies to the app's own queries. Treating those as "the operator
+ * typed" is wrong — it is the same defect that made the review banner claim
+ * "You're typing" on mere pointer movement (issue #1022).
+ *
+ * Each alternative is anchored to its introducer and spelled out through its
+ * terminator — no `.*` — so a reply cannot swallow real bytes batched after it in
+ * the same frame. OSC accepts both terminators (BEL and ST).
+ *
+ * The client fixes the banner a better way (it counts input-origin DOM events, see
+ * ui/src/lib/terminal-input.ts), which is not available here: the server sees only
+ * bytes. One consequence is recorded and accepted — in an alt-buffer TUI that has
+ * NOT negotiated wheel reporting (vim, less), xterm translates a wheel scroll into
+ * `\x1b[A`/`\x1b[B`, byte-identical to a typed arrow key, so it still stamps here.
+ * The seam has no read consumer yet, and those are the bytes the PTY genuinely
+ * receives.
+ */
+const NON_TYPING = new RegExp(
+  [
+    "\\x1b\\[<\\d+;\\d+;\\d+[Mm]", // SGR (and SGR-pixels) mouse report
+    "\\x1b\\[\\d+;\\d+;\\d+M", // urxvt (1015) mouse report
+    "\\x1b\\[[IO]", // focus in / focus out
+    "\\x1b\\[[?>]\\d*(?:;\\d+)*c", // Device Attributes reply
+    "\\x1b\\[\\d+;\\d+R", // cursor-position (DSR) reply
+    "\\x1b\\[\\?\\d+;\\d+\\$y", // DECRPM reply
+    "\\x1b\\[\\d+;\\d+;\\d+t", // XTWINOPS report
+    "\\x1b\\][^\\x07\\x1b]*(?:\\x07|\\x1b\\\\)", // OSC reply (BEL- or ST-terminated)
+    "\\x1bP[^\\x1b]*\\x1b\\\\", // DCS reply (XTGETTCAP, DECRQSS)
+  ].join("|"),
+  "g",
+);
+
+/** True iff `frame` is genuine operator input: not a resize control frame, and not
+ *  purely terminal-generated chatter. A frame counts as typed if ANY byte survives
+ *  stripping the known non-typing sequences — whitespace and control bytes included
+ *  (a typed space, Enter or Ctrl-C is real input); only an empty residue is not. */
 export function isOperatorKeystroke(frame: string): boolean {
-  return !frame.startsWith(RESIZE_PREFIX);
+  if (frame.startsWith(RESIZE_PREFIX)) return false;
+  return frame.replace(NON_TYPING, "").length > 0;
 }
 
 /** Throttle window: at most one stamp per session per this many ms, so a fast

--- a/src/operator-activity.ts
+++ b/src/operator-activity.ts
@@ -46,7 +46,8 @@ const NON_TYPING = new RegExp(
     "\\x1b\\[M[\\s\\S]{3}", // X10/default mouse report (button + col + row as raw bytes)
     "\\x1b\\[[IO]", // focus in / focus out
     "\\x1b\\[[?>]\\d*(?:;\\d+)*c", // Device Attributes reply
-    "\\x1b\\[\\??\\d+;\\d+R", // cursor-position reply: DSR and DECXCPR (`?` form)
+    "\\x1b\\[\\??\\d+;\\d+R", // cursor-position reply: DSR-6 and DECXCPR (`?` form)
+    "\\x1b\\[\\d*n", // DSR-5 status reply (`\x1b[0n`) — same deviceStatus handler as DSR-6
     "\\x1b\\[\\?\\d+;\\d+\\$y", // DECRPM reply
     "\\x1b\\[\\d+;\\d+;\\d+t", // XTWINOPS report
     "\\x1b\\][^\\x07\\x1b]*(?:\\x07|\\x1b\\\\)", // OSC reply (BEL- or ST-terminated)

--- a/src/operator-activity.ts
+++ b/src/operator-activity.ts
@@ -24,6 +24,13 @@ const RESIZE_PREFIX = "\x00resize:";
  * terminator — no `.*` — so a reply cannot swallow real bytes batched after it in
  * the same frame. OSC accepts both terminators (BEL and ST).
  *
+ * All three mouse encodings are covered, including X10/default (`\x1b[M` + 3 raw
+ * bytes), which an app gets by enabling ?1000/?1002/?1003 without negotiating an
+ * extended encoding (vim with ttymouse=xterm). Today that frame cannot actually
+ * reach us — xterm emits default-encoding reports on `onBinary`, which the browser
+ * never subscribes to, so they are dropped client-side — but the predicate should
+ * be complete in the encoding, not in what one client currently forwards.
+ *
  * The client fixes the banner a better way (it counts input-origin DOM events, see
  * ui/src/lib/terminal-input.ts), which is not available here: the server sees only
  * bytes. One consequence is recorded and accepted — in an alt-buffer TUI that has
@@ -36,9 +43,10 @@ const NON_TYPING = new RegExp(
   [
     "\\x1b\\[<\\d+;\\d+;\\d+[Mm]", // SGR (and SGR-pixels) mouse report
     "\\x1b\\[\\d+;\\d+;\\d+M", // urxvt (1015) mouse report
+    "\\x1b\\[M[\\s\\S]{3}", // X10/default mouse report (button + col + row as raw bytes)
     "\\x1b\\[[IO]", // focus in / focus out
     "\\x1b\\[[?>]\\d*(?:;\\d+)*c", // Device Attributes reply
-    "\\x1b\\[\\d+;\\d+R", // cursor-position (DSR) reply
+    "\\x1b\\[\\??\\d+;\\d+R", // cursor-position reply: DSR and DECXCPR (`?` form)
     "\\x1b\\[\\?\\d+;\\d+\\$y", // DECRPM reply
     "\\x1b\\[\\d+;\\d+;\\d+t", // XTWINOPS report
     "\\x1b\\][^\\x07\\x1b]*(?:\\x07|\\x1b\\\\)", // OSC reply (BEL- or ST-terminated)

--- a/test/operator-activity.test.ts
+++ b/test/operator-activity.test.ts
@@ -34,6 +34,7 @@ test("focus reports and terminal query replies are NOT operator input", () => {
   expect(isOperatorKeystroke("\x1b[>0;10;1c")).toBe(false); // DA2
   expect(isOperatorKeystroke("\x1b[12;3R")).toBe(false); // cursor position (DSR)
   expect(isOperatorKeystroke("\x1b[?12;3R")).toBe(false); // cursor position (DECXCPR)
+  expect(isOperatorKeystroke("\x1b[0n")).toBe(false); // DSR-5 status reply
   expect(isOperatorKeystroke("\x1b[?2026;2$y")).toBe(false); // DECRPM
   expect(isOperatorKeystroke("\x1b[8;40;120t")).toBe(false); // XTWINOPS
   expect(isOperatorKeystroke("\x1b]11;rgb:1e1e/1e1e/2e2e\x07")).toBe(false); // OSC, BEL-terminated
@@ -49,6 +50,7 @@ test("typed bytes batched after a reply still count as operator input", () => {
   // The non-typing patterns are anchored through their terminators (no greedy `.*`),
   // so a reply can't swallow real input that arrives in the same frame.
   expect(isOperatorKeystroke("\x1b[12;3Rx")).toBe(true);
+  expect(isOperatorKeystroke("\x1b[0nx")).toBe(true);
   expect(isOperatorKeystroke("\x1b[<35;12;5Ma")).toBe(true);
   expect(isOperatorKeystroke("\x1b]11;rgb:1e1e/1e1e/2e2e\x07hi")).toBe(true);
 });

--- a/test/operator-activity.test.ts
+++ b/test/operator-activity.test.ts
@@ -16,6 +16,50 @@ test("a resize control frame is NOT operator input", () => {
   expect(isOperatorKeystroke("\x00resize:120:40\n")).toBe(false);
 });
 
+test("a mouse report is NOT operator input", () => {
+  // With mouse tracking on, xterm forwards a report for every move/click/drag/wheel
+  // over the terminal — nobody typed those (issue #1022).
+  expect(isOperatorKeystroke("\x1b[<35;12;5M")).toBe(false); // SGR motion
+  expect(isOperatorKeystroke("\x1b[<0;12;5M")).toBe(false); // SGR press
+  expect(isOperatorKeystroke("\x1b[<0;12;5m")).toBe(false); // SGR release
+  expect(isOperatorKeystroke("\x1b[<64;12;5M")).toBe(false); // SGR wheel up
+  expect(isOperatorKeystroke("\x1b[32;12;5M")).toBe(false); // urxvt (1015)
+});
+
+test("focus reports and terminal query replies are NOT operator input", () => {
+  expect(isOperatorKeystroke("\x1b[I")).toBe(false); // focus in
+  expect(isOperatorKeystroke("\x1b[O")).toBe(false); // focus out
+  expect(isOperatorKeystroke("\x1b[?62;1;6c")).toBe(false); // DA1
+  expect(isOperatorKeystroke("\x1b[>0;10;1c")).toBe(false); // DA2
+  expect(isOperatorKeystroke("\x1b[12;3R")).toBe(false); // cursor position (DSR)
+  expect(isOperatorKeystroke("\x1b[?2026;2$y")).toBe(false); // DECRPM
+  expect(isOperatorKeystroke("\x1b[8;40;120t")).toBe(false); // XTWINOPS
+  expect(isOperatorKeystroke("\x1b]11;rgb:1e1e/1e1e/2e2e\x07")).toBe(false); // OSC, BEL-terminated
+  expect(isOperatorKeystroke("\x1b]10;rgb:c0c0/c0c0/c0c0\x1b\\")).toBe(false); // OSC, ST-terminated
+  expect(isOperatorKeystroke("\x1bP1+r5463=787465726d\x1b\\")).toBe(false); // DCS (XTGETTCAP)
+});
+
+test("a burst of mouse reports in one frame is NOT operator input", () => {
+  expect(isOperatorKeystroke("\x1b[<35;10;5M\x1b[<35;11;5M\x1b[<35;12;5M")).toBe(false);
+});
+
+test("typed bytes batched after a reply still count as operator input", () => {
+  // The non-typing patterns are anchored through their terminators (no greedy `.*`),
+  // so a reply can't swallow real input that arrives in the same frame.
+  expect(isOperatorKeystroke("\x1b[12;3Rx")).toBe(true);
+  expect(isOperatorKeystroke("\x1b[<35;12;5Ma")).toBe(true);
+  expect(isOperatorKeystroke("\x1b]11;rgb:1e1e/1e1e/2e2e\x07hi")).toBe(true);
+});
+
+test("whitespace and control bytes are operator input", () => {
+  expect(isOperatorKeystroke(" ")).toBe(true); // typed space
+  expect(isOperatorKeystroke("\r")).toBe(true); // Enter
+  expect(isOperatorKeystroke("\t")).toBe(true); // Tab
+  expect(isOperatorKeystroke("\x03")).toBe(true); // Ctrl-C
+  expect(isOperatorKeystroke("\x1b")).toBe(true); // Escape
+  expect(isOperatorKeystroke("\x1b[200~pasted\x1b[201~")).toBe(true); // bracketed paste
+});
+
 test("stamp writes the timestamp and getLast reads it back", () => {
   const map = new Map<string, number>();
   expect(getLastOperatorKeystrokeAt(map, "s1")).toBeUndefined();

--- a/test/operator-activity.test.ts
+++ b/test/operator-activity.test.ts
@@ -24,6 +24,7 @@ test("a mouse report is NOT operator input", () => {
   expect(isOperatorKeystroke("\x1b[<0;12;5m")).toBe(false); // SGR release
   expect(isOperatorKeystroke("\x1b[<64;12;5M")).toBe(false); // SGR wheel up
   expect(isOperatorKeystroke("\x1b[32;12;5M")).toBe(false); // urxvt (1015)
+  expect(isOperatorKeystroke("\x1b[M\x20\x30\x40")).toBe(false); // X10/default encoding
 });
 
 test("focus reports and terminal query replies are NOT operator input", () => {
@@ -32,6 +33,7 @@ test("focus reports and terminal query replies are NOT operator input", () => {
   expect(isOperatorKeystroke("\x1b[?62;1;6c")).toBe(false); // DA1
   expect(isOperatorKeystroke("\x1b[>0;10;1c")).toBe(false); // DA2
   expect(isOperatorKeystroke("\x1b[12;3R")).toBe(false); // cursor position (DSR)
+  expect(isOperatorKeystroke("\x1b[?12;3R")).toBe(false); // cursor position (DECXCPR)
   expect(isOperatorKeystroke("\x1b[?2026;2$y")).toBe(false); // DECRPM
   expect(isOperatorKeystroke("\x1b[8;40;120t")).toBe(false); // XTWINOPS
   expect(isOperatorKeystroke("\x1b]11;rgb:1e1e/1e1e/2e2e\x07")).toBe(false); // OSC, BEL-terminated

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -40,6 +40,7 @@
   import { trimTrailingWhitespace } from "$lib/terminalSelection";
   import { composeKeystrokes } from "$lib/compose";
   import { findCommandLinks } from "$lib/slashLinks";
+  import { createTypingCounter } from "$lib/terminal-input";
   import { shouldForwardEscape } from "$lib/terminalEscape";
   import { altComboKey, isCommandBarChord } from "./herd-keynav";
   import { detectNotesKey } from "$lib/notesAffordance";
@@ -281,12 +282,27 @@
 
   // composed send: routes the line through composeKeystrokes (atomic bracketed
   // paste) instead of xterm's textarea, sidestepping the Android IME duplication bug.
-  const sendComposed = (text: string) => conn?.send(composeKeystrokes(text));
+  const sendComposed = (text: string) => {
+    bumpOperatorInput();
+    conn?.send(composeKeystrokes(text));
+  };
 
-  // monotonic local keystroke counter, bumped on every term.onData — drives the
+  // monotonic counter of genuine operator input into this PTY — drives the
   // ReviewInFlightBanner's client-side escalation (issue #1022). Pure UI signal,
   // independent of the server-side lastOperatorKeystrokeAt seam.
+  //
+  // RULE: every path that puts *operator* input into the PTY bumps this. That is
+  // (a) input through xterm's helper textarea (createTypingCounter, wired at
+  // term.open) and (b) the sends below that bypass xterm entirely — ComposeBar,
+  // the touch key bar, image paste, slash-command taps, the synthesized Shift+Enter
+  // and Escape. It is NOT bumped from term.onData: that channel also carries mouse
+  // reports (mouse tracking is on — see agentOwnsScroll), focus reports and the
+  // terminal's replies to app queries, none of which are typing, and counting them
+  // made the banner claim "You're typing" on mere pointer movement.
+  // View control (jump-to-bottom, /tui fullscreen) is deliberately NOT counted —
+  // it moves the view, it doesn't enter text that could collide with a steer.
   let opKeystrokes = $state(0);
+  const bumpOperatorInput = () => opKeystrokes++;
   // occupied height (px) of the ReviewInFlightBanner while it's shown, 0 otherwise.
   // Published as --review-banner-h on .vp-body so the floating jump-to-latest button
   // (a sibling in ViewportTermBanners) can lift clear of the bottom banner strip.
@@ -1334,6 +1350,10 @@
     try {
       for (const f of imgs) {
         const path = await uploadImage(f, session.id);
+        // Genuine operator input: the capture-phase image-paste interceptor on `el`
+        // stopImmediatePropagation()s, so xterm's textarea never sees this paste —
+        // count it here or a pasted screenshot would never escalate the banner.
+        bumpOperatorInput();
         conn.send(` \x1b[200~${path}\x1b[201~ `);
       }
     } catch {
@@ -1557,6 +1577,10 @@
     term.open(el);
     fit.fit();
 
+    // Count operator input arriving through xterm's helper textarea (typing, IME,
+    // paste, dropped text). Only valid after open() — that's when the textarea exists.
+    const typingCounter = createTypingCounter(term, bumpOperatorInput);
+
     // WebGL renderer. The default DOM renderer flows text with a per-glyph
     // letter-spacing derived from a fractional cell width; at a non-integer
     // fontSize (12.5) on a HiDPI display (devicePixelRatio 2) xterm's glyph
@@ -1605,10 +1629,10 @@
       },
     );
     conn = c;
-    term.onData((d) => {
-      opKeystrokes++;
-      c.send(d);
-    });
+    // Forward everything xterm emits — keystrokes AND the mouse/focus/query-reply
+    // frames the app negotiated. Deliberately does NOT bump opKeystrokes: see the
+    // RULE at its declaration.
+    term.onData((d) => c.send(d));
 
     // Linkify slash-command tokens Claude suggests in its output (e.g. "/squad",
     // "/gsd-quick") so a tap pastes the command into the prompt — on a phone the
@@ -1643,6 +1667,7 @@
               end: { x: colAt[f.end - 1]! + 1, y: bufferLineNumber },
             },
             activate: () => {
+              bumpOperatorInput();
               c.send(`\x1b[200~/${f.name}\x1b[201~`);
             },
           })),
@@ -1723,6 +1748,7 @@
         !e.metaKey
       ) {
         e.preventDefault();
+        bumpOperatorInput();
         c.send("\n");
         return false;
       }
@@ -1809,6 +1835,9 @@
         return;
       e.preventDefault();
       e.stopImmediatePropagation();
+      // stopImmediatePropagation() in the window capture phase means xterm's textarea
+      // never sees this keydown — count it here or Escape wouldn't escalate.
+      bumpOperatorInput();
       c.send("\x1b");
       term.focus();
     };
@@ -2100,6 +2129,7 @@
       el?.removeEventListener("touchmove", onTouchMove);
       el?.removeEventListener("touchend", onTouchEnd);
       el?.removeEventListener("wheel", onWheelTrack, { capture: true });
+      typingCounter.destroy();
       stopFling();
       scrollSub.dispose();
       bufSub.dispose();
@@ -2989,7 +3019,10 @@
       onedit={(id) => onedit?.(id)}
       {mobile}
       {touch}
-      termSend={(seq) => conn?.send(seq)}
+      termSend={(seq) => {
+        bumpOperatorInput();
+        conn?.send(seq);
+      }}
       {micAvailable}
       ondictate={() => {
         composeDictate = true;
@@ -3004,7 +3037,10 @@
     {mobile}
     {touch}
     {tab}
-    send={(seq) => conn?.send(seq)}
+    send={(seq) => {
+      bumpOperatorInput();
+      conn?.send(seq);
+    }}
     {notesKey}
     {enter}
     {uploading}

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -294,13 +294,15 @@
   // RULE: every path that puts *operator* input into the PTY bumps this. That is
   // (a) input through xterm's helper textarea (createTypingCounter, wired at
   // term.open) and (b) the sends below that bypass xterm entirely — ComposeBar,
-  // the touch key bar, image paste, slash-command taps, the synthesized Shift+Enter
-  // and Escape. It is NOT bumped from term.onData: that channel also carries mouse
-  // reports (mouse tracking is on — see agentOwnsScroll), focus reports and the
-  // terminal's replies to app queries, none of which are typing, and counting them
-  // made the banner claim "You're typing" on mere pointer movement.
-  // View control (jump-to-bottom, /tui fullscreen) is deliberately NOT counted —
-  // it moves the view, it doesn't enter text that could collide with a steer.
+  // the touch key bar, image paste, slash-command taps, the /tui fullscreen redraw
+  // (a bracketed paste + CR, i.e. a submitted prompt line), the synthesized
+  // Shift+Enter and Escape. It is NOT bumped from term.onData: that channel also
+  // carries mouse reports (mouse tracking is on — see agentOwnsScroll), focus
+  // reports and the terminal's replies to app queries, none of which are typing,
+  // and counting them made the banner claim "You're typing" on mere pointer movement.
+  // The one deliberate carve-out is the jump-to-top/bottom scroll sends: those are
+  // navigation keys (Ctrl+End / Ctrl+Home + PageUp) that the agent interprets as
+  // scrolling and never as prompt text, so they can't collide with an incoming steer.
   let opKeystrokes = $state(0);
   const bumpOperatorInput = () => opKeystrokes++;
   // occupied height (px) of the ReviewInFlightBanner while it's shown, 0 otherwise.
@@ -1492,6 +1494,9 @@
   //    intercept mid-typing.
   function redrawFullscreen() {
     redrawOpen = false;
+    // Same byte path as the compose bar: a bracketed paste + submitting CR. It really
+    // does enter (and send) a line at the agent's prompt, so it counts as operator input.
+    bumpOperatorInput();
     conn?.send(composeKeystrokes("/tui fullscreen"));
   }
   // 4) Heavy: force a fresh provider resume — re-renders the FULL conversation

--- a/ui/src/lib/components/viewport/ReviewInFlightBanner.browser.test.ts
+++ b/ui/src/lib/components/viewport/ReviewInFlightBanner.browser.test.ts
@@ -222,3 +222,28 @@ describe("ReviewInFlightBanner preview — negative cases (no preview / no dim)"
     expect(document.querySelector(".rb-preview")).toBeNull();
   });
 });
+
+// The `keystrokes` prop is a monotonic count of genuine operator input into the PTY
+// (Viewport's opKeystrokes). It is deliberately NOT a count of xterm onData frames —
+// those also carry mouse reports, which is what used to escalate this banner on mere
+// pointer movement (issue #1022). The banner just reacts to the number going up.
+describe("ReviewInFlightBanner — sticky escalation on operator input", () => {
+  it("stays calm while the count holds, escalates once it rises mid-review", async () => {
+    planGates.applyReviewing(ID, true);
+    const { rerender } = await render(ReviewInFlightBanner, props({ keystrokes: 0 }) as never);
+
+    await expect.poll(() => banner()?.getAttribute("data-tone")).toBe("calm");
+
+    // pointer activity no longer moves the count → banner stays calm
+    await rerender(props({ keystrokes: 0 }) as never);
+    await expect.poll(() => banner()?.getAttribute("data-tone")).toBe("calm");
+
+    // the operator types → the count rises → escalate, and stick
+    await rerender(props({ keystrokes: 1 }) as never);
+    await expect.poll(() => banner()?.getAttribute("data-tone")).toBe("escalated");
+    await expect.poll(() => banner()?.textContent?.includes(m.reviewbanner_escalated())).toBe(true);
+
+    await rerender(props({ keystrokes: 1 }) as never);
+    await expect.poll(() => banner()?.getAttribute("data-tone")).toBe("escalated");
+  });
+});

--- a/ui/src/lib/terminal-input.browser.test.ts
+++ b/ui/src/lib/terminal-input.browser.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Terminal } from "@xterm/xterm";
+import "@xterm/xterm/css/xterm.css";
+import { createTypingCounter } from "./terminal-input";
+
+// The regression this pins (issue #1022): the banner's escalation counter used to
+// be bumped from term.onData, which — with mouse tracking on, the mode Claude Code
+// runs in — also carries a report for every mouse move/click/drag/wheel. Moving the
+// mouse made the banner claim "You're typing".
+//
+// So each pointer case asserts BOTH halves: that the gesture really did produce an
+// onData frame (i.e. the frame the old code would have counted was genuinely
+// emitted — without this the test could pass against a broken mechanism), AND that
+// the counter did not move. A real xterm Terminal in a real browser is what makes
+// the first half meaningful; a hand-fed frame would be circular.
+
+/** Mouse-tracking modes a TUI plausibly negotiates. agentOwnsScroll (Viewport.svelte)
+ *  only tells us mouseTrackingMode !== "none", not which one — so cover all three.
+ *  They differ in what they report: 1000 press/release, 1002 adds drag, 1003 adds
+ *  bare motion. All with SGR (1006) encoding, which routes reports through onData. */
+const MODES = [
+  { name: "?1000 (press/release)", seq: "\x1b[?1000;1006h", reportsMotion: false },
+  { name: "?1002 (＋drag)", seq: "\x1b[?1002;1006h", reportsMotion: false },
+  { name: "?1003 (＋motion)", seq: "\x1b[?1003;1006h", reportsMotion: true },
+] as const;
+
+let host: HTMLDivElement;
+let term: Terminal;
+let counter: { destroy(): void };
+let count = 0;
+let frames: string[] = [];
+
+/** Terminal.write is async (parser queue); flush before asserting on emitted data. */
+const flush = () => new Promise<void>((r) => term.write("", r));
+
+/** Cell-centre-ish coordinates inside the screen element, so xterm maps the event
+ *  onto a real cell (a report is only emitted for an in-bounds col/row). */
+function screenEl(): HTMLElement {
+  const s = host.querySelector<HTMLElement>(".xterm-screen");
+  if (!s) throw new Error("no .xterm-screen — term.open() did not render");
+  return s;
+}
+
+function pointerEventInit(el: HTMLElement): MouseEventInit {
+  const r = el.getBoundingClientRect();
+  return {
+    clientX: r.left + 20,
+    clientY: r.top + 20,
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+    buttons: 1,
+  };
+}
+
+async function setup(modeSeq: string) {
+  host = document.createElement("div");
+  host.style.width = "640px";
+  host.style.height = "320px";
+  document.body.appendChild(host);
+
+  term = new Terminal({ allowProposedApi: true });
+  term.open(host);
+
+  frames = [];
+  term.onData((d) => frames.push(d));
+
+  count = 0;
+  counter = createTypingCounter(term, () => count++);
+
+  term.write(modeSeq);
+  await flush();
+}
+
+afterEach(() => {
+  counter?.destroy();
+  term?.dispose();
+  host?.remove();
+});
+
+describe("createTypingCounter — pointer activity is not typing", () => {
+  for (const mode of MODES) {
+    describe(mode.name, () => {
+      beforeEach(async () => await setup(mode.seq));
+
+      it("a click reports to the app but does not count as typing", async () => {
+        const el = screenEl();
+        const init = pointerEventInit(el);
+        el.dispatchEvent(new MouseEvent("mousedown", init));
+        el.dispatchEvent(new MouseEvent("mouseup", { ...init, buttons: 0 }));
+        await flush();
+
+        expect(frames.length, "click emitted a mouse report on onData").toBeGreaterThan(0);
+        expect(count, "click is not typing").toBe(0);
+      });
+
+      it("a bare mousemove does not count as typing", async () => {
+        const el = screenEl();
+        el.dispatchEvent(new MouseEvent("mousemove", { ...pointerEventInit(el), buttons: 0 }));
+        await flush();
+
+        // Only motion-reporting mode (?1003) emits anything for a bare move; in the
+        // others there is no frame to mis-count in the first place.
+        if (mode.reportsMotion) {
+          expect(frames.length, "bare move emitted a motion report on onData").toBeGreaterThan(0);
+        }
+        expect(count, "moving the mouse is not typing").toBe(0);
+      });
+
+      it("a drag released outside the terminal does not count as typing", async () => {
+        // xterm tracks the drag on the *document* so a drag leaving the element keeps
+        // reporting — the release lands on document, not on the terminal.
+        const el = screenEl();
+        const init = pointerEventInit(el);
+        el.dispatchEvent(new MouseEvent("mousedown", init));
+        document.dispatchEvent(
+          new MouseEvent("mousemove", { ...init, clientX: init.clientX! + 40, buttons: 1 }),
+        );
+        document.dispatchEvent(
+          new MouseEvent("mouseup", { ...init, clientX: 0, clientY: 0, buttons: 0 }),
+        );
+        await flush();
+
+        expect(frames.length, "drag emitted mouse reports on onData").toBeGreaterThan(0);
+        expect(count, "dragging is not typing").toBe(0);
+      });
+
+      it("a wheel scroll does not count as typing", async () => {
+        const el = screenEl();
+        el.dispatchEvent(
+          new WheelEvent("wheel", { ...pointerEventInit(el), deltaY: 120, deltaMode: 0 }),
+        );
+        await flush();
+
+        expect(frames.length, "wheel emitted a report on onData").toBeGreaterThan(0);
+        expect(count, "scrolling is not typing").toBe(0);
+      });
+
+      it("a synthesized touch-fling wheel does not count as typing", async () => {
+        // Viewport dispatches exactly this on .xterm-screen for one-finger drags and
+        // for the rAF fling frames after touchend — a flick-scroll on a phone.
+        const el = screenEl();
+        for (const deltaY of [-90, -60, -30]) {
+          el.dispatchEvent(
+            new WheelEvent("wheel", { deltaY, deltaMode: 0, bubbles: true, cancelable: true }),
+          );
+        }
+        await flush();
+
+        expect(frames.length, "fling emitted reports on onData").toBeGreaterThan(0);
+        expect(count, "touch fling is not typing").toBe(0);
+      });
+    });
+  }
+});
+
+describe("createTypingCounter — real operator input counts", () => {
+  beforeEach(async () => await setup("\x1b[?1003;1006h"));
+
+  it("a keystroke counts", async () => {
+    const ta = term.textarea!;
+    expect(ta, "textarea exists after open()").toBeTruthy();
+    ta.dispatchEvent(new KeyboardEvent("keydown", { key: "a", bubbles: true }));
+    expect(count).toBe(1);
+  });
+
+  it("a bare modifier does not count", () => {
+    const ta = term.textarea!;
+    ta.dispatchEvent(new KeyboardEvent("keydown", { key: "Shift", bubbles: true }));
+    ta.dispatchEvent(new KeyboardEvent("keydown", { key: "Control", bubbles: true }));
+    expect(count).toBe(0);
+  });
+
+  it("a paste counts (incl. the middle-click primary-selection shape)", () => {
+    const ta = term.textarea!;
+    ta.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true }));
+    expect(count).toBe(1);
+  });
+
+  it("mobile IME composition counts", () => {
+    const ta = term.textarea!;
+    // A soft keyboard finalizes through the composition/input path, never a keydown —
+    // this is why xterm's onKey was not usable as the signal.
+    ta.dispatchEvent(new CompositionEvent("compositionend", { data: "こんにちは", bubbles: true }));
+    expect(count).toBe(1);
+  });
+
+  it("dropped text counts", () => {
+    const ta = term.textarea!;
+    ta.dispatchEvent(new DragEvent("drop", { bubbles: true, cancelable: true }));
+    expect(count).toBe(1);
+  });
+
+  it("stops counting after destroy()", () => {
+    const ta = term.textarea!;
+    counter.destroy();
+    ta.dispatchEvent(new KeyboardEvent("keydown", { key: "a", bubbles: true }));
+    expect(count).toBe(0);
+  });
+});

--- a/ui/src/lib/terminal-input.browser.test.ts
+++ b/ui/src/lib/terminal-input.browser.test.ts
@@ -154,21 +154,51 @@ describe("createTypingCounter — pointer activity is not typing", () => {
   }
 });
 
+/** Dispatch a keydown on xterm's textarea the way a browser would — xterm reads
+ *  keyCode/code, so a `key`-only synthetic event resolves to nothing. */
+function press(init: KeyboardEventInit) {
+  term.textarea!.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, ...init }));
+}
+
 describe("createTypingCounter — real operator input counts", () => {
   beforeEach(async () => await setup("\x1b[?1003;1006h"));
 
   it("a keystroke counts", async () => {
-    const ta = term.textarea!;
-    expect(ta, "textarea exists after open()").toBeTruthy();
-    ta.dispatchEvent(new KeyboardEvent("keydown", { key: "a", bubbles: true }));
+    expect(term.textarea, "textarea exists after open()").toBeTruthy();
+    press({ key: "a", code: "KeyA", keyCode: 65 });
+    await flush();
+    expect(frames.join(""), "the key reached the PTY").toBe("a");
     expect(count).toBe(1);
   });
 
+  it("keys that produce input count: Enter, arrows, F-keys, Ctrl+C", async () => {
+    press({ key: "Enter", code: "Enter", keyCode: 13 });
+    press({ key: "ArrowUp", code: "ArrowUp", keyCode: 38 });
+    press({ key: "F5", code: "F5", keyCode: 116 });
+    press({ key: "c", code: "KeyC", keyCode: 67, ctrlKey: true }); // SIGINT — real input
+    await flush();
+
+    expect(frames.join(""), "each of these reached the PTY").toContain("\x03");
+    expect(count).toBe(4);
+  });
+
   it("a bare modifier does not count", () => {
-    const ta = term.textarea!;
-    ta.dispatchEvent(new KeyboardEvent("keydown", { key: "Shift", bubbles: true }));
-    ta.dispatchEvent(new KeyboardEvent("keydown", { key: "Control", bubbles: true }));
+    press({ key: "Shift", code: "ShiftLeft", keyCode: 16, shiftKey: true });
+    press({ key: "Control", code: "ControlLeft", keyCode: 17, ctrlKey: true });
     expect(count).toBe(0);
+  });
+
+  it("keys that put nothing into the PTY do not count (locks, copy chords)", async () => {
+    // The critic's case: copying a line of output mid-review must not announce
+    // "You're typing" — nothing was typed INTO the terminal.
+    press({ key: "CapsLock", code: "CapsLock", keyCode: 20 });
+    press({ key: "NumLock", code: "NumLock", keyCode: 144 });
+    press({ key: "c", code: "KeyC", keyCode: 67, ctrlKey: true, shiftKey: true }); // Ctrl+Shift+C = copy
+    press({ key: "c", code: "KeyC", keyCode: 67, metaKey: true }); // Cmd+C = copy (macOS)
+    await flush();
+
+    expect(frames.join(""), "none of these reached the PTY").toBe("");
+    expect(count, "copying is not typing").toBe(0);
   });
 
   it("a paste counts (incl. the middle-click primary-selection shape)", () => {
@@ -192,9 +222,9 @@ describe("createTypingCounter — real operator input counts", () => {
   });
 
   it("stops counting after destroy()", () => {
-    const ta = term.textarea!;
     counter.destroy();
-    ta.dispatchEvent(new KeyboardEvent("keydown", { key: "a", bubbles: true }));
+    press({ key: "a", code: "KeyA", keyCode: 65 });
+    term.textarea!.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true }));
     expect(count).toBe(0);
   });
 });

--- a/ui/src/lib/terminal-input.ts
+++ b/ui/src/lib/terminal-input.ts
@@ -22,30 +22,37 @@ import type { Terminal } from "@xterm/xterm";
 // paste, slash-command taps) — those call Viewport's bumpOperatorInput()
 // directly, since they never reach this textarea.
 
-/** Modifier keys that produce no input on their own — held Shift while reading
- *  output is not typing. */
-const BARE_MODIFIERS = new Set(["Shift", "Control", "Alt", "Meta", "AltGraph"]);
-
 /**
- * Count operator input that flows through xterm's helper textarea: keystrokes,
- * IME composition (mobile soft keyboards finalize this way — xterm's composition
- * helper emits data without a keydown), text paste (incl. middle-click primary
- * selection) and dropped text.
+ * Count operator input that flows through xterm: keystrokes, IME composition,
+ * text paste (incl. middle-click primary selection) and dropped text.
+ *
+ * Two signals, because neither covers the other:
+ *
+ *  - `term.onKey` for the keyboard. It fires only when a key actually RESOLVES TO
+ *    INPUT for the PTY, which is the precision a raw `keydown` listener lacks:
+ *    CapsLock, NumLock and locally-handled chords (Cmd/Ctrl+Shift+C to copy) put
+ *    nothing into the terminal, and counting them would announce "You're typing"
+ *    to someone who only copied a line of output. Keys that DO produce input —
+ *    printable characters, Enter, arrows, F-keys, Ctrl+C — all fire it.
+ *  - The textarea's `input` / `compositionend` / `paste` / `drop`, because those
+ *    paths never reach `onKey`: a mobile soft keyboard finalizes through xterm's
+ *    composition helper (no keydown at all), and paste/drop are not keys. This is
+ *    why `onKey` alone was not usable as the signal.
+ *
+ * A key that both fires `onKey` and produces an `input` event would be counted
+ * twice; that is harmless — the counter is monotonic and its consumer only asks
+ * whether it went up.
  *
  * `term.textarea` only exists once `term.open()` has run, so create the counter
  * after opening. Returns a disposer that removes every listener.
  */
 export function createTypingCounter(term: Terminal, onInput: () => void): { destroy(): void } {
+  const keySub = term.onKey(() => onInput());
+
   const ta = term.textarea;
-  if (!ta) return { destroy() {} };
+  if (!ta) return { destroy: () => keySub.dispose() };
 
-  const onKeyDown = (e: KeyboardEvent) => {
-    if (BARE_MODIFIERS.has(e.key)) return;
-    onInput();
-  };
   const bump = () => onInput();
-
-  ta.addEventListener("keydown", onKeyDown);
   ta.addEventListener("input", bump);
   ta.addEventListener("compositionend", bump);
   ta.addEventListener("paste", bump);
@@ -53,7 +60,7 @@ export function createTypingCounter(term: Terminal, onInput: () => void): { dest
 
   return {
     destroy() {
-      ta.removeEventListener("keydown", onKeyDown);
+      keySub.dispose();
       ta.removeEventListener("input", bump);
       ta.removeEventListener("compositionend", bump);
       ta.removeEventListener("paste", bump);

--- a/ui/src/lib/terminal-input.ts
+++ b/ui/src/lib/terminal-input.ts
@@ -1,0 +1,63 @@
+import type { Terminal } from "@xterm/xterm";
+
+// Operator-input origin detection for the ReviewInFlightBanner's escalation
+// counter (issue #1022).
+//
+// The banner used to count xterm's `onData` frames, but onData is xterm's
+// *outbound data* channel, not a typing signal: with mouse tracking on (Claude
+// Code runs that way — see `agentOwnsScroll` in Viewport.svelte) every mouse
+// move / click / drag / wheel is reported to the app as an escape sequence on
+// that same channel, as are focus reports and the terminal's replies to app
+// queries. Counting them made the banner claim "You're typing" whenever the
+// pointer moved.
+//
+// So we count the *origin* instead of the payload: text can only enter xterm
+// through its helper textarea, and every noise source above is synthesized
+// inside xterm's own JS and never touches it. That excludes the noise by
+// construction — no escape-sequence pattern matching, and no assumption about
+// when xterm emits a frame relative to the DOM event that caused it.
+//
+// This covers only input that goes *through* xterm. Shepherd also injects
+// operator input straight into the PTY (ComposeBar, the touch key bar, image
+// paste, slash-command taps) — those call Viewport's bumpOperatorInput()
+// directly, since they never reach this textarea.
+
+/** Modifier keys that produce no input on their own — held Shift while reading
+ *  output is not typing. */
+const BARE_MODIFIERS = new Set(["Shift", "Control", "Alt", "Meta", "AltGraph"]);
+
+/**
+ * Count operator input that flows through xterm's helper textarea: keystrokes,
+ * IME composition (mobile soft keyboards finalize this way — xterm's composition
+ * helper emits data without a keydown), text paste (incl. middle-click primary
+ * selection) and dropped text.
+ *
+ * `term.textarea` only exists once `term.open()` has run, so create the counter
+ * after opening. Returns a disposer that removes every listener.
+ */
+export function createTypingCounter(term: Terminal, onInput: () => void): { destroy(): void } {
+  const ta = term.textarea;
+  if (!ta) return { destroy() {} };
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (BARE_MODIFIERS.has(e.key)) return;
+    onInput();
+  };
+  const bump = () => onInput();
+
+  ta.addEventListener("keydown", onKeyDown);
+  ta.addEventListener("input", bump);
+  ta.addEventListener("compositionend", bump);
+  ta.addEventListener("paste", bump);
+  ta.addEventListener("drop", bump);
+
+  return {
+    destroy() {
+      ta.removeEventListener("keydown", onKeyDown);
+      ta.removeEventListener("input", bump);
+      ta.removeEventListener("compositionend", bump);
+      ta.removeEventListener("paste", bump);
+      ta.removeEventListener("drop", bump);
+    },
+  };
+}


### PR DESCRIPTION
## The bug

During an in-flight review the terminal banner escalated from calm to **"You're typing — an incoming directive may collide with your input"** whenever the operator merely **moved the mouse** over the terminal (also on click, drag, wheel, and — on mobile — a touch fling).

## Root cause

`Viewport.svelte` bumped the escalation counter on **every** `term.onData` frame. But `onData` is xterm's *outbound data* channel, not a typing signal. With mouse tracking on — which is how Claude Code runs, as `agentOwnsScroll` (`Viewport.svelte:1358-1366`) already documents — xterm reports **every mouse move / click / drag / wheel** to the app on that same channel, along with focus reports and the terminal's replies to the app's own queries. The banner counted all of it as keystrokes.

## The fix

Count operator-input **origins**, never data frames.

1. **Through xterm** — `createTypingCounter` (new `ui/src/lib/terminal-input.ts`) listens on xterm's helper textarea: `keydown` (minus bare modifiers), `input`, `compositionend`, `paste`, `drop`. Mouse reports, focus reports and query replies are synthesized inside xterm's JS and never touch that textarea, so they're excluded *by construction* — no escape-sequence pattern matching on the client.
2. **Bypassing xterm** — Shepherd injects operator input straight into the PTY from six sites (ComposeBar/`sendComposed`, the touch control-key bar, `attachImages`, slash-command link taps, the synthesized Shift+Enter and Escape). **None of these counted before**, and on mobile they are the *primary* input surfaces — so a textarea-only counter would have left the banner permanently silent on a phone. They now call `bumpOperatorInput()`.

Two deliberate carve-outs, both commented in place:

- **View control does not count** (jump-to-bottom, `/tui fullscreen`) — it moves the view; it doesn't enter text that could collide with a steer.
- **Image paste is counted inside `attachImages`**, not via the textarea: the capture-phase image-paste interceptor on `el` calls `stopImmediatePropagation()`, so a textarea `paste` listener never sees a pasted screenshot — even though it injects a path into the prompt.

### Server seam

`src/operator-activity.ts` had the same defect: `isOperatorKeystroke()` filtered only `\x00resize:` frames, so mouse reports stamped `lastOperatorKeystrokeAt` as "the operator typed". It has no DOM, so it filters by bytes (SGR/urxvt mouse, focus, DA, DSR, DECRPM, XTWINOPS, OSC, DCS), anchored through each terminator so a reply can't swallow real bytes batched after it. One limitation is recorded in the file: in an alt-buffer TUI that hasn't negotiated wheel reporting (`vim`, `less`), xterm turns a wheel scroll into `\x1b[A`/`\x1b[B` — byte-identical to a typed arrow — so it still stamps there. The seam has no read consumer, and those are the bytes the PTY genuinely receives.

## Why the tests are worth trusting

`ui/src/lib/terminal-input.browser.test.ts` mounts a **real xterm `Terminal`** in Chromium and drives **real** wheel / mousedown / mousemove / drag events, parameterized over `?1000` / `?1002` / `?1003` (`agentOwnsScroll` only proves `mouseTrackingMode !== "none"`, not *which* mode — and under `?1000` a bare `mousemove` reports nothing, so a test pinned to it would never exercise the gesture in the bug report).

Each pointer case asserts **both halves**: that `onData` genuinely fired — i.e. the frame the old code would have counted was really emitted — **and** that the counter stayed at 0. Without the first assertion the test could pass against a broken mechanism. Real operator input (keystroke, paste incl. the middle-click shape, IME `compositionend`, dropped text) is asserted to still count, and `ReviewInFlightBanner.browser.test.ts` gains the escalation case it never had.

## Verification

- Root: `bun run lint` ✅, `bun test` ✅ (6968 pass)
- UI: `bun run check` ✅ (0 errors), `bun test` ✅ (3789 pass, node + browser)

[no-feature-entry] — bug fix, no new user-facing capability; banner copy unchanged, so no new i18n keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)