### PR TITLE
fix(epic): rebase epic landing PR at open time + notify on genuine conflict (#1838)

### DIFF
--- a/src/drain.ts
+++ b/src/drain.ts
@@ -39,6 +39,7 @@ import { EmptyDiffError } from "./forge/types";
 import { mapBounded } from "./map-bounded";
 import { config } from "./config";
 import { rebaseLandingBranch, isUnionDriverRegistered } from "./landing-rebase";
+import type { NotifyInput } from "./push";
 
 /** Concurrency cap for the per-child blocked_by fan-out when assembling an epic.
  *  Bounds `gh api` subprocesses so a large (100+-child) epic can't exhaust FDs or
@@ -255,6 +256,9 @@ export interface DrainDeps {
   /** #1071: injectable seam for the driver-pause fast-path re-probe (tests inject a fake).
    *  Defaults to the real isUnionDriverRegistered (src/landing-rebase.ts) in the constructor. */
   isDriverRegistered?: (repoPath: string) => Promise<boolean>;
+  /** #1838: push a notification (→ push.notify). Optional — absent in tests that don't assert it.
+   *  Used by enterLandingConflict to surface a genuine-conflict landing pause to the operator. */
+  notify?: (input: NotifyInput) => Promise<boolean> | void;
 }
 
 /**
@@ -1082,11 +1086,17 @@ export class DrainService {
         cfg.preWarmEpicLandingCi,
       );
       this.resolveLanding(repoPath, parentIssueNumber, resolution);
-      // Migration-awareness checkpoint (#645): once the landing PR's number is known, detect any
-      // migration files it carries so the band can ask the operator to acknowledge them. Strictly
-      // best-effort — a detection failure (or a forge without prChangedPaths) leaves no paths,
-      // hence no chip, and NEVER affects the landing resolution above.
       if (resolution.state === "open" && resolution.prNumber != null) {
+        // #1838: the open-time rebase (in openNewLandingPr / adoptOpenLanding) hit a genuine
+        // conflict — layer the conflict pause + operator push on AFTER resolveLanding has persisted
+        // the PR, so a store/notify hiccup can never demote the just-opened PR to error+attempts++.
+        if (resolution.rebaseConflict) {
+          this.enterLandingConflict(repoPath, parentIssueNumber, resolution.prNumber);
+        }
+        // Migration-awareness checkpoint (#645): once the landing PR's number is known, detect any
+        // migration files it carries so the band can ask the operator to acknowledge them. Strictly
+        // best-effort — a detection failure (or a forge without prChangedPaths) leaves no paths,
+        // hence no chip, and NEVER affects the landing resolution above.
         await this.detectAndPersistMigrations(
           forge,
           repoPath,
@@ -1125,6 +1135,7 @@ export class DrainService {
     prNumber: number | null;
     prUrl: string | null;
     attempts: number;
+    rebaseConflict?: boolean;
   }> {
     const { repoPath, parentIssueNumber, landingAttempts } = row;
     try {
@@ -1267,8 +1278,31 @@ export class DrainService {
     prNumber: number | null;
     prUrl: string | null;
     attempts: number;
+    rebaseConflict?: boolean;
   }> {
     const { repoPath, parentIssueNumber, landingAttempts } = row;
+    // #1838: a pre-warm draft (drain.ts openPr, no rebase) is finalized here, bypassing
+    // openNewLandingPr — so rebase the integration branch onto the current default at adoption too.
+    // For the record-failed re-adoption (already rebased at its openNewLandingPr) this hits the
+    // seam's `current` short-circuit and cheaply returns false. Wrapped so a defaultBranch hiccup
+    // degrades to no-rebase (PR still adopted) — honoring adoptOpenLanding's "sub-steps swallow
+    // their own forge-call errors" contract rather than demoting a healthy adoption to error.
+    let rebaseConflict = false;
+    try {
+      const defaultBranch = await forge.defaultBranch();
+      rebaseConflict = await this.rebaseIntegrationAtLanding(
+        forge,
+        repoPath,
+        integrationBranch,
+        defaultBranch,
+        parentIssueNumber,
+      );
+    } catch (err) {
+      console.warn(
+        `[drain] open-time rebase prep failed for ${repoPath}#${parentIssueNumber}:`,
+        err,
+      );
+    }
     // A.3 — refresh body from the FINAL rollup. Gated on the UNION (preWarm || existing.isDraft)
     //       so the flag-off record-failed-gap (non-draft) stays a no-op, but ANY actual draft
     //       is refreshed even if the operator disabled the flag (or un-drafted) mid-drain.
@@ -1299,7 +1333,71 @@ export class DrainService {
       prNumber: existing.number ?? null,
       prUrl: existing.url ?? null,
       attempts: landingAttempts,
+      rebaseConflict,
     };
+  }
+
+  /**
+   * #1838: Best-effort open-time rebase of an epic's integration branch onto the default branch,
+   * reusing the union-aware landing-rebase seam. Called at landing-PR OPEN time (openNewLandingPr)
+   * and at pre-warm-draft ADOPTION time (adoptOpenLanding) so a landing PR is never born behind an
+   * advanced default. GitHub-only (the seam force-pushes to origin; other forges have no remote to
+   * rebase against) and repair-fenced (never --force-with-lease over a live repair session's
+   * commits, mirroring doLandingRebase). NEVER throws — the seam returns a result union, so a
+   * skipped/short-circuited/faulted attempt yields false. Returns true ONLY on a genuine (non-union)
+   * conflict, so the caller keeps the PR open and routes it to enterLandingConflict.
+   *
+   * Safe to force-push here: both call sites run post-completion (adoption is only reached via
+   * classifyLanding, which requires a completed-epic row), so every child PR is already merged.
+   */
+  private async rebaseIntegrationAtLanding(
+    forge: GitForge,
+    repoPath: string,
+    integrationBranch: string,
+    defaultBranch: string,
+    parent: number,
+  ): Promise<boolean> {
+    if (forge.kind !== "github") return false;
+    if (this.hasLiveRepairSession(repoPath, integrationBranch)) return false;
+    const res = await this.rebaseLandingBranch(repoPath, integrationBranch, defaultBranch);
+    if (res.kind === "conflict") {
+      console.warn(
+        `[drain] open-time rebase for ${repoPath}#${parent} hit a genuine conflict; ` +
+          `opening/adopting the landing PR paused`,
+      );
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * #1838: Transition an epic's landing row into the genuine-conflict pause and notify the operator.
+   * Single source of truth for the conflict pause + push, called from BOTH the open-time paths (via
+   * ensureLandingPr, after resolveLanding has persisted the PR) and the reactive rebase pass's
+   * conflict case. The pause is edge-set (callers reach this only on the transition into conflict),
+   * so the push fires once per transition; a cooldownKey backstops any repeat. NEVER lets a notify
+   * throw/reject escape — a push hiccup must not demote a successfully-opened landing PR.
+   */
+  private enterLandingConflict(repoPath: string, parent: number, landingPr: number | null): void {
+    this.deps.store.setEpicLandingRebaseState(repoPath, parent, { pauseReason: "conflict" });
+    this.emitCompleted(repoPath, parent);
+    try {
+      void Promise.resolve(
+        this.deps.notify?.({
+          kind: "landing_conflict",
+          sessionId: "",
+          tag: `landing-conflict:${repoPath}#${parent}`,
+          name: "epic",
+          epicNumber: parent,
+          landingPr: landingPr ?? undefined,
+          cooldownKey: `landing_conflict:${repoPath}#${parent}`,
+        }),
+      ).catch((err) =>
+        console.warn(`[drain] landing_conflict notify failed for ${repoPath}#${parent}:`, err),
+      );
+    } catch (err) {
+      console.warn(`[drain] landing_conflict notify threw for ${repoPath}#${parent}:`, err);
+    }
   }
 
   /**
@@ -1324,9 +1422,20 @@ export class DrainService {
     prNumber: number | null;
     prUrl: string | null;
     attempts: number;
+    rebaseConflict?: boolean;
   }> {
     const { parentIssueNumber, parentTitle, landingAttempts } = row;
     const defaultBranch = await forge.defaultBranch();
+    // #1838: rebase the integration branch onto the current default BEFORE opening, so the PR is
+    // not born behind/conflicting. A genuine conflict is left un-pushed by the seam; open the PR
+    // anyway (the operator needs a PR to see) and signal it so the caller pauses + notifies.
+    const rebaseConflict = await this.rebaseIntegrationAtLanding(
+      forge,
+      row.repoPath,
+      integrationBranch,
+      defaultBranch,
+      parentIssueNumber,
+    );
     const children = JSON.parse(row.childrenJson) as CompletedEpicChild[];
     const title = buildLandingPrTitle(parentIssueNumber, parentTitle);
     const body = buildLandingPrBody({
@@ -1347,6 +1456,7 @@ export class DrainService {
       prNumber: status.number ?? null,
       prUrl: status.url ?? null,
       attempts: landingAttempts,
+      rebaseConflict,
     };
   }
 
@@ -1647,6 +1757,7 @@ export class DrainService {
       landingRebaseCount: number;
       landingRebaseDriverMisses: number;
       landingRebasePauseReason: "cap" | "conflict" | "driver" | null;
+      landingPrNumber: number | null;
     },
     branch: string,
     defaultBranch: string,
@@ -1685,9 +1796,9 @@ export class DrainService {
         break;
 
       case "conflict":
-        // Genuine conflict (non-union path, or union path + driver self-test passed).
-        this.deps.store.setEpicLandingRebaseState(repoPath, parent, { pauseReason: "conflict" });
-        this.emitCompleted(repoPath, parent);
+        // Genuine conflict (non-union path, or union path + driver self-test passed). #1838: route
+        // through the shared helper so the conflict pause + operator push are set as one transition.
+        this.enterLandingConflict(repoPath, parent, row.landingPrNumber);
         break;
 
       case "driver-absent":

--- a/src/index.ts
+++ b/src/index.ts
@@ -1869,6 +1869,8 @@ const drain = new DrainService({
   telemetry,
   // #1071: wire rebase cap + real rebaseLandingBranch (mirrors autopilot/automerge wiring).
   rebaseCap: config.autoMergeRebaseCap,
+  // #1838: surface a genuine-conflict landing pause to the operator via push.
+  notify: (input) => push.notify(input),
 });
 
 // Drive the drain's archived/review handling off the poller events. `session:git`/`session:status`

--- a/src/push.ts
+++ b/src/push.ts
@@ -25,7 +25,8 @@ export interface PushPayload {
     | "learnings_trialed"
     | "manual_steps"
     | "ready"
-    | "backup_stale";
+    | "backup_stale"
+    | "landing_conflict";
   tag: string;
 }
 
@@ -50,6 +51,8 @@ const KIND_CATEGORY: Record<PushPayload["kind"], PushCategory> = {
   ready: "agent",
   // Host-global operational alert; ride the "agent" toggle like usage_limit/extra_credits.
   backup_stale: "agent",
+  // Epic-global merge/land attention; ride the "ci" toggle like merge_attention/manual_steps.
+  landing_conflict: "ci",
 };
 
 /** A notification described by intent, not text — localized per device at send time. */
@@ -69,7 +72,8 @@ export interface NotifyInput {
     | "learnings_trialed"
     | "manual_steps"
     | "ready"
-    | "backup_stale";
+    | "backup_stale"
+    | "landing_conflict";
   sessionId: string;
   tag: string;
   name: string;
@@ -102,6 +106,10 @@ export interface NotifyInput {
   trialedCount?: number;
   /** For kind "backup_stale": whole hours since the newest snapshot (for the body copy). */
   staleHours?: number;
+  /** For kind "landing_conflict": the epic's parent issue number (subject of the body). */
+  epicNumber?: number;
+  /** For kind "landing_conflict": the epic's landing PR number (subject of the body). */
+  landingPr?: number;
   /** Overrides the cooldown key (default `${kind}:${sessionId}`). */
   cooldownKey?: string;
 }
@@ -170,6 +178,11 @@ const NOTIFY_TEXT = {
       h !== null
         ? `No successful DB backup in ~${h}h — the backup timer may be failing.`
         : "No successful DB backup yet — the backup timer may be failing.",
+    landingConflictTitle: "Landing needs rework",
+    landingConflictBody: (epic: number, pr: number | null) =>
+      pr !== null
+        ? `Epic #${epic}'s landing PR #${pr} has a conflict with the default branch — over to you.`
+        : `Epic #${epic}'s landing PR has a conflict with the default branch — over to you.`,
   },
   de: {
     doneTitle: (name: string) => `${name} — wartet`,
@@ -217,6 +230,11 @@ const NOTIFY_TEXT = {
       h !== null
         ? `Seit ~${h}h kein erfolgreiches DB-Backup — der Backup-Timer könnte fehlschlagen.`
         : "Noch kein erfolgreiches DB-Backup — der Backup-Timer könnte fehlschlagen.",
+    landingConflictTitle: "Landing braucht Überarbeitung",
+    landingConflictBody: (epic: number, pr: number | null) =>
+      pr !== null
+        ? `Der Landing-PR #${pr} von Epic #${epic} hat einen Konflikt mit dem Standard-Branch — du bist dran.`
+        : `Der Landing-PR von Epic #${epic} hat einen Konflikt mit dem Standard-Branch — du bist dran.`,
   },
 } as const;
 
@@ -264,6 +282,14 @@ function mergeAttentionParts(t: NotifyText, input: NotifyInput): { title: string
     return { title: t.rebaseCapTitle, body: t.rebaseCapBody(desig) };
   }
   return { title: t.mergeErrorTitle, body: t.mergeErrorBody(desig) };
+}
+
+/** Landing-conflict title/body: the epic + landing-PR numbers the operator must rework. */
+function landingConflictParts(t: NotifyText, input: NotifyInput): { title: string; body: string } {
+  return {
+    title: t.landingConflictTitle,
+    body: t.landingConflictBody(input.epicNumber ?? 0, input.landingPr ?? null),
+  };
 }
 
 /** Extra-credits body: the spent/cap amount formatted with the optional currency prefix. */
@@ -338,6 +364,8 @@ export function buildPayload(input: NotifyInput, locale: string): PushPayload {
         title: t.backupStaleTitle,
         body: t.backupStaleBody(input.staleHours ?? null),
       };
+    case "landing_conflict":
+      return { ...base, ...landingConflictParts(t, input) };
     default:
       return {
         ...base,

--- a/test/drain-epic-landing.test.ts
+++ b/test/drain-epic-landing.test.ts
@@ -5,6 +5,8 @@ import { EmptyDiffError, EMPTY_BACKLOG_COUNTS } from "../src/forge/types";
 import type { GitForge, Issue, OpenPrInput, PrStatus, SubIssueRef } from "../src/forge/types";
 import type { UsageLimits as UsageLimitsType } from "../src/usage-limits";
 import type { CompletedEpic } from "../src/completed-epic";
+import type { LandingRebaseResult } from "../src/landing-rebase";
+import type { NotifyInput } from "../src/push";
 import { epicIntegrationBranch } from "../src/epic-branch";
 
 const REPO = "/repo";
@@ -132,6 +134,8 @@ interface Harness {
   drain: DrainService;
   completedEmits: CompletedEpic[];
   spy: ForgeSpy;
+  notifyCalls: NotifyInput[];
+  rebaseCalls: string[];
 }
 
 function makeHarness(opts: {
@@ -147,6 +151,12 @@ function makeHarness(opts: {
   /** Skip recording the running epic_run row (e.g. testing tick() in isolation). */
   noEpicRun?: boolean;
   autoDrainEnabled?: boolean;
+  /** #1838: fake open-time rebase seam result (default `current` → hermetic no-op, no real git). */
+  rebaseResult?: LandingRebaseResult;
+  /** #1838: invoked when the fake rebase seam runs (for ordering assertions). */
+  onRebase?: () => void;
+  /** #1838: make the notify seam throw synchronously (assert it can't demote the opened PR). */
+  notifyThrows?: boolean;
 }): Harness {
   const store = new SessionStore(":memory:");
   store.setRepoConfig(REPO, {
@@ -187,6 +197,8 @@ function makeHarness(opts: {
 
   const spy = fakeForge(opts);
   const completedEmits: CompletedEpic[] = [];
+  const notifyCalls: NotifyInput[] = [];
+  const rebaseCalls: string[] = [];
 
   const service = {
     create: async () => {
@@ -208,9 +220,20 @@ function makeHarness(opts: {
     emitEpic: () => {},
     emitEpicCompleted: (e) => completedEmits.push(e),
     rebaseCap: 5,
+    // #1838: hermetic open-time rebase seam — default `current` so no real git runs; overridable.
+    rebaseLandingBranch: async (_repo, branch) => {
+      rebaseCalls.push(branch);
+      opts.onRebase?.();
+      return opts.rebaseResult ?? { kind: "current" };
+    },
+    notify: (input) => {
+      notifyCalls.push(input);
+      if (opts.notifyThrows) throw new Error("notify boom");
+      return undefined;
+    },
   });
 
-  return { store, drain, completedEmits, spy };
+  return { store, drain, completedEmits, spy, notifyCalls, rebaseCalls };
 }
 
 /** Seed a recorded, integration-merged epic_completed row WITHOUT driving the completion
@@ -939,5 +962,165 @@ describe("classifyLanding — adopt + finalize the pre-warm draft landing PR (#1
     const row = h.store.listEpicCompleted(REPO)[0]!;
     expect(row.landingState).toBe("error"); // still a draft, never readied → visible error
     expect(row.landingPrNumber).toBe(52);
+  });
+});
+
+describe("#1838 open-time rebase — freshly-opened landing PR (openNewLandingPr)", () => {
+  test("rebase seam runs BEFORE openPr", async () => {
+    const order: string[] = [];
+    const h = makeHarness({
+      subIssues: [],
+      noEpicRun: true,
+      onRebase: () => order.push("rebase"),
+      openPr: async () => {
+        order.push("openPr");
+        return {
+          state: "open",
+          number: 601,
+          url: "https://github.com/o/r/pull/601",
+          checks: "none",
+          deployConfigured: false,
+        };
+      },
+    });
+    seedCompleted(h);
+
+    await h.drain.tick();
+
+    expect(h.rebaseCalls).toEqual([INTEGRATION_BRANCH]);
+    expect(order).toEqual(["rebase", "openPr"]); // rebase precedes the open
+    expect(h.store.listEpicCompleted(REPO)[0]!.landingState).toBe("open");
+  });
+
+  test("genuine conflict → PR still opened AND pause+notify, with automation OFF", async () => {
+    const h = makeHarness({
+      subIssues: [],
+      noEpicRun: true, // no running epic
+      autoDrainEnabled: false, // + auto-drain off + auto-merge off ⇒ reactive pass is NOT engaged
+      rebaseResult: { kind: "conflict" },
+      openPr: async () => ({
+        state: "open",
+        number: 602,
+        url: "https://github.com/o/r/pull/602",
+        checks: "none",
+        deployConfigured: false,
+      }),
+    });
+    seedCompleted(h);
+
+    await h.drain.tick();
+
+    // The PR is still opened and recorded — a conflict must not block the operator from seeing it.
+    expect(h.spy.openPrCalls).toHaveLength(1);
+    const row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("open");
+    expect(row.landingPrNumber).toBe(602);
+    // …and the conflict is loud even though no automation is engaged: pause + push.
+    expect(row.landingRebasePauseReason).toBe("conflict");
+    expect(h.notifyCalls).toHaveLength(1);
+    expect(h.notifyCalls[0]!.kind).toBe("landing_conflict");
+    expect(h.notifyCalls[0]!.epicNumber).toBe(PARENT);
+    expect(h.notifyCalls[0]!.landingPr).toBe(602);
+  });
+
+  test("no conflict → no pause, no notify", async () => {
+    const h = makeHarness({
+      subIssues: [],
+      noEpicRun: true,
+      rebaseResult: { kind: "rebased", headSha: "deadbeef" },
+      openPr: async () => ({
+        state: "open",
+        number: 603,
+        url: "https://github.com/o/r/pull/603",
+        checks: "none",
+        deployConfigured: false,
+      }),
+    });
+    seedCompleted(h);
+
+    await h.drain.tick();
+
+    const row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("open");
+    expect(row.landingRebasePauseReason).toBe(null);
+    expect(h.notifyCalls).toHaveLength(0);
+  });
+
+  test("a throwing notify does NOT demote the opened PR to error", async () => {
+    const h = makeHarness({
+      subIssues: [],
+      noEpicRun: true,
+      rebaseResult: { kind: "conflict" },
+      notifyThrows: true,
+      openPr: async () => ({
+        state: "open",
+        number: 604,
+        url: "https://github.com/o/r/pull/604",
+        checks: "none",
+        deployConfigured: false,
+      }),
+    });
+    seedCompleted(h);
+
+    await h.drain.tick(); // must not throw
+
+    const row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("open"); // NOT error
+    expect(row.landingPrNumber).toBe(604);
+    expect(row.landingRebasePauseReason).toBe("conflict"); // pause still applied
+    expect(h.notifyCalls).toHaveLength(1); // notify was attempted
+  });
+});
+
+describe("#1838 open-time rebase — pre-warm-adopted landing PR (adoptOpenLanding)", () => {
+  const openExistingDraft = (num: number) => async () =>
+    ({
+      state: "open" as const,
+      number: num,
+      url: `https://github.com/o/r/pull/${num}`,
+      isDraft: true,
+      checks: "none" as const,
+      deployConfigured: false,
+    }) as PrStatus;
+
+  test("adoption invokes the rebase seam (the draft was opened without one)", async () => {
+    const h = makeHarness({
+      subIssues: [],
+      noEpicRun: true,
+      preWarm: true,
+      prStatus: openExistingDraft(701),
+    });
+    seedCompleted(h);
+
+    await h.drain.tick();
+
+    expect(h.spy.openPrCalls).toHaveLength(0); // adopted, not re-opened
+    expect(h.rebaseCalls).toEqual([INTEGRATION_BRANCH]); // …but rebased at adoption
+    expect(h.spy.markReadyCalls).toEqual([701]);
+    const row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("open");
+    expect(row.landingRebasePauseReason).toBe(null);
+  });
+
+  test("genuine conflict at adoption → pause + notify (automation OFF)", async () => {
+    const h = makeHarness({
+      subIssues: [],
+      noEpicRun: true,
+      autoDrainEnabled: false,
+      preWarm: true,
+      rebaseResult: { kind: "conflict" },
+      prStatus: openExistingDraft(702),
+    });
+    seedCompleted(h);
+
+    await h.drain.tick();
+
+    const row = h.store.listEpicCompleted(REPO)[0]!;
+    expect(row.landingState).toBe("open"); // still adopted
+    expect(row.landingPrNumber).toBe(702);
+    expect(row.landingRebasePauseReason).toBe("conflict");
+    expect(h.notifyCalls).toHaveLength(1);
+    expect(h.notifyCalls[0]!.kind).toBe("landing_conflict");
+    expect(h.notifyCalls[0]!.landingPr).toBe(702);
   });
 });

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -634,6 +634,63 @@ test("merge_attention routes to ci category", async () => {
   expect(sent).toEqual(["only-ci"]);
 });
 
+test("buildPayload landing_conflict localizes EN+DE with the epic + PR numbers", () => {
+  const n: NotifyInput = {
+    kind: "landing_conflict",
+    sessionId: "",
+    tag: "landing-conflict:/repo#327",
+    name: "epic",
+    epicNumber: 327,
+    landingPr: 602,
+  };
+  expect(buildPayload(n, "en")).toMatchObject({
+    title: "Landing needs rework",
+    body: "Epic #327's landing PR #602 has a conflict with the default branch — over to you.",
+  });
+  expect(buildPayload(n, "de")).toMatchObject({
+    title: "Landing braucht Überarbeitung",
+    body: "Der Landing-PR #602 von Epic #327 hat einen Konflikt mit dem Standard-Branch — du bist dran.",
+  });
+});
+
+test("buildPayload landing_conflict omits the PR number when absent", () => {
+  const n: NotifyInput = {
+    kind: "landing_conflict",
+    sessionId: "",
+    tag: "landing-conflict:/repo#327",
+    name: "epic",
+    epicNumber: 327,
+  };
+  expect(buildPayload(n, "en").body).toBe(
+    "Epic #327's landing PR has a conflict with the default branch — over to you.",
+  );
+  expect(buildPayload(n, "de").body).toBe(
+    "Der Landing-PR von Epic #327 hat einen Konflikt mit dem Standard-Branch — du bist dran.",
+  );
+});
+
+test("landing_conflict routes to ci category", async () => {
+  const sent: string[] = [];
+  const send: SendFn = async (s) => {
+    sent.push(s.endpoint);
+    return {};
+  };
+  const { store, push } = svc(send);
+  store.putPushSub(sub("only-ci"), "");
+  store.setPushPrefs("only-ci", { agent: false, reviews: false, ci: true });
+  store.putPushSub(sub("no-ci"), "");
+  store.setPushPrefs("no-ci", { agent: true, reviews: true, ci: false });
+  await push.notify({
+    kind: "landing_conflict",
+    sessionId: "",
+    tag: "landing-conflict:/repo#327",
+    name: "epic",
+    epicNumber: 327,
+    landingPr: 602,
+  });
+  expect(sent).toEqual(["only-ci"]);
+});
+
 test("buildPayload usage_limit localizes EN+DE and includes the reset time", () => {
   const n: NotifyInput = {
     kind: "usage_limit",


### PR DESCRIPTION
Fixes #1838.

## Problem
Epic landing PRs shipped **conflicting** because the integration branch's merge-base with `main` is frozen at first-child-spawn and the landing PR was opened with **no rebase**. The reactive rebase pass (`rebaseStuckLandingPrsForRepo`) is gated on automation being *engaged* (`autoMerge || autoDrain || epicRun running`) — which is false once the epic completes. So on an auto-off repo a conflicting landing PR was **fully silent**: no rebase, no `conflict` pause written, and therefore not even the existing standing Tier-1 chip.

## Fix (prevention + make the residual loud)
- **Open-time rebase on BOTH landing paths.** New `rebaseIntegrationAtLanding` helper (GitHub-only, repair-fenced, reuses the union-aware `rebaseLandingBranch` seam) runs before `forge.openPr` in `openNewLandingPr` **and** at the start of `adoptOpenLanding` (the #1664 pre-warm draft is finalized there, bypassing `openNewLandingPr`). Safe to force-push: both run post-completion, so every child PR is merged.
- **Genuine conflict → loud, unconditionally.** On a `conflict` result the PR is still opened/adopted; `enterLandingConflict` then sets `pauseReason:"conflict"` (standing Tier-1 chip) **and** fires a new `landing_conflict` push — regardless of automation state, closing the silent gap. It's invoked **after** `resolveLanding` persists the PR, so a store/notify hiccup can never demote the opened PR to `error`. The notify is throw/reject-safe. The reactive `doLandingRebase` conflict case routes through the same helper (single source of truth, edge-triggered + cooldown-keyed).

## Coverage
| Landing-PR path | Open-time rebase | Conflict → notify |
| --- | --- | --- |
| Freshly-opened (`openNewLandingPr`) | ✅ before `openPr` | ✅ |
| Pre-warm adopted (`adoptOpenLanding`) | ✅ first rebase at adoption | ✅ |
| Idempotency re-adoption | ✅ cheap `current` short-circuit (already rebased prior tick) | ✅ if fresh conflict |

## Why a new push kind (not `merge_attention`)
`merge_attention` is session-scoped (keyed by `sessionId`, carries a session `desig`). A landing conflict is epic/host-global (`sessionId:""`, subject is epic # + landing PR #), so it needs its own copy, cooldown key, and click routing. Same `"ci"` category, distinct kind. Copy is server-side EN+DE in `NOTIFY_TEXT` (not the Paraglide catalog), so `check:i18n` doesn't apply.

## Partial acceptance / deferred → #1841
This meets acceptance bullets 1 (rebased at open, both paths) and 3 (residual conflict notified + standing-surfaced). Bullet 2 ("no unbounded drift over the epic's life") is **partially** met: open-time rebase is one big end-of-epic rebase — turning that into continuous small drift needs the **cadence rebase during the epic**, deferred with the **auto-rework agent** and **conflict stranded-escalation** to #1841.

## Tests
- `test/drain-epic-landing.test.ts`: freshly-opened (rebase before `openPr`; conflict → PR still opened + pause + notify with automation off; no-conflict → no pause/notify; throwing notify doesn't demote) and pre-warm-adopted (rebase at adoption; conflict → pause + notify).
- `test/push.test.ts`: `landing_conflict` payload EN+DE (with/without PR#) + `"ci"` category routing.
- Full root suite green (7245 pass); typecheck + lint + fallow audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)