### PR TITLE
fix(security): move production /tmp paths off world-writable locations

### DIFF
--- a/src/egress.ts
+++ b/src/egress.ts
@@ -25,6 +25,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { execFileSync } from "./instrument";
 import { resolveNodeBin } from "./node-bin";
+import { shepherdRuntimeDir } from "./runtime-dir";
 import {
   type BackendProbeDeps,
   type MembraneInputs,
@@ -616,16 +617,17 @@ export function egressMembraneOverrideFlags(
 
 /**
  * Deterministic per-session temp dir holding the generated egress config files +
- * the dns.log the drop-watcher tails. Lives under the OS temp dir; one dir per
- * session id so the startup sweep can reconcile orphans against the live set.
+ * the dns.log the drop-watcher tails. Lives under the user-private runtime dir
+ * ({@link shepherdRuntimeDir}, `0700`) as `egress/<sessionId>` — one dir per session
+ * id so the startup sweep can reconcile orphans against the live set.
  */
 export function egressTmpDir(sessionId: string): string {
-  return join(tmpdir(), "shepherd-egress", sessionId);
+  return shepherdRuntimeDir("egress", sessionId);
 }
 
 /** Root dir holding every per-session egress temp dir (for the orphan sweep). */
 function egressTmpRoot(): string {
-  return join(tmpdir(), "shepherd-egress");
+  return shepherdRuntimeDir("egress");
 }
 
 /**
@@ -669,7 +671,7 @@ export function removeEgressTmp(sessionId: string): void {
 }
 
 /**
- * Startup reconcile sweep: remove any `shepherd-egress/<id>` dir whose id is NOT in
+ * Startup reconcile sweep: remove any `egress/<id>` dir whose id is NOT in
  * `liveSessionIds` (the non-archived session set). Bounds unbounded growth from
  * sessions whose teardown removal was missed (crash, restart). Best-effort —
  * never throws; a single unremovable entry is skipped.

--- a/src/runtime-dir.ts
+++ b/src/runtime-dir.ts
@@ -1,0 +1,22 @@
+import { join } from "node:path";
+
+/**
+ * User-private base directory for Shepherd's ephemeral runtime files (the deploy
+ * log, the per-session egress config + dns.log). Prefers `$XDG_RUNTIME_DIR`
+ * (`/run/user/<uid>`, `0700`, user-owned, a tmpfs cleared at boot) — which satisfies
+ * CodeQL `js/insecure-temporary-file` (no fixed name in world-writable `/tmp`) AND
+ * preserves the boot reset the update service's `applyState()` marker branch silently
+ * relies on. Shepherd runs as a `systemd --user` service, so the variable is present.
+ *
+ * Falls back to `~/.shepherd/run/` (also user-owned, never world-writable) when
+ * `XDG_RUNTIME_DIR` is unset — a headless CI / container with no login session. A real
+ * deploy cannot reach this branch: `systemd-run --user` itself requires `XDG_RUNTIME_DIR`.
+ *
+ * Read at call time (no module-load snapshot) so tests can flip the env vars. Callers
+ * must `mkdirSync(..., { recursive: true })` before writing — the dir may not exist yet.
+ */
+export function shepherdRuntimeDir(...sub: string[]): string {
+  const xdg = process.env.XDG_RUNTIME_DIR?.trim();
+  const base = xdg ? join(xdg, "shepherd") : join(process.env.HOME ?? "", ".shepherd", "run");
+  return join(base, ...sub);
+}

--- a/src/runtime-dir.ts
+++ b/src/runtime-dir.ts
@@ -1,4 +1,5 @@
-import { join } from "node:path";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
 
 /**
  * User-private base directory for Shepherd's ephemeral runtime files (the deploy
@@ -14,9 +15,15 @@ import { join } from "node:path";
  *
  * Read at call time (no module-load snapshot) so tests can flip the env vars. Callers
  * must `mkdirSync(..., { recursive: true })` before writing — the dir may not exist yet.
+ *
+ * The fallback base uses `$HOME` when it is an absolute path, else `os.homedir()` (the
+ * OS passwd entry) — so it is always absolute, never a cwd-relative `.shepherd/run`.
  */
 export function shepherdRuntimeDir(...sub: string[]): string {
   const xdg = process.env.XDG_RUNTIME_DIR?.trim();
-  const base = xdg ? join(xdg, "shepherd") : join(process.env.HOME ?? "", ".shepherd", "run");
+  const home = process.env.HOME;
+  const base = xdg
+    ? join(xdg, "shepherd")
+    : join(home && isAbsolute(home) ? home : homedir(), ".shepherd", "run");
   return join(base, ...sub);
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -4902,7 +4902,7 @@ export class SessionService {
   private pendingRunawayIds: Set<string> | null = null;
 
   /**
-   * Startup reconcile: remove any orphaned `shepherd-egress/<id>` temp dir whose id is
+   * Startup reconcile: remove any orphaned `egress/<id>` temp dir whose id is
    * not a currently live (non-archived) session — bounds unbounded growth from teardown
    * removals missed across a crash/restart. Best-effort (never throws). Call once at
    * server boot. A live session's dir (incl. its dns.log) is preserved.

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,10 +1,10 @@
 import { execFile, spawn, spawnSync } from "node:child_process";
 import { createHash, type Hash } from "node:crypto";
-import { readFileSync, statSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { timedAsync } from "./instrument";
+import { shepherdRuntimeDir } from "./runtime-dir";
 
 const execFileAsync = promisify(execFile);
 
@@ -232,8 +232,9 @@ export interface UpdateDeps {
   branch?: string;
   /** path to the deploy script run on apply */
   scriptPath?: string;
-  /** where the detached deploy streams its output; defaults to a tmp file shared
-   *  across restarts so a freshly booted shepherd can still read a deploy result */
+  /** where the detached deploy streams its output; defaults to a fixed file under the
+   *  user-private runtime dir ({@link shepherdRuntimeDir}, `0700`), shared across restarts
+   *  so a freshly booted shepherd can still read a deploy result */
   logPath?: string;
   /** inject point for tests; defaults to real `git -C <repoDir> …` */
   git?: GitRunner;
@@ -277,7 +278,7 @@ export class UpdateService {
     this.repoDir = deps.repoDir ?? process.cwd();
     this.branch = deps.branch ?? "main";
     this.scriptPath = deps.scriptPath ?? join(this.repoDir, "deploy", "update.sh");
-    this.logPath = deps.logPath ?? join(tmpdir(), "shepherd-update.log");
+    this.logPath = deps.logPath ?? shepherdRuntimeDir("shepherd-update.log");
     this.limit = deps.limit ?? 20;
     this.sigMaxBytes = deps.sigMaxBytes ?? 64 * 1024 * 1024;
     this.sigTimeoutMs = deps.sigTimeoutMs ?? 10_000;
@@ -353,6 +354,9 @@ export class UpdateService {
    *  be read back and shown to the operator instead of vanishing. Throws if the
    *  unit can't even be registered (e.g. systemd-run missing). */
   private defaultLaunch(discard?: DiscardLaunch): void {
+    // The runtime dir ($XDG_RUNTIME_DIR/shepherd or the ~/.shepherd/run fallback) may not
+    // exist yet — /tmp always did. Create it before the write, or the deploy never launches.
+    mkdirSync(dirname(this.logPath), { recursive: true });
     // truncate up front so the file exists immediately → readState() reports
     // "running" before the scope has had a chance to open it.
     writeFileSync(this.logPath, "");

--- a/test/egress.test.ts
+++ b/test/egress.test.ts
@@ -933,10 +933,21 @@ describe("egressRunnerPath", () => {
 });
 
 describe("egressTmpDir", () => {
-  test("deterministic per-session path under the OS temp dir", () => {
-    const d = egressTmpDir("sess-123");
-    expect(d).toBe(join(tmpdir(), "shepherd-egress", "sess-123"));
-    expect(egressTmpDir("sess-123")).toBe(d); // stable
+  test("deterministic per-session path under the user runtime dir, off world-writable /tmp", () => {
+    const savedXdg = process.env.XDG_RUNTIME_DIR;
+    // Pin the base independently (not via shepherdRuntimeDir — that would be tautological)
+    // so the assertion actually proves the path left /tmp.
+    process.env.XDG_RUNTIME_DIR = "/run/user/9999";
+    try {
+      const d = egressTmpDir("sess-123");
+      expect(d).toBe(join("/run/user/9999", "shepherd", "egress", "sess-123"));
+      // The old world-writable location is gone.
+      expect(d).not.toBe(join(tmpdir(), "shepherd-egress", "sess-123"));
+      expect(egressTmpDir("sess-123")).toBe(d); // stable
+    } finally {
+      if (savedXdg === undefined) delete process.env.XDG_RUNTIME_DIR;
+      else process.env.XDG_RUNTIME_DIR = savedXdg;
+    }
   });
 });
 

--- a/test/runtime-dir.test.ts
+++ b/test/runtime-dir.test.ts
@@ -1,0 +1,37 @@
+import { test, expect, afterEach } from "bun:test";
+import { join } from "node:path";
+import { shepherdRuntimeDir } from "../src/runtime-dir";
+
+const savedXdg = process.env.XDG_RUNTIME_DIR;
+const savedHome = process.env.HOME;
+
+afterEach(() => {
+  // Restore both env vars so a case cannot leak into the next.
+  if (savedXdg === undefined) delete process.env.XDG_RUNTIME_DIR;
+  else process.env.XDG_RUNTIME_DIR = savedXdg;
+  if (savedHome === undefined) delete process.env.HOME;
+  else process.env.HOME = savedHome;
+});
+
+test("uses $XDG_RUNTIME_DIR/shepherd when set", () => {
+  process.env.XDG_RUNTIME_DIR = "/run/user/4242";
+  expect(shepherdRuntimeDir("egress", "sess-1")).toBe(
+    join("/run/user/4242", "shepherd", "egress", "sess-1"),
+  );
+  // Base with no sub-path.
+  expect(shepherdRuntimeDir()).toBe(join("/run/user/4242", "shepherd"));
+});
+
+test("falls back to ~/.shepherd/run when XDG_RUNTIME_DIR is unset", () => {
+  delete process.env.XDG_RUNTIME_DIR;
+  process.env.HOME = "/home/tester";
+  expect(shepherdRuntimeDir("shepherd-update.log")).toBe(
+    join("/home/tester", ".shepherd", "run", "shepherd-update.log"),
+  );
+});
+
+test("treats a blank XDG_RUNTIME_DIR as unset (fallback)", () => {
+  process.env.XDG_RUNTIME_DIR = "   ";
+  process.env.HOME = "/home/tester";
+  expect(shepherdRuntimeDir("egress")).toBe(join("/home/tester", ".shepherd", "run", "egress"));
+});

--- a/test/runtime-dir.test.ts
+++ b/test/runtime-dir.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, afterEach } from "bun:test";
-import { join } from "node:path";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
 import { shepherdRuntimeDir } from "../src/runtime-dir";
 
 const savedXdg = process.env.XDG_RUNTIME_DIR;
@@ -34,4 +35,18 @@ test("treats a blank XDG_RUNTIME_DIR as unset (fallback)", () => {
   process.env.XDG_RUNTIME_DIR = "   ";
   process.env.HOME = "/home/tester";
   expect(shepherdRuntimeDir("egress")).toBe(join("/home/tester", ".shepherd", "run", "egress"));
+});
+
+test("fallback base stays absolute when HOME is unset or relative", () => {
+  delete process.env.XDG_RUNTIME_DIR;
+  // Unset HOME → os.homedir() (always absolute), never a cwd-relative base.
+  delete process.env.HOME;
+  const unset = shepherdRuntimeDir("egress");
+  expect(isAbsolute(unset)).toBe(true);
+  expect(unset).toBe(join(homedir(), ".shepherd", "run", "egress"));
+  // A relative HOME is rejected in favour of the absolute os.homedir().
+  process.env.HOME = "relative/home";
+  const relative = shepherdRuntimeDir("egress");
+  expect(isAbsolute(relative)).toBe(true);
+  expect(relative).toBe(join(homedir(), ".shepherd", "run", "egress"));
 });

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -10,6 +10,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { shepherdRuntimeDir } from "../src/runtime-dir";
 import { SessionStore } from "../src/store";
 import {
   SessionService,
@@ -7383,7 +7384,7 @@ test("baseUrl: egress-confined autonomous on host-loopback slirp → hooks via 1
     expect(hooksUrlFrom(record.argv)).toBe(`http://10.0.2.2:7331/api/sessions/${s.id}/hooks`);
   } finally {
     config.hooksIngest = prev;
-    rmSync(join(tmpdir(), "shepherd-egress"), { recursive: true, force: true });
+    rmSync(shepherdRuntimeDir("egress"), { recursive: true, force: true });
   }
 });
 
@@ -7414,7 +7415,7 @@ test("baseUrl: autonomous but slirp NOT host-loopback-capable → falls back to 
     );
   } finally {
     config.hooksIngest = prev;
-    rmSync(join(tmpdir(), "shepherd-egress"), { recursive: true, force: true });
+    rmSync(shepherdRuntimeDir("egress"), { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
Closes #1868.

## What

Clears all six CodeQL `js/insecure-temporary-file` alerts on production code. The deploy log and the per-session egress config/`dns.log` dir used **fixed names under `os.tmpdir()`** (`/tmp`), which another local user could pre-create or symlink. Both now resolve through one shared helper to a **user-private (`0700`) runtime dir**.

## How

New `src/runtime-dir.ts` → `shepherdRuntimeDir(...sub)`:
- **Primary:** `$XDG_RUNTIME_DIR/shepherd/…` — `/run/user/<uid>`, `0700`, user-owned, a tmpfs cleared at boot. Reliably present because shepherd runs as a `systemd --user` service.
- **Fallback:** `~/.shepherd/run/` when `XDG_RUNTIME_DIR` is unset (headless CI/containers) — still user-owned, never world-writable.

Standalone module rather than wiring through `config.ts`, because `update.ts` doesn't import `./config` and doing so would pull `applyHerdrSocket()`'s side effect into the update tests.

| Flagged site | Fix |
| --- | --- |
| `update.ts:358` (path from `:280`) | `logPath` default → `shepherdRuntimeDir("shepherd-update.log")`; `mkdirSync` guard before the `writeFileSync` (a derived dir may not exist — `/tmp` always did) |
| `egress.ts:638-641` (`egressTmpDir` `:623`, `egressTmpRoot` `:628`) | → `shepherdRuntimeDir("egress", …)` |
| `egress-watch.ts:24` | no change — `dnsLogPath` derives from `egressTmpDir`, clears transitively |

Also: dropped the now-orphaned `tmpdir` import from `update.ts`; corrected stale JSDoc in `update.ts`, `egress.ts` (`egressTmpDir` + `sweepEgressTmp`), and `service.ts` (`shepherd-egress/<id>` → `egress/<id>`).

## Why no `applyState()` marker-branch TTL work

`applyState()`'s marker branch returns `done`/`failed` with **no age check** — survivable today only because `/tmp` is boot-cleared. `$XDG_RUNTIME_DIR` is *also* a boot-cleared tmpfs, so the property is preserved. Stronger: `defaultLaunch()` deploys via `systemd-run --user`, which **itself requires `XDG_RUNTIME_DIR`** — so a real deploy can only run in the primary (boot-cleared) branch, never the persistent `~/.shepherd/run/` fallback. No TTL work is needed.

## Testing

- `bun run lint` ✓ · `bun run typecheck` ✓ · `bun test ./test` → **7488 pass, 0 fail** ✓
- New `test/runtime-dir.test.ts` covers **both** helper branches (XDG set; XDG cleared + `HOME` set; blank XDG treated as unset).
- `test/egress.test.ts` pins `XDG_RUNTIME_DIR` independently and asserts the resolved path **is not** the old `join(tmpdir(), "shepherd-egress", id)` — so the assertion actually proves the path left `/tmp`.

## Egress cannot be verified by `bun run test`

Per the issue: the runner's `$TMP` readability checks are fail-closed and run *before* `unshare`, the dir is ro-bind-mounted into the sandbox, and every live runner test is `skipIf`-gated. A regression would abort **every** sandboxed spawn. The change only moves *where* the dir lives — the runner reads it as the real user before `unshare`, and every bwrap override bind targets files by **absolute path** — but this needs one real confined spawn to confirm.

```shepherd:manual-steps
- [ ] Verify egress on a capable host (setpriv/unshare/slirp4netns/nft/dnsmasq): run one real egress-confined autonomous spawn and confirm the agent starts + DNS drops are still observed, before relying on this change.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)