### PR TITLE
fix(ui): restore Up Next row density (inline START)

### DIFF
--- a/ui/src/lib/components/UpNextPanel.browser.test.ts
+++ b/ui/src/lib/components/UpNextPanel.browser.test.ts
@@ -262,7 +262,7 @@ describe("UpNextPanel compact issue rows", () => {
     expect(row.querySelector(".issue-list-actions .un-start")).not.toBeNull();
   });
 
-  it("keeps checkbox, issue link, and Start touch-sized without narrow-row overflow", async () => {
+  it("hides the per-row Start on mobile while checkbox and link stay touch-sized", async () => {
     await page.viewport(390, 800);
     render(UpNextPanel, {});
 
@@ -272,11 +272,69 @@ describe("UpNextPanel compact issue rows", () => {
       getComputedStyle(document.documentElement).getPropertyValue("--mobile-actionbar-hit"),
     );
 
-    for (const selector of [".un-check", ".un-link", ".un-start"]) {
+    // Checkbox + link remain the 44px touch targets…
+    for (const selector of [".un-check", ".un-link"]) {
       expect(
         row.querySelector<HTMLElement>(selector)!.getBoundingClientRect().height,
       ).toBeGreaterThanOrEqual(hitSize);
     }
+    // …but the per-row Start is hidden entirely (out of the layout + a11y tree).
+    // Starting one issue goes through the checkbox → sticky batch bar instead.
+    const actions = row.querySelector<HTMLElement>(".un-actions")!;
+    expect(getComputedStyle(actions).display).toBe("none");
+    expect(row.querySelector<HTMLElement>(".un-start")!.getBoundingClientRect().height).toBe(0);
+    expect(row.scrollWidth).toBeLessThanOrEqual(row.clientWidth);
+  });
+
+  it("keeps a worst-case row single-line with Start inline and no overflow at 360px", async () => {
+    // Widest row content: priority + epic pills and multiple label chips. On a
+    // narrow desktop sidebar the mobile @media branch does not fire (wide viewport,
+    // fine pointer), so this exercises the strict-nowrap + title-valve path.
+    await page.viewport(1024, 900);
+    upNext.snapshot = {
+      generatedAt: 1,
+      repoCount: 1,
+      fallback: null,
+      failedRepoCount: 0,
+      sections: [
+        {
+          kind: "repo",
+          repoPath: "~/projects/homeassistant",
+          repoSlug: null,
+          repoLabel: "homeassistant",
+          totalCount: 1,
+          items: [
+            item("~/projects/homeassistant", 1642, true, {
+              kind: "epic",
+              title: "herdr terminal transport rewrite with a deliberately long title",
+              labels: ["enhancement", "operator UX", "feedback"],
+              labelColors: { enhancement: "#a2eeef", feedback: "#d4c5f9" },
+            }),
+          ],
+        },
+      ],
+    };
+
+    render(UpNextPanel, {});
+    await expect.poll(() => document.querySelector(".un-row")).toBeTruthy();
+    const panel = document.querySelector<HTMLElement>(".upnext")!;
+    const row = document.querySelector<HTMLElement>(".un-row")!;
+
+    // Both pills render and Start stays inline (not hidden) on desktop.
+    expect(row.querySelector(".un-pill-priority")).not.toBeNull();
+    expect(row.querySelector(".un-pill-epic")).not.toBeNull();
+    expect(getComputedStyle(row.querySelector<HTMLElement>(".un-actions")!).display).not.toBe(
+      "none",
+    );
+
+    const measure = (w: number): number => {
+      panel.style.width = `${w}px`;
+      return row.offsetHeight; // forces reflow; integer px avoids subpixel noise
+    };
+    const wide = measure(600);
+    // At the narrowest supported desktop width the row stays a single line (Start
+    // never wraps → same height as wide) and its content does not overflow.
+    expect(measure(360)).toBe(wide);
     expect(row.scrollWidth).toBeLessThanOrEqual(row.clientWidth);
   });
 });

--- a/ui/src/lib/components/UpNextPanel.svelte
+++ b/ui/src/lib/components/UpNextPanel.svelte
@@ -684,7 +684,14 @@
     border-color: var(--color-amber);
   }
 
+  /* Sticky so the single-start affordance stays reachable: on mobile the per-row
+     START is hidden, making this bar the only way to launch one issue, and it must
+     not scroll off when a row is ticked deep in a long list. Pins to the top of
+     the .upnext scroll container (overflow:auto). */
   .un-batch {
+    position: sticky;
+    top: 0;
+    z-index: 2;
     display: flex;
     align-items: center;
     gap: 8px;
@@ -761,9 +768,6 @@
     display: flex;
     flex-direction: column;
     gap: 2px;
-  }
-  .un-row {
-    flex-wrap: wrap;
   }
   .un-check {
     display: flex;
@@ -857,11 +861,13 @@
     flex: none;
   }
 
-  @container issue-list-row (max-width: 520px) {
-    .un-actions {
-      flex-basis: 100%;
-      justify-content: flex-end;
-      padding-left: 28px;
+  /* At narrow row widths the title becomes the shrink-valve so the inline START,
+     priority/epic pills and age (all flex:none) never overflow the panel. Only
+     Up Next lowers the shared 6rem .issue-list-title floor here; IssueRow /
+     PromptSources keep it. */
+  @container issue-list-row (max-width: 460px) {
+    .un-title {
+      min-width: 0;
     }
   }
 
@@ -877,9 +883,11 @@
       min-height: var(--mobile-actionbar-hit);
     }
 
-    .un-start {
-      min-height: var(--mobile-actionbar-hit);
-      padding: 2px 14px;
+    /* Hide the per-row START on mobile/coarse-pointer; display:none also drops it
+       from the tab order / a11y tree. Single-start path: tick the checkbox → the
+       (sticky) batch bar's "Start selected (1)". */
+    .un-actions {
+      display: none;
     }
   }
 


### PR DESCRIPTION
## Problem

After #1775 (\"align issue selector rows\") unified the Up Next row onto the shared `.issue-list-row` recipe and added label chips, a container query forced the per-row **START** button to `flex-basis: 100%` — its own line — whenever a row is narrower than **520px**. The Up Next sidebar is ~460px, so *every* row wrapped, doubling its height and gutting the panel's information density.

| | Before this PR | After |
|---|---|---|
| Desktop sidebar (~460px) | START on its own line, 2-line rows | START inline, single-line rows |
| Mobile / coarse-pointer | START inline (2-line, cramped) | START hidden; tick → sticky batch bar |

## Change (CSS-only + tests)

- **Remove the wrap.** Drop `.un-row { flex-wrap: wrap }` and the `@container (max-width: 520px) { .un-actions { flex-basis: 100% } }` block so START stays inline at every desktop width.
- **Narrow-width shrink-valve.** With strict `nowrap`, the pills/age/START are all `flex: none` and `.issue-list-title` has a 6rem floor, so a worst-case **priority + epic + chips** row could overflow at ~320–400px. Lower `.un-title` `min-width` to 0 below 460px (Up Next only — `IssueRow`/`PromptSources` keep the shared floor). Guaranteed no overflow ≥ 360px desktop.
- **Hide START on mobile/coarse-pointer** (`.un-actions { display: none }` — also leaves the a11y tree). Starting one issue goes through the checkbox → batch bar's \"Start selected (1)\".
- **Sticky batch bar** (`position: sticky; top: 0`) so that single-start affordance can't scroll off-screen when a row deep in a long list is ticked.

### Design decision

Hiding per-row START on mobile in favour of the checkbox → batch-bar path is an **explicit operator choice** made against a live mockup (the simpler \"inline everywhere\" option was offered and declined). The sticky batch bar resolves the single-start UX gap that hiding the inline button would otherwise introduce.

## Testing

- `bun run check` (svelte-check): 0 errors.
- `bun run check:i18n`: locales in parity (no new strings — `fix`, not `feat`, so no feature-catalog entry).
- Prettier + ESLint clean (pre-commit hook).
- `UpNextPanel.browser.test.ts` (32 passing), including two updated/added guards that render the real component against `app.css` and assert layout geometry:
  - **Mobile (390px):** `.un-actions` computed `display: none`, START rect height 0, checkbox + link ≥ 44px, no row overflow.
  - **Desktop worst-case (priority + epic + 2 chips):** at 360px the row stays single-line (`offsetHeight` equals its 600px height → START never wrapped) and `scrollWidth ≤ clientWidth`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)