### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs-site/src/content/docs/reference/glossary.md
+++ b/docs-site/src/content/docs/reference/glossary.md
@@ -68,7 +68,7 @@ the model reasons before answering — higher effort spends more tokens for deep
 reasoning, lower is faster and cheaper. Selectable per session in the New Task
 picker — and when spawning a variant, comparison, or replacement — with a per-repo
 or global default in Settings, plus a per-role override for each satellite pass
-(critic, planner, recap, doc-agent, namer, autopilot) in the Settings agent matrix;
+(critic, planner, recap, doc-agent, distiller, namer, autopilot) in the Settings agent matrix;
 leave it at **default** to use the CLI's own effort. Shepherd passes it to the
 agent CLI as `--effort` (Claude) or `model_reasoning_effort` (Codex).
 


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Documentation update summary

## Changes

- **`docs-site/src/content/docs/reference/glossary.md`** — In the *Reasoning
  effort* entry, added `distiller` to the enumerated list of per-role overrides in
  the Settings agent matrix (was `critic, planner, recap, doc-agent, namer,
  autopilot`; now includes `distiller`). Grounded in commit `9773d7ed`
  (feat(learnings): configure Distiller provider and cadence, #1769), which added
  `distillerCli` / `distillerModel` / `distillerEffort` to `src/config.ts` and the
  `distiller` role to the UI role matrix — see `ui/src/lib/api.ts` (`RoleBase` now
  ends `… | "autopilot" | "distiller"`) and `ui/src/lib/components/Settings.svelte`
  (`ROLE_PRIMARY = [..., "distiller"]`, with title "Learnings Distiller"). The
  effort dial is therefore now settable per-role for the distiller too, so the old
  list was incomplete.

## Uncertain / needs human judgment

- **`docs-site/src/content/docs/reference/configuration.md` — Distiller env vars
  not added (deliberately left alone).** Commit `9773d7ed` (#1769) introduced four
  new env vars: `SHEPHERD_DISTILLER_CLI` (`inherit`), `SHEPHERD_DISTILLER_MODEL`
  (`default`), `SHEPHERD_DISTILLER_EFFORT` (`default`), and
  `SHEPHERD_DISTILLER_INTERVAL_DAYS` (`1`, clamped to `1`–`14` via
  `DISTILLER_INTERVAL_DAYS_MIN`/`MAX`). I did **not** add a Learnings/Distiller
  section because configuration.md is already selective about role env vars: it
  documents the doc-agent role vars but omits the equivalent
  `SHEPHERD_CRITIC_*` / `SHEPHERD_PLANNER_*` / `SHEPHERD_RECAP_*` /
  `SHEPHERD_NAMER_*` / `SHEPHERD_AUTOPILOT_*` vars entirely. Adding only the
  distiller vars would be a gap-fill (and inconsistent), not a staleness
  correction, so this is a judgment call for a human: either add a "Learnings
  Distiller" section documenting the four vars above, or continue omitting per-role
  env vars as the page currently does.

- **`glossary.md` — *Satellite pass* entry left unchanged.** It lists "critic /
  PR-review, plan-gate, recap, rundown, or doc-agent" as passes "spawned alongside
  the main task agent." The Distiller is an account-wide / per-repo *periodic*
  background pass (throttled by `distillerIntervalDays`), not one spawned alongside
  a task, so by that definition it is not a satellite pass and I did not add it
  here. If the intended meaning of "satellite pass" is broader (any Shepherd-spawned
  LLM overhead pass), a human may want to mention the distiller here too.