### PR TITLE
fix(ui): bind an open epic's head and children into one group

### DIFF
--- a/ui/src/lib/components/EpicPanel.svelte
+++ b/ui/src/lib/components/EpicPanel.svelte
@@ -291,7 +291,8 @@
     gap: 6px;
     padding: 8px 10px;
     background: var(--color-panel);
-    border-top: 1px solid var(--color-line);
+    /* No border-top: the host ([data-epic-panel]) owns the single head↔children
+       divider, so it also covers the pre-resolve loading line. */
     font-family: var(--font-mono);
     font-size: var(--fs-meta);
   }
@@ -304,9 +305,15 @@
   }
 
   /* ── child list ─────────────────────────────────────────────────────────── */
+  /* A leading rail marks these rows as the epic's CHILDREN, separating them from
+     their siblings on the same panel surface (.epic-head's progress/import/diagnose
+     above, .epic-controls below). Mirrors the same cue on the herd's epic groups
+     (HerdEpicGroups.svelte). The rail sits on the scroll container, so it stays put
+     while a long child list scrolls under it — intended. */
   .epic-children {
     margin: 0;
-    padding: 0;
+    padding: 0 0 0 8px;
+    border-left: 1px solid color-mix(in srgb, var(--status-running) 30%, var(--color-line));
     list-style: none;
     display: flex;
     flex-direction: column;

--- a/ui/src/lib/components/IssuesPanel.browser.test.ts
+++ b/ui/src/lib/components/IssuesPanel.browser.test.ts
@@ -603,6 +603,35 @@ describe("IssuesPanel expandEpic", () => {
     expect(mockEpic).toHaveBeenCalledWith("/repo", 327);
   });
 
+  // Cheap regression guard for the open-epic group container (#1808): the wrapper
+  // only reads as one bounded unit while `epic-open` is on it. This asserts the hook
+  // exists and tracks the toggle — it does NOT prove the visual result, which rests
+  // on the design tokens and review.
+  it("marks the wrapper epic-open only while the epic is expanded", async () => {
+    mockIssues.mockResolvedValue({
+      slug: "acme/repo",
+      webUrl: null,
+      issues: [issue(327), issue(400)],
+      viewer: null,
+    });
+    mockEpics.mockResolvedValue({ epics: [summary(327)], subIssues: [] });
+    mockEpic.mockResolvedValue(epic(327));
+
+    render(IssuesPanel, { repoPath: "/repo", onnewtask: noop, expandEpic: 327 });
+
+    const row = () => document.querySelector("#epic-issue-row-327");
+    await expect.poll(() => row()).toBeTruthy();
+
+    // Expanded (auto-expand targeted it): the wrapper is the group container.
+    await expect.poll(() => row()?.classList.contains("epic-open")).toBe(true);
+
+    // Collapsed: the container treatment is gone, so the row renders as before.
+    (document.querySelector(".epic-badge") as HTMLButtonElement).click();
+    await expect.poll(() => row()?.classList.contains("epic-open")).toBe(false);
+    // ...while it stays an epic row — only the OPEN state gained the container.
+    expect(row()?.classList.contains("is-epic")).toBe(true);
+  });
+
   it("lets the user collapse the targeted epic — it does NOT spring back open", async () => {
     mockIssues.mockResolvedValue({
       slug: "acme/repo",

--- a/ui/src/lib/components/issues-panel/IssueRow.svelte
+++ b/ui/src/lib/components/issues-panel/IssueRow.svelte
@@ -147,6 +147,7 @@
 <div
   class="issue-row"
   class:is-epic={isEpicParent}
+  class:epic-open={isEpicParent && isExpanded}
   id={`epic-issue-row-${issue.number}`}
   use:epicRowClick
   use:issueMenuTrigger={{ onopen: openMenu }}
@@ -290,6 +291,42 @@
     border-color: color-mix(in srgb, var(--status-running) 35%, var(--color-line));
     background: color-mix(in oklab, var(--status-running) 6%, var(--color-inset));
     cursor: pointer;
+  }
+
+  /* ── Open epic = one bounded group ───────────────────────────────────────
+     The wrapper (inert while collapsed) becomes the group container: it owns the
+     outline, so the closing bottom edge answers "where does the epic end". Follows
+     the .panel recipe (see /design-system) for ground + the 2px radius rung —
+     deliberately NOT --radius-chip, which app.css reserves for chips/controls.
+     The one departure is the border hue: this is a STATE surface carrying epic
+     semantics, so it mixes --status-running like .epic-badge and .is-epic do.
+     No overflow:hidden — the border draws the edge, and clipping would put the
+     fixed-position EpicDiagnosisModal (rendered inside this wrapper) one stray
+     transform/filter away from being clipped.
+     The amber ground spans the PARENT issue (header + its body preview); the
+     children sit below on the panel surface. gap:0 so the two meet on a single
+     seam instead of drifting 3px apart. */
+  .issue-row.epic-open {
+    gap: 0;
+    border: 1px solid color-mix(in srgb, var(--status-running) 35%, var(--color-line));
+    border-radius: 2px;
+    background: color-mix(in oklab, var(--status-running) 6%, var(--color-inset));
+  }
+
+  /* The head becomes the group's header bar: the container draws the outline now,
+     so the row sheds its own box and inherits the container's ground. Must follow
+     .issue-row.is-epic .issue-main — equal specificity, later rule wins. */
+  .issue-row.epic-open .issue-main {
+    border-color: transparent;
+    border-radius: 0;
+    background: transparent;
+  }
+
+  /* The body preview belongs to the PARENT issue, so it stays on the amber ground
+     above the divider — never with the children. Restores the vertical rhythm the
+     container's gap:0 removes. */
+  .issue-row.epic-open .body-preview {
+    margin-top: 4px;
   }
 
   .issue-num {
@@ -491,9 +528,21 @@
     background: color-mix(in oklab, var(--status-running) 22%, transparent);
   }
 
+  /* The children's panel surface, and the single head↔children divider. Both live
+     here rather than on EpicPanel's .epic because this node is present in BOTH
+     branches — .epic renders only once the epic resolves, so a divider hung there
+     would vanish under the loading line. (Previously .epic carried a border-top of
+     its own on top of this one: two rules ~6px apart, which is what made the open
+     epic read as loose blocks.) */
   [data-epic-panel] {
-    padding-top: 6px;
-    border-top: 1px solid var(--color-line);
+    border-top: 1px solid color-mix(in srgb, var(--status-running) 25%, var(--color-line));
+    background: var(--color-panel);
+  }
+
+  /* The loading line stands in for .epic, so it borrows .epic's panel padding
+     (8px 10px) instead of sitting flush against the divider. */
+  .issue-row.epic-open .muted {
+    padding: 8px 10px;
   }
 
   @container issue-list-row (max-width: 560px) {


### PR DESCRIPTION
An expanded epic in the backlog issues list was hard to read as one thing. Reported: you can't tell which children belong to the epic, you can't see where the group ends, and the head itself is too inconspicuous.

## Why it happened

Three things in the code, all in the open state:

- **Nothing framed it.** The `.issue-row` wrapper had no rendering of its own — so there was no bottom edge to answer "where does the epic end", and a `gap: 3px` pushed head and panel apart.
- **A doubled divider.** `[data-epic-panel]` *and* `.epic` each carried their own `border-top` — two rules ~6px apart, which is what made the epic read as loose blocks.
- **The head looked finished, not opened.** It inherits `.issue-list-row`, so it's a closed 2px-radius box; expanding only darkened the badge fill.

## What changed

The wrapper becomes the group container: it owns the outline, so its bottom edge closes the group, and the head sheds its own box to read as a header bar. The amber ground now spans the **parent issue** (head + its body preview); the **children** sit below on the panel surface behind a **single** divider, with a rail marking them off from their siblings in that panel (`3/7 MERGED`/`Diagnose` above, `Start`/`Pause` below).

The divider and panel ground moved onto `[data-epic-panel]` rather than `.epic`, because that node is present in **both** branches — `.epic` renders only once the epic resolves, so a divider hung there would vanish under the loading line.

Net effect: **one** new border, and the doubled divider reduced to one.

## Design-system notes

- Follows the `.panel` recipe for ground and the **2px** radius rung — deliberately **not** `--radius-chip`, which `app.css` reserves for chips/controls.
- **One departure, deliberate:** the border hue. This is a *state* surface carrying epic semantics, so it mixes `--status-running` like `.epic-badge` and `.issue-row.is-epic` already do. Ground and radius follow the recipe unchanged.
- **No `overflow: hidden`** — the border draws the edge, and clipping would leave the fixed-position `EpicDiagnosisModal` (rendered inside this wrapper) one stray `transform`/`filter` away from being clipped.
- **The collapsed row is deliberately untouched**, keeping #1775's "the whole row is one state surface" decision. Measured: it differs by 12 corner-antialiasing pixels of 1–2/255 (RMSE 3.9e-05) — imperceptible.

## Verification

Screenshotted the real component across the full matrix: open/collapsed × dark/light × desktop/narrow, plus body preview on/off, loading, empty child list, long (scrolling) child list, and the diagnosis modal open (confirmed unclipped, scrim blur intact).

The added test is only a cheap regression guard that `epic-open` tracks the toggle — it does not prove the visual result.

`bun run check`, `bun run test` (3945 pass), `check:i18n`, glossary, branch-hygiene and feature-catalog gates all green. No new i18n keys (CSS + one class binding). No feature-announcement entry: expanding already existed, so this is a `fix`, not a `feat` — the catalog gate confirms it's not armed.

## Follow-up observation (not fixed here)

Epics use **different hues on different surfaces**: the herd's `EpicGroupHeader.svelte:104` claims blue is "epics' semantic hue (mirrors the EpicBadge + the backlog)", but the backlog's badge is amber. I stayed amber for local consistency rather than widen scope. Worth reconciling separately.