### PR TITLE
fix(ui): keep new-task modal content above the iOS keyboard

### DIFF
--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -3039,4 +3039,23 @@ describe("NewTask keyboard-aware viewport (mobile)", () => {
       restore();
     }
   });
+
+  it("runs the mobile layout + keyboard handling in wide-but-short phone landscape", async () => {
+    // Keyboard already open on a landscape phone: width > 768 (would be the desktop
+    // rail under a width-only gate) but short height must still get the mobile layout
+    // AND the overlay mirror, else content hides behind the keyboard.
+    const { restore } = installFakeViewport(200, 0);
+    try {
+      await page.viewport(852, 393);
+      mockListRepos.mockResolvedValue({ repos: makeRepos(3), recentWindowDays: 30 });
+      render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo/kbd-00" } });
+      // The combined repo·branch chip only renders in the mobile layout.
+      await expect.poll(() => document.querySelector(".ctx-chip")).toBeTruthy();
+      expect(document.querySelector(".rail")).toBeNull();
+      // The overlay is mirrored to the visible region above the keyboard.
+      await expect.poll(() => overlay()?.style.height).toBe("200px");
+    } finally {
+      restore();
+    }
+  });
 });

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -3040,12 +3040,13 @@ describe("NewTask keyboard-aware viewport (mobile)", () => {
     }
   });
 
-  it("runs the mobile layout + keyboard handling in wide-but-short phone landscape", async () => {
-    // Keyboard already open on a landscape phone: width > 768 (would be the desktop
-    // rail under a width-only gate) but short height must still get the mobile layout
-    // AND the overlay mirror, else content hides behind the keyboard.
+  it("runs the mobile layout + keyboard handling in wide-but-short TOUCH landscape", async () => {
+    // Keyboard already open on a landscape phone (coarse pointer): width > 768 (would be
+    // the desktop rail under a width-only gate) but short-and-touch must still get the
+    // mobile layout AND the overlay mirror, else content hides behind the keyboard.
     const { restore } = installFakeViewport(200, 0);
     try {
+      mockPointer(true); // coarse pointer = phone/tablet with a soft keyboard
       await page.viewport(852, 393);
       mockListRepos.mockResolvedValue({ repos: makeRepos(3), recentWindowDays: 30 });
       render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo/kbd-00" } });
@@ -3054,6 +3055,24 @@ describe("NewTask keyboard-aware viewport (mobile)", () => {
       expect(document.querySelector(".rail")).toBeNull();
       // The overlay is mirrored to the visible region above the keyboard.
       await expect.poll(() => overlay()?.style.height).toBe("200px");
+    } finally {
+      restore();
+    }
+  });
+
+  it("leaves a short DESKTOP window (fine pointer) on the desktop layout, overlay untouched", async () => {
+    // Same short-and-wide viewport, but a fine pointer = hardware keyboard: it must stay
+    // on the desktop rail with the overlay never mutated — the no-desktop-change boundary
+    // (the height gate is touch-only, so a resized desktop window doesn't flip to mobile).
+    const { restore } = installFakeViewport(200, 0);
+    try {
+      mockPointer(false);
+      await page.viewport(852, 393);
+      mockListRepos.mockResolvedValue({ repos: makeRepos(3), recentWindowDays: 30 });
+      render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo/kbd-00" } });
+      await expect.poll(() => document.querySelector(".rail")).toBeTruthy();
+      expect(document.querySelector(".ctx-chip")).toBeNull();
+      expect(overlay().style.height).toBe("");
     } finally {
       restore();
     }

--- a/ui/src/lib/components/NewTask.browser.test.ts
+++ b/ui/src/lib/components/NewTask.browser.test.ts
@@ -2927,3 +2927,116 @@ describe("NewTask mobile sheets + shortcuts", () => {
     expect(isOn(planGateSwitch())).toBe(true);
   });
 });
+
+// iOS Safari overlays the soft keyboard WITHOUT shrinking the layout viewport, so a
+// bottom-anchored sheet (and the footer) hide behind it. NewTask mirrors visualViewport
+// onto the overlay to keep content above the keyboard. The harness can't raise a real
+// keyboard, so we substitute a mutable fake visualViewport and drive its events; the
+// real iOS geometry is validated manually on-device.
+describe("NewTask keyboard-aware viewport (mobile)", () => {
+  class FakeVisualViewport extends EventTarget {
+    height: number;
+    offsetTop: number;
+    constructor(height: number, offsetTop = 0) {
+      super();
+      this.height = height;
+      this.offsetTop = offsetTop;
+    }
+  }
+
+  function installFakeViewport(height: number, offsetTop = 0) {
+    const fake = new FakeVisualViewport(height, offsetTop);
+    const prev = Object.getOwnPropertyDescriptor(window, "visualViewport");
+    Object.defineProperty(window, "visualViewport", { configurable: true, value: fake });
+    const restore = () => {
+      if (prev) Object.defineProperty(window, "visualViewport", prev);
+      else delete (window as unknown as { visualViewport?: unknown }).visualViewport;
+    };
+    return { fake, restore };
+  }
+
+  function makeRepos(n: number): RepoEntry[] {
+    return Array.from({ length: n }, (_, i) => {
+      const id = String(i).padStart(2, "0");
+      return {
+        name: `repo-${id}`,
+        path: `/repo/kbd-${id}`,
+        display: `repo-${id}`,
+        realPath: `/repo/kbd-${id}`,
+      };
+    });
+  }
+
+  const overlay = () => document.querySelector<HTMLElement>(".overlay")!;
+
+  it("mirrors visualViewport height/offsetTop onto the overlay and resets on breakpoint change", async () => {
+    const { fake, restore } = installFakeViewport(380, 0);
+    try {
+      await page.viewport(390, 844);
+      mockListRepos.mockResolvedValue({ repos: makeRepos(3), recentWindowDays: 30 });
+      render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo/kbd-00" } });
+
+      // Mobile: the overlay is sized to the visible region above the keyboard.
+      await expect.poll(() => overlay()?.style.height).toBe("380px");
+
+      // Keyboard grows + iOS scrolls the layout viewport → both are mirrored.
+      fake.height = 300;
+      fake.offsetTop = 12;
+      fake.dispatchEvent(new Event("resize"));
+      await expect.poll(() => overlay().style.height).toBe("300px");
+      expect(overlay().style.transform).toBe("translateY(12px)");
+
+      // Reset-on-breakpoint: crossing to desktop detaches the listener AND clears the
+      // inline geometry, so no stale height/transform survives onto the desktop layout.
+      await page.viewport(1280, 900);
+      await expect.poll(() => overlay().style.height).toBe("");
+      expect(overlay().style.transform).toBe("");
+    } finally {
+      restore();
+    }
+  });
+
+  it("keeps the repo filter and the results reachable above the keyboard in the context sheet", async () => {
+    const KB_TOP = 380; // simulated top edge of the keyboard (visible viewport height)
+    const { restore } = installFakeViewport(KB_TOP, 0);
+    try {
+      // Smallest supported portrait: a long repo list forces the panel to overflow.
+      await page.viewport(375, 667);
+      mockListRepos.mockResolvedValue({ repos: makeRepos(20), recentWindowDays: 30 });
+      render(NewTask, { props: { onsubmit: vi.fn(), initialRepoPath: "/repo/kbd-00" } });
+      await expect.poll(() => document.querySelector(".ctx-chip")).toBeTruthy();
+      await expect.poll(() => overlay()?.style.height).toBe("380px");
+
+      // Open the context sheet, then the repo dropdown + its filter.
+      document.querySelector<HTMLButtonElement>(".ctx-chip")!.click();
+      await expect.poll(() => document.querySelector(".ctx-sheet")).toBeTruthy();
+      document.querySelector<HTMLButtonElement>(".ctx-sheet .rs-trigger")!.click();
+      await expect.poll(() => document.querySelector(".ctx-sheet .rs-filter")).toBeTruthy();
+
+      const filter = document.querySelector<HTMLInputElement>(".ctx-sheet .rs-filter")!;
+      const sheetBody = document.querySelector<HTMLElement>(".sheet-body")!;
+
+      // The filter sits fully above the simulated keyboard line.
+      const fr0 = filter.getBoundingClientRect();
+      expect(fr0.top).toBeGreaterThanOrEqual(0);
+      expect(fr0.bottom).toBeLessThanOrEqual(KB_TOP + 1);
+
+      // The sheet-body is the single scroller and the long list overflows it.
+      expect(sheetBody.scrollHeight).toBeGreaterThan(sheetBody.clientHeight);
+      sheetBody.scrollTop = sheetBody.scrollHeight;
+
+      // After scrolling to the bottom, the deepest result is reachable above the
+      // keyboard (not stuck behind it)…
+      const opts = document.querySelectorAll<HTMLElement>('.ctx-sheet [role="option"]');
+      const last = opts[opts.length - 1]!;
+      await expect.poll(() => last.getBoundingClientRect().bottom).toBeLessThanOrEqual(KB_TOP + 1);
+
+      // …and the sticky filter is still pinned in view (it never scrolls behind the keyboard).
+      const fr1 = filter.getBoundingClientRect();
+      expect(fr1.top).toBeGreaterThanOrEqual(0);
+      expect(fr1.bottom).toBeLessThanOrEqual(KB_TOP + 1);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -303,8 +303,13 @@
   // Coarse pointer = touch-primary device: hide keyboard-combo hints it can't fulfil.
   const coarse = new MediaQuery("(pointer: coarse)");
   // Layout breakpoint — drives the SINGLE mounted instance of RunSettingsGroups
-  // (desktop rail vs. mobile engine sheet) and the mobile-only chrome.
-  const mobile = new MediaQuery("(max-width: 768px)");
+  // (desktop rail vs. mobile engine sheet), the mobile-only chrome, and the
+  // keyboard-aware viewport effect below. Short-height is OR'd in so wide-but-short
+  // phone LANDSCAPE (e.g. 852×393) — where the keyboard eats the most vertical space —
+  // gets the mobile layout + keyboard handling instead of the desktop rail. Keyed on
+  // the layout viewport, which iOS keeps stable when the keyboard opens (no thrash).
+  // The matching CSS media queries (NewTask/RepoSelect/RunSettingsGroups) mirror this.
+  const mobile = new MediaQuery("(max-width: 768px), (max-height: 480px)");
   // Single active-sheet invariant: at most one mobile sheet is open, by construction.
   let activeSheet = $state<"engine" | "context" | null>(null);
   let contextSheetEl = $state<HTMLElement | null>(null);
@@ -2310,8 +2315,10 @@
     border: 0;
   }
 
-  /* ── mobile: full-height sheet, fixed header/footer, single middle scroller ── */
-  @media (max-width: 768px) {
+  /* ── mobile: full-height sheet, fixed header/footer, single middle scroller ──
+     Short-height is OR'd in so phone landscape gets this layout too — mirrors the
+     `mobile` MediaQuery gate in the script. */
+  @media (max-width: 768px), (max-height: 480px) {
     .overlay {
       align-items: stretch;
       justify-content: stretch;

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -302,20 +302,24 @@
   let isMac = $state(false);
   // Coarse pointer = touch-primary device: hide keyboard-combo hints it can't fulfil.
   const coarse = new MediaQuery("(pointer: coarse)");
-  // Layout breakpoint — drives the SINGLE mounted instance of RunSettingsGroups
+  // Small-screen layout gate — drives the SINGLE mounted instance of RunSettingsGroups
   // (desktop rail vs. mobile engine sheet), the mobile-only chrome, and the
-  // keyboard-aware viewport effect below. Short-height is OR'd in so wide-but-short
-  // phone LANDSCAPE (e.g. 852×393) — where the keyboard eats the most vertical space —
-  // gets the mobile layout + keyboard handling instead of the desktop rail. Keyed on
-  // the layout viewport, which iOS keeps stable when the keyboard opens (no thrash).
-  // The matching CSS media queries (NewTask/RepoSelect/RunSettingsGroups) mirror this.
-  const mobile = new MediaQuery("(max-width: 768px), (max-height: 480px)");
+  // keyboard-aware viewport effect below. True when NARROW (portrait phones / narrow
+  // windows) OR SHORT-AND-TOUCH (phone/tablet LANDSCAPE, e.g. 852×393, where the
+  // keyboard eats the height). Gating the short branch on a coarse pointer keeps
+  // ordinary short DESKTOP windows on the desktop layout — they have a hardware
+  // keyboard, so the visualViewport mirror must never touch them. Keyed on the layout
+  // viewport, which iOS keeps stable when the keyboard opens (no thrash). The matching
+  // CSS media queries (NewTask/RepoSelect/RunSettingsGroups) mirror this exact logic.
+  const narrowViewport = new MediaQuery("(max-width: 768px)");
+  const shortViewport = new MediaQuery("(max-height: 480px)");
+  const mobile = $derived(narrowViewport.current || (shortViewport.current && coarse.current));
   // Single active-sheet invariant: at most one mobile sheet is open, by construction.
   let activeSheet = $state<"engine" | "context" | null>(null);
   let contextSheetEl = $state<HTMLElement | null>(null);
   // Leaving mobile while a sheet is open: the rail takes over; close the sheet.
   $effect(() => {
-    if (!mobile.current && activeSheet !== null) activeSheet = null;
+    if (!mobile && activeSheet !== null) activeSheet = null;
   });
 
   // ── inline slash-command autocomplete (reuses the /api/commands index) ──
@@ -433,7 +437,7 @@
   // both detaches the listeners and clears the inline geometry left from the mobile
   // state (reset-on-breakpoint), so a stale height/transform never survives onto desktop.
   $effect(() => {
-    if (!overlayEl || !mobile.current) return;
+    if (!overlayEl || !mobile) return;
     syncViewport();
     const vv = window.visualViewport;
     vv?.addEventListener("resize", syncViewport);
@@ -964,7 +968,7 @@
    *  inside the context sheet, so the shortcut opens the sheet (closing the engine
    *  sheet per the single-sheet invariant) and then the panel once mounted. */
   async function openRepoPicker() {
-    if (mobile.current) {
+    if (mobile) {
       activeSheet = "context";
       await tick();
     }
@@ -1224,7 +1228,7 @@
   >
     <div class="chead">
       <span class="chead-title">{heading}</span>
-      {#if mobile.current}
+      {#if mobile}
         <!-- Combined repo·branch chip: one control naming both payload-critical values;
              opens the context sheet where each is independently editable. -->
         <button
@@ -1269,7 +1273,7 @@
     <div class="composer" class:hidden={confirmStep}>
       <div class="cbody">
         <div class="left">
-          {#if !mobile.current}
+          {#if !mobile}
             <!-- Context chips row: repo (existing RepoSelect, chip-styled) from branch. -->
             <div class="ctx-row" use:coachTarget={"nt-repo"}>
               <div class="repo-chip">
@@ -1344,7 +1348,7 @@
 
           <!-- Prompt hero: the single visual hero — the only field with a bright border. -->
           <div class="prompt-block">
-            {#if !mobile.current}
+            {#if !mobile}
               <div class="prompt-label-row">
                 <label class="prompt-label" for="nt-prompt">{m.newtask_prompt_label()}</label>
                 <span class="syntax-hint">
@@ -1416,7 +1420,7 @@
                   />
                 {/each}
                 <span class="char-count">
-                  {#if mobile.current}
+                  {#if mobile}
                     {m.newtask_syntax_hint_touch()}
                   {:else}
                     {m.newtask_char_count({ count: prompt.length })}
@@ -1466,7 +1470,7 @@
             {/if}
           {/if}
 
-          {#if mobile.current}
+          {#if mobile}
             <!-- Mobile: Mode segments + the engine summary row (opens the sheet). -->
             {@render modeSeg()}
             <button
@@ -1488,7 +1492,7 @@
             </button>
           {/if}
 
-          {#if repoPath && !mobile.current}
+          {#if repoPath && !mobile}
             <PromptSources
               {repoPath}
               {issueData}
@@ -1523,7 +1527,7 @@
           {/if}
         </div>
 
-        {#if !mobile.current}
+        {#if !mobile}
           <div class="rail">
             <span class="group-label">{m.newtask_group_mode()}</span>
             {@render modeSeg()}
@@ -1542,7 +1546,7 @@
           {:else}
             <span class="r-ok" aria-hidden="true">✓</span>
             {m.newtask_readiness_ready()} ·
-            {#if mobile.current && footerCapacity}
+            {#if mobile && footerCapacity}
               <span class="r-cap"
                 >{footerCapacity.code}
                 {m.newtask_provider_capacity_free({ pct: footerCapacity.freePct })}</span
@@ -1585,7 +1589,7 @@
                   : m.newtask_edit_held_submit()
                 : submitting
                   ? m.newtask_spawning()
-                  : selectedRepoName && !mobile.current
+                  : selectedRepoName && !mobile
                     ? m.newtask_submit_in_repo({ repo: selectedRepoName })
                     : m.newtask_submit()}</span
             >
@@ -1597,7 +1601,7 @@
       </div>
     </div>
 
-    {#if mobile.current && activeSheet === "engine"}
+    {#if mobile && activeSheet === "engine"}
       <MobileEngineSheet
         label={m.newtask_engine_sheet_title()}
         title={m.newtask_engine_sheet_title()}
@@ -1606,7 +1610,7 @@
         {@render modeLockedNote()}
         {@render settingsGroups()}
       </MobileEngineSheet>
-    {:else if mobile.current && activeSheet === "context"}
+    {:else if mobile && activeSheet === "context"}
       <MobileEngineSheet
         label={m.newtask_context_sheet_title()}
         title={m.newtask_context_sheet_title()}
@@ -2316,9 +2320,9 @@
   }
 
   /* ── mobile: full-height sheet, fixed header/footer, single middle scroller ──
-     Short-height is OR'd in so phone landscape gets this layout too — mirrors the
-     `mobile` MediaQuery gate in the script. */
-  @media (max-width: 768px), (max-height: 480px) {
+     Short-and-touch is OR'd in so phone LANDSCAPE gets this layout too, while a short
+     DESKTOP window (fine pointer) stays on the rail — mirrors the `mobile` gate. */
+  @media (max-width: 768px), (max-height: 480px) and (pointer: coarse) {
     .overlay {
       align-items: stretch;
       justify-content: stretch;

--- a/ui/src/lib/components/NewTask.svelte
+++ b/ui/src/lib/components/NewTask.svelte
@@ -293,6 +293,10 @@
   let uploading = $state(false);
   let fileInput = $state<HTMLInputElement>();
   let promptInput = $state<HTMLTextAreaElement>();
+  // The modal backdrop. On mobile we mirror the visualViewport onto it so the card and
+  // the fixed bottom sheets sit above the software keyboard (iOS Safari overlays the
+  // keyboard WITHOUT shrinking the layout viewport — see the viewport effect below).
+  let overlayEl = $state<HTMLElement | null>(null);
   let repoSelect: RepoSelect | undefined = $state();
   let mic: MicButton | undefined = $state();
   let isMac = $state(false);
@@ -400,6 +404,40 @@
     // Paste anywhere in the modal (the textarea need not be focused first).
     window.addEventListener("paste", onPaste);
     return () => window.removeEventListener("paste", onPaste);
+  });
+
+  // ── keyboard-aware viewport (mobile only) ─────────────────────────────────
+  // iOS Safari overlays the soft keyboard WITHOUT shrinking the layout viewport
+  // (dvh/vh don't react; interactive-widget isn't in WebKit). visualViewport reports
+  // the region above the keyboard; mirror its height + offsetTop onto the overlay so
+  // the card fills it and the fixed bottom sheet (contained by the overlay via its
+  // backdrop-filter) re-anchors above the keyboard. Same pattern as ComposeBar.
+  function syncViewport() {
+    const vv = typeof window !== "undefined" ? window.visualViewport : null;
+    if (!vv || !overlayEl) return;
+    overlayEl.style.height = `${vv.height}px`;
+    overlayEl.style.transform = `translateY(${vv.offsetTop}px)`;
+  }
+  function resetViewport() {
+    if (!overlayEl) return;
+    overlayEl.style.height = "";
+    overlayEl.style.transform = "";
+  }
+  // Gated to the mobile layout: on desktop the overlay is never touched, so desktop
+  // pinch-zoom can't move it. The effect re-runs when the breakpoint flips; its teardown
+  // both detaches the listeners and clears the inline geometry left from the mobile
+  // state (reset-on-breakpoint), so a stale height/transform never survives onto desktop.
+  $effect(() => {
+    if (!overlayEl || !mobile.current) return;
+    syncViewport();
+    const vv = window.visualViewport;
+    vv?.addEventListener("resize", syncViewport);
+    vv?.addEventListener("scroll", syncViewport);
+    return () => {
+      vv?.removeEventListener("resize", syncViewport);
+      vv?.removeEventListener("scroll", syncViewport);
+      resetViewport();
+    };
   });
 
   // load branches for the selected repo; reset base to the repo's current branch
@@ -1144,6 +1182,7 @@
 
 <div
   class="overlay"
+  bind:this={overlayEl}
   role="presentation"
   onclick={(e) => {
     if (e.target === e.currentTarget) {
@@ -2281,7 +2320,10 @@
     .card {
       width: 100%;
       max-width: none;
-      max-height: none;
+      /* Fill the overlay, which the viewport effect shrinks to the region above the
+         keyboard — so the footer/CTA stay visible instead of hiding behind it. The
+         100dvh is the no-keyboard fallback (overlay ≈ full viewport then). */
+      max-height: 100%;
       height: 100dvh;
       margin: 0;
       border: 0;
@@ -2455,6 +2497,24 @@
       display: flex;
       flex-direction: column;
       gap: 8px;
+    }
+    /* Repo dropdown inside the context sheet: make it an in-flow, single-scroll
+       section with a sticky filter. The default RepoSelect panel is an absolute
+       dropdown that opens DOWN from the trigger — in this short, bottom-anchored
+       sheet that lands in the keyboard. In-flow, it instead grows the sheet-body
+       (bounded to the keyboard-visible area), which is the sole scroller; the filter
+       stays pinned so it — and what you type — never scrolls out of view. */
+    .ctx-sheet :global(.rs-panel) {
+      position: static;
+      box-shadow: none;
+    }
+    .ctx-sheet :global(.rs-list) {
+      max-height: none;
+    }
+    .ctx-sheet :global(.rs-filter) {
+      position: sticky;
+      top: 0;
+      z-index: 1;
     }
     .ctx-sheet .ctx-branch-select {
       background: var(--color-inset);

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -647,7 +647,9 @@
     margin-top: 4px;
   }
 
-  @media (max-width: 768px) {
+  /* Short-height OR'd in so phone landscape keeps 44px touch targets too — mirrors
+     NewTask's `mobile` breakpoint (the context sheet renders this in that layout). */
+  @media (max-width: 768px), (max-height: 480px) {
     .rs-trigger {
       min-height: 44px;
     }

--- a/ui/src/lib/components/RepoSelect.svelte
+++ b/ui/src/lib/components/RepoSelect.svelte
@@ -647,9 +647,9 @@
     margin-top: 4px;
   }
 
-  /* Short-height OR'd in so phone landscape keeps 44px touch targets too — mirrors
-     NewTask's `mobile` breakpoint (the context sheet renders this in that layout). */
-  @media (max-width: 768px), (max-height: 480px) {
+  /* Short-and-touch OR'd in so phone landscape keeps 44px touch targets too — mirrors
+     NewTask's `mobile` gate (the context sheet renders this in that layout). */
+  @media (max-width: 768px), (max-height: 480px) and (pointer: coarse) {
     .rs-trigger {
       min-height: 44px;
     }

--- a/ui/src/lib/components/new-task/MobileEngineSheet.svelte
+++ b/ui/src/lib/components/new-task/MobileEngineSheet.svelte
@@ -50,7 +50,10 @@
     right: 0;
     bottom: 0;
     box-sizing: border-box;
-    max-height: 85dvh;
+    /* Percentage of the containing block (NewTask's overlay), which the viewport
+       effect shrinks to the region above the keyboard — so the sheet stays fully
+       above it. Equivalent to 85dvh when standalone (containing block = viewport). */
+    max-height: 85%;
     display: flex;
     flex-direction: column;
     background: var(--color-panel);

--- a/ui/src/lib/components/new-task/RunSettingsGroups.svelte
+++ b/ui/src/lib/components/new-task/RunSettingsGroups.svelte
@@ -434,7 +434,9 @@
     white-space: nowrap;
     border: 0;
   }
-  @media (max-width: 768px) {
+  /* Short-height OR'd in so phone landscape keeps 44px select targets — mirrors
+     NewTask's `mobile` breakpoint (this renders in the engine sheet in that layout). */
+  @media (max-width: 768px), (max-height: 480px) {
     .field-select select {
       min-height: 44px;
       font-size: var(--fs-lg);

--- a/ui/src/lib/components/new-task/RunSettingsGroups.svelte
+++ b/ui/src/lib/components/new-task/RunSettingsGroups.svelte
@@ -434,9 +434,9 @@
     white-space: nowrap;
     border: 0;
   }
-  /* Short-height OR'd in so phone landscape keeps 44px select targets — mirrors
-     NewTask's `mobile` breakpoint (this renders in the engine sheet in that layout). */
-  @media (max-width: 768px), (max-height: 480px) {
+  /* Short-and-touch OR'd in so phone landscape keeps 44px select targets — mirrors
+     NewTask's `mobile` gate (this renders in the engine sheet in that layout). */
+  @media (max-width: 768px), (max-height: 480px) and (pointer: coarse) {
     .field-select select {
       min-height: 44px;
       font-size: var(--fs-lg);


### PR DESCRIPTION
## Problem

On iPhone (iOS Safari) the New-Task modal doesn't react when the software keyboard opens. Bottom-anchored surfaces end up **behind** the keyboard while you type — most painfully the **repo filter**: you can't see what you're typing to pick the right repo (see reporter's screenshots). The main prompt's footer/CTA hides the same way.

## Root cause

iOS Safari overlays the keyboard **without** shrinking the layout viewport — `dvh`/`vh` don't react, and `interactive-widget=resizes-content` isn't implemented in WebKit. So the modal's `.overlay` (`position: fixed; inset: 0`) and the `MobileEngineSheet` (`position: fixed; bottom: 0`) stay pinned to the full viewport, behind the keyboard.

## Fix

Reuses the pattern already in `ComposeBar.svelte`: mirror `window.visualViewport` (`height` + `offsetTop`) onto the modal overlay so it tracks the region **above** the keyboard.

- **Overlay + card** — the overlay is sized to the visible region; the mobile `.card` gains `max-height: 100%` so it fills that region (footer/CTA stay visible, the prompt field shrinks instead of hiding). `.overlay` is already the containing block for the fixed sheet (via its `backdrop-filter`), so the sheet's `bottom: 0` re-anchors above the keyboard automatically. `MobileEngineSheet` caps to `max-height: 85%` (of that region) instead of `85dvh`.
- **Bounded repo dropdown** — the default `RepoSelect` panel is an absolute dropdown that opens *down* into the keyboard inside the short, bottom-anchored context sheet. Scoped under `.ctx-sheet`, it becomes an **in-flow, single-scroll** section with a **sticky filter**, so the filter (and what you type) and the results stay reachable at the smallest keyboard-visible height. `RepoSelect.svelte` itself is unchanged, so other usages are untouched.
- **Gated to mobile** — the listener is bound to the `max-width: 768px` layout; on desktop the overlay is never touched (pinch-zoom can't move it), and the effect's teardown clears the inline geometry on breakpoint change so nothing stale survives onto desktop.

No new user-facing strings (no i18n / glossary / feature-catalog entries).

## Testing

- `bun run check` — clean.
- `bun run test:browser` (NewTask + MobileEngineSheet) — 113 passed, incl. 2 new regressions that fake a mutable `visualViewport`: (1) overlay mirrors `height`/`offsetTop` and resets on breakpoint change; (2) in the context sheet the repo filter + results stay within the simulated visible viewport (sticky filter, scrollable results). The existing mobile geometry fixtures still pass.
- `bunx prettier --check` + `check:i18n` — clean.
- The real iOS keyboard can't be synthesized in the harness → to be validated manually on an iPhone.