### PR TITLE
feat(usage): show Claude model usage by role

### DIFF
--- a/src/codex-usage.ts
+++ b/src/codex-usage.ts
@@ -205,10 +205,7 @@ export function readCodexTokenUsage(dbPath: string, now: number): UsageProviderS
 }
 
 /** Raw Codex token totals grouped by model for OpenAI threads updated in the selected range. */
-export function readCodexModelUsage(
-  dbPath: string | null,
-  cutoff: number,
-): Record<string, number> {
+export function readCodexModelUsage(dbPath: string | null, cutoff: number): Record<string, number> {
   if (!dbPath || !existsSync(dbPath)) return {};
   let db: Database | null = null;
   try {
@@ -233,7 +230,9 @@ export function readCodexModelUsage(
          GROUP BY COALESCE(NULLIF(model, ''), 'unknown')`,
       )
       .all(cutoff);
-    return Object.fromEntries(rows.filter((row) => row.tokens > 0).map((row) => [row.model, row.tokens]));
+    return Object.fromEntries(
+      rows.filter((row) => row.tokens > 0).map((row) => [row.model, row.tokens]),
+    );
   } catch {
     return {};
   } finally {

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,11 +53,7 @@ import { parseManualSteps } from "./manual-steps";
 import { annotateHandoff } from "./repo-roles";
 import { AccountUsageIndex, SessionUsageRollup } from "./usage";
 import { UsageLimitsService, calibrateDelay, type UsageLimits } from "./usage-limits";
-import {
-  CodexUsageProvider,
-  latestCodexStateDb,
-  readCodexModelUsage,
-} from "./codex-usage";
+import { CodexUsageProvider, latestCodexStateDb, readCodexModelUsage } from "./codex-usage";
 import { singleFlight } from "./single-flight";
 import { HerdrUsageProbe } from "./usage-probe";
 import { sweepStaging, STAGING_TTL_MS } from "./uploads";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1119,9 +1119,13 @@ export interface UsageKindUnits {
   count: number; // number of completed passes of that kind, in range
 }
 
+export type UsageRole = "coding" | "review" | "plan_gate" | "recap" | "rundown" | "doc_agent";
+export type UsageByRole = Partial<Record<UsageRole, Record<string, number>>>;
+
 export interface UsageModelBreakdown {
   totalTokens: number;
   byModel: Record<string, number>;
+  byRole: UsageByRole;
 }
 
 export interface UsageBreakdown {
@@ -1184,7 +1188,7 @@ export const USAGE_REPO_KEYS = [
 // Mirrors UsageKindUnits:
 export const USAGE_KIND_UNITS_KEYS = ["kind", "units", "count"] as const;
 // Mirrors UsageModelBreakdown:
-export const USAGE_MODEL_BREAKDOWN_KEYS = ["totalTokens", "byModel"] as const;
+export const USAGE_MODEL_BREAKDOWN_KEYS = ["totalTokens", "byModel", "byRole"] as const;
 // Mirrors UsageBreakdown:
 export const USAGE_BREAKDOWN_KEYS = [
   "range",

--- a/src/usage-breakdown.ts
+++ b/src/usage-breakdown.ts
@@ -238,14 +238,8 @@ function isLegacyClaudeModel(model: string): boolean {
   return CLAUDE_MODEL_ALIASES.has(model) || CLAUDE_FULL_MODEL_ID.test(model);
 }
 
-function claudeUsageByRole(
-  taskMap: Map<string, TaskAccum>,
-  spawns: ReturnType<SessionStore["listReviewerSpawns"]>,
-  cutoff: number,
-): UsageByRole {
-  const byRole: UsageByRole = {};
+function codingUsageByModel(taskMap: Map<string, TaskAccum>): Record<string, number> {
   const coding: Record<string, number> = {};
-
   for (const task of taskMap.values()) {
     for (const [rawModel, tokens] of Object.entries(task.rawByModel)) {
       const model = usableModel(rawModel);
@@ -253,24 +247,41 @@ function claudeUsageByRole(
       coding[model] = (coding[model] ?? 0) + tokens;
     }
   }
-  if (Object.keys(coding).length > 0) byRole.coding = coding;
+  return coding;
+}
 
+function spawnRawTokens(spawn: ReturnType<SessionStore["listReviewerSpawns"]>[number]): number {
+  return (
+    (spawn.inputTokens ?? 0) +
+    (spawn.outputTokens ?? 0) +
+    (spawn.cacheReadTokens ?? 0) +
+    (spawn.cacheWriteTokens ?? 0)
+  );
+}
+
+function claudeSpawnModel(
+  spawn: ReturnType<SessionStore["listReviewerSpawns"]>[number],
+  cutoff: number,
+): string | null {
+  if (spawn.totalTokens == null) return null;
+  if ((spawn.completedAt ?? spawn.spawnedAt) < cutoff) return null;
+  const model = usableModel(spawn.model);
+  if (!model) return null;
+  if (spawn.reviewerProvider === "claude") return model;
+  if (spawn.reviewerProvider == null && isLegacyClaudeModel(model)) return model;
+  return null;
+}
+
+function claudeSpawnUsageByRole(
+  spawns: ReturnType<SessionStore["listReviewerSpawns"]>,
+  cutoff: number,
+): UsageByRole {
+  const byRole: UsageByRole = {};
   for (const sp of spawns) {
-    if (sp.totalTokens == null) continue;
-    if ((sp.completedAt ?? sp.spawnedAt) < cutoff) continue;
-
-    const model = usableModel(sp.model);
+    const model = claudeSpawnModel(sp, cutoff);
     if (!model) continue;
-    const isClaude =
-      sp.reviewerProvider === "claude" ||
-      (sp.reviewerProvider == null && isLegacyClaudeModel(model));
-    if (!isClaude) continue;
 
-    const tokens =
-      (sp.inputTokens ?? 0) +
-      (sp.outputTokens ?? 0) +
-      (sp.cacheReadTokens ?? 0) +
-      (sp.cacheWriteTokens ?? 0);
+    const tokens = spawnRawTokens(sp);
     if (tokens <= 0) continue;
 
     const role = byRole[sp.kind] ?? {};
@@ -278,6 +289,17 @@ function claudeUsageByRole(
     byRole[sp.kind] = role;
   }
 
+  return byRole;
+}
+
+function claudeUsageByRole(
+  taskMap: Map<string, TaskAccum>,
+  spawns: ReturnType<SessionStore["listReviewerSpawns"]>,
+  cutoff: number,
+): UsageByRole {
+  const byRole = claudeSpawnUsageByRole(spawns, cutoff);
+  const coding = codingUsageByModel(taskMap);
+  if (Object.keys(coding).length > 0) byRole.coding = coding;
   return byRole;
 }
 

--- a/src/usage-breakdown.ts
+++ b/src/usage-breakdown.ts
@@ -1,6 +1,8 @@
 import { basename } from "node:path";
 import type { SessionStore } from "./store";
+import { MODELS } from "./types";
 import type {
+  UsageByRole,
   UsageRange,
   UsageBreakdown,
   UsageKindUnits,
@@ -12,6 +14,9 @@ import type {
 import { isOperationalArchetype } from "./usage-archetype";
 import { jsonlPathFor, sessionCost, dominantModel, SessionUsageRollup } from "./usage";
 import { weightedUnits } from "./pricing";
+
+const CLAUDE_MODEL_ALIASES = new Set<string>(MODELS);
+const CLAUDE_FULL_MODEL_ID = /^claude-(?:opus|sonnet|haiku)(?:-\d+)+$/i;
 
 /** Internal accumulator — public fields + private cacheRead accumulators. */
 interface TaskAccum {
@@ -221,6 +226,70 @@ function satelliteUnitsByKind(
   return [...byKind.entries()]
     .map(([kind, b]) => ({ kind, units: b.units, count: b.count }))
     .sort((a, b) => b.units - a.units);
+}
+
+function usableModel(model: string | null): string | null {
+  const normalized = model?.trim();
+  if (!normalized || normalized === "<synthetic>") return null;
+  return normalized;
+}
+
+function isLegacyClaudeModel(model: string): boolean {
+  return CLAUDE_MODEL_ALIASES.has(model) || CLAUDE_FULL_MODEL_ID.test(model);
+}
+
+function claudeUsageByRole(
+  taskMap: Map<string, TaskAccum>,
+  spawns: ReturnType<SessionStore["listReviewerSpawns"]>,
+  cutoff: number,
+): UsageByRole {
+  const byRole: UsageByRole = {};
+  const coding: Record<string, number> = {};
+
+  for (const task of taskMap.values()) {
+    for (const [rawModel, tokens] of Object.entries(task.rawByModel)) {
+      const model = usableModel(rawModel);
+      if (!model || tokens <= 0) continue;
+      coding[model] = (coding[model] ?? 0) + tokens;
+    }
+  }
+  if (Object.keys(coding).length > 0) byRole.coding = coding;
+
+  for (const sp of spawns) {
+    if (sp.totalTokens == null) continue;
+    if ((sp.completedAt ?? sp.spawnedAt) < cutoff) continue;
+
+    const model = usableModel(sp.model);
+    if (!model) continue;
+    const isClaude =
+      sp.reviewerProvider === "claude" ||
+      (sp.reviewerProvider == null && isLegacyClaudeModel(model));
+    if (!isClaude) continue;
+
+    const tokens =
+      (sp.inputTokens ?? 0) +
+      (sp.outputTokens ?? 0) +
+      (sp.cacheReadTokens ?? 0) +
+      (sp.cacheWriteTokens ?? 0);
+    if (tokens <= 0) continue;
+
+    const role = byRole[sp.kind] ?? {};
+    role[model] = (role[model] ?? 0) + tokens;
+    byRole[sp.kind] = role;
+  }
+
+  return byRole;
+}
+
+function foldModels(byRole: UsageByRole): Record<string, number> {
+  const byModel: Record<string, number> = {};
+  for (const models of Object.values(byRole)) {
+    if (!models) continue;
+    for (const [model, tokens] of Object.entries(models)) {
+      byModel[model] = (byModel[model] ?? 0) + tokens;
+    }
+  }
+  return byModel;
 }
 
 /** Group task accumulators by repo, sort within each repo, and produce public repo breakdowns. */
@@ -437,16 +506,13 @@ export async function buildUsageBreakdown(opts: {
   // Global per-kind satellite tally — spawn-timestamp-filtered, independent of attribution.
   const satelliteByKind = satelliteUnitsByKind(spawns, cutoff);
 
-  const claudeByModel: Record<string, number> = {};
-  for (const task of taskMap.values()) {
-    for (const [model, tokens] of Object.entries(task.rawByModel)) {
-      claudeByModel[model] = (claudeByModel[model] ?? 0) + tokens;
-    }
-  }
+  const claudeByRole = claudeUsageByRole(taskMap, spawns, cutoff);
+  const claudeByModel = foldModels(claudeByRole);
   const codexByModel = opts.codexModelUsage?.(cutoff) ?? {};
-  const modelBreakdown = (byModel: Record<string, number>) => ({
+  const modelBreakdown = (byModel: Record<string, number>, byRole: UsageByRole = {}) => ({
     totalTokens: Object.values(byModel).reduce((sum, tokens) => sum + tokens, 0),
     byModel,
+    byRole,
   });
 
   return {
@@ -456,7 +522,7 @@ export async function buildUsageBreakdown(opts: {
     satelliteByKind,
     dollars: apiKey ? totals.totalUnits : null,
     models: {
-      claude: modelBreakdown(claudeByModel),
+      claude: modelBreakdown(claudeByModel, claudeByRole),
       codex: modelBreakdown(codexByModel),
     },
     repos,

--- a/test/server-usage-breakdown.test.ts
+++ b/test/server-usage-breakdown.test.ts
@@ -84,8 +84,9 @@ test("GET /api/usage/breakdown?range=7d → 200 with correct shape", async () =>
   expect(body.models.claude).toEqual({
     totalTokens: 3600,
     byModel: { "claude-sonnet-4": 3600 },
+    byRole: { coding: { "claude-sonnet-4": 3600 } },
   });
-  expect(body.models.codex).toEqual({ totalTokens: 0, byModel: {} });
+  expect(body.models.codex).toEqual({ totalTokens: 0, byModel: {}, byRole: {} });
 
   for (const repo of body.repos) {
     exactKeys(repo, USAGE_REPO_KEYS);
@@ -134,15 +135,14 @@ test("GET /api/usage/breakdown forwards cutoff to the Codex model dependency", a
   });
 
   const before = Date.now() - 7 * 86_400_000;
-  const body = await (
-    await app.fetch(new Request("http://x/api/usage/breakdown?range=7d"))
-  ).json();
+  const body = await (await app.fetch(new Request("http://x/api/usage/breakdown?range=7d"))).json();
   const after = Date.now() - 7 * 86_400_000;
   expect(receivedCutoff).toBeGreaterThanOrEqual(before);
   expect(receivedCutoff).toBeLessThanOrEqual(after);
   expect(body.models.codex).toEqual({
     totalTokens: 1000,
     byModel: { "gpt-5.5": 700, unknown: 300 },
+    byRole: {},
   });
 });
 

--- a/test/usage-breakdown.test.ts
+++ b/test/usage-breakdown.test.ts
@@ -111,7 +111,195 @@ function makeSnap(over: {
   };
 }
 
+function seedRoleSpawn(
+  store: SessionStore,
+  r: {
+    id: string;
+    kind: "review" | "plan_gate" | "recap" | "rundown" | "doc_agent";
+    provider: "claude" | "codex" | null;
+    model: string | null;
+    spawnedAt?: number;
+    completedAt?: number | null;
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+  },
+): void {
+  const input = r.input ?? 0;
+  const output = r.output ?? 0;
+  const cacheRead = r.cacheRead ?? 0;
+  const cacheWrite = r.cacheWrite ?? 0;
+  // @ts-expect-error accessing internal db for focused aggregate setup
+  store.db.run(
+    `INSERT INTO reviewer_spawns
+       (reviewerSessionId, taskSessionId, kind, worktreePath, reviewerProvider, model,
+        spawnedAt, completedAt, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens,
+        totalTokens)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+    [
+      r.id,
+      "task-a",
+      r.kind,
+      "/wt/" + r.id,
+      r.provider,
+      r.model,
+      r.spawnedAt ?? NOW - 2_000,
+      r.completedAt === undefined ? NOW - 1_000 : r.completedAt,
+      input,
+      output,
+      cacheRead,
+      cacheWrite,
+      input + output + cacheRead + cacheWrite,
+    ],
+  );
+}
+
 // ── actual test suite ─────────────────────────────────────────────────────────
+
+test("Claude model breakdown preserves role × model identity and exact token total", async () => {
+  const store = new SessionStore(":memory:");
+  store.upsertSessionUsage(
+    makeSnap({
+      sessionId: "task-a",
+      desig: "TASK-01",
+      repoPath: "/repos/alpha",
+      input: 100,
+      output: 200,
+      weightedUnits: 0,
+      cacheReadUnits: 0,
+      rawByModel: { "claude-opus-4-8": 100, "claude-sonnet-4-8": 200 },
+      snapshotAt: NOW,
+    }),
+  );
+
+  seedRoleSpawn(store, {
+    id: "review",
+    kind: "review",
+    provider: "claude",
+    model: "claude-opus-4-8",
+    input: 10,
+    output: 20,
+    cacheRead: 30,
+    cacheWrite: 40,
+  });
+  seedRoleSpawn(store, {
+    id: "plan",
+    kind: "plan_gate",
+    provider: "claude",
+    model: "claude-sonnet-4-8",
+    input: 50,
+  });
+  seedRoleSpawn(store, {
+    id: "recap",
+    kind: "recap",
+    provider: null,
+    model: "fable",
+    input: 25,
+  });
+  seedRoleSpawn(store, {
+    id: "rundown",
+    kind: "rundown",
+    provider: "claude",
+    model: "claude-opus-4-8",
+    output: 15,
+  });
+  seedRoleSpawn(store, {
+    id: "doc",
+    kind: "doc_agent",
+    provider: "claude",
+    model: "haiku",
+    cacheRead: 10,
+  });
+
+  const bd = await buildUsageBreakdown({ store, range: "all", now: NOW, apiKey: false });
+
+  expect(bd.models.claude).toEqual({
+    totalTokens: 500,
+    byModel: {
+      "claude-opus-4-8": 215,
+      "claude-sonnet-4-8": 250,
+      fable: 25,
+      haiku: 10,
+    },
+    byRole: {
+      coding: { "claude-opus-4-8": 100, "claude-sonnet-4-8": 200 },
+      review: { "claude-opus-4-8": 100 },
+      plan_gate: { "claude-sonnet-4-8": 50 },
+      recap: { fable: 25 },
+      rundown: { "claude-opus-4-8": 15 },
+      doc_agent: { haiku: 10 },
+    },
+  });
+  expect(bd.models.codex.byRole).toEqual({});
+  const roleTotal = Object.values(bd.models.claude.byRole).reduce(
+    (total, models) => total + Object.values(models ?? {}).reduce((sum, tokens) => sum + tokens, 0),
+    0,
+  );
+  expect(roleTotal).toBe(bd.models.claude.totalTokens);
+});
+
+test("legacy null-provider Claude classifier is anchored and range-filtered", async () => {
+  const store = new SessionStore(":memory:");
+  const accepted = [
+    "fable",
+    "opus",
+    "opus[1m]",
+    "sonnet",
+    "sonnet[1m]",
+    "haiku",
+    "claude-opus-4-8",
+    "claude-sonnet-4-20250514",
+    "claude-haiku-3-5",
+  ];
+  accepted.forEach((model, index) => {
+    seedRoleSpawn(store, {
+      id: `accepted-${index}`,
+      kind: "recap",
+      provider: null,
+      model,
+      input: 1,
+    });
+  });
+  for (const [index, model] of [
+    "my-claude-opus-4-8",
+    "claude-opus-latest",
+    "gpt-5.5",
+    "<synthetic>",
+    " ",
+  ].entries()) {
+    seedRoleSpawn(store, {
+      id: `rejected-${index}`,
+      kind: "recap",
+      provider: null,
+      model,
+      input: 100,
+    });
+  }
+  seedRoleSpawn(store, {
+    id: "explicit-codex-wins",
+    kind: "review",
+    provider: "codex",
+    model: "claude-opus-4-8",
+    input: 100,
+  });
+  seedRoleSpawn(store, {
+    id: "stale",
+    kind: "review",
+    provider: "claude",
+    model: "claude-opus-4-8",
+    spawnedAt: NOW - 2 * H24,
+    completedAt: null,
+    input: 100,
+  });
+
+  const bd = await buildUsageBreakdown({ store, range: "24h", now: NOW, apiKey: false });
+
+  expect(bd.models.claude.byRole).toEqual({
+    recap: Object.fromEntries(accepted.map((model) => [model, 1])),
+  });
+  expect(bd.models.claude.totalTokens).toBe(accepted.length);
+});
 
 test("repo→task grouping, sorting, field mapping", async () => {
   const store = new SessionStore(":memory:");
@@ -842,7 +1030,11 @@ test("persisted windowed sub-session: 24h returns only recent hour; 30d/all retu
   expect(task24h!.tokens.input).toBe(300);
   expect(task24h!.tokens.output).toBe(100);
   expect(task24h!.authoringUnits).toBeCloseTo(recentWu, 10);
-  expect(bd24h.models.claude).toEqual({ totalTokens: 400, byModel: { [model]: 400 } });
+  expect(bd24h.models.claude).toEqual({
+    totalTokens: 400,
+    byModel: { [model]: 400 },
+    byRole: { coding: { [model]: 400 } },
+  });
 
   // 30d: both buckets (old hour is 48h ago, within 30d)
   const bd30d = await buildUsageBreakdown({ store, range: "30d", now: NOW, apiKey: false });
@@ -851,7 +1043,11 @@ test("persisted windowed sub-session: 24h returns only recent hour; 30d/all retu
   expect(task30d!.tokens.input).toBe(800);
   expect(task30d!.tokens.output).toBe(300);
   expect(task30d!.authoringUnits).toBeCloseTo(totalWu, 10);
-  expect(bd30d.models.claude).toEqual({ totalTokens: 1100, byModel: { [model]: 1100 } });
+  expect(bd30d.models.claude).toEqual({
+    totalTokens: 1100,
+    byModel: { [model]: 1100 },
+    byRole: { coding: { [model]: 1100 } },
+  });
 
   // all: uses aggregate row → same total
   const bdAll = await buildUsageBreakdown({ store, range: "all", now: NOW, apiKey: false });

--- a/test/usage-timeline.test.ts
+++ b/test/usage-timeline.test.ts
@@ -161,7 +161,6 @@ test("finalized reviewer spawns add units at floorHour(completedAt); unfinalized
       messageCount: 1,
       lastActivity: NOW - HOUR,
       byModel: { [MODEL]: 450 },
-      rawByModel: { [MODEL]: 0 },
       fullRecaches: 0,
       sidechainCount: 0,
     },

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -1977,6 +1977,9 @@
   "usage_models_other": "Andere",
   "usage_models_empty": "In diesem Zeitraum wurde keine Modellnutzung erfasst",
   "usage_models_bar_aria": "Modell-Mix für {provider}, {tokens} gesamt",
+  "usage_models_by_role": "Aufschlüsselung nach Rolle",
+  "usage_models_role_coding": "Coding",
+  "usage_models_codex_roles_unavailable": "Pro Rolle nicht aufgeschlüsselt",
   "usage_limits_tab": "Limits",
   "usage_range_label": "Zeitraum",
   "usage_range_24h": "24h",
@@ -3115,5 +3118,7 @@
   "feat_automerge_session_jump_title": "Aus Voll-Auto-Merge springen",
   "feat_automerge_session_jump_body": "Klicke auf einen aktiven Voll-Auto-Merge-Eintrag, um direkt zu seinem Task und Terminal zu springen. Shepherd entfernt Filter, die ihn verbergen würden, und folgt dem Task ins richtige Repository.",
   "feat_build_queue_progress_toggle_title": "Build-Queue direkt öffnen",
-  "feat_build_queue_progress_toggle_body": "Klicke auf das Fortschritts-Badge einer Session, um sie auszuwählen und ihre Build-Queue über dem Terminal zu öffnen. Klicke erneut auf das Badge der ausgewählten Session, um die Queue ein- oder auszuklappen."
+  "feat_build_queue_progress_toggle_body": "Klicke auf das Fortschritts-Badge einer Session, um sie auszuwählen und ihre Build-Queue über dem Terminal zu öffnen. Klicke erneut auf das Badge der ausgewählten Session, um die Queue ein- oder auszuklappen.",
+  "feat_usage_role_model_breakdown_title": "Claude-Verbrauch nach Rolle und Modell erkennen",
+  "feat_usage_role_model_breakdown_body": "Klappe Coding, Review, Plan Gate und weitere Claude-Rollen unter Nutzung → Modelle auf, um das verwendete Modell, seine Tokens und den jeweiligen Anteil zu sehen."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -1977,6 +1977,9 @@
   "usage_models_other": "Other",
   "usage_models_empty": "No model usage recorded in this range",
   "usage_models_bar_aria": "{provider} model mix, {tokens} total",
+  "usage_models_by_role": "Breakdown by role",
+  "usage_models_role_coding": "Coding",
+  "usage_models_codex_roles_unavailable": "Not broken down by role",
   "usage_limits_tab": "Limits",
   "usage_range_label": "Time range",
   "usage_range_24h": "24h",
@@ -3115,5 +3118,7 @@
   "feat_automerge_session_jump_title": "Jump from Full-auto merge",
   "feat_automerge_session_jump_body": "Click any active Full-auto merge entry to jump straight to its task and terminal. Shepherd clears filters that would hide it and follows the task into the right repository.",
   "feat_build_queue_progress_toggle_title": "Open the build queue from progress",
-  "feat_build_queue_progress_toggle_body": "Click a session's progress badge to select it and open its build queue above the terminal. Click the selected session's badge again to collapse or expand the queue."
+  "feat_build_queue_progress_toggle_body": "Click a session's progress badge to select it and open its build queue above the terminal. Click the selected session's badge again to collapse or expand the queue.",
+  "feat_usage_role_model_breakdown_title": "See Claude usage by role and model",
+  "feat_usage_role_model_breakdown_body": "Expand Coding, Review, Plan gate, and other Claude roles in Usage → Models to see which model consumed their tokens and what share it represents."
 }

--- a/ui/src/lib/components/usage/ModelsLens.browser.test.ts
+++ b/ui/src/lib/components/usage/ModelsLens.browser.test.ts
@@ -25,8 +25,20 @@ describe("ModelsLens", () => {
             gamma: 150,
             delta: 150,
           },
+          byRole: {
+            coding: {
+              "claude-opus-4-8": 1000,
+              "claude-sonnet-4-5": 800,
+              "claude-haiku-4-5": 600,
+              fable: 400,
+              alpha: 300,
+              beta: 200,
+              gamma: 150,
+              delta: 150,
+            },
+          },
         },
-        codex: { totalTokens: 1000, byModel: { "gpt-5.5": 700, unknown: 300 } },
+        codex: { totalTokens: 1000, byModel: { "gpt-5.5": 700, unknown: 300 }, byRole: {} },
       },
     });
 
@@ -37,6 +49,7 @@ describe("ModelsLens", () => {
     expect(claude.querySelectorAll(".model-list li")).toHaveLength(7);
     expect(codex.textContent).toContain("GPT-5.5");
     expect(codex.textContent).toContain(formatTokenLabel(1000));
+    expect(codex.querySelector(".role-unavailable")).not.toBeNull();
     expect(document.querySelectorAll('[role="img"]')).toHaveLength(2);
 
     for (const block of [claude, codex]) {
@@ -51,8 +64,8 @@ describe("ModelsLens", () => {
   it("shows a provider-specific zero total and no misleading bar for empty data", () => {
     render(ModelsLens, {
       models: {
-        claude: { totalTokens: 0, byModel: {} },
-        codex: { totalTokens: 0, byModel: {} },
+        claude: { totalTokens: 0, byModel: {}, byRole: {} },
+        codex: { totalTokens: 0, byModel: {}, byRole: {} },
       },
     });
 
@@ -75,13 +88,57 @@ describe("ModelsLens", () => {
             omega: 100,
             Zulu: 100,
           },
+          byRole: {
+            coding: {
+              alpha: 100,
+              beta: 100,
+              delta: 100,
+              epsilon: 100,
+              gamma: 100,
+              omega: 100,
+              Zulu: 100,
+            },
+          },
         },
-        codex: { totalTokens: 0, byModel: {} },
+        codex: { totalTokens: 0, byModel: {}, byRole: {} },
       },
     });
 
     const claude = document.querySelector<HTMLElement>('[data-provider="claude"]')!;
-    expect(claude.textContent).toContain("Zulu");
-    expect(claude.textContent).not.toContain("Omega");
+    const modelList = claude.querySelector<HTMLElement>(".model-list")!;
+    expect(modelList.textContent).toContain("Zulu");
+    expect(modelList.textContent).not.toContain("Omega");
+  });
+
+  it("expands Claude roles into models with provider and role percentages", () => {
+    render(ModelsLens, {
+      models: {
+        claude: {
+          totalTokens: 500,
+          byModel: { "claude-opus-4-8": 200, "claude-sonnet-4-5": 300 },
+          byRole: {
+            coding: { "claude-sonnet-4-5": 300 },
+            review: { "claude-opus-4-8": 100 },
+            plan_gate: { "claude-opus-4-8": 100 },
+          },
+        },
+        codex: { totalTokens: 0, byModel: {}, byRole: {} },
+      },
+    });
+
+    const claude = document.querySelector<HTMLElement>('[data-provider="claude"]')!;
+    const roles = claude.querySelectorAll<HTMLDetailsElement>(".role-detail");
+    expect(roles).toHaveLength(3);
+    expect([...roles].map((role) => role.dataset.role)).toEqual(["coding", "review", "plan_gate"]);
+
+    const planGate = claude.querySelector<HTMLDetailsElement>('[data-role="plan_gate"]')!;
+    expect(planGate.querySelector("summary")?.textContent).toContain("20.0%");
+    planGate.querySelector<HTMLElement>("summary")!.click();
+    expect(planGate.open).toBe(true);
+
+    const modelRow = planGate.querySelector<HTMLElement>(".role-model-row")!;
+    expect(modelRow.textContent).toContain("Opus 4.8");
+    expect(modelRow.textContent).toContain("100.0%");
+    expect(modelRow.textContent).toContain(formatTokenLabel(100));
   });
 });

--- a/ui/src/lib/components/usage/ModelsLens.svelte
+++ b/ui/src/lib/components/usage/ModelsLens.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { UsageBreakdown, UsageModelBreakdown } from "$lib/types";
+  import type { UsageBreakdown, UsageModelBreakdown, UsageRole } from "$lib/types";
   import { m } from "$lib/paraglide/messages";
   import { formatTokenLabel } from "$lib/format";
   import { modelDisplayName } from "$lib/components/usage-gauges";
@@ -23,6 +23,40 @@
     exactPct: number;
     displayPct: number;
     tone: string;
+  }
+
+  interface RoleRow {
+    id: UsageRole;
+    label: string;
+    tokens: number;
+    providerPct: number;
+    models: Array<{ id: string; label: string; tokens: number; rolePct: number }>;
+  }
+
+  const ROLE_ORDER: UsageRole[] = [
+    "coding",
+    "review",
+    "plan_gate",
+    "recap",
+    "rundown",
+    "doc_agent",
+  ];
+
+  function roleLabel(role: UsageRole): string {
+    switch (role) {
+      case "coding":
+        return m.usage_models_role_coding();
+      case "review":
+        return m.usage_kind_review();
+      case "plan_gate":
+        return m.usage_kind_plan_gate();
+      case "recap":
+        return m.usage_kind_recap();
+      case "rundown":
+        return m.usage_kind_rundown();
+      case "doc_agent":
+        return m.usage_kind_doc_agent();
+    }
   }
 
   function rowsFor(data: UsageModelBreakdown): ModelRow[] {
@@ -59,6 +93,33 @@
     }));
   }
 
+  function roleRowsFor(data: UsageModelBreakdown): RoleRow[] {
+    return ROLE_ORDER.flatMap((role) => {
+      const models = Object.entries(data.byRole[role] ?? {})
+        .filter(([, tokens]) => tokens > 0)
+        .sort(
+          ([aModel, aTokens], [bModel, bTokens]) =>
+            bTokens - aTokens || (aModel < bModel ? -1 : aModel > bModel ? 1 : 0),
+        );
+      const tokens = models.reduce((sum, [, modelTokens]) => sum + modelTokens, 0);
+      if (tokens === 0) return [];
+      return [
+        {
+          id: role,
+          label: roleLabel(role),
+          tokens,
+          providerPct: data.totalTokens > 0 ? (tokens / data.totalTokens) * 100 : 0,
+          models: models.map(([id, modelTokens]) => ({
+            id,
+            label: modelDisplayName(id),
+            tokens: modelTokens,
+            rolePct: (modelTokens / tokens) * 100,
+          })),
+        },
+      ];
+    });
+  }
+
   const providers = $derived([
     { id: "claude", label: m.agent_provider_claude(), data: models.claude },
     { id: "codex", label: m.agent_provider_codex(), data: models.codex },
@@ -68,10 +129,18 @@
 <div class="models-lens">
   {#each providers as provider (provider.id)}
     {@const rows = rowsFor(provider.data)}
+    {@const roleRows = roleRowsFor(provider.data)}
     <section class="provider-block" data-provider={provider.id}>
       <header class="provider-head">
         <h2>{provider.label}</h2>
-        <span>{m.usage_models_total({ tokens: formatTokenLabel(provider.data.totalTokens) })}</span>
+        <div class="provider-meta">
+          <span
+            >{m.usage_models_total({ tokens: formatTokenLabel(provider.data.totalTokens) })}</span
+          >
+          {#if provider.id === "codex"}
+            <span class="role-unavailable">{m.usage_models_codex_roles_unavailable()}</span>
+          {/if}
+        </div>
       </header>
 
       {#if rows.length > 0}
@@ -84,10 +153,7 @@
           })}
         >
           {#each rows as row (row.id)}
-            <span
-              aria-hidden="true"
-              style:width={`${row.exactPct}%`}
-              style:background={row.tone}
+            <span aria-hidden="true" style:width={`${row.exactPct}%`} style:background={row.tone}
             ></span>
           {/each}
         </div>
@@ -104,6 +170,32 @@
         </ul>
       {:else}
         <p class="empty">{m.usage_models_empty()}</p>
+      {/if}
+
+      {#if provider.id === "claude" && roleRows.length > 0}
+        <div class="role-breakdown">
+          <h3>{m.usage_models_by_role()}</h3>
+          {#each roleRows as role (role.id)}
+            <details class="role-detail" data-role={role.id}>
+              <summary>
+                <span class="role-summary-content">
+                  <span class="role-name">{role.label}</span>
+                  <span class="role-pct">{role.providerPct.toFixed(1)}%</span>
+                  <span class="role-tokens">{formatTokenLabel(role.tokens)}</span>
+                </span>
+              </summary>
+              <ul class="role-model-list">
+                {#each role.models as model (model.id)}
+                  <li class="role-model-row">
+                    <span class="role-model-name">{model.label}</span>
+                    <span class="role-model-pct">{model.rolePct.toFixed(1)}%</span>
+                    <span class="role-model-tokens">{formatTokenLabel(model.tokens)}</span>
+                  </li>
+                {/each}
+              </ul>
+            </details>
+          {/each}
+        </div>
       {/if}
     </section>
   {/each}
@@ -140,10 +232,27 @@
     text-transform: uppercase;
   }
 
-  .provider-head span {
+  .provider-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 4px;
+  }
+
+  .provider-meta > span:first-child {
     color: var(--color-muted);
     font-size: var(--fs-meta);
     font-variant-numeric: tabular-nums;
+  }
+
+  .role-unavailable {
+    padding: 1px 6px;
+    color: var(--color-muted);
+    font-size: var(--fs-micro);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    border: 1px solid var(--color-line);
+    border-radius: 2px;
   }
 
   .stacked-bar {
@@ -215,9 +324,92 @@
     font-size: var(--fs-base);
   }
 
+  .role-breakdown {
+    margin-top: 18px;
+    border-top: 1px solid var(--color-line);
+  }
+
+  .role-breakdown h3 {
+    margin: 12px 0 6px;
+    color: var(--color-muted);
+    font-size: var(--fs-meta);
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .role-detail {
+    border-bottom: 1px solid var(--color-line);
+  }
+
+  .role-detail summary {
+    padding: 7px 0;
+    color: var(--color-ink);
+    font-size: var(--fs-base);
+    cursor: pointer;
+  }
+
+  .role-detail summary::marker {
+    color: var(--color-muted);
+  }
+
+  .role-summary-content,
+  .role-model-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 4.5rem 7rem;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .role-name,
+  .role-model-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .role-pct,
+  .role-tokens,
+  .role-model-pct,
+  .role-model-tokens {
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+  }
+
+  .role-pct,
+  .role-model-pct {
+    color: var(--color-ink-bright);
+  }
+
+  .role-tokens,
+  .role-model-tokens,
+  .role-model-name {
+    color: var(--color-muted);
+  }
+
+  .role-model-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 0 0 8px 18px;
+    margin: 0;
+    list-style: none;
+  }
+
+  .role-model-row {
+    min-height: 24px;
+    font-size: var(--fs-meta);
+  }
+
   @media (max-width: 520px) {
     .model-list li {
       grid-template-columns: 10px minmax(0, 1fr) 3.75rem 5.75rem;
+      gap: 6px;
+    }
+
+    .role-summary-content,
+    .role-model-row {
+      grid-template-columns: minmax(0, 1fr) 3.75rem 5.75rem;
       gap: 6px;
     }
   }

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-usage-role-model-breakdown.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-usage-role-model-breakdown.ts
@@ -1,0 +1,8 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+export default {
+  id: "usage-role-model-breakdown",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_usage_role_model_breakdown_title",
+  bodyKey: "feat_usage_role_model_breakdown_body",
+} satisfies FeatureAnnouncement;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1275,9 +1275,13 @@ export interface UsageKindUnits {
   count: number; // number of completed passes of that kind, in range
 }
 
+export type UsageRole = "coding" | "review" | "plan_gate" | "recap" | "rundown" | "doc_agent";
+export type UsageByRole = Partial<Record<UsageRole, Record<string, number>>>;
+
 export interface UsageModelBreakdown {
   totalTokens: number;
   byModel: Record<string, number>;
+  byRole: UsageByRole;
 }
 
 /** Top-level breakdown — serves the Spend + Overhead lenses. */

--- a/ui/src/lib/usage-mock.ts
+++ b/ui/src/lib/usage-mock.ts
@@ -34,53 +34,69 @@ function task(t: Omit<UsageTaskBreakdown, "dollars">): UsageTaskBreakdown {
   return { ...t, dollars: t.authoringUnits + t.satelliteUnits };
 }
 
-function modelBreakdown(byModel: Record<string, number>): UsageModelBreakdown {
+function modelBreakdown(
+  byModel: Record<string, number>,
+  includeCodingRole = false,
+): UsageModelBreakdown {
   return {
     totalTokens: Object.values(byModel).reduce((sum, tokens) => sum + tokens, 0),
     byModel,
+    byRole: includeCodingRole ? { coding: byModel } : {},
   };
 }
 
 function modelsFor(range: UsageRange): UsageBreakdown["models"] {
   if (range === "24h") {
     return {
-      claude: modelBreakdown({
-        "claude-opus-4-8": 2_400_000,
-        "claude-sonnet-4-5": 1_150_000,
-        fable: 420_000,
-      }),
+      claude: modelBreakdown(
+        {
+          "claude-opus-4-8": 2_400_000,
+          "claude-sonnet-4-5": 1_150_000,
+          fable: 420_000,
+        },
+        true,
+      ),
       codex: modelBreakdown({ "gpt-5.5": 1_800_000, "gpt-5.4": 350_000 }),
     };
   }
   if (range === "7d") {
     return {
-      claude: modelBreakdown({
-        "claude-opus-4-8": 12_800_000,
-        "claude-sonnet-4-5": 7_300_000,
-        "claude-haiku-4-5": 1_950_000,
-        fable: 1_100_000,
-      }),
+      claude: modelBreakdown(
+        {
+          "claude-opus-4-8": 12_800_000,
+          "claude-sonnet-4-5": 7_300_000,
+          "claude-haiku-4-5": 1_950_000,
+          fable: 1_100_000,
+        },
+        true,
+      ),
       codex: modelBreakdown({ "gpt-5.5": 8_900_000, "gpt-5.4": 2_600_000, unknown: 240_000 }),
     };
   }
   if (range === "30d") {
     return {
-      claude: modelBreakdown({
-        "claude-opus-4-8": 48_600_000,
-        "claude-sonnet-4-5": 29_400_000,
-        "claude-haiku-4-5": 8_700_000,
-        fable: 4_200_000,
-      }),
+      claude: modelBreakdown(
+        {
+          "claude-opus-4-8": 48_600_000,
+          "claude-sonnet-4-5": 29_400_000,
+          "claude-haiku-4-5": 8_700_000,
+          fable: 4_200_000,
+        },
+        true,
+      ),
       codex: modelBreakdown({ "gpt-5.5": 31_500_000, "gpt-5.4": 12_400_000, unknown: 860_000 }),
     };
   }
   return {
-    claude: modelBreakdown({
-      "claude-opus-4-8": 76_200_000,
-      "claude-sonnet-4-5": 45_800_000,
-      "claude-haiku-4-5": 13_100_000,
-      fable: 6_700_000,
-    }),
+    claude: modelBreakdown(
+      {
+        "claude-opus-4-8": 76_200_000,
+        "claude-sonnet-4-5": 45_800_000,
+        "claude-haiku-4-5": 13_100_000,
+        fable: 6_700_000,
+      },
+      true,
+    ),
     codex: modelBreakdown({ "gpt-5.5": 49_600_000, "gpt-5.4": 18_900_000, unknown: 1_200_000 }),
   };
 }

--- a/ui/src/routes/design-system/+page.svelte
+++ b/ui/src/routes/design-system/+page.svelte
@@ -593,8 +593,8 @@ input, select, textarea {
   <section class="panel">
     <h2>Color · categorical data</h2>
     <p class="when">
-      Use these ordered tones for categorical charts whose series are also identified by text.
-      They encode identity, never status. Green is intentionally absent so READY stays exclusive.
+      Use these ordered tones for categorical charts whose series are also identified by text. They
+      encode identity, never status. Green is intentionally absent so READY stays exclusive.
     </p>
     <div class="swatches">
       {#each dataColors as t (t.name)}


### PR DESCRIPTION
# Goal

Make expensive Claude role assignments visible in Usage → Models by showing which model consumed raw tokens for Coding, Review, Plan gate, Recap, Rundown, and Doc agent.

# Solution

Add a role-by-model breakdown to the Claude usage response and render it as expandable role rows in the Models lens. Keep the Codex provider explicit with a neutral “not broken down by role” badge until its follow-up adds equivalent tracking.

## Technical details

- derive Coding from the range-filtered raw model totals
- aggregate finalized Claude reviewer spawns by kind and model using raw input, output, cache-read, and cache-write tokens
- include null-provider legacy rows only for canonical Claude aliases or anchored full Claude model IDs
- fold Claude `byModel` and `totalTokens` from `byRole`, guaranteeing identical role and provider totals
- add EN/DE chrome plus a v1.44.0 feature announcement
- repair the inherited timeline fixture type mismatch and small Epic formatting drift required by the integration pre-push gate

## Verification

- root: 6940 passed, 7 skipped, 0 failed in the final pre-push run
- UI: check, i18n parity, tests, and production build passed
- extension: check, i18n parity, 86 tests, and build passed
- branch hygiene, feature catalog, announcement version, glossary, TypeScript, ESLint, Prettier, and Fallow gates passed

Closes #1726
