### PR TITLE
ci: exempt Dependabot PRs from the title gate

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,12 +1,18 @@
 name: PR title
 
-# Squash-merge makes the PR *title* the commit subject on main, and release-please
+# Squash-merge can make the PR *title* the commit subject on main, and release-please
 # builds the changelog by parsing that subject. A non-conventional title lands a
 # non-conventional subject even when the branch's own commits are conventional, so
 # release-please silently drops the change from the release notes (that's how #1278
 # vanished from the 1.39.0 notes). commitlint's commit-msg hook gates commit
 # *messages*, not the PR title — so gate the title here with the very same
 # commitlint config (commitlint.config.js) for zero rule drift.
+#
+# Precisely which string lands depends on this repo's `squash_merge_commit_title`
+# setting, which is COMMIT_OR_PR_TITLE: a MULTI-commit PR squashes under the PR
+# title (this gate covers it), a SINGLE-commit PR squashes under that commit's own
+# subject (the commit-msg hook covers it). Both paths are gated, by different
+# mechanisms — verified against merged history (#1866 vs #1604).
 on:
   pull_request:
     # `edited` so re-titling a PR re-runs the check (default types omit it).
@@ -19,11 +25,26 @@ permissions:
 jobs:
   pr-title:
     name: pr title
-    # release-please's generated title ("chore(main): release X.Y.Z") is already
-    # conventional and its branch is bot-maintained — skip to match ci.yml /
-    # pr-hygiene.yml, which guard off the same head_ref prefix AND the release-bot
-    # identity (branch-name-only was a fork-spoofable required-check skip).
-    if: ${{ !(startsWith(github.head_ref, 'release-please--') && (github.event.pull_request.user.login == 'shepherd-release-please[bot]' || github.event.pull_request.user.login == 'github-actions[bot]')) }}
+    # Skipped for two bot authors whose titles this gate cannot usefully police.
+    # Both guards pair the head_ref prefix WITH the bot identity — branch-name-only
+    # was a fork-spoofable required-check skip; the author login cannot be spoofed.
+    #
+    #  • release-please: its title ("chore(main): release X.Y.Z") is already
+    #    conventional and its branch is bot-maintained — matches ci.yml / pr-hygiene.yml.
+    #
+    #  • dependabot: its title format is not ours to fix. When a group carries exactly
+    #    one update it emits e.g. "...bump typedoc from 0.28.19 to 0.28.20 in /docs-site
+    #    in the development-dependencies group across 1 directory" — 124 chars, over
+    #    commitlint's header-max-length — and `@dependabot recreate` regenerates the
+    #    same string, so the PR wedges until a human retitles it (#1866). The title's
+    #    *type* is safe regardless: dependabot.yml pins commit-message.prefix to
+    #    chore(deps)/chore(deps-dev)/chore(ci), so it is always conventional and only
+    #    ever over-LONG. Length is the sole exposure, and it is bounded — dependabot
+    #    PRs are usually single-commit (so the short commit subject lands, not the
+    #    title), and every dependabot subject is a `chore`, which release-please-
+    #    config.json marks "hidden": true. A long subject can therefore reach `git log`
+    #    on main, but never a changelog section.
+    if: ${{ !(startsWith(github.head_ref, 'release-please--') && (github.event.pull_request.user.login == 'shepherd-release-please[bot]' || github.event.pull_request.user.login == 'github-actions[bot]')) && !(startsWith(github.head_ref, 'dependabot/') && github.event.pull_request.user.login == 'dependabot[bot]') }}
     # Pinned to GitHub-hosted — public repo, no CI_RUNNER toggle (see ci.yml).
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Problem

When a Dependabot group carries exactly one update, it appends a redundant suffix to a subject that already names the package and directory:

```
chore(deps-dev): bump typedoc from 0.28.19 to 0.28.20 in /docs-site in the development-dependencies group across 1 directory
```

124 chars — over commitlint's `header-max-length`, so `pr title` fails and the PR sits `BLOCKED`. `@dependabot recreate` regenerates the identical string, so there is no bot-side escape: every one of these wedges until a human retitles it (#1866 did).

## Fix

Skip the gate for Dependabot, guarded on head_ref prefix **and** author login — matching the existing release-please skip. The login can't be spoofed; the branch name alone could be (that was the #1125-era fork-spoofable-skip problem).

Linting a title we don't author, can't configure, and can't get the bot to regenerate was never going to hold.

## Why this is safe

**The title *type* is guaranteed independent of this gate.** `dependabot.yml` pins `commit-message.prefix` to `chore(deps)` / `chore(deps-dev)` / `chore(ci)`, so a Dependabot title is always conventional. The only rule it can ever violate is length — release-please parses it fine either way, so the #1278 failure mode this gate exists to prevent (a non-conventional subject silently dropped from release notes) cannot occur here.

**Length exposure is bounded twice over.** I verified the repo's `squash_merge_commit_title` is `COMMIT_OR_PR_TITLE`, which means the PR title lands as the commit subject *only for multi-commit PRs*; a single-commit PR squashes under its own commit subject. Checked against merged history — only PRs where the two differ are evidence:

| PR | commits | PR title | landed subject | source |
|---|---|---|---|---|
| #1866 | 1 | `…bump typedoc from 0.28.19 to 0.28.20 in /docs-site` | `chore(deps-dev): bump typedoc` | **commit** |
| #1809 | 1 | 95 chars | `chore(deps): bump svelte-dnd-action` | **commit** |
| #1581 | 1 | 53 chars | `chore(deps): bump marked` | **commit** |
| #1604 | **2** | 92 chars | full 92-char title | **PR title** |
| #1584 | **2** | 70 chars | full 70-char title | **PR title** |

Setting and observed behaviour agree exactly. Dependabot PRs are usually single-commit, so the short commit subject lands rather than the long title.

**And the residual case is cosmetic.** Every Dependabot subject is a `chore`, which `release-please-config.json` marks `"hidden": true` — so it never reaches a changelog section at all.

## The honest caveat

This is a small real loosening, not free. **2 of 12 sampled Dependabot PRs were multi-commit** (~17%, from rebases picking up an extra commit). A lone-package group PR — exactly the >100-char shape — that later gains a second commit *would* land its 124-char subject on `main`. The cost is `git log` readability on a commit type hidden from the changelog. That is the whole downside, and it is being accepted deliberately rather than overlooked.

## Also corrected

The workflow header asserted "Squash-merge makes the PR *title* the commit subject on main." That is only true for multi-commit PRs. The comment now states the actual `COMMIT_OR_PR_TITLE` behaviour and notes that both paths are gated by different mechanisms — PR title by this workflow, single-commit subject by commitlint's `commit-msg` hook.

## Verification

- The `if:` expression was re-implemented in JS and truth-tabled over six cases. Both bots skip; **a human PR on a spoofed `dependabot/` branch still runs** (login check holds), as does a Dependabot PR on an unexpected branch, and normal human PRs.
- Workflow YAML parse-validated.
- Skipped jobs do not block required checks here — established precedent in this repo: release-please PRs already skip this exact job, and `onboarding-release-gate` reports `skipping` on green PRs.

Note this PR cannot exercise the exemption itself — it isn't Dependabot-authored, so `pr title` runs normally on it. First real proof is the next dependency bump.

## Considered and rejected

Auto-shortening the title in-workflow (#1867). It required `pull-requests: write` on a job that checks out the PR's merge ref, runs `bun install`, and evaluates the PR's own `commitlint.config.js` — handing a PR-write token to a job executing PR-controlled code. Closed as not planned; not worth it to save a retitle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)