### PR TITLE
fix(ui): group git-rail passive status, unify mobile tap-target heights

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -253,6 +253,14 @@
         "reason": "Tier 1: global Svelte <template> complexity bar (#851; see comment above)."
       },
       {
+        "files": ["ui/src/lib/components/git-rail/RailStatusActions.svelte"],
+        "functions": ["<template>"],
+        "maxCyclomatic": 40,
+        "maxCognitive": 70,
+        "maxCrap": 20000,
+        "reason": "The mobile git-rail is split by affordance into a leading passive-status zone (de-boxed readouts) and a trailing tap-target zone, each item gated by its own hasPassive/hasActions term and the reviewing span-vs-button split; the added per-item guards take cognitive just over the Tier-1 60 bar (68), cyclomatic stays under (36). Keep capped until the rail is split into passive/actions child components (#855)."
+      },
+      {
         "files": ["ui/src/lib/components/UpdateModal.svelte"],
         "functions": ["<template>"],
         "maxCyclomatic": 45,

--- a/ui/src/lib/components/GitRail.browser.test.ts
+++ b/ui/src/lib/components/GitRail.browser.test.ts
@@ -160,8 +160,11 @@ function assertControlsWithin(cell: HTMLElement) {
     const expectedTouchHeight = Number.parseFloat(
       getComputedStyle(document.documentElement).getPropertyValue("--mobile-actionbar-hit"),
     );
+    // Every tappable control reaches the 44px touch floor — including the promoted
+    // interactive status-chips (Issue link <a>, PR-menu trigger <button>), which used to
+    // render at ~23px below the floor (the a11y bug this change fixes).
     const touchButtons = rail!.querySelectorAll<HTMLElement>(
-      "button.gbtn, button.verdict-chip, button.ready-toggle",
+      "button.gbtn, button.verdict-chip, button.ready-toggle, a.status-chip, button.status-chip",
     );
     expect(expectedTouchHeight, "mobile actionbar height token").toBeGreaterThan(0);
     expect(touchButtons.length, "mobile rail has touch buttons").toBeGreaterThan(0);
@@ -171,6 +174,26 @@ function assertControlsWithin(cell: HTMLElement) {
       expect(button.getBoundingClientRect().height, `${label} uses mobile touch height`).toBe(
         expectedTouchHeight,
       );
+    }
+    // Conversely, de-boxed passive readouts (<span> status/verdict chips) must NOT be blown up
+    // into 44px boxes — they stay short inline labels (no fake tap targets) — and must sit
+    // before the first tap target in DOM order (grouped into the leading status zone).
+    const passiveLabels = rail!.querySelectorAll<HTMLElement>(
+      "span.status-chip, span.verdict-chip",
+    );
+    const firstControl = rail!.querySelector<HTMLElement>("button, a[href]");
+    for (const label of passiveLabels) {
+      const name = label.textContent?.trim() || label.className;
+      expect(
+        label.getBoundingClientRect().height,
+        `${name} passive label must stay short (not a 44px box)`,
+      ).toBeLessThan(expectedTouchHeight);
+      if (firstControl) {
+        expect(
+          Boolean(label.compareDocumentPosition(firstControl) & Node.DOCUMENT_POSITION_FOLLOWING),
+          `${name} passive label must precede the first control`,
+        ).toBe(true);
+      }
     }
     const tallest = Math.max(...[...controls].map((c) => c.getBoundingClientRect().height));
     const railH = rail!.getBoundingClientRect().height;
@@ -685,6 +708,120 @@ describe("GitRail — controls stay within the cell", () => {
     await expect.element(screen.getByRole("button", { name: /confirm/i })).toBeVisible();
 
     assertControlsWithin(h);
+  });
+});
+
+describe("GitRail — status │ actions seam (no orphan dividers)", () => {
+  async function railOf(h: HTMLElement): Promise<HTMLElement> {
+    return await vi.waitFor(() => {
+      const r = h.querySelector<HTMLElement>(".rail");
+      expect(r, "rail mounted").not.toBeNull();
+      return r!;
+    });
+  }
+
+  it("open: exactly one seam, between the passive readouts and the tap targets", async () => {
+    gitStateFn.mockResolvedValue(openPrState);
+    await page.viewport(400, 900);
+    const h = host(360);
+    await render(GitRail, { target: h, props: { ...baseProps, mobile: true } });
+    const rail = await railOf(h);
+    await vi.waitFor(() =>
+      expect(rail.querySelector("button.status-chip"), "PR button present").not.toBeNull(),
+    );
+    const seams = rail.querySelectorAll(".rail-status-sep");
+    expect(seams.length, "exactly one status│actions seam").toBe(1);
+    const seam = seams[0];
+    const ci = rail.querySelector("span.status-chip"); // CI readout (passive)
+    const prBtn = rail.querySelector("button.status-chip"); // PR menu trigger (action)
+    expect(ci, "CI passive label present").not.toBeNull();
+    expect(prBtn, "PR action present").not.toBeNull();
+    // CI (passive) precedes the seam; the PR button (action) follows it
+    expect(Boolean(ci!.compareDocumentPosition(seam) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(
+      true,
+    );
+    expect(Boolean(seam.compareDocumentPosition(prBtn!) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(
+      true,
+    );
+    // right-pin: first .rail child is the leading passive chip (gets margin-left:auto)
+    expect(rail.firstElementChild, "first child is the leading passive readout").toBe(ci);
+  });
+
+  it("state:none + autopilot on: no seam, first child is the auto-pill divider (leading-orphan guard)", async () => {
+    const noneState: GitState = {
+      kind: "github",
+      state: "none",
+      checks: "none",
+      deployConfigured: false,
+    };
+    gitStateFn.mockResolvedValue(noneState);
+    await page.viewport(400, 900);
+    const h = host(360);
+    // repoPath present → auto-pill renders; autopilotOn hides Open PR → BOTH zones empty
+    await render(GitRail, { target: h, props: { ...baseProps, mobile: true, autopilotOn: true } });
+    const rail = await railOf(h);
+    await vi.waitFor(() =>
+      expect(rail.querySelector(".auto-pill"), "auto-pill present").not.toBeNull(),
+    );
+    expect(rail.querySelector(".rail-status-sep"), "no dangling status seam").toBeNull();
+    // no leading orphan: first child is GitRail's own rail-sep, so margin-left:auto lands on a
+    // real divider rather than a 1px status seam
+    expect(
+      rail.firstElementChild?.classList.contains("rail-sep"),
+      "first child is the auto-pill divider",
+    ).toBe(true);
+  });
+
+  it("state:none + autopilot off: no seam, first child is the Open PR action (empty-passive right-pin)", async () => {
+    const noneState: GitState = {
+      kind: "github",
+      state: "none",
+      checks: "none",
+      deployConfigured: false,
+    };
+    gitStateFn.mockResolvedValue(noneState);
+    await page.viewport(400, 900);
+    const h = host(360);
+    await render(GitRail, {
+      target: h,
+      props: { ...baseProps, mobile: true, autopilotOn: false },
+    });
+    const rail = await railOf(h);
+    await vi.waitFor(() =>
+      expect(rail.querySelector("button.gbtn"), "Open PR present").not.toBeNull(),
+    );
+    expect(rail.querySelector(".rail-status-sep"), "no seam without passive").toBeNull();
+    // right-pin with empty passive zone: first child is the first tap target (Open PR)
+    expect(
+      rail.firstElementChild?.matches("button.gbtn"),
+      "first child is the Open PR button",
+    ).toBe(true);
+  });
+
+  it("state:closed: passive label but empty actions → no seam, no double divider (trailing-orphan guard)", async () => {
+    const closedState: GitState = {
+      kind: "github",
+      state: "closed",
+      checks: "none",
+      deployConfigured: false,
+    };
+    gitStateFn.mockResolvedValue(closedState);
+    await page.viewport(400, 900);
+    const h = host(360);
+    const screen = await render(GitRail, { target: h, props: { ...baseProps, mobile: true } });
+    await expect.element(screen.getByText(/closed/i)).toBeVisible();
+    const rail = await railOf(h);
+    await vi.waitFor(() =>
+      expect(rail.querySelector(".auto-pill"), "auto-pill present").not.toBeNull(),
+    );
+    expect(rail.querySelector(".rail-status-sep"), "no trailing status seam").toBeNull();
+    // only ONE divider precedes the auto-pill (GitRail's rail-sep) — never `│ │`
+    expect(rail.querySelectorAll(".rail-sep").length, "single divider, no doubling").toBe(1);
+    // right-pin with passive present: first child is the CLOSED readout
+    expect(
+      rail.firstElementChild?.matches("span.status-chip"),
+      "first child is the CLOSED label",
+    ).toBe(true);
   });
 });
 

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -1062,12 +1062,36 @@
     align-items: center;
     gap: 5px;
   }
-  /* Read-only status readouts are now .status-chip (was .prlink/.dot/.merged);
-     keep their touch legibility at --fs-base. Non-interactive, so NO 40px rule
-     (that stays scoped to .gbtn / button.verdict-chip above) — no fake tap targets.
-     The CI word is a sibling of the .dot, so the dot rule below still enlarges it. */
+  /* status-chips keep their touch legibility at --fs-base. Height/box treatment then
+     splits by affordance (element type), NOT by a blanket rule: */
   .rail.mobile :global(.status-chip) {
     font-size: var(--fs-base);
+  }
+  /* Tappable status-chips — the Issue link (<a>) and the PR-menu trigger (<button>) — ARE
+     tap targets, so promote them to the 44px touch floor like their .gbtn / button.verdict-chip
+     siblings. Fixes the sub-44px a11y violation; the span. readouts below stay short. */
+  .rail.mobile :global(a.status-chip),
+  .rail.mobile :global(button.status-chip) {
+    min-height: var(--mobile-actionbar-hit);
+    padding: 6px 9px;
+  }
+  /* Passive readouts (CI, merged, closed, plain/ready PR) and the reviewing-no-findings chip
+     de-box on mobile: drop the fill + border so they read as inline dot+text labels rather
+     than short boxes clashing against the 44px controls. Hue stays on the dot + text. The
+     `span.` prefix keeps specificity above the .status-chip.info/.pend/… hue variants so the
+     transparent border wins. No min-height → they stay short (not fake tap targets). */
+  .rail.mobile :global(span.status-chip),
+  .rail.mobile :global(span.verdict-chip) {
+    background: transparent;
+    border-color: transparent;
+    padding: 0;
+    font-size: var(--fs-base);
+  }
+  /* automation divider breathes 14px each side on mobile (8px margin + the .rail 6px gap),
+     matching the new status-sep. Scoped to .rail.mobile so the base .rail-sep (shared with the
+     test-only desktop mount) is untouched. */
+  .rail.mobile .rail-sep {
+    margin: 0 8px;
   }
   .rail.mobile :global(.dot) {
     width: 9px;

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -3899,7 +3899,10 @@
     align-items: center;
     gap: 6px;
     flex: 0 0 auto;
-    padding-left: 8px;
+    /* divider breathes 14px each side: 8px margin + the strip's 6px gap on the left,
+       14px padding on the right — matching the rail's status-sep / rail-sep spacing */
+    margin-left: 8px;
+    padding-left: 14px;
     border-left: 1px solid var(--color-line);
   }
   /* the strip's GitRail uses the shared actionbar touch height — match it so the

--- a/ui/src/lib/components/git-rail/RailStatusActions.svelte
+++ b/ui/src/lib/components/git-rail/RailStatusActions.svelte
@@ -104,39 +104,126 @@
   async function toggleDraftState() {
     if (await togglePrDraft(git.isDraft !== true)) closePrMenu();
   }
+
+  // ── Passive vs. tappable split (mobile grouping) ──────────────────────────
+  // The row is split into a leading passive-status zone (de-boxed labels) and a
+  // trailing actions zone (44px tap targets). Each predicate below mirrors the
+  // render guard of exactly ONE item so the two can never drift; `hasPassive` /
+  // `hasActions` are the unions. The `rail-status-sep` renders iff BOTH are
+  // non-empty, so it can never orphan (leading: steal the .rail `margin-left:auto`
+  // first-child; trailing: double-divider against GitRail's own rail-sep).
+
+  // passive readouts (non-interactive <span> chips) — each maps 1:1 to a span:
+  const readyToMerge = $derived(git.state === "open" && local); // "ready to merge #N"
+  const plainPr = $derived(git.state === "open" && !local && !git.url); // no-url plain PR
+  const ciStatus = $derived(git.state === "open" && !local); // CI status
+  const mergedSpan = $derived(git.state === "merged");
+  // the closed span renders from the template {:else} catch-all, NOT `=== "closed"`;
+  // key off the same negation so it can't drift if a 5th GitState.state value appears.
+  const closedSpan = $derived(
+    git.state !== "none" && git.state !== "open" && git.state !== "merged",
+  );
+  const reviewingSpan = $derived(chip.kind === "reviewing" && !chip.hasFindings);
+  const hasPassive = $derived(
+    readyToMerge || plainPr || ciStatus || mergedSpan || closedSpan || reviewingSpan,
+  );
+
+  // tappable controls (<a>/<button> + ReadyToggle) — each maps 1:1 to a control:
+  const issueChip = $derived(!!git.issueUrl && issueNumber != null);
+  const openPrBtn = $derived(git.state === "none" && !autopilotOn);
+  const prMenuBtn = $derived(git.state === "open" && !local && !!git.url);
+  const mergeBtn = $derived(git.state === "open"); // always shown in open (may be disabled)
+  const redeployBtn = $derived(git.state === "merged" && git.deployConfigured);
+  const readyToggleShown = $derived(
+    showReady && (git.state === "open" || ready) && status !== "running" && status !== "blocked",
+  );
+  const verdictBtn = $derived(
+    chip.kind === "verdict" || (chip.kind === "reviewing" && chip.hasFindings),
+  );
+  const hasActions = $derived(
+    issueChip ||
+      openPrBtn ||
+      prMenuBtn ||
+      mergeBtn ||
+      redeployBtn ||
+      readyToggleShown ||
+      verdictBtn ||
+      canReview ||
+      canReviewPlan,
+  );
 </script>
 
-{#if git.issueUrl && issueNumber != null}
-  <!-- eslint-disable svelte/no-navigation-without-resolve -- external git-host URL, not an app route -->
-  <a
-    class="status-chip"
-    href={git.issueUrl}
-    target="_blank"
-    rel="noopener"
-    title={m.gitrail_issue_label({ number: issueNumber })}
-    aria-label={m.gitrail_issue_label({ number: issueNumber })}
-    ><span class="dot" aria-hidden="true"></span>{m.gitrail_open_issue()}</a
-  >
-  <!-- eslint-enable svelte/no-navigation-without-resolve -->
-{/if}
-{#if git.state === "none"}
-  <!-- Hidden whenever autopilot is effectively on — the agent opens the PR itself,
-       so the manual button is redundant. This stays hidden even while autopilot is
-       PAUSED (autopilotPaused): a paused autopilot is still on and will resume and
-       open the PR; the human escape hatch is the AP toggle in the same strip.
-       autopilotPaused is surfaced separately via AutopilotBadge — not a signal to
-       re-show this button. -->
-  {#if !autopilotOn}
+<!-- Leading passive-status zone: non-interactive readouts, de-boxed to inline labels
+     on mobile (see GitRail .rail.mobile). Each {#if} guard mirrors a `hasPassive` term. -->
+{#snippet passiveZone()}
+  {#if readyToMerge}
+    <span class="status-chip info"
+      ><span class="dot" aria-hidden="true"></span>{m.gitrail_ready_to_merge()} #{git.number}</span
+    >
+  {/if}
+  {#if plainPr}
+    <span class="status-chip info" title={m.prbadge_open({ number: git.number ?? 0 })}
+      ><span class="dot" aria-hidden="true"></span>{m.gitrail_pr_plain()}</span
+    >
+  {/if}
+  {#if ciStatus}
+    <span
+      class={["status-chip", ciMod(git.checks)]}
+      title={m.gitrail_ci_status({ status: git.checks })}
+      aria-label={m.gitrail_ci_status({ status: git.checks })}
+    >
+      <span class="dot" aria-hidden="true"></span>{ciLabel(git.checks)}
+    </span>
+  {/if}
+  {#if mergedSpan}
+    <span class="status-chip parked"
+      ><span class="dot" aria-hidden="true"></span>{local
+        ? m.gitrail_merged_locally()
+        : m.gitrail_merged()}</span
+    >
+  {/if}
+  {#if closedSpan}
+    <span class="status-chip parked"
+      ><span class="dot" aria-hidden="true"></span>{m.gitrail_closed()}</span
+    >
+  {/if}
+  {#if reviewingSpan}
+    <span class="verdict-chip critic-reviewing" title={m.criticbadge_reviewing_title()}>
+      <span class="rev-dot" aria-hidden="true"></span>{m.criticbadge_reviewing()}
+    </span>
+  {/if}
+{/snippet}
+
+<!-- Trailing actions zone: 44px tap targets (Issue link, PR menu, Merge, Ready, verdict, …).
+     Each {#if} guard mirrors a `hasActions` term. -->
+{#snippet actionsZone()}
+  {#if git.issueUrl && issueNumber != null}
+    <!-- guard inline (not the `issueChip` derived) so TS narrows `issueNumber` to non-null;
+         `issueChip` mirrors this exact condition for the `hasActions` union above. -->
+    <!-- eslint-disable svelte/no-navigation-without-resolve -- external git-host URL, not an app route -->
+    <a
+      class="status-chip"
+      href={git.issueUrl}
+      target="_blank"
+      rel="noopener"
+      title={m.gitrail_issue_label({ number: issueNumber })}
+      aria-label={m.gitrail_issue_label({ number: issueNumber })}
+      ><span class="dot" aria-hidden="true"></span>{m.gitrail_open_issue()}</a
+    >
+    <!-- eslint-enable svelte/no-navigation-without-resolve -->
+  {/if}
+  {#if openPrBtn}
+    <!-- Hidden whenever autopilot is effectively on — the agent opens the PR itself,
+         so the manual button is redundant. This stays hidden even while autopilot is
+         PAUSED (autopilotPaused): a paused autopilot is still on and will resume and
+         open the PR; the human escape hatch is the AP toggle in the same strip.
+         autopilotPaused is surfaced separately via AutopilotBadge — not a signal to
+         re-show this button. -->
     <button class="gbtn" type="button" disabled={busy} onclick={startPr}
       >{local ? m.gitrail_open_for_merge() : m.gitrail_open_pr()}</button
     >
   {/if}
-{:else if git.state === "open"}
-  {#if local}
-    <span class="status-chip info"
-      ><span class="dot" aria-hidden="true"></span>{m.gitrail_ready_to_merge()} #{git.number}</span
-    >
-  {:else if git.url}
+  {#if prMenuBtn}
     <button
       bind:this={prButton}
       type="button"
@@ -151,40 +238,23 @@
       onclick={togglePrMenu}
       ><span class="dot" aria-hidden="true"></span>{m.gitrail_pr_link()}</button
     >
-  {:else}
-    <span class="status-chip info" title={m.prbadge_open({ number: git.number ?? 0 })}
-      ><span class="dot" aria-hidden="true"></span>{m.gitrail_pr_plain()}</span
-    >
   {/if}
-  {#if !local}
-    <span
-      class={["status-chip", ciMod(git.checks)]}
-      title={m.gitrail_ci_status({ status: git.checks })}
-      aria-label={m.gitrail_ci_status({ status: git.checks })}
+  {#if mergeBtn}
+    <button
+      class={["gbtn", "merge", { armed: armed === "merge" }]}
+      type="button"
+      disabled={mergeBlocked}
+      title={mergeBlockedReason}
+      onclick={() => doMerge()}
     >
-      <span class="dot" aria-hidden="true"></span>{ciLabel(git.checks)}
-    </span>
+      {#if local}
+        {armed === "merge" ? m.gitrail_confirm_merge_locally() : m.gitrail_merge_locally()}
+      {:else}
+        {armed === "merge" ? m.gitrail_confirm_merge() : m.gitrail_merge()}
+      {/if}
+    </button>
   {/if}
-  <button
-    class={["gbtn", "merge", { armed: armed === "merge" }]}
-    type="button"
-    disabled={mergeBlocked}
-    title={mergeBlockedReason}
-    onclick={() => doMerge()}
-  >
-    {#if local}
-      {armed === "merge" ? m.gitrail_confirm_merge_locally() : m.gitrail_merge_locally()}
-    {:else}
-      {armed === "merge" ? m.gitrail_confirm_merge() : m.gitrail_merge()}
-    {/if}
-  </button>
-{:else if git.state === "merged"}
-  <span class="status-chip parked"
-    ><span class="dot" aria-hidden="true"></span>{local
-      ? m.gitrail_merged_locally()
-      : m.gitrail_merged()}</span
-  >
-  {#if git.deployConfigured}
+  {#if redeployBtn}
     <button
       class="gbtn"
       class:armed={armed === "redeploy"}
@@ -195,11 +265,75 @@
       {armed === "redeploy" ? m.gitrail_confirm_redeploy() : m.gitrail_redeploy()}
     </button>
   {/if}
-{:else}
-  <span class="status-chip parked"
-    ><span class="dot" aria-hidden="true"></span>{m.gitrail_closed()}</span
-  >
+  {#if readyToggleShown}
+    <ReadyToggle {sessionId} {ready} {mobile} />
+  {/if}
+  <!-- while re-reviewing: keep the prior findings reachable (hasFindings ⇒ verdict body
+       exists, so the showReview popover has content). The no-findings variant is a
+       non-interactive <span> and lives in the passive zone above instead. -->
+  {#if chip.kind === "reviewing" && chip.hasFindings}
+    <button
+      class={["verdict-chip", "critic-reviewing", { armed: showReview }]}
+      type="button"
+      aria-haspopup="dialog"
+      aria-expanded={showReview}
+      title={m.criticbadge_reviewing_title()}
+      onclick={(e) => toggleReview(e)}
+    >
+      <span class="rev-dot" aria-hidden="true"></span>{m.criticbadge_reviewing()}
+    </button>
+  {:else if chip.kind === "verdict"}
+    <button
+      class={["verdict-chip", `critic-${chip.decision}`, { armed: showReview }]}
+      type="button"
+      aria-haspopup="dialog"
+      aria-expanded={showReview}
+      title={m.gitrail_review_title()}
+      onclick={(e) => toggleReview(e)}
+    >
+      {chip.label}
+    </button>
+  {/if}
+  {#if canReview}
+    <button
+      class="gbtn"
+      class:armed={armed === "review"}
+      type="button"
+      onclick={() => doReview()}
+      use:coachTarget={"manual-critic-review"}
+    >
+      {reviewLabel}
+    </button>
+  {/if}
+  {#if canReviewPlan}
+    <button
+      class="gbtn"
+      class:armed={armed === "review-plan" && !planReviewBlockedReason}
+      type="button"
+      disabled={planReviewing}
+      aria-disabled={planReviewBlockedReason ? "true" : undefined}
+      title={planReviewBlockedReason ?? undefined}
+      aria-label={planReviewBlockedReason
+        ? `${planReviewLabel} — ${planReviewBlockedReason}`
+        : undefined}
+      onclick={() => {
+        if (planReviewBlockedReason) return;
+        doReviewPlan();
+      }}
+    >
+      {planReviewLabel}
+    </button>
+  {/if}
+{/snippet}
+
+{@render passiveZone()}
+<!-- status │ actions divider — mobile only, and only when BOTH zones are non-empty so it
+     can never orphan (leading: become .rail :first-child and steal margin-left:auto;
+     trailing: double up with GitRail's own rail-sep before the auto-pill). -->
+{#if mobile && hasPassive && hasActions}
+  <span class="rail-status-sep" aria-hidden="true"></span>
 {/if}
+{@render actionsZone()}
 
 {#if prMenuAnchor}
   <PrBadgeMenu
@@ -213,73 +347,6 @@
     ontoggledraft={toggleDraftState}
     onclose={closePrMenu}
   />
-{/if}
-
-{#if showReady && (git.state === "open" || ready) && status !== "running" && status !== "blocked"}
-  <ReadyToggle {sessionId} {ready} {mobile} />
-{/if}
-<!-- while re-reviewing: keep the prior findings reachable (hasFindings ⇒ verdict body exists,
-     so the showReview popover below still has content); otherwise a plain status chip. -->
-{#if chip.kind === "reviewing"}
-  {#if chip.hasFindings}
-    <button
-      class={["verdict-chip", "critic-reviewing", { armed: showReview }]}
-      type="button"
-      aria-haspopup="dialog"
-      aria-expanded={showReview}
-      title={m.criticbadge_reviewing_title()}
-      onclick={(e) => toggleReview(e)}
-    >
-      <span class="rev-dot" aria-hidden="true"></span>{m.criticbadge_reviewing()}
-    </button>
-  {:else}
-    <span class="verdict-chip critic-reviewing" title={m.criticbadge_reviewing_title()}>
-      <span class="rev-dot" aria-hidden="true"></span>{m.criticbadge_reviewing()}
-    </span>
-  {/if}
-{:else if chip.kind === "verdict"}
-  <button
-    class={["verdict-chip", `critic-${chip.decision}`, { armed: showReview }]}
-    type="button"
-    aria-haspopup="dialog"
-    aria-expanded={showReview}
-    title={m.gitrail_review_title()}
-    onclick={(e) => toggleReview(e)}
-  >
-    {chip.label}
-  </button>
-{/if}
-
-{#if canReview}
-  <button
-    class="gbtn"
-    class:armed={armed === "review"}
-    type="button"
-    onclick={() => doReview()}
-    use:coachTarget={"manual-critic-review"}
-  >
-    {reviewLabel}
-  </button>
-{/if}
-
-{#if canReviewPlan}
-  <button
-    class="gbtn"
-    class:armed={armed === "review-plan" && !planReviewBlockedReason}
-    type="button"
-    disabled={planReviewing}
-    aria-disabled={planReviewBlockedReason ? "true" : undefined}
-    title={planReviewBlockedReason ?? undefined}
-    aria-label={planReviewBlockedReason
-      ? `${planReviewLabel} — ${planReviewBlockedReason}`
-      : undefined}
-    onclick={() => {
-      if (planReviewBlockedReason) return;
-      doReviewPlan();
-    }}
-  >
-    {planReviewLabel}
-  </button>
 {/if}
 
 <style>
@@ -330,6 +397,17 @@
   .gbtn.merge:not(:disabled) {
     border-color: var(--color-amber);
     color: var(--color-amber);
+  }
+
+  /* status │ actions divider (mobile only — rendered iff mobile && hasPassive && hasActions).
+     Mirrors GitRail's own .rail-sep; the 8px side margins + the .rail 6px gap give 14px of
+     breathing room each side, marking the passive-status → tap-target boundary. */
+  .rail-status-sep {
+    width: 1px;
+    align-self: stretch;
+    background: var(--color-line);
+    flex-shrink: 0;
+    margin: 0 8px;
   }
 
   /* Status Chip — component-scoped copy of the canonical recipe (DESIGN.json;


### PR DESCRIPTION
## Problem

On the mobile git-rail chip strip, passive readouts (~23px) and tap targets (44px) were interleaved, so the row looked jagged (two shape heights that "occasionally look weird"). Two issues underneath the visual one:

1. **Ordering** — passive status could sit between tall controls (`PR ● PENDING Merge`).
2. **A11y** — `Issue` (`<a>`) and `PR` (`<button>`) are real tap targets rendered at ~23px, **below the 44px touch-target floor**.

## Fix (design reached via an interactive mockup review)

Split the row by **affordance**, keyed on the element type the DOM already carries:

- **Tappable** (`a`/`button` chips, `.gbtn`, verdict button, ReadyToggle) → uniform **44px** outlined boxes. Promoting `Issue`/`PR` to 44px fixes the sub-44 a11y violation.
- **Passive** (`span` status/verdict chips: CI, merged, closed, plain/ready PR, reviewing-no-findings) → **de-boxed** into inline dot+hued-text labels, grouped into a **leading status zone**, split from the controls by a divider.

Row now reads `status │ actions`; no short item sits between tall boxes.

### Key implementation points

- `RailStatusActions.svelte` reorganised into `passiveZone` / `actionsZone` snippets. Single-source-of-truth `hasPassive` / `hasActions` `$derived`s (each term mirrors exactly one item's render guard) gate the seam on **`hasPassive && hasActions`**, so the divider can never orphan — neither leading (steal the `.rail` `margin-left:auto` first-child) nor trailing (double up with GitRail's own `rail-sep` → `[closed] │ │`).
- Height/de-box/spacing CSS is scoped to `.rail.mobile`; the non-`mobile` path (test-only) is unchanged. The `span.` selector prefix keeps the de-box specific enough to beat the `.status-chip.info/.pend/…` hue variants.
- Base `.rail-sep` (shared with the test-only desktop mount) is left untouched; the mobile margin is added only under `.rail.mobile`.
- All rail dividers now get **14px** breathing room each side (`status│actions` seam, automation `rail-sep`, and the `.strip-controls` autopilot divider).
- The `closed` passive term keys off the template `{:else}` catch-all (`!none && !open && !merged`), not `=== "closed"`, so it can't drift if a 5th `GitState.state` value is ever added.

### Fallow

The affordance split adds per-item zone guards, taking `RailStatusActions:<template>` cognitive complexity to 68 (just over the Tier-1 60 bar; cyclomatic stays at 36, under). Added a narrow per-template threshold override with a reason + #855 tracking, matching the existing Viewport/Settings/NewTask/PromptSources entries.

## Testing

- `bun run check` — 0 errors · `check:i18n` — 2 locales in parity (no new keys)
- `bun run test:node` — 2423 pass · `bun run test:browser` — 1421 pass
- New browser-test coverage: promoted Issue/PR reach 44px; de-boxed passive labels stay short and precede the first control; exactly one seam between zones (open); **no orphan seam** in `state:none`+autopilot (leading) and `state:closed`/empty-actions (trailing); right-pin first-child holds in both passive-present and passive-empty cases.
- `fallow audit` — passes (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)