### PR TITLE
fix(ui): show repo on Owed lens cards

### DIFF
--- a/ui/src/lib/components/PostMergeStepsPanel.browser.test.ts
+++ b/ui/src/lib/components/PostMergeStepsPanel.browser.test.ts
@@ -30,6 +30,7 @@ vi.mock("$lib/api", async (importOriginal) => {
 });
 
 const { postMergeSteps } = await import("$lib/post-merge-steps.svelte");
+const { projectIcons } = await import("$lib/projectIcons.svelte");
 const PostMergeStepsPanel = (await import("./PostMergeStepsPanel.svelte")).default;
 
 function record(p: Partial<PostMergeSteps> & { sessionId: string }): PostMergeSteps {
@@ -54,6 +55,7 @@ function record(p: Partial<PostMergeSteps> & { sessionId: string }): PostMergeSt
 function snapshot(p: Partial<OwedFocusSnapshot> & { sessionId: string }): OwedFocusSnapshot {
   return {
     desig: "TASK-09",
+    repoPath: "/repo/shepherd",
     prNumber: 12,
     steps: [
       { id: "ms1", text: "Set FLAG=1", postMerge: false },
@@ -69,8 +71,28 @@ describe("PostMergeStepsPanel", () => {
     postMergeSteps.records = [];
     postMergeSteps.loaded = false;
     postMergeSteps.settled = false;
+    projectIcons.map = {};
     setManualStepDone.mockClear();
     dismissManualSteps.mockClear();
+  });
+
+  it("live card shows the repo marker: basename + project emoji when set", async () => {
+    projectIcons.map = { "/repo/shepherd": "🐑" };
+    postMergeSteps.records = [record({ sessionId: "s1", repoPath: "/repo/shepherd" })];
+    const screen = await render(PostMergeStepsPanel);
+    await expect.element(page.getByText("shepherd")).toBeInTheDocument();
+    const icon = screen.container.querySelector(".ow-repo-icon");
+    expect(icon).not.toBeNull();
+    expect(icon?.textContent).toBe("🐑");
+  });
+
+  it("live card with no project emoji renders name-only — no ▣, no icon slot", async () => {
+    // projectIcons.map is empty (reset in beforeEach) → iconFor returns null.
+    postMergeSteps.records = [record({ sessionId: "s1", repoPath: "/repo/web-app" })];
+    const screen = await render(PostMergeStepsPanel);
+    await expect.element(page.getByText("web-app")).toBeInTheDocument();
+    expect(screen.container.querySelector(".ow-repo-icon")).toBeNull();
+    expect(screen.container.textContent).not.toContain("▣");
   });
 
   it("shows the empty state when nothing is owed", async () => {
@@ -157,6 +179,22 @@ describe("PostMergeStepsPanel — focus (#1275)", () => {
     postMergeSteps.records = [];
     postMergeSteps.loaded = false;
     postMergeSteps.settled = false;
+    projectIcons.map = {};
+  });
+
+  it("frozen fallback card shows the repo marker (basename from the snapshot's repoPath)", async () => {
+    // merged + cleared → frozen card (no live record). The repo reference must render here too.
+    postMergeSteps.loaded = true;
+    postMergeSteps.settled = true;
+    const screen = await render(PostMergeStepsPanel, {
+      focusSnapshot: snapshot({ sessionId: "s1", merged: true, repoPath: "/repo/shepherd" }),
+      focusNonce: 1,
+      focusHandledNonce: 0,
+    });
+    await expect.element(page.getByText(m.owed_frozen_cleared_note())).toBeInTheDocument();
+    const frozen = screen.container.querySelector(".ow-card--frozen");
+    expect(frozen).not.toBeNull();
+    expect(frozen?.querySelector(".ow-repo")?.textContent).toContain("shepherd");
   });
 
   it("live record + loaded: highlights the live card, no frozen fallback", async () => {

--- a/ui/src/lib/components/PostMergeStepsPanel.svelte
+++ b/ui/src/lib/components/PostMergeStepsPanel.svelte
@@ -2,6 +2,8 @@
   import { onDestroy, tick } from "svelte";
   import type { PostMergeSteps, OwedFocusSnapshot } from "$lib/types";
   import { postMergeSteps, owedRecordsForRepo } from "$lib/post-merge-steps.svelte";
+  import { projectIcons } from "$lib/projectIcons.svelte";
+  import { basename } from "./learnings-drawer";
   import { formatAgo } from "$lib/format";
   import { clock } from "$lib/now.svelte";
   import { m } from "$lib/paraglide/messages";
@@ -156,6 +158,12 @@
       >
         <header class="ow-card-head">
           <div class="ow-card-id">
+            <span class="ow-repo" title={frozenCard.repoPath}>
+              {#if projectIcons.iconFor(frozenCard.repoPath)}<span
+                  class="ow-repo-icon"
+                  aria-hidden="true">{projectIcons.iconFor(frozenCard.repoPath)}</span
+                >{/if}{basename(frozenCard.repoPath)}
+            </span>
             <span class="ow-desig">{frozenCard.desig}</span>
             {#if frozenCard.prNumber != null}<span class="ow-pr">#{frozenCard.prNumber}</span>{/if}
           </div>
@@ -189,6 +197,12 @@
         >
           <header class="ow-card-head">
             <div class="ow-card-id">
+              <span class="ow-repo" title={rec.repoPath}>
+                {#if projectIcons.iconFor(rec.repoPath)}<span
+                    class="ow-repo-icon"
+                    aria-hidden="true">{projectIcons.iconFor(rec.repoPath)}</span
+                  >{/if}{basename(rec.repoPath)}
+              </span>
               <span class="ow-desig">{rec.desig}</span>
               {#if rec.prNumber != null}<span class="ow-pr">#{rec.prNumber}</span>{/if}
               <span class="ow-count"
@@ -306,6 +320,23 @@
     align-items: baseline;
     gap: 8px;
     flex-wrap: wrap;
+  }
+  /* Quiet repo identity marker ahead of the designation — mirrors EpicGroupHeader's
+     .repo / .repo-icon (icon only when set, no ▣ fallback). */
+  .ow-repo {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    min-width: 0;
+    max-width: 16ch;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+  }
+  .ow-repo-icon {
+    flex: none;
   }
   .ow-desig {
     font-size: var(--fs-sm);

--- a/ui/src/lib/components/PostMergeStepsPanel.svelte
+++ b/ui/src/lib/components/PostMergeStepsPanel.svelte
@@ -151,6 +151,7 @@
   {:else}
     <p class="ow-note">{m.owed_note()}</p>
     {#if frozenCard}
+      {@const frozenIcon = projectIcons.iconFor(frozenCard.repoPath)}
       <section
         class="ow-card ow-card--frozen"
         data-session-id={frozenCard.sessionId}
@@ -159,9 +160,7 @@
         <header class="ow-card-head">
           <div class="ow-card-id">
             <span class="ow-repo" title={frozenCard.repoPath}>
-              {#if projectIcons.iconFor(frozenCard.repoPath)}<span
-                  class="ow-repo-icon"
-                  aria-hidden="true">{projectIcons.iconFor(frozenCard.repoPath)}</span
+              {#if frozenIcon}<span class="ow-repo-icon" aria-hidden="true">{frozenIcon}</span
                 >{/if}{basename(frozenCard.repoPath)}
             </span>
             <span class="ow-desig">{frozenCard.desig}</span>
@@ -190,6 +189,7 @@
     {/if}
     <div class="ow-list">
       {#each shownRecords as rec (rec.sessionId)}
+        {@const repoIcon = projectIcons.iconFor(rec.repoPath)}
         <section
           class="ow-card"
           data-session-id={rec.sessionId}
@@ -198,9 +198,7 @@
           <header class="ow-card-head">
             <div class="ow-card-id">
               <span class="ow-repo" title={rec.repoPath}>
-                {#if projectIcons.iconFor(rec.repoPath)}<span
-                    class="ow-repo-icon"
-                    aria-hidden="true">{projectIcons.iconFor(rec.repoPath)}</span
+                {#if repoIcon}<span class="ow-repo-icon" aria-hidden="true">{repoIcon}</span
                   >{/if}{basename(rec.repoPath)}
               </span>
               <span class="ow-desig">{rec.desig}</span>

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1123,6 +1123,7 @@ export interface PostMergeSteps {
 export interface OwedFocusSnapshot {
   sessionId: string;
   desig: string;
+  repoPath: string; // session.repoPath — feeds the frozen card's repo reference (keys projectIcons)
   prNumber: number | null;
   steps: ManualStep[]; // frozen from session.manualSteps at click time
   merged: boolean; // git state === "merged" at click time

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -2455,6 +2455,7 @@
       owedFocusSnapshot = {
         sessionId: id,
         desig: s.desig,
+        repoPath: s.repoPath,
         prNumber: store.git[id]?.number ?? null,
         steps: s.manualSteps,
         merged: store.git[id]?.state === "merged",


### PR DESCRIPTION
## Problem

The Owed lens (`PostMergeStepsPanel`) aggregates outstanding post-merge manual-step cards across **all** repos, but a card showed only its designation (`TASK-1503`), PR number, count, and title — never **which repo** the steps affect. In a multi-repo herd there was no way to tell a `TASK-1503` in one repo from another.

## Change

Add a quiet **icon + repo-name** marker leading each card's identity row, following the nearest structural precedent — `EpicGroupHeader`'s repo marker (icon rendered only when a project emoji is set, **no `▣` fallback**; emoji-less repos render name-only), **not** the interactive RepoSwitcher chip.

- **Live card** — `PostMergeSteps.repoPath` was already on the record; just render it.
- **Frozen fallback card** — added `repoPath` to `OwedFocusSnapshot`, populated from `s.repoPath` at the single construction site (`onShowOwed`).

Both variants key `projectIcons.iconFor` on the **same** `session.repoPath` (the server builds the live record with `repoPath: session.repoPath` in `src/post-merge-steps.ts`; the snapshot copies `s.repoPath`), so the icon resolves identically on both — no silent fallback on one card variant but not the other.

The repo name is verbatim path data (not app chrome) → not translated, no new i18n key. The emoji is `aria-hidden`; the basename stays screen-reader readable. Styling uses design-system tokens only (quiet `--color-muted`, `--fs-meta`).

## Tests

Expanded `PostMergeStepsPanel.browser.test.ts`:
- repo basename renders on a **live** card (with project emoji shown when set);
- repo basename renders on the **frozen** fallback card;
- **unset-icon path**: an emoji-less repo renders **name-only** — no `▣`, no stray glyph.

All 21 panel tests + full UI suite (3866) pass; `bun run check`, `check:i18n`, prettier, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)