### PR TITLE
feat(rundown): make herd digest provider-aware

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -797,6 +797,11 @@ export const config = {
   recapCli: normalizeRoleCli(process.env.SHEPHERD_RECAP_CLI) ?? "claude",
   recapModel: normalizeRoleModelToken(process.env.SHEPHERD_RECAP_MODEL) ?? "sonnet",
   recapEffort: normalizeDefaultEffortSetting(process.env.SHEPHERD_RECAP_EFFORT) ?? "low",
+  // Per-role ENVIRONMENT for the daily Herd Rundown. Inherit follows the global provider/model;
+  // explicit Claude preserves the prior Sonnet path. Persisted + UI-configurable.
+  rundownCli: normalizeRoleCli(process.env.SHEPHERD_RUNDOWN_CLI) ?? "inherit",
+  rundownModel: normalizeRoleModelToken(process.env.SHEPHERD_RUNDOWN_MODEL) ?? "sonnet",
+  rundownEffort: normalizeDefaultEffortSetting(process.env.SHEPHERD_RUNDOWN_EFFORT) ?? "low",
   // Default model for spawned agents. Persisted + UI-configurable. "auto" = unset seed
   // (picker uses client promo fallback, drain falls back to no --model); an explicit
   // value applies to both the New Task picker and drain/autopilot auto-spawns. Env seeds

--- a/src/herd-digest.ts
+++ b/src/herd-digest.ts
@@ -1,6 +1,6 @@
 /**
  * HerdDigestService — synthesizes a cross-session "what needs a human right now?"
- * attention digest once per calendar day via a transient Sonnet spawn. Mirrors
+ * attention digest once per calendar day via a transient role spawn. Mirrors
  * RecapService structure, but keyed by calendar DAY (single-flight) instead of by
  * session head:
  *   sweep()      — daily auto-spark (presence-gated, non-empty herd, once/day)
@@ -9,10 +9,10 @@
  *   regenerate() — on-demand force (re-spawns today's digest even if ready)
  *   snapshot()   — latest digest for client bootstrap
  *
- * Spawn pattern mirrors src/recap.ts: tmpdir cwd, Write-only, dontAsk,
- * disableAllHooks, disable-slash-commands. No worktree, no membrane. All herd
- * state is supplied via injected accessors so the service stays unit-testable and
- * never reaches into index.ts's live caches directly (Task 3 wires the real ones).
+ * Spawn pattern mirrors src/recap.ts: tmpdir cwd and the provider-specific
+ * writer-only transient-agent sandbox. No worktree, no membrane. All herd state
+ * is supplied via injected accessors so the service stays unit-testable and never
+ * reaches into index.ts's live caches directly (Task 3 wires the real ones).
  */
 import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -23,8 +23,9 @@ import type { HerdDigest, ReviewVerdict, PlanGate, Recap, RundownEpicItem } from
 import type { GitState } from "./forge/types";
 import type { SessionUsage } from "./usage";
 import { readSessionUsage } from "./usage";
-import { isApiKeyMode, isApiKeyConfigured, apiKeyPassthroughEnv } from "./spawn-auth";
+import { apiKeyFailClosed, apiKeyPassthroughEnv } from "./spawn-auth";
 import type { OperatorLanguage } from "./operator-language";
+import type { RoleEnvironment } from "./default-model";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
 import {
   assembleHerdState,
@@ -82,11 +83,19 @@ function defaultCleanup(cwd: string): void {
 
 /**
  * The rundown spawn's argv — the shared `writer-only` transient-agent shape. The input is
- * cross-session digest text (UNTRUSTED); bare `Write` is safe via the sandbox shape, not an
- * input-trust claim. See buildTransientAgentArgv for the flag-order + isolation rationale.
+ * cross-session digest text (UNTRUSTED); write access is constrained by the selected provider's
+ * sandbox shape, not an input-trust claim. See buildTransientAgentArgv for the isolation rationale.
  */
-function rundownArgv(model: string | null, prompt: string): { argv: string[]; sessionId: string } {
-  return buildTransientAgentArgv("writer-only", { model, prompt });
+function rundownArgv(
+  environment: RoleEnvironment,
+  prompt: string,
+): { argv: string[]; sessionId: string } {
+  return buildTransientAgentArgv("writer-only", {
+    provider: environment.provider,
+    model: environment.model,
+    effort: environment.effort,
+    prompt,
+  });
 }
 
 /** `YYYY-MM-DD` for the operator's LOCAL day at `now`. The single-flight key. */
@@ -140,7 +149,8 @@ export interface HerdDigestServiceDeps {
    *  as the sweep() pre-filter so an idle herd with a pending epic still triggers generate(); the
    *  authoritative not-ready→no-spawn decision lives in generate(). Optional — absent → false. */
   hasOpenLandingEpics?: () => boolean;
-  model?: string | null;
+  /** Live role environment, resolved per spawn so Settings changes need no restart. */
+  environment?: () => RoleEnvironment;
   /** Live operator-language setting, read per spawn (#1586). Absent → "en" (no directive). */
   operatorLanguage?: () => OperatorLanguage;
   now?: () => number;
@@ -161,7 +171,7 @@ export class HerdDigestService {
   private now: () => number;
   private timeoutMs: number;
   private topN: number;
-  private model: string | null;
+  private environment: () => RoleEnvironment;
   private operatorLanguage: () => OperatorLanguage;
 
   private _readVerdict: (cwd: string) => string | null;
@@ -178,7 +188,8 @@ export class HerdDigestService {
     this.now = deps.now ?? Date.now;
     this.timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.topN = deps.topN ?? RUNDOWN_DEFAULT_TOPN;
-    this.model = deps.model ?? "sonnet";
+    this.environment =
+      deps.environment ?? (() => ({ provider: "claude", model: "sonnet", effort: "low" }));
     this.operatorLanguage = deps.operatorLanguage ?? (() => "en");
     this._readVerdict = deps.readVerdict ?? defaultReadVerdict;
     this._readUsage = deps.readUsage ?? readSessionUsage;
@@ -264,8 +275,9 @@ export class HerdDigestService {
    * `opts.force` (regenerate) bypasses the existing-generating-row skip.
    */
   async generate(opts?: { force?: boolean }): Promise<GenerateResult> {
-    // Fail closed: api-key mode without a configured key must NOT bill the subscription.
-    if (isApiKeyMode() && !isApiKeyConfigured()) {
+    const environment = this.environment();
+    // Fail closed only for Claude: Codex authenticates independently of the Anthropic API key.
+    if (apiKeyFailClosed(environment.provider)) {
       console.warn(
         "[rundown] api-key mode enabled but no API key configured — skipping (fail closed)",
       );
@@ -345,11 +357,16 @@ export class HerdDigestService {
       );
 
       const prompt = buildRundownPrompt(assembled, this.operatorLanguage());
-      const { argv, sessionId: spawnSessionId } = rundownArgv(this.model, prompt);
+      const { argv, sessionId: spawnSessionId } = rundownArgv(environment, prompt);
 
       const cwd = this._makeTmpDir();
       try {
-        await this.deps.herdr.start("rundown", cwd, argv, apiKeyPassthroughEnv(false));
+        await this.deps.herdr.start(
+          "rundown",
+          cwd,
+          argv,
+          environment.provider === "claude" ? apiKeyPassthroughEnv(false) : undefined,
+        );
       } catch {
         this._cleanup(cwd);
         return "error"; // spawn failed; no row left so a later sweep can retry
@@ -362,7 +379,9 @@ export class HerdDigestService {
         taskSessionId: "", // herd-wide — not bound to a single task
         kind: "rundown",
         worktreePath: cwd,
-        model: this.model,
+        reviewerProvider: environment.provider,
+        model: environment.model,
+        reviewerEffort: environment.effort ?? null,
         spawnedAt,
       });
 
@@ -380,7 +399,7 @@ export class HerdDigestService {
         attentionFingerprint: fingerprint,
         spawnSessionId,
         cwd,
-        model: this.model,
+        model: environment.model,
         spawnedAt,
         generatedAt: null,
         updatedAt: spawnedAt,

--- a/src/herd-digest.ts
+++ b/src/herd-digest.ts
@@ -98,6 +98,11 @@ function rundownArgv(
   });
 }
 
+function rundownSpawnEnv(environment: RoleEnvironment): Record<string, string> | undefined {
+  if (environment.provider !== "claude") return undefined;
+  return apiKeyPassthroughEnv(false);
+}
+
 /** `YYYY-MM-DD` for the operator's LOCAL day at `now`. The single-flight key. */
 export function dayKeyFor(now: number): string {
   const d = new Date(now);
@@ -361,12 +366,7 @@ export class HerdDigestService {
 
       const cwd = this._makeTmpDir();
       try {
-        await this.deps.herdr.start(
-          "rundown",
-          cwd,
-          argv,
-          environment.provider === "claude" ? apiKeyPassthroughEnv(false) : undefined,
-        );
+        await this.deps.herdr.start("rundown", cwd, argv, rundownSpawnEnv(environment));
       } catch {
         this._cleanup(cwd);
         return "error"; // spawn failed; no row left so a later sweep can retry

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,6 +296,7 @@ for (const role of [
   "critic",
   "planner",
   "recap",
+  "rundown",
   "docAgent",
   "namer",
   "autopilot",
@@ -2086,6 +2087,7 @@ const landingReadyEpics = async (): Promise<RundownEpicItem[]> => {
 const herdDigestService = new HerdDigestService({
   store,
   herdr,
+  environment: () => roleEnv(config.rundownCli, config.rundownModel, config.rundownEffort),
   // Live operator-language setting, read per spawn (#1586).
   operatorLanguage: () => config.operatorLanguage,
   isActive: () => presence.isActive(),

--- a/src/server.ts
+++ b/src/server.ts
@@ -4490,6 +4490,9 @@ async function handleSettings({ req, parts, deps }: Ctx): Promise<Response | nul
       recapCli: config.recapCli,
       recapModel: config.recapModel,
       recapEffort: config.recapEffort,
+      rundownCli: config.rundownCli,
+      rundownModel: config.rundownModel,
+      rundownEffort: config.rundownEffort,
       docAgentCli: config.docAgentCli,
       docAgentModel: config.docAgentModel,
       docAgentEffort: config.docAgentEffort,
@@ -4577,6 +4580,9 @@ const SETTING_PATCHES: [string, (value: unknown, deps: Ctx["deps"]) => Response]
   ["recapCli", makeRoleCliPatch("recap")],
   ["recapModel", makeRoleModelPatch("recap")],
   ["recapEffort", makeRoleEffortPatch("recap")],
+  ["rundownCli", makeRoleCliPatch("rundown")],
+  ["rundownModel", makeRoleModelPatch("rundown")],
+  ["rundownEffort", makeRoleEffortPatch("rundown")],
   ["docAgentCli", makeRoleCliPatch("docAgent")],
   ["docAgentModel", makeRoleModelPatch("docAgent")],
   ["docAgentEffort", makeRoleEffortPatch("docAgent")],
@@ -4696,7 +4702,8 @@ function putDefaultEffort(value: unknown, deps: Ctx["deps"]): Response {
 // is a PAIR: a `<role>Cli` ("inherit"|<provider>) and a `<role>Model` ("default"|<alias>). Both
 // live-update config (the spawn-time thunks read config per spawn, so no restart) and persist.
 // cli/model are validated + stored independently; resolveRoleEnvironment clamps an incoherent pair.
-type RoleKey = "critic" | "planner" | "recap" | "docAgent" | "namer" | "autopilot" | "distiller";
+type RoleKey =
+  "critic" | "planner" | "recap" | "rundown" | "docAgent" | "namer" | "autopilot" | "distiller";
 
 function makeRoleCliPatch(role: RoleKey): (value: unknown, deps: Ctx["deps"]) => Response {
   const key = `${role}Cli` as const;

--- a/src/types.ts
+++ b/src/types.ts
@@ -702,7 +702,7 @@ export interface HerdDigest {
    *  at spawn time and kept live intraday by reconcileEpics() (see HerdDigestService). */
   epicsToLand: RundownEpicItem[];
   attentionFingerprint: Record<string, string[]>; // sessionId → sorted signal codes
-  spawnSessionId: string; // claude --session-id of the rundown spawn (usage + pane resolve)
+  spawnSessionId: string; // provider spawn tracking id (usage attribution + pane resolve)
   cwd: string; // tmpdir cwd of the spawn (verdict file read + pane reap)
   model: string | null;
   spawnedAt: number;

--- a/test/herd-digest.test.ts
+++ b/test/herd-digest.test.ts
@@ -3,7 +3,9 @@ import { HerdDigestService, dayKeyFor } from "../src/herd-digest";
 import type { HerdSnapshots, MergeTrainState } from "../src/herd-digest";
 import { SessionStore } from "../src/store";
 import type { HerdDigest, RundownEpicItem, Session } from "../src/types";
-import { RUNDOWN_EPICS_CAP } from "../src/rundown-core";
+import type { RoleEnvironment } from "../src/default-model";
+import { config } from "../src/config";
+import { RUNDOWN_EPICS_CAP, RUNDOWN_VERDICT_FILE } from "../src/rundown-core";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
 
 beforeEach(() => {
@@ -173,6 +175,7 @@ function buildSvc(opts: {
   backlogPriority?: () => Record<string, number>;
   landingReadyEpics?: () => Promise<RundownEpicItem[]>;
   hasOpenLandingEpics?: () => boolean;
+  environment?: () => RoleEnvironment;
   verdict?: string | null;
   timeoutMs?: number;
   readUsage?: () => Promise<any>;
@@ -191,7 +194,7 @@ function buildSvc(opts: {
     backlogPriority: opts.backlogPriority,
     landingReadyEpics: opts.landingReadyEpics,
     hasOpenLandingEpics: opts.hasOpenLandingEpics,
-    model: "sonnet",
+    environment: opts.environment,
     now: opts.nowFn,
     timeoutMs: opts.timeoutMs ?? 300_000,
     readVerdict: () => (opts.verdict !== undefined ? opts.verdict : null),
@@ -513,6 +516,99 @@ test("argv: --model sonnet, --permission-mode AFTER --allowedTools, prompt last"
   const last = argv[argv.length - 1]!;
   expect(last.startsWith("--")).toBe(false);
   expect(last).toContain("what needs a human right now");
+});
+
+const PROVIDER_DRIVERS = ["sweep", "regenerate"] as const;
+const PROVIDER_ENVS = [
+  { provider: "claude", model: "sonnet", effort: "low" },
+  { provider: "codex", model: "gpt-5.5", effort: "high" },
+] as const satisfies readonly RoleEnvironment[];
+
+for (const driver of PROVIDER_DRIVERS) {
+  for (const environment of PROVIDER_ENVS) {
+    test(`${driver}: ${environment.provider} uses its CLI and attributes the resolved environment`, async () => {
+      const store = makeStore([makeSession()]);
+      const herdr = makeHerdr();
+      const svc = buildSvc({
+        store,
+        herdr,
+        nowFn: () => DAY1,
+        environment: () => environment,
+      });
+
+      await svc[driver]();
+
+      const argv = herdr.started[0]!.argv;
+      const prompt = argv.at(-1)!;
+      expect(prompt).toContain(RUNDOWN_VERDICT_FILE);
+      if (environment.provider === "claude") {
+        expect(argv[0]).toBe("claude");
+        expect(argv[argv.indexOf("--model") + 1]).toBe(environment.model);
+        expect(argv[argv.indexOf("--effort") + 1]).toBe(environment.effort);
+        expect(argv.indexOf("--permission-mode")).toBeGreaterThan(argv.indexOf("--allowedTools"));
+      } else {
+        expect(argv.slice(0, 4)).toEqual(["codex", "exec", "--sandbox", "workspace-write"]);
+        expect(argv[argv.indexOf("-m") + 1]).toBe(environment.model);
+        expect(argv).toContain(`model_reasoning_effort=${environment.effort}`);
+        expect(argv).not.toContain("--allowedTools");
+      }
+
+      const reviewerSpawn = store.reviewerSpawns[0];
+      expect(typeof reviewerSpawn?.reviewerSessionId).toBe("string");
+      expect(reviewerSpawn).toMatchObject({
+        taskSessionId: "",
+        kind: "rundown",
+        reviewerProvider: environment.provider,
+        model: environment.model,
+        reviewerEffort: environment.effort,
+      });
+      const digest = store.getHerdDigest(dayKeyFor(DAY1));
+      expect(digest?.spawnSessionId).toBe(reviewerSpawn?.reviewerSessionId);
+      expect(digest?.model).toBe(environment.model);
+    });
+  }
+}
+
+test("generate resolves the environment again for a later regenerate", async () => {
+  const store = makeStore([makeSession()]);
+  const herdr = makeHerdr();
+  let environment: RoleEnvironment = { provider: "claude", model: "sonnet", effort: "low" };
+  const svc = buildSvc({ store, herdr, nowFn: () => DAY1, environment: () => environment });
+
+  expect(await svc.generate()).toBe("started");
+  environment = { provider: "codex", model: "gpt-5.5", effort: "medium" };
+  expect(await svc.regenerate()).toBe("started");
+
+  expect(herdr.started.map((spawn) => spawn.argv[0])).toEqual(["claude", "codex"]);
+  expect(store.reviewerSpawns.map((spawn) => spawn.reviewerProvider)).toEqual(["claude", "codex"]);
+  expect(store.reviewerSpawns[1]).toMatchObject({
+    model: "gpt-5.5",
+    reviewerEffort: "medium",
+  });
+});
+
+test("generate does not apply the Claude API-key fail-closed gate to Codex", async () => {
+  const previousMode = config.authMode;
+  const previousHelper = config.authApiKeyHelperPath;
+  config.authMode = "api-key";
+  config.authApiKeyHelperPath = null;
+  try {
+    const store = makeStore([makeSession()]);
+    const herdr = makeHerdr();
+    const svc = buildSvc({
+      store,
+      herdr,
+      nowFn: () => DAY1,
+      environment: () => ({ provider: "codex", model: "gpt-5.5", effort: "low" }),
+    });
+
+    expect(await svc.generate()).toBe("started");
+    expect(herdr.started[0]!.argv[0]).toBe("codex");
+    expect(herdr.started[0]!.env).toBeUndefined();
+  } finally {
+    config.authMode = previousMode;
+    config.authApiKeyHelperPath = previousHelper;
+  }
 });
 
 // ── empty-herd short-circuit in generate (no active sessions) ─────────────────────
@@ -875,7 +971,7 @@ test("reconcileEpics: real store round-trip is idempotent for a ready epic (regr
     isActive: () => true,
     onChange: (d) => changes.push(d),
     snapshots: () => EMPTY_SNAPSHOTS,
-    model: "sonnet",
+    environment: () => ({ provider: "claude", model: "sonnet", effort: "low" }),
     now: () => DAY1,
     timeoutMs: 300_000,
     readVerdict: () => null,
@@ -937,7 +1033,7 @@ test("reconcileEpics: real store round-trip is idempotent for a paused epic (reg
     isActive: () => true,
     onChange: (d) => changes.push(d),
     snapshots: () => EMPTY_SNAPSHOTS,
-    model: "sonnet",
+    environment: () => ({ provider: "claude", model: "sonnet", effort: "low" }),
     now: () => DAY1,
     timeoutMs: 300_000,
     readVerdict: () => null,

--- a/test/server-settings.test.ts
+++ b/test/server-settings.test.ts
@@ -30,6 +30,7 @@ const ROLE_BASES = [
   "critic",
   "planner",
   "recap",
+  "rundown",
   "docAgent",
   "namer",
   "autopilot",
@@ -511,6 +512,9 @@ test("GET /api/settings includes every per-role cli + model + effort setting (ra
   config.recapCli = "claude";
   config.recapModel = "sonnet";
   config.recapEffort = "low";
+  config.rundownCli = "codex";
+  config.rundownModel = "gpt-5.5";
+  config.rundownEffort = "low";
   const { app } = harness();
   const body = await (await app.fetch(new Request("http://x/api/settings"))).json();
   expect(body.criticCli).toBe("codex");
@@ -522,6 +526,9 @@ test("GET /api/settings includes every per-role cli + model + effort setting (ra
   expect(body.recapCli).toBe("claude");
   expect(body.recapModel).toBe("sonnet");
   expect(body.recapEffort).toBe("low");
+  expect(body.rundownCli).toBe("codex");
+  expect(body.rundownModel).toBe("gpt-5.5");
+  expect(body.rundownEffort).toBe("low");
 });
 
 for (const role of ROLE_BASES) {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3155,5 +3155,9 @@
   "feat_collapsible_coding_cli_sections_body": "Die Coding-CLI-Einstellungen sind jetzt in einklappbare Bereiche gegliedert und praktisch sortiert: globale Standards, Claude Code, Codex und anschließend die Umgebungen der Hilfsagenten.",
   "issuechips_more": "+{count}",
   "feat_consistent_issue_selectors_title": "Einheitliche Issue-Zeilen",
-  "feat_consistent_issue_selectors_body": "„Neue Aufgabe“, „Repos“ und „Als Nächstes“ verwenden jetzt denselben kompakten Issue-Aufbau, dieselben Forge-Label-Farben und dieselbe responsive Hierarchie. Die jeweiligen Aktionen bleiben erhalten."
+  "feat_consistent_issue_selectors_body": "„Neue Aufgabe“, „Repos“ und „Als Nächstes“ verwenden jetzt denselben kompakten Issue-Aufbau, dieselben Forge-Label-Farben und dieselbe responsive Hierarchie. Die jeweiligen Aktionen bleiben erhalten.",
+  "settings_role_model_rundown_title": "Herd-Rundown",
+  "settings_role_model_rundown_hint": "Fasst einmal täglich und bei Bedarf die Aufmerksamkeit der gesamten Herde zusammen.",
+  "feat_rundown_provider_title": "Kosten des Herd-Rundowns steuern",
+  "feat_rundown_provider_body": "Wähle CLI, Modell und Aufwand des Herd-Rundowns für automatische und neu erzeugte Digests."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3155,5 +3155,9 @@
   "feat_collapsible_coding_cli_sections_body": "Coding CLI settings are now grouped into collapsible sections in a practical order: global defaults, Claude Code, Codex, then helper-agent environments.",
   "issuechips_more": "+{count}",
   "feat_consistent_issue_selectors_title": "Consistent issue rows",
-  "feat_consistent_issue_selectors_body": "New Task, Repos, and Up Next now share the same compact issue layout, forge-label colors, and responsive hierarchy while keeping their surface-specific actions."
+  "feat_consistent_issue_selectors_body": "New Task, Repos, and Up Next now share the same compact issue layout, forge-label colors, and responsive hierarchy while keeping their surface-specific actions.",
+  "settings_role_model_rundown_title": "Herd Rundown",
+  "settings_role_model_rundown_hint": "Summarizes herd-wide attention once per day and on demand.",
+  "feat_rundown_provider_title": "Control Herd Rundown cost",
+  "feat_rundown_provider_body": "Choose the Herd Rundown CLI, model, and effort for automatic and regenerated digests."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -615,7 +615,7 @@ export const putDefaultAgentProvider = (
 // `<role>Cli` ("inherit" | "claude" | "codex") and a `<role>Model` ("default" | <alias>). The
 // server validates + persists each independently and echoes the stored value under the same key.
 export type RoleBase =
-  "critic" | "planner" | "recap" | "docAgent" | "namer" | "autopilot" | "distiller";
+  "critic" | "planner" | "recap" | "rundown" | "docAgent" | "namer" | "autopilot" | "distiller";
 export type RoleCliKey = `${RoleBase}Cli`;
 export type RoleModelKey = `${RoleBase}Model`;
 export type RoleEffortKey = `${RoleBase}Effort`;

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -77,6 +77,9 @@ function settings(over: Partial<SettingsPayload> = {}): SettingsPayload {
     recapCli: "claude",
     recapModel: "sonnet",
     recapEffort: "low",
+    rundownCli: "claude",
+    rundownModel: "sonnet",
+    rundownEffort: "low",
     docAgentCli: "inherit",
     docAgentModel: "default",
     docAgentEffort: "low",
@@ -312,6 +315,22 @@ describe("Settings Coding CLI sections", () => {
 });
 
 describe("Settings default coding environment", () => {
+  it("shows the saved Herd Rundown CLI, model, and effort", async () => {
+    mountCodingAgents();
+
+    const role = "Herd Rundown";
+    await expect.element(page.getByText(role, { exact: true })).toBeInTheDocument();
+    await expect
+      .element(page.getByRole("combobox", { name: m.settings_role_cli_label({ role }) }))
+      .toHaveValue("claude");
+    await expect
+      .element(page.getByRole("combobox", { name: m.settings_role_model_label({ role }) }))
+      .toHaveValue("sonnet");
+    await expect
+      .element(page.getByRole("combobox", { name: m.settings_role_effort_label({ role }) }))
+      .toHaveValue("low");
+  });
+
   it("loads the saved model for the selected Codex CLI", async () => {
     mockGetSettings.mockResolvedValue(
       settings({ defaultAgentProvider: "codex", defaultCodexModel: "gpt-5.4" }),

--- a/ui/src/lib/components/Settings.browser.test.ts
+++ b/ui/src/lib/components/Settings.browser.test.ts
@@ -316,7 +316,9 @@ describe("Settings Coding CLI sections", () => {
 
 describe("Settings default coding environment", () => {
   it("shows the saved Herd Rundown CLI, model, and effort", async () => {
-    mountCodingAgents();
+    await mountCodingAgents();
+    const { disclosure } = requiredCodingSectionButton(m.settings_role_models_title());
+    await disclosure.click();
 
     const role = "Herd Rundown";
     await expect.element(page.getByText(role, { exact: true })).toBeInTheDocument();

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -287,6 +287,7 @@
     "critic",
     "docAgent",
     "recap",
+    "rundown",
     "distiller",
     "namer",
     "autopilot",
@@ -297,6 +298,7 @@
     critic: "inherit",
     docAgent: "inherit",
     recap: "claude",
+    rundown: "inherit",
     namer: "claude",
     autopilot: "claude",
     distiller: "inherit",
@@ -306,6 +308,7 @@
     critic: "default",
     docAgent: "default",
     recap: "sonnet",
+    rundown: "sonnet",
     namer: "haiku",
     autopilot: "haiku",
     distiller: "default",
@@ -316,6 +319,7 @@
     critic: "high",
     docAgent: "low",
     recap: "low",
+    rundown: "low",
     namer: "low",
     autopilot: "low",
     distiller: "default",
@@ -331,12 +335,20 @@
     critic: false,
     docAgent: false,
     recap: false,
+    rundown: false,
     namer: false,
     autopilot: false,
     distiller: false,
   });
   // Foreground (content) roles vs. collapsed classifiers (constant-cadence, kept cheap).
-  const ROLE_PRIMARY: RoleBase[] = ["planner", "critic", "docAgent", "recap", "distiller"];
+  const ROLE_PRIMARY: RoleBase[] = [
+    "planner",
+    "critic",
+    "docAgent",
+    "recap",
+    "rundown",
+    "distiller",
+  ];
   const ROLE_CLASSIFIERS: RoleBase[] = ["namer", "autopilot"];
 
   function roleTitle(role: RoleBase): string {
@@ -349,6 +361,8 @@
         return m.settings_role_model_docagent_title();
       case "recap":
         return m.settings_role_model_recap_title();
+      case "rundown":
+        return m.settings_role_model_rundown_title();
       case "namer":
         return m.settings_role_model_namer_title();
       case "autopilot":
@@ -367,6 +381,8 @@
         return m.settings_role_model_docagent_hint();
       case "recap":
         return m.settings_role_model_recap_hint();
+      case "rundown":
+        return m.settings_role_model_rundown_hint();
       case "namer":
         return m.settings_role_model_namer_hint();
       case "autopilot":

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-rundown-provider.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-rundown-provider.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "rundown-provider",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_rundown_provider_title",
+  bodyKey: "feat_rundown_provider_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -110,6 +110,9 @@ export interface Settings {
   recapCli: string;
   recapModel: string;
   recapEffort: string;
+  rundownCli?: string;
+  rundownModel?: string;
+  rundownEffort?: string;
   docAgentCli: string;
   docAgentModel: string;
   docAgentEffort: string;


### PR DESCRIPTION
## Problem / Goal

The Herd Rundown was implicitly tied to Claude even when Shepherd's global provider was Codex. Its spawn omitted the provider, defaulted to Sonnet, did not receive the role environment at startup, and persisted no effective provider for usage attribution.

This PR makes the Rundown a provider-aware vertical slice while preserving its daily single-flight, presence gate, restart recovery, timeout, teardown, and verdict-file contract.

Closes #1754.

## Solution / Added

- Add persisted Rundown settings for CLI (`inherit | claude | codex`), model, and reasoning effort.
- Resolve the effective provider, compatible model, and effort freshly for every automatic or manual spawn.
- Keep Claude on the existing write-only path and route Codex through the existing `codex exec` path.
- Persist the actual provider, model, and effort in `reviewer_spawns` for correct usage attribution.
- Surface the role settings in the Settings UI with English and German translations.
- Add a What's New entry for the new user-facing configuration.

## Technical details

- The server hydrates and exposes the new settings through the existing settings API.
- `HerdDigestService` snapshots the current role environment when generation begins and passes provider/model/effort to the shared transient-agent builder.
- Provider-specific auth environments are isolated: Claude retains its API-key behavior, while Codex does not inherit Claude-only credentials.
- Both providers continue to write the result through `RUNDOWN_VERDICT_FILE`.
- Focused coverage exercises Claude and Codex across automatic sweep and manual regeneration, live setting changes, attribution, auth isolation, verdict handling, and single-flight behavior.

## Validation

- Root lint and typecheck
- Root test suite
- UI checks, i18n validation, and full UI test suite (3,821 tests)
- Extension checks
- Branch hygiene, feature catalog, announcement version, and glossary gates
- Fallow audit: no issues in the changed files
