### PR TITLE
feat(herdr): push derived lifecycle state to herdr for sandboxed 0.7.5 agents (#1891)

### DIFF
--- a/src/herdr-socket-driver.ts
+++ b/src/herdr-socket-driver.ts
@@ -17,6 +17,7 @@ import {
   type HerdrTab,
   type IHerdrDriver,
 } from "./herdr";
+import type { RequestPaneAgentState } from "./generated/herdr-protocol";
 import { config, HERDR_SOCKET_SUPPORTED_PROTOCOLS } from "./config";
 import {
   detectedHerdrVersion,
@@ -262,6 +263,25 @@ export class SocketHerdrDriver implements IHerdrDriver {
     } catch {
       /* best-effort; tab may already be gone */
     }
+  }
+
+  /**
+   * Interface completeness (issue #1891): the lifecycle-state push targets externally-registered
+   * sandboxed 0.7.5 agents, which the socket driver never hosts (it refuses the 0.7.5
+   * external-registration spawn branch in `start`). Implemented as a real `pane.report_agent`
+   * request nonetheless so the socket driver is a faithful `IHerdrDriver`.
+   */
+  async reportAgentState(
+    paneId: string,
+    agentName: string,
+    state: RequestPaneAgentState,
+  ): Promise<void> {
+    await this.client.request("pane.report_agent", {
+      pane_id: paneId,
+      source: "shepherd",
+      agent: agentName,
+      state,
+    });
   }
 }
 

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -11,6 +11,7 @@ import {
 import { maintenance } from "./maintenance";
 import { compileCacheDir, agentTmpDir } from "./tmp-sweep";
 import type { HerdrState, LivenessState, SessionStatus } from "./types";
+import type { RequestPaneAgentState } from "./generated/herdr-protocol";
 
 const execFileAsync = promisify(execFile);
 
@@ -118,6 +119,31 @@ export function mapState(s: HerdrState): SessionStatus {
     default:
       return "idle";
   }
+}
+
+/** The reachable subset of {@link RequestPaneAgentState} Shepherd derives for a LIVE session — never
+ *  `done` (not a valid report-agent state) nor `unknown` (a live session always resolves to one of
+ *  these three). */
+export type PushableAgentState = "idle" | "working" | "blocked";
+
+/**
+ * Map Shepherd's own per-tick classifier view to the state to push to herdr via `pane report-agent`
+ * (issue #1891). herdr freezes `agent_status` for externally-registered, sandboxed 0.7.5 agents (its
+ * pane/PID view is `bwrap`, not the agent binary), so Shepherd must report the state IT derives from
+ * the terminal + hook signals. Pure so the classifier→push seam is unit-testable in isolation.
+ *
+ *  - `blocked` — a block reason is currently surfaced for the session (menu/y-n/awaiting-input/stall/
+ *    quota); takes precedence, since a block is the actionable state regardless of turn activity.
+ *  - `working` — no block AND a fresh active-turn signal (a live turn's spinner/transcript still
+ *    advancing, or a fresh hook activity).
+ *  - `idle` — no block AND no fresh activity (the agent finished its turn / is resting).
+ */
+export function deriveHerdrState(input: {
+  blocked: boolean;
+  working: boolean;
+}): PushableAgentState {
+  if (input.blocked) return "blocked";
+  return input.working ? "working" : "idle";
 }
 
 /**
@@ -656,6 +682,10 @@ export interface IHerdrDriver {
   tabsAsync(): Promise<HerdrTab[]>;
   panes(): HerdrPane[];
   paneForegroundProcs(paneId: string): Promise<string[]>;
+  /** Push a Shepherd-derived lifecycle state to a pane's registered agent (`pane report-agent
+   *  --state`, issue #1891). Used for externally-registered sandboxed 0.7.5 agents whose
+   *  `agent_status` herdr cannot advance on its own. */
+  reportAgentState(paneId: string, agentName: string, state: RequestPaneAgentState): Promise<void>;
   /** Spawn an agent (issue #1553: async — socket-backed when `SHEPHERD_HERDR_SOCKET=1`,
    *  else non-blocking CLI). Returns the started `HerdrAgent`. */
   start(
@@ -742,6 +772,31 @@ export class HerdrDriver implements IHerdrDriver {
     } catch {
       return [];
     }
+  }
+
+  /**
+   * Push a Shepherd-derived lifecycle state onto a pane's registered agent (issue #1891). Mirrors the
+   * arg shape of the register pair (`pane report-agent <paneId> --source shepherd --agent <name>
+   * --state <state>`; the paneId is a leading positional before the flags — CLI quirk). Used only for
+   * externally-registered sandboxed 0.7.5 agents, whose `agent_status` herdr freezes at registration
+   * (its pane/PID view is `bwrap`), so `agent list` reflects reality only if Shepherd reports it.
+   */
+  async reportAgentState(
+    paneId: string,
+    agentName: string,
+    state: RequestPaneAgentState,
+  ): Promise<void> {
+    await this.asyncRunner([
+      "pane",
+      "report-agent",
+      paneId,
+      "--source",
+      "shepherd",
+      "--agent",
+      agentName,
+      "--state",
+      state,
+    ]);
   }
 
   /**

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -2,13 +2,17 @@ import type { SessionStore } from "./store";
 import type { LivenessState, Session } from "./types";
 import {
   classifyLiveness,
+  deriveHerdrState,
   isAutoRevivable,
   mapState,
   matchAgents,
   needsAccountRedrive,
   type HerdrDriver,
   type HerdrAgent,
+  type PushableAgentState,
 } from "./herdr";
+import { herdrUsesExternalRegistrationSpawn } from "./herdr-capabilities";
+import type { SandboxProfile } from "./sandbox";
 import {
   classifyBlocked,
   hasActiveSpinner,
@@ -100,6 +104,16 @@ export interface LivenessWiring {
   onChange: (id: string, alive: boolean, liveness: LivenessState) => void;
 }
 
+/** #1891: a genuinely sandboxed session — a non-`trusted` profile was actually applied AND did not
+ *  degrade to unconfined. Only these run behind the membrane (`bwrap`), so only these are the
+ *  externally-registered agents herdr cannot observe and whose state Shepherd must push. */
+function isSandboxedSession(s: {
+  sandboxApplied: SandboxProfile | null;
+  sandboxDegraded: boolean;
+}): boolean {
+  return s.sandboxApplied != null && s.sandboxApplied !== "trusted" && !s.sandboxDegraded;
+}
+
 /** Bounded tail read + auth-URL detection for a session's transcript; the default
  *  `detectAuth` wiring. Missing/unreadable transcript (or no claude session yet) ⇒ null. */
 function readAuthUrl(s: Session): string | null {
@@ -183,6 +197,15 @@ export class StatusPoller {
    *  bootstrap via `blockSnapshot()`. Maintained by `emitBlock`; blocks are otherwise
    *  edge-emitted and would be absent on a fresh page load / push-then-open. */
   private lastBlockReason = new Map<string, BlockReason>();
+  /** #1891: last lifecycle state pushed to herdr per session, for push-on-change dedup. */
+  private lastPushedState = new Map<string, PushableAgentState>();
+  /** #1891: ms of the last detected active turn (an `emitActivity` this probe) — the terminal-scrape
+   *  half of the working↔idle signal, so the boundary works on the frozen-`working` route where
+   *  `maybeClassify` never runs and hooks may be off. */
+  private lastActiveTurnAt = new Map<string, number>();
+  /** #1891: sessions with an in-flight `reportAgentState` push — serialize per session so two pushes
+   *  can't reorder on herdr; the push's `finally` re-evaluates to catch a state change mid-flight. */
+  private pushInFlight = new Set<string>();
   /** Transcript mtime at the last resting-auth probe per session — gates `maybeAuthAtRest`'s
    *  bounded read to ticks where the transcript actually changed (see AUTH_SIG). */
   private lastAuthMtime = new Map<string, number | null>();
@@ -322,7 +345,7 @@ export class StatusPoller {
 
   constructor(
     private store: SessionStore,
-    private herdr: Pick<HerdrDriver, "listAsync" | "read" | "readAsync">,
+    private herdr: Pick<HerdrDriver, "listAsync" | "read" | "readAsync" | "reportAgentState">,
     private onChange: (id: string, status: string) => void,
     private onBlock: (id: string, block: BlockReason | null) => void,
     private intervalMs = 1000,
@@ -750,6 +773,11 @@ export class StatusPoller {
     if (status === "blocked") this.maybeClassify(s, s.herdrAgentId);
     else if (status === "running") this.maybeProbe(s);
     else this.maybeQuota(s, status);
+    // #1891: catch the working→idle timeout (a pure absence of activity — no emission sink fires for
+    // it) and seed the state after a fresh match. Block/working EDGES already pushed via
+    // emitBlock/emitActivity. Skipped on the tryHookAwaitingBlock early-return above — that path is a
+    // blocked edge emitBlock already handled.
+    this.maybePushAgentState(s.id);
   }
 
   /**
@@ -875,6 +903,9 @@ export class StatusPoller {
       ...this.codexCaptureBackoff.keys(),
       ...this.lastActivitySig.keys(),
       ...this.lastActivity.keys(),
+      ...this.lastPushedState.keys(),
+      ...this.lastActiveTurnAt.keys(),
+      ...this.pushInFlight,
       ...this.liveness.keys(),
       ...this.previewStopState.keys(),
       ...this.workingWhileBlocked,
@@ -905,6 +936,10 @@ export class StatusPoller {
         this.codexCaptureBackoff.delete(id);
         this.lastActivitySig.delete(id);
         this.lastActivity.delete(id);
+        // #1891: lifecycle-state push tracking
+        this.lastPushedState.delete(id);
+        this.lastActiveTurnAt.delete(id);
+        this.pushInFlight.delete(id);
         this.liveness.delete(id);
         this.previewStopState.delete(id);
         // archived/removed → no client cares anymore; drop without an emit
@@ -1184,6 +1219,10 @@ export class StatusPoller {
     if (block) this.lastBlockReason.set(id, block);
     else this.lastBlockReason.delete(id);
     this.onBlock(id, block);
+    // #1891: mirror the block/unblock EDGE to herdr on the same tick. Driven from this sink (not a
+    // post-routing call in reconcileAgent) so a hook-driven awaiting-input block that early-returns at
+    // `tryHookAwaitingBlock` still pushes `blocked` immediately, not a tick late.
+    this.maybePushAgentState(id);
   }
 
   /** Last-emitted block reason per session, for client bootstrap. */
@@ -1193,11 +1232,75 @@ export class StatusPoller {
 
   /** Emit an activity signal, deduped by content so clients see only real changes. */
   private emitActivity(id: string, activity: SessionActivity): void {
+    // #1891: any activity detected this probe refreshes the working-signal stamp — even a
+    // content-deduped repeat, since the turn is still live (the client emit is deduped, the stamp
+    // is not).
+    this.lastActiveTurnAt.set(id, this.now());
     const sig = JSON.stringify(activity);
-    if (sig === this.lastActivitySig.get(id)) return;
-    this.lastActivitySig.set(id, sig);
-    this.lastActivity.set(id, activity);
-    this.onActivity(id, activity);
+    if (sig !== this.lastActivitySig.get(id)) {
+      this.lastActivitySig.set(id, sig);
+      this.lastActivity.set(id, activity);
+      this.onActivity(id, activity);
+    }
+    this.maybePushAgentState(id);
+  }
+
+  /** True when the session shows a FRESH active turn — a hook activity OR a probe/transcript activity
+   *  emit within the last two probe cadences. The `lastActiveTurnAt` half is set in `emitActivity`,
+   *  which runs on the `maybeProbe` path that drives the frozen-`working` route, so this does not
+   *  depend on hooks being on. A session we have NEVER observed a turn for reads working (not idle):
+   *  it was just registered `working`, and a spawning agent works before it rests — so this avoids a
+   *  spurious `working→idle→working` flap at startup, before the first probe/activity lands. */
+  private isActiveTurnFresh(id: string, now: number): boolean {
+    if (this.hookActivityFresh(id, now)) return true;
+    const at = this.lastActiveTurnAt.get(id);
+    if (at === undefined) return true;
+    return now - at < 2 * this.probeCheckMs;
+  }
+
+  /**
+   * Push Shepherd's own derived lifecycle state to herdr for an externally-registered SANDBOXED 0.7.5
+   * session whose `agent_status` herdr freezes at registration (issue #1891 — its pane/PID view is
+   * `bwrap`, so it never advances the state on its own). Idempotent + push-on-change: recomputes the
+   * derived state from the block + active-turn signals and reports it only when it differs from the
+   * last pushed value. Best-effort + fire-and-forget — a report failure must never throw in the 1s
+   * tick. The pane target comes from THIS tick's match (`lastMatched`).
+   *
+   * Gated to genuinely-sandboxed spawns (a non-`trusted` profile actually applied, not degraded to
+   * unconfined): those are the externally-registered agents herdr can't observe. A `trusted`/degraded
+   * 0.7.5 spawn keeps the foreground agent binary herdr sees directly, so pushing there could race
+   * herdr's own advance — left unchanged, matching the issue's scope.
+   */
+  private maybePushAgentState(id: string): void {
+    if (!herdrUsesExternalRegistrationSpawn()) return;
+    const agent = this.lastMatched.get(id);
+    if (!agent || !agent.paneId) return;
+    const s = this.store.get(id);
+    if (!s || !isSandboxedSession(s)) return;
+    const state = deriveHerdrState({
+      blocked: this.lastBlockReason.has(id),
+      working: this.isActiveTurnFresh(id, this.now()),
+    });
+    if (this.lastPushedState.get(id) === state) return;
+    if (this.pushInFlight.has(id)) return; // a push is serializing; its resolution re-evaluates
+    this.pushInFlight.add(id);
+    this.lastPushedState.set(id, state);
+    void this.herdr.reportAgentState(agent.paneId, agent.name, state).then(
+      () => {
+        this.pushInFlight.delete(id);
+        // Re-evaluate: the derived state may have changed while this push was in flight (pushes are
+        // serialized so they can't reorder on herdr). Converges — a no-op once the state is stable.
+        this.maybePushAgentState(id);
+      },
+      (err) => {
+        // Roll back so a LATER tick retries rather than sticking on a value herdr never received. Do
+        // NOT re-invoke here — a persistently failing report would otherwise spin as fast as each
+        // call settles; the next 1s tick paces the retry.
+        this.lastPushedState.delete(id);
+        this.pushInFlight.delete(id);
+        console.warn(`[poller] report-agent state push failed for ${id}:`, err);
+      },
+    );
   }
 
   /** Clear a live stall flag (no-op if none); leaves the terminal baseline intact. */

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -2,6 +2,7 @@ import { test, expect, beforeEach, afterEach } from "bun:test";
 import {
   HerdrDriver,
   HerdrSpawnUnsupportedError,
+  deriveHerdrState,
   isHeadlessCodexExec,
   mapState,
   matchAgent,
@@ -579,6 +580,16 @@ test("mapState maps herdr states to shepherd status", async () => {
   expect(mapState("unknown")).toBe("idle");
 });
 
+test("deriveHerdrState maps the classifier view to a pushable report-agent state (#1891)", () => {
+  // blocked wins regardless of turn activity — a surfaced block is the actionable state.
+  expect(deriveHerdrState({ blocked: true, working: true })).toBe("blocked");
+  expect(deriveHerdrState({ blocked: true, working: false })).toBe("blocked");
+  // no block: a fresh active turn is working; otherwise idle.
+  expect(deriveHerdrState({ blocked: false, working: true })).toBe("working");
+  expect(deriveHerdrState({ blocked: false, working: false })).toBe("idle");
+  // never emits `done` — not a valid RequestPaneAgentState (excluded by the return type).
+});
+
 const mkAgent = (over: Partial<HerdrAgent>) =>
   ({
     agent: "claude",
@@ -972,6 +983,54 @@ test("paneForegroundProcs() returns multi-name list for a live pane", async () =
   );
   const procs = await d.paneForegroundProcs("w65:p4");
   expect(procs).toEqual(["claude", "npm", "node-MainThread"]);
+});
+
+// #1891 Phase-0: a live SANDBOXED pane's foreground process is the `bwrap` monitor, not the agent
+// binary. `paneForegroundProcs` reports it verbatim; its consumers treat any non-shell foreground as
+// alive (see isSpawnAlive / classifyHelperTab), so a live sandboxed agent reads alive by this signal.
+const SANDBOXED_PROC_REPLY = JSON.stringify({
+  result: {
+    process_info: {
+      foreground_process_group_id: 6001000,
+      foreground_processes: [{ name: "bwrap", pid: 6001000 }],
+      pane_id: "w65:p6",
+      shell_pid: 6000900,
+    },
+    type: "pane_process_info",
+  },
+});
+
+test("paneForegroundProcs() reports ['bwrap'] for a live sandboxed pane (#1891)", async () => {
+  const d = new HerdrDriver(
+    () => FIXTURE,
+    async () => SANDBOXED_PROC_REPLY,
+  );
+  expect(await d.paneForegroundProcs("w65:p6")).toEqual(["bwrap"]);
+});
+
+test("reportAgentState() issues pane report-agent with the state (#1891)", async () => {
+  const calls: string[][] = [];
+  const d = new HerdrDriver(
+    () => FIXTURE,
+    async (args) => {
+      calls.push(args);
+      return "{}";
+    },
+  );
+  await d.reportAgentState("w65:p6", "task-01", "idle");
+  expect(calls).toEqual([
+    [
+      "pane",
+      "report-agent",
+      "w65:p6",
+      "--source",
+      "shepherd",
+      "--agent",
+      "task-01",
+      "--state",
+      "idle",
+    ],
+  ]);
 });
 
 test("paneForegroundProcs() returns [] on unparseable reply (JSON parse failure)", async () => {

--- a/test/json-tolerant.test.ts
+++ b/test/json-tolerant.test.ts
@@ -177,6 +177,13 @@ describe("isSpawnAlive", () => {
     expect(await isSpawnAlive(herdr, CWD)).toBe(false);
   });
 
+  test("idle + sandboxed foreground ['bwrap'] (live membrane pane) → alive (#1891)", async () => {
+    // A sandboxed agent's pane foreground is the `bwrap` monitor, not `claude`. The non-shell rule
+    // correctly reads it alive; a dead sandbox falls back to a bare shell ('zsh' above) → dead.
+    const herdr = makeHerdrStub({ agents: [agent("idle")], procs: ["bwrap"] });
+    expect(await isSpawnAlive(herdr, CWD)).toBe(true);
+  });
+
   test("idle + empty procs [] (undeterminable) → alive (fail-closed)", async () => {
     const herdr = makeHerdrStub({ agents: [agent("idle")], procs: [] });
     expect(await isSpawnAlive(herdr, CWD)).toBe(true);

--- a/test/poller-listasync.test.ts
+++ b/test/poller-listasync.test.ts
@@ -11,7 +11,7 @@ function fakeStore(): SessionStore {
   return { list: mock(() => []) } as unknown as SessionStore;
 }
 
-type FakeHerdr = Pick<HerdrDriver, "listAsync" | "read" | "readAsync">;
+type FakeHerdr = Pick<HerdrDriver, "listAsync" | "read" | "readAsync" | "reportAgentState">;
 
 function newPoller(herdr: FakeHerdr): StatusPoller {
   return new StatusPoller(

--- a/test/poller-report-agent.test.ts
+++ b/test/poller-report-agent.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, expect, test } from "bun:test";
+import { StatusPoller } from "../src/poller";
+import { SessionStore } from "../src/store";
+import type { HerdrAgent } from "../src/herdr";
+import { classifyBlocked } from "../src/blocked";
+import { setDetectedHerdrVersion } from "../src/herdr-capabilities";
+import type { SandboxProfile } from "../src/sandbox";
+import { config } from "../src/config";
+
+// Issue #1891: for an externally-registered SANDBOXED 0.7.5 agent, herdr freezes `agent_status` at
+// `working` (its pane/PID view is `bwrap`). These tests drive a session whose herdr agent stays
+// `working` for the whole run — proving the state Shepherd pushes comes from ITS OWN classifier
+// (maybeProbe activity + the hook awaiting-input block path), NOT from herdr advancing, and NOT from
+// the herdr-`blocked`→`maybeClassify` route (which never fires on the frozen-`working` route).
+
+const base = {
+  name: "task-01",
+  prompt: "x",
+  repoPath: "/r",
+  baseBranch: "main",
+  branch: "shepherd/x",
+  worktreePath: "/wt",
+  isolated: true,
+  herdrSession: "default",
+  herdrAgentId: "term_a",
+};
+
+/** Let the fire-and-forget push chain (`.catch`/`.finally`, which clears `pushInFlight` and
+ *  re-evaluates) settle before the next tick/assertion. */
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+function harness(opts?: {
+  sandboxApplied?: SandboxProfile | null;
+  sandboxDegraded?: boolean;
+  visible?: () => string;
+}) {
+  const store = new SessionStore(":memory:");
+  const s = store.create({
+    ...base,
+    sandboxApplied: opts?.sandboxApplied === undefined ? "standard" : opts.sandboxApplied,
+    sandboxDegraded: opts?.sandboxDegraded ?? false,
+  });
+  const pushes: { paneId: string; agentName: string; state: string }[] = [];
+  let clock = 1_700_000_000_000;
+  const visible = opts?.visible ?? (() => "Computing… (1s)");
+  // herdr agent is PINNED to `working` for the whole run — the frozen sandboxed case.
+  const herdr = {
+    list: (): HerdrAgent[] => [
+      {
+        agent: "claude",
+        agentStatus: "working",
+        cwd: "/wt",
+        paneId: "p",
+        tabId: "t",
+        name: "task-01",
+        terminalId: "term_a",
+        workspaceId: "w",
+      } as HerdrAgent,
+    ],
+    listAsync: () => Promise.resolve(herdr.list()),
+    read: () => visible(),
+    readAsync: () => Promise.resolve(visible()),
+    reportAgentState: (paneId: string, agentName: string, state: string) => {
+      pushes.push({ paneId, agentName, state });
+      return Promise.resolve();
+    },
+  };
+  const poller = new StatusPoller(
+    store,
+    herdr as never,
+    () => {},
+    () => {},
+    1000,
+    3000,
+    classifyBlocked,
+    () => clock,
+    () => ({ snapshot: null, activity: null }),
+    // Realistic stall windows so a quiet-but-static terminal reads idle, not a spurious stall block.
+    { stallMs: 8 * 60_000, pendingStallMs: 20 * 60_000 },
+    7000, // probeCheckMs
+  );
+  return {
+    poller,
+    store,
+    pushes,
+    id: s.id,
+    advance: (ms: number) => (clock += ms),
+    now: () => clock,
+  };
+}
+
+afterEach(() => {
+  setDetectedHerdrVersion(null);
+});
+
+test("pushes working (baseline) then idle when the turn goes quiet — herdr status stays working", async () => {
+  setDetectedHerdrVersion("0.7.5");
+  const h = harness();
+
+  // First tick populates the match; a never-observed turn reads working (registration baseline).
+  await h.poller.tick();
+  await flush();
+  expect(h.pushes).toEqual([{ paneId: "p", agentName: "task-01", state: "working" }]);
+
+  // A live turn: hook activity refreshes the working stamp; still working → deduped, no re-push.
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    h.poller.ingestActivity(h.id, { toolName: "Edit", status: "ok", ts: h.now() });
+    await flush();
+    expect(h.pushes).toHaveLength(1);
+
+    // Turn goes quiet past 2× probeCheckMs → derived idle → pushed on the same tick it is derived.
+    h.advance(15_000);
+    await h.poller.tick();
+    await flush();
+    expect(h.pushes.at(-1)).toEqual({ paneId: "p", agentName: "task-01", state: "idle" });
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("pushes blocked on the awaiting-input early-return, same tick, without herdr reporting blocked", async () => {
+  setDetectedHerdrVersion("0.7.5");
+  const orig = config.hooksSignals;
+  config.hooksSignals = true;
+  try {
+    // TUI shows a menu, but herdr status stays `working` (frozen) — the push notification, not
+    // herdr's latch, must surface the block.
+    const h = harness({ visible: () => "❯ 1. Yes\n  2. No" });
+    await h.poller.tick(); // baseline working
+    await flush();
+    expect(h.pushes.at(-1)?.state).toBe("working");
+
+    h.poller.ingestNotification(h.id, "permission_prompt");
+    h.advance(5000);
+    await h.poller.tick(); // tryHookAwaitingBlock → maybeClassify → emitBlock → push, then early-return
+    await flush();
+    expect(h.pushes.at(-1)).toEqual({ paneId: "p", agentName: "task-01", state: "blocked" });
+    // Confirm herdr never advanced the agent itself — the push is Shepherd's own derivation.
+    expect(h.store.get(h.id)?.status).toBe("running"); // mapState("working")
+  } finally {
+    config.hooksSignals = orig;
+  }
+});
+
+test("push-on-change dedup: an unchanged derived state is pushed only once", async () => {
+  setDetectedHerdrVersion("0.7.5");
+  const h = harness();
+  await h.poller.tick();
+  await flush();
+  await h.poller.tick(); // still working, still quiet-but-unobserved → no state change
+  await flush();
+  await h.poller.tick();
+  await flush();
+  expect(h.pushes).toEqual([{ paneId: "p", agentName: "task-01", state: "working" }]);
+});
+
+test("gate: no push on herdr ≤ 0.7.4 (non-external-registration path)", async () => {
+  setDetectedHerdrVersion("0.7.4");
+  const h = harness();
+  await h.poller.tick();
+  await h.advance(15_000);
+  await h.poller.tick();
+  await flush();
+  expect(h.pushes).toEqual([]);
+});
+
+test("gate: no push for a trusted (non-sandboxed) 0.7.5 session", async () => {
+  setDetectedHerdrVersion("0.7.5");
+  const h = harness({ sandboxApplied: "trusted" });
+  await h.poller.tick();
+  await flush();
+  expect(h.pushes).toEqual([]);
+});
+
+test("gate: no push for a degraded sandbox (requested but ran unconfined)", async () => {
+  setDetectedHerdrVersion("0.7.5");
+  const h = harness({ sandboxApplied: "standard", sandboxDegraded: true });
+  await h.poller.tick();
+  await flush();
+  expect(h.pushes).toEqual([]);
+});

--- a/test/poller.test.ts
+++ b/test/poller.test.ts
@@ -37,8 +37,14 @@ const flush = () => new Promise((r) => setTimeout(r, 0));
  */
 function withListAsync<T extends { list: () => HerdrAgent[] }>(
   herdr: T,
-): T & { listAsync: () => Promise<HerdrAgent[]> } {
-  return { ...herdr, listAsync: () => Promise.resolve(herdr.list()) };
+): T & { listAsync: () => Promise<HerdrAgent[]>; reportAgentState: () => Promise<void> } {
+  // Default `reportAgentState` (#1891) so poller fakes don't each need it; a caller-provided one wins
+  // (spread after the default). The push is version-gated off here anyway (no 0.7.5 detected).
+  return {
+    reportAgentState: () => Promise.resolve(),
+    ...herdr,
+    listAsync: () => Promise.resolve(herdr.list()),
+  };
 }
 
 test("tick maps herdr state to status and emits only on change", async () => {

--- a/test/process-reaper.test.ts
+++ b/test/process-reaper.test.ts
@@ -379,6 +379,35 @@ test("claude-alive: every supplied worktree appears as a key; empty input is fin
   expect(out.get("/wt/a")).toBe(false);
 });
 
+// #1891 Phase-0 regression: a SANDBOXED agent runs as `bwrap [membrane] -- env … claude …`. Empirical
+// capture (bwrap 0.11.1, faithful membrane flags) showed the inner `claude` IS host-visible with
+// `comm=claude` and `/proc/<pid>/cwd` resolving under the worktree — `--unshare-pid` does not hide a
+// descendant from the host, and the worktree is bind-mounted at the same path. So the host-wide scan
+// already marks a live sandboxed agent alive; there is no husk false-positive to fix. These lock that.
+test("claude-alive: a live sandboxed agent (claude under bwrap, worktree cwd) is alive", () => {
+  const out = scanClaudeAliveByWorktree(
+    ["/wt/repo-x"],
+    makeProbes({
+      scanProcs: () => [
+        { pid: 100, cwd: "/wt/repo-x", comm: "bwrap" }, // outer monitor (ignored — not an agent comm)
+        { pid: 101, cwd: "/wt/repo-x", comm: "bwrap" }, // sandbox init (ignored)
+        { pid: 102, cwd: "/wt/repo-x", comm: "claude" }, // inner agent — host-visible, worktree cwd
+      ],
+    }),
+  );
+  expect(out.get("/wt/repo-x")).toBe(true);
+});
+
+test("claude-alive: a dead sandboxed agent leaves no worktree-cwd claude → husk", () => {
+  // Phase-0 Step B: killing the inner `claude` makes the `bwrap` monitors reap it and exit, so no
+  // worktree-cwd process survives. The scan reads false → the husk is still caught.
+  const out = scanClaudeAliveByWorktree(
+    ["/wt/repo-x"],
+    makeProbes({ scanProcs: () => [{ pid: 200, cwd: "/wt/repo-x", comm: "zsh" }] }),
+  );
+  expect(out.get("/wt/repo-x")).toBe(false);
+});
+
 // ── #1133: orphan reaping (PPID-1 busy-loops the port-based detector misses) ──
 
 const WT = "/home/u/Work/.shepherd-worktrees/repo-x"; // a real worktree path (has the marker)

--- a/test/tab-reaper.test.ts
+++ b/test/tab-reaper.test.ts
@@ -83,6 +83,18 @@ test("live spare: a helper pane running claude is never closed, counts as spared
   expect(r2.sparedLive).toBe(1);
 });
 
+test("live spare: a sandboxed helper pane (foreground 'bwrap') is spared as live (#1891)", async () => {
+  // A sandboxed helper's foreground is the membrane monitor, not `claude`; the non-shell rule spares
+  // it as live (a dead sandbox drops to a bare shell and is reaped by the shell-only path above).
+  const panes = [pane("w1:p1", "w1:t1", "review TASK-09")];
+  const procMap: Record<string, string[]> = { "w1:p1": ["bwrap"] };
+  const f1 = procFake(panes, procMap);
+  const r1 = await reapOrphanTabs(f1.h);
+  expect(r1.closed).toEqual([]);
+  expect(r1.sparedLive).toBe(1);
+  expect(r1.shellOnly.has("w1:t1")).toBe(false);
+});
+
 test("process-info error spare: paneForegroundProcs throwing spares the pane (sparedError)", async () => {
   const panes = [pane("w1:p1", "w1:t1", PROBE_NAME)];
   const procMap: Record<string, Error> = {


### PR DESCRIPTION
Part of epic #1889; closes #1891. Base: `epic/1889-herdr-0-7-5-protocol-17-agent-spawning-v`.

## What & why

herdr freezes `agent_status` for externally-registered, **sandboxed** 0.7.5 agents — its pane/PID view is the `bwrap` monitor, not the agent binary, so it can't advance the state it was handed at registration. `agent list` (and the herdr UI) then shows `working` forever. Shepherd already derives block/idle/working from the terminal + hook signals; this PR **pushes** that derived state back to herdr.

## Part A — lifecycle-state push (the actual change)

- **`deriveHerdrState({blocked, working}) → RequestPaneAgentState`** (`idle|working|blocked`) — the pure classifier→state seam. Typed to the generated protocol union (`src/generated/herdr-protocol.ts`), which excludes `done`, so an invalid state can't be pushed.
- **`HerdrDriver.reportAgentState(paneId, agentName, state)`** — issues `pane report-agent <paneId> --source shepherd --agent <name> --state <state>` (mirrors the register pair). Added to `IHerdrDriver` + the socket driver (interface completeness; the socket driver never hosts a 0.7.5 external-registration spawn).
- **Poller wiring** — the push is driven from the **emission sinks** (`emitBlock`, `emitActivity`) plus an end-of-`reconcileAgent` idle-timeout check, funnelled through one idempotent, push-on-change `maybePushAgentState`:
  - A hook-driven awaiting-input `blocked` edge early-returns at `tryHookAwaitingBlock`; driving the push from `emitBlock` means it still lands **same-tick**, not a tick late.
  - working/idle derive from a `lastActiveTurnAt` stamp set in `emitActivity` (the `maybeProbe` path that runs on the frozen-`working` route — **not** `maybeClassify`), OR-ed with hook freshness. A never-observed session reads `working` (matches the registration baseline) to avoid a startup `working→idle→working` flap.
  - Pushes serialized per session (can't reorder on herdr); best-effort, never throws in the 1s tick; a failed report rolls back so the next tick retries (no failure storm).
- **Gate:** the 0.7.5 external-registration path **and** a genuinely-sandboxed spawn (`sandboxApplied ∈ {standard, autonomous} && !sandboxDegraded`). ≤0.7.4 and `trusted`/degraded spawns are unchanged.

## Part B — reconcile/husk correctness: empirically DROPPED (no source change)

The plan gated Part B behind a HALTing Phase-0 empirical check, because the "herdr can't see `claude` under `--unshare-pid`" premise applies to herdr's *pane* detection, **not** `scanClaudeAliveByWorktree`'s *host-wide* `/proc` scan. Reproduced the membrane process tree with `bwrap 0.11.1` and the faithful `buildMembraneFlags` set:

- **Live:** the inner `claude` is host-visible with `comm=claude` and `/proc/<pid>/cwd` resolving under the worktree (alongside two `bwrap` monitors). `--unshare-pid` does **not** hide a descendant from the host, and the worktree is bind-mounted at the same path. → `scanClaudeAliveByWorktree` already marks a live sandboxed agent **alive**. No husk false-positive exists.
- **Dead:** killing only the inner `claude` (parent shell kept alive) → the `bwrap` monitors reap it and exit; **no worktree-cwd `bwrap`/`claude` remains** → the scan reads `false` → still a husk. (`--die-with-parent` governs parent death; the child-exit teardown was confirmed empirically, not assumed.)

Both halves of the acceptance already hold with existing code, so the `scanClaudeAliveByWorktree` change would be a no-op — **dropped**. Broadening `AGENT_COMMS` to include `bwrap` would be *wrong*: it's the SIGKILL-sparing prefilter for the orphan reapers, and a genuinely dead/orphaned `bwrap` must stay reap-able (a live `bwrap` is already spared there by the PPID-1 / deleted-cwd / archived-terminality / listening-port gates). Instead: **regression fixtures** lock the proven behavior.

## Tests

- `deriveHerdrState` truth table; `reportAgentState` argv; `paneForegroundProcs`/`reportAgentState` shapes.
- `test/poller-report-agent.test.ts` (new): a session pinned to herdr `working` for the whole run pushes `working→idle` and `blocked` (same-tick, via the awaiting-input early-return), plus push-on-change dedup and gate-off (≤0.7.4, trusted, degraded).
- Part B regression: `scanClaudeAliveByWorktree` alive for a live sandboxed tree, husk for a dead one; `bwrap`-foreground reads alive in `isSpawnAlive` / `classifyHelperTab`.
- `bun install && bun run lint && bun run typecheck && bun run test` all pass (7578 pass, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)