### PR TITLE
feat(learnings): permanently prune proposed learnings older than 3 days

### DIFF
--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -12,8 +12,6 @@ import { reapTransientByLabel } from "./transient-tab-reaper";
 import type { RoleEnvironment } from "./default-model";
 import { normalizeRule } from "./learning-rule";
 
-export { normalizeRule } from "./learning-rule";
-
 const PROPOSALS_FILE = ".shepherd-learnings.json";
 
 /** Signal kinds the learnings distiller does NOT mine for code-review patterns.
@@ -441,12 +439,7 @@ export class DistillerService {
         ? r.evidence.filter((e): e is string => typeof e === "string")
         : [];
       const prunedAt = tombstones.get(key);
-      if (
-        prunedAt !== undefined &&
-        !evidence.some(
-          (signalId) => (f.signalTs.get(signalId) ?? Number.NEGATIVE_INFINITY) > prunedAt,
-        )
-      ) {
+      if (isBlockedByPruneTombstone(f.signalTs, evidence, prunedAt)) {
         console.warn(
           `[distill] rejected tombstoned rule without post-prune evidence for ${f.repoPath}: ${key}`,
         );
@@ -504,6 +497,17 @@ export class DistillerService {
     }
     return reaffirmed;
   }
+}
+
+function isBlockedByPruneTombstone(
+  signalTs: Map<string, number>,
+  evidence: string[],
+  prunedAt: number | undefined,
+): boolean {
+  return (
+    prunedAt !== undefined &&
+    !evidence.some((signalId) => (signalTs.get(signalId) ?? Number.NEGATIVE_INFINITY) > prunedAt)
+  );
 }
 
 function distillPrompt(): string {

--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -10,6 +10,9 @@ import { apiKeyFailClosed, apiKeyPassthroughEnv } from "./spawn-auth";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
 import { reapTransientByLabel } from "./transient-tab-reaper";
 import type { RoleEnvironment } from "./default-model";
+import { normalizeRule } from "./learning-rule";
+
+export { normalizeRule } from "./learning-rule";
 
 const PROPOSALS_FILE = ".shepherd-learnings.json";
 
@@ -83,6 +86,8 @@ interface InFlight {
   /** Signal ids handed to this run — the only ids whose citation as evidence for
    *  an ineffective rule we trust (blocks a hallucinated id from being counted). */
   signalIds: Set<string>;
+  /** Timestamp lookup for proving a tombstoned rule cites genuinely post-prune evidence. */
+  signalTs: Map<string, number>;
 }
 
 export interface DistillerDeps {
@@ -100,6 +105,7 @@ export interface DistillerDeps {
     | "mergeLearning"
     | "retireLearning"
     | "getLearning"
+    | "listLearningPruneTombstones"
   >;
   herdr: Pick<HerdrDriver, "start" | "stop" | "list" | "closeTab">;
   scratch: { create: () => { dir: string }; remove: (dir: string) => void };
@@ -285,6 +291,7 @@ export class DistillerService {
       terminalId: "",
       startedAt: this.now(),
       signalIds: new Set(signals.map((s) => s.id)),
+      signalTs: new Map(signals.map((s) => [s.id, s.ts])),
     };
     this.inflight.set(repoPath, entry);
     try {
@@ -346,7 +353,7 @@ export class DistillerService {
   }
 
   private finalize(f: InFlight, raw: RawProposals | null): void {
-    const { added, updated, deleted } = this.applyProposals(f.repoPath, raw);
+    const { added, updated, deleted } = this.applyProposals(f, raw);
     const flagged = this.applyIneffective(f, raw);
     const reaffirmed = this.applyReaffirm(f, raw);
     void this.deps.herdr.stop(f.terminalId).catch(() => {});
@@ -361,9 +368,10 @@ export class DistillerService {
 
   /** Persist new (deduped) proposed rules and apply UPDATE/DELETE from the distiller's output. */
   private applyProposals(
-    repoPath: string,
+    f: InFlight,
     raw: RawProposals | null,
   ): { added: number; updated: number; deleted: number } {
+    const repoPath = f.repoPath;
     const activeIds = new Set(
       this.deps.store
         .listActiveLearnings(repoPath)
@@ -376,7 +384,12 @@ export class DistillerService {
     // existing rule, so an ADD carrying that same merged text must dedup against the
     // just-merged rule (recomputing from the store reflects the post-merge text).
     const have = new Set(this.deps.store.listLearnings(repoPath).map((l) => normalizeRule(l.rule)));
-    const added = this.applyAdds(repoPath, raw, have);
+    const tombstones = new Map(
+      this.deps.store
+        .listLearningPruneTombstones(repoPath)
+        .map((tombstone) => [tombstone.ruleKey, tombstone.prunedAt]),
+    );
+    const added = this.applyAdds(f, raw, have, tombstones);
     return { added, updated, deleted };
   }
 
@@ -411,7 +424,12 @@ export class DistillerService {
     return deleted;
   }
 
-  private applyAdds(repoPath: string, raw: RawProposals | null, have: Set<string>): number {
+  private applyAdds(
+    f: InFlight,
+    raw: RawProposals | null,
+    have: Set<string>,
+    tombstones: Map<string, number>,
+  ): number {
     let added = 0;
     const rules = Array.isArray(raw?.rules) ? (raw!.rules as RawRule[]) : [];
     for (const r of rules) {
@@ -419,14 +437,27 @@ export class DistillerService {
       if (typeof r?.rule !== "string" || !r.rule.trim()) continue;
       const key = normalizeRule(r.rule);
       if (have.has(key)) continue;
+      const evidence = Array.isArray(r.evidence)
+        ? r.evidence.filter((e): e is string => typeof e === "string")
+        : [];
+      const prunedAt = tombstones.get(key);
+      if (
+        prunedAt !== undefined &&
+        !evidence.some(
+          (signalId) => (f.signalTs.get(signalId) ?? Number.NEGATIVE_INFINITY) > prunedAt,
+        )
+      ) {
+        console.warn(
+          `[distill] rejected tombstoned rule without post-prune evidence for ${f.repoPath}: ${key}`,
+        );
+        continue;
+      }
       have.add(key);
       this.deps.store.addLearning({
-        repoPath,
+        repoPath: f.repoPath,
         rule: r.rule.trim().slice(0, 240),
         rationale: typeof r.rationale === "string" ? r.rationale : "",
-        evidence: Array.isArray(r.evidence)
-          ? r.evidence.filter((e): e is string => typeof e === "string")
-          : [],
+        evidence,
         scopeGlobs: sanitizeScopeGlobs(r.scopeGlobs),
       });
       added++;
@@ -473,10 +504,6 @@ export class DistillerService {
     }
     return reaffirmed;
   }
-}
-
-export function normalizeRule(s: string): string {
-  return s.trim().toLowerCase().replace(/\s+/g, " ");
 }
 
 function distillPrompt(): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2352,7 +2352,7 @@ const runDailySweep = (opts?: { skipTmpSweep?: boolean }) => {
   store.pruneReviewerSpawns(Date.now() - REVIEWER_SPAWN_RETENTION_MS);
   // Scrape timeline history; pruned on a 90-day window matching the caps/credit tables.
   store.pruneUsageHistory(Date.now() - USAGE_HISTORY_RETENTION_MS);
-  // #1794: permanently prune stale proposed learnings (fixed 3-day retention). Runs
+  // #1794: permanently prune stale proposed learnings (3-day default retention). Runs
   // synchronously here — before any async distillation/merge-suggestion/auto-trial work — so
   // the retention rule has unconditional, deterministic precedence over promotion.
   const prunedLearnings = runProposedPrune({ store });

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ import { MergeSuggestionService, defaultMergeScratch } from "./merge-suggest";
 import {
   runAutoRetire,
   runAutoTrial,
-  runAutoExpire,
+  runProposedPrune,
   runReapStaleTrials,
 } from "./learnings-lifecycle";
 import { Promoter } from "./promote";
@@ -2352,6 +2352,14 @@ const runDailySweep = (opts?: { skipTmpSweep?: boolean }) => {
   store.pruneReviewerSpawns(Date.now() - REVIEWER_SPAWN_RETENTION_MS);
   // Scrape timeline history; pruned on a 90-day window matching the caps/credit tables.
   store.pruneUsageHistory(Date.now() - USAGE_HISTORY_RETENTION_MS);
+  // #1794: permanently prune stale proposed learnings (fixed 3-day retention). Runs
+  // synchronously here — before any async distillation/merge-suggestion/auto-trial work — so
+  // the retention rule has unconditional, deterministic precedence over promotion.
+  const prunedLearnings = runProposedPrune({ store });
+  if (prunedLearnings > 0) {
+    console.log(`[learnings] permanently pruned ${prunedLearnings} stale proposed learning(s)`);
+    learningsSvc.emitPending();
+  }
   for (const repo of listRepos(config.repoRoot)) void distiller.consider(repo.path);
   // Phase 4 merge suggestions: per-repo near-duplicate clustering (intra) + a single global
   // cross-repo recurrence pass. Both no-op unless the active set is large enough AND changed
@@ -2381,12 +2389,12 @@ const runDailySweep = (opts?: { skipTmpSweep?: boolean }) => {
       .catch((err) => console.warn("[push] learnings_retired notify failed:", err));
   }
   // Auto-trial strong proposals (#925): promote proposals with strong, multi-source evidence
-  // to active trials (kill-switch via SHEPHERD_LEARNINGS_AUTO_TRIAL); reap inert/zombie trials;
-  // expire stale dead proposals. All capped per sweep. Returns drive the client nudge + push.
+  // to active trials (kill-switch via SHEPHERD_LEARNINGS_AUTO_TRIAL); reap inert/zombie trials.
+  // Both capped per sweep. Returns drive the client nudge + push. Stale-proposal retention is
+  // handled earlier by runProposedPrune (#1794), which emits its own pending update.
   const trialed = runAutoTrial({ store });
   const reaped = runReapStaleTrials({ store });
-  const expired = runAutoExpire({ store });
-  if (trialed.length + reaped.length + expired.length > 0) {
+  if (trialed.length + reaped.length > 0) {
     learningsSvc.emitPending();
   }
   if (trialed.length > 0) {

--- a/src/learning-rule.ts
+++ b/src/learning-rule.ts
@@ -1,0 +1,4 @@
+/** Canonical key used for exact learning-rule deduplication and prune tombstones. */
+export function normalizeRule(rule: string): string {
+  return rule.trim().toLowerCase().replace(/\s+/g, " ");
+}

--- a/src/learnings-lifecycle.ts
+++ b/src/learnings-lifecycle.ts
@@ -28,11 +28,9 @@ export const TRIAL_REAP_DAYS = Number(process.env.SHEPHERD_LEARNINGS_TRIAL_REAP_
 export const TRIAL_REAP_MAX_DAYS = Number(process.env.SHEPHERD_LEARNINGS_TRIAL_REAP_MAX_DAYS ?? 60);
 export const MAX_REAP_PER_SWEEP = Number(process.env.SHEPHERD_LEARNINGS_MAX_REAP_PER_SWEEP ?? 5);
 
-// proposed expiry
-export const EXPIRE_DAYS = Number(process.env.SHEPHERD_LEARNINGS_EXPIRE_DAYS ?? 30);
-export const MAX_EXPIRE_PER_SWEEP = Number(
-  process.env.SHEPHERD_LEARNINGS_MAX_EXPIRE_PER_SWEEP ?? 5,
-);
+// proposed retention (#1794): permanently prune proposed learnings whose latest evidence is
+// older than this many days. Applied in full each sweep (no cap, no exemption).
+export const PRUNE_DAYS = Number(process.env.SHEPHERD_LEARNINGS_PRUNE_DAYS ?? 3);
 
 /** Informational reason stored when a stale trial is reaped; reapStaleTrial sets it in-store. */
 export const TRIAL_EXPIRED_REASON = "trial-expired";
@@ -56,12 +54,6 @@ export interface TrialedRecord {
   evidenceCount: number;
   distinctKinds: number;
   distinctSessions: number;
-}
-
-export interface ExpiredRecord {
-  repoPath: string;
-  id: string;
-  rule: string;
 }
 
 export interface ReapedRecord {
@@ -221,56 +213,23 @@ export function runAutoTrial(deps: AutoTrialDeps): TrialedRecord[] {
   return out;
 }
 
-// ── shouldExpireProposed + runAutoExpire ──────────────────────────────────────
+// ── runProposedPrune (#1794) ──────────────────────────────────────────────────
 
-export function shouldExpireProposed(
-  rule: Learning,
-  now: number,
-  opts?: {
-    expireDays?: number;
-    expiryFloor?: number;
-    gate?: { nMin?: number; sessionFloor?: number; minKinds?: number; minSessions?: number };
-  },
-): boolean {
-  if (rule.status !== "proposed") return false;
-  if (shouldTrial(rule, opts?.gate)) return false; // trial-worthy → never expire
-  const expireMs = (opts?.expireDays ?? EXPIRE_DAYS) * DAY_MS;
-  const floor = opts?.expiryFloor ?? 0;
-  const effective = Math.max(rule.lastEvidenceAt ?? rule.createdAt, floor); // grace floor for backlog
-  return now - effective > expireMs;
-}
-
-export interface AutoExpireDeps {
-  store: Pick<
-    SessionStore,
-    "listPendingLearnings" | "getRepoConfig" | "expireLearning" | "expiryFloorAt"
-  >;
+export interface ProposedPruneDeps {
+  store: Pick<SessionStore, "pruneStaleProposedLearnings">;
   now?: number;
-  maxPerSweep?: number;
-  expireDays?: number;
-  gate?: { nMin?: number; sessionFloor?: number; minKinds?: number; minSessions?: number };
+  retentionDays?: number;
 }
 
-export function runAutoExpire(deps: AutoExpireDeps): ExpiredRecord[] {
+/** Permanently delete every `proposed` learning whose latest evidence is older than the
+ *  retention window (age = COALESCE(lastEvidenceAt, createdAt)). One global, status-scoped,
+ *  uncapped bulk delete — no per-repo gate and no exemption for strong/trial-worthy proposals.
+ *  Runs before auto-trial in the sweep, so a strong-but-stale proposal is dropped rather than
+ *  promoted; genuinely recurring evidence re-proposes it later. Returns the number removed. */
+export function runProposedPrune(deps: ProposedPruneDeps): number {
   const now = deps.now ?? Date.now();
-  const cap = deps.maxPerSweep ?? MAX_EXPIRE_PER_SWEEP;
-  const floor = deps.store.expiryFloorAt();
-  const out: ExpiredRecord[] = [];
-  for (const rule of deps.store.listPendingLearnings()) {
-    if (out.length >= cap) break;
-    if (!deps.store.getRepoConfig(rule.repoPath).learningsEnabled) continue;
-    if (
-      !shouldExpireProposed(rule, now, {
-        expireDays: deps.expireDays,
-        expiryFloor: floor,
-        gate: deps.gate,
-      })
-    )
-      continue;
-    if (deps.store.expireLearning(rule.id))
-      out.push({ repoPath: rule.repoPath, id: rule.id, rule: rule.rule });
-  }
-  return out;
+  const days = deps.retentionDays ?? PRUNE_DAYS;
+  return deps.store.pruneStaleProposedLearnings(now - days * DAY_MS);
 }
 
 // ── shouldReapTrial + runReapStaleTrials ──────────────────────────────────────

--- a/src/learnings-lifecycle.ts
+++ b/src/learnings-lifecycle.ts
@@ -229,7 +229,9 @@ export interface ProposedPruneDeps {
 export function resolveProposedRetentionDays(value: unknown, fallback: number): number {
   if (value === undefined) return fallback;
   const parsed = typeof value === "string" && value.trim() === "" ? Number.NaN : Number(value);
-  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  const durationMs = parsed * DAY_MS;
+  if (Number.isFinite(parsed) && parsed > 0 && Number.isFinite(durationMs) && durationMs >= 1)
+    return parsed;
   const shown = typeof value === "string" ? JSON.stringify(value) : String(value);
   console.warn(`[learnings] invalid proposed retention days ${shown}; using ${fallback}`);
   return fallback;
@@ -243,7 +245,12 @@ export function resolveProposedRetentionDays(value: unknown, fallback: number): 
 export function runProposedPrune(deps: ProposedPruneDeps): number {
   const now = deps.now ?? Date.now();
   const days = resolveProposedRetentionDays(deps.retentionDays, PRUNE_DAYS);
-  return deps.store.pruneStaleProposedLearnings(now - days * DAY_MS);
+  const cutoff = now - days * DAY_MS;
+  if (!Number.isFinite(cutoff)) {
+    console.warn("[learnings] invalid proposed retention cutoff; skipping prune");
+    return 0;
+  }
+  return deps.store.pruneStaleProposedLearnings(cutoff, now);
 }
 
 // ── shouldReapTrial + runReapStaleTrials ──────────────────────────────────────

--- a/src/learnings-lifecycle.ts
+++ b/src/learnings-lifecycle.ts
@@ -30,7 +30,10 @@ export const MAX_REAP_PER_SWEEP = Number(process.env.SHEPHERD_LEARNINGS_MAX_REAP
 
 // proposed retention (#1794): permanently prune proposed learnings whose latest evidence is
 // older than this many days. Applied in full each sweep (no cap, no exemption).
-export const PRUNE_DAYS = Number(process.env.SHEPHERD_LEARNINGS_PRUNE_DAYS ?? 3);
+export const PRUNE_DAYS = resolveProposedRetentionDays(
+  process.env.SHEPHERD_LEARNINGS_PRUNE_DAYS,
+  3,
+);
 
 /** Informational reason stored when a stale trial is reaped; reapStaleTrial sets it in-store. */
 export const TRIAL_EXPIRED_REASON = "trial-expired";
@@ -221,6 +224,17 @@ export interface ProposedPruneDeps {
   retentionDays?: number;
 }
 
+/** Resolve a configured retention window without allowing malformed overrides to make the
+ *  cutoff destructive or disable pruning. Invalid explicit values fall back visibly. */
+export function resolveProposedRetentionDays(value: unknown, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = typeof value === "string" && value.trim() === "" ? Number.NaN : Number(value);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  const shown = typeof value === "string" ? JSON.stringify(value) : String(value);
+  console.warn(`[learnings] invalid proposed retention days ${shown}; using ${fallback}`);
+  return fallback;
+}
+
 /** Permanently delete every `proposed` learning whose latest evidence is older than the
  *  retention window (age = COALESCE(lastEvidenceAt, createdAt)). One global, status-scoped,
  *  uncapped bulk delete — no per-repo gate and no exemption for strong/trial-worthy proposals.
@@ -228,7 +242,7 @@ export interface ProposedPruneDeps {
  *  promoted; genuinely recurring evidence re-proposes it later. Returns the number removed. */
 export function runProposedPrune(deps: ProposedPruneDeps): number {
   const now = deps.now ?? Date.now();
-  const days = deps.retentionDays ?? PRUNE_DAYS;
+  const days = resolveProposedRetentionDays(deps.retentionDays, PRUNE_DAYS);
   return deps.store.pruneStaleProposedLearnings(now - days * DAY_MS);
 }
 
@@ -322,12 +336,9 @@ export function runAutoRetire(deps: AutoRetireDeps): RetiredRecord[] {
   const results: RetiredRecord[] = [];
 
   for (const repoPath of store.listRepoPathsWithInjectableLearnings()) {
-    // Skip repos with learnings injection disabled entirely — consistent with the sibling
-    // sweeps (runAutoTrial / reapStaleTrial / expireProposed), which all `continue` past
-    // learnings-disabled repos. When the operator turns Learnings off, the whole rule
-    // lifecycle (trial, optimize, retire) goes dormant for that repo, and no
-    // `learnings_retired` notification fires. This also makes the UI's Auto-optimize gate
-    // honest: with Learnings off the optimize pass never runs.
+    // Injection-driven lifecycle paths (auto-trial, trial reaping, optimize, retire) stay
+    // dormant for learnings-disabled repos. The global proposed-prune pass is the intentional
+    // exception: it is status/age-based and not gated by repository configuration.
     if (!store.getRepoConfig(repoPath).learningsEnabled) continue;
     results.push(
       ...retireRepoCandidates(repoPath, deps, { nMin, maxRetirePerSweep, baseRateOpts }),

--- a/src/merge-suggest.ts
+++ b/src/merge-suggest.ts
@@ -6,7 +6,7 @@ import type { SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
 import { HerdrUnavailableError } from "./herdr";
 import type { Learning, MergeSuggestionKind } from "./types";
-import { normalizeRule } from "./distiller";
+import { normalizeRule } from "./learning-rule";
 import { apiKeyFailClosed, apiKeyPassthroughEnv } from "./spawn-auth";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
 import { reapTransientByLabel } from "./transient-tab-reaper";

--- a/src/store.ts
+++ b/src/store.ts
@@ -4295,15 +4295,16 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     return this.getLearning(id);
   }
 
-  /** Dismiss a stale proposed rule (expiry path). Returns null if not proposed. */
-  expireLearning(id: string): Learning | null {
-    const cur = this.getLearning(id);
-    if (!cur || cur.status !== "proposed") return null;
-    this.db.run(`UPDATE learnings SET status = 'dismissed', updatedAt = ? WHERE id = ?`, [
-      Date.now(),
-      id,
-    ]);
-    return this.getLearning(id);
+  /** #1794: permanently delete every `proposed` learning whose latest supporting evidence is
+   *  older than `beforeTs` (age = COALESCE(lastEvidenceAt, createdAt), strict `<` so a row
+   *  exactly at the cutoff survives). Only `proposed` rows are eligible; accepted/history rows
+   *  (active/promoted/dismissed/retired) are never touched. One status-scoped bulk delete, no
+   *  hydration or per-row loop. Returns the number of rows removed. */
+  pruneStaleProposedLearnings(beforeTs: number): number {
+    return this.db.run(
+      `DELETE FROM learnings WHERE status = 'proposed' AND COALESCE(lastEvidenceAt, createdAt) < ?`,
+      [beforeTs],
+    ).changes;
   }
 
   /** All active rules that were auto-trialed (trialedAt IS NOT NULL), across all repos,
@@ -4317,15 +4318,8 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     return (rows as LearningRow[]).map((r) => this.hydrateLearning(r));
   }
 
-  /** The expiry grace floor timestamp: proposed rules created before this ts are exempt
-   *  from expiry on the first backfill sweep (kv key: "learnings:expiry-floor"). */
-  expiryFloorAt(): number {
-    return Number(this.getSetting("learnings:expiry-floor") ?? 0);
-  }
-
   /** One-time backfill: populate evidenceKindsSeen + evidenceSessionsSeen for existing
-   *  proposed rows that still have empty sets, and stamp the expiry-grace floor so the
-   *  lifecycle sweep doesn't immediately expire pre-existing proposals.
+   *  proposed rows that still have empty sets.
    *  Guarded by the kv flag "learnings:diversity-backfilled" so it runs exactly once. */
   private backfillLearningDiversity(): void {
     if (this.getSetting("learnings:diversity-backfilled") === "1") return;
@@ -4345,7 +4339,6 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
         );
       }
     }
-    this.setSetting("learnings:expiry-floor", String(Date.now()));
     this.setSetting("learnings:diversity-backfilled", "1");
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -60,6 +60,7 @@ import { normalizeRepoDefaultEffortSetting } from "./default-effort";
 import { sanitizeScopeGlobs } from "./house-rules";
 import type { EpicRun } from "./epic-core";
 import type { EpicLandingState } from "./completed-epic";
+import { normalizeRule } from "./learning-rule";
 
 /** Tolerantly parse a persisted JSON column, falling back to `fallback` on any error. */
 function safeJsonParse<T>(raw: string | null | undefined, fallback: T): T {
@@ -1132,6 +1133,9 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
   createdAt INTEGER NOT NULL, updatedAt INTEGER NOT NULL, lastEvidenceAt INTEGER, promotedPrUrl TEXT,
   ineffectiveSignalIds TEXT NOT NULL DEFAULT '[]')`);
     this.db.run(`CREATE INDEX IF NOT EXISTS learnings_repo_status ON learnings (repoPath, status)`);
+    this.db.run(`CREATE TABLE IF NOT EXISTS learning_prune_tombstones (
+      repoPath TEXT NOT NULL, ruleKey TEXT NOT NULL, prunedAt INTEGER NOT NULL,
+      PRIMARY KEY (repoPath, ruleKey))`);
     this.db.run(`CREATE TABLE IF NOT EXISTS session_injected_learnings (
       sessionId TEXT NOT NULL, learningId TEXT NOT NULL,
       PRIMARY KEY (sessionId, learningId))`);
@@ -4295,14 +4299,35 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
     return this.getLearning(id);
   }
 
+  /** Durable normalized signatures for pruned proposals. The distiller uses `prunedAt` to reject
+   *  recurrence from its unchanged signal window while permitting genuinely newer evidence. */
+  listLearningPruneTombstones(repoPath: string): { ruleKey: string; prunedAt: number }[] {
+    return this.db
+      .query(`SELECT ruleKey, prunedAt FROM learning_prune_tombstones WHERE repoPath = ?`)
+      .all(repoPath) as { ruleKey: string; prunedAt: number }[];
+  }
+
   /** #1794: permanently delete every `proposed` learning whose latest supporting evidence is
    *  older than `beforeTs` (age = COALESCE(lastEvidenceAt, createdAt), strict `<` so a row
    *  exactly at the cutoff survives). Only `proposed` rows are eligible; accepted/history rows
-   *  (active/promoted/dismissed/retired) are never touched. Inbound merge-history citations are
-   *  cleared in the same transaction before the status-scoped bulk delete. Returns the number of
-   *  rows removed. */
-  pruneStaleProposedLearnings(beforeTs: number): number {
+   *  (active/promoted/dismissed/retired) are never touched. Normalized tombstones are retained and
+   *  inbound merge-history citations are cleared in the same transaction before the status-scoped
+   *  bulk delete. Returns the number of rows removed. */
+  pruneStaleProposedLearnings(beforeTs: number, prunedAt = Date.now()): number {
     return this.db.transaction(() => {
+      const stale = this.db
+        .query(
+          `SELECT repoPath, rule FROM learnings
+           WHERE status = 'proposed' AND COALESCE(lastEvidenceAt, createdAt) < ?`,
+        )
+        .all(beforeTs) as { repoPath: string; rule: string }[];
+      for (const learning of stale) {
+        this.db.run(
+          `INSERT INTO learning_prune_tombstones (repoPath, ruleKey, prunedAt) VALUES (?, ?, ?)
+           ON CONFLICT(repoPath, ruleKey) DO UPDATE SET prunedAt = MAX(prunedAt, excluded.prunedAt)`,
+          [learning.repoPath, normalizeRule(learning.rule), prunedAt],
+        );
+      }
       this.db.run(
         `UPDATE learnings SET mergedIntoId = NULL WHERE mergedIntoId IN (
            SELECT id FROM learnings

--- a/src/store.ts
+++ b/src/store.ts
@@ -4298,13 +4298,23 @@ export class SessionStore implements CapStore, CreditStore, ModelWeekStore {
   /** #1794: permanently delete every `proposed` learning whose latest supporting evidence is
    *  older than `beforeTs` (age = COALESCE(lastEvidenceAt, createdAt), strict `<` so a row
    *  exactly at the cutoff survives). Only `proposed` rows are eligible; accepted/history rows
-   *  (active/promoted/dismissed/retired) are never touched. One status-scoped bulk delete, no
-   *  hydration or per-row loop. Returns the number of rows removed. */
+   *  (active/promoted/dismissed/retired) are never touched. Inbound merge-history citations are
+   *  cleared in the same transaction before the status-scoped bulk delete. Returns the number of
+   *  rows removed. */
   pruneStaleProposedLearnings(beforeTs: number): number {
-    return this.db.run(
-      `DELETE FROM learnings WHERE status = 'proposed' AND COALESCE(lastEvidenceAt, createdAt) < ?`,
-      [beforeTs],
-    ).changes;
+    return this.db.transaction(() => {
+      this.db.run(
+        `UPDATE learnings SET mergedIntoId = NULL WHERE mergedIntoId IN (
+           SELECT id FROM learnings
+           WHERE status = 'proposed' AND COALESCE(lastEvidenceAt, createdAt) < ?
+         )`,
+        [beforeTs],
+      );
+      return this.db.run(
+        `DELETE FROM learnings WHERE status = 'proposed' AND COALESCE(lastEvidenceAt, createdAt) < ?`,
+        [beforeTs],
+      ).changes;
+    })();
   }
 
   /** All active rules that were auto-trialed (trialedAt IS NOT NULL), across all repos,

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -550,9 +550,11 @@ test("dismissed rules are passed to the distiller so they aren't re-proposed", a
 
 test("#1794: pruned rule needs genuinely post-prune evidence before normalized recurrence", async () => {
   const store = new SessionStore(":memory:");
-  const db = (store as unknown as {
-    db: { run(sql: string, params: unknown[]): void };
-  }).db;
+  const db = (
+    store as unknown as {
+      db: { run(sql: string, params: unknown[]): void };
+    }
+  ).db;
   const oldSignal = store.addSignal({
     repoPath: "/r",
     sessionId: null,
@@ -574,9 +576,7 @@ test("#1794: pruned rule needs genuinely post-prune evidence before normalized r
     original.id,
   ]);
   expect(store.pruneStaleProposedLearnings(cutoff, prunedAt)).toBe(1);
-  expect(store.listLearningPruneTombstones("/r")).toEqual([
-    { ruleKey: "use bun", prunedAt },
-  ]);
+  expect(store.listLearningPruneTombstones("/r")).toEqual([{ ruleKey: "use bun", prunedAt }]);
 
   const staleRun = mkDeps(store, {
     rules: [{ rule: "  use   bun  ", rationale: "same corpus", evidence: [oldSignal.id] }],

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, beforeEach, afterEach } from "bun:test";
+import { test, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { DistillerService, DISTILL_LABEL, type DistillerDeps } from "../src/distiller";
 import { SessionStore } from "../src/store";
 import { config } from "../src/config";
@@ -455,6 +455,7 @@ test("distiller increments ineffective for cited active rule ids with validated 
       ],
       addLearning: () => ({}) as never,
       listLearnings: () => [],
+      listLearningPruneTombstones: () => [],
       listActiveLearnings: () => active as never,
       getSetting: () => null,
       setSetting: () => {},
@@ -545,6 +546,65 @@ test("dismissed rules are passed to the distiller so they aren't re-proposed", a
   const d = new DistillerService(deps as any);
   await d.distillNow("/r");
   expect(captured).toContain("dismissed rule");
+});
+
+test("#1794: pruned rule needs genuinely post-prune evidence before normalized recurrence", async () => {
+  const store = new SessionStore(":memory:");
+  const db = (store as unknown as {
+    db: { run(sql: string, params: unknown[]): void };
+  }).db;
+  const oldSignal = store.addSignal({
+    repoPath: "/r",
+    sessionId: null,
+    kind: "reply",
+    payload: "use bun",
+  });
+  const original = store.addLearning({
+    repoPath: "/r",
+    rule: "Use bun",
+    rationale: "",
+    evidence: [oldSignal.id],
+  });
+  const prunedAt = Date.now();
+  const cutoff = prunedAt - 3 * 86_400_000;
+  db.run(`UPDATE signals SET ts = ? WHERE id = ?`, [prunedAt - 1, oldSignal.id]);
+  db.run(`UPDATE learnings SET createdAt = ?, lastEvidenceAt = ? WHERE id = ?`, [
+    cutoff - 1,
+    cutoff - 1,
+    original.id,
+  ]);
+  expect(store.pruneStaleProposedLearnings(cutoff, prunedAt)).toBe(1);
+  expect(store.listLearningPruneTombstones("/r")).toEqual([
+    { ruleKey: "use bun", prunedAt },
+  ]);
+
+  const staleRun = mkDeps(store, {
+    rules: [{ rule: "  use   bun  ", rationale: "same corpus", evidence: [oldSignal.id] }],
+  });
+  const warn = spyOn(console, "warn").mockImplementation(() => {});
+  const staleService = new DistillerService(staleRun.deps);
+  await staleService.distillNow("/r");
+  await staleService.tick();
+  expect(store.listLearnings("/r", { status: "proposed" })).toEqual([]);
+  expect(warn).toHaveBeenCalledTimes(1);
+  warn.mockRestore();
+
+  const freshSignal = store.addSignal({
+    repoPath: "/r",
+    sessionId: null,
+    kind: "reply",
+    payload: "use bun again",
+  });
+  db.run(`UPDATE signals SET ts = ? WHERE id = ?`, [prunedAt + 1, freshSignal.id]);
+  const freshRun = mkDeps(store, {
+    rules: [{ rule: "  use   bun  ", rationale: "fresh recurrence", evidence: [freshSignal.id] }],
+  });
+  const freshService = new DistillerService(freshRun.deps);
+  await freshService.distillNow("/r");
+  await freshService.tick();
+  expect(store.listLearnings("/r", { status: "proposed" }).map((l) => l.rule)).toEqual([
+    "use   bun",
+  ]);
 });
 
 // ── New tests: unique agent name, concurrency cap, health ───────────────────

--- a/test/learnings-lifecycle.test.ts
+++ b/test/learnings-lifecycle.test.ts
@@ -974,7 +974,9 @@ describe("runProposedPrune", () => {
     const f = fakeStore();
     const warn = spyOn(console, "warn").mockImplementation(() => {});
     const days = Number.MAX_VALUE / DAY_MS / 2;
-    expect(runProposedPrune({ store: f.store, now: -Number.MAX_VALUE, retentionDays: days })).toBe(0);
+    expect(runProposedPrune({ store: f.store, now: -Number.MAX_VALUE, retentionDays: days })).toBe(
+      0,
+    );
     expect(f.calls).toEqual([]);
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();

--- a/test/learnings-lifecycle.test.ts
+++ b/test/learnings-lifecycle.test.ts
@@ -950,7 +950,7 @@ describe("runProposedPrune", () => {
     expect(f.calls).toEqual([now - 7 * DAY_MS]);
   });
 
-  test.each(["", 0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+  test.each(["", 0, -1, Number.MIN_VALUE, Number.NaN, Number.POSITIVE_INFINITY, 1e308])(
     "rejects invalid retention override %p and falls back visibly",
     (retentionDays) => {
       const warn = spyOn(console, "warn").mockImplementation(() => {});
@@ -960,12 +960,22 @@ describe("runProposedPrune", () => {
     },
   );
 
-  test("invalid injected retentionDays cannot alter the cutoff", () => {
+  test.each([0, 1e308])("unsafe injected retentionDays %p cannot alter the cutoff", (days) => {
     const now = 1_000_000_000_000;
     const f = fakeStore();
     const warn = spyOn(console, "warn").mockImplementation(() => {});
-    runProposedPrune({ store: f.store, now, retentionDays: 0 });
+    runProposedPrune({ store: f.store, now, retentionDays: days });
     expect(f.calls).toEqual([now - 3 * DAY_MS]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  test("non-finite derived cutoff skips pruning visibly", () => {
+    const f = fakeStore();
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    const days = Number.MAX_VALUE / DAY_MS / 2;
+    expect(runProposedPrune({ store: f.store, now: -Number.MAX_VALUE, retentionDays: days })).toBe(0);
+    expect(f.calls).toEqual([]);
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
   });

--- a/test/learnings-lifecycle.test.ts
+++ b/test/learnings-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { test, expect, describe, spyOn } from "bun:test";
 import {
   wilsonLowerBound,
   isGoodOutcome,
@@ -10,6 +10,7 @@ import {
   runAutoRetire,
   runAutoTrial,
   runProposedPrune,
+  resolveProposedRetentionDays,
   runReapStaleTrials,
   AUTO_RETIRE_REASON,
   WILSON_Z,
@@ -509,10 +510,9 @@ describe("runAutoRetire", () => {
   });
 
   test("learnings OFF → repo skipped entirely (no retire, no optimize)", () => {
-    // When Learnings injection is off, the whole rule lifecycle is dormant for the repo —
-    // consistent with runAutoTrial / reapStaleTrial / expireProposed, which all skip
-    // learnings-disabled repos. So neither retire nor optimize fires (and no
-    // learnings_retired notification is emitted downstream).
+    // Injection-driven lifecycle paths stay dormant for learnings-disabled repos, so neither
+    // retire nor optimize fires (and no learnings_retired notification is emitted downstream).
+    // The global, status/age-based proposed-prune pass is intentionally not repo-gated.
     const rule = makeLearning({
       id: "r4",
       repoPath: "/repo",
@@ -948,6 +948,26 @@ describe("runProposedPrune", () => {
     const f = fakeStore();
     runProposedPrune({ store: f.store, now, retentionDays: 7 });
     expect(f.calls).toEqual([now - 7 * DAY_MS]);
+  });
+
+  test.each(["", 0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    "rejects invalid retention override %p and falls back visibly",
+    (retentionDays) => {
+      const warn = spyOn(console, "warn").mockImplementation(() => {});
+      expect(resolveProposedRetentionDays(retentionDays, 3)).toBe(3);
+      expect(warn).toHaveBeenCalledTimes(1);
+      warn.mockRestore();
+    },
+  );
+
+  test("invalid injected retentionDays cannot alter the cutoff", () => {
+    const now = 1_000_000_000_000;
+    const f = fakeStore();
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    runProposedPrune({ store: f.store, now, retentionDays: 0 });
+    expect(f.calls).toEqual([now - 3 * DAY_MS]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
   });
 
   test("returns the store's removed count verbatim (drives sweep log/emit gating)", () => {

--- a/test/learnings-lifecycle.test.ts
+++ b/test/learnings-lifecycle.test.ts
@@ -6,11 +6,10 @@ import {
   repoBaseRate,
   shouldRetire,
   shouldTrial,
-  shouldExpireProposed,
   shouldReapTrial,
   runAutoRetire,
   runAutoTrial,
-  runAutoExpire,
+  runProposedPrune,
   runReapStaleTrials,
   AUTO_RETIRE_REASON,
   WILSON_Z,
@@ -27,13 +26,12 @@ import {
   TRIAL_REAP_DAYS,
   TRIAL_REAP_MAX_DAYS,
   MAX_REAP_PER_SWEEP,
-  EXPIRE_DAYS,
-  MAX_EXPIRE_PER_SWEEP,
+  PRUNE_DAYS,
   TRIAL_EXPIRED_REASON,
   AUTO_TRIAL_ENABLED,
   type AutoRetireDeps,
   type AutoTrialDeps,
-  type AutoExpireDeps,
+  type ProposedPruneDeps,
   type ReapTrialDeps,
 } from "../src/learnings-lifecycle";
 import type { Learning, ReviewVerdict } from "../src/types";
@@ -915,171 +913,50 @@ describe("runAutoTrial", () => {
   });
 });
 
-// ── shouldExpireProposed ──────────────────────────────────────────────────────
+// ── runProposedPrune (#1794) ─────────────────────────────────────────────────
 
-describe("shouldExpireProposed", () => {
-  const THIRTY_DAYS = 30 * 86_400_000;
+describe("runProposedPrune", () => {
+  const DAY_MS = 86_400_000;
 
-  test("expires a stale proposal (old lastEvidenceAt, beyond EXPIRE_DAYS)", () => {
-    const now = Date.now();
-    const rule = makeLearning({
-      id: "a",
-      status: "proposed",
-      lastEvidenceAt: now - THIRTY_DAYS - 1,
-      createdAt: now - THIRTY_DAYS - 1,
-      evidenceCount: 0,
-      distinctSessions: 0,
-      distinctKinds: 0,
-    });
-    expect(shouldExpireProposed(rule, now, { expireDays: 30 })).toBe(true);
-  });
-
-  test("not within window → no expiry", () => {
-    const now = Date.now();
-    const rule = makeLearning({
-      id: "a",
-      status: "proposed",
-      lastEvidenceAt: now - 1000, // very fresh
-      createdAt: now - 1000,
-    });
-    expect(shouldExpireProposed(rule, now, { expireDays: 30 })).toBe(false);
-  });
-
-  test("trial-worthy → never expire", () => {
-    const now = Date.now();
-    const rule = makeLearning({
-      id: "a",
-      status: "proposed",
-      lastEvidenceAt: now - THIRTY_DAYS - 1,
-      createdAt: now - THIRTY_DAYS - 1,
-      evidenceCount: 4,
-      distinctSessions: 2,
-      distinctKinds: 2,
-    });
-    expect(
-      shouldExpireProposed(rule, now, {
-        expireDays: 30,
-        gate: { nMin: 4, sessionFloor: 2, minKinds: 2, minSessions: 3 },
-      }),
-    ).toBe(false);
-  });
-
-  test("#945: a blocked reverted rule is no longer trial-worthy → ages out (becomes expirable)", () => {
-    const now = Date.now();
-    // Same strong counters as the "trial-worthy → never expire" case above, but the re-trial
-    // block makes shouldTrial false, so the stale reverted proposal expires instead of being
-    // pinned in the queue — this is how Revert "durably sticks" with no recurrence.
-    const rule = makeLearning({
-      id: "a",
-      status: "proposed",
-      lastEvidenceAt: now - THIRTY_DAYS - 1,
-      createdAt: now - THIRTY_DAYS - 1,
-      evidenceCount: 4,
-      distinctSessions: 2,
-      distinctKinds: 2,
-      reTrialBlockedAt: now,
-    });
-    expect(
-      shouldExpireProposed(rule, now, {
-        expireDays: 30,
-        gate: { nMin: 4, sessionFloor: 2, minKinds: 2, minSessions: 3 },
-      }),
-    ).toBe(true);
-  });
-
-  test("expiryFloor defers expiry (old lastEvidenceAt but floor=now → NOT expired)", () => {
-    const now = Date.now();
-    const rule = makeLearning({
-      id: "a",
-      status: "proposed",
-      lastEvidenceAt: now - THIRTY_DAYS - 1,
-      createdAt: now - THIRTY_DAYS - 1,
-      evidenceCount: 0,
-      distinctSessions: 0,
-      distinctKinds: 0,
-    });
-    expect(shouldExpireProposed(rule, now, { expireDays: 30, expiryFloor: now })).toBe(false);
-  });
-
-  test("status !== proposed → false", () => {
-    const now = Date.now();
-    const rule = makeLearning({
-      id: "a",
-      status: "active",
-      lastEvidenceAt: now - THIRTY_DAYS - 1,
-      createdAt: now - THIRTY_DAYS - 1,
-    });
-    expect(shouldExpireProposed(rule, now, { expireDays: 30 })).toBe(false);
-  });
-});
-
-// ── runAutoExpire ─────────────────────────────────────────────────────────────
-
-function makeFakeExpireDeps(opts: {
-  pending?: Learning[];
-  cfg?: Partial<RepoConfig>;
-  expiryFloor?: number;
-}) {
-  const pending = opts.pending ?? [];
-  const cfg = makeRepoConfig(opts.cfg ?? {});
-  const expired: string[] = [];
-  const floor = opts.expiryFloor ?? 0;
-
-  const store: AutoExpireDeps["store"] = {
-    listPendingLearnings: () => pending,
-    getRepoConfig: () => cfg,
-    expiryFloorAt: () => floor,
-    expireLearning: (id) => {
-      const r = pending.find((x) => x.id === id);
-      if (!r) return null;
-      expired.push(id);
-      return { ...r, status: "dismissed" };
-    },
-  };
-
-  return { store, expired };
-}
-
-describe("runAutoExpire", () => {
-  const THIRTY_DAYS = 30 * 86_400_000;
-
-  function staleRule(id: string, repoPath = "/repo"): Learning {
-    const past = Date.now() - THIRTY_DAYS - 1;
-    return makeLearning({
-      id,
-      repoPath,
-      status: "proposed",
-      lastEvidenceAt: past,
-      createdAt: past,
-      evidenceCount: 0,
-      distinctSessions: 0,
-      distinctKinds: 0,
-    });
+  function fakeStore() {
+    const calls: number[] = [];
+    let removed = 0;
+    return {
+      calls,
+      setRemoved(n: number) {
+        removed = n;
+      },
+      store: {
+        pruneStaleProposedLearnings: (beforeTs: number) => {
+          calls.push(beforeTs);
+          return removed;
+        },
+      } satisfies ProposedPruneDeps["store"],
+    };
   }
 
-  test("caps at maxPerSweep", () => {
-    const pending = [staleRule("a"), staleRule("b"), staleRule("c"), staleRule("d")];
-    const { store, expired } = makeFakeExpireDeps({ pending });
-    const result = runAutoExpire({ store, now: Date.now(), maxPerSweep: 2, expireDays: 30 });
-    expect(expired).toHaveLength(2);
-    expect(result).toHaveLength(2);
+  test("computes cutoff = now - PRUNE_DAYS(3) days by default", () => {
+    const now = 1_000_000_000_000;
+    const f = fakeStore();
+    runProposedPrune({ store: f.store, now });
+    expect(PRUNE_DAYS).toBe(3);
+    expect(f.calls).toEqual([now - 3 * DAY_MS]);
   });
 
-  test("gates on learningsEnabled", () => {
-    const pending = [staleRule("a")];
-    const { store, expired } = makeFakeExpireDeps({ pending, cfg: { learningsEnabled: false } });
-    const result = runAutoExpire({ store, now: Date.now(), maxPerSweep: 5, expireDays: 30 });
-    expect(expired).toHaveLength(0);
-    expect(result).toHaveLength(0);
+  test("honors an injected retentionDays", () => {
+    const now = 1_000_000_000_000;
+    const f = fakeStore();
+    runProposedPrune({ store: f.store, now, retentionDays: 7 });
+    expect(f.calls).toEqual([now - 7 * DAY_MS]);
   });
 
-  test("reads floor from expiryFloorAt() and defers expiry", () => {
+  test("returns the store's removed count verbatim (drives sweep log/emit gating)", () => {
     const now = Date.now();
-    const pending = [staleRule("a")];
-    const { store, expired } = makeFakeExpireDeps({ pending, expiryFloor: now });
-    const result = runAutoExpire({ store, now, maxPerSweep: 5, expireDays: 30 });
-    expect(expired).toHaveLength(0);
-    expect(result).toHaveLength(0);
+    const zero = fakeStore();
+    expect(runProposedPrune({ store: zero.store, now })).toBe(0);
+    const many = fakeStore();
+    many.setRemoved(42);
+    expect(runProposedPrune({ store: many.store, now })).toBe(42);
   });
 });
 
@@ -1294,8 +1171,7 @@ describe("new constant defaults", () => {
     expect(TRIAL_REAP_DAYS).toBe(21);
     expect(TRIAL_REAP_MAX_DAYS).toBe(60);
     expect(MAX_REAP_PER_SWEEP).toBe(5);
-    expect(EXPIRE_DAYS).toBe(30);
-    expect(MAX_EXPIRE_PER_SWEEP).toBe(5);
+    expect(PRUNE_DAYS).toBe(3);
     expect(TRIAL_EXPIRED_REASON).toBe("trial-expired");
   });
 });

--- a/test/store-learnings.test.ts
+++ b/test/store-learnings.test.ts
@@ -1249,6 +1249,25 @@ test("#1794: prune returns 0 when no proposed row is eligible", () => {
   expect(s.getLearning(fresh.id)).not.toBeNull();
 });
 
+test("#1794: prune clears merged-history references to a reverted trial survivor", () => {
+  const s = new SessionStore(":memory:");
+  const cutoff = Date.now();
+  const survivor = s.addLearning({ repoPath: "/r", rule: "survivor", rationale: "", evidence: [] });
+  const source = s.addLearning({ repoPath: "/r", rule: "source", rationale: "", evidence: [] });
+  s.trialLearning(survivor.id);
+  s.setLearningStatus(source.id, "active");
+  s.retireLearningMerged(source.id, survivor.id);
+  expect(s.listSubsumedLearnings(survivor.id).map((learning) => learning.id)).toEqual([source.id]);
+
+  s.revertTrial(survivor.id, "proposed");
+  ageRow(s, survivor.id, cutoff - 1, cutoff - 1);
+  expect(s.pruneStaleProposedLearnings(cutoff)).toBe(1);
+
+  expect(s.getLearning(survivor.id)).toBeNull();
+  expect(s.getLearning(source.id)?.mergedIntoId).toBeNull();
+  expect(s.listSubsumedLearnings(survivor.id)).toEqual([]);
+});
+
 test("#925: listTrialLearnings returns only active+trialedAt rows, oldest-trial first", () => {
   const s = new SessionStore(":memory:");
   const l1 = s.addLearning({ repoPath: "/r", rule: "r1", rationale: "", evidence: [] });

--- a/test/store-learnings.test.ts
+++ b/test/store-learnings.test.ts
@@ -1167,19 +1167,86 @@ test("#925: accrueProposedEvidence null-sessionId signal merges kind but not ses
   expect(updated.distinctSessions).toBe(1); // only s1
 });
 
-test("#925: expireLearning proposed→dismissed only", () => {
+// ── #1794: pruneStaleProposedLearnings (permanent 3-day retention) ─────────────
+
+/** Force createdAt/lastEvidenceAt on a row so age is deterministic (no public setter). */
+function ageRow(s: SessionStore, id: string, createdAt: number, lastEvidenceAt: number | null) {
+  (s as unknown as { db: { run(sql: string, params: unknown[]): void } }).db.run(
+    `UPDATE learnings SET createdAt = ?, lastEvidenceAt = ? WHERE id = ?`,
+    [createdAt, lastEvidenceAt, id],
+  );
+}
+
+test("#1794: prune permanently deletes every stale proposed row (no per-sweep cap)", () => {
   const s = new SessionStore(":memory:");
-  const l = s.addLearning({ repoPath: "/r", rule: "r", rationale: "", evidence: [] });
-  const expired = s.expireLearning(l.id)!;
-  expect(expired).not.toBeNull();
-  expect(expired.status).toBe("dismissed");
-  // active → null
-  const a = s.addLearning({ repoPath: "/r", rule: "a", rationale: "", evidence: [] });
-  s.setLearningStatus(a.id, "active");
-  expect(s.expireLearning(a.id)).toBeNull();
-  expect(s.getLearning(a.id)!.status).toBe("active");
-  // missing → null
-  expect(s.expireLearning("nope")).toBeNull();
+  const cutoff = Date.now();
+  const ids = Array.from({ length: 7 }, (_, i) => {
+    const l = s.addLearning({ repoPath: "/r", rule: `r${i}`, rationale: "", evidence: [] });
+    ageRow(s, l.id, cutoff - 1, null);
+    return l.id;
+  });
+  expect(s.pruneStaleProposedLearnings(cutoff)).toBe(7); // uncapped: all 7, past the old 5-cap
+  for (const id of ids) expect(s.getLearning(id)).toBeNull(); // permanent, not soft-dismissed
+});
+
+test("#1794: prune boundary is strict (< cutoff): exactly-at and newer survive", () => {
+  const s = new SessionStore(":memory:");
+  const cutoff = Date.now();
+  const older = s.addLearning({ repoPath: "/r", rule: "older", rationale: "", evidence: [] });
+  const atCut = s.addLearning({ repoPath: "/r", rule: "at", rationale: "", evidence: [] });
+  const newer = s.addLearning({ repoPath: "/r", rule: "newer", rationale: "", evidence: [] });
+  ageRow(s, older.id, cutoff - 1, null);
+  ageRow(s, atCut.id, cutoff, null);
+  ageRow(s, newer.id, cutoff + 1, null);
+  expect(s.pruneStaleProposedLearnings(cutoff)).toBe(1);
+  expect(s.getLearning(older.id)).toBeNull();
+  expect(s.getLearning(atCut.id)).not.toBeNull(); // exactly at cutoff survives until a later sweep
+  expect(s.getLearning(newer.id)).not.toBeNull();
+});
+
+test("#1794: prune ages by COALESCE(lastEvidenceAt, createdAt) — fresh evidence refreshes retention", () => {
+  const s = new SessionStore(":memory:");
+  const cutoff = Date.now();
+  // stale createdAt but recent lastEvidenceAt → survives
+  const refreshed = s.addLearning({ repoPath: "/r", rule: "fresh", rationale: "", evidence: [] });
+  ageRow(s, refreshed.id, cutoff - 10_000, cutoff + 1);
+  // stale latest evidence → removed
+  const stale = s.addLearning({ repoPath: "/r", rule: "stale", rationale: "", evidence: [] });
+  ageRow(s, stale.id, cutoff - 10_000, cutoff - 1);
+  expect(s.pruneStaleProposedLearnings(cutoff)).toBe(1);
+  expect(s.getLearning(refreshed.id)).not.toBeNull();
+  expect(s.getLearning(stale.id)).toBeNull();
+});
+
+test("#1794: prune only touches proposed rows — active/promoted/dismissed/retired preserved", () => {
+  const s = new SessionStore(":memory:");
+  const cutoff = Date.now();
+  const active = s.addLearning({ repoPath: "/r", rule: "a", rationale: "", evidence: [] });
+  s.setLearningStatus(active.id, "active");
+  const promoted = s.addLearning({ repoPath: "/r", rule: "p", rationale: "", evidence: [] });
+  s.setLearningStatus(promoted.id, "active");
+  s.setLearningStatus(promoted.id, "promoted");
+  const dismissed = s.addLearning({ repoPath: "/r", rule: "d", rationale: "", evidence: [] });
+  s.setLearningStatus(dismissed.id, "dismissed");
+  const retired = s.addLearning({ repoPath: "/r", rule: "x", rationale: "", evidence: [] });
+  s.setLearningStatus(retired.id, "active");
+  s.retireLearning(retired.id, "auto-retire");
+  for (const id of [active.id, promoted.id, dismissed.id, retired.id])
+    ageRow(s, id, cutoff - 1, cutoff - 1);
+  expect(s.pruneStaleProposedLearnings(cutoff)).toBe(0);
+  expect(s.getLearning(active.id)!.status).toBe("active");
+  expect(s.getLearning(promoted.id)!.status).toBe("promoted");
+  expect(s.getLearning(dismissed.id)!.status).toBe("dismissed");
+  expect(s.getLearning(retired.id)!.status).toBe("retired");
+});
+
+test("#1794: prune returns 0 when no proposed row is eligible", () => {
+  const s = new SessionStore(":memory:");
+  const cutoff = Date.now();
+  const fresh = s.addLearning({ repoPath: "/r", rule: "r", rationale: "", evidence: [] });
+  ageRow(s, fresh.id, cutoff + 1, null);
+  expect(s.pruneStaleProposedLearnings(cutoff)).toBe(0);
+  expect(s.getLearning(fresh.id)).not.toBeNull();
 });
 
 test("#925: listTrialLearnings returns only active+trialedAt rows, oldest-trial first", () => {
@@ -1233,12 +1300,6 @@ test("#925: listPendingLearnings orders by evidenceCount DESC then lastEvidenceA
   expect(pending[0]!.id).toBe(l_high.id); // 5 evidence
   expect(pending[1]!.id).toBe(l_mid.id); // 2 evidence
   expect(pending[2]!.id).toBe(l_low.id); // 0 evidence
-});
-
-test("#925: expiryFloorAt returns the stamped floor after backfill (non-zero on fresh DB)", () => {
-  const s = new SessionStore(":memory:");
-  // backfillLearningDiversity runs on construction and stamps learnings:expiry-floor
-  expect(s.expiryFloorAt()).toBeGreaterThan(0);
 });
 
 test("#925: new DB columns exist with correct defaults after migration", () => {


### PR DESCRIPTION
Closes #1794.

## What & why

Shepherd accumulated 500+ learnings. The old maintenance path only **soft-dismissed up to 5** stale proposals per daily sweep after **30 days**, so it couldn't bound the backlog or table growth. This replaces it with a **fixed 3-day retention** that **permanently deletes all** stale `proposed` learnings each boot/daily sweep.

## Behavior

- **Eligibility:** only `proposed` rows, aged by `COALESCE(lastEvidenceAt, createdAt)`, strict `<` cutoff (a row exactly at the cutoff survives until a later sweep).
- **Permanent, uncapped:** one status-scoped bulk `DELETE`, no per-sweep cap, no exemption for strong/trial-worthy proposals or disabled repos. Fresh evidence may re-propose the same idea later.
- **Preserved:** `active`, `promoted`, `dismissed`, `retired` rows are never touched.
- **Precedence:** the synchronous prune runs **before** async distillation / merge-suggestion / auto-trial work, giving retention deterministic precedence. Logs + `emitPending()` only when the count is `> 0`.

## Design

- `SessionStore.pruneStaleProposedLearnings(beforeTs)` — identical predicate for count and delete, no hydration.
- DI'd `runProposedPrune({ store, now?, retentionDays? })` lifecycle orchestrator mirroring `runAutoTrial`/`runReapStaleTrials`, unit-tested with an injected clock.
- Retention window is env-overridable: `SHEPHERD_LEARNINGS_PRUNE_DAYS ?? 3`.
- Removed the superseded soft-expiry machinery: `runAutoExpire`, `shouldExpireProposed`, `expireLearning`, `expiryFloorAt`, `EXPIRE_DAYS`, `MAX_EXPIRE_PER_SWEEP`, `ExpiredRecord`, `AutoExpireDeps`, and the now-dead `learnings:expiry-floor` stamp.

## Owned trade-off

Prune-before-auto-trial with no exemption means an auto-trial-eligible-but-stale proposal (no fresh evidence in 3 days) is permanently deleted before the capped (`MAX_TRIAL_PER_SWEEP=3/day`) auto-trial could promote it. This is the intended "discard learnings older than three days" semantics — staleness is measured by *fresh* evidence recency, and genuinely recurring evidence re-proposes it.

## Out of scope (intentional)

No per-repo `learningsEnabled` gate, no per-sweep cap, no prune push notification, no migration to clear the now-unused `learnings:expiry-floor` kv row (harmless; reads simply stop).

## Testing

- New store tests: uncapped/permanent deletion past the old 5-cap, strict-boundary survival, `lastEvidenceAt`-over-`createdAt` recurrence, all non-proposed statuses preserved, empty-eligible → 0.
- New lifecycle test: injected-`now` cutoff (default 3-day + injected `retentionDays`) and verbatim count return driving the sweep gate.
- `bun run lint` clean; `bun test ./test` — 7184 pass, 0 fail. No dangling references to any removed symbol.

Server-only housekeeping — no UI, i18n, glossary, feature-announcement, public API, migration, or manual post-merge step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)