### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs/sandbox-security.md
+++ b/docs/sandbox-security.md
@@ -11,7 +11,7 @@ The egress firewall (slirp4netns + nftables + dnsmasq, shipped in **PR #601**,
 closed **#551** — `src/egress.ts`) confines outbound traffic to
 `api.anthropic.com` + `statsig.anthropic.com` + the GitHub hosts, and watches
 for DNS drops. Egress is keyed to the **autonomous profile**, not to
-attendedness (`src/sandbox.ts` `egressApplies`, ~L554).
+attendedness (`src/sandbox.ts` `egressApplies`, ~L682).
 
 This note records two residuals the operator has **accepted** after the audit.
 
@@ -20,12 +20,12 @@ This note records two residuals the operator has **accepted** after the audit.
 The membrane keeps two token surfaces readable to any in-membrane tool call:
 
 - `~/.claude/.credentials.json` — bound **RW** so OAuth refresh writes back
-  (`src/sandbox.ts:315-317`, `--bind-try`); the whole `~/.claude` dir is
-  `--ro-bind`ed at `src/sandbox.ts:308-310`.
+  (`src/sandbox.ts:436-438`, `--bind-try`); the whole `~/.claude` dir is
+  `--ro-bind`ed at `src/sandbox.ts:429-431`.
 - `~/.config/gh` — bound **RO** (the gh token, needed to `git push` /
-  `gh pr create`) at `src/sandbox.ts:413`.
+  `gh pr create`) at `src/sandbox.ts:539`.
 
-`--clearenv` (`src/sandbox.ts:438`) strips **all** inherited env
+`--clearenv` (`src/sandbox.ts:564`) strips **all** inherited env
 (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `GH_TOKEN`, `SHEPHERD_TOKEN`,
 …), re-setting only HOME/PATH/TERM + non-secret locale vars — so these two
 **bound files** are the only token surfaces left inside the membrane.
@@ -50,8 +50,8 @@ secrets out of the membrane entirely.
 ## Attended-mode egress coverage
 
 Egress confinement is keyed to the autonomous **profile**, not to whether a human
-is watching (`willEgressConfine`, `src/sandbox.ts:565-570`; applied at
-`src/service.ts:1873`): the wrap applies iff the autonomous profile resolves
+is watching (`willEgressConfine`, `src/sandbox.ts:693-698`; applied at
+`src/service.ts:1879`): the wrap applies iff the autonomous profile resolves
 **and** the fs + egress backends are present, independent of `ctx.auto`.
 Consequences:
 
@@ -100,7 +100,7 @@ still stand.
 
 - **Autonomous task agents** run `--dangerously-skip-permissions`, but behind
   **both** the filesystem and the egress membrane. `standard` auto-spawns are
-  refused outright (`src/sandbox.ts` `autoHoldReason`, ~L501-502).
+  refused outright (`src/sandbox.ts` `autoHoldReason`, ~L623).
 - **Unattended reviewers** (PR critic + plan-gate) run **read-only**, not
   skip-permissions: `--safe-mode --disable-slash-commands --allowedTools Read
 Grep Glob Bash(git diff *) Bash(git log *) Bash(git show *) Bash(git status)
@@ -108,7 +108,7 @@ Write --permission-mode dontAsk` (`src/transient-agent-argv.ts`,
   `buildTransientAgentArgv("reviewer", …)`).
 - **Research is the deliberately egress-UNCONFINED surface.** A research session
   that would resolve to `autonomous` is **downgraded to `standard`**
-  (`src/service.ts` `researchSafeProfileOverride`, ~L2697, warns once),
+  (`src/service.ts` `researchSafeProfileOverride`, ~L2708, warns once),
   because research needs **open** web egress (search/fetch + sub-agents) that the
   autonomous firewall would block. The same downgrade applies to an
   **epic-authoring** session (`input.epicAuthoring`, #1507), which likewise needs


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc update summary

## Changes

- **`docs/sandbox-security.md`** — refreshed stale source line-number citations that
  drifted after commit `5ffde28c` (#1802, "let codex aux roles start and authenticate
  inside the bwrap membrane"), which grew `src/sandbox.ts` by ~136 lines. Updated:
  - `egressApplies` `~L554` → `~L682`
  - credentials `--bind-try` `src/sandbox.ts:315-317` → `436-438`
  - whole-`~/.claude` `--ro-bind` `src/sandbox.ts:308-310` → `429-431`
  - `~/.config/gh` RO bind `src/sandbox.ts:413` → `539`
  - `--clearenv` `src/sandbox.ts:438` → `564`
  - `willEgressConfine` `src/sandbox.ts:565-570` → `693-698`; its application point
    `src/service.ts:1873` → `1879`
  - `standard` auto-spawn refusal `autoHoldReason` `~L501-502` → `~L623`
  - `researchSafeProfileOverride` `src/service.ts` `~L2697` → `~L2708`

  All new anchors verified against the current source in this checkout. The
  `src/autopilot.ts` citations (`:42-47`, `:40-45`, dispatch `L335`) were re-checked
  and are still accurate — left unchanged.

No other in-scope page was demonstrably stale. `docs/external-task-api.md`,
`docs/token-usage-analysis.md`, `docs-site/.../index.md`, `getting-started.md`,
`operating.md`, `reference/configuration.md`, and `reference/glossary.md` all still
match current source (e.g. `SHEPHERD_AUTO_REVIVE` from #1630 is already documented; the
glossary role list already includes `merge-suggester`).

## Uncertain / needs human judgment

- **`docs/sandbox-security.md` R3 — codex token surface (not changed).** Commit
  `5ffde28c` (#1802) now binds `CODEX_HOME` (`~/.codex`, including `auth.json`) **RW**
  inside the membrane for sandboxed **codex** role spawns (plan-gate, PR critic,
  standalone critic, doc-agent). R3 currently states the two claude token binds
  (`.credentials.json` + `~/.config/gh`) are "the only token surfaces left inside the
  membrane" — that is now incomplete for codex spawns, which carry a third
  (`~/.codex/auth.json`). I did not edit the residual analysis because whether this new
  surface is an *accepted* residual (and how it should be framed alongside R3) is a
  security judgment call, not a mechanical fact. Similarly the opening sentence
  ("wraps each spawned `claude` agent") is now narrower than reality (codex aux roles
  are wrapped too). Recommend a human review these against #1802.

- **`reference/configuration.md` — per-role env vars (not added).** The page opens with
  "Every environment variable" but omits the per-role `ENVIRONMENT` knobs in
  `src/config.ts` (`SHEPHERD_CRITIC_*`, `SHEPHERD_PLANNER_*`, `SHEPHERD_RECAP_*`,
  `SHEPHERD_RUNDOWN_*`, `SHEPHERD_NAMER_*`, `SHEPHERD_AUTOPILOT_*`,
  `SHEPHERD_DISTILLER_*`, `SHEPHERD_OPTIMIZER_*`, `SHEPHERD_MERGE_SUGGEST_*`, and the
  `SHEPHERD_*_CLI/_MODEL/_EFFORT` triples), plus `SHEPHERD_EXTRA_CREDITS_DRAIN_CEILING`,
  `SHEPHERD_AUTOMERGE_REBASE_CAP`, `SHEPHERD_HOUSE_RULES_BUDGET_CHARS`,
  `SHEPHERD_AUTOPILOT_STEP_CAP`, `SHEPHERD_HERDR_SOCKET_TERMINAL`,
  `SHEPHERD_REVIEW_CYCLES_CAP`, `SHEPHERD_PLAN_REVIEW_CYCLES_CAP`,
  `SHEPHERD_STANDARD_COMMAND`, `SHEPHERD_SESSION_HOUSEKEEPING`, `SHEPHERD_LLM_NAMING`,
  `SHEPHERD_REMOTE_CONTROL_AT_STARTUP`, `SHEPHERD_REDUCED_PUSH_MODE`,
  `SHEPHERD_PUSH_COOLDOWN_MS`, and others. These are long-standing (not new since the
  last sync), and prior doc-sync passes deliberately kept the page to an operator-facing
  subset, so I did not add them rather than guess at intended scope. If the page is meant
  to be exhaustive, a human should decide which of these to surface.