### PR TITLE
fix(plan-gate): preserve codex reviewer verdicts

### DIFF
--- a/src/herdr-socket-driver.ts
+++ b/src/herdr-socket-driver.ts
@@ -3,6 +3,7 @@ import {
   HerdrDriver,
   buildWrappedArgv,
   createSerializer,
+  isHeadlessCodexExec,
   isNameTakenError,
   parseAgentInfo,
   parseAgents,
@@ -129,7 +130,7 @@ export class SocketHerdrDriver implements IHerdrDriver {
         cwd,
         buildWrappedArgv(argv, env),
       );
-      if (rootPaneId) {
+      if (rootPaneId && !isHeadlessCodexExec(argv)) {
         try {
           await this.client.request("pane.close", { pane_id: rootPaneId });
         } catch {

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -311,6 +311,13 @@ export function buildWrappedArgv(argv: string[], env?: Record<string, string>): 
   ];
 }
 
+/** A headless Codex role shares its tab's process lifetime with the initial shell pane.
+ * Closing that pane immediately after `agent start` can terminate the role before it writes its
+ * file-based result, so transient `codex exec` runs deliberately retain it. */
+export function isHeadlessCodexExec(argv: string[]): boolean {
+  return argv[0] === "codex" && argv[1] === "exec";
+}
+
 /**
  * A promise-chain serializer (issue #1553): runs each submitted async fn only after the
  * prior one settles, restoring the mutual exclusion the blocking sync `execFileSync` path
@@ -570,7 +577,7 @@ export class HerdrDriver implements IHerdrDriver {
       // absent from agent.list, and closing the remaining shell pane can remove the whole tab.
       const agent = await this.startAgentWithCollisionRetry(name, tabId, cwd, wrapped);
 
-      if (rootPaneId) {
+      if (rootPaneId && !isHeadlessCodexExec(argv)) {
         try {
           await this.asyncRunner(["pane", "close", rootPaneId]);
         } catch {

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -149,6 +149,7 @@ export function reviewerArgv(
 // How long an in-flight plan review may run before tick() (Task 6) gives up on the verdict.
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_CAP = 5;
+const CODEX_EXIT_GRACE_MS = 5_000;
 
 /** Zeroed usage for a completed reviewer whose transcript yields no totals — notably a Codex
  *  role spawn (`codex exec` writes no Claude JSONL) or a half-written transcript. Recording
@@ -688,13 +689,28 @@ export class PlanGateService {
     return this.deps.herdr.list().find((a) => a.cwd === worktreePath)?.terminalId ?? "";
   }
 
+  /** A Codex role is a one-shot `codex exec`: after a brief registration grace period, a missing
+   * terminal without a verdict means it has already exited. Avoid making the operator wait for the
+   * full file timeout; a Herdr read failure remains inconclusive and falls back to that timeout. */
+  private codexReviewerExited(f: PlanInFlight, now: number): boolean {
+    if (f.reviewerProvider !== "codex" || !f.terminalId || now - f.startedAt < CODEX_EXIT_GRACE_MS)
+      return false;
+    try {
+      return !this.deps.herdr.list().some((a) => a.terminalId === f.terminalId);
+    } catch {
+      return false;
+    }
+  }
+
   /** Finalize any in-flight plan review whose verdict file is ready or that timed out. */
   async tick(): Promise<void> {
     for (const f of [...this.inflight.values()]) {
       if (f.finalizing) continue; // already being finalized by an overlapping tick
       const raw = this.readVerdict(f.worktreePath);
-      const timedOut = this.now() - f.startedAt > this.timeoutMs;
-      if (!raw && !timedOut) {
+      const now = this.now();
+      const timedOut = now - f.startedAt > this.timeoutMs;
+      const exited = !raw && this.codexReviewerExited(f, now);
+      if (!raw && !timedOut && !exited) {
         // still running — surface what the reviewer is doing right now. Emit every tick (not
         // only on change) so a reloaded client repopulates within one tick; the client dedups
         // identical summaries. Mirrors ReviewService.tick's critic-activity signal.
@@ -702,6 +718,8 @@ export class PlanGateService {
         if (summary) this.deps.onActivity?.(f.sessionId, summary);
         continue;
       }
+      if (exited)
+        console.warn(`[plan-gate] codex reviewer exited without a verdict for ${f.sessionId}`);
       f.finalizing = true; // stay claimed in `inflight` so consider() won't re-spawn mid-finalize
       // Always drop the entry, even if finalize throws — otherwise it stays
       // `finalizing=true` and every later tick `continue`s past it, wedging the

--- a/test/herdr-socket-driver.test.ts
+++ b/test/herdr-socket-driver.test.ts
@@ -279,6 +279,15 @@ describe("SocketHerdrDriver — socket-backed async writes (#1553, #1567)", () =
     expect(startCall.argv.slice(-2)).toEqual(["claude", "go"]);
   });
 
+  it("start() keeps the root pane for a headless codex exec role", async () => {
+    const rec: { method: string; params: unknown }[] = [];
+    const driver = new SocketHerdrDriver(writeClient(rec), fakeCli() as unknown as HerdrDriver);
+
+    await driver.start("plan-review TASK-693", "/repo/worktree", ["codex", "exec", "go"]);
+
+    expect(rec.map((r) => r.method)).toEqual(["workspace.list", "tab.create", "agent.start"]);
+  });
+
   it("start() bootstraps a 'shepherd' workspace when herdr has none", async () => {
     const rec: { method: string; params: unknown }[] = [];
     const driver = new SocketHerdrDriver(

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -277,12 +277,38 @@ test("start: captures agent start reply before root-pane close can remove the ta
   };
   const d = new HerdrDriver(runner, async (a) => runner(a));
 
-  const agent = await d.start("flatten", "/wt/a", ["codex", "exec", "go"]);
+  const agent = await d.start("flatten", "/wt/a", ["claude", "go"]);
 
   expect(agent).toMatchObject({ terminalId: "term_started", tabId: "t_new" });
   expect(tabPresent).toBe(false);
   expect(calls.some((c) => c[0] === "agent" && c[1] === "list")).toBe(false);
   expect(calls.some((c) => c[0] === "tab" && c[1] === "list")).toBe(false);
+});
+
+test("start: keeps the root pane alive for a headless codex exec role", async () => {
+  const calls: string[][] = [];
+  let tabPresent = false;
+  const runner = (args: string[]): string => {
+    calls.push(args);
+    if (args[0] === "workspace" && args[1] === "list") return WORKSPACE_LIST;
+    if (args[0] === "tab" && args[1] === "create") {
+      tabPresent = true;
+      return TAB_CREATE;
+    }
+    if (args[0] === "agent" && args[1] === "start") return AGENT_STARTED;
+    if (args[0] === "pane" && args[1] === "close") {
+      tabPresent = false;
+      return "{}";
+    }
+    return "{}";
+  };
+  const d = new HerdrDriver(runner, async (a) => runner(a));
+
+  const agent = await d.start("plan-review TASK-693", "/wt/a", ["codex", "exec", "go"]);
+
+  expect(agent).toMatchObject({ terminalId: "term_started", tabId: "t_new" });
+  expect(tabPresent).toBe(true);
+  expect(calls.some((c) => c[0] === "pane" && c[1] === "close")).toBe(false);
 });
 
 const TAB_LIST = JSON.stringify({

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -798,6 +798,22 @@ test("timeout with no verdict → error gate, reaped, not released", async () =>
   expect(h.removed).toContain("/wt-detached");
 });
 
+test("an exited codex reviewer without a verdict fails before the file timeout", async () => {
+  let t = 1000;
+  const h = harness({
+    env: () => ({ provider: "codex", model: "gpt-5.5", effort: null }),
+    now: () => t,
+    readVerdict: () => null,
+    herdr: { start: async () => ({ terminalId: "t1" }), async stop() {}, list: () => [] },
+  });
+  await h.svc.consider(planningSession() as any);
+  t += 5_000;
+  await h.svc.tick();
+
+  expect(h.store.gate.decision).toBe("error");
+  expect(h.removed).toContain("/wt-detached");
+});
+
 test("approved verdict carries no summaryCode (reviewer text is the summary)", async () => {
   const h = harness({
     readVerdict: () => ({ decision: "approve", summary: "looks good", body: "", findings: [] }),


### PR DESCRIPTION
# Problem

Codex-basierte Plan-Reviewer konnten kein Verdict schreiben: Nach `agent start` schloss Shepherd das Root-Pane des neuen Tabs. Für den kurzlebigen `codex exec`-Prozess beendet dies den Parent und damit den Reviewer, bevor seine dateibasierte Verdict-Ausgabe vorliegt. Die betroffenen Aufgaben endeten erst nach dem zehnminütigen Plan-Gate-Timeout mit `no-verdict`.

# Solution

- Das Root-Pane bleibt für headless `codex exec`-Rollen bestehen; interaktive und Claude-Rollen behalten den bisherigen Cleanup.
- Plan Gate erkennt einen verschwundenen Codex-Reviewer nach einer kurzen Grace-Period und finalisiert den Fehler sofort statt nach zehn Minuten.
- Regressionstests decken den CLI- und Socket-Startpfad sowie den schnellen Fehlerpfad ab.

## Technical details

Der Codex-spezifische Schutz wird anhand des unverpackten Argv (`codex exec`) entschieden, bevor Herdr das anfängliche Shell-Pane schließt. Der Plan-Gate-Check liest weiterhin zuerst die Verdict-Datei und nutzt die Terminal-Abwesenheit nur als sichere Negativbedingung; bei einem Herdr-Lesefehler bleibt der bestehende Timeout aktiv.

## Validation

- `bun test test/herdr.test.ts test/herdr-socket-driver.test.ts test/plan-gate-service.test.ts`
- `bun run lint`
- `git diff --check origin/main...HEAD`