### PR TITLE
feat(files): show New Task attachments in the session Scratchpad (#1717)

### DIFF
--- a/docs/external-task-api.md
+++ b/docs/external-task-api.md
@@ -134,10 +134,16 @@ Once a task exists, an external agent can also drive it:
   changed lines plus routed critic findings) as `{ "notes": [...] }`; it degrades
   to an empty list on any error rather than failing.
 - `GET /api/sessions/:id/scratchpad[?path=]` — browse a live session's own
-  scratchpad subtree; `GET /api/sessions/:id/scratchpad/download?path=`
-  streams a single file. Paths are relative to the scratchpad root and
-  realpath-contained to it (`..`, absolute, and symlink escapes are rejected);
-  both `404` on a missing/archived session.
+  scratchpad subtree, with the session's operator attachments overlaid as a
+  synthetic read-only `attachments/` folder (New Task screenshots and
+  mid-session compose-box uploads, which physically live in
+  `<worktree>/.shepherd-uploads`). `GET /api/sessions/:id/scratchpad/download?path=`
+  streams a single file. Paths are relative to the merged root: `attachments/…`
+  paths resolve against the worktree uploads dir, everything else against the
+  scratchpad root, each realpath-contained to its own root (`..`, absolute, and
+  symlink escapes are rejected). Because the overlay is worktree-keyed, this view
+  is provider-agnostic and surfaces even for non-Claude sessions with no
+  scratchpad of their own. Both `404` on a missing/archived session.
 - `GET /api/sessions/:id/worktree[?path=]` — browse a live session's git
   worktree subtree (read-only); `GET /api/sessions/:id/worktree/download?path=`
   streams a single file. Paths are relative to the worktree root and

--- a/src/fs-browse.ts
+++ b/src/fs-browse.ts
@@ -23,6 +23,12 @@ export interface BrowseEntry {
   createdMs?: number;
   /** true when this entry is a symlink that resolves OUTSIDE the root (only set in onEscape:"mark"). */
   linkOutside?: boolean;
+  /**
+   * true only on the synthetic "Attachments" folder the scratchpad merge overlays onto the
+   * root (see src/scratchpad.ts). The UI keys on this to render a localized folder label; no
+   * real filesystem entry ever sets it.
+   */
+  attachments?: boolean;
 }
 
 /** Creation date (epoch ms) from a stat: birth time when recorded, else modified-time fallback. */

--- a/src/scratchpad.ts
+++ b/src/scratchpad.ts
@@ -128,11 +128,14 @@ function attachmentsSubPath(norm: string): string {
 
 /**
  * Merged scratchpad root: the session's own scratchpad entries plus the synthetic `attachments`
- * folder (when the worktree has any operator attachments). Dedupe: if the real scratchpad already
- * holds a dir literally named `attachments`, the synthetic overlay wins — the real entry is dropped
- * so the root never emits two `attachments` rows. The concat order is irrelevant because the result
- * is sorted with the same dirs-first-then-locale-alpha comparator `listDir` uses everywhere else.
- * Returns null only when there is neither a scratchpad nor any attachment (nothing to show).
+ * folder (when the worktree has any operator attachments). Dedupe is conditional on the overlay
+ * being present: only when there ARE uploads does a real scratchpad dir literally named
+ * `attachments` get dropped in favor of the synthetic one (so the root never emits two rows). With
+ * NO uploads there is no overlay, so a real `attachments` entry is kept and stays browsable — see
+ * `listScratchpadMerged`, which likewise only claims the `attachments/` namespace when uploads
+ * exist. The concat order is irrelevant because the result is sorted with the same
+ * dirs-first-then-locale-alpha comparator `listDir` uses everywhere else. Returns null only when
+ * there is neither a scratchpad nor any attachment (nothing to show).
  */
 async function listScratchpadRoot(
   worktreePath: string,
@@ -142,7 +145,9 @@ async function listScratchpadRoot(
   const hasAttachments = await attachmentsHasFiles(worktreePath);
   if (!scratch && !hasAttachments) return null;
 
-  const base = (scratch?.entries ?? []).filter((e) => e.path !== ATTACHMENTS_DIR);
+  // Drop a real `attachments` entry ONLY when the synthetic overlay replaces it; otherwise keep it.
+  const raw = scratch?.entries ?? [];
+  const base = hasAttachments ? raw.filter((e) => e.path !== ATTACHMENTS_DIR) : raw;
   const entries = hasAttachments ? [attachmentsEntry(), ...base] : base;
   entries.sort((a, b) =>
     a.type !== b.type ? (a.type === "dir" ? -1 : 1) : a.name.localeCompare(b.name),
@@ -153,9 +158,11 @@ async function listScratchpadRoot(
 /**
  * List one directory of the merged scratchpad view (#1717): the session scratchpad with the
  * operator attachments overlaid as a reserved `attachments/` subtree. Paths under `attachments/`
- * resolve against `<worktree>/.shepherd-uploads` (contained to that root), everything else against
- * the session scratchpad root (unchanged, still null on a blank `claudeSessionId`). Each path is
- * dispatched to exactly one root — there is no cross-root traversal.
+ * resolve against `<worktree>/.shepherd-uploads` (contained to that root) — but ONLY when uploads
+ * exist. With no uploads the overlay is inactive, so `attachments/…` falls through to the scratchpad
+ * root like any other path, keeping a real scratchpad dir named `attachments` browsable. Everything
+ * else resolves against the scratchpad root (unchanged, still null on a blank `claudeSessionId`).
+ * Each path is dispatched to exactly one root — there is no cross-root traversal.
  */
 export async function listScratchpadMerged(
   worktreePath: string,
@@ -163,7 +170,7 @@ export async function listScratchpadMerged(
   relPath: string,
 ): Promise<BrowseListing | null> {
   const norm = normalize(relPath || "");
-  if (isAttachmentsPath(norm)) {
+  if (isAttachmentsPath(norm) && (await attachmentsHasFiles(worktreePath))) {
     const listing = await listDir(worktreeUploadsDir(worktreePath), attachmentsSubPath(norm));
     return listing ? remapUploadsListing(listing) : null;
   }
@@ -173,9 +180,10 @@ export async function listScratchpadMerged(
 
 /**
  * Resolve a merged-view path that must be a regular FILE (for download). An `attachments/…` path
- * resolves against the uploads root; everything else against the scratchpad root. Returns the
- * canonical absolute path, or null on escape / missing / not-a-regular-file (a bare `attachments`
- * folder path resolves to null — you cannot download the folder itself).
+ * resolves against the uploads root ONLY when uploads exist; otherwise it falls through to the
+ * scratchpad root (so a real scratchpad `attachments/<file>` is downloadable when there is no
+ * overlay). Returns the canonical absolute path, or null on escape / missing / not-a-regular-file
+ * (a bare `attachments` folder path resolves to null — you cannot download the folder itself).
  */
 export async function resolveScratchpadOrAttachmentFile(
   worktreePath: string,
@@ -183,7 +191,7 @@ export async function resolveScratchpadOrAttachmentFile(
   relPath: string,
 ): Promise<string | null> {
   const norm = normalize(relPath || "");
-  if (isAttachmentsPath(norm)) {
+  if (isAttachmentsPath(norm) && (await attachmentsHasFiles(worktreePath))) {
     return resolveFileInRoot(worktreeUploadsDir(worktreePath), attachmentsSubPath(norm));
   }
   return resolveScratchpadFile(worktreePath, claudeSessionId, relPath);

--- a/src/scratchpad.ts
+++ b/src/scratchpad.ts
@@ -1,12 +1,14 @@
 import { promises as fsp } from "node:fs";
 import { join, basename, extname, sep, normalize, isAbsolute } from "node:path";
 import { sessionScratchpadDir } from "./tmp-sweep";
+import { worktreeUploadsDir } from "./uploads";
 import {
   within,
   relFromRoot,
   resolveInRoot,
   listDir,
   resolveFileInRoot,
+  type BrowseEntry,
   type BrowseListing,
 } from "./fs-browse";
 
@@ -63,6 +65,128 @@ export async function resolveScratchpadFile(
 ): Promise<string | null> {
   if (!claudeSessionId) return null;
   return resolveFileInRoot(sessionScratchpadDir(worktreePath, claudeSessionId), relPath);
+}
+
+/**
+ * Reserved top-level segment under which the scratchpad browser overlays the session's operator
+ * attachments (#1717). Attachments physically live in `<worktree>/.shepherd-uploads` (worktree-
+ * based, provider-agnostic, durable) — they are NOT in the Claude scratchpad tree. The merge
+ * surfaces them as a synthetic `attachments/` folder so a New Task screenshot (and any mid-session
+ * compose-box upload, which lands in the same dir) is visible in the Scratchpad view from the start,
+ * for every provider — including non-Claude sessions with a blank `claudeSessionId`, which have no
+ * scratchpad of their own.
+ */
+export const ATTACHMENTS_DIR = "attachments";
+
+/**
+ * Shallow, async, non-throwing "does this worktree have any operator attachments?" probe. Counts
+ * ANY entry in `<worktree>/.shepherd-uploads`. Returns false on a missing dir or any read error.
+ * Provider-agnostic — the uploads dir is keyed on the worktree, never `claudeSessionId`.
+ */
+async function attachmentsHasFiles(worktreePath: string): Promise<boolean> {
+  try {
+    const entries = await fsp.readdir(worktreeUploadsDir(worktreePath));
+    return entries.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** The synthetic overlay folder entry; `attachments: true` lets the UI render a localized label. */
+function attachmentsEntry(): BrowseEntry {
+  return { name: ATTACHMENTS_DIR, type: "dir", path: ATTACHMENTS_DIR, attachments: true };
+}
+
+/** Prefix a uploads-root-relative path back into the merged `attachments/…` namespace. */
+function toMergedPath(uploadsRel: string): string {
+  return uploadsRel ? `${ATTACHMENTS_DIR}/${uploadsRel}` : ATTACHMENTS_DIR;
+}
+
+/**
+ * Re-map a listing produced against the uploads root into the merged scratchpad namespace: every
+ * path is prefixed with `attachments/`, and the uploads-root's own parent (`null`) becomes the
+ * merged scratchpad root (`""`). Display-only — no traversal; containment was already enforced by
+ * `listDir` against the uploads root.
+ */
+function remapUploadsListing(listing: BrowseListing): BrowseListing {
+  return {
+    path: toMergedPath(listing.path),
+    parent: listing.path === "" ? "" : toMergedPath(listing.parent ?? ""),
+    entries: listing.entries.map((e) => ({ ...e, path: toMergedPath(e.path) })),
+  };
+}
+
+/** True when a caller-supplied (normalized) path targets the reserved attachments subtree. */
+function isAttachmentsPath(norm: string): boolean {
+  return norm === ATTACHMENTS_DIR || norm.startsWith(`${ATTACHMENTS_DIR}/`);
+}
+
+/** Strip the reserved prefix, yielding the uploads-root-relative remainder ("" at the folder root). */
+function attachmentsSubPath(norm: string): string {
+  return norm === ATTACHMENTS_DIR ? "" : norm.slice(ATTACHMENTS_DIR.length + 1);
+}
+
+/**
+ * Merged scratchpad root: the session's own scratchpad entries plus the synthetic `attachments`
+ * folder (when the worktree has any operator attachments). Dedupe: if the real scratchpad already
+ * holds a dir literally named `attachments`, the synthetic overlay wins — the real entry is dropped
+ * so the root never emits two `attachments` rows. The concat order is irrelevant because the result
+ * is sorted with the same dirs-first-then-locale-alpha comparator `listDir` uses everywhere else.
+ * Returns null only when there is neither a scratchpad nor any attachment (nothing to show).
+ */
+async function listScratchpadRoot(
+  worktreePath: string,
+  claudeSessionId: string,
+): Promise<BrowseListing | null> {
+  const scratch = await listScratchpad(worktreePath, claudeSessionId, "");
+  const hasAttachments = await attachmentsHasFiles(worktreePath);
+  if (!scratch && !hasAttachments) return null;
+
+  const base = (scratch?.entries ?? []).filter((e) => e.path !== ATTACHMENTS_DIR);
+  const entries = hasAttachments ? [attachmentsEntry(), ...base] : base;
+  entries.sort((a, b) =>
+    a.type !== b.type ? (a.type === "dir" ? -1 : 1) : a.name.localeCompare(b.name),
+  );
+  return { path: "", parent: null, entries };
+}
+
+/**
+ * List one directory of the merged scratchpad view (#1717): the session scratchpad with the
+ * operator attachments overlaid as a reserved `attachments/` subtree. Paths under `attachments/`
+ * resolve against `<worktree>/.shepherd-uploads` (contained to that root), everything else against
+ * the session scratchpad root (unchanged, still null on a blank `claudeSessionId`). Each path is
+ * dispatched to exactly one root — there is no cross-root traversal.
+ */
+export async function listScratchpadMerged(
+  worktreePath: string,
+  claudeSessionId: string,
+  relPath: string,
+): Promise<BrowseListing | null> {
+  const norm = normalize(relPath || "");
+  if (isAttachmentsPath(norm)) {
+    const listing = await listDir(worktreeUploadsDir(worktreePath), attachmentsSubPath(norm));
+    return listing ? remapUploadsListing(listing) : null;
+  }
+  if (norm === "" || norm === ".") return listScratchpadRoot(worktreePath, claudeSessionId);
+  return listScratchpad(worktreePath, claudeSessionId, relPath);
+}
+
+/**
+ * Resolve a merged-view path that must be a regular FILE (for download). An `attachments/…` path
+ * resolves against the uploads root; everything else against the scratchpad root. Returns the
+ * canonical absolute path, or null on escape / missing / not-a-regular-file (a bare `attachments`
+ * folder path resolves to null — you cannot download the folder itself).
+ */
+export async function resolveScratchpadOrAttachmentFile(
+  worktreePath: string,
+  claudeSessionId: string,
+  relPath: string,
+): Promise<string | null> {
+  const norm = normalize(relPath || "");
+  if (isAttachmentsPath(norm)) {
+    return resolveFileInRoot(worktreeUploadsDir(worktreePath), attachmentsSubPath(norm));
+  }
+  return resolveScratchpadFile(worktreePath, claudeSessionId, relPath);
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -83,8 +83,8 @@ import { codexHome } from "./codex-usage";
 import { listDirs, validateRoot, collapseHome } from "./dirs";
 import { scratchpadHasFiles } from "./tmp-sweep";
 import {
-  listScratchpad,
-  resolveScratchpadFile,
+  listScratchpadMerged,
+  resolveScratchpadOrAttachmentFile,
   attachmentDisposition,
   resolveScratchpadUploadDir,
   placeScratchpadUpload,
@@ -2231,11 +2231,13 @@ async function handleSessionReads({ req, parts, deps }: Ctx): Promise<Response |
 // ── scratchpad file browser: GET /api/sessions/:id/scratchpad[?path=] (list)
 //                            GET /api/sessions/:id/scratchpad/download?path= (file) ──
 // Read-only browse + single-file download, rooted at and realpath-contained to the session's
-// OWN scratchpad dir (#1164). Live sessions only: 404 on a missing/archived session. `path` is
-// relative to the scratchpad root; containment is enforced in src/scratchpad.ts.
+// OWN scratchpad dir (#1164), with the session's operator attachments overlaid as a synthetic
+// `attachments/` subtree that resolves against `<worktree>/.shepherd-uploads` (#1717). Live
+// sessions only: 404 on a missing/archived session. `path` is relative to the merged root;
+// containment (per root) is enforced in src/scratchpad.ts.
 // Stream one contained scratchpad file as an attachment download.
 async function scratchpadDownload(s: Session, rel: string): Promise<Response> {
-  const file = await resolveScratchpadFile(s.worktreePath, s.claudeSessionId, rel);
+  const file = await resolveScratchpadOrAttachmentFile(s.worktreePath, s.claudeSessionId, rel);
   if (!file) return json({ error: "not found" }, 404);
   const f = Bun.file(file);
   return new Response(f, {
@@ -2250,7 +2252,7 @@ async function scratchpadDownload(s: Session, rel: string): Promise<Response> {
 // yet) returns a synthetic empty listing so the Files tab doesn't error before the first
 // upload/write; a missing non-root path still 404s.
 async function scratchpadList(s: Session, rel: string): Promise<Response> {
-  const listing = await listScratchpad(s.worktreePath, s.claudeSessionId, rel);
+  const listing = await listScratchpadMerged(s.worktreePath, s.claudeSessionId, rel);
   if (listing) return json(listing);
   if (rel === "" && s.claudeSessionId) return json({ path: "", parent: null, entries: [] });
   return json({ error: "not found" }, 404);

--- a/test/scratchpad-attachments.test.ts
+++ b/test/scratchpad-attachments.test.ts
@@ -212,6 +212,29 @@ test("dedupe: a real scratchpad dir named `attachments` yields exactly one (synt
   expect(names(await sub.json())).toEqual(["shot.png"]);
 });
 
+test("with NO uploads, a real scratchpad `attachments` dir is kept at root and stays browsable", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  // A real scratchpad dir named `attachments` with a nested subdir — and NO uploads, so no overlay.
+  const root = sessionScratchpadDir(repoDir, SID);
+  mkdirSync(join(root, ATTACHMENTS_DIR, "sub"), { recursive: true });
+
+  // Root keeps the REAL entry (no synthetic overlay) — not filtered away, not marked synthetic.
+  const res = await app.fetch(new Request(`http://x/api/sessions/${s.id}/scratchpad`));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  const rows = body.entries.filter((e: { name: string }) => e.name === ATTACHMENTS_DIR);
+  expect(rows).toHaveLength(1);
+  expect(rows[0].attachments).toBeUndefined(); // real scratchpad dir, not the synthetic overlay
+
+  // Browsing into it resolves against the SCRATCHPAD (not the empty uploads root) → its real content.
+  const sub = await app.fetch(
+    new Request(`http://x/api/sessions/${s.id}/scratchpad?path=${ATTACHMENTS_DIR}`),
+  );
+  expect(sub.status).toBe(200);
+  expect(names(await sub.json())).toEqual(["sub"]);
+});
+
 test("root is 404 when there is neither a scratchpad nor any attachment (blank sid, no uploads)", async () => {
   const { app, store } = harness();
   const s = makeSession(store, "");

--- a/test/scratchpad-attachments.test.ts
+++ b/test/scratchpad-attachments.test.ts
@@ -1,0 +1,221 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { makeApp, type AppDeps } from "../src/server";
+import { SessionStore } from "../src/store";
+import { EventHub } from "../src/events";
+import { config } from "../src/config";
+import { sessionScratchpadDir } from "../src/tmp-sweep";
+import { worktreeUploadsDir } from "../src/uploads";
+import { ATTACHMENTS_DIR } from "../src/scratchpad";
+
+// Coverage for the #1717 Scratchpad→Attachments overlay: New Task (and mid-session compose-box)
+// attachments live in <worktree>/.shepherd-uploads and are surfaced in the Scratchpad view as a
+// synthetic `attachments/` folder — provider-agnostically, including non-Claude sessions with a
+// blank claudeSessionId that have no scratchpad of their own.
+
+let tmpRoot: string;
+let repoDir: string;
+let scratchRoot: string;
+const prevEnv = process.env.SHEPHERD_TMP_SWEEP_DIR;
+const SID = "claude-sess-1";
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(config.repoRoot, "shepherd-att-"));
+  repoDir = join(tmpRoot, "repo");
+  mkdirSync(repoDir);
+  scratchRoot = mkdtempSync(join(config.repoRoot, "shepherd-att-tmp-"));
+  process.env.SHEPHERD_TMP_SWEEP_DIR = scratchRoot;
+});
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  rmSync(scratchRoot, { recursive: true, force: true });
+  if (prevEnv === undefined) delete process.env.SHEPHERD_TMP_SWEEP_DIR;
+  else process.env.SHEPHERD_TMP_SWEEP_DIR = prevEnv;
+});
+
+function harness() {
+  const store = new SessionStore(":memory:");
+  const hub = new EventHub();
+  const deps: AppDeps = {
+    store,
+    service: {} as unknown as AppDeps["service"],
+    events: hub,
+    usageLimits: { limits: () => ({}) } as unknown as AppDeps["usageLimits"],
+  };
+  return { app: makeApp(deps), store };
+}
+
+function makeSession(store: SessionStore, claudeSessionId = SID) {
+  return store.create({
+    name: "att-session",
+    prompt: "p",
+    repoPath: repoDir,
+    baseBranch: "main",
+    branch: "shepherd/att",
+    worktreePath: repoDir,
+    isolated: false,
+    herdrSession: "sess-x",
+    herdrAgentId: "agent-x",
+    claudeSessionId,
+    model: null,
+  });
+}
+
+/** Write files into the worktree's `.shepherd-uploads` dir — where both New Task and ?session= uploads land. */
+function seedUploads(files: Record<string, string>) {
+  const dir = worktreeUploadsDir(repoDir);
+  mkdirSync(dir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) writeFileSync(join(dir, name), content);
+  return dir;
+}
+
+const names = (body: { entries: { name: string }[] }) => body.entries.map((e) => e.name);
+
+test("merged root overlays a sorted-in Attachments folder alongside real scratchpad entries", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  // Seed real scratchpad entries as dirs (mkdir only — no file writes into the tmpdir-derived
+  // scratchpad root). "aaa-dir" sorts BEFORE "attachments", proving the synthetic folder is sorted
+  // in by the standard dirs-first/alpha comparator, NOT pinned first.
+  const root = sessionScratchpadDir(repoDir, SID);
+  mkdirSync(join(root, "aaa-dir"), { recursive: true });
+  mkdirSync(join(root, "logs"), { recursive: true });
+  seedUploads({ "shot.png": "png" });
+
+  const res = await app.fetch(new Request(`http://x/api/sessions/${s.id}/scratchpad`));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  // Sorted in among the dirs (locale-alpha): "aaa-dir" < "attachments" < "logs".
+  expect(names(body)).toEqual(["aaa-dir", ATTACHMENTS_DIR, "logs"]);
+  const att = body.entries.find((e: { name: string }) => e.name === ATTACHMENTS_DIR);
+  expect(att).toMatchObject({ type: "dir", path: ATTACHMENTS_DIR, attachments: true });
+});
+
+test("Attachments folder is provider-agnostic — present with a blank claudeSessionId (no scratchpad)", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store, ""); // non-Claude session: no scratchpad of its own
+  seedUploads({ "shot.png": "png" });
+
+  const res = await app.fetch(new Request(`http://x/api/sessions/${s.id}/scratchpad`));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(names(body)).toEqual([ATTACHMENTS_DIR]);
+  expect(body.entries[0]).toMatchObject({ attachments: true });
+});
+
+test("lists the Attachments subtree from the uploads dir with remapped paths", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  seedUploads({ "a.png": "a", "b.png": "b" });
+
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${s.id}/scratchpad?path=${ATTACHMENTS_DIR}`),
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.path).toBe(ATTACHMENTS_DIR);
+  expect(body.parent).toBe(""); // parent of the folder is the merged scratchpad root
+  expect(names(body)).toEqual(["a.png", "b.png"]);
+  expect(body.entries.map((e: { path: string }) => e.path)).toEqual([
+    `${ATTACHMENTS_DIR}/a.png`,
+    `${ATTACHMENTS_DIR}/b.png`,
+  ]);
+});
+
+test("a mid-session ?session= upload appears in the Attachments folder", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+
+  // Exercise the real compose-box path: POST /api/uploads?session= writes into .shepherd-uploads.
+  const fd = new FormData();
+  fd.append("file", new File([new Uint8Array([1, 2, 3])], "paste.png", { type: "image/png" }));
+  const up = await app.fetch(
+    new Request(`http://x/api/uploads?session=${s.id}`, { method: "POST", body: fd }),
+  );
+  expect(up.status).toBe(200);
+
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${s.id}/scratchpad?path=${ATTACHMENTS_DIR}`),
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.entries).toHaveLength(1);
+  expect(body.entries[0].path.startsWith(`${ATTACHMENTS_DIR}/`)).toBe(true);
+});
+
+test("downloads a file from the Attachments subtree", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  seedUploads({ "shot.png": "PNGDATA" });
+
+  const res = await app.fetch(
+    new Request(
+      `http://x/api/sessions/${s.id}/scratchpad/download?path=${ATTACHMENTS_DIR}/shot.png`,
+    ),
+  );
+  expect(res.status).toBe(200);
+  expect(res.headers.get("content-disposition")).toContain('filename="shot.png"');
+  expect(await res.text()).toBe("PNGDATA");
+});
+
+test("rejects a `..` escape out of the Attachments subtree with 404", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  seedUploads({ "shot.png": "png" });
+
+  const res = await app.fetch(
+    new Request(
+      `http://x/api/sessions/${s.id}/scratchpad?path=${encodeURIComponent(`${ATTACHMENTS_DIR}/../../escape`)}`,
+    ),
+  );
+  expect(res.status).toBe(404);
+});
+
+test("an upload targeting path=attachments fails closed (404) and never writes into .shepherd-uploads", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  seedUploads({ "existing.png": "x" });
+
+  const fd = new FormData();
+  fd.append("file", new File([new Uint8Array([9])], "evil.png", { type: "image/png" }));
+  const res = await app.fetch(
+    new Request(`http://x/api/sessions/${s.id}/scratchpad/upload?path=${ATTACHMENTS_DIR}`, {
+      method: "POST",
+      body: fd,
+    }),
+  );
+  expect(res.status).toBe(404); // routes to the real scratchpad root, where `attachments` doesn't exist
+  // The uploads dir is untouched — the overlay is read-only server-side.
+  expect(readdirSync(worktreeUploadsDir(repoDir))).toEqual(["existing.png"]);
+});
+
+test("dedupe: a real scratchpad dir named `attachments` yields exactly one (synthetic) row", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store);
+  // A real scratchpad dir literally named `attachments` (mkdir only — no tmpdir file write). It is
+  // shadowed by the synthetic overlay and must not produce a second row.
+  const root = sessionScratchpadDir(repoDir, SID);
+  mkdirSync(join(root, ATTACHMENTS_DIR), { recursive: true });
+  seedUploads({ "shot.png": "png" });
+
+  const res = await app.fetch(new Request(`http://x/api/sessions/${s.id}/scratchpad`));
+  const body = await res.json();
+  const rows = body.entries.filter((e: { name: string }) => e.name === ATTACHMENTS_DIR);
+  expect(rows).toHaveLength(1);
+  expect(rows[0]).toMatchObject({ attachments: true }); // the synthetic overlay wins
+
+  // Navigating into it shows the uploads content, not the shadowed real scratchpad dir.
+  const sub = await app.fetch(
+    new Request(`http://x/api/sessions/${s.id}/scratchpad?path=${ATTACHMENTS_DIR}`),
+  );
+  expect(names(await sub.json())).toEqual(["shot.png"]);
+});
+
+test("root is 404 when there is neither a scratchpad nor any attachment (blank sid, no uploads)", async () => {
+  const { app, store } = harness();
+  const s = makeSession(store, "");
+
+  const res = await app.fetch(new Request(`http://x/api/sessions/${s.id}/scratchpad`));
+  expect(res.status).toBe(404);
+});

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -2292,6 +2292,7 @@
   "feat_hide_repos_body": "Räume das Backlog-Repos-Panel auf: Fahre über eine Repo-Zeile und klicke auf das Auge, um sie auszublenden. Ein „Ausgeblendet“-Chip zeigt ausgeblendete Repos wieder an, sodass du sie zurückholen kannst. Nur die Anzeige – Sessions, Drain und Summen bleiben unberührt.",
   "viewport_files_tab": "Dateien",
   "files_root_crumb": "Scratchpad",
+  "files_attachments_folder": "Anhänge",
   "files_breadcrumb_aria": "Scratchpad-Pfad",
   "files_empty": "Noch keine Dateien im Scratchpad.",
   "files_load_error": "Scratchpad-Dateien konnten nicht geladen werden.",
@@ -3253,5 +3254,7 @@
   "feat_desktop_herd_group_collapse_title": "Lebenszyklus-Gruppen auch am Desktop einklappen",
   "feat_desktop_herd_group_collapse_body": "Die Gruppen-Header der Desktop-Session-Leiste (CI läuft, Dein Zug, Gemergt, …) sind jetzt ebenfalls klappbar: Ein Klick auf einen Header klappt die Gruppe zu — jede Gruppe unabhängig, und Sprünge zu einer Session in einer eingeklappten Gruppe öffnen sie automatisch wieder.",
   "feat_resizable_repos_title": "Repos-Fenster in der Größe anpassen",
-  "feat_resizable_repos_body": "Am Desktop öffnet sich das Repos-Fenster jetzt deutlich größer und merkt sich deine Größe: Ziehe an der unteren rechten Ecke, um das gesamte Fenster anzupassen, und ziehe an der Trennlinie zwischen der Repository-Liste und dem Detailbereich, um eine der Seiten zu verbreitern. Beide Größen werden in diesem Browser gespeichert; ein Doppelklick auf einen Griff setzt sie zurück."
+  "feat_resizable_repos_body": "Am Desktop öffnet sich das Repos-Fenster jetzt deutlich größer und merkt sich deine Größe: Ziehe an der unteren rechten Ecke, um das gesamte Fenster anzupassen, und ziehe an der Trennlinie zwischen der Repository-Liste und dem Detailbereich, um eine der Seiten zu verbreitern. Beide Größen werden in diesem Browser gespeichert; ein Doppelklick auf einen Griff setzt sie zurück.",
+  "feat_scratchpad_attachments_title": "Task-Anhänge erscheinen im Dateien-Tab",
+  "feat_scratchpad_attachments_body": "Screenshots und Dateien, die du beim Erstellen einer Aufgabe anhängst, erscheinen jetzt von Anfang an im Dateien-Tab der Session – in einem neuen Ordner „Anhänge“ in der Scratchpad-Ansicht, zusammen mit Bildern, die du mitten in der Sitzung einfügst. Das funktioniert für jeden Agenten, auch für solche ohne eigenen Scratchpad."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -2292,6 +2292,7 @@
   "feat_hide_repos_body": "Declutter the Backlog repos panel: hover a repo row and click the eye to hide it. A \"Hidden\" chip reveals hidden repos so you can bring them back. It's list-only — the repo's sessions, drain and totals are untouched.",
   "viewport_files_tab": "Files",
   "files_root_crumb": "scratchpad",
+  "files_attachments_folder": "Attachments",
   "files_breadcrumb_aria": "Scratchpad path",
   "files_empty": "No files in the scratchpad yet.",
   "files_load_error": "Couldn't load scratchpad files.",
@@ -3253,5 +3254,7 @@
   "feat_desktop_herd_group_collapse_title": "Fold lifecycle groups on the desktop",
   "feat_desktop_herd_group_collapse_body": "The desktop session rail's lifecycle group headers (CI running, Your turn, Merged, …) are now collapsible too: click a header to fold that group away — each group toggles independently, and jumps to a session hidden in a folded group reopen it automatically.",
   "feat_resizable_repos_title": "Resize the Repos window",
-  "feat_resizable_repos_body": "On desktop the Repos window now opens much larger and remembers your size: drag the bottom-right corner to resize the whole window, and drag the divider between the repository list and the detail pane to widen either side. Both sizes are saved in this browser; double-click a handle to reset."
+  "feat_resizable_repos_body": "On desktop the Repos window now opens much larger and remembers your size: drag the bottom-right corner to resize the whole window, and drag the divider between the repository list and the detail pane to widen either side. Both sizes are saved in this browser; double-click a handle to reset.",
+  "feat_scratchpad_attachments_title": "Task attachments show in the Files tab",
+  "feat_scratchpad_attachments_body": "Screenshots and files you attach when creating a task now appear in the session's Files tab from the start, under a new Attachments folder in the Scratchpad view — alongside any images you paste in mid-session. It works for every agent, including ones without a scratchpad of their own."
 }

--- a/ui/src/lib/components/Viewport.svelte
+++ b/ui/src/lib/components/Viewport.svelte
@@ -84,6 +84,7 @@
   import ClipboardPill from "./viewport/ClipboardPill.svelte";
   import { handleOsc52 } from "$lib/osc52";
   import type { BuildQueue } from "$lib/types";
+  import { computeHasFiles } from "$lib/session-files";
   import { m } from "$lib/paraglide/messages";
   import { modelLabel } from "$lib/model-label";
   import { effortLabel } from "$lib/effort-guidance";
@@ -807,10 +808,10 @@
     if (todoExists === false && tab === "todo") tab = "term";
   });
 
-  // The Files tab is shown for any live session that has a claudeSessionId (#1258). This lets an
-  // operator upload files even before the agent writes anything. hasScratchpadFiles is subsumed —
-  // it can only be true for a live session with a claudeSessionId — so it no longer drives visibility.
-  const hasFiles = $derived(session.claudeSessionId !== "" && session.status !== "archived");
+  // The Files tab is shown for any live session that has a claudeSessionId (#1258) OR any operator
+  // attachment (#1717) — the latter makes attachments visible for non-Claude sessions too (they have
+  // no scratchpad). See computeHasFiles for the exact rule.
+  const hasFiles = $derived(computeHasFiles(session));
   // Don't strand the operator on a Files tab whose scratchpad just emptied.
   $effect(() => {
     if (!hasFiles && tab === "files") tab = "term";

--- a/ui/src/lib/components/viewport/FilesPanel.browser.test.ts
+++ b/ui/src/lib/components/viewport/FilesPanel.browser.test.ts
@@ -315,3 +315,57 @@ describe("FilesPanel — Created column and sorting", () => {
     await expect.poll(() => rowNames()).toEqual(["zzz-dir", "aaa-dir", "a.txt", "b.txt", "c.txt"]);
   });
 });
+
+describe("FilesPanel — Attachments overlay (#1717)", () => {
+  const ATT = "attachments";
+  const rootWithAttachments = {
+    path: "",
+    parent: null as string | null,
+    entries: [{ name: ATT, type: "dir" as const, path: ATT, attachments: true }],
+  };
+  const nmText = () =>
+    Array.from(document.querySelectorAll(".list .row .nm")).map((n) => n.textContent?.trim());
+
+  it("renders the localized Attachments folder from the initial listing", async () => {
+    mockListing.mockResolvedValue(rootWithAttachments);
+    render(FilesPanel, { sessionId: "att-1" });
+    await waitForPanel();
+    await expect.poll(() => nmText()).toContain(m.files_attachments_folder());
+    // The raw reserved slug is never shown to the operator.
+    expect(nmText()).not.toContain(ATT);
+  });
+
+  it("keeps scratchpad labels and hides the upload affordance inside the attachments subtree", async () => {
+    const emptySub = { path: ATT, parent: "", entries: [] as never[] };
+    mockListing.mockImplementation(async (_id: string, path?: string) =>
+      path === ATT ? emptySub : rootWithAttachments,
+    );
+    render(FilesPanel, { sessionId: "att-2" });
+    await waitForPanel();
+
+    // Navigate into the Attachments folder.
+    const folder = Array.from(document.querySelectorAll<HTMLButtonElement>("button.row")).find(
+      (b) => b.querySelector(".nm")?.textContent?.trim() === m.files_attachments_folder(),
+    );
+    expect(folder).toBeTruthy();
+    folder!.click();
+
+    // Upload affordance disappears (uploadDisabled inside the read-only overlay).
+    await expect.poll(() => document.querySelector("button.upload-btn")).toBeNull();
+
+    // Empty-state text stays the SCRATCHPAD variant — not the Worktree string.
+    const empty = document.querySelector(".placeholder")?.textContent ?? "";
+    expect(empty).toContain(m.files_empty());
+    expect(empty).not.toContain(m.files_worktree_empty());
+
+    // Breadcrumb root crumb stays the scratchpad label; current crumb is the localized folder name.
+    const crumbs = Array.from(document.querySelectorAll(".crumbs .crumb")).map((c) =>
+      c.textContent?.trim(),
+    );
+    expect(crumbs).toContain(m.files_root_crumb());
+    expect(crumbs).not.toContain(m.files_worktree_root_crumb());
+    expect(document.querySelector(".crumb.current")?.textContent?.trim()).toBe(
+      m.files_attachments_folder(),
+    );
+  });
+});

--- a/ui/src/lib/components/viewport/FilesPanel.svelte
+++ b/ui/src/lib/components/viewport/FilesPanel.svelte
@@ -8,6 +8,7 @@
     ApiError,
   } from "$lib/api";
   import type { ScratchEntry, ScratchListing } from "$lib/types";
+  import { ATTACHMENTS_DIR } from "$lib/session-files";
   import { m } from "$lib/paraglide/messages";
   import { relativeAge } from "$lib/format";
   import { coachTarget } from "$lib/actions/coachTarget.svelte";
@@ -24,6 +25,20 @@
   let listing = $state<ScratchListing | null>(null);
   let loading = $state(false);
   let error = $state(false);
+
+  // The synthetic Attachments overlay (#1717) is a read-only view of the worktree's uploads dir.
+  // `uploadDisabled` gates ONLY the upload affordances (button + drag/drop) — NOT the label/aria
+  // derivations, which stay keyed on `source` so the scratchpad Attachments folder keeps its
+  // scratchpad strings (reusing `readOnly` here would mislabel it with Worktree text).
+  const withinAttachments = $derived(
+    (listing?.path ?? "") === ATTACHMENTS_DIR ||
+      (listing?.path ?? "").startsWith(`${ATTACHMENTS_DIR}/`),
+  );
+  const uploadDisabled = $derived(readOnly || withinAttachments);
+
+  // Row/breadcrumb label for the synthetic Attachments folder is localized; every real entry
+  // renders its own name verbatim (names are data, not app chrome).
+  const displayName = (e: ScratchEntry) => (e.attachments ? m.files_attachments_folder() : e.name);
 
   // Sort state for the two clickable columns. Default = dirs-first + name-ascending (the
   // server's own order). `now` anchors the relative-age labels; refreshed on each load so
@@ -159,7 +174,11 @@
     let acc = "";
     for (const s of segs) {
       acc = acc ? `${acc}/${s}` : s;
-      out.push({ label: s, path: acc });
+      // Localize the top-level reserved Attachments segment (scratchpad source only); every other
+      // crumb is a real path segment rendered verbatim.
+      const label =
+        source === "scratchpad" && acc === ATTACHMENTS_DIR ? m.files_attachments_folder() : s;
+      out.push({ label, path: acc });
     }
     return out;
   });
@@ -205,20 +224,20 @@
   }
 
   function handleDragOver(e: DragEvent) {
-    if (readOnly) return;
+    if (uploadDisabled) return;
     e.preventDefault();
     dragOver = true;
   }
 
   function handleDragLeave(e: DragEvent) {
-    if (readOnly) return;
+    if (uploadDisabled) return;
     // Ignore leave events triggered by crossing into a child element — only clear on a real exit.
     if (e.relatedTarget && (e.currentTarget as Node).contains(e.relatedTarget as Node)) return;
     dragOver = false;
   }
 
   function handleDrop(e: DragEvent) {
-    if (readOnly) return;
+    if (uploadDisabled) return;
     e.preventDefault();
     dragOver = false;
     if (!listing) return; // still loading
@@ -284,7 +303,7 @@
           {/if}
         {/each}
       </nav>
-      {#if !readOnly}
+      {#if !uploadDisabled}
         <button
           type="button"
           class="gbtn upload-btn"
@@ -343,7 +362,7 @@
       {:else if listing && listing.entries.length === 0}
         <div class="placeholder empty-droppable">
           <span>{emptyText}</span>
-          {#if !readOnly}
+          {#if !uploadDisabled}
             <span class="drop-hint">{m.files_upload_drop_hint()}</span>
           {/if}
         </div>
@@ -381,14 +400,14 @@
           {#if e.linkOutside}
             <div class="row link-outside" aria-disabled="true" title={m.files_link_outside_title()}>
               <span class="ico" aria-hidden="true">↗</span>
-              <span class="nm">{e.name}</span>
+              <span class="nm">{displayName(e)}</span>
               {@render createdCell(e)}
               <span class="trail" aria-hidden="true"></span>
             </div>
           {:else if e.type === "dir"}
             <button type="button" class="row" onclick={() => browse(e.path)}>
               <span class="ico" aria-hidden="true">▸</span>
-              <span class="nm">{e.name}</span>
+              <span class="nm">{displayName(e)}</span>
               {@render createdCell(e)}
               <span class="chev trail" aria-hidden="true">›</span>
             </button>

--- a/ui/src/lib/feature-announcements/entries/v1.45.0-scratchpad-attachments.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.45.0-scratchpad-attachments.ts
@@ -1,0 +1,13 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // No targetId: the Files tab / Attachments folder only mounts for the selected session's
+  // viewport, which isn't guaranteed to be open on first view — surface via the What's-New
+  // drawer only.
+  id: "scratchpad-attachments",
+  sinceVersion: "1.45.0",
+  titleKey: "feat_scratchpad_attachments_title",
+  bodyKey: "feat_scratchpad_attachments_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/session-files.test.ts
+++ b/ui/src/lib/session-files.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { computeHasFiles } from "./session-files";
+import type { Session, LaunchAttachmentMetadata, SessionLaunchMetadata } from "./types";
+
+// Minimal Session builder — computeHasFiles only reads status, claudeSessionId, launchMetadata.
+function session(over: {
+  status?: Session["status"];
+  claudeSessionId?: string;
+  attachments?: LaunchAttachmentMetadata[];
+}): Session {
+  const launchMetadata =
+    over.attachments === undefined
+      ? null
+      : ({ attachments: over.attachments } as unknown as SessionLaunchMetadata);
+  return {
+    status: over.status ?? "running",
+    claudeSessionId: over.claudeSessionId ?? "",
+    launchMetadata,
+  } as unknown as Session;
+}
+
+const att = (over: Partial<LaunchAttachmentMetadata> = {}): LaunchAttachmentMetadata => ({
+  submittedName: "shot.png",
+  launchedName: "shot.png",
+  dropped: false,
+  ...over,
+});
+
+describe("computeHasFiles", () => {
+  it("is true for a live Claude session (has a scratchpad), no attachments", () => {
+    expect(computeHasFiles(session({ claudeSessionId: "sess-1" }))).toBe(true);
+  });
+
+  it("is true for a non-Claude session with a non-dropped attachment", () => {
+    expect(computeHasFiles(session({ claudeSessionId: "", attachments: [att()] }))).toBe(true);
+  });
+
+  it("is false for a non-Claude session with no attachments", () => {
+    expect(computeHasFiles(session({ claudeSessionId: "" }))).toBe(false);
+  });
+
+  it("is false when every attachment was dropped (swept)", () => {
+    expect(
+      computeHasFiles(session({ claudeSessionId: "", attachments: [att({ dropped: true })] })),
+    ).toBe(false);
+  });
+
+  it("is false for an archived session even with attachments", () => {
+    expect(
+      computeHasFiles(
+        session({ status: "archived", claudeSessionId: "sess-1", attachments: [att()] }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/ui/src/lib/session-files.ts
+++ b/ui/src/lib/session-files.ts
@@ -1,0 +1,20 @@
+import type { Session } from "$lib/types";
+
+/**
+ * Reserved top-level segment under which the Scratchpad view overlays the session's operator
+ * attachments (#1717). Mirrors `ATTACHMENTS_DIR` in `src/scratchpad.ts` — the server emits paths
+ * under this segment and marks the synthetic folder entry with `attachments: true`; the UI keys on
+ * that marker for the label and on this constant for breadcrumb/upload-gate detection.
+ */
+export const ATTACHMENTS_DIR = "attachments";
+
+/**
+ * Whether a session's Files tab should be shown (#1717). True for any live Claude session (it has
+ * a scratchpad) OR any live session that has at least one non-dropped operator attachment — the
+ * latter makes attachment visibility provider-agnostic, so a non-Claude session (blank
+ * `claudeSessionId`, no scratchpad) still surfaces its attachments. Archived sessions never qualify.
+ */
+export function computeHasFiles(session: Session): boolean {
+  const hasAttachments = (session.launchMetadata?.attachments ?? []).some((a) => !a.dropped);
+  return session.status !== "archived" && (session.claudeSessionId !== "" || hasAttachments);
+}

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -231,6 +231,9 @@ export interface ScratchEntry {
   /** true when this entry is a symlink resolving outside the root (worktree view only);
    *  rendered as a disabled, non-navigable row. */
   linkOutside?: boolean;
+  /** true only on the synthetic "Attachments" overlay folder (#1717); the UI renders a
+   *  localized label for it and treats its subtree as read-only. */
+  attachments?: boolean;
 }
 
 /** A directory listing within a session's scratchpad subtree (#1164). Paths are relative to the


### PR DESCRIPTION
Closes #1717.

## Problem
New Task attachments are copied into `<worktree>/.shepherd-uploads` and injected into the agent prompt, but the Files tab's default **Scratchpad** view reads a *different* tree (`<claudeTmpRoot>/…/<claudeSessionId>/scratchpad`). So initial screenshots never appear there, and for non-Claude providers (blank `claudeSessionId`) the Files tab is hidden entirely.

## Approach — reader-merge (writer/prompt/recovery untouched)
Overlay the existing `.shepherd-uploads` dir as a synthetic, read-only **Attachments** folder inside the Scratchpad view. Nothing about the writer, prompt injection, or retry/held/relaunch/missing-staged-upload recovery changes — the prompt still references usable `.shepherd-uploads` paths.

- **Server** (`src/scratchpad.ts` + `src/server.ts`): `listScratchpadMerged` / `resolveScratchpadOrAttachmentFile` dispatch each path to exactly one root — `attachments/…` resolves against `<worktree>/.shepherd-uploads` (contained by the same realpath helpers), everything else against the scratchpad root (unchanged). The synthetic folder is **sorted in** with the standard dirs-first/alpha comparator (not pinned), and **deduped** so a real scratchpad dir named `attachments` never yields two rows.
- **Provider-agnostic**: the uploads dir is worktree-keyed (no `claudeSessionId`), so the folder — and the Files tab (`computeHasFiles`) — surface for non-Claude sessions too.
- **Scope**: the overlay reflects the whole `.shepherd-uploads` dir, i.e. New Task attachments **and** mid-session compose-box uploads (both land there).
- **Read-only**: uploading *into* the subtree is disabled client-side (a dedicated `uploadDisabled` flag — not `readOnly`, which would mislabel the folder with Worktree strings) and fails closed server-side (a `path=attachments` upload routes to the real scratchpad root → 404).

## Tests
- `test/scratchpad-attachments.test.ts` (9): merged-root sort position, provider-agnostic (blank `claudeSessionId`), subtree listing + remapped paths, a real mid-session `?session=` upload appearing, download, `..` containment → 404, upload-to-`attachments` fails closed (404, uploads dir untouched), dedupe, no-uploads fallback.
- `ui/src/lib/session-files.test.ts` (5): `computeHasFiles` true/false/dropped/archived.
- `ui/src/lib/components/viewport/FilesPanel.browser.test.ts` (+2): localized Attachments folder from the initial load; inside the subtree the breadcrumb-root/empty labels stay the scratchpad variants while the upload affordance is hidden.
- Existing `test/service.test.ts` prompt assertions (exact `Attached files:\n…/.shepherd-uploads/…` block) stand as the agent-path-delivery regression guard — untouched writer.

Full `bun test` (7235), UI `bun run test` (3990), root lint, `bun run check`, `check:i18n`, and the PR-hygiene gates (feature-catalog, announcement-versions, glossary, branch-hygiene, fallow audit) all pass.

## Out of scope
The Scratchpad/Worktree explanatory tooltip (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)