### PR TITLE
feat(update): explain a dirty self-update repo and offer a safe discard

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -253,6 +253,14 @@
         "reason": "Tier 1: global Svelte <template> complexity bar (#851; see comment above)."
       },
       {
+        "files": ["ui/src/lib/components/UpdateModal.svelte"],
+        "functions": ["<template>"],
+        "maxCyclomatic": 45,
+        "maxCognitive": 60,
+        "maxCrap": 20000,
+        "reason": "The dirty-repo self-update flow adds render modes (progress/loading/clean/dirty/toolarge/nowclean/rawlog) so the operator can be shown, and re-confirm, exactly which changes a discard would revert; the extra {#if mode ===} branches take cyclomatic to 44 (over the Tier-1 40 bar), cognitive stays under (54). Keep capped until the dirty section splits into a child component (#855)."
+      },
+      {
         "files": ["ui/src/lib/components/Viewport.svelte"],
         "functions": ["<template>"],
         "maxCyclomatic": 90,

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Deploy local code to the running Shepherd service.
 # Idempotent: install deps → build UI → restart unit → health check.
-#   deploy/update.sh           # deploy the current working tree
-#   deploy/update.sh --pull    # fast-forward main from origin first (dev==prod box: skip)
+#   deploy/update.sh                     # deploy the current working tree
+#   deploy/update.sh --pull              # fast-forward main from origin first (dev==prod box: skip)
+#   deploy/update.sh --pull --discard    # discard the CONFIRMED tracked changes first, then pull
 set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -11,7 +12,15 @@ cd "$REPO"
 UNIT="shepherd"
 PORT="${SHEPHERD_PORT:-7330}"
 PULL=0
-[[ "${1:-}" == "--pull" ]] && PULL=1
+DISCARD=0
+# Parse ALL args (order-independent), not just $1 — so `--pull --discard` and
+# `--discard --pull` both take effect.
+for arg in "$@"; do
+  case "$arg" in
+    --pull) PULL=1 ;;
+    --discard) DISCARD=1 ;;
+  esac
+done
 
 note() { printf '\033[36m▸ %s\033[0m\n' "$*"; }
 warn() { printf '\033[33m! %s\033[0m\n' "$*"; }
@@ -39,6 +48,26 @@ retry() {
   return 1
 }
 
+# sha256 of stdin as bare hex (Linux: sha256sum; macOS: shasum -a 256)
+sha256_hex() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | cut -d' ' -f1
+  else
+    shasum -a 256 | cut -d' ' -f1
+  fi
+}
+# Framed content signature of the tracked dirty state: three per-command subhashes
+# (status + staged diff + unstaged diff), then hash their concatenated hex. Diff
+# config fully neutralised so it depends only on real content. Must match the
+# Node side in src/update.ts byte-for-byte.
+discard_sig() {
+  local s1 s2 s3
+  s1="$(git status --porcelain -z --untracked-files=no | sha256_hex)"
+  s2="$(git diff --cached --binary --no-color --no-ext-diff --no-textconv | sha256_hex)"
+  s3="$(git diff --binary --no-color --no-ext-diff --no-textconv | sha256_hex)"
+  printf '%s%s%s' "$s1" "$s2" "$s3" | sha256_hex
+}
+
 # ── guard: the working tree IS the deployment ────────────────────────────────
 branch="$(git rev-parse --abbrev-ref HEAD)"
 [[ "$branch" == "main" ]] || warn "on branch '$branch' (not main) — the service will run THIS code"
@@ -48,6 +77,33 @@ fi
 
 if [[ "$PULL" == "1" ]]; then
   [[ "$branch" == "main" ]] || die "--pull requires being on main (currently '$branch')"
+
+  # ── scoped discard of the CONFIRMED tracked changes ─────────────────────────
+  # Never a blanket `git reset --hard` (which would also wipe anything written to
+  # the tree between confirmation and now). Instead restore ONLY the confirmed
+  # NUL pathspecs, re-verified against the confirmed signature at the last instant.
+  if [[ "$DISCARD" == "1" ]]; then
+    [[ -n "${SHEPHERD_DISCARD_SIG:-}" && -n "${SHEPHERD_DISCARD_DIR:-}" \
+      && -n "${SHEPHERD_DISCARD_PATHSPEC_ALL:-}" && -n "${SHEPHERD_DISCARD_PATHSPEC_WT:-}" ]] \
+      || die "--discard requires the confirmation tokens"
+    # remove the private pathspec dir on ANY exit path (guarded against rm -rf "")
+    trap '[ -n "${SHEPHERD_DISCARD_DIR:-}" ] && rm -rf "$SHEPHERD_DISCARD_DIR"' EXIT
+    [[ "$(discard_sig)" == "$SHEPHERD_DISCARD_SIG" ]] \
+      || die "SHEPHERD_DISCARD_STALE: working tree changed since confirmation"
+    note "discarding confirmed local changes"
+    # --literal-pathspecs: a confirmed filename may itself contain pathspec magic
+    # (e.g. *.ts or :(glob)…); treat every listed path literally so the restore
+    # can't fan out to unconfirmed matching files.
+    git --literal-pathspecs restore --source=HEAD --staged \
+      --pathspec-from-file="$SHEPHERD_DISCARD_PATHSPEC_ALL" --pathspec-file-nul
+    if [[ -s "$SHEPHERD_DISCARD_PATHSPEC_WT" ]]; then
+      git --literal-pathspecs restore --source=HEAD --worktree \
+        --pathspec-from-file="$SHEPHERD_DISCARD_PATHSPEC_WT" --pathspec-file-nul
+    fi
+  fi
+
+  # final gate: if an UNconfirmed tracked change slipped in (not in the pathspec),
+  # abort here rather than pulling over a dirty tree — routes back to reconfirm.
   git diff --quiet && git diff --cached --quiet || die "--pull needs a clean tree"
   note "fast-forwarding main from origin"
   git pull --ff-only

--- a/src/server.ts
+++ b/src/server.ts
@@ -181,7 +181,8 @@ import { parseEpicBody } from "./epic-parse";
 import { countDefinedWorkflows, type CountsService, type RepoCounts } from "./backlog";
 import type { OpenPrSnapshotService } from "./open-pr-snapshot";
 import { join, normalize, basename } from "node:path";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import type { ServerWebSocket } from "bun";
 import { execFileSync, markPtyEvent } from "./instrument";
 import { isOperatorKeystroke, stampOperatorKeystroke } from "./operator-activity";
@@ -289,7 +290,8 @@ export interface AppDeps {
   /** Resolve the git forge for a repo dir; null when none is configured. */
   resolveForge?: (repoDir: string) => GitForge | null;
   /** Self-update tracker; absent in environments where it isn't wired. */
-  updates?: Pick<UpdateService, "current" | "apply"> & Partial<Pick<UpdateService, "applyState">>;
+  updates?: Pick<UpdateService, "current" | "apply"> &
+    Partial<Pick<UpdateService, "applyState" | "dirtyStatus">>;
   /** herdr-version tracker + applier; absent in environments where it isn't wired. */
   herdrUpdates?: Pick<HerdrUpdateService, "current" | "apply">;
   /** codex-version tracker + applier; absent in environments where it isn't wired. */
@@ -3978,20 +3980,91 @@ function updateStatus(deps: AppDeps): Response {
   );
 }
 
-function updateApply(deps: AppDeps): Response {
+/** Fresh dirty snapshot for the UI, with the server-internal raw pathspec buffers
+ *  stripped (the UI only needs the display list + count + signature). */
+async function updateDirty(deps: AppDeps): Promise<Response> {
+  if (!deps.updates?.dirtyStatus) return json({ error: "updates not available" }, 503);
+  const { dirty, dirtyFiles, dirtyCount, sig } = await deps.updates.dirtyStatus();
+  return json({ dirty, dirtyFiles, dirtyCount, sig });
+}
+
+async function updateApply(req: Request, deps: AppDeps): Promise<Response> {
   if (!deps.updates) return json({ error: "updates not available" }, 503);
+  const body = (await req.json().catch(() => ({}))) as { discard?: unknown; sig?: unknown };
+  if (body.discard !== undefined && typeof body.discard !== "boolean")
+    return json({ error: "body.discard must be a boolean" }, 400);
+  if (body.sig !== undefined && typeof body.sig !== "string")
+    return json({ error: "body.sig must be a string" }, 400);
+
+  // Existing no-update guard runs FIRST — before any dirty probe, tempfile, or
+  // apply — so a discard request with nothing to update has zero side effects.
   const status = deps.updates.current();
   if (!status || status.behind <= 0) return json({ error: "no update available" }, 409);
+
+  if (body.discard === true) {
+    if (!deps.updates.dirtyStatus) return json({ error: "updates not available" }, 503);
+    // re-probe fresh and validate the confirmed signature before doing anything
+    const fresh = await deps.updates.dirtyStatus();
+    if (!fresh.dirty || fresh.sig == null || fresh.sig !== body.sig)
+      return json(
+        {
+          error: "stale",
+          dirty: {
+            dirty: fresh.dirty,
+            dirtyFiles: fresh.dirtyFiles,
+            dirtyCount: fresh.dirtyCount,
+            sig: fresh.sig,
+          },
+        },
+        409,
+      );
+    // symlink-safe: a private 0700 dir + exclusive (wx) file creation, so a
+    // pre-planted path/symlink can't be written through.
+    const dir = mkdtempSync(join(tmpdir(), "shepherd-discard-"));
+    try {
+      const pathspecAllFile = join(dir, "all");
+      const pathspecWtFile = join(dir, "worktree");
+      writeFileSync(pathspecAllFile, fresh.pathspecAll, { flag: "wx", mode: 0o600 });
+      writeFileSync(pathspecWtFile, fresh.pathspecWorktree, { flag: "wx", mode: 0o600 });
+      const r = deps.updates.apply({
+        discard: true,
+        sig: fresh.sig,
+        dir,
+        pathspecAllFile,
+        pathspecWtFile,
+      });
+      if (!r.started) {
+        rmSync(dir, { recursive: true, force: true });
+        return json({ error: r.error ?? "could not start the update" }, 409);
+      }
+      // success → the detached update.sh trap removes `dir` after it runs
+      return json({ ok: true }, 202);
+    } catch (e) {
+      rmSync(dir, { recursive: true, force: true });
+      return json({ error: e instanceof Error ? e.message : "could not start the update" }, 500);
+    }
+  }
+
   const r = deps.updates.apply();
   if (r.started) return json({ ok: true }, 202);
   // never a bare status: carry the real reason so the UI can show it
   return json({ error: r.error ?? "could not start the update" }, 409);
 }
 
-function handleUpdate({ req, parts, deps }: Ctx): Response | null {
+async function handleUpdate({ req, parts, deps }: Ctx): Promise<Response | null> {
   if (parts[0] === "api" && parts[1] === "update" && !parts[2]) {
     if (req.method === "GET") return updateStatus(deps);
-    if (req.method === "POST") return updateApply(deps);
+    if (req.method === "POST") return updateApply(req, deps);
+  }
+  // fresh dirty snapshot of the running deployment (never cached)
+  if (
+    req.method === "GET" &&
+    parts[0] === "api" &&
+    parts[1] === "update" &&
+    parts[2] === "dirty" &&
+    !parts[3]
+  ) {
+    return updateDirty(deps);
   }
   // live state of an in-flight/failed deploy so the modal can show why it failed
   if (

--- a/src/server.ts
+++ b/src/server.ts
@@ -3988,6 +3988,48 @@ async function updateDirty(deps: AppDeps): Promise<Response> {
   return json({ dirty, dirtyFiles, dirtyCount, sig });
 }
 
+/** Validate the confirmed dirty signature, then launch a scoped discard+update.
+ *  Writes the pathspecs symlink-safely (private 0700 dir + exclusive wx/0600 files)
+ *  and cleans the dir up on any non-launch outcome (success leaves it for the
+ *  detached update.sh trap). */
+async function updateDiscardApply(updates: NonNullable<AppDeps["updates"]>, sig?: string) {
+  if (!updates.dirtyStatus) return json({ error: "updates not available" }, 503);
+  const fresh = await updates.dirtyStatus();
+  if (!fresh.dirty || fresh.sig == null || fresh.sig !== sig)
+    return json(
+      {
+        error: "stale",
+        dirty: {
+          dirty: fresh.dirty,
+          dirtyFiles: fresh.dirtyFiles,
+          dirtyCount: fresh.dirtyCount,
+          sig: fresh.sig,
+        },
+      },
+      409,
+    );
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-discard-"));
+  try {
+    const pathspecAllFile = join(dir, "all");
+    const pathspecWtFile = join(dir, "worktree");
+    writeFileSync(pathspecAllFile, fresh.pathspecAll, { flag: "wx", mode: 0o600 });
+    writeFileSync(pathspecWtFile, fresh.pathspecWorktree, { flag: "wx", mode: 0o600 });
+    const r = updates.apply({
+      discard: true,
+      sig: fresh.sig,
+      dir,
+      pathspecAllFile,
+      pathspecWtFile,
+    });
+    if (r.started) return json({ ok: true }, 202); // update.sh's trap removes `dir`
+    rmSync(dir, { recursive: true, force: true });
+    return json({ error: r.error ?? "could not start the update" }, 409);
+  } catch (e) {
+    rmSync(dir, { recursive: true, force: true });
+    return json({ error: e instanceof Error ? e.message : "could not start the update" }, 500);
+  }
+}
+
 async function updateApply(req: Request, deps: AppDeps): Promise<Response> {
   if (!deps.updates) return json({ error: "updates not available" }, 503);
   const body = (await req.json().catch(() => ({}))) as { discard?: unknown; sig?: unknown };
@@ -4001,49 +4043,7 @@ async function updateApply(req: Request, deps: AppDeps): Promise<Response> {
   const status = deps.updates.current();
   if (!status || status.behind <= 0) return json({ error: "no update available" }, 409);
 
-  if (body.discard === true) {
-    if (!deps.updates.dirtyStatus) return json({ error: "updates not available" }, 503);
-    // re-probe fresh and validate the confirmed signature before doing anything
-    const fresh = await deps.updates.dirtyStatus();
-    if (!fresh.dirty || fresh.sig == null || fresh.sig !== body.sig)
-      return json(
-        {
-          error: "stale",
-          dirty: {
-            dirty: fresh.dirty,
-            dirtyFiles: fresh.dirtyFiles,
-            dirtyCount: fresh.dirtyCount,
-            sig: fresh.sig,
-          },
-        },
-        409,
-      );
-    // symlink-safe: a private 0700 dir + exclusive (wx) file creation, so a
-    // pre-planted path/symlink can't be written through.
-    const dir = mkdtempSync(join(tmpdir(), "shepherd-discard-"));
-    try {
-      const pathspecAllFile = join(dir, "all");
-      const pathspecWtFile = join(dir, "worktree");
-      writeFileSync(pathspecAllFile, fresh.pathspecAll, { flag: "wx", mode: 0o600 });
-      writeFileSync(pathspecWtFile, fresh.pathspecWorktree, { flag: "wx", mode: 0o600 });
-      const r = deps.updates.apply({
-        discard: true,
-        sig: fresh.sig,
-        dir,
-        pathspecAllFile,
-        pathspecWtFile,
-      });
-      if (!r.started) {
-        rmSync(dir, { recursive: true, force: true });
-        return json({ error: r.error ?? "could not start the update" }, 409);
-      }
-      // success → the detached update.sh trap removes `dir` after it runs
-      return json({ ok: true }, 202);
-    } catch (e) {
-      rmSync(dir, { recursive: true, force: true });
-      return json({ error: e instanceof Error ? e.message : "could not start the update" }, 500);
-    }
-  }
+  if (body.discard === true) return updateDiscardApply(deps.updates, body.sig);
 
   const r = deps.updates.apply();
   if (r.started) return json({ ok: true }, 202);

--- a/src/update.ts
+++ b/src/update.ts
@@ -62,6 +62,14 @@ const DISCARD_STALE_MARKER = "SHEPHERD_DISCARD_STALE";
 /** Signature the `--pull` clean-tree guard prints; classified as reason "dirty". */
 const CLEAN_TREE_MARKER = "needs a clean tree";
 
+/** Classify a failed deploy's log so the UI can route it through the dirty-repo flow. */
+function classifyDeployReason(exitCode: number, log: string): "dirty" | "stale" | null {
+  if (exitCode === 0) return null;
+  if (log.includes(DISCARD_STALE_MARKER)) return "stale";
+  if (log.includes(CLEAN_TREE_MARKER)) return "dirty";
+  return null;
+}
+
 /** Marker the launch wrapper appends once the deploy script returns, carrying
  *  its exit code. Lets a surviving (or freshly restarted) shepherd tell a
  *  finished deploy from one still in flight. */
@@ -77,6 +85,37 @@ const tail = (s: string, max = 6000): string => (s.length > max ? s.slice(s.leng
 const shq = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`;
 
 const NUL = 0x00;
+
+/** Split a NUL-separated buffer into field slices (drops a trailing empty field). */
+function splitNul(buf: Buffer): Buffer[] {
+  const fields: Buffer[] = [];
+  let start = 0;
+  for (let i = 0; i < buf.length; i++) {
+    if (buf[i] === NUL) {
+      fields.push(buf.subarray(start, i));
+      start = i + 1;
+    }
+  }
+  if (start < buf.length) fields.push(buf.subarray(start));
+  return fields;
+}
+
+/**
+ * Which restore pathspecs a single porcelain entry contributes.
+ * `all` → `git restore --staged` (every confirmed path; both sides of a rename/copy).
+ * `wt`  → `git restore --worktree` (only paths that exist in HEAD, so pure adds and the
+ *          new side of a rename/copy are left as untracked instead of being deleted).
+ */
+function entrySpecs(
+  x: string,
+  path: Buffer,
+  orig: Buffer | undefined,
+): { all: Buffer[]; wt: Buffer[] } {
+  if (x === "R" || x === "C") {
+    return orig ? { all: [path, orig], wt: [orig] } : { all: [path], wt: [] };
+  }
+  return { all: [path], wt: x === "A" ? [] : [path] };
+}
 
 /**
  * Parse `git status --porcelain -z --untracked-files=no` output (raw bytes) into
@@ -96,23 +135,13 @@ function parsePorcelain(
   buf: Buffer,
   limit: number,
 ): { dirtyFiles: string[]; dirtyCount: number; pathspecAll: Buffer; pathspecWorktree: Buffer } {
-  // split on NUL into field slices (drop a trailing empty field)
-  const fields: Buffer[] = [];
-  let start = 0;
-  for (let i = 0; i < buf.length; i++) {
-    if (buf[i] === NUL) {
-      fields.push(buf.subarray(start, i));
-      start = i + 1;
-    }
-  }
-  if (start < buf.length) fields.push(buf.subarray(start));
-
+  const fields = splitNul(buf);
   const dirtyFiles: string[] = [];
   const allParts: Buffer[] = [];
   const wtParts: Buffer[] = [];
   const sep = Buffer.from([NUL]);
-  const pushSpec = (parts: Buffer[], p: Buffer) => {
-    parts.push(p, sep);
+  const push = (parts: Buffer[], paths: Buffer[]) => {
+    for (const p of paths) parts.push(p, sep);
   };
 
   let dirtyCount = 0;
@@ -124,26 +153,17 @@ function parsePorcelain(
       continue; // malformed / empty — skip
     }
     const x = String.fromCharCode(rec[0]!);
-    const status = rec.subarray(0, 2).toString("latin1");
     const path = rec.subarray(3); // skip "XY "
-    const isRenameOrCopy = x === "R" || x === "C";
-    const orig = isRenameOrCopy ? fields[i + 1] : undefined;
-    i += isRenameOrCopy ? 2 : 1;
+    const orig = x === "R" || x === "C" ? fields[i + 1] : undefined;
+    i += orig ? 2 : 1;
 
     dirtyCount++;
-    if (dirtyFiles.length < limit) dirtyFiles.push(`${status} ${path.toString("utf8")}`);
+    if (dirtyFiles.length < limit)
+      dirtyFiles.push(`${rec.subarray(0, 2).toString("latin1")} ${path.toString("utf8")}`);
 
-    if (isRenameOrCopy) {
-      pushSpec(allParts, path); // new side
-      if (orig) {
-        pushSpec(allParts, orig); // old side (in HEAD)
-        pushSpec(wtParts, orig); // restore the old path in the worktree
-      }
-      // new side is NOT in HEAD → left untracked, never worktree-restored
-    } else {
-      pushSpec(allParts, path);
-      if (x !== "A") pushSpec(wtParts, path); // pure adds aren't in HEAD → keep as untracked
-    }
+    const { all, wt } = entrySpecs(x, path, orig);
+    push(allParts, all);
+    push(wtParts, wt);
   }
 
   return {
@@ -382,15 +402,7 @@ export class UpdateService {
       const log = tail(clean.replace(m[0], "").trimEnd());
       // Classify a failed deploy so the UI can route it through the friendly
       // dirty-repo flow (fresh probe + refreshed list) instead of the raw log.
-      // The markers are stable English git/script output, never translated.
-      const reason =
-        exitCode === 0
-          ? null
-          : log.includes(DISCARD_STALE_MARKER)
-            ? "stale"
-            : log.includes(CLEAN_TREE_MARKER)
-              ? "dirty"
-              : null;
+      const reason = classifyDeployReason(exitCode, log);
       return { phase: exitCode === 0 ? "done" : "failed", exitCode, log, reason };
     }
     let mtimeMs = 0;

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,4 +1,5 @@
-import { execFile, spawnSync } from "node:child_process";
+import { execFile, spawn, spawnSync } from "node:child_process";
+import { createHash, type Hash } from "node:crypto";
 import { readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -22,7 +23,44 @@ export interface DeployState {
   /** tail of the deploy's captured stdout+stderr (ANSI stripped) so the UI can
    *  show *why* a deploy failed instead of a bare status code */
   log: string;
+  /** classified failure cause, so the UI can route a dirty/stale deploy through the
+   *  friendly dirty-repo flow instead of the raw log. `"dirty"` = the working tree
+   *  blocked `--pull` (`needs a clean tree`); `"stale"` = the discard's confirmed
+   *  signature no longer matched at reset time (`SHEPHERD_DISCARD_STALE`). */
+  reason?: "dirty" | "stale" | null;
 }
+
+/**
+ * Fresh snapshot of the running deployment's *tracked* dirty state, computed on
+ * demand (never from the periodic {@link UpdateService.check}). Drives the
+ * dirty-repo update flow: the file list the operator confirms, a content-sensitive
+ * signature the discard is validated against, and the exact NUL pathspecs the
+ * scoped `git restore` runs over.
+ */
+export interface DirtyStatus {
+  /** true when the tracked tree has staged or unstaged changes (what blocks `--pull`) */
+  dirty: boolean;
+  /** capped, display-formatted `XY path` lines (lossy UTF-8 ok — display only) */
+  dirtyFiles: string[];
+  /** total number of changed entries, independent of the capped {@link dirtyFiles} */
+  dirtyCount: number;
+  /** SHA-256 over the framed per-command subhashes (status + both content diffs);
+   *  null when the diff was too large / timed out (auto-discard then unavailable) */
+  sig: string | null;
+  /** raw NUL-joined pathspec bytes for `git restore --staged` — every confirmed
+   *  path (both sides of a rename/copy). Server-internal; stripped from the API. */
+  pathspecAll: Buffer;
+  /** raw NUL-joined pathspec bytes for `git restore --worktree` — only paths that
+   *  exist in HEAD (excludes pure adds + the new side of renames/copies, which are
+   *  left as untracked so created content is never deleted). Server-internal. */
+  pathspecWorktree: Buffer;
+}
+
+/** Marker `update.sh` dies with when a discard's confirmed signature no longer
+ *  matches the tree at reset time; classified as {@link DeployState.reason} "stale". */
+const DISCARD_STALE_MARKER = "SHEPHERD_DISCARD_STALE";
+/** Signature the `--pull` clean-tree guard prints; classified as reason "dirty". */
+const CLEAN_TREE_MARKER = "needs a clean tree";
 
 /** Marker the launch wrapper appends once the deploy script returns, carrying
  *  its exit code. Lets a surviving (or freshly restarted) shepherd tell a
@@ -37,6 +75,84 @@ const ANSI_RE = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
 const stripAnsi = (s: string): string => s.replace(ANSI_RE, "");
 const tail = (s: string, max = 6000): string => (s.length > max ? s.slice(s.length - max) : s);
 const shq = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`;
+
+const NUL = 0x00;
+
+/**
+ * Parse `git status --porcelain -z --untracked-files=no` output (raw bytes) into
+ * the display list + the two restore pathspecs, all NUL-safe.
+ *
+ * Each record is `XY<space>PATH`; a rename/copy (X ∈ {R,C}) is followed by an
+ * extra NUL field carrying the ORIGinal path. Path bytes are taken **verbatim**
+ * (never decoded) for the pathspecs, so non-UTF-8 paths still match under
+ * `git restore --pathspec-from-file --pathspec-file-nul`; only the capped display
+ * strings are decoded (lossy is fine — they're never used to match).
+ *
+ * `pathspecWorktree` excludes paths that don't exist in HEAD (pure adds and the new
+ * side of a rename/copy) so `git restore --worktree` never tries — and can't be
+ * asked — to delete them; they're left as untracked, preserving created content.
+ */
+function parsePorcelain(
+  buf: Buffer,
+  limit: number,
+): { dirtyFiles: string[]; dirtyCount: number; pathspecAll: Buffer; pathspecWorktree: Buffer } {
+  // split on NUL into field slices (drop a trailing empty field)
+  const fields: Buffer[] = [];
+  let start = 0;
+  for (let i = 0; i < buf.length; i++) {
+    if (buf[i] === NUL) {
+      fields.push(buf.subarray(start, i));
+      start = i + 1;
+    }
+  }
+  if (start < buf.length) fields.push(buf.subarray(start));
+
+  const dirtyFiles: string[] = [];
+  const allParts: Buffer[] = [];
+  const wtParts: Buffer[] = [];
+  const sep = Buffer.from([NUL]);
+  const pushSpec = (parts: Buffer[], p: Buffer) => {
+    parts.push(p, sep);
+  };
+
+  let dirtyCount = 0;
+  let i = 0;
+  while (i < fields.length) {
+    const rec = fields[i];
+    if (!rec || rec.length < 3) {
+      i++;
+      continue; // malformed / empty — skip
+    }
+    const x = String.fromCharCode(rec[0]!);
+    const status = rec.subarray(0, 2).toString("latin1");
+    const path = rec.subarray(3); // skip "XY "
+    const isRenameOrCopy = x === "R" || x === "C";
+    const orig = isRenameOrCopy ? fields[i + 1] : undefined;
+    i += isRenameOrCopy ? 2 : 1;
+
+    dirtyCount++;
+    if (dirtyFiles.length < limit) dirtyFiles.push(`${status} ${path.toString("utf8")}`);
+
+    if (isRenameOrCopy) {
+      pushSpec(allParts, path); // new side
+      if (orig) {
+        pushSpec(allParts, orig); // old side (in HEAD)
+        pushSpec(wtParts, orig); // restore the old path in the worktree
+      }
+      // new side is NOT in HEAD → left untracked, never worktree-restored
+    } else {
+      pushSpec(allParts, path);
+      if (x !== "A") pushSpec(wtParts, path); // pure adds aren't in HEAD → keep as untracked
+    }
+  }
+
+  return {
+    dirtyFiles,
+    dirtyCount,
+    pathspecAll: Buffer.concat(allParts),
+    pathspecWorktree: Buffer.concat(wtParts),
+  };
+}
 
 export interface UpdateStatus {
   /** how many commits the tracked branch is ahead of the running HEAD; 0 = up to date */
@@ -63,6 +179,32 @@ const EMPTY = (now: number): UpdateStatus => ({
 /** Runs git inside a fixed repo dir and returns stdout; injectable for tests. */
 export type GitRunner = (args: string[]) => Promise<string>;
 
+/** Runs git and returns raw stdout **bytes** (no UTF-8 decode), so a signature or
+ *  pathspec built from it is byte-exact even for non-UTF-8 paths. Injectable. */
+export type GitRawRunner = (args: string[]) => Promise<Buffer>;
+
+/** Streams a git command's stdout chunk-by-chunk into `hash` (never buffering the
+ *  whole output — so a huge `git diff --binary` can't overflow memory), returning
+ *  the byte count streamed. Must throw if it streamed more than `limit.maxBytes`
+ *  before completing or ran past `limit.timeoutMs`. Injectable for tests. */
+export type GitHashStreamer = (
+  args: string[],
+  hash: Hash,
+  limit: { maxBytes: number; timeoutMs: number },
+) => Promise<number>;
+
+/** Discard args passed through {@link UpdateService.apply} to the deploy launch. */
+export interface DiscardLaunch {
+  /** confirmed content signature the script re-verifies before restoring */
+  sig: string;
+  /** private temp dir holding the two pathspec files (script `trap`s its removal) */
+  dir: string;
+  /** file of NUL-joined pathspec bytes for `git restore --staged` */
+  pathspecAllFile: string;
+  /** file of NUL-joined pathspec bytes for `git restore --worktree` */
+  pathspecWtFile: string;
+}
+
 export interface UpdateDeps {
   /** repo to check; defaults to the service working dir (the live deployment) */
   repoDir?: string;
@@ -75,10 +217,18 @@ export interface UpdateDeps {
   logPath?: string;
   /** inject point for tests; defaults to real `git -C <repoDir> …` */
   git?: GitRunner;
+  /** inject point for tests; defaults to real `git -C <repoDir> …` returning bytes */
+  gitRaw?: GitRawRunner;
+  /** inject point for tests; defaults to streaming `git -C <repoDir> …` into a hash */
+  gitHashStream?: GitHashStreamer;
   /** inject point for tests; defaults to launching the deploy script detached */
-  launch?: () => void;
+  launch?: (discard?: DiscardLaunch) => void;
   /** cap the commit list shown in the UI */
   limit?: number;
+  /** cap the total signature bytes hashed before falling back to sig:null */
+  sigMaxBytes?: number;
+  /** timeout for the whole signature computation before falling back to sig:null */
+  sigTimeoutMs?: number;
 }
 
 /**
@@ -94,8 +244,12 @@ export class UpdateService {
   private scriptPath: string;
   private logPath: string;
   private git: GitRunner;
-  private launch: () => void;
+  private gitRaw: GitRawRunner;
+  private gitHashStream: GitHashStreamer;
+  private launch: (discard?: DiscardLaunch) => void;
   private limit: number;
+  private sigMaxBytes: number;
+  private sigTimeoutMs: number;
   private last: UpdateStatus | null = null;
   private applying = false;
 
@@ -105,6 +259,8 @@ export class UpdateService {
     this.scriptPath = deps.scriptPath ?? join(this.repoDir, "deploy", "update.sh");
     this.logPath = deps.logPath ?? join(tmpdir(), "shepherd-update.log");
     this.limit = deps.limit ?? 20;
+    this.sigMaxBytes = deps.sigMaxBytes ?? 64 * 1024 * 1024;
+    this.sigTimeoutMs = deps.sigTimeoutMs ?? 10_000;
     this.git =
       deps.git ??
       (async (args) => {
@@ -113,7 +269,59 @@ export class UpdateService {
         );
         return stdout as string;
       });
-    this.launch = deps.launch ?? (() => this.defaultLaunch());
+    this.gitRaw =
+      deps.gitRaw ??
+      (async (args) => {
+        const { stdout } = await execFileAsync("git", ["-C", this.repoDir, ...args], {
+          encoding: "buffer",
+          maxBuffer: this.sigMaxBytes,
+        });
+        return stdout as Buffer;
+      });
+    this.gitHashStream =
+      deps.gitHashStream ?? ((args, hash, limit) => this.streamGit(args, hash, limit));
+    this.launch = deps.launch ?? ((discard) => this.defaultLaunch(discard));
+  }
+
+  /** Default {@link GitHashStreamer}: spawn `git` and pipe stdout into `hash`,
+   *  aborting (kill + throw) once the running total exceeds the cap or the timeout
+   *  fires — so an enormous `--binary` diff never buffers or hangs the request. */
+  private streamGit(
+    args: string[],
+    hash: Hash,
+    limit: { maxBytes: number; timeoutMs: number },
+  ): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const child = spawn("git", ["-C", this.repoDir, ...args], {
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      let streamed = 0;
+      let done = false;
+      const finish = (err?: Error) => {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        if (err) {
+          child.kill("SIGKILL");
+          reject(err);
+        } else {
+          resolve(streamed);
+        }
+      };
+      const timer = setTimeout(() => finish(new Error("signature timed out")), limit.timeoutMs);
+      child.on("error", (e) => finish(e));
+      child.stdout.on("data", (chunk: Buffer) => {
+        streamed += chunk.length;
+        if (streamed > limit.maxBytes) {
+          finish(new Error("signature too large"));
+          return;
+        }
+        hash.update(chunk);
+      });
+      child.on("close", (code) =>
+        code === 0 ? finish() : finish(new Error(`git exited ${code}`)),
+      );
+    });
   }
 
   /** Launch the deploy script in its own transient systemd scope so it survives
@@ -124,7 +332,7 @@ export class UpdateService {
    *  the script returns, so a failed deploy (which never restarts shepherd) can
    *  be read back and shown to the operator instead of vanishing. Throws if the
    *  unit can't even be registered (e.g. systemd-run missing). */
-  private defaultLaunch(): void {
+  private defaultLaunch(discard?: DiscardLaunch): void {
     // truncate up front so the file exists immediately → readState() reports
     // "running" before the scope has had a chance to open it.
     writeFileSync(this.logPath, "");
@@ -132,9 +340,17 @@ export class UpdateService {
     // deploy script needs bun/herdr/git/systemctl, which live on the service's PATH.
     const args = ["--user", "--collect", "--unit=shepherd-update"];
     if (process.env.PATH) args.push(`--setenv=PATH=${process.env.PATH}`);
+    // A discard forwards the confirmed signature + the private pathspec dir so the
+    // script can re-verify the tree and restore ONLY the confirmed paths.
+    if (discard) {
+      args.push(`--setenv=SHEPHERD_DISCARD_SIG=${discard.sig}`);
+      args.push(`--setenv=SHEPHERD_DISCARD_DIR=${discard.dir}`);
+      args.push(`--setenv=SHEPHERD_DISCARD_PATHSPEC_ALL=${discard.pathspecAllFile}`);
+      args.push(`--setenv=SHEPHERD_DISCARD_PATHSPEC_WT=${discard.pathspecWtFile}`);
+    }
     const inner =
       `exec >${shq(this.logPath)} 2>&1; ` +
-      `bash ${shq(this.scriptPath)} --pull; ` +
+      `bash ${shq(this.scriptPath)} --pull${discard ? " --discard" : ""}; ` +
       `echo "${EXIT_MARKER}:$?"`;
     args.push("bash", "-c", inner);
     const r = spawnSync("systemd-run", args, {
@@ -164,7 +380,18 @@ export class UpdateService {
     if (m) {
       const exitCode = Number(m[1]);
       const log = tail(clean.replace(m[0], "").trimEnd());
-      return { phase: exitCode === 0 ? "done" : "failed", exitCode, log };
+      // Classify a failed deploy so the UI can route it through the friendly
+      // dirty-repo flow (fresh probe + refreshed list) instead of the raw log.
+      // The markers are stable English git/script output, never translated.
+      const reason =
+        exitCode === 0
+          ? null
+          : log.includes(DISCARD_STALE_MARKER)
+            ? "stale"
+            : log.includes(CLEAN_TREE_MARKER)
+              ? "dirty"
+              : null;
+      return { phase: exitCode === 0 ? "done" : "failed", exitCode, log, reason };
     }
     let mtimeMs = 0;
     try {
@@ -185,6 +412,64 @@ export class UpdateService {
   /** Last computed status, or null before the first check. */
   current(): UpdateStatus | null {
     return this.last;
+  }
+
+  /**
+   * Compute a **fresh** snapshot of the running deployment's tracked dirty state.
+   * Never cached (the tree changes underfoot), so both the proactive warning and
+   * the reactive failure path read the current truth.
+   *
+   * The `sig` is content-sensitive and framed: each of three git commands
+   * (status, staged diff, unstaged diff) is hashed independently, then the three
+   * fixed-length hex digests are hashed together — unambiguous, and the heavy
+   * `--binary` diffs stream (never buffered). All diff commands neutralise the
+   * repo's diff config (`--no-ext-diff --no-textconv`) so `sig` depends only on
+   * real content. If the diffs exceed the byte cap or timeout, `sig` is null and
+   * the caller must not offer a one-click discard.
+   */
+  async dirtyStatus(): Promise<DirtyStatus> {
+    // status: small + bounded → buffer it raw (bytes, not UTF-8) for parsing AND
+    // as the first signature input.
+    const statusBuf = await this.gitRaw(["status", "--porcelain", "-z", "--untracked-files=no"]);
+    const { dirtyFiles, dirtyCount, pathspecAll, pathspecWorktree } = parsePorcelain(
+      statusBuf,
+      this.limit,
+    );
+    const dirty = dirtyCount > 0;
+
+    let sig: string | null;
+    try {
+      const hStatus = createHash("sha256").update(statusBuf);
+      const hCached = createHash("sha256");
+      const hWt = createHash("sha256");
+      // shared byte budget across the two streamed diffs (status already counted)
+      let remaining = Math.max(0, this.sigMaxBytes - statusBuf.length);
+      const cachedArgs = [
+        "diff",
+        "--cached",
+        "--binary",
+        "--no-color",
+        "--no-ext-diff",
+        "--no-textconv",
+      ];
+      const wtArgs = ["diff", "--binary", "--no-color", "--no-ext-diff", "--no-textconv"];
+      remaining -= await this.gitHashStream(cachedArgs, hCached, {
+        maxBytes: remaining,
+        timeoutMs: this.sigTimeoutMs,
+      });
+      await this.gitHashStream(wtArgs, hWt, {
+        maxBytes: Math.max(0, remaining),
+        timeoutMs: this.sigTimeoutMs,
+      });
+      sig = createHash("sha256")
+        .update(hStatus.digest("hex") + hCached.digest("hex") + hWt.digest("hex"))
+        .digest("hex");
+    } catch {
+      // too large / timed out / git error → no signature; discard stays unavailable
+      sig = null;
+    }
+
+    return { dirty, dirtyFiles, dirtyCount, sig, pathspecAll, pathspecWorktree };
   }
 
   /** Fetch origin and recompute how far behind the tracked branch we are. On any
@@ -221,8 +506,15 @@ export class UpdateService {
   /** Kick off the detached deploy script. Guards against double-launch, but
    *  self-heals: once a prior deploy has finished (or crashed), the latch clears
    *  so a failed update can be retried. Returns `started: false` with a reason
-   *  the UI can surface verbatim — never a bare status code. */
-  apply(): { started: boolean; error?: string } {
+   *  the UI can surface verbatim — never a bare status code.
+   *
+   *  `opts.discard` forwards the confirmed signature + private pathspec dir so the
+   *  deploy runs a scoped `git restore` of only the confirmed paths (see
+   *  {@link DiscardLaunch}); throwing propagates so the caller can clean the dir up. */
+  apply(opts?: { discard?: boolean } & Partial<DiscardLaunch>): {
+    started: boolean;
+    error?: string;
+  } {
     // reconcile the in-process latch with the real deploy result: a terminal
     // deploy (done/failed) means we're free to launch again.
     const phase = this.applyState().phase;
@@ -234,10 +526,20 @@ export class UpdateService {
       };
     }
     this.applying = true;
+    const discard =
+      opts?.discard && opts.sig && opts.dir && opts.pathspecAllFile && opts.pathspecWtFile
+        ? {
+            sig: opts.sig,
+            dir: opts.dir,
+            pathspecAllFile: opts.pathspecAllFile,
+            pathspecWtFile: opts.pathspecWtFile,
+          }
+        : undefined;
     try {
-      this.launch();
+      this.launch(discard);
     } catch (e) {
       this.applying = false;
+      // never launched → the caller (server) removes the private pathspec dir it wrote
       return {
         started: false,
         error: e instanceof Error ? e.message : "could not launch the update",

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,5 +1,13 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, rmSync, existsSync, realpathSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  existsSync,
+  realpathSync,
+  statSync,
+  readFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
 import { stagingDir } from "../src/uploads";
@@ -1094,6 +1102,142 @@ test("GET /api/update/log returns the deploy state", async () => {
     exitCode: 1,
     log: "build failed: tsc error",
   });
+});
+
+// ── dirty-repo discard endpoints ───────────────────────────────────────────
+const BEHIND = { behind: 1, current: "a", latest: "b", commits: [], checkedAt: 1 };
+function dirtyFixture(sig: string | null) {
+  return {
+    dirty: true,
+    dirtyFiles: [" M a.ts"],
+    dirtyCount: 1,
+    sig,
+    pathspecAll: Buffer.from("a.ts\0"),
+    pathspecWorktree: Buffer.from("a.ts\0"),
+  };
+}
+function postUpdate(app: ReturnType<typeof makeApp>, body: unknown) {
+  return app.fetch(
+    new Request("http://x/api/update", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+test("POST /api/update rejects a non-boolean discard / non-string sig with 400", async () => {
+  const app = harnessWithUpdates({ current: () => BEHIND, apply: () => ({ started: true }) });
+  expect((await postUpdate(app, { discard: "yes" })).status).toBe(400);
+  expect((await postUpdate(app, { discard: true, sig: 1 })).status).toBe(400);
+});
+
+test("GET /api/update/dirty returns the fresh status with pathspec buffers stripped", async () => {
+  const app = harnessWithUpdates({
+    current: () => BEHIND,
+    apply: () => ({ started: true }),
+    dirtyStatus: async () => dirtyFixture("S"),
+  });
+  const res = await app.fetch(new Request("http://x/api/update/dirty"));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({
+    dirty: true,
+    dirtyFiles: [" M a.ts"],
+    dirtyCount: 1,
+    sig: "S",
+  });
+});
+
+test("discard when no update available → 409 with NO dirty probe / apply", async () => {
+  let probes = 0;
+  let applies = 0;
+  const app = harnessWithUpdates({
+    current: () => ({ behind: 0, current: "a", latest: "a", commits: [], checkedAt: 1 }),
+    apply: () => {
+      applies++;
+      return { started: true };
+    },
+    dirtyStatus: async () => {
+      probes++;
+      return dirtyFixture("S");
+    },
+  });
+  const res = await postUpdate(app, { discard: true, sig: "S" });
+  expect(res.status).toBe(409);
+  expect(probes).toBe(0); // no-update guard ran BEFORE any probe
+  expect(applies).toBe(0);
+});
+
+test("discard with a stale sig → 409 stale, apply not called", async () => {
+  let applies = 0;
+  const app = harnessWithUpdates({
+    current: () => BEHIND,
+    apply: () => {
+      applies++;
+      return { started: true };
+    },
+    dirtyStatus: async () => dirtyFixture("FRESH"),
+  });
+  const res = await postUpdate(app, { discard: true, sig: "STALE" });
+  expect(res.status).toBe(409);
+  expect((await res.json()).error).toBe("stale");
+  expect(applies).toBe(0);
+});
+
+test("discard with sig:null (too large) → 409, apply not called", async () => {
+  let applies = 0;
+  const app = harnessWithUpdates({
+    current: () => BEHIND,
+    apply: () => {
+      applies++;
+      return { started: true };
+    },
+    dirtyStatus: async () => dirtyFixture(null),
+  });
+  expect((await postUpdate(app, { discard: true, sig: "S" })).status).toBe(409);
+  expect(applies).toBe(0);
+});
+
+test("discard with a matching sig writes two 0600 pathspec files and launches", async () => {
+  let seen: { dir?: string; all?: string; wt?: string; allBytes?: Buffer; mode?: number } = {};
+  const app = harnessWithUpdates({
+    current: () => BEHIND,
+    apply: (opts?) => {
+      // capture what the server wrote, while the temp files still exist
+      seen = {
+        dir: opts?.dir,
+        all: opts?.pathspecAllFile,
+        wt: opts?.pathspecWtFile,
+        allBytes: opts?.pathspecAllFile ? readFileSync(opts.pathspecAllFile) : undefined,
+        mode: opts?.pathspecAllFile ? statSync(opts.pathspecAllFile).mode & 0o777 : undefined,
+      };
+      return { started: true };
+    },
+    dirtyStatus: async () => dirtyFixture("S"),
+  });
+  const res = await postUpdate(app, { discard: true, sig: "S" });
+  expect(res.status).toBe(202);
+  expect(seen.dir).toBeTruthy();
+  expect(seen.allBytes?.toString()).toBe("a.ts\0"); // byte-verbatim pathspec
+  expect(seen.mode).toBe(0o600); // private perms
+  // on success the server leaves the dir for update.sh's trap; clean it up here
+  if (seen.dir) rmSync(seen.dir, { recursive: true, force: true });
+});
+
+test("discard cleans up the private dir when the launch fails", async () => {
+  let capturedDir: string | undefined;
+  const app = harnessWithUpdates({
+    current: () => BEHIND,
+    apply: (opts?) => {
+      capturedDir = opts?.dir;
+      return { started: false, error: "a deploy is already running" };
+    },
+    dirtyStatus: async () => dirtyFixture("S"),
+  });
+  const res = await postUpdate(app, { discard: true, sig: "S" });
+  expect(res.status).toBe(409);
+  expect(capturedDir).toBeTruthy();
+  expect(existsSync(capturedDir!)).toBe(false); // dir removed, no orphaned pathspec
 });
 
 test("GET /api/update/log with no updater → idle", async () => {

--- a/test/update-dirty-sig-parity.test.ts
+++ b/test/update-dirty-sig-parity.test.ts
@@ -1,0 +1,106 @@
+import { test, expect } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { UpdateService } from "../src/update";
+
+// The Node signature (src/update.ts) and the update.sh signature must be byte-for-byte
+// identical, and both must depend only on real content (not on the repo's diff config).
+
+const HAVE_SHA256SUM = (() => {
+  try {
+    execFileSync("bash", ["-c", "command -v sha256sum"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+function git(repo: string, ...args: string[]): string {
+  return execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+}
+
+function newRepo(): string {
+  const repo = mkdtempSync(join(tmpdir(), "shepherd-parity-"));
+  git(repo, "init", "-q");
+  git(repo, "config", "user.email", "t@t");
+  git(repo, "config", "user.name", "t");
+  git(repo, "config", "commit.gpgsign", "false");
+  return repo;
+}
+
+/** The exact framed signature update.sh computes (three subhashes → hash the hex). */
+function shellSig(repo: string): string {
+  const script = [
+    `cd "${repo}"`,
+    `s1=$(git status --porcelain -z --untracked-files=no | sha256sum | cut -d' ' -f1)`,
+    `s2=$(git diff --cached --binary --no-color --no-ext-diff --no-textconv | sha256sum | cut -d' ' -f1)`,
+    `s3=$(git diff --binary --no-color --no-ext-diff --no-textconv | sha256sum | cut -d' ' -f1)`,
+    `printf '%s%s%s' "$s1" "$s2" "$s3" | sha256sum | cut -d' ' -f1`,
+  ].join("\n");
+  return execFileSync("bash", ["-c", script], { encoding: "utf8" }).trim();
+}
+
+async function nodeSig(repo: string): Promise<string | null> {
+  return (await new UpdateService({ repoDir: repo, launch: () => {} }).dirtyStatus()).sig;
+}
+
+test.if(HAVE_SHA256SUM)(
+  "Node signature matches the update.sh signature byte-for-byte",
+  async () => {
+    const repo = newRepo();
+    writeFileSync(join(repo, "a.txt"), "one\n");
+    writeFileSync(join(repo, "with space.txt"), "two\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-qm", "init");
+    writeFileSync(join(repo, "a.txt"), "one-EDIT\n"); // unstaged modify
+    writeFileSync(join(repo, "with space.txt"), "two-EDIT\n");
+    git(repo, "add", "with space.txt"); // staged modify
+
+    expect(await nodeSig(repo)).toBe(shellSig(repo));
+  },
+);
+
+test.if(HAVE_SHA256SUM)("signature changes on a content edit under the same status", async () => {
+  const repo = newRepo();
+  writeFileSync(join(repo, "f.txt"), "base\n");
+  git(repo, "add", "-A");
+  git(repo, "commit", "-qm", "init");
+
+  writeFileSync(join(repo, "f.txt"), "base\nedit1\n");
+  const status1 = git(repo, "status", "--porcelain");
+  const sig1 = await nodeSig(repo);
+  expect(sig1).toBe(shellSig(repo));
+
+  writeFileSync(join(repo, "f.txt"), "base\nedit1\nedit2\n"); // still ' M f.txt'
+  const status2 = git(repo, "status", "--porcelain");
+  const sig2 = await nodeSig(repo);
+  expect(sig2).toBe(shellSig(repo));
+
+  expect(status2).toBe(status1); // status unchanged…
+  expect(sig2).not.toBe(sig1); // …but the content signature moved
+});
+
+test.if(HAVE_SHA256SUM)(
+  "textconv/ext-diff config can't collapse or diverge the signature",
+  async () => {
+    const repo = newRepo();
+    // a textconv driver that maps ANY content to a constant + an external differ
+    writeFileSync(join(repo, ".gitattributes"), "*.dat diff=lossy\n");
+    git(repo, "config", "diff.lossy.textconv", "printf CONST");
+    git(repo, "config", "diff.external", "true");
+    writeFileSync(join(repo, "x.dat"), "AAAA\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-qm", "init");
+
+    writeFileSync(join(repo, "x.dat"), "AAAA-content-B\n");
+    const sigB = await nodeSig(repo);
+    expect(sigB).toBe(shellSig(repo)); // Node == shell despite the hostile config
+
+    writeFileSync(join(repo, "x.dat"), "AAAA-different-C\n"); // a textconv would collapse B and C
+    const sigC = await nodeSig(repo);
+    expect(sigC).toBe(shellSig(repo));
+    expect(sigC).not.toBe(sigB); // --no-textconv keeps distinct content distinct
+  },
+);

--- a/test/update-discard-scope.test.ts
+++ b/test/update-discard-scope.test.ts
@@ -1,0 +1,151 @@
+import { test, expect } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { UpdateService } from "../src/update";
+
+// Real-git integration: prove the scoped, path-limited discard restores exactly the
+// confirmed paths per category (modify / rename / add / non-UTF-8) and that pathspec
+// magic in a confirmed filename can't fan out to unconfirmed files.
+
+function git(repo: string, ...args: string[]): string {
+  return execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+}
+
+function newRepo(): string {
+  const repo = mkdtempSync(join(tmpdir(), "shepherd-scope-"));
+  git(repo, "init", "-q");
+  git(repo, "config", "user.email", "t@t");
+  git(repo, "config", "user.name", "t");
+  git(repo, "config", "commit.gpgsign", "false");
+  return repo;
+}
+
+/** Mirror update.sh's two-step scoped discard (with --literal-pathspecs). */
+function scopedDiscard(repo: string, all: Buffer, wt: Buffer): void {
+  const spec = mkdtempSync(join(tmpdir(), "shepherd-spec-"));
+  const allFile = join(spec, "all");
+  const wtFile = join(spec, "wt");
+  writeFileSync(allFile, all);
+  writeFileSync(wtFile, wt);
+  git(
+    repo,
+    "--literal-pathspecs",
+    "restore",
+    "--source=HEAD",
+    "--staged",
+    `--pathspec-from-file=${allFile}`,
+    "--pathspec-file-nul",
+  );
+  if (wt.length > 0)
+    git(
+      repo,
+      "--literal-pathspecs",
+      "restore",
+      "--source=HEAD",
+      "--worktree",
+      `--pathspec-from-file=${wtFile}`,
+      "--pathspec-file-nul",
+    );
+}
+
+/** Tracked tree is clean (what the --pull guard checks). */
+function trackedClean(repo: string): boolean {
+  return git(repo, "status", "--porcelain", "--untracked-files=no").trim() === "";
+}
+
+test("scoped discard leaves an UNCONFIRMED path dirty (last-window safety)", async () => {
+  const repo = newRepo();
+  writeFileSync(join(repo, "a.txt"), "a0\n");
+  writeFileSync(join(repo, "b.txt"), "b0\n");
+  git(repo, "add", "-A");
+  git(repo, "commit", "-qm", "init");
+
+  // confirm only a.txt
+  writeFileSync(join(repo, "a.txt"), "a-EDIT\n");
+  const confirmed = await new UpdateService({ repoDir: repo, launch: () => {} }).dirtyStatus();
+
+  // AFTER confirmation, an unconfirmed change to b.txt appears
+  writeFileSync(join(repo, "b.txt"), "b-EDIT\n");
+
+  scopedDiscard(repo, confirmed.pathspecAll, confirmed.pathspecWorktree);
+
+  expect(readFileSync(join(repo, "a.txt"), "utf8")).toBe("a0\n"); // confirmed → restored
+  expect(readFileSync(join(repo, "b.txt"), "utf8")).toBe("b-EDIT\n"); // unconfirmed → untouched
+  // A blanket `git reset --hard` would have wiped b.txt too.
+});
+
+test("staged rename: tracked state fully restored (both sides in pathspec)", async () => {
+  const repo = newRepo();
+  writeFileSync(join(repo, "a.txt"), "hi\n");
+  git(repo, "add", "-A");
+  git(repo, "commit", "-qm", "init");
+  git(repo, "mv", "a.txt", "b.txt");
+
+  const d = await new UpdateService({ repoDir: repo, launch: () => {} }).dirtyStatus();
+  scopedDiscard(repo, d.pathspecAll, d.pathspecWorktree);
+
+  expect(trackedClean(repo)).toBe(true); // rename undone at the tracked level
+  expect(readFileSync(join(repo, "a.txt"), "utf8")).toBe("hi\n"); // old path back
+  // b.txt (the new side) is allowed to linger as untracked — non-destructive
+});
+
+test("staged add is preserved as an untracked file (never deleted)", async () => {
+  const repo = newRepo();
+  writeFileSync(join(repo, "base.txt"), "base\n");
+  git(repo, "add", "-A");
+  git(repo, "commit", "-qm", "init");
+  writeFileSync(join(repo, "created.txt"), "my work\n");
+  git(repo, "add", "created.txt");
+
+  const d = await new UpdateService({ repoDir: repo, launch: () => {} }).dirtyStatus();
+  scopedDiscard(repo, d.pathspecAll, d.pathspecWorktree);
+
+  expect(trackedClean(repo)).toBe(true); // guard passes (untracked doesn't block)
+  expect(existsSync(join(repo, "created.txt"))).toBe(true);
+  expect(readFileSync(join(repo, "created.txt"), "utf8")).toBe("my work\n"); // content kept
+  expect(git(repo, "status", "--porcelain")).toContain("?? created.txt"); // now untracked
+});
+
+test("non-UTF-8 path is restored via the byte-verbatim pathspec", async () => {
+  const repo = newRepo();
+  // a real 0xff byte in the filename → only expressible as a Buffer path (a
+  // string round-trip would re-encode it as UTF-8 and defeat the test)
+  const fullPath = Buffer.concat([
+    Buffer.from(`${repo}/`, "utf8"),
+    Buffer.from([0x66, 0x6f, 0x6f, 0xff, 0x2e, 0x74, 0x78, 0x74]),
+  ]);
+  writeFileSync(fullPath, "orig\n");
+  git(repo, "add", "-A");
+  git(repo, "commit", "-qm", "init");
+  writeFileSync(fullPath, "changed\n");
+
+  const d = await new UpdateService({ repoDir: repo, launch: () => {} }).dirtyStatus();
+  // the raw pathspec must carry the 0xff byte verbatim (a lossy string would drop it)
+  expect(d.pathspecAll.includes(0xff)).toBe(true);
+  scopedDiscard(repo, d.pathspecAll, d.pathspecWorktree);
+
+  expect(trackedClean(repo)).toBe(true);
+  expect(readFileSync(fullPath, "utf8")).toBe("orig\n");
+});
+
+test("pathspec magic in a confirmed filename stays literal (no fan-out)", async () => {
+  const repo = newRepo();
+  writeFileSync(join(repo, "*.ts"), "star0\n"); // a file literally named *.ts
+  writeFileSync(join(repo, "other.ts"), "other0\n");
+  git(repo, "add", "-A");
+  git(repo, "commit", "-qm", "init");
+
+  // confirm ONLY the literal "*.ts"
+  writeFileSync(join(repo, "*.ts"), "star-EDIT\n");
+  const confirmed = await new UpdateService({ repoDir: repo, launch: () => {} }).dirtyStatus();
+
+  // an unconfirmed sibling that a *.ts GLOB would match becomes dirty afterwards
+  writeFileSync(join(repo, "other.ts"), "other-EDIT\n");
+
+  scopedDiscard(repo, confirmed.pathspecAll, confirmed.pathspecWorktree);
+
+  expect(readFileSync(join(repo, "*.ts"), "utf8")).toBe("star0\n"); // literal restored
+  expect(readFileSync(join(repo, "other.ts"), "utf8")).toBe("other-EDIT\n"); // NOT matched
+});

--- a/test/update-sh-discard.test.ts
+++ b/test/update-sh-discard.test.ts
@@ -1,0 +1,183 @@
+import { test, expect } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Executable harness: run the REAL deploy/update.sh with stub git/bun/systemctl on
+// PATH (so nothing touches the host), and assert on the recorded git calls. Proves
+// the flag parsing, the scoped `git restore` (never `git reset --hard`), the token
+// requirement, the framed stale-guard, and the trap cleanup.
+
+const REPO = join(import.meta.dir, "..");
+const SCRIPT = join(REPO, "deploy", "update.sh");
+
+// Fixed stub outputs for the signature commands; the matching sig is their framing.
+// (No NUL here — a JS "\0" would be a real NUL, but a literal \0 inside the bash
+// stub, so they'd never hash equal; NUL parsing is covered by the real-git tests.)
+const STATUS = " M a.ts";
+const CACHED = "CACHED-DIFF";
+const WT = "WT-DIFF";
+const sub = (s: string) => createHash("sha256").update(s).digest("hex");
+const GOOD_SIG = createHash("sha256")
+  .update(sub(STATUS) + sub(CACHED) + sub(WT))
+  .digest("hex");
+
+function makeStubs(): string {
+  const bin = mkdtempSync(join(tmpdir(), "shepherd-stub-bin-"));
+  const gitlog = join(bin, "git.log");
+  const git = `#!/usr/bin/env bash
+echo "git $*" >> "${gitlog}"
+sub="$1"; [ "$sub" = "--literal-pathspecs" ] && sub="$2"
+case "$sub" in
+  rev-parse) echo "\${STUB_BRANCH:-main}" ;;
+  status) printf '%s' "${STATUS}" ;;
+  diff)
+    for a in "$@"; do [ "$a" = "--quiet" ] && exit 0; done
+    if printf '%s\\n' "$@" | grep -q -- '--cached'; then printf '%s' "${CACHED}"; else printf '%s' "${WT}"; fi ;;
+esac
+exit 0
+`;
+  writeFileSync(join(bin, "git"), git);
+  chmodSync(join(bin, "git"), 0o755);
+  // stub bun: no-op for install/build; stub systemctl: present but --user unavailable
+  writeFileSync(join(bin, "bun"), "#!/usr/bin/env bash\nexit 0\n");
+  chmodSync(join(bin, "bun"), 0o755);
+  writeFileSync(
+    join(bin, "systemctl"),
+    '#!/usr/bin/env bash\n[ "$1" = "--user" ] && [ "$2" = "show-environment" ] && exit 1\nexit 0\n',
+  );
+  chmodSync(join(bin, "systemctl"), 0o755);
+  return bin;
+}
+
+function makeDiscardDir(wtContent: string): {
+  dir: string;
+  all: string;
+  wt: string;
+} {
+  const dir = mkdtempSync(join(tmpdir(), "shepherd-discard-"));
+  const all = join(dir, "all");
+  const wt = join(dir, "wt");
+  writeFileSync(all, "a.ts\0");
+  writeFileSync(wt, wtContent);
+  return { dir, all, wt };
+}
+
+type RunOpts = {
+  args?: string[];
+  branch?: string;
+  sig?: string | null;
+  dir?: string | null;
+  all?: string | null;
+  wt?: string | null;
+};
+
+function run(bin: string, opts: RunOpts = {}): { code: number; git: string } {
+  const gitlog = join(bin, "git.log");
+  writeFileSync(gitlog, "");
+  const env: Record<string, string> = {
+    ...process.env,
+    PATH: `${bin}:${process.env.PATH}`,
+    STUB_BRANCH: opts.branch ?? "main",
+  };
+  if (opts.sig != null) env.SHEPHERD_DISCARD_SIG = opts.sig;
+  if (opts.dir != null) env.SHEPHERD_DISCARD_DIR = opts.dir;
+  if (opts.all != null) env.SHEPHERD_DISCARD_PATHSPEC_ALL = opts.all;
+  if (opts.wt != null) env.SHEPHERD_DISCARD_PATHSPEC_WT = opts.wt;
+  let code = 0;
+  try {
+    execFileSync("bash", [SCRIPT, ...(opts.args ?? [])], { env, stdio: "ignore" });
+  } catch (e) {
+    code = (e as { status?: number }).status ?? 1;
+  }
+  return { code, git: readFileSync(gitlog, "utf8") };
+}
+
+function discardRun(bin: string, over: Partial<RunOpts> = {}) {
+  const { dir, all, wt } = makeDiscardDir("from.ts\0");
+  return {
+    ...run(bin, { args: ["--pull", "--discard"], sig: GOOD_SIG, dir, all, wt, ...over }),
+    dir,
+  };
+}
+
+test("discard runs a scoped git restore and NEVER git reset --hard", () => {
+  const bin = makeStubs();
+  const { code, git } = discardRun(bin);
+  expect(code).toBe(0);
+  expect(git).not.toContain("reset --hard");
+  expect(git).toContain("restore --source=HEAD --staged --pathspec-from-file=");
+  expect(git).toContain("--pathspec-file-nul");
+  expect(git).toContain("--literal-pathspecs");
+  expect(git).toContain("pull --ff-only");
+});
+
+test("--discard --pull (reversed order) also discards", () => {
+  const bin = makeStubs();
+  const { dir, all, wt } = makeDiscardDir("from.ts\0");
+  const { code, git } = run(bin, { args: ["--discard", "--pull"], sig: GOOD_SIG, dir, all, wt });
+  expect(code).toBe(0);
+  expect(git).toContain("restore --source=HEAD --staged");
+});
+
+test("--pull without --discard performs no restore", () => {
+  const bin = makeStubs();
+  const { code, git } = run(bin, { args: ["--pull"] });
+  expect(code).toBe(0);
+  expect(git).not.toContain("restore");
+});
+
+test("--discard without --pull performs no restore (discard lives in the pull block)", () => {
+  const bin = makeStubs();
+  const { dir, all, wt } = makeDiscardDir("from.ts\0");
+  const { code, git } = run(bin, { args: ["--discard"], sig: GOOD_SIG, dir, all, wt });
+  expect(code).toBe(0);
+  expect(git).not.toContain("restore");
+});
+
+test("empty worktree pathspec → only the --staged restore runs", () => {
+  const bin = makeStubs();
+  const { code, git } = discardRun(bin, { wt: (() => makeDiscardDir("").wt)() });
+  expect(code).toBe(0);
+  expect(git).toContain("restore --source=HEAD --staged");
+  expect(git).not.toContain("restore --source=HEAD --worktree");
+});
+
+test("discard on a non-main branch aborts with no restore", () => {
+  const bin = makeStubs();
+  const { code, git } = discardRun(bin, { branch: "feature" });
+  expect(code).not.toBe(0);
+  expect(git).not.toContain("restore");
+});
+
+test("missing any confirmation token aborts with no restore", () => {
+  const bin = makeStubs();
+  for (const drop of ["sig", "dir", "all", "wt"] as const) {
+    const { code, git } = discardRun(bin, { [drop]: null } as Partial<RunOpts>);
+    expect(code).not.toBe(0);
+    expect(git).not.toContain("restore");
+  }
+});
+
+test("stale/content-drifted signature aborts with no restore, and the trap cleans up", () => {
+  const bin = makeStubs();
+  const { code, git, dir } = discardRun(bin, { sig: "deadbeef" });
+  expect(code).not.toBe(0);
+  expect(git).not.toContain("restore");
+  expect(existsSync(dir)).toBe(false); // trap rm -rf'd the private dir
+});
+
+test("matching signature discards AND the trap removes the private dir on success", () => {
+  const bin = makeStubs();
+  const { code, dir } = discardRun(bin);
+  expect(code).toBe(0);
+  expect(existsSync(dir)).toBe(false);
+});
+
+// belt-and-suspenders alignment with the macOS restart test's assumption
+test("the deploy script never invokes an unguarded restart at column 0", () => {
+  const src = readFileSync(SCRIPT, "utf8");
+  expect(src.split("\n").filter((l) => /^systemctl --user restart/.test(l))).toEqual([]);
+});

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -1,8 +1,15 @@
 import { test, expect } from "bun:test";
 import { mkdtempSync, writeFileSync } from "node:fs";
+import { createHash, type Hash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { UpdateService, type GitRunner } from "../src/update";
+import {
+  UpdateService,
+  type DiscardLaunch,
+  type GitHashStreamer,
+  type GitRawRunner,
+  type GitRunner,
+} from "../src/update";
 
 /** A logPath guaranteed not to exist, so applyState() reads "idle". */
 function freshLog(): string {
@@ -173,4 +180,164 @@ test("apply() retries after a previous deploy failed (latch self-heals)", () => 
   writeFileSync(logPath, "boom\n__SHEPHERD_UPDATE_EXIT__:1\n");
   expect(svc.apply().started).toBe(true); // not stuck — retry is allowed
   expect(launches).toBe(2);
+});
+
+// ── dirtyStatus() + discard ──────────────────────────────────────────────────
+
+const NUL = "\0";
+/** Expected framed signature: three per-command subhashes, then hash their hex. */
+function frameSig(status: Buffer, cached: Buffer, wt: Buffer): string {
+  const h = (b: Buffer) => createHash("sha256").update(b).digest("hex");
+  return createHash("sha256")
+    .update(h(status) + h(cached) + h(wt))
+    .digest("hex");
+}
+
+/** Build a service whose signature inputs are fixed fixtures (status via gitRaw,
+ *  the two diffs via gitHashStream). `streamThrows` simulates the cap/timeout. */
+function dirtySvc(opts: { status: Buffer; cached?: Buffer; wt?: Buffer; streamThrows?: boolean }) {
+  const cached = opts.cached ?? Buffer.alloc(0);
+  const wt = opts.wt ?? Buffer.alloc(0);
+  const gitRaw: GitRawRunner = async () => opts.status;
+  const gitHashStream: GitHashStreamer = async (args, hash: Hash) => {
+    if (opts.streamThrows) throw new Error("signature too large");
+    const buf = args.includes("--cached") ? cached : wt;
+    hash.update(buf);
+    return buf.length;
+  };
+  return new UpdateService({ git: fakeGit(UP_TO_DATE), launch: () => {}, gitRaw, gitHashStream });
+}
+
+test("dirtyStatus(): clean tree → not dirty, sig of empty streams", async () => {
+  const svc = dirtySvc({ status: Buffer.alloc(0) });
+  const s = await svc.dirtyStatus();
+  expect(s.dirty).toBe(false);
+  expect(s.dirtyCount).toBe(0);
+  expect(s.dirtyFiles).toEqual([]);
+  expect(s.sig).toBe(frameSig(Buffer.alloc(0), Buffer.alloc(0), Buffer.alloc(0)));
+  expect(s.pathspecAll.length).toBe(0);
+  expect(s.pathspecWorktree.length).toBe(0);
+});
+
+test("dirtyStatus(): parses modify/add/rename into the two pathspecs", async () => {
+  // ' M mod.ts'  (in HEAD → worktree),  'A  add.ts' (pure add → NOT worktree),
+  // 'R  to.ts\0from.ts' (both sides in All; only the old side in Worktree)
+  const status = Buffer.from(` M mod.ts${NUL}A  add.ts${NUL}R  to.ts${NUL}from.ts${NUL}`, "utf8");
+  const s = await dirtySvc({ status }).dirtyStatus();
+  expect(s.dirty).toBe(true);
+  expect(s.dirtyCount).toBe(3); // three entries (rename is one)
+  expect(s.dirtyFiles).toEqual([" M mod.ts", "A  add.ts", "R  to.ts"]);
+  // pathspecAll: mod.ts, add.ts, to.ts (new), from.ts (old)
+  expect(s.pathspecAll.toString("utf8")).toBe(`mod.ts${NUL}add.ts${NUL}to.ts${NUL}from.ts${NUL}`);
+  // pathspecWorktree: mod.ts, from.ts — excludes the pure add and the rename's new side
+  expect(s.pathspecWorktree.toString("utf8")).toBe(`mod.ts${NUL}from.ts${NUL}`);
+});
+
+test("dirtyStatus(): sig is content-sensitive — same status, different diff → different sig", async () => {
+  const status = Buffer.from(` M a.ts${NUL}`, "utf8");
+  // A pure status signature would MATCH here (status bytes identical); the framed
+  // content signature must differ because the unstaged diff content differs.
+  const s1 = await dirtySvc({ status, wt: Buffer.from("diff v1") }).dirtyStatus();
+  const s2 = await dirtySvc({ status, wt: Buffer.from("diff v2") }).dirtyStatus();
+  expect(s1.sig).not.toBe(s2.sig);
+  expect(s1.sig).toBe(frameSig(status, Buffer.alloc(0), Buffer.from("diff v1")));
+});
+
+test("dirtyStatus(): dirtyFiles cap + total count", async () => {
+  const entries = Array.from({ length: 25 }, (_, i) => ` M f${i}.ts`).join(NUL) + NUL;
+  const s = await new UpdateService({
+    git: fakeGit(UP_TO_DATE),
+    launch: () => {},
+    limit: 20,
+    gitRaw: async () => Buffer.from(entries, "utf8"),
+    gitHashStream: async () => 0,
+  }).dirtyStatus();
+  expect(s.dirtyCount).toBe(25);
+  expect(s.dirtyFiles.length).toBe(20); // capped for display
+});
+
+test("dirtyStatus(): cap/timeout → sig null but still dirty + counted", async () => {
+  const status = Buffer.from(` M big.bin${NUL}`, "utf8");
+  const s = await dirtySvc({ status, streamThrows: true }).dirtyStatus();
+  expect(s.dirty).toBe(true);
+  expect(s.dirtyCount).toBe(1);
+  expect(s.sig).toBeNull(); // friendly fallback: no one-click discard
+});
+
+test("applyState() classifies dirty / stale reasons from the deploy log", () => {
+  const dirtyLog = freshLog();
+  const svcDirty = new UpdateService({
+    git: fakeGit(UP_TO_DATE),
+    logPath: dirtyLog,
+    launch: () => {},
+  });
+  writeFileSync(dirtyLog, "✗ --pull needs a clean tree\n__SHEPHERD_UPDATE_EXIT__:1\n");
+  expect(svcDirty.applyState().reason).toBe("dirty");
+
+  const staleLog = freshLog();
+  const svcStale = new UpdateService({
+    git: fakeGit(UP_TO_DATE),
+    logPath: staleLog,
+    launch: () => {},
+  });
+  writeFileSync(
+    staleLog,
+    "✗ SHEPHERD_DISCARD_STALE: working tree changed\n__SHEPHERD_UPDATE_EXIT__:1\n",
+  );
+  expect(svcStale.applyState().reason).toBe("stale");
+
+  const otherLog = freshLog();
+  const svcOther = new UpdateService({
+    git: fakeGit(UP_TO_DATE),
+    logPath: otherLog,
+    launch: () => {},
+  });
+  writeFileSync(otherLog, "✗ tsc error\n__SHEPHERD_UPDATE_EXIT__:1\n");
+  expect(svcOther.applyState().reason).toBeNull();
+});
+
+test("apply({discard}) forwards the confirmation tokens to launch", () => {
+  const discardLaunches: DiscardLaunch[] = [];
+  let plainLaunches = 0;
+  const svc = new UpdateService({
+    git: fakeGit(UP_TO_DATE),
+    logPath: freshLog(),
+    launch: (d) => {
+      if (d) discardLaunches.push(d);
+      else plainLaunches++;
+    },
+  });
+  const r = svc.apply({
+    discard: true,
+    sig: "SIG",
+    dir: "/tmp/d",
+    pathspecAllFile: "/tmp/d/all",
+    pathspecWtFile: "/tmp/d/worktree",
+  });
+  expect(r.started).toBe(true);
+  expect(discardLaunches).toEqual([
+    {
+      sig: "SIG",
+      dir: "/tmp/d",
+      pathspecAllFile: "/tmp/d/all",
+      pathspecWtFile: "/tmp/d/worktree",
+    },
+  ]);
+  expect(plainLaunches).toBe(0);
+});
+
+test("apply() without discard opts launches plainly (no discard forwarded)", () => {
+  const discardLaunches: DiscardLaunch[] = [];
+  let plain = 0;
+  const svc = new UpdateService({
+    git: fakeGit(UP_TO_DATE),
+    logPath: freshLog(),
+    launch: (d) => {
+      if (d) discardLaunches.push(d);
+      else plain++;
+    },
+  });
+  expect(svc.apply().started).toBe(true);
+  expect(discardLaunches).toEqual([]);
+  expect(plain).toBe(1);
 });

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3181,5 +3181,17 @@
   "settings_role_model_merge_suggest_title": "Learnings-Merge-Suggester",
   "settings_role_model_merge_suggest_hint": "Konsolidiert überschneidende Learnings-Regeln innerhalb und über Repositorys hinweg.",
   "feat_merge_suggester_provider_title": "Kosten des Merge-Suggesters steuern",
-  "feat_merge_suggester_provider_body": "Wähle CLI, Modell und Aufwand des Learnings-Merge-Suggesters."
+  "feat_merge_suggester_provider_body": "Wähle CLI, Modell und Aufwand des Learnings-Merge-Suggesters.",
+  "updatemodal_dirty_title": "Lokale Änderungen blockieren das Update",
+  "updatemodal_dirty_body": "Du hast nicht committete Änderungen im Repo, in dem Shepherd läuft — deshalb kann die neue Version nicht sauber geholt werden. Verwirf deine Änderungen, um zu aktualisieren, oder lass sie stehen und aktualisiere später, nachdem du sie selbst committet hast.",
+  "updatemodal_dirty_files_head": "Geänderte Dateien",
+  "updatemodal_dirty_files_more": "… und {count} weitere",
+  "updatemodal_discard_and_update": "Verwerfen & aktualisieren",
+  "updatemodal_discard_confirm": "{count} getrackte Änderung(en) auf den letzten Commit zurücksetzen? Bearbeitungen an vorhandenen Dateien gehen verloren; neu hinzugefügte Dateien werden nicht gelöscht — sie bleiben als ungetrackte Dateien liegen.",
+  "updatemodal_discard_confirm_yes": "Ja, zurücksetzen",
+  "updatemodal_now_clean": "Der Baum ist jetzt sauber — versuche das Update erneut.",
+  "updatemodal_dirty_stale": "Die Änderungen haben sich seit der Anzeige geändert — bitte prüfe die aktualisierte Liste und bestätige erneut.",
+  "updatemodal_dirty_too_large": "Die Änderungen sind zu groß, um sie für einen Ein-Klick-Discard sicher zu prüfen — bitte committe oder verwirf sie manuell.",
+  "feat_safe_update_dirty_repo_title": "Update bei „dirty\" Repo, erklärt",
+  "feat_safe_update_dirty_repo_body": "Wenn ein Update nicht laufen kann, weil du nicht committete Änderungen im Repo hast, in dem Shepherd läuft, erklärt der Update-Dialog das jetzt in Klartext und listet die geänderten Dateien. Du kannst genau diese Änderungen verwerfen und mit einem Klick aktualisieren — oder sie stehen lassen und später aktualisieren. Neu hinzugefügte Dateien bleiben immer erhalten."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3181,5 +3181,17 @@
   "settings_role_model_merge_suggest_title": "Learnings Merge Suggester",
   "settings_role_model_merge_suggest_hint": "Consolidates overlapping Learnings rules within and across repositories.",
   "feat_merge_suggester_provider_title": "Control Merge Suggester cost",
-  "feat_merge_suggester_provider_body": "Choose the Learnings Merge Suggester CLI, model, and effort."
+  "feat_merge_suggester_provider_body": "Choose the Learnings Merge Suggester CLI, model, and effort.",
+  "updatemodal_dirty_title": "Local changes are blocking the update",
+  "updatemodal_dirty_body": "You have uncommitted changes in the repo where Shepherd runs, so it can't pull the new version cleanly. Discard your changes to update, or leave them and update later after committing them yourself.",
+  "updatemodal_dirty_files_head": "Changed files",
+  "updatemodal_dirty_files_more": "… and {count} more",
+  "updatemodal_discard_and_update": "Discard & update",
+  "updatemodal_discard_confirm": "Reset {count} tracked change(s) to the last commit? Edits to existing files are lost; newly added files aren't deleted — they stay as untracked files.",
+  "updatemodal_discard_confirm_yes": "Yes, reset",
+  "updatemodal_now_clean": "The tree is clean now — try the update again.",
+  "updatemodal_dirty_stale": "The changes shifted since they were shown — review the updated list and confirm again.",
+  "updatemodal_dirty_too_large": "The changes are too large to verify safely for a one-click discard — please commit or discard them manually.",
+  "feat_safe_update_dirty_repo_title": "Updating a dirty repo, explained",
+  "feat_safe_update_dirty_repo_body": "When an update can't run because you have uncommitted changes in the repo where Shepherd runs, the update dialog now explains it in plain language and lists the changed files. You can discard exactly those changes and update in one click, or leave them and update later — newly added files are always kept."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -22,6 +22,7 @@ import type {
   ScratchListing,
   UpdateStatus,
   DeployState,
+  DirtyStatus,
   HerdrUpdateStatus,
   CodexUpdateStatus,
   DiagnosticsSnapshot,
@@ -1352,6 +1353,24 @@ export async function getUpdateLog(): Promise<DeployState> {
   return r.json();
 }
 
+/** Fresh dirty snapshot of the running deployment's repo (never cached), so the
+ *  update modal can warn before a discard and re-check after a stale failure. */
+export async function getUpdateDirty(): Promise<DirtyStatus> {
+  const r = await fetch("/api/update/dirty");
+  if (!r.ok) throw await failed(r, "update dirty status");
+  return r.json();
+}
+
+/** Thrown by {@link applyUpdate} when the server rejects a discard because the
+ *  tree drifted from what the operator confirmed (HTTP 409 `stale`). Carries the
+ *  fresh {@link DirtyStatus} so the modal can re-render and ask for re-confirmation. */
+export class StaleDirtyError extends Error {
+  constructor(readonly dirty: DirtyStatus) {
+    super("stale");
+    this.name = "StaleDirtyError";
+  }
+}
+
 /** Current herdr-version update status (whether a newer herdr exists). */
 export async function getHerdrUpdate(): Promise<HerdrUpdateStatus> {
   const r = await fetch("/api/herdr-update");
@@ -1572,12 +1591,25 @@ export async function triggerRestart(opts: {
   return { ok: false, error: typeof body.error === "string" ? body.error : "restart_failed" };
 }
 
-/** Trigger the deploy script (pull → rebuild → restart). Server restarts on success. */
-export async function applyUpdate(): Promise<void> {
-  const r = await fetch("/api/update", { method: "POST", headers: JSON_HEADERS });
+/** Trigger the deploy script (pull → rebuild → restart). Server restarts on success.
+ *  `discard` runs a scoped `git restore` of the confirmed dirty paths first; `sig`
+ *  is the signature of the dirty state the operator confirmed. On a 409 `stale`
+ *  response (tree drifted since confirmation) throws {@link StaleDirtyError} with
+ *  the fresh dirty status so the modal can re-render + re-confirm. */
+export async function applyUpdate(discard = false, sig?: string): Promise<void> {
+  const r = await fetch("/api/update", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify(discard ? { discard, sig } : {}),
+  });
   if (!r.ok) {
-    const msg = await r.json().catch(() => ({ error: `${r.status}` }));
-    throw apiError(r.status, msg as { error?: string }, `error ${r.status}`);
+    const msg = (await r.json().catch(() => ({ error: `${r.status}` }))) as {
+      error?: string;
+      dirty?: DirtyStatus;
+    };
+    if (r.status === 409 && msg.error === "stale" && msg.dirty)
+      throw new StaleDirtyError(msg.dirty);
+    throw apiError(r.status, msg, `error ${r.status}`);
   }
 }
 

--- a/ui/src/lib/components/UpdateModal.browser.test.ts
+++ b/ui/src/lib/components/UpdateModal.browser.test.ts
@@ -2,14 +2,28 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
-import type { DeployState, UpdateStatus } from "$lib/types";
+import type { DeployState, DirtyStatus, UpdateStatus } from "$lib/types";
 
 vi.mock("$lib/api", async (orig) => ({
   ...((await orig()) as object),
   applyUpdate: vi.fn(() => new Promise(() => {})),
+  getUpdateDirty: vi.fn(async () => ({ dirty: false, dirtyFiles: [], dirtyCount: 0, sig: null })),
 }));
 
 import UpdateModal from "./UpdateModal.svelte";
+import { applyUpdate, getUpdateDirty } from "$lib/api";
+
+const mockApply = applyUpdate as unknown as ReturnType<typeof vi.fn>;
+const mockDirty = getUpdateDirty as unknown as ReturnType<typeof vi.fn>;
+const DIRTY = (over: Partial<DirtyStatus> = {}): DirtyStatus => ({
+  dirty: true,
+  dirtyFiles: [" M src/a.ts"],
+  dirtyCount: 1,
+  sig: "SIG-1",
+  ...over,
+});
+const btn = (re: RegExp) =>
+  [...document.querySelectorAll("button")].find((b) => re.test(b.textContent ?? ""));
 
 const update: UpdateStatus = {
   behind: 1,
@@ -34,6 +48,10 @@ const deploy: DeployState = {
 afterEach(async () => {
   document.body.innerHTML = "";
   vi.restoreAllMocks();
+  mockApply.mockReset();
+  mockApply.mockImplementation(() => new Promise(() => {}));
+  mockDirty.mockReset();
+  mockDirty.mockResolvedValue({ dirty: false, dirtyFiles: [], dirtyCount: 0, sig: null });
   await page.viewport(1280, 900);
 });
 
@@ -204,5 +222,75 @@ describe("UpdateModal", () => {
     expect(getComputedStyle(actor!).animationName).toBe("none");
     expect(flock!.querySelectorAll('[data-flock-actor="sheep"]').length).toBeGreaterThan(1);
     expect(flock!.querySelector("[data-sheep-body]")).not.toBeNull();
+  });
+
+  // ── dirty-repo flow ────────────────────────────────────────────────────────
+
+  it("discard is two-click: the first arms only, the second sends the displayed sig", async () => {
+    mockDirty.mockResolvedValue(DIRTY({ sig: "SIG-1" }));
+    mockApply.mockResolvedValue(undefined);
+    render(UpdateModal, { props: { update, updating: false, deploy: null } });
+
+    // proactive probe resolves → the discard button appears
+    await vi.waitFor(() => expect(btn(/discard & update/i)).toBeTruthy());
+    expect(document.body.textContent).toContain("src/a.ts"); // changed-file list
+
+    btn(/discard & update/i)!.click(); // FIRST click: arm only
+    await vi.waitFor(() => expect(btn(/yes, reset/i)).toBeTruthy());
+    expect(mockApply).not.toHaveBeenCalled(); // no API call yet
+
+    btn(/yes, reset/i)!.click(); // SECOND click: send
+    await vi.waitFor(() => expect(mockApply).toHaveBeenCalledTimes(1));
+    expect(mockApply).toHaveBeenCalledWith(true, "SIG-1");
+  });
+
+  it("a failed dirty probe falls back to an enabled Update now (never a stuck button)", async () => {
+    mockDirty.mockRejectedValue(new Error("network"));
+    render(UpdateModal, { props: { update, updating: false, deploy: null } });
+
+    await vi.waitFor(() => {
+      const b = btn(/update now/i);
+      expect(b).toBeTruthy();
+      expect((b as HTMLButtonElement).disabled).toBe(false);
+    });
+    expect(btn(/discard & update/i)).toBeFalsy();
+  });
+
+  it("too-large (sig:null) offers no discard button, just the manual hint", async () => {
+    mockDirty.mockResolvedValue(DIRTY({ sig: null }));
+    render(UpdateModal, { props: { update, updating: false, deploy: null } });
+
+    await vi.waitFor(() => expect(document.body.textContent).toContain("src/a.ts"));
+    expect(btn(/discard & update/i)).toBeFalsy();
+    expect(document.body.textContent).toContain("too large");
+  });
+
+  it("a reactive stale failure shows the refreshed list + re-confirm, not the raw log", async () => {
+    mockDirty.mockResolvedValue(DIRTY({ dirtyFiles: [" M src/fresh.ts"], sig: "SIG-2" }));
+    const failedDeploy: DeployState = {
+      phase: "failed",
+      exitCode: 1,
+      log: "SHEPHERD_DISCARD_STALE: working tree changed",
+      reason: "stale",
+    };
+    render(UpdateModal, { props: { update, updating: false, deploy: failedDeploy } });
+
+    await vi.waitFor(() => expect(btn(/discard & update/i)).toBeTruthy());
+    expect(document.body.textContent).toContain("src/fresh.ts");
+    expect(document.body.textContent).not.toContain("SHEPHERD_DISCARD_STALE"); // raw log hidden
+  });
+
+  it("a reactive dirty failure that is now clean offers a plain retry, no discard", async () => {
+    mockDirty.mockResolvedValue({ dirty: false, dirtyFiles: [], dirtyCount: 0, sig: null });
+    const failedDeploy: DeployState = {
+      phase: "failed",
+      exitCode: 1,
+      log: "--pull needs a clean tree",
+      reason: "dirty",
+    };
+    render(UpdateModal, { props: { update, updating: false, deploy: failedDeploy } });
+
+    await vi.waitFor(() => expect(btn(/retry/i)).toBeTruthy());
+    expect(btn(/discard & update/i)).toBeFalsy();
   });
 });

--- a/ui/src/lib/components/UpdateModal.svelte
+++ b/ui/src/lib/components/UpdateModal.svelte
@@ -79,18 +79,22 @@
   );
 
   type Mode = "progress" | "loading" | "clean" | "dirty" | "toolarge" | "nowclean" | "rawlog";
+  // once a fresh probe has resolved: still pending → loading; dirty → dirty (or
+  // toolarge when the signature was unavailable); anything else → the normal update UI
+  const probeMode = (): Mode => {
+    if (dirtyProbe === "pending" || dirtyProbe === "idle") return "loading";
+    if (dirtyProbe === "dirty") return dirty?.sig == null ? "toolarge" : "dirty";
+    return "clean";
+  };
   const mode = $derived.by((): Mode => {
     if (busy) return "progress";
     if (dirtyReactive) {
-      if (dirtyProbe === "pending" || dirtyProbe === "idle") return "loading";
       if (dirtyProbe === "error") return "rawlog"; // couldn't probe → raw log fallback
       if (dirtyProbe === "clean") return "nowclean"; // tree got cleaned meanwhile
-      return dirty?.sig == null ? "toolarge" : "dirty";
+      return probeMode();
     }
     if (failed) return "rawlog";
-    if (dirtyProbe === "pending" || dirtyProbe === "idle") return "loading";
-    if (dirtyProbe === "clean" || dirtyProbe === "error") return "clean";
-    return dirty?.sig == null ? "toolarge" : "dirty";
+    return probeMode(); // probe error degrades to the normal (clean) update UI
   });
 
   const moreCount = $derived(dirty ? dirty.dirtyCount - dirty.dirtyFiles.length : 0);

--- a/ui/src/lib/components/UpdateModal.svelte
+++ b/ui/src/lib/components/UpdateModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import type { UpdateStatus, DeployState } from "$lib/types";
-  import { applyUpdate } from "$lib/api";
+  import type { UpdateStatus, DeployState, DirtyStatus } from "$lib/types";
+  import { applyUpdate, getUpdateDirty, StaleDirtyError } from "$lib/api";
   import { dialog } from "$lib/a11yDialog";
   import { m } from "$lib/paraglide/messages";
   import SvgFlockOverlay from "$lib/components/SvgFlockOverlay.svelte";
@@ -28,13 +28,79 @@
   let expanded = $state<Record<string, boolean>>({});
   const toggle = (sha: string) => (expanded[sha] = !expanded[sha]);
 
+  const busy = $derived(submitting || updating);
   const failed = $derived(deploy?.phase === "failed");
+  // while the deploy is in flight, show its captured output so the user sees
+  // real progress (install → build → restart) instead of a frozen spinner
+  const liveLog = $derived(busy && !failed && deploy?.log ? deploy.log : null);
 
-  async function confirm() {
+  // ── dirty-repo flow ────────────────────────────────────────────────────────
+  // The tracked dirty state is volatile, so we always fetch it FRESH (never from
+  // the cached update status): once proactively when the dialog opens, and again
+  // reactively if a deploy fails because the tree blocked the pull / drifted.
+  let dirtyProbe = $state<"idle" | "pending" | "clean" | "dirty" | "error">("idle");
+  let dirty = $state<DirtyStatus | null>(null);
+  // two-click destructive confirm: the first click only arms (no API call)
+  let arming = $state(false);
+  // shown when the deploy failed because the tree changed since confirmation
+  let staleHint = $state(false);
+
+  const displayedSig = $derived(dirty?.sig ?? undefined);
+
+  async function probe() {
+    dirtyProbe = "pending";
+    arming = false;
+    try {
+      const d = await getUpdateDirty();
+      dirty = d;
+      dirtyProbe = d.dirty ? "dirty" : "clean";
+    } catch {
+      dirty = null;
+      dirtyProbe = "error"; // degrade to the normal update UI — never a stuck button
+    }
+  }
+
+  // proactive: probe once when the dialog mounts on an available update
+  $effect(() => {
+    if (update.behind > 0 && dirtyProbe === "idle") void probe();
+  });
+
+  // reactive: a failed deploy classified dirty/stale → re-probe fresh and route
+  // through the same dirty UI (with a "changed since shown" hint for stale)
+  $effect(() => {
+    if (failed && (deploy?.reason === "dirty" || deploy?.reason === "stale")) {
+      staleHint = deploy?.reason === "stale";
+      void probe();
+    }
+  });
+
+  const dirtyReactive = $derived(
+    failed && (deploy?.reason === "dirty" || deploy?.reason === "stale"),
+  );
+
+  type Mode = "progress" | "loading" | "clean" | "dirty" | "toolarge" | "nowclean" | "rawlog";
+  const mode = $derived.by((): Mode => {
+    if (busy) return "progress";
+    if (dirtyReactive) {
+      if (dirtyProbe === "pending" || dirtyProbe === "idle") return "loading";
+      if (dirtyProbe === "error") return "rawlog"; // couldn't probe → raw log fallback
+      if (dirtyProbe === "clean") return "nowclean"; // tree got cleaned meanwhile
+      return dirty?.sig == null ? "toolarge" : "dirty";
+    }
+    if (failed) return "rawlog";
+    if (dirtyProbe === "pending" || dirtyProbe === "idle") return "loading";
+    if (dirtyProbe === "clean" || dirtyProbe === "error") return "clean";
+    return dirty?.sig == null ? "toolarge" : "dirty";
+  });
+
+  const moreCount = $derived(dirty ? dirty.dirtyCount - dirty.dirtyFiles.length : 0);
+
+  /** Clean/retry path: a plain (non-destructive) update. */
+  async function runUpdate() {
     submitting = true;
     error = null;
     try {
-      await applyUpdate();
+      await applyUpdate(false);
       onconfirm?.(); // store marks `updating`; the page reloads once the new build is live
     } catch (e) {
       error = e instanceof Error ? e.message : m.updatemodal_update_failed();
@@ -42,10 +108,26 @@
     }
   }
 
-  const busy = $derived(submitting || updating);
-  // while the deploy is in flight, show its captured output so the user sees
-  // real progress (install → build → restart) instead of a frozen spinner
-  const liveLog = $derived(busy && !failed && deploy?.log ? deploy.log : null);
+  /** Destructive path, second click: send the discard with the DISPLAYED sig. */
+  async function confirmDiscard() {
+    submitting = true;
+    error = null;
+    try {
+      await applyUpdate(true, displayedSig);
+      onconfirm?.();
+    } catch (e) {
+      submitting = false;
+      if (e instanceof StaleDirtyError) {
+        // the tree drifted since we showed the list → re-render fresh + re-confirm
+        dirty = e.dirty;
+        dirtyProbe = e.dirty.dirty ? "dirty" : "clean";
+        arming = false;
+        staleHint = true;
+      } else {
+        error = e instanceof Error ? e.message : m.updatemodal_update_failed();
+      }
+    }
+  }
 </script>
 
 <div
@@ -98,9 +180,6 @@
             title={c.subject}
             onclick={() => toggle(c.sha)}
           >
-            <!-- inner wrapper carries the flex layout: WebKit doesn't reliably
-                 grow a <button> that is itself a flex container when a child
-                 wraps, which painted the expanded subject over the next row -->
             <span class="row">
               <span class="sha">{c.sha}</span>
               <span class="subject">{c.subject}</span>
@@ -109,18 +188,51 @@
         {/each}
       </div>
 
-      {#if busy}
+      {#if mode === "progress"}
         <div class="status" aria-live="polite">{m.updatemodal_status()}</div>
+        {#if liveLog}
+          <div class="loghead micro">{m.updatemodal_deploy_log()}</div>
+          <!-- The concise .status line above is the polite announcement; the raw log
+               stays silent so a fast-appending stream doesn't re-announce every line. -->
+          <pre class="log">{liveLog}</pre>
+        {/if}
       {/if}
-      {#if liveLog}
-        <div class="loghead micro">{m.updatemodal_deploy_log()}</div>
-        <!-- The concise .status line above is the polite announcement; the raw log
-             stays silent so a fast-appending stream doesn't re-announce every line. -->
-        <pre class="log">{liveLog}</pre>
-      {/if}
-      {#if error}<div class="err">{error}</div>{/if}
 
-      {#if failed}
+      {#if mode === "dirty" || mode === "toolarge"}
+        <div class="dirty">
+          <div class="dirty-title err">{m.updatemodal_dirty_title()}</div>
+          <p class="dirty-body">{m.updatemodal_dirty_body()}</p>
+          {#if staleHint}
+            <p class="dirty-stale">{m.updatemodal_dirty_stale()}</p>
+          {/if}
+          {#if dirty && dirty.dirtyFiles.length}
+            <div class="loghead micro">{m.updatemodal_dirty_files_head()}</div>
+            <ul class="files">
+              {#each dirty.dirtyFiles as f (f)}
+                <li>{f}</li>
+              {/each}
+              {#if moreCount > 0}
+                <li class="more">{m.updatemodal_dirty_files_more({ count: moreCount })}</li>
+              {/if}
+            </ul>
+          {/if}
+          {#if mode === "toolarge"}
+            <p class="dirty-hint">{m.updatemodal_dirty_too_large()}</p>
+          {:else if arming}
+            <div class="confirm">
+              <span class="confirm-q"
+                >{m.updatemodal_discard_confirm({ count: dirty?.dirtyCount ?? 0 })}</span
+              >
+            </div>
+          {/if}
+        </div>
+      {/if}
+
+      {#if mode === "nowclean"}
+        <div class="status">{m.updatemodal_now_clean()}</div>
+      {/if}
+
+      {#if mode === "rawlog"}
         <div class="failure">
           <div class="err">
             {m.updatemodal_deploy_failed()}
@@ -135,19 +247,45 @@
         </div>
       {/if}
 
+      {#if error}<div class="err">{error}</div>{/if}
+
       <div class="actions">
         {#if !busy}
-          <button type="button" class="later" onclick={() => onclose?.()}
-            >{m.updatemodal_later()}</button
+          <button
+            type="button"
+            class="later"
+            onclick={() => (arming ? (arming = false) : onclose?.())}
           >
+            {arming ? m.common_close() : m.updatemodal_later()}
+          </button>
         {/if}
-        <button type="button" class="run" onclick={confirm} disabled={busy}>
-          {busy
-            ? m.updatemodal_updating()
-            : failed
-              ? m.updatemodal_retry()
-              : m.updatemodal_update_now()}
-        </button>
+
+        {#if mode === "dirty"}
+          {#if arming}
+            <button type="button" class="run danger" onclick={confirmDiscard} disabled={busy}>
+              {m.updatemodal_discard_confirm_yes()}
+            </button>
+          {:else}
+            <button type="button" class="run danger" onclick={() => (arming = true)}>
+              {m.updatemodal_discard_and_update()}
+            </button>
+          {/if}
+        {:else if mode === "toolarge"}
+          <!-- no destructive action offered; the operator resolves it manually -->
+        {:else}
+          <button
+            type="button"
+            class="run"
+            onclick={runUpdate}
+            disabled={busy || mode === "loading"}
+          >
+            {busy
+              ? m.updatemodal_updating()
+              : mode === "rawlog" || mode === "nowclean"
+                ? m.updatemodal_retry()
+                : m.updatemodal_update_now()}
+          </button>
+        {/if}
       </div>
     </div>
   </div>
@@ -322,7 +460,8 @@
     color: var(--color-red);
     font-size: var(--fs-base);
   }
-  .failure {
+  .failure,
+  .dirty {
     display: flex;
     flex-direction: column;
     gap: 6px;
@@ -331,6 +470,50 @@
     color: var(--color-faint);
     font-variant-numeric: tabular-nums;
     margin-left: 6px;
+  }
+  .dirty-title {
+    font-weight: 600;
+  }
+  .dirty-body,
+  .dirty-hint,
+  .dirty-stale {
+    margin: 0;
+    font-size: var(--fs-base);
+    line-height: 1.45;
+    color: var(--color-ink);
+  }
+  .dirty-hint {
+    color: var(--color-muted);
+  }
+  .dirty-stale {
+    color: var(--color-amber);
+  }
+  .files {
+    margin: 0;
+    list-style: none;
+    padding: 8px 10px;
+    max-height: 160px;
+    overflow: auto;
+    border: 1px solid var(--color-line);
+    background: var(--color-inset);
+    color: var(--color-ink-bright);
+    font-family: var(--font-mono, monospace);
+    font-size: var(--fs-meta);
+    line-height: 1.5;
+    white-space: pre;
+  }
+  .files .more {
+    color: var(--color-faint);
+    white-space: normal;
+  }
+  .confirm {
+    padding: 8px 10px;
+    border: 1px solid var(--color-red);
+    background: var(--color-inset);
+  }
+  .confirm-q {
+    font-size: var(--fs-base);
+    color: var(--color-ink-bright);
   }
   .loghead {
     color: var(--color-muted);
@@ -372,6 +555,12 @@
     cursor: pointer;
     letter-spacing: 0.06em;
     box-shadow: inset 0 0 18px -10px var(--color-amber);
+  }
+  /* destructive variant: same recipe, danger hue (traffic-light semantics) */
+  .run.danger {
+    border-color: var(--color-red);
+    color: var(--color-red);
+    box-shadow: inset 0 0 18px -10px var(--color-red);
   }
   .run:disabled {
     opacity: 0.6;

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-safe-update-dirty-repo.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-safe-update-dirty-repo.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "safe-update-dirty-repo",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_safe_update_dirty_repo_title",
+  bodyKey: "feat_safe_update_dirty_repo_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1385,6 +1385,22 @@ export interface DeployState {
   phase: DeployPhase;
   exitCode: number | null;
   log: string;
+  /** classified failure cause so a dirty/stale deploy routes through the friendly
+   *  dirty-repo flow instead of the raw log (mirrors src/update.ts) */
+  reason?: "dirty" | "stale" | null;
+}
+
+/** Fresh snapshot of the running deployment's tracked dirty state (never cached),
+ *  as served by `GET /api/update/dirty` (raw pathspec buffers stripped server-side). */
+export interface DirtyStatus {
+  dirty: boolean;
+  /** capped, display-formatted `XY path` lines */
+  dirtyFiles: string[];
+  /** total changed entries, independent of the capped list */
+  dirtyCount: number;
+  /** content signature the discard is validated against; null when the diff was
+   *  too large / timed out (auto-discard then unavailable) */
+  sig: string | null;
 }
 
 /** Informational herdr-version update check (no auto-apply). */


### PR DESCRIPTION
## The problem

When Shepherd self-updates, it runs `deploy/update.sh --pull`, which hard-requires a
clean working tree. If the operator has made **uncommitted changes to the repo where
Shepherd runs**, the deploy aborts and the user is left staring at a raw, technical
wall:

```
Das Update konnte nicht abgeschlossen werden. Der Deploy ist abgebrochen…
DEPLOY-AUSGABE
  ! working tree has uncommitted changes — they will go live
  × --pull needs a clean tree
```

Nothing explains *why* it failed or what to do about it. The goal of this PR is to
**catch this case** and, instead of a bare error, explain in plain language that the
operator's own local changes are blocking the update — and offer a safe way out.

## The solution

The update dialog now fetches a **fresh** snapshot of the deployment repo's dirty
state and, when it's dirty, replaces the technical log with a clear explanation, the
list of changed files, and exactly two choices:

- **Discard & update** — throw away *exactly the changes shown* (revert tracked files
  to the last commit) and then pull + deploy. Two-click confirmation; newly-added
  files are **never deleted**, they're kept as untracked files.
- **Do nothing** — the dialog explains the situation and lists the files; the operator
  resolves it themselves (commit or discard) and updates later.

It works both **proactively** (warns as soon as the dialog opens on a dirty repo) and
**reactively** (catches a deploy that fails because the tree was, or became, dirty —
routing it into the same friendly flow instead of the raw log).

Because a self-update discard is destructive and runs *detached*, the whole thing is
built to **never discard anything the operator didn't confirm**.

## Technical details

**Never a blanket `git reset --hard`.** The discard restores only the confirmed paths
via `git restore --literal-pathspecs --pathspec-from-file … --pathspec-file-nul`, in
two steps (`--staged` over every confirmed path, `--worktree` only over paths that
exist in HEAD). Consequences, each covered by a real-git integration test:
- A tracked change written to a **different** path after confirmation is not in the
  pathspec, so it survives (a blanket reset would have wiped it).
- **Renames** carry both sides; the tracked state is fully restored.
- **Staged adds** are preserved as untracked files (content kept, never deleted).
- **Non-UTF-8 paths** are carried as raw bytes, so they still match.
- `--literal-pathspecs` stops a filename containing pathspec magic (e.g. `*.ts`) from
  fanning out to unconfirmed files.

**Content-sensitive, config-neutral signature.** `dirtyStatus()` computes a framed
signature — three per-command SHA-256 subhashes (`status` + staged diff + unstaged
diff), then a hash of their hex — so it detects a content edit even when the file's
status is unchanged. All diffs use `--no-ext-diff --no-textconv` so the signature
depends only on real content, not the repo's diff config. The heavy `--binary` diffs
are **streamed** into the hash (byte cap + timeout → `sig: null` → the UI offers no
one-click discard, just a manual hint). The Node and shell signatures are proven
byte-for-byte identical by a parity test.

**Guarded against TOCTOU.** The confirmed signature is re-validated (a) on the server
before launch (drift → `409` + refreshed list + re-confirm), and (b) inside
`update.sh` immediately before the restore (drift → abort, classified as `stale`).
A final clean-tree guard catches anything that slips into the last window and routes
back to re-confirmation rather than discarding it. The `POST /api/update` discard path
runs the existing *no-update* guard first (no side effects when there's nothing to
update), validates the body strictly, and writes the pathspec temp files
**symlink-safely** (`mkdtemp` `0700` dir + exclusive `wx`/`0600` files), cleaning them
up on launch failure; `update.sh` `trap`s their removal after the detached run.

**Surface area:** new `GET /api/update/dirty`; `dirtyStatus()` on the update service;
a two-click, state-machine-driven dirty view in `UpdateModal.svelte`; EN + DE strings;
a feature-announcement entry. Fully covered by unit, real-git integration, shell, HTTP
endpoint, and browser-component tests.
