### PR TITLE
fix(ui): stop the reviewing amber border leaking into FINAL REVIEW

### DIFF
--- a/ui/src/lib/components/CriticBadge.browser.test.ts
+++ b/ui/src/lib/components/CriticBadge.browser.test.ts
@@ -115,7 +115,7 @@ describe("CriticBadge streak label", () => {
 
   it("verdict + final round → FINAL REVIEW streak label with streak-final class", async () => {
     // addressRound === addressCap, findings present, finalRoundPending true, updatedAt recent
-    // → addressRoundInfo returns status "final" (dim).
+    // → addressRoundInfo returns status "final" (warn — caution, last chance).
     reviews.map = {
       s1: v({
         addressRound: 5,
@@ -134,7 +134,7 @@ describe("CriticBadge streak label", () => {
     await expect.element(page.getByText(/FINAL REVIEW/)).toBeInTheDocument();
     // verdict word replaced, not appended
     expect(page.getByText(/CHANGES/).elements().length, "no CHANGES text").toBe(0);
-    // badge carries the dim class
+    // badge carries the warn (final-rung) class — resolved colors are asserted in the ladder suite
     const streak = document.querySelector(".streak-final");
     expect(streak, "streak-final rendered").not.toBeNull();
   });

--- a/ui/src/lib/components/CriticBadge.browser.test.ts
+++ b/ui/src/lib/components/CriticBadge.browser.test.ts
@@ -140,6 +140,116 @@ describe("CriticBadge streak label", () => {
   });
 });
 
+/**
+ * The grey-in-orange FINAL REVIEW bug shipped WITH the correct `.streak-final` class applied — the
+ * class was never the defect, the resolved border-color was (`.critic-reviewing`'s amber leaking
+ * through underneath a state that only recolored its text). So these assert computed style, not
+ * classes; a class assertion here would be regression-proof against nothing.
+ *
+ * Expected values are resolved from the tokens via a probe element rather than hardcoded as hex, so
+ * a palette retune in app.css can't fail these for the wrong reason.
+ */
+describe("CriticBadge streak ladder — resolved colors", () => {
+  /** Computed rgb() a token resolves to in the live stylesheet. */
+  function token(name: string): string {
+    const probe = document.createElement("span");
+    probe.style.color = `var(${name})`;
+    document.body.appendChild(probe);
+    const c = getComputedStyle(probe).color;
+    probe.remove();
+    return c;
+  }
+
+  const badge = () => document.querySelector(".critic-badge") as HTMLElement;
+  // border is `1px solid` on all four sides, so the top side speaks for the whole box.
+  const ink = (el: HTMLElement) => {
+    const s = getComputedStyle(el);
+    return { color: s.color, border: s.borderTopColor };
+  };
+
+  const roundVerdict = (extra: Partial<ReviewVerdict> = {}) =>
+    v({ addressRound: 2, addressCap: 5, ...extra });
+  const finalVerdict = () =>
+    v({
+      addressRound: 5,
+      addressCap: 5,
+      finalRoundPending: true,
+      findings: ["x"],
+      updatedAt: Date.now() - 1_000, // recent → "final", not yet timed out into "stalled"
+    });
+  const stalledVerdict = () =>
+    v({ addressRound: 5, addressCap: 5, finalRoundPending: false, findings: ["x"] });
+
+  it("final: warn text AND warn border — the border no longer leaks amber", async () => {
+    reviews.map = { s1: finalVerdict() };
+    render(CriticBadge, { sessionId: "s1" });
+    await expect.element(page.getByText(/FINAL REVIEW/)).toBeInTheDocument();
+
+    const warn = token("--status-warn");
+    const { color, border } = ink(badge());
+    expect(color, "final text is --status-warn").toBe(warn);
+    expect(border, "final border is --status-warn, not amber").toBe(warn);
+    expect(border, "border hue agrees with text hue").toBe(color);
+  });
+
+  it("final + reviewing: still warn on both — the exact cascade that produced grey-in-orange", async () => {
+    reviews.map = { s1: finalVerdict() };
+    reviews.reviewing = { s1: true }; // adds .critic-reviewing, whose amber border leaked before
+    render(CriticBadge, { sessionId: "s1" });
+    await expect.element(page.getByText(/FINAL REVIEW/)).toBeInTheDocument();
+
+    const warn = token("--status-warn");
+    const { color, border } = ink(badge());
+    expect(color, "text stays --status-warn under .critic-reviewing").toBe(warn);
+    expect(border, "border is NOT the reviewing amber").toBe(warn);
+    expect(border).not.toBe(token("--color-amber"));
+    // and it is certainly not the old recessive faint text
+    expect(color).not.toBe(token("--color-faint"));
+  });
+
+  it("stalled: blocked-red text AND border", async () => {
+    reviews.map = { s1: stalledVerdict() };
+    render(CriticBadge, { sessionId: "s1" });
+    await expect.element(page.getByText(/STALLED REVIEW/)).toBeInTheDocument();
+
+    const blocked = token("--status-blocked");
+    const { color, border } = ink(badge());
+    expect(color, "stalled text is --status-blocked").toBe(blocked);
+    expect(border, "stalled border is --status-blocked").toBe(blocked);
+  });
+
+  it("round keeps amber (in-progress), and agrees with its border while reviewing", async () => {
+    reviews.map = { s1: roundVerdict() };
+    reviews.reviewing = { s1: true };
+    render(CriticBadge, { sessionId: "s1" });
+    await expect.element(page.getByText(/REVIEW 2\/5/)).toBeInTheDocument();
+
+    const amber = token("--color-amber");
+    const { color, border } = ink(badge());
+    expect(color, "round stays amber = in progress").toBe(amber);
+    expect(border, "reviewing border agrees with the amber text").toBe(amber);
+  });
+
+  it("stalled + reviewing: the pulsing dot stays AMBER, never red", async () => {
+    // Reachable in practice: addressStallStatus escalates to "stalled" on the finalRoundTimeoutMs
+    // clock while a re-review is still in flight, and roundView still sets dot: true. A dot that
+    // followed currentColor would pulse RED here — DESIGN.md forbids a pulsing subordinate red
+    // (that loudest red is reserved for the blocked-agent pip; Four-Light Rule).
+    reviews.map = { s1: stalledVerdict() };
+    reviews.reviewing = { s1: true };
+    render(CriticBadge, { sessionId: "s1" });
+    await expect.element(page.getByText(/STALLED REVIEW/)).toBeInTheDocument();
+
+    const dot = document.querySelector(".rev-dot") as HTMLElement;
+    expect(dot, "running dot rendered while re-reviewing a stalled streak").not.toBeNull();
+    expect(getComputedStyle(dot).backgroundColor, "dot is amber (running), not red").toBe(
+      token("--color-amber"),
+    );
+    // the pill itself is still red — hue (severity) and dot (running) are orthogonal axes
+    expect(getComputedStyle(badge()).color).toBe(token("--status-blocked"));
+  });
+});
+
 describe("CriticBadge tip mode (card) — Open PR dialog + URL safety", () => {
   const dialogOpen = () => document.querySelector(".status-tip-dialog:popover-open");
 

--- a/ui/src/lib/components/CriticBadge.svelte
+++ b/ui/src/lib/components/CriticBadge.svelte
@@ -272,23 +272,31 @@
       opacity: 1;
     }
   }
-  /* auto-address streak label that takes over the whole pill. streak-round now matches the
-     reviewing amber (cohesive amber pill, like the plain REVIEWING badge); the amber border +
-     rev-dot still signal running. Compound selectors (.critic-badge.streak-*, specificity 0,2,0)
-     so the recessive states (streak-final faint) still beat the reviewing amber
-     (.critic-reviewing, 0,1,0) by specificity rather than source order — robust against
-     stylesheet reordering. */
+  /* auto-address streak label that takes over the whole pill. TWO ORTHOGONAL AXES:
+       hue = severity   (round amber → final warn → stalled blocked; climbs with the ladder)
+       dot = running    (the amber .rev-dot, unchanged, whenever the critic is re-reviewing)
+     So an amber dot inside a warn/blocked pill is correct — it reports a different thing than
+     the hue does. Each streak state therefore owns BOTH color and border-color: .critic-reviewing
+     (0,1,0) sets an amber border, and a state that recolored only the text would let that amber
+     leak through underneath it (which is exactly how FINAL REVIEW came to render faint-grey inside
+     an orange border). The compound selectors (.critic-badge.streak-*, 0,2,0) beat it by
+     specificity rather than source order — robust against stylesheet reordering.
+     NB: .rev-dot must NOT follow currentColor — stalled + reviewing co-occur (addressStallStatus
+     escalates on the finalRoundTimeoutMs clock while a re-review is still in flight), which would
+     render a pulsing RED dot; DESIGN.md forbids a haloed/pulsing subordinate red. */
   .critic-badge.streak-round {
     color: var(--color-amber);
   }
-  /* final allowed round in flight: recessive (faint) vs. the amber in-progress/stalled streak states */
+  /* final allowed round in flight — caution: last chance before the streak stalls */
   .critic-badge.streak-final {
-    color: var(--color-faint);
+    color: var(--status-warn);
+    border-color: var(--status-warn);
   }
-  /* auto-address gave up at the cap — needs a human */
+  /* auto-address gave up at the cap — blocked, needs a human. Subordinate red: text + border
+     only, never a halo/pulse/wash — the blocked-agent pip stays the loudest red (Four-Light Rule). */
   .critic-badge.streak-stalled {
-    color: var(--color-amber);
+    color: var(--status-blocked);
     font-weight: 600;
-    border-color: var(--color-amber);
+    border-color: var(--status-blocked);
   }
 </style>

--- a/ui/src/lib/components/CriticBadge.svelte
+++ b/ui/src/lib/components/CriticBadge.svelte
@@ -276,10 +276,15 @@
        hue = severity   (round amber → final warn → stalled blocked; climbs with the ladder)
        dot = running    (the amber .rev-dot, unchanged, whenever the critic is re-reviewing)
      So an amber dot inside a warn/blocked pill is correct — it reports a different thing than
-     the hue does. Each streak state therefore owns BOTH color and border-color: .critic-reviewing
-     (0,1,0) sets an amber border, and a state that recolored only the text would let that amber
-     leak through underneath it (which is exactly how FINAL REVIEW came to render faint-grey inside
-     an orange border). The compound selectors (.critic-badge.streak-*, 0,2,0) beat it by
+     the hue does.
+     The invariant: no streak state may show a border hue that CONTRADICTS its text hue. So any
+     state whose text is NOT amber must also claim the border — .critic-reviewing (0,1,0) sets an
+     amber border, and a state that recolored only its text would let that amber leak through
+     underneath (exactly how FINAL REVIEW came to render faint-grey inside an orange border).
+     streak-round is the one state that needs no border-color: its text IS amber, so it agrees with
+     the reviewing border when re-reviewing, and at rest it keeps the neutral --color-line hairline
+     every badge carries — a neutral hairline is not a competing hue, so there is nothing to
+     contradict. The compound selectors (.critic-badge.streak-*, 0,2,0) beat .critic-reviewing by
      specificity rather than source order — robust against stylesheet reordering.
      NB: .rev-dot must NOT follow currentColor — stalled + reviewing co-occur (addressStallStatus
      escalates on the finalRoundTimeoutMs clock while a re-review is still in flight), which would

--- a/ui/src/lib/components/critic-badge.ts
+++ b/ui/src/lib/components/critic-badge.ts
@@ -44,13 +44,15 @@ export type AddressStatus = "round" | "final" | "stalled";
  * Auto-address streak state for the badge, or null when no streak is in progress.
  * The cap comes off the verdict (`addressCap`) — the server's live value — so the badge
  * math never drifts from a hardcoded mirror.
- *  - "round":   below the cap, agent addressing findings, more rounds left (blue). Also
- *               covers a transient error verdict that holds the streak with no findings.
+ * The badge paints these on a severity ladder (hue climbs with the rung; the separate pulsing
+ * dot — not the hue — is what reports that the critic is re-reviewing right now):
+ *  - "round":   below the cap, agent addressing findings, more rounds left (amber = in progress).
+ *               Also covers a transient error verdict that holds the streak with no findings.
  *  - "final":   cap-th steer just delivered (`finalRoundPending`), agent addressing the
- *               last allowed round (dimmed). Escalates to "stalled" after the verdict's
- *               `finalRoundTimeoutMs` if no re-review lands (agent abandoned it).
+ *               last allowed round (warn = caution, last chance). Escalates to "stalled" after
+ *               the verdict's `finalRoundTimeoutMs` if no re-review lands (agent abandoned it).
  *  - "stalled": cap reached and that final round already failed re-review, OR the pending
- *               final round timed out → needs a human (orange).
+ *               final round timed out → needs a human (blocked red).
  * `now` is the current time (ms); pass a reactive clock so the timeout escalation is live.
  */
 export function addressRoundInfo(


### PR DESCRIPTION
## The question this answers

> "FINAL REVIEW" is slate/grey in an orange border. Is that on purpose?

**Half of it was.** Two independent things produced that pill, and only one is a bug:

- **The grey text was intentional.** `.critic-badge.streak-final { color: var(--color-faint) }` made the final round deliberately *recessive*, and the comment there said so.
- **The orange border was not.** `.critic-reviewing` (specificity 0,1,0) sets `border-color: var(--color-amber)` for the "critic is running" state. `.streak-final` overrode the *color* but never the *border* — so the amber leaked through underneath the recessive text. Nothing chose that combination; it fell out of two rules meeting.

So this isn't one bug presented as a ladder-wide redesign. It's a cascade leak, plus a ladder that the leak exposed as non-monotonic.

## The change

Each streak state now owns **text + border** together, which closes the leak structurally — no state can show a border hue that disagrees with its text hue. And the ladder now climbs with severity, where before `final` (faint) was *less* salient than `round` (amber) despite being the last-chance state:

| State | Label | Text + border | Change |
|---|---|---|---|
| `round` | `REVIEW 2/5` | `--color-amber` (in progress) | **none** |
| `final` | `FINAL REVIEW` | `--status-warn` text **and** border | recolored (was faint grey) |
| `stalled` | `STALLED REVIEW` | `--status-blocked` text **and** border, weight 600 | recolored (was amber) |

Two axes, deliberately orthogonal: **hue = severity, the pulsing dot = running.** An amber dot inside a warn or red pill is correct — they report different things.

### Two things left alone on purpose

- **`round` keeps its amber.** `DESIGN.md:219` assigns amber to "in progress" and `--status-running` is amber. (Muting it would also have made `.streak-round` a no-op — the base `.critic-badge` rule is *already* muted text on a `--color-line` border.)
- **`.rev-dot` stays amber; `currentColor` was rejected.** It would render a **pulsing red dot** when `stalled` + `reviewing` co-occur — reachable in practice, since `addressStallStatus` escalates on the `finalRoundTimeoutMs` clock while a re-review is still in flight, and `roundView` still sets `dot: true`. `DESIGN.md:220`/`:263` forbid a pulsing subordinate red; that loudest red is reserved for the blocked-agent pip (Four-Light Rule). There's now a test pinning this.

Also fixes the `addressRoundInfo` doc comment in `critic-badge.ts`, which claimed `round` = blue and `stalled` = orange — a scheme the CSS never implemented.

## Tests assert computed style, not classes

The bug **shipped with the correct `.streak-final` class applied**, so a class assertion would be regression-proof against nothing. The new tests read `getComputedStyle().color` / `.borderTopColor` and assert they agree per state — **including with `.critic-reviewing` applied**, which is the exact cascade that leaked. Expected values are resolved from the tokens via a probe element rather than hardcoded hex, so an `app.css` palette retune can't fail them for the wrong reason.

Verified they're real guards: reverting the CSS to the old rule fails the two FINAL tests and passes the rest.

## Contrast: measured, and NOT claimed as an AA fix

Badge text is `--fs-micro`, so AA = 4.5:1. Measured across all four palettes:

| Palette | `--warn` on bg/panel | `--red` on bg/panel | `--amber` (existing `round`) |
|---|---|---|---|
| dark | 6.40 / 6.10 | 4.99 / 4.75 | 8.91 / 8.49 |
| light | **4.06** / 4.62 | 4.49 / 5.11 | **3.75** / 4.27 |
| dark-hc | 9.28 / 8.83 | 7.75 / 7.38 | 12.23 / 11.65 |
| light-hc | 6.25 / 7.11 | 6.57 / 7.47 | 7.08 / 6.22 |

Light `--warn` on `--bg` is **4.06:1** — under AA — so **no AA claim is made here**. Worth noting the same measurement puts light `--amber` (the *existing, untouched* `round` color) at **3.75:1**: sub-AA badge text is a **pre-existing, palette-level** property of the light theme, not something this PR introduces, and fixing it means retuning `app.css` for every consumer. Worth a follow-up; out of scope here.

What this PR does claim: it **strictly improves** `final`'s contrast in all four palettes (today's `--color-faint` is ~2.1:1 light / ~2.4:1 dark).

## Checks

`bun run lint` · `cd ui && bun run check && bun run check:i18n && bun run test && bun run build` — all green (3772 tests). Full 7-lane pre-push passed. No new i18n keys (labels/tooltips unchanged); no feature-catalog entry (a `fix`, not a `feat`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)