### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs-site/src/content/docs/reference/glossary.md
+++ b/docs-site/src/content/docs/reference/glossary.md
@@ -68,7 +68,8 @@ the model reasons before answering — higher effort spends more tokens for deep
 reasoning, lower is faster and cheaper. Selectable per session in the New Task
 picker — and when spawning a variant, comparison, or replacement — with a per-repo
 or global default in Settings, plus a per-role override for each satellite pass
-(critic, planner, recap, doc-agent, distiller, namer, autopilot) in the Settings agent matrix;
+(critic, planner, recap, doc-agent, distiller, optimizer, merge-suggester, rundown,
+namer, autopilot) in the Settings agent matrix;
 leave it at **default** to use the CLI's own effort. Shepherd passes it to the
 agent CLI as `--effort` (Claude) or `model_reasoning_effort` (Codex).
 


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc-update summary

## Changes

- **`docs-site/src/content/docs/reference/glossary.md`** — In the **Reasoning effort**
  entry, extended the enumerated list of Settings-agent-matrix roles that carry a
  per-role effort override to include `optimizer`, `merge-suggester`, and `rundown`
  (the list previously read `critic, planner, recap, doc-agent, distiller, namer,
  autopilot`).
  - _Source:_ these three roles each gained a per-role CLI/model/**effort** setting
    that is persisted + UI-configurable in the agent matrix, added after the last
    doc-sync (#1773) but before this run:
    - `rundownEffort` — `feat(rundown): make herd digest provider-aware` (#1779, `e5c0a067`)
    - `optimizerEffort` — `feat(learnings): make Learnings Optimizer provider-aware` (#1781, `966389b6`)
    - `mergeSuggestEffort` — `feat(learnings): make merge suggester provider-aware` (#1783, `b20aadf8`)
  - All three are confirmed in `src/config.ts` (`rundownEffort` / `optimizerEffort` /
    `mergeSuggestEffort`, each “Persisted + UI-configurable”) and surfaced in the
    Settings agent matrix (`ui/messages/en.json`: `settings_role_model_rundown_title`,
    `settings_role_model_optimizer_title`, `settings_role_model_merge_suggest_title`).
  - This mirrors the sole prior doc-sync change (#1773, `82d7f950`), which added
    `distiller` to exactly this list when the Distiller became provider/effort-aware
    (#1769). Adding `distiller` but not the three roles that landed the same day was an
    oversight the list is meant to track.

## Uncertain / needs human judgment

- **New per-role env vars not documented in `docs-site/.../reference/configuration.md`.**
  The recent provider-aware work added `SHEPHERD_DISTILLER_{CLI,MODEL,EFFORT}` +
  `SHEPHERD_DISTILLER_INTERVAL_DAYS` (#1769), `SHEPHERD_RUNDOWN_{CLI,MODEL,EFFORT}`
  (#1779), `SHEPHERD_OPTIMIZER_{CLI,MODEL,EFFORT}` (#1781), and
  `SHEPHERD_MERGE_SUGGEST_{CLI,MODEL,EFFORT}` (#1783). `configuration.md` currently
  documents per-role env vars **only** for the doc agent (`SHEPHERD_DOC_AGENT_*`) and
  does not enumerate the other roles' vars (`SHEPHERD_CRITIC_*`, `SHEPHERD_PLANNER_*`,
  `SHEPHERD_RECAP_*`, `SHEPHERD_NAMER_*`, `SHEPHERD_AUTOPILOT_*`, etc.) either. Because
  these role vars have never been documented there, adding them is **new content**, not
  a staleness fix — left as-is. A human may want to decide whether `configuration.md`
  should grow a "per-role agent environment" section covering all of them uniformly.

- **`docs/sandbox-security.md` line-number references.** The note cites approximate
  `src/sandbox.ts` / `src/service.ts` line numbers (e.g. `~L554`, `~L2697`,
  `src/sandbox.ts:315-317`). No sandbox/egress source changed in the recent history
  inspected, so these were left untouched; they were not line-verified against the
  current files in this pass.