### PR TITLE
feat(ui): resizable Repos modal + repository sidebar with local persistence

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -326,6 +326,8 @@
   "promptsources_epic_hint": "Über „Start“ starten, nicht als Aufgabe.",
   "slash_menu_label": "Slash-Befehle",
   "slash_menu_empty": "keine passenden Befehle",
+  "repos_resize_modal": "Ziehen zum Anpassen des Repos-Fensters · Doppelklick zum Zurücksetzen",
+  "repos_resize_sidebar": "Ziehen zum Anpassen der Repository-Liste · Doppelklick zum Zurücksetzen",
   "reposelect_placeholder": "Repo auswählen…",
   "reposelect_filter_placeholder": "filtern…",
   "reposelect_no_matches": "keine Treffer",
@@ -3242,5 +3244,7 @@
   "feat_recap_diagnostics_title": "Fehlende Recaps verstehen",
   "feat_recap_diagnostics_body": "Abgeschlossene Sessions zeigen jetzt, wie sie beendet wurden und warum ein Recap fehlt. Sessions ohne Änderungen erhalten weiterhin ein Recap mit einem klaren No-Diff-Hinweis; technische Fehler enthalten eine Handlungsempfehlung und redigierte Details.",
   "feat_desktop_herd_group_collapse_title": "Lebenszyklus-Gruppen auch am Desktop einklappen",
-  "feat_desktop_herd_group_collapse_body": "Die Gruppen-Header der Desktop-Session-Leiste (CI läuft, Dein Zug, Gemergt, …) sind jetzt ebenfalls klappbar: Ein Klick auf einen Header klappt die Gruppe zu — jede Gruppe unabhängig, und Sprünge zu einer Session in einer eingeklappten Gruppe öffnen sie automatisch wieder."
+  "feat_desktop_herd_group_collapse_body": "Die Gruppen-Header der Desktop-Session-Leiste (CI läuft, Dein Zug, Gemergt, …) sind jetzt ebenfalls klappbar: Ein Klick auf einen Header klappt die Gruppe zu — jede Gruppe unabhängig, und Sprünge zu einer Session in einer eingeklappten Gruppe öffnen sie automatisch wieder.",
+  "feat_resizable_repos_title": "Repos-Fenster in der Größe anpassen",
+  "feat_resizable_repos_body": "Am Desktop öffnet sich das Repos-Fenster jetzt deutlich größer und merkt sich deine Größe: Ziehe an der unteren rechten Ecke, um das gesamte Fenster anzupassen, und ziehe an der Trennlinie zwischen der Repository-Liste und dem Detailbereich, um eine der Seiten zu verbreitern. Beide Größen werden in diesem Browser gespeichert; ein Doppelklick auf einen Griff setzt sie zurück."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -326,6 +326,8 @@
   "promptsources_epic_hint": "Run via Start, not as a task.",
   "slash_menu_label": "slash commands",
   "slash_menu_empty": "no matching commands",
+  "repos_resize_modal": "Drag to resize the Repos window · double-click to reset",
+  "repos_resize_sidebar": "Drag to resize the repository list · double-click to reset",
   "reposelect_placeholder": "select a repo…",
   "reposelect_filter_placeholder": "filter…",
   "reposelect_no_matches": "no matches",
@@ -3242,5 +3244,7 @@
   "feat_recap_diagnostics_title": "Understand missing recaps",
   "feat_recap_diagnostics_body": "Finished sessions now show how they were completed and why a recap is missing. No-change sessions still get a recap with a clear no-diff warning; technical failures include actionable guidance and redacted details.",
   "feat_desktop_herd_group_collapse_title": "Fold lifecycle groups on the desktop",
-  "feat_desktop_herd_group_collapse_body": "The desktop session rail's lifecycle group headers (CI running, Your turn, Merged, …) are now collapsible too: click a header to fold that group away — each group toggles independently, and jumps to a session hidden in a folded group reopen it automatically."
+  "feat_desktop_herd_group_collapse_body": "The desktop session rail's lifecycle group headers (CI running, Your turn, Merged, …) are now collapsible too: click a header to fold that group away — each group toggles independently, and jumps to a session hidden in a folded group reopen it automatically.",
+  "feat_resizable_repos_title": "Resize the Repos window",
+  "feat_resizable_repos_body": "On desktop the Repos window now opens much larger and remembers your size: drag the bottom-right corner to resize the whole window, and drag the divider between the repository list and the detail pane to widen either side. Both sizes are saved in this browser; double-click a handle to reset."
 }

--- a/ui/src/lib/backlog-layout.svelte.test.ts
+++ b/ui/src/lib/backlog-layout.svelte.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+// Stub localStorage before importing the module so the singleton's read() calls
+// at init don't touch a real or missing localStorage. (Mirrors
+// herd-width.svelte.test.ts.)
+const store: Record<string, string> = {};
+const localStorageMock = {
+  getItem: (key: string) => store[key] ?? null,
+  setItem: (key: string, value: string) => {
+    store[key] = value;
+  },
+  removeItem: (key: string) => {
+    delete store[key];
+  },
+  clear: () => {
+    for (const k of Object.keys(store)) delete store[k];
+  },
+};
+// @ts-expect-error stubbing global
+globalThis.localStorage = localStorageMock;
+
+import {
+  backlogLayout,
+  parseStored,
+  clampModalWidth,
+  clampModalHeight,
+  clampSidebarWidth,
+  MODAL_MIN_W,
+  MODAL_MIN_H,
+  OVERLAY_PAD,
+  SIDEBAR_MIN,
+  SIDEBAR_MAX,
+  DETAIL_MIN,
+} from "./backlog-layout.svelte";
+
+const KEY_W = "shepherd:repos-modal-w";
+const KEY_H = "shepherd:repos-modal-h";
+const KEY_SB = "shepherd:repos-sidebar-w";
+
+beforeEach(() => {
+  localStorageMock.clear();
+  backlogLayout.resetModal();
+  backlogLayout.resetSidebar();
+  localStorageMock.clear(); // clear side-effect writes from the resets above
+});
+
+// ---------------------------------------------------------------------------
+// parseStored — corrupt-storage fallback
+// ---------------------------------------------------------------------------
+
+describe("parseStored", () => {
+  it("returns null for missing / non-numeric / empty input", () => {
+    expect(parseStored(null)).toBe(null);
+    expect(parseStored("abc")).toBe(null);
+    expect(parseStored("")).toBe(null);
+    expect(parseStored("NaN")).toBe(null);
+  });
+
+  it("rejects non-positive and out-of-sanity-range values", () => {
+    expect(parseStored("0")).toBe(null);
+    expect(parseStored("-5")).toBe(null);
+    expect(parseStored("20000")).toBe(null); // over the absolute sanity ceiling
+  });
+
+  it("passes through a sane positive number (float preserved for later clamp)", () => {
+    expect(parseStored("300")).toBe(300);
+    expect(parseStored("300.6")).toBe(300.6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure clamps
+// ---------------------------------------------------------------------------
+
+describe("clampModalWidth", () => {
+  it("clamps below the minimum up to MODAL_MIN_W", () => {
+    expect(clampModalWidth(100, 1920)).toBe(MODAL_MIN_W);
+    expect(clampModalWidth(MODAL_MIN_W - 1, 1920)).toBe(MODAL_MIN_W);
+  });
+
+  it("clamps to the viewport ceiling minus the overlay padding", () => {
+    expect(clampModalWidth(5000, 1200)).toBe(1200 - OVERLAY_PAD);
+  });
+
+  it("passes through and rounds a value inside the range", () => {
+    expect(clampModalWidth(1000, 1920)).toBe(1000);
+    expect(clampModalWidth(1000.6, 1920)).toBe(1001);
+  });
+
+  it("never returns below the floor even on a tiny viewport", () => {
+    // vw - PAD < MODAL_MIN_W → floor wins (narrow desktop → mobile layout anyway)
+    expect(clampModalWidth(500, 400)).toBe(MODAL_MIN_W);
+  });
+});
+
+describe("clampModalHeight", () => {
+  it("clamps below the minimum up to MODAL_MIN_H", () => {
+    expect(clampModalHeight(100, 1080)).toBe(MODAL_MIN_H);
+  });
+
+  it("clamps to the viewport ceiling minus the overlay padding", () => {
+    expect(clampModalHeight(5000, 900)).toBe(900 - OVERLAY_PAD);
+  });
+
+  it("passes through inside the range", () => {
+    expect(clampModalHeight(700, 1080)).toBe(700);
+  });
+});
+
+describe("clampSidebarWidth", () => {
+  it("clamps below the minimum up to SIDEBAR_MIN", () => {
+    expect(clampSidebarWidth(50, 1600)).toBe(SIDEBAR_MIN);
+  });
+
+  it("clamps to SIDEBAR_MAX when the split is wide", () => {
+    expect(clampSidebarWidth(9999, 4000)).toBe(SIDEBAR_MAX);
+  });
+
+  it("leaves the detail pane at least DETAIL_MIN (narrow split lowers the max)", () => {
+    // max = min(SIDEBAR_MAX, innerW - DETAIL_MIN) = min(560, 800-380) = 420
+    expect(clampSidebarWidth(9999, 800)).toBe(800 - DETAIL_MIN);
+  });
+
+  it("passes through and rounds a value inside the range", () => {
+    expect(clampSidebarWidth(300, 1600)).toBe(300);
+    expect(clampSidebarWidth(300.4, 1600)).toBe(300);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Store: set / commit / reset / localStorage
+// ---------------------------------------------------------------------------
+
+describe("backlogLayout store", () => {
+  it("starts null (defaults) with unset localStorage", () => {
+    expect(backlogLayout.width).toBe(null);
+    expect(backlogLayout.height).toBe(null);
+    expect(backlogLayout.sidebar).toBe(null);
+  });
+
+  it("setModal updates without persisting", () => {
+    backlogLayout.setModal(1200, 800);
+    expect(backlogLayout.width).toBe(1200);
+    expect(backlogLayout.height).toBe(800);
+    expect(store[KEY_W]).toBeUndefined();
+    expect(store[KEY_H]).toBeUndefined();
+  });
+
+  it("commitModal persists both dimensions", () => {
+    backlogLayout.setModal(1200, 800);
+    backlogLayout.commitModal();
+    expect(store[KEY_W]).toBe("1200");
+    expect(store[KEY_H]).toBe("800");
+  });
+
+  it("commitModal no-ops when unset (never pins the default)", () => {
+    backlogLayout.commitModal();
+    expect(store[KEY_W]).toBeUndefined();
+    expect(store[KEY_H]).toBeUndefined();
+  });
+
+  it("resetModal clears state + stored values", () => {
+    backlogLayout.setModal(1200, 800);
+    backlogLayout.commitModal();
+    backlogLayout.resetModal();
+    expect(backlogLayout.width).toBe(null);
+    expect(backlogLayout.height).toBe(null);
+    expect(store[KEY_W]).toBeUndefined();
+    expect(store[KEY_H]).toBeUndefined();
+  });
+
+  it("setSidebar / commitSidebar / resetSidebar round-trip", () => {
+    backlogLayout.setSidebar(360);
+    expect(backlogLayout.sidebar).toBe(360);
+    expect(store[KEY_SB]).toBeUndefined();
+    backlogLayout.commitSidebar();
+    expect(store[KEY_SB]).toBe("360");
+    backlogLayout.resetSidebar();
+    expect(backlogLayout.sidebar).toBe(null);
+    expect(store[KEY_SB]).toBeUndefined();
+  });
+
+  it("commit swallows storage errors (unavailable / private mode)", () => {
+    backlogLayout.setModal(1000, 700);
+    backlogLayout.setSidebar(300);
+    const orig = localStorageMock.setItem;
+    localStorageMock.setItem = () => {
+      throw new Error("QuotaExceeded");
+    };
+    expect(() => backlogLayout.commitModal()).not.toThrow();
+    expect(() => backlogLayout.commitSidebar()).not.toThrow();
+    localStorageMock.setItem = orig;
+  });
+});

--- a/ui/src/lib/backlog-layout.svelte.ts
+++ b/ui/src/lib/backlog-layout.svelte.ts
@@ -1,0 +1,140 @@
+// Persisted desktop layout for the Repos modal (BacklogOverlay) + its internal
+// repository sidebar (BacklogView). Mirrors herd-width.svelte.ts: a singleton of
+// $state prefs (null = "use the CSS default"), a live set() during a drag, a
+// commit() on pointerup, and a reset() that clears both the state + stored value.
+// All localStorage access is try/caught (SSR / private mode). Issue #1787.
+
+const KEY_W = "shepherd:repos-modal-w";
+const KEY_H = "shepherd:repos-modal-h";
+const KEY_SB = "shepherd:repos-sidebar-w";
+
+// Modal floors — keep the header, tabs, repo controls + detail content usable.
+export const MODAL_MIN_W = 640;
+export const MODAL_MIN_H = 460;
+// The .overlay padding (24px each side) the live viewport ceiling must leave free
+// so the card edge / close button can't be clipped. Mirrored in the render CSS as
+// min(stored, calc(100vw - 48px)).
+export const OVERLAY_PAD = 48;
+
+// Sidebar bounds. MIN aligns to the existing design min track (minmax(220px,300px));
+// DETAIL_MIN keeps the detail column usable, so the sidebar's live max always
+// leaves it room. The 300px default lives in CSS (var(--repos-sidebar, 300px)).
+export const SIDEBAR_MIN = 220;
+export const SIDEBAR_MAX = 560;
+export const DETAIL_MIN = 380;
+
+// Generous absolute ceiling for a stored dimension — rejects garbage at parse time
+// while the live viewport ceiling is enforced in CSS.
+const ABS_MAX = 10000;
+
+/** Parse a raw localStorage string into a sane positive px number, else null.
+ *  Rejects non-numeric / non-finite / non-positive / out-of-sanity-range values
+ *  (corrupt-storage fallback). Kept pure + exported for unit testing. */
+export function parseStored(raw: string | null): number | null {
+  if (raw === null) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 && n <= ABS_MAX ? n : null;
+}
+
+/** Round + clamp a modal width into [MODAL_MIN_W, min(vw - OVERLAY_PAD, ABS_MAX)].
+ *  `vw` = viewport width (pass window.innerWidth live during a drag, or a fixed
+ *  value in tests). Used by the corner-drag handler; render CSS mirrors the ceiling. */
+export function clampModalWidth(px: number, vw: number): number {
+  const max = Math.min(ABS_MAX, Math.max(MODAL_MIN_W, vw - OVERLAY_PAD));
+  return Math.round(Math.min(max, Math.max(MODAL_MIN_W, px)));
+}
+
+/** Round + clamp a modal height into [MODAL_MIN_H, min(vh - OVERLAY_PAD, ABS_MAX)]. */
+export function clampModalHeight(px: number, vh: number): number {
+  const max = Math.min(ABS_MAX, Math.max(MODAL_MIN_H, vh - OVERLAY_PAD));
+  return Math.round(Math.min(max, Math.max(MODAL_MIN_H, px)));
+}
+
+/** Round + clamp a sidebar width into
+ *  [SIDEBAR_MIN, min(SIDEBAR_MAX, modalInnerW - DETAIL_MIN)].
+ *  `modalInnerW` = the .desktop-split width; keeps the detail pane >= DETAIL_MIN. */
+export function clampSidebarWidth(px: number, modalInnerW: number): number {
+  const max = Math.max(SIDEBAR_MIN, Math.min(SIDEBAR_MAX, modalInnerW - DETAIL_MIN));
+  return Math.round(Math.min(max, Math.max(SIDEBAR_MIN, px)));
+}
+
+function readNum(key: string): number | null {
+  try {
+    return parseStored(localStorage.getItem(key));
+  } catch {
+    return null;
+  }
+}
+
+/** Sidebar read applies the viewport-independent [SIDEBAR_MIN, SIDEBAR_MAX] clamp
+ *  at init; the component re-clamps against the live split width (DETAIL_MIN) on
+ *  the next render/drag. */
+function readSidebar(): number | null {
+  const n = readNum(KEY_SB);
+  if (n === null) return null;
+  return Math.round(Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, n)));
+}
+
+/** Persisted, drag-driven desktop layout for the Repos modal. Each field null =
+ *  "use the responsive default"; a number is a pinned px value. */
+class BacklogLayout {
+  width = $state<number | null>(readNum(KEY_W));
+  height = $state<number | null>(readNum(KEY_H));
+  sidebar = $state<number | null>(readSidebar());
+
+  /** Live modal-drag update — caller pre-clamps with clampModal{Width,Height};
+   *  NOT persisted (avoids localStorage thrash on every pointermove). */
+  setModal(w: number, h: number) {
+    this.width = w;
+    this.height = h;
+  }
+
+  /** Persist the modal size. No-ops when unset so a never-moved drag can't pin
+   *  the default. */
+  commitModal() {
+    if (this.width === null || this.height === null) return;
+    try {
+      localStorage.setItem(KEY_W, String(this.width));
+      localStorage.setItem(KEY_H, String(this.height));
+    } catch {
+      /* private mode / SSR — preference just won't survive reload */
+    }
+  }
+
+  /** Reset the modal to its CSS default (clears the pin + stored values). */
+  resetModal() {
+    this.width = null;
+    this.height = null;
+    try {
+      localStorage.removeItem(KEY_W);
+      localStorage.removeItem(KEY_H);
+    } catch {
+      /* private mode / SSR — nothing to clear */
+    }
+  }
+
+  /** Live sidebar-drag update — caller pre-clamps with clampSidebarWidth. */
+  setSidebar(w: number) {
+    this.sidebar = w;
+  }
+
+  commitSidebar() {
+    if (this.sidebar === null) return;
+    try {
+      localStorage.setItem(KEY_SB, String(this.sidebar));
+    } catch {
+      /* private mode / SSR */
+    }
+  }
+
+  resetSidebar() {
+    this.sidebar = null;
+    try {
+      localStorage.removeItem(KEY_SB);
+    } catch {
+      /* private mode / SSR */
+    }
+  }
+}
+
+export const backlogLayout = new BacklogLayout();

--- a/ui/src/lib/components/BacklogOverlay.browser.test.ts
+++ b/ui/src/lib/components/BacklogOverlay.browser.test.ts
@@ -1,11 +1,17 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { tick } from "svelte";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
 import BacklogOverlay from "./BacklogOverlay.svelte";
+import { backlogLayout } from "$lib/backlog-layout.svelte";
 import type { BacklogPayload, BacklogProject } from "$lib/types";
 
 const noop = () => {};
+
+const KEY_W = "shepherd:repos-modal-w";
+const KEY_H = "shepherd:repos-modal-h";
+const KEY_SB = "shepherd:repos-sidebar-w";
 
 function project(path: string): BacklogProject {
   return {
@@ -22,8 +28,8 @@ function project(path: string): BacklogProject {
   };
 }
 
-// n projects → the master list wants to be n·rows tall; pre-fix (max-height only)
-// the shell grows to fit that, so busy vs sparse payloads yield different shell heights.
+// n projects → the master list wants to be n·rows tall; the fixed shell height
+// keeps busy vs sparse payloads from resizing the shell (the list scrolls inside).
 function payload(n: number): BacklogPayload {
   return {
     pinnedPath: null,
@@ -48,40 +54,165 @@ function props(over: Partial<Record<string, unknown>> = {}) {
   };
 }
 
-// Mirrors the "Settings dialog layout stability" guard added in PR #1369 for the
-// Settings modal: the Repos modal shell (.card in BacklogOverlay) carries a fixed
-// height: min(720px, 88vh), so switching between a content-heavy and a sparse repo
-// list must NOT resize the shell — the master list scrolls inside instead.
-describe("BacklogOverlay (Repos) shell layout stability", () => {
-  afterEach(async () => {
-    await page.viewport(1280, 900);
+function pointer(el: Element, type: string, x: number, y: number) {
+  el.dispatchEvent(
+    new PointerEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      clientX: x,
+      clientY: y,
+      button: 0,
+      pointerId: 1,
+      isPrimary: true,
+    }),
+  );
+}
+
+/** Drag `el` by (dx,dy) from its current center via synthetic pointer events. */
+function drag(el: Element, dx: number, dy: number) {
+  const r = el.getBoundingClientRect();
+  const sx = r.left + r.width / 2;
+  const sy = r.top + r.height / 2;
+  pointer(el, "pointerdown", sx, sy);
+  pointer(el, "pointermove", sx + dx, sy + dy);
+  pointer(el, "pointerup", sx + dx, sy + dy);
+}
+
+beforeEach(async () => {
+  localStorage.removeItem(KEY_W);
+  localStorage.removeItem(KEY_H);
+  localStorage.removeItem(KEY_SB);
+  backlogLayout.resetModal();
+  backlogLayout.resetSidebar();
+  await page.viewport(1280, 900);
+});
+
+afterEach(async () => {
+  backlogLayout.resetModal();
+  backlogLayout.resetSidebar();
+  await page.viewport(1280, 900);
+});
+
+// ── default geometry + stability ────────────────────────────────────────────
+describe("BacklogOverlay (Repos) default geometry", () => {
+  it("opens at ~90vw × 88vh (no more 960px cap)", async () => {
+    await render(BacklogOverlay, props());
+    const card = document.querySelector<HTMLElement>(".card")!;
+    expect(card.classList.contains("mobile")).toBe(false);
+    const rect = card.getBoundingClientRect();
+    expect(rect.width).toBeCloseTo(0.9 * window.innerWidth, -1);
+    expect(rect.height).toBeCloseTo(0.88 * window.innerHeight, -1);
+    // Substantially wider than the old 960px cap.
+    expect(rect.width).toBeGreaterThan(1000);
   });
 
-  it("keeps the modal shell height stable across content changes", async () => {
-    await page.viewport(1280, 900);
+  it("keeps the shell geometry stable across content changes", async () => {
     const { rerender } = await render(BacklogOverlay, props({ payload: payload(40) }));
+    const card = document.querySelector<HTMLElement>(".card")!;
+    const before = card.getBoundingClientRect();
 
-    const card = document.querySelector<HTMLElement>(".card");
-    expect(card).not.toBeNull();
-    // desktop shell, not the mobile full-screen sheet (whose height rules differ)
-    expect(card!.classList.contains("mobile")).toBe(false);
+    // The repo list — not the shell — absorbs overflow.
+    const master = document.querySelector<HTMLElement>(".master-pane")!;
+    expect(getComputedStyle(master).overflowY).toBe("auto");
 
-    const before = card!.getBoundingClientRect();
-    // Fixed height = min(720px, 88vh); at this viewport it resolves to the px clamp,
-    // i.e. NOT the taller content-driven height a 40-repo list would otherwise force.
-    const expected = Math.min(720, 0.88 * window.innerHeight);
-    expect(Math.abs(before.height - expected)).toBeLessThanOrEqual(3);
-
-    // The repo list — not the shell — is the scroller that absorbs overflow.
-    const master = document.querySelector<HTMLElement>(".master-pane");
-    expect(master).not.toBeNull();
-    expect(getComputedStyle(master!).overflowY).toBe("auto");
-
-    // Swap to a sparse payload: pre-fix this collapses the shell to its content;
-    // with the fixed height the shell geometry must be unchanged.
     await rerender(props({ payload: payload(2) }));
     const after = document.querySelector<HTMLElement>(".card")!.getBoundingClientRect();
     expect(after.height).toBeCloseTo(before.height, 0);
     expect(after.top).toBeCloseTo(before.top, 0);
+  });
+});
+
+// ── outer modal resize + persistence ────────────────────────────────────────
+describe("BacklogOverlay (Repos) modal resize", () => {
+  it("shrinks the shell on a corner drag and persists the size", async () => {
+    await render(BacklogOverlay, props());
+    const card = document.querySelector<HTMLElement>(".card")!;
+    const before = card.getBoundingClientRect();
+    const handle = document.querySelector<HTMLElement>(".resize-corner")!;
+    expect(handle).not.toBeNull();
+
+    // Drag the bottom-right corner up-left to shrink (stays clear of clamps).
+    drag(handle, -140, -100);
+    await tick();
+
+    const after = card.getBoundingClientRect();
+    expect(after.width).toBeLessThan(before.width - 50);
+    expect(after.height).toBeLessThan(before.height - 30);
+    // Committed to localStorage + the store.
+    expect(backlogLayout.width).not.toBeNull();
+    expect(localStorage.getItem(KEY_W)).toBe(String(backlogLayout.width));
+    expect(localStorage.getItem(KEY_H)).toBe(String(backlogLayout.height));
+  });
+
+  it("keeps the corner under the pointer (2× delta compensates for centering)", async () => {
+    await render(BacklogOverlay, props());
+    const card = document.querySelector<HTMLElement>(".card")!;
+    const handle = document.querySelector<HTMLElement>(".resize-corner")!;
+    const before = card.getBoundingClientRect();
+
+    // Shrink by (dx,dy): the bottom-right edge must follow the pointer 1:1, i.e.
+    // move by (dx,dy) — a 1× delta bug would move it only half as far.
+    const dx = -140;
+    const dy = -100;
+    drag(handle, dx, dy);
+    await tick();
+
+    const after = card.getBoundingClientRect();
+    expect(after.right - before.right).toBeCloseTo(dx, -1);
+    expect(after.bottom - before.bottom).toBeCloseTo(dy, -1);
+  });
+
+  it("clamps an oversized stored size to the viewport (measured geometry)", async () => {
+    // Seed a size far larger than the viewport, then render smaller.
+    backlogLayout.setModal(4000, 4000);
+    backlogLayout.commitModal();
+    await page.viewport(1100, 780);
+
+    await render(BacklogOverlay, props());
+    const rect = document.querySelector<HTMLElement>(".card")!.getBoundingClientRect();
+    // CSS ceiling = calc(100vw/vh − 48px); measured geometry must respect it.
+    expect(rect.width).toBeLessThanOrEqual(window.innerWidth - 48 + 1);
+    expect(rect.height).toBeLessThanOrEqual(window.innerHeight - 48 + 1);
+  });
+});
+
+// ── internal repository-sidebar resize + persistence ────────────────────────
+describe("BacklogOverlay (Repos) sidebar resize", () => {
+  it("widens the repo list on a divider drag and persists the width", async () => {
+    await render(BacklogOverlay, props());
+    const master = document.querySelector<HTMLElement>(".master-pane")!;
+    const splitter = document.querySelector<HTMLElement>(".repo-splitter")!;
+    expect(splitter).not.toBeNull();
+    const before = master.getBoundingClientRect().width;
+
+    drag(splitter, 90, 0);
+    await tick();
+
+    const after = document
+      .querySelector<HTMLElement>(".master-pane")!
+      .getBoundingClientRect().width;
+    expect(after).toBeGreaterThan(before + 40);
+    expect(backlogLayout.sidebar).not.toBeNull();
+    expect(localStorage.getItem(KEY_SB)).toBe(String(backlogLayout.sidebar));
+  });
+});
+
+// ── mobile ignores stored desktop sizes ─────────────────────────────────────
+describe("BacklogOverlay (Repos) mobile", () => {
+  it("stays full-screen and renders no resize handles despite stored sizes", async () => {
+    backlogLayout.setModal(800, 600);
+    backlogLayout.commitModal();
+    backlogLayout.setSidebar(500);
+    backlogLayout.commitSidebar();
+
+    await render(BacklogOverlay, props({ mobile: true }));
+    const card = document.querySelector<HTMLElement>(".card")!;
+    expect(card.classList.contains("mobile")).toBe(true);
+    expect(card.classList.contains("resized")).toBe(false);
+    // Full-screen, not the stored 800px.
+    expect(card.getBoundingClientRect().width).toBeCloseTo(window.innerWidth, -1);
+    // No desktop resize affordances mounted.
+    expect(document.querySelector(".resize-corner")).toBeNull();
+    expect(document.querySelector(".repo-splitter")).toBeNull();
   });
 });

--- a/ui/src/lib/components/BacklogOverlay.svelte
+++ b/ui/src/lib/components/BacklogOverlay.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import type { BacklogPayload, DrainStatus, Epic, Issue, PullRequest, Steer } from "$lib/types";
+  import { MediaQuery } from "svelte/reactivity";
   import { m } from "$lib/paraglide/messages";
   import { dialog } from "$lib/a11yDialog";
+  import { backlogLayout, clampModalWidth, clampModalHeight } from "$lib/backlog-layout.svelte";
+  import { createResizeDrag } from "$lib/resize-drag";
   import BacklogView from "./BacklogView.svelte";
 
   let {
@@ -51,6 +54,42 @@
      *  Automation tab's epic banner + drain-cap would be stale here. */
     drain?: Record<string, DrainStatus>;
   } = $props();
+
+  // ── Desktop modal resize (issue #1787) ──────────────────────────────────────
+  // Shared drag lifecycle (createResizeDrag) mirrors the Herd sidebar splitter:
+  // pointer capture, a threshold, live setModal on move, commit on up,
+  // double-click reset. Gated on !mobile && fine-pointer so the mobile
+  // full-screen sheet and touch tablets are untouched. The .card is flex-centered
+  // by .overlay, so a 1:1 delta would move the bottom-right corner at half speed —
+  // onDrag doubles the delta per axis so the corner tracks the pointer 1:1.
+  const coarse = new MediaQuery("(pointer: coarse)");
+  const resizable = $derived(!mobile && !coarse.current);
+  const resized = $derived(
+    resizable && backlogLayout.width !== null && backlogLayout.height !== null,
+  );
+  const sizeStyle = $derived(
+    resized ? `--repos-w:${backlogLayout.width}px;--repos-h:${backlogLayout.height}px` : undefined,
+  );
+
+  let cardEl = $state<HTMLElement>();
+  let modalResizing = $state(false);
+
+  const startModalResize = createResizeDrag<{ x: number; y: number; w: number; h: number }>({
+    axis: "both",
+    onActive: (a) => (modalResizing = a),
+    onStart: (e) => {
+      if (!resizable || !cardEl) return null;
+      const r = cardEl.getBoundingClientRect();
+      return { x: e.clientX, y: e.clientY, w: r.width, h: r.height };
+    },
+    onDrag: (e, c) =>
+      backlogLayout.setModal(
+        clampModalWidth(c.w + 2 * (e.clientX - c.x), window.innerWidth),
+        clampModalHeight(c.h + 2 * (e.clientY - c.y), window.innerHeight),
+      ),
+    onCommit: () => backlogLayout.commitModal(),
+    onReset: () => backlogLayout.resetModal(),
+  });
 </script>
 
 <div
@@ -64,6 +103,10 @@
   <div
     class="card"
     class:mobile
+    class:resized
+    class:resizing={modalResizing}
+    bind:this={cardEl}
+    style={sizeStyle}
     role="dialog"
     aria-modal="true"
     aria-label={m.actionbar_backlog()}
@@ -93,6 +136,20 @@
         {drain}
       />
     </div>
+    {#if resizable}
+      <!-- Bottom-right resize grip (issue #1787). Drag to resize the modal,
+           double-click to reset — see startModalResize. Rendered only on
+           fine-pointer desktop; never on the mobile full-screen sheet. role
+           mirrors the Herd splitter (no ideal ARIA role for a 2D grip). -->
+      <div
+        class="resize-corner"
+        class:dragging={modalResizing}
+        role="separator"
+        aria-label={m.repos_resize_modal()}
+        title={m.repos_resize_modal()}
+        onpointerdown={startModalResize}
+      ></div>
+    {/if}
   </div>
 </div>
 
@@ -111,14 +168,32 @@
     padding: 0;
   }
   .card {
-    width: min(960px, 94vw);
-    height: min(720px, 88vh);
-    max-height: 88vh;
+    /* Default (issue #1787): fill most of a wide desktop viewport — the old
+       min(960px, 94vw) cap left large monitors mostly unused. */
+    width: 90vw;
+    height: 88vh;
+    position: relative;
     border: 1px solid var(--color-line-bright);
     background: var(--color-panel);
     display: flex;
     flex-direction: column;
     overflow: hidden;
+  }
+  /* Operator-chosen size (issue #1787). --repos-w/-h are clamped px from the
+     corner drag; min(stored, calc(100vw/vh - 48px)) is the reactive clamp-on-
+     restore — the -48px leaves the .overlay's 24px padding on each side free so
+     the card edge / close button can't be clipped when the viewport shrinks.
+     min-width/min-height keep the shell usable if a stored value is tiny. */
+  .card.resized {
+    width: min(var(--repos-w), calc(100vw - 48px));
+    height: min(var(--repos-h), calc(100vh - 48px));
+    min-width: 640px;
+    min-height: 460px;
+  }
+  /* During an active drag: kill text selection + force the resize cursor. */
+  .card.resizing {
+    user-select: none;
+    cursor: nwse-resize;
   }
   .card.mobile {
     width: 100%;
@@ -160,5 +235,38 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
+  }
+  /* Bottom-right resize grip (issue #1787): a restrained ~16px hit target with a
+     diagonal hairline (::after) that brightens on hover/focus/drag — detectable
+     without decorative color, matching the Herd splitter's treatment. */
+  .resize-corner {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    width: 16px;
+    height: 16px;
+    cursor: nwse-resize;
+    z-index: 5;
+    touch-action: none;
+  }
+  .resize-corner::after {
+    content: "";
+    position: absolute;
+    right: 3px;
+    bottom: 3px;
+    width: 7px;
+    height: 7px;
+    border-right: 2px solid var(--color-line-bright);
+    border-bottom: 2px solid var(--color-line-bright);
+    opacity: 0.5;
+    transition: opacity 0.12s ease;
+  }
+  .resize-corner:hover::after,
+  .resize-corner:focus-visible::after,
+  .resize-corner.dragging::after {
+    opacity: 1;
+  }
+  .resize-corner:focus-visible {
+    outline: none;
   }
 </style>

--- a/ui/src/lib/components/BacklogView.svelte
+++ b/ui/src/lib/components/BacklogView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { untrack } from "svelte";
+  import { MediaQuery } from "svelte/reactivity";
   import type {
     BacklogPayload,
     DocAgentOutcome,
@@ -20,6 +21,8 @@
   import { actionsTabState, filterProjects, splitHidden } from "./backlog-view";
   import { repoConfig } from "$lib/reviews.svelte";
   import { pullMainAndToast } from "$lib/pull-offer";
+  import { backlogLayout, clampSidebarWidth } from "$lib/backlog-layout.svelte";
+  import { createResizeDrag } from "$lib/resize-drag";
 
   let {
     payload,
@@ -92,6 +95,40 @@
      *  brand-new (zero issues/PRs) repo isn't excluded from the visible list. */
     selectPath?: string | null;
   } = $props();
+
+  // ── Desktop repository-sidebar resize (issue #1787) ─────────────────────────
+  // Shared drag lifecycle (createResizeDrag) — see BacklogOverlay. The separator
+  // lives in .desktop-split (a non-scrolling position:relative wrapper) at the
+  // track boundary, so drag adjusts only the repo-list width; the 1fr detail
+  // column absorbs the rest. Gated on !mobile && fine-pointer.
+  const coarse = new MediaQuery("(pointer: coarse)");
+  const sbResizable = $derived(!mobile && !coarse.current);
+  const sidebarStyle = $derived(
+    sbResizable && backlogLayout.sidebar !== null
+      ? `--repos-sidebar:${backlogLayout.sidebar}px`
+      : undefined,
+  );
+
+  let splitEl = $state<HTMLElement>();
+  let masterEl = $state<HTMLElement>();
+  let sbResizing = $state(false);
+
+  const startSidebarResize = createResizeDrag<{ x: number; w: number; splitW: number }>({
+    axis: "x",
+    onActive: (a) => (sbResizing = a),
+    onStart: (e) => {
+      if (!sbResizable || !splitEl || !masterEl) return null;
+      return {
+        x: e.clientX,
+        w: masterEl.getBoundingClientRect().width,
+        splitW: splitEl.getBoundingClientRect().width,
+      };
+    },
+    onDrag: (e, c) =>
+      backlogLayout.setSidebar(clampSidebarWidth(c.w + (e.clientX - c.x), c.splitW)),
+    onCommit: () => backlogLayout.commitSidebar(),
+    onReset: () => backlogLayout.resetSidebar(),
+  });
 
   type Tab = "issues" | "prs" | "actions" | "readiness" | "automation";
   let activeTab = $state<Tab>("issues");
@@ -387,8 +424,13 @@
          detail pane (not the whole view) — the project list on the left is shared
          across tabs, so the tabs only switch the selected repo's detail content;
          keeping them inside the detail column makes that hierarchy legible. -->
-    <div class="desktop-split">
-      <div class="master-pane">
+    <div
+      class="desktop-split"
+      class:sb-resizing={sbResizing}
+      bind:this={splitEl}
+      style={sidebarStyle}
+    >
+      <div class="master-pane" bind:this={masterEl}>
         <ProjectBacklogList
           projects={visibleProjects}
           hiddenProjects={shownHidden}
@@ -449,6 +491,22 @@
           {/if}
         </div>
       </div>
+      {#if sbResizable}
+        <!-- Vertical separator (issue #1787): an abs-positioned child of the
+             non-scrolling .desktop-split wrapper, sitting at the track boundary
+             (left: var(--repos-sidebar)). NOT a child of the scrolling
+             .master-pane, which would clip it / scroll it away. Drag to resize
+             the repo list, double-click to reset — see startSidebarResize. -->
+        <div
+          class="repo-splitter"
+          class:dragging={sbResizing}
+          role="separator"
+          aria-orientation="vertical"
+          aria-label={m.repos_resize_sidebar()}
+          title={m.repos_resize_sidebar()}
+          onpointerdown={startSidebarResize}
+        ></div>
+      {/if}
     </div>
   {/if}
 </div>
@@ -499,12 +557,56 @@
   }
 
   /* ── desktop split layout ── */
+  /* position:relative hosts the abs-positioned .repo-splitter (issue #1787). The
+     first track reads var(--repos-sidebar, 300px) — a concrete 300px default (the
+     minmax(220,300) first track already resolved to ~300px in the modal, the 1fr
+     detail being the hungry track) so the grid boundary and the separator's `left`
+     read from one shared variable and can't drift. */
   .desktop-split {
     display: grid;
-    grid-template-columns: minmax(220px, 300px) 1fr;
+    grid-template-columns: var(--repos-sidebar, 300px) 1fr;
+    position: relative;
     flex: 1;
     min-height: 0;
     overflow: hidden;
+  }
+  /* During a sidebar drag: kill text selection + force the resize cursor. */
+  .desktop-split.sb-resizing {
+    user-select: none;
+    cursor: col-resize;
+  }
+  /* Vertical splitter: ~12px hit strip centred on the master/detail boundary.
+     A 2px hairline (::after) is invisible at rest and brightens on hover/drag —
+     mirrors the Herd splitter. */
+  .repo-splitter {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: var(--repos-sidebar, 300px);
+    width: 12px;
+    transform: translateX(-50%);
+    cursor: col-resize;
+    z-index: 5;
+    touch-action: none;
+  }
+  .repo-splitter::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    width: 2px;
+    transform: translateX(-50%);
+    background: transparent;
+    transition: background 0.12s ease;
+  }
+  .repo-splitter:hover::after,
+  .repo-splitter:focus-visible::after,
+  .repo-splitter.dragging::after {
+    background: var(--color-line-bright);
+  }
+  .repo-splitter:focus-visible {
+    outline: none;
   }
 
   .master-pane {

--- a/ui/src/lib/feature-announcements/entries/v1.45.0-resizable-repos-modal.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.45.0-resizable-repos-modal.ts
@@ -1,0 +1,15 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // No targetId: the corner handle only mounts while the Repos modal is open, and
+  // the modal is closed on first view — so a coachmark anchor would be unmounted.
+  // Surface via the What's-New drawer only (same rationale as issue-search /
+  // preview-start). The body copy is device-neutral so it reads sensibly in the
+  // drawer on mobile/touch, where the resize handles aren't rendered at all.
+  id: "resizable-repos-modal",
+  sinceVersion: "1.45.0",
+  titleKey: "feat_resizable_repos_title",
+  bodyKey: "feat_resizable_repos_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/resize-drag.ts
+++ b/ui/src/lib/resize-drag.ts
@@ -1,0 +1,86 @@
+// Shared pointer-drag lifecycle for the Repos modal + repository-sidebar
+// resizers (issue #1787). Mirrors the Herd sidebar splitter: best-effort pointer
+// capture, a drag threshold, live onDrag on qualifying moves, commit on
+// pointer-up after a real drag, and a manual double-click detector (two
+// threshold-less clicks within DBLCLICK_MS) that fires onReset. Extracted so the
+// modal (2-D corner) and sidebar (1-D divider) share one implementation instead
+// of near-identical clones.
+
+const THRESHOLD = 3;
+const DBLCLICK_MS = 400;
+
+export interface ResizeDragOptions<C> {
+  /** Runs at pointer-down: apply caller guards (return null to abort the drag)
+   *  and capture the per-drag start geometry into a context passed back to onDrag. */
+  onStart: (e: PointerEvent) => C | null;
+  /** Called on each qualifying move with the live event + the start context. */
+  onDrag: (e: PointerEvent, ctx: C) => void;
+  /** Called on pointer-up after a real drag (moved past THRESHOLD). */
+  onCommit: () => void;
+  /** Called on a double-click with no drag between the two clicks. */
+  onReset: () => void;
+  /** Toggled true on drag start, false on drag end — drives the .dragging class. */
+  onActive: (active: boolean) => void;
+  /** Threshold axis: "x" for the 1-D divider, "both" for the 2-D corner grip. */
+  axis: "x" | "both";
+}
+
+/** Build a pointerdown handler. The returned closure keeps the per-handle
+ *  double-click timestamp between invocations. */
+export function createResizeDrag<C>(opts: ResizeDragOptions<C>) {
+  let lastClickTs = 0;
+
+  return function onPointerDown(e: PointerEvent) {
+    if (e.button !== 0) return;
+    const ctx = opts.onStart(e);
+    if (ctx === null) return; // caller guard rejected (not resizable / no refs)
+    e.preventDefault();
+    const handle = e.currentTarget as HTMLElement;
+    const startX = e.clientX;
+    const startY = e.clientY;
+    let moved = false;
+    // Best-effort: a synthetic (untrusted) pointer has no active capture target
+    // and throws — moves still route via the handle's own listeners.
+    try {
+      handle.setPointerCapture(e.pointerId);
+    } catch {
+      /* no active pointer (e.g. synthetic events in tests) */
+    }
+
+    const onMove = (ev: PointerEvent) => {
+      if (!moved) {
+        const past =
+          Math.abs(ev.clientX - startX) >= THRESHOLD ||
+          (opts.axis === "both" && Math.abs(ev.clientY - startY) >= THRESHOLD);
+        if (!past) return;
+        moved = true;
+        opts.onActive(true);
+      }
+      opts.onDrag(ev, ctx);
+    };
+    const onUp = (ev: PointerEvent) => {
+      try {
+        handle.releasePointerCapture(e.pointerId);
+      } catch {
+        /* capture never taken */
+      }
+      handle.removeEventListener("pointermove", onMove);
+      handle.removeEventListener("pointerup", onUp);
+      if (moved) {
+        opts.onActive(false);
+        opts.onCommit();
+        lastClickTs = 0; // a drag isn't a click
+        return;
+      }
+      // No drag → treat as a click; two within the window reset to default.
+      if (lastClickTs && ev.timeStamp - lastClickTs < DBLCLICK_MS) {
+        opts.onReset();
+        lastClickTs = 0;
+      } else {
+        lastClickTs = ev.timeStamp;
+      }
+    };
+    handle.addEventListener("pointermove", onMove);
+    handle.addEventListener("pointerup", onUp);
+  };
+}


### PR DESCRIPTION
Closes #1787.

## What

The desktop **Repos** modal now uses far more of a wide screen and is operator-resizable, with both sizes persisted locally.

- **Modal**: opens at **90vw × 88vh** (drops the fixed `960px` width cap). Drag the **bottom-right corner** to resize; **double-click** it to reset.
- **Repository list**: a **vertical divider** between the list and the detail pane resizes only the list; the detail column absorbs the remainder. Double-click resets.
- **Persistence**: committed sizes are saved to `localStorage` and restored on reopen/reload. Values are clamped to the current viewport (minus the overlay padding) and to layout minimums, so a stored size larger than the window can never push the close button off-screen.
- **Mobile/touch**: unchanged — full-screen, non-resizable; the handles aren't rendered and stored desktop sizes are ignored (gated on `!mobile && fine-pointer`, mirroring the Herd sidebar).

## How

- New SSR-safe singleton `ui/src/lib/backlog-layout.svelte.ts` owns the modal width/height + sidebar width prefs with pure, viewport-aware clamp helpers and corrupt/unavailable-storage fallback.
- New `ui/src/lib/resize-drag.ts` shared pointer-drag lifecycle (pointer capture, drag threshold, live-set / commit-on-up, double-click reset) — used by both resizers, mirroring the proven Herd sidebar (`herd-width.svelte.ts`) interaction. The modal corner applies **2× the pointer delta per axis** so the corner tracks the pointer 1:1 despite the modal being flex-centered.
- Separator is an absolutely-positioned child of the non-scrolling `.desktop-split` wrapper at the track boundary (`left: var(--repos-sidebar)`) — not inside the scrolling `.master-pane`.

## Tests

- Unit (`backlog-layout.svelte.test.ts`): parsing, clamping, commit/reset, corrupt + unavailable storage.
- Browser (`BacklogOverlay.browser.test.ts`): new default geometry, geometry stability across payloads, corner drag + persistence, **corner-tracking** (2×-delta), **measured** oversized-restore clamp, sidebar drag + persistence, and mobile ignoring stored sizes.
- Local: `cd ui && bun run check`, `check:i18n`, and full `bun test` (3977 tests) pass; branch-hygiene / feature-catalog / announcement-version / fallow gates pass.

## i18n & discovery

EN + DE keys added (resize labels + announcement). Feature announcement fragment `v1.45.0-resizable-repos-modal.ts` surfaces via the What's-New drawer (no coachTarget — the modal is closed on first view, so an anchor would be unmounted; degrades cleanly to drawer-only on mobile/touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)