### PR TITLE
fix(tmp): point trusted agents at a disk-backed TMPDIR (#1875)

### DIFF
--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -3,7 +3,7 @@ import { promisify } from "node:util";
 import { execFileSync } from "./instrument";
 import { config } from "./config";
 import { maintenance } from "./maintenance";
-import { compileCacheDir } from "./tmp-sweep";
+import { compileCacheDir, agentTmpDir } from "./tmp-sweep";
 import type { HerdrState, LivenessState, SessionStatus } from "./types";
 
 const execFileAsync = promisify(execFile);
@@ -363,6 +363,16 @@ export function parseAgentInfo(agent: unknown): HerdrAgent {
  * xterm keystrokes). The main-session spawn computes its own renderer env and routes it
  * through both the membrane --setenv and this shim, so re-adding the pin here would
  * duplicate it (and `env`'s last-wins would let the pin override an intended NO_FLICKER).
+ *
+ * Points the agent at the disk-backed `agentTmpDir()` via `TMPDIR=` (#1875) so its temp I/O stays
+ * off the `/tmp` tmpfs whose inode table it exhausts, and STRIPS the inherited `CLAUDE_CODE_TMPDIR`
+ * via `env -u`: the server sets that on its OWN env so `claudeTmpRoot()` follows, but claude honours
+ * it as a BASE and appends its own `claude-$uid`, so letting it reach the agent would double-suffix
+ * the agent's root and desync it from the server's read path. Both are skipped when the redirect is
+ * disabled (`agentTmpDir()===null`); the `TMPDIR=` token is skipped if the caller already set one.
+ * NOTE: for a membrane-wrapped (sandboxed) spawn this OUTER `env` shim is wiped by `bwrap --clearenv`
+ * (identically to `NODE_COMPILE_CACHE`), so the redirect is a TRUSTED-spawn guarantee — a sandbox's
+ * own ephemeral `--tmpfs /tmp` never threatens the host inode table.
  */
 export function buildWrappedArgv(argv: string[], env?: Record<string, string>): string[] {
   const envTokens = env
@@ -372,8 +382,17 @@ export function buildWrappedArgv(argv: string[], env?: Record<string, string>): 
     : [];
   const callerSetRenderer =
     !!env && ("CLAUDE_CODE_NO_FLICKER" in env || "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN" in env);
+  // `-u CLAUDE_CODE_TMPDIR` must precede the KEY=VALUE assignments (coreutils `env` stops option
+  // parsing at the first operand). When enabled we ALWAYS strip CLAUDE_CODE_TMPDIR (even if a caller
+  // set TMPDIR — claude prefers CLAUDE_CODE_TMPDIR over TMPDIR, so a leak would still double-suffix),
+  // and add our TMPDIR= only when the caller didn't provide one.
+  const agentTmp = agentTmpDir();
+  const tmpTokens = agentTmp
+    ? ["-u", "CLAUDE_CODE_TMPDIR", ...(env && "TMPDIR" in env ? [] : [`TMPDIR=${agentTmp}`])]
+    : [];
   return [
     "env",
+    ...tmpTokens,
     `NODE_COMPILE_CACHE=${compileCacheDir()}`,
     ...(callerSetRenderer ? [] : ["CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1"]),
     ...envTokens,

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,8 @@ import {
   reapFallowCaches,
   pruneRepoWorktrees,
   scratchpadHasFiles,
+  agentTmpDir,
+  agentClaudeTmpRoot,
 } from "./tmp-sweep";
 import { runSessionUsageBackfill } from "./usage-backfill";
 import { PreviewService } from "./preview";
@@ -781,6 +783,24 @@ try {
   mkdirSync(compileCacheDir(), { recursive: true });
 } catch (err) {
   console.warn("[tmp-sweep] could not create compile-cache dir:", err);
+}
+
+// Point spawned (trusted) agents at a disk-backed TMPDIR (#1875), and mirror it into the server's
+// OWN env so claudeTmpRoot() — and thus every scratch/sweep consumer — follows the agents to disk.
+// We set CLAUDE_CODE_TMPDIR (NOT TMPDIR) so os.tmpdir() is untouched and readTmpInodeUsePct() keeps
+// monitoring the real tmpfs. The value carries the claude-$uid suffix (claudeTmpRoot() treats
+// CLAUDE_CODE_TMPDIR as the FINAL root); the spawn shim strips it from agents (env -u) so they
+// re-derive the SAME root from TMPDIR without double-suffixing. Runs before any spawn or scratchpad
+// read. Null = disabled (SHEPHERD_AGENT_TMPDIR="") → tmpfs rollback, leave the env untouched.
+const agentTmp = agentTmpDir();
+const agentClaudeRoot = agentClaudeTmpRoot();
+if (agentTmp && agentClaudeRoot) {
+  try {
+    mkdirSync(agentTmp, { recursive: true });
+  } catch (err) {
+    console.warn("[tmp-sweep] could not create agent tmp dir:", err);
+  }
+  process.env.CLAUDE_CODE_TMPDIR = agentClaudeRoot;
 }
 
 // Inode-guard sweep: drops the compile cache + stale scratch once /tmp inode pressure

--- a/src/scratchpad.ts
+++ b/src/scratchpad.ts
@@ -1,6 +1,6 @@
 import { promises as fsp } from "node:fs";
 import { join, basename, extname, sep, normalize, isAbsolute } from "node:path";
-import { sessionScratchpadDir } from "./tmp-sweep";
+import { existingScratchpadDir } from "./tmp-sweep";
 import { worktreeUploadsDir } from "./uploads";
 import {
   within,
@@ -35,7 +35,7 @@ export async function resolveScratchpadPath(
   relPath: string,
 ): Promise<{ rootReal: string; resolved: string } | null> {
   if (!claudeSessionId) return null;
-  return resolveInRoot(sessionScratchpadDir(worktreePath, claudeSessionId), relPath);
+  return resolveInRoot(await existingScratchpadDir(worktreePath, claudeSessionId), relPath);
 }
 
 /**
@@ -51,7 +51,7 @@ export async function listScratchpad(
   relPath: string,
 ): Promise<ScratchListing | null> {
   if (!claudeSessionId) return null;
-  return listDir(sessionScratchpadDir(worktreePath, claudeSessionId), relPath);
+  return listDir(await existingScratchpadDir(worktreePath, claudeSessionId), relPath);
 }
 
 /**
@@ -64,7 +64,7 @@ export async function resolveScratchpadFile(
   relPath: string,
 ): Promise<string | null> {
   if (!claudeSessionId) return null;
-  return resolveFileInRoot(sessionScratchpadDir(worktreePath, claudeSessionId), relPath);
+  return resolveFileInRoot(await existingScratchpadDir(worktreePath, claudeSessionId), relPath);
 }
 
 /**
@@ -237,8 +237,10 @@ export async function resolveScratchpadUploadDir(
 ): Promise<{ rootReal: string; dirReal: string } | null> {
   if (!claudeSessionId) return null;
 
-  // Ensure the root exists — async mkdir so the event loop isn't blocked.
-  const root = sessionScratchpadDir(worktreePath, claudeSessionId);
+  // Ensure the root exists — async mkdir so the event loop isn't blocked. Uploads target the SAME
+  // root the reads use (#1875): a legacy-only (adopted) session's uploads land beside its agent's
+  // files on the tmpfs; otherwise the disk primary is created on demand.
+  const root = await existingScratchpadDir(worktreePath, claudeSessionId);
   await fsp.mkdir(root, { recursive: true });
 
   let rootReal: string;

--- a/src/tmp-sweep.ts
+++ b/src/tmp-sweep.ts
@@ -61,12 +61,70 @@ export function compileCacheDir(): string {
 }
 
 /**
+ * The disk-backed `TMPDIR` that spawned (trusted) agents are pointed at (#1875), so ALL their temp
+ * I/O — the per-session scratch tree, git worktrees, dependency installs, and bare-`$TMPDIR` tool
+ * caches (fallow/bunx/agent-browser) — lands on a real filesystem instead of the `/tmp` tmpfs, whose
+ * INODE table it otherwise exhausts (ENOSPC with bytes to spare). Default mirrors `compileCacheDir()`'s
+ * `~/.cache/shepherd/*` home. Read from env at call time.
+ *
+ * Returns `null` when the redirect is DISABLED — the operator set `SHEPHERD_AGENT_TMPDIR` to the
+ * empty string — restoring the pre-#1875 tmpfs inheritance as a one-env-var rollback (the write
+ * traffic this relocates to disk is unmeasured). A non-empty value overrides the default path.
+ */
+export function agentTmpDir(): string | null {
+  const v = process.env.SHEPHERD_AGENT_TMPDIR;
+  if (v === "") return null; // explicitly disabled
+  return v ?? join(homedir(), ".cache", "shepherd", "tmp");
+}
+
+/**
+ * The value the SERVER sets as its own `CLAUDE_CODE_TMPDIR` at boot so `claudeTmpRoot()` (and every
+ * scratch consumer) follows trusted agents onto the disk `agentTmpDir()`. It is `agentTmpDir()` plus
+ * the `claude-$uid` suffix, because `claudeTmpRoot()` treats `CLAUDE_CODE_TMPDIR` as the FINAL root
+ * (returns it verbatim). Null when the redirect is disabled.
+ *
+ * The spawn shim STRIPS `CLAUDE_CODE_TMPDIR` from the agent (`env -u`, see `buildWrappedArgv`): claude
+ * honours it as a BASE and appends its OWN `claude-$uid`, so an inherited value would double-suffix the
+ * agent's root (`<disk>/claude-$uid/claude-$uid`) and desync it from this server-side read path. Instead
+ * the agent re-derives this SAME path from `TMPDIR=agentTmpDir()` alone.
+ */
+export function agentClaudeTmpRoot(): string | null {
+  const base = agentTmpDir();
+  return base === null ? null : join(base, `claude-${uid()}`);
+}
+
+/**
+ * The pre-#1875 claude tmp root on the system tmpfs — `<os.tmpdir()>/claude-$uid`. After the boot
+ * override moves `claudeTmpRoot()` to the disk `agentClaudeTmpRoot()`, this is where an ADOPTED
+ * (pre-upgrade) session's live agent — which kept its spawn-time `TMPDIR=/tmp` across the deploy —
+ * still writes. The dual-read / dual-clean / sweep paths consult it so those sessions are not orphaned.
+ * Read at call time.
+ */
+export function legacyClaudeTmpRoot(): string {
+  return join(tmpdir(), `claude-${uid()}`);
+}
+
+/**
  * The per-session scratch dir a NESTED claude derives for a given worktree cwd:
  * `<claudeTmpRoot>/claude-$uid/<dashified-worktree-path>`. The doubled `claude-$uid`
  * is real — our spawned agents inherit TMPDIR and re-derive their own claude root under it.
  */
 export function worktreeScratchDir(worktreePath: string): string {
   return join(claudeTmpRoot(), `claude-${uid()}`, dashify(worktreePath));
+}
+
+/**
+ * Ordered, DEDUPED nested-scratch-dir candidates for a worktree (#1875 migration). Primary is the
+ * live `worktreeScratchDir()` (disk after the boot override); the second is the same doubled
+ * `claude-$uid/<dashified>` tail under the legacy tmpfs root, where an ADOPTED pre-upgrade session's
+ * live agent still writes. `removeWorktreeScratch` reclaims BOTH on archival — without this the
+ * disk-only primary would silently stop reclaiming those tmpfs dirs, regressing an existing
+ * automatic tmpfs-inode reclaim. No override → the two collapse and dedupe to one → unchanged.
+ */
+export function worktreeScratchDirCandidates(worktreePath: string): string[] {
+  const primary = worktreeScratchDir(worktreePath);
+  const legacy = join(legacyClaudeTmpRoot(), `claude-${uid()}`, dashify(worktreePath));
+  return [...new Set([primary, legacy])];
 }
 
 /**
@@ -86,22 +144,67 @@ export function sessionScratchpadDir(worktreePath: string, claudeSessionId: stri
 }
 
 /**
+ * Ordered, DEDUPED scratchpad-dir candidates for a session (#1875 migration). The primary is the
+ * live `sessionScratchpadDir()` (disk after the boot override); the second is the same tail under
+ * the legacy tmpfs root, where an ADOPTED pre-upgrade session's live agent — which kept its
+ * spawn-time `TMPDIR=/tmp` — still writes. When no override is active (`claudeTmpRoot()` ===
+ * `legacyClaudeTmpRoot()`) the two collapse and the list dedupes to a single entry, so every
+ * non-migration consumer is byte-for-byte unchanged.
+ */
+export function sessionScratchpadDirCandidates(
+  worktreePath: string,
+  claudeSessionId: string,
+): string[] {
+  const primary = sessionScratchpadDir(worktreePath, claudeSessionId);
+  const legacy = join(legacyClaudeTmpRoot(), dashify(worktreePath), claudeSessionId, "scratchpad");
+  return [...new Set([primary, legacy])];
+}
+
+/**
+ * Resolve which scratchpad root a session ACTUALLY uses: the first candidate that exists, else the
+ * primary (for creation). Rule: a live disk session → disk; a legacy-only (adopted) session →
+ * legacy tmpfs; if BOTH exist (e.g. a respawned session) → prefer disk (the live root). Keeps a
+ * SINGLE root per session so reads, downloads, and uploads never split across roots. Returns the
+ * primary on a blank `claudeSessionId` (callers already guard that separately).
+ */
+export async function existingScratchpadDir(
+  worktreePath: string,
+  claudeSessionId: string,
+): Promise<string> {
+  const primary = sessionScratchpadDir(worktreePath, claudeSessionId);
+  for (const dir of sessionScratchpadDirCandidates(worktreePath, claudeSessionId)) {
+    try {
+      await fsp.access(dir);
+      return dir;
+    } catch {
+      // try the next candidate
+    }
+  }
+  return primary;
+}
+
+/**
  * Shallow, async, non-throwing "does this session's scratchpad hold any entry?" probe — the
  * cheap signal that gates the UI's Files tab (#1164). Counts ANY entry (files OR subdirs,
  * dotfiles included). Returns false on a blank `claudeSessionId` (pre-`--session-id` session /
- * agent not yet started), a missing dir, or any read error. Single shallow `readdir`.
+ * agent not yet started), a missing dir, or any read error. Dual-read across the disk + legacy
+ * candidates (#1875) so an adopted pre-upgrade session on the tmpfs still lights the tab; a single
+ * shallow `readdir` per candidate, short-circuiting on the first non-empty hit.
  */
 export async function scratchpadHasFiles(
   worktreePath: string,
   claudeSessionId: string,
 ): Promise<boolean> {
   if (!claudeSessionId) return false;
-  try {
-    const entries = await fsp.readdir(sessionScratchpadDir(worktreePath, claudeSessionId));
-    return entries.length > 0;
-  } catch {
-    return false;
+  for (const dir of sessionScratchpadDirCandidates(worktreePath, claudeSessionId)) {
+    try {
+      const entries = await fsp.readdir(dir);
+      if (entries.length > 0) return true;
+    } catch {
+      // missing/unreadable candidate — try the next
+    }
   }
+  return false;
 }
 
 export interface SweepResult {
@@ -322,6 +425,29 @@ async function sweepDir(dir: string, ctx: SweepCtx): Promise<number> {
 }
 
 /**
+ * The directories one sweep visits. An explicit `root` (`explicitRoot`, tests) sweeps ONLY that
+ * root + its nested `claude-$uid` dir — today's behavior, byte-for-byte, and never touches the real
+ * disk/legacy roots. The default (production) path expands (#1875) to the DEDUPED set of the bare
+ * disk `agentTmpDir()` — where bare-`$TMPDIR` tool caches (fallow/bunx/agent-browser) land — the
+ * disk claude `root` + nested, and the legacy tmpfs root + nested — where an adopted pre-upgrade
+ * session's live agent still writes. No override → the roots collapse and dedupe to today's pair.
+ */
+function resolveSweepRoots(root: string, nestedName: string, explicitRoot: boolean): string[] {
+  if (explicitRoot) return [root, join(root, nestedName)];
+  const agentTmp = agentTmpDir();
+  const legacy = legacyClaudeTmpRoot();
+  return [
+    ...new Set([
+      ...(agentTmp ? [agentTmp] : []),
+      root,
+      join(root, nestedName),
+      legacy,
+      join(legacy, nestedName),
+    ]),
+  ];
+}
+
+/**
  * Threshold-gated inode guard. TOTAL by contract: it NEVER throws or rejects — any
  * unexpected error resolves to `{ swept:false, reason:"error", removed:0 }` after logging,
  * so a caller can fire-and-forget it on a timer without a guard.
@@ -382,7 +508,7 @@ export async function sweepClaudeTmp(opts?: SweepOpts): Promise<SweepResult> {
 
     const nestedName = `claude-${uid()}`;
     const ctx: SweepCtx = { ops, now, staleMs, nestedName, log };
-    const sweepRoots = [root, join(root, nestedName)];
+    const sweepRoots = resolveSweepRoots(root, nestedName, opts?.root !== undefined);
 
     let removed = 0;
     for (const dir of sweepRoots) removed += await sweepDir(dir, ctx);
@@ -399,19 +525,23 @@ export async function sweepClaudeTmp(opts?: SweepOpts): Promise<SweepResult> {
 }
 
 /**
- * Best-effort targeted teardown of one worktree's scratch dir (e.g. on session retire).
- * No-op when absent (`force:true`), swallows every error — never throws.
+ * Best-effort targeted teardown of one worktree's scratch dir (e.g. on session retire). Reclaims
+ * BOTH the disk and legacy-tmpfs candidates (#1875) so an adopted pre-upgrade session's nested
+ * scratch on the tmpfs is still freed. No-op per candidate when absent (`force:true`), swallows
+ * every error — never throws. An explicit `opts.dir` (tests) targets exactly that one dir.
  */
 export async function removeWorktreeScratch(
   worktreePath: string,
   opts?: { dir?: string; rm?: typeof fsp.rm },
 ): Promise<void> {
-  const dir = opts?.dir ?? worktreeScratchDir(worktreePath);
+  const dirs = opts?.dir ? [opts.dir] : worktreeScratchDirCandidates(worktreePath);
   const rm = opts?.rm ?? fsp.rm;
-  try {
-    await rm(dir, { recursive: true, force: true });
-  } catch {
-    /* best-effort */
+  for (const dir of dirs) {
+    try {
+      await rm(dir, { recursive: true, force: true });
+    } catch {
+      /* best-effort — continue to the next candidate */
+    }
   }
 }
 
@@ -507,15 +637,19 @@ export async function reapFallowCaches(opts?: ReapFallowOpts): Promise<ReapFallo
     rm: fsp.rm,
   };
 
-  // Dedupe roots: claudeTmpRoot(), claude-$uid subdir, and bare tmpdir() for caches whose
-  // TMPDIR was the system default. Using a Set so a reconfigured env can't double-scan.
-  // opts?.roots overrides the computed set (lets tests isolate from bare /tmp — #817).
+  // Dedupe roots: claudeTmpRoot(), claude-$uid subdir, bare tmpdir() for caches whose TMPDIR was
+  // the system default, and (when enabled) the bare disk agentTmpDir() — where an agent's Bash tool
+  // running fallow writes `fallow-audit-base-cache-*` at its bare `$TMPDIR` (#1875). Without the
+  // agentTmpDir() root those disk caches are reaped by NEITHER this pass nor sweepClaudeTmp, so they
+  // accrete unbounded on disk. Using a Set so a reconfigured env can't double-scan. opts?.roots
+  // overrides the computed set (lets tests isolate from bare /tmp — #817).
   const claudeRoot = claudeTmpRoot();
   const nestedRoot = join(claudeRoot, `claude-${uid()}`);
   const systemTmp = tmpdir();
+  const agentTmp = agentTmpDir();
   const roots = opts?.roots
     ? [...new Set(opts.roots)]
-    : [...new Set([claudeRoot, nestedRoot, systemTmp])];
+    : [...new Set([claudeRoot, nestedRoot, systemTmp, ...(agentTmp ? [agentTmp] : [])])];
 
   const ctx: ReapFallowCtx = { ops, now, staleMs, log };
   let removed = 0;

--- a/test/herdr-parity.test.ts
+++ b/test/herdr-parity.test.ts
@@ -95,3 +95,57 @@ describe("buildWrappedArgv — shared spawn argv", () => {
     expect(w.indexOf("CLAUDE_CODE_NO_FLICKER=1")).toBeLessThan(w.indexOf("FOO=b"));
   });
 });
+
+/**
+ * #1875: the shim points trusted agents at the disk-backed TMPDIR and strips the inherited
+ * CLAUDE_CODE_TMPDIR (which claude would double-suffix). These assertions run on the UNWRAPPED
+ * (trusted) argv shape — the token is effective ONLY when it directly precedes the agent with no
+ * `bwrap --clearenv` between them; asserting it on a bwrap-wrapped argv would falsely pass while the
+ * variable is inert inside the sandbox.
+ */
+describe("buildWrappedArgv — disk TMPDIR redirect (#1875)", () => {
+  const KEY = "SHEPHERD_AGENT_TMPDIR";
+  function withEnv(val: string | undefined, fn: () => void) {
+    const prev = process.env[KEY];
+    if (val === undefined) delete process.env[KEY];
+    else process.env[KEY] = val;
+    try {
+      fn();
+    } finally {
+      if (prev === undefined) delete process.env[KEY];
+      else process.env[KEY] = prev;
+    }
+  }
+
+  it("adds `-u CLAUDE_CODE_TMPDIR` then `TMPDIR=<disk>`, before NODE_COMPILE_CACHE, unwrapped", () => {
+    withEnv("/disk/agent", () => {
+      const w = buildWrappedArgv(["claude", "go"]);
+      expect(w).not.toContain("bwrap"); // trusted/unwrapped shape — where the token is effective
+      const uIdx = w.indexOf("-u");
+      expect(uIdx).toBeGreaterThan(0);
+      expect(w[uIdx + 1]).toBe("CLAUDE_CODE_TMPDIR");
+      const tmpIdx = w.indexOf("TMPDIR=/disk/agent");
+      const nccIdx = w.findIndex((t) => t.startsWith("NODE_COMPILE_CACHE="));
+      expect(tmpIdx).toBeGreaterThan(uIdx);
+      expect(tmpIdx).toBeLessThan(nccIdx); // options + TMPDIR precede the other assignments
+      expect(w.slice(-2)).toEqual(["claude", "go"]);
+    });
+  });
+
+  it("omits both the `-u` and the TMPDIR token when disabled (empty string)", () => {
+    withEnv("", () => {
+      const w = buildWrappedArgv(["claude"]);
+      expect(w).not.toContain("-u");
+      expect(w.some((t) => t.startsWith("TMPDIR="))).toBe(false);
+    });
+  });
+
+  it("still strips CLAUDE_CODE_TMPDIR but skips our token when the caller set TMPDIR", () => {
+    withEnv("/disk/agent", () => {
+      const w = buildWrappedArgv(["claude"], { TMPDIR: "/caller/tmp" });
+      expect(w[w.indexOf("-u") + 1]).toBe("CLAUDE_CODE_TMPDIR"); // always strip when enabled
+      expect(w).toContain("TMPDIR=/caller/tmp"); // caller's value, via the sorted env tokens
+      expect(w).not.toContain("TMPDIR=/disk/agent"); // our token is skipped
+    });
+  });
+});

--- a/test/herdr-socket-driver.test.ts
+++ b/test/herdr-socket-driver.test.ts
@@ -275,7 +275,7 @@ describe("SocketHerdrDriver — socket-backed async writes (#1553, #1567)", () =
     expect(startCall.focus).toBe(false);
     // byte-identical wrapped argv (env shim + classic-renderer pin) ends with the raw argv
     expect(startCall.argv[0]).toBe("env");
-    expect(startCall.argv[1]).toContain("NODE_COMPILE_CACHE=");
+    expect(startCall.argv.some((t: string) => t.startsWith("NODE_COMPILE_CACHE="))).toBe(true);
     expect(startCall.argv.slice(-2)).toEqual(["claude", "go"]);
   });
 

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -9,16 +9,23 @@ import {
 } from "../src/herdr";
 
 // Pin compileCacheDir() to a deterministic sentinel so the `env NODE_COMPILE_CACHE=…`
-// shim that start() prepends to every agent argv is assertable.
+// shim that start() prepends to every agent argv is assertable. Also disable the disk-TMPDIR
+// redirect (#1875) here so these argv-shape assertions stay scoped to the #560 compile-cache
+// shim + env sorting; the TMPDIR / `-u CLAUDE_CODE_TMPDIR` tokens are covered by herdr-parity.test.ts.
 const NCC_SENTINEL = "/disk/ncc";
 let prevNcc: string | undefined;
+let prevAgentTmp: string | undefined;
 beforeEach(() => {
   prevNcc = process.env.SHEPHERD_NODE_COMPILE_CACHE;
   process.env.SHEPHERD_NODE_COMPILE_CACHE = NCC_SENTINEL;
+  prevAgentTmp = process.env.SHEPHERD_AGENT_TMPDIR;
+  process.env.SHEPHERD_AGENT_TMPDIR = ""; // disabled → no TMPDIR token in the wrapped argv
 });
 afterEach(() => {
   if (prevNcc === undefined) delete process.env.SHEPHERD_NODE_COMPILE_CACHE;
   else process.env.SHEPHERD_NODE_COMPILE_CACHE = prevNcc;
+  if (prevAgentTmp === undefined) delete process.env.SHEPHERD_AGENT_TMPDIR;
+  else process.env.SHEPHERD_AGENT_TMPDIR = prevAgentTmp;
 });
 
 /** Build a HerdrDriver whose sync AND async runners share ONE fake. The write surface

--- a/test/scratchpad.test.ts
+++ b/test/scratchpad.test.ts
@@ -7,6 +7,7 @@ import {
   listScratchpad,
   resolveScratchpadPath,
   resolveScratchpadFile,
+  resolveScratchpadUploadDir,
   attachmentDisposition,
 } from "../src/scratchpad";
 
@@ -39,6 +40,67 @@ afterEach(() => {
   rmSync(outside, { recursive: true, force: true });
   if (prevEnv === undefined) delete process.env.SHEPHERD_TMP_SWEEP_DIR;
   else process.env.SHEPHERD_TMP_SWEEP_DIR = prevEnv;
+});
+
+// ── #1875 dual-read migration: reads/uploads follow an adopted session onto the legacy tmpfs ──
+
+/**
+ * Set up disk (primary, via SHEPHERD_TMP_SWEEP_DIR) + legacy (via TMPDIR) roots, run `fn`, and
+ * restore TMPDIR. SHEPHERD_TMP_SWEEP_DIR is restored by the file-level afterEach.
+ */
+async function withDualRoots(
+  fn: (ctx: { diskRoot: string; legacyBase: string; uidn: number }) => Promise<void>,
+): Promise<void> {
+  const prevTmp = process.env.TMPDIR;
+  const diskRoot = realpathSync(mkdtempSync(join(tmpdir(), "shepherd-disk-")));
+  const legacyBase = realpathSync(mkdtempSync(join(tmpdir(), "shepherd-legacy-")));
+  process.env.SHEPHERD_TMP_SWEEP_DIR = diskRoot; // claudeTmpRoot() → disk primary
+  process.env.TMPDIR = legacyBase; // legacyClaudeTmpRoot() → legacyBase/claude-$uid
+  try {
+    await fn({ diskRoot, legacyBase, uidn: process.getuid?.() ?? 1000 });
+  } finally {
+    rmSync(diskRoot, { recursive: true, force: true });
+    rmSync(legacyBase, { recursive: true, force: true });
+    if (prevTmp === undefined) delete process.env.TMPDIR;
+    else process.env.TMPDIR = prevTmp;
+  }
+}
+
+test("dual-read: resolves reads against the legacy tmpfs root when only it exists", async () => {
+  await withDualRoots(async ({ legacyBase, uidn }) => {
+    const wt = "/home/u/Work/legacyproj";
+    const sid = "legacy-sid";
+    const dash = wt.replace(/[/.]/g, "-");
+    const legacyDir = join(legacyBase, `claude-${uidn}`, dash, sid, "scratchpad");
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(join(legacyDir, "hello.txt"), "hi");
+    // The disk primary does NOT exist → list/resolve fall back to the legacy root.
+    const listing = await listScratchpad(wt, sid, "");
+    expect(listing?.entries.map((e) => e.name)).toEqual(["hello.txt"]);
+    const file = await resolveScratchpadFile(wt, sid, "hello.txt");
+    expect(file).toContain(legacyBase);
+    expect(file?.endsWith("hello.txt")).toBe(true);
+    const path = await resolveScratchpadPath(wt, sid, "hello.txt");
+    expect(path?.rootReal).toBe(realpathSync(legacyDir));
+  });
+});
+
+test("upload: targets the session's existing (legacy) root, else creates the disk primary", async () => {
+  await withDualRoots(async ({ diskRoot, legacyBase, uidn }) => {
+    // Adopted session: legacy scratchpad already exists → uploads land there, beside the agent's files.
+    const wt = "/home/u/Work/legacyproj";
+    const sid = "legacy-sid";
+    const dash = wt.replace(/[/.]/g, "-");
+    const legacyDir = join(legacyBase, `claude-${uidn}`, dash, sid, "scratchpad");
+    mkdirSync(legacyDir, { recursive: true });
+    const adopted = await resolveScratchpadUploadDir(wt, sid, "");
+    expect(adopted?.rootReal).toBe(realpathSync(legacyDir));
+
+    // Brand-new session: neither root exists → the disk primary is created on demand.
+    const freshSid = "fresh-sid";
+    const fresh = await resolveScratchpadUploadDir(wt, freshSid, "");
+    expect(fresh?.rootReal).toBe(realpathSync(join(diskRoot, dash, freshSid, "scratchpad")));
+  });
 });
 
 // ── scratchpadHasFiles ──────────────────────────────────────────────────────────

--- a/test/tmp-sweep.test.ts
+++ b/test/tmp-sweep.test.ts
@@ -1,10 +1,11 @@
 import { test, expect, describe, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync, existsSync } from "node:fs";
 import * as fsp from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   worktreeScratchDir,
+  worktreeScratchDirCandidates,
   sweepClaudeTmp,
   removeWorktreeScratch,
   reapFallowCaches,
@@ -13,6 +14,12 @@ import {
   tmpInodeBands,
   TMP_INODE_ERROR_PCT,
   FALLOW_CACHE_PREFIX,
+  agentTmpDir,
+  agentClaudeTmpRoot,
+  legacyClaudeTmpRoot,
+  sessionScratchpadDirCandidates,
+  existingScratchpadDir,
+  scratchpadHasFiles,
 } from "../src/tmp-sweep";
 
 const uid = (): number => process.getuid?.() ?? 1000;
@@ -541,6 +548,154 @@ describe("removeWorktreeScratch", () => {
         },
       }),
     ).resolves.toBeUndefined();
+  });
+
+  test("dual-cleans BOTH the disk and legacy roots (#1875)", async () => {
+    setEnv("SHEPHERD_TMP_SWEEP_DIR", "/disk/root"); // claudeTmpRoot() → disk
+    setEnv("TMPDIR", "/legacy/base"); // legacyClaudeTmpRoot() → /legacy/base/claude-$uid
+    const wt = "/home/u/Work/proj";
+    const calls: string[] = [];
+    await removeWorktreeScratch(wt, {
+      rm: (async (p: string) => {
+        calls.push(String(p));
+      }) as never,
+    });
+    // rm is called once per DEDUPED candidate, in order (disk primary, then legacy tmpfs).
+    expect(calls).toEqual(worktreeScratchDirCandidates(wt));
+    expect(calls.length).toBe(2);
+  });
+
+  test("no-override collapses the two roots to a single rm call", async () => {
+    setEnv("SHEPHERD_TMP_SWEEP_DIR", legacyClaudeTmpRoot()); // claudeTmpRoot() === legacy
+    const calls: string[] = [];
+    await removeWorktreeScratch("/home/u/Work/proj", {
+      rm: (async (p: string) => {
+        calls.push(String(p));
+      }) as never,
+    });
+    expect(calls.length).toBe(1);
+  });
+});
+
+// ── #1875: disk-backed agent TMPDIR geometry + migration helpers ────────────────
+describe("agent tmp dir geometry (#1875)", () => {
+  test("agentTmpDir(): default is ~/.cache/shepherd/tmp", () => {
+    expect(agentTmpDir()).toBe(join(homedir(), ".cache", "shepherd", "tmp"));
+  });
+
+  test("agentTmpDir(): honors an explicit override", () => {
+    setEnv("SHEPHERD_AGENT_TMPDIR", "/custom/disk");
+    expect(agentTmpDir()).toBe("/custom/disk");
+  });
+
+  test("agentTmpDir(): an empty string disables the redirect (null)", () => {
+    setEnv("SHEPHERD_AGENT_TMPDIR", "");
+    expect(agentTmpDir()).toBeNull();
+  });
+
+  test("agentClaudeTmpRoot(): agentTmpDir + claude-$uid, null when disabled", () => {
+    setEnv("SHEPHERD_AGENT_TMPDIR", "/custom/disk");
+    expect(agentClaudeTmpRoot()).toBe(join("/custom/disk", nested));
+    setEnv("SHEPHERD_AGENT_TMPDIR", "");
+    expect(agentClaudeTmpRoot()).toBeNull();
+  });
+
+  test("legacyClaudeTmpRoot(): <tmpdir>/claude-$uid", () => {
+    expect(legacyClaudeTmpRoot()).toBe(join(tmpdir(), nested));
+  });
+
+  test("sessionScratchpadDirCandidates: dedupes to one with no override, two under an override", () => {
+    setEnv("SHEPHERD_TMP_SWEEP_DIR", legacyClaudeTmpRoot()); // primary === legacy
+    expect(sessionScratchpadDirCandidates("/home/u/Work/proj", "sid").length).toBe(1);
+    setEnv("SHEPHERD_TMP_SWEEP_DIR", "/disk/root"); // primary !== legacy
+    expect(sessionScratchpadDirCandidates("/home/u/Work/proj", "sid").length).toBe(2);
+  });
+
+  test("existingScratchpadDir + scratchpadHasFiles: fall back to the legacy tmpfs root", async () => {
+    const diskRoot = mkTmp();
+    const legacyBase = mkTmp();
+    setEnv("SHEPHERD_TMP_SWEEP_DIR", diskRoot); // claudeTmpRoot() → disk (primary, absent)
+    setEnv("TMPDIR", legacyBase); // legacyClaudeTmpRoot() → legacyBase/claude-$uid
+    const wt = "/home/u/Work/proj";
+    const sid = "sess-legacy";
+    const dash = wt.replace(/[/.]/g, "-");
+    const legacyDir = join(legacyBase, nested, dash, sid, "scratchpad");
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(join(legacyDir, "note.txt"), "x");
+    // Only the legacy dir exists → resolver falls back to it, and the Files-tab gate lights.
+    expect(await existingScratchpadDir(wt, sid)).toBe(legacyDir);
+    expect(await scratchpadHasFiles(wt, sid)).toBe(true);
+  });
+
+  test("existingScratchpadDir: prefers the disk root when BOTH exist", async () => {
+    const diskRoot = mkTmp();
+    const legacyBase = mkTmp();
+    setEnv("SHEPHERD_TMP_SWEEP_DIR", diskRoot);
+    setEnv("TMPDIR", legacyBase);
+    const wt = "/home/u/Work/proj";
+    const sid = "sess-both";
+    const dash = wt.replace(/[/.]/g, "-");
+    const primaryDir = join(diskRoot, dash, sid, "scratchpad");
+    const legacyDir = join(legacyBase, nested, dash, sid, "scratchpad");
+    mkdirSync(primaryDir, { recursive: true });
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(join(primaryDir, "b"), "y");
+    writeFileSync(join(legacyDir, "a"), "x");
+    expect(await existingScratchpadDir(wt, sid)).toBe(primaryDir);
+  });
+
+  test("reapFallowCaches: default set reaps a stale fallow cache at the bare agentTmpDir() root", async () => {
+    const agentRoot = mkTmp();
+    const claudeRootDir = mkTmp();
+    const tmpBase = mkTmp(); // empty — keeps the other default roots (+bare /tmp) out of play
+    setEnv("SHEPHERD_AGENT_TMPDIR", agentRoot);
+    setEnv("SHEPHERD_TMP_SWEEP_DIR", claudeRootDir);
+    setEnv("TMPDIR", tmpBase);
+    const dir = join(agentRoot, `${FALLOW_CACHE_PREFIX}bare`);
+    mkdirSync(dir);
+    const now = Date.now();
+    const old = new Date(now - 48 * 3600_000);
+    utimesSync(dir, old, old);
+    // NO `roots` override → exercises the DEFAULT computed set, which must include agentTmpDir().
+    await reapFallowCaches({ now, staleMs: 24 * 3600_000, fsOps: fsp, log: () => {} });
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  test("reapFallowCaches: a DISABLED agent tmp dir is not scanned", async () => {
+    const agentRoot = mkTmp();
+    const claudeRootDir = mkTmp();
+    const tmpBase = mkTmp();
+    setEnv("SHEPHERD_AGENT_TMPDIR", ""); // disabled
+    setEnv("SHEPHERD_TMP_SWEEP_DIR", claudeRootDir);
+    setEnv("TMPDIR", tmpBase);
+    const dir = join(agentRoot, `${FALLOW_CACHE_PREFIX}x`);
+    mkdirSync(dir);
+    const now = Date.now();
+    const old = new Date(now - 48 * 3600_000);
+    utimesSync(dir, old, old);
+    await reapFallowCaches({ now, staleMs: 24 * 3600_000, fsOps: fsp, log: () => {} });
+    expect(existsSync(dir)).toBe(true); // survives — bare agent root not in the default set
+  });
+
+  test("sweepClaudeTmp: the default (forced) path also sweeps the bare agentTmpDir() root", async () => {
+    const agentRoot = mkTmp();
+    const claudeRootDir = mkTmp();
+    const tmpBase = mkTmp();
+    setEnv("SHEPHERD_AGENT_TMPDIR", agentRoot);
+    setEnv("SHEPHERD_TMP_SWEEP_DIR", claudeRootDir);
+    setEnv("TMPDIR", tmpBase);
+    const ncc = join(agentRoot, "node-compile-cache");
+    mkdirSync(ncc);
+    const staleBunx = join(agentRoot, "bunx-1000-x");
+    mkdirSync(staleBunx);
+    const now = Date.now();
+    const old = new Date(now - 48 * 3600_000);
+    utimesSync(staleBunx, old, old);
+    // thresholdPct: 0 forces the sweep (gate bypassed); NO `root` override → default sweepRoots.
+    const res = await sweepClaudeTmp({ thresholdPct: 0, now, fsOps: fsp, log: () => {} });
+    expect(res.swept).toBe(true);
+    expect(existsSync(ncc)).toBe(false); // wholesale, at the bare agent root
+    expect(existsSync(staleBunx)).toBe(false); // stale regenerable cache, at the bare agent root
   });
 });
 


### PR DESCRIPTION
Closes #1875. Follow-up to #1862 — replaces its **advisory** "keep off the tmpfs" directive with a **structural** guarantee for trusted spawns.

## What

`buildWrappedArgv` now points every **trusted** spawned agent at a disk-backed `TMPDIR` (default `~/.cache/shepherd/tmp`, knob `SHEPHERD_AGENT_TMPDIR`, `""` = disable), so agent temp I/O — the per-session scratch tree, worktrees, dependency installs, and bare-`$TMPDIR` tool caches — lands on a real filesystem instead of the `/tmp` tmpfs whose **inode** table it exhausts (ENOSPC with bytes to spare).

## Key facts (empirically probed this session)

- **Claude prefers `CLAUDE_CODE_TMPDIR` over `TMPDIR` and appends its own `claude-$uid` to it** (double-suffix). The server sets its *own* `CLAUDE_CODE_TMPDIR` so `claudeTmpRoot()` follows agents to disk — so the shim **strips the inherited value** (`env -u CLAUDE_CODE_TMPDIR`) and the agent re-derives the *same* root from `TMPDIR` alone. Without the strip, the agent would write to `<disk>/claude-$uid/claude-$uid/…` while the server reads `<disk>/claude-$uid/…`, blanking the Files tab.
- We set `CLAUDE_CODE_TMPDIR`, **not** `TMPDIR`, on the server, so `os.tmpdir()` — and thus `readTmpInodeUsePct()`'s `tmp_inodes` monitor — keeps watching the real tmpfs.
- **Trusted spawns only:** the outer `env` shim is wiped by `bwrap --clearenv` for sandboxed spawns (exactly as `NODE_COMPILE_CACHE` is today); a sandbox's `--tmpfs /tmp` is ephemeral and never threatens the host inode table. The #1862 advisory belt is retained for agents that hardcode `/tmp`.

## Migration (adopted agents keep `TMPDIR=/tmp` across a deploy)

- **dual-read** — scratchpad read/list/upload resolve to the first *existing* of `[disk, legacy tmpfs]` (prefer disk); `scratchpadHasFiles` dual-reads.
- **dual-clean** — `removeWorktreeScratch` reclaims both roots on archival.
- **bare-root coverage** — `reapFallowCaches` + `sweepClaudeTmp` also scan the bare `agentTmpDir()`, where fallow/bunx write at `$TMPDIR` (verified: `mktemp` in a Bash tool lands there), else unbounded disk-inode accretion.

All root sets are **deduped**, so the no-override case is byte-for-byte unchanged.

## Divergence, stated & handled

Post-change `sweepClaudeTmp` gates on the disk root while `tmp_inodes` watches tmpfs. Intended: trusted agents no longer accrete tmpfs inodes, so new pressure stops. Residual tmpfs pressure = pre-existing accumulation (reclaimed by #1874); the one-click **forced** sweep still clears the legacy tmpfs root.

## Test

`bun run lint`, `bunx tsc --noEmit`, full `bun test` (7503 pass), and pre-push (7 lanes incl. fallow audit) all green. New tests: geometry helpers + disable, dual-read fallback / prefer-disk, dual-clean both roots, bare-root reap + sweep, and parity assertions for the `TMPDIR=` / `-u CLAUDE_CODE_TMPDIR` tokens on the unwrapped argv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)