### PR TITLE
fix(herdr): recognize wrapped Codex exec roles

### DIFF
--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -313,9 +313,11 @@ export function buildWrappedArgv(argv: string[], env?: Record<string, string>): 
 
 /** A headless Codex role shares its tab's process lifetime with the initial shell pane.
  * Closing that pane immediately after `agent start` can terminate the role before it writes its
- * file-based result, so transient `codex exec` runs deliberately retain it. */
+ * file-based result, so direct `codex exec` and membrane-wrapped `bwrap … -- codex exec` runs
+ * deliberately retain it. */
 export function isHeadlessCodexExec(argv: string[]): boolean {
-  return argv[0] === "codex" && argv[1] === "exec";
+  const commandStart = argv[0] === "bwrap" ? argv.indexOf("--") + 1 : 0;
+  return argv[commandStart] === "codex" && argv[commandStart + 1] === "exec";
 }
 
 /**

--- a/test/herdr-socket-driver.test.ts
+++ b/test/herdr-socket-driver.test.ts
@@ -283,7 +283,14 @@ describe("SocketHerdrDriver — socket-backed async writes (#1553, #1567)", () =
     const rec: { method: string; params: unknown }[] = [];
     const driver = new SocketHerdrDriver(writeClient(rec), fakeCli() as unknown as HerdrDriver);
 
-    await driver.start("plan-review TASK-693", "/repo/worktree", ["codex", "exec", "go"]);
+    await driver.start("plan-review TASK-707", "/repo/worktree", [
+      "bwrap",
+      "--die-with-parent",
+      "--",
+      "codex",
+      "exec",
+      "go",
+    ]);
 
     expect(rec.map((r) => r.method)).toEqual(["workspace.list", "tab.create", "agent.start"]);
   });

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -327,9 +327,9 @@ test("start: keeps the root pane alive for a headless codex exec role", async ()
 
 test("isHeadlessCodexExec recognizes direct and bwrap-wrapped exec roles only", () => {
   expect(isHeadlessCodexExec(["codex", "exec", "go"])).toBe(true);
-  expect(
-    isHeadlessCodexExec(["bwrap", "--die-with-parent", "--", "codex", "exec", "go"]),
-  ).toBe(true);
+  expect(isHeadlessCodexExec(["bwrap", "--die-with-parent", "--", "codex", "exec", "go"])).toBe(
+    true,
+  );
   expect(
     isHeadlessCodexExec(["bwrap", "--die-with-parent", "--", "codex", "--no-alt-screen"]),
   ).toBe(false);

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -1,5 +1,12 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
-import { HerdrDriver, mapState, matchAgent, matchAgents, type HerdrAgent } from "../src/herdr";
+import {
+  HerdrDriver,
+  isHeadlessCodexExec,
+  mapState,
+  matchAgent,
+  matchAgents,
+  type HerdrAgent,
+} from "../src/herdr";
 
 // Pin compileCacheDir() to a deterministic sentinel so the `env NODE_COMPILE_CACHE=…`
 // shim that start() prepends to every agent argv is assertable.
@@ -304,11 +311,29 @@ test("start: keeps the root pane alive for a headless codex exec role", async ()
   };
   const d = new HerdrDriver(runner, async (a) => runner(a));
 
-  const agent = await d.start("plan-review TASK-693", "/wt/a", ["codex", "exec", "go"]);
+  const agent = await d.start("plan-review TASK-707", "/wt/a", [
+    "bwrap",
+    "--die-with-parent",
+    "--",
+    "codex",
+    "exec",
+    "go",
+  ]);
 
   expect(agent).toMatchObject({ terminalId: "term_started", tabId: "t_new" });
   expect(tabPresent).toBe(true);
   expect(calls.some((c) => c[0] === "pane" && c[1] === "close")).toBe(false);
+});
+
+test("isHeadlessCodexExec recognizes direct and bwrap-wrapped exec roles only", () => {
+  expect(isHeadlessCodexExec(["codex", "exec", "go"])).toBe(true);
+  expect(
+    isHeadlessCodexExec(["bwrap", "--die-with-parent", "--", "codex", "exec", "go"]),
+  ).toBe(true);
+  expect(
+    isHeadlessCodexExec(["bwrap", "--die-with-parent", "--", "codex", "--no-alt-screen"]),
+  ).toBe(false);
+  expect(isHeadlessCodexExec(["claude", "codex exec appears only in prompt"])).toBe(false);
 });
 
 const TAB_LIST = JSON.stringify({


### PR DESCRIPTION
# Problem

Headless Codex helper roles are launched through the membrane as `bwrap … -- codex exec …`. Herdr only recognized a direct `codex exec` argv, so it closed the initial shell pane immediately after starting a wrapped reviewer. That could terminate the reviewer before it wrote its verdict file, leaving Plan Gate with `REVIEW ERR` and “The plan reviewer did not produce a verdict.”

# Solution

Teach the shared Herdr classifier to recognize both direct and membrane-wrapped headless Codex executions. The CLI and socket drivers now retain the root pane for either argv shape, allowing reviewer and other headless helper roles to finish and persist their result.

## Technical details

- Resolve the effective command after Bubblewrap’s `--` separator.
- Keep the existing exact `codex exec` match for direct launches.
- Add CLI-driver and socket-driver regressions using the real wrapped argv shape.
- Add negative classifier coverage so interactive Codex and incidental prompt text are not misclassified.

## Validation

- `bun test ./test` — 7043 passed, 8 skipped, 0 failed
- `bun run typecheck`
- `bun run lint`
- `scripts/check-branch-hygiene.sh origin/main`
- `git diff --check origin/main...HEAD`
