### PR TITLE
fix(codex-update): show completed version transition

### DIFF
--- a/ui/src/lib/components/CodexUpdateModal.browser.test.ts
+++ b/ui/src/lib/components/CodexUpdateModal.browser.test.ts
@@ -78,4 +78,17 @@ describe("CodexUpdateModal", () => {
       ),
     );
   });
+
+  it("keeps the completed update's actual version transition after status refreshes", async () => {
+    const { rerender } = await render(CodexUpdateModal, { props: { update } });
+
+    await rerender({
+      update: { ...update, current: "0.142.5", latest: "0.142.5", updateAvailable: false },
+      done: { ok: true, from: "0.142.4", to: "0.142.5" },
+    });
+
+    await vi.waitFor(() =>
+      expect(document.querySelector(".versions")?.textContent).toContain("0.142.4 → 0.142.5"),
+    );
+  });
 });

--- a/ui/src/lib/components/CodexUpdateModal.svelte
+++ b/ui/src/lib/components/CodexUpdateModal.svelte
@@ -24,6 +24,8 @@
   let logEl = $state<HTMLPreElement | null>(null);
 
   const CODEX_RELEASES_URL = "https://github.com/openai/codex/releases";
+  const displayedCurrent = $derived(done?.from ?? update.current);
+  const displayedLatest = $derived(done?.to ?? update.latest);
 
   // `codex update` runs server-side in a managed child; shepherd stays up and the
   // modal resolves itself via the `done` result. Busy only while the update is in
@@ -77,12 +79,12 @@
       >
     </div>
 
-    {#if update.current && update.latest}
+    {#if displayedCurrent && displayedLatest}
       <div class="summary">
         <span class="versions"
           >{m.codexupdate_versions({
-            current: update.current,
-            latest: update.latest,
+            current: displayedCurrent,
+            latest: displayedLatest,
           })}</span
         >
       </div>


### PR DESCRIPTION
## Problem

After a Codex update finishes, the modal refreshes its availability status. Both displayed versions can then be the newly installed version, making the transition read `0.144.5 → 0.144.5` instead of showing what actually changed.

## Solution

The completed modal now uses the terminal update result to display the actual `from → to` version transition. The pre-update and in-progress view still uses the available update status.

## Technical details

- Derive the summary versions from `done.from` and `done.to` once a terminal result is available, with the existing status values as fallback.
- Add browser coverage for a refreshed `new → new` status following a successful update.
- Verified with the focused browser test, `bun run check`, and `bun run check:i18n`.