### PR TITLE
fix(ui): stop the stalled-review pill pulsing an orange dot

### DIFF
--- a/ui/src/lib/components/CommandBar.browser.test.ts
+++ b/ui/src/lib/components/CommandBar.browser.test.ts
@@ -845,14 +845,27 @@ describe("CommandBar — destructive command two-step arm", () => {
     renderBar({ commands });
     await page.getByRole("combobox").fill("decom");
 
-    await decomRow().click();
-    await decomRow().click(); // immediate second click — inside the dwell
-    expect(run).not.toHaveBeenCalled();
-    // Still armed, so a deliberate confirm afterwards works.
-    await expect.element(decomRow()).toHaveTextContent(CONFIRM);
-    await pastDwell();
-    await decomRow().click();
-    expect(run).toHaveBeenCalledTimes(1);
+    // The guard is `Date.now() - armedAt < ARM_DWELL_MS` (CommandBar.svelte), so freeze the clock
+    // rather than racing it: a back-to-back click PAIR is only "inside the dwell" if the runner
+    // dispatches both within 300ms of wall time, which a contended CI runner does not — the second
+    // click then lands legitimately past the dwell and confirms. Pinning Date.now() asserts the
+    // guard's logic instead of the machine's speed. The other dwell tests wait 320ms to get PAST
+    // the window, so they fail safe and stay on the real clock.
+    const t0 = Date.now();
+    const now = vi.spyOn(Date, "now").mockReturnValue(t0);
+    try {
+      await decomRow().click();
+      await decomRow().click(); // second click, still at t0 — inside the dwell
+      expect(run).not.toHaveBeenCalled();
+      // Still armed, so a deliberate confirm afterwards works.
+      await expect.element(decomRow()).toHaveTextContent(CONFIRM);
+
+      now.mockReturnValue(t0 + 320); // past the dwell
+      await decomRow().click();
+      expect(run).toHaveBeenCalledTimes(1);
+    } finally {
+      now.mockRestore();
+    }
   });
 
   it("disarms on typing and on moving the cursor", async () => {

--- a/ui/src/lib/components/CriticBadge.browser.test.ts
+++ b/ui/src/lib/components/CriticBadge.browser.test.ts
@@ -230,23 +230,37 @@ describe("CriticBadge streak ladder — resolved colors", () => {
     expect(border, "reviewing border agrees with the amber text").toBe(amber);
   });
 
-  it("stalled + reviewing: the pulsing dot stays AMBER, never red", async () => {
-    // Reachable in practice: addressStallStatus escalates to "stalled" on the finalRoundTimeoutMs
-    // clock while a re-review is still in flight, and roundView still sets dot: true. A dot that
-    // followed currentColor would pulse RED here — DESIGN.md forbids a pulsing subordinate red
-    // (that loudest red is reserved for the blocked-agent pip; Four-Light Rule).
+  it("stalled + reviewing: the REVIEWING pill wins — no red pill, and no red dot", async () => {
+    // Two ways in. (1) forceReview persists a streak reset (addressRound: 0) but emits no onChange
+    // until the verdict lands, so this cached verdict is a STALE claim of a stall the server already
+    // cleared. (2) addressStallStatus escalates to "stalled" on the finalRoundTimeoutMs clock while
+    // a re-review is still in flight — there the stall is real, and the pill deliberately flips
+    // STALLED → REVIEWING → STALLED (an in-flight run supersedes a timeout's guess).
+    // Either way the running dot must not sit inside a blocked-red pill: recoloring it to follow
+    // currentColor would pulse RED, which DESIGN.md forbids for a subordinate (the loudest red is
+    // the blocked-agent pip; Four-Light Rule). So the pill yields instead of the dot changing hue.
     reviews.map = { s1: stalledVerdict() };
     reviews.reviewing = { s1: true };
     render(CriticBadge, { sessionId: "s1" });
-    await expect.element(page.getByText(/STALLED REVIEW/)).toBeInTheDocument();
 
+    expect(document.querySelectorAll(".critic-badge").length, "exactly one .critic-badge").toBe(1);
+    await expect.element(page.getByText(/REVIEWING/)).toBeInTheDocument();
+    expect(page.getByText(/STALLED REVIEW/).elements().length, "no STALLED REVIEW text").toBe(0);
+    expect(document.querySelector(".streak-stalled"), "no stalled pill while reviewing").toBeNull();
+
+    // the running dot is present and amber — the reviewing pill is where it belongs
     const dot = document.querySelector(".rev-dot") as HTMLElement;
-    expect(dot, "running dot rendered while re-reviewing a stalled streak").not.toBeNull();
+    expect(dot, "running dot rendered while re-reviewing").not.toBeNull();
     expect(getComputedStyle(dot).backgroundColor, "dot is amber (running), not red").toBe(
       token("--color-amber"),
     );
-    // the pill itself is still red — hue (severity) and dot (running) are orthogonal axes
-    expect(getComputedStyle(badge()).color).toBe(token("--status-blocked"));
+    // and the pill itself is the reviewing amber, NOT blocked-red
+    const { color, border } = ink(badge());
+    expect(color, "pill is the reviewing amber").toBe(token("--color-amber"));
+    expect(border, "border agrees with the amber text").toBe(token("--color-amber"));
+    expect(color, "pill is not blocked-red while a re-review is in flight").not.toBe(
+      token("--status-blocked"),
+    );
   });
 });
 

--- a/ui/src/lib/components/CriticBadge.svelte
+++ b/ui/src/lib/components/CriticBadge.svelte
@@ -59,8 +59,16 @@
   }
 
   // Which visual state renders, and its class / label / tooltip text / dot.
+  // A STALLED streak yields to the reviewing view while the critic is actually re-reviewing: a
+  // stall is a claim about a run that ended, and an in-flight run supersedes it. Same rule the
+  // plan gate already applies (plan-gate-badge.ts: `if (reviewing)` precedes the stall branches;
+  // canShowPlanStallActions requires !reviewing) and the one criticChip states for plain verdicts.
+  // It also stops a STALE paint: forceReview persists a streak reset (addressRound: 0) but emits no
+  // onChange until the new verdict lands, so during a forced re-review this cached verdict is the
+  // last surface still claiming a stall the server already cleared. round/final keep their counter
+  // — it is not stale mid-streak, and the number is the useful thing to show.
   const view = $derived.by((): CriticView | null => {
-    if (round) return roundView(round);
+    if (round && !(round.status === "stalled" && reviewing)) return roundView(round);
     if (chip.kind === "reviewing") return reviewingView();
     if (chip.kind === "verdict")
       return {
@@ -272,11 +280,15 @@
       opacity: 1;
     }
   }
-  /* auto-address streak label that takes over the whole pill. TWO ORTHOGONAL AXES:
-       hue = severity   (round amber → final warn → stalled blocked; climbs with the ladder)
-       dot = running    (the amber .rev-dot, unchanged, whenever the critic is re-reviewing)
-     So an amber dot inside a warn/blocked pill is correct — it reports a different thing than
-     the hue does.
+  /* auto-address streak label that takes over the whole pill. hue = severity (round amber → final
+     warn → stalled blocked; climbs with the ladder); the amber .rev-dot reports the orthogonal fact
+     that the critic is re-reviewing RIGHT NOW.
+     .streak-stalled never co-occurs with .critic-reviewing: the `view` dispatcher hands a stalled
+     streak to the REVIEWING pill while a re-review is in flight, so a .rev-dot inside a stalled pill
+     is unreachable. Only round/final can pair the dot with their hue. That is also why the dot is
+     not simply recolored to follow currentColor: a red pill would then pulse a RED dot, and
+     DESIGN.md forbids a haloed/pulsing subordinate red (the loudest red belongs to the
+     blocked-agent pip — Four-Light Rule). Yielding the pill, not tinting the dot, is the fix.
      The invariant: no streak state may show a border hue that CONTRADICTS its text hue. So any
      state whose text is NOT amber must also claim the border — .critic-reviewing (0,1,0) sets an
      amber border, and a state that recolored only its text would let that amber leak through
@@ -285,10 +297,7 @@
      the reviewing border when re-reviewing, and at rest it keeps the neutral --color-line hairline
      every badge carries — a neutral hairline is not a competing hue, so there is nothing to
      contradict. The compound selectors (.critic-badge.streak-*, 0,2,0) beat .critic-reviewing by
-     specificity rather than source order — robust against stylesheet reordering.
-     NB: .rev-dot must NOT follow currentColor — stalled + reviewing co-occur (addressStallStatus
-     escalates on the finalRoundTimeoutMs clock while a re-review is still in flight), which would
-     render a pulsing RED dot; DESIGN.md forbids a haloed/pulsing subordinate red. */
+     specificity rather than source order — robust against stylesheet reordering. */
   .critic-badge.streak-round {
     color: var(--color-amber);
   }


### PR DESCRIPTION
> **Scope — two independent commits.** `f527cc27` is the badge fix (`CriticBadge` only) and is the whole point of this PR. `f491c486` is an unrelated test-only deflake of `CommandBar.browser.test.ts`, which was failing CI on this branch through no fault of the badge change (details at the bottom). They're separate commits and touch disjoint files, so the badge fix stays independently revertable and bisectable — revert `f491c486` alone and nothing here is affected.

A session whose auto-address streak had stalled rendered a blocked-red `STALLED REVIEW` pill with an amber **pulsing** dot inside it. The hue says *gave up*; the dot says *something is running*. It reads as broken.

## The dot wasn't the bug — the pill was

`forceReview` (`src/review.ts:468-505`) **persists** a streak reset (`putReview` with `addressRound: 0`) but deliberately withholds `onChange` until the new verdict lands. So on the force path the server row is no longer stalled: `quotaBlockReason` (`src/blocked.ts:148`) stops returning the `rework` block, and the `REWORK CAP` badge **and** the "Auto-fix hit its limit" hold line both clear. Only the client's cached verdict keeps painting the red pill — the last surface still claiming a stall the server had already cleared. After a force the session genuinely *is not stalled*.

So the fix isn't to hide the dot; it's to stop rendering a stalled pill over a live re-review.

## What changed

A stalled streak now yields to the normal amber `REVIEWING` pill while the critic is actually re-reviewing — which is where the pulsing dot belongs. When the verdict lands, the badge paints whatever it says, `STALLED REVIEW` (red, static, no dot) included.

| Streak rung | Re-reviewing | Before | After |
| --- | --- | --- | --- |
| `stalled` | yes | red `STALLED REVIEW` + amber pulsing dot | amber `REVIEWING` + pulsing dot |
| `stalled` | no | red `STALLED REVIEW`, no dot | unchanged |
| `round` / `final` | yes | counter + amber dot | unchanged |

`round` / `final` keep their counter and dot: mid-streak that number isn't stale, and it's the useful thing to show.

This is the rule the plan gate already applies — `plan-gate-badge.ts:49` (`if (reviewing) return { kind: "reviewing" }` ahead of the stall branches), `:74`/`:88-94` (`canShowPlanStallActions` requires `!reviewing`), `PlanGateBadge.svelte:204` (dot only in the reviewing branch) — and the one `criticChip` already states in prose for plain verdicts. `CriticBadge` was the outlier.

**Rejected alternative:** `dot: reviewing && r.status !== "stalled"` (keep the red pill, drop the dot). One line, satisfies the literal complaint, but leaves the badge painting an already-reset stale `5/5` verdict for the whole forced re-review.

## Deliberate flicker on the timeout path

`addressStallStatus` can also escalate to `stalled` on the `finalRoundTimeoutMs` clock *while* a re-review is in flight. There the pill visibly flips `STALLED REVIEW` → `REVIEWING` → `STALLED REVIEW`. **Intended:** the timeout is a guess (it fires precisely because we don't know whether the agent abandoned the round); a live re-review is fact and supersedes it. On that path the server row *is* still stalled, so `REWORK CAP` + the hold line stay on the row and carry the stall meanwhile.

## Tests

`CriticBadge.browser.test.ts:233` pinned the old behavior (STALLED text + red pill + dot) for exactly this state, so it was **rewritten**, not supplemented — it now asserts the reviewing pill wins: one badge, reads `REVIEWING`, no `.streak-stalled`, dot present and amber, pill amber and **not** `--status-blocked`. Verified it fails against the pre-change component (only that test) and passes after. The at-rest `"stalled: blocked-red text AND border"` test is unchanged and is now its pair.

`.rev-dot` inside a stalled pill is now unreachable; `.streak-stalled`'s border/color stays (it's the at-rest state) and DESIGN.md's "no pulsing subordinate red" remains the standing reason the dot isn't simply recolored to the pill's hue.

Local: `bun run check` (0 errors), `bun run test` (3800 passed), `check:i18n` (parity), root `bun run lint` clean. No new i18n keys (`criticbadge_reviewing` exists); UI-only `fix`, no new user-facing capability, so no feature-catalog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Second commit: deflaking `CommandBar.browser.test.ts` (unrelated, but it was red)

CI failed on `CommandBar — drops a confirm that lands inside the 300ms dwell`, which this PR's diff doesn't touch. It's a genuine pre-existing flake from #1751, not a rerun-away blip: the guard reads wall time (`Date.now() - armedAt < ARM_DWELL_MS`, `CommandBar.svelte:442`) and the test fired two real clicks hoping *both* land within 300ms. A contended runner dispatches the second one later than that, the dwell has legitimately expired, and the confirm fires — the test raced the machine, not the guard.

Fixed by pinning `Date.now()` across the click pair, then advancing it past the dwell for the deliberate confirm. Verified it still **fails** when the guard is disabled, so it stays load-bearing rather than becoming vacuous. The other `pastDwell()` tests wait 320ms to get *past* the window, so they fail safe and stay on the real clock.

