### PR TITLE
fix(usage): reconcile weekly gauge after a mid-window reset; hide dead credits

### DIFF
--- a/src/usage-limits.ts
+++ b/src/usage-limits.ts
@@ -354,6 +354,14 @@ export interface UsageProviderSource {
 // 1h, unlike the 2-week cap stale that tolerates JSONL-recomputed windows drifting.
 const CREDIT_STALE_MS = 60 * 60 * 1000;
 
+// Beyond this age the credit snapshot is treated as DEAD (extra usage was turned off): calibrate
+// runs at least daily, so a snapshot older than two calibration cycles means the `/usage` panel has
+// stopped rendering a credits section across multiple successful scrapes — the account no longer has
+// credits enabled. `limits()` drops it entirely rather than lingering a "SCRAPED Nd AGO / SNAPSHOT
+// STALE" gauge the user can't refresh away. The persisted snapshot + history are untouched, so if
+// credits are re-enabled the next scrape re-populates it and the gauge returns.
+const CREDIT_DROP_MS = 2 * CALIBRATE_INTERVAL_MS;
+
 // Per-model weekly passthrough is scrape-fresh-only too, but — unlike credits — it isn't put on
 // the near-cap 15-min watch cadence, so a 1h stale would flip it "stale" within an hour of every
 // daily calibration. Tie it to the calibration cadence, tolerant of one missed daily run.
@@ -526,6 +534,30 @@ export class UsageLimitsService {
     return any;
   }
 
+  /**
+   * Effective units consumed in the current window, anchored to the last scrape.
+   *
+   * `row.pct` is the account's true % at `row.scrapedAt` (⇒ `pct/100 * cap` units), so we add ONLY
+   * local usage since the scrape. This reconciles a mid-window account reset — Claude zeroes the
+   * weekly counter without moving the reset boundary — that a fixed windowed sum misses: the
+   * pre-reset usage stays inside the window but no longer counts toward the account cap, and a
+   * scraped `pct` below MIN_CALIBRATION_PCT can't re-invert the cap, so `windowSum/cap` would stay
+   * stuck at the pre-reset % forever (the "usage reset but the gauge won't update" bug).
+   *
+   * In the normal (non-reset) path this is provably identical to `windowSum(windowStart, now)/cap`:
+   * the cap was inverted from `unitsAtScrape / (pct/100)`, so `pct/100*cap == unitsAtScrape` and
+   * `unitsAtScrape + windowSum(scrapedAt, now) == windowSum(windowStart, now)`.
+   *
+   * When the window has rolled over since the scrape (`resetAt` advanced past the stored anchor),
+   * the anchor belongs to the previous window — fall back to the plain windowed sum of the fresh
+   * window (matches the pre-anchor post-boundary behavior).
+   */
+  private currentUnits(row: CapRow, resetAt: number, now: number): number {
+    const period = PERIOD_MS[row.window];
+    if (resetAt !== row.resetAt) return this.index.windowSum(resetAt - period, now);
+    return (row.pct / 100) * row.cap + this.index.windowSum(row.scrapedAt, now);
+  }
+
   /** Current live limits, recomputed from local JSONL against the calibrated caps. */
   limits(now: number): UsageLimits {
     const rows = new Map(this.caps.getCaps().map((r) => [r.window, r]));
@@ -535,8 +567,7 @@ export class UsageLimitsService {
       if (!row || row.cap <= 0) return null;
       calibratedAt = Math.max(calibratedAt ?? 0, row.scrapedAt);
       const resetAt = rollForward(row.resetAt, PERIOD_MS[key], now);
-      const units = this.index.windowSum(resetAt - PERIOD_MS[key], now);
-      return { pct: clampPct((units / row.cap) * 100), resetAt };
+      return { pct: clampPct((this.currentUnits(row, resetAt, now) / row.cap) * 100), resetAt };
     };
     const session5h = compute("session5h");
     const week = compute("week");
@@ -544,10 +575,16 @@ export class UsageLimitsService {
     // Credits is a passthrough of the stored snapshot — not recomputed from JSONL.
     const snap = this.creditStore.getCreditSnapshot();
     let credits: CreditWindow | null = null;
-    // Post-reset guard: a snapshot whose monthly budget has already rolled over is meaningless
-    // until re-scraped — drop it (also stops the gauge showing a past reset date). An unparseable
-    // (null) resetAt can't be known to have rolled over, so it passes through.
-    if (snap && !(snap.resetAt != null && snap.resetAt <= now)) {
+    // Two guards keep `credits` null (gauge hidden):
+    //  1. Post-reset: a snapshot whose monthly budget already rolled over is meaningless until
+    //     re-scraped (also stops the gauge showing a past reset date). An unparseable (null)
+    //     resetAt can't be known to have rolled over, so it passes through.
+    //  2. Dead: a snapshot older than CREDIT_DROP_MS means extra usage was turned off (the `/usage`
+    //     panel stopped rendering credits across multiple daily scrapes) — hide it rather than
+    //     linger a stale, un-refreshable "SCRAPED Nd AGO" gauge. The snapshot itself is untouched.
+    const rolledOver = snap != null && snap.resetAt != null && snap.resetAt <= now;
+    const dead = snap != null && now - snap.scrapedAt > CREDIT_DROP_MS;
+    if (snap && !rolledOver && !dead) {
       credits = {
         pct: snap.pct,
         spent: snap.spent,
@@ -616,7 +653,9 @@ export class UsageLimitsService {
       const period = PERIOD_MS[key];
       const resetAt = rollForward(row.resetAt, period, now);
       const windowStart = resetAt - period;
-      const curUnits = this.index.windowSum(windowStart, now);
+      // Anchored to the last scrape (same reconciliation as limits()) so a mid-window reset doesn't
+      // leave the projection basing off pre-reset usage that no longer counts.
+      const curUnits = this.currentUnits(row, resetAt, now);
       const lookback = LOOKBACK_MS[key];
       // numerator start clamped to windowStart so the trailing window never bleeds
       // pre-reset burn into a fresh window; denominator stays the NOMINAL lookback hours

--- a/test/usage-limits.test.ts
+++ b/test/usage-limits.test.ts
@@ -425,6 +425,30 @@ test("limits computes pct = units/cap and rolls the reset anchor forward", () =>
   expect(l.stale).toBe(false);
 });
 
+test("limits reconciles a mid-window weekly reset: a scraped 0% drops the gauge off a stale high local sum", () => {
+  const H = 3_600_000;
+  const WEEK = 7 * 24 * H;
+  const now = NOW;
+  const resetAt = now + 2 * H; // the weekly boundary did NOT move — the reset only zeroed the counter
+  const windowStart = resetAt - WEEK;
+  // Account JSONL still holds ~the whole cap of pre-reset usage inside the (unchanged) window.
+  const index = seededIndex([{ ts: windowStart + H, units: 980 }]);
+  const caps = new MemCaps();
+
+  // Before the reset: calibrated at 98% (980/1000). The gauge reads 98%.
+  caps.putCap({ window: "week", cap: 1000, resetAt, pct: 98, scrapedAt: windowStart + 2 * H });
+  const pre = new UsageLimitsService(index, caps, new StubProbe(null), new MemCredits());
+  expect(pre.limits(now).week!.pct).toBe(98);
+
+  // The reset scrape lands: 0% < MIN_CALIBRATION_PCT so the cap is unchanged, but the anchor is
+  // re-stamped to pct=0 at `now` (same resetAt) — exactly the row calibrateWindow persists.
+  caps.putCap({ window: "week", cap: 1000, resetAt, pct: 0, scrapedAt: now });
+  const post = new UsageLimitsService(index, caps, new StubProbe(null), new MemCredits());
+  // Pre-anchor code returned windowSum/cap = 980/1000 = 98% forever (the reported bug); anchored to
+  // the fresh scrape it tracks 0% + (no) post-scrape usage.
+  expect(post.limits(now).week!.pct).toBe(0);
+});
+
 test("limits clamps to 100 and reports stale when never calibrated", () => {
   const empty = new UsageLimitsService(
     fakeIndex(0),
@@ -451,7 +475,8 @@ test("limits keeps Claude usage when an extra provider throws", () => {
     },
   };
   const svc = new UsageLimitsService(
-    fakeIndex(50),
+    // no post-scrape usage → the gauge shows the scraped anchor pct (20%) verbatim
+    seededIndex([]),
     caps,
     new StubProbe(null),
     new MemCredits(),
@@ -461,7 +486,7 @@ test("limits keeps Claude usage when an extra provider throws", () => {
 
   const l = svc.limits(NOW);
 
-  expect(l.week!.pct).toBe(25);
+  expect(l.week!.pct).toBe(20);
   expect(l.providers).toHaveLength(1);
   expect(l.providers?.[0]?.provider).toBe("claude");
 });
@@ -547,6 +572,24 @@ test("limits drops a credit snapshot whose monthly budget already reset", () => 
   });
   const svc = new UsageLimitsService(fakeIndex(0), new MemCaps(), new StubProbe(null), credits);
   expect(svc.limits(NOW).credits).toBeNull();
+});
+
+test("limits drops a dead credit snapshot (extra usage turned off) past CREDIT_DROP_MS", () => {
+  const credits = new MemCredits();
+  const DAY = 24 * 3600_000;
+  credits.putCreditSnapshot({
+    spent: 46.47,
+    cap: 100,
+    currency: "€",
+    pct: 46,
+    resetAt: NOW + 30 * DAY, // monthly reset still ahead → NOT the post-reset drop
+    scrapedAt: NOW - 3 * DAY, // 3 days stale: past CREDIT_DROP_MS (2 daily calibrations)
+  });
+  const svc = new UsageLimitsService(fakeIndex(0), new MemCaps(), new StubProbe(null), credits);
+  // Hidden entirely rather than lingered as a stale, un-refreshable "SCRAPED Nd AGO" gauge.
+  expect(svc.limits(NOW).credits).toBeNull();
+  // The snapshot itself is untouched — recoverable if credits are re-enabled and re-scraped.
+  expect(credits.getCreditSnapshot()).not.toBeNull();
 });
 
 test("limits keeps a credit snapshot with an unparseable (null) resetAt", () => {
@@ -752,9 +795,9 @@ test("projections: will-exceed (projectedPct > 100) is NOT clamped", () => {
   const now = NOW;
   const resetAt = now + 2 * H;
   const caps = new MemCaps();
-  // cap=100, windowStart=now-3h
-  caps.putCap({ window: "session5h", cap: 100, resetAt, pct: 50, scrapedAt: now });
-  // 200 units in last 0.5h → burnRatePerHour=200, curUnits=200, hoursToReset=2
+  // cap=100, windowStart=now-3h; scraped 0% at now-1h so the whole window's burn is post-scrape
+  caps.putCap({ window: "session5h", cap: 100, resetAt, pct: 0, scrapedAt: now - H });
+  // 200 units in last 0.5h → burnRatePerHour=200, curUnits = 0-anchor + 200 delta = 200, hoursToReset=2
   // projectedPct = round((200 + 200*2)/100 * 100) = 600
   const records = [{ ts: now - 0.5 * H, units: 200 }];
   const svc = new UsageLimitsService(
@@ -790,8 +833,9 @@ test("projections: just-after-reset boundary excludes pre-reset records", () => 
   );
   const proj = svc.projections(now);
   const p = proj[0]!;
-  // (a) pre-reset records excluded → curUnits=10, projectedPct = round((10 + 10*4.5)/1000*100) = 6
-  expect(p.projectedPct).toBe(6);
+  // (a) curUnits anchored to the scrape (5% of 1000 = 50) + post-scrape delta (windowSum(now,now)=0)
+  //     = 50; projectedPct = round((50 + 10*4.5)/1000*100) = round(9.5) = 10
+  expect(p.projectedPct).toBe(10);
   // recentUnits clamped to windowStart → only the 0.25h record = 10; burnRatePerHour = 10
   expect(p.burnRatePerHour).toBe(10);
   // (b) non-vacuous: unclamped windowSum(now-1h, now) WOULD include the pre-reset record

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1276,7 +1276,7 @@
   "topbar_credits_age_now": "gerade abgerufen",
   "topbar_credits_stale": "Snapshot veraltet — für Live-Verbrauch aktualisieren",
   "topbar_credits_alert_aria": "Zusatzguthaben in Nutzung: {amount}",
-  "topbar_credits_refresh": "Aktualisieren",
+  "topbar_usage_refresh": "Aktualisieren",
   "settings_extra_credits_ceiling_title": "Ausgabenlimit für Zusatzguthaben",
   "settings_extra_credits_ceiling_hint": "Pausiert autonomen Drain und Autopilot, sobald die seit dem letzten Reset des Wochenfensters angefallenen Pay-as-you-go-Ausgaben für Zusatzguthaben (echtes Geld über dein Abo hinaus) diesen Betrag in deiner Kontowährung übersteigen. 0 pausiert bei jeglichen neuen Zusatzguthaben-Ausgaben. Aus einer früheren Woche übernommene Ausgaben zählen nicht mehr, sobald das Wochenfenster zurücksetzt — die Pause folgt so deinem Abo-Rhythmus, nicht dem monatlichen Guthaben-Reset.",
   "settings_extra_credits_ceiling_label": "Pausieren, wenn Ausgaben übersteigen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1276,7 +1276,7 @@
   "topbar_credits_age_now": "scraped just now",
   "topbar_credits_stale": "snapshot stale — refresh for live spend",
   "topbar_credits_alert_aria": "Extra credits in use: {amount}",
-  "topbar_credits_refresh": "Refresh",
+  "topbar_usage_refresh": "Refresh",
   "settings_extra_credits_ceiling_title": "Extra-credit spend ceiling",
   "settings_extra_credits_ceiling_hint": "Pauses autonomous drain and autopilot once pay-as-you-go extra-credit spend (real money beyond your subscription) accrued since the weekly window reset exceeds this amount, in your account currency. 0 pauses on any new extra-credit spend. Overage carried over from an earlier week stops counting once the weekly window resets, so the pause tracks your subscription cadence — not the monthly credit reset.",
   "settings_extra_credits_ceiling_label": "Pause when spend exceeds",

--- a/ui/src/lib/components/TopBar.browser.test.ts
+++ b/ui/src/lib/components/TopBar.browser.test.ts
@@ -1604,8 +1604,10 @@ describe("TopBar — CR extra-credit gauge", () => {
     // 2-decimal precision, aligned with the server push copy (src/push.ts extraCreditsBody)
     expect(txt, "cap").toContain("€50.00");
     expect(txt, "snapshot age (5m)").toContain(m.topbar_credits_age({ age: "5m" }));
-    // REFRESH is reachable — present in the open, clickable dialog (the bug was it closed on mouseout)
-    expect(detail!.querySelector(".credit-refresh"), "refresh button reachable").not.toBeNull();
+    // REFRESH is reachable — present in the open, clickable dialog (the bug was it closed on mouseout).
+    // It lives at the Claude-section level now (not inside the credit block), so it survives credits
+    // being hidden.
+    expect(pop!.querySelector(".usage-refresh"), "refresh button reachable").not.toBeNull();
   });
 
   it("a stale Claude snapshot dims only the Claude section, not fresh Codex usage", async () => {
@@ -1686,10 +1688,7 @@ describe("TopBar — CR extra-credit gauge", () => {
     await nextFrame();
     const detail = hud.querySelector<HTMLElement>(".credit-detail");
     expect(detail, "credit detail in credits-only popover").not.toBeNull();
-    expect(
-      detail!.querySelector(".credit-refresh"),
-      "refresh reachable in credits-only",
-    ).not.toBeNull();
+    expect(hud.querySelector(".usage-refresh"), "refresh reachable in credits-only").not.toBeNull();
     // no usage windows → the popover carries no 5-Hour/Weekly window blocks (only the credit detail,
     // whose own header reads "Extra credits", not a window period label)
     const pop = hud.querySelector<HTMLElement>(".gauge-pop-desk");
@@ -1906,7 +1905,7 @@ describe("TopBar — CR extra-credit gauge", () => {
 
   it("fail-closed: a rejected refresh surfaces the error state, not silent success", async () => {
     // The house-rule fail-closed path: refreshUsage() rejects → the popover must show
-    // its visible error state (role=alert / .credit-error / retry message) so the user
+    // its visible error state (role=alert / .usage-refresh-error / retry message) so the user
     // sees the refresh FAILED rather than it looking like a success.
     vi.mocked(refreshUsage).mockRejectedValueOnce(new Error("network down"));
     const hud = await renderDesktop(limitsWithCredit({}));
@@ -1915,16 +1914,16 @@ describe("TopBar — CR extra-credit gauge", () => {
     const detail = hud.querySelector<HTMLElement>(".credit-detail");
     expect(detail, "credit detail rendered on click").not.toBeNull();
     // No error before the refresh is attempted.
-    expect(detail!.querySelector(".credit-error"), "no error before refresh").toBeNull();
+    expect(hud.querySelector(".usage-refresh-error"), "no error before refresh").toBeNull();
 
-    const refreshBtn = detail!.querySelector<HTMLButtonElement>(".credit-refresh");
+    const refreshBtn = hud.querySelector<HTMLButtonElement>(".usage-refresh");
     expect(refreshBtn, "refresh button present").not.toBeNull();
     refreshBtn!.click();
 
     // The rejection sets refreshError → the error alert appears. Poll for the rAF/
     // microtask settle so a genuinely-missing error state still fails the test.
     await vi.waitFor(() => {
-      const err = hud.querySelector<HTMLElement>(".credit-error");
+      const err = hud.querySelector<HTMLElement>(".usage-refresh-error");
       expect(err, "error state appears on rejected refresh").not.toBeNull();
       expect(err!.getAttribute("role"), "error is an alert").toBe("alert");
       expect(err!.textContent ?? "", "retry message").toContain(m.common_retry());

--- a/ui/src/lib/components/top-bar/CreditDetail.svelte
+++ b/ui/src/lib/components/top-bar/CreditDetail.svelte
@@ -9,18 +9,12 @@
     creditColor,
     creditAmount,
     nowMs,
-    refreshing,
-    refreshError,
-    onRefresh,
   }: {
     credits: CreditWindow | null;
     creditFill: number;
     creditColor: string;
     creditAmount: string;
     nowMs: number;
-    refreshing: boolean;
-    refreshError: boolean;
-    onRefresh: () => void;
   } = $props();
 
   // relativeAge returns the "now" sentinel for <60s; branch it to a natural phrase
@@ -54,18 +48,6 @@
     </div>
     {#if credits.stale}
       <div class="credit-stale micro">{m.topbar_credits_stale()}</div>
-    {/if}
-    <button
-      type="button"
-      class="credit-refresh micro"
-      disabled={refreshing}
-      aria-busy={refreshing}
-      onclick={onRefresh}
-    >
-      {refreshing ? m.common_loading() : m.topbar_credits_refresh()}
-    </button>
-    {#if refreshError}
-      <div class="credit-error micro" role="alert">{m.common_retry()}</div>
     {/if}
   </div>
 {/if}
@@ -111,32 +93,6 @@
     text-transform: none;
     letter-spacing: 0.04em;
     color: var(--color-amber);
-  }
-  .credit-error {
-    text-transform: none;
-    letter-spacing: 0.04em;
-    color: var(--color-red);
-  }
-  .credit-refresh {
-    align-self: flex-start;
-    margin-top: 2px;
-    background: transparent;
-    border: 1px solid var(--color-line-bright);
-    border-radius: 2px;
-    color: var(--color-ink);
-    font: inherit;
-    font-size: var(--fs-meta);
-    text-transform: none;
-    letter-spacing: 0.04em;
-    padding: 4px 9px;
-    cursor: pointer;
-  }
-  .credit-refresh:hover:not(:disabled) {
-    background: var(--color-inset);
-  }
-  .credit-refresh:disabled {
-    cursor: default;
-    opacity: 0.5;
   }
   .gp-head {
     display: flex;

--- a/ui/src/lib/components/top-bar/TopBarMobileSheet.svelte
+++ b/ui/src/lib/components/top-bar/TopBarMobileSheet.svelte
@@ -209,16 +209,23 @@
                 <ModelWeekGauge {entry} {nowMs} />
               </div>
             {/each}
-            <CreditDetail
-              {credits}
-              {creditFill}
-              {creditColor}
-              {creditAmount}
-              {nowMs}
-              {refreshing}
-              {refreshError}
-              {onRefresh}
-            />
+            <CreditDetail {credits} {creditFill} {creditColor} {creditAmount} {nowMs} />
+            <!-- Section-level refresh (not inside the credits block) so it survives credits being
+                 hidden — a dead/absent credits panel must not take the only refresh control with it. -->
+            <div class="sheet-refresh">
+              <button
+                type="button"
+                class="usage-refresh micro"
+                disabled={refreshing}
+                aria-busy={refreshing}
+                onclick={onRefresh}
+              >
+                {refreshing ? m.common_loading() : m.topbar_usage_refresh()}
+              </button>
+              {#if refreshError}
+                <span class="usage-refresh-error micro" role="alert">{m.common_retry()}</span>
+              {/if}
+            </div>
           </div>
         {/if}
         {#if codexUsage}
@@ -576,6 +583,37 @@
   }
   .sheet-gauges.stale {
     opacity: 0.5;
+  }
+  /* Section-level refresh control (see markup note). */
+  .sheet-refresh {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding-top: 2px;
+  }
+  .usage-refresh {
+    background: transparent;
+    border: 1px solid var(--color-line-bright);
+    border-radius: 2px;
+    color: var(--color-ink);
+    font: inherit;
+    font-size: var(--fs-meta);
+    text-transform: none;
+    letter-spacing: 0.04em;
+    padding: 6px 11px;
+    cursor: pointer;
+  }
+  .usage-refresh:hover:not(:disabled) {
+    background: var(--color-inset);
+  }
+  .usage-refresh:disabled {
+    cursor: default;
+    opacity: 0.5;
+  }
+  .usage-refresh-error {
+    text-transform: none;
+    letter-spacing: 0.04em;
+    color: var(--color-red);
   }
   .sheet-model-row {
     display: flex;

--- a/ui/src/lib/components/top-bar/TopBarMobileSheet.svelte
+++ b/ui/src/lib/components/top-bar/TopBarMobileSheet.svelte
@@ -13,6 +13,7 @@
   import CreditDetail from "./CreditDetail.svelte";
   import LimitGaugeRow from "./LimitGaugeRow.svelte";
   import ModelWeekGauge from "../usage/ModelWeekGauge.svelte";
+  import UsageRefreshButton from "./UsageRefreshButton.svelte";
   import { codexGaugeList } from "../usage-gauges";
   import { formatTokenLabel } from "$lib/format";
   import { REPO_URL, DOCS_URL, version } from "$lib/build-info";
@@ -212,20 +213,7 @@
             <CreditDetail {credits} {creditFill} {creditColor} {creditAmount} {nowMs} />
             <!-- Section-level refresh (not inside the credits block) so it survives credits being
                  hidden — a dead/absent credits panel must not take the only refresh control with it. -->
-            <div class="sheet-refresh">
-              <button
-                type="button"
-                class="usage-refresh micro"
-                disabled={refreshing}
-                aria-busy={refreshing}
-                onclick={onRefresh}
-              >
-                {refreshing ? m.common_loading() : m.topbar_usage_refresh()}
-              </button>
-              {#if refreshError}
-                <span class="usage-refresh-error micro" role="alert">{m.common_retry()}</span>
-              {/if}
-            </div>
+            <UsageRefreshButton {refreshing} {refreshError} {onRefresh} />
           </div>
         {/if}
         {#if codexUsage}
@@ -583,37 +571,6 @@
   }
   .sheet-gauges.stale {
     opacity: 0.5;
-  }
-  /* Section-level refresh control (see markup note). */
-  .sheet-refresh {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding-top: 2px;
-  }
-  .usage-refresh {
-    background: transparent;
-    border: 1px solid var(--color-line-bright);
-    border-radius: 2px;
-    color: var(--color-ink);
-    font: inherit;
-    font-size: var(--fs-meta);
-    text-transform: none;
-    letter-spacing: 0.04em;
-    padding: 6px 11px;
-    cursor: pointer;
-  }
-  .usage-refresh:hover:not(:disabled) {
-    background: var(--color-inset);
-  }
-  .usage-refresh:disabled {
-    cursor: default;
-    opacity: 0.5;
-  }
-  .usage-refresh-error {
-    text-transform: none;
-    letter-spacing: 0.04em;
-    color: var(--color-red);
   }
   .sheet-model-row {
     display: flex;

--- a/ui/src/lib/components/top-bar/TopBarUsagePopover.svelte
+++ b/ui/src/lib/components/top-bar/TopBarUsagePopover.svelte
@@ -84,16 +84,7 @@
       {/each}
       {#if credits}
         <div class="gp-window">
-          <CreditDetail
-            {credits}
-            {creditFill}
-            {creditColor}
-            {creditAmount}
-            {nowMs}
-            {refreshing}
-            {refreshError}
-            {onRefresh}
-          />
+          <CreditDetail {credits} {creditFill} {creditColor} {creditAmount} {nowMs} />
         </div>
       {/if}
     {:else}
@@ -105,16 +96,26 @@
           <ModelWeekGauge {entry} {nowMs} />
         </div>
       {/each}
-      <CreditDetail
-        {credits}
-        {creditFill}
-        {creditColor}
-        {creditAmount}
-        {nowMs}
-        {refreshing}
-        {refreshError}
-        {onRefresh}
-      />
+      <CreditDetail {credits} {creditFill} {creditColor} {creditAmount} {nowMs} />
+    {/if}
+    {#if hasClaude}
+      <!-- Manual re-scrape of `/usage`. Lives at the Claude-section level (not inside the credits
+           block) so it survives when the credits gauge is hidden — a dead/absent credits panel must
+           not take the only refresh control with it. -->
+      <div class="gp-refresh">
+        <button
+          type="button"
+          class="usage-refresh micro"
+          disabled={refreshing}
+          aria-busy={refreshing}
+          onclick={onRefresh}
+        >
+          {refreshing ? m.common_loading() : m.topbar_usage_refresh()}
+        </button>
+        {#if refreshError}
+          <span class="usage-refresh-error micro" role="alert">{m.common_retry()}</span>
+        {/if}
+      </div>
     {/if}
   </div>
   {#if codexUsage}
@@ -171,6 +172,37 @@
   }
   .gauge-pop-row-model {
     margin-bottom: 6px;
+  }
+  /* Refresh control, section-level so it survives the credits gauge being hidden. */
+  .gp-refresh {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 10px;
+  }
+  .usage-refresh {
+    background: transparent;
+    border: 1px solid var(--color-line-bright);
+    border-radius: 2px;
+    color: var(--color-ink);
+    font: inherit;
+    font-size: var(--fs-meta);
+    text-transform: none;
+    letter-spacing: 0.04em;
+    padding: 4px 9px;
+    cursor: pointer;
+  }
+  .usage-refresh:hover:not(:disabled) {
+    background: var(--color-inset);
+  }
+  .usage-refresh:disabled {
+    cursor: default;
+    opacity: 0.5;
+  }
+  .usage-refresh-error {
+    text-transform: none;
+    letter-spacing: 0.04em;
+    color: var(--color-red);
   }
   .gauge-pop-link {
     appearance: none;

--- a/ui/src/lib/components/top-bar/TopBarUsagePopover.svelte
+++ b/ui/src/lib/components/top-bar/TopBarUsagePopover.svelte
@@ -8,6 +8,7 @@
   import CreditDetail from "./CreditDetail.svelte";
   import LimitGaugeRow from "./LimitGaugeRow.svelte";
   import ModelWeekGauge from "../usage/ModelWeekGauge.svelte";
+  import UsageRefreshButton from "./UsageRefreshButton.svelte";
 
   let {
     desktop,
@@ -99,22 +100,8 @@
       <CreditDetail {credits} {creditFill} {creditColor} {creditAmount} {nowMs} />
     {/if}
     {#if hasClaude}
-      <!-- Manual re-scrape of `/usage`. Lives at the Claude-section level (not inside the credits
-           block) so it survives when the credits gauge is hidden — a dead/absent credits panel must
-           not take the only refresh control with it. -->
       <div class="gp-refresh">
-        <button
-          type="button"
-          class="usage-refresh micro"
-          disabled={refreshing}
-          aria-busy={refreshing}
-          onclick={onRefresh}
-        >
-          {refreshing ? m.common_loading() : m.topbar_usage_refresh()}
-        </button>
-        {#if refreshError}
-          <span class="usage-refresh-error micro" role="alert">{m.common_retry()}</span>
-        {/if}
+        <UsageRefreshButton {refreshing} {refreshError} {onRefresh} />
       </div>
     {/if}
   </div>
@@ -175,34 +162,7 @@
   }
   /* Refresh control, section-level so it survives the credits gauge being hidden. */
   .gp-refresh {
-    display: flex;
-    align-items: center;
-    gap: 8px;
     margin-top: 10px;
-  }
-  .usage-refresh {
-    background: transparent;
-    border: 1px solid var(--color-line-bright);
-    border-radius: 2px;
-    color: var(--color-ink);
-    font: inherit;
-    font-size: var(--fs-meta);
-    text-transform: none;
-    letter-spacing: 0.04em;
-    padding: 4px 9px;
-    cursor: pointer;
-  }
-  .usage-refresh:hover:not(:disabled) {
-    background: var(--color-inset);
-  }
-  .usage-refresh:disabled {
-    cursor: default;
-    opacity: 0.5;
-  }
-  .usage-refresh-error {
-    text-transform: none;
-    letter-spacing: 0.04em;
-    color: var(--color-red);
   }
   .gauge-pop-link {
     appearance: none;

--- a/ui/src/lib/components/top-bar/UsageRefreshButton.svelte
+++ b/ui/src/lib/components/top-bar/UsageRefreshButton.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+
+  // Manual re-scrape of `/usage`. Shared by the desktop popover and the mobile sheet so it lives at
+  // the Claude-section level (not inside the credits block) — a hidden/absent credits gauge must not
+  // take the only refresh control with it. Kept as its own component so the ternary + error branch
+  // stay out of the parents' large templates (fallow template-complexity budget).
+  let {
+    refreshing,
+    refreshError,
+    onRefresh,
+  }: {
+    refreshing: boolean;
+    refreshError: boolean;
+    onRefresh: () => void;
+  } = $props();
+</script>
+
+<div class="usage-refresh-row">
+  <button
+    type="button"
+    class="usage-refresh micro"
+    disabled={refreshing}
+    aria-busy={refreshing}
+    onclick={onRefresh}
+  >
+    {refreshing ? m.common_loading() : m.topbar_usage_refresh()}
+  </button>
+  {#if refreshError}
+    <span class="usage-refresh-error micro" role="alert">{m.common_retry()}</span>
+  {/if}
+</div>
+
+<style>
+  .usage-refresh-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .usage-refresh {
+    background: transparent;
+    border: 1px solid var(--color-line-bright);
+    border-radius: 2px;
+    color: var(--color-ink);
+    font: inherit;
+    font-size: var(--fs-meta);
+    text-transform: none;
+    letter-spacing: 0.04em;
+    padding: 5px 10px;
+    cursor: pointer;
+  }
+  .usage-refresh:hover:not(:disabled) {
+    background: var(--color-inset);
+  }
+  .usage-refresh:disabled {
+    cursor: default;
+    opacity: 0.5;
+  }
+  .usage-refresh-error {
+    text-transform: none;
+    letter-spacing: 0.04em;
+    color: var(--color-red);
+  }
+  .micro {
+    font-size: var(--fs-meta);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+</style>


### PR DESCRIPTION
## Problem

After a weekly **usage reset**, the top-bar **Claude Code Usage** popover stays stuck at the pre-reset percentage (screenshot: **Weekly 98%**) and clicking **REFRESH** changes nothing — while Claude Code's own `/usage` in the terminal reports the current week at **0% used**.

## Root cause (evidence-backed via the live DB)

- The weekly/5H gauge is **recomputed on the server** as `windowSum(resetAt−period, now) / cap` over *all* `~/.claude` JSONL — not passed through from the scrape.
- The scrape works: the live `usage_caps.week` row was re-scraped and correctly recorded `pct = 0`. Claude reset the weekly **counter** to 0 **without moving the reset boundary**, so the local JSONL still holds the pre-reset usage in that fixed window → `~5705 / 5728 ≈ 100%`.
- A scraped `pct = 0` is below `MIN_CALIBRATION_PCT (5)`, so `calibrateWindow` can't re-invert the cap. The display never reconciles, and refresh (which re-scrapes fine) can't move it.
- Separately, the credits gauge showed **"SCRAPED 9D AGO / SNAPSHOT STALE"** because *Usage Credits* was turned **off** — `/usage` renders no credits panel, so the last snapshot lingers. That block also hosted the only REFRESH button.

## Fix

1. **Anchor the recompute to the last scrape** (`currentUnits` in `src/usage-limits.ts`, used by `limits()` + `projections()`): take the scraped `pct` as truth at `scrapedAt`, add only local usage since. **Provably identical to the old `windowSum/cap` in the normal path**; reconciles to ~0 on a mid-window reset. No DB schema change.
2. **Hide a dead credits snapshot** once it's older than `CREDIT_DROP_MS` (2 daily calibrations ⇒ credits are off). The persisted row/history are untouched (recoverable if re-enabled).
3. **Relocate the REFRESH control** out of the credits block up to the popover / mobile-sheet level, so hiding credits doesn't take the only refresh button with it.

## Verification

Real-data replay against the live DB + real `~/.claude` index:

| window | OLD (pre-fix) | NEW (anchored) |
|--------|--------------|----------------|
| `week` | **100%** (stuck) | **2%** ✓ (scraped 0% + 91.6 units since scrape) |
| `session5h` | 4% | 4% (no regression) |
| `credits` | stale 10d | **hidden** ✓ |

Gates: root `lint` + `bun test ./test` (7112 pass; the 1 fail is the pre-existing `node-pty` native-module env issue in worktrees, unrelated), UI `check` + `test` (3862 pass) + `check:i18n` (parity, 3216 keys). New unit tests cover the reset-reconcile and the dead-credit drop; UI browser tests updated for the relocated refresh.

No manual steps — pure code fix. `fix` (not `feat`), so no feature-catalog entry.