### PR TITLE
fix(ui): make the pending-login auth banner visually unmissable

### DIFF
--- a/ui/src/lib/components/viewport/ViewportTermBanners.browser.test.ts
+++ b/ui/src/lib/components/viewport/ViewportTermBanners.browser.test.ts
@@ -57,4 +57,51 @@ describe("ViewportTermBanners auth banner", () => {
     render(ViewportTermBanners, { ...baseProps, authUrl: null });
     await expect.element(page.getByRole("button", { name: /open/i })).not.toBeInTheDocument();
   });
+
+  it("rest state: amber wash that preserves the strip's translucency", async () => {
+    render(ViewportTermBanners, { ...baseProps, authUrl: AUTH_URL });
+    const banner = document.querySelector<HTMLElement>(".auth-banner");
+    expect(banner).not.toBeNull();
+    // Resolve the intended wash through a probe element so the assertion tracks the
+    // design tokens instead of hard-coding channel values.
+    const probe = document.createElement("div");
+    document.body.appendChild(probe);
+    probe.style.background =
+      "color-mix(in srgb, color-mix(in srgb, var(--color-amber) 14%, var(--color-head)) 96%, transparent)";
+    const expected = getComputedStyle(probe).backgroundColor;
+    expect(getComputedStyle(banner!).backgroundColor).toBe(expected);
+    // Translucency guard: the pre-existing 96% alpha must survive the amber wash.
+    expect(alphaOf(expected)).toBeGreaterThan(0.9);
+    expect(alphaOf(expected)).toBeLessThan(1);
+    // Wash guard: the surface is genuinely tinted, not the plain head tone.
+    probe.style.background = "color-mix(in srgb, var(--color-head) 96%, transparent)";
+    expect(getComputedStyle(banner!).backgroundColor).not.toBe(
+      getComputedStyle(probe).backgroundColor,
+    );
+  });
+
+  it("pulsing ::after halo: pointer-transparent, glowing, and continuous", async () => {
+    render(ViewportTermBanners, { ...baseProps, authUrl: AUTH_URL });
+    const banner = document.querySelector<HTMLElement>(".auth-banner");
+    expect(banner).not.toBeNull();
+    const after = getComputedStyle(banner!, "::after");
+    expect(after.content).toBe('""');
+    // The overlay-interaction guard: the halo layer must never intercept input.
+    expect(after.pointerEvents).toBe("none");
+    expect(after.boxShadow).not.toBe("none");
+    // Svelte hashes component-local keyframe names, so match the authored substring,
+    // never the unscoped literal.
+    expect(after.animationName).not.toBe("none");
+    expect(after.animationName).toContain("auth-banner-glow");
+    expect(parseFloat(after.animationDuration)).toBeGreaterThan(0);
+    expect(after.animationIterationCount).toBe("infinite");
+  });
 });
+
+/** Alpha channel of a computed color, handling both `rgba(r, g, b, a)` and
+ *  `color(srgb r g b / a)` serializations; a fully-opaque serialization has no
+ *  alpha component, which reads as 1. */
+function alphaOf(color: string): number {
+  const m = /\/\s*([\d.]+)\)\s*$/.exec(color) ?? /rgba\([^)]*,\s*([\d.]+)\)\s*$/.exec(color);
+  return m ? parseFloat(m[1]) : 1;
+}

--- a/ui/src/lib/components/viewport/ViewportTermBanners.svelte
+++ b/ui/src/lib/components/viewport/ViewportTermBanners.svelte
@@ -131,7 +131,9 @@
 <style>
   /* auth-banner: non-modal top strip surfacing a pending MCP OAuth URL. Anchored at the
      top so it never covers the prompt/input at the terminal's bottom. Amber accent — an
-     actionable "needs you" state, not a success. */
+     actionable "needs you" state, not a success. The session stalls silently until the
+     operator acts, so the strip is deliberately loud: amber-washed surface, slide-down
+     entry, and a continuous "breathing" halo (below) for as long as the URL is pending. */
   .auth-banner {
     position: absolute;
     top: 0;
@@ -142,10 +144,63 @@
     align-items: center;
     gap: 10px;
     padding: 8px 12px;
-    background: color-mix(in srgb, var(--color-head) 96%, transparent);
+    /* Nested mix: the inner mix tints the head tone amber; the outer mix restores the
+       strip's 96% translucency so the backdrop blur keeps reading through (a single
+       amber/head mix would silently produce an opaque surface). */
+    background: color-mix(
+      in srgb,
+      color-mix(in srgb, var(--color-amber) 14%, var(--color-head)) 96%,
+      transparent
+    );
     backdrop-filter: blur(2px);
-    border-bottom: 1px solid color-mix(in srgb, var(--color-amber) 55%, var(--color-line-bright));
+    border-bottom: 1px solid color-mix(in srgb, var(--color-amber) 80%, var(--color-line-bright));
     box-shadow: 0 3px 12px rgba(0, 0, 0, 0.35);
+    animation: auth-banner-in 0.14s ease;
+  }
+  /* Continuous amber halo, pulsed by animating this pseudo's OPACITY only — an infinite
+     box-shadow animation would repaint the full-width strip every frame. Downward-only
+     geometry: .vp-body clips at overflow:hidden and the banner sits flush with its
+     top/left/right edges, so a symmetric halo would clip on three sides. An outer
+     box-shadow renders outside the border-box only, so nothing inside the strip is
+     tinted; z-index -1 keeps it under the text/buttons within the banner's own
+     stacking context (z-index 3 above). */
+  .auth-banner::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: -1;
+    box-shadow: 0 4px 18px color-mix(in srgb, var(--color-amber) 55%, transparent);
+    animation: auth-banner-glow 2s ease-in-out infinite alternate;
+  }
+  @keyframes auth-banner-in {
+    from {
+      opacity: 0;
+      transform: translateY(-6px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  @keyframes auth-banner-glow {
+    from {
+      opacity: 0.35;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .auth-banner {
+      animation: none;
+    }
+    .auth-banner::after {
+      /* No motion — the halo rests at a steady mid opacity so the banner still reads
+         clearly louder than the terminal behind it. */
+      animation: none;
+      opacity: 0.6;
+    }
   }
   .auth-icon {
     color: var(--color-amber);
@@ -166,7 +221,9 @@
     line-height: 1.2;
   }
   .auth-url {
-    color: var(--color-muted);
+    /* --color-ink, not muted: muted lands marginally under the 4.5:1 AA floor on the
+       amber-washed surface (≈4.4:1 in dark and light themes). */
+    color: var(--color-ink);
     font-size: var(--fs-base);
     font-family: var(--font-mono, monospace);
     white-space: nowrap;


### PR DESCRIPTION
## Problem

When an agent waits on an OAuth/login URL (MCP auth flows), the "Authorize in your browser to continue" strip is a slim dark banner that blends into the terminal. The operator can miss it entirely and the session silently stalls until they notice.

## Change (CSS-only + one regression test)

All in `ViewportTermBanners.svelte`'s `.auth-banner` styles:

- **Amber-washed rest surface** via a nested `color-mix` — the inner mix tints the head tone amber (14%), the outer mix restores the strip's existing 96% translucency so the backdrop blur keeps reading through (a single-level mix would have silently produced an opaque surface). Border brightened to an 80% amber mix.
- **Slide-down entry** — dedicated `auth-banner-in` keyframe from `translateY(-6px)` (the existing `scroll-bottom-in` animates upward and is wrong for a top-anchored strip).
- **Continuous "breathing" amber halo** while the URL is pending — per user choice (continuous pulse over one-shot). The halo lives on an `::after` overlay (`content:""`, `inset:0`, `pointer-events:none`, `z-index:-1` inside the banner's own stacking context) and only its **opacity** animates (2s ease-in-out infinite alternate) — an infinite `box-shadow` animation would repaint the full-width strip every frame. The halo is **downward-only** because `.vp-body` is `overflow:hidden` and the banner sits flush with its top/left/right edges — a symmetric glow would clip on three sides.
- **`prefers-reduced-motion: reduce`**: no entry animation, no pulse; the halo rests at a steady mid opacity so the banner still reads clearly louder than before.
- **URL line `--color-muted` → `--color-ink`**: measured contrast of muted on the washed surface is ~4.4:1 in dark and light themes — marginally under the 4.5:1 AA floor. Ink measures ~9.4–9.8:1. Title stays `--color-ink-bright` (13–15:1 in all four theme modes).

New computed-style regression test in `ViewportTermBanners.browser.test.ts`:
- rest-state wash resolved via a probe element applying the same `color-mix` expression (tracks tokens, no hard-coded channels) + alpha ≈ 0.96 translucency guard + differs-from-plain-head wash guard;
- full `::after` contract: `content`, `pointer-events: none` (the direct overlay-interaction guard), `box-shadow` non-`none`, `animation-name` containing the `auth-banner-glow` substring (Svelte hashes local keyframe names), nonzero duration, `infinite` iteration count.

Existing behavior tests (URL render, Open, Copy, no-authUrl) unchanged.

No i18n changes (no copy touched). `fix`, not `feat`: this repairs discoverability of the already-announced auth-URL banner (`v1.42.0-auth-url-banner`), so no new What's-New entry.

## Verification

- `cd ui && bun run check` — 0 errors / 0 warnings
- `cd ui && bun run test` — 263 files, 4024 tests passed (incl. the 2 new ones)
- `cd ui && bun run check:i18n` — 2 locales in parity
- `bunx prettier --check` on both touched files — clean
- branch-hygiene / feature-catalog / announcement-version gates — all green
- Visual check via a throwaway browser-test harness (not committed): banner screenshotted over terminal-like content in dark, light, dark-high-contrast, and light-high-contrast — wash, border, and halo read clearly; text readable in all four. WCAG contrast additionally computed numerically from the theme tokens.