### PR TITLE
feat(learnings): make Learnings Optimizer provider-aware

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -676,6 +676,12 @@ export const config = {
   distillerModel: normalizeRoleModelToken(process.env.SHEPHERD_DISTILLER_MODEL) ?? "default",
   distillerEffort:
     normalizeDefaultEffortSetting(process.env.SHEPHERD_DISTILLER_EFFORT) ?? "default",
+  // Per-role environment for the Learnings Optimizer. Inherit follows the operator's global
+  // provider/model/effort selection; explicit providers keep "default" effort provider-native.
+  optimizerCli: normalizeRoleCli(process.env.SHEPHERD_OPTIMIZER_CLI) ?? "inherit",
+  optimizerModel: normalizeRoleModelToken(process.env.SHEPHERD_OPTIMIZER_MODEL) ?? "default",
+  optimizerEffort:
+    normalizeDefaultEffortSetting(process.env.SHEPHERD_OPTIMIZER_EFFORT) ?? "default",
   // Automatic runs are throttled per repository; 1 preserves the historic daily behavior.
   distillerIntervalDays: clampCap(
     Number(process.env.SHEPHERD_DISTILLER_INTERVAL_DAYS ?? 1),

--- a/src/index.ts
+++ b/src/index.ts
@@ -301,6 +301,7 @@ for (const role of [
   "namer",
   "autopilot",
   "distiller",
+  "optimizer",
 ] as const) {
   const savedCli = store.getSetting(`${role}Cli`);
   if (savedCli !== null) {
@@ -654,6 +655,14 @@ function distillerEnv(): RoleEnvironment {
       ? config.defaultEffort
       : config.distillerEffort;
   return roleEnv(config.distillerCli, config.distillerModel, effort);
+}
+
+function optimizerEnv(): RoleEnvironment {
+  const effort =
+    config.optimizerCli === "inherit" && config.optimizerEffort === "default"
+      ? config.defaultEffort
+      : config.optimizerEffort;
+  return roleEnv(config.optimizerCli, config.optimizerModel, effort);
 }
 
 // Anonymous product telemetry (Aptabase). No-op unless the operator has explicitly
@@ -2199,6 +2208,7 @@ const optimizer = new OptimizerService({
   herdr,
   scratch: defaultOptimizerScratch,
   promoter,
+  environment: optimizerEnv,
   onChange: () => learningsSvc.emitPending(),
 });
 deferredStarts.push(() => {

--- a/src/optimizer.ts
+++ b/src/optimizer.ts
@@ -5,9 +5,10 @@ import type { SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
 import { HerdrUnavailableError } from "./herdr";
 import type { Promoter } from "./promote";
-import { isApiKeyMode, isApiKeyConfigured, apiKeyPassthroughEnv } from "./spawn-auth";
+import { apiKeyFailClosed, apiKeyPassthroughEnv } from "./spawn-auth";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
 import { reapTransientByLabel } from "./transient-tab-reaper";
+import type { RoleEnvironment } from "./default-model";
 
 const INPUT_FILE = "input.json";
 const OUTPUT_FILE = "optimized.json";
@@ -59,6 +60,7 @@ export interface OptimizerDeps {
   promoter: Pick<Promoter, "resyncPromoted">;
   onChange: () => void;
   model?: string | null;
+  environment?: () => RoleEnvironment;
   now?: () => number;
   timeoutMs?: number; // default 10*60*1000 (match distiller)
   maxConcurrent?: number; // default 3
@@ -71,7 +73,7 @@ export interface OptimizerDeps {
  * their failure evidence, applies the rewrites in place (clearing the flag), and opens a
  * CLAUDE.md sync PR for any revised *promoted* rule. A faithful sibling of
  * {@link DistillerService} — same inflight/queue/tick/finalize/health shape and the same
- * hard-won read-only claude spawn contract. NEVER runs on a timer inside the service.
+ * shared read-only transient-agent contract. NEVER runs on a timer inside the service.
  */
 export class OptimizerService {
   private inflight = new Map<string, InFlight>();
@@ -188,8 +190,13 @@ export class OptimizerService {
 
   private async begin(repoPath: string, ids: string[]): Promise<void> {
     const { dir } = this.deps.scratch.create();
+    const environment = this.deps.environment?.() ?? {
+      provider: "claude" as const,
+      model: this.deps.model ?? null,
+      effort: null,
+    };
     // Fail closed: api-key mode without a configured key must NOT bill the subscription.
-    if (isApiKeyMode() && !isApiKeyConfigured()) {
+    if (apiKeyFailClosed(environment.provider)) {
       console.warn(
         "[optimize] api-key mode enabled but no API key configured — skipping (fail closed, not billing subscription)",
       );
@@ -212,7 +219,9 @@ export class OptimizerService {
     // Read-only optimizer — the shared `writer-ro` transient-agent shape (untrusted agent/repo
     // text); see buildTransientAgentArgv for the flag-order + isolation rationale.
     const { argv, sessionId } = buildTransientAgentArgv("writer-ro", {
-      model: this.deps.model ?? null,
+      provider: environment.provider,
+      model: environment.model,
+      effort: environment.effort,
       prompt: optimizePrompt(),
     });
     const agentName = OPTIMIZE_LABEL + sessionId.slice(0, 8);
@@ -234,7 +243,12 @@ export class OptimizerService {
     this.inflight.set(repoPath, entry);
     try {
       entry.terminalId = (
-        await this.deps.herdr.start(agentName, dir, argv, apiKeyPassthroughEnv(false))
+        await this.deps.herdr.start(
+          agentName,
+          dir,
+          argv,
+          environment.provider === "claude" ? apiKeyPassthroughEnv(false) : undefined,
+        )
       ).terminalId;
     } catch (err) {
       this.inflight.delete(repoPath); // release the reservation

--- a/src/server.ts
+++ b/src/server.ts
@@ -4499,6 +4499,9 @@ async function handleSettings({ req, parts, deps }: Ctx): Promise<Response | nul
       distillerCli: config.distillerCli,
       distillerModel: config.distillerModel,
       distillerEffort: config.distillerEffort,
+      optimizerCli: config.optimizerCli,
+      optimizerModel: config.optimizerModel,
+      optimizerEffort: config.optimizerEffort,
       distillerIntervalDays: config.distillerIntervalDays,
       distillerIntervalDaysMin: DISTILLER_INTERVAL_DAYS_MIN,
       distillerIntervalDaysMax: DISTILLER_INTERVAL_DAYS_MAX,
@@ -4589,6 +4592,9 @@ const SETTING_PATCHES: [string, (value: unknown, deps: Ctx["deps"]) => Response]
   ["distillerCli", makeRoleCliPatch("distiller")],
   ["distillerModel", makeRoleModelPatch("distiller")],
   ["distillerEffort", makeRoleEffortPatch("distiller")],
+  ["optimizerCli", makeRoleCliPatch("optimizer")],
+  ["optimizerModel", makeRoleModelPatch("optimizer")],
+  ["optimizerEffort", makeRoleEffortPatch("optimizer")],
   ["distillerIntervalDays", putDistillerIntervalDays],
   ["namerCli", makeRoleCliPatch("namer")],
   ["namerModel", makeRoleModelPatch("namer")],
@@ -4698,12 +4704,20 @@ function putDefaultEffort(value: unknown, deps: Ctx["deps"]): Response {
   return json({ defaultEffort: config.defaultEffort });
 }
 
-// Per-role ENVIRONMENT patch handlers (critic/planner/recap/doc-agent/namer/autopilot). Each role
-// is a PAIR: a `<role>Cli` ("inherit"|<provider>) and a `<role>Model` ("default"|<alias>). Both
+// Per-role ENVIRONMENT patch handlers. Each role has `<role>Cli` ("inherit"|<provider>),
+// `<role>Model` ("default"|<alias>), and `<role>Effort` ("default"|<tier>). All three
 // live-update config (the spawn-time thunks read config per spawn, so no restart) and persist.
 // cli/model are validated + stored independently; resolveRoleEnvironment clamps an incoherent pair.
 type RoleKey =
-  "critic" | "planner" | "recap" | "rundown" | "docAgent" | "namer" | "autopilot" | "distiller";
+  | "critic"
+  | "planner"
+  | "recap"
+  | "rundown"
+  | "docAgent"
+  | "namer"
+  | "autopilot"
+  | "distiller"
+  | "optimizer";
 
 function makeRoleCliPatch(role: RoleKey): (value: unknown, deps: Ctx["deps"]) => Response {
   const key = `${role}Cli` as const;

--- a/test/optimizer.test.ts
+++ b/test/optimizer.test.ts
@@ -406,9 +406,7 @@ for (const entryPoint of ["optimizeOne", "optimizeAllFlagged"] as const) {
       expect(store.getLearning(b)!.rule).toBe(
         entryPoint === "optimizeOne" ? "rule B" : "B revised",
       );
-      expect(store.getLearning(b)!.ineffectiveCount).toBe(
-        entryPoint === "optimizeOne" ? 1 : 0,
-      );
+      expect(store.getLearning(b)!.ineffectiveCount).toBe(entryPoint === "optimizeOne" ? 1 : 0);
     });
   }
 }
@@ -469,12 +467,7 @@ test("Codex optimizer is not blocked by missing Anthropic api-key configuration"
 
     await new OptimizerService(deps as any).optimizeOne(id);
 
-    expect(cap.argv[0]!.slice(0, 4)).toEqual([
-      "codex",
-      "exec",
-      "--sandbox",
-      "workspace-write",
-    ]);
+    expect(cap.argv[0]!.slice(0, 4)).toEqual(["codex", "exec", "--sandbox", "workspace-write"]);
     expect(cap.env[0]).toBeUndefined();
   });
 });

--- a/test/optimizer.test.ts
+++ b/test/optimizer.test.ts
@@ -3,6 +3,8 @@ import { OptimizerService, OPTIMIZE_LABEL, type OptimizerTarget } from "../src/o
 import { SessionStore } from "../src/store";
 import { HerdrUnavailableError } from "../src/herdr";
 import { __setApiKeyConfigDirProvisionForTest } from "../src/spawn-auth";
+import { config } from "../src/config";
+import type { RoleEnvironment } from "../src/default-model";
 
 beforeEach(() => {
   __setApiKeyConfigDirProvisionForTest(() => "/tmp/shepherd-test-apikey-config");
@@ -89,6 +91,57 @@ function mkDeps(
 }
 
 type RawLike = { revisions?: { id?: unknown; rule?: unknown; rationale?: unknown }[] } | null;
+
+function optimizerSpawnCapture(
+  store: SessionStore,
+  readOutput: () => RawLike,
+  environment: () => RoleEnvironment,
+) {
+  const cap: {
+    argv: string[][];
+    env: (Record<string, string> | undefined)[];
+    removed: number;
+  } = { argv: [], env: [], removed: 0 };
+  const deps = {
+    store,
+    herdr: {
+      start: async (_name: string, _cwd: string, argv: string[], env?: Record<string, string>) => {
+        cap.argv.push(argv);
+        cap.env.push(env);
+        return { terminalId: `o${cap.argv.length}` };
+      },
+      stop: async () => {},
+    } as any,
+    scratch: {
+      create: () => ({ dir: `/scratch/${cap.argv.length}` }),
+      remove: () => cap.removed++,
+    },
+    promoter: fakePromoter(),
+    onChange: () => {},
+    now: () => 1000,
+    environment,
+    writeInput: () => {},
+    readOutput,
+  };
+  return { deps, cap };
+}
+
+async function withAuth(
+  mode: typeof config.authMode,
+  helper: string | null,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const previousMode = config.authMode;
+  const previousHelper = config.authApiKeyHelperPath;
+  config.authMode = mode;
+  config.authApiKeyHelperPath = helper;
+  try {
+    await fn();
+  } finally {
+    config.authMode = previousMode;
+    config.authApiKeyHelperPath = previousHelper;
+  }
+}
 
 test("applies revisions + clears flag; onChange fires", async () => {
   const store = new SessionStore(":memory:");
@@ -290,6 +343,160 @@ test("spawn argv follows the safe contract + unique __optimize__ name", async ()
   expect(write).toBeLessThan(mode);
   expect(argv).toContain('{"disableAllHooks":true}');
   expect(argv.length).toBeGreaterThan(mode + 2); // prompt trails dontAsk
+});
+
+for (const entryPoint of ["optimizeOne", "optimizeAllFlagged"] as const) {
+  for (const provider of ["claude", "codex"] as const) {
+    test(`${entryPoint} uses the resolved ${provider} environment and applies the shared revision output`, async () => {
+      const store = new SessionStore(":memory:");
+      const a = seedActiveRule(store, "/r", "rule A");
+      const b = seedActiveRule(store, "/r", "rule B");
+      flag(store, "/r", a);
+      flag(store, "/r", b);
+      const environment: RoleEnvironment =
+        provider === "claude"
+          ? { provider, model: "sonnet", effort: "high" }
+          : { provider, model: "gpt-5.5", effort: "high" };
+      const { deps, cap } = optimizerSpawnCapture(
+        store,
+        () => ({
+          revisions: [
+            { id: a, rule: "A revised" },
+            { id: b, rule: "B revised" },
+          ],
+        }),
+        () => environment,
+      );
+      const svc = new OptimizerService(deps as any);
+
+      if (entryPoint === "optimizeOne") await svc.optimizeOne(a);
+      else await svc.optimizeAllFlagged("/r");
+      await svc.tick();
+
+      const argv = cap.argv[0]!;
+      if (provider === "claude") {
+        expect(argv[0]).toBe("claude");
+        expect(argv).toContain("--allowedTools");
+        expect(argv).toContain("Write");
+        expect(argv).toContain("--permission-mode");
+        expect(argv).toContain("dontAsk");
+        expect(argv.slice(argv.indexOf("--model"), argv.indexOf("--model") + 2)).toEqual([
+          "--model",
+          "sonnet",
+        ]);
+        expect(argv.slice(argv.indexOf("--effort"), argv.indexOf("--effort") + 2)).toEqual([
+          "--effort",
+          "high",
+        ]);
+      } else {
+        expect(argv).toEqual([
+          "codex",
+          "exec",
+          "--sandbox",
+          "workspace-write",
+          "-m",
+          "gpt-5.5",
+          "-c",
+          "model_reasoning_effort=high",
+          expect.any(String),
+        ]);
+      }
+      expect(store.getLearning(a)!.rule).toBe("A revised");
+      expect(store.getLearning(a)!.ineffectiveCount).toBe(0);
+      expect(store.getLearning(b)!.rule).toBe(
+        entryPoint === "optimizeOne" ? "rule B" : "B revised",
+      );
+      expect(store.getLearning(b)!.ineffectiveCount).toBe(
+        entryPoint === "optimizeOne" ? 1 : 0,
+      );
+    });
+  }
+}
+
+test("resolves a fresh environment for every optimizer spawn", async () => {
+  const store = new SessionStore(":memory:");
+  const id = seedActiveRule(store, "/r", "rule");
+  flag(store, "/r", id);
+  let environment: RoleEnvironment = { provider: "claude", model: "sonnet", effort: "high" };
+  let revision = "Claude revision";
+  const { deps, cap } = optimizerSpawnCapture(
+    store,
+    () => ({ revisions: [{ id, rule: revision }] }),
+    () => environment,
+  );
+  const svc = new OptimizerService(deps as any);
+
+  await svc.optimizeOne(id);
+  await svc.tick();
+  environment = { provider: "codex", model: "gpt-5.5", effort: "medium" };
+  revision = "Codex revision";
+  flag(store, "/r", id);
+  await svc.optimizeOne(id);
+  await svc.tick();
+
+  expect(cap.argv.map((argv) => argv[0])).toEqual(["claude", "codex"]);
+  expect(store.getLearning(id)!.rule).toBe("Codex revision");
+});
+
+test("Claude optimizer fails closed in api-key mode when no key is configured", async () => {
+  await withAuth("api-key", null, async () => {
+    const store = new SessionStore(":memory:");
+    const id = seedActiveRule(store, "/r", "rule");
+    flag(store, "/r", id);
+    const { deps, cap } = optimizerSpawnCapture(
+      store,
+      () => null,
+      () => ({ provider: "claude", model: null, effort: null }),
+    );
+
+    await new OptimizerService(deps as any).optimizeOne(id);
+
+    expect(cap.argv).toHaveLength(0);
+    expect(cap.removed).toBe(1);
+  });
+});
+
+test("Codex optimizer is not blocked by missing Anthropic api-key configuration", async () => {
+  await withAuth("api-key", null, async () => {
+    const store = new SessionStore(":memory:");
+    const id = seedActiveRule(store, "/r", "rule");
+    flag(store, "/r", id);
+    const { deps, cap } = optimizerSpawnCapture(
+      store,
+      () => null,
+      () => ({ provider: "codex", model: null, effort: null }),
+    );
+
+    await new OptimizerService(deps as any).optimizeOne(id);
+
+    expect(cap.argv[0]!.slice(0, 4)).toEqual([
+      "codex",
+      "exec",
+      "--sandbox",
+      "workspace-write",
+    ]);
+    expect(cap.env[0]).toBeUndefined();
+  });
+});
+
+test("Claude optimizer keeps apiKeyHelper settings and CLAUDE_CONFIG_DIR passthrough", async () => {
+  await withAuth("api-key", "/helper.sh", async () => {
+    const store = new SessionStore(":memory:");
+    const id = seedActiveRule(store, "/r", "rule");
+    flag(store, "/r", id);
+    const { deps, cap } = optimizerSpawnCapture(
+      store,
+      () => null,
+      () => ({ provider: "claude", model: "sonnet", effort: "high" }),
+    );
+
+    await new OptimizerService(deps as any).optimizeOne(id);
+
+    const argv = cap.argv[0]!;
+    const settings = JSON.parse(argv[argv.indexOf("--settings") + 1]!);
+    expect(settings.apiKeyHelper).toBe("/helper.sh");
+    expect(Object.keys(cap.env[0]!)).toEqual(["CLAUDE_CONFIG_DIR"]);
+  });
 });
 
 // ── boot reapOrphans (issue #1135) ──────────────────────────────────────────

--- a/test/server-settings.test.ts
+++ b/test/server-settings.test.ts
@@ -35,6 +35,7 @@ const ROLE_BASES = [
   "namer",
   "autopilot",
   "distiller",
+  "optimizer",
 ] as const;
 let savedRoleEnvs: Record<string, string>;
 let savedDefaultAgentProvider: typeof config.defaultAgentProvider;
@@ -515,6 +516,9 @@ test("GET /api/settings includes every per-role cli + model + effort setting (ra
   config.rundownCli = "codex";
   config.rundownModel = "gpt-5.5";
   config.rundownEffort = "low";
+  config.optimizerCli = "codex";
+  config.optimizerModel = "gpt-5.5";
+  config.optimizerEffort = "medium";
   const { app } = harness();
   const body = await (await app.fetch(new Request("http://x/api/settings"))).json();
   expect(body.criticCli).toBe("codex");
@@ -529,6 +533,9 @@ test("GET /api/settings includes every per-role cli + model + effort setting (ra
   expect(body.rundownCli).toBe("codex");
   expect(body.rundownModel).toBe("gpt-5.5");
   expect(body.rundownEffort).toBe("low");
+  expect(body.optimizerCli).toBe("codex");
+  expect(body.optimizerModel).toBe("gpt-5.5");
+  expect(body.optimizerEffort).toBe("medium");
 });
 
 for (const role of ROLE_BASES) {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3173,5 +3173,9 @@
   "settings_role_model_rundown_title": "Herd-Rundown",
   "settings_role_model_rundown_hint": "Fasst einmal täglich und bei Bedarf die Aufmerksamkeit der gesamten Herde zusammen.",
   "feat_rundown_provider_title": "Kosten des Herd-Rundowns steuern",
-  "feat_rundown_provider_body": "Wähle CLI, Modell und Aufwand des Herd-Rundowns für automatische und neu erzeugte Digests."
+  "feat_rundown_provider_body": "Wähle CLI, Modell und Aufwand des Herd-Rundowns für automatische und neu erzeugte Digests.",
+  "settings_role_model_optimizer_title": "Learnings-Optimierer",
+  "settings_role_model_optimizer_hint": "Verschärft als unwirksam markierte Regeln anhand ihrer Fehlerbelege.",
+  "feat_optimizer_provider_aware_title": "Umgebung des Learnings-Optimierers wählen",
+  "feat_optimizer_provider_aware_body": "Wähle CLI, Modell und Reasoning-Aufwand, mit denen der Optimierer als unwirksam markierte Regeln verschärft."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3173,5 +3173,9 @@
   "settings_role_model_rundown_title": "Herd Rundown",
   "settings_role_model_rundown_hint": "Summarizes herd-wide attention once per day and on demand.",
   "feat_rundown_provider_title": "Control Herd Rundown cost",
-  "feat_rundown_provider_body": "Choose the Herd Rundown CLI, model, and effort for automatic and regenerated digests."
+  "feat_rundown_provider_body": "Choose the Herd Rundown CLI, model, and effort for automatic and regenerated digests.",
+  "settings_role_model_optimizer_title": "Learnings Optimizer",
+  "settings_role_model_optimizer_hint": "Strengthens rules marked as not working using their failure evidence.",
+  "feat_optimizer_provider_aware_title": "Choose the Learnings Optimizer environment",
+  "feat_optimizer_provider_aware_body": "Choose the CLI, model, and reasoning effort the Optimizer uses when strengthening rules marked as not working."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -611,11 +611,19 @@ export const putDefaultAgentProvider = (
 ): Promise<{ defaultAgentProvider: AgentProvider }> =>
   patchSettings<{ defaultAgentProvider: AgentProvider }>({ defaultAgentProvider: provider });
 
-// The per-role ENVIRONMENT settings the Settings UI can override. Each role has a PAIR: a
-// `<role>Cli` ("inherit" | "claude" | "codex") and a `<role>Model` ("default" | <alias>). The
-// server validates + persists each independently and echoes the stored value under the same key.
+// The per-role ENVIRONMENT settings the Settings UI can override: `<role>Cli`
+// ("inherit" | "claude" | "codex"), `<role>Model` ("default" | <alias>), and `<role>Effort`.
+// The server validates + persists each independently and echoes the stored value under the same key.
 export type RoleBase =
-  "critic" | "planner" | "recap" | "rundown" | "docAgent" | "namer" | "autopilot" | "distiller";
+  | "critic"
+  | "planner"
+  | "recap"
+  | "rundown"
+  | "docAgent"
+  | "namer"
+  | "autopilot"
+  | "distiller"
+  | "optimizer";
 export type RoleCliKey = `${RoleBase}Cli`;
 export type RoleModelKey = `${RoleBase}Model`;
 export type RoleEffortKey = `${RoleBase}Effort`;

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -278,10 +278,9 @@
   let distillerIntervalDaysMin = $state(1);
   let distillerIntervalDaysMax = $state(14);
   let distillerIntervalBusy = $state(false);
-  // Per-role ENVIRONMENT overrides (plan reviewer, PR critic, recap, doc-agent, namer, autopilot).
-  // Each role is a PAIR: a CLI (`<role>Cli` ∈ "inherit"|"claude"|"codex"; "inherit" follows the
-  // global provider+model) and a model (`<role>Model` ∈ "default"|<alias for that CLI>). Seeds
-  // mirror the server defaults so the pickers read sensibly before load() resolves.
+  // Per-role ENVIRONMENT overrides. Each role has CLI, model, and reasoning-effort settings;
+  // `inherit` follows the global provider+model. Seeds mirror the server defaults so the pickers
+  // read sensibly before load() resolves.
   const ROLE_BASES = [
     "planner",
     "critic",
@@ -289,6 +288,7 @@
     "recap",
     "rundown",
     "distiller",
+    "optimizer",
     "namer",
     "autopilot",
   ] as const;
@@ -302,6 +302,7 @@
     namer: "claude",
     autopilot: "claude",
     distiller: "inherit",
+    optimizer: "inherit",
   };
   const ROLE_MODEL_SEED: Record<RoleBase, string> = {
     planner: "default",
@@ -312,6 +313,7 @@
     namer: "haiku",
     autopilot: "haiku",
     distiller: "default",
+    optimizer: "default",
   };
   // Per-role reasoning-effort tier ("default"|<tier>), orthogonal to CLI/model — always shown.
   const ROLE_EFFORT_SEED: Record<RoleBase, string> = {
@@ -323,6 +325,7 @@
     namer: "low",
     autopilot: "low",
     distiller: "default",
+    optimizer: "default",
   };
   let roleCli = $state<Record<RoleBase, string>>({ ...ROLE_CLI_SEED });
   let roleCliSaved: Record<RoleBase, string> = { ...ROLE_CLI_SEED };
@@ -339,6 +342,7 @@
     namer: false,
     autopilot: false,
     distiller: false,
+    optimizer: false,
   });
   // Foreground (content) roles vs. collapsed classifiers (constant-cadence, kept cheap).
   const ROLE_PRIMARY: RoleBase[] = [
@@ -348,6 +352,7 @@
     "recap",
     "rundown",
     "distiller",
+    "optimizer",
   ];
   const ROLE_CLASSIFIERS: RoleBase[] = ["namer", "autopilot"];
 
@@ -369,6 +374,8 @@
         return m.settings_role_model_autopilot_title();
       case "distiller":
         return m.settings_role_model_distiller_title();
+      case "optimizer":
+        return m.settings_role_model_optimizer_title();
     }
   }
   function roleHint(role: RoleBase): string {
@@ -389,6 +396,8 @@
         return m.settings_role_model_autopilot_hint();
       case "distiller":
         return m.settings_role_model_distiller_hint();
+      case "optimizer":
+        return m.settings_role_model_optimizer_hint();
     }
   }
   // Display label for a CLI/provider (the CLI dropdown options + the effective line).

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-optimizer-provider-aware.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-optimizer-provider-aware.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "optimizer-provider-aware",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_optimizer_provider_aware_title",
+  bodyKey: "feat_optimizer_provider_aware_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -100,7 +100,7 @@ export interface Settings {
   /** Per-role ENVIRONMENT settings for the helper agents Shepherd spawns: a CLI pair per role.
    *  `<role>Cli` ∈ "inherit" | "claude" | "codex" ("inherit" follows `defaultAgentProvider` +
    *  `defaultModel`); `<role>Model` ∈ "default" | <alias for that CLI>. The Settings UI shows each
-   *  role's effective resolved CLI · model alongside its two pickers. */
+   *  role's effective resolved CLI · model alongside its environment pickers. */
   criticCli: string;
   criticModel: string;
   criticEffort: string;
@@ -125,6 +125,9 @@ export interface Settings {
   distillerCli?: string;
   distillerModel?: string;
   distillerEffort?: string;
+  optimizerCli?: string;
+  optimizerModel?: string;
+  optimizerEffort?: string;
   distillerIntervalDays?: number;
   distillerIntervalDaysMin?: number;
   distillerIntervalDaysMax?: number;


### PR DESCRIPTION
# Problem

The Learnings Optimizer ignored Shepherd's global Codex selection because it had no persisted role environment and its spawn path never received a provider. As a result, optimization runs always started Claude Code, even when the operator selected Codex globally, and the service could not be tuned independently for CLI, model, or reasoning effort.

Closes #1755.

# Solution

- Add a persisted Learnings Optimizer environment with `inherit`, `claude`, and `codex` CLI choices plus provider-compatible model and reasoning-effort settings.
- Resolve the environment fresh for every optimizer spawn, including global inheritance, Codex auth-model clamping, Claude-only usage downgrade, and provider-aware API-key handling.
- Reuse the existing `writer-ro` transient-agent contract so Claude keeps its established read-only invocation while Codex uses `codex exec --sandbox workspace-write`.
- Surface the Optimizer in Settings with the shared role controls, effective CLI/model display, EN/DE copy, and a v1.44.0 feature announcement.

## Technical details

- `inherit` follows the live global provider, provider-specific model, and global effort. Explicit providers leave model and effort unset when their setting is `default`.
- Anthropic API-key fail-closed behavior is keyed to the resolved provider, so missing Anthropic credentials cannot block Codex or leak `CLAUDE_CONFIG_DIR` into Codex spawns.
- Both providers consume the same `optimized.json` revision shape. Queueing, target-ID validation, promoted-rule resync, timeouts, health tracking, and teardown remain unchanged.
- The provider/entry-point matrix covers `optimizeOne` and `optimizeAllFlagged` on Claude and Codex, including revision application, live environment changes, and authentication boundaries.

## Validation

- `bun test test/optimizer.test.ts test/server-settings.test.ts test/default-model.test.ts test/transient-agent-argv.test.ts test/learnings-lifecycle.test.ts` — 327 passed
- `bun run test` — 7,057 passed, 8 skipped
- `bun run lint`
- `bun run typecheck`
- `cd ui && bun run check:i18n`
- `cd ui && bun run check`
- `cd ui && bun run test` — 3,825 passed
- `bun run check:glossary`
- `bun run check:announcement-versions`
- `scripts/check-branch-hygiene.sh origin/main`
