### PR TITLE
fix(plan-gate): anchor the plan reviewer to the planner's tree

### DIFF
--- a/src/critic-core.ts
+++ b/src/critic-core.ts
@@ -620,7 +620,7 @@ export async function defaultComputePatchId(
     // Resolve the base to a concrete immutable SHA NOW: FETCH_HEAD is transient (a later
     // in-worktree fetch moves it; undefined on a failed fetch), so capturing the rev-parsed
     // SHA gives the prompt + backstop a base that provably equals the one we fingerprint.
-    // `--end-of-options` guards a hostile ref (mirrors defaultBaseSha in plan-gate.ts). Null
+    // `--end-of-options` guards a hostile ref (mirrors defaultPlanAnchorSha in plan-gate.ts). Null
     // on failure → caller diffs the `ref` string best-effort and skips the backstop.
     let baseSha: string | null = null;
     try {

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -283,7 +283,12 @@ function locationReferenceBlock(
   }
   lines.push(
     "- Files, symbols, tests and message keys the plan proposes to ADD, RENAME or MOVE are NEVER findings on resolution grounds. A plan describes code that does not exist yet.",
-    "- Identify code by FILE PATH + SYMBOL (function / type / const / message key). A line number, a line range, or the precision of a location reference is NEVER a finding — line numbers have been removed from the plan you were shown and are not part of the contract.",
+    // Deliberately NOT "line numbers have been removed": stripPlanLineRefs only removes refs
+    // attached to an extension-bearing path, so `Makefile:88` and prose like `foo.ts (line 411)`
+    // reach the reviewer intact. Promising exhaustive removal would be visibly false the first
+    // time one survives, which discredits the rule it is meant to justify. The load-bearing claim
+    // is that line numbers are not part of the contract — true whatever survived.
+    "- Identify code by FILE PATH + SYMBOL (function / type / const / message key). A line number, a line range, or the precision of a location reference is NEVER a finding — line numbers are not part of the contract, and any you do see in the plan carry no authority.",
     '- When you AUTHOR A NEW finding, cite path + symbol, not line numbers, in "findings" and "body".',
     "- EXEMPTION: re-raising a prior finding verbatim is REQUIRED by the re-review instruction above and OVERRIDES the previous rule. Reproduce its text unchanged, line numbers included; a re-raised prior finding is not itself a location complaint, and must not be dropped, reworded or reclassified on those grounds.",
   );

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -5,7 +5,7 @@ import {
   codexLastMessageFile,
 } from "./codex-last-message";
 import { join } from "node:path";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { execFileSync } from "./instrument";
 import type { SessionStore } from "./store";
 import type { HerdrDriver } from "./herdr";
@@ -83,15 +83,86 @@ const PLAN_BLOCKS_FILE = ".shepherd-plan-blocks.json";
 /** The file the adversarial plan reviewer writes its verdict JSON to, in its detached worktree. */
 export const PLAN_VERDICT_FILE = ".shepherd-plan-review.json";
 
+/** Rewrite `path.ext:120` / `path.ext:120-140` / `path.ext#L120-L140` to the bare `path.ext`.
+ *
+ *  Applied ONLY to the plan text embedded in {@link planReviewPrompt} — the plan file on disk, the
+ *  UI's copy and the planning agent's own view are untouched, and so are `task` / `issueBody` /
+ *  prior findings (see below). It exists because the planner and the reviewer historically read
+ *  DIFFERENT trees, so a line number correct on one side was wrong on the other and the round was
+ *  spent arguing about it. `planAnchorSha` now co-locates the two trees, which fixes the common
+ *  case; this strip is the deterministic backstop for the case the anchor cannot reach — a plan
+ *  reference into code the planner has itself committed this session, which the merge-base anchor
+ *  deliberately excludes. The prompt FORBIDS line-number findings; this makes them unraisable.
+ *
+ *  Deliberately NOT applied to:
+ *  - `task` / `issueBody` — human-authored ground truth the reviewer judges the plan against,
+ *    fixed across rounds. Stripping them cost the reviewer the ability to check the plan targets
+ *    the location the operator actually named, and bought nothing: no round-over-round churn
+ *    originates there.
+ *  - prior findings — `planReviewPrompt` orders them re-raised VERBATIM. Mutating one turns
+ *    "the ref `x.ts:12` points at the wrong function" into an un-addressable "the ref `x.ts`
+ *    points at the wrong function" that the next round recycles, LENGTHENING the loop.
+ *
+ *  The pattern is narrow ON PURPOSE: it requires a path-ish token bearing a file EXTENSION
+ *  immediately before the ref, so `10:30` and `--flag=3:4` are left alone. The leading lookbehind
+ *  forces the match to begin at a real token boundary, which is what keeps a URL authority safe:
+ *  in `https://example.com:443/x`, `example.com` is preceded by `/` and the `//` is preceded by
+ *  `:`, so neither can start a match and the port is not mistaken for a line number. (`.com` is
+ *  otherwise a perfectly good "extension", and `/` is a legal token char, so BOTH exclusions are
+ *  needed — this was a live false positive, caught twice by the guard test.)
+ *
+ *  Known survivals (bare `:1090` continuations, `foo.ts (line 411)`, extension-less paths like
+ *  `Makefile:88`) are accepted — widening this would trade a rare false negative for a common
+ *  false positive on timestamps, ports and ratios. Those are covered by the prompt rule instead. */
+export function stripPlanLineRefs(text: string): string {
+  return text.replace(
+    /(?<![A-Za-z0-9_.:\-/\\])([A-Za-z0-9_.\-/\\]*[A-Za-z0-9_\-/\\]\.[A-Za-z0-9]{1,8})(?::\d+(?:-\d+)?|#L\d+(?:-L?\d+)?)\b/g,
+    "$1",
+  );
+}
+
+/** What the reviewer's detached worktree is checked out at, when `planAnchorSha` resolved the
+ *  merge-base (`anchored`). `sha` is that commit; `ahead` is how many commits the planning agent
+ *  has made past it in its own worktree — the count that decides whether an unresolvable symbol
+ *  reference is a defect or merely invisible from here. */
+export interface PlanAnchor {
+  sha: string;
+  ahead: number;
+}
+
+/** How far the anchor sits behind the (freshly fetched) base branch, and which paths moved.
+ *  Computed AFTER `createDetached`'s fetch — see {@link defaultAnchorStaleness}. */
+export interface AnchorStaleness {
+  behind: number;
+  changedSince: string[];
+  /** Paths elided by the cap, so the prompt can say "and N more" instead of implying the list is
+   *  exhaustive. */
+  more?: number;
+}
+
 /** Self-contained instructions for the adversarial plan reviewer. NOT UI chrome — never i18n'd.
  *  The plan text is UNTRUSTED agent output embedded as data; the read-only dontAsk sandbox
- *  (mirrors the PR critic) contains any injection. */
+ *  (mirrors the PR critic) contains any injection.
+ *
+ *  `anchor` / `staleness` are optional and TRAILING on purpose: both existing callers pass
+ *  `operatorLanguage` positionally, so a parameter inserted before it would silently mis-bind.
+ *
+ *  Three tiers, keyed on what this reviewer can actually SEE (see the LOCATION REFERENCES block):
+ *  - `anchor` set, `ahead === 0` — the strong tier. Its tree IS the planner's tree for every
+ *    pre-existing file, so an unresolvable reference to existing code is a real defect.
+ *  - `anchor` set, `ahead > 0` — the planner has committed since the branch point and the anchor
+ *    (a merge-base) excludes exactly those commits, so a reference may name code the planner has
+ *    ALREADY written this session. Ambiguous ⇒ `body`, never `findings`.
+ *  - `anchor` absent — the anchor could not be resolved, so the tree may have drifted. Same
+ *    ambiguity, same routing. Mirrors critic-core's degraded epic block. */
 export function planReviewPrompt(
   task: string,
   plan: string,
   priorFindings: string[] = [],
   issueBody?: string | null,
   operatorLanguage: OperatorLanguage = "en",
+  anchor?: PlanAnchor | null,
+  staleness?: AnchorStaleness | null,
 ): string {
   const lines = [
     "You are an adversarial plan reviewer. Read-only — do NOT modify, build, commit, or run anything.",
@@ -118,7 +189,9 @@ export function planReviewPrompt(
       "",
     );
   }
-  lines.push("PLAN (.shepherd-plan.md):", plan, "");
+  // Line refs are stripped from the PLAN only — never from `task`/`issueBody` above (human-authored
+  // ground truth) nor from the prior findings below (re-raised verbatim). See stripPlanLineRefs.
+  lines.push("PLAN (.shepherd-plan.md):", stripPlanLineRefs(plan), "");
   if (priorFindings.length) {
     lines.push(
       "This is a RE-REVIEW. For EACH prior point, confirm the revised plan addresses it; if it does not, re-raise it verbatim:",
@@ -126,6 +199,7 @@ export function planReviewPrompt(
       "",
     );
   }
+  lines.push(...locationReferenceBlock(anchor, staleness), "");
   lines.push(
     `Write your verdict as JSON to \`${PLAN_VERDICT_FILE}\` in the current directory, with EXACTLY this shape:`,
     '{"decision": "approve" | "request-changes", "summary": "<=100 char one-liner", "body": "<full markdown>", "findings": ["<discrete actionable revision>", ...]}',
@@ -143,6 +217,59 @@ export function planReviewPrompt(
   return lines.join("\n");
 }
 
+/** The LOCATION REFERENCES block: how the reviewer must treat WHERE the plan says code lives.
+ *
+ *  Two tiers of tree-claims (conditional) wrapped around one set of referencing rules
+ *  (unconditional, byte-identical in every tier — they never depend on which commit is checked
+ *  out, only the claims ABOUT the tree do).
+ *
+ *  The rules exist to kill three distinct manufactured-finding classes, each observed or
+ *  predicted: (1) arguing about a line number that is stale only because the two sides read
+ *  different trees; (2) flagging a symbol the plan PROPOSES TO CREATE as "unresolvable" — every
+ *  plan describes code that does not exist yet; (3) flagging a symbol the planner has ALREADY
+ *  COMMITTED this session, which the merge-base anchor excludes by construction and which bites
+ *  hardest on exactly the long multi-round sessions this whole change targets. */
+function locationReferenceBlock(
+  anchor?: PlanAnchor | null,
+  staleness?: AnchorStaleness | null,
+): string[] {
+  const lines = ["LOCATION REFERENCES — how to treat WHERE the plan says code lives:"];
+  if (anchor) {
+    lines.push(
+      `- Your worktree is checked out at \`${anchor.sha}\`, the merge-base the planning agent's own worktree derives from — you both share that commit exactly. Divergence from newer commits on the base branch is NOT a finding.`,
+    );
+    if (anchor.ahead > 0) {
+      // NOTE the claim withheld here: with commits past the anchor, a pre-existing file the agent
+      // has since edited does NOT read the same on both sides, so "reads IDENTICALLY" would be a
+      // lie in this tier — and a lie that licenses exactly the false findings this block prevents.
+      lines.push(
+        `- The planning agent has made ${anchor.ahead} commit(s) SINCE that merge-base, and this checkout deliberately excludes them. So a file or symbol that does not resolve here — or that reads differently than the plan describes — may be code the agent has ALREADY WRITTEN this session, not a mistake. Such a reference is AMBIGUOUS: report it in "body" as a stated limitation, NEVER in "findings".`,
+      );
+    } else {
+      lines.push(
+        "- The planning agent has committed nothing since, so every file reads IDENTICALLY for both of you. A reference to code that ALREADY EXISTS naming a file or symbol you cannot resolve IS therefore a finding — a wrong reference, not an imprecise one.",
+      );
+    }
+  } else {
+    lines.push(
+      '- The commit your worktree sits at could NOT be tied to the planning agent\'s tree, so the two may have drifted apart. A file or symbol that does not resolve here is therefore AMBIGUOUS — it may be a genuine mistake, or it may have moved or been renamed since this session started. Do NOT raise it as a finding; report it in "body" as a stated limitation.',
+    );
+  }
+  if (staleness && staleness.behind > 0 && staleness.changedSince.length) {
+    const more = staleness.more ? `, and ${staleness.more} more` : "";
+    lines.push(
+      `- Your anchor is ${staleness.behind} commit(s) behind the base branch. These paths have changed on the base branch since (some may not exist in your checkout at all): ${staleness.changedSince.join(", ")}${more}. If the plan targets any of them, you MAY note it — but ONLY in "body", in a single section headed exactly \`Anchor staleness (informational, non-blocking):\`. It is NEVER a finding and NEVER makes the decision "request-changes".`,
+    );
+  }
+  lines.push(
+    "- Files, symbols, tests and message keys the plan proposes to ADD, RENAME or MOVE are NEVER findings on resolution grounds. A plan describes code that does not exist yet.",
+    "- Identify code by FILE PATH + SYMBOL (function / type / const / message key). A line number, a line range, or the precision of a location reference is NEVER a finding — line numbers have been removed from the plan you were shown and are not part of the contract.",
+    '- When you AUTHOR A NEW finding, cite path + symbol, not line numbers, in "findings" and "body".',
+    "- EXEMPTION: re-raising a prior finding verbatim is REQUIRED by the re-review instruction above and OVERRIDES the previous rule. Reproduce its text unchanged, line numbers included; a re-raised prior finding is not itself a location complaint, and must not be dropped, reworded or reclassified on those grounds.",
+  );
+  return lines;
+}
+
 /** The read-only plan reviewer's argv — the PR critic's exact hardening, shared via one builder
  *  (the plan text is UNTRUSTED, so it gets the same injection-contained sandbox). Also returns
  *  the reviewer's pinned `--session-id` so begin() can locate its transcript for token totals. */
@@ -151,6 +278,7 @@ export function reviewerArgv(
   model: string | null,
   prompt: string,
   effort: string | null = null,
+  sessionId?: string,
 ): { argv: string[]; sessionId: string } {
   // The plan reviewer participates in the session's resolved reasoning effort (no longer force-
   // unbudgeted): it inherits `session.effort` — the tier this session runs at, itself the session
@@ -162,6 +290,7 @@ export function reviewerArgv(
     prompt,
     effort,
     captureLastMessage: true,
+    sessionId,
   });
 }
 
@@ -270,8 +399,12 @@ export interface PlanGateServiceDeps extends MembraneSeams {
   worktreeExists?: (worktreePath: string) => boolean;
   /** default: read PLAN_VERDICT_FILE from the reviewer's disposable worktree. */
   readVerdict?: (worktreePath: string, spawnSessionId?: string) => RawPlanVerdict | null;
-  /** default: `git rev-parse origin/<base>` (fallback `<base>`) in the repo. */
-  baseSha?: (repoPath: string, base: string) => string;
+  /** default: {@link defaultPlanAnchorSha} — the merge-base of the session worktree's HEAD and
+   *  `origin/<base>`, falling back to `origin/<base>` → `<base>` → the bare ref name. */
+  baseSha?: (repoPath: string, base: string, worktreePath: string) => PlanAnchorResolution;
+  /** default: {@link defaultAnchorStaleness}. MUST be called AFTER the reviewer worktree is
+   *  created — `createDetached` fetches `origin/<base>` and this measures against it. */
+  anchorStaleness?: (repoPath: string, sha: string, base: string) => AnchorStaleness;
   /** Injectable reader for the plan reviewer's latest tool-use summary (default: parse its JSONL
    *  transcript via readActivitySignal). null = no parseable activity yet. */
   readActivity?: (worktreePath: string, reviewerSessionId: string) => string | null;
@@ -331,7 +464,8 @@ export class PlanGateService {
   private readPlanBlocks: (worktreePath: string) => VisualBlock[];
   private readVerdict: (worktreePath: string, spawnSessionId?: string) => RawPlanVerdict | null;
   private worktreeExists: (worktreePath: string) => boolean;
-  private baseSha: (repoPath: string, base: string) => string;
+  private baseSha: (repoPath: string, base: string, worktreePath: string) => PlanAnchorResolution;
+  private anchorStaleness: (repoPath: string, sha: string, base: string) => AnchorStaleness;
   private readActivity: (worktreePath: string, reviewerSessionId: string) => string | null;
   private readUsage: (
     worktreePath: string,
@@ -348,7 +482,8 @@ export class PlanGateService {
     this.readPlanBlocks = deps.readPlanBlocks ?? defaultReadPlanBlocks;
     this.readVerdict = deps.readVerdict ?? defaultReadVerdict;
     this.worktreeExists = deps.worktreeExists ?? existsSync;
-    this.baseSha = deps.baseSha ?? defaultBaseSha;
+    this.baseSha = deps.baseSha ?? defaultPlanAnchorSha;
+    this.anchorStaleness = deps.anchorStaleness ?? defaultAnchorStaleness;
     this.readActivity = deps.readActivity ?? defaultReadActivity;
     this.readUsage = deps.readUsage ?? readSessionUsage;
   }
@@ -398,6 +533,37 @@ export class PlanGateService {
     }
   }
 
+  /** Assemble the reviewer prompt, resolving the two facts that decide how it talks about
+   *  locations: which tier applies (from the anchor), and whether the anchor has fallen materially
+   *  behind the base branch.
+   *
+   *  CALL ORDER MATTERS: this must run AFTER the reviewer worktree is created, because
+   *  `createDetached` fetches `origin/<base>` and the staleness numbers are measured against it.
+   *  Called before, they compare against a stale local ref and systematically understate — usually
+   *  all the way to `behind: 0`, which silently suppresses the note in exactly the fast-merging
+   *  repos it exists for. */
+  private composeReviewerPrompt(
+    session: Session,
+    plan: string,
+    prior: PlanGate | null,
+    issueBody: string | null | undefined,
+    anchor: PlanAnchorResolution,
+  ): string {
+    // Drift from an anchor that isn't the planner's tree is meaningless, so don't even measure it.
+    const staleness = anchor.anchored
+      ? this.anchorStaleness(session.repoPath, anchor.sha, session.baseBranch)
+      : null;
+    return planReviewPrompt(
+      session.prompt,
+      plan,
+      prior?.findings ?? [],
+      issueBody,
+      this.deps.operatorLanguage?.() ?? "en",
+      anchor.anchored ? { sha: anchor.sha, ahead: anchor.ahead } : undefined,
+      staleness && staleness.behind > 0 ? staleness : undefined,
+    );
+  }
+
   private async begin(
     session: Session,
     plan: string,
@@ -405,38 +571,34 @@ export class PlanGateService {
     prior: PlanGate | null,
     forced: boolean,
   ): Promise<PlanReviewTrigger> {
-    // Resolve the base SHA so the reviewer inspects a CLEAN copy of the codebase at the base
-    // branch — never the live worktree (the planning agent is still editing it). baseSha's
-    // default catches internally and falls back to the base ref / name, so this won't throw.
-    const sha = this.baseSha(session.repoPath, session.baseBranch);
+    // Resolve the anchor so the reviewer inspects a CLEAN copy of the codebase — never the live
+    // worktree (the planning agent is still editing it). Prefers the merge-base the planning
+    // agent's own tree derives from, so both sides read identical bytes for pre-existing files;
+    // `anchored: false` means the fallback chain ran and the trees may have drifted. Catches
+    // internally and falls back to the base ref / name, so this won't throw.
+    const { sha, anchored, ahead } = this.baseSha(
+      session.repoPath,
+      session.baseBranch,
+      session.worktreePath,
+    );
 
     // Pre-inject the originating issue's body as UNTRUSTED reviewer context (the agent has no
     // gh/network — the sandbox stays airtight). Best-effort: a missing issue / forge / getIssue
     // must never block or throw the review, so any failure degrades to no issue context.
     const issueBody = await this.fetchIssueBody(session);
-    const prompt = planReviewPrompt(
-      session.prompt,
-      plan,
-      prior?.findings ?? [],
-      issueBody,
-      this.deps.operatorLanguage?.() ?? "en",
-    );
-    // Mint the reviewer argv (and its pinned per-spawn --session-id) BEFORE createDetached so the
-    // reviewer session id can key the worktree path. It's a fresh randomUUID() per run.
     const reviewerEnv = this.deps.env?.() ?? {
       provider: "claude" as const,
       model: null,
       effort: null,
     };
     const reviewerEffort = reviewerEnv.effort ?? session.effort ?? null;
-    const { argv, sessionId: reviewerSessionId } = reviewerArgv(
-      reviewerEnv.provider,
-      reviewerEnv.model,
-      prompt,
-      reviewerEffort,
-    );
+    // Mint the per-spawn reviewer session id BEFORE createDetached — it keys the worktree path —
+    // but build the PROMPT after, because the prompt's staleness block depends on the fetch that
+    // createDetached performs. reviewerArgv takes the pre-minted id and pins the same
+    // `--session-id`, so the path/transcript/verdict wiring is unchanged.
+    const reviewerSessionId = randomUUID();
 
-    // Disposable detached worktree at the base: read-only codebase inspection that can't race
+    // Disposable detached worktree at the anchor: read-only codebase inspection that can't race
     // the live planning agent. The plan TEXT travels inline in the prompt, not via this tree.
     // Key the path on the per-RUN reviewer session id (a fresh randomUUID per spawn): every
     // session detaches at the SAME base sha, so even two reviews of the SAME session at that sha
@@ -455,6 +617,20 @@ export class PlanGateService {
       console.warn(`[plan-gate] worktree failed for ${session.id}:`, err);
       return "error-worktree";
     }
+
+    // MUST be after createDetached — see composeReviewerPrompt.
+    const prompt = this.composeReviewerPrompt(session, plan, prior, issueBody, {
+      sha,
+      anchored,
+      ahead,
+    });
+    const { argv } = reviewerArgv(
+      reviewerEnv.provider,
+      reviewerEnv.model,
+      prompt,
+      reviewerEffort,
+      reviewerSessionId,
+    );
 
     // forget() (session archived) may have fired during either await above (getIssue OR the slow
     // createDetached: git fetch + worktree add); it clears our `starting` claim as a tombstone.
@@ -1291,23 +1467,111 @@ function defaultReadVerdict(worktreePath: string, spawnSessionId?: string): RawP
   }
 }
 
-/** Resolve the base branch's SHA for the disposable worktree. Prefer the freshest `origin/<base>`,
- *  fall back to the local `<base>` ref, and finally to the branch name itself (createDetached can
- *  still resolve it). `--end-of-options` guards a hostile branch name from flag-smuggling (the
- *  rev-parse-correct terminator — `--` makes rev-parse read the operand as a pathspec). Any git
- *  failure degrades to the next fallback — never throws. */
-function defaultBaseSha(repoPath: string, base: string): string {
-  const revParse = (ref: string): string | null => {
+/** What {@link defaultPlanAnchorSha} resolved: the commit to check the reviewer out at, whether
+ *  that commit is the planner's own merge-base (`anchored`), and how far the planner has moved
+ *  past it. `anchored: false` means the fallback chain ran and the tree may have DRIFTED from what
+ *  the planning agent reads — the prompt must not then claim the two are co-located. */
+export interface PlanAnchorResolution {
+  sha: string;
+  anchored: boolean;
+  ahead: number;
+}
+
+/** Resolve the commit the plan reviewer's disposable worktree is checked out at.
+ *
+ *  Prefer the MERGE-BASE of the session worktree's HEAD and `origin/<base>` — the commit the
+ *  planning agent's own tree derives from — so both sides read identical bytes for every
+ *  pre-existing file and a location reference correct for one is correct for the other.
+ *
+ *  Merge-base, NOT the session worktree's raw HEAD, for two reasons:
+ *  - `ShepherdService.advanceToExecutionOnPr` exists precisely because agents write code and open
+ *    PRs while `planPhase` is still `"planning"`, so HEAD often carries the planner's own commits.
+ *  - More importantly, HEAD is UNTRUSTED. A worktree at the session branch contains whatever the
+ *    planning agent has committed — including `CLAUDE.md`, `.claude/settings.json`, hooks and
+ *    skills — and the reviewer is launched in that directory, so the agent under review would be
+ *    supplying the reviewing agent's own instructions. A merge-base is a commit on the base
+ *    branch's history, which is what `begin()` means by detaching at the TRUSTED base. (The
+ *    pre-seeded-verdict hole is separately closed by `scrubStaleVerdictArtifacts`; scrubbing one
+ *    known filename does nothing about repo-level agent configuration.)
+ *
+ *  Falls back to the previous behaviour on any failure — `origin/<base>` → `<base>` → the bare ref
+ *  name — flagged `anchored: false` so the prompt degrades honestly. The last rung is effectively
+ *  an error path: `createDetached` validates `/^[0-9a-f]{7,40}$/` and throws on a branch name, and
+ *  `begin()` turns that into `error-worktree`. It is kept as-is rather than removed.
+ *
+ *  Resolved BEFORE `createDetached`'s fetch, which is sound: a merge-base does not move when
+ *  `origin/<base>` merely fast-forwards. Only the staleness DISTANCE needs the fresh ref — see
+ *  {@link defaultAnchorStaleness}.
+ *
+ *  `--end-of-options` guards a hostile branch name from flag-smuggling (the rev-parse-correct
+ *  terminator — `--` makes rev-parse read the operand as a pathspec). Never throws. */
+export function defaultPlanAnchorSha(
+  repoPath: string,
+  base: string,
+  worktreePath: string,
+): PlanAnchorResolution {
+  const git = (cwd: string, args: string[]): string | null => {
     try {
-      return execFileSync("git", ["rev-parse", "--verify", "--end-of-options", ref], {
-        cwd: repoPath,
-        stdio: ["ignore", "pipe", "ignore"],
-      })
+      return execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "ignore"] })
         .toString()
         .trim();
     } catch {
       return null;
     }
   };
-  return revParse(`origin/${base}`) ?? revParse(base) ?? base;
+  const revParse = (ref: string): string | null =>
+    git(repoPath, ["rev-parse", "--verify", "--end-of-options", ref]);
+
+  const mergeBase = git(worktreePath, ["merge-base", "--end-of-options", "HEAD", `origin/${base}`]);
+  if (mergeBase) {
+    // How far the planner has moved past the anchor. Drives the prompt's "ahead" tier: those
+    // commits are excluded from the reviewer's tree by construction, so a symbol that fails to
+    // resolve there may be code the planner has already written rather than a mistake.
+    const ahead = Number(
+      git(worktreePath, ["rev-list", "--count", "--end-of-options", `${mergeBase}..HEAD`]) ?? "0",
+    );
+    return { sha: mergeBase, anchored: true, ahead: Number.isFinite(ahead) ? ahead : 0 };
+  }
+  return { sha: revParse(`origin/${base}`) ?? revParse(base) ?? base, anchored: false, ahead: 0 };
+}
+
+/** Cap on the changed-path list handed to the reviewer — enough to spot an overlap with the plan,
+ *  bounded so a long-lived session can't blow up the prompt. */
+const CHANGED_SINCE_CAP = 50;
+
+/** How far the anchor sits behind the base branch, and which paths moved, for the prompt's
+ *  informational staleness note.
+ *
+ *  MUST run AFTER the reviewer's worktree is created: `createDetached` performs a
+ *  `git fetch origin -- <branch>` first, and measuring before it would compare against a possibly
+ *  stale local `origin/<base>` — systematically understating, including reporting `behind: 0` and
+ *  suppressing the note entirely for a materially stale session, in exactly the fast-merging repo
+ *  this targets. If that fetch failed (offline), the numbers fall back to the last successful
+ *  fetch: a LOWER BOUND, never an overstatement, and the note is informational either way.
+ *
+ *  Zeroed on any git failure — never throws, never blocks a review. */
+export function defaultAnchorStaleness(
+  repoPath: string,
+  sha: string,
+  base: string,
+): AnchorStaleness {
+  const git = (args: string[]): string | null => {
+    try {
+      return execFileSync("git", args, { cwd: repoPath, stdio: ["ignore", "pipe", "ignore"] })
+        .toString()
+        .trim();
+    } catch {
+      return null;
+    }
+  };
+  const range = `${sha}..origin/${base}`;
+  const behind = Number(git(["rev-list", "--count", "--end-of-options", range]) ?? "0");
+  if (!Number.isFinite(behind) || behind <= 0) return { behind: 0, changedSince: [] };
+  const raw = git(["diff", "--name-only", "--end-of-options", range]);
+  const all = raw ? raw.split("\n").filter(Boolean) : [];
+  return {
+    behind,
+    changedSince: all.slice(0, CHANGED_SINCE_CAP),
+    more: all.length > CHANGED_SINCE_CAP ? all.length - CHANGED_SINCE_CAP : undefined,
+  };
 }

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -107,19 +107,28 @@ export const PLAN_VERDICT_FILE = ".shepherd-plan-review.json";
  *  immediately before the ref, so `10:30` and `--flag=3:4` are left alone. The extension must
  *  START WITH A LETTER, which is what keeps decimals safe — without it `16.9:1` and `1.5:30` read
  *  as "file `16.9`, line 1" and get rewritten, defeating the ratio/timestamp guarantee one line
- *  up. Every real code extension qualifies (`.ts`, `.rs`, `.svelte`, `.mjs`, `.h`). The leading lookbehind
- *  forces the match to begin at a real token boundary, which is what keeps a URL authority safe:
- *  in `https://example.com:443/x`, `example.com` is preceded by `/` and the `//` is preceded by
- *  `:`, so neither can start a match and the port is not mistaken for a line number. (`.com` is
- *  otherwise a perfectly good "extension", and `/` is a legal token char, so BOTH exclusions are
- *  needed — this was a live false positive, caught twice by the guard test.)
+ *  up. Every real code extension qualifies (`.ts`, `.rs`, `.svelte`, `.mjs`, `.h`).
  *
- *  Known survivals (bare `:1090` continuations, `foo.ts (line 411)`, extension-less paths like
- *  `Makefile:88`) are accepted — widening this would trade a rare false negative for a common
- *  false positive on timestamps, ports and ratios. Those are covered by the prompt rule instead. */
+ *  Trailing `(?::\d+)*` swallows grep/compiler `file:line:col` forms WHOLE. Matching only the
+ *  `:line` part would rewrite `foo.ts:12:5` to `foo.ts:5` — a surviving, plausible-looking
+ *  reference to the WRONG line, which is worse than not matching at all.
+ *
+ *  Two guards keep host:port out. The leading lookbehind forces the match to start at a token
+ *  boundary, so in `https://example.com:443/x` neither `example.com` (preceded by `/`) nor `//`
+ *  (preceded by `:`) can start one. That argument only holds when a `//` scheme prefix is present,
+ *  so the trailing `(?!/)` covers the rest: a port is followed by a path, a line number never is —
+ *  it rescues bare `ghcr.io:443/x`. (`.com`/`.io` are perfectly good "extensions" and `/` is a
+ *  legal token char, so both guards are load-bearing.)
+ *
+ *  Known survivals, all accepted: bare `:1090` continuations, `foo.ts (line 411)`, extension-less
+ *  paths like `Makefile:88`. Known FALSE POSITIVE, also accepted: a bare `host:port` with no path
+ *  (`ghcr.io:443` → `ghcr.io`). Distinguishing it would need a TLD blocklist, and TLDs collide
+ *  head-on with real code extensions — `.rs`, `.sh`, `.pl` and `.ml` are all both — so the cure is
+ *  worse than the disease. It is cosmetic besides: the reviewer's copy of the plan loses a port,
+ *  which costs nothing, whereas the whole point is to deny it a line number to argue about. */
 export function stripPlanLineRefs(text: string): string {
   return text.replace(
-    /(?<![A-Za-z0-9_.:\-/\\])([A-Za-z0-9_.\-/\\]*[A-Za-z0-9_\-/\\]\.[A-Za-z][A-Za-z0-9]{0,7})(?::\d+(?:-\d+)?|#L\d+(?:-L?\d+)?)\b/g,
+    /(?<![A-Za-z0-9_.:\-/\\])([A-Za-z0-9_.\-/\\]*[A-Za-z0-9_\-/\\]\.[A-Za-z][A-Za-z0-9]{0,7})(?::\d+(?:-\d+)?(?::\d+)*|#L\d+(?:-L?\d+)?)\b(?!\/)/g,
     "$1",
   );
 }

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -104,7 +104,10 @@ export const PLAN_VERDICT_FILE = ".shepherd-plan-review.json";
  *    points at the wrong function" that the next round recycles, LENGTHENING the loop.
  *
  *  The pattern is narrow ON PURPOSE: it requires a path-ish token bearing a file EXTENSION
- *  immediately before the ref, so `10:30` and `--flag=3:4` are left alone. The leading lookbehind
+ *  immediately before the ref, so `10:30` and `--flag=3:4` are left alone. The extension must
+ *  START WITH A LETTER, which is what keeps decimals safe — without it `16.9:1` and `1.5:30` read
+ *  as "file `16.9`, line 1" and get rewritten, defeating the ratio/timestamp guarantee one line
+ *  up. Every real code extension qualifies (`.ts`, `.rs`, `.svelte`, `.mjs`, `.h`). The leading lookbehind
  *  forces the match to begin at a real token boundary, which is what keeps a URL authority safe:
  *  in `https://example.com:443/x`, `example.com` is preceded by `/` and the `//` is preceded by
  *  `:`, so neither can start a match and the port is not mistaken for a line number. (`.com` is
@@ -116,7 +119,7 @@ export const PLAN_VERDICT_FILE = ".shepherd-plan-review.json";
  *  false positive on timestamps, ports and ratios. Those are covered by the prompt rule instead. */
 export function stripPlanLineRefs(text: string): string {
   return text.replace(
-    /(?<![A-Za-z0-9_.:\-/\\])([A-Za-z0-9_.\-/\\]*[A-Za-z0-9_\-/\\]\.[A-Za-z0-9]{1,8})(?::\d+(?:-\d+)?|#L\d+(?:-L?\d+)?)\b/g,
+    /(?<![A-Za-z0-9_.:\-/\\])([A-Za-z0-9_.\-/\\]*[A-Za-z0-9_\-/\\]\.[A-Za-z][A-Za-z0-9]{0,7})(?::\d+(?:-\d+)?|#L\d+(?:-L?\d+)?)\b/g,
     "$1",
   );
 }
@@ -246,8 +249,16 @@ function locationReferenceBlock(
         `- The planning agent has made ${anchor.ahead} commit(s) SINCE that merge-base, and this checkout deliberately excludes them. So a file or symbol that does not resolve here — or that reads differently than the plan describes — may be code the agent has ALREADY WRITTEN this session, not a mistake. Such a reference is AMBIGUOUS: report it in "body" as a stated limitation, NEVER in "findings".`,
       );
     } else {
+      // Same discipline as the ahead>0 branch above, for the other way the trees can differ:
+      // `ahead` counts COMMITS, so the planner's uncommitted working-tree edits are invisible to
+      // this reviewer even at ahead=0 — and there is always at least one (the plan file), often
+      // product code (see advanceToExecutionOnPr in defaultPlanAnchorSha's doc). An unqualified
+      // "every file reads identically" would be false, and it is the premise the ONLY blocking
+      // rule in this block rests on, so the overclaim would license false findings against
+      // symbols that exist solely in the planner's dirty tree.
       lines.push(
-        "- The planning agent has committed nothing since, so every file reads IDENTICALLY for both of you. A reference to code that ALREADY EXISTS naming a file or symbol you cannot resolve IS therefore a finding — a wrong reference, not an imprecise one.",
+        "- The planning agent has committed nothing since, so every file COMMITTED at that point reads IDENTICALLY for both of you. A reference to such already-committed code naming a file or symbol you cannot resolve IS therefore a finding — a wrong reference, not an imprecise one.",
+        '- Its UNCOMMITTED working-tree edits are still invisible here, though. If an unresolvable reference plausibly names this session\'s own in-progress work rather than pre-existing code, it is AMBIGUOUS: report it in "body", NOT in "findings".',
       );
     }
   } else {

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -211,7 +211,9 @@ export function planReviewPrompt(
       "",
     );
   }
-  lines.push(...locationReferenceBlock(anchor, staleness), "");
+  // The re-raise exemption is gated on the SAME condition as the re-review block above — it cites
+  // that instruction, so emitting it on a first round would point at text the prompt doesn't have.
+  lines.push(...locationReferenceBlock(anchor, staleness, priorFindings.length > 0), "");
   lines.push(
     `Write your verdict as JSON to \`${PLAN_VERDICT_FILE}\` in the current directory, with EXACTLY this shape:`,
     '{"decision": "approve" | "request-changes", "summary": "<=100 char one-liner", "body": "<full markdown>", "findings": ["<discrete actionable revision>", ...]}',
@@ -244,6 +246,7 @@ export function planReviewPrompt(
 function locationReferenceBlock(
   anchor?: PlanAnchor | null,
   staleness?: AnchorStaleness | null,
+  isReReview = false,
 ): string[] {
   const lines = ["LOCATION REFERENCES — how to treat WHERE the plan says code lives:"];
   if (anchor) {
@@ -290,8 +293,17 @@ function locationReferenceBlock(
     // is that line numbers are not part of the contract — true whatever survived.
     "- Identify code by FILE PATH + SYMBOL (function / type / const / message key). A line number, a line range, or the precision of a location reference is NEVER a finding — line numbers are not part of the contract, and any you do see in the plan carry no authority.",
     '- When you AUTHOR A NEW finding, cite path + symbol, not line numbers, in "findings" and "body".',
-    "- EXEMPTION: re-raising a prior finding verbatim is REQUIRED by the re-review instruction above and OVERRIDES the previous rule. Reproduce its text unchanged, line numbers included; a re-raised prior finding is not itself a location complaint, and must not be dropped, reworded or reclassified on those grounds.",
   );
+  // Only on a RE-REVIEW: this bullet resolves a genuine conflict between the rule above and the
+  // "re-raise it verbatim" instruction, which is itself emitted only when there are prior
+  // findings. On a first round that instruction is absent, so an unconditional exemption would
+  // cite text the reviewer was never given — noise at best, and an invitation to invent a
+  // re-raise at worst.
+  if (isReReview) {
+    lines.push(
+      "- EXEMPTION: re-raising a prior finding verbatim is REQUIRED by the re-review instruction above and OVERRIDES the previous rule. Reproduce its text unchanged, line numbers included; a re-raised prior finding is not itself a location complaint, and must not be dropped, reworded or reclassified on those grounds.",
+    );
+  }
   return lines;
 }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -1041,14 +1041,32 @@ export function planBlockInstructions(opts: {
   return lines.join("\n");
 }
 
+/** How a plan must point at code. Shared verbatim by both plan-gate directives (interactive +
+ *  auto) so the two stay a pure provider delta.
+ *
+ *  Line numbers were the single biggest source of wasted rework rounds: the planner and the
+ *  adversarial reviewer historically read different trees, so a line number correct on one side
+ *  was wrong on the other, and rounds were spent re-numbering rather than improving the plan. The
+ *  reviewer now reads the planner's own merge-base AND has line refs stripped from the plan it is
+ *  shown, so a line citation is invisible to it — stating that here is what stops the planner
+ *  producing them in the first place. */
+const PLAN_REFERENCE_STYLE =
+  "Reference code by FILE PATH + SYMBOL (e.g. `src/foo.ts` → `handleX()`), never by line number: " +
+  "line numbers are stripped from the plan the reviewer is shown, so a line citation is noise, not " +
+  "evidence.\n";
+
 /**
  * The interactive plan-gate directive, provider-adjusted. Two Codex-specific divergences:
  *  - Codex has no AskUserQuestion tool, so step 2 tells it to ask in the conversation instead.
  *  - Codex's default disposition is eager (it caused TASK-413 by implementing instead of researching),
  *    so a hardened stop clause leads the directive: code stays untouched, the plan file is the only
  *    deliverable this turn, then STOP. Claude keeps the original phrasing verbatim.
- * `planGateDirectiveInteractive("claude")` is byte-identical to the prior
- * `PLAN_GATE_DIRECTIVE_INTERACTIVE` constant — keep it that way (Claude regression).
+ * `PLAN_GATE_DIRECTIVE_INTERACTIVE` is this builder called with "claude", so there is no separate
+ * constant left to drift from. What the old "byte-identical" note was really protecting still
+ * holds and is the rule to keep: the Claude output is the BASELINE, and provider-specific wording
+ * lives ONLY in the two clauses above. Any shared edit (e.g. the path+symbol line below) goes in
+ * the common body so both providers receive it verbatim — never duplicated per branch, where it
+ * could silently diverge (Claude regression).
  */
 function planGateDirectiveInteractive(
   agentProvider: AgentProvider,
@@ -1077,6 +1095,7 @@ function planGateDirectiveInteractive(
     "ready for review. The plan must contain NO open / " +
     "unresolved / TBD questions — resolve every question by asking first; it may still record stated " +
     "assumptions and resolved decisions.\n" +
+    PLAN_REFERENCE_STYLE +
     "An adversarial reviewer will critique the plan; address its findings by revising `.shepherd-plan.md`. " +
     "Begin implementing ONLY after the plan is approved and you are told to execute.\n\n" +
     planBlockInstructions({ allowQuestionForm: false, agentProvider, operatorLanguage })
@@ -1087,8 +1106,10 @@ const PLAN_GATE_DIRECTIVE_INTERACTIVE = planGateDirectiveInteractive("claude");
  * The unattended (drain) plan-gate directive, provider-adjusted. The auto path has NO human to catch
  * an eager Codex that starts implementing — so it needs the hardened stop clause even MORE than the
  * interactive path. Codex gets the same lead-in stop clause; Claude keeps the original phrasing.
- * `planGateDirectiveAuto("claude")` is byte-identical to the prior `PLAN_GATE_DIRECTIVE_AUTO`
- * constant — keep it that way (Claude regression).
+ * `PLAN_GATE_DIRECTIVE_AUTO` is this builder called with "claude". Same baseline rule as
+ * {@link planGateDirectiveInteractive}: Claude output is the reference shape, provider-specific
+ * wording stays in the stop clause above, and shared edits (e.g. the path+symbol referencing line)
+ * go in the common body so both providers receive them verbatim (Claude regression).
  */
 function planGateDirectiveAuto(
   agentProvider: AgentProvider,
@@ -1104,7 +1125,9 @@ function planGateDirectiveAuto(
     "You are in Shepherd's pre-execution PLAN GATE, running unattended (no human to ask). Do NOT write " +
     "or modify product code yet. Research the codebase, then write a concrete plan to `.shepherd-plan.md` " +
     "at the repo root (goal, approach, out of scope, files, testing seams + decisions, steps, risks, " +
-    "success criteria). An adversarial reviewer " +
+    "success criteria).\n" +
+    PLAN_REFERENCE_STYLE +
+    "An adversarial reviewer " +
     "will critique it; revise `.shepherd-plan.md` to address findings. Begin implementing ONLY after you " +
     "are told the plan is approved.\n\n" +
     planBlockInstructions({ allowQuestionForm: true, agentProvider, operatorLanguage })

--- a/src/service.ts
+++ b/src/service.ts
@@ -1047,13 +1047,17 @@ export function planBlockInstructions(opts: {
  *  Line numbers were the single biggest source of wasted rework rounds: the planner and the
  *  adversarial reviewer historically read different trees, so a line number correct on one side
  *  was wrong on the other, and rounds were spent re-numbering rather than improving the plan. The
- *  reviewer now reads the planner's own merge-base AND has line refs stripped from the plan it is
- *  shown, so a line citation is invisible to it — stating that here is what stops the planner
- *  producing them in the first place. */
+ *  reviewer now reads the planner's own merge-base and is barred from raising location findings —
+ *  stating that here is what stops the planner producing them in the first place.
+ *
+ *  The stripping clause is deliberately qualified ("path-attached"): `stripPlanLineRefs` only
+ *  removes refs bound to an extension-bearing path, so `Makefile:88` and prose like
+ *  `foo.ts (line 411)` reach the reviewer intact. Claiming blanket removal would overstate the
+ *  guarantee, and the barred-from-findings half is the part that actually holds unconditionally. */
 const PLAN_REFERENCE_STYLE =
   "Reference code by FILE PATH + SYMBOL (e.g. `src/foo.ts` → `handleX()`), never by line number: " +
-  "line numbers are stripped from the plan the reviewer is shown, so a line citation is noise, not " +
-  "evidence.\n";
+  "path-attached line refs are stripped from the plan the reviewer is shown, and it is barred from " +
+  "raising location findings either way, so a line citation is noise, not evidence.\n";
 
 /**
  * The interactive plan-gate directive, provider-adjusted. Two Codex-specific divergences:

--- a/src/transient-agent-argv.ts
+++ b/src/transient-agent-argv.ts
@@ -88,6 +88,12 @@ export interface TransientAgentArgvOptions {
    *  (nor, for the checkout-running kinds, a fixed `-o` target a committed symlink could redirect).
    *  Claude spawns ignore it (Claude has no `-o`). Default false. */
   captureLastMessage?: boolean;
+  /** Pre-minted session id to pin, instead of the fresh `randomUUID()` this builder would generate.
+   *  For a caller that needs the id BEFORE it can build the prompt — the plan gate keys its
+   *  reviewer worktree path on this id, but its prompt depends on facts that only exist once that
+   *  worktree has been created (the post-fetch anchor staleness), so it mints the id, creates the
+   *  worktree, then builds prompt + argv. Omitted everywhere else: the default is unchanged. */
+  sessionId?: string;
 }
 
 /** Read-only git grounding — diff/log/show/status only. NO add/commit/push. Shared by reviewer+doc. */
@@ -161,7 +167,7 @@ export function buildTransientAgentArgv(
   opts: TransientAgentArgvOptions,
 ): { argv: string[]; sessionId: string } {
   const preset = PRESETS[kind];
-  const sessionId = randomUUID();
+  const sessionId = opts.sessionId ?? randomUUID();
 
   // Codex CLI path: a headless, workspace-write-sandboxed `codex exec` runs the same prompt (which
   // writes the kind's result/verdict file). None of the Claude-only flags (--settings, --safe-mode,

--- a/test/plan-gate-anchor.test.ts
+++ b/test/plan-gate-anchor.test.ts
@@ -1,0 +1,141 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { defaultPlanAnchorSha, defaultAnchorStaleness } from "../src/plan-gate";
+
+/** A real repo with a real `origin`, because the whole point of these functions is WHICH commit
+ *  git actually picks — stubbing git would test nothing. Mirrors the temp-repo pattern in
+ *  critic-core.test.ts. Returns the "origin" (bare-ish upstream), the session worktree clone, and
+ *  a `git` helper bound to the clone. */
+function scaffold() {
+  const root = mkdtempSync(join(tmpdir(), "shep-anchor-"));
+  const upstream = join(root, "upstream");
+  const clone = join(root, "clone");
+  const git = (cwd: string, ...args: string[]) => {
+    const r = spawnSync("git", args, { cwd, stdio: "pipe" });
+    if (r.status !== 0) throw new Error(`git ${args.join(" ")}: ${r.stderr}`);
+    return new TextDecoder().decode(r.stdout).trim();
+  };
+  spawnSync("git", ["init", "-q", "-b", "main", upstream], { stdio: "pipe" });
+  git(upstream, "config", "user.email", "t@t");
+  git(upstream, "config", "user.name", "T");
+  writeFileSync(join(upstream, "existing.ts"), "export const a = 1;\n");
+  git(upstream, "add", "-A");
+  git(upstream, "commit", "-qm", "base");
+  const branchPoint = git(upstream, "rev-parse", "HEAD");
+
+  spawnSync("git", ["clone", "-q", upstream, clone], { stdio: "pipe" });
+  git(clone, "config", "user.email", "t@t");
+  git(clone, "config", "user.name", "T");
+  git(clone, "checkout", "-q", "-b", "feature");
+
+  return { root, upstream, clone, git, branchPoint };
+}
+
+test("anchor: merge-base wins, and is IDENTICAL whether or not the planner has committed", () => {
+  const { root, clone, git, branchPoint } = scaffold();
+  try {
+    // planner has committed nothing yet
+    const clean = defaultPlanAnchorSha(clone, "main", clone);
+    expect(clean).toEqual({ sha: branchPoint, anchored: true, ahead: 0 });
+
+    // planner commits code mid-gate — advanceToExecutionOnPr exists because this really happens
+    writeFileSync(join(clone, "scaffolding.ts"), "export const b = 2;\n");
+    git(clone, "add", "-A");
+    git(clone, "commit", "-qm", "planner scaffolding");
+    const dirty = defaultPlanAnchorSha(clone, "main", clone);
+
+    // Same anchor — this is why merge-base beats raw HEAD: the reviewer's tree does not swing
+    // under it as the planner works, so round N+1 anchors exactly where round N did.
+    expect(dirty.sha).toBe(branchPoint);
+    expect(dirty.anchored).toBe(true);
+    // ...but `ahead` now reports what the anchor is NOT showing the reviewer.
+    expect(dirty.ahead).toBe(1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("anchor: falls back to anchored:false when there is no origin to merge-base against", () => {
+  const root = mkdtempSync(join(tmpdir(), "shep-anchor-solo-"));
+  try {
+    spawnSync("git", ["init", "-q", "-b", "main", root], { stdio: "pipe" });
+    spawnSync("git", ["config", "user.email", "t@t"], { cwd: root, stdio: "pipe" });
+    spawnSync("git", ["config", "user.name", "T"], { cwd: root, stdio: "pipe" });
+    writeFileSync(join(root, "a.ts"), "1\n");
+    spawnSync("git", ["add", "-A"], { cwd: root, stdio: "pipe" });
+    spawnSync("git", ["commit", "-qm", "only"], { cwd: root, stdio: "pipe" });
+
+    const r = defaultPlanAnchorSha(root, "main", root);
+    // No `origin/main` ⇒ no merge-base ⇒ the legacy chain runs and the prompt must degrade.
+    expect(r.anchored).toBe(false);
+    expect(r.ahead).toBe(0);
+    // The local `main` rung still yields a real sha (rev-parse resolves the ref) — createDetached
+    // needs a hex sha, so only this rung and `origin/<base>` can actually reach a spawned review.
+    expect(r.sha).toMatch(/^[0-9a-f]{40}$/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("anchor: never throws on a non-repo path", () => {
+  const r = defaultPlanAnchorSha("/nonexistent-path-xyz", "main", "/nonexistent-path-xyz");
+  expect(r).toEqual({ sha: "main", anchored: false, ahead: 0 });
+});
+
+test("staleness: counts commits + changed paths on the base branch since the anchor", () => {
+  const { root, upstream, clone, git, branchPoint } = scaffold();
+  try {
+    // main moves on after the session branched
+    writeFileSync(join(upstream, "existing.ts"), "export const a = 99;\n");
+    writeFileSync(join(upstream, "brand-new.ts"), "export const n = 1;\n");
+    git(upstream, "add", "-A");
+    git(upstream, "commit", "-qm", "main moves on");
+
+    // nothing yet — the clone has not fetched, which is exactly the pre-fetch blind spot the
+    // production ordering avoids by calling this AFTER createDetached's fetch.
+    expect(defaultAnchorStaleness(clone, branchPoint, "main")).toEqual({
+      behind: 0,
+      changedSince: [],
+    });
+
+    git(clone, "fetch", "-q", "origin", "main");
+    const after = defaultAnchorStaleness(clone, branchPoint, "main");
+    expect(after.behind).toBe(1);
+    expect(after.changedSince.sort()).toEqual(["brand-new.ts", "existing.ts"]);
+    expect(after.more).toBeUndefined();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("staleness: caps the path list and reports the overflow count", () => {
+  const { root, upstream, clone, git, branchPoint } = scaffold();
+  try {
+    for (let i = 0; i < 55; i++)
+      writeFileSync(join(upstream, `f${i}.ts`), `export const x=${i};\n`);
+    git(upstream, "add", "-A");
+    git(upstream, "commit", "-qm", "many files");
+    git(clone, "fetch", "-q", "origin", "main");
+
+    const s = defaultAnchorStaleness(clone, branchPoint, "main");
+    expect(s.behind).toBe(1);
+    expect(s.changedSince.length).toBe(50); // CHANGED_SINCE_CAP
+    expect(s.more).toBe(5); // 55 - 50, so the prompt can say "and 5 more" honestly
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("staleness: zeroed (never throws) on a bad sha / non-repo", () => {
+  expect(defaultAnchorStaleness("/nonexistent-path-xyz", "abc1234", "main")).toEqual({
+    behind: 0,
+    changedSince: [],
+  });
+  expect(defaultAnchorStaleness(process.cwd(), "not-a-sha; rm -rf /", "main")).toEqual({
+    behind: 0,
+    changedSince: [],
+  });
+});

--- a/test/plan-gate-prompt.test.ts
+++ b/test/plan-gate-prompt.test.ts
@@ -109,6 +109,13 @@ test("stripPlanLineRefs leaves non-path colon forms alone (false-positive guard)
     "--flag=3:4",
     "ratio 16:9",
     "https://example.com:443/x",
+    // DECIMAL-bearing forms: `16.9` would read as "file 16.9" and `:1` as its line number unless
+    // the extension is required to start with a letter. Aspect ratios, versions and clock times
+    // with a fractional part all land in this class.
+    "16.9:1",
+    "1.5:30",
+    "v2.0:5",
+    "cpu 0.75:1",
   ]) {
     expect(stripPlanLineRefs(s)).toBe(s);
   }
@@ -152,6 +159,18 @@ test("strong tier (anchored, ahead=0): names the anchor and makes an unresolvabl
   expect(p).toContain("IS therefore a finding");
   expect(p).not.toContain("commit(s) SINCE that merge-base");
   expect(p).not.toContain("could NOT be tied");
+});
+
+test("strong tier scopes its claim to COMMITTED code and carves out the planner's dirty tree", () => {
+  // `ahead` counts commits, so uncommitted working-tree edits are invisible even at ahead=0 —
+  // and there is always at least one (the plan file). An unqualified "every file reads
+  // identically" would be the premise of this block's ONLY blocking rule, so the overclaim would
+  // license false findings against symbols that exist solely in the planner's dirty tree.
+  const p = planReviewPrompt("t", "plan", [], null, "en", STRONG);
+  expect(p).toContain("every file COMMITTED at that point reads IDENTICALLY");
+  expect(p).toContain("such already-committed code");
+  expect(p).toContain("UNCOMMITTED working-tree edits are still invisible");
+  expect(p).toContain('report it in "body", NOT in "findings"');
 });
 
 test("ahead tier (anchored, ahead>0): unresolvable refs route to body, never findings", () => {

--- a/test/plan-gate-prompt.test.ts
+++ b/test/plan-gate-prompt.test.ts
@@ -221,7 +221,7 @@ test("degraded tier (no anchor): no anchor claim, unresolvable refs go to body",
   expect(p).not.toContain("IS therefore a finding");
 });
 
-test("every tier carries the same carve-out, line-number ban, output rule and re-raise exemption", () => {
+test("every tier carries the same carve-out, line-number ban and output rule", () => {
   for (const p of [
     planReviewPrompt("t", "plan", [], null, "en", STRONG),
     planReviewPrompt("t", "plan", [], null, "en", AHEAD),
@@ -235,7 +235,24 @@ test("every tier carries the same carve-out, line-number ban, output rule and re
     expect(p).toContain("line numbers are not part of the contract");
     expect(p).not.toContain("have been removed from the plan you were shown");
     expect(p).toContain("When you AUTHOR A NEW finding");
-    expect(p).toContain("EXEMPTION: re-raising a prior finding verbatim is REQUIRED");
+  }
+});
+
+test("the re-raise exemption tracks the re-review block it cites, in every tier", () => {
+  const EXEMPTION = "EXEMPTION: re-raising a prior finding verbatim is REQUIRED";
+  const anchors = [STRONG, AHEAD, undefined];
+  for (const a of anchors) {
+    // First round: no prior findings ⇒ no "re-raise it verbatim" instruction ⇒ the exemption
+    // would cite text the reviewer was never given.
+    const first = planReviewPrompt("t", "plan", [], null, "en", a);
+    expect(first).not.toContain("RE-REVIEW");
+    expect(first).not.toContain(EXEMPTION);
+
+    // Re-review: both appear, and the exemption's "above" now resolves.
+    const re = planReviewPrompt("t", "plan", ["prior: src/a.ts:9 wrong"], null, "en", a);
+    expect(re).toContain("re-raise it verbatim");
+    expect(re).toContain(EXEMPTION);
+    expect(re.indexOf("re-raise it verbatim")).toBeLessThan(re.indexOf(EXEMPTION));
   }
 });
 

--- a/test/plan-gate-prompt.test.ts
+++ b/test/plan-gate-prompt.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "bun:test";
-import { planReviewPrompt, reviewerArgv, PLAN_VERDICT_FILE } from "../src/plan-gate";
+import {
+  planReviewPrompt,
+  reviewerArgv,
+  stripPlanLineRefs,
+  PLAN_VERDICT_FILE,
+} from "../src/plan-gate";
 
 test("prompt embeds task + plan + prior findings + verdict file + read-only", () => {
   const p = planReviewPrompt("do X", "PLAN TEXT", ["earlier nit"]);
@@ -79,4 +84,131 @@ test("de: planReviewPrompt names summary/body/findings as German-prose fields, k
   expect(p).toContain("findings");
   expect(p).toContain("decision");
   expect(p).toContain('"approve" | "request-changes"');
+});
+
+// ─── line-reference stripping ────────────────────────────────────────────────────────────────
+// The strip is a NARROW deterministic backstop, not a sanitiser: it requires an extension-bearing
+// path token immediately before the ref. The "survives" cases below are the deliberate trade —
+// widening the pattern to catch them would start eating timestamps, ports and ratios. They are
+// asserted here so the trade-off is pinned by a test rather than by prose in the plan.
+
+test("stripPlanLineRefs removes extension-bearing path:line and #Lline refs", () => {
+  expect(stripPlanLineRefs("see src/ui/mod.rs:1385-1388 now")).toBe("see src/ui/mod.rs now");
+  expect(stripPlanLineRefs("foo.ts:12")).toBe("foo.ts");
+  expect(stripPlanLineRefs("a/b/x.svelte#L20-L40")).toBe("a/b/x.svelte");
+  expect(stripPlanLineRefs("a/b/x.svelte#L20")).toBe("a/b/x.svelte");
+  expect(stripPlanLineRefs("plan-gate.ts:1227-1231, review.ts:312")).toBe(
+    "plan-gate.ts, review.ts",
+  );
+});
+
+test("stripPlanLineRefs leaves non-path colon forms alone (false-positive guard)", () => {
+  for (const s of [
+    "10:30",
+    "http://host:8080",
+    "--flag=3:4",
+    "ratio 16:9",
+    "https://example.com:443/x",
+  ]) {
+    expect(stripPlanLineRefs(s)).toBe(s);
+  }
+});
+
+test("stripPlanLineRefs: documented gaps survive (governed by the prompt rule, not the regex)", () => {
+  // bare `:NNN` continuation — the leading path ref goes, the detached one stays
+  expect(stripPlanLineRefs("foo.ts:1085, :1090")).toBe("foo.ts, :1090");
+  // prose forms and extension-less paths are untouched entirely
+  for (const s of ["foo.ts (line 411)", "line 411 of foo.ts", "Makefile:88", "Dockerfile:12"]) {
+    expect(stripPlanLineRefs(s)).toBe(s);
+  }
+});
+
+test("prompt strips line refs from the PLAN but never from task / issueBody / prior findings", () => {
+  const p = planReviewPrompt(
+    "fix the clamp at task.ts:120",
+    "rewrite handleX in src/plan.ts:412",
+    ["the ref src/old.ts:99 points at the wrong function"],
+    "issue mentions src/issue.ts:7",
+  );
+  // plan: stripped
+  expect(p).toContain("rewrite handleX in src/plan.ts");
+  expect(p).not.toContain("src/plan.ts:412");
+  // task / issueBody / prior findings: verbatim — human-authored ground truth, and findings are
+  // re-raised verbatim, so mutating them would make them un-addressable.
+  expect(p).toContain("task.ts:120");
+  expect(p).toContain("src/issue.ts:7");
+  expect(p).toContain("src/old.ts:99");
+});
+
+// ─── the three tiers + the unconditional referencing rules ───────────────────────────────────
+
+const STRONG = { sha: "abc1234", ahead: 0 };
+const AHEAD = { sha: "abc1234", ahead: 3 };
+
+test("strong tier (anchored, ahead=0): names the anchor and makes an unresolvable ref a finding", () => {
+  const p = planReviewPrompt("t", "plan", [], null, "en", STRONG);
+  expect(p).toContain("abc1234");
+  expect(p).toContain("reads IDENTICALLY");
+  expect(p).toContain("IS therefore a finding");
+  expect(p).not.toContain("commit(s) SINCE that merge-base");
+  expect(p).not.toContain("could NOT be tied");
+});
+
+test("ahead tier (anchored, ahead>0): unresolvable refs route to body, never findings", () => {
+  const p = planReviewPrompt("t", "plan", [], null, "en", AHEAD);
+  expect(p).toContain("3 commit(s) SINCE that merge-base");
+  expect(p).toContain('report it in "body"');
+  expect(p).toContain('NEVER in "findings"');
+  // the blocking form must NOT appear — this is the regression that manufactured junk findings
+  // on long multi-round sessions (round 3 citing round 1's committed scaffolding).
+  expect(p).not.toContain("IS therefore a finding");
+  // ...and neither may the co-location claim: with commits past the anchor, a pre-existing file
+  // the agent has since edited does NOT read the same on both sides, so asserting it would
+  // license the very false findings this tier exists to prevent.
+  expect(p).not.toContain("reads IDENTICALLY");
+});
+
+test("degraded tier (no anchor): no anchor claim, unresolvable refs go to body", () => {
+  const p = planReviewPrompt("t", "plan");
+  expect(p).toContain("could NOT be tied");
+  expect(p).toContain('report it in "body"');
+  expect(p).not.toContain("reads IDENTICALLY");
+  expect(p).not.toContain("IS therefore a finding");
+});
+
+test("every tier carries the same carve-out, line-number ban, output rule and re-raise exemption", () => {
+  for (const p of [
+    planReviewPrompt("t", "plan", [], null, "en", STRONG),
+    planReviewPrompt("t", "plan", [], null, "en", AHEAD),
+    planReviewPrompt("t", "plan"),
+  ]) {
+    expect(p).toContain("ADD, RENAME or MOVE are NEVER findings");
+    expect(p).toContain("precision of a location reference is NEVER a finding");
+    expect(p).toContain("When you AUTHOR A NEW finding");
+    expect(p).toContain("EXEMPTION: re-raising a prior finding verbatim is REQUIRED");
+  }
+});
+
+test("staleness block: emitted only with behind>0 AND changed paths, and is body-only", () => {
+  const p = planReviewPrompt("t", "plan", [], null, "en", STRONG, {
+    behind: 12,
+    changedSince: ["src/a.ts", "src/b.ts"],
+    more: 4,
+  });
+  expect(p).toContain("12 commit(s) behind");
+  expect(p).toContain("src/a.ts, src/b.ts");
+  expect(p).toContain("and 4 more");
+  expect(p).toContain("Anchor staleness (informational, non-blocking):");
+  expect(p).toContain("NEVER a finding");
+
+  // omitted entirely when there is nothing material to say
+  for (const s of [
+    null,
+    { behind: 0, changedSince: ["src/a.ts"] },
+    { behind: 5, changedSince: [] },
+  ]) {
+    expect(planReviewPrompt("t", "plan", [], null, "en", STRONG, s)).not.toContain(
+      "Anchor staleness",
+    );
+  }
 });

--- a/test/plan-gate-prompt.test.ts
+++ b/test/plan-gate-prompt.test.ts
@@ -102,6 +102,32 @@ test("stripPlanLineRefs removes extension-bearing path:line and #Lline refs", ()
   );
 });
 
+test("stripPlanLineRefs consumes grep/compiler file:line:col refs WHOLE", () => {
+  // Matching only the `:line` half would leave `foo.ts:5` — a surviving, plausible-looking
+  // reference to the WRONG line. That is strictly worse than not matching at all, since it
+  // re-arms the exact argument the strip exists to prevent, now pointing somewhere bogus.
+  expect(stripPlanLineRefs("foo.ts:12:5")).toBe("foo.ts");
+  expect(stripPlanLineRefs("src/a.rs:10:3: error")).toBe("src/a.rs: error");
+  expect(stripPlanLineRefs("src/a.ts:1:2:3")).toBe("src/a.ts");
+});
+
+test("stripPlanLineRefs leaves host:port/path alone even without a scheme prefix", () => {
+  // The token-boundary lookbehind only defuses a URL when `//` is present; a bare registry ref
+  // has no scheme, so the trailing (?!/) does the work — a port is followed by a path, a line
+  // number never is.
+  for (const s of ["ghcr.io:443/x", "registry.io:5000/img:tag", "docker.io:5000/a/b"]) {
+    expect(stripPlanLineRefs(s)).toBe(s);
+  }
+});
+
+test("stripPlanLineRefs: bare host:port is a KNOWN, accepted false positive", () => {
+  // With no path there is nothing left to distinguish `ghcr.io:443` from `foo.ts:443`, and a TLD
+  // blocklist is not an option: `.rs`, `.sh`, `.pl` and `.ml` are all simultaneously real code
+  // extensions and real TLDs. Accepted because it is cosmetic — the reviewer's copy of the plan
+  // loses a port number, which costs nothing. Asserted so the behaviour is pinned, not forgotten.
+  expect(stripPlanLineRefs("ghcr.io:443")).toBe("ghcr.io");
+});
+
 test("stripPlanLineRefs leaves non-path colon forms alone (false-positive guard)", () => {
   for (const s of [
     "10:30",

--- a/test/plan-gate-prompt.test.ts
+++ b/test/plan-gate-prompt.test.ts
@@ -229,6 +229,11 @@ test("every tier carries the same carve-out, line-number ban, output rule and re
   ]) {
     expect(p).toContain("ADD, RENAME or MOVE are NEVER findings");
     expect(p).toContain("precision of a location reference is NEVER a finding");
+    // The reviewer must NOT be told line numbers were exhaustively removed: the strip only
+    // catches path-attached refs, so `Makefile:88` reaches it intact and a blanket promise would
+    // be visibly false the first time one survives — discrediting the rule it justifies.
+    expect(p).toContain("line numbers are not part of the contract");
+    expect(p).not.toContain("have been removed from the plan you were shown");
     expect(p).toContain("When you AUTHOR A NEW finding");
     expect(p).toContain("EXEMPTION: re-raising a prior finding verbatim is REQUIRED");
   }

--- a/test/plan-gate-service.test.ts
+++ b/test/plan-gate-service.test.ts
@@ -82,7 +82,8 @@ function harness(over: any = {}) {
     now: () => 1000,
     readPlan: () => "PLAN TEXT",
     readVerdict: () => null,
-    baseSha: () => "abc",
+    baseSha: () => ({ sha: "abc", anchored: true, ahead: 0 }),
+    anchorStaleness: () => ({ behind: 0, changedSince: [] }),
     // `store` is already merged above (base + over.store); exclude it here so the
     // deps-level spread doesn't re-overwrite it with the un-merged per-test partial.
     ...overWithoutStore,
@@ -2079,4 +2080,154 @@ test("tab baseline: repeated plan reviews (approve + timeout + cancel) leave zer
     expect(openTabs.size).toBe(0);
   }
   expect(n).toBe(6); // six real spawns; all six tabs were closed
+});
+
+// ─── anchor resolution + staleness ordering ──────────────────────────────────────────────────
+
+test("begin passes the session worktreePath to the anchor resolver", async () => {
+  const seen: any[] = [];
+  const h = harness({
+    baseSha: (repoPath: string, base: string, worktreePath: string) => {
+      seen.push([repoPath, base, worktreePath]);
+      return { sha: "abc", anchored: true, ahead: 0 };
+    },
+  });
+  await h.svc.consider(planningSession() as any);
+  // The third argument is the whole point: without the planner's own worktree there is no
+  // merge-base to anchor to, and the reviewer falls back to the drifted freshest origin/<base>.
+  expect(seen).toEqual([["/r", "main", "/wt"]]);
+});
+
+test("anchorStaleness runs AFTER createDetached (its fetch is what makes the numbers real)", async () => {
+  const order: string[] = [];
+  const h = harness({
+    worktree: {
+      createDetached: async () => {
+        order.push("createDetached");
+        return { worktreePath: "/wt-detached", branch: "main" };
+      },
+      remove: () => {},
+      gitCommonDir: () => "/fake-git-common",
+    },
+    anchorStaleness: () => {
+      order.push("anchorStaleness");
+      return { behind: 0, changedSince: [] };
+    },
+  });
+  await h.svc.consider(planningSession() as any);
+  // Ordering is invisible in the returned numbers — only this assertion catches a regression that
+  // measures against a pre-fetch origin/<base> and silently understates (often to zero).
+  expect(order).toEqual(["createDetached", "anchorStaleness"]);
+});
+
+test("anchored=false suppresses the anchor claim AND skips staleness entirely", async () => {
+  let stalenessCalls = 0;
+  const h = harness({
+    baseSha: () => ({ sha: "deadbeef", anchored: false, ahead: 0 }),
+    anchorStaleness: () => {
+      stalenessCalls++;
+      return { behind: 9, changedSince: ["src/a.ts"] };
+    },
+  });
+  await h.svc.consider(planningSession() as any);
+  const prompt = h.started[0].argv.at(-1) as string;
+  expect(prompt).toContain("could NOT be tied");
+  expect(prompt).not.toContain("reads IDENTICALLY");
+  // Measuring drift from an anchor that isn't the planner's tree would be meaningless.
+  expect(stalenessCalls).toBe(0);
+});
+
+test("ahead>0 routes unresolvable refs to body; the staleness block reaches the prompt", async () => {
+  const h = harness({
+    baseSha: () => ({ sha: "abc1234", anchored: true, ahead: 2 }),
+    anchorStaleness: () => ({ behind: 7, changedSince: ["src/a.ts"], more: 3 }),
+  });
+  await h.svc.consider(planningSession() as any);
+  const prompt = h.started[0].argv.at(-1) as string;
+  expect(prompt).toContain("2 commit(s) SINCE that merge-base");
+  expect(prompt).not.toContain("IS therefore a finding");
+  expect(prompt).toContain("7 commit(s) behind");
+  expect(prompt).toContain("Anchor staleness (informational, non-blocking):");
+});
+
+test("the reviewer argv pins the same session id that keys the worktree path", async () => {
+  const slugs: string[] = [];
+  const h = harness({
+    worktree: {
+      createDetached: async (_r: string, _b: string, _s: string, slug: string) => {
+        slugs.push(slug);
+        return { worktreePath: "/wt-detached", branch: "main" };
+      },
+      remove: () => {},
+      gitCommonDir: () => "/fake-git-common",
+    },
+  });
+  await h.svc.consider(planningSession() as any);
+  // The prompt is now built after createDetached, so the id is minted up front and threaded into
+  // reviewerArgv. If those ever diverge, the transcript/verdict lookups silently miss.
+  const argv = h.started[0].argv as string[];
+  const idIdx = argv.indexOf("--session-id");
+  expect(idIdx).toBeGreaterThan(-1);
+  expect(argv[idIdx + 1]).toBe(slugs[0]);
+  expect(h.recordedSpawns[0].reviewerSessionId).toBe(slugs[0]);
+});
+
+// ─── findings are never mutated (both resolveFindings branches) ──────────────────────────────
+// The strip is INBOUND-only. Findings travel to the planner verbatim — via steerFindings, via
+// resume()'s re-steer, and via the next round's "re-raise it verbatim" instruction — so rewriting
+// them would turn "the ref x.ts:12 points at the wrong function" into an un-addressable
+// "the ref x.ts points at the wrong function" that the next round recycles, LENGTHENING the loop.
+
+test("findings reach the gate byte-identical (parsed-array branch)", async () => {
+  const h = harness({
+    readVerdict: () => ({
+      decision: "request-changes",
+      summary: "s",
+      body: "the body cites src/b.ts:77",
+      findings: ["src/a.ts:412 clamps the wrong value", "second point"],
+    }),
+  });
+  await h.svc.consider(planningSession() as any);
+  await h.svc.tick();
+  expect(h.store.gate.findings).toEqual(["src/a.ts:412 clamps the wrong value", "second point"]);
+  expect(h.store.gate.body).toBe("the body cites src/b.ts:77");
+});
+
+test("findings reach the gate byte-identical (empty-findings rawSummary fallback branch)", async () => {
+  // resolveFindings falls back to the UN-clamped raw summary when findings[] is empty. That value
+  // is assembled separately from normalizeFindings, so a strip placed there would have missed it —
+  // this branch is what invalidated an earlier design.
+  const h = harness({
+    readVerdict: () => ({
+      decision: "request-changes",
+      summary: "the plan's ref src/ui/mod.rs:1385-1388 is wrong",
+      body: "B",
+      findings: [],
+    }),
+  });
+  await h.svc.consider(planningSession() as any);
+  await h.svc.tick();
+  expect(h.store.gate.findings).toEqual(["the plan's ref src/ui/mod.rs:1385-1388 is wrong"]);
+  expect(h.store.gate.summary).toBe("the plan's ref src/ui/mod.rs:1385-1388 is wrong");
+});
+
+test("prior findings are re-raised into the next prompt verbatim, line numbers intact", async () => {
+  const h = harness({
+    store: {
+      getPlanGate: () => ({
+        sessionId: "s1",
+        planHash: "OLD",
+        decision: "changes_requested",
+        approved: false,
+        round: 1,
+        findings: ["the ref src/old.ts:99 points at the wrong function"],
+      }),
+    },
+  });
+  await h.svc.consider(planningSession() as any);
+  const prompt = lastPrompt(h);
+  expect(prompt).toContain("the ref src/old.ts:99 points at the wrong function");
+  // ...and the prompt must tell the reviewer that reproducing it is REQUIRED, so the new
+  // "cite path + symbol, not line numbers" rule cannot be read as an order to rewrite it.
+  expect(prompt).toContain("EXEMPTION: re-raising a prior finding verbatim is REQUIRED");
 });

--- a/test/service-plan-gate.test.ts
+++ b/test/service-plan-gate.test.ts
@@ -246,3 +246,14 @@ test("worktree-stash-notice recommends read-only + create/apply, never store or 
   // Bare stash/pop explicitly prohibited.
   expect(p).toContain("never bare `git stash`");
 });
+
+test("both plan-gate directives tell the planner to reference code by path + symbol", () => {
+  // The reviewer never sees line numbers (they are stripped from the plan it is shown) and is
+  // forbidden from raising location findings — so a planner still emitting them produces noise
+  // that cannot be acted on. Both directives must carry the rule, byte-identically.
+  for (const d of [PLAN_GATE_DIRECTIVE_INTERACTIVE, PLAN_GATE_DIRECTIVE_AUTO]) {
+    expect(d).toContain("FILE PATH + SYMBOL");
+    expect(d).toContain("never by line number");
+    expect(d).toContain("line numbers are stripped from the plan the reviewer is shown");
+  }
+});

--- a/test/service-plan-gate.test.ts
+++ b/test/service-plan-gate.test.ts
@@ -248,12 +248,16 @@ test("worktree-stash-notice recommends read-only + create/apply, never store or 
 });
 
 test("both plan-gate directives tell the planner to reference code by path + symbol", () => {
-  // The reviewer never sees line numbers (they are stripped from the plan it is shown) and is
-  // forbidden from raising location findings — so a planner still emitting them produces noise
-  // that cannot be acted on. Both directives must carry the rule, byte-identically.
+  // The reviewer is barred from raising location findings, so a planner still emitting line
+  // numbers produces noise that cannot be acted on. Both directives must carry the rule.
   for (const d of [PLAN_GATE_DIRECTIVE_INTERACTIVE, PLAN_GATE_DIRECTIVE_AUTO]) {
     expect(d).toContain("FILE PATH + SYMBOL");
     expect(d).toContain("never by line number");
-    expect(d).toContain("line numbers are stripped from the plan the reviewer is shown");
+    // The stripping claim must stay QUALIFIED: stripPlanLineRefs only removes refs bound to an
+    // extension-bearing path, so `Makefile:88` and `foo.ts (line 411)` survive (pinned in
+    // plan-gate-prompt.test.ts). An unqualified "line numbers are stripped" would promise a
+    // guarantee the code does not make.
+    expect(d).toContain("path-attached line refs are stripped");
+    expect(d).not.toContain("line numbers are stripped");
   }
 });


### PR DESCRIPTION
## Problem

The plan reviewer detached at the **freshest `origin/<base>`**, while the planning agent read its own session worktree — cut from `origin/main` whenever the session started. Different trees, and neither prompt named a commit. So both sides cited `file:line` from different ground truth, both were "verifiably right", and rounds were spent re-numbering instead of improving the plan.

## The observation is real, and it's this gate

Read-only measurement over `reviewer_spawns` (1035 sessions, 90-day retention window, oldest surviving row 2026-06-10):

| Metric | plan_gate | review (PR critic) |
| --- | --- | --- |
| Spawns / sessions | 3316 / 1035 | 2269 / 1156 |
| Mean per session | **3.20** | 1.96 |
| Max | **35** | 18 |
| Sessions at ≥10 rounds | **29** | 6 |

Top-decile streaks are plan-gate dominated (35/18, 29/4, 27/1, 27/0). At default caps neither gate reaches 10-12 alone (plan-gate 5, PR-critic `2*cap`=6), so those counts imply raised caps or `resume()` budget resets — which is why spawn rows, not `plan_gates.round`, are the metric: `plan_gates` is one upserted row per session and `buildGate` zeroes `round` + empties `findings` on approval, destroying the evidence of every session that passed.

**§9a baseline for post-merge comparison: mean 3.20 plan_gate spawns/session.**

## Change

**Anchor** — `planAnchorSha` resolves the merge-base of the session worktree's `HEAD` and `origin/<base>`, so both sides read identical bytes for pre-existing files. Not raw `HEAD`: that tree is **untrusted** — it carries whatever the planner committed, including `CLAUDE.md`, `.claude/settings.json`, hooks and skills, and the reviewer launches *in that directory*, so the agent under review would supply the reviewing agent's own instructions. (`scrubStaleVerdictArtifacts` already closes the pre-seeded-verdict hole; scrubbing one filename does nothing about agent config.) Falls back to the previous chain flagged `anchored: false`.

**Three prompt tiers, by what the reviewer can actually see:**

| | strong (`ahead=0`) | ahead (`ahead>0`) | degraded (no anchor) |
| --- | --- | --- | --- |
| co-location claim | emitted | withheld | withheld |
| unresolvable ref to existing code | **is a finding** | `body`, not `findings` | `body`, not `findings` |
| ref to a newly-proposed symbol | never a finding | never a finding | never a finding |
| line-number / precision findings | forbidden | forbidden | forbidden |

The `ahead` tier exists because merge-base excludes the planner's own commits by construction — on a multi-round session, round 3's plan cites round 1's committed scaffolding, and without it the resolution rule manufactures junk findings on exactly the long sessions this targets.

**Strip** — `stripPlanLineRefs` removes `path.ext:NNN` / `#LNNN` from **the plan text only**. Deliberately not from `task`/`issueBody` (human-authored ground truth the reviewer judges against) and not from findings: `planReviewPrompt` orders prior findings re-raised **verbatim**, so rewriting one turns "the ref `x.ts:12` points at the wrong function" into an un-addressable "the ref `x.ts` points at the wrong function" that the next round recycles forever. The output rule is scoped to *newly authored* findings and carries an explicit re-raise exemption, so the two instructions can't contradict each other for gates already in `changes_requested` at rollout.

**Staleness** — `behind`/`changedSince` are computed **after** `createDetached`'s fetch. Before it, they measured a stale local ref and systematically understated, usually to `behind: 0`, silently suppressing the note. Routed to `body` under a fixed heading, never a finding — the plan gate is the only pre-execution gate, so it should be able to *inform* about a plan targeting code `main` has since restructured, without gaining a new way to block.

**Directives** — both plan-gate directives now tell the planner to reference code by path + symbol.

## Notes for review

- The regex is narrow on purpose and its gaps are asserted to **survive** (`Makefile:88`, `foo.ts (line 411)`, bare `:1090`), so the trade-off is pinned by tests rather than prose. Self-review caught two live false positives on `https://example.com:443/x` — `.com` reads as an extension and `/` is a legal token char — fixed by a token-boundary lookbehind.
- `buildTransientAgentArgv` gains an optional `sessionId`. The plan gate needs the id *before* it can build the prompt (the id keys the worktree path; the prompt depends on that worktree's post-fetch state). Additive, default unchanged, no other caller passes it.
- `begin()` crossed the fallow complexity threshold with the added branches; prompt assembly is extracted to `composeReviewerPrompt`, which also documents the call-order requirement at the place that could break it.
- Server-only, no UI/i18n/catalog surface — `fix:` does not arm the feature-catalog gate.
- One flaky UI failure was seen on the first push attempt (`TopBar.browser.test.ts`, `expected 51.99998474121094 to be >= 52`) and passed clean on re-run. This PR touches no `ui/` files.

## Verification

`bun run lint`, `bun test` (7392 pass / 0 fail, +25 new), `cd ui && bun run test` (4171 pass), `check:i18n`, `check-glossary`, branch + feature-catalog hygiene, `fallow@2.100.0 audit` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)