### PR TITLE
feat(cardmenu): offer Merge PR in the session-list right-click menu

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2355,6 +2355,8 @@
   "feat_newtask_wider_body": "Das Fenster „Neue Aufgabe“ ist jetzt breiter und gibt dem Prompt und der Liste „Übernehmen aus“ mehr Platz. Issue-Zeilen zeigen mehr vom Titel und bis zu zwei Labels auf einen Blick statt einem.",
   "feat_revive_stranded_title": "Von einem herdr-Neustart gestrandete Sessions wiederbeleben",
   "feat_revive_stranded_body": "Wenn der herdr-Daemon neu startet (Reboot, Absturz oder fehlgeschlagenes Update), stellt er deine Panes als leere Shells wieder her — die Agenten darin sind weg. Shepherd erkennt diese gestrandeten Sessions jetzt, markiert jede Karte mit einer Aktion „Agent beendet — wiederbeleben“ und zeigt ein Banner, um alle auf einmal wiederzubeleben. Aktiviere Auto-Wiederbeleben in den Einstellungen, damit Shepherd Standard-Konto-Agenten automatisch zurückholt.",
+  "feat_merge_pr_context_menu_title": "Einen PR direkt aus der Session-Liste mergen",
+  "feat_merge_pr_context_menu_body": "Wenn der Pull Request einer Session merge-bereit ist, hat ihr Rechtsklick-Menü (oder Long-Press auf Touch) jetzt ganz oben eine Aktion „PR mergen“ — die Session muss nicht erst geöffnet werden. Einmal klicken zum Scharfschalten, erneut zum Bestätigen, und Shepherd merged ihn für dich.",
   "feat_terminal_font_size_title": "Textgröße des Terminals anpassen",
   "feat_terminal_font_size_body": "Das Schraubenschlüssel-Menü des Terminals hat jetzt einen experimentellen Regler für die Textgröße. Vergrößere oder verkleinere die Agent-Ausgabe – praktisch, wenn sie zu klein wird, besonders auf dem Handy. Deine Wahl wird auf diesem Gerät über Sitzungen hinweg gespeichert.",
   "feat_epic_stall_legibility_title": "Sehen, worauf ein Epic wartet",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2355,6 +2355,8 @@
   "feat_newtask_wider_body": "The New Task pane is now wider, giving the prompt and the Seed From issues list more room. Issue rows show more of the title, and up to two labels at a glance instead of one.",
   "feat_revive_stranded_title": "Revive sessions stranded by a herdr restart",
   "feat_revive_stranded_body": "When the herdr daemon restarts (a reboot, crash, or failed update), it restores your panes as bare shells — the agents inside are gone. Shepherd now spots these stranded sessions, flags each card with an \"agent died — revive\" action, and shows one banner to revive them all at once. Turn on auto-revive in Settings to have Shepherd bring default-account agents back automatically.",
+  "feat_merge_pr_context_menu_title": "Merge a PR straight from the session list",
+  "feat_merge_pr_context_menu_body": "When a session's pull request is ready to merge, its right-click (or long-press on touch) menu now has a Merge PR action right at the top — no need to open the session first. Click once to arm, again to confirm, and Shepherd merges it for you.",
   "feat_terminal_font_size_title": "Adjust the terminal text size",
   "feat_terminal_font_size_body": "The terminal wrench menu now has an experimental Text size stepper. Bump the agent output up or down — handy when it gets squinty, especially on mobile. Your choice is remembered across sessions on this device.",
   "feat_epic_stall_legibility_title": "See why an epic is waiting",

--- a/ui/src/lib/components/CardMenu.browser.test.ts
+++ b/ui/src/lib/components/CardMenu.browser.test.ts
@@ -83,3 +83,57 @@ describe("CardMenu relaunch action", () => {
     }
   });
 });
+
+describe("CardMenu merge action", () => {
+  it("renders the Merge PR item only when onmergepr is provided", async () => {
+    const { rerender } = await render(CardMenu, { props: base() });
+    // no onmergepr → no Merge PR item
+    expect(page.getByRole("menuitem", { name: m.prbadge_merge() }).query()).toBeNull();
+
+    await rerender(base({ onmergepr: vi.fn() }));
+    await expect
+      .element(page.getByRole("menuitem", { name: m.prbadge_merge() }))
+      .toBeInTheDocument();
+  });
+
+  it("a single click arms (does NOT fire onmergepr) and a second click fires it once", async () => {
+    const onmergepr = vi.fn();
+    render(CardMenu, { props: base({ onmergepr }) });
+
+    const item = page.getByRole("menuitem", { name: m.prbadge_merge() });
+    await item.click();
+
+    // armed: label switched to the confirm text, callback NOT yet fired
+    expect(onmergepr).not.toHaveBeenCalled();
+    const confirm = page.getByRole("menuitem", { name: m.prbadge_confirm_merge() });
+    await expect.element(confirm).toBeInTheDocument();
+    // merge arms amber (positive), a distinct class from relaunch's red danger wash
+    await expect.element(confirm).toHaveClass(/\bmerge-armed\b/);
+
+    // second click within the window fires it exactly once
+    await confirm.click();
+    expect(onmergepr).toHaveBeenCalledTimes(1);
+  });
+
+  it("auto-disarms after the arm window without firing onmergepr", async () => {
+    vi.useFakeTimers();
+    try {
+      const onmergepr = vi.fn();
+      render(CardMenu, { props: base({ onmergepr }) });
+
+      await page.getByRole("menuitem", { name: m.prbadge_merge() }).click();
+      await expect
+        .element(page.getByRole("menuitem", { name: m.prbadge_confirm_merge() }))
+        .toBeInTheDocument();
+
+      // past the ~3s arm window → disarms back to the idle label (and drops the wash), no fire
+      vi.advanceTimersByTime(3500);
+      const idle = page.getByRole("menuitem", { name: m.prbadge_merge() });
+      await expect.element(idle).toBeInTheDocument();
+      await expect.element(idle).not.toHaveClass(/\bmerge-armed\b/);
+      expect(onmergepr).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/ui/src/lib/components/CardMenu.svelte
+++ b/ui/src/lib/components/CardMenu.svelte
@@ -11,6 +11,7 @@
     y,
     resumable,
     opener,
+    onmergepr,
     onresume,
     onrename,
     onrelaunch,
@@ -27,6 +28,10 @@
     resumable: boolean;
     // the element that opened the menu (the card hit-target) — focus returns here on close
     opener?: HTMLElement;
+    // when provided, a two-step armed "Merge PR" item appears at the top (the session's PR is
+    // eligible to merge). Positive but consequential, so it arms amber (not the red danger wash) —
+    // the parent's handler closes over the session id + runs the merge, like the badge menu.
+    onmergepr?: () => void;
     onresume?: () => void;
     onrename?: () => void;
     // when provided, a two-step armed Relaunch item appears between Resume and
@@ -63,6 +68,25 @@
     relaunchTimer = setTimeout(() => (relaunchArmed = false), RELAUNCH_ARM_MS);
   }
   $effect(() => () => clearTimeout(relaunchTimer));
+
+  // Two-step arm → confirm for Merge PR (GitRail/PrBadge parity): merging is consequential, so the
+  // first click arms (label swaps to the confirm text) and only a second click within the window
+  // fires it. Same 3s window + unmount cleanup as Relaunch, but armed amber (positive, not danger).
+  const MERGE_ARM_MS = 3000;
+  let mergeArmed = $state(false);
+  let mergeTimer: ReturnType<typeof setTimeout> | undefined;
+  function onMergeClick() {
+    if (mergeArmed) {
+      clearTimeout(mergeTimer);
+      mergeArmed = false;
+      onmergepr?.();
+      return;
+    }
+    mergeArmed = true;
+    clearTimeout(mergeTimer);
+    mergeTimer = setTimeout(() => (mergeArmed = false), MERGE_ARM_MS);
+  }
+  $effect(() => () => clearTimeout(mergeTimer));
 
   let el = $state<HTMLDivElement>();
 
@@ -144,6 +168,20 @@
   style="left:{pos?.left ?? x}px;top:{pos?.top ?? y}px"
   onkeydown={onNav}
 >
+  {#if onmergepr}
+    <button
+      class="cm-item"
+      class:merge-armed={mergeArmed}
+      type="button"
+      role="menuitem"
+      tabindex="-1"
+      onclick={onMergeClick}
+    >
+      <span class="cm-icon" aria-hidden="true">⇥</span>{mergeArmed
+        ? m.prbadge_confirm_merge()
+        : m.prbadge_merge()}
+    </button>
+  {/if}
   {#if resumable && onresume}
     <button class="cm-item" type="button" role="menuitem" tabindex="-1" onclick={onresume}>
       <span class="cm-icon" aria-hidden="true">↻</span>{m.cardmenu_resume()}
@@ -263,6 +301,17 @@
   .cm-item.armed:hover,
   .cm-item.armed:focus-visible {
     background: color-mix(in srgb, var(--color-red) 22%, var(--color-panel));
+  }
+  /* Armed merge: positive-but-consequential, so it arms amber (like .gbtn.armed / PrBadgeMenu's
+     merge), not the red danger wash relaunch uses. The wash marks it hot so the second click reads
+     as "click again to confirm". */
+  .cm-item.merge-armed {
+    color: var(--color-amber);
+    background: color-mix(in srgb, var(--color-amber) 14%, var(--color-panel));
+  }
+  .cm-item.merge-armed:hover,
+  .cm-item.merge-armed:focus-visible {
+    background: color-mix(in srgb, var(--color-amber) 22%, var(--color-panel));
   }
   .cm-icon {
     font-size: var(--fs-meta);

--- a/ui/src/lib/components/UnitRow.browser.test.ts
+++ b/ui/src/lib/components/UnitRow.browser.test.ts
@@ -23,11 +23,12 @@ vi.mock("$lib/api", async (importOriginal) => {
     retryCi: vi.fn(
       async () => ({ ok: true }) as { ok: boolean; reason?: "unsupported" | "no-run" },
     ),
+    mergePr: vi.fn(async () => ({ state: "merged" }) as never),
   };
 });
 
 const { reviews, planGates, repoConfig } = await import("$lib/reviews.svelte");
-const { releasePlanGate, reviewPlan, resumeQuota, retryCi } = await import("$lib/api");
+const { releasePlanGate, reviewPlan, resumeQuota, retryCi, mergePr } = await import("$lib/api");
 const { toasts } = await import("$lib/toasts.svelte");
 
 function session(partial: Partial<Session> & { id: string }): Session {
@@ -131,6 +132,9 @@ beforeEach(() => {
   vi.mocked(reviewPlan).mockReset().mockResolvedValue("started");
   vi.mocked(resumeQuota).mockReset().mockResolvedValue({ status: "resumed" });
   vi.mocked(retryCi).mockReset().mockResolvedValue({ ok: true });
+  vi.mocked(mergePr)
+    .mockReset()
+    .mockResolvedValue({ state: "merged" } as never);
 });
 
 function loadPreviewMode(repoPath: string, mode: "ask" | "inline" | "tab" = "ask") {
@@ -468,6 +472,44 @@ describe("UnitRow context menu", () => {
     openMenu("merged row");
 
     await expect.element(page.getByText(m.cardmenu_replace_with())).not.toBeInTheDocument();
+  });
+
+  it("offers Merge PR for a merge-eligible row; two-tap arm then merges via the session id", async () => {
+    render(UnitRow, {
+      session: session({ id: "merge-row", name: "merge row" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+      git: openGreenGit(),
+    });
+
+    openMenu("merge row");
+
+    // first click arms (no merge yet), second confirms
+    await page.getByRole("menuitem", { name: m.prbadge_merge() }).click();
+    expect(mergePr).not.toHaveBeenCalled();
+    await page.getByRole("menuitem", { name: m.prbadge_confirm_merge() }).click();
+
+    expect(mergePr).toHaveBeenCalledWith("merge-row");
+    // The toast container isn't mounted in an isolated row render — assert on the store.
+    await vi.waitFor(() =>
+      expect(toasts.items.some((t) => t.text === m.prbadge_merged_toast({ number: 7 }))).toBe(true),
+    );
+  });
+
+  it("does not offer Merge PR when the PR is not eligible (draft)", async () => {
+    render(UnitRow, {
+      session: session({ id: "draft-row", name: "draft row" }),
+      selected: false,
+      nowMs: Date.now(),
+      onselect: () => {},
+      git: openGreenGit({ isDraft: true }),
+      onrename: vi.fn(),
+    });
+
+    openMenu("draft row");
+
+    await expect.element(page.getByText(m.prbadge_merge())).not.toBeInTheDocument();
   });
 });
 

--- a/ui/src/lib/components/UnitRow.svelte
+++ b/ui/src/lib/components/UnitRow.svelte
@@ -25,7 +25,9 @@
     isPlanReviewError,
     resumeQuota,
     retryCi,
+    mergePr,
   } from "$lib/api";
+  import { prMergeAvailable } from "./pr-badge";
   import CardMenu from "./CardMenu.svelte";
   import TaskIdButton from "./TaskIdButton.svelte";
   import { longPress } from "./longpress";
@@ -579,13 +581,19 @@
   const comparisonRow = $derived(session.experimentRole === "comparison");
   const variantable = $derived(!!onvariant && !comparisonRow && canRelaunch(session, git, nowMs));
   const replaceable = $derived(!!onreplace && !comparisonRow && canRelaunch(session, git, nowMs));
+  // Merge PR: offered when the session's PR is eligible to merge — the SAME predicate PrBadge uses
+  // (open, non-draft, mergeable, checks not failing), so the in-list menu and the badge never
+  // disagree. The merge endpoint is session-scoped, so no parent callback is needed; the server
+  // re-validates on merge (a stale-eligibility merge fails harmlessly → toast).
+  const mergeable = $derived(prMergeAvailable(git));
   let hitEl = $state<HTMLButtonElement>();
   let elapsedEl = $state<HTMLSpanElement>();
   let menu = $state<{ x: number; y: number; opener: HTMLElement } | null>(null);
   // Returns whether a menu actually opened (so the long-press can decide whether to
   // swallow the trailing tap). No-ops when nothing to offer or one is already open.
   const hasMenu = $derived(
-    resumable ||
+    mergeable ||
+      resumable ||
       !!ondecommission ||
       !!onrename ||
       relaunchable ||
@@ -623,6 +631,24 @@
       toasts.info(m.cardmenu_resume_failed({ name: session.name }));
     } finally {
       ctaBusy = false;
+    }
+  }
+  // Confirmed (second-tap) merge from the card menu — mirrors PrBadge.doMerge's API + toast
+  // contract, incl. the shared `pr-merge:${id}` key so a badge merge and a menu merge of the same
+  // session dedupe into one toast. The two-tap arm lives in CardMenu, so this only runs on confirm.
+  async function mergeFromMenu() {
+    menu = null;
+    const number = git?.number ?? 0;
+    try {
+      await mergePr(session.id);
+      toasts.info(m.prbadge_merged_toast({ number }), { key: `pr-merge:${session.id}` });
+    } catch (err) {
+      toasts.info(
+        m.prbadge_merge_failed({
+          reason: err instanceof Error ? err.message : m.prbadge_unknown_error(),
+        }),
+        { alert: true, key: `pr-merge:${session.id}` },
+      );
     }
   }
   function decommissionFromMenu() {
@@ -934,6 +960,7 @@
     y={menu.y}
     {resumable}
     opener={menu.opener}
+    onmergepr={mergeable ? mergeFromMenu : undefined}
     onresume={resumeFromMenu}
     onrename={onrename ? renameFromMenu : undefined}
     onrelaunch={relaunchable ? relaunchFromMenu : undefined}

--- a/ui/src/lib/feature-announcements/entries/v1.44.0-merge-pr-context-menu.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.44.0-merge-pr-context-menu.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "merge-pr-context-menu",
+  sinceVersion: "1.44.0",
+  titleKey: "feat_merge_pr_context_menu_title",
+  bodyKey: "feat_merge_pr_context_menu_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;


### PR DESCRIPTION
## What

Adds a **Merge PR** item to the session-list context menu (`CardMenu` — right-click on desktop, long-press on touch), shown only when the session's PR is eligible to merge. Lets you merge without opening the session first.

## How

- **`CardMenu.svelte`** — new `onmergepr` prop + a two-tap arm (mirroring the existing Relaunch arm), rendered as the top item. Merge is positive-but-consequential, so it arms **amber** (`--color-amber`, like `PrBadgeMenu`), not the red danger wash Relaunch uses.
- **`UnitRow.svelte`** — `mergeable = prMergeAvailable(git)` — the **same predicate `PrBadge` uses** (open, non-draft, mergeable, checks not failing), so the badge and the menu never disagree about whether merge is offered. Added to the `hasMenu` gate (menu still opens when merge is the only eligible action); `mergeFromMenu()` calls the session-scoped `mergePr(session.id)` and toasts success/failure, mirroring `PrBadge.doMerge` incl. the shared `pr-merge:${id}` toast key so badge + menu merges dedupe.
- **No new label/toast keys** — reuses `prbadge_merge` / `prbadge_confirm_merge` and the `prbadge_*` toast keys (already in both catalogs). Only the feature-announcement `titleKey`/`bodyKey` are new (EN + DE).
- Feature-announcement entry added (`v1.44.0-merge-pr-context-menu`).

Decisions (confirmed with operator during planning): two-tap arm · server-default merge method (no submenu) · eligibility = PR-mergeability only (not the manual `readyToMerge` flag), aligned exactly with `PrBadge`.

## Verification

- `cd ui && bun run check` (0 errors), `bun run check:i18n` (parity), root `bun run lint` — all clean.
- `bun run test` — 3878 pass (+5 new). New browser tests drive the real flow end-to-end: eligibility gating (eligible shows / draft hides), two-tap arm, `mergePr` call with the session id, and the success toast.
- Pre-push gates (branch-hygiene, i18n, feature-catalog, announcement-version) passed.

Merging in the full app requires a live server with a real merge-eligible GitHub PR, so the component browser tests are the behavioral verification here.