### PR TITLE
feat(herdr): drive the socket driver on herdr 0.7.5 (protocol 17) (#1892)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -76,7 +76,9 @@ export const HERDR_MIN_VERSION = "0.7.0";
 // herdr's native Unix-socket JSON-RPC protocol is versioned and still preview-unstable
 // (issue #1529) — admit only protocol numbers we've actually validated against a live
 // herdr, never an open `>=` floor. Extend this set explicitly as new protocols are verified.
-export const HERDR_SOCKET_SUPPORTED_PROTOCOLS = new Set([16]);
+// 17 = herdr 0.7.5: the socket driver branches its spawn/drive surface to the 0.7.5
+// external-registration path (#1892), mirroring the CLI driver.
+export const HERDR_SOCKET_SUPPORTED_PROTOCOLS = new Set([16, 17]);
 // TTL backing DiagnosticsService.current() — a request without ?refresh=1 reads
 // this cache. Matches the existing CountsService/backlog 60s TTL.
 export const DIAGNOSTICS_TTL_MS = 60_000;

--- a/src/generated/herdr-protocol.ts
+++ b/src/generated/herdr-protocol.ts
@@ -3,19 +3,112 @@
 // Regenerate: bun run gen:herdr-types
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestAgentStatus".
+ */
+export type RequestAgentStatus = "idle" | "working" | "blocked" | "done" | "unknown";
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "RequestReadSource".
  */
 export type RequestReadSource = "visible" | "recent" | "recent_unwrapped" | "detection";
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
- * via the `definition` "RequestSplitDirection".
+ * via the `definition` "RequestAgentViewBuiltinField".
  */
-export type RequestSplitDirection = "right" | "down";
+export type RequestAgentViewBuiltinField =
+  "status" | "workspace_id" | "tab_id" | "pane_id" | "agent" | "seen" | "state_change_seq";
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
- * via the `definition` "RequestAgentStatus".
+ * via the `definition` "RequestAgentViewBuiltinSortField".
  */
-export type RequestAgentStatus = "idle" | "working" | "blocked" | "done" | "unknown";
+export type RequestAgentViewBuiltinSortField =
+  | "workspace_order"
+  | "tab_order"
+  | "pane_order"
+  | "attention"
+  | "status"
+  | "agent"
+  | "seen"
+  | "state_change_seq";
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestAgentViewContext".
+ */
+export type RequestAgentViewContext = "current_workspace_id" | "current_tab_id";
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestAgentViewField".
+ */
+export type RequestAgentViewField =
+  | RequestAgentViewBuiltinField
+  | {
+      token: string;
+      [k: string]: unknown;
+    };
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestAgentViewFilter".
+ */
+export type RequestAgentViewFilter =
+  | {
+      filters: RequestAgentViewFilter[];
+      op: "all";
+      [k: string]: unknown;
+    }
+  | {
+      filters: RequestAgentViewFilter[];
+      op: "any";
+      [k: string]: unknown;
+    }
+  | {
+      filter: RequestAgentViewFilter;
+      op: "not";
+      [k: string]: unknown;
+    }
+  | {
+      field: RequestAgentViewField;
+      op: "eq";
+      value: RequestAgentViewValue;
+      [k: string]: unknown;
+    }
+  | {
+      field: RequestAgentViewField;
+      op: "in";
+      values: RequestAgentViewValue[];
+      [k: string]: unknown;
+    }
+  | {
+      field: RequestAgentViewField;
+      op: "exists";
+      [k: string]: unknown;
+    };
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestAgentViewValue".
+ */
+export type RequestAgentViewValue =
+  | string
+  | boolean
+  | number
+  | {
+      context: RequestAgentViewContext;
+      [k: string]: unknown;
+    };
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestAgentViewSortField".
+ */
+export type RequestAgentViewSortField =
+  | RequestAgentViewBuiltinSortField
+  | {
+      token: string;
+      [k: string]: unknown;
+    };
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestAgentViewSortOrder".
+ */
+export type RequestAgentViewSortOrder = "asc" | "desc";
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "RequestEventMatch".
@@ -137,6 +230,10 @@ export type RequestSubscription =
       [k: string]: unknown;
     }
   | {
+      type: "workspace.metadata_updated";
+      [k: string]: unknown;
+    }
+  | {
       type: "workspace.renamed";
       [k: string]: unknown;
     }
@@ -190,6 +287,10 @@ export type RequestSubscription =
     }
   | {
       type: "pane.closed";
+      [k: string]: unknown;
+    }
+  | {
+      type: "pane.updated";
       [k: string]: unknown;
     }
   | {
@@ -292,6 +393,11 @@ export type RequestLayoutNode =
     };
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestSplitDirection".
+ */
+export type RequestSplitDirection = "right" | "down";
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "RequestToastHerdrPosition".
  */
 export type RequestToastHerdrPosition = "top-left" | "top-right" | "bottom-left" | "bottom-right";
@@ -310,6 +416,11 @@ export type RequestPaneAgentState = "idle" | "working" | "blocked" | "unknown";
  * via the `definition` "RequestPaneDirection".
  */
 export type RequestPaneDirection = "left" | "right" | "up" | "down";
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestPaneGraphicsFormat".
+ */
+export type RequestPaneGraphicsFormat = "png" | "rgb" | "rgba";
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "RequestPaneMoveDestination".
@@ -342,9 +453,14 @@ export type RequestPaneMoveDestination =
 export type RequestPaneZoomMode = "toggle" | "on" | "off";
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestPopupSize".
+ */
+export type RequestPopupSize = number | string;
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "RequestPluginPanePlacement".
  */
-export type RequestPluginPanePlacement = "overlay" | "split" | "tab" | "zoomed";
+export type RequestPluginPanePlacement = "overlay" | "popup" | "split" | "tab" | "zoomed";
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "RequestPluginSourceKind".
@@ -387,6 +503,11 @@ export type SuccessResponseEventData =
     }
   | {
       type: "workspace_updated";
+      workspace: SuccessResponseWorkspaceInfo;
+      [k: string]: unknown;
+    }
+  | {
+      type: "workspace_metadata_updated";
       workspace: SuccessResponseWorkspaceInfo;
       [k: string]: unknown;
     }
@@ -479,6 +600,11 @@ export type SuccessResponseEventData =
       [k: string]: unknown;
     }
   | {
+      pane: SuccessResponsePaneInfo;
+      type: "pane_updated";
+      [k: string]: unknown;
+    }
+  | {
       pane_id: string;
       type: "pane_focused";
       workspace_id: string;
@@ -511,7 +637,9 @@ export type SuccessResponseEventData =
     }
   | {
       agent?: string | null;
+      final_status?: SuccessResponseAgentStatus | null;
       pane_id: string;
+      released?: boolean;
       type: "pane_agent_detected";
       workspace_id: string;
       [k: string]: unknown;
@@ -519,7 +647,6 @@ export type SuccessResponseEventData =
   | {
       agent?: string | null;
       agent_status: SuccessResponseAgentStatus;
-      custom_status?: string | null;
       display_agent?: string | null;
       pane_id: string;
       state_labels?: {
@@ -547,6 +674,7 @@ export type SuccessResponseSplitDirection = "right" | "down";
 export type SuccessResponseEventKind =
   | "workspace_created"
   | "workspace_updated"
+  | "workspace_metadata_updated"
   | "workspace_closed"
   | "workspace_renamed"
   | "workspace_moved"
@@ -561,6 +689,7 @@ export type SuccessResponseEventKind =
   | "tab_focused"
   | "pane_created"
   | "pane_closed"
+  | "pane_updated"
   | "pane_focused"
   | "pane_moved"
   | "pane_output_changed"
@@ -579,6 +708,11 @@ export type SuccessResponsePluginActionContext =
  * via the `definition` "SuccessResponsePluginPlatform".
  */
 export type SuccessResponsePluginPlatform = "linux" | "macos" | "windows";
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "SuccessResponsePopupSize".
+ */
+export type SuccessResponsePopupSize = number | string;
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "SuccessResponseIntegrationTarget".
@@ -677,7 +811,7 @@ export type SuccessResponsePluginCommandStatus = "running" | "succeeded" | "fail
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "SuccessResponsePluginPanePlacement".
  */
-export type SuccessResponsePluginPanePlacement = "overlay" | "split" | "tab" | "zoomed";
+export type SuccessResponsePluginPanePlacement = "overlay" | "popup" | "split" | "tab" | "zoomed";
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "SuccessResponsePluginSourceKind".
@@ -775,8 +909,20 @@ export type SuccessResponseResponseResult =
       [k: string]: unknown;
     }
   | {
+      agent: SuccessResponseAgentInfo;
+      type: "agent_prompted";
+      [k: string]: unknown;
+    }
+  | {
       agents: SuccessResponseAgentInfo[];
       type: "agent_list";
+      [k: string]: unknown;
+    }
+  | {
+      active: boolean;
+      label?: string | null;
+      source?: string | null;
+      type: "agent_view";
       [k: string]: unknown;
     }
   | {
@@ -857,6 +1003,12 @@ export type SuccessResponseResponseResult =
   | {
       read: SuccessResponsePaneReadResult;
       type: "pane_read";
+      [k: string]: unknown;
+    }
+  | {
+      cell_height_px: number;
+      cell_width_px: number;
+      type: "pane_graphics_info";
       [k: string]: unknown;
     }
   | {
@@ -1011,6 +1163,11 @@ export type EventEventData =
       [k: string]: unknown;
     }
   | {
+      type: "workspace_metadata_updated";
+      workspace: EventWorkspaceInfo;
+      [k: string]: unknown;
+    }
+  | {
       type: "workspace_closed";
       workspace?: EventWorkspaceInfo | null;
       workspace_id: string;
@@ -1099,6 +1256,11 @@ export type EventEventData =
       [k: string]: unknown;
     }
   | {
+      pane: EventPaneInfo;
+      type: "pane_updated";
+      [k: string]: unknown;
+    }
+  | {
       pane_id: string;
       type: "pane_focused";
       workspace_id: string;
@@ -1131,7 +1293,9 @@ export type EventEventData =
     }
   | {
       agent?: string | null;
+      final_status?: EventAgentStatus | null;
       pane_id: string;
+      released?: boolean;
       type: "pane_agent_detected";
       workspace_id: string;
       [k: string]: unknown;
@@ -1139,7 +1303,6 @@ export type EventEventData =
   | {
       agent?: string | null;
       agent_status: EventAgentStatus;
-      custom_status?: string | null;
       display_agent?: string | null;
       pane_id: string;
       state_labels?: {
@@ -1167,6 +1330,7 @@ export type EventSplitDirection = "right" | "down";
 export type EventEventKind =
   | "workspace_created"
   | "workspace_updated"
+  | "workspace_metadata_updated"
   | "workspace_closed"
   | "workspace_renamed"
   | "workspace_moved"
@@ -1181,6 +1345,7 @@ export type EventEventKind =
   | "tab_focused"
   | "pane_created"
   | "pane_closed"
+  | "pane_updated"
   | "pane_focused"
   | "pane_moved"
   | "pane_output_changed"
@@ -1223,6 +1388,23 @@ export interface HerdrProtocol {
 }
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestAgentPromptParams".
+ */
+export interface RequestAgentPromptParams {
+  target: string;
+  text: string;
+  wait?: RequestAgentPromptWaitOptions | null;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestAgentPromptWaitOptions".
+ */
+export interface RequestAgentPromptWaitOptions {
+  timeout_ms?: number | null;
+  until?: RequestAgentStatus[];
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "RequestAgentReadParams".
  */
 export interface RequestAgentReadParams {
@@ -1242,27 +1424,25 @@ export interface RequestAgentRenameParams {
 }
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
- * via the `definition` "RequestAgentSendParams".
+ * via the `definition` "RequestAgentSendKeysParams".
  */
-export interface RequestAgentSendParams {
+export interface RequestAgentSendKeysParams {
+  keys: string[];
   target: string;
-  text: string;
 }
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "RequestAgentStartParams".
  */
 export interface RequestAgentStartParams {
-  argv: string[];
-  cwd?: string | null;
-  env?: {
-    [k: string]: string;
-  };
-  focus?: boolean;
+  args?: string[];
+  kind: string;
   name: string;
-  split?: RequestSplitDirection | null;
-  tab_id?: string | null;
-  workspace_id?: string | null;
+  pane_id: string;
+  /**
+   * Startup timeout in milliseconds. Values must be greater than 3000 and at most 300000.
+   */
+  timeout_ms?: number | null;
 }
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
@@ -1270,6 +1450,40 @@ export interface RequestAgentStartParams {
  */
 export interface RequestAgentTarget {
   target: string;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestAgentViewClearParams".
+ */
+export interface RequestAgentViewClearParams {
+  source?: string | null;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestAgentViewSetParams".
+ */
+export interface RequestAgentViewSetParams {
+  filter?: RequestAgentViewFilter | null;
+  label?: string | null;
+  sort?: RequestAgentViewSort[];
+  source: string;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestAgentViewSort".
+ */
+export interface RequestAgentViewSort {
+  field: RequestAgentViewSortField;
+  order?: "asc" | "desc";
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestAgentWaitParams".
+ */
+export interface RequestAgentWaitParams {
+  target: string;
+  timeout_ms?: number | null;
+  until?: RequestAgentStatus[];
 }
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
@@ -1384,6 +1598,41 @@ export interface RequestPaneFocusDirectionParams {
 }
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestPaneGraphicsClearParams".
+ */
+export interface RequestPaneGraphicsClearParams {
+  pane_id: string;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestPaneGraphicsPlacementParams".
+ */
+export interface RequestPaneGraphicsPlacementParams {
+  grid_cols?: number;
+  grid_rows?: number;
+  viewport_col?: number;
+  viewport_row?: number;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestPaneGraphicsSetParams".
+ */
+export interface RequestPaneGraphicsSetParams {
+  data_base64?: string;
+  format: RequestPaneGraphicsFormat;
+  image_height: number;
+  image_width: number;
+  pane_id: string;
+  placement?: RequestPaneGraphicsPlacementParams1;
+}
+export interface RequestPaneGraphicsPlacementParams1 {
+  grid_cols?: number;
+  grid_rows?: number;
+  viewport_col?: number;
+  viewport_row?: number;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "RequestPaneLayoutParams".
  */
 export interface RequestPaneLayoutParams {
@@ -1457,7 +1706,6 @@ export interface RequestPaneReportAgentParams {
   agent: string;
   agent_session_id?: string | null;
   agent_session_path?: string | null;
-  custom_status?: string | null;
   message?: string | null;
   pane_id: string;
   seq?: number | null;
@@ -1484,11 +1732,9 @@ export interface RequestPaneReportAgentSessionParams {
 export interface RequestPaneReportMetadataParams {
   agent?: string | null;
   applies_to_source?: string | null;
-  clear_custom_status?: boolean;
   clear_display_agent?: boolean;
   clear_state_labels?: boolean;
   clear_title?: boolean;
-  custom_status?: string | null;
   display_agent?: string | null;
   pane_id: string;
   seq?: number | null;
@@ -1497,6 +1743,9 @@ export interface RequestPaneReportMetadataParams {
     [k: string]: string;
   };
   title?: string | null;
+  tokens?: {
+    [k: string]: string | null;
+  };
   ttl_ms?: number | null;
 }
 /**
@@ -1702,9 +1951,11 @@ export interface RequestPluginPaneOpenParams {
     [k: string]: string;
   };
   focus?: boolean;
+  height?: RequestPopupSize | null;
   placement?: RequestPluginPanePlacement | null;
   plugin_id: string;
   target_pane_id?: string | null;
+  width?: RequestPopupSize | null;
   workspace_id?: string | null;
 }
 /**
@@ -1803,6 +2054,19 @@ export interface RequestWorkspaceRenameParams {
 }
 /**
  * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "RequestWorkspaceReportMetadataParams".
+ */
+export interface RequestWorkspaceReportMetadataParams {
+  seq?: number | null;
+  source: string;
+  tokens: {
+    [k: string]: string | null;
+  };
+  ttl_ms?: number | null;
+  workspace_id: string;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
  * via the `definition` "RequestWorkspaceTarget".
  */
 export interface RequestWorkspaceTarget {
@@ -1857,21 +2121,28 @@ export interface SuccessResponseAgentInfo {
   agent?: string | null;
   agent_session?: SuccessResponseAgentSessionInfo | null;
   agent_status: SuccessResponseAgentStatus;
-  custom_status?: string | null;
   cwd?: string | null;
   display_agent?: string | null;
   focused: boolean;
   foreground_cwd?: string | null;
+  interactive_ready?: boolean;
+  launch_pending?: boolean;
   name?: string | null;
   pane_id: string;
   revision: number;
   screen_detection_skipped?: boolean;
+  state_change_seq?: number;
   state_labels?: {
     [k: string]: string;
   };
   tab_id: string;
   terminal_id: string;
+  terminal_title?: string | null;
+  terminal_title_stripped?: string | null;
   title?: string | null;
+  tokens?: {
+    [k: string]: string;
+  };
   workspace_id: string;
   [k: string]: unknown;
 }
@@ -1915,6 +2186,9 @@ export interface SuccessResponseWorkspaceInfo {
   number: number;
   pane_count: number;
   tab_count: number;
+  tokens?: {
+    [k: string]: string;
+  };
   workspace_id: string;
   worktree?: SuccessResponseWorkspaceWorktreeInfo | null;
   [k: string]: unknown;
@@ -1968,7 +2242,6 @@ export interface SuccessResponsePaneInfo {
   agent?: string | null;
   agent_session?: SuccessResponseAgentSessionInfo | null;
   agent_status: SuccessResponseAgentStatus;
-  custom_status?: string | null;
   cwd?: string | null;
   display_agent?: string | null;
   focused: boolean;
@@ -1982,7 +2255,12 @@ export interface SuccessResponsePaneInfo {
   };
   tab_id: string;
   terminal_id: string;
+  terminal_title?: string | null;
+  terminal_title_stripped?: string | null;
   title?: string | null;
+  tokens?: {
+    [k: string]: string;
+  };
   workspace_id: string;
   [k: string]: unknown;
 }
@@ -2070,6 +2348,7 @@ export interface SuccessResponseInstalledPluginInfo {
   plugin_id: string;
   plugin_root: string;
   source?: SuccessResponsePluginSourceInfo;
+  startup?: SuccessResponsePluginManifestStartup[];
   version: string;
   /**
    * Warnings collected at link time or on registry load (e.g. unknown event names,
@@ -2129,10 +2408,12 @@ export interface SuccessResponsePluginManifestLinkHandler {
 export interface SuccessResponsePluginManifestPane {
   command: string[];
   description?: string | null;
+  height?: SuccessResponsePopupSize | null;
   id: string;
-  placement?: "overlay" | "split" | "tab" | "zoomed";
+  placement?: "overlay" | "popup" | "split" | "tab" | "zoomed";
   platforms?: SuccessResponsePluginPlatform[] | null;
   title: string;
+  width?: SuccessResponsePopupSize | null;
   [k: string]: unknown;
 }
 export interface SuccessResponsePluginSourceInfo {
@@ -2144,6 +2425,15 @@ export interface SuccessResponsePluginSourceInfo {
   requested_ref?: string | null;
   resolved_commit?: string | null;
   subdir?: string | null;
+  [k: string]: unknown;
+}
+/**
+ * This interface was referenced by `HerdrProtocol`'s JSON-Schema
+ * via the `definition` "SuccessResponsePluginManifestStartup".
+ */
+export interface SuccessResponsePluginManifestStartup {
+  command: string[];
+  platforms?: SuccessResponsePluginPlatform[] | null;
   [k: string]: unknown;
 }
 /**
@@ -2451,6 +2741,9 @@ export interface EventWorkspaceInfo {
   number: number;
   pane_count: number;
   tab_count: number;
+  tokens?: {
+    [k: string]: string;
+  };
   workspace_id: string;
   worktree?: EventWorkspaceWorktreeInfo | null;
   [k: string]: unknown;
@@ -2504,7 +2797,6 @@ export interface EventPaneInfo {
   agent?: string | null;
   agent_session?: EventAgentSessionInfo | null;
   agent_status: EventAgentStatus;
-  custom_status?: string | null;
   cwd?: string | null;
   display_agent?: string | null;
   focused: boolean;
@@ -2518,7 +2810,12 @@ export interface EventPaneInfo {
   };
   tab_id: string;
   terminal_id: string;
+  terminal_title?: string | null;
+  terminal_title_stripped?: string | null;
   title?: string | null;
+  tokens?: {
+    [k: string]: string;
+  };
   workspace_id: string;
   [k: string]: unknown;
 }
@@ -2585,7 +2882,6 @@ export interface EventPaneLayoutSplit {
 export interface SubscriptionEventPaneAgentStatusChangedEvent {
   agent?: string | null;
   agent_status: SubscriptionEventAgentStatus;
-  custom_status?: string | null;
   display_agent?: string | null;
   pane_id: string;
   state_labels?: {
@@ -2650,7 +2946,7 @@ export interface ErrorResponseErrorBody {
   [k: string]: unknown;
 }
 
-export const HERDR_PROTOCOL = 16 as const;
+export const HERDR_PROTOCOL = 17 as const;
 
 export interface HerdrParams {
   ping: RequestPingParams;
@@ -2669,6 +2965,7 @@ export interface HerdrParams {
   "workspace.focus": RequestWorkspaceTarget;
   "workspace.rename": RequestWorkspaceRenameParams;
   "workspace.move": RequestWorkspaceMoveParams;
+  "workspace.report_metadata": RequestWorkspaceReportMetadataParams;
   "workspace.close": RequestWorkspaceTarget;
   "worktree.list": RequestWorktreeListParams;
   "worktree.create": RequestWorktreeCreateParams;
@@ -2685,10 +2982,14 @@ export interface HerdrParams {
   "agent.get": RequestAgentTarget;
   "agent.read": RequestAgentReadParams;
   "agent.explain": RequestAgentTarget;
-  "agent.send": RequestAgentSendParams;
+  "agent.send_keys": RequestAgentSendKeysParams;
   "agent.rename": RequestAgentRenameParams;
+  "agent.view.set": RequestAgentViewSetParams;
+  "agent.view.clear": RequestAgentViewClearParams;
   "agent.focus": RequestAgentTarget;
   "agent.start": RequestAgentStartParams;
+  "agent.prompt": RequestAgentPromptParams;
+  "agent.wait": RequestAgentWaitParams;
   "pane.split": RequestPaneSplitParams;
   "pane.swap": RequestPaneSwapParams;
   "pane.move": RequestPaneMoveParams;
@@ -2711,12 +3012,16 @@ export interface HerdrParams {
   "pane.send_keys": RequestPaneSendKeysParams;
   "pane.send_input": RequestPaneSendInputParams;
   "pane.read": RequestPaneReadParams;
+  "pane.graphics.set": RequestPaneGraphicsSetParams;
+  "pane.graphics.clear": RequestPaneGraphicsClearParams;
+  "pane.graphics.info": RequestPaneTarget;
   "pane.report_agent": RequestPaneReportAgentParams;
   "pane.report_agent_session": RequestPaneReportAgentSessionParams;
   "pane.report_metadata": RequestPaneReportMetadataParams;
   "pane.clear_agent_authority": RequestPaneClearAgentAuthorityParams;
   "pane.release_agent": RequestPaneReleaseAgentParams;
   "pane.close": RequestPaneTarget;
+  "popup.close": RequestEmptyParams;
   "events.subscribe": RequestEventsSubscribeParams;
   "events.wait": RequestEventsWaitParams;
   "pane.wait_for_output": RequestPaneWaitForOutputParams;

--- a/src/generated/herdr-schema.json
+++ b/src/generated/herdr-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "protocol": 16,
+  "protocol": 17,
   "schema_version": 1,
   "schemas": {
     "error_response": {
@@ -14,7 +14,10 @@
               "type": "string"
             }
           },
-          "required": ["code", "message"],
+          "required": [
+            "code",
+            "message"
+          ],
           "type": "object"
         }
       },
@@ -27,7 +30,10 @@
           "type": "string"
         }
       },
-      "required": ["id", "error"],
+      "required": [
+        "id",
+        "error"
+      ],
       "title": "ErrorResponse",
       "type": "object"
     },
@@ -48,15 +54,29 @@
               "type": "string"
             }
           },
-          "required": ["source", "agent", "kind", "value"],
+          "required": [
+            "source",
+            "agent",
+            "kind",
+            "value"
+          ],
           "type": "object"
         },
         "AgentSessionRefKind": {
-          "enum": ["id", "path"],
+          "enum": [
+            "id",
+            "path"
+          ],
           "type": "string"
         },
         "AgentStatus": {
-          "enum": ["idle", "working", "blocked", "done", "unknown"],
+          "enum": [
+            "idle",
+            "working",
+            "blocked",
+            "done",
+            "unknown"
+          ],
           "type": "string"
         },
         "EventData": {
@@ -71,7 +91,10 @@
                   "$ref": "#/schemas/event/$defs/WorkspaceInfo"
                 }
               },
-              "required": ["type", "workspace"],
+              "required": [
+                "type",
+                "workspace"
+              ],
               "type": "object"
             },
             {
@@ -84,7 +107,26 @@
                   "$ref": "#/schemas/event/$defs/WorkspaceInfo"
                 }
               },
-              "required": ["type", "workspace"],
+              "required": [
+                "type",
+                "workspace"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace_metadata_updated",
+                  "type": "string"
+                },
+                "workspace": {
+                  "$ref": "#/schemas/event/$defs/WorkspaceInfo"
+                }
+              },
+              "required": [
+                "type",
+                "workspace"
+              ],
               "type": "object"
             },
             {
@@ -107,7 +149,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "workspace_id"],
+              "required": [
+                "type",
+                "workspace_id"
+              ],
               "type": "object"
             },
             {
@@ -123,7 +168,11 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "workspace_id", "label"],
+              "required": [
+                "type",
+                "workspace_id",
+                "label"
+              ],
               "type": "object"
             },
             {
@@ -147,7 +196,12 @@
                   "type": "array"
                 }
               },
-              "required": ["type", "workspace_id", "insert_index", "workspaces"],
+              "required": [
+                "type",
+                "workspace_id",
+                "insert_index",
+                "workspaces"
+              ],
               "type": "object"
             },
             {
@@ -160,7 +214,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "workspace_id"],
+              "required": [
+                "type",
+                "workspace_id"
+              ],
               "type": "object"
             },
             {
@@ -176,7 +233,11 @@
                   "$ref": "#/schemas/event/$defs/WorktreeInfo"
                 }
               },
-              "required": ["type", "workspace", "worktree"],
+              "required": [
+                "type",
+                "workspace",
+                "worktree"
+              ],
               "type": "object"
             },
             {
@@ -195,7 +256,12 @@
                   "$ref": "#/schemas/event/$defs/WorktreeInfo"
                 }
               },
-              "required": ["type", "workspace", "worktree", "already_open"],
+              "required": [
+                "type",
+                "workspace",
+                "worktree",
+                "already_open"
+              ],
               "type": "object"
             },
             {
@@ -224,7 +290,12 @@
                   "$ref": "#/schemas/event/$defs/WorktreeInfo"
                 }
               },
-              "required": ["type", "workspace_id", "worktree", "forced"],
+              "required": [
+                "type",
+                "workspace_id",
+                "worktree",
+                "forced"
+              ],
               "type": "object"
             },
             {
@@ -237,7 +308,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "tab"],
+              "required": [
+                "type",
+                "tab"
+              ],
               "type": "object"
             },
             {
@@ -253,7 +327,11 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "tab_id", "workspace_id"],
+              "required": [
+                "type",
+                "tab_id",
+                "workspace_id"
+              ],
               "type": "object"
             },
             {
@@ -272,7 +350,12 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "tab_id", "workspace_id", "label"],
+              "required": [
+                "type",
+                "tab_id",
+                "workspace_id",
+                "label"
+              ],
               "type": "object"
             },
             {
@@ -299,7 +382,13 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "tab_id", "workspace_id", "insert_index", "tabs"],
+              "required": [
+                "type",
+                "tab_id",
+                "workspace_id",
+                "insert_index",
+                "tabs"
+              ],
               "type": "object"
             },
             {
@@ -315,7 +404,11 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "tab_id", "workspace_id"],
+              "required": [
+                "type",
+                "tab_id",
+                "workspace_id"
+              ],
               "type": "object"
             },
             {
@@ -328,7 +421,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane"],
+              "required": [
+                "type",
+                "pane"
+              ],
               "type": "object"
             },
             {
@@ -344,7 +440,27 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane_id", "workspace_id"],
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pane": {
+                  "$ref": "#/schemas/event/$defs/PaneInfo"
+                },
+                "type": {
+                  "const": "pane_updated",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane"
+              ],
               "type": "object"
             },
             {
@@ -360,16 +476,26 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane_id", "workspace_id"],
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id"
+              ],
               "type": "object"
             },
             {
               "properties": {
                 "closed_tab_id": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "closed_workspace_id": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "created_tab": {
                   "anyOf": [
@@ -435,7 +561,12 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane_id", "workspace_id", "revision"],
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id",
+                "revision"
+              ],
               "type": "object"
             },
             {
@@ -451,16 +582,36 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane_id", "workspace_id"],
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id"
+              ],
               "type": "object"
             },
             {
               "properties": {
                 "agent": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "final_status": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/event/$defs/AgentStatus"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "pane_id": {
                   "type": "string"
+                },
+                "released": {
+                  "type": "boolean"
                 },
                 "type": {
                   "const": "pane_agent_detected",
@@ -470,22 +621,29 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane_id", "workspace_id"],
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id"
+              ],
               "type": "object"
             },
             {
               "properties": {
                 "agent": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "agent_status": {
                   "$ref": "#/schemas/event/$defs/AgentStatus"
                 },
-                "custom_status": {
-                  "type": ["string", "null"]
-                },
                 "display_agent": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "pane_id": {
                   "type": "string"
@@ -497,7 +655,10 @@
                   "type": "object"
                 },
                 "title": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "type": {
                   "const": "pane_agent_status_changed",
@@ -507,7 +668,12 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane_id", "workspace_id", "agent_status"],
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id",
+                "agent_status"
+              ],
               "type": "object"
             },
             {
@@ -520,7 +686,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "layout"],
+              "required": [
+                "type",
+                "layout"
+              ],
               "type": "object"
             }
           ]
@@ -529,6 +698,7 @@
           "enum": [
             "workspace_created",
             "workspace_updated",
+            "workspace_metadata_updated",
             "workspace_closed",
             "workspace_renamed",
             "workspace_moved",
@@ -543,6 +713,7 @@
             "tab_focused",
             "pane_created",
             "pane_closed",
+            "pane_updated",
             "pane_focused",
             "pane_moved",
             "pane_output_changed",
@@ -556,7 +727,10 @@
         "PaneInfo": {
           "properties": {
             "agent": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "agent_session": {
               "anyOf": [
@@ -571,23 +745,32 @@
             "agent_status": {
               "$ref": "#/schemas/event/$defs/AgentStatus"
             },
-            "custom_status": {
-              "type": ["string", "null"]
-            },
             "cwd": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "display_agent": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "focused": {
               "type": "boolean"
             },
             "foreground_cwd": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "label": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "pane_id": {
               "type": "string"
@@ -619,8 +802,33 @@
             "terminal_id": {
               "type": "string"
             },
+            "terminal_title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "terminal_title_stripped": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "title": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tokens": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "maxProperties": 32,
+              "propertyNames": {
+                "pattern": "^[A-Za-z0-9_-]{1,32}$"
+              },
+              "type": "object"
             },
             "workspace_id": {
               "type": "string"
@@ -649,7 +857,11 @@
               "$ref": "#/schemas/event/$defs/PaneLayoutRect"
             }
           },
-          "required": ["pane_id", "focused", "rect"],
+          "required": [
+            "pane_id",
+            "focused",
+            "rect"
+          ],
           "type": "object"
         },
         "PaneLayoutRect": {
@@ -679,7 +891,12 @@
               "type": "integer"
             }
           },
-          "required": ["x", "y", "width", "height"],
+          "required": [
+            "x",
+            "y",
+            "width",
+            "height"
+          ],
           "type": "object"
         },
         "PaneLayoutSnapshot": {
@@ -739,7 +956,12 @@
               "$ref": "#/schemas/event/$defs/PaneLayoutRect"
             }
           },
-          "required": ["id", "direction", "ratio", "rect"],
+          "required": [
+            "id",
+            "direction",
+            "ratio",
+            "rect"
+          ],
           "type": "object"
         },
         "PaneScrollInfo": {
@@ -760,11 +982,18 @@
               "type": "integer"
             }
           },
-          "required": ["offset_from_bottom", "max_offset_from_bottom", "viewport_rows"],
+          "required": [
+            "offset_from_bottom",
+            "max_offset_from_bottom",
+            "viewport_rows"
+          ],
           "type": "object"
         },
         "SplitDirection": {
-          "enum": ["right", "down"],
+          "enum": [
+            "right",
+            "down"
+          ],
           "type": "string"
         },
         "TabInfo": {
@@ -835,6 +1064,16 @@
               "minimum": 0,
               "type": "integer"
             },
+            "tokens": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "maxProperties": 32,
+              "propertyNames": {
+                "pattern": "^[A-Za-z0-9_-]{1,32}$"
+              },
+              "type": "object"
+            },
             "workspace_id": {
               "type": "string"
             },
@@ -879,13 +1118,22 @@
               "type": "string"
             }
           },
-          "required": ["repo_key", "repo_name", "repo_root", "checkout_path", "is_linked_worktree"],
+          "required": [
+            "repo_key",
+            "repo_name",
+            "repo_root",
+            "checkout_path",
+            "is_linked_worktree"
+          ],
           "type": "object"
         },
         "WorktreeInfo": {
           "properties": {
             "branch": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "is_bare": {
               "type": "boolean"
@@ -903,7 +1151,10 @@
               "type": "string"
             },
             "open_workspace_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "path": {
               "type": "string"
@@ -929,12 +1180,59 @@
           "$ref": "#/schemas/event/$defs/EventKind"
         }
       },
-      "required": ["event", "data"],
+      "required": [
+        "event",
+        "data"
+      ],
       "title": "EventEnvelope",
       "type": "object"
     },
     "request": {
       "$defs": {
+        "AgentPromptParams": {
+          "properties": {
+            "target": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            },
+            "wait": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/AgentPromptWaitOptions"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "target",
+            "text"
+          ],
+          "type": "object"
+        },
+        "AgentPromptWaitOptions": {
+          "properties": {
+            "timeout_ms": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "until": {
+              "items": {
+                "$ref": "#/schemas/request/$defs/AgentStatus"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
         "AgentReadParams": {
           "properties": {
             "format": {
@@ -944,7 +1242,10 @@
             "lines": {
               "format": "uint32",
               "minimum": 0,
-              "type": ["integer", "null"]
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "source": {
               "$ref": "#/schemas/request/$defs/ReadSource"
@@ -957,79 +1258,89 @@
               "type": "string"
             }
           },
-          "required": ["target", "source"],
+          "required": [
+            "target",
+            "source"
+          ],
           "type": "object"
         },
         "AgentRenameParams": {
           "properties": {
             "name": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "target": {
               "type": "string"
             }
           },
-          "required": ["target"],
+          "required": [
+            "target"
+          ],
           "type": "object"
         },
-        "AgentSendParams": {
+        "AgentSendKeysParams": {
           "properties": {
-            "target": {
-              "type": "string"
-            },
-            "text": {
-              "type": "string"
-            }
-          },
-          "required": ["target", "text"],
-          "type": "object"
-        },
-        "AgentStartParams": {
-          "properties": {
-            "argv": {
+            "keys": {
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
-            "cwd": {
-              "type": ["string", "null"]
-            },
-            "env": {
-              "additionalProperties": {
+            "target": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "target",
+            "keys"
+          ],
+          "type": "object"
+        },
+        "AgentStartParams": {
+          "properties": {
+            "args": {
+              "items": {
                 "type": "string"
               },
-              "type": "object"
+              "type": "array"
             },
-            "focus": {
-              "default": false,
-              "type": "boolean"
+            "kind": {
+              "type": "string"
             },
             "name": {
               "type": "string"
             },
-            "split": {
-              "anyOf": [
-                {
-                  "$ref": "#/schemas/request/$defs/SplitDirection"
-                },
-                {
-                  "type": "null"
-                }
+            "pane_id": {
+              "type": "string"
+            },
+            "timeout_ms": {
+              "description": "Startup timeout in milliseconds. Values must be greater than 3000 and at most 300000.",
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
               ]
-            },
-            "tab_id": {
-              "type": ["string", "null"]
-            },
-            "workspace_id": {
-              "type": ["string", "null"]
             }
           },
-          "required": ["name", "argv"],
+          "required": [
+            "name",
+            "kind",
+            "pane_id"
+          ],
           "type": "object"
         },
         "AgentStatus": {
-          "enum": ["idle", "working", "blocked", "done", "unknown"],
+          "enum": [
+            "idle",
+            "working",
+            "blocked",
+            "done",
+            "unknown"
+          ],
           "type": "string"
         },
         "AgentTarget": {
@@ -1038,7 +1349,311 @@
               "type": "string"
             }
           },
-          "required": ["target"],
+          "required": [
+            "target"
+          ],
+          "type": "object"
+        },
+        "AgentViewBuiltinField": {
+          "enum": [
+            "status",
+            "workspace_id",
+            "tab_id",
+            "pane_id",
+            "agent",
+            "seen",
+            "state_change_seq"
+          ],
+          "type": "string"
+        },
+        "AgentViewBuiltinSortField": {
+          "enum": [
+            "workspace_order",
+            "tab_order",
+            "pane_order",
+            "attention",
+            "status",
+            "agent",
+            "seen",
+            "state_change_seq"
+          ],
+          "type": "string"
+        },
+        "AgentViewClearParams": {
+          "properties": {
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "AgentViewContext": {
+          "enum": [
+            "current_workspace_id",
+            "current_tab_id"
+          ],
+          "type": "string"
+        },
+        "AgentViewField": {
+          "anyOf": [
+            {
+              "$ref": "#/schemas/request/$defs/AgentViewBuiltinField"
+            },
+            {
+              "properties": {
+                "token": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "token"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "AgentViewFilter": {
+          "oneOf": [
+            {
+              "properties": {
+                "filters": {
+                  "items": {
+                    "$ref": "#/schemas/request/$defs/AgentViewFilter"
+                  },
+                  "type": "array"
+                },
+                "op": {
+                  "const": "all",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "op",
+                "filters"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "filters": {
+                  "items": {
+                    "$ref": "#/schemas/request/$defs/AgentViewFilter"
+                  },
+                  "type": "array"
+                },
+                "op": {
+                  "const": "any",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "op",
+                "filters"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "filter": {
+                  "$ref": "#/schemas/request/$defs/AgentViewFilter"
+                },
+                "op": {
+                  "const": "not",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "op",
+                "filter"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "field": {
+                  "$ref": "#/schemas/request/$defs/AgentViewField"
+                },
+                "op": {
+                  "const": "eq",
+                  "type": "string"
+                },
+                "value": {
+                  "$ref": "#/schemas/request/$defs/AgentViewValue"
+                }
+              },
+              "required": [
+                "op",
+                "field",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "field": {
+                  "$ref": "#/schemas/request/$defs/AgentViewField"
+                },
+                "op": {
+                  "const": "in",
+                  "type": "string"
+                },
+                "values": {
+                  "items": {
+                    "$ref": "#/schemas/request/$defs/AgentViewValue"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "op",
+                "field",
+                "values"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "field": {
+                  "$ref": "#/schemas/request/$defs/AgentViewField"
+                },
+                "op": {
+                  "const": "exists",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "op",
+                "field"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "AgentViewSetParams": {
+          "properties": {
+            "filter": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/AgentViewFilter"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sort": {
+              "items": {
+                "$ref": "#/schemas/request/$defs/AgentViewSort"
+              },
+              "type": "array"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "source"
+          ],
+          "type": "object"
+        },
+        "AgentViewSort": {
+          "properties": {
+            "field": {
+              "$ref": "#/schemas/request/$defs/AgentViewSortField"
+            },
+            "order": {
+              "$ref": "#/schemas/request/$defs/AgentViewSortOrder",
+              "default": "asc"
+            }
+          },
+          "required": [
+            "field"
+          ],
+          "type": "object"
+        },
+        "AgentViewSortField": {
+          "anyOf": [
+            {
+              "$ref": "#/schemas/request/$defs/AgentViewBuiltinSortField"
+            },
+            {
+              "properties": {
+                "token": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "token"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "AgentViewSortOrder": {
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "type": "string"
+        },
+        "AgentViewValue": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "properties": {
+                "context": {
+                  "$ref": "#/schemas/request/$defs/AgentViewContext"
+                }
+              },
+              "required": [
+                "context"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "AgentWaitParams": {
+          "properties": {
+            "target": {
+              "type": "string"
+            },
+            "timeout_ms": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "until": {
+              "items": {
+                "$ref": "#/schemas/request/$defs/AgentStatus"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "target"
+          ],
           "type": "object"
         },
         "ClientWindowTitleSetParams": {
@@ -1047,7 +1662,9 @@
               "type": "string"
             }
           },
-          "required": ["title"],
+          "required": [
+            "title"
+          ],
           "type": "object"
         },
         "EmptyParams": {
@@ -1062,10 +1679,15 @@
                   "type": "string"
                 },
                 "workspace_id": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 }
               },
-              "required": ["event"],
+              "required": [
+                "event"
+              ],
               "type": "object"
             },
             {
@@ -1078,7 +1700,10 @@
                   "type": "string"
                 }
               },
-              "required": ["event", "workspace_id"],
+              "required": [
+                "event",
+                "workspace_id"
+              ],
               "type": "object"
             },
             {
@@ -1091,7 +1716,10 @@
                   "type": "string"
                 }
               },
-              "required": ["event", "workspace_id"],
+              "required": [
+                "event",
+                "workspace_id"
+              ],
               "type": "object"
             },
             {
@@ -1101,13 +1729,19 @@
                   "type": "string"
                 },
                 "label": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "workspace_id": {
                   "type": "string"
                 }
               },
-              "required": ["event", "workspace_id"],
+              "required": [
+                "event",
+                "workspace_id"
+              ],
               "type": "object"
             },
             {
@@ -1120,7 +1754,10 @@
                   "type": "string"
                 }
               },
-              "required": ["event", "workspace_id"],
+              "required": [
+                "event",
+                "workspace_id"
+              ],
               "type": "object"
             },
             {
@@ -1133,7 +1770,10 @@
                   "type": "string"
                 }
               },
-              "required": ["event", "workspace_id"],
+              "required": [
+                "event",
+                "workspace_id"
+              ],
               "type": "object"
             },
             {
@@ -1143,13 +1783,21 @@
                   "type": "string"
                 },
                 "tab_id": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "workspace_id": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 }
               },
-              "required": ["event"],
+              "required": [
+                "event"
+              ],
               "type": "object"
             },
             {
@@ -1162,7 +1810,10 @@
                   "type": "string"
                 }
               },
-              "required": ["event", "tab_id"],
+              "required": [
+                "event",
+                "tab_id"
+              ],
               "type": "object"
             },
             {
@@ -1172,13 +1823,19 @@
                   "type": "string"
                 },
                 "label": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "tab_id": {
                   "type": "string"
                 }
               },
-              "required": ["event", "tab_id"],
+              "required": [
+                "event",
+                "tab_id"
+              ],
               "type": "object"
             },
             {
@@ -1191,7 +1848,10 @@
                   "type": "string"
                 }
               },
-              "required": ["event", "tab_id"],
+              "required": [
+                "event",
+                "tab_id"
+              ],
               "type": "object"
             },
             {
@@ -1204,7 +1864,10 @@
                   "type": "string"
                 }
               },
-              "required": ["event", "tab_id"],
+              "required": [
+                "event",
+                "tab_id"
+              ],
               "type": "object"
             },
             {
@@ -1214,13 +1877,21 @@
                   "type": "string"
                 },
                 "pane_id": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "workspace_id": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 }
               },
-              "required": ["event"],
+              "required": [
+                "event"
+              ],
               "type": "object"
             },
             {
@@ -1233,7 +1904,10 @@
                   "type": "string"
                 }
               },
-              "required": ["event", "pane_id"],
+              "required": [
+                "event",
+                "pane_id"
+              ],
               "type": "object"
             },
             {
@@ -1246,7 +1920,10 @@
                   "type": "string"
                 }
               },
-              "required": ["event", "pane_id"],
+              "required": [
+                "event",
+                "pane_id"
+              ],
               "type": "object"
             },
             {
@@ -1259,7 +1936,10 @@
                   "type": "string"
                 }
               },
-              "required": ["event", "pane_id"],
+              "required": [
+                "event",
+                "pane_id"
+              ],
               "type": "object"
             },
             {
@@ -1271,13 +1951,19 @@
                 "min_revision": {
                   "format": "uint64",
                   "minimum": 0,
-                  "type": ["integer", "null"]
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
                 },
                 "pane_id": {
                   "type": "string"
                 }
               },
-              "required": ["event", "pane_id"],
+              "required": [
+                "event",
+                "pane_id"
+              ],
               "type": "object"
             },
             {
@@ -1290,13 +1976,19 @@
                   "type": "string"
                 }
               },
-              "required": ["event", "pane_id"],
+              "required": [
+                "event",
+                "pane_id"
+              ],
               "type": "object"
             },
             {
               "properties": {
                 "agent": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "event": {
                   "const": "pane_agent_detected",
@@ -1306,7 +1998,10 @@
                   "type": "string"
                 }
               },
-              "required": ["event", "pane_id"],
+              "required": [
+                "event",
+                "pane_id"
+              ],
               "type": "object"
             },
             {
@@ -1322,7 +2017,11 @@
                   "type": "string"
                 }
               },
-              "required": ["event", "pane_id", "agent_status"],
+              "required": [
+                "event",
+                "pane_id",
+                "agent_status"
+              ],
               "type": "object"
             }
           ]
@@ -1336,7 +2035,9 @@
               "type": "array"
             }
           },
-          "required": ["subscriptions"],
+          "required": [
+            "subscriptions"
+          ],
           "type": "object"
         },
         "EventsWaitParams": {
@@ -1347,10 +2048,15 @@
             "timeout_ms": {
               "format": "uint64",
               "minimum": 0,
-              "type": ["integer", "null"]
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
-          "required": ["match_event"],
+          "required": [
+            "match_event"
+          ],
           "type": "object"
         },
         "IntegrationInstallParams": {
@@ -1359,7 +2065,9 @@
               "$ref": "#/schemas/request/$defs/IntegrationTarget"
             }
           },
-          "required": ["target"],
+          "required": [
+            "target"
+          ],
           "type": "object"
         },
         "IntegrationTarget": {
@@ -1387,7 +2095,9 @@
               "$ref": "#/schemas/request/$defs/IntegrationTarget"
             }
           },
-          "required": ["target"],
+          "required": [
+            "target"
+          ],
           "type": "object"
         },
         "LayoutApplyParams": {
@@ -1400,25 +2110,42 @@
               "$ref": "#/schemas/request/$defs/LayoutNode"
             },
             "tab_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "tab_label": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "workspace_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "required": ["root"],
+          "required": [
+            "root"
+          ],
           "type": "object"
         },
         "LayoutExportParams": {
           "properties": {
             "pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "tab_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -1431,10 +2158,16 @@
                   "items": {
                     "type": "string"
                   },
-                  "type": ["array", "null"]
+                  "type": [
+                    "array",
+                    "null"
+                  ]
                 },
                 "cwd": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "env": {
                   "additionalProperties": {
@@ -1443,17 +2176,25 @@
                   "type": "object"
                 },
                 "label": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "pane_id": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "type": {
                   "const": "pane",
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -1476,7 +2217,13 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "direction", "ratio", "first", "second"],
+              "required": [
+                "type",
+                "direction",
+                "ratio",
+                "first",
+                "second"
+              ],
               "type": "object"
             }
           ]
@@ -1484,7 +2231,10 @@
         "LayoutSetSplitRatioParams": {
           "properties": {
             "pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "path": {
               "items": {
@@ -1497,16 +2247,25 @@
               "type": "number"
             },
             "tab_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "required": ["path", "ratio"],
+          "required": [
+            "path",
+            "ratio"
+          ],
           "type": "object"
         },
         "NotificationShowParams": {
           "properties": {
             "body": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "position": {
               "anyOf": [
@@ -1525,11 +2284,17 @@
               "type": "string"
             }
           },
-          "required": ["title"],
+          "required": [
+            "title"
+          ],
           "type": "object"
         },
         "NotificationShowSound": {
-          "enum": ["none", "done", "request"],
+          "enum": [
+            "none",
+            "done",
+            "request"
+          ],
           "type": "string"
         },
         "OutputMatch": {
@@ -1544,7 +2309,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "value"],
+              "required": [
+                "type",
+                "value"
+              ],
               "type": "object"
             },
             {
@@ -1557,13 +2325,21 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "value"],
+              "required": [
+                "type",
+                "value"
+              ],
               "type": "object"
             }
           ]
         },
         "PaneAgentState": {
-          "enum": ["idle", "working", "blocked", "unknown"],
+          "enum": [
+            "idle",
+            "working",
+            "blocked",
+            "unknown"
+          ],
           "type": "string"
         },
         "PaneClearAgentAuthorityParams": {
@@ -1574,31 +2350,50 @@
             "seq": {
               "format": "uint64",
               "minimum": 0,
-              "type": ["integer", "null"]
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "source": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "required": ["pane_id"],
+          "required": [
+            "pane_id"
+          ],
           "type": "object"
         },
         "PaneCurrentParams": {
           "properties": {
             "caller_pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
         },
         "PaneDirection": {
-          "enum": ["left", "right", "up", "down"],
+          "enum": [
+            "left",
+            "right",
+            "up",
+            "down"
+          ],
           "type": "string"
         },
         "PaneEdgesParams": {
           "properties": {
             "pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -1609,16 +2404,110 @@
               "$ref": "#/schemas/request/$defs/PaneDirection"
             },
             "pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "required": ["direction"],
+          "required": [
+            "direction"
+          ],
+          "type": "object"
+        },
+        "PaneGraphicsClearParams": {
+          "properties": {
+            "pane_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id"
+          ],
+          "type": "object"
+        },
+        "PaneGraphicsFormat": {
+          "enum": [
+            "png",
+            "rgb",
+            "rgba"
+          ],
+          "type": "string"
+        },
+        "PaneGraphicsPlacementParams": {
+          "properties": {
+            "grid_cols": {
+              "default": 0,
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "grid_rows": {
+              "default": 0,
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "viewport_col": {
+              "default": 0,
+              "format": "int32",
+              "type": "integer"
+            },
+            "viewport_row": {
+              "default": 0,
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "PaneGraphicsSetParams": {
+          "properties": {
+            "data_base64": {
+              "default": "",
+              "type": "string"
+            },
+            "format": {
+              "$ref": "#/schemas/request/$defs/PaneGraphicsFormat"
+            },
+            "image_height": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "image_width": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "placement": {
+              "$ref": "#/schemas/request/$defs/PaneGraphicsPlacementParams",
+              "default": {
+                "grid_cols": 0,
+                "grid_rows": 0,
+                "viewport_col": 0,
+                "viewport_row": 0
+              }
+            }
+          },
+          "required": [
+            "pane_id",
+            "format",
+            "image_width",
+            "image_height"
+          ],
           "type": "object"
         },
         "PaneLayoutParams": {
           "properties": {
             "pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -1626,7 +2515,10 @@
         "PaneListParams": {
           "properties": {
             "workspace_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -1637,7 +2529,10 @@
               "properties": {
                 "ratio": {
                   "format": "float",
-                  "type": ["number", "null"]
+                  "type": [
+                    "number",
+                    "null"
+                  ]
                 },
                 "split": {
                   "$ref": "#/schemas/request/$defs/SplitDirection"
@@ -1646,46 +2541,69 @@
                   "type": "string"
                 },
                 "target_pane_id": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "type": {
                   "const": "tab",
                   "type": "string"
                 }
               },
-              "required": ["type", "tab_id", "split"],
+              "required": [
+                "type",
+                "tab_id",
+                "split"
+              ],
               "type": "object"
             },
             {
               "properties": {
                 "label": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "type": {
                   "const": "new_tab",
                   "type": "string"
                 },
                 "workspace_id": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
               "properties": {
                 "label": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "tab_label": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "type": {
                   "const": "new_workspace",
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             }
           ]
@@ -1703,7 +2621,10 @@
               "type": "string"
             }
           },
-          "required": ["pane_id", "destination"],
+          "required": [
+            "pane_id",
+            "destination"
+          ],
           "type": "object"
         },
         "PaneNeighborParams": {
@@ -1712,16 +2633,24 @@
               "$ref": "#/schemas/request/$defs/PaneDirection"
             },
             "pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "required": ["direction"],
+          "required": [
+            "direction"
+          ],
           "type": "object"
         },
         "PaneProcessInfoParams": {
           "properties": {
             "pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -1735,7 +2664,10 @@
             "lines": {
               "format": "uint32",
               "minimum": 0,
-              "type": ["integer", "null"]
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "pane_id": {
               "type": "string"
@@ -1748,7 +2680,10 @@
               "type": "boolean"
             }
           },
-          "required": ["pane_id", "source"],
+          "required": [
+            "pane_id",
+            "source"
+          ],
           "type": "object"
         },
         "PaneReleaseAgentParams": {
@@ -1762,25 +2697,37 @@
             "seq": {
               "format": "uint64",
               "minimum": 0,
-              "type": ["integer", "null"]
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "source": {
               "type": "string"
             }
           },
-          "required": ["pane_id", "source", "agent"],
+          "required": [
+            "pane_id",
+            "source",
+            "agent"
+          ],
           "type": "object"
         },
         "PaneRenameParams": {
           "properties": {
             "label": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "pane_id": {
               "type": "string"
             }
           },
-          "required": ["pane_id"],
+          "required": [
+            "pane_id"
+          ],
           "type": "object"
         },
         "PaneReportAgentParams": {
@@ -1789,16 +2736,22 @@
               "type": "string"
             },
             "agent_session_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "agent_session_path": {
-              "type": ["string", "null"]
-            },
-            "custom_status": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "message": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "pane_id": {
               "type": "string"
@@ -1806,7 +2759,10 @@
             "seq": {
               "format": "uint64",
               "minimum": 0,
-              "type": ["integer", "null"]
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "source": {
               "type": "string"
@@ -1815,7 +2771,12 @@
               "$ref": "#/schemas/request/$defs/PaneAgentState"
             }
           },
-          "required": ["pane_id", "source", "agent", "state"],
+          "required": [
+            "pane_id",
+            "source",
+            "agent",
+            "state"
+          ],
           "type": "object"
         },
         "PaneReportAgentSessionParams": {
@@ -1824,10 +2785,16 @@
               "type": "string"
             },
             "agent_session_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "agent_session_path": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "pane_id": {
               "type": "string"
@@ -1835,29 +2802,41 @@
             "seq": {
               "format": "uint64",
               "minimum": 0,
-              "type": ["integer", "null"]
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "session_start_source": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "source": {
               "type": "string"
             }
           },
-          "required": ["pane_id", "source", "agent"],
+          "required": [
+            "pane_id",
+            "source",
+            "agent"
+          ],
           "type": "object"
         },
         "PaneReportMetadataParams": {
           "properties": {
             "agent": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "applies_to_source": {
-              "type": ["string", "null"]
-            },
-            "clear_custom_status": {
-              "default": false,
-              "type": "boolean"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "clear_display_agent": {
               "default": false,
@@ -1871,11 +2850,11 @@
               "default": false,
               "type": "boolean"
             },
-            "custom_status": {
-              "type": ["string", "null"]
-            },
             "display_agent": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "pane_id": {
               "type": "string"
@@ -1883,7 +2862,10 @@
             "seq": {
               "format": "uint64",
               "minimum": 0,
-              "type": ["integer", "null"]
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "source": {
               "type": "string"
@@ -1895,31 +2877,62 @@
               "type": "object"
             },
             "title": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tokens": {
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "maxProperties": 16,
+              "propertyNames": {
+                "pattern": "^[A-Za-z0-9_-]{1,32}$"
+              },
+              "type": "object"
             },
             "ttl_ms": {
               "format": "uint64",
-              "minimum": 0,
-              "type": ["integer", "null"]
+              "maximum": 86400000,
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
-          "required": ["pane_id", "source"],
+          "required": [
+            "pane_id",
+            "source"
+          ],
           "type": "object"
         },
         "PaneResizeParams": {
           "properties": {
             "amount": {
               "format": "float",
-              "type": ["number", "null"]
+              "type": [
+                "number",
+                "null"
+              ]
             },
             "direction": {
               "$ref": "#/schemas/request/$defs/PaneDirection"
             },
             "pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "required": ["direction"],
+          "required": [
+            "direction"
+          ],
           "type": "object"
         },
         "PaneSendInputParams": {
@@ -1937,7 +2950,9 @@
               "type": "string"
             }
           },
-          "required": ["pane_id"],
+          "required": [
+            "pane_id"
+          ],
           "type": "object"
         },
         "PaneSendKeysParams": {
@@ -1952,7 +2967,10 @@
               "type": "string"
             }
           },
-          "required": ["pane_id", "keys"],
+          "required": [
+            "pane_id",
+            "keys"
+          ],
           "type": "object"
         },
         "PaneSendTextParams": {
@@ -1964,13 +2982,19 @@
               "type": "string"
             }
           },
-          "required": ["pane_id", "text"],
+          "required": [
+            "pane_id",
+            "text"
+          ],
           "type": "object"
         },
         "PaneSplitParams": {
           "properties": {
             "cwd": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "direction": {
               "$ref": "#/schemas/request/$defs/SplitDirection"
@@ -1987,16 +3011,27 @@
             },
             "ratio": {
               "format": "float",
-              "type": ["number", "null"]
+              "type": [
+                "number",
+                "null"
+              ]
             },
             "target_pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "workspace_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "required": ["direction"],
+          "required": [
+            "direction"
+          ],
           "type": "object"
         },
         "PaneSwapParams": {
@@ -2012,13 +3047,22 @@
               ]
             },
             "pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "source_pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "target_pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -2029,7 +3073,9 @@
               "type": "string"
             }
           },
-          "required": ["pane_id"],
+          "required": [
+            "pane_id"
+          ],
           "type": "object"
         },
         "PaneWaitForOutputParams": {
@@ -2037,7 +3083,10 @@
             "lines": {
               "format": "uint32",
               "minimum": 0,
-              "type": ["integer", "null"]
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "match": {
               "$ref": "#/schemas/request/$defs/OutputMatch"
@@ -2055,14 +3104,25 @@
             "timeout_ms": {
               "format": "uint64",
               "minimum": 0,
-              "type": ["integer", "null"]
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
-          "required": ["pane_id", "source", "match"],
+          "required": [
+            "pane_id",
+            "source",
+            "match"
+          ],
           "type": "object"
         },
         "PaneZoomMode": {
-          "enum": ["toggle", "on", "off"],
+          "enum": [
+            "toggle",
+            "on",
+            "off"
+          ],
           "type": "string"
         },
         "PaneZoomParams": {
@@ -2072,7 +3132,10 @@
               "default": "toggle"
             },
             "pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -2096,16 +3159,24 @@
               ]
             },
             "plugin_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "required": ["action_id"],
+          "required": [
+            "action_id"
+          ],
           "type": "object"
         },
         "PluginActionListParams": {
           "properties": {
             "plugin_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -2113,19 +3184,34 @@
         "PluginInvocationContext": {
           "properties": {
             "clicked_url": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "correlation_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "focused_pane_agent": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "focused_pane_cwd": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "focused_pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "focused_pane_status": {
               "anyOf": [
@@ -2138,28 +3224,52 @@
               ]
             },
             "invocation_source": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "link_handler_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "selected_text": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "tab_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "tab_label": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "workspace_cwd": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "workspace_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "workspace_label": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "worktree": {
               "anyOf": [
@@ -2194,13 +3304,18 @@
               ]
             }
           },
-          "required": ["path"],
+          "required": [
+            "path"
+          ],
           "type": "object"
         },
         "PluginListParams": {
           "properties": {
             "plugin_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -2210,10 +3325,16 @@
             "limit": {
               "format": "uint",
               "minimum": 0,
-              "type": ["integer", "null"]
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "plugin_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -2224,7 +3345,9 @@
               "type": "string"
             }
           },
-          "required": ["pane_id"],
+          "required": [
+            "pane_id"
+          ],
           "type": "object"
         },
         "PluginPaneFocusParams": {
@@ -2233,13 +3356,18 @@
               "type": "string"
             }
           },
-          "required": ["pane_id"],
+          "required": [
+            "pane_id"
+          ],
           "type": "object"
         },
         "PluginPaneOpenParams": {
           "properties": {
             "cwd": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "direction": {
               "anyOf": [
@@ -2264,6 +3392,16 @@
               "default": false,
               "type": "boolean"
             },
+            "height": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/PopupSize"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "placement": {
               "anyOf": [
                 {
@@ -2278,17 +3416,42 @@
               "type": "string"
             },
             "target_pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "width": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/PopupSize"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "workspace_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "required": ["plugin_id", "entrypoint"],
+          "required": [
+            "plugin_id",
+            "entrypoint"
+          ],
           "type": "object"
         },
         "PluginPanePlacement": {
-          "enum": ["overlay", "split", "tab", "zoomed"],
+          "enum": [
+            "overlay",
+            "popup",
+            "split",
+            "tab",
+            "zoomed"
+          ],
           "type": "string"
         },
         "PluginSetEnabledParams": {
@@ -2297,7 +3460,9 @@
               "type": "string"
             }
           },
-          "required": ["plugin_id"],
+          "required": [
+            "plugin_id"
+          ],
           "type": "object"
         },
         "PluginSourceInfo": {
@@ -2305,35 +3470,59 @@
             "installed_unix_ms": {
               "format": "uint64",
               "minimum": 0,
-              "type": ["integer", "null"]
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "kind": {
               "$ref": "#/schemas/request/$defs/PluginSourceKind",
               "default": "local"
             },
             "managed_path": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "owner": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "repo": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "requested_ref": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "resolved_commit": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "subdir": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
         },
         "PluginSourceKind": {
-          "enum": ["local", "github"],
+          "enum": [
+            "local",
+            "github"
+          ],
           "type": "string"
         },
         "PluginUnlinkParams": {
@@ -2342,15 +3531,40 @@
               "type": "string"
             }
           },
-          "required": ["plugin_id"],
+          "required": [
+            "plugin_id"
+          ],
           "type": "object"
         },
+        "PopupSize": {
+          "oneOf": [
+            {
+              "description": "Outer popup size in terminal cells, including the border.",
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "description": "Outer popup size as a percentage of the terminal area, for example 80%.",
+              "pattern": "^(100|[1-9][0-9]?)%$",
+              "type": "string"
+            }
+          ]
+        },
         "ReadFormat": {
-          "enum": ["text", "ansi"],
+          "enum": [
+            "text",
+            "ansi"
+          ],
           "type": "string"
         },
         "ReadSource": {
-          "enum": ["visible", "recent", "recent_unwrapped", "detection"],
+          "enum": [
+            "visible",
+            "recent",
+            "recent_unwrapped",
+            "detection"
+          ],
           "type": "string"
         },
         "ServerLiveHandoffParams": {
@@ -2358,19 +3572,31 @@
             "expected_protocol": {
               "format": "uint32",
               "minimum": 0,
-              "type": ["integer", "null"]
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "expected_version": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "import_exe": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
         },
         "SplitDirection": {
-          "enum": ["right", "down"],
+          "enum": [
+            "right",
+            "down"
+          ],
           "type": "string"
         },
         "Subscription": {
@@ -2382,7 +3608,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2392,7 +3620,21 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace.metadata_updated",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2402,7 +3644,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2412,7 +3656,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2422,7 +3668,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2432,7 +3680,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2442,7 +3692,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2452,7 +3704,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2462,7 +3716,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2472,7 +3728,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2482,7 +3740,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2492,7 +3752,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2502,7 +3764,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2512,7 +3776,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2522,7 +3788,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2532,7 +3800,21 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "pane.updated",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2542,7 +3824,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2552,7 +3836,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2562,7 +3848,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2572,7 +3860,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -2580,7 +3870,10 @@
                 "lines": {
                   "format": "uint32",
                   "minimum": 0,
-                  "type": ["integer", "null"]
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
                 },
                 "match": {
                   "$ref": "#/schemas/request/$defs/OutputMatch"
@@ -2600,7 +3893,12 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane_id", "source", "match"],
+              "required": [
+                "type",
+                "pane_id",
+                "source",
+                "match"
+              ],
               "type": "object"
             },
             {
@@ -2623,7 +3921,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane_id"],
+              "required": [
+                "type",
+                "pane_id"
+              ],
               "type": "object"
             },
             {
@@ -2636,7 +3937,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane_id"],
+              "required": [
+                "type",
+                "pane_id"
+              ],
               "type": "object"
             },
             {
@@ -2646,7 +3950,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             }
           ]
@@ -2654,7 +3960,10 @@
         "TabCreateParams": {
           "properties": {
             "cwd": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "env": {
               "additionalProperties": {
@@ -2667,10 +3976,16 @@
               "type": "boolean"
             },
             "label": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "workspace_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -2678,7 +3993,10 @@
         "TabListParams": {
           "properties": {
             "workspace_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -2694,7 +4012,10 @@
               "type": "string"
             }
           },
-          "required": ["tab_id", "insert_index"],
+          "required": [
+            "tab_id",
+            "insert_index"
+          ],
           "type": "object"
         },
         "TabRenameParams": {
@@ -2706,7 +4027,10 @@
               "type": "string"
             }
           },
-          "required": ["tab_id", "label"],
+          "required": [
+            "tab_id",
+            "label"
+          ],
           "type": "object"
         },
         "TabTarget": {
@@ -2715,17 +4039,27 @@
               "type": "string"
             }
           },
-          "required": ["tab_id"],
+          "required": [
+            "tab_id"
+          ],
           "type": "object"
         },
         "ToastHerdrPosition": {
-          "enum": ["top-left", "top-right", "bottom-left", "bottom-right"],
+          "enum": [
+            "top-left",
+            "top-right",
+            "bottom-left",
+            "bottom-right"
+          ],
           "type": "string"
         },
         "WorkspaceCreateParams": {
           "properties": {
             "cwd": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "env": {
               "additionalProperties": {
@@ -2738,7 +4072,10 @@
               "type": "boolean"
             },
             "label": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -2754,7 +4091,10 @@
               "type": "string"
             }
           },
-          "required": ["workspace_id", "insert_index"],
+          "required": [
+            "workspace_id",
+            "insert_index"
+          ],
           "type": "object"
         },
         "WorkspaceRenameParams": {
@@ -2766,7 +4106,56 @@
               "type": "string"
             }
           },
-          "required": ["workspace_id", "label"],
+          "required": [
+            "workspace_id",
+            "label"
+          ],
+          "type": "object"
+        },
+        "WorkspaceReportMetadataParams": {
+          "properties": {
+            "seq": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "source": {
+              "type": "string"
+            },
+            "tokens": {
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "maxProperties": 16,
+              "propertyNames": {
+                "pattern": "^[A-Za-z0-9_-]{1,32}$"
+              },
+              "type": "object"
+            },
+            "ttl_ms": {
+              "format": "uint64",
+              "maximum": 86400000,
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "workspace_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "workspace_id",
+            "source",
+            "tokens"
+          ],
           "type": "object"
         },
         "WorkspaceTarget": {
@@ -2775,7 +4164,9 @@
               "type": "string"
             }
           },
-          "required": ["workspace_id"],
+          "required": [
+            "workspace_id"
+          ],
           "type": "object"
         },
         "WorkspaceWorktreeInfo": {
@@ -2796,32 +4187,56 @@
               "type": "string"
             }
           },
-          "required": ["repo_key", "repo_name", "repo_root", "checkout_path", "is_linked_worktree"],
+          "required": [
+            "repo_key",
+            "repo_name",
+            "repo_root",
+            "checkout_path",
+            "is_linked_worktree"
+          ],
           "type": "object"
         },
         "WorktreeCreateParams": {
           "properties": {
             "base": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "branch": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "cwd": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "focus": {
               "default": false,
               "type": "boolean"
             },
             "label": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "path": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "workspace_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -2829,10 +4244,16 @@
         "WorktreeListParams": {
           "properties": {
             "cwd": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "workspace_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -2840,23 +4261,38 @@
         "WorktreeOpenParams": {
           "properties": {
             "branch": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "cwd": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "focus": {
               "default": false,
               "type": "boolean"
             },
             "label": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "path": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "workspace_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -2871,7 +4307,9 @@
               "type": "string"
             }
           },
-          "required": ["workspace_id"],
+          "required": [
+            "workspace_id"
+          ],
           "type": "object"
         }
       },
@@ -2887,7 +4325,10 @@
               "$ref": "#/schemas/request/$defs/PingParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -2900,7 +4341,10 @@
               "$ref": "#/schemas/request/$defs/EmptyParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -2913,7 +4357,10 @@
               "$ref": "#/schemas/request/$defs/ServerLiveHandoffParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -2926,7 +4373,10 @@
               "$ref": "#/schemas/request/$defs/EmptyParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -2939,7 +4389,10 @@
               "$ref": "#/schemas/request/$defs/EmptyParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -2952,7 +4405,10 @@
               "$ref": "#/schemas/request/$defs/EmptyParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -2965,7 +4421,10 @@
               "$ref": "#/schemas/request/$defs/NotificationShowParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -2978,7 +4437,10 @@
               "$ref": "#/schemas/request/$defs/ClientWindowTitleSetParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -2991,7 +4453,10 @@
               "$ref": "#/schemas/request/$defs/EmptyParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3004,7 +4469,10 @@
               "$ref": "#/schemas/request/$defs/EmptyParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3017,7 +4485,10 @@
               "$ref": "#/schemas/request/$defs/WorkspaceCreateParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3030,7 +4501,10 @@
               "$ref": "#/schemas/request/$defs/EmptyParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3043,7 +4517,10 @@
               "$ref": "#/schemas/request/$defs/WorkspaceTarget"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3056,7 +4533,10 @@
               "$ref": "#/schemas/request/$defs/WorkspaceTarget"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3069,7 +4549,10 @@
               "$ref": "#/schemas/request/$defs/WorkspaceRenameParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3082,7 +4565,26 @@
               "$ref": "#/schemas/request/$defs/WorkspaceMoveParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "workspace.report_metadata",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/WorkspaceReportMetadataParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3095,7 +4597,10 @@
               "$ref": "#/schemas/request/$defs/WorkspaceTarget"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3108,7 +4613,10 @@
               "$ref": "#/schemas/request/$defs/WorktreeListParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3121,7 +4629,10 @@
               "$ref": "#/schemas/request/$defs/WorktreeCreateParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3134,7 +4645,10 @@
               "$ref": "#/schemas/request/$defs/WorktreeOpenParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3147,7 +4661,10 @@
               "$ref": "#/schemas/request/$defs/WorktreeRemoveParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3160,7 +4677,10 @@
               "$ref": "#/schemas/request/$defs/TabCreateParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3173,7 +4693,10 @@
               "$ref": "#/schemas/request/$defs/TabListParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3186,7 +4709,10 @@
               "$ref": "#/schemas/request/$defs/TabTarget"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3199,7 +4725,10 @@
               "$ref": "#/schemas/request/$defs/TabTarget"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3212,7 +4741,10 @@
               "$ref": "#/schemas/request/$defs/TabRenameParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3225,7 +4757,10 @@
               "$ref": "#/schemas/request/$defs/TabMoveParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3238,7 +4773,10 @@
               "$ref": "#/schemas/request/$defs/TabTarget"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3251,7 +4789,10 @@
               "$ref": "#/schemas/request/$defs/EmptyParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3264,7 +4805,10 @@
               "$ref": "#/schemas/request/$defs/AgentTarget"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3277,7 +4821,10 @@
               "$ref": "#/schemas/request/$defs/AgentReadParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3290,20 +4837,26 @@
               "$ref": "#/schemas/request/$defs/AgentTarget"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
           "properties": {
             "method": {
-              "const": "agent.send",
+              "const": "agent.send_keys",
               "type": "string"
             },
             "params": {
-              "$ref": "#/schemas/request/$defs/AgentSendParams"
+              "$ref": "#/schemas/request/$defs/AgentSendKeysParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3316,7 +4869,42 @@
               "$ref": "#/schemas/request/$defs/AgentRenameParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "agent.view.set",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/AgentViewSetParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "agent.view.clear",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/AgentViewClearParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3329,7 +4917,10 @@
               "$ref": "#/schemas/request/$defs/AgentTarget"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3342,7 +4933,42 @@
               "$ref": "#/schemas/request/$defs/AgentStartParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "agent.prompt",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/AgentPromptParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "agent.wait",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/AgentWaitParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3355,7 +4981,10 @@
               "$ref": "#/schemas/request/$defs/PaneSplitParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3368,7 +4997,10 @@
               "$ref": "#/schemas/request/$defs/PaneSwapParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3381,7 +5013,10 @@
               "$ref": "#/schemas/request/$defs/PaneMoveParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3394,7 +5029,10 @@
               "$ref": "#/schemas/request/$defs/PaneZoomParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3407,7 +5045,10 @@
               "$ref": "#/schemas/request/$defs/PaneLayoutParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3420,7 +5061,10 @@
               "$ref": "#/schemas/request/$defs/PaneProcessInfoParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3433,7 +5077,10 @@
               "$ref": "#/schemas/request/$defs/LayoutExportParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3446,7 +5093,10 @@
               "$ref": "#/schemas/request/$defs/LayoutApplyParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3459,7 +5109,10 @@
               "$ref": "#/schemas/request/$defs/LayoutSetSplitRatioParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3472,7 +5125,10 @@
               "$ref": "#/schemas/request/$defs/PaneNeighborParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3485,7 +5141,10 @@
               "$ref": "#/schemas/request/$defs/PaneEdgesParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3498,7 +5157,10 @@
               "$ref": "#/schemas/request/$defs/PaneFocusDirectionParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3511,7 +5173,10 @@
               "$ref": "#/schemas/request/$defs/PaneResizeParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3524,7 +5189,10 @@
               "$ref": "#/schemas/request/$defs/PaneListParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3537,7 +5205,10 @@
               "$ref": "#/schemas/request/$defs/PaneCurrentParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3550,7 +5221,10 @@
               "$ref": "#/schemas/request/$defs/PaneTarget"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3563,7 +5237,10 @@
               "$ref": "#/schemas/request/$defs/PaneTarget"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3576,7 +5253,10 @@
               "$ref": "#/schemas/request/$defs/PaneRenameParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3589,7 +5269,10 @@
               "$ref": "#/schemas/request/$defs/PaneSendTextParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3602,7 +5285,10 @@
               "$ref": "#/schemas/request/$defs/PaneSendKeysParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3615,7 +5301,10 @@
               "$ref": "#/schemas/request/$defs/PaneSendInputParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3628,7 +5317,58 @@
               "$ref": "#/schemas/request/$defs/PaneReadParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.graphics.set",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneGraphicsSetParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.graphics.clear",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneGraphicsClearParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.graphics.info",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneTarget"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3641,7 +5381,10 @@
               "$ref": "#/schemas/request/$defs/PaneReportAgentParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3654,7 +5397,10 @@
               "$ref": "#/schemas/request/$defs/PaneReportAgentSessionParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3667,7 +5413,10 @@
               "$ref": "#/schemas/request/$defs/PaneReportMetadataParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3680,7 +5429,10 @@
               "$ref": "#/schemas/request/$defs/PaneClearAgentAuthorityParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3693,7 +5445,10 @@
               "$ref": "#/schemas/request/$defs/PaneReleaseAgentParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3706,7 +5461,26 @@
               "$ref": "#/schemas/request/$defs/PaneTarget"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "popup.close",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/EmptyParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3719,7 +5493,10 @@
               "$ref": "#/schemas/request/$defs/EventsSubscribeParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3732,7 +5509,10 @@
               "$ref": "#/schemas/request/$defs/EventsWaitParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3745,7 +5525,10 @@
               "$ref": "#/schemas/request/$defs/PaneWaitForOutputParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3758,7 +5541,10 @@
               "$ref": "#/schemas/request/$defs/IntegrationInstallParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3771,7 +5557,10 @@
               "$ref": "#/schemas/request/$defs/IntegrationUninstallParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3784,7 +5573,10 @@
               "$ref": "#/schemas/request/$defs/PluginLinkParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3797,7 +5589,10 @@
               "$ref": "#/schemas/request/$defs/PluginListParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3810,7 +5605,10 @@
               "$ref": "#/schemas/request/$defs/PluginUnlinkParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3823,7 +5621,10 @@
               "$ref": "#/schemas/request/$defs/PluginSetEnabledParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3836,7 +5637,10 @@
               "$ref": "#/schemas/request/$defs/PluginSetEnabledParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3849,7 +5653,10 @@
               "$ref": "#/schemas/request/$defs/PluginActionListParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3862,7 +5669,10 @@
               "$ref": "#/schemas/request/$defs/PluginActionInvokeParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3875,7 +5685,10 @@
               "$ref": "#/schemas/request/$defs/PluginLogListParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3888,7 +5701,10 @@
               "$ref": "#/schemas/request/$defs/PluginPaneOpenParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3901,7 +5717,10 @@
               "$ref": "#/schemas/request/$defs/PluginPaneFocusParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         },
         {
@@ -3914,7 +5733,10 @@
               "$ref": "#/schemas/request/$defs/PluginPaneCloseParams"
             }
           },
-          "required": ["method", "params"],
+          "required": [
+            "method",
+            "params"
+          ],
           "type": "object"
         }
       ],
@@ -3923,29 +5745,40 @@
           "type": "string"
         }
       },
-      "required": ["id"],
+      "required": [
+        "id"
+      ],
       "title": "Request",
       "type": "object"
     },
     "subscription_event": {
       "$defs": {
         "AgentStatus": {
-          "enum": ["idle", "working", "blocked", "done", "unknown"],
+          "enum": [
+            "idle",
+            "working",
+            "blocked",
+            "done",
+            "unknown"
+          ],
           "type": "string"
         },
         "PaneAgentStatusChangedEvent": {
           "properties": {
             "agent": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "agent_status": {
               "$ref": "#/schemas/subscription_event/$defs/AgentStatus"
             },
-            "custom_status": {
-              "type": ["string", "null"]
-            },
             "display_agent": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "pane_id": {
               "type": "string"
@@ -3957,13 +5790,20 @@
               "type": "object"
             },
             "title": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "workspace_id": {
               "type": "string"
             }
           },
-          "required": ["pane_id", "workspace_id", "agent_status"],
+          "required": [
+            "pane_id",
+            "workspace_id",
+            "agent_status"
+          ],
           "type": "object"
         },
         "PaneOutputMatchedEvent": {
@@ -3978,7 +5818,11 @@
               "$ref": "#/schemas/subscription_event/$defs/PaneReadResult"
             }
           },
-          "required": ["pane_id", "matched_line", "read"],
+          "required": [
+            "pane_id",
+            "matched_line",
+            "read"
+          ],
           "type": "object"
         },
         "PaneReadResult": {
@@ -4034,7 +5878,11 @@
               "type": "string"
             }
           },
-          "required": ["pane_id", "workspace_id", "scroll"],
+          "required": [
+            "pane_id",
+            "workspace_id",
+            "scroll"
+          ],
           "type": "object"
         },
         "PaneScrollInfo": {
@@ -4055,15 +5903,27 @@
               "type": "integer"
             }
           },
-          "required": ["offset_from_bottom", "max_offset_from_bottom", "viewport_rows"],
+          "required": [
+            "offset_from_bottom",
+            "max_offset_from_bottom",
+            "viewport_rows"
+          ],
           "type": "object"
         },
         "ReadFormat": {
-          "enum": ["text", "ansi"],
+          "enum": [
+            "text",
+            "ansi"
+          ],
           "type": "string"
         },
         "ReadSource": {
-          "enum": ["visible", "recent", "recent_unwrapped", "detection"],
+          "enum": [
+            "visible",
+            "recent",
+            "recent_unwrapped",
+            "detection"
+          ],
           "type": "string"
         },
         "SubscriptionEventData": {
@@ -4080,7 +5940,11 @@
           ]
         },
         "SubscriptionEventKind": {
-          "enum": ["pane.output_matched", "pane.agent_status_changed", "pane.scroll_changed"],
+          "enum": [
+            "pane.output_matched",
+            "pane.agent_status_changed",
+            "pane.scroll_changed"
+          ],
           "type": "string"
         }
       },
@@ -4093,7 +5957,10 @@
           "$ref": "#/schemas/subscription_event/$defs/SubscriptionEventKind"
         }
       },
-      "required": ["event", "data"],
+      "required": [
+        "event",
+        "data"
+      ],
       "title": "SubscriptionEventEnvelope",
       "type": "object"
     },
@@ -4102,7 +5969,10 @@
         "AgentInfo": {
           "properties": {
             "agent": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "agent_session": {
               "anyOf": [
@@ -4117,23 +5987,38 @@
             "agent_status": {
               "$ref": "#/schemas/success_response/$defs/AgentStatus"
             },
-            "custom_status": {
-              "type": ["string", "null"]
-            },
             "cwd": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "display_agent": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "focused": {
               "type": "boolean"
             },
             "foreground_cwd": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "interactive_ready": {
+              "type": "boolean"
+            },
+            "launch_pending": {
+              "type": "boolean"
             },
             "name": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "pane_id": {
               "type": "string"
@@ -4145,6 +6030,12 @@
             },
             "screen_detection_skipped": {
               "type": "boolean"
+            },
+            "state_change_seq": {
+              "default": 0,
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
             },
             "state_labels": {
               "additionalProperties": {
@@ -4158,8 +6049,33 @@
             "terminal_id": {
               "type": "string"
             },
+            "terminal_title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "terminal_title_stripped": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "title": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tokens": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "maxProperties": 32,
+              "propertyNames": {
+                "pattern": "^[A-Za-z0-9_-]{1,32}$"
+              },
+              "type": "object"
             },
             "workspace_id": {
               "type": "string"
@@ -4179,13 +6095,19 @@
         "AgentManifestInfo": {
           "properties": {
             "active_version": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "agent": {
               "type": "string"
             },
             "cached_remote_version": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "local_override_shadowing_remote": {
               "type": "boolean"
@@ -4193,13 +6115,22 @@
             "remote_last_checked_unix": {
               "format": "uint64",
               "minimum": 0,
-              "type": ["integer", "null"]
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "remote_update_error": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "remote_update_result": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "source": {
               "type": "string"
@@ -4208,10 +6139,18 @@
               "type": "string"
             },
             "warning": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "required": ["agent", "source", "source_kind", "local_override_shadowing_remote"],
+          "required": [
+            "agent",
+            "source",
+            "source_kind",
+            "local_override_shadowing_remote"
+          ],
           "type": "object"
         },
         "AgentSessionInfo": {
@@ -4229,23 +6168,45 @@
               "type": "string"
             }
           },
-          "required": ["source", "agent", "kind", "value"],
+          "required": [
+            "source",
+            "agent",
+            "kind",
+            "value"
+          ],
           "type": "object"
         },
         "AgentSessionRefKind": {
-          "enum": ["id", "path"],
+          "enum": [
+            "id",
+            "path"
+          ],
           "type": "string"
         },
         "AgentStatus": {
-          "enum": ["idle", "working", "blocked", "done", "unknown"],
+          "enum": [
+            "idle",
+            "working",
+            "blocked",
+            "done",
+            "unknown"
+          ],
           "type": "string"
         },
         "ClientWindowTitleReason": {
-          "enum": ["set", "cleared", "no_foreground_client"],
+          "enum": [
+            "set",
+            "cleared",
+            "no_foreground_client"
+          ],
           "type": "string"
         },
         "ConfigReloadStatus": {
-          "enum": ["applied", "partial", "failed"],
+          "enum": [
+            "applied",
+            "partial",
+            "failed"
+          ],
           "type": "string"
         },
         "EventData": {
@@ -4260,7 +6221,10 @@
                   "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
                 }
               },
-              "required": ["type", "workspace"],
+              "required": [
+                "type",
+                "workspace"
+              ],
               "type": "object"
             },
             {
@@ -4273,7 +6237,26 @@
                   "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
                 }
               },
-              "required": ["type", "workspace"],
+              "required": [
+                "type",
+                "workspace"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace_metadata_updated",
+                  "type": "string"
+                },
+                "workspace": {
+                  "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
+                }
+              },
+              "required": [
+                "type",
+                "workspace"
+              ],
               "type": "object"
             },
             {
@@ -4296,7 +6279,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "workspace_id"],
+              "required": [
+                "type",
+                "workspace_id"
+              ],
               "type": "object"
             },
             {
@@ -4312,7 +6298,11 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "workspace_id", "label"],
+              "required": [
+                "type",
+                "workspace_id",
+                "label"
+              ],
               "type": "object"
             },
             {
@@ -4336,7 +6326,12 @@
                   "type": "array"
                 }
               },
-              "required": ["type", "workspace_id", "insert_index", "workspaces"],
+              "required": [
+                "type",
+                "workspace_id",
+                "insert_index",
+                "workspaces"
+              ],
               "type": "object"
             },
             {
@@ -4349,7 +6344,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "workspace_id"],
+              "required": [
+                "type",
+                "workspace_id"
+              ],
               "type": "object"
             },
             {
@@ -4365,7 +6363,11 @@
                   "$ref": "#/schemas/success_response/$defs/WorktreeInfo"
                 }
               },
-              "required": ["type", "workspace", "worktree"],
+              "required": [
+                "type",
+                "workspace",
+                "worktree"
+              ],
               "type": "object"
             },
             {
@@ -4384,7 +6386,12 @@
                   "$ref": "#/schemas/success_response/$defs/WorktreeInfo"
                 }
               },
-              "required": ["type", "workspace", "worktree", "already_open"],
+              "required": [
+                "type",
+                "workspace",
+                "worktree",
+                "already_open"
+              ],
               "type": "object"
             },
             {
@@ -4413,7 +6420,12 @@
                   "$ref": "#/schemas/success_response/$defs/WorktreeInfo"
                 }
               },
-              "required": ["type", "workspace_id", "worktree", "forced"],
+              "required": [
+                "type",
+                "workspace_id",
+                "worktree",
+                "forced"
+              ],
               "type": "object"
             },
             {
@@ -4426,7 +6438,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "tab"],
+              "required": [
+                "type",
+                "tab"
+              ],
               "type": "object"
             },
             {
@@ -4442,7 +6457,11 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "tab_id", "workspace_id"],
+              "required": [
+                "type",
+                "tab_id",
+                "workspace_id"
+              ],
               "type": "object"
             },
             {
@@ -4461,7 +6480,12 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "tab_id", "workspace_id", "label"],
+              "required": [
+                "type",
+                "tab_id",
+                "workspace_id",
+                "label"
+              ],
               "type": "object"
             },
             {
@@ -4488,7 +6512,13 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "tab_id", "workspace_id", "insert_index", "tabs"],
+              "required": [
+                "type",
+                "tab_id",
+                "workspace_id",
+                "insert_index",
+                "tabs"
+              ],
               "type": "object"
             },
             {
@@ -4504,7 +6534,11 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "tab_id", "workspace_id"],
+              "required": [
+                "type",
+                "tab_id",
+                "workspace_id"
+              ],
               "type": "object"
             },
             {
@@ -4517,7 +6551,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane"],
+              "required": [
+                "type",
+                "pane"
+              ],
               "type": "object"
             },
             {
@@ -4533,7 +6570,27 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane_id", "workspace_id"],
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pane": {
+                  "$ref": "#/schemas/success_response/$defs/PaneInfo"
+                },
+                "type": {
+                  "const": "pane_updated",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane"
+              ],
               "type": "object"
             },
             {
@@ -4549,16 +6606,26 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane_id", "workspace_id"],
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id"
+              ],
               "type": "object"
             },
             {
               "properties": {
                 "closed_tab_id": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "closed_workspace_id": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "created_tab": {
                   "anyOf": [
@@ -4624,7 +6691,12 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane_id", "workspace_id", "revision"],
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id",
+                "revision"
+              ],
               "type": "object"
             },
             {
@@ -4640,16 +6712,36 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane_id", "workspace_id"],
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id"
+              ],
               "type": "object"
             },
             {
               "properties": {
                 "agent": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "final_status": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/success_response/$defs/AgentStatus"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "pane_id": {
                   "type": "string"
+                },
+                "released": {
+                  "type": "boolean"
                 },
                 "type": {
                   "const": "pane_agent_detected",
@@ -4659,22 +6751,29 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane_id", "workspace_id"],
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id"
+              ],
               "type": "object"
             },
             {
               "properties": {
                 "agent": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "agent_status": {
                   "$ref": "#/schemas/success_response/$defs/AgentStatus"
                 },
-                "custom_status": {
-                  "type": ["string", "null"]
-                },
                 "display_agent": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "pane_id": {
                   "type": "string"
@@ -4686,7 +6785,10 @@
                   "type": "object"
                 },
                 "title": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "type": {
                   "const": "pane_agent_status_changed",
@@ -4696,7 +6798,12 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane_id", "workspace_id", "agent_status"],
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id",
+                "agent_status"
+              ],
               "type": "object"
             },
             {
@@ -4709,7 +6816,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "layout"],
+              "required": [
+                "type",
+                "layout"
+              ],
               "type": "object"
             }
           ]
@@ -4723,13 +6833,17 @@
               "$ref": "#/schemas/success_response/$defs/EventKind"
             }
           },
-          "required": ["event", "data"],
+          "required": [
+            "event",
+            "data"
+          ],
           "type": "object"
         },
         "EventKind": {
           "enum": [
             "workspace_created",
             "workspace_updated",
+            "workspace_metadata_updated",
             "workspace_closed",
             "workspace_renamed",
             "workspace_moved",
@@ -4744,6 +6858,7 @@
             "tab_focused",
             "pane_created",
             "pane_closed",
+            "pane_updated",
             "pane_focused",
             "pane_moved",
             "pane_output_changed",
@@ -4769,7 +6884,10 @@
               "type": "array"
             },
             "description": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "enabled": {
               "type": "boolean"
@@ -4806,7 +6924,10 @@
               "items": {
                 "$ref": "#/schemas/success_response/$defs/PluginPlatform"
               },
-              "type": ["array", "null"]
+              "type": [
+                "array",
+                "null"
+              ]
             },
             "plugin_id": {
               "type": "string"
@@ -4820,6 +6941,12 @@
                 "kind": "local"
               }
             },
+            "startup": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PluginManifestStartup"
+              },
+              "type": "array"
+            },
             "version": {
               "type": "string"
             },
@@ -4831,7 +6958,14 @@
               "type": "array"
             }
           },
-          "required": ["plugin_id", "name", "version", "manifest_path", "plugin_root", "enabled"],
+          "required": [
+            "plugin_id",
+            "name",
+            "version",
+            "manifest_path",
+            "plugin_root",
+            "enabled"
+          ],
           "type": "object"
         },
         "IntegrationInstallResult": {
@@ -4843,7 +6977,9 @@
               "type": "array"
             }
           },
-          "required": ["messages"],
+          "required": [
+            "messages"
+          ],
           "type": "object"
         },
         "IntegrationTarget": {
@@ -4874,7 +7010,9 @@
               "type": "array"
             }
           },
-          "required": ["messages"],
+          "required": [
+            "messages"
+          ],
           "type": "object"
         },
         "LayoutDescription": {
@@ -4895,7 +7033,13 @@
               "type": "boolean"
             }
           },
-          "required": ["workspace_id", "tab_id", "zoomed", "focused_pane_id", "root"],
+          "required": [
+            "workspace_id",
+            "tab_id",
+            "zoomed",
+            "focused_pane_id",
+            "root"
+          ],
           "type": "object"
         },
         "LayoutNode": {
@@ -4906,10 +7050,16 @@
                   "items": {
                     "type": "string"
                   },
-                  "type": ["array", "null"]
+                  "type": [
+                    "array",
+                    "null"
+                  ]
                 },
                 "cwd": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "env": {
                   "additionalProperties": {
@@ -4918,17 +7068,25 @@
                   "type": "object"
                 },
                 "label": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "pane_id": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "type": {
                   "const": "pane",
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -4951,17 +7109,34 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "direction", "ratio", "first", "second"],
+              "required": [
+                "type",
+                "direction",
+                "ratio",
+                "first",
+                "second"
+              ],
               "type": "object"
             }
           ]
         },
         "NotificationShowReason": {
-          "enum": ["shown", "disabled", "rate_limited", "no_foreground_client", "busy"],
+          "enum": [
+            "shown",
+            "disabled",
+            "rate_limited",
+            "no_foreground_client",
+            "busy"
+          ],
           "type": "string"
         },
         "PaneDirection": {
-          "enum": ["left", "right", "up", "down"],
+          "enum": [
+            "left",
+            "right",
+            "up",
+            "down"
+          ],
           "type": "string"
         },
         "PaneEdgesResult": {
@@ -4985,11 +7160,20 @@
               "type": "boolean"
             }
           },
-          "required": ["pane_id", "left", "right", "up", "down", "layout"],
+          "required": [
+            "pane_id",
+            "left",
+            "right",
+            "up",
+            "down",
+            "layout"
+          ],
           "type": "object"
         },
         "PaneFocusDirectionReason": {
-          "enum": ["no_neighbor"],
+          "enum": [
+            "no_neighbor"
+          ],
           "type": "string"
         },
         "PaneFocusDirectionResult": {
@@ -4998,7 +7182,10 @@
               "type": "boolean"
             },
             "focused_pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "layout": {
               "$ref": "#/schemas/success_response/$defs/PaneLayoutSnapshot"
@@ -5017,13 +7204,20 @@
               "type": "string"
             }
           },
-          "required": ["changed", "source_pane_id", "layout"],
+          "required": [
+            "changed",
+            "source_pane_id",
+            "layout"
+          ],
           "type": "object"
         },
         "PaneInfo": {
           "properties": {
             "agent": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "agent_session": {
               "anyOf": [
@@ -5038,23 +7232,32 @@
             "agent_status": {
               "$ref": "#/schemas/success_response/$defs/AgentStatus"
             },
-            "custom_status": {
-              "type": ["string", "null"]
-            },
             "cwd": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "display_agent": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "focused": {
               "type": "boolean"
             },
             "foreground_cwd": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "label": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "pane_id": {
               "type": "string"
@@ -5086,8 +7289,33 @@
             "terminal_id": {
               "type": "string"
             },
+            "terminal_title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "terminal_title_stripped": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "title": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tokens": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "maxProperties": 32,
+              "propertyNames": {
+                "pattern": "^[A-Za-z0-9_-]{1,32}$"
+              },
+              "type": "object"
             },
             "workspace_id": {
               "type": "string"
@@ -5116,7 +7344,11 @@
               "$ref": "#/schemas/success_response/$defs/PaneLayoutRect"
             }
           },
-          "required": ["pane_id", "focused", "rect"],
+          "required": [
+            "pane_id",
+            "focused",
+            "rect"
+          ],
           "type": "object"
         },
         "PaneLayoutRect": {
@@ -5146,7 +7378,12 @@
               "type": "integer"
             }
           },
-          "required": ["x", "y", "width", "height"],
+          "required": [
+            "x",
+            "y",
+            "width",
+            "height"
+          ],
           "type": "object"
         },
         "PaneLayoutSnapshot": {
@@ -5206,11 +7443,19 @@
               "$ref": "#/schemas/success_response/$defs/PaneLayoutRect"
             }
           },
-          "required": ["id", "direction", "ratio", "rect"],
+          "required": [
+            "id",
+            "direction",
+            "ratio",
+            "rect"
+          ],
           "type": "object"
         },
         "PaneMoveReason": {
-          "enum": ["same_tab", "zoomed_tab"],
+          "enum": [
+            "same_tab",
+            "zoomed_tab"
+          ],
           "type": "string"
         },
         "PaneMoveResult": {
@@ -5219,10 +7464,16 @@
               "type": "boolean"
             },
             "closed_tab_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "closed_workspace_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "created_tab": {
               "anyOf": [
@@ -5303,13 +7554,20 @@
               "$ref": "#/schemas/success_response/$defs/PaneLayoutSnapshot"
             },
             "neighbor_pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "pane_id": {
               "type": "string"
             }
           },
-          "required": ["pane_id", "direction", "layout"],
+          "required": [
+            "pane_id",
+            "direction",
+            "layout"
+          ],
           "type": "object"
         },
         "PaneProcessInfo": {
@@ -5317,7 +7575,10 @@
             "foreground_process_group_id": {
               "format": "uint32",
               "minimum": 0,
-              "type": ["integer", "null"]
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "foreground_processes": {
               "items": {
@@ -5331,13 +7592,21 @@
             "shell_pid": {
               "format": "uint32",
               "minimum": 0,
-              "type": ["integer", "null"]
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "tty": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "required": ["pane_id"],
+          "required": [
+            "pane_id"
+          ],
           "type": "object"
         },
         "PaneProcessInfoProcess": {
@@ -5346,16 +7615,28 @@
               "items": {
                 "type": "string"
               },
-              "type": ["array", "null"]
+              "type": [
+                "array",
+                "null"
+              ]
             },
             "argv0": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "cmdline": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "cwd": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "name": {
               "type": "string"
@@ -5366,7 +7647,10 @@
               "type": "integer"
             }
           },
-          "required": ["pid", "name"],
+          "required": [
+            "pid",
+            "name"
+          ],
           "type": "object"
         },
         "PaneReadResult": {
@@ -5411,7 +7695,9 @@
           "type": "object"
         },
         "PaneResizeReason": {
-          "enum": ["unchanged"],
+          "enum": [
+            "unchanged"
+          ],
           "type": "string"
         },
         "PaneResizeResult": {
@@ -5439,7 +7725,12 @@
               ]
             }
           },
-          "required": ["changed", "pane_id", "focused_pane_id", "layout"],
+          "required": [
+            "changed",
+            "pane_id",
+            "focused_pane_id",
+            "layout"
+          ],
           "type": "object"
         },
         "PaneScrollInfo": {
@@ -5460,11 +7751,20 @@
               "type": "integer"
             }
           },
-          "required": ["offset_from_bottom", "max_offset_from_bottom", "viewport_rows"],
+          "required": [
+            "offset_from_bottom",
+            "max_offset_from_bottom",
+            "viewport_rows"
+          ],
           "type": "object"
         },
         "PaneSwapReason": {
-          "enum": ["no_neighbor", "same_pane", "not_found", "cross_tab"],
+          "enum": [
+            "no_neighbor",
+            "same_pane",
+            "not_found",
+            "cross_tab"
+          ],
           "type": "string"
         },
         "PaneSwapResult": {
@@ -5492,14 +7792,26 @@
               "type": "string"
             },
             "target_pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "required": ["changed", "source_pane_id", "focused_pane_id", "layout"],
+          "required": [
+            "changed",
+            "source_pane_id",
+            "focused_pane_id",
+            "layout"
+          ],
           "type": "object"
         },
         "PaneZoomReason": {
-          "enum": ["single_pane", "already_zoomed", "already_unzoomed"],
+          "enum": [
+            "single_pane",
+            "already_zoomed",
+            "already_unzoomed"
+          ],
           "type": "string"
         },
         "PaneZoomResult": {
@@ -5548,7 +7860,13 @@
           "type": "object"
         },
         "PluginActionContext": {
-          "enum": ["global", "workspace", "tab", "pane", "selection"],
+          "enum": [
+            "global",
+            "workspace",
+            "tab",
+            "pane",
+            "selection"
+          ],
           "type": "string"
         },
         "PluginActionInfo": {
@@ -5569,13 +7887,19 @@
               "type": "array"
             },
             "description": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "platforms": {
               "items": {
                 "$ref": "#/schemas/success_response/$defs/PluginPlatform"
               },
-              "type": ["array", "null"]
+              "type": [
+                "array",
+                "null"
+              ]
             },
             "plugin_id": {
               "type": "string"
@@ -5584,13 +7908,21 @@
               "type": "string"
             }
           },
-          "required": ["plugin_id", "action_id", "title", "command"],
+          "required": [
+            "plugin_id",
+            "action_id",
+            "title",
+            "command"
+          ],
           "type": "object"
         },
         "PluginCommandLogInfo": {
           "properties": {
             "action_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "command": {
               "items": {
@@ -5599,19 +7931,31 @@
               "type": "array"
             },
             "error": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "event": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "exit_code": {
               "format": "int32",
-              "type": ["integer", "null"]
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "finished_unix_ms": {
               "format": "uint64",
               "minimum": 0,
-              "type": ["integer", "null"]
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "log_id": {
               "type": "string"
@@ -5628,35 +7972,66 @@
               "$ref": "#/schemas/success_response/$defs/PluginCommandStatus"
             },
             "stderr": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "stdout": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "required": ["log_id", "plugin_id", "command", "status", "started_unix_ms"],
+          "required": [
+            "log_id",
+            "plugin_id",
+            "command",
+            "status",
+            "started_unix_ms"
+          ],
           "type": "object"
         },
         "PluginCommandStatus": {
-          "enum": ["running", "succeeded", "failed"],
+          "enum": [
+            "running",
+            "succeeded",
+            "failed"
+          ],
           "type": "string"
         },
         "PluginInvocationContext": {
           "properties": {
             "clicked_url": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "correlation_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "focused_pane_agent": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "focused_pane_cwd": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "focused_pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "focused_pane_status": {
               "anyOf": [
@@ -5669,28 +8044,52 @@
               ]
             },
             "invocation_source": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "link_handler_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "selected_text": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "tab_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "tab_label": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "workspace_cwd": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "workspace_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "workspace_label": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "worktree": {
               "anyOf": [
@@ -5720,7 +8119,10 @@
               "type": "array"
             },
             "description": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "id": {
               "type": "string"
@@ -5729,13 +8131,20 @@
               "items": {
                 "$ref": "#/schemas/success_response/$defs/PluginPlatform"
               },
-              "type": ["array", "null"]
+              "type": [
+                "array",
+                "null"
+              ]
             },
             "title": {
               "type": "string"
             }
           },
-          "required": ["id", "title", "command"],
+          "required": [
+            "id",
+            "title",
+            "command"
+          ],
           "type": "object"
         },
         "PluginManifestBuild": {
@@ -5750,10 +8159,15 @@
               "items": {
                 "$ref": "#/schemas/success_response/$defs/PluginPlatform"
               },
-              "type": ["array", "null"]
+              "type": [
+                "array",
+                "null"
+              ]
             }
           },
-          "required": ["command"],
+          "required": [
+            "command"
+          ],
           "type": "object"
         },
         "PluginManifestEventHook": {
@@ -5771,10 +8185,16 @@
               "items": {
                 "$ref": "#/schemas/success_response/$defs/PluginPlatform"
               },
-              "type": ["array", "null"]
+              "type": [
+                "array",
+                "null"
+              ]
             }
           },
-          "required": ["on", "command"],
+          "required": [
+            "on",
+            "command"
+          ],
           "type": "object"
         },
         "PluginManifestLinkHandler": {
@@ -5792,13 +8212,21 @@
               "items": {
                 "$ref": "#/schemas/success_response/$defs/PluginPlatform"
               },
-              "type": ["array", "null"]
+              "type": [
+                "array",
+                "null"
+              ]
             },
             "title": {
               "type": "string"
             }
           },
-          "required": ["id", "title", "pattern", "action"],
+          "required": [
+            "id",
+            "title",
+            "pattern",
+            "action"
+          ],
           "type": "object"
         },
         "PluginManifestPane": {
@@ -5810,7 +8238,20 @@
               "type": "array"
             },
             "description": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "height": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/success_response/$defs/PopupSize"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "id": {
               "type": "string"
@@ -5823,13 +8264,53 @@
               "items": {
                 "$ref": "#/schemas/success_response/$defs/PluginPlatform"
               },
-              "type": ["array", "null"]
+              "type": [
+                "array",
+                "null"
+              ]
             },
             "title": {
               "type": "string"
+            },
+            "width": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/success_response/$defs/PopupSize"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
-          "required": ["id", "title", "command"],
+          "required": [
+            "id",
+            "title",
+            "command"
+          ],
+          "type": "object"
+        },
+        "PluginManifestStartup": {
+          "properties": {
+            "command": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "platforms": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PluginPlatform"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "command"
+          ],
           "type": "object"
         },
         "PluginPaneInfo": {
@@ -5844,15 +8325,29 @@
               "type": "string"
             }
           },
-          "required": ["plugin_id", "entrypoint", "pane"],
+          "required": [
+            "plugin_id",
+            "entrypoint",
+            "pane"
+          ],
           "type": "object"
         },
         "PluginPanePlacement": {
-          "enum": ["overlay", "split", "tab", "zoomed"],
+          "enum": [
+            "overlay",
+            "popup",
+            "split",
+            "tab",
+            "zoomed"
+          ],
           "type": "string"
         },
         "PluginPlatform": {
-          "enum": ["linux", "macos", "windows"],
+          "enum": [
+            "linux",
+            "macos",
+            "windows"
+          ],
           "type": "string"
         },
         "PluginSourceInfo": {
@@ -5860,43 +8355,90 @@
             "installed_unix_ms": {
               "format": "uint64",
               "minimum": 0,
-              "type": ["integer", "null"]
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "kind": {
               "$ref": "#/schemas/success_response/$defs/PluginSourceKind",
               "default": "local"
             },
             "managed_path": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "owner": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "repo": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "requested_ref": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "resolved_commit": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "subdir": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
         },
         "PluginSourceKind": {
-          "enum": ["local", "github"],
+          "enum": [
+            "local",
+            "github"
+          ],
           "type": "string"
         },
+        "PopupSize": {
+          "oneOf": [
+            {
+              "description": "Outer popup size in terminal cells, including the border.",
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "description": "Outer popup size as a percentage of the terminal area, for example 80%.",
+              "pattern": "^(100|[1-9][0-9]?)%$",
+              "type": "string"
+            }
+          ]
+        },
         "ReadFormat": {
-          "enum": ["text", "ansi"],
+          "enum": [
+            "text",
+            "ansi"
+          ],
           "type": "string"
         },
         "ReadSource": {
-          "enum": ["visible", "recent", "recent_unwrapped", "detection"],
+          "enum": [
+            "visible",
+            "recent",
+            "recent_unwrapped",
+            "detection"
+          ],
           "type": "string"
         },
         "ResponseResult": {
@@ -5927,7 +8469,11 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "version", "protocol"],
+              "required": [
+                "type",
+                "version",
+                "protocol"
+              ],
               "type": "object"
             },
             {
@@ -5940,7 +8486,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "snapshot"],
+              "required": [
+                "type",
+                "snapshot"
+              ],
               "type": "object"
             },
             {
@@ -5953,7 +8502,10 @@
                   "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
                 }
               },
-              "required": ["type", "workspace"],
+              "required": [
+                "type",
+                "workspace"
+              ],
               "type": "object"
             },
             {
@@ -5972,7 +8524,12 @@
                   "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
                 }
               },
-              "required": ["type", "workspace", "tab", "root_pane"],
+              "required": [
+                "type",
+                "workspace",
+                "tab",
+                "root_pane"
+              ],
               "type": "object"
             },
             {
@@ -5988,7 +8545,10 @@
                   "type": "array"
                 }
               },
-              "required": ["type", "workspaces"],
+              "required": [
+                "type",
+                "workspaces"
+              ],
               "type": "object"
             },
             {
@@ -6007,7 +8567,11 @@
                   "type": "array"
                 }
               },
-              "required": ["type", "source", "worktrees"],
+              "required": [
+                "type",
+                "source",
+                "worktrees"
+              ],
               "type": "object"
             },
             {
@@ -6029,7 +8593,13 @@
                   "$ref": "#/schemas/success_response/$defs/WorktreeInfo"
                 }
               },
-              "required": ["type", "workspace", "tab", "root_pane", "worktree"],
+              "required": [
+                "type",
+                "workspace",
+                "tab",
+                "root_pane",
+                "worktree"
+              ],
               "type": "object"
             },
             {
@@ -6054,7 +8624,14 @@
                   "$ref": "#/schemas/success_response/$defs/WorktreeInfo"
                 }
               },
-              "required": ["type", "workspace", "tab", "root_pane", "worktree", "already_open"],
+              "required": [
+                "type",
+                "workspace",
+                "tab",
+                "root_pane",
+                "worktree",
+                "already_open"
+              ],
               "type": "object"
             },
             {
@@ -6073,7 +8650,12 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "workspace_id", "path", "forced"],
+              "required": [
+                "type",
+                "workspace_id",
+                "path",
+                "forced"
+              ],
               "type": "object"
             },
             {
@@ -6086,7 +8668,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "tab"],
+              "required": [
+                "type",
+                "tab"
+              ],
               "type": "object"
             },
             {
@@ -6102,7 +8687,11 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "tab", "root_pane"],
+              "required": [
+                "type",
+                "tab",
+                "root_pane"
+              ],
               "type": "object"
             },
             {
@@ -6118,7 +8707,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "tabs"],
+              "required": [
+                "type",
+                "tabs"
+              ],
               "type": "object"
             },
             {
@@ -6131,7 +8723,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "agent"],
+              "required": [
+                "type",
+                "agent"
+              ],
               "type": "object"
             },
             {
@@ -6150,7 +8745,27 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "agent", "argv"],
+              "required": [
+                "type",
+                "agent",
+                "argv"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "agent": {
+                  "$ref": "#/schemas/success_response/$defs/AgentInfo"
+                },
+                "type": {
+                  "const": "agent_prompted",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "agent"
+              ],
               "type": "object"
             },
             {
@@ -6166,7 +8781,38 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "agents"],
+              "required": [
+                "type",
+                "agents"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "active": {
+                  "type": "boolean"
+                },
+                "label": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "source": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "type": {
+                  "const": "agent_view",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "active"
+              ],
               "type": "object"
             },
             {
@@ -6179,7 +8825,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane"],
+              "required": [
+                "type",
+                "pane"
+              ],
               "type": "object"
             },
             {
@@ -6195,7 +8844,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "panes"],
+              "required": [
+                "type",
+                "panes"
+              ],
               "type": "object"
             },
             {
@@ -6208,7 +8860,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane"],
+              "required": [
+                "type",
+                "pane"
+              ],
               "type": "object"
             },
             {
@@ -6221,7 +8876,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "swap"],
+              "required": [
+                "type",
+                "swap"
+              ],
               "type": "object"
             },
             {
@@ -6234,7 +8892,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "move_result"],
+              "required": [
+                "type",
+                "move_result"
+              ],
               "type": "object"
             },
             {
@@ -6247,7 +8908,10 @@
                   "$ref": "#/schemas/success_response/$defs/PaneZoomResult"
                 }
               },
-              "required": ["type", "zoom"],
+              "required": [
+                "type",
+                "zoom"
+              ],
               "type": "object"
             },
             {
@@ -6260,7 +8924,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "layout"],
+              "required": [
+                "type",
+                "layout"
+              ],
               "type": "object"
             },
             {
@@ -6273,7 +8940,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "process_info"],
+              "required": [
+                "type",
+                "process_info"
+              ],
               "type": "object"
             },
             {
@@ -6286,7 +8956,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "layout"],
+              "required": [
+                "type",
+                "layout"
+              ],
               "type": "object"
             },
             {
@@ -6299,7 +8972,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "layout"],
+              "required": [
+                "type",
+                "layout"
+              ],
               "type": "object"
             },
             {
@@ -6312,7 +8988,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "layout"],
+              "required": [
+                "type",
+                "layout"
+              ],
               "type": "object"
             },
             {
@@ -6325,7 +9004,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "neighbor"],
+              "required": [
+                "type",
+                "neighbor"
+              ],
               "type": "object"
             },
             {
@@ -6338,7 +9020,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "edges"],
+              "required": [
+                "type",
+                "edges"
+              ],
               "type": "object"
             },
             {
@@ -6351,7 +9036,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "focus"],
+              "required": [
+                "type",
+                "focus"
+              ],
               "type": "object"
             },
             {
@@ -6364,7 +9052,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "resize"],
+              "required": [
+                "type",
+                "resize"
+              ],
               "type": "object"
             },
             {
@@ -6377,7 +9068,34 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "read"],
+              "required": [
+                "type",
+                "read"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "cell_height_px": {
+                  "format": "uint32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "cell_width_px": {
+                  "format": "uint32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": {
+                  "const": "pane_graphics_info",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "cell_width_px",
+                "cell_height_px"
+              ],
               "type": "object"
             },
             {
@@ -6388,7 +9106,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "explain"],
+              "required": [
+                "type",
+                "explain"
+              ],
               "type": "object"
             },
             {
@@ -6398,7 +9119,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             },
             {
@@ -6411,13 +9134,19 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "event"],
+              "required": [
+                "type",
+                "event"
+              ],
               "type": "object"
             },
             {
               "properties": {
                 "matched_line": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "pane_id": {
                   "type": "string"
@@ -6435,7 +9164,12 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane_id", "revision", "read"],
+              "required": [
+                "type",
+                "pane_id",
+                "revision",
+                "read"
+              ],
               "type": "object"
             },
             {
@@ -6451,7 +9185,11 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "shown", "reason"],
+              "required": [
+                "type",
+                "shown",
+                "reason"
+              ],
               "type": "object"
             },
             {
@@ -6467,7 +9205,11 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "changed", "reason"],
+              "required": [
+                "type",
+                "changed",
+                "reason"
+              ],
               "type": "object"
             },
             {
@@ -6483,7 +9225,11 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "target", "details"],
+              "required": [
+                "type",
+                "target",
+                "details"
+              ],
               "type": "object"
             },
             {
@@ -6499,7 +9245,11 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "target", "details"],
+              "required": [
+                "type",
+                "target",
+                "details"
+              ],
               "type": "object"
             },
             {
@@ -6515,7 +9265,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "manifests"],
+              "required": [
+                "type",
+                "manifests"
+              ],
               "type": "object"
             },
             {
@@ -6523,10 +9276,16 @@
                 "last_check_unix": {
                   "format": "uint64",
                   "minimum": 0,
-                  "type": ["integer", "null"]
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
                 },
                 "last_result": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "manifests": {
                   "items": {
@@ -6539,7 +9298,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "manifests"],
+              "required": [
+                "type",
+                "manifests"
+              ],
               "type": "object"
             },
             {
@@ -6552,7 +9314,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "plugin"],
+              "required": [
+                "type",
+                "plugin"
+              ],
               "type": "object"
             },
             {
@@ -6568,7 +9333,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "plugins"],
+              "required": [
+                "type",
+                "plugins"
+              ],
               "type": "object"
             },
             {
@@ -6584,7 +9352,11 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "plugin_id", "removed"],
+              "required": [
+                "type",
+                "plugin_id",
+                "removed"
+              ],
               "type": "object"
             },
             {
@@ -6597,7 +9369,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "plugin"],
+              "required": [
+                "type",
+                "plugin"
+              ],
               "type": "object"
             },
             {
@@ -6610,7 +9385,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "plugin"],
+              "required": [
+                "type",
+                "plugin"
+              ],
               "type": "object"
             },
             {
@@ -6626,7 +9404,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "actions"],
+              "required": [
+                "type",
+                "actions"
+              ],
               "type": "object"
             },
             {
@@ -6645,7 +9426,12 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "action", "context", "log"],
+              "required": [
+                "type",
+                "action",
+                "context",
+                "log"
+              ],
               "type": "object"
             },
             {
@@ -6661,7 +9447,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "logs"],
+              "required": [
+                "type",
+                "logs"
+              ],
               "type": "object"
             },
             {
@@ -6674,7 +9463,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "plugin_pane"],
+              "required": [
+                "type",
+                "plugin_pane"
+              ],
               "type": "object"
             },
             {
@@ -6687,7 +9479,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "plugin_pane"],
+              "required": [
+                "type",
+                "plugin_pane"
+              ],
               "type": "object"
             },
             {
@@ -6700,7 +9495,10 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "pane_id"],
+              "required": [
+                "type",
+                "pane_id"
+              ],
               "type": "object"
             },
             {
@@ -6719,7 +9517,11 @@
                   "type": "string"
                 }
               },
-              "required": ["type", "status", "diagnostics"],
+              "required": [
+                "type",
+                "status",
+                "diagnostics"
+              ],
               "type": "object"
             },
             {
@@ -6729,7 +9531,9 @@
                   "type": "string"
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "type": "object"
             }
           ]
@@ -6744,7 +9548,9 @@
               "type": "boolean"
             }
           },
-          "required": ["live_handoff"],
+          "required": [
+            "live_handoff"
+          ],
           "type": "object"
         },
         "SessionSnapshot": {
@@ -6756,13 +9562,22 @@
               "type": "array"
             },
             "focused_pane_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "focused_tab_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "focused_workspace_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "layouts": {
               "items": {
@@ -6797,11 +9612,22 @@
               "type": "array"
             }
           },
-          "required": ["version", "protocol", "workspaces", "tabs", "panes", "layouts", "agents"],
+          "required": [
+            "version",
+            "protocol",
+            "workspaces",
+            "tabs",
+            "panes",
+            "layouts",
+            "agents"
+          ],
           "type": "object"
         },
         "SplitDirection": {
-          "enum": ["right", "down"],
+          "enum": [
+            "right",
+            "down"
+          ],
           "type": "string"
         },
         "TabInfo": {
@@ -6872,6 +9698,16 @@
               "minimum": 0,
               "type": "integer"
             },
+            "tokens": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "maxProperties": 32,
+              "propertyNames": {
+                "pattern": "^[A-Za-z0-9_-]{1,32}$"
+              },
+              "type": "object"
+            },
             "workspace_id": {
               "type": "string"
             },
@@ -6916,13 +9752,22 @@
               "type": "string"
             }
           },
-          "required": ["repo_key", "repo_name", "repo_root", "checkout_path", "is_linked_worktree"],
+          "required": [
+            "repo_key",
+            "repo_name",
+            "repo_root",
+            "checkout_path",
+            "is_linked_worktree"
+          ],
           "type": "object"
         },
         "WorktreeInfo": {
           "properties": {
             "branch": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "is_bare": {
               "type": "boolean"
@@ -6940,7 +9785,10 @@
               "type": "string"
             },
             "open_workspace_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "path": {
               "type": "string"
@@ -6971,10 +9819,18 @@
               "type": "string"
             },
             "source_workspace_id": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "required": ["repo_key", "repo_name", "repo_root", "source_checkout_path"],
+          "required": [
+            "repo_key",
+            "repo_name",
+            "repo_root",
+            "source_checkout_path"
+          ],
           "type": "object"
         }
       },
@@ -6987,7 +9843,10 @@
           "$ref": "#/schemas/success_response/$defs/ResponseResult"
         }
       },
-      "required": ["id", "result"],
+      "required": [
+        "id",
+        "result"
+      ],
       "title": "SuccessResponse",
       "type": "object"
     }

--- a/src/herdr-socket-client.ts
+++ b/src/herdr-socket-client.ts
@@ -57,12 +57,39 @@ export class HerdrSocketClient {
     params: HerdrParams[M],
     opts?: { timeoutMs?: number },
   ): Promise<HerdrResult<M>> {
+    return this.roundTrip<HerdrResult<M>>(method, params, opts);
+  }
+
+  /**
+   * Untyped escape hatch for the ≤0.7.4 (protocol ≤16) driver arm to call methods that the
+   * VENDORED (protocol 17) schema no longer describes: `agent.send` was removed in p17 (replaced
+   * by `agent.send_keys`) and `agent.start` was reshaped incompatibly (`{ kind, pane_id, … }`).
+   * Both are still valid on a live ≤0.7.4 server, so the socket driver keeps speaking them on the
+   * legacy branch — but they are no longer `HerdrMethod`s, so `request()` can't type them. This
+   * keeps that concession in ONE place (the transport, which is protocol-agnostic by design)
+   * instead of scattering casts through the driver, and everything on the 0.7.5 path plus every
+   * unchanged shared method stays fully typed via `request()`.
+   */
+  requestLegacy<T>(
+    method: string,
+    params: Record<string, unknown>,
+    opts?: { timeoutMs?: number },
+  ): Promise<T> {
+    return this.roundTrip<T>(method, params, opts);
+  }
+
+  /** Shared NDJSON round-trip core for {@link request} / {@link requestLegacy}. */
+  private async roundTrip<T>(
+    method: string,
+    params: unknown,
+    opts?: { timeoutMs?: number },
+  ): Promise<T> {
     if (maintenance.active) throw new HerdrUnavailableError();
 
     const id = String(this.nextId++);
     const timeoutMs = opts?.timeoutMs ?? SOCKET_REQUEST_TIMEOUT_MS;
 
-    return new Promise<HerdrResult<M>>((resolve, reject) => {
+    return new Promise<T>((resolve, reject) => {
       let settled = false;
       let buffer = "";
       const socket = net.createConnection(this.socketPath);
@@ -117,7 +144,7 @@ export class HerdrSocketClient {
             const message = typeof res.error.message === "string" ? res.error.message : "";
             reject(new HerdrSocketError(code, message));
           } else {
-            resolve(res.result as HerdrResult<M>);
+            resolve(res.result as T);
           }
         });
       });

--- a/src/herdr-socket-driver.ts
+++ b/src/herdr-socket-driver.ts
@@ -4,6 +4,7 @@ import {
   HerdrSpawnUnsupportedError,
   TabLedger,
   buildWrappedArgv,
+  classifyPaneWrite,
   createSerializer,
   isHeadlessCodexExec,
   isNameTakenError,
@@ -12,6 +13,9 @@ import {
   parseProcs,
   parseReadText,
   parseTabs,
+  posixShellJoin,
+  resolvePaneId,
+  sanitizeHerdrAgentName,
   stopViaRecordedTab,
   type HerdrAgent,
   type HerdrTab,
@@ -62,9 +66,23 @@ export class SocketHerdrDriver implements IHerdrDriver {
     source: "visible" | "recent" = "visible",
     lines = 200,
   ): Promise<string> {
+    // 0.7.5 addresses reads by pane_id (terminal_id/label are rejected as agent_not_found — #1890);
+    // ≤0.7.4 is identity. A gone pane resolves to null → "" (matches the CLI readAsync).
+    const resolved = await this.resolveTarget(target);
+    if (resolved === null) return "";
     return parseReadText(
-      await this.client.request("agent.read", { target, source, lines, format: "text" }),
+      await this.client.request("agent.read", { target: resolved, source, lines, format: "text" }),
     );
+  }
+
+  /**
+   * Map a session `terminal_id` to the target the current herdr wants for read/rename. ≤0.7.4:
+   * identity. 0.7.5: the agent's `pane_id`, resolved from a fresh `agent list` (null when the pane
+   * is gone, so callers can no-op). Mirrors `HerdrDriver.resolveTargetAsync`.
+   */
+  private async resolveTarget(terminalId: string): Promise<string | null> {
+    if (!herdrUsesExternalRegistrationSpawn()) return terminalId;
+    return resolvePaneId(await this.listAsync(), terminalId);
   }
 
   /**
@@ -111,7 +129,24 @@ export class SocketHerdrDriver implements IHerdrDriver {
    * driver would also stall unrelated panes behind a slow one.
    */
   async send(target: string, text: string): Promise<void> {
-    await this.client.request("agent.send", { target, text });
+    if (!herdrUsesExternalRegistrationSpawn()) {
+      // ≤0.7.4: `agent.send` was removed from the vendored protocol-17 types (replaced by
+      // `agent.send_keys`) but is still valid on a live ≤0.7.4 server, so reach it via the legacy
+      // escape — keeps the ≤p16 wire behavior byte-identical. See `HerdrSocketClient.requestLegacy`.
+      await this.client.requestLegacy("agent.send", { target, text });
+      return;
+    }
+    // 0.7.5: `agent.send` returns `agent_not_ready` on a registered-but-undetected sandboxed agent,
+    // so write to the resolved `pane_id` via `pane.send_text` / `pane.send_keys` (mirrors the CLI
+    // `send`). Never best-effort: a gone pane throws rather than silently dropping the steer.
+    const paneId = resolvePaneId(await this.listAsync(), target);
+    if (!paneId) throw new Error(`herdr: no live pane for terminal ${target} (send)`);
+    const write = classifyPaneWrite(text);
+    if (write.kind === "keys") {
+      await this.client.request("pane.send_keys", { pane_id: paneId, keys: write.keys });
+    } else {
+      await this.client.request("pane.send_text", { pane_id: paneId, text: write.text });
+    }
   }
 
   /**
@@ -128,15 +163,126 @@ export class SocketHerdrDriver implements IHerdrDriver {
     env?: Record<string, string>,
   ): Promise<HerdrAgent> {
     // Same unsupported-herdr guard as the CLI driver (defensive: the socket only activates on a
-    // supported protocol today, but the version ceiling is the source of truth). See #1889.
+    // supported protocol, but the version ceiling is the source of truth). See #1889.
     if (!herdrSpawnSupported()) throw new HerdrSpawnUnsupportedError(detectedHerdrVersion());
-    // The 0.7.5 external-registration spawn path is CLI-only (#1890); this socket driver does not
-    // implement it. It is never *selected* on protocol 17 (17 ∉ HERDR_SOCKET_SUPPORTED_PROTOCOLS),
-    // so this is belt-and-suspenders — refuse rather than attempt the broken socket `agent.start`.
-    if (herdrUsesExternalRegistrationSpawn()) {
-      throw new HerdrSpawnUnsupportedError(detectedHerdrVersion());
+    return this.serializeStart(() =>
+      // 0.7.5 (protocol 17) can't launch the wrapped argv through `agent.start`; use the
+      // external-registration path instead (#1892), mirroring `HerdrDriver.startImpl075`.
+      // ≤0.7.4 keeps the legacy `agent.start` path.
+      herdrUsesExternalRegistrationSpawn()
+        ? this.startImpl075(name, cwd, argv, env)
+        : this.startImpl(name, cwd, argv, env),
+    );
+  }
+
+  /**
+   * herdr 0.7.5 (protocol 17) spawn via EXTERNAL REGISTRATION — the socket sibling of
+   * `HerdrDriver.startImpl075` (#1892). `agent.start` can't express Shepherd's `env`-shim + `bwrap`
+   * argv wrap, so instead: `tab.create` → run the wrapped argv in the tab's root pane → register the
+   * agent (`pane.report_agent_session` + `pane.report_agent`) so `agent.list` surfaces it → resolve
+   * the started `HerdrAgent` from the live list by `pane_id`. Preserves the dedicated-tab +
+   * `TabLedger` teardown semantics of the ≤0.7.4 path; the wrapped argv flows in byte-identically.
+   * Unlike the ≤0.7.4 path there is NO leftover shell pane to close — the run reuses the root pane.
+   */
+  private async startImpl075(
+    name: string,
+    cwd: string,
+    argv: string[],
+    env?: Record<string, string>,
+  ): Promise<HerdrAgent> {
+    await this.ensureWorkspace(cwd);
+    const created = await this.client.request("tab.create", { cwd, label: name, focus: false });
+    const tabId = created?.tab?.tab_id;
+    const rootPaneId = created?.root_pane?.pane_id;
+    if (!tabId) throw new Error(`herdr: tab.create returned no tab_id for ${name}`);
+
+    // The tab already exists, so on ANY post-create failure we must close it (mirrors the ≤0.7.4
+    // rollback). A missing root pane is such a failure — on 0.7.5 that pane IS the agent pane.
+    try {
+      if (!rootPaneId) throw new Error(`herdr: tab.create returned no root pane for ${name}`);
+      await this.runInReadyPane(rootPaneId, buildWrappedArgv(argv, env));
+      await this.registerAgentWithCollisionRetry(rootPaneId, sanitizeHerdrAgentName(name));
+      // No `agent_started` reply on 0.7.5 — resolve the freshly-registered agent from the live
+      // list, joining on the pane_id we ran in. Its terminal_id is the id Shepherd keys on.
+      const agent = (await this.listAsync()).find((a) => a.paneId === rootPaneId);
+      if (!agent || !agent.terminalId) {
+        throw new Error(
+          `herdr: agent list has no registered agent for pane ${rootPaneId} (${name})`,
+        );
+      }
+      // Retain the authoritative spawn handle (#1852) — the tab is ours even if the process inside
+      // dies before it next appears in `agent.list`.
+      this.ledger.record(agent.terminalId, tabId, name);
+      return agent;
+    } catch (err) {
+      await this.closeTab(tabId); // roll back the orphan tab before propagating
+      throw err;
     }
-    return this.serializeStart(() => this.startImpl(name, cwd, argv, env));
+  }
+
+  /**
+   * Launch `wrapped` in `paneId`'s shell. herdr's protocol-17 socket API exposes NO direct pane-run
+   * RPC (unlike the CLI `pane run`, #1892), so the wrapped argv is TYPED into the pane's ready shell
+   * as a POSIX-quoted command line (`pane.send_text`) then submitted with Enter (`pane.send_keys`).
+   * `send_text` is bounded-retried on ANY failure to ride out shell-not-ready without hinging on an
+   * unverified busy-error code: a rejected `send_text` means herdr didn't write it, so a retry never
+   * double-types (mirrors the CLI `runInReadyPane` reject-before-exec contract). The Enter is sent
+   * once, OUTSIDE that loop, so a delivered command is never re-typed. NOTE: this routes through the
+   * interactive shell rather than a direct exec — the per-token quoting keeps it robust; only the
+   * 0.7.5 socket spawn path (default-off) reaches it.
+   */
+  private async runInReadyPane(paneId: string, wrapped: string[]): Promise<void> {
+    const cmdline = posixShellJoin(wrapped);
+    const MAX_ATTEMPTS = 3;
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      try {
+        await this.client.request("pane.send_text", { pane_id: paneId, text: cmdline });
+        lastErr = undefined;
+        break;
+      } catch (err) {
+        lastErr = err;
+      }
+    }
+    if (lastErr) throw lastErr;
+    await this.client.request("pane.send_keys", { pane_id: paneId, keys: ["Enter"] });
+  }
+
+  /**
+   * Register an externally-launched agent so `agent.list` surfaces it — the socket sibling of
+   * `HerdrDriver.registerAgentWithCollisionRetry`: `pane.report_agent_session` (establishes the
+   * agent session) then `pane.report_agent` (`state: "working"`). Bounded collision-retry at the
+   * REGISTER step: the `agent` name is bound here, and our tab/pane are already live, so a
+   * collision re-runs ONLY the register pair after evicting same-named squatters (never
+   * tab-create/pane-run). The opaque per-pane `agent_session_id` (`shepherd-<paneId>`) is stable +
+   * unique per spawn (one pane per spawn).
+   */
+  private async registerAgentWithCollisionRetry(paneId: string, agentName: string): Promise<void> {
+    const agentSessionId = `shepherd-${paneId}`;
+    const MAX_ATTEMPTS = 3;
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      try {
+        await this.client.request("pane.report_agent_session", {
+          pane_id: paneId,
+          source: "shepherd",
+          agent: agentName,
+          agent_session_id: agentSessionId,
+        });
+        await this.client.request("pane.report_agent", {
+          pane_id: paneId,
+          source: "shepherd",
+          agent: agentName,
+          state: "working",
+        });
+        return;
+      } catch (err) {
+        if (!isNameTakenError(err) || attempt === MAX_ATTEMPTS - 1) throw err;
+        // Evict squatter(s) by name — never by regex-parsing the error string — then re-run the
+        // register pair against our existing pane.
+        const squatters = (await this.listAsync()).filter((a) => a.name === agentName);
+        for (const sq of squatters) await this.closeTab(sq.tabId);
+      }
+    }
   }
 
   private async startImpl(
@@ -204,7 +350,9 @@ export class SocketHerdrDriver implements IHerdrDriver {
     const MAX_ATTEMPTS = 3;
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
       try {
-        const res = await this.client.request("agent.start", {
+        // ≤0.7.4 only: `agent.start` was reshaped incompatibly in protocol 17 (`{ kind, pane_id, …}`),
+        // so the p16 request shape lives outside the vendored types — call it via the legacy escape.
+        const res = await this.client.requestLegacy<{ agent?: unknown }>("agent.start", {
           name,
           argv: wrapped,
           cwd,
@@ -240,10 +388,18 @@ export class SocketHerdrDriver implements IHerdrDriver {
       return;
     }
     if (!agent) return;
-    try {
-      await this.client.request("agent.rename", { target: terminalId, name: newName });
-    } catch {
-      /* best-effort */
+    // 0.7.5: `agent.rename` must target the pane_id and the agent label must satisfy herdr's name
+    // grammar (#1890). ≤0.7.4: target the terminal_id with the raw name. The TAB rename below always
+    // uses the raw, human-facing label (tab labels are unconstrained). Mirrors the CLI relabel.
+    const external = herdrUsesExternalRegistrationSpawn();
+    const renameTarget = external ? agent.paneId : terminalId;
+    const agentLabel = external ? sanitizeHerdrAgentName(newName) : newName;
+    if (renameTarget) {
+      try {
+        await this.client.request("agent.rename", { target: renameTarget, name: agentLabel });
+      } catch {
+        /* best-effort */
+      }
     }
     if (agent.tabId) {
       try {

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -456,6 +456,18 @@ export function classifyPaneWrite(text: string): PaneWrite {
 }
 
 /**
+ * Join argv into a single POSIX-shell command line, single-quoting every token so paths with
+ * spaces or shell metacharacters survive intact (empty-string token → `''`). Used ONLY by the
+ * socket driver's 0.7.5 spawn path: herdr's protocol-17 socket API exposes no direct pane-run RPC
+ * (unlike the CLI `pane run`, #1892), so the wrapped argv is typed into the pane's ready shell as a
+ * command line. Single-quoting is complete for POSIX shells: nothing inside `'…'` is special, and
+ * an embedded `'` is emitted as the standard `'\''` break-out sequence.
+ */
+export function posixShellJoin(argv: string[]): string {
+  return argv.map((tok) => `'${tok.replaceAll("'", `'\\''`)}'`).join(" ");
+}
+
+/**
  * Builds the wrapped spawn argv shared by BOTH drivers (issue #1553), so a socket-backed
  * `start` spawns a byte-identical process to the CLI path. Wraps argv (always
  * `["claude", …]`) in a coreutils `env` shim that pins the V8 compile cache to a disk-backed

--- a/test/herdr-socket-075.test.ts
+++ b/test/herdr-socket-075.test.ts
@@ -1,0 +1,244 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { SocketHerdrDriver, selectHerdrDriver } from "../src/herdr-socket-driver";
+import {
+  buildWrappedArgv,
+  posixShellJoin,
+  sanitizeHerdrAgentName,
+  type HerdrDriver,
+} from "../src/herdr";
+import { HerdrSocketError, type HerdrSocketClient } from "../src/herdr-socket-client";
+import { setDetectedHerdrVersion } from "../src/herdr-capabilities";
+
+// ── captured 0.7.5 (protocol 17) reply fixtures (shared with test/herdr-075.test.ts) ────────────
+// The socket client returns `res.result`, so the driver receives the INNER result object — unwrap
+// the fixtures' `{ result }` envelope here.
+const FIX = join(import.meta.dir, "fixtures/herdr-responses/v0.7.5");
+const result = (name: string): Record<string, unknown> =>
+  JSON.parse(readFileSync(join(FIX, `${name}.json`), "utf8")).result;
+
+/** Fake socket client routing `request`/`requestLegacy` by method to the captured p17 replies.
+ *  `agents`/`tabs` override the `agent.list`/`tab.list` bodies; `onReport`/`onSendText` inject faults. */
+function mkClient(
+  opts: {
+    agents?: () => unknown[];
+    tabs?: () => unknown[];
+    onReport?: () => void;
+    onSendText?: () => void;
+  } = {},
+) {
+  const rec: { method: string; params: unknown }[] = [];
+  const registered = result("agent-list-registered").agents as unknown[];
+  const tabListing = result("tab-list").tabs as unknown[];
+  const impl = (method: string, params: unknown): unknown => {
+    rec.push({ method, params });
+    switch (method) {
+      case "workspace.list":
+        return result("workspace-list");
+      case "workspace.create":
+        return { type: "workspace_created" };
+      case "tab.create":
+        return result("tab-create");
+      case "pane.send_text":
+        opts.onSendText?.();
+        return result("pane-send-text");
+      case "pane.send_keys":
+        return result("pane-send-keys");
+      case "pane.report_agent_session":
+        return result("report-agent-session");
+      case "pane.report_agent":
+        opts.onReport?.();
+        return result("report-agent");
+      case "agent.list":
+        return { type: "agent_list", agents: opts.agents ? opts.agents() : registered };
+      case "agent.read":
+        return result("agent-read");
+      case "tab.list":
+        return { type: "tab_list", tabs: opts.tabs ? opts.tabs() : tabListing };
+      default:
+        return { type: "ok" };
+    }
+  };
+  const client = { request: mock(impl), requestLegacy: mock(impl) } as unknown as HerdrSocketClient;
+  return { rec, client };
+}
+
+const noCli = {} as unknown as HerdrDriver;
+
+describe("SocketHerdrDriver — 0.7.5 (protocol 17) external-registration spawn", () => {
+  let prevNcc: string | undefined;
+  let prevAgentTmp: string | undefined;
+  beforeEach(() => {
+    // Arm the external-registration branch and pin the wrapped-argv env so the `pane.send_text`
+    // command-line assertion is deterministic (mirrors test/herdr-075.test.ts).
+    setDetectedHerdrVersion("0.7.5");
+    prevNcc = process.env.SHEPHERD_NODE_COMPILE_CACHE;
+    process.env.SHEPHERD_NODE_COMPILE_CACHE = "/disk/ncc";
+    prevAgentTmp = process.env.SHEPHERD_AGENT_TMPDIR;
+    process.env.SHEPHERD_AGENT_TMPDIR = "";
+  });
+  afterEach(() => {
+    setDetectedHerdrVersion(null);
+    if (prevNcc === undefined) delete process.env.SHEPHERD_NODE_COMPILE_CACHE;
+    else process.env.SHEPHERD_NODE_COMPILE_CACHE = prevNcc;
+    if (prevAgentTmp === undefined) delete process.env.SHEPHERD_AGENT_TMPDIR;
+    else process.env.SHEPHERD_AGENT_TMPDIR = prevAgentTmp;
+  });
+
+  it("start() runs the wrapped argv in the root pane, registers, resolves by pane_id (no pane.close)", async () => {
+    const { rec, client } = mkClient();
+    const driver = new SocketHerdrDriver(client, noCli);
+
+    const agent = await driver.start("review-task-09", "/wt/a", ["claude", "go"]);
+
+    // resolved from agent.list by the pane we ran in — its terminal_id is the id Shepherd keys on
+    expect(agent.terminalId).toBe("term_075");
+    expect(agent.paneId).toBe("p_075");
+    expect(rec.map((r) => r.method)).toEqual([
+      "workspace.list",
+      "tab.create",
+      "pane.send_text",
+      "pane.send_keys",
+      "pane.report_agent_session",
+      "pane.report_agent",
+      "agent.list",
+    ]);
+    // the run reuses the root pane — no leftover shell pane to close
+    expect(rec.some((r) => r.method === "pane.close")).toBe(false);
+
+    // the wrapped argv is typed into the root pane as a POSIX-quoted command line, then submitted
+    const sendText = rec.find((r) => r.method === "pane.send_text")!.params as {
+      pane_id: string;
+      text: string;
+    };
+    expect(sendText.pane_id).toBe("p_075");
+    expect(sendText.text).toBe(posixShellJoin(buildWrappedArgv(["claude", "go"])));
+    expect(rec.find((r) => r.method === "pane.send_keys")!.params).toEqual({
+      pane_id: "p_075",
+      keys: ["Enter"],
+    });
+
+    // register pair carries the sanitized name + a stable per-pane session id
+    expect(rec.find((r) => r.method === "pane.report_agent_session")!.params).toMatchObject({
+      pane_id: "p_075",
+      source: "shepherd",
+      agent: sanitizeHerdrAgentName("review-task-09"),
+      agent_session_id: "shepherd-p_075",
+    });
+    expect(rec.find((r) => r.method === "pane.report_agent")!.params).toMatchObject({
+      pane_id: "p_075",
+      source: "shepherd",
+      agent: sanitizeHerdrAgentName("review-task-09"),
+      state: "working",
+    });
+  });
+
+  it("start() rolls back the freshly created tab when registration fails", async () => {
+    const { rec, client } = mkClient({
+      onReport: () => {
+        throw new HerdrSocketError("report_failed", "boom");
+      },
+    });
+    const driver = new SocketHerdrDriver(client, noCli);
+
+    await expect(driver.start("t", "/wt/a", ["claude"])).rejects.toThrow();
+    expect(rec).toContainEqual({ method: "tab.close", params: { tab_id: "t_075" } });
+  });
+
+  it("start() records the spawn handle: a later stop() closes the recorded tab (agent-list-free)", async () => {
+    // tab.list label matches the start name so the recorded-tab-first close fires without agent.list
+    const { rec, client } = mkClient({
+      tabs: () => [{ tab_id: "t_075", label: "review-task-09" }],
+    });
+    const driver = new SocketHerdrDriver(client, noCli);
+    await driver.start("review-task-09", "/wt/a", ["claude"]);
+    const startEnd = rec.length;
+
+    await driver.stop("term_075");
+
+    expect(rec.slice(startEnd).map((r) => r.method)).toEqual(["tab.list", "tab.close"]);
+    expect(rec.at(-1)!.params).toEqual({ tab_id: "t_075" });
+  });
+
+  it("send() writes literal text to the resolved pane via pane.send_text", async () => {
+    const { rec, client } = mkClient();
+    const driver = new SocketHerdrDriver(client, noCli);
+
+    await driver.send("term_075", "hello");
+
+    expect(rec.map((r) => r.method)).toEqual(["agent.list", "pane.send_text"]);
+    expect(rec[1]!.params).toEqual({ pane_id: "p_075", text: "hello" });
+  });
+
+  it("send() maps a lone CR to pane.send_keys Enter", async () => {
+    const { rec, client } = mkClient();
+    const driver = new SocketHerdrDriver(client, noCli);
+
+    await driver.send("term_075", "\r");
+
+    expect(rec.map((r) => r.method)).toEqual(["agent.list", "pane.send_keys"]);
+    expect(rec[1]!.params).toEqual({ pane_id: "p_075", keys: ["Enter"] });
+  });
+
+  it("send() throws when the terminal has no live pane (never a silent drop)", async () => {
+    const { client } = mkClient({ agents: () => [] });
+    const driver = new SocketHerdrDriver(client, noCli);
+
+    await expect(driver.send("gone", "hi")).rejects.toThrow(/no live pane/);
+  });
+
+  it("readAsync() resolves the pane_id and reads it", async () => {
+    const { rec, client } = mkClient();
+    const driver = new SocketHerdrDriver(client, noCli);
+
+    const text = await driver.readAsync("term_075", "visible", 50);
+
+    expect(text).toBe("● Ready.\n> ");
+    expect(rec.map((r) => r.method)).toEqual(["agent.list", "agent.read"]);
+    expect(rec[1]!.params).toEqual({
+      target: "p_075",
+      source: "visible",
+      lines: 50,
+      format: "text",
+    });
+  });
+
+  it("readAsync() returns '' when the pane is gone", async () => {
+    const { client } = mkClient({ agents: () => [] });
+    const driver = new SocketHerdrDriver(client, noCli);
+
+    expect(await driver.readAsync("gone")).toBe("");
+  });
+
+  it("relabel() renames the pane with a sanitized label and the tab with the raw label", async () => {
+    const { rec, client } = mkClient();
+    const driver = new SocketHerdrDriver(client, noCli);
+
+    await driver.relabel("term_075", "Fresh Name!");
+
+    expect(rec.map((r) => r.method)).toEqual(["agent.list", "agent.rename", "tab.rename"]);
+    expect(rec[1]!.params).toEqual({
+      target: "p_075",
+      name: sanitizeHerdrAgentName("Fresh Name!"),
+    });
+    expect(rec[2]!.params).toEqual({ tab_id: "t_075", label: "Fresh Name!" });
+  });
+});
+
+describe("selectHerdrDriver — protocol 17", () => {
+  it("activates the socket driver on protocol 17 via the default supported set", async () => {
+    const client = {
+      ping: mock(() => Promise.resolve({ protocol: 17 })),
+      close: mock(() => undefined),
+    };
+    const driver = await selectHerdrDriver({
+      enabled: true,
+      makeCli: () => noCli,
+      makeClient: () => client as unknown as HerdrSocketClient,
+    });
+
+    expect(driver).toBeInstanceOf(SocketHerdrDriver);
+    expect(client.close).not.toHaveBeenCalled();
+  });
+});

--- a/test/herdr-socket-driver.test.ts
+++ b/test/herdr-socket-driver.test.ts
@@ -3,10 +3,11 @@ import { SocketHerdrDriver, selectHerdrDriver } from "../src/herdr-socket-driver
 import type { HerdrDriver, HerdrAgent, HerdrTab, HerdrPane } from "../src/herdr";
 import { HerdrSocketError, type HerdrSocketClient } from "../src/herdr-socket-client";
 
-/** Fake client exposing a controllable `request` spy. Cast through `unknown` (no
- *  explicit `any`) since the driver only ever calls `.request(...)` on it. */
+/** Fake client exposing controllable `request` / `requestLegacy` spies routed through the same
+ *  `impl`. Cast through `unknown` (no explicit `any`). `requestLegacy` carries the ≤0.7.4
+ *  `agent.send` / `agent.start` calls whose shapes the vendored protocol-17 types no longer describe. */
 function fakeClient(impl: (method: string, params: unknown) => unknown): HerdrSocketClient {
-  return { request: mock(impl) } as unknown as HerdrSocketClient;
+  return { request: mock(impl), requestLegacy: mock(impl) } as unknown as HerdrSocketClient;
 }
 
 /** Fake CLI driver where every `IHerdrDriver` method is a spy. Cast through `unknown`
@@ -183,7 +184,7 @@ function writeClient(
         return { type: "ok" };
     }
   };
-  return { request: mock(impl) } as unknown as HerdrSocketClient;
+  return { request: mock(impl), requestLegacy: mock(impl) } as unknown as HerdrSocketClient;
 }
 
 describe("SocketHerdrDriver — socket-backed async writes (#1553, #1567)", () => {
@@ -363,7 +364,10 @@ describe("SocketHerdrDriver — socket-backed async writes (#1553, #1567)", () =
       if (method === "agent.start") return { type: "agent_started", agent: agentBody.agents[0] };
       return { type: "ok" };
     };
-    const client = { request: mock(impl) } as unknown as HerdrSocketClient;
+    const client = {
+      request: mock(impl),
+      requestLegacy: mock(impl),
+    } as unknown as HerdrSocketClient;
     const driver = new SocketHerdrDriver(client, fakeCli() as unknown as HerdrDriver);
 
     await Promise.all([
@@ -402,7 +406,10 @@ describe("SocketHerdrDriver — spawn-handle ledger (#1852)", () => {
           return { type: "ok" };
       }
     };
-    return { rec, client: { request: mock(impl) } as unknown as HerdrSocketClient };
+    return {
+      rec,
+      client: { request: mock(impl), requestLegacy: mock(impl) } as unknown as HerdrSocketClient,
+    };
   }
 
   it("tabsAsync() requests tab.list and returns the parsed tabs", async () => {

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -7,6 +7,7 @@ import {
   mapState,
   matchAgent,
   matchAgents,
+  posixShellJoin,
   type HerdrAgent,
 } from "../src/herdr";
 import { setDetectedHerdrVersion } from "../src/herdr-capabilities";
@@ -63,6 +64,17 @@ const FIXTURE = JSON.stringify({
       },
     ],
   },
+});
+
+test("posixShellJoin single-quotes every token so spaces/metacharacters/quotes survive", () => {
+  // Plain tokens are still quoted (harmless, keeps the rule uniform).
+  expect(posixShellJoin(["env", "claude", "go"])).toBe("'env' 'claude' 'go'");
+  // Spaces (e.g. a worktree path) and shell metacharacters stay literal inside the quotes.
+  expect(posixShellJoin(["a b", "/wt/my repo", "x&y|z"])).toBe("'a b' '/wt/my repo' 'x&y|z'");
+  // An embedded single quote uses the standard '\'' break-out sequence.
+  expect(posixShellJoin(["it's"])).toBe("'it'\\''s'");
+  // Empty token → '' (never an empty gap that the shell would drop).
+  expect(posixShellJoin(["", ""])).toBe("'' ''");
 });
 
 test("list parses herdr json into typed agents", async () => {


### PR DESCRIPTION
Brings the **default-off** socket driver (`SocketHerdrDriver`) to herdr **protocol 17**, closing #1892 (epic #1889). Regenerates the vendored schema/types from a real 0.7.5 and branches the socket driver's spawn/write surface to the 0.7.5 external-registration path, mirroring the already-merged CLI child (#1895).

## What changed

- **Regen from 0.7.5** — `src/generated/herdr-schema.json` + `herdr-protocol.ts` regenerated from a real `herdr 0.7.5` (protocol 17). Provenance: downloaded the `v0.7.5` `linux-x86_64` release asset to a scratch path and ran `HERDR_BIN=… bun run gen:herdr-schema` (dumps the binary's **bundled** schema offline — never touched the live 0.7.4 daemon or its socket). `bun run check:herdr-types` is clean; gen is deterministic.
- **Accept protocol 17** — `HERDR_SOCKET_SUPPORTED_PROTOCOLS` → `{16, 17}`, so the socket driver activates on a 0.7.5 server.
- **`start()` 0.7.5 branch** (`startImpl075`) — `tab.create` → type the wrapped argv into the tab's root pane → register (`pane.report_agent_session` + `pane.report_agent`) → resolve the agent from `agent.list` by `pane_id` → record the `TabLedger` handle. No `pane.close` (the run reuses the root pane). Rolls back the orphan tab on any failure. ≤0.7.4 keeps its legacy `agent.start` path.
- **`send()`** — version-branched exactly like the CLI: `pane.send_text`/`pane.send_keys` against the resolved `pane_id` on 0.7.5; `agent.send` on ≤0.7.4.
- **`read`/`relabel`** — target the resolved `pane_id` on 0.7.5 (sanitized rename label), identity on ≤0.7.4.

## Two things worth a reviewer's eye

1. **No socket pane-run RPC in p17.** The regenerated schema confirms herdr's protocol-17 socket API exposes **no** direct pane-run method (unlike the CLI `pane run`). So the 0.7.5 socket spawn types the wrapped argv into the pane's ready shell as a POSIX-quoted command line (`posixShellJoin`) + Enter. This routes through the interactive shell rather than a direct exec; per-token single-quoting keeps paths/metacharacters robust. Only the default-off 0.7.5 socket path reaches it.
2. **`requestLegacy` escape.** The vendored types now track p17, but the driver still supports both protocols. Protocol 17 **removed** `agent.send` and **reshaped** `agent.start` incompatibly, so those two ≤0.7.4-only calls are no longer typeable via `request()`. `HerdrSocketClient.requestLegacy()` carries them untyped — keeping the concession in one place (the protocol-agnostic transport) so **≤p16 stays byte-identical on the wire** and everything on the 0.7.5 path + every unchanged shared method stays fully typed.

The `feat` duplication warning (socket `startImpl075`/register mirror the CLI siblings across transports) is expected — the two speak different transports (argv vs JSON-RPC), so the shared logic is the pure helpers already extracted into `herdr.ts`.

## Testing

- New `test/herdr-socket-075.test.ts`: a fake socket client routes the captured p17 fixtures (`test/fixtures/herdr-responses/v0.7.5/`) by method; asserts the spawn method sequence + shell-quoted argv, `send`/`read`/`relabel` pane_id targeting, ledger record→stop, rollback, and protocol-17 selection.
- `test/herdr-socket-driver.test.ts`: fakes updated for `requestLegacy`; existing ≤p16 assertions unchanged (still green) — proves ≤p16 is unaffected.
- Added a focused `posixShellJoin` unit test (spaces/metacharacters/embedded-quote/empty).
- `bun run lint`, `bun run typecheck`, `bun run check:herdr-types`, and the root test suite (pre-push `root-tests` lane) all pass. The pre-push `ui` lane hit a pre-existing sub-pixel flake in `TopBar.browser.test.ts` (`51.99998 ≥ 52`) unrelated to this server-only change; passed on retry.

## Scope

Default-off behavior and ≤p16 servers are unaffected. Out of scope (per the issue): flipping the socket default-on, the unused p17 methods (`pane.graphics.*`, `agent.view.*`, `popup.close`, `agent.prompt/wait`), and lifting the CLI/updater version ceiling.

[no-feature-entry] — server-only, default-off plumbing; no user-facing UX.
