### PR TITLE
fix(ui): keep drain cap/ceiling editable during an epic

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2229,6 +2229,7 @@
   "topbar_held_spawning": "Wird gestartet…",
   "topbar_held_discarding": "Wird verworfen…",
   "automation_drain_fields_intro": "Diese Regler steuern die Backlog-Abarbeitung und gelten nur, solange sie aktiv ist:",
+  "automation_drain_fields_intro_epic": "Diese Regler steuern weiterhin die Abarbeitung des laufenden Epics — passe sie an, um es im Lauf nachzujustieren:",
   "drain_cap_hint": "Wie viele auto-gestartete Agenten höchstens gleichzeitig laufen. Ist das Limit erreicht, wartet Shepherd auf einen freien Platz, bevor das nächste Issue aufgegriffen wird.",
   "drain_label_hint": "Nur Issues mit diesem Label werden aufgegriffen — versieh die Tickets, die automatisch abgearbeitet werden sollen, damit.",
   "drain_ceiling_hint": "Pausiert neue Auto-Starts, sobald die Konto-Auslastung diesen Prozentwert erreicht. Ein höherer Wert lässt die Abarbeitung länger weiterlaufen; Standard ist 80.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2229,6 +2229,7 @@
   "topbar_held_spawning": "Starting…",
   "topbar_held_discarding": "Discarding…",
   "automation_drain_fields_intro": "These dials govern Auto-Drain and apply only while it's on:",
+  "automation_drain_fields_intro_epic": "These dials still govern the running epic's draining — adjust them to retune it in flight:",
   "drain_cap_hint": "Most auto-started agents allowed to run at once. Once it's reached, Shepherd waits for a slot to free before picking up the next issue.",
   "drain_label_hint": "Only issues carrying this label get picked up — tag the tickets you want worked automatically with it.",
   "drain_ceiling_hint": "Pause new auto-starts once your account usage reaches this percentage. A higher value lets the drain keep going longer; the default is 80.",

--- a/ui/src/lib/components/AutomationSettings.svelte
+++ b/ui/src/lib/components/AutomationSettings.svelte
@@ -52,9 +52,14 @@
   const flags = $derived(repoConfig.flags(repoPath));
   /** True when this repo is configured for local-only (lightweight) mode. */
   const lightweight = $derived(repoConfig.repoModeFor(repoPath) === "lightweight");
-  /** Auto-Drain's rails are live only when drain is on, not epic-suspended, and the
-   *  repo is a forge — mirrors the Auto-Drain switch's own enabled condition. */
-  const drainRailsActive = $derived(flags.autoDrain && !epicActive && !lightweight);
+  /** Auto-Drain's rails (cap / usage ceiling) govern spawning whenever draining is
+   *  happening — label-drain (`flags.autoDrain`) OR a running epic — so they stay
+   *  reachable while an epic runs, since both `maxAuto` and the usage ceiling are
+   *  still enforced against the epic's children (drain-core capHold/usageHold). The
+   *  label field is the exception (label-drain is suspended mid-epic); the component
+   *  hides just that field on `epicActive`. Only lightweight (non-forge) repos, which
+   *  never drain, hide the group entirely. */
+  const drainRailsActive = $derived(!lightweight && (flags.autoDrain || epicActive));
   // Switch-pulse is per-task; only meaningful when this instance is bound to a session.
   const reviewing = $derived(sessionId ? reviews.isReviewing(sessionId) : false);
   const planReviewing = $derived(sessionId ? planGates.isReviewing(sessionId) : false);
@@ -433,10 +438,12 @@
   </button>
 </div>
 <!-- Auto-Drain's rails (cap / label / usage ceiling), inline directly under its
-     toggle so they read as part of that switch. The component renders them only
-     while drain is genuinely active (on, not epic-suspended, forge repo) —
-     visibility is gated inside it via `active` so this template stays flat. -->
-<AutomationDrainFields {repoPath} active={drainRailsActive} />
+     toggle so they read as part of that switch. `active` gates the whole group
+     (shown while label-drain is on OR an epic is running); `epicActive` tells the
+     component to hide just the label field (label-drain is suspended mid-epic) and
+     switch to the epic-scoped intro copy. Both flags are gated inside the component
+     so this template stays flat. -->
+<AutomationDrainFields {repoPath} active={drainRailsActive} {epicActive} />
 <div class={["auto-row", { disabled: lightweight }]}>
   <div class="auto-meta">
     <div class="auto-name">☑ {m.automation_prewarm_epic_ci_name()}</div>

--- a/ui/src/lib/components/automation-settings/AutomationDrainFields.svelte
+++ b/ui/src/lib/components/automation-settings/AutomationDrainFields.svelte
@@ -6,11 +6,18 @@
   import "./automation-fields.css";
 
   // The Auto-Drain "rails" (cap / label / usage ceiling). Rendered inline directly
-  // beneath the Auto-Drain toggle — and only while it's on — so the dials read as
-  // belonging to that switch rather than floating in an unrelated section below.
-  // `active` gates visibility here (instead of an {#if} at the call site) to keep
-  // the parent's already-large template flat.
-  let { repoPath, active }: { repoPath: string; active: boolean } = $props();
+  // beneath the Auto-Drain toggle so the dials read as belonging to that switch
+  // rather than floating in an unrelated section below. `active` gates visibility
+  // here (instead of an {#if} at the call site) to keep the parent's already-large
+  // template flat. `epicActive` (a running epic has taken over draining) hides the
+  // label field — label-drain is suspended mid-epic, so its dial is inert — while
+  // the cap and usage ceiling stay editable, since both are still enforced against
+  // the epic's children.
+  let {
+    repoPath,
+    active,
+    epicActive = false,
+  }: { repoPath: string; active: boolean; epicActive?: boolean } = $props();
 
   // Per-instance prefix so the hint IDs (and the inputs' aria-describedby) stay
   // unique even if two panels mount at once (e.g. in-task popover + backlog tab).
@@ -61,7 +68,9 @@
 
 {#if active}
   <div class="drain-fields" role="group" aria-label={m.automation_autodrain_name()}>
-    <p class="drain-intro">{m.automation_drain_fields_intro()}</p>
+    <p class="drain-intro">
+      {epicActive ? m.automation_drain_fields_intro_epic() : m.automation_drain_fields_intro()}
+    </p>
     <label class="drain-field">
       <span class="drain-label">{m.drain_cap_label()}</span>
       <input
@@ -76,19 +85,21 @@
       />
     </label>
     <p id="{uid}-cap" class="drain-hint">{m.drain_cap_hint()}</p>
-    <label class="drain-field">
-      <span class="drain-label">{m.drain_label_label()}</span>
-      <input
-        class="afield-num txt"
-        type="text"
-        bind:value={drainLabel}
-        aria-label={m.drain_label_label()}
-        aria-describedby="{uid}-label"
-        onchange={commitDrainLabel}
-        onblur={commitDrainLabel}
-      />
-    </label>
-    <p id="{uid}-label" class="drain-hint">{m.drain_label_hint()}</p>
+    {#if !epicActive}
+      <label class="drain-field">
+        <span class="drain-label">{m.drain_label_label()}</span>
+        <input
+          class="afield-num txt"
+          type="text"
+          bind:value={drainLabel}
+          aria-label={m.drain_label_label()}
+          aria-describedby="{uid}-label"
+          onchange={commitDrainLabel}
+          onblur={commitDrainLabel}
+        />
+      </label>
+      <p id="{uid}-label" class="drain-hint">{m.drain_label_hint()}</p>
+    {/if}
     <label class="drain-field">
       <span class="drain-label">{m.drain_ceiling_label()}</span>
       <input


### PR DESCRIPTION
## Problem

The Auto-Drain **cap** and **usage-ceiling** dials (`AutomationDrainFields`) were gated on `drainRailsActive = flags.autoDrain && !epicActive && !lightweight`, and the Auto-Drain toggle is disabled while an epic runs. So once an epic kicks off, the whole rails group disappears and the toggle can't be flipped — the capacity setting is effectively **unreachable** for the duration of the epic.

But that setting is exactly what's still governing the epic: during an epic, `Drain.buildState` still copies `cfg.maxAuto` / `cfg.usageCeilingPct` into the drain state (`src/drain.ts`), and `computeNext` still enforces both — `capHold` (`src/drain-core.ts:317`) and `usageHold` (`:321`) — against the epic's children. So the one live, still-enforced knob was hidden precisely when tuning it matters most.

## Fix

- **Cap + usage ceiling** now show whenever draining is happening — label-drain on **or** an epic running: `drainRailsActive = !lightweight && (flags.autoDrain || epicActive)`. Editing them writes straight through `repoConfig.setMaxAuto` / `setUsageCeiling` (no server-side epic guard existed — only the UI was hiding the control), and the drain pump picks up the new value on its next cycle.
- **Label** field stays hidden mid-epic — label-drain is genuinely suspended while an epic owns the candidate set, so its dial is inert. Gated inside the component on a new `epicActive` prop.
- **Intro copy** switches to an epic-scoped line (`automation_drain_fields_intro_epic`, EN+DE) so the panel doesn't claim the dials "apply only while Auto-Drain is on" when an epic is driving them.

## Verification

- `cd ui && bun run check` → 0 errors / 0 warnings
- `cd ui && bun run check:i18n` → 2 locales in parity (new key present in both)
- prettier + eslint clean (pre-commit + pre-push hooks passed)

Purely a visibility/reachability change to an existing settings panel — no drain-core or persistence logic touched. `[no-feature-entry]` (a fix to an existing control's reachability, not a new user-facing feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)