### PR TITLE
docs: sync docs to recent source changes

### DIFF
--- a/docs-site/src/content/docs/operating.md
+++ b/docs-site/src/content/docs/operating.md
@@ -95,7 +95,10 @@ live session's scratch). As a host-level belt on long-uptime hosts, raise `/tmp`
 tmpfs /tmp tmpfs nr_inodes=4194304 0 0
 ```
 
-The relevant override env vars (`SHEPHERD_NODE_COMPILE_CACHE`,
+Shepherd also points spawned (trusted) agents' `TMPDIR` at a disk-backed dir
+(`~/.cache/shepherd/tmp` by default) so their temp I/O — scratch trees, git
+worktrees, and dependency installs — stays off the tmpfs entirely. The relevant
+override env vars (`SHEPHERD_NODE_COMPILE_CACHE`, `SHEPHERD_AGENT_TMPDIR`,
 `SHEPHERD_TMP_INODE_PCT`, `SHEPHERD_TMP_STALE_HOURS`, `SHEPHERD_TMP_SWEEP_DIR`) are
 listed in [Configuration](/reference/configuration/).
 

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -53,6 +53,7 @@ lines), read by the systemd unit if present.
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `SHEPHERD_NODE_COMPILE_CACHE` | _(disk dir)_ | Node compile-cache dir (kept off the `/tmp` tmpfs) |
+| `SHEPHERD_AGENT_TMPDIR` | `~/.cache/shepherd/tmp` | Disk-backed `TMPDIR` that spawned (trusted) agents are pointed at ([#1875](https://github.com/erwins-enkel/shepherd/issues/1875)), so all their temp I/O — per-session scratch, git worktrees, dependency installs, and bare-`$TMPDIR` tool caches — lands on a real filesystem instead of the `/tmp` tmpfs whose inode table it otherwise exhausts. Set to the **empty string** to disable the redirect and restore the pre-`#1875` tmpfs inheritance (a one-var rollback); a non-empty value overrides the default path |
 | `SHEPHERD_TMP_INODE_PCT` | `80` | Inode-sweep threshold (% of `/tmp` inodes) — also the warning band of the **Temp filesystem inodes** Diagnose row (row bands stay ordered: >95 raises the error band too; outside `(0, 100]` the row falls back to 80, the sweep still honours it) |
 | `SHEPHERD_TMP_STALE_HOURS` | `24` | Scratch staleness cutoff |
 | `SHEPHERD_TMP_SWEEP_DIR` | _(default tmp root)_ | Override the swept tmp root |


### PR DESCRIPTION
Automated, **grounded** documentation update proposed by Shepherd's PR-gated doc agent.

Each change below cites the source it was grounded in; items the agent was unsure about are
flagged for human judgment. **This PR is for review only — it is never auto-merged.**

---

# Doc update summary

## Changes

- **`docs-site/src/content/docs/reference/configuration.md`** — Added a
  `SHEPHERD_AGENT_TMPDIR` row to the **Host tuning (tmpfs inodes)** table. This
  operator-facing env var was introduced in #1875 / #1882 ("point trusted agents at
  a disk-backed TMPDIR") and defined in `src/tmp-sweep.ts` (`agentTmpDir()`, lines
  71–86), wired at boot in `src/index.ts:817-819` and consumed by `src/herdr.ts:387+`,
  but was undocumented. Default `~/.cache/shepherd/tmp`; empty string disables the
  redirect (one-var rollback to the pre-#1875 tmpfs inheritance); a non-empty value
  overrides the path — all per the source doc comments.

- **`docs-site/src/content/docs/operating.md`** — The "Host tuning — tmpfs inodes"
  section enumerated the tmp override env vars but omitted `SHEPHERD_AGENT_TMPDIR`.
  Added a sentence describing the disk-backed agent `TMPDIR` redirect and added the
  var to the enumerated override list, matching `src/tmp-sweep.ts` `agentTmpDir()`.
  Grounded in the same #1875 / #1882 change.

## Uncertain / needs human judgment

- **`docs/sandbox-security.md` line-number citations are drifting.** Several
  `src/…:NNN` references have moved since they were written: the doc cites
  `willEgressConfine` "applied at `src/service.ts:1879`" but the call site is now
  ~`src/service.ts:1975`; `RESEARCH_PROCEED_STEER` is cited at `src/autopilot.ts:42-47`
  / dispatched at `L335` but is now defined at `:44` and dispatched at `:356`; and the
  cited `researchSafeProfileOverride` (`~src/service.ts:2708`) no longer resolves by
  that name (the research→standard downgrade logic appears to have been refactored,
  cf. `epicAuthoring`/`nonCodeMode` handling around `src/service.ts:1439`). The
  `sandbox.ts` refs I spot-checked (`--clearenv` at 564, `egressApplies` at 682,
  `willEgressConfine` at 693-698) are still accurate, and the substantive posture
  (egress hosts, profiles, accepted residuals) matches source. I did **not** rewrite
  the drifted line numbers — pinning them precisely (and confirming the current name
  of the research-downgrade path) needs a human pass; guessing risks introducing worse
  references than the slightly-stale ones.

- **`docs-site/.../reference/configuration.md` does not enumerate every env var** in
  `src/config.ts` (e.g. `SHEPHERD_DEFAULT_MODEL`, `SHEPHERD_DEFAULT_CODEX_MODEL`,
  `SHEPHERD_AUTH_MODE`, the per-role `*_CLI` / `*_MODEL` / `*_EFFORT` families). These
  are UI-configurable settings that the page appears to intentionally omit (it notes
  DB/UI-configurable toggles live outside env), so this is a long-standing scope choice
  rather than a regression from a recent change — left unchanged.

- **`docs/token-usage-analysis.md`** is a point-in-time analysis report. Its pricing
  weights (Opus 5/25, Sonnet 3/15, Haiku 1/5, Fable 10/50, cache 0.1×/1.25×/2×) still
  match `src/pricing.ts`, so nothing was edited; the per-task figures are a historical
  snapshot and should not be mechanically updated.