### PR TITLE
feat(learnings): make the Learnings Merge Suggester provider-aware

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -682,6 +682,12 @@ export const config = {
   optimizerModel: normalizeRoleModelToken(process.env.SHEPHERD_OPTIMIZER_MODEL) ?? "default",
   optimizerEffort:
     normalizeDefaultEffortSetting(process.env.SHEPHERD_OPTIMIZER_EFFORT) ?? "default",
+  // Per-role environment for the Learnings Merge Suggester. Inherit follows the live global
+  // provider/model/effort selection while explicit providers keep their natural defaults.
+  mergeSuggestCli: normalizeRoleCli(process.env.SHEPHERD_MERGE_SUGGEST_CLI) ?? "inherit",
+  mergeSuggestModel: normalizeRoleModelToken(process.env.SHEPHERD_MERGE_SUGGEST_MODEL) ?? "default",
+  mergeSuggestEffort:
+    normalizeDefaultEffortSetting(process.env.SHEPHERD_MERGE_SUGGEST_EFFORT) ?? "default",
   // Automatic runs are throttled per repository; 1 preserves the historic daily behavior.
   distillerIntervalDays: clampCap(
     Number(process.env.SHEPHERD_DISTILLER_INTERVAL_DAYS ?? 1),

--- a/src/index.ts
+++ b/src/index.ts
@@ -302,6 +302,7 @@ for (const role of [
   "autopilot",
   "distiller",
   "optimizer",
+  "mergeSuggest",
 ] as const) {
   const savedCli = store.getSetting(`${role}Cli`);
   if (savedCli !== null) {
@@ -663,6 +664,14 @@ function optimizerEnv(): RoleEnvironment {
       ? config.defaultEffort
       : config.optimizerEffort;
   return roleEnv(config.optimizerCli, config.optimizerModel, effort);
+}
+
+function mergeSuggestEnv(): RoleEnvironment {
+  const effort =
+    config.mergeSuggestCli === "inherit" && config.mergeSuggestEffort === "default"
+      ? config.defaultEffort
+      : config.mergeSuggestEffort;
+  return roleEnv(config.mergeSuggestCli, config.mergeSuggestModel, effort);
 }
 
 // Anonymous product telemetry (Aptabase). No-op unless the operator has explicitly
@@ -2225,6 +2234,7 @@ const mergeSuggest = new MergeSuggestionService({
   store,
   herdr,
   scratch: defaultMergeScratch,
+  environment: mergeSuggestEnv,
   onChange: () => learningsSvc.emitPending(),
 });
 deferredStarts.push(() => {

--- a/src/merge-suggest.ts
+++ b/src/merge-suggest.ts
@@ -7,9 +7,10 @@ import type { HerdrDriver } from "./herdr";
 import { HerdrUnavailableError } from "./herdr";
 import type { Learning, MergeSuggestionKind } from "./types";
 import { normalizeRule } from "./distiller";
-import { isApiKeyMode, isApiKeyConfigured, apiKeyPassthroughEnv } from "./spawn-auth";
+import { apiKeyFailClosed, apiKeyPassthroughEnv } from "./spawn-auth";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
 import { reapTransientByLabel } from "./transient-tab-reaper";
+import type { RoleEnvironment } from "./default-model";
 
 const RULES_FILE = "rules.json";
 const OUTPUT_FILE = ".shepherd-merge.json";
@@ -69,6 +70,7 @@ export interface MergeSuggestionDeps {
   scratch: { create: () => { dir: string }; remove: (dir: string) => void };
   onChange: () => void;
   model?: string | null;
+  environment?: () => RoleEnvironment;
   now?: () => number;
   timeoutMs?: number;
   /** Min active rules in a repo before an intra pass runs (default 8). */
@@ -215,8 +217,13 @@ export class MergeSuggestionService {
     }
 
     const { dir } = this.deps.scratch.create();
+    const environment = this.deps.environment?.() ?? {
+      provider: "claude" as const,
+      model: this.deps.model ?? null,
+      effort: null,
+    };
     // Fail closed: api-key mode without a configured key must NOT bill the subscription.
-    if (isApiKeyMode() && !isApiKeyConfigured()) {
+    if (apiKeyFailClosed(environment.provider)) {
       console.warn(
         "[merge] api-key mode enabled but no API key configured — skipping (fail closed)",
       );
@@ -237,7 +244,9 @@ export class MergeSuggestionService {
     // Read-only merge suggester — the shared `writer-ro` transient-agent shape (untrusted
     // agent-authored rule text); see buildTransientAgentArgv for the flag-order + isolation rationale.
     const { argv, sessionId } = buildTransientAgentArgv("writer-ro", {
-      model: this.deps.model ?? null,
+      provider: environment.provider,
+      model: environment.model,
+      effort: environment.effort,
       prompt: kind === "cross" ? crossPrompt() : intraPrompt(),
     });
     const agentName = MERGE_LABEL + sessionId.slice(0, 8);
@@ -260,7 +269,12 @@ export class MergeSuggestionService {
     this.inflight.set(key, entry);
     try {
       entry.terminalId = (
-        await this.deps.herdr.start(agentName, dir, argv, apiKeyPassthroughEnv(false))
+        await this.deps.herdr.start(
+          agentName,
+          dir,
+          argv,
+          environment.provider === "claude" ? apiKeyPassthroughEnv(false) : undefined,
+        )
       ).terminalId;
     } catch (err) {
       this.inflight.delete(key); // release the reservation

--- a/src/server.ts
+++ b/src/server.ts
@@ -4502,6 +4502,9 @@ async function handleSettings({ req, parts, deps }: Ctx): Promise<Response | nul
       optimizerCli: config.optimizerCli,
       optimizerModel: config.optimizerModel,
       optimizerEffort: config.optimizerEffort,
+      mergeSuggestCli: config.mergeSuggestCli,
+      mergeSuggestModel: config.mergeSuggestModel,
+      mergeSuggestEffort: config.mergeSuggestEffort,
       distillerIntervalDays: config.distillerIntervalDays,
       distillerIntervalDaysMin: DISTILLER_INTERVAL_DAYS_MIN,
       distillerIntervalDaysMax: DISTILLER_INTERVAL_DAYS_MAX,
@@ -4595,6 +4598,9 @@ const SETTING_PATCHES: [string, (value: unknown, deps: Ctx["deps"]) => Response]
   ["optimizerCli", makeRoleCliPatch("optimizer")],
   ["optimizerModel", makeRoleModelPatch("optimizer")],
   ["optimizerEffort", makeRoleEffortPatch("optimizer")],
+  ["mergeSuggestCli", makeRoleCliPatch("mergeSuggest")],
+  ["mergeSuggestModel", makeRoleModelPatch("mergeSuggest")],
+  ["mergeSuggestEffort", makeRoleEffortPatch("mergeSuggest")],
   ["distillerIntervalDays", putDistillerIntervalDays],
   ["namerCli", makeRoleCliPatch("namer")],
   ["namerModel", makeRoleModelPatch("namer")],
@@ -4717,7 +4723,8 @@ type RoleKey =
   | "namer"
   | "autopilot"
   | "distiller"
-  | "optimizer";
+  | "optimizer"
+  | "mergeSuggest";
 
 function makeRoleCliPatch(role: RoleKey): (value: unknown, deps: Ctx["deps"]) => Response {
   const key = `${role}Cli` as const;

--- a/test/merge-suggest.test.ts
+++ b/test/merge-suggest.test.ts
@@ -227,6 +227,169 @@ test("cross: a group promoted to global (applied) is NOT re-suggested on a later
   expect(store.listMergeSuggestions({ kind: "cross", status: "pending" }).length).toBe(0);
 });
 
+// ── provider-aware spawn contract ──────────────────────────────────────────
+
+test("intra spawn: explicit Claude keeps writer-ro argv and persists the file result", async () => {
+  const store = new SessionStore(":memory:");
+  const a = seedActive(store, "/r", "Use bun, not npm");
+  const b = seedActive(store, "/r", "Prefer bun over npm for installs");
+  const { deps, cap } = mkDeps(
+    store,
+    {
+      groups: [
+        {
+          memberIds: [a.id, b.id],
+          anchorId: a.id,
+          mergedRule: "Use bun, not npm",
+          mergedRationale: "same guidance",
+        },
+      ],
+    },
+    { environment: () => ({ provider: "claude", model: "sonnet", effort: "high" }) },
+  );
+
+  const svc = new MergeSuggestionService(deps);
+  await svc.mergeNow("/r");
+  await svc.tick();
+
+  expect(cap.argv[0]).toBe("claude");
+  expect(cap.argv).toContain("--allowedTools");
+  expect(cap.argv).toContain("Read");
+  expect(cap.argv).toContain("Grep");
+  expect(cap.argv).toContain("Glob");
+  expect(cap.argv).toContain("Write");
+  expect(cap.argv).toContain("--permission-mode");
+  expect(cap.argv).toContain("dontAsk");
+  expect(cap.argv).toContain("--model");
+  expect(cap.argv).toContain("sonnet");
+  expect(cap.argv).toContain("--effort");
+  expect(cap.argv).toContain("high");
+  expect(cap.argv.at(-1)).toContain("ONE repository");
+  expect(store.listMergeSuggestions({ kind: "intra", status: "pending" })).toHaveLength(1);
+});
+
+test("intra spawn: resolved Codex uses codex exec and persists the file result", async () => {
+  const store = new SessionStore(":memory:");
+  const a = seedActive(store, "/r", "Use bun, not npm");
+  const b = seedActive(store, "/r", "Prefer bun over npm for installs");
+  const { deps, cap } = mkDeps(
+    store,
+    {
+      groups: [
+        {
+          memberIds: [a.id, b.id],
+          anchorId: a.id,
+          mergedRule: "Use bun, not npm",
+          mergedRationale: "same guidance",
+        },
+      ],
+    },
+    { environment: () => ({ provider: "codex", model: "gpt-5.5", effort: "high" }) },
+  );
+
+  const svc = new MergeSuggestionService(deps);
+  await svc.mergeNow("/r");
+  await svc.tick();
+
+  expect(cap.argv).toEqual([
+    "codex",
+    "exec",
+    "--sandbox",
+    "workspace-write",
+    "-m",
+    "gpt-5.5",
+    "-c",
+    "model_reasoning_effort=high",
+    expect.stringContaining("ONE repository"),
+  ]);
+  expect(cap.env).toBeUndefined();
+  expect(store.listMergeSuggestions({ kind: "intra", status: "pending" })).toHaveLength(1);
+});
+
+test("cross spawn: explicit Claude keeps writer-ro argv and persists the file result", async () => {
+  const store = new SessionStore(":memory:");
+  const a = seedActive(store, "/r1", "Always write a regression test");
+  const b = seedActive(store, "/r2", "Always write a regression test first");
+  const { deps, cap } = mkDeps(
+    store,
+    { groups: [{ memberIds: [a.id, b.id], canonicalRule: "Always write a regression test" }] },
+    { environment: () => ({ provider: "claude", model: "sonnet", effort: "high" }) },
+  );
+
+  const svc = new MergeSuggestionService(deps);
+  await svc.considerCrossRepo();
+  await svc.tick();
+
+  expect(cap.argv[0]).toBe("claude");
+  expect(cap.argv).toContain("--allowedTools");
+  expect(cap.argv).toContain("--permission-mode");
+  expect(cap.argv).toContain("dontAsk");
+  expect(cap.argv).toContain("--model");
+  expect(cap.argv).toContain("sonnet");
+  expect(cap.argv).toContain("--effort");
+  expect(cap.argv).toContain("high");
+  expect(cap.argv.at(-1)).toContain("MANY repositories");
+  expect(store.listMergeSuggestions({ kind: "cross", status: "pending" })).toHaveLength(1);
+});
+
+test("cross spawn: resolved Codex uses codex exec and persists the file result", async () => {
+  const store = new SessionStore(":memory:");
+  const a = seedActive(store, "/r1", "Always write a regression test");
+  const b = seedActive(store, "/r2", "Always write a regression test first");
+  const { deps, cap } = mkDeps(
+    store,
+    { groups: [{ memberIds: [a.id, b.id], canonicalRule: "Always write a regression test" }] },
+    { environment: () => ({ provider: "codex", model: "gpt-5.5", effort: "high" }) },
+  );
+
+  const svc = new MergeSuggestionService(deps);
+  await svc.considerCrossRepo();
+  await svc.tick();
+
+  expect(cap.argv).toEqual([
+    "codex",
+    "exec",
+    "--sandbox",
+    "workspace-write",
+    "-m",
+    "gpt-5.5",
+    "-c",
+    "model_reasoning_effort=high",
+    expect.stringContaining("MANY repositories"),
+  ]);
+  expect(cap.env).toBeUndefined();
+  expect(store.listMergeSuggestions({ kind: "cross", status: "pending" })).toHaveLength(1);
+});
+
+test("each actual spawn resolves a fresh environment", async () => {
+  const store = new SessionStore(":memory:");
+  seedActive(store, "/r", "rule one");
+  seedActive(store, "/r", "rule two");
+  let calls = 0;
+  const { deps, cap } = mkDeps(
+    store,
+    { groups: [] },
+    {
+      environment: () => {
+        calls++;
+        return calls === 1
+          ? { provider: "claude", model: "sonnet", effort: "low" }
+          : { provider: "codex", model: "gpt-5.5", effort: "high" };
+      },
+    },
+  );
+  const svc = new MergeSuggestionService(deps);
+
+  await svc.mergeNow("/r");
+  await svc.tick();
+  await svc.mergeNow("/r");
+
+  expect(calls).toBe(2);
+  expect(cap.argv.slice(0, 4)).toEqual(["codex", "exec", "--sandbox", "workspace-write"]);
+  expect(cap.argv).toContain("gpt-5.5");
+  expect(cap.argv).toContain("model_reasoning_effort=high");
+});
+
 // ── pure helpers ────────────────────────────────────────────────────────────
 
 test("pickSurvivor: anchor wins; else most-injected; else earliest createdAt", async () => {
@@ -299,10 +462,43 @@ test("api-key mode without a configured key fails closed (no spawn)", async () =
     const store = new SessionStore(":memory:");
     seedActive(store, "/r", "rule a");
     seedActive(store, "/r", "rule b");
-    const { deps, started } = mkDeps(store, { groups: [] });
+    const { deps, started } = mkDeps(
+      store,
+      { groups: [] },
+      {
+        environment: () => ({ provider: "claude", model: null, effort: null }),
+      },
+    );
     new MergeSuggestionService(deps).mergeNow("/r");
     expect(started.length).toBe(0);
   });
+});
+
+test("api-key mode without an Anthropic key does not block resolved Codex", async () => {
+  const previousMode = config.authMode;
+  const previousHelper = config.authApiKeyHelperPath;
+  config.authMode = "api-key";
+  config.authApiKeyHelperPath = null;
+  try {
+    const store = new SessionStore(":memory:");
+    seedActive(store, "/r", "rule one");
+    seedActive(store, "/r", "rule two");
+    const { deps, started, cap } = mkDeps(
+      store,
+      { groups: [] },
+      {
+        environment: () => ({ provider: "codex", model: null, effort: null }),
+      },
+    );
+
+    await new MergeSuggestionService(deps).mergeNow("/r");
+
+    expect(started).toHaveLength(1);
+    expect(cap.argv.slice(0, 4)).toEqual(["codex", "exec", "--sandbox", "workspace-write"]);
+  } finally {
+    config.authMode = previousMode;
+    config.authApiKeyHelperPath = previousHelper;
+  }
 });
 
 // ── boot reapOrphans (issue #1135) ──────────────────────────────────────────

--- a/test/server-settings.test.ts
+++ b/test/server-settings.test.ts
@@ -36,6 +36,7 @@ const ROLE_BASES = [
   "autopilot",
   "distiller",
   "optimizer",
+  "mergeSuggest",
 ] as const;
 let savedRoleEnvs: Record<string, string>;
 let savedDefaultAgentProvider: typeof config.defaultAgentProvider;
@@ -502,7 +503,7 @@ test("GET and PUT resolve a ChatGPT-incompatible Codex model to provider default
   expect(store.getSetting("defaultCodexModel")).toBe("default");
 });
 
-// ── per-role environment settings (cli + model) for the six roles ──
+// ── per-role environment settings (cli + model + effort) ──
 test("GET /api/settings includes every per-role cli + model + effort setting (raw, unresolved)", async () => {
   config.criticCli = "codex";
   config.criticModel = "gpt-5.5";
@@ -519,6 +520,9 @@ test("GET /api/settings includes every per-role cli + model + effort setting (ra
   config.optimizerCli = "codex";
   config.optimizerModel = "gpt-5.5";
   config.optimizerEffort = "medium";
+  config.mergeSuggestCli = "codex";
+  config.mergeSuggestModel = "gpt-5.5";
+  config.mergeSuggestEffort = "high";
   const { app } = harness();
   const body = await (await app.fetch(new Request("http://x/api/settings"))).json();
   expect(body.criticCli).toBe("codex");
@@ -536,6 +540,9 @@ test("GET /api/settings includes every per-role cli + model + effort setting (ra
   expect(body.optimizerCli).toBe("codex");
   expect(body.optimizerModel).toBe("gpt-5.5");
   expect(body.optimizerEffort).toBe("medium");
+  expect(body.mergeSuggestCli).toBe("codex");
+  expect(body.mergeSuggestModel).toBe("gpt-5.5");
+  expect(body.mergeSuggestEffort).toBe("high");
 });
 
 for (const role of ROLE_BASES) {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3177,5 +3177,9 @@
   "settings_role_model_optimizer_title": "Learnings-Optimierer",
   "settings_role_model_optimizer_hint": "Verschärft als unwirksam markierte Regeln anhand ihrer Fehlerbelege.",
   "feat_optimizer_provider_aware_title": "Umgebung des Learnings-Optimierers wählen",
-  "feat_optimizer_provider_aware_body": "Wähle CLI, Modell und Reasoning-Aufwand, mit denen der Optimierer als unwirksam markierte Regeln verschärft."
+  "feat_optimizer_provider_aware_body": "Wähle CLI, Modell und Reasoning-Aufwand, mit denen der Optimierer als unwirksam markierte Regeln verschärft.",
+  "settings_role_model_merge_suggest_title": "Learnings-Merge-Suggester",
+  "settings_role_model_merge_suggest_hint": "Konsolidiert überschneidende Learnings-Regeln innerhalb und über Repositorys hinweg.",
+  "feat_merge_suggester_provider_title": "Kosten des Merge-Suggesters steuern",
+  "feat_merge_suggester_provider_body": "Wähle CLI, Modell und Aufwand des Learnings-Merge-Suggesters."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3177,5 +3177,9 @@
   "settings_role_model_optimizer_title": "Learnings Optimizer",
   "settings_role_model_optimizer_hint": "Strengthens rules marked as not working using their failure evidence.",
   "feat_optimizer_provider_aware_title": "Choose the Learnings Optimizer environment",
-  "feat_optimizer_provider_aware_body": "Choose the CLI, model, and reasoning effort the Optimizer uses when strengthening rules marked as not working."
+  "feat_optimizer_provider_aware_body": "Choose the CLI, model, and reasoning effort the Optimizer uses when strengthening rules marked as not working.",
+  "settings_role_model_merge_suggest_title": "Learnings Merge Suggester",
+  "settings_role_model_merge_suggest_hint": "Consolidates overlapping Learnings rules within and across repositories.",
+  "feat_merge_suggester_provider_title": "Control Merge Suggester cost",
+  "feat_merge_suggester_provider_body": "Choose the Learnings Merge Suggester CLI, model, and effort."
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -623,7 +623,8 @@ export type RoleBase =
   | "namer"
   | "autopilot"
   | "distiller"
-  | "optimizer";
+  | "optimizer"
+  | "mergeSuggest";
 export type RoleCliKey = `${RoleBase}Cli`;
 export type RoleModelKey = `${RoleBase}Model`;
 export type RoleEffortKey = `${RoleBase}Effort`;

--- a/ui/src/lib/components/Settings.svelte
+++ b/ui/src/lib/components/Settings.svelte
@@ -289,6 +289,7 @@
     "rundown",
     "distiller",
     "optimizer",
+    "mergeSuggest",
     "namer",
     "autopilot",
   ] as const;
@@ -303,6 +304,7 @@
     autopilot: "claude",
     distiller: "inherit",
     optimizer: "inherit",
+    mergeSuggest: "inherit",
   };
   const ROLE_MODEL_SEED: Record<RoleBase, string> = {
     planner: "default",
@@ -314,6 +316,7 @@
     autopilot: "haiku",
     distiller: "default",
     optimizer: "default",
+    mergeSuggest: "default",
   };
   // Per-role reasoning-effort tier ("default"|<tier>), orthogonal to CLI/model — always shown.
   const ROLE_EFFORT_SEED: Record<RoleBase, string> = {
@@ -326,6 +329,7 @@
     autopilot: "low",
     distiller: "default",
     optimizer: "default",
+    mergeSuggest: "default",
   };
   let roleCli = $state<Record<RoleBase, string>>({ ...ROLE_CLI_SEED });
   let roleCliSaved: Record<RoleBase, string> = { ...ROLE_CLI_SEED };
@@ -343,6 +347,7 @@
     autopilot: false,
     distiller: false,
     optimizer: false,
+    mergeSuggest: false,
   });
   // Foreground (content) roles vs. collapsed classifiers (constant-cadence, kept cheap).
   const ROLE_PRIMARY: RoleBase[] = [
@@ -353,6 +358,7 @@
     "rundown",
     "distiller",
     "optimizer",
+    "mergeSuggest",
   ];
   const ROLE_CLASSIFIERS: RoleBase[] = ["namer", "autopilot"];
 
@@ -376,6 +382,8 @@
         return m.settings_role_model_distiller_title();
       case "optimizer":
         return m.settings_role_model_optimizer_title();
+      case "mergeSuggest":
+        return m.settings_role_model_merge_suggest_title();
     }
   }
   function roleHint(role: RoleBase): string {
@@ -398,6 +406,8 @@
         return m.settings_role_model_distiller_hint();
       case "optimizer":
         return m.settings_role_model_optimizer_hint();
+      case "mergeSuggest":
+        return m.settings_role_model_merge_suggest_hint();
     }
   }
   // Display label for a CLI/provider (the CLI dropdown options + the effective line).

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-merge-suggester-provider.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-merge-suggester-provider.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "merge-suggester-provider",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_merge_suggester_provider_title",
+  bodyKey: "feat_merge_suggester_provider_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -128,6 +128,9 @@ export interface Settings {
   optimizerCli?: string;
   optimizerModel?: string;
   optimizerEffort?: string;
+  mergeSuggestCli?: string;
+  mergeSuggestModel?: string;
+  mergeSuggestEffort?: string;
   distillerIntervalDays?: number;
   distillerIntervalDaysMin?: number;
   distillerIntervalDaysMax?: number;


### PR DESCRIPTION
# Problem

The Learnings Merge Suggester did not have its own provider configuration. Its transient `writer-ro` spawns omitted the provider, so the shared argv builder fell back to Claude Code even when Codex was the global default. This affected both intra-repository consolidation and the cross-repository pass.

# Solution

- Add a persisted Merge Suggester role environment for CLI, model, and reasoning effort.
- Resolve the environment immediately before every actual intra- or cross-repository spawn.
- Route Codex selections through the existing `codex exec` path while preserving Claude's read-only `writer-ro` invocation.
- Expose the role in Settings with live effective provider/model feedback, EN/DE copy, and a What's New entry.
- Keep the existing result-file contract, concurrency, queueing, deduplication, timeout, authentication, and teardown behavior.

## Technical details

- New settings: `mergeSuggestCli`, `mergeSuggestModel`, and `mergeSuggestEffort`.
- `inherit` follows the live global provider, provider-specific default model, and global effort.
- Provider/model compatibility and Codex authentication constraints reuse the shared role environment resolver.
- Anthropic API-key fail-closed behavior is keyed to the resolved provider, so it does not block Codex.
- Focused coverage exercises Claude and Codex for both intra- and cross-repository result-file flows, fresh per-spawn resolution, persistence, validation, and auth behavior.

## Validation

- `bun run lint`
- `bun run typecheck`
- Focused root provider/settings suite — 266 passed, 0 failed
- `cd ui && bun run check`
- `cd ui && bun run check:i18n`
- `cd ui && bun run test:node -- --maxWorkers=2` — 2,409 passed
- `cd ui && CI=true bun run test:browser` — 1,416 passed
- Branch hygiene, feature catalog, announcement version, and glossary gates

Closes #1753
