### PR TITLE
fix(ui): focus prompt after selecting a repository

### DIFF
--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -1288,6 +1288,33 @@ describe("NewTask repo shortcuts", () => {
       .toBe(true);
   });
 
+  it("Enter after filtering a repo closes the picker and focuses the prompt", async () => {
+    render(NewTask, { props: base({ initialRepoPath: repoA.path }) });
+    await expect.poll(() => triggerLabel()).toBe(repoA.name);
+
+    press("KeyR");
+    await expect.poll(() => document.querySelector(".rs-filter")).toBeTruthy();
+    const filter = document.querySelector<HTMLInputElement>(".rs-filter")!;
+    await expect.poll(() => document.activeElement).toBe(filter);
+
+    filter.value = "char";
+    filter.dispatchEvent(new Event("input", { bubbles: true }));
+    await expect
+      .poll(
+        () =>
+          document.querySelector<HTMLElement>('[role="option"][aria-selected="true"]')?.textContent,
+      )
+      .toContain(repoC.name);
+
+    filter.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }),
+    );
+
+    await expect.poll(() => triggerLabel()).toBe(repoC.name);
+    await expect.poll(() => document.querySelector(".rs-panel")).toBeFalsy();
+    expect(document.activeElement).toBe(document.querySelector("#nt-prompt"));
+  });
+
   it("Escape in open picker closes dropdown but not the modal, refocuses prompt", async () => {
     const onclose = vi.fn();
     render(NewTask, { props: base({ initialRepoPath: repoA.path, onclose }) });

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -750,6 +750,11 @@
     }
   }
 
+  function selectRepo(path: string) {
+    repoPath = path;
+    queueMicrotask(() => promptInput?.focus());
+  }
+
   function cycleRepo(dir: 1 | -1) {
     // Cycle only the non-hidden subset so Alt+[/] can never surface a hidden repo in the
     // trigger label. If the current repo is hidden (cur === -1) we enter the visible subset.
@@ -1048,7 +1053,7 @@
           {repos}
           windowDays={recentRepoWindowDays}
           value={repoPath}
-          onchange={(p) => (repoPath = p)}
+          onchange={selectRepo}
           {onclone}
           {onfork}
           {onnewproject}


### PR DESCRIPTION
## Problem / Goal

When a repository is selected from the New Task dialog using the keyboard flow (`Option+R`, filter, then `Enter`), the repository picker closes but focus falls back to the page body. The operator must click the Prompt field before they can continue typing.

The goal is to keep this workflow keyboard-first: confirming a repository should immediately return the operator to the Prompt field.

## Solution / Added

- Route successful repository selections in the New Task dialog through a small local handler.
- Update the selected repository and focus the Prompt field in a microtask after the picker closes.
- Add a browser regression test covering the complete filter-and-confirm keyboard flow.

## Technical details

- Focus behavior remains owned by `NewTask.svelte`; the generic `RepoSelect` API and its other consumers are unchanged.
- The same successful selection path also focuses the Prompt field when a repository is chosen with a pointer.
- Existing `Escape`, `Option+[`, `Option+]`, and `Option+1–3` behavior remains unchanged.
- The branch was rebased onto the latest `origin/main` before push.

## Validation

- `cd ui && bun run test:browser -- src/lib/components/NewTask.browser.test.ts` — 89 tests passed
- `cd ui && bun run check` — 0 errors and 0 warnings
- `cd ui && bun run check:i18n` — locale catalogs in parity
- ESLint and Prettier checks passed for the changed files
- Branch hygiene, glossary, feature catalog, and announcement version gates passed
