### PR TITLE
fix(ui): improve epic draft readability

### DIFF
--- a/ui/src/lib/components/EpicDraftChildRow.svelte
+++ b/ui/src/lib/components/EpicDraftChildRow.svelte
@@ -56,15 +56,17 @@
   }
   .edp-child-title {
     color: var(--color-ink);
-    font-size: var(--fs-meta);
+    font-size: var(--fs-base);
   }
   .edp-child-num {
     color: var(--color-accent);
     margin-right: 3px;
   }
   .edp-child-body {
+    max-width: 74ch;
     color: var(--color-muted);
-    font-size: var(--fs-micro);
+    font-size: var(--fs-base);
+    line-height: 1.45;
   }
   .edp-blocked {
     color: var(--color-amber);

--- a/ui/src/lib/components/EpicDraftModal.browser.test.ts
+++ b/ui/src/lib/components/EpicDraftModal.browser.test.ts
@@ -92,6 +92,46 @@ describe.each([
 
     unmount();
   });
+
+  it("uses readable text measures and standard-sized review controls", async () => {
+    const sessionId = `epic-draft-modal-readability-${label}`;
+    epicDrafts.upsert(longDraft(sessionId));
+
+    const { container, unmount } = await render(EpicDraftModal, {
+      sessionId,
+      sessionLive: true,
+      onclose: () => {},
+    });
+    const card = container.querySelector<HTMLElement>(".card");
+    if (card) card.style.width = `${width}px`;
+
+    const parentBody = container.querySelector<HTMLElement>(".parent-body")!;
+    const criteria = container.querySelector<HTMLElement>(".crit")!;
+    const childTitle = container.querySelector<HTMLElement>(".edp-child-title")!;
+    const childBody = container.querySelector<HTMLElement>(".edp-child-body")!;
+    const input = container.querySelector<HTMLInputElement>(".amend-input")!;
+    const buttons = [...container.querySelectorAll<HTMLButtonElement>(".btn")];
+    const bodyFontSize = parseFloat(getComputedStyle(document.body).fontSize);
+
+    for (const element of [parentBody, criteria, childTitle, childBody]) {
+      expect(parseFloat(getComputedStyle(element).fontSize)).toBe(bodyFontSize);
+    }
+    for (const element of [parentBody, criteria, childBody]) {
+      const style = getComputedStyle(element);
+      expect(parseFloat(style.lineHeight) / parseFloat(style.fontSize)).toBeGreaterThanOrEqual(1.45);
+      expect(style.maxWidth).not.toBe("none");
+    }
+
+    expect(parseFloat(getComputedStyle(input).fontSize)).toBeGreaterThanOrEqual(bodyFontSize);
+    expect(input.getBoundingClientRect().height).toBeGreaterThanOrEqual(44);
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const button of buttons) {
+      expect(parseFloat(getComputedStyle(button).fontSize)).toBe(bodyFontSize);
+      expect(button.getBoundingClientRect().height).toBeGreaterThanOrEqual(44);
+    }
+
+    unmount();
+  });
 });
 
 describe("EpicDraftModal — dialog behavior", () => {

--- a/ui/src/lib/components/EpicDraftModal.browser.test.ts
+++ b/ui/src/lib/components/EpicDraftModal.browser.test.ts
@@ -118,7 +118,9 @@ describe.each([
     }
     for (const element of [parentBody, criteria, childBody]) {
       const style = getComputedStyle(element);
-      expect(parseFloat(style.lineHeight) / parseFloat(style.fontSize)).toBeGreaterThanOrEqual(1.45);
+      expect(parseFloat(style.lineHeight) / parseFloat(style.fontSize)).toBeGreaterThanOrEqual(
+        1.45,
+      );
       expect(style.maxWidth).not.toBe("none");
     }
 

--- a/ui/src/lib/components/EpicDraftModal.svelte
+++ b/ui/src/lib/components/EpicDraftModal.svelte
@@ -380,6 +380,7 @@
   }
   .parent-body {
     margin: 0;
+    max-width: 74ch;
     color: var(--color-ink);
     font-size: var(--fs-base);
     line-height: 1.5;
@@ -387,6 +388,7 @@
   }
   .crit {
     margin: 0;
+    max-width: 74ch;
     padding-left: 18px;
     color: var(--color-ink);
     font-size: var(--fs-base);


### PR DESCRIPTION
## Problem

Epic drafts contain long parent and child issue descriptions that must be reviewed before approval. Child titles and descriptions were still rendered at compact metadata sizes, while long-form sections could span the full modal width. This made the most detailed content harder to read than comparable review surfaces.

## Solution

- Render child issue titles and descriptions at Shepherd's standard `--fs-base` body size.
- Give child descriptions a comfortable reading line height.
- Cap parent bodies, acceptance/non-goal lists, and child descriptions at `74ch` for a more readable line length.
- Preserve the modal's existing standard-sized amend field and review actions.

## Technical details

- Uses the existing semantic typography tokens; no global design-system primitive was added or changed.
- Adds desktop and narrow-viewport browser regression coverage for computed typography, line measure, input sizing, and action hit targets.
- Keeps the change scoped to the epic-draft modal and child-row presentation.

## Validation

- `cd ui && bun run test:browser -- EpicDraftModal.browser.test.ts` — 6 tests passed
- `cd ui && bun run check` — 0 errors and 0 warnings
- `cd ui && bun run test` — 255 files and 3,819 tests passed
- `scripts/check-branch-hygiene.sh` — branch is linear from `origin/main`
