### PR TITLE
fix(terminal): scale xterm font size with iOS Dynamic Type

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -76,7 +76,11 @@
      The probe caps --ui-scale at 1.5: only type scales here, not spacing or the
      fixed chrome heights below (--mobile-actionbar-hit, --icon-btn-hit), so the
      accessibility end of Dynamic Type (~3x) would overflow those dense bars. The
-     cap honors a meaningfully larger choice while keeping the chrome intact. */
+     cap honors a meaningfully larger choice while keeping the chrome intact.
+
+     The canvas-rendered xterm terminal can't consume the ratio through CSS —
+     it multiplies --ui-scale into its JS fontSize instead (ui-scale.svelte.ts
+     → Viewport.svelte), so terminal text follows the same setting and cap. */
   --ui-scale: 1;
   --fs-micro: calc(10px * var(--ui-scale));
   --fs-meta: calc(11px * var(--ui-scale));

--- a/ui/src/app.html
+++ b/ui/src/app.html
@@ -40,7 +40,9 @@
       })();
     </script>
     <!-- iOS Dynamic Type bridge. The whole type scale is `calc(<px> * var(--ui-scale))`
-         in app.css; this resolves --ui-scale to the user's iOS system Text Size so the
+         in app.css, and the canvas-rendered xterm terminal multiplies the same ratio in
+         on the JS side (ui-scale.svelte.ts observes this element's inline-style writes);
+         this resolves --ui-scale to the user's iOS system Text Size so the
          UI honors that setting (the slider in Control Center / Settings → Display).
          WebKit only exposes the preference through the `-apple-system-body` font
          keyword — never a number — so we render a hidden probe with that font and read

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -22,6 +22,7 @@
   import { connectPty, type PtyConn } from "$lib/pty";
   import { theme, xtermTheme, xtermMinContrast } from "$lib/theme.svelte";
   import { terminalFontSize, FONT_MIN, FONT_MAX } from "$lib/terminal-font-size.svelte";
+  import { uiScale } from "$lib/ui-scale.svelte";
   import { tick, untrack } from "svelte";
   import { SvelteMap } from "svelte/reactivity";
   import {
@@ -351,11 +352,21 @@
   // integer. Rounding here keeps the readout an integer — a fresh desktop user
   // never sees the fractional 12.5 (nor its overflow of the readout box) — and
   // lets stepping move a clean ±1 from the shown number. The ACTUAL xterm size
-  // when unset stays the true termFontDefault (12.5/11) — see the creation +
-  // live-apply effects — so default terminal rendering is unchanged; the ≤0.5px
-  // gap exists only in the never-touched state and closes the moment the user
-  // steps. Never feeds the terminal-creation effect.
+  // when unset stays the true termFontDefault (12.5/11), scaled by --ui-scale
+  // (see appliedFontSize below and the creation + live-apply effects) — so
+  // default terminal rendering is unchanged; the ≤0.5px gap exists only in the
+  // never-touched state and closes the moment the user steps. Never feeds the
+  // terminal-creation effect.
   const effectiveFontSize = $derived(terminalFontSize.size ?? Math.round(termFontDefault));
+  // What xterm actually renders: the base size (pinned or per-device default)
+  // multiplied by the iOS Dynamic Type ratio (--ui-scale, 1 everywhere the
+  // app.html probe never runs). The terminal is canvas-rendered, so it can't
+  // pick the ratio up through the CSS type scale like the rest of the UI —
+  // it has to be multiplied in here. Base stays the readout/stepper/persisted
+  // unit; the product is deliberately unclamped (base is clamped 8–24 by the
+  // store, the probe caps the ratio at 1.5 — both bounds are already enforced
+  // at their sources, mirroring the CSS --fs-* tokens).
+  const appliedFontSize = $derived((terminalFontSize.size ?? termFontDefault) * uiScale.value);
   // A+ / A− step. Snaps to an integer (up → floor+1, down → ceil−1) so stepping
   // can never produce a fractional size; from the rounded default it is a clean
   // ±1 off the shown readout. Store clamps to [FONT_MIN, FONT_MAX].
@@ -1544,9 +1555,12 @@
     const initialTheme = document.documentElement.dataset.theme === "light" ? "light" : "dark";
     // Initial font size: the persisted preference (read UNTRACKED so a later
     // wrench-menu step never re-keys this effect → never recreates the terminal /
-    // PTY), else the per-device default. Live changes are applied in place by the
-    // dedicated effect below.
-    const initialFont = untrack(() => terminalFontSize.size) ?? termFontDefault;
+    // PTY), else the per-device default — times the iOS Dynamic Type ratio
+    // (also untracked: a live Text Size change must never recreate the
+    // terminal either). Live changes are applied in place by the dedicated
+    // effect below.
+    const initialFont =
+      (untrack(() => terminalFontSize.size) ?? termFontDefault) * untrack(() => uiScale.value);
     const term = new Terminal({
       fontFamily: "'JetBrains Mono', monospace",
       fontSize: initialFont,
@@ -1704,6 +1718,16 @@
     // catches display:none; the client-size checks catch transient collapses.
     const refit = () => {
       if (!el || el.offsetParent === null || el.clientWidth === 0 || el.clientHeight === 0) return;
+      // Reconcile a font-size change that arrived while the mount was hidden
+      // (an iOS Dynamic Type change on another tab — see the live-apply effect,
+      // which defers instead of measuring against a hidden mount). Setting the
+      // option NOW is safe: the guard above proves the mount is visible, so
+      // xterm's CharSizeService re-measure is valid, and the fit below reflows
+      // to the fresh cell size. untracked: refit() is called from inside
+      // $effect bodies on some paths, and the reconcile must not become a
+      // reactive dependency of those effects.
+      const desired = untrack(() => appliedFontSize);
+      if (term.options.fontSize !== desired) term.options.fontSize = desired;
       fit.fit();
       c.resize(term.cols, term.rows);
     };
@@ -2161,26 +2185,27 @@
     term.refresh(0, Math.max(0, term.rows - 1));
   });
 
-  // Live-apply the terminal font size (wrench-menu stepper). Mirrors the theme
-  // effect: mutate the option in place — never recreate the terminal/PTY.
-  // Setting term.options.fontSize makes xterm's CharSizeService re-measure the
-  // cell (it watches fontSize), but ONLY when the mount is visible; a hidden
-  // measure is invalid. If the mount is hidden we store the option and return
-  // before fit.fit() (the same 2-col poison guard as refit()) — but the deferred
-  // visibility/ResizeObserver refit() calls fit.fit() alone, which does NOT
-  // re-trigger a CharSizeService measure, so it would reflow against stale cell
-  // metrics. We rely on the invariant that the ONLY font-size trigger is the
-  // wrench menu, which renders on the terminal tab only → the mount is always
-  // visible at change time, so this hidden branch is effectively unreachable for
-  // user-driven changes.
+  // Live-apply the terminal font size. Mirrors the theme effect: mutate the
+  // option in place — never recreate the terminal/PTY. Two triggers feed it:
+  // the wrench-menu stepper (renders on the terminal tab only → mount always
+  // visible) and the iOS Dynamic Type ratio (--ui-scale — can change while ANY
+  // tab is active, so the mount may be hidden). Setting term.options.fontSize
+  // makes xterm's CharSizeService re-measure the cell (it watches fontSize),
+  // but ONLY a visible measure is valid — and the deferred visibility/
+  // ResizeObserver refit() calls fit.fit() alone, which does NOT re-trigger a
+  // measure, so a hidden mutation here would poison the cell metrics for the
+  // terminal's whole life. Therefore: if the mount is hidden, change NOTHING
+  // (guard before the mutation) — refit() reconciles term.options.fontSize
+  // against appliedFontSize the moment the mount is visible again, which is
+  // the only time a measure is trustworthy.
   $effect(() => {
-    const size = terminalFontSize.size ?? termFontDefault;
+    const size = appliedFontSize;
     const term = termRef;
     const fit = fitRef;
     if (!term || !fit) return;
     if (term.options.fontSize === size) return;
-    term.options.fontSize = size;
     if (!el || el.offsetParent === null || el.clientWidth === 0 || el.clientHeight === 0) return;
+    term.options.fontSize = size;
     fit.fit();
     conn?.resize(term.cols, term.rows);
   });

--- a/ui/src/lib/ui-scale.browser.test.ts
+++ b/ui/src/lib/ui-scale.browser.test.ts
@@ -1,0 +1,52 @@
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Exercises the singleton against a real DOM: the constructor's initial
+// getComputedStyle read and the MutationObserver pickup of the inline-style
+// writes the app.html Dynamic Type probe performs. The module is re-imported
+// fresh per test (vi.resetModules) so each case gets its own constructor run.
+
+async function freshStore() {
+  vi.resetModules();
+  return (await import("./ui-scale.svelte")).uiScale;
+}
+
+beforeEach(() => {
+  document.documentElement.style.removeProperty("--ui-scale");
+});
+
+afterEach(() => {
+  document.documentElement.style.removeProperty("--ui-scale");
+});
+
+test("defaults to 1 when --ui-scale is not set (probe never ran)", async () => {
+  const uiScale = await freshStore();
+  expect(uiScale.value).toBe(1);
+});
+
+test("reads a pre-existing inline value at construction (pre-paint probe ran first)", async () => {
+  document.documentElement.style.setProperty("--ui-scale", "1.3");
+  const uiScale = await freshStore();
+  expect(uiScale.value).toBe(1.3);
+});
+
+test("tracks live probe updates via the style-attribute MutationObserver", async () => {
+  const uiScale = await freshStore();
+  expect(uiScale.value).toBe(1);
+  document.documentElement.style.setProperty("--ui-scale", "1.25");
+  await vi.waitFor(() => expect(uiScale.value).toBe(1.25));
+  document.documentElement.style.setProperty("--ui-scale", "0.85");
+  await vi.waitFor(() => expect(uiScale.value).toBe(0.85));
+});
+
+test("falls back to 1 on a removed or unparseable value", async () => {
+  document.documentElement.style.setProperty("--ui-scale", "1.5");
+  const uiScale = await freshStore();
+  expect(uiScale.value).toBe(1.5);
+  document.documentElement.style.removeProperty("--ui-scale");
+  await vi.waitFor(() => expect(uiScale.value).toBe(1));
+  document.documentElement.style.setProperty("--ui-scale", "garbage");
+  // stays 1 (NaN → fallback); waitFor still applies — the observer fires async
+  await vi.waitFor(() => expect(uiScale.value).toBe(1));
+  document.documentElement.style.setProperty("--ui-scale", "-2");
+  await vi.waitFor(() => expect(uiScale.value).toBe(1));
+});

--- a/ui/src/lib/ui-scale.svelte.ts
+++ b/ui/src/lib/ui-scale.svelte.ts
@@ -14,9 +14,7 @@
  *  byte-identical to the unscaled behavior. */
 
 function read(): number {
-  const v = parseFloat(
-    getComputedStyle(document.documentElement).getPropertyValue("--ui-scale"),
-  );
+  const v = parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--ui-scale"));
   return Number.isFinite(v) && v > 0 ? v : 1;
 }
 

--- a/ui/src/lib/ui-scale.svelte.ts
+++ b/ui/src/lib/ui-scale.svelte.ts
@@ -1,0 +1,35 @@
+/** Reactive view of the `--ui-scale` custom property — the iOS Dynamic Type
+ *  ratio the pre-paint probe in app.html resolves from `-apple-system-body`
+ *  and writes as an INLINE STYLE on `<html>` (capped at 1.5 there). The CSS
+ *  type scale consumes it via `calc(<px> * var(--ui-scale))`; this store is
+ *  the JS-side counterpart for canvas-rendered text that CSS can't reach
+ *  (the xterm terminal in Viewport.svelte).
+ *
+ *  Coupling contract: live updates arrive ONLY through the probe's
+ *  `style.setProperty("--ui-scale", …)` writes, so a MutationObserver on the
+ *  root element's `style` attribute is sufficient to see every change. The
+ *  probe runs pre-paint — before any module script — so the constructor read
+ *  already sees the final initial value. Everywhere the probe never runs
+ *  (desktop, Android, SSR) the value stays 1 and terminal rendering is
+ *  byte-identical to the unscaled behavior. */
+
+function read(): number {
+  const v = parseFloat(
+    getComputedStyle(document.documentElement).getPropertyValue("--ui-scale"),
+  );
+  return Number.isFinite(v) && v > 0 ? v : 1;
+}
+
+class UiScale {
+  value = $state(1);
+
+  constructor() {
+    if (typeof document === "undefined") return; // SSR — stays 1
+    this.value = read();
+    new MutationObserver(() => {
+      this.value = read();
+    }).observe(document.documentElement, { attributes: true, attributeFilter: ["style"] });
+  }
+}
+
+export const uiScale = new UiScale();


### PR DESCRIPTION
## Summary

On iPhone, changing the iOS system Text Size (Dynamic Type) scaled Shepherd's UI chrome but **not** the terminal content. The type scale honors the setting via the `--ui-scale` probe in `app.html` (every `--fs-*` token is `calc(<px> * var(--ui-scale))`), but the xterm terminal renders to canvas/WebGL with an absolute px `fontSize` — CSS scaling can never reach it.

## What changed

- **New `ui/src/lib/ui-scale.svelte.ts`** — reactive singleton exposing the current `--ui-scale` (default 1). Live updates via a MutationObserver on `<html>`'s `style` attribute, which is exactly where the app.html probe writes the ratio (coupling documented at both ends). SSR-guarded; stays 1 wherever the probe never runs (desktop/Android → rendering byte-identical to today).
- **`Viewport.svelte`** — xterm now renders `(pinned wrench-menu size ?? per-device default) × uiScale` (`appliedFontSize`). The A+/A− readout, stepper semantics and the persisted preference stay in **base** units. Terminal creation reads the scale untracked, so a live Text Size change never recreates the terminal/PTY (scrollback + socket survive; the existing live-apply effect mutates the option in place).
- **Hidden-mount correctness** — Dynamic Type can change while the terminal tab is hidden, which would previously have made xterm take an *invalid* hidden glyph measurement (the old code's comment relied on the wrench menu being the only trigger). The live-apply effect now defers entirely when the mount is hidden, and `refit()` — the existing single funnel for became-visible/resized — reconciles `fontSize` at the first visible moment, when a measure is valid.
- Comment-only doc alignment in `app.html`/`app.css` naming the terminal as a JS-side `--ui-scale` consumer.

Per-decision detail: a **pinned** A+/A− size also multiplies with Dynamic Type (user-confirmed) — otherwise anyone who ever touched the stepper would lose Dynamic Type response and the bug would return for them.

## Verification

- `bun run check` (0 errors), `bun run test` (257 files / 3866 tests passed, incl. 4 new store tests), `check:i18n`, branch-hygiene, glossary and announcement-version gates all green. No new user-facing strings; `fix`, so no feature-catalog entry.
- **E2E (Playwright against `dev:demo`, measuring xterm's real cell height):**
  - branch: cell 17px @ scale 1 → **25px @ 1.5** → **14px @ 0.85** → 17px after the override is removed; rows/PTY refit accordingly.
  - control on `main`: cell stays 17px at every scale (the reported bug).
  - hidden-mount: hide the mount, set scale 1.5 (nothing applied), unhide → reconciled to 25px with a valid visible measure.
- Remaining device check: confirm on an actual iPhone via the preview URL (both directions of the Text Size slider, with and without a pinned A+/A− size).

## Notes

While verifying, I found a **pre-existing** demo-mode crash (`flatMap` TypeError in Viewport's subtree, mobile detail never opens; reproduces on main) — filed as #1800, not touched here.