### PR TITLE
fix(critic): make the epic landing-PR critic epic-aware (#1761)

### DIFF
--- a/src/critic-core.ts
+++ b/src/critic-core.ts
@@ -55,6 +55,22 @@ export interface EpicContext {
   delta?: EpicBaseDelta | null;
 }
 
+/** Epic LANDING context (issue #1761). Present iff the reviewed PR is the epic's aggregate LANDING
+ *  PR — head = the integration branch, base = the DEFAULT branch — so the critic reviews the WHOLE
+ *  accumulated epic diff against main. Mutually exclusive with {@link EpicContext} (a child's base
+ *  is the integration branch; a landing PR's base is main), and structurally distinct: the landing
+ *  worktree is the integration-branch tip, which already holds every merged child, so there is NO
+ *  stale-tree problem and NONE of the base-delta / VERIFY-override machinery applies. The block is
+ *  PURELY ADDITIVE — it prioritizes integration-level defect classes without narrowing the diff or
+ *  licensing the critic to drop any in-diff finding. */
+export interface LandingContext {
+  /** The epic integration branch being landed (the PR's head), for the reframing header. */
+  integrationBranch: string;
+  /** Number of child PRs the epic drained; 0 when unknown (childrenJson unparseable) → the count
+   *  parenthetical is omitted rather than emitting a false "0 child" claim. */
+  childCount: number;
+}
+
 // Caps for the embedded delta. Bounded so a long-draining epic can't blow up the prompt; the
 // truncation counts are always stated, and the full lists stay one command away.
 const DELTA_PATH_CAP = 100;
@@ -204,12 +220,15 @@ export function reviewPrompt(
  *  the diff for bugs, security issues, and clear quality problems, using the PR's stated intent
  *  (title + body) only as CONTEXT for what the change is trying to do. Shares the EXACT scope rules
  *  and verdict-output contract with reviewPrompt (via scopeAndOutputTail) so the two never diverge.
+ *  `epic` is set iff the PR's base is an epic integration branch (a child PR); `landing` is set iff
+ *  the PR is the epic's aggregate LANDING PR (#1761) — mutually exclusive, at most one block emits.
  *  NOT UI chrome — never i18n'd. */
 export function prReviewPrompt(
   diffBase: string,
   prTitle: string,
   prBody: string,
   epic?: EpicContext | null,
+  landing?: LandingContext | null,
 ): string {
   const lines = [
     "You are a code critic reviewing a pull request. Do NOT modify, build, commit, or run anything — read-only inspection only.",
@@ -228,6 +247,7 @@ export function prReviewPrompt(
       diffBase,
       "Judge the diff ONLY for bugs, security issues, and clear quality problems. Use the stated intent above to understand what the change is for — do NOT raise a finding merely because the diff seems incomplete versus that intent. Tests and lint are handled by CI — do not run them.",
       epic,
+      { landing },
     ),
   );
   return lines.join("\n");
@@ -411,11 +431,36 @@ function epicBlock(epic: EpicContext): string[] {
   return lines;
 }
 
+/** The epic LANDING block (issue #1761), emitted ONLY when the reviewed PR is the epic's aggregate
+ *  landing PR (see {@link LandingContext}). Empty array otherwise — so every non-landing prompt
+ *  stays byte-identical.
+ *
+ *  PURELY ADDITIVE. Unlike {@link epicBlock}, it overrides NOTHING and relaxes NOTHING: the landing
+ *  worktree is the integration-branch tip, which already holds every merged child, so the tree is
+ *  complete and the stale-tree / base-citation machinery does not apply. It carries NO "already
+ *  reviewed / do not re-litigate" wording on purpose — this critic has no child-review history and
+ *  sees only the merged diff, so any suppression hint would invite it to drop a genuine in-diff bug.
+ *  It only shifts PRIORITY toward the integration-level defect classes that surface once the
+ *  children are combined, and it keeps an explicit "a real bug is a finding no matter which child
+ *  introduced it" line adjacent to the reframing so the additive emphasis can never read as license
+ *  to narrow the review. */
+function landingBlock(landing: LandingContext, diffBase: string): string[] {
+  // Count parenthetical omitted when unknown (childCount 0) — never emit a false "0 child" claim.
+  const count = landing.childCount > 0 ? ` (${landing.childCount} child PRs)` : "";
+  return [
+    "",
+    `EPIC LANDING PR — this PR is the AGGREGATE landing of a completed multi-PR epic${count}, merging the epic integration branch \`${landing.integrationBranch}\` into the default branch:`,
+    "- The children each shipped as their own PR; this review's HIGHEST-VALUE target is INTEGRATION-LEVEL defects that only surface once the children are combined: cross-child interaction (one child breaking an assumption another child made), merge/rebase artifacts, duplicated or conflicting definitions across children, and whole-diff coherence against the default branch. PRIORITIZE scanning for these.",
+    `- This is ADDITIVE emphasis, NOT a narrowing: you are STILL reviewing the entire \`git diff ${diffBase}...HEAD\` under every rule above.`,
+    "- A real bug is a finding no matter which child introduced it — nothing about this being a landing PR downgrades or excuses an in-diff defect.",
+  ];
+}
+
 function scopeAndOutputTail(
   diffBase: string,
   judgeClause: string,
   epic?: EpicContext | null,
-  opts: { scopeCreep?: boolean; smellLens?: boolean } = {},
+  opts: { scopeCreep?: boolean; smellLens?: boolean; landing?: LandingContext | null } = {},
 ): string[] {
   return [
     // SCOPE: the critic can Read/grep the whole tree, which historically led it to flag
@@ -449,6 +494,11 @@ function scopeAndOutputTail(
     // VERIFY/CANNOT-VERIFY/ATTRIBUTION rules it supersedes — so the override reads against the rule
     // it overrides. Empty for a non-epic base, keeping those prompts byte-identical.
     ...(epic ? epicBlock(epic) : []),
+    // Epic LANDING context (issue #1761). Mutually exclusive with `epic` (child base = integration
+    // branch; landing base = default branch), so at most one of the two blocks ever emits. Purely
+    // ADDITIVE — it overrides nothing above, only prioritizes integration-level defect classes.
+    // Empty for a non-landing PR, keeping those prompts byte-identical.
+    ...(opts.landing ? landingBlock(opts.landing, diffBase) : []),
     "",
     judgeClause,
     "",

--- a/src/standalone-critic.ts
+++ b/src/standalone-critic.ts
@@ -40,6 +40,7 @@ import {
   reapRun,
   type RawVerdict,
   type EpicContext,
+  type LandingContext,
 } from "./critic-core";
 import type { VerdictRead } from "./json-tolerant";
 import { reapTransientByLabel } from "./transient-tab-reaper";
@@ -294,6 +295,31 @@ export class StandalonePrCriticService {
   }
 
   /**
+   * Epic LANDING context (issue #1761): non-null iff this PR is the aggregate landing PR of an epic
+   * still draining. Detected off the authoritative `epic_completed` row — a PR whose number matches
+   * an OPEN landing row — NOT a branch-name heuristic, so it can't misfire on a hand-opened
+   * `epic/*`→main PR outside the epic flow, and it yields the child count for the prompt. Works
+   * whether the repo is swept via `criticAllPrs` ON or purely for its landing PR (Stage B). Returns
+   * null (→ today's whole-diff behavior) when there is no matching open landing row.
+   */
+  private resolveLandingContext(repoPath: string, pr: PullRequest): LandingContext | null {
+    const row = this.deps.store
+      .listEpicCompleted(repoPath)
+      .find((r) => r.landingPrNumber === pr.number && r.landingState === "open");
+    if (!row) return null;
+    // childCount drives the prompt's "(N child PRs)" parenthetical; an unparseable childrenJson
+    // degrades to 0, and landingBlock then OMITS the count rather than emitting a false "0 child".
+    let childCount = 0;
+    try {
+      const parsed = JSON.parse(row.childrenJson) as unknown;
+      if (Array.isArray(parsed)) childCount = parsed.length;
+    } catch {
+      childCount = 0;
+    }
+    return { integrationBranch: pr.headRefName!, childCount };
+  }
+
+  /**
    * Spawn a critic for one eligible PR. Mirrors ReviewService.begin: claim `starting`
    * synchronously, allocate the disposable worktree at the PR head, fingerprint the diff,
    * patch-id-skip if unchanged, build the session-less prompt, spawn, and record the run +
@@ -385,6 +411,10 @@ export class StandalonePrCriticService {
             delta: baseSha ? await this.collectBaseDelta(wt.worktreePath, baseSha) : null,
           }
         : null;
+      // Epic LANDING PR (#1761): the aggregate landing of a draining epic — head is the integration
+      // branch, base is the default branch (so `epic` above is null; the two are mutually exclusive).
+      // Reframes the whole-epic sweep toward integration-level defects. Cheap synchronous store read.
+      const landing = this.resolveLandingContext(repoPath, pr);
       // Fail-closed guard + membrane-wrapped spawn + spawn-row record live in spawnAndRecord (keeps
       // begin under the cognitive budget). Returns false when nothing spawned (fail-closed / spawn
       // error) — the worktree is reaped inside, so begin just bails.
@@ -394,6 +424,7 @@ export class StandalonePrCriticService {
         files,
         priorReviewedPatchIds: prior?.reviewedPatchIds ?? [],
         epic,
+        landing,
       });
     } finally {
       this.starting.delete(key);
@@ -424,6 +455,8 @@ export class StandalonePrCriticService {
       priorReviewedPatchIds: string[];
       /** Non-null only when the PR's base is an epic integration branch (#1757). */
       epic?: EpicContext | null;
+      /** Non-null only when the PR is the epic's aggregate landing PR (#1761). */
+      landing?: LandingContext | null;
     },
   ): Promise<void> {
     if (apiKeyFailClosed(this.deps.env?.().provider ?? "claude")) {
@@ -438,7 +471,7 @@ export class StandalonePrCriticService {
       provider: env.provider,
       model: env.model,
       effort: env.effort,
-      prompt: prReviewPrompt(diffBase, pr.title, prBody, fp.epic ?? null),
+      prompt: prReviewPrompt(diffBase, pr.title, prBody, fp.epic ?? null, fp.landing ?? null),
     });
     // Fire plugin onSpawn hooks (issue #1205) + bind patched env THROUGH the membrane. Session-less
     // PR critic → no parentSessionId. An abortSpawn cleanly skips (worktree reaped).

--- a/test/critic-core.test.ts
+++ b/test/critic-core.test.ts
@@ -223,6 +223,61 @@ test("reviewPrompt and prReviewPrompt share the identical scope+output tail", ()
   expect(outputContract(a)).toBe(outputContract(b));
 });
 
+// ── #1761 epic LANDING block (prReviewPrompt, purely additive) ──────────────────────────────────
+
+test("prReviewPrompt carries the epic LANDING block, additive with the safety-net line adjacent", () => {
+  const p = prReviewPrompt("BASE", "Land epic", "body", null, {
+    integrationBranch: "epic/1761-landing-critic",
+    childCount: 3,
+  });
+  expect(p).toContain("EPIC LANDING PR");
+  // integration branch + child count surfaced
+  expect(p).toContain("epic/1761-landing-critic");
+  expect(p).toContain("(3 child PRs)");
+  // prioritizes integration-level defect classes
+  expect(p).toContain("INTEGRATION-LEVEL defects");
+  expect(p).toContain("cross-child interaction");
+  // ADDITIVE, not a narrowing — still the whole diff
+  expect(p).toContain("ADDITIVE emphasis, NOT a narrowing");
+  expect(p).toContain("git diff BASE...HEAD");
+  // the safety-net line is present AND adjacent to the reframing (last line of the block, so it
+  // immediately precedes the judge clause) — the additive emphasis can't read as license to drop
+  const safety = "A real bug is a finding no matter which child introduced it";
+  expect(p).toContain(safety);
+  const additiveIdx = p.indexOf("ADDITIVE emphasis, NOT a narrowing");
+  const safetyIdx = p.indexOf(safety);
+  expect(safetyIdx).toBeGreaterThan(additiveIdx);
+  // NO suppression phrasing — this critic has no child-review history and only sees the merged diff
+  expect(p).not.toContain("already reviewed");
+  expect(p).not.toContain("re-litigate");
+  expect(p).not.toContain("do NOT re-raise");
+  // it is NOT the child EPIC CONTEXT block (different frame, base-delta overrides)
+  expect(p).not.toContain("EPIC CONTEXT");
+  expect(p).not.toContain("OVERRIDES the VERIFY rule");
+});
+
+test("prReviewPrompt landing block omits the count parenthetical when childCount is 0 (unknown)", () => {
+  const p = prReviewPrompt("BASE", "Land epic", "body", null, {
+    integrationBranch: "epic/1761-x",
+    childCount: 0,
+  });
+  expect(p).toContain("EPIC LANDING PR");
+  // never a false "0 child" claim — the parenthetical is dropped entirely
+  expect(p).not.toContain("child PRs)");
+  // header reads "...multi-PR epic, merging..." with no count inserted before the comma
+  expect(p).toContain("multi-PR epic, merging the epic integration branch");
+});
+
+test("prReviewPrompt without a landing context leaves the tail byte-identical (non-landing unchanged)", () => {
+  // The title/body fence carries a per-call nonce, so two whole prompts never match there. The
+  // landing block lives in the shared tail (from "SCOPE —" on), which IS deterministic — compare it.
+  const tail = (s: string) => s.slice(s.indexOf("SCOPE — "));
+  const withoutArg = prReviewPrompt("BASE", "My PR", "body");
+  const withNull = prReviewPrompt("BASE", "My PR", "body", null, null);
+  expect(withoutArg).not.toContain("EPIC LANDING PR");
+  expect(tail(withNull)).toBe(tail(withoutArg));
+});
+
 // ── scopeBackstop (pure) ────────────────────────────────────────────────────
 
 test("scopeBackstop drops out-of-diff path-attributed findings, keeps in-diff + unattributed", () => {

--- a/test/standalone-critic.test.ts
+++ b/test/standalone-critic.test.ts
@@ -128,6 +128,9 @@ function makeDeps(
       repoPath: string;
       landingPrNumber: number | null;
       landingState?: string;
+      // JSON array of child issue numbers — its length feeds the #1761 landing prompt's "(N child
+      // PRs)" count. Omitted / unparseable → childCount 0 → the count parenthetical is dropped.
+      childrenJson?: string;
     }[];
   } = {},
 ) {
@@ -911,4 +914,76 @@ test("#1757 ordinary PR (base=main): no epic block", async () => {
   const svc = new StandalonePrCriticService(deps as any);
   await svc.sweep();
   expect(spies.started[0]!.argv.at(-1)!).not.toContain("EPIC CONTEXT");
+});
+
+// ── #1761 epic LANDING PR (head = integration branch, base = main) ────────────────────────────────
+//
+// The landing PR is detected off the authoritative epic_completed row (landingPrNumber match), NOT a
+// branch-name heuristic, so it attaches the additive LANDING block. Its base is main → the child
+// EPIC CONTEXT block (which keys on base==integration) stays absent — the two are mutually exclusive.
+
+test("#1761 epic landing PR: the prompt carries the additive LANDING block with the child count", async () => {
+  const { deps, spies } = makeDeps(
+    {},
+    {
+      criticAllPrs: true,
+      epicCompleted: [
+        {
+          repoPath: "/r",
+          landingPrNumber: 7,
+          landingState: "open",
+          childrenJson: "[101,102,103]",
+        },
+      ],
+    },
+  );
+  // head IS the epic integration branch; base stays main (OPEN_META default) → landing, not child.
+  deps.resolveForge = () =>
+    makeForge(spies, {
+      prs: [pr({ number: 7, headRefName: "epic/1761-landing-critic", headSha: "landsha" })],
+    });
+  const svc = new StandalonePrCriticService(deps as any);
+  await svc.sweep();
+  const prompt = spies.started[0]!.argv.at(-1)!;
+  expect(prompt).toContain("EPIC LANDING PR");
+  expect(prompt).toContain("epic/1761-landing-critic");
+  expect(prompt).toContain("(3 child PRs)");
+  expect(prompt).toContain("INTEGRATION-LEVEL defects");
+  // the safety-net line is present so the additive emphasis can't read as license to drop a finding
+  expect(prompt).toContain("A real bug is a finding no matter which child introduced it");
+  // additive, NOT the child block (no base-delta override machinery)
+  expect(prompt).not.toContain("EPIC CONTEXT");
+  expect(prompt).not.toContain("already reviewed");
+});
+
+test("#1761 landing PR with unparseable childrenJson: block emitted, count parenthetical omitted", async () => {
+  const { deps, spies } = makeDeps(
+    {},
+    {
+      criticAllPrs: true,
+      epicCompleted: [
+        { repoPath: "/r", landingPrNumber: 7, landingState: "open", childrenJson: "not json" },
+      ],
+    },
+  );
+  deps.resolveForge = () =>
+    makeForge(spies, {
+      prs: [pr({ number: 7, headRefName: "epic/1761-x", headSha: "landsha" })],
+    });
+  const svc = new StandalonePrCriticService(deps as any);
+  await svc.sweep();
+  const prompt = spies.started[0]!.argv.at(-1)!;
+  expect(prompt).toContain("EPIC LANDING PR");
+  // childCount falls back to 0 → no "(N child PRs)" and never a false "0 child" claim
+  expect(prompt).not.toContain("child PRs)");
+});
+
+test("#1761 ordinary PR (no matching open landing row): no LANDING block", async () => {
+  // Default makeDeps injects no epic_completed rows → resolveLandingContext returns null.
+  const { deps, spies } = makeDeps();
+  const svc = new StandalonePrCriticService(deps as any);
+  await svc.sweep();
+  const prompt = spies.started[0]!.argv.at(-1)!;
+  expect(prompt).not.toContain("EPIC LANDING PR");
+  expect(prompt).not.toContain("EPIC CONTEXT");
 });


### PR DESCRIPTION
Closes #1761.

## Problem

The epic **landing PR** (head = the epic integration branch, base = the default branch) is reviewed by the standalone critic against the **entire accumulated epic diff vs main**, with **zero epic awareness** — so it re-litigates every child that was already reviewed against the integration branch. #1757's `EpicContext` attaches only when the reviewed PR's *base* is an integration branch (child PRs); the landing PR's base is main, so it got no reframing.

## Decision

Issue #1761 deliberately left this a product call (keep-as-is / epic-aware / narrow-diff). **Option 2 (epic-aware prompt)** was chosen and ratified by the operator in the plan gate: it keeps the full-diff safety net (nothing slips through) while reframing the critic toward integration-level defects. Option 3 (narrow the diff) was rejected as risking a real integration defect slipping through.

## Change

Attach a **landing-specific context** (`src/standalone-critic.ts` + `src/critic-core.ts`):

- **Authoritative detection** — a PR whose number matches an *open* `epic_completed` landing row, not a branch-name heuristic. Can't misfire on a hand-opened `epic/*`→main PR, and yields the child count for the prompt. Works with `criticAllPrs` ON or purely for the landing PR (Stage B).
- **Purely additive block**, deliberately simpler than the child block:
  - the landing worktree is the integration-branch tip, which already holds every merged child, so the tree is complete — **none** of the stale-tree / base-delta / VERIFY-override machinery applies;
  - it carries **no** "already reviewed / do not re-litigate" wording — this critic has no child-review history and sees only the merged diff, so a suppression hint would invite dropping a genuine in-diff bug. It only shifts **priority** toward integration-level defect classes (cross-child interaction, merge/rebase artifacts, duplicated/conflicting definitions, whole-diff coherence vs main);
  - keeps an explicit *"a real bug is a finding no matter which child introduced it"* line adjacent to the reframing so the additive emphasis can never read as license to narrow the review.
- Unparseable `childrenJson` → `childCount` 0 → the `(N child PRs)` parenthetical is omitted (never a false "0 child" claim).

The session critic (`review.ts`) never reviews landing PRs, so it is untouched.

## Scope note

This is a **prompt-only reframing** whose noise-reduction payoff is behavioral and **not unit-testable** — the tests assert only prompt-text presence/shape and the byte-identical non-landing path. A net-neutral outcome (extra tokens, unchanged output) is an accepted risk; the change is additive so it cannot make output worse. `[no-feature-entry]` (server-only critic behavior, no user-facing UI).

## Tests

- `test/critic-core.test.ts`: landing block content + safety-net line adjacency + no-suppression-phrasing + count-omit-when-0 + byte-identical non-landing tail.
- `test/standalone-critic.test.ts`: landing PR carries the block (with `(3 child PRs)`); unparseable `childrenJson` omits the count; ordinary PR gets neither block.
- `bun run lint`, `bun run typecheck`, and the full `bun test ./test` (7252 pass) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)