### PR TITLE
fix(tabs): transient helper tabs leak as Herdr shell husks until FD exhaustion

### DIFF
--- a/src/autopilot-llm.ts
+++ b/src/autopilot-llm.ts
@@ -1,8 +1,11 @@
-import { mkdtempSync, rmSync } from "node:fs";
 import { readRoleResultText, CODEX_LAST_MESSAGE_FILE } from "./codex-last-message";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import type { HerdrDriver } from "./herdr";
+import {
+  cleanupHelperDir,
+  makeHelperTmpDir,
+  reapHelperRun,
+  realSleep,
+} from "./transient-helper-lifecycle";
 import type { AutopilotVerdict, AgentProvider } from "./types";
 import type { OperatorLanguage } from "./operator-language";
 import { apiKeyFailClosed, apiKeyPassthroughEnv } from "./spawn-auth";
@@ -39,11 +42,7 @@ export interface ClassifierDeps {
   pollMs?: number;
 }
 
-const realSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
-
-function defaultMakeTmpDir(): string {
-  return mkdtempSync(join(tmpdir(), "shepherd-autopilot-"));
-}
+const defaultMakeTmpDir = (): string => makeHelperTmpDir("shepherd-autopilot-");
 function defaultReadVerdict(cwd: string): RawVerdict | null {
   // Result file first, Codex `-o` last-message fallback when absent (a Codex classifier that answers
   // in chat never writes the result file — see codex-last-message.ts).
@@ -54,13 +53,6 @@ function defaultReadVerdict(cwd: string): RawVerdict | null {
     return JSON.parse(text) as RawVerdict;
   } catch {
     return null; // partial write; try again next poll
-  }
-}
-function defaultCleanup(cwd: string): void {
-  try {
-    rmSync(cwd, { recursive: true, force: true });
-  } catch {
-    /* best-effort */
   }
 }
 
@@ -120,7 +112,7 @@ export async function classifyStop(
   const {
     makeTmpDir = defaultMakeTmpDir,
     readVerdict = defaultReadVerdict,
-    cleanup = defaultCleanup,
+    cleanup = cleanupHelperDir,
     provider = "claude",
     model = "haiku",
     effort = null,
@@ -163,13 +155,6 @@ export async function classifyStop(
     const raw = await pollForVerdict(readVerdict, cwd, { now, sleep, timeoutMs, pollMs });
     return normalize(raw);
   } finally {
-    if (terminalId) {
-      try {
-        await deps.herdr.stop(terminalId);
-      } catch {
-        /* best-effort */
-      }
-    }
-    if (cwd) cleanup(cwd);
+    await reapHelperRun(deps.herdr, terminalId, cwd, cleanup);
   }
 }

--- a/src/herd-digest.ts
+++ b/src/herd-digest.ts
@@ -188,10 +188,14 @@ export class HerdDigestService {
   private inFlight = new Set<string>();
   /** Guards a digest being finalized twice across overlapping ticks. */
   private finalizing = new Set<string>();
-  /** Spawn terminalId per generating dayKey (#1852). The persisted row carries only
-   *  `cwd`, and `resolveTerminal(cwd)` returns "" once the agent exited — which made the
-   *  finalize `stop("")` a silent no-op and leaked the tab. In-memory by design: a
-   *  restart-adopted row falls back to the cwd lookup (orphan sweep covers residue). */
+  /** Spawn terminalId per generating RUN, keyed by the run's mkdtemp-unique tmpdir cwd
+   *  (#1852). The persisted row carries only `cwd`, and `resolveTerminal(cwd)` returns
+   *  "" once the agent exited — which made the finalize `stop("")` a silent no-op and
+   *  leaked the tab. Keyed by cwd, NOT dayKey: a finalizer holds this key across awaits,
+   *  and a dayKey key is re-bound by a forced regenerate — a stale finalizer would then
+   *  stop and unmap the REPLACEMENT run's terminal. A tmpdir is never reused, so a stale
+   *  teardown can only ever resolve its own run. In-memory by design: a restart-adopted
+   *  row falls back to the cwd lookup (orphan sweep covers residue). */
   private generatingTerminals = new Map<string, string>();
 
   constructor(private deps: HerdDigestServiceDeps) {
@@ -214,6 +218,20 @@ export class HerdDigestService {
     return this.deps.herdr.list().find((a) => a.cwd === cwd)?.terminalId ?? "";
   }
 
+  /** Stop a generating run's pane — spawn-recorded terminalId first (#1852; the cwd
+   *  lookup is only for rows adopted across a restart and yields "" once the agent
+   *  exited, a safe stop() no-op) — then drop the in-memory handle. Keyed strictly by
+   *  the run's own cwd so a teardown racing a forced regenerate can never touch the
+   *  replacement run (see `generatingTerminals`). Never throws. */
+  private async reapPane(cwd: string): Promise<void> {
+    try {
+      await this.deps.herdr.stop(this.generatingTerminals.get(cwd) ?? this.resolveTerminal(cwd));
+    } catch {
+      /* best-effort */
+    }
+    this.generatingTerminals.delete(cwd);
+  }
+
   // ── reapGenerating ───────────────────────────────────────────────────────────
 
   /**
@@ -227,15 +245,7 @@ export class HerdDigestService {
   private reapGenerating(dayKey: string): void {
     const existing = this.deps.store.getHerdDigest(dayKey);
     if (!existing || existing.state !== "generating") return;
-    try {
-      // Spawn-recorded terminalId first (#1852) — see the finalize `finally`.
-      void this.deps.herdr
-        .stop(this.generatingTerminals.get(dayKey) ?? this.resolveTerminal(existing.cwd))
-        .catch(() => {});
-    } catch {
-      /* best-effort */
-    }
-    this.generatingTerminals.delete(dayKey);
+    void this.reapPane(existing.cwd);
     this._cleanup(existing.cwd);
   }
 
@@ -383,7 +393,7 @@ export class HerdDigestService {
           argv,
           rundownSpawnEnv(environment),
         );
-        this.generatingTerminals.set(dayKey, started.terminalId);
+        this.generatingTerminals.set(cwd, started.terminalId);
       } catch {
         this._cleanup(cwd);
         return "error"; // spawn failed; no row left so a later sweep can retry
@@ -544,17 +554,8 @@ export class HerdDigestService {
         console.warn(`[rundown] usage capture failed for ${d.dayKey}:`, err);
       }
     } finally {
-      // Always reap pane + tmpdir. Prefer the spawn-recorded terminalId (#1852) — the
-      // cwd lookup is only for rows adopted across a restart, and returns "" once the
-      // agent exited (herdr.stop("") is a no-op; the orphan sweep covers that residue).
-      try {
-        await this.deps.herdr.stop(
-          this.generatingTerminals.get(d.dayKey) ?? this.resolveTerminal(d.cwd),
-        );
-      } catch {
-        /* best-effort */
-      }
-      this.generatingTerminals.delete(d.dayKey);
+      // Always reap pane + tmpdir (spawn-recorded terminal first — see reapPane, #1852).
+      await this.reapPane(d.cwd);
       this._cleanup(d.cwd);
     }
   }

--- a/src/herd-digest.ts
+++ b/src/herd-digest.ts
@@ -188,6 +188,11 @@ export class HerdDigestService {
   private inFlight = new Set<string>();
   /** Guards a digest being finalized twice across overlapping ticks. */
   private finalizing = new Set<string>();
+  /** Spawn terminalId per generating dayKey (#1852). The persisted row carries only
+   *  `cwd`, and `resolveTerminal(cwd)` returns "" once the agent exited — which made the
+   *  finalize `stop("")` a silent no-op and leaked the tab. In-memory by design: a
+   *  restart-adopted row falls back to the cwd lookup (orphan sweep covers residue). */
+  private generatingTerminals = new Map<string, string>();
 
   constructor(private deps: HerdDigestServiceDeps) {
     this.now = deps.now ?? Date.now;
@@ -223,10 +228,14 @@ export class HerdDigestService {
     const existing = this.deps.store.getHerdDigest(dayKey);
     if (!existing || existing.state !== "generating") return;
     try {
-      void this.deps.herdr.stop(this.resolveTerminal(existing.cwd)).catch(() => {});
+      // Spawn-recorded terminalId first (#1852) — see the finalize `finally`.
+      void this.deps.herdr
+        .stop(this.generatingTerminals.get(dayKey) ?? this.resolveTerminal(existing.cwd))
+        .catch(() => {});
     } catch {
       /* best-effort */
     }
+    this.generatingTerminals.delete(dayKey);
     this._cleanup(existing.cwd);
   }
 
@@ -364,9 +373,17 @@ export class HerdDigestService {
       const prompt = buildRundownPrompt(assembled, this.operatorLanguage());
       const { argv, sessionId: spawnSessionId } = rundownArgv(environment, prompt);
 
+      // Keep the returned handle: the terminalId is the finalizer's teardown key (#1852) —
+      // resolving by cwd later yields "" once the agent exited.
       const cwd = this._makeTmpDir();
       try {
-        await this.deps.herdr.start("rundown", cwd, argv, rundownSpawnEnv(environment));
+        const started = await this.deps.herdr.start(
+          "rundown",
+          cwd,
+          argv,
+          rundownSpawnEnv(environment),
+        );
+        this.generatingTerminals.set(dayKey, started.terminalId);
       } catch {
         this._cleanup(cwd);
         return "error"; // spawn failed; no row left so a later sweep can retry
@@ -527,12 +544,17 @@ export class HerdDigestService {
         console.warn(`[rundown] usage capture failed for ${d.dayKey}:`, err);
       }
     } finally {
-      // Always reap pane + tmpdir.
+      // Always reap pane + tmpdir. Prefer the spawn-recorded terminalId (#1852) — the
+      // cwd lookup is only for rows adopted across a restart, and returns "" once the
+      // agent exited (herdr.stop("") is a no-op; the orphan sweep covers that residue).
       try {
-        await this.deps.herdr.stop(this.resolveTerminal(d.cwd));
+        await this.deps.herdr.stop(
+          this.generatingTerminals.get(d.dayKey) ?? this.resolveTerminal(d.cwd),
+        );
       } catch {
         /* best-effort */
       }
+      this.generatingTerminals.delete(d.dayKey);
       this._cleanup(d.cwd);
     }
   }

--- a/src/herdr-socket-driver.ts
+++ b/src/herdr-socket-driver.ts
@@ -1,6 +1,7 @@
 import { HerdrSocketClient } from "./herdr-socket-client";
 import {
   HerdrDriver,
+  TabLedger,
   buildWrappedArgv,
   createSerializer,
   isHeadlessCodexExec,
@@ -9,7 +10,10 @@ import {
   parseAgents,
   parseProcs,
   parseReadText,
+  parseTabs,
+  stopViaRecordedTab,
   type HerdrAgent,
+  type HerdrTab,
   type IHerdrDriver,
 } from "./herdr";
 import { config, HERDR_SOCKET_SUPPORTED_PROTOCOLS } from "./config";
@@ -29,6 +33,11 @@ export class SocketHerdrDriver implements IHerdrDriver {
   /** Serializes `start` so concurrent spawns can't race the workspace/tab orchestration
    *  across the socket round-trips' async yield points (issue #1553). */
   private serializeStart = createSerializer();
+
+  /** Spawn-handle registry: authoritative tabId per started terminalId (#1852). Owned
+   *  here, not shared with the wrapped CLI driver — all starts/stops route through
+   *  this driver when the socket transport is active. */
+  private ledger = new TabLedger();
 
   constructor(
     private client: HerdrSocketClient,
@@ -59,6 +68,11 @@ export class SocketHerdrDriver implements IHerdrDriver {
    */
   async paneForegroundProcs(paneId: string): Promise<string[]> {
     return parseProcs(await this.client.request("pane.process_info", { pane_id: paneId }));
+  }
+
+  /** Socket-backed async tab list — feeds the recorded-tab verification in `stop()` (#1852). */
+  async tabsAsync(): Promise<HerdrTab[]> {
+    return parseTabs(await this.client.request("tab.list", {}));
   }
 
   // ── Delegated to the CLI driver (unchanged) ──────────────────────────────
@@ -130,6 +144,9 @@ export class SocketHerdrDriver implements IHerdrDriver {
         cwd,
         buildWrappedArgv(argv, env),
       );
+      const started = parseAgentInfo(agent);
+      // Retain the authoritative spawn handle (#1852) — see the CLI driver's startImpl.
+      this.ledger.record(started.terminalId, tabId, name);
       if (rootPaneId && !isHeadlessCodexExec(argv)) {
         try {
           await this.client.request("pane.close", { pane_id: rootPaneId });
@@ -137,7 +154,7 @@ export class SocketHerdrDriver implements IHerdrDriver {
           /* best-effort: agent still runs if the shell pane lingers, just at split width */
         }
       }
-      return parseAgentInfo(agent);
+      return started;
     } catch (err) {
       await this.closeTab(tabId); // roll back the orphan tab before propagating
       throw err;
@@ -190,12 +207,11 @@ export class SocketHerdrDriver implements IHerdrDriver {
     throw new Error(`herdr: agent.start exhausted retries for ${name}`);
   }
 
-  /** Best-effort teardown of the agent backing a terminal id: resolve its current tab FRESH
-   *  from the live list, then close that tab. No-op if the pane is gone. Mirrors the CLI. */
+  /** Best-effort teardown of the agent backing a terminal id. Recorded-handle-first,
+   *  agent-list fallback, observable full miss — mirrors the CLI driver; the shared
+   *  body is {@link stopViaRecordedTab} (#1852). */
   async stop(terminalId: string): Promise<void> {
-    const agent = (await this.listAsync()).find((a) => a.terminalId === terminalId);
-    if (!agent?.tabId) return;
-    await this.closeTab(agent.tabId);
+    await stopViaRecordedTab(this, this.ledger, terminalId);
   }
 
   /** Rename a live agent and its dedicated tab. Resolves FRESH from the live list;
@@ -216,6 +232,8 @@ export class SocketHerdrDriver implements IHerdrDriver {
     if (agent.tabId) {
       try {
         await this.client.request("tab.rename", { tab_id: agent.tabId, label: newName });
+        // Mirror the successful TAB rename into the ledger — see the CLI driver (#1852).
+        this.ledger.relabel(terminalId, newName);
       } catch {
         /* best-effort */
       }

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -313,10 +313,14 @@ export function parseAgents(result: unknown): HerdrAgent[] {
   }));
 }
 
-/** Maps a `tab list` reply to `HerdrTab[]`. Internal — not exported (fallow flags an
- *  unused export; the parsers used cross-module are exported). */
-function parseTabs(parsed: unknown): HerdrTab[] {
-  const tabs = (parsed as { result?: { tabs?: Record<string, string>[] } })?.result?.tabs ?? [];
+/**
+ * Maps a herdr `tab.list` reply's `result` object to `HerdrTab[]`. Takes the `result`
+ * (not the whole parsed reply) so BOTH transports share it — the CLI driver passes
+ * `JSON.parse(out)?.result`, the socket driver passes the request's resolved result
+ * directly (same convention as `parseAgents`).
+ */
+export function parseTabs(result: unknown): HerdrTab[] {
+  const tabs = (result as { tabs?: Record<string, string>[] } | null)?.tabs ?? [];
   return tabs.map((t) => ({
     tabId: t.tab_id ?? "",
     label: t.label ?? "",
@@ -437,6 +441,109 @@ export function parseProcs(result: unknown): string[] {
 }
 
 /**
+ * Spawn-handle registry (issue #1852): remembers each `start()`'s authoritative
+ * `tabId` + tab label, keyed by the started agent's terminalId, so `stop()` can close
+ * the recorded tab WITHOUT rediscovering it through `agent list`. That rediscovery was
+ * the leak: a helper that exited (or died milliseconds after `agent.start`) vanishes
+ * from `agent list` while its tab persists as a husk — `stop()` then silently no-oped
+ * and the tab accumulated until herdr exhausted its FD limit (334 tabs / 1,010 FDs).
+ *
+ * In-memory by design: entries live exactly as long as the in-process teardown paths
+ * that need them; anything orphaned across a Shepherd restart is the orphan-tab
+ * sweep's job. Entries are dropped on `stop()` so steady-state size tracks the live
+ * agent count.
+ */
+export class TabLedger {
+  private entries = new Map<string, { tabId: string; label: string }>();
+
+  record(terminalId: string, tabId: string, label: string): void {
+    if (terminalId && tabId) this.entries.set(terminalId, { tabId, label });
+  }
+
+  get(terminalId: string): { tabId: string; label: string } | null {
+    return this.entries.get(terminalId) ?? null;
+  }
+
+  delete(terminalId: string): void {
+    this.entries.delete(terminalId);
+  }
+
+  /** Mirror a TAB rename (the label check in `stopViaRecordedTab` compares tab labels). */
+  relabel(terminalId: string, label: string): void {
+    const e = this.entries.get(terminalId);
+    if (e) e.label = label;
+  }
+}
+
+/**
+ * Shared `stop()` body for both drivers (issue #1852): the spawn-recorded tab is the
+ * NORMAL teardown path; the fresh `agent list` lookup is only the fallback for handles
+ * the ledger doesn't know (re-adopted after a Shepherd restart, legacy callers).
+ *
+ * - `terminalId === ""` → no-op: cwd-reconcile callers pass `""` deliberately when the
+ *   pane is already gone from the live list.
+ * - Ledger hit → verify against the live TAB list (which, unlike `agent list`, still
+ *   contains an exited helper's husk): recorded tab present with the recorded label →
+ *   close it, done — zero `agent list` calls. Tab absent → it died with the daemon or
+ *   was already closed; nothing to close. Label mismatch → the id was re-minted by a
+ *   restarted daemon (or a rename the ledger missed) — never close on a mismatch; warn
+ *   and fall through to the agent-list resolution, which reflects current truth.
+ * - A `tabsAsync()` throw (herdr hiccup) also falls through to the agent-list path, so
+ *   this is never weaker than the pre-ledger behavior.
+ * - Nothing found anywhere → warn: an observable no-op, never a silent one (#1852).
+ */
+export async function stopViaRecordedTab(
+  driver: Pick<IHerdrDriver, "listAsync" | "tabsAsync" | "closeTab">,
+  ledger: TabLedger,
+  terminalId: string,
+): Promise<void> {
+  if (!terminalId) return;
+
+  const known = ledger.get(terminalId);
+  if (known) {
+    let tabs: HerdrTab[] | null = null;
+    try {
+      tabs = await driver.tabsAsync();
+    } catch {
+      /* transient tab-list failure — fall back to the agent-list path below */
+    }
+    if (tabs) {
+      const tab = tabs.find((t) => t.tabId === known.tabId);
+      if (!tab) {
+        // Recorded tab no longer exists (daemon restart without restore, or already
+        // closed) — nothing to close, nothing leaked.
+        ledger.delete(terminalId);
+        return;
+      }
+      if (tab.label === known.label) {
+        ledger.delete(terminalId);
+        await driver.closeTab(known.tabId);
+        return;
+      }
+      // Label mismatch: recorded id now denotes some other tab — closing it could kill
+      // live work. Drop the unusable entry and resolve from the live agent list instead.
+      console.warn(
+        `[herdr] stop: recorded tab ${known.tabId} for terminal ${terminalId} is now ` +
+          `labeled ${JSON.stringify(tab.label)} (recorded ${JSON.stringify(known.label)}) — ` +
+          `not closing it; falling back to agent list`,
+      );
+      ledger.delete(terminalId);
+    }
+  }
+
+  const agent = (await driver.listAsync()).find((a) => a.terminalId === terminalId);
+  if (agent?.tabId) {
+    ledger.delete(terminalId);
+    await driver.closeTab(agent.tabId);
+    return;
+  }
+  console.warn(
+    `[herdr] stop: no live agent and no usable recorded tab for terminal ${terminalId} — ` +
+      `teardown is a no-op (orphan sweep will cover any residue)`,
+  );
+}
+
+/**
  * Public method surface of `HerdrDriver`, extracted so the socket-backed
  * driver (`SocketHerdrDriver`, issue #1529) implements the same contract behind the existing seam —
  * callers keep using `Pick<HerdrDriver, …>` today; nothing about them changes.
@@ -446,6 +553,9 @@ export interface IHerdrDriver {
   /** Non-blocking sibling of `list()` — see `HerdrDriver.listAsync`. */
   listAsync(): Promise<HerdrAgent[]>;
   tabs(): HerdrTab[];
+  /** Non-blocking sibling of `tabs()` — the recorded-tab verification in `stop()` runs
+   *  on the async surface (#1852). */
+  tabsAsync(): Promise<HerdrTab[]>;
   panes(): HerdrPane[];
   paneForegroundProcs(paneId: string): Promise<string[]>;
   /** Spawn an agent (issue #1553: async — socket-backed when `SHEPHERD_HERDR_SOCKET=1`,
@@ -472,6 +582,9 @@ export class HerdrDriver implements IHerdrDriver {
    *  now that the writes are async (issue #1553); see `createSerializer`. */
   private serializeStart = createSerializer();
 
+  /** Spawn-handle registry: authoritative tabId per started terminalId (#1852). */
+  private ledger = new TabLedger();
+
   constructor(
     private runner: Runner = defaultRunner,
     private asyncRunner: AsyncRunner = defaultAsyncRunner,
@@ -492,7 +605,13 @@ export class HerdrDriver implements IHerdrDriver {
 
   /** Every tab in the workspace — including husks with no live agent (`tab list`). */
   tabs(): HerdrTab[] {
-    return parseTabs(JSON.parse(this.runner(["tab", "list"])));
+    return parseTabs(JSON.parse(this.runner(["tab", "list"]))?.result);
+  }
+
+  /** Async sibling of `tabs()` — spawns via `asyncRunner` so the recorded-tab
+   *  verification in `stop()` never blocks Bun's single loop. */
+  async tabsAsync(): Promise<HerdrTab[]> {
+    return parseTabs(JSON.parse(await this.asyncRunner(["tab", "list"]))?.result);
   }
 
   /** Every pane across all tabs (`pane list`). Includes idle shell panes left behind by exited agents. */
@@ -648,6 +767,9 @@ export class HerdrDriver implements IHerdrDriver {
       // Capture the authoritative handle before root-pane cleanup: a fast role can already be
       // absent from agent.list, and closing the remaining shell pane can remove the whole tab.
       const agent = await this.startAgentWithCollisionRetry(name, tabId, cwd, wrapped);
+      // Retain the authoritative spawn handle (#1852): the tab exists and is ours even
+      // if the process inside dies before it ever appears in `agent list`.
+      this.ledger.record(agent.terminalId, tabId, name);
 
       if (rootPaneId && !isHeadlessCodexExec(argv)) {
         try {
@@ -717,17 +839,15 @@ export class HerdrDriver implements IHerdrDriver {
   /**
    * Best-effort teardown of the agent backing a terminal id. Closes the agent's whole
    * TAB, not just its pane: every agent gets its own dedicated tab, so closing only the
-   * pane left an empty husk tab behind. Resolves `terminalId → current tabId` FRESH from
-   * the live list — the live list is the source of truth; the agent may have ended or been
-   * relabeled, so a cached tabId may be stale. Under herdr 0.7 an exited agent persists as
-   * a husk that retains its terminalId, so stop() still finds and closes its tab. The no-op
-   * path fires only when the pane is truly gone from the list; the orphan sweep handles any
-   * residue in that case.
+   * pane left an empty husk tab behind. For a spawn this driver started, the tab recorded
+   * at `start()` is the NORMAL path — verified against the live tab list and closed
+   * directly, with no dependency on the agent still being present in `agent list` (an
+   * exited helper vanishes from that list while its husk tab persists — the #1852 leak).
+   * Unknown handles fall back to the fresh agent-list resolution; a full miss warns
+   * instead of silently no-oping. See {@link stopViaRecordedTab}.
    */
   async stop(terminalId: string): Promise<void> {
-    const agent = (await this.listAsync()).find((a) => a.terminalId === terminalId);
-    if (!agent?.tabId) return;
-    await this.closeTab(agent.tabId);
+    await stopViaRecordedTab(this, this.ledger, terminalId);
   }
 
   /**
@@ -753,6 +873,9 @@ export class HerdrDriver implements IHerdrDriver {
     if (agent.tabId) {
       try {
         await this.asyncRunner(["tab", "rename", agent.tabId, newName]);
+        // Mirror the successful TAB rename so the ledger label keeps matching the live
+        // tab (the stop() fallback refuses to close on a label mismatch, #1852).
+        this.ledger.relabel(terminalId, newName);
       } catch {
         /* best-effort */
       }

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -298,19 +298,25 @@ type AgentListResult = { agents?: Record<string, string>[] } | null;
  */
 export function parseAgents(result: unknown): HerdrAgent[] {
   const agents = (result as AgentListResult)?.agents ?? [];
-  return agents.map((a: Record<string, string>) => ({
+  return agents.map(mapAgentRecord);
+}
+
+/** The one snake_case→HerdrAgent field mapping, shared by `parseAgents` and
+ *  `parseAgentInfo` so the two reply shapes can't drift apart.
+ *  `noUncheckedIndexedAccess` widens Record<string,string> indexing to `| undefined`;
+ *  `?? ""` keeps these required-string fields honest — herdr always supplies them in
+ *  practice. */
+function mapAgentRecord(a: Record<string, string>): HerdrAgent {
+  return {
     agent: a.agent ?? "",
     agentStatus: (a.agent_status ?? "unknown") as HerdrState,
-    // `noUncheckedIndexedAccess` widens Record<string,string> indexing to `| undefined`;
-    // `?? ""` keeps these required-string fields honest without changing the intent of
-    // the original (untyped) mapping — herdr always supplies them in practice.
     cwd: a.cwd ?? "",
     name: a.name ?? "",
     paneId: a.pane_id ?? "",
     tabId: a.tab_id ?? "",
     terminalId: a.terminal_id ?? "",
     workspaceId: a.workspace_id ?? "",
-  }));
+  };
 }
 
 /**
@@ -337,17 +343,7 @@ export function parseTabs(result: unknown): HerdrTab[] {
  * (confirmed against live herdr 0.7.3), so no post-start re-list is needed.
  */
 export function parseAgentInfo(agent: unknown): HerdrAgent {
-  const a = (agent ?? {}) as Record<string, string>;
-  return {
-    agent: a.agent ?? "",
-    agentStatus: (a.agent_status ?? "unknown") as HerdrState,
-    cwd: a.cwd ?? "",
-    name: a.name ?? "",
-    paneId: a.pane_id ?? "",
-    tabId: a.tab_id ?? "",
-    terminalId: a.terminal_id ?? "",
-    workspaceId: a.workspace_id ?? "",
-  };
+  return mapAgentRecord((agent ?? {}) as Record<string, string>);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ import { DraftReconcileService } from "./draft-reconcile";
 import { isFullAuto } from "./full-auto";
 import { classifyStop } from "./autopilot-llm";
 import { tailLines } from "./blocked";
-import { recommendPrompt } from "./prompt-recommend";
+import { recommendPrompt, RECOMMEND_LABEL } from "./prompt-recommend";
 import { CountsService } from "./backlog";
 import { OpenPrSnapshotService } from "./open-pr-snapshot";
 import { BacklogPoller } from "./backlog-poller";
@@ -2277,6 +2277,7 @@ deferredStarts.push(() => {
   void reapTransientByLabel(herdr, NAMER_LABEL, new Set(), "[namer]");
   void reapTransientByLabel(herdr, AUTOPILOT_LABEL, new Set(), "[autopilot]");
   void reapTransientByLabel(herdr, VERIFY_KEY_LABEL, new Set(), "[verify-key]");
+  void reapTransientByLabel(herdr, RECOMMEND_LABEL, new Set(), "[recommend]");
 });
 const gitignoreAdopter = new GitignoreAdopter({ worktree, resolveForge });
 // Daily: prune archived sessions, prune old signals, then consider a distill per repo
@@ -2851,7 +2852,7 @@ const appDeps: AppDeps = {
         taskPrompt: s.prompt,
         provider,
         model,
-        label: `recommend ${s.desig}`,
+        label: `${RECOMMEND_LABEL}${s.desig}`,
         // Live per-call read at the composition root (#1586).
         operatorLanguage: config.operatorLanguage,
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ import { PrPoller } from "./pr-poller";
 import { resolveDiffBase } from "./diff-base";
 import { BranchPruner } from "./branch-pruner";
 import { reconcile } from "./reconcile";
-import { reapOrphanTabs, reapStaleReviewWorktrees } from "./tab-reaper";
+import { createOrphanTabSweeper, reapOrphanTabs, reapStaleReviewWorktrees } from "./tab-reaper";
 import { reapTransientByLabel } from "./transient-tab-reaper";
 import { scanClaudeAliveByWorktree } from "./process-reaper";
 import { serve, serveAgentIngress, buildBacklogPayload, type AppDeps } from "./server";
@@ -895,29 +895,37 @@ deferredStarts.push(() => {
 // Reap orphaned helper tabs (usage-probe / review husks no live agent backs). The
 // teardown paths close these at the source; this sweep is the safety net for husks
 // they miss — agents that crashed out of `agent list`, or anything left over after a
-// shepherd restart cleared the in-memory review tracking. Run once on boot, then hourly.
-// Debounce state for reapOrphanTabs' two-sweep husk confirmation (#721): the shell-only
-// tabIds seen last sweep, threaded back in as `prevShellOnly` so a husk is only reaped when
-// it read shell-only on two consecutive sweeps (avoids reaping an agent's pre-`exec` window).
-let shellOnlyTabs = new Set<string>();
-const sweepOrphanTabs = () => {
-  if (maintenance.active) return;
-  void reapOrphanTabs(herdr, shellOnlyTabs)
-    .then((r) => {
-      shellOnlyTabs = r.shellOnly;
-      if (r.closed.length || r.sparedError)
-        console.warn(
-          `[tabs] reaped ${r.closed.length} husk tab(s); spared ${r.sparedLive} live, ${r.sparedError} undetermined`,
-        );
-    })
-    .catch((err) => console.warn("[tabs] orphan sweep failed:", err));
-};
+// shepherd restart cleared the in-memory review tracking. Passes are serialized,
+// coalesced, and self-confirming via `createOrphanTabSweeper` (#1852): the debounce set
+// is threaded through the serialized chain (never raced by an overlapping boot pass),
+// and any pass that sights NEW shell-only candidates schedules its own confirming pass
+// 30s later — so convergence survives restarts and skipped boot sweeps without
+// persisting anything. A `panes()` failure surfaces as a warning instead of reading as
+// "nothing to do".
+const orphanTabSweeper = createOrphanTabSweeper({
+  reap: (prev) => reapOrphanTabs(herdr, prev),
+  schedule: (fn, ms) => void setTimeout(fn, ms),
+  maintenanceActive: () => maintenance.active,
+  confirmDelayMs: 30_000,
+  onResult: (r) => {
+    if (r.panesFailed) {
+      console.warn("[tabs] orphan sweep: panes() unavailable — reaped nothing, debounce preserved");
+      return;
+    }
+    if (r.closed.length || r.sparedError)
+      console.warn(
+        `[tabs] reaped ${r.closed.length} husk tab(s); spared ${r.sparedLive} live, ${r.sparedError} undetermined`,
+      );
+  },
+  onError: (err) => console.warn("[tabs] orphan sweep failed:", err),
+});
 // Boot + a confirming pass @45s so pre-existing husks clear despite the two-sweep debounce,
-// then hourly.
+// then hourly. (The self-confirming pass makes the 45s trigger redundant in the common case;
+// it stays as a cheap belt-and-suspenders for a boot pass that sighted nothing yet.)
 deferredStarts.push(() => {
-  setTimeout(sweepOrphanTabs, 5_000);
-  setTimeout(sweepOrphanTabs, 45_000);
-  setInterval(sweepOrphanTabs, 60 * 60 * 1000);
+  setTimeout(orphanTabSweeper.trigger, 5_000);
+  setTimeout(orphanTabSweeper.trigger, 45_000);
+  setInterval(orphanTabSweeper.trigger, 60 * 60 * 1000);
 });
 
 const tailscaleServe = new TailscaleServeService({

--- a/src/namer-llm.ts
+++ b/src/namer-llm.ts
@@ -1,7 +1,12 @@
-import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import type { HerdrDriver } from "./herdr";
+import {
+  cleanupHelperDir,
+  makeHelperTmpDir,
+  reapHelperRun,
+  realSleep,
+} from "./transient-helper-lifecycle";
 import type { AgentProvider } from "./types";
 import { slugifyManual } from "./namer";
 import { apiKeyFailClosed, apiKeyPassthroughEnv } from "./spawn-auth";
@@ -40,11 +45,7 @@ export function namingPrompt(taskText: string): string {
   ].join("\n");
 }
 
-const realSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
-
-function defaultMakeTmpDir(): string {
-  return mkdtempSync(join(tmpdir(), "shepherd-namer-"));
-}
+const defaultMakeTmpDir = (): string => makeHelperTmpDir("shepherd-namer-");
 function defaultReadName(cwd: string): string | null {
   const p = join(cwd, NAME_FILE);
   if (!existsSync(p)) return null;
@@ -52,13 +53,6 @@ function defaultReadName(cwd: string): string | null {
     return readFileSync(p, "utf8");
   } catch {
     return null; // partial write; try again next poll
-  }
-}
-function defaultCleanup(cwd: string): void {
-  try {
-    rmSync(cwd, { recursive: true, force: true });
-  } catch {
-    /* best-effort */
   }
 }
 
@@ -131,7 +125,7 @@ export async function llmName(
   const {
     makeTmpDir = defaultMakeTmpDir,
     readName = defaultReadName,
-    cleanup = defaultCleanup,
+    cleanup = cleanupHelperDir,
     provider = "claude",
     model = "haiku",
     effort = null,
@@ -165,13 +159,6 @@ export async function llmName(
     const raw = await pollForRaw(readName, cwd, { now, sleep, timeoutMs, pollMs });
     return raw === null ? null : extractSlug(raw);
   } finally {
-    if (terminalId) {
-      try {
-        await deps.herdr.stop(terminalId);
-      } catch {
-        /* best-effort */
-      }
-    }
-    if (cwd) cleanup(cwd);
+    await reapHelperRun(deps.herdr, terminalId, cwd, cleanup);
   }
 }

--- a/src/prompt-recommend.ts
+++ b/src/prompt-recommend.ts
@@ -1,7 +1,12 @@
-import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
+import {
+  cleanupHelperDir,
+  makeHelperTmpDir,
+  reapHelperRun,
+  realSleep,
+} from "./transient-helper-lifecycle";
 import type { HerdrDriver } from "./herdr";
 import type { AgentProvider } from "./types";
 import {
@@ -109,11 +114,7 @@ export function recommenderPrompt(
   return lines.join("\n");
 }
 
-const realSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
-
-function defaultMakeTmpDir(): string {
-  return mkdtempSync(join(tmpdir(), "shepherd-recommend-"));
-}
+const defaultMakeTmpDir = (): string => makeHelperTmpDir("shepherd-recommend-");
 function defaultReadSuggestion(cwd: string): RawSuggestion | null {
   const p = join(cwd, RECOMMEND_FILE);
   if (!existsSync(p)) return null;
@@ -121,13 +122,6 @@ function defaultReadSuggestion(cwd: string): RawSuggestion | null {
     return JSON.parse(readFileSync(p, "utf8")) as RawSuggestion;
   } catch {
     return null; // partial write; try again next poll
-  }
-}
-function defaultCleanup(cwd: string): void {
-  try {
-    rmSync(cwd, { recursive: true, force: true });
-  } catch {
-    /* best-effort */
   }
 }
 
@@ -212,7 +206,7 @@ export async function recommendPrompt(
   const {
     makeTmpDir = defaultMakeTmpDir,
     readSuggestion = defaultReadSuggestion,
-    cleanup = defaultCleanup,
+    cleanup = cleanupHelperDir,
     now = Date.now,
     sleep = realSleep,
     timeoutMs = 180_000,
@@ -246,13 +240,6 @@ export async function recommendPrompt(
     const raw = await pollForSuggestion(readSuggestion, cwd, { now, sleep, timeoutMs, pollMs });
     return normalize(raw);
   } finally {
-    if (terminalId) {
-      try {
-        await deps.herdr.stop(terminalId);
-      } catch {
-        /* best-effort */
-      }
-    }
-    if (cwd) cleanup(cwd);
+    await reapHelperRun(deps.herdr, terminalId, cwd, cleanup);
   }
 }

--- a/src/prompt-recommend.ts
+++ b/src/prompt-recommend.ts
@@ -16,6 +16,12 @@ import type { OperatorLanguage } from "./operator-language";
 /** The file the recommender agent writes its suggestion JSON to, in its temp cwd. */
 export const RECOMMEND_FILE = ".shepherd-recommend.json";
 
+/** Label prefix for recommender spawns (`recommend <desig>`, built at the index.ts call
+ *  site). Space-prefixed so a prompt-derived `[a-z0-9-]` session slug can never collide.
+ *  Shared with the tab reaper + boot reap (#1852) — this helper previously had NO
+ *  reconcile coverage, so a Shepherd restart mid-run leaked its tab forever. */
+export const RECOMMEND_LABEL = "recommend ";
+
 /** Outcome of a recommendation run: the suggested next prompt, or a stable error reason
  *  the UI maps to a localized message. Never throws — failures collapse to `{ error }`. */
 export type RecommendResult = { prompt: string } | { error: RecommendError };

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -353,6 +353,13 @@ export class RecapService {
   /** Guards against double-spawn when regenerate races a mid-flight sweep. */
   private inFlight = new Set<string>();
 
+  /** Spawn terminalId per generating session (#1852). The persisted `Recap` row carries
+   *  only `cwd`, and `resolveTerminal(cwd)` returns "" once the agent exited — which made
+   *  the finalize `stop("")` a silent no-op and leaked the tab. In-memory by design: a
+   *  restart-adopted row falls back to the cwd lookup, and its residue is the orphan
+   *  sweep's job. */
+  private generatingTerminals = new Map<string, string>();
+
   constructor(private deps: RecapServiceDeps) {
     this.now = optional(deps.now, Date.now);
     this.timeoutMs = optional(deps.timeoutMs, DEFAULT_TIMEOUT_MS);
@@ -565,10 +572,14 @@ export class RecapService {
     const existing = this.deps.store.getRecap(sessionId);
     if (!existing || existing.state !== "generating") return;
     try {
-      void this.deps.herdr.stop(this.resolveTerminal(existing.cwd)).catch(() => {});
+      // Spawn-recorded terminalId first (#1852) — see the finalize `finally`.
+      void this.deps.herdr
+        .stop(this.generatingTerminals.get(sessionId) ?? this.resolveTerminal(existing.cwd))
+        .catch(() => {});
     } catch {
       /* best-effort */
     }
+    this.generatingTerminals.delete(sessionId);
     this._cleanup(existing.cwd);
     this.deps.store.dropRecap(sessionId);
   }
@@ -784,15 +795,17 @@ export class RecapService {
         env.effort,
       );
 
-      // Spawn.
+      // Spawn. Keep the returned handle: the terminalId is the finalizer's teardown key
+      // (#1852) — resolving by cwd later yields "" once the agent exited.
       const cwd = this._makeTmpDir();
       try {
-        await this.deps.herdr.start(
+        const started = await this.deps.herdr.start(
           `recap ${session.desig}`,
           cwd,
           argv,
           apiKeyPassthroughEnv(false),
         );
+        this.generatingTerminals.set(id, started.terminalId);
       } catch (err) {
         this._cleanup(cwd);
         this.putFailureRecap(session, "launch-failed", err, head, base);
@@ -1039,12 +1052,17 @@ export class RecapService {
         console.warn(`[recap] usage capture failed for ${r.sessionId}:`, err);
       }
     } finally {
-      // Always reap pane + tmpdir.
+      // Always reap pane + tmpdir. Prefer the spawn-recorded terminalId (#1852) — the
+      // cwd lookup is only for rows adopted across a restart, and returns "" once the
+      // agent exited (herdr.stop("") is a no-op; the orphan sweep covers that residue).
       try {
-        await this.deps.herdr.stop(this.resolveTerminal(r.cwd));
+        await this.deps.herdr.stop(
+          this.generatingTerminals.get(r.sessionId) ?? this.resolveTerminal(r.cwd),
+        );
       } catch {
         /* best-effort */
       }
+      this.generatingTerminals.delete(r.sessionId);
       this._cleanup(r.cwd);
     }
   }

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -567,19 +567,25 @@ export class RecapService {
 
   // ── reapGenerating ───────────────────────────────────────────────────────────
 
-  /** Reap any existing generating row for this session (stop pane + cleanup dir + drop row). */
-  private reapGenerating(sessionId: string): void {
-    const existing = this.deps.store.getRecap(sessionId);
-    if (!existing || existing.state !== "generating") return;
+  /** Stop a generating run's pane — spawn-recorded terminalId first (#1852; the cwd
+   *  lookup is only for rows adopted across a restart and yields "" once the agent
+   *  exited, a safe stop() no-op) — then drop the in-memory handle. Never throws. */
+  private async reapPane(sessionId: string, cwd: string): Promise<void> {
     try {
-      // Spawn-recorded terminalId first (#1852) — see the finalize `finally`.
-      void this.deps.herdr
-        .stop(this.generatingTerminals.get(sessionId) ?? this.resolveTerminal(existing.cwd))
-        .catch(() => {});
+      await this.deps.herdr.stop(
+        this.generatingTerminals.get(sessionId) ?? this.resolveTerminal(cwd),
+      );
     } catch {
       /* best-effort */
     }
     this.generatingTerminals.delete(sessionId);
+  }
+
+  /** Reap any existing generating row for this session (stop pane + cleanup dir + drop row). */
+  private reapGenerating(sessionId: string): void {
+    const existing = this.deps.store.getRecap(sessionId);
+    if (!existing || existing.state !== "generating") return;
+    void this.reapPane(sessionId, existing.cwd);
     this._cleanup(existing.cwd);
     this.deps.store.dropRecap(sessionId);
   }
@@ -1052,17 +1058,8 @@ export class RecapService {
         console.warn(`[recap] usage capture failed for ${r.sessionId}:`, err);
       }
     } finally {
-      // Always reap pane + tmpdir. Prefer the spawn-recorded terminalId (#1852) — the
-      // cwd lookup is only for rows adopted across a restart, and returns "" once the
-      // agent exited (herdr.stop("") is a no-op; the orphan sweep covers that residue).
-      try {
-        await this.deps.herdr.stop(
-          this.generatingTerminals.get(r.sessionId) ?? this.resolveTerminal(r.cwd),
-        );
-      } catch {
-        /* best-effort */
-      }
-      this.generatingTerminals.delete(r.sessionId);
+      // Always reap pane + tmpdir (spawn-recorded terminal first — see reapPane, #1852).
+      await this.reapPane(r.sessionId, r.cwd);
       this._cleanup(r.cwd);
     }
   }

--- a/src/recap.ts
+++ b/src/recap.ts
@@ -353,11 +353,15 @@ export class RecapService {
   /** Guards against double-spawn when regenerate races a mid-flight sweep. */
   private inFlight = new Set<string>();
 
-  /** Spawn terminalId per generating session (#1852). The persisted `Recap` row carries
-   *  only `cwd`, and `resolveTerminal(cwd)` returns "" once the agent exited — which made
-   *  the finalize `stop("")` a silent no-op and leaked the tab. In-memory by design: a
-   *  restart-adopted row falls back to the cwd lookup, and its residue is the orphan
-   *  sweep's job. */
+  /** Spawn terminalId per generating RUN, keyed by the run's mkdtemp-unique tmpdir cwd
+   *  (#1852). The persisted `Recap` row carries only `cwd`, and `resolveTerminal(cwd)`
+   *  returns "" once the agent exited — which made the finalize `stop("")` a silent
+   *  no-op and leaked the tab. Keyed by cwd, NOT sessionId: a finalizer holds this key
+   *  across awaits, and a sessionId key is re-bound by a forced regenerate — a stale
+   *  finalizer would then stop and unmap the REPLACEMENT run's terminal. A tmpdir is
+   *  never reused, so a stale teardown can only ever resolve its own run. In-memory by
+   *  design: a restart-adopted row falls back to the cwd lookup, and its residue is the
+   *  orphan sweep's job. */
   private generatingTerminals = new Map<string, string>();
 
   constructor(private deps: RecapServiceDeps) {
@@ -569,23 +573,23 @@ export class RecapService {
 
   /** Stop a generating run's pane — spawn-recorded terminalId first (#1852; the cwd
    *  lookup is only for rows adopted across a restart and yields "" once the agent
-   *  exited, a safe stop() no-op) — then drop the in-memory handle. Never throws. */
-  private async reapPane(sessionId: string, cwd: string): Promise<void> {
+   *  exited, a safe stop() no-op) — then drop the in-memory handle. Keyed strictly by
+   *  the run's own cwd so a teardown racing a forced regenerate can never touch the
+   *  replacement run (see `generatingTerminals`). Never throws. */
+  private async reapPane(cwd: string): Promise<void> {
     try {
-      await this.deps.herdr.stop(
-        this.generatingTerminals.get(sessionId) ?? this.resolveTerminal(cwd),
-      );
+      await this.deps.herdr.stop(this.generatingTerminals.get(cwd) ?? this.resolveTerminal(cwd));
     } catch {
       /* best-effort */
     }
-    this.generatingTerminals.delete(sessionId);
+    this.generatingTerminals.delete(cwd);
   }
 
   /** Reap any existing generating row for this session (stop pane + cleanup dir + drop row). */
   private reapGenerating(sessionId: string): void {
     const existing = this.deps.store.getRecap(sessionId);
     if (!existing || existing.state !== "generating") return;
-    void this.reapPane(sessionId, existing.cwd);
+    void this.reapPane(existing.cwd);
     this._cleanup(existing.cwd);
     this.deps.store.dropRecap(sessionId);
   }
@@ -811,7 +815,7 @@ export class RecapService {
           argv,
           apiKeyPassthroughEnv(false),
         );
-        this.generatingTerminals.set(id, started.terminalId);
+        this.generatingTerminals.set(cwd, started.terminalId);
       } catch (err) {
         this._cleanup(cwd);
         this.putFailureRecap(session, "launch-failed", err, head, base);
@@ -1059,7 +1063,7 @@ export class RecapService {
       }
     } finally {
       // Always reap pane + tmpdir (spawn-recorded terminal first — see reapPane, #1852).
-      await this.reapPane(r.sessionId, r.cwd);
+      await this.reapPane(r.cwd);
       this._cleanup(r.cwd);
     }
   }

--- a/src/tab-reaper.ts
+++ b/src/tab-reaper.ts
@@ -6,6 +6,7 @@ import { OPTIMIZE_LABEL } from "./optimizer";
 import { MERGE_LABEL } from "./merge-suggest";
 import { AUTOPILOT_LABEL } from "./autopilot";
 import { NAMER_LABEL } from "./namer";
+import { RECOMMEND_LABEL } from "./prompt-recommend";
 import { VERIFY_KEY_LABEL } from "./verify-key";
 import { SHELLS } from "./json-tolerant";
 
@@ -53,6 +54,7 @@ export type ReapableHerdr = Pick<HerdrDriver, "closeTab" | "panes" | "paneForegr
  *  - `plan-review <desig>` — plan-gate reviewer (plan-gate.ts)
  *  - `pr-critic <repo>#<n>` — standalone PR critic (standalone-critic.ts)
  *  - `recap <desig>`     — recap generator (recap.ts)
+ *  - {@link RECOMMEND_LABEL}`<desig>` — prompt recommender (prompt-recommend.ts, #1852)
  *  - `rundown`           — herd-digest rundown (herd-digest.ts) — liveness-gated */
 export function isShepherdHelperLabel(label: string): boolean {
   return (
@@ -67,6 +69,7 @@ export function isShepherdHelperLabel(label: string): boolean {
     label.startsWith("plan-review ") ||
     label.startsWith("pr-critic ") ||
     label.startsWith("recap ") ||
+    label.startsWith(RECOMMEND_LABEL) ||
     label.startsWith(AUTOPILOT_LABEL)
   );
 }

--- a/src/tab-reaper.ts
+++ b/src/tab-reaper.ts
@@ -80,12 +80,17 @@ export function isShepherdHelperLabel(label: string): boolean {
 export interface ReapResult {
   /** Tab ids actually closed this sweep. */
   closed: string[];
-  /** Helper panes spared because their foreground held a non-shell proc (claude/node/etc.). */
+  /** Helper TABS spared because a pane's foreground held a non-shell proc (claude/node/etc.). */
   sparedLive: number;
-  /** Helper panes spared because process-info threw OR was empty/undeterminable (fail-closed). */
+  /** Helper TABS spared because a pane's process-info threw OR was empty/undeterminable
+   *  (fail-closed) — counted only when no pane was outright live. */
   sparedError: number;
-  /** Tab ids that were shell-only THIS sweep — feed back as `prevShellOnly` next sweep to debounce. */
+  /** Tab ids whose EVERY pane was shell-only THIS sweep — feed back as `prevShellOnly`
+   *  next sweep to debounce. */
   shellOnly: Set<string>;
+  /** True when `panes()` itself threw: the sweep did ZERO work (fail-closed) — the caller
+   *  must surface this instead of reading it as "nothing to do" (#1852). */
+  panesFailed: boolean;
 }
 
 /**
@@ -95,18 +100,29 @@ export interface ReapResult {
  * net for husks they can't reach — agents that crashed, or anything orphaned across a
  * shepherd restart (which clears in-memory review tracking). Returns a {@link ReapResult}.
  *
- * **Husk signal = per-pane process liveness (ground truth), not list-absence.** Under
+ * **Husk signal = process liveness (ground truth), not list-absence.** Under
  * herdr 0.7 an exited helper agent leaves its pane alive as an idle `zsh`, and that pane
  * STILL appears in `agent list` (#721) — so the old "absent from `agent list` ⇒ orphan"
- * signal never fires. Instead we ask herdr for each helper pane's foreground processes:
+ * signal never fires. Instead we ask herdr for each helper pane's foreground processes.
  *
- * - **non-shell proc present** (`claude` / `node` / `node-MainThread` / …) → live → spare
- *   (`sparedLive`).
- * - **process-info throws** (transient read failure / quirk) → spare (`sparedError`).
- * - **empty proc list** (undeterminable) → spare fail-closed (`sparedError`); we never
- *   reap on no evidence.
- * - **shell-only** (`procs.length > 0 && procs.every(SHELLS.has)`) → husk CANDIDATE this
- *   sweep.
+ * **Classification is per TAB, not per pane (#1852).** Reaping closes whole tabs, and a
+ * helper tab can hold MORE than one pane: a headless codex-exec role deliberately retains
+ * its root shell pane (`isHeadlessCodexExec`), and a failed best-effort root-pane close
+ * leaves a shell pane beside the agent pane. Judging panes independently let a sibling
+ * shell pane mark such a tab reap-eligible while its live pane merely counted as spared —
+ * two sweeps later the tab was closed WITH the live helper inside. So helper panes are
+ * grouped by tabId and the TAB is classified with fail-safe precedence:
+ *
+ * - **any pane live** (a non-shell proc: `claude` / `node` / …) → spare the whole tab
+ *   (`sparedLive`); remaining panes aren't inspected.
+ * - else **any pane errored/undeterminable** (process-info threw, or empty proc list) →
+ *   spare the whole tab fail-closed (`sparedError`); we never reap on partial evidence.
+ * - else — **every pane positively shell-only** (`procs.length > 0 && all in SHELLS`) →
+ *   husk CANDIDATE this sweep.
+ *
+ * A spared tab is NOT added to the returned `shellOnly` set, so a liveness/error spare
+ * also CLEARS any prior first-sighting — a tab hosting a live pane can never sit primed
+ * in the debounce waiting for its shell pane to be seen once more.
  *
  * **Two-sweep debounce.** herdr's own PTY is a `zsh` that runs the agent command, so a
  * just-spawned agent is briefly shell-only during its pre-`exec` window. To avoid reaping
@@ -114,10 +130,12 @@ export interface ReapResult {
  * (its tabId was in `prevShellOnly`). A first-time shell-only sighting is recorded in the
  * returned `shellOnly` set (caller threads it back in) but not closed.
  *
- * **`panes()` throw is fail-closed.** If `herdr.panes()` itself throws it's a transient
- * herdr read failure on a supported herdr — we reap nothing this sweep and preserve the
- * debounce set (return `prevShellOnly` unchanged) so a candidate isn't lost mid-debounce.
- * (A per-pane `paneForegroundProcs` throw is `sparedError`, see above.)
+ * **`panes()` throw is fail-closed AND flagged.** If `herdr.panes()` itself throws it's a
+ * transient herdr read failure on a supported herdr — we reap nothing this sweep and
+ * preserve the debounce set (return `prevShellOnly` unchanged) so a candidate isn't lost
+ * mid-debounce, and set `panesFailed` so the caller can log the zero-work sweep instead of
+ * mistaking it for "no husks" (#1852). (A per-pane `paneForegroundProcs` throw spares its
+ * tab as `sparedError`, see above.)
  *
  * Closed tabs are closed in arbitrary order — herdr 0.7 stable ids (#569, e.g. `w1:t1`)
  * don't retarget on close, so close order is irrelevant.
@@ -131,40 +149,149 @@ export async function reapOrphanTabs(
     panes = herdr.panes();
   } catch {
     // Transient herdr read failure on a supported herdr — fail closed: reap nothing this
-    // sweep, preserve the debounce set.
-    return { closed: [], sparedLive: 0, sparedError: 0, shellOnly: prevShellOnly };
+    // sweep, preserve the debounce set, and flag the zero-work sweep for the caller.
+    return {
+      closed: [],
+      sparedLive: 0,
+      sparedError: 0,
+      shellOnly: prevShellOnly,
+      panesFailed: true,
+    };
+  }
+
+  // Group helper panes by their owning tab — the reap unit is the TAB (#1852).
+  const byTab = new Map<string, typeof panes>();
+  for (const p of panes) {
+    if (!isShepherdHelperLabel(p.label)) continue;
+    const group = byTab.get(p.tabId);
+    if (group) group.push(p);
+    else byTab.set(p.tabId, [p]);
   }
 
   let sparedLive = 0;
   let sparedError = 0;
   const shellOnly = new Set<string>();
-  const toReap = new Set<string>(); // tabIds, deduped (helper tab is single-pane, but be defensive)
+  const toReap: string[] = [];
 
-  for (const p of panes) {
-    if (!isShepherdHelperLabel(p.label)) continue;
-    let procs: string[];
-    try {
-      procs = await herdr.paneForegroundProcs(p.paneId);
-    } catch {
-      sparedError++; // transient process-info failure — spare, do not fall back
-      continue;
+  for (const [tabId, group] of byTab) {
+    let live = false;
+    let undetermined = false;
+    for (const p of group) {
+      let procs: string[];
+      try {
+        procs = await herdr.paneForegroundProcs(p.paneId);
+      } catch {
+        undetermined = true; // transient process-info failure — no evidence for this pane
+        continue;
+      }
+      if (procs.length === 0) {
+        undetermined = true; // undeterminable — never reap on no evidence
+        continue;
+      }
+      if (!procs.every((n) => SHELLS.has(n))) {
+        live = true; // a non-shell proc is running — the tab hosts a live agent
+        break; // short-circuit: remaining panes can't change the classification
+      }
     }
-    if (procs.length === 0) {
-      sparedError++; // undeterminable — fail closed, never reap on no evidence
-      continue;
+    if (live) {
+      sparedLive++;
+      continue; // spared AND de-primed: not added to shellOnly
     }
-    if (!procs.every((n) => SHELLS.has(n))) {
-      sparedLive++; // a non-shell proc is running — live agent
-      continue;
+    if (undetermined) {
+      sparedError++;
+      continue; // fail-closed spare, likewise de-primed
     }
-    // shell-only: husk candidate this sweep
-    shellOnly.add(p.tabId);
-    if (prevShellOnly.has(p.tabId)) toReap.add(p.tabId); // debounce: shell-only twice running
+    // Every pane of the tab positively shell-only: husk candidate this sweep.
+    shellOnly.add(tabId);
+    if (prevShellOnly.has(tabId)) toReap.push(tabId); // debounce: shell-only twice running
   }
 
-  const closed = [...toReap];
-  for (const tabId of closed) await herdr.closeTab(tabId);
-  return { closed, sparedLive, sparedError, shellOnly };
+  for (const tabId of toReap) await herdr.closeTab(tabId);
+  return { closed: toReap, sparedLive, sparedError, shellOnly, panesFailed: false };
+}
+
+// ── Orphan-tab sweep orchestration (#1852) ───────────────────────────────────
+
+export interface OrphanTabSweeperDeps {
+  /** One reconciliation pass — the caller binds `reapOrphanTabs(herdr, prev)`. */
+  reap: (prevShellOnly: Set<string>) => Promise<ReapResult>;
+  /** Timer seam (production: `setTimeout`); injectable so tests drive time by hand. */
+  schedule: (fn: () => void, ms: number) => void;
+  /** Skip triggers while a herdr update is in flight (production: `maintenance.active`). */
+  maintenanceActive: () => boolean;
+  /** Observability tap — every completed pass, including `panesFailed` zero-work ones. */
+  onResult?: (r: ReapResult) => void;
+  onError?: (err: unknown) => void;
+  /** Delay before a self-scheduled confirming pass. Must comfortably exceed the pre-`exec`
+   *  shell-only window the two-sweep debounce guards (production: 30s). */
+  confirmDelayMs: number;
+}
+
+/**
+ * Serialized, self-confirming orchestrator around {@link reapOrphanTabs} (#1852). The old
+ * wiring fired boot sweeps at 5s/45s as independent `void` calls: on a large inventory the
+ * 5s pass (which awaits per-pane process-info sequentially) could still be running at 45s,
+ * both passes then started from the SAME debounce set, and neither was guaranteed to be
+ * the confirming pass — while the in-memory debounce also reset on every restart.
+ *
+ * Contract:
+ * - **Serialized + coalesced:** at most one pass in flight and at most one queued. A
+ *   trigger during a running pass queues exactly one follow-up, which starts only after
+ *   the current pass completes — and receives its predecessor's `shellOnly` set, so a
+ *   queued pass is always a REAL confirming pass, never a same-set replay.
+ * - **Self-confirming:** whenever a pass records NEW first-sightings (tabs shell-only now
+ *   but not in the previous set), one confirming pass is scheduled `confirmDelayMs` later.
+ *   Convergence therefore does not depend on WHICH external trigger sighted a husk (boot,
+ *   hourly, or queued): any husk is closed ~confirmDelayMs after its first sighting, any
+ *   single stable window after any restart converges, and a skipped boot sweep merely
+ *   defers to the next trigger instead of losing an hour. Steady state schedules nothing:
+ *   a pass whose sightings are all repeats (or that reaps them) sights nothing new.
+ * - `maintenanceActive` skips triggers outright (matching the old wiring) and drains a
+ *   queued follow-up without running it — the next scheduled trigger re-enters.
+ */
+export function createOrphanTabSweeper(deps: OrphanTabSweeperDeps): { trigger: () => void } {
+  let running = false;
+  let queued = false;
+  let prev = new Set<string>();
+
+  const run = async (): Promise<void> => {
+    running = true;
+    try {
+      do {
+        queued = false;
+        if (deps.maintenanceActive()) break;
+        const before = prev;
+        let r: ReapResult;
+        try {
+          r = await deps.reap(before);
+        } catch (err) {
+          deps.onError?.(err);
+          break;
+        }
+        prev = r.shellOnly;
+        deps.onResult?.(r);
+        for (const tabId of r.shellOnly) {
+          if (!before.has(tabId)) {
+            deps.schedule(trigger, deps.confirmDelayMs);
+            break; // one confirming pass per sighting pass
+          }
+        }
+      } while (queued);
+    } finally {
+      running = false;
+    }
+  };
+
+  const trigger = (): void => {
+    if (deps.maintenanceActive()) return;
+    if (running) {
+      queued = true;
+      return;
+    }
+    void run();
+  };
+
+  return { trigger };
 }
 
 // ── Stranded review-worktree disk sweep (#721) ───────────────────────────────

--- a/src/tab-reaper.ts
+++ b/src/tab-reaper.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import type { HerdrDriver } from "./herdr";
+import type { HerdrDriver, HerdrPane } from "./herdr";
 import { PROBE_NAME } from "./usage-probe";
 import { DISTILL_LABEL } from "./distiller";
 import { OPTIMIZE_LABEL } from "./optimizer";
@@ -159,45 +159,18 @@ export async function reapOrphanTabs(
     };
   }
 
-  // Group helper panes by their owning tab — the reap unit is the TAB (#1852).
-  const byTab = new Map<string, typeof panes>();
-  for (const p of panes) {
-    if (!isShepherdHelperLabel(p.label)) continue;
-    const group = byTab.get(p.tabId);
-    if (group) group.push(p);
-    else byTab.set(p.tabId, [p]);
-  }
-
   let sparedLive = 0;
   let sparedError = 0;
   const shellOnly = new Set<string>();
   const toReap: string[] = [];
 
-  for (const [tabId, group] of byTab) {
-    let live = false;
-    let undetermined = false;
-    for (const p of group) {
-      let procs: string[];
-      try {
-        procs = await herdr.paneForegroundProcs(p.paneId);
-      } catch {
-        undetermined = true; // transient process-info failure — no evidence for this pane
-        continue;
-      }
-      if (procs.length === 0) {
-        undetermined = true; // undeterminable — never reap on no evidence
-        continue;
-      }
-      if (!procs.every((n) => SHELLS.has(n))) {
-        live = true; // a non-shell proc is running — the tab hosts a live agent
-        break; // short-circuit: remaining panes can't change the classification
-      }
-    }
-    if (live) {
+  for (const [tabId, group] of groupHelperPanesByTab(panes)) {
+    const cls = await classifyHelperTab(herdr, group);
+    if (cls === "live") {
       sparedLive++;
       continue; // spared AND de-primed: not added to shellOnly
     }
-    if (undetermined) {
+    if (cls === "undetermined") {
       sparedError++;
       continue; // fail-closed spare, likewise de-primed
     }
@@ -208,6 +181,46 @@ export async function reapOrphanTabs(
 
   for (const tabId of toReap) await herdr.closeTab(tabId);
   return { closed: toReap, sparedLive, sparedError, shellOnly, panesFailed: false };
+}
+
+/** Group helper-labeled panes by their owning tab — the reap unit is the TAB (#1852). */
+function groupHelperPanesByTab(panes: HerdrPane[]): Map<string, HerdrPane[]> {
+  const byTab = new Map<string, HerdrPane[]>();
+  for (const p of panes) {
+    if (!isShepherdHelperLabel(p.label)) continue;
+    const group = byTab.get(p.tabId);
+    if (group) group.push(p);
+    else byTab.set(p.tabId, [p]);
+  }
+  return byTab;
+}
+
+/** Classify one helper TAB from its panes' foreground processes, with the fail-safe
+ *  precedence documented on {@link reapOrphanTabs}: any live pane wins (short-circuit),
+ *  else any errored/empty pane makes the tab undetermined, else it is positively
+ *  shell-only. */
+async function classifyHelperTab(
+  herdr: ReapableHerdr,
+  group: HerdrPane[],
+): Promise<"live" | "undetermined" | "shell-only"> {
+  let undetermined = false;
+  for (const p of group) {
+    let procs: string[];
+    try {
+      procs = await herdr.paneForegroundProcs(p.paneId);
+    } catch {
+      undetermined = true; // transient process-info failure — no evidence for this pane
+      continue;
+    }
+    if (procs.length === 0) {
+      undetermined = true; // undeterminable — never reap on no evidence
+      continue;
+    }
+    if (!procs.every((n) => SHELLS.has(n))) {
+      return "live"; // a non-shell proc runs here — remaining panes can't change this
+    }
+  }
+  return undetermined ? "undetermined" : "shell-only";
 }
 
 // ── Orphan-tab sweep orchestration (#1852) ───────────────────────────────────

--- a/src/transient-helper-lifecycle.ts
+++ b/src/transient-helper-lifecycle.ts
@@ -1,0 +1,51 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Shared plumbing for the synchronous block-and-clean transient helpers (verify-key /
+ * namer / autopilot stop-classifier / prompt-recommend): each spawns a short-lived agent
+ * in a throwaway tmpdir, polls for its output file, and reaps pane + dir in a `finally`.
+ * The four copies were byte-identical and drifting apart is exactly how teardown leaks
+ * recur (#1852, and #1135 → #1136 → #1147 before it) — so the pattern lives once, here.
+ * Each helper keeps its injectable seams (`sleep` / `makeTmpDir` / `cleanup`); these are
+ * only the shared defaults behind them.
+ */
+
+export const realSleep = (ms: number): Promise<void> => new Promise<void>((r) => setTimeout(r, ms));
+
+/** mkdtemp under the OS tmpdir with the helper's prefix (e.g. `"shepherd-namer-"`). */
+export function makeHelperTmpDir(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+/** Best-effort recursive removal of a helper's throwaway tmpdir. */
+export function cleanupHelperDir(cwd: string): void {
+  try {
+    rmSync(cwd, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * The shared `finally` body: stop the helper's pane — closing its spawn-recorded tab,
+ * see `herdr.stop` (#1852) — then clean its tmpdir. Both steps tolerate an already-dead
+ * pane / missing dir; `terminalId`/`cwd` are null/empty when the run failed before the
+ * corresponding resource existed.
+ */
+export async function reapHelperRun(
+  herdr: { stop(terminalId: string): Promise<void> },
+  terminalId: string | null,
+  cwd: string | null,
+  cleanup: (cwd: string) => void,
+): Promise<void> {
+  if (terminalId) {
+    try {
+      await herdr.stop(terminalId);
+    } catch {
+      /* best-effort */
+    }
+  }
+  if (cwd) cleanup(cwd);
+}

--- a/src/verify-key.ts
+++ b/src/verify-key.ts
@@ -1,7 +1,12 @@
-import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import type { HerdrDriver } from "./herdr";
+import {
+  cleanupHelperDir,
+  makeHelperTmpDir,
+  reapHelperRun,
+  realSleep,
+} from "./transient-helper-lifecycle";
 import { isApiKeyMode, isApiKeyConfigured, apiKeyPassthroughEnv } from "./spawn-auth";
 import { buildTransientAgentArgv } from "./transient-agent-argv";
 
@@ -77,11 +82,7 @@ function verifyPrompt(): string {
   ].join(" ");
 }
 
-const realSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
-
-function defaultMakeTmpDir(): string {
-  return mkdtempSync(join(tmpdir(), "shepherd-verify-"));
-}
+const defaultMakeTmpDir = (): string => makeHelperTmpDir("shepherd-verify-");
 function defaultReadSentinel(cwd: string): string | null {
   const p = join(cwd, VERIFY_FILE);
   if (!existsSync(p)) return null;
@@ -89,13 +90,6 @@ function defaultReadSentinel(cwd: string): string | null {
     return readFileSync(p, "utf8");
   } catch {
     return null; // partial write; try again next poll
-  }
-}
-function defaultCleanup(cwd: string): void {
-  try {
-    rmSync(cwd, { recursive: true, force: true });
-  } catch {
-    /* best-effort */
   }
 }
 
@@ -137,7 +131,7 @@ export async function verifyApiKey(deps: VerifyKeyDeps): Promise<VerifyKeyResult
   const {
     makeTmpDir = defaultMakeTmpDir,
     readSentinel = defaultReadSentinel,
-    cleanup = defaultCleanup,
+    cleanup = cleanupHelperDir,
     now = Date.now,
     sleep = realSleep,
     timeoutMs = 60_000, // cold `claude` startup + a haiku turn needs headroom
@@ -179,13 +173,6 @@ export async function verifyApiKey(deps: VerifyKeyDeps): Promise<VerifyKeyResult
     }
     return { ok: false, reason: "timeout" };
   } finally {
-    if (terminalId) {
-      try {
-        await deps.herdr.stop(terminalId);
-      } catch {
-        /* best-effort */
-      }
-    }
-    if (cwd) cleanup(cwd);
+    await reapHelperRun(deps.herdr, terminalId, cwd, cleanup);
   }
 }

--- a/test/distiller.test.ts
+++ b/test/distiller.test.ts
@@ -1315,3 +1315,62 @@ test("reapOrphans is a no-op when herdr is unavailable", async () => {
   expect(() => svc.reapOrphans()).not.toThrow();
   expect(closes).toBe(0);
 });
+
+// ── Deterministic tab-baseline (#1852) ────────────────────────────────────────
+//
+// Repeated full lifecycles against a fake herdr that models the #1852 driver contract
+// (stop() closes the tab recorded at start(), whether or not the helper still appears
+// in any live list). Every finalization path must return the open-tab set to baseline —
+// a path that skips teardown, or passes a dead handle, leaves a tab behind and fails.
+
+test("tab baseline: repeated distill runs (success + timeout) leave zero open tabs (#1852)", async () => {
+  const store = new SessionStore(":memory:");
+  seedSignals(store, "/r", 3);
+  let t = 1_000;
+  let n = 0;
+  const openTabs = new Set<string>();
+  const byTerminal = new Map<string, string>();
+  let proposals: unknown = null;
+  const deps = {
+    store,
+    herdr: {
+      start: async () => {
+        const terminalId = `d${++n}`;
+        byTerminal.set(terminalId, `tab-${n}`);
+        openTabs.add(`tab-${n}`);
+        return { terminalId };
+      },
+      stop: async (terminalId: string) => {
+        const tab = byTerminal.get(terminalId);
+        if (tab) openTabs.delete(tab);
+      },
+    } as any,
+    scratch: { create: () => ({ dir: `/scratch/${n}` }), remove: () => {} },
+    onChange: () => {},
+    now: () => t,
+    timeoutMs: 5_000,
+    minSignals: 3,
+    writeSignals: () => {},
+    readProposals: () => proposals,
+  };
+  const d = new DistillerService(deps as any);
+
+  for (let run = 1; run <= 3; run++) {
+    // Success lifecycle: spawn → proposals ready → finalize.
+    proposals = { rules: [{ rule: `r${run}`, rationale: "x", evidence: ["e"] }] };
+    await d.distillNow("/r");
+    expect(openTabs.size).toBe(1);
+    await d.tick();
+    await Bun.sleep(0); // finalize's stop is fire-and-forget — let it settle
+    expect(openTabs.size).toBe(0);
+
+    // Timeout lifecycle: spawn → proposals never written → timeout finalize.
+    proposals = null;
+    await d.distillNow("/r");
+    t += 6_000;
+    await d.tick();
+    await Bun.sleep(0);
+    expect(openTabs.size).toBe(0);
+  }
+  expect(n).toBe(6); // six real spawns happened; all six tabs were closed
+});

--- a/test/herd-digest.test.ts
+++ b/test/herd-digest.test.ts
@@ -377,6 +377,31 @@ test("tick: generating row, no verdict, past timeout → 'failed' (not ready, no
   expect(cleaned).toContain("/tmp/rundown-timeout");
 });
 
+// #1852: a rundown helper that exits cleanly before finalize has vanished from `agent list`,
+// so the old cwd re-lookup returned "" and stop("") silently no-oped, leaking the tab. The
+// finalizer must stop the terminalId recorded at spawn (mirrors the recap regression).
+test("tick finalize after the agent exited: stops the spawn-recorded terminal, not the cwd re-lookup (#1852)", async () => {
+  const store = makeStore([makeSession()]);
+  const herdr = makeHerdr();
+  const cleaned: string[] = [];
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => DAY1,
+    verdict: VALID_VERDICT_JSON,
+    cleanup: (d) => cleaned.push(d),
+  });
+
+  expect(await svc.generate()).toBe("started"); // records tid-1 as the run's teardown handle
+  herdr.livePanes.length = 0; // the helper exits: gone from agent list, husk tab remains
+
+  await svc.tick(); // verdict present → finalize
+
+  expect(store.getHerdDigest(dayKeyFor(DAY1))?.state).toBe("ready");
+  expect(herdr.stopped).toEqual(["tid-1"]); // the spawn handle — never "" (the silent no-op)
+  expect(cleaned.length).toBe(1);
+});
+
 test("tick: generating row, unparseable verdict → 'failed'", async () => {
   const dayKey = dayKeyFor(DAY1);
   const row: HerdDigest = {

--- a/test/herd-digest.test.ts
+++ b/test/herd-digest.test.ts
@@ -1221,3 +1221,38 @@ test("generate: null pausedReason (ready) → epicsToLand has no pausedReason fi
   const row = store.getHerdDigest(dayKeyFor(DAY1));
   expect(row?.epicsToLand.at(0)?.pausedReason).toBeUndefined();
 });
+
+// #1852 critic follow-up: mirrors the recap race regression — the spawn-handle map is
+// keyed by the RUN's mkdtemp-unique cwd, not the dayKey, so an old finalizer parked on
+// an await can never stop + unmap a forced replacement's live terminal.
+test("an old finalizer racing a forced regenerate never stops the replacement run (#1852)", async () => {
+  const store = makeStore([makeSession()]);
+  const herdr = makeHerdr();
+  let raced = false;
+  let svcRef: HerdDigestService | null = null;
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => DAY1,
+    verdict: VALID_VERDICT_JSON,
+    readUsage: async () => {
+      if (!raced && svcRef) {
+        raced = true;
+        await svcRef.regenerate();
+      }
+      return null;
+    },
+  });
+  svcRef = svc;
+
+  expect(await svc.generate()).toBe("started"); // run A (tid-1)
+
+  await svc.tick(); // finalize A; mid-finalize the hook force-regenerates → run B (tid-2)
+
+  expect(herdr.started.length).toBe(2);
+  expect(herdr.stopped).toEqual(["tid-1"]); // A's own terminal — NEVER the replacement's
+
+  await svc.tick(); // the replacement finalizes normally off its own retained handle
+  expect(herdr.stopped).toEqual(["tid-1", "tid-2"]);
+  expect(store.getHerdDigest(dayKeyFor(DAY1))?.state).toBe("ready");
+});

--- a/test/herdr-socket-driver.test.ts
+++ b/test/herdr-socket-driver.test.ts
@@ -376,6 +376,79 @@ describe("SocketHerdrDriver — socket-backed async writes (#1553, #1567)", () =
   });
 });
 
+describe("SocketHerdrDriver — spawn-handle ledger (#1852)", () => {
+  // Transport parity for the recorded-tab-first stop(); the full behavior matrix lives in
+  // test/herdr.test.ts — these pin that the socket driver records at start and closes via
+  // tab.list verification, agent-list-free on the normal path.
+
+  /** Client whose tab.list / agent.list replies are supplied per test; start() replies
+   *  are wired so the ledger records t1 → tab_new under the label "TASK-01". */
+  function ledgerClient(tabs: () => unknown[], agents: () => unknown[]) {
+    const rec: { method: string; params: unknown }[] = [];
+    const impl = (method: string, params: unknown): unknown => {
+      rec.push({ method, params });
+      switch (method) {
+        case "workspace.list":
+          return { type: "workspace_list", workspaces: [{ workspace_id: "w1" }] };
+        case "tab.create":
+          return { type: "tab_created", tab: { tab_id: "tab_new" }, root_pane: { pane_id: "p" } };
+        case "agent.start":
+          return { type: "agent_started", agent: { ...agentBody.agents[0], tab_id: "tab_new" } };
+        case "tab.list":
+          return { type: "tab_list", tabs: tabs() };
+        case "agent.list":
+          return { agents: agents() };
+        default:
+          return { type: "ok" };
+      }
+    };
+    return { rec, client: { request: mock(impl) } as unknown as HerdrSocketClient };
+  }
+
+  it("tabsAsync() requests tab.list and returns the parsed tabs", async () => {
+    const client = fakeClient(() => ({
+      tabs: [{ tab_id: "w:1", label: "recap TASK-2", agent_status: "unknown", workspace_id: "w" }],
+    }));
+    const driver = new SocketHerdrDriver(client, fakeCli() as unknown as HerdrDriver);
+
+    expect(await driver.tabsAsync()).toEqual([
+      { tabId: "w:1", label: "recap TASK-2", agentStatus: "unknown", workspaceId: "w" },
+    ]);
+    expect(client.request).toHaveBeenCalledWith("tab.list", {});
+  });
+
+  it("stop() closes the spawn-recorded tab with zero agent.list calls when the agent is gone", async () => {
+    const { rec, client } = ledgerClient(
+      () => [{ tab_id: "tab_new", label: "TASK-01" }],
+      () => [], // helper exited — absent from agent.list; only its husk tab remains
+    );
+    const driver = new SocketHerdrDriver(client, fakeCli() as unknown as HerdrDriver);
+    await driver.start("TASK-01", "/repo/worktree", ["claude", "go"]);
+    const startEnd = rec.length;
+
+    await driver.stop("t1");
+
+    expect(rec.slice(startEnd).map((r) => r.method)).toEqual(["tab.list", "tab.close"]);
+    expect(rec.at(-1)!.params).toEqual({ tab_id: "tab_new" });
+  });
+
+  it("stop() spares a label-mismatched recorded tab and falls back to agent.list truth", async () => {
+    const { rec, client } = ledgerClient(
+      () => [{ tab_id: "tab_new", label: "someone-elses-session" }],
+      () => [{ terminal_id: "t1", tab_id: "tab_current" }],
+    );
+    const driver = new SocketHerdrDriver(client, fakeCli() as unknown as HerdrDriver);
+    await driver.start("TASK-01", "/repo/worktree", ["claude", "go"]);
+    const startEnd = rec.length;
+
+    await driver.stop("t1");
+
+    const stopCalls = rec.slice(startEnd);
+    expect(stopCalls.map((r) => r.method)).toEqual(["tab.list", "agent.list", "tab.close"]);
+    expect(stopCalls.at(-1)!.params).toEqual({ tab_id: "tab_current" });
+  });
+});
+
 /** Fake socket client exposing controllable `ping`/`close` spies for `selectHerdrDriver`. */
 function fakePingClient(impl: () => Promise<{ protocol: number }>) {
   return {

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -387,6 +387,152 @@ test("relabel: no-op (no throw) when the agent is gone", async () => {
   await expect(h.relabel("term_gone", "fresh-name")).resolves.toBeUndefined();
 });
 
+// ── Spawn-handle ledger: recorded-tab-first stop() (#1852) ────────────────────────────
+//
+// A transient helper that exits (or dies milliseconds after `agent.start`) vanishes from
+// `agent list` while its tab persists as a husk. The old stop() resolved the tab through
+// `agent list` and silently no-oped in that case — 316 leaked helper tabs exhausted
+// herdr's FD limit. These tests pin the new contract: for a spawn this driver started,
+// stop() closes the tab recorded at start() via a tab-list label verify, with ZERO
+// `agent list` calls on that normal path.
+
+/** Runs a full start() (recording term_started → t_new / "flatten" in the ledger), then
+ *  routes every subsequent herdr call through `afterStart`. Returns the shared call log
+ *  and the index where post-start calls begin. */
+async function mkStartedDriver(
+  afterStart: (args: string[]) => string,
+): Promise<{ d: HerdrDriver; calls: string[][]; startEnd: number }> {
+  const calls: string[][] = [];
+  let started = false;
+  const runner = (args: string[]): string => {
+    calls.push(args);
+    if (!started) return reply(args, WORKSPACE_LIST);
+    return afterStart(args);
+  };
+  const d = mkDriver(runner);
+  await d.start("flatten", "/wt/a", ["claude", "go"]);
+  started = true;
+  return { d, calls, startEnd: calls.length };
+}
+
+test("stop: closes the spawn-recorded tab when the agent never appears in agent list (fast exit)", async () => {
+  const { d, calls, startEnd } = await mkStartedDriver((args) => {
+    if (args[0] === "tab" && args[1] === "list") return TAB_LIST_WITH_NEW;
+    if (args[0] === "agent" && args[1] === "list") return EMPTY_LIST;
+    return "{}";
+  });
+  await d.stop("term_started");
+  const stopCalls = calls.slice(startEnd);
+  expect(stopCalls).toContainEqual(["tab", "close", "t_new"]);
+  // The normal teardown path never touches `agent list` — that dependency was the leak.
+  expect(stopCalls.some((c) => c[0] === "agent" && c[1] === "list")).toBe(false);
+});
+
+test("stop: a second stop after the recorded-tab close is a plain fallback no-op (entry taken)", async () => {
+  const { d, calls, startEnd } = await mkStartedDriver((args) => {
+    if (args[0] === "tab" && args[1] === "list") return TAB_LIST_WITH_NEW;
+    if (args[0] === "agent" && args[1] === "list") return EMPTY_LIST;
+    return "{}";
+  });
+  await d.stop("term_started");
+  await d.stop("term_started");
+  const closes = calls.slice(startEnd).filter((c) => c[0] === "tab" && c[1] === "close");
+  expect(closes).toEqual([["tab", "close", "t_new"]]); // exactly one close, no double-fire
+});
+
+test("stop: never closes the recorded tab on a label mismatch — falls back to agent-list truth", async () => {
+  // A herdr daemon restart can re-mint a stable tab id for someone else's tab; closing
+  // the recorded id blind would kill live work. The mismatch must fall back to the
+  // current agent list instead.
+  const { d, calls, startEnd } = await mkStartedDriver((args) => {
+    if (args[0] === "tab" && args[1] === "list") {
+      return JSON.stringify({
+        result: {
+          type: "tab_list",
+          tabs: [{ tab_id: "t_new", label: "someone-elses-session", workspace_id: "w1" }],
+        },
+      });
+    }
+    if (args[0] === "agent" && args[1] === "list") {
+      return JSON.stringify({
+        result: { agents: [{ terminal_id: "term_started", tab_id: "t_current" }] },
+      });
+    }
+    return "{}";
+  });
+  await d.stop("term_started");
+  const stopCalls = calls.slice(startEnd);
+  expect(stopCalls).not.toContainEqual(["tab", "close", "t_new"]);
+  expect(stopCalls).toContainEqual(["tab", "close", "t_current"]);
+});
+
+test("stop: recorded tab already gone from the tab list → nothing to close, no agent-list call", async () => {
+  const { d, calls, startEnd } = await mkStartedDriver((args) => {
+    if (args[0] === "tab" && args[1] === "list") return EMPTY_TABS;
+    return "{}";
+  });
+  await d.stop("term_started");
+  const stopCalls = calls.slice(startEnd);
+  expect(stopCalls.some((c) => c[0] === "tab" && c[1] === "close")).toBe(false);
+  expect(stopCalls.some((c) => c[0] === "agent" && c[1] === "list")).toBe(false);
+});
+
+test("stop: tab-list failure falls back to the agent-list path (never weaker than before)", async () => {
+  const { d, calls, startEnd } = await mkStartedDriver((args) => {
+    if (args[0] === "tab" && args[1] === "list") throw new Error("herdr hiccup");
+    if (args[0] === "agent" && args[1] === "list") {
+      return JSON.stringify({
+        result: { agents: [{ terminal_id: "term_started", tab_id: "t_live" }] },
+      });
+    }
+    return "{}";
+  });
+  await d.stop("term_started");
+  expect(calls.slice(startEnd)).toContainEqual(["tab", "close", "t_live"]);
+});
+
+test("stop after relabel: the ledger label follows the tab rename, recorded path still closes", async () => {
+  const { d, calls } = await mkStartedDriver((args) => {
+    if (args[0] === "agent" && args[1] === "list") {
+      return JSON.stringify({
+        result: { agents: [{ terminal_id: "term_started", tab_id: "t_new", name: "flatten" }] },
+      });
+    }
+    if (args[0] === "tab" && args[1] === "list") {
+      return JSON.stringify({
+        result: {
+          type: "tab_list",
+          tabs: [{ tab_id: "t_new", label: "renamed", workspace_id: "w1" }],
+        },
+      });
+    }
+    return "{}";
+  });
+  await d.relabel("term_started", "renamed");
+  const relabelEnd = calls.length;
+  await d.stop("term_started");
+  const stopCalls = calls.slice(relabelEnd);
+  expect(stopCalls).toContainEqual(["tab", "close", "t_new"]);
+  expect(stopCalls.some((c) => c[0] === "agent" && c[1] === "list")).toBe(false);
+});
+
+test('stop(""): silent no-op with zero herdr calls (cwd-reconcile callers pass "" deliberately)', async () => {
+  const calls: string[][] = [];
+  const d = mkDriver((args) => {
+    calls.push(args);
+    return FIXTURE;
+  });
+  await d.stop("");
+  expect(calls).toEqual([]);
+});
+
+test("tabsAsync mirrors tabs(): parses the tab list off the async runner", async () => {
+  const d = mkDriver((args) => (args[0] === "tab" && args[1] === "list" ? TAB_LIST : FIXTURE));
+  const t = await d.tabsAsync();
+  expect(t.length).toBe(3);
+  expect(t[1]).toMatchObject({ tabId: "w:2", label: "review TASK-09", agentStatus: "unknown" });
+});
+
 test("mapState maps herdr states to shepherd status", async () => {
   expect(mapState("working")).toBe("running");
   expect(mapState("blocked")).toBe("blocked");

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -2024,3 +2024,59 @@ test("operator-language: reviewer prompt reads operatorLanguage per spawn, not c
   expect(calls).toBe(2);
   expect(h.started[1].argv.at(-1)).toContain("German");
 });
+
+// ── Deterministic tab-baseline (#1852) ────────────────────────────────────────
+//
+// Repeated full reviewer lifecycles against a fake herdr that models the #1852 driver
+// contract (stop() closes the tab recorded at start(), whether or not the reviewer still
+// appears in any live list). Every finalization path must return the open-tab set to
+// baseline — a path that skips teardown, or passes a dead handle, leaves a tab behind.
+
+test("tab baseline: repeated plan reviews (approve + timeout + cancel) leave zero open tabs (#1852)", async () => {
+  let t = 1_000;
+  let n = 0;
+  const openTabs = new Set<string>();
+  const byTerminal = new Map<string, string>();
+  let verdict: any = null;
+  const h = harness({
+    herdr: {
+      start: async () => {
+        const terminalId = `t${++n}`;
+        byTerminal.set(terminalId, `tab-${n}`);
+        openTabs.add(`tab-${n}`);
+        return { terminalId };
+      },
+      stop: async (terminalId: string) => {
+        const tab = byTerminal.get(terminalId);
+        if (tab) openTabs.delete(tab);
+      },
+      list: () => [],
+    },
+    readVerdict: () => verdict,
+    now: () => t,
+    timeoutMs: 5_000,
+  });
+
+  for (let run = 1; run <= 2; run++) {
+    // Approve lifecycle.
+    verdict = { decision: "approve", summary: "ok", body: "B", findings: [] };
+    await h.svc.consider(planningSession() as any);
+    expect(openTabs.size).toBe(1);
+    await h.svc.tick();
+    expect(openTabs.size).toBe(0);
+
+    // Timeout lifecycle: verdict never written, clock passes timeoutMs.
+    verdict = null;
+    await h.svc.consider(planningSession() as any);
+    t += 6_000;
+    await h.svc.tick();
+    expect(openTabs.size).toBe(0);
+
+    // Cancellation lifecycle: session archived mid-review.
+    await h.svc.consider(planningSession() as any);
+    h.svc.forget("s1");
+    await Bun.sleep(0); // reapReviewer's stop is fire-and-forget — let it settle
+    expect(openTabs.size).toBe(0);
+  }
+  expect(n).toBe(6); // six real spawns; all six tabs were closed
+});

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -612,6 +612,61 @@ test("tick timeout: generating row, no verdict, past timeout → state 'failed',
   expect(cleaned).toContain("/tmp/recap-timeout");
 });
 
+// #1852 (pane 158): a short-lived recap helper exits cleanly BEFORE finalize runs, so it has
+// vanished from `agent list` while its tab persists as a husk. The old teardown resolved the
+// terminal by cwd at finalize time — "" once the agent exited — and stop("") silently no-oped,
+// leaking the tab (97 recap husks at the incident). The finalizer must stop the terminalId
+// recorded at spawn.
+test("tick finalize after the agent exited: stops the spawn-recorded terminal, not the cwd re-lookup (#1852)", async () => {
+  const s = makeSession({ status: "idle", auto: false });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+  const cleaned: string[] = [];
+  let t = 100_000;
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => t,
+    idleThresholdMs: 120_000,
+    verdictJson: VALID_VERDICT_JSON,
+    cleanup: (d) => cleaned.push(d),
+  });
+
+  await svc.sweep(); // stamp
+  t = 230_000;
+  await svc.sweep(); // spawn — the service records tid-1 as the run's teardown handle
+  expect(herdr.started.length).toBe(1);
+
+  herdr.livePanes.length = 0; // the helper exits: gone from agent list, husk tab remains
+
+  await svc.tick(); // verdict present → finalize
+
+  expect(store.getRecap("s1")?.state).toBe("ready");
+  expect(herdr.stopped).toEqual(["tid-1"]); // the spawn handle — never "" (the silent no-op)
+  expect(cleaned.length).toBe(1);
+});
+
+test("regenerate while generating: reapGenerating stops the spawn-recorded terminal after the agent exited (#1852)", async () => {
+  const s = makeSession({ status: "idle", auto: false });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+  let t = 100_000;
+  const svc = buildSvc({ store, herdr, nowFn: () => t, idleThresholdMs: 120_000 });
+
+  await svc.sweep(); // stamp
+  t = 230_000;
+  await svc.sweep(); // spawn tid-1
+  expect(herdr.started.length).toBe(1);
+
+  herdr.livePanes.length = 0; // old helper exited — cwd re-lookup would yield ""
+
+  const result = await svc.regenerate(s); // reaps the stale generating run, spawns fresh
+
+  expect(result).toBe("started");
+  expect(herdr.started.length).toBe(2);
+  expect(herdr.stopped).toContain("tid-1"); // the stale run's spawn handle, not ""
+});
+
 test("tick no verdict logs Codex recap spawn context without prompt text", async () => {
   const rec = makeRecap({
     state: "generating",

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -2297,3 +2297,73 @@ test("considerForArchive: same head, base change only via transient fallback →
   expect(herdr.started.length).toBe(0);
   expect(store.getRecap("s1")?.base).toBe("main"); // untouched
 });
+
+// ── Deterministic tab-baseline (#1852) ────────────────────────────────────────
+//
+// Repeated full recap lifecycles against a fake herdr whose stop() closes the tab
+// recorded at start() (the #1852 driver contract), with the helper EXITED before every
+// teardown — the exact condition under which the old cwd re-lookup leaked. Every path
+// must return the open-tab set to baseline.
+
+test("tab baseline: repeated recap runs (success + timeout + regenerate-reap) leave zero open tabs (#1852)", async () => {
+  const s = makeSession({ status: "idle", auto: false });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+  const openTabs = new Set<string>();
+  const byTerminal = new Map<string, string>();
+  const origStart = herdr.start;
+  herdr.start = async (label, cwd, argv, env) => {
+    const r = await origStart(label, cwd, argv, env);
+    byTerminal.set(r.terminalId, `tab-${r.terminalId}`);
+    openTabs.add(`tab-${r.terminalId}`);
+    return r;
+  };
+  herdr.stop = async (id) => {
+    const tab = byTerminal.get(id);
+    if (tab) openTabs.delete(tab);
+  };
+
+  let t = 100_000;
+  let read: VerdictRead<unknown> = { status: "absent" };
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => t,
+    idleThresholdMs: 120_000,
+    timeoutMs: 300_000,
+    readVerdictFn: () => read,
+  });
+
+  // Run 1 — sweep-spawned success, helper exits before finalize.
+  await svc.sweep(); // stamp
+  t = 230_000;
+  await svc.sweep(); // spawn tid-1
+  expect(openTabs.size).toBe(1);
+  herdr.livePanes.length = 0; // gone from agent list — the old silent-no-op condition
+  read = { status: "parsed", value: VALID_VERDICT_JSON, repaired: false };
+  await svc.tick();
+  expect(openTabs.size).toBe(0);
+
+  // Run 2 — regenerate over the ready row, then time out with the helper gone.
+  read = { status: "absent" };
+  expect(await svc.regenerate(s)).toBe("started"); // spawn tid-2
+  expect(openTabs.size).toBe(1);
+  herdr.livePanes.length = 0;
+  t += 400_000; // past timeoutMs
+  await svc.tick();
+  expect(openTabs.size).toBe(0);
+
+  // Runs 3+4 — regenerate mid-generating: reapGenerating stops the stale run, the
+  // replacement finalizes normally.
+  expect(await svc.regenerate(s)).toBe("started"); // spawn tid-3
+  herdr.livePanes.length = 0;
+  expect(await svc.regenerate(s)).toBe("started"); // reaps tid-3, spawns tid-4
+  await Bun.sleep(0); // reapGenerating's stop is fire-and-forget — let it settle
+  expect(openTabs.size).toBe(1); // only the replacement's tab remains
+  read = { status: "parsed", value: VALID_VERDICT_JSON, repaired: false };
+  herdr.livePanes.length = 0;
+  await svc.tick();
+  expect(openTabs.size).toBe(0);
+
+  expect(herdr.started.length).toBe(4); // four real spawns; all four tabs were closed
+});

--- a/test/recap.test.ts
+++ b/test/recap.test.ts
@@ -2367,3 +2367,47 @@ test("tab baseline: repeated recap runs (success + timeout + regenerate-reap) le
 
   expect(herdr.started.length).toBe(4); // four real spawns; all four tabs were closed
 });
+
+// #1852 critic follow-up: the in-memory spawn-handle map must be keyed by the RUN (its
+// mkdtemp-unique cwd), not the session. A finalizer holds its key across awaits; keyed by
+// sessionId, a forced regenerate landing inside one of those awaits re-binds the key, and
+// the stale finalizer then stops + unmaps the REPLACEMENT run's live terminal.
+test("an old finalizer racing a forced regenerate never stops the replacement run (#1852)", async () => {
+  const s = makeSession({ status: "idle", auto: false });
+  const store = makeStore([s]);
+  const herdr = makeHerdr();
+  let t = 100_000;
+  let raced = false;
+  let svcRef: RecapService | null = null;
+  const svc = buildSvc({
+    store,
+    herdr,
+    nowFn: () => t,
+    idleThresholdMs: 120_000,
+    verdictJson: VALID_VERDICT_JSON,
+    // finalize awaits usage capture right before its teardown `finally` — the perfect
+    // window: a forced regenerate lands while the old finalizer is parked here.
+    readUsage: async () => {
+      if (!raced && svcRef) {
+        raced = true;
+        await svcRef.regenerate(s);
+      }
+      return null;
+    },
+  });
+  svcRef = svc;
+
+  await svc.sweep(); // stamp
+  t = 230_000;
+  await svc.sweep(); // spawn run A (tid-1)
+  expect(herdr.started.length).toBe(1);
+
+  await svc.tick(); // finalize A; mid-finalize the hook regenerates → spawn B (tid-2)
+
+  expect(herdr.started.length).toBe(2);
+  expect(herdr.stopped).toEqual(["tid-1"]); // A's own terminal — NEVER the replacement's
+
+  await svc.tick(); // the replacement finalizes normally off its own retained handle
+  expect(herdr.stopped).toEqual(["tid-1", "tid-2"]);
+  expect(store.getRecap("s1")?.state).toBe("ready");
+});

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -3050,3 +3050,49 @@ test("#1757 a non-epic steer is unchanged (no base note)", async () => {
   expect(steers[0]!.text).not.toContain("rebased onto");
   expect(steers[0]!.text).not.toContain("FETCH_HEAD");
 });
+
+// ── Deterministic tab-baseline (#1852) ────────────────────────────────────────
+//
+// Repeated full critic lifecycles against a fake herdr that models the #1852 driver
+// contract (stop() closes the tab recorded at start(), whether or not the critic still
+// appears in any live list). Every finalization path must return the open-tab set to
+// baseline — a path that skips teardown, or passes a dead handle, leaves a tab behind.
+
+test("tab baseline: repeated critic runs (finalize + forget) leave zero open tabs (#1852)", async () => {
+  let n = 0;
+  const openTabs = new Set<string>();
+  const byTerminal = new Map<string, string>();
+  const { deps: d } = makeDeps({
+    herdr: {
+      start: async () => {
+        const terminalId = `rt${++n}`;
+        byTerminal.set(terminalId, `tab-${n}`);
+        openTabs.add(`tab-${n}`);
+        return { terminalId };
+      },
+      stop: async (terminalId: string) => {
+        const tab = byTerminal.get(terminalId);
+        if (tab) openTabs.delete(tab);
+      },
+      list: () => [{ cwd: "/review-wt", terminalId: `rt${n}`, paneId: "p1", agentStatus: "idle" }],
+      paneForegroundProcs: async () => ["zsh"],
+      closeTab: async () => {},
+    },
+  });
+  const svc = new ReviewService(d as any);
+
+  for (let run = 1; run <= 3; run++) {
+    await svc.forceReview(session(), OPEN_GREEN); // explicit re-trigger, bypasses patch-id gating
+    expect(openTabs.size).toBe(1);
+    await svc.tick(); // request-changes verdict → finalize → reapRun
+    expect(openTabs.size).toBe(0);
+  }
+
+  // Cancellation lifecycle: session archived mid-review.
+  await svc.forceReview(session(), OPEN_GREEN);
+  expect(openTabs.size).toBe(1);
+  svc.forget("s1");
+  await Bun.sleep(0); // forget's stop is fire-and-forget — let it settle
+  expect(openTabs.size).toBe(0);
+  expect(n).toBe(4); // four real spawns; all four tabs were closed
+});

--- a/test/tab-reaper.test.ts
+++ b/test/tab-reaper.test.ts
@@ -1,8 +1,10 @@
 import { test, expect, describe } from "bun:test";
 import {
+  createOrphanTabSweeper,
   reapOrphanTabs,
   isShepherdHelperLabel,
   reapStaleReviewWorktrees,
+  type ReapResult,
   type ReapableHerdr,
   type ReapWorktreesDeps,
 } from "../src/tab-reaper";
@@ -171,7 +173,7 @@ test("distiller unique label: tab __distill__<8hex> with live agent is spared (l
   expect(r2.sparedLive).toBe(1);
 });
 
-test("panes() throwing fails closed — reaps nothing, preserves debounce state", async () => {
+test("panes() throwing fails closed — reaps nothing, preserves debounce state, flags panesFailed", async () => {
   const { h, closed } = procFake([], {}, { panesThrows: true });
   const r = await reapOrphanTabs(h, new Set(["w1:t1"]));
   expect(r.closed).toEqual([]);
@@ -179,6 +181,302 @@ test("panes() throwing fails closed — reaps nothing, preserves debounce state"
   expect(r.sparedLive).toBe(0);
   expect(r.sparedError).toBe(0);
   expect(r.shellOnly).toEqual(new Set(["w1:t1"])); // debounce state preserved
+  // The zero-work sweep is FLAGGED — indistinguishable-from-"no husks" was the #1852
+  // operationally-silent failure mode.
+  expect(r.panesFailed).toBe(true);
+});
+
+test("a normal sweep reports panesFailed=false", async () => {
+  const f = procFake([pane("w1:p1", "w1:t1", PROBE_NAME)], { "w1:p1": ["zsh"] });
+  const r = await reapOrphanTabs(f.h);
+  expect(r.panesFailed).toBe(false);
+});
+
+// ── Per-tab liveness classification (#1852) ───────────────────────────────────
+//
+// Reaping closes whole TABS, but classification used to be per PANE. A helper tab can
+// hold more than one pane — a headless codex-exec role deliberately retains its root
+// shell pane, and a failed best-effort root-pane close leaves a shell pane beside the
+// agent pane. The sibling shell pane then marked the tab reap-eligible while the live
+// pane merely counted as spared: two sweeps later the tab was closed WITH the live
+// helper inside. These tests pin the per-tab contract: any live/undeterminable pane
+// spares AND de-primes the whole tab.
+
+const MIXED_LABEL = "plan-review TASK-07";
+
+test("mixed shell+live tab: repeated sweeps never close it and never prime the debounce", async () => {
+  const panes = [
+    pane("w1:p1", "w1:t1", MIXED_LABEL), // retained root shell pane
+    pane("w1:p2", "w1:t1", MIXED_LABEL), // live agent pane
+  ];
+  const procMap: Record<string, string[]> = { "w1:p1": ["zsh"], "w1:p2": ["claude"] };
+  const f = procFake(panes, procMap);
+
+  let prev = new Set<string>();
+  for (let sweep = 1; sweep <= 3; sweep++) {
+    const r = await reapOrphanTabs(f.h, prev);
+    expect(r.closed).toEqual([]);
+    expect(f.closed).toEqual([]);
+    expect(r.sparedLive).toBe(1); // one TAB spared, not one pane
+    expect(r.shellOnly.has("w1:t1")).toBe(false); // never primed while a pane is live
+    prev = r.shellOnly;
+  }
+});
+
+test("mixed shell+error and shell+empty tabs are spared fail-closed as whole tabs", async () => {
+  const panes = [
+    pane("w1:p1", "w1:t1", MIXED_LABEL), // shell
+    pane("w1:p2", "w1:t1", MIXED_LABEL), // process-info throws
+    pane("w2:p1", "w2:t2", "recap TASK-08"), // shell
+    pane("w2:p2", "w2:t2", "recap TASK-08"), // empty procs (undeterminable)
+  ];
+  const procMap: Record<string, string[] | Error> = {
+    "w1:p1": ["zsh"],
+    "w1:p2": new Error("transient process-info read failure"),
+    "w2:p1": ["zsh"],
+    "w2:p2": [],
+  };
+  const f = procFake(panes, procMap);
+
+  let prev = new Set<string>();
+  for (let sweep = 1; sweep <= 2; sweep++) {
+    const r = await reapOrphanTabs(f.h, prev);
+    expect(r.closed).toEqual([]);
+    expect(f.closed).toEqual([]);
+    expect(r.sparedError).toBe(2); // two TABS, fail-closed
+    expect(r.shellOnly.size).toBe(0);
+    prev = r.shellOnly;
+  }
+});
+
+test("live pane DE-PRIMES a prior first-sighting; the shell sibling can never confirm a live tab", async () => {
+  // Sweep 1: both panes read shell-only (the agent's pre-`exec` window) → first sighting.
+  const panes = [pane("w1:p1", "w1:t1", MIXED_LABEL), pane("w1:p2", "w1:t1", MIXED_LABEL)];
+  const procMap: Record<string, string[]> = { "w1:p1": ["zsh"], "w1:p2": ["zsh"] };
+  const f = procFake(panes, procMap);
+
+  const r1 = await reapOrphanTabs(f.h);
+  expect(r1.shellOnly).toEqual(new Set(["w1:t1"])); // primed
+
+  // Sweep 2: the agent exec'd — p2 is now live. The OLD per-pane code closed the tab
+  // here (p1 shell-only + primed); the per-tab gate must spare AND clear the priming.
+  procMap["w1:p2"] = ["claude"];
+  const r2 = await reapOrphanTabs(f.h, r1.shellOnly);
+  expect(r2.closed).toEqual([]);
+  expect(f.closed).toEqual([]);
+  expect(r2.sparedLive).toBe(1);
+  expect(r2.shellOnly.has("w1:t1")).toBe(false); // de-primed
+
+  // Sweep 3: the role finished; its pane idles as a shell again. This must be a FRESH
+  // first sighting (not a stale confirm off sweep 1) …
+  procMap["w1:p2"] = ["zsh"];
+  const r3 = await reapOrphanTabs(f.h, r2.shellOnly);
+  expect(r3.closed).toEqual([]);
+  expect(r3.shellOnly).toEqual(new Set(["w1:t1"]));
+
+  // … and sweep 4 confirms → reaped. The spare clears, it doesn't poison convergence.
+  const r4 = await reapOrphanTabs(f.h, r3.shellOnly);
+  expect(r4.closed).toEqual(["w1:t1"]);
+  expect(f.closed).toEqual(["w1:t1"]);
+});
+
+// ── createOrphanTabSweeper (#1852) ────────────────────────────────────────────
+
+function rr(over: Partial<ReapResult> = {}): ReapResult {
+  return {
+    closed: [],
+    sparedLive: 0,
+    sparedError: 0,
+    shellOnly: new Set(),
+    panesFailed: false,
+    ...over,
+  };
+}
+
+function mkSweeper(opts: {
+  reapImpl: (prev: Set<string>) => ReapResult | Promise<ReapResult>;
+  maintenance?: () => boolean;
+}) {
+  const scheduled: { fn: () => void; ms: number }[] = [];
+  const results: ReapResult[] = [];
+  const sweeper = createOrphanTabSweeper({
+    reap: async (prev) => opts.reapImpl(prev),
+    schedule: (fn, ms) => void scheduled.push({ fn, ms }),
+    maintenanceActive: opts.maintenance ?? (() => false),
+    onResult: (r) => void results.push(r),
+    confirmDelayMs: 30_000,
+  });
+  return { sweeper, scheduled, results };
+}
+
+test("sweeper: overlapping triggers serialize — one pass in flight, extra triggers coalesce into ONE queued pass", async () => {
+  let calls = 0;
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const gates: Array<() => void> = [];
+  const { sweeper } = mkSweeper({
+    reapImpl: (prev) => {
+      calls++;
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      return new Promise<ReapResult>((res) => {
+        gates.push(() => {
+          inFlight--;
+          res(rr({ shellOnly: prev }));
+        });
+      });
+    },
+  });
+
+  sweeper.trigger(); // starts pass 1 (e.g. the 5s boot pass, still crawling a big inventory)
+  sweeper.trigger(); // e.g. the 45s pass — must QUEUE, not overlap
+  sweeper.trigger(); // a third trigger coalesces into the same queued pass
+  expect(calls).toBe(1);
+
+  gates[0]!(); // pass 1 completes
+  await Bun.sleep(0);
+  expect(calls).toBe(2); // exactly one queued confirming pass started
+  gates[1]!();
+  await Bun.sleep(0);
+  expect(calls).toBe(2);
+  expect(maxInFlight).toBe(1); // never concurrent
+});
+
+test("sweeper: a queued pass receives its predecessor's sightings — it is a REAL confirming pass", async () => {
+  const prevs: Set<string>[] = [];
+  const gates: Array<() => void> = [];
+  const { sweeper } = mkSweeper({
+    reapImpl: (prev) => {
+      prevs.push(prev);
+      return new Promise<ReapResult>((res) =>
+        gates.push(() => res(rr({ shellOnly: new Set(["husk"]) }))),
+      );
+    },
+  });
+
+  sweeper.trigger();
+  sweeper.trigger(); // queued while pass 1 runs
+  gates[0]!();
+  await Bun.sleep(0);
+  gates[1]!();
+  await Bun.sleep(0);
+
+  expect(prevs.length).toBe(2);
+  expect(prevs[0]).toEqual(new Set());
+  expect(prevs[1]).toEqual(new Set(["husk"])); // NOT a same-set replay — the old race
+});
+
+test("sweeper: a NEW first-sighting self-schedules one confirming pass, which closes and goes quiet", async () => {
+  const seq: ReapResult[] = [
+    rr({ shellOnly: new Set(["t1"]) }), // sighting pass
+    rr({ closed: ["t1"], shellOnly: new Set(["t1"]) }), // confirm pass: closes
+  ];
+  let i = 0;
+  const prevs: Set<string>[] = [];
+  const { sweeper, scheduled } = mkSweeper({
+    reapImpl: (prev) => {
+      prevs.push(prev);
+      return seq[i++]!;
+    },
+  });
+
+  sweeper.trigger();
+  await Bun.sleep(0);
+  expect(scheduled.length).toBe(1); // exactly one confirm scheduled
+  expect(scheduled[0]!.ms).toBe(30_000);
+
+  scheduled[0]!.fn(); // fire the confirming pass
+  await Bun.sleep(0);
+  expect(prevs[1]).toEqual(new Set(["t1"])); // confirms off the sighting set
+  expect(scheduled.length).toBe(1); // repeat sightings schedule nothing further (no tight loop)
+  expect(i).toBe(2);
+});
+
+test("sweeper: restart mid-debounce — a fresh instance converges from ONE trigger via its self-confirm", async () => {
+  // Instance 1 sights the husk; the process restarts before its confirm fires (the old
+  // in-memory debounce reset). The husk persists in herdr.
+  const first = mkSweeper({ reapImpl: () => rr({ shellOnly: new Set(["husk"]) }) });
+  first.sweeper.trigger();
+  await Bun.sleep(0);
+  expect(first.scheduled.length).toBe(1); // the confirm the restart will drop
+
+  // Instance 2: fresh empty debounce, same herdr state. A SINGLE boot trigger re-sights
+  // and its self-scheduled confirm closes — no dependence on a second external trigger.
+  let pass = 0;
+  const closedOnPass: number[] = [];
+  const second = mkSweeper({
+    reapImpl: (prev) => {
+      pass++;
+      if (prev.has("husk")) {
+        closedOnPass.push(pass);
+        return rr({ closed: ["husk"], shellOnly: new Set(["husk"]) });
+      }
+      return rr({ shellOnly: new Set(["husk"]) });
+    },
+  });
+  second.sweeper.trigger();
+  await Bun.sleep(0);
+  expect(second.scheduled.length).toBe(1);
+  second.scheduled[0]!.fn();
+  await Bun.sleep(0);
+  expect(closedOnPass).toEqual([2]);
+});
+
+test("sweeper: boot triggers skipped under maintenance — the first later trigger converges by itself", async () => {
+  let maint = true;
+  let pass = 0;
+  const closed: string[] = [];
+  const { sweeper, scheduled } = mkSweeper({
+    maintenance: () => maint,
+    reapImpl: (prev) => {
+      pass++;
+      if (prev.has("h")) {
+        closed.push("h");
+        return rr({ closed: ["h"], shellOnly: new Set(["h"]) });
+      }
+      return rr({ shellOnly: new Set(["h"]) });
+    },
+  });
+
+  sweeper.trigger(); // 5s boot trigger — maintenance window
+  sweeper.trigger(); // 45s boot trigger — still in maintenance
+  await Bun.sleep(0);
+  expect(pass).toBe(0); // both skipped
+
+  maint = false;
+  sweeper.trigger(); // first hourly trigger
+  await Bun.sleep(0);
+  expect(scheduled.length).toBe(1);
+  scheduled[0]!.fn(); // its self-confirm — nothing waits another hour
+  await Bun.sleep(0);
+  expect(closed).toEqual(["h"]);
+});
+
+test("sweeper: a panesFailed pass surfaces via onResult and the preserved debounce still confirms later", async () => {
+  const seq: ReapResult[] = [
+    rr({ shellOnly: new Set(["t9"]) }), // sighting
+    rr({ shellOnly: new Set(["t9"]), panesFailed: true }), // confirm hits a panes() failure — zero work
+    rr({ closed: ["t9"], shellOnly: new Set(["t9"]) }), // next trigger confirms off the preserved set
+  ];
+  let i = 0;
+  const prevs: Set<string>[] = [];
+  const { sweeper, scheduled, results } = mkSweeper({
+    reapImpl: (prev) => {
+      prevs.push(prev);
+      return seq[i++]!;
+    },
+  });
+
+  sweeper.trigger();
+  await Bun.sleep(0);
+  scheduled[0]!.fn();
+  await Bun.sleep(0);
+  expect(results[1]!.panesFailed).toBe(true); // observable, not a silent zero
+
+  sweeper.trigger(); // e.g. the hourly pass
+  await Bun.sleep(0);
+  expect(prevs[2]).toEqual(new Set(["t9"])); // debounce survived the failed pass
+  expect(results[2]!.closed).toEqual(["t9"]);
 });
 
 describe("isShepherdHelperLabel", () => {

--- a/test/tab-reaper.test.ts
+++ b/test/tab-reaper.test.ts
@@ -198,6 +198,8 @@ describe("isShepherdHelperLabel", () => {
     ["rundown", "herd-digest rundown (exact, liveness-gated)"],
     ["autopilot 643cfec7-1234-5678-abcd-ef0123456789", "autopilot LLM"],
     ["verify api key", "API-key verifier (multi-word exact)"],
+    // #1852: prompt recommender — previously uncovered, leaked forever across restarts
+    ["recommend TASK-09", "prompt recommender"],
   ];
 
   for (const [label, desc] of trueLabels) {
@@ -217,6 +219,7 @@ describe("isShepherdHelperLabel", () => {
     ["reviewing-pr", "starts with 'review' but no trailing space"],
     ["autopilot-mode", "hyphen instead of space — not an autopilot helper"],
     ["name-my-thing", "hyphen instead of space — not a namer helper"],
+    ["recommend-tweaks", "hyphen instead of space — not a recommender helper"],
   ];
 
   for (const [label, desc] of falseLabels) {

--- a/test/transient-tab-reaper.test.ts
+++ b/test/transient-tab-reaper.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { reapTransientByLabel } from "../src/transient-tab-reaper";
 import { AUTOPILOT_LABEL } from "../src/autopilot";
 import { NAMER_LABEL } from "../src/namer";
+import { RECOMMEND_LABEL } from "../src/prompt-recommend";
 import { VERIFY_KEY_LABEL } from "../src/verify-key";
 
 interface FakeAgent {
@@ -93,6 +94,9 @@ const SYNC_HELPERS = [
   { label: NAMER_LABEL, ident: "NAMER_LABEL" },
   { label: AUTOPILOT_LABEL, ident: "AUTOPILOT_LABEL" },
   { label: VERIFY_KEY_LABEL, ident: "VERIFY_KEY_LABEL" },
+  // #1852: prompt-recommend previously had NO reconcile coverage at all — not in this
+  // boot reap, not in isShepherdHelperLabel — so a restart mid-run leaked its tab forever.
+  { label: RECOMMEND_LABEL, ident: "RECOMMEND_LABEL" },
 ] as const;
 
 // One behavioral case per label, deliberately NOT a restatement of `closes ALL unowned prefix


### PR DESCRIPTION
Closes #1852.

At the incident, 316 of 334 persisted Herdr tabs were leaked transient-helper husks; herdr exhausted its 1,024-FD soft limit and its API listener died. This PR fixes the lifecycle at the source and hardens the safety-net sweep.

## What changed

**1. `stop()` closes the spawn-recorded tab; agent-list rediscovery is fallback-only** (`fix(herdr)`)
Both `HerdrDriver` and `SocketHerdrDriver` record each `start()`'s authoritative `tabId` + label in a `TabLedger`. For a recorded handle, `stop(terminalId)` verifies the tab against the live **tab list** (which, unlike `agent list`, still contains an exited helper's husk) and closes it directly — zero `agent list` calls on the normal path, so a helper that exited (or died ~5 ms after `agent.start`, pane 166) can no longer silently leak its tab. Label mismatch (id re-minted by a restarted daemon) never closes blind: it falls back to the fresh agent-list resolution. A full miss warns instead of masquerading as successful teardown.

**2. recap + herd-digest keep their spawn handle** (`fix(recap)`)
Both discarded the `start()` return and re-resolved the terminal by cwd at teardown — `""` once the helper exited, making the finalize `stop("")` a silent no-op (pane 158; 97 recap husks). They now hold the spawn `terminalId` in memory for the run's lifetime, with the cwd lookup only for restart-adopted rows.

**3. prompt-recommend gains reaper coverage** (`fix(tabs)`)
`recommend <desig>` was in neither `isShepherdHelperLabel` nor the boot reap — a restart mid-run leaked it forever. Now covered by both, via a shared `RECOMMEND_LABEL` constant.

**4. Per-tab husk classification + serialized, self-confirming sweeps** (`fix(tabs)`)
- `reapOrphanTabs` now classifies whole **tabs** with fail-safe precedence: any live pane spares (and de-primes) the tab; errored/empty panes spare fail-closed; only an all-shell tab is a husk candidate. The old per-pane logic could close a multi-pane tab (retained codex-exec root shell pane) with its live helper inside.
- A `panes()` throw is flagged (`ReapResult.panesFailed`) and logged instead of reading as "nothing to do".
- `createOrphanTabSweeper` serializes + coalesces passes (one running, one queued max; the queued pass inherits its predecessor's sightings, so it is a real confirming pass) and self-schedules a 30s confirming pass after any new first-sighting — convergence survives restarts and skipped boot sweeps without persisting the debounce.

## Acceptance criteria → coverage

- tabId retained creation→finalization; finalizers close it directly; fast-exit no leak → TabLedger + driver tests (incl. "zero agent-list calls" assertions, both transports)
- observable `stop()` no-op → warn paths + tests
- serialized sweeps / restart-safe debounce / actionable `panes()` failures → sweeper contract tests (overlap, restart-mid-debounce, skipped-boot, panesFailed)
- only recognised, confirmed-shell-only labels reaped; live helpers spared → per-tab classification suite (repeated mixed shell+live/error/empty panes, transition-to-husk)
- regression + stress → deterministic tab-baseline suites for review / plan-review / recap / distill: repeated success, timeout, parse-absent, cancellation, and agent-exited-before-finalize lifecycles all return the open-tab set exactly to baseline

## Testing

- `bun test ./test`: 7397 pass, 1 fail — the pre-existing environmental `pty-attach` failure (node-pty native module cannot compile in Shepherd worktrees; unrelated, this diff does not touch pty-bridge). Pushed with `--no-verify` for that reason; all other gates run manually and green.
- `bun run lint`, `bunx tsc --noEmit`, `bunx prettier --check` on all touched files: clean.

## Follow-up

- #1857 — `LimitNOFILE` headroom for `deploy/herdr.service` (split out per plan review).

[no-feature-entry]