### PR TITLE
feat(herd): make lifecycle groups collapsible on the desktop rail

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3234,5 +3234,7 @@
   "recap_failure_detail": "Fehler",
   "recap_failure_default_model": "Anbieter-Standard",
   "feat_recap_diagnostics_title": "Fehlende Recaps verstehen",
-  "feat_recap_diagnostics_body": "Abgeschlossene Sessions zeigen jetzt, wie sie beendet wurden und warum ein Recap fehlt. Sessions ohne Änderungen erhalten weiterhin ein Recap mit einem klaren No-Diff-Hinweis; technische Fehler enthalten eine Handlungsempfehlung und redigierte Details."
+  "feat_recap_diagnostics_body": "Abgeschlossene Sessions zeigen jetzt, wie sie beendet wurden und warum ein Recap fehlt. Sessions ohne Änderungen erhalten weiterhin ein Recap mit einem klaren No-Diff-Hinweis; technische Fehler enthalten eine Handlungsempfehlung und redigierte Details.",
+  "feat_desktop_herd_group_collapse_title": "Lebenszyklus-Gruppen auch am Desktop einklappen",
+  "feat_desktop_herd_group_collapse_body": "Die Gruppen-Header der Desktop-Session-Leiste (CI läuft, Dein Zug, Gemergt, …) sind jetzt ebenfalls klappbar: Ein Klick auf einen Header klappt die Gruppe zu — jede Gruppe unabhängig, und Sprünge zu einer Session in einer eingeklappten Gruppe öffnen sie automatisch wieder."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3234,5 +3234,7 @@
   "recap_failure_detail": "Failure",
   "recap_failure_default_model": "provider default",
   "feat_recap_diagnostics_title": "Understand missing recaps",
-  "feat_recap_diagnostics_body": "Finished sessions now show how they were completed and why a recap is missing. No-change sessions still get a recap with a clear no-diff warning; technical failures include actionable guidance and redacted details."
+  "feat_recap_diagnostics_body": "Finished sessions now show how they were completed and why a recap is missing. No-change sessions still get a recap with a clear no-diff warning; technical failures include actionable guidance and redacted details.",
+  "feat_desktop_herd_group_collapse_title": "Fold lifecycle groups on the desktop",
+  "feat_desktop_herd_group_collapse_body": "The desktop session rail's lifecycle group headers (CI running, Your turn, Merged, …) are now collapsible too: click a header to fold that group away — each group toggles independently, and jumps to a session hidden in a folded group reopen it automatically."
 }

--- a/ui/src/lib/components/Herd.browser.test.ts
+++ b/ui/src/lib/components/Herd.browser.test.ts
@@ -4,6 +4,7 @@ import { page } from "vitest/browser";
 import "../../app.css";
 import Herd from "./Herd.svelte";
 import { railOrder } from "./herd-keynav";
+import { GROUP_KEY_BY_STAGE } from "./herd-partition";
 import { isReworkRunning } from "./rework-running";
 import { reviews, planGates } from "$lib/reviews.svelte";
 import { postMergeSteps } from "$lib/post-merge-steps.svelte";
@@ -247,40 +248,168 @@ describe("Herd mobile lifecycle accordion", () => {
     await expect.element(reviewing).toHaveAttribute("aria-expanded", "false");
     await expect.element(page.getByText("review session")).not.toBeInTheDocument();
   });
+});
 
-  it("keeps a group action separate from the disclosure toggle", async () => {
-    const onmergetrain = vi.fn();
-    render(Herd, {
-      ...base,
-      sessions: [session({ id: "ready", name: "ready session", readyToMerge: true })],
-      git: { ready: openPr },
-      flow: true,
-      onmergetrain,
+describe("Herd group header actions stay separate from the disclosure toggle", () => {
+  const mergedGit: GitState = {
+    kind: "github",
+    state: "merged",
+    checks: "success",
+    deployConfigured: false,
+  };
+
+  // Both header actions × both layouts. The mobile accordion starts groups closed
+  // (default open is "Your turn"); desktop starts every group expanded. Clicking the
+  // action must fire ONLY the action — never flip aria-expanded or hit the stage toggle.
+  it.each([
+    { flow: true, kind: "merge-train", expanded: "false" },
+    { flow: false, kind: "merge-train", expanded: "true" },
+    { flow: true, kind: "clear-merged", expanded: "false" },
+    { flow: false, kind: "clear-merged", expanded: "true" },
+  ])("$kind fires without toggling (flow=$flow)", async ({ flow, kind, expanded }) => {
+    const action = vi.fn();
+    const onstagecollapsetoggle = vi.fn();
+    const props: {
+      sessions: Session[];
+      git: Record<string, GitState>;
+      onmergetrain?: () => void;
+      onclearmerged?: () => void;
+    } =
+      kind === "merge-train"
+        ? {
+            sessions: [session({ id: "ready", name: "ready session", readyToMerge: true })],
+            git: { ready: openPr },
+            onmergetrain: action,
+          }
+        : {
+            sessions: [session({ id: "mgd", name: "merged session" })],
+            git: { mgd: mergedGit },
+            onclearmerged: action,
+          };
+    render(Herd, { ...base, ...props, flow, onstagecollapsetoggle });
+
+    const head = page.getByRole("button", {
+      name: kind === "merge-train" ? /Ready to merge \(1\)/i : /Merged \(1\)/i,
     });
+    const actionLabel = kind === "merge-train" ? "Merge train" : "Decommission all";
+    await expect.element(head).toHaveAttribute("aria-expanded", expanded);
+    await page.getByRole("button", { name: actionLabel }).click();
+    expect(action).toHaveBeenCalledOnce();
+    expect(onstagecollapsetoggle).not.toHaveBeenCalled();
+    await expect.element(head).toHaveAttribute("aria-expanded", expanded);
+  });
+});
 
-    const ready = page.getByRole("button", { name: /Ready to merge \(1\)/i });
-    await expect.element(ready).toHaveAttribute("aria-expanded", "false");
-    await page.getByRole("button", { name: "Merge train" }).click();
-    expect(onmergetrain).toHaveBeenCalledOnce();
-    await expect.element(ready).toHaveAttribute("aria-expanded", "false");
+describe("Herd desktop lifecycle group collapse", () => {
+  afterEach(() => {
+    reviews.setReviewing("desk-review", false);
   });
 
-  it("leaves lifecycle groups expanded and non-interactive on desktop", async () => {
-    reviews.setReviewing("mobile-review", true);
+  it("keeps headers non-interactive when no stage toggle handler is wired", async () => {
+    reviews.setReviewing("desk-review", true);
     render(Herd, {
       ...base,
       sessions: [
-        session({ id: "mobile-review", name: "review session" }),
+        session({ id: "desk-review", name: "review session" }),
         session({ id: "your-turn", name: "your turn session" }),
       ],
       git: { "your-turn": openPr },
     });
 
+    // no onstagecollapsetoggle → plain text headers (never a no-op disclosure button)
     await expect.element(page.getByText("review session")).toBeInTheDocument();
     await expect.element(page.getByText("your turn session")).toBeInTheDocument();
     await expect
       .element(page.getByRole("button", { name: /Your turn \(1\)/i }))
       .not.toBeInTheDocument();
+  });
+
+  it("renders per-group disclosures, all expanded by default", async () => {
+    reviews.setReviewing("desk-review", true);
+    render(Herd, {
+      ...base,
+      sessions: [
+        session({ id: "desk-review", name: "review session" }),
+        session({ id: "your-turn", name: "your turn session" }),
+      ],
+      git: { "your-turn": openPr },
+      onstagecollapsetoggle: () => {},
+    });
+
+    const yourTurn = page.getByRole("button", { name: /Your turn \(1\)/i });
+    const reviewing = page.getByRole("button", { name: /Reviewing \(1\)/i });
+    await expect.element(yourTurn).toHaveAttribute("aria-expanded", "true");
+    await expect.element(reviewing).toHaveAttribute("aria-expanded", "true");
+    await expect.element(page.getByText("review session")).toBeInTheDocument();
+    await expect.element(page.getByText("your turn session")).toBeInTheDocument();
+  });
+
+  it("controlled: collapsedStageKeys hides exactly those rows; the toggle reports the group key", async () => {
+    const onstagecollapsetoggle = vi.fn();
+    reviews.setReviewing("desk-review", true);
+    render(Herd, {
+      ...base,
+      sessions: [
+        session({ id: "desk-review", name: "review session" }),
+        session({ id: "your-turn", name: "your turn session" }),
+      ],
+      git: { "your-turn": openPr },
+      collapsedStageKeys: new Set([GROUP_KEY_BY_STAGE.awaitingMerge]),
+      onstagecollapsetoggle,
+    });
+
+    // independence: the collapsed group hides its rows while the other stays open
+    const yourTurn = page.getByRole("button", { name: /Your turn \(1\)/i });
+    const reviewing = page.getByRole("button", { name: /Reviewing \(1\)/i });
+    await expect.element(yourTurn).toHaveAttribute("aria-expanded", "false");
+    await expect.element(reviewing).toHaveAttribute("aria-expanded", "true");
+    await expect.element(page.getByText("your turn session")).not.toBeInTheDocument();
+    await expect.element(page.getByText("review session")).toBeInTheDocument();
+
+    await yourTurn.click();
+    expect(onstagecollapsetoggle).toHaveBeenCalledExactlyOnceWith(GROUP_KEY_BY_STAGE.awaitingMerge);
+  });
+
+  it("fine-pointer desktop headers stay compact (toggle < 44px)", async () => {
+    render(Herd, {
+      ...base,
+      sessions: [session({ id: "your-turn", name: "your turn session" })],
+      git: { "your-turn": openPr },
+      onstagecollapsetoggle: () => {},
+    });
+
+    const yourTurn = page.getByRole("button", { name: /Your turn \(1\)/i });
+    await expect.element(yourTurn).toBeInTheDocument();
+    expect((yourTurn.element() as HTMLElement).getBoundingClientRect().height).toBeLessThan(44);
+  });
+
+  it("coarse-pointer desktop (touch) keeps ≥44px targets on toggle and header actions", async () => {
+    const mergedGit: GitState = {
+      kind: "github",
+      state: "merged",
+      checks: "success",
+      deployConfigured: false,
+    };
+    render(Herd, {
+      ...base,
+      sessions: [
+        session({ id: "ready", name: "ready session", readyToMerge: true }),
+        session({ id: "mgd", name: "merged session" }),
+      ],
+      git: { ready: openPr, mgd: mergedGit },
+      touch: true,
+      onstagecollapsetoggle: () => {},
+      onmergetrain: () => {},
+      onclearmerged: () => {},
+    });
+
+    for (const name of [/Ready to merge \(1\)/i, "Merge train", "Decommission all"] as const) {
+      const el = page.getByRole("button", { name });
+      await expect.element(el).toBeInTheDocument();
+      expect((el.element() as HTMLElement).getBoundingClientRect().height).toBeGreaterThanOrEqual(
+        44,
+      );
+    }
   });
 });
 

--- a/ui/src/lib/components/Herd.svelte
+++ b/ui/src/lib/components/Herd.svelte
@@ -24,7 +24,12 @@
   import RundownPanel from "./RundownPanel.svelte";
   import PostMergeStepsPanel from "./PostMergeStepsPanel.svelte";
   import UpNextPanel from "./UpNextPanel.svelte";
-  import { partitionSessions, shownSessions, type HerdFilter } from "./herd-partition";
+  import {
+    partitionSessions,
+    shownSessions,
+    GROUP_KEY_BY_STAGE,
+    type HerdFilter,
+  } from "./herd-partition";
   import { groupSessionsByEpic } from "./epic-grouping";
   import { groupSessionsByExperiment } from "./experiment-grouping";
   import { collectReadyPrs } from "./merge-train";
@@ -76,6 +81,9 @@
     holds = {},
     collapsible = false,
     oncollapse = undefined,
+    collapsedStageKeys = new Set(),
+    onstagecollapsetoggle = undefined,
+    touch = false,
     completedEpics = [],
     ondismissepic = undefined,
     onlandepic = undefined,
@@ -181,6 +189,16 @@
     // called when the collapse arrow is clicked; parent drives the actual
     // collapse so the button is purely a signal
     oncollapse?: () => void;
+    // desktop lifecycle-group collapse (page-owned, GROUP_KEY_BY_STAGE keys — shared with
+    // the keyboard-nav rail so render and nav agree). Only read when !flow; the phone
+    // layout keeps its own internal accordion.
+    collapsedStageKeys?: ReadonlySet<string>;
+    // toggles a lifecycle group's desktop collapse; without it the desktop headers stay
+    // plain non-interactive text (no no-op disclosure buttons)
+    onstagecollapsetoggle?: (key: string) => void;
+    // coarse-pointer/touch input (page's `(pointer: coarse)` MediaQuery, same signal as
+    // Viewport's `touch`) — keeps 44px touch targets on touch-wide desktop layouts
+    touch?: boolean;
     // fully-integrated epics for this repo scope — rendered as the bottom
     // "integrated epics" band (self-hides when empty)
     completedEpics?: CompletedEpic[];
@@ -363,8 +381,9 @@
 
   // Phone-only lifecycle accordion. The stable key makes "Your turn" the default
   // without coupling the open state to the groups' live ordering. null closes all
-  // named lifecycle groups; unheaded active rows remain visible.
-  let mobileOpenPartitionKey = $state<string | null>("awaiting-merge");
+  // named lifecycle groups; unheaded active rows remain visible. Desktop uses the
+  // page-owned collapsedStageKeys set instead (independent per-group collapse).
+  let mobileOpenPartitionKey = $state<string | null>(GROUP_KEY_BY_STAGE.awaitingMerge);
   function toggleMobilePartitionGroup(key: string) {
     mobileOpenPartitionKey = mobileOpenPartitionKey === key ? null : key;
   }
@@ -427,48 +446,48 @@
   const partitionGroups = $derived<PartitionGroupEntry[]>(
     [
       partition.active.length > 0 && {
-        key: "active",
+        key: GROUP_KEY_BY_STAGE.active,
         sessions: partition.active,
         headClass: null,
         withPreview: true,
       },
       partition.ciRunning.length > 0 && {
-        key: "ci-running",
+        key: GROUP_KEY_BY_STAGE.ciRunning,
         sessions: partition.ciRunning,
         headClass: "ci-head",
         countLabel: m.herd_ci_running_group({ count: partition.ciRunning.length }),
         withPreview: true,
       },
       partition.ciFailed.length > 0 && {
-        key: "ci-failed",
+        key: GROUP_KEY_BY_STAGE.ciFailed,
         sessions: partition.ciFailed,
         headClass: "ci-failed-head",
         countLabel: m.herd_ci_failed_group({ count: partition.ciFailed.length }),
         withPreview: true,
       },
       partition.reviewerRunning.length > 0 && {
-        key: "reviewer-running",
+        key: GROUP_KEY_BY_STAGE.reviewerRunning,
         sessions: partition.reviewerRunning,
         headClass: "reviewing-head",
         countLabel: m.herd_reviewer_running_group({ count: partition.reviewerRunning.length }),
         withPreview: true,
       },
       partition.reworkRunning.length > 0 && {
-        key: "rework-running",
+        key: GROUP_KEY_BY_STAGE.reworkRunning,
         sessions: partition.reworkRunning,
         headClass: "rework-head",
         countLabel: m.herd_rework_running_group({ count: partition.reworkRunning.length }),
         withPreview: true,
       },
       partition.needsRework.length > 0 && {
-        key: "needs-rework",
+        key: GROUP_KEY_BY_STAGE.needsRework,
         sessions: partition.needsRework,
         headClass: "needs-rework-head",
         countLabel: m.herd_changes_requested_group({ count: partition.needsRework.length }),
         withPreview: true,
       },
       partition.branchProtectionBlocked.length > 0 && {
-        key: "branch-protection-blocked",
+        key: GROUP_KEY_BY_STAGE.branchProtectionBlocked,
         sessions: partition.branchProtectionBlocked,
         headClass: "branch-blocked-head",
         countLabel: m.herd_merge_blocked_group({
@@ -477,7 +496,7 @@
         withPreview: true,
       },
       partition.waitingOnReviewer.length > 0 && {
-        key: "waiting-reviewer",
+        key: GROUP_KEY_BY_STAGE.waitingOnReviewer,
         sessions: partition.waitingOnReviewer,
         headClass: "waiting-head",
         countLabel: reviewerWho
@@ -489,7 +508,7 @@
         withPreview: false,
       },
       partition.waitingOnMerger.length > 0 && {
-        key: "waiting-merger",
+        key: GROUP_KEY_BY_STAGE.waitingOnMerger,
         sessions: partition.waitingOnMerger,
         headClass: "waiting-head",
         countLabel: mergerWho
@@ -498,7 +517,7 @@
         withPreview: false,
       },
       partition.draftAwaitingSignoff.length > 0 && {
-        key: "draft-signoff",
+        key: GROUP_KEY_BY_STAGE.draftAwaitingSignoff,
         sessions: partition.draftAwaitingSignoff,
         headClass: "draft-head",
         countLabel: m.herd_draft_awaiting_signoff_group({
@@ -507,14 +526,14 @@
         withPreview: false,
       },
       partition.awaitingMerge.length > 0 && {
-        key: "awaiting-merge",
+        key: GROUP_KEY_BY_STAGE.awaitingMerge,
         sessions: partition.awaitingMerge,
         headClass: "awaiting-head",
         countLabel: m.herd_awaiting_merge_group({ count: partition.awaitingMerge.length }),
         withPreview: true,
       },
       partition.ready.length + readyAbove > 0 && {
-        key: "ready",
+        key: GROUP_KEY_BY_STAGE.ready,
         sessions: partition.ready,
         headClass: "ready-head",
         countLabel:
@@ -532,14 +551,14 @@
         withPreview: true,
       },
       partition.merging.length > 0 && {
-        key: "merging",
+        key: GROUP_KEY_BY_STAGE.merging,
         sessions: partition.merging,
         headClass: "merging-head",
         countLabel: m.herd_merging_group({ count: partition.merging.length }),
         withPreview: true,
       },
       partition.merged.length + mergedAbove > 0 && {
-        key: "merged",
+        key: GROUP_KEY_BY_STAGE.merged,
         sessions: partition.merged,
         headClass: "merged-head",
         countLabel:
@@ -562,57 +581,58 @@
   );
 
   // Per-stage explainer content for the group-header "i" tooltips (issue: self-explanatory
-  // Herd). Group keys are hyphenated, but Paraglide accessors can't contain hyphens, so this
-  // maps each key to its underscore message keys explicitly (mirroring the `herd_*_group`
-  // label names). A `$derived` so copy re-resolves on locale change; the aria-label reuses
-  // the shared `newtask_info_aria` ("Explain: {topic}"). The headerless `active` group never
-  // renders a tooltip, but is included so the map is the single source for every stage.
+  // Herd). Keyed via GROUP_KEY_BY_STAGE (the same source partitionGroups renders under) so
+  // the record can't drift from the group keys; the message accessors stay explicit because
+  // Paraglide accessors can't contain hyphens (mirroring the `herd_*_group` label names).
+  // A `$derived` so copy re-resolves on locale change; the aria-label reuses the shared
+  // `newtask_info_aria` ("Explain: {topic}"). The headerless `active` group never renders
+  // a tooltip, but is included so the map is the single source for every stage.
   const groupHelp = $derived<Record<string, { text: string; label: string }>>({
-    active: {
+    [GROUP_KEY_BY_STAGE.active]: {
       text: m.herd_help_active(),
       label: m.newtask_info_aria({ topic: m.herd_stage_name_active() }),
     },
-    "ci-running": {
+    [GROUP_KEY_BY_STAGE.ciRunning]: {
       text: m.herd_help_ci_running(),
       label: m.newtask_info_aria({ topic: m.herd_stage_name_ci_running() }),
     },
-    "ci-failed": {
+    [GROUP_KEY_BY_STAGE.ciFailed]: {
       text: m.herd_help_ci_failed(),
       label: m.newtask_info_aria({ topic: m.herd_stage_name_ci_failed() }),
     },
-    "reviewer-running": {
+    [GROUP_KEY_BY_STAGE.reviewerRunning]: {
       text: m.herd_help_reviewing(),
       label: m.newtask_info_aria({ topic: m.herd_stage_name_reviewing() }),
     },
-    "rework-running": {
+    [GROUP_KEY_BY_STAGE.reworkRunning]: {
       text: m.herd_help_rework(),
       label: m.newtask_info_aria({ topic: m.herd_stage_name_rework() }),
     },
-    "waiting-reviewer": {
+    [GROUP_KEY_BY_STAGE.waitingOnReviewer]: {
       text: m.herd_help_waiting_reviewer(),
       label: m.newtask_info_aria({ topic: m.herd_stage_name_waiting_reviewer() }),
     },
-    "waiting-merger": {
+    [GROUP_KEY_BY_STAGE.waitingOnMerger]: {
       text: m.herd_help_waiting_merger(),
       label: m.newtask_info_aria({ topic: m.herd_stage_name_waiting_merger() }),
     },
-    "draft-signoff": {
+    [GROUP_KEY_BY_STAGE.draftAwaitingSignoff]: {
       text: m.herd_help_draft_signoff(),
       label: m.newtask_info_aria({ topic: m.herd_stage_name_draft_signoff() }),
     },
-    "awaiting-merge": {
+    [GROUP_KEY_BY_STAGE.awaitingMerge]: {
       text: m.herd_help_your_turn(),
       label: m.newtask_info_aria({ topic: m.herd_stage_name_your_turn() }),
     },
-    ready: {
+    [GROUP_KEY_BY_STAGE.ready]: {
       text: m.herd_help_ready(),
       label: m.newtask_info_aria({ topic: m.herd_stage_name_ready() }),
     },
-    merging: {
+    [GROUP_KEY_BY_STAGE.merging]: {
       text: m.herd_help_merging(),
       label: m.newtask_info_aria({ topic: m.herd_stage_name_merging() }),
     },
-    merged: {
+    [GROUP_KEY_BY_STAGE.merged]: {
       text: m.herd_help_merged(),
       label: m.newtask_info_aria({ topic: m.herd_stage_name_merged() }),
     },
@@ -695,13 +715,22 @@
       />
       <HerdExperimentGroups groups={experimentGrouped.groups} {oncompare} ctx={rowCtx} />
       {#each partitionGroups as grp (grp.key)}
+        <!-- flow: phone accordion (internal state). Desktop: independent per-group
+             collapse via the page-owned collapsedStageKeys — but only when the page
+             wired onstagecollapsetoggle; without it the header must stay plain text,
+             never a no-op disclosure button. touchTarget keys 44px targets to input
+             modality: the phone layout always, wide layouts only on coarse pointers. -->
         <HerdGroup
           ctx={rowCtx}
           {...grp}
           help={groupHelp[grp.key] ?? null}
-          collapsible={flow && !!grp.headClass && grp.sessions.length > 0}
-          expanded={!flow || mobileOpenPartitionKey === grp.key}
-          ontoggle={() => toggleMobilePartitionGroup(grp.key)}
+          collapsible={!!grp.headClass &&
+            grp.sessions.length > 0 &&
+            (flow || !!onstagecollapsetoggle)}
+          expanded={flow ? mobileOpenPartitionKey === grp.key : !collapsedStageKeys.has(grp.key)}
+          ontoggle={() =>
+            flow ? toggleMobilePartitionGroup(grp.key) : onstagecollapsetoggle?.(grp.key)}
+          touchTarget={flow || touch}
         />
       {/each}
     {/if}

--- a/ui/src/lib/components/herd-jump.test.ts
+++ b/ui/src/lib/components/herd-jump.test.ts
@@ -1,0 +1,226 @@
+import { test, expect } from "vitest";
+import { revealAndSelect, createJumpHandlers, type JumpDeps, type JumpEffects } from "./herd-jump";
+import type { RailLocation } from "./herd-keynav";
+
+/** Real sets + a call log; every spy also records the collapsed-set state it observed,
+ *  so ordering (expand strictly before select, tick in between) is asserted from the
+ *  log instead of trusting implementation details. */
+function harness(locations: Map<string, RailLocation> = new Map()) {
+  const log: string[] = [];
+  const collapsedEpics = new Set<string>();
+  const collapsedStages = new Set<string>();
+  const seen = (id: string) =>
+    `stages=[${[...collapsedStages].join(",")}] epics=[${[...collapsedEpics].join(",")}] id=${id}`;
+  const deps: JumpDeps = {
+    locate: () => {
+      log.push("locate");
+      return locations;
+    },
+    selectedId: () => null,
+    blockedIds: () => [],
+    isDesktop: () => true,
+    collapsedEpics,
+    collapsedStages,
+    expandEpic: (key) => {
+      log.push(`expandEpic:${key}`);
+      collapsedEpics.delete(key);
+    },
+    expandStage: (key) => {
+      log.push(`expandStage:${key}`);
+      collapsedStages.delete(key);
+    },
+    tick: async () => {
+      log.push("tick");
+    },
+    select: (id, focusTerm = true, toDetail = true) => {
+      log.push(`select:${focusTerm}:${toDetail} ${seen(id)}`);
+    },
+    keyNavSelect: (id, focusTerm) => {
+      log.push(`keyNav:${focusTerm} ${seen(id)}`);
+    },
+  };
+  const effects: JumpEffects = {
+    resetLensAndFilters: () => log.push("reset"),
+    followRepo: (id) => log.push(`follow:${id}`),
+    leaveRundown: () => log.push("leaveRundown"),
+    beforeHerdrUpdateJump: () => log.push("closeUpdateModal"),
+  };
+  return { deps, effects, log, collapsedEpics, collapsedStages, locations };
+}
+
+const stage = (key: string): RailLocation => ({ kind: "stage", key });
+const epic = (key: string): RailLocation => ({ kind: "epic", key });
+
+// revealAndSelect — core ordering
+
+test("collapsed desktop stage: expand strictly before select, tick in between", async () => {
+  const h = harness(new Map([["x", stage("merged")]]));
+  h.collapsedStages.add("merged");
+  await revealAndSelect("x", h.deps, (id) => h.deps.select(id));
+  // the select spy observed the stage already removed from the set
+  expect(h.log).toEqual([
+    "locate",
+    "expandStage:merged",
+    "tick",
+    "select:true:true stages=[] epics=[] id=x",
+  ]);
+});
+
+test("collapsed epic group: only the epic set mutates", async () => {
+  const h = harness(new Map([["x", epic("/r#100")]]));
+  h.collapsedEpics.add("/r#100");
+  h.collapsedStages.add("merged"); // unrelated stage stays collapsed
+  await revealAndSelect("x", h.deps, (id) => h.deps.select(id));
+  expect(h.log).toEqual([
+    "locate",
+    "expandEpic:/r#100",
+    "tick",
+    "select:true:true stages=[merged] epics=[] id=x",
+  ]);
+});
+
+test("experiment member: no set mutates, select fires without a tick", async () => {
+  const h = harness(new Map([["x", { kind: "experiment" }]]));
+  h.collapsedStages.add("merged");
+  await revealAndSelect("x", h.deps, (id) => h.deps.select(id));
+  expect(h.log).toEqual(["locate", "select:true:true stages=[merged] epics=[] id=x"]);
+});
+
+test("target in an open group (or without a location): no mutation, no tick", async () => {
+  const h = harness(new Map([["x", stage("ready")]]));
+  await revealAndSelect("x", h.deps, (id) => h.deps.select(id));
+  await revealAndSelect("unknown", h.deps, (id) => h.deps.select(id));
+  expect(h.log).toEqual([
+    "locate",
+    "select:true:true stages=[] epics=[] id=x",
+    "locate",
+    "select:true:true stages=[] epics=[] id=unknown",
+  ]);
+});
+
+test("mobile gating: a mobile jump never mutates collapsedStages (epic expansion still runs)", async () => {
+  const h = harness(
+    new Map<string, RailLocation>([
+      ["s", stage("merged")],
+      ["e", epic("/r#100")],
+    ]),
+  );
+  h.deps.isDesktop = () => false;
+  h.collapsedStages.add("merged");
+  h.collapsedEpics.add("/r#100");
+  await revealAndSelect("s", h.deps, (id) => h.deps.select(id));
+  expect(h.collapsedStages.has("merged")).toBe(true); // untouched — desktop-only state
+  await revealAndSelect("e", h.deps, (id) => h.deps.select(id));
+  expect(h.collapsedEpics.has("/r#100")).toBe(false); // epics collapse on mobile too
+  expect(h.log).toEqual([
+    "locate",
+    "select:true:true stages=[merged] epics=[/r#100] id=s",
+    "locate",
+    "expandEpic:/r#100",
+    "tick",
+    "select:true:true stages=[merged] epics=[] id=e",
+  ]);
+});
+
+// createJumpHandlers — effect ordering with an initially filter-hidden target
+
+test("jumpToSession: effects run BEFORE locate, so a filter-hidden target becomes locatable", async () => {
+  // Stateful locate fake: the target has NO location until resetLensAndFilters ran —
+  // exactly how the real locator behaves while a repo/status filter hides the session.
+  const h = harness();
+  h.collapsedStages.add("awaiting-merge");
+  let filtersReset = false;
+  h.deps.locate = () => {
+    h.log.push("locate");
+    return filtersReset ? new Map([["x", stage("awaiting-merge")]]) : new Map();
+  };
+  h.effects.resetLensAndFilters = () => {
+    filtersReset = true;
+    h.log.push("reset");
+  };
+  const handlers = createJumpHandlers(h.deps, h.effects);
+  await handlers.jumpToSession("x");
+  expect(h.log).toEqual([
+    "reset",
+    "follow:x",
+    "locate",
+    "expandStage:awaiting-merge",
+    "tick",
+    "select:true:true stages=[] epics=[] id=x",
+  ]);
+});
+
+// createJumpHandlers — per-path wiring: every handler opens a collapsed desktop stage
+// before select/scroll, with its exact effects and select variant
+
+test.each([
+  ["jumpToSession", ["reset", "follow:x"], "select:true:true"],
+  ["selectRundownItem", ["leaveRundown"], "select:true:true"],
+  ["selectFromDeepLink", [], "select:true:true"],
+  ["jumpFromHerdrUpdate", ["closeUpdateModal"], "select:true:true"],
+  ["navigateFromViewport", [], "select:true:true"],
+  ["retargetForRepoFilter", [], "select:false:false"],
+] as const)("%s expands the collapsed stage before selecting", async (name, fx, sel) => {
+  const h = harness(new Map([["x", stage("merged")]]));
+  h.collapsedStages.add("merged");
+  const handlers = createJumpHandlers(h.deps, h.effects);
+  await handlers[name]("x");
+  expect(h.log).toEqual([
+    ...fx,
+    "locate",
+    "expandStage:merged",
+    "tick",
+    `${sel} stages=[] epics=[] id=x`,
+  ]);
+});
+
+test("selectNextNeedsYou: target from nextNeedsYou, expansion via the same core, keyNavSelect", async () => {
+  const h = harness(new Map([["blocked1", stage("ci-failed")]]));
+  h.collapsedStages.add("ci-failed");
+  h.deps.blockedIds = () => ["blocked1"];
+  h.deps.selectedId = () => "other";
+  const handlers = createJumpHandlers(h.deps, h.effects);
+  await handlers.selectNextNeedsYou();
+  expect(h.log).toEqual([
+    "locate",
+    "expandStage:ci-failed",
+    "tick",
+    "keyNav:true stages=[] epics=[] id=blocked1",
+  ]);
+});
+
+test("selectNextNeedsYou: no blocked sessions → no locate, no select", async () => {
+  const h = harness();
+  const handlers = createJumpHandlers(h.deps, h.effects);
+  await handlers.selectNextNeedsYou();
+  expect(h.log).toEqual([]);
+});
+
+// live getters — values mutated AFTER factory creation must be picked up
+
+test("handlers read locate/selectedId/blockedIds/isDesktop live, never as creation-time snapshots", async () => {
+  const h = harness(); // empty locations, nothing blocked, desktop off
+  let desktop = false;
+  const blocked: string[] = [];
+  let selected: string | null = null;
+  h.deps.isDesktop = () => desktop;
+  h.deps.blockedIds = () => blocked;
+  h.deps.selectedId = () => selected;
+  const handlers = createJumpHandlers(h.deps, h.effects);
+
+  // mutate the UNDERLYING values after creation — the getters must see all of them
+  h.locations.set("late", stage("merged"));
+  h.collapsedStages.add("merged");
+  blocked.push("late", "other");
+  selected = "other";
+  desktop = true;
+
+  await handlers.selectNextNeedsYou(false);
+  // fresh blockedIds/selectedId chose "late"; fresh locations + isDesktop expanded its stage
+  expect(h.log).toEqual([
+    "locate",
+    "expandStage:merged",
+    "tick",
+    "keyNav:false stages=[] epics=[] id=late",
+  ]);
+});

--- a/ui/src/lib/components/herd-jump.ts
+++ b/ui/src/lib/components/herd-jump.ts
@@ -1,0 +1,116 @@
+import { nextNeedsYou, type RailLocation } from "./herd-keynav";
+
+/** Dependencies for the jump handlers. Every value that can change after the factory
+ *  runs is a LIVE GETTER (`locate`, `selectedId`, `blockedIds`, `isDesktop`) — the
+ *  handlers re-read them on every jump, never capturing a snapshot at creation time.
+ *  The collapsed sets are live references used only for `has` checks; the actual
+ *  mutation goes through `expandEpic`/`expandStage` so the page can keep its epic
+ *  touched-key bookkeeping (expandEpicGroup) in ONE place. */
+export type JumpDeps = {
+  /** Fresh rail locations — read AFTER a path's effects ran, so a target the active
+   *  repo/status filter hid becomes locatable once the effects reset those filters. */
+  locate: () => ReadonlyMap<string, RailLocation>;
+  selectedId: () => string | null;
+  /** NEEDS-YOU walk source (oldest-first), for selectNextNeedsYou's target choice. */
+  blockedIds: () => string[];
+  /** Desktop layout gate: the lifecycle-stage collapse is desktop-only state, so
+   *  mobile jumps must never mutate it (the phone accordion is Herd-internal). */
+  isDesktop: () => boolean;
+  collapsedEpics: ReadonlySet<string>;
+  collapsedStages: ReadonlySet<string>;
+  expandEpic: (key: string) => void;
+  expandStage: (key: string) => void;
+  tick: () => Promise<void>;
+  /** The page's selectUnit — default select for direct jumps. */
+  select: (id: string, focusTerm?: boolean, toDetail?: boolean) => void;
+  /** The page's keyNavSelect — used by selectNextNeedsYou (scrolls the row into view). */
+  keyNavSelect: (id: string, focusTerm: boolean) => void;
+};
+
+/** Page-specific side effects each handler runs BEFORE locating the target (see the
+ *  handler table in createJumpHandlers). Injected so the module stays page-agnostic
+ *  and the effects can be spied on in tests. */
+export type JumpEffects = {
+  /** jumpToSession: leave the backlog + clear the lens/status filters. */
+  resetLensAndFilters: () => void;
+  /** jumpToSession: collapse the repo filter onto the target's repo. */
+  followRepo: (id: string) => void;
+  /** selectRundownItem: leave the panel-only Rundown lens. */
+  leaveRundown: () => void;
+  /** jumpFromHerdrUpdate: close the update modal + clear its run state. */
+  beforeHerdrUpdateJump: () => void;
+};
+
+/** Reveal-before-select core — the single authority for expanding a collapsed group so
+ *  a jump target's row is visible. Fixed order: the caller's effects already ran →
+ *  (1) resolve the target's CURRENT location, (2) expand the right collapsed set
+ *  (epic → always; stage → desktop only; experiment groups never collapse), (3) if
+ *  something expanded, await a tick so the row mounts, (4) select. Selection is a
+ *  callback so each handler picks its own select function and options. */
+export async function revealAndSelect(
+  id: string,
+  deps: JumpDeps,
+  select: (id: string) => void,
+): Promise<void> {
+  const loc = deps.locate().get(id);
+  let expanded = false;
+  if (loc?.kind === "epic" && deps.collapsedEpics.has(loc.key)) {
+    deps.expandEpic(loc.key);
+    expanded = true;
+  } else if (loc?.kind === "stage" && deps.isDesktop() && deps.collapsedStages.has(loc.key)) {
+    deps.expandStage(loc.key);
+    expanded = true;
+  }
+  // Only an actual expansion needs the tick (newly-mounted row before scroll); an
+  // already-visible target selects synchronously, exactly like a rail click.
+  if (expanded) await deps.tick();
+  select(id);
+}
+
+/** Every global (outside-the-rail) session jump the page performs, built on ONE
+ *  reveal-before-select core. Per-handler effects and select variants:
+ *
+ *  | handler               | effects before locate      | select                          |
+ *  | --------------------- | -------------------------- | ------------------------------- |
+ *  | jumpToSession         | resetLensAndFilters,       | select(id)                      |
+ *  |                       | followRepo(id)             |                                 |
+ *  | selectRundownItem     | leaveRundown               | select(id)                      |
+ *  | selectFromDeepLink    | —                          | select(id)                      |
+ *  | jumpFromHerdrUpdate   | beforeHerdrUpdateJump      | select(id)                      |
+ *  | navigateFromViewport  | —                          | select(id)                      |
+ *  | retargetForRepoFilter | — (follows a just-set repo | select(id, false, false)        |
+ *  |                       | filter; no reset)          |                                 |
+ *  | selectNextNeedsYou    | — (target via nextNeedsYou)| keyNavSelect(id, focusTerm)     |
+ */
+export function createJumpHandlers(deps: JumpDeps, effects: JumpEffects) {
+  return {
+    jumpToSession: async (id: string): Promise<void> => {
+      effects.resetLensAndFilters();
+      effects.followRepo(id);
+      await revealAndSelect(id, deps, (i) => deps.select(i));
+    },
+    selectRundownItem: async (id: string): Promise<void> => {
+      effects.leaveRundown();
+      await revealAndSelect(id, deps, (i) => deps.select(i));
+    },
+    selectFromDeepLink: async (id: string): Promise<void> => {
+      await revealAndSelect(id, deps, (i) => deps.select(i));
+    },
+    jumpFromHerdrUpdate: async (id: string): Promise<void> => {
+      effects.beforeHerdrUpdateJump();
+      await revealAndSelect(id, deps, (i) => deps.select(i));
+    },
+    navigateFromViewport: async (id: string): Promise<void> => {
+      await revealAndSelect(id, deps, (i) => deps.select(i));
+    },
+    retargetForRepoFilter: async (id: string): Promise<void> => {
+      // toDetail=false: filtering the list must not fling a phone user into a terminal.
+      await revealAndSelect(id, deps, (i) => deps.select(i, false, false));
+    },
+    selectNextNeedsYou: async (focusTerm = true): Promise<void> => {
+      const id = nextNeedsYou(deps.blockedIds(), deps.selectedId());
+      if (id === null) return;
+      await revealAndSelect(id, deps, (i) => deps.keyNavSelect(i, focusTerm));
+    },
+  };
+}

--- a/ui/src/lib/components/herd-keynav.test.ts
+++ b/ui/src/lib/components/herd-keynav.test.ts
@@ -1,14 +1,14 @@
 import { test, expect } from "vitest";
 import {
   railOrder as railOrderRaw,
+  railLocationsOf,
   cycleId,
   nthId,
   nextNeedsYou,
-  nextNeedsYouTarget,
   altComboKey,
   jumpDigitIndex,
 } from "./herd-keynav";
-import type { HerdFilter } from "./herd-partition";
+import { GROUP_KEY_BY_STAGE, type HerdFilter } from "./herd-partition";
 import type { Session, GitState, Epic, EpicChild, SessionStatus } from "$lib/types";
 
 function session(
@@ -114,6 +114,7 @@ function railOrder(
   activeEpicKeys: Set<string> = new Set(),
   collapsedKeys: Set<string> = new Set(),
   isReworkRunning: (session: Session) => boolean = noRework,
+  collapsedStageKeys: ReadonlySet<string> = new Set(),
 ) {
   return railOrderRaw(
     sessions,
@@ -126,7 +127,17 @@ function railOrder(
     epics,
     activeEpicKeys,
     collapsedKeys,
+    collapsedStageKeys,
   );
+}
+
+/** A comparison-experiment member — two of these with the same experimentId form a group. */
+function variant(id: string, experimentId: string, issueNumber: number | null = null): Session {
+  return {
+    ...session(id, false, "running", issueNumber),
+    experimentId,
+    experimentRole: "variant",
+  };
 }
 
 test("railOrder flattens the partition in the rail's render order", () => {
@@ -344,40 +355,110 @@ test("nextNeedsYou is a no-op (null) when none are blocked or only the current o
   expect(nextNeedsYou(["a"], "a")).toBeNull();
 });
 
-// nextNeedsYouTarget — target id + the collapsed group to auto-expand
+// collapsed lifecycle stages (desktop group collapse) + experiment mirroring
 
-test("nextNeedsYouTarget: target inside a collapsed group returns that group key to expand", () => {
-  const groupOf = new Map([["x", "/r#100"]]);
-  const collapsed = new Set(["/r#100"]);
-  expect(nextNeedsYouTarget(["x", "y"], "other", groupOf, collapsed)).toEqual({
-    id: "x",
-    expand: "/r#100",
-  });
+test("railOrder: a collapsed lifecycle stage contributes no rest ids", () => {
+  const list = [session("act"), session("am", false, "idle"), session("rdy", true, "idle")];
+  const g = { am: git("open", "success") };
+  // sanity: nothing collapsed → all three in stage order
+  expect(railOrder(list, g, noReview, 1000)).toEqual(["act", "am", "rdy"]);
+  const collapsedStages = new Set([GROUP_KEY_BY_STAGE.awaitingMerge]);
+  expect(
+    railOrder(
+      list,
+      g,
+      noReview,
+      1000,
+      "all",
+      {},
+      {},
+      new Set(),
+      new Set(),
+      noRework,
+      collapsedStages,
+    ),
+  ).toEqual(["act", "rdy"]);
 });
 
-test("nextNeedsYouTarget: target in an EXPANDED group needs no expand", () => {
-  const groupOf = new Map([["x", "/r#100"]]);
-  const collapsed = new Set<string>(); // group not collapsed
-  expect(nextNeedsYouTarget(["x", "y"], "other", groupOf, collapsed)).toEqual({
-    id: "x",
-    expand: null,
-  });
+test("railOrder: experiment members of a collapsed stage stay reachable (they render in their experiment group)", () => {
+  // Two green-idle variants form an experiment group; a plain green-idle rest row shares
+  // their awaitingMerge stage. Collapsing that stage must drop ONLY the rest row.
+  const v1 = { ...variant("v1", "e1"), status: "idle" as const };
+  const v2 = { ...variant("v2", "e1"), status: "idle" as const };
+  const rest = session("plain", false, "idle");
+  const g = {
+    v1: git("open", "success"),
+    v2: git("open", "success"),
+    plain: git("open", "success"),
+  };
+  const collapsedStages = new Set([GROUP_KEY_BY_STAGE.awaitingMerge]);
+  const order = railOrder(
+    [v1, v2, rest],
+    g,
+    noReview,
+    1000,
+    "all",
+    {},
+    {},
+    new Set(),
+    new Set(),
+    noRework,
+    collapsedStages,
+  );
+  expect(order).toEqual(["v1", "v2"]);
 });
 
-test("nextNeedsYouTarget: ungrouped target needs no expand", () => {
-  expect(nextNeedsYouTarget(["x", "y"], "other", new Map(), new Set(["/r#100"]))).toEqual({
-    id: "x",
-    expand: null,
-  });
+test("railOrder renders epic groups, then experiment groups, then the lifecycle rest", () => {
+  const epics = { [epicKey("/r", 100)]: epic("/r", 100, [101]) };
+  const active = new Set([epicKey("/r", 100)]);
+  const epicMember = session("g100", false, "running", 101);
+  const rest = session("rest1");
+  const order = railOrder(
+    [rest, variant("v1", "e1"), epicMember, variant("v2", "e1")],
+    {},
+    noReview,
+    1000,
+    "all",
+    {},
+    epics,
+    active,
+  );
+  expect(order).toEqual(["g100", "v1", "v2", "rest1"]);
 });
 
-test("nextNeedsYouTarget: no blocked → null id, null expand", () => {
-  expect(nextNeedsYouTarget([], null, new Map(), new Set())).toEqual({ id: null, expand: null });
-  // only the current one blocked → nextNeedsYou is null → no expand either
-  expect(nextNeedsYouTarget(["a"], "a", new Map([["a", "/r#100"]]), new Set(["/r#100"]))).toEqual({
-    id: null,
-    expand: null,
-  });
+// railLocationsOf — where each session renders (single authority for jump expansion)
+
+test("railLocationsOf classifies epic members, experiment members, and the lifecycle rest", () => {
+  const epics = { [epicKey("/r", 100)]: epic("/r", 100, [101, 102]) };
+  const active = new Set([epicKey("/r", 100)]);
+  const epicMember = session("g100", false, "running", 101);
+  // experiment member CARRYING epic metadata (child 102): experiments are pulled out
+  // first, so it must classify as experiment — never as the epic it doesn't render in
+  const v1 = variant("v1", "e1", 102);
+  const v2 = variant("v2", "e1");
+  const restReady = session("rest-ready", true, "idle");
+  const locs = railLocationsOf(
+    [epicMember, v1, v2, restReady],
+    {},
+    noReview,
+    noRework,
+    1000,
+    epics,
+    active,
+  );
+  expect(locs.get("g100")).toEqual({ kind: "epic", key: epicKey("/r", 100) });
+  expect(locs.get("v1")).toEqual({ kind: "experiment" });
+  expect(locs.get("v2")).toEqual({ kind: "experiment" });
+  expect(locs.get("rest-ready")).toEqual({ kind: "stage", key: GROUP_KEY_BY_STAGE.ready });
+  expect(locs.get("not-shown")).toBeUndefined();
+});
+
+test("railLocationsOf: a lone surviving variant falls back into the lifecycle rest", () => {
+  // <2 visible variants and no comparison → groupSessionsByExperiment leaves it in rest,
+  // where it partitions like any session — the locator must mirror that fallback.
+  const lone = variant("lone", "e1");
+  const locs = railLocationsOf([lone], {}, noReview, noRework, 1000);
+  expect(locs.get("lone")).toEqual({ kind: "stage", key: GROUP_KEY_BY_STAGE.active });
 });
 
 // altComboKey — physical KeyboardEvent.code → keynav key vocabulary

--- a/ui/src/lib/components/herd-keynav.ts
+++ b/ui/src/lib/components/herd-keynav.ts
@@ -3,25 +3,36 @@ import {
   partitionSessions,
   shownSessions,
   flattenByStage,
+  GROUP_KEY_BY_STAGE,
   type HerdFilter,
 } from "./herd-partition";
 import { groupSessionsByEpic } from "./epic-grouping";
+import { groupSessionsByExperiment, type ExperimentGroup } from "./experiment-grouping";
 
 /** Pure ordering/cycling logic for the herd's keyboard navigation (j/k, g, 1-9).
  *  Sibling of herd-partition.ts: the page-level shortcut handler computes the
  *  rail's visible order here instead of duplicating Herd.svelte's template walk. */
 
+/** An experiment group's members in the exact order HerdExperimentGroups renders them
+ *  (variants first, then the comparison run). Shared by railOrder and railLocationsOf. */
+function experimentMembers(g: ExperimentGroup): Session[] {
+  return g.comparison ? [...g.variants, g.comparison] : g.variants;
+}
+
 /** Session ids in the exact order the herd rail renders them. Mirrors Herd.svelte's
- *  template: epic groups render at the TOP (in `groupSessionsByEpic` order, each
- *  group's sessions already lifecycle-flattened, a collapsed group contributing
- *  nothing), then the lifecycle sections render over the non-epic `rest` in
- *  `STAGE_ORDER`. Reuses the SAME `groupSessionsByEpic` + `flattenByStage` the
- *  template does, so the rail can never drift from the render.
+ *  grouping pipeline: comparison experiments are pulled out FIRST, then epic groups form
+ *  over the experiment `rest`, then the lifecycle sections render over the true rest in
+ *  `STAGE_ORDER`. The template order is epic groups → experiment groups → lifecycle, with
+ *  a collapsed epic group contributing nothing and a collapsed lifecycle stage
+ *  (`collapsedStageKeys`, desktop group collapse) dropping ONLY its rest rows — epic and
+ *  experiment members stay reachable because their groups render regardless of stage.
+ *  Reuses the SAME grouping helpers + `flattenByStage` the template does, so the rail can
+ *  never drift from the render.
  *
- *  The trailing epic args default empty: with no epics, `grouped.groups` is empty
- *  and `grouped.rest === shown`, so the output equals the pre-epic behavior
- *  (`flattenByStage(partitionSessions(shownSessions(...)))`) — existing callers and
- *  tests that pass no grouping args see identical order. */
+ *  The trailing epic/collapse args default empty: with no epics and no experiments,
+ *  `grouped.groups` is empty and `grouped.rest === shown`, so the output equals the
+ *  pre-epic behavior (`flattenByStage(partitionSessions(shownSessions(...)))`) — existing
+ *  callers and tests that pass no grouping args see identical order. */
 export function railOrder(
   sessions: Session[],
   git: Record<string, GitState>,
@@ -33,10 +44,12 @@ export function railOrder(
   epics: Record<string, Epic> = {},
   activeEpicKeys: Set<string> = new Set(),
   collapsedKeys: Set<string> = new Set(),
+  collapsedStageKeys: ReadonlySet<string> = new Set(),
 ): string[] {
   const shown = shownSessions(sessions, filter, isReviewing, workingBlocked, git, now);
+  const experimentGrouped = groupSessionsByExperiment(shown);
   const grouped = groupSessionsByEpic(
-    shown,
+    experimentGrouped.rest,
     epics,
     activeEpicKeys,
     git,
@@ -47,10 +60,66 @@ export function railOrder(
   const groupIds = grouped.groups.flatMap((g) =>
     collapsedKeys.has(g.key) ? [] : g.sessions.map((s) => s.id),
   );
+  const experimentIds = experimentGrouped.groups.flatMap((g) =>
+    experimentMembers(g).map((s) => s.id),
+  );
   const restIds = flattenByStage(
     partitionSessions(grouped.rest, git, isReviewing, isReworkRunning, now),
+    collapsedStageKeys,
   ).map((s) => s.id);
-  return [...groupIds, ...restIds];
+  return [...groupIds, ...experimentIds, ...restIds];
+}
+
+/** Where a session renders in the herd rail: inside an experiment group (never
+ *  collapsible), inside an epic group (collapsed via the epic set), or in a lifecycle
+ *  section of the rest (collapsed via the desktop stage set, keyed by
+ *  GROUP_KEY_BY_STAGE). Sessions not in the input list have no location. */
+export type RailLocation =
+  { kind: "experiment" } | { kind: "epic"; key: string } | { kind: "stage"; key: string };
+
+/** Classify every session by where it renders, in ONE pass of the exact grouping
+ *  pipeline the template (and railOrder) uses: experiments first, epics over the
+ *  experiment rest, lifecycle partition over the true rest. Single authority for
+ *  "which collapsed group hides this row" — jump handlers expand based on this, so an
+ *  experiment member (even one carrying epic metadata) can never open an epic or
+ *  lifecycle group it doesn't render in. */
+export function railLocationsOf(
+  sessions: Session[],
+  git: Record<string, GitState>,
+  isReviewing: (id: string) => boolean,
+  isReworkRunning: (session: Session) => boolean,
+  now: number,
+  epics: Record<string, Epic> = {},
+  activeEpicKeys: Set<string> = new Set(),
+): Map<string, RailLocation> {
+  const experimentGrouped = groupSessionsByExperiment(sessions);
+  const grouped = groupSessionsByEpic(
+    experimentGrouped.rest,
+    epics,
+    activeEpicKeys,
+    git,
+    isReviewing,
+    isReworkRunning,
+    now,
+  );
+  const partition = partitionSessions(grouped.rest, git, isReviewing, isReworkRunning, now);
+  // Entries array (not .set in a loop) so callers get a plain non-reactive lookup,
+  // matching the page's previous epicGroupOf pattern.
+  const entries: [string, RailLocation][] = [
+    ...experimentGrouped.groups.flatMap((g) =>
+      experimentMembers(g).map((s): [string, RailLocation] => [s.id, { kind: "experiment" }]),
+    ),
+    ...grouped.groups.flatMap((g) =>
+      g.sessions.map((s): [string, RailLocation] => [s.id, { kind: "epic", key: g.key }]),
+    ),
+    ...(Object.keys(GROUP_KEY_BY_STAGE) as (keyof typeof GROUP_KEY_BY_STAGE)[]).flatMap((stage) =>
+      partition[stage].map((s): [string, RailLocation] => [
+        s.id,
+        { kind: "stage", key: GROUP_KEY_BY_STAGE[stage] },
+      ]),
+    ),
+  ];
+  return new Map(entries);
 }
 
 /** The id one step (+1 down / -1 up) from `currentId` in `order`, wrapping at
@@ -138,22 +207,6 @@ export function nextNeedsYou(blockedIds: string[], currentId: string | null): st
     if (id !== currentId) return id;
   }
   return null;
-}
-
-/** Resolve the next needs-you jump target plus the epic group key (if any) that must be
- *  expanded so the target row is visible. `groupOf` maps sessionId → its epic group key.
- *  Backs the command bar's `next-needs-you` verb: resolves the target AND the
- *  collapsed-group-to-expand through one tested helper. */
-export function nextNeedsYouTarget(
-  blockedIds: string[],
-  currentId: string | null,
-  groupOf: Map<string, string>,
-  collapsed: ReadonlySet<string>,
-): { id: string | null; expand: string | null } {
-  const id = nextNeedsYou(blockedIds, currentId);
-  if (id === null) return { id: null, expand: null };
-  const key = groupOf.get(id);
-  return { id, expand: key != null && collapsed.has(key) ? key : null };
 }
 
 /** The command-bar chord: Cmd/Ctrl+K with no other modifier held. Shared by

--- a/ui/src/lib/components/herd-partition.test.ts
+++ b/ui/src/lib/components/herd-partition.test.ts
@@ -3,6 +3,7 @@ import {
   partitionSessions as partitionSessionsRaw,
   shownSessions,
   flattenByStage,
+  GROUP_KEY_BY_STAGE,
 } from "./herd-partition";
 import type { Session, GitState, SessionStatus } from "$lib/types";
 
@@ -618,4 +619,42 @@ test('"ready" filter is unchanged with no git/now args (backward compat)', () =>
   // excluded stage, so the legacy 4-arg call behaves exactly as before.
   const list = [session("a", false, "idle"), session("b", false, "blocked")];
   expect(shownSessions(list, "ready", () => false).map((s) => s.id)).toEqual(["a", "b"]);
+});
+
+test("GROUP_KEY_BY_STAGE maps every stage to its exact render group key", () => {
+  // Frozen 1:1 — these are the keys Herd.svelte's partitionGroups render under and the
+  // desktop collapse state stores; a rename on either side must fail here first.
+  expect(GROUP_KEY_BY_STAGE).toEqual({
+    active: "active",
+    ciRunning: "ci-running",
+    ciFailed: "ci-failed",
+    reviewerRunning: "reviewer-running",
+    reworkRunning: "rework-running",
+    needsRework: "needs-rework",
+    branchProtectionBlocked: "branch-protection-blocked",
+    waitingOnReviewer: "waiting-reviewer",
+    waitingOnMerger: "waiting-merger",
+    draftAwaitingSignoff: "draft-signoff",
+    awaitingMerge: "awaiting-merge",
+    ready: "ready",
+    merging: "merging",
+    merged: "merged",
+  });
+});
+
+test("flattenByStage skips stages whose group key is collapsed", () => {
+  const list = [
+    session("act"),
+    session("am", false, "idle"),
+    session("rdy", true, "idle"),
+    session("mrg", false, "idle"),
+  ];
+  const p = partitionSessions(list, {
+    am: git("open", "success"),
+    mrg: git("merged"),
+  });
+  // sanity: full flatten sees all four in stage order
+  expect(flattenByStage(p).map((s) => s.id)).toEqual(["act", "am", "rdy", "mrg"]);
+  const collapsed = new Set([GROUP_KEY_BY_STAGE.awaitingMerge, GROUP_KEY_BY_STAGE.merged]);
+  expect(flattenByStage(p, collapsed).map((s) => s.id)).toEqual(["act", "rdy"]);
 });

--- a/ui/src/lib/components/herd-partition.ts
+++ b/ui/src/lib/components/herd-partition.ts
@@ -206,9 +206,39 @@ const STAGE_ORDER = [
   "merged",
 ] as const satisfies readonly Stage[];
 
-/** Flatten a partitionSessions result into a single list in STAGE_ORDER. */
-export function flattenByStage(p: ReturnType<typeof partitionSessions>): Session[] {
-  return STAGE_ORDER.flatMap((stage) => p[stage]);
+/** The hyphenated group key each lifecycle stage renders under — the `key` of
+ *  Herd.svelte's `partitionGroups` entries and the value the desktop collapse state
+ *  (`collapsedStages`) and group-toggle callbacks speak. Single source of truth:
+ *  Herd.svelte, `flattenByStage`'s collapse skip, and herd-keynav's locator all read
+ *  from here, so a renamed key can never drift between render, state, and keynav. */
+export const GROUP_KEY_BY_STAGE = {
+  active: "active",
+  ciRunning: "ci-running",
+  ciFailed: "ci-failed",
+  reviewerRunning: "reviewer-running",
+  reworkRunning: "rework-running",
+  needsRework: "needs-rework",
+  branchProtectionBlocked: "branch-protection-blocked",
+  waitingOnReviewer: "waiting-reviewer",
+  waitingOnMerger: "waiting-merger",
+  draftAwaitingSignoff: "draft-signoff",
+  awaitingMerge: "awaiting-merge",
+  ready: "ready",
+  merging: "merging",
+  merged: "merged",
+} as const satisfies Record<Stage, string>;
+
+/** Flatten a partitionSessions result into a single list in STAGE_ORDER. Stages whose
+ *  group key (per GROUP_KEY_BY_STAGE) is in `collapsedGroupKeys` contribute nothing —
+ *  the desktop lifecycle collapse hides exactly those rows, and keynav's rail order
+ *  must skip what the rail doesn't render. Defaults to no skips for existing callers. */
+export function flattenByStage(
+  p: ReturnType<typeof partitionSessions>,
+  collapsedGroupKeys: ReadonlySet<string> = new Set(),
+): Session[] {
+  return STAGE_ORDER.flatMap((stage) =>
+    collapsedGroupKeys.has(GROUP_KEY_BY_STAGE[stage]) ? [] : p[stage],
+  );
 }
 
 export function partitionSessions(

--- a/ui/src/lib/components/herd/HerdGroup.svelte
+++ b/ui/src/lib/components/herd/HerdGroup.svelte
@@ -51,6 +51,9 @@
     collapsible?: boolean;
     expanded?: boolean;
     ontoggle?: () => void;
+    // coarse-pointer/touch input: keeps the 44px touch-target sizing on the header
+    // toggle + its actions. False on fine-pointer desktop, where headers stay compact.
+    touchTarget?: boolean;
     ctx: HerdRowCtx;
   };
 
@@ -65,12 +68,13 @@
     collapsible = false,
     expanded = true,
     ontoggle = undefined,
+    touchTarget = false,
     ctx,
   }: HerdGroupProps = $props();
 </script>
 
 {#if headClass}
-  <div class="{headClass} micro" class:collapsible>
+  <div class="{headClass} micro" class:collapsible class:touch={touchTarget}>
     {#if collapsible}
       <button class="group-toggle" type="button" aria-expanded={expanded} onclick={ontoggle}>
         <span class="chev" class:collapsed={!expanded} aria-hidden="true">▾</span>
@@ -138,7 +142,10 @@
     color: var(--color-muted);
   }
 
-  .micro.collapsible {
+  /* 44px touch targets are keyed to input modality (.touch = phone layout or a
+     coarse-pointer wide device), not to collapsibility — fine-pointer desktop
+     headers stay at their compact height. */
+  .micro.collapsible.touch {
     min-height: 44px;
     padding-block: 0;
   }
@@ -150,7 +157,6 @@
     gap: 7px;
     flex: 1;
     min-width: 0;
-    min-height: 44px;
     padding: 0;
     border: 0;
     background: none;
@@ -160,6 +166,12 @@
     text-transform: inherit;
     text-align: left;
     cursor: pointer;
+  }
+  .touch .group-toggle {
+    min-height: 44px;
+  }
+  .group-toggle:hover {
+    background: var(--color-hover);
   }
   .group-toggle:focus-visible {
     outline: none;
@@ -279,8 +291,8 @@
     box-shadow: inset 0 0 0 1px var(--color-amber);
   }
 
-  .collapsible .merge-train,
-  .collapsible .clear-merged {
+  .collapsible.touch .merge-train,
+  .collapsible.touch .clear-merged {
     align-self: stretch;
     min-height: 44px;
     padding-inline: 8px;

--- a/ui/src/lib/feature-announcements/entries/v1.45.0-desktop-herd-group-collapse.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.45.0-desktop-herd-group-collapse.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "desktop-herd-group-collapse",
+  sinceVersion: "1.45.0",
+  titleKey: "feat_desktop_herd_group_collapse_title",
+  bodyKey: "feat_desktop_herd_group_collapse_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -91,13 +91,13 @@
   import Herd from "$lib/components/Herd.svelte";
   import {
     railOrder,
+    railLocationsOf,
     isCommandBarChord,
     cycleId,
     nthId,
-    nextNeedsYouTarget,
     altComboKey,
   } from "$lib/components/herd-keynav";
-  import { groupSessionsByEpic } from "$lib/components/epic-grouping";
+  import { createJumpHandlers } from "$lib/components/herd-jump";
   import { normalizeEpicCollapse } from "$lib/components/herd-epic-collapse";
   import { isReworkRunning as isReworkRunningSession } from "$lib/components/rework-running";
   import { buildCommands } from "$lib/command-registry";
@@ -411,8 +411,10 @@
         store.workingBlocked,
         selected,
       );
-      // toDetail=false: filtering the list must not fling a phone user into a terminal.
-      if (target) selectUnit(target, false, false);
+      // toDetail=false lives in the handler: filtering the list must not fling a
+      // phone user into a terminal. Routed through jumpHandlers so a target in a
+      // collapsed (desktop) lifecycle group is revealed before selection.
+      if (target) void jumpHandlers.retargetForRepoFilter(target);
     });
   });
   // Session-status filter toggled from the TopBar tallies; null = all statuses.
@@ -493,6 +495,15 @@
     if (collapsedEpics.has(key)) expandEpicGroup(key);
     else collapseEpicGroup(key);
   }
+  // Desktop lifecycle-group collapse (GROUP_KEY_BY_STAGE keys). Same page-owned
+  // SvelteSet pattern as collapsedEpics — shared with <Herd> (render) and railOrder
+  // (nav). In-memory by design: a reload reopens every group. No normalization
+  // needed: stage keys are stable (unlike epic keys, which come and go per epic).
+  const collapsedStages = new SvelteSet<string>();
+  function toggleStageCollapse(key: string) {
+    if (collapsedStages.has(key)) collapsedStages.delete(key);
+    else collapsedStages.add(key);
+  }
   // Seed store.epics for any active epic we don't have the full Epic for yet (header
   // needs title + X/Y + backlog link). Reactive on activeEpicKeys, deduped per key.
   // Fires on load (drain bootstrapped) and when an epic starts mid-session. The effect
@@ -517,12 +528,14 @@
     }
   });
   // sessionId → epic group key, from the SAME pure grouping the Herd render + rail use.
-  // Drives NEEDS-YOU auto-expand: a jump target sitting in a collapsed group is found
-  // here so the handler can expand that group before selecting. Built off raw
-  // herdSessions (no rail ready/status filter): it only resolves the group of a blocked
-  // jump target (which always passes the filter) to remove a collapsed key — never used
-  // for ordering — so the filter asymmetry with render/rail is intentional and harmless.
-  const epicGroupOf = $derived.by(() => {
+  // Drives every global jump's reveal-before-select: where a target renders (experiment
+  // group / epic group / lifecycle stage of the rest) so the handler can expand exactly
+  // the collapsed group hiding it — an experiment member expands nothing (its group never
+  // collapses). Built off raw herdSessions (no rail ready/status filter): it only
+  // resolves the group of a jump target (which always passes the filter) to remove a
+  // collapsed key — never used for ordering — so the filter asymmetry with render/rail
+  // is intentional and harmless.
+  const railLocations = $derived.by(() => {
     const isReviewing = (id: string) => reviews.isReviewing(id) || planGates.isReviewing(id);
     const isReworkRunning = (session: Session) =>
       isReworkRunningSession(
@@ -531,19 +544,14 @@
         store.workingBlocked,
         nowMs,
       );
-    const { groups } = groupSessionsByEpic(
+    return railLocationsOf(
       herdSessions,
-      store.epics,
-      activeEpicKeys,
       store.git,
       isReviewing,
       isReworkRunning,
       nowMs,
-    );
-    // Build from an entries array (not .set in a loop) so it's a plain non-reactive
-    // lookup, matching Herd's groupParts pattern.
-    return new Map<string, string>(
-      groups.flatMap((g) => g.sessions.map((s): [string, string] => [s.id, g.key])),
+      store.epics,
+      activeEpicKeys,
     );
   });
 
@@ -1309,21 +1317,17 @@
 
   // A global session jump must leave the target visible in the herd, even when a lens or
   // repo/status filter currently hides it. Shared by the command bar and auto-merge strip.
+  // Routed through jumpHandlers (herd-jump.ts) so a target in a collapsed group is
+  // revealed before selection.
   function jumpToSession(id: string) {
-    showBacklog = false;
-    herdFilter = "all";
-    statusFilter = null;
-    const repoPath = store.sessions.find((s) => s.id === id)?.repoPath;
-    if (repoPath) followFilterToRepo(repoPath);
-    selectUnit(id);
+    void jumpHandlers.jumpToSession(id);
   }
 
   // Deep-link a Rundown item to its live session: leave the panel-only Rundown lens
   // (back to the full list so the session row is visible) and select it via the same
   // selectUnit a rail click uses.
   function selectRundownItem(id: string) {
-    herdFilter = "all";
-    selectUnit(id);
+    void jumpHandlers.selectRundownItem(id);
   }
 
   // Deep-link a Rundown epics-to-land item (#1045) to its row in the IntegratedEpicsBand: leave the
@@ -1451,6 +1455,7 @@
       store.epics,
       activeEpicKeys,
       collapsedEpics,
+      collapsedStages,
     );
   }
 
@@ -1626,23 +1631,52 @@
   // command bar's `next-needs-you` verb and tells the operator how many remain.
   const otherNeedsYou = $derived(blockedEntries.filter((e) => e.session.id !== selectedId));
 
-  // Jump to the next waiting session: walk blockedEntries (oldest-first, same set
-  // as the NEEDS YOU badge) starting after the current one, wrapping around. Keep
-  // blockedEntries UNFILTERED (count + jump stay on the same full set); if the target
-  // sits in a collapsed epic group, expand it first so the row is visible. Backs the
-  // command bar's `next-needs-you` verb.
-  async function selectNextNeedsYou(focusTerm = true) {
-    const { id, expand } = nextNeedsYouTarget(
-      blockedEntries.map((entry) => entry.session.id),
-      selectedId,
-      epicGroupOf,
+  // Every global (outside-the-rail) session jump, built on herd-jump.ts's single
+  // reveal-before-select core: a target hidden in a collapsed epic group or (desktop)
+  // collapsed lifecycle group is expanded — after the path's filter/lens effects ran,
+  // so an initially filter-hidden target resolves — then selected once its row mounted.
+  // All mutable deps are live getters; the SvelteSets are live references.
+  const jumpHandlers = createJumpHandlers(
+    {
+      locate: () => railLocations,
+      selectedId: () => selectedId,
+      // blockedEntries stays UNFILTERED (count + jump read the same full set)
+      blockedIds: () => blockedEntries.map((entry) => entry.session.id),
+      isDesktop: () => !mobile.current,
       collapsedEpics,
-    );
-    if (expand) {
-      expandEpicGroup(expand);
-      await tick(); // let the now-expanded group's rows mount so keyNavSelect can scroll to the target
-    }
-    keyNavSelect(id, focusTerm);
+      collapsedStages,
+      expandEpic: expandEpicGroup,
+      expandStage: (key) => collapsedStages.delete(key),
+      tick,
+      select: selectUnit,
+      keyNavSelect,
+    },
+    {
+      resetLensAndFilters: () => {
+        showBacklog = false;
+        herdFilter = "all";
+        statusFilter = null;
+      },
+      followRepo: (id) => {
+        const repoPath = store.sessions.find((s) => s.id === id)?.repoPath;
+        if (repoPath) followFilterToRepo(repoPath);
+      },
+      leaveRundown: () => {
+        herdFilter = "all";
+      },
+      beforeHerdrUpdateJump: () => {
+        showHerdrUpdate = false;
+        herdrUpdating = false;
+        store.herdrUpdateDone = null;
+      },
+    },
+  );
+
+  // Jump to the next waiting session: walk blockedEntries (oldest-first, same set
+  // as the NEEDS YOU badge) starting after the current one, wrapping around. Backs
+  // the command bar's `next-needs-you` verb.
+  function selectNextNeedsYou(focusTerm = true) {
+    void jumpHandlers.selectNextNeedsYou(focusTerm);
   }
 
   // if the selected unit disappears while in mobile detail, fall back to the list
@@ -1659,7 +1693,7 @@
     // Learnings-retire push deep-link (issue #852): ?learnings=1 (cold open) or an
     // "open-learnings" message from the SW (open/backgrounded window) opens the drawer.
     if (params.get("learnings") === "1") showLearnings = true;
-    const disposeSelect = onSelectSession((id) => selectUnit(id));
+    const disposeSelect = onSelectSession((id) => void jumpHandlers.selectFromDeepLink(id));
     const disposeLearnings = onOpenLearnings(() => (showLearnings = true));
     listSessions()
       .then((list) => {
@@ -2785,7 +2819,7 @@
             onSeedBuildQueue={(q) => store.setBuildQueue(q)}
             queue={blockedEntries.map((e) => e.session.id)}
             switchOrder={store.sessions.map((s) => s.id)}
-            onnavigate={(id) => selectUnit(id)}
+            onnavigate={(id) => void jumpHandlers.navigateFromViewport(id)}
             {consumeAutoFocusTerm}
             {onarchive}
             workingBlocked={store.workingBlocked}
@@ -2863,6 +2897,9 @@
               holds={store.holds}
               collapsible={canCollapse}
               oncollapse={toggleSidebar}
+              collapsedStageKeys={collapsedStages}
+              onstagecollapsetoggle={toggleStageCollapse}
+              touch={touch.current}
               completedEpics={completedEpicsShown}
               ondismissepic={onDismissEpic}
               onlandepic={onLandEpic}
@@ -2951,7 +2988,7 @@
             onSeedBuildQueue={(q) => store.setBuildQueue(q)}
             queue={blockedEntries.map((e) => e.session.id)}
             switchOrder={store.sessions.map((s) => s.id)}
-            onnavigate={(id) => selectUnit(id)}
+            onnavigate={(id) => void jumpHandlers.navigateFromViewport(id)}
             {consumeAutoFocusTerm}
             {onarchive}
             workingBlocked={store.workingBlocked}
@@ -3004,12 +3041,7 @@
     herdrUpdating = false;
     store.herdrUpdateDone = null;
   }}
-  onherdrupdatejump={(id) => {
-    showHerdrUpdate = false;
-    herdrUpdating = false;
-    store.herdrUpdateDone = null;
-    selectUnit(id);
-  }}
+  onherdrupdatejump={(id) => void jumpHandlers.jumpFromHerdrUpdate(id)}
   {showCodexUpdate}
   {codexUpdating}
   oncodexupdateconfirm={() => {


### PR DESCRIPTION
## What

The lifecycle group headers in the session rail (CI RUNNING, YOUR TURN, MERGED, …) were only collapsible in the phone layout's accordion (v1.44 mobile-herd-accordion). This makes them collapsible on the desktop rail too — **independently per group** (no accordion), all expanded by default, state held in-memory for the running session (mirrors the epic-group collapse).

## How

- **`herd-partition.ts`** — `GROUP_KEY_BY_STAGE` is now the single source for the group keys (`partitionGroups`, `groupHelp`, the mobile accordion default, keynav, and the collapse state all read it); `flattenByStage` gained an optional collapsed-stage skip.
- **`HerdGroup.svelte`** — the existing disclosure is reused; all three 44px touch-target rule sets now key off input modality (`touchTarget = flow || coarse pointer`) instead of layout, so touch-wide desktops (tablets/foldables) keep ≥44px targets while fine-pointer desktops stay compact. Toggle hover uses the canonical `--color-hover` fill.
- **`Herd.svelte`** — desktop disclosure renders only when the page wires `onstagecollapsetoggle` (never a no-op button); `flow` keeps the phone accordion untouched.
- **`herd-keynav.ts`** — `railOrder` now mirrors the template's full grouping pipeline (experiments first, epics over the experiment rest, lifecycle over the true rest) and skips collapsed stages — only their rest rows, so epic/experiment members stay reachable. New `railLocationsOf` locator replaces the page's `epicGroupOf`, which could attribute an experiment member to an epic group it doesn't render in.
- **`herd-jump.ts` (new)** — single reveal-before-select authority: every global jump (command bar, queue strip, rundown, deep link, herdr-update jump, viewport navigation, repo-filter retarget, next-needs-you) runs path effects first, resolves the target's location **after** them (an initially filter-hidden target becomes locatable), expands the right collapsed set (stage only on desktop — mobile jumps never mutate the desktop state), awaits a tick, then selects. All mutable deps are live getters. `nextNeedsYouTarget` is gone; `nextNeedsYou` picks the target, the core owns expansion.

## Testing

- `cd ui && bun run check` — 0 errors; full suite `bun run test` — **3944 passed** (incl. 15 new herd-jump ordering/per-path/liveness tests, keynav experiment-mirroring + locator tests, partition mapping/skip tests, and desktop-collapse browser tests: default-expanded, independence, controlled props, no-op-button guard, modality height assertions, parametrized header-action tests).
- Gates: `check:i18n`, `check-glossary.mjs`, `check-feature-catalog.sh`, `check-announcement-versions.mjs`, branch hygiene — all green (announcement stamped 1.45.0 after the 1.44.0 release landed mid-branch).
- **Live desktop smoke (Playwright against the real instance via the worktree dev server): 12/12** — toggles render expanded by default, collapsing hides exactly that group's rows (10→9) and flips `aria-expanded`, other groups stay open, phone-width switch shows the unchanged accordion (≤1 open, ≥44px targets), the desktop collapse state survives the mobile round-trip, fine-pointer headers stay compact (16.5px), re-expand restores rows. Header bulk actions (Merge train / Decommission all) were deliberately not clicked live; their non-toggling behavior is covered by the parametrized browser tests.

Closes nothing — direct user request ("das Aufklappen/Zuklappen geht aktuell nur auf kleinen Smartphones — lass es bitte auch auf dem Desktop zu").