### PR TITLE
feat(ui): align issue selectors across task workflows

### DIFF
--- a/src/up-next-core.ts
+++ b/src/up-next-core.ts
@@ -29,6 +29,9 @@ export interface UpNextItem {
   /** The issue's labels (standalone) or the parent epic's labels (epic unit) — used by the
    *  UI's client-side hide-blocked display filter (isBlocked in issues-panel.ts). */
   labels: string[];
+  /** Forge label name → source color. Optional presentational metadata; names in `labels`
+   *  remain authoritative and a missing/partial map renders with the neutral fallback. */
+  labelColors?: Record<string, string>;
   /** Present iff this row represents an epic unit (the parent it rolls up). */
   epicParent?: { number: number; title: string };
   /** Payload for SessionService.create()'s issueRef on Start. */
@@ -66,6 +69,8 @@ export interface EpicUnitInput {
   parentUrl: string;
   parentCreatedAt: number;
   parentLabels: string[];
+  /** Forge colors paired with parentLabels; forwarded to the collapsed Up Next row. */
+  parentLabelColors?: Record<string, string>;
   /** The epic parent's assignees. The unit is filtered by these (#824) — the candidate child
    *  is synthesized with `assignees: []`, so the parent is the assignee-bearing issue (matching
    *  what the Backlog hides). */
@@ -167,6 +172,7 @@ function standaloneItem(repo: RepoInput, issue: Issue, linkedSet: Set<number>): 
     priority: hasLabel(labelSet, PRIORITY_LABEL),
     createdAt: issue.createdAt,
     labels: issue.labels,
+    labelColors: issue.labelColors,
     issueRef: { number: issue.number, url: issue.url, title: issue.title, body: issue.body },
   };
 }
@@ -193,6 +199,7 @@ function epicItem(repo: RepoInput, e: EpicUnitInput, linkedSet: Set<number>): Up
     priority: hasLabel(parentLabelSet, PRIORITY_LABEL),
     createdAt: e.parentCreatedAt,
     labels: e.parentLabels,
+    labelColors: e.parentLabelColors,
     epicParent: { number: e.parentNumber, title: e.parentTitle },
     issueRef: { number: c.number, url: c.url, title: c.title, body: c.body },
   };

--- a/src/up-next.ts
+++ b/src/up-next.ts
@@ -285,6 +285,7 @@ export class UpNextService {
         parentUrl: parent.url,
         parentCreatedAt: parent.createdAt,
         parentLabels: parent.labels,
+        parentLabelColors: parent.labelColors,
         parentAssignees: parent.assignees,
         memberNumbers: epic.children.map((c) => c.number),
         candidate: selectEpicCandidates(epic.children)[0] ?? null,

--- a/test/up-next-core.test.ts
+++ b/test/up-next-core.test.ts
@@ -75,11 +75,22 @@ describe("classification", () => {
 });
 
 describe("labels", () => {
-  test("standalone item carries the issue's labels", () => {
-    const r = [repo({ openIssues: [issue(1, { labels: ["blocked-upstream", "bug"] })] })];
-    expect(repoSection(r, "/r/a")!.items[0]!.labels).toEqual(["blocked-upstream", "bug"]);
+  test("standalone item carries the issue's labels and available forge colors", () => {
+    const r = [
+      repo({
+        openIssues: [
+          issue(1, {
+            labels: ["blocked-upstream", "bug"],
+            labelColors: { "blocked-upstream": "#111111", bug: "#d73a4a" },
+          }),
+        ],
+      }),
+    ];
+    const item = repoSection(r, "/r/a")!.items[0]!;
+    expect(item.labels).toEqual(["blocked-upstream", "bug"]);
+    expect(item.labelColors).toEqual({ "blocked-upstream": "#111111", bug: "#d73a4a" });
   });
-  test("epic unit carries the PARENT's labels, not the candidate child's", () => {
+  test("epic unit carries the PARENT's labels and colors, not the candidate child's", () => {
     const r = [
       repo({
         openIssues: [issue(1), issue(2)],
@@ -88,13 +99,18 @@ describe("labels", () => {
             parentNumber: 100,
             memberNumbers: [2],
             parentLabels: ["blocked-upstream", "epic"],
-            candidate: issue(2, { labels: ["unrelated-child-label"] }),
+            parentLabelColors: { "blocked-upstream": "#111111", epic: "#7057ff" },
+            candidate: issue(2, {
+              labels: ["unrelated-child-label"],
+              labelColors: { "unrelated-child-label": "#ffffff" },
+            }),
           }),
         ],
       }),
     ];
     const epicRow = repoSection(r, "/r/a")!.items.find((i) => i.kind === "epic")!;
     expect(epicRow.labels).toEqual(["blocked-upstream", "epic"]);
+    expect(epicRow.labelColors).toEqual({ "blocked-upstream": "#111111", epic: "#7057ff" });
   });
 });
 

--- a/test/up-next.test.ts
+++ b/test/up-next.test.ts
@@ -59,6 +59,25 @@ describe("UpNextService.refresh", () => {
     expect(s.snapshot()).toBe(snap);
   });
 
+  test("retains available forge label colors in the snapshot", async () => {
+    const s = svc({
+      resolveForge: () =>
+        fakeForge({
+          issues: [
+            issue(1, {
+              labels: ["enhancement"],
+              labelColors: { enhancement: "#a2eeef" },
+            }),
+          ],
+        }),
+    });
+
+    const snap = await s.refresh();
+    const row = snap.sections.find((section) => section.kind === "repo")!.items[0]!;
+    expect(row.labels).toEqual(["enhancement"]);
+    expect(row.labelColors).toEqual({ enhancement: "#a2eeef" });
+  });
+
   test("a repo whose listIssues throws is dropped and flagged as a fetch failure", async () => {
     const s = svc({
       resolveForge: () =>

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -320,7 +320,6 @@
   "promptsources_commands_tab": "Befehle",
   "promptsources_no_todos": "keine offenen TODO-Einträge",
   "promptsources_no_github": "kein GitHub-Upstream",
-  "promptsources_more_labels": "+{count}",
   "promptsources_no_commands": "keine installierten Befehle",
   "promptsources_commands_filter": "Befehle filtern…",
   "promptsources_epic_tag": "EPIC",
@@ -2314,7 +2313,6 @@
   "upnext_batch_aria": "Aktionen für Stapelstart",
   "upnext_select_aria": "#{number} {title} auswählen",
   "upnext_pill_priority": "Priorität",
-  "upnext_pill_bug": "Bug",
   "upnext_pill_epic": "Epic",
   "upnext_show_all": "alle {count} anzeigen",
   "upnext_show_less": "weniger anzeigen",
@@ -3154,5 +3152,8 @@
   "feat_distiller_provider_cadence_body": "Wähle CLI, Modell, Aufwand und die Tage zwischen automatischen Distiller-Läufen.",
   "settings_cli_defaults_title": "Globale Standards",
   "feat_collapsible_coding_cli_sections_title": "Einklappbare Coding-CLI-Einstellungen",
-  "feat_collapsible_coding_cli_sections_body": "Die Coding-CLI-Einstellungen sind jetzt in einklappbare Bereiche gegliedert und praktisch sortiert: globale Standards, Claude Code, Codex und anschließend die Umgebungen der Hilfsagenten."
+  "feat_collapsible_coding_cli_sections_body": "Die Coding-CLI-Einstellungen sind jetzt in einklappbare Bereiche gegliedert und praktisch sortiert: globale Standards, Claude Code, Codex und anschließend die Umgebungen der Hilfsagenten.",
+  "issuechips_more": "+{count}",
+  "feat_consistent_issue_selectors_title": "Einheitliche Issue-Zeilen",
+  "feat_consistent_issue_selectors_body": "„Neue Aufgabe“, „Repos“ und „Als Nächstes“ verwenden jetzt denselben kompakten Issue-Aufbau, dieselben Forge-Label-Farben und dieselbe responsive Hierarchie. Die jeweiligen Aktionen bleiben erhalten."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -320,7 +320,6 @@
   "promptsources_commands_tab": "Commands",
   "promptsources_no_todos": "no open TODO items",
   "promptsources_no_github": "no GitHub upstream",
-  "promptsources_more_labels": "+{count}",
   "promptsources_no_commands": "no installed commands",
   "promptsources_commands_filter": "filter commands…",
   "promptsources_epic_tag": "EPIC",
@@ -2314,7 +2313,6 @@
   "upnext_batch_aria": "Batch start actions",
   "upnext_select_aria": "Select #{number} {title}",
   "upnext_pill_priority": "priority",
-  "upnext_pill_bug": "bug",
   "upnext_pill_epic": "epic",
   "upnext_show_all": "show all {count}",
   "upnext_show_less": "show less",
@@ -3154,5 +3152,8 @@
   "feat_distiller_provider_cadence_body": "Choose the Distiller CLI, model, effort, and the days between automatic runs.",
   "settings_cli_defaults_title": "Global defaults",
   "feat_collapsible_coding_cli_sections_title": "Collapsible Coding CLI settings",
-  "feat_collapsible_coding_cli_sections_body": "Coding CLI settings are now grouped into collapsible sections in a practical order: global defaults, Claude Code, Codex, then helper-agent environments."
+  "feat_collapsible_coding_cli_sections_body": "Coding CLI settings are now grouped into collapsible sections in a practical order: global defaults, Claude Code, Codex, then helper-agent environments.",
+  "issuechips_more": "+{count}",
+  "feat_consistent_issue_selectors_title": "Consistent issue rows",
+  "feat_consistent_issue_selectors_body": "New Task, Repos, and Up Next now share the same compact issue layout, forge-label colors, and responsive hierarchy while keeping their surface-specific actions."
 }

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -396,6 +396,113 @@ button {
   }
 }
 
+/* ── Issue-list row recipe ─────────────────────────────────────────────────
+   Canonical compact anatomy shared by New Task, Repos and Up Next. Hosts own
+   their semantic controls (whole-row button vs links/actions vs checkbox/Start);
+   these classes own only the common visual hierarchy. The named inline-size
+   container lets label chips respond to the row's real width, which matters for
+   the desktop sidebar where viewport width says nothing about available space. */
+.issue-list-row {
+  container-name: issue-list-row;
+  container-type: inline-size;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  width: 100%;
+  min-width: 0;
+  padding: 4px 10px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  color: var(--color-ink);
+  font-family: var(--font-mono);
+  font-size: var(--fs-base);
+  text-align: left;
+}
+
+button.issue-list-row {
+  cursor: pointer;
+}
+
+@media (max-width: 768px), (pointer: coarse) {
+  button.issue-list-row {
+    align-items: center;
+    min-height: var(--mobile-actionbar-hit);
+  }
+}
+
+.issue-list-row.is-interactive {
+  transition:
+    background 0.12s,
+    border-color 0.12s,
+    color 0.12s;
+}
+
+.issue-list-row.is-interactive:hover,
+.issue-list-row.is-interactive:focus-within {
+  background: var(--color-panel);
+  color: var(--color-ink-bright);
+}
+
+.issue-list-row.is-interactive:focus-visible {
+  outline: none;
+  border-color: var(--color-line-bright);
+  box-shadow: inset 0 0 0 1px var(--color-amber);
+}
+
+.issue-list-leading,
+.issue-list-trailing {
+  flex: none;
+}
+
+.issue-list-number {
+  flex: none;
+  color: var(--color-muted);
+  font-size: var(--fs-meta);
+  text-decoration: none;
+}
+
+.issue-list-title {
+  flex: 1;
+  min-width: 6rem;
+  overflow: hidden;
+  color: var(--color-ink);
+  text-overflow: ellipsis;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+a.issue-list-number:hover,
+a.issue-list-title:hover {
+  color: var(--color-ink-bright);
+}
+
+.issue-list-author,
+.issue-list-meta {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-faint);
+  font-size: var(--fs-micro);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.issue-list-author {
+  flex: 0 1 auto;
+}
+
+.issue-list-meta {
+  flex: none;
+}
+
+.issue-list-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  flex: none;
+}
+
 /* ── Header icon-button recipe ──────────────────────────────────────────────
    Shared .icon-btn class + .spin keyframes for terminal-header glyph controls
    (redraw, etc.). Replaces ad-hoc per-control sizing (.vp-redraw, etc.). */

--- a/ui/src/lib/components/IssueLabelChips.svelte
+++ b/ui/src/lib/components/IssueLabelChips.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+  import { labelChipStyle } from "$lib/label-color";
+  import { m } from "$lib/paraglide/messages";
+  import { ACTIVE_LABEL } from "./issues-panel";
+
+  let {
+    labels,
+    labelColors = undefined,
+  }: { labels: string[]; labelColors?: Record<string, string> } = $props();
+
+  // Claimed work is the one semantic label Shepherd owns. Keep it first so it
+  // survives the responsive cap; forge labels retain their source order.
+  const ordered = $derived(
+    labels.includes(ACTIVE_LABEL)
+      ? [ACTIVE_LABEL, ...labels.filter((label) => label !== ACTIVE_LABEL)]
+      : labels,
+  );
+
+  const chipStyle = (label: string): string | null =>
+    label === ACTIVE_LABEL ? null : labelChipStyle(labelColors?.[label] ?? "");
+</script>
+
+{#if ordered.length > 0}
+  <span class="issue-labels">
+    {#each ordered.slice(0, 2) as label, index (label)}
+      {@const style = chipStyle(label)}
+      <span
+        class="issue-label-chip"
+        class:issue-label-second={index === 1}
+        class:active={label === ACTIVE_LABEL}
+        class:hued={style !== null}
+        {style}
+        title={label === ACTIVE_LABEL ? m.issuespanel_active_label_title() : undefined}
+        >{label}</span
+      >
+    {/each}
+    {#if ordered.length > 2}
+      <span class="issue-label-chip issue-label-more more-wide" title={ordered.slice(2).join(", ")}
+        >{m.issuechips_more({ count: ordered.length - 2 })}</span
+      >
+    {/if}
+    {#if ordered.length > 1}
+      <span
+        class="issue-label-chip issue-label-more more-narrow"
+        title={ordered.slice(1).join(", ")}>{m.issuechips_more({ count: ordered.length - 1 })}</span
+      >
+    {/if}
+  </span>
+{/if}
+
+<style>
+  .issue-labels {
+    display: flex;
+    align-items: baseline;
+    gap: 3px;
+    min-width: 0;
+    flex: 0 1 auto;
+  }
+
+  .issue-label-chip {
+    max-width: 14ch;
+    overflow: hidden;
+    padding: 0 4px;
+    border: 1px solid var(--color-faint);
+    border-radius: 2px;
+    color: var(--color-slate);
+    font-size: var(--fs-micro);
+    letter-spacing: 0.08em;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .issue-label-chip.active {
+    border-color: var(--status-running);
+    background: color-mix(in srgb, var(--status-running) 14%, transparent);
+    color: var(--status-running);
+  }
+
+  /* Forge label colors are data, not Shepherd chrome. labelChipStyle()
+     normalizes their lightness and supplies the per-theme variables. */
+  .issue-label-chip.hued {
+    border-color: var(--lc-border-d);
+    background: var(--lc-fill-d);
+    color: var(--lc-text-d);
+  }
+
+  :global([data-theme="light"]) .issue-label-chip.hued {
+    border-color: var(--lc-border-l);
+    background: var(--lc-fill-l);
+    color: var(--lc-text-l);
+  }
+
+  .issue-label-more {
+    max-width: none;
+    flex: none;
+    border-color: transparent;
+    color: var(--color-muted);
+  }
+
+  .more-narrow {
+    display: none;
+  }
+
+  @container issue-list-row (max-width: 520px) {
+    .issue-label-second,
+    .more-wide {
+      display: none;
+    }
+
+    .more-narrow {
+      display: inline-block;
+    }
+  }
+</style>

--- a/ui/src/lib/components/IssuesPanel.browser.test.ts
+++ b/ui/src/lib/components/IssuesPanel.browser.test.ts
@@ -48,8 +48,9 @@ beforeEach(() => {
   );
 });
 
-afterEach(() => {
+afterEach(async () => {
   document.body.innerHTML = "";
+  await page.viewport(1024, 768);
 });
 
 const noop = () => {};
@@ -128,6 +129,104 @@ describe("IssuesPanel empty vs fetch-failed", () => {
     expect(document.querySelector(".issues-list")?.textContent).not.toContain(
       m.common_no_open_issues(),
     );
+  });
+});
+
+describe("IssuesPanel compact issue rows", () => {
+  it("uses the shared row hierarchy and keeps Task beside bounded forge labels", async () => {
+    mockListIssues.mockResolvedValue({
+      slug: "owner/repo",
+      webUrl: null,
+      viewer: null,
+      issues: [
+        {
+          number: 42,
+          title: "Compact issue row",
+          body: "",
+          url: "https://example.com/issues/42",
+          labels: ["enhancement", "feedback", "operator UX"],
+          labelColors: {
+            enhancement: "#a2eeef",
+            feedback: "#d4c5f9",
+            "operator UX": "#7057ff",
+          },
+          createdAt: 0,
+          assignees: [],
+          author: "octocat",
+        },
+      ],
+    });
+    mockGetEpics.mockResolvedValue({ epics: [], subIssues: [] });
+
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop });
+
+    await expect.poll(() => document.querySelector(".issue-main")).toBeTruthy();
+    const row = document.querySelector<HTMLElement>(".issue-main")!;
+    expect(row.classList).toContain("issue-list-row");
+    expect(row.querySelector(".issue-list-number")?.textContent).toBe("#42");
+    expect(row.querySelector(".issue-list-title")?.textContent).toBe("Compact issue row");
+    expect(row.querySelector(".issue-list-author")?.textContent).toContain("octocat");
+    expect(row.querySelectorAll(".issue-label-chip:not(.issue-label-more)")).toHaveLength(2);
+    expect(row.querySelector(".issue-label-more")?.textContent).toContain("+1");
+    expect(row.querySelector(".issue-list-actions .task-btn")).not.toBeNull();
+  });
+
+  it("keeps every narrow-row action scroll-reachable and issue links touch-sized", async () => {
+    await page.viewport(400, 800);
+    mockListIssues.mockResolvedValue({
+      slug: "owner/repo",
+      webUrl: null,
+      viewer: null,
+      issues: [
+        {
+          number: 42,
+          title: "Issue with several quick actions",
+          body: "",
+          url: "https://example.com/issues/42",
+          labels: [],
+          createdAt: 0,
+          assignees: [],
+        },
+      ],
+    });
+    mockGetEpics.mockResolvedValue({ epics: [], subIssues: [] });
+
+    const previousSteers = steers.list;
+    steers.list = Array.from({ length: 8 }, (_, index) => ({
+      id: `quick-${index}`,
+      label: `Long action ${index + 1}`,
+      text: `Run action ${index + 1}`,
+      inSteerBar: false,
+      onIssues: true,
+    }));
+
+    try {
+      render(IssuesPanel, { repoPath: "/repo", onnewtask: noop, onquick: noop });
+      await expect.poll(() => document.querySelectorAll(".quick-btn").length).toBe(8);
+
+      const actions = document.querySelector<HTMLElement>(".issue-actions")!;
+      const buttons = actions.querySelectorAll<HTMLElement>("button");
+      const actionsRect = actions.getBoundingClientRect();
+      expect(actions.scrollWidth).toBeGreaterThan(actions.clientWidth);
+      expect(buttons[0]!.getBoundingClientRect().left).toBeGreaterThanOrEqual(actionsRect.left);
+
+      actions.scrollLeft = actions.scrollWidth;
+      await expect.poll(() => actions.scrollLeft).toBeGreaterThan(0);
+      expect(buttons[buttons.length - 1]!.getBoundingClientRect().right).toBeLessThanOrEqual(
+        actionsRect.right + 1,
+      );
+
+      const hitSize = parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue("--mobile-actionbar-hit"),
+      );
+      for (const selector of [".issue-num", ".issue-title"]) {
+        const rect = document.querySelector<HTMLElement>(selector)!.getBoundingClientRect();
+        expect(rect.height).toBeGreaterThanOrEqual(hitSize);
+        expect(rect.width).toBeGreaterThanOrEqual(hitSize);
+      }
+    } finally {
+      steers.list = previousSteers;
+    }
   });
 });
 

--- a/ui/src/lib/components/IssuesPanel.svelte
+++ b/ui/src/lib/components/IssuesPanel.svelte
@@ -598,7 +598,7 @@
     padding: 0 12px 10px;
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 2px;
   }
 
   .issues-list::-webkit-scrollbar {

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -750,15 +750,17 @@ describe("NewTask issue picker epic-parent rows", () => {
     // Open the Issues tab in the picker, then wait for the rows to render.
     // exact: true avoids matching the "hide sub-issues" chip (accessible name contains "issues").
     await page.getByRole("button", { name: m.promptsources_issues_tab(), exact: true }).click();
-    await expect.poll(() => document.querySelectorAll(".ps-body .row").length).toBe(2);
+    await expect.poll(() => document.querySelectorAll(".ps-body .issue-source-row").length).toBe(2);
 
     // The EPIC tag chip renders (exact match: "Epic parent" also contains "Epic").
     await expect
       .element(page.getByText(m.promptsources_epic_tag(), { exact: true }))
       .toBeInTheDocument();
-    expect(document.querySelector(".chip-epic")?.textContent).toBe(m.promptsources_epic_tag());
+    expect(document.querySelector(".source-epic-tag")?.textContent).toBe(
+      m.promptsources_epic_tag(),
+    );
 
-    const rows = Array.from(document.querySelectorAll<HTMLElement>(".ps-body .row"));
+    const rows = Array.from(document.querySelectorAll<HTMLElement>(".ps-body .issue-source-row"));
     const epicRow = rows.find((r) => r.textContent?.includes("Epic parent"))!;
     const plainRow = rows.find((r) => r.textContent?.includes("Plain issue"))!;
 
@@ -769,10 +771,8 @@ describe("NewTask issue picker epic-parent rows", () => {
 
     // The epic row keeps the issue's normal label chips ALONGSIDE the EPIC tag:
     // the EPIC chip and the "shepherd:active" highlight chip both render.
-    expect(epicRow.querySelector(".chip-epic")?.textContent).toBe(m.promptsources_epic_tag());
-    const epicLabelChips = Array.from(
-      epicRow.querySelectorAll<HTMLElement>(".chip:not(.chip-epic)"),
-    );
+    expect(epicRow.querySelector(".source-epic-tag")?.textContent).toBe(m.promptsources_epic_tag());
+    const epicLabelChips = Array.from(epicRow.querySelectorAll<HTMLElement>(".issue-label-chip"));
     expect(epicLabelChips.map((c) => c.textContent?.trim())).toContain("shepherd:active");
     expect(epicLabelChips.some((c) => c.classList.contains("active"))).toBe(true);
 
@@ -2267,8 +2267,8 @@ describe("NewTask issue steer inject (context menu)", () => {
   // pointerdown first pins lastPointerType away from "touch" so the contextmenu opens.
   async function openIssueMenu() {
     await page.getByRole("button", { name: m.promptsources_issues_tab(), exact: true }).click();
-    await expect.poll(() => document.querySelectorAll(".ps-body .row").length).toBe(1);
-    const row = document.querySelector<HTMLElement>(".ps-body .row")!;
+    await expect.poll(() => document.querySelectorAll(".ps-body .issue-source-row").length).toBe(1);
+    const row = document.querySelector<HTMLElement>(".ps-body .issue-source-row")!;
     window.dispatchEvent(new PointerEvent("pointerdown", { pointerType: "mouse" }));
     row.dispatchEvent(
       new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 20, clientY: 20 }),

--- a/ui/src/lib/components/PromptSources.browser.test.ts
+++ b/ui/src/lib/components/PromptSources.browser.test.ts
@@ -110,7 +110,9 @@ describe("PromptSources filter bar (popover + sticky coverage)", () => {
     render(PromptSources, { repoPath: "/repo", onpick: noop, onpickissue: noop });
 
     // Wait for the issues to load.
-    await expect.poll(() => document.querySelectorAll(".ps-body .row").length).toBeGreaterThan(0);
+    await expect
+      .poll(() => document.querySelectorAll(".ps-body .issue-source-row").length)
+      .toBeGreaterThan(0);
 
     // The Filters trigger button renders inside .ps-filter-bar.
     const filterBar = document.querySelector(".ps-body .ps-filter-bar");
@@ -138,7 +140,9 @@ describe("PromptSources filter bar (popover + sticky coverage)", () => {
 
     // Both issues visible before toggling.
     const titles = () =>
-      [...document.querySelectorAll(".ps-body .row .row-text")].map((el) => el.textContent?.trim());
+      [...document.querySelectorAll(".ps-body .issue-source-row .issue-list-title")].map((el) =>
+        el.textContent?.trim(),
+      );
     expect(titles()).toContain("Active issue");
     expect(titles()).toContain("Plain issue");
 
@@ -280,9 +284,15 @@ describe("PromptSources label chips (responsive 1↔2 cap)", () => {
     !!el && getComputedStyle(el as HTMLElement).display !== "none";
   // Real label chips (excludes the "+N" more-counters).
   const visibleChips = () =>
-    [...document.querySelectorAll(".ps-body .row .chip:not(.chip-more)")].filter(shown);
-  const moreWide = () => document.querySelector<HTMLElement>(".ps-body .row .more-wide");
-  const moreNarrow = () => document.querySelector<HTMLElement>(".ps-body .row .more-narrow");
+    [
+      ...document.querySelectorAll(
+        ".ps-body .issue-source-row .issue-label-chip:not(.issue-label-more)",
+      ),
+    ].filter(shown);
+  const moreWide = () =>
+    document.querySelector<HTMLElement>(".ps-body .issue-source-row .more-wide");
+  const moreNarrow = () =>
+    document.querySelector<HTMLElement>(".ps-body .issue-source-row .more-narrow");
 
   afterEach(async () => {
     // Restore a wide viewport so a leaked narrow width can't perturb the layout
@@ -300,13 +310,15 @@ describe("PromptSources label chips (responsive 1↔2 cap)", () => {
     });
 
     render(PromptSources, { repoPath: "/repo", onpick: noop, onpickissue: noop });
-    await expect.poll(() => document.querySelectorAll(".ps-body .row").length).toBeGreaterThan(0);
+    await expect
+      .poll(() => document.querySelectorAll(".ps-body .issue-source-row").length)
+      .toBeGreaterThan(0);
 
     // Two visible label chips (default/wide regime).
     await expect.poll(() => visibleChips().length).toBe(2);
     // Wide "+N" counts the labels beyond the 2 shown (len - 2 = 1); narrow one hidden.
     expect(shown(moreWide())).toBe(true);
-    expect(moreWide()!.textContent).toContain(m.promptsources_more_labels({ count: 1 }));
+    expect(moreWide()!.textContent).toContain(m.issuechips_more({ count: 1 }));
     expect(shown(moreNarrow())).toBe(false);
   });
 
@@ -320,16 +332,25 @@ describe("PromptSources label chips (responsive 1↔2 cap)", () => {
     });
 
     render(PromptSources, { repoPath: "/repo", onpick: noop, onpickissue: noop });
-    await expect.poll(() => document.querySelectorAll(".ps-body .row").length).toBeGreaterThan(0);
+    await expect
+      .poll(() => document.querySelectorAll(".ps-body .issue-source-row").length)
+      .toBeGreaterThan(0);
 
     // The media-query fallback: only 1 chip visible; the 2nd chip is in the DOM but hidden.
     await expect.poll(() => visibleChips().length).toBe(1);
-    const chip2 = document.querySelector(".ps-body .row .chip-2");
+    const chip2 = document.querySelector(".ps-body .issue-source-row .issue-label-second");
     expect(chip2).not.toBeNull();
     expect(shown(chip2)).toBe(false);
     // Narrow "+N" counts labels beyond the 1 shown (len - 1 = 2); wide one hidden.
     expect(shown(moreWide())).toBe(false);
     expect(shown(moreNarrow())).toBe(true);
-    expect(moreNarrow()!.textContent).toContain(m.promptsources_more_labels({ count: 2 }));
+    expect(moreNarrow()!.textContent).toContain(m.issuechips_more({ count: 2 }));
+
+    const hitSize = parseFloat(
+      getComputedStyle(document.documentElement).getPropertyValue("--mobile-actionbar-hit"),
+    );
+    expect(
+      document.querySelector<HTMLElement>(".issue-source-row")!.getBoundingClientRect().height,
+    ).toBeGreaterThanOrEqual(hitSize);
   });
 });

--- a/ui/src/lib/components/PromptSources.svelte
+++ b/ui/src/lib/components/PromptSources.svelte
@@ -4,7 +4,6 @@
   import { getTodo, listIssues, getCommands } from "$lib/api";
   import type { Issue, SlashCommand, Steer } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
-  import { labelChipStyle } from "$lib/label-color";
   import {
     commandInsertable,
     commandInvocation,
@@ -21,7 +20,6 @@
     distinctAuthors,
     distinctLabels,
     labelColorMap,
-    ACTIVE_LABEL,
   } from "./issues-panel";
   import { issuesFilter } from "$lib/issues-filter.svelte";
   import IssueFilterPopover from "./IssueFilterPopover.svelte";
@@ -30,6 +28,7 @@
   import { steers } from "$lib/steers.svelte";
   import { repos } from "$lib/repos.svelte";
   import { steerAppliesToRepo } from "$lib/steer-scope";
+  import IssueLabelChips from "./IssueLabelChips.svelte";
 
   let {
     repoPath,
@@ -180,19 +179,6 @@
   let hasTodo = $state<boolean | null>(null);
 
   const OPEN_RE = /^\s*-\s\[ \]\s+(.*)$/;
-
-  // ACTIVE_LABEL (imported from ./issues-panel) is surfaced first + highlighted so
-  // a taken issue reads as already-being-worked-on, same as the Issues panel.
-  // Active-first ordering so the claimed marker survives the 3-chip cap below.
-  const orderedLabels = (labels: string[]): string[] =>
-    labels.includes(ACTIVE_LABEL)
-      ? [ACTIVE_LABEL, ...labels.filter((l) => l !== ACTIVE_LABEL)]
-      : labels;
-
-  // Inline `--lc-*` style vars for a label chip's real forge color, or null for the
-  // system ACTIVE_LABEL (stays semantic amber) / a missing/invalid color (neutral chip).
-  const chipStyle = (lbl: string, colors: Record<string, string> | undefined): string | null =>
-    lbl === ACTIVE_LABEL ? null : labelChipStyle(colors?.[lbl] ?? "");
 
   // Resolve TODO.md eagerly per repo (independent of the active tab) so the To-Do
   // tab is hidden outright when the repo has no TODO.md, and the panel opens on
@@ -448,40 +434,35 @@
           <div class="muted">{m.issues_filter_no_match()}</div>
         {/if}
         {#each visibleIssues as i (i.number)}
-          {@const ordered = orderedLabels(i.labels)}
           {#if epicParents.has(i.number)}
             <!-- Epic-parent tracking issue: not pickable as a manual task (it would
                  collide with the Epic Runner). Shown disabled with an EPIC tag + hint;
                  epics launch via the epic panel's Start control. -->
             <div
-              class="row row-epic"
+              class="issue-list-row issue-source-row row-epic"
               aria-disabled="true"
               title={m.promptsources_epic_hint()}
               use:issueMenuTrigger={{ onopen: (x, y, node) => openMenu(i, false, x, y, node) }}
             >
-              <span class="issue-num">#{i.number}</span>
-              <span class="row-text">{i.title}</span>
+              <span class="issue-list-number">#{i.number}</span>
+              <span class="issue-list-title">{i.title}</span>
               {@render issueAuthor(i.author)}
-              <span class="chips">
-                <span class="chip chip-epic">{m.promptsources_epic_tag()}</span>
-                {@render labelChips(ordered, i.labelColors)}
-              </span>
+              <span class="source-epic-tag">{m.promptsources_epic_tag()}</span>
+              <IssueLabelChips labels={i.labels} labelColors={i.labelColors} />
             </div>
           {:else}
             <button
-              class="row"
+              class="issue-list-row is-interactive issue-source-row"
               type="button"
               onclick={() => onpickissue(i)}
               use:issueMenuTrigger={{
                 onopen: (x, y, node) => openMenu(i, onpicksteer != null, x, y, node),
               }}
             >
-              <span class="issue-num">#{i.number}</span>
-              <span class="row-text">{i.title}</span>
+              <span class="issue-list-number">#{i.number}</span>
+              <span class="issue-list-title">{i.title}</span>
               {@render issueAuthor(i.author)}
-              {#if ordered.length > 0}
-                <span class="chips">{@render labelChips(ordered, i.labelColors)}</span>
-              {/if}
+              <IssueLabelChips labels={i.labels} labelColors={i.labelColors} />
             </button>
           {/if}
         {/each}
@@ -503,36 +484,7 @@
 
 {#snippet issueAuthor(login: string | undefined)}
   {#if login}
-    <span class="issue-author">{m.issuerow_author_by({ login })}</span>
-  {/if}
-{/snippet}
-
-{#snippet labelChips(ordered: string[], colors: Record<string, string> | undefined)}
-  {#each ordered.slice(0, 2) as lbl, idx (lbl)}
-    {@const style = chipStyle(lbl, colors)}
-    <span
-      class="chip"
-      class:chip-2={idx === 1}
-      class:active={lbl === ACTIVE_LABEL}
-      class:hued={style !== null}
-      {style}
-      title={lbl === ACTIVE_LABEL ? m.issuespanel_active_label_title() : undefined}>{lbl}</span
-    >
-  {/each}
-  <!-- Two "+N" counters, one per regime (toggled by the pane-width media query in
-       <style>): the wide regime shows 2 chips so it hides ordered[2..]; the narrow
-       regime shows 1 chip so it hides ordered[1..]. Each title lists ONLY the labels
-       it actually hides — the wide counter must start at slice(2), or it would
-       over-list ordered[1], which is itself a visible chip when wide. -->
-  {#if ordered.length > 2}
-    <span class="chip chip-more more-wide" title={ordered.slice(2).join(", ")}>
-      {m.promptsources_more_labels({ count: ordered.length - 2 })}
-    </span>
-  {/if}
-  {#if ordered.length > 1}
-    <span class="chip chip-more more-narrow" title={ordered.slice(1).join(", ")}>
-      {m.promptsources_more_labels({ count: ordered.length - 1 })}
-    </span>
+    <span class="issue-list-author">{m.issuerow_author_by({ login })}</span>
   {/if}
 {/snippet}
 
@@ -662,34 +614,33 @@
     color: var(--color-faint);
   }
 
-  /* Epic-parent rows are listed but not selectable — muted, no hover affordance. */
-  .row-epic {
-    color: var(--color-faint);
-    cursor: default;
-  }
-
   .row-marker {
     color: var(--color-faint);
     flex-shrink: 0;
     font-size: var(--fs-micro);
   }
 
-  .issue-num {
-    color: var(--color-muted);
-    flex-shrink: 0;
-    font-size: var(--fs-meta);
+  /* Epic-parent rows are listed but not selectable. Their amber EPIC badge is
+     the state signal; the row itself stays quiet and has no hover affordance. */
+  .row-epic {
+    cursor: default;
   }
 
-  /* Subtle "by {login}" author metadata — dimmed, sits between the title and the label
-     chips; shrinks/ellipsates before the title's min-width floor so it never crushes it. */
-  .issue-author {
-    flex-shrink: 1;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  .row-epic .issue-list-number,
+  .row-epic .issue-list-title {
     color: var(--color-faint);
+  }
+
+  .source-epic-tag {
+    flex: none;
+    padding: 0 4px;
+    border: 1px solid var(--status-running);
+    border-radius: 2px;
+    background: color-mix(in srgb, var(--status-running) 14%, transparent);
+    color: var(--status-running);
     font-size: var(--fs-micro);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
   }
 
   /* Search input fills the sticky .ps-filter-bar wrapper (which provides the
@@ -738,28 +689,16 @@
 
   .row-text {
     flex: 1;
-    /* Explicit floor: flex-basis is 0%, so on a very narrow row (where #num + chips
-       already fill the width) the title would otherwise grow by 0 and sit near 0px.
-       This reserves a readable minimum; the bounded, shrinkable chips yield first. */
+    /* Keep To-Do and command descriptions readable beside their fixed markers. */
     min-width: 6rem;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
-  /* Up to 2 label chips + a "+N" count (labelChips caps inline chips at 2 in the
-     wide pane, 1 below 520px — see the responsive rule below). The group is bounded
-     so the title keeps the row instead of being crushed to a character: it may
-     shrink (min-width:0), the label chips ellipsate, and the count never clips.
-     Combined with .row-text's min-width floor, the title can't collapse to nothing. */
-  .chips {
-    display: flex;
-    gap: 3px;
-    min-width: 0;
-    flex-shrink: 1;
-  }
-
   .chip {
+    /* Commands-tab scope marker (for example "user"). Issue labels use the
+       shared IssueLabelChips component instead. */
     font-size: var(--fs-micro);
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -767,67 +706,9 @@
     border: 1px solid var(--color-faint);
     border-radius: 2px;
     padding: 0 4px;
-    /* Cap a pathologically long single label (e.g. COMPONENT/VALUEMAP…) so it
-       truncates instead of pushing the "+N" count off the row. */
     max-width: 14ch;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-  }
-
-  /* shepherd:active — claimed work. Same semantic running/in-progress token as
-     IssuesPanel so a taken issue stands out with the running-session hue.
-     The EPIC tag (.chip-epic) shares this hue, matching the backlog epic badge. */
-  .chip.active,
-  .chip-epic {
-    color: var(--status-running);
-    border-color: var(--status-running);
-    background: color-mix(in srgb, var(--status-running) 14%, transparent);
-  }
-
-  /* Real forge label color (issue: labels-almost-invisible) — sanctioned exception to
-     "accent hues are semantic, not decorative" (see /design-system). Never coexists with
-     .active: the snippet only computes a style for non-active labels, so the semantic
-     amber rule above always wins where it applies. */
-  .chip.hued {
-    color: var(--lc-text-d);
-    border-color: var(--lc-border-d);
-    background: var(--lc-fill-d);
-  }
-  :global([data-theme="light"]) .chip.hued {
-    color: var(--lc-text-l);
-    border-color: var(--lc-border-l);
-    background: var(--lc-fill-l);
-  }
-
-  .chip-more {
-    color: var(--color-muted);
-    border-color: transparent;
-    cursor: default;
-    /* Always visible — the count is the signal that more labels exist, so it must
-       never be the thing that gets clipped when the row is tight. */
-    flex-shrink: 0;
-    max-width: none;
-  }
-
-  /* Responsive label cap: show 2 chips by default (the pane is now 760px wide),
-     falling back to 1 chip + a "+N" count when the pane is narrower than 520px.
-     The pane width is min(760px, 92vw) on desktop and 100vw on the mobile
-     full-bleed sheet, so "pane < 520" is exactly "viewport < 520" — a viewport
-     media query is equivalent to a container query here WITHOUT establishing
-     inline-size containment on the NewTask card (which would make it a containing
-     block for any position:fixed/absolute descendant). If the card-width formula
-     or the 768px mobile breakpoint changes, revisit this 519.98px threshold. */
-  .more-narrow {
-    display: none;
-  }
-  @media (max-width: 519.98px) {
-    .chip-2,
-    .more-wide {
-      display: none;
-    }
-    .more-narrow {
-      display: inline-block;
-    }
   }
 </style>

--- a/ui/src/lib/components/UpNextPanel.browser.test.ts
+++ b/ui/src/lib/components/UpNextPanel.browser.test.ts
@@ -31,7 +31,13 @@ const item = (
   repoPath: string,
   number: number,
   priority = false,
-  opts: { title?: string; createdAt?: number; labels?: string[] } = {},
+  opts: {
+    title?: string;
+    createdAt?: number;
+    labels?: string[];
+    labelColors?: Record<string, string>;
+    kind?: UpNextItem["kind"];
+  } = {},
 ): UpNextItem => ({
   repoPath,
   repoSlug: null,
@@ -39,10 +45,11 @@ const item = (
   number,
   title: opts.title ?? `issue ${number}`,
   url: `https://example.test/${number}`,
-  kind: "feature",
+  kind: opts.kind ?? "feature",
   priority,
   createdAt: opts.createdAt ?? 0,
   labels: opts.labels ?? [],
+  labelColors: opts.labelColors,
   issueRef: {
     number,
     url: `https://example.test/${number}`,
@@ -180,13 +187,14 @@ beforeEach(() => {
   }`;
   document.head.appendChild(fontStyle);
 });
-afterEach(() => {
+afterEach(async () => {
   upNext.snapshot = null;
   upNext.loadError = false;
   localStorage.removeItem("shepherd.upnext.sort");
   issuesFilter.setBlocked(true); // restore the default so it never bleeds into other tests
   vi.clearAllMocks();
   fontStyle.remove();
+  await page.viewport(1024, 768);
 });
 
 describe("UpNextPanel repo filter", () => {
@@ -214,6 +222,62 @@ describe("UpNextPanel repo filter", () => {
     await expect
       .element(page.getByText(m.upnext_repo_filter_empty({ repo: "does-not-exist" })))
       .toBeInTheDocument();
+  });
+});
+
+describe("UpNextPanel compact issue rows", () => {
+  it("renders bounded forge labels with colored and neutral fallbacks beside Start", async () => {
+    upNext.snapshot = {
+      generatedAt: 1,
+      repoCount: 1,
+      fallback: null,
+      failedRepoCount: 0,
+      sections: [
+        {
+          kind: "repo",
+          repoPath: "~/projects/homeassistant",
+          repoSlug: null,
+          repoLabel: "homeassistant",
+          totalCount: 1,
+          items: [
+            item("~/projects/homeassistant", 42, false, {
+              labels: ["enhancement", "operator UX", "feedback"],
+              labelColors: { enhancement: "#a2eeef", feedback: "#d4c5f9" },
+            }),
+          ],
+        },
+      ],
+    };
+
+    render(UpNextPanel, {});
+
+    await expect.poll(() => document.querySelector(".un-row")).toBeTruthy();
+    const row = document.querySelector<HTMLElement>(".un-row")!;
+    expect(row.classList).toContain("issue-list-row");
+    const chips = row.querySelectorAll<HTMLElement>(".issue-label-chip:not(.issue-label-more)");
+    expect(chips).toHaveLength(2);
+    expect(chips[0]!.classList).toContain("hued");
+    expect(chips[1]!.classList).not.toContain("hued");
+    expect(row.querySelector(".issue-label-more")?.textContent).toContain("+1");
+    expect(row.querySelector(".issue-list-actions .un-start")).not.toBeNull();
+  });
+
+  it("keeps checkbox, issue link, and Start touch-sized without narrow-row overflow", async () => {
+    await page.viewport(390, 800);
+    render(UpNextPanel, {});
+
+    await expect.poll(() => document.querySelector(".un-row")).toBeTruthy();
+    const row = document.querySelector<HTMLElement>(".un-row")!;
+    const hitSize = parseFloat(
+      getComputedStyle(document.documentElement).getPropertyValue("--mobile-actionbar-hit"),
+    );
+
+    for (const selector of [".un-check", ".un-link", ".un-start"]) {
+      expect(
+        row.querySelector<HTMLElement>(selector)!.getBoundingClientRect().height,
+      ).toBeGreaterThanOrEqual(hitSize);
+    }
+    expect(row.scrollWidth).toBeLessThanOrEqual(row.clientWidth);
   });
 });
 

--- a/ui/src/lib/components/UpNextPanel.svelte
+++ b/ui/src/lib/components/UpNextPanel.svelte
@@ -13,6 +13,7 @@
   import ModelCliPicker from "./new-task/ModelCliPicker.svelte";
   import UpNextSortMenu from "./UpNextSortMenu.svelte";
   import { isBlocked } from "./issues-panel";
+  import IssueLabelChips from "./IssueLabelChips.svelte";
   import { issuesFilter } from "$lib/issues-filter.svelte";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
   import {
@@ -72,6 +73,7 @@
   // Manual starts bypass the per-repo maxAuto drain cap, so a large batch could launch a swarm
   // unintentionally — confirm above this many selected (issue #1169 tunable).
   const CONFIRM_THRESHOLD = 3;
+  const PRIORITY_LABEL = "shepherd:priority";
   const SORT_MODES: SortMode[] = ["recommended", "newest", "oldest", "title-asc", "title-desc"];
   const SORT_LABELS: Record<SortMode, () => string> = {
     recommended: m.upnext_sort_recommended,
@@ -266,6 +268,16 @@
     return expanded.has(g.id) ? g.items : g.items.slice(0, g.cap);
   }
 
+  // Priority and epic are Up Next workflow badges, so suppress their exact forge
+  // label duplicates while retaining every other real label and color.
+  function displayLabels(it: UpNextItem): string[] {
+    return it.labels.filter((label) => {
+      const normalized = label.toLowerCase();
+      if (normalized === PRIORITY_LABEL) return false;
+      return !(it.kind === "epic" && normalized === "epic");
+    });
+  }
+
   // Selected items still present in the current snapshot (a refresh may have dropped some).
   const selectedItems = $derived(
     renderGroups.flatMap((g) => g.items).filter((it) => selected.has(keyOf(it))),
@@ -400,8 +412,8 @@
 {/snippet}
 
 {#snippet row(it: UpNextItem, showRepo: boolean)}
-  <li class="un-row">
-    <label class="un-check">
+  <li class="un-row issue-list-row is-interactive">
+    <label class="un-check issue-list-leading">
       <input
         type="checkbox"
         checked={selected.has(keyOf(it))}
@@ -411,25 +423,27 @@
     </label>
     <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external forge URL, not an app route -->
     <a class="un-link" href={it.url} target="_blank" rel="noopener noreferrer">
-      <span class="un-num">#{it.number}</span>
-      <span class="un-title">{it.title}</span>
-      {#if showRepo}
-        <span class="un-repo">{it.repoLabel || repoBase(it.repoPath)}</span>
-      {/if}
+      <span class="un-num issue-list-number">#{it.number}</span>
+      <span class="un-title issue-list-title">{it.title}</span>
     </a>
+    {#if showRepo}
+      <span class="un-repo issue-list-meta">{it.repoLabel || repoBase(it.repoPath)}</span>
+    {/if}
     <span class="un-pills">
       {#if it.priority}{@render pill(m.upnext_pill_priority(), "un-pill-priority")}{/if}
       {#if it.kind === "epic"}{@render pill(m.upnext_pill_epic(), "un-pill-epic")}{/if}
-      {#if it.kind === "bug"}{@render pill(m.upnext_pill_bug(), "un-pill-bug")}{/if}
     </span>
-    <span class="un-age">{formatAgo(clock.current - it.createdAt)}</span>
-    <button
-      type="button"
-      class="un-start"
-      disabled={starting}
-      onclick={(e) => requestStart([it], e.currentTarget as HTMLElement)}
-      title={m.upnext_start()}>{m.upnext_start()}</button
-    >
+    <IssueLabelChips labels={displayLabels(it)} labelColors={it.labelColors} />
+    <span class="un-age issue-list-meta">{formatAgo(clock.current - it.createdAt)}</span>
+    <span class="un-actions issue-list-actions">
+      <button
+        type="button"
+        class="un-start"
+        disabled={starting}
+        onclick={(e) => requestStart([it], e.currentTarget as HTMLElement)}
+        title={m.upnext_start()}>{m.upnext_start()}</button
+      >
+    </span>
   </li>
 {/snippet}
 
@@ -749,16 +763,15 @@
     gap: 2px;
   }
   .un-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 3px 0;
+    flex-wrap: wrap;
   }
   .un-check {
     display: flex;
     align-items: center;
   }
   .un-check input {
+    margin: 0;
+    accent-color: var(--color-amber);
     cursor: pointer;
   }
   .un-link {
@@ -774,16 +787,9 @@
     color: var(--color-amber);
   }
   .un-num {
-    font-size: var(--fs-micro);
-    color: var(--color-muted);
     flex: none;
   }
   .un-title {
-    font-size: var(--fs-meta);
-    color: var(--color-ink);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     transition: color 0.12s ease;
   }
   .un-repo {
@@ -808,10 +814,6 @@
   .un-pill-priority {
     color: var(--color-amber);
     border-color: var(--color-amber);
-  }
-  .un-pill-bug {
-    color: var(--color-red);
-    border-color: var(--color-red);
   }
   .un-pill-epic {
     color: var(--color-ink-bright);
@@ -849,6 +851,36 @@
   .un-start:disabled {
     opacity: 0.4;
     cursor: not-allowed;
+  }
+
+  .un-actions {
+    flex: none;
+  }
+
+  @container issue-list-row (max-width: 520px) {
+    .un-actions {
+      flex-basis: 100%;
+      justify-content: flex-end;
+      padding-left: 28px;
+    }
+  }
+
+  @media (max-width: 768px), (pointer: coarse) {
+    .un-check {
+      justify-content: center;
+      min-width: var(--mobile-actionbar-hit);
+      min-height: var(--mobile-actionbar-hit);
+    }
+
+    .un-link {
+      align-items: center;
+      min-height: var(--mobile-actionbar-hit);
+    }
+
+    .un-start {
+      min-height: var(--mobile-actionbar-hit);
+      padding: 2px 14px;
+    }
   }
 
   .un-expand {

--- a/ui/src/lib/components/issues-panel/IssueRow.svelte
+++ b/ui/src/lib/components/issues-panel/IssueRow.svelte
@@ -4,13 +4,13 @@
   import { fitLabels } from "$lib/fit-labels";
   import { relativeAge } from "$lib/format";
   import { clock } from "$lib/now.svelte";
-  import { labelChipStyle } from "$lib/label-color";
-  import { ACTIVE_LABEL, epicFlagForOthers } from "../issues-panel";
+  import { epicFlagForOthers } from "../issues-panel";
   import { progress } from "../epic-panel";
   import EpicPanel from "../EpicPanel.svelte";
   import IssueMenuLayer from "../IssueMenuLayer.svelte";
   import { issueMenuTrigger } from "../issue-menu-trigger";
   import EpicOthersPill from "./EpicOthersPill.svelte";
+  import IssueLabelChips from "../IssueLabelChips.svelte";
 
   // One backlog issue row, extracted from IssuesPanel so the panel template clears the
   // Tier-1 <template> complexity bar (#855). The row owns all its nested conditionals
@@ -151,23 +151,42 @@
   use:epicRowClick
   use:issueMenuTrigger={{ onopen: openMenu }}
 >
-  <div class="issue-top">
+  <div class="issue-list-row is-interactive issue-main">
     <!-- eslint-disable svelte/no-navigation-without-resolve -- external GitHub URL, not an app route -->
     <a
-      class="issue-num"
+      class="issue-num issue-list-number"
       href={issue.url}
       target="_blank"
       rel="noopener"
       title={m.issuespanel_open_on_github()}>#{issue.number}</a
     >
     <a
-      class="issue-title"
+      class="issue-title issue-list-title"
       href={issue.url}
       target="_blank"
       rel="noopener"
       title={m.issuespanel_open_on_github()}>{issue.title}</a
     >
     <!-- eslint-enable svelte/no-navigation-without-resolve -->
+    {#if issue.author}
+      <span class="issue-list-author">{m.issuerow_author_by({ login: issue.author })}</span>
+    {/if}
+    {#if !isEpicParent && issue.blockedBy?.length}
+      <span class="blocked-chip"
+        >{m.issuerow_blocked_on({ deps: issue.blockedBy.map((n) => `#${n}`).join(", ") })}</span
+      >
+    {/if}
+    {#if showAssignees}
+      {#each issue.assignees as login (login)}
+        <span class="label-chip assignee" title={m.issuerow_assignee_title({ login })}
+          ><span class="assignee-glyph" aria-hidden="true">👤</span>{login}</span
+        >
+      {/each}
+    {/if}
+    <IssueLabelChips labels={issue.labels} labelColors={issue.labelColors} />
+    {#if age}
+      <span class="issue-list-meta age-chip">{relativeAge(issue.createdAt, clock.current)}</span>
+    {/if}
     {#if epicSummary}
       {@const isNative = epicSummary.source === "native"}
       <button
@@ -193,77 +212,44 @@
          so the row carries just the pill, no duplicate notice. Extracted into a child so the
          tier→copy branching doesn't inflate this row's <template> complexity. -->
     <EpicOthersPill flag={othersFlag} />
+    <!-- fitLabels toggles `compact` when the buttons overflow their available
+         trailing region: emoji-carrying controls shed the visible label while
+         title/aria-label keep the full action name. -->
+    <div class="issue-actions issue-list-actions" use:fitLabels>
+      {#if onquick}
+        {#each issueActions as a (a.id)}
+          <button
+            class="quick-btn"
+            class:has-emoji={!!a.emoji}
+            disabled={isEpicParent}
+            onclick={() => onquick(issue, a)}
+            aria-label={isEpicParent
+              ? m.issuespanel_task_button_epic_disabled()
+              : m.issuespanel_action_aria({ label: a.label })}
+            title={isEpicParent ? m.issuespanel_task_button_epic_disabled() : a.text}
+            >{#if a.emoji}<span class="act-emoji" aria-hidden="true">{a.emoji}</span>{/if}<span
+              class="act-label">{a.label}</span
+            ></button
+          >
+        {/each}
+      {/if}
+      <button
+        class="task-btn has-emoji"
+        disabled={isEpicParent}
+        onclick={() => onnewtask(issue)}
+        title={isEpicParent ? m.issuespanel_task_button_epic_disabled() : undefined}
+        aria-label={isEpicParent
+          ? m.issuespanel_task_button_epic_disabled()
+          : m.issuespanel_task_button()}
+        ><span class="act-emoji" aria-hidden="true">+</span><span class="act-label"
+          >{m.issuespanel_task_button()}</span
+        ></button
+      >
+    </div>
   </div>
   {#if bodyPreview && issue.body}
     <div class="body-preview">{issue.body}</div>
   {/if}
-  {#if issue.labels.length > 0 || age || issue.author || (showAssignees && issue.assignees.length > 0) || (!isEpicParent && issue.blockedBy?.length)}
-    <div class="label-row">
-      {#if !isEpicParent && issue.blockedBy?.length}
-        <span class="blocked-chip"
-          >{m.issuerow_blocked_on({ deps: issue.blockedBy.map((n) => `#${n}`).join(", ") })}</span
-        >
-      {/if}
-      {#if showAssignees}
-        {#each issue.assignees as login (login)}
-          <span class="label-chip assignee" title={m.issuerow_assignee_title({ login })}
-            ><span class="assignee-glyph" aria-hidden="true">👤</span>{login}</span
-          >
-        {/each}
-      {/if}
-      {#each issue.labels as label (label)}
-        {@const style =
-          label !== ACTIVE_LABEL ? labelChipStyle(issue.labelColors?.[label] ?? "") : null}
-        <span
-          class="label-chip"
-          class:active={label === ACTIVE_LABEL}
-          class:hued={style !== null}
-          {style}
-          title={label === ACTIVE_LABEL ? m.issuespanel_active_label_title() : undefined}
-          >{label}</span
-        >
-      {/each}
-      {#if issue.author}
-        <span class="issue-author">{m.issuerow_author_by({ login: issue.author })}</span>
-      {/if}
-      {#if age}
-        <span class="age-chip">{relativeAge(issue.createdAt, clock.current)}</span>
-      {/if}
-    </div>
-  {/if}
-  <!-- fitLabels toggles `compact` when the buttons overflow the row: emoji-
-       carrying buttons collapse to their emoji (label stays in title/aria). -->
-  <div class="issue-actions" use:fitLabels>
-    {#if onquick}
-      {#each issueActions as a (a.id)}
-        <button
-          class="quick-btn"
-          class:has-emoji={!!a.emoji}
-          disabled={isEpicParent}
-          onclick={() => onquick(issue, a)}
-          aria-label={isEpicParent
-            ? m.issuespanel_task_button_epic_disabled()
-            : m.issuespanel_action_aria({ label: a.label })}
-          title={isEpicParent ? m.issuespanel_task_button_epic_disabled() : a.text}
-          >{#if a.emoji}<span class="act-emoji" aria-hidden="true">{a.emoji}</span>{/if}<span
-            class="act-label">{a.label}</span
-          ></button
-        >
-      {/each}
-    {/if}
-    <button
-      class="task-btn has-emoji"
-      disabled={isEpicParent}
-      onclick={() => onnewtask(issue)}
-      title={isEpicParent ? m.issuespanel_task_button_epic_disabled() : undefined}
-      aria-label={isEpicParent
-        ? m.issuespanel_task_button_epic_disabled()
-        : m.issuespanel_task_button()}
-      ><span class="act-emoji" aria-hidden="true">+</span><span class="act-label"
-        >{m.issuespanel_task_button()}</span
-      ></button
-    >
-  </div>
   {#if epicSummary && isExpanded}
     <div data-epic-panel>
       {#if epic}
@@ -291,35 +277,23 @@
     display: flex;
     flex-direction: column;
     gap: 3px;
-    padding: 7px 8px;
-    border: 1px solid var(--color-line);
-    border-radius: 2px;
-    background: var(--color-inset);
+    min-width: 0;
   }
 
-  /* Epic parent rows stand out from ordinary issues: an amber (--status-running,
-     the epic/in-progress semantic) left accent + a faint amber wash. The tint is
-     deliberately low (6%) so the accent, the amber EPIC badge, and amber button
-     hovers on the same row read as one signal, not three competing ones. The
-     2px left border compensates 1px off the left padding to keep text aligned
-     with neighbouring non-epic rows. */
-  .issue-row.is-epic {
-    border-left: 2px solid var(--status-running);
-    padding-left: 7px;
+  .issue-main {
+    flex-wrap: wrap;
+  }
+
+  /* Epic state is carried by the EPIC/sub-issue badge plus a quiet full-row
+     treatment. No colored side stripe: the whole row is one state surface. */
+  .issue-row.is-epic .issue-main {
+    border-color: color-mix(in srgb, var(--status-running) 35%, var(--color-line));
     background: color-mix(in oklab, var(--status-running) 6%, var(--color-inset));
-  }
-
-  .issue-top {
-    display: flex;
-    align-items: baseline;
-    gap: 6px;
+    cursor: pointer;
   }
 
   .issue-num {
-    font-size: var(--fs-meta);
     color: var(--color-faint);
-    flex-shrink: 0;
-    text-decoration: none;
     transition: color 0.12s;
   }
 
@@ -328,12 +302,7 @@
   }
 
   .issue-title {
-    flex: 1;
-    font-size: var(--fs-base);
-    color: var(--color-ink);
     line-height: 1.4;
-    word-break: break-word;
-    text-decoration: none;
     transition: color 0.12s;
   }
 
@@ -341,34 +310,38 @@
     color: var(--color-ink-bright);
   }
 
-  .label-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
-  }
-
   .label-chip {
-    font-size: var(--fs-micro);
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    color: var(--color-muted);
+    flex: 0 1 auto;
+    max-width: 14ch;
+    overflow: hidden;
+    padding: 1px 5px;
     border: 1px solid var(--color-line);
     border-radius: 2px;
-    padding: 1px 5px;
+    color: var(--color-muted);
+    font-size: var(--fs-micro);
+    letter-spacing: 0.1em;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
   }
 
   /* "blocked on #N" — standalone (non-epic-parent) issues held back by an open dependency.
      Uses the semantic blocked token (red); never green, never a raw hex. Mirrors EpicPanel's
      .deps chip but as its own class since it lives in the label-row, not the epic child list. */
   .blocked-chip {
-    font-size: var(--fs-micro);
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    color: var(--status-blocked);
+    flex: 0 1 auto;
+    max-width: 18ch;
+    overflow: hidden;
+    padding: 1px 5px;
     border: 1px solid var(--status-blocked);
     border-radius: 2px;
-    padding: 1px 5px;
     background: color-mix(in srgb, var(--status-blocked) 14%, transparent);
+    color: var(--status-blocked);
+    font-size: var(--fs-micro);
+    letter-spacing: 0.1em;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
   }
 
   /* Assignee chip — reuses the label-chip recipe but keeps the login verbatim (logins are
@@ -386,67 +359,29 @@
     font-size: var(--fs-micro);
   }
 
-  /* shepherd:active — claimed work. Uses the semantic running/in-progress token so a
-     taken issue stands out from neutral labels with the same hue as running sessions. */
-  .label-chip.active {
-    color: var(--status-running);
-    border-color: var(--status-running);
-    background: color-mix(in srgb, var(--status-running) 14%, transparent);
-  }
-
-  /* Real forge label color (issue: labels-almost-invisible) — sanctioned exception to
-     "accent hues are semantic, not decorative" (see /design-system). Never coexists with
-     .active: labelChipStyle is only computed for non-active labels, so the semantic amber
-     rule above always wins where it applies. Vars come from labelChipStyle(); dark is the
-     default, [data-theme="light"] overrides. */
-  .label-chip.hued {
-    color: var(--lc-text-d);
-    border-color: var(--lc-border-d);
-    background: var(--lc-fill-d);
-  }
-  :global([data-theme="light"]) .label-chip.hued {
-    color: var(--lc-text-l);
-    border-color: var(--lc-border-l);
-    background: var(--lc-fill-l);
-  }
-
   .body-preview {
-    font-size: var(--fs-meta);
-    color: var(--color-muted);
-    line-height: 1.4;
     display: -webkit-box;
+    margin: 0 10px 4px 42px;
+    overflow: hidden;
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+    line-height: 1.4;
+    word-break: break-word;
     -webkit-line-clamp: 3;
     line-clamp: 3;
     -webkit-box-orient: vertical;
-    overflow: hidden;
-    word-break: break-word;
   }
 
   .age-chip {
-    font-size: var(--fs-micro);
     letter-spacing: 0.1em;
-    color: var(--color-faint);
-    padding: 1px 0;
-  }
-
-  /* Subtle "by {login}" author text — dimmed, no chip border, so it reads as metadata
-     alongside the age and distinct from the 👤 assignee chip. Logins are verbatim. */
-  .issue-author {
-    font-size: var(--fs-micro);
-    color: var(--color-faint);
-    padding: 1px 0;
-    white-space: nowrap;
   }
 
   .issue-actions {
-    display: flex;
-    gap: 6px;
-    margin-top: 2px;
+    flex: 0 1 auto;
+    max-width: 45%;
     min-width: 0;
     /* Final fallback when even the compact (emoji-only) rendering overflows — e.g.
-       several emoji-less actions: scroll instead of clipping. Right-alignment comes
-       from the first child's auto margin (NOT justify-content: flex-end, whose
-       start-side overflow would be unreachable in a scroll container). */
+       several emoji-less actions: scroll instead of clipping. */
     overflow-x: auto;
     scrollbar-width: none;
     -webkit-overflow-scrolling: touch;
@@ -556,11 +491,35 @@
     background: color-mix(in oklab, var(--status-running) 22%, transparent);
   }
 
-  @media (max-width: 768px) {
+  [data-epic-panel] {
+    padding-top: 6px;
+    border-top: 1px solid var(--color-line);
+  }
+
+  @container issue-list-row (max-width: 560px) {
+    .issue-actions {
+      flex-basis: 100%;
+      max-width: 100%;
+      padding-left: 42px;
+    }
+  }
+
+  @media (max-width: 768px), (pointer: coarse) {
     .task-btn,
     .quick-btn {
-      min-height: 40px;
+      min-height: var(--mobile-actionbar-hit);
       padding: 2px 14px;
+    }
+
+    .issue-num,
+    .issue-title {
+      min-height: var(--mobile-actionbar-hit);
+      line-height: var(--mobile-actionbar-hit);
+    }
+
+    .issue-num {
+      min-width: var(--mobile-actionbar-hit);
+      text-align: center;
     }
   }
 </style>

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-consistent-issue-selectors.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-consistent-issue-selectors.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "consistent-issue-selectors",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_consistent_issue_selectors_title",
+  bodyKey: "feat_consistent_issue_selectors_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1637,6 +1637,8 @@ export interface UpNextItem {
   /** The issue's labels (standalone) or the parent epic's labels (epic unit) — used by the
    *  hide-blocked display filter (isBlocked in issues-panel.ts). */
   labels: string[];
+  /** Forge label name → source color. Optional/partial; labels without a color render neutral. */
+  labelColors?: Record<string, string>;
   epicParent?: { number: number; title: string };
   issueRef: { number: number; url: string; title: string; body: string };
 }

--- a/ui/src/routes/design-system/+page.svelte
+++ b/ui/src/routes/design-system/+page.svelte
@@ -18,6 +18,7 @@
   import { theme } from "$lib/theme.svelte";
   import { INFO_TIPS_FORCE } from "$lib/info-tips.svelte";
   import IssueFilterPopover from "$lib/components/IssueFilterPopover.svelte";
+  import IssueLabelChips from "$lib/components/IssueLabelChips.svelte";
   import GlossaryText from "$lib/components/GlossaryText.svelte";
   import { labelChipStyle } from "$lib/label-color";
   // Graphical plugin-UI widgets (issue #1189). Unlike the static meter demo, these
@@ -167,6 +168,18 @@ input, select, textarea {
   border-color: var(--lc-border-l);
   background: var(--lc-fill-l);
 }`;
+
+  const issueRowMarkup = `<div class="issue-list-row is-interactive">
+  <span class="issue-list-number">#1699</span>
+  <span class="issue-list-title">Diff tab: source per-line annotations</span>
+  <span class="issue-list-author">by scoop</span>
+  <IssueLabelChips labels={issue.labels} labelColors={issue.labelColors} />
+  <span class="issue-list-actions"><button class="gbtn">Task</button></span>
+</div>
+
+<!-- The host owns semantics: New Task uses a whole-row button; Repos keeps
+     links/actions; Up Next keeps checkbox/Start. The shared classes own only
+     spacing, hierarchy, hover/focus and responsive label behaviour. -->`;
 
   const statusChipMarkup = `<span class="status-chip info"><span class="dot"></span>PR #42</span>
 <span class="status-chip ready"><span class="dot"></span>CI passing</span>
@@ -905,6 +918,38 @@ input, select, textarea {
       <span class="label-chip-demo" style={demoLabelStyle3}>enhancement</span>
     </div>
     <pre><code>{labelChipMarkup}</code></pre>
+  </section>
+
+  <section class="panel">
+    <h2>Issue-list rows</h2>
+    <p class="when">
+      <strong>When:</strong> an issue appears in New Task, Repos or Up Next. Use the shared row
+      anatomy for number, truncating title, secondary metadata, forge labels and trailing actions.
+      The host still owns the correct semantics: never put a checkbox/link/button inside a whole-row
+      button. Labels cap against the row's actual width, not the viewport.
+      <strong>When not:</strong> expanded epic content remains an in-flow panel beneath its issue row;
+      it is not forced into this single-line recipe.
+    </p>
+    <div class="demo demo-col">
+      <div class="issue-list-row is-interactive">
+        <span class="issue-list-number">#1699</span>
+        <span class="issue-list-title">Diff tab: source per-line annotations</span>
+        <span class="issue-list-author">by scoop</span>
+        <IssueLabelChips
+          labels={["enhancement", "feedback", "operator UX"]}
+          labelColors={{ enhancement: "#a2eeef", feedback: "#d4c5f9", "operator UX": "#7057ff" }}
+        />
+        <span class="issue-list-actions"><button class="gbtn">Task</button></span>
+      </div>
+      <div class="issue-list-row is-interactive">
+        <input type="checkbox" aria-label="Select issue 1630" />
+        <span class="issue-list-number">#1630</span>
+        <span class="issue-list-title">Revive stranded sessions after restart</span>
+        <span class="issue-list-meta">2d</span>
+        <span class="issue-list-actions"><button class="gbtn primary">Start</button></span>
+      </div>
+    </div>
+    <pre><code>{issueRowMarkup}</code></pre>
   </section>
 
   <section class="panel">


### PR DESCRIPTION
## Problem / Goal

Issue selection appears in three places—New Task, Repos, and Up Next—but the surfaces had drifted into different row densities, label treatments, action layouts, and responsive behavior. The goal is a consistent, modern issue-selection experience without changing the purpose of each workflow.

## Solution / Added

- Applied one shared issue-row visual recipe across New Task, Repos, and Up Next.
- Added reusable, forge-aware label chips with responsive overflow counts.
- Kept issue actions reachable on narrow screens and preserved mobile touch targets.
- Carried label colors through the Up Next server snapshot so all surfaces render labels consistently.
- Preserved upstream slash-command disabled states and epic ownership indicators during the rebase.
- Added localized EN/DE copy, design-system documentation, and a What's New announcement for v1.44.0.

## Technical details

- Added `IssueLabelChips.svelte` for shared label rendering and color contrast handling.
- Moved the common row anatomy into semantic-token styles in `app.css`.
- Extended Up Next issue data with `labelColors` and covered standalone plus epic-parent propagation.
- Added browser coverage for label caps, action reachability, touch geometry, and consistent row behavior across all three selectors.

## Validation

- `bun run lint`
- `bun test test/up-next-core.test.ts test/up-next.test.ts` — 59 passed
- `cd ui && bun run check` — 0 errors, 0 warnings
- `cd ui && bun run test` — 255 files / 3,810 tests passed
- Branch hygiene, feature catalog, announcement version, i18n, and glossary gates passed
