### PR TITLE
fix(sandbox): let codex aux roles start and authenticate inside the bwrap membrane

### DIFF
--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -16,7 +16,7 @@
  * rather than hard-failing the spawn.
  */
 import { existsSync, readdirSync, realpathSync } from "node:fs";
-import { dirname } from "node:path";
+import { basename, dirname } from "node:path";
 import { execFileSync } from "./instrument";
 import { resolveNodeBin } from "./node-bin";
 import type { EgressBackend } from "./egress";
@@ -193,6 +193,94 @@ export interface MembraneInputs {
    *  where Shepherd's usage/activity readback looks (config.claudeProjectsDir via
    *  jsonlPathFor) even though auth comes from the (pool) claudeDir. */
   projectsBindSource?: string;
+  /** Codex CLI support — set only for a `codex` inner argv (see membraneForArgv).
+   *  Absent (claude spawns): flags stay byte-identical to the historical output. */
+  codex?: CodexMembraneInputs;
+}
+
+// ── codex CLI membrane support ────────────────────────────────────────────────
+
+/**
+ * Resolved host paths that let a wrapped `codex exec` role start and authenticate
+ * inside the membrane. Without them every sandboxed codex spawn (plan-gate reviewer,
+ * PR critic, standalone critic, doc-agent) died silently: the claude-only membrane
+ * bound neither the codex launcher chain (execvp ENOENT on the dangling
+ * `~/.bun/bin/codex` symlink) nor `~/.codex` (`--tmpfs $HOME` hides auth.json → 401).
+ */
+export interface CodexMembraneInputs {
+  /** dirname of the `codex` launcher as found on Shepherd's PATH (often a symlink
+   *  dir, e.g. `~/.bun/bin`) — bound RO and appended to the sandbox PATH. */
+  binDir: string;
+  /** RO bind covering the launcher's REAL file and its runtime siblings: the nearest
+   *  `node_modules` ancestor of the realpath'd launcher (the platform package holding
+   *  the native binary is a SIBLING package, so the package dir alone is not enough),
+   *  or the realpath's dirname when no node_modules ancestor exists (standalone bin). */
+  pkgRoot: string;
+  /** CODEX_HOME (auth.json, config.toml, sessions/, sqlite state) — bound RW: token
+   *  refresh, rollout writes and sqlite WAL all need a writable directory. Tool-level
+   *  writes stay confined by codex's own `--sandbox workspace-write`. */
+  codexHome: string;
+}
+
+/** Injectable host probes for codex membrane resolution (tests never touch the host). */
+export interface CodexProbeDeps {
+  /** PATH lookup; default Bun.which. */
+  which?: (cmd: string) => string | null;
+  /** realpath; default safeRealpath. */
+  realpath?: (p: string) => string;
+  /** Host env (CODEX_HOME override); default process.env. */
+  env?: Record<string, string | undefined>;
+}
+
+/** Nearest ancestor directory named `node_modules`, or null when none. */
+function nodeModulesAncestor(p: string): string | null {
+  for (let dir = dirname(p); ; dir = dirname(dir)) {
+    if (basename(dir) === "node_modules") return dir;
+    if (dirname(dir) === dir) return null;
+  }
+}
+
+/**
+ * Resolve the codex membrane inputs for `home`, or null (with a warn — never a
+ * silent drop) when `codex` is not on Shepherd's own PATH. On null the spawn fails
+ * exactly as before, but traceably.
+ */
+export function resolveCodexMembrane(
+  home: string,
+  deps: CodexProbeDeps = {},
+): CodexMembraneInputs | null {
+  const which = deps.which ?? ((cmd: string) => Bun.which(cmd));
+  const bin = which("codex");
+  if (!bin) {
+    console.warn(
+      "[sandbox] codex spawn requested but `codex` is not on PATH — membrane gets no codex binds",
+    );
+    return null;
+  }
+  const real = (deps.realpath ?? safeRealpath)(bin);
+  const env = deps.env ?? process.env;
+  const codexHome = env.CODEX_HOME || `${home}/.codex`;
+  return {
+    binDir: dirname(bin),
+    pkgRoot: nodeModulesAncestor(real) ?? dirname(real),
+    codexHome,
+  };
+}
+
+/**
+ * The membrane for an inner argv: a `codex` spawn gets the resolved codex inputs
+ * folded in (unless the caller already did); anything else passes through untouched.
+ * SINGLE source for the detection so wrapArgv and service.ts's egress branch (which
+ * calls buildMembraneFlags directly) can never drift.
+ */
+export function membraneForArgv(
+  innerArgv: string[],
+  membrane: MembraneInputs,
+  deps: CodexProbeDeps = {},
+): MembraneInputs {
+  if (innerArgv[0] !== "codex" || membrane.codex) return membrane;
+  const codex = resolveCodexMembrane(membrane.home, deps);
+  return codex ? { ...membrane, codex } : membrane;
 }
 
 /**
@@ -259,6 +347,39 @@ function nodeToolchainFlags(inputs: MembraneInputs, exists: (p: string) => boole
   }
   add(binDir);
   return flags;
+}
+
+/**
+ * Codex CLI flags — empty for a non-codex spawn, keeping claude flags byte-identical.
+ * Launcher chain RO: binDir (the PATH lookup target, often a symlink dir) plus the
+ * realpath'd package tree (the native platform binary is a SIBLING package under the
+ * same node_modules, so binding the launcher's package alone would not start).
+ * CODEX_HOME RW: auth.json token refresh, sessions/ rollouts and sqlite WAL files
+ * all need a writable directory; tool-level writes remain confined by codex's own
+ * `--sandbox workspace-write`.
+ */
+function codexCliFlags(codex: CodexMembraneInputs | undefined): string[] {
+  if (!codex) return [];
+  const f = ["--ro-bind-try", codex.binDir, codex.binDir];
+  if (codex.pkgRoot !== codex.binDir) f.push("--ro-bind-try", codex.pkgRoot, codex.pkgRoot);
+  f.push("--bind-try", codex.codexHome, codex.codexHome);
+  return f;
+}
+
+/** The sandbox PATH. A codex spawn appends the launcher's bin dir so `codex` resolves
+ *  by name; skipped when it already is an entry (claude spawns are unchanged either way). */
+function sandboxPath(home: string, nodeBinDir: string, codex?: CodexMembraneInputs): string {
+  const entries = [`${home}/.local/bin`, nodeBinDir, "/usr/bin", "/bin"];
+  if (codex && !entries.includes(codex.binDir)) entries.push(codex.binDir);
+  return entries.join(":");
+}
+
+/** `--setenv CODEX_HOME` for a codex spawn with a non-default home: --clearenv strips
+ *  it, and codex must be pointed back at the dir the membrane bound (the default
+ *  ~/.codex needs no env — codex derives it from HOME). Empty otherwise. */
+function codexEnvFlags(home: string, codex?: CodexMembraneInputs): string[] {
+  if (!codex || codex.codexHome === `${home}/.codex`) return [];
+  return ["--setenv", "CODEX_HOME", codex.codexHome];
 }
 
 /**
@@ -408,6 +529,11 @@ export function buildMembraneFlags(inputs: MembraneInputs, deps: PathProbeDeps =
   // ── node toolchain (binary's libs must resolve) ──────────────────────────
   f.push(...nodeToolchainFlags(inputs, exists));
 
+  // ── codex CLI (codex spawns only — claude flags stay byte-identical) ─────
+  // MUST sit after the `--tmpfs home` above so the RW CODEX_HOME bind punches
+  // through the tmpfs.
+  f.push(...codexCliFlags(inputs.codex));
+
   // ── commit identity + gh token ───────────────────────────────────────────
   f.push("--ro-bind-try", `${home}/.gitconfig`, `${home}/.gitconfig`);
   f.push("--ro-bind-try", `${home}/.config/gh`, `${home}/.config/gh`);
@@ -437,12 +563,13 @@ export function buildMembraneFlags(inputs: MembraneInputs, deps: PathProbeDeps =
   const nodeBinDir = dirname(inputs.nodeBinReal);
   f.push("--clearenv");
   f.push("--setenv", "HOME", home);
-  f.push("--setenv", "PATH", `${home}/.local/bin:${nodeBinDir}:/usr/bin:/bin`);
+  f.push("--setenv", "PATH", sandboxPath(home, nodeBinDir, inputs.codex));
   f.push("--setenv", "TERM", term);
   // --clearenv strips CLAUDE_CONFIG_DIR; re-set it when the bound config dir is NOT the
   // default ~/.claude, else claude would fall back to an empty ~/.claude tmpfs (the custom
   // dir IS bound above) and lose auth/onboarding state.
   if (claudeDir !== `${home}/.claude`) f.push("--setenv", "CLAUDE_CONFIG_DIR", claudeDir);
+  f.push(...codexEnvFlags(home, inputs.codex));
   for (const [k, v] of Object.entries(inputs.extraEnv ?? {}).sort(([a], [b]) =>
     a.localeCompare(b),
   )) {
@@ -468,10 +595,11 @@ export function buildMembraneFlags(inputs: MembraneInputs, deps: PathProbeDeps =
 export function wrapArgv(
   innerArgv: string[],
   opts: { profile: SandboxProfile; backend: SandboxBackend; membrane: MembraneInputs },
-  deps: PathProbeDeps = {},
+  deps: PathProbeDeps & CodexProbeDeps = {},
 ): string[] {
   if (opts.profile === "trusted" || opts.backend === null) return innerArgv;
-  return ["bwrap", ...buildMembraneFlags(opts.membrane, deps), "--", ...innerArgv];
+  const membrane = membraneForArgv(innerArgv, opts.membrane, deps);
+  return ["bwrap", ...buildMembraneFlags(membrane, deps), "--", ...innerArgv];
 }
 
 // ── auto-gate ─────────────────────────────────────────────────────────────────

--- a/src/service.ts
+++ b/src/service.ts
@@ -71,6 +71,7 @@ import {
   willEgressConfine,
   wrapArgv,
   buildMembraneFlags,
+  membraneForArgv,
   safeRealpath,
   collectPassthroughEnv,
   SandboxAutoRefused,
@@ -2228,7 +2229,9 @@ export class SessionService {
     writeEgressConfigFiles(tmp, cfg);
     const bwrapArgv = [
       "bwrap",
-      ...buildMembraneFlags(membrane),
+      // membraneForArgv folds the codex binds in for a codex inner argv (this branch
+      // bypasses wrapArgv, which does the same fold — keep the two in lockstep).
+      ...buildMembraneFlags(membraneForArgv(innerArgv, membrane)),
       ...egressMembraneOverrideFlags(tmp),
       "--",
       ...innerArgv,

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -14,7 +14,10 @@ import {
   detectBackend,
   resetBackendCache,
   collectPassthroughEnv,
+  resolveCodexMembrane,
+  membraneForArgv,
   type MembraneInputs,
+  type CodexMembraneInputs,
 } from "../src/sandbox";
 import { resolveNodeBin } from "../src/node-bin";
 import type { EgressBackend } from "../src/egress";
@@ -940,5 +943,188 @@ describe("#1144 session marker survives the membrane", () => {
     expect(i).toBeGreaterThanOrEqual(0);
     expect(f[i - 1]).toBe("--setenv");
     expect(f[i + 1]).toBe("sess-abc");
+  });
+});
+
+// ── codex membrane support ────────────────────────────────────────────────────
+// The membrane was claude-only: a wrapped `codex exec` role died on a dangling
+// launcher symlink (execvp ENOENT) or an empty tmpfs ~/.codex (401, no verdict).
+// These tests pin the codex fold: detection, bind set, PATH, and — critically —
+// that claude spawns stay byte-identical when no codex inputs are present.
+
+/** Deterministic probe deps simulating the bun-global layout: the launcher on PATH
+ *  is a symlink whose realpath lives inside a node_modules tree. */
+const bunGlobalDeps = {
+  which: (cmd: string) => (cmd === "codex" ? "/home/me/.bun/bin/codex" : null),
+  realpath: (p: string) =>
+    p === "/home/me/.bun/bin/codex"
+      ? "/home/me/.bun/install/global/node_modules/@openai/codex/bin/codex.js"
+      : p,
+  env: {} as Record<string, string | undefined>,
+};
+
+const fakeCodex: CodexMembraneInputs = {
+  binDir: "/home/me/.bun/bin",
+  pkgRoot: "/home/me/.bun/install/global/node_modules",
+  codexHome: "/home/me/.codex",
+};
+
+describe("resolveCodexMembrane", () => {
+  test("bun-global symlink layout → binDir + nearest node_modules root + default codexHome", () => {
+    const r = resolveCodexMembrane("/home/me", bunGlobalDeps);
+    expect(r).toEqual(fakeCodex);
+  });
+
+  test("standalone binary (no node_modules ancestor) → pkgRoot is the realpath's dir", () => {
+    const r = resolveCodexMembrane("/home/me", {
+      ...bunGlobalDeps,
+      realpath: () => "/opt/codex/bin/codex",
+    });
+    expect(r?.pkgRoot).toBe("/opt/codex/bin");
+  });
+
+  test("host CODEX_HOME override wins over the home default", () => {
+    const r = resolveCodexMembrane("/home/me", {
+      ...bunGlobalDeps,
+      env: { CODEX_HOME: "/data/codex-home" },
+    });
+    expect(r?.codexHome).toBe("/data/codex-home");
+  });
+
+  test("codex not on PATH → null (spawn fails as before, but traceably)", () => {
+    expect(resolveCodexMembrane("/home/me", { ...bunGlobalDeps, which: () => null })).toBeNull();
+  });
+});
+
+describe("membraneForArgv", () => {
+  test("claude argv passes through untouched — no host probe runs", () => {
+    const m = fakeMembrane();
+    const out = membraneForArgv(["claude", "--model", "opus"], m, {
+      which: () => {
+        throw new Error("which must not be called for a claude argv");
+      },
+    });
+    expect(out).toBe(m);
+  });
+
+  test("codex argv folds the resolved codex inputs", () => {
+    const out = membraneForArgv(["codex", "exec", "prompt"], fakeMembrane(), bunGlobalDeps);
+    expect(out.codex).toEqual(fakeCodex);
+  });
+
+  test("pre-resolved membrane.codex is kept (no re-probe)", () => {
+    const m = fakeMembrane({ codex: fakeCodex });
+    const out = membraneForArgv(["codex", "exec", "p"], m, {
+      which: () => {
+        throw new Error("which must not be called when codex is pre-resolved");
+      },
+    });
+    expect(out).toBe(m);
+  });
+
+  test("unresolvable codex → membrane unchanged", () => {
+    const m = fakeMembrane();
+    const out = membraneForArgv(["codex", "exec", "p"], m, { ...bunGlobalDeps, which: () => null });
+    expect(out).toBe(m);
+    expect(out.codex).toBeUndefined();
+  });
+});
+
+describe("buildMembraneFlags codex flags", () => {
+  test("no codex inputs → claude flags stay byte-identical (no codex traces)", () => {
+    const f = buildMembraneFlags(fakeMembrane(), detDeps);
+    expect(f.join("\n")).not.toContain(".codex");
+    expect(f.join("\n")).not.toContain(".bun");
+    expect(
+      hasTriple(
+        f,
+        "--setenv",
+        "PATH",
+        "/home/me/.local/bin:/home/linuxbrew/.linuxbrew/Cellar/node/22.0.0/bin:/usr/bin:/bin",
+      ),
+    ).toBe(true);
+  });
+
+  test("codex inputs → RO binDir + RO pkgRoot + RW codexHome, all after the home tmpfs", () => {
+    const f = buildMembraneFlags(fakeMembrane({ codex: fakeCodex }), detDeps);
+    expect(hasTriple(f, "--ro-bind-try", fakeCodex.binDir, fakeCodex.binDir)).toBe(true);
+    expect(hasTriple(f, "--ro-bind-try", fakeCodex.pkgRoot, fakeCodex.pkgRoot)).toBe(true);
+    expect(hasTriple(f, "--bind-try", fakeCodex.codexHome, fakeCodex.codexHome)).toBe(true);
+    // the RW codexHome bind must punch THROUGH the home tmpfs → must come after it
+    const tmpfsHome = f.findIndex((v, i) => v === "--tmpfs" && f[i + 1] === "/home/me");
+    const codexBind = f.findIndex((v, i) => v === "--bind-try" && f[i + 1] === fakeCodex.codexHome);
+    expect(tmpfsHome).toBeGreaterThanOrEqual(0);
+    expect(codexBind).toBeGreaterThan(tmpfsHome);
+  });
+
+  test("pkgRoot equal to binDir is not re-bound", () => {
+    const f = buildMembraneFlags(
+      fakeMembrane({ codex: { ...fakeCodex, pkgRoot: fakeCodex.binDir } }),
+      detDeps,
+    );
+    const targets = f.filter((v, i) => f[i - 2] === "--ro-bind-try" && v === fakeCodex.binDir);
+    expect(targets.length).toBe(1);
+  });
+
+  test("PATH gains the codex binDir when it is not already an entry", () => {
+    const f = buildMembraneFlags(fakeMembrane({ codex: fakeCodex }), detDeps);
+    expect(
+      hasTriple(
+        f,
+        "--setenv",
+        "PATH",
+        "/home/me/.local/bin:/home/linuxbrew/.linuxbrew/Cellar/node/22.0.0/bin:/usr/bin:/bin:/home/me/.bun/bin",
+      ),
+    ).toBe(true);
+  });
+
+  test("PATH unchanged when the codex binDir already is a PATH entry", () => {
+    const f = buildMembraneFlags(
+      fakeMembrane({
+        nodeBinReal: "/home/me/.bun/bin/bun",
+        codex: fakeCodex,
+      }),
+      detDeps,
+    );
+    expect(
+      hasTriple(f, "--setenv", "PATH", "/home/me/.local/bin:/home/me/.bun/bin:/usr/bin:/bin"),
+    ).toBe(true);
+  });
+
+  test("CODEX_HOME setenv only for a non-default home", () => {
+    const def = buildMembraneFlags(fakeMembrane({ codex: fakeCodex }), detDeps);
+    expect(def).not.toContain("CODEX_HOME");
+    const custom = buildMembraneFlags(
+      fakeMembrane({ codex: { ...fakeCodex, codexHome: "/data/codex-home" } }),
+      detDeps,
+    );
+    expect(hasTriple(custom, "--setenv", "CODEX_HOME", "/data/codex-home")).toBe(true);
+    expect(hasTriple(custom, "--bind-try", "/data/codex-home", "/data/codex-home")).toBe(true);
+  });
+});
+
+describe("wrapArgv codex fold", () => {
+  test("codex inner argv gets the codex binds; inner argv preserved", () => {
+    const inner = ["codex", "exec", "--sandbox", "workspace-write", "prompt"];
+    const out = wrapArgv(
+      inner,
+      { profile: "standard", backend: "bwrap", membrane: fakeMembrane() },
+      { ...detDeps, ...bunGlobalDeps },
+    );
+    expect(out[0]).toBe("bwrap");
+    const sep = out.indexOf("--");
+    expect(out.slice(sep + 1)).toEqual(inner);
+    const flags = out.slice(1, sep);
+    expect(hasTriple(flags, "--bind-try", "/home/me/.codex", "/home/me/.codex")).toBe(true);
+    expect(hasTriple(flags, "--ro-bind-try", fakeCodex.pkgRoot, fakeCodex.pkgRoot)).toBe(true);
+  });
+
+  test("claude inner argv wrapped WITHOUT codex binds", () => {
+    const out = wrapArgv(
+      ["claude", "--model", "opus", "task"],
+      { profile: "standard", backend: "bwrap", membrane: fakeMembrane() },
+      { ...detDeps, ...bunGlobalDeps },
+    );
+    expect(out.join("\n")).not.toContain(".codex");
   });
 });


### PR DESCRIPTION
## Problem

Every sandboxed **codex** helper role — plan-gate reviewer, PR critic, standalone critic, doc-agent — dies without producing its result file. The plan gate then lands `decision=error / summaryCode=no-verdict` and the UI shows *“The plan reviewer did not produce a verdict.”* / *“Review errored — nothing pasted.”* Observed live in TASK-726 and dozens of sessions before it; several prior fixes (#1714, #1724, #1742, #1768, #1780) repaired lifecycle races *around* the exec but the exec itself never started.

## Root cause (diagnosed + reproduced on the reference host)

`resolveAuxSpawn` wraps every aux spawn with `profile: "standard"` whenever a bwrap backend exists — and `buildMembraneFlags` was claude-only:

1. **The codex launcher doesn’t resolve inside the sandbox.** `~/.bun/bin/codex` is a symlink into `~/.bun/install/global/node_modules/@openai/codex/bin/codex.js`; the membrane binds the bin dir but never the realpath target → `bwrap: execvp codex: No such file or directory` in 4 ms (reproduced with an exact membrane replica). Matches the DB evidence: every `plan_gate` reviewer spawn completes ~8–15 s after start (5 s codex exit-grace + tick) with 0 tokens, and no rollout file ever appears in `~/.codex/sessions`.
2. **`--tmpfs $HOME` hides `~/.codex`.** Even with a resolvable binary there is no `auth.json` → 401 retry loop → exit without a verdict (also reproduced).

Main codex sessions never hit this because they run the `trusted` profile (no bwrap).

## Fix

New `membraneForArgv(innerArgv, membrane)` folds resolved codex inputs into the membrane **only for a `codex` inner argv** (single source, used by `wrapArgv` and service.ts’s egress branch so the two can’t drift):

- **Launcher chain RO**: the PATH lookup’s bin dir + the nearest `node_modules` ancestor of the realpath’d launcher (the native platform binary is a *sibling* package, so the launcher’s package alone would not start). Falls back to the realpath’s dir for standalone binaries.
- **`CODEX_HOME` RW** (`--bind-try`): auth.json token refresh, sessions/ rollouts and sqlite WAL all need a writable directory. Tool-level writes remain confined by codex’s own `--sandbox workspace-write` (operator-confirmed decision over an RO+selective-RW split, which risks re-introducing this exact silent failure on codex layout changes).
- **PATH** gains the codex bin dir when it isn’t already an entry; **`CODEX_HOME` setenv** re-exported through `--clearenv` for non-default homes.
- `codex` missing from PATH warns instead of failing silently.

Claude spawns stay **byte-identical** (guarded flags; asserted by tests).

## Verification

- New unit tests: resolution (bun-global symlink layout, standalone layout, `CODEX_HOME` override, not-on-PATH), fold semantics, flag emission (bind set, tmpfs ordering, PATH, setenv), wrapArgv fold, and claude no-codex-traces regression.
- Full root suite in a throwaway worktree: **7126 pass**, 1 fail = `pty-attach` (pre-existing node-pty native build failure on this host, unrelated).
- **On-host end-to-end**: the real flag set built by this code now runs `codex exec --sandbox workspace-write -m gpt-5.6-sol` to completion inside bwrap — authenticates, writes the verdict file, exit 0 — where it previously died in 4 ms.
- `bun run lint`, `bun run typecheck`, prettier clean.

Fixes the failure investigated in TASK-726.

```shepherd:manual-steps
- [ ] POST-MERGE: After Shepherd restarts on the fixed build, click “Review plan now” on plan gates still stuck in “Review did not complete” (e.g. TASK-726) — errored interactive gates do not re-trigger themselves.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)