### PR TITLE
fix(ui): show Learnings in desktop menu

### DIFF
--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -2134,6 +2134,64 @@ describe("TopBar — mobile learnings sheet row", () => {
   });
 });
 
+describe("TopBar — desktop learnings menu row", () => {
+  it("idle desktop: learnings opens the menu, calls onlearnings, and closes", async () => {
+    await page.viewport(1280, 900);
+    document.body.style.width = "1280px";
+    const onlearnings = vi.fn();
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.desktop,
+      sessions: [{ id: "d1", status: "done" }] as unknown as Session[],
+      learnings: 2,
+      onlearnings,
+    });
+
+    await page.getByRole("button", { name: m.topbar_menu_aria() }).click();
+    const learningsItem = page.getByRole("menuitem", {
+      name: m.learnings_open_aria({ count: 2 }),
+    });
+    await expect.element(learningsItem).toBeInTheDocument();
+    await learningsItem.click();
+    expect(onlearnings).toHaveBeenCalledTimes(1);
+    await expect.element(learningsItem).not.toBeInTheDocument();
+  });
+
+  it("desktop menu: choosing learnings disarms the halt action", async () => {
+    await page.viewport(1280, 900);
+    document.body.style.width = "1280px";
+    const onhalt = vi.fn();
+    render(TopBar, {
+      nowMs: 1_700_000_000_000,
+      connected: true,
+      ...FLAGS.desktop,
+      sessions: sessions(1),
+      learnings: 2,
+      onhalt,
+    });
+
+    const menuItem = (name: string) =>
+      [...document.querySelectorAll<HTMLButtonElement>("[role='menuitem']")].find(
+        (item) => item.getAttribute("aria-label") === name,
+      );
+    const gear = document.querySelector<HTMLButtonElement>(".gear")!;
+
+    gear.click();
+    await Promise.resolve();
+    menuItem(m.halt_all_aria({ count: 1 }))!.click();
+    menuItem(m.learnings_open_aria({ count: 2 }))!.click();
+    await Promise.resolve();
+
+    gear.click();
+    await Promise.resolve();
+    const haltItem = menuItem(m.halt_all_aria({ count: 1 }));
+    expect(haltItem, "halt action is unarmed after choosing Learnings").toBeDefined();
+    haltItem!.click();
+    expect(onhalt).not.toHaveBeenCalled();
+  });
+});
+
 describe("TopBar — mobile gear sheet portals out of transformed ancestor", () => {
   // Regression guard for the fixed-containing-block bug: on mobile the sheet lives
   // inside <header class="chrome"> which carries `will-change: transform` on

--- a/ui/src/lib/components/TopBar.svelte
+++ b/ui/src/lib/components/TopBar.svelte
@@ -594,8 +594,11 @@
   // under measured overflow (compactBadges), where the gear opens the menu (which
   // carries Documentation + Settings) even with an idle herd, so those stay reachable
   // once the bar has crowded down to icons.
-  // Plugin items also force menu mode: their actions live in the menu, not the gear click.
-  const gearOpensMenu = $derived(mobile || haltable > 0 || compactBadges || pluginItems.length > 0);
+  // Learnings and plugin items also force menu mode: their actions live in the menu,
+  // not the gear's direct-to-Settings click.
+  const gearOpensMenu = $derived(
+    mobile || haltable > 0 || compactBadges || learningsPresent || pluginItems.length > 0,
+  );
   // Mobile only: settings-owned diagnostics attention collapses into one dot on
   // the gear, because the Diagnose row lives inside the gear sheet on phones.
   // Herd/session state stays on the tallies and rows instead of duplicating here.
@@ -636,6 +639,10 @@
     menuOpen = false;
     disarmHalt();
     onusage?.();
+  }
+  function chooseLearnings() {
+    closeMenu();
+    onlearnings?.();
   }
   function choosePlugin(id: string) {
     menuOpen = false;
@@ -678,6 +685,11 @@
     // Under measured overflow the gear is a menu button even with an idle herd, so keep
     // the menu open here too — just drop armed state.
     if (compactBadges) {
+      disarmHalt();
+      return;
+    }
+    // Pending Learnings keep the desktop menu valid with an idle herd so the row stays reachable.
+    if (learningsPresent) {
       disarmHalt();
       return;
     }
@@ -835,6 +847,12 @@
       {clickHalt}
       {chooseSettings}
       {chooseUsage}
+      {learningsPresent}
+      {learnings}
+      {learningsCurate}
+      {learningsLabel}
+      {learningsCount}
+      {chooseLearnings}
       {onMenuKey}
       {onFeedback}
       {pluginItems}

--- a/ui/src/lib/components/top-bar/TopBarGear.svelte
+++ b/ui/src/lib/components/top-bar/TopBarGear.svelte
@@ -20,6 +20,12 @@
     clickHalt,
     chooseSettings,
     chooseUsage,
+    learningsPresent,
+    learnings,
+    learningsCurate,
+    learningsLabel,
+    learningsCount,
+    chooseLearnings,
     onMenuKey,
     onFeedback,
     pluginItems = [],
@@ -38,6 +44,12 @@
     clickHalt: () => void;
     chooseSettings: () => void;
     chooseUsage: () => void;
+    learningsPresent: boolean;
+    learnings: number;
+    learningsCurate: number;
+    learningsLabel: string;
+    learningsCount: number;
+    chooseLearnings: () => void;
     onMenuKey: (e: KeyboardEvent) => void;
     onFeedback: (kind: FeedbackKind) => void;
     pluginItems?: { id: string; label: string; icon?: string }[];
@@ -110,6 +122,20 @@
         <span class="menu-glyph" aria-hidden="true">▦</span>
         <span class="menu-label">{m.topbar_usage_link()}</span>
       </button>
+      {#if learningsPresent}
+        <button
+          class="menu-item"
+          type="button"
+          role="menuitem"
+          aria-label={learnings > 0
+            ? m.learnings_open_aria({ count: learnings })
+            : m.learnings_open_curate_aria({ count: learningsCurate })}
+          onclick={chooseLearnings}
+        >
+          <span class="menu-glyph" aria-hidden="true">✦</span>
+          <span class="menu-label">{learningsLabel} · {learningsCount}</span>
+        </button>
+      {/if}
       <!-- External docs site — opens in a new tab; ↗ marks it external, matching the
            mobile sheet + Settings → About link convention. Closes the menu on click. -->
       <a


### PR DESCRIPTION
## Summary

- add the existing Learnings/Erkenntnisse row to the desktop gear menu
- keep the desktop menu reachable for pending Learnings even when the herd is idle
- reuse the existing localized count/accessible label and safely disarm Halt when navigating away

## Testing

- `cd ui && bun run test:browser -- src/lib/components/TopBar.browser.test.ts` (79 passed)
- `cd ui && bun run check` (0 errors, 0 warnings)
- `cd ui && bun run test`
- `cd ui && bun run check:i18n`
- `bunx prettier --check ui/src/lib/components/TopBar.browser.test.ts ui/src/lib/components/TopBar.svelte ui/src/lib/components/top-bar/TopBarGear.svelte`
- `bash scripts/check-branch-hygiene.sh`