### PR TITLE
feat(tmp): partial pnpm store reclaim (free unlinked content, not all-or-nothing)

### DIFF
--- a/docs-site/src/content/docs/operating.md
+++ b/docs-site/src/content/docs/operating.md
@@ -109,9 +109,14 @@ the real cause.
 
 Its **Fix** button runs the sweep immediately, ignoring the usage threshold. It reclaims
 what Shepherd owns — the compile cache and stale tool caches — so the row can legitimately
-stay non-OK afterwards: a package-manager store or a leftover git worktree that an agent
-put in the temp filesystem is **not** reclaimed yet. Those are the two largest consumers
-when an agent has run a dependency install there, and removing them is tracked separately.
+stay non-OK right after you click it: the two largest consumers when an agent has run a
+dependency install in the temp filesystem — a leftover git worktree and the forked
+package-manager (pnpm) store it pinned — are **not** touched by the on-demand Fix button.
+They are reclaimed by the background sweep that runs at boot and daily: abandoned agent
+worktrees are reaped, then the forked pnpm store is **partially** reclaimed — under inode
+pressure it unlinks the store content nothing still references and prunes the emptied bucket
+dirs, while keeping content a surviving worktree still hardlinks. So a store that is still
+partly pinned frees its unlinked fraction rather than nothing at all.
 
 ## Host tuning — resource guardrails
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -844,12 +844,13 @@ const fireTmpSweep = (phase: "boot" | "daily") => {
     })
     .catch((err) => console.warn(`[tmp-sweep] ${phase} orphan reap failed:`, err));
 
-  // #1874: reclaim abandoned agent worktrees under /tmp, THEN the forked pnpm store they
-  // pinned. Order is load-bearing — while a tmp worktree survives, every store file sits at
-  // nlink=2, so removing the store first reclaims ~zero and the next install re-forks it.
-  // The reaper's `retained` count is the store pass's go/no-go gate. A single microtask-
-  // deferred liveProcCwds() snapshot keeps that synchronous /proc scan off the event loop
-  // and out of the all-async tmp-sweep module.
+  // #1874/#1880: reap abandoned agent worktrees under /tmp, THEN partially reclaim the forked
+  // pnpm store they pinned. Order is load-bearing — reaping a truly-abandoned worktree drops the
+  // store files it linked from nlink=2 to nlink=1, making them reclaimable by the store pass.
+  // Partial reclaim (#1880) frees the nlink=1 fraction regardless of `retained`: a surviving
+  // worktree's still-linked (nlink>1) content is kept, not a blocker. A single microtask-
+  // deferred liveProcCwds() snapshot keeps that synchronous /proc scan off the event loop and
+  // out of the all-async tmp-sweep module.
   void Promise.resolve()
     .then(async () => {
       const liveWorktreePaths = store
@@ -861,10 +862,11 @@ const fireTmpSweep = (phase: "boot" | "daily") => {
         liveWorktreePaths,
         liveCwds: liveProcCwds(),
       });
-      const storeResult = await reclaimForkedPnpmStore({ retained: reap.retained });
+      const storeResult = await reclaimForkedPnpmStore({});
       console.warn(
         `[tmp-sweep] ${phase}: worktree reap removed ${reap.reaped} (retained ${reap.retained}), ` +
-          `pnpm store ${storeResult.removed ? "reclaimed" : `kept (${storeResult.reason})`}`,
+          `pnpm store freed ${storeResult.freedFiles} file(s)/${storeResult.freedDirs} dir(s) ` +
+          `(${storeResult.reason})`,
       );
     })
     .catch((err) => console.warn(`[tmp-sweep] ${phase} worktree/store reclaim failed:`, err));

--- a/src/tmp-sweep.ts
+++ b/src/tmp-sweep.ts
@@ -226,6 +226,8 @@ interface FsOps {
   readdir: typeof fsp.readdir;
   stat: typeof fsp.stat;
   rm: typeof fsp.rm;
+  unlink: typeof fsp.unlink;
+  rmdir: typeof fsp.rmdir;
 }
 
 interface SweepOpts {
@@ -486,6 +488,8 @@ export async function sweepClaudeTmp(opts?: SweepOpts): Promise<SweepResult> {
       readdir: fsp.readdir,
       stat: fsp.stat,
       rm: fsp.rm,
+      unlink: fsp.unlink,
+      rmdir: fsp.rmdir,
     };
 
     // FORCED sweep (#1862): `thresholdPct <= 0` means "sweep unconditionally" — the operator's
@@ -1018,15 +1022,21 @@ export async function reapAbandonedWorktrees(
 // ── forked pnpm store reclaimer ─────────────────────────────────────────────
 //
 // pnpm forks a content-addressable store onto the tmpfs (`<tmp>/.pnpm-store/v<N>/`) to
-// stay same-filesystem for hardlinking. Once every worktree that linked it is gone, the
-// store is dead weight pinning inodes. Removal is ALL-OR-NOTHING (skip the whole store if
-// ANY file still has `nlink > 1`): measured, pnpm re-fetches cleanly online after content
-// is deleted, but partial reclaim is deferred (see the issue's follow-up). Every
-// non-exhaustive outcome resolves to KEEP — `removed:false` means *provably idle*, never
-// *failed to probe*.
+// stay same-filesystem for hardlinking. Store content lingers pinning inodes long after the
+// worktrees that linked it are gone. Reclaim is PARTIAL (#1880): under each idle version dir,
+// unlink only the `nlink === 1` content (nothing else references it) and prune the bucket dirs
+// that empty out, leaving still-linked (`nlink > 1`) content and the `index/` metadata intact.
+// `index/` pointing at removed content is a clean re-fetch trigger, not a hard error — measured
+// on pnpm 10.28.2: offline reinstall reports `ERR_PNPM_NO_OFFLINE_TARBALL` (it *wants* to
+// download), online reinstall re-fetches cleanly. So partial reclaim is safe GIVEN NETWORK AT
+// REINSTALL TIME. This supersedes #1874's all-or-nothing removal: the residual case where some
+// content is still hardlinked (a surviving worktree, an orphaned `node_modules`) — where
+// all-or-nothing freed ZERO — now frees the unlinked fraction. Every unprobable subtree or
+// per-entry error resolves to KEEP: we only ever remove content we positively proved is
+// `nlink === 1`, never on a failure-to-probe.
 
-/** The `/^v\d+$/` version subdirs of a store root. Shared by both probes: an empty result
- *  makes the caller skip (an unrecognized layout is never removed) — the harmless direction. */
+/** The `/^v\d+$/` version subdirs of a store root. An empty result makes the caller skip (an
+ *  unrecognized layout is never touched) — the harmless direction. */
 export function resolveStoreVersionDirs(rootEntries: Dirent[]): string[] {
   return rootEntries.filter((e) => e.isDirectory() && /^v\d+$/.test(e.name)).map((e) => e.name);
 }
@@ -1074,54 +1084,98 @@ async function storeVersionDirIsIdle(
   }
 }
 
-/**
- * `true` when the version dir's `files/` tree still holds a hardlink (some `nlink > 1`) OR
- * could not be exhaustively probed (missing `files/`, any readdir/stat error) — i.e. NOT
- * safe to remove. `false` only after a full walk proves every content file is `nlink === 1`.
- * Exhaustive with early exit on the first surviving link: the dangerous case is the cheap
- * one, and the full walk only completes when we are about to `rm -rf` these files anyway.
- */
-async function storeVersionDirHasLinks(
-  filesDir: string,
-  stat: FsOps["stat"],
-  readdir: FsOps["readdir"],
+/** Running tally of a partial reclaim: content files unlinked + bucket dirs pruned. */
+interface ReclaimCounters {
+  freedFiles: number;
+  freedDirs: number;
+}
+type ContentOps = Pick<FsOps, "readdir" | "stat" | "unlink" | "rmdir">;
+
+/** Reclaim a subdir, then prune it if it emptied out. `true` iff it was pruned (`rmdir` ok). */
+async function reclaimAndPruneSubdir(
+  p: string,
+  ops: ContentOps,
+  c: ReclaimCounters,
 ): Promise<boolean> {
-  const stack: string[] = [filesDir];
+  if (!(await reclaimContentDir(p, ops, c))) return false; // still holds linked/unprobable content
   try {
-    while (stack.length > 0) {
-      const dir = stack.pop() as string;
-      const entries = (await readdir(dir, { withFileTypes: true })) as Dirent[];
-      for (const ent of entries) {
-        const p = join(dir, ent.name);
-        if (ent.isDirectory()) {
-          stack.push(p);
-          continue;
-        }
-        if (Number((await stat(p)).nlink) > 1) return true; // a link survives — early exit
-      }
-    }
-    return false; // fully walked, every file nlink === 1
+    await ops.rmdir(p);
+    c.freedDirs += 1;
+    return true;
   } catch {
-    return true; // missing files/ or any error → not provably unlinked → keep
+    return false; // rmdir raced/failed → keep
   }
+}
+
+/** Unlink a content file iff it is provably `nlink === 1`. `true` iff it was unlinked. Any
+ *  stat/unlink error or a surviving reference (`nlink > 1`) leaves it in place → `false`. */
+async function unlinkIfUnlinked(p: string, ops: ContentOps, c: ReclaimCounters): Promise<boolean> {
+  let nlink: number;
+  try {
+    nlink = Number((await ops.stat(p)).nlink);
+  } catch {
+    return false; // unstattable → keep
+  }
+  if (nlink > 1) return false; // another reference survives → keep
+  try {
+    await ops.unlink(p);
+    c.freedFiles += 1;
+    return true;
+  } catch {
+    return false; // unlink failed → keep
+  }
+}
+
+/**
+ * Recursive post-order reclaim of one content dir: unlink every file that is provably
+ * `nlink === 1` (no other reference), recurse into subdirs and `rmdir` any that empty out, and
+ * leave still-linked (`nlink > 1`) files in place. NEVER throws — an unreadable dir or a
+ * per-entry stat/unlink/rmdir error just leaves that entry standing (counted as remaining), so
+ * we only ever remove content we positively proved is unlinked. Returns `true` iff `dir` has
+ * ZERO remaining entries after the pass (so the caller can prune it). Exhaustive, unbudgeted:
+ * the full walk is the point, and it runs microtask-deferred off the event loop.
+ */
+async function reclaimContentDir(
+  dir: string,
+  ops: ContentOps,
+  c: ReclaimCounters,
+): Promise<boolean> {
+  let entries: Dirent[];
+  try {
+    entries = (await ops.readdir(dir, { withFileTypes: true })) as Dirent[];
+  } catch {
+    return false; // unprobable subtree → keep, treat as non-empty
+  }
+  let remaining = 0;
+  for (const ent of entries) {
+    const p = join(dir, ent.name);
+    const reclaimed = ent.isDirectory()
+      ? await reclaimAndPruneSubdir(p, ops, c)
+      : await unlinkIfUnlinked(p, ops, c);
+    if (!reclaimed) remaining += 1;
+  }
+  return remaining === 0;
 }
 
 export interface ReclaimStoreOpts {
   /** The forked store root. Default `<tmpdir>/.pnpm-store` — the only name allowed to reach
    *  bare `tmpdir()`. A wrong mount root just yields a missing dir → safe skip. */
   storeRoot?: string;
-  /** Worktree candidates still on disk (from `reapAbandonedWorktrees`). > 0 ⇒ skip. */
-  retained: number;
   thresholdPct?: number;
   staleMs?: number;
   now?: number;
   statfs?: FsOps["statfs"];
-  fsOps?: Pick<FsOps, "readdir" | "stat" | "rm">;
+  fsOps?: Pick<FsOps, "readdir" | "stat" | "unlink" | "rmdir">;
   log?: (msg: string) => void;
 }
 
 export interface ReclaimStoreResult {
-  removed: boolean;
+  /** Content files unlinked (`nlink === 1`) across all idle version dirs. */
+  freedFiles: number;
+  /** Bucket dirs pruned after emptying out. */
+  freedDirs: number;
+  /** A whole-store skip reason (`below-threshold …`, `no-store`, `sibling-fresh …`, …), or
+   *  `reclaimed` when the per-file pass ran (freed counts carry the detail). */
   reason: string;
 }
 
@@ -1147,67 +1201,75 @@ async function siblingBlocker(
   return null;
 }
 
-/** A skip reason for any version dir that is not depth-2-idle or not fully unlinked — else `null`. */
-async function versionDirBlocker(
+/** Partial-reclaim every depth-2-idle version dir's `files/` tree into `c`; a busy dir is
+ *  skipped (logged), never touched. `index/` metadata is left intact as a re-fetch trigger. */
+async function reclaimIdleVersionDirs(
   storeRoot: string,
   versionDirs: string[],
   cutoff: number,
-  readdir: FsOps["readdir"],
-  stat: FsOps["stat"],
-): Promise<string | null> {
+  ops: ContentOps,
+  c: ReclaimCounters,
+  log: (msg: string) => void,
+): Promise<void> {
   for (const v of versionDirs) {
     const vdir = join(storeRoot, v);
-    if (!(await storeVersionDirIsIdle(vdir, cutoff, readdir, stat))) return `store-busy ${v}`;
-    if (await storeVersionDirHasLinks(join(vdir, "files"), stat, readdir))
-      return `store-linked-or-unprobed ${v}`;
+    if (!(await storeVersionDirIsIdle(vdir, cutoff, ops.readdir, ops.stat))) {
+      log(`[tmp-sweep] store reclaim: skip busy version dir ${v}`);
+      continue;
+    }
+    await reclaimContentDir(join(vdir, "files"), ops, c);
   }
-  return null;
 }
 
 /**
- * All-or-nothing reclaim of the forked pnpm store. TOTAL by contract — never throws. Removes
- * `<storeRoot>` only when: `retained === 0`, inode pressure >= threshold, the layout is a
- * recognized `v<N>` store, no non-`v*` sibling is fresh or an unrecognized dir, and EVERY
- * version dir is depth-2-idle AND fully unlinked. Any other outcome is a keep with a reason.
+ * Partial reclaim of the forked pnpm store. TOTAL by contract — never throws. Under sustained
+ * inode pressure, for each depth-2-idle version dir it unlinks the `nlink === 1` content in
+ * `files/`, prunes the bucket dirs that empty out, and leaves still-linked content, `index/`,
+ * and the store root intact. WHOLE-STORE skip gates (return freed 0): inode pressure below
+ * threshold, an unreadable / non-`v<N>` store, or a fresh / unrecognized non-`v*` sibling
+ * (active install → touch nothing). A NON-idle version dir is skipped per-dir (logged), so an
+ * idle sibling version dir is still reclaimed. Unlike #1874's all-or-nothing removal, a
+ * surviving hardlink no longer blocks the reclaim — the linked file is simply kept. The caller
+ * runs the worktree reaper FIRST so a truly-abandoned worktree's links drop to `nlink === 1`
+ * before this pass. Safe GIVEN NETWORK AT REINSTALL TIME (see module header).
  */
 export async function reclaimForkedPnpmStore(opts: ReclaimStoreOpts): Promise<ReclaimStoreResult> {
   const log = opts.log ?? console.warn;
+  const c: ReclaimCounters = { freedFiles: 0, freedDirs: 0 };
   try {
     const storeRoot = opts.storeRoot ?? join(tmpdir(), ".pnpm-store");
     const { cutoff, thresholdPct } = resolveTmpGate(opts);
     const readdir = opts.fsOps?.readdir ?? fsp.readdir;
     const stat = opts.fsOps?.stat ?? fsp.stat;
-    const rm = opts.fsOps?.rm ?? fsp.rm;
+    const unlink = opts.fsOps?.unlink ?? fsp.unlink;
+    const rmdir = opts.fsOps?.rmdir ?? fsp.rmdir;
     const statfs = opts.statfs ?? fsp.statfs;
 
-    if (opts.retained > 0) return { removed: false, reason: `retained-worktrees ${opts.retained}` };
-
     const usePct = await inodeUsePct(tmpdir(), statfs, log);
-    if (typeof usePct === "string") return { removed: false, reason: usePct };
+    if (typeof usePct === "string") return { ...c, reason: usePct };
     if (usePct < thresholdPct) {
-      return { removed: false, reason: `below-threshold ${usePct.toFixed(1)}%` };
+      return { ...c, reason: `below-threshold ${usePct.toFixed(1)}%` };
     }
 
     let rootEntries: Dirent[];
     try {
       rootEntries = (await readdir(storeRoot, { withFileTypes: true })) as Dirent[];
     } catch {
-      return { removed: false, reason: "no-store" };
+      return { ...c, reason: "no-store" };
     }
 
     const versionDirs = resolveStoreVersionDirs(rootEntries);
-    if (versionDirs.length === 0) return { removed: false, reason: "no-version-dir" };
+    if (versionDirs.length === 0) return { ...c, reason: "no-version-dir" };
 
-    const blocker =
-      (await siblingBlocker(rootEntries, storeRoot, cutoff, stat)) ??
-      (await versionDirBlocker(storeRoot, versionDirs, cutoff, readdir, stat));
-    if (blocker) return { removed: false, reason: blocker };
+    const sibling = await siblingBlocker(rootEntries, storeRoot, cutoff, stat);
+    if (sibling) return { ...c, reason: sibling };
 
-    await rm(storeRoot, { recursive: true, force: true });
-    return { removed: true, reason: `reclaimed ${storeRoot}` };
+    const contentOps: ContentOps = { readdir, stat, unlink, rmdir };
+    await reclaimIdleVersionDirs(storeRoot, versionDirs, cutoff, contentOps, c, log);
+    return { ...c, reason: "reclaimed" };
   } catch (err) {
     log(`[tmp-sweep] store reclaim unexpected error: ${String(err)}`);
-    return { removed: false, reason: "error" };
+    return { ...c, reason: "error" };
   }
 }
 

--- a/test/tmp-sweep.test.ts
+++ b/test/tmp-sweep.test.ts
@@ -1156,7 +1156,10 @@ describe("reclaimForkedPnpmStore", () => {
   const NOW = 1_700_000_000_000;
   const ROOT = "/tmp/.pnpm-store";
 
-  // A removable store: v10 with files/ + index/, all stale, every content file nlink 1.
+  // A reclaimable store: v10 with files/ (one bucket, one content file) + index/, all stale,
+  // every content file nlink 1. The harness fakes fs entirely in memory — `unlink`/`rmdir`
+  // just record paths; emptiness is derived by reclaimContentDir from the per-entry pass, so
+  // the recorded paths (not a mutated tree) are what the assertions read.
   function storeHarness() {
     const R: Record<string, Dirent[]> = {
       [ROOT]: [dirent("v10", true)],
@@ -1167,10 +1170,11 @@ describe("reclaimForkedPnpmStore", () => {
     };
     const mtimes: Record<string, number> = {};
     const nlinks: Record<string, number> = {};
-    const removed: string[] = [];
+    const unlinked: string[] = [];
+    const rmdirs: string[] = [];
+    const unlinkErrors = new Set<string>();
     const opts = {
       storeRoot: ROOT,
-      retained: 0,
       now: NOW,
       statfs: fakeStatfs(1000, 100), // 90% ≥ 80
       fsOps: {
@@ -1184,35 +1188,52 @@ describe("reclaimForkedPnpmStore", () => {
             mtimeMs: mtimes[String(p)] ?? 0,
             nlink: nlinks[String(p)] ?? 1,
           }) as unknown as Awaited<ReturnType<typeof fsp.stat>>,
-        rm: async (p: string) => {
-          removed.push(String(p));
+        unlink: async (p: string) => {
+          if (unlinkErrors.has(String(p))) throw new Error("EACCES " + p);
+          unlinked.push(String(p));
+        },
+        rmdir: async (p: string) => {
+          rmdirs.push(String(p));
         },
       },
       log: () => {},
     };
-    return { opts, R, mtimes, nlinks, removed };
+    return { opts, R, mtimes, nlinks, unlinked, rmdirs, unlinkErrors };
   }
 
-  test("fully idle + unlinked → removes the whole store root", async () => {
-    const { opts, removed } = storeHarness();
+  test("fully idle + unlinked → frees every file, prunes the bucket, leaves index/", async () => {
+    const { opts, unlinked, rmdirs } = storeHarness();
     const r = await reclaimForkedPnpmStore(opts as never);
-    expect(r.removed).toBe(true);
-    expect(removed).toEqual([ROOT]);
+    expect(r.reason).toBe("reclaimed");
+    expect(r.freedFiles).toBe(1);
+    expect(r.freedDirs).toBe(1);
+    expect(unlinked).toEqual([`${ROOT}/v10/files/9f/abc`]);
+    expect(rmdirs).toEqual([`${ROOT}/v10/files/9f`]); // emptied bucket pruned
+    // index/ metadata and the files/ dir itself are never touched.
+    expect(unlinked).not.toContain(`${ROOT}/v10/index/meta`);
+    expect(rmdirs).not.toContain(`${ROOT}/v10/files`);
   });
 
-  test("retained > 0 → skip", async () => {
-    const { opts, removed } = storeHarness();
-    opts.retained = 1;
+  test("retained worktrees no longer gate: the pass still frees the unlinked fraction", async () => {
+    // #1880 relaxed the retained skip — a linked (nlink>1) file is kept, an unlinked sibling freed.
+    const { opts, R, nlinks, unlinked, rmdirs } = storeHarness();
+    R[`${ROOT}/v10/files/9f`] = [dirent("abc", false), dirent("def", false)];
+    nlinks[`${ROOT}/v10/files/9f/abc`] = 2; // still linked by a surviving worktree → keep
     const r = await reclaimForkedPnpmStore(opts as never);
-    expect(r.removed).toBe(false);
-    expect(r.reason).toContain("retained");
-    expect(removed).toEqual([]);
+    expect(r.reason).toBe("reclaimed");
+    expect(r.freedFiles).toBe(1);
+    expect(unlinked).toEqual([`${ROOT}/v10/files/9f/def`]); // only the nlink===1 file
+    expect(r.freedDirs).toBe(0);
+    expect(rmdirs).toEqual([]); // bucket still holds the linked file → not pruned
   });
 
-  test("inode pressure below threshold → skip", async () => {
-    const { opts } = storeHarness();
+  test("inode pressure below threshold → skip, nothing freed", async () => {
+    const { opts, unlinked } = storeHarness();
     opts.statfs = fakeStatfs(1000, 900); // 10%
-    expect((await reclaimForkedPnpmStore(opts as never)).removed).toBe(false);
+    const r = await reclaimForkedPnpmStore(opts as never);
+    expect(r.reason).toContain("below-threshold");
+    expect(r.freedFiles).toBe(0);
+    expect(unlinked).toEqual([]);
   });
 
   test("missing store dir → no-store", async () => {
@@ -1220,7 +1241,9 @@ describe("reclaimForkedPnpmStore", () => {
     opts.fsOps.readdir = async () => {
       throw new Error("ENOENT");
     };
-    expect((await reclaimForkedPnpmStore(opts as never)).reason).toBe("no-store");
+    const r = await reclaimForkedPnpmStore(opts as never);
+    expect(r.reason).toBe("no-store");
+    expect(r.freedFiles).toBe(0);
   });
 
   test("no v* dir → no-version-dir", async () => {
@@ -1229,46 +1252,66 @@ describe("reclaimForkedPnpmStore", () => {
     expect((await reclaimForkedPnpmStore(opts as never)).reason).toBe("no-version-dir");
   });
 
-  test("fresh non-v* sibling → skip", async () => {
-    const { opts, R, mtimes } = storeHarness();
+  test("fresh non-v* sibling → whole-store skip", async () => {
+    const { opts, R, mtimes, unlinked } = storeHarness();
     R[ROOT] = [dirent("v10", true), dirent("staging.lock", false)];
     mtimes[`${ROOT}/staging.lock`] = NOW; // fresh
     const r = await reclaimForkedPnpmStore(opts as never);
-    expect(r.removed).toBe(false);
     expect(r.reason).toContain("sibling-fresh");
+    expect(unlinked).toEqual([]);
   });
 
-  test("stale but unrecognized non-v* directory sibling → skip", async () => {
-    const { opts, R } = storeHarness();
+  test("stale but unrecognized non-v* directory sibling → whole-store skip", async () => {
+    const { opts, R, unlinked } = storeHarness();
     R[ROOT] = [dirent("v10", true), dirent("staging", true)]; // stale dir, unknown
     const r = await reclaimForkedPnpmStore(opts as never);
-    expect(r.removed).toBe(false);
     expect(r.reason).toContain("sibling-unrecognized");
+    expect(unlinked).toEqual([]);
   });
 
-  test("a depth-2 entry with a recent mtime → store-busy (idleness probes at depth 2)", async () => {
-    const { opts, mtimes } = storeHarness();
+  test("a busy version dir (recent depth-2 mtime) is skipped per-dir, nothing freed", async () => {
+    const { opts, mtimes, unlinked } = storeHarness();
     mtimes[`${ROOT}/v10/files/9f`] = NOW; // a bucket (depth 2) touched recently
     const r = await reclaimForkedPnpmStore(opts as never);
-    expect(r.removed).toBe(false);
-    expect(r.reason).toContain("store-busy");
+    expect(r.reason).toBe("reclaimed"); // pass ran; the busy dir was just skipped
+    expect(r.freedFiles).toBe(0);
+    expect(unlinked).toEqual([]);
   });
 
-  test("any file with nlink > 1 → store-linked (skip)", async () => {
-    const { opts, nlinks } = storeHarness();
-    nlinks[`${ROOT}/v10/files/9f/abc`] = 2; // a worktree still links it
+  test("busy version dir skipped, idle sibling version dir still reclaimed", async () => {
+    const { opts, R, mtimes, unlinked } = storeHarness();
+    R[ROOT] = [dirent("v10", true), dirent("v11", true)];
+    R[`${ROOT}/v11`] = [dirent("files", true), dirent("index", true)];
+    R[`${ROOT}/v11/files`] = [dirent("aa", true)];
+    R[`${ROOT}/v11/files/aa`] = [dirent("xyz", false)];
+    R[`${ROOT}/v11/index`] = [dirent("meta", false)];
+    mtimes[`${ROOT}/v10/files/9f`] = NOW; // v10 busy → skipped
     const r = await reclaimForkedPnpmStore(opts as never);
-    expect(r.removed).toBe(false);
-    expect(r.reason).toContain("store-linked");
+    expect(r.freedFiles).toBe(1);
+    expect(unlinked).toEqual([`${ROOT}/v11/files/aa/xyz`]); // only the idle dir reclaimed
   });
 
-  test("a bucket unreadable during the nlink walk → keep (not provably unlinked)", async () => {
-    // Idleness passes (depth-2 only stats the bucket dir), but the exhaustive nlink walk must
-    // descend into it — a readdir error there resolves to keep, never a removal.
-    const { opts, R } = storeHarness();
-    delete R[`${ROOT}/v10/files/9f`]; // readdir(bucket) throws inside storeVersionDirHasLinks
+  test("a bucket unreadable during the walk → kept (not provably unlinked), no throw", async () => {
+    // Idleness passes (depth-2 only stats the bucket dir), but the reclaim walk must descend
+    // into it — a readdir error there leaves the bucket standing, never an unlink/prune.
+    const { opts, R, unlinked, rmdirs } = storeHarness();
+    delete R[`${ROOT}/v10/files/9f`]; // readdir(bucket) throws inside reclaimContentDir
     const r = await reclaimForkedPnpmStore(opts as never);
-    expect(r.removed).toBe(false);
-    expect(r.reason).toContain("store-linked-or-unprobed");
+    expect(r.reason).toBe("reclaimed");
+    expect(r.freedFiles).toBe(0);
+    expect(unlinked).toEqual([]);
+    expect(rmdirs).toEqual([]); // bucket not pruned
+  });
+
+  test("an unlink error leaves that file and its bucket in place, others still freed", async () => {
+    const { opts, R, unlinked, rmdirs, unlinkErrors } = storeHarness();
+    R[`${ROOT}/v10/files/9f`] = [dirent("abc", false), dirent("def", false)];
+    unlinkErrors.add(`${ROOT}/v10/files/9f/def`); // unlink throws for def
+    const r = await reclaimForkedPnpmStore(opts as never);
+    expect(r.reason).toBe("reclaimed");
+    expect(r.freedFiles).toBe(1);
+    expect(unlinked).toEqual([`${ROOT}/v10/files/9f/abc`]); // abc freed, def kept
+    expect(r.freedDirs).toBe(0);
+    expect(rmdirs).toEqual([]); // def remains → bucket not pruned
   });
 });


### PR DESCRIPTION
Follow-up to #1874. Replaces the **all-or-nothing** forked-pnpm-store reclaimer in `src/tmp-sweep.ts` with a **per-file partial reclaim**.

## What changed

For each depth-2-idle `v<N>` version dir, the reclaimer now walks `files/**`, **unlinks only `nlink === 1` content** (nothing else references it), prunes the bucket dirs that empty out, and **leaves still-linked (`nlink > 1`) content and `index/` intact**. This frees the unlinked fraction in the residual case — a surviving worktree or an orphaned `node_modules` still hardlinks *some* store files — where all-or-nothing reclaimed **zero**.

- **Dropped the `retained` skip gate.** Link survival is now handled per-file, so a surviving worktree no longer blocks the reclaim (its linked files are simply kept). The worktree reaper still runs **first** in `src/index.ts` so a truly-abandoned worktree's links drop to `nlink === 1` before this pass. `retained` is removed from `ReclaimStoreOpts`.
- **Per-dir idleness.** A non-idle version dir is skipped per-dir (logged), not a whole-store bail — an idle sibling version dir is still reclaimed.
- **Kept gates:** inode-pressure threshold, unreadable / non-`v<N>` store, and fresh / unrecognized non-`v*` sibling (active install → touch nothing) all still short-circuit the whole pass.
- **Result shape** → `{ freedFiles, freedDirs, reason }` (dropped `removed: boolean` — the store root now always persists via `index/`); `src/index.ts` log reports freed counts.

## Safety

`index/` metadata pointing at removed content is a **clean re-fetch trigger, not a hard error** — measured on pnpm 10.28.2 (issue Phase-0): offline reinstall reports `ERR_PNPM_NO_OFFLINE_TARBALL` (it *wants* to download), online reinstall re-fetches cleanly. Partial reclaim is therefore safe **given network at reinstall time**, and only ever removes content positively proved `nlink === 1` — every unprobable subtree or per-entry error resolves to KEEP. TOTAL by contract (never throws).

## Testing

- `bun run typecheck`, `bun run lint`, `bun test ./test` (7537 pass / 0 fail), `fallow audit` — all green.
- Rewrote/extended the `reclaimForkedPnpmStore` test harness (in-memory fs fakes injecting `unlink`/`rmdir`): full-idle prune + `index/` untouched, partial (nlink mix), relaxed-retained, per-dir busy-skip, idle-sibling-still-reclaimed, unreadable-bucket, and unlink-error cases.

Closes #1880. Refs #1874.

🤖 Generated with [Claude Code](https://claude.com/claude-code)