### PR TITLE
fix(epic): dedupe epic-dag members so multi-line blockers don't break the panel

### DIFF
--- a/src/epic-model.ts
+++ b/src/epic-model.ts
@@ -116,7 +116,12 @@ function resolveMarkdown(input: AssembleInput): ResolvedGraph {
 export function assembleEpic(input: AssembleInput): Epic {
   const native = input.subIssues.length > 0;
   const graph = native ? resolveNative(input) : resolveMarkdown(input);
-  const { order, resolved, edges } = graph;
+  // Defense-in-depth: children are keyed by number in EpicPanel's {#each}, so a duplicate in
+  // `order` (from any source) would throw each_key_duplicate and crash the panel on mount. The
+  // markdown parser already dedupes members; this guards the native path (repeated subIssue
+  // number) and any future source. First-seen wins; `members`/`done` derive from `order` below.
+  const { resolved, edges } = graph;
+  const order = [...new Set(graph.order)];
   const warnings = [...graph.warnings];
 
   const members = new Set(order);

--- a/src/epic-parse.ts
+++ b/src/epic-parse.ts
@@ -30,7 +30,11 @@ function parseFencedEpic(fenceBody: string): ParsedEpic {
     const m = line.match(LINE_RE);
     if (!m) continue;
     const dependent = Number(m[1]);
-    order.push(dependent);
+    // A member is a set: a node listed on multiple lines (e.g. `#9 <- #7` then `#9 <- #8`
+    // to express two blockers) counts once, keeping its first-seen position — later lines
+    // still contribute their edges below. A duplicate member would otherwise flow into a
+    // duplicate epic child and break EpicPanel's keyed {#each} (each_key_duplicate).
+    if (!order.includes(dependent)) order.push(dependent);
     if (m[2]) edges.push(...parseFenceEdges(dependent, m[2]));
   }
   return { members: [...order], order, edges };
@@ -40,6 +44,10 @@ export function parseEpicBody(body: string): ParsedEpic {
   const fence = body.match(FENCE_RE);
   if (fence) return parseFencedEpic(fence[1] ?? "");
   const members: number[] = [];
-  for (const m of body.matchAll(CHECK_RE)) members.push(Number(m[1]));
+  // Dedupe (first-seen wins) for the same set-of-members reason as the fenced path.
+  for (const m of body.matchAll(CHECK_RE)) {
+    const n = Number(m[1]);
+    if (!members.includes(n)) members.push(n);
+  }
   return { members, order: [...members], edges: [] };
 }

--- a/test/epic-import.test.ts
+++ b/test/epic-import.test.ts
@@ -97,6 +97,25 @@ describe("importEpicLinks", () => {
     expect(r.unresolved.filter((n) => n === 320)).toHaveLength(1);
   });
 
+  // A child listed on multiple `<-` lines (two blockers) must be added exactly once. Before the
+  // parser dedup, the duplicated member was re-`addSubIssue`'d — the pre-loop existingSubs snapshot
+  // didn't yet contain it, so the forge threw and it landed in `unresolved` (spurious miscount).
+  test("multi-line blockers → child added once, both edges wired", async () => {
+    const body = "```epic-dag\n#707\n#708\n#709 <- #707\n#709 <- #708\n```";
+    const f = fakeForge([], new Map());
+    const r = await importEpicLinks(f.forge, 327, body);
+    expect(f.subAdds).toEqual([
+      [327, 707],
+      [327, 708],
+      [327, 709],
+    ]);
+    expect(f.depAdds).toEqual([
+      [709, 707],
+      [709, 708],
+    ]);
+    expect(r).toEqual({ subIssuesAdded: 3, dependenciesAdded: 2, skipped: 0, unresolved: [] });
+  });
+
   test("throws on forge with no native support", async () => {
     const bare = {} as never;
     await expect(importEpicLinks(bare, 1, BODY)).rejects.toThrow(

--- a/test/epic-model.test.ts
+++ b/test/epic-model.test.ts
@@ -42,6 +42,23 @@ describe("assembleEpic", () => {
     // 322 (unclaimed) is "ready" ONLY because 320 was detected closed from native state, not openIssues.
     expect(assembleEpic(BASE).children.find((c) => c.number === 322)!.state).toBe("ready");
   });
+  // Defense-in-depth: EpicPanel keys its {#each} by child number, so a duplicate would throw
+  // each_key_duplicate and crash the panel. The markdown parser now dedupes members, so the only
+  // way to reach the guard is a repeated number on the NATIVE path (unrealistic from GitHub, but
+  // the honest seam for the guard). assembleEpic must collapse it to a single child.
+  test("native: duplicate sub-issue number → single child (dedup guard)", () => {
+    const e = assembleEpic({
+      ...BASE,
+      subIssues: [
+        { number: 707, title: "a", url: "u707", body: "", closed: false, labels: [] },
+        { number: 709, title: "b", url: "u709", body: "", closed: false, labels: [] },
+        { number: 709, title: "b", url: "u709", body: "", closed: false, labels: [] },
+      ],
+      blockedBy: new Map(),
+    });
+    expect(e.children.map((c) => c.number)).toEqual([707, 709]);
+    expect(e.children.map((c) => c.order)).toEqual([0, 1]);
+  });
   test("claimed child with no live session surfaces as in-review (retired/in-flight, PR awaiting merge)", () => {
     const e = assembleEpic({
       ...BASE,

--- a/test/epic-parse.test.ts
+++ b/test/epic-parse.test.ts
@@ -35,6 +35,27 @@ describe("parseEpicBody", () => {
   });
   test("no structure → empty", () =>
     expect(parseEpicBody("prose")).toEqual({ members: [], order: [], edges: [] }));
+
+  // A node listed on multiple `<-` lines to express several blockers (`#709 <- #707` then
+  // `#709 <- #708`) must count as ONE member — a duplicate `order` entry flows into a
+  // duplicate epic child and throws each_key_duplicate in EpicPanel's keyed {#each}.
+  test("fenced multi-line blockers → member once, edges unioned", () => {
+    const r = parseEpicBody(
+      ["```epic-dag", "#707", "#708", "#709 <- #707", "#709 <- #708", "```"].join("\n"),
+    );
+    expect(r.members).toEqual([707, 708, 709]);
+    expect(r.order).toEqual([707, 708, 709]);
+    expect(r.edges).toEqual([
+      { dependent: 709, blocker: 707 },
+      { dependent: 709, blocker: 708 },
+    ]);
+  });
+
+  test("checklist with a repeated member → member once", () => {
+    const r = parseEpicBody("- [ ] #10 a\n- [ ] #11 b\n- [x] #10 a again\n");
+    expect(r.members).toEqual([10, 11]);
+    expect(r.order).toEqual([10, 11]);
+  });
 });
 
 // #1391 — the injected epic-shape contract's embedded examples are the SOURCE OF TRUTH for the

--- a/ui/src/lib/components/EpicPanel.browser.test.ts
+++ b/ui/src/lib/components/EpicPanel.browser.test.ts
@@ -171,3 +171,43 @@ describe("EpicPanel legibility lines (#1447)", () => {
     expect(page.getByText(m.epic_hold_cap({ inFlight: 3, max: 3 })).query()).toBeNull();
   });
 });
+
+// The "epic not loading" bug: a duplicate child (an epic-dag node listed on two `<-` lines) reaches
+// EpicPanel's `{#each epic.children as c (c.number)}`, whose duplicate key throws each_key_duplicate
+// and crashes the panel on mount. The data-layer fix (parser + assembleEpic dedup) guarantees unique
+// children; these cases pin the user-visible outcome. The clean-mount case runs first — the throwing
+// render can leak a partially-mounted subtree, so the throw assertion is kept last.
+describe("EpicPanel duplicate-child guard", () => {
+  it("mounts and renders each child row when numbers are unique", async () => {
+    const e: Epic = {
+      ...epic(),
+      children: [child({ number: 707 }), child({ number: 708 }), child({ number: 709 })],
+    };
+    render(EpicPanel, { repoPath: "/repo", parent: 327, epic: e });
+
+    await expect.element(page.getByRole("link", { name: "#709" })).toBeInTheDocument();
+  });
+
+  it("crashes the child list with each_key_duplicate on a duplicate child number", async () => {
+    // The each block's effect throws asynchronously (Svelte schedules it), surfacing as an
+    // unhandled rejection rather than a synchronous throw from render() — capture it here and
+    // preventDefault so it's asserted, not leaked into the run as a false failure.
+    let captured: string | null = null;
+    const onRejection = (ev: PromiseRejectionEvent) => {
+      const msg = String((ev.reason as Error)?.message ?? ev.reason ?? "");
+      if (msg.includes("each_key_duplicate")) {
+        captured = msg;
+        ev.preventDefault();
+      }
+    };
+    window.addEventListener("unhandledrejection", onRejection);
+    try {
+      const e: Epic = { ...epic(), children: [child({ number: 709 }), child({ number: 709 })] };
+      render(EpicPanel, { repoPath: "/repo", parent: 327, epic: e });
+      await new Promise((r) => setTimeout(r, 50));
+      expect(captured).toMatch(/each_key_duplicate/);
+    } finally {
+      window.removeEventListener("unhandledrejection", onRejection);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

An epic's panel failed to load (screenshot showed a stuck `loading…`, then the panel never appeared). Reproduced against flowagent epic **#686**: `GET /api/epic?…&parent=686` returns **HTTP 200** but with `children: [707, 708, 709, **709**]` — issue **#709 duplicated**.

Root cause: #686's `epic-dag` expresses two blockers by listing the child on two lines:

```
#709 <- #707
#709 <- #708
```

`parseFencedEpic` did `order.push(dependent)` **once per line**, so `#709` landed in `order` twice → `assembleEpic` produced a duplicate child → `EpicPanel`'s keyed `{#each … (c.number)}` hit a duplicate key. Svelte 5 throws `each_key_duplicate` in **both dev and production**, and it fires in an **async effect with no `<svelte:boundary>`** around it, so the panel crashes on mount and the epic never loads. It also skewed the badge count (0/**4** vs the real 0/3).

## Fix

- **`src/epic-parse.ts`** — a member is a set: push each node **once** (first-seen position), still unioning its edges across lines. Covers the fenced and task-list paths.
- **`src/epic-model.ts`** — dedupe `order` in `assembleEpic` before building children as **defense-in-depth**, guarding the native path (repeated sub-issue number) and any future source.
- Side benefit: fixes the native-import path — `importEpicLinks` no longer re-`addSubIssue`s a duplicated member into `unresolved`.

Multi-line blockers are already valid input; no grammar/authoring change.

## Verification

- New parser on real **#686** body → `members: [707,708,709]`, both edges preserved, badge total **3**.
- `test/epic-parse.test.ts` — multi-line blockers → member once, edges unioned; repeated task-list member.
- `test/epic-model.test.ts` — native duplicate sub-issue number → single child (guard seam).
- `test/epic-import.test.ts` — multi-line-blocker body → child added once, both edges wired, `unresolved` empty.
- `ui/…/EpicPanel.browser.test.ts` — reproduces the `each_key_duplicate` crash (before) and a clean mount rendering child rows (after).
- Green: `bun run lint`, `bun test ./test` (7226 pass), `cd ui && bun run check` (0 errors), full UI browser suite (1493 pass).

## Consumer sweep

`parseEpicBody().members` feeds ~8 sites; dedup impact audited: `markdownCounts` corrects the /api/epics badge 4→3 (desired); presence checks (`.length > 0`) are no-ops; the rest fold members into a `Set` (no-op). No site relied on positional/duplicate semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)