### PR TITLE
feat(ui): show Codex release notes in the update dialog

### DIFF
--- a/src/codex-update.ts
+++ b/src/codex-update.ts
@@ -384,16 +384,7 @@ export class CodexUpdateService {
     this.historyLoadTimeoutMs = deps.historyLoadTimeoutMs ?? HISTORY_LOAD_TIMEOUT_MS;
     this.fetchLatest =
       deps.fetchLatest ??
-      (async () => {
-        const controller = new AbortController();
-        const { value } = await this.boundedJson(
-          LATEST_URL,
-          NPM_RESPONSE_LIMIT,
-          { bytes: 0 },
-          controller.signal,
-        );
-        return value as { version: string };
-      });
+      (() => fetch(LATEST_URL).then((response) => response.json() as Promise<{ version: string }>));
     this.runUpdate =
       deps.runUpdate ??
       ((onLine, signal, preferred) => this.defaultRunUpdate(onLine, signal, preferred));

--- a/src/codex-update.ts
+++ b/src/codex-update.ts
@@ -2,17 +2,92 @@ import { existsSync } from "node:fs";
 import { delimiter, join } from "node:path";
 import { execFileSync } from "./instrument";
 import { config } from "./config";
-import { compareSemver } from "./herdr-update";
 import { runScriptChild } from "./script-child";
 import { readInstalledVersion, readActualVersion } from "./version-probe";
-import type { CodexUpdateStatus } from "./types";
+import type { CodexReleaseNotesResult, CodexUpdateStatus } from "./types";
 
-export type { CodexUpdateStatus };
+export type { CodexReleaseNotesResult, CodexUpdateStatus };
 
 const SEMVER_RE = /(\d+\.\d+\.\d+)/;
+const NPM_STABLE_VERSION_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 /** npm registry manifest for the latest published @openai/codex. Returns the
  *  full packument for the `latest` dist-tag, which carries the `version` field. */
 const LATEST_URL = "https://registry.npmjs.org/@openai/codex/latest";
+const CATALOG_URL = "https://registry.npmjs.org/@openai%2Fcodex";
+const RELEASES_URL = "https://api.github.com/repos/openai/codex/releases";
+const HISTORY_PROGRESS_INTERVAL_MS = 60_000;
+const HISTORY_REQUEST_TIMEOUT_MS = 5_000;
+const HISTORY_LOAD_TIMEOUT_MS = 15_000;
+const NPM_RESPONSE_LIMIT = 8 * 1024 * 1024;
+const GITHUB_RESPONSE_LIMIT = 12 * 1024 * 1024;
+const INVOCATION_RESPONSE_LIMIT = 32 * 1024 * 1024;
+const RELEASE_BODY_LIMIT = 256 * 1024;
+const RELEASE_BODIES_LIMIT = 1024 * 1024;
+const GITHUB_RATE_RESERVE = 10;
+
+let githubBlockedUntil = 0;
+
+function parseNpmStableVersion(value: unknown): string | null {
+  return typeof value === "string" && NPM_STABLE_VERSION_RE.test(value) ? value : null;
+}
+
+function compareVersionComponent(a: string, b: string): number {
+  const normalizedA = a.replace(/^0+(?=\d)/, "");
+  const normalizedB = b.replace(/^0+(?=\d)/, "");
+  if (normalizedA.length !== normalizedB.length) {
+    return normalizedA.length < normalizedB.length ? -1 : 1;
+  }
+  return normalizedA === normalizedB ? 0 : normalizedA < normalizedB ? -1 : 1;
+}
+
+function compareStableVersions(a: string, b: string): number {
+  const aParts = a.split(".");
+  const bParts = b.split(".");
+  for (let i = 0; i < 3; i++) {
+    const compared = compareVersionComponent(aParts[i]!, bParts[i]!);
+    if (compared !== 0) return compared;
+  }
+  return 0;
+}
+
+interface ReleaseNotesProgress {
+  key: string;
+  current: string;
+  latest: string;
+  inFlight?: Promise<CodexReleaseNotesResult>;
+  result?: CodexReleaseNotesResult;
+  catalogLoaded: boolean;
+  catalogComplete: boolean;
+  targets: Set<string>;
+  unresolved: Set<string>;
+  notesByVersion: Map<string, string>;
+  terminalFailures: Set<string>;
+  nextListPage: number;
+  listExhausted: boolean;
+  outputIncomplete: boolean;
+  bodyBytes: number;
+  nextAttemptAt: number;
+}
+
+interface HistoryBudget {
+  bytes: number;
+}
+
+interface BoundedJsonResult {
+  value: unknown;
+  headers: Headers;
+}
+
+type HistoryFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+class HistoryHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly headers: Headers,
+  ) {
+    super(`history request failed: ${status}`);
+  }
+}
 
 /** Prefix every step marker the update script echoes. Stable + greppable so the
  *  operator can `cat ~/.shepherd/codex-update.log | grep '>>> codex-update'` and
@@ -211,6 +286,13 @@ export interface CodexUpdateDeps {
   versionRunner?: () => string;
   /** inject point for tests; defaults to fetching the npm registry manifest */
   fetchLatest?: () => Promise<{ version: string }>;
+  /** on-demand npm/GitHub transport; separate from periodic status checks */
+  fetchHistory?: HistoryFetch;
+  /** deterministic clock and retry interval seams for bounded history tests */
+  historyNow?: () => number;
+  historyProgressIntervalMs?: number;
+  historyRequestTimeoutMs?: number;
+  historyLoadTimeoutMs?: number;
   /**
    * Run the update child, streaming each output line to onLine, resolving when
    * it exits. The AbortSignal fires on watchdog timeout — the default kills the
@@ -270,6 +352,11 @@ export interface CodexUpdateDeps {
 export class CodexUpdateService {
   private versionRunner: () => string;
   private fetchLatest: () => Promise<{ version: string }>;
+  private fetchHistory: HistoryFetch;
+  private historyNow: () => number;
+  private historyProgressIntervalMs: number;
+  private historyRequestTimeoutMs: number;
+  private historyLoadTimeoutMs: number;
   private runUpdate: (
     onLine: (line: string) => void,
     signal: AbortSignal,
@@ -284,14 +371,29 @@ export class CodexUpdateService {
   private watchdogMs: number;
   private last: CodexUpdateStatus | null = null;
   private applying = false;
+  private notesCache: ReleaseNotesProgress | null = null;
 
   constructor(deps: CodexUpdateDeps = {}) {
     this.versionRunner =
       deps.versionRunner ??
       (() => execFileSync(config.codexBin, ["--version"], { encoding: "utf8" }));
+    this.fetchHistory = deps.fetchHistory ?? ((input, init) => fetch(input, init));
+    this.historyNow = deps.historyNow ?? Date.now;
+    this.historyProgressIntervalMs = deps.historyProgressIntervalMs ?? HISTORY_PROGRESS_INTERVAL_MS;
+    this.historyRequestTimeoutMs = deps.historyRequestTimeoutMs ?? HISTORY_REQUEST_TIMEOUT_MS;
+    this.historyLoadTimeoutMs = deps.historyLoadTimeoutMs ?? HISTORY_LOAD_TIMEOUT_MS;
     this.fetchLatest =
       deps.fetchLatest ??
-      (() => fetch(LATEST_URL).then((r) => r.json() as Promise<{ version: string }>));
+      (async () => {
+        const controller = new AbortController();
+        const { value } = await this.boundedJson(
+          LATEST_URL,
+          NPM_RESPONSE_LIMIT,
+          { bytes: 0 },
+          controller.signal,
+        );
+        return value as { version: string };
+      });
     this.runUpdate =
       deps.runUpdate ??
       ((onLine, signal, preferred) => this.defaultRunUpdate(onLine, signal, preferred));
@@ -343,6 +445,353 @@ export class CodexUpdateService {
   /** Parse the installed version from `codex --version`; null if unreadable. */
   private installedVersion(): string | null {
     return readInstalledVersion(this.versionRunner, SEMVER_RE);
+  }
+
+  private liveNotesRange(): { current: string; latest: string; key: string } | null {
+    const current = this.last?.current;
+    const latest = parseNpmStableVersion(this.last?.latest);
+    if (
+      !this.last?.updateAvailable ||
+      !current ||
+      !latest ||
+      compareStableVersions(latest, current) <= 0
+    ) {
+      return null;
+    }
+    return { current, latest, key: `${current} -> ${latest}` };
+  }
+
+  private releaseNotesResult(progress: ReleaseNotesProgress): CodexReleaseNotesResult {
+    const notes = [...progress.notesByVersion.entries()]
+      .filter(([, body]) => body !== "")
+      .sort(([a], [b]) => compareStableVersions(b, a))
+      .map(([version, body]) => ({ version, body }));
+    return {
+      current: progress.current,
+      latest: progress.latest,
+      notes,
+      complete:
+        progress.catalogComplete &&
+        progress.unresolved.size === 0 &&
+        progress.terminalFailures.size === 0 &&
+        !progress.outputIncomplete,
+    };
+  }
+
+  private async boundedJson(
+    url: string,
+    perResponseLimit: number,
+    budget: HistoryBudget,
+    loadSignal: AbortSignal,
+    github = false,
+  ): Promise<BoundedJsonResult> {
+    const controller = new AbortController();
+    const abort = () => controller.abort();
+    if (loadSignal.aborted) controller.abort();
+    else loadSignal.addEventListener("abort", abort, { once: true });
+    const timeout = setTimeout(abort, this.historyRequestTimeoutMs);
+    try {
+      const response = await this.fetchHistory(url, {
+        signal: controller.signal,
+        headers: github
+          ? {
+              Accept: "application/vnd.github+json",
+              "X-GitHub-Api-Version": "2022-11-28",
+              "User-Agent": "Shepherd",
+            }
+          : { Accept: "application/vnd.npm.install-v1+json" },
+      });
+      if (!response.ok) {
+        await response.body?.cancel();
+        throw new HistoryHttpError(response.status, response.headers);
+      }
+      const declared = Number(response.headers.get("content-length"));
+      if (Number.isFinite(declared) && declared > perResponseLimit) {
+        await response.body?.cancel();
+        throw new Error("history response too large");
+      }
+      if (!response.body) throw new Error("history response has no body");
+      const reader = response.body.getReader();
+      const chunks: Uint8Array[] = [];
+      let responseBytes = 0;
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          responseBytes += value.byteLength;
+          budget.bytes += value.byteLength;
+          if (responseBytes > perResponseLimit || budget.bytes > INVOCATION_RESPONSE_LIMIT) {
+            await reader.cancel();
+            throw new Error("history response too large");
+          }
+          chunks.push(value);
+        }
+      } finally {
+        reader.releaseLock();
+      }
+      const joined = new Uint8Array(responseBytes);
+      let offset = 0;
+      for (const chunk of chunks) {
+        joined.set(chunk, offset);
+        offset += chunk.byteLength;
+      }
+      const decoded = new TextDecoder("utf-8", { fatal: true }).decode(joined);
+      return { value: JSON.parse(decoded), headers: response.headers };
+    } finally {
+      clearTimeout(timeout);
+      loadSignal.removeEventListener("abort", abort);
+    }
+  }
+
+  private noteRateLimit(headers: Headers): boolean {
+    const now = this.historyNow();
+    const remainingRaw = headers.get("x-ratelimit-remaining");
+    const resetRaw = headers.get("x-ratelimit-reset");
+    if (remainingRaw === null && resetRaw === null) {
+      githubBlockedUntil = Math.max(githubBlockedUntil, now + this.historyProgressIntervalMs);
+      return false;
+    }
+    const remaining = Number(remainingRaw);
+    const reset = Number(resetRaw);
+    if (!Number.isFinite(remaining) || !Number.isFinite(reset)) {
+      githubBlockedUntil = Math.max(githubBlockedUntil, now + this.historyProgressIntervalMs);
+      return false;
+    }
+    if (remaining <= GITHUB_RATE_RESERVE) {
+      githubBlockedUntil = Math.max(githubBlockedUntil, reset * 1000);
+      return false;
+    }
+    return true;
+  }
+
+  private noteRateFailure(error: unknown): boolean {
+    if (!(error instanceof HistoryHttpError) || (error.status !== 403 && error.status !== 429)) {
+      return false;
+    }
+    const now = this.historyNow();
+    const retryAfter = Number(error.headers.get("retry-after"));
+    const reset = Number(error.headers.get("x-ratelimit-reset"));
+    const retryAt = Number.isFinite(retryAfter) ? now + retryAfter * 1000 : 0;
+    const resetAt = Number.isFinite(reset) ? reset * 1000 : 0;
+    githubBlockedUntil = Math.max(
+      githubBlockedUntil,
+      retryAt,
+      resetAt,
+      now + this.historyProgressIntervalMs,
+    );
+    return true;
+  }
+
+  private admitRelease(progress: ReleaseNotesProgress, raw: unknown, exact?: string): boolean {
+    const release = this.parseRelease(raw, exact, progress.targets);
+    if (!release) return false;
+    const { version, body } = release;
+    if (!progress.unresolved.has(version)) {
+      if (progress.notesByVersion.get(version) !== body) progress.terminalFailures.add(version);
+      return true;
+    }
+    const bodyBytes = new TextEncoder().encode(body).byteLength;
+    progress.unresolved.delete(version);
+    if (bodyBytes > RELEASE_BODY_LIMIT || progress.bodyBytes + bodyBytes > RELEASE_BODIES_LIMIT) {
+      progress.outputIncomplete = true;
+      progress.terminalFailures.add(version);
+      return true;
+    }
+    progress.notesByVersion.set(version, body);
+    progress.bodyBytes += bodyBytes;
+    return true;
+  }
+
+  private parseRelease(
+    raw: unknown,
+    exact: string | undefined,
+    targets: Set<string>,
+  ): { version: string; body: string } | null {
+    if (!raw || typeof raw !== "object") return null;
+    const value = raw as Record<string, unknown>;
+    const tag = typeof value.tag_name === "string" ? value.tag_name : "";
+    const version = tag.startsWith("rust-v") ? parseNpmStableVersion(tag.slice(6)) : null;
+    if (!version || (exact && version !== exact) || !targets.has(version)) return null;
+    if (value.draft !== false || value.prerelease !== false) return null;
+    if (value.body !== null && typeof value.body !== "string") return null;
+    return { version, body: value.body ?? "" };
+  }
+
+  private newestUnresolved(progress: ReleaseNotesProgress): string | null {
+    return [...progress.unresolved].sort(compareStableVersions).at(-1) ?? null;
+  }
+
+  private async loadReleaseCatalog(
+    progress: ReleaseNotesProgress,
+    budget: HistoryBudget,
+    signal: AbortSignal,
+  ): Promise<void> {
+    progress.catalogLoaded = true;
+    try {
+      const { value } = await this.boundedJson(CATALOG_URL, NPM_RESPONSE_LIMIT, budget, signal);
+      if (!value || typeof value !== "object" || !("versions" in value)) {
+        throw new Error("invalid npm catalog");
+      }
+      const versions = (value as { versions?: unknown }).versions;
+      if (!versions || typeof versions !== "object" || Array.isArray(versions)) {
+        throw new Error("invalid npm catalog");
+      }
+      let includesLatest = false;
+      for (const candidate of Object.keys(versions)) {
+        const version = parseNpmStableVersion(candidate);
+        if (!version) continue;
+        if (version === progress.latest) includesLatest = true;
+        if (
+          compareStableVersions(version, progress.current) > 0 &&
+          compareStableVersions(version, progress.latest) <= 0
+        ) {
+          progress.targets.add(version);
+          progress.unresolved.add(version);
+        }
+      }
+      progress.catalogComplete = includesLatest;
+    } catch {
+      progress.catalogComplete = false;
+      progress.listExhausted = true;
+    }
+  }
+
+  private async loadReleasePage(
+    progress: ReleaseNotesProgress,
+    budget: HistoryBudget,
+    signal: AbortSignal,
+  ): Promise<boolean> {
+    try {
+      const { value, headers } = await this.boundedJson(
+        `${RELEASES_URL}?per_page=30&page=${progress.nextListPage}`,
+        GITHUB_RESPONSE_LIMIT,
+        budget,
+        signal,
+        true,
+      );
+      if (!Array.isArray(value)) throw new Error("invalid GitHub releases page");
+      for (const record of value) this.admitRelease(progress, record);
+      const link = headers.get("link") ?? "";
+      if (link.includes('rel="next"')) progress.nextListPage++;
+      else progress.listExhausted = true;
+      return this.noteRateLimit(headers);
+    } catch (error) {
+      if (this.noteRateFailure(error)) return false;
+      progress.listExhausted = true;
+      return true;
+    }
+  }
+
+  private async loadExactReleases(
+    progress: ReleaseNotesProgress,
+    budget: HistoryBudget,
+    signal: AbortSignal,
+    requestLimit: number,
+  ): Promise<void> {
+    for (let request = 0; request < requestLimit && progress.unresolved.size > 0; request++) {
+      const version = this.newestUnresolved(progress);
+      if (!version) return;
+      try {
+        const { value, headers } = await this.boundedJson(
+          `${RELEASES_URL}/tags/rust-v${version}`,
+          GITHUB_RESPONSE_LIMIT,
+          budget,
+          signal,
+          true,
+        );
+        if (!this.admitRelease(progress, value, version)) {
+          progress.unresolved.delete(version);
+          progress.terminalFailures.add(version);
+        }
+        if (!this.noteRateLimit(headers)) return;
+      } catch (error) {
+        if (error instanceof HistoryHttpError && error.status === 404) {
+          progress.unresolved.delete(version);
+          progress.terminalFailures.add(version);
+        } else {
+          this.noteRateFailure(error);
+        }
+        return;
+      }
+    }
+  }
+
+  private async loadReleaseNotes(progress: ReleaseNotesProgress): Promise<CodexReleaseNotesResult> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.historyLoadTimeoutMs);
+    const budget: HistoryBudget = { bytes: 0 };
+    let githubRequests = 0;
+    try {
+      if (!progress.catalogLoaded)
+        await this.loadReleaseCatalog(progress, budget, controller.signal);
+
+      if (this.historyNow() < githubBlockedUntil) return this.releaseNotesResult(progress);
+
+      if (!progress.listExhausted && progress.unresolved.size > 0) {
+        githubRequests++;
+        const canContinue = await this.loadReleasePage(progress, budget, controller.signal);
+        if (!canContinue) return this.releaseNotesResult(progress);
+      }
+
+      await this.loadExactReleases(progress, budget, controller.signal, 2 - githubRequests);
+    } catch {
+      // The public contract is total: accumulated notes remain available.
+    } finally {
+      clearTimeout(timeout);
+      progress.nextAttemptAt = Math.max(
+        this.historyNow() + this.historyProgressIntervalMs,
+        githubBlockedUntil,
+      );
+    }
+    return this.releaseNotesResult(progress);
+  }
+
+  /** Load original GitHub release bodies only when the update dialog asks. */
+  releaseNotes(): Promise<CodexReleaseNotesResult> {
+    const range = this.liveNotesRange();
+    if (!range) {
+      this.notesCache = null;
+      return Promise.resolve({
+        current: this.last?.current ?? null,
+        latest: this.last?.latest ?? null,
+        notes: [],
+        complete: true,
+      });
+    }
+
+    let entry = this.notesCache;
+    if (!entry || entry.key !== range.key) {
+      entry = {
+        ...range,
+        catalogLoaded: false,
+        catalogComplete: false,
+        targets: new Set([range.latest]),
+        unresolved: new Set([range.latest]),
+        notesByVersion: new Map(),
+        terminalFailures: new Set(),
+        nextListPage: 1,
+        listExhausted: false,
+        outputIncomplete: false,
+        bodyBytes: 0,
+        nextAttemptAt: 0,
+      };
+      this.notesCache = entry;
+    }
+    if (entry.inFlight) return entry.inFlight;
+    if (entry.result?.complete || (entry.result && this.historyNow() < entry.nextAttemptAt)) {
+      return Promise.resolve(entry.result);
+    }
+
+    const capturedEntry = entry;
+    const promise = this.loadReleaseNotes(capturedEntry).then((result) => {
+      if (this.notesCache === capturedEntry && capturedEntry.inFlight === promise) {
+        capturedEntry.result = result;
+        capturedEntry.inFlight = undefined;
+      }
+      return result;
+    });
+    capturedEntry.inFlight = promise;
+    return promise;
   }
 
   /** Best-effort installed version for the "what are we ACTUALLY on?" report.
@@ -463,7 +912,7 @@ export class CodexUpdateService {
     // A force-killed run proves nothing: return BEFORE the memo write below, so a
     // later refactor cannot start memoizing a channel from a killed update.
     if (aborted) return { ok: false, from, to: after, error: "codex update timed out" };
-    const ok = !!after && !!from && compareSemver(after, from) > 0;
+    const ok = !!after && !!from && compareStableVersions(after, from) > 0;
     // Memo the winner ONLY when we converged AND the script named the channel that
     // did it. `ok` is our own compareSemver verdict — it says THAT codex advanced,
     // never BY WHAT — so with no marker there is nothing to attribute and we leave
@@ -488,7 +937,7 @@ export class CodexUpdateService {
     this.last = {
       current: after,
       latest: to,
-      updateAvailable: !!after && !!to && compareSemver(to, after) > 0,
+      updateAvailable: !!after && !!to && compareStableVersions(to, after) > 0,
       notes: null,
       checkedAt: Date.now(),
       error: ok ? undefined : "codex was not updated",
@@ -507,10 +956,9 @@ export class CodexUpdateService {
       const current = currentMatch ? currentMatch[1]! : null;
 
       const latestRaw = await this.fetchLatest();
-      const latestMatch = latestRaw?.version ? SEMVER_RE.exec(latestRaw.version) : null;
-      const latest = latestMatch ? latestMatch[1]! : null;
+      const latest = parseNpmStableVersion(latestRaw?.version);
 
-      const updateAvailable = !!current && !!latest && compareSemver(latest, current) > 0;
+      const updateAvailable = !!current && !!latest && compareStableVersions(latest, current) > 0;
 
       this.last = {
         current,

--- a/src/server.ts
+++ b/src/server.ts
@@ -297,7 +297,7 @@ export interface AppDeps {
   /** herdr-version tracker + applier; absent in environments where it isn't wired. */
   herdrUpdates?: Pick<HerdrUpdateService, "current" | "apply" | "downgrade">;
   /** codex-version tracker + applier; absent in environments where it isn't wired. */
-  codexUpdates?: Pick<CodexUpdateService, "current" | "apply">;
+  codexUpdates?: Pick<CodexUpdateService, "current" | "apply" | "releaseNotes">;
   /** installed-plugin update tracker: `current()` for the badge/status, `check()` for
    *  an on-demand re-scan, `apply()` to fetch-and-swap a plugin's new version on disk
    *  (issue #1124); absent when unwired. */
@@ -4243,8 +4243,32 @@ function handleHerdrDowngrade({ req, parts, deps }: Ctx): Response | null {
 }
 
 // ── codex update: status + (non-destructive) apply ─────────────────────
-function handleCodexUpdate({ req, parts, deps }: Ctx): Response | null {
-  if (!(parts[0] === "api" && parts[1] === "codex-update" && !parts[2])) return null;
+async function codexReleaseNotesResponse(deps: Ctx["deps"]): Promise<Response> {
+  if (!deps.codexUpdates) {
+    return json({ current: null, latest: null, notes: [], complete: true });
+  }
+  try {
+    return json(await deps.codexUpdates.releaseNotes());
+  } catch (error) {
+    console.warn(
+      `[codex-update] release notes unavailable: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    const status = deps.codexUpdates.current();
+    return json({
+      current: status?.current ?? null,
+      latest: status?.latest ?? null,
+      notes: [],
+      complete: false,
+    });
+  }
+}
+
+async function handleCodexUpdate({ req, parts, deps }: Ctx): Promise<Response | null> {
+  if (!(parts[0] === "api" && parts[1] === "codex-update")) return null;
+  if (req.method === "GET" && parts[2] === "notes" && !parts[3]) {
+    return codexReleaseNotesResponse(deps);
+  }
+  if (parts[2]) return null;
   if (req.method === "GET") {
     return json(deps.codexUpdates?.current() ?? { ...HERDR_UPDATE_IDLE, checkedAt: Date.now() });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -451,6 +451,18 @@ export interface CodexUpdateStatus {
   error?: string;
 }
 
+export interface CodexReleaseNote {
+  version: string;
+  body: string;
+}
+
+export interface CodexReleaseNotesResult {
+  current: string | null;
+  latest: string | null;
+  notes: CodexReleaseNote[];
+  complete: boolean;
+}
+
 // ── plugin update check (informational only) ────────────────────────────────
 /** Per-plugin update state. `no-source` = no way to check (no declared
  *  repository and not a git checkout); `incompatible` = a newer version exists

--- a/test/codex-update.test.ts
+++ b/test/codex-update.test.ts
@@ -324,6 +324,40 @@ test("current == latest → updateAvailable false", async () => {
   expect(s.updateAvailable).toBe(false);
 });
 
+test("check keeps its default latest fetch independent from the release-history transport", async () => {
+  const originalFetch = globalThis.fetch;
+  let latestCalls = 0;
+  let historyCalls = 0;
+  globalThis.fetch = Object.assign(
+    async (input: RequestInfo | URL) => {
+      latestCalls++;
+      expect(String(input)).toBe("https://registry.npmjs.org/@openai/codex/latest");
+      return jsonResponse({ version: "0.145.0" });
+    },
+    { preconnect: originalFetch.preconnect },
+  );
+  try {
+    const svc = new CodexUpdateService({
+      versionRunner: () => "@openai/codex 0.144.0",
+      fetchHistory: async () => {
+        historyCalls++;
+        throw new Error("release history must stay on demand");
+      },
+    });
+
+    expect(await svc.check(3_000)).toMatchObject({
+      current: "0.144.0",
+      latest: "0.145.0",
+      updateAvailable: true,
+      notes: null,
+    });
+    expect(latestCalls).toBe(1);
+    expect(historyCalls).toBe(0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("versionRunner throws → fail-safe, no badge, error set", async () => {
   const svc = new CodexUpdateService({
     versionRunner: () => {

--- a/test/codex-update.test.ts
+++ b/test/codex-update.test.ts
@@ -22,6 +22,22 @@ import {
 const LOG = "/home/op/.shepherd/codex-update.log";
 const CB = "codex";
 
+function jsonResponse(value: unknown, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+function release(version: string, body: string | null) {
+  return {
+    tag_name: `rust-v${version}`,
+    draft: false,
+    prerelease: false,
+    body,
+  };
+}
+
 // ── buildUpdateScript: two channels, tried in the memo's order ─────────────────
 test("buildUpdateScript: can run either channel", () => {
   const s = buildUpdateScript(LOG, "0.142.2", "0.142.4", CB);
@@ -318,6 +334,339 @@ test("versionRunner throws → fail-safe, no badge, error set", async () => {
   const s = await svc.check(4000);
   expect(s.updateAvailable).toBe(false);
   expect(s.error).toContain("command not found");
+});
+
+test("check isolates status from history and validates npm latest as an anchored stable version", async () => {
+  for (const latest of ["0.145.0-alpha.1", "v0.145.0", "00.145.0", "0.145", "0.145.0 extra"]) {
+    let historyCalls = 0;
+    const svc = new CodexUpdateService({
+      versionRunner: () => "codex-cli 0.144.0 (build metadata is tolerated)",
+      fetchLatest: async () => ({ version: latest }),
+      fetchHistory: async () => {
+        historyCalls++;
+        return jsonResponse({});
+      },
+    });
+
+    const status = await svc.check(5);
+    expect(status).toMatchObject({ latest: null, updateAvailable: false, notes: null });
+    expect(await svc.releaseNotes()).toEqual({
+      current: "0.144.0",
+      latest: null,
+      notes: [],
+      complete: true,
+    });
+    expect(historyCalls).toBe(0);
+  }
+});
+
+test("check compares arbitrarily large stable components without Number coercion", async () => {
+  const svc = new CodexUpdateService({
+    versionRunner: () => "codex-cli 90071992547409931234567890.2.3",
+    fetchLatest: async () => ({ version: "90071992547409931234567891.0.0" }),
+  });
+
+  expect(await svc.check(6)).toMatchObject({
+    current: "90071992547409931234567890.2.3",
+    latest: "90071992547409931234567891.0.0",
+    updateAvailable: true,
+    notes: null,
+  });
+});
+
+test("releaseNotes resumes a finite npm target set with at most two serial GitHub requests per call", async () => {
+  let now = 1_000;
+  const calls: string[] = [];
+  const fetchHistory = async (input: RequestInfo | URL): Promise<Response> => {
+    const url = String(input);
+    calls.push(url);
+    if (url === "https://registry.npmjs.org/@openai%2Fcodex") {
+      return jsonResponse({
+        versions: {
+          "0.145.0": {},
+          "0.141.0": {},
+          "0.144.0": {},
+          "0.142.0": {},
+          "0.143.0": {},
+        },
+      });
+    }
+    if (url.endsWith("releases?per_page=30&page=1")) {
+      return jsonResponse([release("0.140.0", "current"), release("0.144.0", "notes 144")], {
+        link: '<https://api.github.com/repos/openai/codex/releases?per_page=30&page=2>; rel="next"',
+        "x-ratelimit-remaining": "50",
+        "x-ratelimit-reset": "9999999999",
+      });
+    }
+    if (url.endsWith("releases/tags/rust-v0.145.0")) {
+      return jsonResponse(release("0.145.0", "notes 145"), {
+        "x-ratelimit-remaining": "49",
+        "x-ratelimit-reset": "9999999999",
+      });
+    }
+    if (url.endsWith("releases?per_page=30&page=2")) {
+      return jsonResponse([release("0.142.0", "notes 142"), release("0.141.0", "notes 141")], {
+        "x-ratelimit-remaining": "48",
+        "x-ratelimit-reset": "9999999999",
+      });
+    }
+    if (url.endsWith("releases/tags/rust-v0.143.0")) {
+      return jsonResponse(release("0.143.0", "notes 143"), {
+        "x-ratelimit-remaining": "47",
+        "x-ratelimit-reset": "9999999999",
+      });
+    }
+    throw new Error(`unexpected history URL: ${url}`);
+  };
+  const svc = new CodexUpdateService({
+    versionRunner: () => "codex-cli 0.140.0",
+    fetchLatest: async () => ({ version: "0.145.0" }),
+    fetchHistory,
+    historyNow: () => now,
+    historyProgressIntervalMs: 60_000,
+  });
+  await svc.check(7);
+
+  const first = await svc.releaseNotes();
+  expect(first).toEqual({
+    current: "0.140.0",
+    latest: "0.145.0",
+    notes: [
+      { version: "0.145.0", body: "notes 145" },
+      { version: "0.144.0", body: "notes 144" },
+    ],
+    complete: false,
+  });
+  expect(calls.filter((url) => url.includes("api.github.com"))).toHaveLength(2);
+
+  now = 30_000;
+  expect(await svc.releaseNotes()).toEqual(first);
+  expect(calls.filter((url) => url.includes("api.github.com"))).toHaveLength(2);
+
+  now = 61_001;
+  const complete = await svc.releaseNotes();
+  expect(complete).toEqual({
+    current: "0.140.0",
+    latest: "0.145.0",
+    notes: [
+      { version: "0.145.0", body: "notes 145" },
+      { version: "0.144.0", body: "notes 144" },
+      { version: "0.143.0", body: "notes 143" },
+      { version: "0.142.0", body: "notes 142" },
+      { version: "0.141.0", body: "notes 141" },
+    ],
+    complete: true,
+  });
+  expect(calls.filter((url) => url.includes("api.github.com"))).toHaveLength(4);
+  expect(calls).toContain("https://api.github.com/repos/openai/codex/releases?per_page=30&page=2");
+  expect(calls).toContain("https://api.github.com/repos/openai/codex/releases/tags/rust-v0.143.0");
+});
+
+test("releaseNotes remains total when catalog evidence is incomplete and stops retrying a terminal exact tag", async () => {
+  let now = 1_000;
+  const calls: string[] = [];
+  const svc = new CodexUpdateService({
+    versionRunner: () => "codex-cli 0.144.0",
+    fetchLatest: async () => ({ version: "0.145.0" }),
+    fetchHistory: async (input) => {
+      const url = String(input);
+      calls.push(url);
+      if (url.includes("registry.npmjs.org")) return jsonResponse({ versions: { "0.144.0": {} } });
+      if (url.includes("releases?")) {
+        return jsonResponse([], {
+          "x-ratelimit-remaining": "50",
+          "x-ratelimit-reset": "9999999999",
+        });
+      }
+      return new Response("missing", {
+        status: 404,
+        headers: {
+          "x-ratelimit-remaining": "49",
+          "x-ratelimit-reset": "9999999999",
+        },
+      });
+    },
+    historyNow: () => now,
+  });
+  await svc.check(8);
+
+  expect(await svc.releaseNotes()).toEqual({
+    current: "0.144.0",
+    latest: "0.145.0",
+    notes: [],
+    complete: false,
+  });
+  const callsAfterTerminalMiss = calls.length;
+  now += 61_000;
+  expect(await svc.releaseNotes()).toMatchObject({ complete: false, notes: [] });
+  expect(calls).toHaveLength(callsAfterTerminalMiss);
+});
+
+test("releaseNotes honors a GitHub rate gate across range keys", async () => {
+  let now = 1_000;
+  let current = "0.140.0";
+  let latest = "0.141.0";
+  const githubCalls: string[] = [];
+  const svc = new CodexUpdateService({
+    versionRunner: () => `codex-cli ${current}`,
+    fetchLatest: async () => ({ version: latest }),
+    fetchHistory: async (input) => {
+      const url = String(input);
+      if (url.includes("registry.npmjs.org")) return jsonResponse({ versions: { [latest]: {} } });
+      githubCalls.push(url);
+      return new Response("limited", {
+        status: 429,
+        headers: { "retry-after": "60", "x-ratelimit-reset": "61" },
+      });
+    },
+    historyNow: () => now,
+  });
+  await svc.check(11);
+  expect(await svc.releaseNotes()).toMatchObject({ complete: false });
+  expect(githubCalls).toHaveLength(1);
+
+  current = "0.141.0";
+  latest = "0.142.0";
+  await svc.check(12);
+  expect(await svc.releaseNotes()).toEqual({
+    current: "0.141.0",
+    latest: "0.142.0",
+    notes: [],
+    complete: false,
+  });
+  expect(githubCalls).toHaveLength(1);
+
+  now = 61_001;
+  await svc.releaseNotes();
+  expect(githubCalls).toHaveLength(2);
+});
+
+test("releaseNotes bounds malformed, timed-out, oversized, and over-limit upstream payloads", async () => {
+  for (const catalogFailure of ["malformed", "timeout", "oversized"] as const) {
+    let calls = 0;
+    const svc = new CodexUpdateService({
+      versionRunner: () => "codex-cli 0.144.0",
+      fetchLatest: async () => ({ version: "0.145.0" }),
+      fetchHistory: async (input, init) => {
+        calls++;
+        const url = String(input);
+        if (url.includes("registry.npmjs.org")) {
+          if (catalogFailure === "malformed") return new Response("{");
+          if (catalogFailure === "oversized") {
+            return new Response("{}", {
+              headers: { "content-length": String(8 * 1024 * 1024 + 1) },
+            });
+          }
+          return new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener(
+              "abort",
+              () => reject(new DOMException("aborted", "AbortError")),
+              { once: true },
+            );
+          });
+        }
+        return jsonResponse(release("0.145.0", "latest survives catalog failure"), {
+          "x-ratelimit-remaining": "50",
+          "x-ratelimit-reset": "9999999999",
+        });
+      },
+      historyRequestTimeoutMs: 2,
+      historyLoadTimeoutMs: 50,
+    });
+    await svc.check(13);
+
+    expect(await svc.releaseNotes()).toEqual({
+      current: "0.144.0",
+      latest: "0.145.0",
+      notes: [{ version: "0.145.0", body: "latest survives catalog failure" }],
+      complete: false,
+    });
+    expect(calls).toBe(2);
+  }
+
+  for (const exactFailure of ["oversized-response", "oversized-body"] as const) {
+    let calls = 0;
+    const svc = new CodexUpdateService({
+      versionRunner: () => "codex-cli 0.144.0",
+      fetchLatest: async () => ({ version: "0.145.0" }),
+      fetchHistory: async (input) => {
+        calls++;
+        const url = String(input);
+        if (url.includes("registry.npmjs.org")) {
+          return jsonResponse({ versions: { "0.145.0": {} } });
+        }
+        if (url.includes("releases?")) return new Response("{");
+        if (exactFailure === "oversized-response") {
+          return new Response("{}", {
+            headers: { "content-length": String(12 * 1024 * 1024 + 1) },
+          });
+        }
+        return jsonResponse(release("0.145.0", "x".repeat(256 * 1024 + 1)), {
+          "x-ratelimit-remaining": "50",
+          "x-ratelimit-reset": "9999999999",
+        });
+      },
+    });
+    await svc.check(14);
+
+    expect(await svc.releaseNotes()).toMatchObject({ notes: [], complete: false });
+    expect(calls).toBe(3);
+  }
+});
+
+test("releaseNotes deduplicates in-flight work and late range A cannot overwrite cached range B", async () => {
+  let current = "0.140.0";
+  let latest = "0.141.0";
+  let resolveCatalogA!: (response: Response) => void;
+  const catalogA = new Promise<Response>((resolve) => {
+    resolveCatalogA = resolve;
+  });
+  const calls: string[] = [];
+  let catalogCalls = 0;
+  const svc = new CodexUpdateService({
+    versionRunner: () => `codex-cli ${current}`,
+    fetchLatest: async () => ({ version: latest }),
+    fetchHistory: async (input) => {
+      const url = String(input);
+      calls.push(url);
+      if (url.includes("registry.npmjs.org")) {
+        catalogCalls++;
+        if (catalogCalls === 1) return catalogA;
+        return jsonResponse({ versions: { "0.142.0": {} } });
+      }
+      if (url.includes("releases?")) {
+        const version = latest;
+        return jsonResponse([release(version, `notes ${version}`)], {
+          "x-ratelimit-remaining": "50",
+          "x-ratelimit-reset": "9999999999",
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    },
+  });
+  await svc.check(9);
+
+  const rangeA = svc.releaseNotes();
+  expect(svc.releaseNotes()).toBe(rangeA);
+
+  current = "0.141.0";
+  latest = "0.142.0";
+  await svc.check(10);
+  const rangeB = await svc.releaseNotes();
+  expect(rangeB).toEqual({
+    current: "0.141.0",
+    latest: "0.142.0",
+    notes: [{ version: "0.142.0", body: "notes 0.142.0" }],
+    complete: true,
+  });
+  const callsAfterB = calls.length;
+
+  resolveCatalogA(jsonResponse({ versions: { "0.141.0": {} } }));
+  expect(await rangeA).toMatchObject({ current: "0.140.0", latest: "0.141.0" });
+  const callsAfterA = calls.length;
+  expect(await svc.releaseNotes()).toEqual(rangeB);
+  expect(callsAfterA).toBeGreaterThan(callsAfterB);
+  expect(calls).toHaveLength(callsAfterA);
 });
 
 // ── apply(): success/failure detection from a re-read version ──────────────────

--- a/test/codex-update.test.ts
+++ b/test/codex-update.test.ts
@@ -437,11 +437,11 @@ test("releaseNotes resumes a finite npm target set with at most two serial GitHu
     ],
     complete: false,
   });
-  expect(calls.filter((url) => url.includes("api.github.com"))).toHaveLength(2);
+  expect(calls.filter((url) => new URL(url).hostname === "api.github.com")).toHaveLength(2);
 
   now = 30_000;
   expect(await svc.releaseNotes()).toEqual(first);
-  expect(calls.filter((url) => url.includes("api.github.com"))).toHaveLength(2);
+  expect(calls.filter((url) => new URL(url).hostname === "api.github.com")).toHaveLength(2);
 
   now = 61_001;
   const complete = await svc.releaseNotes();
@@ -457,7 +457,7 @@ test("releaseNotes resumes a finite npm target set with at most two serial GitHu
     ],
     complete: true,
   });
-  expect(calls.filter((url) => url.includes("api.github.com"))).toHaveLength(4);
+  expect(calls.filter((url) => new URL(url).hostname === "api.github.com")).toHaveLength(4);
   expect(calls).toContain("https://api.github.com/repos/openai/codex/releases?per_page=30&page=2");
   expect(calls).toContain("https://api.github.com/repos/openai/codex/releases/tags/rust-v0.143.0");
 });
@@ -471,7 +471,9 @@ test("releaseNotes remains total when catalog evidence is incomplete and stops r
     fetchHistory: async (input) => {
       const url = String(input);
       calls.push(url);
-      if (url.includes("registry.npmjs.org")) return jsonResponse({ versions: { "0.144.0": {} } });
+      if (new URL(url).hostname === "registry.npmjs.org") {
+        return jsonResponse({ versions: { "0.144.0": {} } });
+      }
       if (url.includes("releases?")) {
         return jsonResponse([], {
           "x-ratelimit-remaining": "50",
@@ -512,7 +514,9 @@ test("releaseNotes honors a GitHub rate gate across range keys", async () => {
     fetchLatest: async () => ({ version: latest }),
     fetchHistory: async (input) => {
       const url = String(input);
-      if (url.includes("registry.npmjs.org")) return jsonResponse({ versions: { [latest]: {} } });
+      if (new URL(url).hostname === "registry.npmjs.org") {
+        return jsonResponse({ versions: { [latest]: {} } });
+      }
       githubCalls.push(url);
       return new Response("limited", {
         status: 429,
@@ -550,7 +554,7 @@ test("releaseNotes bounds malformed, timed-out, oversized, and over-limit upstre
       fetchHistory: async (input, init) => {
         calls++;
         const url = String(input);
-        if (url.includes("registry.npmjs.org")) {
+        if (new URL(url).hostname === "registry.npmjs.org") {
           if (catalogFailure === "malformed") return new Response("{");
           if (catalogFailure === "oversized") {
             return new Response("{}", {
@@ -592,7 +596,7 @@ test("releaseNotes bounds malformed, timed-out, oversized, and over-limit upstre
       fetchHistory: async (input) => {
         calls++;
         const url = String(input);
-        if (url.includes("registry.npmjs.org")) {
+        if (new URL(url).hostname === "registry.npmjs.org") {
           return jsonResponse({ versions: { "0.145.0": {} } });
         }
         if (url.includes("releases?")) return new Response("{");
@@ -629,7 +633,7 @@ test("releaseNotes deduplicates in-flight work and late range A cannot overwrite
     fetchHistory: async (input) => {
       const url = String(input);
       calls.push(url);
-      if (url.includes("registry.npmjs.org")) {
+      if (new URL(url).hostname === "registry.npmjs.org") {
         catalogCalls++;
         if (catalogCalls === 1) return catalogA;
         return jsonResponse({ versions: { "0.142.0": {} } });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -84,6 +84,42 @@ function harness() {
   return makeApp(deps);
 }
 
+test("GET /api/codex-update/notes has a total empty fallback", async () => {
+  const res = await harness().fetch(new Request("http://x/api/codex-update/notes"));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ current: null, latest: null, notes: [], complete: true });
+});
+
+test("GET /api/codex-update keeps the existing notes:null fallback contract", async () => {
+  const res = await harness().fetch(new Request("http://x/api/codex-update"));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({
+    current: null,
+    latest: null,
+    updateAvailable: false,
+    notes: null,
+  });
+});
+
+test("GET /api/codex-update/notes returns the on-demand service result", async () => {
+  const deps = makeDeps();
+  const result = {
+    current: "0.144.0",
+    latest: "0.145.0",
+    notes: [{ version: "0.145.0", body: "original body" }],
+    complete: false,
+  };
+  deps.codexUpdates = {
+    current: () => null,
+    apply: () => ({ started: false }),
+    releaseNotes: async () => result,
+  };
+
+  const res = await makeApp(deps).fetch(new Request("http://x/api/codex-update/notes"));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual(result);
+});
+
 test("GET /api/usage/limits returns limits + projections", async () => {
   const res = await harness().fetch(new Request("http://x/api/usage/limits"));
   expect(res.status).toBe(200);

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -3369,5 +3369,10 @@
   "feat_herdr_sandbox_advisory_title": "Sandboxed-Sitzungen unter herdr 0.7.5: eine Status-Einschränkung",
   "feat_herdr_sandbox_advisory_body": "Unter herdr 0.7.5 erscheint ein ruhender sandboxed Agent als „arbeitet\", bis er eine Frage stellt oder fertig ist — herdr kann seinen Ruhezustand nicht melden (Issue #1716). Trusted-Sitzungen sind nicht betroffen. Wenn du auf sandboxed Sitzungen angewiesen bist und einen korrekten Ruhestatus möchtest, bietet der herdr-Update-Dialog jetzt ein Downgrade mit einem Klick auf eine Version ohne diese Einschränkung.",
   "feat_herdr_downgrade_title": "Auf kaputtem herdr gestrandet? Downgrade mit einem Klick",
-  "feat_herdr_downgrade_body": "Wenn herdr sich per Auto-Update auf eine Version aktualisiert hat, die Shepherd nicht ansteuern kann (0.7.5+ hat das Starten von Agenten kaputt gemacht), heilt sich Shepherd jetzt selbst: Update-Dialog und Diagnose-Tab bieten ein Ein-Klick-Downgrade auf die höchste unterstützte Version — heruntergeladen, verifiziert, getauscht und neu gestartet komplett in der App, mit Schritt-für-Schritt-Audit-Log."
+  "feat_herdr_downgrade_body": "Wenn herdr sich per Auto-Update auf eine Version aktualisiert hat, die Shepherd nicht ansteuern kann (0.7.5+ hat das Starten von Agenten kaputt gemacht), heilt sich Shepherd jetzt selbst: Update-Dialog und Diagnose-Tab bieten ein Ein-Klick-Downgrade auf die höchste unterstützte Version — heruntergeladen, verifiziert, getauscht und neu gestartet komplett in der App, mit Schritt-für-Schritt-Audit-Log.",
+  "codexupdate_notes_heading": "Release-Notes",
+  "codexupdate_notes_loading": "Release-Notes werden geladen…",
+  "codexupdate_notes_incomplete": "Der vollständige Release-Verlauf ist hier noch nicht verfügbar. Du kannst trotzdem jetzt aktualisieren oder die Quelle auf GitHub ansehen.",
+  "feat_codex_release_notes_title": "Codex-Änderungen vor dem Update lesen",
+  "feat_codex_release_notes_body": "Das Codex-Update-Fenster zeigt jetzt die originalen GitHub-Release-Notes für jede auf npm veröffentlichte stabile Version in deinem Update-Bereich – neueste zuerst."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -3369,5 +3369,10 @@
   "feat_herdr_sandbox_advisory_title": "Sandboxed sessions on herdr 0.7.5: a status caveat",
   "feat_herdr_sandbox_advisory_body": "On herdr 0.7.5, a resting sandboxed agent shows as \"working\" until it asks a question or finishes — herdr can't report its idle state (issue #1716). Trusted sessions are unaffected. If you rely on sandboxed sessions and want accurate idle status, the herdr update dialog now offers a one-click downgrade to a version without the regression.",
   "feat_herdr_downgrade_title": "Stranded on a broken herdr? One-click downgrade",
-  "feat_herdr_downgrade_body": "If herdr auto-updated into a version Shepherd cannot drive (0.7.5+ broke agent spawning), Shepherd now heals itself: the herdr-update dialog and the Diagnose tab offer a one-click downgrade to the highest supported version — downloaded, verified, swapped and restarted entirely in-app, with a step-by-step audit log."
+  "feat_herdr_downgrade_body": "If herdr auto-updated into a version Shepherd cannot drive (0.7.5+ broke agent spawning), Shepherd now heals itself: the herdr-update dialog and the Diagnose tab offer a one-click downgrade to the highest supported version — downloaded, verified, swapped and restarted entirely in-app, with a step-by-step audit log.",
+  "codexupdate_notes_heading": "Release notes",
+  "codexupdate_notes_loading": "Loading release notes…",
+  "codexupdate_notes_incomplete": "The full release history is not available here yet. You can still update now or view the source on GitHub.",
+  "feat_codex_release_notes_title": "Read Codex changes before updating",
+  "feat_codex_release_notes_body": "The Codex update dialog now shows the original GitHub release notes for every npm-published stable version in your update range, newest first."
 }

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getCommands } from "./api";
+import { fetchCodexReleaseNotes, getCommands } from "./api";
 
 vi.mock("$lib/auth.svelte", () => ({
   auth: { unauthenticated: false, checked: false },
@@ -29,5 +29,37 @@ describe("getCommands", () => {
     await getCommands("/repo path");
 
     expect(fetchMock).toHaveBeenCalledWith("/api/commands?repo=%2Frepo+path");
+  });
+});
+
+describe("fetchCodexReleaseNotes", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("uses the notes endpoint and forwards the exact AbortSignal", async () => {
+    const result = {
+      current: "0.144.0",
+      latest: "0.145.0",
+      notes: [{ version: "0.145.0", body: "notes" }],
+      complete: true,
+    };
+    const fetchMock = vi.fn(async () => Response.json(result));
+    globalThis.fetch = fetchMock as typeof fetch;
+    const controller = new AbortController();
+
+    await expect(fetchCodexReleaseNotes(controller.signal)).resolves.toEqual(result);
+    expect(fetchMock).toHaveBeenCalledWith("/api/codex-update/notes", {
+      signal: controller.signal,
+    });
+  });
+
+  it("rejects non-OK responses", async () => {
+    globalThis.fetch = vi.fn(async () => Response.json({ error: "nope" }, { status: 503 }));
+
+    await expect(fetchCodexReleaseNotes(new AbortController().signal)).rejects.toThrow();
   });
 });

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -25,6 +25,7 @@ import type {
   DirtyStatus,
   HerdrUpdateStatus,
   CodexUpdateStatus,
+  CodexReleaseNotesResult,
   DiagnosticsSnapshot,
   PluginInfo,
   InstalledPlugin,
@@ -1402,6 +1403,15 @@ export async function getHerdrUpdate(): Promise<HerdrUpdateStatus> {
 export async function getCodexUpdate(): Promise<CodexUpdateStatus> {
   const r = await fetch("/api/codex-update");
   if (!r.ok) throw await failed(r, "codex update status");
+  return r.json();
+}
+
+/** Original GitHub release bodies for the currently available Codex update range. */
+export async function fetchCodexReleaseNotes(
+  signal: AbortSignal,
+): Promise<CodexReleaseNotesResult> {
+  const r = await fetch("/api/codex-update/notes", { signal });
+  if (!r.ok) throw await failed(r, "codex update release notes");
   return r.json();
 }
 

--- a/ui/src/lib/codex-release-notes-renderer.ts
+++ b/ui/src/lib/codex-release-notes-renderer.ts
@@ -1,0 +1,254 @@
+const GITHUB_REPO_BASE = "https://github.com/openai/codex/";
+const GITHUB_ORIGIN = "https://github.com";
+const RAW_TAGS = new Set([
+  "p",
+  "br",
+  "hr",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "ul",
+  "ol",
+  "li",
+  "blockquote",
+  "pre",
+  "code",
+  "strong",
+  "em",
+  "del",
+  "a",
+  "details",
+  "summary",
+  "table",
+  "thead",
+  "tbody",
+  "tr",
+  "th",
+  "td",
+]);
+const NON_VISIBLE_TAGS = new Set(["script", "style", "template"]);
+const ALLOWED_TAGS = [...RAW_TAGS];
+const ALLOWED_ATTR = ["href", "title", "open"];
+
+interface MarkdownParser {
+  parseInline(tokens: unknown[]): string;
+}
+
+interface MarkdownRenderer {
+  image(token: { text: string }): string;
+  html(token: { text: string }): string;
+  link(
+    this: { parser: MarkdownParser },
+    token: { href: string; title?: string | null; tokens: unknown[] },
+  ): string;
+}
+
+interface RendererModules {
+  Marked: new (extension: { renderer: MarkdownRenderer }) => {
+    parse(source: string, options: { async: false }): string;
+  };
+  DOMPurify: {
+    sanitize(
+      source: string,
+      options: {
+        ALLOWED_TAGS: string[];
+        ALLOWED_ATTR: string[];
+        ALLOW_DATA_ATTR: false;
+        ALLOW_ARIA_ATTR: false;
+      },
+    ): string;
+  };
+}
+
+export interface CodexReleaseRendererOptions {
+  load?: () => Promise<RendererModules>;
+  beforeSanitize?: (html: string) => void;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function tagEnd(source: string, start: number): number {
+  let quote = "";
+  for (let i = start + 1; i < source.length; i++) {
+    const char = source[i]!;
+    if (quote) {
+      if (char === quote) quote = "";
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === ">") {
+      return i;
+    }
+  }
+  return -1;
+}
+
+interface RawTag {
+  closing: boolean;
+  name: string;
+  attributes: string;
+}
+
+interface RawToken {
+  text: string;
+  tag: RawTag | null;
+  next: number;
+  terminal: boolean;
+}
+
+function parseRawTag(source: string): RawTag | null {
+  const match = /^<\s*(\/?)\s*([A-Za-z][\w:-]*)([\s\S]*?)\/?\s*>$/.exec(source);
+  if (!match) return null;
+  return {
+    closing: match[1] === "/",
+    name: match[2]!.toLowerCase(),
+    attributes: match[3]!.trim(),
+  };
+}
+
+function projectedTag(tag: RawTag): string {
+  if (!RAW_TAGS.has(tag.name)) return "";
+  if (tag.closing) return `</${tag.name}>`;
+  if (tag.name === "br" || tag.name === "hr") return `<${tag.name}>`;
+  if (tag.name === "details" && /(?:^|\s)open(?=\s|$)/.test(tag.attributes)) {
+    return "<details open>";
+  }
+  return `<${tag.name}>`;
+}
+
+function nextRawToken(source: string, cursor: number): RawToken {
+  const open = source.indexOf("<", cursor);
+  if (open === -1) {
+    return { text: source.slice(cursor), tag: null, next: source.length, terminal: true };
+  }
+  const text = source.slice(cursor, open);
+  if (source.startsWith("<!--", open)) {
+    const close = source.indexOf("-->", open + 4);
+    return {
+      text,
+      tag: null,
+      next: close === -1 ? source.length : close + 3,
+      terminal: close === -1,
+    };
+  }
+  const end = tagEnd(source, open);
+  if (end === -1) return { text, tag: null, next: source.length, terminal: true };
+  return {
+    text,
+    tag: parseRawTag(source.slice(open, end + 1)),
+    next: end + 1,
+    terminal: false,
+  };
+}
+
+function projectRawTag(
+  tag: RawTag,
+  hidden: string | null,
+): { html: string; hidden: string | null } {
+  if (hidden) {
+    return { html: "", hidden: tag.closing && tag.name === hidden ? null : hidden };
+  }
+  if (!tag.closing && NON_VISIBLE_TAGS.has(tag.name)) {
+    return { html: "", hidden: tag.name };
+  }
+  return { html: projectedTag(tag), hidden: null };
+}
+
+/** Project raw HTML without ever handing its attributes or media URLs to a DOM parser. */
+function projectCodexRawHtml(source: string): string {
+  let output = "";
+  let cursor = 0;
+  let hidden: string | null = null;
+  while (cursor < source.length) {
+    const token = nextRawToken(source, cursor);
+    if (!hidden) output += token.text.replaceAll("<", "&lt;");
+    cursor = token.next;
+    if (token.tag) {
+      const projected = projectRawTag(token.tag, hidden);
+      output += projected.html;
+      hidden = projected.hidden;
+    }
+    if (token.terminal) break;
+  }
+  return output;
+}
+
+function normalizeCodexReleaseHref(rawHref: string, version: string): string | null {
+  const href = rawHref.trim();
+  const hasControlCharacter = [...href].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127;
+  });
+  if (!href || hasControlCharacter || href.startsWith("//")) return null;
+  if (/^[A-Za-z][A-Za-z\d+.-]*:/.test(href)) {
+    try {
+      const url = new URL(href);
+      if (!new Set(["http:", "https:", "mailto:"]).has(url.protocol)) return null;
+      if (url.username || url.password) return null;
+      return url.href;
+    } catch {
+      return null;
+    }
+  }
+  try {
+    if (href.startsWith("#")) {
+      return new URL(href, `${GITHUB_REPO_BASE}releases/tag/rust-v${encodeURIComponent(version)}`)
+        .href;
+    }
+    if (href.startsWith("/")) return new URL(href, GITHUB_ORIGIN).href;
+    return new URL(href, GITHUB_REPO_BASE).href;
+  } catch {
+    return null;
+  }
+}
+
+async function defaultLoad(): Promise<RendererModules> {
+  const [{ Marked }, { default: DOMPurify }] = await Promise.all([
+    import("marked"),
+    import("dompurify"),
+  ]);
+  return { Marked, DOMPurify };
+}
+
+export async function renderCodexReleaseMarkdown(
+  body: string,
+  version: string,
+  options: CodexReleaseRendererOptions = {},
+): Promise<string> {
+  const { Marked, DOMPurify } = await (options.load ?? defaultLoad)();
+  const marked = new Marked({
+    renderer: {
+      image({ text }) {
+        return escapeHtml(text);
+      },
+      html({ text }) {
+        return projectCodexRawHtml(text);
+      },
+      link({ href, title, tokens }) {
+        const label = this.parser.parseInline(tokens);
+        const normalized = normalizeCodexReleaseHref(href, version);
+        if (!normalized) return label;
+        const safeTitle = title ? ` title="${escapeHtml(title)}"` : "";
+        return `<a href="${escapeHtml(normalized)}"${safeTitle}>${label}</a>`;
+      },
+    },
+  });
+  const beforeSanitize = marked.parse(body, { async: false }) as string;
+  options.beforeSanitize?.(beforeSanitize);
+  const sanitized = DOMPurify.sanitize(beforeSanitize, {
+    ALLOWED_TAGS,
+    ALLOWED_ATTR,
+    ALLOW_DATA_ATTR: false,
+    ALLOW_ARIA_ATTR: false,
+  });
+  return sanitized.replace(/<a href=/g, '<a target="_blank" rel="noopener noreferrer" href=');
+}

--- a/ui/src/lib/components/CodexReleaseNotes.browser.test.ts
+++ b/ui/src/lib/components/CodexReleaseNotes.browser.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-svelte";
+import CodexReleaseNotes from "./CodexReleaseNotes.svelte";
+import { renderCodexReleaseMarkdown } from "$lib/codex-release-notes-renderer";
+
+const hostileMarkdown = `
+![diagram](https://tracker.invalid/pixel.png)
+<img src="https://tracker.invalid/raw.png" alt="raw image">
+<script>hidden script</script><style>hidden style</style>
+<details open class="global" id="global" style="color:red"><summary>Visible summary</summary>
+Visible details
+<table class="global"><thead><tr><th>Head</th></tr></thead><tbody><tr><td>Cell</td></tr></tbody></table>
+</details>
+<form><label>Visible form label</label><input name="secret"></form>
+
+[relative](docs/guide.md) [root](/openai/codex/issues/7) [section](#section)
+[danger](javascript:alert(1))
+`;
+
+describe("CodexReleaseNotes", () => {
+  it("removes media URLs before DOMPurify and preserves safe visible raw-HTML structure", async () => {
+    const [{ Marked }, { default: DOMPurify }] = await Promise.all([
+      import("marked"),
+      import("dompurify"),
+    ]);
+    let beforeSanitize = "";
+    const html = await renderCodexReleaseMarkdown(hostileMarkdown, "0.145.0", {
+      load: async () => ({ Marked, DOMPurify }),
+      beforeSanitize: (value) => {
+        beforeSanitize = value;
+      },
+    });
+
+    expect(beforeSanitize).not.toContain("tracker.invalid");
+    expect(beforeSanitize).not.toMatch(/<img|\bsrc\s*=/i);
+    expect(beforeSanitize).toContain("diagram");
+    expect(beforeSanitize).toContain("<details open>");
+    expect(beforeSanitize).toContain("<summary>Visible summary</summary>");
+    expect(beforeSanitize).toContain("<table>");
+    expect(beforeSanitize).toContain("Visible form label");
+    expect(beforeSanitize).not.toMatch(/<form|<input|\b(?:class|id|style)\s*=/i);
+
+    expect(html).not.toMatch(/<img|<script|<style|<form|<input/i);
+    expect(html).not.toMatch(/\b(?:class|id|style|src)\s*=/i);
+    expect(html).not.toContain("javascript:");
+    expect(html).toContain('href="https://github.com/openai/codex/docs/guide.md"');
+    expect(html).toContain('href="https://github.com/openai/codex/issues/7"');
+    expect(html).toContain(
+      'href="https://github.com/openai/codex/releases/tag/rust-v0.145.0#section"',
+    );
+  });
+
+  it("mounts only sanitized DOM and never creates an image element", async () => {
+    const { container } = await render(CodexReleaseNotes, {
+      version: "0.145.0",
+      body: hostileMarkdown,
+    });
+
+    await expect.poll(() => container.textContent).toContain("Visible details");
+    expect(container.querySelector("img, script, style, form, input")).toBeNull();
+    expect(container.querySelector("details[open] summary")?.textContent).toBe("Visible summary");
+    expect(container.querySelector("table th")?.textContent).toBe("Head");
+    expect(container.querySelector("table td")?.textContent).toBe("Cell");
+    expect(container.querySelector("a[href^='/']")).toBeNull();
+  });
+});

--- a/ui/src/lib/components/CodexReleaseNotes.svelte
+++ b/ui/src/lib/components/CodexReleaseNotes.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import { renderCodexReleaseMarkdown } from "$lib/codex-release-notes-renderer";
+
+  let {
+    version,
+    body,
+    renderMarkdown = renderCodexReleaseMarkdown,
+  }: {
+    version: string;
+    body: string;
+    renderMarkdown?: typeof renderCodexReleaseMarkdown;
+  } = $props();
+
+  let rendered = $state("");
+  let failed = $state(false);
+
+  $effect(() => {
+    let alive = true;
+    rendered = "";
+    failed = false;
+    renderMarkdown(body, version)
+      .then((html) => {
+        if (alive) rendered = html;
+      })
+      .catch((error) => {
+        console.warn("codex release notes markdown render failed", error);
+        if (alive) failed = true;
+      });
+    return () => {
+      alive = false;
+    };
+  });
+</script>
+
+{#if rendered}
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- Codex-only closed renderer + DOMPurify -->
+  <div class="release-markdown">{@html rendered}</div>
+{:else if failed}
+  <pre class="release-fallback">{body}</pre>
+{/if}
+
+<style>
+  .release-markdown,
+  .release-fallback {
+    color: var(--color-ink);
+    font-size: var(--fs-base);
+    line-height: 1.55;
+  }
+  .release-fallback {
+    margin: 0;
+    white-space: pre-wrap;
+  }
+  .release-markdown :global(:first-child) {
+    margin-top: 0;
+  }
+  .release-markdown :global(:last-child) {
+    margin-bottom: 0;
+  }
+  .release-markdown :global(a) {
+    color: var(--color-amber);
+  }
+  .release-markdown :global(pre) {
+    overflow-x: auto;
+    padding: 10px;
+    background: var(--color-inset);
+    border: 1px solid var(--color-line);
+  }
+  .release-markdown :global(code) {
+    font-size: var(--fs-meta);
+  }
+  .release-markdown :global(table) {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  .release-markdown :global(th),
+  .release-markdown :global(td) {
+    padding: 6px 8px;
+    border: 1px solid var(--color-line);
+    text-align: left;
+  }
+</style>

--- a/ui/src/lib/components/CodexUpdateModal.browser.test.ts
+++ b/ui/src/lib/components/CodexUpdateModal.browser.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import "../../app.css";
-import type { CodexUpdateStatus } from "$lib/types";
+import type { CodexReleaseNotesResult, CodexUpdateStatus } from "$lib/types";
+import { m } from "$lib/paraglide/messages";
 
 vi.mock("$lib/api", async (orig) => ({
   ...((await orig()) as object),
@@ -25,12 +26,108 @@ afterEach(async () => {
 });
 
 describe("CodexUpdateModal", () => {
+  it("loads notes exactly once while keeping localized pending/incomplete states and controls usable", async () => {
+    let resolveNotes!: (result: CodexReleaseNotesResult) => void;
+    const pending = new Promise<CodexReleaseNotesResult>((resolve) => {
+      resolveNotes = resolve;
+    });
+    const loadReleaseNotes = vi.fn(() => pending);
+    const onclose = vi.fn();
+    const { rerender } = await render(CodexUpdateModal, {
+      props: { update, loadReleaseNotes, onclose },
+    });
+
+    await expect.element(page.getByText(m.codexupdate_notes_loading())).toBeVisible();
+    expect(loadReleaseNotes).toHaveBeenCalledTimes(1);
+    expect(document.querySelector<HTMLButtonElement>(".run")?.disabled).toBe(false);
+    document.querySelector<HTMLButtonElement>(".later")?.click();
+    expect(onclose).toHaveBeenCalledOnce();
+
+    await rerender({
+      update: { ...update, checkedAt: 1 },
+      loadReleaseNotes,
+      onclose,
+    });
+    expect(loadReleaseNotes).toHaveBeenCalledTimes(1);
+
+    resolveNotes({
+      current: update.current,
+      latest: update.latest,
+      notes: [{ version: "0.142.5", body: "Original **release body**" }],
+      complete: false,
+    });
+    await expect.element(page.getByText(m.codexupdate_notes_incomplete())).toBeVisible();
+    await expect.element(page.getByText("release body")).toBeVisible();
+    expect(document.querySelector<HTMLButtonElement>(".run")?.disabled).toBe(false);
+  });
+
+  it("turns a notes request rejection into the visible fallback without disabling update actions", async () => {
+    const loadReleaseNotes = vi.fn(async () => {
+      throw new Error("offline");
+    });
+    await render(CodexUpdateModal, { props: { update, loadReleaseNotes } });
+
+    await expect.element(page.getByText(m.codexupdate_notes_incomplete())).toBeVisible();
+    expect(document.querySelector<HTMLButtonElement>(".run")?.disabled).toBe(false);
+    expect(document.querySelector(".all-notes")).not.toBeNull();
+  });
+
+  it("ends the pending state at the fixed deadline even when the loader ignores abort", async () => {
+    const capturedSignals: AbortSignal[] = [];
+    const loadReleaseNotes = vi.fn((signal: AbortSignal) => {
+      capturedSignals.push(signal);
+      return new Promise<CodexReleaseNotesResult>(() => {});
+    });
+    await render(CodexUpdateModal, {
+      props: { update, loadReleaseNotes, notesTimeoutMs: 1 },
+    });
+
+    await expect.element(page.getByText(m.codexupdate_notes_incomplete())).toBeVisible();
+    expect(capturedSignals[0]?.aborted).toBe(true);
+    expect(loadReleaseNotes).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides a late range-A result after status moves to B without refetching", async () => {
+    let resolveNotes!: (result: CodexReleaseNotesResult) => void;
+    const loadReleaseNotes = vi.fn(
+      () =>
+        new Promise<CodexReleaseNotesResult>((resolve) => {
+          resolveNotes = resolve;
+        }),
+    );
+    const { rerender } = await render(CodexUpdateModal, {
+      props: { update, loadReleaseNotes },
+    });
+    const rangeB = {
+      ...update,
+      current: "0.142.5",
+      latest: "0.142.6",
+      checkedAt: 2,
+    };
+    await rerender({ update: rangeB, loadReleaseNotes });
+    resolveNotes({
+      current: update.current,
+      latest: update.latest,
+      notes: [{ version: "0.142.5", body: "stale range A body" }],
+      complete: true,
+    });
+
+    await vi.waitFor(() => expect(loadReleaseNotes).toHaveBeenCalledTimes(1));
+    expect(document.body.textContent).not.toContain("stale range A body");
+  });
+
   it("keeps modal chrome from creating stray scrollbars with an active update log", async () => {
     await page.viewport(800, 600);
 
     render(CodexUpdateModal, {
       props: {
         update,
+        loadReleaseNotes: async () => ({
+          current: update.current,
+          latest: update.latest,
+          notes: [{ version: "0.142.5", body: "Long release detail\n\n".repeat(80) }],
+          complete: true,
+        }),
         log: [
           "=== codex-update 2026-07-01T07:10:00Z 0.142.4 -> 0.142.5 ===",
           ">>> codex-update: running codex update",
@@ -40,6 +137,16 @@ describe("CodexUpdateModal", () => {
         ],
       },
     });
+
+    await expect.element(page.getByText("Long release detail").first()).toBeVisible();
+    const history = document.querySelector<HTMLElement>(".release-history");
+    expect(history).not.toBeNull();
+    expect(history!.scrollHeight).toBeGreaterThan(history!.clientHeight);
+    const actions = document.querySelector<HTMLElement>(".actions");
+    const cardBeforeUpdate = document.querySelector<HTMLElement>(".card");
+    expect(actions!.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+      cardBeforeUpdate!.getBoundingClientRect().bottom,
+    );
 
     document.querySelector<HTMLButtonElement>(".run")?.click();
     await vi.waitFor(() => expect(document.querySelector(".log")).not.toBeNull());

--- a/ui/src/lib/components/CodexUpdateModal.svelte
+++ b/ui/src/lib/components/CodexUpdateModal.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import { tick } from "svelte";
-  import type { CodexUpdateStatus, CodexUpdateResult } from "$lib/types";
-  import { applyCodexUpdate } from "$lib/api";
+  import { onMount, tick } from "svelte";
+  import type { CodexReleaseNotesResult, CodexUpdateStatus, CodexUpdateResult } from "$lib/types";
+  import { applyCodexUpdate, fetchCodexReleaseNotes } from "$lib/api";
   import { dialog } from "$lib/a11yDialog";
   import { m } from "$lib/paraglide/messages";
+  import CodexReleaseNotes from "./CodexReleaseNotes.svelte";
 
   let {
     update,
@@ -11,21 +12,59 @@
     done = null,
     onconfirm,
     onclose,
+    loadReleaseNotes = fetchCodexReleaseNotes,
+    notesTimeoutMs = 16_000,
   }: {
     update: CodexUpdateStatus;
     log?: string[];
     done?: CodexUpdateResult | null;
     onconfirm?: () => void;
     onclose?: () => void;
+    loadReleaseNotes?: (signal: AbortSignal) => Promise<CodexReleaseNotesResult>;
+    notesTimeoutMs?: number;
   } = $props();
 
   let submitting = $state(false);
   let error = $state<string | null>(null);
   let logEl = $state<HTMLPreElement | null>(null);
+  let releaseNotes = $state<CodexReleaseNotesResult | null>(null);
+  let notesFinished = $state(false);
 
   const CODEX_RELEASES_URL = "https://github.com/openai/codex/releases";
   const displayedCurrent = $derived(done?.from ?? update.current);
   const displayedLatest = $derived(done?.to ?? update.latest);
+  const visibleReleaseNotes = $derived(
+    releaseNotes?.current === update.current && releaseNotes?.latest === update.latest
+      ? releaseNotes
+      : null,
+  );
+
+  onMount(() => {
+    const controller = new AbortController();
+    let alive = true;
+    let settled = false;
+    const timeout = setTimeout(() => {
+      controller.abort();
+      if (alive && !settled) notesFinished = true;
+    }, notesTimeoutMs);
+    loadReleaseNotes(controller.signal)
+      .then((result) => {
+        if (alive && !controller.signal.aborted) releaseNotes = result;
+      })
+      .catch(() => {
+        if (alive) releaseNotes = null;
+      })
+      .finally(() => {
+        settled = true;
+        clearTimeout(timeout);
+        if (alive) notesFinished = true;
+      });
+    return () => {
+      alive = false;
+      clearTimeout(timeout);
+      controller.abort();
+    };
+  });
 
   // `codex update` runs server-side in a managed child; shepherd stays up and the
   // modal resolves itself via the `done` result. Busy only while the update is in
@@ -93,6 +132,29 @@
     <a class="all-notes" href={CODEX_RELEASES_URL} target="_blank" rel="noopener noreferrer"
       >{m.codexupdate_all_notes_link()} ↗</a
     >
+
+    {#if !submitting}
+      <section class="release-history" aria-labelledby="codex-release-notes-heading">
+        <h2 id="codex-release-notes-heading" class="micro">{m.codexupdate_notes_heading()}</h2>
+        {#if !notesFinished}
+          <div class="notes-state" aria-live="polite">{m.codexupdate_notes_loading()}</div>
+        {:else}
+          {#if visibleReleaseNotes}
+            {#each visibleReleaseNotes.notes as note (note.version)}
+              <article class="release-note">
+                <h3>v{note.version}</h3>
+                <CodexReleaseNotes version={note.version} body={note.body} />
+              </article>
+            {/each}
+          {/if}
+          {#if !visibleReleaseNotes || !visibleReleaseNotes.complete}
+            <div class="notes-state incomplete" aria-live="polite">
+              {m.codexupdate_notes_incomplete()}
+            </div>
+          {/if}
+        {/if}
+      </section>
+    {/if}
 
     <div class="instructions">{m.codexupdate_instructions()}</div>
 
@@ -230,6 +292,38 @@
     font-size: var(--fs-base);
     line-height: 1.5;
     color: var(--color-ink-bright);
+  }
+  .release-history {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    min-height: 48px;
+    max-height: 36dvh;
+    overflow-y: auto;
+    padding: 12px;
+    border: 1px solid var(--color-line);
+    background: var(--color-inset);
+  }
+  .release-history h2,
+  .release-history h3 {
+    margin: 0;
+  }
+  .release-note {
+    padding-top: 10px;
+    border-top: 1px solid var(--color-line);
+  }
+  .release-note h3 {
+    margin-bottom: 8px;
+    color: var(--color-blue);
+    font-size: var(--fs-base);
+  }
+  .notes-state {
+    color: var(--color-muted);
+    font-size: var(--fs-base);
+    line-height: 1.5;
+  }
+  .notes-state.incomplete {
+    color: var(--color-warn);
   }
   .status {
     color: var(--color-blue);

--- a/ui/src/lib/feature-announcements/entries/v1.45.0-codex-release-notes.ts
+++ b/ui/src/lib/feature-announcements/entries/v1.45.0-codex-release-notes.ts
@@ -1,0 +1,12 @@
+import type { FeatureAnnouncement } from "../../feature-announcements";
+
+const entry = {
+  // The update modal only exists while a Codex update is available, so there is
+  // no stable always-mounted coach target; announce it in What's New instead.
+  id: "codex-release-notes",
+  sinceVersion: "1.45.0",
+  titleKey: "feat_codex_release_notes_title",
+  bodyKey: "feat_codex_release_notes_body",
+} satisfies FeatureAnnouncement;
+
+export default entry;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1486,6 +1486,18 @@ export interface CodexUpdateStatus {
   error?: string;
 }
 
+export interface CodexReleaseNote {
+  version: string;
+  body: string;
+}
+
+export interface CodexReleaseNotesResult {
+  current: string | null;
+  latest: string | null;
+  notes: CodexReleaseNote[];
+  complete: boolean;
+}
+
 /** Terminal outcome of a codex update apply() — the UI mirror of the server's
  *  CodexUpdateResult (src/codex-update.ts). Shared by the `codex-update:done`
  *  event, the store's `codexUpdateDone` signal, and the modal's `done` prop. */


### PR DESCRIPTION
## Problem / Goal

The Codex update dialog only linked to GitHub, so operators had to leave Shepherd to understand what changed. When several stable Codex releases were skipped, there was no in-app view of the cumulative release history.

## Solution / Added

The dialog now loads and displays the original GitHub release notes for every npm-published stable Codex version in the available update range, newest first. Loading happens on demand, and partial or unavailable history falls back visibly to the existing GitHub source link without blocking the **Later** or **Update** actions.

## Technical details

- Adds `GET /api/codex-update/notes` while preserving `notes: null` on periodic status and WebSocket payloads.
- Enumerates the finite npm-published stable version range, then resolves GitHub releases through a resumable, rate-limit-aware loader capped at two serial GitHub requests per invocation.
- Enforces request, aggregate-byte, body-size, timeout, and cache-identity bounds; stale range results cannot replace a newer range.
- Renders release Markdown through a Codex-only sanitizer. Image URLs are removed before browser parsing, visible raw HTML content including details and tables is preserved, relative links are normalized to GitHub, and unsafe elements, attributes, and URL schemes are rejected.
- Adds localized English and German loading/incomplete states and a `v1.45.0` feature announcement.

## Validation

- Root lint and complete root test lane
- UI typecheck and complete UI test lane
- Extension typecheck
- `scripts/check-ui-build.sh`
- Branch hygiene, feature catalog, announcement version, glossary, diff hygiene, and Fallow audit
