### PR TITLE
feat(herdr): spawn on herdr 0.7.5 via the cli external-registration path

### DIFF
--- a/docs-site/src/content/docs/getting-started.md
+++ b/docs-site/src/content/docs/getting-started.md
@@ -108,10 +108,14 @@ Open <http://localhost:7330>. To expose it (e.g. via Tailscale), set
 - [Bun](https://bun.sh) — backend runtime + package manager
 - `herdr` on `PATH` — [Can Celik](https://github.com/ogulcancelik)'s agent
   multiplexer ([herdr.dev](https://herdr.dev)); manages the interactive `claude`
-  panes (owns the PTYs). **Pin to herdr 0.7.4 — do not upgrade to 0.7.5+ yet.**
-  herdr 0.7.5 reshaped `agent start`, and Shepherd cannot spawn agents on it
-  (spawning fails); Shepherd warns at startup and blocks the in-app updater until
-  [issue #1889](https://github.com/erwins-enkel/shepherd/issues/1889) ships a fix.
+  panes (owns the PTYs). **Pin to herdr 0.7.4 or 0.7.5 — do not upgrade past
+  0.7.5 yet.** herdr 0.7.5 (protocol 17) reshaped `agent start`, so Shepherd now
+  spawns on it through a CLI external-registration path (`tab create` →
+  `pane run` → `report-agent`) rather than the legacy `agent start`. 0.7.4 still
+  remains the last *supported* version, though: on 0.7.5 Shepherd continues to
+  warn at startup and blocks the in-app updater, and it refuses to spawn on
+  0.7.6+ entirely, until [issue #1889](https://github.com/erwins-enkel/shepherd/issues/1889)
+  ships a broader fix.
 - The `claude` CLI, logged in with your Max/Pro subscription
 - Node.js — for the PTY helper subprocess
 

--- a/src/herdr-capabilities.ts
+++ b/src/herdr-capabilities.ts
@@ -10,8 +10,23 @@
 // diagnostics), fail spawns loudly (the driver), and block the in-app herdr-update to 0.7.5+.
 import { compareSemver } from "./semver";
 
-/** The newest herdr version Shepherd can drive. 0.7.5+ broke agent spawning — see #1889. */
+/** The newest herdr version Shepherd's general ceiling admits. Feeds the preflight banner, the
+ *  in-app updater block, and the diagnostics ceiling display — retiring THOSE is a separate child of
+ *  #1889, so this stays `0.7.4` here even though the CLI driver can now spawn on 0.7.5 (see
+ *  {@link HERDR_LAST_SPAWNABLE_VERSION}). */
 export const HERDR_LAST_SUPPORTED_VERSION = "0.7.4";
+
+/** The newest herdr version the CLI driver can SPAWN on. 0.7.5 (protocol 17) is spawnable via the
+ *  external-registration path (`tab create` → `pane run` → `report-agent`, #1890); this is
+ *  decoupled from {@link HERDR_LAST_SUPPORTED_VERSION} so lifting the CLI spawn refusal for 0.7.5
+ *  does not also un-gate the updater/preflight ceiling. */
+export const HERDR_LAST_SPAWNABLE_VERSION = "0.7.5";
+
+/** First herdr version that requires the external-registration spawn path instead of `agent start`
+ *  (protocol 17 reshaped `agent start` so the wrapped `env …`/`bwrap …` argv can no longer be
+ *  launched through it — #1890). Module-private: consumed only by
+ *  {@link herdrUsesExternalRegistrationSpawn}. */
+const HERDR_EXTERNAL_REGISTRATION_VERSION = "0.7.5";
 
 const SEMVER_RE = /(\d+\.\d+\.\d+)/;
 
@@ -41,8 +56,20 @@ export function detectedHerdrVersion(): string | null {
   return detected;
 }
 
-/** Whether the installed herdr is one Shepherd can spawn agents on. Defaults to true before
- *  detection so an un-probed process behaves as the shipping build did. */
+/** Whether the installed herdr is one Shepherd can spawn agents on. Decoupled from
+ *  {@link isHerdrVersionSupported} (the general 0.7.4 ceiling): the CLI driver can now spawn up to
+ *  {@link HERDR_LAST_SPAWNABLE_VERSION} (0.7.5) via the external-registration path (#1890).
+ *  null/unparseable → true (never false-alarm on an unreadable version). */
 export function herdrSpawnSupported(): boolean {
-  return isHerdrVersionSupported(detected);
+  if (!detected) return true;
+  return compareSemver(detected, HERDR_LAST_SPAWNABLE_VERSION) <= 0;
+}
+
+/** Whether the detected herdr requires the 0.7.5+ external-registration spawn path (CLI driver) —
+ *  `tab create` → `pane run` → `report-agent` — instead of the legacy `agent start`. null/
+ *  unparseable → false, so an un-probed process takes the legacy path (the shipping build's
+ *  behavior). */
+export function herdrUsesExternalRegistrationSpawn(): boolean {
+  if (!detected) return false;
+  return compareSemver(detected, HERDR_EXTERNAL_REGISTRATION_VERSION) >= 0;
 }

--- a/src/herdr-socket-driver.ts
+++ b/src/herdr-socket-driver.ts
@@ -18,7 +18,11 @@ import {
   type IHerdrDriver,
 } from "./herdr";
 import { config, HERDR_SOCKET_SUPPORTED_PROTOCOLS } from "./config";
-import { detectedHerdrVersion, herdrSpawnSupported } from "./herdr-capabilities";
+import {
+  detectedHerdrVersion,
+  herdrSpawnSupported,
+  herdrUsesExternalRegistrationSpawn,
+} from "./herdr-capabilities";
 
 /**
  * Socket-backed `IHerdrDriver` (issues #1529, #1553, #1567): routes the async read surface —
@@ -125,6 +129,12 @@ export class SocketHerdrDriver implements IHerdrDriver {
     // Same unsupported-herdr guard as the CLI driver (defensive: the socket only activates on a
     // supported protocol today, but the version ceiling is the source of truth). See #1889.
     if (!herdrSpawnSupported()) throw new HerdrSpawnUnsupportedError(detectedHerdrVersion());
+    // The 0.7.5 external-registration spawn path is CLI-only (#1890); this socket driver does not
+    // implement it. It is never *selected* on protocol 17 (17 ∉ HERDR_SOCKET_SUPPORTED_PROTOCOLS),
+    // so this is belt-and-suspenders — refuse rather than attempt the broken socket `agent.start`.
+    if (herdrUsesExternalRegistrationSpawn()) {
+      throw new HerdrSpawnUnsupportedError(detectedHerdrVersion());
+    }
     return this.serializeStart(() => this.startImpl(name, cwd, argv, env));
   }
 

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -121,6 +121,20 @@ export function mapState(s: HerdrState): SessionStatus {
 }
 
 /**
+ * Compare a herdr agent's name to a session's name for the cwd-collision disambiguator. On the
+ * 0.7.5 external-registration path the agent's `--agent` label was coerced through
+ * {@link sanitizeHerdrAgentName} (e.g. `review TASK-09` → `review-task-09`), so it will NOT equal
+ * the raw `session.name` — compare in sanitized space there. ≤0.7.4 keeps a strict raw comparison,
+ * so its matching is byte-identical. Without this, 2+ same-cwd 0.7.5 sessions could never re-pair by
+ * name after a herdr daemon restart (stale terminalIds), misclassifying a live session as stranded.
+ */
+function agentNameMatchesSession(agentName: string, sessionName: string): boolean {
+  return herdrUsesExternalRegistrationSpawn()
+    ? agentName === sanitizeHerdrAgentName(sessionName)
+    : agentName === sessionName;
+}
+
+/**
  * Resolve a session to its live herdr agent by a STABLE key. terminalId is the fast
  * path but is volatile across a herdr daemon restart, so on a miss we fall back to the
  * immutable worktree cwd. A cwd shared by 2+ agents (non-isolated same-repo sessions)
@@ -135,7 +149,7 @@ export function matchAgent(
   const byCwd = agents.filter((a) => a.cwd === s.worktreePath);
   if (byCwd.length === 1) return byCwd[0]!;
   if (byCwd.length > 1) {
-    const byName = byCwd.filter((a) => a.name === s.name);
+    const byName = byCwd.filter((a) => agentNameMatchesSession(a.name, s.name));
     if (byName.length === 1) return byName[0]!;
   }
   return null;
@@ -237,7 +251,9 @@ function pickByCwd(
   contended: boolean,
 ): HerdrAgent | null {
   if (!contended) return matchAgent(s, candidates);
-  const byName = candidates.filter((c) => c.cwd === s.worktreePath && c.name === s.name);
+  const byName = candidates.filter(
+    (c) => c.cwd === s.worktreePath && agentNameMatchesSession(c.name, s.name),
+  );
   return byName.length === 1 ? byName[0]! : null;
 }
 

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -6,6 +6,7 @@ import {
   detectedHerdrVersion,
   HERDR_LAST_SUPPORTED_VERSION,
   herdrSpawnSupported,
+  herdrUsesExternalRegistrationSpawn,
 } from "./herdr-capabilities";
 import { maintenance } from "./maintenance";
 import { compileCacheDir, agentTmpDir } from "./tmp-sweep";
@@ -364,6 +365,52 @@ export function parseTabs(result: unknown): HerdrTab[] {
  */
 export function parseAgentInfo(agent: unknown): HerdrAgent {
   return mapAgentRecord((agent ?? {}) as Record<string, string>);
+}
+
+/**
+ * Coerce an arbitrary Shepherd label into herdr's agent-name grammar `^[a-z][a-z0-9_-]{0,31}$`
+ * (spike-confirmed on 0.7.5: `TASK-01`, `plan-review TASK-707` are rejected as
+ * `invalid_agent_name`). Deterministic + stable: lowercase → replace every run of chars outside
+ * `[a-z0-9_-]` with a single `-` → strip leading chars that are not `[a-z]` (the first char must be
+ * a letter) → fall back to `agent` when nothing survives → truncate to 32. Applied on the 0.7.5
+ * path to the `pane report-agent`/`report-agent-session` `--agent` label and to `agent rename`.
+ * ≤0.7.4 never calls it (that path passes the raw name to `agent start`), so its behavior is
+ * unchanged.
+ */
+export function sanitizeHerdrAgentName(raw: string): string {
+  const lowered = raw.toLowerCase().replace(/[^a-z0-9_-]+/g, "-");
+  const trimmed = lowered.replace(/^[^a-z]+/, "");
+  return (trimmed.length > 0 ? trimmed : "agent").slice(0, 32);
+}
+
+/**
+ * Resolve a herdr `terminal_id` to its `pane_id` from an `agent list` snapshot. On herdr 0.7.5 the
+ * driver's read/send/relabel must target `pane_id` — `terminal_id` and label are rejected as
+ * `agent_not_found` — but Shepherd keys sessions on `terminal_id`, so this lookup is load-bearing.
+ * Returns null when no agent carries that `terminal_id` (gone/exited) or the matched record has no
+ * `pane_id` (unusable as a target).
+ */
+export function resolvePaneId(agents: HerdrAgent[], terminalId: string): string | null {
+  return agents.find((a) => a.terminalId === terminalId)?.paneId || null;
+}
+
+/** A single 0.7.5 pane write: either literal PTY text (`pane send-text`) or named keys
+ *  (`pane send-keys`). */
+export type PaneWrite = { kind: "text"; text: string } | { kind: "keys"; keys: string[] };
+
+/**
+ * Classify a driver `send(text)` payload for the 0.7.5 write path (spike-confirmed writes go through
+ * `pane send-text` + `pane send-keys Enter`, NOT `agent send`/`agent send-keys` — those return
+ * `agent_not_ready` on a registered-but-undetected sandboxed agent). A lone CR/LF becomes the
+ * `Enter` key; everything else (including a lone ESC byte and the bracketed-paste-wrapped steer
+ * blob) is delivered as literal PTY text. Only the `Enter` key name is spike-confirmed, so ESC and
+ * the paste markers ride `pane send-text` as literal bytes rather than depending on an unverified
+ * key name. This keeps `SessionService.sendSteerTo`'s two-call paste-then-CR sequence correct with
+ * no caller change: the CR maps to `Enter`, the paste blob to `send-text` (markers preserved).
+ */
+export function classifyPaneWrite(text: string): PaneWrite {
+  if (text === "\r" || text === "\n" || text === "\r\n") return { kind: "keys", keys: ["Enter"] };
+  return { kind: "text", text };
 }
 
 /**
@@ -762,10 +809,164 @@ export class HerdrDriver implements IHerdrDriver {
     argv: string[],
     env?: Record<string, string>,
   ): Promise<HerdrAgent> {
-    // Refuse loudly on an unsupported herdr (0.7.5+) rather than spawning a broken agent — see
-    // HerdrSpawnUnsupportedError / #1889. Steering/reading existing agents still works.
+    // Refuse loudly on a herdr too new to spawn on at all (see HerdrSpawnUnsupportedError / #1889).
+    // Steering/reading existing agents still works.
     if (!herdrSpawnSupported()) throw new HerdrSpawnUnsupportedError(detectedHerdrVersion());
-    return this.serializeStart(() => this.startImpl(name, cwd, argv, env));
+    return this.serializeStart(() =>
+      // 0.7.5 (protocol 17) can't launch the wrapped argv through `agent start`; use the
+      // external-registration path instead (#1890). ≤0.7.4 keeps the byte-identical legacy path.
+      herdrUsesExternalRegistrationSpawn()
+        ? this.startImpl075(name, cwd, argv, env)
+        : this.startImpl(name, cwd, argv, env),
+    );
+  }
+
+  /**
+   * Create a dedicated full-width tab for one agent and return its id + root pane id. Shared by both
+   * spawn paths (the ≤0.7.4 `agent start` split and the 0.7.5 `pane run`). Each agent gets its OWN
+   * tab so its pane spans the full herdr window width: a `--tab`-less `agent start` splits the active
+   * tab, so agents pile up as side-by-side panes each ~window/N wide — and that split-fixed width
+   * (not the browser's attach size) is what the PTY renders at, so the HUD terminal comes out
+   * tall-and-narrow and resizing the browser can't widen it. Throws if herdr returns no `tab_id`
+   * (nothing created yet, so nothing to roll back).
+   */
+  private async createDedicatedTab(
+    name: string,
+    cwd: string,
+  ): Promise<{ tabId: string; rootPaneId: string | undefined }> {
+    const created = JSON.parse(
+      await this.asyncRunner(["tab", "create", "--cwd", cwd, "--label", name, "--no-focus"]),
+    );
+    const tabId: string | undefined = created?.result?.tab?.tab_id;
+    if (!tabId) throw new Error(`herdr: tab create returned no tab_id for ${name}`);
+    const rootPaneId: string | undefined = created?.result?.root_pane?.pane_id;
+    return { tabId, rootPaneId };
+  }
+
+  /**
+   * herdr 0.7.5 (protocol 17) spawn via EXTERNAL REGISTRATION (#1890). `agent start --kind` can't
+   * express Shepherd's `env`-shim + `bwrap` argv wrap, so instead: `tab create` → run the wrapped
+   * argv in the tab's root pane once its shell is ready → register the agent
+   * (`report-agent-session` + `report-agent`) so `agent list` surfaces it (the membrane's
+   * `--unshare-pid` hides `claude` from herdr's passive detection) → resolve the started `HerdrAgent`
+   * from the live list by `pane_id`. Preserves the dedicated-tab + `TabLedger` teardown semantics of
+   * the ≤0.7.4 path; the wrapped argv (`buildWrappedArgv`) flows into `pane run` byte-identically.
+   * Unlike the ≤0.7.4 path there is NO leftover shell pane to close — `pane run` reuses the tab's
+   * root pane as the agent pane.
+   */
+  private async startImpl075(
+    name: string,
+    cwd: string,
+    argv: string[],
+    env?: Record<string, string>,
+  ): Promise<HerdrAgent> {
+    await this.ensureWorkspace(cwd);
+    // Dedicated full-width tab per agent (same rationale as the ≤0.7.4 path). No --env: the wrapped
+    // argv carries every env var itself (the `env …` shim, or bwrap `--setenv`), so the shell pane's
+    // own environment is irrelevant to the launched process.
+    const { tabId, rootPaneId } = await this.createDedicatedTab(name, cwd);
+
+    // The tab already exists, so on ANY post-create failure we must close it — otherwise it lingers
+    // forever as an empty husk. (Mirrors the ≤0.7.4 rollback.) A missing root pane is such a failure,
+    // so it is checked INSIDE the try to get the same rollback.
+    try {
+      // On 0.7.5 the tab's root pane IS the agent pane (`pane run` reuses it) — not a leftover to
+      // close, so a missing one is fatal.
+      const paneId = rootPaneId;
+      if (!paneId) throw new Error(`herdr: tab create returned no root pane for ${name}`);
+      const wrapped = buildWrappedArgv(argv, env);
+      await this.runInReadyPane(paneId, wrapped);
+      const agentName = sanitizeHerdrAgentName(name);
+      await this.registerAgentWithCollisionRetry(paneId, agentName);
+      // There is no `agent_started` reply on 0.7.5 — resolve the freshly-registered agent from the
+      // live list, joining on the pane_id we ran in. Its terminal_id is the id Shepherd keys on.
+      const agent = (await this.listAsync()).find((a) => a.paneId === paneId);
+      if (!agent || !agent.terminalId) {
+        throw new Error(`herdr: agent list has no registered agent for pane ${paneId} (${name})`);
+      }
+      // Retain the authoritative spawn handle (#1852): the tab is ours even if the process inside
+      // dies before it next appears in `agent list`.
+      this.ledger.record(agent.terminalId, tabId, name);
+      return agent;
+    } catch (err) {
+      await this.closeTab(tabId); // roll back the orphan tab before propagating
+      throw err;
+    }
+  }
+
+  /**
+   * Run `wrapped` in `paneId` once its shell is ready. Readiness is guaranteed by a bounded retry of
+   * `pane run` itself, retrying on ANY failure — deliberately name-independent so it does not hinge
+   * on herdr's exact busy-error code or prompt string (both unverified). No sleep between attempts:
+   * each failed `pane run` is a real herdr round-trip, which provides the spacing (same rationale as
+   * the ≤0.7.4 collision retry). A `pane run` that reaches the shell either launches the command or
+   * rejects before executing, so a retry never double-launches. CLI quirk: the `pane_id` positional
+   * precedes any flags — here it precedes the command argv.
+   */
+  private async runInReadyPane(paneId: string, wrapped: string[]): Promise<void> {
+    const MAX_ATTEMPTS = 3;
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      try {
+        await this.asyncRunner(["pane", "run", paneId, ...wrapped]);
+        return;
+      } catch (err) {
+        lastErr = err;
+      }
+    }
+    throw lastErr ?? new Error(`herdr: pane run failed for pane ${paneId}`);
+  }
+
+  /**
+   * Register an externally-launched agent so `agent list` surfaces it: `pane report-agent-session`
+   * (establishes the agent session) then `pane report-agent --state working` (sets its live state).
+   * Both take the `pane_id` positional BEFORE the flags (CLI quirk). Bounded retry mirrors the
+   * ≤0.7.4 name-collision breaker but at the REGISTER step — on 0.7.5 the `--agent` name is bound
+   * here, not at spawn, and our tab/pane/`claude` are already live — so a collision re-runs ONLY the
+   * register pair (never tab-create/pane-run) after evicting same-named squatters. Whether
+   * `report-agent(-session)` even emits `agent_name_taken` is unverified; because `agentName` is
+   * sanitized AND de-duped upstream (`uniqueName`) and each spawn registers a freshly-created pane, a
+   * real collision is expected to be rare/absent, and the retry collapses to a single pass otherwise.
+   */
+  private async registerAgentWithCollisionRetry(paneId: string, agentName: string): Promise<void> {
+    // Opaque per-pane associator: claude's own session id is unknown at spawn, and herdr only echoes
+    // this back on the agent record — keeping agent_status fresh via a real session id is a separate
+    // child (#1889). Stable + unique per spawn (one pane per spawn).
+    const agentSessionId = `shepherd-${paneId}`;
+    const MAX_ATTEMPTS = 3;
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      try {
+        await this.asyncRunner([
+          "pane",
+          "report-agent-session",
+          paneId,
+          "--source",
+          "shepherd",
+          "--agent",
+          agentName,
+          "--agent-session-id",
+          agentSessionId,
+        ]);
+        await this.asyncRunner([
+          "pane",
+          "report-agent",
+          paneId,
+          "--source",
+          "shepherd",
+          "--agent",
+          agentName,
+          "--state",
+          "working",
+        ]);
+        return;
+      } catch (err) {
+        if (!isNameTakenError(err) || attempt === MAX_ATTEMPTS - 1) throw err;
+        // Evict squatter(s) by name — never by regex-parsing the error string — then re-run the
+        // register pair against our existing pane.
+        const squatters = (await this.listAsync()).filter((a) => a.name === agentName);
+        for (const sq of squatters) await this.closeTab(sq.tabId);
+      }
+    }
   }
 
   private async startImpl(
@@ -776,20 +977,9 @@ export class HerdrDriver implements IHerdrDriver {
   ): Promise<HerdrAgent> {
     // herdr needs an active workspace before any tab can be created — guarantee one.
     await this.ensureWorkspace(cwd);
-    // Give each agent its OWN tab so its pane spans the full herdr window width.
-    // `agent start` with no --tab splits the active tab, so agents pile up as
-    // side-by-side panes each ~window/N wide — and that split-fixed width (not the
-    // browser's attach size) is what the PTY renders at, so the HUD terminal comes
-    // out tall-and-narrow and resizing the browser can't widen it. A dedicated tab
-    // keeps every agent full-width regardless of how many are running.
-    const created = JSON.parse(
-      await this.asyncRunner(["tab", "create", "--cwd", cwd, "--label", name, "--no-focus"]),
-    );
-    const tabId: string | undefined = created?.result?.tab?.tab_id;
     // a fresh tab opens with an empty shell pane; `agent start --tab` splits it, so
     // we close that leftover pane afterward to leave the agent as the sole pane
-    const rootPaneId: string | undefined = created?.result?.root_pane?.pane_id;
-    if (!tabId) throw new Error(`herdr: tab create returned no tab_id for ${name}`);
+    const { tabId, rootPaneId } = await this.createDedicatedTab(name, cwd);
 
     // `agent start` can fail (e.g. name-taken exhaustion). The tab already exists, so on
     // failure we must close it — otherwise it lingers forever as an empty husk with no
@@ -824,10 +1014,43 @@ export class HerdrDriver implements IHerdrDriver {
     }
   }
 
-  /** Write literal text to an agent's PTY (no implicit Enter). Async since #1567 — spawns via
-   *  `asyncRunner` so a steer never blocks Bun's loop, matching the other async writes. */
+  /**
+   * Map a session `terminal_id` to the target the current herdr wants for read/send/relabel. ≤0.7.4:
+   * identity (`terminal_id` is the target). 0.7.5: the `pane_id` — `terminal_id`/label are rejected
+   * as `agent_not_found` (#1890) — resolved from a fresh `agent list`. Returns null on 0.7.5 when the
+   * agent is gone (no live pane), so callers can no-op/throw rather than issue a doomed CLI call.
+   */
+  private async resolveTargetAsync(terminalId: string): Promise<string | null> {
+    if (!herdrUsesExternalRegistrationSpawn()) return terminalId;
+    return resolvePaneId(await this.listAsync(), terminalId);
+  }
+
+  /** Sync sibling of {@link resolveTargetAsync} for the sync `read` (uses the sync `list()`). */
+  private resolveTargetSync(terminalId: string): string | null {
+    if (!herdrUsesExternalRegistrationSpawn()) return terminalId;
+    return resolvePaneId(this.list(), terminalId);
+  }
+
+  /**
+   * Write literal text to an agent's PTY (no implicit Enter). Async since #1567 — spawns via
+   * `asyncRunner` so a steer never blocks Bun's loop, matching the other async writes. On 0.7.5 the
+   * write goes through `pane send-text` / `pane send-keys` against the resolved `pane_id`
+   * (`agent send` returns `agent_not_ready` on a registered-but-undetected sandboxed agent — #1890);
+   * `send` is never best-effort, so a gone pane throws rather than silently dropping the steer.
+   */
   async send(target: string, text: string): Promise<void> {
-    await this.asyncRunner(["agent", "send", target, text]);
+    if (!herdrUsesExternalRegistrationSpawn()) {
+      await this.asyncRunner(["agent", "send", target, text]);
+      return;
+    }
+    const paneId = resolvePaneId(await this.listAsync(), target);
+    if (!paneId) throw new Error(`herdr: no live pane for terminal ${target} (send)`);
+    const write = classifyPaneWrite(text);
+    await this.asyncRunner(
+      write.kind === "keys"
+        ? ["pane", "send-keys", paneId, ...write.keys]
+        : ["pane", "send-text", paneId, write.text],
+    );
   }
 
   /** The `agent read` argv shared by the sync and async readers. */
@@ -854,9 +1077,12 @@ export class HerdrDriver implements IHerdrDriver {
     }
   }
 
-  /** Read an agent's terminal buffer as plain text (default: the visible viewport). */
+  /** Read an agent's terminal buffer as plain text (default: the visible viewport). On 0.7.5 the
+   *  same `agent read` command targets the resolved `pane_id` (#1890); a gone pane reads as `""`. */
   read(target: string, source: "visible" | "recent" = "visible", lines = 200): string {
-    return this.parseRead(this.runner(this.readArgs(target, source, lines)));
+    const resolved = this.resolveTargetSync(target);
+    if (resolved === null) return "";
+    return this.parseRead(this.runner(this.readArgs(resolved, source, lines)));
   }
 
   /**
@@ -871,7 +1097,9 @@ export class HerdrDriver implements IHerdrDriver {
     source: "visible" | "recent" = "visible",
     lines = 200,
   ): Promise<string> {
-    return this.parseRead(await this.asyncRunner(this.readArgs(target, source, lines)));
+    const resolved = await this.resolveTargetAsync(target);
+    if (resolved === null) return "";
+    return this.parseRead(await this.asyncRunner(this.readArgs(resolved, source, lines)));
   }
 
   /**
@@ -903,10 +1131,18 @@ export class HerdrDriver implements IHerdrDriver {
       return;
     }
     if (!agent) return;
-    try {
-      await this.asyncRunner(["agent", "rename", terminalId, newName]);
-    } catch {
-      /* best-effort */
+    // 0.7.5: `agent rename` must target the pane_id and the agent label must satisfy herdr's name
+    // grammar (#1890). ≤0.7.4: byte-identical — target the terminal_id with the raw name. The TAB
+    // rename below always uses the raw, human-facing label (tab labels are unconstrained).
+    const external = herdrUsesExternalRegistrationSpawn();
+    const renameTarget = external ? agent.paneId : terminalId;
+    const agentLabel = external ? sanitizeHerdrAgentName(newName) : newName;
+    if (renameTarget) {
+      try {
+        await this.asyncRunner(["agent", "rename", renameTarget, agentLabel]);
+      } catch {
+        /* best-effort */
+      }
     }
     if (agent.tabId) {
       try {

--- a/test/fixtures/herdr-responses/v0.7.5/agent-list-registered.json
+++ b/test/fixtures/herdr-responses/v0.7.5/agent-list-registered.json
@@ -1,0 +1,17 @@
+{
+  "result": {
+    "type": "agent_list",
+    "agents": [
+      {
+        "agent": "claude",
+        "agent_status": "working",
+        "cwd": "/wt/a",
+        "name": "review-task-09",
+        "pane_id": "p_075",
+        "tab_id": "t_075",
+        "terminal_id": "term_075",
+        "workspace_id": "w1"
+      }
+    ]
+  }
+}

--- a/test/fixtures/herdr-responses/v0.7.5/agent-read.json
+++ b/test/fixtures/herdr-responses/v0.7.5/agent-read.json
@@ -1,0 +1,6 @@
+{
+  "result": {
+    "type": "agent_read",
+    "read": { "text": "● Ready.\n> " }
+  }
+}

--- a/test/fixtures/herdr-responses/v0.7.5/pane-run.json
+++ b/test/fixtures/herdr-responses/v0.7.5/pane-run.json
@@ -1,0 +1,6 @@
+{
+  "result": {
+    "type": "pane_command_started",
+    "pane_id": "p_075"
+  }
+}

--- a/test/fixtures/herdr-responses/v0.7.5/pane-send-keys.json
+++ b/test/fixtures/herdr-responses/v0.7.5/pane-send-keys.json
@@ -1,0 +1,6 @@
+{
+  "result": {
+    "type": "keys_sent",
+    "pane_id": "p_075"
+  }
+}

--- a/test/fixtures/herdr-responses/v0.7.5/pane-send-text.json
+++ b/test/fixtures/herdr-responses/v0.7.5/pane-send-text.json
@@ -1,0 +1,6 @@
+{
+  "result": {
+    "type": "text_sent",
+    "pane_id": "p_075"
+  }
+}

--- a/test/fixtures/herdr-responses/v0.7.5/report-agent-session.json
+++ b/test/fixtures/herdr-responses/v0.7.5/report-agent-session.json
@@ -1,0 +1,6 @@
+{
+  "result": {
+    "type": "agent_session_reported",
+    "pane_id": "p_075"
+  }
+}

--- a/test/fixtures/herdr-responses/v0.7.5/report-agent.json
+++ b/test/fixtures/herdr-responses/v0.7.5/report-agent.json
@@ -1,0 +1,6 @@
+{
+  "result": {
+    "type": "agent_reported",
+    "pane_id": "p_075"
+  }
+}

--- a/test/fixtures/herdr-responses/v0.7.5/tab-create.json
+++ b/test/fixtures/herdr-responses/v0.7.5/tab-create.json
@@ -1,0 +1,7 @@
+{
+  "result": {
+    "type": "tab_created",
+    "tab": { "tab_id": "t_075", "workspace_id": "w1" },
+    "root_pane": { "pane_id": "p_075", "tab_id": "t_075", "terminal_id": "term_075" }
+  }
+}

--- a/test/fixtures/herdr-responses/v0.7.5/tab-list.json
+++ b/test/fixtures/herdr-responses/v0.7.5/tab-list.json
@@ -1,0 +1,8 @@
+{
+  "result": {
+    "type": "tab_list",
+    "tabs": [
+      { "tab_id": "t_075", "label": "flatten", "agent_status": "working", "workspace_id": "w1" }
+    ]
+  }
+}

--- a/test/fixtures/herdr-responses/v0.7.5/workspace-list.json
+++ b/test/fixtures/herdr-responses/v0.7.5/workspace-list.json
@@ -1,0 +1,6 @@
+{
+  "result": {
+    "type": "workspace_list",
+    "workspaces": [{ "workspace_id": "w1", "label": "shepherd" }]
+  }
+}

--- a/test/herdr-075.test.ts
+++ b/test/herdr-075.test.ts
@@ -1,0 +1,221 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  classifyPaneWrite,
+  HerdrDriver,
+  resolvePaneId,
+  sanitizeHerdrAgentName,
+  type HerdrAgent,
+} from "../src/herdr";
+import { setDetectedHerdrVersion } from "../src/herdr-capabilities";
+
+// ── captured 0.7.5 (protocol 17) reply fixtures ──────────────────────────────
+const FIX = join(import.meta.dir, "fixtures/herdr-responses/v0.7.5");
+const fixture = (name: string): string => readFileSync(join(FIX, `${name}.json`), "utf8");
+
+const WORKSPACE_LIST = fixture("workspace-list");
+const TAB_CREATE = fixture("tab-create");
+const PANE_RUN = fixture("pane-run");
+const REPORT_SESSION = fixture("report-agent-session");
+const REPORT_AGENT = fixture("report-agent");
+const AGENT_LIST = fixture("agent-list-registered");
+const AGENT_READ = fixture("agent-read");
+const SEND_TEXT = fixture("pane-send-text");
+const SEND_KEYS = fixture("pane-send-keys");
+const TAB_LIST = fixture("tab-list");
+const OK = JSON.stringify({ result: { type: "ok" } });
+
+/** Route a captured fixture by the herdr subcommand the runner is invoked with. */
+function route(args: string[]): string {
+  const [a, b] = args;
+  if (a === "workspace" && b === "list") return WORKSPACE_LIST;
+  if (a === "tab" && b === "create") return TAB_CREATE;
+  if (a === "pane" && b === "run") return PANE_RUN;
+  if (a === "pane" && b === "report-agent-session") return REPORT_SESSION;
+  if (a === "pane" && b === "report-agent") return REPORT_AGENT;
+  if (a === "agent" && b === "list") return AGENT_LIST;
+  if (a === "tab" && b === "list") return TAB_LIST;
+  if (a === "agent" && b === "read") return AGENT_READ;
+  if (a === "pane" && b === "send-text") return SEND_TEXT;
+  if (a === "pane" && b === "send-keys") return SEND_KEYS;
+  return OK; // agent rename / tab rename / tab close
+}
+
+/** A HerdrDriver whose sync + async runners share ONE fake that records every call. */
+function mkDriver(fake: (args: string[]) => string): { d: HerdrDriver; calls: string[][] } {
+  const calls: string[][] = [];
+  const runner = (args: string[]) => {
+    calls.push(args);
+    return fake(args);
+  };
+  return { d: new HerdrDriver(runner, async (args) => runner(args)), calls };
+}
+
+// Pin the compile-cache dir + disable the disk-TMPDIR redirect so buildWrappedArgv's output is
+// deterministic (mirrors test/herdr.test.ts), keeping the `pane run` argv assertion stable.
+let prevNcc: string | undefined;
+let prevAgentTmp: string | undefined;
+beforeEach(() => {
+  setDetectedHerdrVersion("0.7.5");
+  prevNcc = process.env.SHEPHERD_NODE_COMPILE_CACHE;
+  process.env.SHEPHERD_NODE_COMPILE_CACHE = "/disk/ncc";
+  prevAgentTmp = process.env.SHEPHERD_AGENT_TMPDIR;
+  process.env.SHEPHERD_AGENT_TMPDIR = "";
+});
+afterEach(() => {
+  setDetectedHerdrVersion(null);
+  if (prevNcc === undefined) delete process.env.SHEPHERD_NODE_COMPILE_CACHE;
+  else process.env.SHEPHERD_NODE_COMPILE_CACHE = prevNcc;
+  if (prevAgentTmp === undefined) delete process.env.SHEPHERD_AGENT_TMPDIR;
+  else process.env.SHEPHERD_AGENT_TMPDIR = prevAgentTmp;
+});
+
+// ── pure leaves ──────────────────────────────────────────────────────────────
+
+test("sanitizeHerdrAgentName coerces Shepherd labels into herdr's name grammar", () => {
+  expect(sanitizeHerdrAgentName("TASK-01")).toBe("task-01");
+  expect(sanitizeHerdrAgentName("review TASK-09")).toBe("review-task-09");
+  expect(sanitizeHerdrAgentName("plan-review TASK-707")).toBe("plan-review-task-707");
+  expect(sanitizeHerdrAgentName("9foo")).toBe("foo"); // first char must be [a-z]
+  expect(sanitizeHerdrAgentName("---")).toBe("agent"); // nothing survives → fallback
+  expect(sanitizeHerdrAgentName("")).toBe("agent");
+  const long = sanitizeHerdrAgentName("a".repeat(50));
+  expect(long).toBe("a".repeat(32)); // truncated to 32
+  // Every output must satisfy herdr's grammar.
+  const grammar = /^[a-z][a-z0-9_-]{0,31}$/;
+  for (const raw of ["TASK-01", "review TASK-09", "plan-review TASK-707", "9foo", "!!", ""]) {
+    expect(sanitizeHerdrAgentName(raw)).toMatch(grammar);
+  }
+});
+
+test("resolvePaneId maps terminal_id → pane_id, null when gone or pane-less", () => {
+  const agents: HerdrAgent[] = [
+    {
+      agent: "claude",
+      agentStatus: "working",
+      cwd: "/wt/a",
+      name: "x",
+      paneId: "p1",
+      tabId: "t1",
+      terminalId: "term_1",
+      workspaceId: "w1",
+    },
+  ];
+  expect(resolvePaneId(agents, "term_1")).toBe("p1");
+  expect(resolvePaneId(agents, "term_gone")).toBeNull();
+  expect(resolvePaneId([{ ...agents[0]!, paneId: "" }], "term_1")).toBeNull();
+});
+
+test("classifyPaneWrite: CR/LF → Enter key, everything else → literal text", () => {
+  expect(classifyPaneWrite("\r")).toEqual({ kind: "keys", keys: ["Enter"] });
+  expect(classifyPaneWrite("\n")).toEqual({ kind: "keys", keys: ["Enter"] });
+  expect(classifyPaneWrite("\r\n")).toEqual({ kind: "keys", keys: ["Enter"] });
+  expect(classifyPaneWrite("hello")).toEqual({ kind: "text", text: "hello" });
+  // The bracketed-paste-wrapped steer blob rides send-text verbatim (markers preserved).
+  const blob = "\x1b[200~multi\nline\x1b[201~";
+  expect(classifyPaneWrite(blob)).toEqual({ kind: "text", text: blob });
+  // A lone ESC stays literal text (only the Enter key name is spike-confirmed).
+  expect(classifyPaneWrite("\x1b")).toEqual({ kind: "text", text: "\x1b" });
+});
+
+// ── start() via external registration ────────────────────────────────────────
+
+test("start (0.7.5): tab create → pane run wrapped argv → register → resolve from agent list", async () => {
+  const { d, calls } = mkDriver(route);
+  const agent = await d.start("review TASK-09", "/wt/a", ["claude", "go"]);
+
+  // Resolved from the live list, joined on the pane we ran in.
+  expect(agent).toMatchObject({ terminalId: "term_075", paneId: "p_075", tabId: "t_075" });
+
+  // No legacy `agent start`, and the root pane is reused (never closed).
+  expect(calls.some((c) => c[0] === "agent" && c[1] === "start")).toBe(false);
+  expect(calls.some((c) => c[0] === "pane" && c[1] === "close")).toBe(false);
+
+  // The wrapped argv flows into `pane run` verbatim, pane_id positional first.
+  const paneRun = calls.find((c) => c[0] === "pane" && c[1] === "run")!;
+  expect(paneRun.slice(0, 4)).toEqual(["pane", "run", "p_075", "env"]);
+  expect(paneRun.slice(-2)).toEqual(["claude", "go"]);
+
+  // Registration uses the SANITIZED --agent label, pane_id positional before the flags.
+  const session = calls.find((c) => c[1] === "report-agent-session")!;
+  expect(session[2]).toBe("p_075");
+  expect(session).toContain("--source");
+  expect(session[session.indexOf("--agent") + 1]).toBe("review-task-09");
+  const report = calls.find((c) => c[1] === "report-agent")!;
+  expect(report[2]).toBe("p_075");
+  expect(report[report.indexOf("--agent") + 1]).toBe("review-task-09");
+  expect(report[report.indexOf("--state") + 1]).toBe("working");
+});
+
+test("start (0.7.5): rolls the tab back if registration keeps failing", async () => {
+  const { d, calls } = mkDriver((args) => {
+    if (args[1] === "report-agent-session") throw new Error("boom");
+    return route(args);
+  });
+  await expect(d.start("flatten", "/wt/a", ["claude", "go"])).rejects.toThrow();
+  // The orphan tab is closed on failure.
+  expect(calls.some((c) => c[0] === "tab" && c[1] === "close" && c[2] === "t_075")).toBe(true);
+});
+
+test("start (0.7.5): retries pane run until the shell is ready", async () => {
+  let runAttempts = 0;
+  const { d } = mkDriver((args) => {
+    if (args[0] === "pane" && args[1] === "run") {
+      runAttempts++;
+      if (runAttempts < 2) throw new Error("agent_pane_busy");
+    }
+    return route(args);
+  });
+  const agent = await d.start("flatten", "/wt/a", ["claude", "go"]);
+  expect(agent.terminalId).toBe("term_075");
+  expect(runAttempts).toBe(2);
+});
+
+// ── read / send / relabel target pane_id ─────────────────────────────────────
+
+test("read (0.7.5): resolves pane_id and reads it with the same agent read command", async () => {
+  const { d, calls } = mkDriver(route);
+  const text = await d.readAsync("term_075");
+  expect(text).toBe("● Ready.\n> ");
+  const read = calls.find((c) => c[0] === "agent" && c[1] === "read")!;
+  expect(read[2]).toBe("p_075"); // target is the pane_id, not the terminal_id
+});
+
+test("read (0.7.5): a gone terminal reads as empty (no doomed CLI call)", async () => {
+  const { d, calls } = mkDriver(route);
+  expect(await d.readAsync("term_gone")).toBe("");
+  expect(calls.some((c) => c[0] === "agent" && c[1] === "read")).toBe(false);
+});
+
+test("send (0.7.5): literal text via pane send-text, CR via pane send-keys Enter", async () => {
+  const { d, calls } = mkDriver(route);
+  await d.send("term_075", "\x1b[200~hi\x1b[201~");
+  await d.send("term_075", "\r");
+  const text = calls.find((c) => c[1] === "send-text")!;
+  expect(text).toEqual(["pane", "send-text", "p_075", "\x1b[200~hi\x1b[201~"]);
+  const keys = calls.find((c) => c[1] === "send-keys")!;
+  expect(keys).toEqual(["pane", "send-keys", "p_075", "Enter"]);
+});
+
+test("send (0.7.5): a gone terminal throws (a steer is never silently dropped)", async () => {
+  const { d } = mkDriver(route);
+  await expect(d.send("term_gone", "hi")).rejects.toThrow(/no live pane/);
+});
+
+test("relabel (0.7.5): agent rename targets pane_id with a sanitized label; tab keeps raw label", async () => {
+  const { d, calls } = mkDriver(route);
+  await d.relabel("term_075", "review TASK-42");
+  const rename = calls.find((c) => c[0] === "agent" && c[1] === "rename")!;
+  expect(rename).toEqual(["agent", "rename", "p_075", "review-task-42"]);
+  const tabRename = calls.find((c) => c[0] === "tab" && c[1] === "rename")!;
+  expect(tabRename).toEqual(["tab", "rename", "t_075", "review TASK-42"]);
+});
+
+test("stop (0.7.5): closes the recorded tab of a started agent", async () => {
+  const { d, calls } = mkDriver(route);
+  await d.start("flatten", "/wt/a", ["claude", "go"]);
+  calls.length = 0;
+  await d.stop("term_075");
+  expect(calls.some((c) => c[0] === "tab" && c[1] === "close" && c[2] === "t_075")).toBe(true);
+});

--- a/test/herdr-075.test.ts
+++ b/test/herdr-075.test.ts
@@ -4,6 +4,8 @@ import { test, expect, beforeEach, afterEach } from "bun:test";
 import {
   classifyPaneWrite,
   HerdrDriver,
+  matchAgent,
+  matchAgents,
   resolvePaneId,
   sanitizeHerdrAgentName,
   type HerdrAgent,
@@ -210,6 +212,49 @@ test("relabel (0.7.5): agent rename targets pane_id with a sanitized label; tab 
   expect(rename).toEqual(["agent", "rename", "p_075", "review-task-42"]);
   const tabRename = calls.find((c) => c[0] === "tab" && c[1] === "rename")!;
   expect(tabRename).toEqual(["tab", "rename", "t_075", "review TASK-42"]);
+});
+
+// ── cwd-collision name disambiguation tolerates 0.7.5 sanitization ────────────
+
+/** Two 0.7.5 agents sharing a cwd, each with a SANITIZED herdr name, plus stale terminalIds (as
+ *  after a daemon restart). The sessions still hold their RAW names. */
+const SANITIZED_AGENTS: HerdrAgent[] = [
+  {
+    agent: "claude",
+    agentStatus: "working",
+    cwd: "/wt/shared",
+    name: "review-task-09", // sanitized from "review TASK-09"
+    paneId: "pA",
+    tabId: "tA",
+    terminalId: "term_A",
+    workspaceId: "w1",
+  },
+  {
+    agent: "claude",
+    agentStatus: "working",
+    cwd: "/wt/shared",
+    name: "review-task-10", // sanitized from "review TASK-10"
+    paneId: "pB",
+    tabId: "tB",
+    terminalId: "term_B",
+    workspaceId: "w1",
+  },
+];
+
+test("matchAgent (0.7.5): same-cwd sessions re-pair by SANITIZED name after stale terminalId", () => {
+  // terminalId is stale (daemon restart) → cwd fallback; cwd is contended → name disambiguation.
+  const s = { herdrAgentId: "stale", worktreePath: "/wt/shared", name: "review TASK-10" };
+  expect(matchAgent(s, SANITIZED_AGENTS)?.terminalId).toBe("term_B");
+});
+
+test("matchAgents (0.7.5): both same-cwd sessions resolve via sanitized-name arbitration", () => {
+  const sessions = [
+    { id: "s1", herdrAgentId: "stale1", worktreePath: "/wt/shared", name: "review TASK-09" },
+    { id: "s2", herdrAgentId: "stale2", worktreePath: "/wt/shared", name: "review TASK-10" },
+  ];
+  const out = matchAgents(sessions, SANITIZED_AGENTS);
+  expect(out.get("s1")?.terminalId).toBe("term_A");
+  expect(out.get("s2")?.terminalId).toBe("term_B");
 });
 
 test("stop (0.7.5): closes the recorded tab of a started agent", async () => {

--- a/test/herdr-capabilities.test.ts
+++ b/test/herdr-capabilities.test.ts
@@ -1,8 +1,10 @@
 import { test, expect, afterEach } from "bun:test";
 import {
   detectedHerdrVersion,
+  HERDR_LAST_SPAWNABLE_VERSION,
   HERDR_LAST_SUPPORTED_VERSION,
   herdrSpawnSupported,
+  herdrUsesExternalRegistrationSpawn,
   isHerdrVersionSupported,
   parseHerdrVersion,
   setDetectedHerdrVersion,
@@ -55,7 +57,36 @@ test("setDetectedHerdrVersion drives detectedHerdrVersion + herdrSpawnSupported"
   expect(detectedHerdrVersion()).toBe("0.7.4");
   expect(herdrSpawnSupported()).toBe(true);
 
+  // 0.7.5 is now SPAWNABLE via the CLI external-registration path (#1890) — decoupled from the
+  // 0.7.4 general ceiling (which still gates the preflight/updater/diagnostics).
   setDetectedHerdrVersion("0.7.5");
   expect(detectedHerdrVersion()).toBe("0.7.5");
+  expect(herdrSpawnSupported()).toBe(true);
+
+  // Beyond the spawnable ceiling → still refused.
+  setDetectedHerdrVersion("0.7.6");
   expect(herdrSpawnSupported()).toBe(false);
+  setDetectedHerdrVersion("0.8.0");
+  expect(herdrSpawnSupported()).toBe(false);
+});
+
+// ── external-registration spawn path (0.7.5+) ────────────────────────────────
+
+test("HERDR_LAST_SPAWNABLE_VERSION is 0.7.5 (decoupled from the 0.7.4 support ceiling)", () => {
+  expect(HERDR_LAST_SPAWNABLE_VERSION).toBe("0.7.5");
+  // The support ceiling (updater/preflight) stays at 0.7.4 — 0.7.5 is spawnable but not "supported".
+  expect(isHerdrVersionSupported("0.7.5")).toBe(false);
+});
+
+test("herdrUsesExternalRegistrationSpawn: true from 0.7.5 up, false below and pre-detection", () => {
+  setDetectedHerdrVersion(null);
+  expect(herdrUsesExternalRegistrationSpawn()).toBe(false); // un-probed → legacy path
+
+  setDetectedHerdrVersion("0.7.4");
+  expect(herdrUsesExternalRegistrationSpawn()).toBe(false);
+
+  setDetectedHerdrVersion("0.7.5");
+  expect(herdrUsesExternalRegistrationSpawn()).toBe(true);
+  setDetectedHerdrVersion("0.8.0");
+  expect(herdrUsesExternalRegistrationSpawn()).toBe(true);
 });

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -120,8 +120,8 @@ function reply(args: string[], workspaceList: string): string {
   return FIXTURE;
 }
 
-test("start REFUSES on an unsupported herdr (0.7.5+) with a clear error, spawning nothing", async () => {
-  setDetectedHerdrVersion("0.7.5");
+test("start REFUSES on a herdr above the spawnable ceiling (>0.7.5), spawning nothing", async () => {
+  setDetectedHerdrVersion("0.7.6");
   try {
     const calls: string[][] = [];
     const d = mkDriver((args) => {


### PR DESCRIPTION
Part of epic #1889. Closes #1890. **DAG root — first child to drain.**

## What

Gives Shepherd a herdr **0.7.5 (protocol 17)** agent-spawn path on the **CLI driver** via herdr's
**external-registration** seam, and routes 0.7.5 spawns through it — lifting the hard spawn refusal
#1887 added (for the CLI path). herdr 0.7.5's `agent start --kind` can't express Shepherd's
`env`-shim + `bwrap`-sandbox argv wrap; `pane run` runs the wrapped argv verbatim instead.

All spawns still funnel through the single `IHerdrDriver` seam — this is a **version-branched
reimplementation** of `start`/`read`/`send`/`relabel`. **`≤0.7.4` behavior is byte-identical.**

## How (spike-confirmed against a live 0.7.5)

**`start` (0.7.5):** `ensureWorkspace` → `tab create` → shell-readiness wait → `pane run <pane_id>
<wrapped argv>` → `pane report-agent-session` + `pane report-agent` (so `agent list` surfaces the
agent — the membrane's `--unshare-pid` hides `claude` from passive detection) → resolve the started
`HerdrAgent` from `agent list` by `pane_id`. Dedicated-tab + `TabLedger` teardown preserved; the
tab's root pane IS the agent pane (no leftover shell pane to close).

**`read`/`send`/`relabel` (0.7.5):** resolve `terminal_id`→`pane_id` (`terminal_id`/label are
rejected as `agent_not_found`). `read` keeps the same `agent read` command with a `pane_id` target;
`send` goes through `pane send-text` / `pane send-keys Enter` (`agent send` returns
`agent_not_ready` on a registered-but-undetected sandboxed agent); `agent rename` targets the
`pane_id` with a sanitized label. `stop` is unchanged (tab-close on `tab_id`, version-agnostic).

**New pure leaves** (unit-tested): `sanitizeHerdrAgentName()` enforces herdr's
`^[a-z][a-z0-9_-]{0,31}$` (`TASK-01` → `task-01`); `resolvePaneId()`; `classifyPaneWrite()`.

**Gate:** `herdrSpawnSupported()` is decoupled from the `0.7.4` support ceiling — a new spawn
ceiling (`0.7.5`) + `herdrUsesExternalRegistrationSpawn()`. `HERDR_LAST_SUPPORTED_VERSION` (`0.7.4`)
still gates the preflight banner / in-app updater / diagnostics (their retirement is a separate
child of #1889). The socket driver defensively refuses the 0.7.5 branch (it's never selected on
protocol 17 anyway).

## Testing

`test/herdr-075.test.ts` drives the 0.7.5 orchestration with a fake `Runner` returning captured
0.7.5 JSON fixtures under `test/fixtures/herdr-responses/v0.7.5/`; the pure leaves are unit-tested as
leaves. `bun install && bun run lint && bun run typecheck && bun test ./test` all pass; existing
herdr tests stay green (`≤0.7.4` byte-identical).

## Known limitations (deferred to sibling children of #1889)

- **`report-agent-session --agent-session-id`** is a synthetic per-pane associator (`shepherd-<pane>`)
  — claude's real session id isn't known at spawn; herdr only echoes it back. Keeping `agent_status`
  fresh via a real session id is a separate child.

## Addressed in review

- **`agent.name` vs `session.name` drift (critic finding).** The sanitized `--agent` label differs
  from the raw `session.name`, so the cwd-contended fallback in `matchAgent`/`pickByCwd` could never
  re-pair 2+ same-cwd 0.7.5 sessions after a daemon restart. Fixed via `agentNameMatchesSession()`,
  which compares in sanitized space on the external-registration path; `≤0.7.4` keeps the strict raw
  comparison (byte-identical). Covered by two new `matchAgent`/`matchAgents` tests.

## Reviewer-confirm — items validated against the spike, not a live 0.7.5 in CI

- **Bracketed-paste over `pane send-text`.** Primary design passes the steer's `ESC[200~ … ESC[201~`
  blob verbatim to `pane send-text` (the same bytes `agent send` carries today). If a live 0.7.5
  shows `send-text` strips ESC bytes, the fallback is an ordered `send-keys`/`send-text` sequence
  (never marker-stripping — that would reintroduce #1567 multi-line auto-submit).
- **`report-agent` name-collision behavior** (`agent_name_taken` at register) is guarded by a
  bounded retry but is itself unverified; sanitized + upstream-unique names make a real collision
  rare, and the retry collapses to a single pass if register is idempotent.

[no-feature-entry] — server-only change; ships no user-facing UX.
