### PR TITLE
ci: gate site/ builds and assert on emitted artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,3 +225,60 @@ jobs:
         run: |
           bun run check
           bun run build
+
+  # The shepherd.run marketing site (site/) is the 5th in-monorepo package with its
+  # own lockfile. Like docs-site it builds self-contained, so it needs only a plain
+  # checkout + its own install, and it lives in its OWN job for the same reason: an
+  # install flake there must not red the whole suite.
+  #
+  # Deliberately NOT filtered with `paths:` (#1859). A path-filtered job reports no
+  # status at all on PRs that don't touch those paths, and a required check that never
+  # reports blocks the PR from merging forever. It runs on every PR instead; the build
+  # is sub-second.
+  #
+  # NB the fonts pipeline reaches cdn.jsdelivr.net at BUILD time (the npm font provider
+  # fetches the woff2 for the lockfile-pinned @fontsource version), so this job needs
+  # network during `build`, not just during install. A fetch failure fails the build
+  # loudly. That is deliberately left unretried, matching every other build step here —
+  # `bun-install-retry` wraps installs only, and the repo adds retries in response to
+  # observed flakes (#944, #1134), not in anticipation of one.
+  site:
+    name: site
+    # Skip release-please's generated PR, mirroring the two jobs above.
+    if: ${{ !(startsWith(github.head_ref, 'release-please--') && (github.event.pull_request.user.login == 'shepherd-release-please[bot]' || github.event.pull_request.user.login == 'github-actions[bot]')) }}
+    # Pinned to GitHub-hosted like the others — public repo, no CI_RUNNER toggle.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Cache bun store (site)
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-site-${{ hashFiles('site/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-site-
+
+      - name: Install (site)
+        uses: ./.github/actions/bun-install-retry
+        with:
+          working-directory: site
+
+      # check + build, then assert on what the build actually emitted: a green
+      # `astro build` does NOT prove the site is correct. Point a font family's
+      # provider at a package it can't resolve and the build still exits 0 with only
+      # a [WARN], shipping a dist/ where that family silently degraded to system
+      # fonts. check:artifacts is what catches that; its own logic is unit-tested in
+      # test/check-build-artifacts.test.ts, which runs in `verify`.
+      - name: Build (site)
+        working-directory: site
+        run: |
+          bun run check
+          bun run build
+          bun run check:artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,8 +233,9 @@ jobs:
   #
   # Deliberately NOT filtered with `paths:` (#1859). A path-filtered job reports no
   # status at all on PRs that don't touch those paths, and a required check that never
-  # reports blocks the PR from merging forever. It runs on every PR instead; the build
-  # is sub-second.
+  # reports blocks the PR from merging forever. So it runs on every PR instead — the
+  # job is small next to `verify`, and correctness of the required-check contract is
+  # the reason, not cost.
   #
   # NB the fonts pipeline reaches cdn.jsdelivr.net at BUILD time (the npm font provider
   # fetches the woff2 for the lockfile-pinned @fontsource version), so this job needs

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -28,9 +28,9 @@ Those gates are scoped to `ui/` + `extension/` and to `feat(...)` commits touchi
 root `tsconfig.json` `exclude` (it type-checks via `astro check`, not the server
 `tsc`).
 
-Unlike `site/`, this package **stays in the monorepo** and **is wired into CI**
-(`.github/workflows/ci.yml`): `cd docs-site && bun install --frozen-lockfile &&
-bun run check && bun run build`.
+Unlike `site/`, this package **stays in the monorepo**. Both are wired into CI
+(`.github/workflows/ci.yml`), each in its own job: `cd docs-site && bun install
+--frozen-lockfile && bun run check && bun run build`.
 
 ## Generated content
 

--- a/site/README.md
+++ b/site/README.md
@@ -34,8 +34,23 @@ build, every aggregate signal survives — `@font-face` blocks are still present
 emitted. The one check that discriminates is per-family: does the family each
 `--font-*` variable names actually have a `url()`-backed `@font-face`?
 
-`scripts/check-build-artifacts.mjs` asserts that, plus route coverage (derived from
-`src/pages/**`, so a new page is covered automatically) and font-file size floors.
+`scripts/check-build-artifacts.mjs` asserts that, plus route coverage and font-file
+size floors. The expected font families are read from `astro.config.mjs`, so adding
+one brings it under the gate automatically.
+
+Routes are derived from `src/pages/**`, so a new **static `.astro`** page — nested
+included — is covered with no change to the script. Anything the directory-format
+mapping cannot resolve to a single output path **fails the gate by design**, rather
+than being silently skipped:
+
+- a Markdown/MDX page (`about.md`) — the mapping only understands `.astro`
+- a dynamic or spread route (`[slug].astro`) — its outputs come from
+  `getStaticPaths` at build time, so they cannot be derived from the filename
+
+If you add either, extend `routeForPage()` to cover it; the red is telling you the
+gate would otherwise stop covering a route. Underscore- and dot-prefixed entries
+(`_components/`, `.DS_Store`) are not routes and are skipped.
+
 Its logic is unit-tested from the monorepo root in `test/check-build-artifacts.test.ts`,
 alongside the repo's other gate-script tests.
 

--- a/site/README.md
+++ b/site/README.md
@@ -36,7 +36,11 @@ emitted. The one check that discriminates is per-family: does the family each
 
 `scripts/check-build-artifacts.mjs` asserts that, plus route coverage and font-file
 size floors. The expected font families are read from `astro.config.mjs`, so adding
-one brings it under the gate automatically.
+one brings it under the gate automatically — and every configured family is required
+on **every** route. That holds because `src/layouts/Base.astro` renders one `<Font>`
+tag per family and all pages use that layout. A family scoped to a single page or
+layout would therefore fail the gate; supporting one means teaching the check which
+routes a family applies to, rather than assuming all of them.
 
 Routes are derived from `src/pages/**`, so a new **static `.astro`** page — nested
 included — is covered with no change to the script. Anything the directory-format

--- a/site/README.md
+++ b/site/README.md
@@ -14,10 +14,30 @@ Vercel project.
 ```bash
 cd site
 bun install
-bun run dev      # local dev server
-bun run build    # static output to dist/
-bun run preview  # serve the built dist/
+bun run dev             # local dev server
+bun run build           # static output to dist/
+bun run preview         # serve the built dist/
+bun run check:artifacts # assert on what the build emitted (run after build)
 ```
+
+## CI
+
+The `site` job in `.github/workflows/ci.yml` runs `bun run check`, `bun run build`
+and `bun run check:artifacts` on every PR.
+
+That last step exists because **a green `astro build` does not prove the site is
+correct**. The Fonts API fails *silently*: point a family's provider at a package it
+cannot resolve and the build still exits 0 with only a `[WARN]`, emitting a `dist/`
+where that family has degraded to system fonts. Measured against a real degraded
+build, every aggregate signal survives — `@font-face` blocks are still present, the
+`--font-*` variables are still declared, woff2 files and preload links are still
+emitted. The one check that discriminates is per-family: does the family each
+`--font-*` variable names actually have a `url()`-backed `@font-face`?
+
+`scripts/check-build-artifacts.mjs` asserts that, plus route coverage (derived from
+`src/pages/**`, so a new page is covered automatically) and font-file size floors.
+Its logic is unit-tested from the monorepo root in `test/check-build-artifacts.test.ts`,
+alongside the repo's other gate-script tests.
 
 ## Routing (`vercel.json`)
 

--- a/site/package.json
+++ b/site/package.json
@@ -7,7 +7,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "check": "astro check"
+    "check": "astro check",
+    "check:artifacts": "bun scripts/check-build-artifacts.mjs"
   },
   "dependencies": {
     "@fontsource/jetbrains-mono": "^5.2.8",

--- a/site/scripts/check-build-artifacts.mjs
+++ b/site/scripts/check-build-artifacts.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env bun
+// Artifact assertions for the built marketing site (`site/dist`).
+//
+// WHY THIS EXISTS: a green `astro build` does not prove the site is correct. The
+// Fonts API's failure mode is *silent* — point a family's provider at a package it
+// cannot resolve and the build still exits 0 with only a [WARN], emitting a `dist/`
+// where that family has no webfont at all. Measured against a real degraded build,
+// every aggregate signal survives it (`@font-face` still present, the `--font-*`
+// variable still present, woff2 files still emitted, preload links still emitted).
+// The one signal that discriminates is per-family: does the family named by each
+// `--font-*` variable actually have a `url()`-backed `@font-face`? That is the
+// assertion this script exists for; the rest are cheap floors around it.
+//
+// Run after `astro build`: `bun run check:artifacts`.
+//
+// Roots default to this package (resolved from import.meta.url, never process.cwd(),
+// so running it from the repo root cannot silently derive an empty route list and
+// vacuously pass). Both are env-overridable so the gate can be exercised against
+// synthetic fixtures — see test/check-build-artifacts.test.ts.
+//
+//   SITE_DIST  (or argv[2])  build output to validate      default <pkg>/dist
+//   SITE_PAGES               route source of truth         default <pkg>/src/pages
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PKG_ROOT = resolve(fileURLToPath(import.meta.url), "..", "..");
+const DIST = resolve(process.argv[2] ?? process.env.SITE_DIST ?? join(PKG_ROOT, "dist"));
+const PAGES = resolve(process.env.SITE_PAGES ?? join(PKG_ROOT, "src", "pages"));
+
+/** CSS custom properties every built page must declare, one per configured font
+ *  family (see `fonts` in astro.config.mjs). Listed explicitly rather than derived
+ *  from the built CSS: deriving from the output would make the check vacuous if a
+ *  family were dropped from the config entirely. */
+const EXPECTED_FONT_VARS = ["--font-space-grotesk", "--font-jetbrains-mono"];
+
+/** Minimum size of an emitted route's HTML. The three real routes measure
+ *  28825 / 13862 / 12778 bytes, so this only catches an empty/stub write. */
+const MIN_ROUTE_BYTES = 2000;
+
+/** Minimum size of an emitted woff2 — catches a truncated font, which otherwise
+ *  passes both the presence floor and the per-family check (the file exists and
+ *  its `@font-face` still carries a `url()`). The smallest legitimately emitted
+ *  woff2 measures 1160 bytes, so 1 KB would leave only ~136 bytes of headroom and
+ *  would red the gate whenever subsetting re-chunks. 512 sits comfortably under
+ *  every real file and well over a stub write. */
+const MIN_WOFF2_BYTES = 512;
+
+let failed = false;
+
+function pass(msg) {
+  console.log(`PASS  ${msg}`);
+}
+
+function fail(msg) {
+  console.log(`FAIL  ${msg}`);
+  failed = true;
+}
+
+/** Every file under `dir`, recursively. Returns [] when `dir` does not exist. */
+function walk(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const entry of entries) {
+    const abs = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(abs));
+    else out.push(abs);
+  }
+  return out;
+}
+
+/** Size of a regular file, or -1 if it is missing or is not a regular file.
+ *  The isFile() guard matters: statSync on a directory returns a nonzero size,
+ *  so a directory sitting where a route's index.html belongs would otherwise
+ *  sail past the size floor. */
+function sizeOf(file) {
+  try {
+    const st = statSync(file);
+    return st.isFile() ? st.size : -1;
+  } catch {
+    return -1;
+  }
+}
+
+// ── Routes ───────────────────────────────────────────────────────────────────
+
+/** Map a page file to the HTML Astro emits for it under the default
+ *  `build.format: "directory"`:
+ *
+ *    index.astro            → index.html
+ *    privacy.astro          → privacy/index.html
+ *    legal/terms.astro      → legal/terms/index.html
+ *    legal/index.astro      → legal/index.html
+ *
+ *  Returns "" for a file Astro deliberately does not route (see below), and null
+ *  for anything this mapping does not understand. The caller fails loudly on null
+ *  rather than skipping — silently ignoring an unmapped page is the same
+ *  under-coverage bug as not walking subdirectories at all. */
+function routeForPage(rel) {
+  const segments = rel.split(sep);
+  // Astro excludes any path with an underscore-prefixed segment from routing
+  // (_components/, _draft.astro), so these are not missing routes — asserting on
+  // them would be a false failure.
+  if (segments.some((s) => s.startsWith("_"))) return "";
+  if (!rel.endsWith(".astro")) return null;
+  segments[segments.length - 1] = segments[segments.length - 1].slice(0, -".astro".length);
+  // Dynamic and spread routes ([slug].astro, [...rest].astro) expand via
+  // getStaticPaths at build time, so their outputs cannot be derived from the
+  // filename alone.
+  if (segments.some((s) => s.includes("[") || s.includes("]"))) return null;
+  if (segments[segments.length - 1] === "index") {
+    return join(...segments.slice(0, -1), "index.html");
+  }
+  return join(...segments, "index.html");
+}
+
+function checkRoutes() {
+  const routes = [];
+  for (const abs of walk(PAGES)) {
+    const rel = relative(PAGES, abs);
+    const route = routeForPage(rel);
+    if (route === null) {
+      fail(`page ${rel} has no known output mapping (only static .astro pages are supported)`);
+      continue;
+    }
+    if (route !== "") routes.push(route);
+  }
+
+  // Guard against a vacuous pass: an empty (or wrong) pages root, or one holding
+  // nothing but non-routed files, would otherwise assert nothing at all.
+  if (routes.length === 0) {
+    fail(`no pages found under ${PAGES} — cannot derive the expected route list`);
+    return [];
+  }
+
+  for (const route of routes) {
+    const size = sizeOf(join(DIST, route));
+    if (size < 0) fail(`route ${route} was not emitted`);
+    else if (size <= MIN_ROUTE_BYTES) fail(`route ${route} is only ${size} bytes`);
+    else pass(`route ${route} emitted (${size} bytes)`);
+  }
+
+  return routes;
+}
+
+// ── Fonts ────────────────────────────────────────────────────────────────────
+
+/** Every `@font-face` block in `html`, as { family, src }. Tolerates both minified
+ *  and expanded CSS. Nested braces do not occur inside `@font-face`. */
+function parseFontFaces(html) {
+  const faces = [];
+  for (const match of html.matchAll(/@font-face\s*\{([^}]*)\}/g)) {
+    const body = match[1];
+    const family = /font-family\s*:\s*([^;]+)/.exec(body)?.[1];
+    const src = /src\s*:\s*([^;]+)/.exec(body)?.[1];
+    if (family) faces.push({ family: unquote(family), src: src ?? "" });
+  }
+  return faces;
+}
+
+function unquote(value) {
+  return value.trim().replace(/^['"]|['"]$/g, "");
+}
+
+/** The first family named by a font stack — e.g.
+ *  `"Space Grotesk-abc","Space Grotesk-abc fallback: Arial",system-ui` → `Space Grotesk-abc` */
+function primaryFamily(declarationValue) {
+  return unquote(declarationValue.split(",")[0] ?? "");
+}
+
+function checkFontsForRoute(route) {
+  const file = join(DIST, route);
+  let html;
+  try {
+    html = readFileSync(file, "utf8");
+  } catch {
+    return; // absence already reported by checkRoutes
+  }
+
+  const faces = parseFontFaces(html);
+  // A family counts as really present only when it has a webfont — a `local()`
+  // metric-adjusted fallback block is emitted even when the provider resolved
+  // nothing, so matching on the family name alone would not discriminate.
+  const familiesWithWebfont = new Set(
+    faces.filter((f) => f.src.includes("url(")).map((f) => f.family),
+  );
+
+  for (const varName of EXPECTED_FONT_VARS) {
+    const declaration = new RegExp(`${varName}\\s*:\\s*([^;}]+)`).exec(html)?.[1];
+    if (!declaration) {
+      fail(`${route}: CSS variable ${varName} is not declared`);
+      continue;
+    }
+    const family = primaryFamily(declaration);
+    if (!familiesWithWebfont.has(family)) {
+      fail(
+        `${route}: ${varName} resolves to "${family}", which has no url()-backed @font-face ` +
+          `— the font pipeline degraded to system fallbacks`,
+      );
+      continue;
+    }
+    pass(`${route}: ${varName} → "${family}" has a webfont`);
+  }
+}
+
+function checkFontFiles() {
+  const woff2 = walk(DIST).filter((f) => f.endsWith(".woff2"));
+  if (woff2.length === 0) {
+    fail("no .woff2 files were emitted");
+    return;
+  }
+  // Sanity floor only — a degraded build still emits *some* woff2 (the families
+  // that did resolve), so this can never be the discriminating signal.
+  pass(`${woff2.length} .woff2 file(s) emitted`);
+
+  const truncated = woff2.filter((f) => sizeOf(f) <= MIN_WOFF2_BYTES);
+  if (truncated.length > 0) {
+    for (const f of truncated) {
+      fail(`${relative(DIST, f)} is only ${sizeOf(f)} bytes — truncated font file`);
+    }
+    return;
+  }
+  pass(`all .woff2 files exceed ${MIN_WOFF2_BYTES} bytes`);
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+console.log(`Checking build artifacts in ${DIST}`);
+const routes = checkRoutes();
+for (const route of routes) checkFontsForRoute(route);
+checkFontFiles();
+
+if (failed) {
+  console.error("\nBuild artifact checks FAILED");
+  process.exit(1);
+}
+console.log("\nAll build artifact checks passed");

--- a/site/scripts/check-build-artifacts.mjs
+++ b/site/scripts/check-build-artifacts.mjs
@@ -13,6 +13,11 @@
 //
 // Run after `astro build`: `bun run check:artifacts`.
 //
+// ASSUMPTION: every font family in astro.config.mjs is expected on EVERY route,
+// because Base.astro renders one <Font> tag per family and every page uses that
+// layout. A family scoped to a single page or layout would false-red — see the
+// note on checkFontsForRoute().
+//
 // Roots default to this package (resolved from import.meta.url, never process.cwd(),
 // so running it from the repo root cannot silently derive an empty route list and
 // vacuously pass). Both are env-overridable so the gate can be exercised against
@@ -201,6 +206,18 @@ function primaryFamily(declarationValue) {
   return unquote(declarationValue.split(",")[0] ?? "");
 }
 
+/** Escape a string for literal use inside a RegExp. The variable names come from
+ *  astro.config.mjs, so a `cssVariable` containing a metacharacter would otherwise
+ *  either throw or — worse — silently match the wrong thing and report a pass. */
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Every family in the config must be declared on EVERY route. That holds because
+ *  Base.astro renders one <Font> tag per family and every page uses that layout, so
+ *  all routes carry the full font head. A family scoped to a single page or layout
+ *  would therefore false-red here — if that is ever wanted, this check needs to
+ *  learn which routes a family applies to rather than assuming all of them. */
 function checkFontsForRoute(route, expectedVars) {
   const file = join(DIST, route);
   let html;
@@ -219,7 +236,7 @@ function checkFontsForRoute(route, expectedVars) {
   );
 
   for (const varName of expectedVars) {
-    const declaration = new RegExp(`${varName}\\s*:\\s*([^;}]+)`).exec(html)?.[1];
+    const declaration = new RegExp(`${escapeRegExp(varName)}\\s*:\\s*([^;}]+)`).exec(html)?.[1];
     if (!declaration) {
       fail(`${route}: CSS variable ${varName} is not declared`);
       continue;

--- a/site/scripts/check-build-artifacts.mjs
+++ b/site/scripts/check-build-artifacts.mjs
@@ -18,8 +18,9 @@
 // vacuously pass). Both are env-overridable so the gate can be exercised against
 // synthetic fixtures — see test/check-build-artifacts.test.ts.
 //
-//   SITE_DIST  (or argv[2])  build output to validate      default <pkg>/dist
-//   SITE_PAGES               route source of truth         default <pkg>/src/pages
+//   SITE_DIST   (or argv[2])  build output to validate     default <pkg>/dist
+//   SITE_PAGES                route source of truth        default <pkg>/src/pages
+//   SITE_CONFIG               font config source of truth  default <pkg>/astro.config.mjs
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative, resolve, sep } from "node:path";
@@ -28,12 +29,7 @@ import { fileURLToPath } from "node:url";
 const PKG_ROOT = resolve(fileURLToPath(import.meta.url), "..", "..");
 const DIST = resolve(process.argv[2] ?? process.env.SITE_DIST ?? join(PKG_ROOT, "dist"));
 const PAGES = resolve(process.env.SITE_PAGES ?? join(PKG_ROOT, "src", "pages"));
-
-/** CSS custom properties every built page must declare, one per configured font
- *  family (see `fonts` in astro.config.mjs). Listed explicitly rather than derived
- *  from the built CSS: deriving from the output would make the check vacuous if a
- *  family were dropped from the config entirely. */
-const EXPECTED_FONT_VARS = ["--font-space-grotesk", "--font-jetbrains-mono"];
+const CONFIG = resolve(process.env.SITE_CONFIG ?? join(PKG_ROOT, "astro.config.mjs"));
 
 /** Minimum size of an emitted route's HTML. The three real routes measure
  *  28825 / 13862 / 12778 bytes, so this only catches an empty/stub write. */
@@ -106,8 +102,10 @@ function routeForPage(rel) {
   const segments = rel.split(sep);
   // Astro excludes any path with an underscore-prefixed segment from routing
   // (_components/, _draft.astro), so these are not missing routes — asserting on
-  // them would be a false failure.
-  if (segments.some((s) => s.startsWith("_"))) return "";
+  // them would be a false failure. Dot-prefixed entries are skipped for the same
+  // reason plus one more: a stray .DS_Store is gitignored, so it would red a local
+  // run for a confusing reason while CI never saw it.
+  if (segments.some((s) => s.startsWith("_") || s.startsWith("."))) return "";
   if (!rel.endsWith(".astro")) return null;
   segments[segments.length - 1] = segments[segments.length - 1].slice(0, -".astro".length);
   // Dynamic and spread routes ([slug].astro, [...rest].astro) expand via
@@ -151,6 +149,35 @@ function checkRoutes() {
 
 // ── Fonts ────────────────────────────────────────────────────────────────────
 
+/** The CSS custom properties the build is expected to declare — read straight from
+ *  the `fonts` config's `cssVariable` entries rather than hardcoded here, so adding
+ *  a family to astro.config.mjs automatically brings it under the gate. A hardcoded
+ *  list would drift silently: the new family would never be checked and the gate
+ *  would keep reporting green.
+ *
+ *  Deriving the list from the built CSS instead was rejected — global.css layers its
+ *  own semantic aliases (--font-display, --font-mono) on top of these, so any
+ *  "unexpected --font-* in the output" rule would red the moment Astro inlines that
+ *  stylesheet. The config is the actual source of truth.
+ *
+ *  Parsed textually because this is a plain script with no bundler: astro.config.mjs
+ *  imports from "astro/config", so importing it would drag in the whole toolchain. */
+function expectedFontVars() {
+  let source;
+  try {
+    source = readFileSync(CONFIG, "utf8");
+  } catch {
+    fail(`cannot read font config at ${CONFIG}`);
+    return [];
+  }
+  const vars = [...source.matchAll(/cssVariable:\s*["']([^"']+)["']/g)].map((m) => m[1]);
+  if (vars.length === 0) {
+    fail(`no cssVariable entries found in ${CONFIG} — cannot derive the expected font list`);
+    return [];
+  }
+  return [...new Set(vars)];
+}
+
 /** Every `@font-face` block in `html`, as { family, src }. Tolerates both minified
  *  and expanded CSS. Nested braces do not occur inside `@font-face`. */
 function parseFontFaces(html) {
@@ -174,7 +201,7 @@ function primaryFamily(declarationValue) {
   return unquote(declarationValue.split(",")[0] ?? "");
 }
 
-function checkFontsForRoute(route) {
+function checkFontsForRoute(route, expectedVars) {
   const file = join(DIST, route);
   let html;
   try {
@@ -191,7 +218,7 @@ function checkFontsForRoute(route) {
     faces.filter((f) => f.src.includes("url(")).map((f) => f.family),
   );
 
-  for (const varName of EXPECTED_FONT_VARS) {
+  for (const varName of expectedVars) {
     const declaration = new RegExp(`${varName}\\s*:\\s*([^;}]+)`).exec(html)?.[1];
     if (!declaration) {
       fail(`${route}: CSS variable ${varName} is not declared`);
@@ -233,7 +260,11 @@ function checkFontFiles() {
 
 console.log(`Checking build artifacts in ${DIST}`);
 const routes = checkRoutes();
-for (const route of routes) checkFontsForRoute(route);
+const expectedVars = expectedFontVars();
+if (expectedVars.length > 0) {
+  pass(`font config declares ${expectedVars.length} family variable(s): ${expectedVars.join(", ")}`);
+}
+for (const route of routes) checkFontsForRoute(route, expectedVars);
 checkFontFiles();
 
 if (failed) {

--- a/site/scripts/check-build-artifacts.mjs
+++ b/site/scripts/check-build-artifacts.mjs
@@ -154,6 +154,51 @@ function checkRoutes() {
 
 // ── Fonts ────────────────────────────────────────────────────────────────────
 
+/** Strip `//` and block comments from JS source, leaving string literals intact.
+ *  String-aware on purpose: a blunt line-comment regex would truncate at the `//`
+ *  inside a URL string (`"https://…"`) and could drop real config after it on the
+ *  same line — trading a false red for a silent under-check, which is worse.
+ *
+ *  Does not track regex literals; a `/…/` pattern containing a quote would confuse
+ *  it. That does not occur in an Astro font config, and the failure mode is a loud
+ *  "no cssVariable entries" rather than a silent pass. */
+function stripComments(source) {
+  let out = "";
+  for (let i = 0; i < source.length; ) {
+    const c = source[i];
+    const next = source[i + 1];
+    if (c === '"' || c === "'" || c === "`") {
+      out += c;
+      i++;
+      while (i < source.length) {
+        if (source[i] === "\\") {
+          out += source[i] + (source[i + 1] ?? "");
+          i += 2;
+          continue;
+        }
+        out += source[i];
+        const closed = source[i] === c;
+        i++;
+        if (closed) break;
+      }
+      continue;
+    }
+    if (c === "/" && next === "/") {
+      while (i < source.length && source[i] !== "\n") i++;
+      continue;
+    }
+    if (c === "/" && next === "*") {
+      i += 2;
+      while (i < source.length && !(source[i] === "*" && source[i + 1] === "/")) i++;
+      i += 2;
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
 /** The CSS custom properties the build is expected to declare — read straight from
  *  the `fonts` config's `cssVariable` entries rather than hardcoded here, so adding
  *  a family to astro.config.mjs automatically brings it under the gate. A hardcoded
@@ -175,7 +220,11 @@ function expectedFontVars() {
     fail(`cannot read font config at ${CONFIG}`);
     return [];
   }
-  const vars = [...source.matchAll(/cssVariable:\s*["']([^"']+)["']/g)].map((m) => m[1]);
+  // Comments first: a family left commented out during a swap is NOT configured,
+  // and requiring it would red the gate for a font the site no longer ships.
+  const vars = [...stripComments(source).matchAll(/cssVariable:\s*["']([^"']+)["']/g)].map(
+    (m) => m[1],
+  );
   if (vars.length === 0) {
     fail(`no cssVariable entries found in ${CONFIG} — cannot derive the expected font list`);
     return [];

--- a/test/check-build-artifacts.test.ts
+++ b/test/check-build-artifacts.test.ts
@@ -257,6 +257,31 @@ test("a family removed from the config is no longer required", () => {
   expect(runGate().code).toBe(0);
 });
 
+// The variable name is interpolated into a RegExp, so an unescaped metacharacter
+// either throws (unbalanced paren) or matches the wrong declaration. Both tests
+// below fail if the escaping is removed.
+test("a cssVariable with an unbalanced paren reports cleanly instead of throwing", () => {
+  seedHealthy();
+  writeConfig(["--font-space-grotesk", "--font-jetbrains-mono", "--font-a(b"]);
+  const { code, out } = runGate();
+  expect(code).toBe(1);
+  expect(out).toContain("--font-a(b is not declared");
+  expect(out).not.toContain("Invalid regular expression");
+});
+
+test("a '.' in a cssVariable does not match a similarly-named declaration", () => {
+  seedHealthy();
+  writeConfig(["--font-a.c"]);
+  // The decoy is declared FIRST and resolves to a family with no webfont, so an
+  // unescaped `.` matches it and the run fails; matching literally finds the real
+  // declaration and passes.
+  const vars = { "--font-a-c": `"${JB}"`, "--font-a.c": `"${SG}"` };
+  for (const route of ["index.html", "privacy/index.html", "impressum/index.html"]) {
+    write(dist, route, pageHtml({ webfontFamilies: [SG], vars }));
+  }
+  expect(runGate().code).toBe(0);
+});
+
 test("an unreadable font config fails rather than checking nothing", () => {
   seedHealthy();
   rmSync(config);

--- a/test/check-build-artifacts.test.ts
+++ b/test/check-build-artifacts.test.ts
@@ -282,6 +282,65 @@ test("a '.' in a cssVariable does not match a similarly-named declaration", () =
   expect(runGate().code).toBe(0);
 });
 
+// A family left commented out during a swap is not configured — requiring it would
+// red the gate for a font the site no longer ships.
+test("a commented-out cssVariable is not required", () => {
+  seedHealthy();
+  writeFileSync(
+    config,
+    `export default defineConfig({
+  fonts: [
+    { cssVariable: "--font-space-grotesk" },
+    { cssVariable: "--font-jetbrains-mono" },
+    // { cssVariable: "--font-old-and-removed" },
+  ],
+});
+`,
+  );
+  expect(runGate().code).toBe(0);
+});
+
+test("a block-commented family entry is not required", () => {
+  seedHealthy();
+  writeFileSync(
+    config,
+    `export default defineConfig({
+  fonts: [
+    { cssVariable: "--font-space-grotesk" },
+    { cssVariable: "--font-jetbrains-mono" },
+    /* swapped out:
+       { cssVariable: "--font-old-and-removed" }, */
+  ],
+});
+`,
+  );
+  expect(runGate().code).toBe(0);
+});
+
+// Comment stripping must be string-aware: truncating at the `//` of a URL would
+// drop the real entry after it, silently under-checking instead of false-reding.
+test("a // inside a string does not hide a later cssVariable", () => {
+  seedHealthy();
+  writeFileSync(
+    config,
+    `export default defineConfig({
+  fonts: [
+    { url: "https://example.com/f.css", cssVariable: "--font-space-grotesk" },
+    { cssVariable: "--font-jetbrains-mono" },
+    { cssVariable: "--font-not-in-html" },
+  ],
+});
+`,
+  );
+  const { code, out } = runGate();
+  expect(code).toBe(1);
+  expect(out).toContain("--font-not-in-html is not declared");
+  // The entry sharing a line with the URL must survive: a naive line-strip would
+  // truncate at the `//` and quietly stop checking --font-space-grotesk.
+  expect(out).toContain("declares 3 family variable(s)");
+  expect(out).toContain("--font-space-grotesk");
+});
+
 test("an unreadable font config fails rather than checking nothing", () => {
   seedHealthy();
   rmSync(config);

--- a/test/check-build-artifacts.test.ts
+++ b/test/check-build-artifacts.test.ts
@@ -17,6 +17,16 @@ const JB = "JetBrains Mono-b581649cf8f10209";
 let fixture: string;
 let pages: string;
 let dist: string;
+let config: string;
+
+/** A stand-in astro.config.mjs — the gate reads its `cssVariable` entries as the
+ *  source of truth for which font families must be present. */
+function writeConfig(cssVars: string[]) {
+  const entries = cssVars
+    .map((v) => `    { name: "X", cssVariable: "${v}", provider: fontProviders.npm() },`)
+    .join("\n");
+  writeFileSync(config, `export default defineConfig({\n  fonts: [\n${entries}\n  ],\n});\n`);
+}
 
 function write(root: string, rel: string, contents: string) {
   const abs = join(root, rel);
@@ -84,7 +94,7 @@ function seedHealthy() {
 
 function runGate(): { code: number; out: string } {
   const r = spawnSync("bun", [SCRIPT], {
-    env: { ...process.env, SITE_DIST: dist, SITE_PAGES: pages },
+    env: { ...process.env, SITE_DIST: dist, SITE_PAGES: pages, SITE_CONFIG: config },
     encoding: "utf8",
   });
   return { code: r.status ?? -1, out: `${r.stdout}${r.stderr}` };
@@ -94,8 +104,10 @@ beforeEach(() => {
   fixture = mkdtempSync(join(tmpdir(), "shepherd-site-artifacts-"));
   pages = join(fixture, "src", "pages");
   dist = join(fixture, "dist");
+  config = join(fixture, "astro.config.mjs");
   mkdirSync(pages, { recursive: true });
   mkdirSync(dist, { recursive: true });
+  writeConfig(["--font-space-grotesk", "--font-jetbrains-mono"]);
 });
 afterEach(() => rmSync(fixture, { recursive: true, force: true }));
 
@@ -219,6 +231,46 @@ test("a pages directory of only non-routed files fails rather than passing vacuo
   const { code, out } = runGate();
   expect(code).toBe(1);
   expect(out).toContain("no pages found");
+});
+
+test("dot-prefixed junk under src/pages is ignored", () => {
+  seedHealthy();
+  write(pages, ".DS_Store", "junk\n");
+  expect(runGate().code).toBe(0);
+});
+
+// The expected font list is read from astro.config.mjs rather than hardcoded, so a
+// family added to the config is checked immediately instead of drifting out of
+// coverage while the gate keeps reporting green.
+test("a family added to the config is checked without touching the script", () => {
+  seedHealthy();
+  writeConfig(["--font-space-grotesk", "--font-jetbrains-mono", "--font-newly-added"]);
+  const { code, out } = runGate();
+  expect(code).toBe(1);
+  expect(out).toContain("--font-newly-added is not declared");
+});
+
+test("a family removed from the config is no longer required", () => {
+  seedHealthy();
+  writeConfig(["--font-space-grotesk"]);
+  write(dist, "index.html", pageHtml({ webfontFamilies: [SG] }));
+  expect(runGate().code).toBe(0);
+});
+
+test("an unreadable font config fails rather than checking nothing", () => {
+  seedHealthy();
+  rmSync(config);
+  const { code, out } = runGate();
+  expect(code).toBe(1);
+  expect(out).toContain("cannot read font config");
+});
+
+test("a font config with no cssVariable entries fails", () => {
+  seedHealthy();
+  writeFileSync(config, "export default defineConfig({ fonts: [] });\n");
+  const { code, out } = runGate();
+  expect(code).toBe(1);
+  expect(out).toContain("no cssVariable entries");
 });
 
 // statSync reports a nonzero size for a directory, so without an isFile() guard a

--- a/test/check-build-artifacts.test.ts
+++ b/test/check-build-artifacts.test.ts
@@ -1,0 +1,233 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { spawnSync } from "node:child_process";
+
+// The gate under test lives with the package it validates; the test lives here,
+// matching check-generated-docs.test.ts / check-feature-catalog.test.ts (both of
+// which also reach into a standalone package's tree from root test/).
+const SCRIPT = join(import.meta.dir, "..", "site", "scripts", "check-build-artifacts.mjs");
+
+// Family names as Astro emits them: the human name plus a content hash. The hash
+// is arbitrary here — the gate must never depend on its value.
+const SG = "Space Grotesk-e5e3653021f8a4c5";
+const JB = "JetBrains Mono-b581649cf8f10209";
+
+let fixture: string;
+let pages: string;
+let dist: string;
+
+function write(root: string, rel: string, contents: string) {
+  const abs = join(root, rel);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, contents);
+}
+
+interface PageOpts {
+  /** Families given a real `url()`-backed @font-face. Omitting one models the
+   *  measured silent-fallback build, where the variable is still declared but the
+   *  family it names has no webfont. */
+  webfontFamilies?: string[];
+  /** CSS variables to declare. */
+  vars?: Record<string, string>;
+}
+
+/** Build page HTML shaped like Astro's minified output: the font `@font-face`
+ *  blocks (webfont + `local()` metric fallback) and the `--font-*` stack. */
+function pageHtml({
+  webfontFamilies = [SG, JB],
+  vars = {
+    "--font-space-grotesk": `"${SG}","${SG} fallback: Arial",system-ui,sans-serif`,
+    "--font-jetbrains-mono": `"${JB}","${JB} fallback: Courier New",ui-monospace,monospace`,
+  },
+}: PageOpts = {}) {
+  const faces: string[] = [];
+  for (const family of [SG, JB]) {
+    if (webfontFamilies.includes(family)) {
+      const file = family.startsWith("Space") ? "sg.woff2" : "jb.woff2";
+      faces.push(
+        `@font-face{font-family:"${family}";src:url("/_astro/fonts/${file}") format("woff2")}`,
+      );
+    }
+    // The metric-adjusted local() fallback is emitted either way — which is
+    // precisely why matching on the family name alone cannot discriminate.
+    const fallback = family.startsWith("Space") ? "Arial" : "Courier New";
+    faces.push(
+      `@font-face{font-family:"${family} fallback: ${fallback}";src:local("${fallback}")}`,
+    );
+  }
+  const decls = Object.entries(vars)
+    .map(([k, v]) => `${k}:${v}`)
+    .join(";");
+  // Padded past the gate's 2000-byte route floor, as a real page is.
+  const filler = `<p>${"marketing copy ".repeat(150)}</p>`;
+  return `<!DOCTYPE html><html><head><style>${faces.join("")}:root{${decls}}</style></head><body>${filler}</body></html>`;
+}
+
+/** A woff2 comfortably over the gate's 512-byte truncation floor. */
+function woff2(bytes = 4096) {
+  return "w".repeat(bytes);
+}
+
+/** Seed a healthy three-route site: pages + matching dist + two font files. */
+function seedHealthy() {
+  for (const name of ["index", "privacy", "impressum"]) {
+    write(pages, `${name}.astro`, "<h1>page</h1>\n");
+  }
+  write(dist, "index.html", pageHtml());
+  write(dist, "privacy/index.html", pageHtml());
+  write(dist, "impressum/index.html", pageHtml());
+  write(dist, "_astro/fonts/sg.woff2", woff2());
+  write(dist, "_astro/fonts/jb.woff2", woff2());
+}
+
+function runGate(): { code: number; out: string } {
+  const r = spawnSync("bun", [SCRIPT], {
+    env: { ...process.env, SITE_DIST: dist, SITE_PAGES: pages },
+    encoding: "utf8",
+  });
+  return { code: r.status ?? -1, out: `${r.stdout}${r.stderr}` };
+}
+
+beforeEach(() => {
+  fixture = mkdtempSync(join(tmpdir(), "shepherd-site-artifacts-"));
+  pages = join(fixture, "src", "pages");
+  dist = join(fixture, "dist");
+  mkdirSync(pages, { recursive: true });
+  mkdirSync(dist, { recursive: true });
+});
+afterEach(() => rmSync(fixture, { recursive: true, force: true }));
+
+test("healthy build passes", () => {
+  seedHealthy();
+  const { code, out } = runGate();
+  expect(code).toBe(0);
+  expect(out).toContain("All build artifact checks passed");
+});
+
+// THE load-bearing case: the measured silent-fallback shape. The variable is
+// declared and `@font-face` blocks exist, but the family the variable names has
+// only a local() fallback. Every aggregate check passes here — if this test ever
+// goes green on a loosened assertion, the gate has stopped doing its job.
+test("family with only a local() fallback fails", () => {
+  seedHealthy();
+  const degraded = pageHtml({ webfontFamilies: [SG] });
+  write(dist, "index.html", degraded);
+  const { code, out } = runGate();
+  expect(code).toBe(1);
+  expect(out).toContain("--font-jetbrains-mono");
+  expect(out).toContain("no url()-backed @font-face");
+});
+
+test("truncated woff2 fails", () => {
+  seedHealthy();
+  write(dist, "_astro/fonts/jb.woff2", "xx");
+  const { code, out } = runGate();
+  expect(code).toBe(1);
+  expect(out).toContain("truncated font file");
+});
+
+test("missing route fails", () => {
+  seedHealthy();
+  rmSync(join(dist, "privacy"), { recursive: true, force: true });
+  const { code, out } = runGate();
+  expect(code).toBe(1);
+  expect(out).toContain("privacy/index.html");
+  expect(out).toContain("was not emitted");
+});
+
+test("undersized route fails", () => {
+  seedHealthy();
+  write(dist, "privacy/index.html", "<html></html>");
+  const { code, out } = runGate();
+  expect(code).toBe(1);
+  expect(out).toContain("is only");
+});
+
+test("missing --font-* declaration fails", () => {
+  seedHealthy();
+  write(dist, "index.html", pageHtml({ vars: { "--font-space-grotesk": `"${SG}",system-ui` } }));
+  const { code, out } = runGate();
+  expect(code).toBe(1);
+  expect(out).toContain("--font-jetbrains-mono is not declared");
+});
+
+test("no woff2 emitted fails", () => {
+  seedHealthy();
+  rmSync(join(dist, "_astro"), { recursive: true, force: true });
+  const { code, out } = runGate();
+  expect(code).toBe(1);
+  expect(out).toContain("no .woff2 files were emitted");
+});
+
+// Route derivation must walk subdirectories: a flat glob would silently under-cover
+// a nested page while the gate still reported green.
+test("nested page is asserted on", () => {
+  seedHealthy();
+  write(pages, join("legal", "terms.astro"), "<h1>terms</h1>\n");
+  const missing = runGate();
+  expect(missing.code).toBe(1);
+  expect(missing.out).toContain("legal/terms/index.html");
+
+  write(dist, "legal/terms/index.html", pageHtml());
+  expect(runGate().code).toBe(0);
+});
+
+test("nested index page maps to its directory", () => {
+  seedHealthy();
+  write(pages, join("legal", "index.astro"), "<h1>legal</h1>\n");
+  write(dist, "legal/index.html", pageHtml());
+  expect(runGate().code).toBe(0);
+});
+
+test("unmappable page extension fails loudly", () => {
+  seedHealthy();
+  write(pages, "notes.md", "# notes\n");
+  const { code, out } = runGate();
+  expect(code).toBe(1);
+  expect(out).toContain("no known output mapping");
+});
+
+test("dynamic route fails loudly", () => {
+  seedHealthy();
+  write(pages, "[slug].astro", "<h1>dynamic</h1>\n");
+  const { code, out } = runGate();
+  expect(code).toBe(1);
+  expect(out).toContain("no known output mapping");
+});
+
+test("empty pages directory fails rather than passing vacuously", () => {
+  write(dist, "index.html", pageHtml());
+  const { code, out } = runGate();
+  expect(code).toBe(1);
+  expect(out).toContain("no pages found");
+});
+
+// Astro excludes underscore-prefixed paths from routing, so asserting on them
+// would be a false failure — but they must not be able to make the run vacuous.
+test("underscore-prefixed pages are not treated as routes", () => {
+  seedHealthy();
+  write(pages, "_draft.astro", "<h1>draft</h1>\n");
+  write(pages, join("_components", "Card.astro"), "<div>card</div>\n");
+  expect(runGate().code).toBe(0);
+});
+
+test("a pages directory of only non-routed files fails rather than passing vacuously", () => {
+  write(pages, "_draft.astro", "<h1>draft</h1>\n");
+  write(dist, "index.html", pageHtml());
+  const { code, out } = runGate();
+  expect(code).toBe(1);
+  expect(out).toContain("no pages found");
+});
+
+// statSync reports a nonzero size for a directory, so without an isFile() guard a
+// directory sitting where a route's index.html belongs would clear the size floor.
+test("a directory in place of a route's html fails", () => {
+  seedHealthy();
+  rmSync(join(dist, "privacy", "index.html"));
+  mkdirSync(join(dist, "privacy", "index.html"), { recursive: true });
+  const { code, out } = runGate();
+  expect(code).toBe(1);
+  expect(out).toContain("was not emitted");
+});


### PR DESCRIPTION
Closes #1859.

`site/` had **no CI job**. `ci.yml` had exactly two — `verify` and `docs-site` — and nothing under `.github/workflows/` referenced `site`. Its only protection was whatever the author ran locally, plus the Vercel preview. This adds a `site` job mirroring `docs-site`, **plus assertions on what the build actually emitted**.

## Why assertions, not just a build

**A green `astro build` does not prove the site is correct.** I reproduced a genuine silent-fallback build — point one family's `options.package` at a package it cannot resolve:

```
[WARN] [assets] No data found for font family JetBrains Mono
[assets] Copying fonts (3 files)...     ← healthy build copies 9
[build] ✓ Complete!                      exit 0
```

Against that `dist/`, every aggregate signal survives:

| Signal | Healthy | Degraded | Discriminates? |
| --- | --- | --- | --- |
| `@font-face` present anywhere | 11 blocks | 4 blocks | NO |
| `--font-space-grotesk` declared | yes | yes | NO |
| `--font-jetbrains-mono` declared | yes | **yes** | NO |
| ≥1 `.woff2` emitted | 9 | 3 | NO |
| ≥1 `rel=preload as=font` | 9 | 3 | NO |
| **Family has a `url()`-backed `@font-face`** | yes (6) | **zero** | **YES** |

In the degraded build `--font-jetbrains-mono` still resolves — to a family with **no `@font-face` rule at all**. Only the per-family check tells them apart, and it is verified end-to-end: `astro build` exits 0 on that build, the gate exits 1.

*Honest scope:* this probe models "the provider cannot resolve the family", which `--frozen-lockfile` makes near-impossible in CI. It is not a model of the Fonts API silently changing across an Astro major. That the same assertion catches that case too is reasoned, not measured.

## What ships

- **`site/scripts/check-build-artifacts.mjs`** — routes derived **recursively** from `src/pages/**` (a new or nested page is covered with no edit; underscore-prefixed paths are correctly not routes; anything unmappable fails loudly), both `--font-*` variables declared, the per-family webfont check, and font-file size floors.
- **`test/check-build-artifacts.test.ts`** — 15 cases on the repo's existing gate-script seam (`check-generated-docs` / `check-feature-catalog`): temp-dir fixtures, `spawnSync`, assert `{code, out}`. Rides `verify`'s existing `Test (root)` step. **Verified that loosening the per-family assertion to a global check reds it.**
- **`site` job** — `check` → `build` → `check:artifacts`.

## Decisions worth reviewing

- **No `paths:` filter.** A path-filtered required check reports no status on unrelated PRs, and a required check that never reports blocks merges permanently.
- **The 512 B woff2 floor is measured.** A truncated font passes both the presence floor and the per-family check. The smallest legitimate woff2 is **1160 B**, so a 1 KB floor would leave 136 B of headroom and red the gate whenever subsetting re-chunks.
- **The build's jsdelivr fetch is left unretried.** The npm font provider fetches woff2 from `cdn.jsdelivr.net` at *build* time (at the lockfile-pinned version), so this job needs network during `build`. Left unretried to match every other build step here — `bun-install-retry` wraps installs only, and this repo adds retries in response to *observed* flakes (#944, #1134), not in anticipation.
- **Deferred to follow-ups:** `url()`-resolves-on-disk and preload assertions (most false-red surface, no demonstrated failure), and `weights: [400,500,700]` being declared but only 400 emitted (a real `site/` config finding, mechanically explained: `@fontsource/*` ships weight 400 in `index.css`).

## Note on gate status

This job gates **Shepherd's own automation immediately**, ruleset or not: `rollupChecks()` is worst-of with no required/non-required distinction, and `checksCleared()` (`src/checks-gate.ts:25`) is true only on `"success"`. A red `site` job stalls auto-review, auto-merge, epic drain and the standalone critic for that PR. The manual step below covers *human* merges only.

```shepherd:manual-steps
- [ ] POST-MERGE: Add the `site` check to the branch ruleset's required checks (it only becomes selectable once it has reported on main)
```

## Verification

`site`: `check` (0 errors) → `build` → `check:artifacts` all green. Root: 7415 pass / 0 fail. Full pre-push suite green (prettier, eslint, gates, tsc, ext, root-tests, ui, fallow audit). One unrelated flake on the first pre-push run — `DiffFileStack.browser.test.ts`, a timing-sensitive browser test under 7-lane parallel load; passes in isolation and on retry, and this diff touches no `ui/` file.

[no-feature-entry] — CI infrastructure, no user-facing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)