### PR TITLE
chore(deps): apply supply-chain cooldown to site/ + docs-site/

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # Bun version updates across all three packages. Bun *security* updates are
+  # Bun version updates across all five packages. Bun *security* updates are
   # unsupported by Dependabot and are disabled at the repo level; daily scheduling
   # keeps the version-update (= effective security-fix) channel fresh.
   #
@@ -16,6 +16,8 @@ updates:
       - "/"
       - "/ui"
       - "/extension"
+      - "/site"
+      - "/docs-site"
     schedule:
       interval: "daily"
     cooldown:

--- a/docs-site/bunfig.toml
+++ b/docs-site/bunfig.toml
@@ -1,0 +1,8 @@
+# Supply-chain cooldown: refuse to resolve npm versions published < 3 days ago.
+# Compromised releases are typically yanked within hours, so this filters most
+# such incidents at the resolution layer. Note: only enforced when resolving new
+# versions (`bun add`/`bun update`); versions already pinned in bun.lock are
+# reinstalled without the check, and Dependabot doesn't read this — its own
+# `cooldown` in .github/dependabot.yml guards that vector. 259200s = 3 days.
+[install]
+minimumReleaseAge = 259200

--- a/site/bunfig.toml
+++ b/site/bunfig.toml
@@ -1,0 +1,8 @@
+# Supply-chain cooldown: refuse to resolve npm versions published < 3 days ago.
+# Compromised releases are typically yanked within hours, so this filters most
+# such incidents at the resolution layer. Note: only enforced when resolving new
+# versions (`bun add`/`bun update`); versions already pinned in bun.lock are
+# reinstalled without the check, and Dependabot doesn't read this — its own
+# `cooldown` in .github/dependabot.yml guards that vector. 259200s = 3 days.
+[install]
+minimumReleaseAge = 259200


### PR DESCRIPTION
Closes #1860.

`site/` and `docs-site/` were resolving npm versions with **no supply-chain cooldown at all**. Bun reads `bunfig.toml` from cwd + global only — there is no ancestor-directory walk — and both are standalone packages (own `bun.lock`; the root `package.json` has no `workspaces` field), so the root config never applied.

This is not a new install policy. `ui/bunfig.toml` and `extension/bunfig.toml` already exist as byte-identical copies of the same cooldown block; these two packages were simply missed. This completes the existing convention.

## Changes

| File | Change |
| --- | --- |
| `site/bunfig.toml` | added — verbatim copy of `ui/bunfig.toml` |
| `docs-site/bunfig.toml` | added — verbatim copy of `ui/bunfig.toml` |
| `.github/dependabot.yml` | `/site` + `/docs-site` added to the bun `directories:`; stale "all three packages" comment → "five" |

Dependabot omitted both packages too — same root cause. Including it also makes that block's existing claim ("matches the `minimumReleaseAge` in each bunfig.toml") true.

## Verification

**1. Byte-identity** — `cmp ui/bunfig.toml {site,docs-site}/bunfig.toml` silent for both. ✅

**2. Resolution probe** — proves Bun actually reads a `bunfig.toml` at that cwd, run on a scratch copy of `site/` outside the worktree. `bun add typescript@latest --dry-run`:

| Arm | scratch `bunfig.toml` | resolved |
| --- | --- | --- |
| A | `minimumReleaseAge = 315360000` (~10y) | `typescript@2.0.0` |
| B | file removed | `typescript@7.0.2` |
| C | verbatim committed copy (259200) | `typescript@7.0.2` |

A ≠ B, B at current latest, C resolves on the exact committed file. ✅ The *difference* is the evidence — either arm alone proves nothing.

Worth recording for the next reader: **`minimumReleaseAge` does not hard-fail.** It filters candidates and falls back to the newest version older than the cutoff, which is why arm A resolved an ancient version instead of erroring. An earlier draft of this check asserted "must be refused" and would have reported a false failure. `typescript` was chosen deliberately — its 2012-onward history guarantees versions on both sides of a 10-year cutoff, so the fallback branch engages rather than erroring; a package first published inside the last 10 years (e.g. `astro`) would have made the result depend on registry history.

**3. `dependabot.yml`** parses; bun `directories` is exactly `["/", "/ui", "/extension", "/site", "/docs-site"]`; `open-pull-requests-limit` and `groups` byte-unchanged vs main; the `github-actions` block untouched. ✅

**4. Final gate** — `git diff --exit-code -- '**/bun.lock'` clean, `git status --porcelain` shows only the three intended files. No lockfile moved. ✅

Prettier clean (`.prettierignore` excludes `site`/`docs-site` wholesale, so only `dependabot.yml` is covered). Branch-hygiene + feature-catalog gates pass. Pre-push initially failed on `TopBar.browser.test.ts` — a sub-pixel geometry assertion (`51.99998474121094` vs `52`); it passes in isolation and this branch's `ui/` is byte-identical to `origin/main`, so it is a pre-existing flake, not caused by this change. The retried push passed clean.

## Reviewer notes

- **Vercel pickup is assumed, not verified.** Neither `vercel.json` sets an `installCommand`, and Root Directory lives in the Vercel dashboard, so cwd-at-install is unverifiable from the repo. It holds iff Root Directory is `site` / `docs-site` (near-certain — separate projects in a monorepo). See the manual step below. If it is instead the repo root, Vercel builds stay unprotected; the human-run and Dependabot vectors are fixed either way.
- **Expect new Dependabot PRs** for both packages, against the shared `open-pull-requests-limit: 10`. Intended. Deliberately not mitigated by raising the limit — that is a separate PR-volume policy call.
- **`site/` bump PRs get no CI build signal.** CI builds `docs-site` but not `site`, so Vercel's preview deploy is their only check. Pre-existing CI shape, newly relevant. Not fixed here.
- **Deliberately excluded:** `minimumReleaseAgeExcludes` (no existing config sets one), a root-comment amendment (with all five packages covered there is no out-of-scope package left to document), a parity-enforcement CI gate, and the `ci.yml` comments at `:59`/`:172` — those describe CI job shape, which this change does not alter, unlike the dependabot line.

```shepherd:manual-steps
- [ ] Confirm the Vercel Root Directory for the site and docs-site projects is `site` / `docs-site` (Settings → General → Root Directory, or the install step of a recent build log) so the new bunfig.toml files are picked up on Vercel builds
```

[no-feature-entry]

🤖 Generated with [Claude Code](https://claude.com/claude-code)