### PR TITLE
feat(ui): make Coding CLI settings sections collapsible

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3151,5 +3151,6 @@
   "settings_distiller_interval_hint": "Wähle {min}–{max} ganze Tage. Manuelle Läufe werden nie verzögert.",
   "settings_distiller_interval_save_failed": "Das Distiller-Intervall konnte nicht gespeichert werden.",
   "feat_distiller_provider_cadence_title": "Kosten des Learnings-Distillers steuern",
-  "feat_distiller_provider_cadence_body": "Wähle CLI, Modell, Aufwand und die Tage zwischen automatischen Distiller-Läufen."
+  "feat_distiller_provider_cadence_body": "Wähle CLI, Modell, Aufwand und die Tage zwischen automatischen Distiller-Läufen.",
+  "settings_cli_defaults_title": "Globale Standards"
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3152,5 +3152,7 @@
   "settings_distiller_interval_save_failed": "Das Distiller-Intervall konnte nicht gespeichert werden.",
   "feat_distiller_provider_cadence_title": "Kosten des Learnings-Distillers steuern",
   "feat_distiller_provider_cadence_body": "Wähle CLI, Modell, Aufwand und die Tage zwischen automatischen Distiller-Läufen.",
-  "settings_cli_defaults_title": "Globale Standards"
+  "settings_cli_defaults_title": "Globale Standards",
+  "feat_collapsible_coding_cli_sections_title": "Einklappbare Coding-CLI-Einstellungen",
+  "feat_collapsible_coding_cli_sections_body": "Die Coding-CLI-Einstellungen sind jetzt in einklappbare Bereiche gegliedert und praktisch sortiert: globale Standards, Claude Code, Codex und anschließend die Umgebungen der Hilfsagenten."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3151,5 +3151,6 @@
   "settings_distiller_interval_hint": "Choose {min}–{max} whole days. Manual runs are never delayed.",
   "settings_distiller_interval_save_failed": "Could not save the Distiller interval.",
   "feat_distiller_provider_cadence_title": "Control Learnings Distiller cost",
-  "feat_distiller_provider_cadence_body": "Choose the Distiller CLI, model, effort, and the days between automatic runs."
+  "feat_distiller_provider_cadence_body": "Choose the Distiller CLI, model, effort, and the days between automatic runs.",
+  "settings_cli_defaults_title": "Global defaults"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3152,5 +3152,7 @@
   "settings_distiller_interval_save_failed": "Could not save the Distiller interval.",
   "feat_distiller_provider_cadence_title": "Control Learnings Distiller cost",
   "feat_distiller_provider_cadence_body": "Choose the Distiller CLI, model, effort, and the days between automatic runs.",
-  "settings_cli_defaults_title": "Global defaults"
+  "settings_cli_defaults_title": "Global defaults",
+  "feat_collapsible_coding_cli_sections_title": "Collapsible Coding CLI settings",
+  "feat_collapsible_coding_cli_sections_body": "Coding CLI settings are now grouped into collapsible sections in a practical order: global defaults, Claude Code, Codex, then helper-agent environments."
 }

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
-import { page } from "vitest/browser";
+import { page, userEvent } from "vitest/browser";
 import "../../app.css";
 import type { Settings as SettingsPayload, DiagnosticCheck } from "$lib/types";
 import { m } from "$lib/paraglide/messages";
@@ -165,8 +165,135 @@ const saveBtn = () => page.getByRole("button", { name: m.settings_auth_key_save(
 const keyInput = () => page.getByRole("textbox", { name: m.settings_auth_key_label() });
 
 function mountCodingAgents() {
-  render(Settings, { initialTab: "codingAgents", onclose: noop, onsaved: noop });
+  return render(Settings, { initialTab: "codingAgents", onclose: noop, onsaved: noop });
 }
+
+// During this RED step the disclosure does not exist yet, so keep the fallback for the
+// current flat layout. Once present, API-key tests must open Claude Code before touching
+// controls that intentionally remain mounted but hidden inside the collapsed section.
+async function mountClaudeApiKeySettings() {
+  await mountCodingAgents();
+  const disclosure = page.getByRole("button", {
+    name: m.settings_cli_claude_title(),
+    exact: true,
+  });
+  if (disclosure.query()?.getAttribute("aria-expanded") === "false") {
+    await disclosure.click();
+  }
+}
+
+const codingSectionNames = () => [
+  m.settings_cli_defaults_title(),
+  m.settings_cli_claude_title(),
+  m.settings_cli_codex_title(),
+  m.settings_role_models_title(),
+];
+
+function codingSectionButton(name: string) {
+  return page.getByRole("button", { name, exact: true });
+}
+
+function requiredCodingSectionButton(name: string) {
+  const disclosure = codingSectionButton(name);
+  const button = disclosure.query() as HTMLButtonElement | null;
+  expect(button, `missing Coding CLI disclosure button named "${name}"`).not.toBeNull();
+  return { disclosure, button: button! };
+}
+
+function controlledSection(button: HTMLElement): HTMLElement {
+  const id = button.getAttribute("aria-controls");
+  expect(id, "disclosure has aria-controls").toBeTruthy();
+  const content = document.getElementById(id!);
+  expect(content, `controlled content #${id} stays mounted`).not.toBeNull();
+  return content!;
+}
+
+function expectInitialCodingSectionState() {
+  const names = codingSectionNames();
+  for (const [index, name] of names.entries()) {
+    const { button } = requiredCodingSectionButton(name);
+    const expanded = index === 0;
+    expect(button.getAttribute("aria-expanded")).toBe(String(expanded));
+    expect(controlledSection(button).hidden).toBe(!expanded);
+  }
+}
+
+describe("Settings Coding CLI sections", () => {
+  it("renders the four named disclosures in order with only Global defaults open", async () => {
+    await mountCodingAgents();
+
+    const names = codingSectionNames();
+    const buttons: HTMLElement[] = [];
+    for (const name of names) {
+      buttons.push(requiredCodingSectionButton(name).button);
+    }
+
+    const panel = document.getElementById("settings-panel-codingAgents");
+    expect(panel).not.toBeNull();
+    expect(Array.from(panel!.querySelectorAll("button[aria-controls]"))).toEqual(buttons);
+
+    for (const [index, button] of buttons.entries()) {
+      const expanded = index === 0;
+      expect(button.getAttribute("aria-expanded")).toBe(String(expanded));
+      expect(controlledSection(button).hidden).toBe(!expanded);
+    }
+  });
+
+  it("click toggles a collapsed section without replacing its controlled content", async () => {
+    await mountCodingAgents();
+    const { disclosure, button } = requiredCodingSectionButton(m.settings_cli_claude_title());
+    const content = controlledSection(button);
+    expect(content.hidden).toBe(true);
+
+    await disclosure.click();
+    await expect.poll(() => button.getAttribute("aria-expanded")).toBe("true");
+    expect(document.getElementById(content.id)).toBe(content);
+    expect(content.hidden).toBe(false);
+
+    await disclosure.click();
+    await expect.poll(() => button.getAttribute("aria-expanded")).toBe("false");
+    expect(document.getElementById(content.id)).toBe(content);
+    expect(content.hidden).toBe(true);
+  });
+
+  it("native Enter and Space button interaction toggles a focused disclosure", async () => {
+    await mountCodingAgents();
+    const { button } = requiredCodingSectionButton(m.settings_cli_codex_title());
+    button.focus();
+    expect(document.activeElement).toBe(button);
+
+    await userEvent.keyboard("{Enter}");
+    await expect.poll(() => button.getAttribute("aria-expanded")).toBe("true");
+
+    await userEvent.keyboard(" ");
+    await expect.poll(() => button.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("preserves an expanded section while switching Settings tabs", async () => {
+    await mountCodingAgents();
+    const { disclosure, button } = requiredCodingSectionButton(m.settings_role_models_title());
+    await disclosure.click();
+    await expect.poll(() => button.getAttribute("aria-expanded")).toBe("true");
+
+    await page.getByRole("tab", { name: m.settings_tab_session() }).click();
+    await page.getByRole("tab", { name: m.settings_tab_coding_agents() }).click();
+
+    await expect.poll(() => button.getAttribute("aria-expanded")).toBe("true");
+    expect(controlledSection(button).hidden).toBe(false);
+  });
+
+  it("resets to only Global defaults open after Settings is remounted", async () => {
+    const first = await mountCodingAgents();
+    const { disclosure, button } = requiredCodingSectionButton(m.settings_cli_codex_title());
+    await disclosure.click();
+    await expect.poll(() => button.getAttribute("aria-expanded")).toBe("true");
+
+    await first.unmount();
+    await mountCodingAgents();
+
+    expectInitialCodingSectionState();
+  });
+});
 
 describe("Settings default coding environment", () => {
   it("loads the saved model for the selected Codex CLI", async () => {
@@ -235,7 +362,7 @@ describe("Settings default coding environment", () => {
 describe("Settings api-key verify", () => {
   it("verify → OK renders the verified line", async () => {
     mockVerify.mockResolvedValue({ ok: true });
-    mountCodingAgents();
+    await mountClaudeApiKeySettings();
 
     await expect.element(verifyBtn()).toBeInTheDocument();
     await verifyBtn().click();
@@ -249,7 +376,7 @@ describe("Settings api-key verify", () => {
       reason: "not-authenticated",
       detail: "invalid x-api-key",
     });
-    mountCodingAgents();
+    await mountClaudeApiKeySettings();
 
     await expect.element(verifyBtn()).toBeInTheDocument();
     await verifyBtn().click();
@@ -266,7 +393,7 @@ describe("Settings api-key verify", () => {
 
   it("verify throw → fail-closed (renders FAILED, never OK)", async () => {
     mockVerify.mockRejectedValue(new Error("boom"));
-    mountCodingAgents();
+    await mountClaudeApiKeySettings();
 
     await expect.element(verifyBtn()).toBeInTheDocument();
     await verifyBtn().click();
@@ -283,7 +410,7 @@ describe("Settings api-key verify", () => {
     mockGetSettings.mockResolvedValue(settings({ hasApiKey: false }));
     mockPutKey.mockResolvedValue({ hasApiKey: true });
     mockVerify.mockResolvedValue({ ok: true });
-    mountCodingAgents();
+    await mountClaudeApiKeySettings();
 
     await expect.element(keyInput()).toBeInTheDocument();
     await keyInput().fill("sk-ant-test");

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -228,9 +228,12 @@ describe("Settings Coding CLI sections", () => {
       buttons.push(requiredCodingSectionButton(name).button);
     }
 
-    const panel = document.getElementById("settings-panel-codingAgents");
-    expect(panel).not.toBeNull();
-    expect(Array.from(panel!.querySelectorAll("button[aria-controls]"))).toEqual(buttons);
+    for (let index = 0; index < buttons.length - 1; index += 1) {
+      expect(
+        buttons[index].compareDocumentPosition(buttons[index + 1]) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    }
 
     for (const [index, button] of buttons.entries()) {
       const expanded = index === 0;
@@ -250,10 +253,28 @@ describe("Settings Coding CLI sections", () => {
     expect(document.getElementById(content.id)).toBe(content);
     expect(content.hidden).toBe(false);
 
+    const { button: defaultsButton } = requiredCodingSectionButton(m.settings_cli_defaults_title());
+    expect(defaultsButton.getAttribute("aria-expanded")).toBe("true");
+    expect(controlledSection(defaultsButton).hidden).toBe(false);
+
+    const defaultModelSelect = page
+      .getByRole("combobox", { name: m.settings_default_model_title() })
+      .element();
+    expect(content.contains(defaultModelSelect)).toBe(true);
+
     await disclosure.click();
     await expect.poll(() => button.getAttribute("aria-expanded")).toBe("false");
     expect(document.getElementById(content.id)).toBe(content);
     expect(content.hidden).toBe(true);
+    expect(content.contains(defaultModelSelect)).toBe(true);
+
+    await disclosure.click();
+    await expect.poll(() => button.getAttribute("aria-expanded")).toBe("true");
+    expect(document.getElementById(content.id)).toBe(content);
+    expect(content.hidden).toBe(false);
+    expect(page.getByRole("combobox", { name: m.settings_default_model_title() }).element()).toBe(
+      defaultModelSelect,
+    );
   });
 
   it("native Enter and Space button interaction toggles a focused disclosure", async () => {

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -168,16 +168,10 @@ function mountCodingAgents() {
   return render(Settings, { initialTab: "codingAgents", onclose: noop, onsaved: noop });
 }
 
-// During this RED step the disclosure does not exist yet, so keep the fallback for the
-// current flat layout. Once present, API-key tests must open Claude Code before touching
-// controls that intentionally remain mounted but hidden inside the collapsed section.
 async function mountClaudeApiKeySettings() {
   await mountCodingAgents();
-  const disclosure = page.getByRole("button", {
-    name: m.settings_cli_claude_title(),
-    exact: true,
-  });
-  if (disclosure.query()?.getAttribute("aria-expanded") === "false") {
+  const { disclosure, button } = requiredCodingSectionButton(m.settings_cli_claude_title());
+  if (button.getAttribute("aria-expanded") === "false") {
     await disclosure.click();
   }
 }

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -291,6 +291,7 @@ describe("Settings Coding CLI sections", () => {
   });
 
   it("preserves an expanded section while switching Settings tabs", async () => {
+    await page.viewport(1280, 900);
     await mountCodingAgents();
     const { disclosure, button } = requiredCodingSectionButton(m.settings_role_models_title());
     await disclosure.click();

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -251,23 +251,23 @@ describe("Settings Coding CLI sections", () => {
     expect(defaultsButton.getAttribute("aria-expanded")).toBe("true");
     expect(controlledSection(defaultsButton).hidden).toBe(false);
 
-    const defaultModelSelect = page
-      .getByRole("combobox", { name: m.settings_default_model_title() })
+    const defaultEffortSelect = page
+      .getByRole("combobox", { name: m.settings_default_effort_title() })
       .element();
-    expect(content.contains(defaultModelSelect)).toBe(true);
+    expect(content.contains(defaultEffortSelect)).toBe(true);
 
     await disclosure.click();
     await expect.poll(() => button.getAttribute("aria-expanded")).toBe("false");
     expect(document.getElementById(content.id)).toBe(content);
     expect(content.hidden).toBe(true);
-    expect(content.contains(defaultModelSelect)).toBe(true);
+    expect(content.contains(defaultEffortSelect)).toBe(true);
 
     await disclosure.click();
     await expect.poll(() => button.getAttribute("aria-expanded")).toBe("true");
     expect(document.getElementById(content.id)).toBe(content);
     expect(content.hidden).toBe(false);
-    expect(page.getByRole("combobox", { name: m.settings_default_model_title() }).element()).toBe(
-      defaultModelSelect,
+    expect(page.getByRole("combobox", { name: m.settings_default_effort_title() }).element()).toBe(
+      defaultEffortSelect,
     );
   });
 

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -59,6 +59,7 @@
   import SettingsDiagnosePanel from "$lib/components/settings/SettingsDiagnosePanel.svelte";
   import SettingsPluginsPanel from "$lib/components/settings/SettingsPluginsPanel.svelte";
   import SettingsDefaultEnvironment from "$lib/components/settings/SettingsDefaultEnvironment.svelte";
+  import SettingsSection from "$lib/components/settings/SettingsSection.svelte";
   import RestartShepherdDialog from "$lib/components/RestartShepherdDialog.svelte";
   import ModelGuidance from "$lib/components/ModelGuidance.svelte";
   import { dialog } from "$lib/a11yDialog";
@@ -1236,42 +1237,40 @@
       aria-label={m.settings_tab_coding_agents()}
       hidden={tab !== "codingAgents"}
     >
-      <SettingsDefaultEnvironment
-        bind:defaultAgentProvider
-        bind:defaultModel
-        bind:defaultCodexModel
-        {defaultAgentProviderBusy}
-        {defaultModelBusy}
-        {defaultCodexModelBusy}
-        {fableAvailable}
-        onProviderChange={saveDefaultAgentProvider}
-        onClaudeModelChange={saveDefaultModel}
-        onCodexModelChange={saveDefaultCodexModel}
-      />
+      <SettingsSection title={m.settings_cli_defaults_title()} defaultOpen>
+        <SettingsDefaultEnvironment
+          bind:defaultAgentProvider
+          bind:defaultModel
+          bind:defaultCodexModel
+          {defaultAgentProviderBusy}
+          {defaultModelBusy}
+          {defaultCodexModelBusy}
+          {fableAvailable}
+          onProviderChange={saveDefaultAgentProvider}
+          onClaudeModelChange={saveDefaultModel}
+          onCodexModelChange={saveDefaultCodexModel}
+        />
 
-      <div class="rc">
-        <span class="micro">{m.settings_upnext_skip_cli_picker_label()}</span>
-        <p class="hint">{m.settings_upnext_skip_cli_picker_hint()}</p>
-        <button
-          type="button"
-          class="toggle"
-          role="switch"
-          aria-checked={upnextSkipCliPicker}
-          disabled={upnextSkipCliPickerBusy}
-          onclick={toggleUpnextSkipCliPicker}
-        >
-          <span class="track" class:on={upnextSkipCliPicker}><span class="knob"></span></span>
-          <span class="state"
-            >{upnextSkipCliPicker ? m.settings_usage_hold_on() : m.settings_usage_hold_off()}</span
+        <div class="rc">
+          <span class="micro">{m.settings_upnext_skip_cli_picker_label()}</span>
+          <p class="hint">{m.settings_upnext_skip_cli_picker_hint()}</p>
+          <button
+            type="button"
+            class="toggle"
+            role="switch"
+            aria-checked={upnextSkipCliPicker}
+            disabled={upnextSkipCliPickerBusy}
+            onclick={toggleUpnextSkipCliPicker}
           >
-        </button>
-      </div>
-
-      <div class="cli-section">
-        <div class="cli-head">
-          <span class="micro">{m.settings_cli_claude_title()}</span>
-          <p class="hint">{m.settings_cli_claude_hint()}</p>
+            <span class="track" class:on={upnextSkipCliPicker}><span class="knob"></span></span>
+            <span class="state"
+              >{upnextSkipCliPicker ? m.settings_usage_hold_on() : m.settings_usage_hold_off()}</span
+            >
+          </button>
         </div>
+      </SettingsSection>
+
+      <SettingsSection title={m.settings_cli_claude_title()} hint={m.settings_cli_claude_hint()}>
         <div class="rc">
           <span class="micro">{m.settings_default_effort_title()}</span>
           <p class="hint">{m.settings_default_effort_hint()}</p>
@@ -1368,7 +1367,7 @@
             </div>
           {/if}
         </div>
-      </div>
+      </SettingsSection>
 
       {#snippet roleRow(role: RoleBase)}
         <div class="rc">
@@ -1450,11 +1449,22 @@
         </div>
       {/snippet}
 
-      <div class="cli-section">
-        <div class="cli-head">
-          <span class="micro">{m.settings_role_models_title()}</span>
-          <p class="hint">{m.settings_role_models_hint()}</p>
+      <SettingsSection title={m.settings_cli_codex_title()} hint={m.settings_cli_codex_hint()}>
+        <div class="rc">
+          <span class="micro">{m.settings_cli_codex_auth_title()}</span>
+          <p class="hint">{m.settings_cli_codex_auth_hint()}</p>
+          <select
+            class="model-select"
+            value="local"
+            disabled
+            aria-label={m.settings_cli_codex_auth_title()}
+          >
+            <option value="local">{m.settings_cli_codex_auth_local()}</option>
+          </select>
         </div>
+      </SettingsSection>
+
+      <SettingsSection title={m.settings_role_models_title()} hint={m.settings_role_models_hint()}>
         {#each ROLE_PRIMARY as role (role)}
           {@render roleRow(role)}
         {/each}
@@ -1465,24 +1475,7 @@
             {@render roleRow(role)}
           {/each}
         </details>
-      </div>
-
-      <div class="cli-section">
-        <div class="cli-head">
-          <span class="micro">{m.settings_cli_codex_title()}</span>
-          <p class="hint">{m.settings_cli_codex_hint()}</p>
-        </div>
-        <span class="micro">{m.settings_cli_codex_auth_title()}</span>
-        <p class="hint">{m.settings_cli_codex_auth_hint()}</p>
-        <select
-          class="model-select"
-          value="local"
-          disabled
-          aria-label={m.settings_cli_codex_auth_title()}
-        >
-          <option value="local">{m.settings_cli_codex_auth_local()}</option>
-        </select>
-      </div>
+      </SettingsSection>
     </div>
 
     <div
@@ -2035,28 +2028,7 @@
     flex-direction: column;
     gap: 6px;
   }
-  .cli-section {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    padding: 12px 0 4px;
-    border-top: 1px solid var(--color-line);
-  }
-  .cli-section:first-of-type {
-    border-top: 0;
-  }
-  .cli-head {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-  }
   .rc .hint {
-    color: var(--color-faint);
-    font-size: var(--fs-meta);
-    margin: 0;
-  }
-  .cli-head .hint,
-  .cli-section > .hint {
     color: var(--color-faint);
     font-size: var(--fs-meta);
     margin: 0;

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -1264,7 +1264,9 @@
           >
             <span class="track" class:on={upnextSkipCliPicker}><span class="knob"></span></span>
             <span class="state"
-              >{upnextSkipCliPicker ? m.settings_usage_hold_on() : m.settings_usage_hold_off()}</span
+              >{upnextSkipCliPicker
+                ? m.settings_usage_hold_on()
+                : m.settings_usage_hold_off()}</span
             >
           </button>
         </div>

--- a/ui/src/lib/components/settings/SettingsSection.svelte
+++ b/ui/src/lib/components/settings/SettingsSection.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  import { untrack, type Snippet } from "svelte";
+
+  let {
+    title,
+    hint,
+    defaultOpen = false,
+    children,
+  }: {
+    title: string;
+    hint?: string;
+    defaultOpen?: boolean;
+    children: Snippet;
+  } = $props();
+
+  let expanded = $state(untrack(() => defaultOpen));
+  const sectionId = $props.id();
+  const contentId = `${sectionId}-content`;
+</script>
+
+<section class="settings-section">
+  <h2>
+    <button
+      type="button"
+      aria-expanded={expanded}
+      aria-controls={contentId}
+      onclick={() => (expanded = !expanded)}
+    >
+      <span>{title}</span>
+      <span class="chevron" aria-hidden="true">{expanded ? "▴" : "▾"}</span>
+    </button>
+  </h2>
+  <div id={contentId} class="content" hidden={!expanded}>
+    {#if hint}
+      <p class="hint">{hint}</p>
+    {/if}
+    {@render children()}
+  </div>
+</section>
+
+<style>
+  .settings-section:not(:first-child) {
+    border-top: 1px solid var(--color-line);
+  }
+  h2 {
+    margin: 0;
+  }
+  button {
+    width: 100%;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    border: 0;
+    border-radius: 0;
+    padding: 8px 10px;
+    background: var(--color-panel-2);
+    color: var(--color-ink);
+    cursor: pointer;
+    font: inherit;
+    font-size: var(--fs-meta);
+    font-weight: 500;
+    letter-spacing: 0.12em;
+    text-align: left;
+    text-transform: uppercase;
+  }
+  button:hover {
+    background: var(--color-hover);
+    color: var(--color-ink-bright);
+  }
+  button:focus-visible {
+    outline: 1px solid var(--color-line-bright);
+    outline-offset: -2px;
+    background: var(--color-inset);
+    color: var(--color-ink-bright);
+  }
+  .chevron {
+    flex: 0 0 auto;
+    color: var(--color-muted);
+    font-size: var(--fs-base);
+  }
+  .content:not([hidden]) {
+    display: flex;
+  }
+  .content {
+    flex-direction: column;
+    gap: 10px;
+    padding: 10px 0 4px;
+  }
+  .hint {
+    color: var(--color-faint);
+    font-size: var(--fs-meta);
+    margin: 0;
+  }
+</style>

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-collapsible-coding-cli-sections.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-collapsible-coding-cli-sections.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "collapsible-coding-cli-sections",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_collapsible_coding_cli_sections_title",
+  bodyKey: "feat_collapsible_coding_cli_sections_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## Summary

- group Coding CLI settings into reusable, accessible collapsible sections
- order the sections as Global defaults, Claude Code, Codex, then Agent environments
- keep Global defaults open initially while preserving section state and mounted controls
- add EN/DE copy, browser coverage, and the v1.44.0 feature announcement

## Impact

The Coding CLI settings page is more compact and easier to scan without changing existing values, save behavior, authentication, or nested classifier controls.

## Validation

- `cd ui && bun run test:browser -- src/lib/components/Settings.browser.test.ts` — 18/18 passed
- `cd ui && bun run check` — 0 errors, 0 warnings
- `cd ui && bun run check:i18n` — 2 locales in parity, 3155 keys each
- `cd ui && bun run test` — 255/255 files and 3811/3811 tests passed
- announcement-version, feature-catalog, branch-hygiene, and diff checks passed
