### PR TITLE
feat(ui): unified session status bar across all session views

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -587,9 +587,17 @@ const UNAVAILABLE_USAGE: SessionUsageDto = {
  *     overlap semantics across resumes are unproven and a rollout-tree scan has no place in the
  *     UI's 5s polling path); tracked by the Codex-totals follow-up issue. */
 async function sessionUsageDto(s: Session, store: SessionStore): Promise<SessionUsageDto> {
-  if (s.status === "archived") {
+  // Snapshot rung applies only to Claude sessions: the writer never snapshots Codex, so any
+  // row under a now-Codex session is by definition from a previous (pre-replacement) cycle.
+  if (s.status === "archived" && (s.agentProvider ?? "claude") === "claude") {
     const snap = store.getSessionUsage(s.id);
-    if (snap) {
+    // Provenance guard (restore → replace → re-archive): a replaced session keeps its id but
+    // gets a NEW claudeSessionId, and its re-archive may skip snapshotting (empty/missing
+    // transcript) — the leftover row would then report the previous agent's tokens as
+    // current. Serve only a snapshot from the same agent lineage; '' = legacy row from
+    // before the provenance column, tolerated (it predates restore-with-replace staleness
+    // being reachable for it in practice, and new snapshots always stamp the id).
+    if (snap && (!snap.claudeSessionId || snap.claudeSessionId === s.claudeSessionId)) {
       return {
         available: true,
         source: "snapshot",

--- a/src/server.ts
+++ b/src/server.ts
@@ -96,7 +96,7 @@ import { listBranches } from "./branches";
 import { computeDiff, toSessionDiff } from "./diff";
 import { buildDiffNotes } from "./diff-annotations";
 import { resolveDiffBase } from "./diff-base";
-import { sessionTokens, jsonlPathFor, type SessionUsageRollup } from "./usage";
+import { readSessionUsage, jsonlPathFor, type SessionUsageRollup } from "./usage";
 import { buildUsageBreakdown } from "./usage-breakdown";
 import { buildUsageTimeline } from "./usage-timeline";
 import { isApiKeyMode } from "./spawn-auth";
@@ -548,10 +548,78 @@ export interface AppDeps {
   ) => Promise<import("./prompt-recommend").RecommendResult>;
 }
 
-const sessionUsage = (s: Session) =>
-  s.claudeSessionId
-    ? sessionTokens(jsonlPathFor(s.worktreePath, s.claudeSessionId))
-    : sessionTokens("/nonexistent"); // pre-feature session → zeroed usage
+/** Wire DTO for GET /api/sessions/:id/usage (mirrored by ui/src/lib/types.ts SessionUsage).
+ *  `available: false` is reserved for genuinely absent data — a readable-but-empty transcript
+ *  is `available: true, total: 0`. Splits/messageCount/byModel are null when the resolved
+ *  source doesn't carry them; `byModel` is always RAW tokens per model, never weighted units. */
+export interface SessionUsageDto {
+  available: boolean;
+  source: "live" | "snapshot" | "codex" | "none";
+  total: number;
+  input: number | null;
+  output: number | null;
+  cacheRead: number | null;
+  cacheWrite: number | null;
+  messageCount: number | null;
+  byModel: Record<string, number> | null;
+}
+
+const UNAVAILABLE_USAGE: SessionUsageDto = {
+  available: false,
+  source: "none",
+  total: 0,
+  input: null,
+  output: null,
+  cacheRead: null,
+  cacheWrite: null,
+  messageCount: null,
+  byModel: null,
+};
+
+/** Resolve a session's token usage through the source ladder:
+ *  1. archived → the archive-time session_usage snapshot (usage-snapshot.ts; #965 backfill);
+ *  2. snapshot-less archive → fall through to the live source (writer skips operational
+ *     archetypes / empty transcripts, and the backfill can miss);
+ *  3. Claude → live JSONL, spawn-account-aware (a swap/pool session's JSONL lives under
+ *     <spawnAccountDir>/projects — same rule as sessionDiffAnnotationsRead);
+ *  4. Codex → unavailable: per-session state-DB totals are deliberately NOT read here (thread
+ *     overlap semantics across resumes are unproven and a rollout-tree scan has no place in the
+ *     UI's 5s polling path); tracked by the Codex-totals follow-up issue. */
+async function sessionUsageDto(s: Session, store: SessionStore): Promise<SessionUsageDto> {
+  if (s.status === "archived") {
+    const snap = store.getSessionUsage(s.id);
+    if (snap) {
+      return {
+        available: true,
+        source: "snapshot",
+        total: snap.total,
+        input: snap.input,
+        output: snap.output,
+        cacheRead: snap.cacheRead,
+        cacheWrite: snap.cacheWrite,
+        messageCount: snap.messageCount,
+        // The snapshot's byModel holds WEIGHTED UNITS per model (SessionUsageSnapshot), which
+        // must never be served in this raw-token field.
+        byModel: null,
+      };
+    }
+  }
+  if ((s.agentProvider ?? "claude") === "codex") return UNAVAILABLE_USAGE;
+  if (!s.claudeSessionId) return UNAVAILABLE_USAGE; // pre-feature session: no pinned id
+  const u = await readSessionUsage(s.worktreePath, s.claudeSessionId, s.spawnAccountDir);
+  if (!u) return UNAVAILABLE_USAGE;
+  return {
+    available: true,
+    source: "live",
+    total: u.total,
+    input: u.input,
+    output: u.output,
+    cacheRead: u.cacheRead,
+    cacheWrite: u.cacheWrite,
+    messageCount: u.messageCount,
+    byModel: u.byModel,
+  };
+}
 
 const json = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
@@ -2111,7 +2179,7 @@ async function handleSessionCreate({ req, parts, deps }: Ctx): Promise<Response 
 
 async function sessionUsageRead(id: string, deps: AppDeps): Promise<Response> {
   const s = deps.store.get(id);
-  return s ? json(await sessionUsage(s)) : json({ error: "not found" }, 404);
+  return s ? json(await sessionUsageDto(s, deps.store)) : json({ error: "not found" }, 404);
 }
 
 async function sessionActivityRead(id: string, deps: AppDeps): Promise<Response> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -548,11 +548,12 @@ export interface AppDeps {
   ) => Promise<import("./prompt-recommend").RecommendResult>;
 }
 
-/** Wire DTO for GET /api/sessions/:id/usage (mirrored by ui/src/lib/types.ts SessionUsage).
+/** Wire DTO for GET /api/sessions/:id/usage (mirrored by ui/src/lib/types.ts SessionUsage —
+ *  the two trees don't share a build, so the shape is deliberately not exported/imported).
  *  `available: false` is reserved for genuinely absent data — a readable-but-empty transcript
  *  is `available: true, total: 0`. Splits/messageCount/byModel are null when the resolved
  *  source doesn't carry them; `byModel` is always RAW tokens per model, never weighted units. */
-export interface SessionUsageDto {
+interface SessionUsageDto {
   available: boolean;
   source: "live" | "snapshot" | "codex" | "none";
   total: number;

--- a/src/store.ts
+++ b/src/store.ts
@@ -4990,6 +4990,15 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     }));
   }
 
+  /** One session's archive-time usage snapshot, or null when none was recorded
+   *  (writer skips operational archetypes / empty transcripts; backfill can miss). */
+  getSessionUsage(sessionId: string): SessionUsageSnapshot | null {
+    const row = this.db
+      .query(`SELECT * FROM session_usage WHERE sessionId = ?`)
+      .get(sessionId) as SessionUsageRow | null;
+    return row ? { ...row, byModel: JSON.parse(row.byModel) as Record<string, number> } : null;
+  }
+
   // ── per-session usage buckets ────────────────────────────────────────────────
 
   /** Replace all bucket rows for sessionId atomically.

--- a/src/store.ts
+++ b/src/store.ts
@@ -2348,6 +2348,11 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       now,
       id,
     ]);
+    // The archive-time usage snapshot is stale the moment the session is live again (a
+    // replace can even swap its provider/lineage). Drop it so the archived-usage read can't
+    // serve a pre-restore row — including a legacy blank-provenance one — as current; the
+    // next archive re-snapshots the cumulative transcript.
+    this.deleteSessionUsage(id);
   }
 
   // ── usage limit caps (CapStore) ──────────────────────────────────────────
@@ -5005,6 +5010,15 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       .query(`SELECT * FROM session_usage WHERE sessionId = ?`)
       .get(sessionId) as SessionUsageRow | null;
     return row ? { ...row, byModel: JSON.parse(row.byModel) as Record<string, number> } : null;
+  }
+
+  /** Drop a session's archive-time usage snapshot (+ its buckets via FK cascade). Called on
+   *  restore/unarchive: the snapshot is archive-final, so once the session is live again it is
+   *  provisional — the next archive re-snapshots the (cumulative) transcript. This closes the
+   *  restore → replace → re-archive-with-skipped-snapshot staleness: a legacy blank-provenance
+   *  row can't survive a restore to be served as the replacement's usage. Idempotent. */
+  deleteSessionUsage(sessionId: string): void {
+    this.db.run(`DELETE FROM session_usage WHERE sessionId = ?`, [sessionId]);
   }
 
   // ── per-session usage buckets ────────────────────────────────────────────────

--- a/src/store.ts
+++ b/src/store.ts
@@ -1271,6 +1271,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
       sessionId      TEXT PRIMARY KEY,
       desig          TEXT NOT NULL,
       name           TEXT NOT NULL DEFAULT '',
+      claudeSessionId TEXT NOT NULL DEFAULT '',
       repoPath       TEXT NOT NULL,
       model          TEXT NOT NULL,
       input          INTEGER NOT NULL,
@@ -1306,6 +1307,11 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     const usageCols = this.db.query(`PRAGMA table_info(session_usage)`).all() as { name: string }[];
     if (!usageCols.some((c) => c.name === "name")) {
       this.db.run(`ALTER TABLE session_usage ADD COLUMN name TEXT NOT NULL DEFAULT ''`);
+    }
+    // provenance column (see SessionUsageRow.claudeSessionId): legacy rows default to '',
+    // which the archived-usage read tolerates as "pre-provenance"
+    if (!usageCols.some((c) => c.name === "claudeSessionId")) {
+      this.db.run(`ALTER TABLE session_usage ADD COLUMN claudeSessionId TEXT NOT NULL DEFAULT ''`);
     }
   }
 
@@ -4939,12 +4945,13 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
   upsertSessionUsage(snap: SessionUsageSnapshot): void {
     this.db.run(
       `INSERT INTO session_usage
-         (sessionId, desig, name, repoPath, model, input, output, cacheRead, cacheWrite, total,
+         (sessionId, desig, name, claudeSessionId, repoPath, model, input, output, cacheRead, cacheWrite, total,
           weightedUnits, cacheReadUnits, messageCount, byModel, createdAt, archivedAt, snapshotAt)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
        ON CONFLICT(sessionId) DO UPDATE SET
          desig = excluded.desig,
          name = excluded.name,
+         claudeSessionId = excluded.claudeSessionId,
          repoPath = excluded.repoPath,
          model = excluded.model,
          input = excluded.input,
@@ -4963,6 +4970,7 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
         snap.sessionId,
         snap.desig,
         snap.name,
+        snap.claudeSessionId ?? "",
         snap.repoPath,
         snap.model,
         snap.input,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1064,6 +1064,11 @@ export interface SessionUsageRow {
   sessionId: string;
   desig: string;
   name: string;
+  /** Provenance: the pinned claude session id the snapshot was taken from ('' on legacy
+   *  pre-provenance rows). Guards the archived-usage read against serving a stale row
+   *  after a restore → replace → re-archive cycle (the replacement gets a new id, and a
+   *  Codex replacement never snapshots at all). */
+  claudeSessionId: string;
   repoPath: string;
   model: string;
   input: number;
@@ -1085,6 +1090,9 @@ export interface SessionUsageSnapshot {
   sessionId: string;
   desig: string;
   name: string;
+  /** Provenance guard (see SessionUsageRow.claudeSessionId); optional so legacy fixtures
+   *  and pre-migration rows (which read back as '') need no change. */
+  claudeSessionId?: string;
   repoPath: string;
   model: string;
   input: number;

--- a/src/usage-snapshot.ts
+++ b/src/usage-snapshot.ts
@@ -75,6 +75,9 @@ export async function snapshotSessionUsage(
       sessionId: s.id,
       desig: s.desig,
       name: s.name,
+      // Provenance: ties this snapshot to the agent lineage it measured, so the archived-
+      // usage read can reject it after a restore → replace → re-archive cycle.
+      claudeSessionId: s.claudeSessionId,
       repoPath: s.repoPath,
       model,
       input: agg.input,

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -7,6 +7,7 @@ import {
   realpathSync,
   statSync,
   readFileSync,
+  writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
@@ -204,7 +205,7 @@ test("POST /api/usage/refresh without refreshUsage falls back to current limits 
   });
 });
 
-test("GET /api/sessions/:id/usage returns zeroed usage for a session w/o JSONL", async () => {
+test("GET /api/sessions/:id/usage is unavailable (not fake zero) for a session w/o JSONL", async () => {
   const app = harness();
   const created = await (
     await postSessions(app, { repoPath: validRepo, baseBranch: "main", prompt: "go" })
@@ -212,8 +213,145 @@ test("GET /api/sessions/:id/usage returns zeroed usage for a session w/o JSONL",
   const res = await app.fetch(new Request(`http://x/api/sessions/${created.id}/usage`));
   expect(res.status).toBe(200);
   const u = await res.json();
+  expect(u.available).toBe(false);
+  expect(u.source).toBe("none");
+  expect(u.total).toBe(0);
+  expect(u.messageCount).toBeNull();
+  expect(u.byModel).toBeNull();
+});
+
+// Base row for direct-store usage-ladder tests (bypasses the spawn path).
+const USAGE_SESSION = {
+  name: "u",
+  prompt: "u",
+  repoPath: "/r",
+  baseBranch: "main",
+  branch: "shepherd/u",
+  worktreePath: "/wt-usage",
+  isolated: true,
+  herdrSession: "default",
+  herdrAgentId: "term_u",
+};
+
+test("usage ladder: archived session serves its snapshot — raw fields, byModel withheld", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  const s = deps.store.create({
+    ...USAGE_SESSION,
+    claudeSessionId: "c0ffee00-0000-4000-8000-000000000001",
+  });
+  deps.store.update(s.id, { status: "archived" });
+  deps.store.upsertSessionUsage({
+    sessionId: s.id,
+    desig: s.desig,
+    name: s.name,
+    repoPath: s.repoPath,
+    model: "opus",
+    input: 10,
+    output: 20,
+    cacheRead: 30,
+    cacheWrite: 40,
+    total: 100,
+    weightedUnits: 7,
+    cacheReadUnits: 3,
+    messageCount: 5,
+    byModel: { opus: 7 }, // weighted units — must NOT surface in the raw-token DTO field
+    createdAt: s.createdAt,
+    archivedAt: s.createdAt + 1000,
+    snapshotAt: s.createdAt + 1000,
+  });
+  const u = await (await app.fetch(new Request(`http://x/api/sessions/${s.id}/usage`))).json();
+  expect(u).toEqual({
+    available: true,
+    source: "snapshot",
+    total: 100,
+    input: 10,
+    output: 20,
+    cacheRead: 30,
+    cacheWrite: 40,
+    messageCount: 5,
+    byModel: null,
+  });
+});
+
+test("usage ladder: snapshot-less archive falls back to the live source (here: unavailable)", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  const s = deps.store.create({
+    ...USAGE_SESSION,
+    claudeSessionId: "c0ffee00-0000-4000-8000-000000000002",
+  });
+  deps.store.update(s.id, { status: "archived" });
+  const u = await (await app.fetch(new Request(`http://x/api/sessions/${s.id}/usage`))).json();
+  expect(u.available).toBe(false);
+  expect(u.source).toBe("none");
+});
+
+test("usage ladder: live JSONL resolves under the spawn account dir (raw byModel served)", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  // Swap/pool-account session: its JSONL lives under <spawnAccountDir>/projects, NOT the
+  // default claude projects dir — the exact resolution the old endpoint silently missed.
+  const accountDir = join(tmpRoot, "swap-account");
+  const sid = "c0ffee00-0000-4000-8000-000000000003";
+  const jsonlDir = join(accountDir, "projects", "-wt-usage"); // dashify("/wt-usage")
+  mkdirSync(jsonlDir, { recursive: true });
+  const line = JSON.stringify({
+    type: "assistant",
+    requestId: "req_1",
+    message: { model: "fable", usage: { input_tokens: 5, output_tokens: 7 } },
+  });
+  writeFileSync(join(jsonlDir, `${sid}.jsonl`), `${line}\n`);
+  const s = deps.store.create({ ...USAGE_SESSION, claudeSessionId: sid });
+  deps.store.setSpawnIdentity(s.id, "term_u", accountDir);
+  const u = await (await app.fetch(new Request(`http://x/api/sessions/${s.id}/usage`))).json();
+  expect(u.available).toBe(true);
+  expect(u.source).toBe("live");
+  expect(u.total).toBe(12);
+  expect(u.input).toBe(5);
+  expect(u.output).toBe(7);
+  expect(u.messageCount).toBe(1);
+  expect(u.byModel).toEqual({ fable: 12 }); // raw tokens per model
+});
+
+test("usage ladder: readable-but-empty transcript is a true zero, not unavailable", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  const accountDir = join(tmpRoot, "swap-account-empty");
+  const sid = "c0ffee00-0000-4000-8000-000000000004";
+  const jsonlDir = join(accountDir, "projects", "-wt-usage");
+  mkdirSync(jsonlDir, { recursive: true });
+  writeFileSync(join(jsonlDir, `${sid}.jsonl`), "");
+  const s = deps.store.create({ ...USAGE_SESSION, claudeSessionId: sid });
+  deps.store.setSpawnIdentity(s.id, "term_u", accountDir);
+  const u = await (await app.fetch(new Request(`http://x/api/sessions/${s.id}/usage`))).json();
+  expect(u.available).toBe(true); // the source exists — zero is a real reading
+  expect(u.source).toBe("live");
   expect(u.total).toBe(0);
   expect(u.messageCount).toBe(0);
+});
+
+test("usage ladder: codex session is honestly unavailable — no state-DB or rollout access", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  // The codex branch must short-circuit BEFORE any filesystem source: per-session state-DB
+  // totals are deliberately out of scope (unproven thread-overlap semantics across resumes,
+  // and no tree scan belongs in the UI's 5s polling path — see the codex-totals follow-up
+  // issue). The exact all-null DTO below is the wire contract for that boundary; a future
+  // scan would surface here as available:true / a non-"none" source.
+  const s = deps.store.create({ ...USAGE_SESSION, agentProvider: "codex" as const });
+  const u = await (await app.fetch(new Request(`http://x/api/sessions/${s.id}/usage`))).json();
+  expect(u).toEqual({
+    available: false,
+    source: "none",
+    total: 0,
+    input: null,
+    output: null,
+    cacheRead: null,
+    cacheWrite: null,
+    messageCount: null,
+    byModel: null,
+  });
 });
 
 test("GET /api/sessions/:id/activity returns [] for a session w/o JSONL", async () => {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -302,7 +302,7 @@ function usageSnapFor(
   };
 }
 
-test("usage ladder: restore → replace with codex → re-archive rejects the stale snapshot", async () => {
+test("usage ladder: restore drops the snapshot, so a codex re-archive can't serve stale tokens", async () => {
   const deps = makeDeps();
   const app = makeApp(deps);
   // First life: claude session, archived with a snapshot.
@@ -310,37 +310,59 @@ test("usage ladder: restore → replace with codex → re-archive rejects the st
     ...USAGE_SESSION,
     claudeSessionId: "c0ffee00-0000-4000-8000-00000000000a",
   });
+  deps.store.archive(s.id);
   deps.store.upsertSessionUsage(usageSnapFor(s, s.claudeSessionId));
-  // Restored, replaced with a Codex agent (claudeSessionId cleared), archived again — the
-  // snapshot writer skips codex, so the old claude row is all that exists. It must NOT be
-  // reported as this archive's usage.
-  deps.store.update(s.id, { status: "archived", claudeSessionId: "", agentProvider: "codex" });
+  // Restore via the REAL transition (unarchive): the snapshot is dropped as provisional.
+  deps.store.unarchive(s.id);
+  expect(deps.store.getSessionUsage(s.id)).toBeNull();
+  // Replaced with a Codex agent and re-archived; the snapshot writer skips codex, so no new
+  // row is written. The read must report honest unavailability, not the pre-restore tokens.
+  deps.store.update(s.id, { claudeSessionId: "", agentProvider: "codex" });
+  deps.store.archive(s.id);
   const u = await (await app.fetch(new Request(`http://x/api/sessions/${s.id}/usage`))).json();
   expect(u.available).toBe(false);
   expect(u.source).toBe("none");
 });
 
-test("usage ladder: restore → replace (new claude id, no transcript) → re-archive rejects the stale snapshot", async () => {
+test("usage ladder: restore drops even a legacy blank-provenance snapshot before a transcript-less re-archive", async () => {
   const deps = makeDeps();
   const app = makeApp(deps);
   const s = deps.store.create({
     ...USAGE_SESSION,
     claudeSessionId: "c0ffee00-0000-4000-8000-00000000000b",
   });
-  deps.store.upsertSessionUsage(usageSnapFor(s, s.claudeSessionId));
-  // Replacement pinned a fresh claudeSessionId whose transcript never materialized; the
-  // re-archive snapshot skipped. The old-lineage row must not surface — the ladder falls
-  // through to the (missing) live JSONL and reports honest unavailability.
-  deps.store.update(s.id, {
-    status: "archived",
-    claudeSessionId: "c0ffee00-0000-4000-8000-00000000000c",
-  });
+  deps.store.archive(s.id);
+  // A pre-migration row (blank provenance) — the case the read guard tolerates. It must still
+  // not survive a restore.
+  deps.store.upsertSessionUsage(usageSnapFor(s, ""));
+  deps.store.unarchive(s.id);
+  expect(deps.store.getSessionUsage(s.id)).toBeNull();
+  // Replacement pinned a fresh claudeSessionId whose transcript never materialized; re-archive
+  // snapshots nothing. The stale blank row is gone → honest unavailability.
+  deps.store.update(s.id, { claudeSessionId: "c0ffee00-0000-4000-8000-00000000000c" });
+  deps.store.archive(s.id);
   const u = await (await app.fetch(new Request(`http://x/api/sessions/${s.id}/usage`))).json();
   expect(u.available).toBe(false);
   expect(u.source).toBe("none");
 });
 
-test("usage ladder: legacy pre-provenance snapshot ('' claudeSessionId) is still served", async () => {
+test("usage ladder: a stamped snapshot from a different claude lineage is rejected", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  const s = deps.store.create({
+    ...USAGE_SESSION,
+    claudeSessionId: "c0ffee00-0000-4000-8000-00000000000e",
+  });
+  deps.store.update(s.id, { status: "archived" });
+  // Row stamped with a PRIOR lineage id while the session now carries a different one — the
+  // provenance guard rejects it outright (independent of the unarchive drop above).
+  deps.store.upsertSessionUsage(usageSnapFor(s, "c0ffee00-0000-4000-8000-00000000000f"));
+  const u = await (await app.fetch(new Request(`http://x/api/sessions/${s.id}/usage`))).json();
+  expect(u.available).toBe(false);
+  expect(u.source).toBe("none");
+});
+
+test("usage ladder: legacy pre-provenance snapshot ('' claudeSessionId) on a never-restored archive is served", async () => {
   const deps = makeDeps();
   const app = makeApp(deps);
   const s = deps.store.create({
@@ -348,7 +370,7 @@ test("usage ladder: legacy pre-provenance snapshot ('' claudeSessionId) is still
     claudeSessionId: "c0ffee00-0000-4000-8000-00000000000d",
   });
   deps.store.update(s.id, { status: "archived" });
-  deps.store.upsertSessionUsage(usageSnapFor(s, "")); // pre-migration row shape
+  deps.store.upsertSessionUsage(usageSnapFor(s, "")); // pre-migration row shape, never restored
   const u = await (await app.fetch(new Request(`http://x/api/sessions/${s.id}/usage`))).json();
   expect(u.available).toBe(true);
   expect(u.source).toBe("snapshot");

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -245,6 +245,7 @@ test("usage ladder: archived session serves its snapshot — raw fields, byModel
     sessionId: s.id,
     desig: s.desig,
     name: s.name,
+    claudeSessionId: s.claudeSessionId, // same-lineage provenance → served
     repoPath: s.repoPath,
     model: "opus",
     input: 10,
@@ -272,6 +273,86 @@ test("usage ladder: archived session serves its snapshot — raw fields, byModel
     messageCount: 5,
     byModel: null,
   });
+});
+
+// Minimal snapshot row for the provenance tests below.
+function usageSnapFor(
+  s: { id: string; desig: string; name: string; repoPath: string; createdAt: number },
+  claudeSessionId: string,
+): Parameters<import("../src/store").SessionStore["upsertSessionUsage"]>[0] {
+  return {
+    sessionId: s.id,
+    desig: s.desig,
+    name: s.name,
+    claudeSessionId,
+    repoPath: s.repoPath,
+    model: "opus",
+    input: 10,
+    output: 20,
+    cacheRead: 30,
+    cacheWrite: 40,
+    total: 100,
+    weightedUnits: 7,
+    cacheReadUnits: 3,
+    messageCount: 5,
+    byModel: { opus: 7 },
+    createdAt: s.createdAt,
+    archivedAt: s.createdAt + 1000,
+    snapshotAt: s.createdAt + 1000,
+  };
+}
+
+test("usage ladder: restore → replace with codex → re-archive rejects the stale snapshot", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  // First life: claude session, archived with a snapshot.
+  const s = deps.store.create({
+    ...USAGE_SESSION,
+    claudeSessionId: "c0ffee00-0000-4000-8000-00000000000a",
+  });
+  deps.store.upsertSessionUsage(usageSnapFor(s, s.claudeSessionId));
+  // Restored, replaced with a Codex agent (claudeSessionId cleared), archived again — the
+  // snapshot writer skips codex, so the old claude row is all that exists. It must NOT be
+  // reported as this archive's usage.
+  deps.store.update(s.id, { status: "archived", claudeSessionId: "", agentProvider: "codex" });
+  const u = await (await app.fetch(new Request(`http://x/api/sessions/${s.id}/usage`))).json();
+  expect(u.available).toBe(false);
+  expect(u.source).toBe("none");
+});
+
+test("usage ladder: restore → replace (new claude id, no transcript) → re-archive rejects the stale snapshot", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  const s = deps.store.create({
+    ...USAGE_SESSION,
+    claudeSessionId: "c0ffee00-0000-4000-8000-00000000000b",
+  });
+  deps.store.upsertSessionUsage(usageSnapFor(s, s.claudeSessionId));
+  // Replacement pinned a fresh claudeSessionId whose transcript never materialized; the
+  // re-archive snapshot skipped. The old-lineage row must not surface — the ladder falls
+  // through to the (missing) live JSONL and reports honest unavailability.
+  deps.store.update(s.id, {
+    status: "archived",
+    claudeSessionId: "c0ffee00-0000-4000-8000-00000000000c",
+  });
+  const u = await (await app.fetch(new Request(`http://x/api/sessions/${s.id}/usage`))).json();
+  expect(u.available).toBe(false);
+  expect(u.source).toBe("none");
+});
+
+test("usage ladder: legacy pre-provenance snapshot ('' claudeSessionId) is still served", async () => {
+  const deps = makeDeps();
+  const app = makeApp(deps);
+  const s = deps.store.create({
+    ...USAGE_SESSION,
+    claudeSessionId: "c0ffee00-0000-4000-8000-00000000000d",
+  });
+  deps.store.update(s.id, { status: "archived" });
+  deps.store.upsertSessionUsage(usageSnapFor(s, "")); // pre-migration row shape
+  const u = await (await app.fetch(new Request(`http://x/api/sessions/${s.id}/usage`))).json();
+  expect(u.available).toBe(true);
+  expect(u.source).toBe("snapshot");
+  expect(u.total).toBe(100);
 });
 
 test("usage ladder: snapshot-less archive falls back to the live source (here: unavailable)", async () => {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3283,5 +3283,6 @@
   "statusbar_elapsed_live_title": "Läuft seit {elapsed}",
   "statusbar_elapsed_done_title": "Gesamtlaufzeit {elapsed}",
   "feat_session_status_bar_title": "Eine Statusleiste für jede Session",
-  "feat_session_status_bar_body": "Jede Session-Ansicht endet jetzt in derselben Statusleiste: mit welchem CLI, Modell und Aufwand der Agent läuft, sein Token-Verbrauch und wie lange er schon arbeitet. Sie bleibt auf jedem Tab und in jeder Lebensphase an Ort und Stelle – auch beim Rework, wo das Banner darüber den Reviewer zeigt, während die Leiste die Identität des Task-Agenten behält – und bei fertigen Sessions in der Done-Ansicht."
+  "feat_session_status_bar_body": "Jede Session-Ansicht endet jetzt in derselben Statusleiste: mit welchem CLI, Modell und Aufwand der Agent läuft, sein Token-Verbrauch und wie lange er schon arbeitet. Sie bleibt auf jedem Tab und in jeder Lebensphase an Ort und Stelle – auch beim Rework, wo das Banner darüber den Reviewer zeigt, während die Leiste die Identität des Task-Agenten behält – und bei fertigen Sessions in der Done-Ansicht.",
+  "statusbar_identity_title": "Konfigurierte Umgebung: {identity}. Zur Laufzeit kann beim Start ersetzt werden (Nutzungs-Downgrade, Provider-Begrenzungen), ohne diese Einstellung zu ändern."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3280,8 +3280,8 @@
   "statusbar_aria": "Session-Status",
   "statusbar_tokens_unavailable_title": "Token-Verbrauch ist für diese Session nicht verfügbar",
   "statusbar_tokens_unavailable_codex_title": "Token-Verbrauch wird für Codex-Sessions noch nicht erfasst",
-  "statusbar_elapsed_live_title": "Läuft seit {elapsed}",
-  "statusbar_elapsed_done_title": "Gesamtlaufzeit {elapsed}",
+  "statusbar_elapsed_live_title": "Session-Alter {elapsed} – Zeit seit Erstellung, nicht aktive Laufzeit",
+  "statusbar_elapsed_done_title": "Session-Alter {elapsed} – von Erstellung bis Archivierung, nicht aktive Laufzeit",
   "feat_session_status_bar_title": "Eine Statusleiste für jede Session",
   "feat_session_status_bar_body": "Jede Session-Ansicht endet jetzt in derselben Statusleiste: mit welchem CLI, Modell und Aufwand der Agent läuft, sein Token-Verbrauch und wie lange er schon arbeitet. Sie bleibt auf jedem Tab und in jeder Lebensphase an Ort und Stelle – auch beim Rework, wo das Banner darüber den Reviewer zeigt, während die Leiste die Identität des Task-Agenten behält – und bei fertigen Sessions in der Done-Ansicht.",
   "statusbar_identity_title": "Konfigurierte Umgebung: {identity}. Zur Laufzeit kann beim Start ersetzt werden (Nutzungs-Downgrade, Provider-Begrenzungen), ohne diese Einstellung zu ändern."

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3276,5 +3276,12 @@
   "diagnostics_fix_confirm_title_host_capacity": "Host-Kapazitätslimits anwenden?",
   "diagnostics_fix_confirm_run_host_capacity": "Limits anwenden",
   "diagnostics_fix_unresolved_host_capacity": "Shepherd hat die Limits angewendet, aber der Check ist weiterhin nicht OK — gib ihm einen Moment oder prüfe, ob die Unit benutzerbezogen ist.",
-  "hold_pr_conflict": "Der PR hat Merge-Konflikte — CI kann bis zum Rebase nicht laufen."
+  "hold_pr_conflict": "Der PR hat Merge-Konflikte — CI kann bis zum Rebase nicht laufen.",
+  "statusbar_aria": "Session-Status",
+  "statusbar_tokens_unavailable_title": "Token-Verbrauch ist für diese Session nicht verfügbar",
+  "statusbar_tokens_unavailable_codex_title": "Token-Verbrauch wird für Codex-Sessions noch nicht erfasst",
+  "statusbar_elapsed_live_title": "Läuft seit {elapsed}",
+  "statusbar_elapsed_done_title": "Gesamtlaufzeit {elapsed}",
+  "feat_session_status_bar_title": "Eine Statusleiste für jede Session",
+  "feat_session_status_bar_body": "Jede Session-Ansicht endet jetzt in derselben Statusleiste: mit welchem CLI, Modell und Aufwand der Agent läuft, sein Token-Verbrauch und wie lange er schon arbeitet. Sie bleibt auf jedem Tab und in jeder Lebensphase an Ort und Stelle – auch beim Rework, wo das Banner darüber den Reviewer zeigt, während die Leiste die Identität des Task-Agenten behält – und bei fertigen Sessions in der Done-Ansicht."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3277,12 +3277,12 @@
   "diagnostics_fix_confirm_run_host_capacity": "Limits anwenden",
   "diagnostics_fix_unresolved_host_capacity": "Shepherd hat die Limits angewendet, aber der Check ist weiterhin nicht OK — gib ihm einen Moment oder prüfe, ob die Unit benutzerbezogen ist.",
   "hold_pr_conflict": "Der PR hat Merge-Konflikte — CI kann bis zum Rebase nicht laufen.",
-  "statusbar_aria": "Session-Status",
+  "statusbar_aria": "Session-Status; angezeigtes Modell und Aufwand des Agenten sind die konfigurierten Werte, die zur Laufzeit beim Start ersetzt werden können",
   "statusbar_tokens_unavailable_title": "Token-Verbrauch ist für diese Session nicht verfügbar",
   "statusbar_tokens_unavailable_codex_title": "Token-Verbrauch wird für Codex-Sessions noch nicht erfasst",
   "statusbar_elapsed_live_title": "Session-Alter {elapsed} – Zeit seit Erstellung, nicht aktive Laufzeit",
   "statusbar_elapsed_done_title": "Session-Alter {elapsed} – von Erstellung bis Archivierung, nicht aktive Laufzeit",
   "feat_session_status_bar_title": "Eine Statusleiste für jede Session",
-  "feat_session_status_bar_body": "Jede Session-Ansicht endet jetzt in derselben Statusleiste: mit welchem CLI, Modell und Aufwand der Agent läuft, sein Token-Verbrauch und wie lange er schon arbeitet. Sie bleibt auf jedem Tab und in jeder Lebensphase an Ort und Stelle – auch beim Rework, wo das Banner darüber den Reviewer zeigt, während die Leiste die Identität des Task-Agenten behält – und bei fertigen Sessions in der Done-Ansicht.",
+  "feat_session_status_bar_body": "Jede Session-Ansicht endet jetzt in derselben Statusleiste: das CLI, Modell und der Aufwand, mit denen der Agent konfiguriert ist, sein Token-Verbrauch und das Session-Alter. Sie bleibt auf jedem Tab und in jeder Lebensphase an Ort und Stelle – auch beim Rework, wo das Banner darüber den Reviewer zeigt, während die Leiste die Identität des Task-Agenten behält – und bei fertigen Sessions in der Done-Ansicht.",
   "statusbar_identity_title": "Konfigurierte Umgebung: {identity}. Zur Laufzeit kann beim Start ersetzt werden (Nutzungs-Downgrade, Provider-Begrenzungen), ohne diese Einstellung zu ändern."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3280,8 +3280,8 @@
   "statusbar_aria": "Session status",
   "statusbar_tokens_unavailable_title": "Token usage is unavailable for this session",
   "statusbar_tokens_unavailable_codex_title": "Token usage isn't tracked for Codex sessions yet",
-  "statusbar_elapsed_live_title": "Running for {elapsed}",
-  "statusbar_elapsed_done_title": "Total runtime {elapsed}",
+  "statusbar_elapsed_live_title": "Session age {elapsed} — time since creation, not active runtime",
+  "statusbar_elapsed_done_title": "Session age {elapsed} — creation to archive, not active runtime",
   "feat_session_status_bar_title": "One status bar for every session",
   "feat_session_status_bar_body": "Every session view now ends in the same status strip: which CLI, model and effort the agent runs with, its token usage, and how long it has been at it. It stays put on every tab and lifecycle stage — including rework, where the banner above shows the reviewer while the strip keeps the task agent's own identity — and on finished sessions in the Done lens.",
   "statusbar_identity_title": "Configured environment: {identity}. The runtime may substitute at spawn time (usage downgrade, provider clamps) without changing this configuration."

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3276,5 +3276,12 @@
   "diagnostics_fix_confirm_title_host_capacity": "Apply host capacity limits?",
   "diagnostics_fix_confirm_run_host_capacity": "Apply limits",
   "diagnostics_fix_unresolved_host_capacity": "Shepherd applied the limits, but the check is still not OK — give it a moment, or check the unit is user-scoped.",
-  "hold_pr_conflict": "The PR has merge conflicts — CI can't run until it's rebased."
+  "hold_pr_conflict": "The PR has merge conflicts — CI can't run until it's rebased.",
+  "statusbar_aria": "Session status",
+  "statusbar_tokens_unavailable_title": "Token usage is unavailable for this session",
+  "statusbar_tokens_unavailable_codex_title": "Token usage isn't tracked for Codex sessions yet",
+  "statusbar_elapsed_live_title": "Running for {elapsed}",
+  "statusbar_elapsed_done_title": "Total runtime {elapsed}",
+  "feat_session_status_bar_title": "One status bar for every session",
+  "feat_session_status_bar_body": "Every session view now ends in the same status strip: which CLI, model and effort the agent runs with, its token usage, and how long it has been at it. It stays put on every tab and lifecycle stage — including rework, where the banner above shows the reviewer while the strip keeps the task agent's own identity — and on finished sessions in the Done lens."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3277,12 +3277,12 @@
   "diagnostics_fix_confirm_run_host_capacity": "Apply limits",
   "diagnostics_fix_unresolved_host_capacity": "Shepherd applied the limits, but the check is still not OK — give it a moment, or check the unit is user-scoped.",
   "hold_pr_conflict": "The PR has merge conflicts — CI can't run until it's rebased.",
-  "statusbar_aria": "Session status",
+  "statusbar_aria": "Session status; the agent model and effort shown are the configured values, which the runtime may substitute at spawn",
   "statusbar_tokens_unavailable_title": "Token usage is unavailable for this session",
   "statusbar_tokens_unavailable_codex_title": "Token usage isn't tracked for Codex sessions yet",
   "statusbar_elapsed_live_title": "Session age {elapsed} — time since creation, not active runtime",
   "statusbar_elapsed_done_title": "Session age {elapsed} — creation to archive, not active runtime",
   "feat_session_status_bar_title": "One status bar for every session",
-  "feat_session_status_bar_body": "Every session view now ends in the same status strip: which CLI, model and effort the agent runs with, its token usage, and how long it has been at it. It stays put on every tab and lifecycle stage — including rework, where the banner above shows the reviewer while the strip keeps the task agent's own identity — and on finished sessions in the Done lens.",
+  "feat_session_status_bar_body": "Every session view now ends in the same status strip: the CLI, model and effort the agent is configured with, its token usage, and its session age. It stays put on every tab and lifecycle stage — including rework, where the banner above shows the reviewer while the strip keeps the task agent's own identity — and on finished sessions in the Done lens.",
   "statusbar_identity_title": "Configured environment: {identity}. The runtime may substitute at spawn time (usage downgrade, provider clamps) without changing this configuration."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3283,5 +3283,6 @@
   "statusbar_elapsed_live_title": "Running for {elapsed}",
   "statusbar_elapsed_done_title": "Total runtime {elapsed}",
   "feat_session_status_bar_title": "One status bar for every session",
-  "feat_session_status_bar_body": "Every session view now ends in the same status strip: which CLI, model and effort the agent runs with, its token usage, and how long it has been at it. It stays put on every tab and lifecycle stage — including rework, where the banner above shows the reviewer while the strip keeps the task agent's own identity — and on finished sessions in the Done lens."
+  "feat_session_status_bar_body": "Every session view now ends in the same status strip: which CLI, model and effort the agent runs with, its token usage, and how long it has been at it. It stays put on every tab and lifecycle stage — including rework, where the banner above shows the reviewer while the strip keeps the task agent's own identity — and on finished sessions in the Done lens.",
+  "statusbar_identity_title": "Configured environment: {identity}. The runtime may substitute at spawn time (usage downgrade, provider clamps) without changing this configuration."
 }

--- a/ui/src/lib/components/DoneRecapPanel.browser.test.ts
+++ b/ui/src/lib/components/DoneRecapPanel.browser.test.ts
@@ -5,7 +5,38 @@ import "../../app.css";
 import DoneRecapPanel from "./DoneRecapPanel.svelte";
 import { recaps } from "$lib/recaps.svelte";
 import { m } from "$lib/paraglide/messages";
-import type { Session, Recap } from "$lib/types";
+import type { Session, Recap, SessionUsage } from "$lib/types";
+
+// Deferred-resolution mock for the status bar's usage fetch: each call parks its resolver
+// under the session id so tests control response ORDER (the stale-response test resolves
+// the first session's request last). Unresolved requests are harmless elsewhere — the pane
+// just shows its placeholder.
+const { usageResolvers } = vi.hoisted(() => ({
+  usageResolvers: new Map<string, (u: SessionUsage) => void>(),
+}));
+vi.mock(import("$lib/api"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    getSessionUsage: vi.fn(
+      (id: string) => new Promise<SessionUsage>((resolve) => usageResolvers.set(id, resolve)),
+    ),
+  };
+});
+
+function usageDto(total: number): SessionUsage {
+  return {
+    available: true,
+    source: "snapshot",
+    total,
+    input: total,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    messageCount: 1,
+    byModel: null,
+  };
+}
 
 function session(partial: Partial<Session> & { id: string }): Session {
   return {
@@ -441,5 +472,62 @@ describe("DoneRecapPanel completion source", () => {
 
     await rerender({ session: session({ id: "source", archiveReason: null }) });
     await expect.element(page.getByText("Completion source unknown")).toBeInTheDocument();
+  });
+});
+
+describe("DoneRecapPanel status bar", () => {
+  beforeEach(() => usageResolvers.clear());
+
+  it("pins the status bar while an overflowing body scrolls (constrained height)", async () => {
+    recaps.map = {
+      pin: recap({
+        sessionId: "pin",
+        changedFiles: Array.from({ length: 80 }, (_, i) => `src/deep/path/file-${i}.ts`),
+      }),
+    };
+    const { container } = await render(DoneRecapPanel, {
+      session: session({ id: "pin", status: "archived", model: "opus" }),
+    });
+    // Constrain the mount like the Done lens does (flex column of fixed height).
+    const mount = container as HTMLElement;
+    mount.style.display = "flex";
+    mount.style.flexDirection = "column";
+    mount.style.height = "300px";
+    await expect.element(page.getByText("src/deep/path/file-0.ts")).toBeInTheDocument();
+
+    const panel = mount.querySelector(".done-recap") as HTMLElement;
+    const body = mount.querySelector(".dr-body") as HTMLElement;
+    const bar = mount.querySelector(".ssb") as HTMLElement;
+    expect(bar, "status bar renders").not.toBeNull();
+    // The body overflows and owns the scrolling; the panel itself does not scroll.
+    expect(body.scrollHeight).toBeGreaterThan(body.clientHeight);
+    expect(panel.scrollHeight).toBe(panel.clientHeight);
+    // The pinned bar sits fully inside the visible panel box.
+    const panelRect = panel.getBoundingClientRect();
+    const barRect = bar.getBoundingClientRect();
+    expect(barRect.bottom).toBeLessThanOrEqual(panelRect.bottom + 1);
+    expect(barRect.top).toBeGreaterThanOrEqual(panelRect.top);
+    // Scrolling the body must not move the pinned bar.
+    body.scrollTop = body.scrollHeight;
+    expect(bar.getBoundingClientRect().bottom).toBeCloseTo(barRect.bottom, 0);
+  });
+
+  it("drops a stale usage response after switching sessions (A resolves last)", async () => {
+    recaps.map = { ua: recap({ sessionId: "ua" }), ub: recap({ sessionId: "ub" }) };
+    const { container, rerender } = await render(DoneRecapPanel, {
+      session: session({ id: "ua", status: "archived" }),
+    });
+    // A's request is in flight (unresolved) → placeholder shows.
+    expect((container as HTMLElement).querySelector(".ssb-unavailable")).not.toBeNull();
+
+    await rerender({ session: session({ id: "ub", status: "archived" }) });
+    usageResolvers.get("ub")!(usageDto(500));
+    await expect.element(page.getByText("500 tok")).toBeInTheDocument();
+
+    // A's response arrives LAST — the dead run's alive-guard must drop it.
+    usageResolvers.get("ua")!(usageDto(999_999));
+    await new Promise((r) => setTimeout(r, 20));
+    await expect.element(page.getByText("500 tok")).toBeInTheDocument();
+    expect((container as HTMLElement).textContent).not.toContain("1M tok");
   });
 });

--- a/ui/src/lib/components/DoneRecapPanel.svelte
+++ b/ui/src/lib/components/DoneRecapPanel.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
-  import type { Session, RecapFailureCode, RecapVerdict, SessionArchiveReason } from "$lib/types";
+  import type {
+    Session,
+    SessionUsage,
+    RecapFailureCode,
+    RecapVerdict,
+    SessionArchiveReason,
+  } from "$lib/types";
   import { recaps } from "$lib/recaps.svelte";
   import { formatAgo } from "$lib/format";
   import { clock } from "$lib/now.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { getSessionUsage } from "$lib/api";
   import { recapSkipHeadline, recapSkipBody } from "$lib/recap-skip";
   import VisualReview from "./VisualReview.svelte";
+  import SessionStatusBar from "./SessionStatusBar.svelte";
 
   let {
     session,
@@ -36,6 +44,25 @@
   $effect(() => () => clearTimeout(bringBackTimer));
 
   const recap = $derived(recaps.map[session.id]);
+
+  // Usage for the pinned status bar. The panel can be re-rendered onto a DIFFERENT archived
+  // session without a remount, so the load is keyed on the derived id (a $derived only
+  // notifies on value change, mirroring Viewport's unitId note): the effect resets usage
+  // immediately on a switch and an `alive` flag drops any late response for a previous id.
+  // One-shot fetch — archived usage is snapshot-backed and static, no poll.
+  const unitId = $derived(session.id);
+  let usage = $state<SessionUsage | null>(null);
+  $effect(() => {
+    const id = unitId;
+    usage = null;
+    let alive = true;
+    getSessionUsage(id)
+      .then((u) => alive && (usage = u))
+      .catch(() => {}); // pane shows its explained "—" placeholder
+    return () => {
+      alive = false;
+    };
+  });
 
   // relative "finished X ago" from archivedAt; falls back to updatedAt when an
   // archived session somehow has no archivedAt stamp. Driven by the shared 30s
@@ -221,6 +248,10 @@
       <p class="dr-muted">{m.recap_unavailable()}</p>
     {/if}
   </div>
+
+  <!-- Same persistent status pane as the live viewport, pinned below the scrolling body:
+       finished sessions keep their model/effort/tokens/runtime glanceable. -->
+  <SessionStatusBar {session} {usage} />
 </section>
 
 <style>
@@ -230,7 +261,9 @@
     background: var(--color-panel);
     display: flex;
     flex-direction: column;
-    overflow: auto;
+    /* Scroll ownership lives in .dr-body: the panel itself must not scroll, so the
+       header and the pinned status bar stay in view while the recap body scrolls. */
+    overflow: hidden;
     min-height: 0;
     flex: 1;
   }
@@ -325,6 +358,11 @@
     flex-direction: column;
     gap: 12px;
     padding: 14px 16px;
+    /* The sole scroll container (see .done-recap): overflowing recap content scrolls
+       here while the header above and the status bar below stay pinned. */
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
   }
 
   .dr-verdict {

--- a/ui/src/lib/components/SessionStatusBar.browser.test.ts
+++ b/ui/src/lib/components/SessionStatusBar.browser.test.ts
@@ -240,8 +240,9 @@ describe("SessionStatusBar", () => {
 
   it("labels the identity as configured intent — spawn may substitute the model", async () => {
     // pushModelFlag applies usage-downgrade/availability fallbacks argv-only (never rewrites
-    // session.model), so the bar knowingly shows the CONFIGURED model with an explanatory
-    // title rather than claiming to know the effective spawn value.
+    // session.model), so the bar knowingly shows the CONFIGURED model. The caveat is carried
+    // by the segment's ACCESSIBLE NAME (aria-label), not only the mouse-hover title, so
+    // keyboard/touch/AT users get it too.
     render(SessionStatusBar, {
       session: session({ id: "l", model: "fable", effort: "high" }),
       usage: usage(),
@@ -249,27 +250,35 @@ describe("SessionStatusBar", () => {
     const id = document.querySelector(".ssb-identity") as HTMLElement;
     expect(id.textContent).toBe("Claude Code · fable · High");
     expect(id.title).toContain("Configured environment: Claude Code · fable · High");
-    expect(id.title).toContain("usage downgrade");
+    expect(id.getAttribute("aria-label")).toContain(
+      "Configured environment: Claude Code · fable · High",
+    );
+    expect(id.getAttribute("aria-label")).toContain("usage downgrade");
   });
 
   it("labels a clamped codex effort tier as configured intent", async () => {
     // Codex clamps max → high at spawn while the stored intent keeps "max" — the bar shows
-    // the stored tier, explicitly labeled as configuration, not the effective value.
+    // the stored tier, labeled as configuration in both the title and the accessible name.
     render(SessionStatusBar, {
       session: session({ id: "m", agentProvider: "codex", model: "gpt-5.5", effort: "max" }),
       usage: usage({ available: false, source: "none", total: 0 }),
     });
     const id = document.querySelector(".ssb-identity") as HTMLElement;
     expect(id.textContent).toBe("Codex · gpt-5.5 · Max");
-    expect(id.title).toContain("Configured environment: Codex · gpt-5.5 · Max");
-    expect(id.title).toContain("provider clamps");
+    expect(id.getAttribute("aria-label")).toContain(
+      "Configured environment: Codex · gpt-5.5 · Max",
+    );
+    expect(id.getAttribute("aria-label")).toContain("provider clamps");
   });
 
-  it("is a labelled group and never an ARIA live region", async () => {
+  it("group name frames the identity as configured, and never an ARIA live region", async () => {
     render(SessionStatusBar, { session: session({ id: "j" }), usage: usage() });
     const bar = document.querySelector(".ssb") as HTMLElement;
     expect(bar.getAttribute("role")).toBe("group");
-    expect(bar.getAttribute("aria-label")).toBe("Session status");
+    // The accessible group name — not just a mouse-only tooltip — states the identity is the
+    // CONFIGURED environment (finding: keyboard/touch/AT must get the caveat).
+    expect(bar.getAttribute("aria-label")).toContain("configured");
+    expect(bar.getAttribute("aria-label")).toContain("substitute");
     expect(bar.getAttribute("aria-live")).toBeNull();
     expect(document.querySelector('[role="status"]')).toBeNull();
   });

--- a/ui/src/lib/components/SessionStatusBar.browser.test.ts
+++ b/ui/src/lib/components/SessionStatusBar.browser.test.ts
@@ -99,6 +99,48 @@ describe("SessionStatusBar", () => {
     await expect.element(page.getByText("Claude Code · default · default")).toBeInTheDocument();
   });
 
+  it("replacement to provider defaults wins over stale launch metadata", async () => {
+    // "Continue with provider defaults" writes model/effort = null on the session row while
+    // the ORIGINAL launch record still says opus/high — the bar must show the defaults,
+    // not resurrect the pre-replacement environment.
+    render(SessionStatusBar, {
+      session: session({
+        id: "k",
+        model: null,
+        effort: null,
+        launchMetadata: {
+          sourceKind: "user",
+          prompt: "p",
+          issue: null,
+          attachments: [],
+          branch: { baseBranch: "main", workBranch: "feat/x", sharedCheckout: false },
+          uiState: null,
+          submittedChoices: {
+            planGateOverride: null,
+            autopilotOverride: null,
+            sandboxProfile: null,
+            model: "opus",
+            effort: "high",
+          },
+          resolvedLaunch: {
+            research: false,
+            planGateOptIn: false,
+            autopilotOptIn: false,
+            storedModel: "opus",
+            effort: "high",
+            sandboxApplied: null,
+            sandboxDegraded: false,
+            egressApplied: false,
+            egressDegraded: false,
+          },
+          agent: { provider: "claude", model: "opus", effort: "high" },
+        },
+      }),
+      usage: usage(),
+    });
+    await expect.element(page.getByText("Claude Code · default · default")).toBeInTheDocument();
+  });
+
   it("codex session renders the Codex label and the codex-specific unavailable tokens", async () => {
     render(SessionStatusBar, {
       session: session({ id: "d", agentProvider: "codex", model: "gpt-5.5" }),

--- a/ui/src/lib/components/SessionStatusBar.browser.test.ts
+++ b/ui/src/lib/components/SessionStatusBar.browser.test.ts
@@ -203,6 +203,33 @@ describe("SessionStatusBar", () => {
     await expect.element(page.getByText("1h 30m")).toBeInTheDocument();
   });
 
+  it("labels the identity as configured intent — spawn may substitute the model", async () => {
+    // pushModelFlag applies usage-downgrade/availability fallbacks argv-only (never rewrites
+    // session.model), so the bar knowingly shows the CONFIGURED model with an explanatory
+    // title rather than claiming to know the effective spawn value.
+    render(SessionStatusBar, {
+      session: session({ id: "l", model: "fable", effort: "high" }),
+      usage: usage(),
+    });
+    const id = document.querySelector(".ssb-identity") as HTMLElement;
+    expect(id.textContent).toBe("Claude Code · fable · High");
+    expect(id.title).toContain("Configured environment: Claude Code · fable · High");
+    expect(id.title).toContain("usage downgrade");
+  });
+
+  it("labels a clamped codex effort tier as configured intent", async () => {
+    // Codex clamps max → high at spawn while the stored intent keeps "max" — the bar shows
+    // the stored tier, explicitly labeled as configuration, not the effective value.
+    render(SessionStatusBar, {
+      session: session({ id: "m", agentProvider: "codex", model: "gpt-5.5", effort: "max" }),
+      usage: usage({ available: false, source: "none", total: 0 }),
+    });
+    const id = document.querySelector(".ssb-identity") as HTMLElement;
+    expect(id.textContent).toBe("Codex · gpt-5.5 · Max");
+    expect(id.title).toContain("Configured environment: Codex · gpt-5.5 · Max");
+    expect(id.title).toContain("provider clamps");
+  });
+
   it("is a labelled group and never an ARIA live region", async () => {
     render(SessionStatusBar, { session: session({ id: "j" }), usage: usage() });
     const bar = document.querySelector(".ssb") as HTMLElement;

--- a/ui/src/lib/components/SessionStatusBar.browser.test.ts
+++ b/ui/src/lib/components/SessionStatusBar.browser.test.ts
@@ -189,6 +189,41 @@ describe("SessionStatusBar", () => {
     await expect.element(page.getByText("2h 14m")).toBeInTheDocument();
   });
 
+  it("idle session shows wall-clock age labeled as session age, not runtime", async () => {
+    // No active-interval tracking exists server-side, so the value is deliberately AGE:
+    // an idle session keeps aging and the title says exactly that.
+    const M = 60_000;
+    // clock.current may lag Date.now() by up to its 30s tick — the 40s cushion keeps the
+    // minute floor at 45m for any lag in [0, 30s).
+    render(SessionStatusBar, {
+      session: session({ id: "n", status: "idle", createdAt: Date.now() - 45 * M - 40_000 }),
+      usage: usage(),
+    });
+    const el = document.querySelector(".ssb-elapsed") as HTMLElement;
+    expect(el.textContent).toBe("45m");
+    expect(el.title).toContain("Session age 45m");
+    expect(el.title).toContain("not active runtime");
+  });
+
+  it("restored session ages from creation on the live clock, not the stale archive stamp", async () => {
+    // Bring-back clears archivedAt and flips status back to running; even if a stale
+    // archivedAt survived, the live branch keys on status and must ignore it.
+    const H = 3_600_000;
+    // Same 40s cushion as above against the 30s clock lag.
+    render(SessionStatusBar, {
+      session: session({
+        id: "o",
+        status: "running",
+        createdAt: Date.now() - 3 * H - 40_000,
+        archivedAt: Date.now() - 2 * H, // stale leftover — must not cap the live age
+      }),
+      usage: usage(),
+    });
+    const el = document.querySelector(".ssb-elapsed") as HTMLElement;
+    expect(el.textContent).toBe("3h 00m"); // full age since creation, incl. archived downtime
+    expect(el.title).toContain("Session age 3h 00m");
+  });
+
   it("archived session without archivedAt falls back to updatedAt", async () => {
     render(SessionStatusBar, {
       session: session({

--- a/ui/src/lib/components/SessionStatusBar.browser.test.ts
+++ b/ui/src/lib/components/SessionStatusBar.browser.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import "../../app.css";
+import type { Session, SessionUsage } from "$lib/types";
+
+const { default: SessionStatusBar } = await import("./SessionStatusBar.svelte");
+
+function session(partial: Partial<Session> & { id: string }): Session {
+  return {
+    desig: "TASK-01",
+    name: "task one",
+    prompt: "p",
+    repoPath: "/repo/a",
+    baseBranch: "main",
+    branch: "feat/x",
+    worktreePath: "/wt",
+    isolated: true,
+    herdrSession: "h",
+    herdrAgentId: "ha",
+    claudeSessionId: "cs",
+    model: null,
+    status: "running",
+    readyToMerge: false,
+    mergingSince: null,
+    mergingTrainId: null,
+    mergeTrainPrs: null,
+    autopilotEnabled: null,
+    autopilotStepCount: 0,
+    autopilotPaused: false,
+    autopilotComplete: false,
+    autopilotQuestion: null,
+    planGateEnabled: null,
+    planPhase: null,
+    autoMergeEnabled: null,
+    autoMergeRebaseCount: 0,
+    auto: false,
+    sandboxApplied: null,
+    sandboxDegraded: false,
+    egressApplied: false,
+    egressDegraded: false,
+    research: false,
+    epicAuthoring: false,
+    issueNumber: null,
+    lastState: "",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    archivedAt: null,
+    haltReason: null,
+    haltedAt: null,
+    manualSteps: [],
+    manualStepsAckedAt: null,
+    experimentId: null,
+    experimentRole: null,
+    ...partial,
+  };
+}
+
+function usage(partial: Partial<SessionUsage> = {}): SessionUsage {
+  return {
+    available: true,
+    source: "live",
+    total: 1234,
+    input: 1000,
+    output: 234,
+    cacheRead: 0,
+    cacheWrite: 0,
+    messageCount: 3,
+    byModel: { opus: 1234 },
+    ...partial,
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("SessionStatusBar", () => {
+  it("renders identity, tokens and elapsed for a live Claude session", async () => {
+    render(SessionStatusBar, {
+      session: session({ id: "a", model: "opus", effort: "high" }),
+      usage: usage(),
+    });
+    await expect.element(page.getByText("Claude Code · opus · High")).toBeInTheDocument();
+    await expect.element(page.getByText("1.2k tok")).toBeInTheDocument();
+    await expect.element(page.getByText("0m")).toBeInTheDocument(); // createdAt = now, minute floor
+  });
+
+  it("falls back to the localized default for a null model and effort", async () => {
+    render(SessionStatusBar, { session: session({ id: "b" }), usage: usage() });
+    await expect.element(page.getByText("Claude Code · default · default")).toBeInTheDocument();
+  });
+
+  it("legacy pre-feature session (no launch metadata) still renders identity", async () => {
+    render(SessionStatusBar, {
+      session: session({ id: "c", claudeSessionId: "" }),
+      usage: null,
+    });
+    await expect.element(page.getByText("Claude Code · default · default")).toBeInTheDocument();
+  });
+
+  it("codex session renders the Codex label and the codex-specific unavailable tokens", async () => {
+    render(SessionStatusBar, {
+      session: session({ id: "d", agentProvider: "codex", model: "gpt-5.5" }),
+      usage: usage({ available: false, source: "none", total: 0 }),
+    });
+    await expect.element(page.getByText("Codex · gpt-5.5 · default")).toBeInTheDocument();
+    const dash = document.querySelector(".ssb-unavailable") as HTMLElement;
+    expect(dash.textContent).toBe("—");
+    expect(dash.title).toBe("Token usage isn't tracked for Codex sessions yet");
+  });
+
+  it("unavailable usage shows the explained dash; a true zero shows 0 tok", async () => {
+    render(SessionStatusBar, {
+      session: session({ id: "e" }),
+      usage: usage({ available: false, source: "none", total: 0 }),
+    });
+    const dash = document.querySelector(".ssb-unavailable") as HTMLElement;
+    expect(dash.textContent).toBe("—");
+    expect(dash.title).toBe("Token usage is unavailable for this session");
+    document.body.innerHTML = "";
+
+    render(SessionStatusBar, {
+      session: session({ id: "f" }),
+      usage: usage({ available: true, total: 0 }),
+    });
+    await expect.element(page.getByText("0 tok")).toBeInTheDocument();
+    expect(document.querySelector(".ssb-unavailable")).toBeNull();
+  });
+
+  it("pending usage (null) shows the dash placeholder, not a fake zero", async () => {
+    render(SessionStatusBar, { session: session({ id: "g" }), usage: null });
+    expect((document.querySelector(".ssb-unavailable") as HTMLElement).textContent).toBe("—");
+  });
+
+  it("archived session shows the static total runtime from archivedAt", async () => {
+    const H = 3_600_000;
+    render(SessionStatusBar, {
+      session: session({
+        id: "h",
+        status: "archived",
+        createdAt: 0,
+        archivedAt: 2 * H + 14 * 60_000,
+      }),
+      usage: usage({ source: "snapshot", byModel: null }),
+    });
+    await expect.element(page.getByText("2h 14m")).toBeInTheDocument();
+  });
+
+  it("archived session without archivedAt falls back to updatedAt", async () => {
+    render(SessionStatusBar, {
+      session: session({
+        id: "i",
+        status: "archived",
+        createdAt: 0,
+        archivedAt: null,
+        updatedAt: 90 * 60_000,
+      }),
+      usage: null,
+    });
+    await expect.element(page.getByText("1h 30m")).toBeInTheDocument();
+  });
+
+  it("is a labelled group and never an ARIA live region", async () => {
+    render(SessionStatusBar, { session: session({ id: "j" }), usage: usage() });
+    const bar = document.querySelector(".ssb") as HTMLElement;
+    expect(bar.getAttribute("role")).toBe("group");
+    expect(bar.getAttribute("aria-label")).toBe("Session status");
+    expect(bar.getAttribute("aria-live")).toBeNull();
+    expect(document.querySelector('[role="status"]')).toBeNull();
+  });
+});

--- a/ui/src/lib/components/SessionStatusBar.svelte
+++ b/ui/src/lib/components/SessionStatusBar.svelte
@@ -14,6 +14,12 @@
   // (provider on pre-field rows; effort is optional in the client mirror) fall back.
   // environmentLabel is the same formatter ReviewInFlightBanner uses for the reviewer, so
   // the task strip and the reviewer strip can never drift apart in wording.
+  //
+  // These are the CONFIGURED values, labeled as such via the hover title: the runtime may
+  // substitute at spawn time without rewriting them — pushModelFlag applies usage-downgrade/
+  // availability fallbacks argv-only, and Codex clamps unsupported effort tiers (max → high)
+  // while the stored intent keeps the un-clamped tier. Surfacing the EFFECTIVE spawn values
+  // needs server-side persistence across every spawn path and is tracked separately.
   const launch = $derived(session.launchMetadata ?? null);
   const provider = $derived(session.agentProvider ?? launch?.agent.provider ?? "claude");
   const identity = $derived(
@@ -23,6 +29,7 @@
       session.effort === undefined ? (launch?.resolvedLaunch.effort ?? null) : session.effort,
     ),
   );
+  const identityTitle = $derived(m.statusbar_identity_title({ identity }));
 
   // Archived sessions show a static total runtime (archivedAt ?? updatedAt matches
   // DoneRecapPanel's finishedAt fallback); live sessions tick on the shared 30s clock.
@@ -58,7 +65,7 @@
 <!-- Deliberately NOT a live region (no role="status"/aria-live): the elapsed tick and the
      usage poll would re-announce to screen readers continuously. -->
 <div class="ssb" role="group" aria-label={m.statusbar_aria()}>
-  <span class="ssb-identity" title={identity}>{identity}</span>
+  <span class="ssb-identity" title={identityTitle}>{identity}</span>
   <span class="ssb-sep" aria-hidden="true">·</span>
   {#if tokensKnown}
     <span class="ssb-tokens">{tokensText}</span>

--- a/ui/src/lib/components/SessionStatusBar.svelte
+++ b/ui/src/lib/components/SessionStatusBar.svelte
@@ -7,16 +7,20 @@
 
   let { session, usage }: { session: Session; usage: SessionUsage | null } = $props();
 
-  // Identity mirrors the metaPop fallback chain (Viewport): stored value first, then the
-  // launch record. environmentLabel is the same formatter ReviewInFlightBanner uses for the
-  // reviewer, so the task strip and the reviewer strip can never drift apart in wording.
+  // Identity reads the session row's model/effort as AUTHORITATIVE: null explicitly means
+  // "provider default" (it's what a replace/relaunch with provider defaults writes), so it
+  // must render as "default" — falling back to the original launch metadata here would
+  // resurrect the pre-replacement model forever. Only fields that can be genuinely ABSENT
+  // (provider on pre-field rows; effort is optional in the client mirror) fall back.
+  // environmentLabel is the same formatter ReviewInFlightBanner uses for the reviewer, so
+  // the task strip and the reviewer strip can never drift apart in wording.
   const launch = $derived(session.launchMetadata ?? null);
   const provider = $derived(session.agentProvider ?? launch?.agent.provider ?? "claude");
   const identity = $derived(
     environmentLabel(
       provider,
-      session.model ?? launch?.resolvedLaunch.storedModel ?? null,
-      session.effort ?? launch?.resolvedLaunch.effort ?? null,
+      session.model,
+      session.effort === undefined ? (launch?.resolvedLaunch.effort ?? null) : session.effort,
     ),
   );
 

--- a/ui/src/lib/components/SessionStatusBar.svelte
+++ b/ui/src/lib/components/SessionStatusBar.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+  import type { Session, SessionUsage } from "$lib/types";
+  import { environmentLabel } from "$lib/reviewer-env";
+  import { formatTokens, elapsedCoarse } from "$lib/format";
+  import { clock } from "$lib/now.svelte";
+  import { m } from "$lib/paraglide/messages";
+
+  let { session, usage }: { session: Session; usage: SessionUsage | null } = $props();
+
+  // Identity mirrors the metaPop fallback chain (Viewport): stored value first, then the
+  // launch record. environmentLabel is the same formatter ReviewInFlightBanner uses for the
+  // reviewer, so the task strip and the reviewer strip can never drift apart in wording.
+  const launch = $derived(session.launchMetadata ?? null);
+  const provider = $derived(session.agentProvider ?? launch?.agent.provider ?? "claude");
+  const identity = $derived(
+    environmentLabel(
+      provider,
+      session.model ?? launch?.resolvedLaunch.storedModel ?? null,
+      session.effort ?? launch?.resolvedLaunch.effort ?? null,
+    ),
+  );
+
+  // Archived sessions show a static total runtime (archivedAt ?? updatedAt matches
+  // DoneRecapPanel's finishedAt fallback); live sessions tick on the shared 30s clock.
+  // elapsedCoarse has no seconds, so the 30s tick never reads as a frozen counter.
+  const archived = $derived(session.status === "archived");
+  const elapsedText = $derived(
+    elapsedCoarse(
+      session.createdAt,
+      archived ? (session.archivedAt ?? session.updatedAt) : clock.current,
+    ),
+  );
+  const elapsedTitle = $derived(
+    archived
+      ? m.statusbar_elapsed_done_title({ elapsed: elapsedText })
+      : m.statusbar_elapsed_live_title({ elapsed: elapsedText }),
+  );
+
+  // available:false is a known boundary (Codex, pre-feature, cleaned transcript) — an
+  // explained "—", never a fake 0. A true zero reading renders "0 tok".
+  const tokensKnown = $derived(usage != null && usage.available);
+  const tokensText = $derived(
+    usage != null && usage.available
+      ? m.viewport_tokens_label({ tokens: formatTokens(usage.total) })
+      : "",
+  );
+  const tokensUnavailableTitle = $derived(
+    provider === "codex"
+      ? m.statusbar_tokens_unavailable_codex_title()
+      : m.statusbar_tokens_unavailable_title(),
+  );
+</script>
+
+<!-- Deliberately NOT a live region (no role="status"/aria-live): the elapsed tick and the
+     usage poll would re-announce to screen readers continuously. -->
+<div class="ssb" role="group" aria-label={m.statusbar_aria()}>
+  <span class="ssb-identity" title={identity}>{identity}</span>
+  <span class="ssb-sep" aria-hidden="true">·</span>
+  {#if tokensKnown}
+    <span class="ssb-tokens">{tokensText}</span>
+  {:else}
+    <span
+      class="ssb-tokens ssb-unavailable"
+      title={tokensUnavailableTitle}
+      aria-label={tokensUnavailableTitle}>—</span
+    >
+  {/if}
+  <span class="ssb-sep" aria-hidden="true">·</span>
+  <span class="ssb-elapsed" title={elapsedTitle}>{elapsedText}</span>
+</div>
+
+<style>
+  /* Same chrome recipe as .vp-foot: head wash, hairline top border, meta type. */
+  .ssb {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 12px;
+    background: var(--color-head);
+    border-top: 1px solid var(--color-line);
+    font-size: var(--fs-meta);
+    color: var(--color-muted);
+    flex-shrink: 0;
+    white-space: nowrap;
+    min-width: 0;
+  }
+
+  .ssb-identity {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+  }
+
+  .ssb-sep {
+    color: var(--color-faint);
+  }
+
+  .ssb-tokens,
+  .ssb-elapsed {
+    flex-shrink: 0;
+  }
+
+  .ssb-unavailable {
+    color: var(--color-faint);
+    cursor: help;
+  }
+</style>

--- a/ui/src/lib/components/SessionStatusBar.svelte
+++ b/ui/src/lib/components/SessionStatusBar.svelte
@@ -66,9 +66,12 @@
 </script>
 
 <!-- Deliberately NOT a live region (no role="status"/aria-live): the elapsed tick and the
-     usage poll would re-announce to screen readers continuously. -->
+     usage poll would re-announce to screen readers continuously.
+     The group name and the identity segment's accessible name both carry the configured-
+     intent caveat (not just the mouse-only hover title), so keyboard/touch/AT users get it
+     too — the runtime may substitute model/effort at spawn without rewriting the row. -->
 <div class="ssb" role="group" aria-label={m.statusbar_aria()}>
-  <span class="ssb-identity" title={identityTitle}>{identity}</span>
+  <span class="ssb-identity" title={identityTitle} aria-label={identityTitle}>{identity}</span>
   <span class="ssb-sep" aria-hidden="true">·</span>
   {#if tokensKnown}
     <span class="ssb-tokens">{tokensText}</span>

--- a/ui/src/lib/components/SessionStatusBar.svelte
+++ b/ui/src/lib/components/SessionStatusBar.svelte
@@ -31,9 +31,12 @@
   );
   const identityTitle = $derived(m.statusbar_identity_title({ identity }));
 
-  // Archived sessions show a static total runtime (archivedAt ?? updatedAt matches
-  // DoneRecapPanel's finishedAt fallback); live sessions tick on the shared 30s clock.
-  // elapsedCoarse has no seconds, so the 30s tick never reads as a frozen counter.
+  // The elapsed segment is SESSION AGE — wall-clock since createdAt (to archive time for
+  // archived sessions; archivedAt ?? updatedAt matches DoneRecapPanel's finishedAt
+  // fallback) — and its titles say so explicitly: idle stretches and pre-restore downtime
+  // are included, because no active-interval tracking exists server-side. Live sessions
+  // tick on the shared 30s clock; elapsedCoarse has no seconds, so the tick never reads
+  // as a frozen counter.
   const archived = $derived(session.status === "archived");
   const elapsedText = $derived(
     elapsedCoarse(

--- a/ui/src/lib/components/Viewport.browser.test.ts
+++ b/ui/src/lib/components/Viewport.browser.test.ts
@@ -852,6 +852,33 @@ describe("Viewport active REWORK terminal strip", () => {
     );
   });
 
+  it("keeps the session's OWN model visible in the status bar during active rework", async () => {
+    // The regression this feature exists to prevent: the rework strip shows the REVIEWER's
+    // env, and the task agent's identity used to hide in the hover-only metaPop.
+    const id = "rw-status-bar";
+    planGates.map = { [id]: planGate({ sessionId: id, round: 1, cap: 5 }) };
+
+    const { container } = await render(Viewport, {
+      session: session({
+        id,
+        status: "running",
+        planPhase: "planning",
+        model: "opus",
+        effort: "high",
+      }),
+      activity: activity("edited .shepherd-plan.md"),
+      previewPort: null,
+      openPreviewTick: 0,
+    });
+
+    await expect
+      .element(page.getByText("REWORK · 1/5 · edited .shepherd-plan.md"))
+      .toBeInTheDocument();
+    const bar = container.querySelector(".ssb");
+    expect(bar, "status bar renders alongside the rework strip").not.toBeNull();
+    expect(bar!.textContent).toContain("Claude Code · opus · High");
+  });
+
   it("hides parked plan-gate rework", async () => {
     const id = "rw-plan-parked";
     planGates.map = { [id]: planGate({ sessionId: id, round: 1, cap: 5 }) };
@@ -970,6 +997,37 @@ describe("Viewport active REWORK terminal strip", () => {
 // the touch starts inside `.vp-body` (tagged data-swipe-page); all chrome is excluded
 // by omission. The handler reads e.touches[0].clientX/clientY on start/move and
 // nothing off touchend, so we dispatch bubbling Events with a `touches` shim.
+describe("Viewport usage refetch on session switch", () => {
+  it("refetches usage for the new session when the session prop switches", async () => {
+    // +page.svelte updates the SAME Viewport instance's session prop on unit switch
+    // (no {#key}), so the usage effect must re-key on session.id — otherwise the
+    // status bar keeps polling (and showing) the PREVIOUS session's tokens.
+    const seen: string[] = [];
+    const origFetch = window.fetch;
+    window.fetch = async (...args: Parameters<typeof fetch>) => {
+      const url = String(args[0]);
+      if (url.includes("/usage")) seen.push(url);
+      return origFetch(...args);
+    };
+    try {
+      const { rerender } = await render(Viewport, {
+        session: session({ id: "switch-a" }),
+        previewPort: null,
+        openPreviewTick: 0,
+      });
+      await vi.waitFor(() =>
+        expect(seen.some((u) => u.includes("/sessions/switch-a/usage"))).toBe(true),
+      );
+      await rerender({ session: session({ id: "switch-b" }) });
+      await vi.waitFor(() =>
+        expect(seen.some((u) => u.includes("/sessions/switch-b/usage"))).toBe(true),
+      );
+    } finally {
+      window.fetch = origFetch;
+    }
+  });
+});
+
 describe("Viewport mobile page-swipe scoping", () => {
   // The structural-invariant test below assumes the header is expanded so
   // `.vp-git-strip` / `.bqp` render; clear the persisted collapse flag so a prior

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -770,6 +770,22 @@
   // re-run this effect on every store-driven prop churn, resetting usage to null and
   // re-fetching each tick even while the id stays put.
   let usage = $state<SessionUsage | null>(null);
+  // metaPop's split-breakdown hover title needs all four raw splits; sources that don't
+  // carry them (see SessionUsage) show the plain total with no title.
+  const usageSplitsTitle = $derived(
+    usage != null &&
+      usage.input != null &&
+      usage.output != null &&
+      usage.cacheRead != null &&
+      usage.cacheWrite != null
+      ? m.viewport_usage_title({
+          input: usage.input.toLocaleString(),
+          output: usage.output.toLocaleString(),
+          cacheRead: usage.cacheRead.toLocaleString(),
+          cacheWrite: usage.cacheWrite.toLocaleString(),
+        })
+      : undefined,
+  );
   $effect(() => {
     const id = unitId;
     usage = null;
@@ -2423,21 +2439,8 @@
         <span class="dp-section">{m.tasktip_usage()}</span>
         <span class="dp-row">
           <span class="dp-k">{m.viewport_tokens_meta_label()}</span>
-          <!-- The split-breakdown title needs all four raw splits; sources that don't carry
-               them (see SessionUsage) show the plain total without the hover breakdown. -->
-          <span
-            class="dp-v"
-            title={usage.input != null &&
-            usage.output != null &&
-            usage.cacheRead != null &&
-            usage.cacheWrite != null
-              ? m.viewport_usage_title({
-                  input: usage.input.toLocaleString(),
-                  output: usage.output.toLocaleString(),
-                  cacheRead: usage.cacheRead.toLocaleString(),
-                  cacheWrite: usage.cacheWrite.toLocaleString(),
-                })
-              : undefined}>{m.viewport_tokens_label({ tokens: formatTokens(usage.total) })}</span
+          <span class="dp-v" title={usageSplitsTitle}
+            >{m.viewport_tokens_label({ tokens: formatTokens(usage.total) })}</span
           >
         </span>
       {/if}

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -68,6 +68,7 @@
   import { recaps } from "$lib/recaps.svelte";
   import { toasts } from "$lib/toasts.svelte";
   import SteerBar from "$lib/components/SteerBar.svelte";
+  import SessionStatusBar from "$lib/components/SessionStatusBar.svelte";
   import ComposeBar from "$lib/components/ComposeBar.svelte";
   import LeftoverDialog from "$lib/components/LeftoverDialog.svelte";
   import BuildQueuePanel from "$lib/components/BuildQueuePanel.svelte";
@@ -764,10 +765,13 @@
       : null,
   );
 
-  // per-session token usage from ~/.claude JSONL; refresh on select + every 5s
+  // per-session token usage from ~/.claude JSONL; refresh on select + every 5s.
+  // Keyed on unitId (value-level, see its note above): reading session.id here would
+  // re-run this effect on every store-driven prop churn, resetting usage to null and
+  // re-fetching each tick even while the id stays put.
   let usage = $state<SessionUsage | null>(null);
   $effect(() => {
-    const id = session.id;
+    const id = unitId;
     usage = null;
     let alive = true;
     const load = () =>
@@ -2419,14 +2423,21 @@
         <span class="dp-section">{m.tasktip_usage()}</span>
         <span class="dp-row">
           <span class="dp-k">{m.viewport_tokens_meta_label()}</span>
+          <!-- The split-breakdown title needs all four raw splits; sources that don't carry
+               them (see SessionUsage) show the plain total without the hover breakdown. -->
           <span
             class="dp-v"
-            title={m.viewport_usage_title({
-              input: usage.input.toLocaleString(),
-              output: usage.output.toLocaleString(),
-              cacheRead: usage.cacheRead.toLocaleString(),
-              cacheWrite: usage.cacheWrite.toLocaleString(),
-            })}>{m.viewport_tokens_label({ tokens: formatTokens(usage.total) })}</span
+            title={usage.input != null &&
+            usage.output != null &&
+            usage.cacheRead != null &&
+            usage.cacheWrite != null
+              ? m.viewport_usage_title({
+                  input: usage.input.toLocaleString(),
+                  output: usage.output.toLocaleString(),
+                  cacheRead: usage.cacheRead.toLocaleString(),
+                  cacheWrite: usage.cacheWrite.toLocaleString(),
+                })
+              : undefined}>{m.viewport_tokens_label({ tokens: formatTokens(usage.total) })}</span
           >
         </span>
       {/if}
@@ -3049,6 +3060,13 @@
       </div>
     {/if}
   </div>
+
+  <!-- Persistent session status strip (#pane): the task agent's own identity + usage +
+       elapsed, identical on every tab and lifecycle stage — during rework/review the
+       ReviewInFlightBanner above shows the REVIEWER's env while this keeps the task's.
+       Sits between .vp-body and SteerBar/controls so the ctrl-row stays bottom-most
+       (the foldable swipe-up compose gesture starts on the bottom-most element). -->
+  <SessionStatusBar {session} {usage} />
 
   {#if tab === "term"}
     <SteerBar

--- a/ui/src/lib/demo/router.test.ts
+++ b/ui/src/lib/demo/router.test.ts
@@ -265,11 +265,25 @@ describe("session-detail tab GETs never fall back to {}", () => {
     expect(withPath.body.path).toBe("src");
   });
 
-  it("GET /api/sessions/:id/usage returns a SessionUsage record, never {}", async () => {
+  it("GET /api/sessions/:id/usage returns a full SessionUsage DTO, never {}", async () => {
     const { body } = await get("/api/sessions/coupon/usage");
     expect(typeof body.total).toBe("number");
     expect(body.total).toBeGreaterThan(0);
-    expect(typeof (await get("/api/sessions/rounding/usage")).body.total).toBe("number");
+    expect(body.available).toBe(true);
+    expect(body.source).toBe("live");
+    // seeded true zero: available with total 0 (renders "0 tok", never the placeholder)
+    const zero = (await get("/api/sessions/rounding/usage")).body;
+    expect(zero.available).toBe(true);
+    expect(zero.total).toBe(0);
+    // the one deliberately unavailable session exercises the "—" placeholder path
+    const none = (await get("/api/sessions/neon/usage")).body;
+    expect(none.available).toBe(false);
+    expect(none.source).toBe("none");
+    expect(none.byModel).toBeNull();
+    // unseeded id → the zeroed available fallback, still a full DTO
+    const unseeded = (await get("/api/sessions/not-seeded/usage")).body;
+    expect(unseeded.available).toBe(true);
+    expect(unseeded.total).toBe(0);
   });
 
   it("GET /api/sessions/:id/leftovers returns [], never {}", async () => {

--- a/ui/src/lib/demo/seed.ts
+++ b/ui/src/lib/demo/seed.ts
@@ -1479,44 +1479,59 @@ function buildScratchpad(): Record<string, ScratchListing> {
   };
 }
 
-/** GET /api/sessions/:id/usage — per-session token usage badge (polled while a session is
- *  open). Only the hero has meaningfully large numbers; everyone else is a valid zeroed
- *  record (`usage.total > 0` gates the badge, so a zero record renders nothing — safe, not empty-object). */
+/** GET /api/sessions/:id/usage — per-session token usage (status bar + metaPop). Only the
+ *  hero has meaningfully large numbers; most others are a valid TRUE-ZERO record
+ *  (available:true, total 0 → the bar shows "0 tok", metaPop hides its row). `neon` is the
+ *  one deliberately UNAVAILABLE record so the demo exercises the status bar's explained
+ *  "—" placeholder path. */
 function buildSessionUsage(): Record<string, SessionUsage> {
   const zero: SessionUsage = {
+    available: true,
+    source: "live",
     input: 0,
     output: 0,
     cacheRead: 0,
     cacheWrite: 0,
     total: 0,
     messageCount: 0,
-    lastActivity: null,
     byModel: {},
   };
   return {
     coupon: {
+      available: true,
+      source: "live",
       input: 42_000,
       output: 8_900,
       cacheRead: 120_000,
       cacheWrite: 15_000,
       total: 185_900,
       messageCount: 34,
-      lastActivity: NOW - 20 * SEC,
       byModel: { opus: 185_900 },
     },
     "checkout-child": {
+      available: true,
+      source: "live",
       input: 9_500,
       output: 2_100,
       cacheRead: 30_000,
       cacheWrite: 4_000,
       total: 45_600,
       messageCount: 11,
-      lastActivity: NOW - 40 * SEC,
       byModel: { opus: 45_600 },
     },
     rounding: { ...zero },
     authstore: { ...zero },
-    neon: { ...zero },
+    neon: {
+      available: false,
+      source: "none",
+      input: null,
+      output: null,
+      cacheRead: null,
+      cacheWrite: null,
+      total: 0,
+      messageCount: null,
+      byModel: null,
+    },
     ogimg: { ...zero },
     deps: { ...zero },
   };

--- a/ui/src/lib/demo/state.ts
+++ b/ui/src/lib/demo/state.ts
@@ -115,16 +115,18 @@ export const demoState = {
    *  listing for a session whose scratchpad root doesn't exist yet. */
   scratchpadRoot: (id: string): ScratchListing =>
     world.scratchpad[id] ?? { path: "", parent: null, entries: [] },
-  /** GET /api/sessions/:id/usage — a zeroed (never {}) record for an unseeded session. */
+  /** GET /api/sessions/:id/usage — a zeroed (never {}) record for an unseeded session.
+   *  available:true — in the demo world the data source "exists", so zero is a true zero. */
   sessionUsage: (id: string): SessionUsage =>
     world.sessionUsage[id] ?? {
+      available: true,
+      source: "live",
       input: 0,
       output: 0,
       cacheRead: 0,
       cacheWrite: 0,
       total: 0,
       messageCount: 0,
-      lastActivity: null,
       byModel: {},
     },
   /** GET /api/sessions/:id/leftovers — the demo never leaves real subprocesses running. */

--- a/ui/src/lib/feature-announcements/entries/v1.45.0-session-status-bar.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.45.0-session-status-bar.ts
@@ -1,0 +1,10 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  id: "session-status-bar",
+  sinceVersion: "1.45.0",
+  titleKey: "feat_session_status_bar_title",
+  bodyKey: "feat_session_status_bar_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -4,6 +4,7 @@ import {
   autopilotBadgeShown,
   relativeAge,
   formatAgo,
+  elapsedCoarse,
   formatResetIn,
   heartbeatTone,
   canResume,
@@ -268,6 +269,27 @@ describe("formatAgo", () => {
   ];
   for (const [ms, out] of cases) {
     it(`${ms}ms → ${out}`, () => expect(formatAgo(ms)).toBe(out));
+  }
+});
+
+describe("elapsedCoarse", () => {
+  const M = 60_000;
+  const H = 60 * M;
+  const D = 24 * H;
+  const cases: [number, string][] = [
+    [0, "0m"],
+    [-5000, "0m"], // negative clamps
+    [59_999, "0m"], // sub-minute floors — no seconds at this granularity
+    [M, "1m"],
+    [59 * M + 59_000, "59m"],
+    [H, "1h 00m"],
+    [2 * H + 14 * M, "2h 14m"],
+    [23 * H + 59 * M, "23h 59m"],
+    [D, "1d 00h"],
+    [3 * D + H, "3d 01h"],
+  ];
+  for (const [ms, out] of cases) {
+    it(`${ms}ms → ${out}`, () => expect(elapsedCoarse(0, ms)).toBe(out));
   }
 });
 

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -89,6 +89,20 @@ export function elapsed(fromMs: number, nowMs: number): string {
 }
 
 /**
+ * Minute-granularity elapsed for the status bar: `<60m → "{n}m"`, `<24h → "{H}h {MM}m"`,
+ * else `"{D}d {HH}h"`. No seconds anywhere — the status bar ticks on the shared 30s
+ * clock, and second-level output against a 30s tick would read as a frozen counter.
+ * Unit letters d/h/m are tech notation, NOT translated (same as `elapsed`). Negative/0 → "0m".
+ */
+export function elapsedCoarse(fromMs: number, nowMs: number): string {
+  const min = Math.max(0, Math.floor((nowMs - fromMs) / 60_000));
+  if (min < 60) return `${min}m`;
+  const h = Math.floor(min / 60);
+  if (h < 24) return `${h}h ${String(min % 60).padStart(2, "0")}m`;
+  return `${Math.floor(h / 24)}d ${String(h % 24).padStart(2, "0")}h`;
+}
+
+/**
  * Compact elapsed for the row heartbeat: `<60s → "{n}s"`, `<60m → "{n}m"`,
  * `<24h → "{n}h"`, else `"{n}d"`. Each unit floored; negative/0 → "0s".
  * Unit letters s/m/h/d are tech notation, NOT translated (same as `elapsed`).

--- a/ui/src/lib/reviewer-env.ts
+++ b/ui/src/lib/reviewer-env.ts
@@ -9,10 +9,12 @@ function providerLabel(provider: AgentProvider): string {
   return provider === "codex" ? m.agent_provider_codex() : m.agent_provider_claude();
 }
 
-/** Compose a `CLI · model · effort` label for a plan/reviewer environment. A null/absent provider
- *  degrades to a localized "unavailable" (optionally suffixed with whatever model/effort is known);
- *  callers that must NOT surface that string (e.g. the in-flight reviewing button) should gate on a
- *  non-null provider first. `model`/`effort` fall back to their localized "default" when absent. */
+/** Compose a `CLI · model · effort` label for an agent environment — the plan/reviewer strips
+ *  AND the session status bar share this single formatter so their wording can never drift.
+ *  A null/absent provider degrades to a localized "unavailable" (optionally suffixed with
+ *  whatever model/effort is known); callers that must NOT surface that string (e.g. the
+ *  in-flight reviewing button) should gate on a non-null provider first. `model`/`effort`
+ *  fall back to their localized "default" when absent. */
 export function environmentLabel(
   provider: AgentProvider | null | undefined,
   model: string | null | undefined,

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1146,15 +1146,21 @@ export interface OwedFocusSnapshot {
   merged: boolean; // git state === "merged" at click time
 }
 
+/** Wire mirror of the server's SessionUsageDto (GET /api/sessions/:id/usage).
+ *  `available: false` means no resolvable data source (Codex, pre-feature, cleaned
+ *  transcript) — distinct from a true zero, which is `available: true, total: 0`.
+ *  Splits/messageCount/byModel are null when the resolved source doesn't carry them
+ *  (e.g. archive snapshots withhold byModel: they store weighted units, not raw tokens). */
 export interface SessionUsage {
-  input: number;
-  output: number;
-  cacheRead: number;
-  cacheWrite: number;
+  available: boolean;
+  source: "live" | "snapshot" | "codex" | "none";
   total: number;
-  messageCount: number;
-  lastActivity: number | null;
-  byModel: Record<string, number>;
+  input: number | null;
+  output: number | null;
+  cacheRead: number | null;
+  cacheWrite: number | null;
+  messageCount: number | null;
+  byModel: Record<string, number> | null;
 }
 
 export interface ActivityEntry {


### PR DESCRIPTION
## What

Every session "thing" now ends in the **same status pane**: `provider · model · effort  ·  tokens  ·  elapsed`.

- **All session viewport stages** — normal, rework, plan-gate, drain, critic-review — get a persistent strip below the terminal/tab body, on every tab, desktop and mobile. During **rework** the `ReviewInFlightBanner` keeps showing the *reviewer's* environment while the strip keeps the **task agent's own** identity — previously that identity only existed in the hover-only metaPop tooltip (the reported bug: "status bar for rework is missing model etc.").
- **Finished sessions** (Done lens): the same pane pins to the bottom of `DoneRecapPanel`; scroll ownership moved into `.dr-body` so header and pane stay in view while the recap body scrolls.
- Identity formatting reuses `environmentLabel` — the same formatter the review banner uses — so the two strips can never drift apart in wording.

## Provider-aware usage API

`GET /api/sessions/:id/usage` now returns an explicit DTO (`available`, `source: live|snapshot|codex|none`, raw `total`, nullable splits/messageCount/byModel) resolved through a ladder:

1. **Archived → archive-time `session_usage` snapshot** (new single-row store getter). Raw token fields are served; the snapshot's `byModel` holds *weighted units* and is deliberately **not** copied into the raw-token field (`byModel: null`).
2. Snapshot-less archive → documented fallback to the live source.
3. **Claude → live JSONL, spawn-account-aware**: `readSessionUsage(..., spawnAccountDir)` — swap/pool-account sessions previously resolved a nonexistent path and read as silent zeros.
4. **Codex → honestly unavailable** (`source: "none"`) with Codex-specific explanation copy in the pane ("token usage isn't tracked for Codex sessions yet"). Per-session Codex totals are deliberately out of scope; the accumulated design constraints (version-resilient thread-overlap contract, bounded resume-refresh of `providerSessionId`, background rollout index) are captured as acceptance criteria in #1815. A root test pins that the Codex branch performs no state-DB/rollout access from the 5s polling path.

`available: false` is reserved for genuinely absent data — a readable-but-empty transcript renders **"0 tok"**, never the placeholder. The elapsed segment uses a new minute-granularity `elapsedCoarse` so the shared 30s clock never reads as a frozen counter; archived sessions show the static `archivedAt ?? updatedAt` duration. The pane is a labelled `role="group"`, deliberately **not** an ARIA live region.

Also: Viewport's usage effect now keys on the value-level `unitId` (the file's own documented pattern) instead of the churning `session.id` prop read, with a new regression test asserting the usage refetch on session switch.

## Verification

- Root: `bun run lint` ✓; `bun test ./test` in a clean worktree → 7175 pass, 1 fail = the known node-pty native-compile environment failure (pre-existing, unrelated; local pre-push is blocked by the same, hence gates run manually + `--no-verify` push).
- UI: `bun run check` ✓ (0 errors), `bun run test` ✓ (3941 tests / 260 files), `bun run check:i18n` ✓ (EN/DE parity).
- Hygiene gates ✓: branch-hygiene, feature-catalog (entry `v1.45.0-session-status-bar`, drawer-only), announcement-versions, glossary, prettier.
- Live-verified in demo mode via Playwright: pane renders below the terminal / above the steer bar with `Claude Code · opus · … · 186k tok · …`, correct `role/aria-label`, no live region; Done-recap pane pinned under an overflowing body.

## Note: pre-existing demo staleness (#1821)

While live-verifying, the demo world showed the autofocused hero session's usage on *other* sessions. Reproduced identically on `main` (the metaPop shows the same wrong value there) — a pre-existing demo-environment issue, now simply more visible because the pane is always on. Filed as #1821 with full instrumentation notes; the new Viewport browser test proves the component itself re-fetches correctly on session switch.

Refs #1815, #1821.