### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs/sandbox-security.md
+++ b/docs/sandbox-security.md
@@ -51,7 +51,7 @@ secrets out of the membrane entirely.
 
 Egress confinement is keyed to the autonomous **profile**, not to whether a human
 is watching (`willEgressConfine`, `src/sandbox.ts:693-698`; applied at
-`src/service.ts:1879`): the wrap applies iff the autonomous profile resolves
+`src/service.ts:2071`): the wrap applies iff the autonomous profile resolves
 **and** the fs + egress backends are present, independent of `ctx.auto`.
 Consequences:
 
@@ -108,7 +108,7 @@ Write --permission-mode dontAsk` (`src/transient-agent-argv.ts`,
   `buildTransientAgentArgv("reviewer", …)`).
 - **Research is the deliberately egress-UNCONFINED surface.** A research session
   that would resolve to `autonomous` is **downgraded to `standard`**
-  (`src/service.ts` `researchSafeProfileOverride`, ~L2708, warns once),
+  (`src/service.ts` `researchSafeProfileOverride`, ~L2714, warns once),
   because research needs **open** web egress (search/fetch + sub-agents) that the
   autonomous firewall would block. The same downgrade applies to an
   **epic-authoring** session (`input.epicAuthoring`, #1507), which likewise needs
@@ -117,14 +117,14 @@ Write --permission-mode dontAsk` (`src/transient-agent-argv.ts`,
   route materializes the draft. It is operator-_created_ (cannot be
   auto-drained — `standard` refuses auto-spawn) but **autopilot-steerable, so it
   runs unattended in practice** (`RESEARCH_PROCEED_STEER`,
-  `src/autopilot.ts:42-47`, dispatched at L335). It ingests **untrusted web**
+  `src/autopilot.ts:44-49`, dispatched at L356). It ingests **untrusted web**
   content on `trusted`/`standard` with the **network open**, and can
   `gh pr create` / open issues via the bound gh token — so a hijacked research
   agent has **both** readable tokens **and** open egress.
 
   **Compensating factors:** the downgrade is explicit and warns once; research
   delivers a **report PR or GitHub issue only, never a code PR**
-  (`src/autopilot.ts:40-45`). The residual is **accepted**.
+  (`src/autopilot.ts:42-49`). The residual is **accepted**.
 
 ## See also
 


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc-update summary

The docs were freshly synced very recently (`c99d0924`, "docs: sync docs to
recent source changes"). Everything that landed since is UI/internal or was
documented in the same commit that shipped it (`host_capacity` → `operating.md`;
New-Task scratchpad attachments → `external-task-api.md`). The env-var surface in
`src/config.ts` is **unchanged** since that sync, so `configuration.md` is
current. The only demonstrable staleness I found was drifted source-line
citations in `sandbox-security.md`, where `src/service.ts` and `src/autopilot.ts`
grew after the doc was last synced.

## Changes

- **`docs/sandbox-security.md`** — corrected four precise source-line citations
  that drifted when `src/service.ts` (`c74e9256`) and `src/autopilot.ts`
  (`f6e88684`) gained lines after the doc was last synced. All corrected numbers
  were grep/Read-verified against current `HEAD`; the doc's actual claims were
  already accurate, only the anchors moved. Confidence is corroborated by the
  fact that the doc's `src/sandbox.ts` citations (`:682`, `:693-698`, `:623`) —
  in a file that did **not** change — still match exactly.
  - `applied at src/service.ts:1879` → `:2071`. Line 2071 is
    `const egressOn = willEgressConfine(profile, backend, egressBackend ?? null);`
    with the comment "egress WILL wrap iff autonomous + FS backend + egress
    backend all present" — the exact wrap-decision the surrounding prose
    paraphrases (and it is independent of `ctx.auto`, as the prose states).
  - `researchSafeProfileOverride, ~L2708` → `~L2714` (`src/service.ts:2714`,
    `private researchSafeProfileOverride(`).
  - `RESEARCH_PROCEED_STEER, src/autopilot.ts:42-47, dispatched at L335` →
    `44-49, dispatched at L356`. The `const` now spans `src/autopilot.ts:44-49`
    and its sole dispatch (`this.driveSteer(s, s.research ? RESEARCH_PROCEED_STEER
    : PROCEED_STEER)`) is at line 356.
  - report-PR framing `src/autopilot.ts:40-45` → `42-49` (the comment at 42-43
    plus the steer text at 44-49; lines 40-41 are now `AUTOPILOT_LABEL`).

## Uncertain / needs human judgment

- **`herdr_health` diagnostic (`78dc7ec0`)** — a new Diagnose-only
  runtime-hygiene probe plus a new inline glossary term ("herdr-hygiene") in
  `ui/src/lib/glossary.ts`. I did **not** add it to `operating.md`'s
  "Host tuning — resource guardrails" section or to `reference/glossary.md`,
  because neither doc enumerates every diagnostic/tooltip term (they curate), so
  the omission is not a false statement. A maintainer may still want a short
  mention alongside the `host_capacity` check.
- **`criticSmellLensEnabled` (`4d7420da`) and the scope-creep critic lens
  (`c74e9256`)** — new critic behavior. `criticSmellLensEnabled` is a **per-repo
  SQLite `settings` field (default OFF), not an env var**, so it falls outside
  `configuration.md`'s env-var tables; `configuration.md` only mentions store
  toggles by example (`branchPruneEnabled`). The `glossary.md` "Critic" entry
  ("read-only review agent that inspects a PR's diff … and posts a verdict")
  remains true at that level of abstraction. Left unchanged; flagging in case a
  maintainer wants the glossary/critic prose to mention the new non-blocking
  scope-creep / Fowler-smell lenses.
- **`sandbox-security.md` unverified `src/sandbox.ts` citations** (`:436-438`,
  `:429-431`, `:539`, `:564`) — I did not re-verify each individually, but
  `src/sandbox.ts` did not change since the doc's last sync and its other
  citations in the same doc match exactly, so they are almost certainly still
  accurate.