### PR TITLE
fix(spawn): don't let a slash-leading issue title become a slash command

### DIFF
--- a/src/drain.ts
+++ b/src/drain.ts
@@ -6,6 +6,7 @@ import type { UsageLimits } from "./usage-limits";
 import type { TelemetryService } from "./telemetry";
 import { recordEpicIntegrationIfChild, settleMergedSession } from "./merge-teardown";
 import { isFullAuto } from "./full-auto";
+import { issueSpawnPrompt } from "./issue-spawn-prompt";
 import {
   ACTIVE_LABEL,
   computeNext,
@@ -2388,8 +2389,11 @@ export class DrainService {
     }
     // Epic child actually based on the integration branch → tell the agent to target it as the
     // PR base (the agent opens its own PR and would otherwise default to the main branch).
+    // The directive rides AFTER the templated title so a `/`-leading title can't reach argv
+    // position 0 and be parsed as a slash command (issueSpawnPrompt).
     const usingEpicBase = !!decision.integrationBranch && base === decision.integrationBranch;
-    const prompt = usingEpicBase ? `${title}\n\n${epicBaseDirective(base)}` : title;
+    const task = issueSpawnPrompt(number, title);
+    const prompt = usingEpicBase ? `${task}\n\n${epicBaseDirective(base)}` : task;
     return { base, prompt };
   }
 

--- a/src/issue-spawn-prompt.ts
+++ b/src/issue-spawn-prompt.ts
@@ -10,11 +10,22 @@
  *   $ claude -p $'/zzznope\n\nGitHub Issue #1 (title + body follow as untrusted data):\n…'
  *   Unknown command: /zzznope
  *
- * There is no `--` separator, `--raw` flag, or escape character; only "text does not begin with
- * `/`" reliably avoids the parse. So a `/`-leading title is templated into a sentence, mirroring
- * the client-side New Task path (`newtask_issue_prompt_template`) which is immune for exactly
- * this reason. Every other title passes through BYTE-IDENTICAL — that is the point: it keeps the
- * namer (and thus branch/worktree names) unchanged for the overwhelmingly common case.
+ * `--disable-slash-commands` does NOT rescue this, which is worth stating explicitly because auto
+ * (drain) spawns ALREADY pass it — trimDecision (service.ts) adds it whenever config.trimAutoContext
+ * is on, which is the default — so drain looks immune and isn't. Measured, same prompt:
+ *
+ *   $ claude -p --disable-slash-commands $'/zzznope\n\nGitHub Issue #1 …'
+ *   Unknown command: /zzznope
+ *
+ * And it would be unusable here even if it did work: it strips the whole skill catalog for the
+ * session (config.ts, transient-agent-argv.ts) and would kill the operator-authored leading-`/`
+ * first message that commands.ts supports. There is likewise no `--` separator, `--raw` flag, or
+ * escape character; only "text does not begin with `/`" reliably avoids the parse.
+ *
+ * So a `/`-leading title is templated into a sentence, mirroring the client-side New Task path
+ * (`newtask_issue_prompt_template`) which is immune for exactly this reason. Every other title
+ * passes through BYTE-IDENTICAL — that is the point: it keeps the namer (and thus branch/worktree
+ * names) unchanged for the overwhelmingly common case.
  *
  * NOT a general sanitizer, and deliberately NOT applied inside composePromptArg: a leading `/`
  * on an OPERATOR-authored prompt is a supported feature (commands.ts — New Task's Commands tab

--- a/src/issue-spawn-prompt.ts
+++ b/src/issue-spawn-prompt.ts
@@ -1,0 +1,41 @@
+/**
+ * Compose the spawn prompt for a session started FROM AN ISSUE TITLE (the Up Next start in
+ * server.ts and the auto-drain spawn in drain.ts). Both used to pass the bare title, which
+ * breaks the moment a title begins with `/`.
+ *
+ * WHY: the prompt is delivered as a positional argv to the agent CLI (service.ts `argv.push`),
+ * and Claude Code parses a leading `/` there as a slash command — only the first token, and the
+ * multi-line issue block composePromptArg appends after the title does NOT defeat it:
+ *
+ *   $ claude -p $'/zzznope\n\nGitHub Issue #1 (title + body follow as untrusted data):\n…'
+ *   Unknown command: /zzznope
+ *
+ * There is no `--` separator, `--raw` flag, or escape character; only "text does not begin with
+ * `/`" reliably avoids the parse. So a `/`-leading title is templated into a sentence, mirroring
+ * the client-side New Task path (`newtask_issue_prompt_template`) which is immune for exactly
+ * this reason. Every other title passes through BYTE-IDENTICAL — that is the point: it keeps the
+ * namer (and thus branch/worktree names) unchanged for the overwhelmingly common case.
+ *
+ * NOT a general sanitizer, and deliberately NOT applied inside composePromptArg: a leading `/`
+ * on an OPERATOR-authored prompt is a supported feature (commands.ts — New Task's Commands tab
+ * and the inline `/` picker spawn a session whose first message IS a slash command). Only a
+ * prompt derived from an issue title can be neutralized, because there a leading `/` is never a
+ * command anybody asked for.
+ *
+ * Applies unconditionally across providers even though Codex likely does NOT share the bug (it
+ * invokes skills as `$name`, commands.ts). `relaunch` reuses the stored prompt and can SWITCH
+ * provider, so a prompt left untemplated because it spawned on Codex would break as soon as it
+ * relaunched on Claude. Unconditional is correct-by-construction; a per-provider gate would be a
+ * latent relaunch bug.
+ *
+ * The English wording here is intentionally NOT shared with the i18n'd client-side
+ * `newtask_issue_prompt_template` (ui/messages/*.json): this is agent-facing spawn text (fixed
+ * English, like the drain prompts and directive blocks), that one is operator-visible UI. They
+ * may drift; nothing binds them and nothing needs to. Don't "fix" the duplication by wiring one
+ * to the other.
+ */
+export function issueSpawnPrompt(number: number, title: string): string {
+  // trimStart, not a bare startsWith: a " /foo" title would otherwise be left relying on the
+  // CLI's leading-whitespace trimming to dodge the parse — undocumented and provider-specific.
+  return title.trimStart().startsWith("/") ? `Work on issue #${number}: ${title}` : title;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -208,6 +208,7 @@ import {
   effortBelowHigh,
 } from "./default-effort";
 import { startSerially } from "./up-next";
+import { issueSpawnPrompt } from "./issue-spawn-prompt";
 import { excludeHiddenSections } from "./up-next-core";
 import type { UpNextSnapshot } from "./up-next-core";
 import { normalizeAgentProvider } from "./agent-provider";
@@ -1110,15 +1111,16 @@ async function handleUpNextStart(req: Request, deps: AppDeps): Promise<Response>
     }
     try {
       // Base + prompt = the drain auto-prompt for a plain issue (issue title on the default
-      // branch). Manual epic-child starts also base on default here; integration-branch
-      // orchestration stays the auto epic-runner's job (documented v1 scoping, #1169).
+      // branch, via the same issueSpawnPrompt guard). Manual epic-child starts also base on
+      // default here; integration-branch orchestration stays the auto epic-runner's job
+      // (documented v1 scoping, #1169).
       const base = await forge.defaultBranch();
       const rc = deps.store.getRepoConfig(it.dir);
       const provider = choice?.agentProvider ?? config.defaultAgentProvider;
       const input: CreateSessionInput = {
         repoPath: it.dir,
         baseBranch: base,
-        prompt: it.issueRef.title,
+        prompt: issueSpawnPrompt(it.issueRef.number, it.issueRef.title),
         // Operator default model (repo override wins; "auto"/"inherit" → no --model flag).
         // The Fable promo is client-only and never applied here, matching drain spawns.
         agentProvider: choice?.agentProvider,

--- a/test/drain.test.ts
+++ b/test/drain.test.ts
@@ -412,6 +412,18 @@ test("dedupe: an existing session mapped to #1 → spawns #2 next, not #1", asyn
   expect(h.creates[0]!.issueRef?.number).toBe(2);
 });
 
+test("spawn prompt: an ordinary title rides bare; a slash-leading title is templated", async () => {
+  const h = makeHarness({ maxAuto: 2, issues: [issue(1), issue(2, { title: "/foo bar" })] });
+  await h.drain.pump(REPO);
+  expect(h.creates).toHaveLength(2);
+  // Byte-identical for the common case — the namer derives branch + worktree names from this.
+  expect(h.creates[0]!.prompt).toBe("issue 1");
+  // The prompt is delivered as a positional argv, where a leading "/" is parsed as a slash
+  // command ("Unknown command: /foo bar") and the session dies before it starts.
+  expect(h.creates[1]!.prompt).toBe("Work on issue #2: /foo bar");
+  expect(h.creates[1]!.prompt.startsWith("/")).toBe(false);
+});
+
 test("retire gate: ready session → retired once; forge.merge never called; ensureIssueLink + archive + emitArchived fire", async () => {
   const h = makeHarness({ maxAuto: 1, issues: [] });
   const s = h.store.create({

--- a/test/issue-spawn-prompt.test.ts
+++ b/test/issue-spawn-prompt.test.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "bun:test";
+import { issueSpawnPrompt } from "../src/issue-spawn-prompt";
+
+test("templates a slash-leading title so the CLI can't parse it as a slash command", () => {
+  // `claude -p "/foo bar"` → "Unknown command: /foo bar"; the sentence prefix moves the slash
+  // off position 0, which is the only thing that reliably avoids the parse.
+  expect(issueSpawnPrompt(12, "/foo bar")).toBe("Work on issue #12: /foo bar");
+});
+
+test("templates a path-like title — no such command exists, and that is exactly the broken case", () => {
+  expect(issueSpawnPrompt(12, "/api/users returns 500")).toBe(
+    "Work on issue #12: /api/users returns 500",
+  );
+});
+
+test("templates a bare slash", () => {
+  expect(issueSpawnPrompt(7, "/")).toBe("Work on issue #7: /");
+});
+
+test("templates a title whose slash sits behind leading whitespace", () => {
+  // Dodging the parse via the CLI's whitespace trimming would be undocumented and
+  // provider-specific — template it instead, preserving the title verbatim.
+  expect(issueSpawnPrompt(3, "  /foo")).toBe("Work on issue #3:   /foo");
+});
+
+test("passes a non-slash title through byte-identical", () => {
+  // The byte-identical path is load-bearing: the namer derives branch + worktree names from the
+  // prompt, so every ordinary title must keep the slug it has today.
+  expect(issueSpawnPrompt(12, "Fix login")).toBe("Fix login");
+  expect(issueSpawnPrompt(12, "Rework the /usage probe")).toBe("Rework the /usage probe");
+  expect(issueSpawnPrompt(12, "")).toBe("");
+});

--- a/test/server-up-next.test.ts
+++ b/test/server-up-next.test.ts
@@ -60,6 +60,7 @@ function harness(
     at: number;
     repoPath: string;
     number: number | undefined;
+    prompt: string;
     agentProvider: CreateSessionInput["agentProvider"];
     model: CreateSessionInput["model"];
     effort: CreateSessionInput["effort"];
@@ -78,6 +79,7 @@ function harness(
             at: ++n,
             repoPath: input.repoPath,
             number: input.issueRef?.number,
+            prompt: input.prompt,
             agentProvider: input.agentProvider,
             model: input.model,
             effort: input.effort,
@@ -156,9 +158,27 @@ test("POST /api/up-next/start spawns one session and stamps the claim", async ()
   expect(body.errors).toHaveLength(0);
   expect(createCalls).toHaveLength(1);
   expect(createCalls[0]!.number).toBe(7);
+  // An ordinary title spawns on the bare title, byte-identical — the namer derives branch and
+  // worktree names from it, so the common case must not change.
+  expect(createCalls[0]!.prompt).toBe("t");
   // claim is stamped asynchronously, so it should have recorded #7.
   await new Promise((r) => setTimeout(r, 5));
   expect(labelCalls).toContain(7);
+});
+
+test("POST /api/up-next/start templates a slash-leading title so the CLI can't parse it as a command", async () => {
+  const { app, createCalls } = harness();
+  const res = await app.fetch(
+    startReq([
+      { repoPath: repoDir, issueRef: { number: 7, url: "u", title: "/foo bar", body: "b" } },
+    ]),
+  );
+  expect(res.status).toBe(201);
+  expect(createCalls).toHaveLength(1);
+  // The prompt is delivered as a positional argv; a leading "/" there is parsed as a slash
+  // command ("Unknown command: /foo bar") and the session dies before it starts.
+  expect(createCalls[0]!.prompt).toBe("Work on issue #7: /foo bar");
+  expect(createCalls[0]!.prompt.startsWith("/")).toBe(false);
 });
 
 test("POST /api/up-next/start forwards selected provider, model and effort to create", async () => {


### PR DESCRIPTION
## The bug

An issue titled `/foo bar` kills its own session. **Up Next start** (`server.ts`) and **auto-drain** (`drain.ts`) both passed the **bare** issue title as the spawn prompt, and that prompt is delivered as a **positional argv** to the agent CLI — where Claude Code parses a leading `/` as a slash command.

## Reproduced against the real argv shape

Both sites set `issueRef`, so `composePromptArg` appends a multi-line `GitHub Issue #N …` block after the title. That block does **not** defeat the parse — only the first token is consumed:

```
$ claude -p $'/zzznope-probe\n\nGitHub Issue #1 (title + body follow as untrusted data):\nsay only the word OK'
Unknown command: /zzznope-probe

$ claude -p $'zzznope-probe\n\nsay only the word OK'     # non-slash control
OK
```

There is no `--` separator, `--raw` flag, or escape character. Only "text does not begin with `/`" reliably avoids it.

## The fix

A pure helper, `issueSpawnPrompt(number, title)`, used by both sites:

| Issue title | Prompt before | Prompt after |
| --- | --- | --- |
| `/foo bar` | `/foo bar` → `Unknown command: /foo bar` | `Work on issue #12: /foo bar` |
| `/api/users returns 500` | `Unknown command: /api/users` | `Work on issue #12: /api/users returns 500` |
| `Fix login` | `Fix login` | `Fix login` (**byte-identical**) |

This mirrors **New Task**, which is already immune because it templates the title into `newtask_issue_prompt_template` (`"Work on issue #{number}: {title}"`). The byte-identical passthrough is load-bearing: the namer derives branch + worktree names from the prompt, so the common case must not shift.

## Design notes (the non-obvious parts)

- **Not sanitized centrally in `composePromptArg`**, even though it's the single funnel: a leading `/` on an **operator-authored** prompt is a *supported feature* (`commands.ts` — New Task's Commands tab and inline `/` picker spawn a session whose first message *is* a slash command). Only an issue-title-derived prompt can be neutralized, because there a leading `/` is never a command anyone asked for.
- **Unconditional across providers**, though Codex likely does *not* have this bug (it invokes skills as `$name`; `codex exec` forwarded a slash-leading prompt straight to the model API). The reason is `relaunch`: it reuses the stored prompt and **can switch provider**, so a prompt left untemplated on Codex would break the moment it relaunched on Claude. A per-provider gate would be a latent relaunch bug.
- **`trimStart()`, not bare `startsWith`**: a `" /foo"` title would otherwise rely on the CLI's leading-whitespace trimming — undocumented and provider-specific.

## Known costs (accepted, documented in the helper)

- **Branch slug for slash titles.** `"Work on issue #12: /foo bar"` slugs to `work-issue-12-foo` (measured): `"on"` is a STOPWORD but `work`/`issue` aren't, and the 4-word cap drops `bar`. It's no longer "strong", so the background Haiku refine fires and renames the branch via `git branch -m` — the path `BRANCH_RENAME_NOTICE` already documents. The worktree dir keeps the initial slug. Bounded to slash titles; this is the shape New Task ships today (`"Work on issue #12: Fix login"` → `work-issue-12-login`). Rejected alternatives: adding `work`/`issue` to STOPWORDS (breaks `test/namer.test.ts:109`, churns slugs repo-wide) and threading a `nameHint` (new API surface `relaunch` wouldn't persist).
- **Pre-existing sessions aren't retro-fixed.** `relaunch` reuses `s.prompt` rather than re-deriving from the title, so a session already stored with a bare `/foo` prompt stays broken — re-start the issue from Up Next. A store migration is disproportionate.
- **Intentional drift**: the server helper is fixed English (agent-facing, per house rules); the client template is i18n'd. Not shared by design — the helper's doc comment says so, so nobody later "fixes" the duplication.

## Testing

- New `test/issue-spawn-prompt.test.ts` — slash, path-like slash, bare `/`, leading-whitespace slash, non-slash passthrough.
- `test/server-up-next.test.ts` + `test/drain.test.ts` — assert the prompt reaching `create()` (ordinary title stays bare; slash title templated), drain covering the plain and epic-base variants.
- `bun run lint`, `bun run typecheck`, `bun run test` (**7161 pass, 0 fail**) and the full pre-push gate all pass. Server-only — `ui/` untouched, so no i18n keys and no feature-catalog entry (a `fix`, not a `feat`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)