### PR TITLE
feat(learnings): configure Distiller provider and cadence

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -108,6 +108,8 @@ export const GH_PROBE_RETRY_DELAY_MS = 250;
 // process GROUP is SIGKILLed (see diagnostics.ts runRemediation) so no reparented
 // grandchild survives to flip a later probe green behind a reported failure.
 export const REMEDIATION_TIMEOUT_MS = 120_000;
+export const DISTILLER_INTERVAL_DAYS_MIN = 1;
+export const DISTILLER_INTERVAL_DAYS_MAX = 14;
 // module-local seed defaults, used by the config seeds + boot-override fallbacks only.
 const PR_REVIEW_CYCLES_DEFAULT = 3;
 const PLAN_REVIEW_CYCLES_DEFAULT = 5;
@@ -668,6 +670,18 @@ export const config = {
   docAgentCli: normalizeRoleCli(process.env.SHEPHERD_DOC_AGENT_CLI) ?? "inherit",
   docAgentModel: normalizeRoleModelToken(process.env.SHEPHERD_DOC_AGENT_MODEL) ?? "default",
   docAgentEffort: normalizeDefaultEffortSetting(process.env.SHEPHERD_DOC_AGENT_EFFORT) ?? "low",
+  // Per-role environment for the Learnings Distiller. Inherit is intentionally the default so
+  // it follows the operator's global provider/model/effort selection.
+  distillerCli: normalizeRoleCli(process.env.SHEPHERD_DISTILLER_CLI) ?? "inherit",
+  distillerModel: normalizeRoleModelToken(process.env.SHEPHERD_DISTILLER_MODEL) ?? "default",
+  distillerEffort: normalizeDefaultEffortSetting(process.env.SHEPHERD_DISTILLER_EFFORT) ?? "default",
+  // Automatic runs are throttled per repository; 1 preserves the historic daily behavior.
+  distillerIntervalDays: clampCap(
+    Number(process.env.SHEPHERD_DISTILLER_INTERVAL_DAYS ?? 1),
+    DISTILLER_INTERVAL_DAYS_MIN,
+    DISTILLER_INTERVAL_DAYS_MAX,
+    1,
+  ),
   // Local hour (0–23) at/after which the doc agent's nightly cadence sweep evaluates each doc-tree
   // repo (issue #904). Once/day/repo, and only spawns when the default branch advanced since the last
   // run; default 3 (≈03:00 local). Invalid values fall back to 3.

--- a/src/config.ts
+++ b/src/config.ts
@@ -674,7 +674,8 @@ export const config = {
   // it follows the operator's global provider/model/effort selection.
   distillerCli: normalizeRoleCli(process.env.SHEPHERD_DISTILLER_CLI) ?? "inherit",
   distillerModel: normalizeRoleModelToken(process.env.SHEPHERD_DISTILLER_MODEL) ?? "default",
-  distillerEffort: normalizeDefaultEffortSetting(process.env.SHEPHERD_DISTILLER_EFFORT) ?? "default",
+  distillerEffort:
+    normalizeDefaultEffortSetting(process.env.SHEPHERD_DISTILLER_EFFORT) ?? "default",
   // Automatic runs are throttled per repository; 1 preserves the historic daily behavior.
   distillerIntervalDays: clampCap(
     Number(process.env.SHEPHERD_DISTILLER_INTERVAL_DAYS ?? 1),

--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -6,9 +6,10 @@ import type { HerdrDriver } from "./herdr";
 import { HerdrUnavailableError } from "./herdr";
 import type { Signal, SignalKind } from "./types";
 import { sanitizeScopeGlobs } from "./house-rules";
-import { isApiKeyMode, isApiKeyConfigured, apiKeyPassthroughEnv } from "./spawn-auth";
+import { apiKeyFailClosed, apiKeyPassthroughEnv } from "./spawn-auth";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
 import { reapTransientByLabel } from "./transient-tab-reaper";
+import type { RoleEnvironment } from "./default-model";
 
 const PROPOSALS_FILE = ".shepherd-learnings.json";
 
@@ -92,6 +93,8 @@ export interface DistillerDeps {
     | "listLearnings"
     | "listActiveLearnings"
     | "getRepoConfig"
+    | "getSetting"
+    | "setSetting"
     | "incrementLearningIneffective"
     | "accrueProposedEvidence"
     | "mergeLearning"
@@ -102,11 +105,13 @@ export interface DistillerDeps {
   scratch: { create: () => { dir: string }; remove: (dir: string) => void };
   onChange: () => void;
   model?: string | null;
+  environment?: () => RoleEnvironment;
   now?: () => number;
   timeoutMs?: number;
   windowMs?: number; // how far back to read signals (default 60d)
   minSignals?: number; // threshold for consider() (default 5)
   maxConcurrent?: number; // max simultaneous distill runs (default 3)
+  intervalDays?: () => number;
   writeSignals?: (
     dir: string,
     signals: Signal[],
@@ -188,7 +193,17 @@ export class DistillerService {
     if (!this.deps.store.getRepoConfig(repoPath).learningsEnabled) return;
     const signals = this.recentLearningSignals(repoPath);
     if (signals.length < this.minSignals) return;
+    if (!this.intervalElapsed(repoPath)) return;
     await this.enqueueOrBegin(repoPath, signals);
+  }
+
+  private intervalElapsed(repoPath: string): boolean {
+    const saved = this.deps.store.getSetting?.(`distiller:last-run:${repoPath}`);
+    if (saved === null || saved === undefined) return true;
+    const lastRun = Number(saved);
+    if (!Number.isFinite(lastRun)) return true;
+    const intervalDays = this.deps.intervalDays?.() ?? 1;
+    return this.now() - lastRun >= intervalDays * 24 * 60 * 60 * 1000;
   }
 
   /** Force a distill run regardless of the signal threshold (manual trigger).
@@ -216,8 +231,13 @@ export class DistillerService {
 
   private async begin(repoPath: string, signals: Signal[]): Promise<void> {
     const { dir } = this.deps.scratch.create();
+    const environment = this.deps.environment?.() ?? {
+      provider: "claude" as const,
+      model: this.deps.model ?? null,
+      effort: null,
+    };
     // Fail closed: api-key mode without a configured key must NOT bill the subscription.
-    if (isApiKeyMode() && !isApiKeyConfigured()) {
+    if (apiKeyFailClosed(environment.provider)) {
       console.warn(
         "[distill] api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)",
       );
@@ -247,7 +267,9 @@ export class DistillerService {
     // Read-only distiller — the shared `writer-ro` transient-agent shape. The input is untrusted
     // agent/repo text; see buildTransientAgentArgv for the flag-order + isolation rationale.
     const { argv, sessionId } = buildTransientAgentArgv("writer-ro", {
-      model: this.deps.model ?? null,
+      provider: environment.provider,
+      model: environment.model,
+      effort: environment.effort,
       prompt: distillPrompt(),
     });
     const agentName = DISTILL_LABEL + sessionId.slice(0, 8);
@@ -267,8 +289,14 @@ export class DistillerService {
     this.inflight.set(repoPath, entry);
     try {
       entry.terminalId = (
-        await this.deps.herdr.start(agentName, dir, argv, apiKeyPassthroughEnv(false))
+        await this.deps.herdr.start(
+          agentName,
+          dir,
+          argv,
+          environment.provider === "claude" ? apiKeyPassthroughEnv(false) : undefined,
+        )
       ).terminalId;
+      this.deps.store.setSetting?.(`distiller:last-run:${repoPath}`, String(this.now()));
     } catch (err) {
       this.inflight.delete(repoPath); // release the reservation
       if (err instanceof HerdrUnavailableError) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ import {
   PR_REVIEW_CYCLES_MAX,
   PLAN_REVIEW_CYCLES_MIN,
   PLAN_REVIEW_CYCLES_MAX,
+  DISTILLER_INTERVAL_DAYS_MIN,
+  DISTILLER_INTERVAL_DAYS_MAX,
   DIAGNOSTICS_INTERVAL_MS,
   DIAGNOSTICS_RECHECK_INTERVAL_MS,
   findServedPort,
@@ -290,7 +292,7 @@ if (savedDe !== null) {
 // are ignored (keep the seed rather than clobber). Each role is a PAIR: a `<role>Cli`
 // ("inherit"|<provider>) + a `<role>Model` ("default"|<alias>), resolved to a spawn environment via
 // resolveRoleEnvironment at wiring/spawn time.
-for (const role of ["critic", "planner", "recap", "docAgent", "namer", "autopilot"] as const) {
+for (const role of ["critic", "planner", "recap", "docAgent", "namer", "autopilot", "distiller"] as const) {
   const savedCli = store.getSetting(`${role}Cli`);
   if (savedCli !== null) {
     const v = normalizeRoleCli(savedCli);
@@ -307,6 +309,14 @@ for (const role of ["critic", "planner", "recap", "docAgent", "namer", "autopilo
     if (v !== null) config[`${role}Effort`] = v;
   }
 }
+const savedDistillerIntervalDays = store.getSetting("distillerIntervalDays");
+if (savedDistillerIntervalDays !== null)
+  config.distillerIntervalDays = clampCap(
+    Number(savedDistillerIntervalDays),
+    DISTILLER_INTERVAL_DAYS_MIN,
+    DISTILLER_INTERVAL_DAYS_MAX,
+    config.distillerIntervalDays,
+  );
 const savedProvider = store.getSetting("defaultAgentProvider");
 if (savedProvider !== null) {
   const v = normalizeAgentProvider(savedProvider);
@@ -627,6 +637,14 @@ function roleEnv(cli: string, model: string, effort: string): RoleEnvironment {
   if (dg !== null && env.provider === "claude")
     return { provider: "claude", model: dg, effort: env.effort };
   return env;
+}
+
+function distillerEnv(): RoleEnvironment {
+  const effort =
+    config.distillerCli === "inherit" && config.distillerEffort === "default"
+      ? config.defaultEffort
+      : config.distillerEffort;
+  return roleEnv(config.distillerCli, config.distillerModel, effort);
 }
 
 // Anonymous product telemetry (Aptabase). No-op unless the operator has explicitly
@@ -2154,6 +2172,8 @@ const distiller = new DistillerService({
   store,
   herdr,
   scratch: defaultScratch,
+  environment: distillerEnv,
+  intervalDays: () => config.distillerIntervalDays,
   onChange: () => learningsSvc.emitPending(),
 });
 deferredStarts.push(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -292,7 +292,15 @@ if (savedDe !== null) {
 // are ignored (keep the seed rather than clobber). Each role is a PAIR: a `<role>Cli`
 // ("inherit"|<provider>) + a `<role>Model` ("default"|<alias>), resolved to a spawn environment via
 // resolveRoleEnvironment at wiring/spawn time.
-for (const role of ["critic", "planner", "recap", "docAgent", "namer", "autopilot", "distiller"] as const) {
+for (const role of [
+  "critic",
+  "planner",
+  "recap",
+  "docAgent",
+  "namer",
+  "autopilot",
+  "distiller",
+] as const) {
   const savedCli = store.getSetting(`${role}Cli`);
   if (savedCli !== null) {
     const v = normalizeRoleCli(savedCli);

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,8 @@ import {
   PR_REVIEW_CYCLES_MAX,
   PLAN_REVIEW_CYCLES_MIN,
   PLAN_REVIEW_CYCLES_MAX,
+  DISTILLER_INTERVAL_DAYS_MIN,
+  DISTILLER_INTERVAL_DAYS_MAX,
   USAGE_HISTORY_RETENTION_MS,
 } from "./config";
 import { normalizeTelemetryConsent } from "./telemetry-consent";
@@ -4491,6 +4493,12 @@ async function handleSettings({ req, parts, deps }: Ctx): Promise<Response | nul
       docAgentCli: config.docAgentCli,
       docAgentModel: config.docAgentModel,
       docAgentEffort: config.docAgentEffort,
+      distillerCli: config.distillerCli,
+      distillerModel: config.distillerModel,
+      distillerEffort: config.distillerEffort,
+      distillerIntervalDays: config.distillerIntervalDays,
+      distillerIntervalDaysMin: DISTILLER_INTERVAL_DAYS_MIN,
+      distillerIntervalDaysMax: DISTILLER_INTERVAL_DAYS_MAX,
       namerCli: config.namerCli,
       namerModel: config.namerModel,
       namerEffort: config.namerEffort,
@@ -4572,6 +4580,10 @@ const SETTING_PATCHES: [string, (value: unknown, deps: Ctx["deps"]) => Response]
   ["docAgentCli", makeRoleCliPatch("docAgent")],
   ["docAgentModel", makeRoleModelPatch("docAgent")],
   ["docAgentEffort", makeRoleEffortPatch("docAgent")],
+  ["distillerCli", makeRoleCliPatch("distiller")],
+  ["distillerModel", makeRoleModelPatch("distiller")],
+  ["distillerEffort", makeRoleEffortPatch("distiller")],
+  ["distillerIntervalDays", putDistillerIntervalDays],
   ["namerCli", makeRoleCliPatch("namer")],
   ["namerModel", makeRoleModelPatch("namer")],
   ["namerEffort", makeRoleEffortPatch("namer")],
@@ -4684,7 +4696,7 @@ function putDefaultEffort(value: unknown, deps: Ctx["deps"]): Response {
 // is a PAIR: a `<role>Cli` ("inherit"|<provider>) and a `<role>Model` ("default"|<alias>). Both
 // live-update config (the spawn-time thunks read config per spawn, so no restart) and persist.
 // cli/model are validated + stored independently; resolveRoleEnvironment clamps an incoherent pair.
-type RoleKey = "critic" | "planner" | "recap" | "docAgent" | "namer" | "autopilot";
+type RoleKey = "critic" | "planner" | "recap" | "docAgent" | "namer" | "autopilot" | "distiller";
 
 function makeRoleCliPatch(role: RoleKey): (value: unknown, deps: Ctx["deps"]) => Response {
   const key = `${role}Cli` as const;
@@ -4734,6 +4746,19 @@ function putDefaultAgentProvider(value: unknown, deps: Ctx["deps"]): Response {
   config.defaultAgentProvider = v;
   deps.store.setSetting("defaultAgentProvider", v);
   return json({ defaultAgentProvider: config.defaultAgentProvider });
+}
+
+function putDistillerIntervalDays(value: unknown, deps: Ctx["deps"]): Response {
+  if (typeof value !== "number" || !Number.isFinite(value))
+    return json({ error: "distillerIntervalDays must be a number" }, 400);
+  config.distillerIntervalDays = clampCap(
+    value,
+    DISTILLER_INTERVAL_DAYS_MIN,
+    DISTILLER_INTERVAL_DAYS_MAX,
+    config.distillerIntervalDays,
+  );
+  deps.store.setSetting("distillerIntervalDays", String(config.distillerIntervalDays));
+  return json({ distillerIntervalDays: config.distillerIntervalDays });
 }
 
 // Account-wide extra-credit (paid overage) spend ceiling. Requires a finite, non-negative

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
-import { DistillerService, DISTILL_LABEL } from "../src/distiller";
+import { DistillerService, DISTILL_LABEL, type DistillerDeps } from "../src/distiller";
 import { SessionStore } from "../src/store";
 import { config } from "../src/config";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
@@ -32,7 +32,11 @@ function seedSignals(store: SessionStore, repo: string, n: number) {
   }
 }
 
-function mkDeps(store: SessionStore, proposals: any, onChange = () => {}) {
+function mkDeps(
+  store: SessionStore,
+  proposals: any,
+  onChange = () => {},
+): { deps: DistillerDeps; started: { dir: string }[] } {
   const started: { dir: string }[] = [];
   return {
     deps: {
@@ -231,7 +235,10 @@ test("spawn argv follows the safe critic contract (dontAsk after allowlist, bare
   expect(argv.length).toBeGreaterThan(mode + 2);
 });
 
-function spawnCapture(store: SessionStore) {
+function spawnCapture(store: SessionStore): {
+  deps: DistillerDeps;
+  cap: { argv: string[]; env?: Record<string, string>; starts: number; removed: number };
+} {
   const cap: { argv: string[]; env?: Record<string, string>; starts: number; removed: number } = {
     argv: [],
     env: undefined,
@@ -448,6 +455,8 @@ test("distiller increments ineffective for cited active rule ids with validated 
       addLearning: () => ({}) as never,
       listLearnings: () => [],
       listActiveLearnings: () => active as never,
+      getSetting: () => null,
+      setSetting: () => {},
       getRepoConfig: () => ({
         criticEnabled: true,
         criticAllPrs: false,

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -79,6 +79,43 @@ test("consider does nothing below the signal threshold", async () => {
   expect(started.length).toBe(0);
 });
 
+test("automatic consideration respects the persisted per-repository interval", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+  const { deps, started } = mkDeps(store, { rules: [] });
+  let now = 1_000;
+  deps.now = () => now;
+  deps.intervalDays = () => 3;
+  const d = new DistillerService(deps as any);
+
+  await d.consider("/r");
+  await d.tick();
+  expect(started.length).toBe(1);
+  expect(store.getSetting("distiller:last-run:/r")).toBe(String(now));
+
+  now += 2 * 24 * 60 * 60 * 1000;
+  await d.consider("/r");
+  expect(started.length).toBe(1);
+
+  now += 24 * 60 * 60 * 1000;
+  await d.consider("/r");
+  expect(started.length).toBe(2);
+});
+
+test("manual distill bypasses a recent automatic-run timestamp", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+  const { deps, started } = mkDeps(store, { rules: [] });
+  deps.intervalDays = () => 14;
+  const d = new DistillerService(deps as any);
+
+  await d.consider("/r");
+  await d.tick();
+  await d.distillNow("/r");
+
+  expect(started.length).toBe(2);
+});
+
 test("egress_drop signals are excluded from the learnings corpus + threshold", async () => {
   const store = new SessionStore(":memory:");
   seedSignals(store, "/r", 2); // 2 real learning signals — below minSignals (3)
@@ -255,6 +292,68 @@ test("distill spawn: api-key without a configured key fails closed (no spawn, sc
     expect(cap.starts).toBe(0);
     expect(cap.removed).toBe(1); // allocated scratch dir cleaned up
   });
+});
+
+test("distill spawn: a resolved Codex environment uses codex exec with its model and effort", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+  const { deps, cap } = spawnCapture(store);
+  deps.environment = () => ({ provider: "codex", model: "gpt-5.5", effort: "high" });
+
+  await new DistillerService(deps as any).distillNow("/r");
+
+  expect(cap.argv).toEqual([
+    "codex",
+    "exec",
+    "--sandbox",
+    "workspace-write",
+    "-m",
+    "gpt-5.5",
+    "-c",
+    "model_reasoning_effort=high",
+    expect.any(String),
+  ]);
+  expect(cap.env).toBeUndefined();
+});
+
+test("distill spawn: an explicit Claude environment keeps the writer-ro Claude argv", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+  const { deps, cap } = spawnCapture(store);
+  deps.environment = () => ({ provider: "claude", model: "sonnet", effort: "high" });
+
+  await new DistillerService(deps as any).distillNow("/r");
+
+  expect(cap.argv[0]).toBe("claude");
+  expect(cap.argv).toContain("--settings");
+  expect(cap.argv).toContain("--allowedTools");
+  expect(cap.argv).toContain("--model");
+  expect(cap.argv).toContain("sonnet");
+  expect(cap.argv).toContain("--effort");
+  expect(cap.argv).toContain("high");
+  expect(cap.argv).toContain("--permission-mode");
+  expect(cap.argv).toContain("dontAsk");
+});
+
+test("distill spawn: missing Anthropic api key does not block a resolved Codex environment", async () => {
+  const previousMode = config.authMode;
+  const previousHelper = config.authApiKeyHelperPath;
+  config.authMode = "api-key";
+  config.authApiKeyHelperPath = null;
+  try {
+    const store = new SessionStore(":memory:");
+    seedSignals(store, "/r", 3);
+    const { deps, cap } = spawnCapture(store);
+    deps.environment = () => ({ provider: "codex", model: null, effort: null });
+
+    await new DistillerService(deps as any).distillNow("/r");
+
+    expect(cap.starts).toBe(1);
+    expect(cap.argv.slice(0, 4)).toEqual(["codex", "exec", "--sandbox", "workspace-write"]);
+  } finally {
+    config.authMode = previousMode;
+    config.authApiKeyHelperPath = previousHelper;
+  }
 });
 
 test("tick finalizes and reaps a run that times out without proposals", async () => {

--- a/test/server-settings.test.ts
+++ b/test/server-settings.test.ts
@@ -26,7 +26,7 @@ let savedPrCap: number;
 let savedPlanCap: number;
 let savedDefaultModel: string;
 let savedDefaultCodexModel: string;
-const ROLE_BASES = ["critic", "planner", "recap", "docAgent", "namer", "autopilot"] as const;
+const ROLE_BASES = ["critic", "planner", "recap", "docAgent", "namer", "autopilot", "distiller"] as const;
 let savedRoleEnvs: Record<string, string>;
 let savedDefaultAgentProvider: typeof config.defaultAgentProvider;
 let savedExtraCredits: number;
@@ -412,6 +412,18 @@ test("GET /api/settings includes defaultAgentProvider", async () => {
   expect(res.status).toBe(200);
   const body = await res.json();
   expect(body.defaultAgentProvider).toBe("codex");
+});
+
+test("GET and PUT persist the bounded Distiller interval", async () => {
+  const { app, store } = harness();
+  const initial = await (await app.fetch(new Request("http://x/api/settings"))).json();
+  expect(initial.distillerIntervalDaysMin).toBe(1);
+  expect(initial.distillerIntervalDaysMax).toBe(14);
+
+  const res = await put(app, { distillerIntervalDays: 20 });
+  expect(res.status).toBe(200);
+  expect((await res.json()).distillerIntervalDays).toBe(14);
+  expect(store.getSetting("distillerIntervalDays")).toBe("14");
 });
 
 test("PUT /api/settings sets defaultModel, persists, leaves repoRoot intact", async () => {

--- a/test/server-settings.test.ts
+++ b/test/server-settings.test.ts
@@ -26,7 +26,15 @@ let savedPrCap: number;
 let savedPlanCap: number;
 let savedDefaultModel: string;
 let savedDefaultCodexModel: string;
-const ROLE_BASES = ["critic", "planner", "recap", "docAgent", "namer", "autopilot", "distiller"] as const;
+const ROLE_BASES = [
+  "critic",
+  "planner",
+  "recap",
+  "docAgent",
+  "namer",
+  "autopilot",
+  "distiller",
+] as const;
 let savedRoleEnvs: Record<string, string>;
 let savedDefaultAgentProvider: typeof config.defaultAgentProvider;
 let savedExtraCredits: number;

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3143,5 +3143,12 @@
   "planpanel_review_at_cap": "Erneute Prüfung am Überarbeitungslimit. Der Prüfer kann den Plan weiterhin freigeben, aber falls er erneut Änderungen verlangt, werden diese Befunde nicht an den Planungs-Agenten gesendet. Mit „Mit Befunden fortsetzen“ das Budget zurücksetzen und erneut senden.",
   "planpanel_review_at_cap_no_resume": "Erneute Prüfung am Überarbeitungslimit. Der Prüfer kann den Plan weiterhin freigeben. Verlangt er stattdessen Änderungen, werden diese Befunde nicht an den Planungs-Agenten gesendet – „Mit Befunden fortsetzen“ erscheint dann hier, um das Budget zurückzusetzen und sie erneut zu senden.",
   "drain_paused_epic_base": "Pausiert: Epic-Branch {branch} nicht erstellbar",
-  "epic_hold_epic_base_unavailable": "Pausiert: Der Epic-Branch {branch} konnte auf der Forge nicht erstellt werden. Wird erneut versucht — bis dahin kann kein Child starten."
+  "epic_hold_epic_base_unavailable": "Pausiert: Der Epic-Branch {branch} konnte auf der Forge nicht erstellt werden. Wird erneut versucht — bis dahin kann kein Child starten.",
+  "settings_role_model_distiller_title": "Learnings-Distiller",
+  "settings_role_model_distiller_hint": "Findet wiederkehrende Erkenntnisse aus Repository-Signalen.",
+  "settings_distiller_interval_label": "Tage zwischen automatischen Läufen",
+  "settings_distiller_interval_hint": "Wähle {min}–{max} ganze Tage. Manuelle Läufe werden nie verzögert.",
+  "settings_distiller_interval_save_failed": "Das Distiller-Intervall konnte nicht gespeichert werden.",
+  "feat_distiller_provider_cadence_title": "Kosten des Learnings-Distillers steuern",
+  "feat_distiller_provider_cadence_body": "Wähle CLI, Modell, Aufwand und die Tage zwischen automatischen Distiller-Läufen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3143,5 +3143,12 @@
   "planpanel_review_at_cap": "Re-reviewing at the rework cap. The reviewer can still approve the plan, but if it requests changes again those findings will not be sent to the planning agent. Use “Resume with findings” to reset the budget and re-send them.",
   "planpanel_review_at_cap_no_resume": "Re-reviewing at the rework cap. The reviewer can still approve the plan. If it requests changes instead, those findings will not be sent to the planning agent — “Resume with findings” then appears here to reset the budget and re-send them.",
   "drain_paused_epic_base": "Paused: can't create epic branch {branch}",
-  "epic_hold_epic_base_unavailable": "Paused: the epic branch {branch} could not be created on the forge. Retrying — no child can be started until it exists."
+  "epic_hold_epic_base_unavailable": "Paused: the epic branch {branch} could not be created on the forge. Retrying — no child can be started until it exists.",
+  "settings_role_model_distiller_title": "Learnings Distiller",
+  "settings_role_model_distiller_hint": "Finds recurring lessons from repository signals.",
+  "settings_distiller_interval_label": "Days between automatic runs",
+  "settings_distiller_interval_hint": "Choose {min}–{max} whole days. Manual runs are never delayed.",
+  "settings_distiller_interval_save_failed": "Could not save the Distiller interval.",
+  "feat_distiller_provider_cadence_title": "Control Learnings Distiller cost",
+  "feat_distiller_provider_cadence_body": "Choose the Distiller CLI, model, effort, and the days between automatic runs."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -614,7 +614,7 @@ export const putDefaultAgentProvider = (
 // The per-role ENVIRONMENT settings the Settings UI can override. Each role has a PAIR: a
 // `<role>Cli` ("inherit" | "claude" | "codex") and a `<role>Model` ("default" | <alias>). The
 // server validates + persists each independently and echoes the stored value under the same key.
-export type RoleBase = "critic" | "planner" | "recap" | "docAgent" | "namer" | "autopilot";
+export type RoleBase = "critic" | "planner" | "recap" | "docAgent" | "namer" | "autopilot" | "distiller";
 export type RoleCliKey = `${RoleBase}Cli`;
 export type RoleModelKey = `${RoleBase}Model`;
 export type RoleEffortKey = `${RoleBase}Effort`;
@@ -636,6 +636,10 @@ export const putRoleEffort = (
   key: RoleEffortKey,
   effort: string,
 ): Promise<Partial<Record<RoleEffortKey, string>>> => patchSettings({ [key]: effort });
+
+export const putDistillerIntervalDays = (
+  days: number,
+): Promise<{ distillerIntervalDays: number }> => patchSettings({ distillerIntervalDays: days });
 
 // Switch how spawned agents authenticate (subscription OAuth vs. metered API key).
 export const putAuthMode = (mode: string): Promise<{ authMode: string; hasApiKey: boolean }> =>

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -614,7 +614,8 @@ export const putDefaultAgentProvider = (
 // The per-role ENVIRONMENT settings the Settings UI can override. Each role has a PAIR: a
 // `<role>Cli` ("inherit" | "claude" | "codex") and a `<role>Model` ("default" | <alias>). The
 // server validates + persists each independently and echoes the stored value under the same key.
-export type RoleBase = "critic" | "planner" | "recap" | "docAgent" | "namer" | "autopilot" | "distiller";
+export type RoleBase =
+  "critic" | "planner" | "recap" | "docAgent" | "namer" | "autopilot" | "distiller";
 export type RoleCliKey = `${RoleBase}Cli`;
 export type RoleModelKey = `${RoleBase}Model`;
 export type RoleEffortKey = `${RoleBase}Effort`;

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -281,7 +281,15 @@
   // Each role is a PAIR: a CLI (`<role>Cli` ∈ "inherit"|"claude"|"codex"; "inherit" follows the
   // global provider+model) and a model (`<role>Model` ∈ "default"|<alias for that CLI>). Seeds
   // mirror the server defaults so the pickers read sensibly before load() resolves.
-  const ROLE_BASES = ["planner", "critic", "docAgent", "recap", "distiller", "namer", "autopilot"] as const;
+  const ROLE_BASES = [
+    "planner",
+    "critic",
+    "docAgent",
+    "recap",
+    "distiller",
+    "namer",
+    "autopilot",
+  ] as const;
   type RoleBase = (typeof ROLE_BASES)[number];
   const ROLE_CLI_SEED: Record<RoleBase, string> = {
     planner: "inherit",
@@ -489,14 +497,23 @@
   async function saveDistillerInterval() {
     if (distillerIntervalBusy) return;
     distillerIntervalBusy = true;
-    const value = Math.min(distillerIntervalDaysMax, Math.max(distillerIntervalDaysMin, Math.round(Number(distillerIntervalDays)) || distillerIntervalDaysMin));
+    const value = Math.min(
+      distillerIntervalDaysMax,
+      Math.max(
+        distillerIntervalDaysMin,
+        Math.round(Number(distillerIntervalDays)) || distillerIntervalDaysMin,
+      ),
+    );
     try {
       const r = await putDistillerIntervalDays(value);
       distillerIntervalDays = r.distillerIntervalDays;
       distillerIntervalDaysSaved = r.distillerIntervalDays;
     } catch {
       distillerIntervalDays = distillerIntervalDaysSaved;
-      toasts.info(m.settings_distiller_interval_save_failed(), { key: "distiller-interval", alert: true });
+      toasts.info(m.settings_distiller_interval_save_failed(), {
+        key: "distiller-interval",
+        alert: true,
+      });
     } finally {
       distillerIntervalBusy = false;
     }
@@ -1407,9 +1424,24 @@
           {#if role === "distiller"}
             <label class="cycles">
               <span class="cycles-label">{m.settings_distiller_interval_label()}</span>
-              <input class="num" type="number" min={distillerIntervalDaysMin} max={distillerIntervalDaysMax} step="1" disabled={distillerIntervalBusy} bind:value={distillerIntervalDays} aria-label={m.settings_distiller_interval_label()} onchange={saveDistillerInterval} />
+              <input
+                class="num"
+                type="number"
+                min={distillerIntervalDaysMin}
+                max={distillerIntervalDaysMax}
+                step="1"
+                disabled={distillerIntervalBusy}
+                bind:value={distillerIntervalDays}
+                aria-label={m.settings_distiller_interval_label()}
+                onchange={saveDistillerInterval}
+              />
             </label>
-            <p class="hint">{m.settings_distiller_interval_hint({ min: distillerIntervalDaysMin, max: distillerIntervalDaysMax })}</p>
+            <p class="hint">
+              {m.settings_distiller_interval_hint({
+                min: distillerIntervalDaysMin,
+                max: distillerIntervalDaysMax,
+              })}
+            </p>
           {/if}
         </div>
       {/snippet}

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -13,6 +13,7 @@
     putRoleModel,
     putRoleEffort,
     putRoleCli,
+    putDistillerIntervalDays,
     putDefaultAgentProvider,
     putUpnextSkipCliPicker,
     putAuthMode,
@@ -271,11 +272,16 @@
   let defaultAgentProvider = $state<AgentProvider>("claude");
   let defaultAgentProviderSaved: AgentProvider = "claude";
   let defaultAgentProviderBusy = $state(false);
+  let distillerIntervalDays = $state(1);
+  let distillerIntervalDaysSaved = 1;
+  let distillerIntervalDaysMin = $state(1);
+  let distillerIntervalDaysMax = $state(14);
+  let distillerIntervalBusy = $state(false);
   // Per-role ENVIRONMENT overrides (plan reviewer, PR critic, recap, doc-agent, namer, autopilot).
   // Each role is a PAIR: a CLI (`<role>Cli` ∈ "inherit"|"claude"|"codex"; "inherit" follows the
   // global provider+model) and a model (`<role>Model` ∈ "default"|<alias for that CLI>). Seeds
   // mirror the server defaults so the pickers read sensibly before load() resolves.
-  const ROLE_BASES = ["planner", "critic", "docAgent", "recap", "namer", "autopilot"] as const;
+  const ROLE_BASES = ["planner", "critic", "docAgent", "recap", "distiller", "namer", "autopilot"] as const;
   type RoleBase = (typeof ROLE_BASES)[number];
   const ROLE_CLI_SEED: Record<RoleBase, string> = {
     planner: "inherit",
@@ -284,6 +290,7 @@
     recap: "claude",
     namer: "claude",
     autopilot: "claude",
+    distiller: "inherit",
   };
   const ROLE_MODEL_SEED: Record<RoleBase, string> = {
     planner: "default",
@@ -292,6 +299,7 @@
     recap: "sonnet",
     namer: "haiku",
     autopilot: "haiku",
+    distiller: "default",
   };
   // Per-role reasoning-effort tier ("default"|<tier>), orthogonal to CLI/model — always shown.
   const ROLE_EFFORT_SEED: Record<RoleBase, string> = {
@@ -301,6 +309,7 @@
     recap: "low",
     namer: "low",
     autopilot: "low",
+    distiller: "default",
   };
   let roleCli = $state<Record<RoleBase, string>>({ ...ROLE_CLI_SEED });
   let roleCliSaved: Record<RoleBase, string> = { ...ROLE_CLI_SEED };
@@ -315,9 +324,10 @@
     recap: false,
     namer: false,
     autopilot: false,
+    distiller: false,
   });
   // Foreground (content) roles vs. collapsed classifiers (constant-cadence, kept cheap).
-  const ROLE_PRIMARY: RoleBase[] = ["planner", "critic", "docAgent", "recap"];
+  const ROLE_PRIMARY: RoleBase[] = ["planner", "critic", "docAgent", "recap", "distiller"];
   const ROLE_CLASSIFIERS: RoleBase[] = ["namer", "autopilot"];
 
   function roleTitle(role: RoleBase): string {
@@ -334,6 +344,8 @@
         return m.settings_role_model_namer_title();
       case "autopilot":
         return m.settings_role_model_autopilot_title();
+      case "distiller":
+        return m.settings_role_model_distiller_title();
     }
   }
   function roleHint(role: RoleBase): string {
@@ -350,6 +362,8 @@
         return m.settings_role_model_namer_hint();
       case "autopilot":
         return m.settings_role_model_autopilot_hint();
+      case "distiller":
+        return m.settings_role_model_distiller_hint();
     }
   }
   // Display label for a CLI/provider (the CLI dropdown options + the effective line).
@@ -469,6 +483,22 @@
         key: `role-effort-${role}`,
         alert: true,
       });
+    }
+  }
+
+  async function saveDistillerInterval() {
+    if (distillerIntervalBusy) return;
+    distillerIntervalBusy = true;
+    const value = Math.min(distillerIntervalDaysMax, Math.max(distillerIntervalDaysMin, Math.round(Number(distillerIntervalDays)) || distillerIntervalDaysMin));
+    try {
+      const r = await putDistillerIntervalDays(value);
+      distillerIntervalDays = r.distillerIntervalDays;
+      distillerIntervalDaysSaved = r.distillerIntervalDays;
+    } catch {
+      distillerIntervalDays = distillerIntervalDaysSaved;
+      toasts.info(m.settings_distiller_interval_save_failed(), { key: "distiller-interval", alert: true });
+    } finally {
+      distillerIntervalBusy = false;
     }
   }
   let authMode = $state("subscription"); // how spawned agents authenticate
@@ -1043,6 +1073,10 @@
       planReviewCycles = s.planReviewCyclesCap;
       planReviewCyclesSaved = s.planReviewCyclesCap;
       applyModelPrefs(s);
+      distillerIntervalDays = s.distillerIntervalDays ?? 1;
+      distillerIntervalDaysSaved = distillerIntervalDays;
+      distillerIntervalDaysMin = s.distillerIntervalDaysMin ?? 1;
+      distillerIntervalDaysMax = s.distillerIntervalDaysMax ?? 14;
       // Fall back to the seed default per role when a field is absent (e.g. an older backend that
       // predates per-role environments) so the pickers never render blank — a sensible default is
       // always shown.
@@ -1370,6 +1404,13 @@
             model={roleGuidanceModel(role)}
             context={roleGuidanceContext(role)}
           />
+          {#if role === "distiller"}
+            <label class="cycles">
+              <span class="cycles-label">{m.settings_distiller_interval_label()}</span>
+              <input class="num" type="number" min={distillerIntervalDaysMin} max={distillerIntervalDaysMax} step="1" disabled={distillerIntervalBusy} bind:value={distillerIntervalDays} aria-label={m.settings_distiller_interval_label()} onchange={saveDistillerInterval} />
+            </label>
+            <p class="hint">{m.settings_distiller_interval_hint({ min: distillerIntervalDaysMin, max: distillerIntervalDaysMax })}</p>
+          {/if}
         </div>
       {/snippet}
 

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -1074,6 +1074,13 @@
     operatorLanguageSaved = operatorLanguage;
   }
 
+  function applyDistillerPrefs(s: Awaited<ReturnType<typeof getSettings>>) {
+    distillerIntervalDays = s.distillerIntervalDays ?? 1;
+    distillerIntervalDaysSaved = distillerIntervalDays;
+    distillerIntervalDaysMin = s.distillerIntervalDaysMin ?? 1;
+    distillerIntervalDaysMax = s.distillerIntervalDaysMax ?? 14;
+  }
+
   onMount(async () => {
     try {
       const s = await getSettings();
@@ -1090,10 +1097,7 @@
       planReviewCycles = s.planReviewCyclesCap;
       planReviewCyclesSaved = s.planReviewCyclesCap;
       applyModelPrefs(s);
-      distillerIntervalDays = s.distillerIntervalDays ?? 1;
-      distillerIntervalDaysSaved = distillerIntervalDays;
-      distillerIntervalDaysMin = s.distillerIntervalDaysMin ?? 1;
-      distillerIntervalDaysMax = s.distillerIntervalDaysMax ?? 14;
+      applyDistillerPrefs(s);
       // Fall back to the seed default per role when a field is absent (e.g. an older backend that
       // predates per-role environments) so the pickers never render blank — a sensible default is
       // always shown.

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-distiller-provider-cadence.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-distiller-provider-cadence.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "distiller-provider-cadence",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_distiller_provider_cadence_title",
+  bodyKey: "feat_distiller_provider_cadence_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -119,6 +119,12 @@ export interface Settings {
   autopilotCli: string;
   autopilotModel: string;
   autopilotEffort: string;
+  distillerCli?: string;
+  distillerModel?: string;
+  distillerEffort?: string;
+  distillerIntervalDays?: number;
+  distillerIntervalDaysMin?: number;
+  distillerIntervalDaysMax?: number;
   /** Default interactive agent provider for newly spawned task sessions. */
   defaultAgentProvider?: AgentProvider;
   /** When true, Up Next quick-start launches with the default coding CLI without opening the


### PR DESCRIPTION
## Problem / goal

The Learnings Distiller always fell back to Claude Code even when Shepherd’s default and role settings selected Codex. Its daily per-repository automatic sweep could repeatedly start expensive runs with no configurable spacing.

## Solution / added

- Added a persisted Distiller environment: CLI (`inherit`, Claude, or Codex), provider-compatible model, and reasoning effort.
- Resolved the environment immediately before every spawn; inherited settings follow global provider, model, and effort.
- Added a persisted 1–14-day interval for automatic runs, defaulting to one day. Manual runs remain an explicit override.

## Technical details

- Codex spawns use the shared `codex exec` argv path; explicit Claude retains the existing `writer-ro` invocation.
- Anthropic API-key fail-closed behavior now applies only to Claude, so it does not block a Codex Distiller.
- Successful automatic spawns persist a per-repository timestamp, which also protects the startup sweep from bypassing the chosen interval.
- Added the Settings control, EN/DE text, feature announcement, and focused regression coverage.

## Validation

- `bun run lint`
- `bun test test/distiller.test.ts test/server-settings.test.ts`
- `cd ui && bun run check:i18n`
- `cd ui && bun run check`
- `cd ui && bun run test -- --project browser src/lib/components/Settings.browser.test.ts`