### PR TITLE
fix(tmp): reclaim forked pnpm stores + abandoned agent worktrees

### DIFF
--- a/src/forge/local.ts
+++ b/src/forge/local.ts
@@ -164,32 +164,58 @@ export async function mergeTreeWriteTree(
   );
 }
 
-interface WorktreeEntry {
+export interface WorktreeEntry {
   path: string;
   head?: string;
   branch?: string; // short name (refs/heads/ stripped)
   detached: boolean;
+  /** worktree is locked (`git worktree lock`); its record can't be pruned. */
+  locked: boolean;
+  /** the main worktree of a bare-ish checkout (`bare` line). */
+  bare: boolean;
+  /** git considers the record prunable (its working dir is gone / broken). */
+  prunable: boolean;
+}
+
+/** Apply one non-`worktree` porcelain line to the current entry.
+ *
+ *  `locked`/`prunable` MUST be prefix-matched: git emits a bare `locked` /
+ *  `prunable` line when no reason is present, but `locked <reason>` /
+ *  `prunable <reason>` when one is. An exact match (as for `detached`/`bare`,
+ *  which never carry a reason) would silently drop the flag on the
+ *  reason-carrying form — and a dropped `locked`/`prunable` is exactly the
+ *  worktree whose dangling record cannot be pruned, so a reaper must never
+ *  treat it as reapable. */
+function applyWorktreeAttr(cur: WorktreeEntry, line: string): void {
+  if (line.startsWith("HEAD ")) cur.head = line.slice("HEAD ".length);
+  else if (line.startsWith("branch "))
+    cur.branch = line.slice("branch ".length).replace(/^refs\/heads\//, "");
+  else if (line === "detached") cur.detached = true;
+  else if (line === "bare") cur.bare = true;
+  else if (line === "locked" || line.startsWith("locked ")) cur.locked = true;
+  else if (line === "prunable" || line.startsWith("prunable ")) cur.prunable = true;
 }
 
 /** Parse `git worktree list --porcelain` into structured entries. Blocks are
  *  separated by blank lines; lines are `worktree <path>`, `HEAD <sha>`,
- *  `branch refs/heads/<name>`, or `detached`. */
-function parseWorktrees(porcelain: string): WorktreeEntry[] {
+ *  `branch refs/heads/<name>`, `detached`, `bare`, `locked [<reason>]`, or
+ *  `prunable [<reason>]` (per-line handling in `applyWorktreeAttr`). */
+export function parseWorktrees(porcelain: string): WorktreeEntry[] {
   const out: WorktreeEntry[] = [];
   let cur: WorktreeEntry | null = null;
   for (const raw of porcelain.split("\n")) {
     const line = raw.trimEnd();
     if (line.startsWith("worktree ")) {
       if (cur) out.push(cur);
-      cur = { path: line.slice("worktree ".length), detached: false };
-    } else if (!cur) {
-      continue;
-    } else if (line.startsWith("HEAD ")) {
-      cur.head = line.slice("HEAD ".length);
-    } else if (line.startsWith("branch ")) {
-      cur.branch = line.slice("branch ".length).replace(/^refs\/heads\//, "");
-    } else if (line === "detached") {
-      cur.detached = true;
+      cur = {
+        path: line.slice("worktree ".length),
+        detached: false,
+        locked: false,
+        bare: false,
+        prunable: false,
+      };
+    } else if (cur) {
+      applyWorktreeAttr(cur, line);
     }
   }
   if (cur) out.push(cur);

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,7 @@ import {
   ProcessReaper,
   reapDeletedWorktreeOrphans,
   reapMarkedOrphans,
+  liveProcCwds,
   SESSION_MARKER_ENV,
 } from "./process-reaper";
 import {
@@ -113,6 +114,8 @@ import {
   compileCacheDir,
   reapFallowCaches,
   pruneRepoWorktrees,
+  reapAbandonedWorktrees,
+  reclaimForkedPnpmStore,
   scratchpadHasFiles,
 } from "./tmp-sweep";
 import { runSessionUsageBackfill } from "./usage-backfill";
@@ -820,6 +823,31 @@ const fireTmpSweep = (phase: "boot" | "daily") => {
         console.warn(`[tmp-sweep] ${phase}: reaped ${reaped} deleted-worktree orphan(s)`);
     })
     .catch((err) => console.warn(`[tmp-sweep] ${phase} orphan reap failed:`, err));
+
+  // #1874: reclaim abandoned agent worktrees under /tmp, THEN the forked pnpm store they
+  // pinned. Order is load-bearing — while a tmp worktree survives, every store file sits at
+  // nlink=2, so removing the store first reclaims ~zero and the next install re-forks it.
+  // The reaper's `retained` count is the store pass's go/no-go gate. A single microtask-
+  // deferred liveProcCwds() snapshot keeps that synchronous /proc scan off the event loop
+  // and out of the all-async tmp-sweep module.
+  void Promise.resolve()
+    .then(async () => {
+      const liveWorktreePaths = store
+        .list({ activeOnly: true })
+        .map((s) => s.worktreePath)
+        .filter(Boolean);
+      const reap = await reapAbandonedWorktrees({
+        repoPaths: listRepos(config.repoRoot).map((r) => r.path),
+        liveWorktreePaths,
+        liveCwds: liveProcCwds(),
+      });
+      const storeResult = await reclaimForkedPnpmStore({ retained: reap.retained });
+      console.warn(
+        `[tmp-sweep] ${phase}: worktree reap removed ${reap.reaped} (retained ${reap.retained}), ` +
+          `pnpm store ${storeResult.removed ? "reclaimed" : `kept (${storeResult.reason})`}`,
+      );
+    })
+    .catch((err) => console.warn(`[tmp-sweep] ${phase} worktree/store reclaim failed:`, err));
 };
 
 deferredStarts.push(() => {

--- a/src/process-reaper.ts
+++ b/src/process-reaper.ts
@@ -147,7 +147,9 @@ function isGitComm(comm: string): boolean {
 // Path segment every shepherd session/review worktree lives under. The orphan
 // sweeps refuse to act on any path lacking it, so a mistaken caller passing a repo
 // root (or any non-worktree path) can never SIGKILL unrelated host processes.
-const WORKTREE_MARKER = "/.shepherd-worktrees/";
+// Exported so the tmp-sweep worktree reaper shares the exact same marker rather
+// than forking the definition.
+export const WORKTREE_MARKER = "/.shepherd-worktrees/";
 
 // readlink(/proc/<pid>/cwd) appends this once the directory is unlinked; the kernel
 // keeps the inode alive for the still-running process. A "(deleted)" cwd under the
@@ -159,7 +161,10 @@ export function leftoverKey(l: Pick<Leftover, "kind" | "name" | "port" | "pid">)
   return l.kind === "process" ? `process:${l.pid}` : `system:${l.name}:${l.port ?? ""}`;
 }
 
-function isUnder(path: string, root: string): boolean {
+/** Segment-aligned containment: `path` is `root` itself or lives under it. Exported
+ *  so the tmp-sweep reaper reuses the same idiom (a `startsWith` without the `/`
+ *  guard would treat `/a/bc` as under `/a/b`). */
+export function isUnder(path: string, root: string): boolean {
   return path === root || path.startsWith(root + "/");
 }
 
@@ -426,6 +431,23 @@ const defaultProbes: ReaperProbes = {
     execFileSync(bin, args, { stdio: "ignore" });
   },
 };
+
+/**
+ * A snapshot of every same-uid process's current working directory (raw
+ * `/proc/<pid>/cwd` readlink targets), reusing the existing synchronous
+ * `scanProcs` /proc scan. `readlink` on another user's process yields `EACCES`
+ * and is skipped by `scanProcs` — so this is a same-uid guarantee, not absolute.
+ *
+ * SYNCHRONOUS by design: the tmp-sweep worktree reaper's live-cwd refusal needs
+ * this signal, but that module is all-async — so the caller (`fireTmpSweep`) takes
+ * ONE deferred snapshot here and passes the resolved set in, keeping the sync
+ * `/proc` walk out of the async module. A deleted cwd carries a `" (deleted)"`
+ * suffix; that never resolves to an on-disk worktree, so it is harmless noise the
+ * reaper's realpath step drops.
+ */
+export function liveProcCwds(probes: ReaperProbes = defaultProbes): string[] {
+  return probes.scanProcs().map((p) => p.cwd);
+}
 
 export class ProcessReaper {
   constructor(private probes: ReaperProbes = defaultProbes) {}

--- a/src/tmp-sweep.ts
+++ b/src/tmp-sweep.ts
@@ -3,6 +3,14 @@ import { execFile } from "node:child_process";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import {
+  parseWorktrees,
+  parseGitVersion,
+  gitVersionAtLeast,
+  MIN_GIT_MAJOR,
+  MIN_GIT_MINOR,
+} from "./forge/local";
+import { WORKTREE_MARKER, isUnder } from "./process-reaper";
 
 const execFileAsync = promisify(execFile);
 
@@ -522,6 +530,551 @@ export async function reapFallowCaches(opts?: ReapFallowOpts): Promise<ReapFallo
   for (const root of roots) removed += await reapFallowRoot(root, ctx);
 
   return { removed };
+}
+
+// ── worktree reaper ─────────────────────────────────────────────────────────
+//
+// Removes abandoned agent git worktrees that live under a tmp root: a nested agent
+// creates its own `git worktree add /tmp/…` for a configured repo, then finishes
+// without removing it. Those worktrees hardlink `node_modules` into the forked pnpm
+// store, so their survival pins every store file at `nlink = 2` — the store pass
+// can only reclaim once they are gone. This reaper drops them; its `retained` count
+// is the store pass's go/no-go signal.
+//
+// The removal is DESTRUCTIVE against possibly-unrecoverable data (a worktree can hold
+// uncommitted edits + untracked files existing nowhere else), so it is guarded by a
+// wall of refusals AND gated on live inode pressure — a destructive act needs a live
+// justification. Every path comparison is realpath-normalized: porcelain emits resolved
+// paths while a stored `worktreePath` / `tmpdir()` may be a symlink (macOS `/private/tmp`),
+// and a non-match on the protective side is the dangerous direction.
+
+/** Injectable git exec for the reaper: runs `git -C <cwd> <args>`, resolves stdout,
+ *  rejects on non-zero exit or spawn failure. */
+type ExecGit = (cwd: string, args: string[]) => Promise<string>;
+
+const defaultExecGit: ExecGit = (cwd, args) =>
+  execFileAsync("git", ["-C", cwd, ...args], { timeout: 60_000 }).then((r) => r.stdout);
+
+export interface ReapWorktreesOpts {
+  /** Configured repo paths to enumerate worktrees for (`listRepos(...).map(r => r.path)`). */
+  repoPaths: string[];
+  /** Live-session worktree dirs to spare (from `store.list({ activeOnly: true })`). */
+  liveWorktreePaths?: string[];
+  /** A RESOLVED snapshot of same-uid process cwds (from `liveProcCwds()`), taken by the
+   *  caller so the synchronous `/proc` scan stays out of this async module. */
+  liveCwds?: string[];
+  /** Tmp roots a candidate must live under to be eligible. Default `[claudeTmpRoot(), tmpdir()]`. */
+  tmpRoots?: string[];
+  thresholdPct?: number;
+  staleMs?: number;
+  now?: number;
+  log?: (msg: string) => void;
+  execGit?: ExecGit;
+  realpath?: (p: string) => Promise<string>;
+  statfs?: FsOps["statfs"];
+  fsOps?: Pick<FsOps, "readdir" | "stat">;
+  /** Injectable removal (default `git worktree remove`, no `--force` — cleanliness proven). */
+  removeWorktree?: (repo: string, worktreePath: string) => Promise<void>;
+}
+
+export interface ReapWorktreesResult {
+  reaped: number;
+  /** Candidates under a tmp root still on disk after the pass — the store pass skips when > 0. */
+  retained: number;
+}
+
+/** A discovered, realpath-resolved worktree candidate under a tmp root. */
+interface WorktreeCandidate {
+  repo: string;
+  path: string; // git-registered path
+  real: string; // realpath-resolved (implies on-disk: realpath threw ⇒ not a candidate)
+  locked: boolean;
+  bare: boolean;
+  prunable: boolean;
+}
+
+/** Realpath-resolve each path, dropping unresolvable ones, deduped. */
+async function resolveAllRealpaths(
+  paths: string[],
+  realpath: (p: string) => Promise<string>,
+): Promise<string[]> {
+  const out: string[] = [];
+  for (const p of paths) {
+    try {
+      out.push(await realpath(p));
+    } catch {
+      /* unresolvable (gone / broken) — drop */
+    }
+  }
+  return [...new Set(out)];
+}
+
+/** Max entries the freshness walk will stat before giving up. Sized for a source tree
+ *  with `node_modules`/`.git` pruned from descent; exhaustion resolves to *keep*. */
+const FRESHNESS_ENTRY_BUDGET = 10_000;
+
+/**
+ * True when the worktree looks fresh (recently touched) — the KEEP-biased direction.
+ * Bounded DFS from `root`, statting every entry for its mtime but pruning `node_modules`
+ * and `.git` from DESCENT (they are stat'd for their own mtime — a recent install/git op
+ * shows there — but never walked: `node_modules/.pnpm` alone is thousands of dirs and
+ * would exhaust the budget). ANY of {a mtime within the window, a stat/readdir error,
+ * budget exhaustion} ⇒ `true` (keep). Only a full, error-free walk finding nothing fresh
+ * ⇒ `false` (provably stale ⇒ reapable).
+ */
+/** Mutable entry budget shared across a single freshness/idle walk. */
+interface Budget {
+  n: number;
+}
+
+/**
+ * Scan ONE directory for the freshness walk. `stop: true` is the KEEP-biased outcome (a fresh
+ * mtime, a stat/readdir error, or budget exhaustion); otherwise `children` are the sub-dirs to
+ * descend, with `node_modules`/`.git` pruned from descent (stat'd for mtime, never walked).
+ */
+async function scanFreshDir(
+  dir: string,
+  cutoff: number,
+  budget: Budget,
+  readdir: FsOps["readdir"],
+  stat: FsOps["stat"],
+): Promise<{ stop: boolean; children: string[] }> {
+  const keep = { stop: true, children: [] as string[] };
+  let entries: Dirent[];
+  try {
+    entries = (await readdir(dir, { withFileTypes: true })) as Dirent[];
+  } catch {
+    return keep; // unreadable subtree → keep
+  }
+  const children: string[] = [];
+  for (const ent of entries) {
+    if (--budget.n < 0) return keep; // budget exhausted → keep (never a reap by omission)
+    const p = join(dir, ent.name);
+    try {
+      if (Number((await stat(p)).mtimeMs) > cutoff) return keep; // a fresh entry → keep
+    } catch {
+      return keep; // stat error → keep
+    }
+    if (ent.isDirectory() && ent.name !== "node_modules" && ent.name !== ".git") children.push(p);
+  }
+  return { stop: false, children };
+}
+
+async function worktreeIsFresh(
+  root: string,
+  cutoff: number,
+  readdir: FsOps["readdir"],
+  stat: FsOps["stat"],
+): Promise<boolean> {
+  try {
+    if (Number((await stat(root)).mtimeMs) > cutoff) return true;
+  } catch {
+    return true; // can't even stat the root → keep
+  }
+  const budget: Budget = { n: FRESHNESS_ENTRY_BUDGET };
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const scan = await scanFreshDir(stack.pop() as string, cutoff, budget, readdir, stat);
+    if (scan.stop) return true;
+    stack.push(...scan.children);
+  }
+  return false; // fully walked within budget, nothing fresh
+}
+
+/**
+ * The refusal reason for a candidate, or `null` when it is safe to reap. Cheap checks
+ * (porcelain annotations, the Shepherd-worktree marker, the live sets) run before the
+ * `git status` spawn, which runs before the freshness fs-walk.
+ */
+async function worktreeRefusal(
+  c: WorktreeCandidate,
+  ctx: {
+    liveWorktreePaths: string[];
+    liveCwds: string[];
+    cutoff: number;
+    execGit: ExecGit;
+    readdir: FsOps["readdir"];
+    stat: FsOps["stat"];
+  },
+): Promise<string | null> {
+  if (c.locked) return "locked";
+  if (c.bare) return "bare";
+  if (c.prunable) return "prunable";
+  if (c.real.includes(WORKTREE_MARKER) || c.path.includes(WORKTREE_MARKER))
+    return "shepherd-worktree";
+  if (ctx.liveWorktreePaths.includes(c.real)) return "live-session";
+  if (ctx.liveCwds.some((cwd) => isUnder(cwd, c.real))) return "live-cwd";
+
+  // Dirty check — the `src/worktree.ts` idiom: ANY error counts as dirty (safe default),
+  // because a worktree can hold work that exists nowhere else.
+  let status: string;
+  try {
+    status = await ctx.execGit(c.path, ["status", "--porcelain"]);
+  } catch {
+    return "dirty";
+  }
+  if (status.trim().length > 0) return "dirty";
+
+  if (await worktreeIsFresh(c.real, ctx.cutoff, ctx.readdir, ctx.stat)) return "fresh";
+  return null;
+}
+
+/** Shared option resolution for the two tmp reclaimers: current time, the staleness `cutoff`
+ *  (`SHEPHERD_TMP_STALE_HOURS`, default 24h), and the inode-pressure gate (`SHEPHERD_TMP_INODE_PCT`). */
+function resolveTmpGate(opts: { now?: number; staleMs?: number; thresholdPct?: number }): {
+  now: number;
+  cutoff: number;
+  thresholdPct: number;
+} {
+  const now = opts.now ?? Date.now();
+  const cutoff =
+    now - (opts.staleMs ?? envNum(process.env.SHEPHERD_TMP_STALE_HOURS, 24) * 3600_000);
+  const thresholdPct =
+    opts.thresholdPct ?? envNum(process.env.SHEPHERD_TMP_INODE_PCT, DEFAULT_TMP_INODE_PCT);
+  return { now, cutoff, thresholdPct };
+}
+
+/** True iff the installed git meets the worktree-annotation floor (>= 2.38); unreadable ⇒ false. */
+async function gitMeetsFloor(execGit: ExecGit, repo: string): Promise<boolean> {
+  try {
+    const v = parseGitVersion(await execGit(repo, ["--version"]));
+    return !!v && gitVersionAtLeast(v, MIN_GIT_MAJOR, MIN_GIT_MINOR);
+  } catch {
+    return false;
+  }
+}
+
+/** Enumerate every worktree of the configured repos that realpath-resolves under a tmp root,
+ *  deduped by resolved path (overlapping repo configs can list the same tmp worktree twice). A
+ *  path that fails realpath is gone (not on disk) and skipped. */
+async function discoverTmpWorktreeCandidates(ctx: {
+  repoPaths: string[];
+  tmpRoots: string[];
+  execGit: ExecGit;
+  realpath: (p: string) => Promise<string>;
+  log: (msg: string) => void;
+}): Promise<WorktreeCandidate[]> {
+  const candidates: WorktreeCandidate[] = [];
+  const seen = new Set<string>();
+  for (const repo of ctx.repoPaths) {
+    let porcelain: string;
+    try {
+      porcelain = await ctx.execGit(repo, ["worktree", "list", "--porcelain"]);
+    } catch (err) {
+      ctx.log(`[tmp-sweep] worktree list failed for ${repo}: ${String(err)}`);
+      continue;
+    }
+    for (const e of parseWorktrees(porcelain)) {
+      let real: string;
+      try {
+        real = await ctx.realpath(e.path); // resolves ⇒ on disk; throws ⇒ gone, not a candidate
+      } catch {
+        continue;
+      }
+      if (!ctx.tmpRoots.some((r) => isUnder(real, r)) || seen.has(real)) continue;
+      seen.add(real);
+      candidates.push({
+        repo,
+        path: e.path,
+        real,
+        locked: e.locked,
+        bare: e.bare,
+        prunable: e.prunable,
+      });
+    }
+  }
+  return candidates;
+}
+
+/** Apply refusals to each candidate and reap those with a live justification. Returns the count
+ *  removed. `canRemove` folds the git-floor + inode-pressure gate: false ⇒ discover-only. */
+async function reapCandidates(
+  candidates: WorktreeCandidate[],
+  canRemove: boolean,
+  refusalCtx: Parameters<typeof worktreeRefusal>[1],
+  removeWorktree: (repo: string, worktreePath: string) => Promise<void>,
+  log: (msg: string) => void,
+): Promise<number> {
+  let reaped = 0;
+  for (const c of candidates) {
+    const reason = await worktreeRefusal(c, refusalCtx);
+    if (reason) {
+      log(`[tmp-sweep] keep worktree ${c.real}: ${reason}`);
+      continue;
+    }
+    if (!canRemove) continue; // reapable but no live justification to act
+    try {
+      await removeWorktree(c.repo, c.path);
+      reaped += 1;
+      log(`[tmp-sweep] reaped abandoned worktree ${c.real}`);
+    } catch (err) {
+      log(`[tmp-sweep] worktree remove failed for ${c.real}: ${String(err)}`);
+    }
+  }
+  return reaped;
+}
+
+/**
+ * Reap abandoned tmp worktrees of the configured repos. TOTAL by contract — never throws;
+ * any unexpected failure resolves to a conservative `retained >= 1` so the store pass skips.
+ *
+ * Discovery + refusal always run; only the actual REMOVAL is gated on git >= 2.38 (the floor
+ * for the `locked`/`prunable` annotations that keep a dangling record from being reaped) AND
+ * inode pressure >= `thresholdPct`. `retained` = candidates under a tmp root still on disk
+ * after the pass (every candidate was realpath-resolved, so it exists) minus those removed —
+ * deliberately NOT the raw refusal list, whose off-tmp entries would pin it non-zero forever.
+ */
+export async function reapAbandonedWorktrees(
+  opts: ReapWorktreesOpts,
+): Promise<ReapWorktreesResult> {
+  const log = opts.log ?? console.warn;
+  try {
+    const firstRepo = opts.repoPaths[0];
+    if (firstRepo === undefined) return { reaped: 0, retained: 0 };
+
+    const { cutoff, thresholdPct } = resolveTmpGate(opts);
+    const realpath = opts.realpath ?? fsp.realpath;
+    const statfs = opts.statfs ?? fsp.statfs;
+    const readdir = opts.fsOps?.readdir ?? fsp.readdir;
+    const stat = opts.fsOps?.stat ?? fsp.stat;
+    const execGit = opts.execGit ?? defaultExecGit;
+    const removeWorktree =
+      opts.removeWorktree ??
+      ((repo: string, wt: string) => execGit(repo, ["worktree", "remove", wt]).then(() => {}));
+
+    const [tmpRoots, liveWorktreePaths, liveCwds] = await Promise.all([
+      resolveAllRealpaths(opts.tmpRoots ?? [claudeTmpRoot(), tmpdir()], realpath),
+      resolveAllRealpaths(opts.liveWorktreePaths ?? [], realpath),
+      resolveAllRealpaths(opts.liveCwds ?? [], realpath),
+    ]);
+
+    // Git floor: without the 2.36+ porcelain annotations a locked/prunable worktree looks
+    // reapable while its record can't be pruned — a dangling entry. Below the floor we still
+    // discover (so `retained` reflects reality and the store skips) but never remove.
+    const gitOk = await gitMeetsFloor(execGit, firstRepo);
+    if (!gitOk) log("[tmp-sweep] worktree reap: git < 2.38 or unreadable — discovering only");
+    const usePct = await inodeUsePct(tmpdir(), statfs, log);
+    const pressureOk = typeof usePct === "number" && usePct >= thresholdPct;
+
+    const candidates = await discoverTmpWorktreeCandidates({
+      repoPaths: opts.repoPaths,
+      tmpRoots,
+      execGit,
+      realpath,
+      log,
+    });
+
+    const refusalCtx = { liveWorktreePaths, liveCwds, cutoff, execGit, readdir, stat };
+    const reaped = await reapCandidates(
+      candidates,
+      gitOk && pressureOk,
+      refusalCtx,
+      removeWorktree,
+      log,
+    );
+    // Every candidate is on-disk-under-tmp (realpath-resolved); those not reaped remain.
+    return { reaped, retained: candidates.length - reaped };
+  } catch (err) {
+    log(`[tmp-sweep] worktree reap unexpected error: ${String(err)}`);
+    // Defensive: an unknown failure must NOT let the store pass proceed.
+    return { reaped: 0, retained: 1 };
+  }
+}
+
+// ── forked pnpm store reclaimer ─────────────────────────────────────────────
+//
+// pnpm forks a content-addressable store onto the tmpfs (`<tmp>/.pnpm-store/v<N>/`) to
+// stay same-filesystem for hardlinking. Once every worktree that linked it is gone, the
+// store is dead weight pinning inodes. Removal is ALL-OR-NOTHING (skip the whole store if
+// ANY file still has `nlink > 1`): measured, pnpm re-fetches cleanly online after content
+// is deleted, but partial reclaim is deferred (see the issue's follow-up). Every
+// non-exhaustive outcome resolves to KEEP — `removed:false` means *provably idle*, never
+// *failed to probe*.
+
+/** The `/^v\d+$/` version subdirs of a store root. Shared by both probes: an empty result
+ *  makes the caller skip (an unrecognized layout is never removed) — the harmless direction. */
+export function resolveStoreVersionDirs(rootEntries: Dirent[]): string[] {
+  return rootEntries.filter((e) => e.isDirectory() && /^v\d+$/.test(e.name)).map((e) => e.name);
+}
+
+/**
+ * Provably idle iff a full depth-2 enumeration from the versioned dir finds every mtime
+ * <= `cutoff`. Depth 2 is load-bearing: a mid-install store's depth-<=1 mtimes stop moving
+ * once the buckets exist, so a shallower probe reads a busy store as idle. Any error, or a
+ * budget overrun, ⇒ `false` (keep).
+ */
+/** Every entry directly under `dir` has an mtime <= `cutoff` (and budget wasn't exhausted).
+ *  Throws propagate to the caller's catch. */
+async function childrenAllStale(
+  dir: string,
+  cutoff: number,
+  budget: Budget,
+  readdir: FsOps["readdir"],
+  stat: FsOps["stat"],
+): Promise<boolean> {
+  for (const e of (await readdir(dir, { withFileTypes: true })) as Dirent[]) {
+    if (--budget.n < 0) return false;
+    if (Number((await stat(join(dir, e.name))).mtimeMs) > cutoff) return false;
+  }
+  return true;
+}
+
+async function storeVersionDirIsIdle(
+  vdir: string,
+  cutoff: number,
+  readdir: FsOps["readdir"],
+  stat: FsOps["stat"],
+): Promise<boolean> {
+  const budget: Budget = { n: 100_000 };
+  try {
+    for (const e1 of (await readdir(vdir, { withFileTypes: true })) as Dirent[]) {
+      if (--budget.n < 0) return false;
+      const p1 = join(vdir, e1.name);
+      if (Number((await stat(p1)).mtimeMs) > cutoff) return false;
+      if (e1.isDirectory() && !(await childrenAllStale(p1, cutoff, budget, readdir, stat)))
+        return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * `true` when the version dir's `files/` tree still holds a hardlink (some `nlink > 1`) OR
+ * could not be exhaustively probed (missing `files/`, any readdir/stat error) — i.e. NOT
+ * safe to remove. `false` only after a full walk proves every content file is `nlink === 1`.
+ * Exhaustive with early exit on the first surviving link: the dangerous case is the cheap
+ * one, and the full walk only completes when we are about to `rm -rf` these files anyway.
+ */
+async function storeVersionDirHasLinks(
+  filesDir: string,
+  stat: FsOps["stat"],
+  readdir: FsOps["readdir"],
+): Promise<boolean> {
+  const stack: string[] = [filesDir];
+  try {
+    while (stack.length > 0) {
+      const dir = stack.pop() as string;
+      const entries = (await readdir(dir, { withFileTypes: true })) as Dirent[];
+      for (const ent of entries) {
+        const p = join(dir, ent.name);
+        if (ent.isDirectory()) {
+          stack.push(p);
+          continue;
+        }
+        if (Number((await stat(p)).nlink) > 1) return true; // a link survives — early exit
+      }
+    }
+    return false; // fully walked, every file nlink === 1
+  } catch {
+    return true; // missing files/ or any error → not provably unlinked → keep
+  }
+}
+
+export interface ReclaimStoreOpts {
+  /** The forked store root. Default `<tmpdir>/.pnpm-store` — the only name allowed to reach
+   *  bare `tmpdir()`. A wrong mount root just yields a missing dir → safe skip. */
+  storeRoot?: string;
+  /** Worktree candidates still on disk (from `reapAbandonedWorktrees`). > 0 ⇒ skip. */
+  retained: number;
+  thresholdPct?: number;
+  staleMs?: number;
+  now?: number;
+  statfs?: FsOps["statfs"];
+  fsOps?: Pick<FsOps, "readdir" | "stat" | "rm">;
+  log?: (msg: string) => void;
+}
+
+export interface ReclaimStoreResult {
+  removed: boolean;
+  reason: string;
+}
+
+/** A skip reason for any non-`v*` sibling of the store root that could be freshly written while
+ *  the two v-dir probes (which only look inside `v*`) read "idle" — else `null`. */
+async function siblingBlocker(
+  rootEntries: Dirent[],
+  storeRoot: string,
+  cutoff: number,
+  stat: FsOps["stat"],
+): Promise<string | null> {
+  for (const e of rootEntries) {
+    if (/^v\d+$/.test(e.name)) continue;
+    let st: Awaited<ReturnType<FsOps["stat"]>>;
+    try {
+      st = await stat(join(storeRoot, e.name));
+    } catch {
+      return `sibling-unstattable ${e.name}`;
+    }
+    if (Number(st.mtimeMs) > cutoff) return `sibling-fresh ${e.name}`;
+    if (e.isDirectory()) return `sibling-unrecognized ${e.name}`;
+  }
+  return null;
+}
+
+/** A skip reason for any version dir that is not depth-2-idle or not fully unlinked — else `null`. */
+async function versionDirBlocker(
+  storeRoot: string,
+  versionDirs: string[],
+  cutoff: number,
+  readdir: FsOps["readdir"],
+  stat: FsOps["stat"],
+): Promise<string | null> {
+  for (const v of versionDirs) {
+    const vdir = join(storeRoot, v);
+    if (!(await storeVersionDirIsIdle(vdir, cutoff, readdir, stat))) return `store-busy ${v}`;
+    if (await storeVersionDirHasLinks(join(vdir, "files"), stat, readdir))
+      return `store-linked-or-unprobed ${v}`;
+  }
+  return null;
+}
+
+/**
+ * All-or-nothing reclaim of the forked pnpm store. TOTAL by contract — never throws. Removes
+ * `<storeRoot>` only when: `retained === 0`, inode pressure >= threshold, the layout is a
+ * recognized `v<N>` store, no non-`v*` sibling is fresh or an unrecognized dir, and EVERY
+ * version dir is depth-2-idle AND fully unlinked. Any other outcome is a keep with a reason.
+ */
+export async function reclaimForkedPnpmStore(opts: ReclaimStoreOpts): Promise<ReclaimStoreResult> {
+  const log = opts.log ?? console.warn;
+  try {
+    const storeRoot = opts.storeRoot ?? join(tmpdir(), ".pnpm-store");
+    const { cutoff, thresholdPct } = resolveTmpGate(opts);
+    const readdir = opts.fsOps?.readdir ?? fsp.readdir;
+    const stat = opts.fsOps?.stat ?? fsp.stat;
+    const rm = opts.fsOps?.rm ?? fsp.rm;
+    const statfs = opts.statfs ?? fsp.statfs;
+
+    if (opts.retained > 0) return { removed: false, reason: `retained-worktrees ${opts.retained}` };
+
+    const usePct = await inodeUsePct(tmpdir(), statfs, log);
+    if (typeof usePct === "string") return { removed: false, reason: usePct };
+    if (usePct < thresholdPct) {
+      return { removed: false, reason: `below-threshold ${usePct.toFixed(1)}%` };
+    }
+
+    let rootEntries: Dirent[];
+    try {
+      rootEntries = (await readdir(storeRoot, { withFileTypes: true })) as Dirent[];
+    } catch {
+      return { removed: false, reason: "no-store" };
+    }
+
+    const versionDirs = resolveStoreVersionDirs(rootEntries);
+    if (versionDirs.length === 0) return { removed: false, reason: "no-version-dir" };
+
+    const blocker =
+      (await siblingBlocker(rootEntries, storeRoot, cutoff, stat)) ??
+      (await versionDirBlocker(storeRoot, versionDirs, cutoff, readdir, stat));
+    if (blocker) return { removed: false, reason: blocker };
+
+    await rm(storeRoot, { recursive: true, force: true });
+    return { removed: true, reason: `reclaimed ${storeRoot}` };
+  } catch (err) {
+    log(`[tmp-sweep] store reclaim unexpected error: ${String(err)}`);
+    return { removed: false, reason: "error" };
+  }
 }
 
 interface PruneOpts {

--- a/test/local-forge.test.ts
+++ b/test/local-forge.test.ts
@@ -11,6 +11,7 @@ import {
   mergeTreeWriteTree,
   parseGitVersion,
   gitVersionAtLeast,
+  parseWorktrees,
   BaseCheckoutBusyError,
   MergeConflictError,
 } from "../src/forge/local";
@@ -443,4 +444,58 @@ test("squashMergeLocal surfaces a clear error when git is too old (injected prob
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }
+});
+
+// ── parseWorktrees annotations (locked/bare/prunable) ────────────────────────
+
+test("parseWorktrees: bare AND reason-carrying locked/prunable both set the flag", () => {
+  const porcelain = [
+    "worktree /repo",
+    "HEAD abc123",
+    "branch refs/heads/main",
+    "",
+    "worktree /tmp/wt-locked-bare",
+    "HEAD def456",
+    "detached",
+    "locked", // bare form, no reason
+    "",
+    "worktree /tmp/wt-reason",
+    "HEAD 789abc",
+    "branch refs/heads/feat",
+    "locked on another host", // reason-carrying form — MUST still set the flag
+    "prunable gitdir file points to non-existent location", // reason-carrying
+    "",
+    "worktree /tmp/wt-bare",
+    "bare",
+    "",
+  ].join("\n");
+  const wts = parseWorktrees(porcelain);
+  expect(wts).toHaveLength(4);
+
+  // main worktree — every annotation false
+  expect(wts[0]).toMatchObject({
+    path: "/repo",
+    branch: "main",
+    detached: false,
+    locked: false,
+    bare: false,
+    prunable: false,
+  });
+  // bare `locked` line
+  expect(wts[1]).toMatchObject({ path: "/tmp/wt-locked-bare", detached: true, locked: true });
+  // reason-carrying locked + prunable both flagged (the prefix-match guard)
+  expect(wts[2]).toMatchObject({
+    path: "/tmp/wt-reason",
+    branch: "feat",
+    locked: true,
+    prunable: true,
+  });
+  // `bare` annotation
+  expect(wts[3]).toMatchObject({ path: "/tmp/wt-bare", bare: true });
+});
+
+test("parseWorktrees: absent annotations default to false", () => {
+  const wts = parseWorktrees("worktree /repo\nHEAD abc\nbranch refs/heads/main\n");
+  expect(wts).toHaveLength(1);
+  expect(wts[0]).toMatchObject({ locked: false, bare: false, prunable: false, detached: false });
 });

--- a/test/tmp-sweep.test.ts
+++ b/test/tmp-sweep.test.ts
@@ -3,17 +3,25 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync, existsSync }
 import * as fsp from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { Dirent } from "node:fs";
 import {
   worktreeScratchDir,
   sweepClaudeTmp,
   removeWorktreeScratch,
   reapFallowCaches,
   pruneRepoWorktrees,
+  reapAbandonedWorktrees,
+  reclaimForkedPnpmStore,
+  resolveStoreVersionDirs,
   readTmpInodeUsePct,
   tmpInodeBands,
   TMP_INODE_ERROR_PCT,
   FALLOW_CACHE_PREFIX,
 } from "../src/tmp-sweep";
+
+/** Minimal `Dirent` fake — the reclaimers only read `.name` + `.isDirectory()`. */
+const dirent = (name: string, isDir: boolean): Dirent =>
+  ({ name, isDirectory: () => isDir }) as unknown as Dirent;
 
 const uid = (): number => process.getuid?.() ?? 1000;
 const nested = `claude-${uid()}`;
@@ -795,5 +803,317 @@ describe("pruneRepoWorktrees", () => {
   test("never rejects; empty list returns zeroes", async () => {
     const res = await pruneRepoWorktrees([], { execGit: async () => {}, log: () => {} });
     expect(res).toEqual({ pruned: 0, failed: 0 });
+  });
+});
+
+// ── reapAbandonedWorktrees ───────────────────────────────────────────────────
+
+describe("reapAbandonedWorktrees", () => {
+  const NOW = 1_700_000_000_000;
+  // one worktree block; `extra` carries porcelain annotation lines.
+  const porc = (path: string, extra: string[] = []) =>
+    ["worktree " + path, "HEAD abcdef", "branch refs/heads/feat", ...extra, ""].join("\n");
+
+  // Default: a single stale, clean worktree at /tmp/wt-a, high inode pressure, modern git.
+  function reaperOpts(over: Record<string, unknown> = {}) {
+    const removed: string[] = [];
+    const opts = {
+      repoPaths: ["/repo"],
+      liveWorktreePaths: [] as string[],
+      liveCwds: [] as string[],
+      tmpRoots: ["/tmp"],
+      now: NOW,
+      statfs: fakeStatfs(1000, 100), // 90% used ≥ default 80
+      realpath: async (p: string) => p,
+      execGit: async (_cwd: string, args: string[]) => {
+        if (args[0] === "--version") return "git version 2.54.0";
+        if (args[0] === "worktree" && args[1] === "list") return porc("/tmp/wt-a");
+        if (args[0] === "status") return ""; // clean
+        return "";
+      },
+      fsOps: {
+        readdir: async () => [] as Dirent[], // empty tree → freshness walk finds nothing
+        stat: async () => ({ mtimeMs: 0 }) as unknown as Awaited<ReturnType<typeof fsp.stat>>,
+      },
+      removeWorktree: async (_repo: string, wt: string) => {
+        removed.push(wt);
+      },
+      log: () => {},
+      ...over,
+    };
+    return { opts, removed };
+  }
+
+  test("stale + clean + high pressure + modern git → reaped, retained 0", async () => {
+    const { opts, removed } = reaperOpts();
+    const r = await reapAbandonedWorktrees(opts as never);
+    expect(r).toEqual({ reaped: 1, retained: 0 });
+    expect(removed).toEqual(["/tmp/wt-a"]);
+  });
+
+  test("dirty (git status non-empty) → kept, retained 1", async () => {
+    const { opts, removed } = reaperOpts({
+      execGit: async (_c: string, args: string[]) => {
+        if (args[0] === "--version") return "git version 2.54.0";
+        if (args[0] === "worktree" && args[1] === "list") return porc("/tmp/wt-a");
+        if (args[0] === "status") return " M file.ts\n"; // dirty
+        return "";
+      },
+    });
+    const r = await reapAbandonedWorktrees(opts as never);
+    expect(r).toEqual({ reaped: 0, retained: 1 });
+    expect(removed).toEqual([]);
+  });
+
+  test("git status THROWS → treated as dirty → kept", async () => {
+    const { opts } = reaperOpts({
+      execGit: async (_c: string, args: string[]) => {
+        if (args[0] === "--version") return "git version 2.54.0";
+        if (args[0] === "worktree" && args[1] === "list") return porc("/tmp/wt-a");
+        if (args[0] === "status") throw new Error("git blew up");
+        return "";
+      },
+    });
+    expect(await reapAbandonedWorktrees(opts as never)).toEqual({ reaped: 0, retained: 1 });
+  });
+
+  for (const ann of ["locked", "bare", "prunable"]) {
+    test(`porcelain '${ann}' annotation → kept`, async () => {
+      const { opts, removed } = reaperOpts({
+        execGit: async (_c: string, args: string[]) => {
+          if (args[0] === "--version") return "git version 2.54.0";
+          if (args[0] === "worktree" && args[1] === "list")
+            return porc("/tmp/wt-a", [ann === "bare" ? "bare" : `${ann} some reason here`]);
+          if (args[0] === "status") return "";
+          return "";
+        },
+      });
+      const r = await reapAbandonedWorktrees(opts as never);
+      expect(r).toEqual({ reaped: 0, retained: 1 });
+      expect(removed).toEqual([]);
+    });
+  }
+
+  test("Shepherd session worktree marker → kept", async () => {
+    const marked = "/tmp/x/.shepherd-worktrees/sess-1";
+    const { opts } = reaperOpts({
+      execGit: async (_c: string, args: string[]) => {
+        if (args[0] === "--version") return "git version 2.54.0";
+        if (args[0] === "worktree" && args[1] === "list") return porc(marked);
+        if (args[0] === "status") return "";
+        return "";
+      },
+    });
+    expect(await reapAbandonedWorktrees(opts as never)).toEqual({ reaped: 0, retained: 1 });
+  });
+
+  test("live-session worktreePath → kept", async () => {
+    const { opts } = reaperOpts({ liveWorktreePaths: ["/tmp/wt-a"] });
+    expect(await reapAbandonedWorktrees(opts as never)).toEqual({ reaped: 0, retained: 1 });
+  });
+
+  test("live /proc cwd under the candidate → kept", async () => {
+    const { opts } = reaperOpts({ liveCwds: ["/tmp/wt-a/packages/x"] });
+    expect(await reapAbandonedWorktrees(opts as never)).toEqual({ reaped: 0, retained: 1 });
+  });
+
+  test("fresh (recent mtime) → kept", async () => {
+    const { opts } = reaperOpts({
+      fsOps: {
+        readdir: async () => [] as Dirent[],
+        stat: async () => ({ mtimeMs: NOW }) as unknown as Awaited<ReturnType<typeof fsp.stat>>,
+      },
+    });
+    expect(await reapAbandonedWorktrees(opts as never)).toEqual({ reaped: 0, retained: 1 });
+  });
+
+  test("below inode threshold → discovered but NOT removed; retained reflects it", async () => {
+    const { opts, removed } = reaperOpts({ statfs: fakeStatfs(1000, 900) }); // 10% < 80
+    const r = await reapAbandonedWorktrees(opts as never);
+    expect(r).toEqual({ reaped: 0, retained: 1 });
+    expect(removed).toEqual([]);
+  });
+
+  test("git below the 2.38 floor → discovered but NOT removed", async () => {
+    const { opts, removed } = reaperOpts({
+      execGit: async (_c: string, args: string[]) => {
+        if (args[0] === "--version") return "git version 2.35.0";
+        if (args[0] === "worktree" && args[1] === "list") return porc("/tmp/wt-a");
+        if (args[0] === "status") return "";
+        return "";
+      },
+    });
+    expect(await reapAbandonedWorktrees(opts as never)).toEqual({ reaped: 0, retained: 1 });
+    expect(removed).toEqual([]);
+  });
+
+  test("candidate NOT under any tmp root → not a candidate", async () => {
+    const { opts } = reaperOpts({
+      execGit: async (_c: string, args: string[]) => {
+        if (args[0] === "--version") return "git version 2.54.0";
+        if (args[0] === "worktree" && args[1] === "list") return porc("/home/me/work/wt");
+        if (args[0] === "status") return "";
+        return "";
+      },
+    });
+    expect(await reapAbandonedWorktrees(opts as never)).toEqual({ reaped: 0, retained: 0 });
+  });
+
+  test("symlinked tmp root: resolved candidate still segment-aligns and is refused", async () => {
+    // Porcelain emits /tmp/wt-a; realpath resolves /tmp → /private/tmp (macOS-style), while
+    // tmpRoots + liveCwds arrive in the /private/tmp form. The resolved candidate must still
+    // match a tmp root AND the live-cwd, and be kept — a non-match would read as "not protected".
+    const realpath = async (p: string) => p.replace(/^\/tmp(\/|$)/, "/private/tmp$1");
+    const { opts, removed } = reaperOpts({
+      realpath,
+      tmpRoots: ["/private/tmp"],
+      liveCwds: ["/private/tmp/wt-a/sub"],
+    });
+    const r = await reapAbandonedWorktrees(opts as never);
+    expect(r).toEqual({ reaped: 0, retained: 1 }); // under tmp (so a candidate) AND live-cwd (so kept)
+    expect(removed).toEqual([]);
+  });
+});
+
+// ── resolveStoreVersionDirs ──────────────────────────────────────────────────
+
+describe("resolveStoreVersionDirs", () => {
+  test("keeps only /^v\\d+$/ directories", () => {
+    const entries = [
+      dirent("v10", true),
+      dirent("v9", true),
+      dirent("v10", false), // a FILE named v10 — excluded (not a dir)
+      dirent("index", true),
+      dirent("version", true), // not v<digits>
+      dirent(".lock", false),
+    ];
+    expect(resolveStoreVersionDirs(entries)).toEqual(["v10", "v9"]);
+  });
+
+  test("empty when nothing matches", () => {
+    expect(resolveStoreVersionDirs([dirent("garbage", true)])).toEqual([]);
+  });
+});
+
+// ── reclaimForkedPnpmStore ───────────────────────────────────────────────────
+
+describe("reclaimForkedPnpmStore", () => {
+  const NOW = 1_700_000_000_000;
+  const ROOT = "/tmp/.pnpm-store";
+
+  // A removable store: v10 with files/ + index/, all stale, every content file nlink 1.
+  function storeHarness() {
+    const R: Record<string, Dirent[]> = {
+      [ROOT]: [dirent("v10", true)],
+      [`${ROOT}/v10`]: [dirent("files", true), dirent("index", true)],
+      [`${ROOT}/v10/files`]: [dirent("9f", true)],
+      [`${ROOT}/v10/files/9f`]: [dirent("abc", false)],
+      [`${ROOT}/v10/index`]: [dirent("meta", false)],
+    };
+    const mtimes: Record<string, number> = {};
+    const nlinks: Record<string, number> = {};
+    const removed: string[] = [];
+    const opts = {
+      storeRoot: ROOT,
+      retained: 0,
+      now: NOW,
+      statfs: fakeStatfs(1000, 100), // 90% ≥ 80
+      fsOps: {
+        readdir: async (p: string) => {
+          const e = R[String(p)];
+          if (!e) throw new Error("ENOENT " + p);
+          return e;
+        },
+        stat: async (p: string) =>
+          ({
+            mtimeMs: mtimes[String(p)] ?? 0,
+            nlink: nlinks[String(p)] ?? 1,
+          }) as unknown as Awaited<ReturnType<typeof fsp.stat>>,
+        rm: async (p: string) => {
+          removed.push(String(p));
+        },
+      },
+      log: () => {},
+    };
+    return { opts, R, mtimes, nlinks, removed };
+  }
+
+  test("fully idle + unlinked → removes the whole store root", async () => {
+    const { opts, removed } = storeHarness();
+    const r = await reclaimForkedPnpmStore(opts as never);
+    expect(r.removed).toBe(true);
+    expect(removed).toEqual([ROOT]);
+  });
+
+  test("retained > 0 → skip", async () => {
+    const { opts, removed } = storeHarness();
+    opts.retained = 1;
+    const r = await reclaimForkedPnpmStore(opts as never);
+    expect(r.removed).toBe(false);
+    expect(r.reason).toContain("retained");
+    expect(removed).toEqual([]);
+  });
+
+  test("inode pressure below threshold → skip", async () => {
+    const { opts } = storeHarness();
+    opts.statfs = fakeStatfs(1000, 900); // 10%
+    expect((await reclaimForkedPnpmStore(opts as never)).removed).toBe(false);
+  });
+
+  test("missing store dir → no-store", async () => {
+    const { opts } = storeHarness();
+    opts.fsOps.readdir = async () => {
+      throw new Error("ENOENT");
+    };
+    expect((await reclaimForkedPnpmStore(opts as never)).reason).toBe("no-store");
+  });
+
+  test("no v* dir → no-version-dir", async () => {
+    const { opts, R } = storeHarness();
+    R[ROOT] = [dirent("garbage", true)];
+    expect((await reclaimForkedPnpmStore(opts as never)).reason).toBe("no-version-dir");
+  });
+
+  test("fresh non-v* sibling → skip", async () => {
+    const { opts, R, mtimes } = storeHarness();
+    R[ROOT] = [dirent("v10", true), dirent("staging.lock", false)];
+    mtimes[`${ROOT}/staging.lock`] = NOW; // fresh
+    const r = await reclaimForkedPnpmStore(opts as never);
+    expect(r.removed).toBe(false);
+    expect(r.reason).toContain("sibling-fresh");
+  });
+
+  test("stale but unrecognized non-v* directory sibling → skip", async () => {
+    const { opts, R } = storeHarness();
+    R[ROOT] = [dirent("v10", true), dirent("staging", true)]; // stale dir, unknown
+    const r = await reclaimForkedPnpmStore(opts as never);
+    expect(r.removed).toBe(false);
+    expect(r.reason).toContain("sibling-unrecognized");
+  });
+
+  test("a depth-2 entry with a recent mtime → store-busy (idleness probes at depth 2)", async () => {
+    const { opts, mtimes } = storeHarness();
+    mtimes[`${ROOT}/v10/files/9f`] = NOW; // a bucket (depth 2) touched recently
+    const r = await reclaimForkedPnpmStore(opts as never);
+    expect(r.removed).toBe(false);
+    expect(r.reason).toContain("store-busy");
+  });
+
+  test("any file with nlink > 1 → store-linked (skip)", async () => {
+    const { opts, nlinks } = storeHarness();
+    nlinks[`${ROOT}/v10/files/9f/abc`] = 2; // a worktree still links it
+    const r = await reclaimForkedPnpmStore(opts as never);
+    expect(r.removed).toBe(false);
+    expect(r.reason).toContain("store-linked");
+  });
+
+  test("a bucket unreadable during the nlink walk → keep (not provably unlinked)", async () => {
+    // Idleness passes (depth-2 only stats the bucket dir), but the exhaustive nlink walk must
+    // descend into it — a readdir error there resolves to keep, never a removal.
+    const { opts, R } = storeHarness();
+    delete R[`${ROOT}/v10/files/9f`]; // readdir(bucket) throws inside storeVersionDirHasLinks
+    const r = await reclaimForkedPnpmStore(opts as never);
+    expect(r.removed).toBe(false);
+    expect(r.reason).toContain("store-linked-or-unprobed");
   });
 });


### PR DESCRIPTION
Closes the reclamation gap left by #1862/#1876. Those shipped **prevention** (the `<tmpfs-worktree-notice>` steering agents off `/tmp`) and **diagnosis** (the `tmp_inodes` Diagnose row + one-click forced sweep), but nothing that reclaims inodes already lost to abandoned `/tmp` agent worktrees and the forked pnpm store beside them — so `tmp_inodes` can legitimately sit `warning`/`error` after a *successful* forced sweep. This adds the two reclaimers.

Refs #1874.

## Two reclaimers, wired into `fireTmpSweep` (boot + daily), run **in order**

pnpm hardlinks `node_modules` into its store; an inode frees only on the **last** link drop. While a tmp worktree survives, every store file sits at `nlink = 2`, so removing the store reclaims ~zero *and* the next install re-forks it — net inode use goes **up**. So the worktree reaper runs first, and the store pass consumes its `retained` count as a go/no-go gate.

### `reapAbandonedWorktrees`
Removes stale, clean, unused git worktrees of *configured* repos that physically live under a tmp root (a nested agent's `git worktree add /tmp/…` left behind). Destructive against possibly-unrecoverable data, so it is **gated on live inode pressure** and walled by refusals — **dirty** (`git status --porcelain`, any error = dirty), porcelain **`locked`/`bare`/`prunable`**, the Shepherd `/.shepherd-worktrees/` marker, **live-session** `worktreePath`, **live same-uid `/proc` cwd**, and mtime **freshness** (bounded walk, `node_modules`/`.git` pruned from descent, budget/error → keep). Every comparison is **realpath-normalized** (symlinked `/tmp`, e.g. macOS `/private/tmp`, must not read as "not protected"). Git-floor **2.38** for the `locked`/`prunable` annotations. `retained` = candidates under a tmp root still on disk after the pass.

### `reclaimForkedPnpmStore`
**All-or-nothing** removal of `<tmp>/.pnpm-store` — skip the whole store if *any* file still has `nlink > 1`. Gated on `retained === 0`, inode pressure, non-`v*` sibling freshness, **depth-2 idleness**, and an **exhaustive early-exit `nlink` scan**. Every non-exhaustive outcome (error, budget, missing `files/`) resolves to **keep** — `removed:false` means *provably idle*, never *failed to probe*.

## Phase-0: partial reclaim is safe, but deferred (#1880)

Measured while planning (pnpm 10.28.2, tmpfs, store `v10`): deleting `nlink==1` content makes the next **offline** install error `ERR_PNPM_NO_OFFLINE_TARBALL` and the next **online** install **re-fetch cleanly**. So partial reclaim is safe *given network* — but this PR ships the conservative **all-or-nothing** path; partial reclaim is filed as **#1880** with the evidence.

## Reuse, not new surface
- **No new env vars** — reuses `SHEPHERD_TMP_INODE_PCT` (gate) + `SHEPHERD_TMP_STALE_HOURS` (staleness).
- `parseWorktrees` is **exported + extended** (`locked`/`bare`/`prunable`, `locked`/`prunable` **prefix-matched** for their reason-carrying forms) rather than adding a third porcelain parser.
- `WORKTREE_MARKER`, `isUnder`, and a new `liveProcCwds()` are exported from `process-reaper` for reuse; the sync `/proc` scan is snapshotted at the `index.ts` layer and passed in, keeping it out of the all-async `tmp-sweep`.

## Tests / checks
- New unit tests for both reclaimers + `resolveStoreVersionDirs` + the extended `parseWorktrees` (incl. a **symlinked-tmp-root** refusal test). Fully injectable ops — no real git/`/proc`/tmpfs.
- `bun run lint`, `bun run typecheck`, `bun test ./test` (7513 pass), and `fallow audit` all pass.

## Out of scope
Anything under `/tmp` that is not a worktree of a *configured* repo (an unconfigured repo's worktree, a plain clone, a bare dir that ran an install) — invisible to configured-repo discovery; the `nlink` scan is what stops the store pass from being counterproductive in their presence. Revisiting `tmp_inodes`' `STEADY_STATE_ERROR_CHECK_IDS` membership is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)