### PR TITLE
fix(ui): make GitRail's marked/dompurify imports dynamic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,17 @@ jobs:
         run: cd extension && bun run test
 
       - name: Build (ui)
-        run: cd ui && bun run build
+        # Rollup reports a static import that defeats a dynamic one
+        # (INEFFECTIVE_DYNAMIC_IMPORT) as a WARNING, which does not fail the build —
+        # so assert on it explicitly. One static `import { marked } from "marked"` in
+        # an always-mounted component hoists the lib into the main chunk and silently
+        # cancels the lazy-loading in every other consumer. pipefail so a genuine
+        # build failure still fails the step; `! grep -q` (not `grep -c`, which exits
+        # 1 when the count is 0) so the success case exits 0.
+        run: |
+          set -eo pipefail
+          cd ui && bun run build 2>&1 | tee /tmp/ui-build.log
+          ! grep -q INEFFECTIVE_DYNAMIC_IMPORT /tmp/ui-build.log
 
       - name: Build (extension)
         run: cd extension && bun run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,17 +147,10 @@ jobs:
         run: cd extension && bun run test
 
       - name: Build (ui)
-        # Rollup reports a static import that defeats a dynamic one
-        # (INEFFECTIVE_DYNAMIC_IMPORT) as a WARNING, which does not fail the build —
-        # so assert on it explicitly. One static `import { marked } from "marked"` in
-        # an always-mounted component hoists the lib into the main chunk and silently
-        # cancels the lazy-loading in every other consumer. pipefail so a genuine
-        # build failure still fails the step; `! grep -q` (not `grep -c`, which exits
-        # 1 when the count is 0) so the success case exits 0.
-        run: |
-          set -eo pipefail
-          cd ui && bun run build 2>&1 | tee /tmp/ui-build.log
-          ! grep -q INEFFECTIVE_DYNAMIC_IMPORT /tmp/ui-build.log
+        # Builds, and fails on INEFFECTIVE_DYNAMIC_IMPORT (a static import that defeats
+        # a dynamic one — Rollup only warns, so the build would otherwise stay green).
+        # Same script as the pre-push hook's ui build lane, so the two stay in sync.
+        run: ./scripts/check-ui-build.sh
 
       - name: Build (extension)
         run: cd extension && bun run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ so a hung child can never wedge the push. The checks (per lane) are:
 - **eslint:** root + extension eslint over the push **delta** (see note)
 - **tsc:** `bun run typecheck` (root `tsc --noEmit`)
 - **root-tests:** `bun test ./test`
-- **ui:** `bun run check` → `check:i18n` → `playwright install chromium` → `bun run test` → `bun run build`
+- **ui:** `bun run check` → `check:i18n` → `playwright install chromium` → `bun run test` → `scripts/check-ui-build.sh` (the ui build, plus a fail on Rollup's `INEFFECTIVE_DYNAMIC_IMPORT`; CI's **Build (ui)** step runs the same script)
 - **ext:** `bun run check` → `check:i18n` → `bun run test` → `bun run build`
 - then **`bunx fallow@2.100.0 audit --base origin/main --fail-on-issues`** (delta
   dead-code/complexity audit; version pinned — see note below)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,12 +76,12 @@ and failed pushes. Independent work runs in parallel (bounded by your core count
 lane teeing to its own `.test-logs/` file, with a per-lane wall-clock **timeout backstop**
 so a hung child can never wedge the push. The checks (per lane) are:
 
-- **gates:** branch-hygiene · feature-catalog · generated-docs · glossary
+- **gates:** branch-hygiene · feature-catalog · generated-docs · glossary · announcement-versions · herdr-types
 - **prettier:** `prettier --check` over the push **delta** (see note)
 - **eslint:** root + extension eslint over the push **delta** (see note)
 - **tsc:** `bun run typecheck` (root `tsc --noEmit`)
 - **root-tests:** `bun test ./test`
-- **ui:** `bun run check` → `check:i18n` → `playwright install chromium` → `bun run test` → `scripts/check-ui-build.sh` (the ui build, plus a fail on Rollup's `INEFFECTIVE_DYNAMIC_IMPORT`; CI's **Build (ui)** step runs the same script)
+- **ui:** `bun run check` → `check:i18n` → `check:docs-manifest` → `playwright install chromium` → `bun run test` → `scripts/check-ui-build.sh` (the ui build, plus a fail on Rollup's `INEFFECTIVE_DYNAMIC_IMPORT`; CI's **Build (ui)** step runs the same script)
 - **ext:** `bun run check` → `check:i18n` → `bun run test` → `bun run build`
 - then **`bunx fallow@2.100.0 audit --base origin/main --fail-on-issues`** (delta
   dead-code/complexity audit; version pinned — see note below)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -61,6 +61,34 @@ export default [
         extraFileExtensions: [".svelte"],
       },
     },
+    rules: {
+      // marked + DOMPurify are heavy and are lazily imported by every consumer that
+      // renders markdown. A single STATIC import in an always-mounted component
+      // hoists them into the main chunk and silently defeats all of them, so ban the
+      // static form here. Dynamic `await import("marked")` is unaffected — both
+      // `paths` and `patterns` only match static imports.
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "marked",
+              message:
+                'Import dynamically — see SessionRecap.svelte: Promise.all([import("marked"), import("dompurify")]).',
+            },
+            {
+              name: "dompurify",
+              message:
+                'Import dynamically — see SessionRecap.svelte: Promise.all([import("marked"), import("dompurify")]).',
+            },
+          ],
+          // `paths` matches the exact specifier only, so it would miss a deep import
+          // like "marked/lib/marked.esm.js" — precisely the path Rollup names in the
+          // INEFFECTIVE_DYNAMIC_IMPORT warning this rule exists to prevent.
+          patterns: ["marked/*", "dompurify/*"],
+        },
+      ],
+    },
   },
   // Generated output — never lint
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -61,12 +61,24 @@ export default [
         extraFileExtensions: [".svelte"],
       },
     },
+  },
+  // marked + DOMPurify are heavy and are lazily imported by every consumer that renders
+  // markdown. A single STATIC import hoists them into a shared chunk and silently
+  // defeats all of them (Rollup: INEFFECTIVE_DYNAMIC_IMPORT) — that is what GitRail did
+  // to seven other components.
+  //
+  // Scoped to ALL of ui/src, not just the Svelte files, because Rollup does not warn for
+  // every static importer: a static import from a plain `ui/src/lib/*.ts` helper produces
+  // NO warning at all, so scripts/check-ui-build.sh cannot see it (measured — see the
+  // table in that script's header). For those files this rule is the ONLY gate.
+  //
+  // One block rather than the rule repeated per-glob, so there is a single definition to
+  // keep correct.
+  {
+    files: ["ui/src/**/*"],
     rules: {
-      // marked + DOMPurify are heavy and are lazily imported by every consumer that
-      // renders markdown. A single STATIC import in an always-mounted component
-      // hoists them into the main chunk and silently defeats all of them, so ban the
-      // static form here. Dynamic `await import("marked")` is unaffected — both
-      // `paths` and `patterns` only match static imports.
+      // Dynamic `await import("marked")` is unaffected — both `paths` and `patterns`
+      // only match static imports.
       "no-restricted-imports": [
         "error",
         {

--- a/scripts/check-ui-build.sh
+++ b/scripts/check-ui-build.sh
@@ -11,8 +11,22 @@
 #   - `.github/workflows/ci.yml` and `scripts/pre-push.ts` must stay in sync (see the
 #     job header at ci.yml:24-29). Both call this, so there is ONE implementation to
 #     keep correct rather than two copies of the same shell.
-#   - It also covers the case the Svelte-scoped `no-restricted-imports` lint rule
-#     provably cannot: a static import from a plain `ui/src/lib/*.ts` helper.
+#   - It is not library-specific: the `no-restricted-imports` rule in eslint.config.js
+#     names marked/dompurify, while this fires for ANY module that regresses this way.
+#
+# Known hole — do NOT assume this gate is exhaustive. Rollup emits the warning only for
+# some static importers, so a static import is caught in some files and silently
+# ignored in others. Measured on this repo:
+#
+#   ui/src/lib/components/GitRail.svelte  -> warns      (caught here + by eslint)
+#   ui/src/lib/recaps.svelte.ts           -> warns      (caught here + by eslint)
+#   ui/src/lib/api.ts                     -> NO warning (caught by NEITHER)
+#
+# A static import from a plain `.ts` helper can therefore defeat lazy-loading with both
+# gates green, because Rollup itself stays silent. That case is uncovered; review is the
+# only thing standing behind it. (An earlier version of this comment claimed the
+# opposite — that this script covered the plain-`.ts` case the Svelte-scoped lint rule
+# cannot see. That was inference; the measurement above disproved it.)
 #
 # Note this deliberately does NOT live in ui/vite.config.ts. Both in-build hooks were
 # tried and neither works: `build.rollupOptions.onwarn` is overridden by SvelteKit's

--- a/scripts/check-ui-build.sh
+++ b/scripts/check-ui-build.sh
@@ -43,8 +43,9 @@ trap 'rm -f "$log"' EXIT
 # swallowed by the pipe into tee.
 cd "$repo_root/ui" && bun run build 2>&1 | tee "$log"
 
-# `! grep -q` — NOT `grep -c`, which exits 1 when the count is 0 and would therefore
-# fail on the success case.
+# `grep -q` as the `if` condition, with the failure raised explicitly below — NOT
+# `grep -c`, whose exit status is 1 when the count is 0 and would therefore report
+# failure on the success case.
 if grep -q INEFFECTIVE_DYNAMIC_IMPORT "$log"; then
   echo ""
   echo "✗ INEFFECTIVE_DYNAMIC_IMPORT in the ui build:"

--- a/scripts/check-ui-build.sh
+++ b/scripts/check-ui-build.sh
@@ -14,19 +14,24 @@
 #   - It is not library-specific: the `no-restricted-imports` rule in eslint.config.js
 #     names marked/dompurify, while this fires for ANY module that regresses this way.
 #
-# Known hole — do NOT assume this gate is exhaustive. Rollup emits the warning only for
-# some static importers, so a static import is caught in some files and silently
-# ignored in others. Measured on this repo:
+# Do NOT assume this gate alone is exhaustive: Rollup emits the warning only for SOME
+# static importers. Measured on this repo:
 #
-#   ui/src/lib/components/GitRail.svelte  -> warns      (caught here + by eslint)
-#   ui/src/lib/recaps.svelte.ts           -> warns      (caught here + by eslint)
-#   ui/src/lib/api.ts                     -> NO warning (caught by NEITHER)
+#   ui/src/lib/components/GitRail.svelte  -> warns
+#   ui/src/lib/recaps.svelte.ts           -> warns
+#   ui/src/lib/api.ts  (plain .ts)        -> NO warning at all
 #
-# A static import from a plain `.ts` helper can therefore defeat lazy-loading with both
-# gates green, because Rollup itself stays silent. That case is uncovered; review is the
-# only thing standing behind it. (An earlier version of this comment claimed the
-# opposite — that this script covered the plain-`.ts` case the Svelte-scoped lint rule
-# cannot see. That was inference; the measurement above disproved it.)
+# So the two gates are complementary, and neither is a superset of the other:
+#
+#   this script            — ANY library, but only where Rollup actually warns
+#   no-restricted-imports  — ANY file under ui/src, but only the named libraries
+#                            (marked, dompurify)
+#
+# The plain-`.ts` case above is covered by the lint rule, which is scoped to `ui/src/**/*`
+# precisely because this script cannot see it. Residual hole, uncovered by design: a
+# DIFFERENT library, statically imported from a plain `.ts` where Rollup stays silent —
+# add it to the rule's `paths`/`patterns` if one ever matters. Review is what stands
+# behind that case.
 #
 # Note this deliberately does NOT live in ui/vite.config.ts. Both in-build hooks were
 # tried and neither works: `build.rollupOptions.onwarn` is overridden by SvelteKit's

--- a/scripts/check-ui-build.sh
+++ b/scripts/check-ui-build.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Build the UI and fail on Rollup's INEFFECTIVE_DYNAMIC_IMPORT.
+#
+# A STATIC import of a module that other modules import dynamically silently cancels
+# their lazy-loading: Rollup hoists it into a shared chunk for every consumer. That is
+# exactly what happened with marked/DOMPurify — one static import in the always-mounted
+# GitRail defeated the dynamic imports in seven other components, and because Rollup
+# only WARNS, the build stayed green the whole time.
+#
+# Why a script instead of inlining the check:
+#   - `.github/workflows/ci.yml` and `scripts/pre-push.ts` must stay in sync (see the
+#     job header at ci.yml:24-29). Both call this, so there is ONE implementation to
+#     keep correct rather than two copies of the same shell.
+#   - It also covers the case the Svelte-scoped `no-restricted-imports` lint rule
+#     provably cannot: a static import from a plain `ui/src/lib/*.ts` helper.
+#
+# Note this deliberately does NOT live in ui/vite.config.ts. Both in-build hooks were
+# tried and neither works: `build.rollupOptions.onwarn` is overridden by SvelteKit's
+# config merge, and an `onwarn` returned from a plugin `options` hook is ignored by
+# Vite (the plugin's hooks run, but the handler is never consulted). In both cases the
+# warning still printed and the build still exited 0 — a silently inert gate.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+log="$(mktemp -t shepherd-ui-build.XXXXXX.log)"
+trap 'rm -f "$log"' EXIT
+
+# pipefail (set above) makes a genuine build failure fail the script rather than being
+# swallowed by the pipe into tee.
+cd "$repo_root/ui" && bun run build 2>&1 | tee "$log"
+
+# `! grep -q` — NOT `grep -c`, which exits 1 when the count is 0 and would therefore
+# fail on the success case.
+if grep -q INEFFECTIVE_DYNAMIC_IMPORT "$log"; then
+  echo ""
+  echo "✗ INEFFECTIVE_DYNAMIC_IMPORT in the ui build:"
+  grep INEFFECTIVE_DYNAMIC_IMPORT "$log" || true
+  echo ""
+  echo "  A static import is defeating a dynamic one, forcing the module into a shared"
+  echo "  chunk for every consumer. Import it dynamically instead — see SessionRecap.svelte:"
+  echo "    Promise.all([import(\"marked\"), import(\"dompurify\")])"
+  exit 1
+fi

--- a/scripts/pre-push.ts
+++ b/scripts/pre-push.ts
@@ -562,9 +562,10 @@ function buildLanes(
       { label: "vitest", cmd: "bun", args: ["run", "test", "--maxWorkers", W], cwd: ui },
       // Same script CI's "Build (ui)" step runs (ci.yml:24-29 requires the two to stay
       // in sync): builds, then fails on Rollup's INEFFECTIVE_DYNAMIC_IMPORT — a static
-      // import that defeats a dynamic one, for any module. Not exhaustive: Rollup does
-      // not warn for every static importer, so some (e.g. a plain ui/src/lib/*.ts
-      // helper) slip past this AND eslint. See the header in check-ui-build.sh.
+      // import that defeats a dynamic one, for any module. Rollup does not warn for
+      // every static importer (a plain ui/src/lib/*.ts helper produces none), so the
+      // eslint no-restricted-imports rule covers those files for the named libraries.
+      // The two are complementary; see the header in check-ui-build.sh.
       { label: "build", cmd: join(repoRoot, "scripts/check-ui-build.sh"), args: [], cwd: ui },
     ],
   });

--- a/scripts/pre-push.ts
+++ b/scripts/pre-push.ts
@@ -560,10 +560,11 @@ function buildLanes(
         cwd: ui,
       },
       { label: "vitest", cmd: "bun", args: ["run", "test", "--maxWorkers", W], cwd: ui },
-      // Same script CI's "Build (ui)" step runs: builds, then fails on Rollup's
-      // INEFFECTIVE_DYNAMIC_IMPORT. Catches a static import that defeats a dynamic one
-      // — including from a plain ui/src/lib/*.ts helper, which the Svelte-scoped
-      // no-restricted-imports rule cannot see.
+      // Same script CI's "Build (ui)" step runs (ci.yml:24-29 requires the two to stay
+      // in sync): builds, then fails on Rollup's INEFFECTIVE_DYNAMIC_IMPORT — a static
+      // import that defeats a dynamic one, for any module. Not exhaustive: Rollup does
+      // not warn for every static importer, so some (e.g. a plain ui/src/lib/*.ts
+      // helper) slip past this AND eslint. See the header in check-ui-build.sh.
       { label: "build", cmd: join(repoRoot, "scripts/check-ui-build.sh"), args: [], cwd: ui },
     ],
   });

--- a/scripts/pre-push.ts
+++ b/scripts/pre-push.ts
@@ -560,7 +560,11 @@ function buildLanes(
         cwd: ui,
       },
       { label: "vitest", cmd: "bun", args: ["run", "test", "--maxWorkers", W], cwd: ui },
-      { label: "build", cmd: "bun", args: ["run", "build"], cwd: ui },
+      // Same script CI's "Build (ui)" step runs: builds, then fails on Rollup's
+      // INEFFECTIVE_DYNAMIC_IMPORT. Catches a static import that defeats a dynamic one
+      // — including from a plain ui/src/lib/*.ts helper, which the Svelte-scoped
+      // no-restricted-imports rule cannot see.
+      { label: "build", cmd: join(repoRoot, "scripts/check-ui-build.sh"), args: [], cwd: ui },
     ],
   });
 

--- a/ui/src/lib/components/GitRail.svelte
+++ b/ui/src/lib/components/GitRail.svelte
@@ -27,8 +27,6 @@
   import Coachmark from "$lib/components/Coachmark.svelte";
   import { pollWhileVisible } from "$lib/visibility";
   import { pullMainAndToast } from "$lib/pull-offer";
-  import { marked } from "marked";
-  import createDOMPurify from "dompurify";
 
   let {
     sessionId,
@@ -83,14 +81,6 @@
   // "no forge / no PR"). Drives the error+Retry fallback so the rail never renders
   // silently empty, and keeps the poll retrying until the forge recovers.
   let loadFailed = $state(false);
-  type DomPurifyApi = { sanitize: (dirty: string) => string };
-  type DomPurifyFactory = ((root: Window) => DomPurifyApi) & Partial<DomPurifyApi>;
-  function getDOMPurify(): DomPurifyApi {
-    const candidate = createDOMPurify as unknown as DomPurifyFactory;
-    return typeof candidate.sanitize === "function"
-      ? (candidate as DomPurifyApi)
-      : candidate(window);
-  }
 
   // Open-PR popover
   let showPr = $state(false);
@@ -482,6 +472,9 @@
           : m.gitrail_review_plan(),
   );
   // Render the (AI-authored) findings as markdown, sanitized before @html.
+  // Dynamically imported so marked/DOMPurify stay off the first-paint critical path;
+  // a static import here would hoist both into the main chunk and defeat the same
+  // lazy-loading in every other consumer (SessionRecap, PlanPanel, ...).
   // Gated on showReview so the browser-only sanitizer never runs during SSR.
   let renderedBody = $state("");
   $effect(() => {
@@ -490,8 +483,20 @@
       renderedBody = "";
       return;
     }
-    const DOMPurify = getDOMPurify();
-    renderedBody = DOMPurify.sanitize(marked.parse(body, { async: false }) as string);
+    let alive = true;
+    Promise.all([import("marked"), import("dompurify")])
+      .then(([{ marked }, { default: DOMPurify }]) => {
+        if (alive)
+          renderedBody = DOMPurify.sanitize(marked.parse(body, { async: false }) as string);
+      })
+      .catch((e) => {
+        // Never assigns to renderedBody — a failed load must not leave unsanitized
+        // markup, and the `err` state above is the PR-action error channel, not this.
+        console.warn("Review body markdown render failed", e);
+      });
+    return () => {
+      alive = false;
+    };
   });
   const autoCount = $derived(automationCount(repoConfig.flags(repoPath)));
   let reviewFlash = $state<string | null>(null);


### PR DESCRIPTION
## What

`GitRail.svelte` statically imported `marked` + `dompurify`. GitRail is always mounted, so Rollup hoisted both into the main chunk and **silently cancelled the lazy-loading in all seven other consumers** — the `INEFFECTIVE_DYNAMIC_IMPORT` build warnings.

Several of those siblings carry comments explaining they lazy-load *"so they stay off the first-paint critical path."* That intent was dead code. One static import was defeating seven deliberate dynamic ones.

| Component | Style | Libraries |
|---|---|---|
| SessionRecap, PlanPanel, DoneRecapPanel, HerdrUpdateModal, CalloutBlock, RichTextBlock | dynamic | marked + dompurify |
| `blocks/WireframeBlock.svelte:132` | dynamic | **dompurify only** — never imports marked |
| `GitRail.svelte:30-31` | **STATIC** | both — hoisted them into the main chunk |

Also drops the now-orphaned `getDOMPurify()` shim and its two local types. In a browser dompurify's ESM default is already sanitize-capable — which is why the seven siblings work without the shim. Verified it had exactly one consumer.

## Why gates

**Rollup warnings do not fail `bun run build`.** Without a gate, a future static import silently re-breaks the lazy-loading with a green build.

- **`scripts/check-ui-build.sh`** — builds, then fails on `INEFFECTIVE_DYNAMIC_IMPORT`. Called by **both** CI's `Build (ui)` step and the pre-push ui lane, so the two stay in sync (`ci.yml:24-29` requires this) with one implementation rather than two copies of the same shell.
- **ESLint `no-restricted-imports`** — bans the static form in `**/*.svelte{,.ts,.js}`. Fails in milliseconds at the exact line.

Two details found by testing rather than assumption:

1. `paths` matches the **exact** specifier only — it does *not* catch `marked/lib/marked.esm.js`, which is precisely the path the Rollup warning names. Hence `patterns: ["marked/*", "dompurify/*"]`. Verified `paths` alone finds nothing there.
2. `grep -c` exits **1** when the count is 0, so the obvious form would have failed on the success case. The script uses `! grep -q` with `set -euo pipefail`.

Both `paths` and `patterns` are static-only: with the rule active, bare `import("marked")` and subpath `import("dompurify/dist/purify.es.mjs")` stay clean, so the seven legitimate call sites are untouched.

## Measured gate coverage

I originally claimed the build gate "covers `.ts` importers." **That was reasoning, not measurement, and it was wrong.** Measured:

| Static import added to | Rollup warns? |
|---|---|
| `GitRail.svelte` | yes |
| `ui/src/lib/recaps.svelte.ts` | yes |
| `ui/src/lib/api.ts` (plain `.ts`) | **no — none at all** |

That left the plain-`.ts` case covered by neither gate. Closed in fe90932 by scoping the eslint rule to `ui/src/**/*` rather than just the Svelte block (one definition, not one per glob). The two gates are **complementary, neither a superset of the other**:

- `check-ui-build.sh` — **any** library, but only where Rollup actually warns
- `no-restricted-imports` — **any** file under `ui/src`, but only the named libraries (marked, dompurify)

Verified after the change: probes in `GitRail.svelte`, `recaps.svelte.ts` **and** `api.ts` each fail lint; clean tree passes.

Residual hole, uncovered by design and documented in the script header: a *different* library statically imported from a plain `.ts` where Rollup stays silent. Add it to the rule's `paths`/`patterns` if one ever matters.

## Rejected approach (documented in the script)

Failing inside the build via `ui/vite.config.ts` would have been strictly better — CI, pre-push and a bare local `bun run build` would all inherit it with zero sync burden. **Neither in-build hook works here:** `build.rollupOptions.onwarn` is overridden by SvelteKit's config merge, and an `onwarn` returned from a plugin `options` hook is ignored by Vite (instrumented: the plugin's hooks run, but collected `offenders: 0` while the warning still printed). Both left the build exiting 0 — an inert gate that looks like it works.

## Verification

- `bun run lint`, `bun run typecheck`, `cd ui && bun run check` (0 errors), `bun run test` (4006 pass / 262 files), root `bun test` (7291 pass / 0 fail), prettier — all clean. Pre-push passed with the new script in the ui lane.
- `GitRail.browser.test.ts`: 74 pass, **test file unmodified**.
- **Both gates proven to bite:** reintroducing a static import makes lint exit 1 *and* `check-ui-build.sh` exit 1 with a readable message. Probes reverted, confirmed byte-identical (md5) / clean `git status`.

## Reviewer notes

- `GitRail.browser.test.ts` passes **identically before and after** — it observes rendering, not chunking, so it is a sanitization guard, **not** evidence the deliverable landed.
- Behavior change: the review body renders one microtask later (empty until the chunk resolves). Identical to the seven siblings.
- On a chunk-fetch failure the `.catch` only warns and never assigns, so no unsanitized markup can reach `@html`; the early-return still clears `renderedBody` synchronously when the popover closes.
- Self-review caught the `.catch((err) => …)` parameter shadowing GitRail's `err` `$state` (line 76, drives the error/Retry UI). Renamed to `e`, matching the file's convention.
- The build gate is intentionally broader than this change and will fire for any library — an unrelated future PR can trip it. The script names the fix.
- `[no-feature-entry]` — ships no user-facing UX. No new strings, so no i18n/glossary work.
